### PR TITLE
Another go at fixing translations with wrong whitespaces and run extraction.

### DIFF
--- a/locale/af/LC_MESSAGES/django.po
+++ b/locale/af/LC_MESSAGES/django.po
@@ -7,71 +7,72 @@ msgid ""
 msgstr ""
 "Project-Id-Version: REMORA 0.1\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2016-02-24 21:23+0000\n"
+"POT-Creation-Date: 2016-04-18 15:47+0000\n"
 "PO-Revision-Date: 2015-03-16 11:24+0000\n"
 "Last-Translator: Friedel <friedel@translate.org.za>\n"
 "Language-Team: translate-discuss-af@lists.sourceforge.net\n"
+"Language: \n"
 "MIME-Version: 1.0\n"
-"Content-Type: text/plain; charset=utf-8\n"
+"Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Generated-By: Babel 2.2.0\n"
 
-#: src/olympia/accounts/views.py:52
+#: src/olympia/accounts/views.py:54
 msgid "Your log in attempt could not be parsed. Please try again."
 msgstr ""
 
-#: src/olympia/accounts/views.py:54
+#: src/olympia/accounts/views.py:56
 msgid "Your Firefox Account could not be found. Please try again."
 msgstr ""
 
-#: src/olympia/accounts/views.py:55
+#: src/olympia/accounts/views.py:57
 msgid "You could not be logged in. Please try again."
 msgstr ""
 
-#: src/olympia/accounts/views.py:57
+#: src/olympia/accounts/views.py:59
 msgid "Your account has already been migrated to Firefox Accounts."
 msgstr ""
 
-#: src/olympia/accounts/views.py:59
+#: src/olympia/accounts/views.py:61
 msgid "Your Firefox Account already exists on this site."
 msgstr ""
 
-#: src/olympia/accounts/views.py:108
+#: src/olympia/accounts/views.py:110
 msgid "Great job!"
 msgstr ""
 
-#: src/olympia/accounts/views.py:109
+#: src/olympia/accounts/views.py:111
 msgid "You can now log in to Add-ons with your Firefox Account."
 msgstr ""
 
-#: src/olympia/accounts/views.py:121
+#: src/olympia/accounts/views.py:123
 msgid "Need help?"
 msgstr ""
 
-#: src/olympia/addons/buttons.py:180
+#: src/olympia/addons/buttons.py:177
 msgid "Download Now"
 msgstr "Laai nou af"
 
 # 88%
 # 100%
-#: src/olympia/addons/buttons.py:182
+#: src/olympia/addons/buttons.py:179
 msgid "Download"
 msgstr "Laai af"
 
 #. L10n: please keep &nbsp; in the string so &rarr; does not wrap.
-#: src/olympia/addons/buttons.py:186
+#: src/olympia/addons/buttons.py:183
 msgid "Continue to Download&nbsp;&rarr;"
 msgstr "Gaan voort vir aflaai&nbsp;&rarr;"
 
-#: src/olympia/addons/buttons.py:202 src/olympia/addons/helpers.py:35 src/olympia/addons/views.py:319 src/olympia/addons/templates/addons/impala/details.html:114
+#: src/olympia/addons/buttons.py:199 src/olympia/addons/helpers.py:35 src/olympia/addons/views.py:333 src/olympia/addons/templates/addons/impala/details.html:111
 #: src/olympia/addons/templates/addons/impala/listing/items.html:17 src/olympia/addons/templates/addons/mobile/home.html:40 src/olympia/amo/templates/amo/side_nav.html:6
-#: src/olympia/amo/templates/amo/side_nav.html:10 src/olympia/amo/templates/amo/site_nav.html:2 src/olympia/amo/templates/amo/site_nav.html:55 src/olympia/bandwagon/views.py:95
-#: src/olympia/browse/views.py:54 src/olympia/browse/views.py:68 src/olympia/browse/views.py:235 src/olympia/browse/templates/browse/impala/category_landing.html:22
+#: src/olympia/amo/templates/amo/side_nav.html:10 src/olympia/amo/templates/amo/site_nav.html:2 src/olympia/amo/templates/amo/site_nav.html:53 src/olympia/bandwagon/views.py:95
+#: src/olympia/browse/views.py:54 src/olympia/browse/views.py:68 src/olympia/browse/views.py:202 src/olympia/browse/templates/browse/impala/category_landing.html:22
 #: src/olympia/browse/templates/browse/personas/mobile/category_landing.html:26
 msgid "Featured"
 msgstr "Uitgesoek"
 
-#: src/olympia/addons/buttons.py:221
+#: src/olympia/addons/buttons.py:218
 msgid "Add to {0}"
 msgstr "Voeg by {0}"
 
@@ -119,39 +120,39 @@ msgid_plural "All tags must be at least {0} characters."
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/olympia/addons/forms.py:234
+#: src/olympia/addons/forms.py:238
 msgid "Categories cannot be changed while your add-on is featured for this application."
 msgstr ""
 
 #. L10n: {0} is the number of categories.
-#: src/olympia/addons/forms.py:238
+#: src/olympia/addons/forms.py:242
 msgid "You can have only {0} category."
 msgid_plural "You can have only {0} categories."
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/olympia/addons/forms.py:246
+#: src/olympia/addons/forms.py:250
 msgid "The miscellaneous category cannot be combined with additional categories."
 msgstr ""
 
-#: src/olympia/addons/forms.py:369
+#: src/olympia/addons/forms.py:374
 #, python-format
 msgid "Before changing your default locale you must have a name, summary, and description in that locale. You are missing %s."
 msgstr ""
 
-#: src/olympia/addons/forms.py:484 src/olympia/addons/forms.py:575
+#: src/olympia/addons/forms.py:455 src/olympia/addons/forms.py:546
 msgid "A license must be selected."
 msgstr ""
 
-#: src/olympia/addons/forms.py:556
+#: src/olympia/addons/forms.py:527
 msgid "Give Your Theme a Name."
 msgstr ""
 
-#: src/olympia/addons/forms.py:562 src/olympia/devhub/templates/devhub/personas/submit.html:53
+#: src/olympia/addons/forms.py:533 src/olympia/devhub/templates/devhub/personas/submit.html:53
 msgid "Describe your Theme."
 msgstr ""
 
-#: src/olympia/addons/forms.py:704
+#: src/olympia/addons/forms.py:675
 msgid "Enter a new author's email address"
 msgstr ""
 
@@ -159,41 +160,41 @@ msgstr ""
 msgid "Not Reviewed"
 msgstr "Nie nagegaan nie"
 
-#: src/olympia/addons/models.py:301
+#: src/olympia/addons/models.py:298
 msgid "Users have the option of contributing more or less than this amount."
 msgstr "Gebruikers het die keuse om meer of minder as dié bedag by te dra."
 
-#: src/olympia/addons/models.py:309
-msgid "Users will always be asked in the Add-ons Manager (Firefox 4 and above)"
+#: src/olympia/addons/models.py:306
+msgid "Users will always be asked in the Add-ons Manager (Firefox 4 and above). Only applies to desktop."
 msgstr ""
 
 # Column name in a table.
-#: src/olympia/addons/models.py:1804 src/olympia/addons/templates/addons/details_box.html:55 src/olympia/devhub/templates/devhub/index.html:92
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:102
+#: src/olympia/addons/models.py:1802 src/olympia/addons/templates/addons/details_box.html:55 src/olympia/devhub/templates/devhub/index.html:92
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:89
 msgid "Listed"
 msgstr ""
 
-#: src/olympia/addons/views.py:320 src/olympia/browse/templates/browse/personas/mobile/category_landing.html:27
+#: src/olympia/addons/views.py:334 src/olympia/browse/templates/browse/personas/mobile/category_landing.html:27
 msgid "Popular"
 msgstr "Gewild"
 
-#: src/olympia/addons/views.py:321 src/olympia/browse/views.py:238 src/olympia/browse/views.py:280 src/olympia/browse/views.py:482
+#: src/olympia/addons/views.py:335 src/olympia/browse/views.py:205 src/olympia/browse/views.py:247 src/olympia/browse/views.py:449
 msgid "Recently Added"
 msgstr "Onlangs bygevoeg"
 
 # 75%
 # 100%
-#: src/olympia/addons/views.py:322 src/olympia/bandwagon/views.py:99 src/olympia/browse/views.py:60 src/olympia/browse/views.py:71 src/olympia/search/forms.py:16 src/olympia/search/forms.py:91
+#: src/olympia/addons/views.py:336 src/olympia/bandwagon/views.py:99 src/olympia/browse/views.py:60 src/olympia/browse/views.py:71 src/olympia/search/forms.py:16 src/olympia/search/forms.py:91
 msgid "Recently Updated"
 msgstr "Onlangs bygewerk"
 
 # %1 is an add-on name.
 #. l10n: {0} is the addon name
-#: src/olympia/addons/views.py:520
+#: src/olympia/addons/views.py:534
 msgid "Contribution for {0}"
 msgstr "Bydrae vir {0}"
 
-#: src/olympia/addons/views.py:613
+#: src/olympia/addons/views.py:627
 msgid "Abuse reported."
 msgstr "Misbruik gerapporteer."
 
@@ -262,9 +263,9 @@ msgstr "Dra by"
 #: src/olympia/devhub/templates/devhub/addons/ajax_compat_update.html:36 src/olympia/devhub/templates/devhub/addons/profile.html:44 src/olympia/devhub/templates/devhub/addons/edit/admin.html:101
 #: src/olympia/devhub/templates/devhub/addons/edit/basic.html:152 src/olympia/devhub/templates/devhub/addons/edit/details.html:85 src/olympia/devhub/templates/devhub/addons/edit/support.html:67
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:166 src/olympia/devhub/templates/devhub/addons/forms_shared/media.html:149
-#: src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:44 src/olympia/devhub/templates/devhub/versions/add_file_modal.html:78 src/olympia/devhub/templates/devhub/versions/edit.html:139
-#: src/olympia/devhub/templates/devhub/versions/list.html:242 src/olympia/devhub/templates/devhub/versions/list.html:276 src/olympia/devhub/templates/devhub/versions/list.html:317
-#: src/olympia/devhub/templates/devhub/versions/list.html:351 src/olympia/reviews/templates/reviews/edit_review.html:16 src/olympia/translations/templates/translations/trans-menu.html:50
+#: src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:43 src/olympia/devhub/templates/devhub/versions/add_file_modal.html:58 src/olympia/devhub/templates/devhub/versions/edit.html:139
+#: src/olympia/devhub/templates/devhub/versions/list.html:239 src/olympia/devhub/templates/devhub/versions/list.html:281 src/olympia/devhub/templates/devhub/versions/list.html:315
+#: src/olympia/devhub/templates/devhub/versions/list.html:349 src/olympia/reviews/templates/reviews/edit_review.html:16 src/olympia/translations/templates/translations/trans-menu.html:50
 #: src/olympia/translations/templates/translations/trans-menu.html:62
 msgid "or"
 msgstr "of"
@@ -376,7 +377,7 @@ msgid "Add-on Information for {0}"
 msgstr "Byvoeginginligting vir {0}"
 
 #: src/olympia/addons/templates/addons/details_box.html:30 src/olympia/addons/templates/addons/persona_detail_table.html:3 src/olympia/addons/templates/addons/mobile/details.html:63
-#: src/olympia/addons/templates/addons/mobile/persona_detail_table.html:7 src/olympia/browse/views.py:459 src/olympia/devhub/views.py:75
+#: src/olympia/addons/templates/addons/mobile/persona_detail_table.html:7 src/olympia/browse/views.py:426 src/olympia/devhub/views.py:73
 msgid "Updated"
 msgstr "Bygewerk"
 
@@ -395,11 +396,11 @@ msgstr "Werk met"
 msgid "Visibility"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/details_box.html:57 src/olympia/devhub/templates/devhub/index.html:94 src/olympia/devhub/templates/devhub/includes/addon_details.html:104
+#: src/olympia/addons/templates/addons/details_box.html:57 src/olympia/devhub/templates/devhub/index.html:94 src/olympia/devhub/templates/devhub/includes/addon_details.html:91
 msgid "Hidden"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/details_box.html:59 src/olympia/devhub/templates/devhub/index.html:96 src/olympia/devhub/templates/devhub/includes/addon_details.html:106
+#: src/olympia/addons/templates/addons/details_box.html:59 src/olympia/devhub/templates/devhub/index.html:96 src/olympia/devhub/templates/devhub/includes/addon_details.html:93
 msgid "Unlisted"
 msgstr ""
 
@@ -408,14 +409,14 @@ msgid "Required Add-ons"
 msgstr ""
 
 # 100%
-#: src/olympia/addons/templates/addons/details_box.html:81 src/olympia/addons/templates/addons/persona_detail_table.html:15 src/olympia/browse/views.py:462 src/olympia/devhub/views.py:78
-#: src/olympia/devhub/views.py:85 src/olympia/discovery/templates/discovery/addons/detail.html:57 src/olympia/reviews/forms.py:62 src/olympia/reviews/templates/reviews/add.html:57
+#: src/olympia/addons/templates/addons/details_box.html:81 src/olympia/addons/templates/addons/persona_detail_table.html:15 src/olympia/browse/views.py:429 src/olympia/devhub/views.py:76
+#: src/olympia/devhub/views.py:83 src/olympia/discovery/templates/discovery/addons/detail.html:57 src/olympia/reviews/forms.py:62 src/olympia/reviews/templates/reviews/add.html:57
 #: src/olympia/reviews/templates/reviews/mobile/review_list.html:18
 msgid "Rating"
 msgstr "Gradering"
 
 # 100%
-#: src/olympia/addons/templates/addons/details_box.html:85 src/olympia/browse/views.py:461 src/olympia/devhub/views.py:77 src/olympia/devhub/views.py:84
+#: src/olympia/addons/templates/addons/details_box.html:85 src/olympia/browse/views.py:428 src/olympia/devhub/views.py:75 src/olympia/devhub/views.py:82
 #: src/olympia/stats/templates/stats/addon_report_menu.html:8 src/olympia/stats/templates/stats/collection_report_menu.html:18
 msgid "Downloads"
 msgstr "Afgelaai"
@@ -435,7 +436,7 @@ msgstr ""
 
 #. The Privacy Policy for this add-on.
 #: src/olympia/addons/templates/addons/details_box.html:121 src/olympia/addons/templates/addons/privacy.html:19 src/olympia/addons/templates/addons/privacy.html:23
-#: src/olympia/addons/templates/addons/impala/button.html:43 src/olympia/addons/templates/addons/impala/details.html:307 src/olympia/devhub/templates/devhub/includes/policy_form.html:20
+#: src/olympia/addons/templates/addons/impala/button.html:43 src/olympia/addons/templates/addons/impala/details.html:312 src/olympia/devhub/templates/devhub/includes/policy_form.html:23
 #: src/olympia/templates/mobile/base_addons.html:87
 msgid "Privacy Policy"
 msgstr "Privaatheidbeleid"
@@ -463,7 +464,7 @@ msgstr "Beeldgalery"
 msgid "Developer Comments"
 msgstr "Opmerkings van die ontwikkelaar"
 
-#: src/olympia/addons/templates/addons/details_box.html:199 src/olympia/addons/templates/addons/impala/details.html:259
+#: src/olympia/addons/templates/addons/details_box.html:199 src/olympia/addons/templates/addons/impala/details.html:264
 msgid "Development Channel"
 msgstr ""
 
@@ -483,13 +484,13 @@ msgid ""
 "developer. To stop receiving development updates, reinstall the default version from the link above."
 msgstr ""
 
-#: src/olympia/addons/templates/addons/details_box.html:220 src/olympia/addons/templates/addons/impala/details.html:278
+#: src/olympia/addons/templates/addons/details_box.html:220 src/olympia/addons/templates/addons/impala/details.html:283
 msgid "Version {0}:"
 msgstr "Weergawe {0}:"
 
 #: src/olympia/addons/templates/addons/details_box.html:234
-msgid "Nothing to see here! The developer did not include any details."
-msgstr "Niks te sien hier nie. Die ontwikkelaar het geen besonderhede ingevoeg nie."
+msgid "Nothing to see here!  The developer did not include any details."
+msgstr ""
 
 #: src/olympia/addons/templates/addons/details_box.html:251 src/olympia/devhub/templates/devhub/versions/edit.html:73 src/olympia/editors/templates/editors/review.html:98
 msgid "Version Notes"
@@ -504,7 +505,7 @@ msgid "End-User License Agreement for {0}"
 msgstr "Eindgebruiker-lisensieooreenkoms vir {0}"
 
 #: src/olympia/addons/templates/addons/eula.html:17 src/olympia/addons/templates/addons/eula.html:21 src/olympia/addons/templates/addons/impala/button.html:48
-#: src/olympia/addons/templates/addons/impala/details.html:316 src/olympia/devhub/templates/devhub/includes/policy_form.html:3 src/olympia/discovery/templates/discovery/addons/eula.html:11
+#: src/olympia/addons/templates/addons/impala/details.html:321 src/olympia/devhub/templates/devhub/includes/policy_form.html:3 src/olympia/discovery/templates/discovery/addons/eula.html:11
 msgid "End-User License Agreement"
 msgstr "Eindgebruiker-lisensieooreenkoms"
 
@@ -523,7 +524,7 @@ msgstr "Terug na {0}…"
 msgid "Add-ons for {0}"
 msgstr "Byvoegings vir {0}"
 
-#: src/olympia/addons/templates/addons/home.html:10 src/olympia/addons/templates/addons/home.html:51 src/olympia/browse/templates/browse/impala/base_listing.html:11
+#: src/olympia/addons/templates/addons/home.html:10 src/olympia/addons/templates/addons/home.html:53 src/olympia/browse/templates/browse/impala/base_listing.html:11
 msgid "Featured Extensions"
 msgstr "Uitgesoekte uitbreidings"
 
@@ -531,31 +532,31 @@ msgstr "Uitgesoekte uitbreidings"
 msgid "Popular Extensions"
 msgstr "Gewilde uitbreidings"
 
-#: src/olympia/addons/templates/addons/home.html:42 src/olympia/amo/templates/amo/side_nav.html:3 src/olympia/amo/templates/amo/side_nav.html:11 src/olympia/amo/templates/amo/site_nav.html:3
-#: src/olympia/amo/templates/amo/site_nav.html:25 src/olympia/browse/views.py:236 src/olympia/browse/views.py:281 src/olympia/browse/views.py:481
+#: src/olympia/addons/templates/addons/home.html:44 src/olympia/amo/templates/amo/side_nav.html:3 src/olympia/amo/templates/amo/side_nav.html:11 src/olympia/amo/templates/amo/site_nav.html:3
+#: src/olympia/amo/templates/amo/site_nav.html:25 src/olympia/browse/views.py:203 src/olympia/browse/views.py:248 src/olympia/browse/views.py:448
 msgid "Most Popular"
 msgstr "Gewildste"
 
-#: src/olympia/addons/templates/addons/home.html:43
+#: src/olympia/addons/templates/addons/home.html:45
 msgid "All »"
 msgstr "Almal »"
 
-#: src/olympia/addons/templates/addons/home.html:52 src/olympia/addons/templates/addons/home.html:61 src/olympia/addons/templates/addons/home.html:70 src/olympia/addons/templates/addons/home.html:78
+#: src/olympia/addons/templates/addons/home.html:54 src/olympia/addons/templates/addons/home.html:63 src/olympia/addons/templates/addons/home.html:72 src/olympia/addons/templates/addons/home.html:80
 #: src/olympia/browse/templates/browse/impala/category_landing.html:36
 msgid "See all »"
 msgstr "Sien almal »"
 
-#: src/olympia/addons/templates/addons/home.html:60
+#: src/olympia/addons/templates/addons/home.html:62
 msgid "Up &amp; Coming Extensions"
 msgstr "Opkomende uitbreidings"
 
-#: src/olympia/addons/templates/addons/home.html:69 src/olympia/browse/templates/browse/personas/category_landing.html:61 src/olympia/discovery/templates/discovery/pane.html:74
+#: src/olympia/addons/templates/addons/home.html:71 src/olympia/browse/templates/browse/personas/category_landing.html:61 src/olympia/discovery/templates/discovery/pane.html:74
 msgid "Featured Themes"
 msgstr "Uitgesoekte temas"
 
 # 80%
 # 100%
-#: src/olympia/addons/templates/addons/home.html:77 src/olympia/bandwagon/templates/bandwagon/impala/collection_listing.html:5
+#: src/olympia/addons/templates/addons/home.html:79 src/olympia/bandwagon/templates/bandwagon/impala/collection_listing.html:5
 msgid "Featured Collections"
 msgstr "Uitgesoekte versamelings"
 
@@ -573,7 +574,7 @@ msgid "Updated {0}"
 msgstr "Bygewerk op {0}"
 
 #. {0} is a date.
-#: src/olympia/addons/templates/addons/macros.html:10 src/olympia/addons/templates/addons/macros.html:69 src/olympia/addons/templates/addons/persona_preview.html:21
+#: src/olympia/addons/templates/addons/macros.html:10 src/olympia/addons/templates/addons/macros.html:69 src/olympia/addons/templates/addons/persona_preview.html:22
 #: src/olympia/addons/templates/addons/listing/items_mobile.html:44 src/olympia/addons/templates/addons/listing/macros.html:39
 #: src/olympia/bandwagon/templates/bandwagon/collection_listing_items.html:37 src/olympia/bandwagon/templates/bandwagon/impala/collection_listing_items.html:37
 msgid "Added {0}"
@@ -594,15 +595,14 @@ msgstr[0] "%(num)s gebruiker"
 msgstr[1] "%(num)s gebruikers"
 
 #. {0} is the number of downloads.
-#: src/olympia/addons/templates/addons/macros.html:53 src/olympia/addons/templates/addons/impala/details.html:61
+#: src/olympia/addons/templates/addons/macros.html:53 src/olympia/addons/templates/addons/impala/details.html:59
 msgid "{0} weekly download"
 msgid_plural "{0} weekly downloads"
 msgstr[0] "{0} keer afgelaai per week"
 msgstr[1] "{0} keer afgelaai per week"
 
 #. {0} is the number of users.
-#: src/olympia/addons/templates/addons/macros.html:61 src/olympia/addons/templates/addons/impala/details.html:54 src/olympia/compat/templates/compat/index.html:71
-#: src/olympia/zadmin/templates/zadmin/compat.html:67
+#: src/olympia/addons/templates/addons/macros.html:61 src/olympia/addons/templates/addons/impala/details.html:52 src/olympia/zadmin/templates/zadmin/compat.html:67
 msgid "{0} user"
 msgid_plural "{0} users"
 msgstr[0] "{0} gebruiker"
@@ -620,7 +620,7 @@ msgstr "Betaling voltooi"
 msgid "Return to the addon."
 msgstr "Terug na die byvoeging."
 
-#: src/olympia/addons/templates/addons/persona_detail.html:17 src/olympia/addons/templates/addons/impala/details.html:106 src/olympia/addons/templates/addons/mobile/details.html:23
+#: src/olympia/addons/templates/addons/persona_detail.html:17 src/olympia/addons/templates/addons/impala/details.html:103 src/olympia/addons/templates/addons/mobile/details.html:23
 #: src/olympia/addons/templates/addons/mobile/persona_detail.html:21 src/olympia/discovery/templates/discovery/addons/base.html:27 src/olympia/editors/templates/editors/review.html:31
 msgid "by"
 msgstr "deur"
@@ -664,34 +664,35 @@ msgstr "Daaglikse gebruikers"
 msgid "License"
 msgstr "Lisensie"
 
-#: src/olympia/addons/templates/addons/persona_preview.html:12 src/olympia/constants/base.py:48
+#: src/olympia/addons/templates/addons/persona_preview.html:13 src/olympia/constants/base.py:48
 msgid "Awaiting Review"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/persona_preview.html:14 src/olympia/amo/log.py:180 src/olympia/constants/base.py:42 src/olympia/editors/helpers.py:62
+#: src/olympia/addons/templates/addons/persona_preview.html:15 src/olympia/amo/log.py:180 src/olympia/constants/base.py:42 src/olympia/editors/helpers.py:62
 msgid "Rejected"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/persona_preview.html:16 src/olympia/amo/log.py:159
+#: src/olympia/addons/templates/addons/persona_preview.html:17 src/olympia/amo/log.py:159
 msgid "Approved"
 msgstr ""
 
 #. {0} is the number of users.
-#: src/olympia/addons/templates/addons/persona_preview.html:26 src/olympia/addons/templates/addons/listing/items_mobile.html:36 src/olympia/addons/templates/addons/listing/macros.html:31
+#: src/olympia/addons/templates/addons/persona_preview.html:27 src/olympia/addons/templates/addons/listing/items_mobile.html:36 src/olympia/addons/templates/addons/listing/macros.html:31
 msgid "<strong>{0}</strong> user"
 msgid_plural "<strong>{0}</strong> users"
 msgstr[0] "<strong>{0}</strong> gebruiker"
 msgstr[1] "<strong>{0}</strong> gebruikers"
 
-#: src/olympia/addons/templates/addons/persona_preview.html:40
+#: src/olympia/addons/templates/addons/persona_preview.html:41
 msgid "Hover to Preview"
 msgstr "Sweef vir 'n voorskou"
 
-#: src/olympia/addons/templates/addons/persona_preview.html:46 src/olympia/addons/templates/addons/persona_preview.html:48 src/olympia/reviews/templates/reviews/add.html:15
+#: src/olympia/addons/templates/addons/persona_preview.html:47 src/olympia/addons/templates/addons/persona_preview.html:49 src/olympia/addons/templates/addons/persona_preview.html:97
+#: src/olympia/reviews/templates/reviews/add.html:15
 msgid "Add"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/persona_preview.html:57 src/olympia/bandwagon/templates/bandwagon/ajax_new.html:16 src/olympia/bandwagon/templates/bandwagon/edit.html:19
+#: src/olympia/addons/templates/addons/persona_preview.html:58 src/olympia/bandwagon/templates/bandwagon/ajax_new.html:16 src/olympia/bandwagon/templates/bandwagon/edit.html:19
 #: src/olympia/bandwagon/templates/bandwagon/includes/addedit.html:19 src/olympia/devhub/templates/devhub/addons/edit/admin.html:13 src/olympia/devhub/templates/devhub/addons/edit/basic.html:10
 #: src/olympia/devhub/templates/devhub/addons/edit/details.html:8 src/olympia/devhub/templates/devhub/addons/edit/media.html:6 src/olympia/devhub/templates/devhub/addons/edit/support.html:8
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:9 src/olympia/devhub/templates/devhub/addons/submit/describe.html:29 src/olympia/editors/templates/editors/review.html:257
@@ -700,21 +701,21 @@ msgstr "Redigeer"
 
 #. For datetime formatting, see the table on
 #. http://docs.python.org/library/datetime.html#strftime-and-strptime-behavior
-#: src/olympia/addons/templates/addons/persona_preview.html:66
+#: src/olympia/addons/templates/addons/persona_preview.html:67
 #, python-format
 msgid "%%Y-%%m-%%d"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/persona_preview.html:67
+#: src/olympia/addons/templates/addons/persona_preview.html:68
 msgid "by {0} on {1}"
 msgstr "deur {0} op {1}"
 
-#: src/olympia/addons/templates/addons/persona_preview.html:75 src/olympia/reviews/helpers.py:17 src/olympia/reviews/templates/reviews/review_list.html:63
+#: src/olympia/addons/templates/addons/persona_preview.html:76 src/olympia/reviews/helpers.py:17 src/olympia/reviews/templates/reviews/review_list.html:63
 #: src/olympia/reviews/templates/reviews/reviews_link.html:21 src/olympia/reviews/templates/reviews/impala/reviews_link.html:16
 msgid "Not yet rated"
 msgstr "Nog nie gegradeer nie"
 
-#: src/olympia/addons/templates/addons/persona_preview.html:78
+#: src/olympia/addons/templates/addons/persona_preview.html:79
 msgid "<b>{0}</b> users"
 msgstr "<b>{0}</b> gebruikers"
 
@@ -727,8 +728,8 @@ msgid "Learn more about Firefox"
 msgstr "Vind meer uit oor Firefox"
 
 #: src/olympia/addons/templates/addons/popups.html:22
-msgid "or <b><a class=\"installer\" href=\"{url}\">download anyway</a></b>"
-msgstr "of <b><a class=\"installer\" href=\"{url}\">laai in elk geval af</a></b>"
+msgid "or <b><a class=\"button installer\" href=\"{url}\">download anyway</a></b>"
+msgstr ""
 
 #: src/olympia/addons/templates/addons/popups.html:26
 msgid ""
@@ -826,7 +827,7 @@ msgid ""
 msgstr ""
 
 #: src/olympia/addons/templates/addons/report_abuse.html:6 src/olympia/addons/templates/addons/report_abuse_full.html:10 src/olympia/addons/templates/addons/impala/details-more.html:23
-#: src/olympia/addons/templates/addons/impala/details.html:328
+#: src/olympia/addons/templates/addons/impala/details.html:333
 msgid "Report Abuse"
 msgstr "Rapporteer misbruik"
 
@@ -845,9 +846,9 @@ msgstr "Stuur verslag"
 #: src/olympia/devhub/templates/devhub/addons/ajax_compat_update.html:36 src/olympia/devhub/templates/devhub/addons/profile.html:44 src/olympia/devhub/templates/devhub/addons/edit/admin.html:104
 #: src/olympia/devhub/templates/devhub/addons/edit/basic.html:155 src/olympia/devhub/templates/devhub/addons/edit/details.html:88 src/olympia/devhub/templates/devhub/addons/edit/support.html:70
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:169 src/olympia/devhub/templates/devhub/addons/forms_shared/media.html:152
-#: src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:44 src/olympia/devhub/templates/devhub/personas/edit.html:222 src/olympia/devhub/templates/devhub/versions/add_file_modal.html:79
-#: src/olympia/devhub/templates/devhub/versions/edit.html:140 src/olympia/devhub/templates/devhub/versions/list.html:208 src/olympia/devhub/templates/devhub/versions/list.html:242
-#: src/olympia/devhub/templates/devhub/versions/list.html:276 src/olympia/devhub/templates/devhub/versions/list.html:317 src/olympia/reviews/templates/reviews/edit_review.html:16
+#: src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:43 src/olympia/devhub/templates/devhub/personas/edit.html:222 src/olympia/devhub/templates/devhub/versions/add_file_modal.html:59
+#: src/olympia/devhub/templates/devhub/versions/edit.html:140 src/olympia/devhub/templates/devhub/versions/list.html:208 src/olympia/devhub/templates/devhub/versions/list.html:239
+#: src/olympia/devhub/templates/devhub/versions/list.html:281 src/olympia/devhub/templates/devhub/versions/list.html:315 src/olympia/reviews/templates/reviews/edit_review.html:16
 #: src/olympia/translations/templates/translations/trans-menu.html:50 src/olympia/translations/templates/translations/trans-menu.html:62 src/olympia/zadmin/templates/zadmin/validation.html:105
 msgid "Cancel"
 msgstr "Kanselleer"
@@ -892,7 +893,7 @@ msgstr "Sien die <a href=\"%(support)s\">ondersteuningafdeling</a> om uit te vin
 msgid "Review Guidelines"
 msgstr "Riglyne vir resensies"
 
-#: src/olympia/addons/templates/addons/review_list_box.html:5 src/olympia/addons/templates/addons/impala/details-more.html:27 src/olympia/editors/helpers.py:921
+#: src/olympia/addons/templates/addons/review_list_box.html:5 src/olympia/addons/templates/addons/impala/details-more.html:27 src/olympia/editors/helpers.py:1001
 #: src/olympia/reviews/templates/reviews/add.html:14 src/olympia/reviews/templates/reviews/reply.html:14 src/olympia/reviews/templates/reviews/review_list.html:19
 #: src/olympia/reviews/templates/reviews/mobile/review_list.html:26
 msgid "Reviews"
@@ -984,31 +985,31 @@ msgid_plural "Other add-ons by these authors"
 msgstr[0] "Ander byvoegings deur %(author)s"
 msgstr[1] "Ander byvoegings deur hierdie outeurs"
 
-#: src/olympia/addons/templates/addons/impala/details.html:41
+#: src/olympia/addons/templates/addons/impala/details.html:39
 #, python-format
 msgid "<span itemprop=\"ratingCount\">%(num)s</span> user review"
 msgid_plural "<span itemprop=\"ratingCount\">%(num)s</span> user reviews"
 msgstr[0] "<span itemprop=\"ratingCount\">%(num)s</span> resensie"
 msgstr[1] "<span itemprop=\"ratingCount\">%(num)s</span> resensies"
 
-#: src/olympia/addons/templates/addons/impala/details.html:69
+#: src/olympia/addons/templates/addons/impala/details.html:66
 msgid "View statistics"
 msgstr "Sien statistiek"
 
-#: src/olympia/addons/templates/addons/impala/details.html:84
+#: src/olympia/addons/templates/addons/impala/details.html:81
 msgid "Manage"
 msgstr "Bestuur"
 
 #. {0} is an add-on name.
-#: src/olympia/addons/templates/addons/impala/details.html:96
+#: src/olympia/addons/templates/addons/impala/details.html:93
 msgid "Icon of {0}"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/impala/details.html:103 src/olympia/addons/templates/addons/impala/listing/items.html:14
+#: src/olympia/addons/templates/addons/impala/details.html:100 src/olympia/addons/templates/addons/impala/listing/items.html:14
 msgid "No Restart"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/impala/details.html:127
+#: src/olympia/addons/templates/addons/impala/details.html:124
 #, fuzzy, python-format
 msgid "Meet the Developer: <a href=\"%(url)s\">%(name)s</a>"
 msgid_plural "<a href=\"%(url)s\">Meet the Developers</a>"
@@ -1016,88 +1017,88 @@ msgstr[0] "Ontmoet die ontwikkelaar: <a href=\"%(url)s\">%(name)s</a>"
 msgstr[1] "<a href=\"%(url)s\">Ontmoet die ontwikkelaars</a>"
 
 # {0} is an add-on name.
-#: src/olympia/addons/templates/addons/impala/details.html:137
+#: src/olympia/addons/templates/addons/impala/details.html:134
 msgid "Learn why {0} was created and find out what's next for this add-on."
 msgstr "Vind uit hoekom {0} gemaak is en vind uit wat volgende kom vir dié byvoeging."
 
 #. {0} is an index.
-#: src/olympia/addons/templates/addons/impala/details.html:156
+#: src/olympia/addons/templates/addons/impala/details.html:161
 msgid "Add-on screenshot #{0}"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/impala/details.html:182
+#: src/olympia/addons/templates/addons/impala/details.html:187
 msgid "Add-on home page"
 msgstr "Byvoeging se tuisblad"
 
-#: src/olympia/addons/templates/addons/impala/details.html:185
+#: src/olympia/addons/templates/addons/impala/details.html:190
 msgid "Support site"
 msgstr "Werf vir ondersteuning"
 
-#: src/olympia/addons/templates/addons/impala/details.html:189
+#: src/olympia/addons/templates/addons/impala/details.html:194
 msgid "Support E-mail"
 msgstr "E-posadres vir ondersteuning"
 
-#: src/olympia/addons/templates/addons/impala/details.html:194 src/olympia/devhub/models.py:378 src/olympia/devhub/templates/devhub/versions/list.html:12
+#: src/olympia/addons/templates/addons/impala/details.html:199 src/olympia/devhub/models.py:378 src/olympia/devhub/templates/devhub/versions/list.html:12
 #: src/olympia/versions/templates/versions/version.html:6 src/olympia/versions/templates/versions/mobile/version.html:6
 msgid "Version {0}"
 msgstr "Weergawe {0}"
 
-#: src/olympia/addons/templates/addons/impala/details.html:194
+#: src/olympia/addons/templates/addons/impala/details.html:199
 msgid "Info"
 msgstr "Inligting"
 
-#: src/olympia/addons/templates/addons/impala/details.html:195 src/olympia/devhub/templates/devhub/includes/addon_details.html:129
+#: src/olympia/addons/templates/addons/impala/details.html:200 src/olympia/devhub/templates/devhub/includes/addon_details.html:116
 msgid "Last Updated:"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/impala/details.html:200
+#: src/olympia/addons/templates/addons/impala/details.html:205
 #, python-format
 msgid "Released under <a target=\"_blank\" href=\"%(url)s\">%(name)s</a>"
 msgstr "Vrygestel ingevolge die <a target=\"_blank\" href=\"%(url)s\">%(name)s</a>"
 
-#: src/olympia/addons/templates/addons/impala/details.html:201 src/olympia/addons/templates/addons/impala/details.html:206 src/olympia/amo/helpers.py:398 src/olympia/devhub/forms.py:142
+#: src/olympia/addons/templates/addons/impala/details.html:206 src/olympia/addons/templates/addons/impala/details.html:211 src/olympia/amo/helpers.py:398 src/olympia/devhub/forms.py:142
 #: src/olympia/devhub/forms.py:173 src/olympia/versions/templates/versions/version.html:40 src/olympia/versions/templates/versions/version.html:45
 msgid "Custom License"
 msgstr "Eie lisensie"
 
-#: src/olympia/addons/templates/addons/impala/details.html:205
+#: src/olympia/addons/templates/addons/impala/details.html:210
 #, python-format
 msgid "Released under <a href=\"%(url)s\">%(name)s</a>"
 msgstr "Vrygestel ingevolge die <a href=\"%(url)s\">%(name)s</a>"
 
-#: src/olympia/addons/templates/addons/impala/details.html:217
+#: src/olympia/addons/templates/addons/impala/details.html:222
 msgid "About this Add-on"
 msgstr "Aangaande dié byvoeging"
 
-#: src/olympia/addons/templates/addons/impala/details.html:233
+#: src/olympia/addons/templates/addons/impala/details.html:238
 msgid "Developer’s Comments"
 msgstr "Opmerkings van die ontwikkelaar"
 
-#: src/olympia/addons/templates/addons/impala/details.html:243
+#: src/olympia/addons/templates/addons/impala/details.html:248
 msgid "Version Information"
 msgstr "Weergawe-inligting"
 
-#: src/olympia/addons/templates/addons/impala/details.html:250
+#: src/olympia/addons/templates/addons/impala/details.html:255
 msgid "See complete version history"
 msgstr "Sien volledige weergawe-inligting"
 
-#: src/olympia/addons/templates/addons/impala/details.html:262
+#: src/olympia/addons/templates/addons/impala/details.html:267
 msgid ""
 "The Development Channel lets you test an experimental new version of this add-on before it's released to the general public. Once you install the development version, you will continue to get "
 "updates from this channel. To stop receiving development updates, reinstall the default version from the link above."
 msgstr ""
 
-#: src/olympia/addons/templates/addons/impala/details.html:272
+#: src/olympia/addons/templates/addons/impala/details.html:277
 msgid "<strong>Caution:</strong> Development versions of this add-on have not been reviewed by Mozilla."
 msgstr ""
 
-#: src/olympia/addons/templates/addons/impala/details.html:287
+#: src/olympia/addons/templates/addons/impala/details.html:292
 msgid "See complete development channel history"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/impala/details.html:306 src/olympia/addons/templates/addons/impala/details.html:315 src/olympia/addons/templates/addons/impala/details.html:327
+#: src/olympia/addons/templates/addons/impala/details.html:311 src/olympia/addons/templates/addons/impala/details.html:320 src/olympia/addons/templates/addons/impala/details.html:332
 #: src/olympia/addons/templates/addons/impala/review_add_box.html:4 src/olympia/stats/templates/stats/popup.html:2 src/olympia/stats/templates/stats/popup.html:8
-#: src/olympia/stats/templates/stats/stats.html:202 src/olympia/users/templates/users/profile.html:119
+#: src/olympia/stats/templates/stats/stats.html:204 src/olympia/users/templates/users/profile.html:119
 msgid "close"
 msgstr "sluit"
 
@@ -1156,15 +1157,11 @@ msgstr "Bronkodelisensie vir {addon}"
 msgid "Source Code License"
 msgstr "Bronkodelisensie"
 
-#: src/olympia/addons/templates/addons/impala/persona_grid.html:16 src/olympia/addons/templates/addons/impala/toplist.html:6
-msgid "{0} users"
-msgstr "{0} gebruikers"
-
 #: src/olympia/addons/templates/addons/impala/review_list_box.html:19 src/olympia/reviews/templates/reviews/review.html:40
 msgid "permalink"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/impala/review_list_box.html:23 src/olympia/editors/templates/editors/queue.html:98 src/olympia/reviews/templates/reviews/review.html:44
+#: src/olympia/addons/templates/addons/impala/review_list_box.html:23 src/olympia/editors/templates/editors/queue.html:104 src/olympia/reviews/templates/reviews/review.html:44
 msgid "translate"
 msgstr ""
 
@@ -1183,6 +1180,10 @@ msgstr ""
 msgid "Be the first!"
 msgstr ""
 
+#: src/olympia/addons/templates/addons/impala/toplist.html:6
+msgid "{0} users"
+msgstr "{0} gebruikers"
+
 #: src/olympia/addons/templates/addons/impala/listing/sorter.html:14 src/olympia/devhub/templates/devhub/addons/listing/item_actions.html:49
 msgid "More"
 msgstr "Meer"
@@ -1197,7 +1198,7 @@ msgstr "Voeg by versameling"
 msgid "My Add-ons"
 msgstr "My byvoegings"
 
-#: src/olympia/addons/templates/addons/includes/dashboard_tabs.html:6 src/olympia/amo/context_processors.py:51
+#: src/olympia/addons/templates/addons/includes/dashboard_tabs.html:6 src/olympia/amo/context_processors.py:50
 msgid "My Themes"
 msgstr "My temas"
 
@@ -1254,7 +1255,7 @@ msgstr "Gebruikers"
 msgid "Weekly Downloads"
 msgstr "Weekliks afgelaai"
 
-#: src/olympia/addons/templates/addons/mobile/details.html:99 src/olympia/compat/templates/compat/reporter_detail.html:46 src/olympia/devhub/forms.py:787
+#: src/olympia/addons/templates/addons/mobile/details.html:99 src/olympia/compat/templates/compat/reporter_detail.html:46 src/olympia/devhub/forms.py:788
 #: src/olympia/devhub/templates/devhub/versions/list.html:163
 msgid "Version"
 msgstr "Weergawe"
@@ -1340,7 +1341,7 @@ msgstr "Byvoegings is programme waarmee mens Firefox kan verpersoonlik met ekstr
 #: src/olympia/browse/templates/browse/personas/category_landing.html:21 src/olympia/browse/templates/browse/personas/category_landing.html:23
 #: src/olympia/browse/templates/browse/personas/category_landing.html:38 src/olympia/browse/templates/browse/personas/grid.html:7 src/olympia/browse/templates/browse/personas/grid.html:11
 #: src/olympia/browse/templates/browse/personas/mobile/base.html:7 src/olympia/browse/templates/browse/personas/mobile/category_landing.html:19 src/olympia/constants/base.py:180
-#: src/olympia/devhub/templates/devhub/personas/submit.html:13 src/olympia/editors/helpers.py:105 src/olympia/editors/templates/editors/base.html:26
+#: src/olympia/devhub/templates/devhub/personas/submit.html:13 src/olympia/editors/helpers.py:107 src/olympia/editors/templates/editors/base.html:26
 #: src/olympia/editors/templates/editors/performance.html:73 src/olympia/search/templates/search/personas.html:39 src/olympia/templates/menu_links.html:9
 msgid "Themes"
 msgstr "Temas"
@@ -1366,7 +1367,7 @@ msgid "Highest Rated"
 msgstr "Hoogste gradering"
 
 # 100%
-#: src/olympia/addons/templates/addons/mobile/home.html:74 src/olympia/amo/templates/amo/side_nav.html:5 src/olympia/amo/templates/amo/site_nav.html:27 src/olympia/amo/templates/amo/site_nav.html:57
+#: src/olympia/addons/templates/addons/mobile/home.html:74 src/olympia/amo/templates/amo/side_nav.html:5 src/olympia/amo/templates/amo/site_nav.html:27 src/olympia/amo/templates/amo/site_nav.html:55
 #: src/olympia/bandwagon/views.py:97 src/olympia/browse/views.py:57 src/olympia/browse/views.py:67 src/olympia/browse/templates/browse/personas/mobile/category_landing.html:65
 #: src/olympia/search/forms.py:15 src/olympia/search/forms.py:87
 msgid "Newest"
@@ -1380,90 +1381,90 @@ msgstr ""
 msgid "Theme Info &raquo;"
 msgstr ""
 
-#: src/olympia/amo/context_processors.py:39 src/olympia/devhub/templates/devhub/nav.html:43
+#: src/olympia/amo/context_processors.py:37 src/olympia/devhub/templates/devhub/nav.html:43
 msgid "Tools"
 msgstr "Gereedskap"
 
-#: src/olympia/amo/context_processors.py:48 src/olympia/discovery/templates/discovery/pane_account.html:8 src/olympia/users/templates/users/includes/navigation.html:2
+#: src/olympia/amo/context_processors.py:47 src/olympia/discovery/templates/discovery/pane_account.html:8 src/olympia/users/templates/users/includes/navigation.html:2
 msgid "My Profile"
 msgstr "My profiel"
 
-#: src/olympia/amo/context_processors.py:54 src/olympia/users/templates/users/edit.html:5 src/olympia/users/templates/users/includes/navigation.html:3
+#: src/olympia/amo/context_processors.py:53 src/olympia/users/templates/users/edit.html:5 src/olympia/users/templates/users/includes/navigation.html:3
 msgid "Account Settings"
 msgstr "Rekeningopstelling"
 
-#: src/olympia/amo/context_processors.py:57 src/olympia/discovery/templates/discovery/pane_account.html:11 src/olympia/users/templates/users/profile.html:83
+#: src/olympia/amo/context_processors.py:56 src/olympia/discovery/templates/discovery/pane_account.html:11 src/olympia/users/templates/users/profile.html:83
 #: src/olympia/users/templates/users/includes/navigation.html:4
 msgid "My Collections"
 msgstr "My versamelings"
 
-#: src/olympia/amo/context_processors.py:62 src/olympia/discovery/templates/discovery/pane_account.html:10 src/olympia/users/templates/users/includes/navigation.html:7
+#: src/olympia/amo/context_processors.py:61 src/olympia/discovery/templates/discovery/pane_account.html:10 src/olympia/users/templates/users/includes/navigation.html:7
 msgid "My Favorites"
 msgstr "My gunstelinge"
 
-#: src/olympia/amo/context_processors.py:67 src/olympia/discovery/templates/discovery/pane_account.html:13 src/olympia/templates/impala/user_login.html:14
+#: src/olympia/amo/context_processors.py:66 src/olympia/discovery/templates/discovery/pane_account.html:13 src/olympia/templates/impala/user_login.html:14
 #: src/olympia/templates/mobile/header_auth.html:5
 msgid "Log out"
 msgstr "Meld af"
 
-#: src/olympia/amo/context_processors.py:72 src/olympia/devhub/templates/devhub/addons/dashboard.html:4
+#: src/olympia/amo/context_processors.py:71 src/olympia/devhub/templates/devhub/addons/dashboard.html:4
 msgid "Manage My Submissions"
 msgstr ""
 
-#: src/olympia/amo/context_processors.py:75 src/olympia/devhub/templates/devhub/nav.html:27 src/olympia/devhub/templates/devhub/addons/dashboard.html:25
+#: src/olympia/amo/context_processors.py:74 src/olympia/devhub/templates/devhub/nav.html:27 src/olympia/devhub/templates/devhub/addons/dashboard.html:25
 #: src/olympia/devhub/templates/devhub/addons/submit/base.html:4
 msgid "Submit a New Add-on"
 msgstr "Dien nuwe byvoeging in"
 
-#: src/olympia/amo/context_processors.py:77 src/olympia/browse/templates/browse/personas/base.html:50 src/olympia/devhub/templates/devhub/index.html:24
+#: src/olympia/amo/context_processors.py:76 src/olympia/browse/templates/browse/personas/base.html:50 src/olympia/devhub/templates/devhub/index.html:24
 #: src/olympia/devhub/templates/devhub/addons/dashboard.html:29
 msgid "Submit a New Theme"
 msgstr "Dien 'n nuwe tema in"
 
-#: src/olympia/amo/context_processors.py:79 src/olympia/amo/templates/amo/site_nav.html:87 src/olympia/devhub/helpers.py:36 src/olympia/devhub/helpers.py:68 src/olympia/devhub/helpers.py:102
+#: src/olympia/amo/context_processors.py:78 src/olympia/amo/templates/amo/site_nav.html:85 src/olympia/devhub/helpers.py:36 src/olympia/devhub/helpers.py:68 src/olympia/devhub/helpers.py:102
 #: src/olympia/templates/footer.html:6 src/olympia/templates/menu_links.html:14
 msgid "Developer Hub"
 msgstr "Ontwikkelaars"
 
-#: src/olympia/amo/context_processors.py:83 src/olympia/devhub/views.py:1792
+#: src/olympia/amo/context_processors.py:81 src/olympia/devhub/views.py:1796
 msgid "Manage API Keys"
 msgstr ""
 
-#: src/olympia/amo/context_processors.py:88 src/olympia/editors/helpers.py:82 src/olympia/editors/helpers.py:102 src/olympia/editors/templates/editors/base.html:10
+#: src/olympia/amo/context_processors.py:86 src/olympia/editors/helpers.py:84 src/olympia/editors/helpers.py:104 src/olympia/editors/templates/editors/base.html:10
 msgid "Editor Tools"
 msgstr ""
 
-#: src/olympia/amo/context_processors.py:92
+#: src/olympia/amo/context_processors.py:90
 msgid "Admin Tools"
 msgstr ""
 
-#: src/olympia/amo/fields.py:15
+#: src/olympia/amo/fields.py:20
 msgid "Incorrect, please try again."
 msgstr ""
 
-#: src/olympia/amo/fields.py:16
+#: src/olympia/amo/fields.py:21
 msgid "Error verifying input, please try again."
 msgstr ""
 
-#: src/olympia/amo/fields.py:32
+#: src/olympia/amo/fields.py:37
 msgid "This must be a valid hex color code, such as #000000."
 msgstr ""
 
-#: src/olympia/amo/fields.py:58
+#: src/olympia/amo/fields.py:63
 msgid "Enter at least one value."
 msgstr ""
 
-#: src/olympia/amo/helpers.py:162 src/olympia/amo/templates/amo/site_nav.html:61 src/olympia/bandwagon/templates/bandwagon/add.html:9
+#: src/olympia/amo/helpers.py:162 src/olympia/amo/templates/amo/site_nav.html:59 src/olympia/bandwagon/templates/bandwagon/add.html:9
 #: src/olympia/bandwagon/templates/bandwagon/collection_detail.html:15 src/olympia/bandwagon/templates/bandwagon/delete.html:9 src/olympia/bandwagon/templates/bandwagon/edit.html:15
 #: src/olympia/bandwagon/templates/bandwagon/user_listing.html:18 src/olympia/bandwagon/templates/bandwagon/user_listing.html:21
 #: src/olympia/bandwagon/templates/bandwagon/impala/collection_listing.html:12 src/olympia/bandwagon/templates/bandwagon/impala/collection_listing.html:20
 #: src/olympia/bandwagon/templates/bandwagon/impala/collection_listing.html:24 src/olympia/bandwagon/templates/bandwagon/impala/collection_sidebar.html:3
 #: src/olympia/bandwagon/templates/bandwagon/includes/collection_sidebar.html:2 src/olympia/bandwagon/templates/bandwagon/mobile/collection_listing.html:3
-#: src/olympia/stats/templates/stats/stats.html:77 src/olympia/templates/menu_links.html:12
+#: src/olympia/stats/templates/stats/stats.html:33 src/olympia/templates/menu_links.html:12
 msgid "Collections"
 msgstr "Versamelings"
 
-#: src/olympia/amo/helpers.py:171 src/olympia/amo/templates/amo/site_nav.html:85 src/olympia/browse/templates/browse/language_tools.html:3
+#: src/olympia/amo/helpers.py:171 src/olympia/amo/templates/amo/site_nav.html:83 src/olympia/browse/templates/browse/language_tools.html:3
 msgid "Dictionaries & Language Packs"
 msgstr "Woordeboeke en taalpakke"
 
@@ -1615,8 +1616,8 @@ msgstr ""
 msgid "Comment on {addon} {version}."
 msgstr ""
 
-#: src/olympia/amo/log.py:236 src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:19 src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:47
-#: src/olympia/editors/helpers.py:511 src/olympia/editors/templates/editors/themes/history_table.html:11
+#: src/olympia/amo/log.py:236 src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:17 src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:45
+#: src/olympia/editors/helpers.py:584 src/olympia/editors/templates/editors/themes/history_table.html:11
 msgid "Comment"
 msgstr ""
 
@@ -1944,7 +1945,7 @@ msgstr "Vorige"
 #: src/olympia/amo/templates/amo/mobile/paginator.html:14 src/olympia/amo/templates/amo/mobile/paginator.html:16 src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:51
 #: src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:65 src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:78
 #: src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:91 src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:104
-#: src/olympia/discovery/templates/discovery/pane.html:45 src/olympia/discovery/templates/discovery/addons/detail.html:39 src/olympia/stats/templates/stats/stats.html:167
+#: src/olympia/discovery/templates/discovery/pane.html:45 src/olympia/discovery/templates/discovery/addons/detail.html:39 src/olympia/stats/templates/stats/stats.html:169
 msgid "Next"
 msgstr "Volgende"
 
@@ -1976,7 +1977,7 @@ msgid ""
 msgstr ""
 
 #: src/olympia/amo/templates/amo/side_nav.html:4 src/olympia/amo/templates/amo/side_nav.html:12 src/olympia/amo/templates/amo/site_nav.html:4 src/olympia/amo/templates/amo/site_nav.html:26
-#: src/olympia/browse/views.py:56 src/olympia/browse/views.py:66 src/olympia/browse/views.py:237 src/olympia/browse/views.py:282 src/olympia/search/forms.py:86
+#: src/olympia/browse/views.py:56 src/olympia/browse/views.py:66 src/olympia/browse/views.py:204 src/olympia/browse/views.py:249 src/olympia/search/forms.py:86
 msgid "Top Rated"
 msgstr "Topgegradeer"
 
@@ -1991,38 +1992,38 @@ msgstr "Ontdek"
 msgid "Extensions"
 msgstr "Uitbreidings"
 
-#: src/olympia/amo/templates/amo/site_nav.html:45
+#: src/olympia/amo/templates/amo/site_nav.html:44
 msgid "Want more customization? Try <b>Complete Themes</b>"
 msgstr ""
 
-#: src/olympia/amo/templates/amo/site_nav.html:56 src/olympia/bandwagon/views.py:96
+#: src/olympia/amo/templates/amo/site_nav.html:54 src/olympia/bandwagon/views.py:96
 msgid "Most Followers"
 msgstr "Meeste volgelinge"
 
-#: src/olympia/amo/templates/amo/site_nav.html:68 src/olympia/bandwagon/templates/bandwagon/impala/collection_sidebar.html:16
+#: src/olympia/amo/templates/amo/site_nav.html:66 src/olympia/bandwagon/templates/bandwagon/impala/collection_sidebar.html:16
 #: src/olympia/bandwagon/templates/bandwagon/includes/collection_sidebar.html:18
 msgid "Collections I've Made"
 msgstr "Versamelings wat ek gemaak het"
 
-#: src/olympia/amo/templates/amo/site_nav.html:70 src/olympia/bandwagon/templates/bandwagon/user_listing.html:4 src/olympia/bandwagon/templates/bandwagon/impala/collection_sidebar.html:13
+#: src/olympia/amo/templates/amo/site_nav.html:68 src/olympia/bandwagon/templates/bandwagon/user_listing.html:4 src/olympia/bandwagon/templates/bandwagon/impala/collection_sidebar.html:13
 #: src/olympia/bandwagon/templates/bandwagon/includes/collection_sidebar.html:15
 msgid "Collections I'm Following"
 msgstr "Versamelings wat ek volg"
 
-#: src/olympia/amo/templates/amo/site_nav.html:73 src/olympia/bandwagon/templates/bandwagon/impala/collection_sidebar.html:18
-#: src/olympia/bandwagon/templates/bandwagon/includes/collection_sidebar.html:20 src/olympia/users/models.py:512
+#: src/olympia/amo/templates/amo/site_nav.html:71 src/olympia/bandwagon/templates/bandwagon/impala/collection_sidebar.html:18
+#: src/olympia/bandwagon/templates/bandwagon/includes/collection_sidebar.html:20 src/olympia/users/models.py:521
 msgid "My Favorite Add-ons"
 msgstr "My gunsteling byvoegings"
 
-#: src/olympia/amo/templates/amo/site_nav.html:78
+#: src/olympia/amo/templates/amo/site_nav.html:76
 msgid "More&hellip;"
 msgstr "Meer&hellip;"
 
-#: src/olympia/amo/templates/amo/site_nav.html:82
+#: src/olympia/amo/templates/amo/site_nav.html:80
 msgid "Add-ons for Mobile"
 msgstr "Byvoegings vir selfoon"
 
-#: src/olympia/amo/templates/amo/site_nav.html:86 src/olympia/browse/feeds.py:207 src/olympia/browse/templates/browse/search_tools.html:3 src/olympia/constants/base.py:176
+#: src/olympia/amo/templates/amo/site_nav.html:84 src/olympia/browse/feeds.py:207 src/olympia/browse/templates/browse/search_tools.html:3 src/olympia/constants/base.py:176
 #: src/olympia/templates/menu_links.html:10
 msgid "Search Tools"
 msgstr "Soekgereedskap"
@@ -2038,7 +2039,7 @@ msgid "Jump to first page"
 msgstr "Spring na eerste bladsy"
 
 #: src/olympia/amo/templates/amo/impala/paginator.html:22 src/olympia/amo/templates/amo/mobile/impala_paginator.html:12 src/olympia/discovery/templates/discovery/pane.html:44
-#: src/olympia/discovery/templates/discovery/addons/detail.html:38 src/olympia/stats/templates/stats/stats.html:164
+#: src/olympia/discovery/templates/discovery/addons/detail.html:38 src/olympia/stats/templates/stats/stats.html:166
 msgid "Previous"
 msgstr "Vorige"
 
@@ -2061,30 +2062,49 @@ msgid_plural "Page {n}"
 msgstr[0] "Bladsy {n}"
 msgstr[1] "Bladsy {n}"
 
-#: src/olympia/amo/templates/services/install.html:38
-#, python-format
-msgid "If you are not prompted to install %(addon_name)s in a moment, please <a href=\"%(addon_xpi)s\">click here</a>."
-msgstr ""
-
-#: src/olympia/amo/tests/test_messages.py:57 src/olympia/amo/tests/test_messages.py:58 src/olympia/reviews/forms.py:25 src/olympia/reviews/forms.py:50 src/olympia/reviews/templates/reviews/add.html:56
+#: src/olympia/amo/tests/test_messages.py:56 src/olympia/amo/tests/test_messages.py:57 src/olympia/reviews/forms.py:25 src/olympia/reviews/forms.py:50 src/olympia/reviews/templates/reviews/add.html:56
 #: src/olympia/reviews/templates/reviews/reply.html:30
 msgid "Title"
 msgstr ""
 
-#: src/olympia/amo/tests/test_messages.py:57 src/olympia/amo/tests/test_messages.py:58
+#: src/olympia/amo/tests/test_messages.py:56 src/olympia/amo/tests/test_messages.py:57
 msgid "Body"
 msgstr ""
 
-#: src/olympia/amo/tests/test_messages.py:59
+#: src/olympia/amo/tests/test_messages.py:58
 msgid "Another Title"
 msgstr ""
 
-#: src/olympia/amo/tests/test_messages.py:59
+#: src/olympia/amo/tests/test_messages.py:58
 msgid "Another Body"
 msgstr ""
 
-#: src/olympia/api/views.py:255
-msgid "Not implemented yet."
+#: src/olympia/api/authentication.py:76
+msgid "Signature has expired."
+msgstr ""
+
+#: src/olympia/api/authentication.py:79
+msgid "Error decoding signature."
+msgstr ""
+
+#: src/olympia/api/authentication.py:82
+msgid "Invalid JWT Token."
+msgstr ""
+
+#: src/olympia/api/authentication.py:130
+msgid "Invalid Authorization header. No credentials provided."
+msgstr ""
+
+#: src/olympia/api/authentication.py:133
+msgid "Invalid Authorization header. Credentials string should not contain spaces."
+msgstr ""
+
+#: src/olympia/api/fields.py:29
+msgid "The field must have a length of at least {num} characters."
+msgstr ""
+
+#: src/olympia/api/fields.py:31
+msgid "The language code {lang_code} is invalid."
 msgstr ""
 
 #: src/olympia/applications/views.py:39 src/olympia/applications/templates/applications/appversions.html:3
@@ -2103,7 +2123,7 @@ msgstr ""
 msgid "Add-ons submitted to Mozilla Add-ons must have a manifest file with at least one of the below applications supported. Only the versions listed below are allowed for these applications."
 msgstr ""
 
-#: src/olympia/applications/templates/applications/appversions.html:25
+#: src/olympia/applications/templates/applications/appversions.html:25 src/olympia/editors/helpers.py:361
 msgid "GUID"
 msgstr ""
 
@@ -2221,8 +2241,8 @@ msgstr "Gunsteling"
 msgid "Remove from favorites"
 msgstr "Verwyder uit gunstelinge"
 
-#: src/olympia/bandwagon/views.py:98 src/olympia/bandwagon/views.py:191 src/olympia/browse/views.py:58 src/olympia/browse/views.py:69 src/olympia/browse/views.py:458 src/olympia/devhub/views.py:74
-#: src/olympia/devhub/views.py:82 src/olympia/devhub/templates/devhub/addons/edit/basic.html:20 src/olympia/editors/templates/editors/leaderboard.html:24
+#: src/olympia/bandwagon/views.py:98 src/olympia/bandwagon/views.py:191 src/olympia/browse/views.py:58 src/olympia/browse/views.py:69 src/olympia/browse/views.py:425 src/olympia/devhub/views.py:72
+#: src/olympia/devhub/views.py:80 src/olympia/devhub/templates/devhub/addons/edit/basic.html:20 src/olympia/editors/templates/editors/leaderboard.html:24
 #: src/olympia/editors/templates/editors/themes/queue_list.html:48 src/olympia/search/forms.py:17 src/olympia/search/forms.py:89 src/olympia/users/templates/users/vcard.html:5
 msgid "Name"
 msgstr "Naam"
@@ -2231,7 +2251,7 @@ msgstr "Naam"
 msgid "Recently Popular"
 msgstr "Onlangs populêr"
 
-#: src/olympia/bandwagon/views.py:189 src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:18
+#: src/olympia/bandwagon/views.py:189 src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:16
 msgid "Added"
 msgstr "Bygevoeg"
 
@@ -2246,7 +2266,7 @@ msgstr "Versameling gebou!"
 
 #: src/olympia/bandwagon/views.py:316
 #, python-format
-msgid "Your new collection is shown below. You can <ahref=\"%(url)s\">edit additional settings</a> if you'dlike."
+msgid "Your new collection is shown below. You can <a href=\"%(url)s\">edit additional settings</a> if you'd like."
 msgstr ""
 
 #: src/olympia/bandwagon/views.py:322
@@ -2395,8 +2415,8 @@ msgstr[0] "%(num)s byvoeging in dié versameling"
 msgstr[1] "%(num)s byvoegings in dié versameling"
 
 # 100%
-#: src/olympia/bandwagon/templates/bandwagon/collection_detail.html:125 src/olympia/compat/templates/compat/index.html:25 src/olympia/compat/templates/compat/reporter_detail.html:29
-#: src/olympia/files/templates/files/viewer.html:29 src/olympia/templates/amo_footer.html:17 src/olympia/templates/includes/lang_switcher.html:10
+#: src/olympia/bandwagon/templates/bandwagon/collection_detail.html:125 src/olympia/compat/templates/compat/reporter_detail.html:29 src/olympia/files/templates/files/viewer.html:29
+#: src/olympia/templates/amo_footer.html:17 src/olympia/templates/includes/lang_switcher.html:10
 msgid "Go"
 msgstr "Gaan"
 
@@ -2566,7 +2586,7 @@ msgid "Remove this user as a contributor"
 msgstr ""
 
 #: src/olympia/bandwagon/templates/bandwagon/edit_contributors.html:18 src/olympia/bandwagon/templates/bandwagon/edit_contributors.html:43
-#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:20 src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:48
+#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:18 src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:46
 #: src/olympia/devhub/templates/devhub/addons/ajax_compat_update.html:19
 msgid "Remove"
 msgstr ""
@@ -2617,7 +2637,7 @@ msgid "<b>Warning:</b> By changing the owner of this collection, you will no lon
 msgstr ""
 
 #: src/olympia/bandwagon/templates/bandwagon/edit_contributors.html:83 src/olympia/devhub/templates/devhub/addons/forms_shared/media.html:157
-#: src/olympia/devhub/templates/devhub/addons/submit/describe.html:69 src/olympia/devhub/templates/devhub/addons/submit/license.html:60 src/olympia/devhub/templates/devhub/addons/submit/upload.html:78
+#: src/olympia/devhub/templates/devhub/addons/submit/describe.html:69 src/olympia/devhub/templates/devhub/addons/submit/license.html:60 src/olympia/devhub/templates/devhub/addons/submit/upload.html:70
 #: src/olympia/devhub/templates/devhub/payments/tier.html:17 src/olympia/editors/templates/editors/themes/themes.html:111 src/olympia/editors/templates/editors/themes/themes.html:128
 #: src/olympia/editors/templates/editors/themes/themes.html:134 src/olympia/editors/templates/editors/themes/themes.html:141 src/olympia/users/templates/users/fxa_migration_prompt_content.html:10
 #: src/olympia/users/templates/users/login_form.html:42 src/olympia/users/templates/users/mobile/login.html:57
@@ -2703,31 +2723,31 @@ msgid "Add-ons in Your Collection"
 msgstr ""
 
 #: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:4
-msgid ""
-"To include an add-on in this collection, enter its name in the box below and hit enter.  You can also use the <strong>Add to Collection</strong> links throughout the site to include add-ons later."
+msgid "To include an add-on in this collection, enter its name in the box below and hit enter."
 msgstr ""
 
-#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:17 src/olympia/constants/base.py:400 src/olympia/devhub/templates/devhub/addons/activity.html:62
+#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:15 src/olympia/constants/base.py:400 src/olympia/devhub/templates/devhub/addons/activity.html:62
+#: src/olympia/editors/helpers.py:273 src/olympia/editors/helpers.py:360
 msgid "Add-on"
 msgstr ""
 
-#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:26
+#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:24
 msgid "Enter the name of the add-on to include"
 msgstr ""
 
-#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:28
+#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:26
 msgid "Add to Collection"
 msgstr "Voeg by versameling"
 
-#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:45 src/olympia/editors/helpers.py:936 src/olympia/editors/helpers.py:956
+#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:43 src/olympia/editors/helpers.py:1016 src/olympia/editors/helpers.py:1036
 msgid "Pending"
 msgstr ""
 
-#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:47
+#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:45
 msgid "Add a comment"
 msgstr ""
 
-#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:48
+#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:46
 msgid "Remove this add-on from the collection"
 msgstr ""
 
@@ -2834,12 +2854,12 @@ msgstr "Soekgereedskap"
 msgid "Most Users"
 msgstr "Meeste gebruikers"
 
-#: src/olympia/browse/views.py:61 src/olympia/browse/views.py:72 src/olympia/browse/views.py:279 src/olympia/browse/templates/browse/personas/mobile/category_landing.html:63
+#: src/olympia/browse/views.py:61 src/olympia/browse/views.py:72 src/olympia/browse/views.py:246 src/olympia/browse/templates/browse/personas/mobile/category_landing.html:63
 #: src/olympia/discovery/templates/discovery/pane.html:67 src/olympia/search/forms.py:92
 msgid "Up & Coming"
 msgstr "Opkomend"
 
-#: src/olympia/browse/views.py:460 src/olympia/devhub/views.py:76 src/olympia/devhub/views.py:83 src/olympia/discovery/templates/discovery/addons/detail.html:66
+#: src/olympia/browse/views.py:427 src/olympia/devhub/views.py:74 src/olympia/devhub/views.py:81 src/olympia/discovery/templates/discovery/addons/detail.html:66
 msgid "Created"
 msgstr "Geskep"
 
@@ -3030,8 +3050,8 @@ msgid_plural "See all %(cnt)s extensions in %(name)s &raquo;"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/olympia/browse/templates/browse/mobile/extensions.html:13 src/olympia/compat/templates/compat/index.html:82 src/olympia/devhub/templates/devhub/devhub_search.html:24
-#: src/olympia/devhub/templates/devhub/addons/activity.html:47 src/olympia/search/templates/search/no_results.html:4 src/olympia/search/templates/search/mobile/results.html:36
+#: src/olympia/browse/templates/browse/mobile/extensions.html:13 src/olympia/devhub/templates/devhub/devhub_search.html:24 src/olympia/devhub/templates/devhub/addons/activity.html:47
+#: src/olympia/search/templates/search/no_results.html:4 src/olympia/search/templates/search/mobile/results.html:36
 msgid "No results found."
 msgstr ""
 
@@ -3116,7 +3136,7 @@ msgstr ""
 msgid "All"
 msgstr "Almal"
 
-#: src/olympia/compat/forms.py:22 src/olympia/search/views.py:525
+#: src/olympia/compat/forms.py:22 src/olympia/editors/templates/editors/base.html:69 src/olympia/search/views.py:518
 msgid "All Add-ons"
 msgstr "Alle byvoegings"
 
@@ -3126,54 +3146,6 @@ msgstr ""
 
 #: src/olympia/compat/forms.py:24
 msgid "Non-binary"
-msgstr ""
-
-#. Review points sources other than add-ons and themes.
-#: src/olympia/compat/views.py:87 src/olympia/constants/base.py:388 src/olympia/devhub/forms.py:162 src/olympia/editors/templates/editors/performance.html:75
-#, fuzzy
-msgid "Other"
-msgstr "Ander"
-
-#: src/olympia/compat/templates/compat/index.html:4
-msgid "Add-on Compatibility Report for {app} {version}"
-msgstr ""
-
-#: src/olympia/compat/templates/compat/index.html:11
-msgid "{app} {version} Compatibility"
-msgstr ""
-
-#: src/olympia/compat/templates/compat/index.html:17
-#, python-format
-msgid "Top 95%% compatible with previous version"
-msgstr ""
-
-#: src/olympia/compat/templates/compat/index.html:18
-#, python-format
-msgid "Top 95%% of all add-ons"
-msgstr ""
-
-#: src/olympia/compat/templates/compat/index.html:19
-msgid "All active add-ons"
-msgstr ""
-
-#: src/olympia/compat/templates/compat/index.html:23 src/olympia/constants/base.py:401
-msgid "App"
-msgstr ""
-
-#: src/olympia/compat/templates/compat/index.html:55
-msgid "Details for add-ons compatible with previous version:"
-msgstr ""
-
-#: src/olympia/compat/templates/compat/index.html:57
-msgid "Show all versions"
-msgstr ""
-
-#: src/olympia/compat/templates/compat/index.html:59
-msgid "Details for add-ons compatible with all versions:"
-msgstr ""
-
-#: src/olympia/compat/templates/compat/index.html:61
-msgid "Show previous version only"
 msgstr ""
 
 #: src/olympia/compat/templates/compat/reporter.html:3
@@ -3227,8 +3199,8 @@ msgstr ""
 msgid "Report Type"
 msgstr ""
 
-#: src/olympia/compat/templates/compat/reporter_detail.html:47 src/olympia/devhub/forms.py:784 src/olympia/devhub/templates/devhub/addons/ajax_compat_update.html:17 src/olympia/editors/forms.py:108
-#: src/olympia/zadmin/forms.py:45
+#: src/olympia/compat/templates/compat/reporter_detail.html:47 src/olympia/devhub/forms.py:785 src/olympia/devhub/templates/devhub/addons/ajax_compat_update.html:17 src/olympia/editors/forms.py:108
+#: src/olympia/editors/forms.py:248 src/olympia/zadmin/forms.py:45
 msgid "Application"
 msgstr ""
 
@@ -3318,7 +3290,8 @@ msgstr "Voorlopig nagegaan"
 msgid "Preliminarily Reviewed and Awaiting Full Review"
 msgstr "Voorlopig nagegaan en wag op volledige nagaan"
 
-#: src/olympia/constants/base.py:33 src/olympia/editors/helpers.py:924 src/olympia/editors/templates/editors/themes/history_table.html:34
+#: src/olympia/constants/base.py:33 src/olympia/editors/forms.py:258 src/olympia/editors/helpers.py:73 src/olympia/editors/helpers.py:1004
+#: src/olympia/editors/templates/editors/themes/history_table.html:34
 msgid "Deleted"
 msgstr ""
 
@@ -3420,6 +3393,12 @@ msgstr ""
 msgid "Ask before users can download this add-on"
 msgstr ""
 
+#. Review points sources other than add-ons and themes.
+#: src/olympia/constants/base.py:388 src/olympia/devhub/forms.py:162 src/olympia/editors/templates/editors/performance.html:75
+#, fuzzy
+msgid "Other"
+msgstr "Ander"
+
 #: src/olympia/constants/base.py:389
 msgid "Exception"
 msgstr ""
@@ -3430,6 +3409,10 @@ msgstr ""
 
 #: src/olympia/constants/base.py:391
 msgid "Change"
+msgstr ""
+
+#: src/olympia/constants/base.py:401
+msgid "App"
 msgstr ""
 
 #: src/olympia/constants/base.py:402
@@ -3580,7 +3563,7 @@ msgstr ""
 msgid "Duplicate"
 msgstr ""
 
-#: src/olympia/constants/editors.py:17 src/olympia/editors/helpers.py:502 src/olympia/editors/templates/editors/themes/queue.html:71 src/olympia/editors/templates/editors/themes/themes.html:94
+#: src/olympia/constants/editors.py:17 src/olympia/editors/helpers.py:575 src/olympia/editors/templates/editors/themes/queue.html:71 src/olympia/editors/templates/editors/themes/themes.html:94
 msgid "Reject"
 msgstr ""
 
@@ -3680,7 +3663,7 @@ msgstr "Solaris"
 msgid "Android"
 msgstr "Android"
 
-#: src/olympia/core/apps.py:19
+#: src/olympia/core/apps.py:21
 msgid "Core"
 msgstr ""
 
@@ -3814,7 +3797,7 @@ msgid "Submit my add-on for manual review."
 msgstr ""
 
 #: src/olympia/devhub/forms.py:537
-msgid "Do not list my add-on on this site (beta)"
+msgid "Do not list my add-on on this site"
 msgstr ""
 
 #: src/olympia/devhub/forms.py:538
@@ -3847,46 +3830,46 @@ msgstr ""
 
 #: src/olympia/devhub/forms.py:592
 #, python-format
-msgid "Version %s already exists"
+msgid "Version %s already exists, or was uploaded before."
 msgstr ""
 
-#: src/olympia/devhub/forms.py:604
+#: src/olympia/devhub/forms.py:605
 msgid "Select a valid choice. That choice is not one of the available choices."
 msgstr ""
 
-#: src/olympia/devhub/forms.py:610
+#: src/olympia/devhub/forms.py:611
 msgid "A file with a version ending with a|alpha|b|beta and an optional number is detected as beta."
 msgstr ""
 
-#: src/olympia/devhub/forms.py:633
+#: src/olympia/devhub/forms.py:634
 msgid "You cannot upload any more files for this version."
 msgstr ""
 
-#: src/olympia/devhub/forms.py:639
+#: src/olympia/devhub/forms.py:640
 msgid "Version doesn't match"
 msgstr ""
 
-#: src/olympia/devhub/forms.py:668
+#: src/olympia/devhub/forms.py:669
 msgid "You cannot delete a file once the review process has started.  You must delete the whole version."
 msgstr ""
 
-#: src/olympia/devhub/forms.py:688
+#: src/olympia/devhub/forms.py:689
 msgid "The platform All cannot be combined with specific platforms."
 msgstr ""
 
-#: src/olympia/devhub/forms.py:693
+#: src/olympia/devhub/forms.py:694
 msgid "A platform can only be chosen once."
 msgstr ""
 
-#: src/olympia/devhub/forms.py:706
+#: src/olympia/devhub/forms.py:707
 msgid "A review type must be selected."
 msgstr ""
 
-#: src/olympia/devhub/forms.py:788 src/olympia/editors/forms.py:114 src/olympia/zadmin/forms.py:49 src/olympia/zadmin/forms.py:52
+#: src/olympia/devhub/forms.py:789 src/olympia/editors/forms.py:114 src/olympia/editors/forms.py:254 src/olympia/zadmin/forms.py:49 src/olympia/zadmin/forms.py:52
 msgid "Select an application first"
 msgstr ""
 
-#: src/olympia/devhub/forms.py:840
+#: src/olympia/devhub/forms.py:841
 msgid "There cannot be more than 3 required add-ons."
 msgstr ""
 
@@ -3922,78 +3905,78 @@ msgstr[1] "{0} waarskuwings"
 msgid "Review"
 msgstr "Resensie"
 
-#: src/olympia/devhub/tasks.py:551
+#: src/olympia/devhub/tasks.py:583
 #, python-format
 msgid "%s responded with %s (%s)."
 msgstr ""
 
-#: src/olympia/devhub/tasks.py:555
+#: src/olympia/devhub/tasks.py:587
 #, python-format
 msgid "Connection to \"%s\" timed out."
 msgstr ""
 
-#: src/olympia/devhub/tasks.py:557
+#: src/olympia/devhub/tasks.py:589
 #, python-format
 msgid "Could not contact host at \"%s\"."
 msgstr ""
 
-#: src/olympia/devhub/utils.py:104
+#: src/olympia/devhub/utils.py:105
 #, python-format
 msgid "Validation generated too many errors/warnings so %s messages were truncated. After addressing the visible messages, you'll be able to see the others."
 msgstr ""
 
-#: src/olympia/devhub/views.py:183
+#: src/olympia/devhub/views.py:181
 msgid "All My Add-ons"
 msgstr "Al my byvoegings"
 
-#: src/olympia/devhub/views.py:210
+#: src/olympia/devhub/views.py:208
 msgid "All Activity"
 msgstr "Alle aktiwiteit"
 
-#: src/olympia/devhub/views.py:211
+#: src/olympia/devhub/views.py:209
 msgid "Add-on Updates"
 msgstr ""
 
-#: src/olympia/devhub/views.py:212
+#: src/olympia/devhub/views.py:210
 msgid "Add-on Status"
 msgstr ""
 
 # 75%
 # 100%
-#: src/olympia/devhub/views.py:213
+#: src/olympia/devhub/views.py:211
 msgid "User Collections"
 msgstr ""
 
-#: src/olympia/devhub/views.py:214 src/olympia/devhub/templates/devhub/docs/policies-maintenance.html:68 src/olympia/pages/templates/pages/dev_faq.html:38
+#: src/olympia/devhub/views.py:212 src/olympia/devhub/templates/devhub/docs/policies-maintenance.html:68 src/olympia/pages/templates/pages/dev_faq.html:38
 #: src/olympia/pages/templates/pages/dev_faq.html:484
 msgid "User Reviews"
 msgstr "Gebruikerresensies"
 
-#: src/olympia/devhub/views.py:327 src/olympia/devhub/views.py:331 src/olympia/devhub/views.py:484 src/olympia/devhub/views.py:513 src/olympia/devhub/views.py:564 src/olympia/devhub/views.py:1150
+#: src/olympia/devhub/views.py:325 src/olympia/devhub/views.py:329 src/olympia/devhub/views.py:484 src/olympia/devhub/views.py:513 src/olympia/devhub/views.py:564 src/olympia/devhub/views.py:1156
 msgid "Changes successfully saved."
 msgstr ""
 
-#: src/olympia/devhub/views.py:334 src/olympia/devhub/views.py:1631
+#: src/olympia/devhub/views.py:332 src/olympia/devhub/views.py:1637
 msgid "Please check the form for errors."
 msgstr ""
 
-#: src/olympia/devhub/views.py:346
+#: src/olympia/devhub/views.py:344
 msgid "Add-on cannot be deleted. Disable this add-on instead."
 msgstr ""
 
-#: src/olympia/devhub/views.py:356
+#: src/olympia/devhub/views.py:354
 msgid "Theme deleted."
 msgstr ""
 
-#: src/olympia/devhub/views.py:356
+#: src/olympia/devhub/views.py:354
 msgid "Add-on deleted."
 msgstr ""
 
-#: src/olympia/devhub/views.py:362
+#: src/olympia/devhub/views.py:360
 msgid "URL name was incorrect. Theme was not deleted."
 msgstr ""
 
-#: src/olympia/devhub/views.py:367
+#: src/olympia/devhub/views.py:365
 msgid "URL name was incorrect. Add-on was not deleted."
 msgstr ""
 
@@ -4021,7 +4004,7 @@ msgstr ""
 msgid "Check Add-on Compatibility"
 msgstr ""
 
-#: src/olympia/devhub/views.py:808 src/olympia/signing/views.py:90
+#: src/olympia/devhub/views.py:808 src/olympia/signing/views.py:95
 msgid "You cannot submit this type of add-on"
 msgstr ""
 
@@ -4051,33 +4034,33 @@ msgstr ""
 msgid "There was an error uploading your preview."
 msgstr ""
 
-#: src/olympia/devhub/views.py:1189
+#: src/olympia/devhub/views.py:1195
 #, python-format
 msgid "Version %s disabled."
 msgstr ""
 
-#: src/olympia/devhub/views.py:1193
+#: src/olympia/devhub/views.py:1199
 #, python-format
 msgid "Version %s deleted."
 msgstr ""
 
-#: src/olympia/devhub/views.py:1203
+#: src/olympia/devhub/views.py:1209
 msgid "This upload has failed validation, and may lack complete validation results. Please take due care when reviewing it."
 msgstr ""
 
-#: src/olympia/devhub/views.py:1677
+#: src/olympia/devhub/views.py:1683
 msgid "Preliminary Review Requested."
 msgstr ""
 
-#: src/olympia/devhub/views.py:1678
+#: src/olympia/devhub/views.py:1684
 msgid "Full Review Requested."
 msgstr ""
 
-#: src/olympia/devhub/views.py:1779
+#: src/olympia/devhub/views.py:1783
 msgid "Your old credentials were revoked and are no longer valid. Be sure to update all API clients with the new credentials."
 msgstr ""
 
-#: src/olympia/devhub/views.py:1797
+#: src/olympia/devhub/views.py:1801
 msgid "New API key created"
 msgstr ""
 
@@ -4107,7 +4090,7 @@ msgstr "Terug na byvoegings"
 msgid "{0} :: Search"
 msgstr "{0} :: Soek"
 
-#: src/olympia/devhub/templates/devhub/devhub_search.html:6 src/olympia/devhub/templates/devhub/search.html:8 src/olympia/editors/forms.py:435 src/olympia/editors/forms.py:437
+#: src/olympia/devhub/templates/devhub/devhub_search.html:6 src/olympia/devhub/templates/devhub/search.html:8 src/olympia/editors/forms.py:534 src/olympia/editors/forms.py:536
 #: src/olympia/editors/templates/editors/queue.html:27 src/olympia/editors/templates/editors/themes/queue_list.html:14 src/olympia/search/templates/search/collections.html:17
 #: src/olympia/search/templates/search/personas.html:18 src/olympia/search/templates/search/results.html:18 src/olympia/search/templates/search/mobile/results.html:8
 #: src/olympia/templates/search.html:14 src/olympia/templates/impala/search.html:18
@@ -4167,12 +4150,12 @@ msgstr ""
 msgid "Start Making Add-ons"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/index.html:86 src/olympia/devhub/templates/devhub/addons/listing/items.html:25 src/olympia/devhub/templates/devhub/includes/addon_details.html:15
+#: src/olympia/devhub/templates/devhub/index.html:86 src/olympia/devhub/templates/devhub/addons/listing/items.html:25 src/olympia/devhub/templates/devhub/includes/addon_details.html:20
 #: src/olympia/devhub/templates/devhub/personas/edit.html:43
 msgid "Status:"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/index.html:90 src/olympia/devhub/templates/devhub/includes/addon_details.html:100
+#: src/olympia/devhub/templates/devhub/index.html:90 src/olympia/devhub/templates/devhub/includes/addon_details.html:87
 msgid "Visibility:"
 msgstr ""
 
@@ -4180,11 +4163,11 @@ msgstr ""
 msgid "Latest Version:"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/index.html:109 src/olympia/devhub/templates/devhub/includes/addon_details.html:145 src/olympia/devhub/templates/devhub/personas/edit.html:49
+#: src/olympia/devhub/templates/devhub/index.html:109 src/olympia/devhub/templates/devhub/includes/addon_details.html:131 src/olympia/devhub/templates/devhub/personas/edit.html:49
 msgid "Queue Position:"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/index.html:110 src/olympia/devhub/templates/devhub/includes/addon_details.html:146 src/olympia/devhub/templates/devhub/personas/edit.html:50
+#: src/olympia/devhub/templates/devhub/index.html:110 src/olympia/devhub/templates/devhub/includes/addon_details.html:132 src/olympia/devhub/templates/devhub/personas/edit.html:50
 #, python-format
 msgid "%(position)s of %(total)s"
 msgstr ""
@@ -4286,16 +4269,6 @@ msgstr ""
 msgid "Do you want your add-on to be distributed on this site?"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/validate_addon.html:49 src/olympia/devhub/templates/devhub/addons/submit/upload.html:30 src/olympia/devhub/templates/devhub/versions/add_file_modal.html:14
-#: src/olympia/devhub/templates/devhub/versions/add_file_modal.html:53 src/olympia/devhub/templates/devhub/versions/list.html:298
-msgid "Warning:"
-msgstr ""
-
-#: src/olympia/devhub/templates/devhub/validate_addon.html:50 src/olympia/devhub/templates/devhub/addons/submit/upload.html:31
-#, python-format
-msgid "Submission of unlisted add-ons for signing is currently in an open beta. Please <a href=\"%(url)s\" target=\"_blank\">report any bugs</a> that you encounter."
-msgstr ""
-
 #. first parameter is a filename like lorem-ipsum-1.0.2.xpi
 #: src/olympia/devhub/templates/devhub/validation.html:5
 msgid "Validation Results for {0}"
@@ -4370,7 +4343,7 @@ msgstr ""
 msgid "Update Compatibility"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/addons/ajax_compat_update.html:4
+#: src/olympia/devhub/templates/devhub/addons/ajax_compat_update.html:4 src/olympia/devhub/templates/devhub/versions/edit.html:45
 msgid "Adjusting application information here will allow users to install your add-on even if the install manifest in the package indicates that the add-on is incompatible."
 msgstr ""
 
@@ -4382,9 +4355,9 @@ msgstr ""
 msgid "Add Another Application&hellip;"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/addons/ajax_compat_update.html:38 src/olympia/devhub/templates/devhub/addons/owner.html:86 src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:46
-#: src/olympia/devhub/templates/devhub/versions/list.html:351 src/olympia/devhub/templates/devhub/versions/list.html:353 src/olympia/templates/impala/base.html:132
-#: src/olympia/templates/impala/base.html:143 src/olympia/templates/impala/base.html:161 src/olympia/templates/impala/base.html:171
+#: src/olympia/devhub/templates/devhub/addons/ajax_compat_update.html:38 src/olympia/devhub/templates/devhub/addons/owner.html:86 src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:45
+#: src/olympia/devhub/templates/devhub/versions/list.html:349 src/olympia/devhub/templates/devhub/versions/list.html:351 src/olympia/templates/impala/base.html:129
+#: src/olympia/templates/impala/base.html:140 src/olympia/templates/impala/base.html:158 src/olympia/templates/impala/base.html:168
 msgid "Close"
 msgstr ""
 
@@ -4418,7 +4391,7 @@ msgstr ""
 msgid "Manage Authors & License"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/addons/owner.html:29 src/olympia/editors/templates/editors/review.html:270
+#: src/olympia/devhub/templates/devhub/addons/owner.html:29 src/olympia/editors/helpers.py:362 src/olympia/editors/templates/editors/review.html:270
 msgid "Authors"
 msgstr ""
 
@@ -4487,17 +4460,11 @@ msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/basic.html:52
 msgid ""
-"A short explanation of your add-on's basic\n"
-"                          functionality that is displayed in search and browse\n"
-"                          listings, as well as at the top of your add-on's\n"
-"                          details page. It is only relevant for listed add-ons."
+"A short explanation of your add-on's basic functionality that is displayed in search and browse listings, as well as at the top of your add-on's details page. It is only relevant for listed add-ons."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/basic.html:73
-msgid ""
-"Categories are the primary way users browse through add-ons.\n"
-"                        Choose any that fit your add-on's functionality for the most\n"
-"                        exposure. It is only relevant for listed add-ons."
+msgid "Categories are the primary way users browse through add-ons. Choose any that fit your add-on's functionality for the most exposure. It is only relevant for listed add-ons."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/basic.html:90
@@ -4507,11 +4474,7 @@ msgid ""
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/basic.html:119
-msgid ""
-"Tags help users find your add-on and should be short\n"
-"                        descriptors such as tabs, toolbar, or twitter.  You\n"
-"                        may have a maximum of {0} tags. It is only relevant\n"
-"                        for listed add-ons."
+msgid "Tags help users find your add-on and should be short descriptors such as tabs, toolbar, or twitter. You may have a maximum of {0} tags. It is only relevant for listed add-ons."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/basic.html:129 src/olympia/devhub/templates/devhub/personas/edit.html:97 src/olympia/devhub/templates/devhub/personas/submit.html:46
@@ -4539,11 +4502,7 @@ msgid "Add-on Details for {0}"
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/details.html:22
-msgid ""
-"A longer explanation of features,\n"
-"                          functionality, and other relevant information. This\n"
-"                          field is only displayed on the add-on's details\n"
-"                          page. It is only relevant for listed add-ons."
+msgid "A longer explanation of features, functionality, and other relevant information. This field is only displayed on the add-on's details page. It is only relevant for listed add-ons."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/details.html:44 src/olympia/translations/templates/translations/trans-menu.html:13
@@ -4551,10 +4510,7 @@ msgid "Default Locale"
 msgstr "Versteklokaliteit"
 
 #: src/olympia/devhub/templates/devhub/addons/edit/details.html:45
-msgid ""
-"Information about your add-on is displayed in this locale\n"
-"                        unless you override it with a locale-specific translation.\n"
-"                        It is only relevant for listed add-ons."
+msgid "Information about your add-on is displayed in this locale unless you override it with a locale-specific translation. It is only relevant for listed add-ons."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/details.html:61 src/olympia/users/forms.py:311 src/olympia/users/templates/users/edit.html:122 src/olympia/users/templates/users/register.html:57
@@ -4564,10 +4520,8 @@ msgstr "Tuisblad"
 
 #: src/olympia/devhub/templates/devhub/addons/edit/details.html:63
 msgid ""
-"If your add-on has another homepage, enter its\n"
-"                          address here. If your website is localized into other\n"
-"                          languages multiple translations of this field can be\n"
-"                          added. It is only relevant for listed add-ons."
+"If your add-on has another homepage, enter its address here. If your website is localized into other languages multiple translations of this field can be added. It is only relevant for listed add-"
+"ons."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/media.html:3
@@ -4585,19 +4539,14 @@ msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/support.html:22
 msgid ""
-"If you wish to display an e-mail address for support\n"
-"                          inquiries, enter it here. If you have different\n"
-"                          addresses for each language multiple translations of\n"
-"                          this field can be added. It is only relevant for\n"
-"                          listed add-ons."
+"If you wish to display an e-mail address for support inquiries, enter it here. If you have different addresses for each language multiple translations of this field can be added. It is only "
+"relevant for listed add-ons."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/support.html:45
 msgid ""
-"If your add-on has a support website or forum, enter\n"
-"                          its address here. If your website is localized into\n"
-"                          other languages, multiple translations of this field can\n"
-"                          be added. It is only relevant for listed add-ons."
+"If your add-on has a support website or forum, enter its address here. If your website is localized into other languages, multiple translations of this field can be added. It is only relevant for "
+"listed add-ons."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:6
@@ -4611,11 +4560,8 @@ msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:23
 msgid ""
-"Any information end users may want to know that isn't\n"
-"                          necessarily applicable to the add-on summary or description.\n"
-"                          Common uses include listing known major bugs, information on\n"
-"                          how to report bugs, anticipated release date of a new version,\n"
-"                          etc. It is only relevant for listed add-ons."
+"Any information end users may want to know that isn't necessarily applicable to the add-on summary or description. Common uses include listing known major bugs, information on how to report bugs, "
+"anticipated release date of a new version, etc. It is only relevant for listed add-ons."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:46
@@ -4627,9 +4573,7 @@ msgid "Add-on Flags"
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:69
-msgid ""
-"These flags are used to classify add-ons. It is only\n"
-"                        relevant for listed add-ons."
+msgid "These flags are used to classify add-ons. It is only relevant for listed add-ons."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:74
@@ -4645,9 +4589,7 @@ msgid "View Source?"
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:90
-msgid ""
-"Whether the source of your add-on can be displayed in our\n"
-"                        online viewer. It is only relevant for listed add-ons."
+msgid "Whether the source of your add-on can be displayed in our online viewer. It is only relevant for listed add-ons."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:94
@@ -4663,10 +4605,7 @@ msgid "Public Stats?"
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:102
-msgid ""
-"Whether the download and usage stats of your add-on can\n"
-"                        be displayed in our online viewer.\n"
-"                        It is only relevant for listed add-ons."
+msgid "Whether the download and usage stats of your add-on can be displayed in our online viewer. It is only relevant for listed add-ons."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:107
@@ -4682,10 +4621,7 @@ msgid "Upgrade SDK?"
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:116
-msgid ""
-"If selected, we will try to automatically upgrade your\n"
-"                        add-on when a new version of the SDK is released.\n"
-"                        It is only relevant for listed add-ons."
+msgid "If selected, we will try to automatically upgrade your add-on when a new version of the SDK is released. It is only relevant for listed add-ons."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:121
@@ -4738,10 +4674,8 @@ msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/forms_shared/media.html:16
 msgid ""
-"Upload an icon for your add-on or choose from one of ours. The\n"
-"                      icon is displayed nearly everywhere your add-on is. Uploaded images\n"
-"                      must be one of the following image types: .png, .jpg.\n"
-"                      It is only relevant for listed add-ons."
+"Upload an icon for your add-on or choose from one of ours. The icon is displayed nearly everywhere your add-on is. Uploaded images must be one of the following image types: .png, .jpg. It is only "
+"relevant for listed add-ons."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/forms_shared/media.html:25
@@ -4754,9 +4688,7 @@ msgid "32x32px"
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/forms_shared/media.html:39
-msgid ""
-"Used in listings of add-ons, like search results\n"
-"                            and featured add-ons."
+msgid "Used in listings of add-ons, like search results and featured add-ons."
 msgstr ""
 
 #. The size of the icon
@@ -4851,16 +4783,14 @@ msgid "Deleting your add-on will permanently remove it from the site and prevent
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:24
-msgid ""
-"Enter the following text confirm your decision:\n"
-"           {slug}"
+msgid "Enter the following text confirm your decision: {slug}"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:34
+#: src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:33
 msgid "Please tell us why you are deleting your theme:"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:36
+#: src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:35
 msgid "Please tell us why you are deleting your add-on:"
 msgstr ""
 
@@ -4897,8 +4827,8 @@ msgstr "Nuwe weergawe"
 msgid "Daily statistics on downloads and users."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/addons/listing/item_actions.html:45 src/olympia/stats/templates/stats/stats.html:75 src/olympia/stats/templates/stats/stats.html:79
-#: src/olympia/stats/templates/stats/stats.html:81
+#: src/olympia/devhub/templates/devhub/addons/listing/item_actions.html:45 src/olympia/stats/templates/stats/stats.html:31 src/olympia/stats/templates/stats/stats.html:35
+#: src/olympia/stats/templates/stats/stats.html:37
 msgid "Statistics"
 msgstr "Statistiek"
 
@@ -5017,10 +4947,7 @@ msgid "Your add-on has been submitted to the Full Review queue."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/submit/done.html:18
-msgid ""
-"You'll receive an email once it has been reviewed by an editor. In\n"
-"          the meantime, you and your friends can install it directly from its\n"
-"          details page:"
+msgid "You'll receive an email once it has been reviewed by an editor. In the meantime, you and your friends can install it directly from its details page:"
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/submit/done.html:27 src/olympia/devhub/templates/devhub/addons/submit/done.html:77 src/olympia/devhub/templates/devhub/personas/submit_done.html:16
@@ -5226,11 +5153,11 @@ msgstr ""
 msgid "Use the fields below to upload your add-on package and select any platform restrictions. After upload, a series of automated validation tests will be run on your file."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/addons/submit/upload.html:59 src/olympia/devhub/templates/devhub/versions/add_file_modal.html:39
+#: src/olympia/devhub/templates/devhub/addons/submit/upload.html:51 src/olympia/devhub/templates/devhub/versions/add_file_modal.html:28
 msgid "Which platforms is this file compatible with?"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/addons/submit/upload.html:67 src/olympia/devhub/templates/devhub/versions/add_file_modal.html:65
+#: src/olympia/devhub/templates/devhub/addons/submit/upload.html:59 src/olympia/devhub/templates/devhub/versions/add_file_modal.html:45
 msgid "Administrative overrides"
 msgstr ""
 
@@ -5340,8 +5267,8 @@ msgstr ""
 
 #: src/olympia/devhub/templates/devhub/docs/policies-contact.html:44
 msgid ""
-"If you've found a problem with the site, we'd love to fix it. Please <a href=\"https://github.com/mozilla/olympia/issues\">file a bug report</a> in GitHub, including the location of the problem and "
-"how you encountered it."
+"If you've found a problem with the site, we'd love to fix it. Please <a href=\"https://github.com/mozilla/addons/issues/new\">file a bug report</a> in GitHub, including the location of the problem "
+"and how you encountered it."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/docs/policies-maintenance.html:3 src/olympia/devhub/templates/devhub/docs/policies-maintenance.html:7
@@ -5908,7 +5835,7 @@ msgstr ""
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:282
 msgid ""
-"Add-ons that store or otherwise handle browsing data must support <a href=\"https://developer.mozilla.org/En/Supporting_private_browsing_mode\">Private Browsing Mode</a>.  During a Private Browsing "
+"Add-ons that store or otherwise handle browsing data must support <a href=\"https://developer.mozilla.org/En/Supporting_private_browsing_mode\">Private Browsing Mode</a>. During a Private Browsing "
 "session, no browsing data can be written to disk, and all of this data must be cleared when Firefox quits or the Private Browsing session ends."
 msgstr ""
 
@@ -6073,129 +6000,95 @@ msgstr ""
 msgid "How to get in touch with us regarding these policies or your add-on."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:6
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:10
 msgid "You have disabled this add-on"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:20
-msgid ""
-"Your add-on's listing is disabled and is not showing\n"
-"                             anywhere in our gallery or update service."
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:24
+msgid "Your add-on's listing is disabled and is not showing anywhere in our gallery or update service."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:25
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:27
 msgid "Please complete your add-on."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:29
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:30
 msgid "You will receive an email when the review is complete."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:34
-msgid ""
-"You will receive an email when the review is complete. Until\n"
-"                             then, your add-on is not listed in our gallery but can be\n"
-"                             accessed directly from its details page."
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:33
+msgid "You will receive an email when the review is complete. Until then, your add-on is not listed in our gallery but can be accessed directly from its details page."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:38 src/olympia/devhub/templates/devhub/includes/addon_details.html:48
-msgid ""
-"You will receive an email when the review is\n"
-"                             complete and your add-on is signed."
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:37 src/olympia/devhub/templates/devhub/includes/addon_details.html:45
+msgid "You will receive an email when the review is complete and your add-on is signed."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:44
-msgid ""
-"You will receive an email when the review is complete. Until\n"
-"                             then, your add-on is not listed in our gallery but can be\n"
-"                             accessed directly from its details page. "
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:41
+msgid "You will receive an email when the review is complete. Until then, your add-on is not listed in our gallery but can be accessed directly from its details page. "
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:54
-msgid ""
-"Your add-on is displayed in our gallery and users are\n"
-"                             receiving automatic updates."
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:49
+msgid "Your add-on is displayed in our gallery and users are receiving automatic updates."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:57
-msgid ""
-"Your add-on has been signed and can be bundled with an\n"
-"                             application installer."
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:52
+msgid "Your add-on has been signed and can be bundled with an application installer."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:63
-msgid ""
-"Your add-on was disabled by a site administrator and is no\n"
-"                             longer shown in our gallery. If you have any questions,\n"
-"                             please email amo-admins@mozilla.org."
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:56
+msgid "Your add-on was disabled by a site administrator and is no longer shown in our gallery. If you have any questions, please email amo-admins@mozilla.org."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:70
-msgid ""
-"Your add-on is displayed in our gallery as experimental\n"
-"                             and users are receiving automatic updates. Some features\n"
-"                             are unavailable to your add-on."
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:62
+msgid "Your add-on is displayed in our gallery as experimental and users are receiving automatic updates. Some features are unavailable to your add-on."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:74
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:66
 msgid "Your add-on has been signed."
 msgstr ""
 
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:69
+msgid ""
+"You will receive an email when the full review is complete. Until then, your add-on is displayed in our gallery as experimental and users are receiving automatic updates. Some features are "
+"unavailable to your add-on."
+msgstr ""
+
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:74
+msgid "You will receive an email when the full review is complete, making you able to bundle your add-on with an application installer."
+msgstr ""
+
 #: src/olympia/devhub/templates/devhub/includes/addon_details.html:79
-msgid ""
-"You will receive an email when the full review is complete.\n"
-"                             Until then, your add-on is displayed in our gallery as\n"
-"                             experimental and users are receiving automatic updates.\n"
-"                             Some features are unavailable to your add-on."
+msgid "All add-ons hosted in our gallery must now be reviewed by an editor. If you wish to continue hosting your add-on, please click to select a review process."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:84
-msgid ""
-"You will receive an email when the full review is\n"
-"                             complete, making you able to bundle your add-on with an\n"
-"                             application installer."
-msgstr ""
-
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:91
-msgid ""
-"All add-ons hosted in our gallery must now be reviewed by an\n"
-"                             editor. If you wish to continue hosting your add-on, please\n"
-"                             click to select a review process."
-msgstr ""
-
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:113
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:100
 msgid "Current Version:"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:115
-msgid ""
-"This is the version of your add-on that will\n"
-"                                           be installed if someone clicks the Install\n"
-"                                           button on addons.mozilla.org. It is only\n"
-"                                           relevant for listed add-ons."
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:102
+msgid "This is the version of your add-on that will be installed if someone clicks the Install button on addons.mozilla.org. It is only relevant for listed add-ons."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:123
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:110
 msgid "Created:"
 msgstr ""
 
 #. {0} is a date. dennis-ignore: E201
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:125 src/olympia/devhub/templates/devhub/includes/addon_details.html:131
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:112 src/olympia/devhub/templates/devhub/includes/addon_details.html:118
 #, python-format
 msgid "%%b %%e, %%Y"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:136
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:123
 msgid "Next Version:"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:138
-msgid ""
-"This is the newest uploaded version, however\n"
-"                                           it isn’t live on the site yet."
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:125
+msgid "This is the newest uploaded version, however it isn’t live on the site yet."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:144 src/olympia/devhub/templates/devhub/versions/list.html:30
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:130 src/olympia/devhub/templates/devhub/versions/list.html:30
 msgid "Queues are not reviewed strictly in order"
 msgstr ""
 
@@ -6267,9 +6160,7 @@ msgid "View the blog &#9658;"
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/includes/license_form.html:6
-msgid ""
-"Please choose a license appropriate for the rights you grant on your source code.\n"
-"                  It is only relevant for listed add-ons."
+msgid "Please choose a license appropriate for the rights you grant on your source code. It is only relevant for listed add-ons."
 msgstr ""
 
 #. {0} is a list of HTML tags.
@@ -6296,14 +6187,11 @@ msgstr[1] ""
 #: src/olympia/devhub/templates/devhub/includes/policy_form.html:4
 msgid ""
 "Users will be required to accept the following End-User License Agreement (EULA) prior to installing your add-on. The presence of a EULA significantly affects the number of downloads an add-on "
-"receives. Please note that a EULA is not the same as a code license, such as the GPL or MPL.\n"
-"                It is only relevant for listed add-ons."
+"receives. Please note that a EULA is not the same as a code license, such as the GPL or MPL.It is only relevant for listed add-ons."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/policy_form.html:21
-msgid ""
-"If your add-on transmits any data from the user's computer, a privacy policy is required that explains what data is sent and how it is used.\n"
-"                It is only relevant for listed add-ons."
+#: src/olympia/devhub/templates/devhub/includes/policy_form.html:24
+msgid "If your add-on transmits any data from the user's computer, a privacy policy is required that explains what data is sent and how it is used. It is only relevant for listed add-ons."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/includes/source_form_field.html:2
@@ -6471,12 +6359,8 @@ msgstr ""
 msgid "Add some tags to describe your Theme."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/personas/edit.html:106
-msgid ""
-"A short explanation of your theme's\n"
-"                                basic functionality that is displayed in\n"
-"                                search and browse listings, as well as at\n"
-"                                the top of your theme's details page."
+#: src/olympia/devhub/templates/devhub/personas/edit.html:106 src/olympia/devhub/templates/devhub/personas/submit.html:54
+msgid "A short explanation of your theme's basic functionality that is displayed in search and browse listings, as well as at the top of your theme's details page."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/personas/edit.html:122 src/olympia/devhub/templates/devhub/personas/submit.html:68
@@ -6546,7 +6430,7 @@ msgid "Upon upload and form submission, the AMO Team will review your updated de
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/personas/edit.html:241
-msgid "Your previously resubmitted design,  which is under pending review."
+msgid "Your previously resubmitted design, which is under pending review."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/personas/edit.html:245
@@ -6613,14 +6497,6 @@ msgstr ""
 
 #: src/olympia/devhub/templates/devhub/personas/submit.html:33
 msgid "Give your Theme a name."
-msgstr ""
-
-#: src/olympia/devhub/templates/devhub/personas/submit.html:54
-msgid ""
-"A short explanation of your theme's\n"
-"                                      basic functionality that is displayed in\n"
-"                                      search and browse listings, as well as at\n"
-"                                      the top of your theme's details page."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/personas/submit.html:198
@@ -6697,30 +6573,16 @@ msgstr ""
 msgid "Files added to reviewed versions must be reviewed before they will be available for download."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/add_file_modal.html:15
-#, python-format
-msgid ""
-"Submission of updates to unlisted add-ons for signing is currently in an open beta. Manual review may still be required for a large number of add-ons. Please <a href=\"%(url)s\" target=\"_blank"
-"\">report any bugs</a> that you encounter."
-msgstr ""
-
-#: src/olympia/devhub/templates/devhub/versions/add_file_modal.html:35
+#: src/olympia/devhub/templates/devhub/versions/add_file_modal.html:24
 msgid "Select the target platform for this file."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/add_file_modal.html:46
+#: src/olympia/devhub/templates/devhub/versions/add_file_modal.html:35
 msgid "Which review type would you like to nominate for?"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/add_file_modal.html:51
+#: src/olympia/devhub/templates/devhub/versions/add_file_modal.html:40
 msgid "Only publish this version to my beta channel."
-msgstr ""
-
-#: src/olympia/devhub/templates/devhub/versions/add_file_modal.html:54
-#, python-format
-msgid ""
-"The behavior of the beta channel has changed to accommodate <a href=\"%(addon_signing_url)s\" target=\"_blank\">mandatory add-on signing</a>. The new process is currently in an open beta, and may "
-"change significantly in the near future. Please <a href=\"%(issues_url)s\" target=\"_blank\">report any bugs</a> that you encounter."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/versions/edit.html:5
@@ -6745,19 +6607,10 @@ msgstr ""
 msgid "Upload Another File"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/edit.html:45
-msgid ""
-"Adjusting application information here will allow users to install your\n"
-"                          add-on even if the install manifest in the package indicates that the\n"
-"                          add-on is incompatible."
-msgstr ""
-
 #: src/olympia/devhub/templates/devhub/versions/edit.html:74
 msgid ""
-"Information about changes in this release, new features,\n"
-"                              known bugs, and other useful information specific to this\n"
-"                              release/version. This information is also shown in the\n"
-"                              Add-ons Manager when updating."
+"Information about changes in this release, new features, known bugs, and other useful information specific to this release/version. This information is also shown in the Add-ons Manager when "
+"updating."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/versions/edit.html:99
@@ -6769,10 +6622,7 @@ msgid "Notes for Reviewers"
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/versions/edit.html:114
-msgid ""
-"Optionally, enter any information that may be useful\n"
-"                              to the Editor reviewing this add-on, such as test\n"
-"                              account information."
+msgid "Optionally, enter any information that may be useful to the Editor reviewing this add-on, such as test account information."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/versions/edit.html:127
@@ -6850,7 +6700,7 @@ msgstr ""
 msgid "Request Preliminary Review"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:80 src/olympia/devhub/templates/devhub/versions/list.html:327 src/olympia/devhub/templates/devhub/versions/list.html:350
+#: src/olympia/devhub/templates/devhub/versions/list.html:80 src/olympia/devhub/templates/devhub/versions/list.html:325 src/olympia/devhub/templates/devhub/versions/list.html:348
 msgid "Cancel Review Request"
 msgstr ""
 
@@ -6879,7 +6729,7 @@ msgid "Unlisted:"
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/versions/list.html:114
-msgid "Not distributed on {0}. Developers will upload new versions for signing and distribute the add-ons on their own. (beta)"
+msgid "Not distributed on {0}. Developers will upload new versions for signing and distribute the add-ons on their own."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/versions/list.html:122
@@ -6943,83 +6793,75 @@ msgid "<strong>Important:</strong> Once a version has been deleted, you may not 
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/versions/list.html:230
-msgid ""
-"Deleting a version which has already been reviewed\n"
-"               may also cause a significant delay in the review of\n"
-"               your next update."
-msgstr ""
-
-#: src/olympia/devhub/templates/devhub/versions/list.html:233
 msgid "Are you sure you wish to delete this version?"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:238
+#: src/olympia/devhub/templates/devhub/versions/list.html:235
 msgid "Delete Version"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:240
+#: src/olympia/devhub/templates/devhub/versions/list.html:237
 msgid "Disable Version"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:247
+#: src/olympia/devhub/templates/devhub/versions/list.html:244
 msgid "Add a new Version"
 msgstr ""
 
 # 75%
 # 100%
-#: src/olympia/devhub/templates/devhub/versions/list.html:249
+#: src/olympia/devhub/templates/devhub/versions/list.html:246
 msgid "Add Version"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:256 src/olympia/devhub/templates/devhub/versions/list.html:274
+#: src/olympia/devhub/templates/devhub/versions/list.html:253 src/olympia/devhub/templates/devhub/versions/list.html:279
 msgid "Hide Add-on"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:259
+#: src/olympia/devhub/templates/devhub/versions/list.html:256
 msgid "Hiding your add-on will prevent it from appearing anywhere in our gallery and will stop users from receiving automatic updates."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:265
+#: src/olympia/devhub/templates/devhub/versions/list.html:263
+msgid "The files awaiting review will be disabled and you will need to upload new versions."
+msgstr ""
+
+#: src/olympia/devhub/templates/devhub/versions/list.html:270
 msgid "Are you sure you wish to hide your add-on?"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:286 src/olympia/devhub/templates/devhub/versions/list.html:315
+#: src/olympia/devhub/templates/devhub/versions/list.html:291 src/olympia/devhub/templates/devhub/versions/list.html:313
 msgid "Unlist Add-on"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:289
+#: src/olympia/devhub/templates/devhub/versions/list.html:294
 #, python-format
 msgid ""
 "Unlisting your add-on will make it (and each of its versions/files) invisible on this website. It won't show up in searches, won't have a public facing page, and won't be updated automatically for "
-"current users.  It is recommended for unlisted add-ons to provide a custom <a href=\"%(update_url)s\" target=\"_blank\">updateURL</a> in their manifest file for automatic updates."
+"current users. It is recommended for unlisted add-ons to provide a custom <a href=\"%(update_url)s\" target=\"_blank\">updateURL</a> in their manifest file for automatic updates."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:299
-#, python-format
-msgid "Switching add-ons to unlisted is currently in an open beta. Please <a href=\"%(url)s\" target=\"_blank\">report any bugs</a> that you encounter."
-msgstr ""
-
-#: src/olympia/devhub/templates/devhub/versions/list.html:305
+#: src/olympia/devhub/templates/devhub/versions/list.html:303
 msgid "Unlisting an add-on is irreversible!"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:305
+#: src/olympia/devhub/templates/devhub/versions/list.html:303
 msgid "An unlisted add-on cannot be switched to be listed."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:307
+#: src/olympia/devhub/templates/devhub/versions/list.html:305
 msgid "Are you sure you wish to unlist your add-on?"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:330
+#: src/olympia/devhub/templates/devhub/versions/list.html:328
 msgid "Canceling your review request will leave your add-on as preliminarily reviewed."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:335
+#: src/olympia/devhub/templates/devhub/versions/list.html:333
 msgid "Canceling your review request will mark your add-on incomplete. If you do not complete your add-on after several days by re-requesting review, it will be deleted."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:343
+#: src/olympia/devhub/templates/devhub/versions/list.html:341
 msgid "Are you sure you wish to cancel your review request?"
 msgstr ""
 
@@ -7367,19 +7209,19 @@ msgstr ""
 msgid "Search by add-on name / author email"
 msgstr ""
 
-#: src/olympia/editors/forms.py:103
+#: src/olympia/editors/forms.py:103 src/olympia/editors/forms.py:244 src/olympia/editors/forms.py:257
 msgid "yes"
 msgstr "ja"
 
-#: src/olympia/editors/forms.py:104
+#: src/olympia/editors/forms.py:104 src/olympia/editors/forms.py:244 src/olympia/editors/forms.py:257
 msgid "no"
 msgstr "nee"
 
-#: src/olympia/editors/forms.py:105
+#: src/olympia/editors/forms.py:105 src/olympia/editors/forms.py:245
 msgid "Admin Flag"
 msgstr ""
 
-#: src/olympia/editors/forms.py:113
+#: src/olympia/editors/forms.py:113 src/olympia/editors/forms.py:253
 msgid "Max. Version"
 msgstr ""
 
@@ -7391,55 +7233,59 @@ msgstr ""
 msgid "Add-on Types"
 msgstr ""
 
-#: src/olympia/editors/forms.py:126 src/olympia/editors/helpers.py:267
+#: src/olympia/editors/forms.py:126 src/olympia/editors/helpers.py:279
 msgid "Platforms"
 msgstr "Platforms"
 
+#: src/olympia/editors/forms.py:237
+msgid "Search by add-on name / author email / guid"
+msgstr ""
+
 #. L10n: 0 = platform, 1 = filename, 2 = status message
-#: src/olympia/editors/forms.py:238
+#: src/olympia/editors/forms.py:342
 #, python-format
 msgid "<strong>%s</strong> &middot; %s &middot; %s"
 msgstr ""
 
-#: src/olympia/editors/forms.py:252
+#: src/olympia/editors/forms.py:356
 msgid "Comments:"
 msgstr ""
 
-#: src/olympia/editors/forms.py:256
+#: src/olympia/editors/forms.py:360
 msgid "Operating systems:"
 msgstr "Bedryfstelsels:"
 
-#: src/olympia/editors/forms.py:258
+#: src/olympia/editors/forms.py:362
 msgid "Applications:"
 msgstr "Toepassings:"
 
-#: src/olympia/editors/forms.py:260
+#: src/olympia/editors/forms.py:364
 msgid "Notify me the next time this add-on is updated. (Subsequent updates will not generate an email)"
 msgstr ""
 
-#: src/olympia/editors/forms.py:265
+#: src/olympia/editors/forms.py:369
 msgid "Clear Admin Review Flag"
 msgstr ""
 
-#: src/olympia/editors/forms.py:267
+#: src/olympia/editors/forms.py:371
 msgid "Clear more info requested flag"
 msgstr ""
 
-#: src/olympia/editors/forms.py:281
+#: src/olympia/editors/forms.py:385
 msgid "Choose a canned response..."
 msgstr ""
 
 #. L10n: Description of what can be searched for.
-#: src/olympia/editors/forms.py:324
+#: src/olympia/editors/forms.py:423
 msgid "theme name"
 msgstr ""
 
-#: src/olympia/editors/forms.py:350
+#: src/olympia/editors/forms.py:449
 msgid "Someone else is reviewing this theme."
 msgstr ""
 
 #. L10n: Description of what can be searched for.
-#: src/olympia/editors/forms.py:447
+#: src/olympia/editors/forms.py:546
 msgid "app, reviewer, or comment"
 msgstr ""
 
@@ -7455,246 +7301,264 @@ msgstr ""
 msgid "Rejected or Unreviewed"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:123 src/olympia/editors/helpers.py:136
+#: src/olympia/editors/helpers.py:125 src/olympia/editors/helpers.py:138
 msgid "Queue"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:124 src/olympia/editors/templates/editors/base.html:50 src/olympia/editors/templates/editors/base.html:65
+#: src/olympia/editors/helpers.py:126 src/olympia/editors/templates/editors/base.html:50 src/olympia/editors/templates/editors/base.html:65
 msgid "Pending Updates"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:125 src/olympia/editors/templates/editors/base.html:48 src/olympia/editors/templates/editors/base.html:63
+#: src/olympia/editors/helpers.py:127 src/olympia/editors/templates/editors/base.html:48 src/olympia/editors/templates/editors/base.html:63
 msgid "Full Reviews"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:126 src/olympia/editors/templates/editors/base.html:52 src/olympia/editors/templates/editors/base.html:67
+#: src/olympia/editors/helpers.py:128 src/olympia/editors/templates/editors/base.html:52 src/olympia/editors/templates/editors/base.html:67
 msgid "Preliminary Reviews"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:127 src/olympia/editors/templates/editors/base.html:54
+#: src/olympia/editors/helpers.py:129 src/olympia/editors/templates/editors/base.html:54
 msgid "Moderated Reviews"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:128 src/olympia/editors/templates/editors/base.html:46
+#: src/olympia/editors/helpers.py:130 src/olympia/editors/templates/editors/base.html:46
 msgid "Fast Track"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:130
+#: src/olympia/editors/helpers.py:132
 msgid "Pending Themes"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:131 src/olympia/editors/templates/editors/themes/queue.html:4
+#: src/olympia/editors/helpers.py:133 src/olympia/editors/templates/editors/themes/queue.html:4
 msgid "Flagged Themes"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:132
+#: src/olympia/editors/helpers.py:134
 msgid "Update Themes"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:137
+#: src/olympia/editors/helpers.py:139
 msgid "Unlisted Pending Updates"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:138
+#: src/olympia/editors/helpers.py:140
 msgid "Unlisted Full Reviews"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:139
+#: src/olympia/editors/helpers.py:141
 msgid "Unlisted Preliminary Reviews"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:170
+#: src/olympia/editors/helpers.py:142
+msgid "Unlisted All Add-ons"
+msgstr ""
+
+#: src/olympia/editors/helpers.py:173
 msgid "Fast Track ({0})"
 msgid_plural "Fast Track ({0})"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/olympia/editors/helpers.py:175
+#: src/olympia/editors/helpers.py:178
 msgid "Full Review ({0})"
 msgid_plural "Full Reviews ({0})"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/olympia/editors/helpers.py:180
+#: src/olympia/editors/helpers.py:183
 msgid "Pending Update ({0})"
 msgid_plural "Pending Updates ({0})"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/olympia/editors/helpers.py:185
+#: src/olympia/editors/helpers.py:188
 msgid "Preliminary Review ({0})"
 msgid_plural "Preliminary Reviews ({0})"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/olympia/editors/helpers.py:190
+#: src/olympia/editors/helpers.py:193
 msgid "Moderated Review ({0})"
 msgid_plural "Moderated Reviews ({0})"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/olympia/editors/helpers.py:196
+#: src/olympia/editors/helpers.py:199
 msgid "Unlisted Full Review ({0})"
 msgid_plural "Unlisted Full Reviews ({0})"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/olympia/editors/helpers.py:201
+#: src/olympia/editors/helpers.py:204
 msgid "Unlisted Pending Update ({0})"
 msgid_plural "Unlisted Pending Updates ({0})"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/olympia/editors/helpers.py:206
+#: src/olympia/editors/helpers.py:209
 msgid "Unlisted Preliminary Review ({0})"
 msgid_plural "Unlisted Preliminary Reviews ({0})"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/olympia/editors/helpers.py:261
-msgid "Addon"
-msgstr ""
+#: src/olympia/editors/helpers.py:214
+msgid "Unlisted All Add-ons ({0})"
+msgid_plural "Unlisted All Add-ons ({0})"
+msgstr[0] ""
+msgstr[1] ""
 
-#: src/olympia/editors/helpers.py:262
+#: src/olympia/editors/helpers.py:274
 msgid "Type"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:263
+#: src/olympia/editors/helpers.py:275
 msgid "Waiting Time"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:264 src/olympia/editors/templates/editors/review.html:285
+#: src/olympia/editors/helpers.py:276 src/olympia/editors/templates/editors/review.html:285
 msgid "Flags"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:265
+#: src/olympia/editors/helpers.py:277
 msgid "Applications"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:270
+#: src/olympia/editors/helpers.py:282
 msgid "Additional"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:285
+#: src/olympia/editors/helpers.py:302
 msgid "Site Specific"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:287
+#: src/olympia/editors/helpers.py:304
 msgid "Requires External Software"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:289
+#: src/olympia/editors/helpers.py:306
 msgid "Binary Components"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:313
+#: src/olympia/editors/helpers.py:339
 msgid "moments ago"
 msgstr ""
 
 #. L10n: first argument is number of minutes
-#: src/olympia/editors/helpers.py:316
+#: src/olympia/editors/helpers.py:342
 msgid "{0} minute"
 msgid_plural "{0} minutes"
 msgstr[0] ""
 msgstr[1] ""
 
 #. L10n: first argument is number of hours
-#: src/olympia/editors/helpers.py:320
+#: src/olympia/editors/helpers.py:346
 msgid "{0} hour"
 msgid_plural "{0} hours"
 msgstr[0] ""
 msgstr[1] ""
 
 #. L10n: first argument is number of days
-#: src/olympia/editors/helpers.py:324
+#: src/olympia/editors/helpers.py:350
 msgid "{0} day"
 msgid_plural "{0} days"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/olympia/editors/helpers.py:488
+#: src/olympia/editors/helpers.py:364
+msgid "Last Review"
+msgstr ""
+
+#: src/olympia/editors/helpers.py:366
+msgid "Last Update"
+msgstr ""
+
+#: src/olympia/editors/helpers.py:387
+msgid "No Reviews"
+msgstr ""
+
+#: src/olympia/editors/helpers.py:561
 msgid "Push to public"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:490
+#: src/olympia/editors/helpers.py:563
 msgid "Grant full review"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:505
+#: src/olympia/editors/helpers.py:578
 msgid "Request more information"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:508
+#: src/olympia/editors/helpers.py:581
 msgid "Request super-review"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:519
+#: src/olympia/editors/helpers.py:592
 msgid "Grant preliminary review"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:520
+#: src/olympia/editors/helpers.py:593
 msgid "This will mark the files as preliminarily reviewed."
 msgstr ""
 
-#: src/olympia/editors/helpers.py:522
+#: src/olympia/editors/helpers.py:595
 msgid "Use this form to request more information from the author. They will receive an email and be able to answer here. You will be notified by email when they reply."
 msgstr ""
 
-#: src/olympia/editors/helpers.py:526
+#: src/olympia/editors/helpers.py:599
 msgid ""
 "If you have concerns about this add-on's security, copyright issues, or other concerns that an administrator should look into, enter your comments in the area below. They will be sent to "
 "administrators, not the author."
 msgstr ""
 
-#: src/olympia/editors/helpers.py:532
+#: src/olympia/editors/helpers.py:605
 msgid "This will reject the add-on and remove it from the review queue."
 msgstr ""
 
-#: src/olympia/editors/helpers.py:534
-msgid "Make a comment on this version.  The author won't be able to see this."
+#: src/olympia/editors/helpers.py:607
+msgid "Make a comment on this version. The author won't be able to see this."
 msgstr ""
 
-#: src/olympia/editors/helpers.py:538
+#: src/olympia/editors/helpers.py:611
 msgid "This will reject the files and remove them from the review queue."
 msgstr ""
 
-#: src/olympia/editors/helpers.py:542
+#: src/olympia/editors/helpers.py:615
 msgid "This will mark the add-on as preliminarily reviewed. Future versions will undergo preliminary review."
 msgstr ""
 
-#: src/olympia/editors/helpers.py:547
+#: src/olympia/editors/helpers.py:620
 msgid "This will mark the files as preliminarily reviewed. Future versions will undergo preliminary review."
 msgstr ""
 
-#: src/olympia/editors/helpers.py:552
+#: src/olympia/editors/helpers.py:625
 msgid "Retain preliminary review"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:553
+#: src/olympia/editors/helpers.py:626
 msgid "This will retain the add-on as preliminarily reviewed. Future versions will undergo preliminary review."
 msgstr ""
 
-#: src/olympia/editors/helpers.py:558
+#: src/olympia/editors/helpers.py:631
 msgid "This will approve a sandboxed version of a public add-on to appear on the public side."
 msgstr ""
 
-#: src/olympia/editors/helpers.py:561
+#: src/olympia/editors/helpers.py:634
 msgid "This will reject a version of a public add-on and remove it from the queue."
 msgstr ""
 
-#: src/olympia/editors/helpers.py:564
+#: src/olympia/editors/helpers.py:637
 msgid "This will mark the add-on and its most recent version and files as public. Future versions will go into the sandbox until they are reviewed by an editor."
 msgstr ""
 
-#: src/olympia/editors/helpers.py:637
+#: src/olympia/editors/helpers.py:714
 msgid "add-on"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:940 src/olympia/editors/helpers.py:960
+#: src/olympia/editors/helpers.py:1020 src/olympia/editors/helpers.py:1040
 msgid "Flagged"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:944 src/olympia/editors/helpers.py:963
+#: src/olympia/editors/helpers.py:1024 src/olympia/editors/helpers.py:1043
 msgid "Updates"
 msgstr ""
 
@@ -7746,56 +7610,56 @@ msgstr ""
 msgid "A question about your Theme submission"
 msgstr ""
 
-#: src/olympia/editors/views.py:144
+#: src/olympia/editors/views.py:146
 msgid "New Add-ons (Under 5 days)"
 msgstr ""
 
-#: src/olympia/editors/views.py:145
+#: src/olympia/editors/views.py:147
 msgid "Passable (5 to 10 days)"
 msgstr ""
 
-#: src/olympia/editors/views.py:146
+#: src/olympia/editors/views.py:148
 msgid "Overdue (Over 10 days)"
 msgstr ""
 
-#: src/olympia/editors/views.py:532
+#: src/olympia/editors/views.py:539
 msgid "An unknown error occurred"
 msgstr ""
 
-#: src/olympia/editors/views.py:587
+#: src/olympia/editors/views.py:592
 msgid "Self-reviews are not allowed."
 msgstr ""
 
-#: src/olympia/editors/views.py:609
+#: src/olympia/editors/views.py:613
 msgid "Review successfully processed."
 msgstr ""
 
-#: src/olympia/editors/views.py:807
+#: src/olympia/editors/views.py:812
 msgid "was approved"
 msgstr ""
 
-#: src/olympia/editors/views.py:808
+#: src/olympia/editors/views.py:813
 msgid "given preliminary review"
 msgstr ""
 
-#: src/olympia/editors/views.py:809
+#: src/olympia/editors/views.py:814
 msgid "rejected"
 msgstr ""
 
-#: src/olympia/editors/views.py:810
+#: src/olympia/editors/views.py:815
 msgctxt "editors_review_history_nominated_adminreview"
 msgid "escalated"
 msgstr ""
 
-#: src/olympia/editors/views.py:812
+#: src/olympia/editors/views.py:817
 msgid "needs more information"
 msgstr ""
 
-#: src/olympia/editors/views.py:813
+#: src/olympia/editors/views.py:818
 msgid "needs super review"
 msgstr ""
 
-#: src/olympia/editors/views.py:814
+#: src/olympia/editors/views.py:819
 msgid "commented"
 msgstr ""
 
@@ -7840,28 +7704,28 @@ msgstr ""
 msgid "Unlisted Queues"
 msgstr ""
 
-#: src/olympia/editors/templates/editors/base.html:72 src/olympia/editors/templates/editors/performance.html:6
+#: src/olympia/editors/templates/editors/base.html:74 src/olympia/editors/templates/editors/performance.html:6
 msgid "Performance"
 msgstr "Werkverrigting"
 
-#: src/olympia/editors/templates/editors/base.html:75 src/olympia/editors/templates/editors/themes/base.html:19 src/olympia/editors/templates/editors/themes/base.html:38
+#: src/olympia/editors/templates/editors/base.html:77 src/olympia/editors/templates/editors/themes/base.html:19 src/olympia/editors/templates/editors/themes/base.html:38
 msgid "Logs"
 msgstr ""
 
-#: src/olympia/editors/templates/editors/base.html:78 src/olympia/editors/templates/editors/reviewlog.html:4 src/olympia/editors/templates/editors/reviewlog.html:27
+#: src/olympia/editors/templates/editors/base.html:80 src/olympia/editors/templates/editors/reviewlog.html:4 src/olympia/editors/templates/editors/reviewlog.html:27
 msgid "Add-on Review Log"
 msgstr ""
 
-#: src/olympia/editors/templates/editors/base.html:80 src/olympia/editors/templates/editors/eventlog.html:4 src/olympia/editors/templates/editors/eventlog.html:8
+#: src/olympia/editors/templates/editors/base.html:82 src/olympia/editors/templates/editors/eventlog.html:4 src/olympia/editors/templates/editors/eventlog.html:8
 #: src/olympia/editors/templates/editors/eventlog_detail.html:4
 msgid "Moderated Review Log"
 msgstr ""
 
-#: src/olympia/editors/templates/editors/base.html:82 src/olympia/editors/templates/editors/beta_signed_log.html:4 src/olympia/editors/templates/editors/beta_signed_log.html:8
+#: src/olympia/editors/templates/editors/base.html:84 src/olympia/editors/templates/editors/beta_signed_log.html:4 src/olympia/editors/templates/editors/beta_signed_log.html:8
 msgid "Signed Beta Files Log"
 msgstr ""
 
-#: src/olympia/editors/templates/editors/base.html:87 src/olympia/editors/templates/editors/includes/daily-message.html:4
+#: src/olympia/editors/templates/editors/base.html:89 src/olympia/editors/templates/editors/includes/daily-message.html:4
 msgid "Announcement"
 msgstr "Aankondiging"
 
@@ -8082,45 +7946,45 @@ msgstr ""
 msgid "clear search"
 msgstr ""
 
-#: src/olympia/editors/templates/editors/queue.html:72 src/olympia/editors/templates/editors/queue.html:122
+#: src/olympia/editors/templates/editors/queue.html:78 src/olympia/editors/templates/editors/queue.html:128
 msgid "Process Reviews"
 msgstr ""
 
-#: src/olympia/editors/templates/editors/queue.html:80
+#: src/olympia/editors/templates/editors/queue.html:86
 msgid "Moderation actions:"
 msgstr ""
 
-#: src/olympia/editors/templates/editors/queue.html:90
+#: src/olympia/editors/templates/editors/queue.html:96
 #, python-format
 msgid "by %(user)s on %(date)s %(stars)s (%(locale)s)"
 msgstr ""
 
-#: src/olympia/editors/templates/editors/queue.html:106
+#: src/olympia/editors/templates/editors/queue.html:112
 #, python-format
 msgid "<strong>%(reason)s</strong> <span class=\"light\">Flagged by %(user)s on %(date)s</span>"
 msgstr ""
 
-#: src/olympia/editors/templates/editors/queue.html:119
-msgid "All reviews have been moderated.  Good work!"
+#: src/olympia/editors/templates/editors/queue.html:125
+msgid "All reviews have been moderated. Good work!"
 msgstr ""
 
-#: src/olympia/editors/templates/editors/queue.html:161
+#: src/olympia/editors/templates/editors/queue.html:167
 msgid "Version Notes / Notes for Reviewer"
 msgstr ""
 
-#: src/olympia/editors/templates/editors/queue.html:169
+#: src/olympia/editors/templates/editors/queue.html:175
 msgid "There are currently no add-ons of this type to review."
 msgstr ""
 
-#: src/olympia/editors/templates/editors/queue.html:181 src/olympia/editors/templates/editors/themes/queue_list.html:85
+#: src/olympia/editors/templates/editors/queue.html:187 src/olympia/editors/templates/editors/themes/queue_list.html:85
 msgid "Helpful Links:"
 msgstr ""
 
-#: src/olympia/editors/templates/editors/queue.html:182
+#: src/olympia/editors/templates/editors/queue.html:188
 msgid "Add-on Policy"
 msgstr ""
 
-#: src/olympia/editors/templates/editors/queue.html:184
+#: src/olympia/editors/templates/editors/queue.html:190
 msgid "Editors' Guide"
 msgstr ""
 
@@ -8183,10 +8047,7 @@ msgid "<strong>Warning!</strong> Another user was viewing this page before you."
 msgstr ""
 
 #: src/olympia/editors/templates/editors/review.html:237
-msgid ""
-"The whiteboard is the place to exchange information relevant to\n"
-"               this addon (whatever the version), between the developer and the\n"
-"               editor. This is visible and editable by both."
+msgid "The whiteboard is the place to exchange information relevant to this addon (whatever the version), between the developer and the editor. This is visible and editable by both."
 msgstr ""
 
 #: src/olympia/editors/templates/editors/review.html:241
@@ -8460,7 +8321,7 @@ msgstr ""
 msgid "Describe your reason for flagging"
 msgstr ""
 
-#: src/olympia/files/forms.py:88
+#: src/olympia/files/forms.py:90
 msgid "Cannot diff a version against itself"
 msgstr ""
 
@@ -8495,51 +8356,51 @@ msgstr ""
 msgid "There was an error accessing file %s."
 msgstr ""
 
-#: src/olympia/files/utils.py:343
+#: src/olympia/files/utils.py:340
 msgid "Could not parse uploaded file."
 msgstr ""
 
-#: src/olympia/files/utils.py:380
+#: src/olympia/files/utils.py:377
 msgid "Invalid file name in archive: {0}"
 msgstr ""
 
-#: src/olympia/files/utils.py:388
+#: src/olympia/files/utils.py:385
 msgid "File exceeding size limit in archive: {0}"
 msgstr ""
 
-#: src/olympia/files/utils.py:439
+#: src/olympia/files/utils.py:436
 msgid "Invalid archive."
 msgstr ""
 
-#: src/olympia/files/utils.py:529 src/olympia/files/utils.py:532
+#: src/olympia/files/utils.py:526 src/olympia/files/utils.py:529
 msgid "Could not parse the manifest file."
 msgstr ""
 
-#: src/olympia/files/utils.py:551
+#: src/olympia/files/utils.py:548
 msgid "Could not find an add-on ID."
 msgstr ""
 
-#: src/olympia/files/utils.py:554
+#: src/olympia/files/utils.py:551
 msgid "Add-on ID must be 64 characters or less."
 msgstr ""
 
-#: src/olympia/files/utils.py:556
+#: src/olympia/files/utils.py:553
 msgid "Add-on ID doesn't match add-on."
 msgstr ""
 
-#: src/olympia/files/utils.py:564
+#: src/olympia/files/utils.py:561
 msgid "Duplicate add-on ID found."
 msgstr ""
 
-#: src/olympia/files/utils.py:567
+#: src/olympia/files/utils.py:564
 msgid "Version numbers should have fewer than 32 characters."
 msgstr ""
 
-#: src/olympia/files/utils.py:570
+#: src/olympia/files/utils.py:567
 msgid "Version numbers should only contain letters, numbers, and these punctuation characters: +*.-_."
 msgstr ""
 
-#: src/olympia/files/utils.py:587
+#: src/olympia/files/utils.py:584
 msgid "<em:type> doesn't match add-on"
 msgstr ""
 
@@ -8638,6 +8499,10 @@ msgstr ""
 
 #: src/olympia/files/templates/files/viewer.html:134
 msgid "Fetching file."
+msgstr ""
+
+#: src/olympia/legacy_api/views.py:255
+msgid "Not implemented yet."
 msgstr ""
 
 #: src/olympia/lib/constants.py:6
@@ -9296,10 +9161,6 @@ msgstr ""
 msgid "Zimbabwe Dollar"
 msgstr ""
 
-#: src/olympia/lib/video/ffmpeg.py:112 src/olympia/lib/video/totem.py:81
-msgid "Videos must be in WebM."
-msgstr ""
-
 #: src/olympia/pages/templates/pages/about.lhtml:3 src/olympia/pages/templates/pages/about.lhtml:10
 msgid "About Mozilla Add-ons"
 msgstr ""
@@ -9311,7 +9172,7 @@ msgstr ""
 #: src/olympia/pages/templates/pages/about.lhtml:13
 msgid ""
 "addons.mozilla.org, commonly known as \"AMO\", is Mozilla's official site for add-ons to Mozilla software, such as Firefox, Thunderbird, and SeaMonkey. Add-ons let you add new features and change "
-"the way your browser or application works.  Take a look around and explore the thousands of ways to customize the way you do things online."
+"the way your browser or application works. Take a look around and explore the thousands of ways to customize the way you do things online."
 msgstr ""
 
 #: src/olympia/pages/templates/pages/about.lhtml:19
@@ -9656,7 +9517,7 @@ msgstr ""
 msgid ""
 "Yes. It's possible, but some of the functionality provided by these libraries are available through XPCOM, XUL, and JavaScript. In addition, authors should take care if libraries modify primitive "
 "object prototypes (String.prototype, Date.prototype, etc.) and/or define global functions (eg. the $ function). These are prone to cause conflict with other add-ons, in particular if different add-"
-"ons use different versions of libraries and so on. Developers need to be very, very careful with using them.  Mozilla does not offer documentation on using them to build add-ons."
+"ons use different versions of libraries and so on. Developers need to be very, very careful with using them. Mozilla does not offer documentation on using them to build add-ons."
 msgstr ""
 
 #: src/olympia/pages/templates/pages/dev_faq.html:165
@@ -9770,8 +9631,8 @@ msgstr ""
 #, python-format
 msgid ""
 "Yes. Many developers choose to host their own add-ons. Choosing to host your add-on on <a href=\"%(amo_url)s\">Mozilla's add-on site</a>, though, allows for much greater exposure to your add-on due "
-"to the large volume of visitors to the site.  <a href=\"%(md_url)s\">mozdev.org</a> offers free project hosting for Mozilla applications and extensions providing developers with tools to help "
-"manage source code, version control, bug tracking and documentation."
+"to the large volume of visitors to the site. <a href=\"%(md_url)s\">mozdev.org</a> offers free project hosting for Mozilla applications and extensions providing developers with tools to help manage "
+"source code, version control, bug tracking and documentation."
 msgstr ""
 
 #: src/olympia/pages/templates/pages/dev_faq.html:277
@@ -9819,7 +9680,7 @@ msgstr ""
 #: src/olympia/pages/templates/pages/dev_faq.html:314
 #, python-format
 msgid ""
-"Yes. Mozilla's <a href=\"%(p_url)s\">Add-on Policy</a> describes what is an acceptable submission. This policy is subject to change without notice.  In addition, the AMO editorial team uses the <a "
+"Yes. Mozilla's <a href=\"%(p_url)s\">Add-on Policy</a> describes what is an acceptable submission. This policy is subject to change without notice. In addition, the AMO editorial team uses the <a "
 "href=\"%(g_url)s\">Editors Reviewing Guide</a> to ensure that your add-on meets specific guidelines for functionality and security."
 msgstr ""
 
@@ -9936,7 +9797,7 @@ msgstr ""
 #: src/olympia/pages/templates/pages/dev_faq.html:434
 #, python-format
 msgid ""
-"This is why it's very important to read the <a href=\"%(g_url)s\">Editors Reviewing Guide</a> to ensure that your add-on is setup as expected.  It's also a good idea to read the blog post, <a href="
+"This is why it's very important to read the <a href=\"%(g_url)s\">Editors Reviewing Guide</a> to ensure that your add-on is setup as expected. It's also a good idea to read the blog post, <a href="
 "\"%(blog_url)s\">Successfully Getting your Add-on Reviewed</a> which provides excellent insight into ensuring a smooth review of your add-on."
 msgstr ""
 
@@ -10043,7 +9904,7 @@ msgstr ""
 
 #: src/olympia/pages/templates/pages/dev_faq.html:572
 msgid ""
-"Free Software Foundation provides short summaries of the key open source licenses, including whether the license qualifies as a free software license or a copyleft license.  Also includes a "
+"Free Software Foundation provides short summaries of the key open source licenses, including whether the license qualifies as a free software license or a copyleft license. Also includes a "
 "discussion of what constitutes a free software license or a copyleft license (e.g., a Copyleft license is a general method for making a program or other work free, and requiring all modified and "
 "extended versions of the program to be free as well.)"
 msgstr ""
@@ -10221,19 +10082,13 @@ msgid "Add-on Gallery"
 msgstr ""
 
 #: src/olympia/pages/templates/pages/faq.html:171
-msgid ""
-"How do I choose between add-ons that seem to do the same\n"
-"    thing?"
+msgid "How do I choose between add-ons that seem to do the same thing?"
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:173
+#: src/olympia/pages/templates/pages/faq.html:172
 msgid ""
-"There are often several add-ons that have similar features. To\n"
-"    figure out which is right for you, read the entire description of the\n"
-"    add-on and view its screenshots. If there are still several in the running,\n"
-"    read through the add-on's ratings, user reviews, and statistics to see\n"
-"    which is most liked by other users. Remember that you can also just try\n"
-"    out both and see which you like better."
+"There are often several add-ons that have similar features. To figure out which is right for you, read the entire description of the add-on and view its screenshots. If there are still several in "
+"the running, read through the add-on's ratings, user reviews, and statistics to see which is most liked by other users. Remember that you can also just try out both and see which you like better."
 msgstr ""
 
 #: src/olympia/pages/templates/pages/faq.html:180
@@ -10274,80 +10129,67 @@ msgid "How much do add-ons cost to purchase?"
 msgstr ""
 
 #: src/olympia/pages/templates/pages/faq.html:207
-msgid ""
-"Add-ons hosted in our gallery are free unless clearly marked\n"
-"    otherwise."
+msgid "Add-ons hosted in our gallery are free unless clearly marked otherwise."
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:210
+#: src/olympia/pages/templates/pages/faq.html:209
 msgid "What does it mean when an add-on asks for contributions?"
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:211
+#: src/olympia/pages/templates/pages/faq.html:210
 msgid ""
-"Some add-on authors request users who enjoy an add-on to\n"
-"        contribute to its development by making a monetary contribution. These\n"
-"        contributions go directly to the developer unless a third party is\n"
-"        indicated, such as the non-profit Mozilla Foundation."
+"Some add-on authors request users who enjoy an add-on to contribute to its development by making a monetary contribution. These contributions go directly to the developer unless a third party is "
+"indicated, such as the non-profit Mozilla Foundation."
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:216
+#: src/olympia/pages/templates/pages/faq.html:215
 msgid "What are beta add-ons?"
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:218
+#: src/olympia/pages/templates/pages/faq.html:217
 msgid ""
-"Beta add-ons are unreviewed versions which represent the\n"
-"        latest work of an add-on author. While different authors have different\n"
-"        standards for beta code quality, you should assume that these add-ons\n"
-"        are less stable than the general add-on releases."
+"Beta add-ons are unreviewed versions which represent the latest work of an add-on author. While different authors have different standards for beta code quality, you should assume that these add-"
+"ons are less stable than the general add-on releases."
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:222
+#: src/olympia/pages/templates/pages/faq.html:221
 msgid ""
 "Please note that when you install an add-on from the \"Beta Version\" section of an add-on's listing, you will continue to receive updates for that add-on as they become available. Like the initial "
 "version you installed, all beta releases are unreviewed by Mozilla and may harm your computer."
 msgstr ""
 
+#: src/olympia/pages/templates/pages/faq.html:228
+msgid "What does it mean when an add-on is flagged as slow?"
+msgstr ""
+
 #: src/olympia/pages/templates/pages/faq.html:229
-msgid ""
-"What does it mean when an add-on is flagged as\n"
-"    slow?"
+msgid "Most add-ons load code and resources at the same time Firefox is starting up. In most cases the impact in start-up time is minimal, but some add-ons can cause a noticeable slowdown."
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:231
-msgid ""
-"Most add-ons load code and resources at the same time Firefox\n"
-"        is starting up. In most cases the impact in start-up time is minimal,\n"
-"        but some add-ons can cause a noticeable slowdown."
-msgstr ""
-
-#: src/olympia/pages/templates/pages/faq.html:236
+#: src/olympia/pages/templates/pages/faq.html:234
 msgid "How do I report an inappropriate or spam user review?"
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:237
+#: src/olympia/pages/templates/pages/faq.html:235
 msgid ""
-"To report a user review of an add-on, log in with your account\n"
-"    and visit the add-on's reviews page. Find the review you wish to report,\n"
-"    click \"Report this review\" and select a reason. Our editorial team will\n"
-"    investigate the review and take appropriate action."
+"To report a user review of an add-on, log in with your account and visit the add-on's reviews page. Find the review you wish to report, click \"Report this review\" and select a reason. Our "
+"editorial team will investigate the review and take appropriate action."
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:242
+#: src/olympia/pages/templates/pages/faq.html:240
 msgid "How do I report a bug or contact the Mozilla Add-ons team?"
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:243
+#: src/olympia/pages/templates/pages/faq.html:241
 #, python-format
 msgid "Please visit our <a href=\"%(contact_url)s\">Contact page</a>."
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:246
+#: src/olympia/pages/templates/pages/faq.html:244
 msgid "What is a Source Code License?"
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:247
+#: src/olympia/pages/templates/pages/faq.html:245
 #, python-format
 msgid ""
 "The source code used to create an add-on is an exclusive copyright of the add-on author, unless otherwise declared in a source code license. Many add-ons on this site have <a href=\"%(url)s\" lang="
@@ -10355,63 +10197,63 @@ msgid ""
 "the GPL or BSD licenses instead of making up their own."
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:256
+#: src/olympia/pages/templates/pages/faq.html:254
 #, python-format
 msgid "Firefox and other Mozilla software are <a href=\"%(url)s\">open source</a>."
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:264
+#: src/olympia/pages/templates/pages/faq.html:262
 msgid "Collections and Favorites"
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:267
+#: src/olympia/pages/templates/pages/faq.html:265
 msgid "What is a collection?"
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:268
+#: src/olympia/pages/templates/pages/faq.html:266
 msgid "Collections are groups of related add-ons created by users to share."
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:270
+#: src/olympia/pages/templates/pages/faq.html:268
 msgid "What is the My Favorites collection?"
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:271
+#: src/olympia/pages/templates/pages/faq.html:269
 msgid "Favorite add-ons are add-ons that you have bookmarked to easily get back to later. You can add an add-on to your favorites collection by clicking \"Add to favorites\" on its details page."
 msgstr ""
 
 # 75%
 # 78%
 # 100%
-#: src/olympia/pages/templates/pages/faq.html:275 src/olympia/templates/menu_links.html:13 src/olympia/templates/impala/header_title.html:17
+#: src/olympia/pages/templates/pages/faq.html:273 src/olympia/templates/menu_links.html:13 src/olympia/templates/impala/header_title.html:17
 msgid "Mobile Add-ons"
 msgstr "Selfoon-byvoegings"
 
-#: src/olympia/pages/templates/pages/faq.html:278
+#: src/olympia/pages/templates/pages/faq.html:276
 msgid "What are mobile add-ons?"
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:279
+#: src/olympia/pages/templates/pages/faq.html:277
 #, python-format
 msgid ""
 "Mobile add-ons work with <a href=\"%(mobile_url)s\">Firefox for Mobile</a> and add or modify functionality just like desktop add-ons. You can find add-ons that work with Firefox for Mobile in our "
 "<a href=\"%(gallery_url)s\">gallery</a>."
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:288
+#: src/olympia/pages/templates/pages/faq.html:286
 msgid "Developer Topics"
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:289
+#: src/olympia/pages/templates/pages/faq.html:287
 #, python-format
 msgid "Please see our <a href=\"%(faq_url)s\">Developer FAQ</a> and <a href=\"%(hub_url)s\">Developer Hub</a> for answers to add-on developer-related questions."
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:294
+#: src/olympia/pages/templates/pages/faq.html:292
 msgid "Still have questions?"
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:295
+#: src/olympia/pages/templates/pages/faq.html:293
 #, python-format
 msgid "For general Firefox support, visit our <a href=\"%(sumo_url)s\">support website</a>. For general add-on and website questions, visit our <a href=\"%(forum_url)s\">forum</a>."
 msgstr ""
@@ -10549,7 +10391,7 @@ msgstr ""
 
 #: src/olympia/pages/templates/pages/sunbird.html:29
 msgid ""
-"Development on the Sunbird project has halted and its final release was on March 30, 2010.  We've been proud to host Sunbird add-ons on this site but as the project is no longer maintained we have "
+"Development on the Sunbird project has halted and its final release was on March 30, 2010. We've been proud to host Sunbird add-ons on this site but as the project is no longer maintained we have "
 "disabled our support for the add-ons."
 msgstr ""
 
@@ -10630,7 +10472,7 @@ msgstr ""
 #, python-format
 msgid ""
 "<h2>Keep these tips in mind:</h2> <ul> <li> Write like you're telling a friend about your experience with the add-on. Give specifics and helpful details, such as what features you liked and/or "
-"disliked, how easy to use it is, and any disadvantages it has.  Avoid generic language such as calling it \"Great\" or \"Bad\" unless you can give reasons why you believe this is so. </li> <li> "
+"disliked, how easy to use it is, and any disadvantages it has. Avoid generic language such as calling it \"Great\" or \"Bad\" unless you can give reasons why you believe this is so. </li> <li> "
 "Please do not post bug reports in reviews. We do not make your email address available to add-on developers and they may need to contact you to help resolve your issue. See the <a href=\"%(support)s"
 "\">support section</a> to find out where to get assistance for this add-on. </li> <li>Please keep reviews clean, avoid the use of improper language and do not post any personal information. </li> </"
 "ul> <p>Please read the <a href=\"%(guide)s\" target=\"_blank\">Review Guidelines</a> for more detail about user add-on reviews.</p>"
@@ -10887,16 +10729,16 @@ msgstr "{0}-byvoegings"
 
 #. L10n: {0} is an application, such as Firefox. This means "any version of
 #. Firefox."
-#: src/olympia/search/views.py:554
+#: src/olympia/search/views.py:547
 msgid "Any {0}"
 msgstr "Enige {0}"
 
 #. L10n: "All Systems" means show everything regardless of platform.
-#: src/olympia/search/views.py:589
+#: src/olympia/search/views.py:582
 msgid "All Systems"
 msgstr "Alle stelsels"
 
-#: src/olympia/search/views.py:600
+#: src/olympia/search/views.py:593
 msgid "All Tags"
 msgstr "Alle etikette"
 
@@ -11070,31 +10912,31 @@ msgstr "Deel dié byvoeging"
 msgid "Share this Collection"
 msgstr "Deel dié versameling"
 
-#: src/olympia/signing/views.py:30 src/olympia/templates/base.html:75 src/olympia/templates/impala/base.html:115
+#: src/olympia/signing/views.py:33 src/olympia/templates/base.html:71 src/olympia/templates/impala/base.html:112
 msgid "Some features are temporarily disabled while we perform website maintenance. We'll be back to full capacity shortly."
 msgstr ""
 
-#: src/olympia/signing/views.py:53
+#: src/olympia/signing/views.py:56
 msgid "Could not find add-on with id \"{}\"."
 msgstr ""
 
-#: src/olympia/signing/views.py:67
+#: src/olympia/signing/views.py:70
 msgid "You do not own this addon."
 msgstr ""
 
-#: src/olympia/signing/views.py:82
+#: src/olympia/signing/views.py:87
 msgid "Missing \"upload\" key in multipart file data."
 msgstr ""
 
-#: src/olympia/signing/views.py:96
+#: src/olympia/signing/views.py:101
 msgid "Version does not match the manifest file."
 msgstr ""
 
-#: src/olympia/signing/views.py:100
+#: src/olympia/signing/views.py:105
 msgid "Version already exists."
 msgstr ""
 
-#: src/olympia/signing/views.py:136
+#: src/olympia/signing/views.py:141
 msgid "No uploaded file for that addon and version."
 msgstr ""
 
@@ -11209,89 +11051,89 @@ msgstr ""
 msgid "Statistics Dashboard :: Add-ons for {0}"
 msgstr ""
 
-#: src/olympia/stats/templates/stats/stats.html:30
-msgid "Controls:"
-msgstr ""
-
-#: src/olympia/stats/templates/stats/stats.html:33
-msgid "reset zoom"
-msgstr ""
-
-#: src/olympia/stats/templates/stats/stats.html:40
-msgid "Group by:"
-msgstr ""
-
-#: src/olympia/stats/templates/stats/stats.html:42
-msgid "day"
-msgstr "dag"
-
-#: src/olympia/stats/templates/stats/stats.html:45
-msgid "week"
-msgstr ""
-
-#: src/olympia/stats/templates/stats/stats.html:48
-msgid "month"
-msgstr "maand"
-
-#: src/olympia/stats/templates/stats/stats.html:54
-msgid "For last:"
-msgstr "Vir die afgelope:"
-
-#: src/olympia/stats/templates/stats/stats.html:57
-msgid "7 days"
-msgstr "7 dae"
-
-#: src/olympia/stats/templates/stats/stats.html:60
-msgid "30 days"
-msgstr "30 dae"
-
-#: src/olympia/stats/templates/stats/stats.html:63
-msgid "90 days"
-msgstr "90 dae"
-
-#: src/olympia/stats/templates/stats/stats.html:66
-msgid "365 days"
-msgstr "365 dae"
-
-#: src/olympia/stats/templates/stats/stats.html:69
-msgid "Custom..."
-msgstr ""
-
 #. {0} is an add-on name
-#: src/olympia/stats/templates/stats/stats.html:88 src/olympia/stats/templates/stats/stats.html:91
+#: src/olympia/stats/templates/stats/stats.html:44 src/olympia/stats/templates/stats/stats.html:47
 msgid "Statistics for {0}"
 msgstr "Statistiek vir {0}"
 
-#: src/olympia/stats/templates/stats/stats.html:94
+#: src/olympia/stats/templates/stats/stats.html:50
 msgid "Statistics Dashboard"
 msgstr ""
 
-#: src/olympia/stats/templates/stats/stats.html:104
+#: src/olympia/stats/templates/stats/stats.html:57
+msgid "Controls:"
+msgstr ""
+
+#: src/olympia/stats/templates/stats/stats.html:60
+msgid "reset zoom"
+msgstr ""
+
+#: src/olympia/stats/templates/stats/stats.html:67
+msgid "Group by:"
+msgstr ""
+
+#: src/olympia/stats/templates/stats/stats.html:69
+msgid "day"
+msgstr "dag"
+
+#: src/olympia/stats/templates/stats/stats.html:72
+msgid "week"
+msgstr ""
+
+#: src/olympia/stats/templates/stats/stats.html:75
+msgid "month"
+msgstr "maand"
+
+#: src/olympia/stats/templates/stats/stats.html:81
+msgid "For last:"
+msgstr "Vir die afgelope:"
+
+#: src/olympia/stats/templates/stats/stats.html:84
+msgid "7 days"
+msgstr "7 dae"
+
+#: src/olympia/stats/templates/stats/stats.html:87
+msgid "30 days"
+msgstr "30 dae"
+
+#: src/olympia/stats/templates/stats/stats.html:90
+msgid "90 days"
+msgstr "90 dae"
+
+#: src/olympia/stats/templates/stats/stats.html:93
+msgid "365 days"
+msgstr "365 dae"
+
+#: src/olympia/stats/templates/stats/stats.html:96
+msgid "Custom..."
+msgstr ""
+
+#: src/olympia/stats/templates/stats/stats.html:106
 msgid "Statistics processing is currently disabled, so recent data is unavailable. The statistics are still being collected and this page will be updated soon with the missing data."
 msgstr ""
 
-#: src/olympia/stats/templates/stats/stats.html:110
+#: src/olympia/stats/templates/stats/stats.html:112
 msgid "Loading the latest data&hellip;"
 msgstr ""
 
-#: src/olympia/stats/templates/stats/stats.html:142 src/olympia/stats/templates/stats/reports/overview.html:25 src/olympia/stats/templates/stats/reports/overview.html:37
+#: src/olympia/stats/templates/stats/stats.html:144 src/olympia/stats/templates/stats/reports/overview.html:25 src/olympia/stats/templates/stats/reports/overview.html:37
 #: src/olympia/stats/templates/stats/reports/overview.html:49
 msgid "No data available."
 msgstr ""
 
-#: src/olympia/stats/templates/stats/stats.html:177
+#: src/olympia/stats/templates/stats/stats.html:179
 msgid "This dashboard is currently <b>public</b>."
 msgstr ""
 
-#: src/olympia/stats/templates/stats/stats.html:179
+#: src/olympia/stats/templates/stats/stats.html:181
 msgid "Contribution stats are currently <b>private</b>."
 msgstr ""
 
-#: src/olympia/stats/templates/stats/stats.html:182
+#: src/olympia/stats/templates/stats/stats.html:184
 msgid "This dashboard is currently <b>private</b>."
 msgstr ""
 
-#: src/olympia/stats/templates/stats/stats.html:185
+#: src/olympia/stats/templates/stats/stats.html:187
 msgid "Change settings."
 msgstr ""
 
@@ -11443,16 +11285,6 @@ msgstr ""
 msgid "Application versions by Date"
 msgstr ""
 
-# {0} is a number
-#: src/olympia/tags/templates/tags/top_cloud.html:4
-msgid "Top {0} Tags"
-msgstr ""
-
-#. {0} is the current application name
-#: src/olympia/tags/templates/tags/top_cloud.html:14
-msgid "{0} Top Tags"
-msgstr ""
-
 #: src/olympia/templates/amo_footer.html:6 src/olympia/templates/includes/lang_switcher.html:2
 msgid "Other languages"
 msgstr "Ander tale"
@@ -11465,11 +11297,11 @@ msgstr "Ander tale"
 msgid "Mozilla Add-ons"
 msgstr "Mozilla-byvoegings"
 
-#: src/olympia/templates/base.html:91 src/olympia/templates/impala/base.html:81
+#: src/olympia/templates/base.html:89 src/olympia/templates/impala/base.html:78
 msgid "Find add-ons for other applications"
 msgstr "Vind byvoegings vir ander toepassings"
 
-#: src/olympia/templates/base.html:92 src/olympia/templates/impala/base.html:81
+#: src/olympia/templates/base.html:90 src/olympia/templates/impala/base.html:78
 msgid "Other Applications"
 msgstr "Ander toepassings"
 
@@ -11494,7 +11326,7 @@ msgid "View Mobile Site"
 msgstr "Sien Selfoon-werf"
 
 #: src/olympia/templates/copyright.html:7
-msgid "Site Status "
+msgid "Site Status"
 msgstr ""
 
 #: src/olympia/templates/footer.html:3
@@ -11596,35 +11428,35 @@ msgstr "Welkom, {0}"
 msgid "<a href=\"%(reg)s\">Register</a> or <a href=\"%(login)s\">Log in</a>"
 msgstr "<a href=\"%(reg)s\">Registreer</a> of <a href=\"%(login)s\">Meld aan</a>"
 
-#: src/olympia/templates/impala/base.html:126
+#: src/olympia/templates/impala/base.html:123
 #, python-format
 msgid "To try the thousands of add-ons available here, download <a href=\"%(url)s\">Mozilla Firefox</a>, a fast, free way to surf the Web!"
 msgstr "Om duisende beskikbare byvoegings te probeer, laai <a href=\"%(url)s\">Mozilla Firefox</a> af, 'n gratis en vinnige manier om deur die Web te blaai!"
 
-#: src/olympia/templates/impala/base.html:138
+#: src/olympia/templates/impala/base.html:135
 #, python-format
 msgid "Add-ons is switching to Firefox Accounts for login. <a href=\"%(url)s\" class=\"fxa-login\">Sign in now to transfer your account.</a>"
 msgstr ""
 
 #. {0} is an application, such as Firefox.
-#: src/olympia/templates/impala/base.html:148
+#: src/olympia/templates/impala/base.html:145
 msgid "Welcome to {0} Add-ons."
 msgstr "Welkom by {0} Byvoegings."
 
-#: src/olympia/templates/impala/base.html:151
+#: src/olympia/templates/impala/base.html:148
 msgid "Choose from thousands of extra features and styles to make Firefox your own."
 msgstr "Kies uit duisende ekstra funksies en style om Firefox nommerpas te maak."
 
-#: src/olympia/templates/impala/base.html:156
+#: src/olympia/templates/impala/base.html:153
 #, python-format
 msgid "Add extra features and styles to make %(app)s your own."
 msgstr ""
 
-#: src/olympia/templates/impala/base.html:164
+#: src/olympia/templates/impala/base.html:161
 msgid "On the go?"
 msgstr "Op pad?"
 
-#: src/olympia/templates/impala/base.html:166
+#: src/olympia/templates/impala/base.html:163
 msgid "Check out our <a class=\"mobile-link\" href=\"#\">Mobile Add-ons site</a>."
 msgstr "Kyk bietjie na ons werf met <a class=\"mobile-link\" href=\"#\">Selfoon-byvoegings</a>."
 
@@ -11850,15 +11682,15 @@ msgstr "Geen gebruiker met daardie e-posadres nie."
 
 #. L10n: {id} will be something like "13ad6a", just a random number
 #. to differentiate this user from other anonymous users.
-#: src/olympia/users/models.py:353
+#: src/olympia/users/models.py:362
 msgid "Anonymous user {id}"
 msgstr ""
 
-#: src/olympia/users/models.py:410
+#: src/olympia/users/models.py:419
 msgid "Your account has been restricted"
 msgstr ""
 
-#: src/olympia/users/models.py:480
+#: src/olympia/users/models.py:489
 msgid "Please confirm your email address"
 msgstr "Bevestig asseblief die e-posadres"
 
@@ -11866,7 +11698,7 @@ msgstr "Bevestig asseblief die e-posadres"
 # 78%
 # 82%
 # 100%
-#: src/olympia/users/models.py:506
+#: src/olympia/users/models.py:515
 msgid "My Mobile Add-ons"
 msgstr "My Selfoon-byvoegings"
 
@@ -12146,7 +11978,7 @@ msgstr "Wagwoord"
 
 #: src/olympia/users/templates/users/edit.html:70
 #, python-format
-msgid "Change your password.  If you forgot your password, you can <a href=\"%(reset_url)s\">use the reset form</a>."
+msgid "Change your password. If you forgot your password, you can <a href=\"%(reset_url)s\">use the reset form</a>."
 msgstr ""
 
 # 91%
@@ -12171,7 +12003,7 @@ msgid "Profile"
 msgstr ""
 
 #: src/olympia/users/templates/users/edit.html:100
-msgid "Give us a bit more information about yourself.  All these fields are optional, but they'll help other users get to know you better."
+msgid "Give us a bit more information about yourself. All these fields are optional, but they'll help other users get to know you better."
 msgstr ""
 
 #: src/olympia/users/templates/users/edit.html:124
@@ -12577,7 +12409,7 @@ msgstr ""
 
 #: src/olympia/users/templates/users/unsubscribe.html:30
 #, python-format
-msgid "Unfortunately, we weren't able to unsubscribe you.  The link you clicked is invalid. However, you can unsubscribe still unsubscribe on your <a href=\"%(edit_url)s\">edit profile page</a>."
+msgid "Unfortunately, we weren't able to unsubscribe you. The link you clicked is invalid. However, you can unsubscribe still unsubscribe on your <a href=\"%(edit_url)s\">edit profile page</a>."
 msgstr ""
 
 #: src/olympia/users/templates/users/vcard.html:2
@@ -12634,15 +12466,15 @@ msgstr "%s se weergawegeskiedenis"
 msgid "Version History with Changelogs"
 msgstr ""
 
-#: src/olympia/versions/models.py:314
+#: src/olympia/versions/models.py:313
 msgid "Add-on uses binary components."
 msgstr ""
 
-#: src/olympia/versions/models.py:317
+#: src/olympia/versions/models.py:316
 msgid "Add-on has opted into strict compatibility checking."
 msgstr ""
 
-#: src/olympia/versions/models.py:715
+#: src/olympia/versions/models.py:711
 msgid "{app} {min} and later"
 msgstr ""
 
@@ -12721,4 +12553,8 @@ msgstr ""
 
 #: src/olympia/zadmin/forms.py:105
 msgid "Log emails instead of sending"
+msgstr ""
+
+#: src/olympia/zadmin/forms.py:215
+msgid "Deleted versions can`t be changed."
 msgstr ""

--- a/locale/af/LC_MESSAGES/djangojs.po
+++ b/locale/af/LC_MESSAGES/djangojs.po
@@ -1,1215 +1,1235 @@
-
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2016-02-24 21:23+0000\n"
+"POT-Creation-Date: 2016-04-18 15:47+0000\n"
 "PO-Revision-Date: 2015-03-16 11:06+0000\n"
 "Last-Translator: Friedel <friedel@translate.org.za>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
+"Language: \n"
 "MIME-Version: 1.0\n"
-"Content-Type: text/plain; charset=utf-8\n"
+"Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Generated-By: Babel 2.2.0\n"
 
-#: static/js/common/ratingwidget.js:31
-msgid "{0} star"
-msgid_plural "{0} stars"
-msgstr[0] "{0} ster"
-msgstr[1] "{0} sterre"
-
-#: static/js/common/upload-addon.js:41 static/js/common/upload-image.js:128
-msgid "There was a problem contacting the server."
+#: static/js/common-all.js:1426 static/js/impala-all.js:1511 static/js/zamboni/discovery-all.js:12598 static/js/zamboni/init.js:28 static/js/zamboni/mobile-all.js:14945
+msgid "This feature is temporarily disabled while we perform website maintenance. Please check back a little later."
 msgstr ""
-
-#: static/js/common/upload-addon.js:69
-msgid "Select a file..."
-msgstr "Kies 'n lêer..."
-
-#: static/js/common/upload-addon.js:70
-msgid "Your add-on should end with .xpi, .jar or .xml"
-msgstr ""
-
-#. L10n: {0} is the percent of the file that has been uploaded.
-#: static/js/common/upload-addon.js:104
-#, python-format
-msgid "{0}% complete"
-msgstr ""
-
-#. L10n: "{bytes uploaded} of {total filesize}".
-#: static/js/common/upload-addon.js:107
-msgid "{0} of {1}"
-msgstr ""
-
-#: static/js/common/upload-addon.js:140
-msgid "Cancel"
-msgstr "Kanselleer"
-
-#: static/js/common/upload-addon.js:162
-msgid "Uploading {0}"
-msgstr ""
-
-#: static/js/common/upload-addon.js:189
-msgid "Error with {0}"
-msgstr ""
-
-#: static/js/common/upload-addon.js:194
-msgid "Your add-on failed validation with {0} error."
-msgid_plural "Your add-on failed validation with {0} errors."
-msgstr[0] ""
-msgstr[1] ""
-
-#: static/js/common/upload-addon.js:208
-msgid "&hellip;and {0} more"
-msgid_plural "&hellip;and {0} more"
-msgstr[0] ""
-msgstr[1] ""
-
-#: static/js/common/upload-addon.js:222 static/js/common/upload-addon.js:512
-msgid "See full validation report"
-msgstr ""
-
-#: static/js/common/upload-addon.js:234
-msgid "Validating {0}"
-msgstr ""
-
-#. L10n: first argument is an HTTP status code
-#: static/js/common/upload-addon.js:273
-msgid "Received an empty response from the server; status: {0}"
-msgstr ""
-
-#: static/js/common/upload-addon.js:373
-msgid "Unexpected server error while validating."
-msgstr ""
-
-#: static/js/common/upload-addon.js:412
-msgid "Finished validating {0}"
-msgstr ""
-
-#: static/js/common/upload-addon.js:418
-msgid "Your add-on validation timed out, it will be manually reviewed."
-msgstr ""
-
-#: static/js/common/upload-addon.js:421
-msgid "Your add-on was validated with no errors and {0} warning."
-msgid_plural "Your add-on was validated with no errors and {0} warnings."
-msgstr[0] ""
-msgstr[1] ""
-
-#: static/js/common/upload-addon.js:426
-msgid "Your add-on was validated with no errors and {0} message."
-msgid_plural "Your add-on was validated with no errors and {0} messages."
-msgstr[0] ""
-msgstr[1] ""
-
-#: static/js/common/upload-addon.js:431
-msgid "Your add-on was validated with no errors or warnings."
-msgstr ""
-
-#: static/js/common/upload-addon.js:446
-msgid "Your submission will be automatically signed."
-msgstr ""
-
-#: static/js/common/upload-addon.js:465
-msgid "Include detailed version notes (this can be done in the next step)."
-msgstr ""
-
-#: static/js/common/upload-addon.js:466
-msgid "If your add-on requires an account to a website in order to be fully tested, include a test username and password in the Notes to Reviewer (this can be done in the next step)."
-msgstr ""
-
-#: static/js/common/upload-addon.js:467
-msgid "If your add-on is intended for a limited audience you should choose Preliminary Review instead of Full Review."
-msgstr ""
-
-#: static/js/common/upload-addon.js:480
-msgid "Add-on submission checklist"
-msgstr ""
-
-#: static/js/common/upload-addon.js:481
-msgid "Please verify the following points before finalizing your submission. This will minimize delays or misunderstanding during the review process:"
-msgstr ""
-
-#: static/js/common/upload-addon.js:483
-msgid ""
-"Compiled binaries, as well as minified or obfuscated scripts (excluding known libraries) need to have their sources submitted separately for review. Make sure that you use the source code upload "
-"field to avoid having your submission rejected."
-msgstr ""
-
-#: static/js/common/upload-addon.js:501
-msgid "The validation process found these issues that can lead to rejections:"
-msgstr ""
-
-#: static/js/common/upload-addon.js:518
-msgid "If you are unfamiliar with the add-ons review process, you can read about it here."
-msgstr ""
-
-#: static/js/common/upload-addon.js:555
-msgid "Sorry, no supported platform has been found."
-msgstr ""
-
-#: static/js/common/upload-base.js:57
-msgid "The filetype you uploaded isn't recognized."
-msgstr ""
-
-#: static/js/common/upload-base.js:79
-msgid "You cancelled the upload."
-msgstr ""
-
-#: static/js/common/upload-image.js:97 static/js/impala/users.js:51
-msgid "Images must be either PNG or JPG."
-msgstr ""
-
-#: static/js/common/upload-image.js:101
-msgid "Videos must be in WebM."
-msgstr ""
-
-#: static/js/impala/collections.js:10 static/js/zamboni/collections.js:595
-msgid "Follow this Collection"
-msgstr ""
-
-#: static/js/impala/collections.js:19
-msgid "Stop Following"
-msgstr ""
-
-#: static/js/impala/collections.js:20
-msgid "Following"
-msgstr ""
-
-#. L10n: {0} is an app name.
-#: static/js/impala/listing.js:11 static/js/zamboni/themes.js:13
-msgid "This theme is incompatible with your version of {0}"
-msgstr "Dié tema is onversoenbaar met u weergawe van {0}"
-
-#: static/js/impala/persona_creation.js:60
-msgid "All Rights Reserved"
-msgstr "Alle regte voorbehou"
-
-#: static/js/impala/persona_creation.js:64
-msgid "Creative Commons Attribution 3.0"
-msgstr ""
-
-#: static/js/impala/persona_creation.js:69
-msgid "Creative Commons Attribution-NonCommercial 3.0"
-msgstr ""
-
-#: static/js/impala/persona_creation.js:74
-msgid "Creative Commons Attribution-NonCommercial-NoDerivs 3.0"
-msgstr ""
-
-#: static/js/impala/persona_creation.js:79
-msgid "Creative Commons Attribution-NonCommercial-Share Alike 3.0"
-msgstr ""
-
-#: static/js/impala/persona_creation.js:84
-msgid "Creative Commons Attribution-NoDerivs 3.0"
-msgstr ""
-
-#: static/js/impala/persona_creation.js:89
-msgid "Creative Commons Attribution-ShareAlike 3.0"
-msgstr ""
-
-#: static/js/impala/persona_creation.js:292
-msgid "Your Theme's Name"
-msgstr ""
-
-#: static/js/impala/reviews.js:23 static/js/zamboni/reviews.js:18
-msgid "Flagged for review"
-msgstr ""
-
-#: static/js/impala/reviews.js:40 static/js/zamboni/reviews.js:34
-msgid "Your input is required"
-msgstr ""
-
-#: static/js/impala/reviews.js:152 static/js/zamboni/reviews.js:103
-msgid "Marked for deletion"
-msgstr ""
-
-#: static/js/impala/search.js:114
-msgid "Updating results&hellip;"
-msgstr ""
-
-#: static/js/impala/site_suggestions.js:46
-msgid "Category"
-msgstr "Kategorie"
-
-#: static/js/impala/suggestions.js:39
-msgid "Search themes for <b>{0}</b>"
-msgstr "Deursoek temas vir <b>{0}</b>"
-
-#: static/js/impala/suggestions.js:41
-msgid "Search apps for <b>{0}</b>"
-msgstr "Deursoek webtoepassings vir <b>{0}</b>"
-
-#: static/js/impala/suggestions.js:43
-msgid "Search add-ons for <b>{0}</b>"
-msgstr "Deursoek byvoegings vir <b>{0}</b>"
-
-#: static/js/impala/users.js:33
-msgid "use original"
-msgstr ""
-
-#: static/js/impala/stats/chart.js:267
-msgid "Week of {0}"
-msgstr ""
-
-#: static/js/impala/stats/chart.js:269
-msgid " downloads"
-msgstr ""
-
-#: static/js/impala/stats/chart.js:270
-msgid "{0} users"
-msgstr ""
-
-#: static/js/impala/stats/chart.js:271
-msgid "{0} add-ons"
-msgstr ""
-
-#: static/js/impala/stats/chart.js:272
-msgid "{0} collections"
-msgstr ""
-
-#: static/js/impala/stats/chart.js:273
-msgid "{0} reviews"
-msgstr ""
-
-#: static/js/impala/stats/chart.js:275
-msgid "{0} sales"
-msgstr ""
-
-#: static/js/impala/stats/chart.js:276
-msgid "{0} refunds"
-msgstr ""
-
-#: static/js/impala/stats/chart.js:277
-msgid "{0} installs"
-msgstr ""
-
-#: static/js/impala/stats/chart.js:369 static/js/impala/stats/csv_keys.js:3 static/js/impala/stats/csv_keys.js:109
-msgid "Downloads"
-msgstr ""
-
-#: static/js/impala/stats/chart.js:379 static/js/impala/stats/csv_keys.js:6 static/js/impala/stats/csv_keys.js:110
-msgid "Daily Users"
-msgstr ""
-
-#: static/js/impala/stats/chart.js:410
-msgid "Amount, in USD"
-msgstr ""
-
-#: static/js/impala/stats/chart.js:421 static/js/impala/stats/csv_keys.js:104
-msgid "Number of Contributions"
-msgstr ""
-
-#: static/js/impala/stats/chart.js:447
-msgid "More Info..."
-msgstr ""
-
-#. L10n: {0} is an ISO-formatted date.
-#: static/js/impala/stats/chart.js:451
-msgid "Details for {0}"
-msgstr ""
-
-#: static/js/impala/stats/csv_keys.js:9
-msgid "Collections Created"
-msgstr ""
-
-#: static/js/impala/stats/csv_keys.js:12
-msgid "Add-ons in Use"
-msgstr ""
-
-#: static/js/impala/stats/csv_keys.js:15
-msgid "Add-ons Created"
-msgstr ""
-
-#: static/js/impala/stats/csv_keys.js:18
-msgid "Add-ons Downloaded"
-msgstr ""
-
-#: static/js/impala/stats/csv_keys.js:21
-msgid "Add-ons Updated"
-msgstr ""
-
-#: static/js/impala/stats/csv_keys.js:24
-msgid "Reviews Written"
-msgstr ""
-
-#: static/js/impala/stats/csv_keys.js:27
-msgid "User Signups"
-msgstr ""
-
-#: static/js/impala/stats/csv_keys.js:30
-msgid "Subscribers"
-msgstr ""
-
-#: static/js/impala/stats/csv_keys.js:33
-msgid "Ratings"
-msgstr ""
-
-#: static/js/impala/stats/csv_keys.js:36 static/js/impala/stats/csv_keys.js:114
-msgid "Sales"
-msgstr ""
-
-#: static/js/impala/stats/csv_keys.js:39 static/js/impala/stats/csv_keys.js:113
-msgid "Installs"
-msgstr ""
-
-#: static/js/impala/stats/csv_keys.js:42
-msgid "Unknown"
-msgstr ""
-
-#: static/js/impala/stats/csv_keys.js:43
-msgid "Add-ons Manager"
-msgstr ""
-
-#: static/js/impala/stats/csv_keys.js:44
-msgid "Add-ons Manager Promo"
-msgstr ""
-
-#: static/js/impala/stats/csv_keys.js:45
-msgid "Add-ons Manager Featured"
-msgstr ""
-
-#: static/js/impala/stats/csv_keys.js:46
-msgid "Add-ons Manager Learn More"
-msgstr ""
-
-#: static/js/impala/stats/csv_keys.js:47
-msgid "Search Suggestions"
-msgstr ""
-
-#: static/js/impala/stats/csv_keys.js:48
-msgid "Search Results"
-msgstr "Soekresultate"
-
-#: static/js/impala/stats/csv_keys.js:49 static/js/impala/stats/csv_keys.js:50 static/js/impala/stats/csv_keys.js:51
-msgid "Homepage Promo"
-msgstr ""
-
-#: static/js/impala/stats/csv_keys.js:52 static/js/impala/stats/csv_keys.js:53
-msgid "Homepage Featured"
-msgstr ""
-
-#: static/js/impala/stats/csv_keys.js:54 static/js/impala/stats/csv_keys.js:55
-msgid "Homepage Up and Coming"
-msgstr ""
-
-#: static/js/impala/stats/csv_keys.js:56
-msgid "Homepage Most Popular"
-msgstr ""
-
-#: static/js/impala/stats/csv_keys.js:57 static/js/impala/stats/csv_keys.js:59
-msgid "Detail Page"
-msgstr ""
-
-#: static/js/impala/stats/csv_keys.js:58 static/js/impala/stats/csv_keys.js:60
-msgid "Detail Page (bottom)"
-msgstr ""
-
-#: static/js/impala/stats/csv_keys.js:61
-msgid "Detail Page (Development Channel)"
-msgstr ""
-
-#: static/js/impala/stats/csv_keys.js:62 static/js/impala/stats/csv_keys.js:63 static/js/impala/stats/csv_keys.js:64
-msgid "Often Used With"
-msgstr ""
-
-#: static/js/impala/stats/csv_keys.js:65 static/js/impala/stats/csv_keys.js:66
-msgid "Others By Author"
-msgstr ""
-
-#: static/js/impala/stats/csv_keys.js:67 static/js/impala/stats/csv_keys.js:68
-msgid "Dependencies"
-msgstr ""
-
-#: static/js/impala/stats/csv_keys.js:69 static/js/impala/stats/csv_keys.js:70
-msgid "Upsell"
-msgstr ""
-
-#: static/js/impala/stats/csv_keys.js:71
-msgid "Meet the Developer"
-msgstr ""
-
-#: static/js/impala/stats/csv_keys.js:72
-msgid "User Profile"
-msgstr ""
-
-#: static/js/impala/stats/csv_keys.js:73
-msgid "Version History"
-msgstr ""
-
-#: static/js/impala/stats/csv_keys.js:75
-msgid "Sharing"
-msgstr ""
-
-#: static/js/impala/stats/csv_keys.js:76
-msgid "Category Pages"
-msgstr ""
-
-#: static/js/impala/stats/csv_keys.js:77
-msgid "Collections"
-msgstr ""
-
-#: static/js/impala/stats/csv_keys.js:78 static/js/impala/stats/csv_keys.js:79
-msgid "Category Landing Featured Carousel"
-msgstr ""
-
-#: static/js/impala/stats/csv_keys.js:80 static/js/impala/stats/csv_keys.js:81
-msgid "Category Landing Top Rated"
-msgstr ""
-
-#: static/js/impala/stats/csv_keys.js:82 static/js/impala/stats/csv_keys.js:83
-msgid "Category Landing Most Popular"
-msgstr ""
-
-#: static/js/impala/stats/csv_keys.js:84 static/js/impala/stats/csv_keys.js:85
-msgid "Category Landing Recently Added"
-msgstr ""
-
-#: static/js/impala/stats/csv_keys.js:86 static/js/impala/stats/csv_keys.js:87
-msgid "Browse Listing Featured Sort"
-msgstr ""
-
-#: static/js/impala/stats/csv_keys.js:88 static/js/impala/stats/csv_keys.js:89
-msgid "Browse Listing Users Sort"
-msgstr ""
-
-#: static/js/impala/stats/csv_keys.js:90 static/js/impala/stats/csv_keys.js:91
-msgid "Browse Listing Rating Sort"
-msgstr ""
-
-#: static/js/impala/stats/csv_keys.js:92 static/js/impala/stats/csv_keys.js:93
-msgid "Browse Listing Created Sort"
-msgstr ""
-
-#: static/js/impala/stats/csv_keys.js:94 static/js/impala/stats/csv_keys.js:95
-msgid "Browse Listing Name Sort"
-msgstr ""
-
-#: static/js/impala/stats/csv_keys.js:96 static/js/impala/stats/csv_keys.js:97
-msgid "Browse Listing Popular Sort"
-msgstr ""
-
-#: static/js/impala/stats/csv_keys.js:98 static/js/impala/stats/csv_keys.js:99
-msgid "Browse Listing Updated Sort"
-msgstr ""
-
-#: static/js/impala/stats/csv_keys.js:100 static/js/impala/stats/csv_keys.js:101
-msgid "Browse Listing Up and Coming Sort"
-msgstr ""
-
-#: static/js/impala/stats/csv_keys.js:105
-msgid "Total Amount Contributed"
-msgstr ""
-
-#: static/js/impala/stats/csv_keys.js:106
-msgid "Average Contribution"
-msgstr ""
-
-#: static/js/impala/stats/csv_keys.js:115
-msgid "Usage"
-msgstr ""
-
-#: static/js/impala/stats/csv_keys.js:118
-msgid "Firefox"
-msgstr "Firefox"
-
-#: static/js/impala/stats/csv_keys.js:119
-msgid "Mozilla"
-msgstr "Mozilla"
-
-#: static/js/impala/stats/csv_keys.js:120
-msgid "Thunderbird"
-msgstr "Thunderbird"
-
-#: static/js/impala/stats/csv_keys.js:121
-msgid "Sunbird"
-msgstr "Sunbird"
-
-#: static/js/impala/stats/csv_keys.js:122
-msgid "SeaMonkey"
-msgstr "SeaMonkey"
-
-#: static/js/impala/stats/csv_keys.js:123
-msgid "Fennec"
-msgstr "Fennec"
-
-#: static/js/impala/stats/csv_keys.js:124
-msgid "Android"
-msgstr "Android"
-
-#. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:129
-msgid "Downloads and Daily Users, last {0} days"
-msgstr ""
-
-#. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:131
-msgid "Downloads and Daily Users from {0} to {1}"
-msgstr ""
-
-#. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:135
-msgid "Installs and Daily Users, last {0} days"
-msgstr ""
-
-#. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:137
-msgid "Installs and Daily Users from {0} to {1}"
-msgstr ""
-
-#. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:141
-msgid "Downloads, last {0} days"
-msgstr ""
-
-#. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:143
-msgid "Downloads from {0} to {1}"
-msgstr ""
-
-#. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:147
-msgid "Daily Users, last {0} days"
-msgstr ""
-
-#. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:149
-msgid "Daily Users from {0} to {1}"
-msgstr ""
-
-#. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:153
-msgid "Applications, last {0} days"
-msgstr ""
-
-#. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:155
-msgid "Applications from {0} to {1}"
-msgstr ""
-
-#. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:159
-msgid "Platforms, last {0} days"
-msgstr ""
-
-#. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:161
-msgid "Platforms from {0} to {1}"
-msgstr ""
-
-#. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:165
-msgid "Languages, last {0} days"
-msgstr ""
-
-#. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:167
-msgid "Languages from {0} to {1}"
-msgstr ""
-
-#. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:171
-msgid "Add-on Versions, last {0} days"
-msgstr ""
-
-#. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:173
-msgid "Add-on Versions from {0} to {1}"
-msgstr ""
-
-#. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:177
-msgid "Add-on Status, last {0} days"
-msgstr ""
-
-#. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:179
-msgid "Add-on Status from {0} to {1}"
-msgstr ""
-
-#. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:183
-msgid "Download Sources, last {0} days"
-msgstr ""
-
-#. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:185
-msgid "Download Sources from {0} to {1}"
-msgstr ""
-
-#. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:189
-msgid "Contributions, last {0} days"
-msgstr ""
-
-#. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:191
-msgid "Contributions from {0} to {1}"
-msgstr ""
-
-#. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:195
-msgid "Site Metrics, last {0} days"
-msgstr ""
-
-#. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:197
-msgid "Site Metrics from {0} to {1}"
-msgstr ""
-
-#. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:201
-msgid "Add-ons in Use, last {0} days"
-msgstr ""
-
-#. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:203
-msgid "Add-ons in Use from {0} to {1}"
-msgstr ""
-
-#. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:207
-msgid "Add-ons Downloaded, last {0} days"
-msgstr ""
-
-#. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:209
-msgid "Add-ons Downloaded from {0} to {1}"
-msgstr ""
-
-#. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:213
-msgid "Add-ons Created, last {0} days"
-msgstr ""
-
-#. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:215
-msgid "Add-ons Created from {0} to {1}"
-msgstr ""
-
-#. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:219
-msgid "Add-ons Updated, last {0} days"
-msgstr ""
-
-#. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:221
-msgid "Add-ons Updated from {0} to {1}"
-msgstr ""
-
-#. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:225
-msgid "Reviews Written, last {0} days"
-msgstr ""
-
-#. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:227
-msgid "Reviews Written from {0} to {1}"
-msgstr ""
-
-#. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:231
-msgid "User Signups, last {0} days"
-msgstr ""
-
-#. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:233
-msgid "User Signups from {0} to {1}"
-msgstr ""
-
-#. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:237
-msgid "Collections Created, last {0} days"
-msgstr ""
-
-#. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:239
-msgid "Collections Created from {0} to {1}"
-msgstr ""
-
-#. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:243
-msgid "Subscribers, last {0} days"
-msgstr ""
-
-#. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:245
-msgid "Subscribers from {0} to {1}"
-msgstr ""
-
-#. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:249
-msgid "Ratings, last {0} days"
-msgstr ""
-
-#. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:251
-msgid "Ratings from {0} to {1}"
-msgstr ""
-
-#. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:255
-msgid "Sales, last {0} days"
-msgstr ""
-
-#. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:257
-msgid "Sales from {0} to {1}"
-msgstr ""
-
-#. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:261
-msgid "Installs, last {0} days"
-msgstr ""
-
-#. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:263
-msgid "Installs from {0} to {1}"
-msgstr ""
-
-#. L10n: {0} and {1} are integers.
-#: static/js/impala/stats/csv_keys.js:269
-msgid "<b>{0}</b> in last {1} days"
-msgstr ""
-
-#. L10n: {0} is an integer and {1} and {2} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:271 static/js/impala/stats/csv_keys.js:277
-msgid "<b>{0}</b> from {1} to {2}"
-msgstr ""
-
-#. L10n: {0} and {1} are integers.
-#: static/js/impala/stats/csv_keys.js:275
-msgid "<b>{0}</b> average in last {1} days"
-msgstr ""
-
-#: static/js/impala/stats/overview.js:19
-msgid "No data available."
-msgstr ""
-
-#: static/js/impala/stats/table.js:74
-msgid "Date"
-msgstr ""
-
-#: static/js/impala/stats/topchart.js:96
-msgid "Other"
-msgstr "Ander"
-
-#: static/js/zamboni/admin_validation.js:24 static/js/zamboni/devhub.js:1229 static/js/zamboni/editors.js:295
-msgid "Select an application first"
-msgstr ""
-
-#: static/js/zamboni/admin_validation.js:51
-msgid "Set {0} add-on to a max version of {1} and email the author."
-msgid_plural "Set {0} add-ons to a max version of {1} and email the authors."
-msgstr[0] ""
-msgstr[1] ""
-
-#: static/js/zamboni/admin_validation.js:54
-msgid "Email author of {2} add-on which failed validation."
-msgid_plural "Email authors of {2} add-ons which failed validation."
-msgstr[0] ""
-msgstr[1] ""
 
 #. L10n: {0} is an app name like Firefox.
-#: static/js/zamboni/buttons.js:66
+#: static/js/common-all.js:1837 static/js/impala-all.js:1922 static/js/zamboni/buttons.js:73 static/js/zamboni/discovery-all.js:13108
 msgid "Accept and Install"
 msgstr "Aanvaar en installeer"
 
-#: static/js/zamboni/buttons.js:66
+#: static/js/common-all.js:1837 static/js/impala-all.js:1922 static/js/zamboni/buttons.js:73 static/js/zamboni/discovery-all.js:13108
 msgid "Add to {0}"
 msgstr "Voeg by {0}"
 
-#: static/js/zamboni/buttons.js:71
+#: static/js/common-all.js:1842 static/js/impala-all.js:1927 static/js/zamboni/buttons.js:78 static/js/zamboni/discovery-all.js:13113
 msgid "Download Now"
 msgstr "Laai nou af"
 
-#: static/js/zamboni/buttons.js:112
+#: static/js/common-all.js:1883 static/js/impala-all.js:1968 static/js/zamboni/buttons.js:119 static/js/zamboni/discovery-all.js:13154
 msgid "Add-on has not been updated to support default-to-compatible."
 msgstr ""
 
-#: static/js/zamboni/buttons.js:117
+#: static/js/common-all.js:1888 static/js/impala-all.js:1973 static/js/zamboni/buttons.js:124 static/js/zamboni/discovery-all.js:13159
 msgid "You need to be using Firefox 10.0 or higher."
 msgstr ""
 
-#: static/js/zamboni/buttons.js:129
+#: static/js/common-all.js:1900 static/js/impala-all.js:1985 static/js/zamboni/buttons.js:136 static/js/zamboni/discovery-all.js:13171
 msgid "Mozilla has marked this version as incompatible with your Firefox version."
 msgstr "Mozilla het dié weergawe gemerk as onversoenbaar met u Firefox-weergawe"
 
 #. L10n: {0} is an platform like Windows or Linux.
-#: static/js/zamboni/buttons.js:210
+#: static/js/common-all.js:1981 static/js/impala-all.js:2066 static/js/zamboni/buttons.js:217 static/js/zamboni/discovery-all.js:13252
 msgid "Install for {0} anyway"
 msgstr "Installeer in elk geval vir {0}"
 
-#: static/js/zamboni/buttons.js:210
+#: static/js/common-all.js:1981 static/js/impala-all.js:2066 static/js/zamboni/buttons.js:217 static/js/zamboni/discovery-all.js:13252
 msgid "Download for {0} anyway"
 msgstr "Laai in elk geval af vir {0}"
 
-#: static/js/zamboni/buttons.js:267
+#: static/js/common-all.js:2038 static/js/impala-all.js:2123 static/js/zamboni/buttons.js:274 static/js/zamboni/discovery-all.js:13309
 msgid "Not available for your platform"
 msgstr "Nie beskikbaar vir u platform nie"
 
 #. L10n: {0} is an app name, {1} is the app version.
-#: static/js/zamboni/buttons.js:278 static/js/zamboni/buttons.js:315
+#: static/js/common-all.js:2049 static/js/common-all.js:2086 static/js/impala-all.js:2134 static/js/impala-all.js:2171 static/js/zamboni/buttons.js:286 static/js/zamboni/buttons.js:324
+#: static/js/zamboni/discovery-all.js:13320 static/js/zamboni/discovery-all.js:13357
 msgid "Not available for {0} {1}"
 msgstr "Nie beskikbaar vir {0} {1} nie"
 
-#: static/js/zamboni/buttons.js:341
+#: static/js/common-all.js:2112 static/js/impala-all.js:2197 static/js/zamboni/buttons.js:351 static/js/zamboni/discovery-all.js:13383
 msgid "Works with {app} {min} - {max}"
 msgstr ""
 
-#: static/js/zamboni/buttons.js:343
+#: static/js/common-all.js:2114 static/js/impala-all.js:2199 static/js/zamboni/buttons.js:353 static/js/zamboni/discovery-all.js:13385
 msgid "View other versions"
 msgstr ""
 
-#: static/js/zamboni/buttons.js:391
+#: static/js/common-all.js:2162 static/js/impala-all.js:2247 static/js/zamboni/buttons.js:401 static/js/zamboni/discovery-all.js:13433
 msgid "Only with Firefox — Get Firefox Now!"
 msgstr ""
 
-#: static/js/zamboni/buttons.js:507 static/js/zamboni/mobile/buttons.js:43
+#: static/js/common-all.js:2278 static/js/impala-all.js:2363 static/js/zamboni/buttons.js:517 static/js/zamboni/discovery-all.js:13549 static/js/zamboni/mobile-all.js:15177
+#: static/js/zamboni/mobile/buttons.js:43
 msgid "Sorry, you need a Mozilla-based browser (such as Firefox) to install a search plugin."
 msgstr "Jammer, u het 'n Mozilla-gebaseerde blaaier (soos Firefox) nodig om 'n soekinprop te installer."
 
-#: static/js/zamboni/collections.js:229
-msgid "Adding to Favorites&hellip;"
-msgstr ""
-
-#: static/js/zamboni/collections.js:232
-msgid "Removing Favorite&hellip;"
-msgstr ""
-
-#: static/js/zamboni/collections.js:235
-msgid "Add to Favorites"
-msgstr ""
-
-#: static/js/zamboni/collections.js:238
-msgid "Remove from Favorites"
-msgstr ""
-
-#: static/js/zamboni/collections.js:303
-msgid "Pending"
-msgstr ""
-
-#: static/js/zamboni/collections.js:304
-msgid "Add a comment"
-msgstr ""
-
-#: static/js/zamboni/collections.js:304
-msgid "Comment"
-msgstr ""
-
-#: static/js/zamboni/collections.js:305
-msgid "Remove this add-on from the collection"
-msgstr ""
-
-#: static/js/zamboni/collections.js:305 static/js/zamboni/collections.js:334
-msgid "Remove"
-msgstr ""
-
-#: static/js/zamboni/collections.js:334
-msgid "Remove this user as a contributor"
-msgstr ""
-
-#: static/js/zamboni/collections.js:346
-msgid "An email address is required."
-msgstr ""
-
-#: static/js/zamboni/collections.js:364
-msgid "You cannot add yourself as a contributor."
-msgstr ""
-
-#: static/js/zamboni/collections.js:366
-msgid "You have already added that user."
-msgstr ""
-
-#: static/js/zamboni/collections.js:573
-msgid "Add to favorites"
-msgstr ""
-
-#: static/js/zamboni/collections.js:577
-msgid "Remove from favorites"
-msgstr ""
-
-#: static/js/zamboni/collections.js:604
-msgid "Stop following"
-msgstr ""
-
-#: static/js/zamboni/devhub.js:110
-msgid "Your browser does not support the video tag"
-msgstr ""
-
-#: static/js/zamboni/devhub.js:371
-msgid "Changes Saved"
-msgstr ""
-
-#: static/js/zamboni/devhub.js:387
-msgid "Enter a new author's email address"
-msgstr ""
-
-#: static/js/zamboni/devhub.js:536
-msgid "There was an error uploading your file."
-msgstr ""
-
-#: static/js/zamboni/devhub.js:681
-msgid "{files} file"
-msgid_plural "{files} files"
-msgstr[0] ""
-msgstr[1] ""
-
-#: static/js/zamboni/devhub.js:684
-msgid "{reviews} user review"
-msgid_plural "{reviews} user reviews"
-msgstr[0] ""
-msgstr[1] ""
-
-#: static/js/zamboni/devhub.js:796
-msgid "Learn more"
-msgstr "Meer inligting"
-
-#: static/js/zamboni/devhub.js:800
-msgid "Example"
-msgstr "Voorbeeld"
-
-#: static/js/zamboni/devhub.js:1130
-msgid "Image changes being processed"
-msgstr ""
-
-#: static/js/zamboni/devhub.js:1280
-msgid "Must be a valid e-mail address."
-msgstr ""
-
-#: static/js/zamboni/devhub_search.js:8
-msgid "No results found."
-msgstr ""
-
-#: static/js/zamboni/editors.js:121
-msgid "{name} was viewing this page first."
-msgstr ""
-
-#: static/js/zamboni/editors.js:171
-msgid "Receipt checked by app."
-msgstr ""
-
-#: static/js/zamboni/editors.js:173
-msgid "Receipt was not checked by app."
-msgstr ""
-
-#: static/js/zamboni/editors.js:244
-msgid "{name} was viewing this add-on first."
-msgstr ""
-
-#: static/js/zamboni/editors.js:255
-msgid "Loading&hellip;"
-msgstr "Laai tans&hellip;"
-
-#: static/js/zamboni/editors.js:260
-msgid "Version Notes"
-msgstr ""
-
-#: static/js/zamboni/editors.js:265
-msgid "Notes for Reviewers"
-msgstr ""
-
-#: static/js/zamboni/editors.js:270
-msgid "No version notes found"
-msgstr ""
-
-#: static/js/zamboni/editors.js:330
-msgid "Average Reviews"
-msgstr ""
-
-#: static/js/zamboni/editors.js:386
-msgid "Number of Reviews"
-msgstr ""
-
-#: static/js/zamboni/editors.js:445
-msgid "Error loading translation"
-msgstr ""
-
-#: static/js/zamboni/files.js:411 static/js/zamboni/validator.js:261
-msgid "Ignore this message in future updates"
-msgstr ""
-
-#: static/js/zamboni/files.js:417 static/js/zamboni/validator.js:284
-msgid "Severity for automated signing:"
-msgstr ""
-
-#: static/js/zamboni/global.js:410
+#: static/js/common-all.js:9088 static/js/impala-all.js:9649 static/js/zamboni/global.js:410
 msgid "Loading..."
 msgstr ""
 
 #. L10n: {0} is the number of characters left.
-#: static/js/zamboni/global.js:474
+#: static/js/common-all.js:9152 static/js/impala-all.js:9713 static/js/zamboni/global.js:474
 msgid "<b>{0}</b> character left."
 msgid_plural "<b>{0}</b> characters left."
 msgstr[0] "<b>{0}</b> karakter oor."
 msgstr[1] "<b>{0}</b> karakters oor."
 
-#: static/js/zamboni/init.js:28
-msgid "This feature is temporarily disabled while we perform website maintenance. Please check back a little later."
-msgstr ""
+#: static/js/common-all.js:9589 static/js/common-min.js:6 static/js/impala-all.js:10052 static/js/impala-min.js:6 static/js/common/ratingwidget.js:31 static/js/zamboni/mobile-all.js:16123
+#: static/js/zamboni/mobile-min.js:6
+msgid "{0} star"
+msgid_plural "{0} stars"
+msgstr[0] "{0} ster"
+msgstr[1] "{0} sterre"
 
-#: static/js/zamboni/l10n.js:45
+#: static/js/common-all.js:9676 static/js/common-min.js:6 static/js/impala-all.js:10139 static/js/impala-min.js:6 static/js/zamboni/l10n.js:45
 msgid "Remove this localization"
 msgstr "Verwyder hierdie lokalisering"
 
-#: static/js/zamboni/password-strength.js:20
+#: static/js/common-all.js:10193 static/js/common-min.js:6 static/js/impala-all.js:10674 static/js/impala-min.js:6 static/js/zamboni/discovery-all.js:13678
+msgid "close"
+msgstr ""
+
+#: static/js/common-all.js:10860 static/js/common-min.js:6 static/js/impala-all.js:11481 static/js/impala-min.js:6 static/js/impala/reviews.js:23 static/js/zamboni/reviews.js:18
+msgid "Flagged for review"
+msgstr ""
+
+#: static/js/common-all.js:10876 static/js/common-min.js:6 static/js/impala-all.js:11498 static/js/impala-min.js:6 static/js/impala/reviews.js:40 static/js/zamboni/reviews.js:34
+msgid "Your input is required"
+msgstr ""
+
+#: static/js/common-all.js:10945 static/js/common-min.js:6 static/js/impala-all.js:11610 static/js/impala-min.js:7 static/js/impala/reviews.js:152 static/js/zamboni/reviews.js:103
+msgid "Marked for deletion"
+msgstr ""
+
+#: static/js/common-all.js:11573 static/js/common-min.js:7 static/js/impala-all.js:13809 static/js/impala-min.js:8 static/js/zamboni/collections.js:229
+msgid "Adding to Favorites&hellip;"
+msgstr ""
+
+#: static/js/common-all.js:11576 static/js/common-min.js:7 static/js/impala-all.js:13812 static/js/impala-min.js:8 static/js/zamboni/collections.js:232
+msgid "Removing Favorite&hellip;"
+msgstr ""
+
+#: static/js/common-all.js:11579 static/js/common-min.js:7 static/js/impala-all.js:13815 static/js/impala-min.js:8 static/js/zamboni/collections.js:235
+msgid "Add to Favorites"
+msgstr ""
+
+#: static/js/common-all.js:11582 static/js/common-min.js:7 static/js/impala-all.js:13818 static/js/impala-min.js:8 static/js/zamboni/collections.js:238
+msgid "Remove from Favorites"
+msgstr ""
+
+#: static/js/common-all.js:11647 static/js/common-min.js:7 static/js/impala-all.js:13883 static/js/impala-min.js:8 static/js/zamboni/collections.js:303
+msgid "Pending"
+msgstr ""
+
+#: static/js/common-all.js:11648 static/js/common-min.js:7 static/js/impala-all.js:13884 static/js/impala-min.js:8 static/js/zamboni/collections.js:304
+msgid "Add a comment"
+msgstr ""
+
+#: static/js/common-all.js:11648 static/js/common-min.js:7 static/js/impala-all.js:13884 static/js/impala-min.js:8 static/js/zamboni/collections.js:304
+msgid "Comment"
+msgstr ""
+
+#: static/js/common-all.js:11649 static/js/common-min.js:7 static/js/impala-all.js:13885 static/js/impala-min.js:8 static/js/zamboni/collections.js:305
+msgid "Remove this add-on from the collection"
+msgstr ""
+
+#: static/js/common-all.js:11649 static/js/common-all.js:11678 static/js/common-min.js:7 static/js/impala-all.js:13885 static/js/impala-all.js:13914 static/js/impala-min.js:8
+#: static/js/zamboni/collections.js:305 static/js/zamboni/collections.js:334
+msgid "Remove"
+msgstr ""
+
+#: static/js/common-all.js:11678 static/js/common-min.js:7 static/js/impala-all.js:13914 static/js/impala-min.js:8 static/js/zamboni/collections.js:334
+msgid "Remove this user as a contributor"
+msgstr ""
+
+#: static/js/common-all.js:11690 static/js/common-min.js:7 static/js/impala-all.js:13926 static/js/impala-min.js:8 static/js/zamboni/collections.js:346
+msgid "An email address is required."
+msgstr ""
+
+#: static/js/common-all.js:11708 static/js/common-min.js:7 static/js/impala-all.js:13944 static/js/impala-min.js:8 static/js/zamboni/collections.js:364
+msgid "You cannot add yourself as a contributor."
+msgstr ""
+
+#: static/js/common-all.js:11710 static/js/common-min.js:7 static/js/impala-all.js:13946 static/js/impala-min.js:8 static/js/zamboni/collections.js:366
+msgid "You have already added that user."
+msgstr ""
+
+#: static/js/common-all.js:11917 static/js/common-min.js:7 static/js/impala-all.js:14153 static/js/impala-min.js:8 static/js/zamboni/collections.js:573
+msgid "Add to favorites"
+msgstr ""
+
+#: static/js/common-all.js:11921 static/js/common-min.js:7 static/js/impala-all.js:14157 static/js/impala-min.js:8 static/js/zamboni/collections.js:577
+msgid "Remove from favorites"
+msgstr ""
+
+#: static/js/common-all.js:11939 static/js/common-min.js:7 static/js/impala-all.js:14175 static/js/impala-all.js:14233 static/js/impala-min.js:8 static/js/impala/collections.js:10
+#: static/js/zamboni/collections.js:595
+msgid "Follow this Collection"
+msgstr ""
+
+#: static/js/common-all.js:11948 static/js/common-min.js:7 static/js/impala-all.js:14184 static/js/impala-min.js:8 static/js/zamboni/collections.js:604
+msgid "Stop following"
+msgstr ""
+
+#: static/js/common-all.js:12096 static/js/common-min.js:7 static/js/zamboni/password-strength.js:20
 msgid "Password strength:"
 msgstr "Wagwoordsterkte:"
 
-#: static/js/zamboni/password-strength.js:26
+#: static/js/common-all.js:12102 static/js/common-min.js:7 static/js/zamboni/password-strength.js:26
 msgid "At least {0} character left."
 msgid_plural "At least {0} characters left."
 msgstr[0] "Ten minste {0} karakter oor."
 msgstr[1] "Ten minste {0} karakters oor."
 
-#: static/js/zamboni/themes_review.js:176
-msgid "Requested Info"
+#: static/js/common-all.js:12286 static/js/common-min.js:7 static/js/impala-all.js:14632 static/js/impala-min.js:8 static/js/impala/suggestions.js:39
+msgid "Search themes for <b>{0}</b>"
+msgstr "Deursoek temas vir <b>{0}</b>"
+
+#: static/js/common-all.js:12288 static/js/common-min.js:7 static/js/impala-all.js:14634 static/js/impala-min.js:8 static/js/impala/suggestions.js:41
+msgid "Search apps for <b>{0}</b>"
+msgstr "Deursoek webtoepassings vir <b>{0}</b>"
+
+#: static/js/common-all.js:12290 static/js/common-min.js:7 static/js/impala-all.js:14636 static/js/impala-min.js:8 static/js/impala/suggestions.js:43
+msgid "Search add-ons for <b>{0}</b>"
+msgstr "Deursoek byvoegings vir <b>{0}</b>"
+
+#: static/js/common-all.js:12521 static/js/common-min.js:7 static/js/impala-all.js:14867 static/js/impala-min.js:8 static/js/impala/site_suggestions.js:46
+msgid "Category"
+msgstr "Kategorie"
+
+#. L10n: {0} is an app name.
+#: static/js/impala-all.js:11632 static/js/impala-min.js:7 static/js/impala/listing.js:11 static/js/zamboni/themes.js:13
+msgid "This theme is incompatible with your version of {0}"
+msgstr "Dié tema is onversoenbaar met u weergawe van {0}"
+
+#: static/js/impala-all.js:12146 static/js/impala-all.js:14331 static/js/impala-min.js:7 static/js/impala-min.js:8 static/js/common/upload-image.js:97 static/js/impala/users.js:51
+#: static/js/zamboni/devhub-all.js:894 static/js/zamboni/devhub-min.js:1
+msgid "Images must be either PNG or JPG."
 msgstr ""
 
-#: static/js/zamboni/themes_review.js:177
-msgid "Flagged"
+#: static/js/impala-all.js:12150 static/js/impala-min.js:7 static/js/common/upload-image.js:101 static/js/zamboni/devhub-all.js:898 static/js/zamboni/devhub-min.js:1
+msgid "Videos must be in WebM."
 msgstr ""
 
-#: static/js/zamboni/themes_review.js:178
-msgid "Duplicate"
+#: static/js/impala-all.js:12177 static/js/impala-min.js:7 static/js/common/upload-addon.js:41 static/js/common/upload-image.js:128 static/js/zamboni/devhub-all.js:272
+#: static/js/zamboni/devhub-all.js:925 static/js/zamboni/devhub-min.js:1
+msgid "There was a problem contacting the server."
 msgstr ""
 
-#: static/js/zamboni/themes_review.js:179
-msgid "Rejected"
+#: static/js/impala-all.js:13298 static/js/impala-min.js:7 static/js/impala/persona_creation.js:60
+msgid "All Rights Reserved"
+msgstr "Alle regte voorbehou"
+
+#: static/js/impala-all.js:13302 static/js/impala-min.js:7 static/js/impala/persona_creation.js:64
+msgid "Creative Commons Attribution 3.0"
 msgstr ""
 
-#: static/js/zamboni/themes_review.js:180
-msgid "Approved"
+#: static/js/impala-all.js:13307 static/js/impala-min.js:7 static/js/impala/persona_creation.js:69
+msgid "Creative Commons Attribution-NonCommercial 3.0"
 msgstr ""
 
-#: static/js/zamboni/themes_review.js:424
-msgid "No results found"
+#: static/js/impala-all.js:13312 static/js/impala-min.js:7 static/js/impala/persona_creation.js:74
+msgid "Creative Commons Attribution-NonCommercial-NoDerivs 3.0"
 msgstr ""
 
-#: static/js/zamboni/themes_review_templates.js:31
-msgid "Theme"
+#: static/js/impala-all.js:13317 static/js/impala-min.js:7 static/js/impala/persona_creation.js:79
+msgid "Creative Commons Attribution-NonCommercial-Share Alike 3.0"
 msgstr ""
 
-#: static/js/zamboni/themes_review_templates.js:33
-msgid "Reviewer"
+#: static/js/impala-all.js:13322 static/js/impala-min.js:7 static/js/impala/persona_creation.js:84
+msgid "Creative Commons Attribution-NoDerivs 3.0"
 msgstr ""
 
-#: static/js/zamboni/themes_review_templates.js:35
-msgid "Status"
+#: static/js/impala-all.js:13327 static/js/impala-min.js:7 static/js/impala/persona_creation.js:89
+msgid "Creative Commons Attribution-ShareAlike 3.0"
 msgstr ""
 
-#: static/js/zamboni/validator.js:80
+#: static/js/impala-all.js:13530 static/js/impala-min.js:7 static/js/impala/persona_creation.js:292
+msgid "Your Theme's Name"
+msgstr ""
+
+#: static/js/impala-all.js:14242 static/js/impala-min.js:8 static/js/impala/collections.js:19
+msgid "Stop Following"
+msgstr ""
+
+#: static/js/impala-all.js:14243 static/js/impala-min.js:8 static/js/impala/collections.js:20
+msgid "Following"
+msgstr ""
+
+#: static/js/impala-all.js:14313 static/js/impala-min.js:8 static/js/impala/users.js:33
+msgid "use original"
+msgstr ""
+
+#: static/js/impala-all.js:14523 static/js/impala-min.js:8 static/js/impala/search.js:114
+msgid "Updating results&hellip;"
+msgstr ""
+
+#: static/js/common/upload-addon.js:69 static/js/zamboni/devhub-all.js:300 static/js/zamboni/devhub-min.js:1
+msgid "Select a file..."
+msgstr "Kies 'n lêer..."
+
+#: static/js/common/upload-addon.js:70 static/js/zamboni/devhub-all.js:301 static/js/zamboni/devhub-min.js:1
+msgid "Your add-on should end with .xpi, .jar or .xml"
+msgstr ""
+
+#. L10n: {0} is the percent of the file that has been uploaded.
+#: static/js/common/upload-addon.js:104 static/js/zamboni/devhub-all.js:335 static/js/zamboni/devhub-min.js:1
+#, python-format
+msgid "{0}% complete"
+msgstr ""
+
+#. L10n: "{bytes uploaded} of {total filesize}".
+#: static/js/common/upload-addon.js:107 static/js/zamboni/devhub-all.js:338 static/js/zamboni/devhub-min.js:1
+msgid "{0} of {1}"
+msgstr ""
+
+#: static/js/common/upload-addon.js:140 static/js/zamboni/devhub-all.js:371 static/js/zamboni/devhub-min.js:1
+msgid "Cancel"
+msgstr "Kanselleer"
+
+#: static/js/common/upload-addon.js:162 static/js/zamboni/devhub-all.js:393 static/js/zamboni/devhub-min.js:1
+msgid "Uploading {0}"
+msgstr ""
+
+#: static/js/common/upload-addon.js:189 static/js/zamboni/devhub-all.js:420 static/js/zamboni/devhub-min.js:1
+msgid "Error with {0}"
+msgstr ""
+
+#: static/js/common/upload-addon.js:194 static/js/zamboni/devhub-all.js:425 static/js/zamboni/devhub-min.js:1
+msgid "Your add-on failed validation with {0} error."
+msgid_plural "Your add-on failed validation with {0} errors."
+msgstr[0] ""
+msgstr[1] ""
+
+#: static/js/common/upload-addon.js:208 static/js/zamboni/devhub-all.js:439 static/js/zamboni/devhub-min.js:1
+msgid "&hellip;and {0} more"
+msgid_plural "&hellip;and {0} more"
+msgstr[0] ""
+msgstr[1] ""
+
+#: static/js/common/upload-addon.js:222 static/js/common/upload-addon.js:497 static/js/zamboni/devhub-all.js:453 static/js/zamboni/devhub-all.js:743 static/js/zamboni/devhub-min.js:1
+msgid "See full validation report"
+msgstr ""
+
+#: static/js/common/upload-addon.js:234 static/js/zamboni/devhub-all.js:465 static/js/zamboni/devhub-min.js:1
+msgid "Validating {0}"
+msgstr ""
+
+#. L10n: first argument is an HTTP status code
+#: static/js/common/upload-addon.js:273 static/js/zamboni/devhub-all.js:504 static/js/zamboni/devhub-min.js:1
+msgid "Received an empty response from the server; status: {0}"
+msgstr ""
+
+#: static/js/common/upload-addon.js:370 static/js/zamboni/devhub-all.js:604 static/js/zamboni/devhub-min.js:1
+msgid "Unexpected server error while validating."
+msgstr ""
+
+#: static/js/common/upload-addon.js:409 static/js/zamboni/devhub-all.js:643 static/js/zamboni/devhub-min.js:1
+msgid "Finished validating {0}"
+msgstr ""
+
+#: static/js/common/upload-addon.js:415 static/js/zamboni/devhub-all.js:649 static/js/zamboni/devhub-min.js:1
+msgid "Your add-on validation timed out, it will be manually reviewed."
+msgstr ""
+
+#: static/js/common/upload-addon.js:418 static/js/zamboni/devhub-all.js:652 static/js/zamboni/devhub-min.js:1
+msgid "Your add-on was validated with no errors and {0} warning."
+msgid_plural "Your add-on was validated with no errors and {0} warnings."
+msgstr[0] ""
+msgstr[1] ""
+
+#: static/js/common/upload-addon.js:423 static/js/zamboni/devhub-all.js:657 static/js/zamboni/devhub-min.js:1
+msgid "Your add-on was validated with no errors and {0} message."
+msgid_plural "Your add-on was validated with no errors and {0} messages."
+msgstr[0] ""
+msgstr[1] ""
+
+#: static/js/common/upload-addon.js:428 static/js/zamboni/devhub-all.js:662 static/js/zamboni/devhub-min.js:1
+msgid "Your add-on was validated with no errors or warnings."
+msgstr ""
+
+#: static/js/common/upload-addon.js:443 static/js/zamboni/devhub-all.js:677 static/js/zamboni/devhub-min.js:1
+msgid "Your submission will be automatically signed."
+msgstr ""
+
+#: static/js/common/upload-addon.js:450 static/js/zamboni/devhub-all.js:696 static/js/zamboni/devhub-min.js:1
+msgid "Include detailed version notes (this can be done in the next step)."
+msgstr ""
+
+#: static/js/common/upload-addon.js:451 static/js/zamboni/devhub-all.js:697 static/js/zamboni/devhub-min.js:1
+msgid "If your add-on requires an account to a website in order to be fully tested, include a test username and password in the Notes to Reviewer (this can be done in the next step)."
+msgstr ""
+
+#: static/js/common/upload-addon.js:452 static/js/zamboni/devhub-all.js:698 static/js/zamboni/devhub-min.js:1
+msgid "If your add-on is intended for a limited audience you should choose Preliminary Review instead of Full Review."
+msgstr ""
+
+#: static/js/common/upload-addon.js:465 static/js/zamboni/devhub-all.js:711 static/js/zamboni/devhub-min.js:1
+msgid "Add-on submission checklist"
+msgstr ""
+
+#: static/js/common/upload-addon.js:466 static/js/zamboni/devhub-all.js:712 static/js/zamboni/devhub-min.js:1
+msgid "Please verify the following points before finalizing your submission. This will minimize delays or misunderstanding during the review process:"
+msgstr ""
+
+#: static/js/common/upload-addon.js:468 static/js/zamboni/devhub-all.js:714 static/js/zamboni/devhub-min.js:1
+msgid ""
+"Compiled binaries, as well as minified or obfuscated scripts (excluding known libraries) need to have their sources submitted separately for review. Make sure that you use the source code upload "
+"field to avoid having your submission rejected."
+msgstr ""
+
+#: static/js/common/upload-addon.js:486 static/js/zamboni/devhub-all.js:732 static/js/zamboni/devhub-min.js:1
+msgid "The validation process found these issues that can lead to rejections:"
+msgstr ""
+
+#: static/js/common/upload-addon.js:503 static/js/zamboni/devhub-all.js:749 static/js/zamboni/devhub-min.js:1
+msgid "If you are unfamiliar with the add-ons review process, you can read about it here."
+msgstr ""
+
+#: static/js/common/upload-addon.js:540 static/js/zamboni/devhub-all.js:786 static/js/zamboni/devhub-min.js:1
+msgid "Sorry, no supported platform has been found."
+msgstr ""
+
+#: static/js/common/upload-base.js:57 static/js/zamboni/devhub-all.js:187 static/js/zamboni/devhub-min.js:1
+msgid "The filetype you uploaded isn't recognized."
+msgstr ""
+
+#: static/js/common/upload-base.js:79 static/js/zamboni/devhub-all.js:209 static/js/zamboni/devhub-min.js:1
+msgid "You cancelled the upload."
+msgstr ""
+
+#: static/js/impala/stats/chart.js:267 static/js/zamboni/stats-all.js:16898 static/js/zamboni/stats-min.js:5
+msgid "Week of {0}"
+msgstr ""
+
+#: static/js/impala/stats/chart.js:269 static/js/zamboni/stats-all.js:16900 static/js/zamboni/stats-min.js:5
+msgid " downloads"
+msgstr ""
+
+#: static/js/impala/stats/chart.js:270 static/js/zamboni/stats-all.js:16901 static/js/zamboni/stats-min.js:5
+msgid "{0} users"
+msgstr ""
+
+#: static/js/impala/stats/chart.js:271 static/js/zamboni/stats-all.js:16902 static/js/zamboni/stats-min.js:5
+msgid "{0} add-ons"
+msgstr ""
+
+#: static/js/impala/stats/chart.js:272 static/js/zamboni/stats-all.js:16903 static/js/zamboni/stats-min.js:5
+msgid "{0} collections"
+msgstr ""
+
+#: static/js/impala/stats/chart.js:273 static/js/zamboni/stats-all.js:16904 static/js/zamboni/stats-min.js:5
+msgid "{0} reviews"
+msgstr ""
+
+#: static/js/impala/stats/chart.js:275 static/js/zamboni/stats-all.js:16906 static/js/zamboni/stats-min.js:5
+msgid "{0} sales"
+msgstr ""
+
+#: static/js/impala/stats/chart.js:276 static/js/zamboni/stats-all.js:16907 static/js/zamboni/stats-min.js:5
+msgid "{0} refunds"
+msgstr ""
+
+#: static/js/impala/stats/chart.js:277 static/js/zamboni/stats-all.js:16908 static/js/zamboni/stats-min.js:5
+msgid "{0} installs"
+msgstr ""
+
+#: static/js/impala/stats/chart.js:369 static/js/impala/stats/csv_keys.js:3 static/js/impala/stats/csv_keys.js:109 static/js/zamboni/stats-all.js:15284 static/js/zamboni/stats-all.js:15390
+#: static/js/zamboni/stats-all.js:17000 static/js/zamboni/stats-min.js:4 static/js/zamboni/stats-min.js:5
+msgid "Downloads"
+msgstr ""
+
+#: static/js/impala/stats/chart.js:379 static/js/impala/stats/csv_keys.js:6 static/js/impala/stats/csv_keys.js:110 static/js/zamboni/stats-all.js:15287 static/js/zamboni/stats-all.js:15391
+#: static/js/zamboni/stats-all.js:17010 static/js/zamboni/stats-min.js:4 static/js/zamboni/stats-min.js:5
+msgid "Daily Users"
+msgstr ""
+
+#: static/js/impala/stats/chart.js:410 static/js/zamboni/stats-all.js:17041 static/js/zamboni/stats-min.js:5
+msgid "Amount, in USD"
+msgstr ""
+
+#: static/js/impala/stats/chart.js:421 static/js/impala/stats/csv_keys.js:104 static/js/zamboni/stats-all.js:15385 static/js/zamboni/stats-all.js:17052 static/js/zamboni/stats-min.js:5
+msgid "Number of Contributions"
+msgstr ""
+
+#: static/js/impala/stats/chart.js:447 static/js/zamboni/stats-all.js:17078 static/js/zamboni/stats-min.js:5
+msgid "More Info..."
+msgstr ""
+
+#. L10n: {0} is an ISO-formatted date.
+#: static/js/impala/stats/chart.js:451 static/js/zamboni/stats-all.js:17082 static/js/zamboni/stats-min.js:5
+msgid "Details for {0}"
+msgstr ""
+
+#: static/js/impala/stats/csv_keys.js:9 static/js/zamboni/stats-all.js:15290 static/js/zamboni/stats-min.js:4
+msgid "Collections Created"
+msgstr ""
+
+#: static/js/impala/stats/csv_keys.js:12 static/js/zamboni/stats-all.js:15293 static/js/zamboni/stats-min.js:4
+msgid "Add-ons in Use"
+msgstr ""
+
+#: static/js/impala/stats/csv_keys.js:15 static/js/zamboni/stats-all.js:15296 static/js/zamboni/stats-min.js:4
+msgid "Add-ons Created"
+msgstr ""
+
+#: static/js/impala/stats/csv_keys.js:18 static/js/zamboni/stats-all.js:15299 static/js/zamboni/stats-min.js:4
+msgid "Add-ons Downloaded"
+msgstr ""
+
+#: static/js/impala/stats/csv_keys.js:21 static/js/zamboni/stats-all.js:15302 static/js/zamboni/stats-min.js:4
+msgid "Add-ons Updated"
+msgstr ""
+
+#: static/js/impala/stats/csv_keys.js:24 static/js/zamboni/stats-all.js:15305 static/js/zamboni/stats-min.js:4
+msgid "Reviews Written"
+msgstr ""
+
+#: static/js/impala/stats/csv_keys.js:27 static/js/zamboni/stats-all.js:15308 static/js/zamboni/stats-min.js:4
+msgid "User Signups"
+msgstr ""
+
+#: static/js/impala/stats/csv_keys.js:30 static/js/zamboni/stats-all.js:15311 static/js/zamboni/stats-min.js:4
+msgid "Subscribers"
+msgstr ""
+
+#: static/js/impala/stats/csv_keys.js:33 static/js/zamboni/stats-all.js:15314 static/js/zamboni/stats-min.js:4
+msgid "Ratings"
+msgstr ""
+
+#: static/js/impala/stats/csv_keys.js:36 static/js/impala/stats/csv_keys.js:114 static/js/zamboni/stats-all.js:15317 static/js/zamboni/stats-all.js:15395 static/js/zamboni/stats-min.js:4
+#: static/js/zamboni/stats-min.js:5
+msgid "Sales"
+msgstr ""
+
+#: static/js/impala/stats/csv_keys.js:39 static/js/impala/stats/csv_keys.js:113 static/js/zamboni/stats-all.js:15320 static/js/zamboni/stats-all.js:15394 static/js/zamboni/stats-min.js:4
+#: static/js/zamboni/stats-min.js:5
+msgid "Installs"
+msgstr ""
+
+#: static/js/impala/stats/csv_keys.js:42 static/js/zamboni/stats-all.js:15323 static/js/zamboni/stats-min.js:4
+msgid "Unknown"
+msgstr ""
+
+#: static/js/impala/stats/csv_keys.js:43 static/js/zamboni/stats-all.js:15324 static/js/zamboni/stats-min.js:4
+msgid "Add-ons Manager"
+msgstr ""
+
+#: static/js/impala/stats/csv_keys.js:44 static/js/zamboni/stats-all.js:15325 static/js/zamboni/stats-min.js:4
+msgid "Add-ons Manager Promo"
+msgstr ""
+
+#: static/js/impala/stats/csv_keys.js:45 static/js/zamboni/stats-all.js:15326 static/js/zamboni/stats-min.js:4
+msgid "Add-ons Manager Featured"
+msgstr ""
+
+#: static/js/impala/stats/csv_keys.js:46 static/js/zamboni/stats-all.js:15327 static/js/zamboni/stats-min.js:4
+msgid "Add-ons Manager Learn More"
+msgstr ""
+
+#: static/js/impala/stats/csv_keys.js:47 static/js/zamboni/stats-all.js:15328 static/js/zamboni/stats-min.js:4
+msgid "Search Suggestions"
+msgstr ""
+
+#: static/js/impala/stats/csv_keys.js:48 static/js/zamboni/stats-all.js:15329 static/js/zamboni/stats-min.js:4
+msgid "Search Results"
+msgstr "Soekresultate"
+
+#: static/js/impala/stats/csv_keys.js:49 static/js/impala/stats/csv_keys.js:50 static/js/impala/stats/csv_keys.js:51 static/js/zamboni/stats-all.js:15330 static/js/zamboni/stats-all.js:15331
+#: static/js/zamboni/stats-all.js:15332 static/js/zamboni/stats-min.js:4
+msgid "Homepage Promo"
+msgstr ""
+
+#: static/js/impala/stats/csv_keys.js:52 static/js/impala/stats/csv_keys.js:53 static/js/zamboni/stats-all.js:15333 static/js/zamboni/stats-all.js:15334 static/js/zamboni/stats-min.js:4
+msgid "Homepage Featured"
+msgstr ""
+
+#: static/js/impala/stats/csv_keys.js:54 static/js/impala/stats/csv_keys.js:55 static/js/zamboni/stats-all.js:15335 static/js/zamboni/stats-all.js:15336 static/js/zamboni/stats-min.js:4
+msgid "Homepage Up and Coming"
+msgstr ""
+
+#: static/js/impala/stats/csv_keys.js:56 static/js/zamboni/stats-all.js:15337 static/js/zamboni/stats-min.js:4
+msgid "Homepage Most Popular"
+msgstr ""
+
+#: static/js/impala/stats/csv_keys.js:57 static/js/impala/stats/csv_keys.js:59 static/js/zamboni/stats-all.js:15338 static/js/zamboni/stats-all.js:15340 static/js/zamboni/stats-min.js:4
+msgid "Detail Page"
+msgstr ""
+
+#: static/js/impala/stats/csv_keys.js:58 static/js/impala/stats/csv_keys.js:60 static/js/zamboni/stats-all.js:15339 static/js/zamboni/stats-all.js:15341 static/js/zamboni/stats-min.js:4
+msgid "Detail Page (bottom)"
+msgstr ""
+
+#: static/js/impala/stats/csv_keys.js:61 static/js/zamboni/stats-all.js:15342 static/js/zamboni/stats-min.js:4
+msgid "Detail Page (Development Channel)"
+msgstr ""
+
+#: static/js/impala/stats/csv_keys.js:62 static/js/impala/stats/csv_keys.js:63 static/js/impala/stats/csv_keys.js:64 static/js/zamboni/stats-all.js:15343 static/js/zamboni/stats-all.js:15344
+#: static/js/zamboni/stats-all.js:15345 static/js/zamboni/stats-min.js:4
+msgid "Often Used With"
+msgstr ""
+
+#: static/js/impala/stats/csv_keys.js:65 static/js/impala/stats/csv_keys.js:66 static/js/zamboni/stats-all.js:15346 static/js/zamboni/stats-all.js:15347 static/js/zamboni/stats-min.js:4
+msgid "Others By Author"
+msgstr ""
+
+#: static/js/impala/stats/csv_keys.js:67 static/js/impala/stats/csv_keys.js:68 static/js/zamboni/stats-all.js:15348 static/js/zamboni/stats-all.js:15349 static/js/zamboni/stats-min.js:4
+msgid "Dependencies"
+msgstr ""
+
+#: static/js/impala/stats/csv_keys.js:69 static/js/impala/stats/csv_keys.js:70 static/js/zamboni/stats-all.js:15350 static/js/zamboni/stats-all.js:15351 static/js/zamboni/stats-min.js:4
+msgid "Upsell"
+msgstr ""
+
+#: static/js/impala/stats/csv_keys.js:71 static/js/zamboni/stats-all.js:15352 static/js/zamboni/stats-min.js:4
+msgid "Meet the Developer"
+msgstr ""
+
+#: static/js/impala/stats/csv_keys.js:72 static/js/zamboni/stats-all.js:15353 static/js/zamboni/stats-min.js:4
+msgid "User Profile"
+msgstr ""
+
+#: static/js/impala/stats/csv_keys.js:73 static/js/zamboni/stats-all.js:15354 static/js/zamboni/stats-min.js:4
+msgid "Version History"
+msgstr ""
+
+#: static/js/impala/stats/csv_keys.js:75 static/js/zamboni/stats-all.js:15356 static/js/zamboni/stats-min.js:4
+msgid "Sharing"
+msgstr ""
+
+#: static/js/impala/stats/csv_keys.js:76 static/js/zamboni/stats-all.js:15357 static/js/zamboni/stats-min.js:4
+msgid "Category Pages"
+msgstr ""
+
+#: static/js/impala/stats/csv_keys.js:77 static/js/zamboni/stats-all.js:15358 static/js/zamboni/stats-min.js:4
+msgid "Collections"
+msgstr ""
+
+#: static/js/impala/stats/csv_keys.js:78 static/js/impala/stats/csv_keys.js:79 static/js/zamboni/stats-all.js:15359 static/js/zamboni/stats-all.js:15360 static/js/zamboni/stats-min.js:4
+msgid "Category Landing Featured Carousel"
+msgstr ""
+
+#: static/js/impala/stats/csv_keys.js:80 static/js/impala/stats/csv_keys.js:81 static/js/zamboni/stats-all.js:15361 static/js/zamboni/stats-all.js:15362 static/js/zamboni/stats-min.js:4
+msgid "Category Landing Top Rated"
+msgstr ""
+
+#: static/js/impala/stats/csv_keys.js:82 static/js/impala/stats/csv_keys.js:83 static/js/zamboni/stats-all.js:15363 static/js/zamboni/stats-all.js:15364 static/js/zamboni/stats-min.js:5
+msgid "Category Landing Most Popular"
+msgstr ""
+
+#: static/js/impala/stats/csv_keys.js:84 static/js/impala/stats/csv_keys.js:85 static/js/zamboni/stats-all.js:15365 static/js/zamboni/stats-all.js:15366 static/js/zamboni/stats-min.js:5
+msgid "Category Landing Recently Added"
+msgstr ""
+
+#: static/js/impala/stats/csv_keys.js:86 static/js/impala/stats/csv_keys.js:87 static/js/zamboni/stats-all.js:15367 static/js/zamboni/stats-all.js:15368 static/js/zamboni/stats-min.js:5
+msgid "Browse Listing Featured Sort"
+msgstr ""
+
+#: static/js/impala/stats/csv_keys.js:88 static/js/impala/stats/csv_keys.js:89 static/js/zamboni/stats-all.js:15369 static/js/zamboni/stats-all.js:15370 static/js/zamboni/stats-min.js:5
+msgid "Browse Listing Users Sort"
+msgstr ""
+
+#: static/js/impala/stats/csv_keys.js:90 static/js/impala/stats/csv_keys.js:91 static/js/zamboni/stats-all.js:15371 static/js/zamboni/stats-all.js:15372 static/js/zamboni/stats-min.js:5
+msgid "Browse Listing Rating Sort"
+msgstr ""
+
+#: static/js/impala/stats/csv_keys.js:92 static/js/impala/stats/csv_keys.js:93 static/js/zamboni/stats-all.js:15373 static/js/zamboni/stats-all.js:15374 static/js/zamboni/stats-min.js:5
+msgid "Browse Listing Created Sort"
+msgstr ""
+
+#: static/js/impala/stats/csv_keys.js:94 static/js/impala/stats/csv_keys.js:95 static/js/zamboni/stats-all.js:15375 static/js/zamboni/stats-all.js:15376 static/js/zamboni/stats-min.js:5
+msgid "Browse Listing Name Sort"
+msgstr ""
+
+#: static/js/impala/stats/csv_keys.js:96 static/js/impala/stats/csv_keys.js:97 static/js/zamboni/stats-all.js:15377 static/js/zamboni/stats-all.js:15378 static/js/zamboni/stats-min.js:5
+msgid "Browse Listing Popular Sort"
+msgstr ""
+
+#: static/js/impala/stats/csv_keys.js:98 static/js/impala/stats/csv_keys.js:99 static/js/zamboni/stats-all.js:15379 static/js/zamboni/stats-all.js:15380 static/js/zamboni/stats-min.js:5
+msgid "Browse Listing Updated Sort"
+msgstr ""
+
+#: static/js/impala/stats/csv_keys.js:100 static/js/impala/stats/csv_keys.js:101 static/js/zamboni/stats-all.js:15381 static/js/zamboni/stats-all.js:15382 static/js/zamboni/stats-min.js:5
+msgid "Browse Listing Up and Coming Sort"
+msgstr ""
+
+#: static/js/impala/stats/csv_keys.js:105 static/js/zamboni/stats-all.js:15386 static/js/zamboni/stats-min.js:5
+msgid "Total Amount Contributed"
+msgstr ""
+
+#: static/js/impala/stats/csv_keys.js:106 static/js/zamboni/stats-all.js:15387 static/js/zamboni/stats-min.js:5
+msgid "Average Contribution"
+msgstr ""
+
+#: static/js/impala/stats/csv_keys.js:115 static/js/zamboni/stats-all.js:15396 static/js/zamboni/stats-min.js:5
+msgid "Usage"
+msgstr ""
+
+#: static/js/impala/stats/csv_keys.js:118 static/js/zamboni/stats-all.js:15399 static/js/zamboni/stats-min.js:5
+msgid "Firefox"
+msgstr "Firefox"
+
+#: static/js/impala/stats/csv_keys.js:119 static/js/zamboni/stats-all.js:15400 static/js/zamboni/stats-min.js:5
+msgid "Mozilla"
+msgstr "Mozilla"
+
+#: static/js/impala/stats/csv_keys.js:120 static/js/zamboni/stats-all.js:15401 static/js/zamboni/stats-min.js:5
+msgid "Thunderbird"
+msgstr "Thunderbird"
+
+#: static/js/impala/stats/csv_keys.js:121 static/js/zamboni/stats-all.js:15402 static/js/zamboni/stats-min.js:5
+msgid "Sunbird"
+msgstr "Sunbird"
+
+#: static/js/impala/stats/csv_keys.js:122 static/js/zamboni/stats-all.js:15403 static/js/zamboni/stats-min.js:5
+msgid "SeaMonkey"
+msgstr "SeaMonkey"
+
+#: static/js/impala/stats/csv_keys.js:123 static/js/zamboni/stats-all.js:15404 static/js/zamboni/stats-min.js:5
+msgid "Fennec"
+msgstr "Fennec"
+
+#: static/js/impala/stats/csv_keys.js:124 static/js/zamboni/stats-all.js:15405 static/js/zamboni/stats-min.js:5
+msgid "Android"
+msgstr "Android"
+
+#. L10n: {0} is an integer.
+#: static/js/impala/stats/csv_keys.js:129 static/js/zamboni/stats-all.js:15410 static/js/zamboni/stats-min.js:5
+msgid "Downloads and Daily Users, last {0} days"
+msgstr ""
+
+#. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
+#: static/js/impala/stats/csv_keys.js:131 static/js/zamboni/stats-all.js:15412 static/js/zamboni/stats-min.js:5
+msgid "Downloads and Daily Users from {0} to {1}"
+msgstr ""
+
+#. L10n: {0} is an integer.
+#: static/js/impala/stats/csv_keys.js:135 static/js/zamboni/stats-all.js:15416 static/js/zamboni/stats-min.js:5
+msgid "Installs and Daily Users, last {0} days"
+msgstr ""
+
+#. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
+#: static/js/impala/stats/csv_keys.js:137 static/js/zamboni/stats-all.js:15418 static/js/zamboni/stats-min.js:5
+msgid "Installs and Daily Users from {0} to {1}"
+msgstr ""
+
+#. L10n: {0} is an integer.
+#: static/js/impala/stats/csv_keys.js:141 static/js/zamboni/stats-all.js:15422 static/js/zamboni/stats-min.js:5
+msgid "Downloads, last {0} days"
+msgstr ""
+
+#. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
+#: static/js/impala/stats/csv_keys.js:143 static/js/zamboni/stats-all.js:15424 static/js/zamboni/stats-min.js:5
+msgid "Downloads from {0} to {1}"
+msgstr ""
+
+#. L10n: {0} is an integer.
+#: static/js/impala/stats/csv_keys.js:147 static/js/zamboni/stats-all.js:15428 static/js/zamboni/stats-min.js:5
+msgid "Daily Users, last {0} days"
+msgstr ""
+
+#. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
+#: static/js/impala/stats/csv_keys.js:149 static/js/zamboni/stats-all.js:15430 static/js/zamboni/stats-min.js:5
+msgid "Daily Users from {0} to {1}"
+msgstr ""
+
+#. L10n: {0} is an integer.
+#: static/js/impala/stats/csv_keys.js:153 static/js/zamboni/stats-all.js:15434 static/js/zamboni/stats-min.js:5
+msgid "Applications, last {0} days"
+msgstr ""
+
+#. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
+#: static/js/impala/stats/csv_keys.js:155 static/js/zamboni/stats-all.js:15436 static/js/zamboni/stats-min.js:5
+msgid "Applications from {0} to {1}"
+msgstr ""
+
+#. L10n: {0} is an integer.
+#: static/js/impala/stats/csv_keys.js:159 static/js/zamboni/stats-all.js:15440 static/js/zamboni/stats-min.js:5
+msgid "Platforms, last {0} days"
+msgstr ""
+
+#. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
+#: static/js/impala/stats/csv_keys.js:161 static/js/zamboni/stats-all.js:15442 static/js/zamboni/stats-min.js:5
+msgid "Platforms from {0} to {1}"
+msgstr ""
+
+#. L10n: {0} is an integer.
+#: static/js/impala/stats/csv_keys.js:165 static/js/zamboni/stats-all.js:15446 static/js/zamboni/stats-min.js:5
+msgid "Languages, last {0} days"
+msgstr ""
+
+#. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
+#: static/js/impala/stats/csv_keys.js:167 static/js/zamboni/stats-all.js:15448 static/js/zamboni/stats-min.js:5
+msgid "Languages from {0} to {1}"
+msgstr ""
+
+#. L10n: {0} is an integer.
+#: static/js/impala/stats/csv_keys.js:171 static/js/zamboni/stats-all.js:15452 static/js/zamboni/stats-min.js:5
+msgid "Add-on Versions, last {0} days"
+msgstr ""
+
+#. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
+#: static/js/impala/stats/csv_keys.js:173 static/js/zamboni/stats-all.js:15454 static/js/zamboni/stats-min.js:5
+msgid "Add-on Versions from {0} to {1}"
+msgstr ""
+
+#. L10n: {0} is an integer.
+#: static/js/impala/stats/csv_keys.js:177 static/js/zamboni/stats-all.js:15458 static/js/zamboni/stats-min.js:5
+msgid "Add-on Status, last {0} days"
+msgstr ""
+
+#. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
+#: static/js/impala/stats/csv_keys.js:179 static/js/zamboni/stats-all.js:15460 static/js/zamboni/stats-min.js:5
+msgid "Add-on Status from {0} to {1}"
+msgstr ""
+
+#. L10n: {0} is an integer.
+#: static/js/impala/stats/csv_keys.js:183 static/js/zamboni/stats-all.js:15464 static/js/zamboni/stats-min.js:5
+msgid "Download Sources, last {0} days"
+msgstr ""
+
+#. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
+#: static/js/impala/stats/csv_keys.js:185 static/js/zamboni/stats-all.js:15466 static/js/zamboni/stats-min.js:5
+msgid "Download Sources from {0} to {1}"
+msgstr ""
+
+#. L10n: {0} is an integer.
+#: static/js/impala/stats/csv_keys.js:189 static/js/zamboni/stats-all.js:15470 static/js/zamboni/stats-min.js:5
+msgid "Contributions, last {0} days"
+msgstr ""
+
+#. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
+#: static/js/impala/stats/csv_keys.js:191 static/js/zamboni/stats-all.js:15472 static/js/zamboni/stats-min.js:5
+msgid "Contributions from {0} to {1}"
+msgstr ""
+
+#. L10n: {0} is an integer.
+#: static/js/impala/stats/csv_keys.js:195 static/js/zamboni/stats-all.js:15476 static/js/zamboni/stats-min.js:5
+msgid "Site Metrics, last {0} days"
+msgstr ""
+
+#. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
+#: static/js/impala/stats/csv_keys.js:197 static/js/zamboni/stats-all.js:15478 static/js/zamboni/stats-min.js:5
+msgid "Site Metrics from {0} to {1}"
+msgstr ""
+
+#. L10n: {0} is an integer.
+#: static/js/impala/stats/csv_keys.js:201 static/js/zamboni/stats-all.js:15482 static/js/zamboni/stats-min.js:5
+msgid "Add-ons in Use, last {0} days"
+msgstr ""
+
+#. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
+#: static/js/impala/stats/csv_keys.js:203 static/js/zamboni/stats-all.js:15484 static/js/zamboni/stats-min.js:5
+msgid "Add-ons in Use from {0} to {1}"
+msgstr ""
+
+#. L10n: {0} is an integer.
+#: static/js/impala/stats/csv_keys.js:207 static/js/zamboni/stats-all.js:15488 static/js/zamboni/stats-min.js:5
+msgid "Add-ons Downloaded, last {0} days"
+msgstr ""
+
+#. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
+#: static/js/impala/stats/csv_keys.js:209 static/js/zamboni/stats-all.js:15490 static/js/zamboni/stats-min.js:5
+msgid "Add-ons Downloaded from {0} to {1}"
+msgstr ""
+
+#. L10n: {0} is an integer.
+#: static/js/impala/stats/csv_keys.js:213 static/js/zamboni/stats-all.js:15494 static/js/zamboni/stats-min.js:5
+msgid "Add-ons Created, last {0} days"
+msgstr ""
+
+#. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
+#: static/js/impala/stats/csv_keys.js:215 static/js/zamboni/stats-all.js:15496 static/js/zamboni/stats-min.js:5
+msgid "Add-ons Created from {0} to {1}"
+msgstr ""
+
+#. L10n: {0} is an integer.
+#: static/js/impala/stats/csv_keys.js:219 static/js/zamboni/stats-all.js:15500 static/js/zamboni/stats-min.js:5
+msgid "Add-ons Updated, last {0} days"
+msgstr ""
+
+#. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
+#: static/js/impala/stats/csv_keys.js:221 static/js/zamboni/stats-all.js:15502 static/js/zamboni/stats-min.js:5
+msgid "Add-ons Updated from {0} to {1}"
+msgstr ""
+
+#. L10n: {0} is an integer.
+#: static/js/impala/stats/csv_keys.js:225 static/js/zamboni/stats-all.js:15506 static/js/zamboni/stats-min.js:5
+msgid "Reviews Written, last {0} days"
+msgstr ""
+
+#. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
+#: static/js/impala/stats/csv_keys.js:227 static/js/zamboni/stats-all.js:15508 static/js/zamboni/stats-min.js:5
+msgid "Reviews Written from {0} to {1}"
+msgstr ""
+
+#. L10n: {0} is an integer.
+#: static/js/impala/stats/csv_keys.js:231 static/js/zamboni/stats-all.js:15512 static/js/zamboni/stats-min.js:5
+msgid "User Signups, last {0} days"
+msgstr ""
+
+#. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
+#: static/js/impala/stats/csv_keys.js:233 static/js/zamboni/stats-all.js:15514 static/js/zamboni/stats-min.js:5
+msgid "User Signups from {0} to {1}"
+msgstr ""
+
+#. L10n: {0} is an integer.
+#: static/js/impala/stats/csv_keys.js:237 static/js/zamboni/stats-all.js:15518 static/js/zamboni/stats-min.js:5
+msgid "Collections Created, last {0} days"
+msgstr ""
+
+#. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
+#: static/js/impala/stats/csv_keys.js:239 static/js/zamboni/stats-all.js:15520 static/js/zamboni/stats-min.js:5
+msgid "Collections Created from {0} to {1}"
+msgstr ""
+
+#. L10n: {0} is an integer.
+#: static/js/impala/stats/csv_keys.js:243 static/js/zamboni/stats-all.js:15524 static/js/zamboni/stats-min.js:5
+msgid "Subscribers, last {0} days"
+msgstr ""
+
+#. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
+#: static/js/impala/stats/csv_keys.js:245 static/js/zamboni/stats-all.js:15526 static/js/zamboni/stats-min.js:5
+msgid "Subscribers from {0} to {1}"
+msgstr ""
+
+#. L10n: {0} is an integer.
+#: static/js/impala/stats/csv_keys.js:249 static/js/zamboni/stats-all.js:15530 static/js/zamboni/stats-min.js:5
+msgid "Ratings, last {0} days"
+msgstr ""
+
+#. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
+#: static/js/impala/stats/csv_keys.js:251 static/js/zamboni/stats-all.js:15532 static/js/zamboni/stats-min.js:5
+msgid "Ratings from {0} to {1}"
+msgstr ""
+
+#. L10n: {0} is an integer.
+#: static/js/impala/stats/csv_keys.js:255 static/js/zamboni/stats-all.js:15536 static/js/zamboni/stats-min.js:5
+msgid "Sales, last {0} days"
+msgstr ""
+
+#. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
+#: static/js/impala/stats/csv_keys.js:257 static/js/zamboni/stats-all.js:15538 static/js/zamboni/stats-min.js:5
+msgid "Sales from {0} to {1}"
+msgstr ""
+
+#. L10n: {0} is an integer.
+#: static/js/impala/stats/csv_keys.js:261 static/js/zamboni/stats-all.js:15542 static/js/zamboni/stats-min.js:5
+msgid "Installs, last {0} days"
+msgstr ""
+
+#. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
+#: static/js/impala/stats/csv_keys.js:263 static/js/zamboni/stats-all.js:15544 static/js/zamboni/stats-min.js:5
+msgid "Installs from {0} to {1}"
+msgstr ""
+
+#. L10n: {0} and {1} are integers.
+#: static/js/impala/stats/csv_keys.js:269 static/js/zamboni/stats-all.js:15550 static/js/zamboni/stats-min.js:5
+msgid "<b>{0}</b> in last {1} days"
+msgstr ""
+
+#. L10n: {0} is an integer and {1} and {2} are dates in YYYY-MM-DD format.
+#: static/js/impala/stats/csv_keys.js:271 static/js/impala/stats/csv_keys.js:277 static/js/zamboni/stats-all.js:15552 static/js/zamboni/stats-all.js:15558 static/js/zamboni/stats-min.js:5
+msgid "<b>{0}</b> from {1} to {2}"
+msgstr ""
+
+#. L10n: {0} and {1} are integers.
+#: static/js/impala/stats/csv_keys.js:275 static/js/zamboni/stats-all.js:15556 static/js/zamboni/stats-min.js:5
+msgid "<b>{0}</b> average in last {1} days"
+msgstr ""
+
+#: static/js/impala/stats/overview.js:19 static/js/zamboni/stats-all.js:16469 static/js/zamboni/stats-min.js:5
+msgid "No data available."
+msgstr ""
+
+#: static/js/impala/stats/table.js:74 static/js/zamboni/stats-all.js:17209 static/js/zamboni/stats-min.js:5
+msgid "Date"
+msgstr ""
+
+#: static/js/impala/stats/topchart.js:96 static/js/zamboni/stats-all.js:16600 static/js/zamboni/stats-min.js:5
+msgid "Other"
+msgstr "Ander"
+
+#: static/js/zamboni/admin-all.js:180 static/js/zamboni/admin-min.js:1 static/js/zamboni/admin_validation.js:24 static/js/zamboni/devhub-all.js:2408 static/js/zamboni/devhub-min.js:2
+#: static/js/zamboni/devhub.js:1229 static/js/zamboni/editors-all.js:15576 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:295
+msgid "Select an application first"
+msgstr ""
+
+#: static/js/zamboni/admin-all.js:207 static/js/zamboni/admin-min.js:1 static/js/zamboni/admin_validation.js:51
+msgid "Set {0} add-on to a max version of {1} and email the author."
+msgid_plural "Set {0} add-ons to a max version of {1} and email the authors."
+msgstr[0] ""
+msgstr[1] ""
+
+#: static/js/zamboni/admin-all.js:210 static/js/zamboni/admin-min.js:1 static/js/zamboni/admin_validation.js:54
+msgid "Email author of {2} add-on which failed validation."
+msgid_plural "Email authors of {2} add-ons which failed validation."
+msgstr[0] ""
+msgstr[1] ""
+
+#: static/js/zamboni/devhub-all.js:1289 static/js/zamboni/devhub-min.js:1 static/js/zamboni/devhub.js:110
+msgid "Your browser does not support the video tag"
+msgstr ""
+
+#: static/js/zamboni/devhub-all.js:1550 static/js/zamboni/devhub-min.js:1 static/js/zamboni/devhub.js:371
+msgid "Changes Saved"
+msgstr ""
+
+#: static/js/zamboni/devhub-all.js:1566 static/js/zamboni/devhub-min.js:1 static/js/zamboni/devhub.js:387
+msgid "Enter a new author's email address"
+msgstr ""
+
+#: static/js/zamboni/devhub-all.js:1715 static/js/zamboni/devhub-min.js:1 static/js/zamboni/devhub.js:536
+msgid "There was an error uploading your file."
+msgstr ""
+
+#: static/js/zamboni/devhub-all.js:1860 static/js/zamboni/devhub-min.js:1 static/js/zamboni/devhub.js:681
+msgid "{files} file"
+msgid_plural "{files} files"
+msgstr[0] ""
+msgstr[1] ""
+
+#: static/js/zamboni/devhub-all.js:1863 static/js/zamboni/devhub-min.js:1 static/js/zamboni/devhub.js:684
+msgid "{reviews} user review"
+msgid_plural "{reviews} user reviews"
+msgstr[0] ""
+msgstr[1] ""
+
+#: static/js/zamboni/devhub-all.js:1975 static/js/zamboni/devhub-min.js:2 static/js/zamboni/devhub.js:796
+msgid "Learn more"
+msgstr "Meer inligting"
+
+#: static/js/zamboni/devhub-all.js:1979 static/js/zamboni/devhub-min.js:2 static/js/zamboni/devhub.js:800
+msgid "Example"
+msgstr "Voorbeeld"
+
+#: static/js/zamboni/devhub-all.js:2309 static/js/zamboni/devhub-min.js:2 static/js/zamboni/devhub.js:1130
+msgid "Image changes being processed"
+msgstr ""
+
+#: static/js/zamboni/devhub-all.js:2459 static/js/zamboni/devhub-min.js:2 static/js/zamboni/devhub.js:1280
+msgid "Must be a valid e-mail address."
+msgstr ""
+
+#: static/js/zamboni/devhub-all.js:2613 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:80
 msgid "All tests passed successfully."
 msgstr ""
 
-#: static/js/zamboni/validator.js:83 static/js/zamboni/validator.js:478
+#: static/js/zamboni/devhub-all.js:2616 static/js/zamboni/devhub-all.js:3011 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:83 static/js/zamboni/validator.js:478
 msgid "These tests were not run."
 msgstr ""
 
-#: static/js/zamboni/validator.js:131 static/js/zamboni/validator.js:144
+#: static/js/zamboni/devhub-all.js:2664 static/js/zamboni/devhub-all.js:2677 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:131 static/js/zamboni/validator.js:144
 msgid "Tests"
 msgstr ""
 
-#: static/js/zamboni/validator.js:246 static/js/zamboni/validator.js:575 static/js/zamboni/validator.js:594
+#: static/js/zamboni/devhub-all.js:2779 static/js/zamboni/devhub-all.js:3108 static/js/zamboni/devhub-all.js:3127 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:246
+#: static/js/zamboni/validator.js:575 static/js/zamboni/validator.js:594
 msgid "Error"
 msgstr "Fout"
 
-#: static/js/zamboni/validator.js:247
+#: static/js/zamboni/devhub-all.js:2780 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:247
 msgid "Warning"
 msgstr "Waarskuwing"
 
-#: static/js/zamboni/validator.js:299
+#: static/js/zamboni/devhub-all.js:2794 static/js/zamboni/devhub-min.js:2 static/js/zamboni/files-all.js:5657 static/js/zamboni/files-min.js:3 static/js/zamboni/files.js:411
+#: static/js/zamboni/validator.js:261
+msgid "Ignore this message in future updates"
+msgstr ""
+
+#: static/js/zamboni/devhub-all.js:2817 static/js/zamboni/devhub-min.js:2 static/js/zamboni/files-all.js:5663 static/js/zamboni/files-min.js:3 static/js/zamboni/files.js:417
+#: static/js/zamboni/validator.js:284
+msgid "Severity for automated signing:"
+msgstr ""
+
+#: static/js/zamboni/devhub-all.js:2832 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:299
 msgid "Suggestions for passing automated signing:"
 msgstr ""
 
-#: static/js/zamboni/validator.js:387
+#: static/js/zamboni/devhub-all.js:2920 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:387
 msgid "Compatibility Tests"
 msgstr ""
 
-#: static/js/zamboni/validator.js:466
+#: static/js/zamboni/devhub-all.js:2999 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:466
 msgid "Add-on failed validation."
 msgstr ""
 
-#: static/js/zamboni/validator.js:468
+#: static/js/zamboni/devhub-all.js:3001 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:468
 msgid "Add-on passed validation."
 msgstr ""
 
-#: static/js/zamboni/validator.js:481
+#: static/js/zamboni/devhub-all.js:3014 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:481
 msgid "{0} error"
 msgid_plural "{0} errors"
 msgstr[0] "{0} fout"
 msgstr[1] "{0} foute"
 
-#: static/js/zamboni/validator.js:483
+#: static/js/zamboni/devhub-all.js:3016 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:483
 msgid "{0} warning"
 msgid_plural "{0} warnings"
 msgstr[0] "{0} waarskuwing"
 msgstr[1] "{0} waarskuwings"
 
-#: static/js/zamboni/validator.js:485
+#: static/js/zamboni/devhub-all.js:3018 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:485
 msgid "{0} notice"
 msgid_plural "{0} notices"
 msgstr[0] ""
 msgstr[1] ""
 
-#: static/js/zamboni/validator.js:577
+#: static/js/zamboni/devhub-all.js:3110 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:577
 msgid "Validation task could not complete or completed with errors"
 msgstr ""
 
-#: static/js/zamboni/validator.js:595
+#: static/js/zamboni/devhub-all.js:3128 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:595
 msgid "Internal server error"
 msgstr "Interne bedienerfout"
 
-#: static/js/zamboni/mobile/buttons.js:52
+#: static/js/zamboni/devhub_search.js:8
+msgid "No results found."
+msgstr ""
+
+#: static/js/zamboni/editors-all.js:15402 static/js/zamboni/editors-min.js:4 static/js/zamboni/editors.js:121
+msgid "{name} was viewing this page first."
+msgstr ""
+
+#: static/js/zamboni/editors-all.js:15452 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:171
+msgid "Receipt checked by app."
+msgstr ""
+
+#: static/js/zamboni/editors-all.js:15454 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:173
+msgid "Receipt was not checked by app."
+msgstr ""
+
+#: static/js/zamboni/editors-all.js:15525 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:244
+msgid "{name} was viewing this add-on first."
+msgstr ""
+
+#: static/js/zamboni/editors-all.js:15536 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:255
+msgid "Loading&hellip;"
+msgstr "Laai tans&hellip;"
+
+#: static/js/zamboni/editors-all.js:15541 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:260
+msgid "Version Notes"
+msgstr ""
+
+#: static/js/zamboni/editors-all.js:15546 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:265
+msgid "Notes for Reviewers"
+msgstr ""
+
+#: static/js/zamboni/editors-all.js:15551 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:270
+msgid "No version notes found"
+msgstr ""
+
+#: static/js/zamboni/editors-all.js:15611 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:330
+msgid "Average Reviews"
+msgstr ""
+
+#: static/js/zamboni/editors-all.js:15667 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:386
+msgid "Number of Reviews"
+msgstr ""
+
+#: static/js/zamboni/editors-all.js:15726 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:445
+msgid "Error loading translation"
+msgstr ""
+
+#: static/js/zamboni/editors-all.js:15975 static/js/zamboni/editors-min.js:5 static/js/zamboni/themes_review_templates.js:31
+msgid "Theme"
+msgstr ""
+
+#: static/js/zamboni/editors-all.js:15977 static/js/zamboni/editors-min.js:5 static/js/zamboni/themes_review_templates.js:33
+msgid "Reviewer"
+msgstr ""
+
+#: static/js/zamboni/editors-all.js:15979 static/js/zamboni/editors-min.js:5 static/js/zamboni/themes_review_templates.js:35
+msgid "Status"
+msgstr ""
+
+#: static/js/zamboni/editors-all.js:16196 static/js/zamboni/editors-min.js:5 static/js/zamboni/themes_review.js:176
+msgid "Requested Info"
+msgstr ""
+
+#: static/js/zamboni/editors-all.js:16197 static/js/zamboni/editors-min.js:5 static/js/zamboni/themes_review.js:177
+msgid "Flagged"
+msgstr ""
+
+#: static/js/zamboni/editors-all.js:16198 static/js/zamboni/editors-min.js:5 static/js/zamboni/themes_review.js:178
+msgid "Duplicate"
+msgstr ""
+
+#: static/js/zamboni/editors-all.js:16199 static/js/zamboni/editors-min.js:5 static/js/zamboni/themes_review.js:179
+msgid "Rejected"
+msgstr ""
+
+#: static/js/zamboni/editors-all.js:16200 static/js/zamboni/editors-min.js:5 static/js/zamboni/themes_review.js:180
+msgid "Approved"
+msgstr ""
+
+#: static/js/zamboni/editors-all.js:16444 static/js/zamboni/editors-min.js:5 static/js/zamboni/themes_review.js:424
+msgid "No results found"
+msgstr ""
+
+#: static/js/zamboni/mobile-all.js:15186 static/js/zamboni/mobile/buttons.js:52
 msgid "Not Updated for {0} {1}"
 msgstr ""
 
-#: static/js/zamboni/mobile/buttons.js:53
+#: static/js/zamboni/mobile-all.js:15187 static/js/zamboni/mobile/buttons.js:53
 msgid "Requires Newer Version of {0}"
 msgstr ""
 
-#: static/js/zamboni/mobile/buttons.js:54
+#: static/js/zamboni/mobile-all.js:15188 static/js/zamboni/mobile/buttons.js:54
 msgid "Unreviewed"
 msgstr "Nie nagegaan nie"
 
-#: static/js/zamboni/mobile/buttons.js:55
+#: static/js/zamboni/mobile-all.js:15189 static/js/zamboni/mobile/buttons.js:55
 msgid "Experimental <span>(Learn More)</span>"
 msgstr "Eksperimenteel <span>(Meer inligting)</span>"
 
-#: static/js/zamboni/mobile/buttons.js:56 static/js/zamboni/mobile/buttons.js:57
+#: static/js/zamboni/mobile-all.js:15190 static/js/zamboni/mobile-all.js:15191 static/js/zamboni/mobile/buttons.js:56 static/js/zamboni/mobile/buttons.js:57
 msgid "Not Available for {0}"
 msgstr "Nie beskikbaar vir {0} nie"
 
-#: static/js/zamboni/mobile/buttons.js:58
+#: static/js/zamboni/mobile-all.js:15192 static/js/zamboni/mobile/buttons.js:58
 msgid "Experimental"
 msgstr "Eksperimenteel"
 
-#: static/js/zamboni/mobile/buttons.js:59
+#: static/js/zamboni/mobile-all.js:15193 static/js/zamboni/mobile/buttons.js:59
 msgid "Themes Require Newer Version of {0}"
 msgstr ""
 
-#: static/js/zamboni/mobile/buttons.js:60
+#: static/js/zamboni/mobile-all.js:15194 static/js/zamboni/mobile/buttons.js:60
 msgid "Themes Require {0}"
 msgstr ""
 
-#: static/js/zamboni/mobile/buttons.js:105
+#: static/js/zamboni/mobile-all.js:15239 static/js/zamboni/mobile/buttons.js:105
 msgid "Installing..."
 msgstr ""
 
-#: static/js/zamboni/mobile/buttons.js:125
+#: static/js/zamboni/mobile-all.js:15259 static/js/zamboni/mobile/buttons.js:125
 msgid "This add-on has been preliminarily reviewed by Mozilla."
 msgstr "Dié byvoeging is voorlopig nagegaan deur Mozilla."
 
-#: static/js/zamboni/mobile/buttons.js:250
+#: static/js/zamboni/mobile-all.js:15384 static/js/zamboni/mobile/buttons.js:250
 msgid "Keep it"
 msgstr ""
 
-#: static/js/zamboni/mobile/general.js:344
+#: static/js/zamboni/mobile-all.js:16049 static/js/zamboni/mobile-min.js:6 static/js/zamboni/mobile/general.js:344
 msgid "You're trying it on!"
 msgstr ""
 
-#: static/js/zamboni/mobile/general.js:356
+#: static/js/zamboni/mobile-all.js:16061 static/js/zamboni/mobile-min.js:6 static/js/zamboni/mobile/general.js:356
 msgid "Added to Firefox"
 msgstr "By Firefox gevoeg"
-

--- a/locale/ar/LC_MESSAGES/django.po
+++ b/locale/ar/LC_MESSAGES/django.po
@@ -11,69 +11,70 @@ msgid ""
 msgstr ""
 "Project-Id-Version:  messages\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2016-02-24 21:23+0000\n"
+"POT-Creation-Date: 2016-04-18 15:47+0000\n"
 "PO-Revision-Date: 2013-10-24 09:38+0300\n"
 "Last-Translator: Ellery <linux.anas@gmail.com>\n"
 "Language-Team: Arabeyes <doc@arabeyes.org>\n"
+"Language: \n"
 "MIME-Version: 1.0\n"
-"Content-Type: text/plain; charset=utf-8\n"
+"Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Generated-By: Babel 2.2.0\n"
 
-#: src/olympia/accounts/views.py:52
+#: src/olympia/accounts/views.py:54
 msgid "Your log in attempt could not be parsed. Please try again."
 msgstr ""
 
-#: src/olympia/accounts/views.py:54
+#: src/olympia/accounts/views.py:56
 msgid "Your Firefox Account could not be found. Please try again."
 msgstr ""
 
-#: src/olympia/accounts/views.py:55
+#: src/olympia/accounts/views.py:57
 msgid "You could not be logged in. Please try again."
 msgstr ""
 
-#: src/olympia/accounts/views.py:57
+#: src/olympia/accounts/views.py:59
 msgid "Your account has already been migrated to Firefox Accounts."
 msgstr ""
 
-#: src/olympia/accounts/views.py:59
+#: src/olympia/accounts/views.py:61
 msgid "Your Firefox Account already exists on this site."
 msgstr ""
 
-#: src/olympia/accounts/views.py:108
+#: src/olympia/accounts/views.py:110
 msgid "Great job!"
 msgstr ""
 
-#: src/olympia/accounts/views.py:109
+#: src/olympia/accounts/views.py:111
 msgid "You can now log in to Add-ons with your Firefox Account."
 msgstr ""
 
-#: src/olympia/accounts/views.py:121
+#: src/olympia/accounts/views.py:123
 msgid "Need help?"
 msgstr ""
 
-#: src/olympia/addons/buttons.py:180
+#: src/olympia/addons/buttons.py:177
 msgid "Download Now"
 msgstr "نزّلها الآن"
 
-#: src/olympia/addons/buttons.py:182
+#: src/olympia/addons/buttons.py:179
 msgid "Download"
 msgstr "تنزيل"
 
 #. L10n: please keep &nbsp; in the string so &rarr; does not wrap.
-#: src/olympia/addons/buttons.py:186
+#: src/olympia/addons/buttons.py:183
 msgid "Continue to Download&nbsp;&rarr;"
 msgstr "استمرار وتنزيل&nbsp;&rarr;"
 
-#: src/olympia/addons/buttons.py:202 src/olympia/addons/helpers.py:35 src/olympia/addons/views.py:319 src/olympia/addons/templates/addons/impala/details.html:114
+#: src/olympia/addons/buttons.py:199 src/olympia/addons/helpers.py:35 src/olympia/addons/views.py:333 src/olympia/addons/templates/addons/impala/details.html:111
 #: src/olympia/addons/templates/addons/impala/listing/items.html:17 src/olympia/addons/templates/addons/mobile/home.html:40 src/olympia/amo/templates/amo/side_nav.html:6
-#: src/olympia/amo/templates/amo/side_nav.html:10 src/olympia/amo/templates/amo/site_nav.html:2 src/olympia/amo/templates/amo/site_nav.html:55 src/olympia/bandwagon/views.py:95
-#: src/olympia/browse/views.py:54 src/olympia/browse/views.py:68 src/olympia/browse/views.py:235 src/olympia/browse/templates/browse/impala/category_landing.html:22
+#: src/olympia/amo/templates/amo/side_nav.html:10 src/olympia/amo/templates/amo/site_nav.html:2 src/olympia/amo/templates/amo/site_nav.html:53 src/olympia/bandwagon/views.py:95
+#: src/olympia/browse/views.py:54 src/olympia/browse/views.py:68 src/olympia/browse/views.py:202 src/olympia/browse/templates/browse/impala/category_landing.html:22
 #: src/olympia/browse/templates/browse/personas/mobile/category_landing.html:26
 msgid "Featured"
 msgstr "متميزة"
 
-#: src/olympia/addons/buttons.py:221
+#: src/olympia/addons/buttons.py:218
 msgid "Add to {0}"
 msgstr "أضِف إلى {0}"
 
@@ -96,10 +97,6 @@ msgid "Invalid tag: {0}"
 msgid_plural "Invalid tags: {0}"
 msgstr[0] ""
 msgstr[1] ""
-msgstr[2] ""
-msgstr[3] ""
-msgstr[4] ""
-msgstr[5] ""
 
 #. L10n: {0} is a single tag or a comma-separated list of tags.
 #: src/olympia/addons/forms.py:103
@@ -107,20 +104,12 @@ msgid "\"{0}\" is a reserved tag and cannot be used."
 msgid_plural "\"{0}\" are reserved tags and cannot be used."
 msgstr[0] ""
 msgstr[1] ""
-msgstr[2] ""
-msgstr[3] ""
-msgstr[4] ""
-msgstr[5] ""
 
 #: src/olympia/addons/forms.py:111
 msgid "You have {0} too many tags."
 msgid_plural "You have {0} too many tags."
 msgstr[0] ""
 msgstr[1] ""
-msgstr[2] ""
-msgstr[3] ""
-msgstr[4] ""
-msgstr[5] ""
 
 #: src/olympia/addons/forms.py:117
 #, python-format
@@ -132,48 +121,40 @@ msgid "All tags must be at least {0} character."
 msgid_plural "All tags must be at least {0} characters."
 msgstr[0] ""
 msgstr[1] ""
-msgstr[2] ""
-msgstr[3] ""
-msgstr[4] ""
-msgstr[5] ""
 
-#: src/olympia/addons/forms.py:234
+#: src/olympia/addons/forms.py:238
 msgid "Categories cannot be changed while your add-on is featured for this application."
 msgstr "التصنيفات لا يمكن تغييرها بينما إضافتك ضمن الإضافات المتميزة لهذا التطبيق."
 
 #. L10n: {0} is the number of categories.
-#: src/olympia/addons/forms.py:238
+#: src/olympia/addons/forms.py:242
 msgid "You can have only {0} category."
 msgid_plural "You can have only {0} categories."
 msgstr[0] ""
 msgstr[1] ""
-msgstr[2] ""
-msgstr[3] ""
-msgstr[4] ""
-msgstr[5] ""
 
-#: src/olympia/addons/forms.py:246
+#: src/olympia/addons/forms.py:250
 msgid "The miscellaneous category cannot be combined with additional categories."
 msgstr ""
 
-#: src/olympia/addons/forms.py:369
+#: src/olympia/addons/forms.py:374
 #, python-format
 msgid "Before changing your default locale you must have a name, summary, and description in that locale. You are missing %s."
 msgstr ""
 
-#: src/olympia/addons/forms.py:484 src/olympia/addons/forms.py:575
+#: src/olympia/addons/forms.py:455 src/olympia/addons/forms.py:546
 msgid "A license must be selected."
 msgstr "يجب اختيار رخصة."
 
-#: src/olympia/addons/forms.py:556
+#: src/olympia/addons/forms.py:527
 msgid "Give Your Theme a Name."
 msgstr ""
 
-#: src/olympia/addons/forms.py:562 src/olympia/devhub/templates/devhub/personas/submit.html:53
+#: src/olympia/addons/forms.py:533 src/olympia/devhub/templates/devhub/personas/submit.html:53
 msgid "Describe your Theme."
 msgstr "صِف السمة."
 
-#: src/olympia/addons/forms.py:704
+#: src/olympia/addons/forms.py:675
 msgid "Enter a new author's email address"
 msgstr ""
 
@@ -181,40 +162,40 @@ msgstr ""
 msgid "Not Reviewed"
 msgstr "غير مراجعة"
 
-#: src/olympia/addons/models.py:301
+#: src/olympia/addons/models.py:298
 msgid "Users have the option of contributing more or less than this amount."
 msgstr "المستخدمين لديهم الخيار للمساهمة بأكثر أو أقل من هذه القيمة."
 
-#: src/olympia/addons/models.py:309
-msgid "Users will always be asked in the Add-ons Manager (Firefox 4 and above)"
+#: src/olympia/addons/models.py:306
+msgid "Users will always be asked in the Add-ons Manager (Firefox 4 and above). Only applies to desktop."
 msgstr ""
 
 # Column name in a table.
-#: src/olympia/addons/models.py:1804 src/olympia/addons/templates/addons/details_box.html:55 src/olympia/devhub/templates/devhub/index.html:92
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:102
+#: src/olympia/addons/models.py:1802 src/olympia/addons/templates/addons/details_box.html:55 src/olympia/devhub/templates/devhub/index.html:92
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:89
 #, fuzzy
 msgid "Listed"
 msgstr "Listed"
 
-#: src/olympia/addons/views.py:320 src/olympia/browse/templates/browse/personas/mobile/category_landing.html:27
+#: src/olympia/addons/views.py:334 src/olympia/browse/templates/browse/personas/mobile/category_landing.html:27
 msgid "Popular"
 msgstr "الشعبية"
 
-#: src/olympia/addons/views.py:321 src/olympia/browse/views.py:238 src/olympia/browse/views.py:280 src/olympia/browse/views.py:482
+#: src/olympia/addons/views.py:335 src/olympia/browse/views.py:205 src/olympia/browse/views.py:247 src/olympia/browse/views.py:449
 msgid "Recently Added"
 msgstr "المُضاف مؤخرا"
 
-#: src/olympia/addons/views.py:322 src/olympia/bandwagon/views.py:99 src/olympia/browse/views.py:60 src/olympia/browse/views.py:71 src/olympia/search/forms.py:16 src/olympia/search/forms.py:91
+#: src/olympia/addons/views.py:336 src/olympia/bandwagon/views.py:99 src/olympia/browse/views.py:60 src/olympia/browse/views.py:71 src/olympia/search/forms.py:16 src/olympia/search/forms.py:91
 msgid "Recently Updated"
 msgstr "المُحدّثة مؤخرا"
 
 # %1 is an add-on name.
 #. l10n: {0} is the addon name
-#: src/olympia/addons/views.py:520
+#: src/olympia/addons/views.py:534
 msgid "Contribution for {0}"
 msgstr "المساهمة في {0}"
 
-#: src/olympia/addons/views.py:613
+#: src/olympia/addons/views.py:627
 msgid "Abuse reported."
 msgstr ""
 
@@ -283,9 +264,9 @@ msgstr "ساهم"
 #: src/olympia/devhub/templates/devhub/addons/ajax_compat_update.html:36 src/olympia/devhub/templates/devhub/addons/profile.html:44 src/olympia/devhub/templates/devhub/addons/edit/admin.html:101
 #: src/olympia/devhub/templates/devhub/addons/edit/basic.html:152 src/olympia/devhub/templates/devhub/addons/edit/details.html:85 src/olympia/devhub/templates/devhub/addons/edit/support.html:67
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:166 src/olympia/devhub/templates/devhub/addons/forms_shared/media.html:149
-#: src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:44 src/olympia/devhub/templates/devhub/versions/add_file_modal.html:78 src/olympia/devhub/templates/devhub/versions/edit.html:139
-#: src/olympia/devhub/templates/devhub/versions/list.html:242 src/olympia/devhub/templates/devhub/versions/list.html:276 src/olympia/devhub/templates/devhub/versions/list.html:317
-#: src/olympia/devhub/templates/devhub/versions/list.html:351 src/olympia/reviews/templates/reviews/edit_review.html:16 src/olympia/translations/templates/translations/trans-menu.html:50
+#: src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:43 src/olympia/devhub/templates/devhub/versions/add_file_modal.html:58 src/olympia/devhub/templates/devhub/versions/edit.html:139
+#: src/olympia/devhub/templates/devhub/versions/list.html:239 src/olympia/devhub/templates/devhub/versions/list.html:281 src/olympia/devhub/templates/devhub/versions/list.html:315
+#: src/olympia/devhub/templates/devhub/versions/list.html:349 src/olympia/reviews/templates/reviews/edit_review.html:16 src/olympia/translations/templates/translations/trans-menu.html:50
 #: src/olympia/translations/templates/translations/trans-menu.html:62
 msgid "or"
 msgstr "أو"
@@ -397,7 +378,7 @@ msgid "Add-on Information for {0}"
 msgstr "معلومات الإضافة لـ {0}"
 
 #: src/olympia/addons/templates/addons/details_box.html:30 src/olympia/addons/templates/addons/persona_detail_table.html:3 src/olympia/addons/templates/addons/mobile/details.html:63
-#: src/olympia/addons/templates/addons/mobile/persona_detail_table.html:7 src/olympia/browse/views.py:459 src/olympia/devhub/views.py:75
+#: src/olympia/addons/templates/addons/mobile/persona_detail_table.html:7 src/olympia/browse/views.py:426 src/olympia/devhub/views.py:73
 msgid "Updated"
 msgstr "التحديث"
 
@@ -416,11 +397,11 @@ msgstr "تعمل مع"
 msgid "Visibility"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/details_box.html:57 src/olympia/devhub/templates/devhub/index.html:94 src/olympia/devhub/templates/devhub/includes/addon_details.html:104
+#: src/olympia/addons/templates/addons/details_box.html:57 src/olympia/devhub/templates/devhub/index.html:94 src/olympia/devhub/templates/devhub/includes/addon_details.html:91
 msgid "Hidden"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/details_box.html:59 src/olympia/devhub/templates/devhub/index.html:96 src/olympia/devhub/templates/devhub/includes/addon_details.html:106
+#: src/olympia/addons/templates/addons/details_box.html:59 src/olympia/devhub/templates/devhub/index.html:96 src/olympia/devhub/templates/devhub/includes/addon_details.html:93
 msgid "Unlisted"
 msgstr ""
 
@@ -428,13 +409,13 @@ msgstr ""
 msgid "Required Add-ons"
 msgstr "الإضافات المطلوبة"
 
-#: src/olympia/addons/templates/addons/details_box.html:81 src/olympia/addons/templates/addons/persona_detail_table.html:15 src/olympia/browse/views.py:462 src/olympia/devhub/views.py:78
-#: src/olympia/devhub/views.py:85 src/olympia/discovery/templates/discovery/addons/detail.html:57 src/olympia/reviews/forms.py:62 src/olympia/reviews/templates/reviews/add.html:57
+#: src/olympia/addons/templates/addons/details_box.html:81 src/olympia/addons/templates/addons/persona_detail_table.html:15 src/olympia/browse/views.py:429 src/olympia/devhub/views.py:76
+#: src/olympia/devhub/views.py:83 src/olympia/discovery/templates/discovery/addons/detail.html:57 src/olympia/reviews/forms.py:62 src/olympia/reviews/templates/reviews/add.html:57
 #: src/olympia/reviews/templates/reviews/mobile/review_list.html:18
 msgid "Rating"
 msgstr "التقييم"
 
-#: src/olympia/addons/templates/addons/details_box.html:85 src/olympia/browse/views.py:461 src/olympia/devhub/views.py:77 src/olympia/devhub/views.py:84
+#: src/olympia/addons/templates/addons/details_box.html:85 src/olympia/browse/views.py:428 src/olympia/devhub/views.py:75 src/olympia/devhub/views.py:82
 #: src/olympia/stats/templates/stats/addon_report_menu.html:8 src/olympia/stats/templates/stats/collection_report_menu.html:18
 msgid "Downloads"
 msgstr "التنزيلات"
@@ -454,7 +435,7 @@ msgstr "بلاغات الإساءة"
 
 #. The Privacy Policy for this add-on.
 #: src/olympia/addons/templates/addons/details_box.html:121 src/olympia/addons/templates/addons/privacy.html:19 src/olympia/addons/templates/addons/privacy.html:23
-#: src/olympia/addons/templates/addons/impala/button.html:43 src/olympia/addons/templates/addons/impala/details.html:307 src/olympia/devhub/templates/devhub/includes/policy_form.html:20
+#: src/olympia/addons/templates/addons/impala/button.html:43 src/olympia/addons/templates/addons/impala/details.html:312 src/olympia/devhub/templates/devhub/includes/policy_form.html:23
 #: src/olympia/templates/mobile/base_addons.html:87
 msgid "Privacy Policy"
 msgstr "سياسة الخصوصية"
@@ -479,7 +460,7 @@ msgstr "معرض الصور"
 msgid "Developer Comments"
 msgstr "تعليقات المطور"
 
-#: src/olympia/addons/templates/addons/details_box.html:199 src/olympia/addons/templates/addons/impala/details.html:259
+#: src/olympia/addons/templates/addons/details_box.html:199 src/olympia/addons/templates/addons/impala/details.html:264
 msgid "Development Channel"
 msgstr "قناة التطوير"
 
@@ -501,13 +482,13 @@ msgstr ""
 "<strong>تحذير:</strong> الإصدارات التطويرية لهذه الإضافة لم تراجع بعد من قِبَل موزيلا. بمجرد تثبيتك للإصدارة التطويرية ستستمر باستقبال التحديثاث التطويرية من مطور الإضافة. لإيقاف استقبال التحديثات "
 "التطويرية، أعِد تثبيت الإصدارة الافتراضية من الرابط العلوي الأساسي."
 
-#: src/olympia/addons/templates/addons/details_box.html:220 src/olympia/addons/templates/addons/impala/details.html:278
+#: src/olympia/addons/templates/addons/details_box.html:220 src/olympia/addons/templates/addons/impala/details.html:283
 msgid "Version {0}:"
 msgstr "الإصدارة: {0}"
 
 #: src/olympia/addons/templates/addons/details_box.html:234
-msgid "Nothing to see here! The developer did not include any details."
-msgstr "لا شيء لتراه هنا! المطوّر لم يضمّن أي تفاصيل."
+msgid "Nothing to see here!  The developer did not include any details."
+msgstr ""
 
 #: src/olympia/addons/templates/addons/details_box.html:251 src/olympia/devhub/templates/devhub/versions/edit.html:73 src/olympia/editors/templates/editors/review.html:98
 msgid "Version Notes"
@@ -520,7 +501,7 @@ msgid "End-User License Agreement for {0}"
 msgstr "إتفاقية ترخيص المستخدم النهائي لـ {0}"
 
 #: src/olympia/addons/templates/addons/eula.html:17 src/olympia/addons/templates/addons/eula.html:21 src/olympia/addons/templates/addons/impala/button.html:48
-#: src/olympia/addons/templates/addons/impala/details.html:316 src/olympia/devhub/templates/devhub/includes/policy_form.html:3 src/olympia/discovery/templates/discovery/addons/eula.html:11
+#: src/olympia/addons/templates/addons/impala/details.html:321 src/olympia/devhub/templates/devhub/includes/policy_form.html:3 src/olympia/discovery/templates/discovery/addons/eula.html:11
 msgid "End-User License Agreement"
 msgstr "إتفاقية ترخيص المستخدم النهائي"
 
@@ -539,7 +520,7 @@ msgstr "عودة إلى {0}…"
 msgid "Add-ons for {0}"
 msgstr "إضافات {0}"
 
-#: src/olympia/addons/templates/addons/home.html:10 src/olympia/addons/templates/addons/home.html:51 src/olympia/browse/templates/browse/impala/base_listing.html:11
+#: src/olympia/addons/templates/addons/home.html:10 src/olympia/addons/templates/addons/home.html:53 src/olympia/browse/templates/browse/impala/base_listing.html:11
 msgid "Featured Extensions"
 msgstr "امتدادات متميزة"
 
@@ -547,29 +528,29 @@ msgstr "امتدادات متميزة"
 msgid "Popular Extensions"
 msgstr "امتدادات شهيرة"
 
-#: src/olympia/addons/templates/addons/home.html:42 src/olympia/amo/templates/amo/side_nav.html:3 src/olympia/amo/templates/amo/side_nav.html:11 src/olympia/amo/templates/amo/site_nav.html:3
-#: src/olympia/amo/templates/amo/site_nav.html:25 src/olympia/browse/views.py:236 src/olympia/browse/views.py:281 src/olympia/browse/views.py:481
+#: src/olympia/addons/templates/addons/home.html:44 src/olympia/amo/templates/amo/side_nav.html:3 src/olympia/amo/templates/amo/side_nav.html:11 src/olympia/amo/templates/amo/site_nav.html:3
+#: src/olympia/amo/templates/amo/site_nav.html:25 src/olympia/browse/views.py:203 src/olympia/browse/views.py:248 src/olympia/browse/views.py:448
 msgid "Most Popular"
 msgstr "الأكثر شعبية"
 
-#: src/olympia/addons/templates/addons/home.html:43
+#: src/olympia/addons/templates/addons/home.html:45
 msgid "All »"
 msgstr "الكل »"
 
-#: src/olympia/addons/templates/addons/home.html:52 src/olympia/addons/templates/addons/home.html:61 src/olympia/addons/templates/addons/home.html:70 src/olympia/addons/templates/addons/home.html:78
+#: src/olympia/addons/templates/addons/home.html:54 src/olympia/addons/templates/addons/home.html:63 src/olympia/addons/templates/addons/home.html:72 src/olympia/addons/templates/addons/home.html:80
 #: src/olympia/browse/templates/browse/impala/category_landing.html:36
 msgid "See all »"
 msgstr "عرض الكل »"
 
-#: src/olympia/addons/templates/addons/home.html:60
+#: src/olympia/addons/templates/addons/home.html:62
 msgid "Up &amp; Coming Extensions"
 msgstr "امتدادات قادمة"
 
-#: src/olympia/addons/templates/addons/home.html:69 src/olympia/browse/templates/browse/personas/category_landing.html:61 src/olympia/discovery/templates/discovery/pane.html:74
+#: src/olympia/addons/templates/addons/home.html:71 src/olympia/browse/templates/browse/personas/category_landing.html:61 src/olympia/discovery/templates/discovery/pane.html:74
 msgid "Featured Themes"
 msgstr "السِمات المتميزة"
 
-#: src/olympia/addons/templates/addons/home.html:77 src/olympia/bandwagon/templates/bandwagon/impala/collection_listing.html:5
+#: src/olympia/addons/templates/addons/home.html:79 src/olympia/bandwagon/templates/bandwagon/impala/collection_listing.html:5
 msgid "Featured Collections"
 msgstr "مجموعات متميزة"
 
@@ -587,7 +568,7 @@ msgid "Updated {0}"
 msgstr "آخر تحديث في {0}"
 
 #. {0} is a date.
-#: src/olympia/addons/templates/addons/macros.html:10 src/olympia/addons/templates/addons/macros.html:69 src/olympia/addons/templates/addons/persona_preview.html:21
+#: src/olympia/addons/templates/addons/macros.html:10 src/olympia/addons/templates/addons/macros.html:69 src/olympia/addons/templates/addons/persona_preview.html:22
 #: src/olympia/addons/templates/addons/listing/items_mobile.html:44 src/olympia/addons/templates/addons/listing/macros.html:39
 #: src/olympia/bandwagon/templates/bandwagon/collection_listing_items.html:37 src/olympia/bandwagon/templates/bandwagon/impala/collection_listing_items.html:37
 msgid "Added {0}"
@@ -599,10 +580,6 @@ msgid "%(num)s weekly download"
 msgid_plural "%(num)s weekly downloads"
 msgstr[0] "لا تنزيلات خلال أسبوع"
 msgstr[1] "تنزيل واحد في الأسبوع"
-msgstr[2] "تنزيلين أثنين في أسبوع"
-msgstr[3] "%(num)s تنزيلات في أسبوع"
-msgstr[4] "%(num)s تنزيلا في أسبوع"
-msgstr[5] "%(num)s تنزيل في أسبوع"
 
 #: src/olympia/addons/templates/addons/macros.html:28
 #, python-format
@@ -610,33 +587,20 @@ msgid "%(num)s user"
 msgid_plural "%(num)s users"
 msgstr[0] "لا مستخدمين"
 msgstr[1] "مستخدم واحد"
-msgstr[2] "مستخدمين أثنين"
-msgstr[3] "%(num)s مستخدمين"
-msgstr[4] "%(num)s مستخدمًا"
-msgstr[5] "%(num)s مستخدم"
 
 #. {0} is the number of downloads.
-#: src/olympia/addons/templates/addons/macros.html:53 src/olympia/addons/templates/addons/impala/details.html:61
+#: src/olympia/addons/templates/addons/macros.html:53 src/olympia/addons/templates/addons/impala/details.html:59
 msgid "{0} weekly download"
 msgid_plural "{0} weekly downloads"
 msgstr[0] "لا تنزيلات"
 msgstr[1] "تنزيل واحد أسبوعيا"
-msgstr[2] "تنزيلين أثنين أسبوعيا"
-msgstr[3] "{0} تنزيلات أسبوعيا"
-msgstr[4] "{0} تنزيلا أسبوعيا"
-msgstr[5] "{0} تنزيل أسبوعيا"
 
 #. {0} is the number of users.
-#: src/olympia/addons/templates/addons/macros.html:61 src/olympia/addons/templates/addons/impala/details.html:54 src/olympia/compat/templates/compat/index.html:71
-#: src/olympia/zadmin/templates/zadmin/compat.html:67
+#: src/olympia/addons/templates/addons/macros.html:61 src/olympia/addons/templates/addons/impala/details.html:52 src/olympia/zadmin/templates/zadmin/compat.html:67
 msgid "{0} user"
 msgid_plural "{0} users"
 msgstr[0] "لا مستخدمين"
 msgstr[1] "مستخدم واحد"
-msgstr[2] "مستخدمين أثنين"
-msgstr[3] "{0} مستخدمين"
-msgstr[4] "{0} مستخدما"
-msgstr[5] "{0} مستخدم"
 
 #: src/olympia/addons/templates/addons/paypal_result.html:12
 msgid "Payment cancelled"
@@ -650,7 +614,7 @@ msgstr ""
 msgid "Return to the addon."
 msgstr "عودة إلى الإضافة."
 
-#: src/olympia/addons/templates/addons/persona_detail.html:17 src/olympia/addons/templates/addons/impala/details.html:106 src/olympia/addons/templates/addons/mobile/details.html:23
+#: src/olympia/addons/templates/addons/persona_detail.html:17 src/olympia/addons/templates/addons/impala/details.html:103 src/olympia/addons/templates/addons/mobile/details.html:23
 #: src/olympia/addons/templates/addons/mobile/persona_detail.html:21 src/olympia/discovery/templates/discovery/addons/base.html:27 src/olympia/editors/templates/editors/review.html:31
 msgid "by"
 msgstr "من"
@@ -694,38 +658,35 @@ msgstr "المستخدمين اليوميين"
 msgid "License"
 msgstr "الرخصة"
 
-#: src/olympia/addons/templates/addons/persona_preview.html:12 src/olympia/constants/base.py:48
+#: src/olympia/addons/templates/addons/persona_preview.html:13 src/olympia/constants/base.py:48
 msgid "Awaiting Review"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/persona_preview.html:14 src/olympia/amo/log.py:180 src/olympia/constants/base.py:42 src/olympia/editors/helpers.py:62
+#: src/olympia/addons/templates/addons/persona_preview.html:15 src/olympia/amo/log.py:180 src/olympia/constants/base.py:42 src/olympia/editors/helpers.py:62
 msgid "Rejected"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/persona_preview.html:16 src/olympia/amo/log.py:159
+#: src/olympia/addons/templates/addons/persona_preview.html:17 src/olympia/amo/log.py:159
 msgid "Approved"
 msgstr ""
 
 #. {0} is the number of users.
-#: src/olympia/addons/templates/addons/persona_preview.html:26 src/olympia/addons/templates/addons/listing/items_mobile.html:36 src/olympia/addons/templates/addons/listing/macros.html:31
+#: src/olympia/addons/templates/addons/persona_preview.html:27 src/olympia/addons/templates/addons/listing/items_mobile.html:36 src/olympia/addons/templates/addons/listing/macros.html:31
 msgid "<strong>{0}</strong> user"
 msgid_plural "<strong>{0}</strong> users"
 msgstr[0] "لا مستخدمين"
 msgstr[1] "مستخدم واحد"
-msgstr[2] "مستخدمين إثنين"
-msgstr[3] "<strong>{0}</strong> مستخدمين"
-msgstr[4] "<strong>{0}</strong> مستخدما"
-msgstr[5] "<strong>{0}</strong> مستخدم"
 
-#: src/olympia/addons/templates/addons/persona_preview.html:40
+#: src/olympia/addons/templates/addons/persona_preview.html:41
 msgid "Hover to Preview"
 msgstr "قم بالحومان بالمؤشر للمعاينة"
 
-#: src/olympia/addons/templates/addons/persona_preview.html:46 src/olympia/addons/templates/addons/persona_preview.html:48 src/olympia/reviews/templates/reviews/add.html:15
+#: src/olympia/addons/templates/addons/persona_preview.html:47 src/olympia/addons/templates/addons/persona_preview.html:49 src/olympia/addons/templates/addons/persona_preview.html:97
+#: src/olympia/reviews/templates/reviews/add.html:15
 msgid "Add"
 msgstr "أضِف"
 
-#: src/olympia/addons/templates/addons/persona_preview.html:57 src/olympia/bandwagon/templates/bandwagon/ajax_new.html:16 src/olympia/bandwagon/templates/bandwagon/edit.html:19
+#: src/olympia/addons/templates/addons/persona_preview.html:58 src/olympia/bandwagon/templates/bandwagon/ajax_new.html:16 src/olympia/bandwagon/templates/bandwagon/edit.html:19
 #: src/olympia/bandwagon/templates/bandwagon/includes/addedit.html:19 src/olympia/devhub/templates/devhub/addons/edit/admin.html:13 src/olympia/devhub/templates/devhub/addons/edit/basic.html:10
 #: src/olympia/devhub/templates/devhub/addons/edit/details.html:8 src/olympia/devhub/templates/devhub/addons/edit/media.html:6 src/olympia/devhub/templates/devhub/addons/edit/support.html:8
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:9 src/olympia/devhub/templates/devhub/addons/submit/describe.html:29 src/olympia/editors/templates/editors/review.html:257
@@ -734,21 +695,21 @@ msgstr "تعديل"
 
 #. For datetime formatting, see the table on
 #. http://docs.python.org/library/datetime.html#strftime-and-strptime-behavior
-#: src/olympia/addons/templates/addons/persona_preview.html:66
+#: src/olympia/addons/templates/addons/persona_preview.html:67
 #, python-format
 msgid "%%Y-%%m-%%d"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/persona_preview.html:67
+#: src/olympia/addons/templates/addons/persona_preview.html:68
 msgid "by {0} on {1}"
 msgstr "من {0} في {1}"
 
-#: src/olympia/addons/templates/addons/persona_preview.html:75 src/olympia/reviews/helpers.py:17 src/olympia/reviews/templates/reviews/review_list.html:63
+#: src/olympia/addons/templates/addons/persona_preview.html:76 src/olympia/reviews/helpers.py:17 src/olympia/reviews/templates/reviews/review_list.html:63
 #: src/olympia/reviews/templates/reviews/reviews_link.html:21 src/olympia/reviews/templates/reviews/impala/reviews_link.html:16
 msgid "Not yet rated"
 msgstr "بلا تقييم حتى الآن"
 
-#: src/olympia/addons/templates/addons/persona_preview.html:78
+#: src/olympia/addons/templates/addons/persona_preview.html:79
 msgid "<b>{0}</b> users"
 msgstr "<b>{0}</b> مستخدمين"
 
@@ -761,8 +722,8 @@ msgid "Learn more about Firefox"
 msgstr "اعرف المزيد عن فيرفُكس"
 
 #: src/olympia/addons/templates/addons/popups.html:22
-msgid "or <b><a class=\"installer\" href=\"{url}\">download anyway</a></b>"
-msgstr "أو <b><a class=\"installer\" href=\"{url}\">نزّل الإضافة</a></b> على أي حال"
+msgid "or <b><a class=\"button installer\" href=\"{url}\">download anyway</a></b>"
+msgstr ""
 
 #: src/olympia/addons/templates/addons/popups.html:26
 msgid ""
@@ -853,11 +814,14 @@ msgid "QR code for add-on"
 msgstr "رمز QR للإضافة"
 
 #: src/olympia/addons/templates/addons/qr_code.html:6
-msgid "Want {0} on your mobile Firefox? Scan this QR code to install directly to your phone. (You'll need a QR reader. Search your phone's marketplace if don't have one.)"
-msgstr "ترغب بـ {0} على جهازك المحمول فيرفُكس؟ امسح كود QR هذا لتثبيته مباشرة إلى هاتفك. (ستحتاج لقارئ رموز QR. إن لم يكن لديك واحد مُثبّت، فابحث في المتجر وثبته)"
+msgid ""
+"Want {0} on your mobile Firefox?  Scan this QR code to install directly\n"
+"  to your phone.  (You'll need a QR reader.  Search your phone's marketplace if\n"
+"  don't have one.)"
+msgstr ""
 
 #: src/olympia/addons/templates/addons/report_abuse.html:6 src/olympia/addons/templates/addons/report_abuse_full.html:10 src/olympia/addons/templates/addons/impala/details-more.html:23
-#: src/olympia/addons/templates/addons/impala/details.html:328
+#: src/olympia/addons/templates/addons/impala/details.html:333
 msgid "Report Abuse"
 msgstr "إبلاغ عن إساءة استخدام"
 
@@ -878,9 +842,9 @@ msgstr "أرسِل البلاغ"
 #: src/olympia/devhub/templates/devhub/addons/ajax_compat_update.html:36 src/olympia/devhub/templates/devhub/addons/profile.html:44 src/olympia/devhub/templates/devhub/addons/edit/admin.html:104
 #: src/olympia/devhub/templates/devhub/addons/edit/basic.html:155 src/olympia/devhub/templates/devhub/addons/edit/details.html:88 src/olympia/devhub/templates/devhub/addons/edit/support.html:70
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:169 src/olympia/devhub/templates/devhub/addons/forms_shared/media.html:152
-#: src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:44 src/olympia/devhub/templates/devhub/personas/edit.html:222 src/olympia/devhub/templates/devhub/versions/add_file_modal.html:79
-#: src/olympia/devhub/templates/devhub/versions/edit.html:140 src/olympia/devhub/templates/devhub/versions/list.html:208 src/olympia/devhub/templates/devhub/versions/list.html:242
-#: src/olympia/devhub/templates/devhub/versions/list.html:276 src/olympia/devhub/templates/devhub/versions/list.html:317 src/olympia/reviews/templates/reviews/edit_review.html:16
+#: src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:43 src/olympia/devhub/templates/devhub/personas/edit.html:222 src/olympia/devhub/templates/devhub/versions/add_file_modal.html:59
+#: src/olympia/devhub/templates/devhub/versions/edit.html:140 src/olympia/devhub/templates/devhub/versions/list.html:208 src/olympia/devhub/templates/devhub/versions/list.html:239
+#: src/olympia/devhub/templates/devhub/versions/list.html:281 src/olympia/devhub/templates/devhub/versions/list.html:315 src/olympia/reviews/templates/reviews/edit_review.html:16
 #: src/olympia/translations/templates/translations/trans-menu.html:50 src/olympia/translations/templates/translations/trans-menu.html:62 src/olympia/zadmin/templates/zadmin/validation.html:105
 msgid "Cancel"
 msgstr "ألغِ"
@@ -925,7 +889,7 @@ msgstr "انظر <a href=\"%(support)s\">قسم الدعم</a> لمعرفة أي
 msgid "Review Guidelines"
 msgstr "إرشادات التعليقات"
 
-#: src/olympia/addons/templates/addons/review_list_box.html:5 src/olympia/addons/templates/addons/impala/details-more.html:27 src/olympia/editors/helpers.py:921
+#: src/olympia/addons/templates/addons/review_list_box.html:5 src/olympia/addons/templates/addons/impala/details-more.html:27 src/olympia/editors/helpers.py:1001
 #: src/olympia/reviews/templates/reviews/add.html:14 src/olympia/reviews/templates/reviews/reply.html:14 src/olympia/reviews/templates/reviews/review_list.html:19
 #: src/olympia/reviews/templates/reviews/mobile/review_list.html:26
 msgid "Reviews"
@@ -946,10 +910,6 @@ msgid "See all reviews of this add-on"
 msgid_plural "See all %(cnt)s reviews of this add-on"
 msgstr[0] "عرض جميع التعليقات لهذه الإضافة"
 msgstr[1] "عرض جميع التعليقات لهذه الإضافة"
-msgstr[2] "عرض جميع التعليقات لهذه الإضافة"
-msgstr[3] "عرض جميع التعليقات لهذه الإضافة"
-msgstr[4] "عرض جميع التعليقات لهذه الإضافة"
-msgstr[5] "عرض جميع التعليقات لهذه الإضافة"
 
 #: src/olympia/addons/templates/addons/tags_box.html:3 src/olympia/devhub/templates/devhub/addons/edit/basic.html:118
 msgid "Tags"
@@ -1019,117 +979,105 @@ msgid "Other add-ons by %(author)s"
 msgid_plural "Other add-ons by these authors"
 msgstr[0] "إضافات أخرى من %(author)s"
 msgstr[1] "إضافات أخرى من هؤلاء المطورين"
-msgstr[2] "إضافات أخرى من هؤلاء المطورين"
-msgstr[3] "إضافات أخرى من هؤلاء المطورين"
-msgstr[4] "إضافات أخرى من هؤلاء المطورين"
-msgstr[5] "إضافات أخرى من هؤلاء المطورين"
 
-#: src/olympia/addons/templates/addons/impala/details.html:41
+#: src/olympia/addons/templates/addons/impala/details.html:39
 #, python-format
 msgid "<span itemprop=\"ratingCount\">%(num)s</span> user review"
 msgid_plural "<span itemprop=\"ratingCount\">%(num)s</span> user reviews"
 msgstr[0] "لا تعليقات"
 msgstr[1] "تعليق واحد"
-msgstr[2] "تعليقين اثنين"
-msgstr[3] "<span itemprop=\"ratingCount\">%(num)s</span> تعليقات"
-msgstr[4] "<span itemprop=\"ratingCount\">%(num)s</span> تعليقا"
-msgstr[5] "<span itemprop=\"ratingCount\">%(num)s</span> تعليق"
 
-#: src/olympia/addons/templates/addons/impala/details.html:69
+#: src/olympia/addons/templates/addons/impala/details.html:66
 msgid "View statistics"
 msgstr "عرض الإحصائيات"
 
-#: src/olympia/addons/templates/addons/impala/details.html:84
+#: src/olympia/addons/templates/addons/impala/details.html:81
 msgid "Manage"
 msgstr ""
 
 #. {0} is an add-on name.
-#: src/olympia/addons/templates/addons/impala/details.html:96
+#: src/olympia/addons/templates/addons/impala/details.html:93
 msgid "Icon of {0}"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/impala/details.html:103 src/olympia/addons/templates/addons/impala/listing/items.html:14
+#: src/olympia/addons/templates/addons/impala/details.html:100 src/olympia/addons/templates/addons/impala/listing/items.html:14
 msgid "No Restart"
 msgstr "دون إعادة تشغيل"
 
-#: src/olympia/addons/templates/addons/impala/details.html:127
+#: src/olympia/addons/templates/addons/impala/details.html:124
 #, fuzzy, python-format
 msgid "Meet the Developer: <a href=\"%(url)s\">%(name)s</a>"
 msgid_plural "<a href=\"%(url)s\">Meet the Developers</a>"
 msgstr[0] "تعرّف على المطوّر: <a href=\"%(url)s\">%(name)s</a>"
 msgstr[1] "<a href=\"%(url)s\">تعرّف على المطورين</a>"
-msgstr[2] "<a href=\"%(url)s\">تعرّف على المطورين</a>"
-msgstr[3] "<a href=\"%(url)s\">تعرّف على المطورين</a>"
-msgstr[4] "<a href=\"%(url)s\">تعرّف على المطورين</a>"
-msgstr[5] "<a href=\"%(url)s\">تعرّف على المطورين</a>"
 
 # {0} is an add-on name.
-#: src/olympia/addons/templates/addons/impala/details.html:137
+#: src/olympia/addons/templates/addons/impala/details.html:134
 msgid "Learn why {0} was created and find out what's next for this add-on."
 msgstr "اعرف لماذا أنشأنا {0} واكتشف القادم لهذه الإضافة."
 
 #. {0} is an index.
-#: src/olympia/addons/templates/addons/impala/details.html:156
+#: src/olympia/addons/templates/addons/impala/details.html:161
 msgid "Add-on screenshot #{0}"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/impala/details.html:182
+#: src/olympia/addons/templates/addons/impala/details.html:187
 msgid "Add-on home page"
 msgstr "الصفحة الرئيسية للإضافة"
 
-#: src/olympia/addons/templates/addons/impala/details.html:185
+#: src/olympia/addons/templates/addons/impala/details.html:190
 msgid "Support site"
 msgstr "موقع الدعم"
 
-#: src/olympia/addons/templates/addons/impala/details.html:189
+#: src/olympia/addons/templates/addons/impala/details.html:194
 msgid "Support E-mail"
 msgstr "بريد الدعم"
 
-#: src/olympia/addons/templates/addons/impala/details.html:194 src/olympia/devhub/models.py:378 src/olympia/devhub/templates/devhub/versions/list.html:12
+#: src/olympia/addons/templates/addons/impala/details.html:199 src/olympia/devhub/models.py:378 src/olympia/devhub/templates/devhub/versions/list.html:12
 #: src/olympia/versions/templates/versions/version.html:6 src/olympia/versions/templates/versions/mobile/version.html:6
 msgid "Version {0}"
 msgstr "الإصدارة {0}"
 
-#: src/olympia/addons/templates/addons/impala/details.html:194
+#: src/olympia/addons/templates/addons/impala/details.html:199
 msgid "Info"
 msgstr "معلومات"
 
-#: src/olympia/addons/templates/addons/impala/details.html:195 src/olympia/devhub/templates/devhub/includes/addon_details.html:129
+#: src/olympia/addons/templates/addons/impala/details.html:200 src/olympia/devhub/templates/devhub/includes/addon_details.html:116
 msgid "Last Updated:"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/impala/details.html:200
+#: src/olympia/addons/templates/addons/impala/details.html:205
 #, python-format
 msgid "Released under <a target=\"_blank\" href=\"%(url)s\">%(name)s</a>"
 msgstr "صدرت تحت <a target=\"_blank\" href=\"%(url)s\">%(name)s</a>"
 
-#: src/olympia/addons/templates/addons/impala/details.html:201 src/olympia/addons/templates/addons/impala/details.html:206 src/olympia/amo/helpers.py:398 src/olympia/devhub/forms.py:142
+#: src/olympia/addons/templates/addons/impala/details.html:206 src/olympia/addons/templates/addons/impala/details.html:211 src/olympia/amo/helpers.py:398 src/olympia/devhub/forms.py:142
 #: src/olympia/devhub/forms.py:173 src/olympia/versions/templates/versions/version.html:40 src/olympia/versions/templates/versions/version.html:45
 msgid "Custom License"
 msgstr "رخصة مخصصة"
 
-#: src/olympia/addons/templates/addons/impala/details.html:205
+#: src/olympia/addons/templates/addons/impala/details.html:210
 #, python-format
 msgid "Released under <a href=\"%(url)s\">%(name)s</a>"
 msgstr "صدرت تحت <a href=\"%(url)s\">%(name)s</a>"
 
-#: src/olympia/addons/templates/addons/impala/details.html:217
+#: src/olympia/addons/templates/addons/impala/details.html:222
 msgid "About this Add-on"
 msgstr "عن هذه الإضافة"
 
-#: src/olympia/addons/templates/addons/impala/details.html:233
+#: src/olympia/addons/templates/addons/impala/details.html:238
 msgid "Developer’s Comments"
 msgstr "تعليقات المطورين"
 
-#: src/olympia/addons/templates/addons/impala/details.html:243
+#: src/olympia/addons/templates/addons/impala/details.html:248
 msgid "Version Information"
 msgstr "معلومات الإصدارة"
 
-#: src/olympia/addons/templates/addons/impala/details.html:250
+#: src/olympia/addons/templates/addons/impala/details.html:255
 msgid "See complete version history"
 msgstr "اعرض تاريخ الإصدارات الكامل"
 
-#: src/olympia/addons/templates/addons/impala/details.html:262
+#: src/olympia/addons/templates/addons/impala/details.html:267
 msgid ""
 "The Development Channel lets you test an experimental new version of this add-on before it's released to the general public. Once you install the development version, you will continue to get "
 "updates from this channel. To stop receiving development updates, reinstall the default version from the link above."
@@ -1137,17 +1085,17 @@ msgstr ""
 "تتيح لك قناة التطوير اختبار الإصدارات الجديدة التجريبية من هذه الإضافة قبل صدورها إلى العامة. بمجرد تثبيتك للإصدارة التطويرية، ستستمر باستقبال التحديثات من هذه القناة. لإيقاف استقبال التحديثات "
 "التطويرية، أعِد تثبيت الإصدارة الافتراضية من الرابط العلوي الأساسي."
 
-#: src/olympia/addons/templates/addons/impala/details.html:272
+#: src/olympia/addons/templates/addons/impala/details.html:277
 msgid "<strong>Caution:</strong> Development versions of this add-on have not been reviewed by Mozilla."
 msgstr ""
 
-#: src/olympia/addons/templates/addons/impala/details.html:287
+#: src/olympia/addons/templates/addons/impala/details.html:292
 msgid "See complete development channel history"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/impala/details.html:306 src/olympia/addons/templates/addons/impala/details.html:315 src/olympia/addons/templates/addons/impala/details.html:327
+#: src/olympia/addons/templates/addons/impala/details.html:311 src/olympia/addons/templates/addons/impala/details.html:320 src/olympia/addons/templates/addons/impala/details.html:332
 #: src/olympia/addons/templates/addons/impala/review_add_box.html:4 src/olympia/stats/templates/stats/popup.html:2 src/olympia/stats/templates/stats/popup.html:8
-#: src/olympia/stats/templates/stats/stats.html:202 src/olympia/users/templates/users/profile.html:119
+#: src/olympia/stats/templates/stats/stats.html:204 src/olympia/users/templates/users/profile.html:119
 msgid "close"
 msgstr "أغلق"
 
@@ -1181,10 +1129,6 @@ msgid "About the Developer"
 msgid_plural "About the Developers"
 msgstr[0] "عن المطورين"
 msgstr[1] "عن المطور"
-msgstr[2] "عن المطورين"
-msgstr[3] "عن المطورين"
-msgstr[4] "عن المطورين"
-msgstr[5] "عن المطورين"
 
 #: src/olympia/addons/templates/addons/impala/developers.html:96 src/olympia/users/templates/users/edit.html:130 src/olympia/users/templates/users/profile.html:26
 msgid "No Photo"
@@ -1210,15 +1154,11 @@ msgstr "رخصة الكود المصدري لـ {addon}"
 msgid "Source Code License"
 msgstr "رخصة الكود المصدري"
 
-#: src/olympia/addons/templates/addons/impala/persona_grid.html:16 src/olympia/addons/templates/addons/impala/toplist.html:6
-msgid "{0} users"
-msgstr "{0} مستخدم/مستخدمين"
-
 #: src/olympia/addons/templates/addons/impala/review_list_box.html:19 src/olympia/reviews/templates/reviews/review.html:40
 msgid "permalink"
 msgstr "رابط دائم"
 
-#: src/olympia/addons/templates/addons/impala/review_list_box.html:23 src/olympia/editors/templates/editors/queue.html:98 src/olympia/reviews/templates/reviews/review.html:44
+#: src/olympia/addons/templates/addons/impala/review_list_box.html:23 src/olympia/editors/templates/editors/queue.html:104 src/olympia/reviews/templates/reviews/review.html:44
 msgid "translate"
 msgstr ""
 
@@ -1228,10 +1168,6 @@ msgid "See all user reviews"
 msgid_plural "See all %(cnt)s user reviews"
 msgstr[0] "لا تقييمات"
 msgstr[1] "شاهد جميع تعليقات المستخدمين"
-msgstr[2] "شاهد جميع تعليقات المستخدمين"
-msgstr[3] "شاهد جميع تعليقات المستخدمين"
-msgstr[4] "شاهد جميع تعليقات المستخدمين"
-msgstr[5] "شاهد جميع تعليقات المستخدمين"
 
 #: src/olympia/addons/templates/addons/impala/review_list_box.html:47 src/olympia/reviews/templates/reviews/review_list.html:84
 msgid "This add-on has not yet been reviewed."
@@ -1240,6 +1176,10 @@ msgstr "هذه الإضافة لم يُعلّق عليها بعد."
 #: src/olympia/addons/templates/addons/impala/review_list_box.html:50
 msgid "Be the first!"
 msgstr "كُن الأول!"
+
+#: src/olympia/addons/templates/addons/impala/toplist.html:6
+msgid "{0} users"
+msgstr "{0} مستخدم/مستخدمين"
 
 #: src/olympia/addons/templates/addons/impala/listing/sorter.html:14 src/olympia/devhub/templates/devhub/addons/listing/item_actions.html:49
 msgid "More"
@@ -1253,7 +1193,7 @@ msgstr "أضِف إلى مجموعة"
 msgid "My Add-ons"
 msgstr "إضافاتي"
 
-#: src/olympia/addons/templates/addons/includes/dashboard_tabs.html:6 src/olympia/amo/context_processors.py:51
+#: src/olympia/addons/templates/addons/includes/dashboard_tabs.html:6 src/olympia/amo/context_processors.py:50
 msgid "My Themes"
 msgstr ""
 
@@ -1295,10 +1235,6 @@ msgid "<strong>{0}</strong> weekly download"
 msgid_plural "<strong>{0}</strong> weekly downloads"
 msgstr[0] "لا تنزيلات"
 msgstr[1] "تنزيل واحد أسبوعيا"
-msgstr[2] "تنزيلين أثنين في الأسبوع"
-msgstr[3] "<strong>{0}</strong> تنزيلات أسبوعيا"
-msgstr[4] "<strong>{0}</strong> تنزيلا أسبوعيا"
-msgstr[5] "<strong>{0}</strong> تنزيل أسبوعيا"
 
 #: src/olympia/addons/templates/addons/mobile/details.html:32
 msgid "Read More"
@@ -1312,7 +1248,7 @@ msgstr "المستخدمين"
 msgid "Weekly Downloads"
 msgstr "التنزيلات الأسبوعية"
 
-#: src/olympia/addons/templates/addons/mobile/details.html:99 src/olympia/compat/templates/compat/reporter_detail.html:46 src/olympia/devhub/forms.py:787
+#: src/olympia/addons/templates/addons/mobile/details.html:99 src/olympia/compat/templates/compat/reporter_detail.html:46 src/olympia/devhub/forms.py:788
 #: src/olympia/devhub/templates/devhub/versions/list.html:163
 msgid "Version"
 msgstr "الإصدارة"
@@ -1397,7 +1333,7 @@ msgstr "الإضافات هي عبارة عن تطبيقات إضافية تتي
 #: src/olympia/browse/templates/browse/personas/category_landing.html:21 src/olympia/browse/templates/browse/personas/category_landing.html:23
 #: src/olympia/browse/templates/browse/personas/category_landing.html:38 src/olympia/browse/templates/browse/personas/grid.html:7 src/olympia/browse/templates/browse/personas/grid.html:11
 #: src/olympia/browse/templates/browse/personas/mobile/base.html:7 src/olympia/browse/templates/browse/personas/mobile/category_landing.html:19 src/olympia/constants/base.py:180
-#: src/olympia/devhub/templates/devhub/personas/submit.html:13 src/olympia/editors/helpers.py:105 src/olympia/editors/templates/editors/base.html:26
+#: src/olympia/devhub/templates/devhub/personas/submit.html:13 src/olympia/editors/helpers.py:107 src/olympia/editors/templates/editors/base.html:26
 #: src/olympia/editors/templates/editors/performance.html:73 src/olympia/search/templates/search/personas.html:39 src/olympia/templates/menu_links.html:9
 msgid "Themes"
 msgstr "السِمات"
@@ -1418,7 +1354,7 @@ msgstr "مزيد من الإضافات"
 msgid "Highest Rated"
 msgstr "الأعلى تقييما"
 
-#: src/olympia/addons/templates/addons/mobile/home.html:74 src/olympia/amo/templates/amo/side_nav.html:5 src/olympia/amo/templates/amo/site_nav.html:27 src/olympia/amo/templates/amo/site_nav.html:57
+#: src/olympia/addons/templates/addons/mobile/home.html:74 src/olympia/amo/templates/amo/side_nav.html:5 src/olympia/amo/templates/amo/site_nav.html:27 src/olympia/amo/templates/amo/site_nav.html:55
 #: src/olympia/bandwagon/views.py:97 src/olympia/browse/views.py:57 src/olympia/browse/views.py:67 src/olympia/browse/templates/browse/personas/mobile/category_landing.html:65
 #: src/olympia/search/forms.py:15 src/olympia/search/forms.py:87
 msgid "Newest"
@@ -1432,90 +1368,90 @@ msgstr ""
 msgid "Theme Info &raquo;"
 msgstr "معلومات السِمة &raquo;"
 
-#: src/olympia/amo/context_processors.py:39 src/olympia/devhub/templates/devhub/nav.html:43
+#: src/olympia/amo/context_processors.py:37 src/olympia/devhub/templates/devhub/nav.html:43
 msgid "Tools"
 msgstr "أدوات"
 
-#: src/olympia/amo/context_processors.py:48 src/olympia/discovery/templates/discovery/pane_account.html:8 src/olympia/users/templates/users/includes/navigation.html:2
+#: src/olympia/amo/context_processors.py:47 src/olympia/discovery/templates/discovery/pane_account.html:8 src/olympia/users/templates/users/includes/navigation.html:2
 msgid "My Profile"
 msgstr "ملفي الشخصي"
 
-#: src/olympia/amo/context_processors.py:54 src/olympia/users/templates/users/edit.html:5 src/olympia/users/templates/users/includes/navigation.html:3
+#: src/olympia/amo/context_processors.py:53 src/olympia/users/templates/users/edit.html:5 src/olympia/users/templates/users/includes/navigation.html:3
 msgid "Account Settings"
 msgstr "إعدادات الحساب"
 
-#: src/olympia/amo/context_processors.py:57 src/olympia/discovery/templates/discovery/pane_account.html:11 src/olympia/users/templates/users/profile.html:83
+#: src/olympia/amo/context_processors.py:56 src/olympia/discovery/templates/discovery/pane_account.html:11 src/olympia/users/templates/users/profile.html:83
 #: src/olympia/users/templates/users/includes/navigation.html:4
 msgid "My Collections"
 msgstr "مجموعاتي"
 
-#: src/olympia/amo/context_processors.py:62 src/olympia/discovery/templates/discovery/pane_account.html:10 src/olympia/users/templates/users/includes/navigation.html:7
+#: src/olympia/amo/context_processors.py:61 src/olympia/discovery/templates/discovery/pane_account.html:10 src/olympia/users/templates/users/includes/navigation.html:7
 msgid "My Favorites"
 msgstr "مفضلاتي"
 
-#: src/olympia/amo/context_processors.py:67 src/olympia/discovery/templates/discovery/pane_account.html:13 src/olympia/templates/impala/user_login.html:14
+#: src/olympia/amo/context_processors.py:66 src/olympia/discovery/templates/discovery/pane_account.html:13 src/olympia/templates/impala/user_login.html:14
 #: src/olympia/templates/mobile/header_auth.html:5
 msgid "Log out"
 msgstr "خروج"
 
-#: src/olympia/amo/context_processors.py:72 src/olympia/devhub/templates/devhub/addons/dashboard.html:4
+#: src/olympia/amo/context_processors.py:71 src/olympia/devhub/templates/devhub/addons/dashboard.html:4
 msgid "Manage My Submissions"
 msgstr ""
 
-#: src/olympia/amo/context_processors.py:75 src/olympia/devhub/templates/devhub/nav.html:27 src/olympia/devhub/templates/devhub/addons/dashboard.html:25
+#: src/olympia/amo/context_processors.py:74 src/olympia/devhub/templates/devhub/nav.html:27 src/olympia/devhub/templates/devhub/addons/dashboard.html:25
 #: src/olympia/devhub/templates/devhub/addons/submit/base.html:4
 msgid "Submit a New Add-on"
 msgstr "تقديم إضافة جديدة"
 
-#: src/olympia/amo/context_processors.py:77 src/olympia/browse/templates/browse/personas/base.html:50 src/olympia/devhub/templates/devhub/index.html:24
+#: src/olympia/amo/context_processors.py:76 src/olympia/browse/templates/browse/personas/base.html:50 src/olympia/devhub/templates/devhub/index.html:24
 #: src/olympia/devhub/templates/devhub/addons/dashboard.html:29
 msgid "Submit a New Theme"
 msgstr ""
 
-#: src/olympia/amo/context_processors.py:79 src/olympia/amo/templates/amo/site_nav.html:87 src/olympia/devhub/helpers.py:36 src/olympia/devhub/helpers.py:68 src/olympia/devhub/helpers.py:102
+#: src/olympia/amo/context_processors.py:78 src/olympia/amo/templates/amo/site_nav.html:85 src/olympia/devhub/helpers.py:36 src/olympia/devhub/helpers.py:68 src/olympia/devhub/helpers.py:102
 #: src/olympia/templates/footer.html:6 src/olympia/templates/menu_links.html:14
 msgid "Developer Hub"
 msgstr "مركز المطورين"
 
-#: src/olympia/amo/context_processors.py:83 src/olympia/devhub/views.py:1792
+#: src/olympia/amo/context_processors.py:81 src/olympia/devhub/views.py:1796
 msgid "Manage API Keys"
 msgstr ""
 
-#: src/olympia/amo/context_processors.py:88 src/olympia/editors/helpers.py:82 src/olympia/editors/helpers.py:102 src/olympia/editors/templates/editors/base.html:10
+#: src/olympia/amo/context_processors.py:86 src/olympia/editors/helpers.py:84 src/olympia/editors/helpers.py:104 src/olympia/editors/templates/editors/base.html:10
 msgid "Editor Tools"
 msgstr "أدوات المحررين"
 
-#: src/olympia/amo/context_processors.py:92
+#: src/olympia/amo/context_processors.py:90
 msgid "Admin Tools"
 msgstr ""
 
-#: src/olympia/amo/fields.py:15
+#: src/olympia/amo/fields.py:20
 msgid "Incorrect, please try again."
 msgstr ""
 
-#: src/olympia/amo/fields.py:16
+#: src/olympia/amo/fields.py:21
 msgid "Error verifying input, please try again."
 msgstr ""
 
-#: src/olympia/amo/fields.py:32
+#: src/olympia/amo/fields.py:37
 msgid "This must be a valid hex color code, such as #000000."
 msgstr ""
 
-#: src/olympia/amo/fields.py:58
+#: src/olympia/amo/fields.py:63
 msgid "Enter at least one value."
 msgstr ""
 
-#: src/olympia/amo/helpers.py:162 src/olympia/amo/templates/amo/site_nav.html:61 src/olympia/bandwagon/templates/bandwagon/add.html:9
+#: src/olympia/amo/helpers.py:162 src/olympia/amo/templates/amo/site_nav.html:59 src/olympia/bandwagon/templates/bandwagon/add.html:9
 #: src/olympia/bandwagon/templates/bandwagon/collection_detail.html:15 src/olympia/bandwagon/templates/bandwagon/delete.html:9 src/olympia/bandwagon/templates/bandwagon/edit.html:15
 #: src/olympia/bandwagon/templates/bandwagon/user_listing.html:18 src/olympia/bandwagon/templates/bandwagon/user_listing.html:21
 #: src/olympia/bandwagon/templates/bandwagon/impala/collection_listing.html:12 src/olympia/bandwagon/templates/bandwagon/impala/collection_listing.html:20
 #: src/olympia/bandwagon/templates/bandwagon/impala/collection_listing.html:24 src/olympia/bandwagon/templates/bandwagon/impala/collection_sidebar.html:3
 #: src/olympia/bandwagon/templates/bandwagon/includes/collection_sidebar.html:2 src/olympia/bandwagon/templates/bandwagon/mobile/collection_listing.html:3
-#: src/olympia/stats/templates/stats/stats.html:77 src/olympia/templates/menu_links.html:12
+#: src/olympia/stats/templates/stats/stats.html:33 src/olympia/templates/menu_links.html:12
 msgid "Collections"
 msgstr "المجموعات"
 
-#: src/olympia/amo/helpers.py:171 src/olympia/amo/templates/amo/site_nav.html:85 src/olympia/browse/templates/browse/language_tools.html:3
+#: src/olympia/amo/helpers.py:171 src/olympia/amo/templates/amo/site_nav.html:83 src/olympia/browse/templates/browse/language_tools.html:3
 msgid "Dictionaries & Language Packs"
 msgstr "القواميس وحزم اللغات"
 
@@ -1667,8 +1603,8 @@ msgstr ""
 msgid "Comment on {addon} {version}."
 msgstr ""
 
-#: src/olympia/amo/log.py:236 src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:19 src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:47
-#: src/olympia/editors/helpers.py:511 src/olympia/editors/templates/editors/themes/history_table.html:11
+#: src/olympia/amo/log.py:236 src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:17 src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:45
+#: src/olympia/editors/helpers.py:584 src/olympia/editors/templates/editors/themes/history_table.html:11
 msgid "Comment"
 msgstr "التعليق"
 
@@ -1968,8 +1904,8 @@ msgstr "عفوًا"
 
 #: src/olympia/amo/templates/amo/500.html:6
 #, python-format
-msgid "<h1>Oops! We had an error.</h1> <p>We'll get to fixing that soon.</p> <p> You can try refreshing the page, or head back to the <a href=\"%(home)s\">Add-ons homepage</a>. </p>"
-msgstr "<h1>عفوًا! لدينا خطأ ما.</h1> <p>سوف نصلح ذلك في أقرب وقت ممكن.</p> <p> يمكنك محاولة إعادة تحميل الصفحة أو العودة إلى  <a href=\"%(home)s\">الصفحة الرئيسية للإضافات</a>. </p>"
+msgid "<h1>Oops!  We had an error.</h1> <p>We'll get to fixing that soon.</p> <p> You can try refreshing the page, or head back to the <a href=\"%(home)s\">Add-ons homepage</a>. </p>"
+msgstr ""
 
 #: src/olympia/amo/templates/amo/license_link.html:10
 msgid "Some rights reserved"
@@ -1991,7 +1927,7 @@ msgstr "السابق"
 #: src/olympia/amo/templates/amo/mobile/paginator.html:14 src/olympia/amo/templates/amo/mobile/paginator.html:16 src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:51
 #: src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:65 src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:78
 #: src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:91 src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:104
-#: src/olympia/discovery/templates/discovery/pane.html:45 src/olympia/discovery/templates/discovery/addons/detail.html:39 src/olympia/stats/templates/stats/stats.html:167
+#: src/olympia/discovery/templates/discovery/pane.html:45 src/olympia/discovery/templates/discovery/addons/detail.html:39 src/olympia/stats/templates/stats/stats.html:169
 msgid "Next"
 msgstr "التالي"
 
@@ -2023,7 +1959,7 @@ msgid ""
 msgstr ""
 
 #: src/olympia/amo/templates/amo/side_nav.html:4 src/olympia/amo/templates/amo/side_nav.html:12 src/olympia/amo/templates/amo/site_nav.html:4 src/olympia/amo/templates/amo/site_nav.html:26
-#: src/olympia/browse/views.py:56 src/olympia/browse/views.py:66 src/olympia/browse/views.py:237 src/olympia/browse/views.py:282 src/olympia/search/forms.py:86
+#: src/olympia/browse/views.py:56 src/olympia/browse/views.py:66 src/olympia/browse/views.py:204 src/olympia/browse/views.py:249 src/olympia/search/forms.py:86
 msgid "Top Rated"
 msgstr "الأعلى تقييما"
 
@@ -2038,38 +1974,38 @@ msgstr "استكشف"
 msgid "Extensions"
 msgstr "الامتدادات"
 
-#: src/olympia/amo/templates/amo/site_nav.html:45
+#: src/olympia/amo/templates/amo/site_nav.html:44
 msgid "Want more customization? Try <b>Complete Themes</b>"
 msgstr ""
 
-#: src/olympia/amo/templates/amo/site_nav.html:56 src/olympia/bandwagon/views.py:96
+#: src/olympia/amo/templates/amo/site_nav.html:54 src/olympia/bandwagon/views.py:96
 msgid "Most Followers"
 msgstr "الأكثر متابعة"
 
-#: src/olympia/amo/templates/amo/site_nav.html:68 src/olympia/bandwagon/templates/bandwagon/impala/collection_sidebar.html:16
+#: src/olympia/amo/templates/amo/site_nav.html:66 src/olympia/bandwagon/templates/bandwagon/impala/collection_sidebar.html:16
 #: src/olympia/bandwagon/templates/bandwagon/includes/collection_sidebar.html:18
 msgid "Collections I've Made"
 msgstr "المجموعات التي أنشأتها"
 
-#: src/olympia/amo/templates/amo/site_nav.html:70 src/olympia/bandwagon/templates/bandwagon/user_listing.html:4 src/olympia/bandwagon/templates/bandwagon/impala/collection_sidebar.html:13
+#: src/olympia/amo/templates/amo/site_nav.html:68 src/olympia/bandwagon/templates/bandwagon/user_listing.html:4 src/olympia/bandwagon/templates/bandwagon/impala/collection_sidebar.html:13
 #: src/olympia/bandwagon/templates/bandwagon/includes/collection_sidebar.html:15
 msgid "Collections I'm Following"
 msgstr "المجموعات التي أتابعها"
 
-#: src/olympia/amo/templates/amo/site_nav.html:73 src/olympia/bandwagon/templates/bandwagon/impala/collection_sidebar.html:18
-#: src/olympia/bandwagon/templates/bandwagon/includes/collection_sidebar.html:20 src/olympia/users/models.py:512
+#: src/olympia/amo/templates/amo/site_nav.html:71 src/olympia/bandwagon/templates/bandwagon/impala/collection_sidebar.html:18
+#: src/olympia/bandwagon/templates/bandwagon/includes/collection_sidebar.html:20 src/olympia/users/models.py:521
 msgid "My Favorite Add-ons"
 msgstr "إضافاتي المفضلة"
 
-#: src/olympia/amo/templates/amo/site_nav.html:78
+#: src/olympia/amo/templates/amo/site_nav.html:76
 msgid "More&hellip;"
 msgstr "المزيد&hellip;"
 
-#: src/olympia/amo/templates/amo/site_nav.html:82
+#: src/olympia/amo/templates/amo/site_nav.html:80
 msgid "Add-ons for Mobile"
 msgstr "إضافات الهواتف الذكية"
 
-#: src/olympia/amo/templates/amo/site_nav.html:86 src/olympia/browse/feeds.py:207 src/olympia/browse/templates/browse/search_tools.html:3 src/olympia/constants/base.py:176
+#: src/olympia/amo/templates/amo/site_nav.html:84 src/olympia/browse/feeds.py:207 src/olympia/browse/templates/browse/search_tools.html:3 src/olympia/constants/base.py:176
 #: src/olympia/templates/menu_links.html:10
 msgid "Search Tools"
 msgstr "أدوات البحث"
@@ -2085,7 +2021,7 @@ msgid "Jump to first page"
 msgstr "انتقل إلى الصفحة الأولى"
 
 #: src/olympia/amo/templates/amo/impala/paginator.html:22 src/olympia/amo/templates/amo/mobile/impala_paginator.html:12 src/olympia/discovery/templates/discovery/pane.html:44
-#: src/olympia/discovery/templates/discovery/addons/detail.html:38 src/olympia/stats/templates/stats/stats.html:164
+#: src/olympia/discovery/templates/discovery/addons/detail.html:38 src/olympia/stats/templates/stats/stats.html:166
 msgid "Previous"
 msgstr "السابق"
 
@@ -2107,35 +2043,50 @@ msgid "Page {n}"
 msgid_plural "Page {n}"
 msgstr[0] ""
 msgstr[1] ""
-msgstr[2] ""
-msgstr[3] ""
-msgstr[4] ""
-msgstr[5] ""
 
-#: src/olympia/amo/templates/services/install.html:38
-#, python-format
-msgid "If you are not prompted to install %(addon_name)s in a moment, please <a href=\"%(addon_xpi)s\">click here</a>."
-msgstr ""
-
-#: src/olympia/amo/tests/test_messages.py:57 src/olympia/amo/tests/test_messages.py:58 src/olympia/reviews/forms.py:25 src/olympia/reviews/forms.py:50 src/olympia/reviews/templates/reviews/add.html:56
+#: src/olympia/amo/tests/test_messages.py:56 src/olympia/amo/tests/test_messages.py:57 src/olympia/reviews/forms.py:25 src/olympia/reviews/forms.py:50 src/olympia/reviews/templates/reviews/add.html:56
 #: src/olympia/reviews/templates/reviews/reply.html:30
 msgid "Title"
 msgstr "العنوان"
 
-#: src/olympia/amo/tests/test_messages.py:57 src/olympia/amo/tests/test_messages.py:58
+#: src/olympia/amo/tests/test_messages.py:56 src/olympia/amo/tests/test_messages.py:57
 msgid "Body"
 msgstr ""
 
-#: src/olympia/amo/tests/test_messages.py:59
+#: src/olympia/amo/tests/test_messages.py:58
 msgid "Another Title"
 msgstr "عنوان آخر"
 
-#: src/olympia/amo/tests/test_messages.py:59
+#: src/olympia/amo/tests/test_messages.py:58
 msgid "Another Body"
 msgstr ""
 
-#: src/olympia/api/views.py:255
-msgid "Not implemented yet."
+#: src/olympia/api/authentication.py:76
+msgid "Signature has expired."
+msgstr ""
+
+#: src/olympia/api/authentication.py:79
+msgid "Error decoding signature."
+msgstr ""
+
+#: src/olympia/api/authentication.py:82
+msgid "Invalid JWT Token."
+msgstr ""
+
+#: src/olympia/api/authentication.py:130
+msgid "Invalid Authorization header. No credentials provided."
+msgstr ""
+
+#: src/olympia/api/authentication.py:133
+msgid "Invalid Authorization header. Credentials string should not contain spaces."
+msgstr ""
+
+#: src/olympia/api/fields.py:29
+msgid "The field must have a length of at least {num} characters."
+msgstr ""
+
+#: src/olympia/api/fields.py:31
+msgid "The language code {lang_code} is invalid."
 msgstr ""
 
 #: src/olympia/applications/views.py:39 src/olympia/applications/templates/applications/appversions.html:3
@@ -2154,7 +2105,7 @@ msgstr "إصدارات التطبيقات الصالحة"
 msgid "Add-ons submitted to Mozilla Add-ons must have a manifest file with at least one of the below applications supported. Only the versions listed below are allowed for these applications."
 msgstr ""
 
-#: src/olympia/applications/templates/applications/appversions.html:25
+#: src/olympia/applications/templates/applications/appversions.html:25 src/olympia/editors/helpers.py:361
 msgid "GUID"
 msgstr "المعرّف الفريد"
 
@@ -2268,8 +2219,8 @@ msgstr ""
 msgid "Remove from favorites"
 msgstr "أزِل من المفضلات"
 
-#: src/olympia/bandwagon/views.py:98 src/olympia/bandwagon/views.py:191 src/olympia/browse/views.py:58 src/olympia/browse/views.py:69 src/olympia/browse/views.py:458 src/olympia/devhub/views.py:74
-#: src/olympia/devhub/views.py:82 src/olympia/devhub/templates/devhub/addons/edit/basic.html:20 src/olympia/editors/templates/editors/leaderboard.html:24
+#: src/olympia/bandwagon/views.py:98 src/olympia/bandwagon/views.py:191 src/olympia/browse/views.py:58 src/olympia/browse/views.py:69 src/olympia/browse/views.py:425 src/olympia/devhub/views.py:72
+#: src/olympia/devhub/views.py:80 src/olympia/devhub/templates/devhub/addons/edit/basic.html:20 src/olympia/editors/templates/editors/leaderboard.html:24
 #: src/olympia/editors/templates/editors/themes/queue_list.html:48 src/olympia/search/forms.py:17 src/olympia/search/forms.py:89 src/olympia/users/templates/users/vcard.html:5
 msgid "Name"
 msgstr "الاسم"
@@ -2278,7 +2229,7 @@ msgstr "الاسم"
 msgid "Recently Popular"
 msgstr "المشهورة مؤخرا"
 
-#: src/olympia/bandwagon/views.py:189 src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:18
+#: src/olympia/bandwagon/views.py:189 src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:16
 msgid "Added"
 msgstr "الإنشاء"
 
@@ -2292,7 +2243,7 @@ msgstr "أنشئت المجموعة!"
 
 #: src/olympia/bandwagon/views.py:316
 #, python-format
-msgid "Your new collection is shown below. You can <ahref=\"%(url)s\">edit additional settings</a> if you'dlike."
+msgid "Your new collection is shown below. You can <a href=\"%(url)s\">edit additional settings</a> if you'd like."
 msgstr ""
 
 #: src/olympia/bandwagon/views.py:322
@@ -2373,10 +2324,6 @@ msgid "<span>%(num)s</span> follower"
 msgid_plural "<span>%(num)s</span> followers"
 msgstr[0] "لا متابعين"
 msgstr[1] "متابع واحد"
-msgstr[2] "متابعين أثنين"
-msgstr[3] "<span>%(num)s</span> متابعين"
-msgstr[4] "<span>%(num)s</span> متابعًا"
-msgstr[5] "<span>%(num)s</span> متابع"
 
 #: src/olympia/bandwagon/templates/bandwagon/collection_detail.html:54
 msgid "About this Collection"
@@ -2417,10 +2364,6 @@ msgid "%(num)s Theme in this Collection"
 msgid_plural "%(num)s Themes in this Collection"
 msgstr[0] "لا سِمات في هذه المجموعة"
 msgstr[1] "سِمة واحدة في هذه المجموعة"
-msgstr[2] "سِمتين في هذه المجموعة"
-msgstr[3] "%(num)s سِمات في هذه المجموعة"
-msgstr[4] "%(num)s سِمة في هذه المجموعة"
-msgstr[5] "%(num)s سِمة في هذه المجموعة"
 
 #: src/olympia/bandwagon/templates/bandwagon/collection_detail.html:111
 #, python-format
@@ -2428,13 +2371,9 @@ msgid "%(num)s Add-on in this Collection"
 msgid_plural "%(num)s Add-ons in this Collection"
 msgstr[0] "لا إضافات في هذه المجموعة"
 msgstr[1] "إضافة واحدة في هذه المجموعة"
-msgstr[2] "إضافتين في هذه المجموعة"
-msgstr[3] "%(num)s إضافات في هذه المجموعة"
-msgstr[4] "%(num)s إضافة في هذه المجموعة"
-msgstr[5] "%(num)s إضافة في هذه المجموعة"
 
-#: src/olympia/bandwagon/templates/bandwagon/collection_detail.html:125 src/olympia/compat/templates/compat/index.html:25 src/olympia/compat/templates/compat/reporter_detail.html:29
-#: src/olympia/files/templates/files/viewer.html:29 src/olympia/templates/amo_footer.html:17 src/olympia/templates/includes/lang_switcher.html:10
+#: src/olympia/bandwagon/templates/bandwagon/collection_detail.html:125 src/olympia/compat/templates/compat/reporter_detail.html:29 src/olympia/files/templates/files/viewer.html:29
+#: src/olympia/templates/amo_footer.html:17 src/olympia/templates/includes/lang_switcher.html:10
 msgid "Go"
 msgstr "إذهب"
 
@@ -2468,11 +2407,9 @@ msgstr ""
 
 #: src/olympia/bandwagon/templates/bandwagon/collection_detail.html:186
 msgid ""
-"Add-ons that you mark as favorites using the <b>Add to Favorites</b> feature appear below. This collection is currently <b>private</b>, which means only you can see it. If you would like everyone "
+"Add-ons that you mark as favorites using the <b>Add to Favorites</b> feature appear below. This collection is currently <b>private</b>, which means only you can see it.  If you would like everyone "
 "to be able to see your favorites, click the button below to make it public."
 msgstr ""
-"تتضمن هذه المجموعة الإضافات التي تضيفها للمُفضّلة باستخدام زرّ <b>أضِف إلى المفضلات</b> الذي يظهر في صفحة تنزيل الإضافة على اليسار. هذه المجموعة <b>خاصة</b> حاليًا، وهذا معناه أنه لن يستطيع أن يراها أحد "
-"سواك. إذا رغبت أن يُسمح لأي شخص برؤية إضافاتك المفضلة، انقر على الزرّ أدناه لتجعلها مجموعة عامّة."
 
 #: src/olympia/bandwagon/templates/bandwagon/collection_detail.html:196
 msgid "My favorite add-ons"
@@ -2484,10 +2421,6 @@ msgid "<span>%(addons)s</span> add-on"
 msgid_plural "<span>%(addons)s</span> add-ons"
 msgstr[0] "لا إضافات"
 msgstr[1] "إضافة واحدة"
-msgstr[2] "إضافتين إثنتين"
-msgstr[3] "<span>%(addons)s</span> إضافات"
-msgstr[4] "<span>%(addons)s</span> إضافة"
-msgstr[5] "<span>%(addons)s</span> إضافة"
 
 #: src/olympia/bandwagon/templates/bandwagon/collection_grid.html:32
 #, python-format
@@ -2495,10 +2428,6 @@ msgid "<span>%(followers)s</span> follower"
 msgid_plural "<span>%(followers)s</span> followers"
 msgstr[0] "لا متابعين"
 msgstr[1] "متابع واحد"
-msgstr[2] "متابعيّن إثنين"
-msgstr[3] "<span>%(followers)s</span> متابعين"
-msgstr[4] "<span>%(followers)s</span> متابعًا"
-msgstr[5] "<span>%(followers)s</span> متابع"
 
 #. People "follow" collections to get notified of updates.                    Like
 #. Twitter followers.
@@ -2510,10 +2439,6 @@ msgid "%(num)s weekly follower"
 msgid_plural "%(num)s weekly followers"
 msgstr[0] "لا متابعين"
 msgstr[1] "متابع واحد أسبوعيا"
-msgstr[2] "متابعين أثنين أسبوعيا"
-msgstr[3] "%(num)s متابعين أسبوعيا"
-msgstr[4] "%(num)s متابعًا أسبوعيا"
-msgstr[5] "%(num)s متابع أسبوعيا"
 
 #. People "follow" collections to get notified of updates.                    Like
 #. Twitter followers.
@@ -2523,10 +2448,6 @@ msgid "%(num)s monthly follower"
 msgid_plural "%(num)s monthly followers"
 msgstr[0] "لا متابعين"
 msgstr[1] "متابع واحد شهريا"
-msgstr[2] "متابعين أثنين شهريا"
-msgstr[3] "%(num)s متابعين شهريا"
-msgstr[4] "%(num)s متابعًا شهريا"
-msgstr[5] "%(num)s متابع شهريا"
 
 #. People "follow" collections to get notified of updates.                    Like
 #. Twitter followers.
@@ -2538,10 +2459,6 @@ msgid "%(num)s follower"
 msgid_plural "%(num)s followers"
 msgstr[0] "لا متابعين"
 msgstr[1] "متابع واحد"
-msgstr[2] "متابعين أثنين"
-msgstr[3] "%(num)s متابعين"
-msgstr[4] "%(num)s متابعًا"
-msgstr[5] "%(num)s متابع"
 
 #: src/olympia/bandwagon/templates/bandwagon/collection_listing_items.html:56 src/olympia/bandwagon/templates/bandwagon/impala/collection_listing_items.html:9
 #: src/olympia/devhub/templates/devhub/personas/edit.html:27
@@ -2626,7 +2543,7 @@ msgid "Remove this user as a contributor"
 msgstr "إزالة هذه المستخدم كمساهم"
 
 #: src/olympia/bandwagon/templates/bandwagon/edit_contributors.html:18 src/olympia/bandwagon/templates/bandwagon/edit_contributors.html:43
-#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:20 src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:48
+#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:18 src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:46
 #: src/olympia/devhub/templates/devhub/addons/ajax_compat_update.html:19
 msgid "Remove"
 msgstr "إزالة"
@@ -2637,11 +2554,9 @@ msgstr "المساهمين في المجموعة"
 
 #: src/olympia/bandwagon/templates/bandwagon/edit_contributors.html:26
 msgid ""
-"You can add multiple contributors to this collection. A contributor can add and remove add-ons from this collection, but cannot change its name or description. To add a contributor, enter their "
+"You can add multiple contributors to this collection.  A contributor can add and remove add-ons from this collection, but cannot change its name or description.  To add a contributor, enter their "
 "email in the box below. Contributors must have a Mozilla Add-ons account."
 msgstr ""
-"يمكنك إضافة العديد من المساهمين لهذه المجموعة. المساهم يمكنه إضافة أو إزالة أي إضافات إلى أو من المجموعة. لإضافة مساهم، أدخِل بريده الإلكتروني في المربع أدناه. المساهمون يجب أن يكون لديهم حسابات في "
-"موقع الإضافات ليتمكنوا من المساهمة."
 
 #: src/olympia/bandwagon/templates/bandwagon/edit_contributors.html:40
 msgid "User"
@@ -2677,7 +2592,7 @@ msgid "<b>Warning:</b> By changing the owner of this collection, you will no lon
 msgstr "<b>تحذير:</b> بتغييرك لمالك هذه المجموعة، فلن تتمكن من تعديلها بعد الآن. سوف تتمكن فقط من إضافة أو إزالة الإضافات إليها ومنها."
 
 #: src/olympia/bandwagon/templates/bandwagon/edit_contributors.html:83 src/olympia/devhub/templates/devhub/addons/forms_shared/media.html:157
-#: src/olympia/devhub/templates/devhub/addons/submit/describe.html:69 src/olympia/devhub/templates/devhub/addons/submit/license.html:60 src/olympia/devhub/templates/devhub/addons/submit/upload.html:78
+#: src/olympia/devhub/templates/devhub/addons/submit/describe.html:69 src/olympia/devhub/templates/devhub/addons/submit/license.html:60 src/olympia/devhub/templates/devhub/addons/submit/upload.html:70
 #: src/olympia/devhub/templates/devhub/payments/tier.html:17 src/olympia/editors/templates/editors/themes/themes.html:111 src/olympia/editors/templates/editors/themes/themes.html:128
 #: src/olympia/editors/templates/editors/themes/themes.html:134 src/olympia/editors/templates/editors/themes/themes.html:141 src/olympia/users/templates/users/fxa_migration_prompt_content.html:10
 #: src/olympia/users/templates/users/login_form.html:42 src/olympia/users/templates/users/mobile/login.html:57
@@ -2749,45 +2664,43 @@ msgid "Reset"
 msgstr ""
 
 #: src/olympia/bandwagon/templates/bandwagon/includes/addedit.html:53
-msgid "PNG and JPG supported. Image will be resized to 32x32."
-msgstr "الصور المدعومة هي PNG و JPG. الصور سيعاد تحجيمها إلى 32×32."
+msgid "PNG and JPG supported.  Image will be resized to 32x32."
+msgstr ""
 
 #: src/olympia/bandwagon/templates/bandwagon/includes/addedit_errors.html:3
-msgid "There are errors in this form. Please correct them below."
-msgstr "هناك أخطاء في هذا النموذج. رجاءً صححها أدناه."
+msgid "There are errors in this form.  Please correct them below."
+msgstr ""
 
 #: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:2
 msgid "Add-ons in Your Collection"
 msgstr "الإضافات في مجموعتك"
 
 #: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:4
-msgid ""
-"To include an add-on in this collection, enter its name in the box below and hit enter. You can also use the <strong>Add to Collection</strong> links throughout the site to include add-ons later."
+msgid "To include an add-on in this collection, enter its name in the box below and hit enter."
 msgstr ""
-"لتضمين إضافة إلى هذه المجموعة، أدخِل اسمها في المربع النصي أدناه وانتظر قليلا حتى تظهر لك لتختارها. يمكنك أيضا استخدام أزرار <strong>أضِف إلى مجموعة</strong> الموجودة خلال الموقع لتضمين الإضافات فيما "
-"بعد."
 
-#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:17 src/olympia/constants/base.py:400 src/olympia/devhub/templates/devhub/addons/activity.html:62
+#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:15 src/olympia/constants/base.py:400 src/olympia/devhub/templates/devhub/addons/activity.html:62
+#: src/olympia/editors/helpers.py:273 src/olympia/editors/helpers.py:360
 msgid "Add-on"
 msgstr "الإضافة"
 
-#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:26
+#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:24
 msgid "Enter the name of the add-on to include"
 msgstr "أدخِل اسم الإضافة لتضمينها"
 
-#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:28
+#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:26
 msgid "Add to Collection"
 msgstr "أضِف إلى المجموعة"
 
-#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:45 src/olympia/editors/helpers.py:936 src/olympia/editors/helpers.py:956
+#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:43 src/olympia/editors/helpers.py:1016 src/olympia/editors/helpers.py:1036
 msgid "Pending"
 msgstr "في الانتظار"
 
-#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:47
+#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:45
 msgid "Add a comment"
 msgstr "أضِف تعليقا"
 
-#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:48
+#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:46
 msgid "Remove this add-on from the collection"
 msgstr "إزالة هذه الإضافة من المجموعة"
 
@@ -2894,12 +2807,12 @@ msgstr "أدوات البحث"
 msgid "Most Users"
 msgstr "الأكثر استخداما"
 
-#: src/olympia/browse/views.py:61 src/olympia/browse/views.py:72 src/olympia/browse/views.py:279 src/olympia/browse/templates/browse/personas/mobile/category_landing.html:63
+#: src/olympia/browse/views.py:61 src/olympia/browse/views.py:72 src/olympia/browse/views.py:246 src/olympia/browse/templates/browse/personas/mobile/category_landing.html:63
 #: src/olympia/discovery/templates/discovery/pane.html:67 src/olympia/search/forms.py:92
 msgid "Up & Coming"
 msgstr "القادمة"
 
-#: src/olympia/browse/views.py:460 src/olympia/devhub/views.py:76 src/olympia/devhub/views.py:83 src/olympia/discovery/templates/discovery/addons/detail.html:66
+#: src/olympia/browse/views.py:427 src/olympia/devhub/views.py:74 src/olympia/devhub/views.py:81 src/olympia/discovery/templates/discovery/addons/detail.html:66
 msgid "Created"
 msgstr "الإنشاء"
 
@@ -2980,10 +2893,6 @@ msgid "<b>{0}</b> add-on"
 msgid_plural "<b>{0}</b> add-ons"
 msgstr[0] "لا إضافات"
 msgstr[1] "إضافة واحدة"
-msgstr[2] "إضافتان"
-msgstr[3] "<b>{0}</b> إضافات"
-msgstr[4] "<b>{0}</b> إضافة"
-msgstr[5] "<b>{0}</b> إضافة"
 
 #: src/olympia/browse/templates/browse/search_tools.html:61
 msgid "Search Extensions"
@@ -3090,13 +2999,9 @@ msgid "See the %(cnt)s extension in %(name)s &raquo;"
 msgid_plural "See all %(cnt)s extensions in %(name)s &raquo;"
 msgstr[0] "لا امتدادات أخرى"
 msgstr[1] "اعرض جميع الامتدادات الأخرى في %(name)s &raquo;"
-msgstr[2] "اعرض جميع الامتدادات الأخرى في %(name)s &raquo;"
-msgstr[3] "اعرض جميع الامتدادات الأخرى في %(name)s &raquo;"
-msgstr[4] "اعرض جميع الامتدادات الأخرى في %(name)s &raquo;"
-msgstr[5] "اعرض جميع الامتدادات الأخرى في %(name)s &raquo;"
 
-#: src/olympia/browse/templates/browse/mobile/extensions.html:13 src/olympia/compat/templates/compat/index.html:82 src/olympia/devhub/templates/devhub/devhub_search.html:24
-#: src/olympia/devhub/templates/devhub/addons/activity.html:47 src/olympia/search/templates/search/no_results.html:4 src/olympia/search/templates/search/mobile/results.html:36
+#: src/olympia/browse/templates/browse/mobile/extensions.html:13 src/olympia/devhub/templates/devhub/devhub_search.html:24 src/olympia/devhub/templates/devhub/addons/activity.html:47
+#: src/olympia/search/templates/search/no_results.html:4 src/olympia/search/templates/search/mobile/results.html:36
 msgid "No results found."
 msgstr "لم يُعثر على نتائج."
 
@@ -3181,7 +3086,7 @@ msgstr "» كل السِمات"
 msgid "All"
 msgstr "الكل"
 
-#: src/olympia/compat/forms.py:22 src/olympia/search/views.py:525
+#: src/olympia/compat/forms.py:22 src/olympia/editors/templates/editors/base.html:69 src/olympia/search/views.py:518
 msgid "All Add-ons"
 msgstr "كل الإضافات"
 
@@ -3192,53 +3097,6 @@ msgstr ""
 #: src/olympia/compat/forms.py:24
 msgid "Non-binary"
 msgstr ""
-
-#. Review points sources other than add-ons and themes.
-#: src/olympia/compat/views.py:87 src/olympia/constants/base.py:388 src/olympia/devhub/forms.py:162 src/olympia/editors/templates/editors/performance.html:75
-msgid "Other"
-msgstr "أخرى"
-
-#: src/olympia/compat/templates/compat/index.html:4
-msgid "Add-on Compatibility Report for {app} {version}"
-msgstr ""
-
-#: src/olympia/compat/templates/compat/index.html:11
-msgid "{app} {version} Compatibility"
-msgstr ""
-
-#: src/olympia/compat/templates/compat/index.html:17
-#, python-format
-msgid "Top 95%% compatible with previous version"
-msgstr ""
-
-#: src/olympia/compat/templates/compat/index.html:18
-#, python-format
-msgid "Top 95%% of all add-ons"
-msgstr ""
-
-#: src/olympia/compat/templates/compat/index.html:19
-msgid "All active add-ons"
-msgstr ""
-
-#: src/olympia/compat/templates/compat/index.html:23 src/olympia/constants/base.py:401
-msgid "App"
-msgstr ""
-
-#: src/olympia/compat/templates/compat/index.html:55
-msgid "Details for add-ons compatible with previous version:"
-msgstr ""
-
-#: src/olympia/compat/templates/compat/index.html:57
-msgid "Show all versions"
-msgstr "عرض جميع الإصدارات"
-
-#: src/olympia/compat/templates/compat/index.html:59
-msgid "Details for add-ons compatible with all versions:"
-msgstr ""
-
-#: src/olympia/compat/templates/compat/index.html:61
-msgid "Show previous version only"
-msgstr "عرض الإصدارة السابقة فقط"
 
 #: src/olympia/compat/templates/compat/reporter.html:3
 msgid "Add-on Compatibility Reports"
@@ -3272,20 +3130,12 @@ msgid "{0} success report"
 msgid_plural "{0} success reports"
 msgstr[0] ""
 msgstr[1] ""
-msgstr[2] ""
-msgstr[3] ""
-msgstr[4] ""
-msgstr[5] ""
 
 #: src/olympia/compat/templates/compat/reporter_detail.html:17
 msgid "{0} problem report"
 msgid_plural "{0} problem reports"
 msgstr[0] ""
 msgstr[1] ""
-msgstr[2] ""
-msgstr[3] ""
-msgstr[4] ""
-msgstr[5] ""
 
 #: src/olympia/compat/templates/compat/reporter_detail.html:21 src/olympia/users/templates/users/profile.html:70
 msgid "View all"
@@ -3299,8 +3149,8 @@ msgstr ""
 msgid "Report Type"
 msgstr ""
 
-#: src/olympia/compat/templates/compat/reporter_detail.html:47 src/olympia/devhub/forms.py:784 src/olympia/devhub/templates/devhub/addons/ajax_compat_update.html:17 src/olympia/editors/forms.py:108
-#: src/olympia/zadmin/forms.py:45
+#: src/olympia/compat/templates/compat/reporter_detail.html:47 src/olympia/devhub/forms.py:785 src/olympia/devhub/templates/devhub/addons/ajax_compat_update.html:17 src/olympia/editors/forms.py:108
+#: src/olympia/editors/forms.py:248 src/olympia/zadmin/forms.py:45
 msgid "Application"
 msgstr ""
 
@@ -3388,7 +3238,8 @@ msgstr ""
 msgid "Preliminarily Reviewed and Awaiting Full Review"
 msgstr ""
 
-#: src/olympia/constants/base.py:33 src/olympia/editors/helpers.py:924 src/olympia/editors/templates/editors/themes/history_table.html:34
+#: src/olympia/constants/base.py:33 src/olympia/editors/forms.py:258 src/olympia/editors/helpers.py:73 src/olympia/editors/helpers.py:1004
+#: src/olympia/editors/templates/editors/themes/history_table.html:34
 msgid "Deleted"
 msgstr ""
 
@@ -3491,6 +3342,11 @@ msgstr ""
 msgid "Ask before users can download this add-on"
 msgstr ""
 
+#. Review points sources other than add-ons and themes.
+#: src/olympia/constants/base.py:388 src/olympia/devhub/forms.py:162 src/olympia/editors/templates/editors/performance.html:75
+msgid "Other"
+msgstr "أخرى"
+
 #: src/olympia/constants/base.py:389
 msgid "Exception"
 msgstr ""
@@ -3501,6 +3357,10 @@ msgstr ""
 
 #: src/olympia/constants/base.py:391
 msgid "Change"
+msgstr ""
+
+#: src/olympia/constants/base.py:401
+msgid "App"
 msgstr ""
 
 #: src/olympia/constants/base.py:402
@@ -3652,7 +3512,7 @@ msgstr ""
 msgid "Duplicate"
 msgstr ""
 
-#: src/olympia/constants/editors.py:17 src/olympia/editors/helpers.py:502 src/olympia/editors/templates/editors/themes/queue.html:71 src/olympia/editors/templates/editors/themes/themes.html:94
+#: src/olympia/constants/editors.py:17 src/olympia/editors/helpers.py:575 src/olympia/editors/templates/editors/themes/queue.html:71 src/olympia/editors/templates/editors/themes/themes.html:94
 msgid "Reject"
 msgstr ""
 
@@ -3752,7 +3612,7 @@ msgstr "سولاريس"
 msgid "Android"
 msgstr "أندرويد"
 
-#: src/olympia/core/apps.py:19
+#: src/olympia/core/apps.py:21
 msgid "Core"
 msgstr ""
 
@@ -3886,7 +3746,7 @@ msgid "Submit my add-on for manual review."
 msgstr ""
 
 #: src/olympia/devhub/forms.py:537
-msgid "Do not list my add-on on this site (beta)"
+msgid "Do not list my add-on on this site"
 msgstr ""
 
 #: src/olympia/devhub/forms.py:538
@@ -3919,46 +3779,46 @@ msgstr ""
 
 #: src/olympia/devhub/forms.py:592
 #, python-format
-msgid "Version %s already exists"
+msgid "Version %s already exists, or was uploaded before."
 msgstr ""
 
-#: src/olympia/devhub/forms.py:604
+#: src/olympia/devhub/forms.py:605
 msgid "Select a valid choice. That choice is not one of the available choices."
 msgstr ""
 
-#: src/olympia/devhub/forms.py:610
+#: src/olympia/devhub/forms.py:611
 msgid "A file with a version ending with a|alpha|b|beta and an optional number is detected as beta."
 msgstr ""
 
-#: src/olympia/devhub/forms.py:633
+#: src/olympia/devhub/forms.py:634
 msgid "You cannot upload any more files for this version."
 msgstr ""
 
-#: src/olympia/devhub/forms.py:639
+#: src/olympia/devhub/forms.py:640
 msgid "Version doesn't match"
 msgstr ""
 
-#: src/olympia/devhub/forms.py:668
+#: src/olympia/devhub/forms.py:669
 msgid "You cannot delete a file once the review process has started.  You must delete the whole version."
 msgstr ""
 
-#: src/olympia/devhub/forms.py:688
+#: src/olympia/devhub/forms.py:689
 msgid "The platform All cannot be combined with specific platforms."
 msgstr ""
 
-#: src/olympia/devhub/forms.py:693
+#: src/olympia/devhub/forms.py:694
 msgid "A platform can only be chosen once."
 msgstr ""
 
-#: src/olympia/devhub/forms.py:706
+#: src/olympia/devhub/forms.py:707
 msgid "A review type must be selected."
 msgstr ""
 
-#: src/olympia/devhub/forms.py:788 src/olympia/editors/forms.py:114 src/olympia/zadmin/forms.py:49 src/olympia/zadmin/forms.py:52
+#: src/olympia/devhub/forms.py:789 src/olympia/editors/forms.py:114 src/olympia/editors/forms.py:254 src/olympia/zadmin/forms.py:49 src/olympia/zadmin/forms.py:52
 msgid "Select an application first"
 msgstr ""
 
-#: src/olympia/devhub/forms.py:840
+#: src/olympia/devhub/forms.py:841
 msgid "There cannot be more than 3 required add-ons."
 msgstr ""
 
@@ -3981,10 +3841,6 @@ msgid "{0} error"
 msgid_plural "{0} errors"
 msgstr[0] "لا أخطاء"
 msgstr[1] "خطأ واحد"
-msgstr[2] "خطأين أثنين"
-msgstr[3] "{0} أخطاء"
-msgstr[4] "{0} خطأ"
-msgstr[5] "{0} خطأ"
 
 # {0} is a number
 #. L10n: first parameter is the number of warnings
@@ -3993,85 +3849,81 @@ msgid "{0} warning"
 msgid_plural "{0} warnings"
 msgstr[0] "لا تحذيرات"
 msgstr[1] "تحذير واحد"
-msgstr[2] "تحذيرين أثنين"
-msgstr[3] "{0} تحذيرات"
-msgstr[4] "{0} تحذيرًا"
-msgstr[5] "{0} تحذير"
 
 #: src/olympia/devhub/models.py:375 src/olympia/reviews/templates/reviews/add.html:58
 msgid "Review"
 msgstr "التعليق"
 
-#: src/olympia/devhub/tasks.py:551
+#: src/olympia/devhub/tasks.py:583
 #, python-format
 msgid "%s responded with %s (%s)."
 msgstr ""
 
-#: src/olympia/devhub/tasks.py:555
+#: src/olympia/devhub/tasks.py:587
 #, python-format
 msgid "Connection to \"%s\" timed out."
 msgstr ""
 
-#: src/olympia/devhub/tasks.py:557
+#: src/olympia/devhub/tasks.py:589
 #, python-format
 msgid "Could not contact host at \"%s\"."
 msgstr ""
 
-#: src/olympia/devhub/utils.py:104
+#: src/olympia/devhub/utils.py:105
 #, python-format
 msgid "Validation generated too many errors/warnings so %s messages were truncated. After addressing the visible messages, you'll be able to see the others."
 msgstr ""
 
-#: src/olympia/devhub/views.py:183
+#: src/olympia/devhub/views.py:181
 msgid "All My Add-ons"
 msgstr ""
 
-#: src/olympia/devhub/views.py:210
+#: src/olympia/devhub/views.py:208
 msgid "All Activity"
 msgstr ""
 
-#: src/olympia/devhub/views.py:211
+#: src/olympia/devhub/views.py:209
 msgid "Add-on Updates"
 msgstr ""
 
-#: src/olympia/devhub/views.py:212
+#: src/olympia/devhub/views.py:210
 msgid "Add-on Status"
 msgstr ""
 
-#: src/olympia/devhub/views.py:213
+#: src/olympia/devhub/views.py:211
 msgid "User Collections"
 msgstr ""
 
-#: src/olympia/devhub/views.py:214 src/olympia/devhub/templates/devhub/docs/policies-maintenance.html:68 src/olympia/pages/templates/pages/dev_faq.html:38
+#: src/olympia/devhub/views.py:212 src/olympia/devhub/templates/devhub/docs/policies-maintenance.html:68 src/olympia/pages/templates/pages/dev_faq.html:38
 #: src/olympia/pages/templates/pages/dev_faq.html:484
 msgid "User Reviews"
 msgstr "تعليقات المستخدمين"
 
-#: src/olympia/devhub/views.py:327 src/olympia/devhub/views.py:331 src/olympia/devhub/views.py:484 src/olympia/devhub/views.py:513 src/olympia/devhub/views.py:564 src/olympia/devhub/views.py:1150
+#: src/olympia/devhub/views.py:325 src/olympia/devhub/views.py:329 src/olympia/devhub/views.py:484 src/olympia/devhub/views.py:513 src/olympia/devhub/views.py:564 src/olympia/devhub/views.py:1156
 msgid "Changes successfully saved."
 msgstr "حُفظت التغييرات بنجاح."
 
-#: src/olympia/devhub/views.py:334 src/olympia/devhub/views.py:1631
+#: src/olympia/devhub/views.py:332 src/olympia/devhub/views.py:1637
 msgid "Please check the form for errors."
 msgstr ""
 
-#: src/olympia/devhub/views.py:346
+#: src/olympia/devhub/views.py:344
 msgid "Add-on cannot be deleted. Disable this add-on instead."
 msgstr "لا يمكن حذف الإضافة. يمكنك تعطيل الإضافة بدلا من ذلك."
 
-#: src/olympia/devhub/views.py:356
+#: src/olympia/devhub/views.py:354
 msgid "Theme deleted."
 msgstr ""
 
-#: src/olympia/devhub/views.py:356
+#: src/olympia/devhub/views.py:354
 msgid "Add-on deleted."
 msgstr "حُذفت الإضافة."
 
-#: src/olympia/devhub/views.py:362
+#: src/olympia/devhub/views.py:360
 msgid "URL name was incorrect. Theme was not deleted."
 msgstr ""
 
-#: src/olympia/devhub/views.py:367
+#: src/olympia/devhub/views.py:365
 msgid "URL name was incorrect. Add-on was not deleted."
 msgstr ""
 
@@ -4099,7 +3951,7 @@ msgstr ""
 msgid "Check Add-on Compatibility"
 msgstr "فحص توافقية الإضافة"
 
-#: src/olympia/devhub/views.py:808 src/olympia/signing/views.py:90
+#: src/olympia/devhub/views.py:808 src/olympia/signing/views.py:95
 msgid "You cannot submit this type of add-on"
 msgstr ""
 
@@ -4129,33 +3981,33 @@ msgstr "الصورة يجب أن تطابق {0} بكسل للعرض، و {1} ب�
 msgid "There was an error uploading your preview."
 msgstr "هناك خطأ في رفع المعاينة."
 
-#: src/olympia/devhub/views.py:1189
+#: src/olympia/devhub/views.py:1195
 #, python-format
 msgid "Version %s disabled."
 msgstr ""
 
-#: src/olympia/devhub/views.py:1193
+#: src/olympia/devhub/views.py:1199
 #, python-format
 msgid "Version %s deleted."
 msgstr "حُذفت الإصدارة %s."
 
-#: src/olympia/devhub/views.py:1203
+#: src/olympia/devhub/views.py:1209
 msgid "This upload has failed validation, and may lack complete validation results. Please take due care when reviewing it."
 msgstr ""
 
-#: src/olympia/devhub/views.py:1677
+#: src/olympia/devhub/views.py:1683
 msgid "Preliminary Review Requested."
 msgstr ""
 
-#: src/olympia/devhub/views.py:1678
+#: src/olympia/devhub/views.py:1684
 msgid "Full Review Requested."
 msgstr ""
 
-#: src/olympia/devhub/views.py:1779
+#: src/olympia/devhub/views.py:1783
 msgid "Your old credentials were revoked and are no longer valid. Be sure to update all API clients with the new credentials."
 msgstr ""
 
-#: src/olympia/devhub/views.py:1797
+#: src/olympia/devhub/views.py:1801
 msgid "New API key created"
 msgstr ""
 
@@ -4185,7 +4037,7 @@ msgstr "عودة إلى الإضافات"
 msgid "{0} :: Search"
 msgstr "{0} :: بحث"
 
-#: src/olympia/devhub/templates/devhub/devhub_search.html:6 src/olympia/devhub/templates/devhub/search.html:8 src/olympia/editors/forms.py:435 src/olympia/editors/forms.py:437
+#: src/olympia/devhub/templates/devhub/devhub_search.html:6 src/olympia/devhub/templates/devhub/search.html:8 src/olympia/editors/forms.py:534 src/olympia/editors/forms.py:536
 #: src/olympia/editors/templates/editors/queue.html:27 src/olympia/editors/templates/editors/themes/queue_list.html:14 src/olympia/search/templates/search/collections.html:17
 #: src/olympia/search/templates/search/personas.html:18 src/olympia/search/templates/search/results.html:18 src/olympia/search/templates/search/mobile/results.html:8
 #: src/olympia/templates/search.html:14 src/olympia/templates/impala/search.html:18
@@ -4245,12 +4097,12 @@ msgstr ""
 msgid "Start Making Add-ons"
 msgstr "ابدأ بصنع الإضافات"
 
-#: src/olympia/devhub/templates/devhub/index.html:86 src/olympia/devhub/templates/devhub/addons/listing/items.html:25 src/olympia/devhub/templates/devhub/includes/addon_details.html:15
+#: src/olympia/devhub/templates/devhub/index.html:86 src/olympia/devhub/templates/devhub/addons/listing/items.html:25 src/olympia/devhub/templates/devhub/includes/addon_details.html:20
 #: src/olympia/devhub/templates/devhub/personas/edit.html:43
 msgid "Status:"
 msgstr "الحالة:"
 
-#: src/olympia/devhub/templates/devhub/index.html:90 src/olympia/devhub/templates/devhub/includes/addon_details.html:100
+#: src/olympia/devhub/templates/devhub/index.html:90 src/olympia/devhub/templates/devhub/includes/addon_details.html:87
 msgid "Visibility:"
 msgstr ""
 
@@ -4258,11 +4110,11 @@ msgstr ""
 msgid "Latest Version:"
 msgstr "الإصدارة الأخيرة:"
 
-#: src/olympia/devhub/templates/devhub/index.html:109 src/olympia/devhub/templates/devhub/includes/addon_details.html:145 src/olympia/devhub/templates/devhub/personas/edit.html:49
+#: src/olympia/devhub/templates/devhub/index.html:109 src/olympia/devhub/templates/devhub/includes/addon_details.html:131 src/olympia/devhub/templates/devhub/personas/edit.html:49
 msgid "Queue Position:"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/index.html:110 src/olympia/devhub/templates/devhub/includes/addon_details.html:146 src/olympia/devhub/templates/devhub/personas/edit.html:50
+#: src/olympia/devhub/templates/devhub/index.html:110 src/olympia/devhub/templates/devhub/includes/addon_details.html:132 src/olympia/devhub/templates/devhub/personas/edit.html:50
 #, python-format
 msgid "%(position)s of %(total)s"
 msgstr ""
@@ -4364,16 +4216,6 @@ msgstr ""
 msgid "Do you want your add-on to be distributed on this site?"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/validate_addon.html:49 src/olympia/devhub/templates/devhub/addons/submit/upload.html:30 src/olympia/devhub/templates/devhub/versions/add_file_modal.html:14
-#: src/olympia/devhub/templates/devhub/versions/add_file_modal.html:53 src/olympia/devhub/templates/devhub/versions/list.html:298
-msgid "Warning:"
-msgstr ""
-
-#: src/olympia/devhub/templates/devhub/validate_addon.html:50 src/olympia/devhub/templates/devhub/addons/submit/upload.html:31
-#, python-format
-msgid "Submission of unlisted add-ons for signing is currently in an open beta. Please <a href=\"%(url)s\" target=\"_blank\">report any bugs</a> that you encounter."
-msgstr ""
-
 #. first parameter is a filename like lorem-ipsum-1.0.2.xpi
 #: src/olympia/devhub/templates/devhub/validation.html:5
 msgid "Validation Results for {0}"
@@ -4448,7 +4290,7 @@ msgstr ""
 msgid "Update Compatibility"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/addons/ajax_compat_update.html:4
+#: src/olympia/devhub/templates/devhub/addons/ajax_compat_update.html:4 src/olympia/devhub/templates/devhub/versions/edit.html:45
 msgid "Adjusting application information here will allow users to install your add-on even if the install manifest in the package indicates that the add-on is incompatible."
 msgstr ""
 
@@ -4460,9 +4302,9 @@ msgstr ""
 msgid "Add Another Application&hellip;"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/addons/ajax_compat_update.html:38 src/olympia/devhub/templates/devhub/addons/owner.html:86 src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:46
-#: src/olympia/devhub/templates/devhub/versions/list.html:351 src/olympia/devhub/templates/devhub/versions/list.html:353 src/olympia/templates/impala/base.html:132
-#: src/olympia/templates/impala/base.html:143 src/olympia/templates/impala/base.html:161 src/olympia/templates/impala/base.html:171
+#: src/olympia/devhub/templates/devhub/addons/ajax_compat_update.html:38 src/olympia/devhub/templates/devhub/addons/owner.html:86 src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:45
+#: src/olympia/devhub/templates/devhub/versions/list.html:349 src/olympia/devhub/templates/devhub/versions/list.html:351 src/olympia/templates/impala/base.html:129
+#: src/olympia/templates/impala/base.html:140 src/olympia/templates/impala/base.html:158 src/olympia/templates/impala/base.html:168
 msgid "Close"
 msgstr ""
 
@@ -4482,10 +4324,6 @@ msgid "<b>{0}</b> theme"
 msgid_plural "<b>{0}</b> themes"
 msgstr[0] "<b>{0}</b> مستخدمين"
 msgstr[1] "<b>{0}</b> مستخدمين"
-msgstr[2] "<b>{0}</b> مستخدمين"
-msgstr[3] "<b>{0}</b> مستخدمين"
-msgstr[4] "<b>{0}</b> مستخدمين"
-msgstr[5] "<b>{0}</b> مستخدمين"
 
 #: src/olympia/devhub/templates/devhub/addons/edit.html:3 src/olympia/devhub/templates/devhub/addons/listing/item_actions.html:25
 #: src/olympia/devhub/templates/devhub/addons/listing/item_actions_theme.html:7 src/olympia/devhub/templates/devhub/includes/addons_edit_nav.html:2
@@ -4501,7 +4339,7 @@ msgstr ""
 msgid "Manage Authors & License"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/addons/owner.html:29 src/olympia/editors/templates/editors/review.html:270
+#: src/olympia/devhub/templates/devhub/addons/owner.html:29 src/olympia/editors/helpers.py:362 src/olympia/editors/templates/editors/review.html:270
 #, fuzzy
 msgid "Authors"
 msgstr "Authors"
@@ -4573,17 +4411,11 @@ msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/basic.html:52
 msgid ""
-"A short explanation of your add-on's basic\n"
-"                          functionality that is displayed in search and browse\n"
-"                          listings, as well as at the top of your add-on's\n"
-"                          details page. It is only relevant for listed add-ons."
+"A short explanation of your add-on's basic functionality that is displayed in search and browse listings, as well as at the top of your add-on's details page. It is only relevant for listed add-ons."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/basic.html:73
-msgid ""
-"Categories are the primary way users browse through add-ons.\n"
-"                        Choose any that fit your add-on's functionality for the most\n"
-"                        exposure. It is only relevant for listed add-ons."
+msgid "Categories are the primary way users browse through add-ons. Choose any that fit your add-on's functionality for the most exposure. It is only relevant for listed add-ons."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/basic.html:90
@@ -4593,11 +4425,7 @@ msgid ""
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/basic.html:119
-msgid ""
-"Tags help users find your add-on and should be short\n"
-"                        descriptors such as tabs, toolbar, or twitter.  You\n"
-"                        may have a maximum of {0} tags. It is only relevant\n"
-"                        for listed add-ons."
+msgid "Tags help users find your add-on and should be short descriptors such as tabs, toolbar, or twitter. You may have a maximum of {0} tags. It is only relevant for listed add-ons."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/basic.html:129 src/olympia/devhub/templates/devhub/personas/edit.html:97 src/olympia/devhub/templates/devhub/personas/submit.html:46
@@ -4605,10 +4433,6 @@ msgid "Comma-separated, minimum of {0} character."
 msgid_plural "Comma-separated, minimum of {0} characters."
 msgstr[0] ""
 msgstr[1] ""
-msgstr[2] ""
-msgstr[3] ""
-msgstr[4] ""
-msgstr[5] ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/basic.html:132 src/olympia/devhub/templates/devhub/personas/edit.html:100 src/olympia/devhub/templates/devhub/personas/submit.html:49
 msgid "Example: dark, cinema, noir. Limit 20."
@@ -4619,10 +4443,6 @@ msgid "Reserved tag:"
 msgid_plural "Reserved tags:"
 msgstr[0] ""
 msgstr[1] ""
-msgstr[2] ""
-msgstr[3] ""
-msgstr[4] ""
-msgstr[5] ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/details.html:5
 msgid "Add-on Details"
@@ -4633,11 +4453,7 @@ msgid "Add-on Details for {0}"
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/details.html:22
-msgid ""
-"A longer explanation of features,\n"
-"                          functionality, and other relevant information. This\n"
-"                          field is only displayed on the add-on's details\n"
-"                          page. It is only relevant for listed add-ons."
+msgid "A longer explanation of features, functionality, and other relevant information. This field is only displayed on the add-on's details page. It is only relevant for listed add-ons."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/details.html:44 src/olympia/translations/templates/translations/trans-menu.html:13
@@ -4646,10 +4462,7 @@ msgid "Default Locale"
 msgstr "Default Locale"
 
 #: src/olympia/devhub/templates/devhub/addons/edit/details.html:45
-msgid ""
-"Information about your add-on is displayed in this locale\n"
-"                        unless you override it with a locale-specific translation.\n"
-"                        It is only relevant for listed add-ons."
+msgid "Information about your add-on is displayed in this locale unless you override it with a locale-specific translation. It is only relevant for listed add-ons."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/details.html:61 src/olympia/users/forms.py:311 src/olympia/users/templates/users/edit.html:122 src/olympia/users/templates/users/register.html:57
@@ -4659,10 +4472,8 @@ msgstr "الموقع الإلكتروني"
 
 #: src/olympia/devhub/templates/devhub/addons/edit/details.html:63
 msgid ""
-"If your add-on has another homepage, enter its\n"
-"                          address here. If your website is localized into other\n"
-"                          languages multiple translations of this field can be\n"
-"                          added. It is only relevant for listed add-ons."
+"If your add-on has another homepage, enter its address here. If your website is localized into other languages multiple translations of this field can be added. It is only relevant for listed add-"
+"ons."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/media.html:3
@@ -4680,19 +4491,14 @@ msgstr "معلومات الدعم لـ {0}"
 
 #: src/olympia/devhub/templates/devhub/addons/edit/support.html:22
 msgid ""
-"If you wish to display an e-mail address for support\n"
-"                          inquiries, enter it here. If you have different\n"
-"                          addresses for each language multiple translations of\n"
-"                          this field can be added. It is only relevant for\n"
-"                          listed add-ons."
+"If you wish to display an e-mail address for support inquiries, enter it here. If you have different addresses for each language multiple translations of this field can be added. It is only "
+"relevant for listed add-ons."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/support.html:45
 msgid ""
-"If your add-on has a support website or forum, enter\n"
-"                          its address here. If your website is localized into\n"
-"                          other languages, multiple translations of this field can\n"
-"                          be added. It is only relevant for listed add-ons."
+"If your add-on has a support website or forum, enter its address here. If your website is localized into other languages, multiple translations of this field can be added. It is only relevant for "
+"listed add-ons."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:6
@@ -4706,11 +4512,8 @@ msgstr "التفاصيل التقنية لـ {0}"
 
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:23
 msgid ""
-"Any information end users may want to know that isn't\n"
-"                          necessarily applicable to the add-on summary or description.\n"
-"                          Common uses include listing known major bugs, information on\n"
-"                          how to report bugs, anticipated release date of a new version,\n"
-"                          etc. It is only relevant for listed add-ons."
+"Any information end users may want to know that isn't necessarily applicable to the add-on summary or description. Common uses include listing known major bugs, information on how to report bugs, "
+"anticipated release date of a new version, etc. It is only relevant for listed add-ons."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:46
@@ -4722,9 +4525,7 @@ msgid "Add-on Flags"
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:69
-msgid ""
-"These flags are used to classify add-ons. It is only\n"
-"                        relevant for listed add-ons."
+msgid "These flags are used to classify add-ons. It is only relevant for listed add-ons."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:74
@@ -4740,9 +4541,7 @@ msgid "View Source?"
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:90
-msgid ""
-"Whether the source of your add-on can be displayed in our\n"
-"                        online viewer. It is only relevant for listed add-ons."
+msgid "Whether the source of your add-on can be displayed in our online viewer. It is only relevant for listed add-ons."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:94
@@ -4758,10 +4557,7 @@ msgid "Public Stats?"
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:102
-msgid ""
-"Whether the download and usage stats of your add-on can\n"
-"                        be displayed in our online viewer.\n"
-"                        It is only relevant for listed add-ons."
+msgid "Whether the download and usage stats of your add-on can be displayed in our online viewer. It is only relevant for listed add-ons."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:107
@@ -4777,10 +4573,7 @@ msgid "Upgrade SDK?"
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:116
-msgid ""
-"If selected, we will try to automatically upgrade your\n"
-"                        add-on when a new version of the SDK is released.\n"
-"                        It is only relevant for listed add-ons."
+msgid "If selected, we will try to automatically upgrade your add-on when a new version of the SDK is released. It is only relevant for listed add-ons."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:121
@@ -4831,10 +4624,8 @@ msgstr "إيقونة الإضافة"
 
 #: src/olympia/devhub/templates/devhub/addons/forms_shared/media.html:16
 msgid ""
-"Upload an icon for your add-on or choose from one of ours. The\n"
-"                      icon is displayed nearly everywhere your add-on is. Uploaded images\n"
-"                      must be one of the following image types: .png, .jpg.\n"
-"                      It is only relevant for listed add-ons."
+"Upload an icon for your add-on or choose from one of ours. The icon is displayed nearly everywhere your add-on is. Uploaded images must be one of the following image types: .png, .jpg. It is only "
+"relevant for listed add-ons."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/forms_shared/media.html:25
@@ -4847,9 +4638,7 @@ msgid "32x32px"
 msgstr "32x32 بكسل"
 
 #: src/olympia/devhub/templates/devhub/addons/forms_shared/media.html:39
-msgid ""
-"Used in listings of add-ons, like search results\n"
-"                            and featured add-ons."
+msgid "Used in listings of add-ons, like search results and featured add-ons."
 msgstr ""
 
 #. The size of the icon
@@ -4944,16 +4733,14 @@ msgid "Deleting your add-on will permanently remove it from the site and prevent
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:24
-msgid ""
-"Enter the following text confirm your decision:\n"
-"           {slug}"
+msgid "Enter the following text confirm your decision: {slug}"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:34
+#: src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:33
 msgid "Please tell us why you are deleting your theme:"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:36
+#: src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:35
 msgid "Please tell us why you are deleting your add-on:"
 msgstr ""
 
@@ -4990,8 +4777,8 @@ msgstr "إصدارة جديدة"
 msgid "Daily statistics on downloads and users."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/addons/listing/item_actions.html:45 src/olympia/stats/templates/stats/stats.html:75 src/olympia/stats/templates/stats/stats.html:79
-#: src/olympia/stats/templates/stats/stats.html:81
+#: src/olympia/devhub/templates/devhub/addons/listing/item_actions.html:45 src/olympia/stats/templates/stats/stats.html:31 src/olympia/stats/templates/stats/stats.html:35
+#: src/olympia/stats/templates/stats/stats.html:37
 msgid "Statistics"
 msgstr "الإحصائيات"
 
@@ -5052,10 +4839,6 @@ msgid "<strong>{0}</strong> active user"
 msgid_plural "<strong>{0}</strong> active users"
 msgstr[0] "لا مستخدمين نشطين"
 msgstr[1] "مستخدم واحد نشط"
-msgstr[2] "مستخدمين أثنين نشطين"
-msgstr[3] "<strong>{0}</strong> مستخدين نشطين"
-msgstr[4] "<strong>{0}</strong> مستخدما نشطا"
-msgstr[5] "<strong>{0}</strong> مستخدم نشط"
 
 #: src/olympia/devhub/templates/devhub/addons/submit/base.html:11
 msgid "Submit Add-on"
@@ -5114,10 +4897,7 @@ msgid "Your add-on has been submitted to the Full Review queue."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/submit/done.html:18
-msgid ""
-"You'll receive an email once it has been reviewed by an editor. In\n"
-"          the meantime, you and your friends can install it directly from its\n"
-"          details page:"
+msgid "You'll receive an email once it has been reviewed by an editor. In the meantime, you and your friends can install it directly from its details page:"
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/submit/done.html:27 src/olympia/devhub/templates/devhub/addons/submit/done.html:77 src/olympia/devhub/templates/devhub/personas/submit_done.html:16
@@ -5323,11 +5103,11 @@ msgstr ""
 msgid "Use the fields below to upload your add-on package and select any platform restrictions. After upload, a series of automated validation tests will be run on your file."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/addons/submit/upload.html:59 src/olympia/devhub/templates/devhub/versions/add_file_modal.html:39
+#: src/olympia/devhub/templates/devhub/addons/submit/upload.html:51 src/olympia/devhub/templates/devhub/versions/add_file_modal.html:28
 msgid "Which platforms is this file compatible with?"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/addons/submit/upload.html:67 src/olympia/devhub/templates/devhub/versions/add_file_modal.html:65
+#: src/olympia/devhub/templates/devhub/addons/submit/upload.html:59 src/olympia/devhub/templates/devhub/versions/add_file_modal.html:45
 msgid "Administrative overrides"
 msgstr ""
 
@@ -5437,8 +5217,8 @@ msgstr ""
 
 #: src/olympia/devhub/templates/devhub/docs/policies-contact.html:44
 msgid ""
-"If you've found a problem with the site, we'd love to fix it. Please <a href=\"https://github.com/mozilla/olympia/issues\">file a bug report</a> in GitHub, including the location of the problem and "
-"how you encountered it."
+"If you've found a problem with the site, we'd love to fix it. Please <a href=\"https://github.com/mozilla/addons/issues/new\">file a bug report</a> in GitHub, including the location of the problem "
+"and how you encountered it."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/docs/policies-maintenance.html:3 src/olympia/devhub/templates/devhub/docs/policies-maintenance.html:7
@@ -6005,7 +5785,7 @@ msgstr ""
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:282
 msgid ""
-"Add-ons that store or otherwise handle browsing data must support <a href=\"https://developer.mozilla.org/En/Supporting_private_browsing_mode\">Private Browsing Mode</a>.  During a Private Browsing "
+"Add-ons that store or otherwise handle browsing data must support <a href=\"https://developer.mozilla.org/En/Supporting_private_browsing_mode\">Private Browsing Mode</a>. During a Private Browsing "
 "session, no browsing data can be written to disk, and all of this data must be cleared when Firefox quits or the Private Browsing session ends."
 msgstr ""
 
@@ -6170,129 +5950,95 @@ msgstr ""
 msgid "How to get in touch with us regarding these policies or your add-on."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:6
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:10
 msgid "You have disabled this add-on"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:20
-msgid ""
-"Your add-on's listing is disabled and is not showing\n"
-"                             anywhere in our gallery or update service."
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:24
+msgid "Your add-on's listing is disabled and is not showing anywhere in our gallery or update service."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:25
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:27
 msgid "Please complete your add-on."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:29
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:30
 msgid "You will receive an email when the review is complete."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:34
-msgid ""
-"You will receive an email when the review is complete. Until\n"
-"                             then, your add-on is not listed in our gallery but can be\n"
-"                             accessed directly from its details page."
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:33
+msgid "You will receive an email when the review is complete. Until then, your add-on is not listed in our gallery but can be accessed directly from its details page."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:38 src/olympia/devhub/templates/devhub/includes/addon_details.html:48
-msgid ""
-"You will receive an email when the review is\n"
-"                             complete and your add-on is signed."
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:37 src/olympia/devhub/templates/devhub/includes/addon_details.html:45
+msgid "You will receive an email when the review is complete and your add-on is signed."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:44
-msgid ""
-"You will receive an email when the review is complete. Until\n"
-"                             then, your add-on is not listed in our gallery but can be\n"
-"                             accessed directly from its details page. "
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:41
+msgid "You will receive an email when the review is complete. Until then, your add-on is not listed in our gallery but can be accessed directly from its details page. "
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:54
-msgid ""
-"Your add-on is displayed in our gallery and users are\n"
-"                             receiving automatic updates."
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:49
+msgid "Your add-on is displayed in our gallery and users are receiving automatic updates."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:57
-msgid ""
-"Your add-on has been signed and can be bundled with an\n"
-"                             application installer."
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:52
+msgid "Your add-on has been signed and can be bundled with an application installer."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:63
-msgid ""
-"Your add-on was disabled by a site administrator and is no\n"
-"                             longer shown in our gallery. If you have any questions,\n"
-"                             please email amo-admins@mozilla.org."
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:56
+msgid "Your add-on was disabled by a site administrator and is no longer shown in our gallery. If you have any questions, please email amo-admins@mozilla.org."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:70
-msgid ""
-"Your add-on is displayed in our gallery as experimental\n"
-"                             and users are receiving automatic updates. Some features\n"
-"                             are unavailable to your add-on."
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:62
+msgid "Your add-on is displayed in our gallery as experimental and users are receiving automatic updates. Some features are unavailable to your add-on."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:74
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:66
 msgid "Your add-on has been signed."
 msgstr ""
 
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:69
+msgid ""
+"You will receive an email when the full review is complete. Until then, your add-on is displayed in our gallery as experimental and users are receiving automatic updates. Some features are "
+"unavailable to your add-on."
+msgstr ""
+
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:74
+msgid "You will receive an email when the full review is complete, making you able to bundle your add-on with an application installer."
+msgstr ""
+
 #: src/olympia/devhub/templates/devhub/includes/addon_details.html:79
-msgid ""
-"You will receive an email when the full review is complete.\n"
-"                             Until then, your add-on is displayed in our gallery as\n"
-"                             experimental and users are receiving automatic updates.\n"
-"                             Some features are unavailable to your add-on."
+msgid "All add-ons hosted in our gallery must now be reviewed by an editor. If you wish to continue hosting your add-on, please click to select a review process."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:84
-msgid ""
-"You will receive an email when the full review is\n"
-"                             complete, making you able to bundle your add-on with an\n"
-"                             application installer."
-msgstr ""
-
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:91
-msgid ""
-"All add-ons hosted in our gallery must now be reviewed by an\n"
-"                             editor. If you wish to continue hosting your add-on, please\n"
-"                             click to select a review process."
-msgstr ""
-
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:113
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:100
 msgid "Current Version:"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:115
-msgid ""
-"This is the version of your add-on that will\n"
-"                                           be installed if someone clicks the Install\n"
-"                                           button on addons.mozilla.org. It is only\n"
-"                                           relevant for listed add-ons."
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:102
+msgid "This is the version of your add-on that will be installed if someone clicks the Install button on addons.mozilla.org. It is only relevant for listed add-ons."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:123
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:110
 msgid "Created:"
 msgstr ""
 
 #. {0} is a date. dennis-ignore: E201
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:125 src/olympia/devhub/templates/devhub/includes/addon_details.html:131
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:112 src/olympia/devhub/templates/devhub/includes/addon_details.html:118
 #, python-format
 msgid "%%b %%e, %%Y"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:136
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:123
 msgid "Next Version:"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:138
-msgid ""
-"This is the newest uploaded version, however\n"
-"                                           it isn’t live on the site yet."
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:125
+msgid "This is the newest uploaded version, however it isn’t live on the site yet."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:144 src/olympia/devhub/templates/devhub/versions/list.html:30
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:130 src/olympia/devhub/templates/devhub/versions/list.html:30
 msgid "Queues are not reviewed strictly in order"
 msgstr ""
 
@@ -6360,9 +6106,7 @@ msgid "View the blog &#9658;"
 msgstr "شاهد المدوّنة ◄"
 
 #: src/olympia/devhub/templates/devhub/includes/license_form.html:6
-msgid ""
-"Please choose a license appropriate for the rights you grant on your source code.\n"
-"                  It is only relevant for listed add-ons."
+msgid "Please choose a license appropriate for the rights you grant on your source code. It is only relevant for listed add-ons."
 msgstr ""
 
 #. {0} is a list of HTML tags.
@@ -6385,22 +6129,15 @@ msgid "Select <b>up to {0}</b> {1} category for this add-on:"
 msgid_plural "Select <b>up to {0}</b> {1} categories for this add-on:"
 msgstr[0] ""
 msgstr[1] ""
-msgstr[2] ""
-msgstr[3] ""
-msgstr[4] ""
-msgstr[5] ""
 
 #: src/olympia/devhub/templates/devhub/includes/policy_form.html:4
 msgid ""
 "Users will be required to accept the following End-User License Agreement (EULA) prior to installing your add-on. The presence of a EULA significantly affects the number of downloads an add-on "
-"receives. Please note that a EULA is not the same as a code license, such as the GPL or MPL.\n"
-"                It is only relevant for listed add-ons."
+"receives. Please note that a EULA is not the same as a code license, such as the GPL or MPL.It is only relevant for listed add-ons."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/policy_form.html:21
-msgid ""
-"If your add-on transmits any data from the user's computer, a privacy policy is required that explains what data is sent and how it is used.\n"
-"                It is only relevant for listed add-ons."
+#: src/olympia/devhub/templates/devhub/includes/policy_form.html:24
+msgid "If your add-on transmits any data from the user's computer, a privacy policy is required that explains what data is sent and how it is used. It is only relevant for listed add-ons."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/includes/source_form_field.html:2
@@ -6570,12 +6307,8 @@ msgstr "اختر التصنيف الذي يصف السِمة أفضل وصف."
 msgid "Add some tags to describe your Theme."
 msgstr "صِف السمة."
 
-#: src/olympia/devhub/templates/devhub/personas/edit.html:106
-msgid ""
-"A short explanation of your theme's\n"
-"                                basic functionality that is displayed in\n"
-"                                search and browse listings, as well as at\n"
-"                                the top of your theme's details page."
+#: src/olympia/devhub/templates/devhub/personas/edit.html:106 src/olympia/devhub/templates/devhub/personas/submit.html:54
+msgid "A short explanation of your theme's basic functionality that is displayed in search and browse listings, as well as at the top of your theme's details page."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/personas/edit.html:122 src/olympia/devhub/templates/devhub/personas/submit.html:68
@@ -6647,7 +6380,7 @@ msgid "Upon upload and form submission, the AMO Team will review your updated de
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/personas/edit.html:241
-msgid "Your previously resubmitted design,  which is under pending review."
+msgid "Your previously resubmitted design, which is under pending review."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/personas/edit.html:245
@@ -6718,14 +6451,6 @@ msgstr ""
 #, fuzzy
 msgid "Give your Theme a name."
 msgstr "أعط اسما لمجموعتك."
-
-#: src/olympia/devhub/templates/devhub/personas/submit.html:54
-msgid ""
-"A short explanation of your theme's\n"
-"                                      basic functionality that is displayed in\n"
-"                                      search and browse listings, as well as at\n"
-"                                      the top of your theme's details page."
-msgstr ""
 
 #: src/olympia/devhub/templates/devhub/personas/submit.html:198
 #, python-format
@@ -6801,30 +6526,16 @@ msgstr ""
 msgid "Files added to reviewed versions must be reviewed before they will be available for download."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/add_file_modal.html:15
-#, python-format
-msgid ""
-"Submission of updates to unlisted add-ons for signing is currently in an open beta. Manual review may still be required for a large number of add-ons. Please <a href=\"%(url)s\" target=\"_blank"
-"\">report any bugs</a> that you encounter."
-msgstr ""
-
-#: src/olympia/devhub/templates/devhub/versions/add_file_modal.html:35
+#: src/olympia/devhub/templates/devhub/versions/add_file_modal.html:24
 msgid "Select the target platform for this file."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/add_file_modal.html:46
+#: src/olympia/devhub/templates/devhub/versions/add_file_modal.html:35
 msgid "Which review type would you like to nominate for?"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/add_file_modal.html:51
+#: src/olympia/devhub/templates/devhub/versions/add_file_modal.html:40
 msgid "Only publish this version to my beta channel."
-msgstr ""
-
-#: src/olympia/devhub/templates/devhub/versions/add_file_modal.html:54
-#, python-format
-msgid ""
-"The behavior of the beta channel has changed to accommodate <a href=\"%(addon_signing_url)s\" target=\"_blank\">mandatory add-on signing</a>. The new process is currently in an open beta, and may "
-"change significantly in the near future. Please <a href=\"%(issues_url)s\" target=\"_blank\">report any bugs</a> that you encounter."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/versions/edit.html:5
@@ -6850,19 +6561,10 @@ msgstr ""
 msgid "Upload Another File"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/edit.html:45
-msgid ""
-"Adjusting application information here will allow users to install your\n"
-"                          add-on even if the install manifest in the package indicates that the\n"
-"                          add-on is incompatible."
-msgstr ""
-
 #: src/olympia/devhub/templates/devhub/versions/edit.html:74
 msgid ""
-"Information about changes in this release, new features,\n"
-"                              known bugs, and other useful information specific to this\n"
-"                              release/version. This information is also shown in the\n"
-"                              Add-ons Manager when updating."
+"Information about changes in this release, new features, known bugs, and other useful information specific to this release/version. This information is also shown in the Add-ons Manager when "
+"updating."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/versions/edit.html:99
@@ -6874,10 +6576,7 @@ msgid "Notes for Reviewers"
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/versions/edit.html:114
-msgid ""
-"Optionally, enter any information that may be useful\n"
-"                              to the Editor reviewing this add-on, such as test\n"
-"                              account information."
+msgid "Optionally, enter any information that may be useful to the Editor reviewing this add-on, such as test account information."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/versions/edit.html:127
@@ -6929,10 +6628,6 @@ msgid "{0} file"
 msgid_plural "{0} files"
 msgstr[0] ""
 msgstr[1] ""
-msgstr[2] ""
-msgstr[3] ""
-msgstr[4] ""
-msgstr[5] ""
 
 #: src/olympia/devhub/templates/devhub/versions/list.html:25
 msgid "0 files"
@@ -6959,7 +6654,7 @@ msgstr ""
 msgid "Request Preliminary Review"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:80 src/olympia/devhub/templates/devhub/versions/list.html:327 src/olympia/devhub/templates/devhub/versions/list.html:350
+#: src/olympia/devhub/templates/devhub/versions/list.html:80 src/olympia/devhub/templates/devhub/versions/list.html:325 src/olympia/devhub/templates/devhub/versions/list.html:348
 msgid "Cancel Review Request"
 msgstr ""
 
@@ -6988,7 +6683,7 @@ msgid "Unlisted:"
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/versions/list.html:114
-msgid "Not distributed on {0}. Developers will upload new versions for signing and distribute the add-ons on their own. (beta)"
+msgid "Not distributed on {0}. Developers will upload new versions for signing and distribute the add-ons on their own."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/versions/list.html:122
@@ -7053,81 +6748,73 @@ msgid "<strong>Important:</strong> Once a version has been deleted, you may not 
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/versions/list.html:230
-msgid ""
-"Deleting a version which has already been reviewed\n"
-"               may also cause a significant delay in the review of\n"
-"               your next update."
-msgstr ""
-
-#: src/olympia/devhub/templates/devhub/versions/list.html:233
 msgid "Are you sure you wish to delete this version?"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:238
+#: src/olympia/devhub/templates/devhub/versions/list.html:235
 msgid "Delete Version"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:240
+#: src/olympia/devhub/templates/devhub/versions/list.html:237
 msgid "Disable Version"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:247
+#: src/olympia/devhub/templates/devhub/versions/list.html:244
 msgid "Add a new Version"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:249
+#: src/olympia/devhub/templates/devhub/versions/list.html:246
 msgid "Add Version"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:256 src/olympia/devhub/templates/devhub/versions/list.html:274
+#: src/olympia/devhub/templates/devhub/versions/list.html:253 src/olympia/devhub/templates/devhub/versions/list.html:279
 msgid "Hide Add-on"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:259
+#: src/olympia/devhub/templates/devhub/versions/list.html:256
 msgid "Hiding your add-on will prevent it from appearing anywhere in our gallery and will stop users from receiving automatic updates."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:265
+#: src/olympia/devhub/templates/devhub/versions/list.html:263
+msgid "The files awaiting review will be disabled and you will need to upload new versions."
+msgstr ""
+
+#: src/olympia/devhub/templates/devhub/versions/list.html:270
 msgid "Are you sure you wish to hide your add-on?"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:286 src/olympia/devhub/templates/devhub/versions/list.html:315
+#: src/olympia/devhub/templates/devhub/versions/list.html:291 src/olympia/devhub/templates/devhub/versions/list.html:313
 msgid "Unlist Add-on"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:289
+#: src/olympia/devhub/templates/devhub/versions/list.html:294
 #, python-format
 msgid ""
 "Unlisting your add-on will make it (and each of its versions/files) invisible on this website. It won't show up in searches, won't have a public facing page, and won't be updated automatically for "
-"current users.  It is recommended for unlisted add-ons to provide a custom <a href=\"%(update_url)s\" target=\"_blank\">updateURL</a> in their manifest file for automatic updates."
+"current users. It is recommended for unlisted add-ons to provide a custom <a href=\"%(update_url)s\" target=\"_blank\">updateURL</a> in their manifest file for automatic updates."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:299
-#, python-format
-msgid "Switching add-ons to unlisted is currently in an open beta. Please <a href=\"%(url)s\" target=\"_blank\">report any bugs</a> that you encounter."
-msgstr ""
-
-#: src/olympia/devhub/templates/devhub/versions/list.html:305
+#: src/olympia/devhub/templates/devhub/versions/list.html:303
 msgid "Unlisting an add-on is irreversible!"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:305
+#: src/olympia/devhub/templates/devhub/versions/list.html:303
 msgid "An unlisted add-on cannot be switched to be listed."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:307
+#: src/olympia/devhub/templates/devhub/versions/list.html:305
 msgid "Are you sure you wish to unlist your add-on?"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:330
+#: src/olympia/devhub/templates/devhub/versions/list.html:328
 msgid "Canceling your review request will leave your add-on as preliminarily reviewed."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:335
+#: src/olympia/devhub/templates/devhub/versions/list.html:333
 msgid "Canceling your review request will mark your add-on incomplete. If you do not complete your add-on after several days by re-requesting review, it will be deleted."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:343
+#: src/olympia/devhub/templates/devhub/versions/list.html:341
 msgid "Are you sure you wish to cancel your review request?"
 msgstr ""
 
@@ -7469,19 +7156,19 @@ msgstr ""
 msgid "Search by add-on name / author email"
 msgstr "بحث باسم الإضافة أو البريد الإلكتروني للمؤلف"
 
-#: src/olympia/editors/forms.py:103
+#: src/olympia/editors/forms.py:103 src/olympia/editors/forms.py:244 src/olympia/editors/forms.py:257
 msgid "yes"
 msgstr "نعم"
 
-#: src/olympia/editors/forms.py:104
+#: src/olympia/editors/forms.py:104 src/olympia/editors/forms.py:244 src/olympia/editors/forms.py:257
 msgid "no"
 msgstr "لا"
 
-#: src/olympia/editors/forms.py:105
+#: src/olympia/editors/forms.py:105 src/olympia/editors/forms.py:245
 msgid "Admin Flag"
 msgstr ""
 
-#: src/olympia/editors/forms.py:113
+#: src/olympia/editors/forms.py:113 src/olympia/editors/forms.py:253
 msgid "Max. Version"
 msgstr ""
 
@@ -7493,55 +7180,59 @@ msgstr ""
 msgid "Add-on Types"
 msgstr "أنواع الإضافات"
 
-#: src/olympia/editors/forms.py:126 src/olympia/editors/helpers.py:267
+#: src/olympia/editors/forms.py:126 src/olympia/editors/helpers.py:279
 msgid "Platforms"
 msgstr "المنصات"
 
+#: src/olympia/editors/forms.py:237
+msgid "Search by add-on name / author email / guid"
+msgstr ""
+
 #. L10n: 0 = platform, 1 = filename, 2 = status message
-#: src/olympia/editors/forms.py:238
+#: src/olympia/editors/forms.py:342
 #, python-format
 msgid "<strong>%s</strong> &middot; %s &middot; %s"
 msgstr "<strong>%s</strong> &middot; %s &middot; %s"
 
-#: src/olympia/editors/forms.py:252
+#: src/olympia/editors/forms.py:356
 msgid "Comments:"
 msgstr "التعليقات:"
 
-#: src/olympia/editors/forms.py:256
+#: src/olympia/editors/forms.py:360
 msgid "Operating systems:"
 msgstr "أنظمة التشغيل:"
 
-#: src/olympia/editors/forms.py:258
+#: src/olympia/editors/forms.py:362
 msgid "Applications:"
 msgstr "التطبيقات:"
 
-#: src/olympia/editors/forms.py:260
+#: src/olympia/editors/forms.py:364
 msgid "Notify me the next time this add-on is updated. (Subsequent updates will not generate an email)"
 msgstr "نبّهني عند وجود تحديث لهذه الإضافة (التحديثات اللاحقة لن تتسبب بإرسال رسالة)."
 
-#: src/olympia/editors/forms.py:265
+#: src/olympia/editors/forms.py:369
 msgid "Clear Admin Review Flag"
 msgstr ""
 
-#: src/olympia/editors/forms.py:267
+#: src/olympia/editors/forms.py:371
 msgid "Clear more info requested flag"
 msgstr ""
 
-#: src/olympia/editors/forms.py:281
+#: src/olympia/editors/forms.py:385
 msgid "Choose a canned response..."
 msgstr ""
 
 #. L10n: Description of what can be searched for.
-#: src/olympia/editors/forms.py:324
+#: src/olympia/editors/forms.py:423
 msgid "theme name"
 msgstr ""
 
-#: src/olympia/editors/forms.py:350
+#: src/olympia/editors/forms.py:449
 msgid "Someone else is reviewing this theme."
 msgstr ""
 
 #. L10n: Description of what can be searched for.
-#: src/olympia/editors/forms.py:447
+#: src/olympia/editors/forms.py:546
 msgid "app, reviewer, or comment"
 msgstr ""
 
@@ -7557,291 +7248,265 @@ msgstr ""
 msgid "Rejected or Unreviewed"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:123 src/olympia/editors/helpers.py:136
+#: src/olympia/editors/helpers.py:125 src/olympia/editors/helpers.py:138
 msgid "Queue"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:124 src/olympia/editors/templates/editors/base.html:50 src/olympia/editors/templates/editors/base.html:65
+#: src/olympia/editors/helpers.py:126 src/olympia/editors/templates/editors/base.html:50 src/olympia/editors/templates/editors/base.html:65
 msgid "Pending Updates"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:125 src/olympia/editors/templates/editors/base.html:48 src/olympia/editors/templates/editors/base.html:63
+#: src/olympia/editors/helpers.py:127 src/olympia/editors/templates/editors/base.html:48 src/olympia/editors/templates/editors/base.html:63
 msgid "Full Reviews"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:126 src/olympia/editors/templates/editors/base.html:52 src/olympia/editors/templates/editors/base.html:67
+#: src/olympia/editors/helpers.py:128 src/olympia/editors/templates/editors/base.html:52 src/olympia/editors/templates/editors/base.html:67
 msgid "Preliminary Reviews"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:127 src/olympia/editors/templates/editors/base.html:54
+#: src/olympia/editors/helpers.py:129 src/olympia/editors/templates/editors/base.html:54
 msgid "Moderated Reviews"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:128 src/olympia/editors/templates/editors/base.html:46
+#: src/olympia/editors/helpers.py:130 src/olympia/editors/templates/editors/base.html:46
 msgid "Fast Track"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:130
+#: src/olympia/editors/helpers.py:132
 msgid "Pending Themes"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:131 src/olympia/editors/templates/editors/themes/queue.html:4
+#: src/olympia/editors/helpers.py:133 src/olympia/editors/templates/editors/themes/queue.html:4
 msgid "Flagged Themes"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:132
+#: src/olympia/editors/helpers.py:134
 msgid "Update Themes"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:137
+#: src/olympia/editors/helpers.py:139
 msgid "Unlisted Pending Updates"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:138
+#: src/olympia/editors/helpers.py:140
 msgid "Unlisted Full Reviews"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:139
+#: src/olympia/editors/helpers.py:141
 msgid "Unlisted Preliminary Reviews"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:170
+#: src/olympia/editors/helpers.py:142
+msgid "Unlisted All Add-ons"
+msgstr ""
+
+#: src/olympia/editors/helpers.py:173
 msgid "Fast Track ({0})"
 msgid_plural "Fast Track ({0})"
 msgstr[0] ""
 msgstr[1] ""
-msgstr[2] ""
-msgstr[3] ""
-msgstr[4] ""
-msgstr[5] ""
 
-#: src/olympia/editors/helpers.py:175
+#: src/olympia/editors/helpers.py:178
 msgid "Full Review ({0})"
 msgid_plural "Full Reviews ({0})"
 msgstr[0] ""
 msgstr[1] ""
-msgstr[2] ""
-msgstr[3] ""
-msgstr[4] ""
-msgstr[5] ""
 
-#: src/olympia/editors/helpers.py:180
+#: src/olympia/editors/helpers.py:183
 msgid "Pending Update ({0})"
 msgid_plural "Pending Updates ({0})"
 msgstr[0] ""
 msgstr[1] ""
-msgstr[2] ""
-msgstr[3] ""
-msgstr[4] ""
-msgstr[5] ""
 
-#: src/olympia/editors/helpers.py:185
+#: src/olympia/editors/helpers.py:188
 msgid "Preliminary Review ({0})"
 msgid_plural "Preliminary Reviews ({0})"
 msgstr[0] ""
 msgstr[1] ""
-msgstr[2] ""
-msgstr[3] ""
-msgstr[4] ""
-msgstr[5] ""
 
-#: src/olympia/editors/helpers.py:190
+#: src/olympia/editors/helpers.py:193
 msgid "Moderated Review ({0})"
 msgid_plural "Moderated Reviews ({0})"
 msgstr[0] ""
 msgstr[1] ""
-msgstr[2] ""
-msgstr[3] ""
-msgstr[4] ""
-msgstr[5] ""
 
-#: src/olympia/editors/helpers.py:196
+#: src/olympia/editors/helpers.py:199
 msgid "Unlisted Full Review ({0})"
 msgid_plural "Unlisted Full Reviews ({0})"
 msgstr[0] ""
 msgstr[1] ""
-msgstr[2] ""
-msgstr[3] ""
-msgstr[4] ""
-msgstr[5] ""
 
-#: src/olympia/editors/helpers.py:201
+#: src/olympia/editors/helpers.py:204
 msgid "Unlisted Pending Update ({0})"
 msgid_plural "Unlisted Pending Updates ({0})"
 msgstr[0] ""
 msgstr[1] ""
-msgstr[2] ""
-msgstr[3] ""
-msgstr[4] ""
-msgstr[5] ""
 
-#: src/olympia/editors/helpers.py:206
+#: src/olympia/editors/helpers.py:209
 msgid "Unlisted Preliminary Review ({0})"
 msgid_plural "Unlisted Preliminary Reviews ({0})"
 msgstr[0] ""
 msgstr[1] ""
-msgstr[2] ""
-msgstr[3] ""
-msgstr[4] ""
-msgstr[5] ""
 
-#: src/olympia/editors/helpers.py:261
-msgid "Addon"
-msgstr ""
+#: src/olympia/editors/helpers.py:214
+msgid "Unlisted All Add-ons ({0})"
+msgid_plural "Unlisted All Add-ons ({0})"
+msgstr[0] ""
+msgstr[1] ""
 
-#: src/olympia/editors/helpers.py:262
+#: src/olympia/editors/helpers.py:274
 msgid "Type"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:263
+#: src/olympia/editors/helpers.py:275
 msgid "Waiting Time"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:264 src/olympia/editors/templates/editors/review.html:285
+#: src/olympia/editors/helpers.py:276 src/olympia/editors/templates/editors/review.html:285
 #, fuzzy
 msgid "Flags"
 msgstr "Flags"
 
-#: src/olympia/editors/helpers.py:265
+#: src/olympia/editors/helpers.py:277
 msgid "Applications"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:270
+#: src/olympia/editors/helpers.py:282
 msgid "Additional"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:285
+#: src/olympia/editors/helpers.py:302
 msgid "Site Specific"
 msgstr "مختص بموقع معيّن"
 
-#: src/olympia/editors/helpers.py:287
+#: src/olympia/editors/helpers.py:304
 msgid "Requires External Software"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:289
+#: src/olympia/editors/helpers.py:306
 msgid "Binary Components"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:313
+#: src/olympia/editors/helpers.py:339
 msgid "moments ago"
 msgstr "لحظات مضت"
 
 #. L10n: first argument is number of minutes
-#: src/olympia/editors/helpers.py:316
+#: src/olympia/editors/helpers.py:342
 msgid "{0} minute"
 msgid_plural "{0} minutes"
 msgstr[0] "أقل من دقيقة"
 msgstr[1] "دقيقة واحدة"
-msgstr[2] "دقيقتان"
-msgstr[3] "{0} دقائق"
-msgstr[4] "{0} دقيقة"
-msgstr[5] "{0} دقيقة"
 
 #. L10n: first argument is number of hours
-#: src/olympia/editors/helpers.py:320
+#: src/olympia/editors/helpers.py:346
 msgid "{0} hour"
 msgid_plural "{0} hours"
 msgstr[0] "أقل من ساعة"
 msgstr[1] "ساعة واحدة"
-msgstr[2] "ساعتان"
-msgstr[3] "{0} ساعات"
-msgstr[4] "{0} ساعة"
-msgstr[5] "{0} ساعة"
 
 #. L10n: first argument is number of days
-#: src/olympia/editors/helpers.py:324
+#: src/olympia/editors/helpers.py:350
 msgid "{0} day"
 msgid_plural "{0} days"
 msgstr[0] "أقل من يوم"
 msgstr[1] "يوم واحد"
-msgstr[2] "يومان"
-msgstr[3] "{0} أيام"
-msgstr[4] "{0} يوما"
-msgstr[5] "{0} يوم"
 
-#: src/olympia/editors/helpers.py:488
+#: src/olympia/editors/helpers.py:364
+msgid "Last Review"
+msgstr ""
+
+#: src/olympia/editors/helpers.py:366
+msgid "Last Update"
+msgstr ""
+
+#: src/olympia/editors/helpers.py:387
+msgid "No Reviews"
+msgstr ""
+
+#: src/olympia/editors/helpers.py:561
 msgid "Push to public"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:490
+#: src/olympia/editors/helpers.py:563
 msgid "Grant full review"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:505
+#: src/olympia/editors/helpers.py:578
 msgid "Request more information"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:508
+#: src/olympia/editors/helpers.py:581
 msgid "Request super-review"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:519
+#: src/olympia/editors/helpers.py:592
 msgid "Grant preliminary review"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:520
+#: src/olympia/editors/helpers.py:593
 msgid "This will mark the files as preliminarily reviewed."
 msgstr ""
 
-#: src/olympia/editors/helpers.py:522
+#: src/olympia/editors/helpers.py:595
 msgid "Use this form to request more information from the author. They will receive an email and be able to answer here. You will be notified by email when they reply."
 msgstr "استخدم هذا النموذج لطلب المزيد من المعلومات من المؤلف. سيستلم المؤلف رسالة ليتمكن من الإجابة هنا، وستستلم إشعارًا بريديًا عندما يجيب."
 
-#: src/olympia/editors/helpers.py:526
+#: src/olympia/editors/helpers.py:599
 msgid ""
 "If you have concerns about this add-on's security, copyright issues, or other concerns that an administrator should look into, enter your comments in the area below. They will be sent to "
 "administrators, not the author."
 msgstr "إن كنتَ مهتمًا بخصوص أمن هذه الإضافة أو شؤون حقوق نسخها أو أي أمور أخرى ينبغي للمدير أن يطلع عليها، أدخِل تعليقاتك في المساحة أدناه، وستُرسل إلى المدراء لا إلى المؤلف."
 
-#: src/olympia/editors/helpers.py:532
+#: src/olympia/editors/helpers.py:605
 msgid "This will reject the add-on and remove it from the review queue."
 msgstr "سيؤدي ذلك لرفض الإضافة وإزالتها من قائمة المراجعة."
 
-#: src/olympia/editors/helpers.py:534
-msgid "Make a comment on this version.  The author won't be able to see this."
+#: src/olympia/editors/helpers.py:607
+msgid "Make a comment on this version. The author won't be able to see this."
 msgstr ""
 
-#: src/olympia/editors/helpers.py:538
+#: src/olympia/editors/helpers.py:611
 msgid "This will reject the files and remove them from the review queue."
 msgstr ""
 
-#: src/olympia/editors/helpers.py:542
+#: src/olympia/editors/helpers.py:615
 msgid "This will mark the add-on as preliminarily reviewed. Future versions will undergo preliminary review."
 msgstr ""
 
-#: src/olympia/editors/helpers.py:547
+#: src/olympia/editors/helpers.py:620
 msgid "This will mark the files as preliminarily reviewed. Future versions will undergo preliminary review."
 msgstr ""
 
-#: src/olympia/editors/helpers.py:552
+#: src/olympia/editors/helpers.py:625
 msgid "Retain preliminary review"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:553
+#: src/olympia/editors/helpers.py:626
 msgid "This will retain the add-on as preliminarily reviewed. Future versions will undergo preliminary review."
 msgstr ""
 
-#: src/olympia/editors/helpers.py:558
+#: src/olympia/editors/helpers.py:631
 msgid "This will approve a sandboxed version of a public add-on to appear on the public side."
 msgstr "هذا سيعطي الإذن لنسخة ساحة لعب من إضافة عامة بأن تُنشر في الساحة العامة."
 
-#: src/olympia/editors/helpers.py:561
+#: src/olympia/editors/helpers.py:634
 msgid "This will reject a version of a public add-on and remove it from the queue."
 msgstr ""
 
-#: src/olympia/editors/helpers.py:564
+#: src/olympia/editors/helpers.py:637
 msgid "This will mark the add-on and its most recent version and files as public. Future versions will go into the sandbox until they are reviewed by an editor."
 msgstr "هذا سيضيف علامة النشر للعموم على الإضافة وإصدارتها الأخيرة وملفاتها. ستوضع الإصدارات المستقبلية في ساحة اللعب حتى يراجعها أحد المحرّرين."
 
-#: src/olympia/editors/helpers.py:637
+#: src/olympia/editors/helpers.py:714
 msgid "add-on"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:940 src/olympia/editors/helpers.py:960
+#: src/olympia/editors/helpers.py:1020 src/olympia/editors/helpers.py:1040
 msgid "Flagged"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:944 src/olympia/editors/helpers.py:963
+#: src/olympia/editors/helpers.py:1024 src/olympia/editors/helpers.py:1043
 msgid "Updates"
 msgstr ""
 
@@ -7893,56 +7558,56 @@ msgstr ""
 msgid "A question about your Theme submission"
 msgstr ""
 
-#: src/olympia/editors/views.py:144
+#: src/olympia/editors/views.py:146
 msgid "New Add-ons (Under 5 days)"
 msgstr "إضافات جديدة (أقل من 5 أيام)"
 
-#: src/olympia/editors/views.py:145
+#: src/olympia/editors/views.py:147
 msgid "Passable (5 to 10 days)"
 msgstr ""
 
-#: src/olympia/editors/views.py:146
+#: src/olympia/editors/views.py:148
 msgid "Overdue (Over 10 days)"
 msgstr ""
 
-#: src/olympia/editors/views.py:532
+#: src/olympia/editors/views.py:539
 msgid "An unknown error occurred"
 msgstr ""
 
-#: src/olympia/editors/views.py:587
+#: src/olympia/editors/views.py:592
 msgid "Self-reviews are not allowed."
 msgstr "غير مسموح بتعليقك على إضافاتك."
 
-#: src/olympia/editors/views.py:609
+#: src/olympia/editors/views.py:613
 msgid "Review successfully processed."
 msgstr "عولج التعليق بنجاح."
 
-#: src/olympia/editors/views.py:807
+#: src/olympia/editors/views.py:812
 msgid "was approved"
 msgstr ""
 
-#: src/olympia/editors/views.py:808
+#: src/olympia/editors/views.py:813
 msgid "given preliminary review"
 msgstr ""
 
-#: src/olympia/editors/views.py:809
+#: src/olympia/editors/views.py:814
 msgid "rejected"
 msgstr ""
 
-#: src/olympia/editors/views.py:810
+#: src/olympia/editors/views.py:815
 msgctxt "editors_review_history_nominated_adminreview"
 msgid "escalated"
 msgstr ""
 
-#: src/olympia/editors/views.py:812
+#: src/olympia/editors/views.py:817
 msgid "needs more information"
 msgstr ""
 
-#: src/olympia/editors/views.py:813
+#: src/olympia/editors/views.py:818
 msgid "needs super review"
 msgstr ""
 
-#: src/olympia/editors/views.py:814
+#: src/olympia/editors/views.py:819
 msgid "commented"
 msgstr ""
 
@@ -7951,10 +7616,6 @@ msgid "{0} theme review successfully processed (+{1} points, {2} total)."
 msgid_plural "{0} theme reviews successfully processed (+{1} points, {2} total)."
 msgstr[0] ""
 msgstr[1] ""
-msgstr[2] ""
-msgstr[3] ""
-msgstr[4] ""
-msgstr[5] ""
 
 #: src/olympia/editors/views_themes.py:341
 msgid "Your theme locks have successfully been released. Other reviewers may now review those released themes. You may have to refresh the page to see the changes reflected in the table below."
@@ -7991,28 +7652,28 @@ msgstr ""
 msgid "Unlisted Queues"
 msgstr ""
 
-#: src/olympia/editors/templates/editors/base.html:72 src/olympia/editors/templates/editors/performance.html:6
+#: src/olympia/editors/templates/editors/base.html:74 src/olympia/editors/templates/editors/performance.html:6
 msgid "Performance"
 msgstr "الأداء"
 
-#: src/olympia/editors/templates/editors/base.html:75 src/olympia/editors/templates/editors/themes/base.html:19 src/olympia/editors/templates/editors/themes/base.html:38
+#: src/olympia/editors/templates/editors/base.html:77 src/olympia/editors/templates/editors/themes/base.html:19 src/olympia/editors/templates/editors/themes/base.html:38
 msgid "Logs"
 msgstr ""
 
-#: src/olympia/editors/templates/editors/base.html:78 src/olympia/editors/templates/editors/reviewlog.html:4 src/olympia/editors/templates/editors/reviewlog.html:27
+#: src/olympia/editors/templates/editors/base.html:80 src/olympia/editors/templates/editors/reviewlog.html:4 src/olympia/editors/templates/editors/reviewlog.html:27
 msgid "Add-on Review Log"
 msgstr ""
 
-#: src/olympia/editors/templates/editors/base.html:80 src/olympia/editors/templates/editors/eventlog.html:4 src/olympia/editors/templates/editors/eventlog.html:8
+#: src/olympia/editors/templates/editors/base.html:82 src/olympia/editors/templates/editors/eventlog.html:4 src/olympia/editors/templates/editors/eventlog.html:8
 #: src/olympia/editors/templates/editors/eventlog_detail.html:4
 msgid "Moderated Review Log"
 msgstr ""
 
-#: src/olympia/editors/templates/editors/base.html:82 src/olympia/editors/templates/editors/beta_signed_log.html:4 src/olympia/editors/templates/editors/beta_signed_log.html:8
+#: src/olympia/editors/templates/editors/base.html:84 src/olympia/editors/templates/editors/beta_signed_log.html:4 src/olympia/editors/templates/editors/beta_signed_log.html:8
 msgid "Signed Beta Files Log"
 msgstr ""
 
-#: src/olympia/editors/templates/editors/base.html:87 src/olympia/editors/templates/editors/includes/daily-message.html:4
+#: src/olympia/editors/templates/editors/base.html:89 src/olympia/editors/templates/editors/includes/daily-message.html:4
 msgid "Announcement"
 msgstr ""
 
@@ -8072,30 +7733,18 @@ msgid "Full Review ({num})"
 msgid_plural "Full Reviews ({num})"
 msgstr[0] ""
 msgstr[1] ""
-msgstr[2] ""
-msgstr[3] ""
-msgstr[4] ""
-msgstr[5] ""
 
 #: src/olympia/editors/templates/editors/home.html:18
 msgid "Pending Update ({num})"
 msgid_plural "Pending Updates ({num})"
 msgstr[0] ""
 msgstr[1] ""
-msgstr[2] ""
-msgstr[3] ""
-msgstr[4] ""
-msgstr[5] ""
 
 #: src/olympia/editors/templates/editors/home.html:25
 msgid "Preliminary Review ({num})"
 msgid_plural "Preliminary Reviews ({num})"
 msgstr[0] ""
 msgstr[1] ""
-msgstr[2] ""
-msgstr[3] ""
-msgstr[4] ""
-msgstr[5] ""
 
 #: src/olympia/editors/templates/editors/home.html:36 src/olympia/editors/templates/editors/home.html:86
 msgid "Current waiting times:"
@@ -8106,10 +7755,6 @@ msgid "{0} add-on"
 msgid_plural "{0} add-ons"
 msgstr[0] ""
 msgstr[1] ""
-msgstr[2] ""
-msgstr[3] ""
-msgstr[4] ""
-msgstr[5] ""
 
 #: src/olympia/editors/templates/editors/home.html:45 src/olympia/editors/templates/editors/home.html:95
 #, python-format
@@ -8121,30 +7766,18 @@ msgid "Unlisted Full Review ({num})"
 msgid_plural "Unlisted Full Reviews ({num})"
 msgstr[0] ""
 msgstr[1] ""
-msgstr[2] ""
-msgstr[3] ""
-msgstr[4] ""
-msgstr[5] ""
 
 #: src/olympia/editors/templates/editors/home.html:68
 msgid "Unlisted Pending Update ({num})"
 msgid_plural "Unlisted Pending Updates ({num})"
 msgstr[0] ""
 msgstr[1] ""
-msgstr[2] ""
-msgstr[3] ""
-msgstr[4] ""
-msgstr[5] ""
 
 #: src/olympia/editors/templates/editors/home.html:75
 msgid "Unlisted Preliminary Review ({num})"
 msgid_plural "Unlisted Preliminary Reviews ({num})"
 msgstr[0] ""
 msgstr[1] ""
-msgstr[2] ""
-msgstr[3] ""
-msgstr[4] ""
-msgstr[5] ""
 
 #: src/olympia/editors/templates/editors/home.html:109 src/olympia/editors/templates/editors/performance.html:37 src/olympia/editors/templates/editors/themes/home.html:54
 msgid "Total Reviews"
@@ -8168,10 +7801,6 @@ msgid "Moderated Review ({num})"
 msgid_plural "Moderated Reviews ({num})"
 msgstr[0] ""
 msgstr[1] ""
-msgstr[2] ""
-msgstr[3] ""
-msgstr[4] ""
-msgstr[5] ""
 
 #: src/olympia/editors/templates/editors/leaderboard.html:3 src/olympia/editors/templates/editors/includes/reviewers_score_bar.html:56
 msgid "Reviewer Leaderboard"
@@ -8266,46 +7895,46 @@ msgstr "بحث متقدم"
 msgid "clear search"
 msgstr "تنظيف البحث"
 
-#: src/olympia/editors/templates/editors/queue.html:72 src/olympia/editors/templates/editors/queue.html:122
+#: src/olympia/editors/templates/editors/queue.html:78 src/olympia/editors/templates/editors/queue.html:128
 msgid "Process Reviews"
 msgstr "عالج التعليقات"
 
-#: src/olympia/editors/templates/editors/queue.html:80
+#: src/olympia/editors/templates/editors/queue.html:86
 msgid "Moderation actions:"
 msgstr ""
 
-#: src/olympia/editors/templates/editors/queue.html:90
+#: src/olympia/editors/templates/editors/queue.html:96
 #, python-format
 msgid "by %(user)s on %(date)s %(stars)s (%(locale)s)"
 msgstr ""
 
-#: src/olympia/editors/templates/editors/queue.html:106
+#: src/olympia/editors/templates/editors/queue.html:112
 #, python-format
 msgid "<strong>%(reason)s</strong> <span class=\"light\">Flagged by %(user)s on %(date)s</span>"
 msgstr ""
 
-#: src/olympia/editors/templates/editors/queue.html:119
-msgid "All reviews have been moderated.  Good work!"
+#: src/olympia/editors/templates/editors/queue.html:125
+msgid "All reviews have been moderated. Good work!"
 msgstr ""
 
-#: src/olympia/editors/templates/editors/queue.html:161
+#: src/olympia/editors/templates/editors/queue.html:167
 msgid "Version Notes / Notes for Reviewer"
 msgstr "ملاحظات الإصدارة / ملاحظات للمعلّق"
 
 # %1 is the queue mode
-#: src/olympia/editors/templates/editors/queue.html:169
+#: src/olympia/editors/templates/editors/queue.html:175
 msgid "There are currently no add-ons of this type to review."
 msgstr "لا يوجد إضافات من هذا النوع حاليًا للتعليق."
 
-#: src/olympia/editors/templates/editors/queue.html:181 src/olympia/editors/templates/editors/themes/queue_list.html:85
+#: src/olympia/editors/templates/editors/queue.html:187 src/olympia/editors/templates/editors/themes/queue_list.html:85
 msgid "Helpful Links:"
 msgstr "روابط مفيدة:"
 
-#: src/olympia/editors/templates/editors/queue.html:182
+#: src/olympia/editors/templates/editors/queue.html:188
 msgid "Add-on Policy"
 msgstr "سياسة الإضافة"
 
-#: src/olympia/editors/templates/editors/queue.html:184
+#: src/olympia/editors/templates/editors/queue.html:190
 msgid "Editors' Guide"
 msgstr "مرشد المحرّرين"
 
@@ -8368,10 +7997,7 @@ msgid "<strong>Warning!</strong> Another user was viewing this page before you."
 msgstr ""
 
 #: src/olympia/editors/templates/editors/review.html:237
-msgid ""
-"The whiteboard is the place to exchange information relevant to\n"
-"               this addon (whatever the version), between the developer and the\n"
-"               editor. This is visible and editable by both."
+msgid "The whiteboard is the place to exchange information relevant to this addon (whatever the version), between the developer and the editor. This is visible and editable by both."
 msgstr ""
 
 #: src/olympia/editors/templates/editors/review.html:241
@@ -8516,30 +8142,18 @@ msgid "{num} Pending Theme Review"
 msgid_plural "{num} Pending Theme Reviews"
 msgstr[0] ""
 msgstr[1] ""
-msgstr[2] ""
-msgstr[3] ""
-msgstr[4] ""
-msgstr[5] ""
 
 #: src/olympia/editors/templates/editors/themes/home.html:27
 msgid "{num} Flagged Review"
 msgid_plural "{num} Flagged Reviews"
 msgstr[0] ""
 msgstr[1] ""
-msgstr[2] ""
-msgstr[3] ""
-msgstr[4] ""
-msgstr[5] ""
 
 #: src/olympia/editors/templates/editors/themes/home.html:34
 msgid "{num} Update"
 msgid_plural "{num} Updates"
 msgstr[0] ""
 msgstr[1] ""
-msgstr[2] ""
-msgstr[3] ""
-msgstr[4] ""
-msgstr[5] ""
 
 #: src/olympia/editors/templates/editors/themes/logs.html:4
 msgid "Theme Review Log"
@@ -8658,7 +8272,7 @@ msgstr ""
 msgid "Describe your reason for flagging"
 msgstr ""
 
-#: src/olympia/files/forms.py:88
+#: src/olympia/files/forms.py:90
 msgid "Cannot diff a version against itself"
 msgstr ""
 
@@ -8693,51 +8307,51 @@ msgstr ""
 msgid "There was an error accessing file %s."
 msgstr ""
 
-#: src/olympia/files/utils.py:343
+#: src/olympia/files/utils.py:340
 msgid "Could not parse uploaded file."
 msgstr ""
 
-#: src/olympia/files/utils.py:380
+#: src/olympia/files/utils.py:377
 msgid "Invalid file name in archive: {0}"
 msgstr ""
 
-#: src/olympia/files/utils.py:388
+#: src/olympia/files/utils.py:385
 msgid "File exceeding size limit in archive: {0}"
 msgstr ""
 
-#: src/olympia/files/utils.py:439
+#: src/olympia/files/utils.py:436
 msgid "Invalid archive."
 msgstr ""
 
-#: src/olympia/files/utils.py:529 src/olympia/files/utils.py:532
+#: src/olympia/files/utils.py:526 src/olympia/files/utils.py:529
 msgid "Could not parse the manifest file."
 msgstr ""
 
-#: src/olympia/files/utils.py:551
+#: src/olympia/files/utils.py:548
 msgid "Could not find an add-on ID."
 msgstr ""
 
-#: src/olympia/files/utils.py:554
+#: src/olympia/files/utils.py:551
 msgid "Add-on ID must be 64 characters or less."
 msgstr ""
 
-#: src/olympia/files/utils.py:556
+#: src/olympia/files/utils.py:553
 msgid "Add-on ID doesn't match add-on."
 msgstr ""
 
-#: src/olympia/files/utils.py:564
+#: src/olympia/files/utils.py:561
 msgid "Duplicate add-on ID found."
 msgstr ""
 
-#: src/olympia/files/utils.py:567
+#: src/olympia/files/utils.py:564
 msgid "Version numbers should have fewer than 32 characters."
 msgstr ""
 
-#: src/olympia/files/utils.py:570
+#: src/olympia/files/utils.py:567
 msgid "Version numbers should only contain letters, numbers, and these punctuation characters: +*.-_."
 msgstr ""
 
-#: src/olympia/files/utils.py:587
+#: src/olympia/files/utils.py:584
 msgid "<em:type> doesn't match add-on"
 msgstr ""
 
@@ -8839,6 +8453,10 @@ msgstr ""
 
 #: src/olympia/files/templates/files/viewer.html:134
 msgid "Fetching file."
+msgstr ""
+
+#: src/olympia/legacy_api/views.py:255
+msgid "Not implemented yet."
 msgstr ""
 
 #: src/olympia/lib/constants.py:6
@@ -9497,10 +9115,6 @@ msgstr ""
 msgid "Zimbabwe Dollar"
 msgstr ""
 
-#: src/olympia/lib/video/ffmpeg.py:112 src/olympia/lib/video/totem.py:81
-msgid "Videos must be in WebM."
-msgstr ""
-
 #: src/olympia/pages/templates/pages/about.lhtml:3 src/olympia/pages/templates/pages/about.lhtml:10
 msgid "About Mozilla Add-ons"
 msgstr ""
@@ -9512,7 +9126,7 @@ msgstr ""
 #: src/olympia/pages/templates/pages/about.lhtml:13
 msgid ""
 "addons.mozilla.org, commonly known as \"AMO\", is Mozilla's official site for add-ons to Mozilla software, such as Firefox, Thunderbird, and SeaMonkey. Add-ons let you add new features and change "
-"the way your browser or application works.  Take a look around and explore the thousands of ways to customize the way you do things online."
+"the way your browser or application works. Take a look around and explore the thousands of ways to customize the way you do things online."
 msgstr ""
 
 #: src/olympia/pages/templates/pages/about.lhtml:19
@@ -9857,7 +9471,7 @@ msgstr ""
 msgid ""
 "Yes. It's possible, but some of the functionality provided by these libraries are available through XPCOM, XUL, and JavaScript. In addition, authors should take care if libraries modify primitive "
 "object prototypes (String.prototype, Date.prototype, etc.) and/or define global functions (eg. the $ function). These are prone to cause conflict with other add-ons, in particular if different add-"
-"ons use different versions of libraries and so on. Developers need to be very, very careful with using them.  Mozilla does not offer documentation on using them to build add-ons."
+"ons use different versions of libraries and so on. Developers need to be very, very careful with using them. Mozilla does not offer documentation on using them to build add-ons."
 msgstr ""
 
 #: src/olympia/pages/templates/pages/dev_faq.html:165
@@ -9971,8 +9585,8 @@ msgstr ""
 #, python-format
 msgid ""
 "Yes. Many developers choose to host their own add-ons. Choosing to host your add-on on <a href=\"%(amo_url)s\">Mozilla's add-on site</a>, though, allows for much greater exposure to your add-on due "
-"to the large volume of visitors to the site.  <a href=\"%(md_url)s\">mozdev.org</a> offers free project hosting for Mozilla applications and extensions providing developers with tools to help "
-"manage source code, version control, bug tracking and documentation."
+"to the large volume of visitors to the site. <a href=\"%(md_url)s\">mozdev.org</a> offers free project hosting for Mozilla applications and extensions providing developers with tools to help manage "
+"source code, version control, bug tracking and documentation."
 msgstr ""
 
 #: src/olympia/pages/templates/pages/dev_faq.html:277
@@ -10020,7 +9634,7 @@ msgstr ""
 #: src/olympia/pages/templates/pages/dev_faq.html:314
 #, python-format
 msgid ""
-"Yes. Mozilla's <a href=\"%(p_url)s\">Add-on Policy</a> describes what is an acceptable submission. This policy is subject to change without notice.  In addition, the AMO editorial team uses the <a "
+"Yes. Mozilla's <a href=\"%(p_url)s\">Add-on Policy</a> describes what is an acceptable submission. This policy is subject to change without notice. In addition, the AMO editorial team uses the <a "
 "href=\"%(g_url)s\">Editors Reviewing Guide</a> to ensure that your add-on meets specific guidelines for functionality and security."
 msgstr ""
 
@@ -10137,7 +9751,7 @@ msgstr ""
 #: src/olympia/pages/templates/pages/dev_faq.html:434
 #, python-format
 msgid ""
-"This is why it's very important to read the <a href=\"%(g_url)s\">Editors Reviewing Guide</a> to ensure that your add-on is setup as expected.  It's also a good idea to read the blog post, <a href="
+"This is why it's very important to read the <a href=\"%(g_url)s\">Editors Reviewing Guide</a> to ensure that your add-on is setup as expected. It's also a good idea to read the blog post, <a href="
 "\"%(blog_url)s\">Successfully Getting your Add-on Reviewed</a> which provides excellent insight into ensuring a smooth review of your add-on."
 msgstr ""
 
@@ -10244,7 +9858,7 @@ msgstr ""
 
 #: src/olympia/pages/templates/pages/dev_faq.html:572
 msgid ""
-"Free Software Foundation provides short summaries of the key open source licenses, including whether the license qualifies as a free software license or a copyleft license.  Also includes a "
+"Free Software Foundation provides short summaries of the key open source licenses, including whether the license qualifies as a free software license or a copyleft license. Also includes a "
 "discussion of what constitutes a free software license or a copyleft license (e.g., a Copyleft license is a general method for making a program or other work free, and requiring all modified and "
 "extended versions of the program to be free as well.)"
 msgstr ""
@@ -10422,19 +10036,13 @@ msgid "Add-on Gallery"
 msgstr "معرض الإضافات؟"
 
 #: src/olympia/pages/templates/pages/faq.html:171
-msgid ""
-"How do I choose between add-ons that seem to do the same\n"
-"    thing?"
+msgid "How do I choose between add-ons that seem to do the same thing?"
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:173
+#: src/olympia/pages/templates/pages/faq.html:172
 msgid ""
-"There are often several add-ons that have similar features. To\n"
-"    figure out which is right for you, read the entire description of the\n"
-"    add-on and view its screenshots. If there are still several in the running,\n"
-"    read through the add-on's ratings, user reviews, and statistics to see\n"
-"    which is most liked by other users. Remember that you can also just try\n"
-"    out both and see which you like better."
+"There are often several add-ons that have similar features. To figure out which is right for you, read the entire description of the add-on and view its screenshots. If there are still several in "
+"the running, read through the add-on's ratings, user reviews, and statistics to see which is most liked by other users. Remember that you can also just try out both and see which you like better."
 msgstr ""
 
 #: src/olympia/pages/templates/pages/faq.html:180
@@ -10475,80 +10083,67 @@ msgid "How much do add-ons cost to purchase?"
 msgstr ""
 
 #: src/olympia/pages/templates/pages/faq.html:207
-msgid ""
-"Add-ons hosted in our gallery are free unless clearly marked\n"
-"    otherwise."
+msgid "Add-ons hosted in our gallery are free unless clearly marked otherwise."
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:210
+#: src/olympia/pages/templates/pages/faq.html:209
 msgid "What does it mean when an add-on asks for contributions?"
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:211
+#: src/olympia/pages/templates/pages/faq.html:210
 msgid ""
-"Some add-on authors request users who enjoy an add-on to\n"
-"        contribute to its development by making a monetary contribution. These\n"
-"        contributions go directly to the developer unless a third party is\n"
-"        indicated, such as the non-profit Mozilla Foundation."
+"Some add-on authors request users who enjoy an add-on to contribute to its development by making a monetary contribution. These contributions go directly to the developer unless a third party is "
+"indicated, such as the non-profit Mozilla Foundation."
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:216
+#: src/olympia/pages/templates/pages/faq.html:215
 msgid "What are beta add-ons?"
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:218
+#: src/olympia/pages/templates/pages/faq.html:217
 msgid ""
-"Beta add-ons are unreviewed versions which represent the\n"
-"        latest work of an add-on author. While different authors have different\n"
-"        standards for beta code quality, you should assume that these add-ons\n"
-"        are less stable than the general add-on releases."
+"Beta add-ons are unreviewed versions which represent the latest work of an add-on author. While different authors have different standards for beta code quality, you should assume that these add-"
+"ons are less stable than the general add-on releases."
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:222
+#: src/olympia/pages/templates/pages/faq.html:221
 msgid ""
 "Please note that when you install an add-on from the \"Beta Version\" section of an add-on's listing, you will continue to receive updates for that add-on as they become available. Like the initial "
 "version you installed, all beta releases are unreviewed by Mozilla and may harm your computer."
 msgstr ""
 
+#: src/olympia/pages/templates/pages/faq.html:228
+msgid "What does it mean when an add-on is flagged as slow?"
+msgstr ""
+
 #: src/olympia/pages/templates/pages/faq.html:229
-msgid ""
-"What does it mean when an add-on is flagged as\n"
-"    slow?"
+msgid "Most add-ons load code and resources at the same time Firefox is starting up. In most cases the impact in start-up time is minimal, but some add-ons can cause a noticeable slowdown."
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:231
-msgid ""
-"Most add-ons load code and resources at the same time Firefox\n"
-"        is starting up. In most cases the impact in start-up time is minimal,\n"
-"        but some add-ons can cause a noticeable slowdown."
-msgstr ""
-
-#: src/olympia/pages/templates/pages/faq.html:236
+#: src/olympia/pages/templates/pages/faq.html:234
 msgid "How do I report an inappropriate or spam user review?"
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:237
+#: src/olympia/pages/templates/pages/faq.html:235
 msgid ""
-"To report a user review of an add-on, log in with your account\n"
-"    and visit the add-on's reviews page. Find the review you wish to report,\n"
-"    click \"Report this review\" and select a reason. Our editorial team will\n"
-"    investigate the review and take appropriate action."
+"To report a user review of an add-on, log in with your account and visit the add-on's reviews page. Find the review you wish to report, click \"Report this review\" and select a reason. Our "
+"editorial team will investigate the review and take appropriate action."
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:242
+#: src/olympia/pages/templates/pages/faq.html:240
 msgid "How do I report a bug or contact the Mozilla Add-ons team?"
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:243
+#: src/olympia/pages/templates/pages/faq.html:241
 #, python-format
 msgid "Please visit our <a href=\"%(contact_url)s\">Contact page</a>."
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:246
+#: src/olympia/pages/templates/pages/faq.html:244
 msgid "What is a Source Code License?"
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:247
+#: src/olympia/pages/templates/pages/faq.html:245
 #, python-format
 msgid ""
 "The source code used to create an add-on is an exclusive copyright of the add-on author, unless otherwise declared in a source code license. Many add-ons on this site have <a href=\"%(url)s\" lang="
@@ -10556,40 +10151,40 @@ msgid ""
 "the GPL or BSD licenses instead of making up their own."
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:256
+#: src/olympia/pages/templates/pages/faq.html:254
 #, python-format
 msgid "Firefox and other Mozilla software are <a href=\"%(url)s\">open source</a>."
 msgstr "فيرفُكس وبرمجيات موزيلا الأخرى هي برمجيات <a href=\"%(url)s\">مفتوحة المصدر</a>."
 
-#: src/olympia/pages/templates/pages/faq.html:264
+#: src/olympia/pages/templates/pages/faq.html:262
 msgid "Collections and Favorites"
 msgstr "المجموعات والمفضلات"
 
-#: src/olympia/pages/templates/pages/faq.html:267
+#: src/olympia/pages/templates/pages/faq.html:265
 msgid "What is a collection?"
 msgstr "ما هي المجموعات؟"
 
-#: src/olympia/pages/templates/pages/faq.html:268
+#: src/olympia/pages/templates/pages/faq.html:266
 msgid "Collections are groups of related add-ons created by users to share."
 msgstr "المجموعات عبارة عن مجموعة من الإضافات المُختارة والمُجمّعة مع بعضها البعض والتي يُنشئها المُستخدمون لمشاركتها مع الآخرين."
 
-#: src/olympia/pages/templates/pages/faq.html:270
+#: src/olympia/pages/templates/pages/faq.html:268
 msgid "What is the My Favorites collection?"
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:271
+#: src/olympia/pages/templates/pages/faq.html:269
 msgid "Favorite add-ons are add-ons that you have bookmarked to easily get back to later. You can add an add-on to your favorites collection by clicking \"Add to favorites\" on its details page."
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:275 src/olympia/templates/menu_links.html:13 src/olympia/templates/impala/header_title.html:17
+#: src/olympia/pages/templates/pages/faq.html:273 src/olympia/templates/menu_links.html:13 src/olympia/templates/impala/header_title.html:17
 msgid "Mobile Add-ons"
 msgstr "إضافات الهواتف الذكية"
 
-#: src/olympia/pages/templates/pages/faq.html:278
+#: src/olympia/pages/templates/pages/faq.html:276
 msgid "What are mobile add-ons?"
 msgstr "ما هي إضافات الهواتف الذكية؟"
 
-#: src/olympia/pages/templates/pages/faq.html:279
+#: src/olympia/pages/templates/pages/faq.html:277
 #, python-format
 msgid ""
 "Mobile add-ons work with <a href=\"%(mobile_url)s\">Firefox for Mobile</a> and add or modify functionality just like desktop add-ons. You can find add-ons that work with Firefox for Mobile in our "
@@ -10598,20 +10193,20 @@ msgstr ""
 "إضافات الهواتف الذكية تعمل مع <a href=\"%(mobile_url)s\">فَيَرفُكس للهواتف الذكية</a> وتضيف أو تعدّل وظائف المتصفح تمامًا مثل إضافات النسخة المكتبية. يمكنك إيجاد الإضافات التي تعمل مع فيرفُكس للهواتف "
 "الذكية في <a href=\"%(gallery_url)s\">معرضنا</a>."
 
-#: src/olympia/pages/templates/pages/faq.html:288
+#: src/olympia/pages/templates/pages/faq.html:286
 msgid "Developer Topics"
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:289
+#: src/olympia/pages/templates/pages/faq.html:287
 #, python-format
 msgid "Please see our <a href=\"%(faq_url)s\">Developer FAQ</a> and <a href=\"%(hub_url)s\">Developer Hub</a> for answers to add-on developer-related questions."
 msgstr "رجاءً شاهد <a href=\"%(faq_url)s\">الأسئلة الشائعة للمطورين</a> و<a href=\"%(hub_url)s\">مركز المطورين</a> للحصول على إجابات على الأسئلة المتعلقة بمطوري الإضافات."
 
-#: src/olympia/pages/templates/pages/faq.html:294
+#: src/olympia/pages/templates/pages/faq.html:292
 msgid "Still have questions?"
 msgstr "ما تزال لديك أسئلة؟"
 
-#: src/olympia/pages/templates/pages/faq.html:295
+#: src/olympia/pages/templates/pages/faq.html:293
 #, python-format
 msgid "For general Firefox support, visit our <a href=\"%(sumo_url)s\">support website</a>. For general add-on and website questions, visit our <a href=\"%(forum_url)s\">forum</a>."
 msgstr "للدعم العام لفيرفُكس، قم بزيارة <a href=\"%(sumo_url)s\">موقع الدعم</a>. للأسئلة العامة عن الإضافات والموقع، قم بزيارة <a href=\"%(forum_url)s\">المنتدى</a>."
@@ -10749,7 +10344,7 @@ msgstr ""
 
 #: src/olympia/pages/templates/pages/sunbird.html:29
 msgid ""
-"Development on the Sunbird project has halted and its final release was on March 30, 2010.  We've been proud to host Sunbird add-ons on this site but as the project is no longer maintained we have "
+"Development on the Sunbird project has halted and its final release was on March 30, 2010. We've been proud to host Sunbird add-ons on this site but as the project is no longer maintained we have "
 "disabled our support for the add-ons."
 msgstr ""
 
@@ -10880,10 +10475,6 @@ msgid "This user has a <a href=\"%(user_review_url)s\">previous review</a> of th
 msgid_plural "This user has <a href=\"%(user_review_url)s\">%(cnt)s previous reviews</a> of this add-on."
 msgstr[0] "لا تعليقات سابقة لهذا المستخدم"
 msgstr[1] "هذا المستخدم لديه <a href=\"%(user_review_url)s\">تعليق سابق</a> على هذه الإضافة."
-msgstr[2] "هذا المستخدم لديه <a href=\"%(user_review_url)s\">تعليقين سابقين</a> على هذه الإضافة."
-msgstr[3] "هذا المستخدم لديه <a href=\"%(user_review_url)s\">%(cnt)s تعليقات سابقة</a> على هذه الإضافة."
-msgstr[4] "هذا المستخدم لديه <a href=\"%(user_review_url)s\">%(cnt)s تعليقًا سابقًا</a> على هذه الإضافة."
-msgstr[5] "هذا المستخدم لديه <a href=\"%(user_review_url)s\">%(cnt)s تعليق سابق</a> على هذه الإضافة."
 
 #: src/olympia/reviews/templates/reviews/review.html:62
 #, python-format
@@ -10930,10 +10521,6 @@ msgid "<b>{0}</b> review for this add-on"
 msgid_plural "<b>{0}</b> reviews for this add-on"
 msgstr[0] "لا تعليقات على هذه الإضافة"
 msgstr[1] "تعليق واحد على هذه الإضافة"
-msgstr[2] "تعليقين على هذه الإضافة"
-msgstr[3] "<b>{0}</b> تعليقات على هذه الإضافة"
-msgstr[4] "<b>{0}</b> تعليقا على هذه الإضافة"
-msgstr[5] "<b>{0}</b> تعليق على هذه الإضافة"
 
 #. {0} is a developer's name.
 #: src/olympia/reviews/templates/reviews/review_list.html:33
@@ -10946,10 +10533,6 @@ msgid "Review for %(addon)s by %(user)s"
 msgid_plural "Reviews for %(addon)s by %(user)s"
 msgstr[0] "لا تعليقات على %(addon)s"
 msgstr[1] "تعليق واحد على %(addon)s بواسطة %(user)s"
-msgstr[2] "تعليقين على %(addon)s بواسطة %(user)s"
-msgstr[3] "التعليقات على %(addon)s بواسطة %(user)s"
-msgstr[4] "التعليقات على %(addon)s بواسطة %(user)s"
-msgstr[5] "التعليقات على %(addon)s بواسطة %(user)s"
 
 #: src/olympia/reviews/templates/reviews/review_list.html:42
 msgid "No reviews found."
@@ -10973,10 +10556,6 @@ msgid "{num} review"
 msgid_plural "{num} reviews"
 msgstr[0] "لا تعليقات"
 msgstr[1] "تعليق واحد"
-msgstr[2] "تعليقين أثنين"
-msgstr[3] "{num} تعليقات"
-msgstr[4] "{num} تعليقا"
-msgstr[5] "{num} تعليق"
 
 #: src/olympia/reviews/templates/reviews/impala/reviews_rating.html:1
 msgid "Rated {0} out of 5 stars"
@@ -11004,10 +10583,6 @@ msgid "Average from {0} Rating"
 msgid_plural "Average from {0} Ratings"
 msgstr[0] "لا تقييمات بعد"
 msgstr[1] "المُعدّل من تقييم واحد"
-msgstr[2] "المُعدّل من تقييمين"
-msgstr[3] "المُعدّل من {0} تقييمات"
-msgstr[4] "المُعدّل من {0} تقييما"
-msgstr[5] "المُعدّل من {0} تقييم"
 
 #: src/olympia/reviews/templates/reviews/mobile/review_list.html:34
 #, python-format
@@ -11024,10 +10599,6 @@ msgid "See All Reviews"
 msgid_plural "See All %(cnt)s Reviews"
 msgstr[0] "شاهد كل التعليقات "
 msgstr[1] "شاهد كل التعليقات (%(cnt)s)"
-msgstr[2] "شاهد كل التعليقات (%(cnt)s)"
-msgstr[3] "شاهد كل التعليقات (%(cnt)s)"
-msgstr[4] "شاهد كل التعليقات (%(cnt)s)"
-msgstr[5] "شاهد كل التعليقات (%(cnt)s)"
 
 #: src/olympia/search/forms.py:11
 msgid "Most popular this week"
@@ -11108,16 +10679,16 @@ msgstr "إضافات {0}"
 
 #. L10n: {0} is an application, such as Firefox. This means "any version of
 #. Firefox."
-#: src/olympia/search/views.py:554
+#: src/olympia/search/views.py:547
 msgid "Any {0}"
 msgstr "أي إصدارة من {0}"
 
 #. L10n: "All Systems" means show everything regardless of platform.
-#: src/olympia/search/views.py:589
+#: src/olympia/search/views.py:582
 msgid "All Systems"
 msgstr "كل الأنظمة"
 
-#: src/olympia/search/views.py:600
+#: src/olympia/search/views.py:593
 msgid "All Tags"
 msgstr "كل الوسوم"
 
@@ -11164,10 +10735,6 @@ msgid "<b>{0}</b> matching result"
 msgid_plural "<b>{0}</b> matching results"
 msgstr[0] "لا نتائج مطابقة"
 msgstr[1] "نتيجة واحدة مطابقة"
-msgstr[2] "نتيجتان مطابقتان"
-msgstr[3] "<b>{0}</b> نتائج مطابقة"
-msgstr[4] "<b>{0}</b> نتيجة مطابقة"
-msgstr[5] "<b>{0}</b> نتيجة مطابقة"
 
 #: src/olympia/search/templates/search/results.html:67
 msgid "Filter Results"
@@ -11190,10 +10757,6 @@ msgid "{0} post"
 msgid_plural "{0} posts"
 msgstr[0] "لا مشاركات"
 msgstr[1] "مشاركة واحدة"
-msgstr[2] "مشاركتين"
-msgstr[3] "{0} مشاركات"
-msgstr[4] "{0} مشاركة"
-msgstr[5] "{0} مشاركة"
 
 #: src/olympia/sharing/__init__.py:20
 msgid "Post to Facebook"
@@ -11204,10 +10767,6 @@ msgid "{0} Like"
 msgid_plural "{0} Likes"
 msgstr[0] ""
 msgstr[1] ""
-msgstr[2] ""
-msgstr[3] ""
-msgstr[4] ""
-msgstr[5] ""
 
 #: src/olympia/sharing/__init__.py:30
 msgid "Tweet on Twitter"
@@ -11218,10 +10777,6 @@ msgid "{0} tweet"
 msgid_plural "{0} tweets"
 msgstr[0] "لا تغريدات"
 msgstr[1] "تغريدة واحدة"
-msgstr[2] "تغريدتين"
-msgstr[3] "{0} تغريدات"
-msgstr[4] "{0} تغريدة"
-msgstr[5] "{0} تغريدة"
 
 #: src/olympia/sharing/__init__.py:40
 msgid "Share on g+"
@@ -11256,10 +10811,6 @@ msgid "{0} post on localservice1"
 msgid_plural "{0} posts on localservice1"
 msgstr[0] ""
 msgstr[1] ""
-msgstr[2] ""
-msgstr[3] ""
-msgstr[4] ""
-msgstr[5] ""
 
 #. L10n: Only change if you have reason! wiki.mozilla.org/AMO:Localizers
 #: src/olympia/sharing/__init__.py:76
@@ -11282,10 +10833,6 @@ msgid "{0} post on localservice2"
 msgid_plural "{0} posts on localservice2"
 msgstr[0] ""
 msgstr[1] ""
-msgstr[2] ""
-msgstr[3] ""
-msgstr[4] ""
-msgstr[5] ""
 
 #. L10n: Only change if you have reason! wiki.mozilla.org/AMO:Localizers
 #: src/olympia/sharing/__init__.py:91
@@ -11308,10 +10855,6 @@ msgid "{0} post on localservice3"
 msgid_plural "{0} posts on localservice3"
 msgstr[0] ""
 msgstr[1] ""
-msgstr[2] ""
-msgstr[3] ""
-msgstr[4] ""
-msgstr[5] ""
 
 #: src/olympia/sharing/templates/sharing/sharing_widget.html:2
 msgid "Share this Add-on"
@@ -11321,31 +10864,31 @@ msgstr "شارك هذه الإضافة"
 msgid "Share this Collection"
 msgstr "شارك هذه المجموعة"
 
-#: src/olympia/signing/views.py:30 src/olympia/templates/base.html:75 src/olympia/templates/impala/base.html:115
+#: src/olympia/signing/views.py:33 src/olympia/templates/base.html:71 src/olympia/templates/impala/base.html:112
 msgid "Some features are temporarily disabled while we perform website maintenance. We'll be back to full capacity shortly."
 msgstr ""
 
-#: src/olympia/signing/views.py:53
+#: src/olympia/signing/views.py:56
 msgid "Could not find add-on with id \"{}\"."
 msgstr ""
 
-#: src/olympia/signing/views.py:67
+#: src/olympia/signing/views.py:70
 msgid "You do not own this addon."
 msgstr ""
 
-#: src/olympia/signing/views.py:82
+#: src/olympia/signing/views.py:87
 msgid "Missing \"upload\" key in multipart file data."
 msgstr ""
 
-#: src/olympia/signing/views.py:96
+#: src/olympia/signing/views.py:101
 msgid "Version does not match the manifest file."
 msgstr ""
 
-#: src/olympia/signing/views.py:100
+#: src/olympia/signing/views.py:105
 msgid "Version already exists."
 msgstr ""
 
-#: src/olympia/signing/views.py:136
+#: src/olympia/signing/views.py:141
 msgid "No uploaded file for that addon and version."
 msgstr ""
 
@@ -11458,89 +11001,89 @@ msgstr "{0} :: لوحة الإحصائيات"
 msgid "Statistics Dashboard :: Add-ons for {0}"
 msgstr ""
 
-#: src/olympia/stats/templates/stats/stats.html:30
-msgid "Controls:"
-msgstr ""
-
-#: src/olympia/stats/templates/stats/stats.html:33
-msgid "reset zoom"
-msgstr ""
-
-#: src/olympia/stats/templates/stats/stats.html:40
-msgid "Group by:"
-msgstr "تجميع حسب:"
-
-#: src/olympia/stats/templates/stats/stats.html:42
-msgid "day"
-msgstr "اليوم"
-
-#: src/olympia/stats/templates/stats/stats.html:45
-msgid "week"
-msgstr "الأسبوع"
-
-#: src/olympia/stats/templates/stats/stats.html:48
-msgid "month"
-msgstr "الشهر"
-
-#: src/olympia/stats/templates/stats/stats.html:54
-msgid "For last:"
-msgstr "لآخر:"
-
-#: src/olympia/stats/templates/stats/stats.html:57
-msgid "7 days"
-msgstr "7 أيام"
-
-#: src/olympia/stats/templates/stats/stats.html:60
-msgid "30 days"
-msgstr "30 يوما"
-
-#: src/olympia/stats/templates/stats/stats.html:63
-msgid "90 days"
-msgstr "90 يوما"
-
-#: src/olympia/stats/templates/stats/stats.html:66
-msgid "365 days"
-msgstr "365 يوم"
-
-#: src/olympia/stats/templates/stats/stats.html:69
-msgid "Custom..."
-msgstr "مخصص..."
-
 #. {0} is an add-on name
-#: src/olympia/stats/templates/stats/stats.html:88 src/olympia/stats/templates/stats/stats.html:91
+#: src/olympia/stats/templates/stats/stats.html:44 src/olympia/stats/templates/stats/stats.html:47
 msgid "Statistics for {0}"
 msgstr "إحصائيات {0}"
 
-#: src/olympia/stats/templates/stats/stats.html:94
+#: src/olympia/stats/templates/stats/stats.html:50
 msgid "Statistics Dashboard"
 msgstr "لوحة الإحصائيات"
 
-#: src/olympia/stats/templates/stats/stats.html:104
+#: src/olympia/stats/templates/stats/stats.html:57
+msgid "Controls:"
+msgstr ""
+
+#: src/olympia/stats/templates/stats/stats.html:60
+msgid "reset zoom"
+msgstr ""
+
+#: src/olympia/stats/templates/stats/stats.html:67
+msgid "Group by:"
+msgstr "تجميع حسب:"
+
+#: src/olympia/stats/templates/stats/stats.html:69
+msgid "day"
+msgstr "اليوم"
+
+#: src/olympia/stats/templates/stats/stats.html:72
+msgid "week"
+msgstr "الأسبوع"
+
+#: src/olympia/stats/templates/stats/stats.html:75
+msgid "month"
+msgstr "الشهر"
+
+#: src/olympia/stats/templates/stats/stats.html:81
+msgid "For last:"
+msgstr "لآخر:"
+
+#: src/olympia/stats/templates/stats/stats.html:84
+msgid "7 days"
+msgstr "7 أيام"
+
+#: src/olympia/stats/templates/stats/stats.html:87
+msgid "30 days"
+msgstr "30 يوما"
+
+#: src/olympia/stats/templates/stats/stats.html:90
+msgid "90 days"
+msgstr "90 يوما"
+
+#: src/olympia/stats/templates/stats/stats.html:93
+msgid "365 days"
+msgstr "365 يوم"
+
+#: src/olympia/stats/templates/stats/stats.html:96
+msgid "Custom..."
+msgstr "مخصص..."
+
+#: src/olympia/stats/templates/stats/stats.html:106
 msgid "Statistics processing is currently disabled, so recent data is unavailable. The statistics are still being collected and this page will be updated soon with the missing data."
 msgstr ""
 
-#: src/olympia/stats/templates/stats/stats.html:110
+#: src/olympia/stats/templates/stats/stats.html:112
 msgid "Loading the latest data&hellip;"
 msgstr "يجري تحميل البيانات الأخيرة&hellip;"
 
-#: src/olympia/stats/templates/stats/stats.html:142 src/olympia/stats/templates/stats/reports/overview.html:25 src/olympia/stats/templates/stats/reports/overview.html:37
+#: src/olympia/stats/templates/stats/stats.html:144 src/olympia/stats/templates/stats/reports/overview.html:25 src/olympia/stats/templates/stats/reports/overview.html:37
 #: src/olympia/stats/templates/stats/reports/overview.html:49
 msgid "No data available."
 msgstr "لا بيانات متوفرة."
 
-#: src/olympia/stats/templates/stats/stats.html:177
+#: src/olympia/stats/templates/stats/stats.html:179
 msgid "This dashboard is currently <b>public</b>."
 msgstr "هذه اللوحة <b>عامة</b> حاليا."
 
-#: src/olympia/stats/templates/stats/stats.html:179
+#: src/olympia/stats/templates/stats/stats.html:181
 msgid "Contribution stats are currently <b>private</b>."
 msgstr "إحصائيات المساهمة <b>خاصة</b> حاليا."
 
-#: src/olympia/stats/templates/stats/stats.html:182
+#: src/olympia/stats/templates/stats/stats.html:184
 msgid "This dashboard is currently <b>private</b>."
 msgstr "هذه اللوحة <b>خاصة</b> حاليا."
 
-#: src/olympia/stats/templates/stats/stats.html:185
+#: src/olympia/stats/templates/stats/stats.html:187
 msgid "Change settings."
 msgstr ""
 
@@ -11692,16 +11235,6 @@ msgstr "تسجيلات المستخدمين حسب التاريخ"
 msgid "Application versions by Date"
 msgstr "إصدارات التطبيق حسب التاريخ"
 
-# {0} is a number
-#: src/olympia/tags/templates/tags/top_cloud.html:4
-msgid "Top {0} Tags"
-msgstr "أعلى {0} وسم"
-
-#. {0} is the current application name
-#: src/olympia/tags/templates/tags/top_cloud.html:14
-msgid "{0} Top Tags"
-msgstr "أعلى وسوم {0}"
-
 #: src/olympia/templates/amo_footer.html:6 src/olympia/templates/includes/lang_switcher.html:2
 msgid "Other languages"
 msgstr "لغات أخرى"
@@ -11710,11 +11243,11 @@ msgstr "لغات أخرى"
 msgid "Mozilla Add-ons"
 msgstr "إضافات موزيلا"
 
-#: src/olympia/templates/base.html:91 src/olympia/templates/impala/base.html:81
+#: src/olympia/templates/base.html:89 src/olympia/templates/impala/base.html:78
 msgid "Find add-ons for other applications"
 msgstr "ابحث عن إضافات لتطبيقات أخرى"
 
-#: src/olympia/templates/base.html:92 src/olympia/templates/impala/base.html:81
+#: src/olympia/templates/base.html:90 src/olympia/templates/impala/base.html:78
 msgid "Other Applications"
 msgstr "تطبيقات أخرى"
 
@@ -11739,7 +11272,7 @@ msgid "View Mobile Site"
 msgstr "عرض موقع الهواتف الذكية"
 
 #: src/olympia/templates/copyright.html:7
-msgid "Site Status "
+msgid "Site Status"
 msgstr ""
 
 #: src/olympia/templates/footer.html:3
@@ -11841,35 +11374,35 @@ msgstr "مرحبا، {0}"
 msgid "<a href=\"%(reg)s\">Register</a> or <a href=\"%(login)s\">Log in</a>"
 msgstr "<a href=\"%(reg)s\">سجّل</a> أو <a href=\"%(login)s\">لِج</a>"
 
-#: src/olympia/templates/impala/base.html:126
+#: src/olympia/templates/impala/base.html:123
 #, python-format
 msgid "To try the thousands of add-ons available here, download <a href=\"%(url)s\">Mozilla Firefox</a>, a fast, free way to surf the Web!"
 msgstr "لتجربة الآلاف من الإضافات المتوفرة هنا، نزّل متصفح <a href=\"%(url)s\">موزيلا فَيَرفُكس</a> مجانًا. المتصفح الأسرع والأكثر أمانًا في عالم الإنترنت."
 
-#: src/olympia/templates/impala/base.html:138
+#: src/olympia/templates/impala/base.html:135
 #, python-format
 msgid "Add-ons is switching to Firefox Accounts for login. <a href=\"%(url)s\" class=\"fxa-login\">Sign in now to transfer your account.</a>"
 msgstr ""
 
 #. {0} is an application, such as Firefox.
-#: src/olympia/templates/impala/base.html:148
+#: src/olympia/templates/impala/base.html:145
 msgid "Welcome to {0} Add-ons."
 msgstr "مرحبا بك في إضافات {0}."
 
-#: src/olympia/templates/impala/base.html:151
+#: src/olympia/templates/impala/base.html:148
 msgid "Choose from thousands of extra features and styles to make Firefox your own."
 msgstr "اختر من بين الآلاف من المميزات والمظاهر الإضافية واجعل فيرفُكس ملكًا لك."
 
-#: src/olympia/templates/impala/base.html:156
+#: src/olympia/templates/impala/base.html:153
 #, python-format
 msgid "Add extra features and styles to make %(app)s your own."
 msgstr "أضِف مميزات ومظاهر إضافية واجعل %(app)s ملكًا لك."
 
-#: src/olympia/templates/impala/base.html:164
+#: src/olympia/templates/impala/base.html:161
 msgid "On the go?"
 msgstr "في الطريق، أثناء تنقلك؟"
 
-#: src/olympia/templates/impala/base.html:166
+#: src/olympia/templates/impala/base.html:163
 msgid "Check out our <a class=\"mobile-link\" href=\"#\">Mobile Add-ons site</a>."
 msgstr "ألقِ نظرة على <a class=\"mobile-link\" href=\"#\">موقع إضافات الهواتف الذكية</a>."
 
@@ -12093,19 +11626,19 @@ msgstr ""
 
 #. L10n: {id} will be something like "13ad6a", just a random number
 #. to differentiate this user from other anonymous users.
-#: src/olympia/users/models.py:353
+#: src/olympia/users/models.py:362
 msgid "Anonymous user {id}"
 msgstr ""
 
-#: src/olympia/users/models.py:410
+#: src/olympia/users/models.py:419
 msgid "Your account has been restricted"
 msgstr "تم تقييد حسابك"
 
-#: src/olympia/users/models.py:480
+#: src/olympia/users/models.py:489
 msgid "Please confirm your email address"
 msgstr "رجاءً قم بتأكيد عنوان بريدك الإلكتروني"
 
-#: src/olympia/users/models.py:506
+#: src/olympia/users/models.py:515
 msgid "My Mobile Add-ons"
 msgstr "إضافات هاتفي الذكي"
 
@@ -12627,7 +12160,7 @@ msgid "Confirm password"
 msgstr "أكّد كلمة السرّ"
 
 #: src/olympia/users/templates/users/pwreset_confirm.html:47
-msgid "The password reset link was invalid, possibly because it has already been used.  Please request a new password reset."
+msgid "The password reset link was invalid, possibly because it has already been used. Please request a new password reset."
 msgstr ""
 
 #: src/olympia/users/templates/users/pwreset_request.html:15
@@ -12815,7 +12348,7 @@ msgstr ""
 
 #: src/olympia/users/templates/users/unsubscribe.html:30
 #, python-format
-msgid "Unfortunately, we weren't able to unsubscribe you.  The link you clicked is invalid. However, you can unsubscribe still unsubscribe on your <a href=\"%(edit_url)s\">edit profile page</a>."
+msgid "Unfortunately, we weren't able to unsubscribe you. The link you clicked is invalid. However, you can unsubscribe still unsubscribe on your <a href=\"%(edit_url)s\">edit profile page</a>."
 msgstr ""
 
 #: src/olympia/users/templates/users/vcard.html:2
@@ -12848,10 +12381,6 @@ msgid "%(num)s theme"
 msgid_plural "%(num)s themes"
 msgstr[0] ""
 msgstr[1] ""
-msgstr[2] ""
-msgstr[3] ""
-msgstr[4] ""
-msgstr[5] ""
 
 #: src/olympia/users/templates/users/vcard.html:62
 #, python-format
@@ -12859,10 +12388,6 @@ msgid "%(num)s add-on"
 msgid_plural "%(num)s add-ons"
 msgstr[0] "لا إضافات"
 msgstr[1] "إضافة واحدة"
-msgstr[2] "إضافتين إثنتين"
-msgstr[3] "%(num)s إضافات"
-msgstr[4] "%(num)s إضافة"
-msgstr[5] "%(num)s إضافة"
 
 #: src/olympia/users/templates/users/vcard.html:75
 msgid "Average rating of developer's add-ons"
@@ -12877,15 +12402,15 @@ msgstr "تأريخ إصدار %s"
 msgid "Version History with Changelogs"
 msgstr "تاريخ الإصدارات مع سجل التغييرات"
 
-#: src/olympia/versions/models.py:314
+#: src/olympia/versions/models.py:313
 msgid "Add-on uses binary components."
 msgstr ""
 
-#: src/olympia/versions/models.py:317
+#: src/olympia/versions/models.py:316
 msgid "Add-on has opted into strict compatibility checking."
 msgstr ""
 
-#: src/olympia/versions/models.py:715
+#: src/olympia/versions/models.py:711
 msgid "{app} {min} and later"
 msgstr "{app} {min} وما بعدها"
 
@@ -12924,10 +12449,6 @@ msgid "<b>{0}</b> version"
 msgid_plural "<b>{0}</b> versions"
 msgstr[0] "لا إصدارات أخرى"
 msgstr[1] "إصدارة واحدة"
-msgstr[2] "إصدارتين"
-msgstr[3] "<b>{0}</b> إصدارات"
-msgstr[4] "<b>{0}</b> إصدارًا"
-msgstr[5] "<b>{0}</b> إصدار"
 
 #: src/olympia/versions/templates/versions/version_list.html:35 src/olympia/versions/templates/versions/mobile/version_list.html:14
 msgid "Be careful with old versions!"
@@ -12965,4 +12486,8 @@ msgstr ""
 
 #: src/olympia/zadmin/forms.py:105
 msgid "Log emails instead of sending"
+msgstr ""
+
+#: src/olympia/zadmin/forms.py:215
+msgid "Deleted versions can`t be changed."
 msgstr ""

--- a/locale/ar/LC_MESSAGES/djangojs.po
+++ b/locale/ar/LC_MESSAGES/djangojs.po
@@ -3,1269 +3,1234 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2016-02-24 21:23+0000\n"
+"POT-Creation-Date: 2016-04-18 15:47+0000\n"
 "PO-Revision-Date: 2016-02-11 09:01+0000\n"
 "Last-Translator: Abdelrahman Manna <abood.fcb@hotmail.com>\n"
 "Language-Team: <doc@arabeyes.org>\n"
+"Language: \n"
 "MIME-Version: 1.0\n"
-"Content-Type: text/plain; charset=utf-8\n"
+"Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Generated-By: Babel 2.2.0\n"
 
-#: static/js/common/ratingwidget.js:31
+#: static/js/common-all.js:1426 static/js/impala-all.js:1511 static/js/zamboni/discovery-all.js:12598 static/js/zamboni/init.js:28 static/js/zamboni/mobile-all.js:14945
+msgid "This feature is temporarily disabled while we perform website maintenance. Please check back a little later."
+msgstr "هذه الميزة معطلة مؤقتا بينما نقوم بصيانة الموقع حاليًا. رجاءً حاول مجددًا بعد قليل."
+
+#. L10n: {0} is an app name like Firefox.
+#: static/js/common-all.js:1837 static/js/impala-all.js:1922 static/js/zamboni/buttons.js:73 static/js/zamboni/discovery-all.js:13108
+msgid "Accept and Install"
+msgstr "قبول وتثبيت"
+
+#: static/js/common-all.js:1837 static/js/impala-all.js:1922 static/js/zamboni/buttons.js:73 static/js/zamboni/discovery-all.js:13108
+msgid "Add to {0}"
+msgstr "أضِف إلى {0}"
+
+#: static/js/common-all.js:1842 static/js/impala-all.js:1927 static/js/zamboni/buttons.js:78 static/js/zamboni/discovery-all.js:13113
+msgid "Download Now"
+msgstr "نزّل الآن"
+
+#: static/js/common-all.js:1883 static/js/impala-all.js:1968 static/js/zamboni/buttons.js:119 static/js/zamboni/discovery-all.js:13154
+msgid "Add-on has not been updated to support default-to-compatible."
+msgstr ""
+
+#: static/js/common-all.js:1888 static/js/impala-all.js:1973 static/js/zamboni/buttons.js:124 static/js/zamboni/discovery-all.js:13159
+msgid "You need to be using Firefox 10.0 or higher."
+msgstr ""
+
+#: static/js/common-all.js:1900 static/js/impala-all.js:1985 static/js/zamboni/buttons.js:136 static/js/zamboni/discovery-all.js:13171
+msgid "Mozilla has marked this version as incompatible with your Firefox version."
+msgstr ""
+
+#. L10n: {0} is an platform like Windows or Linux.
+#: static/js/common-all.js:1981 static/js/impala-all.js:2066 static/js/zamboni/buttons.js:217 static/js/zamboni/discovery-all.js:13252
+msgid "Install for {0} anyway"
+msgstr "ثبّت لـ {0} على كل حال"
+
+#: static/js/common-all.js:1981 static/js/impala-all.js:2066 static/js/zamboni/buttons.js:217 static/js/zamboni/discovery-all.js:13252
+msgid "Download for {0} anyway"
+msgstr "نزّل لـ {0} على كل حال"
+
+#: static/js/common-all.js:2038 static/js/impala-all.js:2123 static/js/zamboni/buttons.js:274 static/js/zamboni/discovery-all.js:13309
+msgid "Not available for your platform"
+msgstr "غير متوفر لمنصتك"
+
+#. L10n: {0} is an app name, {1} is the app version.
+#: static/js/common-all.js:2049 static/js/common-all.js:2086 static/js/impala-all.js:2134 static/js/impala-all.js:2171 static/js/zamboni/buttons.js:286 static/js/zamboni/buttons.js:324
+#: static/js/zamboni/discovery-all.js:13320 static/js/zamboni/discovery-all.js:13357
+msgid "Not available for {0} {1}"
+msgstr "غير متوفر لـ {0} {1}"
+
+#: static/js/common-all.js:2112 static/js/impala-all.js:2197 static/js/zamboni/buttons.js:351 static/js/zamboni/discovery-all.js:13383
+msgid "Works with {app} {min} - {max}"
+msgstr "تعمل مع {app} {min} - {max}"
+
+#: static/js/common-all.js:2114 static/js/impala-all.js:2199 static/js/zamboni/buttons.js:353 static/js/zamboni/discovery-all.js:13385
+msgid "View other versions"
+msgstr "عرض الإصدارات الأخرى"
+
+#: static/js/common-all.js:2162 static/js/impala-all.js:2247 static/js/zamboni/buttons.js:401 static/js/zamboni/discovery-all.js:13433
+msgid "Only with Firefox — Get Firefox Now!"
+msgstr ""
+
+#: static/js/common-all.js:2278 static/js/impala-all.js:2363 static/js/zamboni/buttons.js:517 static/js/zamboni/discovery-all.js:13549 static/js/zamboni/mobile-all.js:15177
+#: static/js/zamboni/mobile/buttons.js:43
+msgid "Sorry, you need a Mozilla-based browser (such as Firefox) to install a search plugin."
+msgstr "عفوًا، أنت بحاجة إلى متفصح مبني على موزيلا (مثل متصفح فيرفُكس) لتثبيت مُلحقات البحث."
+
+#: static/js/common-all.js:9088 static/js/impala-all.js:9649 static/js/zamboni/global.js:410
+msgid "Loading..."
+msgstr "يُحمّل..."
+
+#. L10n: {0} is the number of characters left.
+#: static/js/common-all.js:9152 static/js/impala-all.js:9713 static/js/zamboni/global.js:474
+msgid "<b>{0}</b> character left."
+msgid_plural "<b>{0}</b> characters left."
+msgstr[0] "لا حروف متبقية"
+msgstr[1] "حرف واحد متبقي"
+
+#: static/js/common-all.js:9589 static/js/common-min.js:6 static/js/impala-all.js:10052 static/js/impala-min.js:6 static/js/common/ratingwidget.js:31 static/js/zamboni/mobile-all.js:16123
+#: static/js/zamboni/mobile-min.js:6
 msgid "{0} star"
 msgid_plural "{0} stars"
 msgstr[0] "لا نجوم"
 msgstr[1] "نجمة واحدة"
-msgstr[2] "نجمتين"
-msgstr[3] "{0} نجوم"
-msgstr[4] "{0} نجمة"
-msgstr[5] "{0} نجمة"
 
-#: static/js/common/upload-addon.js:41 static/js/common/upload-image.js:128
+#: static/js/common-all.js:9676 static/js/common-min.js:6 static/js/impala-all.js:10139 static/js/impala-min.js:6 static/js/zamboni/l10n.js:45
+msgid "Remove this localization"
+msgstr ""
+
+#: static/js/common-all.js:10193 static/js/common-min.js:6 static/js/impala-all.js:10674 static/js/impala-min.js:6 static/js/zamboni/discovery-all.js:13678
+msgid "close"
+msgstr ""
+
+#: static/js/common-all.js:10860 static/js/common-min.js:6 static/js/impala-all.js:11481 static/js/impala-min.js:6 static/js/impala/reviews.js:23 static/js/zamboni/reviews.js:18
+msgid "Flagged for review"
+msgstr "تم تعليمه للمراجعة"
+
+#: static/js/common-all.js:10876 static/js/common-min.js:6 static/js/impala-all.js:11498 static/js/impala-min.js:6 static/js/impala/reviews.js:40 static/js/zamboni/reviews.js:34
+msgid "Your input is required"
+msgstr ""
+
+#: static/js/common-all.js:10945 static/js/common-min.js:6 static/js/impala-all.js:11610 static/js/impala-min.js:7 static/js/impala/reviews.js:152 static/js/zamboni/reviews.js:103
+msgid "Marked for deletion"
+msgstr "تم تعليمه ليُحذف"
+
+#: static/js/common-all.js:11573 static/js/common-min.js:7 static/js/impala-all.js:13809 static/js/impala-min.js:8 static/js/zamboni/collections.js:229
+msgid "Adding to Favorites&hellip;"
+msgstr "إضافة إلى المفضلات&hellip;"
+
+#: static/js/common-all.js:11576 static/js/common-min.js:7 static/js/impala-all.js:13812 static/js/impala-min.js:8 static/js/zamboni/collections.js:232
+msgid "Removing Favorite&hellip;"
+msgstr "إزالة المفضل&hellip;"
+
+#: static/js/common-all.js:11579 static/js/common-min.js:7 static/js/impala-all.js:13815 static/js/impala-min.js:8 static/js/zamboni/collections.js:235
+msgid "Add to Favorites"
+msgstr "أضِف إلى المفضلات"
+
+#: static/js/common-all.js:11582 static/js/common-min.js:7 static/js/impala-all.js:13818 static/js/impala-min.js:8 static/js/zamboni/collections.js:238
+msgid "Remove from Favorites"
+msgstr "أزِل من المفضلات"
+
+#: static/js/common-all.js:11647 static/js/common-min.js:7 static/js/impala-all.js:13883 static/js/impala-min.js:8 static/js/zamboni/collections.js:303
+msgid "Pending"
+msgstr "في الانتظار"
+
+#: static/js/common-all.js:11648 static/js/common-min.js:7 static/js/impala-all.js:13884 static/js/impala-min.js:8 static/js/zamboni/collections.js:304
+msgid "Add a comment"
+msgstr "أضِف تعليقا"
+
+#: static/js/common-all.js:11648 static/js/common-min.js:7 static/js/impala-all.js:13884 static/js/impala-min.js:8 static/js/zamboni/collections.js:304
+msgid "Comment"
+msgstr "تعليق"
+
+#: static/js/common-all.js:11649 static/js/common-min.js:7 static/js/impala-all.js:13885 static/js/impala-min.js:8 static/js/zamboni/collections.js:305
+msgid "Remove this add-on from the collection"
+msgstr "إزالة هذه الإضافة من المجموعة"
+
+#: static/js/common-all.js:11649 static/js/common-all.js:11678 static/js/common-min.js:7 static/js/impala-all.js:13885 static/js/impala-all.js:13914 static/js/impala-min.js:8
+#: static/js/zamboni/collections.js:305 static/js/zamboni/collections.js:334
+msgid "Remove"
+msgstr "إزالة"
+
+#: static/js/common-all.js:11678 static/js/common-min.js:7 static/js/impala-all.js:13914 static/js/impala-min.js:8 static/js/zamboni/collections.js:334
+msgid "Remove this user as a contributor"
+msgstr "إزالة هذا المستخدم كمساهم"
+
+#: static/js/common-all.js:11690 static/js/common-min.js:7 static/js/impala-all.js:13926 static/js/impala-min.js:8 static/js/zamboni/collections.js:346
+msgid "An email address is required."
+msgstr "مطلوب عنوان بريد إلكتروني."
+
+#: static/js/common-all.js:11708 static/js/common-min.js:7 static/js/impala-all.js:13944 static/js/impala-min.js:8 static/js/zamboni/collections.js:364
+msgid "You cannot add yourself as a contributor."
+msgstr "لا يمكنك إضافة نفسك كمساهم."
+
+#: static/js/common-all.js:11710 static/js/common-min.js:7 static/js/impala-all.js:13946 static/js/impala-min.js:8 static/js/zamboni/collections.js:366
+msgid "You have already added that user."
+msgstr "هذا المستخدم مُضاف بالفعل!"
+
+#: static/js/common-all.js:11917 static/js/common-min.js:7 static/js/impala-all.js:14153 static/js/impala-min.js:8 static/js/zamboni/collections.js:573
+msgid "Add to favorites"
+msgstr "أضِف إلى المفضلات"
+
+#: static/js/common-all.js:11921 static/js/common-min.js:7 static/js/impala-all.js:14157 static/js/impala-min.js:8 static/js/zamboni/collections.js:577
+msgid "Remove from favorites"
+msgstr "إزِل من المفضلات"
+
+#: static/js/common-all.js:11939 static/js/common-min.js:7 static/js/impala-all.js:14175 static/js/impala-all.js:14233 static/js/impala-min.js:8 static/js/impala/collections.js:10
+#: static/js/zamboni/collections.js:595
+msgid "Follow this Collection"
+msgstr "تابع هذه المجموعة"
+
+#: static/js/common-all.js:11948 static/js/common-min.js:7 static/js/impala-all.js:14184 static/js/impala-min.js:8 static/js/zamboni/collections.js:604
+msgid "Stop following"
+msgstr "أوقف المتابعة"
+
+#: static/js/common-all.js:12096 static/js/common-min.js:7 static/js/zamboni/password-strength.js:20
+msgid "Password strength:"
+msgstr "قوة كلمة السر:"
+
+#: static/js/common-all.js:12102 static/js/common-min.js:7 static/js/zamboni/password-strength.js:26
+msgid "At least {0} character left."
+msgid_plural "At least {0} characters left."
+msgstr[0] "لا حروف متبقية"
+msgstr[1] "حرف واحد متبقي على الأقل"
+
+#: static/js/common-all.js:12286 static/js/common-min.js:7 static/js/impala-all.js:14632 static/js/impala-min.js:8 static/js/impala/suggestions.js:39
+msgid "Search themes for <b>{0}</b>"
+msgstr "البحث في السِمات عن <b>{0}</b>"
+
+#: static/js/common-all.js:12288 static/js/common-min.js:7 static/js/impala-all.js:14634 static/js/impala-min.js:8 static/js/impala/suggestions.js:41
+msgid "Search apps for <b>{0}</b>"
+msgstr "البحث في التطبيقات عن <b>{0}</b>"
+
+#: static/js/common-all.js:12290 static/js/common-min.js:7 static/js/impala-all.js:14636 static/js/impala-min.js:8 static/js/impala/suggestions.js:43
+msgid "Search add-ons for <b>{0}</b>"
+msgstr "البحث في الإضافات عن <b>{0}</b>"
+
+#: static/js/common-all.js:12521 static/js/common-min.js:7 static/js/impala-all.js:14867 static/js/impala-min.js:8 static/js/impala/site_suggestions.js:46
+msgid "Category"
+msgstr "التصنيف"
+
+#. L10n: {0} is an app name.
+#: static/js/impala-all.js:11632 static/js/impala-min.js:7 static/js/impala/listing.js:11 static/js/zamboni/themes.js:13
+msgid "This theme is incompatible with your version of {0}"
+msgstr "هذه السِمة غير متوافقة مع إصدارتك من {0}"
+
+#: static/js/impala-all.js:12146 static/js/impala-all.js:14331 static/js/impala-min.js:7 static/js/impala-min.js:8 static/js/common/upload-image.js:97 static/js/impala/users.js:51
+#: static/js/zamboni/devhub-all.js:894 static/js/zamboni/devhub-min.js:1
+msgid "Images must be either PNG or JPG."
+msgstr "الصور يجب أن تكون PNG أو JPG."
+
+#: static/js/impala-all.js:12150 static/js/impala-min.js:7 static/js/common/upload-image.js:101 static/js/zamboni/devhub-all.js:898 static/js/zamboni/devhub-min.js:1
+msgid "Videos must be in WebM."
+msgstr "يجب أن تكون الفيديوهات بصيغة WebM."
+
+#: static/js/impala-all.js:12177 static/js/impala-min.js:7 static/js/common/upload-addon.js:41 static/js/common/upload-image.js:128 static/js/zamboni/devhub-all.js:272
+#: static/js/zamboni/devhub-all.js:925 static/js/zamboni/devhub-min.js:1
 msgid "There was a problem contacting the server."
 msgstr "هناك مشكلة ما في الاتصال بالخادم."
 
-#: static/js/common/upload-addon.js:69
+#: static/js/impala-all.js:13298 static/js/impala-min.js:7 static/js/impala/persona_creation.js:60
+msgid "All Rights Reserved"
+msgstr "جميع الحقوق محفوظة"
+
+#: static/js/impala-all.js:13302 static/js/impala-min.js:7 static/js/impala/persona_creation.js:64
+msgid "Creative Commons Attribution 3.0"
+msgstr ""
+
+#: static/js/impala-all.js:13307 static/js/impala-min.js:7 static/js/impala/persona_creation.js:69
+msgid "Creative Commons Attribution-NonCommercial 3.0"
+msgstr ""
+
+#: static/js/impala-all.js:13312 static/js/impala-min.js:7 static/js/impala/persona_creation.js:74
+msgid "Creative Commons Attribution-NonCommercial-NoDerivs 3.0"
+msgstr ""
+
+#: static/js/impala-all.js:13317 static/js/impala-min.js:7 static/js/impala/persona_creation.js:79
+msgid "Creative Commons Attribution-NonCommercial-Share Alike 3.0"
+msgstr ""
+
+#: static/js/impala-all.js:13322 static/js/impala-min.js:7 static/js/impala/persona_creation.js:84
+msgid "Creative Commons Attribution-NoDerivs 3.0"
+msgstr ""
+
+#: static/js/impala-all.js:13327 static/js/impala-min.js:7 static/js/impala/persona_creation.js:89
+msgid "Creative Commons Attribution-ShareAlike 3.0"
+msgstr ""
+
+#: static/js/impala-all.js:13530 static/js/impala-min.js:7 static/js/impala/persona_creation.js:292
+msgid "Your Theme's Name"
+msgstr ""
+
+#: static/js/impala-all.js:14242 static/js/impala-min.js:8 static/js/impala/collections.js:19
+msgid "Stop Following"
+msgstr "أوقف المتابعة"
+
+#: static/js/impala-all.js:14243 static/js/impala-min.js:8 static/js/impala/collections.js:20
+msgid "Following"
+msgstr ""
+
+#: static/js/impala-all.js:14313 static/js/impala-min.js:8 static/js/impala/users.js:33
+msgid "use original"
+msgstr ""
+
+#: static/js/impala-all.js:14523 static/js/impala-min.js:8 static/js/impala/search.js:114
+msgid "Updating results&hellip;"
+msgstr "يجري تحديث النتائج&hellip;"
+
+#: static/js/common/upload-addon.js:69 static/js/zamboni/devhub-all.js:300 static/js/zamboni/devhub-min.js:1
 msgid "Select a file..."
 msgstr "اختر ملفا..."
 
-#: static/js/common/upload-addon.js:70
+#: static/js/common/upload-addon.js:70 static/js/zamboni/devhub-all.js:301 static/js/zamboni/devhub-min.js:1
 msgid "Your add-on should end with .xpi, .jar or .xml"
 msgstr "إضافتك ينبغي أن تنتهي بـ xpi. أو jar. أو xml."
 
 #. L10n: {0} is the percent of the file that has been uploaded.
-#: static/js/common/upload-addon.js:104
+#: static/js/common/upload-addon.js:104 static/js/zamboni/devhub-all.js:335 static/js/zamboni/devhub-min.js:1
 #, fuzzy, python-format
 msgid "{0}% complete"
 msgstr "اكتمل {0}%"
 
 #. L10n: "{bytes uploaded} of {total filesize}".
-#: static/js/common/upload-addon.js:107
+#: static/js/common/upload-addon.js:107 static/js/zamboni/devhub-all.js:338 static/js/zamboni/devhub-min.js:1
 msgid "{0} of {1}"
 msgstr "{0} من {1}"
 
-#: static/js/common/upload-addon.js:140
+#: static/js/common/upload-addon.js:140 static/js/zamboni/devhub-all.js:371 static/js/zamboni/devhub-min.js:1
 msgid "Cancel"
 msgstr "إلغاء"
 
-#: static/js/common/upload-addon.js:162
+#: static/js/common/upload-addon.js:162 static/js/zamboni/devhub-all.js:393 static/js/zamboni/devhub-min.js:1
 msgid "Uploading {0}"
 msgstr "يرفع {0}"
 
-#: static/js/common/upload-addon.js:189
+#: static/js/common/upload-addon.js:189 static/js/zamboni/devhub-all.js:420 static/js/zamboni/devhub-min.js:1
 msgid "Error with {0}"
 msgstr "خطأ في {0}"
 
-#: static/js/common/upload-addon.js:194
+#: static/js/common/upload-addon.js:194 static/js/zamboni/devhub-all.js:425 static/js/zamboni/devhub-min.js:1
 msgid "Your add-on failed validation with {0} error."
 msgid_plural "Your add-on failed validation with {0} errors."
 msgstr[0] "فشل التحقق من إضافتك ب {0} خطأ."
 msgstr[1] "فشل التحقق من إضافتك بخطأ واحد."
-msgstr[2] "فشل التحقق من إضافتك بخطأين."
-msgstr[3] ""
-msgstr[4] ""
-msgstr[5] ""
 
-#: static/js/common/upload-addon.js:208
+#: static/js/common/upload-addon.js:208 static/js/zamboni/devhub-all.js:439 static/js/zamboni/devhub-min.js:1
 msgid "&hellip;and {0} more"
 msgid_plural "&hellip;and {0} more"
 msgstr[0] ""
 msgstr[1] ""
-msgstr[2] ""
-msgstr[3] ""
-msgstr[4] ""
-msgstr[5] ""
 
-#: static/js/common/upload-addon.js:222 static/js/common/upload-addon.js:512
+#: static/js/common/upload-addon.js:222 static/js/common/upload-addon.js:497 static/js/zamboni/devhub-all.js:453 static/js/zamboni/devhub-all.js:743 static/js/zamboni/devhub-min.js:1
 msgid "See full validation report"
 msgstr "مشاهدة تقرير التحقق كاملاً"
 
-#: static/js/common/upload-addon.js:234
+#: static/js/common/upload-addon.js:234 static/js/zamboni/devhub-all.js:465 static/js/zamboni/devhub-min.js:1
 msgid "Validating {0}"
 msgstr "يتم التحقق {0}"
 
 #. L10n: first argument is an HTTP status code
-#: static/js/common/upload-addon.js:273
+#: static/js/common/upload-addon.js:273 static/js/zamboni/devhub-all.js:504 static/js/zamboni/devhub-min.js:1
 msgid "Received an empty response from the server; status: {0}"
 msgstr ""
 
-#: static/js/common/upload-addon.js:373
+#: static/js/common/upload-addon.js:370 static/js/zamboni/devhub-all.js:604 static/js/zamboni/devhub-min.js:1
 msgid "Unexpected server error while validating."
 msgstr ""
 
-#: static/js/common/upload-addon.js:412
+#: static/js/common/upload-addon.js:409 static/js/zamboni/devhub-all.js:643 static/js/zamboni/devhub-min.js:1
 msgid "Finished validating {0}"
 msgstr "تم انتهاء التحقق {0}"
 
-#: static/js/common/upload-addon.js:418
+#: static/js/common/upload-addon.js:415 static/js/zamboni/devhub-all.js:649 static/js/zamboni/devhub-min.js:1
 msgid "Your add-on validation timed out, it will be manually reviewed."
 msgstr ""
 
-#: static/js/common/upload-addon.js:421
+#: static/js/common/upload-addon.js:418 static/js/zamboni/devhub-all.js:652 static/js/zamboni/devhub-min.js:1
 msgid "Your add-on was validated with no errors and {0} warning."
 msgid_plural "Your add-on was validated with no errors and {0} warnings."
 msgstr[0] ""
 msgstr[1] ""
-msgstr[2] ""
-msgstr[3] ""
-msgstr[4] ""
-msgstr[5] ""
 
-#: static/js/common/upload-addon.js:426
+#: static/js/common/upload-addon.js:423 static/js/zamboni/devhub-all.js:657 static/js/zamboni/devhub-min.js:1
 msgid "Your add-on was validated with no errors and {0} message."
 msgid_plural "Your add-on was validated with no errors and {0} messages."
 msgstr[0] ""
 msgstr[1] ""
-msgstr[2] ""
-msgstr[3] ""
-msgstr[4] ""
-msgstr[5] ""
 
-#: static/js/common/upload-addon.js:431
+#: static/js/common/upload-addon.js:428 static/js/zamboni/devhub-all.js:662 static/js/zamboni/devhub-min.js:1
 msgid "Your add-on was validated with no errors or warnings."
 msgstr ""
 
-#: static/js/common/upload-addon.js:446
+#: static/js/common/upload-addon.js:443 static/js/zamboni/devhub-all.js:677 static/js/zamboni/devhub-min.js:1
 msgid "Your submission will be automatically signed."
 msgstr ""
 
-#: static/js/common/upload-addon.js:465
+#: static/js/common/upload-addon.js:450 static/js/zamboni/devhub-all.js:696 static/js/zamboni/devhub-min.js:1
 msgid "Include detailed version notes (this can be done in the next step)."
 msgstr ""
 
-#: static/js/common/upload-addon.js:466
+#: static/js/common/upload-addon.js:451 static/js/zamboni/devhub-all.js:697 static/js/zamboni/devhub-min.js:1
 msgid "If your add-on requires an account to a website in order to be fully tested, include a test username and password in the Notes to Reviewer (this can be done in the next step)."
 msgstr ""
 
-#: static/js/common/upload-addon.js:467
+#: static/js/common/upload-addon.js:452 static/js/zamboni/devhub-all.js:698 static/js/zamboni/devhub-min.js:1
 msgid "If your add-on is intended for a limited audience you should choose Preliminary Review instead of Full Review."
 msgstr ""
 
-#: static/js/common/upload-addon.js:480
+#: static/js/common/upload-addon.js:465 static/js/zamboni/devhub-all.js:711 static/js/zamboni/devhub-min.js:1
 msgid "Add-on submission checklist"
 msgstr ""
 
-#: static/js/common/upload-addon.js:481
+#: static/js/common/upload-addon.js:466 static/js/zamboni/devhub-all.js:712 static/js/zamboni/devhub-min.js:1
 msgid "Please verify the following points before finalizing your submission. This will minimize delays or misunderstanding during the review process:"
 msgstr ""
 
-#: static/js/common/upload-addon.js:483
+#: static/js/common/upload-addon.js:468 static/js/zamboni/devhub-all.js:714 static/js/zamboni/devhub-min.js:1
 msgid ""
 "Compiled binaries, as well as minified or obfuscated scripts (excluding known libraries) need to have their sources submitted separately for review. Make sure that you use the source code upload "
 "field to avoid having your submission rejected."
 msgstr ""
 
-#: static/js/common/upload-addon.js:501
+#: static/js/common/upload-addon.js:486 static/js/zamboni/devhub-all.js:732 static/js/zamboni/devhub-min.js:1
 msgid "The validation process found these issues that can lead to rejections:"
 msgstr ""
 
-#: static/js/common/upload-addon.js:518
+#: static/js/common/upload-addon.js:503 static/js/zamboni/devhub-all.js:749 static/js/zamboni/devhub-min.js:1
 msgid "If you are unfamiliar with the add-ons review process, you can read about it here."
 msgstr ""
 
-#: static/js/common/upload-addon.js:555
+#: static/js/common/upload-addon.js:540 static/js/zamboni/devhub-all.js:786 static/js/zamboni/devhub-min.js:1
 msgid "Sorry, no supported platform has been found."
 msgstr ""
 
-#: static/js/common/upload-base.js:57
+#: static/js/common/upload-base.js:57 static/js/zamboni/devhub-all.js:187 static/js/zamboni/devhub-min.js:1
 msgid "The filetype you uploaded isn't recognized."
 msgstr ""
 
-#: static/js/common/upload-base.js:79
+#: static/js/common/upload-base.js:79 static/js/zamboni/devhub-all.js:209 static/js/zamboni/devhub-min.js:1
 msgid "You cancelled the upload."
 msgstr "لقد ألغيت الرفع."
 
-#: static/js/common/upload-image.js:97 static/js/impala/users.js:51
-msgid "Images must be either PNG or JPG."
-msgstr "الصور يجب أن تكون PNG أو JPG."
-
-#: static/js/common/upload-image.js:101
-msgid "Videos must be in WebM."
-msgstr "يجب أن تكون الفيديوهات بصيغة WebM."
-
-#: static/js/impala/collections.js:10 static/js/zamboni/collections.js:595
-msgid "Follow this Collection"
-msgstr "تابع هذه المجموعة"
-
-#: static/js/impala/collections.js:19
-msgid "Stop Following"
-msgstr "أوقف المتابعة"
-
-#: static/js/impala/collections.js:20
-msgid "Following"
-msgstr ""
-
-#. L10n: {0} is an app name.
-#: static/js/impala/listing.js:11 static/js/zamboni/themes.js:13
-msgid "This theme is incompatible with your version of {0}"
-msgstr "هذه السِمة غير متوافقة مع إصدارتك من {0}"
-
-#: static/js/impala/persona_creation.js:60
-msgid "All Rights Reserved"
-msgstr "جميع الحقوق محفوظة"
-
-#: static/js/impala/persona_creation.js:64
-msgid "Creative Commons Attribution 3.0"
-msgstr ""
-
-#: static/js/impala/persona_creation.js:69
-msgid "Creative Commons Attribution-NonCommercial 3.0"
-msgstr ""
-
-#: static/js/impala/persona_creation.js:74
-msgid "Creative Commons Attribution-NonCommercial-NoDerivs 3.0"
-msgstr ""
-
-#: static/js/impala/persona_creation.js:79
-msgid "Creative Commons Attribution-NonCommercial-Share Alike 3.0"
-msgstr ""
-
-#: static/js/impala/persona_creation.js:84
-msgid "Creative Commons Attribution-NoDerivs 3.0"
-msgstr ""
-
-#: static/js/impala/persona_creation.js:89
-msgid "Creative Commons Attribution-ShareAlike 3.0"
-msgstr ""
-
-#: static/js/impala/persona_creation.js:292
-msgid "Your Theme's Name"
-msgstr ""
-
-#: static/js/impala/reviews.js:23 static/js/zamboni/reviews.js:18
-msgid "Flagged for review"
-msgstr "تم تعليمه للمراجعة"
-
-#: static/js/impala/reviews.js:40 static/js/zamboni/reviews.js:34
-msgid "Your input is required"
-msgstr ""
-
-#: static/js/impala/reviews.js:152 static/js/zamboni/reviews.js:103
-msgid "Marked for deletion"
-msgstr "تم تعليمه ليُحذف"
-
-#: static/js/impala/search.js:114
-msgid "Updating results&hellip;"
-msgstr "يجري تحديث النتائج&hellip;"
-
-#: static/js/impala/site_suggestions.js:46
-msgid "Category"
-msgstr "التصنيف"
-
-#: static/js/impala/suggestions.js:39
-msgid "Search themes for <b>{0}</b>"
-msgstr "البحث في السِمات عن <b>{0}</b>"
-
-#: static/js/impala/suggestions.js:41
-msgid "Search apps for <b>{0}</b>"
-msgstr "البحث في التطبيقات عن <b>{0}</b>"
-
-#: static/js/impala/suggestions.js:43
-msgid "Search add-ons for <b>{0}</b>"
-msgstr "البحث في الإضافات عن <b>{0}</b>"
-
-#: static/js/impala/users.js:33
-msgid "use original"
-msgstr ""
-
-#: static/js/impala/stats/chart.js:267
+#: static/js/impala/stats/chart.js:267 static/js/zamboni/stats-all.js:16898 static/js/zamboni/stats-min.js:5
 msgid "Week of {0}"
 msgstr ""
 
-#: static/js/impala/stats/chart.js:269
+#: static/js/impala/stats/chart.js:269 static/js/zamboni/stats-all.js:16900 static/js/zamboni/stats-min.js:5
 msgid " downloads"
 msgstr ""
 
-#: static/js/impala/stats/chart.js:270
+#: static/js/impala/stats/chart.js:270 static/js/zamboni/stats-all.js:16901 static/js/zamboni/stats-min.js:5
 msgid "{0} users"
 msgstr ""
 
-#: static/js/impala/stats/chart.js:271
+#: static/js/impala/stats/chart.js:271 static/js/zamboni/stats-all.js:16902 static/js/zamboni/stats-min.js:5
 msgid "{0} add-ons"
 msgstr ""
 
-#: static/js/impala/stats/chart.js:272
+#: static/js/impala/stats/chart.js:272 static/js/zamboni/stats-all.js:16903 static/js/zamboni/stats-min.js:5
 msgid "{0} collections"
 msgstr ""
 
-#: static/js/impala/stats/chart.js:273
+#: static/js/impala/stats/chart.js:273 static/js/zamboni/stats-all.js:16904 static/js/zamboni/stats-min.js:5
 msgid "{0} reviews"
 msgstr ""
 
-#: static/js/impala/stats/chart.js:275
+#: static/js/impala/stats/chart.js:275 static/js/zamboni/stats-all.js:16906 static/js/zamboni/stats-min.js:5
 msgid "{0} sales"
 msgstr ""
 
-#: static/js/impala/stats/chart.js:276
+#: static/js/impala/stats/chart.js:276 static/js/zamboni/stats-all.js:16907 static/js/zamboni/stats-min.js:5
 msgid "{0} refunds"
 msgstr ""
 
-#: static/js/impala/stats/chart.js:277
+#: static/js/impala/stats/chart.js:277 static/js/zamboni/stats-all.js:16908 static/js/zamboni/stats-min.js:5
 msgid "{0} installs"
 msgstr ""
 
-#: static/js/impala/stats/chart.js:369 static/js/impala/stats/csv_keys.js:3 static/js/impala/stats/csv_keys.js:109
+#: static/js/impala/stats/chart.js:369 static/js/impala/stats/csv_keys.js:3 static/js/impala/stats/csv_keys.js:109 static/js/zamboni/stats-all.js:15284 static/js/zamboni/stats-all.js:15390
+#: static/js/zamboni/stats-all.js:17000 static/js/zamboni/stats-min.js:4 static/js/zamboni/stats-min.js:5
 msgid "Downloads"
 msgstr "التنزيلات"
 
-#: static/js/impala/stats/chart.js:379 static/js/impala/stats/csv_keys.js:6 static/js/impala/stats/csv_keys.js:110
+#: static/js/impala/stats/chart.js:379 static/js/impala/stats/csv_keys.js:6 static/js/impala/stats/csv_keys.js:110 static/js/zamboni/stats-all.js:15287 static/js/zamboni/stats-all.js:15391
+#: static/js/zamboni/stats-all.js:17010 static/js/zamboni/stats-min.js:4 static/js/zamboni/stats-min.js:5
 msgid "Daily Users"
 msgstr "الاستخدام اليومي"
 
-#: static/js/impala/stats/chart.js:410
+#: static/js/impala/stats/chart.js:410 static/js/zamboni/stats-all.js:17041 static/js/zamboni/stats-min.js:5
 msgid "Amount, in USD"
 msgstr ""
 
-#: static/js/impala/stats/chart.js:421 static/js/impala/stats/csv_keys.js:104
+#: static/js/impala/stats/chart.js:421 static/js/impala/stats/csv_keys.js:104 static/js/zamboni/stats-all.js:15385 static/js/zamboni/stats-all.js:17052 static/js/zamboni/stats-min.js:5
 msgid "Number of Contributions"
 msgstr "عدد المساهمات"
 
-#: static/js/impala/stats/chart.js:447
+#: static/js/impala/stats/chart.js:447 static/js/zamboni/stats-all.js:17078 static/js/zamboni/stats-min.js:5
 msgid "More Info..."
 msgstr "مزيد من المعلومات..."
 
 #. L10n: {0} is an ISO-formatted date.
-#: static/js/impala/stats/chart.js:451
+#: static/js/impala/stats/chart.js:451 static/js/zamboni/stats-all.js:17082 static/js/zamboni/stats-min.js:5
 msgid "Details for {0}"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:9
+#: static/js/impala/stats/csv_keys.js:9 static/js/zamboni/stats-all.js:15290 static/js/zamboni/stats-min.js:4
 msgid "Collections Created"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:12
+#: static/js/impala/stats/csv_keys.js:12 static/js/zamboni/stats-all.js:15293 static/js/zamboni/stats-min.js:4
 msgid "Add-ons in Use"
 msgstr "الإضافات قيد الاستخدام"
 
-#: static/js/impala/stats/csv_keys.js:15
+#: static/js/impala/stats/csv_keys.js:15 static/js/zamboni/stats-all.js:15296 static/js/zamboni/stats-min.js:4
 msgid "Add-ons Created"
 msgstr "الإضافات المُنشئة"
 
-#: static/js/impala/stats/csv_keys.js:18
+#: static/js/impala/stats/csv_keys.js:18 static/js/zamboni/stats-all.js:15299 static/js/zamboni/stats-min.js:4
 msgid "Add-ons Downloaded"
 msgstr "الإضافات المُنزّلة"
 
-#: static/js/impala/stats/csv_keys.js:21
+#: static/js/impala/stats/csv_keys.js:21 static/js/zamboni/stats-all.js:15302 static/js/zamboni/stats-min.js:4
 msgid "Add-ons Updated"
 msgstr "الإضافات المُحدّثة"
 
-#: static/js/impala/stats/csv_keys.js:24
+#: static/js/impala/stats/csv_keys.js:24 static/js/zamboni/stats-all.js:15305 static/js/zamboni/stats-min.js:4
 msgid "Reviews Written"
 msgstr "التعليقات المكتوبة"
 
-#: static/js/impala/stats/csv_keys.js:27
+#: static/js/impala/stats/csv_keys.js:27 static/js/zamboni/stats-all.js:15308 static/js/zamboni/stats-min.js:4
 msgid "User Signups"
 msgstr "تسجيلات المستخدمين"
 
-#: static/js/impala/stats/csv_keys.js:30
+#: static/js/impala/stats/csv_keys.js:30 static/js/zamboni/stats-all.js:15311 static/js/zamboni/stats-min.js:4
 msgid "Subscribers"
 msgstr "المشتركين"
 
-#: static/js/impala/stats/csv_keys.js:33
+#: static/js/impala/stats/csv_keys.js:33 static/js/zamboni/stats-all.js:15314 static/js/zamboni/stats-min.js:4
 msgid "Ratings"
 msgstr "التقييمات"
 
-#: static/js/impala/stats/csv_keys.js:36 static/js/impala/stats/csv_keys.js:114
+#: static/js/impala/stats/csv_keys.js:36 static/js/impala/stats/csv_keys.js:114 static/js/zamboni/stats-all.js:15317 static/js/zamboni/stats-all.js:15395 static/js/zamboni/stats-min.js:4
+#: static/js/zamboni/stats-min.js:5
 msgid "Sales"
 msgstr "المبيعات"
 
-#: static/js/impala/stats/csv_keys.js:39 static/js/impala/stats/csv_keys.js:113
+#: static/js/impala/stats/csv_keys.js:39 static/js/impala/stats/csv_keys.js:113 static/js/zamboni/stats-all.js:15320 static/js/zamboni/stats-all.js:15394 static/js/zamboni/stats-min.js:4
+#: static/js/zamboni/stats-min.js:5
 msgid "Installs"
 msgstr "التثبيتات"
 
-#: static/js/impala/stats/csv_keys.js:42
+#: static/js/impala/stats/csv_keys.js:42 static/js/zamboni/stats-all.js:15323 static/js/zamboni/stats-min.js:4
 msgid "Unknown"
 msgstr "مجهول"
 
-#: static/js/impala/stats/csv_keys.js:43
+#: static/js/impala/stats/csv_keys.js:43 static/js/zamboni/stats-all.js:15324 static/js/zamboni/stats-min.js:4
 msgid "Add-ons Manager"
 msgstr "مدير الإضافات"
 
-#: static/js/impala/stats/csv_keys.js:44
+#: static/js/impala/stats/csv_keys.js:44 static/js/zamboni/stats-all.js:15325 static/js/zamboni/stats-min.js:4
 msgid "Add-ons Manager Promo"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:45
+#: static/js/impala/stats/csv_keys.js:45 static/js/zamboni/stats-all.js:15326 static/js/zamboni/stats-min.js:4
 msgid "Add-ons Manager Featured"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:46
+#: static/js/impala/stats/csv_keys.js:46 static/js/zamboni/stats-all.js:15327 static/js/zamboni/stats-min.js:4
 msgid "Add-ons Manager Learn More"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:47
+#: static/js/impala/stats/csv_keys.js:47 static/js/zamboni/stats-all.js:15328 static/js/zamboni/stats-min.js:4
 msgid "Search Suggestions"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:48
+#: static/js/impala/stats/csv_keys.js:48 static/js/zamboni/stats-all.js:15329 static/js/zamboni/stats-min.js:4
 msgid "Search Results"
 msgstr "نتائج البحث"
 
-#: static/js/impala/stats/csv_keys.js:49 static/js/impala/stats/csv_keys.js:50 static/js/impala/stats/csv_keys.js:51
+#: static/js/impala/stats/csv_keys.js:49 static/js/impala/stats/csv_keys.js:50 static/js/impala/stats/csv_keys.js:51 static/js/zamboni/stats-all.js:15330 static/js/zamboni/stats-all.js:15331
+#: static/js/zamboni/stats-all.js:15332 static/js/zamboni/stats-min.js:4
 msgid "Homepage Promo"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:52 static/js/impala/stats/csv_keys.js:53
+#: static/js/impala/stats/csv_keys.js:52 static/js/impala/stats/csv_keys.js:53 static/js/zamboni/stats-all.js:15333 static/js/zamboni/stats-all.js:15334 static/js/zamboni/stats-min.js:4
 msgid "Homepage Featured"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:54 static/js/impala/stats/csv_keys.js:55
+#: static/js/impala/stats/csv_keys.js:54 static/js/impala/stats/csv_keys.js:55 static/js/zamboni/stats-all.js:15335 static/js/zamboni/stats-all.js:15336 static/js/zamboni/stats-min.js:4
 msgid "Homepage Up and Coming"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:56
+#: static/js/impala/stats/csv_keys.js:56 static/js/zamboni/stats-all.js:15337 static/js/zamboni/stats-min.js:4
 msgid "Homepage Most Popular"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:57 static/js/impala/stats/csv_keys.js:59
+#: static/js/impala/stats/csv_keys.js:57 static/js/impala/stats/csv_keys.js:59 static/js/zamboni/stats-all.js:15338 static/js/zamboni/stats-all.js:15340 static/js/zamboni/stats-min.js:4
 msgid "Detail Page"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:58 static/js/impala/stats/csv_keys.js:60
+#: static/js/impala/stats/csv_keys.js:58 static/js/impala/stats/csv_keys.js:60 static/js/zamboni/stats-all.js:15339 static/js/zamboni/stats-all.js:15341 static/js/zamboni/stats-min.js:4
 msgid "Detail Page (bottom)"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:61
+#: static/js/impala/stats/csv_keys.js:61 static/js/zamboni/stats-all.js:15342 static/js/zamboni/stats-min.js:4
 msgid "Detail Page (Development Channel)"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:62 static/js/impala/stats/csv_keys.js:63 static/js/impala/stats/csv_keys.js:64
+#: static/js/impala/stats/csv_keys.js:62 static/js/impala/stats/csv_keys.js:63 static/js/impala/stats/csv_keys.js:64 static/js/zamboni/stats-all.js:15343 static/js/zamboni/stats-all.js:15344
+#: static/js/zamboni/stats-all.js:15345 static/js/zamboni/stats-min.js:4
 msgid "Often Used With"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:65 static/js/impala/stats/csv_keys.js:66
+#: static/js/impala/stats/csv_keys.js:65 static/js/impala/stats/csv_keys.js:66 static/js/zamboni/stats-all.js:15346 static/js/zamboni/stats-all.js:15347 static/js/zamboni/stats-min.js:4
 msgid "Others By Author"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:67 static/js/impala/stats/csv_keys.js:68
+#: static/js/impala/stats/csv_keys.js:67 static/js/impala/stats/csv_keys.js:68 static/js/zamboni/stats-all.js:15348 static/js/zamboni/stats-all.js:15349 static/js/zamboni/stats-min.js:4
 msgid "Dependencies"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:69 static/js/impala/stats/csv_keys.js:70
+#: static/js/impala/stats/csv_keys.js:69 static/js/impala/stats/csv_keys.js:70 static/js/zamboni/stats-all.js:15350 static/js/zamboni/stats-all.js:15351 static/js/zamboni/stats-min.js:4
 msgid "Upsell"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:71
+#: static/js/impala/stats/csv_keys.js:71 static/js/zamboni/stats-all.js:15352 static/js/zamboni/stats-min.js:4
 msgid "Meet the Developer"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:72
+#: static/js/impala/stats/csv_keys.js:72 static/js/zamboni/stats-all.js:15353 static/js/zamboni/stats-min.js:4
 msgid "User Profile"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:73
+#: static/js/impala/stats/csv_keys.js:73 static/js/zamboni/stats-all.js:15354 static/js/zamboni/stats-min.js:4
 msgid "Version History"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:75
+#: static/js/impala/stats/csv_keys.js:75 static/js/zamboni/stats-all.js:15356 static/js/zamboni/stats-min.js:4
 msgid "Sharing"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:76
+#: static/js/impala/stats/csv_keys.js:76 static/js/zamboni/stats-all.js:15357 static/js/zamboni/stats-min.js:4
 msgid "Category Pages"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:77
+#: static/js/impala/stats/csv_keys.js:77 static/js/zamboni/stats-all.js:15358 static/js/zamboni/stats-min.js:4
 msgid "Collections"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:78 static/js/impala/stats/csv_keys.js:79
+#: static/js/impala/stats/csv_keys.js:78 static/js/impala/stats/csv_keys.js:79 static/js/zamboni/stats-all.js:15359 static/js/zamboni/stats-all.js:15360 static/js/zamboni/stats-min.js:4
 msgid "Category Landing Featured Carousel"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:80 static/js/impala/stats/csv_keys.js:81
+#: static/js/impala/stats/csv_keys.js:80 static/js/impala/stats/csv_keys.js:81 static/js/zamboni/stats-all.js:15361 static/js/zamboni/stats-all.js:15362 static/js/zamboni/stats-min.js:4
 msgid "Category Landing Top Rated"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:82 static/js/impala/stats/csv_keys.js:83
+#: static/js/impala/stats/csv_keys.js:82 static/js/impala/stats/csv_keys.js:83 static/js/zamboni/stats-all.js:15363 static/js/zamboni/stats-all.js:15364 static/js/zamboni/stats-min.js:5
 msgid "Category Landing Most Popular"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:84 static/js/impala/stats/csv_keys.js:85
+#: static/js/impala/stats/csv_keys.js:84 static/js/impala/stats/csv_keys.js:85 static/js/zamboni/stats-all.js:15365 static/js/zamboni/stats-all.js:15366 static/js/zamboni/stats-min.js:5
 msgid "Category Landing Recently Added"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:86 static/js/impala/stats/csv_keys.js:87
+#: static/js/impala/stats/csv_keys.js:86 static/js/impala/stats/csv_keys.js:87 static/js/zamboni/stats-all.js:15367 static/js/zamboni/stats-all.js:15368 static/js/zamboni/stats-min.js:5
 msgid "Browse Listing Featured Sort"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:88 static/js/impala/stats/csv_keys.js:89
+#: static/js/impala/stats/csv_keys.js:88 static/js/impala/stats/csv_keys.js:89 static/js/zamboni/stats-all.js:15369 static/js/zamboni/stats-all.js:15370 static/js/zamboni/stats-min.js:5
 msgid "Browse Listing Users Sort"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:90 static/js/impala/stats/csv_keys.js:91
+#: static/js/impala/stats/csv_keys.js:90 static/js/impala/stats/csv_keys.js:91 static/js/zamboni/stats-all.js:15371 static/js/zamboni/stats-all.js:15372 static/js/zamboni/stats-min.js:5
 msgid "Browse Listing Rating Sort"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:92 static/js/impala/stats/csv_keys.js:93
+#: static/js/impala/stats/csv_keys.js:92 static/js/impala/stats/csv_keys.js:93 static/js/zamboni/stats-all.js:15373 static/js/zamboni/stats-all.js:15374 static/js/zamboni/stats-min.js:5
 msgid "Browse Listing Created Sort"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:94 static/js/impala/stats/csv_keys.js:95
+#: static/js/impala/stats/csv_keys.js:94 static/js/impala/stats/csv_keys.js:95 static/js/zamboni/stats-all.js:15375 static/js/zamboni/stats-all.js:15376 static/js/zamboni/stats-min.js:5
 msgid "Browse Listing Name Sort"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:96 static/js/impala/stats/csv_keys.js:97
+#: static/js/impala/stats/csv_keys.js:96 static/js/impala/stats/csv_keys.js:97 static/js/zamboni/stats-all.js:15377 static/js/zamboni/stats-all.js:15378 static/js/zamboni/stats-min.js:5
 msgid "Browse Listing Popular Sort"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:98 static/js/impala/stats/csv_keys.js:99
+#: static/js/impala/stats/csv_keys.js:98 static/js/impala/stats/csv_keys.js:99 static/js/zamboni/stats-all.js:15379 static/js/zamboni/stats-all.js:15380 static/js/zamboni/stats-min.js:5
 msgid "Browse Listing Updated Sort"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:100 static/js/impala/stats/csv_keys.js:101
+#: static/js/impala/stats/csv_keys.js:100 static/js/impala/stats/csv_keys.js:101 static/js/zamboni/stats-all.js:15381 static/js/zamboni/stats-all.js:15382 static/js/zamboni/stats-min.js:5
 msgid "Browse Listing Up and Coming Sort"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:105
+#: static/js/impala/stats/csv_keys.js:105 static/js/zamboni/stats-all.js:15386 static/js/zamboni/stats-min.js:5
 msgid "Total Amount Contributed"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:106
+#: static/js/impala/stats/csv_keys.js:106 static/js/zamboni/stats-all.js:15387 static/js/zamboni/stats-min.js:5
 msgid "Average Contribution"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:115
+#: static/js/impala/stats/csv_keys.js:115 static/js/zamboni/stats-all.js:15396 static/js/zamboni/stats-min.js:5
 msgid "Usage"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:118
+#: static/js/impala/stats/csv_keys.js:118 static/js/zamboni/stats-all.js:15399 static/js/zamboni/stats-min.js:5
 msgid "Firefox"
 msgstr "فيرفُكس"
 
-#: static/js/impala/stats/csv_keys.js:119
+#: static/js/impala/stats/csv_keys.js:119 static/js/zamboni/stats-all.js:15400 static/js/zamboni/stats-min.js:5
 msgid "Mozilla"
 msgstr "موزيلا"
 
-#: static/js/impala/stats/csv_keys.js:120
+#: static/js/impala/stats/csv_keys.js:120 static/js/zamboni/stats-all.js:15401 static/js/zamboni/stats-min.js:5
 msgid "Thunderbird"
 msgstr "تندربيرد"
 
-#: static/js/impala/stats/csv_keys.js:121
+#: static/js/impala/stats/csv_keys.js:121 static/js/zamboni/stats-all.js:15402 static/js/zamboni/stats-min.js:5
 msgid "Sunbird"
 msgstr "صنبيرد"
 
-#: static/js/impala/stats/csv_keys.js:122
+#: static/js/impala/stats/csv_keys.js:122 static/js/zamboni/stats-all.js:15403 static/js/zamboni/stats-min.js:5
 msgid "SeaMonkey"
 msgstr "سيمنكي"
 
-#: static/js/impala/stats/csv_keys.js:123
+#: static/js/impala/stats/csv_keys.js:123 static/js/zamboni/stats-all.js:15404 static/js/zamboni/stats-min.js:5
 msgid "Fennec"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:124
+#: static/js/impala/stats/csv_keys.js:124 static/js/zamboni/stats-all.js:15405 static/js/zamboni/stats-min.js:5
 msgid "Android"
 msgstr ""
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:129
+#: static/js/impala/stats/csv_keys.js:129 static/js/zamboni/stats-all.js:15410 static/js/zamboni/stats-min.js:5
 msgid "Downloads and Daily Users, last {0} days"
 msgstr "التنزيلات والاستخدام اليومي، آخر {0} أيام/يوم"
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:131
+#: static/js/impala/stats/csv_keys.js:131 static/js/zamboni/stats-all.js:15412 static/js/zamboni/stats-min.js:5
 msgid "Downloads and Daily Users from {0} to {1}"
 msgstr "التنزيلات والاستخدام اليومي، من {0} إلى {1}"
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:135
+#: static/js/impala/stats/csv_keys.js:135 static/js/zamboni/stats-all.js:15416 static/js/zamboni/stats-min.js:5
 msgid "Installs and Daily Users, last {0} days"
 msgstr "التثبيتات والاستخدام اليومي، آخر {0} أيام/يوم"
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:137
+#: static/js/impala/stats/csv_keys.js:137 static/js/zamboni/stats-all.js:15418 static/js/zamboni/stats-min.js:5
 msgid "Installs and Daily Users from {0} to {1}"
 msgstr "التثبيتات والاستخدام اليومي، من {0} إلى {1}"
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:141
+#: static/js/impala/stats/csv_keys.js:141 static/js/zamboni/stats-all.js:15422 static/js/zamboni/stats-min.js:5
 msgid "Downloads, last {0} days"
 msgstr "التنزيلات، آخر {0} أيام/يوم"
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:143
+#: static/js/impala/stats/csv_keys.js:143 static/js/zamboni/stats-all.js:15424 static/js/zamboni/stats-min.js:5
 msgid "Downloads from {0} to {1}"
 msgstr "التنزيلات، من {0} إلى {1}"
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:147
+#: static/js/impala/stats/csv_keys.js:147 static/js/zamboni/stats-all.js:15428 static/js/zamboni/stats-min.js:5
 msgid "Daily Users, last {0} days"
 msgstr "الاستخدام اليومي، آخر {0} أيام/يوم"
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:149
+#: static/js/impala/stats/csv_keys.js:149 static/js/zamboni/stats-all.js:15430 static/js/zamboni/stats-min.js:5
 msgid "Daily Users from {0} to {1}"
 msgstr "الاستخدام اليومي، من {0} إلى {1}"
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:153
+#: static/js/impala/stats/csv_keys.js:153 static/js/zamboni/stats-all.js:15434 static/js/zamboni/stats-min.js:5
 msgid "Applications, last {0} days"
 msgstr "التطبيقات، آخر {0} أيام/يوم"
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:155
+#: static/js/impala/stats/csv_keys.js:155 static/js/zamboni/stats-all.js:15436 static/js/zamboni/stats-min.js:5
 msgid "Applications from {0} to {1}"
 msgstr "التطبيقات، من {0} إلى {1}"
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:159
+#: static/js/impala/stats/csv_keys.js:159 static/js/zamboni/stats-all.js:15440 static/js/zamboni/stats-min.js:5
 msgid "Platforms, last {0} days"
 msgstr "المنصات، آخر {0} أيام/يوم"
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:161
+#: static/js/impala/stats/csv_keys.js:161 static/js/zamboni/stats-all.js:15442 static/js/zamboni/stats-min.js:5
 msgid "Platforms from {0} to {1}"
 msgstr "المنصات، من {0} إلى {1}"
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:165
+#: static/js/impala/stats/csv_keys.js:165 static/js/zamboni/stats-all.js:15446 static/js/zamboni/stats-min.js:5
 msgid "Languages, last {0} days"
 msgstr "اللغات، آخر {0} أيام/يوم"
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:167
+#: static/js/impala/stats/csv_keys.js:167 static/js/zamboni/stats-all.js:15448 static/js/zamboni/stats-min.js:5
 msgid "Languages from {0} to {1}"
 msgstr "اللغات، من {0} إلى {1}"
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:171
+#: static/js/impala/stats/csv_keys.js:171 static/js/zamboni/stats-all.js:15452 static/js/zamboni/stats-min.js:5
 msgid "Add-on Versions, last {0} days"
 msgstr "إصدارات الإضافة، آخر {0} أيام/يوم"
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:173
+#: static/js/impala/stats/csv_keys.js:173 static/js/zamboni/stats-all.js:15454 static/js/zamboni/stats-min.js:5
 msgid "Add-on Versions from {0} to {1}"
 msgstr "إصدارات الإضافة، من {0} إلى {1}"
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:177
+#: static/js/impala/stats/csv_keys.js:177 static/js/zamboni/stats-all.js:15458 static/js/zamboni/stats-min.js:5
 msgid "Add-on Status, last {0} days"
 msgstr "إحصائات الإضافة، آخر {0} أيام/يوم"
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:179
+#: static/js/impala/stats/csv_keys.js:179 static/js/zamboni/stats-all.js:15460 static/js/zamboni/stats-min.js:5
 msgid "Add-on Status from {0} to {1}"
 msgstr "إحصائات الإضافة، من {0} إلى {1}"
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:183
+#: static/js/impala/stats/csv_keys.js:183 static/js/zamboni/stats-all.js:15464 static/js/zamboni/stats-min.js:5
 msgid "Download Sources, last {0} days"
 msgstr "مصادر التنزيل، آخر {0} أيام/يوم"
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:185
+#: static/js/impala/stats/csv_keys.js:185 static/js/zamboni/stats-all.js:15466 static/js/zamboni/stats-min.js:5
 msgid "Download Sources from {0} to {1}"
 msgstr "مصادر التنزيل، من {0} إلى {1}"
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:189
+#: static/js/impala/stats/csv_keys.js:189 static/js/zamboni/stats-all.js:15470 static/js/zamboni/stats-min.js:5
 msgid "Contributions, last {0} days"
 msgstr "المساهمات، آخر {0} أيام/يوم"
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:191
+#: static/js/impala/stats/csv_keys.js:191 static/js/zamboni/stats-all.js:15472 static/js/zamboni/stats-min.js:5
 msgid "Contributions from {0} to {1}"
 msgstr "المساهمات، من {0} إلى {1}"
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:195
+#: static/js/impala/stats/csv_keys.js:195 static/js/zamboni/stats-all.js:15476 static/js/zamboni/stats-min.js:5
 msgid "Site Metrics, last {0} days"
 msgstr ""
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:197
+#: static/js/impala/stats/csv_keys.js:197 static/js/zamboni/stats-all.js:15478 static/js/zamboni/stats-min.js:5
 msgid "Site Metrics from {0} to {1}"
 msgstr ""
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:201
+#: static/js/impala/stats/csv_keys.js:201 static/js/zamboni/stats-all.js:15482 static/js/zamboni/stats-min.js:5
 msgid "Add-ons in Use, last {0} days"
 msgstr "الإضافات قيد الاستخدام، آخر {0} أيام/يوم"
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:203
+#: static/js/impala/stats/csv_keys.js:203 static/js/zamboni/stats-all.js:15484 static/js/zamboni/stats-min.js:5
 msgid "Add-ons in Use from {0} to {1}"
 msgstr "الإضافات قيد الاستخدام، من {0} إلى {1}"
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:207
+#: static/js/impala/stats/csv_keys.js:207 static/js/zamboni/stats-all.js:15488 static/js/zamboni/stats-min.js:5
 msgid "Add-ons Downloaded, last {0} days"
 msgstr "الإضافات المُنزّلة، آخر {0} أيام/يوم"
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:209
+#: static/js/impala/stats/csv_keys.js:209 static/js/zamboni/stats-all.js:15490 static/js/zamboni/stats-min.js:5
 msgid "Add-ons Downloaded from {0} to {1}"
 msgstr "الإضافات المُنزّلة، من {0} إلى {1}"
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:213
+#: static/js/impala/stats/csv_keys.js:213 static/js/zamboni/stats-all.js:15494 static/js/zamboni/stats-min.js:5
 msgid "Add-ons Created, last {0} days"
 msgstr "الإضافات المُنشئة، آخر {0} أيام/يوم"
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:215
+#: static/js/impala/stats/csv_keys.js:215 static/js/zamboni/stats-all.js:15496 static/js/zamboni/stats-min.js:5
 msgid "Add-ons Created from {0} to {1}"
 msgstr "الإضافات المُنشئة، من {0} إلى {1}"
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:219
+#: static/js/impala/stats/csv_keys.js:219 static/js/zamboni/stats-all.js:15500 static/js/zamboni/stats-min.js:5
 msgid "Add-ons Updated, last {0} days"
 msgstr "الإضافات المُحدّثة، آخر {0} أيام/يوم"
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:221
+#: static/js/impala/stats/csv_keys.js:221 static/js/zamboni/stats-all.js:15502 static/js/zamboni/stats-min.js:5
 msgid "Add-ons Updated from {0} to {1}"
 msgstr "الإضافات المُحدّثة، من {0} إلى {1}"
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:225
+#: static/js/impala/stats/csv_keys.js:225 static/js/zamboni/stats-all.js:15506 static/js/zamboni/stats-min.js:5
 msgid "Reviews Written, last {0} days"
 msgstr "التعليقات المكتوبة، آخر {0} أيام/يوم"
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:227
+#: static/js/impala/stats/csv_keys.js:227 static/js/zamboni/stats-all.js:15508 static/js/zamboni/stats-min.js:5
 msgid "Reviews Written from {0} to {1}"
 msgstr "التعليقات المكتوبة، من {0} إلى {1}"
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:231
+#: static/js/impala/stats/csv_keys.js:231 static/js/zamboni/stats-all.js:15512 static/js/zamboni/stats-min.js:5
 msgid "User Signups, last {0} days"
 msgstr "تسجيلات المستخدمين، آخر {0} أيام/يوم"
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:233
+#: static/js/impala/stats/csv_keys.js:233 static/js/zamboni/stats-all.js:15514 static/js/zamboni/stats-min.js:5
 msgid "User Signups from {0} to {1}"
 msgstr "تسجيلات المستخدمين، من {0} إلى {1}"
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:237
+#: static/js/impala/stats/csv_keys.js:237 static/js/zamboni/stats-all.js:15518 static/js/zamboni/stats-min.js:5
 msgid "Collections Created, last {0} days"
 msgstr "المجموعات المُنشئة، آخر {0} أيام/يوم"
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:239
+#: static/js/impala/stats/csv_keys.js:239 static/js/zamboni/stats-all.js:15520 static/js/zamboni/stats-min.js:5
 msgid "Collections Created from {0} to {1}"
 msgstr "المجموعات المُنشئة، من {0} إلى {1}"
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:243
+#: static/js/impala/stats/csv_keys.js:243 static/js/zamboni/stats-all.js:15524 static/js/zamboni/stats-min.js:5
 msgid "Subscribers, last {0} days"
 msgstr "الاشتراكات، آخر {0} أيام/يوم"
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:245
+#: static/js/impala/stats/csv_keys.js:245 static/js/zamboni/stats-all.js:15526 static/js/zamboni/stats-min.js:5
 msgid "Subscribers from {0} to {1}"
 msgstr "الاشتراكات، من {0} إلى {1}"
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:249
+#: static/js/impala/stats/csv_keys.js:249 static/js/zamboni/stats-all.js:15530 static/js/zamboni/stats-min.js:5
 msgid "Ratings, last {0} days"
 msgstr "التقييمات، آخر {0} أيام/يوم"
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:251
+#: static/js/impala/stats/csv_keys.js:251 static/js/zamboni/stats-all.js:15532 static/js/zamboni/stats-min.js:5
 msgid "Ratings from {0} to {1}"
 msgstr "التقييمات، من {0} إلى {1}"
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:255
+#: static/js/impala/stats/csv_keys.js:255 static/js/zamboni/stats-all.js:15536 static/js/zamboni/stats-min.js:5
 msgid "Sales, last {0} days"
 msgstr "المبيعات، آخر {0} أيام/يوم"
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:257
+#: static/js/impala/stats/csv_keys.js:257 static/js/zamboni/stats-all.js:15538 static/js/zamboni/stats-min.js:5
 msgid "Sales from {0} to {1}"
 msgstr "المبيعات، من {0} إلى {1}"
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:261
+#: static/js/impala/stats/csv_keys.js:261 static/js/zamboni/stats-all.js:15542 static/js/zamboni/stats-min.js:5
 msgid "Installs, last {0} days"
 msgstr "التثبيتات، آخر {0} أيام/يوم"
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:263
+#: static/js/impala/stats/csv_keys.js:263 static/js/zamboni/stats-all.js:15544 static/js/zamboni/stats-min.js:5
 msgid "Installs from {0} to {1}"
 msgstr "التثبيتات، من {0} إلى {1}"
 
 #. L10n: {0} and {1} are integers.
-#: static/js/impala/stats/csv_keys.js:269
+#: static/js/impala/stats/csv_keys.js:269 static/js/zamboni/stats-all.js:15550 static/js/zamboni/stats-min.js:5
 msgid "<b>{0}</b> in last {1} days"
 msgstr "<b>{0}</b> في آخر {1} أيام/يوم"
 
 #. L10n: {0} is an integer and {1} and {2} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:271 static/js/impala/stats/csv_keys.js:277
+#: static/js/impala/stats/csv_keys.js:271 static/js/impala/stats/csv_keys.js:277 static/js/zamboni/stats-all.js:15552 static/js/zamboni/stats-all.js:15558 static/js/zamboni/stats-min.js:5
 msgid "<b>{0}</b> from {1} to {2}"
 msgstr "<b>{0}</b> من {1} إلى {2}"
 
 #. L10n: {0} and {1} are integers.
-#: static/js/impala/stats/csv_keys.js:275
+#: static/js/impala/stats/csv_keys.js:275 static/js/zamboni/stats-all.js:15556 static/js/zamboni/stats-min.js:5
 msgid "<b>{0}</b> average in last {1} days"
 msgstr ""
 
-#: static/js/impala/stats/overview.js:19
+#: static/js/impala/stats/overview.js:19 static/js/zamboni/stats-all.js:16469 static/js/zamboni/stats-min.js:5
 msgid "No data available."
 msgstr "لا بيانات متوفرة."
 
-#: static/js/impala/stats/table.js:74
+#: static/js/impala/stats/table.js:74 static/js/zamboni/stats-all.js:17209 static/js/zamboni/stats-min.js:5
 msgid "Date"
 msgstr ""
 
-#: static/js/impala/stats/topchart.js:96
+#: static/js/impala/stats/topchart.js:96 static/js/zamboni/stats-all.js:16600 static/js/zamboni/stats-min.js:5
 msgid "Other"
 msgstr ""
 
-#: static/js/zamboni/admin_validation.js:24 static/js/zamboni/devhub.js:1229 static/js/zamboni/editors.js:295
+#: static/js/zamboni/admin-all.js:180 static/js/zamboni/admin-min.js:1 static/js/zamboni/admin_validation.js:24 static/js/zamboni/devhub-all.js:2408 static/js/zamboni/devhub-min.js:2
+#: static/js/zamboni/devhub.js:1229 static/js/zamboni/editors-all.js:15576 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:295
 msgid "Select an application first"
 msgstr ""
 
-#: static/js/zamboni/admin_validation.js:51
+#: static/js/zamboni/admin-all.js:207 static/js/zamboni/admin-min.js:1 static/js/zamboni/admin_validation.js:51
 msgid "Set {0} add-on to a max version of {1} and email the author."
 msgid_plural "Set {0} add-ons to a max version of {1} and email the authors."
 msgstr[0] ""
 msgstr[1] ""
-msgstr[2] ""
-msgstr[3] ""
-msgstr[4] ""
-msgstr[5] ""
 
-#: static/js/zamboni/admin_validation.js:54
+#: static/js/zamboni/admin-all.js:210 static/js/zamboni/admin-min.js:1 static/js/zamboni/admin_validation.js:54
 msgid "Email author of {2} add-on which failed validation."
 msgid_plural "Email authors of {2} add-ons which failed validation."
 msgstr[0] ""
 msgstr[1] ""
-msgstr[2] ""
-msgstr[3] ""
-msgstr[4] ""
-msgstr[5] ""
 
-#. L10n: {0} is an app name like Firefox.
-#: static/js/zamboni/buttons.js:66
-msgid "Accept and Install"
-msgstr "قبول وتثبيت"
-
-#: static/js/zamboni/buttons.js:66
-msgid "Add to {0}"
-msgstr "أضِف إلى {0}"
-
-#: static/js/zamboni/buttons.js:71
-msgid "Download Now"
-msgstr "نزّل الآن"
-
-#: static/js/zamboni/buttons.js:112
-msgid "Add-on has not been updated to support default-to-compatible."
-msgstr ""
-
-#: static/js/zamboni/buttons.js:117
-msgid "You need to be using Firefox 10.0 or higher."
-msgstr ""
-
-#: static/js/zamboni/buttons.js:129
-msgid "Mozilla has marked this version as incompatible with your Firefox version."
-msgstr ""
-
-#. L10n: {0} is an platform like Windows or Linux.
-#: static/js/zamboni/buttons.js:210
-msgid "Install for {0} anyway"
-msgstr "ثبّت لـ {0} على كل حال"
-
-#: static/js/zamboni/buttons.js:210
-msgid "Download for {0} anyway"
-msgstr "نزّل لـ {0} على كل حال"
-
-#: static/js/zamboni/buttons.js:267
-msgid "Not available for your platform"
-msgstr "غير متوفر لمنصتك"
-
-#. L10n: {0} is an app name, {1} is the app version.
-#: static/js/zamboni/buttons.js:278 static/js/zamboni/buttons.js:315
-msgid "Not available for {0} {1}"
-msgstr "غير متوفر لـ {0} {1}"
-
-#: static/js/zamboni/buttons.js:341
-msgid "Works with {app} {min} - {max}"
-msgstr "تعمل مع {app} {min} - {max}"
-
-#: static/js/zamboni/buttons.js:343
-msgid "View other versions"
-msgstr "عرض الإصدارات الأخرى"
-
-#: static/js/zamboni/buttons.js:391
-msgid "Only with Firefox — Get Firefox Now!"
-msgstr ""
-
-#: static/js/zamboni/buttons.js:507 static/js/zamboni/mobile/buttons.js:43
-msgid "Sorry, you need a Mozilla-based browser (such as Firefox) to install a search plugin."
-msgstr "عفوًا، أنت بحاجة إلى متفصح مبني على موزيلا (مثل متصفح فيرفُكس) لتثبيت مُلحقات البحث."
-
-#: static/js/zamboni/collections.js:229
-msgid "Adding to Favorites&hellip;"
-msgstr "إضافة إلى المفضلات&hellip;"
-
-#: static/js/zamboni/collections.js:232
-msgid "Removing Favorite&hellip;"
-msgstr "إزالة المفضل&hellip;"
-
-#: static/js/zamboni/collections.js:235
-msgid "Add to Favorites"
-msgstr "أضِف إلى المفضلات"
-
-#: static/js/zamboni/collections.js:238
-msgid "Remove from Favorites"
-msgstr "أزِل من المفضلات"
-
-#: static/js/zamboni/collections.js:303
-msgid "Pending"
-msgstr "في الانتظار"
-
-#: static/js/zamboni/collections.js:304
-msgid "Add a comment"
-msgstr "أضِف تعليقا"
-
-#: static/js/zamboni/collections.js:304
-msgid "Comment"
-msgstr "تعليق"
-
-#: static/js/zamboni/collections.js:305
-msgid "Remove this add-on from the collection"
-msgstr "إزالة هذه الإضافة من المجموعة"
-
-#: static/js/zamboni/collections.js:305 static/js/zamboni/collections.js:334
-msgid "Remove"
-msgstr "إزالة"
-
-#: static/js/zamboni/collections.js:334
-msgid "Remove this user as a contributor"
-msgstr "إزالة هذا المستخدم كمساهم"
-
-#: static/js/zamboni/collections.js:346
-msgid "An email address is required."
-msgstr "مطلوب عنوان بريد إلكتروني."
-
-#: static/js/zamboni/collections.js:364
-msgid "You cannot add yourself as a contributor."
-msgstr "لا يمكنك إضافة نفسك كمساهم."
-
-#: static/js/zamboni/collections.js:366
-msgid "You have already added that user."
-msgstr "هذا المستخدم مُضاف بالفعل!"
-
-#: static/js/zamboni/collections.js:573
-msgid "Add to favorites"
-msgstr "أضِف إلى المفضلات"
-
-#: static/js/zamboni/collections.js:577
-msgid "Remove from favorites"
-msgstr "إزِل من المفضلات"
-
-#: static/js/zamboni/collections.js:604
-msgid "Stop following"
-msgstr "أوقف المتابعة"
-
-#: static/js/zamboni/devhub.js:110
+#: static/js/zamboni/devhub-all.js:1289 static/js/zamboni/devhub-min.js:1 static/js/zamboni/devhub.js:110
 msgid "Your browser does not support the video tag"
 msgstr ""
 
-#: static/js/zamboni/devhub.js:371
+#: static/js/zamboni/devhub-all.js:1550 static/js/zamboni/devhub-min.js:1 static/js/zamboni/devhub.js:371
 msgid "Changes Saved"
 msgstr "حُفظت التغييرات"
 
-#: static/js/zamboni/devhub.js:387
+#: static/js/zamboni/devhub-all.js:1566 static/js/zamboni/devhub-min.js:1 static/js/zamboni/devhub.js:387
 msgid "Enter a new author's email address"
 msgstr ""
 
-#: static/js/zamboni/devhub.js:536
+#: static/js/zamboni/devhub-all.js:1715 static/js/zamboni/devhub-min.js:1 static/js/zamboni/devhub.js:536
 msgid "There was an error uploading your file."
 msgstr "كانت هناك أخطاء أثناء رفع ملفك."
 
-#: static/js/zamboni/devhub.js:681
+#: static/js/zamboni/devhub-all.js:1860 static/js/zamboni/devhub-min.js:1 static/js/zamboni/devhub.js:681
 msgid "{files} file"
 msgid_plural "{files} files"
 msgstr[0] ""
 msgstr[1] ""
-msgstr[2] ""
-msgstr[3] ""
-msgstr[4] ""
-msgstr[5] ""
 
-#: static/js/zamboni/devhub.js:684
+#: static/js/zamboni/devhub-all.js:1863 static/js/zamboni/devhub-min.js:1 static/js/zamboni/devhub.js:684
 msgid "{reviews} user review"
 msgid_plural "{reviews} user reviews"
 msgstr[0] ""
 msgstr[1] ""
-msgstr[2] ""
-msgstr[3] ""
-msgstr[4] ""
-msgstr[5] ""
 
-#: static/js/zamboni/devhub.js:796
+#: static/js/zamboni/devhub-all.js:1975 static/js/zamboni/devhub-min.js:2 static/js/zamboni/devhub.js:796
 msgid "Learn more"
 msgstr "اعرف المزيد"
 
-#: static/js/zamboni/devhub.js:800
+#: static/js/zamboni/devhub-all.js:1979 static/js/zamboni/devhub-min.js:2 static/js/zamboni/devhub.js:800
 msgid "Example"
 msgstr "مثال"
 
-#: static/js/zamboni/devhub.js:1130
+#: static/js/zamboni/devhub-all.js:2309 static/js/zamboni/devhub-min.js:2 static/js/zamboni/devhub.js:1130
 msgid "Image changes being processed"
 msgstr ""
 
-#: static/js/zamboni/devhub.js:1280
+#: static/js/zamboni/devhub-all.js:2459 static/js/zamboni/devhub-min.js:2 static/js/zamboni/devhub.js:1280
 msgid "Must be a valid e-mail address."
 msgstr ""
+
+#: static/js/zamboni/devhub-all.js:2613 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:80
+msgid "All tests passed successfully."
+msgstr ""
+
+#: static/js/zamboni/devhub-all.js:2616 static/js/zamboni/devhub-all.js:3011 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:83 static/js/zamboni/validator.js:478
+msgid "These tests were not run."
+msgstr ""
+
+#: static/js/zamboni/devhub-all.js:2664 static/js/zamboni/devhub-all.js:2677 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:131 static/js/zamboni/validator.js:144
+msgid "Tests"
+msgstr ""
+
+#: static/js/zamboni/devhub-all.js:2779 static/js/zamboni/devhub-all.js:3108 static/js/zamboni/devhub-all.js:3127 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:246
+#: static/js/zamboni/validator.js:575 static/js/zamboni/validator.js:594
+msgid "Error"
+msgstr "خطأ"
+
+#: static/js/zamboni/devhub-all.js:2780 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:247
+msgid "Warning"
+msgstr ""
+
+#: static/js/zamboni/devhub-all.js:2794 static/js/zamboni/devhub-min.js:2 static/js/zamboni/files-all.js:5657 static/js/zamboni/files-min.js:3 static/js/zamboni/files.js:411
+#: static/js/zamboni/validator.js:261
+msgid "Ignore this message in future updates"
+msgstr ""
+
+#: static/js/zamboni/devhub-all.js:2817 static/js/zamboni/devhub-min.js:2 static/js/zamboni/files-all.js:5663 static/js/zamboni/files-min.js:3 static/js/zamboni/files.js:417
+#: static/js/zamboni/validator.js:284
+msgid "Severity for automated signing:"
+msgstr ""
+
+#: static/js/zamboni/devhub-all.js:2832 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:299
+msgid "Suggestions for passing automated signing:"
+msgstr ""
+
+#: static/js/zamboni/devhub-all.js:2920 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:387
+msgid "Compatibility Tests"
+msgstr ""
+
+#: static/js/zamboni/devhub-all.js:2999 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:466
+msgid "Add-on failed validation."
+msgstr ""
+
+#: static/js/zamboni/devhub-all.js:3001 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:468
+msgid "Add-on passed validation."
+msgstr ""
+
+#: static/js/zamboni/devhub-all.js:3014 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:481
+msgid "{0} error"
+msgid_plural "{0} errors"
+msgstr[0] ""
+msgstr[1] ""
+
+#: static/js/zamboni/devhub-all.js:3016 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:483
+msgid "{0} warning"
+msgid_plural "{0} warnings"
+msgstr[0] ""
+msgstr[1] ""
+
+#: static/js/zamboni/devhub-all.js:3018 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:485
+msgid "{0} notice"
+msgid_plural "{0} notices"
+msgstr[0] ""
+msgstr[1] ""
+
+#: static/js/zamboni/devhub-all.js:3110 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:577
+msgid "Validation task could not complete or completed with errors"
+msgstr ""
+
+#: static/js/zamboni/devhub-all.js:3128 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:595
+msgid "Internal server error"
+msgstr "خطأ داخلي في الخادوم"
 
 #: static/js/zamboni/devhub_search.js:8
 msgid "No results found."
 msgstr "لم يُعثر على نتائج."
 
-#: static/js/zamboni/editors.js:121
+#: static/js/zamboni/editors-all.js:15402 static/js/zamboni/editors-min.js:4 static/js/zamboni/editors.js:121
 msgid "{name} was viewing this page first."
 msgstr ""
 
-#: static/js/zamboni/editors.js:171
+#: static/js/zamboni/editors-all.js:15452 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:171
 msgid "Receipt checked by app."
 msgstr ""
 
-#: static/js/zamboni/editors.js:173
+#: static/js/zamboni/editors-all.js:15454 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:173
 msgid "Receipt was not checked by app."
 msgstr ""
 
-#: static/js/zamboni/editors.js:244
+#: static/js/zamboni/editors-all.js:15525 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:244
 msgid "{name} was viewing this add-on first."
 msgstr ""
 
-#: static/js/zamboni/editors.js:255
+#: static/js/zamboni/editors-all.js:15536 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:255
 msgid "Loading&hellip;"
 msgstr "يجري التحميل&hellip;"
 
-#: static/js/zamboni/editors.js:260
+#: static/js/zamboni/editors-all.js:15541 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:260
 msgid "Version Notes"
 msgstr ""
 
-#: static/js/zamboni/editors.js:265
+#: static/js/zamboni/editors-all.js:15546 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:265
 msgid "Notes for Reviewers"
 msgstr ""
 
-#: static/js/zamboni/editors.js:270
+#: static/js/zamboni/editors-all.js:15551 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:270
 msgid "No version notes found"
 msgstr ""
 
-#: static/js/zamboni/editors.js:330
+#: static/js/zamboni/editors-all.js:15611 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:330
 msgid "Average Reviews"
 msgstr ""
 
-#: static/js/zamboni/editors.js:386
+#: static/js/zamboni/editors-all.js:15667 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:386
 msgid "Number of Reviews"
 msgstr ""
 
-#: static/js/zamboni/editors.js:445
+#: static/js/zamboni/editors-all.js:15726 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:445
 msgid "Error loading translation"
 msgstr ""
 
-#: static/js/zamboni/files.js:411 static/js/zamboni/validator.js:261
-msgid "Ignore this message in future updates"
-msgstr ""
-
-#: static/js/zamboni/files.js:417 static/js/zamboni/validator.js:284
-msgid "Severity for automated signing:"
-msgstr ""
-
-#: static/js/zamboni/global.js:410
-msgid "Loading..."
-msgstr "يُحمّل..."
-
-#. L10n: {0} is the number of characters left.
-#: static/js/zamboni/global.js:474
-msgid "<b>{0}</b> character left."
-msgid_plural "<b>{0}</b> characters left."
-msgstr[0] "لا حروف متبقية"
-msgstr[1] "حرف واحد متبقي"
-msgstr[2] "حرفان متبقيان"
-msgstr[3] "<b>{0}</b> حروف متبقية"
-msgstr[4] "<b>{0}</b> حرفا متبقيا"
-msgstr[5] "<b>{0}</b> حرف متبقي"
-
-#: static/js/zamboni/init.js:28
-msgid "This feature is temporarily disabled while we perform website maintenance. Please check back a little later."
-msgstr "هذه الميزة معطلة مؤقتا بينما نقوم بصيانة الموقع حاليًا. رجاءً حاول مجددًا بعد قليل."
-
-#: static/js/zamboni/l10n.js:45
-msgid "Remove this localization"
-msgstr ""
-
-#: static/js/zamboni/password-strength.js:20
-msgid "Password strength:"
-msgstr "قوة كلمة السر:"
-
-#: static/js/zamboni/password-strength.js:26
-msgid "At least {0} character left."
-msgid_plural "At least {0} characters left."
-msgstr[0] "لا حروف متبقية"
-msgstr[1] "حرف واحد متبقي على الأقل"
-msgstr[2] "حرفان متبقيان على الأقل"
-msgstr[3] "{0} حروف متبقية على الأقل"
-msgstr[4] "{0} حرفا متبقيا على الأقل"
-msgstr[5] "{0} حرف متبقي على الأقل"
-
-#: static/js/zamboni/themes_review.js:176
-msgid "Requested Info"
-msgstr ""
-
-#: static/js/zamboni/themes_review.js:177
-msgid "Flagged"
-msgstr ""
-
-#: static/js/zamboni/themes_review.js:178
-msgid "Duplicate"
-msgstr ""
-
-#: static/js/zamboni/themes_review.js:179
-msgid "Rejected"
-msgstr ""
-
-#: static/js/zamboni/themes_review.js:180
-msgid "Approved"
-msgstr ""
-
-#: static/js/zamboni/themes_review.js:424
-msgid "No results found"
-msgstr ""
-
-#: static/js/zamboni/themes_review_templates.js:31
+#: static/js/zamboni/editors-all.js:15975 static/js/zamboni/editors-min.js:5 static/js/zamboni/themes_review_templates.js:31
 msgid "Theme"
 msgstr ""
 
-#: static/js/zamboni/themes_review_templates.js:33
+#: static/js/zamboni/editors-all.js:15977 static/js/zamboni/editors-min.js:5 static/js/zamboni/themes_review_templates.js:33
 msgid "Reviewer"
 msgstr ""
 
-#: static/js/zamboni/themes_review_templates.js:35
+#: static/js/zamboni/editors-all.js:15979 static/js/zamboni/editors-min.js:5 static/js/zamboni/themes_review_templates.js:35
 msgid "Status"
 msgstr ""
 
-#: static/js/zamboni/validator.js:80
-msgid "All tests passed successfully."
+#: static/js/zamboni/editors-all.js:16196 static/js/zamboni/editors-min.js:5 static/js/zamboni/themes_review.js:176
+msgid "Requested Info"
 msgstr ""
 
-#: static/js/zamboni/validator.js:83 static/js/zamboni/validator.js:478
-msgid "These tests were not run."
+#: static/js/zamboni/editors-all.js:16197 static/js/zamboni/editors-min.js:5 static/js/zamboni/themes_review.js:177
+msgid "Flagged"
 msgstr ""
 
-#: static/js/zamboni/validator.js:131 static/js/zamboni/validator.js:144
-msgid "Tests"
+#: static/js/zamboni/editors-all.js:16198 static/js/zamboni/editors-min.js:5 static/js/zamboni/themes_review.js:178
+msgid "Duplicate"
 msgstr ""
 
-#: static/js/zamboni/validator.js:246 static/js/zamboni/validator.js:575 static/js/zamboni/validator.js:594
-msgid "Error"
-msgstr "خطأ"
-
-#: static/js/zamboni/validator.js:247
-msgid "Warning"
+#: static/js/zamboni/editors-all.js:16199 static/js/zamboni/editors-min.js:5 static/js/zamboni/themes_review.js:179
+msgid "Rejected"
 msgstr ""
 
-#: static/js/zamboni/validator.js:299
-msgid "Suggestions for passing automated signing:"
+#: static/js/zamboni/editors-all.js:16200 static/js/zamboni/editors-min.js:5 static/js/zamboni/themes_review.js:180
+msgid "Approved"
 msgstr ""
 
-#: static/js/zamboni/validator.js:387
-msgid "Compatibility Tests"
+#: static/js/zamboni/editors-all.js:16444 static/js/zamboni/editors-min.js:5 static/js/zamboni/themes_review.js:424
+msgid "No results found"
 msgstr ""
 
-#: static/js/zamboni/validator.js:466
-msgid "Add-on failed validation."
-msgstr ""
-
-#: static/js/zamboni/validator.js:468
-msgid "Add-on passed validation."
-msgstr ""
-
-#: static/js/zamboni/validator.js:481
-msgid "{0} error"
-msgid_plural "{0} errors"
-msgstr[0] ""
-msgstr[1] ""
-msgstr[2] ""
-msgstr[3] ""
-msgstr[4] ""
-msgstr[5] ""
-
-#: static/js/zamboni/validator.js:483
-msgid "{0} warning"
-msgid_plural "{0} warnings"
-msgstr[0] ""
-msgstr[1] ""
-msgstr[2] ""
-msgstr[3] ""
-msgstr[4] ""
-msgstr[5] ""
-
-#: static/js/zamboni/validator.js:485
-msgid "{0} notice"
-msgid_plural "{0} notices"
-msgstr[0] ""
-msgstr[1] ""
-msgstr[2] ""
-msgstr[3] ""
-msgstr[4] ""
-msgstr[5] ""
-
-#: static/js/zamboni/validator.js:577
-msgid "Validation task could not complete or completed with errors"
-msgstr ""
-
-#: static/js/zamboni/validator.js:595
-msgid "Internal server error"
-msgstr "خطأ داخلي في الخادوم"
-
-#: static/js/zamboni/mobile/buttons.js:52
+#: static/js/zamboni/mobile-all.js:15186 static/js/zamboni/mobile/buttons.js:52
 msgid "Not Updated for {0} {1}"
 msgstr ""
 
-#: static/js/zamboni/mobile/buttons.js:53
+#: static/js/zamboni/mobile-all.js:15187 static/js/zamboni/mobile/buttons.js:53
 msgid "Requires Newer Version of {0}"
 msgstr ""
 
-#: static/js/zamboni/mobile/buttons.js:54
+#: static/js/zamboni/mobile-all.js:15188 static/js/zamboni/mobile/buttons.js:54
 msgid "Unreviewed"
 msgstr ""
 
-#: static/js/zamboni/mobile/buttons.js:55
+#: static/js/zamboni/mobile-all.js:15189 static/js/zamboni/mobile/buttons.js:55
 msgid "Experimental <span>(Learn More)</span>"
 msgstr ""
 
-#: static/js/zamboni/mobile/buttons.js:56 static/js/zamboni/mobile/buttons.js:57
+#: static/js/zamboni/mobile-all.js:15190 static/js/zamboni/mobile-all.js:15191 static/js/zamboni/mobile/buttons.js:56 static/js/zamboni/mobile/buttons.js:57
 msgid "Not Available for {0}"
 msgstr "غير متوفر لـ {0}"
 
-#: static/js/zamboni/mobile/buttons.js:58
+#: static/js/zamboni/mobile-all.js:15192 static/js/zamboni/mobile/buttons.js:58
 msgid "Experimental"
 msgstr ""
 
-#: static/js/zamboni/mobile/buttons.js:59
+#: static/js/zamboni/mobile-all.js:15193 static/js/zamboni/mobile/buttons.js:59
 msgid "Themes Require Newer Version of {0}"
 msgstr ""
 
-#: static/js/zamboni/mobile/buttons.js:60
+#: static/js/zamboni/mobile-all.js:15194 static/js/zamboni/mobile/buttons.js:60
 msgid "Themes Require {0}"
 msgstr ""
 
-#: static/js/zamboni/mobile/buttons.js:105
+#: static/js/zamboni/mobile-all.js:15239 static/js/zamboni/mobile/buttons.js:105
 msgid "Installing..."
 msgstr ""
 
-#: static/js/zamboni/mobile/buttons.js:125
+#: static/js/zamboni/mobile-all.js:15259 static/js/zamboni/mobile/buttons.js:125
 msgid "This add-on has been preliminarily reviewed by Mozilla."
 msgstr ""
 
-#: static/js/zamboni/mobile/buttons.js:250
+#: static/js/zamboni/mobile-all.js:15384 static/js/zamboni/mobile/buttons.js:250
 msgid "Keep it"
 msgstr ""
 
-#: static/js/zamboni/mobile/general.js:344
+#: static/js/zamboni/mobile-all.js:16049 static/js/zamboni/mobile-min.js:6 static/js/zamboni/mobile/general.js:344
 msgid "You're trying it on!"
 msgstr ""
 
-#: static/js/zamboni/mobile/general.js:356
+#: static/js/zamboni/mobile-all.js:16061 static/js/zamboni/mobile-min.js:6 static/js/zamboni/mobile/general.js:356
 msgid "Added to Firefox"
 msgstr ""
-

--- a/locale/as/LC_MESSAGES/django.po
+++ b/locale/as/LC_MESSAGES/django.po
@@ -3,69 +3,70 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2016-02-24 21:23+0000\n"
+"POT-Creation-Date: 2016-04-18 15:47+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
+"Language: \n"
 "MIME-Version: 1.0\n"
-"Content-Type: text/plain; charset=utf-8\n"
+"Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Generated-By: Babel 2.2.0\n"
 
-#: src/olympia/accounts/views.py:52
+#: src/olympia/accounts/views.py:54
 msgid "Your log in attempt could not be parsed. Please try again."
 msgstr ""
 
-#: src/olympia/accounts/views.py:54
+#: src/olympia/accounts/views.py:56
 msgid "Your Firefox Account could not be found. Please try again."
 msgstr ""
 
-#: src/olympia/accounts/views.py:55
+#: src/olympia/accounts/views.py:57
 msgid "You could not be logged in. Please try again."
 msgstr ""
 
-#: src/olympia/accounts/views.py:57
+#: src/olympia/accounts/views.py:59
 msgid "Your account has already been migrated to Firefox Accounts."
 msgstr ""
 
-#: src/olympia/accounts/views.py:59
+#: src/olympia/accounts/views.py:61
 msgid "Your Firefox Account already exists on this site."
 msgstr ""
 
-#: src/olympia/accounts/views.py:108
+#: src/olympia/accounts/views.py:110
 msgid "Great job!"
 msgstr ""
 
-#: src/olympia/accounts/views.py:109
+#: src/olympia/accounts/views.py:111
 msgid "You can now log in to Add-ons with your Firefox Account."
 msgstr ""
 
-#: src/olympia/accounts/views.py:121
+#: src/olympia/accounts/views.py:123
 msgid "Need help?"
 msgstr ""
 
-#: src/olympia/addons/buttons.py:180
+#: src/olympia/addons/buttons.py:177
 msgid "Download Now"
 msgstr ""
 
-#: src/olympia/addons/buttons.py:182
+#: src/olympia/addons/buttons.py:179
 msgid "Download"
 msgstr ""
 
 #. L10n: please keep &nbsp; in the string so &rarr; does not wrap.
-#: src/olympia/addons/buttons.py:186
+#: src/olympia/addons/buttons.py:183
 msgid "Continue to Download&nbsp;&rarr;"
 msgstr ""
 
-#: src/olympia/addons/buttons.py:202 src/olympia/addons/helpers.py:35 src/olympia/addons/views.py:319 src/olympia/addons/templates/addons/impala/details.html:114
+#: src/olympia/addons/buttons.py:199 src/olympia/addons/helpers.py:35 src/olympia/addons/views.py:333 src/olympia/addons/templates/addons/impala/details.html:111
 #: src/olympia/addons/templates/addons/impala/listing/items.html:17 src/olympia/addons/templates/addons/mobile/home.html:40 src/olympia/amo/templates/amo/side_nav.html:6
-#: src/olympia/amo/templates/amo/side_nav.html:10 src/olympia/amo/templates/amo/site_nav.html:2 src/olympia/amo/templates/amo/site_nav.html:55 src/olympia/bandwagon/views.py:95
-#: src/olympia/browse/views.py:54 src/olympia/browse/views.py:68 src/olympia/browse/views.py:235 src/olympia/browse/templates/browse/impala/category_landing.html:22
+#: src/olympia/amo/templates/amo/side_nav.html:10 src/olympia/amo/templates/amo/site_nav.html:2 src/olympia/amo/templates/amo/site_nav.html:53 src/olympia/bandwagon/views.py:95
+#: src/olympia/browse/views.py:54 src/olympia/browse/views.py:68 src/olympia/browse/views.py:202 src/olympia/browse/templates/browse/impala/category_landing.html:22
 #: src/olympia/browse/templates/browse/personas/mobile/category_landing.html:26
 msgid "Featured"
 msgstr ""
 
-#: src/olympia/addons/buttons.py:221
+#: src/olympia/addons/buttons.py:218
 msgid "Add to {0}"
 msgstr ""
 
@@ -113,39 +114,39 @@ msgid_plural "All tags must be at least {0} characters."
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/olympia/addons/forms.py:234
+#: src/olympia/addons/forms.py:238
 msgid "Categories cannot be changed while your add-on is featured for this application."
 msgstr ""
 
 #. L10n: {0} is the number of categories.
-#: src/olympia/addons/forms.py:238
+#: src/olympia/addons/forms.py:242
 msgid "You can have only {0} category."
 msgid_plural "You can have only {0} categories."
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/olympia/addons/forms.py:246
+#: src/olympia/addons/forms.py:250
 msgid "The miscellaneous category cannot be combined with additional categories."
 msgstr ""
 
-#: src/olympia/addons/forms.py:369
+#: src/olympia/addons/forms.py:374
 #, python-format
 msgid "Before changing your default locale you must have a name, summary, and description in that locale. You are missing %s."
 msgstr ""
 
-#: src/olympia/addons/forms.py:484 src/olympia/addons/forms.py:575
+#: src/olympia/addons/forms.py:455 src/olympia/addons/forms.py:546
 msgid "A license must be selected."
 msgstr ""
 
-#: src/olympia/addons/forms.py:556
+#: src/olympia/addons/forms.py:527
 msgid "Give Your Theme a Name."
 msgstr ""
 
-#: src/olympia/addons/forms.py:562 src/olympia/devhub/templates/devhub/personas/submit.html:53
+#: src/olympia/addons/forms.py:533 src/olympia/devhub/templates/devhub/personas/submit.html:53
 msgid "Describe your Theme."
 msgstr ""
 
-#: src/olympia/addons/forms.py:704
+#: src/olympia/addons/forms.py:675
 msgid "Enter a new author's email address"
 msgstr ""
 
@@ -153,37 +154,37 @@ msgstr ""
 msgid "Not Reviewed"
 msgstr ""
 
-#: src/olympia/addons/models.py:301
+#: src/olympia/addons/models.py:298
 msgid "Users have the option of contributing more or less than this amount."
 msgstr ""
 
-#: src/olympia/addons/models.py:309
-msgid "Users will always be asked in the Add-ons Manager (Firefox 4 and above)"
+#: src/olympia/addons/models.py:306
+msgid "Users will always be asked in the Add-ons Manager (Firefox 4 and above). Only applies to desktop."
 msgstr ""
 
-#: src/olympia/addons/models.py:1804 src/olympia/addons/templates/addons/details_box.html:55 src/olympia/devhub/templates/devhub/index.html:92
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:102
+#: src/olympia/addons/models.py:1802 src/olympia/addons/templates/addons/details_box.html:55 src/olympia/devhub/templates/devhub/index.html:92
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:89
 msgid "Listed"
 msgstr ""
 
-#: src/olympia/addons/views.py:320 src/olympia/browse/templates/browse/personas/mobile/category_landing.html:27
+#: src/olympia/addons/views.py:334 src/olympia/browse/templates/browse/personas/mobile/category_landing.html:27
 msgid "Popular"
 msgstr ""
 
-#: src/olympia/addons/views.py:321 src/olympia/browse/views.py:238 src/olympia/browse/views.py:280 src/olympia/browse/views.py:482
+#: src/olympia/addons/views.py:335 src/olympia/browse/views.py:205 src/olympia/browse/views.py:247 src/olympia/browse/views.py:449
 msgid "Recently Added"
 msgstr ""
 
-#: src/olympia/addons/views.py:322 src/olympia/bandwagon/views.py:99 src/olympia/browse/views.py:60 src/olympia/browse/views.py:71 src/olympia/search/forms.py:16 src/olympia/search/forms.py:91
+#: src/olympia/addons/views.py:336 src/olympia/bandwagon/views.py:99 src/olympia/browse/views.py:60 src/olympia/browse/views.py:71 src/olympia/search/forms.py:16 src/olympia/search/forms.py:91
 msgid "Recently Updated"
 msgstr ""
 
 #. l10n: {0} is the addon name
-#: src/olympia/addons/views.py:520
+#: src/olympia/addons/views.py:534
 msgid "Contribution for {0}"
 msgstr ""
 
-#: src/olympia/addons/views.py:613
+#: src/olympia/addons/views.py:627
 msgid "Abuse reported."
 msgstr ""
 
@@ -250,9 +251,9 @@ msgstr ""
 #: src/olympia/devhub/templates/devhub/addons/ajax_compat_update.html:36 src/olympia/devhub/templates/devhub/addons/profile.html:44 src/olympia/devhub/templates/devhub/addons/edit/admin.html:101
 #: src/olympia/devhub/templates/devhub/addons/edit/basic.html:152 src/olympia/devhub/templates/devhub/addons/edit/details.html:85 src/olympia/devhub/templates/devhub/addons/edit/support.html:67
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:166 src/olympia/devhub/templates/devhub/addons/forms_shared/media.html:149
-#: src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:44 src/olympia/devhub/templates/devhub/versions/add_file_modal.html:78 src/olympia/devhub/templates/devhub/versions/edit.html:139
-#: src/olympia/devhub/templates/devhub/versions/list.html:242 src/olympia/devhub/templates/devhub/versions/list.html:276 src/olympia/devhub/templates/devhub/versions/list.html:317
-#: src/olympia/devhub/templates/devhub/versions/list.html:351 src/olympia/reviews/templates/reviews/edit_review.html:16 src/olympia/translations/templates/translations/trans-menu.html:50
+#: src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:43 src/olympia/devhub/templates/devhub/versions/add_file_modal.html:58 src/olympia/devhub/templates/devhub/versions/edit.html:139
+#: src/olympia/devhub/templates/devhub/versions/list.html:239 src/olympia/devhub/templates/devhub/versions/list.html:281 src/olympia/devhub/templates/devhub/versions/list.html:315
+#: src/olympia/devhub/templates/devhub/versions/list.html:349 src/olympia/reviews/templates/reviews/edit_review.html:16 src/olympia/translations/templates/translations/trans-menu.html:50
 #: src/olympia/translations/templates/translations/trans-menu.html:62
 msgid "or"
 msgstr ""
@@ -363,7 +364,7 @@ msgid "Add-on Information for {0}"
 msgstr ""
 
 #: src/olympia/addons/templates/addons/details_box.html:30 src/olympia/addons/templates/addons/persona_detail_table.html:3 src/olympia/addons/templates/addons/mobile/details.html:63
-#: src/olympia/addons/templates/addons/mobile/persona_detail_table.html:7 src/olympia/browse/views.py:459 src/olympia/devhub/views.py:75
+#: src/olympia/addons/templates/addons/mobile/persona_detail_table.html:7 src/olympia/browse/views.py:426 src/olympia/devhub/views.py:73
 msgid "Updated"
 msgstr ""
 
@@ -382,11 +383,11 @@ msgstr ""
 msgid "Visibility"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/details_box.html:57 src/olympia/devhub/templates/devhub/index.html:94 src/olympia/devhub/templates/devhub/includes/addon_details.html:104
+#: src/olympia/addons/templates/addons/details_box.html:57 src/olympia/devhub/templates/devhub/index.html:94 src/olympia/devhub/templates/devhub/includes/addon_details.html:91
 msgid "Hidden"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/details_box.html:59 src/olympia/devhub/templates/devhub/index.html:96 src/olympia/devhub/templates/devhub/includes/addon_details.html:106
+#: src/olympia/addons/templates/addons/details_box.html:59 src/olympia/devhub/templates/devhub/index.html:96 src/olympia/devhub/templates/devhub/includes/addon_details.html:93
 msgid "Unlisted"
 msgstr ""
 
@@ -394,13 +395,13 @@ msgstr ""
 msgid "Required Add-ons"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/details_box.html:81 src/olympia/addons/templates/addons/persona_detail_table.html:15 src/olympia/browse/views.py:462 src/olympia/devhub/views.py:78
-#: src/olympia/devhub/views.py:85 src/olympia/discovery/templates/discovery/addons/detail.html:57 src/olympia/reviews/forms.py:62 src/olympia/reviews/templates/reviews/add.html:57
+#: src/olympia/addons/templates/addons/details_box.html:81 src/olympia/addons/templates/addons/persona_detail_table.html:15 src/olympia/browse/views.py:429 src/olympia/devhub/views.py:76
+#: src/olympia/devhub/views.py:83 src/olympia/discovery/templates/discovery/addons/detail.html:57 src/olympia/reviews/forms.py:62 src/olympia/reviews/templates/reviews/add.html:57
 #: src/olympia/reviews/templates/reviews/mobile/review_list.html:18
 msgid "Rating"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/details_box.html:85 src/olympia/browse/views.py:461 src/olympia/devhub/views.py:77 src/olympia/devhub/views.py:84
+#: src/olympia/addons/templates/addons/details_box.html:85 src/olympia/browse/views.py:428 src/olympia/devhub/views.py:75 src/olympia/devhub/views.py:82
 #: src/olympia/stats/templates/stats/addon_report_menu.html:8 src/olympia/stats/templates/stats/collection_report_menu.html:18
 msgid "Downloads"
 msgstr ""
@@ -420,7 +421,7 @@ msgstr ""
 
 #. The Privacy Policy for this add-on.
 #: src/olympia/addons/templates/addons/details_box.html:121 src/olympia/addons/templates/addons/privacy.html:19 src/olympia/addons/templates/addons/privacy.html:23
-#: src/olympia/addons/templates/addons/impala/button.html:43 src/olympia/addons/templates/addons/impala/details.html:307 src/olympia/devhub/templates/devhub/includes/policy_form.html:20
+#: src/olympia/addons/templates/addons/impala/button.html:43 src/olympia/addons/templates/addons/impala/details.html:312 src/olympia/devhub/templates/devhub/includes/policy_form.html:23
 #: src/olympia/templates/mobile/base_addons.html:87
 msgid "Privacy Policy"
 msgstr ""
@@ -445,7 +446,7 @@ msgstr ""
 msgid "Developer Comments"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/details_box.html:199 src/olympia/addons/templates/addons/impala/details.html:259
+#: src/olympia/addons/templates/addons/details_box.html:199 src/olympia/addons/templates/addons/impala/details.html:264
 msgid "Development Channel"
 msgstr ""
 
@@ -465,7 +466,7 @@ msgid ""
 "developer. To stop receiving development updates, reinstall the default version from the link above."
 msgstr ""
 
-#: src/olympia/addons/templates/addons/details_box.html:220 src/olympia/addons/templates/addons/impala/details.html:278
+#: src/olympia/addons/templates/addons/details_box.html:220 src/olympia/addons/templates/addons/impala/details.html:283
 msgid "Version {0}:"
 msgstr ""
 
@@ -484,7 +485,7 @@ msgid "End-User License Agreement for {0}"
 msgstr ""
 
 #: src/olympia/addons/templates/addons/eula.html:17 src/olympia/addons/templates/addons/eula.html:21 src/olympia/addons/templates/addons/impala/button.html:48
-#: src/olympia/addons/templates/addons/impala/details.html:316 src/olympia/devhub/templates/devhub/includes/policy_form.html:3 src/olympia/discovery/templates/discovery/addons/eula.html:11
+#: src/olympia/addons/templates/addons/impala/details.html:321 src/olympia/devhub/templates/devhub/includes/policy_form.html:3 src/olympia/discovery/templates/discovery/addons/eula.html:11
 msgid "End-User License Agreement"
 msgstr ""
 
@@ -501,7 +502,7 @@ msgstr ""
 msgid "Add-ons for {0}"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/home.html:10 src/olympia/addons/templates/addons/home.html:51 src/olympia/browse/templates/browse/impala/base_listing.html:11
+#: src/olympia/addons/templates/addons/home.html:10 src/olympia/addons/templates/addons/home.html:53 src/olympia/browse/templates/browse/impala/base_listing.html:11
 msgid "Featured Extensions"
 msgstr ""
 
@@ -509,29 +510,29 @@ msgstr ""
 msgid "Popular Extensions"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/home.html:42 src/olympia/amo/templates/amo/side_nav.html:3 src/olympia/amo/templates/amo/side_nav.html:11 src/olympia/amo/templates/amo/site_nav.html:3
-#: src/olympia/amo/templates/amo/site_nav.html:25 src/olympia/browse/views.py:236 src/olympia/browse/views.py:281 src/olympia/browse/views.py:481
+#: src/olympia/addons/templates/addons/home.html:44 src/olympia/amo/templates/amo/side_nav.html:3 src/olympia/amo/templates/amo/side_nav.html:11 src/olympia/amo/templates/amo/site_nav.html:3
+#: src/olympia/amo/templates/amo/site_nav.html:25 src/olympia/browse/views.py:203 src/olympia/browse/views.py:248 src/olympia/browse/views.py:448
 msgid "Most Popular"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/home.html:43
+#: src/olympia/addons/templates/addons/home.html:45
 msgid "All »"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/home.html:52 src/olympia/addons/templates/addons/home.html:61 src/olympia/addons/templates/addons/home.html:70 src/olympia/addons/templates/addons/home.html:78
+#: src/olympia/addons/templates/addons/home.html:54 src/olympia/addons/templates/addons/home.html:63 src/olympia/addons/templates/addons/home.html:72 src/olympia/addons/templates/addons/home.html:80
 #: src/olympia/browse/templates/browse/impala/category_landing.html:36
 msgid "See all »"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/home.html:60
+#: src/olympia/addons/templates/addons/home.html:62
 msgid "Up &amp; Coming Extensions"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/home.html:69 src/olympia/browse/templates/browse/personas/category_landing.html:61 src/olympia/discovery/templates/discovery/pane.html:74
+#: src/olympia/addons/templates/addons/home.html:71 src/olympia/browse/templates/browse/personas/category_landing.html:61 src/olympia/discovery/templates/discovery/pane.html:74
 msgid "Featured Themes"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/home.html:77 src/olympia/bandwagon/templates/bandwagon/impala/collection_listing.html:5
+#: src/olympia/addons/templates/addons/home.html:79 src/olympia/bandwagon/templates/bandwagon/impala/collection_listing.html:5
 msgid "Featured Collections"
 msgstr ""
 
@@ -549,7 +550,7 @@ msgid "Updated {0}"
 msgstr ""
 
 #. {0} is a date.
-#: src/olympia/addons/templates/addons/macros.html:10 src/olympia/addons/templates/addons/macros.html:69 src/olympia/addons/templates/addons/persona_preview.html:21
+#: src/olympia/addons/templates/addons/macros.html:10 src/olympia/addons/templates/addons/macros.html:69 src/olympia/addons/templates/addons/persona_preview.html:22
 #: src/olympia/addons/templates/addons/listing/items_mobile.html:44 src/olympia/addons/templates/addons/listing/macros.html:39
 #: src/olympia/bandwagon/templates/bandwagon/collection_listing_items.html:37 src/olympia/bandwagon/templates/bandwagon/impala/collection_listing_items.html:37
 msgid "Added {0}"
@@ -570,15 +571,14 @@ msgstr[0] ""
 msgstr[1] ""
 
 #. {0} is the number of downloads.
-#: src/olympia/addons/templates/addons/macros.html:53 src/olympia/addons/templates/addons/impala/details.html:61
+#: src/olympia/addons/templates/addons/macros.html:53 src/olympia/addons/templates/addons/impala/details.html:59
 msgid "{0} weekly download"
 msgid_plural "{0} weekly downloads"
 msgstr[0] ""
 msgstr[1] ""
 
 #. {0} is the number of users.
-#: src/olympia/addons/templates/addons/macros.html:61 src/olympia/addons/templates/addons/impala/details.html:54 src/olympia/compat/templates/compat/index.html:71
-#: src/olympia/zadmin/templates/zadmin/compat.html:67
+#: src/olympia/addons/templates/addons/macros.html:61 src/olympia/addons/templates/addons/impala/details.html:52 src/olympia/zadmin/templates/zadmin/compat.html:67
 msgid "{0} user"
 msgid_plural "{0} users"
 msgstr[0] ""
@@ -596,7 +596,7 @@ msgstr ""
 msgid "Return to the addon."
 msgstr ""
 
-#: src/olympia/addons/templates/addons/persona_detail.html:17 src/olympia/addons/templates/addons/impala/details.html:106 src/olympia/addons/templates/addons/mobile/details.html:23
+#: src/olympia/addons/templates/addons/persona_detail.html:17 src/olympia/addons/templates/addons/impala/details.html:103 src/olympia/addons/templates/addons/mobile/details.html:23
 #: src/olympia/addons/templates/addons/mobile/persona_detail.html:21 src/olympia/discovery/templates/discovery/addons/base.html:27 src/olympia/editors/templates/editors/review.html:31
 msgid "by"
 msgstr ""
@@ -640,34 +640,35 @@ msgstr ""
 msgid "License"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/persona_preview.html:12 src/olympia/constants/base.py:48
+#: src/olympia/addons/templates/addons/persona_preview.html:13 src/olympia/constants/base.py:48
 msgid "Awaiting Review"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/persona_preview.html:14 src/olympia/amo/log.py:180 src/olympia/constants/base.py:42 src/olympia/editors/helpers.py:62
+#: src/olympia/addons/templates/addons/persona_preview.html:15 src/olympia/amo/log.py:180 src/olympia/constants/base.py:42 src/olympia/editors/helpers.py:62
 msgid "Rejected"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/persona_preview.html:16 src/olympia/amo/log.py:159
+#: src/olympia/addons/templates/addons/persona_preview.html:17 src/olympia/amo/log.py:159
 msgid "Approved"
 msgstr ""
 
 #. {0} is the number of users.
-#: src/olympia/addons/templates/addons/persona_preview.html:26 src/olympia/addons/templates/addons/listing/items_mobile.html:36 src/olympia/addons/templates/addons/listing/macros.html:31
+#: src/olympia/addons/templates/addons/persona_preview.html:27 src/olympia/addons/templates/addons/listing/items_mobile.html:36 src/olympia/addons/templates/addons/listing/macros.html:31
 msgid "<strong>{0}</strong> user"
 msgid_plural "<strong>{0}</strong> users"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/olympia/addons/templates/addons/persona_preview.html:40
+#: src/olympia/addons/templates/addons/persona_preview.html:41
 msgid "Hover to Preview"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/persona_preview.html:46 src/olympia/addons/templates/addons/persona_preview.html:48 src/olympia/reviews/templates/reviews/add.html:15
+#: src/olympia/addons/templates/addons/persona_preview.html:47 src/olympia/addons/templates/addons/persona_preview.html:49 src/olympia/addons/templates/addons/persona_preview.html:97
+#: src/olympia/reviews/templates/reviews/add.html:15
 msgid "Add"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/persona_preview.html:57 src/olympia/bandwagon/templates/bandwagon/ajax_new.html:16 src/olympia/bandwagon/templates/bandwagon/edit.html:19
+#: src/olympia/addons/templates/addons/persona_preview.html:58 src/olympia/bandwagon/templates/bandwagon/ajax_new.html:16 src/olympia/bandwagon/templates/bandwagon/edit.html:19
 #: src/olympia/bandwagon/templates/bandwagon/includes/addedit.html:19 src/olympia/devhub/templates/devhub/addons/edit/admin.html:13 src/olympia/devhub/templates/devhub/addons/edit/basic.html:10
 #: src/olympia/devhub/templates/devhub/addons/edit/details.html:8 src/olympia/devhub/templates/devhub/addons/edit/media.html:6 src/olympia/devhub/templates/devhub/addons/edit/support.html:8
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:9 src/olympia/devhub/templates/devhub/addons/submit/describe.html:29 src/olympia/editors/templates/editors/review.html:257
@@ -676,21 +677,21 @@ msgstr ""
 
 #. For datetime formatting, see the table on
 #. http://docs.python.org/library/datetime.html#strftime-and-strptime-behavior
-#: src/olympia/addons/templates/addons/persona_preview.html:66
+#: src/olympia/addons/templates/addons/persona_preview.html:67
 #, python-format
 msgid "%%Y-%%m-%%d"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/persona_preview.html:67
+#: src/olympia/addons/templates/addons/persona_preview.html:68
 msgid "by {0} on {1}"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/persona_preview.html:75 src/olympia/reviews/helpers.py:17 src/olympia/reviews/templates/reviews/review_list.html:63
+#: src/olympia/addons/templates/addons/persona_preview.html:76 src/olympia/reviews/helpers.py:17 src/olympia/reviews/templates/reviews/review_list.html:63
 #: src/olympia/reviews/templates/reviews/reviews_link.html:21 src/olympia/reviews/templates/reviews/impala/reviews_link.html:16
 msgid "Not yet rated"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/persona_preview.html:78
+#: src/olympia/addons/templates/addons/persona_preview.html:79
 msgid "<b>{0}</b> users"
 msgstr ""
 
@@ -703,7 +704,7 @@ msgid "Learn more about Firefox"
 msgstr ""
 
 #: src/olympia/addons/templates/addons/popups.html:22
-msgid "or <b><a class=\"installer\" href=\"{url}\">download anyway</a></b>"
+msgid "or <b><a class=\"button installer\" href=\"{url}\">download anyway</a></b>"
 msgstr ""
 
 #: src/olympia/addons/templates/addons/popups.html:26
@@ -802,7 +803,7 @@ msgid ""
 msgstr ""
 
 #: src/olympia/addons/templates/addons/report_abuse.html:6 src/olympia/addons/templates/addons/report_abuse_full.html:10 src/olympia/addons/templates/addons/impala/details-more.html:23
-#: src/olympia/addons/templates/addons/impala/details.html:328
+#: src/olympia/addons/templates/addons/impala/details.html:333
 msgid "Report Abuse"
 msgstr ""
 
@@ -821,9 +822,9 @@ msgstr ""
 #: src/olympia/devhub/templates/devhub/addons/ajax_compat_update.html:36 src/olympia/devhub/templates/devhub/addons/profile.html:44 src/olympia/devhub/templates/devhub/addons/edit/admin.html:104
 #: src/olympia/devhub/templates/devhub/addons/edit/basic.html:155 src/olympia/devhub/templates/devhub/addons/edit/details.html:88 src/olympia/devhub/templates/devhub/addons/edit/support.html:70
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:169 src/olympia/devhub/templates/devhub/addons/forms_shared/media.html:152
-#: src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:44 src/olympia/devhub/templates/devhub/personas/edit.html:222 src/olympia/devhub/templates/devhub/versions/add_file_modal.html:79
-#: src/olympia/devhub/templates/devhub/versions/edit.html:140 src/olympia/devhub/templates/devhub/versions/list.html:208 src/olympia/devhub/templates/devhub/versions/list.html:242
-#: src/olympia/devhub/templates/devhub/versions/list.html:276 src/olympia/devhub/templates/devhub/versions/list.html:317 src/olympia/reviews/templates/reviews/edit_review.html:16
+#: src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:43 src/olympia/devhub/templates/devhub/personas/edit.html:222 src/olympia/devhub/templates/devhub/versions/add_file_modal.html:59
+#: src/olympia/devhub/templates/devhub/versions/edit.html:140 src/olympia/devhub/templates/devhub/versions/list.html:208 src/olympia/devhub/templates/devhub/versions/list.html:239
+#: src/olympia/devhub/templates/devhub/versions/list.html:281 src/olympia/devhub/templates/devhub/versions/list.html:315 src/olympia/reviews/templates/reviews/edit_review.html:16
 #: src/olympia/translations/templates/translations/trans-menu.html:50 src/olympia/translations/templates/translations/trans-menu.html:62 src/olympia/zadmin/templates/zadmin/validation.html:105
 msgid "Cancel"
 msgstr ""
@@ -868,7 +869,7 @@ msgstr ""
 msgid "Review Guidelines"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/review_list_box.html:5 src/olympia/addons/templates/addons/impala/details-more.html:27 src/olympia/editors/helpers.py:921
+#: src/olympia/addons/templates/addons/review_list_box.html:5 src/olympia/addons/templates/addons/impala/details-more.html:27 src/olympia/editors/helpers.py:1001
 #: src/olympia/reviews/templates/reviews/add.html:14 src/olympia/reviews/templates/reviews/reply.html:14 src/olympia/reviews/templates/reviews/review_list.html:19
 #: src/olympia/reviews/templates/reviews/mobile/review_list.html:26
 msgid "Reviews"
@@ -959,119 +960,119 @@ msgid_plural "Other add-ons by these authors"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/olympia/addons/templates/addons/impala/details.html:41
+#: src/olympia/addons/templates/addons/impala/details.html:39
 #, python-format
 msgid "<span itemprop=\"ratingCount\">%(num)s</span> user review"
 msgid_plural "<span itemprop=\"ratingCount\">%(num)s</span> user reviews"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/olympia/addons/templates/addons/impala/details.html:69
+#: src/olympia/addons/templates/addons/impala/details.html:66
 msgid "View statistics"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/impala/details.html:84
+#: src/olympia/addons/templates/addons/impala/details.html:81
 msgid "Manage"
 msgstr ""
 
 #. {0} is an add-on name.
-#: src/olympia/addons/templates/addons/impala/details.html:96
+#: src/olympia/addons/templates/addons/impala/details.html:93
 msgid "Icon of {0}"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/impala/details.html:103 src/olympia/addons/templates/addons/impala/listing/items.html:14
+#: src/olympia/addons/templates/addons/impala/details.html:100 src/olympia/addons/templates/addons/impala/listing/items.html:14
 msgid "No Restart"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/impala/details.html:127
+#: src/olympia/addons/templates/addons/impala/details.html:124
 #, python-format
 msgid "Meet the Developer: <a href=\"%(url)s\">%(name)s</a>"
 msgid_plural "<a href=\"%(url)s\">Meet the Developers</a>"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/olympia/addons/templates/addons/impala/details.html:137
+#: src/olympia/addons/templates/addons/impala/details.html:134
 msgid "Learn why {0} was created and find out what's next for this add-on."
 msgstr ""
 
 #. {0} is an index.
-#: src/olympia/addons/templates/addons/impala/details.html:156
+#: src/olympia/addons/templates/addons/impala/details.html:161
 msgid "Add-on screenshot #{0}"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/impala/details.html:182
+#: src/olympia/addons/templates/addons/impala/details.html:187
 msgid "Add-on home page"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/impala/details.html:185
+#: src/olympia/addons/templates/addons/impala/details.html:190
 msgid "Support site"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/impala/details.html:189
+#: src/olympia/addons/templates/addons/impala/details.html:194
 msgid "Support E-mail"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/impala/details.html:194 src/olympia/devhub/models.py:378 src/olympia/devhub/templates/devhub/versions/list.html:12
+#: src/olympia/addons/templates/addons/impala/details.html:199 src/olympia/devhub/models.py:378 src/olympia/devhub/templates/devhub/versions/list.html:12
 #: src/olympia/versions/templates/versions/version.html:6 src/olympia/versions/templates/versions/mobile/version.html:6
 msgid "Version {0}"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/impala/details.html:194
+#: src/olympia/addons/templates/addons/impala/details.html:199
 msgid "Info"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/impala/details.html:195 src/olympia/devhub/templates/devhub/includes/addon_details.html:129
+#: src/olympia/addons/templates/addons/impala/details.html:200 src/olympia/devhub/templates/devhub/includes/addon_details.html:116
 msgid "Last Updated:"
-msgstr ""
-
-#: src/olympia/addons/templates/addons/impala/details.html:200
-#, python-format
-msgid "Released under <a target=\"_blank\" href=\"%(url)s\">%(name)s</a>"
-msgstr ""
-
-#: src/olympia/addons/templates/addons/impala/details.html:201 src/olympia/addons/templates/addons/impala/details.html:206 src/olympia/amo/helpers.py:398 src/olympia/devhub/forms.py:142
-#: src/olympia/devhub/forms.py:173 src/olympia/versions/templates/versions/version.html:40 src/olympia/versions/templates/versions/version.html:45
-msgid "Custom License"
 msgstr ""
 
 #: src/olympia/addons/templates/addons/impala/details.html:205
 #, python-format
+msgid "Released under <a target=\"_blank\" href=\"%(url)s\">%(name)s</a>"
+msgstr ""
+
+#: src/olympia/addons/templates/addons/impala/details.html:206 src/olympia/addons/templates/addons/impala/details.html:211 src/olympia/amo/helpers.py:398 src/olympia/devhub/forms.py:142
+#: src/olympia/devhub/forms.py:173 src/olympia/versions/templates/versions/version.html:40 src/olympia/versions/templates/versions/version.html:45
+msgid "Custom License"
+msgstr ""
+
+#: src/olympia/addons/templates/addons/impala/details.html:210
+#, python-format
 msgid "Released under <a href=\"%(url)s\">%(name)s</a>"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/impala/details.html:217
+#: src/olympia/addons/templates/addons/impala/details.html:222
 msgid "About this Add-on"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/impala/details.html:233
+#: src/olympia/addons/templates/addons/impala/details.html:238
 msgid "Developer’s Comments"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/impala/details.html:243
+#: src/olympia/addons/templates/addons/impala/details.html:248
 msgid "Version Information"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/impala/details.html:250
+#: src/olympia/addons/templates/addons/impala/details.html:255
 msgid "See complete version history"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/impala/details.html:262
+#: src/olympia/addons/templates/addons/impala/details.html:267
 msgid ""
 "The Development Channel lets you test an experimental new version of this add-on before it's released to the general public. Once you install the development version, you will continue to get "
 "updates from this channel. To stop receiving development updates, reinstall the default version from the link above."
 msgstr ""
 
-#: src/olympia/addons/templates/addons/impala/details.html:272
+#: src/olympia/addons/templates/addons/impala/details.html:277
 msgid "<strong>Caution:</strong> Development versions of this add-on have not been reviewed by Mozilla."
 msgstr ""
 
-#: src/olympia/addons/templates/addons/impala/details.html:287
+#: src/olympia/addons/templates/addons/impala/details.html:292
 msgid "See complete development channel history"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/impala/details.html:306 src/olympia/addons/templates/addons/impala/details.html:315 src/olympia/addons/templates/addons/impala/details.html:327
+#: src/olympia/addons/templates/addons/impala/details.html:311 src/olympia/addons/templates/addons/impala/details.html:320 src/olympia/addons/templates/addons/impala/details.html:332
 #: src/olympia/addons/templates/addons/impala/review_add_box.html:4 src/olympia/stats/templates/stats/popup.html:2 src/olympia/stats/templates/stats/popup.html:8
-#: src/olympia/stats/templates/stats/stats.html:202 src/olympia/users/templates/users/profile.html:119
+#: src/olympia/stats/templates/stats/stats.html:204 src/olympia/users/templates/users/profile.html:119
 msgid "close"
 msgstr ""
 
@@ -1127,15 +1128,11 @@ msgstr ""
 msgid "Source Code License"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/impala/persona_grid.html:16 src/olympia/addons/templates/addons/impala/toplist.html:6
-msgid "{0} users"
-msgstr ""
-
 #: src/olympia/addons/templates/addons/impala/review_list_box.html:19 src/olympia/reviews/templates/reviews/review.html:40
 msgid "permalink"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/impala/review_list_box.html:23 src/olympia/editors/templates/editors/queue.html:98 src/olympia/reviews/templates/reviews/review.html:44
+#: src/olympia/addons/templates/addons/impala/review_list_box.html:23 src/olympia/editors/templates/editors/queue.html:104 src/olympia/reviews/templates/reviews/review.html:44
 msgid "translate"
 msgstr ""
 
@@ -1154,6 +1151,10 @@ msgstr ""
 msgid "Be the first!"
 msgstr ""
 
+#: src/olympia/addons/templates/addons/impala/toplist.html:6
+msgid "{0} users"
+msgstr ""
+
 #: src/olympia/addons/templates/addons/impala/listing/sorter.html:14 src/olympia/devhub/templates/devhub/addons/listing/item_actions.html:49
 msgid "More"
 msgstr ""
@@ -1166,7 +1167,7 @@ msgstr ""
 msgid "My Add-ons"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/includes/dashboard_tabs.html:6 src/olympia/amo/context_processors.py:51
+#: src/olympia/addons/templates/addons/includes/dashboard_tabs.html:6 src/olympia/amo/context_processors.py:50
 msgid "My Themes"
 msgstr ""
 
@@ -1221,7 +1222,7 @@ msgstr ""
 msgid "Weekly Downloads"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/mobile/details.html:99 src/olympia/compat/templates/compat/reporter_detail.html:46 src/olympia/devhub/forms.py:787
+#: src/olympia/addons/templates/addons/mobile/details.html:99 src/olympia/compat/templates/compat/reporter_detail.html:46 src/olympia/devhub/forms.py:788
 #: src/olympia/devhub/templates/devhub/versions/list.html:163
 msgid "Version"
 msgstr ""
@@ -1305,7 +1306,7 @@ msgstr ""
 #: src/olympia/browse/templates/browse/personas/category_landing.html:21 src/olympia/browse/templates/browse/personas/category_landing.html:23
 #: src/olympia/browse/templates/browse/personas/category_landing.html:38 src/olympia/browse/templates/browse/personas/grid.html:7 src/olympia/browse/templates/browse/personas/grid.html:11
 #: src/olympia/browse/templates/browse/personas/mobile/base.html:7 src/olympia/browse/templates/browse/personas/mobile/category_landing.html:19 src/olympia/constants/base.py:180
-#: src/olympia/devhub/templates/devhub/personas/submit.html:13 src/olympia/editors/helpers.py:105 src/olympia/editors/templates/editors/base.html:26
+#: src/olympia/devhub/templates/devhub/personas/submit.html:13 src/olympia/editors/helpers.py:107 src/olympia/editors/templates/editors/base.html:26
 #: src/olympia/editors/templates/editors/performance.html:73 src/olympia/search/templates/search/personas.html:39 src/olympia/templates/menu_links.html:9
 msgid "Themes"
 msgstr ""
@@ -1326,7 +1327,7 @@ msgstr ""
 msgid "Highest Rated"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/mobile/home.html:74 src/olympia/amo/templates/amo/side_nav.html:5 src/olympia/amo/templates/amo/site_nav.html:27 src/olympia/amo/templates/amo/site_nav.html:57
+#: src/olympia/addons/templates/addons/mobile/home.html:74 src/olympia/amo/templates/amo/side_nav.html:5 src/olympia/amo/templates/amo/site_nav.html:27 src/olympia/amo/templates/amo/site_nav.html:55
 #: src/olympia/bandwagon/views.py:97 src/olympia/browse/views.py:57 src/olympia/browse/views.py:67 src/olympia/browse/templates/browse/personas/mobile/category_landing.html:65
 #: src/olympia/search/forms.py:15 src/olympia/search/forms.py:87
 msgid "Newest"
@@ -1340,90 +1341,90 @@ msgstr ""
 msgid "Theme Info &raquo;"
 msgstr ""
 
-#: src/olympia/amo/context_processors.py:39 src/olympia/devhub/templates/devhub/nav.html:43
+#: src/olympia/amo/context_processors.py:37 src/olympia/devhub/templates/devhub/nav.html:43
 msgid "Tools"
 msgstr ""
 
-#: src/olympia/amo/context_processors.py:48 src/olympia/discovery/templates/discovery/pane_account.html:8 src/olympia/users/templates/users/includes/navigation.html:2
+#: src/olympia/amo/context_processors.py:47 src/olympia/discovery/templates/discovery/pane_account.html:8 src/olympia/users/templates/users/includes/navigation.html:2
 msgid "My Profile"
 msgstr ""
 
-#: src/olympia/amo/context_processors.py:54 src/olympia/users/templates/users/edit.html:5 src/olympia/users/templates/users/includes/navigation.html:3
+#: src/olympia/amo/context_processors.py:53 src/olympia/users/templates/users/edit.html:5 src/olympia/users/templates/users/includes/navigation.html:3
 msgid "Account Settings"
 msgstr ""
 
-#: src/olympia/amo/context_processors.py:57 src/olympia/discovery/templates/discovery/pane_account.html:11 src/olympia/users/templates/users/profile.html:83
+#: src/olympia/amo/context_processors.py:56 src/olympia/discovery/templates/discovery/pane_account.html:11 src/olympia/users/templates/users/profile.html:83
 #: src/olympia/users/templates/users/includes/navigation.html:4
 msgid "My Collections"
 msgstr ""
 
-#: src/olympia/amo/context_processors.py:62 src/olympia/discovery/templates/discovery/pane_account.html:10 src/olympia/users/templates/users/includes/navigation.html:7
+#: src/olympia/amo/context_processors.py:61 src/olympia/discovery/templates/discovery/pane_account.html:10 src/olympia/users/templates/users/includes/navigation.html:7
 msgid "My Favorites"
 msgstr ""
 
-#: src/olympia/amo/context_processors.py:67 src/olympia/discovery/templates/discovery/pane_account.html:13 src/olympia/templates/impala/user_login.html:14
+#: src/olympia/amo/context_processors.py:66 src/olympia/discovery/templates/discovery/pane_account.html:13 src/olympia/templates/impala/user_login.html:14
 #: src/olympia/templates/mobile/header_auth.html:5
 msgid "Log out"
 msgstr ""
 
-#: src/olympia/amo/context_processors.py:72 src/olympia/devhub/templates/devhub/addons/dashboard.html:4
+#: src/olympia/amo/context_processors.py:71 src/olympia/devhub/templates/devhub/addons/dashboard.html:4
 msgid "Manage My Submissions"
 msgstr ""
 
-#: src/olympia/amo/context_processors.py:75 src/olympia/devhub/templates/devhub/nav.html:27 src/olympia/devhub/templates/devhub/addons/dashboard.html:25
+#: src/olympia/amo/context_processors.py:74 src/olympia/devhub/templates/devhub/nav.html:27 src/olympia/devhub/templates/devhub/addons/dashboard.html:25
 #: src/olympia/devhub/templates/devhub/addons/submit/base.html:4
 msgid "Submit a New Add-on"
 msgstr ""
 
-#: src/olympia/amo/context_processors.py:77 src/olympia/browse/templates/browse/personas/base.html:50 src/olympia/devhub/templates/devhub/index.html:24
+#: src/olympia/amo/context_processors.py:76 src/olympia/browse/templates/browse/personas/base.html:50 src/olympia/devhub/templates/devhub/index.html:24
 #: src/olympia/devhub/templates/devhub/addons/dashboard.html:29
 msgid "Submit a New Theme"
 msgstr ""
 
-#: src/olympia/amo/context_processors.py:79 src/olympia/amo/templates/amo/site_nav.html:87 src/olympia/devhub/helpers.py:36 src/olympia/devhub/helpers.py:68 src/olympia/devhub/helpers.py:102
+#: src/olympia/amo/context_processors.py:78 src/olympia/amo/templates/amo/site_nav.html:85 src/olympia/devhub/helpers.py:36 src/olympia/devhub/helpers.py:68 src/olympia/devhub/helpers.py:102
 #: src/olympia/templates/footer.html:6 src/olympia/templates/menu_links.html:14
 msgid "Developer Hub"
 msgstr ""
 
-#: src/olympia/amo/context_processors.py:83 src/olympia/devhub/views.py:1792
+#: src/olympia/amo/context_processors.py:81 src/olympia/devhub/views.py:1796
 msgid "Manage API Keys"
 msgstr ""
 
-#: src/olympia/amo/context_processors.py:88 src/olympia/editors/helpers.py:82 src/olympia/editors/helpers.py:102 src/olympia/editors/templates/editors/base.html:10
+#: src/olympia/amo/context_processors.py:86 src/olympia/editors/helpers.py:84 src/olympia/editors/helpers.py:104 src/olympia/editors/templates/editors/base.html:10
 msgid "Editor Tools"
 msgstr ""
 
-#: src/olympia/amo/context_processors.py:92
+#: src/olympia/amo/context_processors.py:90
 msgid "Admin Tools"
 msgstr ""
 
-#: src/olympia/amo/fields.py:15
+#: src/olympia/amo/fields.py:20
 msgid "Incorrect, please try again."
 msgstr ""
 
-#: src/olympia/amo/fields.py:16
+#: src/olympia/amo/fields.py:21
 msgid "Error verifying input, please try again."
 msgstr ""
 
-#: src/olympia/amo/fields.py:32
+#: src/olympia/amo/fields.py:37
 msgid "This must be a valid hex color code, such as #000000."
 msgstr ""
 
-#: src/olympia/amo/fields.py:58
+#: src/olympia/amo/fields.py:63
 msgid "Enter at least one value."
 msgstr ""
 
-#: src/olympia/amo/helpers.py:162 src/olympia/amo/templates/amo/site_nav.html:61 src/olympia/bandwagon/templates/bandwagon/add.html:9
+#: src/olympia/amo/helpers.py:162 src/olympia/amo/templates/amo/site_nav.html:59 src/olympia/bandwagon/templates/bandwagon/add.html:9
 #: src/olympia/bandwagon/templates/bandwagon/collection_detail.html:15 src/olympia/bandwagon/templates/bandwagon/delete.html:9 src/olympia/bandwagon/templates/bandwagon/edit.html:15
 #: src/olympia/bandwagon/templates/bandwagon/user_listing.html:18 src/olympia/bandwagon/templates/bandwagon/user_listing.html:21
 #: src/olympia/bandwagon/templates/bandwagon/impala/collection_listing.html:12 src/olympia/bandwagon/templates/bandwagon/impala/collection_listing.html:20
 #: src/olympia/bandwagon/templates/bandwagon/impala/collection_listing.html:24 src/olympia/bandwagon/templates/bandwagon/impala/collection_sidebar.html:3
 #: src/olympia/bandwagon/templates/bandwagon/includes/collection_sidebar.html:2 src/olympia/bandwagon/templates/bandwagon/mobile/collection_listing.html:3
-#: src/olympia/stats/templates/stats/stats.html:77 src/olympia/templates/menu_links.html:12
+#: src/olympia/stats/templates/stats/stats.html:33 src/olympia/templates/menu_links.html:12
 msgid "Collections"
 msgstr ""
 
-#: src/olympia/amo/helpers.py:171 src/olympia/amo/templates/amo/site_nav.html:85 src/olympia/browse/templates/browse/language_tools.html:3
+#: src/olympia/amo/helpers.py:171 src/olympia/amo/templates/amo/site_nav.html:83 src/olympia/browse/templates/browse/language_tools.html:3
 msgid "Dictionaries & Language Packs"
 msgstr ""
 
@@ -1575,8 +1576,8 @@ msgstr ""
 msgid "Comment on {addon} {version}."
 msgstr ""
 
-#: src/olympia/amo/log.py:236 src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:19 src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:47
-#: src/olympia/editors/helpers.py:511 src/olympia/editors/templates/editors/themes/history_table.html:11
+#: src/olympia/amo/log.py:236 src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:17 src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:45
+#: src/olympia/editors/helpers.py:584 src/olympia/editors/templates/editors/themes/history_table.html:11
 msgid "Comment"
 msgstr ""
 
@@ -1899,7 +1900,7 @@ msgstr ""
 #: src/olympia/amo/templates/amo/mobile/paginator.html:14 src/olympia/amo/templates/amo/mobile/paginator.html:16 src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:51
 #: src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:65 src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:78
 #: src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:91 src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:104
-#: src/olympia/discovery/templates/discovery/pane.html:45 src/olympia/discovery/templates/discovery/addons/detail.html:39 src/olympia/stats/templates/stats/stats.html:167
+#: src/olympia/discovery/templates/discovery/pane.html:45 src/olympia/discovery/templates/discovery/addons/detail.html:39 src/olympia/stats/templates/stats/stats.html:169
 msgid "Next"
 msgstr ""
 
@@ -1931,7 +1932,7 @@ msgid ""
 msgstr ""
 
 #: src/olympia/amo/templates/amo/side_nav.html:4 src/olympia/amo/templates/amo/side_nav.html:12 src/olympia/amo/templates/amo/site_nav.html:4 src/olympia/amo/templates/amo/site_nav.html:26
-#: src/olympia/browse/views.py:56 src/olympia/browse/views.py:66 src/olympia/browse/views.py:237 src/olympia/browse/views.py:282 src/olympia/search/forms.py:86
+#: src/olympia/browse/views.py:56 src/olympia/browse/views.py:66 src/olympia/browse/views.py:204 src/olympia/browse/views.py:249 src/olympia/search/forms.py:86
 msgid "Top Rated"
 msgstr ""
 
@@ -1945,38 +1946,38 @@ msgstr ""
 msgid "Extensions"
 msgstr ""
 
-#: src/olympia/amo/templates/amo/site_nav.html:45
+#: src/olympia/amo/templates/amo/site_nav.html:44
 msgid "Want more customization? Try <b>Complete Themes</b>"
 msgstr ""
 
-#: src/olympia/amo/templates/amo/site_nav.html:56 src/olympia/bandwagon/views.py:96
+#: src/olympia/amo/templates/amo/site_nav.html:54 src/olympia/bandwagon/views.py:96
 msgid "Most Followers"
 msgstr ""
 
-#: src/olympia/amo/templates/amo/site_nav.html:68 src/olympia/bandwagon/templates/bandwagon/impala/collection_sidebar.html:16
+#: src/olympia/amo/templates/amo/site_nav.html:66 src/olympia/bandwagon/templates/bandwagon/impala/collection_sidebar.html:16
 #: src/olympia/bandwagon/templates/bandwagon/includes/collection_sidebar.html:18
 msgid "Collections I've Made"
 msgstr ""
 
-#: src/olympia/amo/templates/amo/site_nav.html:70 src/olympia/bandwagon/templates/bandwagon/user_listing.html:4 src/olympia/bandwagon/templates/bandwagon/impala/collection_sidebar.html:13
+#: src/olympia/amo/templates/amo/site_nav.html:68 src/olympia/bandwagon/templates/bandwagon/user_listing.html:4 src/olympia/bandwagon/templates/bandwagon/impala/collection_sidebar.html:13
 #: src/olympia/bandwagon/templates/bandwagon/includes/collection_sidebar.html:15
 msgid "Collections I'm Following"
 msgstr ""
 
-#: src/olympia/amo/templates/amo/site_nav.html:73 src/olympia/bandwagon/templates/bandwagon/impala/collection_sidebar.html:18
-#: src/olympia/bandwagon/templates/bandwagon/includes/collection_sidebar.html:20 src/olympia/users/models.py:512
+#: src/olympia/amo/templates/amo/site_nav.html:71 src/olympia/bandwagon/templates/bandwagon/impala/collection_sidebar.html:18
+#: src/olympia/bandwagon/templates/bandwagon/includes/collection_sidebar.html:20 src/olympia/users/models.py:521
 msgid "My Favorite Add-ons"
 msgstr ""
 
-#: src/olympia/amo/templates/amo/site_nav.html:78
+#: src/olympia/amo/templates/amo/site_nav.html:76
 msgid "More&hellip;"
 msgstr ""
 
-#: src/olympia/amo/templates/amo/site_nav.html:82
+#: src/olympia/amo/templates/amo/site_nav.html:80
 msgid "Add-ons for Mobile"
 msgstr ""
 
-#: src/olympia/amo/templates/amo/site_nav.html:86 src/olympia/browse/feeds.py:207 src/olympia/browse/templates/browse/search_tools.html:3 src/olympia/constants/base.py:176
+#: src/olympia/amo/templates/amo/site_nav.html:84 src/olympia/browse/feeds.py:207 src/olympia/browse/templates/browse/search_tools.html:3 src/olympia/constants/base.py:176
 #: src/olympia/templates/menu_links.html:10
 msgid "Search Tools"
 msgstr ""
@@ -1992,7 +1993,7 @@ msgid "Jump to first page"
 msgstr ""
 
 #: src/olympia/amo/templates/amo/impala/paginator.html:22 src/olympia/amo/templates/amo/mobile/impala_paginator.html:12 src/olympia/discovery/templates/discovery/pane.html:44
-#: src/olympia/discovery/templates/discovery/addons/detail.html:38 src/olympia/stats/templates/stats/stats.html:164
+#: src/olympia/discovery/templates/discovery/addons/detail.html:38 src/olympia/stats/templates/stats/stats.html:166
 msgid "Previous"
 msgstr ""
 
@@ -2015,30 +2016,49 @@ msgid_plural "Page {n}"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/olympia/amo/templates/services/install.html:38
-#, python-format
-msgid "If you are not prompted to install %(addon_name)s in a moment, please <a href=\"%(addon_xpi)s\">click here</a>."
-msgstr ""
-
-#: src/olympia/amo/tests/test_messages.py:57 src/olympia/amo/tests/test_messages.py:58 src/olympia/reviews/forms.py:25 src/olympia/reviews/forms.py:50 src/olympia/reviews/templates/reviews/add.html:56
+#: src/olympia/amo/tests/test_messages.py:56 src/olympia/amo/tests/test_messages.py:57 src/olympia/reviews/forms.py:25 src/olympia/reviews/forms.py:50 src/olympia/reviews/templates/reviews/add.html:56
 #: src/olympia/reviews/templates/reviews/reply.html:30
 msgid "Title"
 msgstr ""
 
-#: src/olympia/amo/tests/test_messages.py:57 src/olympia/amo/tests/test_messages.py:58
+#: src/olympia/amo/tests/test_messages.py:56 src/olympia/amo/tests/test_messages.py:57
 msgid "Body"
 msgstr ""
 
-#: src/olympia/amo/tests/test_messages.py:59
+#: src/olympia/amo/tests/test_messages.py:58
 msgid "Another Title"
 msgstr ""
 
-#: src/olympia/amo/tests/test_messages.py:59
+#: src/olympia/amo/tests/test_messages.py:58
 msgid "Another Body"
 msgstr ""
 
-#: src/olympia/api/views.py:255
-msgid "Not implemented yet."
+#: src/olympia/api/authentication.py:76
+msgid "Signature has expired."
+msgstr ""
+
+#: src/olympia/api/authentication.py:79
+msgid "Error decoding signature."
+msgstr ""
+
+#: src/olympia/api/authentication.py:82
+msgid "Invalid JWT Token."
+msgstr ""
+
+#: src/olympia/api/authentication.py:130
+msgid "Invalid Authorization header. No credentials provided."
+msgstr ""
+
+#: src/olympia/api/authentication.py:133
+msgid "Invalid Authorization header. Credentials string should not contain spaces."
+msgstr ""
+
+#: src/olympia/api/fields.py:29
+msgid "The field must have a length of at least {num} characters."
+msgstr ""
+
+#: src/olympia/api/fields.py:31
+msgid "The language code {lang_code} is invalid."
 msgstr ""
 
 #: src/olympia/applications/views.py:39 src/olympia/applications/templates/applications/appversions.html:3
@@ -2057,7 +2077,7 @@ msgstr ""
 msgid "Add-ons submitted to Mozilla Add-ons must have a manifest file with at least one of the below applications supported. Only the versions listed below are allowed for these applications."
 msgstr ""
 
-#: src/olympia/applications/templates/applications/appversions.html:25
+#: src/olympia/applications/templates/applications/appversions.html:25 src/olympia/editors/helpers.py:361
 msgid "GUID"
 msgstr ""
 
@@ -2171,8 +2191,8 @@ msgstr ""
 msgid "Remove from favorites"
 msgstr ""
 
-#: src/olympia/bandwagon/views.py:98 src/olympia/bandwagon/views.py:191 src/olympia/browse/views.py:58 src/olympia/browse/views.py:69 src/olympia/browse/views.py:458 src/olympia/devhub/views.py:74
-#: src/olympia/devhub/views.py:82 src/olympia/devhub/templates/devhub/addons/edit/basic.html:20 src/olympia/editors/templates/editors/leaderboard.html:24
+#: src/olympia/bandwagon/views.py:98 src/olympia/bandwagon/views.py:191 src/olympia/browse/views.py:58 src/olympia/browse/views.py:69 src/olympia/browse/views.py:425 src/olympia/devhub/views.py:72
+#: src/olympia/devhub/views.py:80 src/olympia/devhub/templates/devhub/addons/edit/basic.html:20 src/olympia/editors/templates/editors/leaderboard.html:24
 #: src/olympia/editors/templates/editors/themes/queue_list.html:48 src/olympia/search/forms.py:17 src/olympia/search/forms.py:89 src/olympia/users/templates/users/vcard.html:5
 msgid "Name"
 msgstr ""
@@ -2181,7 +2201,7 @@ msgstr ""
 msgid "Recently Popular"
 msgstr ""
 
-#: src/olympia/bandwagon/views.py:189 src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:18
+#: src/olympia/bandwagon/views.py:189 src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:16
 msgid "Added"
 msgstr ""
 
@@ -2195,7 +2215,7 @@ msgstr ""
 
 #: src/olympia/bandwagon/views.py:316
 #, python-format
-msgid "Your new collection is shown below. You can <ahref=\"%(url)s\">edit additional settings</a> if you'dlike."
+msgid "Your new collection is shown below. You can <a href=\"%(url)s\">edit additional settings</a> if you'd like."
 msgstr ""
 
 #: src/olympia/bandwagon/views.py:322
@@ -2323,8 +2343,8 @@ msgid_plural "%(num)s Add-ons in this Collection"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/olympia/bandwagon/templates/bandwagon/collection_detail.html:125 src/olympia/compat/templates/compat/index.html:25 src/olympia/compat/templates/compat/reporter_detail.html:29
-#: src/olympia/files/templates/files/viewer.html:29 src/olympia/templates/amo_footer.html:17 src/olympia/templates/includes/lang_switcher.html:10
+#: src/olympia/bandwagon/templates/bandwagon/collection_detail.html:125 src/olympia/compat/templates/compat/reporter_detail.html:29 src/olympia/files/templates/files/viewer.html:29
+#: src/olympia/templates/amo_footer.html:17 src/olympia/templates/includes/lang_switcher.html:10
 msgid "Go"
 msgstr ""
 
@@ -2491,7 +2511,7 @@ msgid "Remove this user as a contributor"
 msgstr ""
 
 #: src/olympia/bandwagon/templates/bandwagon/edit_contributors.html:18 src/olympia/bandwagon/templates/bandwagon/edit_contributors.html:43
-#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:20 src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:48
+#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:18 src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:46
 #: src/olympia/devhub/templates/devhub/addons/ajax_compat_update.html:19
 msgid "Remove"
 msgstr ""
@@ -2539,7 +2559,7 @@ msgid "<b>Warning:</b> By changing the owner of this collection, you will no lon
 msgstr ""
 
 #: src/olympia/bandwagon/templates/bandwagon/edit_contributors.html:83 src/olympia/devhub/templates/devhub/addons/forms_shared/media.html:157
-#: src/olympia/devhub/templates/devhub/addons/submit/describe.html:69 src/olympia/devhub/templates/devhub/addons/submit/license.html:60 src/olympia/devhub/templates/devhub/addons/submit/upload.html:78
+#: src/olympia/devhub/templates/devhub/addons/submit/describe.html:69 src/olympia/devhub/templates/devhub/addons/submit/license.html:60 src/olympia/devhub/templates/devhub/addons/submit/upload.html:70
 #: src/olympia/devhub/templates/devhub/payments/tier.html:17 src/olympia/editors/templates/editors/themes/themes.html:111 src/olympia/editors/templates/editors/themes/themes.html:128
 #: src/olympia/editors/templates/editors/themes/themes.html:134 src/olympia/editors/templates/editors/themes/themes.html:141 src/olympia/users/templates/users/fxa_migration_prompt_content.html:10
 #: src/olympia/users/templates/users/login_form.html:42 src/olympia/users/templates/users/mobile/login.html:57
@@ -2622,31 +2642,31 @@ msgid "Add-ons in Your Collection"
 msgstr ""
 
 #: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:4
-msgid ""
-"To include an add-on in this collection, enter its name in the box below and hit enter.  You can also use the <strong>Add to Collection</strong> links throughout the site to include add-ons later."
+msgid "To include an add-on in this collection, enter its name in the box below and hit enter."
 msgstr ""
 
-#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:17 src/olympia/constants/base.py:400 src/olympia/devhub/templates/devhub/addons/activity.html:62
+#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:15 src/olympia/constants/base.py:400 src/olympia/devhub/templates/devhub/addons/activity.html:62
+#: src/olympia/editors/helpers.py:273 src/olympia/editors/helpers.py:360
 msgid "Add-on"
 msgstr ""
 
-#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:26
+#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:24
 msgid "Enter the name of the add-on to include"
 msgstr ""
 
-#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:28
+#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:26
 msgid "Add to Collection"
 msgstr ""
 
-#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:45 src/olympia/editors/helpers.py:936 src/olympia/editors/helpers.py:956
+#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:43 src/olympia/editors/helpers.py:1016 src/olympia/editors/helpers.py:1036
 msgid "Pending"
 msgstr ""
 
-#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:47
+#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:45
 msgid "Add a comment"
 msgstr ""
 
-#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:48
+#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:46
 msgid "Remove this add-on from the collection"
 msgstr ""
 
@@ -2753,12 +2773,12 @@ msgstr ""
 msgid "Most Users"
 msgstr ""
 
-#: src/olympia/browse/views.py:61 src/olympia/browse/views.py:72 src/olympia/browse/views.py:279 src/olympia/browse/templates/browse/personas/mobile/category_landing.html:63
+#: src/olympia/browse/views.py:61 src/olympia/browse/views.py:72 src/olympia/browse/views.py:246 src/olympia/browse/templates/browse/personas/mobile/category_landing.html:63
 #: src/olympia/discovery/templates/discovery/pane.html:67 src/olympia/search/forms.py:92
 msgid "Up & Coming"
 msgstr ""
 
-#: src/olympia/browse/views.py:460 src/olympia/devhub/views.py:76 src/olympia/devhub/views.py:83 src/olympia/discovery/templates/discovery/addons/detail.html:66
+#: src/olympia/browse/views.py:427 src/olympia/devhub/views.py:74 src/olympia/devhub/views.py:81 src/olympia/discovery/templates/discovery/addons/detail.html:66
 msgid "Created"
 msgstr ""
 
@@ -2946,8 +2966,8 @@ msgid_plural "See all %(cnt)s extensions in %(name)s &raquo;"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/olympia/browse/templates/browse/mobile/extensions.html:13 src/olympia/compat/templates/compat/index.html:82 src/olympia/devhub/templates/devhub/devhub_search.html:24
-#: src/olympia/devhub/templates/devhub/addons/activity.html:47 src/olympia/search/templates/search/no_results.html:4 src/olympia/search/templates/search/mobile/results.html:36
+#: src/olympia/browse/templates/browse/mobile/extensions.html:13 src/olympia/devhub/templates/devhub/devhub_search.html:24 src/olympia/devhub/templates/devhub/addons/activity.html:47
+#: src/olympia/search/templates/search/no_results.html:4 src/olympia/search/templates/search/mobile/results.html:36
 msgid "No results found."
 msgstr ""
 
@@ -3032,7 +3052,7 @@ msgstr ""
 msgid "All"
 msgstr ""
 
-#: src/olympia/compat/forms.py:22 src/olympia/search/views.py:525
+#: src/olympia/compat/forms.py:22 src/olympia/editors/templates/editors/base.html:69 src/olympia/search/views.py:518
 msgid "All Add-ons"
 msgstr ""
 
@@ -3042,53 +3062,6 @@ msgstr ""
 
 #: src/olympia/compat/forms.py:24
 msgid "Non-binary"
-msgstr ""
-
-#. Review points sources other than add-ons and themes.
-#: src/olympia/compat/views.py:87 src/olympia/constants/base.py:388 src/olympia/devhub/forms.py:162 src/olympia/editors/templates/editors/performance.html:75
-msgid "Other"
-msgstr ""
-
-#: src/olympia/compat/templates/compat/index.html:4
-msgid "Add-on Compatibility Report for {app} {version}"
-msgstr ""
-
-#: src/olympia/compat/templates/compat/index.html:11
-msgid "{app} {version} Compatibility"
-msgstr ""
-
-#: src/olympia/compat/templates/compat/index.html:17
-#, python-format
-msgid "Top 95%% compatible with previous version"
-msgstr ""
-
-#: src/olympia/compat/templates/compat/index.html:18
-#, python-format
-msgid "Top 95%% of all add-ons"
-msgstr ""
-
-#: src/olympia/compat/templates/compat/index.html:19
-msgid "All active add-ons"
-msgstr ""
-
-#: src/olympia/compat/templates/compat/index.html:23 src/olympia/constants/base.py:401
-msgid "App"
-msgstr ""
-
-#: src/olympia/compat/templates/compat/index.html:55
-msgid "Details for add-ons compatible with previous version:"
-msgstr ""
-
-#: src/olympia/compat/templates/compat/index.html:57
-msgid "Show all versions"
-msgstr ""
-
-#: src/olympia/compat/templates/compat/index.html:59
-msgid "Details for add-ons compatible with all versions:"
-msgstr ""
-
-#: src/olympia/compat/templates/compat/index.html:61
-msgid "Show previous version only"
 msgstr ""
 
 #: src/olympia/compat/templates/compat/reporter.html:3
@@ -3142,8 +3115,8 @@ msgstr ""
 msgid "Report Type"
 msgstr ""
 
-#: src/olympia/compat/templates/compat/reporter_detail.html:47 src/olympia/devhub/forms.py:784 src/olympia/devhub/templates/devhub/addons/ajax_compat_update.html:17 src/olympia/editors/forms.py:108
-#: src/olympia/zadmin/forms.py:45
+#: src/olympia/compat/templates/compat/reporter_detail.html:47 src/olympia/devhub/forms.py:785 src/olympia/devhub/templates/devhub/addons/ajax_compat_update.html:17 src/olympia/editors/forms.py:108
+#: src/olympia/editors/forms.py:248 src/olympia/zadmin/forms.py:45
 msgid "Application"
 msgstr ""
 
@@ -3231,7 +3204,8 @@ msgstr ""
 msgid "Preliminarily Reviewed and Awaiting Full Review"
 msgstr ""
 
-#: src/olympia/constants/base.py:33 src/olympia/editors/helpers.py:924 src/olympia/editors/templates/editors/themes/history_table.html:34
+#: src/olympia/constants/base.py:33 src/olympia/editors/forms.py:258 src/olympia/editors/helpers.py:73 src/olympia/editors/helpers.py:1004
+#: src/olympia/editors/templates/editors/themes/history_table.html:34
 msgid "Deleted"
 msgstr ""
 
@@ -3328,6 +3302,11 @@ msgstr ""
 msgid "Ask before users can download this add-on"
 msgstr ""
 
+#. Review points sources other than add-ons and themes.
+#: src/olympia/constants/base.py:388 src/olympia/devhub/forms.py:162 src/olympia/editors/templates/editors/performance.html:75
+msgid "Other"
+msgstr ""
+
 #: src/olympia/constants/base.py:389
 msgid "Exception"
 msgstr ""
@@ -3338,6 +3317,10 @@ msgstr ""
 
 #: src/olympia/constants/base.py:391
 msgid "Change"
+msgstr ""
+
+#: src/olympia/constants/base.py:401
+msgid "App"
 msgstr ""
 
 #: src/olympia/constants/base.py:402
@@ -3488,7 +3471,7 @@ msgstr ""
 msgid "Duplicate"
 msgstr ""
 
-#: src/olympia/constants/editors.py:17 src/olympia/editors/helpers.py:502 src/olympia/editors/templates/editors/themes/queue.html:71 src/olympia/editors/templates/editors/themes/themes.html:94
+#: src/olympia/constants/editors.py:17 src/olympia/editors/helpers.py:575 src/olympia/editors/templates/editors/themes/queue.html:71 src/olympia/editors/templates/editors/themes/themes.html:94
 msgid "Reject"
 msgstr ""
 
@@ -3588,7 +3571,7 @@ msgstr ""
 msgid "Android"
 msgstr ""
 
-#: src/olympia/core/apps.py:19
+#: src/olympia/core/apps.py:21
 msgid "Core"
 msgstr ""
 
@@ -3722,7 +3705,7 @@ msgid "Submit my add-on for manual review."
 msgstr ""
 
 #: src/olympia/devhub/forms.py:537
-msgid "Do not list my add-on on this site (beta)"
+msgid "Do not list my add-on on this site"
 msgstr ""
 
 #: src/olympia/devhub/forms.py:538
@@ -3755,46 +3738,46 @@ msgstr ""
 
 #: src/olympia/devhub/forms.py:592
 #, python-format
-msgid "Version %s already exists"
+msgid "Version %s already exists, or was uploaded before."
 msgstr ""
 
-#: src/olympia/devhub/forms.py:604
+#: src/olympia/devhub/forms.py:605
 msgid "Select a valid choice. That choice is not one of the available choices."
 msgstr ""
 
-#: src/olympia/devhub/forms.py:610
+#: src/olympia/devhub/forms.py:611
 msgid "A file with a version ending with a|alpha|b|beta and an optional number is detected as beta."
 msgstr ""
 
-#: src/olympia/devhub/forms.py:633
+#: src/olympia/devhub/forms.py:634
 msgid "You cannot upload any more files for this version."
 msgstr ""
 
-#: src/olympia/devhub/forms.py:639
+#: src/olympia/devhub/forms.py:640
 msgid "Version doesn't match"
 msgstr ""
 
-#: src/olympia/devhub/forms.py:668
+#: src/olympia/devhub/forms.py:669
 msgid "You cannot delete a file once the review process has started.  You must delete the whole version."
 msgstr ""
 
-#: src/olympia/devhub/forms.py:688
+#: src/olympia/devhub/forms.py:689
 msgid "The platform All cannot be combined with specific platforms."
 msgstr ""
 
-#: src/olympia/devhub/forms.py:693
+#: src/olympia/devhub/forms.py:694
 msgid "A platform can only be chosen once."
 msgstr ""
 
-#: src/olympia/devhub/forms.py:706
+#: src/olympia/devhub/forms.py:707
 msgid "A review type must be selected."
 msgstr ""
 
-#: src/olympia/devhub/forms.py:788 src/olympia/editors/forms.py:114 src/olympia/zadmin/forms.py:49 src/olympia/zadmin/forms.py:52
+#: src/olympia/devhub/forms.py:789 src/olympia/editors/forms.py:114 src/olympia/editors/forms.py:254 src/olympia/zadmin/forms.py:49 src/olympia/zadmin/forms.py:52
 msgid "Select an application first"
 msgstr ""
 
-#: src/olympia/devhub/forms.py:840
+#: src/olympia/devhub/forms.py:841
 msgid "There cannot be more than 3 required add-ons."
 msgstr ""
 
@@ -3828,76 +3811,76 @@ msgstr[1] ""
 msgid "Review"
 msgstr ""
 
-#: src/olympia/devhub/tasks.py:551
+#: src/olympia/devhub/tasks.py:583
 #, python-format
 msgid "%s responded with %s (%s)."
 msgstr ""
 
-#: src/olympia/devhub/tasks.py:555
+#: src/olympia/devhub/tasks.py:587
 #, python-format
 msgid "Connection to \"%s\" timed out."
 msgstr ""
 
-#: src/olympia/devhub/tasks.py:557
+#: src/olympia/devhub/tasks.py:589
 #, python-format
 msgid "Could not contact host at \"%s\"."
 msgstr ""
 
-#: src/olympia/devhub/utils.py:104
+#: src/olympia/devhub/utils.py:105
 #, python-format
 msgid "Validation generated too many errors/warnings so %s messages were truncated. After addressing the visible messages, you'll be able to see the others."
 msgstr ""
 
-#: src/olympia/devhub/views.py:183
+#: src/olympia/devhub/views.py:181
 msgid "All My Add-ons"
 msgstr ""
 
-#: src/olympia/devhub/views.py:210
+#: src/olympia/devhub/views.py:208
 msgid "All Activity"
 msgstr ""
 
-#: src/olympia/devhub/views.py:211
+#: src/olympia/devhub/views.py:209
 msgid "Add-on Updates"
 msgstr ""
 
-#: src/olympia/devhub/views.py:212
+#: src/olympia/devhub/views.py:210
 msgid "Add-on Status"
 msgstr ""
 
-#: src/olympia/devhub/views.py:213
+#: src/olympia/devhub/views.py:211
 msgid "User Collections"
 msgstr ""
 
-#: src/olympia/devhub/views.py:214 src/olympia/devhub/templates/devhub/docs/policies-maintenance.html:68 src/olympia/pages/templates/pages/dev_faq.html:38
+#: src/olympia/devhub/views.py:212 src/olympia/devhub/templates/devhub/docs/policies-maintenance.html:68 src/olympia/pages/templates/pages/dev_faq.html:38
 #: src/olympia/pages/templates/pages/dev_faq.html:484
 msgid "User Reviews"
 msgstr ""
 
-#: src/olympia/devhub/views.py:327 src/olympia/devhub/views.py:331 src/olympia/devhub/views.py:484 src/olympia/devhub/views.py:513 src/olympia/devhub/views.py:564 src/olympia/devhub/views.py:1150
+#: src/olympia/devhub/views.py:325 src/olympia/devhub/views.py:329 src/olympia/devhub/views.py:484 src/olympia/devhub/views.py:513 src/olympia/devhub/views.py:564 src/olympia/devhub/views.py:1156
 msgid "Changes successfully saved."
 msgstr ""
 
-#: src/olympia/devhub/views.py:334 src/olympia/devhub/views.py:1631
+#: src/olympia/devhub/views.py:332 src/olympia/devhub/views.py:1637
 msgid "Please check the form for errors."
 msgstr ""
 
-#: src/olympia/devhub/views.py:346
+#: src/olympia/devhub/views.py:344
 msgid "Add-on cannot be deleted. Disable this add-on instead."
 msgstr ""
 
-#: src/olympia/devhub/views.py:356
+#: src/olympia/devhub/views.py:354
 msgid "Theme deleted."
 msgstr ""
 
-#: src/olympia/devhub/views.py:356
+#: src/olympia/devhub/views.py:354
 msgid "Add-on deleted."
 msgstr ""
 
-#: src/olympia/devhub/views.py:362
+#: src/olympia/devhub/views.py:360
 msgid "URL name was incorrect. Theme was not deleted."
 msgstr ""
 
-#: src/olympia/devhub/views.py:367
+#: src/olympia/devhub/views.py:365
 msgid "URL name was incorrect. Add-on was not deleted."
 msgstr ""
 
@@ -3925,7 +3908,7 @@ msgstr ""
 msgid "Check Add-on Compatibility"
 msgstr ""
 
-#: src/olympia/devhub/views.py:808 src/olympia/signing/views.py:90
+#: src/olympia/devhub/views.py:808 src/olympia/signing/views.py:95
 msgid "You cannot submit this type of add-on"
 msgstr ""
 
@@ -3955,33 +3938,33 @@ msgstr ""
 msgid "There was an error uploading your preview."
 msgstr ""
 
-#: src/olympia/devhub/views.py:1189
+#: src/olympia/devhub/views.py:1195
 #, python-format
 msgid "Version %s disabled."
 msgstr ""
 
-#: src/olympia/devhub/views.py:1193
+#: src/olympia/devhub/views.py:1199
 #, python-format
 msgid "Version %s deleted."
 msgstr ""
 
-#: src/olympia/devhub/views.py:1203
+#: src/olympia/devhub/views.py:1209
 msgid "This upload has failed validation, and may lack complete validation results. Please take due care when reviewing it."
 msgstr ""
 
-#: src/olympia/devhub/views.py:1677
+#: src/olympia/devhub/views.py:1683
 msgid "Preliminary Review Requested."
 msgstr ""
 
-#: src/olympia/devhub/views.py:1678
+#: src/olympia/devhub/views.py:1684
 msgid "Full Review Requested."
 msgstr ""
 
-#: src/olympia/devhub/views.py:1779
+#: src/olympia/devhub/views.py:1783
 msgid "Your old credentials were revoked and are no longer valid. Be sure to update all API clients with the new credentials."
 msgstr ""
 
-#: src/olympia/devhub/views.py:1797
+#: src/olympia/devhub/views.py:1801
 msgid "New API key created"
 msgstr ""
 
@@ -4011,7 +3994,7 @@ msgstr ""
 msgid "{0} :: Search"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/devhub_search.html:6 src/olympia/devhub/templates/devhub/search.html:8 src/olympia/editors/forms.py:435 src/olympia/editors/forms.py:437
+#: src/olympia/devhub/templates/devhub/devhub_search.html:6 src/olympia/devhub/templates/devhub/search.html:8 src/olympia/editors/forms.py:534 src/olympia/editors/forms.py:536
 #: src/olympia/editors/templates/editors/queue.html:27 src/olympia/editors/templates/editors/themes/queue_list.html:14 src/olympia/search/templates/search/collections.html:17
 #: src/olympia/search/templates/search/personas.html:18 src/olympia/search/templates/search/results.html:18 src/olympia/search/templates/search/mobile/results.html:8
 #: src/olympia/templates/search.html:14 src/olympia/templates/impala/search.html:18
@@ -4071,12 +4054,12 @@ msgstr ""
 msgid "Start Making Add-ons"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/index.html:86 src/olympia/devhub/templates/devhub/addons/listing/items.html:25 src/olympia/devhub/templates/devhub/includes/addon_details.html:15
+#: src/olympia/devhub/templates/devhub/index.html:86 src/olympia/devhub/templates/devhub/addons/listing/items.html:25 src/olympia/devhub/templates/devhub/includes/addon_details.html:20
 #: src/olympia/devhub/templates/devhub/personas/edit.html:43
 msgid "Status:"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/index.html:90 src/olympia/devhub/templates/devhub/includes/addon_details.html:100
+#: src/olympia/devhub/templates/devhub/index.html:90 src/olympia/devhub/templates/devhub/includes/addon_details.html:87
 msgid "Visibility:"
 msgstr ""
 
@@ -4084,11 +4067,11 @@ msgstr ""
 msgid "Latest Version:"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/index.html:109 src/olympia/devhub/templates/devhub/includes/addon_details.html:145 src/olympia/devhub/templates/devhub/personas/edit.html:49
+#: src/olympia/devhub/templates/devhub/index.html:109 src/olympia/devhub/templates/devhub/includes/addon_details.html:131 src/olympia/devhub/templates/devhub/personas/edit.html:49
 msgid "Queue Position:"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/index.html:110 src/olympia/devhub/templates/devhub/includes/addon_details.html:146 src/olympia/devhub/templates/devhub/personas/edit.html:50
+#: src/olympia/devhub/templates/devhub/index.html:110 src/olympia/devhub/templates/devhub/includes/addon_details.html:132 src/olympia/devhub/templates/devhub/personas/edit.html:50
 #, python-format
 msgid "%(position)s of %(total)s"
 msgstr ""
@@ -4190,16 +4173,6 @@ msgstr ""
 msgid "Do you want your add-on to be distributed on this site?"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/validate_addon.html:49 src/olympia/devhub/templates/devhub/addons/submit/upload.html:30 src/olympia/devhub/templates/devhub/versions/add_file_modal.html:14
-#: src/olympia/devhub/templates/devhub/versions/add_file_modal.html:53 src/olympia/devhub/templates/devhub/versions/list.html:298
-msgid "Warning:"
-msgstr ""
-
-#: src/olympia/devhub/templates/devhub/validate_addon.html:50 src/olympia/devhub/templates/devhub/addons/submit/upload.html:31
-#, python-format
-msgid "Submission of unlisted add-ons for signing is currently in an open beta. Please <a href=\"%(url)s\" target=\"_blank\">report any bugs</a> that you encounter."
-msgstr ""
-
 #. first parameter is a filename like lorem-ipsum-1.0.2.xpi
 #: src/olympia/devhub/templates/devhub/validation.html:5
 msgid "Validation Results for {0}"
@@ -4274,7 +4247,7 @@ msgstr ""
 msgid "Update Compatibility"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/addons/ajax_compat_update.html:4
+#: src/olympia/devhub/templates/devhub/addons/ajax_compat_update.html:4 src/olympia/devhub/templates/devhub/versions/edit.html:45
 msgid "Adjusting application information here will allow users to install your add-on even if the install manifest in the package indicates that the add-on is incompatible."
 msgstr ""
 
@@ -4286,9 +4259,9 @@ msgstr ""
 msgid "Add Another Application&hellip;"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/addons/ajax_compat_update.html:38 src/olympia/devhub/templates/devhub/addons/owner.html:86 src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:46
-#: src/olympia/devhub/templates/devhub/versions/list.html:351 src/olympia/devhub/templates/devhub/versions/list.html:353 src/olympia/templates/impala/base.html:132
-#: src/olympia/templates/impala/base.html:143 src/olympia/templates/impala/base.html:161 src/olympia/templates/impala/base.html:171
+#: src/olympia/devhub/templates/devhub/addons/ajax_compat_update.html:38 src/olympia/devhub/templates/devhub/addons/owner.html:86 src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:45
+#: src/olympia/devhub/templates/devhub/versions/list.html:349 src/olympia/devhub/templates/devhub/versions/list.html:351 src/olympia/templates/impala/base.html:129
+#: src/olympia/templates/impala/base.html:140 src/olympia/templates/impala/base.html:158 src/olympia/templates/impala/base.html:168
 msgid "Close"
 msgstr ""
 
@@ -4322,7 +4295,7 @@ msgstr ""
 msgid "Manage Authors & License"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/addons/owner.html:29 src/olympia/editors/templates/editors/review.html:270
+#: src/olympia/devhub/templates/devhub/addons/owner.html:29 src/olympia/editors/helpers.py:362 src/olympia/editors/templates/editors/review.html:270
 msgid "Authors"
 msgstr ""
 
@@ -4391,17 +4364,11 @@ msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/basic.html:52
 msgid ""
-"A short explanation of your add-on's basic\n"
-"                          functionality that is displayed in search and browse\n"
-"                          listings, as well as at the top of your add-on's\n"
-"                          details page. It is only relevant for listed add-ons."
+"A short explanation of your add-on's basic functionality that is displayed in search and browse listings, as well as at the top of your add-on's details page. It is only relevant for listed add-ons."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/basic.html:73
-msgid ""
-"Categories are the primary way users browse through add-ons.\n"
-"                        Choose any that fit your add-on's functionality for the most\n"
-"                        exposure. It is only relevant for listed add-ons."
+msgid "Categories are the primary way users browse through add-ons. Choose any that fit your add-on's functionality for the most exposure. It is only relevant for listed add-ons."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/basic.html:90
@@ -4411,11 +4378,7 @@ msgid ""
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/basic.html:119
-msgid ""
-"Tags help users find your add-on and should be short\n"
-"                        descriptors such as tabs, toolbar, or twitter.  You\n"
-"                        may have a maximum of {0} tags. It is only relevant\n"
-"                        for listed add-ons."
+msgid "Tags help users find your add-on and should be short descriptors such as tabs, toolbar, or twitter. You may have a maximum of {0} tags. It is only relevant for listed add-ons."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/basic.html:129 src/olympia/devhub/templates/devhub/personas/edit.html:97 src/olympia/devhub/templates/devhub/personas/submit.html:46
@@ -4443,11 +4406,7 @@ msgid "Add-on Details for {0}"
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/details.html:22
-msgid ""
-"A longer explanation of features,\n"
-"                          functionality, and other relevant information. This\n"
-"                          field is only displayed on the add-on's details\n"
-"                          page. It is only relevant for listed add-ons."
+msgid "A longer explanation of features, functionality, and other relevant information. This field is only displayed on the add-on's details page. It is only relevant for listed add-ons."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/details.html:44 src/olympia/translations/templates/translations/trans-menu.html:13
@@ -4455,10 +4414,7 @@ msgid "Default Locale"
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/details.html:45
-msgid ""
-"Information about your add-on is displayed in this locale\n"
-"                        unless you override it with a locale-specific translation.\n"
-"                        It is only relevant for listed add-ons."
+msgid "Information about your add-on is displayed in this locale unless you override it with a locale-specific translation. It is only relevant for listed add-ons."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/details.html:61 src/olympia/users/forms.py:311 src/olympia/users/templates/users/edit.html:122 src/olympia/users/templates/users/register.html:57
@@ -4468,10 +4424,8 @@ msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/details.html:63
 msgid ""
-"If your add-on has another homepage, enter its\n"
-"                          address here. If your website is localized into other\n"
-"                          languages multiple translations of this field can be\n"
-"                          added. It is only relevant for listed add-ons."
+"If your add-on has another homepage, enter its address here. If your website is localized into other languages multiple translations of this field can be added. It is only relevant for listed add-"
+"ons."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/media.html:3
@@ -4489,19 +4443,14 @@ msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/support.html:22
 msgid ""
-"If you wish to display an e-mail address for support\n"
-"                          inquiries, enter it here. If you have different\n"
-"                          addresses for each language multiple translations of\n"
-"                          this field can be added. It is only relevant for\n"
-"                          listed add-ons."
+"If you wish to display an e-mail address for support inquiries, enter it here. If you have different addresses for each language multiple translations of this field can be added. It is only "
+"relevant for listed add-ons."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/support.html:45
 msgid ""
-"If your add-on has a support website or forum, enter\n"
-"                          its address here. If your website is localized into\n"
-"                          other languages, multiple translations of this field can\n"
-"                          be added. It is only relevant for listed add-ons."
+"If your add-on has a support website or forum, enter its address here. If your website is localized into other languages, multiple translations of this field can be added. It is only relevant for "
+"listed add-ons."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:6
@@ -4515,11 +4464,8 @@ msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:23
 msgid ""
-"Any information end users may want to know that isn't\n"
-"                          necessarily applicable to the add-on summary or description.\n"
-"                          Common uses include listing known major bugs, information on\n"
-"                          how to report bugs, anticipated release date of a new version,\n"
-"                          etc. It is only relevant for listed add-ons."
+"Any information end users may want to know that isn't necessarily applicable to the add-on summary or description. Common uses include listing known major bugs, information on how to report bugs, "
+"anticipated release date of a new version, etc. It is only relevant for listed add-ons."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:46
@@ -4531,9 +4477,7 @@ msgid "Add-on Flags"
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:69
-msgid ""
-"These flags are used to classify add-ons. It is only\n"
-"                        relevant for listed add-ons."
+msgid "These flags are used to classify add-ons. It is only relevant for listed add-ons."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:74
@@ -4549,9 +4493,7 @@ msgid "View Source?"
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:90
-msgid ""
-"Whether the source of your add-on can be displayed in our\n"
-"                        online viewer. It is only relevant for listed add-ons."
+msgid "Whether the source of your add-on can be displayed in our online viewer. It is only relevant for listed add-ons."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:94
@@ -4567,10 +4509,7 @@ msgid "Public Stats?"
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:102
-msgid ""
-"Whether the download and usage stats of your add-on can\n"
-"                        be displayed in our online viewer.\n"
-"                        It is only relevant for listed add-ons."
+msgid "Whether the download and usage stats of your add-on can be displayed in our online viewer. It is only relevant for listed add-ons."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:107
@@ -4586,10 +4525,7 @@ msgid "Upgrade SDK?"
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:116
-msgid ""
-"If selected, we will try to automatically upgrade your\n"
-"                        add-on when a new version of the SDK is released.\n"
-"                        It is only relevant for listed add-ons."
+msgid "If selected, we will try to automatically upgrade your add-on when a new version of the SDK is released. It is only relevant for listed add-ons."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:121
@@ -4640,10 +4576,8 @@ msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/forms_shared/media.html:16
 msgid ""
-"Upload an icon for your add-on or choose from one of ours. The\n"
-"                      icon is displayed nearly everywhere your add-on is. Uploaded images\n"
-"                      must be one of the following image types: .png, .jpg.\n"
-"                      It is only relevant for listed add-ons."
+"Upload an icon for your add-on or choose from one of ours. The icon is displayed nearly everywhere your add-on is. Uploaded images must be one of the following image types: .png, .jpg. It is only "
+"relevant for listed add-ons."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/forms_shared/media.html:25
@@ -4656,9 +4590,7 @@ msgid "32x32px"
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/forms_shared/media.html:39
-msgid ""
-"Used in listings of add-ons, like search results\n"
-"                            and featured add-ons."
+msgid "Used in listings of add-ons, like search results and featured add-ons."
 msgstr ""
 
 #. The size of the icon
@@ -4753,16 +4685,14 @@ msgid "Deleting your add-on will permanently remove it from the site and prevent
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:24
-msgid ""
-"Enter the following text confirm your decision:\n"
-"           {slug}"
+msgid "Enter the following text confirm your decision: {slug}"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:34
+#: src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:33
 msgid "Please tell us why you are deleting your theme:"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:36
+#: src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:35
 msgid "Please tell us why you are deleting your add-on:"
 msgstr ""
 
@@ -4799,8 +4729,8 @@ msgstr ""
 msgid "Daily statistics on downloads and users."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/addons/listing/item_actions.html:45 src/olympia/stats/templates/stats/stats.html:75 src/olympia/stats/templates/stats/stats.html:79
-#: src/olympia/stats/templates/stats/stats.html:81
+#: src/olympia/devhub/templates/devhub/addons/listing/item_actions.html:45 src/olympia/stats/templates/stats/stats.html:31 src/olympia/stats/templates/stats/stats.html:35
+#: src/olympia/stats/templates/stats/stats.html:37
 msgid "Statistics"
 msgstr ""
 
@@ -4919,10 +4849,7 @@ msgid "Your add-on has been submitted to the Full Review queue."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/submit/done.html:18
-msgid ""
-"You'll receive an email once it has been reviewed by an editor. In\n"
-"          the meantime, you and your friends can install it directly from its\n"
-"          details page:"
+msgid "You'll receive an email once it has been reviewed by an editor. In the meantime, you and your friends can install it directly from its details page:"
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/submit/done.html:27 src/olympia/devhub/templates/devhub/addons/submit/done.html:77 src/olympia/devhub/templates/devhub/personas/submit_done.html:16
@@ -5128,11 +5055,11 @@ msgstr ""
 msgid "Use the fields below to upload your add-on package and select any platform restrictions. After upload, a series of automated validation tests will be run on your file."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/addons/submit/upload.html:59 src/olympia/devhub/templates/devhub/versions/add_file_modal.html:39
+#: src/olympia/devhub/templates/devhub/addons/submit/upload.html:51 src/olympia/devhub/templates/devhub/versions/add_file_modal.html:28
 msgid "Which platforms is this file compatible with?"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/addons/submit/upload.html:67 src/olympia/devhub/templates/devhub/versions/add_file_modal.html:65
+#: src/olympia/devhub/templates/devhub/addons/submit/upload.html:59 src/olympia/devhub/templates/devhub/versions/add_file_modal.html:45
 msgid "Administrative overrides"
 msgstr ""
 
@@ -5242,8 +5169,8 @@ msgstr ""
 
 #: src/olympia/devhub/templates/devhub/docs/policies-contact.html:44
 msgid ""
-"If you've found a problem with the site, we'd love to fix it. Please <a href=\"https://github.com/mozilla/olympia/issues\">file a bug report</a> in GitHub, including the location of the problem and "
-"how you encountered it."
+"If you've found a problem with the site, we'd love to fix it. Please <a href=\"https://github.com/mozilla/addons/issues/new\">file a bug report</a> in GitHub, including the location of the problem "
+"and how you encountered it."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/docs/policies-maintenance.html:3 src/olympia/devhub/templates/devhub/docs/policies-maintenance.html:7
@@ -5810,7 +5737,7 @@ msgstr ""
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:282
 msgid ""
-"Add-ons that store or otherwise handle browsing data must support <a href=\"https://developer.mozilla.org/En/Supporting_private_browsing_mode\">Private Browsing Mode</a>.  During a Private Browsing "
+"Add-ons that store or otherwise handle browsing data must support <a href=\"https://developer.mozilla.org/En/Supporting_private_browsing_mode\">Private Browsing Mode</a>. During a Private Browsing "
 "session, no browsing data can be written to disk, and all of this data must be cleared when Firefox quits or the Private Browsing session ends."
 msgstr ""
 
@@ -5975,129 +5902,95 @@ msgstr ""
 msgid "How to get in touch with us regarding these policies or your add-on."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:6
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:10
 msgid "You have disabled this add-on"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:20
-msgid ""
-"Your add-on's listing is disabled and is not showing\n"
-"                             anywhere in our gallery or update service."
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:24
+msgid "Your add-on's listing is disabled and is not showing anywhere in our gallery or update service."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:25
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:27
 msgid "Please complete your add-on."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:29
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:30
 msgid "You will receive an email when the review is complete."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:34
-msgid ""
-"You will receive an email when the review is complete. Until\n"
-"                             then, your add-on is not listed in our gallery but can be\n"
-"                             accessed directly from its details page."
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:33
+msgid "You will receive an email when the review is complete. Until then, your add-on is not listed in our gallery but can be accessed directly from its details page."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:38 src/olympia/devhub/templates/devhub/includes/addon_details.html:48
-msgid ""
-"You will receive an email when the review is\n"
-"                             complete and your add-on is signed."
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:37 src/olympia/devhub/templates/devhub/includes/addon_details.html:45
+msgid "You will receive an email when the review is complete and your add-on is signed."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:44
-msgid ""
-"You will receive an email when the review is complete. Until\n"
-"                             then, your add-on is not listed in our gallery but can be\n"
-"                             accessed directly from its details page. "
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:41
+msgid "You will receive an email when the review is complete. Until then, your add-on is not listed in our gallery but can be accessed directly from its details page. "
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:54
-msgid ""
-"Your add-on is displayed in our gallery and users are\n"
-"                             receiving automatic updates."
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:49
+msgid "Your add-on is displayed in our gallery and users are receiving automatic updates."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:57
-msgid ""
-"Your add-on has been signed and can be bundled with an\n"
-"                             application installer."
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:52
+msgid "Your add-on has been signed and can be bundled with an application installer."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:63
-msgid ""
-"Your add-on was disabled by a site administrator and is no\n"
-"                             longer shown in our gallery. If you have any questions,\n"
-"                             please email amo-admins@mozilla.org."
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:56
+msgid "Your add-on was disabled by a site administrator and is no longer shown in our gallery. If you have any questions, please email amo-admins@mozilla.org."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:70
-msgid ""
-"Your add-on is displayed in our gallery as experimental\n"
-"                             and users are receiving automatic updates. Some features\n"
-"                             are unavailable to your add-on."
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:62
+msgid "Your add-on is displayed in our gallery as experimental and users are receiving automatic updates. Some features are unavailable to your add-on."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:74
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:66
 msgid "Your add-on has been signed."
 msgstr ""
 
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:69
+msgid ""
+"You will receive an email when the full review is complete. Until then, your add-on is displayed in our gallery as experimental and users are receiving automatic updates. Some features are "
+"unavailable to your add-on."
+msgstr ""
+
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:74
+msgid "You will receive an email when the full review is complete, making you able to bundle your add-on with an application installer."
+msgstr ""
+
 #: src/olympia/devhub/templates/devhub/includes/addon_details.html:79
-msgid ""
-"You will receive an email when the full review is complete.\n"
-"                             Until then, your add-on is displayed in our gallery as\n"
-"                             experimental and users are receiving automatic updates.\n"
-"                             Some features are unavailable to your add-on."
+msgid "All add-ons hosted in our gallery must now be reviewed by an editor. If you wish to continue hosting your add-on, please click to select a review process."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:84
-msgid ""
-"You will receive an email when the full review is\n"
-"                             complete, making you able to bundle your add-on with an\n"
-"                             application installer."
-msgstr ""
-
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:91
-msgid ""
-"All add-ons hosted in our gallery must now be reviewed by an\n"
-"                             editor. If you wish to continue hosting your add-on, please\n"
-"                             click to select a review process."
-msgstr ""
-
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:113
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:100
 msgid "Current Version:"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:115
-msgid ""
-"This is the version of your add-on that will\n"
-"                                           be installed if someone clicks the Install\n"
-"                                           button on addons.mozilla.org. It is only\n"
-"                                           relevant for listed add-ons."
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:102
+msgid "This is the version of your add-on that will be installed if someone clicks the Install button on addons.mozilla.org. It is only relevant for listed add-ons."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:123
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:110
 msgid "Created:"
 msgstr ""
 
 #. {0} is a date. dennis-ignore: E201
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:125 src/olympia/devhub/templates/devhub/includes/addon_details.html:131
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:112 src/olympia/devhub/templates/devhub/includes/addon_details.html:118
 #, python-format
 msgid "%%b %%e, %%Y"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:136
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:123
 msgid "Next Version:"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:138
-msgid ""
-"This is the newest uploaded version, however\n"
-"                                           it isn’t live on the site yet."
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:125
+msgid "This is the newest uploaded version, however it isn’t live on the site yet."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:144 src/olympia/devhub/templates/devhub/versions/list.html:30
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:130 src/olympia/devhub/templates/devhub/versions/list.html:30
 msgid "Queues are not reviewed strictly in order"
 msgstr ""
 
@@ -6165,9 +6058,7 @@ msgid "View the blog &#9658;"
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/includes/license_form.html:6
-msgid ""
-"Please choose a license appropriate for the rights you grant on your source code.\n"
-"                  It is only relevant for listed add-ons."
+msgid "Please choose a license appropriate for the rights you grant on your source code. It is only relevant for listed add-ons."
 msgstr ""
 
 #. {0} is a list of HTML tags.
@@ -6194,14 +6085,11 @@ msgstr[1] ""
 #: src/olympia/devhub/templates/devhub/includes/policy_form.html:4
 msgid ""
 "Users will be required to accept the following End-User License Agreement (EULA) prior to installing your add-on. The presence of a EULA significantly affects the number of downloads an add-on "
-"receives. Please note that a EULA is not the same as a code license, such as the GPL or MPL.\n"
-"                It is only relevant for listed add-ons."
+"receives. Please note that a EULA is not the same as a code license, such as the GPL or MPL.It is only relevant for listed add-ons."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/policy_form.html:21
-msgid ""
-"If your add-on transmits any data from the user's computer, a privacy policy is required that explains what data is sent and how it is used.\n"
-"                It is only relevant for listed add-ons."
+#: src/olympia/devhub/templates/devhub/includes/policy_form.html:24
+msgid "If your add-on transmits any data from the user's computer, a privacy policy is required that explains what data is sent and how it is used. It is only relevant for listed add-ons."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/includes/source_form_field.html:2
@@ -6369,12 +6257,8 @@ msgstr ""
 msgid "Add some tags to describe your Theme."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/personas/edit.html:106
-msgid ""
-"A short explanation of your theme's\n"
-"                                basic functionality that is displayed in\n"
-"                                search and browse listings, as well as at\n"
-"                                the top of your theme's details page."
+#: src/olympia/devhub/templates/devhub/personas/edit.html:106 src/olympia/devhub/templates/devhub/personas/submit.html:54
+msgid "A short explanation of your theme's basic functionality that is displayed in search and browse listings, as well as at the top of your theme's details page."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/personas/edit.html:122 src/olympia/devhub/templates/devhub/personas/submit.html:68
@@ -6444,7 +6328,7 @@ msgid "Upon upload and form submission, the AMO Team will review your updated de
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/personas/edit.html:241
-msgid "Your previously resubmitted design,  which is under pending review."
+msgid "Your previously resubmitted design, which is under pending review."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/personas/edit.html:245
@@ -6511,14 +6395,6 @@ msgstr ""
 
 #: src/olympia/devhub/templates/devhub/personas/submit.html:33
 msgid "Give your Theme a name."
-msgstr ""
-
-#: src/olympia/devhub/templates/devhub/personas/submit.html:54
-msgid ""
-"A short explanation of your theme's\n"
-"                                      basic functionality that is displayed in\n"
-"                                      search and browse listings, as well as at\n"
-"                                      the top of your theme's details page."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/personas/submit.html:198
@@ -6595,30 +6471,16 @@ msgstr ""
 msgid "Files added to reviewed versions must be reviewed before they will be available for download."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/add_file_modal.html:15
-#, python-format
-msgid ""
-"Submission of updates to unlisted add-ons for signing is currently in an open beta. Manual review may still be required for a large number of add-ons. Please <a href=\"%(url)s\" target=\"_blank"
-"\">report any bugs</a> that you encounter."
-msgstr ""
-
-#: src/olympia/devhub/templates/devhub/versions/add_file_modal.html:35
+#: src/olympia/devhub/templates/devhub/versions/add_file_modal.html:24
 msgid "Select the target platform for this file."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/add_file_modal.html:46
+#: src/olympia/devhub/templates/devhub/versions/add_file_modal.html:35
 msgid "Which review type would you like to nominate for?"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/add_file_modal.html:51
+#: src/olympia/devhub/templates/devhub/versions/add_file_modal.html:40
 msgid "Only publish this version to my beta channel."
-msgstr ""
-
-#: src/olympia/devhub/templates/devhub/versions/add_file_modal.html:54
-#, python-format
-msgid ""
-"The behavior of the beta channel has changed to accommodate <a href=\"%(addon_signing_url)s\" target=\"_blank\">mandatory add-on signing</a>. The new process is currently in an open beta, and may "
-"change significantly in the near future. Please <a href=\"%(issues_url)s\" target=\"_blank\">report any bugs</a> that you encounter."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/versions/edit.html:5
@@ -6642,19 +6504,10 @@ msgstr ""
 msgid "Upload Another File"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/edit.html:45
-msgid ""
-"Adjusting application information here will allow users to install your\n"
-"                          add-on even if the install manifest in the package indicates that the\n"
-"                          add-on is incompatible."
-msgstr ""
-
 #: src/olympia/devhub/templates/devhub/versions/edit.html:74
 msgid ""
-"Information about changes in this release, new features,\n"
-"                              known bugs, and other useful information specific to this\n"
-"                              release/version. This information is also shown in the\n"
-"                              Add-ons Manager when updating."
+"Information about changes in this release, new features, known bugs, and other useful information specific to this release/version. This information is also shown in the Add-ons Manager when "
+"updating."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/versions/edit.html:99
@@ -6666,10 +6519,7 @@ msgid "Notes for Reviewers"
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/versions/edit.html:114
-msgid ""
-"Optionally, enter any information that may be useful\n"
-"                              to the Editor reviewing this add-on, such as test\n"
-"                              account information."
+msgid "Optionally, enter any information that may be useful to the Editor reviewing this add-on, such as test account information."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/versions/edit.html:127
@@ -6747,7 +6597,7 @@ msgstr ""
 msgid "Request Preliminary Review"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:80 src/olympia/devhub/templates/devhub/versions/list.html:327 src/olympia/devhub/templates/devhub/versions/list.html:350
+#: src/olympia/devhub/templates/devhub/versions/list.html:80 src/olympia/devhub/templates/devhub/versions/list.html:325 src/olympia/devhub/templates/devhub/versions/list.html:348
 msgid "Cancel Review Request"
 msgstr ""
 
@@ -6776,7 +6626,7 @@ msgid "Unlisted:"
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/versions/list.html:114
-msgid "Not distributed on {0}. Developers will upload new versions for signing and distribute the add-ons on their own. (beta)"
+msgid "Not distributed on {0}. Developers will upload new versions for signing and distribute the add-ons on their own."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/versions/list.html:122
@@ -6839,81 +6689,73 @@ msgid "<strong>Important:</strong> Once a version has been deleted, you may not 
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/versions/list.html:230
-msgid ""
-"Deleting a version which has already been reviewed\n"
-"               may also cause a significant delay in the review of\n"
-"               your next update."
-msgstr ""
-
-#: src/olympia/devhub/templates/devhub/versions/list.html:233
 msgid "Are you sure you wish to delete this version?"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:238
+#: src/olympia/devhub/templates/devhub/versions/list.html:235
 msgid "Delete Version"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:240
+#: src/olympia/devhub/templates/devhub/versions/list.html:237
 msgid "Disable Version"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:247
+#: src/olympia/devhub/templates/devhub/versions/list.html:244
 msgid "Add a new Version"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:249
+#: src/olympia/devhub/templates/devhub/versions/list.html:246
 msgid "Add Version"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:256 src/olympia/devhub/templates/devhub/versions/list.html:274
+#: src/olympia/devhub/templates/devhub/versions/list.html:253 src/olympia/devhub/templates/devhub/versions/list.html:279
 msgid "Hide Add-on"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:259
+#: src/olympia/devhub/templates/devhub/versions/list.html:256
 msgid "Hiding your add-on will prevent it from appearing anywhere in our gallery and will stop users from receiving automatic updates."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:265
+#: src/olympia/devhub/templates/devhub/versions/list.html:263
+msgid "The files awaiting review will be disabled and you will need to upload new versions."
+msgstr ""
+
+#: src/olympia/devhub/templates/devhub/versions/list.html:270
 msgid "Are you sure you wish to hide your add-on?"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:286 src/olympia/devhub/templates/devhub/versions/list.html:315
+#: src/olympia/devhub/templates/devhub/versions/list.html:291 src/olympia/devhub/templates/devhub/versions/list.html:313
 msgid "Unlist Add-on"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:289
+#: src/olympia/devhub/templates/devhub/versions/list.html:294
 #, python-format
 msgid ""
 "Unlisting your add-on will make it (and each of its versions/files) invisible on this website. It won't show up in searches, won't have a public facing page, and won't be updated automatically for "
-"current users.  It is recommended for unlisted add-ons to provide a custom <a href=\"%(update_url)s\" target=\"_blank\">updateURL</a> in their manifest file for automatic updates."
+"current users. It is recommended for unlisted add-ons to provide a custom <a href=\"%(update_url)s\" target=\"_blank\">updateURL</a> in their manifest file for automatic updates."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:299
-#, python-format
-msgid "Switching add-ons to unlisted is currently in an open beta. Please <a href=\"%(url)s\" target=\"_blank\">report any bugs</a> that you encounter."
-msgstr ""
-
-#: src/olympia/devhub/templates/devhub/versions/list.html:305
+#: src/olympia/devhub/templates/devhub/versions/list.html:303
 msgid "Unlisting an add-on is irreversible!"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:305
+#: src/olympia/devhub/templates/devhub/versions/list.html:303
 msgid "An unlisted add-on cannot be switched to be listed."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:307
+#: src/olympia/devhub/templates/devhub/versions/list.html:305
 msgid "Are you sure you wish to unlist your add-on?"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:330
+#: src/olympia/devhub/templates/devhub/versions/list.html:328
 msgid "Canceling your review request will leave your add-on as preliminarily reviewed."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:335
+#: src/olympia/devhub/templates/devhub/versions/list.html:333
 msgid "Canceling your review request will mark your add-on incomplete. If you do not complete your add-on after several days by re-requesting review, it will be deleted."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:343
+#: src/olympia/devhub/templates/devhub/versions/list.html:341
 msgid "Are you sure you wish to cancel your review request?"
 msgstr ""
 
@@ -7252,19 +7094,19 @@ msgstr ""
 msgid "Search by add-on name / author email"
 msgstr ""
 
-#: src/olympia/editors/forms.py:103
+#: src/olympia/editors/forms.py:103 src/olympia/editors/forms.py:244 src/olympia/editors/forms.py:257
 msgid "yes"
 msgstr ""
 
-#: src/olympia/editors/forms.py:104
+#: src/olympia/editors/forms.py:104 src/olympia/editors/forms.py:244 src/olympia/editors/forms.py:257
 msgid "no"
 msgstr ""
 
-#: src/olympia/editors/forms.py:105
+#: src/olympia/editors/forms.py:105 src/olympia/editors/forms.py:245
 msgid "Admin Flag"
 msgstr ""
 
-#: src/olympia/editors/forms.py:113
+#: src/olympia/editors/forms.py:113 src/olympia/editors/forms.py:253
 msgid "Max. Version"
 msgstr ""
 
@@ -7276,55 +7118,59 @@ msgstr ""
 msgid "Add-on Types"
 msgstr ""
 
-#: src/olympia/editors/forms.py:126 src/olympia/editors/helpers.py:267
+#: src/olympia/editors/forms.py:126 src/olympia/editors/helpers.py:279
 msgid "Platforms"
 msgstr ""
 
+#: src/olympia/editors/forms.py:237
+msgid "Search by add-on name / author email / guid"
+msgstr ""
+
 #. L10n: 0 = platform, 1 = filename, 2 = status message
-#: src/olympia/editors/forms.py:238
+#: src/olympia/editors/forms.py:342
 #, python-format
 msgid "<strong>%s</strong> &middot; %s &middot; %s"
 msgstr ""
 
-#: src/olympia/editors/forms.py:252
+#: src/olympia/editors/forms.py:356
 msgid "Comments:"
 msgstr ""
 
-#: src/olympia/editors/forms.py:256
+#: src/olympia/editors/forms.py:360
 msgid "Operating systems:"
 msgstr ""
 
-#: src/olympia/editors/forms.py:258
+#: src/olympia/editors/forms.py:362
 msgid "Applications:"
 msgstr ""
 
-#: src/olympia/editors/forms.py:260
+#: src/olympia/editors/forms.py:364
 msgid "Notify me the next time this add-on is updated. (Subsequent updates will not generate an email)"
 msgstr ""
 
-#: src/olympia/editors/forms.py:265
+#: src/olympia/editors/forms.py:369
 msgid "Clear Admin Review Flag"
 msgstr ""
 
-#: src/olympia/editors/forms.py:267
+#: src/olympia/editors/forms.py:371
 msgid "Clear more info requested flag"
 msgstr ""
 
-#: src/olympia/editors/forms.py:281
+#: src/olympia/editors/forms.py:385
 msgid "Choose a canned response..."
 msgstr ""
 
 #. L10n: Description of what can be searched for.
-#: src/olympia/editors/forms.py:324
+#: src/olympia/editors/forms.py:423
 msgid "theme name"
 msgstr ""
 
-#: src/olympia/editors/forms.py:350
+#: src/olympia/editors/forms.py:449
 msgid "Someone else is reviewing this theme."
 msgstr ""
 
 #. L10n: Description of what can be searched for.
-#: src/olympia/editors/forms.py:447
+#: src/olympia/editors/forms.py:546
 msgid "app, reviewer, or comment"
 msgstr ""
 
@@ -7340,246 +7186,264 @@ msgstr ""
 msgid "Rejected or Unreviewed"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:123 src/olympia/editors/helpers.py:136
+#: src/olympia/editors/helpers.py:125 src/olympia/editors/helpers.py:138
 msgid "Queue"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:124 src/olympia/editors/templates/editors/base.html:50 src/olympia/editors/templates/editors/base.html:65
+#: src/olympia/editors/helpers.py:126 src/olympia/editors/templates/editors/base.html:50 src/olympia/editors/templates/editors/base.html:65
 msgid "Pending Updates"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:125 src/olympia/editors/templates/editors/base.html:48 src/olympia/editors/templates/editors/base.html:63
+#: src/olympia/editors/helpers.py:127 src/olympia/editors/templates/editors/base.html:48 src/olympia/editors/templates/editors/base.html:63
 msgid "Full Reviews"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:126 src/olympia/editors/templates/editors/base.html:52 src/olympia/editors/templates/editors/base.html:67
+#: src/olympia/editors/helpers.py:128 src/olympia/editors/templates/editors/base.html:52 src/olympia/editors/templates/editors/base.html:67
 msgid "Preliminary Reviews"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:127 src/olympia/editors/templates/editors/base.html:54
+#: src/olympia/editors/helpers.py:129 src/olympia/editors/templates/editors/base.html:54
 msgid "Moderated Reviews"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:128 src/olympia/editors/templates/editors/base.html:46
+#: src/olympia/editors/helpers.py:130 src/olympia/editors/templates/editors/base.html:46
 msgid "Fast Track"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:130
+#: src/olympia/editors/helpers.py:132
 msgid "Pending Themes"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:131 src/olympia/editors/templates/editors/themes/queue.html:4
+#: src/olympia/editors/helpers.py:133 src/olympia/editors/templates/editors/themes/queue.html:4
 msgid "Flagged Themes"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:132
+#: src/olympia/editors/helpers.py:134
 msgid "Update Themes"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:137
+#: src/olympia/editors/helpers.py:139
 msgid "Unlisted Pending Updates"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:138
+#: src/olympia/editors/helpers.py:140
 msgid "Unlisted Full Reviews"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:139
+#: src/olympia/editors/helpers.py:141
 msgid "Unlisted Preliminary Reviews"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:170
+#: src/olympia/editors/helpers.py:142
+msgid "Unlisted All Add-ons"
+msgstr ""
+
+#: src/olympia/editors/helpers.py:173
 msgid "Fast Track ({0})"
 msgid_plural "Fast Track ({0})"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/olympia/editors/helpers.py:175
+#: src/olympia/editors/helpers.py:178
 msgid "Full Review ({0})"
 msgid_plural "Full Reviews ({0})"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/olympia/editors/helpers.py:180
+#: src/olympia/editors/helpers.py:183
 msgid "Pending Update ({0})"
 msgid_plural "Pending Updates ({0})"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/olympia/editors/helpers.py:185
+#: src/olympia/editors/helpers.py:188
 msgid "Preliminary Review ({0})"
 msgid_plural "Preliminary Reviews ({0})"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/olympia/editors/helpers.py:190
+#: src/olympia/editors/helpers.py:193
 msgid "Moderated Review ({0})"
 msgid_plural "Moderated Reviews ({0})"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/olympia/editors/helpers.py:196
+#: src/olympia/editors/helpers.py:199
 msgid "Unlisted Full Review ({0})"
 msgid_plural "Unlisted Full Reviews ({0})"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/olympia/editors/helpers.py:201
+#: src/olympia/editors/helpers.py:204
 msgid "Unlisted Pending Update ({0})"
 msgid_plural "Unlisted Pending Updates ({0})"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/olympia/editors/helpers.py:206
+#: src/olympia/editors/helpers.py:209
 msgid "Unlisted Preliminary Review ({0})"
 msgid_plural "Unlisted Preliminary Reviews ({0})"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/olympia/editors/helpers.py:261
-msgid "Addon"
-msgstr ""
+#: src/olympia/editors/helpers.py:214
+msgid "Unlisted All Add-ons ({0})"
+msgid_plural "Unlisted All Add-ons ({0})"
+msgstr[0] ""
+msgstr[1] ""
 
-#: src/olympia/editors/helpers.py:262
+#: src/olympia/editors/helpers.py:274
 msgid "Type"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:263
+#: src/olympia/editors/helpers.py:275
 msgid "Waiting Time"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:264 src/olympia/editors/templates/editors/review.html:285
+#: src/olympia/editors/helpers.py:276 src/olympia/editors/templates/editors/review.html:285
 msgid "Flags"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:265
+#: src/olympia/editors/helpers.py:277
 msgid "Applications"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:270
+#: src/olympia/editors/helpers.py:282
 msgid "Additional"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:285
+#: src/olympia/editors/helpers.py:302
 msgid "Site Specific"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:287
+#: src/olympia/editors/helpers.py:304
 msgid "Requires External Software"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:289
+#: src/olympia/editors/helpers.py:306
 msgid "Binary Components"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:313
+#: src/olympia/editors/helpers.py:339
 msgid "moments ago"
 msgstr ""
 
 #. L10n: first argument is number of minutes
-#: src/olympia/editors/helpers.py:316
+#: src/olympia/editors/helpers.py:342
 msgid "{0} minute"
 msgid_plural "{0} minutes"
 msgstr[0] ""
 msgstr[1] ""
 
 #. L10n: first argument is number of hours
-#: src/olympia/editors/helpers.py:320
+#: src/olympia/editors/helpers.py:346
 msgid "{0} hour"
 msgid_plural "{0} hours"
 msgstr[0] ""
 msgstr[1] ""
 
 #. L10n: first argument is number of days
-#: src/olympia/editors/helpers.py:324
+#: src/olympia/editors/helpers.py:350
 msgid "{0} day"
 msgid_plural "{0} days"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/olympia/editors/helpers.py:488
+#: src/olympia/editors/helpers.py:364
+msgid "Last Review"
+msgstr ""
+
+#: src/olympia/editors/helpers.py:366
+msgid "Last Update"
+msgstr ""
+
+#: src/olympia/editors/helpers.py:387
+msgid "No Reviews"
+msgstr ""
+
+#: src/olympia/editors/helpers.py:561
 msgid "Push to public"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:490
+#: src/olympia/editors/helpers.py:563
 msgid "Grant full review"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:505
+#: src/olympia/editors/helpers.py:578
 msgid "Request more information"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:508
+#: src/olympia/editors/helpers.py:581
 msgid "Request super-review"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:519
+#: src/olympia/editors/helpers.py:592
 msgid "Grant preliminary review"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:520
+#: src/olympia/editors/helpers.py:593
 msgid "This will mark the files as preliminarily reviewed."
 msgstr ""
 
-#: src/olympia/editors/helpers.py:522
+#: src/olympia/editors/helpers.py:595
 msgid "Use this form to request more information from the author. They will receive an email and be able to answer here. You will be notified by email when they reply."
 msgstr ""
 
-#: src/olympia/editors/helpers.py:526
+#: src/olympia/editors/helpers.py:599
 msgid ""
 "If you have concerns about this add-on's security, copyright issues, or other concerns that an administrator should look into, enter your comments in the area below. They will be sent to "
 "administrators, not the author."
 msgstr ""
 
-#: src/olympia/editors/helpers.py:532
+#: src/olympia/editors/helpers.py:605
 msgid "This will reject the add-on and remove it from the review queue."
 msgstr ""
 
-#: src/olympia/editors/helpers.py:534
-msgid "Make a comment on this version.  The author won't be able to see this."
+#: src/olympia/editors/helpers.py:607
+msgid "Make a comment on this version. The author won't be able to see this."
 msgstr ""
 
-#: src/olympia/editors/helpers.py:538
+#: src/olympia/editors/helpers.py:611
 msgid "This will reject the files and remove them from the review queue."
 msgstr ""
 
-#: src/olympia/editors/helpers.py:542
+#: src/olympia/editors/helpers.py:615
 msgid "This will mark the add-on as preliminarily reviewed. Future versions will undergo preliminary review."
 msgstr ""
 
-#: src/olympia/editors/helpers.py:547
+#: src/olympia/editors/helpers.py:620
 msgid "This will mark the files as preliminarily reviewed. Future versions will undergo preliminary review."
 msgstr ""
 
-#: src/olympia/editors/helpers.py:552
+#: src/olympia/editors/helpers.py:625
 msgid "Retain preliminary review"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:553
+#: src/olympia/editors/helpers.py:626
 msgid "This will retain the add-on as preliminarily reviewed. Future versions will undergo preliminary review."
 msgstr ""
 
-#: src/olympia/editors/helpers.py:558
+#: src/olympia/editors/helpers.py:631
 msgid "This will approve a sandboxed version of a public add-on to appear on the public side."
 msgstr ""
 
-#: src/olympia/editors/helpers.py:561
+#: src/olympia/editors/helpers.py:634
 msgid "This will reject a version of a public add-on and remove it from the queue."
 msgstr ""
 
-#: src/olympia/editors/helpers.py:564
+#: src/olympia/editors/helpers.py:637
 msgid "This will mark the add-on and its most recent version and files as public. Future versions will go into the sandbox until they are reviewed by an editor."
 msgstr ""
 
-#: src/olympia/editors/helpers.py:637
+#: src/olympia/editors/helpers.py:714
 msgid "add-on"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:940 src/olympia/editors/helpers.py:960
+#: src/olympia/editors/helpers.py:1020 src/olympia/editors/helpers.py:1040
 msgid "Flagged"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:944 src/olympia/editors/helpers.py:963
+#: src/olympia/editors/helpers.py:1024 src/olympia/editors/helpers.py:1043
 msgid "Updates"
 msgstr ""
 
@@ -7631,56 +7495,56 @@ msgstr ""
 msgid "A question about your Theme submission"
 msgstr ""
 
-#: src/olympia/editors/views.py:144
+#: src/olympia/editors/views.py:146
 msgid "New Add-ons (Under 5 days)"
 msgstr ""
 
-#: src/olympia/editors/views.py:145
+#: src/olympia/editors/views.py:147
 msgid "Passable (5 to 10 days)"
 msgstr ""
 
-#: src/olympia/editors/views.py:146
+#: src/olympia/editors/views.py:148
 msgid "Overdue (Over 10 days)"
 msgstr ""
 
-#: src/olympia/editors/views.py:532
+#: src/olympia/editors/views.py:539
 msgid "An unknown error occurred"
 msgstr ""
 
-#: src/olympia/editors/views.py:587
+#: src/olympia/editors/views.py:592
 msgid "Self-reviews are not allowed."
 msgstr ""
 
-#: src/olympia/editors/views.py:609
+#: src/olympia/editors/views.py:613
 msgid "Review successfully processed."
 msgstr ""
 
-#: src/olympia/editors/views.py:807
+#: src/olympia/editors/views.py:812
 msgid "was approved"
 msgstr ""
 
-#: src/olympia/editors/views.py:808
+#: src/olympia/editors/views.py:813
 msgid "given preliminary review"
 msgstr ""
 
-#: src/olympia/editors/views.py:809
+#: src/olympia/editors/views.py:814
 msgid "rejected"
 msgstr ""
 
-#: src/olympia/editors/views.py:810
+#: src/olympia/editors/views.py:815
 msgctxt "editors_review_history_nominated_adminreview"
 msgid "escalated"
 msgstr ""
 
-#: src/olympia/editors/views.py:812
+#: src/olympia/editors/views.py:817
 msgid "needs more information"
 msgstr ""
 
-#: src/olympia/editors/views.py:813
+#: src/olympia/editors/views.py:818
 msgid "needs super review"
 msgstr ""
 
-#: src/olympia/editors/views.py:814
+#: src/olympia/editors/views.py:819
 msgid "commented"
 msgstr ""
 
@@ -7725,28 +7589,28 @@ msgstr ""
 msgid "Unlisted Queues"
 msgstr ""
 
-#: src/olympia/editors/templates/editors/base.html:72 src/olympia/editors/templates/editors/performance.html:6
+#: src/olympia/editors/templates/editors/base.html:74 src/olympia/editors/templates/editors/performance.html:6
 msgid "Performance"
 msgstr ""
 
-#: src/olympia/editors/templates/editors/base.html:75 src/olympia/editors/templates/editors/themes/base.html:19 src/olympia/editors/templates/editors/themes/base.html:38
+#: src/olympia/editors/templates/editors/base.html:77 src/olympia/editors/templates/editors/themes/base.html:19 src/olympia/editors/templates/editors/themes/base.html:38
 msgid "Logs"
 msgstr ""
 
-#: src/olympia/editors/templates/editors/base.html:78 src/olympia/editors/templates/editors/reviewlog.html:4 src/olympia/editors/templates/editors/reviewlog.html:27
+#: src/olympia/editors/templates/editors/base.html:80 src/olympia/editors/templates/editors/reviewlog.html:4 src/olympia/editors/templates/editors/reviewlog.html:27
 msgid "Add-on Review Log"
 msgstr ""
 
-#: src/olympia/editors/templates/editors/base.html:80 src/olympia/editors/templates/editors/eventlog.html:4 src/olympia/editors/templates/editors/eventlog.html:8
+#: src/olympia/editors/templates/editors/base.html:82 src/olympia/editors/templates/editors/eventlog.html:4 src/olympia/editors/templates/editors/eventlog.html:8
 #: src/olympia/editors/templates/editors/eventlog_detail.html:4
 msgid "Moderated Review Log"
 msgstr ""
 
-#: src/olympia/editors/templates/editors/base.html:82 src/olympia/editors/templates/editors/beta_signed_log.html:4 src/olympia/editors/templates/editors/beta_signed_log.html:8
+#: src/olympia/editors/templates/editors/base.html:84 src/olympia/editors/templates/editors/beta_signed_log.html:4 src/olympia/editors/templates/editors/beta_signed_log.html:8
 msgid "Signed Beta Files Log"
 msgstr ""
 
-#: src/olympia/editors/templates/editors/base.html:87 src/olympia/editors/templates/editors/includes/daily-message.html:4
+#: src/olympia/editors/templates/editors/base.html:89 src/olympia/editors/templates/editors/includes/daily-message.html:4
 msgid "Announcement"
 msgstr ""
 
@@ -7967,45 +7831,45 @@ msgstr ""
 msgid "clear search"
 msgstr ""
 
-#: src/olympia/editors/templates/editors/queue.html:72 src/olympia/editors/templates/editors/queue.html:122
+#: src/olympia/editors/templates/editors/queue.html:78 src/olympia/editors/templates/editors/queue.html:128
 msgid "Process Reviews"
 msgstr ""
 
-#: src/olympia/editors/templates/editors/queue.html:80
+#: src/olympia/editors/templates/editors/queue.html:86
 msgid "Moderation actions:"
 msgstr ""
 
-#: src/olympia/editors/templates/editors/queue.html:90
+#: src/olympia/editors/templates/editors/queue.html:96
 #, python-format
 msgid "by %(user)s on %(date)s %(stars)s (%(locale)s)"
 msgstr ""
 
-#: src/olympia/editors/templates/editors/queue.html:106
+#: src/olympia/editors/templates/editors/queue.html:112
 #, python-format
 msgid "<strong>%(reason)s</strong> <span class=\"light\">Flagged by %(user)s on %(date)s</span>"
 msgstr ""
 
-#: src/olympia/editors/templates/editors/queue.html:119
-msgid "All reviews have been moderated.  Good work!"
+#: src/olympia/editors/templates/editors/queue.html:125
+msgid "All reviews have been moderated. Good work!"
 msgstr ""
 
-#: src/olympia/editors/templates/editors/queue.html:161
+#: src/olympia/editors/templates/editors/queue.html:167
 msgid "Version Notes / Notes for Reviewer"
 msgstr ""
 
-#: src/olympia/editors/templates/editors/queue.html:169
+#: src/olympia/editors/templates/editors/queue.html:175
 msgid "There are currently no add-ons of this type to review."
 msgstr ""
 
-#: src/olympia/editors/templates/editors/queue.html:181 src/olympia/editors/templates/editors/themes/queue_list.html:85
+#: src/olympia/editors/templates/editors/queue.html:187 src/olympia/editors/templates/editors/themes/queue_list.html:85
 msgid "Helpful Links:"
 msgstr ""
 
-#: src/olympia/editors/templates/editors/queue.html:182
+#: src/olympia/editors/templates/editors/queue.html:188
 msgid "Add-on Policy"
 msgstr ""
 
-#: src/olympia/editors/templates/editors/queue.html:184
+#: src/olympia/editors/templates/editors/queue.html:190
 msgid "Editors' Guide"
 msgstr ""
 
@@ -8068,10 +7932,7 @@ msgid "<strong>Warning!</strong> Another user was viewing this page before you."
 msgstr ""
 
 #: src/olympia/editors/templates/editors/review.html:237
-msgid ""
-"The whiteboard is the place to exchange information relevant to\n"
-"               this addon (whatever the version), between the developer and the\n"
-"               editor. This is visible and editable by both."
+msgid "The whiteboard is the place to exchange information relevant to this addon (whatever the version), between the developer and the editor. This is visible and editable by both."
 msgstr ""
 
 #: src/olympia/editors/templates/editors/review.html:241
@@ -8345,7 +8206,7 @@ msgstr ""
 msgid "Describe your reason for flagging"
 msgstr ""
 
-#: src/olympia/files/forms.py:88
+#: src/olympia/files/forms.py:90
 msgid "Cannot diff a version against itself"
 msgstr ""
 
@@ -8380,51 +8241,51 @@ msgstr ""
 msgid "There was an error accessing file %s."
 msgstr ""
 
-#: src/olympia/files/utils.py:343
+#: src/olympia/files/utils.py:340
 msgid "Could not parse uploaded file."
 msgstr ""
 
-#: src/olympia/files/utils.py:380
+#: src/olympia/files/utils.py:377
 msgid "Invalid file name in archive: {0}"
 msgstr ""
 
-#: src/olympia/files/utils.py:388
+#: src/olympia/files/utils.py:385
 msgid "File exceeding size limit in archive: {0}"
 msgstr ""
 
-#: src/olympia/files/utils.py:439
+#: src/olympia/files/utils.py:436
 msgid "Invalid archive."
 msgstr ""
 
-#: src/olympia/files/utils.py:529 src/olympia/files/utils.py:532
+#: src/olympia/files/utils.py:526 src/olympia/files/utils.py:529
 msgid "Could not parse the manifest file."
 msgstr ""
 
-#: src/olympia/files/utils.py:551
+#: src/olympia/files/utils.py:548
 msgid "Could not find an add-on ID."
 msgstr ""
 
-#: src/olympia/files/utils.py:554
+#: src/olympia/files/utils.py:551
 msgid "Add-on ID must be 64 characters or less."
 msgstr ""
 
-#: src/olympia/files/utils.py:556
+#: src/olympia/files/utils.py:553
 msgid "Add-on ID doesn't match add-on."
 msgstr ""
 
-#: src/olympia/files/utils.py:564
+#: src/olympia/files/utils.py:561
 msgid "Duplicate add-on ID found."
 msgstr ""
 
-#: src/olympia/files/utils.py:567
+#: src/olympia/files/utils.py:564
 msgid "Version numbers should have fewer than 32 characters."
 msgstr ""
 
-#: src/olympia/files/utils.py:570
+#: src/olympia/files/utils.py:567
 msgid "Version numbers should only contain letters, numbers, and these punctuation characters: +*.-_."
 msgstr ""
 
-#: src/olympia/files/utils.py:587
+#: src/olympia/files/utils.py:584
 msgid "<em:type> doesn't match add-on"
 msgstr ""
 
@@ -8523,6 +8384,10 @@ msgstr ""
 
 #: src/olympia/files/templates/files/viewer.html:134
 msgid "Fetching file."
+msgstr ""
+
+#: src/olympia/legacy_api/views.py:255
+msgid "Not implemented yet."
 msgstr ""
 
 #: src/olympia/lib/constants.py:6
@@ -9181,10 +9046,6 @@ msgstr ""
 msgid "Zimbabwe Dollar"
 msgstr ""
 
-#: src/olympia/lib/video/ffmpeg.py:112 src/olympia/lib/video/totem.py:81
-msgid "Videos must be in WebM."
-msgstr ""
-
 #: src/olympia/pages/templates/pages/about.lhtml:3 src/olympia/pages/templates/pages/about.lhtml:10
 msgid "About Mozilla Add-ons"
 msgstr ""
@@ -9196,7 +9057,7 @@ msgstr ""
 #: src/olympia/pages/templates/pages/about.lhtml:13
 msgid ""
 "addons.mozilla.org, commonly known as \"AMO\", is Mozilla's official site for add-ons to Mozilla software, such as Firefox, Thunderbird, and SeaMonkey. Add-ons let you add new features and change "
-"the way your browser or application works.  Take a look around and explore the thousands of ways to customize the way you do things online."
+"the way your browser or application works. Take a look around and explore the thousands of ways to customize the way you do things online."
 msgstr ""
 
 #: src/olympia/pages/templates/pages/about.lhtml:19
@@ -9541,7 +9402,7 @@ msgstr ""
 msgid ""
 "Yes. It's possible, but some of the functionality provided by these libraries are available through XPCOM, XUL, and JavaScript. In addition, authors should take care if libraries modify primitive "
 "object prototypes (String.prototype, Date.prototype, etc.) and/or define global functions (eg. the $ function). These are prone to cause conflict with other add-ons, in particular if different add-"
-"ons use different versions of libraries and so on. Developers need to be very, very careful with using them.  Mozilla does not offer documentation on using them to build add-ons."
+"ons use different versions of libraries and so on. Developers need to be very, very careful with using them. Mozilla does not offer documentation on using them to build add-ons."
 msgstr ""
 
 #: src/olympia/pages/templates/pages/dev_faq.html:165
@@ -9655,8 +9516,8 @@ msgstr ""
 #, python-format
 msgid ""
 "Yes. Many developers choose to host their own add-ons. Choosing to host your add-on on <a href=\"%(amo_url)s\">Mozilla's add-on site</a>, though, allows for much greater exposure to your add-on due "
-"to the large volume of visitors to the site.  <a href=\"%(md_url)s\">mozdev.org</a> offers free project hosting for Mozilla applications and extensions providing developers with tools to help "
-"manage source code, version control, bug tracking and documentation."
+"to the large volume of visitors to the site. <a href=\"%(md_url)s\">mozdev.org</a> offers free project hosting for Mozilla applications and extensions providing developers with tools to help manage "
+"source code, version control, bug tracking and documentation."
 msgstr ""
 
 #: src/olympia/pages/templates/pages/dev_faq.html:277
@@ -9704,7 +9565,7 @@ msgstr ""
 #: src/olympia/pages/templates/pages/dev_faq.html:314
 #, python-format
 msgid ""
-"Yes. Mozilla's <a href=\"%(p_url)s\">Add-on Policy</a> describes what is an acceptable submission. This policy is subject to change without notice.  In addition, the AMO editorial team uses the <a "
+"Yes. Mozilla's <a href=\"%(p_url)s\">Add-on Policy</a> describes what is an acceptable submission. This policy is subject to change without notice. In addition, the AMO editorial team uses the <a "
 "href=\"%(g_url)s\">Editors Reviewing Guide</a> to ensure that your add-on meets specific guidelines for functionality and security."
 msgstr ""
 
@@ -9821,7 +9682,7 @@ msgstr ""
 #: src/olympia/pages/templates/pages/dev_faq.html:434
 #, python-format
 msgid ""
-"This is why it's very important to read the <a href=\"%(g_url)s\">Editors Reviewing Guide</a> to ensure that your add-on is setup as expected.  It's also a good idea to read the blog post, <a href="
+"This is why it's very important to read the <a href=\"%(g_url)s\">Editors Reviewing Guide</a> to ensure that your add-on is setup as expected. It's also a good idea to read the blog post, <a href="
 "\"%(blog_url)s\">Successfully Getting your Add-on Reviewed</a> which provides excellent insight into ensuring a smooth review of your add-on."
 msgstr ""
 
@@ -9928,7 +9789,7 @@ msgstr ""
 
 #: src/olympia/pages/templates/pages/dev_faq.html:572
 msgid ""
-"Free Software Foundation provides short summaries of the key open source licenses, including whether the license qualifies as a free software license or a copyleft license.  Also includes a "
+"Free Software Foundation provides short summaries of the key open source licenses, including whether the license qualifies as a free software license or a copyleft license. Also includes a "
 "discussion of what constitutes a free software license or a copyleft license (e.g., a Copyleft license is a general method for making a program or other work free, and requiring all modified and "
 "extended versions of the program to be free as well.)"
 msgstr ""
@@ -10106,19 +9967,13 @@ msgid "Add-on Gallery"
 msgstr ""
 
 #: src/olympia/pages/templates/pages/faq.html:171
-msgid ""
-"How do I choose between add-ons that seem to do the same\n"
-"    thing?"
+msgid "How do I choose between add-ons that seem to do the same thing?"
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:173
+#: src/olympia/pages/templates/pages/faq.html:172
 msgid ""
-"There are often several add-ons that have similar features. To\n"
-"    figure out which is right for you, read the entire description of the\n"
-"    add-on and view its screenshots. If there are still several in the running,\n"
-"    read through the add-on's ratings, user reviews, and statistics to see\n"
-"    which is most liked by other users. Remember that you can also just try\n"
-"    out both and see which you like better."
+"There are often several add-ons that have similar features. To figure out which is right for you, read the entire description of the add-on and view its screenshots. If there are still several in "
+"the running, read through the add-on's ratings, user reviews, and statistics to see which is most liked by other users. Remember that you can also just try out both and see which you like better."
 msgstr ""
 
 #: src/olympia/pages/templates/pages/faq.html:180
@@ -10159,80 +10014,67 @@ msgid "How much do add-ons cost to purchase?"
 msgstr ""
 
 #: src/olympia/pages/templates/pages/faq.html:207
-msgid ""
-"Add-ons hosted in our gallery are free unless clearly marked\n"
-"    otherwise."
+msgid "Add-ons hosted in our gallery are free unless clearly marked otherwise."
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:210
+#: src/olympia/pages/templates/pages/faq.html:209
 msgid "What does it mean when an add-on asks for contributions?"
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:211
+#: src/olympia/pages/templates/pages/faq.html:210
 msgid ""
-"Some add-on authors request users who enjoy an add-on to\n"
-"        contribute to its development by making a monetary contribution. These\n"
-"        contributions go directly to the developer unless a third party is\n"
-"        indicated, such as the non-profit Mozilla Foundation."
+"Some add-on authors request users who enjoy an add-on to contribute to its development by making a monetary contribution. These contributions go directly to the developer unless a third party is "
+"indicated, such as the non-profit Mozilla Foundation."
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:216
+#: src/olympia/pages/templates/pages/faq.html:215
 msgid "What are beta add-ons?"
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:218
+#: src/olympia/pages/templates/pages/faq.html:217
 msgid ""
-"Beta add-ons are unreviewed versions which represent the\n"
-"        latest work of an add-on author. While different authors have different\n"
-"        standards for beta code quality, you should assume that these add-ons\n"
-"        are less stable than the general add-on releases."
+"Beta add-ons are unreviewed versions which represent the latest work of an add-on author. While different authors have different standards for beta code quality, you should assume that these add-"
+"ons are less stable than the general add-on releases."
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:222
+#: src/olympia/pages/templates/pages/faq.html:221
 msgid ""
 "Please note that when you install an add-on from the \"Beta Version\" section of an add-on's listing, you will continue to receive updates for that add-on as they become available. Like the initial "
 "version you installed, all beta releases are unreviewed by Mozilla and may harm your computer."
 msgstr ""
 
+#: src/olympia/pages/templates/pages/faq.html:228
+msgid "What does it mean when an add-on is flagged as slow?"
+msgstr ""
+
 #: src/olympia/pages/templates/pages/faq.html:229
-msgid ""
-"What does it mean when an add-on is flagged as\n"
-"    slow?"
+msgid "Most add-ons load code and resources at the same time Firefox is starting up. In most cases the impact in start-up time is minimal, but some add-ons can cause a noticeable slowdown."
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:231
-msgid ""
-"Most add-ons load code and resources at the same time Firefox\n"
-"        is starting up. In most cases the impact in start-up time is minimal,\n"
-"        but some add-ons can cause a noticeable slowdown."
-msgstr ""
-
-#: src/olympia/pages/templates/pages/faq.html:236
+#: src/olympia/pages/templates/pages/faq.html:234
 msgid "How do I report an inappropriate or spam user review?"
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:237
+#: src/olympia/pages/templates/pages/faq.html:235
 msgid ""
-"To report a user review of an add-on, log in with your account\n"
-"    and visit the add-on's reviews page. Find the review you wish to report,\n"
-"    click \"Report this review\" and select a reason. Our editorial team will\n"
-"    investigate the review and take appropriate action."
+"To report a user review of an add-on, log in with your account and visit the add-on's reviews page. Find the review you wish to report, click \"Report this review\" and select a reason. Our "
+"editorial team will investigate the review and take appropriate action."
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:242
+#: src/olympia/pages/templates/pages/faq.html:240
 msgid "How do I report a bug or contact the Mozilla Add-ons team?"
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:243
+#: src/olympia/pages/templates/pages/faq.html:241
 #, python-format
 msgid "Please visit our <a href=\"%(contact_url)s\">Contact page</a>."
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:246
+#: src/olympia/pages/templates/pages/faq.html:244
 msgid "What is a Source Code License?"
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:247
+#: src/olympia/pages/templates/pages/faq.html:245
 #, python-format
 msgid ""
 "The source code used to create an add-on is an exclusive copyright of the add-on author, unless otherwise declared in a source code license. Many add-ons on this site have <a href=\"%(url)s\" lang="
@@ -10240,60 +10082,60 @@ msgid ""
 "the GPL or BSD licenses instead of making up their own."
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:256
+#: src/olympia/pages/templates/pages/faq.html:254
 #, python-format
 msgid "Firefox and other Mozilla software are <a href=\"%(url)s\">open source</a>."
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:264
+#: src/olympia/pages/templates/pages/faq.html:262
 msgid "Collections and Favorites"
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:267
+#: src/olympia/pages/templates/pages/faq.html:265
 msgid "What is a collection?"
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:268
+#: src/olympia/pages/templates/pages/faq.html:266
 msgid "Collections are groups of related add-ons created by users to share."
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:270
+#: src/olympia/pages/templates/pages/faq.html:268
 msgid "What is the My Favorites collection?"
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:271
+#: src/olympia/pages/templates/pages/faq.html:269
 msgid "Favorite add-ons are add-ons that you have bookmarked to easily get back to later. You can add an add-on to your favorites collection by clicking \"Add to favorites\" on its details page."
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:275 src/olympia/templates/menu_links.html:13 src/olympia/templates/impala/header_title.html:17
+#: src/olympia/pages/templates/pages/faq.html:273 src/olympia/templates/menu_links.html:13 src/olympia/templates/impala/header_title.html:17
 msgid "Mobile Add-ons"
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:278
+#: src/olympia/pages/templates/pages/faq.html:276
 msgid "What are mobile add-ons?"
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:279
+#: src/olympia/pages/templates/pages/faq.html:277
 #, python-format
 msgid ""
 "Mobile add-ons work with <a href=\"%(mobile_url)s\">Firefox for Mobile</a> and add or modify functionality just like desktop add-ons. You can find add-ons that work with Firefox for Mobile in our "
 "<a href=\"%(gallery_url)s\">gallery</a>."
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:288
+#: src/olympia/pages/templates/pages/faq.html:286
 msgid "Developer Topics"
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:289
+#: src/olympia/pages/templates/pages/faq.html:287
 #, python-format
 msgid "Please see our <a href=\"%(faq_url)s\">Developer FAQ</a> and <a href=\"%(hub_url)s\">Developer Hub</a> for answers to add-on developer-related questions."
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:294
+#: src/olympia/pages/templates/pages/faq.html:292
 msgid "Still have questions?"
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:295
+#: src/olympia/pages/templates/pages/faq.html:293
 #, python-format
 msgid "For general Firefox support, visit our <a href=\"%(sumo_url)s\">support website</a>. For general add-on and website questions, visit our <a href=\"%(forum_url)s\">forum</a>."
 msgstr ""
@@ -10431,7 +10273,7 @@ msgstr ""
 
 #: src/olympia/pages/templates/pages/sunbird.html:29
 msgid ""
-"Development on the Sunbird project has halted and its final release was on March 30, 2010.  We've been proud to host Sunbird add-ons on this site but as the project is no longer maintained we have "
+"Development on the Sunbird project has halted and its final release was on March 30, 2010. We've been proud to host Sunbird add-ons on this site but as the project is no longer maintained we have "
 "disabled our support for the add-ons."
 msgstr ""
 
@@ -10509,7 +10351,7 @@ msgstr ""
 #, python-format
 msgid ""
 "<h2>Keep these tips in mind:</h2> <ul> <li> Write like you're telling a friend about your experience with the add-on. Give specifics and helpful details, such as what features you liked and/or "
-"disliked, how easy to use it is, and any disadvantages it has.  Avoid generic language such as calling it \"Great\" or \"Bad\" unless you can give reasons why you believe this is so. </li> <li> "
+"disliked, how easy to use it is, and any disadvantages it has. Avoid generic language such as calling it \"Great\" or \"Bad\" unless you can give reasons why you believe this is so. </li> <li> "
 "Please do not post bug reports in reviews. We do not make your email address available to add-on developers and they may need to contact you to help resolve your issue. See the <a href=\"%(support)s"
 "\">support section</a> to find out where to get assistance for this add-on. </li> <li>Please keep reviews clean, avoid the use of improper language and do not post any personal information. </li> </"
 "ul> <p>Please read the <a href=\"%(guide)s\" target=\"_blank\">Review Guidelines</a> for more detail about user add-on reviews.</p>"
@@ -10745,16 +10587,16 @@ msgstr ""
 
 #. L10n: {0} is an application, such as Firefox. This means "any version of
 #. Firefox."
-#: src/olympia/search/views.py:554
+#: src/olympia/search/views.py:547
 msgid "Any {0}"
 msgstr ""
 
 #. L10n: "All Systems" means show everything regardless of platform.
-#: src/olympia/search/views.py:589
+#: src/olympia/search/views.py:582
 msgid "All Systems"
 msgstr ""
 
-#: src/olympia/search/views.py:600
+#: src/olympia/search/views.py:593
 msgid "All Tags"
 msgstr ""
 
@@ -10928,31 +10770,31 @@ msgstr ""
 msgid "Share this Collection"
 msgstr ""
 
-#: src/olympia/signing/views.py:30 src/olympia/templates/base.html:75 src/olympia/templates/impala/base.html:115
+#: src/olympia/signing/views.py:33 src/olympia/templates/base.html:71 src/olympia/templates/impala/base.html:112
 msgid "Some features are temporarily disabled while we perform website maintenance. We'll be back to full capacity shortly."
 msgstr ""
 
-#: src/olympia/signing/views.py:53
+#: src/olympia/signing/views.py:56
 msgid "Could not find add-on with id \"{}\"."
 msgstr ""
 
-#: src/olympia/signing/views.py:67
+#: src/olympia/signing/views.py:70
 msgid "You do not own this addon."
 msgstr ""
 
-#: src/olympia/signing/views.py:82
+#: src/olympia/signing/views.py:87
 msgid "Missing \"upload\" key in multipart file data."
 msgstr ""
 
-#: src/olympia/signing/views.py:96
+#: src/olympia/signing/views.py:101
 msgid "Version does not match the manifest file."
 msgstr ""
 
-#: src/olympia/signing/views.py:100
+#: src/olympia/signing/views.py:105
 msgid "Version already exists."
 msgstr ""
 
-#: src/olympia/signing/views.py:136
+#: src/olympia/signing/views.py:141
 msgid "No uploaded file for that addon and version."
 msgstr ""
 
@@ -11065,89 +10907,89 @@ msgstr ""
 msgid "Statistics Dashboard :: Add-ons for {0}"
 msgstr ""
 
-#: src/olympia/stats/templates/stats/stats.html:30
-msgid "Controls:"
-msgstr ""
-
-#: src/olympia/stats/templates/stats/stats.html:33
-msgid "reset zoom"
-msgstr ""
-
-#: src/olympia/stats/templates/stats/stats.html:40
-msgid "Group by:"
-msgstr ""
-
-#: src/olympia/stats/templates/stats/stats.html:42
-msgid "day"
-msgstr ""
-
-#: src/olympia/stats/templates/stats/stats.html:45
-msgid "week"
-msgstr ""
-
-#: src/olympia/stats/templates/stats/stats.html:48
-msgid "month"
-msgstr ""
-
-#: src/olympia/stats/templates/stats/stats.html:54
-msgid "For last:"
-msgstr ""
-
-#: src/olympia/stats/templates/stats/stats.html:57
-msgid "7 days"
-msgstr ""
-
-#: src/olympia/stats/templates/stats/stats.html:60
-msgid "30 days"
-msgstr ""
-
-#: src/olympia/stats/templates/stats/stats.html:63
-msgid "90 days"
-msgstr ""
-
-#: src/olympia/stats/templates/stats/stats.html:66
-msgid "365 days"
-msgstr ""
-
-#: src/olympia/stats/templates/stats/stats.html:69
-msgid "Custom..."
-msgstr ""
-
 #. {0} is an add-on name
-#: src/olympia/stats/templates/stats/stats.html:88 src/olympia/stats/templates/stats/stats.html:91
+#: src/olympia/stats/templates/stats/stats.html:44 src/olympia/stats/templates/stats/stats.html:47
 msgid "Statistics for {0}"
 msgstr ""
 
-#: src/olympia/stats/templates/stats/stats.html:94
+#: src/olympia/stats/templates/stats/stats.html:50
 msgid "Statistics Dashboard"
 msgstr ""
 
-#: src/olympia/stats/templates/stats/stats.html:104
+#: src/olympia/stats/templates/stats/stats.html:57
+msgid "Controls:"
+msgstr ""
+
+#: src/olympia/stats/templates/stats/stats.html:60
+msgid "reset zoom"
+msgstr ""
+
+#: src/olympia/stats/templates/stats/stats.html:67
+msgid "Group by:"
+msgstr ""
+
+#: src/olympia/stats/templates/stats/stats.html:69
+msgid "day"
+msgstr ""
+
+#: src/olympia/stats/templates/stats/stats.html:72
+msgid "week"
+msgstr ""
+
+#: src/olympia/stats/templates/stats/stats.html:75
+msgid "month"
+msgstr ""
+
+#: src/olympia/stats/templates/stats/stats.html:81
+msgid "For last:"
+msgstr ""
+
+#: src/olympia/stats/templates/stats/stats.html:84
+msgid "7 days"
+msgstr ""
+
+#: src/olympia/stats/templates/stats/stats.html:87
+msgid "30 days"
+msgstr ""
+
+#: src/olympia/stats/templates/stats/stats.html:90
+msgid "90 days"
+msgstr ""
+
+#: src/olympia/stats/templates/stats/stats.html:93
+msgid "365 days"
+msgstr ""
+
+#: src/olympia/stats/templates/stats/stats.html:96
+msgid "Custom..."
+msgstr ""
+
+#: src/olympia/stats/templates/stats/stats.html:106
 msgid "Statistics processing is currently disabled, so recent data is unavailable. The statistics are still being collected and this page will be updated soon with the missing data."
 msgstr ""
 
-#: src/olympia/stats/templates/stats/stats.html:110
+#: src/olympia/stats/templates/stats/stats.html:112
 msgid "Loading the latest data&hellip;"
 msgstr ""
 
-#: src/olympia/stats/templates/stats/stats.html:142 src/olympia/stats/templates/stats/reports/overview.html:25 src/olympia/stats/templates/stats/reports/overview.html:37
+#: src/olympia/stats/templates/stats/stats.html:144 src/olympia/stats/templates/stats/reports/overview.html:25 src/olympia/stats/templates/stats/reports/overview.html:37
 #: src/olympia/stats/templates/stats/reports/overview.html:49
 msgid "No data available."
 msgstr ""
 
-#: src/olympia/stats/templates/stats/stats.html:177
+#: src/olympia/stats/templates/stats/stats.html:179
 msgid "This dashboard is currently <b>public</b>."
 msgstr ""
 
-#: src/olympia/stats/templates/stats/stats.html:179
+#: src/olympia/stats/templates/stats/stats.html:181
 msgid "Contribution stats are currently <b>private</b>."
 msgstr ""
 
-#: src/olympia/stats/templates/stats/stats.html:182
+#: src/olympia/stats/templates/stats/stats.html:184
 msgid "This dashboard is currently <b>private</b>."
 msgstr ""
 
-#: src/olympia/stats/templates/stats/stats.html:185
+#: src/olympia/stats/templates/stats/stats.html:187
 msgid "Change settings."
 msgstr ""
 
@@ -11299,15 +11141,6 @@ msgstr ""
 msgid "Application versions by Date"
 msgstr ""
 
-#: src/olympia/tags/templates/tags/top_cloud.html:4
-msgid "Top {0} Tags"
-msgstr ""
-
-#. {0} is the current application name
-#: src/olympia/tags/templates/tags/top_cloud.html:14
-msgid "{0} Top Tags"
-msgstr ""
-
 #: src/olympia/templates/amo_footer.html:6 src/olympia/templates/includes/lang_switcher.html:2
 msgid "Other languages"
 msgstr ""
@@ -11316,11 +11149,11 @@ msgstr ""
 msgid "Mozilla Add-ons"
 msgstr ""
 
-#: src/olympia/templates/base.html:91 src/olympia/templates/impala/base.html:81
+#: src/olympia/templates/base.html:89 src/olympia/templates/impala/base.html:78
 msgid "Find add-ons for other applications"
 msgstr ""
 
-#: src/olympia/templates/base.html:92 src/olympia/templates/impala/base.html:81
+#: src/olympia/templates/base.html:90 src/olympia/templates/impala/base.html:78
 msgid "Other Applications"
 msgstr ""
 
@@ -11345,7 +11178,7 @@ msgid "View Mobile Site"
 msgstr ""
 
 #: src/olympia/templates/copyright.html:7
-msgid "Site Status "
+msgid "Site Status"
 msgstr ""
 
 #: src/olympia/templates/footer.html:3
@@ -11445,35 +11278,35 @@ msgstr ""
 msgid "<a href=\"%(reg)s\">Register</a> or <a href=\"%(login)s\">Log in</a>"
 msgstr ""
 
-#: src/olympia/templates/impala/base.html:126
+#: src/olympia/templates/impala/base.html:123
 #, python-format
 msgid "To try the thousands of add-ons available here, download <a href=\"%(url)s\">Mozilla Firefox</a>, a fast, free way to surf the Web!"
 msgstr ""
 
-#: src/olympia/templates/impala/base.html:138
+#: src/olympia/templates/impala/base.html:135
 #, python-format
 msgid "Add-ons is switching to Firefox Accounts for login. <a href=\"%(url)s\" class=\"fxa-login\">Sign in now to transfer your account.</a>"
 msgstr ""
 
 #. {0} is an application, such as Firefox.
-#: src/olympia/templates/impala/base.html:148
+#: src/olympia/templates/impala/base.html:145
 msgid "Welcome to {0} Add-ons."
 msgstr ""
 
-#: src/olympia/templates/impala/base.html:151
+#: src/olympia/templates/impala/base.html:148
 msgid "Choose from thousands of extra features and styles to make Firefox your own."
 msgstr ""
 
-#: src/olympia/templates/impala/base.html:156
+#: src/olympia/templates/impala/base.html:153
 #, python-format
 msgid "Add extra features and styles to make %(app)s your own."
 msgstr ""
 
-#: src/olympia/templates/impala/base.html:164
+#: src/olympia/templates/impala/base.html:161
 msgid "On the go?"
 msgstr ""
 
-#: src/olympia/templates/impala/base.html:166
+#: src/olympia/templates/impala/base.html:163
 msgid "Check out our <a class=\"mobile-link\" href=\"#\">Mobile Add-ons site</a>."
 msgstr ""
 
@@ -11697,19 +11530,19 @@ msgstr ""
 
 #. L10n: {id} will be something like "13ad6a", just a random number
 #. to differentiate this user from other anonymous users.
-#: src/olympia/users/models.py:353
+#: src/olympia/users/models.py:362
 msgid "Anonymous user {id}"
 msgstr ""
 
-#: src/olympia/users/models.py:410
+#: src/olympia/users/models.py:419
 msgid "Your account has been restricted"
 msgstr ""
 
-#: src/olympia/users/models.py:480
+#: src/olympia/users/models.py:489
 msgid "Please confirm your email address"
 msgstr ""
 
-#: src/olympia/users/models.py:506
+#: src/olympia/users/models.py:515
 msgid "My Mobile Add-ons"
 msgstr ""
 
@@ -11986,7 +11819,7 @@ msgstr ""
 
 #: src/olympia/users/templates/users/edit.html:70
 #, python-format
-msgid "Change your password.  If you forgot your password, you can <a href=\"%(reset_url)s\">use the reset form</a>."
+msgid "Change your password. If you forgot your password, you can <a href=\"%(reset_url)s\">use the reset form</a>."
 msgstr ""
 
 #: src/olympia/users/templates/users/edit.html:76
@@ -12006,7 +11839,7 @@ msgid "Profile"
 msgstr ""
 
 #: src/olympia/users/templates/users/edit.html:100
-msgid "Give us a bit more information about yourself.  All these fields are optional, but they'll help other users get to know you better."
+msgid "Give us a bit more information about yourself. All these fields are optional, but they'll help other users get to know you better."
 msgstr ""
 
 #: src/olympia/users/templates/users/edit.html:124
@@ -12222,7 +12055,7 @@ msgid "Confirm password"
 msgstr ""
 
 #: src/olympia/users/templates/users/pwreset_confirm.html:47
-msgid "The password reset link was invalid, possibly because it has already been used.  Please request a new password reset."
+msgid "The password reset link was invalid, possibly because it has already been used. Please request a new password reset."
 msgstr ""
 
 #: src/olympia/users/templates/users/pwreset_request.html:15
@@ -12408,7 +12241,7 @@ msgstr ""
 
 #: src/olympia/users/templates/users/unsubscribe.html:30
 #, python-format
-msgid "Unfortunately, we weren't able to unsubscribe you.  The link you clicked is invalid. However, you can unsubscribe still unsubscribe on your <a href=\"%(edit_url)s\">edit profile page</a>."
+msgid "Unfortunately, we weren't able to unsubscribe you. The link you clicked is invalid. However, you can unsubscribe still unsubscribe on your <a href=\"%(edit_url)s\">edit profile page</a>."
 msgstr ""
 
 #: src/olympia/users/templates/users/vcard.html:2
@@ -12462,15 +12295,15 @@ msgstr ""
 msgid "Version History with Changelogs"
 msgstr ""
 
-#: src/olympia/versions/models.py:314
+#: src/olympia/versions/models.py:313
 msgid "Add-on uses binary components."
 msgstr ""
 
-#: src/olympia/versions/models.py:317
+#: src/olympia/versions/models.py:316
 msgid "Add-on has opted into strict compatibility checking."
 msgstr ""
 
-#: src/olympia/versions/models.py:715
+#: src/olympia/versions/models.py:711
 msgid "{app} {min} and later"
 msgstr ""
 
@@ -12545,4 +12378,8 @@ msgstr ""
 
 #: src/olympia/zadmin/forms.py:105
 msgid "Log emails instead of sending"
+msgstr ""
+
+#: src/olympia/zadmin/forms.py:215
+msgid "Deleted versions can`t be changed."
 msgstr ""

--- a/locale/as/LC_MESSAGES/djangojs.po
+++ b/locale/as/LC_MESSAGES/djangojs.po
@@ -1,1216 +1,1236 @@
-
 #, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2016-02-24 21:23+0000\n"
+"POT-Creation-Date: 2016-04-18 15:47+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
+"Language: \n"
 "MIME-Version: 1.0\n"
-"Content-Type: text/plain; charset=utf-8\n"
+"Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Generated-By: Babel 2.2.0\n"
 
-#: static/js/common/ratingwidget.js:31
+#: static/js/common-all.js:1426 static/js/impala-all.js:1511 static/js/zamboni/discovery-all.js:12598 static/js/zamboni/init.js:28 static/js/zamboni/mobile-all.js:14945
+msgid "This feature is temporarily disabled while we perform website maintenance. Please check back a little later."
+msgstr ""
+
+#. L10n: {0} is an app name like Firefox.
+#: static/js/common-all.js:1837 static/js/impala-all.js:1922 static/js/zamboni/buttons.js:73 static/js/zamboni/discovery-all.js:13108
+msgid "Accept and Install"
+msgstr ""
+
+#: static/js/common-all.js:1837 static/js/impala-all.js:1922 static/js/zamboni/buttons.js:73 static/js/zamboni/discovery-all.js:13108
+msgid "Add to {0}"
+msgstr ""
+
+#: static/js/common-all.js:1842 static/js/impala-all.js:1927 static/js/zamboni/buttons.js:78 static/js/zamboni/discovery-all.js:13113
+msgid "Download Now"
+msgstr ""
+
+#: static/js/common-all.js:1883 static/js/impala-all.js:1968 static/js/zamboni/buttons.js:119 static/js/zamboni/discovery-all.js:13154
+msgid "Add-on has not been updated to support default-to-compatible."
+msgstr ""
+
+#: static/js/common-all.js:1888 static/js/impala-all.js:1973 static/js/zamboni/buttons.js:124 static/js/zamboni/discovery-all.js:13159
+msgid "You need to be using Firefox 10.0 or higher."
+msgstr ""
+
+#: static/js/common-all.js:1900 static/js/impala-all.js:1985 static/js/zamboni/buttons.js:136 static/js/zamboni/discovery-all.js:13171
+msgid "Mozilla has marked this version as incompatible with your Firefox version."
+msgstr ""
+
+#. L10n: {0} is an platform like Windows or Linux.
+#: static/js/common-all.js:1981 static/js/impala-all.js:2066 static/js/zamboni/buttons.js:217 static/js/zamboni/discovery-all.js:13252
+msgid "Install for {0} anyway"
+msgstr ""
+
+#: static/js/common-all.js:1981 static/js/impala-all.js:2066 static/js/zamboni/buttons.js:217 static/js/zamboni/discovery-all.js:13252
+msgid "Download for {0} anyway"
+msgstr ""
+
+#: static/js/common-all.js:2038 static/js/impala-all.js:2123 static/js/zamboni/buttons.js:274 static/js/zamboni/discovery-all.js:13309
+msgid "Not available for your platform"
+msgstr ""
+
+#. L10n: {0} is an app name, {1} is the app version.
+#: static/js/common-all.js:2049 static/js/common-all.js:2086 static/js/impala-all.js:2134 static/js/impala-all.js:2171 static/js/zamboni/buttons.js:286 static/js/zamboni/buttons.js:324
+#: static/js/zamboni/discovery-all.js:13320 static/js/zamboni/discovery-all.js:13357
+msgid "Not available for {0} {1}"
+msgstr ""
+
+#: static/js/common-all.js:2112 static/js/impala-all.js:2197 static/js/zamboni/buttons.js:351 static/js/zamboni/discovery-all.js:13383
+msgid "Works with {app} {min} - {max}"
+msgstr ""
+
+#: static/js/common-all.js:2114 static/js/impala-all.js:2199 static/js/zamboni/buttons.js:353 static/js/zamboni/discovery-all.js:13385
+msgid "View other versions"
+msgstr ""
+
+#: static/js/common-all.js:2162 static/js/impala-all.js:2247 static/js/zamboni/buttons.js:401 static/js/zamboni/discovery-all.js:13433
+msgid "Only with Firefox — Get Firefox Now!"
+msgstr ""
+
+#: static/js/common-all.js:2278 static/js/impala-all.js:2363 static/js/zamboni/buttons.js:517 static/js/zamboni/discovery-all.js:13549 static/js/zamboni/mobile-all.js:15177
+#: static/js/zamboni/mobile/buttons.js:43
+msgid "Sorry, you need a Mozilla-based browser (such as Firefox) to install a search plugin."
+msgstr ""
+
+#: static/js/common-all.js:9088 static/js/impala-all.js:9649 static/js/zamboni/global.js:410
+msgid "Loading..."
+msgstr ""
+
+#. L10n: {0} is the number of characters left.
+#: static/js/common-all.js:9152 static/js/impala-all.js:9713 static/js/zamboni/global.js:474
+msgid "<b>{0}</b> character left."
+msgid_plural "<b>{0}</b> characters left."
+msgstr[0] ""
+msgstr[1] ""
+
+#: static/js/common-all.js:9589 static/js/common-min.js:6 static/js/impala-all.js:10052 static/js/impala-min.js:6 static/js/common/ratingwidget.js:31 static/js/zamboni/mobile-all.js:16123
+#: static/js/zamboni/mobile-min.js:6
 msgid "{0} star"
 msgid_plural "{0} stars"
 msgstr[0] ""
 msgstr[1] ""
 
-#: static/js/common/upload-addon.js:41 static/js/common/upload-image.js:128
+#: static/js/common-all.js:9676 static/js/common-min.js:6 static/js/impala-all.js:10139 static/js/impala-min.js:6 static/js/zamboni/l10n.js:45
+msgid "Remove this localization"
+msgstr ""
+
+#: static/js/common-all.js:10193 static/js/common-min.js:6 static/js/impala-all.js:10674 static/js/impala-min.js:6 static/js/zamboni/discovery-all.js:13678
+msgid "close"
+msgstr ""
+
+#: static/js/common-all.js:10860 static/js/common-min.js:6 static/js/impala-all.js:11481 static/js/impala-min.js:6 static/js/impala/reviews.js:23 static/js/zamboni/reviews.js:18
+msgid "Flagged for review"
+msgstr ""
+
+#: static/js/common-all.js:10876 static/js/common-min.js:6 static/js/impala-all.js:11498 static/js/impala-min.js:6 static/js/impala/reviews.js:40 static/js/zamboni/reviews.js:34
+msgid "Your input is required"
+msgstr ""
+
+#: static/js/common-all.js:10945 static/js/common-min.js:6 static/js/impala-all.js:11610 static/js/impala-min.js:7 static/js/impala/reviews.js:152 static/js/zamboni/reviews.js:103
+msgid "Marked for deletion"
+msgstr ""
+
+#: static/js/common-all.js:11573 static/js/common-min.js:7 static/js/impala-all.js:13809 static/js/impala-min.js:8 static/js/zamboni/collections.js:229
+msgid "Adding to Favorites&hellip;"
+msgstr ""
+
+#: static/js/common-all.js:11576 static/js/common-min.js:7 static/js/impala-all.js:13812 static/js/impala-min.js:8 static/js/zamboni/collections.js:232
+msgid "Removing Favorite&hellip;"
+msgstr ""
+
+#: static/js/common-all.js:11579 static/js/common-min.js:7 static/js/impala-all.js:13815 static/js/impala-min.js:8 static/js/zamboni/collections.js:235
+msgid "Add to Favorites"
+msgstr ""
+
+#: static/js/common-all.js:11582 static/js/common-min.js:7 static/js/impala-all.js:13818 static/js/impala-min.js:8 static/js/zamboni/collections.js:238
+msgid "Remove from Favorites"
+msgstr ""
+
+#: static/js/common-all.js:11647 static/js/common-min.js:7 static/js/impala-all.js:13883 static/js/impala-min.js:8 static/js/zamboni/collections.js:303
+msgid "Pending"
+msgstr ""
+
+#: static/js/common-all.js:11648 static/js/common-min.js:7 static/js/impala-all.js:13884 static/js/impala-min.js:8 static/js/zamboni/collections.js:304
+msgid "Add a comment"
+msgstr ""
+
+#: static/js/common-all.js:11648 static/js/common-min.js:7 static/js/impala-all.js:13884 static/js/impala-min.js:8 static/js/zamboni/collections.js:304
+msgid "Comment"
+msgstr ""
+
+#: static/js/common-all.js:11649 static/js/common-min.js:7 static/js/impala-all.js:13885 static/js/impala-min.js:8 static/js/zamboni/collections.js:305
+msgid "Remove this add-on from the collection"
+msgstr ""
+
+#: static/js/common-all.js:11649 static/js/common-all.js:11678 static/js/common-min.js:7 static/js/impala-all.js:13885 static/js/impala-all.js:13914 static/js/impala-min.js:8
+#: static/js/zamboni/collections.js:305 static/js/zamboni/collections.js:334
+msgid "Remove"
+msgstr ""
+
+#: static/js/common-all.js:11678 static/js/common-min.js:7 static/js/impala-all.js:13914 static/js/impala-min.js:8 static/js/zamboni/collections.js:334
+msgid "Remove this user as a contributor"
+msgstr ""
+
+#: static/js/common-all.js:11690 static/js/common-min.js:7 static/js/impala-all.js:13926 static/js/impala-min.js:8 static/js/zamboni/collections.js:346
+msgid "An email address is required."
+msgstr ""
+
+#: static/js/common-all.js:11708 static/js/common-min.js:7 static/js/impala-all.js:13944 static/js/impala-min.js:8 static/js/zamboni/collections.js:364
+msgid "You cannot add yourself as a contributor."
+msgstr ""
+
+#: static/js/common-all.js:11710 static/js/common-min.js:7 static/js/impala-all.js:13946 static/js/impala-min.js:8 static/js/zamboni/collections.js:366
+msgid "You have already added that user."
+msgstr ""
+
+#: static/js/common-all.js:11917 static/js/common-min.js:7 static/js/impala-all.js:14153 static/js/impala-min.js:8 static/js/zamboni/collections.js:573
+msgid "Add to favorites"
+msgstr ""
+
+#: static/js/common-all.js:11921 static/js/common-min.js:7 static/js/impala-all.js:14157 static/js/impala-min.js:8 static/js/zamboni/collections.js:577
+msgid "Remove from favorites"
+msgstr ""
+
+#: static/js/common-all.js:11939 static/js/common-min.js:7 static/js/impala-all.js:14175 static/js/impala-all.js:14233 static/js/impala-min.js:8 static/js/impala/collections.js:10
+#: static/js/zamboni/collections.js:595
+msgid "Follow this Collection"
+msgstr ""
+
+#: static/js/common-all.js:11948 static/js/common-min.js:7 static/js/impala-all.js:14184 static/js/impala-min.js:8 static/js/zamboni/collections.js:604
+msgid "Stop following"
+msgstr ""
+
+#: static/js/common-all.js:12096 static/js/common-min.js:7 static/js/zamboni/password-strength.js:20
+msgid "Password strength:"
+msgstr ""
+
+#: static/js/common-all.js:12102 static/js/common-min.js:7 static/js/zamboni/password-strength.js:26
+msgid "At least {0} character left."
+msgid_plural "At least {0} characters left."
+msgstr[0] ""
+msgstr[1] ""
+
+#: static/js/common-all.js:12286 static/js/common-min.js:7 static/js/impala-all.js:14632 static/js/impala-min.js:8 static/js/impala/suggestions.js:39
+msgid "Search themes for <b>{0}</b>"
+msgstr ""
+
+#: static/js/common-all.js:12288 static/js/common-min.js:7 static/js/impala-all.js:14634 static/js/impala-min.js:8 static/js/impala/suggestions.js:41
+msgid "Search apps for <b>{0}</b>"
+msgstr ""
+
+#: static/js/common-all.js:12290 static/js/common-min.js:7 static/js/impala-all.js:14636 static/js/impala-min.js:8 static/js/impala/suggestions.js:43
+msgid "Search add-ons for <b>{0}</b>"
+msgstr ""
+
+#: static/js/common-all.js:12521 static/js/common-min.js:7 static/js/impala-all.js:14867 static/js/impala-min.js:8 static/js/impala/site_suggestions.js:46
+msgid "Category"
+msgstr ""
+
+#. L10n: {0} is an app name.
+#: static/js/impala-all.js:11632 static/js/impala-min.js:7 static/js/impala/listing.js:11 static/js/zamboni/themes.js:13
+msgid "This theme is incompatible with your version of {0}"
+msgstr ""
+
+#: static/js/impala-all.js:12146 static/js/impala-all.js:14331 static/js/impala-min.js:7 static/js/impala-min.js:8 static/js/common/upload-image.js:97 static/js/impala/users.js:51
+#: static/js/zamboni/devhub-all.js:894 static/js/zamboni/devhub-min.js:1
+msgid "Images must be either PNG or JPG."
+msgstr ""
+
+#: static/js/impala-all.js:12150 static/js/impala-min.js:7 static/js/common/upload-image.js:101 static/js/zamboni/devhub-all.js:898 static/js/zamboni/devhub-min.js:1
+msgid "Videos must be in WebM."
+msgstr ""
+
+#: static/js/impala-all.js:12177 static/js/impala-min.js:7 static/js/common/upload-addon.js:41 static/js/common/upload-image.js:128 static/js/zamboni/devhub-all.js:272
+#: static/js/zamboni/devhub-all.js:925 static/js/zamboni/devhub-min.js:1
 msgid "There was a problem contacting the server."
 msgstr ""
 
-#: static/js/common/upload-addon.js:69
+#: static/js/impala-all.js:13298 static/js/impala-min.js:7 static/js/impala/persona_creation.js:60
+msgid "All Rights Reserved"
+msgstr ""
+
+#: static/js/impala-all.js:13302 static/js/impala-min.js:7 static/js/impala/persona_creation.js:64
+msgid "Creative Commons Attribution 3.0"
+msgstr ""
+
+#: static/js/impala-all.js:13307 static/js/impala-min.js:7 static/js/impala/persona_creation.js:69
+msgid "Creative Commons Attribution-NonCommercial 3.0"
+msgstr ""
+
+#: static/js/impala-all.js:13312 static/js/impala-min.js:7 static/js/impala/persona_creation.js:74
+msgid "Creative Commons Attribution-NonCommercial-NoDerivs 3.0"
+msgstr ""
+
+#: static/js/impala-all.js:13317 static/js/impala-min.js:7 static/js/impala/persona_creation.js:79
+msgid "Creative Commons Attribution-NonCommercial-Share Alike 3.0"
+msgstr ""
+
+#: static/js/impala-all.js:13322 static/js/impala-min.js:7 static/js/impala/persona_creation.js:84
+msgid "Creative Commons Attribution-NoDerivs 3.0"
+msgstr ""
+
+#: static/js/impala-all.js:13327 static/js/impala-min.js:7 static/js/impala/persona_creation.js:89
+msgid "Creative Commons Attribution-ShareAlike 3.0"
+msgstr ""
+
+#: static/js/impala-all.js:13530 static/js/impala-min.js:7 static/js/impala/persona_creation.js:292
+msgid "Your Theme's Name"
+msgstr ""
+
+#: static/js/impala-all.js:14242 static/js/impala-min.js:8 static/js/impala/collections.js:19
+msgid "Stop Following"
+msgstr ""
+
+#: static/js/impala-all.js:14243 static/js/impala-min.js:8 static/js/impala/collections.js:20
+msgid "Following"
+msgstr ""
+
+#: static/js/impala-all.js:14313 static/js/impala-min.js:8 static/js/impala/users.js:33
+msgid "use original"
+msgstr ""
+
+#: static/js/impala-all.js:14523 static/js/impala-min.js:8 static/js/impala/search.js:114
+msgid "Updating results&hellip;"
+msgstr ""
+
+#: static/js/common/upload-addon.js:69 static/js/zamboni/devhub-all.js:300 static/js/zamboni/devhub-min.js:1
 msgid "Select a file..."
 msgstr ""
 
-#: static/js/common/upload-addon.js:70
+#: static/js/common/upload-addon.js:70 static/js/zamboni/devhub-all.js:301 static/js/zamboni/devhub-min.js:1
 msgid "Your add-on should end with .xpi, .jar or .xml"
 msgstr ""
 
 #. L10n: {0} is the percent of the file that has been uploaded.
-#: static/js/common/upload-addon.js:104
+#: static/js/common/upload-addon.js:104 static/js/zamboni/devhub-all.js:335 static/js/zamboni/devhub-min.js:1
 #, python-format
 msgid "{0}% complete"
 msgstr ""
 
 #. L10n: "{bytes uploaded} of {total filesize}".
-#: static/js/common/upload-addon.js:107
+#: static/js/common/upload-addon.js:107 static/js/zamboni/devhub-all.js:338 static/js/zamboni/devhub-min.js:1
 msgid "{0} of {1}"
 msgstr ""
 
-#: static/js/common/upload-addon.js:140
+#: static/js/common/upload-addon.js:140 static/js/zamboni/devhub-all.js:371 static/js/zamboni/devhub-min.js:1
 msgid "Cancel"
 msgstr ""
 
-#: static/js/common/upload-addon.js:162
+#: static/js/common/upload-addon.js:162 static/js/zamboni/devhub-all.js:393 static/js/zamboni/devhub-min.js:1
 msgid "Uploading {0}"
 msgstr ""
 
-#: static/js/common/upload-addon.js:189
+#: static/js/common/upload-addon.js:189 static/js/zamboni/devhub-all.js:420 static/js/zamboni/devhub-min.js:1
 msgid "Error with {0}"
 msgstr ""
 
-#: static/js/common/upload-addon.js:194
+#: static/js/common/upload-addon.js:194 static/js/zamboni/devhub-all.js:425 static/js/zamboni/devhub-min.js:1
 msgid "Your add-on failed validation with {0} error."
 msgid_plural "Your add-on failed validation with {0} errors."
 msgstr[0] ""
 msgstr[1] ""
 
-#: static/js/common/upload-addon.js:208
+#: static/js/common/upload-addon.js:208 static/js/zamboni/devhub-all.js:439 static/js/zamboni/devhub-min.js:1
 msgid "&hellip;and {0} more"
 msgid_plural "&hellip;and {0} more"
 msgstr[0] ""
 msgstr[1] ""
 
-#: static/js/common/upload-addon.js:222 static/js/common/upload-addon.js:512
+#: static/js/common/upload-addon.js:222 static/js/common/upload-addon.js:497 static/js/zamboni/devhub-all.js:453 static/js/zamboni/devhub-all.js:743 static/js/zamboni/devhub-min.js:1
 msgid "See full validation report"
 msgstr ""
 
-#: static/js/common/upload-addon.js:234
+#: static/js/common/upload-addon.js:234 static/js/zamboni/devhub-all.js:465 static/js/zamboni/devhub-min.js:1
 msgid "Validating {0}"
 msgstr ""
 
 #. L10n: first argument is an HTTP status code
-#: static/js/common/upload-addon.js:273
+#: static/js/common/upload-addon.js:273 static/js/zamboni/devhub-all.js:504 static/js/zamboni/devhub-min.js:1
 msgid "Received an empty response from the server; status: {0}"
 msgstr ""
 
-#: static/js/common/upload-addon.js:373
+#: static/js/common/upload-addon.js:370 static/js/zamboni/devhub-all.js:604 static/js/zamboni/devhub-min.js:1
 msgid "Unexpected server error while validating."
 msgstr ""
 
-#: static/js/common/upload-addon.js:412
+#: static/js/common/upload-addon.js:409 static/js/zamboni/devhub-all.js:643 static/js/zamboni/devhub-min.js:1
 msgid "Finished validating {0}"
 msgstr ""
 
-#: static/js/common/upload-addon.js:418
+#: static/js/common/upload-addon.js:415 static/js/zamboni/devhub-all.js:649 static/js/zamboni/devhub-min.js:1
 msgid "Your add-on validation timed out, it will be manually reviewed."
 msgstr ""
 
-#: static/js/common/upload-addon.js:421
+#: static/js/common/upload-addon.js:418 static/js/zamboni/devhub-all.js:652 static/js/zamboni/devhub-min.js:1
 msgid "Your add-on was validated with no errors and {0} warning."
 msgid_plural "Your add-on was validated with no errors and {0} warnings."
 msgstr[0] ""
 msgstr[1] ""
 
-#: static/js/common/upload-addon.js:426
+#: static/js/common/upload-addon.js:423 static/js/zamboni/devhub-all.js:657 static/js/zamboni/devhub-min.js:1
 msgid "Your add-on was validated with no errors and {0} message."
 msgid_plural "Your add-on was validated with no errors and {0} messages."
 msgstr[0] ""
 msgstr[1] ""
 
-#: static/js/common/upload-addon.js:431
+#: static/js/common/upload-addon.js:428 static/js/zamboni/devhub-all.js:662 static/js/zamboni/devhub-min.js:1
 msgid "Your add-on was validated with no errors or warnings."
 msgstr ""
 
-#: static/js/common/upload-addon.js:446
+#: static/js/common/upload-addon.js:443 static/js/zamboni/devhub-all.js:677 static/js/zamboni/devhub-min.js:1
 msgid "Your submission will be automatically signed."
 msgstr ""
 
-#: static/js/common/upload-addon.js:465
+#: static/js/common/upload-addon.js:450 static/js/zamboni/devhub-all.js:696 static/js/zamboni/devhub-min.js:1
 msgid "Include detailed version notes (this can be done in the next step)."
 msgstr ""
 
-#: static/js/common/upload-addon.js:466
+#: static/js/common/upload-addon.js:451 static/js/zamboni/devhub-all.js:697 static/js/zamboni/devhub-min.js:1
 msgid "If your add-on requires an account to a website in order to be fully tested, include a test username and password in the Notes to Reviewer (this can be done in the next step)."
 msgstr ""
 
-#: static/js/common/upload-addon.js:467
+#: static/js/common/upload-addon.js:452 static/js/zamboni/devhub-all.js:698 static/js/zamboni/devhub-min.js:1
 msgid "If your add-on is intended for a limited audience you should choose Preliminary Review instead of Full Review."
 msgstr ""
 
-#: static/js/common/upload-addon.js:480
+#: static/js/common/upload-addon.js:465 static/js/zamboni/devhub-all.js:711 static/js/zamboni/devhub-min.js:1
 msgid "Add-on submission checklist"
 msgstr ""
 
-#: static/js/common/upload-addon.js:481
+#: static/js/common/upload-addon.js:466 static/js/zamboni/devhub-all.js:712 static/js/zamboni/devhub-min.js:1
 msgid "Please verify the following points before finalizing your submission. This will minimize delays or misunderstanding during the review process:"
 msgstr ""
 
-#: static/js/common/upload-addon.js:483
+#: static/js/common/upload-addon.js:468 static/js/zamboni/devhub-all.js:714 static/js/zamboni/devhub-min.js:1
 msgid ""
 "Compiled binaries, as well as minified or obfuscated scripts (excluding known libraries) need to have their sources submitted separately for review. Make sure that you use the source code upload "
 "field to avoid having your submission rejected."
 msgstr ""
 
-#: static/js/common/upload-addon.js:501
+#: static/js/common/upload-addon.js:486 static/js/zamboni/devhub-all.js:732 static/js/zamboni/devhub-min.js:1
 msgid "The validation process found these issues that can lead to rejections:"
 msgstr ""
 
-#: static/js/common/upload-addon.js:518
+#: static/js/common/upload-addon.js:503 static/js/zamboni/devhub-all.js:749 static/js/zamboni/devhub-min.js:1
 msgid "If you are unfamiliar with the add-ons review process, you can read about it here."
 msgstr ""
 
-#: static/js/common/upload-addon.js:555
+#: static/js/common/upload-addon.js:540 static/js/zamboni/devhub-all.js:786 static/js/zamboni/devhub-min.js:1
 msgid "Sorry, no supported platform has been found."
 msgstr ""
 
-#: static/js/common/upload-base.js:57
+#: static/js/common/upload-base.js:57 static/js/zamboni/devhub-all.js:187 static/js/zamboni/devhub-min.js:1
 msgid "The filetype you uploaded isn't recognized."
 msgstr ""
 
-#: static/js/common/upload-base.js:79
+#: static/js/common/upload-base.js:79 static/js/zamboni/devhub-all.js:209 static/js/zamboni/devhub-min.js:1
 msgid "You cancelled the upload."
 msgstr ""
 
-#: static/js/common/upload-image.js:97 static/js/impala/users.js:51
-msgid "Images must be either PNG or JPG."
-msgstr ""
-
-#: static/js/common/upload-image.js:101
-msgid "Videos must be in WebM."
-msgstr ""
-
-#: static/js/impala/collections.js:10 static/js/zamboni/collections.js:595
-msgid "Follow this Collection"
-msgstr ""
-
-#: static/js/impala/collections.js:19
-msgid "Stop Following"
-msgstr ""
-
-#: static/js/impala/collections.js:20
-msgid "Following"
-msgstr ""
-
-#. L10n: {0} is an app name.
-#: static/js/impala/listing.js:11 static/js/zamboni/themes.js:13
-msgid "This theme is incompatible with your version of {0}"
-msgstr ""
-
-#: static/js/impala/persona_creation.js:60
-msgid "All Rights Reserved"
-msgstr ""
-
-#: static/js/impala/persona_creation.js:64
-msgid "Creative Commons Attribution 3.0"
-msgstr ""
-
-#: static/js/impala/persona_creation.js:69
-msgid "Creative Commons Attribution-NonCommercial 3.0"
-msgstr ""
-
-#: static/js/impala/persona_creation.js:74
-msgid "Creative Commons Attribution-NonCommercial-NoDerivs 3.0"
-msgstr ""
-
-#: static/js/impala/persona_creation.js:79
-msgid "Creative Commons Attribution-NonCommercial-Share Alike 3.0"
-msgstr ""
-
-#: static/js/impala/persona_creation.js:84
-msgid "Creative Commons Attribution-NoDerivs 3.0"
-msgstr ""
-
-#: static/js/impala/persona_creation.js:89
-msgid "Creative Commons Attribution-ShareAlike 3.0"
-msgstr ""
-
-#: static/js/impala/persona_creation.js:292
-msgid "Your Theme's Name"
-msgstr ""
-
-#: static/js/impala/reviews.js:23 static/js/zamboni/reviews.js:18
-msgid "Flagged for review"
-msgstr ""
-
-#: static/js/impala/reviews.js:40 static/js/zamboni/reviews.js:34
-msgid "Your input is required"
-msgstr ""
-
-#: static/js/impala/reviews.js:152 static/js/zamboni/reviews.js:103
-msgid "Marked for deletion"
-msgstr ""
-
-#: static/js/impala/search.js:114
-msgid "Updating results&hellip;"
-msgstr ""
-
-#: static/js/impala/site_suggestions.js:46
-msgid "Category"
-msgstr ""
-
-#: static/js/impala/suggestions.js:39
-msgid "Search themes for <b>{0}</b>"
-msgstr ""
-
-#: static/js/impala/suggestions.js:41
-msgid "Search apps for <b>{0}</b>"
-msgstr ""
-
-#: static/js/impala/suggestions.js:43
-msgid "Search add-ons for <b>{0}</b>"
-msgstr ""
-
-#: static/js/impala/users.js:33
-msgid "use original"
-msgstr ""
-
-#: static/js/impala/stats/chart.js:267
+#: static/js/impala/stats/chart.js:267 static/js/zamboni/stats-all.js:16898 static/js/zamboni/stats-min.js:5
 msgid "Week of {0}"
 msgstr ""
 
-#: static/js/impala/stats/chart.js:269
+#: static/js/impala/stats/chart.js:269 static/js/zamboni/stats-all.js:16900 static/js/zamboni/stats-min.js:5
 msgid " downloads"
 msgstr ""
 
-#: static/js/impala/stats/chart.js:270
+#: static/js/impala/stats/chart.js:270 static/js/zamboni/stats-all.js:16901 static/js/zamboni/stats-min.js:5
 msgid "{0} users"
 msgstr ""
 
-#: static/js/impala/stats/chart.js:271
+#: static/js/impala/stats/chart.js:271 static/js/zamboni/stats-all.js:16902 static/js/zamboni/stats-min.js:5
 msgid "{0} add-ons"
 msgstr ""
 
-#: static/js/impala/stats/chart.js:272
+#: static/js/impala/stats/chart.js:272 static/js/zamboni/stats-all.js:16903 static/js/zamboni/stats-min.js:5
 msgid "{0} collections"
 msgstr ""
 
-#: static/js/impala/stats/chart.js:273
+#: static/js/impala/stats/chart.js:273 static/js/zamboni/stats-all.js:16904 static/js/zamboni/stats-min.js:5
 msgid "{0} reviews"
 msgstr ""
 
-#: static/js/impala/stats/chart.js:275
+#: static/js/impala/stats/chart.js:275 static/js/zamboni/stats-all.js:16906 static/js/zamboni/stats-min.js:5
 msgid "{0} sales"
 msgstr ""
 
-#: static/js/impala/stats/chart.js:276
+#: static/js/impala/stats/chart.js:276 static/js/zamboni/stats-all.js:16907 static/js/zamboni/stats-min.js:5
 msgid "{0} refunds"
 msgstr ""
 
-#: static/js/impala/stats/chart.js:277
+#: static/js/impala/stats/chart.js:277 static/js/zamboni/stats-all.js:16908 static/js/zamboni/stats-min.js:5
 msgid "{0} installs"
 msgstr ""
 
-#: static/js/impala/stats/chart.js:369 static/js/impala/stats/csv_keys.js:3 static/js/impala/stats/csv_keys.js:109
+#: static/js/impala/stats/chart.js:369 static/js/impala/stats/csv_keys.js:3 static/js/impala/stats/csv_keys.js:109 static/js/zamboni/stats-all.js:15284 static/js/zamboni/stats-all.js:15390
+#: static/js/zamboni/stats-all.js:17000 static/js/zamboni/stats-min.js:4 static/js/zamboni/stats-min.js:5
 msgid "Downloads"
 msgstr ""
 
-#: static/js/impala/stats/chart.js:379 static/js/impala/stats/csv_keys.js:6 static/js/impala/stats/csv_keys.js:110
+#: static/js/impala/stats/chart.js:379 static/js/impala/stats/csv_keys.js:6 static/js/impala/stats/csv_keys.js:110 static/js/zamboni/stats-all.js:15287 static/js/zamboni/stats-all.js:15391
+#: static/js/zamboni/stats-all.js:17010 static/js/zamboni/stats-min.js:4 static/js/zamboni/stats-min.js:5
 msgid "Daily Users"
 msgstr ""
 
-#: static/js/impala/stats/chart.js:410
+#: static/js/impala/stats/chart.js:410 static/js/zamboni/stats-all.js:17041 static/js/zamboni/stats-min.js:5
 msgid "Amount, in USD"
 msgstr ""
 
-#: static/js/impala/stats/chart.js:421 static/js/impala/stats/csv_keys.js:104
+#: static/js/impala/stats/chart.js:421 static/js/impala/stats/csv_keys.js:104 static/js/zamboni/stats-all.js:15385 static/js/zamboni/stats-all.js:17052 static/js/zamboni/stats-min.js:5
 msgid "Number of Contributions"
 msgstr ""
 
-#: static/js/impala/stats/chart.js:447
+#: static/js/impala/stats/chart.js:447 static/js/zamboni/stats-all.js:17078 static/js/zamboni/stats-min.js:5
 msgid "More Info..."
 msgstr ""
 
 #. L10n: {0} is an ISO-formatted date.
-#: static/js/impala/stats/chart.js:451
+#: static/js/impala/stats/chart.js:451 static/js/zamboni/stats-all.js:17082 static/js/zamboni/stats-min.js:5
 msgid "Details for {0}"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:9
+#: static/js/impala/stats/csv_keys.js:9 static/js/zamboni/stats-all.js:15290 static/js/zamboni/stats-min.js:4
 msgid "Collections Created"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:12
+#: static/js/impala/stats/csv_keys.js:12 static/js/zamboni/stats-all.js:15293 static/js/zamboni/stats-min.js:4
 msgid "Add-ons in Use"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:15
+#: static/js/impala/stats/csv_keys.js:15 static/js/zamboni/stats-all.js:15296 static/js/zamboni/stats-min.js:4
 msgid "Add-ons Created"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:18
+#: static/js/impala/stats/csv_keys.js:18 static/js/zamboni/stats-all.js:15299 static/js/zamboni/stats-min.js:4
 msgid "Add-ons Downloaded"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:21
+#: static/js/impala/stats/csv_keys.js:21 static/js/zamboni/stats-all.js:15302 static/js/zamboni/stats-min.js:4
 msgid "Add-ons Updated"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:24
+#: static/js/impala/stats/csv_keys.js:24 static/js/zamboni/stats-all.js:15305 static/js/zamboni/stats-min.js:4
 msgid "Reviews Written"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:27
+#: static/js/impala/stats/csv_keys.js:27 static/js/zamboni/stats-all.js:15308 static/js/zamboni/stats-min.js:4
 msgid "User Signups"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:30
+#: static/js/impala/stats/csv_keys.js:30 static/js/zamboni/stats-all.js:15311 static/js/zamboni/stats-min.js:4
 msgid "Subscribers"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:33
+#: static/js/impala/stats/csv_keys.js:33 static/js/zamboni/stats-all.js:15314 static/js/zamboni/stats-min.js:4
 msgid "Ratings"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:36 static/js/impala/stats/csv_keys.js:114
+#: static/js/impala/stats/csv_keys.js:36 static/js/impala/stats/csv_keys.js:114 static/js/zamboni/stats-all.js:15317 static/js/zamboni/stats-all.js:15395 static/js/zamboni/stats-min.js:4
+#: static/js/zamboni/stats-min.js:5
 msgid "Sales"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:39 static/js/impala/stats/csv_keys.js:113
+#: static/js/impala/stats/csv_keys.js:39 static/js/impala/stats/csv_keys.js:113 static/js/zamboni/stats-all.js:15320 static/js/zamboni/stats-all.js:15394 static/js/zamboni/stats-min.js:4
+#: static/js/zamboni/stats-min.js:5
 msgid "Installs"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:42
+#: static/js/impala/stats/csv_keys.js:42 static/js/zamboni/stats-all.js:15323 static/js/zamboni/stats-min.js:4
 msgid "Unknown"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:43
+#: static/js/impala/stats/csv_keys.js:43 static/js/zamboni/stats-all.js:15324 static/js/zamboni/stats-min.js:4
 msgid "Add-ons Manager"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:44
+#: static/js/impala/stats/csv_keys.js:44 static/js/zamboni/stats-all.js:15325 static/js/zamboni/stats-min.js:4
 msgid "Add-ons Manager Promo"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:45
+#: static/js/impala/stats/csv_keys.js:45 static/js/zamboni/stats-all.js:15326 static/js/zamboni/stats-min.js:4
 msgid "Add-ons Manager Featured"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:46
+#: static/js/impala/stats/csv_keys.js:46 static/js/zamboni/stats-all.js:15327 static/js/zamboni/stats-min.js:4
 msgid "Add-ons Manager Learn More"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:47
+#: static/js/impala/stats/csv_keys.js:47 static/js/zamboni/stats-all.js:15328 static/js/zamboni/stats-min.js:4
 msgid "Search Suggestions"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:48
+#: static/js/impala/stats/csv_keys.js:48 static/js/zamboni/stats-all.js:15329 static/js/zamboni/stats-min.js:4
 msgid "Search Results"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:49 static/js/impala/stats/csv_keys.js:50 static/js/impala/stats/csv_keys.js:51
+#: static/js/impala/stats/csv_keys.js:49 static/js/impala/stats/csv_keys.js:50 static/js/impala/stats/csv_keys.js:51 static/js/zamboni/stats-all.js:15330 static/js/zamboni/stats-all.js:15331
+#: static/js/zamboni/stats-all.js:15332 static/js/zamboni/stats-min.js:4
 msgid "Homepage Promo"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:52 static/js/impala/stats/csv_keys.js:53
+#: static/js/impala/stats/csv_keys.js:52 static/js/impala/stats/csv_keys.js:53 static/js/zamboni/stats-all.js:15333 static/js/zamboni/stats-all.js:15334 static/js/zamboni/stats-min.js:4
 msgid "Homepage Featured"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:54 static/js/impala/stats/csv_keys.js:55
+#: static/js/impala/stats/csv_keys.js:54 static/js/impala/stats/csv_keys.js:55 static/js/zamboni/stats-all.js:15335 static/js/zamboni/stats-all.js:15336 static/js/zamboni/stats-min.js:4
 msgid "Homepage Up and Coming"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:56
+#: static/js/impala/stats/csv_keys.js:56 static/js/zamboni/stats-all.js:15337 static/js/zamboni/stats-min.js:4
 msgid "Homepage Most Popular"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:57 static/js/impala/stats/csv_keys.js:59
+#: static/js/impala/stats/csv_keys.js:57 static/js/impala/stats/csv_keys.js:59 static/js/zamboni/stats-all.js:15338 static/js/zamboni/stats-all.js:15340 static/js/zamboni/stats-min.js:4
 msgid "Detail Page"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:58 static/js/impala/stats/csv_keys.js:60
+#: static/js/impala/stats/csv_keys.js:58 static/js/impala/stats/csv_keys.js:60 static/js/zamboni/stats-all.js:15339 static/js/zamboni/stats-all.js:15341 static/js/zamboni/stats-min.js:4
 msgid "Detail Page (bottom)"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:61
+#: static/js/impala/stats/csv_keys.js:61 static/js/zamboni/stats-all.js:15342 static/js/zamboni/stats-min.js:4
 msgid "Detail Page (Development Channel)"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:62 static/js/impala/stats/csv_keys.js:63 static/js/impala/stats/csv_keys.js:64
+#: static/js/impala/stats/csv_keys.js:62 static/js/impala/stats/csv_keys.js:63 static/js/impala/stats/csv_keys.js:64 static/js/zamboni/stats-all.js:15343 static/js/zamboni/stats-all.js:15344
+#: static/js/zamboni/stats-all.js:15345 static/js/zamboni/stats-min.js:4
 msgid "Often Used With"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:65 static/js/impala/stats/csv_keys.js:66
+#: static/js/impala/stats/csv_keys.js:65 static/js/impala/stats/csv_keys.js:66 static/js/zamboni/stats-all.js:15346 static/js/zamboni/stats-all.js:15347 static/js/zamboni/stats-min.js:4
 msgid "Others By Author"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:67 static/js/impala/stats/csv_keys.js:68
+#: static/js/impala/stats/csv_keys.js:67 static/js/impala/stats/csv_keys.js:68 static/js/zamboni/stats-all.js:15348 static/js/zamboni/stats-all.js:15349 static/js/zamboni/stats-min.js:4
 msgid "Dependencies"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:69 static/js/impala/stats/csv_keys.js:70
+#: static/js/impala/stats/csv_keys.js:69 static/js/impala/stats/csv_keys.js:70 static/js/zamboni/stats-all.js:15350 static/js/zamboni/stats-all.js:15351 static/js/zamboni/stats-min.js:4
 msgid "Upsell"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:71
+#: static/js/impala/stats/csv_keys.js:71 static/js/zamboni/stats-all.js:15352 static/js/zamboni/stats-min.js:4
 msgid "Meet the Developer"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:72
+#: static/js/impala/stats/csv_keys.js:72 static/js/zamboni/stats-all.js:15353 static/js/zamboni/stats-min.js:4
 msgid "User Profile"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:73
+#: static/js/impala/stats/csv_keys.js:73 static/js/zamboni/stats-all.js:15354 static/js/zamboni/stats-min.js:4
 msgid "Version History"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:75
+#: static/js/impala/stats/csv_keys.js:75 static/js/zamboni/stats-all.js:15356 static/js/zamboni/stats-min.js:4
 msgid "Sharing"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:76
+#: static/js/impala/stats/csv_keys.js:76 static/js/zamboni/stats-all.js:15357 static/js/zamboni/stats-min.js:4
 msgid "Category Pages"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:77
+#: static/js/impala/stats/csv_keys.js:77 static/js/zamboni/stats-all.js:15358 static/js/zamboni/stats-min.js:4
 msgid "Collections"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:78 static/js/impala/stats/csv_keys.js:79
+#: static/js/impala/stats/csv_keys.js:78 static/js/impala/stats/csv_keys.js:79 static/js/zamboni/stats-all.js:15359 static/js/zamboni/stats-all.js:15360 static/js/zamboni/stats-min.js:4
 msgid "Category Landing Featured Carousel"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:80 static/js/impala/stats/csv_keys.js:81
+#: static/js/impala/stats/csv_keys.js:80 static/js/impala/stats/csv_keys.js:81 static/js/zamboni/stats-all.js:15361 static/js/zamboni/stats-all.js:15362 static/js/zamboni/stats-min.js:4
 msgid "Category Landing Top Rated"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:82 static/js/impala/stats/csv_keys.js:83
+#: static/js/impala/stats/csv_keys.js:82 static/js/impala/stats/csv_keys.js:83 static/js/zamboni/stats-all.js:15363 static/js/zamboni/stats-all.js:15364 static/js/zamboni/stats-min.js:5
 msgid "Category Landing Most Popular"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:84 static/js/impala/stats/csv_keys.js:85
+#: static/js/impala/stats/csv_keys.js:84 static/js/impala/stats/csv_keys.js:85 static/js/zamboni/stats-all.js:15365 static/js/zamboni/stats-all.js:15366 static/js/zamboni/stats-min.js:5
 msgid "Category Landing Recently Added"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:86 static/js/impala/stats/csv_keys.js:87
+#: static/js/impala/stats/csv_keys.js:86 static/js/impala/stats/csv_keys.js:87 static/js/zamboni/stats-all.js:15367 static/js/zamboni/stats-all.js:15368 static/js/zamboni/stats-min.js:5
 msgid "Browse Listing Featured Sort"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:88 static/js/impala/stats/csv_keys.js:89
+#: static/js/impala/stats/csv_keys.js:88 static/js/impala/stats/csv_keys.js:89 static/js/zamboni/stats-all.js:15369 static/js/zamboni/stats-all.js:15370 static/js/zamboni/stats-min.js:5
 msgid "Browse Listing Users Sort"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:90 static/js/impala/stats/csv_keys.js:91
+#: static/js/impala/stats/csv_keys.js:90 static/js/impala/stats/csv_keys.js:91 static/js/zamboni/stats-all.js:15371 static/js/zamboni/stats-all.js:15372 static/js/zamboni/stats-min.js:5
 msgid "Browse Listing Rating Sort"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:92 static/js/impala/stats/csv_keys.js:93
+#: static/js/impala/stats/csv_keys.js:92 static/js/impala/stats/csv_keys.js:93 static/js/zamboni/stats-all.js:15373 static/js/zamboni/stats-all.js:15374 static/js/zamboni/stats-min.js:5
 msgid "Browse Listing Created Sort"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:94 static/js/impala/stats/csv_keys.js:95
+#: static/js/impala/stats/csv_keys.js:94 static/js/impala/stats/csv_keys.js:95 static/js/zamboni/stats-all.js:15375 static/js/zamboni/stats-all.js:15376 static/js/zamboni/stats-min.js:5
 msgid "Browse Listing Name Sort"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:96 static/js/impala/stats/csv_keys.js:97
+#: static/js/impala/stats/csv_keys.js:96 static/js/impala/stats/csv_keys.js:97 static/js/zamboni/stats-all.js:15377 static/js/zamboni/stats-all.js:15378 static/js/zamboni/stats-min.js:5
 msgid "Browse Listing Popular Sort"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:98 static/js/impala/stats/csv_keys.js:99
+#: static/js/impala/stats/csv_keys.js:98 static/js/impala/stats/csv_keys.js:99 static/js/zamboni/stats-all.js:15379 static/js/zamboni/stats-all.js:15380 static/js/zamboni/stats-min.js:5
 msgid "Browse Listing Updated Sort"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:100 static/js/impala/stats/csv_keys.js:101
+#: static/js/impala/stats/csv_keys.js:100 static/js/impala/stats/csv_keys.js:101 static/js/zamboni/stats-all.js:15381 static/js/zamboni/stats-all.js:15382 static/js/zamboni/stats-min.js:5
 msgid "Browse Listing Up and Coming Sort"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:105
+#: static/js/impala/stats/csv_keys.js:105 static/js/zamboni/stats-all.js:15386 static/js/zamboni/stats-min.js:5
 msgid "Total Amount Contributed"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:106
+#: static/js/impala/stats/csv_keys.js:106 static/js/zamboni/stats-all.js:15387 static/js/zamboni/stats-min.js:5
 msgid "Average Contribution"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:115
+#: static/js/impala/stats/csv_keys.js:115 static/js/zamboni/stats-all.js:15396 static/js/zamboni/stats-min.js:5
 msgid "Usage"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:118
+#: static/js/impala/stats/csv_keys.js:118 static/js/zamboni/stats-all.js:15399 static/js/zamboni/stats-min.js:5
 msgid "Firefox"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:119
+#: static/js/impala/stats/csv_keys.js:119 static/js/zamboni/stats-all.js:15400 static/js/zamboni/stats-min.js:5
 msgid "Mozilla"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:120
+#: static/js/impala/stats/csv_keys.js:120 static/js/zamboni/stats-all.js:15401 static/js/zamboni/stats-min.js:5
 msgid "Thunderbird"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:121
+#: static/js/impala/stats/csv_keys.js:121 static/js/zamboni/stats-all.js:15402 static/js/zamboni/stats-min.js:5
 msgid "Sunbird"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:122
+#: static/js/impala/stats/csv_keys.js:122 static/js/zamboni/stats-all.js:15403 static/js/zamboni/stats-min.js:5
 msgid "SeaMonkey"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:123
+#: static/js/impala/stats/csv_keys.js:123 static/js/zamboni/stats-all.js:15404 static/js/zamboni/stats-min.js:5
 msgid "Fennec"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:124
+#: static/js/impala/stats/csv_keys.js:124 static/js/zamboni/stats-all.js:15405 static/js/zamboni/stats-min.js:5
 msgid "Android"
 msgstr ""
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:129
+#: static/js/impala/stats/csv_keys.js:129 static/js/zamboni/stats-all.js:15410 static/js/zamboni/stats-min.js:5
 msgid "Downloads and Daily Users, last {0} days"
 msgstr ""
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:131
+#: static/js/impala/stats/csv_keys.js:131 static/js/zamboni/stats-all.js:15412 static/js/zamboni/stats-min.js:5
 msgid "Downloads and Daily Users from {0} to {1}"
 msgstr ""
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:135
+#: static/js/impala/stats/csv_keys.js:135 static/js/zamboni/stats-all.js:15416 static/js/zamboni/stats-min.js:5
 msgid "Installs and Daily Users, last {0} days"
 msgstr ""
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:137
+#: static/js/impala/stats/csv_keys.js:137 static/js/zamboni/stats-all.js:15418 static/js/zamboni/stats-min.js:5
 msgid "Installs and Daily Users from {0} to {1}"
 msgstr ""
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:141
+#: static/js/impala/stats/csv_keys.js:141 static/js/zamboni/stats-all.js:15422 static/js/zamboni/stats-min.js:5
 msgid "Downloads, last {0} days"
 msgstr ""
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:143
+#: static/js/impala/stats/csv_keys.js:143 static/js/zamboni/stats-all.js:15424 static/js/zamboni/stats-min.js:5
 msgid "Downloads from {0} to {1}"
 msgstr ""
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:147
+#: static/js/impala/stats/csv_keys.js:147 static/js/zamboni/stats-all.js:15428 static/js/zamboni/stats-min.js:5
 msgid "Daily Users, last {0} days"
 msgstr ""
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:149
+#: static/js/impala/stats/csv_keys.js:149 static/js/zamboni/stats-all.js:15430 static/js/zamboni/stats-min.js:5
 msgid "Daily Users from {0} to {1}"
 msgstr ""
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:153
+#: static/js/impala/stats/csv_keys.js:153 static/js/zamboni/stats-all.js:15434 static/js/zamboni/stats-min.js:5
 msgid "Applications, last {0} days"
 msgstr ""
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:155
+#: static/js/impala/stats/csv_keys.js:155 static/js/zamboni/stats-all.js:15436 static/js/zamboni/stats-min.js:5
 msgid "Applications from {0} to {1}"
 msgstr ""
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:159
+#: static/js/impala/stats/csv_keys.js:159 static/js/zamboni/stats-all.js:15440 static/js/zamboni/stats-min.js:5
 msgid "Platforms, last {0} days"
 msgstr ""
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:161
+#: static/js/impala/stats/csv_keys.js:161 static/js/zamboni/stats-all.js:15442 static/js/zamboni/stats-min.js:5
 msgid "Platforms from {0} to {1}"
 msgstr ""
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:165
+#: static/js/impala/stats/csv_keys.js:165 static/js/zamboni/stats-all.js:15446 static/js/zamboni/stats-min.js:5
 msgid "Languages, last {0} days"
 msgstr ""
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:167
+#: static/js/impala/stats/csv_keys.js:167 static/js/zamboni/stats-all.js:15448 static/js/zamboni/stats-min.js:5
 msgid "Languages from {0} to {1}"
 msgstr ""
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:171
+#: static/js/impala/stats/csv_keys.js:171 static/js/zamboni/stats-all.js:15452 static/js/zamboni/stats-min.js:5
 msgid "Add-on Versions, last {0} days"
 msgstr ""
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:173
+#: static/js/impala/stats/csv_keys.js:173 static/js/zamboni/stats-all.js:15454 static/js/zamboni/stats-min.js:5
 msgid "Add-on Versions from {0} to {1}"
 msgstr ""
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:177
+#: static/js/impala/stats/csv_keys.js:177 static/js/zamboni/stats-all.js:15458 static/js/zamboni/stats-min.js:5
 msgid "Add-on Status, last {0} days"
 msgstr ""
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:179
+#: static/js/impala/stats/csv_keys.js:179 static/js/zamboni/stats-all.js:15460 static/js/zamboni/stats-min.js:5
 msgid "Add-on Status from {0} to {1}"
 msgstr ""
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:183
+#: static/js/impala/stats/csv_keys.js:183 static/js/zamboni/stats-all.js:15464 static/js/zamboni/stats-min.js:5
 msgid "Download Sources, last {0} days"
 msgstr ""
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:185
+#: static/js/impala/stats/csv_keys.js:185 static/js/zamboni/stats-all.js:15466 static/js/zamboni/stats-min.js:5
 msgid "Download Sources from {0} to {1}"
 msgstr ""
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:189
+#: static/js/impala/stats/csv_keys.js:189 static/js/zamboni/stats-all.js:15470 static/js/zamboni/stats-min.js:5
 msgid "Contributions, last {0} days"
 msgstr ""
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:191
+#: static/js/impala/stats/csv_keys.js:191 static/js/zamboni/stats-all.js:15472 static/js/zamboni/stats-min.js:5
 msgid "Contributions from {0} to {1}"
 msgstr ""
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:195
+#: static/js/impala/stats/csv_keys.js:195 static/js/zamboni/stats-all.js:15476 static/js/zamboni/stats-min.js:5
 msgid "Site Metrics, last {0} days"
 msgstr ""
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:197
+#: static/js/impala/stats/csv_keys.js:197 static/js/zamboni/stats-all.js:15478 static/js/zamboni/stats-min.js:5
 msgid "Site Metrics from {0} to {1}"
 msgstr ""
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:201
+#: static/js/impala/stats/csv_keys.js:201 static/js/zamboni/stats-all.js:15482 static/js/zamboni/stats-min.js:5
 msgid "Add-ons in Use, last {0} days"
 msgstr ""
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:203
+#: static/js/impala/stats/csv_keys.js:203 static/js/zamboni/stats-all.js:15484 static/js/zamboni/stats-min.js:5
 msgid "Add-ons in Use from {0} to {1}"
 msgstr ""
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:207
+#: static/js/impala/stats/csv_keys.js:207 static/js/zamboni/stats-all.js:15488 static/js/zamboni/stats-min.js:5
 msgid "Add-ons Downloaded, last {0} days"
 msgstr ""
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:209
+#: static/js/impala/stats/csv_keys.js:209 static/js/zamboni/stats-all.js:15490 static/js/zamboni/stats-min.js:5
 msgid "Add-ons Downloaded from {0} to {1}"
 msgstr ""
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:213
+#: static/js/impala/stats/csv_keys.js:213 static/js/zamboni/stats-all.js:15494 static/js/zamboni/stats-min.js:5
 msgid "Add-ons Created, last {0} days"
 msgstr ""
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:215
+#: static/js/impala/stats/csv_keys.js:215 static/js/zamboni/stats-all.js:15496 static/js/zamboni/stats-min.js:5
 msgid "Add-ons Created from {0} to {1}"
 msgstr ""
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:219
+#: static/js/impala/stats/csv_keys.js:219 static/js/zamboni/stats-all.js:15500 static/js/zamboni/stats-min.js:5
 msgid "Add-ons Updated, last {0} days"
 msgstr ""
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:221
+#: static/js/impala/stats/csv_keys.js:221 static/js/zamboni/stats-all.js:15502 static/js/zamboni/stats-min.js:5
 msgid "Add-ons Updated from {0} to {1}"
 msgstr ""
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:225
+#: static/js/impala/stats/csv_keys.js:225 static/js/zamboni/stats-all.js:15506 static/js/zamboni/stats-min.js:5
 msgid "Reviews Written, last {0} days"
 msgstr ""
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:227
+#: static/js/impala/stats/csv_keys.js:227 static/js/zamboni/stats-all.js:15508 static/js/zamboni/stats-min.js:5
 msgid "Reviews Written from {0} to {1}"
 msgstr ""
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:231
+#: static/js/impala/stats/csv_keys.js:231 static/js/zamboni/stats-all.js:15512 static/js/zamboni/stats-min.js:5
 msgid "User Signups, last {0} days"
 msgstr ""
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:233
+#: static/js/impala/stats/csv_keys.js:233 static/js/zamboni/stats-all.js:15514 static/js/zamboni/stats-min.js:5
 msgid "User Signups from {0} to {1}"
 msgstr ""
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:237
+#: static/js/impala/stats/csv_keys.js:237 static/js/zamboni/stats-all.js:15518 static/js/zamboni/stats-min.js:5
 msgid "Collections Created, last {0} days"
 msgstr ""
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:239
+#: static/js/impala/stats/csv_keys.js:239 static/js/zamboni/stats-all.js:15520 static/js/zamboni/stats-min.js:5
 msgid "Collections Created from {0} to {1}"
 msgstr ""
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:243
+#: static/js/impala/stats/csv_keys.js:243 static/js/zamboni/stats-all.js:15524 static/js/zamboni/stats-min.js:5
 msgid "Subscribers, last {0} days"
 msgstr ""
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:245
+#: static/js/impala/stats/csv_keys.js:245 static/js/zamboni/stats-all.js:15526 static/js/zamboni/stats-min.js:5
 msgid "Subscribers from {0} to {1}"
 msgstr ""
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:249
+#: static/js/impala/stats/csv_keys.js:249 static/js/zamboni/stats-all.js:15530 static/js/zamboni/stats-min.js:5
 msgid "Ratings, last {0} days"
 msgstr ""
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:251
+#: static/js/impala/stats/csv_keys.js:251 static/js/zamboni/stats-all.js:15532 static/js/zamboni/stats-min.js:5
 msgid "Ratings from {0} to {1}"
 msgstr ""
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:255
+#: static/js/impala/stats/csv_keys.js:255 static/js/zamboni/stats-all.js:15536 static/js/zamboni/stats-min.js:5
 msgid "Sales, last {0} days"
 msgstr ""
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:257
+#: static/js/impala/stats/csv_keys.js:257 static/js/zamboni/stats-all.js:15538 static/js/zamboni/stats-min.js:5
 msgid "Sales from {0} to {1}"
 msgstr ""
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:261
+#: static/js/impala/stats/csv_keys.js:261 static/js/zamboni/stats-all.js:15542 static/js/zamboni/stats-min.js:5
 msgid "Installs, last {0} days"
 msgstr ""
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:263
+#: static/js/impala/stats/csv_keys.js:263 static/js/zamboni/stats-all.js:15544 static/js/zamboni/stats-min.js:5
 msgid "Installs from {0} to {1}"
 msgstr ""
 
 #. L10n: {0} and {1} are integers.
-#: static/js/impala/stats/csv_keys.js:269
+#: static/js/impala/stats/csv_keys.js:269 static/js/zamboni/stats-all.js:15550 static/js/zamboni/stats-min.js:5
 msgid "<b>{0}</b> in last {1} days"
 msgstr ""
 
 #. L10n: {0} is an integer and {1} and {2} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:271 static/js/impala/stats/csv_keys.js:277
+#: static/js/impala/stats/csv_keys.js:271 static/js/impala/stats/csv_keys.js:277 static/js/zamboni/stats-all.js:15552 static/js/zamboni/stats-all.js:15558 static/js/zamboni/stats-min.js:5
 msgid "<b>{0}</b> from {1} to {2}"
 msgstr ""
 
 #. L10n: {0} and {1} are integers.
-#: static/js/impala/stats/csv_keys.js:275
+#: static/js/impala/stats/csv_keys.js:275 static/js/zamboni/stats-all.js:15556 static/js/zamboni/stats-min.js:5
 msgid "<b>{0}</b> average in last {1} days"
 msgstr ""
 
-#: static/js/impala/stats/overview.js:19
+#: static/js/impala/stats/overview.js:19 static/js/zamboni/stats-all.js:16469 static/js/zamboni/stats-min.js:5
 msgid "No data available."
 msgstr ""
 
-#: static/js/impala/stats/table.js:74
+#: static/js/impala/stats/table.js:74 static/js/zamboni/stats-all.js:17209 static/js/zamboni/stats-min.js:5
 msgid "Date"
 msgstr ""
 
-#: static/js/impala/stats/topchart.js:96
+#: static/js/impala/stats/topchart.js:96 static/js/zamboni/stats-all.js:16600 static/js/zamboni/stats-min.js:5
 msgid "Other"
 msgstr ""
 
-#: static/js/zamboni/admin_validation.js:24 static/js/zamboni/devhub.js:1229 static/js/zamboni/editors.js:295
+#: static/js/zamboni/admin-all.js:180 static/js/zamboni/admin-min.js:1 static/js/zamboni/admin_validation.js:24 static/js/zamboni/devhub-all.js:2408 static/js/zamboni/devhub-min.js:2
+#: static/js/zamboni/devhub.js:1229 static/js/zamboni/editors-all.js:15576 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:295
 msgid "Select an application first"
 msgstr ""
 
-#: static/js/zamboni/admin_validation.js:51
+#: static/js/zamboni/admin-all.js:207 static/js/zamboni/admin-min.js:1 static/js/zamboni/admin_validation.js:51
 msgid "Set {0} add-on to a max version of {1} and email the author."
 msgid_plural "Set {0} add-ons to a max version of {1} and email the authors."
 msgstr[0] ""
 msgstr[1] ""
 
-#: static/js/zamboni/admin_validation.js:54
+#: static/js/zamboni/admin-all.js:210 static/js/zamboni/admin-min.js:1 static/js/zamboni/admin_validation.js:54
 msgid "Email author of {2} add-on which failed validation."
 msgid_plural "Email authors of {2} add-ons which failed validation."
 msgstr[0] ""
 msgstr[1] ""
 
-#. L10n: {0} is an app name like Firefox.
-#: static/js/zamboni/buttons.js:66
-msgid "Accept and Install"
-msgstr ""
-
-#: static/js/zamboni/buttons.js:66
-msgid "Add to {0}"
-msgstr ""
-
-#: static/js/zamboni/buttons.js:71
-msgid "Download Now"
-msgstr ""
-
-#: static/js/zamboni/buttons.js:112
-msgid "Add-on has not been updated to support default-to-compatible."
-msgstr ""
-
-#: static/js/zamboni/buttons.js:117
-msgid "You need to be using Firefox 10.0 or higher."
-msgstr ""
-
-#: static/js/zamboni/buttons.js:129
-msgid "Mozilla has marked this version as incompatible with your Firefox version."
-msgstr ""
-
-#. L10n: {0} is an platform like Windows or Linux.
-#: static/js/zamboni/buttons.js:210
-msgid "Install for {0} anyway"
-msgstr ""
-
-#: static/js/zamboni/buttons.js:210
-msgid "Download for {0} anyway"
-msgstr ""
-
-#: static/js/zamboni/buttons.js:267
-msgid "Not available for your platform"
-msgstr ""
-
-#. L10n: {0} is an app name, {1} is the app version.
-#: static/js/zamboni/buttons.js:278 static/js/zamboni/buttons.js:315
-msgid "Not available for {0} {1}"
-msgstr ""
-
-#: static/js/zamboni/buttons.js:341
-msgid "Works with {app} {min} - {max}"
-msgstr ""
-
-#: static/js/zamboni/buttons.js:343
-msgid "View other versions"
-msgstr ""
-
-#: static/js/zamboni/buttons.js:391
-msgid "Only with Firefox — Get Firefox Now!"
-msgstr ""
-
-#: static/js/zamboni/buttons.js:507 static/js/zamboni/mobile/buttons.js:43
-msgid "Sorry, you need a Mozilla-based browser (such as Firefox) to install a search plugin."
-msgstr ""
-
-#: static/js/zamboni/collections.js:229
-msgid "Adding to Favorites&hellip;"
-msgstr ""
-
-#: static/js/zamboni/collections.js:232
-msgid "Removing Favorite&hellip;"
-msgstr ""
-
-#: static/js/zamboni/collections.js:235
-msgid "Add to Favorites"
-msgstr ""
-
-#: static/js/zamboni/collections.js:238
-msgid "Remove from Favorites"
-msgstr ""
-
-#: static/js/zamboni/collections.js:303
-msgid "Pending"
-msgstr ""
-
-#: static/js/zamboni/collections.js:304
-msgid "Add a comment"
-msgstr ""
-
-#: static/js/zamboni/collections.js:304
-msgid "Comment"
-msgstr ""
-
-#: static/js/zamboni/collections.js:305
-msgid "Remove this add-on from the collection"
-msgstr ""
-
-#: static/js/zamboni/collections.js:305 static/js/zamboni/collections.js:334
-msgid "Remove"
-msgstr ""
-
-#: static/js/zamboni/collections.js:334
-msgid "Remove this user as a contributor"
-msgstr ""
-
-#: static/js/zamboni/collections.js:346
-msgid "An email address is required."
-msgstr ""
-
-#: static/js/zamboni/collections.js:364
-msgid "You cannot add yourself as a contributor."
-msgstr ""
-
-#: static/js/zamboni/collections.js:366
-msgid "You have already added that user."
-msgstr ""
-
-#: static/js/zamboni/collections.js:573
-msgid "Add to favorites"
-msgstr ""
-
-#: static/js/zamboni/collections.js:577
-msgid "Remove from favorites"
-msgstr ""
-
-#: static/js/zamboni/collections.js:604
-msgid "Stop following"
-msgstr ""
-
-#: static/js/zamboni/devhub.js:110
+#: static/js/zamboni/devhub-all.js:1289 static/js/zamboni/devhub-min.js:1 static/js/zamboni/devhub.js:110
 msgid "Your browser does not support the video tag"
 msgstr ""
 
-#: static/js/zamboni/devhub.js:371
+#: static/js/zamboni/devhub-all.js:1550 static/js/zamboni/devhub-min.js:1 static/js/zamboni/devhub.js:371
 msgid "Changes Saved"
 msgstr ""
 
-#: static/js/zamboni/devhub.js:387
+#: static/js/zamboni/devhub-all.js:1566 static/js/zamboni/devhub-min.js:1 static/js/zamboni/devhub.js:387
 msgid "Enter a new author's email address"
 msgstr ""
 
-#: static/js/zamboni/devhub.js:536
+#: static/js/zamboni/devhub-all.js:1715 static/js/zamboni/devhub-min.js:1 static/js/zamboni/devhub.js:536
 msgid "There was an error uploading your file."
 msgstr ""
 
-#: static/js/zamboni/devhub.js:681
+#: static/js/zamboni/devhub-all.js:1860 static/js/zamboni/devhub-min.js:1 static/js/zamboni/devhub.js:681
 msgid "{files} file"
 msgid_plural "{files} files"
 msgstr[0] ""
 msgstr[1] ""
 
-#: static/js/zamboni/devhub.js:684
+#: static/js/zamboni/devhub-all.js:1863 static/js/zamboni/devhub-min.js:1 static/js/zamboni/devhub.js:684
 msgid "{reviews} user review"
 msgid_plural "{reviews} user reviews"
 msgstr[0] ""
 msgstr[1] ""
 
-#: static/js/zamboni/devhub.js:796
+#: static/js/zamboni/devhub-all.js:1975 static/js/zamboni/devhub-min.js:2 static/js/zamboni/devhub.js:796
 msgid "Learn more"
 msgstr ""
 
-#: static/js/zamboni/devhub.js:800
+#: static/js/zamboni/devhub-all.js:1979 static/js/zamboni/devhub-min.js:2 static/js/zamboni/devhub.js:800
 msgid "Example"
 msgstr ""
 
-#: static/js/zamboni/devhub.js:1130
+#: static/js/zamboni/devhub-all.js:2309 static/js/zamboni/devhub-min.js:2 static/js/zamboni/devhub.js:1130
 msgid "Image changes being processed"
 msgstr ""
 
-#: static/js/zamboni/devhub.js:1280
+#: static/js/zamboni/devhub-all.js:2459 static/js/zamboni/devhub-min.js:2 static/js/zamboni/devhub.js:1280
 msgid "Must be a valid e-mail address."
+msgstr ""
+
+#: static/js/zamboni/devhub-all.js:2613 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:80
+msgid "All tests passed successfully."
+msgstr ""
+
+#: static/js/zamboni/devhub-all.js:2616 static/js/zamboni/devhub-all.js:3011 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:83 static/js/zamboni/validator.js:478
+msgid "These tests were not run."
+msgstr ""
+
+#: static/js/zamboni/devhub-all.js:2664 static/js/zamboni/devhub-all.js:2677 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:131 static/js/zamboni/validator.js:144
+msgid "Tests"
+msgstr ""
+
+#: static/js/zamboni/devhub-all.js:2779 static/js/zamboni/devhub-all.js:3108 static/js/zamboni/devhub-all.js:3127 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:246
+#: static/js/zamboni/validator.js:575 static/js/zamboni/validator.js:594
+msgid "Error"
+msgstr ""
+
+#: static/js/zamboni/devhub-all.js:2780 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:247
+msgid "Warning"
+msgstr ""
+
+#: static/js/zamboni/devhub-all.js:2794 static/js/zamboni/devhub-min.js:2 static/js/zamboni/files-all.js:5657 static/js/zamboni/files-min.js:3 static/js/zamboni/files.js:411
+#: static/js/zamboni/validator.js:261
+msgid "Ignore this message in future updates"
+msgstr ""
+
+#: static/js/zamboni/devhub-all.js:2817 static/js/zamboni/devhub-min.js:2 static/js/zamboni/files-all.js:5663 static/js/zamboni/files-min.js:3 static/js/zamboni/files.js:417
+#: static/js/zamboni/validator.js:284
+msgid "Severity for automated signing:"
+msgstr ""
+
+#: static/js/zamboni/devhub-all.js:2832 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:299
+msgid "Suggestions for passing automated signing:"
+msgstr ""
+
+#: static/js/zamboni/devhub-all.js:2920 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:387
+msgid "Compatibility Tests"
+msgstr ""
+
+#: static/js/zamboni/devhub-all.js:2999 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:466
+msgid "Add-on failed validation."
+msgstr ""
+
+#: static/js/zamboni/devhub-all.js:3001 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:468
+msgid "Add-on passed validation."
+msgstr ""
+
+#: static/js/zamboni/devhub-all.js:3014 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:481
+msgid "{0} error"
+msgid_plural "{0} errors"
+msgstr[0] ""
+msgstr[1] ""
+
+#: static/js/zamboni/devhub-all.js:3016 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:483
+msgid "{0} warning"
+msgid_plural "{0} warnings"
+msgstr[0] ""
+msgstr[1] ""
+
+#: static/js/zamboni/devhub-all.js:3018 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:485
+msgid "{0} notice"
+msgid_plural "{0} notices"
+msgstr[0] ""
+msgstr[1] ""
+
+#: static/js/zamboni/devhub-all.js:3110 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:577
+msgid "Validation task could not complete or completed with errors"
+msgstr ""
+
+#: static/js/zamboni/devhub-all.js:3128 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:595
+msgid "Internal server error"
 msgstr ""
 
 #: static/js/zamboni/devhub_search.js:8
 msgid "No results found."
 msgstr ""
 
-#: static/js/zamboni/editors.js:121
+#: static/js/zamboni/editors-all.js:15402 static/js/zamboni/editors-min.js:4 static/js/zamboni/editors.js:121
 msgid "{name} was viewing this page first."
 msgstr ""
 
-#: static/js/zamboni/editors.js:171
+#: static/js/zamboni/editors-all.js:15452 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:171
 msgid "Receipt checked by app."
 msgstr ""
 
-#: static/js/zamboni/editors.js:173
+#: static/js/zamboni/editors-all.js:15454 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:173
 msgid "Receipt was not checked by app."
 msgstr ""
 
-#: static/js/zamboni/editors.js:244
+#: static/js/zamboni/editors-all.js:15525 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:244
 msgid "{name} was viewing this add-on first."
 msgstr ""
 
-#: static/js/zamboni/editors.js:255
+#: static/js/zamboni/editors-all.js:15536 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:255
 msgid "Loading&hellip;"
 msgstr ""
 
-#: static/js/zamboni/editors.js:260
+#: static/js/zamboni/editors-all.js:15541 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:260
 msgid "Version Notes"
 msgstr ""
 
-#: static/js/zamboni/editors.js:265
+#: static/js/zamboni/editors-all.js:15546 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:265
 msgid "Notes for Reviewers"
 msgstr ""
 
-#: static/js/zamboni/editors.js:270
+#: static/js/zamboni/editors-all.js:15551 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:270
 msgid "No version notes found"
 msgstr ""
 
-#: static/js/zamboni/editors.js:330
+#: static/js/zamboni/editors-all.js:15611 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:330
 msgid "Average Reviews"
 msgstr ""
 
-#: static/js/zamboni/editors.js:386
+#: static/js/zamboni/editors-all.js:15667 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:386
 msgid "Number of Reviews"
 msgstr ""
 
-#: static/js/zamboni/editors.js:445
+#: static/js/zamboni/editors-all.js:15726 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:445
 msgid "Error loading translation"
 msgstr ""
 
-#: static/js/zamboni/files.js:411 static/js/zamboni/validator.js:261
-msgid "Ignore this message in future updates"
-msgstr ""
-
-#: static/js/zamboni/files.js:417 static/js/zamboni/validator.js:284
-msgid "Severity for automated signing:"
-msgstr ""
-
-#: static/js/zamboni/global.js:410
-msgid "Loading..."
-msgstr ""
-
-#. L10n: {0} is the number of characters left.
-#: static/js/zamboni/global.js:474
-msgid "<b>{0}</b> character left."
-msgid_plural "<b>{0}</b> characters left."
-msgstr[0] ""
-msgstr[1] ""
-
-#: static/js/zamboni/init.js:28
-msgid "This feature is temporarily disabled while we perform website maintenance. Please check back a little later."
-msgstr ""
-
-#: static/js/zamboni/l10n.js:45
-msgid "Remove this localization"
-msgstr ""
-
-#: static/js/zamboni/password-strength.js:20
-msgid "Password strength:"
-msgstr ""
-
-#: static/js/zamboni/password-strength.js:26
-msgid "At least {0} character left."
-msgid_plural "At least {0} characters left."
-msgstr[0] ""
-msgstr[1] ""
-
-#: static/js/zamboni/themes_review.js:176
-msgid "Requested Info"
-msgstr ""
-
-#: static/js/zamboni/themes_review.js:177
-msgid "Flagged"
-msgstr ""
-
-#: static/js/zamboni/themes_review.js:178
-msgid "Duplicate"
-msgstr ""
-
-#: static/js/zamboni/themes_review.js:179
-msgid "Rejected"
-msgstr ""
-
-#: static/js/zamboni/themes_review.js:180
-msgid "Approved"
-msgstr ""
-
-#: static/js/zamboni/themes_review.js:424
-msgid "No results found"
-msgstr ""
-
-#: static/js/zamboni/themes_review_templates.js:31
+#: static/js/zamboni/editors-all.js:15975 static/js/zamboni/editors-min.js:5 static/js/zamboni/themes_review_templates.js:31
 msgid "Theme"
 msgstr ""
 
-#: static/js/zamboni/themes_review_templates.js:33
+#: static/js/zamboni/editors-all.js:15977 static/js/zamboni/editors-min.js:5 static/js/zamboni/themes_review_templates.js:33
 msgid "Reviewer"
 msgstr ""
 
-#: static/js/zamboni/themes_review_templates.js:35
+#: static/js/zamboni/editors-all.js:15979 static/js/zamboni/editors-min.js:5 static/js/zamboni/themes_review_templates.js:35
 msgid "Status"
 msgstr ""
 
-#: static/js/zamboni/validator.js:80
-msgid "All tests passed successfully."
+#: static/js/zamboni/editors-all.js:16196 static/js/zamboni/editors-min.js:5 static/js/zamboni/themes_review.js:176
+msgid "Requested Info"
 msgstr ""
 
-#: static/js/zamboni/validator.js:83 static/js/zamboni/validator.js:478
-msgid "These tests were not run."
+#: static/js/zamboni/editors-all.js:16197 static/js/zamboni/editors-min.js:5 static/js/zamboni/themes_review.js:177
+msgid "Flagged"
 msgstr ""
 
-#: static/js/zamboni/validator.js:131 static/js/zamboni/validator.js:144
-msgid "Tests"
+#: static/js/zamboni/editors-all.js:16198 static/js/zamboni/editors-min.js:5 static/js/zamboni/themes_review.js:178
+msgid "Duplicate"
 msgstr ""
 
-#: static/js/zamboni/validator.js:246 static/js/zamboni/validator.js:575 static/js/zamboni/validator.js:594
-msgid "Error"
+#: static/js/zamboni/editors-all.js:16199 static/js/zamboni/editors-min.js:5 static/js/zamboni/themes_review.js:179
+msgid "Rejected"
 msgstr ""
 
-#: static/js/zamboni/validator.js:247
-msgid "Warning"
+#: static/js/zamboni/editors-all.js:16200 static/js/zamboni/editors-min.js:5 static/js/zamboni/themes_review.js:180
+msgid "Approved"
 msgstr ""
 
-#: static/js/zamboni/validator.js:299
-msgid "Suggestions for passing automated signing:"
+#: static/js/zamboni/editors-all.js:16444 static/js/zamboni/editors-min.js:5 static/js/zamboni/themes_review.js:424
+msgid "No results found"
 msgstr ""
 
-#: static/js/zamboni/validator.js:387
-msgid "Compatibility Tests"
-msgstr ""
-
-#: static/js/zamboni/validator.js:466
-msgid "Add-on failed validation."
-msgstr ""
-
-#: static/js/zamboni/validator.js:468
-msgid "Add-on passed validation."
-msgstr ""
-
-#: static/js/zamboni/validator.js:481
-msgid "{0} error"
-msgid_plural "{0} errors"
-msgstr[0] ""
-msgstr[1] ""
-
-#: static/js/zamboni/validator.js:483
-msgid "{0} warning"
-msgid_plural "{0} warnings"
-msgstr[0] ""
-msgstr[1] ""
-
-#: static/js/zamboni/validator.js:485
-msgid "{0} notice"
-msgid_plural "{0} notices"
-msgstr[0] ""
-msgstr[1] ""
-
-#: static/js/zamboni/validator.js:577
-msgid "Validation task could not complete or completed with errors"
-msgstr ""
-
-#: static/js/zamboni/validator.js:595
-msgid "Internal server error"
-msgstr ""
-
-#: static/js/zamboni/mobile/buttons.js:52
+#: static/js/zamboni/mobile-all.js:15186 static/js/zamboni/mobile/buttons.js:52
 msgid "Not Updated for {0} {1}"
 msgstr ""
 
-#: static/js/zamboni/mobile/buttons.js:53
+#: static/js/zamboni/mobile-all.js:15187 static/js/zamboni/mobile/buttons.js:53
 msgid "Requires Newer Version of {0}"
 msgstr ""
 
-#: static/js/zamboni/mobile/buttons.js:54
+#: static/js/zamboni/mobile-all.js:15188 static/js/zamboni/mobile/buttons.js:54
 msgid "Unreviewed"
 msgstr ""
 
-#: static/js/zamboni/mobile/buttons.js:55
+#: static/js/zamboni/mobile-all.js:15189 static/js/zamboni/mobile/buttons.js:55
 msgid "Experimental <span>(Learn More)</span>"
 msgstr ""
 
-#: static/js/zamboni/mobile/buttons.js:56 static/js/zamboni/mobile/buttons.js:57
+#: static/js/zamboni/mobile-all.js:15190 static/js/zamboni/mobile-all.js:15191 static/js/zamboni/mobile/buttons.js:56 static/js/zamboni/mobile/buttons.js:57
 msgid "Not Available for {0}"
 msgstr ""
 
-#: static/js/zamboni/mobile/buttons.js:58
+#: static/js/zamboni/mobile-all.js:15192 static/js/zamboni/mobile/buttons.js:58
 msgid "Experimental"
 msgstr ""
 
-#: static/js/zamboni/mobile/buttons.js:59
+#: static/js/zamboni/mobile-all.js:15193 static/js/zamboni/mobile/buttons.js:59
 msgid "Themes Require Newer Version of {0}"
 msgstr ""
 
-#: static/js/zamboni/mobile/buttons.js:60
+#: static/js/zamboni/mobile-all.js:15194 static/js/zamboni/mobile/buttons.js:60
 msgid "Themes Require {0}"
 msgstr ""
 
-#: static/js/zamboni/mobile/buttons.js:105
+#: static/js/zamboni/mobile-all.js:15239 static/js/zamboni/mobile/buttons.js:105
 msgid "Installing..."
 msgstr ""
 
-#: static/js/zamboni/mobile/buttons.js:125
+#: static/js/zamboni/mobile-all.js:15259 static/js/zamboni/mobile/buttons.js:125
 msgid "This add-on has been preliminarily reviewed by Mozilla."
 msgstr ""
 
-#: static/js/zamboni/mobile/buttons.js:250
+#: static/js/zamboni/mobile-all.js:15384 static/js/zamboni/mobile/buttons.js:250
 msgid "Keep it"
 msgstr ""
 
-#: static/js/zamboni/mobile/general.js:344
+#: static/js/zamboni/mobile-all.js:16049 static/js/zamboni/mobile-min.js:6 static/js/zamboni/mobile/general.js:344
 msgid "You're trying it on!"
 msgstr ""
 
-#: static/js/zamboni/mobile/general.js:356
+#: static/js/zamboni/mobile-all.js:16061 static/js/zamboni/mobile-min.js:6 static/js/zamboni/mobile/general.js:356
 msgid "Added to Firefox"
 msgstr ""
-

--- a/locale/ast/LC_MESSAGES/django.po
+++ b/locale/ast/LC_MESSAGES/django.po
@@ -3,69 +3,70 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2016-02-24 21:23+0000\n"
+"POT-Creation-Date: 2016-04-18 15:47+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
+"Language: \n"
 "MIME-Version: 1.0\n"
-"Content-Type: text/plain; charset=utf-8\n"
+"Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Generated-By: Babel 2.2.0\n"
 
-#: src/olympia/accounts/views.py:52
+#: src/olympia/accounts/views.py:54
 msgid "Your log in attempt could not be parsed. Please try again."
 msgstr ""
 
-#: src/olympia/accounts/views.py:54
+#: src/olympia/accounts/views.py:56
 msgid "Your Firefox Account could not be found. Please try again."
 msgstr ""
 
-#: src/olympia/accounts/views.py:55
+#: src/olympia/accounts/views.py:57
 msgid "You could not be logged in. Please try again."
 msgstr ""
 
-#: src/olympia/accounts/views.py:57
+#: src/olympia/accounts/views.py:59
 msgid "Your account has already been migrated to Firefox Accounts."
 msgstr ""
 
-#: src/olympia/accounts/views.py:59
+#: src/olympia/accounts/views.py:61
 msgid "Your Firefox Account already exists on this site."
 msgstr ""
 
-#: src/olympia/accounts/views.py:108
+#: src/olympia/accounts/views.py:110
 msgid "Great job!"
 msgstr ""
 
-#: src/olympia/accounts/views.py:109
+#: src/olympia/accounts/views.py:111
 msgid "You can now log in to Add-ons with your Firefox Account."
 msgstr ""
 
-#: src/olympia/accounts/views.py:121
+#: src/olympia/accounts/views.py:123
 msgid "Need help?"
 msgstr ""
 
-#: src/olympia/addons/buttons.py:180
+#: src/olympia/addons/buttons.py:177
 msgid "Download Now"
 msgstr ""
 
-#: src/olympia/addons/buttons.py:182
+#: src/olympia/addons/buttons.py:179
 msgid "Download"
 msgstr ""
 
 #. L10n: please keep &nbsp; in the string so &rarr; does not wrap.
-#: src/olympia/addons/buttons.py:186
+#: src/olympia/addons/buttons.py:183
 msgid "Continue to Download&nbsp;&rarr;"
 msgstr ""
 
-#: src/olympia/addons/buttons.py:202 src/olympia/addons/helpers.py:35 src/olympia/addons/views.py:319 src/olympia/addons/templates/addons/impala/details.html:114
+#: src/olympia/addons/buttons.py:199 src/olympia/addons/helpers.py:35 src/olympia/addons/views.py:333 src/olympia/addons/templates/addons/impala/details.html:111
 #: src/olympia/addons/templates/addons/impala/listing/items.html:17 src/olympia/addons/templates/addons/mobile/home.html:40 src/olympia/amo/templates/amo/side_nav.html:6
-#: src/olympia/amo/templates/amo/side_nav.html:10 src/olympia/amo/templates/amo/site_nav.html:2 src/olympia/amo/templates/amo/site_nav.html:55 src/olympia/bandwagon/views.py:95
-#: src/olympia/browse/views.py:54 src/olympia/browse/views.py:68 src/olympia/browse/views.py:235 src/olympia/browse/templates/browse/impala/category_landing.html:22
+#: src/olympia/amo/templates/amo/side_nav.html:10 src/olympia/amo/templates/amo/site_nav.html:2 src/olympia/amo/templates/amo/site_nav.html:53 src/olympia/bandwagon/views.py:95
+#: src/olympia/browse/views.py:54 src/olympia/browse/views.py:68 src/olympia/browse/views.py:202 src/olympia/browse/templates/browse/impala/category_landing.html:22
 #: src/olympia/browse/templates/browse/personas/mobile/category_landing.html:26
 msgid "Featured"
 msgstr ""
 
-#: src/olympia/addons/buttons.py:221
+#: src/olympia/addons/buttons.py:218
 msgid "Add to {0}"
 msgstr ""
 
@@ -113,39 +114,39 @@ msgid_plural "All tags must be at least {0} characters."
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/olympia/addons/forms.py:234
+#: src/olympia/addons/forms.py:238
 msgid "Categories cannot be changed while your add-on is featured for this application."
 msgstr ""
 
 #. L10n: {0} is the number of categories.
-#: src/olympia/addons/forms.py:238
+#: src/olympia/addons/forms.py:242
 msgid "You can have only {0} category."
 msgid_plural "You can have only {0} categories."
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/olympia/addons/forms.py:246
+#: src/olympia/addons/forms.py:250
 msgid "The miscellaneous category cannot be combined with additional categories."
 msgstr ""
 
-#: src/olympia/addons/forms.py:369
+#: src/olympia/addons/forms.py:374
 #, python-format
 msgid "Before changing your default locale you must have a name, summary, and description in that locale. You are missing %s."
 msgstr ""
 
-#: src/olympia/addons/forms.py:484 src/olympia/addons/forms.py:575
+#: src/olympia/addons/forms.py:455 src/olympia/addons/forms.py:546
 msgid "A license must be selected."
 msgstr ""
 
-#: src/olympia/addons/forms.py:556
+#: src/olympia/addons/forms.py:527
 msgid "Give Your Theme a Name."
 msgstr ""
 
-#: src/olympia/addons/forms.py:562 src/olympia/devhub/templates/devhub/personas/submit.html:53
+#: src/olympia/addons/forms.py:533 src/olympia/devhub/templates/devhub/personas/submit.html:53
 msgid "Describe your Theme."
 msgstr ""
 
-#: src/olympia/addons/forms.py:704
+#: src/olympia/addons/forms.py:675
 msgid "Enter a new author's email address"
 msgstr ""
 
@@ -153,37 +154,37 @@ msgstr ""
 msgid "Not Reviewed"
 msgstr ""
 
-#: src/olympia/addons/models.py:301
+#: src/olympia/addons/models.py:298
 msgid "Users have the option of contributing more or less than this amount."
 msgstr ""
 
-#: src/olympia/addons/models.py:309
-msgid "Users will always be asked in the Add-ons Manager (Firefox 4 and above)"
+#: src/olympia/addons/models.py:306
+msgid "Users will always be asked in the Add-ons Manager (Firefox 4 and above). Only applies to desktop."
 msgstr ""
 
-#: src/olympia/addons/models.py:1804 src/olympia/addons/templates/addons/details_box.html:55 src/olympia/devhub/templates/devhub/index.html:92
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:102
+#: src/olympia/addons/models.py:1802 src/olympia/addons/templates/addons/details_box.html:55 src/olympia/devhub/templates/devhub/index.html:92
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:89
 msgid "Listed"
 msgstr ""
 
-#: src/olympia/addons/views.py:320 src/olympia/browse/templates/browse/personas/mobile/category_landing.html:27
+#: src/olympia/addons/views.py:334 src/olympia/browse/templates/browse/personas/mobile/category_landing.html:27
 msgid "Popular"
 msgstr ""
 
-#: src/olympia/addons/views.py:321 src/olympia/browse/views.py:238 src/olympia/browse/views.py:280 src/olympia/browse/views.py:482
+#: src/olympia/addons/views.py:335 src/olympia/browse/views.py:205 src/olympia/browse/views.py:247 src/olympia/browse/views.py:449
 msgid "Recently Added"
 msgstr ""
 
-#: src/olympia/addons/views.py:322 src/olympia/bandwagon/views.py:99 src/olympia/browse/views.py:60 src/olympia/browse/views.py:71 src/olympia/search/forms.py:16 src/olympia/search/forms.py:91
+#: src/olympia/addons/views.py:336 src/olympia/bandwagon/views.py:99 src/olympia/browse/views.py:60 src/olympia/browse/views.py:71 src/olympia/search/forms.py:16 src/olympia/search/forms.py:91
 msgid "Recently Updated"
 msgstr ""
 
 #. l10n: {0} is the addon name
-#: src/olympia/addons/views.py:520
+#: src/olympia/addons/views.py:534
 msgid "Contribution for {0}"
 msgstr ""
 
-#: src/olympia/addons/views.py:613
+#: src/olympia/addons/views.py:627
 msgid "Abuse reported."
 msgstr ""
 
@@ -250,9 +251,9 @@ msgstr ""
 #: src/olympia/devhub/templates/devhub/addons/ajax_compat_update.html:36 src/olympia/devhub/templates/devhub/addons/profile.html:44 src/olympia/devhub/templates/devhub/addons/edit/admin.html:101
 #: src/olympia/devhub/templates/devhub/addons/edit/basic.html:152 src/olympia/devhub/templates/devhub/addons/edit/details.html:85 src/olympia/devhub/templates/devhub/addons/edit/support.html:67
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:166 src/olympia/devhub/templates/devhub/addons/forms_shared/media.html:149
-#: src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:44 src/olympia/devhub/templates/devhub/versions/add_file_modal.html:78 src/olympia/devhub/templates/devhub/versions/edit.html:139
-#: src/olympia/devhub/templates/devhub/versions/list.html:242 src/olympia/devhub/templates/devhub/versions/list.html:276 src/olympia/devhub/templates/devhub/versions/list.html:317
-#: src/olympia/devhub/templates/devhub/versions/list.html:351 src/olympia/reviews/templates/reviews/edit_review.html:16 src/olympia/translations/templates/translations/trans-menu.html:50
+#: src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:43 src/olympia/devhub/templates/devhub/versions/add_file_modal.html:58 src/olympia/devhub/templates/devhub/versions/edit.html:139
+#: src/olympia/devhub/templates/devhub/versions/list.html:239 src/olympia/devhub/templates/devhub/versions/list.html:281 src/olympia/devhub/templates/devhub/versions/list.html:315
+#: src/olympia/devhub/templates/devhub/versions/list.html:349 src/olympia/reviews/templates/reviews/edit_review.html:16 src/olympia/translations/templates/translations/trans-menu.html:50
 #: src/olympia/translations/templates/translations/trans-menu.html:62
 msgid "or"
 msgstr ""
@@ -363,7 +364,7 @@ msgid "Add-on Information for {0}"
 msgstr ""
 
 #: src/olympia/addons/templates/addons/details_box.html:30 src/olympia/addons/templates/addons/persona_detail_table.html:3 src/olympia/addons/templates/addons/mobile/details.html:63
-#: src/olympia/addons/templates/addons/mobile/persona_detail_table.html:7 src/olympia/browse/views.py:459 src/olympia/devhub/views.py:75
+#: src/olympia/addons/templates/addons/mobile/persona_detail_table.html:7 src/olympia/browse/views.py:426 src/olympia/devhub/views.py:73
 msgid "Updated"
 msgstr ""
 
@@ -382,11 +383,11 @@ msgstr ""
 msgid "Visibility"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/details_box.html:57 src/olympia/devhub/templates/devhub/index.html:94 src/olympia/devhub/templates/devhub/includes/addon_details.html:104
+#: src/olympia/addons/templates/addons/details_box.html:57 src/olympia/devhub/templates/devhub/index.html:94 src/olympia/devhub/templates/devhub/includes/addon_details.html:91
 msgid "Hidden"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/details_box.html:59 src/olympia/devhub/templates/devhub/index.html:96 src/olympia/devhub/templates/devhub/includes/addon_details.html:106
+#: src/olympia/addons/templates/addons/details_box.html:59 src/olympia/devhub/templates/devhub/index.html:96 src/olympia/devhub/templates/devhub/includes/addon_details.html:93
 msgid "Unlisted"
 msgstr ""
 
@@ -394,13 +395,13 @@ msgstr ""
 msgid "Required Add-ons"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/details_box.html:81 src/olympia/addons/templates/addons/persona_detail_table.html:15 src/olympia/browse/views.py:462 src/olympia/devhub/views.py:78
-#: src/olympia/devhub/views.py:85 src/olympia/discovery/templates/discovery/addons/detail.html:57 src/olympia/reviews/forms.py:62 src/olympia/reviews/templates/reviews/add.html:57
+#: src/olympia/addons/templates/addons/details_box.html:81 src/olympia/addons/templates/addons/persona_detail_table.html:15 src/olympia/browse/views.py:429 src/olympia/devhub/views.py:76
+#: src/olympia/devhub/views.py:83 src/olympia/discovery/templates/discovery/addons/detail.html:57 src/olympia/reviews/forms.py:62 src/olympia/reviews/templates/reviews/add.html:57
 #: src/olympia/reviews/templates/reviews/mobile/review_list.html:18
 msgid "Rating"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/details_box.html:85 src/olympia/browse/views.py:461 src/olympia/devhub/views.py:77 src/olympia/devhub/views.py:84
+#: src/olympia/addons/templates/addons/details_box.html:85 src/olympia/browse/views.py:428 src/olympia/devhub/views.py:75 src/olympia/devhub/views.py:82
 #: src/olympia/stats/templates/stats/addon_report_menu.html:8 src/olympia/stats/templates/stats/collection_report_menu.html:18
 msgid "Downloads"
 msgstr ""
@@ -420,7 +421,7 @@ msgstr ""
 
 #. The Privacy Policy for this add-on.
 #: src/olympia/addons/templates/addons/details_box.html:121 src/olympia/addons/templates/addons/privacy.html:19 src/olympia/addons/templates/addons/privacy.html:23
-#: src/olympia/addons/templates/addons/impala/button.html:43 src/olympia/addons/templates/addons/impala/details.html:307 src/olympia/devhub/templates/devhub/includes/policy_form.html:20
+#: src/olympia/addons/templates/addons/impala/button.html:43 src/olympia/addons/templates/addons/impala/details.html:312 src/olympia/devhub/templates/devhub/includes/policy_form.html:23
 #: src/olympia/templates/mobile/base_addons.html:87
 msgid "Privacy Policy"
 msgstr ""
@@ -445,7 +446,7 @@ msgstr ""
 msgid "Developer Comments"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/details_box.html:199 src/olympia/addons/templates/addons/impala/details.html:259
+#: src/olympia/addons/templates/addons/details_box.html:199 src/olympia/addons/templates/addons/impala/details.html:264
 msgid "Development Channel"
 msgstr ""
 
@@ -465,7 +466,7 @@ msgid ""
 "developer. To stop receiving development updates, reinstall the default version from the link above."
 msgstr ""
 
-#: src/olympia/addons/templates/addons/details_box.html:220 src/olympia/addons/templates/addons/impala/details.html:278
+#: src/olympia/addons/templates/addons/details_box.html:220 src/olympia/addons/templates/addons/impala/details.html:283
 msgid "Version {0}:"
 msgstr ""
 
@@ -484,7 +485,7 @@ msgid "End-User License Agreement for {0}"
 msgstr ""
 
 #: src/olympia/addons/templates/addons/eula.html:17 src/olympia/addons/templates/addons/eula.html:21 src/olympia/addons/templates/addons/impala/button.html:48
-#: src/olympia/addons/templates/addons/impala/details.html:316 src/olympia/devhub/templates/devhub/includes/policy_form.html:3 src/olympia/discovery/templates/discovery/addons/eula.html:11
+#: src/olympia/addons/templates/addons/impala/details.html:321 src/olympia/devhub/templates/devhub/includes/policy_form.html:3 src/olympia/discovery/templates/discovery/addons/eula.html:11
 msgid "End-User License Agreement"
 msgstr ""
 
@@ -501,7 +502,7 @@ msgstr ""
 msgid "Add-ons for {0}"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/home.html:10 src/olympia/addons/templates/addons/home.html:51 src/olympia/browse/templates/browse/impala/base_listing.html:11
+#: src/olympia/addons/templates/addons/home.html:10 src/olympia/addons/templates/addons/home.html:53 src/olympia/browse/templates/browse/impala/base_listing.html:11
 msgid "Featured Extensions"
 msgstr ""
 
@@ -509,29 +510,29 @@ msgstr ""
 msgid "Popular Extensions"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/home.html:42 src/olympia/amo/templates/amo/side_nav.html:3 src/olympia/amo/templates/amo/side_nav.html:11 src/olympia/amo/templates/amo/site_nav.html:3
-#: src/olympia/amo/templates/amo/site_nav.html:25 src/olympia/browse/views.py:236 src/olympia/browse/views.py:281 src/olympia/browse/views.py:481
+#: src/olympia/addons/templates/addons/home.html:44 src/olympia/amo/templates/amo/side_nav.html:3 src/olympia/amo/templates/amo/side_nav.html:11 src/olympia/amo/templates/amo/site_nav.html:3
+#: src/olympia/amo/templates/amo/site_nav.html:25 src/olympia/browse/views.py:203 src/olympia/browse/views.py:248 src/olympia/browse/views.py:448
 msgid "Most Popular"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/home.html:43
+#: src/olympia/addons/templates/addons/home.html:45
 msgid "All »"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/home.html:52 src/olympia/addons/templates/addons/home.html:61 src/olympia/addons/templates/addons/home.html:70 src/olympia/addons/templates/addons/home.html:78
+#: src/olympia/addons/templates/addons/home.html:54 src/olympia/addons/templates/addons/home.html:63 src/olympia/addons/templates/addons/home.html:72 src/olympia/addons/templates/addons/home.html:80
 #: src/olympia/browse/templates/browse/impala/category_landing.html:36
 msgid "See all »"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/home.html:60
+#: src/olympia/addons/templates/addons/home.html:62
 msgid "Up &amp; Coming Extensions"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/home.html:69 src/olympia/browse/templates/browse/personas/category_landing.html:61 src/olympia/discovery/templates/discovery/pane.html:74
+#: src/olympia/addons/templates/addons/home.html:71 src/olympia/browse/templates/browse/personas/category_landing.html:61 src/olympia/discovery/templates/discovery/pane.html:74
 msgid "Featured Themes"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/home.html:77 src/olympia/bandwagon/templates/bandwagon/impala/collection_listing.html:5
+#: src/olympia/addons/templates/addons/home.html:79 src/olympia/bandwagon/templates/bandwagon/impala/collection_listing.html:5
 msgid "Featured Collections"
 msgstr ""
 
@@ -549,7 +550,7 @@ msgid "Updated {0}"
 msgstr ""
 
 #. {0} is a date.
-#: src/olympia/addons/templates/addons/macros.html:10 src/olympia/addons/templates/addons/macros.html:69 src/olympia/addons/templates/addons/persona_preview.html:21
+#: src/olympia/addons/templates/addons/macros.html:10 src/olympia/addons/templates/addons/macros.html:69 src/olympia/addons/templates/addons/persona_preview.html:22
 #: src/olympia/addons/templates/addons/listing/items_mobile.html:44 src/olympia/addons/templates/addons/listing/macros.html:39
 #: src/olympia/bandwagon/templates/bandwagon/collection_listing_items.html:37 src/olympia/bandwagon/templates/bandwagon/impala/collection_listing_items.html:37
 msgid "Added {0}"
@@ -570,15 +571,14 @@ msgstr[0] ""
 msgstr[1] ""
 
 #. {0} is the number of downloads.
-#: src/olympia/addons/templates/addons/macros.html:53 src/olympia/addons/templates/addons/impala/details.html:61
+#: src/olympia/addons/templates/addons/macros.html:53 src/olympia/addons/templates/addons/impala/details.html:59
 msgid "{0} weekly download"
 msgid_plural "{0} weekly downloads"
 msgstr[0] ""
 msgstr[1] ""
 
 #. {0} is the number of users.
-#: src/olympia/addons/templates/addons/macros.html:61 src/olympia/addons/templates/addons/impala/details.html:54 src/olympia/compat/templates/compat/index.html:71
-#: src/olympia/zadmin/templates/zadmin/compat.html:67
+#: src/olympia/addons/templates/addons/macros.html:61 src/olympia/addons/templates/addons/impala/details.html:52 src/olympia/zadmin/templates/zadmin/compat.html:67
 msgid "{0} user"
 msgid_plural "{0} users"
 msgstr[0] ""
@@ -596,7 +596,7 @@ msgstr ""
 msgid "Return to the addon."
 msgstr ""
 
-#: src/olympia/addons/templates/addons/persona_detail.html:17 src/olympia/addons/templates/addons/impala/details.html:106 src/olympia/addons/templates/addons/mobile/details.html:23
+#: src/olympia/addons/templates/addons/persona_detail.html:17 src/olympia/addons/templates/addons/impala/details.html:103 src/olympia/addons/templates/addons/mobile/details.html:23
 #: src/olympia/addons/templates/addons/mobile/persona_detail.html:21 src/olympia/discovery/templates/discovery/addons/base.html:27 src/olympia/editors/templates/editors/review.html:31
 msgid "by"
 msgstr ""
@@ -640,34 +640,35 @@ msgstr ""
 msgid "License"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/persona_preview.html:12 src/olympia/constants/base.py:48
+#: src/olympia/addons/templates/addons/persona_preview.html:13 src/olympia/constants/base.py:48
 msgid "Awaiting Review"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/persona_preview.html:14 src/olympia/amo/log.py:180 src/olympia/constants/base.py:42 src/olympia/editors/helpers.py:62
+#: src/olympia/addons/templates/addons/persona_preview.html:15 src/olympia/amo/log.py:180 src/olympia/constants/base.py:42 src/olympia/editors/helpers.py:62
 msgid "Rejected"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/persona_preview.html:16 src/olympia/amo/log.py:159
+#: src/olympia/addons/templates/addons/persona_preview.html:17 src/olympia/amo/log.py:159
 msgid "Approved"
 msgstr ""
 
 #. {0} is the number of users.
-#: src/olympia/addons/templates/addons/persona_preview.html:26 src/olympia/addons/templates/addons/listing/items_mobile.html:36 src/olympia/addons/templates/addons/listing/macros.html:31
+#: src/olympia/addons/templates/addons/persona_preview.html:27 src/olympia/addons/templates/addons/listing/items_mobile.html:36 src/olympia/addons/templates/addons/listing/macros.html:31
 msgid "<strong>{0}</strong> user"
 msgid_plural "<strong>{0}</strong> users"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/olympia/addons/templates/addons/persona_preview.html:40
+#: src/olympia/addons/templates/addons/persona_preview.html:41
 msgid "Hover to Preview"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/persona_preview.html:46 src/olympia/addons/templates/addons/persona_preview.html:48 src/olympia/reviews/templates/reviews/add.html:15
+#: src/olympia/addons/templates/addons/persona_preview.html:47 src/olympia/addons/templates/addons/persona_preview.html:49 src/olympia/addons/templates/addons/persona_preview.html:97
+#: src/olympia/reviews/templates/reviews/add.html:15
 msgid "Add"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/persona_preview.html:57 src/olympia/bandwagon/templates/bandwagon/ajax_new.html:16 src/olympia/bandwagon/templates/bandwagon/edit.html:19
+#: src/olympia/addons/templates/addons/persona_preview.html:58 src/olympia/bandwagon/templates/bandwagon/ajax_new.html:16 src/olympia/bandwagon/templates/bandwagon/edit.html:19
 #: src/olympia/bandwagon/templates/bandwagon/includes/addedit.html:19 src/olympia/devhub/templates/devhub/addons/edit/admin.html:13 src/olympia/devhub/templates/devhub/addons/edit/basic.html:10
 #: src/olympia/devhub/templates/devhub/addons/edit/details.html:8 src/olympia/devhub/templates/devhub/addons/edit/media.html:6 src/olympia/devhub/templates/devhub/addons/edit/support.html:8
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:9 src/olympia/devhub/templates/devhub/addons/submit/describe.html:29 src/olympia/editors/templates/editors/review.html:257
@@ -676,21 +677,21 @@ msgstr ""
 
 #. For datetime formatting, see the table on
 #. http://docs.python.org/library/datetime.html#strftime-and-strptime-behavior
-#: src/olympia/addons/templates/addons/persona_preview.html:66
+#: src/olympia/addons/templates/addons/persona_preview.html:67
 #, python-format
 msgid "%%Y-%%m-%%d"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/persona_preview.html:67
+#: src/olympia/addons/templates/addons/persona_preview.html:68
 msgid "by {0} on {1}"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/persona_preview.html:75 src/olympia/reviews/helpers.py:17 src/olympia/reviews/templates/reviews/review_list.html:63
+#: src/olympia/addons/templates/addons/persona_preview.html:76 src/olympia/reviews/helpers.py:17 src/olympia/reviews/templates/reviews/review_list.html:63
 #: src/olympia/reviews/templates/reviews/reviews_link.html:21 src/olympia/reviews/templates/reviews/impala/reviews_link.html:16
 msgid "Not yet rated"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/persona_preview.html:78
+#: src/olympia/addons/templates/addons/persona_preview.html:79
 msgid "<b>{0}</b> users"
 msgstr ""
 
@@ -703,7 +704,7 @@ msgid "Learn more about Firefox"
 msgstr ""
 
 #: src/olympia/addons/templates/addons/popups.html:22
-msgid "or <b><a class=\"installer\" href=\"{url}\">download anyway</a></b>"
+msgid "or <b><a class=\"button installer\" href=\"{url}\">download anyway</a></b>"
 msgstr ""
 
 #: src/olympia/addons/templates/addons/popups.html:26
@@ -802,7 +803,7 @@ msgid ""
 msgstr ""
 
 #: src/olympia/addons/templates/addons/report_abuse.html:6 src/olympia/addons/templates/addons/report_abuse_full.html:10 src/olympia/addons/templates/addons/impala/details-more.html:23
-#: src/olympia/addons/templates/addons/impala/details.html:328
+#: src/olympia/addons/templates/addons/impala/details.html:333
 msgid "Report Abuse"
 msgstr ""
 
@@ -821,9 +822,9 @@ msgstr ""
 #: src/olympia/devhub/templates/devhub/addons/ajax_compat_update.html:36 src/olympia/devhub/templates/devhub/addons/profile.html:44 src/olympia/devhub/templates/devhub/addons/edit/admin.html:104
 #: src/olympia/devhub/templates/devhub/addons/edit/basic.html:155 src/olympia/devhub/templates/devhub/addons/edit/details.html:88 src/olympia/devhub/templates/devhub/addons/edit/support.html:70
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:169 src/olympia/devhub/templates/devhub/addons/forms_shared/media.html:152
-#: src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:44 src/olympia/devhub/templates/devhub/personas/edit.html:222 src/olympia/devhub/templates/devhub/versions/add_file_modal.html:79
-#: src/olympia/devhub/templates/devhub/versions/edit.html:140 src/olympia/devhub/templates/devhub/versions/list.html:208 src/olympia/devhub/templates/devhub/versions/list.html:242
-#: src/olympia/devhub/templates/devhub/versions/list.html:276 src/olympia/devhub/templates/devhub/versions/list.html:317 src/olympia/reviews/templates/reviews/edit_review.html:16
+#: src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:43 src/olympia/devhub/templates/devhub/personas/edit.html:222 src/olympia/devhub/templates/devhub/versions/add_file_modal.html:59
+#: src/olympia/devhub/templates/devhub/versions/edit.html:140 src/olympia/devhub/templates/devhub/versions/list.html:208 src/olympia/devhub/templates/devhub/versions/list.html:239
+#: src/olympia/devhub/templates/devhub/versions/list.html:281 src/olympia/devhub/templates/devhub/versions/list.html:315 src/olympia/reviews/templates/reviews/edit_review.html:16
 #: src/olympia/translations/templates/translations/trans-menu.html:50 src/olympia/translations/templates/translations/trans-menu.html:62 src/olympia/zadmin/templates/zadmin/validation.html:105
 msgid "Cancel"
 msgstr ""
@@ -868,7 +869,7 @@ msgstr ""
 msgid "Review Guidelines"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/review_list_box.html:5 src/olympia/addons/templates/addons/impala/details-more.html:27 src/olympia/editors/helpers.py:921
+#: src/olympia/addons/templates/addons/review_list_box.html:5 src/olympia/addons/templates/addons/impala/details-more.html:27 src/olympia/editors/helpers.py:1001
 #: src/olympia/reviews/templates/reviews/add.html:14 src/olympia/reviews/templates/reviews/reply.html:14 src/olympia/reviews/templates/reviews/review_list.html:19
 #: src/olympia/reviews/templates/reviews/mobile/review_list.html:26
 msgid "Reviews"
@@ -959,119 +960,119 @@ msgid_plural "Other add-ons by these authors"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/olympia/addons/templates/addons/impala/details.html:41
+#: src/olympia/addons/templates/addons/impala/details.html:39
 #, python-format
 msgid "<span itemprop=\"ratingCount\">%(num)s</span> user review"
 msgid_plural "<span itemprop=\"ratingCount\">%(num)s</span> user reviews"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/olympia/addons/templates/addons/impala/details.html:69
+#: src/olympia/addons/templates/addons/impala/details.html:66
 msgid "View statistics"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/impala/details.html:84
+#: src/olympia/addons/templates/addons/impala/details.html:81
 msgid "Manage"
 msgstr ""
 
 #. {0} is an add-on name.
-#: src/olympia/addons/templates/addons/impala/details.html:96
+#: src/olympia/addons/templates/addons/impala/details.html:93
 msgid "Icon of {0}"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/impala/details.html:103 src/olympia/addons/templates/addons/impala/listing/items.html:14
+#: src/olympia/addons/templates/addons/impala/details.html:100 src/olympia/addons/templates/addons/impala/listing/items.html:14
 msgid "No Restart"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/impala/details.html:127
+#: src/olympia/addons/templates/addons/impala/details.html:124
 #, python-format
 msgid "Meet the Developer: <a href=\"%(url)s\">%(name)s</a>"
 msgid_plural "<a href=\"%(url)s\">Meet the Developers</a>"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/olympia/addons/templates/addons/impala/details.html:137
+#: src/olympia/addons/templates/addons/impala/details.html:134
 msgid "Learn why {0} was created and find out what's next for this add-on."
 msgstr ""
 
 #. {0} is an index.
-#: src/olympia/addons/templates/addons/impala/details.html:156
+#: src/olympia/addons/templates/addons/impala/details.html:161
 msgid "Add-on screenshot #{0}"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/impala/details.html:182
+#: src/olympia/addons/templates/addons/impala/details.html:187
 msgid "Add-on home page"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/impala/details.html:185
+#: src/olympia/addons/templates/addons/impala/details.html:190
 msgid "Support site"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/impala/details.html:189
+#: src/olympia/addons/templates/addons/impala/details.html:194
 msgid "Support E-mail"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/impala/details.html:194 src/olympia/devhub/models.py:378 src/olympia/devhub/templates/devhub/versions/list.html:12
+#: src/olympia/addons/templates/addons/impala/details.html:199 src/olympia/devhub/models.py:378 src/olympia/devhub/templates/devhub/versions/list.html:12
 #: src/olympia/versions/templates/versions/version.html:6 src/olympia/versions/templates/versions/mobile/version.html:6
 msgid "Version {0}"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/impala/details.html:194
+#: src/olympia/addons/templates/addons/impala/details.html:199
 msgid "Info"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/impala/details.html:195 src/olympia/devhub/templates/devhub/includes/addon_details.html:129
+#: src/olympia/addons/templates/addons/impala/details.html:200 src/olympia/devhub/templates/devhub/includes/addon_details.html:116
 msgid "Last Updated:"
-msgstr ""
-
-#: src/olympia/addons/templates/addons/impala/details.html:200
-#, python-format
-msgid "Released under <a target=\"_blank\" href=\"%(url)s\">%(name)s</a>"
-msgstr ""
-
-#: src/olympia/addons/templates/addons/impala/details.html:201 src/olympia/addons/templates/addons/impala/details.html:206 src/olympia/amo/helpers.py:398 src/olympia/devhub/forms.py:142
-#: src/olympia/devhub/forms.py:173 src/olympia/versions/templates/versions/version.html:40 src/olympia/versions/templates/versions/version.html:45
-msgid "Custom License"
 msgstr ""
 
 #: src/olympia/addons/templates/addons/impala/details.html:205
 #, python-format
+msgid "Released under <a target=\"_blank\" href=\"%(url)s\">%(name)s</a>"
+msgstr ""
+
+#: src/olympia/addons/templates/addons/impala/details.html:206 src/olympia/addons/templates/addons/impala/details.html:211 src/olympia/amo/helpers.py:398 src/olympia/devhub/forms.py:142
+#: src/olympia/devhub/forms.py:173 src/olympia/versions/templates/versions/version.html:40 src/olympia/versions/templates/versions/version.html:45
+msgid "Custom License"
+msgstr ""
+
+#: src/olympia/addons/templates/addons/impala/details.html:210
+#, python-format
 msgid "Released under <a href=\"%(url)s\">%(name)s</a>"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/impala/details.html:217
+#: src/olympia/addons/templates/addons/impala/details.html:222
 msgid "About this Add-on"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/impala/details.html:233
+#: src/olympia/addons/templates/addons/impala/details.html:238
 msgid "Developer’s Comments"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/impala/details.html:243
+#: src/olympia/addons/templates/addons/impala/details.html:248
 msgid "Version Information"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/impala/details.html:250
+#: src/olympia/addons/templates/addons/impala/details.html:255
 msgid "See complete version history"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/impala/details.html:262
+#: src/olympia/addons/templates/addons/impala/details.html:267
 msgid ""
 "The Development Channel lets you test an experimental new version of this add-on before it's released to the general public. Once you install the development version, you will continue to get "
 "updates from this channel. To stop receiving development updates, reinstall the default version from the link above."
 msgstr ""
 
-#: src/olympia/addons/templates/addons/impala/details.html:272
+#: src/olympia/addons/templates/addons/impala/details.html:277
 msgid "<strong>Caution:</strong> Development versions of this add-on have not been reviewed by Mozilla."
 msgstr ""
 
-#: src/olympia/addons/templates/addons/impala/details.html:287
+#: src/olympia/addons/templates/addons/impala/details.html:292
 msgid "See complete development channel history"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/impala/details.html:306 src/olympia/addons/templates/addons/impala/details.html:315 src/olympia/addons/templates/addons/impala/details.html:327
+#: src/olympia/addons/templates/addons/impala/details.html:311 src/olympia/addons/templates/addons/impala/details.html:320 src/olympia/addons/templates/addons/impala/details.html:332
 #: src/olympia/addons/templates/addons/impala/review_add_box.html:4 src/olympia/stats/templates/stats/popup.html:2 src/olympia/stats/templates/stats/popup.html:8
-#: src/olympia/stats/templates/stats/stats.html:202 src/olympia/users/templates/users/profile.html:119
+#: src/olympia/stats/templates/stats/stats.html:204 src/olympia/users/templates/users/profile.html:119
 msgid "close"
 msgstr ""
 
@@ -1127,15 +1128,11 @@ msgstr ""
 msgid "Source Code License"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/impala/persona_grid.html:16 src/olympia/addons/templates/addons/impala/toplist.html:6
-msgid "{0} users"
-msgstr ""
-
 #: src/olympia/addons/templates/addons/impala/review_list_box.html:19 src/olympia/reviews/templates/reviews/review.html:40
 msgid "permalink"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/impala/review_list_box.html:23 src/olympia/editors/templates/editors/queue.html:98 src/olympia/reviews/templates/reviews/review.html:44
+#: src/olympia/addons/templates/addons/impala/review_list_box.html:23 src/olympia/editors/templates/editors/queue.html:104 src/olympia/reviews/templates/reviews/review.html:44
 msgid "translate"
 msgstr ""
 
@@ -1154,6 +1151,10 @@ msgstr ""
 msgid "Be the first!"
 msgstr ""
 
+#: src/olympia/addons/templates/addons/impala/toplist.html:6
+msgid "{0} users"
+msgstr ""
+
 #: src/olympia/addons/templates/addons/impala/listing/sorter.html:14 src/olympia/devhub/templates/devhub/addons/listing/item_actions.html:49
 msgid "More"
 msgstr ""
@@ -1166,7 +1167,7 @@ msgstr ""
 msgid "My Add-ons"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/includes/dashboard_tabs.html:6 src/olympia/amo/context_processors.py:51
+#: src/olympia/addons/templates/addons/includes/dashboard_tabs.html:6 src/olympia/amo/context_processors.py:50
 msgid "My Themes"
 msgstr ""
 
@@ -1221,7 +1222,7 @@ msgstr ""
 msgid "Weekly Downloads"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/mobile/details.html:99 src/olympia/compat/templates/compat/reporter_detail.html:46 src/olympia/devhub/forms.py:787
+#: src/olympia/addons/templates/addons/mobile/details.html:99 src/olympia/compat/templates/compat/reporter_detail.html:46 src/olympia/devhub/forms.py:788
 #: src/olympia/devhub/templates/devhub/versions/list.html:163
 msgid "Version"
 msgstr ""
@@ -1305,7 +1306,7 @@ msgstr ""
 #: src/olympia/browse/templates/browse/personas/category_landing.html:21 src/olympia/browse/templates/browse/personas/category_landing.html:23
 #: src/olympia/browse/templates/browse/personas/category_landing.html:38 src/olympia/browse/templates/browse/personas/grid.html:7 src/olympia/browse/templates/browse/personas/grid.html:11
 #: src/olympia/browse/templates/browse/personas/mobile/base.html:7 src/olympia/browse/templates/browse/personas/mobile/category_landing.html:19 src/olympia/constants/base.py:180
-#: src/olympia/devhub/templates/devhub/personas/submit.html:13 src/olympia/editors/helpers.py:105 src/olympia/editors/templates/editors/base.html:26
+#: src/olympia/devhub/templates/devhub/personas/submit.html:13 src/olympia/editors/helpers.py:107 src/olympia/editors/templates/editors/base.html:26
 #: src/olympia/editors/templates/editors/performance.html:73 src/olympia/search/templates/search/personas.html:39 src/olympia/templates/menu_links.html:9
 msgid "Themes"
 msgstr ""
@@ -1326,7 +1327,7 @@ msgstr ""
 msgid "Highest Rated"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/mobile/home.html:74 src/olympia/amo/templates/amo/side_nav.html:5 src/olympia/amo/templates/amo/site_nav.html:27 src/olympia/amo/templates/amo/site_nav.html:57
+#: src/olympia/addons/templates/addons/mobile/home.html:74 src/olympia/amo/templates/amo/side_nav.html:5 src/olympia/amo/templates/amo/site_nav.html:27 src/olympia/amo/templates/amo/site_nav.html:55
 #: src/olympia/bandwagon/views.py:97 src/olympia/browse/views.py:57 src/olympia/browse/views.py:67 src/olympia/browse/templates/browse/personas/mobile/category_landing.html:65
 #: src/olympia/search/forms.py:15 src/olympia/search/forms.py:87
 msgid "Newest"
@@ -1340,90 +1341,90 @@ msgstr ""
 msgid "Theme Info &raquo;"
 msgstr ""
 
-#: src/olympia/amo/context_processors.py:39 src/olympia/devhub/templates/devhub/nav.html:43
+#: src/olympia/amo/context_processors.py:37 src/olympia/devhub/templates/devhub/nav.html:43
 msgid "Tools"
 msgstr ""
 
-#: src/olympia/amo/context_processors.py:48 src/olympia/discovery/templates/discovery/pane_account.html:8 src/olympia/users/templates/users/includes/navigation.html:2
+#: src/olympia/amo/context_processors.py:47 src/olympia/discovery/templates/discovery/pane_account.html:8 src/olympia/users/templates/users/includes/navigation.html:2
 msgid "My Profile"
 msgstr ""
 
-#: src/olympia/amo/context_processors.py:54 src/olympia/users/templates/users/edit.html:5 src/olympia/users/templates/users/includes/navigation.html:3
+#: src/olympia/amo/context_processors.py:53 src/olympia/users/templates/users/edit.html:5 src/olympia/users/templates/users/includes/navigation.html:3
 msgid "Account Settings"
 msgstr ""
 
-#: src/olympia/amo/context_processors.py:57 src/olympia/discovery/templates/discovery/pane_account.html:11 src/olympia/users/templates/users/profile.html:83
+#: src/olympia/amo/context_processors.py:56 src/olympia/discovery/templates/discovery/pane_account.html:11 src/olympia/users/templates/users/profile.html:83
 #: src/olympia/users/templates/users/includes/navigation.html:4
 msgid "My Collections"
 msgstr ""
 
-#: src/olympia/amo/context_processors.py:62 src/olympia/discovery/templates/discovery/pane_account.html:10 src/olympia/users/templates/users/includes/navigation.html:7
+#: src/olympia/amo/context_processors.py:61 src/olympia/discovery/templates/discovery/pane_account.html:10 src/olympia/users/templates/users/includes/navigation.html:7
 msgid "My Favorites"
 msgstr ""
 
-#: src/olympia/amo/context_processors.py:67 src/olympia/discovery/templates/discovery/pane_account.html:13 src/olympia/templates/impala/user_login.html:14
+#: src/olympia/amo/context_processors.py:66 src/olympia/discovery/templates/discovery/pane_account.html:13 src/olympia/templates/impala/user_login.html:14
 #: src/olympia/templates/mobile/header_auth.html:5
 msgid "Log out"
 msgstr ""
 
-#: src/olympia/amo/context_processors.py:72 src/olympia/devhub/templates/devhub/addons/dashboard.html:4
+#: src/olympia/amo/context_processors.py:71 src/olympia/devhub/templates/devhub/addons/dashboard.html:4
 msgid "Manage My Submissions"
 msgstr ""
 
-#: src/olympia/amo/context_processors.py:75 src/olympia/devhub/templates/devhub/nav.html:27 src/olympia/devhub/templates/devhub/addons/dashboard.html:25
+#: src/olympia/amo/context_processors.py:74 src/olympia/devhub/templates/devhub/nav.html:27 src/olympia/devhub/templates/devhub/addons/dashboard.html:25
 #: src/olympia/devhub/templates/devhub/addons/submit/base.html:4
 msgid "Submit a New Add-on"
 msgstr ""
 
-#: src/olympia/amo/context_processors.py:77 src/olympia/browse/templates/browse/personas/base.html:50 src/olympia/devhub/templates/devhub/index.html:24
+#: src/olympia/amo/context_processors.py:76 src/olympia/browse/templates/browse/personas/base.html:50 src/olympia/devhub/templates/devhub/index.html:24
 #: src/olympia/devhub/templates/devhub/addons/dashboard.html:29
 msgid "Submit a New Theme"
 msgstr ""
 
-#: src/olympia/amo/context_processors.py:79 src/olympia/amo/templates/amo/site_nav.html:87 src/olympia/devhub/helpers.py:36 src/olympia/devhub/helpers.py:68 src/olympia/devhub/helpers.py:102
+#: src/olympia/amo/context_processors.py:78 src/olympia/amo/templates/amo/site_nav.html:85 src/olympia/devhub/helpers.py:36 src/olympia/devhub/helpers.py:68 src/olympia/devhub/helpers.py:102
 #: src/olympia/templates/footer.html:6 src/olympia/templates/menu_links.html:14
 msgid "Developer Hub"
 msgstr ""
 
-#: src/olympia/amo/context_processors.py:83 src/olympia/devhub/views.py:1792
+#: src/olympia/amo/context_processors.py:81 src/olympia/devhub/views.py:1796
 msgid "Manage API Keys"
 msgstr ""
 
-#: src/olympia/amo/context_processors.py:88 src/olympia/editors/helpers.py:82 src/olympia/editors/helpers.py:102 src/olympia/editors/templates/editors/base.html:10
+#: src/olympia/amo/context_processors.py:86 src/olympia/editors/helpers.py:84 src/olympia/editors/helpers.py:104 src/olympia/editors/templates/editors/base.html:10
 msgid "Editor Tools"
 msgstr ""
 
-#: src/olympia/amo/context_processors.py:92
+#: src/olympia/amo/context_processors.py:90
 msgid "Admin Tools"
 msgstr ""
 
-#: src/olympia/amo/fields.py:15
+#: src/olympia/amo/fields.py:20
 msgid "Incorrect, please try again."
 msgstr ""
 
-#: src/olympia/amo/fields.py:16
+#: src/olympia/amo/fields.py:21
 msgid "Error verifying input, please try again."
 msgstr ""
 
-#: src/olympia/amo/fields.py:32
+#: src/olympia/amo/fields.py:37
 msgid "This must be a valid hex color code, such as #000000."
 msgstr ""
 
-#: src/olympia/amo/fields.py:58
+#: src/olympia/amo/fields.py:63
 msgid "Enter at least one value."
 msgstr ""
 
-#: src/olympia/amo/helpers.py:162 src/olympia/amo/templates/amo/site_nav.html:61 src/olympia/bandwagon/templates/bandwagon/add.html:9
+#: src/olympia/amo/helpers.py:162 src/olympia/amo/templates/amo/site_nav.html:59 src/olympia/bandwagon/templates/bandwagon/add.html:9
 #: src/olympia/bandwagon/templates/bandwagon/collection_detail.html:15 src/olympia/bandwagon/templates/bandwagon/delete.html:9 src/olympia/bandwagon/templates/bandwagon/edit.html:15
 #: src/olympia/bandwagon/templates/bandwagon/user_listing.html:18 src/olympia/bandwagon/templates/bandwagon/user_listing.html:21
 #: src/olympia/bandwagon/templates/bandwagon/impala/collection_listing.html:12 src/olympia/bandwagon/templates/bandwagon/impala/collection_listing.html:20
 #: src/olympia/bandwagon/templates/bandwagon/impala/collection_listing.html:24 src/olympia/bandwagon/templates/bandwagon/impala/collection_sidebar.html:3
 #: src/olympia/bandwagon/templates/bandwagon/includes/collection_sidebar.html:2 src/olympia/bandwagon/templates/bandwagon/mobile/collection_listing.html:3
-#: src/olympia/stats/templates/stats/stats.html:77 src/olympia/templates/menu_links.html:12
+#: src/olympia/stats/templates/stats/stats.html:33 src/olympia/templates/menu_links.html:12
 msgid "Collections"
 msgstr ""
 
-#: src/olympia/amo/helpers.py:171 src/olympia/amo/templates/amo/site_nav.html:85 src/olympia/browse/templates/browse/language_tools.html:3
+#: src/olympia/amo/helpers.py:171 src/olympia/amo/templates/amo/site_nav.html:83 src/olympia/browse/templates/browse/language_tools.html:3
 msgid "Dictionaries & Language Packs"
 msgstr ""
 
@@ -1575,8 +1576,8 @@ msgstr ""
 msgid "Comment on {addon} {version}."
 msgstr ""
 
-#: src/olympia/amo/log.py:236 src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:19 src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:47
-#: src/olympia/editors/helpers.py:511 src/olympia/editors/templates/editors/themes/history_table.html:11
+#: src/olympia/amo/log.py:236 src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:17 src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:45
+#: src/olympia/editors/helpers.py:584 src/olympia/editors/templates/editors/themes/history_table.html:11
 msgid "Comment"
 msgstr ""
 
@@ -1899,7 +1900,7 @@ msgstr ""
 #: src/olympia/amo/templates/amo/mobile/paginator.html:14 src/olympia/amo/templates/amo/mobile/paginator.html:16 src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:51
 #: src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:65 src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:78
 #: src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:91 src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:104
-#: src/olympia/discovery/templates/discovery/pane.html:45 src/olympia/discovery/templates/discovery/addons/detail.html:39 src/olympia/stats/templates/stats/stats.html:167
+#: src/olympia/discovery/templates/discovery/pane.html:45 src/olympia/discovery/templates/discovery/addons/detail.html:39 src/olympia/stats/templates/stats/stats.html:169
 msgid "Next"
 msgstr ""
 
@@ -1931,7 +1932,7 @@ msgid ""
 msgstr ""
 
 #: src/olympia/amo/templates/amo/side_nav.html:4 src/olympia/amo/templates/amo/side_nav.html:12 src/olympia/amo/templates/amo/site_nav.html:4 src/olympia/amo/templates/amo/site_nav.html:26
-#: src/olympia/browse/views.py:56 src/olympia/browse/views.py:66 src/olympia/browse/views.py:237 src/olympia/browse/views.py:282 src/olympia/search/forms.py:86
+#: src/olympia/browse/views.py:56 src/olympia/browse/views.py:66 src/olympia/browse/views.py:204 src/olympia/browse/views.py:249 src/olympia/search/forms.py:86
 msgid "Top Rated"
 msgstr ""
 
@@ -1945,38 +1946,38 @@ msgstr ""
 msgid "Extensions"
 msgstr ""
 
-#: src/olympia/amo/templates/amo/site_nav.html:45
+#: src/olympia/amo/templates/amo/site_nav.html:44
 msgid "Want more customization? Try <b>Complete Themes</b>"
 msgstr ""
 
-#: src/olympia/amo/templates/amo/site_nav.html:56 src/olympia/bandwagon/views.py:96
+#: src/olympia/amo/templates/amo/site_nav.html:54 src/olympia/bandwagon/views.py:96
 msgid "Most Followers"
 msgstr ""
 
-#: src/olympia/amo/templates/amo/site_nav.html:68 src/olympia/bandwagon/templates/bandwagon/impala/collection_sidebar.html:16
+#: src/olympia/amo/templates/amo/site_nav.html:66 src/olympia/bandwagon/templates/bandwagon/impala/collection_sidebar.html:16
 #: src/olympia/bandwagon/templates/bandwagon/includes/collection_sidebar.html:18
 msgid "Collections I've Made"
 msgstr ""
 
-#: src/olympia/amo/templates/amo/site_nav.html:70 src/olympia/bandwagon/templates/bandwagon/user_listing.html:4 src/olympia/bandwagon/templates/bandwagon/impala/collection_sidebar.html:13
+#: src/olympia/amo/templates/amo/site_nav.html:68 src/olympia/bandwagon/templates/bandwagon/user_listing.html:4 src/olympia/bandwagon/templates/bandwagon/impala/collection_sidebar.html:13
 #: src/olympia/bandwagon/templates/bandwagon/includes/collection_sidebar.html:15
 msgid "Collections I'm Following"
 msgstr ""
 
-#: src/olympia/amo/templates/amo/site_nav.html:73 src/olympia/bandwagon/templates/bandwagon/impala/collection_sidebar.html:18
-#: src/olympia/bandwagon/templates/bandwagon/includes/collection_sidebar.html:20 src/olympia/users/models.py:512
+#: src/olympia/amo/templates/amo/site_nav.html:71 src/olympia/bandwagon/templates/bandwagon/impala/collection_sidebar.html:18
+#: src/olympia/bandwagon/templates/bandwagon/includes/collection_sidebar.html:20 src/olympia/users/models.py:521
 msgid "My Favorite Add-ons"
 msgstr ""
 
-#: src/olympia/amo/templates/amo/site_nav.html:78
+#: src/olympia/amo/templates/amo/site_nav.html:76
 msgid "More&hellip;"
 msgstr ""
 
-#: src/olympia/amo/templates/amo/site_nav.html:82
+#: src/olympia/amo/templates/amo/site_nav.html:80
 msgid "Add-ons for Mobile"
 msgstr ""
 
-#: src/olympia/amo/templates/amo/site_nav.html:86 src/olympia/browse/feeds.py:207 src/olympia/browse/templates/browse/search_tools.html:3 src/olympia/constants/base.py:176
+#: src/olympia/amo/templates/amo/site_nav.html:84 src/olympia/browse/feeds.py:207 src/olympia/browse/templates/browse/search_tools.html:3 src/olympia/constants/base.py:176
 #: src/olympia/templates/menu_links.html:10
 msgid "Search Tools"
 msgstr ""
@@ -1992,7 +1993,7 @@ msgid "Jump to first page"
 msgstr ""
 
 #: src/olympia/amo/templates/amo/impala/paginator.html:22 src/olympia/amo/templates/amo/mobile/impala_paginator.html:12 src/olympia/discovery/templates/discovery/pane.html:44
-#: src/olympia/discovery/templates/discovery/addons/detail.html:38 src/olympia/stats/templates/stats/stats.html:164
+#: src/olympia/discovery/templates/discovery/addons/detail.html:38 src/olympia/stats/templates/stats/stats.html:166
 msgid "Previous"
 msgstr ""
 
@@ -2015,30 +2016,49 @@ msgid_plural "Page {n}"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/olympia/amo/templates/services/install.html:38
-#, python-format
-msgid "If you are not prompted to install %(addon_name)s in a moment, please <a href=\"%(addon_xpi)s\">click here</a>."
-msgstr ""
-
-#: src/olympia/amo/tests/test_messages.py:57 src/olympia/amo/tests/test_messages.py:58 src/olympia/reviews/forms.py:25 src/olympia/reviews/forms.py:50 src/olympia/reviews/templates/reviews/add.html:56
+#: src/olympia/amo/tests/test_messages.py:56 src/olympia/amo/tests/test_messages.py:57 src/olympia/reviews/forms.py:25 src/olympia/reviews/forms.py:50 src/olympia/reviews/templates/reviews/add.html:56
 #: src/olympia/reviews/templates/reviews/reply.html:30
 msgid "Title"
 msgstr ""
 
-#: src/olympia/amo/tests/test_messages.py:57 src/olympia/amo/tests/test_messages.py:58
+#: src/olympia/amo/tests/test_messages.py:56 src/olympia/amo/tests/test_messages.py:57
 msgid "Body"
 msgstr ""
 
-#: src/olympia/amo/tests/test_messages.py:59
+#: src/olympia/amo/tests/test_messages.py:58
 msgid "Another Title"
 msgstr ""
 
-#: src/olympia/amo/tests/test_messages.py:59
+#: src/olympia/amo/tests/test_messages.py:58
 msgid "Another Body"
 msgstr ""
 
-#: src/olympia/api/views.py:255
-msgid "Not implemented yet."
+#: src/olympia/api/authentication.py:76
+msgid "Signature has expired."
+msgstr ""
+
+#: src/olympia/api/authentication.py:79
+msgid "Error decoding signature."
+msgstr ""
+
+#: src/olympia/api/authentication.py:82
+msgid "Invalid JWT Token."
+msgstr ""
+
+#: src/olympia/api/authentication.py:130
+msgid "Invalid Authorization header. No credentials provided."
+msgstr ""
+
+#: src/olympia/api/authentication.py:133
+msgid "Invalid Authorization header. Credentials string should not contain spaces."
+msgstr ""
+
+#: src/olympia/api/fields.py:29
+msgid "The field must have a length of at least {num} characters."
+msgstr ""
+
+#: src/olympia/api/fields.py:31
+msgid "The language code {lang_code} is invalid."
 msgstr ""
 
 #: src/olympia/applications/views.py:39 src/olympia/applications/templates/applications/appversions.html:3
@@ -2057,7 +2077,7 @@ msgstr ""
 msgid "Add-ons submitted to Mozilla Add-ons must have a manifest file with at least one of the below applications supported. Only the versions listed below are allowed for these applications."
 msgstr ""
 
-#: src/olympia/applications/templates/applications/appversions.html:25
+#: src/olympia/applications/templates/applications/appversions.html:25 src/olympia/editors/helpers.py:361
 msgid "GUID"
 msgstr ""
 
@@ -2171,8 +2191,8 @@ msgstr ""
 msgid "Remove from favorites"
 msgstr ""
 
-#: src/olympia/bandwagon/views.py:98 src/olympia/bandwagon/views.py:191 src/olympia/browse/views.py:58 src/olympia/browse/views.py:69 src/olympia/browse/views.py:458 src/olympia/devhub/views.py:74
-#: src/olympia/devhub/views.py:82 src/olympia/devhub/templates/devhub/addons/edit/basic.html:20 src/olympia/editors/templates/editors/leaderboard.html:24
+#: src/olympia/bandwagon/views.py:98 src/olympia/bandwagon/views.py:191 src/olympia/browse/views.py:58 src/olympia/browse/views.py:69 src/olympia/browse/views.py:425 src/olympia/devhub/views.py:72
+#: src/olympia/devhub/views.py:80 src/olympia/devhub/templates/devhub/addons/edit/basic.html:20 src/olympia/editors/templates/editors/leaderboard.html:24
 #: src/olympia/editors/templates/editors/themes/queue_list.html:48 src/olympia/search/forms.py:17 src/olympia/search/forms.py:89 src/olympia/users/templates/users/vcard.html:5
 msgid "Name"
 msgstr ""
@@ -2181,7 +2201,7 @@ msgstr ""
 msgid "Recently Popular"
 msgstr ""
 
-#: src/olympia/bandwagon/views.py:189 src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:18
+#: src/olympia/bandwagon/views.py:189 src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:16
 msgid "Added"
 msgstr ""
 
@@ -2195,7 +2215,7 @@ msgstr ""
 
 #: src/olympia/bandwagon/views.py:316
 #, python-format
-msgid "Your new collection is shown below. You can <ahref=\"%(url)s\">edit additional settings</a> if you'dlike."
+msgid "Your new collection is shown below. You can <a href=\"%(url)s\">edit additional settings</a> if you'd like."
 msgstr ""
 
 #: src/olympia/bandwagon/views.py:322
@@ -2323,8 +2343,8 @@ msgid_plural "%(num)s Add-ons in this Collection"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/olympia/bandwagon/templates/bandwagon/collection_detail.html:125 src/olympia/compat/templates/compat/index.html:25 src/olympia/compat/templates/compat/reporter_detail.html:29
-#: src/olympia/files/templates/files/viewer.html:29 src/olympia/templates/amo_footer.html:17 src/olympia/templates/includes/lang_switcher.html:10
+#: src/olympia/bandwagon/templates/bandwagon/collection_detail.html:125 src/olympia/compat/templates/compat/reporter_detail.html:29 src/olympia/files/templates/files/viewer.html:29
+#: src/olympia/templates/amo_footer.html:17 src/olympia/templates/includes/lang_switcher.html:10
 msgid "Go"
 msgstr ""
 
@@ -2491,7 +2511,7 @@ msgid "Remove this user as a contributor"
 msgstr ""
 
 #: src/olympia/bandwagon/templates/bandwagon/edit_contributors.html:18 src/olympia/bandwagon/templates/bandwagon/edit_contributors.html:43
-#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:20 src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:48
+#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:18 src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:46
 #: src/olympia/devhub/templates/devhub/addons/ajax_compat_update.html:19
 msgid "Remove"
 msgstr ""
@@ -2539,7 +2559,7 @@ msgid "<b>Warning:</b> By changing the owner of this collection, you will no lon
 msgstr ""
 
 #: src/olympia/bandwagon/templates/bandwagon/edit_contributors.html:83 src/olympia/devhub/templates/devhub/addons/forms_shared/media.html:157
-#: src/olympia/devhub/templates/devhub/addons/submit/describe.html:69 src/olympia/devhub/templates/devhub/addons/submit/license.html:60 src/olympia/devhub/templates/devhub/addons/submit/upload.html:78
+#: src/olympia/devhub/templates/devhub/addons/submit/describe.html:69 src/olympia/devhub/templates/devhub/addons/submit/license.html:60 src/olympia/devhub/templates/devhub/addons/submit/upload.html:70
 #: src/olympia/devhub/templates/devhub/payments/tier.html:17 src/olympia/editors/templates/editors/themes/themes.html:111 src/olympia/editors/templates/editors/themes/themes.html:128
 #: src/olympia/editors/templates/editors/themes/themes.html:134 src/olympia/editors/templates/editors/themes/themes.html:141 src/olympia/users/templates/users/fxa_migration_prompt_content.html:10
 #: src/olympia/users/templates/users/login_form.html:42 src/olympia/users/templates/users/mobile/login.html:57
@@ -2622,31 +2642,31 @@ msgid "Add-ons in Your Collection"
 msgstr ""
 
 #: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:4
-msgid ""
-"To include an add-on in this collection, enter its name in the box below and hit enter.  You can also use the <strong>Add to Collection</strong> links throughout the site to include add-ons later."
+msgid "To include an add-on in this collection, enter its name in the box below and hit enter."
 msgstr ""
 
-#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:17 src/olympia/constants/base.py:400 src/olympia/devhub/templates/devhub/addons/activity.html:62
+#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:15 src/olympia/constants/base.py:400 src/olympia/devhub/templates/devhub/addons/activity.html:62
+#: src/olympia/editors/helpers.py:273 src/olympia/editors/helpers.py:360
 msgid "Add-on"
 msgstr ""
 
-#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:26
+#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:24
 msgid "Enter the name of the add-on to include"
 msgstr ""
 
-#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:28
+#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:26
 msgid "Add to Collection"
 msgstr ""
 
-#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:45 src/olympia/editors/helpers.py:936 src/olympia/editors/helpers.py:956
+#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:43 src/olympia/editors/helpers.py:1016 src/olympia/editors/helpers.py:1036
 msgid "Pending"
 msgstr ""
 
-#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:47
+#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:45
 msgid "Add a comment"
 msgstr ""
 
-#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:48
+#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:46
 msgid "Remove this add-on from the collection"
 msgstr ""
 
@@ -2753,12 +2773,12 @@ msgstr ""
 msgid "Most Users"
 msgstr ""
 
-#: src/olympia/browse/views.py:61 src/olympia/browse/views.py:72 src/olympia/browse/views.py:279 src/olympia/browse/templates/browse/personas/mobile/category_landing.html:63
+#: src/olympia/browse/views.py:61 src/olympia/browse/views.py:72 src/olympia/browse/views.py:246 src/olympia/browse/templates/browse/personas/mobile/category_landing.html:63
 #: src/olympia/discovery/templates/discovery/pane.html:67 src/olympia/search/forms.py:92
 msgid "Up & Coming"
 msgstr ""
 
-#: src/olympia/browse/views.py:460 src/olympia/devhub/views.py:76 src/olympia/devhub/views.py:83 src/olympia/discovery/templates/discovery/addons/detail.html:66
+#: src/olympia/browse/views.py:427 src/olympia/devhub/views.py:74 src/olympia/devhub/views.py:81 src/olympia/discovery/templates/discovery/addons/detail.html:66
 msgid "Created"
 msgstr ""
 
@@ -2946,8 +2966,8 @@ msgid_plural "See all %(cnt)s extensions in %(name)s &raquo;"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/olympia/browse/templates/browse/mobile/extensions.html:13 src/olympia/compat/templates/compat/index.html:82 src/olympia/devhub/templates/devhub/devhub_search.html:24
-#: src/olympia/devhub/templates/devhub/addons/activity.html:47 src/olympia/search/templates/search/no_results.html:4 src/olympia/search/templates/search/mobile/results.html:36
+#: src/olympia/browse/templates/browse/mobile/extensions.html:13 src/olympia/devhub/templates/devhub/devhub_search.html:24 src/olympia/devhub/templates/devhub/addons/activity.html:47
+#: src/olympia/search/templates/search/no_results.html:4 src/olympia/search/templates/search/mobile/results.html:36
 msgid "No results found."
 msgstr ""
 
@@ -3032,7 +3052,7 @@ msgstr ""
 msgid "All"
 msgstr ""
 
-#: src/olympia/compat/forms.py:22 src/olympia/search/views.py:525
+#: src/olympia/compat/forms.py:22 src/olympia/editors/templates/editors/base.html:69 src/olympia/search/views.py:518
 msgid "All Add-ons"
 msgstr ""
 
@@ -3042,53 +3062,6 @@ msgstr ""
 
 #: src/olympia/compat/forms.py:24
 msgid "Non-binary"
-msgstr ""
-
-#. Review points sources other than add-ons and themes.
-#: src/olympia/compat/views.py:87 src/olympia/constants/base.py:388 src/olympia/devhub/forms.py:162 src/olympia/editors/templates/editors/performance.html:75
-msgid "Other"
-msgstr ""
-
-#: src/olympia/compat/templates/compat/index.html:4
-msgid "Add-on Compatibility Report for {app} {version}"
-msgstr ""
-
-#: src/olympia/compat/templates/compat/index.html:11
-msgid "{app} {version} Compatibility"
-msgstr ""
-
-#: src/olympia/compat/templates/compat/index.html:17
-#, python-format
-msgid "Top 95%% compatible with previous version"
-msgstr ""
-
-#: src/olympia/compat/templates/compat/index.html:18
-#, python-format
-msgid "Top 95%% of all add-ons"
-msgstr ""
-
-#: src/olympia/compat/templates/compat/index.html:19
-msgid "All active add-ons"
-msgstr ""
-
-#: src/olympia/compat/templates/compat/index.html:23 src/olympia/constants/base.py:401
-msgid "App"
-msgstr ""
-
-#: src/olympia/compat/templates/compat/index.html:55
-msgid "Details for add-ons compatible with previous version:"
-msgstr ""
-
-#: src/olympia/compat/templates/compat/index.html:57
-msgid "Show all versions"
-msgstr ""
-
-#: src/olympia/compat/templates/compat/index.html:59
-msgid "Details for add-ons compatible with all versions:"
-msgstr ""
-
-#: src/olympia/compat/templates/compat/index.html:61
-msgid "Show previous version only"
 msgstr ""
 
 #: src/olympia/compat/templates/compat/reporter.html:3
@@ -3142,8 +3115,8 @@ msgstr ""
 msgid "Report Type"
 msgstr ""
 
-#: src/olympia/compat/templates/compat/reporter_detail.html:47 src/olympia/devhub/forms.py:784 src/olympia/devhub/templates/devhub/addons/ajax_compat_update.html:17 src/olympia/editors/forms.py:108
-#: src/olympia/zadmin/forms.py:45
+#: src/olympia/compat/templates/compat/reporter_detail.html:47 src/olympia/devhub/forms.py:785 src/olympia/devhub/templates/devhub/addons/ajax_compat_update.html:17 src/olympia/editors/forms.py:108
+#: src/olympia/editors/forms.py:248 src/olympia/zadmin/forms.py:45
 msgid "Application"
 msgstr ""
 
@@ -3231,7 +3204,8 @@ msgstr ""
 msgid "Preliminarily Reviewed and Awaiting Full Review"
 msgstr ""
 
-#: src/olympia/constants/base.py:33 src/olympia/editors/helpers.py:924 src/olympia/editors/templates/editors/themes/history_table.html:34
+#: src/olympia/constants/base.py:33 src/olympia/editors/forms.py:258 src/olympia/editors/helpers.py:73 src/olympia/editors/helpers.py:1004
+#: src/olympia/editors/templates/editors/themes/history_table.html:34
 msgid "Deleted"
 msgstr ""
 
@@ -3328,6 +3302,11 @@ msgstr ""
 msgid "Ask before users can download this add-on"
 msgstr ""
 
+#. Review points sources other than add-ons and themes.
+#: src/olympia/constants/base.py:388 src/olympia/devhub/forms.py:162 src/olympia/editors/templates/editors/performance.html:75
+msgid "Other"
+msgstr ""
+
 #: src/olympia/constants/base.py:389
 msgid "Exception"
 msgstr ""
@@ -3338,6 +3317,10 @@ msgstr ""
 
 #: src/olympia/constants/base.py:391
 msgid "Change"
+msgstr ""
+
+#: src/olympia/constants/base.py:401
+msgid "App"
 msgstr ""
 
 #: src/olympia/constants/base.py:402
@@ -3488,7 +3471,7 @@ msgstr ""
 msgid "Duplicate"
 msgstr ""
 
-#: src/olympia/constants/editors.py:17 src/olympia/editors/helpers.py:502 src/olympia/editors/templates/editors/themes/queue.html:71 src/olympia/editors/templates/editors/themes/themes.html:94
+#: src/olympia/constants/editors.py:17 src/olympia/editors/helpers.py:575 src/olympia/editors/templates/editors/themes/queue.html:71 src/olympia/editors/templates/editors/themes/themes.html:94
 msgid "Reject"
 msgstr ""
 
@@ -3588,7 +3571,7 @@ msgstr ""
 msgid "Android"
 msgstr ""
 
-#: src/olympia/core/apps.py:19
+#: src/olympia/core/apps.py:21
 msgid "Core"
 msgstr ""
 
@@ -3722,7 +3705,7 @@ msgid "Submit my add-on for manual review."
 msgstr ""
 
 #: src/olympia/devhub/forms.py:537
-msgid "Do not list my add-on on this site (beta)"
+msgid "Do not list my add-on on this site"
 msgstr ""
 
 #: src/olympia/devhub/forms.py:538
@@ -3755,46 +3738,46 @@ msgstr ""
 
 #: src/olympia/devhub/forms.py:592
 #, python-format
-msgid "Version %s already exists"
+msgid "Version %s already exists, or was uploaded before."
 msgstr ""
 
-#: src/olympia/devhub/forms.py:604
+#: src/olympia/devhub/forms.py:605
 msgid "Select a valid choice. That choice is not one of the available choices."
 msgstr ""
 
-#: src/olympia/devhub/forms.py:610
+#: src/olympia/devhub/forms.py:611
 msgid "A file with a version ending with a|alpha|b|beta and an optional number is detected as beta."
 msgstr ""
 
-#: src/olympia/devhub/forms.py:633
+#: src/olympia/devhub/forms.py:634
 msgid "You cannot upload any more files for this version."
 msgstr ""
 
-#: src/olympia/devhub/forms.py:639
+#: src/olympia/devhub/forms.py:640
 msgid "Version doesn't match"
 msgstr ""
 
-#: src/olympia/devhub/forms.py:668
+#: src/olympia/devhub/forms.py:669
 msgid "You cannot delete a file once the review process has started.  You must delete the whole version."
 msgstr ""
 
-#: src/olympia/devhub/forms.py:688
+#: src/olympia/devhub/forms.py:689
 msgid "The platform All cannot be combined with specific platforms."
 msgstr ""
 
-#: src/olympia/devhub/forms.py:693
+#: src/olympia/devhub/forms.py:694
 msgid "A platform can only be chosen once."
 msgstr ""
 
-#: src/olympia/devhub/forms.py:706
+#: src/olympia/devhub/forms.py:707
 msgid "A review type must be selected."
 msgstr ""
 
-#: src/olympia/devhub/forms.py:788 src/olympia/editors/forms.py:114 src/olympia/zadmin/forms.py:49 src/olympia/zadmin/forms.py:52
+#: src/olympia/devhub/forms.py:789 src/olympia/editors/forms.py:114 src/olympia/editors/forms.py:254 src/olympia/zadmin/forms.py:49 src/olympia/zadmin/forms.py:52
 msgid "Select an application first"
 msgstr ""
 
-#: src/olympia/devhub/forms.py:840
+#: src/olympia/devhub/forms.py:841
 msgid "There cannot be more than 3 required add-ons."
 msgstr ""
 
@@ -3828,76 +3811,76 @@ msgstr[1] ""
 msgid "Review"
 msgstr ""
 
-#: src/olympia/devhub/tasks.py:551
+#: src/olympia/devhub/tasks.py:583
 #, python-format
 msgid "%s responded with %s (%s)."
 msgstr ""
 
-#: src/olympia/devhub/tasks.py:555
+#: src/olympia/devhub/tasks.py:587
 #, python-format
 msgid "Connection to \"%s\" timed out."
 msgstr ""
 
-#: src/olympia/devhub/tasks.py:557
+#: src/olympia/devhub/tasks.py:589
 #, python-format
 msgid "Could not contact host at \"%s\"."
 msgstr ""
 
-#: src/olympia/devhub/utils.py:104
+#: src/olympia/devhub/utils.py:105
 #, python-format
 msgid "Validation generated too many errors/warnings so %s messages were truncated. After addressing the visible messages, you'll be able to see the others."
 msgstr ""
 
-#: src/olympia/devhub/views.py:183
+#: src/olympia/devhub/views.py:181
 msgid "All My Add-ons"
 msgstr ""
 
-#: src/olympia/devhub/views.py:210
+#: src/olympia/devhub/views.py:208
 msgid "All Activity"
 msgstr ""
 
-#: src/olympia/devhub/views.py:211
+#: src/olympia/devhub/views.py:209
 msgid "Add-on Updates"
 msgstr ""
 
-#: src/olympia/devhub/views.py:212
+#: src/olympia/devhub/views.py:210
 msgid "Add-on Status"
 msgstr ""
 
-#: src/olympia/devhub/views.py:213
+#: src/olympia/devhub/views.py:211
 msgid "User Collections"
 msgstr ""
 
-#: src/olympia/devhub/views.py:214 src/olympia/devhub/templates/devhub/docs/policies-maintenance.html:68 src/olympia/pages/templates/pages/dev_faq.html:38
+#: src/olympia/devhub/views.py:212 src/olympia/devhub/templates/devhub/docs/policies-maintenance.html:68 src/olympia/pages/templates/pages/dev_faq.html:38
 #: src/olympia/pages/templates/pages/dev_faq.html:484
 msgid "User Reviews"
 msgstr ""
 
-#: src/olympia/devhub/views.py:327 src/olympia/devhub/views.py:331 src/olympia/devhub/views.py:484 src/olympia/devhub/views.py:513 src/olympia/devhub/views.py:564 src/olympia/devhub/views.py:1150
+#: src/olympia/devhub/views.py:325 src/olympia/devhub/views.py:329 src/olympia/devhub/views.py:484 src/olympia/devhub/views.py:513 src/olympia/devhub/views.py:564 src/olympia/devhub/views.py:1156
 msgid "Changes successfully saved."
 msgstr ""
 
-#: src/olympia/devhub/views.py:334 src/olympia/devhub/views.py:1631
+#: src/olympia/devhub/views.py:332 src/olympia/devhub/views.py:1637
 msgid "Please check the form for errors."
 msgstr ""
 
-#: src/olympia/devhub/views.py:346
+#: src/olympia/devhub/views.py:344
 msgid "Add-on cannot be deleted. Disable this add-on instead."
 msgstr ""
 
-#: src/olympia/devhub/views.py:356
+#: src/olympia/devhub/views.py:354
 msgid "Theme deleted."
 msgstr ""
 
-#: src/olympia/devhub/views.py:356
+#: src/olympia/devhub/views.py:354
 msgid "Add-on deleted."
 msgstr ""
 
-#: src/olympia/devhub/views.py:362
+#: src/olympia/devhub/views.py:360
 msgid "URL name was incorrect. Theme was not deleted."
 msgstr ""
 
-#: src/olympia/devhub/views.py:367
+#: src/olympia/devhub/views.py:365
 msgid "URL name was incorrect. Add-on was not deleted."
 msgstr ""
 
@@ -3925,7 +3908,7 @@ msgstr ""
 msgid "Check Add-on Compatibility"
 msgstr ""
 
-#: src/olympia/devhub/views.py:808 src/olympia/signing/views.py:90
+#: src/olympia/devhub/views.py:808 src/olympia/signing/views.py:95
 msgid "You cannot submit this type of add-on"
 msgstr ""
 
@@ -3955,33 +3938,33 @@ msgstr ""
 msgid "There was an error uploading your preview."
 msgstr ""
 
-#: src/olympia/devhub/views.py:1189
+#: src/olympia/devhub/views.py:1195
 #, python-format
 msgid "Version %s disabled."
 msgstr ""
 
-#: src/olympia/devhub/views.py:1193
+#: src/olympia/devhub/views.py:1199
 #, python-format
 msgid "Version %s deleted."
 msgstr ""
 
-#: src/olympia/devhub/views.py:1203
+#: src/olympia/devhub/views.py:1209
 msgid "This upload has failed validation, and may lack complete validation results. Please take due care when reviewing it."
 msgstr ""
 
-#: src/olympia/devhub/views.py:1677
+#: src/olympia/devhub/views.py:1683
 msgid "Preliminary Review Requested."
 msgstr ""
 
-#: src/olympia/devhub/views.py:1678
+#: src/olympia/devhub/views.py:1684
 msgid "Full Review Requested."
 msgstr ""
 
-#: src/olympia/devhub/views.py:1779
+#: src/olympia/devhub/views.py:1783
 msgid "Your old credentials were revoked and are no longer valid. Be sure to update all API clients with the new credentials."
 msgstr ""
 
-#: src/olympia/devhub/views.py:1797
+#: src/olympia/devhub/views.py:1801
 msgid "New API key created"
 msgstr ""
 
@@ -4011,7 +3994,7 @@ msgstr ""
 msgid "{0} :: Search"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/devhub_search.html:6 src/olympia/devhub/templates/devhub/search.html:8 src/olympia/editors/forms.py:435 src/olympia/editors/forms.py:437
+#: src/olympia/devhub/templates/devhub/devhub_search.html:6 src/olympia/devhub/templates/devhub/search.html:8 src/olympia/editors/forms.py:534 src/olympia/editors/forms.py:536
 #: src/olympia/editors/templates/editors/queue.html:27 src/olympia/editors/templates/editors/themes/queue_list.html:14 src/olympia/search/templates/search/collections.html:17
 #: src/olympia/search/templates/search/personas.html:18 src/olympia/search/templates/search/results.html:18 src/olympia/search/templates/search/mobile/results.html:8
 #: src/olympia/templates/search.html:14 src/olympia/templates/impala/search.html:18
@@ -4071,12 +4054,12 @@ msgstr ""
 msgid "Start Making Add-ons"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/index.html:86 src/olympia/devhub/templates/devhub/addons/listing/items.html:25 src/olympia/devhub/templates/devhub/includes/addon_details.html:15
+#: src/olympia/devhub/templates/devhub/index.html:86 src/olympia/devhub/templates/devhub/addons/listing/items.html:25 src/olympia/devhub/templates/devhub/includes/addon_details.html:20
 #: src/olympia/devhub/templates/devhub/personas/edit.html:43
 msgid "Status:"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/index.html:90 src/olympia/devhub/templates/devhub/includes/addon_details.html:100
+#: src/olympia/devhub/templates/devhub/index.html:90 src/olympia/devhub/templates/devhub/includes/addon_details.html:87
 msgid "Visibility:"
 msgstr ""
 
@@ -4084,11 +4067,11 @@ msgstr ""
 msgid "Latest Version:"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/index.html:109 src/olympia/devhub/templates/devhub/includes/addon_details.html:145 src/olympia/devhub/templates/devhub/personas/edit.html:49
+#: src/olympia/devhub/templates/devhub/index.html:109 src/olympia/devhub/templates/devhub/includes/addon_details.html:131 src/olympia/devhub/templates/devhub/personas/edit.html:49
 msgid "Queue Position:"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/index.html:110 src/olympia/devhub/templates/devhub/includes/addon_details.html:146 src/olympia/devhub/templates/devhub/personas/edit.html:50
+#: src/olympia/devhub/templates/devhub/index.html:110 src/olympia/devhub/templates/devhub/includes/addon_details.html:132 src/olympia/devhub/templates/devhub/personas/edit.html:50
 #, python-format
 msgid "%(position)s of %(total)s"
 msgstr ""
@@ -4190,16 +4173,6 @@ msgstr ""
 msgid "Do you want your add-on to be distributed on this site?"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/validate_addon.html:49 src/olympia/devhub/templates/devhub/addons/submit/upload.html:30 src/olympia/devhub/templates/devhub/versions/add_file_modal.html:14
-#: src/olympia/devhub/templates/devhub/versions/add_file_modal.html:53 src/olympia/devhub/templates/devhub/versions/list.html:298
-msgid "Warning:"
-msgstr ""
-
-#: src/olympia/devhub/templates/devhub/validate_addon.html:50 src/olympia/devhub/templates/devhub/addons/submit/upload.html:31
-#, python-format
-msgid "Submission of unlisted add-ons for signing is currently in an open beta. Please <a href=\"%(url)s\" target=\"_blank\">report any bugs</a> that you encounter."
-msgstr ""
-
 #. first parameter is a filename like lorem-ipsum-1.0.2.xpi
 #: src/olympia/devhub/templates/devhub/validation.html:5
 msgid "Validation Results for {0}"
@@ -4274,7 +4247,7 @@ msgstr ""
 msgid "Update Compatibility"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/addons/ajax_compat_update.html:4
+#: src/olympia/devhub/templates/devhub/addons/ajax_compat_update.html:4 src/olympia/devhub/templates/devhub/versions/edit.html:45
 msgid "Adjusting application information here will allow users to install your add-on even if the install manifest in the package indicates that the add-on is incompatible."
 msgstr ""
 
@@ -4286,9 +4259,9 @@ msgstr ""
 msgid "Add Another Application&hellip;"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/addons/ajax_compat_update.html:38 src/olympia/devhub/templates/devhub/addons/owner.html:86 src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:46
-#: src/olympia/devhub/templates/devhub/versions/list.html:351 src/olympia/devhub/templates/devhub/versions/list.html:353 src/olympia/templates/impala/base.html:132
-#: src/olympia/templates/impala/base.html:143 src/olympia/templates/impala/base.html:161 src/olympia/templates/impala/base.html:171
+#: src/olympia/devhub/templates/devhub/addons/ajax_compat_update.html:38 src/olympia/devhub/templates/devhub/addons/owner.html:86 src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:45
+#: src/olympia/devhub/templates/devhub/versions/list.html:349 src/olympia/devhub/templates/devhub/versions/list.html:351 src/olympia/templates/impala/base.html:129
+#: src/olympia/templates/impala/base.html:140 src/olympia/templates/impala/base.html:158 src/olympia/templates/impala/base.html:168
 msgid "Close"
 msgstr ""
 
@@ -4322,7 +4295,7 @@ msgstr ""
 msgid "Manage Authors & License"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/addons/owner.html:29 src/olympia/editors/templates/editors/review.html:270
+#: src/olympia/devhub/templates/devhub/addons/owner.html:29 src/olympia/editors/helpers.py:362 src/olympia/editors/templates/editors/review.html:270
 msgid "Authors"
 msgstr ""
 
@@ -4391,17 +4364,11 @@ msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/basic.html:52
 msgid ""
-"A short explanation of your add-on's basic\n"
-"                          functionality that is displayed in search and browse\n"
-"                          listings, as well as at the top of your add-on's\n"
-"                          details page. It is only relevant for listed add-ons."
+"A short explanation of your add-on's basic functionality that is displayed in search and browse listings, as well as at the top of your add-on's details page. It is only relevant for listed add-ons."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/basic.html:73
-msgid ""
-"Categories are the primary way users browse through add-ons.\n"
-"                        Choose any that fit your add-on's functionality for the most\n"
-"                        exposure. It is only relevant for listed add-ons."
+msgid "Categories are the primary way users browse through add-ons. Choose any that fit your add-on's functionality for the most exposure. It is only relevant for listed add-ons."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/basic.html:90
@@ -4411,11 +4378,7 @@ msgid ""
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/basic.html:119
-msgid ""
-"Tags help users find your add-on and should be short\n"
-"                        descriptors such as tabs, toolbar, or twitter.  You\n"
-"                        may have a maximum of {0} tags. It is only relevant\n"
-"                        for listed add-ons."
+msgid "Tags help users find your add-on and should be short descriptors such as tabs, toolbar, or twitter. You may have a maximum of {0} tags. It is only relevant for listed add-ons."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/basic.html:129 src/olympia/devhub/templates/devhub/personas/edit.html:97 src/olympia/devhub/templates/devhub/personas/submit.html:46
@@ -4443,11 +4406,7 @@ msgid "Add-on Details for {0}"
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/details.html:22
-msgid ""
-"A longer explanation of features,\n"
-"                          functionality, and other relevant information. This\n"
-"                          field is only displayed on the add-on's details\n"
-"                          page. It is only relevant for listed add-ons."
+msgid "A longer explanation of features, functionality, and other relevant information. This field is only displayed on the add-on's details page. It is only relevant for listed add-ons."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/details.html:44 src/olympia/translations/templates/translations/trans-menu.html:13
@@ -4455,10 +4414,7 @@ msgid "Default Locale"
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/details.html:45
-msgid ""
-"Information about your add-on is displayed in this locale\n"
-"                        unless you override it with a locale-specific translation.\n"
-"                        It is only relevant for listed add-ons."
+msgid "Information about your add-on is displayed in this locale unless you override it with a locale-specific translation. It is only relevant for listed add-ons."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/details.html:61 src/olympia/users/forms.py:311 src/olympia/users/templates/users/edit.html:122 src/olympia/users/templates/users/register.html:57
@@ -4468,10 +4424,8 @@ msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/details.html:63
 msgid ""
-"If your add-on has another homepage, enter its\n"
-"                          address here. If your website is localized into other\n"
-"                          languages multiple translations of this field can be\n"
-"                          added. It is only relevant for listed add-ons."
+"If your add-on has another homepage, enter its address here. If your website is localized into other languages multiple translations of this field can be added. It is only relevant for listed add-"
+"ons."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/media.html:3
@@ -4489,19 +4443,14 @@ msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/support.html:22
 msgid ""
-"If you wish to display an e-mail address for support\n"
-"                          inquiries, enter it here. If you have different\n"
-"                          addresses for each language multiple translations of\n"
-"                          this field can be added. It is only relevant for\n"
-"                          listed add-ons."
+"If you wish to display an e-mail address for support inquiries, enter it here. If you have different addresses for each language multiple translations of this field can be added. It is only "
+"relevant for listed add-ons."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/support.html:45
 msgid ""
-"If your add-on has a support website or forum, enter\n"
-"                          its address here. If your website is localized into\n"
-"                          other languages, multiple translations of this field can\n"
-"                          be added. It is only relevant for listed add-ons."
+"If your add-on has a support website or forum, enter its address here. If your website is localized into other languages, multiple translations of this field can be added. It is only relevant for "
+"listed add-ons."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:6
@@ -4515,11 +4464,8 @@ msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:23
 msgid ""
-"Any information end users may want to know that isn't\n"
-"                          necessarily applicable to the add-on summary or description.\n"
-"                          Common uses include listing known major bugs, information on\n"
-"                          how to report bugs, anticipated release date of a new version,\n"
-"                          etc. It is only relevant for listed add-ons."
+"Any information end users may want to know that isn't necessarily applicable to the add-on summary or description. Common uses include listing known major bugs, information on how to report bugs, "
+"anticipated release date of a new version, etc. It is only relevant for listed add-ons."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:46
@@ -4531,9 +4477,7 @@ msgid "Add-on Flags"
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:69
-msgid ""
-"These flags are used to classify add-ons. It is only\n"
-"                        relevant for listed add-ons."
+msgid "These flags are used to classify add-ons. It is only relevant for listed add-ons."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:74
@@ -4549,9 +4493,7 @@ msgid "View Source?"
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:90
-msgid ""
-"Whether the source of your add-on can be displayed in our\n"
-"                        online viewer. It is only relevant for listed add-ons."
+msgid "Whether the source of your add-on can be displayed in our online viewer. It is only relevant for listed add-ons."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:94
@@ -4567,10 +4509,7 @@ msgid "Public Stats?"
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:102
-msgid ""
-"Whether the download and usage stats of your add-on can\n"
-"                        be displayed in our online viewer.\n"
-"                        It is only relevant for listed add-ons."
+msgid "Whether the download and usage stats of your add-on can be displayed in our online viewer. It is only relevant for listed add-ons."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:107
@@ -4586,10 +4525,7 @@ msgid "Upgrade SDK?"
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:116
-msgid ""
-"If selected, we will try to automatically upgrade your\n"
-"                        add-on when a new version of the SDK is released.\n"
-"                        It is only relevant for listed add-ons."
+msgid "If selected, we will try to automatically upgrade your add-on when a new version of the SDK is released. It is only relevant for listed add-ons."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:121
@@ -4640,10 +4576,8 @@ msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/forms_shared/media.html:16
 msgid ""
-"Upload an icon for your add-on or choose from one of ours. The\n"
-"                      icon is displayed nearly everywhere your add-on is. Uploaded images\n"
-"                      must be one of the following image types: .png, .jpg.\n"
-"                      It is only relevant for listed add-ons."
+"Upload an icon for your add-on or choose from one of ours. The icon is displayed nearly everywhere your add-on is. Uploaded images must be one of the following image types: .png, .jpg. It is only "
+"relevant for listed add-ons."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/forms_shared/media.html:25
@@ -4656,9 +4590,7 @@ msgid "32x32px"
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/forms_shared/media.html:39
-msgid ""
-"Used in listings of add-ons, like search results\n"
-"                            and featured add-ons."
+msgid "Used in listings of add-ons, like search results and featured add-ons."
 msgstr ""
 
 #. The size of the icon
@@ -4753,16 +4685,14 @@ msgid "Deleting your add-on will permanently remove it from the site and prevent
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:24
-msgid ""
-"Enter the following text confirm your decision:\n"
-"           {slug}"
+msgid "Enter the following text confirm your decision: {slug}"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:34
+#: src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:33
 msgid "Please tell us why you are deleting your theme:"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:36
+#: src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:35
 msgid "Please tell us why you are deleting your add-on:"
 msgstr ""
 
@@ -4799,8 +4729,8 @@ msgstr ""
 msgid "Daily statistics on downloads and users."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/addons/listing/item_actions.html:45 src/olympia/stats/templates/stats/stats.html:75 src/olympia/stats/templates/stats/stats.html:79
-#: src/olympia/stats/templates/stats/stats.html:81
+#: src/olympia/devhub/templates/devhub/addons/listing/item_actions.html:45 src/olympia/stats/templates/stats/stats.html:31 src/olympia/stats/templates/stats/stats.html:35
+#: src/olympia/stats/templates/stats/stats.html:37
 msgid "Statistics"
 msgstr ""
 
@@ -4919,10 +4849,7 @@ msgid "Your add-on has been submitted to the Full Review queue."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/submit/done.html:18
-msgid ""
-"You'll receive an email once it has been reviewed by an editor. In\n"
-"          the meantime, you and your friends can install it directly from its\n"
-"          details page:"
+msgid "You'll receive an email once it has been reviewed by an editor. In the meantime, you and your friends can install it directly from its details page:"
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/submit/done.html:27 src/olympia/devhub/templates/devhub/addons/submit/done.html:77 src/olympia/devhub/templates/devhub/personas/submit_done.html:16
@@ -5128,11 +5055,11 @@ msgstr ""
 msgid "Use the fields below to upload your add-on package and select any platform restrictions. After upload, a series of automated validation tests will be run on your file."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/addons/submit/upload.html:59 src/olympia/devhub/templates/devhub/versions/add_file_modal.html:39
+#: src/olympia/devhub/templates/devhub/addons/submit/upload.html:51 src/olympia/devhub/templates/devhub/versions/add_file_modal.html:28
 msgid "Which platforms is this file compatible with?"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/addons/submit/upload.html:67 src/olympia/devhub/templates/devhub/versions/add_file_modal.html:65
+#: src/olympia/devhub/templates/devhub/addons/submit/upload.html:59 src/olympia/devhub/templates/devhub/versions/add_file_modal.html:45
 msgid "Administrative overrides"
 msgstr ""
 
@@ -5242,8 +5169,8 @@ msgstr ""
 
 #: src/olympia/devhub/templates/devhub/docs/policies-contact.html:44
 msgid ""
-"If you've found a problem with the site, we'd love to fix it. Please <a href=\"https://github.com/mozilla/olympia/issues\">file a bug report</a> in GitHub, including the location of the problem and "
-"how you encountered it."
+"If you've found a problem with the site, we'd love to fix it. Please <a href=\"https://github.com/mozilla/addons/issues/new\">file a bug report</a> in GitHub, including the location of the problem "
+"and how you encountered it."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/docs/policies-maintenance.html:3 src/olympia/devhub/templates/devhub/docs/policies-maintenance.html:7
@@ -5810,7 +5737,7 @@ msgstr ""
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:282
 msgid ""
-"Add-ons that store or otherwise handle browsing data must support <a href=\"https://developer.mozilla.org/En/Supporting_private_browsing_mode\">Private Browsing Mode</a>.  During a Private Browsing "
+"Add-ons that store or otherwise handle browsing data must support <a href=\"https://developer.mozilla.org/En/Supporting_private_browsing_mode\">Private Browsing Mode</a>. During a Private Browsing "
 "session, no browsing data can be written to disk, and all of this data must be cleared when Firefox quits or the Private Browsing session ends."
 msgstr ""
 
@@ -5975,129 +5902,95 @@ msgstr ""
 msgid "How to get in touch with us regarding these policies or your add-on."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:6
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:10
 msgid "You have disabled this add-on"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:20
-msgid ""
-"Your add-on's listing is disabled and is not showing\n"
-"                             anywhere in our gallery or update service."
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:24
+msgid "Your add-on's listing is disabled and is not showing anywhere in our gallery or update service."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:25
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:27
 msgid "Please complete your add-on."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:29
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:30
 msgid "You will receive an email when the review is complete."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:34
-msgid ""
-"You will receive an email when the review is complete. Until\n"
-"                             then, your add-on is not listed in our gallery but can be\n"
-"                             accessed directly from its details page."
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:33
+msgid "You will receive an email when the review is complete. Until then, your add-on is not listed in our gallery but can be accessed directly from its details page."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:38 src/olympia/devhub/templates/devhub/includes/addon_details.html:48
-msgid ""
-"You will receive an email when the review is\n"
-"                             complete and your add-on is signed."
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:37 src/olympia/devhub/templates/devhub/includes/addon_details.html:45
+msgid "You will receive an email when the review is complete and your add-on is signed."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:44
-msgid ""
-"You will receive an email when the review is complete. Until\n"
-"                             then, your add-on is not listed in our gallery but can be\n"
-"                             accessed directly from its details page. "
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:41
+msgid "You will receive an email when the review is complete. Until then, your add-on is not listed in our gallery but can be accessed directly from its details page. "
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:54
-msgid ""
-"Your add-on is displayed in our gallery and users are\n"
-"                             receiving automatic updates."
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:49
+msgid "Your add-on is displayed in our gallery and users are receiving automatic updates."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:57
-msgid ""
-"Your add-on has been signed and can be bundled with an\n"
-"                             application installer."
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:52
+msgid "Your add-on has been signed and can be bundled with an application installer."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:63
-msgid ""
-"Your add-on was disabled by a site administrator and is no\n"
-"                             longer shown in our gallery. If you have any questions,\n"
-"                             please email amo-admins@mozilla.org."
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:56
+msgid "Your add-on was disabled by a site administrator and is no longer shown in our gallery. If you have any questions, please email amo-admins@mozilla.org."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:70
-msgid ""
-"Your add-on is displayed in our gallery as experimental\n"
-"                             and users are receiving automatic updates. Some features\n"
-"                             are unavailable to your add-on."
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:62
+msgid "Your add-on is displayed in our gallery as experimental and users are receiving automatic updates. Some features are unavailable to your add-on."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:74
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:66
 msgid "Your add-on has been signed."
 msgstr ""
 
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:69
+msgid ""
+"You will receive an email when the full review is complete. Until then, your add-on is displayed in our gallery as experimental and users are receiving automatic updates. Some features are "
+"unavailable to your add-on."
+msgstr ""
+
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:74
+msgid "You will receive an email when the full review is complete, making you able to bundle your add-on with an application installer."
+msgstr ""
+
 #: src/olympia/devhub/templates/devhub/includes/addon_details.html:79
-msgid ""
-"You will receive an email when the full review is complete.\n"
-"                             Until then, your add-on is displayed in our gallery as\n"
-"                             experimental and users are receiving automatic updates.\n"
-"                             Some features are unavailable to your add-on."
+msgid "All add-ons hosted in our gallery must now be reviewed by an editor. If you wish to continue hosting your add-on, please click to select a review process."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:84
-msgid ""
-"You will receive an email when the full review is\n"
-"                             complete, making you able to bundle your add-on with an\n"
-"                             application installer."
-msgstr ""
-
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:91
-msgid ""
-"All add-ons hosted in our gallery must now be reviewed by an\n"
-"                             editor. If you wish to continue hosting your add-on, please\n"
-"                             click to select a review process."
-msgstr ""
-
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:113
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:100
 msgid "Current Version:"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:115
-msgid ""
-"This is the version of your add-on that will\n"
-"                                           be installed if someone clicks the Install\n"
-"                                           button on addons.mozilla.org. It is only\n"
-"                                           relevant for listed add-ons."
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:102
+msgid "This is the version of your add-on that will be installed if someone clicks the Install button on addons.mozilla.org. It is only relevant for listed add-ons."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:123
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:110
 msgid "Created:"
 msgstr ""
 
 #. {0} is a date. dennis-ignore: E201
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:125 src/olympia/devhub/templates/devhub/includes/addon_details.html:131
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:112 src/olympia/devhub/templates/devhub/includes/addon_details.html:118
 #, python-format
 msgid "%%b %%e, %%Y"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:136
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:123
 msgid "Next Version:"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:138
-msgid ""
-"This is the newest uploaded version, however\n"
-"                                           it isn’t live on the site yet."
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:125
+msgid "This is the newest uploaded version, however it isn’t live on the site yet."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:144 src/olympia/devhub/templates/devhub/versions/list.html:30
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:130 src/olympia/devhub/templates/devhub/versions/list.html:30
 msgid "Queues are not reviewed strictly in order"
 msgstr ""
 
@@ -6165,9 +6058,7 @@ msgid "View the blog &#9658;"
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/includes/license_form.html:6
-msgid ""
-"Please choose a license appropriate for the rights you grant on your source code.\n"
-"                  It is only relevant for listed add-ons."
+msgid "Please choose a license appropriate for the rights you grant on your source code. It is only relevant for listed add-ons."
 msgstr ""
 
 #. {0} is a list of HTML tags.
@@ -6194,14 +6085,11 @@ msgstr[1] ""
 #: src/olympia/devhub/templates/devhub/includes/policy_form.html:4
 msgid ""
 "Users will be required to accept the following End-User License Agreement (EULA) prior to installing your add-on. The presence of a EULA significantly affects the number of downloads an add-on "
-"receives. Please note that a EULA is not the same as a code license, such as the GPL or MPL.\n"
-"                It is only relevant for listed add-ons."
+"receives. Please note that a EULA is not the same as a code license, such as the GPL or MPL.It is only relevant for listed add-ons."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/policy_form.html:21
-msgid ""
-"If your add-on transmits any data from the user's computer, a privacy policy is required that explains what data is sent and how it is used.\n"
-"                It is only relevant for listed add-ons."
+#: src/olympia/devhub/templates/devhub/includes/policy_form.html:24
+msgid "If your add-on transmits any data from the user's computer, a privacy policy is required that explains what data is sent and how it is used. It is only relevant for listed add-ons."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/includes/source_form_field.html:2
@@ -6369,12 +6257,8 @@ msgstr ""
 msgid "Add some tags to describe your Theme."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/personas/edit.html:106
-msgid ""
-"A short explanation of your theme's\n"
-"                                basic functionality that is displayed in\n"
-"                                search and browse listings, as well as at\n"
-"                                the top of your theme's details page."
+#: src/olympia/devhub/templates/devhub/personas/edit.html:106 src/olympia/devhub/templates/devhub/personas/submit.html:54
+msgid "A short explanation of your theme's basic functionality that is displayed in search and browse listings, as well as at the top of your theme's details page."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/personas/edit.html:122 src/olympia/devhub/templates/devhub/personas/submit.html:68
@@ -6444,7 +6328,7 @@ msgid "Upon upload and form submission, the AMO Team will review your updated de
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/personas/edit.html:241
-msgid "Your previously resubmitted design,  which is under pending review."
+msgid "Your previously resubmitted design, which is under pending review."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/personas/edit.html:245
@@ -6511,14 +6395,6 @@ msgstr ""
 
 #: src/olympia/devhub/templates/devhub/personas/submit.html:33
 msgid "Give your Theme a name."
-msgstr ""
-
-#: src/olympia/devhub/templates/devhub/personas/submit.html:54
-msgid ""
-"A short explanation of your theme's\n"
-"                                      basic functionality that is displayed in\n"
-"                                      search and browse listings, as well as at\n"
-"                                      the top of your theme's details page."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/personas/submit.html:198
@@ -6595,30 +6471,16 @@ msgstr ""
 msgid "Files added to reviewed versions must be reviewed before they will be available for download."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/add_file_modal.html:15
-#, python-format
-msgid ""
-"Submission of updates to unlisted add-ons for signing is currently in an open beta. Manual review may still be required for a large number of add-ons. Please <a href=\"%(url)s\" target=\"_blank"
-"\">report any bugs</a> that you encounter."
-msgstr ""
-
-#: src/olympia/devhub/templates/devhub/versions/add_file_modal.html:35
+#: src/olympia/devhub/templates/devhub/versions/add_file_modal.html:24
 msgid "Select the target platform for this file."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/add_file_modal.html:46
+#: src/olympia/devhub/templates/devhub/versions/add_file_modal.html:35
 msgid "Which review type would you like to nominate for?"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/add_file_modal.html:51
+#: src/olympia/devhub/templates/devhub/versions/add_file_modal.html:40
 msgid "Only publish this version to my beta channel."
-msgstr ""
-
-#: src/olympia/devhub/templates/devhub/versions/add_file_modal.html:54
-#, python-format
-msgid ""
-"The behavior of the beta channel has changed to accommodate <a href=\"%(addon_signing_url)s\" target=\"_blank\">mandatory add-on signing</a>. The new process is currently in an open beta, and may "
-"change significantly in the near future. Please <a href=\"%(issues_url)s\" target=\"_blank\">report any bugs</a> that you encounter."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/versions/edit.html:5
@@ -6642,19 +6504,10 @@ msgstr ""
 msgid "Upload Another File"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/edit.html:45
-msgid ""
-"Adjusting application information here will allow users to install your\n"
-"                          add-on even if the install manifest in the package indicates that the\n"
-"                          add-on is incompatible."
-msgstr ""
-
 #: src/olympia/devhub/templates/devhub/versions/edit.html:74
 msgid ""
-"Information about changes in this release, new features,\n"
-"                              known bugs, and other useful information specific to this\n"
-"                              release/version. This information is also shown in the\n"
-"                              Add-ons Manager when updating."
+"Information about changes in this release, new features, known bugs, and other useful information specific to this release/version. This information is also shown in the Add-ons Manager when "
+"updating."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/versions/edit.html:99
@@ -6666,10 +6519,7 @@ msgid "Notes for Reviewers"
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/versions/edit.html:114
-msgid ""
-"Optionally, enter any information that may be useful\n"
-"                              to the Editor reviewing this add-on, such as test\n"
-"                              account information."
+msgid "Optionally, enter any information that may be useful to the Editor reviewing this add-on, such as test account information."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/versions/edit.html:127
@@ -6747,7 +6597,7 @@ msgstr ""
 msgid "Request Preliminary Review"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:80 src/olympia/devhub/templates/devhub/versions/list.html:327 src/olympia/devhub/templates/devhub/versions/list.html:350
+#: src/olympia/devhub/templates/devhub/versions/list.html:80 src/olympia/devhub/templates/devhub/versions/list.html:325 src/olympia/devhub/templates/devhub/versions/list.html:348
 msgid "Cancel Review Request"
 msgstr ""
 
@@ -6776,7 +6626,7 @@ msgid "Unlisted:"
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/versions/list.html:114
-msgid "Not distributed on {0}. Developers will upload new versions for signing and distribute the add-ons on their own. (beta)"
+msgid "Not distributed on {0}. Developers will upload new versions for signing and distribute the add-ons on their own."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/versions/list.html:122
@@ -6839,81 +6689,73 @@ msgid "<strong>Important:</strong> Once a version has been deleted, you may not 
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/versions/list.html:230
-msgid ""
-"Deleting a version which has already been reviewed\n"
-"               may also cause a significant delay in the review of\n"
-"               your next update."
-msgstr ""
-
-#: src/olympia/devhub/templates/devhub/versions/list.html:233
 msgid "Are you sure you wish to delete this version?"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:238
+#: src/olympia/devhub/templates/devhub/versions/list.html:235
 msgid "Delete Version"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:240
+#: src/olympia/devhub/templates/devhub/versions/list.html:237
 msgid "Disable Version"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:247
+#: src/olympia/devhub/templates/devhub/versions/list.html:244
 msgid "Add a new Version"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:249
+#: src/olympia/devhub/templates/devhub/versions/list.html:246
 msgid "Add Version"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:256 src/olympia/devhub/templates/devhub/versions/list.html:274
+#: src/olympia/devhub/templates/devhub/versions/list.html:253 src/olympia/devhub/templates/devhub/versions/list.html:279
 msgid "Hide Add-on"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:259
+#: src/olympia/devhub/templates/devhub/versions/list.html:256
 msgid "Hiding your add-on will prevent it from appearing anywhere in our gallery and will stop users from receiving automatic updates."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:265
+#: src/olympia/devhub/templates/devhub/versions/list.html:263
+msgid "The files awaiting review will be disabled and you will need to upload new versions."
+msgstr ""
+
+#: src/olympia/devhub/templates/devhub/versions/list.html:270
 msgid "Are you sure you wish to hide your add-on?"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:286 src/olympia/devhub/templates/devhub/versions/list.html:315
+#: src/olympia/devhub/templates/devhub/versions/list.html:291 src/olympia/devhub/templates/devhub/versions/list.html:313
 msgid "Unlist Add-on"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:289
+#: src/olympia/devhub/templates/devhub/versions/list.html:294
 #, python-format
 msgid ""
 "Unlisting your add-on will make it (and each of its versions/files) invisible on this website. It won't show up in searches, won't have a public facing page, and won't be updated automatically for "
-"current users.  It is recommended for unlisted add-ons to provide a custom <a href=\"%(update_url)s\" target=\"_blank\">updateURL</a> in their manifest file for automatic updates."
+"current users. It is recommended for unlisted add-ons to provide a custom <a href=\"%(update_url)s\" target=\"_blank\">updateURL</a> in their manifest file for automatic updates."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:299
-#, python-format
-msgid "Switching add-ons to unlisted is currently in an open beta. Please <a href=\"%(url)s\" target=\"_blank\">report any bugs</a> that you encounter."
-msgstr ""
-
-#: src/olympia/devhub/templates/devhub/versions/list.html:305
+#: src/olympia/devhub/templates/devhub/versions/list.html:303
 msgid "Unlisting an add-on is irreversible!"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:305
+#: src/olympia/devhub/templates/devhub/versions/list.html:303
 msgid "An unlisted add-on cannot be switched to be listed."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:307
+#: src/olympia/devhub/templates/devhub/versions/list.html:305
 msgid "Are you sure you wish to unlist your add-on?"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:330
+#: src/olympia/devhub/templates/devhub/versions/list.html:328
 msgid "Canceling your review request will leave your add-on as preliminarily reviewed."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:335
+#: src/olympia/devhub/templates/devhub/versions/list.html:333
 msgid "Canceling your review request will mark your add-on incomplete. If you do not complete your add-on after several days by re-requesting review, it will be deleted."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:343
+#: src/olympia/devhub/templates/devhub/versions/list.html:341
 msgid "Are you sure you wish to cancel your review request?"
 msgstr ""
 
@@ -7252,19 +7094,19 @@ msgstr ""
 msgid "Search by add-on name / author email"
 msgstr ""
 
-#: src/olympia/editors/forms.py:103
+#: src/olympia/editors/forms.py:103 src/olympia/editors/forms.py:244 src/olympia/editors/forms.py:257
 msgid "yes"
 msgstr ""
 
-#: src/olympia/editors/forms.py:104
+#: src/olympia/editors/forms.py:104 src/olympia/editors/forms.py:244 src/olympia/editors/forms.py:257
 msgid "no"
 msgstr ""
 
-#: src/olympia/editors/forms.py:105
+#: src/olympia/editors/forms.py:105 src/olympia/editors/forms.py:245
 msgid "Admin Flag"
 msgstr ""
 
-#: src/olympia/editors/forms.py:113
+#: src/olympia/editors/forms.py:113 src/olympia/editors/forms.py:253
 msgid "Max. Version"
 msgstr ""
 
@@ -7276,55 +7118,59 @@ msgstr ""
 msgid "Add-on Types"
 msgstr ""
 
-#: src/olympia/editors/forms.py:126 src/olympia/editors/helpers.py:267
+#: src/olympia/editors/forms.py:126 src/olympia/editors/helpers.py:279
 msgid "Platforms"
 msgstr ""
 
+#: src/olympia/editors/forms.py:237
+msgid "Search by add-on name / author email / guid"
+msgstr ""
+
 #. L10n: 0 = platform, 1 = filename, 2 = status message
-#: src/olympia/editors/forms.py:238
+#: src/olympia/editors/forms.py:342
 #, python-format
 msgid "<strong>%s</strong> &middot; %s &middot; %s"
 msgstr ""
 
-#: src/olympia/editors/forms.py:252
+#: src/olympia/editors/forms.py:356
 msgid "Comments:"
 msgstr ""
 
-#: src/olympia/editors/forms.py:256
+#: src/olympia/editors/forms.py:360
 msgid "Operating systems:"
 msgstr ""
 
-#: src/olympia/editors/forms.py:258
+#: src/olympia/editors/forms.py:362
 msgid "Applications:"
 msgstr ""
 
-#: src/olympia/editors/forms.py:260
+#: src/olympia/editors/forms.py:364
 msgid "Notify me the next time this add-on is updated. (Subsequent updates will not generate an email)"
 msgstr ""
 
-#: src/olympia/editors/forms.py:265
+#: src/olympia/editors/forms.py:369
 msgid "Clear Admin Review Flag"
 msgstr ""
 
-#: src/olympia/editors/forms.py:267
+#: src/olympia/editors/forms.py:371
 msgid "Clear more info requested flag"
 msgstr ""
 
-#: src/olympia/editors/forms.py:281
+#: src/olympia/editors/forms.py:385
 msgid "Choose a canned response..."
 msgstr ""
 
 #. L10n: Description of what can be searched for.
-#: src/olympia/editors/forms.py:324
+#: src/olympia/editors/forms.py:423
 msgid "theme name"
 msgstr ""
 
-#: src/olympia/editors/forms.py:350
+#: src/olympia/editors/forms.py:449
 msgid "Someone else is reviewing this theme."
 msgstr ""
 
 #. L10n: Description of what can be searched for.
-#: src/olympia/editors/forms.py:447
+#: src/olympia/editors/forms.py:546
 msgid "app, reviewer, or comment"
 msgstr ""
 
@@ -7340,246 +7186,264 @@ msgstr ""
 msgid "Rejected or Unreviewed"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:123 src/olympia/editors/helpers.py:136
+#: src/olympia/editors/helpers.py:125 src/olympia/editors/helpers.py:138
 msgid "Queue"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:124 src/olympia/editors/templates/editors/base.html:50 src/olympia/editors/templates/editors/base.html:65
+#: src/olympia/editors/helpers.py:126 src/olympia/editors/templates/editors/base.html:50 src/olympia/editors/templates/editors/base.html:65
 msgid "Pending Updates"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:125 src/olympia/editors/templates/editors/base.html:48 src/olympia/editors/templates/editors/base.html:63
+#: src/olympia/editors/helpers.py:127 src/olympia/editors/templates/editors/base.html:48 src/olympia/editors/templates/editors/base.html:63
 msgid "Full Reviews"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:126 src/olympia/editors/templates/editors/base.html:52 src/olympia/editors/templates/editors/base.html:67
+#: src/olympia/editors/helpers.py:128 src/olympia/editors/templates/editors/base.html:52 src/olympia/editors/templates/editors/base.html:67
 msgid "Preliminary Reviews"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:127 src/olympia/editors/templates/editors/base.html:54
+#: src/olympia/editors/helpers.py:129 src/olympia/editors/templates/editors/base.html:54
 msgid "Moderated Reviews"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:128 src/olympia/editors/templates/editors/base.html:46
+#: src/olympia/editors/helpers.py:130 src/olympia/editors/templates/editors/base.html:46
 msgid "Fast Track"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:130
+#: src/olympia/editors/helpers.py:132
 msgid "Pending Themes"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:131 src/olympia/editors/templates/editors/themes/queue.html:4
+#: src/olympia/editors/helpers.py:133 src/olympia/editors/templates/editors/themes/queue.html:4
 msgid "Flagged Themes"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:132
+#: src/olympia/editors/helpers.py:134
 msgid "Update Themes"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:137
+#: src/olympia/editors/helpers.py:139
 msgid "Unlisted Pending Updates"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:138
+#: src/olympia/editors/helpers.py:140
 msgid "Unlisted Full Reviews"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:139
+#: src/olympia/editors/helpers.py:141
 msgid "Unlisted Preliminary Reviews"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:170
+#: src/olympia/editors/helpers.py:142
+msgid "Unlisted All Add-ons"
+msgstr ""
+
+#: src/olympia/editors/helpers.py:173
 msgid "Fast Track ({0})"
 msgid_plural "Fast Track ({0})"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/olympia/editors/helpers.py:175
+#: src/olympia/editors/helpers.py:178
 msgid "Full Review ({0})"
 msgid_plural "Full Reviews ({0})"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/olympia/editors/helpers.py:180
+#: src/olympia/editors/helpers.py:183
 msgid "Pending Update ({0})"
 msgid_plural "Pending Updates ({0})"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/olympia/editors/helpers.py:185
+#: src/olympia/editors/helpers.py:188
 msgid "Preliminary Review ({0})"
 msgid_plural "Preliminary Reviews ({0})"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/olympia/editors/helpers.py:190
+#: src/olympia/editors/helpers.py:193
 msgid "Moderated Review ({0})"
 msgid_plural "Moderated Reviews ({0})"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/olympia/editors/helpers.py:196
+#: src/olympia/editors/helpers.py:199
 msgid "Unlisted Full Review ({0})"
 msgid_plural "Unlisted Full Reviews ({0})"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/olympia/editors/helpers.py:201
+#: src/olympia/editors/helpers.py:204
 msgid "Unlisted Pending Update ({0})"
 msgid_plural "Unlisted Pending Updates ({0})"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/olympia/editors/helpers.py:206
+#: src/olympia/editors/helpers.py:209
 msgid "Unlisted Preliminary Review ({0})"
 msgid_plural "Unlisted Preliminary Reviews ({0})"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/olympia/editors/helpers.py:261
-msgid "Addon"
-msgstr ""
+#: src/olympia/editors/helpers.py:214
+msgid "Unlisted All Add-ons ({0})"
+msgid_plural "Unlisted All Add-ons ({0})"
+msgstr[0] ""
+msgstr[1] ""
 
-#: src/olympia/editors/helpers.py:262
+#: src/olympia/editors/helpers.py:274
 msgid "Type"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:263
+#: src/olympia/editors/helpers.py:275
 msgid "Waiting Time"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:264 src/olympia/editors/templates/editors/review.html:285
+#: src/olympia/editors/helpers.py:276 src/olympia/editors/templates/editors/review.html:285
 msgid "Flags"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:265
+#: src/olympia/editors/helpers.py:277
 msgid "Applications"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:270
+#: src/olympia/editors/helpers.py:282
 msgid "Additional"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:285
+#: src/olympia/editors/helpers.py:302
 msgid "Site Specific"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:287
+#: src/olympia/editors/helpers.py:304
 msgid "Requires External Software"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:289
+#: src/olympia/editors/helpers.py:306
 msgid "Binary Components"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:313
+#: src/olympia/editors/helpers.py:339
 msgid "moments ago"
 msgstr ""
 
 #. L10n: first argument is number of minutes
-#: src/olympia/editors/helpers.py:316
+#: src/olympia/editors/helpers.py:342
 msgid "{0} minute"
 msgid_plural "{0} minutes"
 msgstr[0] ""
 msgstr[1] ""
 
 #. L10n: first argument is number of hours
-#: src/olympia/editors/helpers.py:320
+#: src/olympia/editors/helpers.py:346
 msgid "{0} hour"
 msgid_plural "{0} hours"
 msgstr[0] ""
 msgstr[1] ""
 
 #. L10n: first argument is number of days
-#: src/olympia/editors/helpers.py:324
+#: src/olympia/editors/helpers.py:350
 msgid "{0} day"
 msgid_plural "{0} days"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/olympia/editors/helpers.py:488
+#: src/olympia/editors/helpers.py:364
+msgid "Last Review"
+msgstr ""
+
+#: src/olympia/editors/helpers.py:366
+msgid "Last Update"
+msgstr ""
+
+#: src/olympia/editors/helpers.py:387
+msgid "No Reviews"
+msgstr ""
+
+#: src/olympia/editors/helpers.py:561
 msgid "Push to public"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:490
+#: src/olympia/editors/helpers.py:563
 msgid "Grant full review"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:505
+#: src/olympia/editors/helpers.py:578
 msgid "Request more information"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:508
+#: src/olympia/editors/helpers.py:581
 msgid "Request super-review"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:519
+#: src/olympia/editors/helpers.py:592
 msgid "Grant preliminary review"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:520
+#: src/olympia/editors/helpers.py:593
 msgid "This will mark the files as preliminarily reviewed."
 msgstr ""
 
-#: src/olympia/editors/helpers.py:522
+#: src/olympia/editors/helpers.py:595
 msgid "Use this form to request more information from the author. They will receive an email and be able to answer here. You will be notified by email when they reply."
 msgstr ""
 
-#: src/olympia/editors/helpers.py:526
+#: src/olympia/editors/helpers.py:599
 msgid ""
 "If you have concerns about this add-on's security, copyright issues, or other concerns that an administrator should look into, enter your comments in the area below. They will be sent to "
 "administrators, not the author."
 msgstr ""
 
-#: src/olympia/editors/helpers.py:532
+#: src/olympia/editors/helpers.py:605
 msgid "This will reject the add-on and remove it from the review queue."
 msgstr ""
 
-#: src/olympia/editors/helpers.py:534
-msgid "Make a comment on this version.  The author won't be able to see this."
+#: src/olympia/editors/helpers.py:607
+msgid "Make a comment on this version. The author won't be able to see this."
 msgstr ""
 
-#: src/olympia/editors/helpers.py:538
+#: src/olympia/editors/helpers.py:611
 msgid "This will reject the files and remove them from the review queue."
 msgstr ""
 
-#: src/olympia/editors/helpers.py:542
+#: src/olympia/editors/helpers.py:615
 msgid "This will mark the add-on as preliminarily reviewed. Future versions will undergo preliminary review."
 msgstr ""
 
-#: src/olympia/editors/helpers.py:547
+#: src/olympia/editors/helpers.py:620
 msgid "This will mark the files as preliminarily reviewed. Future versions will undergo preliminary review."
 msgstr ""
 
-#: src/olympia/editors/helpers.py:552
+#: src/olympia/editors/helpers.py:625
 msgid "Retain preliminary review"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:553
+#: src/olympia/editors/helpers.py:626
 msgid "This will retain the add-on as preliminarily reviewed. Future versions will undergo preliminary review."
 msgstr ""
 
-#: src/olympia/editors/helpers.py:558
+#: src/olympia/editors/helpers.py:631
 msgid "This will approve a sandboxed version of a public add-on to appear on the public side."
 msgstr ""
 
-#: src/olympia/editors/helpers.py:561
+#: src/olympia/editors/helpers.py:634
 msgid "This will reject a version of a public add-on and remove it from the queue."
 msgstr ""
 
-#: src/olympia/editors/helpers.py:564
+#: src/olympia/editors/helpers.py:637
 msgid "This will mark the add-on and its most recent version and files as public. Future versions will go into the sandbox until they are reviewed by an editor."
 msgstr ""
 
-#: src/olympia/editors/helpers.py:637
+#: src/olympia/editors/helpers.py:714
 msgid "add-on"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:940 src/olympia/editors/helpers.py:960
+#: src/olympia/editors/helpers.py:1020 src/olympia/editors/helpers.py:1040
 msgid "Flagged"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:944 src/olympia/editors/helpers.py:963
+#: src/olympia/editors/helpers.py:1024 src/olympia/editors/helpers.py:1043
 msgid "Updates"
 msgstr ""
 
@@ -7631,56 +7495,56 @@ msgstr ""
 msgid "A question about your Theme submission"
 msgstr ""
 
-#: src/olympia/editors/views.py:144
+#: src/olympia/editors/views.py:146
 msgid "New Add-ons (Under 5 days)"
 msgstr ""
 
-#: src/olympia/editors/views.py:145
+#: src/olympia/editors/views.py:147
 msgid "Passable (5 to 10 days)"
 msgstr ""
 
-#: src/olympia/editors/views.py:146
+#: src/olympia/editors/views.py:148
 msgid "Overdue (Over 10 days)"
 msgstr ""
 
-#: src/olympia/editors/views.py:532
+#: src/olympia/editors/views.py:539
 msgid "An unknown error occurred"
 msgstr ""
 
-#: src/olympia/editors/views.py:587
+#: src/olympia/editors/views.py:592
 msgid "Self-reviews are not allowed."
 msgstr ""
 
-#: src/olympia/editors/views.py:609
+#: src/olympia/editors/views.py:613
 msgid "Review successfully processed."
 msgstr ""
 
-#: src/olympia/editors/views.py:807
+#: src/olympia/editors/views.py:812
 msgid "was approved"
 msgstr ""
 
-#: src/olympia/editors/views.py:808
+#: src/olympia/editors/views.py:813
 msgid "given preliminary review"
 msgstr ""
 
-#: src/olympia/editors/views.py:809
+#: src/olympia/editors/views.py:814
 msgid "rejected"
 msgstr ""
 
-#: src/olympia/editors/views.py:810
+#: src/olympia/editors/views.py:815
 msgctxt "editors_review_history_nominated_adminreview"
 msgid "escalated"
 msgstr ""
 
-#: src/olympia/editors/views.py:812
+#: src/olympia/editors/views.py:817
 msgid "needs more information"
 msgstr ""
 
-#: src/olympia/editors/views.py:813
+#: src/olympia/editors/views.py:818
 msgid "needs super review"
 msgstr ""
 
-#: src/olympia/editors/views.py:814
+#: src/olympia/editors/views.py:819
 msgid "commented"
 msgstr ""
 
@@ -7725,28 +7589,28 @@ msgstr ""
 msgid "Unlisted Queues"
 msgstr ""
 
-#: src/olympia/editors/templates/editors/base.html:72 src/olympia/editors/templates/editors/performance.html:6
+#: src/olympia/editors/templates/editors/base.html:74 src/olympia/editors/templates/editors/performance.html:6
 msgid "Performance"
 msgstr ""
 
-#: src/olympia/editors/templates/editors/base.html:75 src/olympia/editors/templates/editors/themes/base.html:19 src/olympia/editors/templates/editors/themes/base.html:38
+#: src/olympia/editors/templates/editors/base.html:77 src/olympia/editors/templates/editors/themes/base.html:19 src/olympia/editors/templates/editors/themes/base.html:38
 msgid "Logs"
 msgstr ""
 
-#: src/olympia/editors/templates/editors/base.html:78 src/olympia/editors/templates/editors/reviewlog.html:4 src/olympia/editors/templates/editors/reviewlog.html:27
+#: src/olympia/editors/templates/editors/base.html:80 src/olympia/editors/templates/editors/reviewlog.html:4 src/olympia/editors/templates/editors/reviewlog.html:27
 msgid "Add-on Review Log"
 msgstr ""
 
-#: src/olympia/editors/templates/editors/base.html:80 src/olympia/editors/templates/editors/eventlog.html:4 src/olympia/editors/templates/editors/eventlog.html:8
+#: src/olympia/editors/templates/editors/base.html:82 src/olympia/editors/templates/editors/eventlog.html:4 src/olympia/editors/templates/editors/eventlog.html:8
 #: src/olympia/editors/templates/editors/eventlog_detail.html:4
 msgid "Moderated Review Log"
 msgstr ""
 
-#: src/olympia/editors/templates/editors/base.html:82 src/olympia/editors/templates/editors/beta_signed_log.html:4 src/olympia/editors/templates/editors/beta_signed_log.html:8
+#: src/olympia/editors/templates/editors/base.html:84 src/olympia/editors/templates/editors/beta_signed_log.html:4 src/olympia/editors/templates/editors/beta_signed_log.html:8
 msgid "Signed Beta Files Log"
 msgstr ""
 
-#: src/olympia/editors/templates/editors/base.html:87 src/olympia/editors/templates/editors/includes/daily-message.html:4
+#: src/olympia/editors/templates/editors/base.html:89 src/olympia/editors/templates/editors/includes/daily-message.html:4
 msgid "Announcement"
 msgstr ""
 
@@ -7967,45 +7831,45 @@ msgstr ""
 msgid "clear search"
 msgstr ""
 
-#: src/olympia/editors/templates/editors/queue.html:72 src/olympia/editors/templates/editors/queue.html:122
+#: src/olympia/editors/templates/editors/queue.html:78 src/olympia/editors/templates/editors/queue.html:128
 msgid "Process Reviews"
 msgstr ""
 
-#: src/olympia/editors/templates/editors/queue.html:80
+#: src/olympia/editors/templates/editors/queue.html:86
 msgid "Moderation actions:"
 msgstr ""
 
-#: src/olympia/editors/templates/editors/queue.html:90
+#: src/olympia/editors/templates/editors/queue.html:96
 #, python-format
 msgid "by %(user)s on %(date)s %(stars)s (%(locale)s)"
 msgstr ""
 
-#: src/olympia/editors/templates/editors/queue.html:106
+#: src/olympia/editors/templates/editors/queue.html:112
 #, python-format
 msgid "<strong>%(reason)s</strong> <span class=\"light\">Flagged by %(user)s on %(date)s</span>"
 msgstr ""
 
-#: src/olympia/editors/templates/editors/queue.html:119
-msgid "All reviews have been moderated.  Good work!"
+#: src/olympia/editors/templates/editors/queue.html:125
+msgid "All reviews have been moderated. Good work!"
 msgstr ""
 
-#: src/olympia/editors/templates/editors/queue.html:161
+#: src/olympia/editors/templates/editors/queue.html:167
 msgid "Version Notes / Notes for Reviewer"
 msgstr ""
 
-#: src/olympia/editors/templates/editors/queue.html:169
+#: src/olympia/editors/templates/editors/queue.html:175
 msgid "There are currently no add-ons of this type to review."
 msgstr ""
 
-#: src/olympia/editors/templates/editors/queue.html:181 src/olympia/editors/templates/editors/themes/queue_list.html:85
+#: src/olympia/editors/templates/editors/queue.html:187 src/olympia/editors/templates/editors/themes/queue_list.html:85
 msgid "Helpful Links:"
 msgstr ""
 
-#: src/olympia/editors/templates/editors/queue.html:182
+#: src/olympia/editors/templates/editors/queue.html:188
 msgid "Add-on Policy"
 msgstr ""
 
-#: src/olympia/editors/templates/editors/queue.html:184
+#: src/olympia/editors/templates/editors/queue.html:190
 msgid "Editors' Guide"
 msgstr ""
 
@@ -8068,10 +7932,7 @@ msgid "<strong>Warning!</strong> Another user was viewing this page before you."
 msgstr ""
 
 #: src/olympia/editors/templates/editors/review.html:237
-msgid ""
-"The whiteboard is the place to exchange information relevant to\n"
-"               this addon (whatever the version), between the developer and the\n"
-"               editor. This is visible and editable by both."
+msgid "The whiteboard is the place to exchange information relevant to this addon (whatever the version), between the developer and the editor. This is visible and editable by both."
 msgstr ""
 
 #: src/olympia/editors/templates/editors/review.html:241
@@ -8345,7 +8206,7 @@ msgstr ""
 msgid "Describe your reason for flagging"
 msgstr ""
 
-#: src/olympia/files/forms.py:88
+#: src/olympia/files/forms.py:90
 msgid "Cannot diff a version against itself"
 msgstr ""
 
@@ -8380,51 +8241,51 @@ msgstr ""
 msgid "There was an error accessing file %s."
 msgstr ""
 
-#: src/olympia/files/utils.py:343
+#: src/olympia/files/utils.py:340
 msgid "Could not parse uploaded file."
 msgstr ""
 
-#: src/olympia/files/utils.py:380
+#: src/olympia/files/utils.py:377
 msgid "Invalid file name in archive: {0}"
 msgstr ""
 
-#: src/olympia/files/utils.py:388
+#: src/olympia/files/utils.py:385
 msgid "File exceeding size limit in archive: {0}"
 msgstr ""
 
-#: src/olympia/files/utils.py:439
+#: src/olympia/files/utils.py:436
 msgid "Invalid archive."
 msgstr ""
 
-#: src/olympia/files/utils.py:529 src/olympia/files/utils.py:532
+#: src/olympia/files/utils.py:526 src/olympia/files/utils.py:529
 msgid "Could not parse the manifest file."
 msgstr ""
 
-#: src/olympia/files/utils.py:551
+#: src/olympia/files/utils.py:548
 msgid "Could not find an add-on ID."
 msgstr ""
 
-#: src/olympia/files/utils.py:554
+#: src/olympia/files/utils.py:551
 msgid "Add-on ID must be 64 characters or less."
 msgstr ""
 
-#: src/olympia/files/utils.py:556
+#: src/olympia/files/utils.py:553
 msgid "Add-on ID doesn't match add-on."
 msgstr ""
 
-#: src/olympia/files/utils.py:564
+#: src/olympia/files/utils.py:561
 msgid "Duplicate add-on ID found."
 msgstr ""
 
-#: src/olympia/files/utils.py:567
+#: src/olympia/files/utils.py:564
 msgid "Version numbers should have fewer than 32 characters."
 msgstr ""
 
-#: src/olympia/files/utils.py:570
+#: src/olympia/files/utils.py:567
 msgid "Version numbers should only contain letters, numbers, and these punctuation characters: +*.-_."
 msgstr ""
 
-#: src/olympia/files/utils.py:587
+#: src/olympia/files/utils.py:584
 msgid "<em:type> doesn't match add-on"
 msgstr ""
 
@@ -8523,6 +8384,10 @@ msgstr ""
 
 #: src/olympia/files/templates/files/viewer.html:134
 msgid "Fetching file."
+msgstr ""
+
+#: src/olympia/legacy_api/views.py:255
+msgid "Not implemented yet."
 msgstr ""
 
 #: src/olympia/lib/constants.py:6
@@ -9181,10 +9046,6 @@ msgstr ""
 msgid "Zimbabwe Dollar"
 msgstr ""
 
-#: src/olympia/lib/video/ffmpeg.py:112 src/olympia/lib/video/totem.py:81
-msgid "Videos must be in WebM."
-msgstr ""
-
 #: src/olympia/pages/templates/pages/about.lhtml:3 src/olympia/pages/templates/pages/about.lhtml:10
 msgid "About Mozilla Add-ons"
 msgstr ""
@@ -9196,7 +9057,7 @@ msgstr ""
 #: src/olympia/pages/templates/pages/about.lhtml:13
 msgid ""
 "addons.mozilla.org, commonly known as \"AMO\", is Mozilla's official site for add-ons to Mozilla software, such as Firefox, Thunderbird, and SeaMonkey. Add-ons let you add new features and change "
-"the way your browser or application works.  Take a look around and explore the thousands of ways to customize the way you do things online."
+"the way your browser or application works. Take a look around and explore the thousands of ways to customize the way you do things online."
 msgstr ""
 
 #: src/olympia/pages/templates/pages/about.lhtml:19
@@ -9541,7 +9402,7 @@ msgstr ""
 msgid ""
 "Yes. It's possible, but some of the functionality provided by these libraries are available through XPCOM, XUL, and JavaScript. In addition, authors should take care if libraries modify primitive "
 "object prototypes (String.prototype, Date.prototype, etc.) and/or define global functions (eg. the $ function). These are prone to cause conflict with other add-ons, in particular if different add-"
-"ons use different versions of libraries and so on. Developers need to be very, very careful with using them.  Mozilla does not offer documentation on using them to build add-ons."
+"ons use different versions of libraries and so on. Developers need to be very, very careful with using them. Mozilla does not offer documentation on using them to build add-ons."
 msgstr ""
 
 #: src/olympia/pages/templates/pages/dev_faq.html:165
@@ -9655,8 +9516,8 @@ msgstr ""
 #, python-format
 msgid ""
 "Yes. Many developers choose to host their own add-ons. Choosing to host your add-on on <a href=\"%(amo_url)s\">Mozilla's add-on site</a>, though, allows for much greater exposure to your add-on due "
-"to the large volume of visitors to the site.  <a href=\"%(md_url)s\">mozdev.org</a> offers free project hosting for Mozilla applications and extensions providing developers with tools to help "
-"manage source code, version control, bug tracking and documentation."
+"to the large volume of visitors to the site. <a href=\"%(md_url)s\">mozdev.org</a> offers free project hosting for Mozilla applications and extensions providing developers with tools to help manage "
+"source code, version control, bug tracking and documentation."
 msgstr ""
 
 #: src/olympia/pages/templates/pages/dev_faq.html:277
@@ -9704,7 +9565,7 @@ msgstr ""
 #: src/olympia/pages/templates/pages/dev_faq.html:314
 #, python-format
 msgid ""
-"Yes. Mozilla's <a href=\"%(p_url)s\">Add-on Policy</a> describes what is an acceptable submission. This policy is subject to change without notice.  In addition, the AMO editorial team uses the <a "
+"Yes. Mozilla's <a href=\"%(p_url)s\">Add-on Policy</a> describes what is an acceptable submission. This policy is subject to change without notice. In addition, the AMO editorial team uses the <a "
 "href=\"%(g_url)s\">Editors Reviewing Guide</a> to ensure that your add-on meets specific guidelines for functionality and security."
 msgstr ""
 
@@ -9821,7 +9682,7 @@ msgstr ""
 #: src/olympia/pages/templates/pages/dev_faq.html:434
 #, python-format
 msgid ""
-"This is why it's very important to read the <a href=\"%(g_url)s\">Editors Reviewing Guide</a> to ensure that your add-on is setup as expected.  It's also a good idea to read the blog post, <a href="
+"This is why it's very important to read the <a href=\"%(g_url)s\">Editors Reviewing Guide</a> to ensure that your add-on is setup as expected. It's also a good idea to read the blog post, <a href="
 "\"%(blog_url)s\">Successfully Getting your Add-on Reviewed</a> which provides excellent insight into ensuring a smooth review of your add-on."
 msgstr ""
 
@@ -9928,7 +9789,7 @@ msgstr ""
 
 #: src/olympia/pages/templates/pages/dev_faq.html:572
 msgid ""
-"Free Software Foundation provides short summaries of the key open source licenses, including whether the license qualifies as a free software license or a copyleft license.  Also includes a "
+"Free Software Foundation provides short summaries of the key open source licenses, including whether the license qualifies as a free software license or a copyleft license. Also includes a "
 "discussion of what constitutes a free software license or a copyleft license (e.g., a Copyleft license is a general method for making a program or other work free, and requiring all modified and "
 "extended versions of the program to be free as well.)"
 msgstr ""
@@ -10106,19 +9967,13 @@ msgid "Add-on Gallery"
 msgstr ""
 
 #: src/olympia/pages/templates/pages/faq.html:171
-msgid ""
-"How do I choose between add-ons that seem to do the same\n"
-"    thing?"
+msgid "How do I choose between add-ons that seem to do the same thing?"
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:173
+#: src/olympia/pages/templates/pages/faq.html:172
 msgid ""
-"There are often several add-ons that have similar features. To\n"
-"    figure out which is right for you, read the entire description of the\n"
-"    add-on and view its screenshots. If there are still several in the running,\n"
-"    read through the add-on's ratings, user reviews, and statistics to see\n"
-"    which is most liked by other users. Remember that you can also just try\n"
-"    out both and see which you like better."
+"There are often several add-ons that have similar features. To figure out which is right for you, read the entire description of the add-on and view its screenshots. If there are still several in "
+"the running, read through the add-on's ratings, user reviews, and statistics to see which is most liked by other users. Remember that you can also just try out both and see which you like better."
 msgstr ""
 
 #: src/olympia/pages/templates/pages/faq.html:180
@@ -10159,80 +10014,67 @@ msgid "How much do add-ons cost to purchase?"
 msgstr ""
 
 #: src/olympia/pages/templates/pages/faq.html:207
-msgid ""
-"Add-ons hosted in our gallery are free unless clearly marked\n"
-"    otherwise."
+msgid "Add-ons hosted in our gallery are free unless clearly marked otherwise."
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:210
+#: src/olympia/pages/templates/pages/faq.html:209
 msgid "What does it mean when an add-on asks for contributions?"
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:211
+#: src/olympia/pages/templates/pages/faq.html:210
 msgid ""
-"Some add-on authors request users who enjoy an add-on to\n"
-"        contribute to its development by making a monetary contribution. These\n"
-"        contributions go directly to the developer unless a third party is\n"
-"        indicated, such as the non-profit Mozilla Foundation."
+"Some add-on authors request users who enjoy an add-on to contribute to its development by making a monetary contribution. These contributions go directly to the developer unless a third party is "
+"indicated, such as the non-profit Mozilla Foundation."
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:216
+#: src/olympia/pages/templates/pages/faq.html:215
 msgid "What are beta add-ons?"
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:218
+#: src/olympia/pages/templates/pages/faq.html:217
 msgid ""
-"Beta add-ons are unreviewed versions which represent the\n"
-"        latest work of an add-on author. While different authors have different\n"
-"        standards for beta code quality, you should assume that these add-ons\n"
-"        are less stable than the general add-on releases."
+"Beta add-ons are unreviewed versions which represent the latest work of an add-on author. While different authors have different standards for beta code quality, you should assume that these add-"
+"ons are less stable than the general add-on releases."
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:222
+#: src/olympia/pages/templates/pages/faq.html:221
 msgid ""
 "Please note that when you install an add-on from the \"Beta Version\" section of an add-on's listing, you will continue to receive updates for that add-on as they become available. Like the initial "
 "version you installed, all beta releases are unreviewed by Mozilla and may harm your computer."
 msgstr ""
 
+#: src/olympia/pages/templates/pages/faq.html:228
+msgid "What does it mean when an add-on is flagged as slow?"
+msgstr ""
+
 #: src/olympia/pages/templates/pages/faq.html:229
-msgid ""
-"What does it mean when an add-on is flagged as\n"
-"    slow?"
+msgid "Most add-ons load code and resources at the same time Firefox is starting up. In most cases the impact in start-up time is minimal, but some add-ons can cause a noticeable slowdown."
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:231
-msgid ""
-"Most add-ons load code and resources at the same time Firefox\n"
-"        is starting up. In most cases the impact in start-up time is minimal,\n"
-"        but some add-ons can cause a noticeable slowdown."
-msgstr ""
-
-#: src/olympia/pages/templates/pages/faq.html:236
+#: src/olympia/pages/templates/pages/faq.html:234
 msgid "How do I report an inappropriate or spam user review?"
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:237
+#: src/olympia/pages/templates/pages/faq.html:235
 msgid ""
-"To report a user review of an add-on, log in with your account\n"
-"    and visit the add-on's reviews page. Find the review you wish to report,\n"
-"    click \"Report this review\" and select a reason. Our editorial team will\n"
-"    investigate the review and take appropriate action."
+"To report a user review of an add-on, log in with your account and visit the add-on's reviews page. Find the review you wish to report, click \"Report this review\" and select a reason. Our "
+"editorial team will investigate the review and take appropriate action."
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:242
+#: src/olympia/pages/templates/pages/faq.html:240
 msgid "How do I report a bug or contact the Mozilla Add-ons team?"
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:243
+#: src/olympia/pages/templates/pages/faq.html:241
 #, python-format
 msgid "Please visit our <a href=\"%(contact_url)s\">Contact page</a>."
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:246
+#: src/olympia/pages/templates/pages/faq.html:244
 msgid "What is a Source Code License?"
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:247
+#: src/olympia/pages/templates/pages/faq.html:245
 #, python-format
 msgid ""
 "The source code used to create an add-on is an exclusive copyright of the add-on author, unless otherwise declared in a source code license. Many add-ons on this site have <a href=\"%(url)s\" lang="
@@ -10240,60 +10082,60 @@ msgid ""
 "the GPL or BSD licenses instead of making up their own."
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:256
+#: src/olympia/pages/templates/pages/faq.html:254
 #, python-format
 msgid "Firefox and other Mozilla software are <a href=\"%(url)s\">open source</a>."
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:264
+#: src/olympia/pages/templates/pages/faq.html:262
 msgid "Collections and Favorites"
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:267
+#: src/olympia/pages/templates/pages/faq.html:265
 msgid "What is a collection?"
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:268
+#: src/olympia/pages/templates/pages/faq.html:266
 msgid "Collections are groups of related add-ons created by users to share."
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:270
+#: src/olympia/pages/templates/pages/faq.html:268
 msgid "What is the My Favorites collection?"
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:271
+#: src/olympia/pages/templates/pages/faq.html:269
 msgid "Favorite add-ons are add-ons that you have bookmarked to easily get back to later. You can add an add-on to your favorites collection by clicking \"Add to favorites\" on its details page."
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:275 src/olympia/templates/menu_links.html:13 src/olympia/templates/impala/header_title.html:17
+#: src/olympia/pages/templates/pages/faq.html:273 src/olympia/templates/menu_links.html:13 src/olympia/templates/impala/header_title.html:17
 msgid "Mobile Add-ons"
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:278
+#: src/olympia/pages/templates/pages/faq.html:276
 msgid "What are mobile add-ons?"
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:279
+#: src/olympia/pages/templates/pages/faq.html:277
 #, python-format
 msgid ""
 "Mobile add-ons work with <a href=\"%(mobile_url)s\">Firefox for Mobile</a> and add or modify functionality just like desktop add-ons. You can find add-ons that work with Firefox for Mobile in our "
 "<a href=\"%(gallery_url)s\">gallery</a>."
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:288
+#: src/olympia/pages/templates/pages/faq.html:286
 msgid "Developer Topics"
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:289
+#: src/olympia/pages/templates/pages/faq.html:287
 #, python-format
 msgid "Please see our <a href=\"%(faq_url)s\">Developer FAQ</a> and <a href=\"%(hub_url)s\">Developer Hub</a> for answers to add-on developer-related questions."
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:294
+#: src/olympia/pages/templates/pages/faq.html:292
 msgid "Still have questions?"
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:295
+#: src/olympia/pages/templates/pages/faq.html:293
 #, python-format
 msgid "For general Firefox support, visit our <a href=\"%(sumo_url)s\">support website</a>. For general add-on and website questions, visit our <a href=\"%(forum_url)s\">forum</a>."
 msgstr ""
@@ -10431,7 +10273,7 @@ msgstr ""
 
 #: src/olympia/pages/templates/pages/sunbird.html:29
 msgid ""
-"Development on the Sunbird project has halted and its final release was on March 30, 2010.  We've been proud to host Sunbird add-ons on this site but as the project is no longer maintained we have "
+"Development on the Sunbird project has halted and its final release was on March 30, 2010. We've been proud to host Sunbird add-ons on this site but as the project is no longer maintained we have "
 "disabled our support for the add-ons."
 msgstr ""
 
@@ -10509,7 +10351,7 @@ msgstr ""
 #, python-format
 msgid ""
 "<h2>Keep these tips in mind:</h2> <ul> <li> Write like you're telling a friend about your experience with the add-on. Give specifics and helpful details, such as what features you liked and/or "
-"disliked, how easy to use it is, and any disadvantages it has.  Avoid generic language such as calling it \"Great\" or \"Bad\" unless you can give reasons why you believe this is so. </li> <li> "
+"disliked, how easy to use it is, and any disadvantages it has. Avoid generic language such as calling it \"Great\" or \"Bad\" unless you can give reasons why you believe this is so. </li> <li> "
 "Please do not post bug reports in reviews. We do not make your email address available to add-on developers and they may need to contact you to help resolve your issue. See the <a href=\"%(support)s"
 "\">support section</a> to find out where to get assistance for this add-on. </li> <li>Please keep reviews clean, avoid the use of improper language and do not post any personal information. </li> </"
 "ul> <p>Please read the <a href=\"%(guide)s\" target=\"_blank\">Review Guidelines</a> for more detail about user add-on reviews.</p>"
@@ -10745,16 +10587,16 @@ msgstr ""
 
 #. L10n: {0} is an application, such as Firefox. This means "any version of
 #. Firefox."
-#: src/olympia/search/views.py:554
+#: src/olympia/search/views.py:547
 msgid "Any {0}"
 msgstr ""
 
 #. L10n: "All Systems" means show everything regardless of platform.
-#: src/olympia/search/views.py:589
+#: src/olympia/search/views.py:582
 msgid "All Systems"
 msgstr ""
 
-#: src/olympia/search/views.py:600
+#: src/olympia/search/views.py:593
 msgid "All Tags"
 msgstr ""
 
@@ -10928,31 +10770,31 @@ msgstr ""
 msgid "Share this Collection"
 msgstr ""
 
-#: src/olympia/signing/views.py:30 src/olympia/templates/base.html:75 src/olympia/templates/impala/base.html:115
+#: src/olympia/signing/views.py:33 src/olympia/templates/base.html:71 src/olympia/templates/impala/base.html:112
 msgid "Some features are temporarily disabled while we perform website maintenance. We'll be back to full capacity shortly."
 msgstr ""
 
-#: src/olympia/signing/views.py:53
+#: src/olympia/signing/views.py:56
 msgid "Could not find add-on with id \"{}\"."
 msgstr ""
 
-#: src/olympia/signing/views.py:67
+#: src/olympia/signing/views.py:70
 msgid "You do not own this addon."
 msgstr ""
 
-#: src/olympia/signing/views.py:82
+#: src/olympia/signing/views.py:87
 msgid "Missing \"upload\" key in multipart file data."
 msgstr ""
 
-#: src/olympia/signing/views.py:96
+#: src/olympia/signing/views.py:101
 msgid "Version does not match the manifest file."
 msgstr ""
 
-#: src/olympia/signing/views.py:100
+#: src/olympia/signing/views.py:105
 msgid "Version already exists."
 msgstr ""
 
-#: src/olympia/signing/views.py:136
+#: src/olympia/signing/views.py:141
 msgid "No uploaded file for that addon and version."
 msgstr ""
 
@@ -11065,89 +10907,89 @@ msgstr ""
 msgid "Statistics Dashboard :: Add-ons for {0}"
 msgstr ""
 
-#: src/olympia/stats/templates/stats/stats.html:30
-msgid "Controls:"
-msgstr ""
-
-#: src/olympia/stats/templates/stats/stats.html:33
-msgid "reset zoom"
-msgstr ""
-
-#: src/olympia/stats/templates/stats/stats.html:40
-msgid "Group by:"
-msgstr ""
-
-#: src/olympia/stats/templates/stats/stats.html:42
-msgid "day"
-msgstr ""
-
-#: src/olympia/stats/templates/stats/stats.html:45
-msgid "week"
-msgstr ""
-
-#: src/olympia/stats/templates/stats/stats.html:48
-msgid "month"
-msgstr ""
-
-#: src/olympia/stats/templates/stats/stats.html:54
-msgid "For last:"
-msgstr ""
-
-#: src/olympia/stats/templates/stats/stats.html:57
-msgid "7 days"
-msgstr ""
-
-#: src/olympia/stats/templates/stats/stats.html:60
-msgid "30 days"
-msgstr ""
-
-#: src/olympia/stats/templates/stats/stats.html:63
-msgid "90 days"
-msgstr ""
-
-#: src/olympia/stats/templates/stats/stats.html:66
-msgid "365 days"
-msgstr ""
-
-#: src/olympia/stats/templates/stats/stats.html:69
-msgid "Custom..."
-msgstr ""
-
 #. {0} is an add-on name
-#: src/olympia/stats/templates/stats/stats.html:88 src/olympia/stats/templates/stats/stats.html:91
+#: src/olympia/stats/templates/stats/stats.html:44 src/olympia/stats/templates/stats/stats.html:47
 msgid "Statistics for {0}"
 msgstr ""
 
-#: src/olympia/stats/templates/stats/stats.html:94
+#: src/olympia/stats/templates/stats/stats.html:50
 msgid "Statistics Dashboard"
 msgstr ""
 
-#: src/olympia/stats/templates/stats/stats.html:104
+#: src/olympia/stats/templates/stats/stats.html:57
+msgid "Controls:"
+msgstr ""
+
+#: src/olympia/stats/templates/stats/stats.html:60
+msgid "reset zoom"
+msgstr ""
+
+#: src/olympia/stats/templates/stats/stats.html:67
+msgid "Group by:"
+msgstr ""
+
+#: src/olympia/stats/templates/stats/stats.html:69
+msgid "day"
+msgstr ""
+
+#: src/olympia/stats/templates/stats/stats.html:72
+msgid "week"
+msgstr ""
+
+#: src/olympia/stats/templates/stats/stats.html:75
+msgid "month"
+msgstr ""
+
+#: src/olympia/stats/templates/stats/stats.html:81
+msgid "For last:"
+msgstr ""
+
+#: src/olympia/stats/templates/stats/stats.html:84
+msgid "7 days"
+msgstr ""
+
+#: src/olympia/stats/templates/stats/stats.html:87
+msgid "30 days"
+msgstr ""
+
+#: src/olympia/stats/templates/stats/stats.html:90
+msgid "90 days"
+msgstr ""
+
+#: src/olympia/stats/templates/stats/stats.html:93
+msgid "365 days"
+msgstr ""
+
+#: src/olympia/stats/templates/stats/stats.html:96
+msgid "Custom..."
+msgstr ""
+
+#: src/olympia/stats/templates/stats/stats.html:106
 msgid "Statistics processing is currently disabled, so recent data is unavailable. The statistics are still being collected and this page will be updated soon with the missing data."
 msgstr ""
 
-#: src/olympia/stats/templates/stats/stats.html:110
+#: src/olympia/stats/templates/stats/stats.html:112
 msgid "Loading the latest data&hellip;"
 msgstr ""
 
-#: src/olympia/stats/templates/stats/stats.html:142 src/olympia/stats/templates/stats/reports/overview.html:25 src/olympia/stats/templates/stats/reports/overview.html:37
+#: src/olympia/stats/templates/stats/stats.html:144 src/olympia/stats/templates/stats/reports/overview.html:25 src/olympia/stats/templates/stats/reports/overview.html:37
 #: src/olympia/stats/templates/stats/reports/overview.html:49
 msgid "No data available."
 msgstr ""
 
-#: src/olympia/stats/templates/stats/stats.html:177
+#: src/olympia/stats/templates/stats/stats.html:179
 msgid "This dashboard is currently <b>public</b>."
 msgstr ""
 
-#: src/olympia/stats/templates/stats/stats.html:179
+#: src/olympia/stats/templates/stats/stats.html:181
 msgid "Contribution stats are currently <b>private</b>."
 msgstr ""
 
-#: src/olympia/stats/templates/stats/stats.html:182
+#: src/olympia/stats/templates/stats/stats.html:184
 msgid "This dashboard is currently <b>private</b>."
 msgstr ""
 
-#: src/olympia/stats/templates/stats/stats.html:185
+#: src/olympia/stats/templates/stats/stats.html:187
 msgid "Change settings."
 msgstr ""
 
@@ -11299,15 +11141,6 @@ msgstr ""
 msgid "Application versions by Date"
 msgstr ""
 
-#: src/olympia/tags/templates/tags/top_cloud.html:4
-msgid "Top {0} Tags"
-msgstr ""
-
-#. {0} is the current application name
-#: src/olympia/tags/templates/tags/top_cloud.html:14
-msgid "{0} Top Tags"
-msgstr ""
-
 #: src/olympia/templates/amo_footer.html:6 src/olympia/templates/includes/lang_switcher.html:2
 msgid "Other languages"
 msgstr ""
@@ -11316,11 +11149,11 @@ msgstr ""
 msgid "Mozilla Add-ons"
 msgstr ""
 
-#: src/olympia/templates/base.html:91 src/olympia/templates/impala/base.html:81
+#: src/olympia/templates/base.html:89 src/olympia/templates/impala/base.html:78
 msgid "Find add-ons for other applications"
 msgstr ""
 
-#: src/olympia/templates/base.html:92 src/olympia/templates/impala/base.html:81
+#: src/olympia/templates/base.html:90 src/olympia/templates/impala/base.html:78
 msgid "Other Applications"
 msgstr ""
 
@@ -11345,7 +11178,7 @@ msgid "View Mobile Site"
 msgstr ""
 
 #: src/olympia/templates/copyright.html:7
-msgid "Site Status "
+msgid "Site Status"
 msgstr ""
 
 #: src/olympia/templates/footer.html:3
@@ -11445,35 +11278,35 @@ msgstr ""
 msgid "<a href=\"%(reg)s\">Register</a> or <a href=\"%(login)s\">Log in</a>"
 msgstr ""
 
-#: src/olympia/templates/impala/base.html:126
+#: src/olympia/templates/impala/base.html:123
 #, python-format
 msgid "To try the thousands of add-ons available here, download <a href=\"%(url)s\">Mozilla Firefox</a>, a fast, free way to surf the Web!"
 msgstr ""
 
-#: src/olympia/templates/impala/base.html:138
+#: src/olympia/templates/impala/base.html:135
 #, python-format
 msgid "Add-ons is switching to Firefox Accounts for login. <a href=\"%(url)s\" class=\"fxa-login\">Sign in now to transfer your account.</a>"
 msgstr ""
 
 #. {0} is an application, such as Firefox.
-#: src/olympia/templates/impala/base.html:148
+#: src/olympia/templates/impala/base.html:145
 msgid "Welcome to {0} Add-ons."
 msgstr ""
 
-#: src/olympia/templates/impala/base.html:151
+#: src/olympia/templates/impala/base.html:148
 msgid "Choose from thousands of extra features and styles to make Firefox your own."
 msgstr ""
 
-#: src/olympia/templates/impala/base.html:156
+#: src/olympia/templates/impala/base.html:153
 #, python-format
 msgid "Add extra features and styles to make %(app)s your own."
 msgstr ""
 
-#: src/olympia/templates/impala/base.html:164
+#: src/olympia/templates/impala/base.html:161
 msgid "On the go?"
 msgstr ""
 
-#: src/olympia/templates/impala/base.html:166
+#: src/olympia/templates/impala/base.html:163
 msgid "Check out our <a class=\"mobile-link\" href=\"#\">Mobile Add-ons site</a>."
 msgstr ""
 
@@ -11697,19 +11530,19 @@ msgstr ""
 
 #. L10n: {id} will be something like "13ad6a", just a random number
 #. to differentiate this user from other anonymous users.
-#: src/olympia/users/models.py:353
+#: src/olympia/users/models.py:362
 msgid "Anonymous user {id}"
 msgstr ""
 
-#: src/olympia/users/models.py:410
+#: src/olympia/users/models.py:419
 msgid "Your account has been restricted"
 msgstr ""
 
-#: src/olympia/users/models.py:480
+#: src/olympia/users/models.py:489
 msgid "Please confirm your email address"
 msgstr ""
 
-#: src/olympia/users/models.py:506
+#: src/olympia/users/models.py:515
 msgid "My Mobile Add-ons"
 msgstr ""
 
@@ -11986,7 +11819,7 @@ msgstr ""
 
 #: src/olympia/users/templates/users/edit.html:70
 #, python-format
-msgid "Change your password.  If you forgot your password, you can <a href=\"%(reset_url)s\">use the reset form</a>."
+msgid "Change your password. If you forgot your password, you can <a href=\"%(reset_url)s\">use the reset form</a>."
 msgstr ""
 
 #: src/olympia/users/templates/users/edit.html:76
@@ -12006,7 +11839,7 @@ msgid "Profile"
 msgstr ""
 
 #: src/olympia/users/templates/users/edit.html:100
-msgid "Give us a bit more information about yourself.  All these fields are optional, but they'll help other users get to know you better."
+msgid "Give us a bit more information about yourself. All these fields are optional, but they'll help other users get to know you better."
 msgstr ""
 
 #: src/olympia/users/templates/users/edit.html:124
@@ -12222,7 +12055,7 @@ msgid "Confirm password"
 msgstr ""
 
 #: src/olympia/users/templates/users/pwreset_confirm.html:47
-msgid "The password reset link was invalid, possibly because it has already been used.  Please request a new password reset."
+msgid "The password reset link was invalid, possibly because it has already been used. Please request a new password reset."
 msgstr ""
 
 #: src/olympia/users/templates/users/pwreset_request.html:15
@@ -12408,7 +12241,7 @@ msgstr ""
 
 #: src/olympia/users/templates/users/unsubscribe.html:30
 #, python-format
-msgid "Unfortunately, we weren't able to unsubscribe you.  The link you clicked is invalid. However, you can unsubscribe still unsubscribe on your <a href=\"%(edit_url)s\">edit profile page</a>."
+msgid "Unfortunately, we weren't able to unsubscribe you. The link you clicked is invalid. However, you can unsubscribe still unsubscribe on your <a href=\"%(edit_url)s\">edit profile page</a>."
 msgstr ""
 
 #: src/olympia/users/templates/users/vcard.html:2
@@ -12462,15 +12295,15 @@ msgstr ""
 msgid "Version History with Changelogs"
 msgstr ""
 
-#: src/olympia/versions/models.py:314
+#: src/olympia/versions/models.py:313
 msgid "Add-on uses binary components."
 msgstr ""
 
-#: src/olympia/versions/models.py:317
+#: src/olympia/versions/models.py:316
 msgid "Add-on has opted into strict compatibility checking."
 msgstr ""
 
-#: src/olympia/versions/models.py:715
+#: src/olympia/versions/models.py:711
 msgid "{app} {min} and later"
 msgstr ""
 
@@ -12545,4 +12378,8 @@ msgstr ""
 
 #: src/olympia/zadmin/forms.py:105
 msgid "Log emails instead of sending"
+msgstr ""
+
+#: src/olympia/zadmin/forms.py:215
+msgid "Deleted versions can`t be changed."
 msgstr ""

--- a/locale/ast/LC_MESSAGES/djangojs.po
+++ b/locale/ast/LC_MESSAGES/djangojs.po
@@ -1,1216 +1,1236 @@
-
 #, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2016-02-24 21:23+0000\n"
+"POT-Creation-Date: 2016-04-18 15:47+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
+"Language: \n"
 "MIME-Version: 1.0\n"
-"Content-Type: text/plain; charset=utf-8\n"
+"Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Generated-By: Babel 2.2.0\n"
 
-#: static/js/common/ratingwidget.js:31
+#: static/js/common-all.js:1426 static/js/impala-all.js:1511 static/js/zamboni/discovery-all.js:12598 static/js/zamboni/init.js:28 static/js/zamboni/mobile-all.js:14945
+msgid "This feature is temporarily disabled while we perform website maintenance. Please check back a little later."
+msgstr ""
+
+#. L10n: {0} is an app name like Firefox.
+#: static/js/common-all.js:1837 static/js/impala-all.js:1922 static/js/zamboni/buttons.js:73 static/js/zamboni/discovery-all.js:13108
+msgid "Accept and Install"
+msgstr ""
+
+#: static/js/common-all.js:1837 static/js/impala-all.js:1922 static/js/zamboni/buttons.js:73 static/js/zamboni/discovery-all.js:13108
+msgid "Add to {0}"
+msgstr ""
+
+#: static/js/common-all.js:1842 static/js/impala-all.js:1927 static/js/zamboni/buttons.js:78 static/js/zamboni/discovery-all.js:13113
+msgid "Download Now"
+msgstr ""
+
+#: static/js/common-all.js:1883 static/js/impala-all.js:1968 static/js/zamboni/buttons.js:119 static/js/zamboni/discovery-all.js:13154
+msgid "Add-on has not been updated to support default-to-compatible."
+msgstr ""
+
+#: static/js/common-all.js:1888 static/js/impala-all.js:1973 static/js/zamboni/buttons.js:124 static/js/zamboni/discovery-all.js:13159
+msgid "You need to be using Firefox 10.0 or higher."
+msgstr ""
+
+#: static/js/common-all.js:1900 static/js/impala-all.js:1985 static/js/zamboni/buttons.js:136 static/js/zamboni/discovery-all.js:13171
+msgid "Mozilla has marked this version as incompatible with your Firefox version."
+msgstr ""
+
+#. L10n: {0} is an platform like Windows or Linux.
+#: static/js/common-all.js:1981 static/js/impala-all.js:2066 static/js/zamboni/buttons.js:217 static/js/zamboni/discovery-all.js:13252
+msgid "Install for {0} anyway"
+msgstr ""
+
+#: static/js/common-all.js:1981 static/js/impala-all.js:2066 static/js/zamboni/buttons.js:217 static/js/zamboni/discovery-all.js:13252
+msgid "Download for {0} anyway"
+msgstr ""
+
+#: static/js/common-all.js:2038 static/js/impala-all.js:2123 static/js/zamboni/buttons.js:274 static/js/zamboni/discovery-all.js:13309
+msgid "Not available for your platform"
+msgstr ""
+
+#. L10n: {0} is an app name, {1} is the app version.
+#: static/js/common-all.js:2049 static/js/common-all.js:2086 static/js/impala-all.js:2134 static/js/impala-all.js:2171 static/js/zamboni/buttons.js:286 static/js/zamboni/buttons.js:324
+#: static/js/zamboni/discovery-all.js:13320 static/js/zamboni/discovery-all.js:13357
+msgid "Not available for {0} {1}"
+msgstr ""
+
+#: static/js/common-all.js:2112 static/js/impala-all.js:2197 static/js/zamboni/buttons.js:351 static/js/zamboni/discovery-all.js:13383
+msgid "Works with {app} {min} - {max}"
+msgstr ""
+
+#: static/js/common-all.js:2114 static/js/impala-all.js:2199 static/js/zamboni/buttons.js:353 static/js/zamboni/discovery-all.js:13385
+msgid "View other versions"
+msgstr ""
+
+#: static/js/common-all.js:2162 static/js/impala-all.js:2247 static/js/zamboni/buttons.js:401 static/js/zamboni/discovery-all.js:13433
+msgid "Only with Firefox — Get Firefox Now!"
+msgstr ""
+
+#: static/js/common-all.js:2278 static/js/impala-all.js:2363 static/js/zamboni/buttons.js:517 static/js/zamboni/discovery-all.js:13549 static/js/zamboni/mobile-all.js:15177
+#: static/js/zamboni/mobile/buttons.js:43
+msgid "Sorry, you need a Mozilla-based browser (such as Firefox) to install a search plugin."
+msgstr ""
+
+#: static/js/common-all.js:9088 static/js/impala-all.js:9649 static/js/zamboni/global.js:410
+msgid "Loading..."
+msgstr ""
+
+#. L10n: {0} is the number of characters left.
+#: static/js/common-all.js:9152 static/js/impala-all.js:9713 static/js/zamboni/global.js:474
+msgid "<b>{0}</b> character left."
+msgid_plural "<b>{0}</b> characters left."
+msgstr[0] ""
+msgstr[1] ""
+
+#: static/js/common-all.js:9589 static/js/common-min.js:6 static/js/impala-all.js:10052 static/js/impala-min.js:6 static/js/common/ratingwidget.js:31 static/js/zamboni/mobile-all.js:16123
+#: static/js/zamboni/mobile-min.js:6
 msgid "{0} star"
 msgid_plural "{0} stars"
 msgstr[0] ""
 msgstr[1] ""
 
-#: static/js/common/upload-addon.js:41 static/js/common/upload-image.js:128
+#: static/js/common-all.js:9676 static/js/common-min.js:6 static/js/impala-all.js:10139 static/js/impala-min.js:6 static/js/zamboni/l10n.js:45
+msgid "Remove this localization"
+msgstr ""
+
+#: static/js/common-all.js:10193 static/js/common-min.js:6 static/js/impala-all.js:10674 static/js/impala-min.js:6 static/js/zamboni/discovery-all.js:13678
+msgid "close"
+msgstr ""
+
+#: static/js/common-all.js:10860 static/js/common-min.js:6 static/js/impala-all.js:11481 static/js/impala-min.js:6 static/js/impala/reviews.js:23 static/js/zamboni/reviews.js:18
+msgid "Flagged for review"
+msgstr ""
+
+#: static/js/common-all.js:10876 static/js/common-min.js:6 static/js/impala-all.js:11498 static/js/impala-min.js:6 static/js/impala/reviews.js:40 static/js/zamboni/reviews.js:34
+msgid "Your input is required"
+msgstr ""
+
+#: static/js/common-all.js:10945 static/js/common-min.js:6 static/js/impala-all.js:11610 static/js/impala-min.js:7 static/js/impala/reviews.js:152 static/js/zamboni/reviews.js:103
+msgid "Marked for deletion"
+msgstr ""
+
+#: static/js/common-all.js:11573 static/js/common-min.js:7 static/js/impala-all.js:13809 static/js/impala-min.js:8 static/js/zamboni/collections.js:229
+msgid "Adding to Favorites&hellip;"
+msgstr ""
+
+#: static/js/common-all.js:11576 static/js/common-min.js:7 static/js/impala-all.js:13812 static/js/impala-min.js:8 static/js/zamboni/collections.js:232
+msgid "Removing Favorite&hellip;"
+msgstr ""
+
+#: static/js/common-all.js:11579 static/js/common-min.js:7 static/js/impala-all.js:13815 static/js/impala-min.js:8 static/js/zamboni/collections.js:235
+msgid "Add to Favorites"
+msgstr ""
+
+#: static/js/common-all.js:11582 static/js/common-min.js:7 static/js/impala-all.js:13818 static/js/impala-min.js:8 static/js/zamboni/collections.js:238
+msgid "Remove from Favorites"
+msgstr ""
+
+#: static/js/common-all.js:11647 static/js/common-min.js:7 static/js/impala-all.js:13883 static/js/impala-min.js:8 static/js/zamboni/collections.js:303
+msgid "Pending"
+msgstr ""
+
+#: static/js/common-all.js:11648 static/js/common-min.js:7 static/js/impala-all.js:13884 static/js/impala-min.js:8 static/js/zamboni/collections.js:304
+msgid "Add a comment"
+msgstr ""
+
+#: static/js/common-all.js:11648 static/js/common-min.js:7 static/js/impala-all.js:13884 static/js/impala-min.js:8 static/js/zamboni/collections.js:304
+msgid "Comment"
+msgstr ""
+
+#: static/js/common-all.js:11649 static/js/common-min.js:7 static/js/impala-all.js:13885 static/js/impala-min.js:8 static/js/zamboni/collections.js:305
+msgid "Remove this add-on from the collection"
+msgstr ""
+
+#: static/js/common-all.js:11649 static/js/common-all.js:11678 static/js/common-min.js:7 static/js/impala-all.js:13885 static/js/impala-all.js:13914 static/js/impala-min.js:8
+#: static/js/zamboni/collections.js:305 static/js/zamboni/collections.js:334
+msgid "Remove"
+msgstr ""
+
+#: static/js/common-all.js:11678 static/js/common-min.js:7 static/js/impala-all.js:13914 static/js/impala-min.js:8 static/js/zamboni/collections.js:334
+msgid "Remove this user as a contributor"
+msgstr ""
+
+#: static/js/common-all.js:11690 static/js/common-min.js:7 static/js/impala-all.js:13926 static/js/impala-min.js:8 static/js/zamboni/collections.js:346
+msgid "An email address is required."
+msgstr ""
+
+#: static/js/common-all.js:11708 static/js/common-min.js:7 static/js/impala-all.js:13944 static/js/impala-min.js:8 static/js/zamboni/collections.js:364
+msgid "You cannot add yourself as a contributor."
+msgstr ""
+
+#: static/js/common-all.js:11710 static/js/common-min.js:7 static/js/impala-all.js:13946 static/js/impala-min.js:8 static/js/zamboni/collections.js:366
+msgid "You have already added that user."
+msgstr ""
+
+#: static/js/common-all.js:11917 static/js/common-min.js:7 static/js/impala-all.js:14153 static/js/impala-min.js:8 static/js/zamboni/collections.js:573
+msgid "Add to favorites"
+msgstr ""
+
+#: static/js/common-all.js:11921 static/js/common-min.js:7 static/js/impala-all.js:14157 static/js/impala-min.js:8 static/js/zamboni/collections.js:577
+msgid "Remove from favorites"
+msgstr ""
+
+#: static/js/common-all.js:11939 static/js/common-min.js:7 static/js/impala-all.js:14175 static/js/impala-all.js:14233 static/js/impala-min.js:8 static/js/impala/collections.js:10
+#: static/js/zamboni/collections.js:595
+msgid "Follow this Collection"
+msgstr ""
+
+#: static/js/common-all.js:11948 static/js/common-min.js:7 static/js/impala-all.js:14184 static/js/impala-min.js:8 static/js/zamboni/collections.js:604
+msgid "Stop following"
+msgstr ""
+
+#: static/js/common-all.js:12096 static/js/common-min.js:7 static/js/zamboni/password-strength.js:20
+msgid "Password strength:"
+msgstr ""
+
+#: static/js/common-all.js:12102 static/js/common-min.js:7 static/js/zamboni/password-strength.js:26
+msgid "At least {0} character left."
+msgid_plural "At least {0} characters left."
+msgstr[0] ""
+msgstr[1] ""
+
+#: static/js/common-all.js:12286 static/js/common-min.js:7 static/js/impala-all.js:14632 static/js/impala-min.js:8 static/js/impala/suggestions.js:39
+msgid "Search themes for <b>{0}</b>"
+msgstr ""
+
+#: static/js/common-all.js:12288 static/js/common-min.js:7 static/js/impala-all.js:14634 static/js/impala-min.js:8 static/js/impala/suggestions.js:41
+msgid "Search apps for <b>{0}</b>"
+msgstr ""
+
+#: static/js/common-all.js:12290 static/js/common-min.js:7 static/js/impala-all.js:14636 static/js/impala-min.js:8 static/js/impala/suggestions.js:43
+msgid "Search add-ons for <b>{0}</b>"
+msgstr ""
+
+#: static/js/common-all.js:12521 static/js/common-min.js:7 static/js/impala-all.js:14867 static/js/impala-min.js:8 static/js/impala/site_suggestions.js:46
+msgid "Category"
+msgstr ""
+
+#. L10n: {0} is an app name.
+#: static/js/impala-all.js:11632 static/js/impala-min.js:7 static/js/impala/listing.js:11 static/js/zamboni/themes.js:13
+msgid "This theme is incompatible with your version of {0}"
+msgstr ""
+
+#: static/js/impala-all.js:12146 static/js/impala-all.js:14331 static/js/impala-min.js:7 static/js/impala-min.js:8 static/js/common/upload-image.js:97 static/js/impala/users.js:51
+#: static/js/zamboni/devhub-all.js:894 static/js/zamboni/devhub-min.js:1
+msgid "Images must be either PNG or JPG."
+msgstr ""
+
+#: static/js/impala-all.js:12150 static/js/impala-min.js:7 static/js/common/upload-image.js:101 static/js/zamboni/devhub-all.js:898 static/js/zamboni/devhub-min.js:1
+msgid "Videos must be in WebM."
+msgstr ""
+
+#: static/js/impala-all.js:12177 static/js/impala-min.js:7 static/js/common/upload-addon.js:41 static/js/common/upload-image.js:128 static/js/zamboni/devhub-all.js:272
+#: static/js/zamboni/devhub-all.js:925 static/js/zamboni/devhub-min.js:1
 msgid "There was a problem contacting the server."
 msgstr ""
 
-#: static/js/common/upload-addon.js:69
+#: static/js/impala-all.js:13298 static/js/impala-min.js:7 static/js/impala/persona_creation.js:60
+msgid "All Rights Reserved"
+msgstr ""
+
+#: static/js/impala-all.js:13302 static/js/impala-min.js:7 static/js/impala/persona_creation.js:64
+msgid "Creative Commons Attribution 3.0"
+msgstr ""
+
+#: static/js/impala-all.js:13307 static/js/impala-min.js:7 static/js/impala/persona_creation.js:69
+msgid "Creative Commons Attribution-NonCommercial 3.0"
+msgstr ""
+
+#: static/js/impala-all.js:13312 static/js/impala-min.js:7 static/js/impala/persona_creation.js:74
+msgid "Creative Commons Attribution-NonCommercial-NoDerivs 3.0"
+msgstr ""
+
+#: static/js/impala-all.js:13317 static/js/impala-min.js:7 static/js/impala/persona_creation.js:79
+msgid "Creative Commons Attribution-NonCommercial-Share Alike 3.0"
+msgstr ""
+
+#: static/js/impala-all.js:13322 static/js/impala-min.js:7 static/js/impala/persona_creation.js:84
+msgid "Creative Commons Attribution-NoDerivs 3.0"
+msgstr ""
+
+#: static/js/impala-all.js:13327 static/js/impala-min.js:7 static/js/impala/persona_creation.js:89
+msgid "Creative Commons Attribution-ShareAlike 3.0"
+msgstr ""
+
+#: static/js/impala-all.js:13530 static/js/impala-min.js:7 static/js/impala/persona_creation.js:292
+msgid "Your Theme's Name"
+msgstr ""
+
+#: static/js/impala-all.js:14242 static/js/impala-min.js:8 static/js/impala/collections.js:19
+msgid "Stop Following"
+msgstr ""
+
+#: static/js/impala-all.js:14243 static/js/impala-min.js:8 static/js/impala/collections.js:20
+msgid "Following"
+msgstr ""
+
+#: static/js/impala-all.js:14313 static/js/impala-min.js:8 static/js/impala/users.js:33
+msgid "use original"
+msgstr ""
+
+#: static/js/impala-all.js:14523 static/js/impala-min.js:8 static/js/impala/search.js:114
+msgid "Updating results&hellip;"
+msgstr ""
+
+#: static/js/common/upload-addon.js:69 static/js/zamboni/devhub-all.js:300 static/js/zamboni/devhub-min.js:1
 msgid "Select a file..."
 msgstr ""
 
-#: static/js/common/upload-addon.js:70
+#: static/js/common/upload-addon.js:70 static/js/zamboni/devhub-all.js:301 static/js/zamboni/devhub-min.js:1
 msgid "Your add-on should end with .xpi, .jar or .xml"
 msgstr ""
 
 #. L10n: {0} is the percent of the file that has been uploaded.
-#: static/js/common/upload-addon.js:104
+#: static/js/common/upload-addon.js:104 static/js/zamboni/devhub-all.js:335 static/js/zamboni/devhub-min.js:1
 #, python-format
 msgid "{0}% complete"
 msgstr ""
 
 #. L10n: "{bytes uploaded} of {total filesize}".
-#: static/js/common/upload-addon.js:107
+#: static/js/common/upload-addon.js:107 static/js/zamboni/devhub-all.js:338 static/js/zamboni/devhub-min.js:1
 msgid "{0} of {1}"
 msgstr ""
 
-#: static/js/common/upload-addon.js:140
+#: static/js/common/upload-addon.js:140 static/js/zamboni/devhub-all.js:371 static/js/zamboni/devhub-min.js:1
 msgid "Cancel"
 msgstr ""
 
-#: static/js/common/upload-addon.js:162
+#: static/js/common/upload-addon.js:162 static/js/zamboni/devhub-all.js:393 static/js/zamboni/devhub-min.js:1
 msgid "Uploading {0}"
 msgstr ""
 
-#: static/js/common/upload-addon.js:189
+#: static/js/common/upload-addon.js:189 static/js/zamboni/devhub-all.js:420 static/js/zamboni/devhub-min.js:1
 msgid "Error with {0}"
 msgstr ""
 
-#: static/js/common/upload-addon.js:194
+#: static/js/common/upload-addon.js:194 static/js/zamboni/devhub-all.js:425 static/js/zamboni/devhub-min.js:1
 msgid "Your add-on failed validation with {0} error."
 msgid_plural "Your add-on failed validation with {0} errors."
 msgstr[0] ""
 msgstr[1] ""
 
-#: static/js/common/upload-addon.js:208
+#: static/js/common/upload-addon.js:208 static/js/zamboni/devhub-all.js:439 static/js/zamboni/devhub-min.js:1
 msgid "&hellip;and {0} more"
 msgid_plural "&hellip;and {0} more"
 msgstr[0] ""
 msgstr[1] ""
 
-#: static/js/common/upload-addon.js:222 static/js/common/upload-addon.js:512
+#: static/js/common/upload-addon.js:222 static/js/common/upload-addon.js:497 static/js/zamboni/devhub-all.js:453 static/js/zamboni/devhub-all.js:743 static/js/zamboni/devhub-min.js:1
 msgid "See full validation report"
 msgstr ""
 
-#: static/js/common/upload-addon.js:234
+#: static/js/common/upload-addon.js:234 static/js/zamboni/devhub-all.js:465 static/js/zamboni/devhub-min.js:1
 msgid "Validating {0}"
 msgstr ""
 
 #. L10n: first argument is an HTTP status code
-#: static/js/common/upload-addon.js:273
+#: static/js/common/upload-addon.js:273 static/js/zamboni/devhub-all.js:504 static/js/zamboni/devhub-min.js:1
 msgid "Received an empty response from the server; status: {0}"
 msgstr ""
 
-#: static/js/common/upload-addon.js:373
+#: static/js/common/upload-addon.js:370 static/js/zamboni/devhub-all.js:604 static/js/zamboni/devhub-min.js:1
 msgid "Unexpected server error while validating."
 msgstr ""
 
-#: static/js/common/upload-addon.js:412
+#: static/js/common/upload-addon.js:409 static/js/zamboni/devhub-all.js:643 static/js/zamboni/devhub-min.js:1
 msgid "Finished validating {0}"
 msgstr ""
 
-#: static/js/common/upload-addon.js:418
+#: static/js/common/upload-addon.js:415 static/js/zamboni/devhub-all.js:649 static/js/zamboni/devhub-min.js:1
 msgid "Your add-on validation timed out, it will be manually reviewed."
 msgstr ""
 
-#: static/js/common/upload-addon.js:421
+#: static/js/common/upload-addon.js:418 static/js/zamboni/devhub-all.js:652 static/js/zamboni/devhub-min.js:1
 msgid "Your add-on was validated with no errors and {0} warning."
 msgid_plural "Your add-on was validated with no errors and {0} warnings."
 msgstr[0] ""
 msgstr[1] ""
 
-#: static/js/common/upload-addon.js:426
+#: static/js/common/upload-addon.js:423 static/js/zamboni/devhub-all.js:657 static/js/zamboni/devhub-min.js:1
 msgid "Your add-on was validated with no errors and {0} message."
 msgid_plural "Your add-on was validated with no errors and {0} messages."
 msgstr[0] ""
 msgstr[1] ""
 
-#: static/js/common/upload-addon.js:431
+#: static/js/common/upload-addon.js:428 static/js/zamboni/devhub-all.js:662 static/js/zamboni/devhub-min.js:1
 msgid "Your add-on was validated with no errors or warnings."
 msgstr ""
 
-#: static/js/common/upload-addon.js:446
+#: static/js/common/upload-addon.js:443 static/js/zamboni/devhub-all.js:677 static/js/zamboni/devhub-min.js:1
 msgid "Your submission will be automatically signed."
 msgstr ""
 
-#: static/js/common/upload-addon.js:465
+#: static/js/common/upload-addon.js:450 static/js/zamboni/devhub-all.js:696 static/js/zamboni/devhub-min.js:1
 msgid "Include detailed version notes (this can be done in the next step)."
 msgstr ""
 
-#: static/js/common/upload-addon.js:466
+#: static/js/common/upload-addon.js:451 static/js/zamboni/devhub-all.js:697 static/js/zamboni/devhub-min.js:1
 msgid "If your add-on requires an account to a website in order to be fully tested, include a test username and password in the Notes to Reviewer (this can be done in the next step)."
 msgstr ""
 
-#: static/js/common/upload-addon.js:467
+#: static/js/common/upload-addon.js:452 static/js/zamboni/devhub-all.js:698 static/js/zamboni/devhub-min.js:1
 msgid "If your add-on is intended for a limited audience you should choose Preliminary Review instead of Full Review."
 msgstr ""
 
-#: static/js/common/upload-addon.js:480
+#: static/js/common/upload-addon.js:465 static/js/zamboni/devhub-all.js:711 static/js/zamboni/devhub-min.js:1
 msgid "Add-on submission checklist"
 msgstr ""
 
-#: static/js/common/upload-addon.js:481
+#: static/js/common/upload-addon.js:466 static/js/zamboni/devhub-all.js:712 static/js/zamboni/devhub-min.js:1
 msgid "Please verify the following points before finalizing your submission. This will minimize delays or misunderstanding during the review process:"
 msgstr ""
 
-#: static/js/common/upload-addon.js:483
+#: static/js/common/upload-addon.js:468 static/js/zamboni/devhub-all.js:714 static/js/zamboni/devhub-min.js:1
 msgid ""
 "Compiled binaries, as well as minified or obfuscated scripts (excluding known libraries) need to have their sources submitted separately for review. Make sure that you use the source code upload "
 "field to avoid having your submission rejected."
 msgstr ""
 
-#: static/js/common/upload-addon.js:501
+#: static/js/common/upload-addon.js:486 static/js/zamboni/devhub-all.js:732 static/js/zamboni/devhub-min.js:1
 msgid "The validation process found these issues that can lead to rejections:"
 msgstr ""
 
-#: static/js/common/upload-addon.js:518
+#: static/js/common/upload-addon.js:503 static/js/zamboni/devhub-all.js:749 static/js/zamboni/devhub-min.js:1
 msgid "If you are unfamiliar with the add-ons review process, you can read about it here."
 msgstr ""
 
-#: static/js/common/upload-addon.js:555
+#: static/js/common/upload-addon.js:540 static/js/zamboni/devhub-all.js:786 static/js/zamboni/devhub-min.js:1
 msgid "Sorry, no supported platform has been found."
 msgstr ""
 
-#: static/js/common/upload-base.js:57
+#: static/js/common/upload-base.js:57 static/js/zamboni/devhub-all.js:187 static/js/zamboni/devhub-min.js:1
 msgid "The filetype you uploaded isn't recognized."
 msgstr ""
 
-#: static/js/common/upload-base.js:79
+#: static/js/common/upload-base.js:79 static/js/zamboni/devhub-all.js:209 static/js/zamboni/devhub-min.js:1
 msgid "You cancelled the upload."
 msgstr ""
 
-#: static/js/common/upload-image.js:97 static/js/impala/users.js:51
-msgid "Images must be either PNG or JPG."
-msgstr ""
-
-#: static/js/common/upload-image.js:101
-msgid "Videos must be in WebM."
-msgstr ""
-
-#: static/js/impala/collections.js:10 static/js/zamboni/collections.js:595
-msgid "Follow this Collection"
-msgstr ""
-
-#: static/js/impala/collections.js:19
-msgid "Stop Following"
-msgstr ""
-
-#: static/js/impala/collections.js:20
-msgid "Following"
-msgstr ""
-
-#. L10n: {0} is an app name.
-#: static/js/impala/listing.js:11 static/js/zamboni/themes.js:13
-msgid "This theme is incompatible with your version of {0}"
-msgstr ""
-
-#: static/js/impala/persona_creation.js:60
-msgid "All Rights Reserved"
-msgstr ""
-
-#: static/js/impala/persona_creation.js:64
-msgid "Creative Commons Attribution 3.0"
-msgstr ""
-
-#: static/js/impala/persona_creation.js:69
-msgid "Creative Commons Attribution-NonCommercial 3.0"
-msgstr ""
-
-#: static/js/impala/persona_creation.js:74
-msgid "Creative Commons Attribution-NonCommercial-NoDerivs 3.0"
-msgstr ""
-
-#: static/js/impala/persona_creation.js:79
-msgid "Creative Commons Attribution-NonCommercial-Share Alike 3.0"
-msgstr ""
-
-#: static/js/impala/persona_creation.js:84
-msgid "Creative Commons Attribution-NoDerivs 3.0"
-msgstr ""
-
-#: static/js/impala/persona_creation.js:89
-msgid "Creative Commons Attribution-ShareAlike 3.0"
-msgstr ""
-
-#: static/js/impala/persona_creation.js:292
-msgid "Your Theme's Name"
-msgstr ""
-
-#: static/js/impala/reviews.js:23 static/js/zamboni/reviews.js:18
-msgid "Flagged for review"
-msgstr ""
-
-#: static/js/impala/reviews.js:40 static/js/zamboni/reviews.js:34
-msgid "Your input is required"
-msgstr ""
-
-#: static/js/impala/reviews.js:152 static/js/zamboni/reviews.js:103
-msgid "Marked for deletion"
-msgstr ""
-
-#: static/js/impala/search.js:114
-msgid "Updating results&hellip;"
-msgstr ""
-
-#: static/js/impala/site_suggestions.js:46
-msgid "Category"
-msgstr ""
-
-#: static/js/impala/suggestions.js:39
-msgid "Search themes for <b>{0}</b>"
-msgstr ""
-
-#: static/js/impala/suggestions.js:41
-msgid "Search apps for <b>{0}</b>"
-msgstr ""
-
-#: static/js/impala/suggestions.js:43
-msgid "Search add-ons for <b>{0}</b>"
-msgstr ""
-
-#: static/js/impala/users.js:33
-msgid "use original"
-msgstr ""
-
-#: static/js/impala/stats/chart.js:267
+#: static/js/impala/stats/chart.js:267 static/js/zamboni/stats-all.js:16898 static/js/zamboni/stats-min.js:5
 msgid "Week of {0}"
 msgstr ""
 
-#: static/js/impala/stats/chart.js:269
+#: static/js/impala/stats/chart.js:269 static/js/zamboni/stats-all.js:16900 static/js/zamboni/stats-min.js:5
 msgid " downloads"
 msgstr ""
 
-#: static/js/impala/stats/chart.js:270
+#: static/js/impala/stats/chart.js:270 static/js/zamboni/stats-all.js:16901 static/js/zamboni/stats-min.js:5
 msgid "{0} users"
 msgstr ""
 
-#: static/js/impala/stats/chart.js:271
+#: static/js/impala/stats/chart.js:271 static/js/zamboni/stats-all.js:16902 static/js/zamboni/stats-min.js:5
 msgid "{0} add-ons"
 msgstr ""
 
-#: static/js/impala/stats/chart.js:272
+#: static/js/impala/stats/chart.js:272 static/js/zamboni/stats-all.js:16903 static/js/zamboni/stats-min.js:5
 msgid "{0} collections"
 msgstr ""
 
-#: static/js/impala/stats/chart.js:273
+#: static/js/impala/stats/chart.js:273 static/js/zamboni/stats-all.js:16904 static/js/zamboni/stats-min.js:5
 msgid "{0} reviews"
 msgstr ""
 
-#: static/js/impala/stats/chart.js:275
+#: static/js/impala/stats/chart.js:275 static/js/zamboni/stats-all.js:16906 static/js/zamboni/stats-min.js:5
 msgid "{0} sales"
 msgstr ""
 
-#: static/js/impala/stats/chart.js:276
+#: static/js/impala/stats/chart.js:276 static/js/zamboni/stats-all.js:16907 static/js/zamboni/stats-min.js:5
 msgid "{0} refunds"
 msgstr ""
 
-#: static/js/impala/stats/chart.js:277
+#: static/js/impala/stats/chart.js:277 static/js/zamboni/stats-all.js:16908 static/js/zamboni/stats-min.js:5
 msgid "{0} installs"
 msgstr ""
 
-#: static/js/impala/stats/chart.js:369 static/js/impala/stats/csv_keys.js:3 static/js/impala/stats/csv_keys.js:109
+#: static/js/impala/stats/chart.js:369 static/js/impala/stats/csv_keys.js:3 static/js/impala/stats/csv_keys.js:109 static/js/zamboni/stats-all.js:15284 static/js/zamboni/stats-all.js:15390
+#: static/js/zamboni/stats-all.js:17000 static/js/zamboni/stats-min.js:4 static/js/zamboni/stats-min.js:5
 msgid "Downloads"
 msgstr ""
 
-#: static/js/impala/stats/chart.js:379 static/js/impala/stats/csv_keys.js:6 static/js/impala/stats/csv_keys.js:110
+#: static/js/impala/stats/chart.js:379 static/js/impala/stats/csv_keys.js:6 static/js/impala/stats/csv_keys.js:110 static/js/zamboni/stats-all.js:15287 static/js/zamboni/stats-all.js:15391
+#: static/js/zamboni/stats-all.js:17010 static/js/zamboni/stats-min.js:4 static/js/zamboni/stats-min.js:5
 msgid "Daily Users"
 msgstr ""
 
-#: static/js/impala/stats/chart.js:410
+#: static/js/impala/stats/chart.js:410 static/js/zamboni/stats-all.js:17041 static/js/zamboni/stats-min.js:5
 msgid "Amount, in USD"
 msgstr ""
 
-#: static/js/impala/stats/chart.js:421 static/js/impala/stats/csv_keys.js:104
+#: static/js/impala/stats/chart.js:421 static/js/impala/stats/csv_keys.js:104 static/js/zamboni/stats-all.js:15385 static/js/zamboni/stats-all.js:17052 static/js/zamboni/stats-min.js:5
 msgid "Number of Contributions"
 msgstr ""
 
-#: static/js/impala/stats/chart.js:447
+#: static/js/impala/stats/chart.js:447 static/js/zamboni/stats-all.js:17078 static/js/zamboni/stats-min.js:5
 msgid "More Info..."
 msgstr ""
 
 #. L10n: {0} is an ISO-formatted date.
-#: static/js/impala/stats/chart.js:451
+#: static/js/impala/stats/chart.js:451 static/js/zamboni/stats-all.js:17082 static/js/zamboni/stats-min.js:5
 msgid "Details for {0}"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:9
+#: static/js/impala/stats/csv_keys.js:9 static/js/zamboni/stats-all.js:15290 static/js/zamboni/stats-min.js:4
 msgid "Collections Created"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:12
+#: static/js/impala/stats/csv_keys.js:12 static/js/zamboni/stats-all.js:15293 static/js/zamboni/stats-min.js:4
 msgid "Add-ons in Use"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:15
+#: static/js/impala/stats/csv_keys.js:15 static/js/zamboni/stats-all.js:15296 static/js/zamboni/stats-min.js:4
 msgid "Add-ons Created"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:18
+#: static/js/impala/stats/csv_keys.js:18 static/js/zamboni/stats-all.js:15299 static/js/zamboni/stats-min.js:4
 msgid "Add-ons Downloaded"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:21
+#: static/js/impala/stats/csv_keys.js:21 static/js/zamboni/stats-all.js:15302 static/js/zamboni/stats-min.js:4
 msgid "Add-ons Updated"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:24
+#: static/js/impala/stats/csv_keys.js:24 static/js/zamboni/stats-all.js:15305 static/js/zamboni/stats-min.js:4
 msgid "Reviews Written"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:27
+#: static/js/impala/stats/csv_keys.js:27 static/js/zamboni/stats-all.js:15308 static/js/zamboni/stats-min.js:4
 msgid "User Signups"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:30
+#: static/js/impala/stats/csv_keys.js:30 static/js/zamboni/stats-all.js:15311 static/js/zamboni/stats-min.js:4
 msgid "Subscribers"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:33
+#: static/js/impala/stats/csv_keys.js:33 static/js/zamboni/stats-all.js:15314 static/js/zamboni/stats-min.js:4
 msgid "Ratings"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:36 static/js/impala/stats/csv_keys.js:114
+#: static/js/impala/stats/csv_keys.js:36 static/js/impala/stats/csv_keys.js:114 static/js/zamboni/stats-all.js:15317 static/js/zamboni/stats-all.js:15395 static/js/zamboni/stats-min.js:4
+#: static/js/zamboni/stats-min.js:5
 msgid "Sales"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:39 static/js/impala/stats/csv_keys.js:113
+#: static/js/impala/stats/csv_keys.js:39 static/js/impala/stats/csv_keys.js:113 static/js/zamboni/stats-all.js:15320 static/js/zamboni/stats-all.js:15394 static/js/zamboni/stats-min.js:4
+#: static/js/zamboni/stats-min.js:5
 msgid "Installs"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:42
+#: static/js/impala/stats/csv_keys.js:42 static/js/zamboni/stats-all.js:15323 static/js/zamboni/stats-min.js:4
 msgid "Unknown"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:43
+#: static/js/impala/stats/csv_keys.js:43 static/js/zamboni/stats-all.js:15324 static/js/zamboni/stats-min.js:4
 msgid "Add-ons Manager"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:44
+#: static/js/impala/stats/csv_keys.js:44 static/js/zamboni/stats-all.js:15325 static/js/zamboni/stats-min.js:4
 msgid "Add-ons Manager Promo"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:45
+#: static/js/impala/stats/csv_keys.js:45 static/js/zamboni/stats-all.js:15326 static/js/zamboni/stats-min.js:4
 msgid "Add-ons Manager Featured"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:46
+#: static/js/impala/stats/csv_keys.js:46 static/js/zamboni/stats-all.js:15327 static/js/zamboni/stats-min.js:4
 msgid "Add-ons Manager Learn More"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:47
+#: static/js/impala/stats/csv_keys.js:47 static/js/zamboni/stats-all.js:15328 static/js/zamboni/stats-min.js:4
 msgid "Search Suggestions"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:48
+#: static/js/impala/stats/csv_keys.js:48 static/js/zamboni/stats-all.js:15329 static/js/zamboni/stats-min.js:4
 msgid "Search Results"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:49 static/js/impala/stats/csv_keys.js:50 static/js/impala/stats/csv_keys.js:51
+#: static/js/impala/stats/csv_keys.js:49 static/js/impala/stats/csv_keys.js:50 static/js/impala/stats/csv_keys.js:51 static/js/zamboni/stats-all.js:15330 static/js/zamboni/stats-all.js:15331
+#: static/js/zamboni/stats-all.js:15332 static/js/zamboni/stats-min.js:4
 msgid "Homepage Promo"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:52 static/js/impala/stats/csv_keys.js:53
+#: static/js/impala/stats/csv_keys.js:52 static/js/impala/stats/csv_keys.js:53 static/js/zamboni/stats-all.js:15333 static/js/zamboni/stats-all.js:15334 static/js/zamboni/stats-min.js:4
 msgid "Homepage Featured"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:54 static/js/impala/stats/csv_keys.js:55
+#: static/js/impala/stats/csv_keys.js:54 static/js/impala/stats/csv_keys.js:55 static/js/zamboni/stats-all.js:15335 static/js/zamboni/stats-all.js:15336 static/js/zamboni/stats-min.js:4
 msgid "Homepage Up and Coming"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:56
+#: static/js/impala/stats/csv_keys.js:56 static/js/zamboni/stats-all.js:15337 static/js/zamboni/stats-min.js:4
 msgid "Homepage Most Popular"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:57 static/js/impala/stats/csv_keys.js:59
+#: static/js/impala/stats/csv_keys.js:57 static/js/impala/stats/csv_keys.js:59 static/js/zamboni/stats-all.js:15338 static/js/zamboni/stats-all.js:15340 static/js/zamboni/stats-min.js:4
 msgid "Detail Page"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:58 static/js/impala/stats/csv_keys.js:60
+#: static/js/impala/stats/csv_keys.js:58 static/js/impala/stats/csv_keys.js:60 static/js/zamboni/stats-all.js:15339 static/js/zamboni/stats-all.js:15341 static/js/zamboni/stats-min.js:4
 msgid "Detail Page (bottom)"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:61
+#: static/js/impala/stats/csv_keys.js:61 static/js/zamboni/stats-all.js:15342 static/js/zamboni/stats-min.js:4
 msgid "Detail Page (Development Channel)"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:62 static/js/impala/stats/csv_keys.js:63 static/js/impala/stats/csv_keys.js:64
+#: static/js/impala/stats/csv_keys.js:62 static/js/impala/stats/csv_keys.js:63 static/js/impala/stats/csv_keys.js:64 static/js/zamboni/stats-all.js:15343 static/js/zamboni/stats-all.js:15344
+#: static/js/zamboni/stats-all.js:15345 static/js/zamboni/stats-min.js:4
 msgid "Often Used With"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:65 static/js/impala/stats/csv_keys.js:66
+#: static/js/impala/stats/csv_keys.js:65 static/js/impala/stats/csv_keys.js:66 static/js/zamboni/stats-all.js:15346 static/js/zamboni/stats-all.js:15347 static/js/zamboni/stats-min.js:4
 msgid "Others By Author"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:67 static/js/impala/stats/csv_keys.js:68
+#: static/js/impala/stats/csv_keys.js:67 static/js/impala/stats/csv_keys.js:68 static/js/zamboni/stats-all.js:15348 static/js/zamboni/stats-all.js:15349 static/js/zamboni/stats-min.js:4
 msgid "Dependencies"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:69 static/js/impala/stats/csv_keys.js:70
+#: static/js/impala/stats/csv_keys.js:69 static/js/impala/stats/csv_keys.js:70 static/js/zamboni/stats-all.js:15350 static/js/zamboni/stats-all.js:15351 static/js/zamboni/stats-min.js:4
 msgid "Upsell"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:71
+#: static/js/impala/stats/csv_keys.js:71 static/js/zamboni/stats-all.js:15352 static/js/zamboni/stats-min.js:4
 msgid "Meet the Developer"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:72
+#: static/js/impala/stats/csv_keys.js:72 static/js/zamboni/stats-all.js:15353 static/js/zamboni/stats-min.js:4
 msgid "User Profile"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:73
+#: static/js/impala/stats/csv_keys.js:73 static/js/zamboni/stats-all.js:15354 static/js/zamboni/stats-min.js:4
 msgid "Version History"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:75
+#: static/js/impala/stats/csv_keys.js:75 static/js/zamboni/stats-all.js:15356 static/js/zamboni/stats-min.js:4
 msgid "Sharing"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:76
+#: static/js/impala/stats/csv_keys.js:76 static/js/zamboni/stats-all.js:15357 static/js/zamboni/stats-min.js:4
 msgid "Category Pages"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:77
+#: static/js/impala/stats/csv_keys.js:77 static/js/zamboni/stats-all.js:15358 static/js/zamboni/stats-min.js:4
 msgid "Collections"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:78 static/js/impala/stats/csv_keys.js:79
+#: static/js/impala/stats/csv_keys.js:78 static/js/impala/stats/csv_keys.js:79 static/js/zamboni/stats-all.js:15359 static/js/zamboni/stats-all.js:15360 static/js/zamboni/stats-min.js:4
 msgid "Category Landing Featured Carousel"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:80 static/js/impala/stats/csv_keys.js:81
+#: static/js/impala/stats/csv_keys.js:80 static/js/impala/stats/csv_keys.js:81 static/js/zamboni/stats-all.js:15361 static/js/zamboni/stats-all.js:15362 static/js/zamboni/stats-min.js:4
 msgid "Category Landing Top Rated"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:82 static/js/impala/stats/csv_keys.js:83
+#: static/js/impala/stats/csv_keys.js:82 static/js/impala/stats/csv_keys.js:83 static/js/zamboni/stats-all.js:15363 static/js/zamboni/stats-all.js:15364 static/js/zamboni/stats-min.js:5
 msgid "Category Landing Most Popular"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:84 static/js/impala/stats/csv_keys.js:85
+#: static/js/impala/stats/csv_keys.js:84 static/js/impala/stats/csv_keys.js:85 static/js/zamboni/stats-all.js:15365 static/js/zamboni/stats-all.js:15366 static/js/zamboni/stats-min.js:5
 msgid "Category Landing Recently Added"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:86 static/js/impala/stats/csv_keys.js:87
+#: static/js/impala/stats/csv_keys.js:86 static/js/impala/stats/csv_keys.js:87 static/js/zamboni/stats-all.js:15367 static/js/zamboni/stats-all.js:15368 static/js/zamboni/stats-min.js:5
 msgid "Browse Listing Featured Sort"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:88 static/js/impala/stats/csv_keys.js:89
+#: static/js/impala/stats/csv_keys.js:88 static/js/impala/stats/csv_keys.js:89 static/js/zamboni/stats-all.js:15369 static/js/zamboni/stats-all.js:15370 static/js/zamboni/stats-min.js:5
 msgid "Browse Listing Users Sort"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:90 static/js/impala/stats/csv_keys.js:91
+#: static/js/impala/stats/csv_keys.js:90 static/js/impala/stats/csv_keys.js:91 static/js/zamboni/stats-all.js:15371 static/js/zamboni/stats-all.js:15372 static/js/zamboni/stats-min.js:5
 msgid "Browse Listing Rating Sort"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:92 static/js/impala/stats/csv_keys.js:93
+#: static/js/impala/stats/csv_keys.js:92 static/js/impala/stats/csv_keys.js:93 static/js/zamboni/stats-all.js:15373 static/js/zamboni/stats-all.js:15374 static/js/zamboni/stats-min.js:5
 msgid "Browse Listing Created Sort"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:94 static/js/impala/stats/csv_keys.js:95
+#: static/js/impala/stats/csv_keys.js:94 static/js/impala/stats/csv_keys.js:95 static/js/zamboni/stats-all.js:15375 static/js/zamboni/stats-all.js:15376 static/js/zamboni/stats-min.js:5
 msgid "Browse Listing Name Sort"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:96 static/js/impala/stats/csv_keys.js:97
+#: static/js/impala/stats/csv_keys.js:96 static/js/impala/stats/csv_keys.js:97 static/js/zamboni/stats-all.js:15377 static/js/zamboni/stats-all.js:15378 static/js/zamboni/stats-min.js:5
 msgid "Browse Listing Popular Sort"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:98 static/js/impala/stats/csv_keys.js:99
+#: static/js/impala/stats/csv_keys.js:98 static/js/impala/stats/csv_keys.js:99 static/js/zamboni/stats-all.js:15379 static/js/zamboni/stats-all.js:15380 static/js/zamboni/stats-min.js:5
 msgid "Browse Listing Updated Sort"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:100 static/js/impala/stats/csv_keys.js:101
+#: static/js/impala/stats/csv_keys.js:100 static/js/impala/stats/csv_keys.js:101 static/js/zamboni/stats-all.js:15381 static/js/zamboni/stats-all.js:15382 static/js/zamboni/stats-min.js:5
 msgid "Browse Listing Up and Coming Sort"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:105
+#: static/js/impala/stats/csv_keys.js:105 static/js/zamboni/stats-all.js:15386 static/js/zamboni/stats-min.js:5
 msgid "Total Amount Contributed"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:106
+#: static/js/impala/stats/csv_keys.js:106 static/js/zamboni/stats-all.js:15387 static/js/zamboni/stats-min.js:5
 msgid "Average Contribution"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:115
+#: static/js/impala/stats/csv_keys.js:115 static/js/zamboni/stats-all.js:15396 static/js/zamboni/stats-min.js:5
 msgid "Usage"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:118
+#: static/js/impala/stats/csv_keys.js:118 static/js/zamboni/stats-all.js:15399 static/js/zamboni/stats-min.js:5
 msgid "Firefox"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:119
+#: static/js/impala/stats/csv_keys.js:119 static/js/zamboni/stats-all.js:15400 static/js/zamboni/stats-min.js:5
 msgid "Mozilla"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:120
+#: static/js/impala/stats/csv_keys.js:120 static/js/zamboni/stats-all.js:15401 static/js/zamboni/stats-min.js:5
 msgid "Thunderbird"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:121
+#: static/js/impala/stats/csv_keys.js:121 static/js/zamboni/stats-all.js:15402 static/js/zamboni/stats-min.js:5
 msgid "Sunbird"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:122
+#: static/js/impala/stats/csv_keys.js:122 static/js/zamboni/stats-all.js:15403 static/js/zamboni/stats-min.js:5
 msgid "SeaMonkey"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:123
+#: static/js/impala/stats/csv_keys.js:123 static/js/zamboni/stats-all.js:15404 static/js/zamboni/stats-min.js:5
 msgid "Fennec"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:124
+#: static/js/impala/stats/csv_keys.js:124 static/js/zamboni/stats-all.js:15405 static/js/zamboni/stats-min.js:5
 msgid "Android"
 msgstr ""
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:129
+#: static/js/impala/stats/csv_keys.js:129 static/js/zamboni/stats-all.js:15410 static/js/zamboni/stats-min.js:5
 msgid "Downloads and Daily Users, last {0} days"
 msgstr ""
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:131
+#: static/js/impala/stats/csv_keys.js:131 static/js/zamboni/stats-all.js:15412 static/js/zamboni/stats-min.js:5
 msgid "Downloads and Daily Users from {0} to {1}"
 msgstr ""
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:135
+#: static/js/impala/stats/csv_keys.js:135 static/js/zamboni/stats-all.js:15416 static/js/zamboni/stats-min.js:5
 msgid "Installs and Daily Users, last {0} days"
 msgstr ""
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:137
+#: static/js/impala/stats/csv_keys.js:137 static/js/zamboni/stats-all.js:15418 static/js/zamboni/stats-min.js:5
 msgid "Installs and Daily Users from {0} to {1}"
 msgstr ""
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:141
+#: static/js/impala/stats/csv_keys.js:141 static/js/zamboni/stats-all.js:15422 static/js/zamboni/stats-min.js:5
 msgid "Downloads, last {0} days"
 msgstr ""
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:143
+#: static/js/impala/stats/csv_keys.js:143 static/js/zamboni/stats-all.js:15424 static/js/zamboni/stats-min.js:5
 msgid "Downloads from {0} to {1}"
 msgstr ""
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:147
+#: static/js/impala/stats/csv_keys.js:147 static/js/zamboni/stats-all.js:15428 static/js/zamboni/stats-min.js:5
 msgid "Daily Users, last {0} days"
 msgstr ""
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:149
+#: static/js/impala/stats/csv_keys.js:149 static/js/zamboni/stats-all.js:15430 static/js/zamboni/stats-min.js:5
 msgid "Daily Users from {0} to {1}"
 msgstr ""
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:153
+#: static/js/impala/stats/csv_keys.js:153 static/js/zamboni/stats-all.js:15434 static/js/zamboni/stats-min.js:5
 msgid "Applications, last {0} days"
 msgstr ""
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:155
+#: static/js/impala/stats/csv_keys.js:155 static/js/zamboni/stats-all.js:15436 static/js/zamboni/stats-min.js:5
 msgid "Applications from {0} to {1}"
 msgstr ""
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:159
+#: static/js/impala/stats/csv_keys.js:159 static/js/zamboni/stats-all.js:15440 static/js/zamboni/stats-min.js:5
 msgid "Platforms, last {0} days"
 msgstr ""
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:161
+#: static/js/impala/stats/csv_keys.js:161 static/js/zamboni/stats-all.js:15442 static/js/zamboni/stats-min.js:5
 msgid "Platforms from {0} to {1}"
 msgstr ""
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:165
+#: static/js/impala/stats/csv_keys.js:165 static/js/zamboni/stats-all.js:15446 static/js/zamboni/stats-min.js:5
 msgid "Languages, last {0} days"
 msgstr ""
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:167
+#: static/js/impala/stats/csv_keys.js:167 static/js/zamboni/stats-all.js:15448 static/js/zamboni/stats-min.js:5
 msgid "Languages from {0} to {1}"
 msgstr ""
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:171
+#: static/js/impala/stats/csv_keys.js:171 static/js/zamboni/stats-all.js:15452 static/js/zamboni/stats-min.js:5
 msgid "Add-on Versions, last {0} days"
 msgstr ""
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:173
+#: static/js/impala/stats/csv_keys.js:173 static/js/zamboni/stats-all.js:15454 static/js/zamboni/stats-min.js:5
 msgid "Add-on Versions from {0} to {1}"
 msgstr ""
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:177
+#: static/js/impala/stats/csv_keys.js:177 static/js/zamboni/stats-all.js:15458 static/js/zamboni/stats-min.js:5
 msgid "Add-on Status, last {0} days"
 msgstr ""
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:179
+#: static/js/impala/stats/csv_keys.js:179 static/js/zamboni/stats-all.js:15460 static/js/zamboni/stats-min.js:5
 msgid "Add-on Status from {0} to {1}"
 msgstr ""
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:183
+#: static/js/impala/stats/csv_keys.js:183 static/js/zamboni/stats-all.js:15464 static/js/zamboni/stats-min.js:5
 msgid "Download Sources, last {0} days"
 msgstr ""
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:185
+#: static/js/impala/stats/csv_keys.js:185 static/js/zamboni/stats-all.js:15466 static/js/zamboni/stats-min.js:5
 msgid "Download Sources from {0} to {1}"
 msgstr ""
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:189
+#: static/js/impala/stats/csv_keys.js:189 static/js/zamboni/stats-all.js:15470 static/js/zamboni/stats-min.js:5
 msgid "Contributions, last {0} days"
 msgstr ""
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:191
+#: static/js/impala/stats/csv_keys.js:191 static/js/zamboni/stats-all.js:15472 static/js/zamboni/stats-min.js:5
 msgid "Contributions from {0} to {1}"
 msgstr ""
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:195
+#: static/js/impala/stats/csv_keys.js:195 static/js/zamboni/stats-all.js:15476 static/js/zamboni/stats-min.js:5
 msgid "Site Metrics, last {0} days"
 msgstr ""
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:197
+#: static/js/impala/stats/csv_keys.js:197 static/js/zamboni/stats-all.js:15478 static/js/zamboni/stats-min.js:5
 msgid "Site Metrics from {0} to {1}"
 msgstr ""
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:201
+#: static/js/impala/stats/csv_keys.js:201 static/js/zamboni/stats-all.js:15482 static/js/zamboni/stats-min.js:5
 msgid "Add-ons in Use, last {0} days"
 msgstr ""
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:203
+#: static/js/impala/stats/csv_keys.js:203 static/js/zamboni/stats-all.js:15484 static/js/zamboni/stats-min.js:5
 msgid "Add-ons in Use from {0} to {1}"
 msgstr ""
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:207
+#: static/js/impala/stats/csv_keys.js:207 static/js/zamboni/stats-all.js:15488 static/js/zamboni/stats-min.js:5
 msgid "Add-ons Downloaded, last {0} days"
 msgstr ""
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:209
+#: static/js/impala/stats/csv_keys.js:209 static/js/zamboni/stats-all.js:15490 static/js/zamboni/stats-min.js:5
 msgid "Add-ons Downloaded from {0} to {1}"
 msgstr ""
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:213
+#: static/js/impala/stats/csv_keys.js:213 static/js/zamboni/stats-all.js:15494 static/js/zamboni/stats-min.js:5
 msgid "Add-ons Created, last {0} days"
 msgstr ""
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:215
+#: static/js/impala/stats/csv_keys.js:215 static/js/zamboni/stats-all.js:15496 static/js/zamboni/stats-min.js:5
 msgid "Add-ons Created from {0} to {1}"
 msgstr ""
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:219
+#: static/js/impala/stats/csv_keys.js:219 static/js/zamboni/stats-all.js:15500 static/js/zamboni/stats-min.js:5
 msgid "Add-ons Updated, last {0} days"
 msgstr ""
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:221
+#: static/js/impala/stats/csv_keys.js:221 static/js/zamboni/stats-all.js:15502 static/js/zamboni/stats-min.js:5
 msgid "Add-ons Updated from {0} to {1}"
 msgstr ""
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:225
+#: static/js/impala/stats/csv_keys.js:225 static/js/zamboni/stats-all.js:15506 static/js/zamboni/stats-min.js:5
 msgid "Reviews Written, last {0} days"
 msgstr ""
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:227
+#: static/js/impala/stats/csv_keys.js:227 static/js/zamboni/stats-all.js:15508 static/js/zamboni/stats-min.js:5
 msgid "Reviews Written from {0} to {1}"
 msgstr ""
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:231
+#: static/js/impala/stats/csv_keys.js:231 static/js/zamboni/stats-all.js:15512 static/js/zamboni/stats-min.js:5
 msgid "User Signups, last {0} days"
 msgstr ""
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:233
+#: static/js/impala/stats/csv_keys.js:233 static/js/zamboni/stats-all.js:15514 static/js/zamboni/stats-min.js:5
 msgid "User Signups from {0} to {1}"
 msgstr ""
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:237
+#: static/js/impala/stats/csv_keys.js:237 static/js/zamboni/stats-all.js:15518 static/js/zamboni/stats-min.js:5
 msgid "Collections Created, last {0} days"
 msgstr ""
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:239
+#: static/js/impala/stats/csv_keys.js:239 static/js/zamboni/stats-all.js:15520 static/js/zamboni/stats-min.js:5
 msgid "Collections Created from {0} to {1}"
 msgstr ""
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:243
+#: static/js/impala/stats/csv_keys.js:243 static/js/zamboni/stats-all.js:15524 static/js/zamboni/stats-min.js:5
 msgid "Subscribers, last {0} days"
 msgstr ""
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:245
+#: static/js/impala/stats/csv_keys.js:245 static/js/zamboni/stats-all.js:15526 static/js/zamboni/stats-min.js:5
 msgid "Subscribers from {0} to {1}"
 msgstr ""
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:249
+#: static/js/impala/stats/csv_keys.js:249 static/js/zamboni/stats-all.js:15530 static/js/zamboni/stats-min.js:5
 msgid "Ratings, last {0} days"
 msgstr ""
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:251
+#: static/js/impala/stats/csv_keys.js:251 static/js/zamboni/stats-all.js:15532 static/js/zamboni/stats-min.js:5
 msgid "Ratings from {0} to {1}"
 msgstr ""
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:255
+#: static/js/impala/stats/csv_keys.js:255 static/js/zamboni/stats-all.js:15536 static/js/zamboni/stats-min.js:5
 msgid "Sales, last {0} days"
 msgstr ""
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:257
+#: static/js/impala/stats/csv_keys.js:257 static/js/zamboni/stats-all.js:15538 static/js/zamboni/stats-min.js:5
 msgid "Sales from {0} to {1}"
 msgstr ""
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:261
+#: static/js/impala/stats/csv_keys.js:261 static/js/zamboni/stats-all.js:15542 static/js/zamboni/stats-min.js:5
 msgid "Installs, last {0} days"
 msgstr ""
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:263
+#: static/js/impala/stats/csv_keys.js:263 static/js/zamboni/stats-all.js:15544 static/js/zamboni/stats-min.js:5
 msgid "Installs from {0} to {1}"
 msgstr ""
 
 #. L10n: {0} and {1} are integers.
-#: static/js/impala/stats/csv_keys.js:269
+#: static/js/impala/stats/csv_keys.js:269 static/js/zamboni/stats-all.js:15550 static/js/zamboni/stats-min.js:5
 msgid "<b>{0}</b> in last {1} days"
 msgstr ""
 
 #. L10n: {0} is an integer and {1} and {2} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:271 static/js/impala/stats/csv_keys.js:277
+#: static/js/impala/stats/csv_keys.js:271 static/js/impala/stats/csv_keys.js:277 static/js/zamboni/stats-all.js:15552 static/js/zamboni/stats-all.js:15558 static/js/zamboni/stats-min.js:5
 msgid "<b>{0}</b> from {1} to {2}"
 msgstr ""
 
 #. L10n: {0} and {1} are integers.
-#: static/js/impala/stats/csv_keys.js:275
+#: static/js/impala/stats/csv_keys.js:275 static/js/zamboni/stats-all.js:15556 static/js/zamboni/stats-min.js:5
 msgid "<b>{0}</b> average in last {1} days"
 msgstr ""
 
-#: static/js/impala/stats/overview.js:19
+#: static/js/impala/stats/overview.js:19 static/js/zamboni/stats-all.js:16469 static/js/zamboni/stats-min.js:5
 msgid "No data available."
 msgstr ""
 
-#: static/js/impala/stats/table.js:74
+#: static/js/impala/stats/table.js:74 static/js/zamboni/stats-all.js:17209 static/js/zamboni/stats-min.js:5
 msgid "Date"
 msgstr ""
 
-#: static/js/impala/stats/topchart.js:96
+#: static/js/impala/stats/topchart.js:96 static/js/zamboni/stats-all.js:16600 static/js/zamboni/stats-min.js:5
 msgid "Other"
 msgstr ""
 
-#: static/js/zamboni/admin_validation.js:24 static/js/zamboni/devhub.js:1229 static/js/zamboni/editors.js:295
+#: static/js/zamboni/admin-all.js:180 static/js/zamboni/admin-min.js:1 static/js/zamboni/admin_validation.js:24 static/js/zamboni/devhub-all.js:2408 static/js/zamboni/devhub-min.js:2
+#: static/js/zamboni/devhub.js:1229 static/js/zamboni/editors-all.js:15576 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:295
 msgid "Select an application first"
 msgstr ""
 
-#: static/js/zamboni/admin_validation.js:51
+#: static/js/zamboni/admin-all.js:207 static/js/zamboni/admin-min.js:1 static/js/zamboni/admin_validation.js:51
 msgid "Set {0} add-on to a max version of {1} and email the author."
 msgid_plural "Set {0} add-ons to a max version of {1} and email the authors."
 msgstr[0] ""
 msgstr[1] ""
 
-#: static/js/zamboni/admin_validation.js:54
+#: static/js/zamboni/admin-all.js:210 static/js/zamboni/admin-min.js:1 static/js/zamboni/admin_validation.js:54
 msgid "Email author of {2} add-on which failed validation."
 msgid_plural "Email authors of {2} add-ons which failed validation."
 msgstr[0] ""
 msgstr[1] ""
 
-#. L10n: {0} is an app name like Firefox.
-#: static/js/zamboni/buttons.js:66
-msgid "Accept and Install"
-msgstr ""
-
-#: static/js/zamboni/buttons.js:66
-msgid "Add to {0}"
-msgstr ""
-
-#: static/js/zamboni/buttons.js:71
-msgid "Download Now"
-msgstr ""
-
-#: static/js/zamboni/buttons.js:112
-msgid "Add-on has not been updated to support default-to-compatible."
-msgstr ""
-
-#: static/js/zamboni/buttons.js:117
-msgid "You need to be using Firefox 10.0 or higher."
-msgstr ""
-
-#: static/js/zamboni/buttons.js:129
-msgid "Mozilla has marked this version as incompatible with your Firefox version."
-msgstr ""
-
-#. L10n: {0} is an platform like Windows or Linux.
-#: static/js/zamboni/buttons.js:210
-msgid "Install for {0} anyway"
-msgstr ""
-
-#: static/js/zamboni/buttons.js:210
-msgid "Download for {0} anyway"
-msgstr ""
-
-#: static/js/zamboni/buttons.js:267
-msgid "Not available for your platform"
-msgstr ""
-
-#. L10n: {0} is an app name, {1} is the app version.
-#: static/js/zamboni/buttons.js:278 static/js/zamboni/buttons.js:315
-msgid "Not available for {0} {1}"
-msgstr ""
-
-#: static/js/zamboni/buttons.js:341
-msgid "Works with {app} {min} - {max}"
-msgstr ""
-
-#: static/js/zamboni/buttons.js:343
-msgid "View other versions"
-msgstr ""
-
-#: static/js/zamboni/buttons.js:391
-msgid "Only with Firefox — Get Firefox Now!"
-msgstr ""
-
-#: static/js/zamboni/buttons.js:507 static/js/zamboni/mobile/buttons.js:43
-msgid "Sorry, you need a Mozilla-based browser (such as Firefox) to install a search plugin."
-msgstr ""
-
-#: static/js/zamboni/collections.js:229
-msgid "Adding to Favorites&hellip;"
-msgstr ""
-
-#: static/js/zamboni/collections.js:232
-msgid "Removing Favorite&hellip;"
-msgstr ""
-
-#: static/js/zamboni/collections.js:235
-msgid "Add to Favorites"
-msgstr ""
-
-#: static/js/zamboni/collections.js:238
-msgid "Remove from Favorites"
-msgstr ""
-
-#: static/js/zamboni/collections.js:303
-msgid "Pending"
-msgstr ""
-
-#: static/js/zamboni/collections.js:304
-msgid "Add a comment"
-msgstr ""
-
-#: static/js/zamboni/collections.js:304
-msgid "Comment"
-msgstr ""
-
-#: static/js/zamboni/collections.js:305
-msgid "Remove this add-on from the collection"
-msgstr ""
-
-#: static/js/zamboni/collections.js:305 static/js/zamboni/collections.js:334
-msgid "Remove"
-msgstr ""
-
-#: static/js/zamboni/collections.js:334
-msgid "Remove this user as a contributor"
-msgstr ""
-
-#: static/js/zamboni/collections.js:346
-msgid "An email address is required."
-msgstr ""
-
-#: static/js/zamboni/collections.js:364
-msgid "You cannot add yourself as a contributor."
-msgstr ""
-
-#: static/js/zamboni/collections.js:366
-msgid "You have already added that user."
-msgstr ""
-
-#: static/js/zamboni/collections.js:573
-msgid "Add to favorites"
-msgstr ""
-
-#: static/js/zamboni/collections.js:577
-msgid "Remove from favorites"
-msgstr ""
-
-#: static/js/zamboni/collections.js:604
-msgid "Stop following"
-msgstr ""
-
-#: static/js/zamboni/devhub.js:110
+#: static/js/zamboni/devhub-all.js:1289 static/js/zamboni/devhub-min.js:1 static/js/zamboni/devhub.js:110
 msgid "Your browser does not support the video tag"
 msgstr ""
 
-#: static/js/zamboni/devhub.js:371
+#: static/js/zamboni/devhub-all.js:1550 static/js/zamboni/devhub-min.js:1 static/js/zamboni/devhub.js:371
 msgid "Changes Saved"
 msgstr ""
 
-#: static/js/zamboni/devhub.js:387
+#: static/js/zamboni/devhub-all.js:1566 static/js/zamboni/devhub-min.js:1 static/js/zamboni/devhub.js:387
 msgid "Enter a new author's email address"
 msgstr ""
 
-#: static/js/zamboni/devhub.js:536
+#: static/js/zamboni/devhub-all.js:1715 static/js/zamboni/devhub-min.js:1 static/js/zamboni/devhub.js:536
 msgid "There was an error uploading your file."
 msgstr ""
 
-#: static/js/zamboni/devhub.js:681
+#: static/js/zamboni/devhub-all.js:1860 static/js/zamboni/devhub-min.js:1 static/js/zamboni/devhub.js:681
 msgid "{files} file"
 msgid_plural "{files} files"
 msgstr[0] ""
 msgstr[1] ""
 
-#: static/js/zamboni/devhub.js:684
+#: static/js/zamboni/devhub-all.js:1863 static/js/zamboni/devhub-min.js:1 static/js/zamboni/devhub.js:684
 msgid "{reviews} user review"
 msgid_plural "{reviews} user reviews"
 msgstr[0] ""
 msgstr[1] ""
 
-#: static/js/zamboni/devhub.js:796
+#: static/js/zamboni/devhub-all.js:1975 static/js/zamboni/devhub-min.js:2 static/js/zamboni/devhub.js:796
 msgid "Learn more"
 msgstr ""
 
-#: static/js/zamboni/devhub.js:800
+#: static/js/zamboni/devhub-all.js:1979 static/js/zamboni/devhub-min.js:2 static/js/zamboni/devhub.js:800
 msgid "Example"
 msgstr ""
 
-#: static/js/zamboni/devhub.js:1130
+#: static/js/zamboni/devhub-all.js:2309 static/js/zamboni/devhub-min.js:2 static/js/zamboni/devhub.js:1130
 msgid "Image changes being processed"
 msgstr ""
 
-#: static/js/zamboni/devhub.js:1280
+#: static/js/zamboni/devhub-all.js:2459 static/js/zamboni/devhub-min.js:2 static/js/zamboni/devhub.js:1280
 msgid "Must be a valid e-mail address."
+msgstr ""
+
+#: static/js/zamboni/devhub-all.js:2613 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:80
+msgid "All tests passed successfully."
+msgstr ""
+
+#: static/js/zamboni/devhub-all.js:2616 static/js/zamboni/devhub-all.js:3011 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:83 static/js/zamboni/validator.js:478
+msgid "These tests were not run."
+msgstr ""
+
+#: static/js/zamboni/devhub-all.js:2664 static/js/zamboni/devhub-all.js:2677 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:131 static/js/zamboni/validator.js:144
+msgid "Tests"
+msgstr ""
+
+#: static/js/zamboni/devhub-all.js:2779 static/js/zamboni/devhub-all.js:3108 static/js/zamboni/devhub-all.js:3127 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:246
+#: static/js/zamboni/validator.js:575 static/js/zamboni/validator.js:594
+msgid "Error"
+msgstr ""
+
+#: static/js/zamboni/devhub-all.js:2780 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:247
+msgid "Warning"
+msgstr ""
+
+#: static/js/zamboni/devhub-all.js:2794 static/js/zamboni/devhub-min.js:2 static/js/zamboni/files-all.js:5657 static/js/zamboni/files-min.js:3 static/js/zamboni/files.js:411
+#: static/js/zamboni/validator.js:261
+msgid "Ignore this message in future updates"
+msgstr ""
+
+#: static/js/zamboni/devhub-all.js:2817 static/js/zamboni/devhub-min.js:2 static/js/zamboni/files-all.js:5663 static/js/zamboni/files-min.js:3 static/js/zamboni/files.js:417
+#: static/js/zamboni/validator.js:284
+msgid "Severity for automated signing:"
+msgstr ""
+
+#: static/js/zamboni/devhub-all.js:2832 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:299
+msgid "Suggestions for passing automated signing:"
+msgstr ""
+
+#: static/js/zamboni/devhub-all.js:2920 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:387
+msgid "Compatibility Tests"
+msgstr ""
+
+#: static/js/zamboni/devhub-all.js:2999 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:466
+msgid "Add-on failed validation."
+msgstr ""
+
+#: static/js/zamboni/devhub-all.js:3001 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:468
+msgid "Add-on passed validation."
+msgstr ""
+
+#: static/js/zamboni/devhub-all.js:3014 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:481
+msgid "{0} error"
+msgid_plural "{0} errors"
+msgstr[0] ""
+msgstr[1] ""
+
+#: static/js/zamboni/devhub-all.js:3016 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:483
+msgid "{0} warning"
+msgid_plural "{0} warnings"
+msgstr[0] ""
+msgstr[1] ""
+
+#: static/js/zamboni/devhub-all.js:3018 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:485
+msgid "{0} notice"
+msgid_plural "{0} notices"
+msgstr[0] ""
+msgstr[1] ""
+
+#: static/js/zamboni/devhub-all.js:3110 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:577
+msgid "Validation task could not complete or completed with errors"
+msgstr ""
+
+#: static/js/zamboni/devhub-all.js:3128 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:595
+msgid "Internal server error"
 msgstr ""
 
 #: static/js/zamboni/devhub_search.js:8
 msgid "No results found."
 msgstr ""
 
-#: static/js/zamboni/editors.js:121
+#: static/js/zamboni/editors-all.js:15402 static/js/zamboni/editors-min.js:4 static/js/zamboni/editors.js:121
 msgid "{name} was viewing this page first."
 msgstr ""
 
-#: static/js/zamboni/editors.js:171
+#: static/js/zamboni/editors-all.js:15452 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:171
 msgid "Receipt checked by app."
 msgstr ""
 
-#: static/js/zamboni/editors.js:173
+#: static/js/zamboni/editors-all.js:15454 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:173
 msgid "Receipt was not checked by app."
 msgstr ""
 
-#: static/js/zamboni/editors.js:244
+#: static/js/zamboni/editors-all.js:15525 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:244
 msgid "{name} was viewing this add-on first."
 msgstr ""
 
-#: static/js/zamboni/editors.js:255
+#: static/js/zamboni/editors-all.js:15536 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:255
 msgid "Loading&hellip;"
 msgstr ""
 
-#: static/js/zamboni/editors.js:260
+#: static/js/zamboni/editors-all.js:15541 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:260
 msgid "Version Notes"
 msgstr ""
 
-#: static/js/zamboni/editors.js:265
+#: static/js/zamboni/editors-all.js:15546 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:265
 msgid "Notes for Reviewers"
 msgstr ""
 
-#: static/js/zamboni/editors.js:270
+#: static/js/zamboni/editors-all.js:15551 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:270
 msgid "No version notes found"
 msgstr ""
 
-#: static/js/zamboni/editors.js:330
+#: static/js/zamboni/editors-all.js:15611 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:330
 msgid "Average Reviews"
 msgstr ""
 
-#: static/js/zamboni/editors.js:386
+#: static/js/zamboni/editors-all.js:15667 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:386
 msgid "Number of Reviews"
 msgstr ""
 
-#: static/js/zamboni/editors.js:445
+#: static/js/zamboni/editors-all.js:15726 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:445
 msgid "Error loading translation"
 msgstr ""
 
-#: static/js/zamboni/files.js:411 static/js/zamboni/validator.js:261
-msgid "Ignore this message in future updates"
-msgstr ""
-
-#: static/js/zamboni/files.js:417 static/js/zamboni/validator.js:284
-msgid "Severity for automated signing:"
-msgstr ""
-
-#: static/js/zamboni/global.js:410
-msgid "Loading..."
-msgstr ""
-
-#. L10n: {0} is the number of characters left.
-#: static/js/zamboni/global.js:474
-msgid "<b>{0}</b> character left."
-msgid_plural "<b>{0}</b> characters left."
-msgstr[0] ""
-msgstr[1] ""
-
-#: static/js/zamboni/init.js:28
-msgid "This feature is temporarily disabled while we perform website maintenance. Please check back a little later."
-msgstr ""
-
-#: static/js/zamboni/l10n.js:45
-msgid "Remove this localization"
-msgstr ""
-
-#: static/js/zamboni/password-strength.js:20
-msgid "Password strength:"
-msgstr ""
-
-#: static/js/zamboni/password-strength.js:26
-msgid "At least {0} character left."
-msgid_plural "At least {0} characters left."
-msgstr[0] ""
-msgstr[1] ""
-
-#: static/js/zamboni/themes_review.js:176
-msgid "Requested Info"
-msgstr ""
-
-#: static/js/zamboni/themes_review.js:177
-msgid "Flagged"
-msgstr ""
-
-#: static/js/zamboni/themes_review.js:178
-msgid "Duplicate"
-msgstr ""
-
-#: static/js/zamboni/themes_review.js:179
-msgid "Rejected"
-msgstr ""
-
-#: static/js/zamboni/themes_review.js:180
-msgid "Approved"
-msgstr ""
-
-#: static/js/zamboni/themes_review.js:424
-msgid "No results found"
-msgstr ""
-
-#: static/js/zamboni/themes_review_templates.js:31
+#: static/js/zamboni/editors-all.js:15975 static/js/zamboni/editors-min.js:5 static/js/zamboni/themes_review_templates.js:31
 msgid "Theme"
 msgstr ""
 
-#: static/js/zamboni/themes_review_templates.js:33
+#: static/js/zamboni/editors-all.js:15977 static/js/zamboni/editors-min.js:5 static/js/zamboni/themes_review_templates.js:33
 msgid "Reviewer"
 msgstr ""
 
-#: static/js/zamboni/themes_review_templates.js:35
+#: static/js/zamboni/editors-all.js:15979 static/js/zamboni/editors-min.js:5 static/js/zamboni/themes_review_templates.js:35
 msgid "Status"
 msgstr ""
 
-#: static/js/zamboni/validator.js:80
-msgid "All tests passed successfully."
+#: static/js/zamboni/editors-all.js:16196 static/js/zamboni/editors-min.js:5 static/js/zamboni/themes_review.js:176
+msgid "Requested Info"
 msgstr ""
 
-#: static/js/zamboni/validator.js:83 static/js/zamboni/validator.js:478
-msgid "These tests were not run."
+#: static/js/zamboni/editors-all.js:16197 static/js/zamboni/editors-min.js:5 static/js/zamboni/themes_review.js:177
+msgid "Flagged"
 msgstr ""
 
-#: static/js/zamboni/validator.js:131 static/js/zamboni/validator.js:144
-msgid "Tests"
+#: static/js/zamboni/editors-all.js:16198 static/js/zamboni/editors-min.js:5 static/js/zamboni/themes_review.js:178
+msgid "Duplicate"
 msgstr ""
 
-#: static/js/zamboni/validator.js:246 static/js/zamboni/validator.js:575 static/js/zamboni/validator.js:594
-msgid "Error"
+#: static/js/zamboni/editors-all.js:16199 static/js/zamboni/editors-min.js:5 static/js/zamboni/themes_review.js:179
+msgid "Rejected"
 msgstr ""
 
-#: static/js/zamboni/validator.js:247
-msgid "Warning"
+#: static/js/zamboni/editors-all.js:16200 static/js/zamboni/editors-min.js:5 static/js/zamboni/themes_review.js:180
+msgid "Approved"
 msgstr ""
 
-#: static/js/zamboni/validator.js:299
-msgid "Suggestions for passing automated signing:"
+#: static/js/zamboni/editors-all.js:16444 static/js/zamboni/editors-min.js:5 static/js/zamboni/themes_review.js:424
+msgid "No results found"
 msgstr ""
 
-#: static/js/zamboni/validator.js:387
-msgid "Compatibility Tests"
-msgstr ""
-
-#: static/js/zamboni/validator.js:466
-msgid "Add-on failed validation."
-msgstr ""
-
-#: static/js/zamboni/validator.js:468
-msgid "Add-on passed validation."
-msgstr ""
-
-#: static/js/zamboni/validator.js:481
-msgid "{0} error"
-msgid_plural "{0} errors"
-msgstr[0] ""
-msgstr[1] ""
-
-#: static/js/zamboni/validator.js:483
-msgid "{0} warning"
-msgid_plural "{0} warnings"
-msgstr[0] ""
-msgstr[1] ""
-
-#: static/js/zamboni/validator.js:485
-msgid "{0} notice"
-msgid_plural "{0} notices"
-msgstr[0] ""
-msgstr[1] ""
-
-#: static/js/zamboni/validator.js:577
-msgid "Validation task could not complete or completed with errors"
-msgstr ""
-
-#: static/js/zamboni/validator.js:595
-msgid "Internal server error"
-msgstr ""
-
-#: static/js/zamboni/mobile/buttons.js:52
+#: static/js/zamboni/mobile-all.js:15186 static/js/zamboni/mobile/buttons.js:52
 msgid "Not Updated for {0} {1}"
 msgstr ""
 
-#: static/js/zamboni/mobile/buttons.js:53
+#: static/js/zamboni/mobile-all.js:15187 static/js/zamboni/mobile/buttons.js:53
 msgid "Requires Newer Version of {0}"
 msgstr ""
 
-#: static/js/zamboni/mobile/buttons.js:54
+#: static/js/zamboni/mobile-all.js:15188 static/js/zamboni/mobile/buttons.js:54
 msgid "Unreviewed"
 msgstr ""
 
-#: static/js/zamboni/mobile/buttons.js:55
+#: static/js/zamboni/mobile-all.js:15189 static/js/zamboni/mobile/buttons.js:55
 msgid "Experimental <span>(Learn More)</span>"
 msgstr ""
 
-#: static/js/zamboni/mobile/buttons.js:56 static/js/zamboni/mobile/buttons.js:57
+#: static/js/zamboni/mobile-all.js:15190 static/js/zamboni/mobile-all.js:15191 static/js/zamboni/mobile/buttons.js:56 static/js/zamboni/mobile/buttons.js:57
 msgid "Not Available for {0}"
 msgstr ""
 
-#: static/js/zamboni/mobile/buttons.js:58
+#: static/js/zamboni/mobile-all.js:15192 static/js/zamboni/mobile/buttons.js:58
 msgid "Experimental"
 msgstr ""
 
-#: static/js/zamboni/mobile/buttons.js:59
+#: static/js/zamboni/mobile-all.js:15193 static/js/zamboni/mobile/buttons.js:59
 msgid "Themes Require Newer Version of {0}"
 msgstr ""
 
-#: static/js/zamboni/mobile/buttons.js:60
+#: static/js/zamboni/mobile-all.js:15194 static/js/zamboni/mobile/buttons.js:60
 msgid "Themes Require {0}"
 msgstr ""
 
-#: static/js/zamboni/mobile/buttons.js:105
+#: static/js/zamboni/mobile-all.js:15239 static/js/zamboni/mobile/buttons.js:105
 msgid "Installing..."
 msgstr ""
 
-#: static/js/zamboni/mobile/buttons.js:125
+#: static/js/zamboni/mobile-all.js:15259 static/js/zamboni/mobile/buttons.js:125
 msgid "This add-on has been preliminarily reviewed by Mozilla."
 msgstr ""
 
-#: static/js/zamboni/mobile/buttons.js:250
+#: static/js/zamboni/mobile-all.js:15384 static/js/zamboni/mobile/buttons.js:250
 msgid "Keep it"
 msgstr ""
 
-#: static/js/zamboni/mobile/general.js:344
+#: static/js/zamboni/mobile-all.js:16049 static/js/zamboni/mobile-min.js:6 static/js/zamboni/mobile/general.js:344
 msgid "You're trying it on!"
 msgstr ""
 
-#: static/js/zamboni/mobile/general.js:356
+#: static/js/zamboni/mobile-all.js:16061 static/js/zamboni/mobile-min.js:6 static/js/zamboni/mobile/general.js:356
 msgid "Added to Firefox"
 msgstr ""
-

--- a/locale/be/LC_MESSAGES/django.po
+++ b/locale/be/LC_MESSAGES/django.po
@@ -3,69 +3,70 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2016-02-24 21:23+0000\n"
+"POT-Creation-Date: 2016-04-18 15:47+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
+"Language: \n"
 "MIME-Version: 1.0\n"
-"Content-Type: text/plain; charset=utf-8\n"
+"Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Generated-By: Babel 2.2.0\n"
 
-#: src/olympia/accounts/views.py:52
+#: src/olympia/accounts/views.py:54
 msgid "Your log in attempt could not be parsed. Please try again."
 msgstr ""
 
-#: src/olympia/accounts/views.py:54
+#: src/olympia/accounts/views.py:56
 msgid "Your Firefox Account could not be found. Please try again."
 msgstr ""
 
-#: src/olympia/accounts/views.py:55
+#: src/olympia/accounts/views.py:57
 msgid "You could not be logged in. Please try again."
 msgstr ""
 
-#: src/olympia/accounts/views.py:57
+#: src/olympia/accounts/views.py:59
 msgid "Your account has already been migrated to Firefox Accounts."
 msgstr ""
 
-#: src/olympia/accounts/views.py:59
+#: src/olympia/accounts/views.py:61
 msgid "Your Firefox Account already exists on this site."
 msgstr ""
 
-#: src/olympia/accounts/views.py:108
+#: src/olympia/accounts/views.py:110
 msgid "Great job!"
 msgstr ""
 
-#: src/olympia/accounts/views.py:109
+#: src/olympia/accounts/views.py:111
 msgid "You can now log in to Add-ons with your Firefox Account."
 msgstr ""
 
-#: src/olympia/accounts/views.py:121
+#: src/olympia/accounts/views.py:123
 msgid "Need help?"
 msgstr ""
 
-#: src/olympia/addons/buttons.py:180
+#: src/olympia/addons/buttons.py:177
 msgid "Download Now"
 msgstr ""
 
-#: src/olympia/addons/buttons.py:182
+#: src/olympia/addons/buttons.py:179
 msgid "Download"
 msgstr ""
 
 #. L10n: please keep &nbsp; in the string so &rarr; does not wrap.
-#: src/olympia/addons/buttons.py:186
+#: src/olympia/addons/buttons.py:183
 msgid "Continue to Download&nbsp;&rarr;"
 msgstr ""
 
-#: src/olympia/addons/buttons.py:202 src/olympia/addons/helpers.py:35 src/olympia/addons/views.py:319 src/olympia/addons/templates/addons/impala/details.html:114
+#: src/olympia/addons/buttons.py:199 src/olympia/addons/helpers.py:35 src/olympia/addons/views.py:333 src/olympia/addons/templates/addons/impala/details.html:111
 #: src/olympia/addons/templates/addons/impala/listing/items.html:17 src/olympia/addons/templates/addons/mobile/home.html:40 src/olympia/amo/templates/amo/side_nav.html:6
-#: src/olympia/amo/templates/amo/side_nav.html:10 src/olympia/amo/templates/amo/site_nav.html:2 src/olympia/amo/templates/amo/site_nav.html:55 src/olympia/bandwagon/views.py:95
-#: src/olympia/browse/views.py:54 src/olympia/browse/views.py:68 src/olympia/browse/views.py:235 src/olympia/browse/templates/browse/impala/category_landing.html:22
+#: src/olympia/amo/templates/amo/side_nav.html:10 src/olympia/amo/templates/amo/site_nav.html:2 src/olympia/amo/templates/amo/site_nav.html:53 src/olympia/bandwagon/views.py:95
+#: src/olympia/browse/views.py:54 src/olympia/browse/views.py:68 src/olympia/browse/views.py:202 src/olympia/browse/templates/browse/impala/category_landing.html:22
 #: src/olympia/browse/templates/browse/personas/mobile/category_landing.html:26
 msgid "Featured"
 msgstr ""
 
-#: src/olympia/addons/buttons.py:221
+#: src/olympia/addons/buttons.py:218
 msgid "Add to {0}"
 msgstr ""
 
@@ -113,39 +114,39 @@ msgid_plural "All tags must be at least {0} characters."
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/olympia/addons/forms.py:234
+#: src/olympia/addons/forms.py:238
 msgid "Categories cannot be changed while your add-on is featured for this application."
 msgstr ""
 
 #. L10n: {0} is the number of categories.
-#: src/olympia/addons/forms.py:238
+#: src/olympia/addons/forms.py:242
 msgid "You can have only {0} category."
 msgid_plural "You can have only {0} categories."
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/olympia/addons/forms.py:246
+#: src/olympia/addons/forms.py:250
 msgid "The miscellaneous category cannot be combined with additional categories."
 msgstr ""
 
-#: src/olympia/addons/forms.py:369
+#: src/olympia/addons/forms.py:374
 #, python-format
 msgid "Before changing your default locale you must have a name, summary, and description in that locale. You are missing %s."
 msgstr ""
 
-#: src/olympia/addons/forms.py:484 src/olympia/addons/forms.py:575
+#: src/olympia/addons/forms.py:455 src/olympia/addons/forms.py:546
 msgid "A license must be selected."
 msgstr ""
 
-#: src/olympia/addons/forms.py:556
+#: src/olympia/addons/forms.py:527
 msgid "Give Your Theme a Name."
 msgstr ""
 
-#: src/olympia/addons/forms.py:562 src/olympia/devhub/templates/devhub/personas/submit.html:53
+#: src/olympia/addons/forms.py:533 src/olympia/devhub/templates/devhub/personas/submit.html:53
 msgid "Describe your Theme."
 msgstr ""
 
-#: src/olympia/addons/forms.py:704
+#: src/olympia/addons/forms.py:675
 msgid "Enter a new author's email address"
 msgstr ""
 
@@ -153,37 +154,37 @@ msgstr ""
 msgid "Not Reviewed"
 msgstr ""
 
-#: src/olympia/addons/models.py:301
+#: src/olympia/addons/models.py:298
 msgid "Users have the option of contributing more or less than this amount."
 msgstr ""
 
-#: src/olympia/addons/models.py:309
-msgid "Users will always be asked in the Add-ons Manager (Firefox 4 and above)"
+#: src/olympia/addons/models.py:306
+msgid "Users will always be asked in the Add-ons Manager (Firefox 4 and above). Only applies to desktop."
 msgstr ""
 
-#: src/olympia/addons/models.py:1804 src/olympia/addons/templates/addons/details_box.html:55 src/olympia/devhub/templates/devhub/index.html:92
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:102
+#: src/olympia/addons/models.py:1802 src/olympia/addons/templates/addons/details_box.html:55 src/olympia/devhub/templates/devhub/index.html:92
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:89
 msgid "Listed"
 msgstr ""
 
-#: src/olympia/addons/views.py:320 src/olympia/browse/templates/browse/personas/mobile/category_landing.html:27
+#: src/olympia/addons/views.py:334 src/olympia/browse/templates/browse/personas/mobile/category_landing.html:27
 msgid "Popular"
 msgstr ""
 
-#: src/olympia/addons/views.py:321 src/olympia/browse/views.py:238 src/olympia/browse/views.py:280 src/olympia/browse/views.py:482
+#: src/olympia/addons/views.py:335 src/olympia/browse/views.py:205 src/olympia/browse/views.py:247 src/olympia/browse/views.py:449
 msgid "Recently Added"
 msgstr ""
 
-#: src/olympia/addons/views.py:322 src/olympia/bandwagon/views.py:99 src/olympia/browse/views.py:60 src/olympia/browse/views.py:71 src/olympia/search/forms.py:16 src/olympia/search/forms.py:91
+#: src/olympia/addons/views.py:336 src/olympia/bandwagon/views.py:99 src/olympia/browse/views.py:60 src/olympia/browse/views.py:71 src/olympia/search/forms.py:16 src/olympia/search/forms.py:91
 msgid "Recently Updated"
 msgstr ""
 
 #. l10n: {0} is the addon name
-#: src/olympia/addons/views.py:520
+#: src/olympia/addons/views.py:534
 msgid "Contribution for {0}"
 msgstr ""
 
-#: src/olympia/addons/views.py:613
+#: src/olympia/addons/views.py:627
 msgid "Abuse reported."
 msgstr ""
 
@@ -250,9 +251,9 @@ msgstr ""
 #: src/olympia/devhub/templates/devhub/addons/ajax_compat_update.html:36 src/olympia/devhub/templates/devhub/addons/profile.html:44 src/olympia/devhub/templates/devhub/addons/edit/admin.html:101
 #: src/olympia/devhub/templates/devhub/addons/edit/basic.html:152 src/olympia/devhub/templates/devhub/addons/edit/details.html:85 src/olympia/devhub/templates/devhub/addons/edit/support.html:67
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:166 src/olympia/devhub/templates/devhub/addons/forms_shared/media.html:149
-#: src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:44 src/olympia/devhub/templates/devhub/versions/add_file_modal.html:78 src/olympia/devhub/templates/devhub/versions/edit.html:139
-#: src/olympia/devhub/templates/devhub/versions/list.html:242 src/olympia/devhub/templates/devhub/versions/list.html:276 src/olympia/devhub/templates/devhub/versions/list.html:317
-#: src/olympia/devhub/templates/devhub/versions/list.html:351 src/olympia/reviews/templates/reviews/edit_review.html:16 src/olympia/translations/templates/translations/trans-menu.html:50
+#: src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:43 src/olympia/devhub/templates/devhub/versions/add_file_modal.html:58 src/olympia/devhub/templates/devhub/versions/edit.html:139
+#: src/olympia/devhub/templates/devhub/versions/list.html:239 src/olympia/devhub/templates/devhub/versions/list.html:281 src/olympia/devhub/templates/devhub/versions/list.html:315
+#: src/olympia/devhub/templates/devhub/versions/list.html:349 src/olympia/reviews/templates/reviews/edit_review.html:16 src/olympia/translations/templates/translations/trans-menu.html:50
 #: src/olympia/translations/templates/translations/trans-menu.html:62
 msgid "or"
 msgstr ""
@@ -363,7 +364,7 @@ msgid "Add-on Information for {0}"
 msgstr ""
 
 #: src/olympia/addons/templates/addons/details_box.html:30 src/olympia/addons/templates/addons/persona_detail_table.html:3 src/olympia/addons/templates/addons/mobile/details.html:63
-#: src/olympia/addons/templates/addons/mobile/persona_detail_table.html:7 src/olympia/browse/views.py:459 src/olympia/devhub/views.py:75
+#: src/olympia/addons/templates/addons/mobile/persona_detail_table.html:7 src/olympia/browse/views.py:426 src/olympia/devhub/views.py:73
 msgid "Updated"
 msgstr ""
 
@@ -382,11 +383,11 @@ msgstr ""
 msgid "Visibility"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/details_box.html:57 src/olympia/devhub/templates/devhub/index.html:94 src/olympia/devhub/templates/devhub/includes/addon_details.html:104
+#: src/olympia/addons/templates/addons/details_box.html:57 src/olympia/devhub/templates/devhub/index.html:94 src/olympia/devhub/templates/devhub/includes/addon_details.html:91
 msgid "Hidden"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/details_box.html:59 src/olympia/devhub/templates/devhub/index.html:96 src/olympia/devhub/templates/devhub/includes/addon_details.html:106
+#: src/olympia/addons/templates/addons/details_box.html:59 src/olympia/devhub/templates/devhub/index.html:96 src/olympia/devhub/templates/devhub/includes/addon_details.html:93
 msgid "Unlisted"
 msgstr ""
 
@@ -394,13 +395,13 @@ msgstr ""
 msgid "Required Add-ons"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/details_box.html:81 src/olympia/addons/templates/addons/persona_detail_table.html:15 src/olympia/browse/views.py:462 src/olympia/devhub/views.py:78
-#: src/olympia/devhub/views.py:85 src/olympia/discovery/templates/discovery/addons/detail.html:57 src/olympia/reviews/forms.py:62 src/olympia/reviews/templates/reviews/add.html:57
+#: src/olympia/addons/templates/addons/details_box.html:81 src/olympia/addons/templates/addons/persona_detail_table.html:15 src/olympia/browse/views.py:429 src/olympia/devhub/views.py:76
+#: src/olympia/devhub/views.py:83 src/olympia/discovery/templates/discovery/addons/detail.html:57 src/olympia/reviews/forms.py:62 src/olympia/reviews/templates/reviews/add.html:57
 #: src/olympia/reviews/templates/reviews/mobile/review_list.html:18
 msgid "Rating"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/details_box.html:85 src/olympia/browse/views.py:461 src/olympia/devhub/views.py:77 src/olympia/devhub/views.py:84
+#: src/olympia/addons/templates/addons/details_box.html:85 src/olympia/browse/views.py:428 src/olympia/devhub/views.py:75 src/olympia/devhub/views.py:82
 #: src/olympia/stats/templates/stats/addon_report_menu.html:8 src/olympia/stats/templates/stats/collection_report_menu.html:18
 msgid "Downloads"
 msgstr ""
@@ -420,7 +421,7 @@ msgstr ""
 
 #. The Privacy Policy for this add-on.
 #: src/olympia/addons/templates/addons/details_box.html:121 src/olympia/addons/templates/addons/privacy.html:19 src/olympia/addons/templates/addons/privacy.html:23
-#: src/olympia/addons/templates/addons/impala/button.html:43 src/olympia/addons/templates/addons/impala/details.html:307 src/olympia/devhub/templates/devhub/includes/policy_form.html:20
+#: src/olympia/addons/templates/addons/impala/button.html:43 src/olympia/addons/templates/addons/impala/details.html:312 src/olympia/devhub/templates/devhub/includes/policy_form.html:23
 #: src/olympia/templates/mobile/base_addons.html:87
 msgid "Privacy Policy"
 msgstr ""
@@ -445,7 +446,7 @@ msgstr ""
 msgid "Developer Comments"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/details_box.html:199 src/olympia/addons/templates/addons/impala/details.html:259
+#: src/olympia/addons/templates/addons/details_box.html:199 src/olympia/addons/templates/addons/impala/details.html:264
 msgid "Development Channel"
 msgstr ""
 
@@ -465,7 +466,7 @@ msgid ""
 "developer. To stop receiving development updates, reinstall the default version from the link above."
 msgstr ""
 
-#: src/olympia/addons/templates/addons/details_box.html:220 src/olympia/addons/templates/addons/impala/details.html:278
+#: src/olympia/addons/templates/addons/details_box.html:220 src/olympia/addons/templates/addons/impala/details.html:283
 msgid "Version {0}:"
 msgstr ""
 
@@ -484,7 +485,7 @@ msgid "End-User License Agreement for {0}"
 msgstr ""
 
 #: src/olympia/addons/templates/addons/eula.html:17 src/olympia/addons/templates/addons/eula.html:21 src/olympia/addons/templates/addons/impala/button.html:48
-#: src/olympia/addons/templates/addons/impala/details.html:316 src/olympia/devhub/templates/devhub/includes/policy_form.html:3 src/olympia/discovery/templates/discovery/addons/eula.html:11
+#: src/olympia/addons/templates/addons/impala/details.html:321 src/olympia/devhub/templates/devhub/includes/policy_form.html:3 src/olympia/discovery/templates/discovery/addons/eula.html:11
 msgid "End-User License Agreement"
 msgstr ""
 
@@ -501,7 +502,7 @@ msgstr ""
 msgid "Add-ons for {0}"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/home.html:10 src/olympia/addons/templates/addons/home.html:51 src/olympia/browse/templates/browse/impala/base_listing.html:11
+#: src/olympia/addons/templates/addons/home.html:10 src/olympia/addons/templates/addons/home.html:53 src/olympia/browse/templates/browse/impala/base_listing.html:11
 msgid "Featured Extensions"
 msgstr ""
 
@@ -509,29 +510,29 @@ msgstr ""
 msgid "Popular Extensions"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/home.html:42 src/olympia/amo/templates/amo/side_nav.html:3 src/olympia/amo/templates/amo/side_nav.html:11 src/olympia/amo/templates/amo/site_nav.html:3
-#: src/olympia/amo/templates/amo/site_nav.html:25 src/olympia/browse/views.py:236 src/olympia/browse/views.py:281 src/olympia/browse/views.py:481
+#: src/olympia/addons/templates/addons/home.html:44 src/olympia/amo/templates/amo/side_nav.html:3 src/olympia/amo/templates/amo/side_nav.html:11 src/olympia/amo/templates/amo/site_nav.html:3
+#: src/olympia/amo/templates/amo/site_nav.html:25 src/olympia/browse/views.py:203 src/olympia/browse/views.py:248 src/olympia/browse/views.py:448
 msgid "Most Popular"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/home.html:43
+#: src/olympia/addons/templates/addons/home.html:45
 msgid "All »"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/home.html:52 src/olympia/addons/templates/addons/home.html:61 src/olympia/addons/templates/addons/home.html:70 src/olympia/addons/templates/addons/home.html:78
+#: src/olympia/addons/templates/addons/home.html:54 src/olympia/addons/templates/addons/home.html:63 src/olympia/addons/templates/addons/home.html:72 src/olympia/addons/templates/addons/home.html:80
 #: src/olympia/browse/templates/browse/impala/category_landing.html:36
 msgid "See all »"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/home.html:60
+#: src/olympia/addons/templates/addons/home.html:62
 msgid "Up &amp; Coming Extensions"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/home.html:69 src/olympia/browse/templates/browse/personas/category_landing.html:61 src/olympia/discovery/templates/discovery/pane.html:74
+#: src/olympia/addons/templates/addons/home.html:71 src/olympia/browse/templates/browse/personas/category_landing.html:61 src/olympia/discovery/templates/discovery/pane.html:74
 msgid "Featured Themes"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/home.html:77 src/olympia/bandwagon/templates/bandwagon/impala/collection_listing.html:5
+#: src/olympia/addons/templates/addons/home.html:79 src/olympia/bandwagon/templates/bandwagon/impala/collection_listing.html:5
 msgid "Featured Collections"
 msgstr ""
 
@@ -549,7 +550,7 @@ msgid "Updated {0}"
 msgstr ""
 
 #. {0} is a date.
-#: src/olympia/addons/templates/addons/macros.html:10 src/olympia/addons/templates/addons/macros.html:69 src/olympia/addons/templates/addons/persona_preview.html:21
+#: src/olympia/addons/templates/addons/macros.html:10 src/olympia/addons/templates/addons/macros.html:69 src/olympia/addons/templates/addons/persona_preview.html:22
 #: src/olympia/addons/templates/addons/listing/items_mobile.html:44 src/olympia/addons/templates/addons/listing/macros.html:39
 #: src/olympia/bandwagon/templates/bandwagon/collection_listing_items.html:37 src/olympia/bandwagon/templates/bandwagon/impala/collection_listing_items.html:37
 msgid "Added {0}"
@@ -570,15 +571,14 @@ msgstr[0] ""
 msgstr[1] ""
 
 #. {0} is the number of downloads.
-#: src/olympia/addons/templates/addons/macros.html:53 src/olympia/addons/templates/addons/impala/details.html:61
+#: src/olympia/addons/templates/addons/macros.html:53 src/olympia/addons/templates/addons/impala/details.html:59
 msgid "{0} weekly download"
 msgid_plural "{0} weekly downloads"
 msgstr[0] ""
 msgstr[1] ""
 
 #. {0} is the number of users.
-#: src/olympia/addons/templates/addons/macros.html:61 src/olympia/addons/templates/addons/impala/details.html:54 src/olympia/compat/templates/compat/index.html:71
-#: src/olympia/zadmin/templates/zadmin/compat.html:67
+#: src/olympia/addons/templates/addons/macros.html:61 src/olympia/addons/templates/addons/impala/details.html:52 src/olympia/zadmin/templates/zadmin/compat.html:67
 msgid "{0} user"
 msgid_plural "{0} users"
 msgstr[0] ""
@@ -596,7 +596,7 @@ msgstr ""
 msgid "Return to the addon."
 msgstr ""
 
-#: src/olympia/addons/templates/addons/persona_detail.html:17 src/olympia/addons/templates/addons/impala/details.html:106 src/olympia/addons/templates/addons/mobile/details.html:23
+#: src/olympia/addons/templates/addons/persona_detail.html:17 src/olympia/addons/templates/addons/impala/details.html:103 src/olympia/addons/templates/addons/mobile/details.html:23
 #: src/olympia/addons/templates/addons/mobile/persona_detail.html:21 src/olympia/discovery/templates/discovery/addons/base.html:27 src/olympia/editors/templates/editors/review.html:31
 msgid "by"
 msgstr ""
@@ -640,34 +640,35 @@ msgstr ""
 msgid "License"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/persona_preview.html:12 src/olympia/constants/base.py:48
+#: src/olympia/addons/templates/addons/persona_preview.html:13 src/olympia/constants/base.py:48
 msgid "Awaiting Review"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/persona_preview.html:14 src/olympia/amo/log.py:180 src/olympia/constants/base.py:42 src/olympia/editors/helpers.py:62
+#: src/olympia/addons/templates/addons/persona_preview.html:15 src/olympia/amo/log.py:180 src/olympia/constants/base.py:42 src/olympia/editors/helpers.py:62
 msgid "Rejected"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/persona_preview.html:16 src/olympia/amo/log.py:159
+#: src/olympia/addons/templates/addons/persona_preview.html:17 src/olympia/amo/log.py:159
 msgid "Approved"
 msgstr ""
 
 #. {0} is the number of users.
-#: src/olympia/addons/templates/addons/persona_preview.html:26 src/olympia/addons/templates/addons/listing/items_mobile.html:36 src/olympia/addons/templates/addons/listing/macros.html:31
+#: src/olympia/addons/templates/addons/persona_preview.html:27 src/olympia/addons/templates/addons/listing/items_mobile.html:36 src/olympia/addons/templates/addons/listing/macros.html:31
 msgid "<strong>{0}</strong> user"
 msgid_plural "<strong>{0}</strong> users"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/olympia/addons/templates/addons/persona_preview.html:40
+#: src/olympia/addons/templates/addons/persona_preview.html:41
 msgid "Hover to Preview"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/persona_preview.html:46 src/olympia/addons/templates/addons/persona_preview.html:48 src/olympia/reviews/templates/reviews/add.html:15
+#: src/olympia/addons/templates/addons/persona_preview.html:47 src/olympia/addons/templates/addons/persona_preview.html:49 src/olympia/addons/templates/addons/persona_preview.html:97
+#: src/olympia/reviews/templates/reviews/add.html:15
 msgid "Add"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/persona_preview.html:57 src/olympia/bandwagon/templates/bandwagon/ajax_new.html:16 src/olympia/bandwagon/templates/bandwagon/edit.html:19
+#: src/olympia/addons/templates/addons/persona_preview.html:58 src/olympia/bandwagon/templates/bandwagon/ajax_new.html:16 src/olympia/bandwagon/templates/bandwagon/edit.html:19
 #: src/olympia/bandwagon/templates/bandwagon/includes/addedit.html:19 src/olympia/devhub/templates/devhub/addons/edit/admin.html:13 src/olympia/devhub/templates/devhub/addons/edit/basic.html:10
 #: src/olympia/devhub/templates/devhub/addons/edit/details.html:8 src/olympia/devhub/templates/devhub/addons/edit/media.html:6 src/olympia/devhub/templates/devhub/addons/edit/support.html:8
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:9 src/olympia/devhub/templates/devhub/addons/submit/describe.html:29 src/olympia/editors/templates/editors/review.html:257
@@ -676,21 +677,21 @@ msgstr ""
 
 #. For datetime formatting, see the table on
 #. http://docs.python.org/library/datetime.html#strftime-and-strptime-behavior
-#: src/olympia/addons/templates/addons/persona_preview.html:66
+#: src/olympia/addons/templates/addons/persona_preview.html:67
 #, python-format
 msgid "%%Y-%%m-%%d"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/persona_preview.html:67
+#: src/olympia/addons/templates/addons/persona_preview.html:68
 msgid "by {0} on {1}"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/persona_preview.html:75 src/olympia/reviews/helpers.py:17 src/olympia/reviews/templates/reviews/review_list.html:63
+#: src/olympia/addons/templates/addons/persona_preview.html:76 src/olympia/reviews/helpers.py:17 src/olympia/reviews/templates/reviews/review_list.html:63
 #: src/olympia/reviews/templates/reviews/reviews_link.html:21 src/olympia/reviews/templates/reviews/impala/reviews_link.html:16
 msgid "Not yet rated"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/persona_preview.html:78
+#: src/olympia/addons/templates/addons/persona_preview.html:79
 msgid "<b>{0}</b> users"
 msgstr ""
 
@@ -703,7 +704,7 @@ msgid "Learn more about Firefox"
 msgstr ""
 
 #: src/olympia/addons/templates/addons/popups.html:22
-msgid "or <b><a class=\"installer\" href=\"{url}\">download anyway</a></b>"
+msgid "or <b><a class=\"button installer\" href=\"{url}\">download anyway</a></b>"
 msgstr ""
 
 #: src/olympia/addons/templates/addons/popups.html:26
@@ -802,7 +803,7 @@ msgid ""
 msgstr ""
 
 #: src/olympia/addons/templates/addons/report_abuse.html:6 src/olympia/addons/templates/addons/report_abuse_full.html:10 src/olympia/addons/templates/addons/impala/details-more.html:23
-#: src/olympia/addons/templates/addons/impala/details.html:328
+#: src/olympia/addons/templates/addons/impala/details.html:333
 msgid "Report Abuse"
 msgstr ""
 
@@ -821,9 +822,9 @@ msgstr ""
 #: src/olympia/devhub/templates/devhub/addons/ajax_compat_update.html:36 src/olympia/devhub/templates/devhub/addons/profile.html:44 src/olympia/devhub/templates/devhub/addons/edit/admin.html:104
 #: src/olympia/devhub/templates/devhub/addons/edit/basic.html:155 src/olympia/devhub/templates/devhub/addons/edit/details.html:88 src/olympia/devhub/templates/devhub/addons/edit/support.html:70
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:169 src/olympia/devhub/templates/devhub/addons/forms_shared/media.html:152
-#: src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:44 src/olympia/devhub/templates/devhub/personas/edit.html:222 src/olympia/devhub/templates/devhub/versions/add_file_modal.html:79
-#: src/olympia/devhub/templates/devhub/versions/edit.html:140 src/olympia/devhub/templates/devhub/versions/list.html:208 src/olympia/devhub/templates/devhub/versions/list.html:242
-#: src/olympia/devhub/templates/devhub/versions/list.html:276 src/olympia/devhub/templates/devhub/versions/list.html:317 src/olympia/reviews/templates/reviews/edit_review.html:16
+#: src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:43 src/olympia/devhub/templates/devhub/personas/edit.html:222 src/olympia/devhub/templates/devhub/versions/add_file_modal.html:59
+#: src/olympia/devhub/templates/devhub/versions/edit.html:140 src/olympia/devhub/templates/devhub/versions/list.html:208 src/olympia/devhub/templates/devhub/versions/list.html:239
+#: src/olympia/devhub/templates/devhub/versions/list.html:281 src/olympia/devhub/templates/devhub/versions/list.html:315 src/olympia/reviews/templates/reviews/edit_review.html:16
 #: src/olympia/translations/templates/translations/trans-menu.html:50 src/olympia/translations/templates/translations/trans-menu.html:62 src/olympia/zadmin/templates/zadmin/validation.html:105
 msgid "Cancel"
 msgstr ""
@@ -868,7 +869,7 @@ msgstr ""
 msgid "Review Guidelines"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/review_list_box.html:5 src/olympia/addons/templates/addons/impala/details-more.html:27 src/olympia/editors/helpers.py:921
+#: src/olympia/addons/templates/addons/review_list_box.html:5 src/olympia/addons/templates/addons/impala/details-more.html:27 src/olympia/editors/helpers.py:1001
 #: src/olympia/reviews/templates/reviews/add.html:14 src/olympia/reviews/templates/reviews/reply.html:14 src/olympia/reviews/templates/reviews/review_list.html:19
 #: src/olympia/reviews/templates/reviews/mobile/review_list.html:26
 msgid "Reviews"
@@ -959,119 +960,119 @@ msgid_plural "Other add-ons by these authors"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/olympia/addons/templates/addons/impala/details.html:41
+#: src/olympia/addons/templates/addons/impala/details.html:39
 #, python-format
 msgid "<span itemprop=\"ratingCount\">%(num)s</span> user review"
 msgid_plural "<span itemprop=\"ratingCount\">%(num)s</span> user reviews"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/olympia/addons/templates/addons/impala/details.html:69
+#: src/olympia/addons/templates/addons/impala/details.html:66
 msgid "View statistics"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/impala/details.html:84
+#: src/olympia/addons/templates/addons/impala/details.html:81
 msgid "Manage"
 msgstr ""
 
 #. {0} is an add-on name.
-#: src/olympia/addons/templates/addons/impala/details.html:96
+#: src/olympia/addons/templates/addons/impala/details.html:93
 msgid "Icon of {0}"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/impala/details.html:103 src/olympia/addons/templates/addons/impala/listing/items.html:14
+#: src/olympia/addons/templates/addons/impala/details.html:100 src/olympia/addons/templates/addons/impala/listing/items.html:14
 msgid "No Restart"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/impala/details.html:127
+#: src/olympia/addons/templates/addons/impala/details.html:124
 #, python-format
 msgid "Meet the Developer: <a href=\"%(url)s\">%(name)s</a>"
 msgid_plural "<a href=\"%(url)s\">Meet the Developers</a>"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/olympia/addons/templates/addons/impala/details.html:137
+#: src/olympia/addons/templates/addons/impala/details.html:134
 msgid "Learn why {0} was created and find out what's next for this add-on."
 msgstr ""
 
 #. {0} is an index.
-#: src/olympia/addons/templates/addons/impala/details.html:156
+#: src/olympia/addons/templates/addons/impala/details.html:161
 msgid "Add-on screenshot #{0}"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/impala/details.html:182
+#: src/olympia/addons/templates/addons/impala/details.html:187
 msgid "Add-on home page"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/impala/details.html:185
+#: src/olympia/addons/templates/addons/impala/details.html:190
 msgid "Support site"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/impala/details.html:189
+#: src/olympia/addons/templates/addons/impala/details.html:194
 msgid "Support E-mail"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/impala/details.html:194 src/olympia/devhub/models.py:378 src/olympia/devhub/templates/devhub/versions/list.html:12
+#: src/olympia/addons/templates/addons/impala/details.html:199 src/olympia/devhub/models.py:378 src/olympia/devhub/templates/devhub/versions/list.html:12
 #: src/olympia/versions/templates/versions/version.html:6 src/olympia/versions/templates/versions/mobile/version.html:6
 msgid "Version {0}"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/impala/details.html:194
+#: src/olympia/addons/templates/addons/impala/details.html:199
 msgid "Info"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/impala/details.html:195 src/olympia/devhub/templates/devhub/includes/addon_details.html:129
+#: src/olympia/addons/templates/addons/impala/details.html:200 src/olympia/devhub/templates/devhub/includes/addon_details.html:116
 msgid "Last Updated:"
-msgstr ""
-
-#: src/olympia/addons/templates/addons/impala/details.html:200
-#, python-format
-msgid "Released under <a target=\"_blank\" href=\"%(url)s\">%(name)s</a>"
-msgstr ""
-
-#: src/olympia/addons/templates/addons/impala/details.html:201 src/olympia/addons/templates/addons/impala/details.html:206 src/olympia/amo/helpers.py:398 src/olympia/devhub/forms.py:142
-#: src/olympia/devhub/forms.py:173 src/olympia/versions/templates/versions/version.html:40 src/olympia/versions/templates/versions/version.html:45
-msgid "Custom License"
 msgstr ""
 
 #: src/olympia/addons/templates/addons/impala/details.html:205
 #, python-format
+msgid "Released under <a target=\"_blank\" href=\"%(url)s\">%(name)s</a>"
+msgstr ""
+
+#: src/olympia/addons/templates/addons/impala/details.html:206 src/olympia/addons/templates/addons/impala/details.html:211 src/olympia/amo/helpers.py:398 src/olympia/devhub/forms.py:142
+#: src/olympia/devhub/forms.py:173 src/olympia/versions/templates/versions/version.html:40 src/olympia/versions/templates/versions/version.html:45
+msgid "Custom License"
+msgstr ""
+
+#: src/olympia/addons/templates/addons/impala/details.html:210
+#, python-format
 msgid "Released under <a href=\"%(url)s\">%(name)s</a>"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/impala/details.html:217
+#: src/olympia/addons/templates/addons/impala/details.html:222
 msgid "About this Add-on"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/impala/details.html:233
+#: src/olympia/addons/templates/addons/impala/details.html:238
 msgid "Developer’s Comments"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/impala/details.html:243
+#: src/olympia/addons/templates/addons/impala/details.html:248
 msgid "Version Information"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/impala/details.html:250
+#: src/olympia/addons/templates/addons/impala/details.html:255
 msgid "See complete version history"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/impala/details.html:262
+#: src/olympia/addons/templates/addons/impala/details.html:267
 msgid ""
 "The Development Channel lets you test an experimental new version of this add-on before it's released to the general public. Once you install the development version, you will continue to get "
 "updates from this channel. To stop receiving development updates, reinstall the default version from the link above."
 msgstr ""
 
-#: src/olympia/addons/templates/addons/impala/details.html:272
+#: src/olympia/addons/templates/addons/impala/details.html:277
 msgid "<strong>Caution:</strong> Development versions of this add-on have not been reviewed by Mozilla."
 msgstr ""
 
-#: src/olympia/addons/templates/addons/impala/details.html:287
+#: src/olympia/addons/templates/addons/impala/details.html:292
 msgid "See complete development channel history"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/impala/details.html:306 src/olympia/addons/templates/addons/impala/details.html:315 src/olympia/addons/templates/addons/impala/details.html:327
+#: src/olympia/addons/templates/addons/impala/details.html:311 src/olympia/addons/templates/addons/impala/details.html:320 src/olympia/addons/templates/addons/impala/details.html:332
 #: src/olympia/addons/templates/addons/impala/review_add_box.html:4 src/olympia/stats/templates/stats/popup.html:2 src/olympia/stats/templates/stats/popup.html:8
-#: src/olympia/stats/templates/stats/stats.html:202 src/olympia/users/templates/users/profile.html:119
+#: src/olympia/stats/templates/stats/stats.html:204 src/olympia/users/templates/users/profile.html:119
 msgid "close"
 msgstr ""
 
@@ -1127,15 +1128,11 @@ msgstr ""
 msgid "Source Code License"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/impala/persona_grid.html:16 src/olympia/addons/templates/addons/impala/toplist.html:6
-msgid "{0} users"
-msgstr ""
-
 #: src/olympia/addons/templates/addons/impala/review_list_box.html:19 src/olympia/reviews/templates/reviews/review.html:40
 msgid "permalink"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/impala/review_list_box.html:23 src/olympia/editors/templates/editors/queue.html:98 src/olympia/reviews/templates/reviews/review.html:44
+#: src/olympia/addons/templates/addons/impala/review_list_box.html:23 src/olympia/editors/templates/editors/queue.html:104 src/olympia/reviews/templates/reviews/review.html:44
 msgid "translate"
 msgstr ""
 
@@ -1154,6 +1151,10 @@ msgstr ""
 msgid "Be the first!"
 msgstr ""
 
+#: src/olympia/addons/templates/addons/impala/toplist.html:6
+msgid "{0} users"
+msgstr ""
+
 #: src/olympia/addons/templates/addons/impala/listing/sorter.html:14 src/olympia/devhub/templates/devhub/addons/listing/item_actions.html:49
 msgid "More"
 msgstr ""
@@ -1166,7 +1167,7 @@ msgstr ""
 msgid "My Add-ons"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/includes/dashboard_tabs.html:6 src/olympia/amo/context_processors.py:51
+#: src/olympia/addons/templates/addons/includes/dashboard_tabs.html:6 src/olympia/amo/context_processors.py:50
 msgid "My Themes"
 msgstr ""
 
@@ -1221,7 +1222,7 @@ msgstr ""
 msgid "Weekly Downloads"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/mobile/details.html:99 src/olympia/compat/templates/compat/reporter_detail.html:46 src/olympia/devhub/forms.py:787
+#: src/olympia/addons/templates/addons/mobile/details.html:99 src/olympia/compat/templates/compat/reporter_detail.html:46 src/olympia/devhub/forms.py:788
 #: src/olympia/devhub/templates/devhub/versions/list.html:163
 msgid "Version"
 msgstr ""
@@ -1305,7 +1306,7 @@ msgstr ""
 #: src/olympia/browse/templates/browse/personas/category_landing.html:21 src/olympia/browse/templates/browse/personas/category_landing.html:23
 #: src/olympia/browse/templates/browse/personas/category_landing.html:38 src/olympia/browse/templates/browse/personas/grid.html:7 src/olympia/browse/templates/browse/personas/grid.html:11
 #: src/olympia/browse/templates/browse/personas/mobile/base.html:7 src/olympia/browse/templates/browse/personas/mobile/category_landing.html:19 src/olympia/constants/base.py:180
-#: src/olympia/devhub/templates/devhub/personas/submit.html:13 src/olympia/editors/helpers.py:105 src/olympia/editors/templates/editors/base.html:26
+#: src/olympia/devhub/templates/devhub/personas/submit.html:13 src/olympia/editors/helpers.py:107 src/olympia/editors/templates/editors/base.html:26
 #: src/olympia/editors/templates/editors/performance.html:73 src/olympia/search/templates/search/personas.html:39 src/olympia/templates/menu_links.html:9
 msgid "Themes"
 msgstr ""
@@ -1326,7 +1327,7 @@ msgstr ""
 msgid "Highest Rated"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/mobile/home.html:74 src/olympia/amo/templates/amo/side_nav.html:5 src/olympia/amo/templates/amo/site_nav.html:27 src/olympia/amo/templates/amo/site_nav.html:57
+#: src/olympia/addons/templates/addons/mobile/home.html:74 src/olympia/amo/templates/amo/side_nav.html:5 src/olympia/amo/templates/amo/site_nav.html:27 src/olympia/amo/templates/amo/site_nav.html:55
 #: src/olympia/bandwagon/views.py:97 src/olympia/browse/views.py:57 src/olympia/browse/views.py:67 src/olympia/browse/templates/browse/personas/mobile/category_landing.html:65
 #: src/olympia/search/forms.py:15 src/olympia/search/forms.py:87
 msgid "Newest"
@@ -1340,90 +1341,90 @@ msgstr ""
 msgid "Theme Info &raquo;"
 msgstr ""
 
-#: src/olympia/amo/context_processors.py:39 src/olympia/devhub/templates/devhub/nav.html:43
+#: src/olympia/amo/context_processors.py:37 src/olympia/devhub/templates/devhub/nav.html:43
 msgid "Tools"
 msgstr ""
 
-#: src/olympia/amo/context_processors.py:48 src/olympia/discovery/templates/discovery/pane_account.html:8 src/olympia/users/templates/users/includes/navigation.html:2
+#: src/olympia/amo/context_processors.py:47 src/olympia/discovery/templates/discovery/pane_account.html:8 src/olympia/users/templates/users/includes/navigation.html:2
 msgid "My Profile"
 msgstr ""
 
-#: src/olympia/amo/context_processors.py:54 src/olympia/users/templates/users/edit.html:5 src/olympia/users/templates/users/includes/navigation.html:3
+#: src/olympia/amo/context_processors.py:53 src/olympia/users/templates/users/edit.html:5 src/olympia/users/templates/users/includes/navigation.html:3
 msgid "Account Settings"
 msgstr ""
 
-#: src/olympia/amo/context_processors.py:57 src/olympia/discovery/templates/discovery/pane_account.html:11 src/olympia/users/templates/users/profile.html:83
+#: src/olympia/amo/context_processors.py:56 src/olympia/discovery/templates/discovery/pane_account.html:11 src/olympia/users/templates/users/profile.html:83
 #: src/olympia/users/templates/users/includes/navigation.html:4
 msgid "My Collections"
 msgstr ""
 
-#: src/olympia/amo/context_processors.py:62 src/olympia/discovery/templates/discovery/pane_account.html:10 src/olympia/users/templates/users/includes/navigation.html:7
+#: src/olympia/amo/context_processors.py:61 src/olympia/discovery/templates/discovery/pane_account.html:10 src/olympia/users/templates/users/includes/navigation.html:7
 msgid "My Favorites"
 msgstr ""
 
-#: src/olympia/amo/context_processors.py:67 src/olympia/discovery/templates/discovery/pane_account.html:13 src/olympia/templates/impala/user_login.html:14
+#: src/olympia/amo/context_processors.py:66 src/olympia/discovery/templates/discovery/pane_account.html:13 src/olympia/templates/impala/user_login.html:14
 #: src/olympia/templates/mobile/header_auth.html:5
 msgid "Log out"
 msgstr ""
 
-#: src/olympia/amo/context_processors.py:72 src/olympia/devhub/templates/devhub/addons/dashboard.html:4
+#: src/olympia/amo/context_processors.py:71 src/olympia/devhub/templates/devhub/addons/dashboard.html:4
 msgid "Manage My Submissions"
 msgstr ""
 
-#: src/olympia/amo/context_processors.py:75 src/olympia/devhub/templates/devhub/nav.html:27 src/olympia/devhub/templates/devhub/addons/dashboard.html:25
+#: src/olympia/amo/context_processors.py:74 src/olympia/devhub/templates/devhub/nav.html:27 src/olympia/devhub/templates/devhub/addons/dashboard.html:25
 #: src/olympia/devhub/templates/devhub/addons/submit/base.html:4
 msgid "Submit a New Add-on"
 msgstr ""
 
-#: src/olympia/amo/context_processors.py:77 src/olympia/browse/templates/browse/personas/base.html:50 src/olympia/devhub/templates/devhub/index.html:24
+#: src/olympia/amo/context_processors.py:76 src/olympia/browse/templates/browse/personas/base.html:50 src/olympia/devhub/templates/devhub/index.html:24
 #: src/olympia/devhub/templates/devhub/addons/dashboard.html:29
 msgid "Submit a New Theme"
 msgstr ""
 
-#: src/olympia/amo/context_processors.py:79 src/olympia/amo/templates/amo/site_nav.html:87 src/olympia/devhub/helpers.py:36 src/olympia/devhub/helpers.py:68 src/olympia/devhub/helpers.py:102
+#: src/olympia/amo/context_processors.py:78 src/olympia/amo/templates/amo/site_nav.html:85 src/olympia/devhub/helpers.py:36 src/olympia/devhub/helpers.py:68 src/olympia/devhub/helpers.py:102
 #: src/olympia/templates/footer.html:6 src/olympia/templates/menu_links.html:14
 msgid "Developer Hub"
 msgstr ""
 
-#: src/olympia/amo/context_processors.py:83 src/olympia/devhub/views.py:1792
+#: src/olympia/amo/context_processors.py:81 src/olympia/devhub/views.py:1796
 msgid "Manage API Keys"
 msgstr ""
 
-#: src/olympia/amo/context_processors.py:88 src/olympia/editors/helpers.py:82 src/olympia/editors/helpers.py:102 src/olympia/editors/templates/editors/base.html:10
+#: src/olympia/amo/context_processors.py:86 src/olympia/editors/helpers.py:84 src/olympia/editors/helpers.py:104 src/olympia/editors/templates/editors/base.html:10
 msgid "Editor Tools"
 msgstr ""
 
-#: src/olympia/amo/context_processors.py:92
+#: src/olympia/amo/context_processors.py:90
 msgid "Admin Tools"
 msgstr ""
 
-#: src/olympia/amo/fields.py:15
+#: src/olympia/amo/fields.py:20
 msgid "Incorrect, please try again."
 msgstr ""
 
-#: src/olympia/amo/fields.py:16
+#: src/olympia/amo/fields.py:21
 msgid "Error verifying input, please try again."
 msgstr ""
 
-#: src/olympia/amo/fields.py:32
+#: src/olympia/amo/fields.py:37
 msgid "This must be a valid hex color code, such as #000000."
 msgstr ""
 
-#: src/olympia/amo/fields.py:58
+#: src/olympia/amo/fields.py:63
 msgid "Enter at least one value."
 msgstr ""
 
-#: src/olympia/amo/helpers.py:162 src/olympia/amo/templates/amo/site_nav.html:61 src/olympia/bandwagon/templates/bandwagon/add.html:9
+#: src/olympia/amo/helpers.py:162 src/olympia/amo/templates/amo/site_nav.html:59 src/olympia/bandwagon/templates/bandwagon/add.html:9
 #: src/olympia/bandwagon/templates/bandwagon/collection_detail.html:15 src/olympia/bandwagon/templates/bandwagon/delete.html:9 src/olympia/bandwagon/templates/bandwagon/edit.html:15
 #: src/olympia/bandwagon/templates/bandwagon/user_listing.html:18 src/olympia/bandwagon/templates/bandwagon/user_listing.html:21
 #: src/olympia/bandwagon/templates/bandwagon/impala/collection_listing.html:12 src/olympia/bandwagon/templates/bandwagon/impala/collection_listing.html:20
 #: src/olympia/bandwagon/templates/bandwagon/impala/collection_listing.html:24 src/olympia/bandwagon/templates/bandwagon/impala/collection_sidebar.html:3
 #: src/olympia/bandwagon/templates/bandwagon/includes/collection_sidebar.html:2 src/olympia/bandwagon/templates/bandwagon/mobile/collection_listing.html:3
-#: src/olympia/stats/templates/stats/stats.html:77 src/olympia/templates/menu_links.html:12
+#: src/olympia/stats/templates/stats/stats.html:33 src/olympia/templates/menu_links.html:12
 msgid "Collections"
 msgstr ""
 
-#: src/olympia/amo/helpers.py:171 src/olympia/amo/templates/amo/site_nav.html:85 src/olympia/browse/templates/browse/language_tools.html:3
+#: src/olympia/amo/helpers.py:171 src/olympia/amo/templates/amo/site_nav.html:83 src/olympia/browse/templates/browse/language_tools.html:3
 msgid "Dictionaries & Language Packs"
 msgstr ""
 
@@ -1575,8 +1576,8 @@ msgstr ""
 msgid "Comment on {addon} {version}."
 msgstr ""
 
-#: src/olympia/amo/log.py:236 src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:19 src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:47
-#: src/olympia/editors/helpers.py:511 src/olympia/editors/templates/editors/themes/history_table.html:11
+#: src/olympia/amo/log.py:236 src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:17 src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:45
+#: src/olympia/editors/helpers.py:584 src/olympia/editors/templates/editors/themes/history_table.html:11
 msgid "Comment"
 msgstr ""
 
@@ -1899,7 +1900,7 @@ msgstr ""
 #: src/olympia/amo/templates/amo/mobile/paginator.html:14 src/olympia/amo/templates/amo/mobile/paginator.html:16 src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:51
 #: src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:65 src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:78
 #: src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:91 src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:104
-#: src/olympia/discovery/templates/discovery/pane.html:45 src/olympia/discovery/templates/discovery/addons/detail.html:39 src/olympia/stats/templates/stats/stats.html:167
+#: src/olympia/discovery/templates/discovery/pane.html:45 src/olympia/discovery/templates/discovery/addons/detail.html:39 src/olympia/stats/templates/stats/stats.html:169
 msgid "Next"
 msgstr ""
 
@@ -1931,7 +1932,7 @@ msgid ""
 msgstr ""
 
 #: src/olympia/amo/templates/amo/side_nav.html:4 src/olympia/amo/templates/amo/side_nav.html:12 src/olympia/amo/templates/amo/site_nav.html:4 src/olympia/amo/templates/amo/site_nav.html:26
-#: src/olympia/browse/views.py:56 src/olympia/browse/views.py:66 src/olympia/browse/views.py:237 src/olympia/browse/views.py:282 src/olympia/search/forms.py:86
+#: src/olympia/browse/views.py:56 src/olympia/browse/views.py:66 src/olympia/browse/views.py:204 src/olympia/browse/views.py:249 src/olympia/search/forms.py:86
 msgid "Top Rated"
 msgstr ""
 
@@ -1945,38 +1946,38 @@ msgstr ""
 msgid "Extensions"
 msgstr ""
 
-#: src/olympia/amo/templates/amo/site_nav.html:45
+#: src/olympia/amo/templates/amo/site_nav.html:44
 msgid "Want more customization? Try <b>Complete Themes</b>"
 msgstr ""
 
-#: src/olympia/amo/templates/amo/site_nav.html:56 src/olympia/bandwagon/views.py:96
+#: src/olympia/amo/templates/amo/site_nav.html:54 src/olympia/bandwagon/views.py:96
 msgid "Most Followers"
 msgstr ""
 
-#: src/olympia/amo/templates/amo/site_nav.html:68 src/olympia/bandwagon/templates/bandwagon/impala/collection_sidebar.html:16
+#: src/olympia/amo/templates/amo/site_nav.html:66 src/olympia/bandwagon/templates/bandwagon/impala/collection_sidebar.html:16
 #: src/olympia/bandwagon/templates/bandwagon/includes/collection_sidebar.html:18
 msgid "Collections I've Made"
 msgstr ""
 
-#: src/olympia/amo/templates/amo/site_nav.html:70 src/olympia/bandwagon/templates/bandwagon/user_listing.html:4 src/olympia/bandwagon/templates/bandwagon/impala/collection_sidebar.html:13
+#: src/olympia/amo/templates/amo/site_nav.html:68 src/olympia/bandwagon/templates/bandwagon/user_listing.html:4 src/olympia/bandwagon/templates/bandwagon/impala/collection_sidebar.html:13
 #: src/olympia/bandwagon/templates/bandwagon/includes/collection_sidebar.html:15
 msgid "Collections I'm Following"
 msgstr ""
 
-#: src/olympia/amo/templates/amo/site_nav.html:73 src/olympia/bandwagon/templates/bandwagon/impala/collection_sidebar.html:18
-#: src/olympia/bandwagon/templates/bandwagon/includes/collection_sidebar.html:20 src/olympia/users/models.py:512
+#: src/olympia/amo/templates/amo/site_nav.html:71 src/olympia/bandwagon/templates/bandwagon/impala/collection_sidebar.html:18
+#: src/olympia/bandwagon/templates/bandwagon/includes/collection_sidebar.html:20 src/olympia/users/models.py:521
 msgid "My Favorite Add-ons"
 msgstr ""
 
-#: src/olympia/amo/templates/amo/site_nav.html:78
+#: src/olympia/amo/templates/amo/site_nav.html:76
 msgid "More&hellip;"
 msgstr ""
 
-#: src/olympia/amo/templates/amo/site_nav.html:82
+#: src/olympia/amo/templates/amo/site_nav.html:80
 msgid "Add-ons for Mobile"
 msgstr ""
 
-#: src/olympia/amo/templates/amo/site_nav.html:86 src/olympia/browse/feeds.py:207 src/olympia/browse/templates/browse/search_tools.html:3 src/olympia/constants/base.py:176
+#: src/olympia/amo/templates/amo/site_nav.html:84 src/olympia/browse/feeds.py:207 src/olympia/browse/templates/browse/search_tools.html:3 src/olympia/constants/base.py:176
 #: src/olympia/templates/menu_links.html:10
 msgid "Search Tools"
 msgstr ""
@@ -1992,7 +1993,7 @@ msgid "Jump to first page"
 msgstr ""
 
 #: src/olympia/amo/templates/amo/impala/paginator.html:22 src/olympia/amo/templates/amo/mobile/impala_paginator.html:12 src/olympia/discovery/templates/discovery/pane.html:44
-#: src/olympia/discovery/templates/discovery/addons/detail.html:38 src/olympia/stats/templates/stats/stats.html:164
+#: src/olympia/discovery/templates/discovery/addons/detail.html:38 src/olympia/stats/templates/stats/stats.html:166
 msgid "Previous"
 msgstr ""
 
@@ -2015,30 +2016,49 @@ msgid_plural "Page {n}"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/olympia/amo/templates/services/install.html:38
-#, python-format
-msgid "If you are not prompted to install %(addon_name)s in a moment, please <a href=\"%(addon_xpi)s\">click here</a>."
-msgstr ""
-
-#: src/olympia/amo/tests/test_messages.py:57 src/olympia/amo/tests/test_messages.py:58 src/olympia/reviews/forms.py:25 src/olympia/reviews/forms.py:50 src/olympia/reviews/templates/reviews/add.html:56
+#: src/olympia/amo/tests/test_messages.py:56 src/olympia/amo/tests/test_messages.py:57 src/olympia/reviews/forms.py:25 src/olympia/reviews/forms.py:50 src/olympia/reviews/templates/reviews/add.html:56
 #: src/olympia/reviews/templates/reviews/reply.html:30
 msgid "Title"
 msgstr ""
 
-#: src/olympia/amo/tests/test_messages.py:57 src/olympia/amo/tests/test_messages.py:58
+#: src/olympia/amo/tests/test_messages.py:56 src/olympia/amo/tests/test_messages.py:57
 msgid "Body"
 msgstr ""
 
-#: src/olympia/amo/tests/test_messages.py:59
+#: src/olympia/amo/tests/test_messages.py:58
 msgid "Another Title"
 msgstr ""
 
-#: src/olympia/amo/tests/test_messages.py:59
+#: src/olympia/amo/tests/test_messages.py:58
 msgid "Another Body"
 msgstr ""
 
-#: src/olympia/api/views.py:255
-msgid "Not implemented yet."
+#: src/olympia/api/authentication.py:76
+msgid "Signature has expired."
+msgstr ""
+
+#: src/olympia/api/authentication.py:79
+msgid "Error decoding signature."
+msgstr ""
+
+#: src/olympia/api/authentication.py:82
+msgid "Invalid JWT Token."
+msgstr ""
+
+#: src/olympia/api/authentication.py:130
+msgid "Invalid Authorization header. No credentials provided."
+msgstr ""
+
+#: src/olympia/api/authentication.py:133
+msgid "Invalid Authorization header. Credentials string should not contain spaces."
+msgstr ""
+
+#: src/olympia/api/fields.py:29
+msgid "The field must have a length of at least {num} characters."
+msgstr ""
+
+#: src/olympia/api/fields.py:31
+msgid "The language code {lang_code} is invalid."
 msgstr ""
 
 #: src/olympia/applications/views.py:39 src/olympia/applications/templates/applications/appversions.html:3
@@ -2057,7 +2077,7 @@ msgstr ""
 msgid "Add-ons submitted to Mozilla Add-ons must have a manifest file with at least one of the below applications supported. Only the versions listed below are allowed for these applications."
 msgstr ""
 
-#: src/olympia/applications/templates/applications/appversions.html:25
+#: src/olympia/applications/templates/applications/appversions.html:25 src/olympia/editors/helpers.py:361
 msgid "GUID"
 msgstr ""
 
@@ -2171,8 +2191,8 @@ msgstr ""
 msgid "Remove from favorites"
 msgstr ""
 
-#: src/olympia/bandwagon/views.py:98 src/olympia/bandwagon/views.py:191 src/olympia/browse/views.py:58 src/olympia/browse/views.py:69 src/olympia/browse/views.py:458 src/olympia/devhub/views.py:74
-#: src/olympia/devhub/views.py:82 src/olympia/devhub/templates/devhub/addons/edit/basic.html:20 src/olympia/editors/templates/editors/leaderboard.html:24
+#: src/olympia/bandwagon/views.py:98 src/olympia/bandwagon/views.py:191 src/olympia/browse/views.py:58 src/olympia/browse/views.py:69 src/olympia/browse/views.py:425 src/olympia/devhub/views.py:72
+#: src/olympia/devhub/views.py:80 src/olympia/devhub/templates/devhub/addons/edit/basic.html:20 src/olympia/editors/templates/editors/leaderboard.html:24
 #: src/olympia/editors/templates/editors/themes/queue_list.html:48 src/olympia/search/forms.py:17 src/olympia/search/forms.py:89 src/olympia/users/templates/users/vcard.html:5
 msgid "Name"
 msgstr ""
@@ -2181,7 +2201,7 @@ msgstr ""
 msgid "Recently Popular"
 msgstr ""
 
-#: src/olympia/bandwagon/views.py:189 src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:18
+#: src/olympia/bandwagon/views.py:189 src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:16
 msgid "Added"
 msgstr ""
 
@@ -2195,7 +2215,7 @@ msgstr ""
 
 #: src/olympia/bandwagon/views.py:316
 #, python-format
-msgid "Your new collection is shown below. You can <ahref=\"%(url)s\">edit additional settings</a> if you'dlike."
+msgid "Your new collection is shown below. You can <a href=\"%(url)s\">edit additional settings</a> if you'd like."
 msgstr ""
 
 #: src/olympia/bandwagon/views.py:322
@@ -2323,8 +2343,8 @@ msgid_plural "%(num)s Add-ons in this Collection"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/olympia/bandwagon/templates/bandwagon/collection_detail.html:125 src/olympia/compat/templates/compat/index.html:25 src/olympia/compat/templates/compat/reporter_detail.html:29
-#: src/olympia/files/templates/files/viewer.html:29 src/olympia/templates/amo_footer.html:17 src/olympia/templates/includes/lang_switcher.html:10
+#: src/olympia/bandwagon/templates/bandwagon/collection_detail.html:125 src/olympia/compat/templates/compat/reporter_detail.html:29 src/olympia/files/templates/files/viewer.html:29
+#: src/olympia/templates/amo_footer.html:17 src/olympia/templates/includes/lang_switcher.html:10
 msgid "Go"
 msgstr ""
 
@@ -2491,7 +2511,7 @@ msgid "Remove this user as a contributor"
 msgstr ""
 
 #: src/olympia/bandwagon/templates/bandwagon/edit_contributors.html:18 src/olympia/bandwagon/templates/bandwagon/edit_contributors.html:43
-#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:20 src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:48
+#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:18 src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:46
 #: src/olympia/devhub/templates/devhub/addons/ajax_compat_update.html:19
 msgid "Remove"
 msgstr ""
@@ -2539,7 +2559,7 @@ msgid "<b>Warning:</b> By changing the owner of this collection, you will no lon
 msgstr ""
 
 #: src/olympia/bandwagon/templates/bandwagon/edit_contributors.html:83 src/olympia/devhub/templates/devhub/addons/forms_shared/media.html:157
-#: src/olympia/devhub/templates/devhub/addons/submit/describe.html:69 src/olympia/devhub/templates/devhub/addons/submit/license.html:60 src/olympia/devhub/templates/devhub/addons/submit/upload.html:78
+#: src/olympia/devhub/templates/devhub/addons/submit/describe.html:69 src/olympia/devhub/templates/devhub/addons/submit/license.html:60 src/olympia/devhub/templates/devhub/addons/submit/upload.html:70
 #: src/olympia/devhub/templates/devhub/payments/tier.html:17 src/olympia/editors/templates/editors/themes/themes.html:111 src/olympia/editors/templates/editors/themes/themes.html:128
 #: src/olympia/editors/templates/editors/themes/themes.html:134 src/olympia/editors/templates/editors/themes/themes.html:141 src/olympia/users/templates/users/fxa_migration_prompt_content.html:10
 #: src/olympia/users/templates/users/login_form.html:42 src/olympia/users/templates/users/mobile/login.html:57
@@ -2622,31 +2642,31 @@ msgid "Add-ons in Your Collection"
 msgstr ""
 
 #: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:4
-msgid ""
-"To include an add-on in this collection, enter its name in the box below and hit enter.  You can also use the <strong>Add to Collection</strong> links throughout the site to include add-ons later."
+msgid "To include an add-on in this collection, enter its name in the box below and hit enter."
 msgstr ""
 
-#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:17 src/olympia/constants/base.py:400 src/olympia/devhub/templates/devhub/addons/activity.html:62
+#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:15 src/olympia/constants/base.py:400 src/olympia/devhub/templates/devhub/addons/activity.html:62
+#: src/olympia/editors/helpers.py:273 src/olympia/editors/helpers.py:360
 msgid "Add-on"
 msgstr ""
 
-#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:26
+#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:24
 msgid "Enter the name of the add-on to include"
 msgstr ""
 
-#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:28
+#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:26
 msgid "Add to Collection"
 msgstr ""
 
-#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:45 src/olympia/editors/helpers.py:936 src/olympia/editors/helpers.py:956
+#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:43 src/olympia/editors/helpers.py:1016 src/olympia/editors/helpers.py:1036
 msgid "Pending"
 msgstr ""
 
-#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:47
+#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:45
 msgid "Add a comment"
 msgstr ""
 
-#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:48
+#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:46
 msgid "Remove this add-on from the collection"
 msgstr ""
 
@@ -2753,12 +2773,12 @@ msgstr ""
 msgid "Most Users"
 msgstr ""
 
-#: src/olympia/browse/views.py:61 src/olympia/browse/views.py:72 src/olympia/browse/views.py:279 src/olympia/browse/templates/browse/personas/mobile/category_landing.html:63
+#: src/olympia/browse/views.py:61 src/olympia/browse/views.py:72 src/olympia/browse/views.py:246 src/olympia/browse/templates/browse/personas/mobile/category_landing.html:63
 #: src/olympia/discovery/templates/discovery/pane.html:67 src/olympia/search/forms.py:92
 msgid "Up & Coming"
 msgstr ""
 
-#: src/olympia/browse/views.py:460 src/olympia/devhub/views.py:76 src/olympia/devhub/views.py:83 src/olympia/discovery/templates/discovery/addons/detail.html:66
+#: src/olympia/browse/views.py:427 src/olympia/devhub/views.py:74 src/olympia/devhub/views.py:81 src/olympia/discovery/templates/discovery/addons/detail.html:66
 msgid "Created"
 msgstr ""
 
@@ -2946,8 +2966,8 @@ msgid_plural "See all %(cnt)s extensions in %(name)s &raquo;"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/olympia/browse/templates/browse/mobile/extensions.html:13 src/olympia/compat/templates/compat/index.html:82 src/olympia/devhub/templates/devhub/devhub_search.html:24
-#: src/olympia/devhub/templates/devhub/addons/activity.html:47 src/olympia/search/templates/search/no_results.html:4 src/olympia/search/templates/search/mobile/results.html:36
+#: src/olympia/browse/templates/browse/mobile/extensions.html:13 src/olympia/devhub/templates/devhub/devhub_search.html:24 src/olympia/devhub/templates/devhub/addons/activity.html:47
+#: src/olympia/search/templates/search/no_results.html:4 src/olympia/search/templates/search/mobile/results.html:36
 msgid "No results found."
 msgstr ""
 
@@ -3032,7 +3052,7 @@ msgstr ""
 msgid "All"
 msgstr ""
 
-#: src/olympia/compat/forms.py:22 src/olympia/search/views.py:525
+#: src/olympia/compat/forms.py:22 src/olympia/editors/templates/editors/base.html:69 src/olympia/search/views.py:518
 msgid "All Add-ons"
 msgstr ""
 
@@ -3042,53 +3062,6 @@ msgstr ""
 
 #: src/olympia/compat/forms.py:24
 msgid "Non-binary"
-msgstr ""
-
-#. Review points sources other than add-ons and themes.
-#: src/olympia/compat/views.py:87 src/olympia/constants/base.py:388 src/olympia/devhub/forms.py:162 src/olympia/editors/templates/editors/performance.html:75
-msgid "Other"
-msgstr ""
-
-#: src/olympia/compat/templates/compat/index.html:4
-msgid "Add-on Compatibility Report for {app} {version}"
-msgstr ""
-
-#: src/olympia/compat/templates/compat/index.html:11
-msgid "{app} {version} Compatibility"
-msgstr ""
-
-#: src/olympia/compat/templates/compat/index.html:17
-#, python-format
-msgid "Top 95%% compatible with previous version"
-msgstr ""
-
-#: src/olympia/compat/templates/compat/index.html:18
-#, python-format
-msgid "Top 95%% of all add-ons"
-msgstr ""
-
-#: src/olympia/compat/templates/compat/index.html:19
-msgid "All active add-ons"
-msgstr ""
-
-#: src/olympia/compat/templates/compat/index.html:23 src/olympia/constants/base.py:401
-msgid "App"
-msgstr ""
-
-#: src/olympia/compat/templates/compat/index.html:55
-msgid "Details for add-ons compatible with previous version:"
-msgstr ""
-
-#: src/olympia/compat/templates/compat/index.html:57
-msgid "Show all versions"
-msgstr ""
-
-#: src/olympia/compat/templates/compat/index.html:59
-msgid "Details for add-ons compatible with all versions:"
-msgstr ""
-
-#: src/olympia/compat/templates/compat/index.html:61
-msgid "Show previous version only"
 msgstr ""
 
 #: src/olympia/compat/templates/compat/reporter.html:3
@@ -3142,8 +3115,8 @@ msgstr ""
 msgid "Report Type"
 msgstr ""
 
-#: src/olympia/compat/templates/compat/reporter_detail.html:47 src/olympia/devhub/forms.py:784 src/olympia/devhub/templates/devhub/addons/ajax_compat_update.html:17 src/olympia/editors/forms.py:108
-#: src/olympia/zadmin/forms.py:45
+#: src/olympia/compat/templates/compat/reporter_detail.html:47 src/olympia/devhub/forms.py:785 src/olympia/devhub/templates/devhub/addons/ajax_compat_update.html:17 src/olympia/editors/forms.py:108
+#: src/olympia/editors/forms.py:248 src/olympia/zadmin/forms.py:45
 msgid "Application"
 msgstr ""
 
@@ -3231,7 +3204,8 @@ msgstr ""
 msgid "Preliminarily Reviewed and Awaiting Full Review"
 msgstr ""
 
-#: src/olympia/constants/base.py:33 src/olympia/editors/helpers.py:924 src/olympia/editors/templates/editors/themes/history_table.html:34
+#: src/olympia/constants/base.py:33 src/olympia/editors/forms.py:258 src/olympia/editors/helpers.py:73 src/olympia/editors/helpers.py:1004
+#: src/olympia/editors/templates/editors/themes/history_table.html:34
 msgid "Deleted"
 msgstr ""
 
@@ -3328,6 +3302,11 @@ msgstr ""
 msgid "Ask before users can download this add-on"
 msgstr ""
 
+#. Review points sources other than add-ons and themes.
+#: src/olympia/constants/base.py:388 src/olympia/devhub/forms.py:162 src/olympia/editors/templates/editors/performance.html:75
+msgid "Other"
+msgstr ""
+
 #: src/olympia/constants/base.py:389
 msgid "Exception"
 msgstr ""
@@ -3338,6 +3317,10 @@ msgstr ""
 
 #: src/olympia/constants/base.py:391
 msgid "Change"
+msgstr ""
+
+#: src/olympia/constants/base.py:401
+msgid "App"
 msgstr ""
 
 #: src/olympia/constants/base.py:402
@@ -3488,7 +3471,7 @@ msgstr ""
 msgid "Duplicate"
 msgstr ""
 
-#: src/olympia/constants/editors.py:17 src/olympia/editors/helpers.py:502 src/olympia/editors/templates/editors/themes/queue.html:71 src/olympia/editors/templates/editors/themes/themes.html:94
+#: src/olympia/constants/editors.py:17 src/olympia/editors/helpers.py:575 src/olympia/editors/templates/editors/themes/queue.html:71 src/olympia/editors/templates/editors/themes/themes.html:94
 msgid "Reject"
 msgstr ""
 
@@ -3588,7 +3571,7 @@ msgstr ""
 msgid "Android"
 msgstr ""
 
-#: src/olympia/core/apps.py:19
+#: src/olympia/core/apps.py:21
 msgid "Core"
 msgstr ""
 
@@ -3722,7 +3705,7 @@ msgid "Submit my add-on for manual review."
 msgstr ""
 
 #: src/olympia/devhub/forms.py:537
-msgid "Do not list my add-on on this site (beta)"
+msgid "Do not list my add-on on this site"
 msgstr ""
 
 #: src/olympia/devhub/forms.py:538
@@ -3755,46 +3738,46 @@ msgstr ""
 
 #: src/olympia/devhub/forms.py:592
 #, python-format
-msgid "Version %s already exists"
+msgid "Version %s already exists, or was uploaded before."
 msgstr ""
 
-#: src/olympia/devhub/forms.py:604
+#: src/olympia/devhub/forms.py:605
 msgid "Select a valid choice. That choice is not one of the available choices."
 msgstr ""
 
-#: src/olympia/devhub/forms.py:610
+#: src/olympia/devhub/forms.py:611
 msgid "A file with a version ending with a|alpha|b|beta and an optional number is detected as beta."
 msgstr ""
 
-#: src/olympia/devhub/forms.py:633
+#: src/olympia/devhub/forms.py:634
 msgid "You cannot upload any more files for this version."
 msgstr ""
 
-#: src/olympia/devhub/forms.py:639
+#: src/olympia/devhub/forms.py:640
 msgid "Version doesn't match"
 msgstr ""
 
-#: src/olympia/devhub/forms.py:668
+#: src/olympia/devhub/forms.py:669
 msgid "You cannot delete a file once the review process has started.  You must delete the whole version."
 msgstr ""
 
-#: src/olympia/devhub/forms.py:688
+#: src/olympia/devhub/forms.py:689
 msgid "The platform All cannot be combined with specific platforms."
 msgstr ""
 
-#: src/olympia/devhub/forms.py:693
+#: src/olympia/devhub/forms.py:694
 msgid "A platform can only be chosen once."
 msgstr ""
 
-#: src/olympia/devhub/forms.py:706
+#: src/olympia/devhub/forms.py:707
 msgid "A review type must be selected."
 msgstr ""
 
-#: src/olympia/devhub/forms.py:788 src/olympia/editors/forms.py:114 src/olympia/zadmin/forms.py:49 src/olympia/zadmin/forms.py:52
+#: src/olympia/devhub/forms.py:789 src/olympia/editors/forms.py:114 src/olympia/editors/forms.py:254 src/olympia/zadmin/forms.py:49 src/olympia/zadmin/forms.py:52
 msgid "Select an application first"
 msgstr ""
 
-#: src/olympia/devhub/forms.py:840
+#: src/olympia/devhub/forms.py:841
 msgid "There cannot be more than 3 required add-ons."
 msgstr ""
 
@@ -3828,76 +3811,76 @@ msgstr[1] ""
 msgid "Review"
 msgstr ""
 
-#: src/olympia/devhub/tasks.py:551
+#: src/olympia/devhub/tasks.py:583
 #, python-format
 msgid "%s responded with %s (%s)."
 msgstr ""
 
-#: src/olympia/devhub/tasks.py:555
+#: src/olympia/devhub/tasks.py:587
 #, python-format
 msgid "Connection to \"%s\" timed out."
 msgstr ""
 
-#: src/olympia/devhub/tasks.py:557
+#: src/olympia/devhub/tasks.py:589
 #, python-format
 msgid "Could not contact host at \"%s\"."
 msgstr ""
 
-#: src/olympia/devhub/utils.py:104
+#: src/olympia/devhub/utils.py:105
 #, python-format
 msgid "Validation generated too many errors/warnings so %s messages were truncated. After addressing the visible messages, you'll be able to see the others."
 msgstr ""
 
-#: src/olympia/devhub/views.py:183
+#: src/olympia/devhub/views.py:181
 msgid "All My Add-ons"
 msgstr ""
 
-#: src/olympia/devhub/views.py:210
+#: src/olympia/devhub/views.py:208
 msgid "All Activity"
 msgstr ""
 
-#: src/olympia/devhub/views.py:211
+#: src/olympia/devhub/views.py:209
 msgid "Add-on Updates"
 msgstr ""
 
-#: src/olympia/devhub/views.py:212
+#: src/olympia/devhub/views.py:210
 msgid "Add-on Status"
 msgstr ""
 
-#: src/olympia/devhub/views.py:213
+#: src/olympia/devhub/views.py:211
 msgid "User Collections"
 msgstr ""
 
-#: src/olympia/devhub/views.py:214 src/olympia/devhub/templates/devhub/docs/policies-maintenance.html:68 src/olympia/pages/templates/pages/dev_faq.html:38
+#: src/olympia/devhub/views.py:212 src/olympia/devhub/templates/devhub/docs/policies-maintenance.html:68 src/olympia/pages/templates/pages/dev_faq.html:38
 #: src/olympia/pages/templates/pages/dev_faq.html:484
 msgid "User Reviews"
 msgstr ""
 
-#: src/olympia/devhub/views.py:327 src/olympia/devhub/views.py:331 src/olympia/devhub/views.py:484 src/olympia/devhub/views.py:513 src/olympia/devhub/views.py:564 src/olympia/devhub/views.py:1150
+#: src/olympia/devhub/views.py:325 src/olympia/devhub/views.py:329 src/olympia/devhub/views.py:484 src/olympia/devhub/views.py:513 src/olympia/devhub/views.py:564 src/olympia/devhub/views.py:1156
 msgid "Changes successfully saved."
 msgstr ""
 
-#: src/olympia/devhub/views.py:334 src/olympia/devhub/views.py:1631
+#: src/olympia/devhub/views.py:332 src/olympia/devhub/views.py:1637
 msgid "Please check the form for errors."
 msgstr ""
 
-#: src/olympia/devhub/views.py:346
+#: src/olympia/devhub/views.py:344
 msgid "Add-on cannot be deleted. Disable this add-on instead."
 msgstr ""
 
-#: src/olympia/devhub/views.py:356
+#: src/olympia/devhub/views.py:354
 msgid "Theme deleted."
 msgstr ""
 
-#: src/olympia/devhub/views.py:356
+#: src/olympia/devhub/views.py:354
 msgid "Add-on deleted."
 msgstr ""
 
-#: src/olympia/devhub/views.py:362
+#: src/olympia/devhub/views.py:360
 msgid "URL name was incorrect. Theme was not deleted."
 msgstr ""
 
-#: src/olympia/devhub/views.py:367
+#: src/olympia/devhub/views.py:365
 msgid "URL name was incorrect. Add-on was not deleted."
 msgstr ""
 
@@ -3925,7 +3908,7 @@ msgstr ""
 msgid "Check Add-on Compatibility"
 msgstr ""
 
-#: src/olympia/devhub/views.py:808 src/olympia/signing/views.py:90
+#: src/olympia/devhub/views.py:808 src/olympia/signing/views.py:95
 msgid "You cannot submit this type of add-on"
 msgstr ""
 
@@ -3955,33 +3938,33 @@ msgstr ""
 msgid "There was an error uploading your preview."
 msgstr ""
 
-#: src/olympia/devhub/views.py:1189
+#: src/olympia/devhub/views.py:1195
 #, python-format
 msgid "Version %s disabled."
 msgstr ""
 
-#: src/olympia/devhub/views.py:1193
+#: src/olympia/devhub/views.py:1199
 #, python-format
 msgid "Version %s deleted."
 msgstr ""
 
-#: src/olympia/devhub/views.py:1203
+#: src/olympia/devhub/views.py:1209
 msgid "This upload has failed validation, and may lack complete validation results. Please take due care when reviewing it."
 msgstr ""
 
-#: src/olympia/devhub/views.py:1677
+#: src/olympia/devhub/views.py:1683
 msgid "Preliminary Review Requested."
 msgstr ""
 
-#: src/olympia/devhub/views.py:1678
+#: src/olympia/devhub/views.py:1684
 msgid "Full Review Requested."
 msgstr ""
 
-#: src/olympia/devhub/views.py:1779
+#: src/olympia/devhub/views.py:1783
 msgid "Your old credentials were revoked and are no longer valid. Be sure to update all API clients with the new credentials."
 msgstr ""
 
-#: src/olympia/devhub/views.py:1797
+#: src/olympia/devhub/views.py:1801
 msgid "New API key created"
 msgstr ""
 
@@ -4011,7 +3994,7 @@ msgstr ""
 msgid "{0} :: Search"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/devhub_search.html:6 src/olympia/devhub/templates/devhub/search.html:8 src/olympia/editors/forms.py:435 src/olympia/editors/forms.py:437
+#: src/olympia/devhub/templates/devhub/devhub_search.html:6 src/olympia/devhub/templates/devhub/search.html:8 src/olympia/editors/forms.py:534 src/olympia/editors/forms.py:536
 #: src/olympia/editors/templates/editors/queue.html:27 src/olympia/editors/templates/editors/themes/queue_list.html:14 src/olympia/search/templates/search/collections.html:17
 #: src/olympia/search/templates/search/personas.html:18 src/olympia/search/templates/search/results.html:18 src/olympia/search/templates/search/mobile/results.html:8
 #: src/olympia/templates/search.html:14 src/olympia/templates/impala/search.html:18
@@ -4071,12 +4054,12 @@ msgstr ""
 msgid "Start Making Add-ons"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/index.html:86 src/olympia/devhub/templates/devhub/addons/listing/items.html:25 src/olympia/devhub/templates/devhub/includes/addon_details.html:15
+#: src/olympia/devhub/templates/devhub/index.html:86 src/olympia/devhub/templates/devhub/addons/listing/items.html:25 src/olympia/devhub/templates/devhub/includes/addon_details.html:20
 #: src/olympia/devhub/templates/devhub/personas/edit.html:43
 msgid "Status:"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/index.html:90 src/olympia/devhub/templates/devhub/includes/addon_details.html:100
+#: src/olympia/devhub/templates/devhub/index.html:90 src/olympia/devhub/templates/devhub/includes/addon_details.html:87
 msgid "Visibility:"
 msgstr ""
 
@@ -4084,11 +4067,11 @@ msgstr ""
 msgid "Latest Version:"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/index.html:109 src/olympia/devhub/templates/devhub/includes/addon_details.html:145 src/olympia/devhub/templates/devhub/personas/edit.html:49
+#: src/olympia/devhub/templates/devhub/index.html:109 src/olympia/devhub/templates/devhub/includes/addon_details.html:131 src/olympia/devhub/templates/devhub/personas/edit.html:49
 msgid "Queue Position:"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/index.html:110 src/olympia/devhub/templates/devhub/includes/addon_details.html:146 src/olympia/devhub/templates/devhub/personas/edit.html:50
+#: src/olympia/devhub/templates/devhub/index.html:110 src/olympia/devhub/templates/devhub/includes/addon_details.html:132 src/olympia/devhub/templates/devhub/personas/edit.html:50
 #, python-format
 msgid "%(position)s of %(total)s"
 msgstr ""
@@ -4190,16 +4173,6 @@ msgstr ""
 msgid "Do you want your add-on to be distributed on this site?"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/validate_addon.html:49 src/olympia/devhub/templates/devhub/addons/submit/upload.html:30 src/olympia/devhub/templates/devhub/versions/add_file_modal.html:14
-#: src/olympia/devhub/templates/devhub/versions/add_file_modal.html:53 src/olympia/devhub/templates/devhub/versions/list.html:298
-msgid "Warning:"
-msgstr ""
-
-#: src/olympia/devhub/templates/devhub/validate_addon.html:50 src/olympia/devhub/templates/devhub/addons/submit/upload.html:31
-#, python-format
-msgid "Submission of unlisted add-ons for signing is currently in an open beta. Please <a href=\"%(url)s\" target=\"_blank\">report any bugs</a> that you encounter."
-msgstr ""
-
 #. first parameter is a filename like lorem-ipsum-1.0.2.xpi
 #: src/olympia/devhub/templates/devhub/validation.html:5
 msgid "Validation Results for {0}"
@@ -4274,7 +4247,7 @@ msgstr ""
 msgid "Update Compatibility"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/addons/ajax_compat_update.html:4
+#: src/olympia/devhub/templates/devhub/addons/ajax_compat_update.html:4 src/olympia/devhub/templates/devhub/versions/edit.html:45
 msgid "Adjusting application information here will allow users to install your add-on even if the install manifest in the package indicates that the add-on is incompatible."
 msgstr ""
 
@@ -4286,9 +4259,9 @@ msgstr ""
 msgid "Add Another Application&hellip;"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/addons/ajax_compat_update.html:38 src/olympia/devhub/templates/devhub/addons/owner.html:86 src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:46
-#: src/olympia/devhub/templates/devhub/versions/list.html:351 src/olympia/devhub/templates/devhub/versions/list.html:353 src/olympia/templates/impala/base.html:132
-#: src/olympia/templates/impala/base.html:143 src/olympia/templates/impala/base.html:161 src/olympia/templates/impala/base.html:171
+#: src/olympia/devhub/templates/devhub/addons/ajax_compat_update.html:38 src/olympia/devhub/templates/devhub/addons/owner.html:86 src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:45
+#: src/olympia/devhub/templates/devhub/versions/list.html:349 src/olympia/devhub/templates/devhub/versions/list.html:351 src/olympia/templates/impala/base.html:129
+#: src/olympia/templates/impala/base.html:140 src/olympia/templates/impala/base.html:158 src/olympia/templates/impala/base.html:168
 msgid "Close"
 msgstr ""
 
@@ -4322,7 +4295,7 @@ msgstr ""
 msgid "Manage Authors & License"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/addons/owner.html:29 src/olympia/editors/templates/editors/review.html:270
+#: src/olympia/devhub/templates/devhub/addons/owner.html:29 src/olympia/editors/helpers.py:362 src/olympia/editors/templates/editors/review.html:270
 msgid "Authors"
 msgstr ""
 
@@ -4391,17 +4364,11 @@ msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/basic.html:52
 msgid ""
-"A short explanation of your add-on's basic\n"
-"                          functionality that is displayed in search and browse\n"
-"                          listings, as well as at the top of your add-on's\n"
-"                          details page. It is only relevant for listed add-ons."
+"A short explanation of your add-on's basic functionality that is displayed in search and browse listings, as well as at the top of your add-on's details page. It is only relevant for listed add-ons."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/basic.html:73
-msgid ""
-"Categories are the primary way users browse through add-ons.\n"
-"                        Choose any that fit your add-on's functionality for the most\n"
-"                        exposure. It is only relevant for listed add-ons."
+msgid "Categories are the primary way users browse through add-ons. Choose any that fit your add-on's functionality for the most exposure. It is only relevant for listed add-ons."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/basic.html:90
@@ -4411,11 +4378,7 @@ msgid ""
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/basic.html:119
-msgid ""
-"Tags help users find your add-on and should be short\n"
-"                        descriptors such as tabs, toolbar, or twitter.  You\n"
-"                        may have a maximum of {0} tags. It is only relevant\n"
-"                        for listed add-ons."
+msgid "Tags help users find your add-on and should be short descriptors such as tabs, toolbar, or twitter. You may have a maximum of {0} tags. It is only relevant for listed add-ons."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/basic.html:129 src/olympia/devhub/templates/devhub/personas/edit.html:97 src/olympia/devhub/templates/devhub/personas/submit.html:46
@@ -4443,11 +4406,7 @@ msgid "Add-on Details for {0}"
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/details.html:22
-msgid ""
-"A longer explanation of features,\n"
-"                          functionality, and other relevant information. This\n"
-"                          field is only displayed on the add-on's details\n"
-"                          page. It is only relevant for listed add-ons."
+msgid "A longer explanation of features, functionality, and other relevant information. This field is only displayed on the add-on's details page. It is only relevant for listed add-ons."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/details.html:44 src/olympia/translations/templates/translations/trans-menu.html:13
@@ -4455,10 +4414,7 @@ msgid "Default Locale"
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/details.html:45
-msgid ""
-"Information about your add-on is displayed in this locale\n"
-"                        unless you override it with a locale-specific translation.\n"
-"                        It is only relevant for listed add-ons."
+msgid "Information about your add-on is displayed in this locale unless you override it with a locale-specific translation. It is only relevant for listed add-ons."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/details.html:61 src/olympia/users/forms.py:311 src/olympia/users/templates/users/edit.html:122 src/olympia/users/templates/users/register.html:57
@@ -4468,10 +4424,8 @@ msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/details.html:63
 msgid ""
-"If your add-on has another homepage, enter its\n"
-"                          address here. If your website is localized into other\n"
-"                          languages multiple translations of this field can be\n"
-"                          added. It is only relevant for listed add-ons."
+"If your add-on has another homepage, enter its address here. If your website is localized into other languages multiple translations of this field can be added. It is only relevant for listed add-"
+"ons."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/media.html:3
@@ -4489,19 +4443,14 @@ msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/support.html:22
 msgid ""
-"If you wish to display an e-mail address for support\n"
-"                          inquiries, enter it here. If you have different\n"
-"                          addresses for each language multiple translations of\n"
-"                          this field can be added. It is only relevant for\n"
-"                          listed add-ons."
+"If you wish to display an e-mail address for support inquiries, enter it here. If you have different addresses for each language multiple translations of this field can be added. It is only "
+"relevant for listed add-ons."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/support.html:45
 msgid ""
-"If your add-on has a support website or forum, enter\n"
-"                          its address here. If your website is localized into\n"
-"                          other languages, multiple translations of this field can\n"
-"                          be added. It is only relevant for listed add-ons."
+"If your add-on has a support website or forum, enter its address here. If your website is localized into other languages, multiple translations of this field can be added. It is only relevant for "
+"listed add-ons."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:6
@@ -4515,11 +4464,8 @@ msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:23
 msgid ""
-"Any information end users may want to know that isn't\n"
-"                          necessarily applicable to the add-on summary or description.\n"
-"                          Common uses include listing known major bugs, information on\n"
-"                          how to report bugs, anticipated release date of a new version,\n"
-"                          etc. It is only relevant for listed add-ons."
+"Any information end users may want to know that isn't necessarily applicable to the add-on summary or description. Common uses include listing known major bugs, information on how to report bugs, "
+"anticipated release date of a new version, etc. It is only relevant for listed add-ons."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:46
@@ -4531,9 +4477,7 @@ msgid "Add-on Flags"
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:69
-msgid ""
-"These flags are used to classify add-ons. It is only\n"
-"                        relevant for listed add-ons."
+msgid "These flags are used to classify add-ons. It is only relevant for listed add-ons."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:74
@@ -4549,9 +4493,7 @@ msgid "View Source?"
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:90
-msgid ""
-"Whether the source of your add-on can be displayed in our\n"
-"                        online viewer. It is only relevant for listed add-ons."
+msgid "Whether the source of your add-on can be displayed in our online viewer. It is only relevant for listed add-ons."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:94
@@ -4567,10 +4509,7 @@ msgid "Public Stats?"
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:102
-msgid ""
-"Whether the download and usage stats of your add-on can\n"
-"                        be displayed in our online viewer.\n"
-"                        It is only relevant for listed add-ons."
+msgid "Whether the download and usage stats of your add-on can be displayed in our online viewer. It is only relevant for listed add-ons."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:107
@@ -4586,10 +4525,7 @@ msgid "Upgrade SDK?"
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:116
-msgid ""
-"If selected, we will try to automatically upgrade your\n"
-"                        add-on when a new version of the SDK is released.\n"
-"                        It is only relevant for listed add-ons."
+msgid "If selected, we will try to automatically upgrade your add-on when a new version of the SDK is released. It is only relevant for listed add-ons."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:121
@@ -4640,10 +4576,8 @@ msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/forms_shared/media.html:16
 msgid ""
-"Upload an icon for your add-on or choose from one of ours. The\n"
-"                      icon is displayed nearly everywhere your add-on is. Uploaded images\n"
-"                      must be one of the following image types: .png, .jpg.\n"
-"                      It is only relevant for listed add-ons."
+"Upload an icon for your add-on or choose from one of ours. The icon is displayed nearly everywhere your add-on is. Uploaded images must be one of the following image types: .png, .jpg. It is only "
+"relevant for listed add-ons."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/forms_shared/media.html:25
@@ -4656,9 +4590,7 @@ msgid "32x32px"
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/forms_shared/media.html:39
-msgid ""
-"Used in listings of add-ons, like search results\n"
-"                            and featured add-ons."
+msgid "Used in listings of add-ons, like search results and featured add-ons."
 msgstr ""
 
 #. The size of the icon
@@ -4753,16 +4685,14 @@ msgid "Deleting your add-on will permanently remove it from the site and prevent
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:24
-msgid ""
-"Enter the following text confirm your decision:\n"
-"           {slug}"
+msgid "Enter the following text confirm your decision: {slug}"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:34
+#: src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:33
 msgid "Please tell us why you are deleting your theme:"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:36
+#: src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:35
 msgid "Please tell us why you are deleting your add-on:"
 msgstr ""
 
@@ -4799,8 +4729,8 @@ msgstr ""
 msgid "Daily statistics on downloads and users."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/addons/listing/item_actions.html:45 src/olympia/stats/templates/stats/stats.html:75 src/olympia/stats/templates/stats/stats.html:79
-#: src/olympia/stats/templates/stats/stats.html:81
+#: src/olympia/devhub/templates/devhub/addons/listing/item_actions.html:45 src/olympia/stats/templates/stats/stats.html:31 src/olympia/stats/templates/stats/stats.html:35
+#: src/olympia/stats/templates/stats/stats.html:37
 msgid "Statistics"
 msgstr ""
 
@@ -4919,10 +4849,7 @@ msgid "Your add-on has been submitted to the Full Review queue."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/submit/done.html:18
-msgid ""
-"You'll receive an email once it has been reviewed by an editor. In\n"
-"          the meantime, you and your friends can install it directly from its\n"
-"          details page:"
+msgid "You'll receive an email once it has been reviewed by an editor. In the meantime, you and your friends can install it directly from its details page:"
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/submit/done.html:27 src/olympia/devhub/templates/devhub/addons/submit/done.html:77 src/olympia/devhub/templates/devhub/personas/submit_done.html:16
@@ -5128,11 +5055,11 @@ msgstr ""
 msgid "Use the fields below to upload your add-on package and select any platform restrictions. After upload, a series of automated validation tests will be run on your file."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/addons/submit/upload.html:59 src/olympia/devhub/templates/devhub/versions/add_file_modal.html:39
+#: src/olympia/devhub/templates/devhub/addons/submit/upload.html:51 src/olympia/devhub/templates/devhub/versions/add_file_modal.html:28
 msgid "Which platforms is this file compatible with?"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/addons/submit/upload.html:67 src/olympia/devhub/templates/devhub/versions/add_file_modal.html:65
+#: src/olympia/devhub/templates/devhub/addons/submit/upload.html:59 src/olympia/devhub/templates/devhub/versions/add_file_modal.html:45
 msgid "Administrative overrides"
 msgstr ""
 
@@ -5242,8 +5169,8 @@ msgstr ""
 
 #: src/olympia/devhub/templates/devhub/docs/policies-contact.html:44
 msgid ""
-"If you've found a problem with the site, we'd love to fix it. Please <a href=\"https://github.com/mozilla/olympia/issues\">file a bug report</a> in GitHub, including the location of the problem and "
-"how you encountered it."
+"If you've found a problem with the site, we'd love to fix it. Please <a href=\"https://github.com/mozilla/addons/issues/new\">file a bug report</a> in GitHub, including the location of the problem "
+"and how you encountered it."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/docs/policies-maintenance.html:3 src/olympia/devhub/templates/devhub/docs/policies-maintenance.html:7
@@ -5810,7 +5737,7 @@ msgstr ""
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:282
 msgid ""
-"Add-ons that store or otherwise handle browsing data must support <a href=\"https://developer.mozilla.org/En/Supporting_private_browsing_mode\">Private Browsing Mode</a>.  During a Private Browsing "
+"Add-ons that store or otherwise handle browsing data must support <a href=\"https://developer.mozilla.org/En/Supporting_private_browsing_mode\">Private Browsing Mode</a>. During a Private Browsing "
 "session, no browsing data can be written to disk, and all of this data must be cleared when Firefox quits or the Private Browsing session ends."
 msgstr ""
 
@@ -5975,129 +5902,95 @@ msgstr ""
 msgid "How to get in touch with us regarding these policies or your add-on."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:6
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:10
 msgid "You have disabled this add-on"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:20
-msgid ""
-"Your add-on's listing is disabled and is not showing\n"
-"                             anywhere in our gallery or update service."
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:24
+msgid "Your add-on's listing is disabled and is not showing anywhere in our gallery or update service."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:25
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:27
 msgid "Please complete your add-on."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:29
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:30
 msgid "You will receive an email when the review is complete."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:34
-msgid ""
-"You will receive an email when the review is complete. Until\n"
-"                             then, your add-on is not listed in our gallery but can be\n"
-"                             accessed directly from its details page."
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:33
+msgid "You will receive an email when the review is complete. Until then, your add-on is not listed in our gallery but can be accessed directly from its details page."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:38 src/olympia/devhub/templates/devhub/includes/addon_details.html:48
-msgid ""
-"You will receive an email when the review is\n"
-"                             complete and your add-on is signed."
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:37 src/olympia/devhub/templates/devhub/includes/addon_details.html:45
+msgid "You will receive an email when the review is complete and your add-on is signed."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:44
-msgid ""
-"You will receive an email when the review is complete. Until\n"
-"                             then, your add-on is not listed in our gallery but can be\n"
-"                             accessed directly from its details page. "
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:41
+msgid "You will receive an email when the review is complete. Until then, your add-on is not listed in our gallery but can be accessed directly from its details page. "
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:54
-msgid ""
-"Your add-on is displayed in our gallery and users are\n"
-"                             receiving automatic updates."
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:49
+msgid "Your add-on is displayed in our gallery and users are receiving automatic updates."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:57
-msgid ""
-"Your add-on has been signed and can be bundled with an\n"
-"                             application installer."
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:52
+msgid "Your add-on has been signed and can be bundled with an application installer."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:63
-msgid ""
-"Your add-on was disabled by a site administrator and is no\n"
-"                             longer shown in our gallery. If you have any questions,\n"
-"                             please email amo-admins@mozilla.org."
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:56
+msgid "Your add-on was disabled by a site administrator and is no longer shown in our gallery. If you have any questions, please email amo-admins@mozilla.org."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:70
-msgid ""
-"Your add-on is displayed in our gallery as experimental\n"
-"                             and users are receiving automatic updates. Some features\n"
-"                             are unavailable to your add-on."
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:62
+msgid "Your add-on is displayed in our gallery as experimental and users are receiving automatic updates. Some features are unavailable to your add-on."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:74
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:66
 msgid "Your add-on has been signed."
 msgstr ""
 
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:69
+msgid ""
+"You will receive an email when the full review is complete. Until then, your add-on is displayed in our gallery as experimental and users are receiving automatic updates. Some features are "
+"unavailable to your add-on."
+msgstr ""
+
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:74
+msgid "You will receive an email when the full review is complete, making you able to bundle your add-on with an application installer."
+msgstr ""
+
 #: src/olympia/devhub/templates/devhub/includes/addon_details.html:79
-msgid ""
-"You will receive an email when the full review is complete.\n"
-"                             Until then, your add-on is displayed in our gallery as\n"
-"                             experimental and users are receiving automatic updates.\n"
-"                             Some features are unavailable to your add-on."
+msgid "All add-ons hosted in our gallery must now be reviewed by an editor. If you wish to continue hosting your add-on, please click to select a review process."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:84
-msgid ""
-"You will receive an email when the full review is\n"
-"                             complete, making you able to bundle your add-on with an\n"
-"                             application installer."
-msgstr ""
-
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:91
-msgid ""
-"All add-ons hosted in our gallery must now be reviewed by an\n"
-"                             editor. If you wish to continue hosting your add-on, please\n"
-"                             click to select a review process."
-msgstr ""
-
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:113
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:100
 msgid "Current Version:"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:115
-msgid ""
-"This is the version of your add-on that will\n"
-"                                           be installed if someone clicks the Install\n"
-"                                           button on addons.mozilla.org. It is only\n"
-"                                           relevant for listed add-ons."
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:102
+msgid "This is the version of your add-on that will be installed if someone clicks the Install button on addons.mozilla.org. It is only relevant for listed add-ons."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:123
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:110
 msgid "Created:"
 msgstr ""
 
 #. {0} is a date. dennis-ignore: E201
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:125 src/olympia/devhub/templates/devhub/includes/addon_details.html:131
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:112 src/olympia/devhub/templates/devhub/includes/addon_details.html:118
 #, python-format
 msgid "%%b %%e, %%Y"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:136
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:123
 msgid "Next Version:"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:138
-msgid ""
-"This is the newest uploaded version, however\n"
-"                                           it isn’t live on the site yet."
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:125
+msgid "This is the newest uploaded version, however it isn’t live on the site yet."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:144 src/olympia/devhub/templates/devhub/versions/list.html:30
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:130 src/olympia/devhub/templates/devhub/versions/list.html:30
 msgid "Queues are not reviewed strictly in order"
 msgstr ""
 
@@ -6165,9 +6058,7 @@ msgid "View the blog &#9658;"
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/includes/license_form.html:6
-msgid ""
-"Please choose a license appropriate for the rights you grant on your source code.\n"
-"                  It is only relevant for listed add-ons."
+msgid "Please choose a license appropriate for the rights you grant on your source code. It is only relevant for listed add-ons."
 msgstr ""
 
 #. {0} is a list of HTML tags.
@@ -6194,14 +6085,11 @@ msgstr[1] ""
 #: src/olympia/devhub/templates/devhub/includes/policy_form.html:4
 msgid ""
 "Users will be required to accept the following End-User License Agreement (EULA) prior to installing your add-on. The presence of a EULA significantly affects the number of downloads an add-on "
-"receives. Please note that a EULA is not the same as a code license, such as the GPL or MPL.\n"
-"                It is only relevant for listed add-ons."
+"receives. Please note that a EULA is not the same as a code license, such as the GPL or MPL.It is only relevant for listed add-ons."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/policy_form.html:21
-msgid ""
-"If your add-on transmits any data from the user's computer, a privacy policy is required that explains what data is sent and how it is used.\n"
-"                It is only relevant for listed add-ons."
+#: src/olympia/devhub/templates/devhub/includes/policy_form.html:24
+msgid "If your add-on transmits any data from the user's computer, a privacy policy is required that explains what data is sent and how it is used. It is only relevant for listed add-ons."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/includes/source_form_field.html:2
@@ -6369,12 +6257,8 @@ msgstr ""
 msgid "Add some tags to describe your Theme."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/personas/edit.html:106
-msgid ""
-"A short explanation of your theme's\n"
-"                                basic functionality that is displayed in\n"
-"                                search and browse listings, as well as at\n"
-"                                the top of your theme's details page."
+#: src/olympia/devhub/templates/devhub/personas/edit.html:106 src/olympia/devhub/templates/devhub/personas/submit.html:54
+msgid "A short explanation of your theme's basic functionality that is displayed in search and browse listings, as well as at the top of your theme's details page."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/personas/edit.html:122 src/olympia/devhub/templates/devhub/personas/submit.html:68
@@ -6444,7 +6328,7 @@ msgid "Upon upload and form submission, the AMO Team will review your updated de
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/personas/edit.html:241
-msgid "Your previously resubmitted design,  which is under pending review."
+msgid "Your previously resubmitted design, which is under pending review."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/personas/edit.html:245
@@ -6511,14 +6395,6 @@ msgstr ""
 
 #: src/olympia/devhub/templates/devhub/personas/submit.html:33
 msgid "Give your Theme a name."
-msgstr ""
-
-#: src/olympia/devhub/templates/devhub/personas/submit.html:54
-msgid ""
-"A short explanation of your theme's\n"
-"                                      basic functionality that is displayed in\n"
-"                                      search and browse listings, as well as at\n"
-"                                      the top of your theme's details page."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/personas/submit.html:198
@@ -6595,30 +6471,16 @@ msgstr ""
 msgid "Files added to reviewed versions must be reviewed before they will be available for download."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/add_file_modal.html:15
-#, python-format
-msgid ""
-"Submission of updates to unlisted add-ons for signing is currently in an open beta. Manual review may still be required for a large number of add-ons. Please <a href=\"%(url)s\" target=\"_blank"
-"\">report any bugs</a> that you encounter."
-msgstr ""
-
-#: src/olympia/devhub/templates/devhub/versions/add_file_modal.html:35
+#: src/olympia/devhub/templates/devhub/versions/add_file_modal.html:24
 msgid "Select the target platform for this file."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/add_file_modal.html:46
+#: src/olympia/devhub/templates/devhub/versions/add_file_modal.html:35
 msgid "Which review type would you like to nominate for?"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/add_file_modal.html:51
+#: src/olympia/devhub/templates/devhub/versions/add_file_modal.html:40
 msgid "Only publish this version to my beta channel."
-msgstr ""
-
-#: src/olympia/devhub/templates/devhub/versions/add_file_modal.html:54
-#, python-format
-msgid ""
-"The behavior of the beta channel has changed to accommodate <a href=\"%(addon_signing_url)s\" target=\"_blank\">mandatory add-on signing</a>. The new process is currently in an open beta, and may "
-"change significantly in the near future. Please <a href=\"%(issues_url)s\" target=\"_blank\">report any bugs</a> that you encounter."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/versions/edit.html:5
@@ -6642,19 +6504,10 @@ msgstr ""
 msgid "Upload Another File"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/edit.html:45
-msgid ""
-"Adjusting application information here will allow users to install your\n"
-"                          add-on even if the install manifest in the package indicates that the\n"
-"                          add-on is incompatible."
-msgstr ""
-
 #: src/olympia/devhub/templates/devhub/versions/edit.html:74
 msgid ""
-"Information about changes in this release, new features,\n"
-"                              known bugs, and other useful information specific to this\n"
-"                              release/version. This information is also shown in the\n"
-"                              Add-ons Manager when updating."
+"Information about changes in this release, new features, known bugs, and other useful information specific to this release/version. This information is also shown in the Add-ons Manager when "
+"updating."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/versions/edit.html:99
@@ -6666,10 +6519,7 @@ msgid "Notes for Reviewers"
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/versions/edit.html:114
-msgid ""
-"Optionally, enter any information that may be useful\n"
-"                              to the Editor reviewing this add-on, such as test\n"
-"                              account information."
+msgid "Optionally, enter any information that may be useful to the Editor reviewing this add-on, such as test account information."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/versions/edit.html:127
@@ -6747,7 +6597,7 @@ msgstr ""
 msgid "Request Preliminary Review"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:80 src/olympia/devhub/templates/devhub/versions/list.html:327 src/olympia/devhub/templates/devhub/versions/list.html:350
+#: src/olympia/devhub/templates/devhub/versions/list.html:80 src/olympia/devhub/templates/devhub/versions/list.html:325 src/olympia/devhub/templates/devhub/versions/list.html:348
 msgid "Cancel Review Request"
 msgstr ""
 
@@ -6776,7 +6626,7 @@ msgid "Unlisted:"
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/versions/list.html:114
-msgid "Not distributed on {0}. Developers will upload new versions for signing and distribute the add-ons on their own. (beta)"
+msgid "Not distributed on {0}. Developers will upload new versions for signing and distribute the add-ons on their own."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/versions/list.html:122
@@ -6839,81 +6689,73 @@ msgid "<strong>Important:</strong> Once a version has been deleted, you may not 
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/versions/list.html:230
-msgid ""
-"Deleting a version which has already been reviewed\n"
-"               may also cause a significant delay in the review of\n"
-"               your next update."
-msgstr ""
-
-#: src/olympia/devhub/templates/devhub/versions/list.html:233
 msgid "Are you sure you wish to delete this version?"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:238
+#: src/olympia/devhub/templates/devhub/versions/list.html:235
 msgid "Delete Version"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:240
+#: src/olympia/devhub/templates/devhub/versions/list.html:237
 msgid "Disable Version"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:247
+#: src/olympia/devhub/templates/devhub/versions/list.html:244
 msgid "Add a new Version"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:249
+#: src/olympia/devhub/templates/devhub/versions/list.html:246
 msgid "Add Version"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:256 src/olympia/devhub/templates/devhub/versions/list.html:274
+#: src/olympia/devhub/templates/devhub/versions/list.html:253 src/olympia/devhub/templates/devhub/versions/list.html:279
 msgid "Hide Add-on"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:259
+#: src/olympia/devhub/templates/devhub/versions/list.html:256
 msgid "Hiding your add-on will prevent it from appearing anywhere in our gallery and will stop users from receiving automatic updates."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:265
+#: src/olympia/devhub/templates/devhub/versions/list.html:263
+msgid "The files awaiting review will be disabled and you will need to upload new versions."
+msgstr ""
+
+#: src/olympia/devhub/templates/devhub/versions/list.html:270
 msgid "Are you sure you wish to hide your add-on?"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:286 src/olympia/devhub/templates/devhub/versions/list.html:315
+#: src/olympia/devhub/templates/devhub/versions/list.html:291 src/olympia/devhub/templates/devhub/versions/list.html:313
 msgid "Unlist Add-on"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:289
+#: src/olympia/devhub/templates/devhub/versions/list.html:294
 #, python-format
 msgid ""
 "Unlisting your add-on will make it (and each of its versions/files) invisible on this website. It won't show up in searches, won't have a public facing page, and won't be updated automatically for "
-"current users.  It is recommended for unlisted add-ons to provide a custom <a href=\"%(update_url)s\" target=\"_blank\">updateURL</a> in their manifest file for automatic updates."
+"current users. It is recommended for unlisted add-ons to provide a custom <a href=\"%(update_url)s\" target=\"_blank\">updateURL</a> in their manifest file for automatic updates."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:299
-#, python-format
-msgid "Switching add-ons to unlisted is currently in an open beta. Please <a href=\"%(url)s\" target=\"_blank\">report any bugs</a> that you encounter."
-msgstr ""
-
-#: src/olympia/devhub/templates/devhub/versions/list.html:305
+#: src/olympia/devhub/templates/devhub/versions/list.html:303
 msgid "Unlisting an add-on is irreversible!"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:305
+#: src/olympia/devhub/templates/devhub/versions/list.html:303
 msgid "An unlisted add-on cannot be switched to be listed."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:307
+#: src/olympia/devhub/templates/devhub/versions/list.html:305
 msgid "Are you sure you wish to unlist your add-on?"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:330
+#: src/olympia/devhub/templates/devhub/versions/list.html:328
 msgid "Canceling your review request will leave your add-on as preliminarily reviewed."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:335
+#: src/olympia/devhub/templates/devhub/versions/list.html:333
 msgid "Canceling your review request will mark your add-on incomplete. If you do not complete your add-on after several days by re-requesting review, it will be deleted."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:343
+#: src/olympia/devhub/templates/devhub/versions/list.html:341
 msgid "Are you sure you wish to cancel your review request?"
 msgstr ""
 
@@ -7252,19 +7094,19 @@ msgstr ""
 msgid "Search by add-on name / author email"
 msgstr ""
 
-#: src/olympia/editors/forms.py:103
+#: src/olympia/editors/forms.py:103 src/olympia/editors/forms.py:244 src/olympia/editors/forms.py:257
 msgid "yes"
 msgstr ""
 
-#: src/olympia/editors/forms.py:104
+#: src/olympia/editors/forms.py:104 src/olympia/editors/forms.py:244 src/olympia/editors/forms.py:257
 msgid "no"
 msgstr ""
 
-#: src/olympia/editors/forms.py:105
+#: src/olympia/editors/forms.py:105 src/olympia/editors/forms.py:245
 msgid "Admin Flag"
 msgstr ""
 
-#: src/olympia/editors/forms.py:113
+#: src/olympia/editors/forms.py:113 src/olympia/editors/forms.py:253
 msgid "Max. Version"
 msgstr ""
 
@@ -7276,55 +7118,59 @@ msgstr ""
 msgid "Add-on Types"
 msgstr ""
 
-#: src/olympia/editors/forms.py:126 src/olympia/editors/helpers.py:267
+#: src/olympia/editors/forms.py:126 src/olympia/editors/helpers.py:279
 msgid "Platforms"
 msgstr ""
 
+#: src/olympia/editors/forms.py:237
+msgid "Search by add-on name / author email / guid"
+msgstr ""
+
 #. L10n: 0 = platform, 1 = filename, 2 = status message
-#: src/olympia/editors/forms.py:238
+#: src/olympia/editors/forms.py:342
 #, python-format
 msgid "<strong>%s</strong> &middot; %s &middot; %s"
 msgstr ""
 
-#: src/olympia/editors/forms.py:252
+#: src/olympia/editors/forms.py:356
 msgid "Comments:"
 msgstr ""
 
-#: src/olympia/editors/forms.py:256
+#: src/olympia/editors/forms.py:360
 msgid "Operating systems:"
 msgstr ""
 
-#: src/olympia/editors/forms.py:258
+#: src/olympia/editors/forms.py:362
 msgid "Applications:"
 msgstr ""
 
-#: src/olympia/editors/forms.py:260
+#: src/olympia/editors/forms.py:364
 msgid "Notify me the next time this add-on is updated. (Subsequent updates will not generate an email)"
 msgstr ""
 
-#: src/olympia/editors/forms.py:265
+#: src/olympia/editors/forms.py:369
 msgid "Clear Admin Review Flag"
 msgstr ""
 
-#: src/olympia/editors/forms.py:267
+#: src/olympia/editors/forms.py:371
 msgid "Clear more info requested flag"
 msgstr ""
 
-#: src/olympia/editors/forms.py:281
+#: src/olympia/editors/forms.py:385
 msgid "Choose a canned response..."
 msgstr ""
 
 #. L10n: Description of what can be searched for.
-#: src/olympia/editors/forms.py:324
+#: src/olympia/editors/forms.py:423
 msgid "theme name"
 msgstr ""
 
-#: src/olympia/editors/forms.py:350
+#: src/olympia/editors/forms.py:449
 msgid "Someone else is reviewing this theme."
 msgstr ""
 
 #. L10n: Description of what can be searched for.
-#: src/olympia/editors/forms.py:447
+#: src/olympia/editors/forms.py:546
 msgid "app, reviewer, or comment"
 msgstr ""
 
@@ -7340,246 +7186,264 @@ msgstr ""
 msgid "Rejected or Unreviewed"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:123 src/olympia/editors/helpers.py:136
+#: src/olympia/editors/helpers.py:125 src/olympia/editors/helpers.py:138
 msgid "Queue"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:124 src/olympia/editors/templates/editors/base.html:50 src/olympia/editors/templates/editors/base.html:65
+#: src/olympia/editors/helpers.py:126 src/olympia/editors/templates/editors/base.html:50 src/olympia/editors/templates/editors/base.html:65
 msgid "Pending Updates"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:125 src/olympia/editors/templates/editors/base.html:48 src/olympia/editors/templates/editors/base.html:63
+#: src/olympia/editors/helpers.py:127 src/olympia/editors/templates/editors/base.html:48 src/olympia/editors/templates/editors/base.html:63
 msgid "Full Reviews"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:126 src/olympia/editors/templates/editors/base.html:52 src/olympia/editors/templates/editors/base.html:67
+#: src/olympia/editors/helpers.py:128 src/olympia/editors/templates/editors/base.html:52 src/olympia/editors/templates/editors/base.html:67
 msgid "Preliminary Reviews"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:127 src/olympia/editors/templates/editors/base.html:54
+#: src/olympia/editors/helpers.py:129 src/olympia/editors/templates/editors/base.html:54
 msgid "Moderated Reviews"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:128 src/olympia/editors/templates/editors/base.html:46
+#: src/olympia/editors/helpers.py:130 src/olympia/editors/templates/editors/base.html:46
 msgid "Fast Track"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:130
+#: src/olympia/editors/helpers.py:132
 msgid "Pending Themes"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:131 src/olympia/editors/templates/editors/themes/queue.html:4
+#: src/olympia/editors/helpers.py:133 src/olympia/editors/templates/editors/themes/queue.html:4
 msgid "Flagged Themes"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:132
+#: src/olympia/editors/helpers.py:134
 msgid "Update Themes"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:137
+#: src/olympia/editors/helpers.py:139
 msgid "Unlisted Pending Updates"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:138
+#: src/olympia/editors/helpers.py:140
 msgid "Unlisted Full Reviews"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:139
+#: src/olympia/editors/helpers.py:141
 msgid "Unlisted Preliminary Reviews"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:170
+#: src/olympia/editors/helpers.py:142
+msgid "Unlisted All Add-ons"
+msgstr ""
+
+#: src/olympia/editors/helpers.py:173
 msgid "Fast Track ({0})"
 msgid_plural "Fast Track ({0})"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/olympia/editors/helpers.py:175
+#: src/olympia/editors/helpers.py:178
 msgid "Full Review ({0})"
 msgid_plural "Full Reviews ({0})"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/olympia/editors/helpers.py:180
+#: src/olympia/editors/helpers.py:183
 msgid "Pending Update ({0})"
 msgid_plural "Pending Updates ({0})"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/olympia/editors/helpers.py:185
+#: src/olympia/editors/helpers.py:188
 msgid "Preliminary Review ({0})"
 msgid_plural "Preliminary Reviews ({0})"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/olympia/editors/helpers.py:190
+#: src/olympia/editors/helpers.py:193
 msgid "Moderated Review ({0})"
 msgid_plural "Moderated Reviews ({0})"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/olympia/editors/helpers.py:196
+#: src/olympia/editors/helpers.py:199
 msgid "Unlisted Full Review ({0})"
 msgid_plural "Unlisted Full Reviews ({0})"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/olympia/editors/helpers.py:201
+#: src/olympia/editors/helpers.py:204
 msgid "Unlisted Pending Update ({0})"
 msgid_plural "Unlisted Pending Updates ({0})"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/olympia/editors/helpers.py:206
+#: src/olympia/editors/helpers.py:209
 msgid "Unlisted Preliminary Review ({0})"
 msgid_plural "Unlisted Preliminary Reviews ({0})"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/olympia/editors/helpers.py:261
-msgid "Addon"
-msgstr ""
+#: src/olympia/editors/helpers.py:214
+msgid "Unlisted All Add-ons ({0})"
+msgid_plural "Unlisted All Add-ons ({0})"
+msgstr[0] ""
+msgstr[1] ""
 
-#: src/olympia/editors/helpers.py:262
+#: src/olympia/editors/helpers.py:274
 msgid "Type"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:263
+#: src/olympia/editors/helpers.py:275
 msgid "Waiting Time"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:264 src/olympia/editors/templates/editors/review.html:285
+#: src/olympia/editors/helpers.py:276 src/olympia/editors/templates/editors/review.html:285
 msgid "Flags"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:265
+#: src/olympia/editors/helpers.py:277
 msgid "Applications"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:270
+#: src/olympia/editors/helpers.py:282
 msgid "Additional"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:285
+#: src/olympia/editors/helpers.py:302
 msgid "Site Specific"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:287
+#: src/olympia/editors/helpers.py:304
 msgid "Requires External Software"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:289
+#: src/olympia/editors/helpers.py:306
 msgid "Binary Components"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:313
+#: src/olympia/editors/helpers.py:339
 msgid "moments ago"
 msgstr ""
 
 #. L10n: first argument is number of minutes
-#: src/olympia/editors/helpers.py:316
+#: src/olympia/editors/helpers.py:342
 msgid "{0} minute"
 msgid_plural "{0} minutes"
 msgstr[0] ""
 msgstr[1] ""
 
 #. L10n: first argument is number of hours
-#: src/olympia/editors/helpers.py:320
+#: src/olympia/editors/helpers.py:346
 msgid "{0} hour"
 msgid_plural "{0} hours"
 msgstr[0] ""
 msgstr[1] ""
 
 #. L10n: first argument is number of days
-#: src/olympia/editors/helpers.py:324
+#: src/olympia/editors/helpers.py:350
 msgid "{0} day"
 msgid_plural "{0} days"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/olympia/editors/helpers.py:488
+#: src/olympia/editors/helpers.py:364
+msgid "Last Review"
+msgstr ""
+
+#: src/olympia/editors/helpers.py:366
+msgid "Last Update"
+msgstr ""
+
+#: src/olympia/editors/helpers.py:387
+msgid "No Reviews"
+msgstr ""
+
+#: src/olympia/editors/helpers.py:561
 msgid "Push to public"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:490
+#: src/olympia/editors/helpers.py:563
 msgid "Grant full review"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:505
+#: src/olympia/editors/helpers.py:578
 msgid "Request more information"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:508
+#: src/olympia/editors/helpers.py:581
 msgid "Request super-review"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:519
+#: src/olympia/editors/helpers.py:592
 msgid "Grant preliminary review"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:520
+#: src/olympia/editors/helpers.py:593
 msgid "This will mark the files as preliminarily reviewed."
 msgstr ""
 
-#: src/olympia/editors/helpers.py:522
+#: src/olympia/editors/helpers.py:595
 msgid "Use this form to request more information from the author. They will receive an email and be able to answer here. You will be notified by email when they reply."
 msgstr ""
 
-#: src/olympia/editors/helpers.py:526
+#: src/olympia/editors/helpers.py:599
 msgid ""
 "If you have concerns about this add-on's security, copyright issues, or other concerns that an administrator should look into, enter your comments in the area below. They will be sent to "
 "administrators, not the author."
 msgstr ""
 
-#: src/olympia/editors/helpers.py:532
+#: src/olympia/editors/helpers.py:605
 msgid "This will reject the add-on and remove it from the review queue."
 msgstr ""
 
-#: src/olympia/editors/helpers.py:534
-msgid "Make a comment on this version.  The author won't be able to see this."
+#: src/olympia/editors/helpers.py:607
+msgid "Make a comment on this version. The author won't be able to see this."
 msgstr ""
 
-#: src/olympia/editors/helpers.py:538
+#: src/olympia/editors/helpers.py:611
 msgid "This will reject the files and remove them from the review queue."
 msgstr ""
 
-#: src/olympia/editors/helpers.py:542
+#: src/olympia/editors/helpers.py:615
 msgid "This will mark the add-on as preliminarily reviewed. Future versions will undergo preliminary review."
 msgstr ""
 
-#: src/olympia/editors/helpers.py:547
+#: src/olympia/editors/helpers.py:620
 msgid "This will mark the files as preliminarily reviewed. Future versions will undergo preliminary review."
 msgstr ""
 
-#: src/olympia/editors/helpers.py:552
+#: src/olympia/editors/helpers.py:625
 msgid "Retain preliminary review"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:553
+#: src/olympia/editors/helpers.py:626
 msgid "This will retain the add-on as preliminarily reviewed. Future versions will undergo preliminary review."
 msgstr ""
 
-#: src/olympia/editors/helpers.py:558
+#: src/olympia/editors/helpers.py:631
 msgid "This will approve a sandboxed version of a public add-on to appear on the public side."
 msgstr ""
 
-#: src/olympia/editors/helpers.py:561
+#: src/olympia/editors/helpers.py:634
 msgid "This will reject a version of a public add-on and remove it from the queue."
 msgstr ""
 
-#: src/olympia/editors/helpers.py:564
+#: src/olympia/editors/helpers.py:637
 msgid "This will mark the add-on and its most recent version and files as public. Future versions will go into the sandbox until they are reviewed by an editor."
 msgstr ""
 
-#: src/olympia/editors/helpers.py:637
+#: src/olympia/editors/helpers.py:714
 msgid "add-on"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:940 src/olympia/editors/helpers.py:960
+#: src/olympia/editors/helpers.py:1020 src/olympia/editors/helpers.py:1040
 msgid "Flagged"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:944 src/olympia/editors/helpers.py:963
+#: src/olympia/editors/helpers.py:1024 src/olympia/editors/helpers.py:1043
 msgid "Updates"
 msgstr ""
 
@@ -7631,56 +7495,56 @@ msgstr ""
 msgid "A question about your Theme submission"
 msgstr ""
 
-#: src/olympia/editors/views.py:144
+#: src/olympia/editors/views.py:146
 msgid "New Add-ons (Under 5 days)"
 msgstr ""
 
-#: src/olympia/editors/views.py:145
+#: src/olympia/editors/views.py:147
 msgid "Passable (5 to 10 days)"
 msgstr ""
 
-#: src/olympia/editors/views.py:146
+#: src/olympia/editors/views.py:148
 msgid "Overdue (Over 10 days)"
 msgstr ""
 
-#: src/olympia/editors/views.py:532
+#: src/olympia/editors/views.py:539
 msgid "An unknown error occurred"
 msgstr ""
 
-#: src/olympia/editors/views.py:587
+#: src/olympia/editors/views.py:592
 msgid "Self-reviews are not allowed."
 msgstr ""
 
-#: src/olympia/editors/views.py:609
+#: src/olympia/editors/views.py:613
 msgid "Review successfully processed."
 msgstr ""
 
-#: src/olympia/editors/views.py:807
+#: src/olympia/editors/views.py:812
 msgid "was approved"
 msgstr ""
 
-#: src/olympia/editors/views.py:808
+#: src/olympia/editors/views.py:813
 msgid "given preliminary review"
 msgstr ""
 
-#: src/olympia/editors/views.py:809
+#: src/olympia/editors/views.py:814
 msgid "rejected"
 msgstr ""
 
-#: src/olympia/editors/views.py:810
+#: src/olympia/editors/views.py:815
 msgctxt "editors_review_history_nominated_adminreview"
 msgid "escalated"
 msgstr ""
 
-#: src/olympia/editors/views.py:812
+#: src/olympia/editors/views.py:817
 msgid "needs more information"
 msgstr ""
 
-#: src/olympia/editors/views.py:813
+#: src/olympia/editors/views.py:818
 msgid "needs super review"
 msgstr ""
 
-#: src/olympia/editors/views.py:814
+#: src/olympia/editors/views.py:819
 msgid "commented"
 msgstr ""
 
@@ -7725,28 +7589,28 @@ msgstr ""
 msgid "Unlisted Queues"
 msgstr ""
 
-#: src/olympia/editors/templates/editors/base.html:72 src/olympia/editors/templates/editors/performance.html:6
+#: src/olympia/editors/templates/editors/base.html:74 src/olympia/editors/templates/editors/performance.html:6
 msgid "Performance"
 msgstr ""
 
-#: src/olympia/editors/templates/editors/base.html:75 src/olympia/editors/templates/editors/themes/base.html:19 src/olympia/editors/templates/editors/themes/base.html:38
+#: src/olympia/editors/templates/editors/base.html:77 src/olympia/editors/templates/editors/themes/base.html:19 src/olympia/editors/templates/editors/themes/base.html:38
 msgid "Logs"
 msgstr ""
 
-#: src/olympia/editors/templates/editors/base.html:78 src/olympia/editors/templates/editors/reviewlog.html:4 src/olympia/editors/templates/editors/reviewlog.html:27
+#: src/olympia/editors/templates/editors/base.html:80 src/olympia/editors/templates/editors/reviewlog.html:4 src/olympia/editors/templates/editors/reviewlog.html:27
 msgid "Add-on Review Log"
 msgstr ""
 
-#: src/olympia/editors/templates/editors/base.html:80 src/olympia/editors/templates/editors/eventlog.html:4 src/olympia/editors/templates/editors/eventlog.html:8
+#: src/olympia/editors/templates/editors/base.html:82 src/olympia/editors/templates/editors/eventlog.html:4 src/olympia/editors/templates/editors/eventlog.html:8
 #: src/olympia/editors/templates/editors/eventlog_detail.html:4
 msgid "Moderated Review Log"
 msgstr ""
 
-#: src/olympia/editors/templates/editors/base.html:82 src/olympia/editors/templates/editors/beta_signed_log.html:4 src/olympia/editors/templates/editors/beta_signed_log.html:8
+#: src/olympia/editors/templates/editors/base.html:84 src/olympia/editors/templates/editors/beta_signed_log.html:4 src/olympia/editors/templates/editors/beta_signed_log.html:8
 msgid "Signed Beta Files Log"
 msgstr ""
 
-#: src/olympia/editors/templates/editors/base.html:87 src/olympia/editors/templates/editors/includes/daily-message.html:4
+#: src/olympia/editors/templates/editors/base.html:89 src/olympia/editors/templates/editors/includes/daily-message.html:4
 msgid "Announcement"
 msgstr ""
 
@@ -7967,45 +7831,45 @@ msgstr ""
 msgid "clear search"
 msgstr ""
 
-#: src/olympia/editors/templates/editors/queue.html:72 src/olympia/editors/templates/editors/queue.html:122
+#: src/olympia/editors/templates/editors/queue.html:78 src/olympia/editors/templates/editors/queue.html:128
 msgid "Process Reviews"
 msgstr ""
 
-#: src/olympia/editors/templates/editors/queue.html:80
+#: src/olympia/editors/templates/editors/queue.html:86
 msgid "Moderation actions:"
 msgstr ""
 
-#: src/olympia/editors/templates/editors/queue.html:90
+#: src/olympia/editors/templates/editors/queue.html:96
 #, python-format
 msgid "by %(user)s on %(date)s %(stars)s (%(locale)s)"
 msgstr ""
 
-#: src/olympia/editors/templates/editors/queue.html:106
+#: src/olympia/editors/templates/editors/queue.html:112
 #, python-format
 msgid "<strong>%(reason)s</strong> <span class=\"light\">Flagged by %(user)s on %(date)s</span>"
 msgstr ""
 
-#: src/olympia/editors/templates/editors/queue.html:119
-msgid "All reviews have been moderated.  Good work!"
+#: src/olympia/editors/templates/editors/queue.html:125
+msgid "All reviews have been moderated. Good work!"
 msgstr ""
 
-#: src/olympia/editors/templates/editors/queue.html:161
+#: src/olympia/editors/templates/editors/queue.html:167
 msgid "Version Notes / Notes for Reviewer"
 msgstr ""
 
-#: src/olympia/editors/templates/editors/queue.html:169
+#: src/olympia/editors/templates/editors/queue.html:175
 msgid "There are currently no add-ons of this type to review."
 msgstr ""
 
-#: src/olympia/editors/templates/editors/queue.html:181 src/olympia/editors/templates/editors/themes/queue_list.html:85
+#: src/olympia/editors/templates/editors/queue.html:187 src/olympia/editors/templates/editors/themes/queue_list.html:85
 msgid "Helpful Links:"
 msgstr ""
 
-#: src/olympia/editors/templates/editors/queue.html:182
+#: src/olympia/editors/templates/editors/queue.html:188
 msgid "Add-on Policy"
 msgstr ""
 
-#: src/olympia/editors/templates/editors/queue.html:184
+#: src/olympia/editors/templates/editors/queue.html:190
 msgid "Editors' Guide"
 msgstr ""
 
@@ -8068,10 +7932,7 @@ msgid "<strong>Warning!</strong> Another user was viewing this page before you."
 msgstr ""
 
 #: src/olympia/editors/templates/editors/review.html:237
-msgid ""
-"The whiteboard is the place to exchange information relevant to\n"
-"               this addon (whatever the version), between the developer and the\n"
-"               editor. This is visible and editable by both."
+msgid "The whiteboard is the place to exchange information relevant to this addon (whatever the version), between the developer and the editor. This is visible and editable by both."
 msgstr ""
 
 #: src/olympia/editors/templates/editors/review.html:241
@@ -8345,7 +8206,7 @@ msgstr ""
 msgid "Describe your reason for flagging"
 msgstr ""
 
-#: src/olympia/files/forms.py:88
+#: src/olympia/files/forms.py:90
 msgid "Cannot diff a version against itself"
 msgstr ""
 
@@ -8380,51 +8241,51 @@ msgstr ""
 msgid "There was an error accessing file %s."
 msgstr ""
 
-#: src/olympia/files/utils.py:343
+#: src/olympia/files/utils.py:340
 msgid "Could not parse uploaded file."
 msgstr ""
 
-#: src/olympia/files/utils.py:380
+#: src/olympia/files/utils.py:377
 msgid "Invalid file name in archive: {0}"
 msgstr ""
 
-#: src/olympia/files/utils.py:388
+#: src/olympia/files/utils.py:385
 msgid "File exceeding size limit in archive: {0}"
 msgstr ""
 
-#: src/olympia/files/utils.py:439
+#: src/olympia/files/utils.py:436
 msgid "Invalid archive."
 msgstr ""
 
-#: src/olympia/files/utils.py:529 src/olympia/files/utils.py:532
+#: src/olympia/files/utils.py:526 src/olympia/files/utils.py:529
 msgid "Could not parse the manifest file."
 msgstr ""
 
-#: src/olympia/files/utils.py:551
+#: src/olympia/files/utils.py:548
 msgid "Could not find an add-on ID."
 msgstr ""
 
-#: src/olympia/files/utils.py:554
+#: src/olympia/files/utils.py:551
 msgid "Add-on ID must be 64 characters or less."
 msgstr ""
 
-#: src/olympia/files/utils.py:556
+#: src/olympia/files/utils.py:553
 msgid "Add-on ID doesn't match add-on."
 msgstr ""
 
-#: src/olympia/files/utils.py:564
+#: src/olympia/files/utils.py:561
 msgid "Duplicate add-on ID found."
 msgstr ""
 
-#: src/olympia/files/utils.py:567
+#: src/olympia/files/utils.py:564
 msgid "Version numbers should have fewer than 32 characters."
 msgstr ""
 
-#: src/olympia/files/utils.py:570
+#: src/olympia/files/utils.py:567
 msgid "Version numbers should only contain letters, numbers, and these punctuation characters: +*.-_."
 msgstr ""
 
-#: src/olympia/files/utils.py:587
+#: src/olympia/files/utils.py:584
 msgid "<em:type> doesn't match add-on"
 msgstr ""
 
@@ -8523,6 +8384,10 @@ msgstr ""
 
 #: src/olympia/files/templates/files/viewer.html:134
 msgid "Fetching file."
+msgstr ""
+
+#: src/olympia/legacy_api/views.py:255
+msgid "Not implemented yet."
 msgstr ""
 
 #: src/olympia/lib/constants.py:6
@@ -9181,10 +9046,6 @@ msgstr ""
 msgid "Zimbabwe Dollar"
 msgstr ""
 
-#: src/olympia/lib/video/ffmpeg.py:112 src/olympia/lib/video/totem.py:81
-msgid "Videos must be in WebM."
-msgstr ""
-
 #: src/olympia/pages/templates/pages/about.lhtml:3 src/olympia/pages/templates/pages/about.lhtml:10
 msgid "About Mozilla Add-ons"
 msgstr ""
@@ -9196,7 +9057,7 @@ msgstr ""
 #: src/olympia/pages/templates/pages/about.lhtml:13
 msgid ""
 "addons.mozilla.org, commonly known as \"AMO\", is Mozilla's official site for add-ons to Mozilla software, such as Firefox, Thunderbird, and SeaMonkey. Add-ons let you add new features and change "
-"the way your browser or application works.  Take a look around and explore the thousands of ways to customize the way you do things online."
+"the way your browser or application works. Take a look around and explore the thousands of ways to customize the way you do things online."
 msgstr ""
 
 #: src/olympia/pages/templates/pages/about.lhtml:19
@@ -9541,7 +9402,7 @@ msgstr ""
 msgid ""
 "Yes. It's possible, but some of the functionality provided by these libraries are available through XPCOM, XUL, and JavaScript. In addition, authors should take care if libraries modify primitive "
 "object prototypes (String.prototype, Date.prototype, etc.) and/or define global functions (eg. the $ function). These are prone to cause conflict with other add-ons, in particular if different add-"
-"ons use different versions of libraries and so on. Developers need to be very, very careful with using them.  Mozilla does not offer documentation on using them to build add-ons."
+"ons use different versions of libraries and so on. Developers need to be very, very careful with using them. Mozilla does not offer documentation on using them to build add-ons."
 msgstr ""
 
 #: src/olympia/pages/templates/pages/dev_faq.html:165
@@ -9655,8 +9516,8 @@ msgstr ""
 #, python-format
 msgid ""
 "Yes. Many developers choose to host their own add-ons. Choosing to host your add-on on <a href=\"%(amo_url)s\">Mozilla's add-on site</a>, though, allows for much greater exposure to your add-on due "
-"to the large volume of visitors to the site.  <a href=\"%(md_url)s\">mozdev.org</a> offers free project hosting for Mozilla applications and extensions providing developers with tools to help "
-"manage source code, version control, bug tracking and documentation."
+"to the large volume of visitors to the site. <a href=\"%(md_url)s\">mozdev.org</a> offers free project hosting for Mozilla applications and extensions providing developers with tools to help manage "
+"source code, version control, bug tracking and documentation."
 msgstr ""
 
 #: src/olympia/pages/templates/pages/dev_faq.html:277
@@ -9704,7 +9565,7 @@ msgstr ""
 #: src/olympia/pages/templates/pages/dev_faq.html:314
 #, python-format
 msgid ""
-"Yes. Mozilla's <a href=\"%(p_url)s\">Add-on Policy</a> describes what is an acceptable submission. This policy is subject to change without notice.  In addition, the AMO editorial team uses the <a "
+"Yes. Mozilla's <a href=\"%(p_url)s\">Add-on Policy</a> describes what is an acceptable submission. This policy is subject to change without notice. In addition, the AMO editorial team uses the <a "
 "href=\"%(g_url)s\">Editors Reviewing Guide</a> to ensure that your add-on meets specific guidelines for functionality and security."
 msgstr ""
 
@@ -9821,7 +9682,7 @@ msgstr ""
 #: src/olympia/pages/templates/pages/dev_faq.html:434
 #, python-format
 msgid ""
-"This is why it's very important to read the <a href=\"%(g_url)s\">Editors Reviewing Guide</a> to ensure that your add-on is setup as expected.  It's also a good idea to read the blog post, <a href="
+"This is why it's very important to read the <a href=\"%(g_url)s\">Editors Reviewing Guide</a> to ensure that your add-on is setup as expected. It's also a good idea to read the blog post, <a href="
 "\"%(blog_url)s\">Successfully Getting your Add-on Reviewed</a> which provides excellent insight into ensuring a smooth review of your add-on."
 msgstr ""
 
@@ -9928,7 +9789,7 @@ msgstr ""
 
 #: src/olympia/pages/templates/pages/dev_faq.html:572
 msgid ""
-"Free Software Foundation provides short summaries of the key open source licenses, including whether the license qualifies as a free software license or a copyleft license.  Also includes a "
+"Free Software Foundation provides short summaries of the key open source licenses, including whether the license qualifies as a free software license or a copyleft license. Also includes a "
 "discussion of what constitutes a free software license or a copyleft license (e.g., a Copyleft license is a general method for making a program or other work free, and requiring all modified and "
 "extended versions of the program to be free as well.)"
 msgstr ""
@@ -10106,19 +9967,13 @@ msgid "Add-on Gallery"
 msgstr ""
 
 #: src/olympia/pages/templates/pages/faq.html:171
-msgid ""
-"How do I choose between add-ons that seem to do the same\n"
-"    thing?"
+msgid "How do I choose between add-ons that seem to do the same thing?"
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:173
+#: src/olympia/pages/templates/pages/faq.html:172
 msgid ""
-"There are often several add-ons that have similar features. To\n"
-"    figure out which is right for you, read the entire description of the\n"
-"    add-on and view its screenshots. If there are still several in the running,\n"
-"    read through the add-on's ratings, user reviews, and statistics to see\n"
-"    which is most liked by other users. Remember that you can also just try\n"
-"    out both and see which you like better."
+"There are often several add-ons that have similar features. To figure out which is right for you, read the entire description of the add-on and view its screenshots. If there are still several in "
+"the running, read through the add-on's ratings, user reviews, and statistics to see which is most liked by other users. Remember that you can also just try out both and see which you like better."
 msgstr ""
 
 #: src/olympia/pages/templates/pages/faq.html:180
@@ -10159,80 +10014,67 @@ msgid "How much do add-ons cost to purchase?"
 msgstr ""
 
 #: src/olympia/pages/templates/pages/faq.html:207
-msgid ""
-"Add-ons hosted in our gallery are free unless clearly marked\n"
-"    otherwise."
+msgid "Add-ons hosted in our gallery are free unless clearly marked otherwise."
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:210
+#: src/olympia/pages/templates/pages/faq.html:209
 msgid "What does it mean when an add-on asks for contributions?"
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:211
+#: src/olympia/pages/templates/pages/faq.html:210
 msgid ""
-"Some add-on authors request users who enjoy an add-on to\n"
-"        contribute to its development by making a monetary contribution. These\n"
-"        contributions go directly to the developer unless a third party is\n"
-"        indicated, such as the non-profit Mozilla Foundation."
+"Some add-on authors request users who enjoy an add-on to contribute to its development by making a monetary contribution. These contributions go directly to the developer unless a third party is "
+"indicated, such as the non-profit Mozilla Foundation."
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:216
+#: src/olympia/pages/templates/pages/faq.html:215
 msgid "What are beta add-ons?"
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:218
+#: src/olympia/pages/templates/pages/faq.html:217
 msgid ""
-"Beta add-ons are unreviewed versions which represent the\n"
-"        latest work of an add-on author. While different authors have different\n"
-"        standards for beta code quality, you should assume that these add-ons\n"
-"        are less stable than the general add-on releases."
+"Beta add-ons are unreviewed versions which represent the latest work of an add-on author. While different authors have different standards for beta code quality, you should assume that these add-"
+"ons are less stable than the general add-on releases."
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:222
+#: src/olympia/pages/templates/pages/faq.html:221
 msgid ""
 "Please note that when you install an add-on from the \"Beta Version\" section of an add-on's listing, you will continue to receive updates for that add-on as they become available. Like the initial "
 "version you installed, all beta releases are unreviewed by Mozilla and may harm your computer."
 msgstr ""
 
+#: src/olympia/pages/templates/pages/faq.html:228
+msgid "What does it mean when an add-on is flagged as slow?"
+msgstr ""
+
 #: src/olympia/pages/templates/pages/faq.html:229
-msgid ""
-"What does it mean when an add-on is flagged as\n"
-"    slow?"
+msgid "Most add-ons load code and resources at the same time Firefox is starting up. In most cases the impact in start-up time is minimal, but some add-ons can cause a noticeable slowdown."
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:231
-msgid ""
-"Most add-ons load code and resources at the same time Firefox\n"
-"        is starting up. In most cases the impact in start-up time is minimal,\n"
-"        but some add-ons can cause a noticeable slowdown."
-msgstr ""
-
-#: src/olympia/pages/templates/pages/faq.html:236
+#: src/olympia/pages/templates/pages/faq.html:234
 msgid "How do I report an inappropriate or spam user review?"
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:237
+#: src/olympia/pages/templates/pages/faq.html:235
 msgid ""
-"To report a user review of an add-on, log in with your account\n"
-"    and visit the add-on's reviews page. Find the review you wish to report,\n"
-"    click \"Report this review\" and select a reason. Our editorial team will\n"
-"    investigate the review and take appropriate action."
+"To report a user review of an add-on, log in with your account and visit the add-on's reviews page. Find the review you wish to report, click \"Report this review\" and select a reason. Our "
+"editorial team will investigate the review and take appropriate action."
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:242
+#: src/olympia/pages/templates/pages/faq.html:240
 msgid "How do I report a bug or contact the Mozilla Add-ons team?"
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:243
+#: src/olympia/pages/templates/pages/faq.html:241
 #, python-format
 msgid "Please visit our <a href=\"%(contact_url)s\">Contact page</a>."
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:246
+#: src/olympia/pages/templates/pages/faq.html:244
 msgid "What is a Source Code License?"
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:247
+#: src/olympia/pages/templates/pages/faq.html:245
 #, python-format
 msgid ""
 "The source code used to create an add-on is an exclusive copyright of the add-on author, unless otherwise declared in a source code license. Many add-ons on this site have <a href=\"%(url)s\" lang="
@@ -10240,60 +10082,60 @@ msgid ""
 "the GPL or BSD licenses instead of making up their own."
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:256
+#: src/olympia/pages/templates/pages/faq.html:254
 #, python-format
 msgid "Firefox and other Mozilla software are <a href=\"%(url)s\">open source</a>."
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:264
+#: src/olympia/pages/templates/pages/faq.html:262
 msgid "Collections and Favorites"
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:267
+#: src/olympia/pages/templates/pages/faq.html:265
 msgid "What is a collection?"
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:268
+#: src/olympia/pages/templates/pages/faq.html:266
 msgid "Collections are groups of related add-ons created by users to share."
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:270
+#: src/olympia/pages/templates/pages/faq.html:268
 msgid "What is the My Favorites collection?"
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:271
+#: src/olympia/pages/templates/pages/faq.html:269
 msgid "Favorite add-ons are add-ons that you have bookmarked to easily get back to later. You can add an add-on to your favorites collection by clicking \"Add to favorites\" on its details page."
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:275 src/olympia/templates/menu_links.html:13 src/olympia/templates/impala/header_title.html:17
+#: src/olympia/pages/templates/pages/faq.html:273 src/olympia/templates/menu_links.html:13 src/olympia/templates/impala/header_title.html:17
 msgid "Mobile Add-ons"
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:278
+#: src/olympia/pages/templates/pages/faq.html:276
 msgid "What are mobile add-ons?"
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:279
+#: src/olympia/pages/templates/pages/faq.html:277
 #, python-format
 msgid ""
 "Mobile add-ons work with <a href=\"%(mobile_url)s\">Firefox for Mobile</a> and add or modify functionality just like desktop add-ons. You can find add-ons that work with Firefox for Mobile in our "
 "<a href=\"%(gallery_url)s\">gallery</a>."
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:288
+#: src/olympia/pages/templates/pages/faq.html:286
 msgid "Developer Topics"
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:289
+#: src/olympia/pages/templates/pages/faq.html:287
 #, python-format
 msgid "Please see our <a href=\"%(faq_url)s\">Developer FAQ</a> and <a href=\"%(hub_url)s\">Developer Hub</a> for answers to add-on developer-related questions."
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:294
+#: src/olympia/pages/templates/pages/faq.html:292
 msgid "Still have questions?"
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:295
+#: src/olympia/pages/templates/pages/faq.html:293
 #, python-format
 msgid "For general Firefox support, visit our <a href=\"%(sumo_url)s\">support website</a>. For general add-on and website questions, visit our <a href=\"%(forum_url)s\">forum</a>."
 msgstr ""
@@ -10431,7 +10273,7 @@ msgstr ""
 
 #: src/olympia/pages/templates/pages/sunbird.html:29
 msgid ""
-"Development on the Sunbird project has halted and its final release was on March 30, 2010.  We've been proud to host Sunbird add-ons on this site but as the project is no longer maintained we have "
+"Development on the Sunbird project has halted and its final release was on March 30, 2010. We've been proud to host Sunbird add-ons on this site but as the project is no longer maintained we have "
 "disabled our support for the add-ons."
 msgstr ""
 
@@ -10509,7 +10351,7 @@ msgstr ""
 #, python-format
 msgid ""
 "<h2>Keep these tips in mind:</h2> <ul> <li> Write like you're telling a friend about your experience with the add-on. Give specifics and helpful details, such as what features you liked and/or "
-"disliked, how easy to use it is, and any disadvantages it has.  Avoid generic language such as calling it \"Great\" or \"Bad\" unless you can give reasons why you believe this is so. </li> <li> "
+"disliked, how easy to use it is, and any disadvantages it has. Avoid generic language such as calling it \"Great\" or \"Bad\" unless you can give reasons why you believe this is so. </li> <li> "
 "Please do not post bug reports in reviews. We do not make your email address available to add-on developers and they may need to contact you to help resolve your issue. See the <a href=\"%(support)s"
 "\">support section</a> to find out where to get assistance for this add-on. </li> <li>Please keep reviews clean, avoid the use of improper language and do not post any personal information. </li> </"
 "ul> <p>Please read the <a href=\"%(guide)s\" target=\"_blank\">Review Guidelines</a> for more detail about user add-on reviews.</p>"
@@ -10745,16 +10587,16 @@ msgstr ""
 
 #. L10n: {0} is an application, such as Firefox. This means "any version of
 #. Firefox."
-#: src/olympia/search/views.py:554
+#: src/olympia/search/views.py:547
 msgid "Any {0}"
 msgstr ""
 
 #. L10n: "All Systems" means show everything regardless of platform.
-#: src/olympia/search/views.py:589
+#: src/olympia/search/views.py:582
 msgid "All Systems"
 msgstr ""
 
-#: src/olympia/search/views.py:600
+#: src/olympia/search/views.py:593
 msgid "All Tags"
 msgstr ""
 
@@ -10928,31 +10770,31 @@ msgstr ""
 msgid "Share this Collection"
 msgstr ""
 
-#: src/olympia/signing/views.py:30 src/olympia/templates/base.html:75 src/olympia/templates/impala/base.html:115
+#: src/olympia/signing/views.py:33 src/olympia/templates/base.html:71 src/olympia/templates/impala/base.html:112
 msgid "Some features are temporarily disabled while we perform website maintenance. We'll be back to full capacity shortly."
 msgstr ""
 
-#: src/olympia/signing/views.py:53
+#: src/olympia/signing/views.py:56
 msgid "Could not find add-on with id \"{}\"."
 msgstr ""
 
-#: src/olympia/signing/views.py:67
+#: src/olympia/signing/views.py:70
 msgid "You do not own this addon."
 msgstr ""
 
-#: src/olympia/signing/views.py:82
+#: src/olympia/signing/views.py:87
 msgid "Missing \"upload\" key in multipart file data."
 msgstr ""
 
-#: src/olympia/signing/views.py:96
+#: src/olympia/signing/views.py:101
 msgid "Version does not match the manifest file."
 msgstr ""
 
-#: src/olympia/signing/views.py:100
+#: src/olympia/signing/views.py:105
 msgid "Version already exists."
 msgstr ""
 
-#: src/olympia/signing/views.py:136
+#: src/olympia/signing/views.py:141
 msgid "No uploaded file for that addon and version."
 msgstr ""
 
@@ -11065,89 +10907,89 @@ msgstr ""
 msgid "Statistics Dashboard :: Add-ons for {0}"
 msgstr ""
 
-#: src/olympia/stats/templates/stats/stats.html:30
-msgid "Controls:"
-msgstr ""
-
-#: src/olympia/stats/templates/stats/stats.html:33
-msgid "reset zoom"
-msgstr ""
-
-#: src/olympia/stats/templates/stats/stats.html:40
-msgid "Group by:"
-msgstr ""
-
-#: src/olympia/stats/templates/stats/stats.html:42
-msgid "day"
-msgstr ""
-
-#: src/olympia/stats/templates/stats/stats.html:45
-msgid "week"
-msgstr ""
-
-#: src/olympia/stats/templates/stats/stats.html:48
-msgid "month"
-msgstr ""
-
-#: src/olympia/stats/templates/stats/stats.html:54
-msgid "For last:"
-msgstr ""
-
-#: src/olympia/stats/templates/stats/stats.html:57
-msgid "7 days"
-msgstr ""
-
-#: src/olympia/stats/templates/stats/stats.html:60
-msgid "30 days"
-msgstr ""
-
-#: src/olympia/stats/templates/stats/stats.html:63
-msgid "90 days"
-msgstr ""
-
-#: src/olympia/stats/templates/stats/stats.html:66
-msgid "365 days"
-msgstr ""
-
-#: src/olympia/stats/templates/stats/stats.html:69
-msgid "Custom..."
-msgstr ""
-
 #. {0} is an add-on name
-#: src/olympia/stats/templates/stats/stats.html:88 src/olympia/stats/templates/stats/stats.html:91
+#: src/olympia/stats/templates/stats/stats.html:44 src/olympia/stats/templates/stats/stats.html:47
 msgid "Statistics for {0}"
 msgstr ""
 
-#: src/olympia/stats/templates/stats/stats.html:94
+#: src/olympia/stats/templates/stats/stats.html:50
 msgid "Statistics Dashboard"
 msgstr ""
 
-#: src/olympia/stats/templates/stats/stats.html:104
+#: src/olympia/stats/templates/stats/stats.html:57
+msgid "Controls:"
+msgstr ""
+
+#: src/olympia/stats/templates/stats/stats.html:60
+msgid "reset zoom"
+msgstr ""
+
+#: src/olympia/stats/templates/stats/stats.html:67
+msgid "Group by:"
+msgstr ""
+
+#: src/olympia/stats/templates/stats/stats.html:69
+msgid "day"
+msgstr ""
+
+#: src/olympia/stats/templates/stats/stats.html:72
+msgid "week"
+msgstr ""
+
+#: src/olympia/stats/templates/stats/stats.html:75
+msgid "month"
+msgstr ""
+
+#: src/olympia/stats/templates/stats/stats.html:81
+msgid "For last:"
+msgstr ""
+
+#: src/olympia/stats/templates/stats/stats.html:84
+msgid "7 days"
+msgstr ""
+
+#: src/olympia/stats/templates/stats/stats.html:87
+msgid "30 days"
+msgstr ""
+
+#: src/olympia/stats/templates/stats/stats.html:90
+msgid "90 days"
+msgstr ""
+
+#: src/olympia/stats/templates/stats/stats.html:93
+msgid "365 days"
+msgstr ""
+
+#: src/olympia/stats/templates/stats/stats.html:96
+msgid "Custom..."
+msgstr ""
+
+#: src/olympia/stats/templates/stats/stats.html:106
 msgid "Statistics processing is currently disabled, so recent data is unavailable. The statistics are still being collected and this page will be updated soon with the missing data."
 msgstr ""
 
-#: src/olympia/stats/templates/stats/stats.html:110
+#: src/olympia/stats/templates/stats/stats.html:112
 msgid "Loading the latest data&hellip;"
 msgstr ""
 
-#: src/olympia/stats/templates/stats/stats.html:142 src/olympia/stats/templates/stats/reports/overview.html:25 src/olympia/stats/templates/stats/reports/overview.html:37
+#: src/olympia/stats/templates/stats/stats.html:144 src/olympia/stats/templates/stats/reports/overview.html:25 src/olympia/stats/templates/stats/reports/overview.html:37
 #: src/olympia/stats/templates/stats/reports/overview.html:49
 msgid "No data available."
 msgstr ""
 
-#: src/olympia/stats/templates/stats/stats.html:177
+#: src/olympia/stats/templates/stats/stats.html:179
 msgid "This dashboard is currently <b>public</b>."
 msgstr ""
 
-#: src/olympia/stats/templates/stats/stats.html:179
+#: src/olympia/stats/templates/stats/stats.html:181
 msgid "Contribution stats are currently <b>private</b>."
 msgstr ""
 
-#: src/olympia/stats/templates/stats/stats.html:182
+#: src/olympia/stats/templates/stats/stats.html:184
 msgid "This dashboard is currently <b>private</b>."
 msgstr ""
 
-#: src/olympia/stats/templates/stats/stats.html:185
+#: src/olympia/stats/templates/stats/stats.html:187
 msgid "Change settings."
 msgstr ""
 
@@ -11299,15 +11141,6 @@ msgstr ""
 msgid "Application versions by Date"
 msgstr ""
 
-#: src/olympia/tags/templates/tags/top_cloud.html:4
-msgid "Top {0} Tags"
-msgstr ""
-
-#. {0} is the current application name
-#: src/olympia/tags/templates/tags/top_cloud.html:14
-msgid "{0} Top Tags"
-msgstr ""
-
 #: src/olympia/templates/amo_footer.html:6 src/olympia/templates/includes/lang_switcher.html:2
 msgid "Other languages"
 msgstr ""
@@ -11316,11 +11149,11 @@ msgstr ""
 msgid "Mozilla Add-ons"
 msgstr ""
 
-#: src/olympia/templates/base.html:91 src/olympia/templates/impala/base.html:81
+#: src/olympia/templates/base.html:89 src/olympia/templates/impala/base.html:78
 msgid "Find add-ons for other applications"
 msgstr ""
 
-#: src/olympia/templates/base.html:92 src/olympia/templates/impala/base.html:81
+#: src/olympia/templates/base.html:90 src/olympia/templates/impala/base.html:78
 msgid "Other Applications"
 msgstr ""
 
@@ -11345,7 +11178,7 @@ msgid "View Mobile Site"
 msgstr ""
 
 #: src/olympia/templates/copyright.html:7
-msgid "Site Status "
+msgid "Site Status"
 msgstr ""
 
 #: src/olympia/templates/footer.html:3
@@ -11445,35 +11278,35 @@ msgstr ""
 msgid "<a href=\"%(reg)s\">Register</a> or <a href=\"%(login)s\">Log in</a>"
 msgstr ""
 
-#: src/olympia/templates/impala/base.html:126
+#: src/olympia/templates/impala/base.html:123
 #, python-format
 msgid "To try the thousands of add-ons available here, download <a href=\"%(url)s\">Mozilla Firefox</a>, a fast, free way to surf the Web!"
 msgstr ""
 
-#: src/olympia/templates/impala/base.html:138
+#: src/olympia/templates/impala/base.html:135
 #, python-format
 msgid "Add-ons is switching to Firefox Accounts for login. <a href=\"%(url)s\" class=\"fxa-login\">Sign in now to transfer your account.</a>"
 msgstr ""
 
 #. {0} is an application, such as Firefox.
-#: src/olympia/templates/impala/base.html:148
+#: src/olympia/templates/impala/base.html:145
 msgid "Welcome to {0} Add-ons."
 msgstr ""
 
-#: src/olympia/templates/impala/base.html:151
+#: src/olympia/templates/impala/base.html:148
 msgid "Choose from thousands of extra features and styles to make Firefox your own."
 msgstr ""
 
-#: src/olympia/templates/impala/base.html:156
+#: src/olympia/templates/impala/base.html:153
 #, python-format
 msgid "Add extra features and styles to make %(app)s your own."
 msgstr ""
 
-#: src/olympia/templates/impala/base.html:164
+#: src/olympia/templates/impala/base.html:161
 msgid "On the go?"
 msgstr ""
 
-#: src/olympia/templates/impala/base.html:166
+#: src/olympia/templates/impala/base.html:163
 msgid "Check out our <a class=\"mobile-link\" href=\"#\">Mobile Add-ons site</a>."
 msgstr ""
 
@@ -11697,19 +11530,19 @@ msgstr ""
 
 #. L10n: {id} will be something like "13ad6a", just a random number
 #. to differentiate this user from other anonymous users.
-#: src/olympia/users/models.py:353
+#: src/olympia/users/models.py:362
 msgid "Anonymous user {id}"
 msgstr ""
 
-#: src/olympia/users/models.py:410
+#: src/olympia/users/models.py:419
 msgid "Your account has been restricted"
 msgstr ""
 
-#: src/olympia/users/models.py:480
+#: src/olympia/users/models.py:489
 msgid "Please confirm your email address"
 msgstr ""
 
-#: src/olympia/users/models.py:506
+#: src/olympia/users/models.py:515
 msgid "My Mobile Add-ons"
 msgstr ""
 
@@ -11986,7 +11819,7 @@ msgstr ""
 
 #: src/olympia/users/templates/users/edit.html:70
 #, python-format
-msgid "Change your password.  If you forgot your password, you can <a href=\"%(reset_url)s\">use the reset form</a>."
+msgid "Change your password. If you forgot your password, you can <a href=\"%(reset_url)s\">use the reset form</a>."
 msgstr ""
 
 #: src/olympia/users/templates/users/edit.html:76
@@ -12006,7 +11839,7 @@ msgid "Profile"
 msgstr ""
 
 #: src/olympia/users/templates/users/edit.html:100
-msgid "Give us a bit more information about yourself.  All these fields are optional, but they'll help other users get to know you better."
+msgid "Give us a bit more information about yourself. All these fields are optional, but they'll help other users get to know you better."
 msgstr ""
 
 #: src/olympia/users/templates/users/edit.html:124
@@ -12222,7 +12055,7 @@ msgid "Confirm password"
 msgstr ""
 
 #: src/olympia/users/templates/users/pwreset_confirm.html:47
-msgid "The password reset link was invalid, possibly because it has already been used.  Please request a new password reset."
+msgid "The password reset link was invalid, possibly because it has already been used. Please request a new password reset."
 msgstr ""
 
 #: src/olympia/users/templates/users/pwreset_request.html:15
@@ -12408,7 +12241,7 @@ msgstr ""
 
 #: src/olympia/users/templates/users/unsubscribe.html:30
 #, python-format
-msgid "Unfortunately, we weren't able to unsubscribe you.  The link you clicked is invalid. However, you can unsubscribe still unsubscribe on your <a href=\"%(edit_url)s\">edit profile page</a>."
+msgid "Unfortunately, we weren't able to unsubscribe you. The link you clicked is invalid. However, you can unsubscribe still unsubscribe on your <a href=\"%(edit_url)s\">edit profile page</a>."
 msgstr ""
 
 #: src/olympia/users/templates/users/vcard.html:2
@@ -12462,15 +12295,15 @@ msgstr ""
 msgid "Version History with Changelogs"
 msgstr ""
 
-#: src/olympia/versions/models.py:314
+#: src/olympia/versions/models.py:313
 msgid "Add-on uses binary components."
 msgstr ""
 
-#: src/olympia/versions/models.py:317
+#: src/olympia/versions/models.py:316
 msgid "Add-on has opted into strict compatibility checking."
 msgstr ""
 
-#: src/olympia/versions/models.py:715
+#: src/olympia/versions/models.py:711
 msgid "{app} {min} and later"
 msgstr ""
 
@@ -12545,4 +12378,8 @@ msgstr ""
 
 #: src/olympia/zadmin/forms.py:105
 msgid "Log emails instead of sending"
+msgstr ""
+
+#: src/olympia/zadmin/forms.py:215
+msgid "Deleted versions can`t be changed."
 msgstr ""

--- a/locale/be/LC_MESSAGES/djangojs.po
+++ b/locale/be/LC_MESSAGES/djangojs.po
@@ -1,1216 +1,1236 @@
-
 #, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2016-02-24 21:23+0000\n"
+"POT-Creation-Date: 2016-04-18 15:47+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
+"Language: \n"
 "MIME-Version: 1.0\n"
-"Content-Type: text/plain; charset=utf-8\n"
+"Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Generated-By: Babel 2.2.0\n"
 
-#: static/js/common/ratingwidget.js:31
+#: static/js/common-all.js:1426 static/js/impala-all.js:1511 static/js/zamboni/discovery-all.js:12598 static/js/zamboni/init.js:28 static/js/zamboni/mobile-all.js:14945
+msgid "This feature is temporarily disabled while we perform website maintenance. Please check back a little later."
+msgstr ""
+
+#. L10n: {0} is an app name like Firefox.
+#: static/js/common-all.js:1837 static/js/impala-all.js:1922 static/js/zamboni/buttons.js:73 static/js/zamboni/discovery-all.js:13108
+msgid "Accept and Install"
+msgstr ""
+
+#: static/js/common-all.js:1837 static/js/impala-all.js:1922 static/js/zamboni/buttons.js:73 static/js/zamboni/discovery-all.js:13108
+msgid "Add to {0}"
+msgstr ""
+
+#: static/js/common-all.js:1842 static/js/impala-all.js:1927 static/js/zamboni/buttons.js:78 static/js/zamboni/discovery-all.js:13113
+msgid "Download Now"
+msgstr ""
+
+#: static/js/common-all.js:1883 static/js/impala-all.js:1968 static/js/zamboni/buttons.js:119 static/js/zamboni/discovery-all.js:13154
+msgid "Add-on has not been updated to support default-to-compatible."
+msgstr ""
+
+#: static/js/common-all.js:1888 static/js/impala-all.js:1973 static/js/zamboni/buttons.js:124 static/js/zamboni/discovery-all.js:13159
+msgid "You need to be using Firefox 10.0 or higher."
+msgstr ""
+
+#: static/js/common-all.js:1900 static/js/impala-all.js:1985 static/js/zamboni/buttons.js:136 static/js/zamboni/discovery-all.js:13171
+msgid "Mozilla has marked this version as incompatible with your Firefox version."
+msgstr ""
+
+#. L10n: {0} is an platform like Windows or Linux.
+#: static/js/common-all.js:1981 static/js/impala-all.js:2066 static/js/zamboni/buttons.js:217 static/js/zamboni/discovery-all.js:13252
+msgid "Install for {0} anyway"
+msgstr ""
+
+#: static/js/common-all.js:1981 static/js/impala-all.js:2066 static/js/zamboni/buttons.js:217 static/js/zamboni/discovery-all.js:13252
+msgid "Download for {0} anyway"
+msgstr ""
+
+#: static/js/common-all.js:2038 static/js/impala-all.js:2123 static/js/zamboni/buttons.js:274 static/js/zamboni/discovery-all.js:13309
+msgid "Not available for your platform"
+msgstr ""
+
+#. L10n: {0} is an app name, {1} is the app version.
+#: static/js/common-all.js:2049 static/js/common-all.js:2086 static/js/impala-all.js:2134 static/js/impala-all.js:2171 static/js/zamboni/buttons.js:286 static/js/zamboni/buttons.js:324
+#: static/js/zamboni/discovery-all.js:13320 static/js/zamboni/discovery-all.js:13357
+msgid "Not available for {0} {1}"
+msgstr ""
+
+#: static/js/common-all.js:2112 static/js/impala-all.js:2197 static/js/zamboni/buttons.js:351 static/js/zamboni/discovery-all.js:13383
+msgid "Works with {app} {min} - {max}"
+msgstr ""
+
+#: static/js/common-all.js:2114 static/js/impala-all.js:2199 static/js/zamboni/buttons.js:353 static/js/zamboni/discovery-all.js:13385
+msgid "View other versions"
+msgstr ""
+
+#: static/js/common-all.js:2162 static/js/impala-all.js:2247 static/js/zamboni/buttons.js:401 static/js/zamboni/discovery-all.js:13433
+msgid "Only with Firefox — Get Firefox Now!"
+msgstr ""
+
+#: static/js/common-all.js:2278 static/js/impala-all.js:2363 static/js/zamboni/buttons.js:517 static/js/zamboni/discovery-all.js:13549 static/js/zamboni/mobile-all.js:15177
+#: static/js/zamboni/mobile/buttons.js:43
+msgid "Sorry, you need a Mozilla-based browser (such as Firefox) to install a search plugin."
+msgstr ""
+
+#: static/js/common-all.js:9088 static/js/impala-all.js:9649 static/js/zamboni/global.js:410
+msgid "Loading..."
+msgstr ""
+
+#. L10n: {0} is the number of characters left.
+#: static/js/common-all.js:9152 static/js/impala-all.js:9713 static/js/zamboni/global.js:474
+msgid "<b>{0}</b> character left."
+msgid_plural "<b>{0}</b> characters left."
+msgstr[0] ""
+msgstr[1] ""
+
+#: static/js/common-all.js:9589 static/js/common-min.js:6 static/js/impala-all.js:10052 static/js/impala-min.js:6 static/js/common/ratingwidget.js:31 static/js/zamboni/mobile-all.js:16123
+#: static/js/zamboni/mobile-min.js:6
 msgid "{0} star"
 msgid_plural "{0} stars"
 msgstr[0] ""
 msgstr[1] ""
 
-#: static/js/common/upload-addon.js:41 static/js/common/upload-image.js:128
+#: static/js/common-all.js:9676 static/js/common-min.js:6 static/js/impala-all.js:10139 static/js/impala-min.js:6 static/js/zamboni/l10n.js:45
+msgid "Remove this localization"
+msgstr ""
+
+#: static/js/common-all.js:10193 static/js/common-min.js:6 static/js/impala-all.js:10674 static/js/impala-min.js:6 static/js/zamboni/discovery-all.js:13678
+msgid "close"
+msgstr ""
+
+#: static/js/common-all.js:10860 static/js/common-min.js:6 static/js/impala-all.js:11481 static/js/impala-min.js:6 static/js/impala/reviews.js:23 static/js/zamboni/reviews.js:18
+msgid "Flagged for review"
+msgstr ""
+
+#: static/js/common-all.js:10876 static/js/common-min.js:6 static/js/impala-all.js:11498 static/js/impala-min.js:6 static/js/impala/reviews.js:40 static/js/zamboni/reviews.js:34
+msgid "Your input is required"
+msgstr ""
+
+#: static/js/common-all.js:10945 static/js/common-min.js:6 static/js/impala-all.js:11610 static/js/impala-min.js:7 static/js/impala/reviews.js:152 static/js/zamboni/reviews.js:103
+msgid "Marked for deletion"
+msgstr ""
+
+#: static/js/common-all.js:11573 static/js/common-min.js:7 static/js/impala-all.js:13809 static/js/impala-min.js:8 static/js/zamboni/collections.js:229
+msgid "Adding to Favorites&hellip;"
+msgstr ""
+
+#: static/js/common-all.js:11576 static/js/common-min.js:7 static/js/impala-all.js:13812 static/js/impala-min.js:8 static/js/zamboni/collections.js:232
+msgid "Removing Favorite&hellip;"
+msgstr ""
+
+#: static/js/common-all.js:11579 static/js/common-min.js:7 static/js/impala-all.js:13815 static/js/impala-min.js:8 static/js/zamboni/collections.js:235
+msgid "Add to Favorites"
+msgstr ""
+
+#: static/js/common-all.js:11582 static/js/common-min.js:7 static/js/impala-all.js:13818 static/js/impala-min.js:8 static/js/zamboni/collections.js:238
+msgid "Remove from Favorites"
+msgstr ""
+
+#: static/js/common-all.js:11647 static/js/common-min.js:7 static/js/impala-all.js:13883 static/js/impala-min.js:8 static/js/zamboni/collections.js:303
+msgid "Pending"
+msgstr ""
+
+#: static/js/common-all.js:11648 static/js/common-min.js:7 static/js/impala-all.js:13884 static/js/impala-min.js:8 static/js/zamboni/collections.js:304
+msgid "Add a comment"
+msgstr ""
+
+#: static/js/common-all.js:11648 static/js/common-min.js:7 static/js/impala-all.js:13884 static/js/impala-min.js:8 static/js/zamboni/collections.js:304
+msgid "Comment"
+msgstr ""
+
+#: static/js/common-all.js:11649 static/js/common-min.js:7 static/js/impala-all.js:13885 static/js/impala-min.js:8 static/js/zamboni/collections.js:305
+msgid "Remove this add-on from the collection"
+msgstr ""
+
+#: static/js/common-all.js:11649 static/js/common-all.js:11678 static/js/common-min.js:7 static/js/impala-all.js:13885 static/js/impala-all.js:13914 static/js/impala-min.js:8
+#: static/js/zamboni/collections.js:305 static/js/zamboni/collections.js:334
+msgid "Remove"
+msgstr ""
+
+#: static/js/common-all.js:11678 static/js/common-min.js:7 static/js/impala-all.js:13914 static/js/impala-min.js:8 static/js/zamboni/collections.js:334
+msgid "Remove this user as a contributor"
+msgstr ""
+
+#: static/js/common-all.js:11690 static/js/common-min.js:7 static/js/impala-all.js:13926 static/js/impala-min.js:8 static/js/zamboni/collections.js:346
+msgid "An email address is required."
+msgstr ""
+
+#: static/js/common-all.js:11708 static/js/common-min.js:7 static/js/impala-all.js:13944 static/js/impala-min.js:8 static/js/zamboni/collections.js:364
+msgid "You cannot add yourself as a contributor."
+msgstr ""
+
+#: static/js/common-all.js:11710 static/js/common-min.js:7 static/js/impala-all.js:13946 static/js/impala-min.js:8 static/js/zamboni/collections.js:366
+msgid "You have already added that user."
+msgstr ""
+
+#: static/js/common-all.js:11917 static/js/common-min.js:7 static/js/impala-all.js:14153 static/js/impala-min.js:8 static/js/zamboni/collections.js:573
+msgid "Add to favorites"
+msgstr ""
+
+#: static/js/common-all.js:11921 static/js/common-min.js:7 static/js/impala-all.js:14157 static/js/impala-min.js:8 static/js/zamboni/collections.js:577
+msgid "Remove from favorites"
+msgstr ""
+
+#: static/js/common-all.js:11939 static/js/common-min.js:7 static/js/impala-all.js:14175 static/js/impala-all.js:14233 static/js/impala-min.js:8 static/js/impala/collections.js:10
+#: static/js/zamboni/collections.js:595
+msgid "Follow this Collection"
+msgstr ""
+
+#: static/js/common-all.js:11948 static/js/common-min.js:7 static/js/impala-all.js:14184 static/js/impala-min.js:8 static/js/zamboni/collections.js:604
+msgid "Stop following"
+msgstr ""
+
+#: static/js/common-all.js:12096 static/js/common-min.js:7 static/js/zamboni/password-strength.js:20
+msgid "Password strength:"
+msgstr ""
+
+#: static/js/common-all.js:12102 static/js/common-min.js:7 static/js/zamboni/password-strength.js:26
+msgid "At least {0} character left."
+msgid_plural "At least {0} characters left."
+msgstr[0] ""
+msgstr[1] ""
+
+#: static/js/common-all.js:12286 static/js/common-min.js:7 static/js/impala-all.js:14632 static/js/impala-min.js:8 static/js/impala/suggestions.js:39
+msgid "Search themes for <b>{0}</b>"
+msgstr ""
+
+#: static/js/common-all.js:12288 static/js/common-min.js:7 static/js/impala-all.js:14634 static/js/impala-min.js:8 static/js/impala/suggestions.js:41
+msgid "Search apps for <b>{0}</b>"
+msgstr ""
+
+#: static/js/common-all.js:12290 static/js/common-min.js:7 static/js/impala-all.js:14636 static/js/impala-min.js:8 static/js/impala/suggestions.js:43
+msgid "Search add-ons for <b>{0}</b>"
+msgstr ""
+
+#: static/js/common-all.js:12521 static/js/common-min.js:7 static/js/impala-all.js:14867 static/js/impala-min.js:8 static/js/impala/site_suggestions.js:46
+msgid "Category"
+msgstr ""
+
+#. L10n: {0} is an app name.
+#: static/js/impala-all.js:11632 static/js/impala-min.js:7 static/js/impala/listing.js:11 static/js/zamboni/themes.js:13
+msgid "This theme is incompatible with your version of {0}"
+msgstr ""
+
+#: static/js/impala-all.js:12146 static/js/impala-all.js:14331 static/js/impala-min.js:7 static/js/impala-min.js:8 static/js/common/upload-image.js:97 static/js/impala/users.js:51
+#: static/js/zamboni/devhub-all.js:894 static/js/zamboni/devhub-min.js:1
+msgid "Images must be either PNG or JPG."
+msgstr ""
+
+#: static/js/impala-all.js:12150 static/js/impala-min.js:7 static/js/common/upload-image.js:101 static/js/zamboni/devhub-all.js:898 static/js/zamboni/devhub-min.js:1
+msgid "Videos must be in WebM."
+msgstr ""
+
+#: static/js/impala-all.js:12177 static/js/impala-min.js:7 static/js/common/upload-addon.js:41 static/js/common/upload-image.js:128 static/js/zamboni/devhub-all.js:272
+#: static/js/zamboni/devhub-all.js:925 static/js/zamboni/devhub-min.js:1
 msgid "There was a problem contacting the server."
 msgstr ""
 
-#: static/js/common/upload-addon.js:69
+#: static/js/impala-all.js:13298 static/js/impala-min.js:7 static/js/impala/persona_creation.js:60
+msgid "All Rights Reserved"
+msgstr ""
+
+#: static/js/impala-all.js:13302 static/js/impala-min.js:7 static/js/impala/persona_creation.js:64
+msgid "Creative Commons Attribution 3.0"
+msgstr ""
+
+#: static/js/impala-all.js:13307 static/js/impala-min.js:7 static/js/impala/persona_creation.js:69
+msgid "Creative Commons Attribution-NonCommercial 3.0"
+msgstr ""
+
+#: static/js/impala-all.js:13312 static/js/impala-min.js:7 static/js/impala/persona_creation.js:74
+msgid "Creative Commons Attribution-NonCommercial-NoDerivs 3.0"
+msgstr ""
+
+#: static/js/impala-all.js:13317 static/js/impala-min.js:7 static/js/impala/persona_creation.js:79
+msgid "Creative Commons Attribution-NonCommercial-Share Alike 3.0"
+msgstr ""
+
+#: static/js/impala-all.js:13322 static/js/impala-min.js:7 static/js/impala/persona_creation.js:84
+msgid "Creative Commons Attribution-NoDerivs 3.0"
+msgstr ""
+
+#: static/js/impala-all.js:13327 static/js/impala-min.js:7 static/js/impala/persona_creation.js:89
+msgid "Creative Commons Attribution-ShareAlike 3.0"
+msgstr ""
+
+#: static/js/impala-all.js:13530 static/js/impala-min.js:7 static/js/impala/persona_creation.js:292
+msgid "Your Theme's Name"
+msgstr ""
+
+#: static/js/impala-all.js:14242 static/js/impala-min.js:8 static/js/impala/collections.js:19
+msgid "Stop Following"
+msgstr ""
+
+#: static/js/impala-all.js:14243 static/js/impala-min.js:8 static/js/impala/collections.js:20
+msgid "Following"
+msgstr ""
+
+#: static/js/impala-all.js:14313 static/js/impala-min.js:8 static/js/impala/users.js:33
+msgid "use original"
+msgstr ""
+
+#: static/js/impala-all.js:14523 static/js/impala-min.js:8 static/js/impala/search.js:114
+msgid "Updating results&hellip;"
+msgstr ""
+
+#: static/js/common/upload-addon.js:69 static/js/zamboni/devhub-all.js:300 static/js/zamboni/devhub-min.js:1
 msgid "Select a file..."
 msgstr ""
 
-#: static/js/common/upload-addon.js:70
+#: static/js/common/upload-addon.js:70 static/js/zamboni/devhub-all.js:301 static/js/zamboni/devhub-min.js:1
 msgid "Your add-on should end with .xpi, .jar or .xml"
 msgstr ""
 
 #. L10n: {0} is the percent of the file that has been uploaded.
-#: static/js/common/upload-addon.js:104
+#: static/js/common/upload-addon.js:104 static/js/zamboni/devhub-all.js:335 static/js/zamboni/devhub-min.js:1
 #, python-format
 msgid "{0}% complete"
 msgstr ""
 
 #. L10n: "{bytes uploaded} of {total filesize}".
-#: static/js/common/upload-addon.js:107
+#: static/js/common/upload-addon.js:107 static/js/zamboni/devhub-all.js:338 static/js/zamboni/devhub-min.js:1
 msgid "{0} of {1}"
 msgstr ""
 
-#: static/js/common/upload-addon.js:140
+#: static/js/common/upload-addon.js:140 static/js/zamboni/devhub-all.js:371 static/js/zamboni/devhub-min.js:1
 msgid "Cancel"
 msgstr ""
 
-#: static/js/common/upload-addon.js:162
+#: static/js/common/upload-addon.js:162 static/js/zamboni/devhub-all.js:393 static/js/zamboni/devhub-min.js:1
 msgid "Uploading {0}"
 msgstr ""
 
-#: static/js/common/upload-addon.js:189
+#: static/js/common/upload-addon.js:189 static/js/zamboni/devhub-all.js:420 static/js/zamboni/devhub-min.js:1
 msgid "Error with {0}"
 msgstr ""
 
-#: static/js/common/upload-addon.js:194
+#: static/js/common/upload-addon.js:194 static/js/zamboni/devhub-all.js:425 static/js/zamboni/devhub-min.js:1
 msgid "Your add-on failed validation with {0} error."
 msgid_plural "Your add-on failed validation with {0} errors."
 msgstr[0] ""
 msgstr[1] ""
 
-#: static/js/common/upload-addon.js:208
+#: static/js/common/upload-addon.js:208 static/js/zamboni/devhub-all.js:439 static/js/zamboni/devhub-min.js:1
 msgid "&hellip;and {0} more"
 msgid_plural "&hellip;and {0} more"
 msgstr[0] ""
 msgstr[1] ""
 
-#: static/js/common/upload-addon.js:222 static/js/common/upload-addon.js:512
+#: static/js/common/upload-addon.js:222 static/js/common/upload-addon.js:497 static/js/zamboni/devhub-all.js:453 static/js/zamboni/devhub-all.js:743 static/js/zamboni/devhub-min.js:1
 msgid "See full validation report"
 msgstr ""
 
-#: static/js/common/upload-addon.js:234
+#: static/js/common/upload-addon.js:234 static/js/zamboni/devhub-all.js:465 static/js/zamboni/devhub-min.js:1
 msgid "Validating {0}"
 msgstr ""
 
 #. L10n: first argument is an HTTP status code
-#: static/js/common/upload-addon.js:273
+#: static/js/common/upload-addon.js:273 static/js/zamboni/devhub-all.js:504 static/js/zamboni/devhub-min.js:1
 msgid "Received an empty response from the server; status: {0}"
 msgstr ""
 
-#: static/js/common/upload-addon.js:373
+#: static/js/common/upload-addon.js:370 static/js/zamboni/devhub-all.js:604 static/js/zamboni/devhub-min.js:1
 msgid "Unexpected server error while validating."
 msgstr ""
 
-#: static/js/common/upload-addon.js:412
+#: static/js/common/upload-addon.js:409 static/js/zamboni/devhub-all.js:643 static/js/zamboni/devhub-min.js:1
 msgid "Finished validating {0}"
 msgstr ""
 
-#: static/js/common/upload-addon.js:418
+#: static/js/common/upload-addon.js:415 static/js/zamboni/devhub-all.js:649 static/js/zamboni/devhub-min.js:1
 msgid "Your add-on validation timed out, it will be manually reviewed."
 msgstr ""
 
-#: static/js/common/upload-addon.js:421
+#: static/js/common/upload-addon.js:418 static/js/zamboni/devhub-all.js:652 static/js/zamboni/devhub-min.js:1
 msgid "Your add-on was validated with no errors and {0} warning."
 msgid_plural "Your add-on was validated with no errors and {0} warnings."
 msgstr[0] ""
 msgstr[1] ""
 
-#: static/js/common/upload-addon.js:426
+#: static/js/common/upload-addon.js:423 static/js/zamboni/devhub-all.js:657 static/js/zamboni/devhub-min.js:1
 msgid "Your add-on was validated with no errors and {0} message."
 msgid_plural "Your add-on was validated with no errors and {0} messages."
 msgstr[0] ""
 msgstr[1] ""
 
-#: static/js/common/upload-addon.js:431
+#: static/js/common/upload-addon.js:428 static/js/zamboni/devhub-all.js:662 static/js/zamboni/devhub-min.js:1
 msgid "Your add-on was validated with no errors or warnings."
 msgstr ""
 
-#: static/js/common/upload-addon.js:446
+#: static/js/common/upload-addon.js:443 static/js/zamboni/devhub-all.js:677 static/js/zamboni/devhub-min.js:1
 msgid "Your submission will be automatically signed."
 msgstr ""
 
-#: static/js/common/upload-addon.js:465
+#: static/js/common/upload-addon.js:450 static/js/zamboni/devhub-all.js:696 static/js/zamboni/devhub-min.js:1
 msgid "Include detailed version notes (this can be done in the next step)."
 msgstr ""
 
-#: static/js/common/upload-addon.js:466
+#: static/js/common/upload-addon.js:451 static/js/zamboni/devhub-all.js:697 static/js/zamboni/devhub-min.js:1
 msgid "If your add-on requires an account to a website in order to be fully tested, include a test username and password in the Notes to Reviewer (this can be done in the next step)."
 msgstr ""
 
-#: static/js/common/upload-addon.js:467
+#: static/js/common/upload-addon.js:452 static/js/zamboni/devhub-all.js:698 static/js/zamboni/devhub-min.js:1
 msgid "If your add-on is intended for a limited audience you should choose Preliminary Review instead of Full Review."
 msgstr ""
 
-#: static/js/common/upload-addon.js:480
+#: static/js/common/upload-addon.js:465 static/js/zamboni/devhub-all.js:711 static/js/zamboni/devhub-min.js:1
 msgid "Add-on submission checklist"
 msgstr ""
 
-#: static/js/common/upload-addon.js:481
+#: static/js/common/upload-addon.js:466 static/js/zamboni/devhub-all.js:712 static/js/zamboni/devhub-min.js:1
 msgid "Please verify the following points before finalizing your submission. This will minimize delays or misunderstanding during the review process:"
 msgstr ""
 
-#: static/js/common/upload-addon.js:483
+#: static/js/common/upload-addon.js:468 static/js/zamboni/devhub-all.js:714 static/js/zamboni/devhub-min.js:1
 msgid ""
 "Compiled binaries, as well as minified or obfuscated scripts (excluding known libraries) need to have their sources submitted separately for review. Make sure that you use the source code upload "
 "field to avoid having your submission rejected."
 msgstr ""
 
-#: static/js/common/upload-addon.js:501
+#: static/js/common/upload-addon.js:486 static/js/zamboni/devhub-all.js:732 static/js/zamboni/devhub-min.js:1
 msgid "The validation process found these issues that can lead to rejections:"
 msgstr ""
 
-#: static/js/common/upload-addon.js:518
+#: static/js/common/upload-addon.js:503 static/js/zamboni/devhub-all.js:749 static/js/zamboni/devhub-min.js:1
 msgid "If you are unfamiliar with the add-ons review process, you can read about it here."
 msgstr ""
 
-#: static/js/common/upload-addon.js:555
+#: static/js/common/upload-addon.js:540 static/js/zamboni/devhub-all.js:786 static/js/zamboni/devhub-min.js:1
 msgid "Sorry, no supported platform has been found."
 msgstr ""
 
-#: static/js/common/upload-base.js:57
+#: static/js/common/upload-base.js:57 static/js/zamboni/devhub-all.js:187 static/js/zamboni/devhub-min.js:1
 msgid "The filetype you uploaded isn't recognized."
 msgstr ""
 
-#: static/js/common/upload-base.js:79
+#: static/js/common/upload-base.js:79 static/js/zamboni/devhub-all.js:209 static/js/zamboni/devhub-min.js:1
 msgid "You cancelled the upload."
 msgstr ""
 
-#: static/js/common/upload-image.js:97 static/js/impala/users.js:51
-msgid "Images must be either PNG or JPG."
-msgstr ""
-
-#: static/js/common/upload-image.js:101
-msgid "Videos must be in WebM."
-msgstr ""
-
-#: static/js/impala/collections.js:10 static/js/zamboni/collections.js:595
-msgid "Follow this Collection"
-msgstr ""
-
-#: static/js/impala/collections.js:19
-msgid "Stop Following"
-msgstr ""
-
-#: static/js/impala/collections.js:20
-msgid "Following"
-msgstr ""
-
-#. L10n: {0} is an app name.
-#: static/js/impala/listing.js:11 static/js/zamboni/themes.js:13
-msgid "This theme is incompatible with your version of {0}"
-msgstr ""
-
-#: static/js/impala/persona_creation.js:60
-msgid "All Rights Reserved"
-msgstr ""
-
-#: static/js/impala/persona_creation.js:64
-msgid "Creative Commons Attribution 3.0"
-msgstr ""
-
-#: static/js/impala/persona_creation.js:69
-msgid "Creative Commons Attribution-NonCommercial 3.0"
-msgstr ""
-
-#: static/js/impala/persona_creation.js:74
-msgid "Creative Commons Attribution-NonCommercial-NoDerivs 3.0"
-msgstr ""
-
-#: static/js/impala/persona_creation.js:79
-msgid "Creative Commons Attribution-NonCommercial-Share Alike 3.0"
-msgstr ""
-
-#: static/js/impala/persona_creation.js:84
-msgid "Creative Commons Attribution-NoDerivs 3.0"
-msgstr ""
-
-#: static/js/impala/persona_creation.js:89
-msgid "Creative Commons Attribution-ShareAlike 3.0"
-msgstr ""
-
-#: static/js/impala/persona_creation.js:292
-msgid "Your Theme's Name"
-msgstr ""
-
-#: static/js/impala/reviews.js:23 static/js/zamboni/reviews.js:18
-msgid "Flagged for review"
-msgstr ""
-
-#: static/js/impala/reviews.js:40 static/js/zamboni/reviews.js:34
-msgid "Your input is required"
-msgstr ""
-
-#: static/js/impala/reviews.js:152 static/js/zamboni/reviews.js:103
-msgid "Marked for deletion"
-msgstr ""
-
-#: static/js/impala/search.js:114
-msgid "Updating results&hellip;"
-msgstr ""
-
-#: static/js/impala/site_suggestions.js:46
-msgid "Category"
-msgstr ""
-
-#: static/js/impala/suggestions.js:39
-msgid "Search themes for <b>{0}</b>"
-msgstr ""
-
-#: static/js/impala/suggestions.js:41
-msgid "Search apps for <b>{0}</b>"
-msgstr ""
-
-#: static/js/impala/suggestions.js:43
-msgid "Search add-ons for <b>{0}</b>"
-msgstr ""
-
-#: static/js/impala/users.js:33
-msgid "use original"
-msgstr ""
-
-#: static/js/impala/stats/chart.js:267
+#: static/js/impala/stats/chart.js:267 static/js/zamboni/stats-all.js:16898 static/js/zamboni/stats-min.js:5
 msgid "Week of {0}"
 msgstr ""
 
-#: static/js/impala/stats/chart.js:269
+#: static/js/impala/stats/chart.js:269 static/js/zamboni/stats-all.js:16900 static/js/zamboni/stats-min.js:5
 msgid " downloads"
 msgstr ""
 
-#: static/js/impala/stats/chart.js:270
+#: static/js/impala/stats/chart.js:270 static/js/zamboni/stats-all.js:16901 static/js/zamboni/stats-min.js:5
 msgid "{0} users"
 msgstr ""
 
-#: static/js/impala/stats/chart.js:271
+#: static/js/impala/stats/chart.js:271 static/js/zamboni/stats-all.js:16902 static/js/zamboni/stats-min.js:5
 msgid "{0} add-ons"
 msgstr ""
 
-#: static/js/impala/stats/chart.js:272
+#: static/js/impala/stats/chart.js:272 static/js/zamboni/stats-all.js:16903 static/js/zamboni/stats-min.js:5
 msgid "{0} collections"
 msgstr ""
 
-#: static/js/impala/stats/chart.js:273
+#: static/js/impala/stats/chart.js:273 static/js/zamboni/stats-all.js:16904 static/js/zamboni/stats-min.js:5
 msgid "{0} reviews"
 msgstr ""
 
-#: static/js/impala/stats/chart.js:275
+#: static/js/impala/stats/chart.js:275 static/js/zamboni/stats-all.js:16906 static/js/zamboni/stats-min.js:5
 msgid "{0} sales"
 msgstr ""
 
-#: static/js/impala/stats/chart.js:276
+#: static/js/impala/stats/chart.js:276 static/js/zamboni/stats-all.js:16907 static/js/zamboni/stats-min.js:5
 msgid "{0} refunds"
 msgstr ""
 
-#: static/js/impala/stats/chart.js:277
+#: static/js/impala/stats/chart.js:277 static/js/zamboni/stats-all.js:16908 static/js/zamboni/stats-min.js:5
 msgid "{0} installs"
 msgstr ""
 
-#: static/js/impala/stats/chart.js:369 static/js/impala/stats/csv_keys.js:3 static/js/impala/stats/csv_keys.js:109
+#: static/js/impala/stats/chart.js:369 static/js/impala/stats/csv_keys.js:3 static/js/impala/stats/csv_keys.js:109 static/js/zamboni/stats-all.js:15284 static/js/zamboni/stats-all.js:15390
+#: static/js/zamboni/stats-all.js:17000 static/js/zamboni/stats-min.js:4 static/js/zamboni/stats-min.js:5
 msgid "Downloads"
 msgstr ""
 
-#: static/js/impala/stats/chart.js:379 static/js/impala/stats/csv_keys.js:6 static/js/impala/stats/csv_keys.js:110
+#: static/js/impala/stats/chart.js:379 static/js/impala/stats/csv_keys.js:6 static/js/impala/stats/csv_keys.js:110 static/js/zamboni/stats-all.js:15287 static/js/zamboni/stats-all.js:15391
+#: static/js/zamboni/stats-all.js:17010 static/js/zamboni/stats-min.js:4 static/js/zamboni/stats-min.js:5
 msgid "Daily Users"
 msgstr ""
 
-#: static/js/impala/stats/chart.js:410
+#: static/js/impala/stats/chart.js:410 static/js/zamboni/stats-all.js:17041 static/js/zamboni/stats-min.js:5
 msgid "Amount, in USD"
 msgstr ""
 
-#: static/js/impala/stats/chart.js:421 static/js/impala/stats/csv_keys.js:104
+#: static/js/impala/stats/chart.js:421 static/js/impala/stats/csv_keys.js:104 static/js/zamboni/stats-all.js:15385 static/js/zamboni/stats-all.js:17052 static/js/zamboni/stats-min.js:5
 msgid "Number of Contributions"
 msgstr ""
 
-#: static/js/impala/stats/chart.js:447
+#: static/js/impala/stats/chart.js:447 static/js/zamboni/stats-all.js:17078 static/js/zamboni/stats-min.js:5
 msgid "More Info..."
 msgstr ""
 
 #. L10n: {0} is an ISO-formatted date.
-#: static/js/impala/stats/chart.js:451
+#: static/js/impala/stats/chart.js:451 static/js/zamboni/stats-all.js:17082 static/js/zamboni/stats-min.js:5
 msgid "Details for {0}"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:9
+#: static/js/impala/stats/csv_keys.js:9 static/js/zamboni/stats-all.js:15290 static/js/zamboni/stats-min.js:4
 msgid "Collections Created"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:12
+#: static/js/impala/stats/csv_keys.js:12 static/js/zamboni/stats-all.js:15293 static/js/zamboni/stats-min.js:4
 msgid "Add-ons in Use"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:15
+#: static/js/impala/stats/csv_keys.js:15 static/js/zamboni/stats-all.js:15296 static/js/zamboni/stats-min.js:4
 msgid "Add-ons Created"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:18
+#: static/js/impala/stats/csv_keys.js:18 static/js/zamboni/stats-all.js:15299 static/js/zamboni/stats-min.js:4
 msgid "Add-ons Downloaded"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:21
+#: static/js/impala/stats/csv_keys.js:21 static/js/zamboni/stats-all.js:15302 static/js/zamboni/stats-min.js:4
 msgid "Add-ons Updated"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:24
+#: static/js/impala/stats/csv_keys.js:24 static/js/zamboni/stats-all.js:15305 static/js/zamboni/stats-min.js:4
 msgid "Reviews Written"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:27
+#: static/js/impala/stats/csv_keys.js:27 static/js/zamboni/stats-all.js:15308 static/js/zamboni/stats-min.js:4
 msgid "User Signups"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:30
+#: static/js/impala/stats/csv_keys.js:30 static/js/zamboni/stats-all.js:15311 static/js/zamboni/stats-min.js:4
 msgid "Subscribers"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:33
+#: static/js/impala/stats/csv_keys.js:33 static/js/zamboni/stats-all.js:15314 static/js/zamboni/stats-min.js:4
 msgid "Ratings"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:36 static/js/impala/stats/csv_keys.js:114
+#: static/js/impala/stats/csv_keys.js:36 static/js/impala/stats/csv_keys.js:114 static/js/zamboni/stats-all.js:15317 static/js/zamboni/stats-all.js:15395 static/js/zamboni/stats-min.js:4
+#: static/js/zamboni/stats-min.js:5
 msgid "Sales"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:39 static/js/impala/stats/csv_keys.js:113
+#: static/js/impala/stats/csv_keys.js:39 static/js/impala/stats/csv_keys.js:113 static/js/zamboni/stats-all.js:15320 static/js/zamboni/stats-all.js:15394 static/js/zamboni/stats-min.js:4
+#: static/js/zamboni/stats-min.js:5
 msgid "Installs"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:42
+#: static/js/impala/stats/csv_keys.js:42 static/js/zamboni/stats-all.js:15323 static/js/zamboni/stats-min.js:4
 msgid "Unknown"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:43
+#: static/js/impala/stats/csv_keys.js:43 static/js/zamboni/stats-all.js:15324 static/js/zamboni/stats-min.js:4
 msgid "Add-ons Manager"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:44
+#: static/js/impala/stats/csv_keys.js:44 static/js/zamboni/stats-all.js:15325 static/js/zamboni/stats-min.js:4
 msgid "Add-ons Manager Promo"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:45
+#: static/js/impala/stats/csv_keys.js:45 static/js/zamboni/stats-all.js:15326 static/js/zamboni/stats-min.js:4
 msgid "Add-ons Manager Featured"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:46
+#: static/js/impala/stats/csv_keys.js:46 static/js/zamboni/stats-all.js:15327 static/js/zamboni/stats-min.js:4
 msgid "Add-ons Manager Learn More"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:47
+#: static/js/impala/stats/csv_keys.js:47 static/js/zamboni/stats-all.js:15328 static/js/zamboni/stats-min.js:4
 msgid "Search Suggestions"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:48
+#: static/js/impala/stats/csv_keys.js:48 static/js/zamboni/stats-all.js:15329 static/js/zamboni/stats-min.js:4
 msgid "Search Results"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:49 static/js/impala/stats/csv_keys.js:50 static/js/impala/stats/csv_keys.js:51
+#: static/js/impala/stats/csv_keys.js:49 static/js/impala/stats/csv_keys.js:50 static/js/impala/stats/csv_keys.js:51 static/js/zamboni/stats-all.js:15330 static/js/zamboni/stats-all.js:15331
+#: static/js/zamboni/stats-all.js:15332 static/js/zamboni/stats-min.js:4
 msgid "Homepage Promo"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:52 static/js/impala/stats/csv_keys.js:53
+#: static/js/impala/stats/csv_keys.js:52 static/js/impala/stats/csv_keys.js:53 static/js/zamboni/stats-all.js:15333 static/js/zamboni/stats-all.js:15334 static/js/zamboni/stats-min.js:4
 msgid "Homepage Featured"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:54 static/js/impala/stats/csv_keys.js:55
+#: static/js/impala/stats/csv_keys.js:54 static/js/impala/stats/csv_keys.js:55 static/js/zamboni/stats-all.js:15335 static/js/zamboni/stats-all.js:15336 static/js/zamboni/stats-min.js:4
 msgid "Homepage Up and Coming"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:56
+#: static/js/impala/stats/csv_keys.js:56 static/js/zamboni/stats-all.js:15337 static/js/zamboni/stats-min.js:4
 msgid "Homepage Most Popular"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:57 static/js/impala/stats/csv_keys.js:59
+#: static/js/impala/stats/csv_keys.js:57 static/js/impala/stats/csv_keys.js:59 static/js/zamboni/stats-all.js:15338 static/js/zamboni/stats-all.js:15340 static/js/zamboni/stats-min.js:4
 msgid "Detail Page"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:58 static/js/impala/stats/csv_keys.js:60
+#: static/js/impala/stats/csv_keys.js:58 static/js/impala/stats/csv_keys.js:60 static/js/zamboni/stats-all.js:15339 static/js/zamboni/stats-all.js:15341 static/js/zamboni/stats-min.js:4
 msgid "Detail Page (bottom)"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:61
+#: static/js/impala/stats/csv_keys.js:61 static/js/zamboni/stats-all.js:15342 static/js/zamboni/stats-min.js:4
 msgid "Detail Page (Development Channel)"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:62 static/js/impala/stats/csv_keys.js:63 static/js/impala/stats/csv_keys.js:64
+#: static/js/impala/stats/csv_keys.js:62 static/js/impala/stats/csv_keys.js:63 static/js/impala/stats/csv_keys.js:64 static/js/zamboni/stats-all.js:15343 static/js/zamboni/stats-all.js:15344
+#: static/js/zamboni/stats-all.js:15345 static/js/zamboni/stats-min.js:4
 msgid "Often Used With"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:65 static/js/impala/stats/csv_keys.js:66
+#: static/js/impala/stats/csv_keys.js:65 static/js/impala/stats/csv_keys.js:66 static/js/zamboni/stats-all.js:15346 static/js/zamboni/stats-all.js:15347 static/js/zamboni/stats-min.js:4
 msgid "Others By Author"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:67 static/js/impala/stats/csv_keys.js:68
+#: static/js/impala/stats/csv_keys.js:67 static/js/impala/stats/csv_keys.js:68 static/js/zamboni/stats-all.js:15348 static/js/zamboni/stats-all.js:15349 static/js/zamboni/stats-min.js:4
 msgid "Dependencies"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:69 static/js/impala/stats/csv_keys.js:70
+#: static/js/impala/stats/csv_keys.js:69 static/js/impala/stats/csv_keys.js:70 static/js/zamboni/stats-all.js:15350 static/js/zamboni/stats-all.js:15351 static/js/zamboni/stats-min.js:4
 msgid "Upsell"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:71
+#: static/js/impala/stats/csv_keys.js:71 static/js/zamboni/stats-all.js:15352 static/js/zamboni/stats-min.js:4
 msgid "Meet the Developer"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:72
+#: static/js/impala/stats/csv_keys.js:72 static/js/zamboni/stats-all.js:15353 static/js/zamboni/stats-min.js:4
 msgid "User Profile"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:73
+#: static/js/impala/stats/csv_keys.js:73 static/js/zamboni/stats-all.js:15354 static/js/zamboni/stats-min.js:4
 msgid "Version History"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:75
+#: static/js/impala/stats/csv_keys.js:75 static/js/zamboni/stats-all.js:15356 static/js/zamboni/stats-min.js:4
 msgid "Sharing"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:76
+#: static/js/impala/stats/csv_keys.js:76 static/js/zamboni/stats-all.js:15357 static/js/zamboni/stats-min.js:4
 msgid "Category Pages"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:77
+#: static/js/impala/stats/csv_keys.js:77 static/js/zamboni/stats-all.js:15358 static/js/zamboni/stats-min.js:4
 msgid "Collections"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:78 static/js/impala/stats/csv_keys.js:79
+#: static/js/impala/stats/csv_keys.js:78 static/js/impala/stats/csv_keys.js:79 static/js/zamboni/stats-all.js:15359 static/js/zamboni/stats-all.js:15360 static/js/zamboni/stats-min.js:4
 msgid "Category Landing Featured Carousel"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:80 static/js/impala/stats/csv_keys.js:81
+#: static/js/impala/stats/csv_keys.js:80 static/js/impala/stats/csv_keys.js:81 static/js/zamboni/stats-all.js:15361 static/js/zamboni/stats-all.js:15362 static/js/zamboni/stats-min.js:4
 msgid "Category Landing Top Rated"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:82 static/js/impala/stats/csv_keys.js:83
+#: static/js/impala/stats/csv_keys.js:82 static/js/impala/stats/csv_keys.js:83 static/js/zamboni/stats-all.js:15363 static/js/zamboni/stats-all.js:15364 static/js/zamboni/stats-min.js:5
 msgid "Category Landing Most Popular"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:84 static/js/impala/stats/csv_keys.js:85
+#: static/js/impala/stats/csv_keys.js:84 static/js/impala/stats/csv_keys.js:85 static/js/zamboni/stats-all.js:15365 static/js/zamboni/stats-all.js:15366 static/js/zamboni/stats-min.js:5
 msgid "Category Landing Recently Added"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:86 static/js/impala/stats/csv_keys.js:87
+#: static/js/impala/stats/csv_keys.js:86 static/js/impala/stats/csv_keys.js:87 static/js/zamboni/stats-all.js:15367 static/js/zamboni/stats-all.js:15368 static/js/zamboni/stats-min.js:5
 msgid "Browse Listing Featured Sort"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:88 static/js/impala/stats/csv_keys.js:89
+#: static/js/impala/stats/csv_keys.js:88 static/js/impala/stats/csv_keys.js:89 static/js/zamboni/stats-all.js:15369 static/js/zamboni/stats-all.js:15370 static/js/zamboni/stats-min.js:5
 msgid "Browse Listing Users Sort"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:90 static/js/impala/stats/csv_keys.js:91
+#: static/js/impala/stats/csv_keys.js:90 static/js/impala/stats/csv_keys.js:91 static/js/zamboni/stats-all.js:15371 static/js/zamboni/stats-all.js:15372 static/js/zamboni/stats-min.js:5
 msgid "Browse Listing Rating Sort"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:92 static/js/impala/stats/csv_keys.js:93
+#: static/js/impala/stats/csv_keys.js:92 static/js/impala/stats/csv_keys.js:93 static/js/zamboni/stats-all.js:15373 static/js/zamboni/stats-all.js:15374 static/js/zamboni/stats-min.js:5
 msgid "Browse Listing Created Sort"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:94 static/js/impala/stats/csv_keys.js:95
+#: static/js/impala/stats/csv_keys.js:94 static/js/impala/stats/csv_keys.js:95 static/js/zamboni/stats-all.js:15375 static/js/zamboni/stats-all.js:15376 static/js/zamboni/stats-min.js:5
 msgid "Browse Listing Name Sort"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:96 static/js/impala/stats/csv_keys.js:97
+#: static/js/impala/stats/csv_keys.js:96 static/js/impala/stats/csv_keys.js:97 static/js/zamboni/stats-all.js:15377 static/js/zamboni/stats-all.js:15378 static/js/zamboni/stats-min.js:5
 msgid "Browse Listing Popular Sort"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:98 static/js/impala/stats/csv_keys.js:99
+#: static/js/impala/stats/csv_keys.js:98 static/js/impala/stats/csv_keys.js:99 static/js/zamboni/stats-all.js:15379 static/js/zamboni/stats-all.js:15380 static/js/zamboni/stats-min.js:5
 msgid "Browse Listing Updated Sort"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:100 static/js/impala/stats/csv_keys.js:101
+#: static/js/impala/stats/csv_keys.js:100 static/js/impala/stats/csv_keys.js:101 static/js/zamboni/stats-all.js:15381 static/js/zamboni/stats-all.js:15382 static/js/zamboni/stats-min.js:5
 msgid "Browse Listing Up and Coming Sort"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:105
+#: static/js/impala/stats/csv_keys.js:105 static/js/zamboni/stats-all.js:15386 static/js/zamboni/stats-min.js:5
 msgid "Total Amount Contributed"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:106
+#: static/js/impala/stats/csv_keys.js:106 static/js/zamboni/stats-all.js:15387 static/js/zamboni/stats-min.js:5
 msgid "Average Contribution"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:115
+#: static/js/impala/stats/csv_keys.js:115 static/js/zamboni/stats-all.js:15396 static/js/zamboni/stats-min.js:5
 msgid "Usage"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:118
+#: static/js/impala/stats/csv_keys.js:118 static/js/zamboni/stats-all.js:15399 static/js/zamboni/stats-min.js:5
 msgid "Firefox"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:119
+#: static/js/impala/stats/csv_keys.js:119 static/js/zamboni/stats-all.js:15400 static/js/zamboni/stats-min.js:5
 msgid "Mozilla"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:120
+#: static/js/impala/stats/csv_keys.js:120 static/js/zamboni/stats-all.js:15401 static/js/zamboni/stats-min.js:5
 msgid "Thunderbird"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:121
+#: static/js/impala/stats/csv_keys.js:121 static/js/zamboni/stats-all.js:15402 static/js/zamboni/stats-min.js:5
 msgid "Sunbird"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:122
+#: static/js/impala/stats/csv_keys.js:122 static/js/zamboni/stats-all.js:15403 static/js/zamboni/stats-min.js:5
 msgid "SeaMonkey"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:123
+#: static/js/impala/stats/csv_keys.js:123 static/js/zamboni/stats-all.js:15404 static/js/zamboni/stats-min.js:5
 msgid "Fennec"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:124
+#: static/js/impala/stats/csv_keys.js:124 static/js/zamboni/stats-all.js:15405 static/js/zamboni/stats-min.js:5
 msgid "Android"
 msgstr ""
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:129
+#: static/js/impala/stats/csv_keys.js:129 static/js/zamboni/stats-all.js:15410 static/js/zamboni/stats-min.js:5
 msgid "Downloads and Daily Users, last {0} days"
 msgstr ""
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:131
+#: static/js/impala/stats/csv_keys.js:131 static/js/zamboni/stats-all.js:15412 static/js/zamboni/stats-min.js:5
 msgid "Downloads and Daily Users from {0} to {1}"
 msgstr ""
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:135
+#: static/js/impala/stats/csv_keys.js:135 static/js/zamboni/stats-all.js:15416 static/js/zamboni/stats-min.js:5
 msgid "Installs and Daily Users, last {0} days"
 msgstr ""
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:137
+#: static/js/impala/stats/csv_keys.js:137 static/js/zamboni/stats-all.js:15418 static/js/zamboni/stats-min.js:5
 msgid "Installs and Daily Users from {0} to {1}"
 msgstr ""
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:141
+#: static/js/impala/stats/csv_keys.js:141 static/js/zamboni/stats-all.js:15422 static/js/zamboni/stats-min.js:5
 msgid "Downloads, last {0} days"
 msgstr ""
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:143
+#: static/js/impala/stats/csv_keys.js:143 static/js/zamboni/stats-all.js:15424 static/js/zamboni/stats-min.js:5
 msgid "Downloads from {0} to {1}"
 msgstr ""
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:147
+#: static/js/impala/stats/csv_keys.js:147 static/js/zamboni/stats-all.js:15428 static/js/zamboni/stats-min.js:5
 msgid "Daily Users, last {0} days"
 msgstr ""
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:149
+#: static/js/impala/stats/csv_keys.js:149 static/js/zamboni/stats-all.js:15430 static/js/zamboni/stats-min.js:5
 msgid "Daily Users from {0} to {1}"
 msgstr ""
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:153
+#: static/js/impala/stats/csv_keys.js:153 static/js/zamboni/stats-all.js:15434 static/js/zamboni/stats-min.js:5
 msgid "Applications, last {0} days"
 msgstr ""
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:155
+#: static/js/impala/stats/csv_keys.js:155 static/js/zamboni/stats-all.js:15436 static/js/zamboni/stats-min.js:5
 msgid "Applications from {0} to {1}"
 msgstr ""
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:159
+#: static/js/impala/stats/csv_keys.js:159 static/js/zamboni/stats-all.js:15440 static/js/zamboni/stats-min.js:5
 msgid "Platforms, last {0} days"
 msgstr ""
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:161
+#: static/js/impala/stats/csv_keys.js:161 static/js/zamboni/stats-all.js:15442 static/js/zamboni/stats-min.js:5
 msgid "Platforms from {0} to {1}"
 msgstr ""
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:165
+#: static/js/impala/stats/csv_keys.js:165 static/js/zamboni/stats-all.js:15446 static/js/zamboni/stats-min.js:5
 msgid "Languages, last {0} days"
 msgstr ""
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:167
+#: static/js/impala/stats/csv_keys.js:167 static/js/zamboni/stats-all.js:15448 static/js/zamboni/stats-min.js:5
 msgid "Languages from {0} to {1}"
 msgstr ""
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:171
+#: static/js/impala/stats/csv_keys.js:171 static/js/zamboni/stats-all.js:15452 static/js/zamboni/stats-min.js:5
 msgid "Add-on Versions, last {0} days"
 msgstr ""
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:173
+#: static/js/impala/stats/csv_keys.js:173 static/js/zamboni/stats-all.js:15454 static/js/zamboni/stats-min.js:5
 msgid "Add-on Versions from {0} to {1}"
 msgstr ""
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:177
+#: static/js/impala/stats/csv_keys.js:177 static/js/zamboni/stats-all.js:15458 static/js/zamboni/stats-min.js:5
 msgid "Add-on Status, last {0} days"
 msgstr ""
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:179
+#: static/js/impala/stats/csv_keys.js:179 static/js/zamboni/stats-all.js:15460 static/js/zamboni/stats-min.js:5
 msgid "Add-on Status from {0} to {1}"
 msgstr ""
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:183
+#: static/js/impala/stats/csv_keys.js:183 static/js/zamboni/stats-all.js:15464 static/js/zamboni/stats-min.js:5
 msgid "Download Sources, last {0} days"
 msgstr ""
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:185
+#: static/js/impala/stats/csv_keys.js:185 static/js/zamboni/stats-all.js:15466 static/js/zamboni/stats-min.js:5
 msgid "Download Sources from {0} to {1}"
 msgstr ""
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:189
+#: static/js/impala/stats/csv_keys.js:189 static/js/zamboni/stats-all.js:15470 static/js/zamboni/stats-min.js:5
 msgid "Contributions, last {0} days"
 msgstr ""
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:191
+#: static/js/impala/stats/csv_keys.js:191 static/js/zamboni/stats-all.js:15472 static/js/zamboni/stats-min.js:5
 msgid "Contributions from {0} to {1}"
 msgstr ""
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:195
+#: static/js/impala/stats/csv_keys.js:195 static/js/zamboni/stats-all.js:15476 static/js/zamboni/stats-min.js:5
 msgid "Site Metrics, last {0} days"
 msgstr ""
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:197
+#: static/js/impala/stats/csv_keys.js:197 static/js/zamboni/stats-all.js:15478 static/js/zamboni/stats-min.js:5
 msgid "Site Metrics from {0} to {1}"
 msgstr ""
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:201
+#: static/js/impala/stats/csv_keys.js:201 static/js/zamboni/stats-all.js:15482 static/js/zamboni/stats-min.js:5
 msgid "Add-ons in Use, last {0} days"
 msgstr ""
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:203
+#: static/js/impala/stats/csv_keys.js:203 static/js/zamboni/stats-all.js:15484 static/js/zamboni/stats-min.js:5
 msgid "Add-ons in Use from {0} to {1}"
 msgstr ""
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:207
+#: static/js/impala/stats/csv_keys.js:207 static/js/zamboni/stats-all.js:15488 static/js/zamboni/stats-min.js:5
 msgid "Add-ons Downloaded, last {0} days"
 msgstr ""
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:209
+#: static/js/impala/stats/csv_keys.js:209 static/js/zamboni/stats-all.js:15490 static/js/zamboni/stats-min.js:5
 msgid "Add-ons Downloaded from {0} to {1}"
 msgstr ""
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:213
+#: static/js/impala/stats/csv_keys.js:213 static/js/zamboni/stats-all.js:15494 static/js/zamboni/stats-min.js:5
 msgid "Add-ons Created, last {0} days"
 msgstr ""
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:215
+#: static/js/impala/stats/csv_keys.js:215 static/js/zamboni/stats-all.js:15496 static/js/zamboni/stats-min.js:5
 msgid "Add-ons Created from {0} to {1}"
 msgstr ""
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:219
+#: static/js/impala/stats/csv_keys.js:219 static/js/zamboni/stats-all.js:15500 static/js/zamboni/stats-min.js:5
 msgid "Add-ons Updated, last {0} days"
 msgstr ""
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:221
+#: static/js/impala/stats/csv_keys.js:221 static/js/zamboni/stats-all.js:15502 static/js/zamboni/stats-min.js:5
 msgid "Add-ons Updated from {0} to {1}"
 msgstr ""
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:225
+#: static/js/impala/stats/csv_keys.js:225 static/js/zamboni/stats-all.js:15506 static/js/zamboni/stats-min.js:5
 msgid "Reviews Written, last {0} days"
 msgstr ""
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:227
+#: static/js/impala/stats/csv_keys.js:227 static/js/zamboni/stats-all.js:15508 static/js/zamboni/stats-min.js:5
 msgid "Reviews Written from {0} to {1}"
 msgstr ""
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:231
+#: static/js/impala/stats/csv_keys.js:231 static/js/zamboni/stats-all.js:15512 static/js/zamboni/stats-min.js:5
 msgid "User Signups, last {0} days"
 msgstr ""
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:233
+#: static/js/impala/stats/csv_keys.js:233 static/js/zamboni/stats-all.js:15514 static/js/zamboni/stats-min.js:5
 msgid "User Signups from {0} to {1}"
 msgstr ""
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:237
+#: static/js/impala/stats/csv_keys.js:237 static/js/zamboni/stats-all.js:15518 static/js/zamboni/stats-min.js:5
 msgid "Collections Created, last {0} days"
 msgstr ""
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:239
+#: static/js/impala/stats/csv_keys.js:239 static/js/zamboni/stats-all.js:15520 static/js/zamboni/stats-min.js:5
 msgid "Collections Created from {0} to {1}"
 msgstr ""
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:243
+#: static/js/impala/stats/csv_keys.js:243 static/js/zamboni/stats-all.js:15524 static/js/zamboni/stats-min.js:5
 msgid "Subscribers, last {0} days"
 msgstr ""
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:245
+#: static/js/impala/stats/csv_keys.js:245 static/js/zamboni/stats-all.js:15526 static/js/zamboni/stats-min.js:5
 msgid "Subscribers from {0} to {1}"
 msgstr ""
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:249
+#: static/js/impala/stats/csv_keys.js:249 static/js/zamboni/stats-all.js:15530 static/js/zamboni/stats-min.js:5
 msgid "Ratings, last {0} days"
 msgstr ""
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:251
+#: static/js/impala/stats/csv_keys.js:251 static/js/zamboni/stats-all.js:15532 static/js/zamboni/stats-min.js:5
 msgid "Ratings from {0} to {1}"
 msgstr ""
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:255
+#: static/js/impala/stats/csv_keys.js:255 static/js/zamboni/stats-all.js:15536 static/js/zamboni/stats-min.js:5
 msgid "Sales, last {0} days"
 msgstr ""
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:257
+#: static/js/impala/stats/csv_keys.js:257 static/js/zamboni/stats-all.js:15538 static/js/zamboni/stats-min.js:5
 msgid "Sales from {0} to {1}"
 msgstr ""
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:261
+#: static/js/impala/stats/csv_keys.js:261 static/js/zamboni/stats-all.js:15542 static/js/zamboni/stats-min.js:5
 msgid "Installs, last {0} days"
 msgstr ""
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:263
+#: static/js/impala/stats/csv_keys.js:263 static/js/zamboni/stats-all.js:15544 static/js/zamboni/stats-min.js:5
 msgid "Installs from {0} to {1}"
 msgstr ""
 
 #. L10n: {0} and {1} are integers.
-#: static/js/impala/stats/csv_keys.js:269
+#: static/js/impala/stats/csv_keys.js:269 static/js/zamboni/stats-all.js:15550 static/js/zamboni/stats-min.js:5
 msgid "<b>{0}</b> in last {1} days"
 msgstr ""
 
 #. L10n: {0} is an integer and {1} and {2} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:271 static/js/impala/stats/csv_keys.js:277
+#: static/js/impala/stats/csv_keys.js:271 static/js/impala/stats/csv_keys.js:277 static/js/zamboni/stats-all.js:15552 static/js/zamboni/stats-all.js:15558 static/js/zamboni/stats-min.js:5
 msgid "<b>{0}</b> from {1} to {2}"
 msgstr ""
 
 #. L10n: {0} and {1} are integers.
-#: static/js/impala/stats/csv_keys.js:275
+#: static/js/impala/stats/csv_keys.js:275 static/js/zamboni/stats-all.js:15556 static/js/zamboni/stats-min.js:5
 msgid "<b>{0}</b> average in last {1} days"
 msgstr ""
 
-#: static/js/impala/stats/overview.js:19
+#: static/js/impala/stats/overview.js:19 static/js/zamboni/stats-all.js:16469 static/js/zamboni/stats-min.js:5
 msgid "No data available."
 msgstr ""
 
-#: static/js/impala/stats/table.js:74
+#: static/js/impala/stats/table.js:74 static/js/zamboni/stats-all.js:17209 static/js/zamboni/stats-min.js:5
 msgid "Date"
 msgstr ""
 
-#: static/js/impala/stats/topchart.js:96
+#: static/js/impala/stats/topchart.js:96 static/js/zamboni/stats-all.js:16600 static/js/zamboni/stats-min.js:5
 msgid "Other"
 msgstr ""
 
-#: static/js/zamboni/admin_validation.js:24 static/js/zamboni/devhub.js:1229 static/js/zamboni/editors.js:295
+#: static/js/zamboni/admin-all.js:180 static/js/zamboni/admin-min.js:1 static/js/zamboni/admin_validation.js:24 static/js/zamboni/devhub-all.js:2408 static/js/zamboni/devhub-min.js:2
+#: static/js/zamboni/devhub.js:1229 static/js/zamboni/editors-all.js:15576 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:295
 msgid "Select an application first"
 msgstr ""
 
-#: static/js/zamboni/admin_validation.js:51
+#: static/js/zamboni/admin-all.js:207 static/js/zamboni/admin-min.js:1 static/js/zamboni/admin_validation.js:51
 msgid "Set {0} add-on to a max version of {1} and email the author."
 msgid_plural "Set {0} add-ons to a max version of {1} and email the authors."
 msgstr[0] ""
 msgstr[1] ""
 
-#: static/js/zamboni/admin_validation.js:54
+#: static/js/zamboni/admin-all.js:210 static/js/zamboni/admin-min.js:1 static/js/zamboni/admin_validation.js:54
 msgid "Email author of {2} add-on which failed validation."
 msgid_plural "Email authors of {2} add-ons which failed validation."
 msgstr[0] ""
 msgstr[1] ""
 
-#. L10n: {0} is an app name like Firefox.
-#: static/js/zamboni/buttons.js:66
-msgid "Accept and Install"
-msgstr ""
-
-#: static/js/zamboni/buttons.js:66
-msgid "Add to {0}"
-msgstr ""
-
-#: static/js/zamboni/buttons.js:71
-msgid "Download Now"
-msgstr ""
-
-#: static/js/zamboni/buttons.js:112
-msgid "Add-on has not been updated to support default-to-compatible."
-msgstr ""
-
-#: static/js/zamboni/buttons.js:117
-msgid "You need to be using Firefox 10.0 or higher."
-msgstr ""
-
-#: static/js/zamboni/buttons.js:129
-msgid "Mozilla has marked this version as incompatible with your Firefox version."
-msgstr ""
-
-#. L10n: {0} is an platform like Windows or Linux.
-#: static/js/zamboni/buttons.js:210
-msgid "Install for {0} anyway"
-msgstr ""
-
-#: static/js/zamboni/buttons.js:210
-msgid "Download for {0} anyway"
-msgstr ""
-
-#: static/js/zamboni/buttons.js:267
-msgid "Not available for your platform"
-msgstr ""
-
-#. L10n: {0} is an app name, {1} is the app version.
-#: static/js/zamboni/buttons.js:278 static/js/zamboni/buttons.js:315
-msgid "Not available for {0} {1}"
-msgstr ""
-
-#: static/js/zamboni/buttons.js:341
-msgid "Works with {app} {min} - {max}"
-msgstr ""
-
-#: static/js/zamboni/buttons.js:343
-msgid "View other versions"
-msgstr ""
-
-#: static/js/zamboni/buttons.js:391
-msgid "Only with Firefox — Get Firefox Now!"
-msgstr ""
-
-#: static/js/zamboni/buttons.js:507 static/js/zamboni/mobile/buttons.js:43
-msgid "Sorry, you need a Mozilla-based browser (such as Firefox) to install a search plugin."
-msgstr ""
-
-#: static/js/zamboni/collections.js:229
-msgid "Adding to Favorites&hellip;"
-msgstr ""
-
-#: static/js/zamboni/collections.js:232
-msgid "Removing Favorite&hellip;"
-msgstr ""
-
-#: static/js/zamboni/collections.js:235
-msgid "Add to Favorites"
-msgstr ""
-
-#: static/js/zamboni/collections.js:238
-msgid "Remove from Favorites"
-msgstr ""
-
-#: static/js/zamboni/collections.js:303
-msgid "Pending"
-msgstr ""
-
-#: static/js/zamboni/collections.js:304
-msgid "Add a comment"
-msgstr ""
-
-#: static/js/zamboni/collections.js:304
-msgid "Comment"
-msgstr ""
-
-#: static/js/zamboni/collections.js:305
-msgid "Remove this add-on from the collection"
-msgstr ""
-
-#: static/js/zamboni/collections.js:305 static/js/zamboni/collections.js:334
-msgid "Remove"
-msgstr ""
-
-#: static/js/zamboni/collections.js:334
-msgid "Remove this user as a contributor"
-msgstr ""
-
-#: static/js/zamboni/collections.js:346
-msgid "An email address is required."
-msgstr ""
-
-#: static/js/zamboni/collections.js:364
-msgid "You cannot add yourself as a contributor."
-msgstr ""
-
-#: static/js/zamboni/collections.js:366
-msgid "You have already added that user."
-msgstr ""
-
-#: static/js/zamboni/collections.js:573
-msgid "Add to favorites"
-msgstr ""
-
-#: static/js/zamboni/collections.js:577
-msgid "Remove from favorites"
-msgstr ""
-
-#: static/js/zamboni/collections.js:604
-msgid "Stop following"
-msgstr ""
-
-#: static/js/zamboni/devhub.js:110
+#: static/js/zamboni/devhub-all.js:1289 static/js/zamboni/devhub-min.js:1 static/js/zamboni/devhub.js:110
 msgid "Your browser does not support the video tag"
 msgstr ""
 
-#: static/js/zamboni/devhub.js:371
+#: static/js/zamboni/devhub-all.js:1550 static/js/zamboni/devhub-min.js:1 static/js/zamboni/devhub.js:371
 msgid "Changes Saved"
 msgstr ""
 
-#: static/js/zamboni/devhub.js:387
+#: static/js/zamboni/devhub-all.js:1566 static/js/zamboni/devhub-min.js:1 static/js/zamboni/devhub.js:387
 msgid "Enter a new author's email address"
 msgstr ""
 
-#: static/js/zamboni/devhub.js:536
+#: static/js/zamboni/devhub-all.js:1715 static/js/zamboni/devhub-min.js:1 static/js/zamboni/devhub.js:536
 msgid "There was an error uploading your file."
 msgstr ""
 
-#: static/js/zamboni/devhub.js:681
+#: static/js/zamboni/devhub-all.js:1860 static/js/zamboni/devhub-min.js:1 static/js/zamboni/devhub.js:681
 msgid "{files} file"
 msgid_plural "{files} files"
 msgstr[0] ""
 msgstr[1] ""
 
-#: static/js/zamboni/devhub.js:684
+#: static/js/zamboni/devhub-all.js:1863 static/js/zamboni/devhub-min.js:1 static/js/zamboni/devhub.js:684
 msgid "{reviews} user review"
 msgid_plural "{reviews} user reviews"
 msgstr[0] ""
 msgstr[1] ""
 
-#: static/js/zamboni/devhub.js:796
+#: static/js/zamboni/devhub-all.js:1975 static/js/zamboni/devhub-min.js:2 static/js/zamboni/devhub.js:796
 msgid "Learn more"
 msgstr ""
 
-#: static/js/zamboni/devhub.js:800
+#: static/js/zamboni/devhub-all.js:1979 static/js/zamboni/devhub-min.js:2 static/js/zamboni/devhub.js:800
 msgid "Example"
 msgstr ""
 
-#: static/js/zamboni/devhub.js:1130
+#: static/js/zamboni/devhub-all.js:2309 static/js/zamboni/devhub-min.js:2 static/js/zamboni/devhub.js:1130
 msgid "Image changes being processed"
 msgstr ""
 
-#: static/js/zamboni/devhub.js:1280
+#: static/js/zamboni/devhub-all.js:2459 static/js/zamboni/devhub-min.js:2 static/js/zamboni/devhub.js:1280
 msgid "Must be a valid e-mail address."
+msgstr ""
+
+#: static/js/zamboni/devhub-all.js:2613 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:80
+msgid "All tests passed successfully."
+msgstr ""
+
+#: static/js/zamboni/devhub-all.js:2616 static/js/zamboni/devhub-all.js:3011 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:83 static/js/zamboni/validator.js:478
+msgid "These tests were not run."
+msgstr ""
+
+#: static/js/zamboni/devhub-all.js:2664 static/js/zamboni/devhub-all.js:2677 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:131 static/js/zamboni/validator.js:144
+msgid "Tests"
+msgstr ""
+
+#: static/js/zamboni/devhub-all.js:2779 static/js/zamboni/devhub-all.js:3108 static/js/zamboni/devhub-all.js:3127 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:246
+#: static/js/zamboni/validator.js:575 static/js/zamboni/validator.js:594
+msgid "Error"
+msgstr ""
+
+#: static/js/zamboni/devhub-all.js:2780 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:247
+msgid "Warning"
+msgstr ""
+
+#: static/js/zamboni/devhub-all.js:2794 static/js/zamboni/devhub-min.js:2 static/js/zamboni/files-all.js:5657 static/js/zamboni/files-min.js:3 static/js/zamboni/files.js:411
+#: static/js/zamboni/validator.js:261
+msgid "Ignore this message in future updates"
+msgstr ""
+
+#: static/js/zamboni/devhub-all.js:2817 static/js/zamboni/devhub-min.js:2 static/js/zamboni/files-all.js:5663 static/js/zamboni/files-min.js:3 static/js/zamboni/files.js:417
+#: static/js/zamboni/validator.js:284
+msgid "Severity for automated signing:"
+msgstr ""
+
+#: static/js/zamboni/devhub-all.js:2832 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:299
+msgid "Suggestions for passing automated signing:"
+msgstr ""
+
+#: static/js/zamboni/devhub-all.js:2920 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:387
+msgid "Compatibility Tests"
+msgstr ""
+
+#: static/js/zamboni/devhub-all.js:2999 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:466
+msgid "Add-on failed validation."
+msgstr ""
+
+#: static/js/zamboni/devhub-all.js:3001 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:468
+msgid "Add-on passed validation."
+msgstr ""
+
+#: static/js/zamboni/devhub-all.js:3014 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:481
+msgid "{0} error"
+msgid_plural "{0} errors"
+msgstr[0] ""
+msgstr[1] ""
+
+#: static/js/zamboni/devhub-all.js:3016 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:483
+msgid "{0} warning"
+msgid_plural "{0} warnings"
+msgstr[0] ""
+msgstr[1] ""
+
+#: static/js/zamboni/devhub-all.js:3018 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:485
+msgid "{0} notice"
+msgid_plural "{0} notices"
+msgstr[0] ""
+msgstr[1] ""
+
+#: static/js/zamboni/devhub-all.js:3110 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:577
+msgid "Validation task could not complete or completed with errors"
+msgstr ""
+
+#: static/js/zamboni/devhub-all.js:3128 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:595
+msgid "Internal server error"
 msgstr ""
 
 #: static/js/zamboni/devhub_search.js:8
 msgid "No results found."
 msgstr ""
 
-#: static/js/zamboni/editors.js:121
+#: static/js/zamboni/editors-all.js:15402 static/js/zamboni/editors-min.js:4 static/js/zamboni/editors.js:121
 msgid "{name} was viewing this page first."
 msgstr ""
 
-#: static/js/zamboni/editors.js:171
+#: static/js/zamboni/editors-all.js:15452 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:171
 msgid "Receipt checked by app."
 msgstr ""
 
-#: static/js/zamboni/editors.js:173
+#: static/js/zamboni/editors-all.js:15454 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:173
 msgid "Receipt was not checked by app."
 msgstr ""
 
-#: static/js/zamboni/editors.js:244
+#: static/js/zamboni/editors-all.js:15525 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:244
 msgid "{name} was viewing this add-on first."
 msgstr ""
 
-#: static/js/zamboni/editors.js:255
+#: static/js/zamboni/editors-all.js:15536 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:255
 msgid "Loading&hellip;"
 msgstr ""
 
-#: static/js/zamboni/editors.js:260
+#: static/js/zamboni/editors-all.js:15541 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:260
 msgid "Version Notes"
 msgstr ""
 
-#: static/js/zamboni/editors.js:265
+#: static/js/zamboni/editors-all.js:15546 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:265
 msgid "Notes for Reviewers"
 msgstr ""
 
-#: static/js/zamboni/editors.js:270
+#: static/js/zamboni/editors-all.js:15551 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:270
 msgid "No version notes found"
 msgstr ""
 
-#: static/js/zamboni/editors.js:330
+#: static/js/zamboni/editors-all.js:15611 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:330
 msgid "Average Reviews"
 msgstr ""
 
-#: static/js/zamboni/editors.js:386
+#: static/js/zamboni/editors-all.js:15667 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:386
 msgid "Number of Reviews"
 msgstr ""
 
-#: static/js/zamboni/editors.js:445
+#: static/js/zamboni/editors-all.js:15726 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:445
 msgid "Error loading translation"
 msgstr ""
 
-#: static/js/zamboni/files.js:411 static/js/zamboni/validator.js:261
-msgid "Ignore this message in future updates"
-msgstr ""
-
-#: static/js/zamboni/files.js:417 static/js/zamboni/validator.js:284
-msgid "Severity for automated signing:"
-msgstr ""
-
-#: static/js/zamboni/global.js:410
-msgid "Loading..."
-msgstr ""
-
-#. L10n: {0} is the number of characters left.
-#: static/js/zamboni/global.js:474
-msgid "<b>{0}</b> character left."
-msgid_plural "<b>{0}</b> characters left."
-msgstr[0] ""
-msgstr[1] ""
-
-#: static/js/zamboni/init.js:28
-msgid "This feature is temporarily disabled while we perform website maintenance. Please check back a little later."
-msgstr ""
-
-#: static/js/zamboni/l10n.js:45
-msgid "Remove this localization"
-msgstr ""
-
-#: static/js/zamboni/password-strength.js:20
-msgid "Password strength:"
-msgstr ""
-
-#: static/js/zamboni/password-strength.js:26
-msgid "At least {0} character left."
-msgid_plural "At least {0} characters left."
-msgstr[0] ""
-msgstr[1] ""
-
-#: static/js/zamboni/themes_review.js:176
-msgid "Requested Info"
-msgstr ""
-
-#: static/js/zamboni/themes_review.js:177
-msgid "Flagged"
-msgstr ""
-
-#: static/js/zamboni/themes_review.js:178
-msgid "Duplicate"
-msgstr ""
-
-#: static/js/zamboni/themes_review.js:179
-msgid "Rejected"
-msgstr ""
-
-#: static/js/zamboni/themes_review.js:180
-msgid "Approved"
-msgstr ""
-
-#: static/js/zamboni/themes_review.js:424
-msgid "No results found"
-msgstr ""
-
-#: static/js/zamboni/themes_review_templates.js:31
+#: static/js/zamboni/editors-all.js:15975 static/js/zamboni/editors-min.js:5 static/js/zamboni/themes_review_templates.js:31
 msgid "Theme"
 msgstr ""
 
-#: static/js/zamboni/themes_review_templates.js:33
+#: static/js/zamboni/editors-all.js:15977 static/js/zamboni/editors-min.js:5 static/js/zamboni/themes_review_templates.js:33
 msgid "Reviewer"
 msgstr ""
 
-#: static/js/zamboni/themes_review_templates.js:35
+#: static/js/zamboni/editors-all.js:15979 static/js/zamboni/editors-min.js:5 static/js/zamboni/themes_review_templates.js:35
 msgid "Status"
 msgstr ""
 
-#: static/js/zamboni/validator.js:80
-msgid "All tests passed successfully."
+#: static/js/zamboni/editors-all.js:16196 static/js/zamboni/editors-min.js:5 static/js/zamboni/themes_review.js:176
+msgid "Requested Info"
 msgstr ""
 
-#: static/js/zamboni/validator.js:83 static/js/zamboni/validator.js:478
-msgid "These tests were not run."
+#: static/js/zamboni/editors-all.js:16197 static/js/zamboni/editors-min.js:5 static/js/zamboni/themes_review.js:177
+msgid "Flagged"
 msgstr ""
 
-#: static/js/zamboni/validator.js:131 static/js/zamboni/validator.js:144
-msgid "Tests"
+#: static/js/zamboni/editors-all.js:16198 static/js/zamboni/editors-min.js:5 static/js/zamboni/themes_review.js:178
+msgid "Duplicate"
 msgstr ""
 
-#: static/js/zamboni/validator.js:246 static/js/zamboni/validator.js:575 static/js/zamboni/validator.js:594
-msgid "Error"
+#: static/js/zamboni/editors-all.js:16199 static/js/zamboni/editors-min.js:5 static/js/zamboni/themes_review.js:179
+msgid "Rejected"
 msgstr ""
 
-#: static/js/zamboni/validator.js:247
-msgid "Warning"
+#: static/js/zamboni/editors-all.js:16200 static/js/zamboni/editors-min.js:5 static/js/zamboni/themes_review.js:180
+msgid "Approved"
 msgstr ""
 
-#: static/js/zamboni/validator.js:299
-msgid "Suggestions for passing automated signing:"
+#: static/js/zamboni/editors-all.js:16444 static/js/zamboni/editors-min.js:5 static/js/zamboni/themes_review.js:424
+msgid "No results found"
 msgstr ""
 
-#: static/js/zamboni/validator.js:387
-msgid "Compatibility Tests"
-msgstr ""
-
-#: static/js/zamboni/validator.js:466
-msgid "Add-on failed validation."
-msgstr ""
-
-#: static/js/zamboni/validator.js:468
-msgid "Add-on passed validation."
-msgstr ""
-
-#: static/js/zamboni/validator.js:481
-msgid "{0} error"
-msgid_plural "{0} errors"
-msgstr[0] ""
-msgstr[1] ""
-
-#: static/js/zamboni/validator.js:483
-msgid "{0} warning"
-msgid_plural "{0} warnings"
-msgstr[0] ""
-msgstr[1] ""
-
-#: static/js/zamboni/validator.js:485
-msgid "{0} notice"
-msgid_plural "{0} notices"
-msgstr[0] ""
-msgstr[1] ""
-
-#: static/js/zamboni/validator.js:577
-msgid "Validation task could not complete or completed with errors"
-msgstr ""
-
-#: static/js/zamboni/validator.js:595
-msgid "Internal server error"
-msgstr ""
-
-#: static/js/zamboni/mobile/buttons.js:52
+#: static/js/zamboni/mobile-all.js:15186 static/js/zamboni/mobile/buttons.js:52
 msgid "Not Updated for {0} {1}"
 msgstr ""
 
-#: static/js/zamboni/mobile/buttons.js:53
+#: static/js/zamboni/mobile-all.js:15187 static/js/zamboni/mobile/buttons.js:53
 msgid "Requires Newer Version of {0}"
 msgstr ""
 
-#: static/js/zamboni/mobile/buttons.js:54
+#: static/js/zamboni/mobile-all.js:15188 static/js/zamboni/mobile/buttons.js:54
 msgid "Unreviewed"
 msgstr ""
 
-#: static/js/zamboni/mobile/buttons.js:55
+#: static/js/zamboni/mobile-all.js:15189 static/js/zamboni/mobile/buttons.js:55
 msgid "Experimental <span>(Learn More)</span>"
 msgstr ""
 
-#: static/js/zamboni/mobile/buttons.js:56 static/js/zamboni/mobile/buttons.js:57
+#: static/js/zamboni/mobile-all.js:15190 static/js/zamboni/mobile-all.js:15191 static/js/zamboni/mobile/buttons.js:56 static/js/zamboni/mobile/buttons.js:57
 msgid "Not Available for {0}"
 msgstr ""
 
-#: static/js/zamboni/mobile/buttons.js:58
+#: static/js/zamboni/mobile-all.js:15192 static/js/zamboni/mobile/buttons.js:58
 msgid "Experimental"
 msgstr ""
 
-#: static/js/zamboni/mobile/buttons.js:59
+#: static/js/zamboni/mobile-all.js:15193 static/js/zamboni/mobile/buttons.js:59
 msgid "Themes Require Newer Version of {0}"
 msgstr ""
 
-#: static/js/zamboni/mobile/buttons.js:60
+#: static/js/zamboni/mobile-all.js:15194 static/js/zamboni/mobile/buttons.js:60
 msgid "Themes Require {0}"
 msgstr ""
 
-#: static/js/zamboni/mobile/buttons.js:105
+#: static/js/zamboni/mobile-all.js:15239 static/js/zamboni/mobile/buttons.js:105
 msgid "Installing..."
 msgstr ""
 
-#: static/js/zamboni/mobile/buttons.js:125
+#: static/js/zamboni/mobile-all.js:15259 static/js/zamboni/mobile/buttons.js:125
 msgid "This add-on has been preliminarily reviewed by Mozilla."
 msgstr ""
 
-#: static/js/zamboni/mobile/buttons.js:250
+#: static/js/zamboni/mobile-all.js:15384 static/js/zamboni/mobile/buttons.js:250
 msgid "Keep it"
 msgstr ""
 
-#: static/js/zamboni/mobile/general.js:344
+#: static/js/zamboni/mobile-all.js:16049 static/js/zamboni/mobile-min.js:6 static/js/zamboni/mobile/general.js:344
 msgid "You're trying it on!"
 msgstr ""
 
-#: static/js/zamboni/mobile/general.js:356
+#: static/js/zamboni/mobile-all.js:16061 static/js/zamboni/mobile-min.js:6 static/js/zamboni/mobile/general.js:356
 msgid "Added to Firefox"
 msgstr ""
-

--- a/locale/bg/LC_MESSAGES/django.po
+++ b/locale/bg/LC_MESSAGES/django.po
@@ -6,69 +6,70 @@ msgid ""
 msgstr ""
 "Project-Id-Version:  addons\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2016-02-24 21:23+0000\n"
+"POT-Creation-Date: 2016-04-18 15:47+0000\n"
 "PO-Revision-Date: 2016-02-04 11:28+0000\n"
 "Last-Translator: stoyan <stoyan@gmx.com>\n"
 "Language-Team: none\n"
+"Language: \n"
 "MIME-Version: 1.0\n"
-"Content-Type: text/plain; charset=utf-8\n"
+"Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Generated-By: Babel 2.2.0\n"
 
-#: src/olympia/accounts/views.py:52
+#: src/olympia/accounts/views.py:54
 msgid "Your log in attempt could not be parsed. Please try again."
 msgstr ""
 
-#: src/olympia/accounts/views.py:54
+#: src/olympia/accounts/views.py:56
 msgid "Your Firefox Account could not be found. Please try again."
 msgstr ""
 
-#: src/olympia/accounts/views.py:55
+#: src/olympia/accounts/views.py:57
 msgid "You could not be logged in. Please try again."
 msgstr ""
 
-#: src/olympia/accounts/views.py:57
+#: src/olympia/accounts/views.py:59
 msgid "Your account has already been migrated to Firefox Accounts."
 msgstr ""
 
-#: src/olympia/accounts/views.py:59
+#: src/olympia/accounts/views.py:61
 msgid "Your Firefox Account already exists on this site."
 msgstr ""
 
-#: src/olympia/accounts/views.py:108
+#: src/olympia/accounts/views.py:110
 msgid "Great job!"
 msgstr ""
 
-#: src/olympia/accounts/views.py:109
+#: src/olympia/accounts/views.py:111
 msgid "You can now log in to Add-ons with your Firefox Account."
 msgstr ""
 
-#: src/olympia/accounts/views.py:121
+#: src/olympia/accounts/views.py:123
 msgid "Need help?"
 msgstr ""
 
-#: src/olympia/addons/buttons.py:180
+#: src/olympia/addons/buttons.py:177
 msgid "Download Now"
 msgstr "Изтегляне"
 
-#: src/olympia/addons/buttons.py:182
+#: src/olympia/addons/buttons.py:179
 msgid "Download"
 msgstr "Изтегляне"
 
 #. L10n: please keep &nbsp; in the string so &rarr; does not wrap.
-#: src/olympia/addons/buttons.py:186
+#: src/olympia/addons/buttons.py:183
 msgid "Continue to Download&nbsp;&rarr;"
 msgstr "Продължи към изтеглянето&nbsp;&rarr;"
 
-#: src/olympia/addons/buttons.py:202 src/olympia/addons/helpers.py:35 src/olympia/addons/views.py:319 src/olympia/addons/templates/addons/impala/details.html:114
+#: src/olympia/addons/buttons.py:199 src/olympia/addons/helpers.py:35 src/olympia/addons/views.py:333 src/olympia/addons/templates/addons/impala/details.html:111
 #: src/olympia/addons/templates/addons/impala/listing/items.html:17 src/olympia/addons/templates/addons/mobile/home.html:40 src/olympia/amo/templates/amo/side_nav.html:6
-#: src/olympia/amo/templates/amo/side_nav.html:10 src/olympia/amo/templates/amo/site_nav.html:2 src/olympia/amo/templates/amo/site_nav.html:55 src/olympia/bandwagon/views.py:95
-#: src/olympia/browse/views.py:54 src/olympia/browse/views.py:68 src/olympia/browse/views.py:235 src/olympia/browse/templates/browse/impala/category_landing.html:22
+#: src/olympia/amo/templates/amo/side_nav.html:10 src/olympia/amo/templates/amo/site_nav.html:2 src/olympia/amo/templates/amo/site_nav.html:53 src/olympia/bandwagon/views.py:95
+#: src/olympia/browse/views.py:54 src/olympia/browse/views.py:68 src/olympia/browse/views.py:202 src/olympia/browse/templates/browse/impala/category_landing.html:22
 #: src/olympia/browse/templates/browse/personas/mobile/category_landing.html:26
 msgid "Featured"
 msgstr "Препоръчани"
 
-#: src/olympia/addons/buttons.py:221
+#: src/olympia/addons/buttons.py:218
 msgid "Add to {0}"
 msgstr "Добави към {0}"
 
@@ -116,39 +117,39 @@ msgid_plural "All tags must be at least {0} characters."
 msgstr[0] "Всички етикети трябва да са поне {0} знак."
 msgstr[1] "Всички етикети трябва да са поне {0} знака."
 
-#: src/olympia/addons/forms.py:234
+#: src/olympia/addons/forms.py:238
 msgid "Categories cannot be changed while your add-on is featured for this application."
 msgstr "Категориите не могат да се променят, докато добавката ви е препоръчана за това приложение."
 
 #. L10n: {0} is the number of categories.
-#: src/olympia/addons/forms.py:238
+#: src/olympia/addons/forms.py:242
 msgid "You can have only {0} category."
 msgid_plural "You can have only {0} categories."
 msgstr[0] "Можете да имате само {0} категория."
 msgstr[1] "Можете да имате само {0} категории."
 
-#: src/olympia/addons/forms.py:246
+#: src/olympia/addons/forms.py:250
 msgid "The miscellaneous category cannot be combined with additional categories."
 msgstr "Категорията разни не може да бъде комбинирана с допълнителни категории."
 
-#: src/olympia/addons/forms.py:369
+#: src/olympia/addons/forms.py:374
 #, python-format
 msgid "Before changing your default locale you must have a name, summary, and description in that locale. You are missing %s."
 msgstr "Преди да промените локала си по подразбиране, трябва да имате име, обобщение и описание в този локал. Липсва ви %s."
 
-#: src/olympia/addons/forms.py:484 src/olympia/addons/forms.py:575
+#: src/olympia/addons/forms.py:455 src/olympia/addons/forms.py:546
 msgid "A license must be selected."
 msgstr "Трябва да изберете лиценз."
 
-#: src/olympia/addons/forms.py:556
+#: src/olympia/addons/forms.py:527
 msgid "Give Your Theme a Name."
 msgstr ""
 
-#: src/olympia/addons/forms.py:562 src/olympia/devhub/templates/devhub/personas/submit.html:53
+#: src/olympia/addons/forms.py:533 src/olympia/devhub/templates/devhub/personas/submit.html:53
 msgid "Describe your Theme."
 msgstr ""
 
-#: src/olympia/addons/forms.py:704
+#: src/olympia/addons/forms.py:675
 msgid "Enter a new author's email address"
 msgstr ""
 
@@ -156,39 +157,39 @@ msgstr ""
 msgid "Not Reviewed"
 msgstr "Не е прегледан"
 
-#: src/olympia/addons/models.py:301
+#: src/olympia/addons/models.py:298
 msgid "Users have the option of contributing more or less than this amount."
 msgstr "Потребителите имат възможност да даряват повече или по-малко от тази сума."
 
-#: src/olympia/addons/models.py:309
-msgid "Users will always be asked in the Add-ons Manager (Firefox 4 and above)"
-msgstr "Потребителите ще бъдат питани в Мениджъра на добавки (Firefox 4 и нагоре)"
+#: src/olympia/addons/models.py:306
+msgid "Users will always be asked in the Add-ons Manager (Firefox 4 and above). Only applies to desktop."
+msgstr ""
 
 # Column name in a table.
-#: src/olympia/addons/models.py:1804 src/olympia/addons/templates/addons/details_box.html:55 src/olympia/devhub/templates/devhub/index.html:92
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:102
+#: src/olympia/addons/models.py:1802 src/olympia/addons/templates/addons/details_box.html:55 src/olympia/devhub/templates/devhub/index.html:92
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:89
 msgid "Listed"
 msgstr "Изброен"
 
-#: src/olympia/addons/views.py:320 src/olympia/browse/templates/browse/personas/mobile/category_landing.html:27
+#: src/olympia/addons/views.py:334 src/olympia/browse/templates/browse/personas/mobile/category_landing.html:27
 msgid "Popular"
 msgstr "Популярно"
 
-#: src/olympia/addons/views.py:321 src/olympia/browse/views.py:238 src/olympia/browse/views.py:280 src/olympia/browse/views.py:482
+#: src/olympia/addons/views.py:335 src/olympia/browse/views.py:205 src/olympia/browse/views.py:247 src/olympia/browse/views.py:449
 msgid "Recently Added"
 msgstr "Скоро добавени"
 
-#: src/olympia/addons/views.py:322 src/olympia/bandwagon/views.py:99 src/olympia/browse/views.py:60 src/olympia/browse/views.py:71 src/olympia/search/forms.py:16 src/olympia/search/forms.py:91
+#: src/olympia/addons/views.py:336 src/olympia/bandwagon/views.py:99 src/olympia/browse/views.py:60 src/olympia/browse/views.py:71 src/olympia/search/forms.py:16 src/olympia/search/forms.py:91
 msgid "Recently Updated"
 msgstr "Скоро обновени"
 
 # %1 is an add-on name.
 #. l10n: {0} is the addon name
-#: src/olympia/addons/views.py:520
+#: src/olympia/addons/views.py:534
 msgid "Contribution for {0}"
 msgstr "Принос за {0}"
 
-#: src/olympia/addons/views.py:613
+#: src/olympia/addons/views.py:627
 msgid "Abuse reported."
 msgstr "Злоупотребата докладвана."
 
@@ -257,9 +258,9 @@ msgstr "Допринеси"
 #: src/olympia/devhub/templates/devhub/addons/ajax_compat_update.html:36 src/olympia/devhub/templates/devhub/addons/profile.html:44 src/olympia/devhub/templates/devhub/addons/edit/admin.html:101
 #: src/olympia/devhub/templates/devhub/addons/edit/basic.html:152 src/olympia/devhub/templates/devhub/addons/edit/details.html:85 src/olympia/devhub/templates/devhub/addons/edit/support.html:67
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:166 src/olympia/devhub/templates/devhub/addons/forms_shared/media.html:149
-#: src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:44 src/olympia/devhub/templates/devhub/versions/add_file_modal.html:78 src/olympia/devhub/templates/devhub/versions/edit.html:139
-#: src/olympia/devhub/templates/devhub/versions/list.html:242 src/olympia/devhub/templates/devhub/versions/list.html:276 src/olympia/devhub/templates/devhub/versions/list.html:317
-#: src/olympia/devhub/templates/devhub/versions/list.html:351 src/olympia/reviews/templates/reviews/edit_review.html:16 src/olympia/translations/templates/translations/trans-menu.html:50
+#: src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:43 src/olympia/devhub/templates/devhub/versions/add_file_modal.html:58 src/olympia/devhub/templates/devhub/versions/edit.html:139
+#: src/olympia/devhub/templates/devhub/versions/list.html:239 src/olympia/devhub/templates/devhub/versions/list.html:281 src/olympia/devhub/templates/devhub/versions/list.html:315
+#: src/olympia/devhub/templates/devhub/versions/list.html:349 src/olympia/reviews/templates/reviews/edit_review.html:16 src/olympia/translations/templates/translations/trans-menu.html:50
 #: src/olympia/translations/templates/translations/trans-menu.html:62
 msgid "or"
 msgstr "или"
@@ -297,14 +298,15 @@ msgstr ""
 
 #: src/olympia/addons/templates/addons/contributions_lightbox.html:15
 #, python-format
-msgid "To show your support for <b>%(addon_name)s</b>, the developer asks that you make a donation to the <a href=\"%(charity_url)s\">%(charity_name)s</a> through <a href=\"%(paypal_url)s\">PayPal</a>."
+msgid ""
+"To show your support for <b>%(addon_name)s</b>, the developer asks that you make a donation to the <a href=\"%(charity_url)s\">%(charity_name)s</a> through <a href=\"%(paypal_url)s\">PayPal</a>."
 msgstr ""
 
 #: src/olympia/addons/templates/addons/contributions_lightbox.html:21
 #, python-format
 msgid ""
-"To show your support for <b>%(addon_name)s</b>, the developer asks that you make a small contribution to <a href=\"%(charity_url)s\">%(charity_name)s</a> through <a "
-"href=\"%(paypal_url)s\">PayPal</a>."
+"To show your support for <b>%(addon_name)s</b>, the developer asks that you make a small contribution to <a href=\"%(charity_url)s\">%(charity_name)s</a> through <a href=\"%(paypal_url)s\">PayPal</"
+"a>."
 msgstr ""
 
 #: src/olympia/addons/templates/addons/contributions_lightbox.html:30
@@ -369,7 +371,7 @@ msgid "Add-on Information for {0}"
 msgstr "Информация за {0}"
 
 #: src/olympia/addons/templates/addons/details_box.html:30 src/olympia/addons/templates/addons/persona_detail_table.html:3 src/olympia/addons/templates/addons/mobile/details.html:63
-#: src/olympia/addons/templates/addons/mobile/persona_detail_table.html:7 src/olympia/browse/views.py:459 src/olympia/devhub/views.py:75
+#: src/olympia/addons/templates/addons/mobile/persona_detail_table.html:7 src/olympia/browse/views.py:426 src/olympia/devhub/views.py:73
 msgid "Updated"
 msgstr "Обновяване"
 
@@ -388,11 +390,11 @@ msgstr "Работи с"
 msgid "Visibility"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/details_box.html:57 src/olympia/devhub/templates/devhub/index.html:94 src/olympia/devhub/templates/devhub/includes/addon_details.html:104
+#: src/olympia/addons/templates/addons/details_box.html:57 src/olympia/devhub/templates/devhub/index.html:94 src/olympia/devhub/templates/devhub/includes/addon_details.html:91
 msgid "Hidden"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/details_box.html:59 src/olympia/devhub/templates/devhub/index.html:96 src/olympia/devhub/templates/devhub/includes/addon_details.html:106
+#: src/olympia/addons/templates/addons/details_box.html:59 src/olympia/devhub/templates/devhub/index.html:96 src/olympia/devhub/templates/devhub/includes/addon_details.html:93
 msgid "Unlisted"
 msgstr ""
 
@@ -400,13 +402,13 @@ msgstr ""
 msgid "Required Add-ons"
 msgstr "Нужни добавки"
 
-#: src/olympia/addons/templates/addons/details_box.html:81 src/olympia/addons/templates/addons/persona_detail_table.html:15 src/olympia/browse/views.py:462 src/olympia/devhub/views.py:78
-#: src/olympia/devhub/views.py:85 src/olympia/discovery/templates/discovery/addons/detail.html:57 src/olympia/reviews/forms.py:62 src/olympia/reviews/templates/reviews/add.html:57
+#: src/olympia/addons/templates/addons/details_box.html:81 src/olympia/addons/templates/addons/persona_detail_table.html:15 src/olympia/browse/views.py:429 src/olympia/devhub/views.py:76
+#: src/olympia/devhub/views.py:83 src/olympia/discovery/templates/discovery/addons/detail.html:57 src/olympia/reviews/forms.py:62 src/olympia/reviews/templates/reviews/add.html:57
 #: src/olympia/reviews/templates/reviews/mobile/review_list.html:18
 msgid "Rating"
 msgstr "Оценка"
 
-#: src/olympia/addons/templates/addons/details_box.html:85 src/olympia/browse/views.py:461 src/olympia/devhub/views.py:77 src/olympia/devhub/views.py:84
+#: src/olympia/addons/templates/addons/details_box.html:85 src/olympia/browse/views.py:428 src/olympia/devhub/views.py:75 src/olympia/devhub/views.py:82
 #: src/olympia/stats/templates/stats/addon_report_menu.html:8 src/olympia/stats/templates/stats/collection_report_menu.html:18
 msgid "Downloads"
 msgstr "Изтегляния"
@@ -426,7 +428,7 @@ msgstr "Доклади за злоупотреби"
 
 #. The Privacy Policy for this add-on.
 #: src/olympia/addons/templates/addons/details_box.html:121 src/olympia/addons/templates/addons/privacy.html:19 src/olympia/addons/templates/addons/privacy.html:23
-#: src/olympia/addons/templates/addons/impala/button.html:43 src/olympia/addons/templates/addons/impala/details.html:307 src/olympia/devhub/templates/devhub/includes/policy_form.html:20
+#: src/olympia/addons/templates/addons/impala/button.html:43 src/olympia/addons/templates/addons/impala/details.html:312 src/olympia/devhub/templates/devhub/includes/policy_form.html:23
 #: src/olympia/templates/mobile/base_addons.html:87
 msgid "Privacy Policy"
 msgstr "Декларация за поверителност"
@@ -451,7 +453,7 @@ msgstr "Картинна галерия"
 msgid "Developer Comments"
 msgstr "Коментари от разработчици"
 
-#: src/olympia/addons/templates/addons/details_box.html:199 src/olympia/addons/templates/addons/impala/details.html:259
+#: src/olympia/addons/templates/addons/details_box.html:199 src/olympia/addons/templates/addons/impala/details.html:264
 msgid "Development Channel"
 msgstr "Канал на разработчици"
 
@@ -471,7 +473,7 @@ msgid ""
 "developer. To stop receiving development updates, reinstall the default version from the link above."
 msgstr ""
 
-#: src/olympia/addons/templates/addons/details_box.html:220 src/olympia/addons/templates/addons/impala/details.html:278
+#: src/olympia/addons/templates/addons/details_box.html:220 src/olympia/addons/templates/addons/impala/details.html:283
 msgid "Version {0}:"
 msgstr "Версия {0}:"
 
@@ -490,7 +492,7 @@ msgid "End-User License Agreement for {0}"
 msgstr "Лицензионното споразумение с краен потребител за {0}"
 
 #: src/olympia/addons/templates/addons/eula.html:17 src/olympia/addons/templates/addons/eula.html:21 src/olympia/addons/templates/addons/impala/button.html:48
-#: src/olympia/addons/templates/addons/impala/details.html:316 src/olympia/devhub/templates/devhub/includes/policy_form.html:3 src/olympia/discovery/templates/discovery/addons/eula.html:11
+#: src/olympia/addons/templates/addons/impala/details.html:321 src/olympia/devhub/templates/devhub/includes/policy_form.html:3 src/olympia/discovery/templates/discovery/addons/eula.html:11
 msgid "End-User License Agreement"
 msgstr "Лицензионно споразумение на крайния потребител"
 
@@ -510,7 +512,7 @@ msgstr "Назад към {0}…"
 msgid "Add-ons for {0}"
 msgstr "Добавки за {0}"
 
-#: src/olympia/addons/templates/addons/home.html:10 src/olympia/addons/templates/addons/home.html:51 src/olympia/browse/templates/browse/impala/base_listing.html:11
+#: src/olympia/addons/templates/addons/home.html:10 src/olympia/addons/templates/addons/home.html:53 src/olympia/browse/templates/browse/impala/base_listing.html:11
 msgid "Featured Extensions"
 msgstr "Препоръчани добавки"
 
@@ -518,29 +520,29 @@ msgstr "Препоръчани добавки"
 msgid "Popular Extensions"
 msgstr "Популярни разширения"
 
-#: src/olympia/addons/templates/addons/home.html:42 src/olympia/amo/templates/amo/side_nav.html:3 src/olympia/amo/templates/amo/side_nav.html:11 src/olympia/amo/templates/amo/site_nav.html:3
-#: src/olympia/amo/templates/amo/site_nav.html:25 src/olympia/browse/views.py:236 src/olympia/browse/views.py:281 src/olympia/browse/views.py:481
+#: src/olympia/addons/templates/addons/home.html:44 src/olympia/amo/templates/amo/side_nav.html:3 src/olympia/amo/templates/amo/side_nav.html:11 src/olympia/amo/templates/amo/site_nav.html:3
+#: src/olympia/amo/templates/amo/site_nav.html:25 src/olympia/browse/views.py:203 src/olympia/browse/views.py:248 src/olympia/browse/views.py:448
 msgid "Most Popular"
 msgstr "Най-популярните"
 
-#: src/olympia/addons/templates/addons/home.html:43
+#: src/olympia/addons/templates/addons/home.html:45
 msgid "All »"
 msgstr "Всички »"
 
-#: src/olympia/addons/templates/addons/home.html:52 src/olympia/addons/templates/addons/home.html:61 src/olympia/addons/templates/addons/home.html:70 src/olympia/addons/templates/addons/home.html:78
+#: src/olympia/addons/templates/addons/home.html:54 src/olympia/addons/templates/addons/home.html:63 src/olympia/addons/templates/addons/home.html:72 src/olympia/addons/templates/addons/home.html:80
 #: src/olympia/browse/templates/browse/impala/category_landing.html:36
 msgid "See all »"
 msgstr "Виж всички »"
 
-#: src/olympia/addons/templates/addons/home.html:60
+#: src/olympia/addons/templates/addons/home.html:62
 msgid "Up &amp; Coming Extensions"
 msgstr "Нови и свежи добавки"
 
-#: src/olympia/addons/templates/addons/home.html:69 src/olympia/browse/templates/browse/personas/category_landing.html:61 src/olympia/discovery/templates/discovery/pane.html:74
+#: src/olympia/addons/templates/addons/home.html:71 src/olympia/browse/templates/browse/personas/category_landing.html:61 src/olympia/discovery/templates/discovery/pane.html:74
 msgid "Featured Themes"
 msgstr "Препоръчани теми"
 
-#: src/olympia/addons/templates/addons/home.html:77 src/olympia/bandwagon/templates/bandwagon/impala/collection_listing.html:5
+#: src/olympia/addons/templates/addons/home.html:79 src/olympia/bandwagon/templates/bandwagon/impala/collection_listing.html:5
 msgid "Featured Collections"
 msgstr "Препоръчани колекции"
 
@@ -558,9 +560,9 @@ msgid "Updated {0}"
 msgstr "Обновен {0}"
 
 #. {0} is a date.
-#: src/olympia/addons/templates/addons/macros.html:10 src/olympia/addons/templates/addons/macros.html:69 src/olympia/addons/templates/addons/persona_preview.html:21
-#: src/olympia/addons/templates/addons/listing/items_mobile.html:44 src/olympia/addons/templates/addons/listing/macros.html:39 src/olympia/bandwagon/templates/bandwagon/collection_listing_items.html:37
-#: src/olympia/bandwagon/templates/bandwagon/impala/collection_listing_items.html:37
+#: src/olympia/addons/templates/addons/macros.html:10 src/olympia/addons/templates/addons/macros.html:69 src/olympia/addons/templates/addons/persona_preview.html:22
+#: src/olympia/addons/templates/addons/listing/items_mobile.html:44 src/olympia/addons/templates/addons/listing/macros.html:39
+#: src/olympia/bandwagon/templates/bandwagon/collection_listing_items.html:37 src/olympia/bandwagon/templates/bandwagon/impala/collection_listing_items.html:37
 msgid "Added {0}"
 msgstr "Добави {0}"
 
@@ -579,15 +581,14 @@ msgstr[0] "%(num)s потребител"
 msgstr[1] "%(num)s потребители"
 
 #. {0} is the number of downloads.
-#: src/olympia/addons/templates/addons/macros.html:53 src/olympia/addons/templates/addons/impala/details.html:61
+#: src/olympia/addons/templates/addons/macros.html:53 src/olympia/addons/templates/addons/impala/details.html:59
 msgid "{0} weekly download"
 msgid_plural "{0} weekly downloads"
 msgstr[0] "{0} сваляне седмично"
 msgstr[1] "{0} сваляния седмично"
 
 #. {0} is the number of users.
-#: src/olympia/addons/templates/addons/macros.html:61 src/olympia/addons/templates/addons/impala/details.html:54 src/olympia/compat/templates/compat/index.html:71
-#: src/olympia/zadmin/templates/zadmin/compat.html:67
+#: src/olympia/addons/templates/addons/macros.html:61 src/olympia/addons/templates/addons/impala/details.html:52 src/olympia/zadmin/templates/zadmin/compat.html:67
 msgid "{0} user"
 msgid_plural "{0} users"
 msgstr[0] "{0} потребител"
@@ -605,7 +606,7 @@ msgstr "Плащането завършено"
 msgid "Return to the addon."
 msgstr "Върни се към добавката."
 
-#: src/olympia/addons/templates/addons/persona_detail.html:17 src/olympia/addons/templates/addons/impala/details.html:106 src/olympia/addons/templates/addons/mobile/details.html:23
+#: src/olympia/addons/templates/addons/persona_detail.html:17 src/olympia/addons/templates/addons/impala/details.html:103 src/olympia/addons/templates/addons/mobile/details.html:23
 #: src/olympia/addons/templates/addons/mobile/persona_detail.html:21 src/olympia/discovery/templates/discovery/addons/base.html:27 src/olympia/editors/templates/editors/review.html:31
 msgid "by"
 msgstr "от"
@@ -649,34 +650,35 @@ msgstr "Дневни потребители"
 msgid "License"
 msgstr "Лиценз"
 
-#: src/olympia/addons/templates/addons/persona_preview.html:12 src/olympia/constants/base.py:48
+#: src/olympia/addons/templates/addons/persona_preview.html:13 src/olympia/constants/base.py:48
 msgid "Awaiting Review"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/persona_preview.html:14 src/olympia/amo/log.py:180 src/olympia/constants/base.py:42 src/olympia/editors/helpers.py:62
+#: src/olympia/addons/templates/addons/persona_preview.html:15 src/olympia/amo/log.py:180 src/olympia/constants/base.py:42 src/olympia/editors/helpers.py:62
 msgid "Rejected"
 msgstr "Отказан"
 
-#: src/olympia/addons/templates/addons/persona_preview.html:16 src/olympia/amo/log.py:159
+#: src/olympia/addons/templates/addons/persona_preview.html:17 src/olympia/amo/log.py:159
 msgid "Approved"
 msgstr "Одобрен"
 
 #. {0} is the number of users.
-#: src/olympia/addons/templates/addons/persona_preview.html:26 src/olympia/addons/templates/addons/listing/items_mobile.html:36 src/olympia/addons/templates/addons/listing/macros.html:31
+#: src/olympia/addons/templates/addons/persona_preview.html:27 src/olympia/addons/templates/addons/listing/items_mobile.html:36 src/olympia/addons/templates/addons/listing/macros.html:31
 msgid "<strong>{0}</strong> user"
 msgid_plural "<strong>{0}</strong> users"
 msgstr[0] "<strong>{0}</strong> потребител"
 msgstr[1] "<strong>{0}</strong> потребителя"
 
-#: src/olympia/addons/templates/addons/persona_preview.html:40
+#: src/olympia/addons/templates/addons/persona_preview.html:41
 msgid "Hover to Preview"
 msgstr "Сложи мишката отгоре за преглед"
 
-#: src/olympia/addons/templates/addons/persona_preview.html:46 src/olympia/addons/templates/addons/persona_preview.html:48 src/olympia/reviews/templates/reviews/add.html:15
+#: src/olympia/addons/templates/addons/persona_preview.html:47 src/olympia/addons/templates/addons/persona_preview.html:49 src/olympia/addons/templates/addons/persona_preview.html:97
+#: src/olympia/reviews/templates/reviews/add.html:15
 msgid "Add"
 msgstr "Добави"
 
-#: src/olympia/addons/templates/addons/persona_preview.html:57 src/olympia/bandwagon/templates/bandwagon/ajax_new.html:16 src/olympia/bandwagon/templates/bandwagon/edit.html:19
+#: src/olympia/addons/templates/addons/persona_preview.html:58 src/olympia/bandwagon/templates/bandwagon/ajax_new.html:16 src/olympia/bandwagon/templates/bandwagon/edit.html:19
 #: src/olympia/bandwagon/templates/bandwagon/includes/addedit.html:19 src/olympia/devhub/templates/devhub/addons/edit/admin.html:13 src/olympia/devhub/templates/devhub/addons/edit/basic.html:10
 #: src/olympia/devhub/templates/devhub/addons/edit/details.html:8 src/olympia/devhub/templates/devhub/addons/edit/media.html:6 src/olympia/devhub/templates/devhub/addons/edit/support.html:8
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:9 src/olympia/devhub/templates/devhub/addons/submit/describe.html:29 src/olympia/editors/templates/editors/review.html:257
@@ -685,21 +687,21 @@ msgstr "Редактирай"
 
 #. For datetime formatting, see the table on
 #. http://docs.python.org/library/datetime.html#strftime-and-strptime-behavior
-#: src/olympia/addons/templates/addons/persona_preview.html:66
+#: src/olympia/addons/templates/addons/persona_preview.html:67
 #, python-format
 msgid "%%Y-%%m-%%d"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/persona_preview.html:67
+#: src/olympia/addons/templates/addons/persona_preview.html:68
 msgid "by {0} on {1}"
 msgstr "от {0} на {1}"
 
-#: src/olympia/addons/templates/addons/persona_preview.html:75 src/olympia/reviews/helpers.py:17 src/olympia/reviews/templates/reviews/review_list.html:63
+#: src/olympia/addons/templates/addons/persona_preview.html:76 src/olympia/reviews/helpers.py:17 src/olympia/reviews/templates/reviews/review_list.html:63
 #: src/olympia/reviews/templates/reviews/reviews_link.html:21 src/olympia/reviews/templates/reviews/impala/reviews_link.html:16
 msgid "Not yet rated"
 msgstr "Все още неоценен"
 
-#: src/olympia/addons/templates/addons/persona_preview.html:78
+#: src/olympia/addons/templates/addons/persona_preview.html:79
 msgid "<b>{0}</b> users"
 msgstr "<b>{0}</b> потребители"
 
@@ -712,8 +714,8 @@ msgid "Learn more about Firefox"
 msgstr "Научи повече за Firefox"
 
 #: src/olympia/addons/templates/addons/popups.html:22
-msgid "or <b><a class=\"installer\" href=\"{url}\">download anyway</a></b>"
-msgstr "или <b><a class=\"installer\" href=\"{url}\">изтеглете</a></b>"
+msgid "or <b><a class=\"button installer\" href=\"{url}\">download anyway</a></b>"
+msgstr ""
 
 #: src/olympia/addons/templates/addons/popups.html:26
 msgid ""
@@ -804,11 +806,14 @@ msgid "QR code for add-on"
 msgstr "QR за добавка"
 
 #: src/olympia/addons/templates/addons/qr_code.html:6
-msgid "Want {0} on your mobile Firefox? Scan this QR code to install directly to your phone. (You'll need a QR reader. Search your phone's marketplace if don't have one.)"
-msgstr "Искате {0} на вашия мобилен irefox? Сканирайте този QR код, за да я инсталирате директно на вашия телефон. (Ще ви трябва QR четец. Потърсете в магазина на телефона си, ако нямате.)"
+msgid ""
+"Want {0} on your mobile Firefox?  Scan this QR code to install directly\n"
+"  to your phone.  (You'll need a QR reader.  Search your phone's marketplace if\n"
+"  don't have one.)"
+msgstr ""
 
 #: src/olympia/addons/templates/addons/report_abuse.html:6 src/olympia/addons/templates/addons/report_abuse_full.html:10 src/olympia/addons/templates/addons/impala/details-more.html:23
-#: src/olympia/addons/templates/addons/impala/details.html:328
+#: src/olympia/addons/templates/addons/impala/details.html:333
 msgid "Report Abuse"
 msgstr "Докладвай злоупотреба"
 
@@ -818,8 +823,8 @@ msgid ""
 "If you suspect this add-on violates <a href=\"%(url)s\">our policies</a> or has security or privacy issues, please use the form below to describe your concerns. Please do not use this form for any "
 "other reason."
 msgstr ""
-"Ако подозирате, че тази добавка нарушава <a href=\"%(url)s\">политиките ни</a> или има проблеми със сигурността или поверителността, моля използвайте формата отдолу, за да опишете загрижеността си."
-" Моля, не използвайте тази форма за други въпроси."
+"Ако подозирате, че тази добавка нарушава <a href=\"%(url)s\">политиките ни</a> или има проблеми със сигурността или поверителността, моля използвайте формата отдолу, за да опишете загрижеността си. "
+"Моля, не използвайте тази форма за други въпроси."
 
 #: src/olympia/addons/templates/addons/report_abuse.html:24 src/olympia/users/templates/users/report_abuse.html:19
 msgid "Send Report"
@@ -829,9 +834,9 @@ msgstr "Изпрати доклад"
 #: src/olympia/devhub/templates/devhub/addons/ajax_compat_update.html:36 src/olympia/devhub/templates/devhub/addons/profile.html:44 src/olympia/devhub/templates/devhub/addons/edit/admin.html:104
 #: src/olympia/devhub/templates/devhub/addons/edit/basic.html:155 src/olympia/devhub/templates/devhub/addons/edit/details.html:88 src/olympia/devhub/templates/devhub/addons/edit/support.html:70
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:169 src/olympia/devhub/templates/devhub/addons/forms_shared/media.html:152
-#: src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:44 src/olympia/devhub/templates/devhub/personas/edit.html:222 src/olympia/devhub/templates/devhub/versions/add_file_modal.html:79
-#: src/olympia/devhub/templates/devhub/versions/edit.html:140 src/olympia/devhub/templates/devhub/versions/list.html:208 src/olympia/devhub/templates/devhub/versions/list.html:242
-#: src/olympia/devhub/templates/devhub/versions/list.html:276 src/olympia/devhub/templates/devhub/versions/list.html:317 src/olympia/reviews/templates/reviews/edit_review.html:16
+#: src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:43 src/olympia/devhub/templates/devhub/personas/edit.html:222 src/olympia/devhub/templates/devhub/versions/add_file_modal.html:59
+#: src/olympia/devhub/templates/devhub/versions/edit.html:140 src/olympia/devhub/templates/devhub/versions/list.html:208 src/olympia/devhub/templates/devhub/versions/list.html:239
+#: src/olympia/devhub/templates/devhub/versions/list.html:281 src/olympia/devhub/templates/devhub/versions/list.html:315 src/olympia/reviews/templates/reviews/edit_review.html:16
 #: src/olympia/translations/templates/translations/trans-menu.html:50 src/olympia/translations/templates/translations/trans-menu.html:62 src/olympia/zadmin/templates/zadmin/validation.html:105
 msgid "Cancel"
 msgstr "Откажи"
@@ -876,7 +881,7 @@ msgstr "Вижте <a href=\"%(support)s\">секцията по поддръж�
 msgid "Review Guidelines"
 msgstr "Преглед на насоки"
 
-#: src/olympia/addons/templates/addons/review_list_box.html:5 src/olympia/addons/templates/addons/impala/details-more.html:27 src/olympia/editors/helpers.py:921
+#: src/olympia/addons/templates/addons/review_list_box.html:5 src/olympia/addons/templates/addons/impala/details-more.html:27 src/olympia/editors/helpers.py:1001
 #: src/olympia/reviews/templates/reviews/add.html:14 src/olympia/reviews/templates/reviews/reply.html:14 src/olympia/reviews/templates/reviews/review_list.html:19
 #: src/olympia/reviews/templates/reviews/mobile/review_list.html:26
 msgid "Reviews"
@@ -967,31 +972,31 @@ msgid_plural "Other add-ons by these authors"
 msgstr[0] "Други добавки от %(author)s"
 msgstr[1] "Други добавки от тези автори"
 
-#: src/olympia/addons/templates/addons/impala/details.html:41
+#: src/olympia/addons/templates/addons/impala/details.html:39
 #, python-format
 msgid "<span itemprop=\"ratingCount\">%(num)s</span> user review"
 msgid_plural "<span itemprop=\"ratingCount\">%(num)s</span> user reviews"
 msgstr[0] "<span itemprop=\"ratingCount\">%(num)s</span> потребителска рецензия"
 msgstr[1] "<span itemprop=\"ratingCount\">%(num)s</span> потребителски рецензии"
 
-#: src/olympia/addons/templates/addons/impala/details.html:69
+#: src/olympia/addons/templates/addons/impala/details.html:66
 msgid "View statistics"
 msgstr "Виж статистиките"
 
-#: src/olympia/addons/templates/addons/impala/details.html:84
+#: src/olympia/addons/templates/addons/impala/details.html:81
 msgid "Manage"
 msgstr "Управление"
 
 #. {0} is an add-on name.
-#: src/olympia/addons/templates/addons/impala/details.html:96
+#: src/olympia/addons/templates/addons/impala/details.html:93
 msgid "Icon of {0}"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/impala/details.html:103 src/olympia/addons/templates/addons/impala/listing/items.html:14
+#: src/olympia/addons/templates/addons/impala/details.html:100 src/olympia/addons/templates/addons/impala/listing/items.html:14
 msgid "No Restart"
 msgstr "Без рестарт"
 
-#: src/olympia/addons/templates/addons/impala/details.html:127
+#: src/olympia/addons/templates/addons/impala/details.html:124
 #, fuzzy, python-format
 msgid "Meet the Developer: <a href=\"%(url)s\">%(name)s</a>"
 msgid_plural "<a href=\"%(url)s\">Meet the Developers</a>"
@@ -999,88 +1004,88 @@ msgstr[0] "Запознай се с разработчика: <a href=\"%(url)s\
 msgstr[1] "<a href=\"%(url)s\">Запознай се с разработчиците</a>"
 
 # {0} is an add-on name.
-#: src/olympia/addons/templates/addons/impala/details.html:137
+#: src/olympia/addons/templates/addons/impala/details.html:134
 msgid "Learn why {0} was created and find out what's next for this add-on."
 msgstr "Научи защо {0} бе създадена и разбери какво следва за тази добавка."
 
 #. {0} is an index.
-#: src/olympia/addons/templates/addons/impala/details.html:156
+#: src/olympia/addons/templates/addons/impala/details.html:161
 msgid "Add-on screenshot #{0}"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/impala/details.html:182
+#: src/olympia/addons/templates/addons/impala/details.html:187
 msgid "Add-on home page"
 msgstr "Страница на добавката"
 
-#: src/olympia/addons/templates/addons/impala/details.html:185
+#: src/olympia/addons/templates/addons/impala/details.html:190
 msgid "Support site"
 msgstr "Сайт за поддръжка"
 
-#: src/olympia/addons/templates/addons/impala/details.html:189
+#: src/olympia/addons/templates/addons/impala/details.html:194
 msgid "Support E-mail"
 msgstr "Имейл за поддръжка"
 
-#: src/olympia/addons/templates/addons/impala/details.html:194 src/olympia/devhub/models.py:378 src/olympia/devhub/templates/devhub/versions/list.html:12
+#: src/olympia/addons/templates/addons/impala/details.html:199 src/olympia/devhub/models.py:378 src/olympia/devhub/templates/devhub/versions/list.html:12
 #: src/olympia/versions/templates/versions/version.html:6 src/olympia/versions/templates/versions/mobile/version.html:6
 msgid "Version {0}"
 msgstr "Версия {0}"
 
-#: src/olympia/addons/templates/addons/impala/details.html:194
+#: src/olympia/addons/templates/addons/impala/details.html:199
 msgid "Info"
 msgstr "Информация"
 
-#: src/olympia/addons/templates/addons/impala/details.html:195 src/olympia/devhub/templates/devhub/includes/addon_details.html:129
+#: src/olympia/addons/templates/addons/impala/details.html:200 src/olympia/devhub/templates/devhub/includes/addon_details.html:116
 msgid "Last Updated:"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/impala/details.html:200
+#: src/olympia/addons/templates/addons/impala/details.html:205
 #, python-format
 msgid "Released under <a target=\"_blank\" href=\"%(url)s\">%(name)s</a>"
 msgstr "Разпространява се под <a target=\"_blank\" href=\"%(url)s\">%(name)s</a>"
 
-#: src/olympia/addons/templates/addons/impala/details.html:201 src/olympia/addons/templates/addons/impala/details.html:206 src/olympia/amo/helpers.py:398 src/olympia/devhub/forms.py:142
+#: src/olympia/addons/templates/addons/impala/details.html:206 src/olympia/addons/templates/addons/impala/details.html:211 src/olympia/amo/helpers.py:398 src/olympia/devhub/forms.py:142
 #: src/olympia/devhub/forms.py:173 src/olympia/versions/templates/versions/version.html:40 src/olympia/versions/templates/versions/version.html:45
 msgid "Custom License"
 msgstr "Потребителски лиценз"
 
-#: src/olympia/addons/templates/addons/impala/details.html:205
+#: src/olympia/addons/templates/addons/impala/details.html:210
 #, python-format
 msgid "Released under <a href=\"%(url)s\">%(name)s</a>"
 msgstr "Пуснат под <a href=\"%(url)s\">%(name)s</a>"
 
-#: src/olympia/addons/templates/addons/impala/details.html:217
+#: src/olympia/addons/templates/addons/impala/details.html:222
 msgid "About this Add-on"
 msgstr "Относно тази добавка"
 
-#: src/olympia/addons/templates/addons/impala/details.html:233
+#: src/olympia/addons/templates/addons/impala/details.html:238
 msgid "Developer’s Comments"
 msgstr "Коментари на разработчика"
 
-#: src/olympia/addons/templates/addons/impala/details.html:243
+#: src/olympia/addons/templates/addons/impala/details.html:248
 msgid "Version Information"
 msgstr "Информация за версията"
 
-#: src/olympia/addons/templates/addons/impala/details.html:250
+#: src/olympia/addons/templates/addons/impala/details.html:255
 msgid "See complete version history"
 msgstr "Виж пълна история на версиите"
 
-#: src/olympia/addons/templates/addons/impala/details.html:262
+#: src/olympia/addons/templates/addons/impala/details.html:267
 msgid ""
 "The Development Channel lets you test an experimental new version of this add-on before it's released to the general public. Once you install the development version, you will continue to get "
 "updates from this channel. To stop receiving development updates, reinstall the default version from the link above."
 msgstr ""
 
-#: src/olympia/addons/templates/addons/impala/details.html:272
+#: src/olympia/addons/templates/addons/impala/details.html:277
 msgid "<strong>Caution:</strong> Development versions of this add-on have not been reviewed by Mozilla."
 msgstr ""
 
-#: src/olympia/addons/templates/addons/impala/details.html:287
+#: src/olympia/addons/templates/addons/impala/details.html:292
 msgid "See complete development channel history"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/impala/details.html:306 src/olympia/addons/templates/addons/impala/details.html:315 src/olympia/addons/templates/addons/impala/details.html:327
+#: src/olympia/addons/templates/addons/impala/details.html:311 src/olympia/addons/templates/addons/impala/details.html:320 src/olympia/addons/templates/addons/impala/details.html:332
 #: src/olympia/addons/templates/addons/impala/review_add_box.html:4 src/olympia/stats/templates/stats/popup.html:2 src/olympia/stats/templates/stats/popup.html:8
-#: src/olympia/stats/templates/stats/stats.html:202 src/olympia/users/templates/users/profile.html:119
+#: src/olympia/stats/templates/stats/stats.html:204 src/olympia/users/templates/users/profile.html:119
 msgid "close"
 msgstr "затвори"
 
@@ -1139,15 +1144,11 @@ msgstr "Лиценз на изходния код за {addon}"
 msgid "Source Code License"
 msgstr "Лиценз на изходния код"
 
-#: src/olympia/addons/templates/addons/impala/persona_grid.html:16 src/olympia/addons/templates/addons/impala/toplist.html:6
-msgid "{0} users"
-msgstr "{0} потребителя"
-
 #: src/olympia/addons/templates/addons/impala/review_list_box.html:19 src/olympia/reviews/templates/reviews/review.html:40
 msgid "permalink"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/impala/review_list_box.html:23 src/olympia/editors/templates/editors/queue.html:98 src/olympia/reviews/templates/reviews/review.html:44
+#: src/olympia/addons/templates/addons/impala/review_list_box.html:23 src/olympia/editors/templates/editors/queue.html:104 src/olympia/reviews/templates/reviews/review.html:44
 msgid "translate"
 msgstr ""
 
@@ -1166,6 +1167,10 @@ msgstr "Тази добавка все още не е прегледана."
 msgid "Be the first!"
 msgstr "Бъдете първи!"
 
+#: src/olympia/addons/templates/addons/impala/toplist.html:6
+msgid "{0} users"
+msgstr "{0} потребителя"
+
 #: src/olympia/addons/templates/addons/impala/listing/sorter.html:14 src/olympia/devhub/templates/devhub/addons/listing/item_actions.html:49
 msgid "More"
 msgstr "Още"
@@ -1178,7 +1183,7 @@ msgstr "Добави към колекция"
 msgid "My Add-ons"
 msgstr "Моите добавки"
 
-#: src/olympia/addons/templates/addons/includes/dashboard_tabs.html:6 src/olympia/amo/context_processors.py:51
+#: src/olympia/addons/templates/addons/includes/dashboard_tabs.html:6 src/olympia/amo/context_processors.py:50
 msgid "My Themes"
 msgstr ""
 
@@ -1233,7 +1238,7 @@ msgstr "Потребители"
 msgid "Weekly Downloads"
 msgstr "Седмични сваляния"
 
-#: src/olympia/addons/templates/addons/mobile/details.html:99 src/olympia/compat/templates/compat/reporter_detail.html:46 src/olympia/devhub/forms.py:787
+#: src/olympia/addons/templates/addons/mobile/details.html:99 src/olympia/compat/templates/compat/reporter_detail.html:46 src/olympia/devhub/forms.py:788
 #: src/olympia/devhub/templates/devhub/versions/list.html:163
 msgid "Version"
 msgstr "Версия"
@@ -1290,8 +1295,9 @@ msgid "Return to the {0} Add-ons homepage"
 msgstr "Върни се към началната страница на {0}"
 
 #: src/olympia/addons/templates/addons/mobile/home.html:21 src/olympia/amo/helpers.py:237 src/olympia/bandwagon/templates/bandwagon/edit.html:34 src/olympia/discovery/templates/discovery/pane.html:92
-#: src/olympia/editors/templates/editors/base.html:21 src/olympia/editors/templates/editors/performance.html:72 src/olympia/templates/menu_links.html:4 src/olympia/templates/impala/header_title.html:13
-#: src/olympia/templates/impala/header_title.html:15 src/olympia/templates/impala/header_title.html:19 src/olympia/templates/impala/header_title.html:23 src/olympia/templates/mobile/base_addons.html:47
+#: src/olympia/editors/templates/editors/base.html:21 src/olympia/editors/templates/editors/performance.html:72 src/olympia/templates/menu_links.html:4
+#: src/olympia/templates/impala/header_title.html:13 src/olympia/templates/impala/header_title.html:15 src/olympia/templates/impala/header_title.html:19
+#: src/olympia/templates/impala/header_title.html:23 src/olympia/templates/mobile/base_addons.html:47
 msgid "Add-ons"
 msgstr "Добавки"
 
@@ -1312,11 +1318,12 @@ msgstr ""
 
 #. {0} is a category name. Ex: "Sports"
 #. {0} is a category name, such as Nature.
-#: src/olympia/addons/templates/addons/mobile/home.html:43 src/olympia/amo/templates/amo/site_nav.html:32 src/olympia/browse/feeds.py:107 src/olympia/browse/templates/browse/impala/base_listing.html:38
-#: src/olympia/browse/templates/browse/personas/base.html:6 src/olympia/browse/templates/browse/personas/base.html:42 src/olympia/browse/templates/browse/personas/category_landing.html:21
-#: src/olympia/browse/templates/browse/personas/category_landing.html:23 src/olympia/browse/templates/browse/personas/category_landing.html:38 src/olympia/browse/templates/browse/personas/grid.html:7
-#: src/olympia/browse/templates/browse/personas/grid.html:11 src/olympia/browse/templates/browse/personas/mobile/base.html:7 src/olympia/browse/templates/browse/personas/mobile/category_landing.html:19
-#: src/olympia/constants/base.py:180 src/olympia/devhub/templates/devhub/personas/submit.html:13 src/olympia/editors/helpers.py:105 src/olympia/editors/templates/editors/base.html:26
+#: src/olympia/addons/templates/addons/mobile/home.html:43 src/olympia/amo/templates/amo/site_nav.html:32 src/olympia/browse/feeds.py:107
+#: src/olympia/browse/templates/browse/impala/base_listing.html:38 src/olympia/browse/templates/browse/personas/base.html:6 src/olympia/browse/templates/browse/personas/base.html:42
+#: src/olympia/browse/templates/browse/personas/category_landing.html:21 src/olympia/browse/templates/browse/personas/category_landing.html:23
+#: src/olympia/browse/templates/browse/personas/category_landing.html:38 src/olympia/browse/templates/browse/personas/grid.html:7 src/olympia/browse/templates/browse/personas/grid.html:11
+#: src/olympia/browse/templates/browse/personas/mobile/base.html:7 src/olympia/browse/templates/browse/personas/mobile/category_landing.html:19 src/olympia/constants/base.py:180
+#: src/olympia/devhub/templates/devhub/personas/submit.html:13 src/olympia/editors/helpers.py:107 src/olympia/editors/templates/editors/base.html:26
 #: src/olympia/editors/templates/editors/performance.html:73 src/olympia/search/templates/search/personas.html:39 src/olympia/templates/menu_links.html:9
 msgid "Themes"
 msgstr "Теми"
@@ -1337,7 +1344,7 @@ msgstr "Още добавки"
 msgid "Highest Rated"
 msgstr "Най-високо оценени"
 
-#: src/olympia/addons/templates/addons/mobile/home.html:74 src/olympia/amo/templates/amo/side_nav.html:5 src/olympia/amo/templates/amo/site_nav.html:27 src/olympia/amo/templates/amo/site_nav.html:57
+#: src/olympia/addons/templates/addons/mobile/home.html:74 src/olympia/amo/templates/amo/side_nav.html:5 src/olympia/amo/templates/amo/site_nav.html:27 src/olympia/amo/templates/amo/site_nav.html:55
 #: src/olympia/bandwagon/views.py:97 src/olympia/browse/views.py:57 src/olympia/browse/views.py:67 src/olympia/browse/templates/browse/personas/mobile/category_landing.html:65
 #: src/olympia/search/forms.py:15 src/olympia/search/forms.py:87
 msgid "Newest"
@@ -1351,88 +1358,90 @@ msgstr "Пробайте я!"
 msgid "Theme Info &raquo;"
 msgstr ""
 
-#: src/olympia/amo/context_processors.py:39 src/olympia/devhub/templates/devhub/nav.html:43
+#: src/olympia/amo/context_processors.py:37 src/olympia/devhub/templates/devhub/nav.html:43
 msgid "Tools"
 msgstr "Инструменти"
 
-#: src/olympia/amo/context_processors.py:48 src/olympia/discovery/templates/discovery/pane_account.html:8 src/olympia/users/templates/users/includes/navigation.html:2
+#: src/olympia/amo/context_processors.py:47 src/olympia/discovery/templates/discovery/pane_account.html:8 src/olympia/users/templates/users/includes/navigation.html:2
 msgid "My Profile"
 msgstr "Моят профил"
 
-#: src/olympia/amo/context_processors.py:54 src/olympia/users/templates/users/edit.html:5 src/olympia/users/templates/users/includes/navigation.html:3
+#: src/olympia/amo/context_processors.py:53 src/olympia/users/templates/users/edit.html:5 src/olympia/users/templates/users/includes/navigation.html:3
 msgid "Account Settings"
 msgstr "Настройки на акаунта"
 
-#: src/olympia/amo/context_processors.py:57 src/olympia/discovery/templates/discovery/pane_account.html:11 src/olympia/users/templates/users/profile.html:83
+#: src/olympia/amo/context_processors.py:56 src/olympia/discovery/templates/discovery/pane_account.html:11 src/olympia/users/templates/users/profile.html:83
 #: src/olympia/users/templates/users/includes/navigation.html:4
 msgid "My Collections"
 msgstr "Моите колекции"
 
-#: src/olympia/amo/context_processors.py:62 src/olympia/discovery/templates/discovery/pane_account.html:10 src/olympia/users/templates/users/includes/navigation.html:7
+#: src/olympia/amo/context_processors.py:61 src/olympia/discovery/templates/discovery/pane_account.html:10 src/olympia/users/templates/users/includes/navigation.html:7
 msgid "My Favorites"
 msgstr "Моите любими"
 
-#: src/olympia/amo/context_processors.py:67 src/olympia/discovery/templates/discovery/pane_account.html:13 src/olympia/templates/impala/user_login.html:14 src/olympia/templates/mobile/header_auth.html:5
+#: src/olympia/amo/context_processors.py:66 src/olympia/discovery/templates/discovery/pane_account.html:13 src/olympia/templates/impala/user_login.html:14
+#: src/olympia/templates/mobile/header_auth.html:5
 msgid "Log out"
 msgstr "Изход"
 
-#: src/olympia/amo/context_processors.py:72 src/olympia/devhub/templates/devhub/addons/dashboard.html:4
+#: src/olympia/amo/context_processors.py:71 src/olympia/devhub/templates/devhub/addons/dashboard.html:4
 msgid "Manage My Submissions"
 msgstr "Управление на моите творения"
 
-#: src/olympia/amo/context_processors.py:75 src/olympia/devhub/templates/devhub/nav.html:27 src/olympia/devhub/templates/devhub/addons/dashboard.html:25
+#: src/olympia/amo/context_processors.py:74 src/olympia/devhub/templates/devhub/nav.html:27 src/olympia/devhub/templates/devhub/addons/dashboard.html:25
 #: src/olympia/devhub/templates/devhub/addons/submit/base.html:4
 msgid "Submit a New Add-on"
 msgstr "Прати нова добавка"
 
-#: src/olympia/amo/context_processors.py:77 src/olympia/browse/templates/browse/personas/base.html:50 src/olympia/devhub/templates/devhub/index.html:24
+#: src/olympia/amo/context_processors.py:76 src/olympia/browse/templates/browse/personas/base.html:50 src/olympia/devhub/templates/devhub/index.html:24
 #: src/olympia/devhub/templates/devhub/addons/dashboard.html:29
 msgid "Submit a New Theme"
 msgstr "Качи тема"
 
-#: src/olympia/amo/context_processors.py:79 src/olympia/amo/templates/amo/site_nav.html:87 src/olympia/devhub/helpers.py:36 src/olympia/devhub/helpers.py:68 src/olympia/devhub/helpers.py:102
+#: src/olympia/amo/context_processors.py:78 src/olympia/amo/templates/amo/site_nav.html:85 src/olympia/devhub/helpers.py:36 src/olympia/devhub/helpers.py:68 src/olympia/devhub/helpers.py:102
 #: src/olympia/templates/footer.html:6 src/olympia/templates/menu_links.html:14
 msgid "Developer Hub"
 msgstr "Център за разработчици"
 
-#: src/olympia/amo/context_processors.py:83 src/olympia/devhub/views.py:1792
+#: src/olympia/amo/context_processors.py:81 src/olympia/devhub/views.py:1796
 msgid "Manage API Keys"
 msgstr ""
 
-#: src/olympia/amo/context_processors.py:88 src/olympia/editors/helpers.py:82 src/olympia/editors/helpers.py:102 src/olympia/editors/templates/editors/base.html:10
+#: src/olympia/amo/context_processors.py:86 src/olympia/editors/helpers.py:84 src/olympia/editors/helpers.py:104 src/olympia/editors/templates/editors/base.html:10
 msgid "Editor Tools"
 msgstr "Редакторски инструменти"
 
-#: src/olympia/amo/context_processors.py:92
+#: src/olympia/amo/context_processors.py:90
 msgid "Admin Tools"
 msgstr "Администраторски инструменти"
 
-#: src/olympia/amo/fields.py:15
+#: src/olympia/amo/fields.py:20
 msgid "Incorrect, please try again."
 msgstr ""
 
-#: src/olympia/amo/fields.py:16
+#: src/olympia/amo/fields.py:21
 msgid "Error verifying input, please try again."
 msgstr ""
 
-#: src/olympia/amo/fields.py:32
+#: src/olympia/amo/fields.py:37
 msgid "This must be a valid hex color code, such as #000000."
 msgstr "Това трябва да е валиден шестнадесетичен код за цвят, например #000000."
 
-#: src/olympia/amo/fields.py:58
+#: src/olympia/amo/fields.py:63
 msgid "Enter at least one value."
 msgstr ""
 
-#: src/olympia/amo/helpers.py:162 src/olympia/amo/templates/amo/site_nav.html:61 src/olympia/bandwagon/templates/bandwagon/add.html:9 src/olympia/bandwagon/templates/bandwagon/collection_detail.html:15
-#: src/olympia/bandwagon/templates/bandwagon/delete.html:9 src/olympia/bandwagon/templates/bandwagon/edit.html:15 src/olympia/bandwagon/templates/bandwagon/user_listing.html:18
-#: src/olympia/bandwagon/templates/bandwagon/user_listing.html:21 src/olympia/bandwagon/templates/bandwagon/impala/collection_listing.html:12
-#: src/olympia/bandwagon/templates/bandwagon/impala/collection_listing.html:20 src/olympia/bandwagon/templates/bandwagon/impala/collection_listing.html:24
-#: src/olympia/bandwagon/templates/bandwagon/impala/collection_sidebar.html:3 src/olympia/bandwagon/templates/bandwagon/includes/collection_sidebar.html:2
-#: src/olympia/bandwagon/templates/bandwagon/mobile/collection_listing.html:3 src/olympia/stats/templates/stats/stats.html:77 src/olympia/templates/menu_links.html:12
+#: src/olympia/amo/helpers.py:162 src/olympia/amo/templates/amo/site_nav.html:59 src/olympia/bandwagon/templates/bandwagon/add.html:9
+#: src/olympia/bandwagon/templates/bandwagon/collection_detail.html:15 src/olympia/bandwagon/templates/bandwagon/delete.html:9 src/olympia/bandwagon/templates/bandwagon/edit.html:15
+#: src/olympia/bandwagon/templates/bandwagon/user_listing.html:18 src/olympia/bandwagon/templates/bandwagon/user_listing.html:21
+#: src/olympia/bandwagon/templates/bandwagon/impala/collection_listing.html:12 src/olympia/bandwagon/templates/bandwagon/impala/collection_listing.html:20
+#: src/olympia/bandwagon/templates/bandwagon/impala/collection_listing.html:24 src/olympia/bandwagon/templates/bandwagon/impala/collection_sidebar.html:3
+#: src/olympia/bandwagon/templates/bandwagon/includes/collection_sidebar.html:2 src/olympia/bandwagon/templates/bandwagon/mobile/collection_listing.html:3
+#: src/olympia/stats/templates/stats/stats.html:33 src/olympia/templates/menu_links.html:12
 msgid "Collections"
 msgstr "Колекции"
 
-#: src/olympia/amo/helpers.py:171 src/olympia/amo/templates/amo/site_nav.html:85 src/olympia/browse/templates/browse/language_tools.html:3
+#: src/olympia/amo/helpers.py:171 src/olympia/amo/templates/amo/site_nav.html:83 src/olympia/browse/templates/browse/language_tools.html:3
 msgid "Dictionaries & Language Packs"
 msgstr "Речници & Езикови пакети"
 
@@ -1584,8 +1593,8 @@ msgstr "Супер рецензия поискана"
 msgid "Comment on {addon} {version}."
 msgstr "Коментар на {addon} {version}."
 
-#: src/olympia/amo/log.py:236 src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:19 src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:47
-#: src/olympia/editors/helpers.py:511 src/olympia/editors/templates/editors/themes/history_table.html:11
+#: src/olympia/amo/log.py:236 src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:17 src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:45
+#: src/olympia/editors/helpers.py:584 src/olympia/editors/templates/editors/themes/history_table.html:11
 msgid "Comment"
 msgstr "Коментар"
 
@@ -1874,18 +1883,18 @@ msgstr "Не е намерен"
 #, python-format
 msgid ""
 "<h1>We're sorry, but we can't find what you're looking for.</h1> <p> The page or file you requested wasn't found on our site. It's possible that you clicked a link that's out of date, or typed in "
-"the address incorrectly. </p> <ul> <li>If you typed in the address, please double check the spelling.</li> <li> If you followed a link from somewhere, please let us know at <a "
-"href=\"mailto:webmaster@mozilla.com\">webmaster@mozilla.com</a>. Tell us where you came from and what you were looking for, and we'll do our best to fix it. </li> </ul> <p>Or you can just jump over"
-" to some of the popular pages on our website.</p> <ul> <li>Are you interested in a <a href=\"%(rec)s\">list of featured add-ons</a>?</li> <li> Do you want to <a href=\"%(search)s\">search for add-"
-"ons</a>? You may go to the <a href=\"%(search)s\">search page</a> or just use the search field above. </li> <li> If you prefer to start over, just go to the <a href=\"%(home)s\">add-ons front "
-"page</a>. </li> </ul>"
+"the address incorrectly. </p> <ul> <li>If you typed in the address, please double check the spelling.</li> <li> If you followed a link from somewhere, please let us know at <a href=\"mailto:"
+"webmaster@mozilla.com\">webmaster@mozilla.com</a>. Tell us where you came from and what you were looking for, and we'll do our best to fix it. </li> </ul> <p>Or you can just jump over to some of "
+"the popular pages on our website.</p> <ul> <li>Are you interested in a <a href=\"%(rec)s\">list of featured add-ons</a>?</li> <li> Do you want to <a href=\"%(search)s\">search for add-ons</a>? You "
+"may go to the <a href=\"%(search)s\">search page</a> or just use the search field above. </li> <li> If you prefer to start over, just go to the <a href=\"%(home)s\">add-ons front page</a>. </li> </"
+"ul>"
 msgstr ""
 "<h1>Съжаляваме, но не можем да намерим това, което търсите.</h1> <p> Страницата или файлът, който сте поискали не бе намерен на нашия сайт. Възможно е да сте кликнали остаряла връзка или да сте "
-"написали адреса грешно. </p> <ul> <li>Ако сте написали адреса, моля проверете пак дали е правилно написан.</li> <li> Ако сте последвали връзка от някъде, моля кажете ни на <a "
-"href=\"mailto:webmaster@mozilla.com\">webmaster@mozilla.com</a>. Кажете ни от къде дойдохте и какво търсихте, и ние ще направим всичко възможно, за да го оправим. </li> </ul> <p>Или може просто да "
-"прескочите към някои от по-известните страници на сайта ни.</p> <ul> <li>Интересувате ли се от <a href=\"%(rec)s\">списък с препоръчани добавки</a>?</li> <li> Искате ли да <a "
-"href=\"%(search)s\">търсите добавки</a>? Можете да отидете на <a href=\"%(search)s\">страницата за търсене</a> или просто да използвате полето отгоре. </li> <li> Ако предпочитате да започнете "
-"отначало, просто отидете на <a href=\"%(home)s\">главната страница на добавките</a>. </li> </ul>"
+"написали адреса грешно. </p> <ul> <li>Ако сте написали адреса, моля проверете пак дали е правилно написан.</li> <li> Ако сте последвали връзка от някъде, моля кажете ни на <a href=\"mailto:"
+"webmaster@mozilla.com\">webmaster@mozilla.com</a>. Кажете ни от къде дойдохте и какво търсихте, и ние ще направим всичко възможно, за да го оправим. </li> </ul> <p>Или може просто да прескочите към "
+"някои от по-известните страници на сайта ни.</p> <ul> <li>Интересувате ли се от <a href=\"%(rec)s\">списък с препоръчани добавки</a>?</li> <li> Искате ли да <a href=\"%(search)s\">търсите добавки</"
+"a>? Можете да отидете на <a href=\"%(search)s\">страницата за търсене</a> или просто да използвате полето отгоре. </li> <li> Ако предпочитате да започнете отначало, просто отидете на <a href="
+"\"%(home)s\">главната страница на добавките</a>. </li> </ul>"
 
 #: src/olympia/amo/templates/amo/500.html:3
 msgid "Oops"
@@ -1893,8 +1902,8 @@ msgstr "Опаа"
 
 #: src/olympia/amo/templates/amo/500.html:6
 #, python-format
-msgid "<h1>Oops! We had an error.</h1> <p>We'll get to fixing that soon.</p> <p> You can try refreshing the page, or head back to the <a href=\"%(home)s\">Add-ons homepage</a>. </p>"
-msgstr "<h1>Опаа! Стана грешка.</h1> <p>Ще се заемем с оправянето ѝ скоро.</p> <p> Може да опитате да обновите страницата или да се върнете към <a href=\"%(home)s\">началната страница на Добавки</a>. </p>"
+msgid "<h1>Oops!  We had an error.</h1> <p>We'll get to fixing that soon.</p> <p> You can try refreshing the page, or head back to the <a href=\"%(home)s\">Add-ons homepage</a>. </p>"
+msgstr ""
 
 #: src/olympia/amo/templates/amo/license_link.html:10
 msgid "Some rights reserved"
@@ -1916,7 +1925,7 @@ msgstr "Пред"
 #: src/olympia/amo/templates/amo/mobile/paginator.html:14 src/olympia/amo/templates/amo/mobile/paginator.html:16 src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:51
 #: src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:65 src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:78
 #: src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:91 src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:104
-#: src/olympia/discovery/templates/discovery/pane.html:45 src/olympia/discovery/templates/discovery/addons/detail.html:39 src/olympia/stats/templates/stats/stats.html:167
+#: src/olympia/discovery/templates/discovery/pane.html:45 src/olympia/discovery/templates/discovery/addons/detail.html:39 src/olympia/stats/templates/stats/stats.html:169
 msgid "Next"
 msgstr "Следващ"
 
@@ -1948,7 +1957,7 @@ msgid ""
 msgstr ""
 
 #: src/olympia/amo/templates/amo/side_nav.html:4 src/olympia/amo/templates/amo/side_nav.html:12 src/olympia/amo/templates/amo/site_nav.html:4 src/olympia/amo/templates/amo/site_nav.html:26
-#: src/olympia/browse/views.py:56 src/olympia/browse/views.py:66 src/olympia/browse/views.py:237 src/olympia/browse/views.py:282 src/olympia/search/forms.py:86
+#: src/olympia/browse/views.py:56 src/olympia/browse/views.py:66 src/olympia/browse/views.py:204 src/olympia/browse/views.py:249 src/olympia/search/forms.py:86
 msgid "Top Rated"
 msgstr "Най-високо оценени"
 
@@ -1963,37 +1972,38 @@ msgstr "Разглеждане"
 msgid "Extensions"
 msgstr "Разширения"
 
-#: src/olympia/amo/templates/amo/site_nav.html:45
+#: src/olympia/amo/templates/amo/site_nav.html:44
 msgid "Want more customization? Try <b>Complete Themes</b>"
 msgstr ""
 
-#: src/olympia/amo/templates/amo/site_nav.html:56 src/olympia/bandwagon/views.py:96
+#: src/olympia/amo/templates/amo/site_nav.html:54 src/olympia/bandwagon/views.py:96
 msgid "Most Followers"
 msgstr "Най-много последователи"
 
-#: src/olympia/amo/templates/amo/site_nav.html:68 src/olympia/bandwagon/templates/bandwagon/impala/collection_sidebar.html:16 src/olympia/bandwagon/templates/bandwagon/includes/collection_sidebar.html:18
+#: src/olympia/amo/templates/amo/site_nav.html:66 src/olympia/bandwagon/templates/bandwagon/impala/collection_sidebar.html:16
+#: src/olympia/bandwagon/templates/bandwagon/includes/collection_sidebar.html:18
 msgid "Collections I've Made"
 msgstr "Колекции, които съм направил"
 
-#: src/olympia/amo/templates/amo/site_nav.html:70 src/olympia/bandwagon/templates/bandwagon/user_listing.html:4 src/olympia/bandwagon/templates/bandwagon/impala/collection_sidebar.html:13
+#: src/olympia/amo/templates/amo/site_nav.html:68 src/olympia/bandwagon/templates/bandwagon/user_listing.html:4 src/olympia/bandwagon/templates/bandwagon/impala/collection_sidebar.html:13
 #: src/olympia/bandwagon/templates/bandwagon/includes/collection_sidebar.html:15
 msgid "Collections I'm Following"
 msgstr "Колекции, които следвам"
 
-#: src/olympia/amo/templates/amo/site_nav.html:73 src/olympia/bandwagon/templates/bandwagon/impala/collection_sidebar.html:18 src/olympia/bandwagon/templates/bandwagon/includes/collection_sidebar.html:20
-#: src/olympia/users/models.py:512
+#: src/olympia/amo/templates/amo/site_nav.html:71 src/olympia/bandwagon/templates/bandwagon/impala/collection_sidebar.html:18
+#: src/olympia/bandwagon/templates/bandwagon/includes/collection_sidebar.html:20 src/olympia/users/models.py:521
 msgid "My Favorite Add-ons"
 msgstr "Моите любими добавки"
 
-#: src/olympia/amo/templates/amo/site_nav.html:78
+#: src/olympia/amo/templates/amo/site_nav.html:76
 msgid "More&hellip;"
 msgstr "Още&hellip;"
 
-#: src/olympia/amo/templates/amo/site_nav.html:82
+#: src/olympia/amo/templates/amo/site_nav.html:80
 msgid "Add-ons for Mobile"
 msgstr "Добавки за мобилни"
 
-#: src/olympia/amo/templates/amo/site_nav.html:86 src/olympia/browse/feeds.py:207 src/olympia/browse/templates/browse/search_tools.html:3 src/olympia/constants/base.py:176
+#: src/olympia/amo/templates/amo/site_nav.html:84 src/olympia/browse/feeds.py:207 src/olympia/browse/templates/browse/search_tools.html:3 src/olympia/constants/base.py:176
 #: src/olympia/templates/menu_links.html:10
 msgid "Search Tools"
 msgstr "Инструменти за търсене"
@@ -2009,7 +2019,7 @@ msgid "Jump to first page"
 msgstr "Скочи на първата страница"
 
 #: src/olympia/amo/templates/amo/impala/paginator.html:22 src/olympia/amo/templates/amo/mobile/impala_paginator.html:12 src/olympia/discovery/templates/discovery/pane.html:44
-#: src/olympia/discovery/templates/discovery/addons/detail.html:38 src/olympia/stats/templates/stats/stats.html:164
+#: src/olympia/discovery/templates/discovery/addons/detail.html:38 src/olympia/stats/templates/stats/stats.html:166
 msgid "Previous"
 msgstr "Предишен"
 
@@ -2032,31 +2042,50 @@ msgid_plural "Page {n}"
 msgstr[0] "Страница {n}"
 msgstr[1] "Страница {n}"
 
-#: src/olympia/amo/templates/services/install.html:38
-#, python-format
-msgid "If you are not prompted to install %(addon_name)s in a moment, please <a href=\"%(addon_xpi)s\">click here</a>."
-msgstr "Ако не сте запитани да инсталирате %(addon_name)s след малко, моля <a href=\"%(addon_xpi)s\">кликнете тук</a>."
-
-#: src/olympia/amo/tests/test_messages.py:57 src/olympia/amo/tests/test_messages.py:58 src/olympia/reviews/forms.py:25 src/olympia/reviews/forms.py:50 src/olympia/reviews/templates/reviews/add.html:56
+#: src/olympia/amo/tests/test_messages.py:56 src/olympia/amo/tests/test_messages.py:57 src/olympia/reviews/forms.py:25 src/olympia/reviews/forms.py:50 src/olympia/reviews/templates/reviews/add.html:56
 #: src/olympia/reviews/templates/reviews/reply.html:30
 msgid "Title"
 msgstr "Заглавие"
 
-#: src/olympia/amo/tests/test_messages.py:57 src/olympia/amo/tests/test_messages.py:58
+#: src/olympia/amo/tests/test_messages.py:56 src/olympia/amo/tests/test_messages.py:57
 msgid "Body"
 msgstr ""
 
-#: src/olympia/amo/tests/test_messages.py:59
+#: src/olympia/amo/tests/test_messages.py:58
 msgid "Another Title"
 msgstr ""
 
-#: src/olympia/amo/tests/test_messages.py:59
+#: src/olympia/amo/tests/test_messages.py:58
 msgid "Another Body"
 msgstr ""
 
-#: src/olympia/api/views.py:255
-msgid "Not implemented yet."
-msgstr "Не е приложено все още."
+#: src/olympia/api/authentication.py:76
+msgid "Signature has expired."
+msgstr ""
+
+#: src/olympia/api/authentication.py:79
+msgid "Error decoding signature."
+msgstr ""
+
+#: src/olympia/api/authentication.py:82
+msgid "Invalid JWT Token."
+msgstr ""
+
+#: src/olympia/api/authentication.py:130
+msgid "Invalid Authorization header. No credentials provided."
+msgstr ""
+
+#: src/olympia/api/authentication.py:133
+msgid "Invalid Authorization header. Credentials string should not contain spaces."
+msgstr ""
+
+#: src/olympia/api/fields.py:29
+msgid "The field must have a length of at least {num} characters."
+msgstr ""
+
+#: src/olympia/api/fields.py:31
+msgid "The language code {lang_code} is invalid."
+msgstr ""
 
 #: src/olympia/applications/views.py:39 src/olympia/applications/templates/applications/appversions.html:3
 msgid "Application Versions"
@@ -2074,7 +2103,7 @@ msgstr "Валидни версии на приложения"
 msgid "Add-ons submitted to Mozilla Add-ons must have a manifest file with at least one of the below applications supported. Only the versions listed below are allowed for these applications."
 msgstr ""
 
-#: src/olympia/applications/templates/applications/appversions.html:25
+#: src/olympia/applications/templates/applications/appversions.html:25 src/olympia/editors/helpers.py:361
 msgid "GUID"
 msgstr "GUID"
 
@@ -2188,8 +2217,8 @@ msgstr "Любим"
 msgid "Remove from favorites"
 msgstr "Премахни от любими"
 
-#: src/olympia/bandwagon/views.py:98 src/olympia/bandwagon/views.py:191 src/olympia/browse/views.py:58 src/olympia/browse/views.py:69 src/olympia/browse/views.py:458 src/olympia/devhub/views.py:74
-#: src/olympia/devhub/views.py:82 src/olympia/devhub/templates/devhub/addons/edit/basic.html:20 src/olympia/editors/templates/editors/leaderboard.html:24
+#: src/olympia/bandwagon/views.py:98 src/olympia/bandwagon/views.py:191 src/olympia/browse/views.py:58 src/olympia/browse/views.py:69 src/olympia/browse/views.py:425 src/olympia/devhub/views.py:72
+#: src/olympia/devhub/views.py:80 src/olympia/devhub/templates/devhub/addons/edit/basic.html:20 src/olympia/editors/templates/editors/leaderboard.html:24
 #: src/olympia/editors/templates/editors/themes/queue_list.html:48 src/olympia/search/forms.py:17 src/olympia/search/forms.py:89 src/olympia/users/templates/users/vcard.html:5
 msgid "Name"
 msgstr "Име"
@@ -2198,7 +2227,7 @@ msgstr "Име"
 msgid "Recently Popular"
 msgstr "Популярни наскоро"
 
-#: src/olympia/bandwagon/views.py:189 src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:18
+#: src/olympia/bandwagon/views.py:189 src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:16
 msgid "Added"
 msgstr "Добавено"
 
@@ -2212,7 +2241,7 @@ msgstr "Колекцията създадена!"
 
 #: src/olympia/bandwagon/views.py:316
 #, python-format
-msgid "Your new collection is shown below. You can <ahref=\"%(url)s\">edit additional settings</a> if you'dlike."
+msgid "Your new collection is shown below. You can <a href=\"%(url)s\">edit additional settings</a> if you'd like."
 msgstr ""
 
 #: src/olympia/bandwagon/views.py:322
@@ -2340,8 +2369,8 @@ msgid_plural "%(num)s Add-ons in this Collection"
 msgstr[0] "%(num)s добавка в тази колекция"
 msgstr[1] "%(num)s добавки в тази колекция"
 
-#: src/olympia/bandwagon/templates/bandwagon/collection_detail.html:125 src/olympia/compat/templates/compat/index.html:25 src/olympia/compat/templates/compat/reporter_detail.html:29
-#: src/olympia/files/templates/files/viewer.html:29 src/olympia/templates/amo_footer.html:17 src/olympia/templates/includes/lang_switcher.html:10
+#: src/olympia/bandwagon/templates/bandwagon/collection_detail.html:125 src/olympia/compat/templates/compat/reporter_detail.html:29 src/olympia/files/templates/files/viewer.html:29
+#: src/olympia/templates/amo_footer.html:17 src/olympia/templates/includes/lang_switcher.html:10
 msgid "Go"
 msgstr "Давай"
 
@@ -2375,11 +2404,9 @@ msgstr ""
 
 #: src/olympia/bandwagon/templates/bandwagon/collection_detail.html:186
 msgid ""
-"Add-ons that you mark as favorites using the <b>Add to Favorites</b> feature appear below. This collection is currently <b>private</b>, which means only you can see it. If you would like everyone "
+"Add-ons that you mark as favorites using the <b>Add to Favorites</b> feature appear below. This collection is currently <b>private</b>, which means only you can see it.  If you would like everyone "
 "to be able to see your favorites, click the button below to make it public."
 msgstr ""
-"Добавките, които маркирате като любими, използвайки функцията <b>Доабви в Любими</b>, се показват отдолу. В момента тази колекция е <b>лична</b>, което означава, че само вие я виждате. Ако искате "
-"всеки да може да вижда любимите ви, кликнете бутона отдолу, за да я направите публична."
 
 #: src/olympia/bandwagon/templates/bandwagon/collection_detail.html:196
 msgid "My favorite add-ons"
@@ -2513,7 +2540,7 @@ msgid "Remove this user as a contributor"
 msgstr "Премахни този потребител като допринесъл"
 
 #: src/olympia/bandwagon/templates/bandwagon/edit_contributors.html:18 src/olympia/bandwagon/templates/bandwagon/edit_contributors.html:43
-#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:20 src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:48
+#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:18 src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:46
 #: src/olympia/devhub/templates/devhub/addons/ajax_compat_update.html:19
 msgid "Remove"
 msgstr "Премахни"
@@ -2524,11 +2551,9 @@ msgstr "Допринесли за колекцията"
 
 #: src/olympia/bandwagon/templates/bandwagon/edit_contributors.html:26
 msgid ""
-"You can add multiple contributors to this collection. A contributor can add and remove add-ons from this collection, but cannot change its name or description. To add a contributor, enter their "
+"You can add multiple contributors to this collection.  A contributor can add and remove add-ons from this collection, but cannot change its name or description.  To add a contributor, enter their "
 "email in the box below. Contributors must have a Mozilla Add-ons account."
 msgstr ""
-"Можете да добавяте много съдружници в тази колекция. Съдружникът може да добавя и премахва добавки от тази колекция, но не може да променя името или описанието ѝ. За да добавите съдружник, въведете"
-" имейла му в полето отдолу. Съдружниците трябва да имат акаунт в Mozilla Добавки."
 
 #: src/olympia/bandwagon/templates/bandwagon/edit_contributors.html:40
 msgid "User"
@@ -2564,7 +2589,7 @@ msgid "<b>Warning:</b> By changing the owner of this collection, you will no lon
 msgstr "<b>Внимание:</b> Като промените собственика на тази колекция, няма да можете да я редактирате. Ще можете само да добавяте и премахвате добавки от нея."
 
 #: src/olympia/bandwagon/templates/bandwagon/edit_contributors.html:83 src/olympia/devhub/templates/devhub/addons/forms_shared/media.html:157
-#: src/olympia/devhub/templates/devhub/addons/submit/describe.html:69 src/olympia/devhub/templates/devhub/addons/submit/license.html:60 src/olympia/devhub/templates/devhub/addons/submit/upload.html:78
+#: src/olympia/devhub/templates/devhub/addons/submit/describe.html:69 src/olympia/devhub/templates/devhub/addons/submit/license.html:60 src/olympia/devhub/templates/devhub/addons/submit/upload.html:70
 #: src/olympia/devhub/templates/devhub/payments/tier.html:17 src/olympia/editors/templates/editors/themes/themes.html:111 src/olympia/editors/templates/editors/themes/themes.html:128
 #: src/olympia/editors/templates/editors/themes/themes.html:134 src/olympia/editors/templates/editors/themes/themes.html:141 src/olympia/users/templates/users/fxa_migration_prompt_content.html:10
 #: src/olympia/users/templates/users/login_form.html:42 src/olympia/users/templates/users/mobile/login.html:57
@@ -2635,44 +2660,43 @@ msgid "Reset"
 msgstr "Нулиране"
 
 #: src/olympia/bandwagon/templates/bandwagon/includes/addedit.html:53
-msgid "PNG and JPG supported. Image will be resized to 32x32."
-msgstr "PNG и JPG поддържани. Изображенията ще бъдат оразмерени до 32x32."
+msgid "PNG and JPG supported.  Image will be resized to 32x32."
+msgstr ""
 
 #: src/olympia/bandwagon/templates/bandwagon/includes/addedit_errors.html:3
-msgid "There are errors in this form. Please correct them below."
-msgstr "В тази форма има грешки. Моля, поправете ги отдолу."
+msgid "There are errors in this form.  Please correct them below."
+msgstr ""
 
 #: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:2
 msgid "Add-ons in Your Collection"
 msgstr "Добавки в колекцията Ви"
 
 #: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:4
-msgid "To include an add-on in this collection, enter its name in the box below and hit enter. You can also use the <strong>Add to Collection</strong> links throughout the site to include add-ons later."
+msgid "To include an add-on in this collection, enter its name in the box below and hit enter."
 msgstr ""
-"За да включите добавка в тази колекция, въведете името ѝ в кутийката отдолу и натиснете Enter. Можете също да използвате връзките <strong>Добави към колекция</strong>, които са из целия сайт, за да"
-" включите добавки по-късно."
 
-#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:17 src/olympia/constants/base.py:400 src/olympia/devhub/templates/devhub/addons/activity.html:62
+#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:15 src/olympia/constants/base.py:400 src/olympia/devhub/templates/devhub/addons/activity.html:62
+#: src/olympia/editors/helpers.py:273 src/olympia/editors/helpers.py:360
 msgid "Add-on"
 msgstr "Добавка"
 
-#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:26
+#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:24
 msgid "Enter the name of the add-on to include"
 msgstr "Въведете името на добавката, която да включите"
 
-#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:28
+#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:26
 msgid "Add to Collection"
 msgstr "Добави към колекция"
 
-#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:45 src/olympia/editors/helpers.py:936 src/olympia/editors/helpers.py:956
+#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:43 src/olympia/editors/helpers.py:1016 src/olympia/editors/helpers.py:1036
 msgid "Pending"
 msgstr "Висяща"
 
-#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:47
+#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:45
 msgid "Add a comment"
 msgstr "Добави коментар"
 
-#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:48
+#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:46
 msgid "Remove this add-on from the collection"
 msgstr "Премахни тази добавка от колекцията"
 
@@ -2721,10 +2745,8 @@ msgstr "Проблемната добавка или плъгин ще бъде 
 #, python-format
 msgid ""
 "When Mozilla becomes aware of add-ons, plugins, or other third-party software that seriously compromises %(app)s security, stability, or performance and meets <a href=\"%(criteria)s\">certain "
-"criteria</a>, the software may be blocked from general use. For more information, please read <a href=\"%(support)s\">this support article</a>."
+"criteria</a>, the software may be blocked from general use.  For more information, please read <a href=\"%(support)s\">this support article</a>."
 msgstr ""
-"Когато Mozilla узнае за добавки, плъгини или друг софтуер от трета страна, който сериозно компроментира сигурността, стабилността или производителността на %(app)s и удовлетворява <a "
-"href=\"%(criteria)s\">определени критерии</a>, софтуерът може да бъде блокиран изцяло. За повече информация, моля прочетете <a href=\"%(support)s\">тази статия</a>."
 
 #: src/olympia/blocklist/templates/blocklist/blocked_detail.html:44
 #, python-format
@@ -2781,12 +2803,12 @@ msgstr "Инструменти за търсене"
 msgid "Most Users"
 msgstr "Най-много потребители"
 
-#: src/olympia/browse/views.py:61 src/olympia/browse/views.py:72 src/olympia/browse/views.py:279 src/olympia/browse/templates/browse/personas/mobile/category_landing.html:63
+#: src/olympia/browse/views.py:61 src/olympia/browse/views.py:72 src/olympia/browse/views.py:246 src/olympia/browse/templates/browse/personas/mobile/category_landing.html:63
 #: src/olympia/discovery/templates/discovery/pane.html:67 src/olympia/search/forms.py:92
 msgid "Up & Coming"
 msgstr "Настоящи и предстоящи"
 
-#: src/olympia/browse/views.py:460 src/olympia/devhub/views.py:76 src/olympia/devhub/views.py:83 src/olympia/discovery/templates/discovery/addons/detail.html:66
+#: src/olympia/browse/views.py:427 src/olympia/devhub/views.py:74 src/olympia/devhub/views.py:81 src/olympia/discovery/templates/discovery/addons/detail.html:66
 msgid "Created"
 msgstr "Дата на създаване"
 
@@ -2974,8 +2996,8 @@ msgid_plural "See all %(cnt)s extensions in %(name)s &raquo;"
 msgstr[0] "Виж %(cnt)s разширение в %(name)s &raquo;"
 msgstr[1] "Виж всички %(cnt)s разширения в %(name)s &raquo;"
 
-#: src/olympia/browse/templates/browse/mobile/extensions.html:13 src/olympia/compat/templates/compat/index.html:82 src/olympia/devhub/templates/devhub/devhub_search.html:24
-#: src/olympia/devhub/templates/devhub/addons/activity.html:47 src/olympia/search/templates/search/no_results.html:4 src/olympia/search/templates/search/mobile/results.html:36
+#: src/olympia/browse/templates/browse/mobile/extensions.html:13 src/olympia/devhub/templates/devhub/devhub_search.html:24 src/olympia/devhub/templates/devhub/addons/activity.html:47
+#: src/olympia/search/templates/search/no_results.html:4 src/olympia/search/templates/search/mobile/results.html:36
 msgid "No results found."
 msgstr "Няма резултати."
 
@@ -3060,7 +3082,7 @@ msgstr ""
 msgid "All"
 msgstr "Всички"
 
-#: src/olympia/compat/forms.py:22 src/olympia/search/views.py:525
+#: src/olympia/compat/forms.py:22 src/olympia/editors/templates/editors/base.html:69 src/olympia/search/views.py:518
 msgid "All Add-ons"
 msgstr "Всички добавки"
 
@@ -3071,53 +3093,6 @@ msgstr "Двоично"
 #: src/olympia/compat/forms.py:24
 msgid "Non-binary"
 msgstr "Не двоично"
-
-#. Review points sources other than add-ons and themes.
-#: src/olympia/compat/views.py:87 src/olympia/constants/base.py:388 src/olympia/devhub/forms.py:162 src/olympia/editors/templates/editors/performance.html:75
-msgid "Other"
-msgstr "Друго"
-
-#: src/olympia/compat/templates/compat/index.html:4
-msgid "Add-on Compatibility Report for {app} {version}"
-msgstr ""
-
-#: src/olympia/compat/templates/compat/index.html:11
-msgid "{app} {version} Compatibility"
-msgstr "{app} {version} съвместимост"
-
-#: src/olympia/compat/templates/compat/index.html:17
-#, python-format
-msgid "Top 95%% compatible with previous version"
-msgstr ""
-
-#: src/olympia/compat/templates/compat/index.html:18
-#, python-format
-msgid "Top 95%% of all add-ons"
-msgstr ""
-
-#: src/olympia/compat/templates/compat/index.html:19
-msgid "All active add-ons"
-msgstr "Всички активни добавки"
-
-#: src/olympia/compat/templates/compat/index.html:23 src/olympia/constants/base.py:401
-msgid "App"
-msgstr "Приложение"
-
-#: src/olympia/compat/templates/compat/index.html:55
-msgid "Details for add-ons compatible with previous version:"
-msgstr "Детайли за добавки, съвместими с предишни версии:"
-
-#: src/olympia/compat/templates/compat/index.html:57
-msgid "Show all versions"
-msgstr "Покажи всички версии"
-
-#: src/olympia/compat/templates/compat/index.html:59
-msgid "Details for add-ons compatible with all versions:"
-msgstr "Детайли за добавки, съвместими с всички версии:"
-
-#: src/olympia/compat/templates/compat/index.html:61
-msgid "Show previous version only"
-msgstr "Покажи само предишни версии"
 
 #: src/olympia/compat/templates/compat/reporter.html:3
 msgid "Add-on Compatibility Reports"
@@ -3170,8 +3145,8 @@ msgstr "Филтрирай по приложение"
 msgid "Report Type"
 msgstr "Тип на доклада"
 
-#: src/olympia/compat/templates/compat/reporter_detail.html:47 src/olympia/devhub/forms.py:784 src/olympia/devhub/templates/devhub/addons/ajax_compat_update.html:17 src/olympia/editors/forms.py:108
-#: src/olympia/zadmin/forms.py:45
+#: src/olympia/compat/templates/compat/reporter_detail.html:47 src/olympia/devhub/forms.py:785 src/olympia/devhub/templates/devhub/addons/ajax_compat_update.html:17 src/olympia/editors/forms.py:108
+#: src/olympia/editors/forms.py:248 src/olympia/zadmin/forms.py:45
 msgid "Application"
 msgstr "Приложение"
 
@@ -3259,7 +3234,8 @@ msgstr "Предварителен преглед"
 msgid "Preliminarily Reviewed and Awaiting Full Review"
 msgstr "Предварителен преглед, очакващ пълен преглед"
 
-#: src/olympia/constants/base.py:33 src/olympia/editors/helpers.py:924 src/olympia/editors/templates/editors/themes/history_table.html:34
+#: src/olympia/constants/base.py:33 src/olympia/editors/forms.py:258 src/olympia/editors/helpers.py:73 src/olympia/editors/helpers.py:1004
+#: src/olympia/editors/templates/editors/themes/history_table.html:34
 msgid "Deleted"
 msgstr "Изтрит"
 
@@ -3359,6 +3335,11 @@ msgstr "Питай, след като потребителите започна�
 msgid "Ask before users can download this add-on"
 msgstr "Питай преди потребителите да могат да свалят тази добавка"
 
+#. Review points sources other than add-ons and themes.
+#: src/olympia/constants/base.py:388 src/olympia/devhub/forms.py:162 src/olympia/editors/templates/editors/performance.html:75
+msgid "Other"
+msgstr "Друго"
+
 #: src/olympia/constants/base.py:389
 msgid "Exception"
 msgstr "Изключение"
@@ -3370,6 +3351,10 @@ msgstr ""
 #: src/olympia/constants/base.py:391
 msgid "Change"
 msgstr "Промени"
+
+#: src/olympia/constants/base.py:401
+msgid "App"
+msgstr "Приложение"
 
 #: src/olympia/constants/base.py:402
 msgid "Persona"
@@ -3522,7 +3507,7 @@ msgstr "Флагове"
 msgid "Duplicate"
 msgstr ""
 
-#: src/olympia/constants/editors.py:17 src/olympia/editors/helpers.py:502 src/olympia/editors/templates/editors/themes/queue.html:71 src/olympia/editors/templates/editors/themes/themes.html:94
+#: src/olympia/constants/editors.py:17 src/olympia/editors/helpers.py:575 src/olympia/editors/templates/editors/themes/queue.html:71 src/olympia/editors/templates/editors/themes/themes.html:94
 msgid "Reject"
 msgstr "Откажи"
 
@@ -3625,7 +3610,7 @@ msgstr "Solaris"
 msgid "Android"
 msgstr "Android"
 
-#: src/olympia/core/apps.py:19
+#: src/olympia/core/apps.py:21
 msgid "Core"
 msgstr ""
 
@@ -3759,7 +3744,7 @@ msgid "Submit my add-on for manual review."
 msgstr ""
 
 #: src/olympia/devhub/forms.py:537
-msgid "Do not list my add-on on this site (beta)"
+msgid "Do not list my add-on on this site"
 msgstr ""
 
 #: src/olympia/devhub/forms.py:538
@@ -3792,46 +3777,46 @@ msgstr ""
 
 #: src/olympia/devhub/forms.py:592
 #, python-format
-msgid "Version %s already exists"
-msgstr "Версия %s вече съществува"
+msgid "Version %s already exists, or was uploaded before."
+msgstr ""
 
-#: src/olympia/devhub/forms.py:604
+#: src/olympia/devhub/forms.py:605
 msgid "Select a valid choice. That choice is not one of the available choices."
 msgstr ""
 
-#: src/olympia/devhub/forms.py:610
+#: src/olympia/devhub/forms.py:611
 msgid "A file with a version ending with a|alpha|b|beta and an optional number is detected as beta."
 msgstr ""
 
-#: src/olympia/devhub/forms.py:633
+#: src/olympia/devhub/forms.py:634
 msgid "You cannot upload any more files for this version."
 msgstr "Не можете да качвате повече файлове за тази версия."
 
-#: src/olympia/devhub/forms.py:639
+#: src/olympia/devhub/forms.py:640
 msgid "Version doesn't match"
 msgstr "Версията не съвпада"
 
-#: src/olympia/devhub/forms.py:668
-msgid "You cannot delete a file once the review process has started. You must delete the whole version."
-msgstr "Не можете да изтриете файл след като веднъж е започнат процеса по одобрение. Трябва да изтриете цялата версия."
+#: src/olympia/devhub/forms.py:669
+msgid "You cannot delete a file once the review process has started.  You must delete the whole version."
+msgstr ""
 
-#: src/olympia/devhub/forms.py:688
+#: src/olympia/devhub/forms.py:689
 msgid "The platform All cannot be combined with specific platforms."
 msgstr "Платформата всички не може да бъде комбинирана със специфични платформи."
 
-#: src/olympia/devhub/forms.py:693
+#: src/olympia/devhub/forms.py:694
 msgid "A platform can only be chosen once."
 msgstr "Платформа може да се избира само веднъж."
 
-#: src/olympia/devhub/forms.py:706
+#: src/olympia/devhub/forms.py:707
 msgid "A review type must be selected."
 msgstr "Трябва да се избере вид на рецензията."
 
-#: src/olympia/devhub/forms.py:788 src/olympia/editors/forms.py:114 src/olympia/zadmin/forms.py:49 src/olympia/zadmin/forms.py:52
+#: src/olympia/devhub/forms.py:789 src/olympia/editors/forms.py:114 src/olympia/editors/forms.py:254 src/olympia/zadmin/forms.py:49 src/olympia/zadmin/forms.py:52
 msgid "Select an application first"
 msgstr "Първо изберете приложение"
 
-#: src/olympia/devhub/forms.py:840
+#: src/olympia/devhub/forms.py:841
 msgid "There cannot be more than 3 required add-ons."
 msgstr "Не може да има повече от 3 задължителни добавки."
 
@@ -3867,76 +3852,76 @@ msgstr[1] "{0} предупреждения"
 msgid "Review"
 msgstr "Отзив"
 
-#: src/olympia/devhub/tasks.py:551
+#: src/olympia/devhub/tasks.py:583
 #, python-format
 msgid "%s responded with %s (%s)."
 msgstr "%s отговори с %s (%s)."
 
-#: src/olympia/devhub/tasks.py:555
+#: src/olympia/devhub/tasks.py:587
 #, python-format
 msgid "Connection to \"%s\" timed out."
 msgstr "Връзката към \"%s\" бе прекъсната."
 
-#: src/olympia/devhub/tasks.py:557
+#: src/olympia/devhub/tasks.py:589
 #, python-format
 msgid "Could not contact host at \"%s\"."
 msgstr "Не можах да се свържа с хоста на \"%s\"."
 
-#: src/olympia/devhub/utils.py:104
+#: src/olympia/devhub/utils.py:105
 #, python-format
 msgid "Validation generated too many errors/warnings so %s messages were truncated. After addressing the visible messages, you'll be able to see the others."
 msgstr ""
 
-#: src/olympia/devhub/views.py:183
+#: src/olympia/devhub/views.py:181
 msgid "All My Add-ons"
 msgstr "Всичките ми добавки"
 
-#: src/olympia/devhub/views.py:210
+#: src/olympia/devhub/views.py:208
 msgid "All Activity"
 msgstr "Всичка активност"
 
-#: src/olympia/devhub/views.py:211
+#: src/olympia/devhub/views.py:209
 msgid "Add-on Updates"
 msgstr "Актуализации на добавката"
 
-#: src/olympia/devhub/views.py:212
+#: src/olympia/devhub/views.py:210
 msgid "Add-on Status"
 msgstr "Състояние на добавката"
 
-#: src/olympia/devhub/views.py:213
+#: src/olympia/devhub/views.py:211
 msgid "User Collections"
 msgstr "Потребителски колекции"
 
-#: src/olympia/devhub/views.py:214 src/olympia/devhub/templates/devhub/docs/policies-maintenance.html:68 src/olympia/pages/templates/pages/dev_faq.html:38
+#: src/olympia/devhub/views.py:212 src/olympia/devhub/templates/devhub/docs/policies-maintenance.html:68 src/olympia/pages/templates/pages/dev_faq.html:38
 #: src/olympia/pages/templates/pages/dev_faq.html:484
 msgid "User Reviews"
 msgstr "Потребителски рецензии"
 
-#: src/olympia/devhub/views.py:327 src/olympia/devhub/views.py:331 src/olympia/devhub/views.py:484 src/olympia/devhub/views.py:513 src/olympia/devhub/views.py:564 src/olympia/devhub/views.py:1150
+#: src/olympia/devhub/views.py:325 src/olympia/devhub/views.py:329 src/olympia/devhub/views.py:484 src/olympia/devhub/views.py:513 src/olympia/devhub/views.py:564 src/olympia/devhub/views.py:1156
 msgid "Changes successfully saved."
 msgstr "Промените запазени успешно."
 
-#: src/olympia/devhub/views.py:334 src/olympia/devhub/views.py:1631
+#: src/olympia/devhub/views.py:332 src/olympia/devhub/views.py:1637
 msgid "Please check the form for errors."
 msgstr ""
 
-#: src/olympia/devhub/views.py:346
+#: src/olympia/devhub/views.py:344
 msgid "Add-on cannot be deleted. Disable this add-on instead."
 msgstr ""
 
-#: src/olympia/devhub/views.py:356
+#: src/olympia/devhub/views.py:354
 msgid "Theme deleted."
 msgstr ""
 
-#: src/olympia/devhub/views.py:356
+#: src/olympia/devhub/views.py:354
 msgid "Add-on deleted."
 msgstr "Добавката изтрита."
 
-#: src/olympia/devhub/views.py:362
+#: src/olympia/devhub/views.py:360
 msgid "URL name was incorrect. Theme was not deleted."
 msgstr ""
 
-#: src/olympia/devhub/views.py:367
+#: src/olympia/devhub/views.py:365
 msgid "URL name was incorrect. Add-on was not deleted."
 msgstr ""
 
@@ -3964,7 +3949,7 @@ msgstr "Валидиране на добавката"
 msgid "Check Add-on Compatibility"
 msgstr "Провери съвместимостта на добавката"
 
-#: src/olympia/devhub/views.py:808 src/olympia/signing/views.py:90
+#: src/olympia/devhub/views.py:808 src/olympia/signing/views.py:95
 msgid "You cannot submit this type of add-on"
 msgstr ""
 
@@ -3994,33 +3979,33 @@ msgstr "Изображенията трябва да са точно {0} пик�
 msgid "There was an error uploading your preview."
 msgstr "Стана грешка при качването на рецензията ви."
 
-#: src/olympia/devhub/views.py:1189
+#: src/olympia/devhub/views.py:1195
 #, python-format
 msgid "Version %s disabled."
 msgstr ""
 
-#: src/olympia/devhub/views.py:1193
+#: src/olympia/devhub/views.py:1199
 #, python-format
 msgid "Version %s deleted."
 msgstr "Версия %s изтрита."
 
-#: src/olympia/devhub/views.py:1203
+#: src/olympia/devhub/views.py:1209
 msgid "This upload has failed validation, and may lack complete validation results. Please take due care when reviewing it."
 msgstr ""
 
-#: src/olympia/devhub/views.py:1677
+#: src/olympia/devhub/views.py:1683
 msgid "Preliminary Review Requested."
 msgstr "Поискан е предварителен преглед."
 
-#: src/olympia/devhub/views.py:1678
+#: src/olympia/devhub/views.py:1684
 msgid "Full Review Requested."
 msgstr "Поискан е пълен преглед."
 
-#: src/olympia/devhub/views.py:1779
+#: src/olympia/devhub/views.py:1783
 msgid "Your old credentials were revoked and are no longer valid. Be sure to update all API clients with the new credentials."
 msgstr ""
 
-#: src/olympia/devhub/views.py:1797
+#: src/olympia/devhub/views.py:1801
 msgid "New API key created"
 msgstr ""
 
@@ -4050,10 +4035,10 @@ msgstr "Назад към добавките"
 msgid "{0} :: Search"
 msgstr "{0} :: Търсене"
 
-#: src/olympia/devhub/templates/devhub/devhub_search.html:6 src/olympia/devhub/templates/devhub/search.html:8 src/olympia/editors/forms.py:435 src/olympia/editors/forms.py:437
+#: src/olympia/devhub/templates/devhub/devhub_search.html:6 src/olympia/devhub/templates/devhub/search.html:8 src/olympia/editors/forms.py:534 src/olympia/editors/forms.py:536
 #: src/olympia/editors/templates/editors/queue.html:27 src/olympia/editors/templates/editors/themes/queue_list.html:14 src/olympia/search/templates/search/collections.html:17
-#: src/olympia/search/templates/search/personas.html:18 src/olympia/search/templates/search/results.html:18 src/olympia/search/templates/search/mobile/results.html:8 src/olympia/templates/search.html:14
-#: src/olympia/templates/impala/search.html:18
+#: src/olympia/search/templates/search/personas.html:18 src/olympia/search/templates/search/results.html:18 src/olympia/search/templates/search/mobile/results.html:8
+#: src/olympia/templates/search.html:14 src/olympia/templates/impala/search.html:18
 msgid "Search"
 msgstr "Търси"
 
@@ -4099,9 +4084,9 @@ msgstr ""
 
 #: src/olympia/devhub/templates/devhub/index.html:41
 msgid ""
-"Add-ons let millions of Firefox users enhance and customize their browsing experience. If you're a Web developer and know <a href=\"https://developer.mozilla.org/docs/Web/HTML\">HTML</a>, <a "
-"href=\"https://developer.mozilla.org/docs/Web/JavaScript\">JavaScript</a>, and <a href=\"https://developer.mozilla.org/docs/Web/CSS\">CSS</a>, you already have all the necessary skills to make a "
-"great add-on."
+"Add-ons let millions of Firefox users enhance and customize their browsing experience. If you're a Web developer and know <a href=\"https://developer.mozilla.org/docs/Web/HTML\">HTML</a>, <a href="
+"\"https://developer.mozilla.org/docs/Web/JavaScript\">JavaScript</a>, and <a href=\"https://developer.mozilla.org/docs/Web/CSS\">CSS</a>, you already have all the necessary skills to make a great "
+"add-on."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/index.html:51
@@ -4112,12 +4097,12 @@ msgstr ""
 msgid "Start Making Add-ons"
 msgstr "Започни да създаваш"
 
-#: src/olympia/devhub/templates/devhub/index.html:86 src/olympia/devhub/templates/devhub/addons/listing/items.html:25 src/olympia/devhub/templates/devhub/includes/addon_details.html:15
+#: src/olympia/devhub/templates/devhub/index.html:86 src/olympia/devhub/templates/devhub/addons/listing/items.html:25 src/olympia/devhub/templates/devhub/includes/addon_details.html:20
 #: src/olympia/devhub/templates/devhub/personas/edit.html:43
 msgid "Status:"
 msgstr "Състояние:"
 
-#: src/olympia/devhub/templates/devhub/index.html:90 src/olympia/devhub/templates/devhub/includes/addon_details.html:100
+#: src/olympia/devhub/templates/devhub/index.html:90 src/olympia/devhub/templates/devhub/includes/addon_details.html:87
 msgid "Visibility:"
 msgstr ""
 
@@ -4125,11 +4110,11 @@ msgstr ""
 msgid "Latest Version:"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/index.html:109 src/olympia/devhub/templates/devhub/includes/addon_details.html:145 src/olympia/devhub/templates/devhub/personas/edit.html:49
+#: src/olympia/devhub/templates/devhub/index.html:109 src/olympia/devhub/templates/devhub/includes/addon_details.html:131 src/olympia/devhub/templates/devhub/personas/edit.html:49
 msgid "Queue Position:"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/index.html:110 src/olympia/devhub/templates/devhub/includes/addon_details.html:146 src/olympia/devhub/templates/devhub/personas/edit.html:50
+#: src/olympia/devhub/templates/devhub/index.html:110 src/olympia/devhub/templates/devhub/includes/addon_details.html:132 src/olympia/devhub/templates/devhub/personas/edit.html:50
 #, python-format
 msgid "%(position)s of %(total)s"
 msgstr ""
@@ -4234,16 +4219,6 @@ msgstr ""
 msgid "Do you want your add-on to be distributed on this site?"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/validate_addon.html:49 src/olympia/devhub/templates/devhub/addons/submit/upload.html:30 src/olympia/devhub/templates/devhub/versions/add_file_modal.html:14
-#: src/olympia/devhub/templates/devhub/versions/add_file_modal.html:53 src/olympia/devhub/templates/devhub/versions/list.html:298
-msgid "Warning:"
-msgstr ""
-
-#: src/olympia/devhub/templates/devhub/validate_addon.html:50 src/olympia/devhub/templates/devhub/addons/submit/upload.html:31
-#, python-format
-msgid "Submission of unlisted add-ons for signing is currently in an open beta. Please <a href=\"%(url)s\" target=\"_blank\">report any bugs</a> that you encounter."
-msgstr ""
-
 #. first parameter is a filename like lorem-ipsum-1.0.2.xpi
 #: src/olympia/devhub/templates/devhub/validation.html:5
 msgid "Validation Results for {0}"
@@ -4298,17 +4273,17 @@ msgid ""
 "This add-on is incompatible with <b>%(app_name)s %(app_version)s</b>, the latest release of %(app_name)s. Please consider updating your add-on's compatibility info, or uploading a newer version of "
 "this add-on."
 msgstr ""
-"Тази добавка е несъвместима с <b>%(app_name)s %(app_version)s</b>, последната версия на %(app_name)s. Моля, помислете за актуализиране на информацията за съвместимост на добавката ви или качете "
-"по-нова версия."
+"Тази добавка е несъвместима с <b>%(app_name)s %(app_version)s</b>, последната версия на %(app_name)s. Моля, помислете за актуализиране на информацията за съвместимост на добавката ви или качете по-"
+"нова версия."
 
 #: src/olympia/devhub/templates/devhub/addons/ajax_compat_error.html:15
 #, python-format
 msgid ""
-"<a href=\"#\" class=\"button compat-update\" data-updateurl=\"%(update_url)s\">Update Compatibility</a> <a href=\"%(version_url)s\" class=\"button\">Upload New Version</a> or <a href=\"#\" "
-"class=\"close\">Ignore</a>"
+"<a href=\"#\" class=\"button compat-update\" data-updateurl=\"%(update_url)s\">Update Compatibility</a> <a href=\"%(version_url)s\" class=\"button\">Upload New Version</a> or <a href=\"#\" class="
+"\"close\">Ignore</a>"
 msgstr ""
-"<a href=\"#\" class=\"button compat-update\" data-updateurl=\"%(update_url)s\">Обнови съвместимостта</a>, <a href=\"%(version_url)s\" class=\"button\">Качи нова версия</a> или <a href=\"#\" "
-"class=\"close\">Игнорирай</a>"
+"<a href=\"#\" class=\"button compat-update\" data-updateurl=\"%(update_url)s\">Обнови съвместимостта</a>, <a href=\"%(version_url)s\" class=\"button\">Качи нова версия</a> или <a href=\"#\" class="
+"\"close\">Игнорирай</a>"
 
 #: src/olympia/devhub/templates/devhub/addons/ajax_compat_status.html:5
 msgid "View and update application compatibility ranges."
@@ -4322,7 +4297,7 @@ msgstr "Съвместимост"
 msgid "Update Compatibility"
 msgstr "Обнови съвместимост"
 
-#: src/olympia/devhub/templates/devhub/addons/ajax_compat_update.html:4
+#: src/olympia/devhub/templates/devhub/addons/ajax_compat_update.html:4 src/olympia/devhub/templates/devhub/versions/edit.html:45
 msgid "Adjusting application information here will allow users to install your add-on even if the install manifest in the package indicates that the add-on is incompatible."
 msgstr "Нагласяването на информацията на приложението тук ще даде възможност на потребителите да инсталират добавката ви, дори ако инсталационния манифест показва, че тя не е съвместима."
 
@@ -4334,9 +4309,9 @@ msgstr "Поддържани версии"
 msgid "Add Another Application&hellip;"
 msgstr "Добави друго приложение&hellip;"
 
-#: src/olympia/devhub/templates/devhub/addons/ajax_compat_update.html:38 src/olympia/devhub/templates/devhub/addons/owner.html:86 src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:46
-#: src/olympia/devhub/templates/devhub/versions/list.html:351 src/olympia/devhub/templates/devhub/versions/list.html:353 src/olympia/templates/impala/base.html:132
-#: src/olympia/templates/impala/base.html:143 src/olympia/templates/impala/base.html:161 src/olympia/templates/impala/base.html:171
+#: src/olympia/devhub/templates/devhub/addons/ajax_compat_update.html:38 src/olympia/devhub/templates/devhub/addons/owner.html:86 src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:45
+#: src/olympia/devhub/templates/devhub/versions/list.html:349 src/olympia/devhub/templates/devhub/versions/list.html:351 src/olympia/templates/impala/base.html:129
+#: src/olympia/templates/impala/base.html:140 src/olympia/templates/impala/base.html:158 src/olympia/templates/impala/base.html:168
 msgid "Close"
 msgstr "Затвори"
 
@@ -4370,7 +4345,7 @@ msgstr "Никакъв"
 msgid "Manage Authors & License"
 msgstr "Управление на автори и лиценз"
 
-#: src/olympia/devhub/templates/devhub/addons/owner.html:29 src/olympia/editors/templates/editors/review.html:270
+#: src/olympia/devhub/templates/devhub/addons/owner.html:29 src/olympia/editors/helpers.py:362 src/olympia/editors/templates/editors/review.html:270
 msgid "Authors"
 msgstr "Автори"
 
@@ -4439,30 +4414,21 @@ msgstr "Обобщение"
 
 #: src/olympia/devhub/templates/devhub/addons/edit/basic.html:52
 msgid ""
-"A short explanation of your add-on's basic\n"
-"                          functionality that is displayed in search and browse\n"
-"                          listings, as well as at the top of your add-on's\n"
-"                          details page. It is only relevant for listed add-ons."
+"A short explanation of your add-on's basic functionality that is displayed in search and browse listings, as well as at the top of your add-on's details page. It is only relevant for listed add-ons."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/basic.html:73
-msgid ""
-"Categories are the primary way users browse through add-ons.\n"
-"                        Choose any that fit your add-on's functionality for the most\n"
-"                        exposure. It is only relevant for listed add-ons."
+msgid "Categories are the primary way users browse through add-ons. Choose any that fit your add-on's functionality for the most exposure. It is only relevant for listed add-ons."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/basic.html:90
 #, python-format
-msgid "Categories cannot be changed while your add-on is featured for this application. Please email <a href=\"mailto:%(email)s\">%(email)s</a> if there is a reason you need to modify your categories."
+msgid ""
+"Categories cannot be changed while your add-on is featured for this application. Please email <a href=\"mailto:%(email)s\">%(email)s</a> if there is a reason you need to modify your categories."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/basic.html:119
-msgid ""
-"Tags help users find your add-on and should be short\n"
-"                        descriptors such as tabs, toolbar, or twitter.  You\n"
-"                        may have a maximum of {0} tags. It is only relevant\n"
-"                        for listed add-ons."
+msgid "Tags help users find your add-on and should be short descriptors such as tabs, toolbar, or twitter. You may have a maximum of {0} tags. It is only relevant for listed add-ons."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/basic.html:129 src/olympia/devhub/templates/devhub/personas/edit.html:97 src/olympia/devhub/templates/devhub/personas/submit.html:46
@@ -4490,11 +4456,7 @@ msgid "Add-on Details for {0}"
 msgstr "Детайли за {0}"
 
 #: src/olympia/devhub/templates/devhub/addons/edit/details.html:22
-msgid ""
-"A longer explanation of features,\n"
-"                          functionality, and other relevant information. This\n"
-"                          field is only displayed on the add-on's details\n"
-"                          page. It is only relevant for listed add-ons."
+msgid "A longer explanation of features, functionality, and other relevant information. This field is only displayed on the add-on's details page. It is only relevant for listed add-ons."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/details.html:44 src/olympia/translations/templates/translations/trans-menu.html:13
@@ -4502,10 +4464,7 @@ msgid "Default Locale"
 msgstr "Локал по подразбиране"
 
 #: src/olympia/devhub/templates/devhub/addons/edit/details.html:45
-msgid ""
-"Information about your add-on is displayed in this locale\n"
-"                        unless you override it with a locale-specific translation.\n"
-"                        It is only relevant for listed add-ons."
+msgid "Information about your add-on is displayed in this locale unless you override it with a locale-specific translation. It is only relevant for listed add-ons."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/details.html:61 src/olympia/users/forms.py:311 src/olympia/users/templates/users/edit.html:122 src/olympia/users/templates/users/register.html:57
@@ -4515,10 +4474,8 @@ msgstr "Начална страница"
 
 #: src/olympia/devhub/templates/devhub/addons/edit/details.html:63
 msgid ""
-"If your add-on has another homepage, enter its\n"
-"                          address here. If your website is localized into other\n"
-"                          languages multiple translations of this field can be\n"
-"                          added. It is only relevant for listed add-ons."
+"If your add-on has another homepage, enter its address here. If your website is localized into other languages multiple translations of this field can be added. It is only relevant for listed add-"
+"ons."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/media.html:3
@@ -4536,19 +4493,14 @@ msgstr "Информация за поддръжка за {0}"
 
 #: src/olympia/devhub/templates/devhub/addons/edit/support.html:22
 msgid ""
-"If you wish to display an e-mail address for support\n"
-"                          inquiries, enter it here. If you have different\n"
-"                          addresses for each language multiple translations of\n"
-"                          this field can be added. It is only relevant for\n"
-"                          listed add-ons."
+"If you wish to display an e-mail address for support inquiries, enter it here. If you have different addresses for each language multiple translations of this field can be added. It is only "
+"relevant for listed add-ons."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/support.html:45
 msgid ""
-"If your add-on has a support website or forum, enter\n"
-"                          its address here. If your website is localized into\n"
-"                          other languages, multiple translations of this field can\n"
-"                          be added. It is only relevant for listed add-ons."
+"If your add-on has a support website or forum, enter its address here. If your website is localized into other languages, multiple translations of this field can be added. It is only relevant for "
+"listed add-ons."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:6
@@ -4562,11 +4514,8 @@ msgstr "Технически детайли за {0}"
 
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:23
 msgid ""
-"Any information end users may want to know that isn't\n"
-"                          necessarily applicable to the add-on summary or description.\n"
-"                          Common uses include listing known major bugs, information on\n"
-"                          how to report bugs, anticipated release date of a new version,\n"
-"                          etc. It is only relevant for listed add-ons."
+"Any information end users may want to know that isn't necessarily applicable to the add-on summary or description. Common uses include listing known major bugs, information on how to report bugs, "
+"anticipated release date of a new version, etc. It is only relevant for listed add-ons."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:46
@@ -4578,9 +4527,7 @@ msgid "Add-on Flags"
 msgstr "Флагове на добавката"
 
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:69
-msgid ""
-"These flags are used to classify add-ons. It is only\n"
-"                        relevant for listed add-ons."
+msgid "These flags are used to classify add-ons. It is only relevant for listed add-ons."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:74
@@ -4596,9 +4543,7 @@ msgid "View Source?"
 msgstr "Виж изходния код?"
 
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:90
-msgid ""
-"Whether the source of your add-on can be displayed in our\n"
-"                        online viewer. It is only relevant for listed add-ons."
+msgid "Whether the source of your add-on can be displayed in our online viewer. It is only relevant for listed add-ons."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:94
@@ -4614,10 +4559,7 @@ msgid "Public Stats?"
 msgstr "Публични статистики?"
 
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:102
-msgid ""
-"Whether the download and usage stats of your add-on can\n"
-"                        be displayed in our online viewer.\n"
-"                        It is only relevant for listed add-ons."
+msgid "Whether the download and usage stats of your add-on can be displayed in our online viewer. It is only relevant for listed add-ons."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:107
@@ -4633,10 +4575,7 @@ msgid "Upgrade SDK?"
 msgstr "Обнови SDK?"
 
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:116
-msgid ""
-"If selected, we will try to automatically upgrade your\n"
-"                        add-on when a new version of the SDK is released.\n"
-"                        It is only relevant for listed add-ons."
+msgid "If selected, we will try to automatically upgrade your add-on when a new version of the SDK is released. It is only relevant for listed add-ons."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:121
@@ -4690,10 +4629,8 @@ msgstr "Иконка на добавката"
 
 #: src/olympia/devhub/templates/devhub/addons/forms_shared/media.html:16
 msgid ""
-"Upload an icon for your add-on or choose from one of ours. The\n"
-"                      icon is displayed nearly everywhere your add-on is. Uploaded images\n"
-"                      must be one of the following image types: .png, .jpg.\n"
-"                      It is only relevant for listed add-ons."
+"Upload an icon for your add-on or choose from one of ours. The icon is displayed nearly everywhere your add-on is. Uploaded images must be one of the following image types: .png, .jpg. It is only "
+"relevant for listed add-ons."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/forms_shared/media.html:25
@@ -4804,16 +4741,14 @@ msgid "Deleting your add-on will permanently remove it from the site and prevent
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:24
-msgid ""
-"Enter the following text confirm your decision:\n"
-"           {slug}"
+msgid "Enter the following text confirm your decision: {slug}"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:34
+#: src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:33
 msgid "Please tell us why you are deleting your theme:"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:36
+#: src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:35
 msgid "Please tell us why you are deleting your add-on:"
 msgstr ""
 
@@ -4850,13 +4785,13 @@ msgstr "Нова версия"
 msgid "Daily statistics on downloads and users."
 msgstr "Дневни статистики на свалянията и потребителите."
 
-#: src/olympia/devhub/templates/devhub/addons/listing/item_actions.html:45 src/olympia/stats/templates/stats/stats.html:75 src/olympia/stats/templates/stats/stats.html:79
-#: src/olympia/stats/templates/stats/stats.html:81
+#: src/olympia/devhub/templates/devhub/addons/listing/item_actions.html:45 src/olympia/stats/templates/stats/stats.html:31 src/olympia/stats/templates/stats/stats.html:35
+#: src/olympia/stats/templates/stats/stats.html:37
 msgid "Statistics"
 msgstr "Статистика"
 
-#: src/olympia/devhub/templates/devhub/addons/listing/item_actions.html:54 src/olympia/devhub/templates/devhub/includes/addons_edit_nav.html:5 src/olympia/devhub/templates/devhub/payments/payments.html:3
-#: src/olympia/devhub/templates/devhub/payments/tier.html:4
+#: src/olympia/devhub/templates/devhub/addons/listing/item_actions.html:54 src/olympia/devhub/templates/devhub/includes/addons_edit_nav.html:5
+#: src/olympia/devhub/templates/devhub/payments/payments.html:3 src/olympia/devhub/templates/devhub/payments/tier.html:4
 msgid "Manage Payments"
 msgstr "Управление на плащанията"
 
@@ -5072,8 +5007,8 @@ msgid ""
 "All add-ons hosted in our gallery must be reviewed by an editor before they appear in categories or search results. While waiting for review, your add-on can still be accessed through its direct "
 "URL. Please choose the review process below that best fits your add-on."
 msgstr ""
-"Всички добавки, поместени в нашата галерия трябва да са прегледани от редактор преди да се покажат в категориите или резултатите от търсене. Докато очаква преглед, вашата добавка все още е достъпна"
-" директно на адреса ѝ. Моля, изберете процеса на преглед, който най-добре подхожда на добавката ви, отдолу."
+"Всички добавки, поместени в нашата галерия трябва да са прегледани от редактор преди да се покажат в категориите или резултатите от търсене. Докато очаква преглед, вашата добавка все още е достъпна "
+"директно на адреса ѝ. Моля, изберете процеса на преглед, който най-добре подхожда на добавката ви, отдолу."
 
 #: src/olympia/devhub/templates/devhub/addons/submit/select-review.html:26
 #, python-format
@@ -5178,11 +5113,11 @@ msgstr "Стъпка 2. Качете добавката си"
 msgid "Use the fields below to upload your add-on package and select any platform restrictions. After upload, a series of automated validation tests will be run on your file."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/addons/submit/upload.html:59 src/olympia/devhub/templates/devhub/versions/add_file_modal.html:39
+#: src/olympia/devhub/templates/devhub/addons/submit/upload.html:51 src/olympia/devhub/templates/devhub/versions/add_file_modal.html:28
 msgid "Which platforms is this file compatible with?"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/addons/submit/upload.html:67 src/olympia/devhub/templates/devhub/versions/add_file_modal.html:65
+#: src/olympia/devhub/templates/devhub/addons/submit/upload.html:59 src/olympia/devhub/templates/devhub/versions/add_file_modal.html:45
 msgid "Administrative overrides"
 msgstr ""
 
@@ -5210,8 +5145,8 @@ msgstr ""
 #: src/olympia/devhub/templates/devhub/api/key.html:37
 #, python-format
 msgid ""
-"To make API requests, send a <a href=\"%(jwt_url)s\">JSON Web Token (JWT)</a> as the authorization header. You'll need to generate a JWT for every request as explained in the <a "
-"href=\"%(docs_url)s\">API documentation</a>."
+"To make API requests, send a <a href=\"%(jwt_url)s\">JSON Web Token (JWT)</a> as the authorization header. You'll need to generate a JWT for every request as explained in the <a href=\"%(docs_url)s"
+"\">API documentation</a>."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/api/key.html:47
@@ -5231,8 +5166,8 @@ msgstr ""
 msgid "Generate new credentials"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/docs/policies-agreement.html:3 src/olympia/devhub/templates/devhub/docs/policies-agreement.html:7 src/olympia/devhub/templates/devhub/docs/policies-agreement.html:9
-#: src/olympia/devhub/templates/devhub/docs/policies.html:24 src/olympia/devhub/templates/devhub/docs/policies.html:103
+#: src/olympia/devhub/templates/devhub/docs/policies-agreement.html:3 src/olympia/devhub/templates/devhub/docs/policies-agreement.html:7
+#: src/olympia/devhub/templates/devhub/docs/policies-agreement.html:9 src/olympia/devhub/templates/devhub/docs/policies.html:24 src/olympia/devhub/templates/devhub/docs/policies.html:103
 msgid "Developer Agreement"
 msgstr ""
 
@@ -5266,8 +5201,8 @@ msgstr "amo-editors в mozilla точка org"
 #: src/olympia/devhub/templates/devhub/docs/policies-contact.html:26
 #, python-format
 msgid ""
-"If you have a question about an Editor's review of an add-on or want to report a policy violation, please email %(mail_editors)s. <strong>Almost all add-on reports fall under this "
-"category.</strong> Please be sure to include a link to the add-on in question and a detailed description of your question or comment."
+"If you have a question about an Editor's review of an add-on or want to report a policy violation, please email %(mail_editors)s. <strong>Almost all add-on reports fall under this category.</"
+"strong> Please be sure to include a link to the add-on in question and a detailed description of your question or comment."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/docs/policies-contact.html:31
@@ -5282,8 +5217,8 @@ msgstr ""
 #, python-format
 msgid ""
 "If you have discovered a security vulnerability in an add-on, even if it is not hosted here, Mozilla is very interested in your discovery and will work with the add-on developer to correct the "
-"issue as soon as possible. Add-on security issues can be reported <a href=\"http://www.mozilla.org/projects/security/security-bugs-policy.html\">confidentially</a> in <a "
-"href=\"%(link_bugzilla)s\">Bugzilla</a> or by emailing %(mail_admins)s."
+"issue as soon as possible. Add-on security issues can be reported <a href=\"http://www.mozilla.org/projects/security/security-bugs-policy.html\">confidentially</a> in <a href=\"%(link_bugzilla)s"
+"\">Bugzilla</a> or by emailing %(mail_admins)s."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/docs/policies-contact.html:42
@@ -5292,8 +5227,8 @@ msgstr ""
 
 #: src/olympia/devhub/templates/devhub/docs/policies-contact.html:44
 msgid ""
-"If you've found a problem with the site, we'd love to fix it. Please <a href=\"https://github.com/mozilla/olympia/issues\">file a bug report</a> in GitHub, including the location of the problem and"
-" how you encountered it."
+"If you've found a problem with the site, we'd love to fix it. Please <a href=\"https://github.com/mozilla/addons/issues/new\">file a bug report</a> in GitHub, including the location of the problem "
+"and how you encountered it."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/docs/policies-maintenance.html:3 src/olympia/devhub/templates/devhub/docs/policies-maintenance.html:7
@@ -5307,9 +5242,9 @@ msgstr "Пращане на нови версии на добавката ви"
 
 #: src/olympia/devhub/templates/devhub/docs/policies-maintenance.html:12
 msgid ""
-"Developers are encouraged to submit updates to their add-ons to fix bugs, add features, and otherwise improve their product. New versions of an add-on must have a <a "
-"href=\"https://developer.mozilla.org/en/Toolkit_version_format\">higher version number</a> and can be submitted through the Developer Tools provided. There is no limit to the number of versions "
-"that can be submitted, but please remember that versions must be reviewed by an editor."
+"Developers are encouraged to submit updates to their add-ons to fix bugs, add features, and otherwise improve their product. New versions of an add-on must have a <a href=\"https://developer."
+"mozilla.org/en/Toolkit_version_format\">higher version number</a> and can be submitted through the Developer Tools provided. There is no limit to the number of versions that can be submitted, but "
+"please remember that versions must be reviewed by an editor."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/docs/policies-maintenance.html:18
@@ -5372,8 +5307,8 @@ msgstr ""
 
 #: src/olympia/devhub/templates/devhub/docs/policies-maintenance.html:70
 msgid ""
-"Mozilla encourages its users to offer feedback on their experiences when using an add-on. This allows other users to determine if the add-on is stable and useful. It also provides valuable feedback"
-" to developers, allowing them to continuously improve their add-on to meet user needs."
+"Mozilla encourages its users to offer feedback on their experiences when using an add-on. This allows other users to determine if the add-on is stable and useful. It also provides valuable feedback "
+"to developers, allowing them to continuously improve their add-on to meet user needs."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/docs/policies-maintenance.html:76
@@ -5422,7 +5357,8 @@ msgid ""
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/docs/policies-recommended.html:19
-msgid "Featured add-ons are chosen by the Featured Add-ons Advisory Board, a small group of add-on developers and fans from the Mozilla community who have volunteered to review and vote on nominations."
+msgid ""
+"Featured add-ons are chosen by the Featured Add-ons Advisory Board, a small group of add-on developers and fans from the Mozilla community who have volunteered to review and vote on nominations."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/docs/policies-recommended.html:25
@@ -5606,9 +5542,9 @@ msgstr ""
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:31
 msgid ""
-"Detailed descriptions of each option are below. After selecting a review process at submission, the add-on will be placed in the queue. Add-ons are reviewed by the <a "
-"href=\"https://wiki.mozilla.org/AMO:Editors\">AMO Editors</a>, a group of talented developers that volunteer to help the Mozilla project by reviewing add-ons to ensure a stable and safe experience "
-"for users. Developers will receive an email with any updates throughout the review process."
+"Detailed descriptions of each option are below. After selecting a review process at submission, the add-on will be placed in the queue. Add-ons are reviewed by the <a href=\"https://wiki.mozilla."
+"org/AMO:Editors\">AMO Editors</a>, a group of talented developers that volunteer to help the Mozilla project by reviewing add-ons to ensure a stable and safe experience for users. Developers will "
+"receive an email with any updates throughout the review process."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:37
@@ -5619,8 +5555,8 @@ msgstr ""
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:44
 msgid ""
-"Full reviews are appropriate for add-ons that are well-tested, stable, fast, and have wide appeal to our users. If you aren't confident that your add-on meets that criteria, please consider working"
-" out the kinks while in preliminary review and accumulating user feedback first."
+"Full reviews are appropriate for add-ons that are well-tested, stable, fast, and have wide appeal to our users. If you aren't confident that your add-on meets that criteria, please consider working "
+"out the kinks while in preliminary review and accumulating user feedback first."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:50
@@ -5715,8 +5651,8 @@ msgstr ""
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:123
 #, python-format
 msgid ""
-"Many of the above restrictions are tested automatically by an extension scanner that will flag suspicious add-ons for editor review. You can read more about this scanner in the <a "
-"href=\"%(link_validation)s\">Validation Help</a> document."
+"Many of the above restrictions are tested automatically by an extension scanner that will flag suspicious add-ons for editor review. You can read more about this scanner in the <a href="
+"\"%(link_validation)s\">Validation Help</a> document."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:129
@@ -5737,8 +5673,8 @@ msgstr ""
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:142
 msgid ""
-"Subsequent versions of the add-on will automatically be placed in the full review queue. Until the review is completed, the new version will only be displayed on the Version History page of the "
-"add-on. Once reviewed, the version will be updated across the site and deployed through the automatic update service."
+"Subsequent versions of the add-on will automatically be placed in the full review queue. Until the review is completed, the new version will only be displayed on the Version History page of the add-"
+"on. Once reviewed, the version will be updated across the site and deployed through the automatic update service."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:148
@@ -5840,9 +5776,9 @@ msgstr ""
 msgid ""
 "<p> Whenever an add-on includes any unexpected* feature that </p> <ul> <li>compromises user privacy or security (like sending data to third parties),</li> <li>changes default settings like the "
 "homepage or search engine, or</li> <li>changes settings or features in other add-ons or deactivates them altogether</li> </ul> <p>the features must adhere to the following requirements:</p> <ul> "
-"<li>The add-on description must clearly state what changes the add-on makes.</li> <li>All changes must be opt-in, meaning the user must take non-default action to enact the change.</li> <li>The "
-"opt-in dialog must clearly state the name of the add-on requesting the change.</li> <li>Uninstalling the add-on restores the user's original settings if they were changed.</li> </ul> <p>*Unexpected"
-" features are those that are unrelated to the add-on's primary function.</p>"
+"<li>The add-on description must clearly state what changes the add-on makes.</li> <li>All changes must be opt-in, meaning the user must take non-default action to enact the change.</li> <li>The opt-"
+"in dialog must clearly state the name of the add-on requesting the change.</li> <li>Uninstalling the add-on restores the user's original settings if they were changed.</li> </ul> <p>*Unexpected "
+"features are those that are unrelated to the add-on's primary function.</p>"
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:268
@@ -5859,8 +5795,8 @@ msgstr ""
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:282
 msgid ""
-"Add-ons that store or otherwise handle browsing data must support <a href=\"https://developer.mozilla.org/En/Supporting_private_browsing_mode\">Private Browsing Mode</a>.  During a Private Browsing"
-" session, no browsing data can be written to disk, and all of this data must be cleared when Firefox quits or the Private Browsing session ends."
+"Add-ons that store or otherwise handle browsing data must support <a href=\"https://developer.mozilla.org/En/Supporting_private_browsing_mode\">Private Browsing Mode</a>. During a Private Browsing "
+"session, no browsing data can be written to disk, and all of this data must be cleared when Firefox quits or the Private Browsing session ends."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:287
@@ -5903,10 +5839,10 @@ msgstr ""
 
 #: src/olympia/devhub/templates/devhub/docs/policies-submission.html:25
 msgid ""
-"<strong>Is the add-on clearly and accurately described?</strong> It's of the utmost importance to us that users get what they expect when they try a new add-on. Your add-on name should be clear and"
-" concise, and you should refrain from using special characters or numbers to get higher search rankings or for decorative purposes. Your description should provide details about what the add-on "
-"does, how a user should take advantage of it, and what the user should expect when they install it. Links to external documents for detailed instructions are fine, but the description itself should"
-" cover the basics and leave users confident that they know what they'll get. Also, it is important that you maintain version notes appropriately as you improve and change your add-on. Users should "
+"<strong>Is the add-on clearly and accurately described?</strong> It's of the utmost importance to us that users get what they expect when they try a new add-on. Your add-on name should be clear and "
+"concise, and you should refrain from using special characters or numbers to get higher search rankings or for decorative purposes. Your description should provide details about what the add-on "
+"does, how a user should take advantage of it, and what the user should expect when they install it. Links to external documents for detailed instructions are fine, but the description itself should "
+"cover the basics and leave users confident that they know what they'll get. Also, it is important that you maintain version notes appropriately as you improve and change your add-on. Users should "
 "be able to see what's new in an add-on they may have tried previously, and should be made aware of changes that might affect their current use of the add-on when they update."
 msgstr ""
 
@@ -5920,8 +5856,8 @@ msgstr ""
 #: src/olympia/devhub/templates/devhub/docs/policies-submission.html:37
 msgid ""
 "<strong>Has the add-on been well-tested, and is it free of obvious or serious defects?</strong> One important thing that we look for when considering an add-on is whether its user reviews indicate "
-"that it has received thorough testing, and that it doesn't have serious problems or negative impacts on the browser. If reviewers report problems such as major performance issues, crashes, frequent"
-" problems using the functions of the add-on, or spamming of messages to the error console, you should take those reports to heart, and re-submit your add-on after you've addressed them as best you "
+"that it has received thorough testing, and that it doesn't have serious problems or negative impacts on the browser. If reviewers report problems such as major performance issues, crashes, frequent "
+"problems using the functions of the add-on, or spamming of messages to the error console, you should take those reports to heart, and re-submit your add-on after you've addressed them as best you "
 "can. We don't expect you to perfectly optimize or have zero bugs &mdash; Firefox itself undergoes constant improvement in these areas &mdash; but we do want you to take reasonable efforts to "
 "minimize downsides, and to clearly call out cases where users may be surprised by those that remain."
 msgstr ""
@@ -5929,8 +5865,8 @@ msgstr ""
 #: src/olympia/devhub/templates/devhub/docs/policies-submission.html:43
 msgid ""
 "<strong>Do the add-on and add-on author both treat the user respectfully?</strong> Your software should not intrude on the user unnecessarily, try to trick the user, or conceal any of its "
-"activities from the user. Users (or even non-users) are sometimes rude in their comments, and while we will do our best to filter out inaccurate reviews as they're reported to us, we do expect that"
-" authors will avoid retaliating with rudeness of their own."
+"activities from the user. Users (or even non-users) are sometimes rude in their comments, and while we will do our best to filter out inaccurate reviews as they're reported to us, we do expect that "
+"authors will avoid retaliating with rudeness of their own."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/docs/policies-submission.html:49
@@ -5941,8 +5877,8 @@ msgstr ""
 
 #: src/olympia/devhub/templates/devhub/docs/policies-submission.html:55
 msgid ""
-"We are constantly looking at ways to improve the organization of the site to better accommodate add-ons that are exemplary in other ways, but are aimed at only a small community of potential users."
-" Correctly categorizing and maintaining the metadata of your add-on will help us figure out how we can surface more of those sorts of add-ons to people who are most likely to benefit from them."
+"We are constantly looking at ways to improve the organization of the site to better accommodate add-ons that are exemplary in other ways, but are aimed at only a small community of potential users. "
+"Correctly categorizing and maintaining the metadata of your add-on will help us figure out how we can surface more of those sorts of add-ons to people who are most likely to benefit from them."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/docs/policies-submission.html:61
@@ -5953,8 +5889,8 @@ msgstr ""
 
 #: src/olympia/devhub/templates/devhub/docs/policies-submission.html:67
 msgid ""
-"<strong>Is the add-on free of unlicensed trademarks and copyrights?</strong> Though you may mean no harm to the holder of a trademark, or the owner of a copyrighted work, we can't host add-ons that"
-" infringe on trademarks or copyrights. If you don't have permission to use a trademarked name or image, please do not submit your add-on to us. If your add-on includes code that is copyrighted by "
+"<strong>Is the add-on free of unlicensed trademarks and copyrights?</strong> Though you may mean no harm to the holder of a trademark, or the owner of a copyrighted work, we can't host add-ons that "
+"infringe on trademarks or copyrights. If you don't have permission to use a trademarked name or image, please do not submit your add-on to us. If your add-on includes code that is copyrighted by "
 "someone else, and is not licensed to you to use in your add-on, please do not submit your add-on to us."
 msgstr ""
 
@@ -5978,8 +5914,8 @@ msgstr "Лицензиране"
 
 #: src/olympia/devhub/templates/devhub/docs/policies-submission.html:86
 msgid ""
-"Selecting an appropriate license for your add-on is a very important step in the submission process. A license specifies the rights you grant on your source code and is important in protecting your"
-" intellectual property."
+"Selecting an appropriate license for your add-on is a very important step in the submission process. A license specifies the rights you grant on your source code and is important in protecting your "
+"intellectual property."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/docs/policies-submission.html:92
@@ -6027,121 +5963,95 @@ msgstr ""
 msgid "How to get in touch with us regarding these policies or your add-on."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:6
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:10
 msgid "You have disabled this add-on"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:20
-msgid ""
-"Your add-on's listing is disabled and is not showing\n"
-"                             anywhere in our gallery or update service."
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:24
+msgid "Your add-on's listing is disabled and is not showing anywhere in our gallery or update service."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:25
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:27
 msgid "Please complete your add-on."
 msgstr "Моля, завършете добавката си."
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:29
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:30
 msgid "You will receive an email when the review is complete."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:34
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:33
 msgid "You will receive an email when the review is complete. Until then, your add-on is not listed in our gallery but can be accessed directly from its details page."
 msgstr "Ще получите имейл, когато прегледът е завършен. Дотогава добавката ви няма да е показана в галерията ни, но е достъпна директно от страницата ѝ."
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:38 src/olympia/devhub/templates/devhub/includes/addon_details.html:48
-msgid ""
-"You will receive an email when the review is\n"
-"                             complete and your add-on is signed."
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:37 src/olympia/devhub/templates/devhub/includes/addon_details.html:45
+msgid "You will receive an email when the review is complete and your add-on is signed."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:44
-msgid "You will receive an email when the review is complete. Until then, your add-on is not listed in our gallery but can be accessed directly from its details page."
-msgstr "Ще получите имейл, когато прегледът е завършен. Дотогава добавката ви няма да е показана в галерията ни, но е достъпна директно от страницата ѝ."
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:41
+msgid "You will receive an email when the review is complete. Until then, your add-on is not listed in our gallery but can be accessed directly from its details page. "
+msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:54
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:49
 msgid "Your add-on is displayed in our gallery and users are receiving automatic updates."
 msgstr "Добавката ви се показва в галерията ни и потребителите получават автоматични актуализации."
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:57
-msgid ""
-"Your add-on has been signed and can be bundled with an\n"
-"                             application installer."
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:52
+msgid "Your add-on has been signed and can be bundled with an application installer."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:63
-msgid ""
-"Your add-on was disabled by a site administrator and is no\n"
-"                             longer shown in our gallery. If you have any questions,\n"
-"                             please email amo-admins@mozilla.org."
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:56
+msgid "Your add-on was disabled by a site administrator and is no longer shown in our gallery. If you have any questions, please email amo-admins@mozilla.org."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:70
-msgid ""
-"Your add-on is displayed in our gallery as experimental\n"
-"                             and users are receiving automatic updates. Some features\n"
-"                             are unavailable to your add-on."
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:62
+msgid "Your add-on is displayed in our gallery as experimental and users are receiving automatic updates. Some features are unavailable to your add-on."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:74
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:66
 msgid "Your add-on has been signed."
 msgstr ""
 
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:69
+msgid ""
+"You will receive an email when the full review is complete. Until then, your add-on is displayed in our gallery as experimental and users are receiving automatic updates. Some features are "
+"unavailable to your add-on."
+msgstr ""
+
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:74
+msgid "You will receive an email when the full review is complete, making you able to bundle your add-on with an application installer."
+msgstr ""
+
 #: src/olympia/devhub/templates/devhub/includes/addon_details.html:79
-msgid ""
-"You will receive an email when the full review is complete.\n"
-"                             Until then, your add-on is displayed in our gallery as\n"
-"                             experimental and users are receiving automatic updates.\n"
-"                             Some features are unavailable to your add-on."
+msgid "All add-ons hosted in our gallery must now be reviewed by an editor. If you wish to continue hosting your add-on, please click to select a review process."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:84
-msgid ""
-"You will receive an email when the full review is\n"
-"                             complete, making you able to bundle your add-on with an\n"
-"                             application installer."
-msgstr ""
-
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:91
-msgid ""
-"All add-ons hosted in our gallery must now be reviewed by an\n"
-"                             editor. If you wish to continue hosting your add-on, please\n"
-"                             click to select a review process."
-msgstr ""
-
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:113
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:100
 msgid "Current Version:"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:115
-msgid ""
-"This is the version of your add-on that will\n"
-"                                           be installed if someone clicks the Install\n"
-"                                           button on addons.mozilla.org. It is only\n"
-"                                           relevant for listed add-ons."
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:102
+msgid "This is the version of your add-on that will be installed if someone clicks the Install button on addons.mozilla.org. It is only relevant for listed add-ons."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:123
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:110
 msgid "Created:"
 msgstr ""
 
 #. {0} is a date. dennis-ignore: E201
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:125 src/olympia/devhub/templates/devhub/includes/addon_details.html:131
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:112 src/olympia/devhub/templates/devhub/includes/addon_details.html:118
 #, python-format
 msgid "%%b %%e, %%Y"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:136
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:123
 msgid "Next Version:"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:138
-msgid ""
-"This is the newest uploaded version, however\n"
-"                                           it isn’t live on the site yet."
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:125
+msgid "This is the newest uploaded version, however it isn’t live on the site yet."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:144 src/olympia/devhub/templates/devhub/versions/list.html:30
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:130 src/olympia/devhub/templates/devhub/versions/list.html:30
 msgid "Queues are not reviewed strictly in order"
 msgstr ""
 
@@ -6218,9 +6128,7 @@ msgid "View the blog &#9658;"
 msgstr "Вижте повече &#9658;"
 
 #: src/olympia/devhub/templates/devhub/includes/license_form.html:6
-msgid ""
-"Please choose a license appropriate for the rights you grant on your source code.\n"
-"                  It is only relevant for listed add-ons."
+msgid "Please choose a license appropriate for the rights you grant on your source code. It is only relevant for listed add-ons."
 msgstr ""
 
 #. {0} is a list of HTML tags.
@@ -6247,14 +6155,11 @@ msgstr[1] ""
 #: src/olympia/devhub/templates/devhub/includes/policy_form.html:4
 msgid ""
 "Users will be required to accept the following End-User License Agreement (EULA) prior to installing your add-on. The presence of a EULA significantly affects the number of downloads an add-on "
-"receives. Please note that a EULA is not the same as a code license, such as the GPL or MPL.\n"
-"                It is only relevant for listed add-ons."
+"receives. Please note that a EULA is not the same as a code license, such as the GPL or MPL.It is only relevant for listed add-ons."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/policy_form.html:21
-msgid ""
-"If your add-on transmits any data from the user's computer, a privacy policy is required that explains what data is sent and how it is used.\n"
-"                It is only relevant for listed add-ons."
+#: src/olympia/devhub/templates/devhub/includes/policy_form.html:24
+msgid "If your add-on transmits any data from the user's computer, a privacy policy is required that explains what data is sent and how it is used. It is only relevant for listed add-ons."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/includes/source_form_field.html:2
@@ -6395,8 +6300,8 @@ msgstr "Автоматично ще пратим това съобщение н�
 
 #: src/olympia/devhub/templates/devhub/payments/voluntary.html:49
 msgid ""
-"We recommend thanking the user and telling them how much you appreciate their support. You might also want to tell them about what's next for your add-on and about any other add-ons you've made for"
-" them to try."
+"We recommend thanking the user and telling them how much you appreciate their support. You might also want to tell them about what's next for your add-on and about any other add-ons you've made for "
+"them to try."
 msgstr ""
 "Препоръчваме да благодарите на потребителя и да му кажете колко много оценявате подкрепата му. Може също и да искате да му кажете какво следва за добавката ви или за други добавки, които сте "
 "направили да опитат."
@@ -6432,12 +6337,8 @@ msgstr "Изберете категория, която най-добре опи
 msgid "Add some tags to describe your Theme."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/personas/edit.html:106
-msgid ""
-"A short explanation of your theme's\n"
-"                                basic functionality that is displayed in\n"
-"                                search and browse listings, as well as at\n"
-"                                the top of your theme's details page."
+#: src/olympia/devhub/templates/devhub/personas/edit.html:106 src/olympia/devhub/templates/devhub/personas/submit.html:54
+msgid "A short explanation of your theme's basic functionality that is displayed in search and browse listings, as well as at the top of your theme's details page."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/personas/edit.html:122 src/olympia/devhub/templates/devhub/personas/submit.html:68
@@ -6516,7 +6417,7 @@ msgid "Upon upload and form submission, the AMO Team will review your updated de
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/personas/edit.html:241
-msgid "Your previously resubmitted design,  which is under pending review."
+msgid "Your previously resubmitted design, which is under pending review."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/personas/edit.html:245
@@ -6583,14 +6484,6 @@ msgstr ""
 
 #: src/olympia/devhub/templates/devhub/personas/submit.html:33
 msgid "Give your Theme a name."
-msgstr ""
-
-#: src/olympia/devhub/templates/devhub/personas/submit.html:54
-msgid ""
-"A short explanation of your theme's\n"
-"                                      basic functionality that is displayed in\n"
-"                                      search and browse listings, as well as at\n"
-"                                      the top of your theme's details page."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/personas/submit.html:198
@@ -6673,30 +6566,16 @@ msgstr "Избери друго долно изображение"
 msgid "Files added to reviewed versions must be reviewed before they will be available for download."
 msgstr "Файловете добавени към прегледани версии, трябва да бъдат прегледани преди да бъдат достъпни за сваляне."
 
-#: src/olympia/devhub/templates/devhub/versions/add_file_modal.html:15
-#, python-format
-msgid ""
-"Submission of updates to unlisted add-ons for signing is currently in an open beta. Manual review may still be required for a large number of add-ons. Please <a href=\"%(url)s\" "
-"target=\"_blank\">report any bugs</a> that you encounter."
-msgstr ""
-
-#: src/olympia/devhub/templates/devhub/versions/add_file_modal.html:35
+#: src/olympia/devhub/templates/devhub/versions/add_file_modal.html:24
 msgid "Select the target platform for this file."
 msgstr "Избери целевата платформа за този файл."
 
-#: src/olympia/devhub/templates/devhub/versions/add_file_modal.html:46
+#: src/olympia/devhub/templates/devhub/versions/add_file_modal.html:35
 msgid "Which review type would you like to nominate for?"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/add_file_modal.html:51
+#: src/olympia/devhub/templates/devhub/versions/add_file_modal.html:40
 msgid "Only publish this version to my beta channel."
-msgstr ""
-
-#: src/olympia/devhub/templates/devhub/versions/add_file_modal.html:54
-#, python-format
-msgid ""
-"The behavior of the beta channel has changed to accommodate <a href=\"%(addon_signing_url)s\" target=\"_blank\">mandatory add-on signing</a>. The new process is currently in an open beta, and may "
-"change significantly in the near future. Please <a href=\"%(issues_url)s\" target=\"_blank\">report any bugs</a> that you encounter."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/versions/edit.html:5
@@ -6721,16 +6600,10 @@ msgstr "Файлове"
 msgid "Upload Another File"
 msgstr "Качи друг файл"
 
-#: src/olympia/devhub/templates/devhub/versions/edit.html:45
-msgid "Adjusting application information here will allow users to install your add-on even if the install manifest in the package indicates that the add-on is incompatible."
-msgstr "Нагласяването на информацията на приложението тук ще даде възможност на потребителите да инсталират добавката ви, дори ако инсталационния манифест показва, че тя не е съвместима."
-
 #: src/olympia/devhub/templates/devhub/versions/edit.html:74
 msgid ""
-"Information about changes in this release, new features,\n"
-"                              known bugs, and other useful information specific to this\n"
-"                              release/version. This information is also shown in the\n"
-"                              Add-ons Manager when updating."
+"Information about changes in this release, new features, known bugs, and other useful information specific to this release/version. This information is also shown in the Add-ons Manager when "
+"updating."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/versions/edit.html:99
@@ -6742,10 +6615,7 @@ msgid "Notes for Reviewers"
 msgstr "Бележки за преглеждащите"
 
 #: src/olympia/devhub/templates/devhub/versions/edit.html:114
-msgid ""
-"Optionally, enter any information that may be useful\n"
-"                              to the Editor reviewing this add-on, such as test\n"
-"                              account information."
+msgid "Optionally, enter any information that may be useful to the Editor reviewing this add-on, such as test account information."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/versions/edit.html:127
@@ -6825,7 +6695,7 @@ msgstr "Поискай пълен преглед"
 msgid "Request Preliminary Review"
 msgstr "Поискай предварителен преглед"
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:80 src/olympia/devhub/templates/devhub/versions/list.html:327 src/olympia/devhub/templates/devhub/versions/list.html:350
+#: src/olympia/devhub/templates/devhub/versions/list.html:80 src/olympia/devhub/templates/devhub/versions/list.html:325 src/olympia/devhub/templates/devhub/versions/list.html:348
 msgid "Cancel Review Request"
 msgstr "Откажи искането за рецензия"
 
@@ -6854,7 +6724,7 @@ msgid "Unlisted:"
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/versions/list.html:114
-msgid "Not distributed on {0}. Developers will upload new versions for signing and distribute the add-ons on their own. (beta)"
+msgid "Not distributed on {0}. Developers will upload new versions for signing and distribute the add-ons on their own."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/versions/list.html:122
@@ -6905,7 +6775,8 @@ msgid "Delete Version {version}"
 msgstr "Изтрий версия {version}"
 
 #: src/olympia/devhub/templates/devhub/versions/list.html:218
-msgid "You are about to delete the current version of your add-on. This may cause your add-on status to change, or your listing to lose public visibility, if this is the only public version of your add-on."
+msgid ""
+"You are about to delete the current version of your add-on. This may cause your add-on status to change, or your listing to lose public visibility, if this is the only public version of your add-on."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/versions/list.html:219
@@ -6917,81 +6788,73 @@ msgid "<strong>Important:</strong> Once a version has been deleted, you may not 
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/versions/list.html:230
-msgid ""
-"Deleting a version which has already been reviewed\n"
-"               may also cause a significant delay in the review of\n"
-"               your next update."
-msgstr ""
-
-#: src/olympia/devhub/templates/devhub/versions/list.html:233
 msgid "Are you sure you wish to delete this version?"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:238
+#: src/olympia/devhub/templates/devhub/versions/list.html:235
 msgid "Delete Version"
 msgstr "Изтрий версия"
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:240
+#: src/olympia/devhub/templates/devhub/versions/list.html:237
 msgid "Disable Version"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:247
+#: src/olympia/devhub/templates/devhub/versions/list.html:244
 msgid "Add a new Version"
 msgstr "Добави нова версия"
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:249
+#: src/olympia/devhub/templates/devhub/versions/list.html:246
 msgid "Add Version"
 msgstr "Добави версия"
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:256 src/olympia/devhub/templates/devhub/versions/list.html:274
+#: src/olympia/devhub/templates/devhub/versions/list.html:253 src/olympia/devhub/templates/devhub/versions/list.html:279
 msgid "Hide Add-on"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:259
+#: src/olympia/devhub/templates/devhub/versions/list.html:256
 msgid "Hiding your add-on will prevent it from appearing anywhere in our gallery and will stop users from receiving automatic updates."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:265
+#: src/olympia/devhub/templates/devhub/versions/list.html:263
+msgid "The files awaiting review will be disabled and you will need to upload new versions."
+msgstr ""
+
+#: src/olympia/devhub/templates/devhub/versions/list.html:270
 msgid "Are you sure you wish to hide your add-on?"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:286 src/olympia/devhub/templates/devhub/versions/list.html:315
+#: src/olympia/devhub/templates/devhub/versions/list.html:291 src/olympia/devhub/templates/devhub/versions/list.html:313
 msgid "Unlist Add-on"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:289
+#: src/olympia/devhub/templates/devhub/versions/list.html:294
 #, python-format
 msgid ""
 "Unlisting your add-on will make it (and each of its versions/files) invisible on this website. It won't show up in searches, won't have a public facing page, and won't be updated automatically for "
-"current users.  It is recommended for unlisted add-ons to provide a custom <a href=\"%(update_url)s\" target=\"_blank\">updateURL</a> in their manifest file for automatic updates."
+"current users. It is recommended for unlisted add-ons to provide a custom <a href=\"%(update_url)s\" target=\"_blank\">updateURL</a> in their manifest file for automatic updates."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:299
-#, python-format
-msgid "Switching add-ons to unlisted is currently in an open beta. Please <a href=\"%(url)s\" target=\"_blank\">report any bugs</a> that you encounter."
-msgstr ""
-
-#: src/olympia/devhub/templates/devhub/versions/list.html:305
+#: src/olympia/devhub/templates/devhub/versions/list.html:303
 msgid "Unlisting an add-on is irreversible!"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:305
+#: src/olympia/devhub/templates/devhub/versions/list.html:303
 msgid "An unlisted add-on cannot be switched to be listed."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:307
+#: src/olympia/devhub/templates/devhub/versions/list.html:305
 msgid "Are you sure you wish to unlist your add-on?"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:330
+#: src/olympia/devhub/templates/devhub/versions/list.html:328
 msgid "Canceling your review request will leave your add-on as preliminarily reviewed."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:335
+#: src/olympia/devhub/templates/devhub/versions/list.html:333
 msgid "Canceling your review request will mark your add-on incomplete. If you do not complete your add-on after several days by re-requesting review, it will be deleted."
 msgstr "Отказването на искането ви за преглед ще маркира добавката ви като незавършена. Ако не завършите добавката си след няколко дни, като пак поискате преглед, тя ще бъде изтритя."
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:343
+#: src/olympia/devhub/templates/devhub/versions/list.html:341
 msgid "Are you sure you wish to cancel your review request?"
 msgstr "Сигурни ли сте, че искате да откажете заявката си за рецензия?"
 
@@ -7180,8 +7043,8 @@ msgstr "Какво са разширенията?"
 #, python-format
 msgid "Add-ons are applications that let you personalize %(app)s with extra functionality or style. Try a time-saving sidebar, a weather notifier, or a themed look to make %(app)s your own."
 msgstr ""
-"Добавките са приложения, които ви дават възможност да персонализирате %(app)s с допълнителна функционалност или стил. Опитайте странична лента, спестяваща време, нотификатор за времети или тема, за"
-" да направите %(app)s ваша собствена."
+"Добавките са приложения, които ви дават възможност да персонализирате %(app)s с допълнителна функционалност или стил. Опитайте странична лента, спестяваща време, нотификатор за времети или тема, за "
+"да направите %(app)s ваша собствена."
 
 #: src/olympia/discovery/templates/discovery/pane.html:62
 msgid "Learn More About Add-ons"
@@ -7343,19 +7206,19 @@ msgstr ""
 msgid "Search by add-on name / author email"
 msgstr "Търси по име на добавката / имейл на автора"
 
-#: src/olympia/editors/forms.py:103
+#: src/olympia/editors/forms.py:103 src/olympia/editors/forms.py:244 src/olympia/editors/forms.py:257
 msgid "yes"
 msgstr "да"
 
-#: src/olympia/editors/forms.py:104
+#: src/olympia/editors/forms.py:104 src/olympia/editors/forms.py:244 src/olympia/editors/forms.py:257
 msgid "no"
 msgstr "но"
 
-#: src/olympia/editors/forms.py:105
+#: src/olympia/editors/forms.py:105 src/olympia/editors/forms.py:245
 msgid "Admin Flag"
 msgstr "Администраторски флаг"
 
-#: src/olympia/editors/forms.py:113
+#: src/olympia/editors/forms.py:113 src/olympia/editors/forms.py:253
 msgid "Max. Version"
 msgstr "Макс. версия"
 
@@ -7367,55 +7230,59 @@ msgstr "Дни от пращането"
 msgid "Add-on Types"
 msgstr "Видове добавки"
 
-#: src/olympia/editors/forms.py:126 src/olympia/editors/helpers.py:267
+#: src/olympia/editors/forms.py:126 src/olympia/editors/helpers.py:279
 msgid "Platforms"
 msgstr "Платформи"
 
+#: src/olympia/editors/forms.py:237
+msgid "Search by add-on name / author email / guid"
+msgstr ""
+
 #. L10n: 0 = platform, 1 = filename, 2 = status message
-#: src/olympia/editors/forms.py:238
+#: src/olympia/editors/forms.py:342
 #, python-format
 msgid "<strong>%s</strong> &middot; %s &middot; %s"
 msgstr "<strong>%s</strong> &middot; %s &middot; %s"
 
-#: src/olympia/editors/forms.py:252
+#: src/olympia/editors/forms.py:356
 msgid "Comments:"
 msgstr "Коментари:"
 
-#: src/olympia/editors/forms.py:256
+#: src/olympia/editors/forms.py:360
 msgid "Operating systems:"
 msgstr "Операционни системи:"
 
-#: src/olympia/editors/forms.py:258
+#: src/olympia/editors/forms.py:362
 msgid "Applications:"
 msgstr "Приложения:"
 
-#: src/olympia/editors/forms.py:260
+#: src/olympia/editors/forms.py:364
 msgid "Notify me the next time this add-on is updated. (Subsequent updates will not generate an email)"
 msgstr "Уведоми ме следващия път, когато тази добавка е обновена. (Последователни актуализации няма да генерират имейл)"
 
-#: src/olympia/editors/forms.py:265
+#: src/olympia/editors/forms.py:369
 msgid "Clear Admin Review Flag"
 msgstr ""
 
-#: src/olympia/editors/forms.py:267
+#: src/olympia/editors/forms.py:371
 msgid "Clear more info requested flag"
 msgstr ""
 
-#: src/olympia/editors/forms.py:281
+#: src/olympia/editors/forms.py:385
 msgid "Choose a canned response..."
 msgstr "Изберете шаблонен отговор..."
 
 #. L10n: Description of what can be searched for.
-#: src/olympia/editors/forms.py:324
+#: src/olympia/editors/forms.py:423
 msgid "theme name"
 msgstr ""
 
-#: src/olympia/editors/forms.py:350
+#: src/olympia/editors/forms.py:449
 msgid "Someone else is reviewing this theme."
 msgstr ""
 
 #. L10n: Description of what can be searched for.
-#: src/olympia/editors/forms.py:447
+#: src/olympia/editors/forms.py:546
 msgid "app, reviewer, or comment"
 msgstr ""
 
@@ -7431,67 +7298,71 @@ msgstr "Чакаща предварителна рецензия"
 msgid "Rejected or Unreviewed"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:123 src/olympia/editors/helpers.py:136
+#: src/olympia/editors/helpers.py:125 src/olympia/editors/helpers.py:138
 msgid "Queue"
 msgstr "Опашка"
 
-#: src/olympia/editors/helpers.py:124 src/olympia/editors/templates/editors/base.html:50 src/olympia/editors/templates/editors/base.html:65
+#: src/olympia/editors/helpers.py:126 src/olympia/editors/templates/editors/base.html:50 src/olympia/editors/templates/editors/base.html:65
 msgid "Pending Updates"
 msgstr "Чакащи актуализации"
 
-#: src/olympia/editors/helpers.py:125 src/olympia/editors/templates/editors/base.html:48 src/olympia/editors/templates/editors/base.html:63
+#: src/olympia/editors/helpers.py:127 src/olympia/editors/templates/editors/base.html:48 src/olympia/editors/templates/editors/base.html:63
 msgid "Full Reviews"
 msgstr "Пълни рецензии"
 
-#: src/olympia/editors/helpers.py:126 src/olympia/editors/templates/editors/base.html:52 src/olympia/editors/templates/editors/base.html:67
+#: src/olympia/editors/helpers.py:128 src/olympia/editors/templates/editors/base.html:52 src/olympia/editors/templates/editors/base.html:67
 msgid "Preliminary Reviews"
 msgstr "Предварителни рецензии"
 
-#: src/olympia/editors/helpers.py:127 src/olympia/editors/templates/editors/base.html:54
+#: src/olympia/editors/helpers.py:129 src/olympia/editors/templates/editors/base.html:54
 msgid "Moderated Reviews"
 msgstr "Модерирани рецензии"
 
-#: src/olympia/editors/helpers.py:128 src/olympia/editors/templates/editors/base.html:46
+#: src/olympia/editors/helpers.py:130 src/olympia/editors/templates/editors/base.html:46
 msgid "Fast Track"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:130
+#: src/olympia/editors/helpers.py:132
 msgid "Pending Themes"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:131 src/olympia/editors/templates/editors/themes/queue.html:4
+#: src/olympia/editors/helpers.py:133 src/olympia/editors/templates/editors/themes/queue.html:4
 msgid "Flagged Themes"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:132
+#: src/olympia/editors/helpers.py:134
 msgid "Update Themes"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:137
+#: src/olympia/editors/helpers.py:139
 msgid "Unlisted Pending Updates"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:138
+#: src/olympia/editors/helpers.py:140
 msgid "Unlisted Full Reviews"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:139
+#: src/olympia/editors/helpers.py:141
 msgid "Unlisted Preliminary Reviews"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:170
+#: src/olympia/editors/helpers.py:142
+msgid "Unlisted All Add-ons"
+msgstr ""
+
+#: src/olympia/editors/helpers.py:173
 msgid "Fast Track ({0})"
 msgid_plural "Fast Track ({0})"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/olympia/editors/helpers.py:175
+#: src/olympia/editors/helpers.py:178
 msgid "Full Review ({0})"
 msgid_plural "Full Reviews ({0})"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/olympia/editors/helpers.py:180
+#: src/olympia/editors/helpers.py:183
 msgid "Pending Update ({0})"
 msgid_plural "Pending Updates ({0})"
 msgstr[0] ""
@@ -7499,7 +7370,7 @@ msgstr[1] ""
 
 # 75%
 # 100%
-#: src/olympia/editors/helpers.py:185
+#: src/olympia/editors/helpers.py:188
 msgid "Preliminary Review ({0})"
 msgid_plural "Preliminary Reviews ({0})"
 msgstr[0] "Предварителен преглед ({0})"
@@ -7508,178 +7379,192 @@ msgstr[1] "Предварителни прегледи ({0})"
 # 80%
 # 77%
 # 100%
-#: src/olympia/editors/helpers.py:190
+#: src/olympia/editors/helpers.py:193
 msgid "Moderated Review ({0})"
 msgid_plural "Moderated Reviews ({0})"
 msgstr[0] "Модерирана рецензия ({0})"
 msgstr[1] "Модерирани рецензии ({0})"
 
-#: src/olympia/editors/helpers.py:196
+#: src/olympia/editors/helpers.py:199
 msgid "Unlisted Full Review ({0})"
 msgid_plural "Unlisted Full Reviews ({0})"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/olympia/editors/helpers.py:201
+#: src/olympia/editors/helpers.py:204
 msgid "Unlisted Pending Update ({0})"
 msgid_plural "Unlisted Pending Updates ({0})"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/olympia/editors/helpers.py:206
+#: src/olympia/editors/helpers.py:209
 msgid "Unlisted Preliminary Review ({0})"
 msgid_plural "Unlisted Preliminary Reviews ({0})"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/olympia/editors/helpers.py:261
-msgid "Addon"
-msgstr "Добавка"
+#: src/olympia/editors/helpers.py:214
+msgid "Unlisted All Add-ons ({0})"
+msgid_plural "Unlisted All Add-ons ({0})"
+msgstr[0] ""
+msgstr[1] ""
 
-#: src/olympia/editors/helpers.py:262
+#: src/olympia/editors/helpers.py:274
 msgid "Type"
 msgstr "Тип"
 
-#: src/olympia/editors/helpers.py:263
+#: src/olympia/editors/helpers.py:275
 msgid "Waiting Time"
 msgstr "Време за чакане"
 
-#: src/olympia/editors/helpers.py:264 src/olympia/editors/templates/editors/review.html:285
+#: src/olympia/editors/helpers.py:276 src/olympia/editors/templates/editors/review.html:285
 msgid "Flags"
 msgstr "Флагове"
 
-#: src/olympia/editors/helpers.py:265
+#: src/olympia/editors/helpers.py:277
 msgid "Applications"
 msgstr "Приложения"
 
-#: src/olympia/editors/helpers.py:270
+#: src/olympia/editors/helpers.py:282
 msgid "Additional"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:285
+#: src/olympia/editors/helpers.py:302
 msgid "Site Specific"
 msgstr "Специфични за сайт"
 
-#: src/olympia/editors/helpers.py:287
+#: src/olympia/editors/helpers.py:304
 msgid "Requires External Software"
 msgstr "Изисква външен софтуер"
 
-#: src/olympia/editors/helpers.py:289
+#: src/olympia/editors/helpers.py:306
 msgid "Binary Components"
 msgstr "Бинарни компоненти"
 
-#: src/olympia/editors/helpers.py:313
+#: src/olympia/editors/helpers.py:339
 msgid "moments ago"
 msgstr "преди секунди"
 
 #. L10n: first argument is number of minutes
-#: src/olympia/editors/helpers.py:316
+#: src/olympia/editors/helpers.py:342
 msgid "{0} minute"
 msgid_plural "{0} minutes"
 msgstr[0] "{0} минута"
 msgstr[1] "{0} минути"
 
 #. L10n: first argument is number of hours
-#: src/olympia/editors/helpers.py:320
+#: src/olympia/editors/helpers.py:346
 msgid "{0} hour"
 msgid_plural "{0} hours"
 msgstr[0] "{0} час"
 msgstr[1] "{0} часа"
 
 #. L10n: first argument is number of days
-#: src/olympia/editors/helpers.py:324
+#: src/olympia/editors/helpers.py:350
 msgid "{0} day"
 msgid_plural "{0} days"
 msgstr[0] "{0} ден"
 msgstr[1] "{0} дни"
 
-#: src/olympia/editors/helpers.py:488
+#: src/olympia/editors/helpers.py:364
+msgid "Last Review"
+msgstr ""
+
+#: src/olympia/editors/helpers.py:366
+msgid "Last Update"
+msgstr ""
+
+#: src/olympia/editors/helpers.py:387
+msgid "No Reviews"
+msgstr ""
+
+#: src/olympia/editors/helpers.py:561
 msgid "Push to public"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:490
+#: src/olympia/editors/helpers.py:563
 msgid "Grant full review"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:505
+#: src/olympia/editors/helpers.py:578
 msgid "Request more information"
 msgstr "Изискай още информация"
 
-#: src/olympia/editors/helpers.py:508
+#: src/olympia/editors/helpers.py:581
 msgid "Request super-review"
 msgstr "Поискай супер рецензия"
 
-#: src/olympia/editors/helpers.py:519
+#: src/olympia/editors/helpers.py:592
 msgid "Grant preliminary review"
 msgstr "Даване на предварителна рецензия"
 
-#: src/olympia/editors/helpers.py:520
+#: src/olympia/editors/helpers.py:593
 msgid "This will mark the files as preliminarily reviewed."
 msgstr ""
 
-#: src/olympia/editors/helpers.py:522
+#: src/olympia/editors/helpers.py:595
 msgid "Use this form to request more information from the author. They will receive an email and be able to answer here. You will be notified by email when they reply."
 msgstr ""
 
-#: src/olympia/editors/helpers.py:526
+#: src/olympia/editors/helpers.py:599
 msgid ""
 "If you have concerns about this add-on's security, copyright issues, or other concerns that an administrator should look into, enter your comments in the area below. They will be sent to "
 "administrators, not the author."
 msgstr ""
 
-#: src/olympia/editors/helpers.py:532
+#: src/olympia/editors/helpers.py:605
 msgid "This will reject the add-on and remove it from the review queue."
 msgstr ""
 
-#: src/olympia/editors/helpers.py:534
-msgid "Make a comment on this version.  The author won't be able to see this."
+#: src/olympia/editors/helpers.py:607
+msgid "Make a comment on this version. The author won't be able to see this."
 msgstr ""
 
-#: src/olympia/editors/helpers.py:538
+#: src/olympia/editors/helpers.py:611
 msgid "This will reject the files and remove them from the review queue."
 msgstr ""
 
-#: src/olympia/editors/helpers.py:542
+#: src/olympia/editors/helpers.py:615
 msgid "This will mark the add-on as preliminarily reviewed. Future versions will undergo preliminary review."
 msgstr ""
 
-#: src/olympia/editors/helpers.py:547
+#: src/olympia/editors/helpers.py:620
 msgid "This will mark the files as preliminarily reviewed. Future versions will undergo preliminary review."
 msgstr ""
 
-#: src/olympia/editors/helpers.py:552
+#: src/olympia/editors/helpers.py:625
 msgid "Retain preliminary review"
 msgstr "Задръж предварителната рецензия"
 
-#: src/olympia/editors/helpers.py:553
+#: src/olympia/editors/helpers.py:626
 msgid "This will retain the add-on as preliminarily reviewed. Future versions will undergo preliminary review."
 msgstr ""
 
-#: src/olympia/editors/helpers.py:558
+#: src/olympia/editors/helpers.py:631
 msgid "This will approve a sandboxed version of a public add-on to appear on the public side."
 msgstr ""
 
-#: src/olympia/editors/helpers.py:561
+#: src/olympia/editors/helpers.py:634
 msgid "This will reject a version of a public add-on and remove it from the queue."
 msgstr ""
 
-#: src/olympia/editors/helpers.py:564
+#: src/olympia/editors/helpers.py:637
 msgid "This will mark the add-on and its most recent version and files as public. Future versions will go into the sandbox until they are reviewed by an editor."
 msgstr ""
 
 # 83%
 # 100%
-#: src/olympia/editors/helpers.py:637
+#: src/olympia/editors/helpers.py:714
 msgid "add-on"
 msgstr "добавка"
 
-#: src/olympia/editors/helpers.py:940 src/olympia/editors/helpers.py:960
+#: src/olympia/editors/helpers.py:1020 src/olympia/editors/helpers.py:1040
 msgid "Flagged"
 msgstr ""
 
 # 85%
 # 100%
-#: src/olympia/editors/helpers.py:944 src/olympia/editors/helpers.py:963
+#: src/olympia/editors/helpers.py:1024 src/olympia/editors/helpers.py:1043
 msgid "Updates"
 msgstr "Обновления"
 
@@ -7737,56 +7622,56 @@ msgstr ""
 msgid "A question about your Theme submission"
 msgstr ""
 
-#: src/olympia/editors/views.py:144
+#: src/olympia/editors/views.py:146
 msgid "New Add-ons (Under 5 days)"
 msgstr ""
 
-#: src/olympia/editors/views.py:145
+#: src/olympia/editors/views.py:147
 msgid "Passable (5 to 10 days)"
 msgstr ""
 
-#: src/olympia/editors/views.py:146
+#: src/olympia/editors/views.py:148
 msgid "Overdue (Over 10 days)"
 msgstr ""
 
-#: src/olympia/editors/views.py:532
+#: src/olympia/editors/views.py:539
 msgid "An unknown error occurred"
 msgstr ""
 
-#: src/olympia/editors/views.py:587
+#: src/olympia/editors/views.py:592
 msgid "Self-reviews are not allowed."
 msgstr "Собствени рецензии не са позволени."
 
-#: src/olympia/editors/views.py:609
+#: src/olympia/editors/views.py:613
 msgid "Review successfully processed."
 msgstr "Рецензията обработена успешно."
 
-#: src/olympia/editors/views.py:807
+#: src/olympia/editors/views.py:812
 msgid "was approved"
 msgstr "беше одобрем"
 
-#: src/olympia/editors/views.py:808
+#: src/olympia/editors/views.py:813
 msgid "given preliminary review"
 msgstr "получи предварителен преглед"
 
-#: src/olympia/editors/views.py:809
+#: src/olympia/editors/views.py:814
 msgid "rejected"
 msgstr "отказан"
 
-#: src/olympia/editors/views.py:810
+#: src/olympia/editors/views.py:815
 msgctxt "editors_review_history_nominated_adminreview"
 msgid "escalated"
 msgstr "ескалиран"
 
-#: src/olympia/editors/views.py:812
+#: src/olympia/editors/views.py:817
 msgid "needs more information"
 msgstr "има нужда от още информация"
 
-#: src/olympia/editors/views.py:813
+#: src/olympia/editors/views.py:818
 msgid "needs super review"
 msgstr "има нужда от супер рецензия"
 
-#: src/olympia/editors/views.py:814
+#: src/olympia/editors/views.py:819
 msgid "commented"
 msgstr ""
 
@@ -7831,31 +7716,31 @@ msgstr "Опашки"
 msgid "Unlisted Queues"
 msgstr ""
 
-#: src/olympia/editors/templates/editors/base.html:72 src/olympia/editors/templates/editors/performance.html:6
+#: src/olympia/editors/templates/editors/base.html:74 src/olympia/editors/templates/editors/performance.html:6
 msgid "Performance"
 msgstr "Изпълнение"
 
-#: src/olympia/editors/templates/editors/base.html:75 src/olympia/editors/templates/editors/themes/base.html:19 src/olympia/editors/templates/editors/themes/base.html:38
+#: src/olympia/editors/templates/editors/base.html:77 src/olympia/editors/templates/editors/themes/base.html:19 src/olympia/editors/templates/editors/themes/base.html:38
 msgid "Logs"
 msgstr "Записи"
 
-#: src/olympia/editors/templates/editors/base.html:78 src/olympia/editors/templates/editors/reviewlog.html:4 src/olympia/editors/templates/editors/reviewlog.html:27
+#: src/olympia/editors/templates/editors/base.html:80 src/olympia/editors/templates/editors/reviewlog.html:4 src/olympia/editors/templates/editors/reviewlog.html:27
 msgid "Add-on Review Log"
 msgstr ""
 
 # 80%
 # 100%
-#: src/olympia/editors/templates/editors/base.html:80 src/olympia/editors/templates/editors/eventlog.html:4 src/olympia/editors/templates/editors/eventlog.html:8
+#: src/olympia/editors/templates/editors/base.html:82 src/olympia/editors/templates/editors/eventlog.html:4 src/olympia/editors/templates/editors/eventlog.html:8
 #: src/olympia/editors/templates/editors/eventlog_detail.html:4
 #, fuzzy
 msgid "Moderated Review Log"
 msgstr "Модерирани рецензии"
 
-#: src/olympia/editors/templates/editors/base.html:82 src/olympia/editors/templates/editors/beta_signed_log.html:4 src/olympia/editors/templates/editors/beta_signed_log.html:8
+#: src/olympia/editors/templates/editors/base.html:84 src/olympia/editors/templates/editors/beta_signed_log.html:4 src/olympia/editors/templates/editors/beta_signed_log.html:8
 msgid "Signed Beta Files Log"
 msgstr ""
 
-#: src/olympia/editors/templates/editors/base.html:87 src/olympia/editors/templates/editors/includes/daily-message.html:4
+#: src/olympia/editors/templates/editors/base.html:89 src/olympia/editors/templates/editors/includes/daily-message.html:4
 msgid "Announcement"
 msgstr "Обявление"
 
@@ -8097,45 +7982,45 @@ msgstr "Разширено търсене"
 msgid "clear search"
 msgstr "изчиасти търсене"
 
-#: src/olympia/editors/templates/editors/queue.html:72 src/olympia/editors/templates/editors/queue.html:122
+#: src/olympia/editors/templates/editors/queue.html:78 src/olympia/editors/templates/editors/queue.html:128
 msgid "Process Reviews"
 msgstr ""
 
-#: src/olympia/editors/templates/editors/queue.html:80
+#: src/olympia/editors/templates/editors/queue.html:86
 msgid "Moderation actions:"
 msgstr "Действия по модериране:"
 
-#: src/olympia/editors/templates/editors/queue.html:90
+#: src/olympia/editors/templates/editors/queue.html:96
 #, python-format
 msgid "by %(user)s on %(date)s %(stars)s (%(locale)s)"
 msgstr "от %(user)s на %(date)s %(stars)s (%(locale)s)"
 
-#: src/olympia/editors/templates/editors/queue.html:106
+#: src/olympia/editors/templates/editors/queue.html:112
 #, python-format
 msgid "<strong>%(reason)s</strong> <span class=\"light\">Flagged by %(user)s on %(date)s</span>"
 msgstr ""
 
-#: src/olympia/editors/templates/editors/queue.html:119
+#: src/olympia/editors/templates/editors/queue.html:125
 msgid "All reviews have been moderated. Good work!"
 msgstr "Всички рецензии са модерирани. Браво!"
 
-#: src/olympia/editors/templates/editors/queue.html:161
+#: src/olympia/editors/templates/editors/queue.html:167
 msgid "Version Notes / Notes for Reviewer"
 msgstr ""
 
-#: src/olympia/editors/templates/editors/queue.html:169
+#: src/olympia/editors/templates/editors/queue.html:175
 msgid "There are currently no add-ons of this type to review."
 msgstr "В момента няма добавки от този тип за рецензиране."
 
-#: src/olympia/editors/templates/editors/queue.html:181 src/olympia/editors/templates/editors/themes/queue_list.html:85
+#: src/olympia/editors/templates/editors/queue.html:187 src/olympia/editors/templates/editors/themes/queue_list.html:85
 msgid "Helpful Links:"
 msgstr "Полезни връзки:"
 
-#: src/olympia/editors/templates/editors/queue.html:182
+#: src/olympia/editors/templates/editors/queue.html:188
 msgid "Add-on Policy"
 msgstr "Полица на добавката"
 
-#: src/olympia/editors/templates/editors/queue.html:184
+#: src/olympia/editors/templates/editors/queue.html:190
 msgid "Editors' Guide"
 msgstr "Наръчник на редакторите"
 
@@ -8198,10 +8083,7 @@ msgid "<strong>Warning!</strong> Another user was viewing this page before you."
 msgstr ""
 
 #: src/olympia/editors/templates/editors/review.html:237
-msgid ""
-"The whiteboard is the place to exchange information relevant to\n"
-"               this addon (whatever the version), between the developer and the\n"
-"               editor. This is visible and editable by both."
+msgid "The whiteboard is the place to exchange information relevant to this addon (whatever the version), between the developer and the editor. This is visible and editable by both."
 msgstr ""
 
 #: src/olympia/editors/templates/editors/review.html:241
@@ -8304,8 +8186,9 @@ msgstr ""
 
 # 75%
 # 100%
-#: src/olympia/editors/templates/editors/includes/search_results_themes.html:6 src/olympia/editors/templates/editors/themes/history_table.html:7 src/olympia/editors/templates/editors/themes/logs.html:19
-#: src/olympia/editors/templates/editors/themes/queue_list.html:49 src/olympia/editors/templates/editors/themes/single.html:26 src/olympia/editors/templates/editors/themes/themes.html:45
+#: src/olympia/editors/templates/editors/includes/search_results_themes.html:6 src/olympia/editors/templates/editors/themes/history_table.html:7
+#: src/olympia/editors/templates/editors/themes/logs.html:19 src/olympia/editors/templates/editors/themes/queue_list.html:49 src/olympia/editors/templates/editors/themes/single.html:26
+#: src/olympia/editors/templates/editors/themes/themes.html:45
 #, fuzzy
 msgid "Reviewer"
 msgstr "Отзив"
@@ -8480,7 +8363,7 @@ msgstr ""
 msgid "Describe your reason for flagging"
 msgstr ""
 
-#: src/olympia/files/forms.py:88
+#: src/olympia/files/forms.py:90
 msgid "Cannot diff a version against itself"
 msgstr ""
 
@@ -8515,51 +8398,51 @@ msgstr "Имаше грешка при достъпването на файл %s
 msgid "There was an error accessing file %s."
 msgstr "Имаше грешка при достъпването на файл %s."
 
-#: src/olympia/files/utils.py:343
+#: src/olympia/files/utils.py:340
 msgid "Could not parse uploaded file."
 msgstr ""
 
-#: src/olympia/files/utils.py:380
+#: src/olympia/files/utils.py:377
 msgid "Invalid file name in archive: {0}"
 msgstr ""
 
-#: src/olympia/files/utils.py:388
+#: src/olympia/files/utils.py:385
 msgid "File exceeding size limit in archive: {0}"
 msgstr ""
 
-#: src/olympia/files/utils.py:439
+#: src/olympia/files/utils.py:436
 msgid "Invalid archive."
 msgstr "Невалиден архив."
 
-#: src/olympia/files/utils.py:529 src/olympia/files/utils.py:532
+#: src/olympia/files/utils.py:526 src/olympia/files/utils.py:529
 msgid "Could not parse the manifest file."
 msgstr ""
 
-#: src/olympia/files/utils.py:551
+#: src/olympia/files/utils.py:548
 msgid "Could not find an add-on ID."
 msgstr ""
 
-#: src/olympia/files/utils.py:554
+#: src/olympia/files/utils.py:551
 msgid "Add-on ID must be 64 characters or less."
 msgstr ""
 
-#: src/olympia/files/utils.py:556
+#: src/olympia/files/utils.py:553
 msgid "Add-on ID doesn't match add-on."
 msgstr ""
 
-#: src/olympia/files/utils.py:564
+#: src/olympia/files/utils.py:561
 msgid "Duplicate add-on ID found."
 msgstr ""
 
-#: src/olympia/files/utils.py:567
+#: src/olympia/files/utils.py:564
 msgid "Version numbers should have fewer than 32 characters."
 msgstr "Номерата на версиите трябва да са по-малки от 32 знака."
 
-#: src/olympia/files/utils.py:570
+#: src/olympia/files/utils.py:567
 msgid "Version numbers should only contain letters, numbers, and these punctuation characters: +*.-_."
 msgstr "Номерата на версиите трябва да съдържат само букви, цифри и тези пунктуационни знаци: +*.-_."
 
-#: src/olympia/files/utils.py:587
+#: src/olympia/files/utils.py:584
 msgid "<em:type> doesn't match add-on"
 msgstr "<em:type> не съвпада с добавката"
 
@@ -8664,6 +8547,10 @@ msgstr "Няма файлове в качения файл."
 #: src/olympia/files/templates/files/viewer.html:134
 msgid "Fetching file."
 msgstr "Вземане на файла."
+
+#: src/olympia/legacy_api/views.py:255
+msgid "Not implemented yet."
+msgstr "Не е приложено все още."
 
 #: src/olympia/lib/constants.py:6
 msgid "United Arab Emirates Dirham"
@@ -9321,10 +9208,6 @@ msgstr ""
 msgid "Zimbabwe Dollar"
 msgstr ""
 
-#: src/olympia/lib/video/ffmpeg.py:112 src/olympia/lib/video/totem.py:81
-msgid "Videos must be in WebM."
-msgstr ""
-
 #: src/olympia/pages/templates/pages/about.lhtml:3 src/olympia/pages/templates/pages/about.lhtml:10
 msgid "About Mozilla Add-ons"
 msgstr ""
@@ -9336,7 +9219,7 @@ msgstr ""
 #: src/olympia/pages/templates/pages/about.lhtml:13
 msgid ""
 "addons.mozilla.org, commonly known as \"AMO\", is Mozilla's official site for add-ons to Mozilla software, such as Firefox, Thunderbird, and SeaMonkey. Add-ons let you add new features and change "
-"the way your browser or application works.  Take a look around and explore the thousands of ways to customize the way you do things online."
+"the way your browser or application works. Take a look around and explore the thousands of ways to customize the way you do things online."
 msgstr ""
 
 #: src/olympia/pages/templates/pages/about.lhtml:19
@@ -9392,7 +9275,8 @@ msgstr ""
 
 #: src/olympia/pages/templates/pages/about.lhtml:49
 #, python-format
-msgid "Help improve this website. It's open source, and you can file bugs and submit patches. <a href=\"%(url)s\"> GitHub</a> contains all of our current bugs, legacy bugs can still be found in Bugzilla."
+msgid ""
+"Help improve this website. It's open source, and you can file bugs and submit patches. <a href=\"%(url)s\"> GitHub</a> contains all of our current bugs, legacy bugs can still be found in Bugzilla."
 msgstr ""
 
 #: src/olympia/pages/templates/pages/about.lhtml:55
@@ -9435,8 +9319,8 @@ msgstr ""
 #: src/olympia/pages/templates/pages/about.lhtml:77
 #, python-format
 msgid ""
-"Over the years, many people have contributed to this website, including both volunteers from the community and a dedicated AMO team. A list of significant contributors can be found on our <a "
-"href=\"%(url)s\"> Site Credits</a> page."
+"Over the years, many people have contributed to this website, including both volunteers from the community and a dedicated AMO team. A list of significant contributors can be found on our <a href="
+"\"%(url)s\"> Site Credits</a> page."
 msgstr ""
 
 # 93%
@@ -9473,8 +9357,8 @@ msgstr ""
 #: src/olympia/pages/templates/pages/acr_firstrun.html:61
 #, python-format
 msgid ""
-"If you upgrade to a new version of Firefox or update your add-ons, your reports for the old versions will be hidden to allow you to test the new version. If you have any questions, please ask in <a"
-" href=\"%(url)s\">our forums</a>."
+"If you upgrade to a new version of Firefox or update your add-ons, your reports for the old versions will be hidden to allow you to test the new version. If you have any questions, please ask in <a "
+"href=\"%(url)s\">our forums</a>."
 msgstr ""
 
 #: src/olympia/pages/templates/pages/acr_firstrun.html:69
@@ -9541,8 +9425,8 @@ msgstr ""
 
 #: src/olympia/pages/templates/pages/credits.html:61
 msgid ""
-"Some pages use elements of <a href=\"http://shop.highsoft.com/highcharts.html\">Highcharts</a> (non-commercial), licensed under a <a href=\"http://creativecommons.org/licenses/by-nc/3.0/\">Creative"
-" Commons Attribution-NonCommercial 3.0 License</a>."
+"Some pages use elements of <a href=\"http://shop.highsoft.com/highcharts.html\">Highcharts</a> (non-commercial), licensed under a <a href=\"http://creativecommons.org/licenses/by-nc/3.0/\">Creative "
+"Commons Attribution-NonCommercial 3.0 License</a>."
 msgstr ""
 
 #: src/olympia/pages/templates/pages/credits.html:65
@@ -9685,7 +9569,8 @@ msgstr ""
 
 #: src/olympia/pages/templates/pages/dev_faq.html:143
 #, python-format
-msgid "Yes. You can use Mozilla's <a href=\"%(url)s\">XPCOM component object model</a> to enhance your add-ons. XPCOM components be used and implemented in JavaScript, Java, and Python in addition to C++."
+msgid ""
+"Yes. You can use Mozilla's <a href=\"%(url)s\">XPCOM component object model</a> to enhance your add-ons. XPCOM components be used and implemented in JavaScript, Java, and Python in addition to C++."
 msgstr ""
 
 #: src/olympia/pages/templates/pages/dev_faq.html:150
@@ -9696,7 +9581,7 @@ msgstr ""
 msgid ""
 "Yes. It's possible, but some of the functionality provided by these libraries are available through XPCOM, XUL, and JavaScript. In addition, authors should take care if libraries modify primitive "
 "object prototypes (String.prototype, Date.prototype, etc.) and/or define global functions (eg. the $ function). These are prone to cause conflict with other add-ons, in particular if different add-"
-"ons use different versions of libraries and so on. Developers need to be very, very careful with using them.  Mozilla does not offer documentation on using them to build add-ons."
+"ons use different versions of libraries and so on. Developers need to be very, very careful with using them. Mozilla does not offer documentation on using them to build add-ons."
 msgstr ""
 
 #: src/olympia/pages/templates/pages/dev_faq.html:165
@@ -9726,8 +9611,8 @@ msgstr ""
 #: src/olympia/pages/templates/pages/dev_faq.html:187
 #, python-format
 msgid ""
-"Poorly written extensions can have a severe impact on the browsing experience, including on the overall performance of Firefox itself. The following page contains many good <a "
-"href=\"%(url)s\">guides</a> that help you improve performance, whether you're developing core Mozilla code or an add-on."
+"Poorly written extensions can have a severe impact on the browsing experience, including on the overall performance of Firefox itself. The following page contains many good <a href=\"%(url)s"
+"\">guides</a> that help you improve performance, whether you're developing core Mozilla code or an add-on."
 msgstr ""
 
 #: src/olympia/pages/templates/pages/dev_faq.html:195
@@ -9798,8 +9683,8 @@ msgstr ""
 #: src/olympia/pages/templates/pages/dev_faq.html:248
 #, python-format
 msgid ""
-"Yes. You may find 3rd party developers via the <a href=\"%(forum_url)s\">Add-ons forum</a>, <a href=\"%(list_url)s\">mozilla.jobs list</a>, <a href=\"%(mz_url)s\">mozillaZine forums</a> or <a "
-"href=\"%(wiki_url)s\">the Mozilla Wiki</a>. Please note that Mozilla does not offer developer recommendations."
+"Yes. You may find 3rd party developers via the <a href=\"%(forum_url)s\">Add-ons forum</a>, <a href=\"%(list_url)s\">mozilla.jobs list</a>, <a href=\"%(mz_url)s\">mozillaZine forums</a> or <a href="
+"\"%(wiki_url)s\">the Mozilla Wiki</a>. Please note that Mozilla does not offer developer recommendations."
 msgstr ""
 
 #: src/olympia/pages/templates/pages/dev_faq.html:263
@@ -9809,9 +9694,9 @@ msgstr ""
 #: src/olympia/pages/templates/pages/dev_faq.html:265
 #, python-format
 msgid ""
-"Yes. Many developers choose to host their own add-ons. Choosing to host your add-on on <a href=\"%(amo_url)s\">Mozilla's add-on site</a>, though, allows for much greater exposure to your add-on due"
-" to the large volume of visitors to the site.  <a href=\"%(md_url)s\">mozdev.org</a> offers free project hosting for Mozilla applications and extensions providing developers with tools to help "
-"manage source code, version control, bug tracking and documentation."
+"Yes. Many developers choose to host their own add-ons. Choosing to host your add-on on <a href=\"%(amo_url)s\">Mozilla's add-on site</a>, though, allows for much greater exposure to your add-on due "
+"to the large volume of visitors to the site. <a href=\"%(md_url)s\">mozdev.org</a> offers free project hosting for Mozilla applications and extensions providing developers with tools to help manage "
+"source code, version control, bug tracking and documentation."
 msgstr ""
 
 #: src/olympia/pages/templates/pages/dev_faq.html:277
@@ -9859,7 +9744,7 @@ msgstr ""
 #: src/olympia/pages/templates/pages/dev_faq.html:314
 #, python-format
 msgid ""
-"Yes. Mozilla's <a href=\"%(p_url)s\">Add-on Policy</a> describes what is an acceptable submission. This policy is subject to change without notice.  In addition, the AMO editorial team uses the <a "
+"Yes. Mozilla's <a href=\"%(p_url)s\">Add-on Policy</a> describes what is an acceptable submission. This policy is subject to change without notice. In addition, the AMO editorial team uses the <a "
 "href=\"%(g_url)s\">Editors Reviewing Guide</a> to ensure that your add-on meets specific guidelines for functionality and security."
 msgstr ""
 
@@ -9888,8 +9773,8 @@ msgstr ""
 
 #: src/olympia/pages/templates/pages/dev_faq.html:346
 msgid ""
-"The choice of category is dependent on what type of audience you are targeting and the functionality of your add-on. If you're unsure of which category your add-on falls into, please choose "
-"\"Other\". The AMO team may re-categorize your add-on if it's determined that it's better suited in a different category."
+"The choice of category is dependent on what type of audience you are targeting and the functionality of your add-on. If you're unsure of which category your add-on falls into, please choose \"Other"
+"\". The AMO team may re-categorize your add-on if it's determined that it's better suited in a different category."
 msgstr ""
 
 #: src/olympia/pages/templates/pages/dev_faq.html:355
@@ -9923,8 +9808,8 @@ msgstr ""
 #: src/olympia/pages/templates/pages/dev_faq.html:385
 #, python-format
 msgid ""
-"All add-ons submitted, whether new or updated, are reviewed to ensure that Mozilla users have a stable and safe experience. All add-ons submissions are reviewed using the guidelines outlined in the"
-" <a href=\"%(url)s\">Editors Reviewing Guide</a>."
+"All add-ons submitted, whether new or updated, are reviewed to ensure that Mozilla users have a stable and safe experience. All add-ons submissions are reviewed using the guidelines outlined in the "
+"<a href=\"%(url)s\">Editors Reviewing Guide</a>."
 msgstr ""
 
 #: src/olympia/pages/templates/pages/dev_faq.html:393
@@ -9976,8 +9861,8 @@ msgstr ""
 #: src/olympia/pages/templates/pages/dev_faq.html:434
 #, python-format
 msgid ""
-"This is why it's very important to read the <a href=\"%(g_url)s\">Editors Reviewing Guide</a> to ensure that your add-on is setup as expected.  It's also a good idea to read the blog post, <a "
-"href=\"%(blog_url)s\">Successfully Getting your Add-on Reviewed</a> which provides excellent insight into ensuring a smooth review of your add-on."
+"This is why it's very important to read the <a href=\"%(g_url)s\">Editors Reviewing Guide</a> to ensure that your add-on is setup as expected. It's also a good idea to read the blog post, <a href="
+"\"%(blog_url)s\">Successfully Getting your Add-on Reviewed</a> which provides excellent insight into ensuring a smooth review of your add-on."
 msgstr ""
 
 #: src/olympia/pages/templates/pages/dev_faq.html:446
@@ -9993,7 +9878,8 @@ msgid "How can I see how many active users are using my add-on?"
 msgstr ""
 
 #: src/olympia/pages/templates/pages/dev_faq.html:457
-msgid "The Statistics Dashboard found in the Developer Tools dashboard provides information that can help you determine how many users have been actively using your add-on since you've submitted it to AMO."
+msgid ""
+"The Statistics Dashboard found in the Developer Tools dashboard provides information that can help you determine how many users have been actively using your add-on since you've submitted it to AMO."
 msgstr ""
 
 #: src/olympia/pages/templates/pages/dev_faq.html:464
@@ -10082,7 +9968,7 @@ msgstr ""
 
 #: src/olympia/pages/templates/pages/dev_faq.html:572
 msgid ""
-"Free Software Foundation provides short summaries of the key open source licenses, including whether the license qualifies as a free software license or a copyleft license.  Also includes a "
+"Free Software Foundation provides short summaries of the key open source licenses, including whether the license qualifies as a free software license or a copyleft license. Also includes a "
 "discussion of what constitutes a free software license or a copyleft license (e.g., a Copyleft license is a general method for making a program or other work free, and requiring all modified and "
 "extended versions of the program to be free as well.)"
 msgstr ""
@@ -10127,14 +10013,13 @@ msgstr "Ще работят ли добавките с моя браузър и�
 #: src/olympia/pages/templates/pages/faq.html:27
 #, python-format
 msgid ""
-"Add-ons listed in this gallery only work with Mozilla-based applications, such as <a href=\"%(getfirefox_url)s\">Firefox</a>, <a href=\"%(getmobile_url)s\">Firefox Mobile</a>, <a "
-"href=\"%(getseamonkey_url)s\">SeaMonkey</a>, and <a href=\"%(getthunderbird_url)s\">Thunderbird</a>. However, not all add-ons work with each of those applications or every version of those "
-"applications. Each add-on specifies which applications and versions it works with, such as Firefox 2.0 - 3.6.*. For Firefox add-ons, the install buttons will indicate whether the add-on is "
-"compatible or not."
+"Add-ons listed in this gallery only work with Mozilla-based applications, such as <a href=\"%(getfirefox_url)s\">Firefox</a>, <a href=\"%(getmobile_url)s\">Firefox Mobile</a>, <a href="
+"\"%(getseamonkey_url)s\">SeaMonkey</a>, and <a href=\"%(getthunderbird_url)s\">Thunderbird</a>. However, not all add-ons work with each of those applications or every version of those applications. "
+"Each add-on specifies which applications and versions it works with, such as Firefox 2.0 - 3.6.*. For Firefox add-ons, the install buttons will indicate whether the add-on is compatible or not."
 msgstr ""
-"Добавките, изброени в тази галерия работят само с Mozilla-базирани приложения, като например <a href=\"%(getfirefox_url)s\">Firefox</a>, <a href=\"%(getmobile_url)s\">Firefox Mobile</a>, <a "
-"href=\"%(getseamonkey_url)s\">SeaMonkey</a> и <a href=\"%(getthunderbird_url)s\">Thunderbird</a>. Обаче, не всички добавки работят с вяко от тези приложения или всяка тяхна версия. Всяка добавка "
-"указва с кое приложение работи и версиите, с които работи, например Firefox 2.0 - 3.6.*. За Firefox добавки бутонът за инсталация показва дали са съвместими или не."
+"Добавките, изброени в тази галерия работят само с Mozilla-базирани приложения, като например <a href=\"%(getfirefox_url)s\">Firefox</a>, <a href=\"%(getmobile_url)s\">Firefox Mobile</a>, <a href="
+"\"%(getseamonkey_url)s\">SeaMonkey</a> и <a href=\"%(getthunderbird_url)s\">Thunderbird</a>. Обаче, не всички добавки работят с вяко от тези приложения или всяка тяхна версия. Всяка добавка указва "
+"с кое приложение работи и версиите, с които работи, например Firefox 2.0 - 3.6.*. За Firefox добавки бутонът за инсталация показва дали са съвместими или не."
 
 #: src/olympia/pages/templates/pages/faq.html:42
 msgid "What are the different types of add-ons?"
@@ -10167,7 +10052,8 @@ msgstr ""
 #: src/olympia/pages/templates/pages/faq.html:66
 #, python-format
 msgid "<strong><a href=\"%(browse_url)s\">Search Providers</a> </strong> add additional choices to the search box dropdown. These providers allow you to quickly search any website."
-msgstr "<strong><a href=\"%(browse_url)s\">Доставчиците на търсачки</a> </strong> добавят допълнителни възможности в полето за търсене. Тези доставчици ви дават възможност бързо да търсите във всеки сайт."
+msgstr ""
+"<strong><a href=\"%(browse_url)s\">Доставчиците на търсачки</a> </strong> добавят допълнителни възможности в полето за търсене. Тези доставчици ви дават възможност бързо да търсите във всеки сайт."
 
 #: src/olympia/pages/templates/pages/faq.html:72
 #, python-format
@@ -10198,8 +10084,8 @@ msgstr "Как да инсталирам добавки без да рестар
 #: src/olympia/pages/templates/pages/faq.html:101
 #, python-format
 msgid ""
-"In Firefox, add-ons marked with \"No restart required\" can be installed without restarting. These add-ons have been created using the <a href=\"%(sdk_url)s\">Add-on SDK</a> or <a "
-"href=\"%(bootstrap_url)s\">bootstrapping</a>. Other add-ons will still require a restart before you can use them."
+"In Firefox, add-ons marked with \"No restart required\" can be installed without restarting. These add-ons have been created using the <a href=\"%(sdk_url)s\">Add-on SDK</a> or <a href="
+"\"%(bootstrap_url)s\">bootstrapping</a>. Other add-ons will still require a restart before you can use them."
 msgstr ""
 
 #: src/olympia/pages/templates/pages/faq.html:110
@@ -10210,8 +10096,8 @@ msgstr "Как да поддържам тази добавка актуална?
 #, python-format
 msgid ""
 "Add-ons, unlike plugins, are automatically checked for updates once every day. In Firefox, updates are automatically installed by default. Versions of Firefox prior to 4 (and other applications) "
-"will alert you that updates to your add-ons are available. <a href=\"%(plugin_url)s\">Plugins</a> are not currently automatically checked for updates, so be sure to regularly visit the <a "
-"href=\"%(plugincheck_url)s\">Plugin Check</a> page to stay up-to-date."
+"will alert you that updates to your add-ons are available. <a href=\"%(plugin_url)s\">Plugins</a> are not currently automatically checked for updates, so be sure to regularly visit the <a href="
+"\"%(plugincheck_url)s\">Plugin Check</a> page to stay up-to-date."
 msgstr ""
 
 #: src/olympia/pages/templates/pages/faq.html:122
@@ -10221,13 +10107,13 @@ msgstr "Безопасни ли са добавките за инсталира�
 #: src/olympia/pages/templates/pages/faq.html:123
 #, python-format
 msgid ""
-"Unless clearly marked otherwise, add-ons available from this gallery have been checked and approved by Mozilla's team of editors and are safe to install. We recommend that you only install approved"
-" add-ons. If you wish to install unapproved add-ons or add-ons from third-party websites, use caution as these add-ons may harm your computer or violate your privacy. <a "
-"href=\"%(learnmore_url)s\">Learn more about our approval process</a>"
+"Unless clearly marked otherwise, add-ons available from this gallery have been checked and approved by Mozilla's team of editors and are safe to install. We recommend that you only install approved "
+"add-ons. If you wish to install unapproved add-ons or add-ons from third-party websites, use caution as these add-ons may harm your computer or violate your privacy. <a href=\"%(learnmore_url)s"
+"\">Learn more about our approval process</a>"
 msgstr ""
 "Освен ако не е ясно посочено инче, добавките в тази галерия са проверени и одобрени от екипа редактори на Mozilla и са безопасни за инсталиране. Препоръчваме ви да инсталирате само одобрени "
-"добавки. Ако искате да инсталирате неодобрени добавки или добавки от трети страни, внимавайте, защото те може да навредят на компютъра ви или да нарушат неприкосновеността ви. <a "
-"href=\"%(learnmore_url)s\">Научете още за процеса на одобрение</a>"
+"добавки. Ако искате да инсталирате неодобрени добавки или добавки от трети страни, внимавайте, защото те може да навредят на компютъра ви или да нарушат неприкосновеността ви. <a href="
+"\"%(learnmore_url)s\">Научете още за процеса на одобрение</a>"
 
 #: src/olympia/pages/templates/pages/faq.html:133
 #, python-format
@@ -10250,8 +10136,8 @@ msgstr "%(app_name)s ми каза, че добавка е несъвмести�
 #, python-format
 msgid ""
 "If an add-on isn't compatible with your version of %(app_name)s, it is usually either because your version of %(app_name)s is outdated or the add-on author has not yet updated the add-on to be "
-"compatible with a newer version you are using. Mozilla does not recommend trying to circumvent these compatibility checks, as they can lead to browser instability or in some cases loss of data. For"
-" users who are testing out alpha or beta versions of Firefox, we offer the <a href=\"%(acr_url)s\">Add-on Compatibility Reporter</a> to help add-on developers update their compatibility."
+"compatible with a newer version you are using. Mozilla does not recommend trying to circumvent these compatibility checks, as they can lead to browser instability or in some cases loss of data. For "
+"users who are testing out alpha or beta versions of Firefox, we offer the <a href=\"%(acr_url)s\">Add-on Compatibility Reporter</a> to help add-on developers update their compatibility."
 msgstr ""
 "Ако добавка не е съвместима с версията ви на %(app_name)s, обикновено това е така, защото версията ви на %(app_name)s е стара или авторът на добавката все още не я е обновил, за да е съвместима с "
 "по-новата версия, която ползвате. Mozilla не препоръчва да заобикаляте тези проверки за съвместимост, защото те могат да доведат до нестабилност на браузъра или загуба на данни в някои случаи. За "
@@ -10281,7 +10167,7 @@ msgstr "Галерия на добавката"
 msgid "How do I choose between add-ons that seem to do the same thing?"
 msgstr "Как да избера между добавки, които изглежда правят едно и също?"
 
-#: src/olympia/pages/templates/pages/faq.html:173
+#: src/olympia/pages/templates/pages/faq.html:172
 msgid ""
 "There are often several add-ons that have similar features. To figure out which is right for you, read the entire description of the add-on and view its screenshots. If there are still several in "
 "the running, read through the add-on's ratings, user reviews, and statistics to see which is most liked by other users. Remember that you can also just try out both and see which you like better."
@@ -10307,8 +10193,8 @@ msgstr "Какво означава, че някоя добавка е \"екс�
 #: src/olympia/pages/templates/pages/faq.html:188
 #, python-format
 msgid ""
-"Experimental add-ons have been checked by our editors to make sure they don't have security problems, but they may still have bugs or not work properly. Use caution when installing experimental "
-"add-ons and uninstall the add-on immediately if you notice problems. <a href=\"%(url)s\">Learn more about our review process</a></dd>"
+"Experimental add-ons have been checked by our editors to make sure they don't have security problems, but they may still have bugs or not work properly. Use caution when installing experimental add-"
+"ons and uninstall the add-on immediately if you notice problems. <a href=\"%(url)s\">Learn more about our review process</a></dd>"
 msgstr ""
 
 #: src/olympia/pages/templates/pages/faq.html:196
@@ -10330,54 +10216,51 @@ msgstr "Колко струват добавките?"
 msgid "Add-ons hosted in our gallery are free unless clearly marked otherwise."
 msgstr "Добавките, поместени в нашата галерия са безплатни, освен ако ясно не е посочено нещо различно."
 
-#: src/olympia/pages/templates/pages/faq.html:210
+#: src/olympia/pages/templates/pages/faq.html:209
 msgid "What does it mean when an add-on asks for contributions?"
 msgstr "Какво означава добавка да иска дарения?"
 
-#: src/olympia/pages/templates/pages/faq.html:211
+#: src/olympia/pages/templates/pages/faq.html:210
 msgid ""
 "Some add-on authors request users who enjoy an add-on to contribute to its development by making a monetary contribution. These contributions go directly to the developer unless a third party is "
 "indicated, such as the non-profit Mozilla Foundation."
 msgstr ""
-"Някои автори на добавки искат потребителите, които се наслаждават на добавките им да допринесат за развитието им, като направят малко парично дарение. Тези дарения отиват директно при разработчика,"
-" освен ако не е указана трета страна, като фондацията с нестопанска цел Mozilla."
+"Някои автори на добавки искат потребителите, които се наслаждават на добавките им да допринесат за развитието им, като направят малко парично дарение. Тези дарения отиват директно при разработчика, "
+"освен ако не е указана трета страна, като фондацията с нестопанска цел Mozilla."
 
-#: src/olympia/pages/templates/pages/faq.html:216
+#: src/olympia/pages/templates/pages/faq.html:215
 msgid "What are beta add-ons?"
 msgstr "Какво са бета добавките?"
 
-#: src/olympia/pages/templates/pages/faq.html:218
+#: src/olympia/pages/templates/pages/faq.html:217
 msgid ""
 "Beta add-ons are unreviewed versions which represent the latest work of an add-on author. While different authors have different standards for beta code quality, you should assume that these add-"
 "ons are less stable than the general add-on releases."
 msgstr ""
-"Бета добавките са непрегледани версии, които представляват най-новата работа на автора им. Тъй като различните автори имат различни стандарти за качеството на бета код, трябва да допуснете, че тези"
-" добавки са по-малко стабилни от главните версии."
+"Бета добавките са непрегледани версии, които представляват най-новата работа на автора им. Тъй като различните автори имат различни стандарти за качеството на бета код, трябва да допуснете, че тези "
+"добавки са по-малко стабилни от главните версии."
 
-#: src/olympia/pages/templates/pages/faq.html:222
+#: src/olympia/pages/templates/pages/faq.html:221
 msgid ""
-"Please note that when you install an add-on from the \"Beta Version\" section of an add-on's listing, you will continue to receive updates for that add-on as they become available. Like the initial"
-" version you installed, all beta releases are unreviewed by Mozilla and may harm your computer."
+"Please note that when you install an add-on from the \"Beta Version\" section of an add-on's listing, you will continue to receive updates for that add-on as they become available. Like the initial "
+"version you installed, all beta releases are unreviewed by Mozilla and may harm your computer."
 msgstr ""
 "Моля забележете, че когато инсталирате добавка от секцията \"Бета версия \" на страницата на някоя добавка, ще продължите да получавате актуализации за тази добавка, когато станат достъпни. Както "
 "началната версия, която сте инсталирали, всички бета рилийзи са непрегледани от Mozilla и може да наранят компютъра Ви."
 
-#: src/olympia/pages/templates/pages/faq.html:229
+#: src/olympia/pages/templates/pages/faq.html:228
 msgid "What does it mean when an add-on is flagged as slow?"
 msgstr "Какво означава някоя добавка да е маркирана като бавна?"
 
-#: src/olympia/pages/templates/pages/faq.html:231
-msgid ""
-"Most add-ons load code and resources at the same time Firefox\n"
-"        is starting up. In most cases the impact in start-up time is minimal,\n"
-"        but some add-ons can cause a noticeable slowdown."
+#: src/olympia/pages/templates/pages/faq.html:229
+msgid "Most add-ons load code and resources at the same time Firefox is starting up. In most cases the impact in start-up time is minimal, but some add-ons can cause a noticeable slowdown."
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:236
+#: src/olympia/pages/templates/pages/faq.html:234
 msgid "How do I report an inappropriate or spam user review?"
 msgstr "Как да докладвам за неподходяща или спам рецензия?"
 
-#: src/olympia/pages/templates/pages/faq.html:237
+#: src/olympia/pages/templates/pages/faq.html:235
 msgid ""
 "To report a user review of an add-on, log in with your account and visit the add-on's reviews page. Find the review you wish to report, click \"Report this review\" and select a reason. Our "
 "editorial team will investigate the review and take appropriate action."
@@ -10385,64 +10268,65 @@ msgstr ""
 "За да докладвате потребителска рецензия на добавка, влезте с акаунта си и посетете страницата на рецензиите. Намерете рецензията, която искате да докладвате, кликнете \"Докладвай тази рецензия\" и "
 "изберете причина. Нашият редакторски епип ще разследва рецензията и ще предприеме подходящи действия"
 
-#: src/olympia/pages/templates/pages/faq.html:242
+#: src/olympia/pages/templates/pages/faq.html:240
 msgid "How do I report a bug or contact the Mozilla Add-ons team?"
 msgstr "Как да докладвам бъг или да съ свържа с екипа за добавки на Mozilla?"
 
-#: src/olympia/pages/templates/pages/faq.html:243
+#: src/olympia/pages/templates/pages/faq.html:241
 #, python-format
 msgid "Please visit our <a href=\"%(contact_url)s\">Contact page</a>."
 msgstr "Моля, посетете нашата <a href=\"%(contact_url)s\">страница за контакти</a>."
 
-#: src/olympia/pages/templates/pages/faq.html:246
+#: src/olympia/pages/templates/pages/faq.html:244
 msgid "What is a Source Code License?"
 msgstr "Какво е лиценз на изходния код?"
 
-#: src/olympia/pages/templates/pages/faq.html:247
+#: src/olympia/pages/templates/pages/faq.html:245
 #, python-format
 msgid ""
-"The source code used to create an add-on is an exclusive copyright of the add-on author, unless otherwise declared in a source code license. Many add-ons on this site have <a href=\"%(url)s\" "
-"lang=\"en\">open source licenses</a> that make the source code publicly available for copy and reuse under conditions determined by the author. Most authors choose widely known open source licenses"
-" like the GPL or BSD licenses instead of making up their own."
+"The source code used to create an add-on is an exclusive copyright of the add-on author, unless otherwise declared in a source code license. Many add-ons on this site have <a href=\"%(url)s\" lang="
+"\"en\">open source licenses</a> that make the source code publicly available for copy and reuse under conditions determined by the author. Most authors choose widely known open source licenses like "
+"the GPL or BSD licenses instead of making up their own."
 msgstr ""
 "Изходният код, използван, за да се създаде тази добавка е изключително право на автора, освен ако не е посочено друго в лиценза на изходния код. Много добавки в този сайт са с <a href=\"%(url)s\" "
 "lang=\"en\">лицензи за отворен код</a>, които правят кода публично достъпен за копиране и използване при условия, определени от автора. Повечето автори избират широко познати лицензи като GPL или "
 "BSD, вместо да измислят техни"
 
-#: src/olympia/pages/templates/pages/faq.html:256
+#: src/olympia/pages/templates/pages/faq.html:254
 #, python-format
 msgid "Firefox and other Mozilla software are <a href=\"%(url)s\">open source</a>."
 msgstr "Firefox и другия Mozilla софтуер са <a href=\"%(url)s\">с отворен код</a>."
 
-#: src/olympia/pages/templates/pages/faq.html:264
+#: src/olympia/pages/templates/pages/faq.html:262
 msgid "Collections and Favorites"
 msgstr "Колекции и Любими"
 
-#: src/olympia/pages/templates/pages/faq.html:267
+#: src/olympia/pages/templates/pages/faq.html:265
 msgid "What is a collection?"
 msgstr "Какво е колекция?"
 
-#: src/olympia/pages/templates/pages/faq.html:268
+#: src/olympia/pages/templates/pages/faq.html:266
 msgid "Collections are groups of related add-ons created by users to share."
 msgstr "Колекциите са групи от сродни добавки, създадени от потребители, за да споделят."
 
-#: src/olympia/pages/templates/pages/faq.html:270
+#: src/olympia/pages/templates/pages/faq.html:268
 msgid "What is the My Favorites collection?"
 msgstr "Какво е колекцията Моите любими?"
 
-#: src/olympia/pages/templates/pages/faq.html:271
+#: src/olympia/pages/templates/pages/faq.html:269
 msgid "Favorite add-ons are add-ons that you have bookmarked to easily get back to later. You can add an add-on to your favorites collection by clicking \"Add to favorites\" on its details page."
-msgstr "Любимите добавки са добавките, които се маркирали, за да се върнете лесно към тях по-късно. Можете да добавите добавка в колекцията си от любими, като кликнете \"Добави в любими\" на страницата ѝ."
+msgstr ""
+"Любимите добавки са добавките, които се маркирали, за да се върнете лесно към тях по-късно. Можете да добавите добавка в колекцията си от любими, като кликнете \"Добави в любими\" на страницата ѝ."
 
-#: src/olympia/pages/templates/pages/faq.html:275 src/olympia/templates/menu_links.html:13 src/olympia/templates/impala/header_title.html:17
+#: src/olympia/pages/templates/pages/faq.html:273 src/olympia/templates/menu_links.html:13 src/olympia/templates/impala/header_title.html:17
 msgid "Mobile Add-ons"
 msgstr "Мобилни добавки"
 
-#: src/olympia/pages/templates/pages/faq.html:278
+#: src/olympia/pages/templates/pages/faq.html:276
 msgid "What are mobile add-ons?"
 msgstr "Какво са мобилните добавки?"
 
-#: src/olympia/pages/templates/pages/faq.html:279
+#: src/olympia/pages/templates/pages/faq.html:277
 #, python-format
 msgid ""
 "Mobile add-ons work with <a href=\"%(mobile_url)s\">Firefox for Mobile</a> and add or modify functionality just like desktop add-ons. You can find add-ons that work with Firefox for Mobile in our "
@@ -10451,20 +10335,20 @@ msgstr ""
 "Мобилните разширения работят с <a href=\"%(mobile_url)s\">Firefox за мобилни</a> и добавят или променят функционалността също като разширенията за настолната версия. Можете да намерите разширения, "
 "които работят с Firefox за мобилни устройства в нашата <a href=\"%(gallery_url)s\">галерия</a>."
 
-#: src/olympia/pages/templates/pages/faq.html:288
+#: src/olympia/pages/templates/pages/faq.html:286
 msgid "Developer Topics"
 msgstr "Теми за разработчици"
 
-#: src/olympia/pages/templates/pages/faq.html:289
+#: src/olympia/pages/templates/pages/faq.html:287
 #, python-format
 msgid "Please see our <a href=\"%(faq_url)s\">Developer FAQ</a> and <a href=\"%(hub_url)s\">Developer Hub</a> for answers to add-on developer-related questions."
 msgstr "Моля, вижте нашите <a href=\"%(faq_url)s\">ЧЗВ за разработчици </a> и <a href=\"%(hub_url)s\">центърът за разработчици</a> за отговори на въпроси, свързани с разработката на добавки."
 
-#: src/olympia/pages/templates/pages/faq.html:294
+#: src/olympia/pages/templates/pages/faq.html:292
 msgid "Still have questions?"
 msgstr "Все още имате въпроси?"
 
-#: src/olympia/pages/templates/pages/faq.html:295
+#: src/olympia/pages/templates/pages/faq.html:293
 #, python-format
 msgid "For general Firefox support, visit our <a href=\"%(sumo_url)s\">support website</a>. For general add-on and website questions, visit our <a href=\"%(forum_url)s\">forum</a>."
 msgstr "За обща поддръжка на Firefox, посетете нашия <a href=\"%(sumo_url)s\">сайт за поддръжка</a>. За обща поддръжка и въпроси по сайта, посетете <a href=\"%(forum_url)s\">форума ни</a>."
@@ -10602,7 +10486,7 @@ msgstr ""
 
 #: src/olympia/pages/templates/pages/sunbird.html:29
 msgid ""
-"Development on the Sunbird project has halted and its final release was on March 30, 2010.  We've been proud to host Sunbird add-ons on this site but as the project is no longer maintained we have "
+"Development on the Sunbird project has halted and its final release was on March 30, 2010. We've been proud to host Sunbird add-ons on this site but as the project is no longer maintained we have "
 "disabled our support for the add-ons."
 msgstr ""
 
@@ -10680,10 +10564,10 @@ msgstr "Добави рецензия за {0}"
 #, python-format
 msgid ""
 "<h2>Keep these tips in mind:</h2> <ul> <li> Write like you're telling a friend about your experience with the add-on. Give specifics and helpful details, such as what features you liked and/or "
-"disliked, how easy to use it is, and any disadvantages it has.  Avoid generic language such as calling it \"Great\" or \"Bad\" unless you can give reasons why you believe this is so. </li> <li> "
-"Please do not post bug reports in reviews. We do not make your email address available to add-on developers and they may need to contact you to help resolve your issue. See the <a "
-"href=\"%(support)s\">support section</a> to find out where to get assistance for this add-on. </li> <li>Please keep reviews clean, avoid the use of improper language and do not post any personal "
-"information. </li> </ul> <p>Please read the <a href=\"%(guide)s\" target=\"_blank\">Review Guidelines</a> for more detail about user add-on reviews.</p>"
+"disliked, how easy to use it is, and any disadvantages it has. Avoid generic language such as calling it \"Great\" or \"Bad\" unless you can give reasons why you believe this is so. </li> <li> "
+"Please do not post bug reports in reviews. We do not make your email address available to add-on developers and they may need to contact you to help resolve your issue. See the <a href=\"%(support)s"
+"\">support section</a> to find out where to get assistance for this add-on. </li> <li>Please keep reviews clean, avoid the use of improper language and do not post any personal information. </li> </"
+"ul> <p>Please read the <a href=\"%(guide)s\" target=\"_blank\">Review Guidelines</a> for more detail about user add-on reviews.</p>"
 msgstr ""
 
 #: src/olympia/reviews/templates/reviews/reply.html:4
@@ -10934,16 +10818,16 @@ msgstr "{0} Добавки"
 
 #. L10n: {0} is an application, such as Firefox. This means "any version of
 #. Firefox."
-#: src/olympia/search/views.py:554
+#: src/olympia/search/views.py:547
 msgid "Any {0}"
 msgstr ""
 
 #. L10n: "All Systems" means show everything regardless of platform.
-#: src/olympia/search/views.py:589
+#: src/olympia/search/views.py:582
 msgid "All Systems"
 msgstr ""
 
-#: src/olympia/search/views.py:600
+#: src/olympia/search/views.py:593
 msgid "All Tags"
 msgstr "Всички етикети"
 
@@ -11121,31 +11005,31 @@ msgstr "Сподели тази добавка"
 msgid "Share this Collection"
 msgstr "Сподели тази колекция"
 
-#: src/olympia/signing/views.py:30 src/olympia/templates/base.html:75 src/olympia/templates/impala/base.html:115
+#: src/olympia/signing/views.py:33 src/olympia/templates/base.html:71 src/olympia/templates/impala/base.html:112
 msgid "Some features are temporarily disabled while we perform website maintenance. We'll be back to full capacity shortly."
 msgstr "Някои свойства са временно спрени, докато извършваме работа по поддръжката на сайта. Ще се върнем скоро."
 
-#: src/olympia/signing/views.py:53
+#: src/olympia/signing/views.py:56
 msgid "Could not find add-on with id \"{}\"."
 msgstr ""
 
-#: src/olympia/signing/views.py:67
+#: src/olympia/signing/views.py:70
 msgid "You do not own this addon."
 msgstr ""
 
-#: src/olympia/signing/views.py:82
+#: src/olympia/signing/views.py:87
 msgid "Missing \"upload\" key in multipart file data."
 msgstr ""
 
-#: src/olympia/signing/views.py:96
+#: src/olympia/signing/views.py:101
 msgid "Version does not match the manifest file."
 msgstr ""
 
-#: src/olympia/signing/views.py:100
+#: src/olympia/signing/views.py:105
 msgid "Version already exists."
 msgstr ""
 
-#: src/olympia/signing/views.py:136
+#: src/olympia/signing/views.py:141
 msgid "No uploaded file for that addon and version."
 msgstr ""
 
@@ -11278,93 +11162,93 @@ msgstr "{0} :: Табло със статистики"
 msgid "Statistics Dashboard :: Add-ons for {0}"
 msgstr "Табло със статистики :: Разширения за {0}"
 
-#: src/olympia/stats/templates/stats/stats.html:30
-msgid "Controls:"
-msgstr ""
-
-#: src/olympia/stats/templates/stats/stats.html:33
-msgid "reset zoom"
-msgstr ""
-
-#: src/olympia/stats/templates/stats/stats.html:40
-msgid "Group by:"
-msgstr ""
-
-#: src/olympia/stats/templates/stats/stats.html:42
-msgid "day"
-msgstr "ден"
-
-#: src/olympia/stats/templates/stats/stats.html:45
-msgid "week"
-msgstr ""
-
-#: src/olympia/stats/templates/stats/stats.html:48
-msgid "month"
-msgstr "месец"
-
-#: src/olympia/stats/templates/stats/stats.html:54
-msgid "For last:"
-msgstr "За последните:"
-
-#: src/olympia/stats/templates/stats/stats.html:57
-msgid "7 days"
-msgstr "7 дни"
-
-#: src/olympia/stats/templates/stats/stats.html:60
-msgid "30 days"
-msgstr "30 дни"
-
-#: src/olympia/stats/templates/stats/stats.html:63
-msgid "90 days"
-msgstr "90 дни"
-
-#: src/olympia/stats/templates/stats/stats.html:66
-msgid "365 days"
-msgstr "365 дни"
-
-#: src/olympia/stats/templates/stats/stats.html:69
-msgid "Custom..."
-msgstr ""
-
 # %1 is the name of a collection
 #. {0} is an add-on name
-#: src/olympia/stats/templates/stats/stats.html:88 src/olympia/stats/templates/stats/stats.html:91
+#: src/olympia/stats/templates/stats/stats.html:44 src/olympia/stats/templates/stats/stats.html:47
 msgid "Statistics for {0}"
 msgstr "Статистики за {0}"
 
 # 80%
 # 100%
-#: src/olympia/stats/templates/stats/stats.html:94
+#: src/olympia/stats/templates/stats/stats.html:50
 #, fuzzy
 msgid "Statistics Dashboard"
 msgstr "Покажи таблото със статистики"
 
-#: src/olympia/stats/templates/stats/stats.html:104
+#: src/olympia/stats/templates/stats/stats.html:57
+msgid "Controls:"
+msgstr ""
+
+#: src/olympia/stats/templates/stats/stats.html:60
+msgid "reset zoom"
+msgstr ""
+
+#: src/olympia/stats/templates/stats/stats.html:67
+msgid "Group by:"
+msgstr ""
+
+#: src/olympia/stats/templates/stats/stats.html:69
+msgid "day"
+msgstr "ден"
+
+#: src/olympia/stats/templates/stats/stats.html:72
+msgid "week"
+msgstr ""
+
+#: src/olympia/stats/templates/stats/stats.html:75
+msgid "month"
+msgstr "месец"
+
+#: src/olympia/stats/templates/stats/stats.html:81
+msgid "For last:"
+msgstr "За последните:"
+
+#: src/olympia/stats/templates/stats/stats.html:84
+msgid "7 days"
+msgstr "7 дни"
+
+#: src/olympia/stats/templates/stats/stats.html:87
+msgid "30 days"
+msgstr "30 дни"
+
+#: src/olympia/stats/templates/stats/stats.html:90
+msgid "90 days"
+msgstr "90 дни"
+
+#: src/olympia/stats/templates/stats/stats.html:93
+msgid "365 days"
+msgstr "365 дни"
+
+#: src/olympia/stats/templates/stats/stats.html:96
+msgid "Custom..."
+msgstr ""
+
+#: src/olympia/stats/templates/stats/stats.html:106
 msgid "Statistics processing is currently disabled, so recent data is unavailable. The statistics are still being collected and this page will be updated soon with the missing data."
 msgstr ""
 
-#: src/olympia/stats/templates/stats/stats.html:110
+#: src/olympia/stats/templates/stats/stats.html:112
 msgid "Loading the latest data&hellip;"
 msgstr "Зареждане на последните данни&hellip;"
 
-#: src/olympia/stats/templates/stats/stats.html:142 src/olympia/stats/templates/stats/reports/overview.html:25 src/olympia/stats/templates/stats/reports/overview.html:37
+#: src/olympia/stats/templates/stats/stats.html:144 src/olympia/stats/templates/stats/reports/overview.html:25 src/olympia/stats/templates/stats/reports/overview.html:37
 #: src/olympia/stats/templates/stats/reports/overview.html:49
 msgid "No data available."
 msgstr ""
 
-#: src/olympia/stats/templates/stats/stats.html:177
+#: src/olympia/stats/templates/stats/stats.html:179
 msgid "This dashboard is currently <b>public</b>."
 msgstr ""
 
-#: src/olympia/stats/templates/stats/stats.html:179
+#: src/olympia/stats/templates/stats/stats.html:181
 msgid "Contribution stats are currently <b>private</b>."
 msgstr ""
 
-#: src/olympia/stats/templates/stats/stats.html:182
+#: src/olympia/stats/templates/stats/stats.html:184
 msgid "This dashboard is currently <b>private</b>."
 msgstr ""
 
-#: src/olympia/stats/templates/stats/stats.html:185
+#: src/olympia/stats/templates/stats/stats.html:187
 msgid "Change settings."
 msgstr ""
 
@@ -11483,10 +11367,10 @@ msgstr ""
 #, python-format
 msgid ""
 "<h2>Tracking external sources</h2> <p> If you link to your add-on's details page or directly to its file from an external site, such as your blog or website, you can append a parameter to be "
-"tracked as an additional download source on this page. For example, the following links would appear as sourced by your blog: <dl> <dt>Add-on Details Page</dt> "
-"<dd>https://addons.mozilla.org/addon/%(slug)s?src=<b>external-blog</b></dd> <dt>Direct File Link</dt> <dd>https://addons.mozilla.org/downloads/latest/%(id)s/addon-%(id)s-latest.xpi?src=<b>external-"
-"blog</b></dd> </dl> <p> Only src parameters that begin with \"external-\" will be tracked, up to 61 additional characters. Any text after \"external-\" can be used to describe the source, such as "
-"\"external-blog\", \"external-sidebar\", \"external-campaign225\", etc. The following URL-safe characters are allowed: <code>a-z A-Z - . _ ~ %% +</code>"
+"tracked as an additional download source on this page. For example, the following links would appear as sourced by your blog: <dl> <dt>Add-on Details Page</dt> <dd>https://addons.mozilla.org/addon/"
+"%(slug)s?src=<b>external-blog</b></dd> <dt>Direct File Link</dt> <dd>https://addons.mozilla.org/downloads/latest/%(id)s/addon-%(id)s-latest.xpi?src=<b>external-blog</b></dd> </dl> <p> Only src "
+"parameters that begin with \"external-\" will be tracked, up to 61 additional characters. Any text after \"external-\" can be used to describe the source, such as \"external-blog\", \"external-"
+"sidebar\", \"external-campaign225\", etc. The following URL-safe characters are allowed: <code>a-z A-Z - . _ ~ %% +</code>"
 msgstr ""
 
 #: src/olympia/stats/templates/stats/reports/statuses.html:3
@@ -11513,8 +11397,8 @@ msgstr ""
 
 #: src/olympia/stats/templates/stats/reports/usage.html:20
 msgid ""
-"<h2>What are daily users?</h2> <p> Add-ons downloaded from this site check for updates once per day. The total number of these update pings is known as Active Daily Users. Daily users can be broken"
-" down by add-on version, operating system, add-on status, application, and locale. </p>"
+"<h2>What are daily users?</h2> <p> Add-ons downloaded from this site check for updates once per day. The total number of these update pings is known as Active Daily Users. Daily users can be broken "
+"down by add-on version, operating system, add-on status, application, and locale. </p>"
 msgstr ""
 
 #: src/olympia/stats/templates/stats/reports/users_created.html:3
@@ -11525,15 +11409,6 @@ msgstr ""
 msgid "Application versions by Date"
 msgstr "Версии на приложението по дата"
 
-#: src/olympia/tags/templates/tags/top_cloud.html:4
-msgid "Top {0} Tags"
-msgstr "Топ {0} етикети"
-
-#. {0} is the current application name
-#: src/olympia/tags/templates/tags/top_cloud.html:14
-msgid "{0} Top Tags"
-msgstr "{0} Топ етикети"
-
 #: src/olympia/templates/amo_footer.html:6 src/olympia/templates/includes/lang_switcher.html:2
 msgid "Other languages"
 msgstr "Други езици"
@@ -11542,11 +11417,11 @@ msgstr "Други езици"
 msgid "Mozilla Add-ons"
 msgstr "Mozilla добавки"
 
-#: src/olympia/templates/base.html:91 src/olympia/templates/impala/base.html:81
+#: src/olympia/templates/base.html:89 src/olympia/templates/impala/base.html:78
 msgid "Find add-ons for other applications"
 msgstr "Намери добавки за други приложения"
 
-#: src/olympia/templates/base.html:92 src/olympia/templates/impala/base.html:81
+#: src/olympia/templates/base.html:90 src/olympia/templates/impala/base.html:78
 msgid "Other Applications"
 msgstr "Други приложения"
 
@@ -11571,7 +11446,7 @@ msgid "View Mobile Site"
 msgstr "Виж мобилния сайт"
 
 #: src/olympia/templates/copyright.html:7
-msgid "Site Status "
+msgid "Site Status"
 msgstr ""
 
 #: src/olympia/templates/footer.html:3
@@ -11673,35 +11548,35 @@ msgstr "Добре дошъл, {0}"
 msgid "<a href=\"%(reg)s\">Register</a> or <a href=\"%(login)s\">Log in</a>"
 msgstr "<a href=\"%(reg)s\">Регистрация</a> или <a href=\"%(login)s\">Вписване</a>"
 
-#: src/olympia/templates/impala/base.html:126
+#: src/olympia/templates/impala/base.html:123
 #, python-format
 msgid "To try the thousands of add-ons available here, download <a href=\"%(url)s\">Mozilla Firefox</a>, a fast, free way to surf the Web!"
 msgstr "За да изпробвате хилядите добавки, които се намират на този сайт, изтеглете <a href=\"%(url)s\">Mozilla Firefox на български</a> - бърз и свободен начин на сърфирате в Уеб."
 
-#: src/olympia/templates/impala/base.html:138
+#: src/olympia/templates/impala/base.html:135
 #, python-format
 msgid "Add-ons is switching to Firefox Accounts for login. <a href=\"%(url)s\" class=\"fxa-login\">Sign in now to transfer your account.</a>"
 msgstr ""
 
 #. {0} is an application, such as Firefox.
-#: src/olympia/templates/impala/base.html:148
+#: src/olympia/templates/impala/base.html:145
 msgid "Welcome to {0} Add-ons."
 msgstr "Добре дошли в {0} Добавки."
 
-#: src/olympia/templates/impala/base.html:151
+#: src/olympia/templates/impala/base.html:148
 msgid "Choose from thousands of extra features and styles to make Firefox your own."
 msgstr ""
 
-#: src/olympia/templates/impala/base.html:156
+#: src/olympia/templates/impala/base.html:153
 #, python-format
 msgid "Add extra features and styles to make %(app)s your own."
 msgstr ""
 
-#: src/olympia/templates/impala/base.html:164
+#: src/olympia/templates/impala/base.html:161
 msgid "On the go?"
 msgstr "В движение?"
 
-#: src/olympia/templates/impala/base.html:166
+#: src/olympia/templates/impala/base.html:163
 msgid "Check out our <a class=\"mobile-link\" href=\"#\">Mobile Add-ons site</a>."
 msgstr ""
 
@@ -11925,19 +11800,19 @@ msgstr "Няма потребител с този имейл."
 
 #. L10n: {id} will be something like "13ad6a", just a random number
 #. to differentiate this user from other anonymous users.
-#: src/olympia/users/models.py:353
+#: src/olympia/users/models.py:362
 msgid "Anonymous user {id}"
 msgstr ""
 
-#: src/olympia/users/models.py:410
+#: src/olympia/users/models.py:419
 msgid "Your account has been restricted"
 msgstr ""
 
-#: src/olympia/users/models.py:480
+#: src/olympia/users/models.py:489
 msgid "Please confirm your email address"
 msgstr "Моля, потвърдете имейл адреса си"
 
-#: src/olympia/users/models.py:506
+#: src/olympia/users/models.py:515
 msgid "My Mobile Add-ons"
 msgstr "Моите мобилни добавки"
 
@@ -12217,7 +12092,7 @@ msgstr "Парола"
 
 #: src/olympia/users/templates/users/edit.html:70
 #, python-format
-msgid "Change your password.  If you forgot your password, you can <a href=\"%(reset_url)s\">use the reset form</a>."
+msgid "Change your password. If you forgot your password, you can <a href=\"%(reset_url)s\">use the reset form</a>."
 msgstr ""
 
 #: src/olympia/users/templates/users/edit.html:76
@@ -12237,7 +12112,7 @@ msgid "Profile"
 msgstr ""
 
 #: src/olympia/users/templates/users/edit.html:100
-msgid "Give us a bit more information about yourself.  All these fields are optional, but they'll help other users get to know you better."
+msgid "Give us a bit more information about yourself. All these fields are optional, but they'll help other users get to know you better."
 msgstr ""
 
 #: src/olympia/users/templates/users/edit.html:124
@@ -12476,7 +12351,8 @@ msgid "Send password reset link"
 msgstr "Изпрати връзка за нулиране на паролата"
 
 #: src/olympia/users/templates/users/pwreset_sent.html:10
-msgid "An email has been sent to the requested account with further information. If you do not receive an email then please confirm you have entered the same email address used during account registration."
+msgid ""
+"An email has been sent to the requested account with further information. If you do not receive an email then please confirm you have entered the same email address used during account registration."
 msgstr "Изпратен е имейл с допълнителна информация на искания акаунт. Ако не получите имейла, моля потвърдете, че сте въвели същия имейл, който е използван при регистрацията на акаунта."
 
 #: src/olympia/users/templates/users/register.html:4
@@ -12649,7 +12525,7 @@ msgstr "Не можахме да ви отпишем"
 
 #: src/olympia/users/templates/users/unsubscribe.html:30
 #, python-format
-msgid "Unfortunately, we weren't able to unsubscribe you.  The link you clicked is invalid. However, you can unsubscribe still unsubscribe on your <a href=\"%(edit_url)s\">edit profile page</a>."
+msgid "Unfortunately, we weren't able to unsubscribe you. The link you clicked is invalid. However, you can unsubscribe still unsubscribe on your <a href=\"%(edit_url)s\">edit profile page</a>."
 msgstr ""
 
 #: src/olympia/users/templates/users/vcard.html:2
@@ -12706,15 +12582,15 @@ msgstr "История на версиите за %s"
 msgid "Version History with Changelogs"
 msgstr "История на версиите с история на промените"
 
-#: src/olympia/versions/models.py:314
+#: src/olympia/versions/models.py:313
 msgid "Add-on uses binary components."
 msgstr ""
 
-#: src/olympia/versions/models.py:317
+#: src/olympia/versions/models.py:316
 msgid "Add-on has opted into strict compatibility checking."
 msgstr ""
 
-#: src/olympia/versions/models.py:715
+#: src/olympia/versions/models.py:711
 msgid "{app} {min} and later"
 msgstr ""
 
@@ -12795,3 +12671,6 @@ msgstr "Прати имейл, когато е готово"
 msgid "Log emails instead of sending"
 msgstr ""
 
+#: src/olympia/zadmin/forms.py:215
+msgid "Deleted versions can`t be changed."
+msgstr ""

--- a/locale/bg/LC_MESSAGES/djangojs.po
+++ b/locale/bg/LC_MESSAGES/djangojs.po
@@ -1,1215 +1,1235 @@
-
 msgid ""
 msgstr ""
 "Project-Id-Version: AMO-JS 0.1\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2016-02-24 21:23+0000\n"
+"POT-Creation-Date: 2016-04-18 15:47+0000\n"
 "PO-Revision-Date: 2015-02-27 22:16+0000\n"
 "Last-Translator: Стоян <stoyan@gmx.com>\n"
 "Language-Team: none\n"
+"Language: \n"
 "MIME-Version: 1.0\n"
-"Content-Type: text/plain; charset=utf-8\n"
+"Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Generated-By: Babel 2.2.0\n"
 
-#: static/js/common/ratingwidget.js:31
-msgid "{0} star"
-msgid_plural "{0} stars"
-msgstr[0] "{0} звезда"
-msgstr[1] "{0} звезди"
-
-#: static/js/common/upload-addon.js:41 static/js/common/upload-image.js:128
-msgid "There was a problem contacting the server."
-msgstr "Имаше проблем при свързването със сървъра."
-
-#: static/js/common/upload-addon.js:69
-msgid "Select a file..."
-msgstr "Изберете файл..."
-
-#: static/js/common/upload-addon.js:70
-msgid "Your add-on should end with .xpi, .jar or .xml"
-msgstr "Добавката ви трябва да завършва с .xpi, .jar или .xml"
-
-#. L10n: {0} is the percent of the file that has been uploaded.
-#: static/js/common/upload-addon.js:104
-#, fuzzy, python-format
-msgid "{0}% complete"
-msgstr "{0}% завършени"
-
-#. L10n: "{bytes uploaded} of {total filesize}".
-#: static/js/common/upload-addon.js:107
-msgid "{0} of {1}"
-msgstr "{0} от {1}"
-
-#: static/js/common/upload-addon.js:140
-msgid "Cancel"
-msgstr "Откажи"
-
-#: static/js/common/upload-addon.js:162
-msgid "Uploading {0}"
-msgstr "Качване {0}"
-
-#: static/js/common/upload-addon.js:189
-msgid "Error with {0}"
-msgstr "Грешка с {0}"
-
-#: static/js/common/upload-addon.js:194
-msgid "Your add-on failed validation with {0} error."
-msgid_plural "Your add-on failed validation with {0} errors."
-msgstr[0] "Добавката ви не премина валидирането с {0} грешка."
-msgstr[1] "Добавката ви не премина валидирането с {0} грешки."
-
-#: static/js/common/upload-addon.js:208
-msgid "&hellip;and {0} more"
-msgid_plural "&hellip;and {0} more"
-msgstr[0] "&hellip;и {0} още"
-msgstr[1] "&hellip;и {0} още"
-
-#: static/js/common/upload-addon.js:222 static/js/common/upload-addon.js:512
-msgid "See full validation report"
-msgstr "Виж целия доклад за валидацията"
-
-#: static/js/common/upload-addon.js:234
-msgid "Validating {0}"
-msgstr "Валидиране {0}"
-
-#. L10n: first argument is an HTTP status code
-#: static/js/common/upload-addon.js:273
-msgid "Received an empty response from the server; status: {0}"
-msgstr "Получих празен отговор от сървъра; състояние {0}"
-
-#: static/js/common/upload-addon.js:373
-msgid "Unexpected server error while validating."
-msgstr "Неочаквана грешка на сървъра, докато се валидира."
-
-#: static/js/common/upload-addon.js:412
-msgid "Finished validating {0}"
-msgstr "Валидирането приключи {0}"
-
-#: static/js/common/upload-addon.js:418
-msgid "Your add-on validation timed out, it will be manually reviewed."
-msgstr ""
-
-#: static/js/common/upload-addon.js:421
-msgid "Your add-on was validated with no errors and {0} warning."
-msgid_plural "Your add-on was validated with no errors and {0} warnings."
-msgstr[0] ""
-msgstr[1] ""
-
-#: static/js/common/upload-addon.js:426
-msgid "Your add-on was validated with no errors and {0} message."
-msgid_plural "Your add-on was validated with no errors and {0} messages."
-msgstr[0] ""
-msgstr[1] ""
-
-#: static/js/common/upload-addon.js:431
-msgid "Your add-on was validated with no errors or warnings."
-msgstr ""
-
-#: static/js/common/upload-addon.js:446
-msgid "Your submission will be automatically signed."
-msgstr ""
-
-#: static/js/common/upload-addon.js:465
-msgid "Include detailed version notes (this can be done in the next step)."
-msgstr ""
-
-#: static/js/common/upload-addon.js:466
-msgid "If your add-on requires an account to a website in order to be fully tested, include a test username and password in the Notes to Reviewer (this can be done in the next step)."
-msgstr ""
-
-#: static/js/common/upload-addon.js:467
-msgid "If your add-on is intended for a limited audience you should choose Preliminary Review instead of Full Review."
-msgstr ""
-
-#: static/js/common/upload-addon.js:480
-msgid "Add-on submission checklist"
-msgstr "Стъпки за изпращане на добавка"
-
-#: static/js/common/upload-addon.js:481
-msgid "Please verify the following points before finalizing your submission. This will minimize delays or misunderstanding during the review process:"
-msgstr "Проверете следните точки преди да изпратите добавката. Така ще бъдат намалени забавянията поради неясноти по време на процеса на преглед:"
-
-#: static/js/common/upload-addon.js:483
-msgid ""
-"Compiled binaries, as well as minified or obfuscated scripts (excluding known libraries) need to have their sources submitted separately for review. Make sure that you use the source code upload "
-"field to avoid having your submission rejected."
-msgstr ""
-
-#: static/js/common/upload-addon.js:501
-msgid "The validation process found these issues that can lead to rejections:"
-msgstr ""
-
-#: static/js/common/upload-addon.js:518
-msgid "If you are unfamiliar with the add-ons review process, you can read about it here."
-msgstr ""
-
-#: static/js/common/upload-addon.js:555
-msgid "Sorry, no supported platform has been found."
-msgstr ""
-
-#: static/js/common/upload-base.js:57
-msgid "The filetype you uploaded isn't recognized."
-msgstr "Видът на файла, който качихте не е разпознат."
-
-#: static/js/common/upload-base.js:79
-msgid "You cancelled the upload."
-msgstr "Вие отказахте качването."
-
-#: static/js/common/upload-image.js:97 static/js/impala/users.js:51
-msgid "Images must be either PNG or JPG."
-msgstr "Изображенията трябва да са PNG или JPG."
-
-#: static/js/common/upload-image.js:101
-msgid "Videos must be in WebM."
-msgstr "Видеотата трябва да са във формат WebM."
-
-#: static/js/impala/collections.js:10 static/js/zamboni/collections.js:595
-msgid "Follow this Collection"
-msgstr "Следвай тази колекция"
-
-#: static/js/impala/collections.js:19
-msgid "Stop Following"
-msgstr "Спри да следваш"
-
-#: static/js/impala/collections.js:20
-msgid "Following"
-msgstr "Следва"
-
-#. L10n: {0} is an app name.
-#: static/js/impala/listing.js:11 static/js/zamboni/themes.js:13
-msgid "This theme is incompatible with your version of {0}"
-msgstr "Тази тема е несъвместима с вашата версия на {0}"
-
-#: static/js/impala/persona_creation.js:60
-msgid "All Rights Reserved"
-msgstr "Всички права запазени"
-
-#: static/js/impala/persona_creation.js:64
-msgid "Creative Commons Attribution 3.0"
-msgstr "Creative Commons Attribution 3.0"
-
-#: static/js/impala/persona_creation.js:69
-msgid "Creative Commons Attribution-NonCommercial 3.0"
-msgstr "Creative Commons Attribution-NonCommercial 3.0"
-
-#: static/js/impala/persona_creation.js:74
-msgid "Creative Commons Attribution-NonCommercial-NoDerivs 3.0"
-msgstr "Creative Commons Attribution-NonCommercial-NoDerivs 3.0"
-
-#: static/js/impala/persona_creation.js:79
-msgid "Creative Commons Attribution-NonCommercial-Share Alike 3.0"
-msgstr "Creative Commons Attribution-NonCommercial-Share Alike 3.0"
-
-#: static/js/impala/persona_creation.js:84
-msgid "Creative Commons Attribution-NoDerivs 3.0"
-msgstr "Creative Commons Attribution-NoDerivs 3.0"
-
-#: static/js/impala/persona_creation.js:89
-msgid "Creative Commons Attribution-ShareAlike 3.0"
-msgstr "Creative Commons Attribution-ShareAlike 3.0"
-
-#: static/js/impala/persona_creation.js:292
-msgid "Your Theme's Name"
-msgstr "Името на темата Ви"
-
-#: static/js/impala/reviews.js:23 static/js/zamboni/reviews.js:18
-msgid "Flagged for review"
-msgstr "Отбелязана за преглед"
-
-#: static/js/impala/reviews.js:40 static/js/zamboni/reviews.js:34
-msgid "Your input is required"
-msgstr "Моля, въведете нещо тук"
-
-#: static/js/impala/reviews.js:152 static/js/zamboni/reviews.js:103
-msgid "Marked for deletion"
-msgstr "Отбелязан за изтриване"
-
-#: static/js/impala/search.js:114
-msgid "Updating results&hellip;"
-msgstr "Актуализиране на резултатите&hellip;"
-
-#: static/js/impala/site_suggestions.js:46
-msgid "Category"
-msgstr "Категория"
-
-#: static/js/impala/suggestions.js:39
-msgid "Search themes for <b>{0}</b>"
-msgstr "Търсене на <b>{0}</b> в темите"
-
-#: static/js/impala/suggestions.js:41
-msgid "Search apps for <b>{0}</b>"
-msgstr "Търси приложения за <b>{0}</b>"
-
-#: static/js/impala/suggestions.js:43
-msgid "Search add-ons for <b>{0}</b>"
-msgstr "Търси добавки за <b>{0}</b>"
-
-#: static/js/impala/users.js:33
-msgid "use original"
-msgstr "използвай оригинала"
-
-#: static/js/impala/stats/chart.js:267
-msgid "Week of {0}"
-msgstr "Седмица от {0}"
-
-#: static/js/impala/stats/chart.js:269
-msgid " downloads"
-msgstr ""
-
-#: static/js/impala/stats/chart.js:270
-msgid "{0} users"
-msgstr "{0} потребители"
-
-#: static/js/impala/stats/chart.js:271
-msgid "{0} add-ons"
-msgstr "{0} добавки"
-
-#: static/js/impala/stats/chart.js:272
-msgid "{0} collections"
-msgstr "{0} колекции"
-
-#: static/js/impala/stats/chart.js:273
-msgid "{0} reviews"
-msgstr "{0} рецензии"
-
-#: static/js/impala/stats/chart.js:275
-msgid "{0} sales"
-msgstr "{0} продажби"
-
-#: static/js/impala/stats/chart.js:276
-msgid "{0} refunds"
-msgstr "{0} възстановявания"
-
-#: static/js/impala/stats/chart.js:277
-msgid "{0} installs"
-msgstr "{0} инсталации"
-
-#: static/js/impala/stats/chart.js:369 static/js/impala/stats/csv_keys.js:3 static/js/impala/stats/csv_keys.js:109
-msgid "Downloads"
-msgstr "Сваляния"
-
-#: static/js/impala/stats/chart.js:379 static/js/impala/stats/csv_keys.js:6 static/js/impala/stats/csv_keys.js:110
-msgid "Daily Users"
-msgstr "Потребители дневно"
-
-#: static/js/impala/stats/chart.js:410
-msgid "Amount, in USD"
-msgstr "Размер, в USD"
-
-#: static/js/impala/stats/chart.js:421 static/js/impala/stats/csv_keys.js:104
-msgid "Number of Contributions"
-msgstr "Брой допринесли"
-
-#: static/js/impala/stats/chart.js:447
-msgid "More Info..."
-msgstr "Още информация..."
-
-#. L10n: {0} is an ISO-formatted date.
-#: static/js/impala/stats/chart.js:451
-msgid "Details for {0}"
-msgstr "Детайли за {0}"
-
-#: static/js/impala/stats/csv_keys.js:9
-msgid "Collections Created"
-msgstr "Създадени колекции"
-
-#: static/js/impala/stats/csv_keys.js:12
-msgid "Add-ons in Use"
-msgstr "Добавки в употреба"
-
-#: static/js/impala/stats/csv_keys.js:15
-msgid "Add-ons Created"
-msgstr "Създадени добавки"
-
-#: static/js/impala/stats/csv_keys.js:18
-msgid "Add-ons Downloaded"
-msgstr "Свалени добавки"
-
-#: static/js/impala/stats/csv_keys.js:21
-msgid "Add-ons Updated"
-msgstr "Обновени добавки"
-
-#: static/js/impala/stats/csv_keys.js:24
-msgid "Reviews Written"
-msgstr "Написани рецензии"
-
-#: static/js/impala/stats/csv_keys.js:27
-msgid "User Signups"
-msgstr "Регистрирани потребители"
-
-#: static/js/impala/stats/csv_keys.js:30
-msgid "Subscribers"
-msgstr "Абонати"
-
-#: static/js/impala/stats/csv_keys.js:33
-msgid "Ratings"
-msgstr "Оценки"
-
-#: static/js/impala/stats/csv_keys.js:36 static/js/impala/stats/csv_keys.js:114
-msgid "Sales"
-msgstr "Продажби"
-
-#: static/js/impala/stats/csv_keys.js:39 static/js/impala/stats/csv_keys.js:113
-msgid "Installs"
-msgstr "Инсталации"
-
-#: static/js/impala/stats/csv_keys.js:42
-msgid "Unknown"
-msgstr "Непознат"
-
-#: static/js/impala/stats/csv_keys.js:43
-msgid "Add-ons Manager"
-msgstr "Мениджър на добавките"
-
-#: static/js/impala/stats/csv_keys.js:44
-msgid "Add-ons Manager Promo"
-msgstr ""
-
-#: static/js/impala/stats/csv_keys.js:45
-msgid "Add-ons Manager Featured"
-msgstr ""
-
-#: static/js/impala/stats/csv_keys.js:46
-msgid "Add-ons Manager Learn More"
-msgstr ""
-
-#: static/js/impala/stats/csv_keys.js:47
-msgid "Search Suggestions"
-msgstr ""
-
-#: static/js/impala/stats/csv_keys.js:48
-msgid "Search Results"
-msgstr "Резултати от търсенето"
-
-#: static/js/impala/stats/csv_keys.js:49 static/js/impala/stats/csv_keys.js:50 static/js/impala/stats/csv_keys.js:51
-msgid "Homepage Promo"
-msgstr "Начална страница Промо"
-
-#: static/js/impala/stats/csv_keys.js:52 static/js/impala/stats/csv_keys.js:53
-msgid "Homepage Featured"
-msgstr "Начална страница Препоръчани"
-
-#: static/js/impala/stats/csv_keys.js:54 static/js/impala/stats/csv_keys.js:55
-msgid "Homepage Up and Coming"
-msgstr "Начална страница Up and Coming"
-
-#: static/js/impala/stats/csv_keys.js:56
-msgid "Homepage Most Popular"
-msgstr "Начална страница Най-известнии"
-
-#: static/js/impala/stats/csv_keys.js:57 static/js/impala/stats/csv_keys.js:59
-msgid "Detail Page"
-msgstr "Страница с детайли"
-
-#: static/js/impala/stats/csv_keys.js:58 static/js/impala/stats/csv_keys.js:60
-msgid "Detail Page (bottom)"
-msgstr "Страница с детайли (дъно)"
-
-#: static/js/impala/stats/csv_keys.js:61
-msgid "Detail Page (Development Channel)"
-msgstr "Страница с детайли (канал за разработка)"
-
-#: static/js/impala/stats/csv_keys.js:62 static/js/impala/stats/csv_keys.js:63 static/js/impala/stats/csv_keys.js:64
-msgid "Often Used With"
-msgstr "Често използван с"
-
-#: static/js/impala/stats/csv_keys.js:65 static/js/impala/stats/csv_keys.js:66
-msgid "Others By Author"
-msgstr "Други от автора"
-
-#: static/js/impala/stats/csv_keys.js:67 static/js/impala/stats/csv_keys.js:68
-msgid "Dependencies"
-msgstr "Зависимости"
-
-#: static/js/impala/stats/csv_keys.js:69 static/js/impala/stats/csv_keys.js:70
-msgid "Upsell"
-msgstr "Upsell"
-
-#: static/js/impala/stats/csv_keys.js:71
-msgid "Meet the Developer"
-msgstr ""
-
-#: static/js/impala/stats/csv_keys.js:72
-msgid "User Profile"
-msgstr ""
-
-#: static/js/impala/stats/csv_keys.js:73
-msgid "Version History"
-msgstr ""
-
-#: static/js/impala/stats/csv_keys.js:75
-msgid "Sharing"
-msgstr "Споделяне"
-
-#: static/js/impala/stats/csv_keys.js:76
-msgid "Category Pages"
-msgstr "Страници с категории"
-
-#: static/js/impala/stats/csv_keys.js:77
-msgid "Collections"
-msgstr "Колекции"
-
-#: static/js/impala/stats/csv_keys.js:78 static/js/impala/stats/csv_keys.js:79
-msgid "Category Landing Featured Carousel"
-msgstr "Category Landing Featured Carousel"
-
-#: static/js/impala/stats/csv_keys.js:80 static/js/impala/stats/csv_keys.js:81
-msgid "Category Landing Top Rated"
-msgstr "Категория Най-високо оценени"
-
-#: static/js/impala/stats/csv_keys.js:82 static/js/impala/stats/csv_keys.js:83
-msgid "Category Landing Most Popular"
-msgstr "Категория най-известни"
-
-#: static/js/impala/stats/csv_keys.js:84 static/js/impala/stats/csv_keys.js:85
-msgid "Category Landing Recently Added"
-msgstr "Категория Наскоро добавени"
-
-#: static/js/impala/stats/csv_keys.js:86 static/js/impala/stats/csv_keys.js:87
-msgid "Browse Listing Featured Sort"
-msgstr "Browse Listing Featured Sort"
-
-#: static/js/impala/stats/csv_keys.js:88 static/js/impala/stats/csv_keys.js:89
-msgid "Browse Listing Users Sort"
-msgstr "Browse Listing Users Sort"
-
-#: static/js/impala/stats/csv_keys.js:90 static/js/impala/stats/csv_keys.js:91
-msgid "Browse Listing Rating Sort"
-msgstr "Browse Listing Rating Sort"
-
-#: static/js/impala/stats/csv_keys.js:92 static/js/impala/stats/csv_keys.js:93
-msgid "Browse Listing Created Sort"
-msgstr "Browse Listing Created Sort"
-
-#: static/js/impala/stats/csv_keys.js:94 static/js/impala/stats/csv_keys.js:95
-msgid "Browse Listing Name Sort"
-msgstr "Browse Listing Name Sort"
-
-#: static/js/impala/stats/csv_keys.js:96 static/js/impala/stats/csv_keys.js:97
-msgid "Browse Listing Popular Sort"
-msgstr "Browse Listing Popular Sort"
-
-#: static/js/impala/stats/csv_keys.js:98 static/js/impala/stats/csv_keys.js:99
-msgid "Browse Listing Updated Sort"
-msgstr "Browse Listing Updated Sort"
-
-#: static/js/impala/stats/csv_keys.js:100 static/js/impala/stats/csv_keys.js:101
-msgid "Browse Listing Up and Coming Sort"
-msgstr "Browse Listing Up and Coming Sort"
-
-#: static/js/impala/stats/csv_keys.js:105
-msgid "Total Amount Contributed"
-msgstr "Общо дарено"
-
-#: static/js/impala/stats/csv_keys.js:106
-msgid "Average Contribution"
-msgstr "Средни дарения"
-
-#: static/js/impala/stats/csv_keys.js:115
-msgid "Usage"
-msgstr "Употреба"
-
-#: static/js/impala/stats/csv_keys.js:118
-msgid "Firefox"
-msgstr "Firefox"
-
-#: static/js/impala/stats/csv_keys.js:119
-msgid "Mozilla"
-msgstr "Mozilla"
-
-#: static/js/impala/stats/csv_keys.js:120
-msgid "Thunderbird"
-msgstr "Thunderbird"
-
-#: static/js/impala/stats/csv_keys.js:121
-msgid "Sunbird"
-msgstr "Sunbird"
-
-#: static/js/impala/stats/csv_keys.js:122
-msgid "SeaMonkey"
-msgstr "SeaMonkey"
-
-#: static/js/impala/stats/csv_keys.js:123
-msgid "Fennec"
-msgstr "Fennec"
-
-#: static/js/impala/stats/csv_keys.js:124
-msgid "Android"
-msgstr "Андроид"
-
-#. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:129
-msgid "Downloads and Daily Users, last {0} days"
-msgstr "Сваляния и дневни потребители последните {0} дни"
-
-#. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:131
-msgid "Downloads and Daily Users from {0} to {1}"
-msgstr "Сваляния и потребители дневно от {0} до {1}"
-
-#. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:135
-msgid "Installs and Daily Users, last {0} days"
-msgstr "Инсталации и потребители дневно последните {0} дни"
-
-#. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:137
-msgid "Installs and Daily Users from {0} to {1}"
-msgstr "Инсталации и потребители дневно от {0} до {1}"
-
-#. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:141
-msgid "Downloads, last {0} days"
-msgstr "Сваляния последните {0} дни"
-
-#. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:143
-msgid "Downloads from {0} to {1}"
-msgstr "Сваляния от {0} от {1}"
-
-#. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:147
-msgid "Daily Users, last {0} days"
-msgstr "Потребители дневно последните {0} дни"
-
-#. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:149
-msgid "Daily Users from {0} to {1}"
-msgstr "Потребители дневно от {0} до {1}"
-
-#. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:153
-msgid "Applications, last {0} days"
-msgstr "Приложения последните {0} дни"
-
-#. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:155
-msgid "Applications from {0} to {1}"
-msgstr "Приложения от {0} до {1}"
-
-#. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:159
-msgid "Platforms, last {0} days"
-msgstr "Платформи последните {0} дни"
-
-#. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:161
-msgid "Platforms from {0} to {1}"
-msgstr "Платформи от {0} до {1}"
-
-#. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:165
-msgid "Languages, last {0} days"
-msgstr "Езици последните {0} дни"
-
-#. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:167
-msgid "Languages from {0} to {1}"
-msgstr "Езици от {0} до {1}"
-
-#. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:171
-msgid "Add-on Versions, last {0} days"
-msgstr "Версии на добавката последните {0} дни"
-
-#. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:173
-msgid "Add-on Versions from {0} to {1}"
-msgstr "Версии от {0} {1}"
-
-#. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:177
-msgid "Add-on Status, last {0} days"
-msgstr "Състояние на добавката последните {0} дни"
-
-#. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:179
-msgid "Add-on Status from {0} to {1}"
-msgstr "Състояние на добавката от {0} до {1}"
-
-#. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:183
-msgid "Download Sources, last {0} days"
-msgstr "Източници на сваляне последните {0} дни"
-
-#. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:185
-msgid "Download Sources from {0} to {1}"
-msgstr "Източници на сваляне от {0} до {1}"
-
-#. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:189
-msgid "Contributions, last {0} days"
-msgstr "Дарения последните {0} дни"
-
-#. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:191
-msgid "Contributions from {0} to {1}"
-msgstr "Дарения от {0} от {1}"
-
-#. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:195
-msgid "Site Metrics, last {0} days"
-msgstr "Статистики на сайта за последните {0} дни"
-
-#. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:197
-msgid "Site Metrics from {0} to {1}"
-msgstr "Статистики на сайта от {0} до {1}"
-
-#. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:201
-msgid "Add-ons in Use, last {0} days"
-msgstr "Използвани добавки последните {0} дни"
-
-#. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:203
-msgid "Add-ons in Use from {0} to {1}"
-msgstr "Използвани добавки от {0} до {0}"
-
-#. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:207
-msgid "Add-ons Downloaded, last {0} days"
-msgstr "Добавки, свалени последните {0} дни"
-
-#. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:209
-msgid "Add-ons Downloaded from {0} to {1}"
-msgstr "Добавки, свалени от {0} до {1}"
-
-#. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:213
-msgid "Add-ons Created, last {0} days"
-msgstr "Добавки, създадени последните {0} дни"
-
-#. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:215
-msgid "Add-ons Created from {0} to {1}"
-msgstr "Добавки, създадени от {0} до {1}"
-
-#. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:219
-msgid "Add-ons Updated, last {0} days"
-msgstr "Обновени добавки през последните {0} дни"
-
-#. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:221
-msgid "Add-ons Updated from {0} to {1}"
-msgstr "Обновени добавки от {0} до {1}"
-
-#. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:225
-msgid "Reviews Written, last {0} days"
-msgstr "Написани рецензии последните {0} дни"
-
-#. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:227
-msgid "Reviews Written from {0} to {1}"
-msgstr "Написани рецензии от {0} до {1}"
-
-#. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:231
-msgid "User Signups, last {0} days"
-msgstr "Регистрирани потребители последните {0} дни"
-
-#. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:233
-msgid "User Signups from {0} to {1}"
-msgstr "Регистрирани потребители от {0} до {1}"
-
-#. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:237
-msgid "Collections Created, last {0} days"
-msgstr "Създадени колекции последните {0} дни"
-
-#. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:239
-msgid "Collections Created from {0} to {1}"
-msgstr "Колекции, създадени от {0} до {1}"
-
-#. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:243
-msgid "Subscribers, last {0} days"
-msgstr "Абонати последните {0} дни"
-
-#. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:245
-msgid "Subscribers from {0} to {1}"
-msgstr "Абонати от {0} до {1}"
-
-#. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:249
-msgid "Ratings, last {0} days"
-msgstr "Оценки последните {0} дни"
-
-#. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:251
-msgid "Ratings from {0} to {1}"
-msgstr "Оценки от {0} до {1}"
-
-#. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:255
-msgid "Sales, last {0} days"
-msgstr "Продажби в последните {0} дни"
-
-#. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:257
-msgid "Sales from {0} to {1}"
-msgstr "Продажби от {0} до {1}"
-
-#. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:261
-msgid "Installs, last {0} days"
-msgstr "Инсталации последните {0} дни"
-
-#. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:263
-msgid "Installs from {0} to {1}"
-msgstr "Инсталации от {0} до {1}"
-
-#. L10n: {0} and {1} are integers.
-#: static/js/impala/stats/csv_keys.js:269
-msgid "<b>{0}</b> in last {1} days"
-msgstr "<b>{0}</b> в последните {1} дни"
-
-#. L10n: {0} is an integer and {1} and {2} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:271 static/js/impala/stats/csv_keys.js:277
-msgid "<b>{0}</b> from {1} to {2}"
-msgstr "<b>{0}</b> от {1} до {2}"
-
-#. L10n: {0} and {1} are integers.
-#: static/js/impala/stats/csv_keys.js:275
-msgid "<b>{0}</b> average in last {1} days"
-msgstr "<b>{0}</b> средно в последните {1} дни"
-
-#: static/js/impala/stats/overview.js:19
-msgid "No data available."
-msgstr "Няма достъпни данни."
-
-#: static/js/impala/stats/table.js:74
-msgid "Date"
-msgstr "Дата"
-
-#: static/js/impala/stats/topchart.js:96
-msgid "Other"
-msgstr "Друго"
-
-#: static/js/zamboni/admin_validation.js:24 static/js/zamboni/devhub.js:1229 static/js/zamboni/editors.js:295
-msgid "Select an application first"
-msgstr "Първо изберете приложение"
-
-#: static/js/zamboni/admin_validation.js:51
-msgid "Set {0} add-on to a max version of {1} and email the author."
-msgid_plural "Set {0} add-ons to a max version of {1} and email the authors."
-msgstr[0] "Настрой добавка {0} на максимална версия от {1} и пишете на автора."
-msgstr[1] "Настрой добавка {0} на максимална версия от {1} и пишете на авторите."
-
-#: static/js/zamboni/admin_validation.js:54
-msgid "Email author of {2} add-on which failed validation."
-msgid_plural "Email authors of {2} add-ons which failed validation."
-msgstr[0] ""
-msgstr[1] ""
+#: static/js/common-all.js:1426 static/js/impala-all.js:1511 static/js/zamboni/discovery-all.js:12598 static/js/zamboni/init.js:28 static/js/zamboni/mobile-all.js:14945
+msgid "This feature is temporarily disabled while we perform website maintenance. Please check back a little later."
+msgstr "Това свойство е временно спряно, докато правим промени по сайта. Моля, проверете отново малко по-късно."
 
 #. L10n: {0} is an app name like Firefox.
-#: static/js/zamboni/buttons.js:66
+#: static/js/common-all.js:1837 static/js/impala-all.js:1922 static/js/zamboni/buttons.js:73 static/js/zamboni/discovery-all.js:13108
 msgid "Accept and Install"
 msgstr "Приеми и инсталирай"
 
-#: static/js/zamboni/buttons.js:66
+#: static/js/common-all.js:1837 static/js/impala-all.js:1922 static/js/zamboni/buttons.js:73 static/js/zamboni/discovery-all.js:13108
 msgid "Add to {0}"
 msgstr "Добави към {0}"
 
-#: static/js/zamboni/buttons.js:71
+#: static/js/common-all.js:1842 static/js/impala-all.js:1927 static/js/zamboni/buttons.js:78 static/js/zamboni/discovery-all.js:13113
 msgid "Download Now"
 msgstr "Свали сега"
 
-#: static/js/zamboni/buttons.js:112
+#: static/js/common-all.js:1883 static/js/impala-all.js:1968 static/js/zamboni/buttons.js:119 static/js/zamboni/discovery-all.js:13154
 msgid "Add-on has not been updated to support default-to-compatible."
 msgstr "Добавката не е обновена да поддържа default-to-compatible."
 
-#: static/js/zamboni/buttons.js:117
+#: static/js/common-all.js:1888 static/js/impala-all.js:1973 static/js/zamboni/buttons.js:124 static/js/zamboni/discovery-all.js:13159
 msgid "You need to be using Firefox 10.0 or higher."
 msgstr "Трябва да използвате Firefox 10.0 или по-нова."
 
-#: static/js/zamboni/buttons.js:129
+#: static/js/common-all.js:1900 static/js/impala-all.js:1985 static/js/zamboni/buttons.js:136 static/js/zamboni/discovery-all.js:13171
 msgid "Mozilla has marked this version as incompatible with your Firefox version."
 msgstr "Mozilla маркира тази версия като несъвместима с Вашата версия на Firefox."
 
 #. L10n: {0} is an platform like Windows or Linux.
-#: static/js/zamboni/buttons.js:210
+#: static/js/common-all.js:1981 static/js/impala-all.js:2066 static/js/zamboni/buttons.js:217 static/js/zamboni/discovery-all.js:13252
 msgid "Install for {0} anyway"
 msgstr "Инсталирай за {0} така или иначе"
 
-#: static/js/zamboni/buttons.js:210
+#: static/js/common-all.js:1981 static/js/impala-all.js:2066 static/js/zamboni/buttons.js:217 static/js/zamboni/discovery-all.js:13252
 msgid "Download for {0} anyway"
 msgstr "Свали за {0} така или иначе"
 
-#: static/js/zamboni/buttons.js:267
+#: static/js/common-all.js:2038 static/js/impala-all.js:2123 static/js/zamboni/buttons.js:274 static/js/zamboni/discovery-all.js:13309
 msgid "Not available for your platform"
 msgstr "Не е налично за платформата ви"
 
 #. L10n: {0} is an app name, {1} is the app version.
-#: static/js/zamboni/buttons.js:278 static/js/zamboni/buttons.js:315
+#: static/js/common-all.js:2049 static/js/common-all.js:2086 static/js/impala-all.js:2134 static/js/impala-all.js:2171 static/js/zamboni/buttons.js:286 static/js/zamboni/buttons.js:324
+#: static/js/zamboni/discovery-all.js:13320 static/js/zamboni/discovery-all.js:13357
 msgid "Not available for {0} {1}"
 msgstr "Не е налично за {0} {1}"
 
-#: static/js/zamboni/buttons.js:341
+#: static/js/common-all.js:2112 static/js/impala-all.js:2197 static/js/zamboni/buttons.js:351 static/js/zamboni/discovery-all.js:13383
 msgid "Works with {app} {min} - {max}"
 msgstr "Работи с {app} {min} - {max}"
 
-#: static/js/zamboni/buttons.js:343
+#: static/js/common-all.js:2114 static/js/impala-all.js:2199 static/js/zamboni/buttons.js:353 static/js/zamboni/discovery-all.js:13385
 msgid "View other versions"
 msgstr "Виж други версии"
 
-#: static/js/zamboni/buttons.js:391
+#: static/js/common-all.js:2162 static/js/impala-all.js:2247 static/js/zamboni/buttons.js:401 static/js/zamboni/discovery-all.js:13433
 msgid "Only with Firefox — Get Firefox Now!"
 msgstr ""
 
-#: static/js/zamboni/buttons.js:507 static/js/zamboni/mobile/buttons.js:43
+#: static/js/common-all.js:2278 static/js/impala-all.js:2363 static/js/zamboni/buttons.js:517 static/js/zamboni/discovery-all.js:13549 static/js/zamboni/mobile-all.js:15177
+#: static/js/zamboni/mobile/buttons.js:43
 msgid "Sorry, you need a Mozilla-based browser (such as Firefox) to install a search plugin."
 msgstr "Съжаляваме, трябва да имате Mozilla-базиран браузър (като Firefox), за да инсталирате търсеща добавка."
 
-#: static/js/zamboni/collections.js:229
-msgid "Adding to Favorites&hellip;"
-msgstr "Добавяне към Любими&hellip;"
-
-#: static/js/zamboni/collections.js:232
-msgid "Removing Favorite&hellip;"
-msgstr "Премахване от Любими&hellip;"
-
-#: static/js/zamboni/collections.js:235
-msgid "Add to Favorites"
-msgstr "Добави към Любими"
-
-#: static/js/zamboni/collections.js:238
-msgid "Remove from Favorites"
-msgstr "Премахни от Любими"
-
-#: static/js/zamboni/collections.js:303
-msgid "Pending"
-msgstr "Чакащ"
-
-#: static/js/zamboni/collections.js:304
-msgid "Add a comment"
-msgstr "Добавяне на коментар"
-
-#: static/js/zamboni/collections.js:304
-msgid "Comment"
-msgstr "Коментар"
-
-#: static/js/zamboni/collections.js:305
-msgid "Remove this add-on from the collection"
-msgstr "Премахни тази добавка от колекцията"
-
-#: static/js/zamboni/collections.js:305 static/js/zamboni/collections.js:334
-msgid "Remove"
-msgstr "Премахни"
-
-#: static/js/zamboni/collections.js:334
-msgid "Remove this user as a contributor"
-msgstr "Премахни този потребител като допринесъл"
-
-#: static/js/zamboni/collections.js:346
-msgid "An email address is required."
-msgstr "Нужен е имейл адрес."
-
-#: static/js/zamboni/collections.js:364
-msgid "You cannot add yourself as a contributor."
-msgstr "Не може да добавяте себе си като сътрудник."
-
-#: static/js/zamboni/collections.js:366
-msgid "You have already added that user."
-msgstr "Вече сте добавили този потребител."
-
-#: static/js/zamboni/collections.js:573
-msgid "Add to favorites"
-msgstr "Добави в любими"
-
-#: static/js/zamboni/collections.js:577
-msgid "Remove from favorites"
-msgstr "Премахни от любими"
-
-#: static/js/zamboni/collections.js:604
-msgid "Stop following"
-msgstr "Спри да следваш"
-
-#: static/js/zamboni/devhub.js:110
-msgid "Your browser does not support the video tag"
-msgstr "Браузърът ви не поддържа video тага"
-
-#: static/js/zamboni/devhub.js:371
-msgid "Changes Saved"
-msgstr "Промените са запазени"
-
-#: static/js/zamboni/devhub.js:387
-msgid "Enter a new author's email address"
-msgstr "Въведете е-пощата на новия автор"
-
-#: static/js/zamboni/devhub.js:536
-msgid "There was an error uploading your file."
-msgstr "Стана грешка при качването на файла ви."
-
-#: static/js/zamboni/devhub.js:681
-msgid "{files} file"
-msgid_plural "{files} files"
-msgstr[0] "{files} файл"
-msgstr[1] "{files} файла"
-
-#: static/js/zamboni/devhub.js:684
-msgid "{reviews} user review"
-msgid_plural "{reviews} user reviews"
-msgstr[0] "{reviews} отзив"
-msgstr[1] "{reviews} отзива"
-
-#: static/js/zamboni/devhub.js:796
-msgid "Learn more"
-msgstr "Научи още"
-
-#: static/js/zamboni/devhub.js:800
-msgid "Example"
-msgstr "Пример"
-
-#: static/js/zamboni/devhub.js:1130
-msgid "Image changes being processed"
-msgstr "Обработват се промените по изображението"
-
-#: static/js/zamboni/devhub.js:1280
-msgid "Must be a valid e-mail address."
-msgstr "Трябва да е валиден имейл адрес."
-
-#: static/js/zamboni/devhub_search.js:8
-msgid "No results found."
-msgstr "Няма резултати."
-
-#: static/js/zamboni/editors.js:121
-msgid "{name} was viewing this page first."
-msgstr "{name} разглеждаше тази страница първо."
-
-#: static/js/zamboni/editors.js:171
-msgid "Receipt checked by app."
-msgstr "Разписката проверена от приложението."
-
-#: static/js/zamboni/editors.js:173
-msgid "Receipt was not checked by app."
-msgstr "Разписката не е проверена от приложението."
-
-#: static/js/zamboni/editors.js:244
-msgid "{name} was viewing this add-on first."
-msgstr "{name} първи гледаше тази добавка."
-
-#: static/js/zamboni/editors.js:255
-msgid "Loading&hellip;"
-msgstr "Зареждане&hellip;"
-
-#: static/js/zamboni/editors.js:260
-msgid "Version Notes"
-msgstr "Бележки по версията"
-
-#: static/js/zamboni/editors.js:265
-msgid "Notes for Reviewers"
-msgstr "Бележки за рецензенти"
-
-#: static/js/zamboni/editors.js:270
-msgid "No version notes found"
-msgstr "Няма намерени бележки по версията"
-
-#: static/js/zamboni/editors.js:330
-msgid "Average Reviews"
-msgstr ""
-
-#: static/js/zamboni/editors.js:386
-msgid "Number of Reviews"
-msgstr ""
-
-#: static/js/zamboni/editors.js:445
-msgid "Error loading translation"
-msgstr "Грешка при зареждане на превода"
-
-#: static/js/zamboni/files.js:411 static/js/zamboni/validator.js:261
-msgid "Ignore this message in future updates"
-msgstr ""
-
-#: static/js/zamboni/files.js:417 static/js/zamboni/validator.js:284
-msgid "Severity for automated signing:"
-msgstr ""
-
-#: static/js/zamboni/global.js:410
+#: static/js/common-all.js:9088 static/js/impala-all.js:9649 static/js/zamboni/global.js:410
 msgid "Loading..."
 msgstr "Зареждане..."
 
 #. L10n: {0} is the number of characters left.
-#: static/js/zamboni/global.js:474
+#: static/js/common-all.js:9152 static/js/impala-all.js:9713 static/js/zamboni/global.js:474
 msgid "<b>{0}</b> character left."
 msgid_plural "<b>{0}</b> characters left."
 msgstr[0] "остава <b>{0}</b> знак."
 msgstr[1] "остават <b>{0}</b> знака."
 
-#: static/js/zamboni/init.js:28
-msgid "This feature is temporarily disabled while we perform website maintenance. Please check back a little later."
-msgstr "Това свойство е временно спряно, докато правим промени по сайта. Моля, проверете отново малко по-късно."
+#: static/js/common-all.js:9589 static/js/common-min.js:6 static/js/impala-all.js:10052 static/js/impala-min.js:6 static/js/common/ratingwidget.js:31 static/js/zamboni/mobile-all.js:16123
+#: static/js/zamboni/mobile-min.js:6
+msgid "{0} star"
+msgid_plural "{0} stars"
+msgstr[0] "{0} звезда"
+msgstr[1] "{0} звезди"
 
-#: static/js/zamboni/l10n.js:45
+#: static/js/common-all.js:9676 static/js/common-min.js:6 static/js/impala-all.js:10139 static/js/impala-min.js:6 static/js/zamboni/l10n.js:45
 msgid "Remove this localization"
 msgstr "Премахни тази локализация"
 
-#: static/js/zamboni/password-strength.js:20
+#: static/js/common-all.js:10193 static/js/common-min.js:6 static/js/impala-all.js:10674 static/js/impala-min.js:6 static/js/zamboni/discovery-all.js:13678
+msgid "close"
+msgstr ""
+
+#: static/js/common-all.js:10860 static/js/common-min.js:6 static/js/impala-all.js:11481 static/js/impala-min.js:6 static/js/impala/reviews.js:23 static/js/zamboni/reviews.js:18
+msgid "Flagged for review"
+msgstr "Отбелязана за преглед"
+
+#: static/js/common-all.js:10876 static/js/common-min.js:6 static/js/impala-all.js:11498 static/js/impala-min.js:6 static/js/impala/reviews.js:40 static/js/zamboni/reviews.js:34
+msgid "Your input is required"
+msgstr "Моля, въведете нещо тук"
+
+#: static/js/common-all.js:10945 static/js/common-min.js:6 static/js/impala-all.js:11610 static/js/impala-min.js:7 static/js/impala/reviews.js:152 static/js/zamboni/reviews.js:103
+msgid "Marked for deletion"
+msgstr "Отбелязан за изтриване"
+
+#: static/js/common-all.js:11573 static/js/common-min.js:7 static/js/impala-all.js:13809 static/js/impala-min.js:8 static/js/zamboni/collections.js:229
+msgid "Adding to Favorites&hellip;"
+msgstr "Добавяне към Любими&hellip;"
+
+#: static/js/common-all.js:11576 static/js/common-min.js:7 static/js/impala-all.js:13812 static/js/impala-min.js:8 static/js/zamboni/collections.js:232
+msgid "Removing Favorite&hellip;"
+msgstr "Премахване от Любими&hellip;"
+
+#: static/js/common-all.js:11579 static/js/common-min.js:7 static/js/impala-all.js:13815 static/js/impala-min.js:8 static/js/zamboni/collections.js:235
+msgid "Add to Favorites"
+msgstr "Добави към Любими"
+
+#: static/js/common-all.js:11582 static/js/common-min.js:7 static/js/impala-all.js:13818 static/js/impala-min.js:8 static/js/zamboni/collections.js:238
+msgid "Remove from Favorites"
+msgstr "Премахни от Любими"
+
+#: static/js/common-all.js:11647 static/js/common-min.js:7 static/js/impala-all.js:13883 static/js/impala-min.js:8 static/js/zamboni/collections.js:303
+msgid "Pending"
+msgstr "Чакащ"
+
+#: static/js/common-all.js:11648 static/js/common-min.js:7 static/js/impala-all.js:13884 static/js/impala-min.js:8 static/js/zamboni/collections.js:304
+msgid "Add a comment"
+msgstr "Добавяне на коментар"
+
+#: static/js/common-all.js:11648 static/js/common-min.js:7 static/js/impala-all.js:13884 static/js/impala-min.js:8 static/js/zamboni/collections.js:304
+msgid "Comment"
+msgstr "Коментар"
+
+#: static/js/common-all.js:11649 static/js/common-min.js:7 static/js/impala-all.js:13885 static/js/impala-min.js:8 static/js/zamboni/collections.js:305
+msgid "Remove this add-on from the collection"
+msgstr "Премахни тази добавка от колекцията"
+
+#: static/js/common-all.js:11649 static/js/common-all.js:11678 static/js/common-min.js:7 static/js/impala-all.js:13885 static/js/impala-all.js:13914 static/js/impala-min.js:8
+#: static/js/zamboni/collections.js:305 static/js/zamboni/collections.js:334
+msgid "Remove"
+msgstr "Премахни"
+
+#: static/js/common-all.js:11678 static/js/common-min.js:7 static/js/impala-all.js:13914 static/js/impala-min.js:8 static/js/zamboni/collections.js:334
+msgid "Remove this user as a contributor"
+msgstr "Премахни този потребител като допринесъл"
+
+#: static/js/common-all.js:11690 static/js/common-min.js:7 static/js/impala-all.js:13926 static/js/impala-min.js:8 static/js/zamboni/collections.js:346
+msgid "An email address is required."
+msgstr "Нужен е имейл адрес."
+
+#: static/js/common-all.js:11708 static/js/common-min.js:7 static/js/impala-all.js:13944 static/js/impala-min.js:8 static/js/zamboni/collections.js:364
+msgid "You cannot add yourself as a contributor."
+msgstr "Не може да добавяте себе си като сътрудник."
+
+#: static/js/common-all.js:11710 static/js/common-min.js:7 static/js/impala-all.js:13946 static/js/impala-min.js:8 static/js/zamboni/collections.js:366
+msgid "You have already added that user."
+msgstr "Вече сте добавили този потребител."
+
+#: static/js/common-all.js:11917 static/js/common-min.js:7 static/js/impala-all.js:14153 static/js/impala-min.js:8 static/js/zamboni/collections.js:573
+msgid "Add to favorites"
+msgstr "Добави в любими"
+
+#: static/js/common-all.js:11921 static/js/common-min.js:7 static/js/impala-all.js:14157 static/js/impala-min.js:8 static/js/zamboni/collections.js:577
+msgid "Remove from favorites"
+msgstr "Премахни от любими"
+
+#: static/js/common-all.js:11939 static/js/common-min.js:7 static/js/impala-all.js:14175 static/js/impala-all.js:14233 static/js/impala-min.js:8 static/js/impala/collections.js:10
+#: static/js/zamboni/collections.js:595
+msgid "Follow this Collection"
+msgstr "Следвай тази колекция"
+
+#: static/js/common-all.js:11948 static/js/common-min.js:7 static/js/impala-all.js:14184 static/js/impala-min.js:8 static/js/zamboni/collections.js:604
+msgid "Stop following"
+msgstr "Спри да следваш"
+
+#: static/js/common-all.js:12096 static/js/common-min.js:7 static/js/zamboni/password-strength.js:20
 msgid "Password strength:"
 msgstr "Надежност на паролата:"
 
-#: static/js/zamboni/password-strength.js:26
+#: static/js/common-all.js:12102 static/js/common-min.js:7 static/js/zamboni/password-strength.js:26
 msgid "At least {0} character left."
 msgid_plural "At least {0} characters left."
 msgstr[0] "Остава поне {0} знак."
 msgstr[1] "Остават поне {0} знака."
 
-#: static/js/zamboni/themes_review.js:176
-msgid "Requested Info"
-msgstr "Изискана информация"
+#: static/js/common-all.js:12286 static/js/common-min.js:7 static/js/impala-all.js:14632 static/js/impala-min.js:8 static/js/impala/suggestions.js:39
+msgid "Search themes for <b>{0}</b>"
+msgstr "Търсене на <b>{0}</b> в темите"
 
-#: static/js/zamboni/themes_review.js:177
-msgid "Flagged"
-msgstr "Маркиран"
+#: static/js/common-all.js:12288 static/js/common-min.js:7 static/js/impala-all.js:14634 static/js/impala-min.js:8 static/js/impala/suggestions.js:41
+msgid "Search apps for <b>{0}</b>"
+msgstr "Търси приложения за <b>{0}</b>"
 
-#: static/js/zamboni/themes_review.js:178
-msgid "Duplicate"
-msgstr "Дубликат"
+#: static/js/common-all.js:12290 static/js/common-min.js:7 static/js/impala-all.js:14636 static/js/impala-min.js:8 static/js/impala/suggestions.js:43
+msgid "Search add-ons for <b>{0}</b>"
+msgstr "Търси добавки за <b>{0}</b>"
 
-#: static/js/zamboni/themes_review.js:179
-msgid "Rejected"
-msgstr "Отказан"
+#: static/js/common-all.js:12521 static/js/common-min.js:7 static/js/impala-all.js:14867 static/js/impala-min.js:8 static/js/impala/site_suggestions.js:46
+msgid "Category"
+msgstr "Категория"
 
-#: static/js/zamboni/themes_review.js:180
-msgid "Approved"
-msgstr "Одобрен"
+#. L10n: {0} is an app name.
+#: static/js/impala-all.js:11632 static/js/impala-min.js:7 static/js/impala/listing.js:11 static/js/zamboni/themes.js:13
+msgid "This theme is incompatible with your version of {0}"
+msgstr "Тази тема е несъвместима с вашата версия на {0}"
 
-#: static/js/zamboni/themes_review.js:424
-msgid "No results found"
+#: static/js/impala-all.js:12146 static/js/impala-all.js:14331 static/js/impala-min.js:7 static/js/impala-min.js:8 static/js/common/upload-image.js:97 static/js/impala/users.js:51
+#: static/js/zamboni/devhub-all.js:894 static/js/zamboni/devhub-min.js:1
+msgid "Images must be either PNG or JPG."
+msgstr "Изображенията трябва да са PNG или JPG."
+
+#: static/js/impala-all.js:12150 static/js/impala-min.js:7 static/js/common/upload-image.js:101 static/js/zamboni/devhub-all.js:898 static/js/zamboni/devhub-min.js:1
+msgid "Videos must be in WebM."
+msgstr "Видеотата трябва да са във формат WebM."
+
+#: static/js/impala-all.js:12177 static/js/impala-min.js:7 static/js/common/upload-addon.js:41 static/js/common/upload-image.js:128 static/js/zamboni/devhub-all.js:272
+#: static/js/zamboni/devhub-all.js:925 static/js/zamboni/devhub-min.js:1
+msgid "There was a problem contacting the server."
+msgstr "Имаше проблем при свързването със сървъра."
+
+#: static/js/impala-all.js:13298 static/js/impala-min.js:7 static/js/impala/persona_creation.js:60
+msgid "All Rights Reserved"
+msgstr "Всички права запазени"
+
+#: static/js/impala-all.js:13302 static/js/impala-min.js:7 static/js/impala/persona_creation.js:64
+msgid "Creative Commons Attribution 3.0"
+msgstr "Creative Commons Attribution 3.0"
+
+#: static/js/impala-all.js:13307 static/js/impala-min.js:7 static/js/impala/persona_creation.js:69
+msgid "Creative Commons Attribution-NonCommercial 3.0"
+msgstr "Creative Commons Attribution-NonCommercial 3.0"
+
+#: static/js/impala-all.js:13312 static/js/impala-min.js:7 static/js/impala/persona_creation.js:74
+msgid "Creative Commons Attribution-NonCommercial-NoDerivs 3.0"
+msgstr "Creative Commons Attribution-NonCommercial-NoDerivs 3.0"
+
+#: static/js/impala-all.js:13317 static/js/impala-min.js:7 static/js/impala/persona_creation.js:79
+msgid "Creative Commons Attribution-NonCommercial-Share Alike 3.0"
+msgstr "Creative Commons Attribution-NonCommercial-Share Alike 3.0"
+
+#: static/js/impala-all.js:13322 static/js/impala-min.js:7 static/js/impala/persona_creation.js:84
+msgid "Creative Commons Attribution-NoDerivs 3.0"
+msgstr "Creative Commons Attribution-NoDerivs 3.0"
+
+#: static/js/impala-all.js:13327 static/js/impala-min.js:7 static/js/impala/persona_creation.js:89
+msgid "Creative Commons Attribution-ShareAlike 3.0"
+msgstr "Creative Commons Attribution-ShareAlike 3.0"
+
+#: static/js/impala-all.js:13530 static/js/impala-min.js:7 static/js/impala/persona_creation.js:292
+msgid "Your Theme's Name"
+msgstr "Името на темата Ви"
+
+#: static/js/impala-all.js:14242 static/js/impala-min.js:8 static/js/impala/collections.js:19
+msgid "Stop Following"
+msgstr "Спри да следваш"
+
+#: static/js/impala-all.js:14243 static/js/impala-min.js:8 static/js/impala/collections.js:20
+msgid "Following"
+msgstr "Следва"
+
+#: static/js/impala-all.js:14313 static/js/impala-min.js:8 static/js/impala/users.js:33
+msgid "use original"
+msgstr "използвай оригинала"
+
+#: static/js/impala-all.js:14523 static/js/impala-min.js:8 static/js/impala/search.js:114
+msgid "Updating results&hellip;"
+msgstr "Актуализиране на резултатите&hellip;"
+
+#: static/js/common/upload-addon.js:69 static/js/zamboni/devhub-all.js:300 static/js/zamboni/devhub-min.js:1
+msgid "Select a file..."
+msgstr "Изберете файл..."
+
+#: static/js/common/upload-addon.js:70 static/js/zamboni/devhub-all.js:301 static/js/zamboni/devhub-min.js:1
+msgid "Your add-on should end with .xpi, .jar or .xml"
+msgstr "Добавката ви трябва да завършва с .xpi, .jar или .xml"
+
+#. L10n: {0} is the percent of the file that has been uploaded.
+#: static/js/common/upload-addon.js:104 static/js/zamboni/devhub-all.js:335 static/js/zamboni/devhub-min.js:1
+#, fuzzy, python-format
+msgid "{0}% complete"
+msgstr "{0}% завършени"
+
+#. L10n: "{bytes uploaded} of {total filesize}".
+#: static/js/common/upload-addon.js:107 static/js/zamboni/devhub-all.js:338 static/js/zamboni/devhub-min.js:1
+msgid "{0} of {1}"
+msgstr "{0} от {1}"
+
+#: static/js/common/upload-addon.js:140 static/js/zamboni/devhub-all.js:371 static/js/zamboni/devhub-min.js:1
+msgid "Cancel"
+msgstr "Откажи"
+
+#: static/js/common/upload-addon.js:162 static/js/zamboni/devhub-all.js:393 static/js/zamboni/devhub-min.js:1
+msgid "Uploading {0}"
+msgstr "Качване {0}"
+
+#: static/js/common/upload-addon.js:189 static/js/zamboni/devhub-all.js:420 static/js/zamboni/devhub-min.js:1
+msgid "Error with {0}"
+msgstr "Грешка с {0}"
+
+#: static/js/common/upload-addon.js:194 static/js/zamboni/devhub-all.js:425 static/js/zamboni/devhub-min.js:1
+msgid "Your add-on failed validation with {0} error."
+msgid_plural "Your add-on failed validation with {0} errors."
+msgstr[0] "Добавката ви не премина валидирането с {0} грешка."
+msgstr[1] "Добавката ви не премина валидирането с {0} грешки."
+
+#: static/js/common/upload-addon.js:208 static/js/zamboni/devhub-all.js:439 static/js/zamboni/devhub-min.js:1
+msgid "&hellip;and {0} more"
+msgid_plural "&hellip;and {0} more"
+msgstr[0] "&hellip;и {0} още"
+msgstr[1] "&hellip;и {0} още"
+
+#: static/js/common/upload-addon.js:222 static/js/common/upload-addon.js:497 static/js/zamboni/devhub-all.js:453 static/js/zamboni/devhub-all.js:743 static/js/zamboni/devhub-min.js:1
+msgid "See full validation report"
+msgstr "Виж целия доклад за валидацията"
+
+#: static/js/common/upload-addon.js:234 static/js/zamboni/devhub-all.js:465 static/js/zamboni/devhub-min.js:1
+msgid "Validating {0}"
+msgstr "Валидиране {0}"
+
+#. L10n: first argument is an HTTP status code
+#: static/js/common/upload-addon.js:273 static/js/zamboni/devhub-all.js:504 static/js/zamboni/devhub-min.js:1
+msgid "Received an empty response from the server; status: {0}"
+msgstr "Получих празен отговор от сървъра; състояние {0}"
+
+#: static/js/common/upload-addon.js:370 static/js/zamboni/devhub-all.js:604 static/js/zamboni/devhub-min.js:1
+msgid "Unexpected server error while validating."
+msgstr "Неочаквана грешка на сървъра, докато се валидира."
+
+#: static/js/common/upload-addon.js:409 static/js/zamboni/devhub-all.js:643 static/js/zamboni/devhub-min.js:1
+msgid "Finished validating {0}"
+msgstr "Валидирането приключи {0}"
+
+#: static/js/common/upload-addon.js:415 static/js/zamboni/devhub-all.js:649 static/js/zamboni/devhub-min.js:1
+msgid "Your add-on validation timed out, it will be manually reviewed."
 msgstr ""
 
-#: static/js/zamboni/themes_review_templates.js:31
-msgid "Theme"
+#: static/js/common/upload-addon.js:418 static/js/zamboni/devhub-all.js:652 static/js/zamboni/devhub-min.js:1
+msgid "Your add-on was validated with no errors and {0} warning."
+msgid_plural "Your add-on was validated with no errors and {0} warnings."
+msgstr[0] ""
+msgstr[1] ""
+
+#: static/js/common/upload-addon.js:423 static/js/zamboni/devhub-all.js:657 static/js/zamboni/devhub-min.js:1
+msgid "Your add-on was validated with no errors and {0} message."
+msgid_plural "Your add-on was validated with no errors and {0} messages."
+msgstr[0] ""
+msgstr[1] ""
+
+#: static/js/common/upload-addon.js:428 static/js/zamboni/devhub-all.js:662 static/js/zamboni/devhub-min.js:1
+msgid "Your add-on was validated with no errors or warnings."
 msgstr ""
 
-#: static/js/zamboni/themes_review_templates.js:33
-msgid "Reviewer"
+#: static/js/common/upload-addon.js:443 static/js/zamboni/devhub-all.js:677 static/js/zamboni/devhub-min.js:1
+msgid "Your submission will be automatically signed."
 msgstr ""
 
-#: static/js/zamboni/themes_review_templates.js:35
-msgid "Status"
+#: static/js/common/upload-addon.js:450 static/js/zamboni/devhub-all.js:696 static/js/zamboni/devhub-min.js:1
+msgid "Include detailed version notes (this can be done in the next step)."
 msgstr ""
 
-#: static/js/zamboni/validator.js:80
+#: static/js/common/upload-addon.js:451 static/js/zamboni/devhub-all.js:697 static/js/zamboni/devhub-min.js:1
+msgid "If your add-on requires an account to a website in order to be fully tested, include a test username and password in the Notes to Reviewer (this can be done in the next step)."
+msgstr ""
+
+#: static/js/common/upload-addon.js:452 static/js/zamboni/devhub-all.js:698 static/js/zamboni/devhub-min.js:1
+msgid "If your add-on is intended for a limited audience you should choose Preliminary Review instead of Full Review."
+msgstr ""
+
+#: static/js/common/upload-addon.js:465 static/js/zamboni/devhub-all.js:711 static/js/zamboni/devhub-min.js:1
+msgid "Add-on submission checklist"
+msgstr "Стъпки за изпращане на добавка"
+
+#: static/js/common/upload-addon.js:466 static/js/zamboni/devhub-all.js:712 static/js/zamboni/devhub-min.js:1
+msgid "Please verify the following points before finalizing your submission. This will minimize delays or misunderstanding during the review process:"
+msgstr "Проверете следните точки преди да изпратите добавката. Така ще бъдат намалени забавянията поради неясноти по време на процеса на преглед:"
+
+#: static/js/common/upload-addon.js:468 static/js/zamboni/devhub-all.js:714 static/js/zamboni/devhub-min.js:1
+msgid ""
+"Compiled binaries, as well as minified or obfuscated scripts (excluding known libraries) need to have their sources submitted separately for review. Make sure that you use the source code upload "
+"field to avoid having your submission rejected."
+msgstr ""
+
+#: static/js/common/upload-addon.js:486 static/js/zamboni/devhub-all.js:732 static/js/zamboni/devhub-min.js:1
+msgid "The validation process found these issues that can lead to rejections:"
+msgstr ""
+
+#: static/js/common/upload-addon.js:503 static/js/zamboni/devhub-all.js:749 static/js/zamboni/devhub-min.js:1
+msgid "If you are unfamiliar with the add-ons review process, you can read about it here."
+msgstr ""
+
+#: static/js/common/upload-addon.js:540 static/js/zamboni/devhub-all.js:786 static/js/zamboni/devhub-min.js:1
+msgid "Sorry, no supported platform has been found."
+msgstr ""
+
+#: static/js/common/upload-base.js:57 static/js/zamboni/devhub-all.js:187 static/js/zamboni/devhub-min.js:1
+msgid "The filetype you uploaded isn't recognized."
+msgstr "Видът на файла, който качихте не е разпознат."
+
+#: static/js/common/upload-base.js:79 static/js/zamboni/devhub-all.js:209 static/js/zamboni/devhub-min.js:1
+msgid "You cancelled the upload."
+msgstr "Вие отказахте качването."
+
+#: static/js/impala/stats/chart.js:267 static/js/zamboni/stats-all.js:16898 static/js/zamboni/stats-min.js:5
+msgid "Week of {0}"
+msgstr "Седмица от {0}"
+
+#: static/js/impala/stats/chart.js:269 static/js/zamboni/stats-all.js:16900 static/js/zamboni/stats-min.js:5
+msgid " downloads"
+msgstr ""
+
+#: static/js/impala/stats/chart.js:270 static/js/zamboni/stats-all.js:16901 static/js/zamboni/stats-min.js:5
+msgid "{0} users"
+msgstr "{0} потребители"
+
+#: static/js/impala/stats/chart.js:271 static/js/zamboni/stats-all.js:16902 static/js/zamboni/stats-min.js:5
+msgid "{0} add-ons"
+msgstr "{0} добавки"
+
+#: static/js/impala/stats/chart.js:272 static/js/zamboni/stats-all.js:16903 static/js/zamboni/stats-min.js:5
+msgid "{0} collections"
+msgstr "{0} колекции"
+
+#: static/js/impala/stats/chart.js:273 static/js/zamboni/stats-all.js:16904 static/js/zamboni/stats-min.js:5
+msgid "{0} reviews"
+msgstr "{0} рецензии"
+
+#: static/js/impala/stats/chart.js:275 static/js/zamboni/stats-all.js:16906 static/js/zamboni/stats-min.js:5
+msgid "{0} sales"
+msgstr "{0} продажби"
+
+#: static/js/impala/stats/chart.js:276 static/js/zamboni/stats-all.js:16907 static/js/zamboni/stats-min.js:5
+msgid "{0} refunds"
+msgstr "{0} възстановявания"
+
+#: static/js/impala/stats/chart.js:277 static/js/zamboni/stats-all.js:16908 static/js/zamboni/stats-min.js:5
+msgid "{0} installs"
+msgstr "{0} инсталации"
+
+#: static/js/impala/stats/chart.js:369 static/js/impala/stats/csv_keys.js:3 static/js/impala/stats/csv_keys.js:109 static/js/zamboni/stats-all.js:15284 static/js/zamboni/stats-all.js:15390
+#: static/js/zamboni/stats-all.js:17000 static/js/zamboni/stats-min.js:4 static/js/zamboni/stats-min.js:5
+msgid "Downloads"
+msgstr "Сваляния"
+
+#: static/js/impala/stats/chart.js:379 static/js/impala/stats/csv_keys.js:6 static/js/impala/stats/csv_keys.js:110 static/js/zamboni/stats-all.js:15287 static/js/zamboni/stats-all.js:15391
+#: static/js/zamboni/stats-all.js:17010 static/js/zamboni/stats-min.js:4 static/js/zamboni/stats-min.js:5
+msgid "Daily Users"
+msgstr "Потребители дневно"
+
+#: static/js/impala/stats/chart.js:410 static/js/zamboni/stats-all.js:17041 static/js/zamboni/stats-min.js:5
+msgid "Amount, in USD"
+msgstr "Размер, в USD"
+
+#: static/js/impala/stats/chart.js:421 static/js/impala/stats/csv_keys.js:104 static/js/zamboni/stats-all.js:15385 static/js/zamboni/stats-all.js:17052 static/js/zamboni/stats-min.js:5
+msgid "Number of Contributions"
+msgstr "Брой допринесли"
+
+#: static/js/impala/stats/chart.js:447 static/js/zamboni/stats-all.js:17078 static/js/zamboni/stats-min.js:5
+msgid "More Info..."
+msgstr "Още информация..."
+
+#. L10n: {0} is an ISO-formatted date.
+#: static/js/impala/stats/chart.js:451 static/js/zamboni/stats-all.js:17082 static/js/zamboni/stats-min.js:5
+msgid "Details for {0}"
+msgstr "Детайли за {0}"
+
+#: static/js/impala/stats/csv_keys.js:9 static/js/zamboni/stats-all.js:15290 static/js/zamboni/stats-min.js:4
+msgid "Collections Created"
+msgstr "Създадени колекции"
+
+#: static/js/impala/stats/csv_keys.js:12 static/js/zamboni/stats-all.js:15293 static/js/zamboni/stats-min.js:4
+msgid "Add-ons in Use"
+msgstr "Добавки в употреба"
+
+#: static/js/impala/stats/csv_keys.js:15 static/js/zamboni/stats-all.js:15296 static/js/zamboni/stats-min.js:4
+msgid "Add-ons Created"
+msgstr "Създадени добавки"
+
+#: static/js/impala/stats/csv_keys.js:18 static/js/zamboni/stats-all.js:15299 static/js/zamboni/stats-min.js:4
+msgid "Add-ons Downloaded"
+msgstr "Свалени добавки"
+
+#: static/js/impala/stats/csv_keys.js:21 static/js/zamboni/stats-all.js:15302 static/js/zamboni/stats-min.js:4
+msgid "Add-ons Updated"
+msgstr "Обновени добавки"
+
+#: static/js/impala/stats/csv_keys.js:24 static/js/zamboni/stats-all.js:15305 static/js/zamboni/stats-min.js:4
+msgid "Reviews Written"
+msgstr "Написани рецензии"
+
+#: static/js/impala/stats/csv_keys.js:27 static/js/zamboni/stats-all.js:15308 static/js/zamboni/stats-min.js:4
+msgid "User Signups"
+msgstr "Регистрирани потребители"
+
+#: static/js/impala/stats/csv_keys.js:30 static/js/zamboni/stats-all.js:15311 static/js/zamboni/stats-min.js:4
+msgid "Subscribers"
+msgstr "Абонати"
+
+#: static/js/impala/stats/csv_keys.js:33 static/js/zamboni/stats-all.js:15314 static/js/zamboni/stats-min.js:4
+msgid "Ratings"
+msgstr "Оценки"
+
+#: static/js/impala/stats/csv_keys.js:36 static/js/impala/stats/csv_keys.js:114 static/js/zamboni/stats-all.js:15317 static/js/zamboni/stats-all.js:15395 static/js/zamboni/stats-min.js:4
+#: static/js/zamboni/stats-min.js:5
+msgid "Sales"
+msgstr "Продажби"
+
+#: static/js/impala/stats/csv_keys.js:39 static/js/impala/stats/csv_keys.js:113 static/js/zamboni/stats-all.js:15320 static/js/zamboni/stats-all.js:15394 static/js/zamboni/stats-min.js:4
+#: static/js/zamboni/stats-min.js:5
+msgid "Installs"
+msgstr "Инсталации"
+
+#: static/js/impala/stats/csv_keys.js:42 static/js/zamboni/stats-all.js:15323 static/js/zamboni/stats-min.js:4
+msgid "Unknown"
+msgstr "Непознат"
+
+#: static/js/impala/stats/csv_keys.js:43 static/js/zamboni/stats-all.js:15324 static/js/zamboni/stats-min.js:4
+msgid "Add-ons Manager"
+msgstr "Мениджър на добавките"
+
+#: static/js/impala/stats/csv_keys.js:44 static/js/zamboni/stats-all.js:15325 static/js/zamboni/stats-min.js:4
+msgid "Add-ons Manager Promo"
+msgstr ""
+
+#: static/js/impala/stats/csv_keys.js:45 static/js/zamboni/stats-all.js:15326 static/js/zamboni/stats-min.js:4
+msgid "Add-ons Manager Featured"
+msgstr ""
+
+#: static/js/impala/stats/csv_keys.js:46 static/js/zamboni/stats-all.js:15327 static/js/zamboni/stats-min.js:4
+msgid "Add-ons Manager Learn More"
+msgstr ""
+
+#: static/js/impala/stats/csv_keys.js:47 static/js/zamboni/stats-all.js:15328 static/js/zamboni/stats-min.js:4
+msgid "Search Suggestions"
+msgstr ""
+
+#: static/js/impala/stats/csv_keys.js:48 static/js/zamboni/stats-all.js:15329 static/js/zamboni/stats-min.js:4
+msgid "Search Results"
+msgstr "Резултати от търсенето"
+
+#: static/js/impala/stats/csv_keys.js:49 static/js/impala/stats/csv_keys.js:50 static/js/impala/stats/csv_keys.js:51 static/js/zamboni/stats-all.js:15330 static/js/zamboni/stats-all.js:15331
+#: static/js/zamboni/stats-all.js:15332 static/js/zamboni/stats-min.js:4
+msgid "Homepage Promo"
+msgstr "Начална страница Промо"
+
+#: static/js/impala/stats/csv_keys.js:52 static/js/impala/stats/csv_keys.js:53 static/js/zamboni/stats-all.js:15333 static/js/zamboni/stats-all.js:15334 static/js/zamboni/stats-min.js:4
+msgid "Homepage Featured"
+msgstr "Начална страница Препоръчани"
+
+#: static/js/impala/stats/csv_keys.js:54 static/js/impala/stats/csv_keys.js:55 static/js/zamboni/stats-all.js:15335 static/js/zamboni/stats-all.js:15336 static/js/zamboni/stats-min.js:4
+msgid "Homepage Up and Coming"
+msgstr "Начална страница Up and Coming"
+
+#: static/js/impala/stats/csv_keys.js:56 static/js/zamboni/stats-all.js:15337 static/js/zamboni/stats-min.js:4
+msgid "Homepage Most Popular"
+msgstr "Начална страница Най-известнии"
+
+#: static/js/impala/stats/csv_keys.js:57 static/js/impala/stats/csv_keys.js:59 static/js/zamboni/stats-all.js:15338 static/js/zamboni/stats-all.js:15340 static/js/zamboni/stats-min.js:4
+msgid "Detail Page"
+msgstr "Страница с детайли"
+
+#: static/js/impala/stats/csv_keys.js:58 static/js/impala/stats/csv_keys.js:60 static/js/zamboni/stats-all.js:15339 static/js/zamboni/stats-all.js:15341 static/js/zamboni/stats-min.js:4
+msgid "Detail Page (bottom)"
+msgstr "Страница с детайли (дъно)"
+
+#: static/js/impala/stats/csv_keys.js:61 static/js/zamboni/stats-all.js:15342 static/js/zamboni/stats-min.js:4
+msgid "Detail Page (Development Channel)"
+msgstr "Страница с детайли (канал за разработка)"
+
+#: static/js/impala/stats/csv_keys.js:62 static/js/impala/stats/csv_keys.js:63 static/js/impala/stats/csv_keys.js:64 static/js/zamboni/stats-all.js:15343 static/js/zamboni/stats-all.js:15344
+#: static/js/zamboni/stats-all.js:15345 static/js/zamboni/stats-min.js:4
+msgid "Often Used With"
+msgstr "Често използван с"
+
+#: static/js/impala/stats/csv_keys.js:65 static/js/impala/stats/csv_keys.js:66 static/js/zamboni/stats-all.js:15346 static/js/zamboni/stats-all.js:15347 static/js/zamboni/stats-min.js:4
+msgid "Others By Author"
+msgstr "Други от автора"
+
+#: static/js/impala/stats/csv_keys.js:67 static/js/impala/stats/csv_keys.js:68 static/js/zamboni/stats-all.js:15348 static/js/zamboni/stats-all.js:15349 static/js/zamboni/stats-min.js:4
+msgid "Dependencies"
+msgstr "Зависимости"
+
+#: static/js/impala/stats/csv_keys.js:69 static/js/impala/stats/csv_keys.js:70 static/js/zamboni/stats-all.js:15350 static/js/zamboni/stats-all.js:15351 static/js/zamboni/stats-min.js:4
+msgid "Upsell"
+msgstr "Upsell"
+
+#: static/js/impala/stats/csv_keys.js:71 static/js/zamboni/stats-all.js:15352 static/js/zamboni/stats-min.js:4
+msgid "Meet the Developer"
+msgstr ""
+
+#: static/js/impala/stats/csv_keys.js:72 static/js/zamboni/stats-all.js:15353 static/js/zamboni/stats-min.js:4
+msgid "User Profile"
+msgstr ""
+
+#: static/js/impala/stats/csv_keys.js:73 static/js/zamboni/stats-all.js:15354 static/js/zamboni/stats-min.js:4
+msgid "Version History"
+msgstr ""
+
+#: static/js/impala/stats/csv_keys.js:75 static/js/zamboni/stats-all.js:15356 static/js/zamboni/stats-min.js:4
+msgid "Sharing"
+msgstr "Споделяне"
+
+#: static/js/impala/stats/csv_keys.js:76 static/js/zamboni/stats-all.js:15357 static/js/zamboni/stats-min.js:4
+msgid "Category Pages"
+msgstr "Страници с категории"
+
+#: static/js/impala/stats/csv_keys.js:77 static/js/zamboni/stats-all.js:15358 static/js/zamboni/stats-min.js:4
+msgid "Collections"
+msgstr "Колекции"
+
+#: static/js/impala/stats/csv_keys.js:78 static/js/impala/stats/csv_keys.js:79 static/js/zamboni/stats-all.js:15359 static/js/zamboni/stats-all.js:15360 static/js/zamboni/stats-min.js:4
+msgid "Category Landing Featured Carousel"
+msgstr "Category Landing Featured Carousel"
+
+#: static/js/impala/stats/csv_keys.js:80 static/js/impala/stats/csv_keys.js:81 static/js/zamboni/stats-all.js:15361 static/js/zamboni/stats-all.js:15362 static/js/zamboni/stats-min.js:4
+msgid "Category Landing Top Rated"
+msgstr "Категория Най-високо оценени"
+
+#: static/js/impala/stats/csv_keys.js:82 static/js/impala/stats/csv_keys.js:83 static/js/zamboni/stats-all.js:15363 static/js/zamboni/stats-all.js:15364 static/js/zamboni/stats-min.js:5
+msgid "Category Landing Most Popular"
+msgstr "Категория най-известни"
+
+#: static/js/impala/stats/csv_keys.js:84 static/js/impala/stats/csv_keys.js:85 static/js/zamboni/stats-all.js:15365 static/js/zamboni/stats-all.js:15366 static/js/zamboni/stats-min.js:5
+msgid "Category Landing Recently Added"
+msgstr "Категория Наскоро добавени"
+
+#: static/js/impala/stats/csv_keys.js:86 static/js/impala/stats/csv_keys.js:87 static/js/zamboni/stats-all.js:15367 static/js/zamboni/stats-all.js:15368 static/js/zamboni/stats-min.js:5
+msgid "Browse Listing Featured Sort"
+msgstr "Browse Listing Featured Sort"
+
+#: static/js/impala/stats/csv_keys.js:88 static/js/impala/stats/csv_keys.js:89 static/js/zamboni/stats-all.js:15369 static/js/zamboni/stats-all.js:15370 static/js/zamboni/stats-min.js:5
+msgid "Browse Listing Users Sort"
+msgstr "Browse Listing Users Sort"
+
+#: static/js/impala/stats/csv_keys.js:90 static/js/impala/stats/csv_keys.js:91 static/js/zamboni/stats-all.js:15371 static/js/zamboni/stats-all.js:15372 static/js/zamboni/stats-min.js:5
+msgid "Browse Listing Rating Sort"
+msgstr "Browse Listing Rating Sort"
+
+#: static/js/impala/stats/csv_keys.js:92 static/js/impala/stats/csv_keys.js:93 static/js/zamboni/stats-all.js:15373 static/js/zamboni/stats-all.js:15374 static/js/zamboni/stats-min.js:5
+msgid "Browse Listing Created Sort"
+msgstr "Browse Listing Created Sort"
+
+#: static/js/impala/stats/csv_keys.js:94 static/js/impala/stats/csv_keys.js:95 static/js/zamboni/stats-all.js:15375 static/js/zamboni/stats-all.js:15376 static/js/zamboni/stats-min.js:5
+msgid "Browse Listing Name Sort"
+msgstr "Browse Listing Name Sort"
+
+#: static/js/impala/stats/csv_keys.js:96 static/js/impala/stats/csv_keys.js:97 static/js/zamboni/stats-all.js:15377 static/js/zamboni/stats-all.js:15378 static/js/zamboni/stats-min.js:5
+msgid "Browse Listing Popular Sort"
+msgstr "Browse Listing Popular Sort"
+
+#: static/js/impala/stats/csv_keys.js:98 static/js/impala/stats/csv_keys.js:99 static/js/zamboni/stats-all.js:15379 static/js/zamboni/stats-all.js:15380 static/js/zamboni/stats-min.js:5
+msgid "Browse Listing Updated Sort"
+msgstr "Browse Listing Updated Sort"
+
+#: static/js/impala/stats/csv_keys.js:100 static/js/impala/stats/csv_keys.js:101 static/js/zamboni/stats-all.js:15381 static/js/zamboni/stats-all.js:15382 static/js/zamboni/stats-min.js:5
+msgid "Browse Listing Up and Coming Sort"
+msgstr "Browse Listing Up and Coming Sort"
+
+#: static/js/impala/stats/csv_keys.js:105 static/js/zamboni/stats-all.js:15386 static/js/zamboni/stats-min.js:5
+msgid "Total Amount Contributed"
+msgstr "Общо дарено"
+
+#: static/js/impala/stats/csv_keys.js:106 static/js/zamboni/stats-all.js:15387 static/js/zamboni/stats-min.js:5
+msgid "Average Contribution"
+msgstr "Средни дарения"
+
+#: static/js/impala/stats/csv_keys.js:115 static/js/zamboni/stats-all.js:15396 static/js/zamboni/stats-min.js:5
+msgid "Usage"
+msgstr "Употреба"
+
+#: static/js/impala/stats/csv_keys.js:118 static/js/zamboni/stats-all.js:15399 static/js/zamboni/stats-min.js:5
+msgid "Firefox"
+msgstr "Firefox"
+
+#: static/js/impala/stats/csv_keys.js:119 static/js/zamboni/stats-all.js:15400 static/js/zamboni/stats-min.js:5
+msgid "Mozilla"
+msgstr "Mozilla"
+
+#: static/js/impala/stats/csv_keys.js:120 static/js/zamboni/stats-all.js:15401 static/js/zamboni/stats-min.js:5
+msgid "Thunderbird"
+msgstr "Thunderbird"
+
+#: static/js/impala/stats/csv_keys.js:121 static/js/zamboni/stats-all.js:15402 static/js/zamboni/stats-min.js:5
+msgid "Sunbird"
+msgstr "Sunbird"
+
+#: static/js/impala/stats/csv_keys.js:122 static/js/zamboni/stats-all.js:15403 static/js/zamboni/stats-min.js:5
+msgid "SeaMonkey"
+msgstr "SeaMonkey"
+
+#: static/js/impala/stats/csv_keys.js:123 static/js/zamboni/stats-all.js:15404 static/js/zamboni/stats-min.js:5
+msgid "Fennec"
+msgstr "Fennec"
+
+#: static/js/impala/stats/csv_keys.js:124 static/js/zamboni/stats-all.js:15405 static/js/zamboni/stats-min.js:5
+msgid "Android"
+msgstr "Андроид"
+
+#. L10n: {0} is an integer.
+#: static/js/impala/stats/csv_keys.js:129 static/js/zamboni/stats-all.js:15410 static/js/zamboni/stats-min.js:5
+msgid "Downloads and Daily Users, last {0} days"
+msgstr "Сваляния и дневни потребители последните {0} дни"
+
+#. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
+#: static/js/impala/stats/csv_keys.js:131 static/js/zamboni/stats-all.js:15412 static/js/zamboni/stats-min.js:5
+msgid "Downloads and Daily Users from {0} to {1}"
+msgstr "Сваляния и потребители дневно от {0} до {1}"
+
+#. L10n: {0} is an integer.
+#: static/js/impala/stats/csv_keys.js:135 static/js/zamboni/stats-all.js:15416 static/js/zamboni/stats-min.js:5
+msgid "Installs and Daily Users, last {0} days"
+msgstr "Инсталации и потребители дневно последните {0} дни"
+
+#. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
+#: static/js/impala/stats/csv_keys.js:137 static/js/zamboni/stats-all.js:15418 static/js/zamboni/stats-min.js:5
+msgid "Installs and Daily Users from {0} to {1}"
+msgstr "Инсталации и потребители дневно от {0} до {1}"
+
+#. L10n: {0} is an integer.
+#: static/js/impala/stats/csv_keys.js:141 static/js/zamboni/stats-all.js:15422 static/js/zamboni/stats-min.js:5
+msgid "Downloads, last {0} days"
+msgstr "Сваляния последните {0} дни"
+
+#. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
+#: static/js/impala/stats/csv_keys.js:143 static/js/zamboni/stats-all.js:15424 static/js/zamboni/stats-min.js:5
+msgid "Downloads from {0} to {1}"
+msgstr "Сваляния от {0} от {1}"
+
+#. L10n: {0} is an integer.
+#: static/js/impala/stats/csv_keys.js:147 static/js/zamboni/stats-all.js:15428 static/js/zamboni/stats-min.js:5
+msgid "Daily Users, last {0} days"
+msgstr "Потребители дневно последните {0} дни"
+
+#. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
+#: static/js/impala/stats/csv_keys.js:149 static/js/zamboni/stats-all.js:15430 static/js/zamboni/stats-min.js:5
+msgid "Daily Users from {0} to {1}"
+msgstr "Потребители дневно от {0} до {1}"
+
+#. L10n: {0} is an integer.
+#: static/js/impala/stats/csv_keys.js:153 static/js/zamboni/stats-all.js:15434 static/js/zamboni/stats-min.js:5
+msgid "Applications, last {0} days"
+msgstr "Приложения последните {0} дни"
+
+#. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
+#: static/js/impala/stats/csv_keys.js:155 static/js/zamboni/stats-all.js:15436 static/js/zamboni/stats-min.js:5
+msgid "Applications from {0} to {1}"
+msgstr "Приложения от {0} до {1}"
+
+#. L10n: {0} is an integer.
+#: static/js/impala/stats/csv_keys.js:159 static/js/zamboni/stats-all.js:15440 static/js/zamboni/stats-min.js:5
+msgid "Platforms, last {0} days"
+msgstr "Платформи последните {0} дни"
+
+#. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
+#: static/js/impala/stats/csv_keys.js:161 static/js/zamboni/stats-all.js:15442 static/js/zamboni/stats-min.js:5
+msgid "Platforms from {0} to {1}"
+msgstr "Платформи от {0} до {1}"
+
+#. L10n: {0} is an integer.
+#: static/js/impala/stats/csv_keys.js:165 static/js/zamboni/stats-all.js:15446 static/js/zamboni/stats-min.js:5
+msgid "Languages, last {0} days"
+msgstr "Езици последните {0} дни"
+
+#. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
+#: static/js/impala/stats/csv_keys.js:167 static/js/zamboni/stats-all.js:15448 static/js/zamboni/stats-min.js:5
+msgid "Languages from {0} to {1}"
+msgstr "Езици от {0} до {1}"
+
+#. L10n: {0} is an integer.
+#: static/js/impala/stats/csv_keys.js:171 static/js/zamboni/stats-all.js:15452 static/js/zamboni/stats-min.js:5
+msgid "Add-on Versions, last {0} days"
+msgstr "Версии на добавката последните {0} дни"
+
+#. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
+#: static/js/impala/stats/csv_keys.js:173 static/js/zamboni/stats-all.js:15454 static/js/zamboni/stats-min.js:5
+msgid "Add-on Versions from {0} to {1}"
+msgstr "Версии от {0} {1}"
+
+#. L10n: {0} is an integer.
+#: static/js/impala/stats/csv_keys.js:177 static/js/zamboni/stats-all.js:15458 static/js/zamboni/stats-min.js:5
+msgid "Add-on Status, last {0} days"
+msgstr "Състояние на добавката последните {0} дни"
+
+#. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
+#: static/js/impala/stats/csv_keys.js:179 static/js/zamboni/stats-all.js:15460 static/js/zamboni/stats-min.js:5
+msgid "Add-on Status from {0} to {1}"
+msgstr "Състояние на добавката от {0} до {1}"
+
+#. L10n: {0} is an integer.
+#: static/js/impala/stats/csv_keys.js:183 static/js/zamboni/stats-all.js:15464 static/js/zamboni/stats-min.js:5
+msgid "Download Sources, last {0} days"
+msgstr "Източници на сваляне последните {0} дни"
+
+#. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
+#: static/js/impala/stats/csv_keys.js:185 static/js/zamboni/stats-all.js:15466 static/js/zamboni/stats-min.js:5
+msgid "Download Sources from {0} to {1}"
+msgstr "Източници на сваляне от {0} до {1}"
+
+#. L10n: {0} is an integer.
+#: static/js/impala/stats/csv_keys.js:189 static/js/zamboni/stats-all.js:15470 static/js/zamboni/stats-min.js:5
+msgid "Contributions, last {0} days"
+msgstr "Дарения последните {0} дни"
+
+#. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
+#: static/js/impala/stats/csv_keys.js:191 static/js/zamboni/stats-all.js:15472 static/js/zamboni/stats-min.js:5
+msgid "Contributions from {0} to {1}"
+msgstr "Дарения от {0} от {1}"
+
+#. L10n: {0} is an integer.
+#: static/js/impala/stats/csv_keys.js:195 static/js/zamboni/stats-all.js:15476 static/js/zamboni/stats-min.js:5
+msgid "Site Metrics, last {0} days"
+msgstr "Статистики на сайта за последните {0} дни"
+
+#. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
+#: static/js/impala/stats/csv_keys.js:197 static/js/zamboni/stats-all.js:15478 static/js/zamboni/stats-min.js:5
+msgid "Site Metrics from {0} to {1}"
+msgstr "Статистики на сайта от {0} до {1}"
+
+#. L10n: {0} is an integer.
+#: static/js/impala/stats/csv_keys.js:201 static/js/zamboni/stats-all.js:15482 static/js/zamboni/stats-min.js:5
+msgid "Add-ons in Use, last {0} days"
+msgstr "Използвани добавки последните {0} дни"
+
+#. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
+#: static/js/impala/stats/csv_keys.js:203 static/js/zamboni/stats-all.js:15484 static/js/zamboni/stats-min.js:5
+msgid "Add-ons in Use from {0} to {1}"
+msgstr "Използвани добавки от {0} до {0}"
+
+#. L10n: {0} is an integer.
+#: static/js/impala/stats/csv_keys.js:207 static/js/zamboni/stats-all.js:15488 static/js/zamboni/stats-min.js:5
+msgid "Add-ons Downloaded, last {0} days"
+msgstr "Добавки, свалени последните {0} дни"
+
+#. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
+#: static/js/impala/stats/csv_keys.js:209 static/js/zamboni/stats-all.js:15490 static/js/zamboni/stats-min.js:5
+msgid "Add-ons Downloaded from {0} to {1}"
+msgstr "Добавки, свалени от {0} до {1}"
+
+#. L10n: {0} is an integer.
+#: static/js/impala/stats/csv_keys.js:213 static/js/zamboni/stats-all.js:15494 static/js/zamboni/stats-min.js:5
+msgid "Add-ons Created, last {0} days"
+msgstr "Добавки, създадени последните {0} дни"
+
+#. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
+#: static/js/impala/stats/csv_keys.js:215 static/js/zamboni/stats-all.js:15496 static/js/zamboni/stats-min.js:5
+msgid "Add-ons Created from {0} to {1}"
+msgstr "Добавки, създадени от {0} до {1}"
+
+#. L10n: {0} is an integer.
+#: static/js/impala/stats/csv_keys.js:219 static/js/zamboni/stats-all.js:15500 static/js/zamboni/stats-min.js:5
+msgid "Add-ons Updated, last {0} days"
+msgstr "Обновени добавки през последните {0} дни"
+
+#. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
+#: static/js/impala/stats/csv_keys.js:221 static/js/zamboni/stats-all.js:15502 static/js/zamboni/stats-min.js:5
+msgid "Add-ons Updated from {0} to {1}"
+msgstr "Обновени добавки от {0} до {1}"
+
+#. L10n: {0} is an integer.
+#: static/js/impala/stats/csv_keys.js:225 static/js/zamboni/stats-all.js:15506 static/js/zamboni/stats-min.js:5
+msgid "Reviews Written, last {0} days"
+msgstr "Написани рецензии последните {0} дни"
+
+#. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
+#: static/js/impala/stats/csv_keys.js:227 static/js/zamboni/stats-all.js:15508 static/js/zamboni/stats-min.js:5
+msgid "Reviews Written from {0} to {1}"
+msgstr "Написани рецензии от {0} до {1}"
+
+#. L10n: {0} is an integer.
+#: static/js/impala/stats/csv_keys.js:231 static/js/zamboni/stats-all.js:15512 static/js/zamboni/stats-min.js:5
+msgid "User Signups, last {0} days"
+msgstr "Регистрирани потребители последните {0} дни"
+
+#. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
+#: static/js/impala/stats/csv_keys.js:233 static/js/zamboni/stats-all.js:15514 static/js/zamboni/stats-min.js:5
+msgid "User Signups from {0} to {1}"
+msgstr "Регистрирани потребители от {0} до {1}"
+
+#. L10n: {0} is an integer.
+#: static/js/impala/stats/csv_keys.js:237 static/js/zamboni/stats-all.js:15518 static/js/zamboni/stats-min.js:5
+msgid "Collections Created, last {0} days"
+msgstr "Създадени колекции последните {0} дни"
+
+#. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
+#: static/js/impala/stats/csv_keys.js:239 static/js/zamboni/stats-all.js:15520 static/js/zamboni/stats-min.js:5
+msgid "Collections Created from {0} to {1}"
+msgstr "Колекции, създадени от {0} до {1}"
+
+#. L10n: {0} is an integer.
+#: static/js/impala/stats/csv_keys.js:243 static/js/zamboni/stats-all.js:15524 static/js/zamboni/stats-min.js:5
+msgid "Subscribers, last {0} days"
+msgstr "Абонати последните {0} дни"
+
+#. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
+#: static/js/impala/stats/csv_keys.js:245 static/js/zamboni/stats-all.js:15526 static/js/zamboni/stats-min.js:5
+msgid "Subscribers from {0} to {1}"
+msgstr "Абонати от {0} до {1}"
+
+#. L10n: {0} is an integer.
+#: static/js/impala/stats/csv_keys.js:249 static/js/zamboni/stats-all.js:15530 static/js/zamboni/stats-min.js:5
+msgid "Ratings, last {0} days"
+msgstr "Оценки последните {0} дни"
+
+#. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
+#: static/js/impala/stats/csv_keys.js:251 static/js/zamboni/stats-all.js:15532 static/js/zamboni/stats-min.js:5
+msgid "Ratings from {0} to {1}"
+msgstr "Оценки от {0} до {1}"
+
+#. L10n: {0} is an integer.
+#: static/js/impala/stats/csv_keys.js:255 static/js/zamboni/stats-all.js:15536 static/js/zamboni/stats-min.js:5
+msgid "Sales, last {0} days"
+msgstr "Продажби в последните {0} дни"
+
+#. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
+#: static/js/impala/stats/csv_keys.js:257 static/js/zamboni/stats-all.js:15538 static/js/zamboni/stats-min.js:5
+msgid "Sales from {0} to {1}"
+msgstr "Продажби от {0} до {1}"
+
+#. L10n: {0} is an integer.
+#: static/js/impala/stats/csv_keys.js:261 static/js/zamboni/stats-all.js:15542 static/js/zamboni/stats-min.js:5
+msgid "Installs, last {0} days"
+msgstr "Инсталации последните {0} дни"
+
+#. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
+#: static/js/impala/stats/csv_keys.js:263 static/js/zamboni/stats-all.js:15544 static/js/zamboni/stats-min.js:5
+msgid "Installs from {0} to {1}"
+msgstr "Инсталации от {0} до {1}"
+
+#. L10n: {0} and {1} are integers.
+#: static/js/impala/stats/csv_keys.js:269 static/js/zamboni/stats-all.js:15550 static/js/zamboni/stats-min.js:5
+msgid "<b>{0}</b> in last {1} days"
+msgstr "<b>{0}</b> в последните {1} дни"
+
+#. L10n: {0} is an integer and {1} and {2} are dates in YYYY-MM-DD format.
+#: static/js/impala/stats/csv_keys.js:271 static/js/impala/stats/csv_keys.js:277 static/js/zamboni/stats-all.js:15552 static/js/zamboni/stats-all.js:15558 static/js/zamboni/stats-min.js:5
+msgid "<b>{0}</b> from {1} to {2}"
+msgstr "<b>{0}</b> от {1} до {2}"
+
+#. L10n: {0} and {1} are integers.
+#: static/js/impala/stats/csv_keys.js:275 static/js/zamboni/stats-all.js:15556 static/js/zamboni/stats-min.js:5
+msgid "<b>{0}</b> average in last {1} days"
+msgstr "<b>{0}</b> средно в последните {1} дни"
+
+#: static/js/impala/stats/overview.js:19 static/js/zamboni/stats-all.js:16469 static/js/zamboni/stats-min.js:5
+msgid "No data available."
+msgstr "Няма достъпни данни."
+
+#: static/js/impala/stats/table.js:74 static/js/zamboni/stats-all.js:17209 static/js/zamboni/stats-min.js:5
+msgid "Date"
+msgstr "Дата"
+
+#: static/js/impala/stats/topchart.js:96 static/js/zamboni/stats-all.js:16600 static/js/zamboni/stats-min.js:5
+msgid "Other"
+msgstr "Друго"
+
+#: static/js/zamboni/admin-all.js:180 static/js/zamboni/admin-min.js:1 static/js/zamboni/admin_validation.js:24 static/js/zamboni/devhub-all.js:2408 static/js/zamboni/devhub-min.js:2
+#: static/js/zamboni/devhub.js:1229 static/js/zamboni/editors-all.js:15576 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:295
+msgid "Select an application first"
+msgstr "Първо изберете приложение"
+
+#: static/js/zamboni/admin-all.js:207 static/js/zamboni/admin-min.js:1 static/js/zamboni/admin_validation.js:51
+msgid "Set {0} add-on to a max version of {1} and email the author."
+msgid_plural "Set {0} add-ons to a max version of {1} and email the authors."
+msgstr[0] "Настрой добавка {0} на максимална версия от {1} и пишете на автора."
+msgstr[1] "Настрой добавка {0} на максимална версия от {1} и пишете на авторите."
+
+#: static/js/zamboni/admin-all.js:210 static/js/zamboni/admin-min.js:1 static/js/zamboni/admin_validation.js:54
+msgid "Email author of {2} add-on which failed validation."
+msgid_plural "Email authors of {2} add-ons which failed validation."
+msgstr[0] ""
+msgstr[1] ""
+
+#: static/js/zamboni/devhub-all.js:1289 static/js/zamboni/devhub-min.js:1 static/js/zamboni/devhub.js:110
+msgid "Your browser does not support the video tag"
+msgstr "Браузърът ви не поддържа video тага"
+
+#: static/js/zamboni/devhub-all.js:1550 static/js/zamboni/devhub-min.js:1 static/js/zamboni/devhub.js:371
+msgid "Changes Saved"
+msgstr "Промените са запазени"
+
+#: static/js/zamboni/devhub-all.js:1566 static/js/zamboni/devhub-min.js:1 static/js/zamboni/devhub.js:387
+msgid "Enter a new author's email address"
+msgstr "Въведете е-пощата на новия автор"
+
+#: static/js/zamboni/devhub-all.js:1715 static/js/zamboni/devhub-min.js:1 static/js/zamboni/devhub.js:536
+msgid "There was an error uploading your file."
+msgstr "Стана грешка при качването на файла ви."
+
+#: static/js/zamboni/devhub-all.js:1860 static/js/zamboni/devhub-min.js:1 static/js/zamboni/devhub.js:681
+msgid "{files} file"
+msgid_plural "{files} files"
+msgstr[0] "{files} файл"
+msgstr[1] "{files} файла"
+
+#: static/js/zamboni/devhub-all.js:1863 static/js/zamboni/devhub-min.js:1 static/js/zamboni/devhub.js:684
+msgid "{reviews} user review"
+msgid_plural "{reviews} user reviews"
+msgstr[0] "{reviews} отзив"
+msgstr[1] "{reviews} отзива"
+
+#: static/js/zamboni/devhub-all.js:1975 static/js/zamboni/devhub-min.js:2 static/js/zamboni/devhub.js:796
+msgid "Learn more"
+msgstr "Научи още"
+
+#: static/js/zamboni/devhub-all.js:1979 static/js/zamboni/devhub-min.js:2 static/js/zamboni/devhub.js:800
+msgid "Example"
+msgstr "Пример"
+
+#: static/js/zamboni/devhub-all.js:2309 static/js/zamboni/devhub-min.js:2 static/js/zamboni/devhub.js:1130
+msgid "Image changes being processed"
+msgstr "Обработват се промените по изображението"
+
+#: static/js/zamboni/devhub-all.js:2459 static/js/zamboni/devhub-min.js:2 static/js/zamboni/devhub.js:1280
+msgid "Must be a valid e-mail address."
+msgstr "Трябва да е валиден имейл адрес."
+
+#: static/js/zamboni/devhub-all.js:2613 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:80
 msgid "All tests passed successfully."
 msgstr "Всички тестове преминати успешно."
 
-#: static/js/zamboni/validator.js:83 static/js/zamboni/validator.js:478
+#: static/js/zamboni/devhub-all.js:2616 static/js/zamboni/devhub-all.js:3011 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:83 static/js/zamboni/validator.js:478
 msgid "These tests were not run."
 msgstr "Тези тестове не са пускани."
 
-#: static/js/zamboni/validator.js:131 static/js/zamboni/validator.js:144
+#: static/js/zamboni/devhub-all.js:2664 static/js/zamboni/devhub-all.js:2677 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:131 static/js/zamboni/validator.js:144
 msgid "Tests"
 msgstr "Тестове"
 
-#: static/js/zamboni/validator.js:246 static/js/zamboni/validator.js:575 static/js/zamboni/validator.js:594
+#: static/js/zamboni/devhub-all.js:2779 static/js/zamboni/devhub-all.js:3108 static/js/zamboni/devhub-all.js:3127 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:246
+#: static/js/zamboni/validator.js:575 static/js/zamboni/validator.js:594
 msgid "Error"
 msgstr "Грешка"
 
-#: static/js/zamboni/validator.js:247
+#: static/js/zamboni/devhub-all.js:2780 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:247
 msgid "Warning"
 msgstr "Внимание"
 
-#: static/js/zamboni/validator.js:299
+#: static/js/zamboni/devhub-all.js:2794 static/js/zamboni/devhub-min.js:2 static/js/zamboni/files-all.js:5657 static/js/zamboni/files-min.js:3 static/js/zamboni/files.js:411
+#: static/js/zamboni/validator.js:261
+msgid "Ignore this message in future updates"
+msgstr ""
+
+#: static/js/zamboni/devhub-all.js:2817 static/js/zamboni/devhub-min.js:2 static/js/zamboni/files-all.js:5663 static/js/zamboni/files-min.js:3 static/js/zamboni/files.js:417
+#: static/js/zamboni/validator.js:284
+msgid "Severity for automated signing:"
+msgstr ""
+
+#: static/js/zamboni/devhub-all.js:2832 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:299
 msgid "Suggestions for passing automated signing:"
 msgstr ""
 
-#: static/js/zamboni/validator.js:387
+#: static/js/zamboni/devhub-all.js:2920 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:387
 msgid "Compatibility Tests"
 msgstr "Тестове за съвместимост"
 
-#: static/js/zamboni/validator.js:466
+#: static/js/zamboni/devhub-all.js:2999 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:466
 msgid "Add-on failed validation."
 msgstr "Добавката не премина валидацията."
 
-#: static/js/zamboni/validator.js:468
+#: static/js/zamboni/devhub-all.js:3001 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:468
 msgid "Add-on passed validation."
 msgstr "Добавката премина валидацията."
 
-#: static/js/zamboni/validator.js:481
+#: static/js/zamboni/devhub-all.js:3014 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:481
 msgid "{0} error"
 msgid_plural "{0} errors"
 msgstr[0] "{0} грешка"
 msgstr[1] "{0} грешки"
 
-#: static/js/zamboni/validator.js:483
+#: static/js/zamboni/devhub-all.js:3016 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:483
 msgid "{0} warning"
 msgid_plural "{0} warnings"
 msgstr[0] "{0} предупреждение"
 msgstr[1] "{0} предупреждения"
 
-#: static/js/zamboni/validator.js:485
+#: static/js/zamboni/devhub-all.js:3018 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:485
 msgid "{0} notice"
 msgid_plural "{0} notices"
 msgstr[0] "{0} известие"
 msgstr[1] "{0} известия"
 
-#: static/js/zamboni/validator.js:577
+#: static/js/zamboni/devhub-all.js:3110 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:577
 msgid "Validation task could not complete or completed with errors"
 msgstr "Задачата за валидация не можа да премине или завърши с грешки"
 
-#: static/js/zamboni/validator.js:595
+#: static/js/zamboni/devhub-all.js:3128 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:595
 msgid "Internal server error"
 msgstr "Вътрешна сървърна грешка"
 
-#: static/js/zamboni/mobile/buttons.js:52
+#: static/js/zamboni/devhub_search.js:8
+msgid "No results found."
+msgstr "Няма резултати."
+
+#: static/js/zamboni/editors-all.js:15402 static/js/zamboni/editors-min.js:4 static/js/zamboni/editors.js:121
+msgid "{name} was viewing this page first."
+msgstr "{name} разглеждаше тази страница първо."
+
+#: static/js/zamboni/editors-all.js:15452 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:171
+msgid "Receipt checked by app."
+msgstr "Разписката проверена от приложението."
+
+#: static/js/zamboni/editors-all.js:15454 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:173
+msgid "Receipt was not checked by app."
+msgstr "Разписката не е проверена от приложението."
+
+#: static/js/zamboni/editors-all.js:15525 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:244
+msgid "{name} was viewing this add-on first."
+msgstr "{name} първи гледаше тази добавка."
+
+#: static/js/zamboni/editors-all.js:15536 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:255
+msgid "Loading&hellip;"
+msgstr "Зареждане&hellip;"
+
+#: static/js/zamboni/editors-all.js:15541 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:260
+msgid "Version Notes"
+msgstr "Бележки по версията"
+
+#: static/js/zamboni/editors-all.js:15546 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:265
+msgid "Notes for Reviewers"
+msgstr "Бележки за рецензенти"
+
+#: static/js/zamboni/editors-all.js:15551 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:270
+msgid "No version notes found"
+msgstr "Няма намерени бележки по версията"
+
+#: static/js/zamboni/editors-all.js:15611 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:330
+msgid "Average Reviews"
+msgstr ""
+
+#: static/js/zamboni/editors-all.js:15667 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:386
+msgid "Number of Reviews"
+msgstr ""
+
+#: static/js/zamboni/editors-all.js:15726 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:445
+msgid "Error loading translation"
+msgstr "Грешка при зареждане на превода"
+
+#: static/js/zamboni/editors-all.js:15975 static/js/zamboni/editors-min.js:5 static/js/zamboni/themes_review_templates.js:31
+msgid "Theme"
+msgstr ""
+
+#: static/js/zamboni/editors-all.js:15977 static/js/zamboni/editors-min.js:5 static/js/zamboni/themes_review_templates.js:33
+msgid "Reviewer"
+msgstr ""
+
+#: static/js/zamboni/editors-all.js:15979 static/js/zamboni/editors-min.js:5 static/js/zamboni/themes_review_templates.js:35
+msgid "Status"
+msgstr ""
+
+#: static/js/zamboni/editors-all.js:16196 static/js/zamboni/editors-min.js:5 static/js/zamboni/themes_review.js:176
+msgid "Requested Info"
+msgstr "Изискана информация"
+
+#: static/js/zamboni/editors-all.js:16197 static/js/zamboni/editors-min.js:5 static/js/zamboni/themes_review.js:177
+msgid "Flagged"
+msgstr "Маркиран"
+
+#: static/js/zamboni/editors-all.js:16198 static/js/zamboni/editors-min.js:5 static/js/zamboni/themes_review.js:178
+msgid "Duplicate"
+msgstr "Дубликат"
+
+#: static/js/zamboni/editors-all.js:16199 static/js/zamboni/editors-min.js:5 static/js/zamboni/themes_review.js:179
+msgid "Rejected"
+msgstr "Отказан"
+
+#: static/js/zamboni/editors-all.js:16200 static/js/zamboni/editors-min.js:5 static/js/zamboni/themes_review.js:180
+msgid "Approved"
+msgstr "Одобрен"
+
+#: static/js/zamboni/editors-all.js:16444 static/js/zamboni/editors-min.js:5 static/js/zamboni/themes_review.js:424
+msgid "No results found"
+msgstr ""
+
+#: static/js/zamboni/mobile-all.js:15186 static/js/zamboni/mobile/buttons.js:52
 msgid "Not Updated for {0} {1}"
 msgstr "Не е актуализирано за {0} {1}"
 
-#: static/js/zamboni/mobile/buttons.js:53
+#: static/js/zamboni/mobile-all.js:15187 static/js/zamboni/mobile/buttons.js:53
 msgid "Requires Newer Version of {0}"
 msgstr "Изисква по-нова версия на {0}"
 
-#: static/js/zamboni/mobile/buttons.js:54
+#: static/js/zamboni/mobile-all.js:15188 static/js/zamboni/mobile/buttons.js:54
 msgid "Unreviewed"
 msgstr "Непрегледано"
 
-#: static/js/zamboni/mobile/buttons.js:55
+#: static/js/zamboni/mobile-all.js:15189 static/js/zamboni/mobile/buttons.js:55
 msgid "Experimental <span>(Learn More)</span>"
 msgstr "Експериментална <span>(Научи още)</span>"
 
-#: static/js/zamboni/mobile/buttons.js:56 static/js/zamboni/mobile/buttons.js:57
+#: static/js/zamboni/mobile-all.js:15190 static/js/zamboni/mobile-all.js:15191 static/js/zamboni/mobile/buttons.js:56 static/js/zamboni/mobile/buttons.js:57
 msgid "Not Available for {0}"
 msgstr "Не е достъпно за {0}"
 
-#: static/js/zamboni/mobile/buttons.js:58
+#: static/js/zamboni/mobile-all.js:15192 static/js/zamboni/mobile/buttons.js:58
 msgid "Experimental"
 msgstr "Експериментална"
 
-#: static/js/zamboni/mobile/buttons.js:59
+#: static/js/zamboni/mobile-all.js:15193 static/js/zamboni/mobile/buttons.js:59
 msgid "Themes Require Newer Version of {0}"
 msgstr "Темите изискват нова версия на {0}"
 
-#: static/js/zamboni/mobile/buttons.js:60
+#: static/js/zamboni/mobile-all.js:15194 static/js/zamboni/mobile/buttons.js:60
 msgid "Themes Require {0}"
 msgstr "Темите изискват {0}"
 
-#: static/js/zamboni/mobile/buttons.js:105
+#: static/js/zamboni/mobile-all.js:15239 static/js/zamboni/mobile/buttons.js:105
 msgid "Installing..."
 msgstr "Инсталиране..."
 
-#: static/js/zamboni/mobile/buttons.js:125
+#: static/js/zamboni/mobile-all.js:15259 static/js/zamboni/mobile/buttons.js:125
 msgid "This add-on has been preliminarily reviewed by Mozilla."
 msgstr "Тази добавка е предварително прегледана от Mozilla."
 
-#: static/js/zamboni/mobile/buttons.js:250
+#: static/js/zamboni/mobile-all.js:15384 static/js/zamboni/mobile/buttons.js:250
 msgid "Keep it"
 msgstr "Запази го"
 
-#: static/js/zamboni/mobile/general.js:344
+#: static/js/zamboni/mobile-all.js:16049 static/js/zamboni/mobile-min.js:6 static/js/zamboni/mobile/general.js:344
 msgid "You're trying it on!"
 msgstr "В момента я пробвате!"
 
-#: static/js/zamboni/mobile/general.js:356
+#: static/js/zamboni/mobile-all.js:16061 static/js/zamboni/mobile-min.js:6 static/js/zamboni/mobile/general.js:356
 msgid "Added to Firefox"
 msgstr "Добавено към Firefox"
-

--- a/locale/bn_BD/LC_MESSAGES/django.po
+++ b/locale/bn_BD/LC_MESSAGES/django.po
@@ -2,70 +2,71 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2016-02-24 21:23+0000\n"
+"POT-Creation-Date: 2016-04-18 15:47+0000\n"
 "PO-Revision-Date: 2014-08-19 04:41+0000\n"
 "Last-Translator: Riyad <riyadrir@yahoo.com>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
+"Language: \n"
 "MIME-Version: 1.0\n"
-"Content-Type: text/plain; charset=utf-8\n"
+"Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Generated-By: Babel 2.2.0\n"
 
-#: src/olympia/accounts/views.py:52
+#: src/olympia/accounts/views.py:54
 msgid "Your log in attempt could not be parsed. Please try again."
 msgstr ""
 
-#: src/olympia/accounts/views.py:54
+#: src/olympia/accounts/views.py:56
 msgid "Your Firefox Account could not be found. Please try again."
 msgstr ""
 
-#: src/olympia/accounts/views.py:55
+#: src/olympia/accounts/views.py:57
 msgid "You could not be logged in. Please try again."
 msgstr ""
 
-#: src/olympia/accounts/views.py:57
+#: src/olympia/accounts/views.py:59
 msgid "Your account has already been migrated to Firefox Accounts."
 msgstr ""
 
-#: src/olympia/accounts/views.py:59
+#: src/olympia/accounts/views.py:61
 msgid "Your Firefox Account already exists on this site."
 msgstr ""
 
-#: src/olympia/accounts/views.py:108
+#: src/olympia/accounts/views.py:110
 msgid "Great job!"
 msgstr ""
 
-#: src/olympia/accounts/views.py:109
+#: src/olympia/accounts/views.py:111
 msgid "You can now log in to Add-ons with your Firefox Account."
 msgstr ""
 
-#: src/olympia/accounts/views.py:121
+#: src/olympia/accounts/views.py:123
 msgid "Need help?"
 msgstr ""
 
-#: src/olympia/addons/buttons.py:180
+#: src/olympia/addons/buttons.py:177
 msgid "Download Now"
 msgstr "ডাউনলোড করুন"
 
-#: src/olympia/addons/buttons.py:182
+#: src/olympia/addons/buttons.py:179
 msgid "Download"
 msgstr "ডাউনলোড"
 
 #. L10n: please keep &nbsp; in the string so &rarr; does not wrap.
-#: src/olympia/addons/buttons.py:186
+#: src/olympia/addons/buttons.py:183
 msgid "Continue to Download&nbsp;&rarr;"
 msgstr "ডাউনলোড বহাল রাখুন"
 
 # ডেলটা, selected হলো নির্বাচিত।
-#: src/olympia/addons/buttons.py:202 src/olympia/addons/helpers.py:35 src/olympia/addons/views.py:319 src/olympia/addons/templates/addons/impala/details.html:114
+#: src/olympia/addons/buttons.py:199 src/olympia/addons/helpers.py:35 src/olympia/addons/views.py:333 src/olympia/addons/templates/addons/impala/details.html:111
 #: src/olympia/addons/templates/addons/impala/listing/items.html:17 src/olympia/addons/templates/addons/mobile/home.html:40 src/olympia/amo/templates/amo/side_nav.html:6
-#: src/olympia/amo/templates/amo/side_nav.html:10 src/olympia/amo/templates/amo/site_nav.html:2 src/olympia/amo/templates/amo/site_nav.html:55 src/olympia/bandwagon/views.py:95
-#: src/olympia/browse/views.py:54 src/olympia/browse/views.py:68 src/olympia/browse/views.py:235 src/olympia/browse/templates/browse/impala/category_landing.html:22
+#: src/olympia/amo/templates/amo/side_nav.html:10 src/olympia/amo/templates/amo/site_nav.html:2 src/olympia/amo/templates/amo/site_nav.html:53 src/olympia/bandwagon/views.py:95
+#: src/olympia/browse/views.py:54 src/olympia/browse/views.py:68 src/olympia/browse/views.py:202 src/olympia/browse/templates/browse/impala/category_landing.html:22
 #: src/olympia/browse/templates/browse/personas/mobile/category_landing.html:26
 msgid "Featured"
 msgstr "বৈশিষ্ট্যপূর্ণ"
 
-#: src/olympia/addons/buttons.py:221
+#: src/olympia/addons/buttons.py:218
 msgid "Add to {0}"
 msgstr "{0} তে যুক্ত করুন"
 
@@ -113,39 +114,39 @@ msgid_plural "All tags must be at least {0} characters."
 msgstr[0] "সকল ট্যাগ কমপক্ষে {0} অক্ষরের হতে হবে।"
 msgstr[1] "সকল ট্যাগ কমপক্ষে {0} অক্ষরের হতে হবে।"
 
-#: src/olympia/addons/forms.py:234
+#: src/olympia/addons/forms.py:238
 msgid "Categories cannot be changed while your add-on is featured for this application."
 msgstr "যেহেতু আপনার অ্যাড-অন এই অ্যাপলিকেশনের জন্য নির্বাচিত হয়েছে তাই বিষয়শ্রেণী পরিবর্তন করা যাবে না।"
 
 #. L10n: {0} is the number of categories.
-#: src/olympia/addons/forms.py:238
+#: src/olympia/addons/forms.py:242
 msgid "You can have only {0} category."
 msgid_plural "You can have only {0} categories."
 msgstr[0] "আপনার কেবলমাত্র {0} টি বিষয়শ্রেণী রয়েছে।"
 msgstr[1] "আপনার কেবলমাত্র {0} টি বিষয়শ্রেণী রয়েছে।"
 
-#: src/olympia/addons/forms.py:246
+#: src/olympia/addons/forms.py:250
 msgid "The miscellaneous category cannot be combined with additional categories."
 msgstr "বিবিধ বিষয়শ্রেণী বাড়তি বিষয়শ্রেণীর সাথে মেশানো যাবে না।"
 
-#: src/olympia/addons/forms.py:369
+#: src/olympia/addons/forms.py:374
 #, python-format
 msgid "Before changing your default locale you must have a name, summary, and description in that locale. You are missing %s."
 msgstr "পূর্বনির্ধারিত লোকেল পরিবর্তন করার পূর্বে আপনার অবশ্যই ঐ লোকেলে একটি নাম, সারসংক্ষেপ ও বিবরণ থাকতে হবে। আপনার %s বাদ পরেছে।"
 
-#: src/olympia/addons/forms.py:484 src/olympia/addons/forms.py:575
+#: src/olympia/addons/forms.py:455 src/olympia/addons/forms.py:546
 msgid "A license must be selected."
 msgstr "একটি লাইসেন্স অবশ্যই নির্বাচন করতে হবে।"
 
-#: src/olympia/addons/forms.py:556
+#: src/olympia/addons/forms.py:527
 msgid "Give Your Theme a Name."
 msgstr "আপনার থিমের একটি নাম দিন।"
 
-#: src/olympia/addons/forms.py:562 src/olympia/devhub/templates/devhub/personas/submit.html:53
+#: src/olympia/addons/forms.py:533 src/olympia/devhub/templates/devhub/personas/submit.html:53
 msgid "Describe your Theme."
 msgstr "আপনার থিমটির বর্ণনা দিন।"
 
-#: src/olympia/addons/forms.py:704
+#: src/olympia/addons/forms.py:675
 msgid "Enter a new author's email address"
 msgstr "একজন নতুন সম্পাদকের ইমেল ঠিকানা প্রবেশ করান"
 
@@ -153,37 +154,37 @@ msgstr "একজন নতুন সম্পাদকের ইমেল ঠ�
 msgid "Not Reviewed"
 msgstr "পর্যালোচিত হয় নি"
 
-#: src/olympia/addons/models.py:301
+#: src/olympia/addons/models.py:298
 msgid "Users have the option of contributing more or less than this amount."
 msgstr "ব্যবহারকারীদের এর থেকে বেশি বা কম অবদান রাখার সুযোগ রয়েছে।"
 
-#: src/olympia/addons/models.py:309
-msgid "Users will always be asked in the Add-ons Manager (Firefox 4 and above)"
-msgstr "ব্যবহারকারীরা অ্যাড-অনস ম্যানেজারে সর্বদা জিজ্ঞাসিত হবে (ফায়ারফক্স ৪ ও অধিকের ক্ষেত্রে)"
+#: src/olympia/addons/models.py:306
+msgid "Users will always be asked in the Add-ons Manager (Firefox 4 and above). Only applies to desktop."
+msgstr ""
 
-#: src/olympia/addons/models.py:1804 src/olympia/addons/templates/addons/details_box.html:55 src/olympia/devhub/templates/devhub/index.html:92
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:102
+#: src/olympia/addons/models.py:1802 src/olympia/addons/templates/addons/details_box.html:55 src/olympia/devhub/templates/devhub/index.html:92
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:89
 msgid "Listed"
 msgstr "তালিকাভুক্ত"
 
-#: src/olympia/addons/views.py:320 src/olympia/browse/templates/browse/personas/mobile/category_landing.html:27
+#: src/olympia/addons/views.py:334 src/olympia/browse/templates/browse/personas/mobile/category_landing.html:27
 msgid "Popular"
 msgstr "জনপ্রিয়"
 
-#: src/olympia/addons/views.py:321 src/olympia/browse/views.py:238 src/olympia/browse/views.py:280 src/olympia/browse/views.py:482
+#: src/olympia/addons/views.py:335 src/olympia/browse/views.py:205 src/olympia/browse/views.py:247 src/olympia/browse/views.py:449
 msgid "Recently Added"
 msgstr "সম্প্রতি যোগ করা হয়েছে"
 
-#: src/olympia/addons/views.py:322 src/olympia/bandwagon/views.py:99 src/olympia/browse/views.py:60 src/olympia/browse/views.py:71 src/olympia/search/forms.py:16 src/olympia/search/forms.py:91
+#: src/olympia/addons/views.py:336 src/olympia/bandwagon/views.py:99 src/olympia/browse/views.py:60 src/olympia/browse/views.py:71 src/olympia/search/forms.py:16 src/olympia/search/forms.py:91
 msgid "Recently Updated"
 msgstr "সম্প্রতি হাল নাগাদ করা হয়েছে"
 
 #. l10n: {0} is the addon name
-#: src/olympia/addons/views.py:520
+#: src/olympia/addons/views.py:534
 msgid "Contribution for {0}"
 msgstr "{0} এর জন্য অনুদান"
 
-#: src/olympia/addons/views.py:613
+#: src/olympia/addons/views.py:627
 msgid "Abuse reported."
 msgstr "অপব্যবহার রিপোর্ট করা হয়েছে।"
 
@@ -250,9 +251,9 @@ msgstr "অবদান রাখুন"
 #: src/olympia/devhub/templates/devhub/addons/ajax_compat_update.html:36 src/olympia/devhub/templates/devhub/addons/profile.html:44 src/olympia/devhub/templates/devhub/addons/edit/admin.html:101
 #: src/olympia/devhub/templates/devhub/addons/edit/basic.html:152 src/olympia/devhub/templates/devhub/addons/edit/details.html:85 src/olympia/devhub/templates/devhub/addons/edit/support.html:67
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:166 src/olympia/devhub/templates/devhub/addons/forms_shared/media.html:149
-#: src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:44 src/olympia/devhub/templates/devhub/versions/add_file_modal.html:78 src/olympia/devhub/templates/devhub/versions/edit.html:139
-#: src/olympia/devhub/templates/devhub/versions/list.html:242 src/olympia/devhub/templates/devhub/versions/list.html:276 src/olympia/devhub/templates/devhub/versions/list.html:317
-#: src/olympia/devhub/templates/devhub/versions/list.html:351 src/olympia/reviews/templates/reviews/edit_review.html:16 src/olympia/translations/templates/translations/trans-menu.html:50
+#: src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:43 src/olympia/devhub/templates/devhub/versions/add_file_modal.html:58 src/olympia/devhub/templates/devhub/versions/edit.html:139
+#: src/olympia/devhub/templates/devhub/versions/list.html:239 src/olympia/devhub/templates/devhub/versions/list.html:281 src/olympia/devhub/templates/devhub/versions/list.html:315
+#: src/olympia/devhub/templates/devhub/versions/list.html:349 src/olympia/reviews/templates/reviews/edit_review.html:16 src/olympia/translations/templates/translations/trans-menu.html:50
 #: src/olympia/translations/templates/translations/trans-menu.html:62
 msgid "or"
 msgstr "অথবা"
@@ -364,7 +365,7 @@ msgid "Add-on Information for {0}"
 msgstr "{0} এর জন্য অ্যাড-অনের তথ্য"
 
 #: src/olympia/addons/templates/addons/details_box.html:30 src/olympia/addons/templates/addons/persona_detail_table.html:3 src/olympia/addons/templates/addons/mobile/details.html:63
-#: src/olympia/addons/templates/addons/mobile/persona_detail_table.html:7 src/olympia/browse/views.py:459 src/olympia/devhub/views.py:75
+#: src/olympia/addons/templates/addons/mobile/persona_detail_table.html:7 src/olympia/browse/views.py:426 src/olympia/devhub/views.py:73
 msgid "Updated"
 msgstr "হালনাগাদকৃত"
 
@@ -383,11 +384,11 @@ msgstr "কাজ করবে"
 msgid "Visibility"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/details_box.html:57 src/olympia/devhub/templates/devhub/index.html:94 src/olympia/devhub/templates/devhub/includes/addon_details.html:104
+#: src/olympia/addons/templates/addons/details_box.html:57 src/olympia/devhub/templates/devhub/index.html:94 src/olympia/devhub/templates/devhub/includes/addon_details.html:91
 msgid "Hidden"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/details_box.html:59 src/olympia/devhub/templates/devhub/index.html:96 src/olympia/devhub/templates/devhub/includes/addon_details.html:106
+#: src/olympia/addons/templates/addons/details_box.html:59 src/olympia/devhub/templates/devhub/index.html:96 src/olympia/devhub/templates/devhub/includes/addon_details.html:93
 msgid "Unlisted"
 msgstr ""
 
@@ -395,13 +396,13 @@ msgstr ""
 msgid "Required Add-ons"
 msgstr "প্রয়োজনীয় অ্যাড-অন"
 
-#: src/olympia/addons/templates/addons/details_box.html:81 src/olympia/addons/templates/addons/persona_detail_table.html:15 src/olympia/browse/views.py:462 src/olympia/devhub/views.py:78
-#: src/olympia/devhub/views.py:85 src/olympia/discovery/templates/discovery/addons/detail.html:57 src/olympia/reviews/forms.py:62 src/olympia/reviews/templates/reviews/add.html:57
+#: src/olympia/addons/templates/addons/details_box.html:81 src/olympia/addons/templates/addons/persona_detail_table.html:15 src/olympia/browse/views.py:429 src/olympia/devhub/views.py:76
+#: src/olympia/devhub/views.py:83 src/olympia/discovery/templates/discovery/addons/detail.html:57 src/olympia/reviews/forms.py:62 src/olympia/reviews/templates/reviews/add.html:57
 #: src/olympia/reviews/templates/reviews/mobile/review_list.html:18
 msgid "Rating"
 msgstr "রেটিং"
 
-#: src/olympia/addons/templates/addons/details_box.html:85 src/olympia/browse/views.py:461 src/olympia/devhub/views.py:77 src/olympia/devhub/views.py:84
+#: src/olympia/addons/templates/addons/details_box.html:85 src/olympia/browse/views.py:428 src/olympia/devhub/views.py:75 src/olympia/devhub/views.py:82
 #: src/olympia/stats/templates/stats/addon_report_menu.html:8 src/olympia/stats/templates/stats/collection_report_menu.html:18
 msgid "Downloads"
 msgstr "ডাউনলোডসমূহ"
@@ -421,7 +422,7 @@ msgstr "অপব্যবহারের রিপোর্ট"
 
 #. The Privacy Policy for this add-on.
 #: src/olympia/addons/templates/addons/details_box.html:121 src/olympia/addons/templates/addons/privacy.html:19 src/olympia/addons/templates/addons/privacy.html:23
-#: src/olympia/addons/templates/addons/impala/button.html:43 src/olympia/addons/templates/addons/impala/details.html:307 src/olympia/devhub/templates/devhub/includes/policy_form.html:20
+#: src/olympia/addons/templates/addons/impala/button.html:43 src/olympia/addons/templates/addons/impala/details.html:312 src/olympia/devhub/templates/devhub/includes/policy_form.html:23
 #: src/olympia/templates/mobile/base_addons.html:87
 msgid "Privacy Policy"
 msgstr "গোপনীয়তার নীতি"
@@ -446,7 +447,7 @@ msgstr "ইমেজ গ্যালারি"
 msgid "Developer Comments"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/details_box.html:199 src/olympia/addons/templates/addons/impala/details.html:259
+#: src/olympia/addons/templates/addons/details_box.html:199 src/olympia/addons/templates/addons/impala/details.html:264
 msgid "Development Channel"
 msgstr "সম্প্রসারনের চ্যানেল"
 
@@ -468,13 +469,13 @@ msgstr ""
 "<strong>সতর্কতা:</strong> এই অ্যাড-অনটির ডেভলপমেট মজিলা দ্বারা পর্যালোচনা করা হয়নি। যখনই আপনি একটি ডেভলপমেন্ট সংস্করণ ইন্সটল করবেন, তার পর থেকেই আপনি ডেভলপার হতে অ্যাড অনটির ডেভলপমেন্ট হালনাগাদ পেতে থাকবেন। "
 "ডেভলপমেন্ট হালনাগাদ বন্ধ করতে, উপরের লিংক হতে পূর্বনির্ধারিত সংস্করণটি ইন্সটল করুন।"
 
-#: src/olympia/addons/templates/addons/details_box.html:220 src/olympia/addons/templates/addons/impala/details.html:278
+#: src/olympia/addons/templates/addons/details_box.html:220 src/olympia/addons/templates/addons/impala/details.html:283
 msgid "Version {0}:"
 msgstr "সংস্করণ {0}:"
 
 #: src/olympia/addons/templates/addons/details_box.html:234
-msgid "Nothing to see here! The developer did not include any details."
-msgstr "এখানে কিছুই দেখা যাচ্ছে না! ডেভেলপার বিস্তারিত কোন কিছুই যুক্ত করেনি।"
+msgid "Nothing to see here!  The developer did not include any details."
+msgstr ""
 
 #: src/olympia/addons/templates/addons/details_box.html:251 src/olympia/devhub/templates/devhub/versions/edit.html:73 src/olympia/editors/templates/editors/review.html:98
 msgid "Version Notes"
@@ -487,7 +488,7 @@ msgid "End-User License Agreement for {0}"
 msgstr "{0} এর এন্ড ইউজার লাইসেন্স এগ্রিমেন্ট"
 
 #: src/olympia/addons/templates/addons/eula.html:17 src/olympia/addons/templates/addons/eula.html:21 src/olympia/addons/templates/addons/impala/button.html:48
-#: src/olympia/addons/templates/addons/impala/details.html:316 src/olympia/devhub/templates/devhub/includes/policy_form.html:3 src/olympia/discovery/templates/discovery/addons/eula.html:11
+#: src/olympia/addons/templates/addons/impala/details.html:321 src/olympia/devhub/templates/devhub/includes/policy_form.html:3 src/olympia/discovery/templates/discovery/addons/eula.html:11
 msgid "End-User License Agreement"
 msgstr "এন্ড ইউজার লাইসেন্স এগ্রিমেন্ট"
 
@@ -504,7 +505,7 @@ msgstr "{0} তে ফিরে যান…"
 msgid "Add-ons for {0}"
 msgstr "{0} জন্য অ্যাড-অন"
 
-#: src/olympia/addons/templates/addons/home.html:10 src/olympia/addons/templates/addons/home.html:51 src/olympia/browse/templates/browse/impala/base_listing.html:11
+#: src/olympia/addons/templates/addons/home.html:10 src/olympia/addons/templates/addons/home.html:53 src/olympia/browse/templates/browse/impala/base_listing.html:11
 msgid "Featured Extensions"
 msgstr "নির্বাচিত এক্সটেনশনসমূহ"
 
@@ -512,29 +513,29 @@ msgstr "নির্বাচিত এক্সটেনশনসমূহ"
 msgid "Popular Extensions"
 msgstr "জনপ্রিয় এক্সটেনশনসমূহ"
 
-#: src/olympia/addons/templates/addons/home.html:42 src/olympia/amo/templates/amo/side_nav.html:3 src/olympia/amo/templates/amo/side_nav.html:11 src/olympia/amo/templates/amo/site_nav.html:3
-#: src/olympia/amo/templates/amo/site_nav.html:25 src/olympia/browse/views.py:236 src/olympia/browse/views.py:281 src/olympia/browse/views.py:481
+#: src/olympia/addons/templates/addons/home.html:44 src/olympia/amo/templates/amo/side_nav.html:3 src/olympia/amo/templates/amo/side_nav.html:11 src/olympia/amo/templates/amo/site_nav.html:3
+#: src/olympia/amo/templates/amo/site_nav.html:25 src/olympia/browse/views.py:203 src/olympia/browse/views.py:248 src/olympia/browse/views.py:448
 msgid "Most Popular"
 msgstr "সবথেকে জনপ্রিয়"
 
-#: src/olympia/addons/templates/addons/home.html:43
+#: src/olympia/addons/templates/addons/home.html:45
 msgid "All »"
 msgstr "সকল »"
 
-#: src/olympia/addons/templates/addons/home.html:52 src/olympia/addons/templates/addons/home.html:61 src/olympia/addons/templates/addons/home.html:70 src/olympia/addons/templates/addons/home.html:78
+#: src/olympia/addons/templates/addons/home.html:54 src/olympia/addons/templates/addons/home.html:63 src/olympia/addons/templates/addons/home.html:72 src/olympia/addons/templates/addons/home.html:80
 #: src/olympia/browse/templates/browse/impala/category_landing.html:36
 msgid "See all »"
 msgstr "সবগুলো দেখুন »"
 
-#: src/olympia/addons/templates/addons/home.html:60
+#: src/olympia/addons/templates/addons/home.html:62
 msgid "Up &amp; Coming Extensions"
 msgstr "আসন্ন এক্সটেনশন সমূহ"
 
-#: src/olympia/addons/templates/addons/home.html:69 src/olympia/browse/templates/browse/personas/category_landing.html:61 src/olympia/discovery/templates/discovery/pane.html:74
+#: src/olympia/addons/templates/addons/home.html:71 src/olympia/browse/templates/browse/personas/category_landing.html:61 src/olympia/discovery/templates/discovery/pane.html:74
 msgid "Featured Themes"
 msgstr "নির্বাচিত থিমসমূহ"
 
-#: src/olympia/addons/templates/addons/home.html:77 src/olympia/bandwagon/templates/bandwagon/impala/collection_listing.html:5
+#: src/olympia/addons/templates/addons/home.html:79 src/olympia/bandwagon/templates/bandwagon/impala/collection_listing.html:5
 msgid "Featured Collections"
 msgstr "নির্বাচিত সংগ্রহসমূহ"
 
@@ -553,7 +554,7 @@ msgstr "হালনাগাদকৃত {0}"
 
 # যেহেতু এখানে {0} তারিখ বুঝানো হয়েছে...
 #. {0} is a date.
-#: src/olympia/addons/templates/addons/macros.html:10 src/olympia/addons/templates/addons/macros.html:69 src/olympia/addons/templates/addons/persona_preview.html:21
+#: src/olympia/addons/templates/addons/macros.html:10 src/olympia/addons/templates/addons/macros.html:69 src/olympia/addons/templates/addons/persona_preview.html:22
 #: src/olympia/addons/templates/addons/listing/items_mobile.html:44 src/olympia/addons/templates/addons/listing/macros.html:39
 #: src/olympia/bandwagon/templates/bandwagon/collection_listing_items.html:37 src/olympia/bandwagon/templates/bandwagon/impala/collection_listing_items.html:37
 msgid "Added {0}"
@@ -574,15 +575,14 @@ msgstr[0] "%(num)s জন ব্যবহারকারী"
 msgstr[1] "%(num)s জন ব্যবহারকারী"
 
 #. {0} is the number of downloads.
-#: src/olympia/addons/templates/addons/macros.html:53 src/olympia/addons/templates/addons/impala/details.html:61
+#: src/olympia/addons/templates/addons/macros.html:53 src/olympia/addons/templates/addons/impala/details.html:59
 msgid "{0} weekly download"
 msgid_plural "{0} weekly downloads"
 msgstr[0] "সপ্তাহে {0} টি ডাউনলোড"
 msgstr[1] "সপ্তাহে {0} টি ডাউনলোড"
 
 #. {0} is the number of users.
-#: src/olympia/addons/templates/addons/macros.html:61 src/olympia/addons/templates/addons/impala/details.html:54 src/olympia/compat/templates/compat/index.html:71
-#: src/olympia/zadmin/templates/zadmin/compat.html:67
+#: src/olympia/addons/templates/addons/macros.html:61 src/olympia/addons/templates/addons/impala/details.html:52 src/olympia/zadmin/templates/zadmin/compat.html:67
 msgid "{0} user"
 msgid_plural "{0} users"
 msgstr[0] "{0} জন ব্যবহারকারী"
@@ -600,7 +600,7 @@ msgstr "পেমেন্ট সম্পন্ন হয়েছে"
 msgid "Return to the addon."
 msgstr "অ্যাড-অনে ফিরুন।"
 
-#: src/olympia/addons/templates/addons/persona_detail.html:17 src/olympia/addons/templates/addons/impala/details.html:106 src/olympia/addons/templates/addons/mobile/details.html:23
+#: src/olympia/addons/templates/addons/persona_detail.html:17 src/olympia/addons/templates/addons/impala/details.html:103 src/olympia/addons/templates/addons/mobile/details.html:23
 #: src/olympia/addons/templates/addons/mobile/persona_detail.html:21 src/olympia/discovery/templates/discovery/addons/base.html:27 src/olympia/editors/templates/editors/review.html:31
 msgid "by"
 msgstr "দ্বারা"
@@ -644,34 +644,35 @@ msgstr "দৈনিক ব্যবহারকারী"
 msgid "License"
 msgstr "লাইসেন্স"
 
-#: src/olympia/addons/templates/addons/persona_preview.html:12 src/olympia/constants/base.py:48
+#: src/olympia/addons/templates/addons/persona_preview.html:13 src/olympia/constants/base.py:48
 msgid "Awaiting Review"
 msgstr "পর্যালোচনার জন্য অপেক্ষা করছে"
 
-#: src/olympia/addons/templates/addons/persona_preview.html:14 src/olympia/amo/log.py:180 src/olympia/constants/base.py:42 src/olympia/editors/helpers.py:62
+#: src/olympia/addons/templates/addons/persona_preview.html:15 src/olympia/amo/log.py:180 src/olympia/constants/base.py:42 src/olympia/editors/helpers.py:62
 msgid "Rejected"
 msgstr "বাতিলকৃত"
 
-#: src/olympia/addons/templates/addons/persona_preview.html:16 src/olympia/amo/log.py:159
+#: src/olympia/addons/templates/addons/persona_preview.html:17 src/olympia/amo/log.py:159
 msgid "Approved"
 msgstr "অনুমোদিত"
 
 #. {0} is the number of users.
-#: src/olympia/addons/templates/addons/persona_preview.html:26 src/olympia/addons/templates/addons/listing/items_mobile.html:36 src/olympia/addons/templates/addons/listing/macros.html:31
+#: src/olympia/addons/templates/addons/persona_preview.html:27 src/olympia/addons/templates/addons/listing/items_mobile.html:36 src/olympia/addons/templates/addons/listing/macros.html:31
 msgid "<strong>{0}</strong> user"
 msgid_plural "<strong>{0}</strong> users"
 msgstr[0] "<strong>{0}</strong> জন ব্যবহারকারী"
 msgstr[1] "<strong>{0}</strong> জন ব্যবহারকারী"
 
-#: src/olympia/addons/templates/addons/persona_preview.html:40
+#: src/olympia/addons/templates/addons/persona_preview.html:41
 msgid "Hover to Preview"
 msgstr "প্রাকদর্শনের জন্য হোভার করুন"
 
-#: src/olympia/addons/templates/addons/persona_preview.html:46 src/olympia/addons/templates/addons/persona_preview.html:48 src/olympia/reviews/templates/reviews/add.html:15
+#: src/olympia/addons/templates/addons/persona_preview.html:47 src/olympia/addons/templates/addons/persona_preview.html:49 src/olympia/addons/templates/addons/persona_preview.html:97
+#: src/olympia/reviews/templates/reviews/add.html:15
 msgid "Add"
 msgstr "যোগ করুন"
 
-#: src/olympia/addons/templates/addons/persona_preview.html:57 src/olympia/bandwagon/templates/bandwagon/ajax_new.html:16 src/olympia/bandwagon/templates/bandwagon/edit.html:19
+#: src/olympia/addons/templates/addons/persona_preview.html:58 src/olympia/bandwagon/templates/bandwagon/ajax_new.html:16 src/olympia/bandwagon/templates/bandwagon/edit.html:19
 #: src/olympia/bandwagon/templates/bandwagon/includes/addedit.html:19 src/olympia/devhub/templates/devhub/addons/edit/admin.html:13 src/olympia/devhub/templates/devhub/addons/edit/basic.html:10
 #: src/olympia/devhub/templates/devhub/addons/edit/details.html:8 src/olympia/devhub/templates/devhub/addons/edit/media.html:6 src/olympia/devhub/templates/devhub/addons/edit/support.html:8
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:9 src/olympia/devhub/templates/devhub/addons/submit/describe.html:29 src/olympia/editors/templates/editors/review.html:257
@@ -680,21 +681,21 @@ msgstr "সম্পাদনা করুন"
 
 #. For datetime formatting, see the table on
 #. http://docs.python.org/library/datetime.html#strftime-and-strptime-behavior
-#: src/olympia/addons/templates/addons/persona_preview.html:66
+#: src/olympia/addons/templates/addons/persona_preview.html:67
 #, python-format
 msgid "%%Y-%%m-%%d"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/persona_preview.html:67
+#: src/olympia/addons/templates/addons/persona_preview.html:68
 msgid "by {0} on {1}"
 msgstr "{1} তে {0} দ্বারা"
 
-#: src/olympia/addons/templates/addons/persona_preview.html:75 src/olympia/reviews/helpers.py:17 src/olympia/reviews/templates/reviews/review_list.html:63
+#: src/olympia/addons/templates/addons/persona_preview.html:76 src/olympia/reviews/helpers.py:17 src/olympia/reviews/templates/reviews/review_list.html:63
 #: src/olympia/reviews/templates/reviews/reviews_link.html:21 src/olympia/reviews/templates/reviews/impala/reviews_link.html:16
 msgid "Not yet rated"
 msgstr "এখনও রেট করা হয় নি"
 
-#: src/olympia/addons/templates/addons/persona_preview.html:78
+#: src/olympia/addons/templates/addons/persona_preview.html:79
 msgid "<b>{0}</b> users"
 msgstr "<b>{0}</b> জন ব্যবহারকারী"
 
@@ -707,8 +708,8 @@ msgid "Learn more about Firefox"
 msgstr "ফায়ারফক্স সম্পর্কে বিস্তারিত জানুন"
 
 #: src/olympia/addons/templates/addons/popups.html:22
-msgid "or <b><a class=\"installer\" href=\"{url}\">download anyway</a></b>"
-msgstr "অথবা <b><a class=\"installer\" href=\"{url}\">যেকোন ভাবে ডাউনলোড করুন</a></b>"
+msgid "or <b><a class=\"button installer\" href=\"{url}\">download anyway</a></b>"
+msgstr ""
 
 #: src/olympia/addons/templates/addons/popups.html:26
 msgid ""
@@ -801,11 +802,14 @@ msgid "QR code for add-on"
 msgstr "অ্যাড-অনের জন্য QR কোড"
 
 #: src/olympia/addons/templates/addons/qr_code.html:6
-msgid "Want {0} on your mobile Firefox? Scan this QR code to install directly to your phone. (You'll need a QR reader. Search your phone's marketplace if don't have one.)"
-msgstr "{0} আপনার মোবাইলের ফায়ারফক্সে চান? আপনার ফোনে সরাসরি ইন্সটল করতে এই QR কোডটি স্ক্যান করুন। (আপনার একটি QR রিডারের প্রয়োজন হবে। আপনার কাছে না থেকে থাকলে আপনার ফোনের মার্কেটপ্লেসে অনুসন্ধান করুন।)"
+msgid ""
+"Want {0} on your mobile Firefox?  Scan this QR code to install directly\n"
+"  to your phone.  (You'll need a QR reader.  Search your phone's marketplace if\n"
+"  don't have one.)"
+msgstr ""
 
 #: src/olympia/addons/templates/addons/report_abuse.html:6 src/olympia/addons/templates/addons/report_abuse_full.html:10 src/olympia/addons/templates/addons/impala/details-more.html:23
-#: src/olympia/addons/templates/addons/impala/details.html:328
+#: src/olympia/addons/templates/addons/impala/details.html:333
 msgid "Report Abuse"
 msgstr "অপব্যবহার রিপোর্ট করুন"
 
@@ -826,9 +830,9 @@ msgstr "রিপোর্ট পাঠান"
 #: src/olympia/devhub/templates/devhub/addons/ajax_compat_update.html:36 src/olympia/devhub/templates/devhub/addons/profile.html:44 src/olympia/devhub/templates/devhub/addons/edit/admin.html:104
 #: src/olympia/devhub/templates/devhub/addons/edit/basic.html:155 src/olympia/devhub/templates/devhub/addons/edit/details.html:88 src/olympia/devhub/templates/devhub/addons/edit/support.html:70
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:169 src/olympia/devhub/templates/devhub/addons/forms_shared/media.html:152
-#: src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:44 src/olympia/devhub/templates/devhub/personas/edit.html:222 src/olympia/devhub/templates/devhub/versions/add_file_modal.html:79
-#: src/olympia/devhub/templates/devhub/versions/edit.html:140 src/olympia/devhub/templates/devhub/versions/list.html:208 src/olympia/devhub/templates/devhub/versions/list.html:242
-#: src/olympia/devhub/templates/devhub/versions/list.html:276 src/olympia/devhub/templates/devhub/versions/list.html:317 src/olympia/reviews/templates/reviews/edit_review.html:16
+#: src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:43 src/olympia/devhub/templates/devhub/personas/edit.html:222 src/olympia/devhub/templates/devhub/versions/add_file_modal.html:59
+#: src/olympia/devhub/templates/devhub/versions/edit.html:140 src/olympia/devhub/templates/devhub/versions/list.html:208 src/olympia/devhub/templates/devhub/versions/list.html:239
+#: src/olympia/devhub/templates/devhub/versions/list.html:281 src/olympia/devhub/templates/devhub/versions/list.html:315 src/olympia/reviews/templates/reviews/edit_review.html:16
 #: src/olympia/translations/templates/translations/trans-menu.html:50 src/olympia/translations/templates/translations/trans-menu.html:62 src/olympia/zadmin/templates/zadmin/validation.html:105
 msgid "Cancel"
 msgstr "বাতিল"
@@ -874,7 +878,7 @@ msgstr "এই অ্যাড-অনটির জন্য কোথায় স�
 msgid "Review Guidelines"
 msgstr "পর্যালোচনা নির্দেশিকা"
 
-#: src/olympia/addons/templates/addons/review_list_box.html:5 src/olympia/addons/templates/addons/impala/details-more.html:27 src/olympia/editors/helpers.py:921
+#: src/olympia/addons/templates/addons/review_list_box.html:5 src/olympia/addons/templates/addons/impala/details-more.html:27 src/olympia/editors/helpers.py:1001
 #: src/olympia/reviews/templates/reviews/add.html:14 src/olympia/reviews/templates/reviews/reply.html:14 src/olympia/reviews/templates/reviews/review_list.html:19
 #: src/olympia/reviews/templates/reviews/mobile/review_list.html:26
 msgid "Reviews"
@@ -965,103 +969,103 @@ msgid_plural "Other add-ons by these authors"
 msgstr[0] "%(author)s অনান্য এড অনস"
 msgstr[1] "এই অথরস এর অনান্য এড অনস"
 
-#: src/olympia/addons/templates/addons/impala/details.html:41
+#: src/olympia/addons/templates/addons/impala/details.html:39
 #, python-format
 msgid "<span itemprop=\"ratingCount\">%(num)s</span> user review"
 msgid_plural "<span itemprop=\"ratingCount\">%(num)s</span> user reviews"
 msgstr[0] "<span itemprop=\"ratingCount\">%(num)s</span> টি ব্যবহারকারীর পর্যালোচনা"
 msgstr[1] "<span itemprop=\"ratingCount\">%(num)s</span> টি ব্যবহারকারীর পর্যালোচনা"
 
-#: src/olympia/addons/templates/addons/impala/details.html:69
+#: src/olympia/addons/templates/addons/impala/details.html:66
 msgid "View statistics"
 msgstr "পরিসংখ্যান দেখুন"
 
-#: src/olympia/addons/templates/addons/impala/details.html:84
+#: src/olympia/addons/templates/addons/impala/details.html:81
 msgid "Manage"
 msgstr "পরিচালনা"
 
 #. {0} is an add-on name.
-#: src/olympia/addons/templates/addons/impala/details.html:96
+#: src/olympia/addons/templates/addons/impala/details.html:93
 msgid "Icon of {0}"
 msgstr "{0} এর আইকন"
 
-#: src/olympia/addons/templates/addons/impala/details.html:103 src/olympia/addons/templates/addons/impala/listing/items.html:14
+#: src/olympia/addons/templates/addons/impala/details.html:100 src/olympia/addons/templates/addons/impala/listing/items.html:14
 msgid "No Restart"
 msgstr "পুনরায় চালুর প্রয়োজন নেই"
 
-#: src/olympia/addons/templates/addons/impala/details.html:127
+#: src/olympia/addons/templates/addons/impala/details.html:124
 #, fuzzy, python-format
 msgid "Meet the Developer: <a href=\"%(url)s\">%(name)s</a>"
 msgid_plural "<a href=\"%(url)s\">Meet the Developers</a>"
 msgstr[0] "ডেভেলপারের সাথে পরিচিত হোন: <a href=\"%(url)s\">%(name)s</a>"
 msgstr[1] "<a href=\"%(url)s\">ডেভেলপারদের সাথে পরিচিত হোন</a>"
 
-#: src/olympia/addons/templates/addons/impala/details.html:137
+#: src/olympia/addons/templates/addons/impala/details.html:134
 msgid "Learn why {0} was created and find out what's next for this add-on."
 msgstr "কেন {0} তৈরি করা হয়েছে এবং এই অ্যাড-অনটির ভবিষ্যত কি জানুন।"
 
 #. {0} is an index.
-#: src/olympia/addons/templates/addons/impala/details.html:156
+#: src/olympia/addons/templates/addons/impala/details.html:161
 msgid "Add-on screenshot #{0}"
 msgstr "অ্যাড-অন স্ক্রিনশট #{0}"
 
-#: src/olympia/addons/templates/addons/impala/details.html:182
+#: src/olympia/addons/templates/addons/impala/details.html:187
 msgid "Add-on home page"
 msgstr "অ্যাড-অন হোম পেজ"
 
-#: src/olympia/addons/templates/addons/impala/details.html:185
+#: src/olympia/addons/templates/addons/impala/details.html:190
 msgid "Support site"
 msgstr "সহায়ক সাইট"
 
-#: src/olympia/addons/templates/addons/impala/details.html:189
+#: src/olympia/addons/templates/addons/impala/details.html:194
 msgid "Support E-mail"
 msgstr "ই-মেইল সহায়তা"
 
-#: src/olympia/addons/templates/addons/impala/details.html:194 src/olympia/devhub/models.py:378 src/olympia/devhub/templates/devhub/versions/list.html:12
+#: src/olympia/addons/templates/addons/impala/details.html:199 src/olympia/devhub/models.py:378 src/olympia/devhub/templates/devhub/versions/list.html:12
 #: src/olympia/versions/templates/versions/version.html:6 src/olympia/versions/templates/versions/mobile/version.html:6
 msgid "Version {0}"
 msgstr "সংস্করণ {0}"
 
-#: src/olympia/addons/templates/addons/impala/details.html:194
+#: src/olympia/addons/templates/addons/impala/details.html:199
 msgid "Info"
 msgstr "তথ্য"
 
-#: src/olympia/addons/templates/addons/impala/details.html:195 src/olympia/devhub/templates/devhub/includes/addon_details.html:129
+#: src/olympia/addons/templates/addons/impala/details.html:200 src/olympia/devhub/templates/devhub/includes/addon_details.html:116
 msgid "Last Updated:"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/impala/details.html:200
+#: src/olympia/addons/templates/addons/impala/details.html:205
 #, python-format
 msgid "Released under <a target=\"_blank\" href=\"%(url)s\">%(name)s</a>"
 msgstr "<a target=\"_blank\" href=\"%(url)s\">%(name)s</a> এর অধীনে প্রকাশিত"
 
-#: src/olympia/addons/templates/addons/impala/details.html:201 src/olympia/addons/templates/addons/impala/details.html:206 src/olympia/amo/helpers.py:398 src/olympia/devhub/forms.py:142
+#: src/olympia/addons/templates/addons/impala/details.html:206 src/olympia/addons/templates/addons/impala/details.html:211 src/olympia/amo/helpers.py:398 src/olympia/devhub/forms.py:142
 #: src/olympia/devhub/forms.py:173 src/olympia/versions/templates/versions/version.html:40 src/olympia/versions/templates/versions/version.html:45
 msgid "Custom License"
 msgstr "কাস্টম লাইসেন্স"
 
-#: src/olympia/addons/templates/addons/impala/details.html:205
+#: src/olympia/addons/templates/addons/impala/details.html:210
 #, python-format
 msgid "Released under <a href=\"%(url)s\">%(name)s</a>"
 msgstr "<a href=\"%(url)s\">%(name)s</a> এর অধীনে প্রকাশিত"
 
-#: src/olympia/addons/templates/addons/impala/details.html:217
+#: src/olympia/addons/templates/addons/impala/details.html:222
 msgid "About this Add-on"
 msgstr "এই অ্যাড-অন সম্পর্কে"
 
-#: src/olympia/addons/templates/addons/impala/details.html:233
+#: src/olympia/addons/templates/addons/impala/details.html:238
 msgid "Developer’s Comments"
 msgstr "ডেভেলপার’এর মন্তব্যসমূহ"
 
-#: src/olympia/addons/templates/addons/impala/details.html:243
+#: src/olympia/addons/templates/addons/impala/details.html:248
 msgid "Version Information"
 msgstr "সংস্করণের তথ্য"
 
-#: src/olympia/addons/templates/addons/impala/details.html:250
+#: src/olympia/addons/templates/addons/impala/details.html:255
 msgid "See complete version history"
 msgstr "সংস্করণের সম্পূর্ন ইতিহাস দেখুন"
 
-#: src/olympia/addons/templates/addons/impala/details.html:262
+#: src/olympia/addons/templates/addons/impala/details.html:267
 msgid ""
 "The Development Channel lets you test an experimental new version of this add-on before it's released to the general public. Once you install the development version, you will continue to get "
 "updates from this channel. To stop receiving development updates, reinstall the default version from the link above."
@@ -1069,17 +1073,17 @@ msgstr ""
 "ডেভেলপমেন্ট চ্যানেলে আপনাকে এই অ্যাড-অনের একটা নতুন পরীক্ষামূলক ভার্সন সবার জন্য উন্মুক্ত হবার আগে পরীক্ষা করে দেখতে দিবে। ডেভেলপমেন্ট ভার্সন ইনস্টল করার পর আপনি এই চ্যানেল থেকে আপডেট পেতে থাকবেন। ডেভেলপমেন্ট আপডেট "
 "পেতে না চাইলে উপরের লিংক থেকে অ্যাড-অনের ডিফল্ট ভার্সনটি পুনরায় ইনস্টল করে নিন। "
 
-#: src/olympia/addons/templates/addons/impala/details.html:272
+#: src/olympia/addons/templates/addons/impala/details.html:277
 msgid "<strong>Caution:</strong> Development versions of this add-on have not been reviewed by Mozilla."
 msgstr ""
 
-#: src/olympia/addons/templates/addons/impala/details.html:287
+#: src/olympia/addons/templates/addons/impala/details.html:292
 msgid "See complete development channel history"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/impala/details.html:306 src/olympia/addons/templates/addons/impala/details.html:315 src/olympia/addons/templates/addons/impala/details.html:327
+#: src/olympia/addons/templates/addons/impala/details.html:311 src/olympia/addons/templates/addons/impala/details.html:320 src/olympia/addons/templates/addons/impala/details.html:332
 #: src/olympia/addons/templates/addons/impala/review_add_box.html:4 src/olympia/stats/templates/stats/popup.html:2 src/olympia/stats/templates/stats/popup.html:8
-#: src/olympia/stats/templates/stats/stats.html:202 src/olympia/users/templates/users/profile.html:119
+#: src/olympia/stats/templates/stats/stats.html:204 src/olympia/users/templates/users/profile.html:119
 msgid "close"
 msgstr "বন্ধ"
 
@@ -1135,15 +1139,11 @@ msgstr "{addon} এর সোর্স কোড লাইসেন্স"
 msgid "Source Code License"
 msgstr "সোর্স কোড লাইসেন্স"
 
-#: src/olympia/addons/templates/addons/impala/persona_grid.html:16 src/olympia/addons/templates/addons/impala/toplist.html:6
-msgid "{0} users"
-msgstr "{0} জন ব্যবহারকারী"
-
 #: src/olympia/addons/templates/addons/impala/review_list_box.html:19 src/olympia/reviews/templates/reviews/review.html:40
 msgid "permalink"
 msgstr "permalink"
 
-#: src/olympia/addons/templates/addons/impala/review_list_box.html:23 src/olympia/editors/templates/editors/queue.html:98 src/olympia/reviews/templates/reviews/review.html:44
+#: src/olympia/addons/templates/addons/impala/review_list_box.html:23 src/olympia/editors/templates/editors/queue.html:104 src/olympia/reviews/templates/reviews/review.html:44
 msgid "translate"
 msgstr "অনুবাদ"
 
@@ -1162,6 +1162,10 @@ msgstr "অ্যাড-অনটি এখনও পর্যালোচনা
 msgid "Be the first!"
 msgstr "প্রথম পর্যালোচনাকারী হোন!"
 
+#: src/olympia/addons/templates/addons/impala/toplist.html:6
+msgid "{0} users"
+msgstr "{0} জন ব্যবহারকারী"
+
 #: src/olympia/addons/templates/addons/impala/listing/sorter.html:14 src/olympia/devhub/templates/devhub/addons/listing/item_actions.html:49
 msgid "More"
 msgstr "আরও"
@@ -1174,7 +1178,7 @@ msgstr "সংগ্রহে যোগ করুন"
 msgid "My Add-ons"
 msgstr "আমার অ্যাড-অনসমূহ"
 
-#: src/olympia/addons/templates/addons/includes/dashboard_tabs.html:6 src/olympia/amo/context_processors.py:51
+#: src/olympia/addons/templates/addons/includes/dashboard_tabs.html:6 src/olympia/amo/context_processors.py:50
 msgid "My Themes"
 msgstr "আমার থিমসমূহ"
 
@@ -1229,7 +1233,7 @@ msgstr "ব্যবহারকারী"
 msgid "Weekly Downloads"
 msgstr "সাপ্তাহিক ডাউনলোড"
 
-#: src/olympia/addons/templates/addons/mobile/details.html:99 src/olympia/compat/templates/compat/reporter_detail.html:46 src/olympia/devhub/forms.py:787
+#: src/olympia/addons/templates/addons/mobile/details.html:99 src/olympia/compat/templates/compat/reporter_detail.html:46 src/olympia/devhub/forms.py:788
 #: src/olympia/devhub/templates/devhub/versions/list.html:163
 msgid "Version"
 msgstr "সংস্করণ"
@@ -1314,7 +1318,7 @@ msgstr ""
 #: src/olympia/browse/templates/browse/personas/category_landing.html:21 src/olympia/browse/templates/browse/personas/category_landing.html:23
 #: src/olympia/browse/templates/browse/personas/category_landing.html:38 src/olympia/browse/templates/browse/personas/grid.html:7 src/olympia/browse/templates/browse/personas/grid.html:11
 #: src/olympia/browse/templates/browse/personas/mobile/base.html:7 src/olympia/browse/templates/browse/personas/mobile/category_landing.html:19 src/olympia/constants/base.py:180
-#: src/olympia/devhub/templates/devhub/personas/submit.html:13 src/olympia/editors/helpers.py:105 src/olympia/editors/templates/editors/base.html:26
+#: src/olympia/devhub/templates/devhub/personas/submit.html:13 src/olympia/editors/helpers.py:107 src/olympia/editors/templates/editors/base.html:26
 #: src/olympia/editors/templates/editors/performance.html:73 src/olympia/search/templates/search/personas.html:39 src/olympia/templates/menu_links.html:9
 msgid "Themes"
 msgstr "থিম"
@@ -1335,7 +1339,7 @@ msgstr "আরও অ্যাড-অন"
 msgid "Highest Rated"
 msgstr "সর্বচ্চো রেটেড"
 
-#: src/olympia/addons/templates/addons/mobile/home.html:74 src/olympia/amo/templates/amo/side_nav.html:5 src/olympia/amo/templates/amo/site_nav.html:27 src/olympia/amo/templates/amo/site_nav.html:57
+#: src/olympia/addons/templates/addons/mobile/home.html:74 src/olympia/amo/templates/amo/side_nav.html:5 src/olympia/amo/templates/amo/site_nav.html:27 src/olympia/amo/templates/amo/site_nav.html:55
 #: src/olympia/bandwagon/views.py:97 src/olympia/browse/views.py:57 src/olympia/browse/views.py:67 src/olympia/browse/templates/browse/personas/mobile/category_landing.html:65
 #: src/olympia/search/forms.py:15 src/olympia/search/forms.py:87
 msgid "Newest"
@@ -1349,90 +1353,90 @@ msgstr "ব্যবহার করে দেখুন!"
 msgid "Theme Info &raquo;"
 msgstr "থিমের তথ্য &raquo;"
 
-#: src/olympia/amo/context_processors.py:39 src/olympia/devhub/templates/devhub/nav.html:43
+#: src/olympia/amo/context_processors.py:37 src/olympia/devhub/templates/devhub/nav.html:43
 msgid "Tools"
 msgstr "টুলস"
 
-#: src/olympia/amo/context_processors.py:48 src/olympia/discovery/templates/discovery/pane_account.html:8 src/olympia/users/templates/users/includes/navigation.html:2
+#: src/olympia/amo/context_processors.py:47 src/olympia/discovery/templates/discovery/pane_account.html:8 src/olympia/users/templates/users/includes/navigation.html:2
 msgid "My Profile"
 msgstr "আমার প্রোফাইল"
 
-#: src/olympia/amo/context_processors.py:54 src/olympia/users/templates/users/edit.html:5 src/olympia/users/templates/users/includes/navigation.html:3
+#: src/olympia/amo/context_processors.py:53 src/olympia/users/templates/users/edit.html:5 src/olympia/users/templates/users/includes/navigation.html:3
 msgid "Account Settings"
 msgstr "অ্যাকাউন্ট সেটিংস"
 
-#: src/olympia/amo/context_processors.py:57 src/olympia/discovery/templates/discovery/pane_account.html:11 src/olympia/users/templates/users/profile.html:83
+#: src/olympia/amo/context_processors.py:56 src/olympia/discovery/templates/discovery/pane_account.html:11 src/olympia/users/templates/users/profile.html:83
 #: src/olympia/users/templates/users/includes/navigation.html:4
 msgid "My Collections"
 msgstr "আমার সংগ্রহসমূহ"
 
-#: src/olympia/amo/context_processors.py:62 src/olympia/discovery/templates/discovery/pane_account.html:10 src/olympia/users/templates/users/includes/navigation.html:7
+#: src/olympia/amo/context_processors.py:61 src/olympia/discovery/templates/discovery/pane_account.html:10 src/olympia/users/templates/users/includes/navigation.html:7
 msgid "My Favorites"
 msgstr "আমার পছন্দসমূহ"
 
-#: src/olympia/amo/context_processors.py:67 src/olympia/discovery/templates/discovery/pane_account.html:13 src/olympia/templates/impala/user_login.html:14
+#: src/olympia/amo/context_processors.py:66 src/olympia/discovery/templates/discovery/pane_account.html:13 src/olympia/templates/impala/user_login.html:14
 #: src/olympia/templates/mobile/header_auth.html:5
 msgid "Log out"
 msgstr "লগ আউট"
 
-#: src/olympia/amo/context_processors.py:72 src/olympia/devhub/templates/devhub/addons/dashboard.html:4
+#: src/olympia/amo/context_processors.py:71 src/olympia/devhub/templates/devhub/addons/dashboard.html:4
 msgid "Manage My Submissions"
 msgstr "আমার জমাকৃতগুলো নিয়ন্ত্রন করা"
 
-#: src/olympia/amo/context_processors.py:75 src/olympia/devhub/templates/devhub/nav.html:27 src/olympia/devhub/templates/devhub/addons/dashboard.html:25
+#: src/olympia/amo/context_processors.py:74 src/olympia/devhub/templates/devhub/nav.html:27 src/olympia/devhub/templates/devhub/addons/dashboard.html:25
 #: src/olympia/devhub/templates/devhub/addons/submit/base.html:4
 msgid "Submit a New Add-on"
 msgstr "নতুন অ্যাড-অন জমা দিন"
 
-#: src/olympia/amo/context_processors.py:77 src/olympia/browse/templates/browse/personas/base.html:50 src/olympia/devhub/templates/devhub/index.html:24
+#: src/olympia/amo/context_processors.py:76 src/olympia/browse/templates/browse/personas/base.html:50 src/olympia/devhub/templates/devhub/index.html:24
 #: src/olympia/devhub/templates/devhub/addons/dashboard.html:29
 msgid "Submit a New Theme"
 msgstr "নতুন থিম জমা দিন"
 
-#: src/olympia/amo/context_processors.py:79 src/olympia/amo/templates/amo/site_nav.html:87 src/olympia/devhub/helpers.py:36 src/olympia/devhub/helpers.py:68 src/olympia/devhub/helpers.py:102
+#: src/olympia/amo/context_processors.py:78 src/olympia/amo/templates/amo/site_nav.html:85 src/olympia/devhub/helpers.py:36 src/olympia/devhub/helpers.py:68 src/olympia/devhub/helpers.py:102
 #: src/olympia/templates/footer.html:6 src/olympia/templates/menu_links.html:14
 msgid "Developer Hub"
 msgstr "ডেভেলপার হাব"
 
-#: src/olympia/amo/context_processors.py:83 src/olympia/devhub/views.py:1792
+#: src/olympia/amo/context_processors.py:81 src/olympia/devhub/views.py:1796
 msgid "Manage API Keys"
 msgstr ""
 
-#: src/olympia/amo/context_processors.py:88 src/olympia/editors/helpers.py:82 src/olympia/editors/helpers.py:102 src/olympia/editors/templates/editors/base.html:10
+#: src/olympia/amo/context_processors.py:86 src/olympia/editors/helpers.py:84 src/olympia/editors/helpers.py:104 src/olympia/editors/templates/editors/base.html:10
 msgid "Editor Tools"
 msgstr "সম্পাদনা টুলস"
 
-#: src/olympia/amo/context_processors.py:92
+#: src/olympia/amo/context_processors.py:90
 msgid "Admin Tools"
 msgstr "অ্যাডমিন টুলস"
 
-#: src/olympia/amo/fields.py:15
+#: src/olympia/amo/fields.py:20
 msgid "Incorrect, please try again."
 msgstr ""
 
-#: src/olympia/amo/fields.py:16
+#: src/olympia/amo/fields.py:21
 msgid "Error verifying input, please try again."
 msgstr ""
 
-#: src/olympia/amo/fields.py:32
+#: src/olympia/amo/fields.py:37
 msgid "This must be a valid hex color code, such as #000000."
 msgstr "অবশ্যই বৈধ হেক্স কালার কোড হতে হবে, যেমন #000000।"
 
-#: src/olympia/amo/fields.py:58
+#: src/olympia/amo/fields.py:63
 msgid "Enter at least one value."
 msgstr "কমপক্ষে একটি মান প্রবেশ করান"
 
-#: src/olympia/amo/helpers.py:162 src/olympia/amo/templates/amo/site_nav.html:61 src/olympia/bandwagon/templates/bandwagon/add.html:9
+#: src/olympia/amo/helpers.py:162 src/olympia/amo/templates/amo/site_nav.html:59 src/olympia/bandwagon/templates/bandwagon/add.html:9
 #: src/olympia/bandwagon/templates/bandwagon/collection_detail.html:15 src/olympia/bandwagon/templates/bandwagon/delete.html:9 src/olympia/bandwagon/templates/bandwagon/edit.html:15
 #: src/olympia/bandwagon/templates/bandwagon/user_listing.html:18 src/olympia/bandwagon/templates/bandwagon/user_listing.html:21
 #: src/olympia/bandwagon/templates/bandwagon/impala/collection_listing.html:12 src/olympia/bandwagon/templates/bandwagon/impala/collection_listing.html:20
 #: src/olympia/bandwagon/templates/bandwagon/impala/collection_listing.html:24 src/olympia/bandwagon/templates/bandwagon/impala/collection_sidebar.html:3
 #: src/olympia/bandwagon/templates/bandwagon/includes/collection_sidebar.html:2 src/olympia/bandwagon/templates/bandwagon/mobile/collection_listing.html:3
-#: src/olympia/stats/templates/stats/stats.html:77 src/olympia/templates/menu_links.html:12
+#: src/olympia/stats/templates/stats/stats.html:33 src/olympia/templates/menu_links.html:12
 msgid "Collections"
 msgstr "সংগ্রহ"
 
-#: src/olympia/amo/helpers.py:171 src/olympia/amo/templates/amo/site_nav.html:85 src/olympia/browse/templates/browse/language_tools.html:3
+#: src/olympia/amo/helpers.py:171 src/olympia/amo/templates/amo/site_nav.html:83 src/olympia/browse/templates/browse/language_tools.html:3
 msgid "Dictionaries & Language Packs"
 msgstr "অভিধান এবং ভাষা প্যাকসমূহ"
 
@@ -1584,8 +1588,8 @@ msgstr "সুপার পর্যালোচনার অনুরোধ ক
 msgid "Comment on {addon} {version}."
 msgstr "মন্তব্য করুন {addon} {version}।"
 
-#: src/olympia/amo/log.py:236 src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:19 src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:47
-#: src/olympia/editors/helpers.py:511 src/olympia/editors/templates/editors/themes/history_table.html:11
+#: src/olympia/amo/log.py:236 src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:17 src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:45
+#: src/olympia/editors/helpers.py:584 src/olympia/editors/templates/editors/themes/history_table.html:11
 msgid "Comment"
 msgstr "মন্তব্য করুন"
 
@@ -1738,8 +1742,8 @@ msgid "Reviewer escalation"
 msgstr "রিভিউয়ার অপসারন"
 
 #: src/olympia/amo/log.py:442
-msgid "Video removed from {addon} because of a problem with the video."
-msgstr "ভিডিও এর সাথে একটি সমস্যা থাকায় {addon} থেকে ভিডিও অপসারন করা হয়েছে।"
+msgid "Video removed from {addon} because of a problem with the video. "
+msgstr ""
 
 #: src/olympia/amo/log.py:444
 msgid "Video removed"
@@ -1908,7 +1912,7 @@ msgstr "আগের"
 #: src/olympia/amo/templates/amo/mobile/paginator.html:14 src/olympia/amo/templates/amo/mobile/paginator.html:16 src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:51
 #: src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:65 src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:78
 #: src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:91 src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:104
-#: src/olympia/discovery/templates/discovery/pane.html:45 src/olympia/discovery/templates/discovery/addons/detail.html:39 src/olympia/stats/templates/stats/stats.html:167
+#: src/olympia/discovery/templates/discovery/pane.html:45 src/olympia/discovery/templates/discovery/addons/detail.html:39 src/olympia/stats/templates/stats/stats.html:169
 msgid "Next"
 msgstr "পরের"
 
@@ -1940,7 +1944,7 @@ msgid ""
 msgstr ""
 
 #: src/olympia/amo/templates/amo/side_nav.html:4 src/olympia/amo/templates/amo/side_nav.html:12 src/olympia/amo/templates/amo/site_nav.html:4 src/olympia/amo/templates/amo/site_nav.html:26
-#: src/olympia/browse/views.py:56 src/olympia/browse/views.py:66 src/olympia/browse/views.py:237 src/olympia/browse/views.py:282 src/olympia/search/forms.py:86
+#: src/olympia/browse/views.py:56 src/olympia/browse/views.py:66 src/olympia/browse/views.py:204 src/olympia/browse/views.py:249 src/olympia/search/forms.py:86
 msgid "Top Rated"
 msgstr "শীর্ষস্থানীয়"
 
@@ -1954,38 +1958,38 @@ msgstr "ঘুরে বেড়ান"
 msgid "Extensions"
 msgstr "এক্সটেনশন"
 
-#: src/olympia/amo/templates/amo/site_nav.html:45
+#: src/olympia/amo/templates/amo/site_nav.html:44
 msgid "Want more customization? Try <b>Complete Themes</b>"
 msgstr ""
 
-#: src/olympia/amo/templates/amo/site_nav.html:56 src/olympia/bandwagon/views.py:96
+#: src/olympia/amo/templates/amo/site_nav.html:54 src/olympia/bandwagon/views.py:96
 msgid "Most Followers"
 msgstr "সর্বাধিক অনুসরণকারী"
 
-#: src/olympia/amo/templates/amo/site_nav.html:68 src/olympia/bandwagon/templates/bandwagon/impala/collection_sidebar.html:16
+#: src/olympia/amo/templates/amo/site_nav.html:66 src/olympia/bandwagon/templates/bandwagon/impala/collection_sidebar.html:16
 #: src/olympia/bandwagon/templates/bandwagon/includes/collection_sidebar.html:18
 msgid "Collections I've Made"
 msgstr "আমার তৈরি সংগ্রহসমূহ"
 
-#: src/olympia/amo/templates/amo/site_nav.html:70 src/olympia/bandwagon/templates/bandwagon/user_listing.html:4 src/olympia/bandwagon/templates/bandwagon/impala/collection_sidebar.html:13
+#: src/olympia/amo/templates/amo/site_nav.html:68 src/olympia/bandwagon/templates/bandwagon/user_listing.html:4 src/olympia/bandwagon/templates/bandwagon/impala/collection_sidebar.html:13
 #: src/olympia/bandwagon/templates/bandwagon/includes/collection_sidebar.html:15
 msgid "Collections I'm Following"
 msgstr "আমার অনুসারিত সংগ্রহসমূহ"
 
-#: src/olympia/amo/templates/amo/site_nav.html:73 src/olympia/bandwagon/templates/bandwagon/impala/collection_sidebar.html:18
-#: src/olympia/bandwagon/templates/bandwagon/includes/collection_sidebar.html:20 src/olympia/users/models.py:512
+#: src/olympia/amo/templates/amo/site_nav.html:71 src/olympia/bandwagon/templates/bandwagon/impala/collection_sidebar.html:18
+#: src/olympia/bandwagon/templates/bandwagon/includes/collection_sidebar.html:20 src/olympia/users/models.py:521
 msgid "My Favorite Add-ons"
 msgstr "আমার পছন্দের অ্যাড-অনসমূহ"
 
-#: src/olympia/amo/templates/amo/site_nav.html:78
+#: src/olympia/amo/templates/amo/site_nav.html:76
 msgid "More&hellip;"
 msgstr "More&hellip;"
 
-#: src/olympia/amo/templates/amo/site_nav.html:82
+#: src/olympia/amo/templates/amo/site_nav.html:80
 msgid "Add-ons for Mobile"
 msgstr "মোবাইলের জন্য অ্যাড-অন"
 
-#: src/olympia/amo/templates/amo/site_nav.html:86 src/olympia/browse/feeds.py:207 src/olympia/browse/templates/browse/search_tools.html:3 src/olympia/constants/base.py:176
+#: src/olympia/amo/templates/amo/site_nav.html:84 src/olympia/browse/feeds.py:207 src/olympia/browse/templates/browse/search_tools.html:3 src/olympia/constants/base.py:176
 #: src/olympia/templates/menu_links.html:10
 msgid "Search Tools"
 msgstr "অনুসন্ধান টুল"
@@ -2001,7 +2005,7 @@ msgid "Jump to first page"
 msgstr "প্রথম পাতায় যান"
 
 #: src/olympia/amo/templates/amo/impala/paginator.html:22 src/olympia/amo/templates/amo/mobile/impala_paginator.html:12 src/olympia/discovery/templates/discovery/pane.html:44
-#: src/olympia/discovery/templates/discovery/addons/detail.html:38 src/olympia/stats/templates/stats/stats.html:164
+#: src/olympia/discovery/templates/discovery/addons/detail.html:38 src/olympia/stats/templates/stats/stats.html:166
 msgid "Previous"
 msgstr "পূর্বের"
 
@@ -2024,31 +2028,50 @@ msgid_plural "Page {n}"
 msgstr[0] "পেজ {n}"
 msgstr[1] "পেজ {n}"
 
-#: src/olympia/amo/templates/services/install.html:38
-#, python-format
-msgid "If you are not prompted to install %(addon_name)s in a moment, please <a href=\"%(addon_xpi)s\">click here</a>."
-msgstr "যদি আপনি এই মুহুর্তে %(addon_name)s ইন্সটল অনুরোধ না করেন. দয়া করে <a href=\"%(addon_xpi)s\">এখানে ক্লিক করুন</a>."
-
-#: src/olympia/amo/tests/test_messages.py:57 src/olympia/amo/tests/test_messages.py:58 src/olympia/reviews/forms.py:25 src/olympia/reviews/forms.py:50 src/olympia/reviews/templates/reviews/add.html:56
+#: src/olympia/amo/tests/test_messages.py:56 src/olympia/amo/tests/test_messages.py:57 src/olympia/reviews/forms.py:25 src/olympia/reviews/forms.py:50 src/olympia/reviews/templates/reviews/add.html:56
 #: src/olympia/reviews/templates/reviews/reply.html:30
 msgid "Title"
 msgstr "শিরেনাম"
 
-#: src/olympia/amo/tests/test_messages.py:57 src/olympia/amo/tests/test_messages.py:58
+#: src/olympia/amo/tests/test_messages.py:56 src/olympia/amo/tests/test_messages.py:57
 msgid "Body"
 msgstr "বডি"
 
-#: src/olympia/amo/tests/test_messages.py:59
+#: src/olympia/amo/tests/test_messages.py:58
 msgid "Another Title"
 msgstr "অন্য শিরোনাম"
 
-#: src/olympia/amo/tests/test_messages.py:59
+#: src/olympia/amo/tests/test_messages.py:58
 msgid "Another Body"
 msgstr "অন্য বডি"
 
-#: src/olympia/api/views.py:255
-msgid "Not implemented yet."
-msgstr "এখনও বাস্তবায়িত হয়নি।"
+#: src/olympia/api/authentication.py:76
+msgid "Signature has expired."
+msgstr ""
+
+#: src/olympia/api/authentication.py:79
+msgid "Error decoding signature."
+msgstr ""
+
+#: src/olympia/api/authentication.py:82
+msgid "Invalid JWT Token."
+msgstr ""
+
+#: src/olympia/api/authentication.py:130
+msgid "Invalid Authorization header. No credentials provided."
+msgstr ""
+
+#: src/olympia/api/authentication.py:133
+msgid "Invalid Authorization header. Credentials string should not contain spaces."
+msgstr ""
+
+#: src/olympia/api/fields.py:29
+msgid "The field must have a length of at least {num} characters."
+msgstr ""
+
+#: src/olympia/api/fields.py:31
+msgid "The language code {lang_code} is invalid."
+msgstr ""
 
 #: src/olympia/applications/views.py:39 src/olympia/applications/templates/applications/appversions.html:3
 msgid "Application Versions"
@@ -2066,7 +2089,7 @@ msgstr "বৈধ অ্যাপ্লিকেশন সংস্করণ"
 msgid "Add-ons submitted to Mozilla Add-ons must have a manifest file with at least one of the below applications supported. Only the versions listed below are allowed for these applications."
 msgstr ""
 
-#: src/olympia/applications/templates/applications/appversions.html:25
+#: src/olympia/applications/templates/applications/appversions.html:25 src/olympia/editors/helpers.py:361
 msgid "GUID"
 msgstr "GUID"
 
@@ -2180,8 +2203,8 @@ msgstr "পছন্দ"
 msgid "Remove from favorites"
 msgstr "পছন্দের তালিকা হতে অপসারণ করুন"
 
-#: src/olympia/bandwagon/views.py:98 src/olympia/bandwagon/views.py:191 src/olympia/browse/views.py:58 src/olympia/browse/views.py:69 src/olympia/browse/views.py:458 src/olympia/devhub/views.py:74
-#: src/olympia/devhub/views.py:82 src/olympia/devhub/templates/devhub/addons/edit/basic.html:20 src/olympia/editors/templates/editors/leaderboard.html:24
+#: src/olympia/bandwagon/views.py:98 src/olympia/bandwagon/views.py:191 src/olympia/browse/views.py:58 src/olympia/browse/views.py:69 src/olympia/browse/views.py:425 src/olympia/devhub/views.py:72
+#: src/olympia/devhub/views.py:80 src/olympia/devhub/templates/devhub/addons/edit/basic.html:20 src/olympia/editors/templates/editors/leaderboard.html:24
 #: src/olympia/editors/templates/editors/themes/queue_list.html:48 src/olympia/search/forms.py:17 src/olympia/search/forms.py:89 src/olympia/users/templates/users/vcard.html:5
 msgid "Name"
 msgstr "নাম"
@@ -2190,7 +2213,7 @@ msgstr "নাম"
 msgid "Recently Popular"
 msgstr "সাম্প্রতিক জনপ্রিয়"
 
-#: src/olympia/bandwagon/views.py:189 src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:18
+#: src/olympia/bandwagon/views.py:189 src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:16
 msgid "Added"
 msgstr "যুক্ত করা হয়েছে"
 
@@ -2204,7 +2227,7 @@ msgstr "সংগ্রহ তৈরি করা হয়েছে!"
 
 #: src/olympia/bandwagon/views.py:316
 #, python-format
-msgid "Your new collection is shown below. You can <ahref=\"%(url)s\">edit additional settings</a> if you'dlike."
+msgid "Your new collection is shown below. You can <a href=\"%(url)s\">edit additional settings</a> if you'd like."
 msgstr ""
 
 #: src/olympia/bandwagon/views.py:322
@@ -2332,8 +2355,8 @@ msgid_plural "%(num)s Add-ons in this Collection"
 msgstr[0] "এই সংগ্রহের %(num)s অ্যাড-অনস"
 msgstr[1] "এই সংগ্রহের %(num)s অ্যাড-অনস"
 
-#: src/olympia/bandwagon/templates/bandwagon/collection_detail.html:125 src/olympia/compat/templates/compat/index.html:25 src/olympia/compat/templates/compat/reporter_detail.html:29
-#: src/olympia/files/templates/files/viewer.html:29 src/olympia/templates/amo_footer.html:17 src/olympia/templates/includes/lang_switcher.html:10
+#: src/olympia/bandwagon/templates/bandwagon/collection_detail.html:125 src/olympia/compat/templates/compat/reporter_detail.html:29 src/olympia/files/templates/files/viewer.html:29
+#: src/olympia/templates/amo_footer.html:17 src/olympia/templates/includes/lang_switcher.html:10
 msgid "Go"
 msgstr "চলুন"
 
@@ -2500,7 +2523,7 @@ msgid "Remove this user as a contributor"
 msgstr "একজন অবদানকারী হিসেবে এই ব্যবহারকারীকে অপসারণ করুন"
 
 #: src/olympia/bandwagon/templates/bandwagon/edit_contributors.html:18 src/olympia/bandwagon/templates/bandwagon/edit_contributors.html:43
-#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:20 src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:48
+#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:18 src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:46
 #: src/olympia/devhub/templates/devhub/addons/ajax_compat_update.html:19
 msgid "Remove"
 msgstr "অপসারণ করুন"
@@ -2548,7 +2571,7 @@ msgid "<b>Warning:</b> By changing the owner of this collection, you will no lon
 msgstr ""
 
 #: src/olympia/bandwagon/templates/bandwagon/edit_contributors.html:83 src/olympia/devhub/templates/devhub/addons/forms_shared/media.html:157
-#: src/olympia/devhub/templates/devhub/addons/submit/describe.html:69 src/olympia/devhub/templates/devhub/addons/submit/license.html:60 src/olympia/devhub/templates/devhub/addons/submit/upload.html:78
+#: src/olympia/devhub/templates/devhub/addons/submit/describe.html:69 src/olympia/devhub/templates/devhub/addons/submit/license.html:60 src/olympia/devhub/templates/devhub/addons/submit/upload.html:70
 #: src/olympia/devhub/templates/devhub/payments/tier.html:17 src/olympia/editors/templates/editors/themes/themes.html:111 src/olympia/editors/templates/editors/themes/themes.html:128
 #: src/olympia/editors/templates/editors/themes/themes.html:134 src/olympia/editors/templates/editors/themes/themes.html:141 src/olympia/users/templates/users/fxa_migration_prompt_content.html:10
 #: src/olympia/users/templates/users/login_form.html:42 src/olympia/users/templates/users/mobile/login.html:57
@@ -2619,43 +2642,43 @@ msgid "Reset"
 msgstr "রিসেট"
 
 #: src/olympia/bandwagon/templates/bandwagon/includes/addedit.html:53
-msgid "PNG and JPG supported. Image will be resized to 32x32."
-msgstr "PNG এবং JPG সমর্থিত। ছবি ৩২x৩২ তে পরিবর্তিত হবে।"
+msgid "PNG and JPG supported.  Image will be resized to 32x32."
+msgstr ""
 
 #: src/olympia/bandwagon/templates/bandwagon/includes/addedit_errors.html:3
-msgid "There are errors in this form. Please correct them below."
-msgstr "এই ফর্মে ভুল আছে। দয়া করে সেগুলো নিচে ঠিক করুন।"
+msgid "There are errors in this form.  Please correct them below."
+msgstr ""
 
 #: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:2
 msgid "Add-ons in Your Collection"
 msgstr "আপনার সংগ্রহের অ্যাড-অনগুলো"
 
 #: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:4
-msgid ""
-"To include an add-on in this collection, enter its name in the box below and hit enter.  You can also use the <strong>Add to Collection</strong> links throughout the site to include add-ons later."
+msgid "To include an add-on in this collection, enter its name in the box below and hit enter."
 msgstr ""
 
-#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:17 src/olympia/constants/base.py:400 src/olympia/devhub/templates/devhub/addons/activity.html:62
+#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:15 src/olympia/constants/base.py:400 src/olympia/devhub/templates/devhub/addons/activity.html:62
+#: src/olympia/editors/helpers.py:273 src/olympia/editors/helpers.py:360
 msgid "Add-on"
 msgstr "অ্যাড-অন"
 
-#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:26
+#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:24
 msgid "Enter the name of the add-on to include"
 msgstr "অন্তর্ভুক্ত করার জন্য অ্যাড-অনের নামটি প্রবেশ করান"
 
-#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:28
+#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:26
 msgid "Add to Collection"
 msgstr "সংগ্রহে যুক্ত করুন"
 
-#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:45 src/olympia/editors/helpers.py:936 src/olympia/editors/helpers.py:956
+#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:43 src/olympia/editors/helpers.py:1016 src/olympia/editors/helpers.py:1036
 msgid "Pending"
 msgstr "অনিষ্পন্ন"
 
-#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:47
+#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:45
 msgid "Add a comment"
 msgstr "মন্তব্য করুন"
 
-#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:48
+#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:46
 msgid "Remove this add-on from the collection"
 msgstr "সংগ্রহ হতে অ্যাড-অনটি অপসারণ করুন"
 
@@ -2762,12 +2785,12 @@ msgstr ""
 msgid "Most Users"
 msgstr "অধিকাংশ ব্যবহারকারী"
 
-#: src/olympia/browse/views.py:61 src/olympia/browse/views.py:72 src/olympia/browse/views.py:279 src/olympia/browse/templates/browse/personas/mobile/category_landing.html:63
+#: src/olympia/browse/views.py:61 src/olympia/browse/views.py:72 src/olympia/browse/views.py:246 src/olympia/browse/templates/browse/personas/mobile/category_landing.html:63
 #: src/olympia/discovery/templates/discovery/pane.html:67 src/olympia/search/forms.py:92
 msgid "Up & Coming"
 msgstr ""
 
-#: src/olympia/browse/views.py:460 src/olympia/devhub/views.py:76 src/olympia/devhub/views.py:83 src/olympia/discovery/templates/discovery/addons/detail.html:66
+#: src/olympia/browse/views.py:427 src/olympia/devhub/views.py:74 src/olympia/devhub/views.py:81 src/olympia/discovery/templates/discovery/addons/detail.html:66
 msgid "Created"
 msgstr "তৈরী করা হয়েছে"
 
@@ -2955,8 +2978,8 @@ msgid_plural "See all %(cnt)s extensions in %(name)s &raquo;"
 msgstr[0] "%(name)s এর অধীনে %(cnt)s এক্সটেনশন দেখুন &raquo;"
 msgstr[1] "%(name)s এর অধীনে %(cnt)s সকল এক্সটেনশন দেখুন &raquo;"
 
-#: src/olympia/browse/templates/browse/mobile/extensions.html:13 src/olympia/compat/templates/compat/index.html:82 src/olympia/devhub/templates/devhub/devhub_search.html:24
-#: src/olympia/devhub/templates/devhub/addons/activity.html:47 src/olympia/search/templates/search/no_results.html:4 src/olympia/search/templates/search/mobile/results.html:36
+#: src/olympia/browse/templates/browse/mobile/extensions.html:13 src/olympia/devhub/templates/devhub/devhub_search.html:24 src/olympia/devhub/templates/devhub/addons/activity.html:47
+#: src/olympia/search/templates/search/no_results.html:4 src/olympia/search/templates/search/mobile/results.html:36
 msgid "No results found."
 msgstr "ফলাফল পাওয়া যায় নি।"
 
@@ -3041,7 +3064,7 @@ msgstr ""
 msgid "All"
 msgstr ""
 
-#: src/olympia/compat/forms.py:22 src/olympia/search/views.py:525
+#: src/olympia/compat/forms.py:22 src/olympia/editors/templates/editors/base.html:69 src/olympia/search/views.py:518
 msgid "All Add-ons"
 msgstr ""
 
@@ -3051,53 +3074,6 @@ msgstr ""
 
 #: src/olympia/compat/forms.py:24
 msgid "Non-binary"
-msgstr ""
-
-#. Review points sources other than add-ons and themes.
-#: src/olympia/compat/views.py:87 src/olympia/constants/base.py:388 src/olympia/devhub/forms.py:162 src/olympia/editors/templates/editors/performance.html:75
-msgid "Other"
-msgstr "অন্যান্য"
-
-#: src/olympia/compat/templates/compat/index.html:4
-msgid "Add-on Compatibility Report for {app} {version}"
-msgstr "{app} {version} এর জন্য অ্যাড-অন কম্প্যাটিবিলিটি রিপোর্ট"
-
-#: src/olympia/compat/templates/compat/index.html:11
-msgid "{app} {version} Compatibility"
-msgstr "{app} {version} সামঞ্জস্য"
-
-#: src/olympia/compat/templates/compat/index.html:17
-#, python-format
-msgid "Top 95%% compatible with previous version"
-msgstr ""
-
-#: src/olympia/compat/templates/compat/index.html:18
-#, python-format
-msgid "Top 95%% of all add-ons"
-msgstr ""
-
-#: src/olympia/compat/templates/compat/index.html:19
-msgid "All active add-ons"
-msgstr "সকল সচল অ্যাড-অন"
-
-#: src/olympia/compat/templates/compat/index.html:23 src/olympia/constants/base.py:401
-msgid "App"
-msgstr "অ্যাপ"
-
-#: src/olympia/compat/templates/compat/index.html:55
-msgid "Details for add-ons compatible with previous version:"
-msgstr "পূর্ববর্তী সংস্করণের সাথে সামঞ্জস্যপূর্ণ বিস্তারিত অ্যাড-অনের জন্য:"
-
-#: src/olympia/compat/templates/compat/index.html:57
-msgid "Show all versions"
-msgstr "সকল সংস্করণ দেখুন"
-
-#: src/olympia/compat/templates/compat/index.html:59
-msgid "Details for add-ons compatible with all versions:"
-msgstr ""
-
-#: src/olympia/compat/templates/compat/index.html:61
-msgid "Show previous version only"
 msgstr ""
 
 #: src/olympia/compat/templates/compat/reporter.html:3
@@ -3151,8 +3127,8 @@ msgstr "অ্যাপ্লিকেশন অনুযায়ী বাছু�
 msgid "Report Type"
 msgstr "রিপোর্টের ধরন"
 
-#: src/olympia/compat/templates/compat/reporter_detail.html:47 src/olympia/devhub/forms.py:784 src/olympia/devhub/templates/devhub/addons/ajax_compat_update.html:17 src/olympia/editors/forms.py:108
-#: src/olympia/zadmin/forms.py:45
+#: src/olympia/compat/templates/compat/reporter_detail.html:47 src/olympia/devhub/forms.py:785 src/olympia/devhub/templates/devhub/addons/ajax_compat_update.html:17 src/olympia/editors/forms.py:108
+#: src/olympia/editors/forms.py:248 src/olympia/zadmin/forms.py:45
 msgid "Application"
 msgstr "অ্যাপ্লিকেশন"
 
@@ -3240,7 +3216,8 @@ msgstr "প্রাথমিকভাবে পর্যালোচনা ক�
 msgid "Preliminarily Reviewed and Awaiting Full Review"
 msgstr "প্রাথমিকভাবে পর্যালোচনা করা হয়েছে এবং সম্পূর্ণ পর্যালোচনা জন্য অপেক্ষা করছে"
 
-#: src/olympia/constants/base.py:33 src/olympia/editors/helpers.py:924 src/olympia/editors/templates/editors/themes/history_table.html:34
+#: src/olympia/constants/base.py:33 src/olympia/editors/forms.py:258 src/olympia/editors/helpers.py:73 src/olympia/editors/helpers.py:1004
+#: src/olympia/editors/templates/editors/themes/history_table.html:34
 msgid "Deleted"
 msgstr "অপসারন করা হয়েছে"
 
@@ -3337,6 +3314,11 @@ msgstr ""
 msgid "Ask before users can download this add-on"
 msgstr ""
 
+#. Review points sources other than add-ons and themes.
+#: src/olympia/constants/base.py:388 src/olympia/devhub/forms.py:162 src/olympia/editors/templates/editors/performance.html:75
+msgid "Other"
+msgstr "অন্যান্য"
+
 #: src/olympia/constants/base.py:389
 msgid "Exception"
 msgstr "ব্যতিক্রম"
@@ -3348,6 +3330,10 @@ msgstr "রিলিজ"
 #: src/olympia/constants/base.py:391
 msgid "Change"
 msgstr "পরিবর্তন"
+
+#: src/olympia/constants/base.py:401
+msgid "App"
+msgstr "অ্যাপ"
 
 #: src/olympia/constants/base.py:402
 msgid "Persona"
@@ -3497,7 +3483,7 @@ msgstr ""
 msgid "Duplicate"
 msgstr ""
 
-#: src/olympia/constants/editors.py:17 src/olympia/editors/helpers.py:502 src/olympia/editors/templates/editors/themes/queue.html:71 src/olympia/editors/templates/editors/themes/themes.html:94
+#: src/olympia/constants/editors.py:17 src/olympia/editors/helpers.py:575 src/olympia/editors/templates/editors/themes/queue.html:71 src/olympia/editors/templates/editors/themes/themes.html:94
 msgid "Reject"
 msgstr ""
 
@@ -3597,7 +3583,7 @@ msgstr "সোলারিস"
 msgid "Android"
 msgstr "এনড্রয়েড"
 
-#: src/olympia/core/apps.py:19
+#: src/olympia/core/apps.py:21
 msgid "Core"
 msgstr ""
 
@@ -3731,7 +3717,7 @@ msgid "Submit my add-on for manual review."
 msgstr ""
 
 #: src/olympia/devhub/forms.py:537
-msgid "Do not list my add-on on this site (beta)"
+msgid "Do not list my add-on on this site"
 msgstr ""
 
 #: src/olympia/devhub/forms.py:538
@@ -3764,46 +3750,46 @@ msgstr ""
 
 #: src/olympia/devhub/forms.py:592
 #, python-format
-msgid "Version %s already exists"
-msgstr "সংস্করণ %s আগে থেকেই রয়েছে"
+msgid "Version %s already exists, or was uploaded before."
+msgstr ""
 
-#: src/olympia/devhub/forms.py:604
+#: src/olympia/devhub/forms.py:605
 msgid "Select a valid choice. That choice is not one of the available choices."
 msgstr ""
 
-#: src/olympia/devhub/forms.py:610
+#: src/olympia/devhub/forms.py:611
 msgid "A file with a version ending with a|alpha|b|beta and an optional number is detected as beta."
 msgstr ""
 
-#: src/olympia/devhub/forms.py:633
+#: src/olympia/devhub/forms.py:634
 msgid "You cannot upload any more files for this version."
 msgstr "আপনি এই সংস্করণের জন্য আর কোন ফাইল আপলোড করতে পারবেন না।"
 
-#: src/olympia/devhub/forms.py:639
+#: src/olympia/devhub/forms.py:640
 msgid "Version doesn't match"
 msgstr "সংস্করণ মেলেনি"
 
-#: src/olympia/devhub/forms.py:668
-msgid "You cannot delete a file once the review process has started. You must delete the whole version."
-msgstr "রিভিউ প্রক্রিয়া শুরু হওয়ার পর আপনি কোন ফাইল অপসারন করতে পারবেন না। আপনাকে অবশ্যই সম্পূর্ণ ভার্সন মুছে দিতে হবে।"
+#: src/olympia/devhub/forms.py:669
+msgid "You cannot delete a file once the review process has started.  You must delete the whole version."
+msgstr ""
 
-#: src/olympia/devhub/forms.py:688
+#: src/olympia/devhub/forms.py:689
 msgid "The platform All cannot be combined with specific platforms."
 msgstr ""
 
-#: src/olympia/devhub/forms.py:693
+#: src/olympia/devhub/forms.py:694
 msgid "A platform can only be chosen once."
 msgstr ""
 
-#: src/olympia/devhub/forms.py:706
+#: src/olympia/devhub/forms.py:707
 msgid "A review type must be selected."
 msgstr ""
 
-#: src/olympia/devhub/forms.py:788 src/olympia/editors/forms.py:114 src/olympia/zadmin/forms.py:49 src/olympia/zadmin/forms.py:52
+#: src/olympia/devhub/forms.py:789 src/olympia/editors/forms.py:114 src/olympia/editors/forms.py:254 src/olympia/zadmin/forms.py:49 src/olympia/zadmin/forms.py:52
 msgid "Select an application first"
 msgstr ""
 
-#: src/olympia/devhub/forms.py:840
+#: src/olympia/devhub/forms.py:841
 msgid "There cannot be more than 3 required add-ons."
 msgstr ""
 
@@ -3837,76 +3823,76 @@ msgstr[1] ""
 msgid "Review"
 msgstr ""
 
-#: src/olympia/devhub/tasks.py:551
+#: src/olympia/devhub/tasks.py:583
 #, python-format
 msgid "%s responded with %s (%s)."
 msgstr ""
 
-#: src/olympia/devhub/tasks.py:555
+#: src/olympia/devhub/tasks.py:587
 #, python-format
 msgid "Connection to \"%s\" timed out."
 msgstr ""
 
-#: src/olympia/devhub/tasks.py:557
+#: src/olympia/devhub/tasks.py:589
 #, python-format
 msgid "Could not contact host at \"%s\"."
 msgstr ""
 
-#: src/olympia/devhub/utils.py:104
+#: src/olympia/devhub/utils.py:105
 #, python-format
 msgid "Validation generated too many errors/warnings so %s messages were truncated. After addressing the visible messages, you'll be able to see the others."
 msgstr ""
 
-#: src/olympia/devhub/views.py:183
+#: src/olympia/devhub/views.py:181
 msgid "All My Add-ons"
 msgstr ""
 
-#: src/olympia/devhub/views.py:210
+#: src/olympia/devhub/views.py:208
 msgid "All Activity"
 msgstr ""
 
-#: src/olympia/devhub/views.py:211
+#: src/olympia/devhub/views.py:209
 msgid "Add-on Updates"
 msgstr ""
 
-#: src/olympia/devhub/views.py:212
+#: src/olympia/devhub/views.py:210
 msgid "Add-on Status"
 msgstr ""
 
-#: src/olympia/devhub/views.py:213
+#: src/olympia/devhub/views.py:211
 msgid "User Collections"
 msgstr ""
 
-#: src/olympia/devhub/views.py:214 src/olympia/devhub/templates/devhub/docs/policies-maintenance.html:68 src/olympia/pages/templates/pages/dev_faq.html:38
+#: src/olympia/devhub/views.py:212 src/olympia/devhub/templates/devhub/docs/policies-maintenance.html:68 src/olympia/pages/templates/pages/dev_faq.html:38
 #: src/olympia/pages/templates/pages/dev_faq.html:484
 msgid "User Reviews"
 msgstr ""
 
-#: src/olympia/devhub/views.py:327 src/olympia/devhub/views.py:331 src/olympia/devhub/views.py:484 src/olympia/devhub/views.py:513 src/olympia/devhub/views.py:564 src/olympia/devhub/views.py:1150
+#: src/olympia/devhub/views.py:325 src/olympia/devhub/views.py:329 src/olympia/devhub/views.py:484 src/olympia/devhub/views.py:513 src/olympia/devhub/views.py:564 src/olympia/devhub/views.py:1156
 msgid "Changes successfully saved."
 msgstr "পরিবর্তনগুলো সফলতার সাথে সংরক্ষিত হয়েছে।"
 
-#: src/olympia/devhub/views.py:334 src/olympia/devhub/views.py:1631
+#: src/olympia/devhub/views.py:332 src/olympia/devhub/views.py:1637
 msgid "Please check the form for errors."
 msgstr ""
 
-#: src/olympia/devhub/views.py:346
+#: src/olympia/devhub/views.py:344
 msgid "Add-on cannot be deleted. Disable this add-on instead."
 msgstr ""
 
-#: src/olympia/devhub/views.py:356
+#: src/olympia/devhub/views.py:354
 msgid "Theme deleted."
 msgstr "থিম মুছে ফেলা হয়েছে।"
 
-#: src/olympia/devhub/views.py:356
+#: src/olympia/devhub/views.py:354
 msgid "Add-on deleted."
 msgstr "অ্যাড-অন মুছে ফেলা হয়েছে।"
 
-#: src/olympia/devhub/views.py:362
+#: src/olympia/devhub/views.py:360
 msgid "URL name was incorrect. Theme was not deleted."
 msgstr ""
 
-#: src/olympia/devhub/views.py:367
+#: src/olympia/devhub/views.py:365
 msgid "URL name was incorrect. Add-on was not deleted."
 msgstr ""
 
@@ -3934,7 +3920,7 @@ msgstr ""
 msgid "Check Add-on Compatibility"
 msgstr ""
 
-#: src/olympia/devhub/views.py:808 src/olympia/signing/views.py:90
+#: src/olympia/devhub/views.py:808 src/olympia/signing/views.py:95
 msgid "You cannot submit this type of add-on"
 msgstr ""
 
@@ -3964,33 +3950,33 @@ msgstr ""
 msgid "There was an error uploading your preview."
 msgstr ""
 
-#: src/olympia/devhub/views.py:1189
+#: src/olympia/devhub/views.py:1195
 #, python-format
 msgid "Version %s disabled."
 msgstr "%s সংস্করণ নিষ্ক্রিয় করা হয়েছে।"
 
-#: src/olympia/devhub/views.py:1193
+#: src/olympia/devhub/views.py:1199
 #, python-format
 msgid "Version %s deleted."
 msgstr "%s সংস্করণ মুছে ফেলা হয়েছে।"
 
-#: src/olympia/devhub/views.py:1203
+#: src/olympia/devhub/views.py:1209
 msgid "This upload has failed validation, and may lack complete validation results. Please take due care when reviewing it."
 msgstr ""
 
-#: src/olympia/devhub/views.py:1677
+#: src/olympia/devhub/views.py:1683
 msgid "Preliminary Review Requested."
 msgstr ""
 
-#: src/olympia/devhub/views.py:1678
+#: src/olympia/devhub/views.py:1684
 msgid "Full Review Requested."
 msgstr ""
 
-#: src/olympia/devhub/views.py:1779
+#: src/olympia/devhub/views.py:1783
 msgid "Your old credentials were revoked and are no longer valid. Be sure to update all API clients with the new credentials."
 msgstr ""
 
-#: src/olympia/devhub/views.py:1797
+#: src/olympia/devhub/views.py:1801
 msgid "New API key created"
 msgstr ""
 
@@ -4020,7 +4006,7 @@ msgstr "অ্যাড-অনে ফিরে যান"
 msgid "{0} :: Search"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/devhub_search.html:6 src/olympia/devhub/templates/devhub/search.html:8 src/olympia/editors/forms.py:435 src/olympia/editors/forms.py:437
+#: src/olympia/devhub/templates/devhub/devhub_search.html:6 src/olympia/devhub/templates/devhub/search.html:8 src/olympia/editors/forms.py:534 src/olympia/editors/forms.py:536
 #: src/olympia/editors/templates/editors/queue.html:27 src/olympia/editors/templates/editors/themes/queue_list.html:14 src/olympia/search/templates/search/collections.html:17
 #: src/olympia/search/templates/search/personas.html:18 src/olympia/search/templates/search/results.html:18 src/olympia/search/templates/search/mobile/results.html:8
 #: src/olympia/templates/search.html:14 src/olympia/templates/impala/search.html:18
@@ -4080,12 +4066,12 @@ msgstr ""
 msgid "Start Making Add-ons"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/index.html:86 src/olympia/devhub/templates/devhub/addons/listing/items.html:25 src/olympia/devhub/templates/devhub/includes/addon_details.html:15
+#: src/olympia/devhub/templates/devhub/index.html:86 src/olympia/devhub/templates/devhub/addons/listing/items.html:25 src/olympia/devhub/templates/devhub/includes/addon_details.html:20
 #: src/olympia/devhub/templates/devhub/personas/edit.html:43
 msgid "Status:"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/index.html:90 src/olympia/devhub/templates/devhub/includes/addon_details.html:100
+#: src/olympia/devhub/templates/devhub/index.html:90 src/olympia/devhub/templates/devhub/includes/addon_details.html:87
 msgid "Visibility:"
 msgstr ""
 
@@ -4093,11 +4079,11 @@ msgstr ""
 msgid "Latest Version:"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/index.html:109 src/olympia/devhub/templates/devhub/includes/addon_details.html:145 src/olympia/devhub/templates/devhub/personas/edit.html:49
+#: src/olympia/devhub/templates/devhub/index.html:109 src/olympia/devhub/templates/devhub/includes/addon_details.html:131 src/olympia/devhub/templates/devhub/personas/edit.html:49
 msgid "Queue Position:"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/index.html:110 src/olympia/devhub/templates/devhub/includes/addon_details.html:146 src/olympia/devhub/templates/devhub/personas/edit.html:50
+#: src/olympia/devhub/templates/devhub/index.html:110 src/olympia/devhub/templates/devhub/includes/addon_details.html:132 src/olympia/devhub/templates/devhub/personas/edit.html:50
 #, python-format
 msgid "%(position)s of %(total)s"
 msgstr ""
@@ -4199,16 +4185,6 @@ msgstr ""
 msgid "Do you want your add-on to be distributed on this site?"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/validate_addon.html:49 src/olympia/devhub/templates/devhub/addons/submit/upload.html:30 src/olympia/devhub/templates/devhub/versions/add_file_modal.html:14
-#: src/olympia/devhub/templates/devhub/versions/add_file_modal.html:53 src/olympia/devhub/templates/devhub/versions/list.html:298
-msgid "Warning:"
-msgstr ""
-
-#: src/olympia/devhub/templates/devhub/validate_addon.html:50 src/olympia/devhub/templates/devhub/addons/submit/upload.html:31
-#, python-format
-msgid "Submission of unlisted add-ons for signing is currently in an open beta. Please <a href=\"%(url)s\" target=\"_blank\">report any bugs</a> that you encounter."
-msgstr ""
-
 #. first parameter is a filename like lorem-ipsum-1.0.2.xpi
 #: src/olympia/devhub/templates/devhub/validation.html:5
 msgid "Validation Results for {0}"
@@ -4283,7 +4259,7 @@ msgstr ""
 msgid "Update Compatibility"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/addons/ajax_compat_update.html:4
+#: src/olympia/devhub/templates/devhub/addons/ajax_compat_update.html:4 src/olympia/devhub/templates/devhub/versions/edit.html:45
 msgid "Adjusting application information here will allow users to install your add-on even if the install manifest in the package indicates that the add-on is incompatible."
 msgstr ""
 
@@ -4295,9 +4271,9 @@ msgstr ""
 msgid "Add Another Application&hellip;"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/addons/ajax_compat_update.html:38 src/olympia/devhub/templates/devhub/addons/owner.html:86 src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:46
-#: src/olympia/devhub/templates/devhub/versions/list.html:351 src/olympia/devhub/templates/devhub/versions/list.html:353 src/olympia/templates/impala/base.html:132
-#: src/olympia/templates/impala/base.html:143 src/olympia/templates/impala/base.html:161 src/olympia/templates/impala/base.html:171
+#: src/olympia/devhub/templates/devhub/addons/ajax_compat_update.html:38 src/olympia/devhub/templates/devhub/addons/owner.html:86 src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:45
+#: src/olympia/devhub/templates/devhub/versions/list.html:349 src/olympia/devhub/templates/devhub/versions/list.html:351 src/olympia/templates/impala/base.html:129
+#: src/olympia/templates/impala/base.html:140 src/olympia/templates/impala/base.html:158 src/olympia/templates/impala/base.html:168
 msgid "Close"
 msgstr ""
 
@@ -4331,7 +4307,7 @@ msgstr ""
 msgid "Manage Authors & License"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/addons/owner.html:29 src/olympia/editors/templates/editors/review.html:270
+#: src/olympia/devhub/templates/devhub/addons/owner.html:29 src/olympia/editors/helpers.py:362 src/olympia/editors/templates/editors/review.html:270
 msgid "Authors"
 msgstr ""
 
@@ -4400,17 +4376,11 @@ msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/basic.html:52
 msgid ""
-"A short explanation of your add-on's basic\n"
-"                          functionality that is displayed in search and browse\n"
-"                          listings, as well as at the top of your add-on's\n"
-"                          details page. It is only relevant for listed add-ons."
+"A short explanation of your add-on's basic functionality that is displayed in search and browse listings, as well as at the top of your add-on's details page. It is only relevant for listed add-ons."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/basic.html:73
-msgid ""
-"Categories are the primary way users browse through add-ons.\n"
-"                        Choose any that fit your add-on's functionality for the most\n"
-"                        exposure. It is only relevant for listed add-ons."
+msgid "Categories are the primary way users browse through add-ons. Choose any that fit your add-on's functionality for the most exposure. It is only relevant for listed add-ons."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/basic.html:90
@@ -4420,11 +4390,7 @@ msgid ""
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/basic.html:119
-msgid ""
-"Tags help users find your add-on and should be short\n"
-"                        descriptors such as tabs, toolbar, or twitter.  You\n"
-"                        may have a maximum of {0} tags. It is only relevant\n"
-"                        for listed add-ons."
+msgid "Tags help users find your add-on and should be short descriptors such as tabs, toolbar, or twitter. You may have a maximum of {0} tags. It is only relevant for listed add-ons."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/basic.html:129 src/olympia/devhub/templates/devhub/personas/edit.html:97 src/olympia/devhub/templates/devhub/personas/submit.html:46
@@ -4452,11 +4418,7 @@ msgid "Add-on Details for {0}"
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/details.html:22
-msgid ""
-"A longer explanation of features,\n"
-"                          functionality, and other relevant information. This\n"
-"                          field is only displayed on the add-on's details\n"
-"                          page. It is only relevant for listed add-ons."
+msgid "A longer explanation of features, functionality, and other relevant information. This field is only displayed on the add-on's details page. It is only relevant for listed add-ons."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/details.html:44 src/olympia/translations/templates/translations/trans-menu.html:13
@@ -4464,10 +4426,7 @@ msgid "Default Locale"
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/details.html:45
-msgid ""
-"Information about your add-on is displayed in this locale\n"
-"                        unless you override it with a locale-specific translation.\n"
-"                        It is only relevant for listed add-ons."
+msgid "Information about your add-on is displayed in this locale unless you override it with a locale-specific translation. It is only relevant for listed add-ons."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/details.html:61 src/olympia/users/forms.py:311 src/olympia/users/templates/users/edit.html:122 src/olympia/users/templates/users/register.html:57
@@ -4477,10 +4436,8 @@ msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/details.html:63
 msgid ""
-"If your add-on has another homepage, enter its\n"
-"                          address here. If your website is localized into other\n"
-"                          languages multiple translations of this field can be\n"
-"                          added. It is only relevant for listed add-ons."
+"If your add-on has another homepage, enter its address here. If your website is localized into other languages multiple translations of this field can be added. It is only relevant for listed add-"
+"ons."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/media.html:3
@@ -4498,19 +4455,14 @@ msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/support.html:22
 msgid ""
-"If you wish to display an e-mail address for support\n"
-"                          inquiries, enter it here. If you have different\n"
-"                          addresses for each language multiple translations of\n"
-"                          this field can be added. It is only relevant for\n"
-"                          listed add-ons."
+"If you wish to display an e-mail address for support inquiries, enter it here. If you have different addresses for each language multiple translations of this field can be added. It is only "
+"relevant for listed add-ons."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/support.html:45
 msgid ""
-"If your add-on has a support website or forum, enter\n"
-"                          its address here. If your website is localized into\n"
-"                          other languages, multiple translations of this field can\n"
-"                          be added. It is only relevant for listed add-ons."
+"If your add-on has a support website or forum, enter its address here. If your website is localized into other languages, multiple translations of this field can be added. It is only relevant for "
+"listed add-ons."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:6
@@ -4524,11 +4476,8 @@ msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:23
 msgid ""
-"Any information end users may want to know that isn't\n"
-"                          necessarily applicable to the add-on summary or description.\n"
-"                          Common uses include listing known major bugs, information on\n"
-"                          how to report bugs, anticipated release date of a new version,\n"
-"                          etc. It is only relevant for listed add-ons."
+"Any information end users may want to know that isn't necessarily applicable to the add-on summary or description. Common uses include listing known major bugs, information on how to report bugs, "
+"anticipated release date of a new version, etc. It is only relevant for listed add-ons."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:46
@@ -4540,9 +4489,7 @@ msgid "Add-on Flags"
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:69
-msgid ""
-"These flags are used to classify add-ons. It is only\n"
-"                        relevant for listed add-ons."
+msgid "These flags are used to classify add-ons. It is only relevant for listed add-ons."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:74
@@ -4558,9 +4505,7 @@ msgid "View Source?"
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:90
-msgid ""
-"Whether the source of your add-on can be displayed in our\n"
-"                        online viewer. It is only relevant for listed add-ons."
+msgid "Whether the source of your add-on can be displayed in our online viewer. It is only relevant for listed add-ons."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:94
@@ -4576,10 +4521,7 @@ msgid "Public Stats?"
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:102
-msgid ""
-"Whether the download and usage stats of your add-on can\n"
-"                        be displayed in our online viewer.\n"
-"                        It is only relevant for listed add-ons."
+msgid "Whether the download and usage stats of your add-on can be displayed in our online viewer. It is only relevant for listed add-ons."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:107
@@ -4595,10 +4537,7 @@ msgid "Upgrade SDK?"
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:116
-msgid ""
-"If selected, we will try to automatically upgrade your\n"
-"                        add-on when a new version of the SDK is released.\n"
-"                        It is only relevant for listed add-ons."
+msgid "If selected, we will try to automatically upgrade your add-on when a new version of the SDK is released. It is only relevant for listed add-ons."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:121
@@ -4649,10 +4588,8 @@ msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/forms_shared/media.html:16
 msgid ""
-"Upload an icon for your add-on or choose from one of ours. The\n"
-"                      icon is displayed nearly everywhere your add-on is. Uploaded images\n"
-"                      must be one of the following image types: .png, .jpg.\n"
-"                      It is only relevant for listed add-ons."
+"Upload an icon for your add-on or choose from one of ours. The icon is displayed nearly everywhere your add-on is. Uploaded images must be one of the following image types: .png, .jpg. It is only "
+"relevant for listed add-ons."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/forms_shared/media.html:25
@@ -4665,9 +4602,7 @@ msgid "32x32px"
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/forms_shared/media.html:39
-msgid ""
-"Used in listings of add-ons, like search results\n"
-"                            and featured add-ons."
+msgid "Used in listings of add-ons, like search results and featured add-ons."
 msgstr ""
 
 #. The size of the icon
@@ -4762,16 +4697,14 @@ msgid "Deleting your add-on will permanently remove it from the site and prevent
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:24
-msgid ""
-"Enter the following text confirm your decision:\n"
-"           {slug}"
+msgid "Enter the following text confirm your decision: {slug}"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:34
+#: src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:33
 msgid "Please tell us why you are deleting your theme:"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:36
+#: src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:35
 msgid "Please tell us why you are deleting your add-on:"
 msgstr ""
 
@@ -4808,8 +4741,8 @@ msgstr ""
 msgid "Daily statistics on downloads and users."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/addons/listing/item_actions.html:45 src/olympia/stats/templates/stats/stats.html:75 src/olympia/stats/templates/stats/stats.html:79
-#: src/olympia/stats/templates/stats/stats.html:81
+#: src/olympia/devhub/templates/devhub/addons/listing/item_actions.html:45 src/olympia/stats/templates/stats/stats.html:31 src/olympia/stats/templates/stats/stats.html:35
+#: src/olympia/stats/templates/stats/stats.html:37
 msgid "Statistics"
 msgstr "পরিসংখ্যান"
 
@@ -4928,10 +4861,7 @@ msgid "Your add-on has been submitted to the Full Review queue."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/submit/done.html:18
-msgid ""
-"You'll receive an email once it has been reviewed by an editor. In\n"
-"          the meantime, you and your friends can install it directly from its\n"
-"          details page:"
+msgid "You'll receive an email once it has been reviewed by an editor. In the meantime, you and your friends can install it directly from its details page:"
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/submit/done.html:27 src/olympia/devhub/templates/devhub/addons/submit/done.html:77 src/olympia/devhub/templates/devhub/personas/submit_done.html:16
@@ -5137,11 +5067,11 @@ msgstr ""
 msgid "Use the fields below to upload your add-on package and select any platform restrictions. After upload, a series of automated validation tests will be run on your file."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/addons/submit/upload.html:59 src/olympia/devhub/templates/devhub/versions/add_file_modal.html:39
+#: src/olympia/devhub/templates/devhub/addons/submit/upload.html:51 src/olympia/devhub/templates/devhub/versions/add_file_modal.html:28
 msgid "Which platforms is this file compatible with?"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/addons/submit/upload.html:67 src/olympia/devhub/templates/devhub/versions/add_file_modal.html:65
+#: src/olympia/devhub/templates/devhub/addons/submit/upload.html:59 src/olympia/devhub/templates/devhub/versions/add_file_modal.html:45
 msgid "Administrative overrides"
 msgstr ""
 
@@ -5251,8 +5181,8 @@ msgstr ""
 
 #: src/olympia/devhub/templates/devhub/docs/policies-contact.html:44
 msgid ""
-"If you've found a problem with the site, we'd love to fix it. Please <a href=\"https://github.com/mozilla/olympia/issues\">file a bug report</a> in GitHub, including the location of the problem and "
-"how you encountered it."
+"If you've found a problem with the site, we'd love to fix it. Please <a href=\"https://github.com/mozilla/addons/issues/new\">file a bug report</a> in GitHub, including the location of the problem "
+"and how you encountered it."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/docs/policies-maintenance.html:3 src/olympia/devhub/templates/devhub/docs/policies-maintenance.html:7
@@ -5819,7 +5749,7 @@ msgstr ""
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:282
 msgid ""
-"Add-ons that store or otherwise handle browsing data must support <a href=\"https://developer.mozilla.org/En/Supporting_private_browsing_mode\">Private Browsing Mode</a>.  During a Private Browsing "
+"Add-ons that store or otherwise handle browsing data must support <a href=\"https://developer.mozilla.org/En/Supporting_private_browsing_mode\">Private Browsing Mode</a>. During a Private Browsing "
 "session, no browsing data can be written to disk, and all of this data must be cleared when Firefox quits or the Private Browsing session ends."
 msgstr ""
 
@@ -5984,129 +5914,95 @@ msgstr ""
 msgid "How to get in touch with us regarding these policies or your add-on."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:6
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:10
 msgid "You have disabled this add-on"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:20
-msgid ""
-"Your add-on's listing is disabled and is not showing\n"
-"                             anywhere in our gallery or update service."
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:24
+msgid "Your add-on's listing is disabled and is not showing anywhere in our gallery or update service."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:25
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:27
 msgid "Please complete your add-on."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:29
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:30
 msgid "You will receive an email when the review is complete."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:34
-msgid ""
-"You will receive an email when the review is complete. Until\n"
-"                             then, your add-on is not listed in our gallery but can be\n"
-"                             accessed directly from its details page."
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:33
+msgid "You will receive an email when the review is complete. Until then, your add-on is not listed in our gallery but can be accessed directly from its details page."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:38 src/olympia/devhub/templates/devhub/includes/addon_details.html:48
-msgid ""
-"You will receive an email when the review is\n"
-"                             complete and your add-on is signed."
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:37 src/olympia/devhub/templates/devhub/includes/addon_details.html:45
+msgid "You will receive an email when the review is complete and your add-on is signed."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:44
-msgid ""
-"You will receive an email when the review is complete. Until\n"
-"                             then, your add-on is not listed in our gallery but can be\n"
-"                             accessed directly from its details page. "
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:41
+msgid "You will receive an email when the review is complete. Until then, your add-on is not listed in our gallery but can be accessed directly from its details page. "
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:54
-msgid ""
-"Your add-on is displayed in our gallery and users are\n"
-"                             receiving automatic updates."
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:49
+msgid "Your add-on is displayed in our gallery and users are receiving automatic updates."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:57
-msgid ""
-"Your add-on has been signed and can be bundled with an\n"
-"                             application installer."
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:52
+msgid "Your add-on has been signed and can be bundled with an application installer."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:63
-msgid ""
-"Your add-on was disabled by a site administrator and is no\n"
-"                             longer shown in our gallery. If you have any questions,\n"
-"                             please email amo-admins@mozilla.org."
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:56
+msgid "Your add-on was disabled by a site administrator and is no longer shown in our gallery. If you have any questions, please email amo-admins@mozilla.org."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:70
-msgid ""
-"Your add-on is displayed in our gallery as experimental\n"
-"                             and users are receiving automatic updates. Some features\n"
-"                             are unavailable to your add-on."
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:62
+msgid "Your add-on is displayed in our gallery as experimental and users are receiving automatic updates. Some features are unavailable to your add-on."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:74
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:66
 msgid "Your add-on has been signed."
 msgstr ""
 
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:69
+msgid ""
+"You will receive an email when the full review is complete. Until then, your add-on is displayed in our gallery as experimental and users are receiving automatic updates. Some features are "
+"unavailable to your add-on."
+msgstr ""
+
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:74
+msgid "You will receive an email when the full review is complete, making you able to bundle your add-on with an application installer."
+msgstr ""
+
 #: src/olympia/devhub/templates/devhub/includes/addon_details.html:79
-msgid ""
-"You will receive an email when the full review is complete.\n"
-"                             Until then, your add-on is displayed in our gallery as\n"
-"                             experimental and users are receiving automatic updates.\n"
-"                             Some features are unavailable to your add-on."
+msgid "All add-ons hosted in our gallery must now be reviewed by an editor. If you wish to continue hosting your add-on, please click to select a review process."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:84
-msgid ""
-"You will receive an email when the full review is\n"
-"                             complete, making you able to bundle your add-on with an\n"
-"                             application installer."
-msgstr ""
-
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:91
-msgid ""
-"All add-ons hosted in our gallery must now be reviewed by an\n"
-"                             editor. If you wish to continue hosting your add-on, please\n"
-"                             click to select a review process."
-msgstr ""
-
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:113
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:100
 msgid "Current Version:"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:115
-msgid ""
-"This is the version of your add-on that will\n"
-"                                           be installed if someone clicks the Install\n"
-"                                           button on addons.mozilla.org. It is only\n"
-"                                           relevant for listed add-ons."
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:102
+msgid "This is the version of your add-on that will be installed if someone clicks the Install button on addons.mozilla.org. It is only relevant for listed add-ons."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:123
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:110
 msgid "Created:"
 msgstr ""
 
 #. {0} is a date. dennis-ignore: E201
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:125 src/olympia/devhub/templates/devhub/includes/addon_details.html:131
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:112 src/olympia/devhub/templates/devhub/includes/addon_details.html:118
 #, python-format
 msgid "%%b %%e, %%Y"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:136
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:123
 msgid "Next Version:"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:138
-msgid ""
-"This is the newest uploaded version, however\n"
-"                                           it isn’t live on the site yet."
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:125
+msgid "This is the newest uploaded version, however it isn’t live on the site yet."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:144 src/olympia/devhub/templates/devhub/versions/list.html:30
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:130 src/olympia/devhub/templates/devhub/versions/list.html:30
 msgid "Queues are not reviewed strictly in order"
 msgstr ""
 
@@ -6174,9 +6070,7 @@ msgid "View the blog &#9658;"
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/includes/license_form.html:6
-msgid ""
-"Please choose a license appropriate for the rights you grant on your source code.\n"
-"                  It is only relevant for listed add-ons."
+msgid "Please choose a license appropriate for the rights you grant on your source code. It is only relevant for listed add-ons."
 msgstr ""
 
 #. {0} is a list of HTML tags.
@@ -6203,14 +6097,11 @@ msgstr[1] ""
 #: src/olympia/devhub/templates/devhub/includes/policy_form.html:4
 msgid ""
 "Users will be required to accept the following End-User License Agreement (EULA) prior to installing your add-on. The presence of a EULA significantly affects the number of downloads an add-on "
-"receives. Please note that a EULA is not the same as a code license, such as the GPL or MPL.\n"
-"                It is only relevant for listed add-ons."
+"receives. Please note that a EULA is not the same as a code license, such as the GPL or MPL.It is only relevant for listed add-ons."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/policy_form.html:21
-msgid ""
-"If your add-on transmits any data from the user's computer, a privacy policy is required that explains what data is sent and how it is used.\n"
-"                It is only relevant for listed add-ons."
+#: src/olympia/devhub/templates/devhub/includes/policy_form.html:24
+msgid "If your add-on transmits any data from the user's computer, a privacy policy is required that explains what data is sent and how it is used. It is only relevant for listed add-ons."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/includes/source_form_field.html:2
@@ -6378,12 +6269,8 @@ msgstr ""
 msgid "Add some tags to describe your Theme."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/personas/edit.html:106
-msgid ""
-"A short explanation of your theme's\n"
-"                                basic functionality that is displayed in\n"
-"                                search and browse listings, as well as at\n"
-"                                the top of your theme's details page."
+#: src/olympia/devhub/templates/devhub/personas/edit.html:106 src/olympia/devhub/templates/devhub/personas/submit.html:54
+msgid "A short explanation of your theme's basic functionality that is displayed in search and browse listings, as well as at the top of your theme's details page."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/personas/edit.html:122 src/olympia/devhub/templates/devhub/personas/submit.html:68
@@ -6522,14 +6409,6 @@ msgstr ""
 msgid "Give your Theme a name."
 msgstr "আপনার থিমের একটি নাম দিন।"
 
-#: src/olympia/devhub/templates/devhub/personas/submit.html:54
-msgid ""
-"A short explanation of your theme's\n"
-"                                      basic functionality that is displayed in\n"
-"                                      search and browse listings, as well as at\n"
-"                                      the top of your theme's details page."
-msgstr ""
-
 #: src/olympia/devhub/templates/devhub/personas/submit.html:198
 #, python-format
 msgid ""
@@ -6604,30 +6483,16 @@ msgstr ""
 msgid "Files added to reviewed versions must be reviewed before they will be available for download."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/add_file_modal.html:15
-#, python-format
-msgid ""
-"Submission of updates to unlisted add-ons for signing is currently in an open beta. Manual review may still be required for a large number of add-ons. Please <a href=\"%(url)s\" target=\"_blank"
-"\">report any bugs</a> that you encounter."
-msgstr ""
-
-#: src/olympia/devhub/templates/devhub/versions/add_file_modal.html:35
+#: src/olympia/devhub/templates/devhub/versions/add_file_modal.html:24
 msgid "Select the target platform for this file."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/add_file_modal.html:46
+#: src/olympia/devhub/templates/devhub/versions/add_file_modal.html:35
 msgid "Which review type would you like to nominate for?"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/add_file_modal.html:51
+#: src/olympia/devhub/templates/devhub/versions/add_file_modal.html:40
 msgid "Only publish this version to my beta channel."
-msgstr ""
-
-#: src/olympia/devhub/templates/devhub/versions/add_file_modal.html:54
-#, python-format
-msgid ""
-"The behavior of the beta channel has changed to accommodate <a href=\"%(addon_signing_url)s\" target=\"_blank\">mandatory add-on signing</a>. The new process is currently in an open beta, and may "
-"change significantly in the near future. Please <a href=\"%(issues_url)s\" target=\"_blank\">report any bugs</a> that you encounter."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/versions/edit.html:5
@@ -6651,19 +6516,10 @@ msgstr ""
 msgid "Upload Another File"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/edit.html:45
-msgid ""
-"Adjusting application information here will allow users to install your\n"
-"                          add-on even if the install manifest in the package indicates that the\n"
-"                          add-on is incompatible."
-msgstr ""
-
 #: src/olympia/devhub/templates/devhub/versions/edit.html:74
 msgid ""
-"Information about changes in this release, new features,\n"
-"                              known bugs, and other useful information specific to this\n"
-"                              release/version. This information is also shown in the\n"
-"                              Add-ons Manager when updating."
+"Information about changes in this release, new features, known bugs, and other useful information specific to this release/version. This information is also shown in the Add-ons Manager when "
+"updating."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/versions/edit.html:99
@@ -6675,10 +6531,7 @@ msgid "Notes for Reviewers"
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/versions/edit.html:114
-msgid ""
-"Optionally, enter any information that may be useful\n"
-"                              to the Editor reviewing this add-on, such as test\n"
-"                              account information."
+msgid "Optionally, enter any information that may be useful to the Editor reviewing this add-on, such as test account information."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/versions/edit.html:127
@@ -6756,7 +6609,7 @@ msgstr ""
 msgid "Request Preliminary Review"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:80 src/olympia/devhub/templates/devhub/versions/list.html:327 src/olympia/devhub/templates/devhub/versions/list.html:350
+#: src/olympia/devhub/templates/devhub/versions/list.html:80 src/olympia/devhub/templates/devhub/versions/list.html:325 src/olympia/devhub/templates/devhub/versions/list.html:348
 msgid "Cancel Review Request"
 msgstr ""
 
@@ -6785,7 +6638,7 @@ msgid "Unlisted:"
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/versions/list.html:114
-msgid "Not distributed on {0}. Developers will upload new versions for signing and distribute the add-ons on their own. (beta)"
+msgid "Not distributed on {0}. Developers will upload new versions for signing and distribute the add-ons on their own."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/versions/list.html:122
@@ -6848,81 +6701,73 @@ msgid "<strong>Important:</strong> Once a version has been deleted, you may not 
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/versions/list.html:230
-msgid ""
-"Deleting a version which has already been reviewed\n"
-"               may also cause a significant delay in the review of\n"
-"               your next update."
-msgstr ""
-
-#: src/olympia/devhub/templates/devhub/versions/list.html:233
 msgid "Are you sure you wish to delete this version?"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:238
+#: src/olympia/devhub/templates/devhub/versions/list.html:235
 msgid "Delete Version"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:240
+#: src/olympia/devhub/templates/devhub/versions/list.html:237
 msgid "Disable Version"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:247
+#: src/olympia/devhub/templates/devhub/versions/list.html:244
 msgid "Add a new Version"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:249
+#: src/olympia/devhub/templates/devhub/versions/list.html:246
 msgid "Add Version"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:256 src/olympia/devhub/templates/devhub/versions/list.html:274
+#: src/olympia/devhub/templates/devhub/versions/list.html:253 src/olympia/devhub/templates/devhub/versions/list.html:279
 msgid "Hide Add-on"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:259
+#: src/olympia/devhub/templates/devhub/versions/list.html:256
 msgid "Hiding your add-on will prevent it from appearing anywhere in our gallery and will stop users from receiving automatic updates."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:265
+#: src/olympia/devhub/templates/devhub/versions/list.html:263
+msgid "The files awaiting review will be disabled and you will need to upload new versions."
+msgstr ""
+
+#: src/olympia/devhub/templates/devhub/versions/list.html:270
 msgid "Are you sure you wish to hide your add-on?"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:286 src/olympia/devhub/templates/devhub/versions/list.html:315
+#: src/olympia/devhub/templates/devhub/versions/list.html:291 src/olympia/devhub/templates/devhub/versions/list.html:313
 msgid "Unlist Add-on"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:289
+#: src/olympia/devhub/templates/devhub/versions/list.html:294
 #, python-format
 msgid ""
 "Unlisting your add-on will make it (and each of its versions/files) invisible on this website. It won't show up in searches, won't have a public facing page, and won't be updated automatically for "
-"current users.  It is recommended for unlisted add-ons to provide a custom <a href=\"%(update_url)s\" target=\"_blank\">updateURL</a> in their manifest file for automatic updates."
+"current users. It is recommended for unlisted add-ons to provide a custom <a href=\"%(update_url)s\" target=\"_blank\">updateURL</a> in their manifest file for automatic updates."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:299
-#, python-format
-msgid "Switching add-ons to unlisted is currently in an open beta. Please <a href=\"%(url)s\" target=\"_blank\">report any bugs</a> that you encounter."
-msgstr ""
-
-#: src/olympia/devhub/templates/devhub/versions/list.html:305
+#: src/olympia/devhub/templates/devhub/versions/list.html:303
 msgid "Unlisting an add-on is irreversible!"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:305
+#: src/olympia/devhub/templates/devhub/versions/list.html:303
 msgid "An unlisted add-on cannot be switched to be listed."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:307
+#: src/olympia/devhub/templates/devhub/versions/list.html:305
 msgid "Are you sure you wish to unlist your add-on?"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:330
+#: src/olympia/devhub/templates/devhub/versions/list.html:328
 msgid "Canceling your review request will leave your add-on as preliminarily reviewed."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:335
+#: src/olympia/devhub/templates/devhub/versions/list.html:333
 msgid "Canceling your review request will mark your add-on incomplete. If you do not complete your add-on after several days by re-requesting review, it will be deleted."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:343
+#: src/olympia/devhub/templates/devhub/versions/list.html:341
 msgid "Are you sure you wish to cancel your review request?"
 msgstr ""
 
@@ -7261,19 +7106,19 @@ msgstr ""
 msgid "Search by add-on name / author email"
 msgstr ""
 
-#: src/olympia/editors/forms.py:103
+#: src/olympia/editors/forms.py:103 src/olympia/editors/forms.py:244 src/olympia/editors/forms.py:257
 msgid "yes"
 msgstr ""
 
-#: src/olympia/editors/forms.py:104
+#: src/olympia/editors/forms.py:104 src/olympia/editors/forms.py:244 src/olympia/editors/forms.py:257
 msgid "no"
 msgstr ""
 
-#: src/olympia/editors/forms.py:105
+#: src/olympia/editors/forms.py:105 src/olympia/editors/forms.py:245
 msgid "Admin Flag"
 msgstr ""
 
-#: src/olympia/editors/forms.py:113
+#: src/olympia/editors/forms.py:113 src/olympia/editors/forms.py:253
 msgid "Max. Version"
 msgstr ""
 
@@ -7285,55 +7130,59 @@ msgstr ""
 msgid "Add-on Types"
 msgstr ""
 
-#: src/olympia/editors/forms.py:126 src/olympia/editors/helpers.py:267
+#: src/olympia/editors/forms.py:126 src/olympia/editors/helpers.py:279
 msgid "Platforms"
 msgstr ""
 
+#: src/olympia/editors/forms.py:237
+msgid "Search by add-on name / author email / guid"
+msgstr ""
+
 #. L10n: 0 = platform, 1 = filename, 2 = status message
-#: src/olympia/editors/forms.py:238
+#: src/olympia/editors/forms.py:342
 #, python-format
 msgid "<strong>%s</strong> &middot; %s &middot; %s"
 msgstr ""
 
-#: src/olympia/editors/forms.py:252
+#: src/olympia/editors/forms.py:356
 msgid "Comments:"
 msgstr ""
 
-#: src/olympia/editors/forms.py:256
+#: src/olympia/editors/forms.py:360
 msgid "Operating systems:"
 msgstr ""
 
-#: src/olympia/editors/forms.py:258
+#: src/olympia/editors/forms.py:362
 msgid "Applications:"
 msgstr ""
 
-#: src/olympia/editors/forms.py:260
+#: src/olympia/editors/forms.py:364
 msgid "Notify me the next time this add-on is updated. (Subsequent updates will not generate an email)"
 msgstr ""
 
-#: src/olympia/editors/forms.py:265
+#: src/olympia/editors/forms.py:369
 msgid "Clear Admin Review Flag"
 msgstr ""
 
-#: src/olympia/editors/forms.py:267
+#: src/olympia/editors/forms.py:371
 msgid "Clear more info requested flag"
 msgstr ""
 
-#: src/olympia/editors/forms.py:281
+#: src/olympia/editors/forms.py:385
 msgid "Choose a canned response..."
 msgstr ""
 
 #. L10n: Description of what can be searched for.
-#: src/olympia/editors/forms.py:324
+#: src/olympia/editors/forms.py:423
 msgid "theme name"
 msgstr ""
 
-#: src/olympia/editors/forms.py:350
+#: src/olympia/editors/forms.py:449
 msgid "Someone else is reviewing this theme."
 msgstr ""
 
 #. L10n: Description of what can be searched for.
-#: src/olympia/editors/forms.py:447
+#: src/olympia/editors/forms.py:546
 msgid "app, reviewer, or comment"
 msgstr ""
 
@@ -7349,246 +7198,264 @@ msgstr ""
 msgid "Rejected or Unreviewed"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:123 src/olympia/editors/helpers.py:136
+#: src/olympia/editors/helpers.py:125 src/olympia/editors/helpers.py:138
 msgid "Queue"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:124 src/olympia/editors/templates/editors/base.html:50 src/olympia/editors/templates/editors/base.html:65
+#: src/olympia/editors/helpers.py:126 src/olympia/editors/templates/editors/base.html:50 src/olympia/editors/templates/editors/base.html:65
 msgid "Pending Updates"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:125 src/olympia/editors/templates/editors/base.html:48 src/olympia/editors/templates/editors/base.html:63
+#: src/olympia/editors/helpers.py:127 src/olympia/editors/templates/editors/base.html:48 src/olympia/editors/templates/editors/base.html:63
 msgid "Full Reviews"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:126 src/olympia/editors/templates/editors/base.html:52 src/olympia/editors/templates/editors/base.html:67
+#: src/olympia/editors/helpers.py:128 src/olympia/editors/templates/editors/base.html:52 src/olympia/editors/templates/editors/base.html:67
 msgid "Preliminary Reviews"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:127 src/olympia/editors/templates/editors/base.html:54
+#: src/olympia/editors/helpers.py:129 src/olympia/editors/templates/editors/base.html:54
 msgid "Moderated Reviews"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:128 src/olympia/editors/templates/editors/base.html:46
+#: src/olympia/editors/helpers.py:130 src/olympia/editors/templates/editors/base.html:46
 msgid "Fast Track"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:130
+#: src/olympia/editors/helpers.py:132
 msgid "Pending Themes"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:131 src/olympia/editors/templates/editors/themes/queue.html:4
+#: src/olympia/editors/helpers.py:133 src/olympia/editors/templates/editors/themes/queue.html:4
 msgid "Flagged Themes"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:132
+#: src/olympia/editors/helpers.py:134
 msgid "Update Themes"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:137
+#: src/olympia/editors/helpers.py:139
 msgid "Unlisted Pending Updates"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:138
+#: src/olympia/editors/helpers.py:140
 msgid "Unlisted Full Reviews"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:139
+#: src/olympia/editors/helpers.py:141
 msgid "Unlisted Preliminary Reviews"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:170
+#: src/olympia/editors/helpers.py:142
+msgid "Unlisted All Add-ons"
+msgstr ""
+
+#: src/olympia/editors/helpers.py:173
 msgid "Fast Track ({0})"
 msgid_plural "Fast Track ({0})"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/olympia/editors/helpers.py:175
+#: src/olympia/editors/helpers.py:178
 msgid "Full Review ({0})"
 msgid_plural "Full Reviews ({0})"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/olympia/editors/helpers.py:180
+#: src/olympia/editors/helpers.py:183
 msgid "Pending Update ({0})"
 msgid_plural "Pending Updates ({0})"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/olympia/editors/helpers.py:185
+#: src/olympia/editors/helpers.py:188
 msgid "Preliminary Review ({0})"
 msgid_plural "Preliminary Reviews ({0})"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/olympia/editors/helpers.py:190
+#: src/olympia/editors/helpers.py:193
 msgid "Moderated Review ({0})"
 msgid_plural "Moderated Reviews ({0})"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/olympia/editors/helpers.py:196
+#: src/olympia/editors/helpers.py:199
 msgid "Unlisted Full Review ({0})"
 msgid_plural "Unlisted Full Reviews ({0})"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/olympia/editors/helpers.py:201
+#: src/olympia/editors/helpers.py:204
 msgid "Unlisted Pending Update ({0})"
 msgid_plural "Unlisted Pending Updates ({0})"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/olympia/editors/helpers.py:206
+#: src/olympia/editors/helpers.py:209
 msgid "Unlisted Preliminary Review ({0})"
 msgid_plural "Unlisted Preliminary Reviews ({0})"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/olympia/editors/helpers.py:261
-msgid "Addon"
-msgstr ""
+#: src/olympia/editors/helpers.py:214
+msgid "Unlisted All Add-ons ({0})"
+msgid_plural "Unlisted All Add-ons ({0})"
+msgstr[0] ""
+msgstr[1] ""
 
-#: src/olympia/editors/helpers.py:262
+#: src/olympia/editors/helpers.py:274
 msgid "Type"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:263
+#: src/olympia/editors/helpers.py:275
 msgid "Waiting Time"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:264 src/olympia/editors/templates/editors/review.html:285
+#: src/olympia/editors/helpers.py:276 src/olympia/editors/templates/editors/review.html:285
 msgid "Flags"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:265
+#: src/olympia/editors/helpers.py:277
 msgid "Applications"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:270
+#: src/olympia/editors/helpers.py:282
 msgid "Additional"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:285
+#: src/olympia/editors/helpers.py:302
 msgid "Site Specific"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:287
+#: src/olympia/editors/helpers.py:304
 msgid "Requires External Software"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:289
+#: src/olympia/editors/helpers.py:306
 msgid "Binary Components"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:313
+#: src/olympia/editors/helpers.py:339
 msgid "moments ago"
 msgstr ""
 
 #. L10n: first argument is number of minutes
-#: src/olympia/editors/helpers.py:316
+#: src/olympia/editors/helpers.py:342
 msgid "{0} minute"
 msgid_plural "{0} minutes"
 msgstr[0] ""
 msgstr[1] ""
 
 #. L10n: first argument is number of hours
-#: src/olympia/editors/helpers.py:320
+#: src/olympia/editors/helpers.py:346
 msgid "{0} hour"
 msgid_plural "{0} hours"
 msgstr[0] ""
 msgstr[1] ""
 
 #. L10n: first argument is number of days
-#: src/olympia/editors/helpers.py:324
+#: src/olympia/editors/helpers.py:350
 msgid "{0} day"
 msgid_plural "{0} days"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/olympia/editors/helpers.py:488
+#: src/olympia/editors/helpers.py:364
+msgid "Last Review"
+msgstr ""
+
+#: src/olympia/editors/helpers.py:366
+msgid "Last Update"
+msgstr ""
+
+#: src/olympia/editors/helpers.py:387
+msgid "No Reviews"
+msgstr ""
+
+#: src/olympia/editors/helpers.py:561
 msgid "Push to public"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:490
+#: src/olympia/editors/helpers.py:563
 msgid "Grant full review"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:505
+#: src/olympia/editors/helpers.py:578
 msgid "Request more information"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:508
+#: src/olympia/editors/helpers.py:581
 msgid "Request super-review"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:519
+#: src/olympia/editors/helpers.py:592
 msgid "Grant preliminary review"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:520
+#: src/olympia/editors/helpers.py:593
 msgid "This will mark the files as preliminarily reviewed."
 msgstr ""
 
-#: src/olympia/editors/helpers.py:522
+#: src/olympia/editors/helpers.py:595
 msgid "Use this form to request more information from the author. They will receive an email and be able to answer here. You will be notified by email when they reply."
 msgstr ""
 
-#: src/olympia/editors/helpers.py:526
+#: src/olympia/editors/helpers.py:599
 msgid ""
 "If you have concerns about this add-on's security, copyright issues, or other concerns that an administrator should look into, enter your comments in the area below. They will be sent to "
 "administrators, not the author."
 msgstr ""
 
-#: src/olympia/editors/helpers.py:532
+#: src/olympia/editors/helpers.py:605
 msgid "This will reject the add-on and remove it from the review queue."
 msgstr ""
 
-#: src/olympia/editors/helpers.py:534
-msgid "Make a comment on this version.  The author won't be able to see this."
+#: src/olympia/editors/helpers.py:607
+msgid "Make a comment on this version. The author won't be able to see this."
 msgstr ""
 
-#: src/olympia/editors/helpers.py:538
+#: src/olympia/editors/helpers.py:611
 msgid "This will reject the files and remove them from the review queue."
 msgstr ""
 
-#: src/olympia/editors/helpers.py:542
+#: src/olympia/editors/helpers.py:615
 msgid "This will mark the add-on as preliminarily reviewed. Future versions will undergo preliminary review."
 msgstr ""
 
-#: src/olympia/editors/helpers.py:547
+#: src/olympia/editors/helpers.py:620
 msgid "This will mark the files as preliminarily reviewed. Future versions will undergo preliminary review."
 msgstr ""
 
-#: src/olympia/editors/helpers.py:552
+#: src/olympia/editors/helpers.py:625
 msgid "Retain preliminary review"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:553
+#: src/olympia/editors/helpers.py:626
 msgid "This will retain the add-on as preliminarily reviewed. Future versions will undergo preliminary review."
 msgstr ""
 
-#: src/olympia/editors/helpers.py:558
+#: src/olympia/editors/helpers.py:631
 msgid "This will approve a sandboxed version of a public add-on to appear on the public side."
 msgstr ""
 
-#: src/olympia/editors/helpers.py:561
+#: src/olympia/editors/helpers.py:634
 msgid "This will reject a version of a public add-on and remove it from the queue."
 msgstr ""
 
-#: src/olympia/editors/helpers.py:564
+#: src/olympia/editors/helpers.py:637
 msgid "This will mark the add-on and its most recent version and files as public. Future versions will go into the sandbox until they are reviewed by an editor."
 msgstr ""
 
-#: src/olympia/editors/helpers.py:637
+#: src/olympia/editors/helpers.py:714
 msgid "add-on"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:940 src/olympia/editors/helpers.py:960
+#: src/olympia/editors/helpers.py:1020 src/olympia/editors/helpers.py:1040
 msgid "Flagged"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:944 src/olympia/editors/helpers.py:963
+#: src/olympia/editors/helpers.py:1024 src/olympia/editors/helpers.py:1043
 msgid "Updates"
 msgstr ""
 
@@ -7640,56 +7507,56 @@ msgstr ""
 msgid "A question about your Theme submission"
 msgstr ""
 
-#: src/olympia/editors/views.py:144
+#: src/olympia/editors/views.py:146
 msgid "New Add-ons (Under 5 days)"
 msgstr ""
 
-#: src/olympia/editors/views.py:145
+#: src/olympia/editors/views.py:147
 msgid "Passable (5 to 10 days)"
 msgstr ""
 
-#: src/olympia/editors/views.py:146
+#: src/olympia/editors/views.py:148
 msgid "Overdue (Over 10 days)"
 msgstr ""
 
-#: src/olympia/editors/views.py:532
+#: src/olympia/editors/views.py:539
 msgid "An unknown error occurred"
 msgstr ""
 
-#: src/olympia/editors/views.py:587
+#: src/olympia/editors/views.py:592
 msgid "Self-reviews are not allowed."
 msgstr ""
 
-#: src/olympia/editors/views.py:609
+#: src/olympia/editors/views.py:613
 msgid "Review successfully processed."
 msgstr ""
 
-#: src/olympia/editors/views.py:807
+#: src/olympia/editors/views.py:812
 msgid "was approved"
 msgstr ""
 
-#: src/olympia/editors/views.py:808
+#: src/olympia/editors/views.py:813
 msgid "given preliminary review"
 msgstr ""
 
-#: src/olympia/editors/views.py:809
+#: src/olympia/editors/views.py:814
 msgid "rejected"
 msgstr ""
 
-#: src/olympia/editors/views.py:810
+#: src/olympia/editors/views.py:815
 msgctxt "editors_review_history_nominated_adminreview"
 msgid "escalated"
 msgstr ""
 
-#: src/olympia/editors/views.py:812
+#: src/olympia/editors/views.py:817
 msgid "needs more information"
 msgstr ""
 
-#: src/olympia/editors/views.py:813
+#: src/olympia/editors/views.py:818
 msgid "needs super review"
 msgstr ""
 
-#: src/olympia/editors/views.py:814
+#: src/olympia/editors/views.py:819
 msgid "commented"
 msgstr ""
 
@@ -7734,28 +7601,28 @@ msgstr ""
 msgid "Unlisted Queues"
 msgstr ""
 
-#: src/olympia/editors/templates/editors/base.html:72 src/olympia/editors/templates/editors/performance.html:6
+#: src/olympia/editors/templates/editors/base.html:74 src/olympia/editors/templates/editors/performance.html:6
 msgid "Performance"
 msgstr ""
 
-#: src/olympia/editors/templates/editors/base.html:75 src/olympia/editors/templates/editors/themes/base.html:19 src/olympia/editors/templates/editors/themes/base.html:38
+#: src/olympia/editors/templates/editors/base.html:77 src/olympia/editors/templates/editors/themes/base.html:19 src/olympia/editors/templates/editors/themes/base.html:38
 msgid "Logs"
 msgstr ""
 
-#: src/olympia/editors/templates/editors/base.html:78 src/olympia/editors/templates/editors/reviewlog.html:4 src/olympia/editors/templates/editors/reviewlog.html:27
+#: src/olympia/editors/templates/editors/base.html:80 src/olympia/editors/templates/editors/reviewlog.html:4 src/olympia/editors/templates/editors/reviewlog.html:27
 msgid "Add-on Review Log"
 msgstr ""
 
-#: src/olympia/editors/templates/editors/base.html:80 src/olympia/editors/templates/editors/eventlog.html:4 src/olympia/editors/templates/editors/eventlog.html:8
+#: src/olympia/editors/templates/editors/base.html:82 src/olympia/editors/templates/editors/eventlog.html:4 src/olympia/editors/templates/editors/eventlog.html:8
 #: src/olympia/editors/templates/editors/eventlog_detail.html:4
 msgid "Moderated Review Log"
 msgstr ""
 
-#: src/olympia/editors/templates/editors/base.html:82 src/olympia/editors/templates/editors/beta_signed_log.html:4 src/olympia/editors/templates/editors/beta_signed_log.html:8
+#: src/olympia/editors/templates/editors/base.html:84 src/olympia/editors/templates/editors/beta_signed_log.html:4 src/olympia/editors/templates/editors/beta_signed_log.html:8
 msgid "Signed Beta Files Log"
 msgstr ""
 
-#: src/olympia/editors/templates/editors/base.html:87 src/olympia/editors/templates/editors/includes/daily-message.html:4
+#: src/olympia/editors/templates/editors/base.html:89 src/olympia/editors/templates/editors/includes/daily-message.html:4
 msgid "Announcement"
 msgstr ""
 
@@ -7976,45 +7843,45 @@ msgstr ""
 msgid "clear search"
 msgstr ""
 
-#: src/olympia/editors/templates/editors/queue.html:72 src/olympia/editors/templates/editors/queue.html:122
+#: src/olympia/editors/templates/editors/queue.html:78 src/olympia/editors/templates/editors/queue.html:128
 msgid "Process Reviews"
 msgstr ""
 
-#: src/olympia/editors/templates/editors/queue.html:80
+#: src/olympia/editors/templates/editors/queue.html:86
 msgid "Moderation actions:"
 msgstr ""
 
-#: src/olympia/editors/templates/editors/queue.html:90
+#: src/olympia/editors/templates/editors/queue.html:96
 #, python-format
 msgid "by %(user)s on %(date)s %(stars)s (%(locale)s)"
 msgstr ""
 
-#: src/olympia/editors/templates/editors/queue.html:106
+#: src/olympia/editors/templates/editors/queue.html:112
 #, python-format
 msgid "<strong>%(reason)s</strong> <span class=\"light\">Flagged by %(user)s on %(date)s</span>"
 msgstr ""
 
-#: src/olympia/editors/templates/editors/queue.html:119
-msgid "All reviews have been moderated.  Good work!"
+#: src/olympia/editors/templates/editors/queue.html:125
+msgid "All reviews have been moderated. Good work!"
 msgstr ""
 
-#: src/olympia/editors/templates/editors/queue.html:161
+#: src/olympia/editors/templates/editors/queue.html:167
 msgid "Version Notes / Notes for Reviewer"
 msgstr ""
 
-#: src/olympia/editors/templates/editors/queue.html:169
+#: src/olympia/editors/templates/editors/queue.html:175
 msgid "There are currently no add-ons of this type to review."
 msgstr ""
 
-#: src/olympia/editors/templates/editors/queue.html:181 src/olympia/editors/templates/editors/themes/queue_list.html:85
+#: src/olympia/editors/templates/editors/queue.html:187 src/olympia/editors/templates/editors/themes/queue_list.html:85
 msgid "Helpful Links:"
 msgstr ""
 
-#: src/olympia/editors/templates/editors/queue.html:182
+#: src/olympia/editors/templates/editors/queue.html:188
 msgid "Add-on Policy"
 msgstr ""
 
-#: src/olympia/editors/templates/editors/queue.html:184
+#: src/olympia/editors/templates/editors/queue.html:190
 msgid "Editors' Guide"
 msgstr ""
 
@@ -8077,10 +7944,7 @@ msgid "<strong>Warning!</strong> Another user was viewing this page before you."
 msgstr ""
 
 #: src/olympia/editors/templates/editors/review.html:237
-msgid ""
-"The whiteboard is the place to exchange information relevant to\n"
-"               this addon (whatever the version), between the developer and the\n"
-"               editor. This is visible and editable by both."
+msgid "The whiteboard is the place to exchange information relevant to this addon (whatever the version), between the developer and the editor. This is visible and editable by both."
 msgstr ""
 
 #: src/olympia/editors/templates/editors/review.html:241
@@ -8354,7 +8218,7 @@ msgstr ""
 msgid "Describe your reason for flagging"
 msgstr ""
 
-#: src/olympia/files/forms.py:88
+#: src/olympia/files/forms.py:90
 msgid "Cannot diff a version against itself"
 msgstr ""
 
@@ -8389,51 +8253,51 @@ msgstr ""
 msgid "There was an error accessing file %s."
 msgstr ""
 
-#: src/olympia/files/utils.py:343
+#: src/olympia/files/utils.py:340
 msgid "Could not parse uploaded file."
 msgstr ""
 
-#: src/olympia/files/utils.py:380
+#: src/olympia/files/utils.py:377
 msgid "Invalid file name in archive: {0}"
 msgstr ""
 
-#: src/olympia/files/utils.py:388
+#: src/olympia/files/utils.py:385
 msgid "File exceeding size limit in archive: {0}"
 msgstr ""
 
-#: src/olympia/files/utils.py:439
+#: src/olympia/files/utils.py:436
 msgid "Invalid archive."
 msgstr ""
 
-#: src/olympia/files/utils.py:529 src/olympia/files/utils.py:532
+#: src/olympia/files/utils.py:526 src/olympia/files/utils.py:529
 msgid "Could not parse the manifest file."
 msgstr ""
 
-#: src/olympia/files/utils.py:551
+#: src/olympia/files/utils.py:548
 msgid "Could not find an add-on ID."
 msgstr ""
 
-#: src/olympia/files/utils.py:554
+#: src/olympia/files/utils.py:551
 msgid "Add-on ID must be 64 characters or less."
 msgstr ""
 
-#: src/olympia/files/utils.py:556
+#: src/olympia/files/utils.py:553
 msgid "Add-on ID doesn't match add-on."
 msgstr ""
 
-#: src/olympia/files/utils.py:564
+#: src/olympia/files/utils.py:561
 msgid "Duplicate add-on ID found."
 msgstr ""
 
-#: src/olympia/files/utils.py:567
+#: src/olympia/files/utils.py:564
 msgid "Version numbers should have fewer than 32 characters."
 msgstr ""
 
-#: src/olympia/files/utils.py:570
+#: src/olympia/files/utils.py:567
 msgid "Version numbers should only contain letters, numbers, and these punctuation characters: +*.-_."
 msgstr ""
 
-#: src/olympia/files/utils.py:587
+#: src/olympia/files/utils.py:584
 msgid "<em:type> doesn't match add-on"
 msgstr ""
 
@@ -8533,6 +8397,10 @@ msgstr ""
 #: src/olympia/files/templates/files/viewer.html:134
 msgid "Fetching file."
 msgstr ""
+
+#: src/olympia/legacy_api/views.py:255
+msgid "Not implemented yet."
+msgstr "এখনও বাস্তবায়িত হয়নি।"
 
 #: src/olympia/lib/constants.py:6
 msgid "United Arab Emirates Dirham"
@@ -9190,10 +9058,6 @@ msgstr ""
 msgid "Zimbabwe Dollar"
 msgstr ""
 
-#: src/olympia/lib/video/ffmpeg.py:112 src/olympia/lib/video/totem.py:81
-msgid "Videos must be in WebM."
-msgstr ""
-
 #: src/olympia/pages/templates/pages/about.lhtml:3 src/olympia/pages/templates/pages/about.lhtml:10
 msgid "About Mozilla Add-ons"
 msgstr ""
@@ -9205,7 +9069,7 @@ msgstr ""
 #: src/olympia/pages/templates/pages/about.lhtml:13
 msgid ""
 "addons.mozilla.org, commonly known as \"AMO\", is Mozilla's official site for add-ons to Mozilla software, such as Firefox, Thunderbird, and SeaMonkey. Add-ons let you add new features and change "
-"the way your browser or application works.  Take a look around and explore the thousands of ways to customize the way you do things online."
+"the way your browser or application works. Take a look around and explore the thousands of ways to customize the way you do things online."
 msgstr ""
 
 #: src/olympia/pages/templates/pages/about.lhtml:19
@@ -9550,7 +9414,7 @@ msgstr ""
 msgid ""
 "Yes. It's possible, but some of the functionality provided by these libraries are available through XPCOM, XUL, and JavaScript. In addition, authors should take care if libraries modify primitive "
 "object prototypes (String.prototype, Date.prototype, etc.) and/or define global functions (eg. the $ function). These are prone to cause conflict with other add-ons, in particular if different add-"
-"ons use different versions of libraries and so on. Developers need to be very, very careful with using them.  Mozilla does not offer documentation on using them to build add-ons."
+"ons use different versions of libraries and so on. Developers need to be very, very careful with using them. Mozilla does not offer documentation on using them to build add-ons."
 msgstr ""
 
 #: src/olympia/pages/templates/pages/dev_faq.html:165
@@ -9664,8 +9528,8 @@ msgstr ""
 #, python-format
 msgid ""
 "Yes. Many developers choose to host their own add-ons. Choosing to host your add-on on <a href=\"%(amo_url)s\">Mozilla's add-on site</a>, though, allows for much greater exposure to your add-on due "
-"to the large volume of visitors to the site.  <a href=\"%(md_url)s\">mozdev.org</a> offers free project hosting for Mozilla applications and extensions providing developers with tools to help "
-"manage source code, version control, bug tracking and documentation."
+"to the large volume of visitors to the site. <a href=\"%(md_url)s\">mozdev.org</a> offers free project hosting for Mozilla applications and extensions providing developers with tools to help manage "
+"source code, version control, bug tracking and documentation."
 msgstr ""
 
 #: src/olympia/pages/templates/pages/dev_faq.html:277
@@ -9713,7 +9577,7 @@ msgstr ""
 #: src/olympia/pages/templates/pages/dev_faq.html:314
 #, python-format
 msgid ""
-"Yes. Mozilla's <a href=\"%(p_url)s\">Add-on Policy</a> describes what is an acceptable submission. This policy is subject to change without notice.  In addition, the AMO editorial team uses the <a "
+"Yes. Mozilla's <a href=\"%(p_url)s\">Add-on Policy</a> describes what is an acceptable submission. This policy is subject to change without notice. In addition, the AMO editorial team uses the <a "
 "href=\"%(g_url)s\">Editors Reviewing Guide</a> to ensure that your add-on meets specific guidelines for functionality and security."
 msgstr ""
 
@@ -9830,7 +9694,7 @@ msgstr ""
 #: src/olympia/pages/templates/pages/dev_faq.html:434
 #, python-format
 msgid ""
-"This is why it's very important to read the <a href=\"%(g_url)s\">Editors Reviewing Guide</a> to ensure that your add-on is setup as expected.  It's also a good idea to read the blog post, <a href="
+"This is why it's very important to read the <a href=\"%(g_url)s\">Editors Reviewing Guide</a> to ensure that your add-on is setup as expected. It's also a good idea to read the blog post, <a href="
 "\"%(blog_url)s\">Successfully Getting your Add-on Reviewed</a> which provides excellent insight into ensuring a smooth review of your add-on."
 msgstr ""
 
@@ -9937,7 +9801,7 @@ msgstr ""
 
 #: src/olympia/pages/templates/pages/dev_faq.html:572
 msgid ""
-"Free Software Foundation provides short summaries of the key open source licenses, including whether the license qualifies as a free software license or a copyleft license.  Also includes a "
+"Free Software Foundation provides short summaries of the key open source licenses, including whether the license qualifies as a free software license or a copyleft license. Also includes a "
 "discussion of what constitutes a free software license or a copyleft license (e.g., a Copyleft license is a general method for making a program or other work free, and requiring all modified and "
 "extended versions of the program to be free as well.)"
 msgstr ""
@@ -10115,19 +9979,13 @@ msgid "Add-on Gallery"
 msgstr ""
 
 #: src/olympia/pages/templates/pages/faq.html:171
-msgid ""
-"How do I choose between add-ons that seem to do the same\n"
-"    thing?"
+msgid "How do I choose between add-ons that seem to do the same thing?"
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:173
+#: src/olympia/pages/templates/pages/faq.html:172
 msgid ""
-"There are often several add-ons that have similar features. To\n"
-"    figure out which is right for you, read the entire description of the\n"
-"    add-on and view its screenshots. If there are still several in the running,\n"
-"    read through the add-on's ratings, user reviews, and statistics to see\n"
-"    which is most liked by other users. Remember that you can also just try\n"
-"    out both and see which you like better."
+"There are often several add-ons that have similar features. To figure out which is right for you, read the entire description of the add-on and view its screenshots. If there are still several in "
+"the running, read through the add-on's ratings, user reviews, and statistics to see which is most liked by other users. Remember that you can also just try out both and see which you like better."
 msgstr ""
 
 #: src/olympia/pages/templates/pages/faq.html:180
@@ -10168,80 +10026,67 @@ msgid "How much do add-ons cost to purchase?"
 msgstr ""
 
 #: src/olympia/pages/templates/pages/faq.html:207
-msgid ""
-"Add-ons hosted in our gallery are free unless clearly marked\n"
-"    otherwise."
+msgid "Add-ons hosted in our gallery are free unless clearly marked otherwise."
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:210
+#: src/olympia/pages/templates/pages/faq.html:209
 msgid "What does it mean when an add-on asks for contributions?"
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:211
+#: src/olympia/pages/templates/pages/faq.html:210
 msgid ""
-"Some add-on authors request users who enjoy an add-on to\n"
-"        contribute to its development by making a monetary contribution. These\n"
-"        contributions go directly to the developer unless a third party is\n"
-"        indicated, such as the non-profit Mozilla Foundation."
+"Some add-on authors request users who enjoy an add-on to contribute to its development by making a monetary contribution. These contributions go directly to the developer unless a third party is "
+"indicated, such as the non-profit Mozilla Foundation."
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:216
+#: src/olympia/pages/templates/pages/faq.html:215
 msgid "What are beta add-ons?"
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:218
+#: src/olympia/pages/templates/pages/faq.html:217
 msgid ""
-"Beta add-ons are unreviewed versions which represent the\n"
-"        latest work of an add-on author. While different authors have different\n"
-"        standards for beta code quality, you should assume that these add-ons\n"
-"        are less stable than the general add-on releases."
+"Beta add-ons are unreviewed versions which represent the latest work of an add-on author. While different authors have different standards for beta code quality, you should assume that these add-"
+"ons are less stable than the general add-on releases."
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:222
+#: src/olympia/pages/templates/pages/faq.html:221
 msgid ""
 "Please note that when you install an add-on from the \"Beta Version\" section of an add-on's listing, you will continue to receive updates for that add-on as they become available. Like the initial "
 "version you installed, all beta releases are unreviewed by Mozilla and may harm your computer."
 msgstr ""
 
+#: src/olympia/pages/templates/pages/faq.html:228
+msgid "What does it mean when an add-on is flagged as slow?"
+msgstr ""
+
 #: src/olympia/pages/templates/pages/faq.html:229
-msgid ""
-"What does it mean when an add-on is flagged as\n"
-"    slow?"
+msgid "Most add-ons load code and resources at the same time Firefox is starting up. In most cases the impact in start-up time is minimal, but some add-ons can cause a noticeable slowdown."
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:231
-msgid ""
-"Most add-ons load code and resources at the same time Firefox\n"
-"        is starting up. In most cases the impact in start-up time is minimal,\n"
-"        but some add-ons can cause a noticeable slowdown."
-msgstr ""
-
-#: src/olympia/pages/templates/pages/faq.html:236
+#: src/olympia/pages/templates/pages/faq.html:234
 msgid "How do I report an inappropriate or spam user review?"
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:237
+#: src/olympia/pages/templates/pages/faq.html:235
 msgid ""
-"To report a user review of an add-on, log in with your account\n"
-"    and visit the add-on's reviews page. Find the review you wish to report,\n"
-"    click \"Report this review\" and select a reason. Our editorial team will\n"
-"    investigate the review and take appropriate action."
+"To report a user review of an add-on, log in with your account and visit the add-on's reviews page. Find the review you wish to report, click \"Report this review\" and select a reason. Our "
+"editorial team will investigate the review and take appropriate action."
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:242
+#: src/olympia/pages/templates/pages/faq.html:240
 msgid "How do I report a bug or contact the Mozilla Add-ons team?"
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:243
+#: src/olympia/pages/templates/pages/faq.html:241
 #, python-format
 msgid "Please visit our <a href=\"%(contact_url)s\">Contact page</a>."
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:246
+#: src/olympia/pages/templates/pages/faq.html:244
 msgid "What is a Source Code License?"
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:247
+#: src/olympia/pages/templates/pages/faq.html:245
 #, python-format
 msgid ""
 "The source code used to create an add-on is an exclusive copyright of the add-on author, unless otherwise declared in a source code license. Many add-ons on this site have <a href=\"%(url)s\" lang="
@@ -10249,60 +10094,60 @@ msgid ""
 "the GPL or BSD licenses instead of making up their own."
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:256
+#: src/olympia/pages/templates/pages/faq.html:254
 #, python-format
 msgid "Firefox and other Mozilla software are <a href=\"%(url)s\">open source</a>."
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:264
+#: src/olympia/pages/templates/pages/faq.html:262
 msgid "Collections and Favorites"
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:267
+#: src/olympia/pages/templates/pages/faq.html:265
 msgid "What is a collection?"
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:268
+#: src/olympia/pages/templates/pages/faq.html:266
 msgid "Collections are groups of related add-ons created by users to share."
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:270
+#: src/olympia/pages/templates/pages/faq.html:268
 msgid "What is the My Favorites collection?"
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:271
+#: src/olympia/pages/templates/pages/faq.html:269
 msgid "Favorite add-ons are add-ons that you have bookmarked to easily get back to later. You can add an add-on to your favorites collection by clicking \"Add to favorites\" on its details page."
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:275 src/olympia/templates/menu_links.html:13 src/olympia/templates/impala/header_title.html:17
+#: src/olympia/pages/templates/pages/faq.html:273 src/olympia/templates/menu_links.html:13 src/olympia/templates/impala/header_title.html:17
 msgid "Mobile Add-ons"
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:278
+#: src/olympia/pages/templates/pages/faq.html:276
 msgid "What are mobile add-ons?"
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:279
+#: src/olympia/pages/templates/pages/faq.html:277
 #, python-format
 msgid ""
 "Mobile add-ons work with <a href=\"%(mobile_url)s\">Firefox for Mobile</a> and add or modify functionality just like desktop add-ons. You can find add-ons that work with Firefox for Mobile in our "
 "<a href=\"%(gallery_url)s\">gallery</a>."
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:288
+#: src/olympia/pages/templates/pages/faq.html:286
 msgid "Developer Topics"
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:289
+#: src/olympia/pages/templates/pages/faq.html:287
 #, python-format
 msgid "Please see our <a href=\"%(faq_url)s\">Developer FAQ</a> and <a href=\"%(hub_url)s\">Developer Hub</a> for answers to add-on developer-related questions."
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:294
+#: src/olympia/pages/templates/pages/faq.html:292
 msgid "Still have questions?"
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:295
+#: src/olympia/pages/templates/pages/faq.html:293
 #, python-format
 msgid "For general Firefox support, visit our <a href=\"%(sumo_url)s\">support website</a>. For general add-on and website questions, visit our <a href=\"%(forum_url)s\">forum</a>."
 msgstr ""
@@ -10440,7 +10285,7 @@ msgstr ""
 
 #: src/olympia/pages/templates/pages/sunbird.html:29
 msgid ""
-"Development on the Sunbird project has halted and its final release was on March 30, 2010.  We've been proud to host Sunbird add-ons on this site but as the project is no longer maintained we have "
+"Development on the Sunbird project has halted and its final release was on March 30, 2010. We've been proud to host Sunbird add-ons on this site but as the project is no longer maintained we have "
 "disabled our support for the add-ons."
 msgstr ""
 
@@ -10518,7 +10363,7 @@ msgstr ""
 #, python-format
 msgid ""
 "<h2>Keep these tips in mind:</h2> <ul> <li> Write like you're telling a friend about your experience with the add-on. Give specifics and helpful details, such as what features you liked and/or "
-"disliked, how easy to use it is, and any disadvantages it has.  Avoid generic language such as calling it \"Great\" or \"Bad\" unless you can give reasons why you believe this is so. </li> <li> "
+"disliked, how easy to use it is, and any disadvantages it has. Avoid generic language such as calling it \"Great\" or \"Bad\" unless you can give reasons why you believe this is so. </li> <li> "
 "Please do not post bug reports in reviews. We do not make your email address available to add-on developers and they may need to contact you to help resolve your issue. See the <a href=\"%(support)s"
 "\">support section</a> to find out where to get assistance for this add-on. </li> <li>Please keep reviews clean, avoid the use of improper language and do not post any personal information. </li> </"
 "ul> <p>Please read the <a href=\"%(guide)s\" target=\"_blank\">Review Guidelines</a> for more detail about user add-on reviews.</p>"
@@ -10754,16 +10599,16 @@ msgstr ""
 
 #. L10n: {0} is an application, such as Firefox. This means "any version of
 #. Firefox."
-#: src/olympia/search/views.py:554
+#: src/olympia/search/views.py:547
 msgid "Any {0}"
 msgstr ""
 
 #. L10n: "All Systems" means show everything regardless of platform.
-#: src/olympia/search/views.py:589
+#: src/olympia/search/views.py:582
 msgid "All Systems"
 msgstr ""
 
-#: src/olympia/search/views.py:600
+#: src/olympia/search/views.py:593
 msgid "All Tags"
 msgstr ""
 
@@ -10937,31 +10782,31 @@ msgstr ""
 msgid "Share this Collection"
 msgstr ""
 
-#: src/olympia/signing/views.py:30 src/olympia/templates/base.html:75 src/olympia/templates/impala/base.html:115
+#: src/olympia/signing/views.py:33 src/olympia/templates/base.html:71 src/olympia/templates/impala/base.html:112
 msgid "Some features are temporarily disabled while we perform website maintenance. We'll be back to full capacity shortly."
 msgstr ""
 
-#: src/olympia/signing/views.py:53
+#: src/olympia/signing/views.py:56
 msgid "Could not find add-on with id \"{}\"."
 msgstr ""
 
-#: src/olympia/signing/views.py:67
+#: src/olympia/signing/views.py:70
 msgid "You do not own this addon."
 msgstr ""
 
-#: src/olympia/signing/views.py:82
+#: src/olympia/signing/views.py:87
 msgid "Missing \"upload\" key in multipart file data."
 msgstr ""
 
-#: src/olympia/signing/views.py:96
+#: src/olympia/signing/views.py:101
 msgid "Version does not match the manifest file."
 msgstr ""
 
-#: src/olympia/signing/views.py:100
+#: src/olympia/signing/views.py:105
 msgid "Version already exists."
 msgstr ""
 
-#: src/olympia/signing/views.py:136
+#: src/olympia/signing/views.py:141
 msgid "No uploaded file for that addon and version."
 msgstr ""
 
@@ -11074,89 +10919,89 @@ msgstr ""
 msgid "Statistics Dashboard :: Add-ons for {0}"
 msgstr ""
 
-#: src/olympia/stats/templates/stats/stats.html:30
-msgid "Controls:"
-msgstr ""
-
-#: src/olympia/stats/templates/stats/stats.html:33
-msgid "reset zoom"
-msgstr ""
-
-#: src/olympia/stats/templates/stats/stats.html:40
-msgid "Group by:"
-msgstr ""
-
-#: src/olympia/stats/templates/stats/stats.html:42
-msgid "day"
-msgstr ""
-
-#: src/olympia/stats/templates/stats/stats.html:45
-msgid "week"
-msgstr ""
-
-#: src/olympia/stats/templates/stats/stats.html:48
-msgid "month"
-msgstr ""
-
-#: src/olympia/stats/templates/stats/stats.html:54
-msgid "For last:"
-msgstr ""
-
-#: src/olympia/stats/templates/stats/stats.html:57
-msgid "7 days"
-msgstr ""
-
-#: src/olympia/stats/templates/stats/stats.html:60
-msgid "30 days"
-msgstr ""
-
-#: src/olympia/stats/templates/stats/stats.html:63
-msgid "90 days"
-msgstr ""
-
-#: src/olympia/stats/templates/stats/stats.html:66
-msgid "365 days"
-msgstr ""
-
-#: src/olympia/stats/templates/stats/stats.html:69
-msgid "Custom..."
-msgstr ""
-
 #. {0} is an add-on name
-#: src/olympia/stats/templates/stats/stats.html:88 src/olympia/stats/templates/stats/stats.html:91
+#: src/olympia/stats/templates/stats/stats.html:44 src/olympia/stats/templates/stats/stats.html:47
 msgid "Statistics for {0}"
 msgstr ""
 
-#: src/olympia/stats/templates/stats/stats.html:94
+#: src/olympia/stats/templates/stats/stats.html:50
 msgid "Statistics Dashboard"
 msgstr ""
 
-#: src/olympia/stats/templates/stats/stats.html:104
+#: src/olympia/stats/templates/stats/stats.html:57
+msgid "Controls:"
+msgstr ""
+
+#: src/olympia/stats/templates/stats/stats.html:60
+msgid "reset zoom"
+msgstr ""
+
+#: src/olympia/stats/templates/stats/stats.html:67
+msgid "Group by:"
+msgstr ""
+
+#: src/olympia/stats/templates/stats/stats.html:69
+msgid "day"
+msgstr ""
+
+#: src/olympia/stats/templates/stats/stats.html:72
+msgid "week"
+msgstr ""
+
+#: src/olympia/stats/templates/stats/stats.html:75
+msgid "month"
+msgstr ""
+
+#: src/olympia/stats/templates/stats/stats.html:81
+msgid "For last:"
+msgstr ""
+
+#: src/olympia/stats/templates/stats/stats.html:84
+msgid "7 days"
+msgstr ""
+
+#: src/olympia/stats/templates/stats/stats.html:87
+msgid "30 days"
+msgstr ""
+
+#: src/olympia/stats/templates/stats/stats.html:90
+msgid "90 days"
+msgstr ""
+
+#: src/olympia/stats/templates/stats/stats.html:93
+msgid "365 days"
+msgstr ""
+
+#: src/olympia/stats/templates/stats/stats.html:96
+msgid "Custom..."
+msgstr ""
+
+#: src/olympia/stats/templates/stats/stats.html:106
 msgid "Statistics processing is currently disabled, so recent data is unavailable. The statistics are still being collected and this page will be updated soon with the missing data."
 msgstr ""
 
-#: src/olympia/stats/templates/stats/stats.html:110
+#: src/olympia/stats/templates/stats/stats.html:112
 msgid "Loading the latest data&hellip;"
 msgstr ""
 
-#: src/olympia/stats/templates/stats/stats.html:142 src/olympia/stats/templates/stats/reports/overview.html:25 src/olympia/stats/templates/stats/reports/overview.html:37
+#: src/olympia/stats/templates/stats/stats.html:144 src/olympia/stats/templates/stats/reports/overview.html:25 src/olympia/stats/templates/stats/reports/overview.html:37
 #: src/olympia/stats/templates/stats/reports/overview.html:49
 msgid "No data available."
 msgstr ""
 
-#: src/olympia/stats/templates/stats/stats.html:177
+#: src/olympia/stats/templates/stats/stats.html:179
 msgid "This dashboard is currently <b>public</b>."
 msgstr ""
 
-#: src/olympia/stats/templates/stats/stats.html:179
+#: src/olympia/stats/templates/stats/stats.html:181
 msgid "Contribution stats are currently <b>private</b>."
 msgstr ""
 
-#: src/olympia/stats/templates/stats/stats.html:182
+#: src/olympia/stats/templates/stats/stats.html:184
 msgid "This dashboard is currently <b>private</b>."
 msgstr ""
 
-#: src/olympia/stats/templates/stats/stats.html:185
+#: src/olympia/stats/templates/stats/stats.html:187
 msgid "Change settings."
 msgstr ""
 
@@ -11308,15 +11153,6 @@ msgstr ""
 msgid "Application versions by Date"
 msgstr ""
 
-#: src/olympia/tags/templates/tags/top_cloud.html:4
-msgid "Top {0} Tags"
-msgstr ""
-
-#. {0} is the current application name
-#: src/olympia/tags/templates/tags/top_cloud.html:14
-msgid "{0} Top Tags"
-msgstr ""
-
 #: src/olympia/templates/amo_footer.html:6 src/olympia/templates/includes/lang_switcher.html:2
 msgid "Other languages"
 msgstr "অন্যান্য ভাষা"
@@ -11325,11 +11161,11 @@ msgstr "অন্যান্য ভাষা"
 msgid "Mozilla Add-ons"
 msgstr "মজিলা অ্যাড-অন"
 
-#: src/olympia/templates/base.html:91 src/olympia/templates/impala/base.html:81
+#: src/olympia/templates/base.html:89 src/olympia/templates/impala/base.html:78
 msgid "Find add-ons for other applications"
 msgstr "অন্য অ্যাপ্লিকেশনের জন্য অ্যাড-অন খুঁজুন"
 
-#: src/olympia/templates/base.html:92 src/olympia/templates/impala/base.html:81
+#: src/olympia/templates/base.html:90 src/olympia/templates/impala/base.html:78
 msgid "Other Applications"
 msgstr "অন্যান্য অ্যাপ্লিকেশন"
 
@@ -11354,7 +11190,7 @@ msgid "View Mobile Site"
 msgstr "মোবাইল সাইট দেখুন"
 
 #: src/olympia/templates/copyright.html:7
-msgid "Site Status "
+msgid "Site Status"
 msgstr ""
 
 #: src/olympia/templates/footer.html:3
@@ -11454,35 +11290,35 @@ msgstr "স্বাগতম, {0}"
 msgid "<a href=\"%(reg)s\">Register</a> or <a href=\"%(login)s\">Log in</a>"
 msgstr "<a href=\"%(reg)s\">রেজিস্টার</a> অথবা <a href=\"%(login)s\">লগ ইন</a>"
 
-#: src/olympia/templates/impala/base.html:126
+#: src/olympia/templates/impala/base.html:123
 #, python-format
 msgid "To try the thousands of add-ons available here, download <a href=\"%(url)s\">Mozilla Firefox</a>, a fast, free way to surf the Web!"
 msgstr ""
 
-#: src/olympia/templates/impala/base.html:138
+#: src/olympia/templates/impala/base.html:135
 #, python-format
 msgid "Add-ons is switching to Firefox Accounts for login. <a href=\"%(url)s\" class=\"fxa-login\">Sign in now to transfer your account.</a>"
 msgstr ""
 
 #. {0} is an application, such as Firefox.
-#: src/olympia/templates/impala/base.html:148
+#: src/olympia/templates/impala/base.html:145
 msgid "Welcome to {0} Add-ons."
 msgstr "{0} অ্যাড-অন এ স্বাগতম।"
 
-#: src/olympia/templates/impala/base.html:151
+#: src/olympia/templates/impala/base.html:148
 msgid "Choose from thousands of extra features and styles to make Firefox your own."
 msgstr "হাজারো অতিরিক্ত বৈশিষ্ট্য ও স্টাইল থেকে আপনার পছন্দেরটি বেছে নিয়ে ফায়ারফক্সকে নিজের মত করে সাজান।"
 
-#: src/olympia/templates/impala/base.html:156
+#: src/olympia/templates/impala/base.html:153
 #, python-format
 msgid "Add extra features and styles to make %(app)s your own."
 msgstr ""
 
-#: src/olympia/templates/impala/base.html:164
+#: src/olympia/templates/impala/base.html:161
 msgid "On the go?"
 msgstr ""
 
-#: src/olympia/templates/impala/base.html:166
+#: src/olympia/templates/impala/base.html:163
 msgid "Check out our <a class=\"mobile-link\" href=\"#\">Mobile Add-ons site</a>."
 msgstr "আমাদের <a class=\"mobile-link\" href=\"#\">মোবাইল অ্যাড-অন সাইটটি</a> দেখুন।"
 
@@ -11706,19 +11542,19 @@ msgstr ""
 
 #. L10n: {id} will be something like "13ad6a", just a random number
 #. to differentiate this user from other anonymous users.
-#: src/olympia/users/models.py:353
+#: src/olympia/users/models.py:362
 msgid "Anonymous user {id}"
 msgstr ""
 
-#: src/olympia/users/models.py:410
+#: src/olympia/users/models.py:419
 msgid "Your account has been restricted"
 msgstr ""
 
-#: src/olympia/users/models.py:480
+#: src/olympia/users/models.py:489
 msgid "Please confirm your email address"
 msgstr ""
 
-#: src/olympia/users/models.py:506
+#: src/olympia/users/models.py:515
 msgid "My Mobile Add-ons"
 msgstr ""
 
@@ -11995,7 +11831,7 @@ msgstr ""
 
 #: src/olympia/users/templates/users/edit.html:70
 #, python-format
-msgid "Change your password.  If you forgot your password, you can <a href=\"%(reset_url)s\">use the reset form</a>."
+msgid "Change your password. If you forgot your password, you can <a href=\"%(reset_url)s\">use the reset form</a>."
 msgstr ""
 
 #: src/olympia/users/templates/users/edit.html:76
@@ -12015,7 +11851,7 @@ msgid "Profile"
 msgstr ""
 
 #: src/olympia/users/templates/users/edit.html:100
-msgid "Give us a bit more information about yourself.  All these fields are optional, but they'll help other users get to know you better."
+msgid "Give us a bit more information about yourself. All these fields are optional, but they'll help other users get to know you better."
 msgstr ""
 
 #: src/olympia/users/templates/users/edit.html:124
@@ -12231,7 +12067,7 @@ msgid "Confirm password"
 msgstr ""
 
 #: src/olympia/users/templates/users/pwreset_confirm.html:47
-msgid "The password reset link was invalid, possibly because it has already been used.  Please request a new password reset."
+msgid "The password reset link was invalid, possibly because it has already been used. Please request a new password reset."
 msgstr ""
 
 #: src/olympia/users/templates/users/pwreset_request.html:15
@@ -12417,7 +12253,7 @@ msgstr ""
 
 #: src/olympia/users/templates/users/unsubscribe.html:30
 #, python-format
-msgid "Unfortunately, we weren't able to unsubscribe you.  The link you clicked is invalid. However, you can unsubscribe still unsubscribe on your <a href=\"%(edit_url)s\">edit profile page</a>."
+msgid "Unfortunately, we weren't able to unsubscribe you. The link you clicked is invalid. However, you can unsubscribe still unsubscribe on your <a href=\"%(edit_url)s\">edit profile page</a>."
 msgstr ""
 
 #: src/olympia/users/templates/users/vcard.html:2
@@ -12471,15 +12307,15 @@ msgstr ""
 msgid "Version History with Changelogs"
 msgstr ""
 
-#: src/olympia/versions/models.py:314
+#: src/olympia/versions/models.py:313
 msgid "Add-on uses binary components."
 msgstr ""
 
-#: src/olympia/versions/models.py:317
+#: src/olympia/versions/models.py:316
 msgid "Add-on has opted into strict compatibility checking."
 msgstr ""
 
-#: src/olympia/versions/models.py:715
+#: src/olympia/versions/models.py:711
 msgid "{app} {min} and later"
 msgstr ""
 
@@ -12554,4 +12390,8 @@ msgstr ""
 
 #: src/olympia/zadmin/forms.py:105
 msgid "Log emails instead of sending"
+msgstr ""
+
+#: src/olympia/zadmin/forms.py:215
+msgid "Deleted versions can`t be changed."
 msgstr ""

--- a/locale/bn_BD/LC_MESSAGES/djangojs.po
+++ b/locale/bn_BD/LC_MESSAGES/djangojs.po
@@ -1,1215 +1,1235 @@
-
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2016-02-24 21:23+0000\n"
+"POT-Creation-Date: 2016-04-18 15:47+0000\n"
 "PO-Revision-Date: 2014-02-06 10:18+0000\n"
 "Last-Translator: Matjaž <m@owca.info>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
+"Language: \n"
 "MIME-Version: 1.0\n"
-"Content-Type: text/plain; charset=utf-8\n"
+"Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Generated-By: Babel 2.2.0\n"
 
-#: static/js/common/ratingwidget.js:31
+#: static/js/common-all.js:1426 static/js/impala-all.js:1511 static/js/zamboni/discovery-all.js:12598 static/js/zamboni/init.js:28 static/js/zamboni/mobile-all.js:14945
+msgid "This feature is temporarily disabled while we perform website maintenance. Please check back a little later."
+msgstr ""
+
+#. L10n: {0} is an app name like Firefox.
+#: static/js/common-all.js:1837 static/js/impala-all.js:1922 static/js/zamboni/buttons.js:73 static/js/zamboni/discovery-all.js:13108
+msgid "Accept and Install"
+msgstr ""
+
+#: static/js/common-all.js:1837 static/js/impala-all.js:1922 static/js/zamboni/buttons.js:73 static/js/zamboni/discovery-all.js:13108
+msgid "Add to {0}"
+msgstr ""
+
+#: static/js/common-all.js:1842 static/js/impala-all.js:1927 static/js/zamboni/buttons.js:78 static/js/zamboni/discovery-all.js:13113
+msgid "Download Now"
+msgstr ""
+
+#: static/js/common-all.js:1883 static/js/impala-all.js:1968 static/js/zamboni/buttons.js:119 static/js/zamboni/discovery-all.js:13154
+msgid "Add-on has not been updated to support default-to-compatible."
+msgstr ""
+
+#: static/js/common-all.js:1888 static/js/impala-all.js:1973 static/js/zamboni/buttons.js:124 static/js/zamboni/discovery-all.js:13159
+msgid "You need to be using Firefox 10.0 or higher."
+msgstr ""
+
+#: static/js/common-all.js:1900 static/js/impala-all.js:1985 static/js/zamboni/buttons.js:136 static/js/zamboni/discovery-all.js:13171
+msgid "Mozilla has marked this version as incompatible with your Firefox version."
+msgstr ""
+
+#. L10n: {0} is an platform like Windows or Linux.
+#: static/js/common-all.js:1981 static/js/impala-all.js:2066 static/js/zamboni/buttons.js:217 static/js/zamboni/discovery-all.js:13252
+msgid "Install for {0} anyway"
+msgstr ""
+
+#: static/js/common-all.js:1981 static/js/impala-all.js:2066 static/js/zamboni/buttons.js:217 static/js/zamboni/discovery-all.js:13252
+msgid "Download for {0} anyway"
+msgstr ""
+
+#: static/js/common-all.js:2038 static/js/impala-all.js:2123 static/js/zamboni/buttons.js:274 static/js/zamboni/discovery-all.js:13309
+msgid "Not available for your platform"
+msgstr ""
+
+#. L10n: {0} is an app name, {1} is the app version.
+#: static/js/common-all.js:2049 static/js/common-all.js:2086 static/js/impala-all.js:2134 static/js/impala-all.js:2171 static/js/zamboni/buttons.js:286 static/js/zamboni/buttons.js:324
+#: static/js/zamboni/discovery-all.js:13320 static/js/zamboni/discovery-all.js:13357
+msgid "Not available for {0} {1}"
+msgstr ""
+
+#: static/js/common-all.js:2112 static/js/impala-all.js:2197 static/js/zamboni/buttons.js:351 static/js/zamboni/discovery-all.js:13383
+msgid "Works with {app} {min} - {max}"
+msgstr ""
+
+#: static/js/common-all.js:2114 static/js/impala-all.js:2199 static/js/zamboni/buttons.js:353 static/js/zamboni/discovery-all.js:13385
+msgid "View other versions"
+msgstr ""
+
+#: static/js/common-all.js:2162 static/js/impala-all.js:2247 static/js/zamboni/buttons.js:401 static/js/zamboni/discovery-all.js:13433
+msgid "Only with Firefox — Get Firefox Now!"
+msgstr ""
+
+#: static/js/common-all.js:2278 static/js/impala-all.js:2363 static/js/zamboni/buttons.js:517 static/js/zamboni/discovery-all.js:13549 static/js/zamboni/mobile-all.js:15177
+#: static/js/zamboni/mobile/buttons.js:43
+msgid "Sorry, you need a Mozilla-based browser (such as Firefox) to install a search plugin."
+msgstr ""
+
+#: static/js/common-all.js:9088 static/js/impala-all.js:9649 static/js/zamboni/global.js:410
+msgid "Loading..."
+msgstr ""
+
+#. L10n: {0} is the number of characters left.
+#: static/js/common-all.js:9152 static/js/impala-all.js:9713 static/js/zamboni/global.js:474
+msgid "<b>{0}</b> character left."
+msgid_plural "<b>{0}</b> characters left."
+msgstr[0] ""
+msgstr[1] ""
+
+#: static/js/common-all.js:9589 static/js/common-min.js:6 static/js/impala-all.js:10052 static/js/impala-min.js:6 static/js/common/ratingwidget.js:31 static/js/zamboni/mobile-all.js:16123
+#: static/js/zamboni/mobile-min.js:6
 msgid "{0} star"
 msgid_plural "{0} stars"
 msgstr[0] ""
 msgstr[1] ""
 
-#: static/js/common/upload-addon.js:41 static/js/common/upload-image.js:128
+#: static/js/common-all.js:9676 static/js/common-min.js:6 static/js/impala-all.js:10139 static/js/impala-min.js:6 static/js/zamboni/l10n.js:45
+msgid "Remove this localization"
+msgstr ""
+
+#: static/js/common-all.js:10193 static/js/common-min.js:6 static/js/impala-all.js:10674 static/js/impala-min.js:6 static/js/zamboni/discovery-all.js:13678
+msgid "close"
+msgstr ""
+
+#: static/js/common-all.js:10860 static/js/common-min.js:6 static/js/impala-all.js:11481 static/js/impala-min.js:6 static/js/impala/reviews.js:23 static/js/zamboni/reviews.js:18
+msgid "Flagged for review"
+msgstr ""
+
+#: static/js/common-all.js:10876 static/js/common-min.js:6 static/js/impala-all.js:11498 static/js/impala-min.js:6 static/js/impala/reviews.js:40 static/js/zamboni/reviews.js:34
+msgid "Your input is required"
+msgstr ""
+
+#: static/js/common-all.js:10945 static/js/common-min.js:6 static/js/impala-all.js:11610 static/js/impala-min.js:7 static/js/impala/reviews.js:152 static/js/zamboni/reviews.js:103
+msgid "Marked for deletion"
+msgstr ""
+
+#: static/js/common-all.js:11573 static/js/common-min.js:7 static/js/impala-all.js:13809 static/js/impala-min.js:8 static/js/zamboni/collections.js:229
+msgid "Adding to Favorites&hellip;"
+msgstr ""
+
+#: static/js/common-all.js:11576 static/js/common-min.js:7 static/js/impala-all.js:13812 static/js/impala-min.js:8 static/js/zamboni/collections.js:232
+msgid "Removing Favorite&hellip;"
+msgstr ""
+
+#: static/js/common-all.js:11579 static/js/common-min.js:7 static/js/impala-all.js:13815 static/js/impala-min.js:8 static/js/zamboni/collections.js:235
+msgid "Add to Favorites"
+msgstr ""
+
+#: static/js/common-all.js:11582 static/js/common-min.js:7 static/js/impala-all.js:13818 static/js/impala-min.js:8 static/js/zamboni/collections.js:238
+msgid "Remove from Favorites"
+msgstr ""
+
+#: static/js/common-all.js:11647 static/js/common-min.js:7 static/js/impala-all.js:13883 static/js/impala-min.js:8 static/js/zamboni/collections.js:303
+msgid "Pending"
+msgstr ""
+
+#: static/js/common-all.js:11648 static/js/common-min.js:7 static/js/impala-all.js:13884 static/js/impala-min.js:8 static/js/zamboni/collections.js:304
+msgid "Add a comment"
+msgstr ""
+
+#: static/js/common-all.js:11648 static/js/common-min.js:7 static/js/impala-all.js:13884 static/js/impala-min.js:8 static/js/zamboni/collections.js:304
+msgid "Comment"
+msgstr ""
+
+#: static/js/common-all.js:11649 static/js/common-min.js:7 static/js/impala-all.js:13885 static/js/impala-min.js:8 static/js/zamboni/collections.js:305
+msgid "Remove this add-on from the collection"
+msgstr ""
+
+#: static/js/common-all.js:11649 static/js/common-all.js:11678 static/js/common-min.js:7 static/js/impala-all.js:13885 static/js/impala-all.js:13914 static/js/impala-min.js:8
+#: static/js/zamboni/collections.js:305 static/js/zamboni/collections.js:334
+msgid "Remove"
+msgstr ""
+
+#: static/js/common-all.js:11678 static/js/common-min.js:7 static/js/impala-all.js:13914 static/js/impala-min.js:8 static/js/zamboni/collections.js:334
+msgid "Remove this user as a contributor"
+msgstr ""
+
+#: static/js/common-all.js:11690 static/js/common-min.js:7 static/js/impala-all.js:13926 static/js/impala-min.js:8 static/js/zamboni/collections.js:346
+msgid "An email address is required."
+msgstr ""
+
+#: static/js/common-all.js:11708 static/js/common-min.js:7 static/js/impala-all.js:13944 static/js/impala-min.js:8 static/js/zamboni/collections.js:364
+msgid "You cannot add yourself as a contributor."
+msgstr ""
+
+#: static/js/common-all.js:11710 static/js/common-min.js:7 static/js/impala-all.js:13946 static/js/impala-min.js:8 static/js/zamboni/collections.js:366
+msgid "You have already added that user."
+msgstr ""
+
+#: static/js/common-all.js:11917 static/js/common-min.js:7 static/js/impala-all.js:14153 static/js/impala-min.js:8 static/js/zamboni/collections.js:573
+msgid "Add to favorites"
+msgstr ""
+
+#: static/js/common-all.js:11921 static/js/common-min.js:7 static/js/impala-all.js:14157 static/js/impala-min.js:8 static/js/zamboni/collections.js:577
+msgid "Remove from favorites"
+msgstr ""
+
+#: static/js/common-all.js:11939 static/js/common-min.js:7 static/js/impala-all.js:14175 static/js/impala-all.js:14233 static/js/impala-min.js:8 static/js/impala/collections.js:10
+#: static/js/zamboni/collections.js:595
+msgid "Follow this Collection"
+msgstr ""
+
+#: static/js/common-all.js:11948 static/js/common-min.js:7 static/js/impala-all.js:14184 static/js/impala-min.js:8 static/js/zamboni/collections.js:604
+msgid "Stop following"
+msgstr ""
+
+#: static/js/common-all.js:12096 static/js/common-min.js:7 static/js/zamboni/password-strength.js:20
+msgid "Password strength:"
+msgstr ""
+
+#: static/js/common-all.js:12102 static/js/common-min.js:7 static/js/zamboni/password-strength.js:26
+msgid "At least {0} character left."
+msgid_plural "At least {0} characters left."
+msgstr[0] ""
+msgstr[1] ""
+
+#: static/js/common-all.js:12286 static/js/common-min.js:7 static/js/impala-all.js:14632 static/js/impala-min.js:8 static/js/impala/suggestions.js:39
+msgid "Search themes for <b>{0}</b>"
+msgstr ""
+
+#: static/js/common-all.js:12288 static/js/common-min.js:7 static/js/impala-all.js:14634 static/js/impala-min.js:8 static/js/impala/suggestions.js:41
+msgid "Search apps for <b>{0}</b>"
+msgstr ""
+
+#: static/js/common-all.js:12290 static/js/common-min.js:7 static/js/impala-all.js:14636 static/js/impala-min.js:8 static/js/impala/suggestions.js:43
+msgid "Search add-ons for <b>{0}</b>"
+msgstr ""
+
+#: static/js/common-all.js:12521 static/js/common-min.js:7 static/js/impala-all.js:14867 static/js/impala-min.js:8 static/js/impala/site_suggestions.js:46
+msgid "Category"
+msgstr ""
+
+#. L10n: {0} is an app name.
+#: static/js/impala-all.js:11632 static/js/impala-min.js:7 static/js/impala/listing.js:11 static/js/zamboni/themes.js:13
+msgid "This theme is incompatible with your version of {0}"
+msgstr ""
+
+#: static/js/impala-all.js:12146 static/js/impala-all.js:14331 static/js/impala-min.js:7 static/js/impala-min.js:8 static/js/common/upload-image.js:97 static/js/impala/users.js:51
+#: static/js/zamboni/devhub-all.js:894 static/js/zamboni/devhub-min.js:1
+msgid "Images must be either PNG or JPG."
+msgstr ""
+
+#: static/js/impala-all.js:12150 static/js/impala-min.js:7 static/js/common/upload-image.js:101 static/js/zamboni/devhub-all.js:898 static/js/zamboni/devhub-min.js:1
+msgid "Videos must be in WebM."
+msgstr ""
+
+#: static/js/impala-all.js:12177 static/js/impala-min.js:7 static/js/common/upload-addon.js:41 static/js/common/upload-image.js:128 static/js/zamboni/devhub-all.js:272
+#: static/js/zamboni/devhub-all.js:925 static/js/zamboni/devhub-min.js:1
 msgid "There was a problem contacting the server."
 msgstr "12345"
 
-#: static/js/common/upload-addon.js:69
+#: static/js/impala-all.js:13298 static/js/impala-min.js:7 static/js/impala/persona_creation.js:60
+msgid "All Rights Reserved"
+msgstr ""
+
+#: static/js/impala-all.js:13302 static/js/impala-min.js:7 static/js/impala/persona_creation.js:64
+msgid "Creative Commons Attribution 3.0"
+msgstr ""
+
+#: static/js/impala-all.js:13307 static/js/impala-min.js:7 static/js/impala/persona_creation.js:69
+msgid "Creative Commons Attribution-NonCommercial 3.0"
+msgstr ""
+
+#: static/js/impala-all.js:13312 static/js/impala-min.js:7 static/js/impala/persona_creation.js:74
+msgid "Creative Commons Attribution-NonCommercial-NoDerivs 3.0"
+msgstr ""
+
+#: static/js/impala-all.js:13317 static/js/impala-min.js:7 static/js/impala/persona_creation.js:79
+msgid "Creative Commons Attribution-NonCommercial-Share Alike 3.0"
+msgstr ""
+
+#: static/js/impala-all.js:13322 static/js/impala-min.js:7 static/js/impala/persona_creation.js:84
+msgid "Creative Commons Attribution-NoDerivs 3.0"
+msgstr ""
+
+#: static/js/impala-all.js:13327 static/js/impala-min.js:7 static/js/impala/persona_creation.js:89
+msgid "Creative Commons Attribution-ShareAlike 3.0"
+msgstr ""
+
+#: static/js/impala-all.js:13530 static/js/impala-min.js:7 static/js/impala/persona_creation.js:292
+msgid "Your Theme's Name"
+msgstr ""
+
+#: static/js/impala-all.js:14242 static/js/impala-min.js:8 static/js/impala/collections.js:19
+msgid "Stop Following"
+msgstr ""
+
+#: static/js/impala-all.js:14243 static/js/impala-min.js:8 static/js/impala/collections.js:20
+msgid "Following"
+msgstr ""
+
+#: static/js/impala-all.js:14313 static/js/impala-min.js:8 static/js/impala/users.js:33
+msgid "use original"
+msgstr ""
+
+#: static/js/impala-all.js:14523 static/js/impala-min.js:8 static/js/impala/search.js:114
+msgid "Updating results&hellip;"
+msgstr ""
+
+#: static/js/common/upload-addon.js:69 static/js/zamboni/devhub-all.js:300 static/js/zamboni/devhub-min.js:1
 msgid "Select a file..."
 msgstr ""
 
-#: static/js/common/upload-addon.js:70
+#: static/js/common/upload-addon.js:70 static/js/zamboni/devhub-all.js:301 static/js/zamboni/devhub-min.js:1
 msgid "Your add-on should end with .xpi, .jar or .xml"
 msgstr ""
 
 #. L10n: {0} is the percent of the file that has been uploaded.
-#: static/js/common/upload-addon.js:104
+#: static/js/common/upload-addon.js:104 static/js/zamboni/devhub-all.js:335 static/js/zamboni/devhub-min.js:1
 #, python-format
 msgid "{0}% complete"
 msgstr ""
 
 #. L10n: "{bytes uploaded} of {total filesize}".
-#: static/js/common/upload-addon.js:107
+#: static/js/common/upload-addon.js:107 static/js/zamboni/devhub-all.js:338 static/js/zamboni/devhub-min.js:1
 msgid "{0} of {1}"
 msgstr ""
 
-#: static/js/common/upload-addon.js:140
+#: static/js/common/upload-addon.js:140 static/js/zamboni/devhub-all.js:371 static/js/zamboni/devhub-min.js:1
 msgid "Cancel"
 msgstr ""
 
-#: static/js/common/upload-addon.js:162
+#: static/js/common/upload-addon.js:162 static/js/zamboni/devhub-all.js:393 static/js/zamboni/devhub-min.js:1
 msgid "Uploading {0}"
 msgstr ""
 
-#: static/js/common/upload-addon.js:189
+#: static/js/common/upload-addon.js:189 static/js/zamboni/devhub-all.js:420 static/js/zamboni/devhub-min.js:1
 msgid "Error with {0}"
 msgstr ""
 
-#: static/js/common/upload-addon.js:194
+#: static/js/common/upload-addon.js:194 static/js/zamboni/devhub-all.js:425 static/js/zamboni/devhub-min.js:1
 msgid "Your add-on failed validation with {0} error."
 msgid_plural "Your add-on failed validation with {0} errors."
 msgstr[0] ""
 msgstr[1] ""
 
-#: static/js/common/upload-addon.js:208
+#: static/js/common/upload-addon.js:208 static/js/zamboni/devhub-all.js:439 static/js/zamboni/devhub-min.js:1
 msgid "&hellip;and {0} more"
 msgid_plural "&hellip;and {0} more"
 msgstr[0] ""
 msgstr[1] ""
 
-#: static/js/common/upload-addon.js:222 static/js/common/upload-addon.js:512
+#: static/js/common/upload-addon.js:222 static/js/common/upload-addon.js:497 static/js/zamboni/devhub-all.js:453 static/js/zamboni/devhub-all.js:743 static/js/zamboni/devhub-min.js:1
 msgid "See full validation report"
 msgstr ""
 
-#: static/js/common/upload-addon.js:234
+#: static/js/common/upload-addon.js:234 static/js/zamboni/devhub-all.js:465 static/js/zamboni/devhub-min.js:1
 msgid "Validating {0}"
 msgstr ""
 
 #. L10n: first argument is an HTTP status code
-#: static/js/common/upload-addon.js:273
+#: static/js/common/upload-addon.js:273 static/js/zamboni/devhub-all.js:504 static/js/zamboni/devhub-min.js:1
 msgid "Received an empty response from the server; status: {0}"
 msgstr ""
 
-#: static/js/common/upload-addon.js:373
+#: static/js/common/upload-addon.js:370 static/js/zamboni/devhub-all.js:604 static/js/zamboni/devhub-min.js:1
 msgid "Unexpected server error while validating."
 msgstr ""
 
-#: static/js/common/upload-addon.js:412
+#: static/js/common/upload-addon.js:409 static/js/zamboni/devhub-all.js:643 static/js/zamboni/devhub-min.js:1
 msgid "Finished validating {0}"
 msgstr ""
 
-#: static/js/common/upload-addon.js:418
+#: static/js/common/upload-addon.js:415 static/js/zamboni/devhub-all.js:649 static/js/zamboni/devhub-min.js:1
 msgid "Your add-on validation timed out, it will be manually reviewed."
 msgstr ""
 
-#: static/js/common/upload-addon.js:421
+#: static/js/common/upload-addon.js:418 static/js/zamboni/devhub-all.js:652 static/js/zamboni/devhub-min.js:1
 msgid "Your add-on was validated with no errors and {0} warning."
 msgid_plural "Your add-on was validated with no errors and {0} warnings."
 msgstr[0] ""
 msgstr[1] ""
 
-#: static/js/common/upload-addon.js:426
+#: static/js/common/upload-addon.js:423 static/js/zamboni/devhub-all.js:657 static/js/zamboni/devhub-min.js:1
 msgid "Your add-on was validated with no errors and {0} message."
 msgid_plural "Your add-on was validated with no errors and {0} messages."
 msgstr[0] ""
 msgstr[1] ""
 
-#: static/js/common/upload-addon.js:431
+#: static/js/common/upload-addon.js:428 static/js/zamboni/devhub-all.js:662 static/js/zamboni/devhub-min.js:1
 msgid "Your add-on was validated with no errors or warnings."
 msgstr ""
 
-#: static/js/common/upload-addon.js:446
+#: static/js/common/upload-addon.js:443 static/js/zamboni/devhub-all.js:677 static/js/zamboni/devhub-min.js:1
 msgid "Your submission will be automatically signed."
 msgstr ""
 
-#: static/js/common/upload-addon.js:465
+#: static/js/common/upload-addon.js:450 static/js/zamboni/devhub-all.js:696 static/js/zamboni/devhub-min.js:1
 msgid "Include detailed version notes (this can be done in the next step)."
 msgstr ""
 
-#: static/js/common/upload-addon.js:466
+#: static/js/common/upload-addon.js:451 static/js/zamboni/devhub-all.js:697 static/js/zamboni/devhub-min.js:1
 msgid "If your add-on requires an account to a website in order to be fully tested, include a test username and password in the Notes to Reviewer (this can be done in the next step)."
 msgstr ""
 
-#: static/js/common/upload-addon.js:467
+#: static/js/common/upload-addon.js:452 static/js/zamboni/devhub-all.js:698 static/js/zamboni/devhub-min.js:1
 msgid "If your add-on is intended for a limited audience you should choose Preliminary Review instead of Full Review."
 msgstr ""
 
-#: static/js/common/upload-addon.js:480
+#: static/js/common/upload-addon.js:465 static/js/zamboni/devhub-all.js:711 static/js/zamboni/devhub-min.js:1
 msgid "Add-on submission checklist"
 msgstr ""
 
-#: static/js/common/upload-addon.js:481
+#: static/js/common/upload-addon.js:466 static/js/zamboni/devhub-all.js:712 static/js/zamboni/devhub-min.js:1
 msgid "Please verify the following points before finalizing your submission. This will minimize delays or misunderstanding during the review process:"
 msgstr ""
 
-#: static/js/common/upload-addon.js:483
+#: static/js/common/upload-addon.js:468 static/js/zamboni/devhub-all.js:714 static/js/zamboni/devhub-min.js:1
 msgid ""
 "Compiled binaries, as well as minified or obfuscated scripts (excluding known libraries) need to have their sources submitted separately for review. Make sure that you use the source code upload "
 "field to avoid having your submission rejected."
 msgstr ""
 
-#: static/js/common/upload-addon.js:501
+#: static/js/common/upload-addon.js:486 static/js/zamboni/devhub-all.js:732 static/js/zamboni/devhub-min.js:1
 msgid "The validation process found these issues that can lead to rejections:"
 msgstr ""
 
-#: static/js/common/upload-addon.js:518
+#: static/js/common/upload-addon.js:503 static/js/zamboni/devhub-all.js:749 static/js/zamboni/devhub-min.js:1
 msgid "If you are unfamiliar with the add-ons review process, you can read about it here."
 msgstr ""
 
-#: static/js/common/upload-addon.js:555
+#: static/js/common/upload-addon.js:540 static/js/zamboni/devhub-all.js:786 static/js/zamboni/devhub-min.js:1
 msgid "Sorry, no supported platform has been found."
 msgstr ""
 
-#: static/js/common/upload-base.js:57
+#: static/js/common/upload-base.js:57 static/js/zamboni/devhub-all.js:187 static/js/zamboni/devhub-min.js:1
 msgid "The filetype you uploaded isn't recognized."
 msgstr ""
 
-#: static/js/common/upload-base.js:79
+#: static/js/common/upload-base.js:79 static/js/zamboni/devhub-all.js:209 static/js/zamboni/devhub-min.js:1
 msgid "You cancelled the upload."
 msgstr ""
 
-#: static/js/common/upload-image.js:97 static/js/impala/users.js:51
-msgid "Images must be either PNG or JPG."
-msgstr ""
-
-#: static/js/common/upload-image.js:101
-msgid "Videos must be in WebM."
-msgstr ""
-
-#: static/js/impala/collections.js:10 static/js/zamboni/collections.js:595
-msgid "Follow this Collection"
-msgstr ""
-
-#: static/js/impala/collections.js:19
-msgid "Stop Following"
-msgstr ""
-
-#: static/js/impala/collections.js:20
-msgid "Following"
-msgstr ""
-
-#. L10n: {0} is an app name.
-#: static/js/impala/listing.js:11 static/js/zamboni/themes.js:13
-msgid "This theme is incompatible with your version of {0}"
-msgstr ""
-
-#: static/js/impala/persona_creation.js:60
-msgid "All Rights Reserved"
-msgstr ""
-
-#: static/js/impala/persona_creation.js:64
-msgid "Creative Commons Attribution 3.0"
-msgstr ""
-
-#: static/js/impala/persona_creation.js:69
-msgid "Creative Commons Attribution-NonCommercial 3.0"
-msgstr ""
-
-#: static/js/impala/persona_creation.js:74
-msgid "Creative Commons Attribution-NonCommercial-NoDerivs 3.0"
-msgstr ""
-
-#: static/js/impala/persona_creation.js:79
-msgid "Creative Commons Attribution-NonCommercial-Share Alike 3.0"
-msgstr ""
-
-#: static/js/impala/persona_creation.js:84
-msgid "Creative Commons Attribution-NoDerivs 3.0"
-msgstr ""
-
-#: static/js/impala/persona_creation.js:89
-msgid "Creative Commons Attribution-ShareAlike 3.0"
-msgstr ""
-
-#: static/js/impala/persona_creation.js:292
-msgid "Your Theme's Name"
-msgstr ""
-
-#: static/js/impala/reviews.js:23 static/js/zamboni/reviews.js:18
-msgid "Flagged for review"
-msgstr ""
-
-#: static/js/impala/reviews.js:40 static/js/zamboni/reviews.js:34
-msgid "Your input is required"
-msgstr ""
-
-#: static/js/impala/reviews.js:152 static/js/zamboni/reviews.js:103
-msgid "Marked for deletion"
-msgstr ""
-
-#: static/js/impala/search.js:114
-msgid "Updating results&hellip;"
-msgstr ""
-
-#: static/js/impala/site_suggestions.js:46
-msgid "Category"
-msgstr ""
-
-#: static/js/impala/suggestions.js:39
-msgid "Search themes for <b>{0}</b>"
-msgstr ""
-
-#: static/js/impala/suggestions.js:41
-msgid "Search apps for <b>{0}</b>"
-msgstr ""
-
-#: static/js/impala/suggestions.js:43
-msgid "Search add-ons for <b>{0}</b>"
-msgstr ""
-
-#: static/js/impala/users.js:33
-msgid "use original"
-msgstr ""
-
-#: static/js/impala/stats/chart.js:267
+#: static/js/impala/stats/chart.js:267 static/js/zamboni/stats-all.js:16898 static/js/zamboni/stats-min.js:5
 msgid "Week of {0}"
 msgstr ""
 
-#: static/js/impala/stats/chart.js:269
+#: static/js/impala/stats/chart.js:269 static/js/zamboni/stats-all.js:16900 static/js/zamboni/stats-min.js:5
 msgid " downloads"
 msgstr ""
 
-#: static/js/impala/stats/chart.js:270
+#: static/js/impala/stats/chart.js:270 static/js/zamboni/stats-all.js:16901 static/js/zamboni/stats-min.js:5
 msgid "{0} users"
 msgstr ""
 
-#: static/js/impala/stats/chart.js:271
+#: static/js/impala/stats/chart.js:271 static/js/zamboni/stats-all.js:16902 static/js/zamboni/stats-min.js:5
 msgid "{0} add-ons"
 msgstr ""
 
-#: static/js/impala/stats/chart.js:272
+#: static/js/impala/stats/chart.js:272 static/js/zamboni/stats-all.js:16903 static/js/zamboni/stats-min.js:5
 msgid "{0} collections"
 msgstr ""
 
-#: static/js/impala/stats/chart.js:273
+#: static/js/impala/stats/chart.js:273 static/js/zamboni/stats-all.js:16904 static/js/zamboni/stats-min.js:5
 msgid "{0} reviews"
 msgstr ""
 
-#: static/js/impala/stats/chart.js:275
+#: static/js/impala/stats/chart.js:275 static/js/zamboni/stats-all.js:16906 static/js/zamboni/stats-min.js:5
 msgid "{0} sales"
 msgstr ""
 
-#: static/js/impala/stats/chart.js:276
+#: static/js/impala/stats/chart.js:276 static/js/zamboni/stats-all.js:16907 static/js/zamboni/stats-min.js:5
 msgid "{0} refunds"
 msgstr ""
 
-#: static/js/impala/stats/chart.js:277
+#: static/js/impala/stats/chart.js:277 static/js/zamboni/stats-all.js:16908 static/js/zamboni/stats-min.js:5
 msgid "{0} installs"
 msgstr ""
 
-#: static/js/impala/stats/chart.js:369 static/js/impala/stats/csv_keys.js:3 static/js/impala/stats/csv_keys.js:109
+#: static/js/impala/stats/chart.js:369 static/js/impala/stats/csv_keys.js:3 static/js/impala/stats/csv_keys.js:109 static/js/zamboni/stats-all.js:15284 static/js/zamboni/stats-all.js:15390
+#: static/js/zamboni/stats-all.js:17000 static/js/zamboni/stats-min.js:4 static/js/zamboni/stats-min.js:5
 msgid "Downloads"
 msgstr ""
 
-#: static/js/impala/stats/chart.js:379 static/js/impala/stats/csv_keys.js:6 static/js/impala/stats/csv_keys.js:110
+#: static/js/impala/stats/chart.js:379 static/js/impala/stats/csv_keys.js:6 static/js/impala/stats/csv_keys.js:110 static/js/zamboni/stats-all.js:15287 static/js/zamboni/stats-all.js:15391
+#: static/js/zamboni/stats-all.js:17010 static/js/zamboni/stats-min.js:4 static/js/zamboni/stats-min.js:5
 msgid "Daily Users"
 msgstr ""
 
-#: static/js/impala/stats/chart.js:410
+#: static/js/impala/stats/chart.js:410 static/js/zamboni/stats-all.js:17041 static/js/zamboni/stats-min.js:5
 msgid "Amount, in USD"
 msgstr ""
 
-#: static/js/impala/stats/chart.js:421 static/js/impala/stats/csv_keys.js:104
+#: static/js/impala/stats/chart.js:421 static/js/impala/stats/csv_keys.js:104 static/js/zamboni/stats-all.js:15385 static/js/zamboni/stats-all.js:17052 static/js/zamboni/stats-min.js:5
 msgid "Number of Contributions"
 msgstr ""
 
-#: static/js/impala/stats/chart.js:447
+#: static/js/impala/stats/chart.js:447 static/js/zamboni/stats-all.js:17078 static/js/zamboni/stats-min.js:5
 msgid "More Info..."
 msgstr ""
 
 #. L10n: {0} is an ISO-formatted date.
-#: static/js/impala/stats/chart.js:451
+#: static/js/impala/stats/chart.js:451 static/js/zamboni/stats-all.js:17082 static/js/zamboni/stats-min.js:5
 msgid "Details for {0}"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:9
+#: static/js/impala/stats/csv_keys.js:9 static/js/zamboni/stats-all.js:15290 static/js/zamboni/stats-min.js:4
 msgid "Collections Created"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:12
+#: static/js/impala/stats/csv_keys.js:12 static/js/zamboni/stats-all.js:15293 static/js/zamboni/stats-min.js:4
 msgid "Add-ons in Use"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:15
+#: static/js/impala/stats/csv_keys.js:15 static/js/zamboni/stats-all.js:15296 static/js/zamboni/stats-min.js:4
 msgid "Add-ons Created"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:18
+#: static/js/impala/stats/csv_keys.js:18 static/js/zamboni/stats-all.js:15299 static/js/zamboni/stats-min.js:4
 msgid "Add-ons Downloaded"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:21
+#: static/js/impala/stats/csv_keys.js:21 static/js/zamboni/stats-all.js:15302 static/js/zamboni/stats-min.js:4
 msgid "Add-ons Updated"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:24
+#: static/js/impala/stats/csv_keys.js:24 static/js/zamboni/stats-all.js:15305 static/js/zamboni/stats-min.js:4
 msgid "Reviews Written"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:27
+#: static/js/impala/stats/csv_keys.js:27 static/js/zamboni/stats-all.js:15308 static/js/zamboni/stats-min.js:4
 msgid "User Signups"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:30
+#: static/js/impala/stats/csv_keys.js:30 static/js/zamboni/stats-all.js:15311 static/js/zamboni/stats-min.js:4
 msgid "Subscribers"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:33
+#: static/js/impala/stats/csv_keys.js:33 static/js/zamboni/stats-all.js:15314 static/js/zamboni/stats-min.js:4
 msgid "Ratings"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:36 static/js/impala/stats/csv_keys.js:114
+#: static/js/impala/stats/csv_keys.js:36 static/js/impala/stats/csv_keys.js:114 static/js/zamboni/stats-all.js:15317 static/js/zamboni/stats-all.js:15395 static/js/zamboni/stats-min.js:4
+#: static/js/zamboni/stats-min.js:5
 msgid "Sales"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:39 static/js/impala/stats/csv_keys.js:113
+#: static/js/impala/stats/csv_keys.js:39 static/js/impala/stats/csv_keys.js:113 static/js/zamboni/stats-all.js:15320 static/js/zamboni/stats-all.js:15394 static/js/zamboni/stats-min.js:4
+#: static/js/zamboni/stats-min.js:5
 msgid "Installs"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:42
+#: static/js/impala/stats/csv_keys.js:42 static/js/zamboni/stats-all.js:15323 static/js/zamboni/stats-min.js:4
 msgid "Unknown"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:43
+#: static/js/impala/stats/csv_keys.js:43 static/js/zamboni/stats-all.js:15324 static/js/zamboni/stats-min.js:4
 msgid "Add-ons Manager"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:44
+#: static/js/impala/stats/csv_keys.js:44 static/js/zamboni/stats-all.js:15325 static/js/zamboni/stats-min.js:4
 msgid "Add-ons Manager Promo"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:45
+#: static/js/impala/stats/csv_keys.js:45 static/js/zamboni/stats-all.js:15326 static/js/zamboni/stats-min.js:4
 msgid "Add-ons Manager Featured"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:46
+#: static/js/impala/stats/csv_keys.js:46 static/js/zamboni/stats-all.js:15327 static/js/zamboni/stats-min.js:4
 msgid "Add-ons Manager Learn More"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:47
+#: static/js/impala/stats/csv_keys.js:47 static/js/zamboni/stats-all.js:15328 static/js/zamboni/stats-min.js:4
 msgid "Search Suggestions"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:48
+#: static/js/impala/stats/csv_keys.js:48 static/js/zamboni/stats-all.js:15329 static/js/zamboni/stats-min.js:4
 msgid "Search Results"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:49 static/js/impala/stats/csv_keys.js:50 static/js/impala/stats/csv_keys.js:51
+#: static/js/impala/stats/csv_keys.js:49 static/js/impala/stats/csv_keys.js:50 static/js/impala/stats/csv_keys.js:51 static/js/zamboni/stats-all.js:15330 static/js/zamboni/stats-all.js:15331
+#: static/js/zamboni/stats-all.js:15332 static/js/zamboni/stats-min.js:4
 msgid "Homepage Promo"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:52 static/js/impala/stats/csv_keys.js:53
+#: static/js/impala/stats/csv_keys.js:52 static/js/impala/stats/csv_keys.js:53 static/js/zamboni/stats-all.js:15333 static/js/zamboni/stats-all.js:15334 static/js/zamboni/stats-min.js:4
 msgid "Homepage Featured"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:54 static/js/impala/stats/csv_keys.js:55
+#: static/js/impala/stats/csv_keys.js:54 static/js/impala/stats/csv_keys.js:55 static/js/zamboni/stats-all.js:15335 static/js/zamboni/stats-all.js:15336 static/js/zamboni/stats-min.js:4
 msgid "Homepage Up and Coming"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:56
+#: static/js/impala/stats/csv_keys.js:56 static/js/zamboni/stats-all.js:15337 static/js/zamboni/stats-min.js:4
 msgid "Homepage Most Popular"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:57 static/js/impala/stats/csv_keys.js:59
+#: static/js/impala/stats/csv_keys.js:57 static/js/impala/stats/csv_keys.js:59 static/js/zamboni/stats-all.js:15338 static/js/zamboni/stats-all.js:15340 static/js/zamboni/stats-min.js:4
 msgid "Detail Page"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:58 static/js/impala/stats/csv_keys.js:60
+#: static/js/impala/stats/csv_keys.js:58 static/js/impala/stats/csv_keys.js:60 static/js/zamboni/stats-all.js:15339 static/js/zamboni/stats-all.js:15341 static/js/zamboni/stats-min.js:4
 msgid "Detail Page (bottom)"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:61
+#: static/js/impala/stats/csv_keys.js:61 static/js/zamboni/stats-all.js:15342 static/js/zamboni/stats-min.js:4
 msgid "Detail Page (Development Channel)"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:62 static/js/impala/stats/csv_keys.js:63 static/js/impala/stats/csv_keys.js:64
+#: static/js/impala/stats/csv_keys.js:62 static/js/impala/stats/csv_keys.js:63 static/js/impala/stats/csv_keys.js:64 static/js/zamboni/stats-all.js:15343 static/js/zamboni/stats-all.js:15344
+#: static/js/zamboni/stats-all.js:15345 static/js/zamboni/stats-min.js:4
 msgid "Often Used With"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:65 static/js/impala/stats/csv_keys.js:66
+#: static/js/impala/stats/csv_keys.js:65 static/js/impala/stats/csv_keys.js:66 static/js/zamboni/stats-all.js:15346 static/js/zamboni/stats-all.js:15347 static/js/zamboni/stats-min.js:4
 msgid "Others By Author"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:67 static/js/impala/stats/csv_keys.js:68
+#: static/js/impala/stats/csv_keys.js:67 static/js/impala/stats/csv_keys.js:68 static/js/zamboni/stats-all.js:15348 static/js/zamboni/stats-all.js:15349 static/js/zamboni/stats-min.js:4
 msgid "Dependencies"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:69 static/js/impala/stats/csv_keys.js:70
+#: static/js/impala/stats/csv_keys.js:69 static/js/impala/stats/csv_keys.js:70 static/js/zamboni/stats-all.js:15350 static/js/zamboni/stats-all.js:15351 static/js/zamboni/stats-min.js:4
 msgid "Upsell"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:71
+#: static/js/impala/stats/csv_keys.js:71 static/js/zamboni/stats-all.js:15352 static/js/zamboni/stats-min.js:4
 msgid "Meet the Developer"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:72
+#: static/js/impala/stats/csv_keys.js:72 static/js/zamboni/stats-all.js:15353 static/js/zamboni/stats-min.js:4
 msgid "User Profile"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:73
+#: static/js/impala/stats/csv_keys.js:73 static/js/zamboni/stats-all.js:15354 static/js/zamboni/stats-min.js:4
 msgid "Version History"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:75
+#: static/js/impala/stats/csv_keys.js:75 static/js/zamboni/stats-all.js:15356 static/js/zamboni/stats-min.js:4
 msgid "Sharing"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:76
+#: static/js/impala/stats/csv_keys.js:76 static/js/zamboni/stats-all.js:15357 static/js/zamboni/stats-min.js:4
 msgid "Category Pages"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:77
+#: static/js/impala/stats/csv_keys.js:77 static/js/zamboni/stats-all.js:15358 static/js/zamboni/stats-min.js:4
 msgid "Collections"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:78 static/js/impala/stats/csv_keys.js:79
+#: static/js/impala/stats/csv_keys.js:78 static/js/impala/stats/csv_keys.js:79 static/js/zamboni/stats-all.js:15359 static/js/zamboni/stats-all.js:15360 static/js/zamboni/stats-min.js:4
 msgid "Category Landing Featured Carousel"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:80 static/js/impala/stats/csv_keys.js:81
+#: static/js/impala/stats/csv_keys.js:80 static/js/impala/stats/csv_keys.js:81 static/js/zamboni/stats-all.js:15361 static/js/zamboni/stats-all.js:15362 static/js/zamboni/stats-min.js:4
 msgid "Category Landing Top Rated"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:82 static/js/impala/stats/csv_keys.js:83
+#: static/js/impala/stats/csv_keys.js:82 static/js/impala/stats/csv_keys.js:83 static/js/zamboni/stats-all.js:15363 static/js/zamboni/stats-all.js:15364 static/js/zamboni/stats-min.js:5
 msgid "Category Landing Most Popular"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:84 static/js/impala/stats/csv_keys.js:85
+#: static/js/impala/stats/csv_keys.js:84 static/js/impala/stats/csv_keys.js:85 static/js/zamboni/stats-all.js:15365 static/js/zamboni/stats-all.js:15366 static/js/zamboni/stats-min.js:5
 msgid "Category Landing Recently Added"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:86 static/js/impala/stats/csv_keys.js:87
+#: static/js/impala/stats/csv_keys.js:86 static/js/impala/stats/csv_keys.js:87 static/js/zamboni/stats-all.js:15367 static/js/zamboni/stats-all.js:15368 static/js/zamboni/stats-min.js:5
 msgid "Browse Listing Featured Sort"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:88 static/js/impala/stats/csv_keys.js:89
+#: static/js/impala/stats/csv_keys.js:88 static/js/impala/stats/csv_keys.js:89 static/js/zamboni/stats-all.js:15369 static/js/zamboni/stats-all.js:15370 static/js/zamboni/stats-min.js:5
 msgid "Browse Listing Users Sort"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:90 static/js/impala/stats/csv_keys.js:91
+#: static/js/impala/stats/csv_keys.js:90 static/js/impala/stats/csv_keys.js:91 static/js/zamboni/stats-all.js:15371 static/js/zamboni/stats-all.js:15372 static/js/zamboni/stats-min.js:5
 msgid "Browse Listing Rating Sort"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:92 static/js/impala/stats/csv_keys.js:93
+#: static/js/impala/stats/csv_keys.js:92 static/js/impala/stats/csv_keys.js:93 static/js/zamboni/stats-all.js:15373 static/js/zamboni/stats-all.js:15374 static/js/zamboni/stats-min.js:5
 msgid "Browse Listing Created Sort"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:94 static/js/impala/stats/csv_keys.js:95
+#: static/js/impala/stats/csv_keys.js:94 static/js/impala/stats/csv_keys.js:95 static/js/zamboni/stats-all.js:15375 static/js/zamboni/stats-all.js:15376 static/js/zamboni/stats-min.js:5
 msgid "Browse Listing Name Sort"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:96 static/js/impala/stats/csv_keys.js:97
+#: static/js/impala/stats/csv_keys.js:96 static/js/impala/stats/csv_keys.js:97 static/js/zamboni/stats-all.js:15377 static/js/zamboni/stats-all.js:15378 static/js/zamboni/stats-min.js:5
 msgid "Browse Listing Popular Sort"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:98 static/js/impala/stats/csv_keys.js:99
+#: static/js/impala/stats/csv_keys.js:98 static/js/impala/stats/csv_keys.js:99 static/js/zamboni/stats-all.js:15379 static/js/zamboni/stats-all.js:15380 static/js/zamboni/stats-min.js:5
 msgid "Browse Listing Updated Sort"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:100 static/js/impala/stats/csv_keys.js:101
+#: static/js/impala/stats/csv_keys.js:100 static/js/impala/stats/csv_keys.js:101 static/js/zamboni/stats-all.js:15381 static/js/zamboni/stats-all.js:15382 static/js/zamboni/stats-min.js:5
 msgid "Browse Listing Up and Coming Sort"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:105
+#: static/js/impala/stats/csv_keys.js:105 static/js/zamboni/stats-all.js:15386 static/js/zamboni/stats-min.js:5
 msgid "Total Amount Contributed"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:106
+#: static/js/impala/stats/csv_keys.js:106 static/js/zamboni/stats-all.js:15387 static/js/zamboni/stats-min.js:5
 msgid "Average Contribution"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:115
+#: static/js/impala/stats/csv_keys.js:115 static/js/zamboni/stats-all.js:15396 static/js/zamboni/stats-min.js:5
 msgid "Usage"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:118
+#: static/js/impala/stats/csv_keys.js:118 static/js/zamboni/stats-all.js:15399 static/js/zamboni/stats-min.js:5
 msgid "Firefox"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:119
+#: static/js/impala/stats/csv_keys.js:119 static/js/zamboni/stats-all.js:15400 static/js/zamboni/stats-min.js:5
 msgid "Mozilla"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:120
+#: static/js/impala/stats/csv_keys.js:120 static/js/zamboni/stats-all.js:15401 static/js/zamboni/stats-min.js:5
 msgid "Thunderbird"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:121
+#: static/js/impala/stats/csv_keys.js:121 static/js/zamboni/stats-all.js:15402 static/js/zamboni/stats-min.js:5
 msgid "Sunbird"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:122
+#: static/js/impala/stats/csv_keys.js:122 static/js/zamboni/stats-all.js:15403 static/js/zamboni/stats-min.js:5
 msgid "SeaMonkey"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:123
+#: static/js/impala/stats/csv_keys.js:123 static/js/zamboni/stats-all.js:15404 static/js/zamboni/stats-min.js:5
 msgid "Fennec"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:124
+#: static/js/impala/stats/csv_keys.js:124 static/js/zamboni/stats-all.js:15405 static/js/zamboni/stats-min.js:5
 msgid "Android"
 msgstr ""
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:129
+#: static/js/impala/stats/csv_keys.js:129 static/js/zamboni/stats-all.js:15410 static/js/zamboni/stats-min.js:5
 msgid "Downloads and Daily Users, last {0} days"
 msgstr ""
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:131
+#: static/js/impala/stats/csv_keys.js:131 static/js/zamboni/stats-all.js:15412 static/js/zamboni/stats-min.js:5
 msgid "Downloads and Daily Users from {0} to {1}"
 msgstr ""
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:135
+#: static/js/impala/stats/csv_keys.js:135 static/js/zamboni/stats-all.js:15416 static/js/zamboni/stats-min.js:5
 msgid "Installs and Daily Users, last {0} days"
 msgstr ""
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:137
+#: static/js/impala/stats/csv_keys.js:137 static/js/zamboni/stats-all.js:15418 static/js/zamboni/stats-min.js:5
 msgid "Installs and Daily Users from {0} to {1}"
 msgstr ""
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:141
+#: static/js/impala/stats/csv_keys.js:141 static/js/zamboni/stats-all.js:15422 static/js/zamboni/stats-min.js:5
 msgid "Downloads, last {0} days"
 msgstr ""
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:143
+#: static/js/impala/stats/csv_keys.js:143 static/js/zamboni/stats-all.js:15424 static/js/zamboni/stats-min.js:5
 msgid "Downloads from {0} to {1}"
 msgstr ""
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:147
+#: static/js/impala/stats/csv_keys.js:147 static/js/zamboni/stats-all.js:15428 static/js/zamboni/stats-min.js:5
 msgid "Daily Users, last {0} days"
 msgstr ""
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:149
+#: static/js/impala/stats/csv_keys.js:149 static/js/zamboni/stats-all.js:15430 static/js/zamboni/stats-min.js:5
 msgid "Daily Users from {0} to {1}"
 msgstr ""
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:153
+#: static/js/impala/stats/csv_keys.js:153 static/js/zamboni/stats-all.js:15434 static/js/zamboni/stats-min.js:5
 msgid "Applications, last {0} days"
 msgstr ""
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:155
+#: static/js/impala/stats/csv_keys.js:155 static/js/zamboni/stats-all.js:15436 static/js/zamboni/stats-min.js:5
 msgid "Applications from {0} to {1}"
 msgstr ""
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:159
+#: static/js/impala/stats/csv_keys.js:159 static/js/zamboni/stats-all.js:15440 static/js/zamboni/stats-min.js:5
 msgid "Platforms, last {0} days"
 msgstr ""
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:161
+#: static/js/impala/stats/csv_keys.js:161 static/js/zamboni/stats-all.js:15442 static/js/zamboni/stats-min.js:5
 msgid "Platforms from {0} to {1}"
 msgstr ""
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:165
+#: static/js/impala/stats/csv_keys.js:165 static/js/zamboni/stats-all.js:15446 static/js/zamboni/stats-min.js:5
 msgid "Languages, last {0} days"
 msgstr ""
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:167
+#: static/js/impala/stats/csv_keys.js:167 static/js/zamboni/stats-all.js:15448 static/js/zamboni/stats-min.js:5
 msgid "Languages from {0} to {1}"
 msgstr ""
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:171
+#: static/js/impala/stats/csv_keys.js:171 static/js/zamboni/stats-all.js:15452 static/js/zamboni/stats-min.js:5
 msgid "Add-on Versions, last {0} days"
 msgstr ""
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:173
+#: static/js/impala/stats/csv_keys.js:173 static/js/zamboni/stats-all.js:15454 static/js/zamboni/stats-min.js:5
 msgid "Add-on Versions from {0} to {1}"
 msgstr ""
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:177
+#: static/js/impala/stats/csv_keys.js:177 static/js/zamboni/stats-all.js:15458 static/js/zamboni/stats-min.js:5
 msgid "Add-on Status, last {0} days"
 msgstr ""
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:179
+#: static/js/impala/stats/csv_keys.js:179 static/js/zamboni/stats-all.js:15460 static/js/zamboni/stats-min.js:5
 msgid "Add-on Status from {0} to {1}"
 msgstr ""
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:183
+#: static/js/impala/stats/csv_keys.js:183 static/js/zamboni/stats-all.js:15464 static/js/zamboni/stats-min.js:5
 msgid "Download Sources, last {0} days"
 msgstr ""
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:185
+#: static/js/impala/stats/csv_keys.js:185 static/js/zamboni/stats-all.js:15466 static/js/zamboni/stats-min.js:5
 msgid "Download Sources from {0} to {1}"
 msgstr ""
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:189
+#: static/js/impala/stats/csv_keys.js:189 static/js/zamboni/stats-all.js:15470 static/js/zamboni/stats-min.js:5
 msgid "Contributions, last {0} days"
 msgstr ""
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:191
+#: static/js/impala/stats/csv_keys.js:191 static/js/zamboni/stats-all.js:15472 static/js/zamboni/stats-min.js:5
 msgid "Contributions from {0} to {1}"
 msgstr ""
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:195
+#: static/js/impala/stats/csv_keys.js:195 static/js/zamboni/stats-all.js:15476 static/js/zamboni/stats-min.js:5
 msgid "Site Metrics, last {0} days"
 msgstr ""
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:197
+#: static/js/impala/stats/csv_keys.js:197 static/js/zamboni/stats-all.js:15478 static/js/zamboni/stats-min.js:5
 msgid "Site Metrics from {0} to {1}"
 msgstr ""
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:201
+#: static/js/impala/stats/csv_keys.js:201 static/js/zamboni/stats-all.js:15482 static/js/zamboni/stats-min.js:5
 msgid "Add-ons in Use, last {0} days"
 msgstr ""
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:203
+#: static/js/impala/stats/csv_keys.js:203 static/js/zamboni/stats-all.js:15484 static/js/zamboni/stats-min.js:5
 msgid "Add-ons in Use from {0} to {1}"
 msgstr ""
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:207
+#: static/js/impala/stats/csv_keys.js:207 static/js/zamboni/stats-all.js:15488 static/js/zamboni/stats-min.js:5
 msgid "Add-ons Downloaded, last {0} days"
 msgstr ""
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:209
+#: static/js/impala/stats/csv_keys.js:209 static/js/zamboni/stats-all.js:15490 static/js/zamboni/stats-min.js:5
 msgid "Add-ons Downloaded from {0} to {1}"
 msgstr ""
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:213
+#: static/js/impala/stats/csv_keys.js:213 static/js/zamboni/stats-all.js:15494 static/js/zamboni/stats-min.js:5
 msgid "Add-ons Created, last {0} days"
 msgstr ""
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:215
+#: static/js/impala/stats/csv_keys.js:215 static/js/zamboni/stats-all.js:15496 static/js/zamboni/stats-min.js:5
 msgid "Add-ons Created from {0} to {1}"
 msgstr ""
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:219
+#: static/js/impala/stats/csv_keys.js:219 static/js/zamboni/stats-all.js:15500 static/js/zamboni/stats-min.js:5
 msgid "Add-ons Updated, last {0} days"
 msgstr ""
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:221
+#: static/js/impala/stats/csv_keys.js:221 static/js/zamboni/stats-all.js:15502 static/js/zamboni/stats-min.js:5
 msgid "Add-ons Updated from {0} to {1}"
 msgstr ""
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:225
+#: static/js/impala/stats/csv_keys.js:225 static/js/zamboni/stats-all.js:15506 static/js/zamboni/stats-min.js:5
 msgid "Reviews Written, last {0} days"
 msgstr ""
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:227
+#: static/js/impala/stats/csv_keys.js:227 static/js/zamboni/stats-all.js:15508 static/js/zamboni/stats-min.js:5
 msgid "Reviews Written from {0} to {1}"
 msgstr ""
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:231
+#: static/js/impala/stats/csv_keys.js:231 static/js/zamboni/stats-all.js:15512 static/js/zamboni/stats-min.js:5
 msgid "User Signups, last {0} days"
 msgstr ""
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:233
+#: static/js/impala/stats/csv_keys.js:233 static/js/zamboni/stats-all.js:15514 static/js/zamboni/stats-min.js:5
 msgid "User Signups from {0} to {1}"
 msgstr ""
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:237
+#: static/js/impala/stats/csv_keys.js:237 static/js/zamboni/stats-all.js:15518 static/js/zamboni/stats-min.js:5
 msgid "Collections Created, last {0} days"
 msgstr ""
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:239
+#: static/js/impala/stats/csv_keys.js:239 static/js/zamboni/stats-all.js:15520 static/js/zamboni/stats-min.js:5
 msgid "Collections Created from {0} to {1}"
 msgstr ""
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:243
+#: static/js/impala/stats/csv_keys.js:243 static/js/zamboni/stats-all.js:15524 static/js/zamboni/stats-min.js:5
 msgid "Subscribers, last {0} days"
 msgstr ""
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:245
+#: static/js/impala/stats/csv_keys.js:245 static/js/zamboni/stats-all.js:15526 static/js/zamboni/stats-min.js:5
 msgid "Subscribers from {0} to {1}"
 msgstr ""
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:249
+#: static/js/impala/stats/csv_keys.js:249 static/js/zamboni/stats-all.js:15530 static/js/zamboni/stats-min.js:5
 msgid "Ratings, last {0} days"
 msgstr ""
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:251
+#: static/js/impala/stats/csv_keys.js:251 static/js/zamboni/stats-all.js:15532 static/js/zamboni/stats-min.js:5
 msgid "Ratings from {0} to {1}"
 msgstr ""
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:255
+#: static/js/impala/stats/csv_keys.js:255 static/js/zamboni/stats-all.js:15536 static/js/zamboni/stats-min.js:5
 msgid "Sales, last {0} days"
 msgstr ""
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:257
+#: static/js/impala/stats/csv_keys.js:257 static/js/zamboni/stats-all.js:15538 static/js/zamboni/stats-min.js:5
 msgid "Sales from {0} to {1}"
 msgstr ""
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:261
+#: static/js/impala/stats/csv_keys.js:261 static/js/zamboni/stats-all.js:15542 static/js/zamboni/stats-min.js:5
 msgid "Installs, last {0} days"
 msgstr ""
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:263
+#: static/js/impala/stats/csv_keys.js:263 static/js/zamboni/stats-all.js:15544 static/js/zamboni/stats-min.js:5
 msgid "Installs from {0} to {1}"
 msgstr ""
 
 #. L10n: {0} and {1} are integers.
-#: static/js/impala/stats/csv_keys.js:269
+#: static/js/impala/stats/csv_keys.js:269 static/js/zamboni/stats-all.js:15550 static/js/zamboni/stats-min.js:5
 msgid "<b>{0}</b> in last {1} days"
 msgstr ""
 
 #. L10n: {0} is an integer and {1} and {2} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:271 static/js/impala/stats/csv_keys.js:277
+#: static/js/impala/stats/csv_keys.js:271 static/js/impala/stats/csv_keys.js:277 static/js/zamboni/stats-all.js:15552 static/js/zamboni/stats-all.js:15558 static/js/zamboni/stats-min.js:5
 msgid "<b>{0}</b> from {1} to {2}"
 msgstr ""
 
 #. L10n: {0} and {1} are integers.
-#: static/js/impala/stats/csv_keys.js:275
+#: static/js/impala/stats/csv_keys.js:275 static/js/zamboni/stats-all.js:15556 static/js/zamboni/stats-min.js:5
 msgid "<b>{0}</b> average in last {1} days"
 msgstr ""
 
-#: static/js/impala/stats/overview.js:19
+#: static/js/impala/stats/overview.js:19 static/js/zamboni/stats-all.js:16469 static/js/zamboni/stats-min.js:5
 msgid "No data available."
 msgstr ""
 
-#: static/js/impala/stats/table.js:74
+#: static/js/impala/stats/table.js:74 static/js/zamboni/stats-all.js:17209 static/js/zamboni/stats-min.js:5
 msgid "Date"
 msgstr ""
 
-#: static/js/impala/stats/topchart.js:96
+#: static/js/impala/stats/topchart.js:96 static/js/zamboni/stats-all.js:16600 static/js/zamboni/stats-min.js:5
 msgid "Other"
 msgstr ""
 
-#: static/js/zamboni/admin_validation.js:24 static/js/zamboni/devhub.js:1229 static/js/zamboni/editors.js:295
+#: static/js/zamboni/admin-all.js:180 static/js/zamboni/admin-min.js:1 static/js/zamboni/admin_validation.js:24 static/js/zamboni/devhub-all.js:2408 static/js/zamboni/devhub-min.js:2
+#: static/js/zamboni/devhub.js:1229 static/js/zamboni/editors-all.js:15576 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:295
 msgid "Select an application first"
 msgstr ""
 
-#: static/js/zamboni/admin_validation.js:51
+#: static/js/zamboni/admin-all.js:207 static/js/zamboni/admin-min.js:1 static/js/zamboni/admin_validation.js:51
 msgid "Set {0} add-on to a max version of {1} and email the author."
 msgid_plural "Set {0} add-ons to a max version of {1} and email the authors."
 msgstr[0] ""
 msgstr[1] ""
 
-#: static/js/zamboni/admin_validation.js:54
+#: static/js/zamboni/admin-all.js:210 static/js/zamboni/admin-min.js:1 static/js/zamboni/admin_validation.js:54
 msgid "Email author of {2} add-on which failed validation."
 msgid_plural "Email authors of {2} add-ons which failed validation."
 msgstr[0] ""
 msgstr[1] ""
 
-#. L10n: {0} is an app name like Firefox.
-#: static/js/zamboni/buttons.js:66
-msgid "Accept and Install"
-msgstr ""
-
-#: static/js/zamboni/buttons.js:66
-msgid "Add to {0}"
-msgstr ""
-
-#: static/js/zamboni/buttons.js:71
-msgid "Download Now"
-msgstr ""
-
-#: static/js/zamboni/buttons.js:112
-msgid "Add-on has not been updated to support default-to-compatible."
-msgstr ""
-
-#: static/js/zamboni/buttons.js:117
-msgid "You need to be using Firefox 10.0 or higher."
-msgstr ""
-
-#: static/js/zamboni/buttons.js:129
-msgid "Mozilla has marked this version as incompatible with your Firefox version."
-msgstr ""
-
-#. L10n: {0} is an platform like Windows or Linux.
-#: static/js/zamboni/buttons.js:210
-msgid "Install for {0} anyway"
-msgstr ""
-
-#: static/js/zamboni/buttons.js:210
-msgid "Download for {0} anyway"
-msgstr ""
-
-#: static/js/zamboni/buttons.js:267
-msgid "Not available for your platform"
-msgstr ""
-
-#. L10n: {0} is an app name, {1} is the app version.
-#: static/js/zamboni/buttons.js:278 static/js/zamboni/buttons.js:315
-msgid "Not available for {0} {1}"
-msgstr ""
-
-#: static/js/zamboni/buttons.js:341
-msgid "Works with {app} {min} - {max}"
-msgstr ""
-
-#: static/js/zamboni/buttons.js:343
-msgid "View other versions"
-msgstr ""
-
-#: static/js/zamboni/buttons.js:391
-msgid "Only with Firefox — Get Firefox Now!"
-msgstr ""
-
-#: static/js/zamboni/buttons.js:507 static/js/zamboni/mobile/buttons.js:43
-msgid "Sorry, you need a Mozilla-based browser (such as Firefox) to install a search plugin."
-msgstr ""
-
-#: static/js/zamboni/collections.js:229
-msgid "Adding to Favorites&hellip;"
-msgstr ""
-
-#: static/js/zamboni/collections.js:232
-msgid "Removing Favorite&hellip;"
-msgstr ""
-
-#: static/js/zamboni/collections.js:235
-msgid "Add to Favorites"
-msgstr ""
-
-#: static/js/zamboni/collections.js:238
-msgid "Remove from Favorites"
-msgstr ""
-
-#: static/js/zamboni/collections.js:303
-msgid "Pending"
-msgstr ""
-
-#: static/js/zamboni/collections.js:304
-msgid "Add a comment"
-msgstr ""
-
-#: static/js/zamboni/collections.js:304
-msgid "Comment"
-msgstr ""
-
-#: static/js/zamboni/collections.js:305
-msgid "Remove this add-on from the collection"
-msgstr ""
-
-#: static/js/zamboni/collections.js:305 static/js/zamboni/collections.js:334
-msgid "Remove"
-msgstr ""
-
-#: static/js/zamboni/collections.js:334
-msgid "Remove this user as a contributor"
-msgstr ""
-
-#: static/js/zamboni/collections.js:346
-msgid "An email address is required."
-msgstr ""
-
-#: static/js/zamboni/collections.js:364
-msgid "You cannot add yourself as a contributor."
-msgstr ""
-
-#: static/js/zamboni/collections.js:366
-msgid "You have already added that user."
-msgstr ""
-
-#: static/js/zamboni/collections.js:573
-msgid "Add to favorites"
-msgstr ""
-
-#: static/js/zamboni/collections.js:577
-msgid "Remove from favorites"
-msgstr ""
-
-#: static/js/zamboni/collections.js:604
-msgid "Stop following"
-msgstr ""
-
-#: static/js/zamboni/devhub.js:110
+#: static/js/zamboni/devhub-all.js:1289 static/js/zamboni/devhub-min.js:1 static/js/zamboni/devhub.js:110
 msgid "Your browser does not support the video tag"
 msgstr ""
 
-#: static/js/zamboni/devhub.js:371
+#: static/js/zamboni/devhub-all.js:1550 static/js/zamboni/devhub-min.js:1 static/js/zamboni/devhub.js:371
 msgid "Changes Saved"
 msgstr ""
 
-#: static/js/zamboni/devhub.js:387
+#: static/js/zamboni/devhub-all.js:1566 static/js/zamboni/devhub-min.js:1 static/js/zamboni/devhub.js:387
 msgid "Enter a new author's email address"
 msgstr ""
 
-#: static/js/zamboni/devhub.js:536
+#: static/js/zamboni/devhub-all.js:1715 static/js/zamboni/devhub-min.js:1 static/js/zamboni/devhub.js:536
 msgid "There was an error uploading your file."
 msgstr ""
 
-#: static/js/zamboni/devhub.js:681
+#: static/js/zamboni/devhub-all.js:1860 static/js/zamboni/devhub-min.js:1 static/js/zamboni/devhub.js:681
 msgid "{files} file"
 msgid_plural "{files} files"
 msgstr[0] ""
 msgstr[1] ""
 
-#: static/js/zamboni/devhub.js:684
+#: static/js/zamboni/devhub-all.js:1863 static/js/zamboni/devhub-min.js:1 static/js/zamboni/devhub.js:684
 msgid "{reviews} user review"
 msgid_plural "{reviews} user reviews"
 msgstr[0] ""
 msgstr[1] ""
 
-#: static/js/zamboni/devhub.js:796
+#: static/js/zamboni/devhub-all.js:1975 static/js/zamboni/devhub-min.js:2 static/js/zamboni/devhub.js:796
 msgid "Learn more"
 msgstr ""
 
-#: static/js/zamboni/devhub.js:800
+#: static/js/zamboni/devhub-all.js:1979 static/js/zamboni/devhub-min.js:2 static/js/zamboni/devhub.js:800
 msgid "Example"
 msgstr ""
 
-#: static/js/zamboni/devhub.js:1130
+#: static/js/zamboni/devhub-all.js:2309 static/js/zamboni/devhub-min.js:2 static/js/zamboni/devhub.js:1130
 msgid "Image changes being processed"
 msgstr ""
 
-#: static/js/zamboni/devhub.js:1280
+#: static/js/zamboni/devhub-all.js:2459 static/js/zamboni/devhub-min.js:2 static/js/zamboni/devhub.js:1280
 msgid "Must be a valid e-mail address."
+msgstr ""
+
+#: static/js/zamboni/devhub-all.js:2613 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:80
+msgid "All tests passed successfully."
+msgstr ""
+
+#: static/js/zamboni/devhub-all.js:2616 static/js/zamboni/devhub-all.js:3011 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:83 static/js/zamboni/validator.js:478
+msgid "These tests were not run."
+msgstr ""
+
+#: static/js/zamboni/devhub-all.js:2664 static/js/zamboni/devhub-all.js:2677 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:131 static/js/zamboni/validator.js:144
+msgid "Tests"
+msgstr ""
+
+#: static/js/zamboni/devhub-all.js:2779 static/js/zamboni/devhub-all.js:3108 static/js/zamboni/devhub-all.js:3127 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:246
+#: static/js/zamboni/validator.js:575 static/js/zamboni/validator.js:594
+msgid "Error"
+msgstr ""
+
+#: static/js/zamboni/devhub-all.js:2780 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:247
+msgid "Warning"
+msgstr ""
+
+#: static/js/zamboni/devhub-all.js:2794 static/js/zamboni/devhub-min.js:2 static/js/zamboni/files-all.js:5657 static/js/zamboni/files-min.js:3 static/js/zamboni/files.js:411
+#: static/js/zamboni/validator.js:261
+msgid "Ignore this message in future updates"
+msgstr ""
+
+#: static/js/zamboni/devhub-all.js:2817 static/js/zamboni/devhub-min.js:2 static/js/zamboni/files-all.js:5663 static/js/zamboni/files-min.js:3 static/js/zamboni/files.js:417
+#: static/js/zamboni/validator.js:284
+msgid "Severity for automated signing:"
+msgstr ""
+
+#: static/js/zamboni/devhub-all.js:2832 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:299
+msgid "Suggestions for passing automated signing:"
+msgstr ""
+
+#: static/js/zamboni/devhub-all.js:2920 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:387
+msgid "Compatibility Tests"
+msgstr ""
+
+#: static/js/zamboni/devhub-all.js:2999 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:466
+msgid "Add-on failed validation."
+msgstr ""
+
+#: static/js/zamboni/devhub-all.js:3001 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:468
+msgid "Add-on passed validation."
+msgstr ""
+
+#: static/js/zamboni/devhub-all.js:3014 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:481
+msgid "{0} error"
+msgid_plural "{0} errors"
+msgstr[0] ""
+msgstr[1] ""
+
+#: static/js/zamboni/devhub-all.js:3016 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:483
+msgid "{0} warning"
+msgid_plural "{0} warnings"
+msgstr[0] ""
+msgstr[1] ""
+
+#: static/js/zamboni/devhub-all.js:3018 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:485
+msgid "{0} notice"
+msgid_plural "{0} notices"
+msgstr[0] ""
+msgstr[1] ""
+
+#: static/js/zamboni/devhub-all.js:3110 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:577
+msgid "Validation task could not complete or completed with errors"
+msgstr ""
+
+#: static/js/zamboni/devhub-all.js:3128 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:595
+msgid "Internal server error"
 msgstr ""
 
 #: static/js/zamboni/devhub_search.js:8
 msgid "No results found."
 msgstr ""
 
-#: static/js/zamboni/editors.js:121
+#: static/js/zamboni/editors-all.js:15402 static/js/zamboni/editors-min.js:4 static/js/zamboni/editors.js:121
 msgid "{name} was viewing this page first."
 msgstr ""
 
-#: static/js/zamboni/editors.js:171
+#: static/js/zamboni/editors-all.js:15452 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:171
 msgid "Receipt checked by app."
 msgstr ""
 
-#: static/js/zamboni/editors.js:173
+#: static/js/zamboni/editors-all.js:15454 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:173
 msgid "Receipt was not checked by app."
 msgstr ""
 
-#: static/js/zamboni/editors.js:244
+#: static/js/zamboni/editors-all.js:15525 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:244
 msgid "{name} was viewing this add-on first."
 msgstr ""
 
-#: static/js/zamboni/editors.js:255
+#: static/js/zamboni/editors-all.js:15536 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:255
 msgid "Loading&hellip;"
 msgstr ""
 
-#: static/js/zamboni/editors.js:260
+#: static/js/zamboni/editors-all.js:15541 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:260
 msgid "Version Notes"
 msgstr ""
 
-#: static/js/zamboni/editors.js:265
+#: static/js/zamboni/editors-all.js:15546 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:265
 msgid "Notes for Reviewers"
 msgstr ""
 
-#: static/js/zamboni/editors.js:270
+#: static/js/zamboni/editors-all.js:15551 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:270
 msgid "No version notes found"
 msgstr ""
 
-#: static/js/zamboni/editors.js:330
+#: static/js/zamboni/editors-all.js:15611 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:330
 msgid "Average Reviews"
 msgstr ""
 
-#: static/js/zamboni/editors.js:386
+#: static/js/zamboni/editors-all.js:15667 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:386
 msgid "Number of Reviews"
 msgstr ""
 
-#: static/js/zamboni/editors.js:445
+#: static/js/zamboni/editors-all.js:15726 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:445
 msgid "Error loading translation"
 msgstr ""
 
-#: static/js/zamboni/files.js:411 static/js/zamboni/validator.js:261
-msgid "Ignore this message in future updates"
-msgstr ""
-
-#: static/js/zamboni/files.js:417 static/js/zamboni/validator.js:284
-msgid "Severity for automated signing:"
-msgstr ""
-
-#: static/js/zamboni/global.js:410
-msgid "Loading..."
-msgstr ""
-
-#. L10n: {0} is the number of characters left.
-#: static/js/zamboni/global.js:474
-msgid "<b>{0}</b> character left."
-msgid_plural "<b>{0}</b> characters left."
-msgstr[0] ""
-msgstr[1] ""
-
-#: static/js/zamboni/init.js:28
-msgid "This feature is temporarily disabled while we perform website maintenance. Please check back a little later."
-msgstr ""
-
-#: static/js/zamboni/l10n.js:45
-msgid "Remove this localization"
-msgstr ""
-
-#: static/js/zamboni/password-strength.js:20
-msgid "Password strength:"
-msgstr ""
-
-#: static/js/zamboni/password-strength.js:26
-msgid "At least {0} character left."
-msgid_plural "At least {0} characters left."
-msgstr[0] ""
-msgstr[1] ""
-
-#: static/js/zamboni/themes_review.js:176
-msgid "Requested Info"
-msgstr ""
-
-#: static/js/zamboni/themes_review.js:177
-msgid "Flagged"
-msgstr ""
-
-#: static/js/zamboni/themes_review.js:178
-msgid "Duplicate"
-msgstr ""
-
-#: static/js/zamboni/themes_review.js:179
-msgid "Rejected"
-msgstr ""
-
-#: static/js/zamboni/themes_review.js:180
-msgid "Approved"
-msgstr ""
-
-#: static/js/zamboni/themes_review.js:424
-msgid "No results found"
-msgstr ""
-
-#: static/js/zamboni/themes_review_templates.js:31
+#: static/js/zamboni/editors-all.js:15975 static/js/zamboni/editors-min.js:5 static/js/zamboni/themes_review_templates.js:31
 msgid "Theme"
 msgstr ""
 
-#: static/js/zamboni/themes_review_templates.js:33
+#: static/js/zamboni/editors-all.js:15977 static/js/zamboni/editors-min.js:5 static/js/zamboni/themes_review_templates.js:33
 msgid "Reviewer"
 msgstr ""
 
-#: static/js/zamboni/themes_review_templates.js:35
+#: static/js/zamboni/editors-all.js:15979 static/js/zamboni/editors-min.js:5 static/js/zamboni/themes_review_templates.js:35
 msgid "Status"
 msgstr ""
 
-#: static/js/zamboni/validator.js:80
-msgid "All tests passed successfully."
+#: static/js/zamboni/editors-all.js:16196 static/js/zamboni/editors-min.js:5 static/js/zamboni/themes_review.js:176
+msgid "Requested Info"
 msgstr ""
 
-#: static/js/zamboni/validator.js:83 static/js/zamboni/validator.js:478
-msgid "These tests were not run."
+#: static/js/zamboni/editors-all.js:16197 static/js/zamboni/editors-min.js:5 static/js/zamboni/themes_review.js:177
+msgid "Flagged"
 msgstr ""
 
-#: static/js/zamboni/validator.js:131 static/js/zamboni/validator.js:144
-msgid "Tests"
+#: static/js/zamboni/editors-all.js:16198 static/js/zamboni/editors-min.js:5 static/js/zamboni/themes_review.js:178
+msgid "Duplicate"
 msgstr ""
 
-#: static/js/zamboni/validator.js:246 static/js/zamboni/validator.js:575 static/js/zamboni/validator.js:594
-msgid "Error"
+#: static/js/zamboni/editors-all.js:16199 static/js/zamboni/editors-min.js:5 static/js/zamboni/themes_review.js:179
+msgid "Rejected"
 msgstr ""
 
-#: static/js/zamboni/validator.js:247
-msgid "Warning"
+#: static/js/zamboni/editors-all.js:16200 static/js/zamboni/editors-min.js:5 static/js/zamboni/themes_review.js:180
+msgid "Approved"
 msgstr ""
 
-#: static/js/zamboni/validator.js:299
-msgid "Suggestions for passing automated signing:"
+#: static/js/zamboni/editors-all.js:16444 static/js/zamboni/editors-min.js:5 static/js/zamboni/themes_review.js:424
+msgid "No results found"
 msgstr ""
 
-#: static/js/zamboni/validator.js:387
-msgid "Compatibility Tests"
-msgstr ""
-
-#: static/js/zamboni/validator.js:466
-msgid "Add-on failed validation."
-msgstr ""
-
-#: static/js/zamboni/validator.js:468
-msgid "Add-on passed validation."
-msgstr ""
-
-#: static/js/zamboni/validator.js:481
-msgid "{0} error"
-msgid_plural "{0} errors"
-msgstr[0] ""
-msgstr[1] ""
-
-#: static/js/zamboni/validator.js:483
-msgid "{0} warning"
-msgid_plural "{0} warnings"
-msgstr[0] ""
-msgstr[1] ""
-
-#: static/js/zamboni/validator.js:485
-msgid "{0} notice"
-msgid_plural "{0} notices"
-msgstr[0] ""
-msgstr[1] ""
-
-#: static/js/zamboni/validator.js:577
-msgid "Validation task could not complete or completed with errors"
-msgstr ""
-
-#: static/js/zamboni/validator.js:595
-msgid "Internal server error"
-msgstr ""
-
-#: static/js/zamboni/mobile/buttons.js:52
+#: static/js/zamboni/mobile-all.js:15186 static/js/zamboni/mobile/buttons.js:52
 msgid "Not Updated for {0} {1}"
 msgstr ""
 
-#: static/js/zamboni/mobile/buttons.js:53
+#: static/js/zamboni/mobile-all.js:15187 static/js/zamboni/mobile/buttons.js:53
 msgid "Requires Newer Version of {0}"
 msgstr ""
 
-#: static/js/zamboni/mobile/buttons.js:54
+#: static/js/zamboni/mobile-all.js:15188 static/js/zamboni/mobile/buttons.js:54
 msgid "Unreviewed"
 msgstr ""
 
-#: static/js/zamboni/mobile/buttons.js:55
+#: static/js/zamboni/mobile-all.js:15189 static/js/zamboni/mobile/buttons.js:55
 msgid "Experimental <span>(Learn More)</span>"
 msgstr ""
 
-#: static/js/zamboni/mobile/buttons.js:56 static/js/zamboni/mobile/buttons.js:57
+#: static/js/zamboni/mobile-all.js:15190 static/js/zamboni/mobile-all.js:15191 static/js/zamboni/mobile/buttons.js:56 static/js/zamboni/mobile/buttons.js:57
 msgid "Not Available for {0}"
 msgstr ""
 
-#: static/js/zamboni/mobile/buttons.js:58
+#: static/js/zamboni/mobile-all.js:15192 static/js/zamboni/mobile/buttons.js:58
 msgid "Experimental"
 msgstr ""
 
-#: static/js/zamboni/mobile/buttons.js:59
+#: static/js/zamboni/mobile-all.js:15193 static/js/zamboni/mobile/buttons.js:59
 msgid "Themes Require Newer Version of {0}"
 msgstr ""
 
-#: static/js/zamboni/mobile/buttons.js:60
+#: static/js/zamboni/mobile-all.js:15194 static/js/zamboni/mobile/buttons.js:60
 msgid "Themes Require {0}"
 msgstr ""
 
-#: static/js/zamboni/mobile/buttons.js:105
+#: static/js/zamboni/mobile-all.js:15239 static/js/zamboni/mobile/buttons.js:105
 msgid "Installing..."
 msgstr ""
 
-#: static/js/zamboni/mobile/buttons.js:125
+#: static/js/zamboni/mobile-all.js:15259 static/js/zamboni/mobile/buttons.js:125
 msgid "This add-on has been preliminarily reviewed by Mozilla."
 msgstr ""
 
-#: static/js/zamboni/mobile/buttons.js:250
+#: static/js/zamboni/mobile-all.js:15384 static/js/zamboni/mobile/buttons.js:250
 msgid "Keep it"
 msgstr ""
 
-#: static/js/zamboni/mobile/general.js:344
+#: static/js/zamboni/mobile-all.js:16049 static/js/zamboni/mobile-min.js:6 static/js/zamboni/mobile/general.js:344
 msgid "You're trying it on!"
 msgstr ""
 
-#: static/js/zamboni/mobile/general.js:356
+#: static/js/zamboni/mobile-all.js:16061 static/js/zamboni/mobile-min.js:6 static/js/zamboni/mobile/general.js:356
 msgid "Added to Firefox"
 msgstr ""
-

--- a/locale/bn_IN/LC_MESSAGES/django.po
+++ b/locale/bn_IN/LC_MESSAGES/django.po
@@ -3,69 +3,70 @@ msgid ""
 msgstr ""
 "Project-Id-Version:  0.1\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2016-02-24 21:23+0000\n"
+"POT-Creation-Date: 2016-04-18 15:47+0000\n"
 "PO-Revision-Date: 2012-02-27 09:15-0800\n"
 "Last-Translator: Wil Clouser <clouserw@khan.mozilla.org>\n"
 "Language-Team: Bengali\n"
+"Language: \n"
 "MIME-Version: 1.0\n"
-"Content-Type: text/plain; charset=utf-8\n"
+"Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Generated-By: Babel 2.2.0\n"
 
-#: src/olympia/accounts/views.py:52
+#: src/olympia/accounts/views.py:54
 msgid "Your log in attempt could not be parsed. Please try again."
 msgstr ""
 
-#: src/olympia/accounts/views.py:54
+#: src/olympia/accounts/views.py:56
 msgid "Your Firefox Account could not be found. Please try again."
 msgstr ""
 
-#: src/olympia/accounts/views.py:55
+#: src/olympia/accounts/views.py:57
 msgid "You could not be logged in. Please try again."
 msgstr ""
 
-#: src/olympia/accounts/views.py:57
+#: src/olympia/accounts/views.py:59
 msgid "Your account has already been migrated to Firefox Accounts."
 msgstr ""
 
-#: src/olympia/accounts/views.py:59
+#: src/olympia/accounts/views.py:61
 msgid "Your Firefox Account already exists on this site."
 msgstr ""
 
-#: src/olympia/accounts/views.py:108
+#: src/olympia/accounts/views.py:110
 msgid "Great job!"
 msgstr ""
 
-#: src/olympia/accounts/views.py:109
+#: src/olympia/accounts/views.py:111
 msgid "You can now log in to Add-ons with your Firefox Account."
 msgstr ""
 
-#: src/olympia/accounts/views.py:121
+#: src/olympia/accounts/views.py:123
 msgid "Need help?"
 msgstr ""
 
-#: src/olympia/addons/buttons.py:180
+#: src/olympia/addons/buttons.py:177
 msgid "Download Now"
 msgstr ""
 
-#: src/olympia/addons/buttons.py:182
+#: src/olympia/addons/buttons.py:179
 msgid "Download"
 msgstr ""
 
 #. L10n: please keep &nbsp; in the string so &rarr; does not wrap.
-#: src/olympia/addons/buttons.py:186
+#: src/olympia/addons/buttons.py:183
 msgid "Continue to Download&nbsp;&rarr;"
 msgstr ""
 
-#: src/olympia/addons/buttons.py:202 src/olympia/addons/helpers.py:35 src/olympia/addons/views.py:319 src/olympia/addons/templates/addons/impala/details.html:114
+#: src/olympia/addons/buttons.py:199 src/olympia/addons/helpers.py:35 src/olympia/addons/views.py:333 src/olympia/addons/templates/addons/impala/details.html:111
 #: src/olympia/addons/templates/addons/impala/listing/items.html:17 src/olympia/addons/templates/addons/mobile/home.html:40 src/olympia/amo/templates/amo/side_nav.html:6
-#: src/olympia/amo/templates/amo/side_nav.html:10 src/olympia/amo/templates/amo/site_nav.html:2 src/olympia/amo/templates/amo/site_nav.html:55 src/olympia/bandwagon/views.py:95
-#: src/olympia/browse/views.py:54 src/olympia/browse/views.py:68 src/olympia/browse/views.py:235 src/olympia/browse/templates/browse/impala/category_landing.html:22
+#: src/olympia/amo/templates/amo/side_nav.html:10 src/olympia/amo/templates/amo/site_nav.html:2 src/olympia/amo/templates/amo/site_nav.html:53 src/olympia/bandwagon/views.py:95
+#: src/olympia/browse/views.py:54 src/olympia/browse/views.py:68 src/olympia/browse/views.py:202 src/olympia/browse/templates/browse/impala/category_landing.html:22
 #: src/olympia/browse/templates/browse/personas/mobile/category_landing.html:26
 msgid "Featured"
 msgstr ""
 
-#: src/olympia/addons/buttons.py:221
+#: src/olympia/addons/buttons.py:218
 msgid "Add to {0}"
 msgstr ""
 
@@ -113,39 +114,39 @@ msgid_plural "All tags must be at least {0} characters."
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/olympia/addons/forms.py:234
+#: src/olympia/addons/forms.py:238
 msgid "Categories cannot be changed while your add-on is featured for this application."
 msgstr ""
 
 #. L10n: {0} is the number of categories.
-#: src/olympia/addons/forms.py:238
+#: src/olympia/addons/forms.py:242
 msgid "You can have only {0} category."
 msgid_plural "You can have only {0} categories."
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/olympia/addons/forms.py:246
+#: src/olympia/addons/forms.py:250
 msgid "The miscellaneous category cannot be combined with additional categories."
 msgstr ""
 
-#: src/olympia/addons/forms.py:369
+#: src/olympia/addons/forms.py:374
 #, python-format
 msgid "Before changing your default locale you must have a name, summary, and description in that locale. You are missing %s."
 msgstr ""
 
-#: src/olympia/addons/forms.py:484 src/olympia/addons/forms.py:575
+#: src/olympia/addons/forms.py:455 src/olympia/addons/forms.py:546
 msgid "A license must be selected."
 msgstr ""
 
-#: src/olympia/addons/forms.py:556
+#: src/olympia/addons/forms.py:527
 msgid "Give Your Theme a Name."
 msgstr ""
 
-#: src/olympia/addons/forms.py:562 src/olympia/devhub/templates/devhub/personas/submit.html:53
+#: src/olympia/addons/forms.py:533 src/olympia/devhub/templates/devhub/personas/submit.html:53
 msgid "Describe your Theme."
 msgstr ""
 
-#: src/olympia/addons/forms.py:704
+#: src/olympia/addons/forms.py:675
 msgid "Enter a new author's email address"
 msgstr ""
 
@@ -153,37 +154,37 @@ msgstr ""
 msgid "Not Reviewed"
 msgstr ""
 
-#: src/olympia/addons/models.py:301
+#: src/olympia/addons/models.py:298
 msgid "Users have the option of contributing more or less than this amount."
 msgstr ""
 
-#: src/olympia/addons/models.py:309
-msgid "Users will always be asked in the Add-ons Manager (Firefox 4 and above)"
+#: src/olympia/addons/models.py:306
+msgid "Users will always be asked in the Add-ons Manager (Firefox 4 and above). Only applies to desktop."
 msgstr ""
 
-#: src/olympia/addons/models.py:1804 src/olympia/addons/templates/addons/details_box.html:55 src/olympia/devhub/templates/devhub/index.html:92
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:102
+#: src/olympia/addons/models.py:1802 src/olympia/addons/templates/addons/details_box.html:55 src/olympia/devhub/templates/devhub/index.html:92
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:89
 msgid "Listed"
 msgstr ""
 
-#: src/olympia/addons/views.py:320 src/olympia/browse/templates/browse/personas/mobile/category_landing.html:27
+#: src/olympia/addons/views.py:334 src/olympia/browse/templates/browse/personas/mobile/category_landing.html:27
 msgid "Popular"
 msgstr ""
 
-#: src/olympia/addons/views.py:321 src/olympia/browse/views.py:238 src/olympia/browse/views.py:280 src/olympia/browse/views.py:482
+#: src/olympia/addons/views.py:335 src/olympia/browse/views.py:205 src/olympia/browse/views.py:247 src/olympia/browse/views.py:449
 msgid "Recently Added"
 msgstr ""
 
-#: src/olympia/addons/views.py:322 src/olympia/bandwagon/views.py:99 src/olympia/browse/views.py:60 src/olympia/browse/views.py:71 src/olympia/search/forms.py:16 src/olympia/search/forms.py:91
+#: src/olympia/addons/views.py:336 src/olympia/bandwagon/views.py:99 src/olympia/browse/views.py:60 src/olympia/browse/views.py:71 src/olympia/search/forms.py:16 src/olympia/search/forms.py:91
 msgid "Recently Updated"
 msgstr ""
 
 #. l10n: {0} is the addon name
-#: src/olympia/addons/views.py:520
+#: src/olympia/addons/views.py:534
 msgid "Contribution for {0}"
 msgstr ""
 
-#: src/olympia/addons/views.py:613
+#: src/olympia/addons/views.py:627
 msgid "Abuse reported."
 msgstr ""
 
@@ -250,9 +251,9 @@ msgstr ""
 #: src/olympia/devhub/templates/devhub/addons/ajax_compat_update.html:36 src/olympia/devhub/templates/devhub/addons/profile.html:44 src/olympia/devhub/templates/devhub/addons/edit/admin.html:101
 #: src/olympia/devhub/templates/devhub/addons/edit/basic.html:152 src/olympia/devhub/templates/devhub/addons/edit/details.html:85 src/olympia/devhub/templates/devhub/addons/edit/support.html:67
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:166 src/olympia/devhub/templates/devhub/addons/forms_shared/media.html:149
-#: src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:44 src/olympia/devhub/templates/devhub/versions/add_file_modal.html:78 src/olympia/devhub/templates/devhub/versions/edit.html:139
-#: src/olympia/devhub/templates/devhub/versions/list.html:242 src/olympia/devhub/templates/devhub/versions/list.html:276 src/olympia/devhub/templates/devhub/versions/list.html:317
-#: src/olympia/devhub/templates/devhub/versions/list.html:351 src/olympia/reviews/templates/reviews/edit_review.html:16 src/olympia/translations/templates/translations/trans-menu.html:50
+#: src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:43 src/olympia/devhub/templates/devhub/versions/add_file_modal.html:58 src/olympia/devhub/templates/devhub/versions/edit.html:139
+#: src/olympia/devhub/templates/devhub/versions/list.html:239 src/olympia/devhub/templates/devhub/versions/list.html:281 src/olympia/devhub/templates/devhub/versions/list.html:315
+#: src/olympia/devhub/templates/devhub/versions/list.html:349 src/olympia/reviews/templates/reviews/edit_review.html:16 src/olympia/translations/templates/translations/trans-menu.html:50
 #: src/olympia/translations/templates/translations/trans-menu.html:62
 msgid "or"
 msgstr ""
@@ -363,7 +364,7 @@ msgid "Add-on Information for {0}"
 msgstr ""
 
 #: src/olympia/addons/templates/addons/details_box.html:30 src/olympia/addons/templates/addons/persona_detail_table.html:3 src/olympia/addons/templates/addons/mobile/details.html:63
-#: src/olympia/addons/templates/addons/mobile/persona_detail_table.html:7 src/olympia/browse/views.py:459 src/olympia/devhub/views.py:75
+#: src/olympia/addons/templates/addons/mobile/persona_detail_table.html:7 src/olympia/browse/views.py:426 src/olympia/devhub/views.py:73
 msgid "Updated"
 msgstr ""
 
@@ -382,11 +383,11 @@ msgstr ""
 msgid "Visibility"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/details_box.html:57 src/olympia/devhub/templates/devhub/index.html:94 src/olympia/devhub/templates/devhub/includes/addon_details.html:104
+#: src/olympia/addons/templates/addons/details_box.html:57 src/olympia/devhub/templates/devhub/index.html:94 src/olympia/devhub/templates/devhub/includes/addon_details.html:91
 msgid "Hidden"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/details_box.html:59 src/olympia/devhub/templates/devhub/index.html:96 src/olympia/devhub/templates/devhub/includes/addon_details.html:106
+#: src/olympia/addons/templates/addons/details_box.html:59 src/olympia/devhub/templates/devhub/index.html:96 src/olympia/devhub/templates/devhub/includes/addon_details.html:93
 msgid "Unlisted"
 msgstr ""
 
@@ -394,13 +395,13 @@ msgstr ""
 msgid "Required Add-ons"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/details_box.html:81 src/olympia/addons/templates/addons/persona_detail_table.html:15 src/olympia/browse/views.py:462 src/olympia/devhub/views.py:78
-#: src/olympia/devhub/views.py:85 src/olympia/discovery/templates/discovery/addons/detail.html:57 src/olympia/reviews/forms.py:62 src/olympia/reviews/templates/reviews/add.html:57
+#: src/olympia/addons/templates/addons/details_box.html:81 src/olympia/addons/templates/addons/persona_detail_table.html:15 src/olympia/browse/views.py:429 src/olympia/devhub/views.py:76
+#: src/olympia/devhub/views.py:83 src/olympia/discovery/templates/discovery/addons/detail.html:57 src/olympia/reviews/forms.py:62 src/olympia/reviews/templates/reviews/add.html:57
 #: src/olympia/reviews/templates/reviews/mobile/review_list.html:18
 msgid "Rating"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/details_box.html:85 src/olympia/browse/views.py:461 src/olympia/devhub/views.py:77 src/olympia/devhub/views.py:84
+#: src/olympia/addons/templates/addons/details_box.html:85 src/olympia/browse/views.py:428 src/olympia/devhub/views.py:75 src/olympia/devhub/views.py:82
 #: src/olympia/stats/templates/stats/addon_report_menu.html:8 src/olympia/stats/templates/stats/collection_report_menu.html:18
 msgid "Downloads"
 msgstr ""
@@ -420,7 +421,7 @@ msgstr ""
 
 #. The Privacy Policy for this add-on.
 #: src/olympia/addons/templates/addons/details_box.html:121 src/olympia/addons/templates/addons/privacy.html:19 src/olympia/addons/templates/addons/privacy.html:23
-#: src/olympia/addons/templates/addons/impala/button.html:43 src/olympia/addons/templates/addons/impala/details.html:307 src/olympia/devhub/templates/devhub/includes/policy_form.html:20
+#: src/olympia/addons/templates/addons/impala/button.html:43 src/olympia/addons/templates/addons/impala/details.html:312 src/olympia/devhub/templates/devhub/includes/policy_form.html:23
 #: src/olympia/templates/mobile/base_addons.html:87
 msgid "Privacy Policy"
 msgstr ""
@@ -445,7 +446,7 @@ msgstr ""
 msgid "Developer Comments"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/details_box.html:199 src/olympia/addons/templates/addons/impala/details.html:259
+#: src/olympia/addons/templates/addons/details_box.html:199 src/olympia/addons/templates/addons/impala/details.html:264
 msgid "Development Channel"
 msgstr ""
 
@@ -465,7 +466,7 @@ msgid ""
 "developer. To stop receiving development updates, reinstall the default version from the link above."
 msgstr ""
 
-#: src/olympia/addons/templates/addons/details_box.html:220 src/olympia/addons/templates/addons/impala/details.html:278
+#: src/olympia/addons/templates/addons/details_box.html:220 src/olympia/addons/templates/addons/impala/details.html:283
 msgid "Version {0}:"
 msgstr ""
 
@@ -484,7 +485,7 @@ msgid "End-User License Agreement for {0}"
 msgstr ""
 
 #: src/olympia/addons/templates/addons/eula.html:17 src/olympia/addons/templates/addons/eula.html:21 src/olympia/addons/templates/addons/impala/button.html:48
-#: src/olympia/addons/templates/addons/impala/details.html:316 src/olympia/devhub/templates/devhub/includes/policy_form.html:3 src/olympia/discovery/templates/discovery/addons/eula.html:11
+#: src/olympia/addons/templates/addons/impala/details.html:321 src/olympia/devhub/templates/devhub/includes/policy_form.html:3 src/olympia/discovery/templates/discovery/addons/eula.html:11
 msgid "End-User License Agreement"
 msgstr ""
 
@@ -501,7 +502,7 @@ msgstr ""
 msgid "Add-ons for {0}"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/home.html:10 src/olympia/addons/templates/addons/home.html:51 src/olympia/browse/templates/browse/impala/base_listing.html:11
+#: src/olympia/addons/templates/addons/home.html:10 src/olympia/addons/templates/addons/home.html:53 src/olympia/browse/templates/browse/impala/base_listing.html:11
 msgid "Featured Extensions"
 msgstr ""
 
@@ -509,29 +510,29 @@ msgstr ""
 msgid "Popular Extensions"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/home.html:42 src/olympia/amo/templates/amo/side_nav.html:3 src/olympia/amo/templates/amo/side_nav.html:11 src/olympia/amo/templates/amo/site_nav.html:3
-#: src/olympia/amo/templates/amo/site_nav.html:25 src/olympia/browse/views.py:236 src/olympia/browse/views.py:281 src/olympia/browse/views.py:481
+#: src/olympia/addons/templates/addons/home.html:44 src/olympia/amo/templates/amo/side_nav.html:3 src/olympia/amo/templates/amo/side_nav.html:11 src/olympia/amo/templates/amo/site_nav.html:3
+#: src/olympia/amo/templates/amo/site_nav.html:25 src/olympia/browse/views.py:203 src/olympia/browse/views.py:248 src/olympia/browse/views.py:448
 msgid "Most Popular"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/home.html:43
+#: src/olympia/addons/templates/addons/home.html:45
 msgid "All »"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/home.html:52 src/olympia/addons/templates/addons/home.html:61 src/olympia/addons/templates/addons/home.html:70 src/olympia/addons/templates/addons/home.html:78
+#: src/olympia/addons/templates/addons/home.html:54 src/olympia/addons/templates/addons/home.html:63 src/olympia/addons/templates/addons/home.html:72 src/olympia/addons/templates/addons/home.html:80
 #: src/olympia/browse/templates/browse/impala/category_landing.html:36
 msgid "See all »"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/home.html:60
+#: src/olympia/addons/templates/addons/home.html:62
 msgid "Up &amp; Coming Extensions"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/home.html:69 src/olympia/browse/templates/browse/personas/category_landing.html:61 src/olympia/discovery/templates/discovery/pane.html:74
+#: src/olympia/addons/templates/addons/home.html:71 src/olympia/browse/templates/browse/personas/category_landing.html:61 src/olympia/discovery/templates/discovery/pane.html:74
 msgid "Featured Themes"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/home.html:77 src/olympia/bandwagon/templates/bandwagon/impala/collection_listing.html:5
+#: src/olympia/addons/templates/addons/home.html:79 src/olympia/bandwagon/templates/bandwagon/impala/collection_listing.html:5
 msgid "Featured Collections"
 msgstr ""
 
@@ -549,7 +550,7 @@ msgid "Updated {0}"
 msgstr ""
 
 #. {0} is a date.
-#: src/olympia/addons/templates/addons/macros.html:10 src/olympia/addons/templates/addons/macros.html:69 src/olympia/addons/templates/addons/persona_preview.html:21
+#: src/olympia/addons/templates/addons/macros.html:10 src/olympia/addons/templates/addons/macros.html:69 src/olympia/addons/templates/addons/persona_preview.html:22
 #: src/olympia/addons/templates/addons/listing/items_mobile.html:44 src/olympia/addons/templates/addons/listing/macros.html:39
 #: src/olympia/bandwagon/templates/bandwagon/collection_listing_items.html:37 src/olympia/bandwagon/templates/bandwagon/impala/collection_listing_items.html:37
 msgid "Added {0}"
@@ -570,15 +571,14 @@ msgstr[0] ""
 msgstr[1] ""
 
 #. {0} is the number of downloads.
-#: src/olympia/addons/templates/addons/macros.html:53 src/olympia/addons/templates/addons/impala/details.html:61
+#: src/olympia/addons/templates/addons/macros.html:53 src/olympia/addons/templates/addons/impala/details.html:59
 msgid "{0} weekly download"
 msgid_plural "{0} weekly downloads"
 msgstr[0] ""
 msgstr[1] ""
 
 #. {0} is the number of users.
-#: src/olympia/addons/templates/addons/macros.html:61 src/olympia/addons/templates/addons/impala/details.html:54 src/olympia/compat/templates/compat/index.html:71
-#: src/olympia/zadmin/templates/zadmin/compat.html:67
+#: src/olympia/addons/templates/addons/macros.html:61 src/olympia/addons/templates/addons/impala/details.html:52 src/olympia/zadmin/templates/zadmin/compat.html:67
 msgid "{0} user"
 msgid_plural "{0} users"
 msgstr[0] ""
@@ -596,7 +596,7 @@ msgstr ""
 msgid "Return to the addon."
 msgstr ""
 
-#: src/olympia/addons/templates/addons/persona_detail.html:17 src/olympia/addons/templates/addons/impala/details.html:106 src/olympia/addons/templates/addons/mobile/details.html:23
+#: src/olympia/addons/templates/addons/persona_detail.html:17 src/olympia/addons/templates/addons/impala/details.html:103 src/olympia/addons/templates/addons/mobile/details.html:23
 #: src/olympia/addons/templates/addons/mobile/persona_detail.html:21 src/olympia/discovery/templates/discovery/addons/base.html:27 src/olympia/editors/templates/editors/review.html:31
 msgid "by"
 msgstr ""
@@ -640,34 +640,35 @@ msgstr ""
 msgid "License"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/persona_preview.html:12 src/olympia/constants/base.py:48
+#: src/olympia/addons/templates/addons/persona_preview.html:13 src/olympia/constants/base.py:48
 msgid "Awaiting Review"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/persona_preview.html:14 src/olympia/amo/log.py:180 src/olympia/constants/base.py:42 src/olympia/editors/helpers.py:62
+#: src/olympia/addons/templates/addons/persona_preview.html:15 src/olympia/amo/log.py:180 src/olympia/constants/base.py:42 src/olympia/editors/helpers.py:62
 msgid "Rejected"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/persona_preview.html:16 src/olympia/amo/log.py:159
+#: src/olympia/addons/templates/addons/persona_preview.html:17 src/olympia/amo/log.py:159
 msgid "Approved"
 msgstr ""
 
 #. {0} is the number of users.
-#: src/olympia/addons/templates/addons/persona_preview.html:26 src/olympia/addons/templates/addons/listing/items_mobile.html:36 src/olympia/addons/templates/addons/listing/macros.html:31
+#: src/olympia/addons/templates/addons/persona_preview.html:27 src/olympia/addons/templates/addons/listing/items_mobile.html:36 src/olympia/addons/templates/addons/listing/macros.html:31
 msgid "<strong>{0}</strong> user"
 msgid_plural "<strong>{0}</strong> users"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/olympia/addons/templates/addons/persona_preview.html:40
+#: src/olympia/addons/templates/addons/persona_preview.html:41
 msgid "Hover to Preview"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/persona_preview.html:46 src/olympia/addons/templates/addons/persona_preview.html:48 src/olympia/reviews/templates/reviews/add.html:15
+#: src/olympia/addons/templates/addons/persona_preview.html:47 src/olympia/addons/templates/addons/persona_preview.html:49 src/olympia/addons/templates/addons/persona_preview.html:97
+#: src/olympia/reviews/templates/reviews/add.html:15
 msgid "Add"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/persona_preview.html:57 src/olympia/bandwagon/templates/bandwagon/ajax_new.html:16 src/olympia/bandwagon/templates/bandwagon/edit.html:19
+#: src/olympia/addons/templates/addons/persona_preview.html:58 src/olympia/bandwagon/templates/bandwagon/ajax_new.html:16 src/olympia/bandwagon/templates/bandwagon/edit.html:19
 #: src/olympia/bandwagon/templates/bandwagon/includes/addedit.html:19 src/olympia/devhub/templates/devhub/addons/edit/admin.html:13 src/olympia/devhub/templates/devhub/addons/edit/basic.html:10
 #: src/olympia/devhub/templates/devhub/addons/edit/details.html:8 src/olympia/devhub/templates/devhub/addons/edit/media.html:6 src/olympia/devhub/templates/devhub/addons/edit/support.html:8
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:9 src/olympia/devhub/templates/devhub/addons/submit/describe.html:29 src/olympia/editors/templates/editors/review.html:257
@@ -676,21 +677,21 @@ msgstr ""
 
 #. For datetime formatting, see the table on
 #. http://docs.python.org/library/datetime.html#strftime-and-strptime-behavior
-#: src/olympia/addons/templates/addons/persona_preview.html:66
+#: src/olympia/addons/templates/addons/persona_preview.html:67
 #, python-format
 msgid "%%Y-%%m-%%d"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/persona_preview.html:67
+#: src/olympia/addons/templates/addons/persona_preview.html:68
 msgid "by {0} on {1}"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/persona_preview.html:75 src/olympia/reviews/helpers.py:17 src/olympia/reviews/templates/reviews/review_list.html:63
+#: src/olympia/addons/templates/addons/persona_preview.html:76 src/olympia/reviews/helpers.py:17 src/olympia/reviews/templates/reviews/review_list.html:63
 #: src/olympia/reviews/templates/reviews/reviews_link.html:21 src/olympia/reviews/templates/reviews/impala/reviews_link.html:16
 msgid "Not yet rated"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/persona_preview.html:78
+#: src/olympia/addons/templates/addons/persona_preview.html:79
 msgid "<b>{0}</b> users"
 msgstr ""
 
@@ -703,7 +704,7 @@ msgid "Learn more about Firefox"
 msgstr ""
 
 #: src/olympia/addons/templates/addons/popups.html:22
-msgid "or <b><a class=\"installer\" href=\"{url}\">download anyway</a></b>"
+msgid "or <b><a class=\"button installer\" href=\"{url}\">download anyway</a></b>"
 msgstr ""
 
 #: src/olympia/addons/templates/addons/popups.html:26
@@ -802,7 +803,7 @@ msgid ""
 msgstr ""
 
 #: src/olympia/addons/templates/addons/report_abuse.html:6 src/olympia/addons/templates/addons/report_abuse_full.html:10 src/olympia/addons/templates/addons/impala/details-more.html:23
-#: src/olympia/addons/templates/addons/impala/details.html:328
+#: src/olympia/addons/templates/addons/impala/details.html:333
 msgid "Report Abuse"
 msgstr ""
 
@@ -821,9 +822,9 @@ msgstr ""
 #: src/olympia/devhub/templates/devhub/addons/ajax_compat_update.html:36 src/olympia/devhub/templates/devhub/addons/profile.html:44 src/olympia/devhub/templates/devhub/addons/edit/admin.html:104
 #: src/olympia/devhub/templates/devhub/addons/edit/basic.html:155 src/olympia/devhub/templates/devhub/addons/edit/details.html:88 src/olympia/devhub/templates/devhub/addons/edit/support.html:70
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:169 src/olympia/devhub/templates/devhub/addons/forms_shared/media.html:152
-#: src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:44 src/olympia/devhub/templates/devhub/personas/edit.html:222 src/olympia/devhub/templates/devhub/versions/add_file_modal.html:79
-#: src/olympia/devhub/templates/devhub/versions/edit.html:140 src/olympia/devhub/templates/devhub/versions/list.html:208 src/olympia/devhub/templates/devhub/versions/list.html:242
-#: src/olympia/devhub/templates/devhub/versions/list.html:276 src/olympia/devhub/templates/devhub/versions/list.html:317 src/olympia/reviews/templates/reviews/edit_review.html:16
+#: src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:43 src/olympia/devhub/templates/devhub/personas/edit.html:222 src/olympia/devhub/templates/devhub/versions/add_file_modal.html:59
+#: src/olympia/devhub/templates/devhub/versions/edit.html:140 src/olympia/devhub/templates/devhub/versions/list.html:208 src/olympia/devhub/templates/devhub/versions/list.html:239
+#: src/olympia/devhub/templates/devhub/versions/list.html:281 src/olympia/devhub/templates/devhub/versions/list.html:315 src/olympia/reviews/templates/reviews/edit_review.html:16
 #: src/olympia/translations/templates/translations/trans-menu.html:50 src/olympia/translations/templates/translations/trans-menu.html:62 src/olympia/zadmin/templates/zadmin/validation.html:105
 msgid "Cancel"
 msgstr ""
@@ -868,7 +869,7 @@ msgstr ""
 msgid "Review Guidelines"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/review_list_box.html:5 src/olympia/addons/templates/addons/impala/details-more.html:27 src/olympia/editors/helpers.py:921
+#: src/olympia/addons/templates/addons/review_list_box.html:5 src/olympia/addons/templates/addons/impala/details-more.html:27 src/olympia/editors/helpers.py:1001
 #: src/olympia/reviews/templates/reviews/add.html:14 src/olympia/reviews/templates/reviews/reply.html:14 src/olympia/reviews/templates/reviews/review_list.html:19
 #: src/olympia/reviews/templates/reviews/mobile/review_list.html:26
 msgid "Reviews"
@@ -959,119 +960,119 @@ msgid_plural "Other add-ons by these authors"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/olympia/addons/templates/addons/impala/details.html:41
+#: src/olympia/addons/templates/addons/impala/details.html:39
 #, python-format
 msgid "<span itemprop=\"ratingCount\">%(num)s</span> user review"
 msgid_plural "<span itemprop=\"ratingCount\">%(num)s</span> user reviews"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/olympia/addons/templates/addons/impala/details.html:69
+#: src/olympia/addons/templates/addons/impala/details.html:66
 msgid "View statistics"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/impala/details.html:84
+#: src/olympia/addons/templates/addons/impala/details.html:81
 msgid "Manage"
 msgstr ""
 
 #. {0} is an add-on name.
-#: src/olympia/addons/templates/addons/impala/details.html:96
+#: src/olympia/addons/templates/addons/impala/details.html:93
 msgid "Icon of {0}"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/impala/details.html:103 src/olympia/addons/templates/addons/impala/listing/items.html:14
+#: src/olympia/addons/templates/addons/impala/details.html:100 src/olympia/addons/templates/addons/impala/listing/items.html:14
 msgid "No Restart"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/impala/details.html:127
+#: src/olympia/addons/templates/addons/impala/details.html:124
 #, python-format
 msgid "Meet the Developer: <a href=\"%(url)s\">%(name)s</a>"
 msgid_plural "<a href=\"%(url)s\">Meet the Developers</a>"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/olympia/addons/templates/addons/impala/details.html:137
+#: src/olympia/addons/templates/addons/impala/details.html:134
 msgid "Learn why {0} was created and find out what's next for this add-on."
 msgstr ""
 
 #. {0} is an index.
-#: src/olympia/addons/templates/addons/impala/details.html:156
+#: src/olympia/addons/templates/addons/impala/details.html:161
 msgid "Add-on screenshot #{0}"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/impala/details.html:182
+#: src/olympia/addons/templates/addons/impala/details.html:187
 msgid "Add-on home page"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/impala/details.html:185
+#: src/olympia/addons/templates/addons/impala/details.html:190
 msgid "Support site"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/impala/details.html:189
+#: src/olympia/addons/templates/addons/impala/details.html:194
 msgid "Support E-mail"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/impala/details.html:194 src/olympia/devhub/models.py:378 src/olympia/devhub/templates/devhub/versions/list.html:12
+#: src/olympia/addons/templates/addons/impala/details.html:199 src/olympia/devhub/models.py:378 src/olympia/devhub/templates/devhub/versions/list.html:12
 #: src/olympia/versions/templates/versions/version.html:6 src/olympia/versions/templates/versions/mobile/version.html:6
 msgid "Version {0}"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/impala/details.html:194
+#: src/olympia/addons/templates/addons/impala/details.html:199
 msgid "Info"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/impala/details.html:195 src/olympia/devhub/templates/devhub/includes/addon_details.html:129
+#: src/olympia/addons/templates/addons/impala/details.html:200 src/olympia/devhub/templates/devhub/includes/addon_details.html:116
 msgid "Last Updated:"
-msgstr ""
-
-#: src/olympia/addons/templates/addons/impala/details.html:200
-#, python-format
-msgid "Released under <a target=\"_blank\" href=\"%(url)s\">%(name)s</a>"
-msgstr ""
-
-#: src/olympia/addons/templates/addons/impala/details.html:201 src/olympia/addons/templates/addons/impala/details.html:206 src/olympia/amo/helpers.py:398 src/olympia/devhub/forms.py:142
-#: src/olympia/devhub/forms.py:173 src/olympia/versions/templates/versions/version.html:40 src/olympia/versions/templates/versions/version.html:45
-msgid "Custom License"
 msgstr ""
 
 #: src/olympia/addons/templates/addons/impala/details.html:205
 #, python-format
+msgid "Released under <a target=\"_blank\" href=\"%(url)s\">%(name)s</a>"
+msgstr ""
+
+#: src/olympia/addons/templates/addons/impala/details.html:206 src/olympia/addons/templates/addons/impala/details.html:211 src/olympia/amo/helpers.py:398 src/olympia/devhub/forms.py:142
+#: src/olympia/devhub/forms.py:173 src/olympia/versions/templates/versions/version.html:40 src/olympia/versions/templates/versions/version.html:45
+msgid "Custom License"
+msgstr ""
+
+#: src/olympia/addons/templates/addons/impala/details.html:210
+#, python-format
 msgid "Released under <a href=\"%(url)s\">%(name)s</a>"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/impala/details.html:217
+#: src/olympia/addons/templates/addons/impala/details.html:222
 msgid "About this Add-on"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/impala/details.html:233
+#: src/olympia/addons/templates/addons/impala/details.html:238
 msgid "Developer’s Comments"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/impala/details.html:243
+#: src/olympia/addons/templates/addons/impala/details.html:248
 msgid "Version Information"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/impala/details.html:250
+#: src/olympia/addons/templates/addons/impala/details.html:255
 msgid "See complete version history"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/impala/details.html:262
+#: src/olympia/addons/templates/addons/impala/details.html:267
 msgid ""
 "The Development Channel lets you test an experimental new version of this add-on before it's released to the general public. Once you install the development version, you will continue to get "
 "updates from this channel. To stop receiving development updates, reinstall the default version from the link above."
 msgstr ""
 
-#: src/olympia/addons/templates/addons/impala/details.html:272
+#: src/olympia/addons/templates/addons/impala/details.html:277
 msgid "<strong>Caution:</strong> Development versions of this add-on have not been reviewed by Mozilla."
 msgstr ""
 
-#: src/olympia/addons/templates/addons/impala/details.html:287
+#: src/olympia/addons/templates/addons/impala/details.html:292
 msgid "See complete development channel history"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/impala/details.html:306 src/olympia/addons/templates/addons/impala/details.html:315 src/olympia/addons/templates/addons/impala/details.html:327
+#: src/olympia/addons/templates/addons/impala/details.html:311 src/olympia/addons/templates/addons/impala/details.html:320 src/olympia/addons/templates/addons/impala/details.html:332
 #: src/olympia/addons/templates/addons/impala/review_add_box.html:4 src/olympia/stats/templates/stats/popup.html:2 src/olympia/stats/templates/stats/popup.html:8
-#: src/olympia/stats/templates/stats/stats.html:202 src/olympia/users/templates/users/profile.html:119
+#: src/olympia/stats/templates/stats/stats.html:204 src/olympia/users/templates/users/profile.html:119
 msgid "close"
 msgstr ""
 
@@ -1127,15 +1128,11 @@ msgstr ""
 msgid "Source Code License"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/impala/persona_grid.html:16 src/olympia/addons/templates/addons/impala/toplist.html:6
-msgid "{0} users"
-msgstr ""
-
 #: src/olympia/addons/templates/addons/impala/review_list_box.html:19 src/olympia/reviews/templates/reviews/review.html:40
 msgid "permalink"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/impala/review_list_box.html:23 src/olympia/editors/templates/editors/queue.html:98 src/olympia/reviews/templates/reviews/review.html:44
+#: src/olympia/addons/templates/addons/impala/review_list_box.html:23 src/olympia/editors/templates/editors/queue.html:104 src/olympia/reviews/templates/reviews/review.html:44
 msgid "translate"
 msgstr ""
 
@@ -1154,6 +1151,10 @@ msgstr ""
 msgid "Be the first!"
 msgstr ""
 
+#: src/olympia/addons/templates/addons/impala/toplist.html:6
+msgid "{0} users"
+msgstr ""
+
 #: src/olympia/addons/templates/addons/impala/listing/sorter.html:14 src/olympia/devhub/templates/devhub/addons/listing/item_actions.html:49
 msgid "More"
 msgstr ""
@@ -1166,7 +1167,7 @@ msgstr ""
 msgid "My Add-ons"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/includes/dashboard_tabs.html:6 src/olympia/amo/context_processors.py:51
+#: src/olympia/addons/templates/addons/includes/dashboard_tabs.html:6 src/olympia/amo/context_processors.py:50
 msgid "My Themes"
 msgstr ""
 
@@ -1221,7 +1222,7 @@ msgstr ""
 msgid "Weekly Downloads"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/mobile/details.html:99 src/olympia/compat/templates/compat/reporter_detail.html:46 src/olympia/devhub/forms.py:787
+#: src/olympia/addons/templates/addons/mobile/details.html:99 src/olympia/compat/templates/compat/reporter_detail.html:46 src/olympia/devhub/forms.py:788
 #: src/olympia/devhub/templates/devhub/versions/list.html:163
 msgid "Version"
 msgstr ""
@@ -1305,7 +1306,7 @@ msgstr ""
 #: src/olympia/browse/templates/browse/personas/category_landing.html:21 src/olympia/browse/templates/browse/personas/category_landing.html:23
 #: src/olympia/browse/templates/browse/personas/category_landing.html:38 src/olympia/browse/templates/browse/personas/grid.html:7 src/olympia/browse/templates/browse/personas/grid.html:11
 #: src/olympia/browse/templates/browse/personas/mobile/base.html:7 src/olympia/browse/templates/browse/personas/mobile/category_landing.html:19 src/olympia/constants/base.py:180
-#: src/olympia/devhub/templates/devhub/personas/submit.html:13 src/olympia/editors/helpers.py:105 src/olympia/editors/templates/editors/base.html:26
+#: src/olympia/devhub/templates/devhub/personas/submit.html:13 src/olympia/editors/helpers.py:107 src/olympia/editors/templates/editors/base.html:26
 #: src/olympia/editors/templates/editors/performance.html:73 src/olympia/search/templates/search/personas.html:39 src/olympia/templates/menu_links.html:9
 msgid "Themes"
 msgstr ""
@@ -1326,7 +1327,7 @@ msgstr ""
 msgid "Highest Rated"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/mobile/home.html:74 src/olympia/amo/templates/amo/side_nav.html:5 src/olympia/amo/templates/amo/site_nav.html:27 src/olympia/amo/templates/amo/site_nav.html:57
+#: src/olympia/addons/templates/addons/mobile/home.html:74 src/olympia/amo/templates/amo/side_nav.html:5 src/olympia/amo/templates/amo/site_nav.html:27 src/olympia/amo/templates/amo/site_nav.html:55
 #: src/olympia/bandwagon/views.py:97 src/olympia/browse/views.py:57 src/olympia/browse/views.py:67 src/olympia/browse/templates/browse/personas/mobile/category_landing.html:65
 #: src/olympia/search/forms.py:15 src/olympia/search/forms.py:87
 msgid "Newest"
@@ -1340,90 +1341,90 @@ msgstr ""
 msgid "Theme Info &raquo;"
 msgstr ""
 
-#: src/olympia/amo/context_processors.py:39 src/olympia/devhub/templates/devhub/nav.html:43
+#: src/olympia/amo/context_processors.py:37 src/olympia/devhub/templates/devhub/nav.html:43
 msgid "Tools"
 msgstr ""
 
-#: src/olympia/amo/context_processors.py:48 src/olympia/discovery/templates/discovery/pane_account.html:8 src/olympia/users/templates/users/includes/navigation.html:2
+#: src/olympia/amo/context_processors.py:47 src/olympia/discovery/templates/discovery/pane_account.html:8 src/olympia/users/templates/users/includes/navigation.html:2
 msgid "My Profile"
 msgstr ""
 
-#: src/olympia/amo/context_processors.py:54 src/olympia/users/templates/users/edit.html:5 src/olympia/users/templates/users/includes/navigation.html:3
+#: src/olympia/amo/context_processors.py:53 src/olympia/users/templates/users/edit.html:5 src/olympia/users/templates/users/includes/navigation.html:3
 msgid "Account Settings"
 msgstr ""
 
-#: src/olympia/amo/context_processors.py:57 src/olympia/discovery/templates/discovery/pane_account.html:11 src/olympia/users/templates/users/profile.html:83
+#: src/olympia/amo/context_processors.py:56 src/olympia/discovery/templates/discovery/pane_account.html:11 src/olympia/users/templates/users/profile.html:83
 #: src/olympia/users/templates/users/includes/navigation.html:4
 msgid "My Collections"
 msgstr ""
 
-#: src/olympia/amo/context_processors.py:62 src/olympia/discovery/templates/discovery/pane_account.html:10 src/olympia/users/templates/users/includes/navigation.html:7
+#: src/olympia/amo/context_processors.py:61 src/olympia/discovery/templates/discovery/pane_account.html:10 src/olympia/users/templates/users/includes/navigation.html:7
 msgid "My Favorites"
 msgstr ""
 
-#: src/olympia/amo/context_processors.py:67 src/olympia/discovery/templates/discovery/pane_account.html:13 src/olympia/templates/impala/user_login.html:14
+#: src/olympia/amo/context_processors.py:66 src/olympia/discovery/templates/discovery/pane_account.html:13 src/olympia/templates/impala/user_login.html:14
 #: src/olympia/templates/mobile/header_auth.html:5
 msgid "Log out"
 msgstr ""
 
-#: src/olympia/amo/context_processors.py:72 src/olympia/devhub/templates/devhub/addons/dashboard.html:4
+#: src/olympia/amo/context_processors.py:71 src/olympia/devhub/templates/devhub/addons/dashboard.html:4
 msgid "Manage My Submissions"
 msgstr ""
 
-#: src/olympia/amo/context_processors.py:75 src/olympia/devhub/templates/devhub/nav.html:27 src/olympia/devhub/templates/devhub/addons/dashboard.html:25
+#: src/olympia/amo/context_processors.py:74 src/olympia/devhub/templates/devhub/nav.html:27 src/olympia/devhub/templates/devhub/addons/dashboard.html:25
 #: src/olympia/devhub/templates/devhub/addons/submit/base.html:4
 msgid "Submit a New Add-on"
 msgstr ""
 
-#: src/olympia/amo/context_processors.py:77 src/olympia/browse/templates/browse/personas/base.html:50 src/olympia/devhub/templates/devhub/index.html:24
+#: src/olympia/amo/context_processors.py:76 src/olympia/browse/templates/browse/personas/base.html:50 src/olympia/devhub/templates/devhub/index.html:24
 #: src/olympia/devhub/templates/devhub/addons/dashboard.html:29
 msgid "Submit a New Theme"
 msgstr ""
 
-#: src/olympia/amo/context_processors.py:79 src/olympia/amo/templates/amo/site_nav.html:87 src/olympia/devhub/helpers.py:36 src/olympia/devhub/helpers.py:68 src/olympia/devhub/helpers.py:102
+#: src/olympia/amo/context_processors.py:78 src/olympia/amo/templates/amo/site_nav.html:85 src/olympia/devhub/helpers.py:36 src/olympia/devhub/helpers.py:68 src/olympia/devhub/helpers.py:102
 #: src/olympia/templates/footer.html:6 src/olympia/templates/menu_links.html:14
 msgid "Developer Hub"
 msgstr ""
 
-#: src/olympia/amo/context_processors.py:83 src/olympia/devhub/views.py:1792
+#: src/olympia/amo/context_processors.py:81 src/olympia/devhub/views.py:1796
 msgid "Manage API Keys"
 msgstr ""
 
-#: src/olympia/amo/context_processors.py:88 src/olympia/editors/helpers.py:82 src/olympia/editors/helpers.py:102 src/olympia/editors/templates/editors/base.html:10
+#: src/olympia/amo/context_processors.py:86 src/olympia/editors/helpers.py:84 src/olympia/editors/helpers.py:104 src/olympia/editors/templates/editors/base.html:10
 msgid "Editor Tools"
 msgstr ""
 
-#: src/olympia/amo/context_processors.py:92
+#: src/olympia/amo/context_processors.py:90
 msgid "Admin Tools"
 msgstr ""
 
-#: src/olympia/amo/fields.py:15
+#: src/olympia/amo/fields.py:20
 msgid "Incorrect, please try again."
 msgstr ""
 
-#: src/olympia/amo/fields.py:16
+#: src/olympia/amo/fields.py:21
 msgid "Error verifying input, please try again."
 msgstr ""
 
-#: src/olympia/amo/fields.py:32
+#: src/olympia/amo/fields.py:37
 msgid "This must be a valid hex color code, such as #000000."
 msgstr ""
 
-#: src/olympia/amo/fields.py:58
+#: src/olympia/amo/fields.py:63
 msgid "Enter at least one value."
 msgstr ""
 
-#: src/olympia/amo/helpers.py:162 src/olympia/amo/templates/amo/site_nav.html:61 src/olympia/bandwagon/templates/bandwagon/add.html:9
+#: src/olympia/amo/helpers.py:162 src/olympia/amo/templates/amo/site_nav.html:59 src/olympia/bandwagon/templates/bandwagon/add.html:9
 #: src/olympia/bandwagon/templates/bandwagon/collection_detail.html:15 src/olympia/bandwagon/templates/bandwagon/delete.html:9 src/olympia/bandwagon/templates/bandwagon/edit.html:15
 #: src/olympia/bandwagon/templates/bandwagon/user_listing.html:18 src/olympia/bandwagon/templates/bandwagon/user_listing.html:21
 #: src/olympia/bandwagon/templates/bandwagon/impala/collection_listing.html:12 src/olympia/bandwagon/templates/bandwagon/impala/collection_listing.html:20
 #: src/olympia/bandwagon/templates/bandwagon/impala/collection_listing.html:24 src/olympia/bandwagon/templates/bandwagon/impala/collection_sidebar.html:3
 #: src/olympia/bandwagon/templates/bandwagon/includes/collection_sidebar.html:2 src/olympia/bandwagon/templates/bandwagon/mobile/collection_listing.html:3
-#: src/olympia/stats/templates/stats/stats.html:77 src/olympia/templates/menu_links.html:12
+#: src/olympia/stats/templates/stats/stats.html:33 src/olympia/templates/menu_links.html:12
 msgid "Collections"
 msgstr ""
 
-#: src/olympia/amo/helpers.py:171 src/olympia/amo/templates/amo/site_nav.html:85 src/olympia/browse/templates/browse/language_tools.html:3
+#: src/olympia/amo/helpers.py:171 src/olympia/amo/templates/amo/site_nav.html:83 src/olympia/browse/templates/browse/language_tools.html:3
 msgid "Dictionaries & Language Packs"
 msgstr ""
 
@@ -1575,8 +1576,8 @@ msgstr ""
 msgid "Comment on {addon} {version}."
 msgstr ""
 
-#: src/olympia/amo/log.py:236 src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:19 src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:47
-#: src/olympia/editors/helpers.py:511 src/olympia/editors/templates/editors/themes/history_table.html:11
+#: src/olympia/amo/log.py:236 src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:17 src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:45
+#: src/olympia/editors/helpers.py:584 src/olympia/editors/templates/editors/themes/history_table.html:11
 msgid "Comment"
 msgstr ""
 
@@ -1899,7 +1900,7 @@ msgstr ""
 #: src/olympia/amo/templates/amo/mobile/paginator.html:14 src/olympia/amo/templates/amo/mobile/paginator.html:16 src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:51
 #: src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:65 src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:78
 #: src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:91 src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:104
-#: src/olympia/discovery/templates/discovery/pane.html:45 src/olympia/discovery/templates/discovery/addons/detail.html:39 src/olympia/stats/templates/stats/stats.html:167
+#: src/olympia/discovery/templates/discovery/pane.html:45 src/olympia/discovery/templates/discovery/addons/detail.html:39 src/olympia/stats/templates/stats/stats.html:169
 msgid "Next"
 msgstr ""
 
@@ -1931,7 +1932,7 @@ msgid ""
 msgstr ""
 
 #: src/olympia/amo/templates/amo/side_nav.html:4 src/olympia/amo/templates/amo/side_nav.html:12 src/olympia/amo/templates/amo/site_nav.html:4 src/olympia/amo/templates/amo/site_nav.html:26
-#: src/olympia/browse/views.py:56 src/olympia/browse/views.py:66 src/olympia/browse/views.py:237 src/olympia/browse/views.py:282 src/olympia/search/forms.py:86
+#: src/olympia/browse/views.py:56 src/olympia/browse/views.py:66 src/olympia/browse/views.py:204 src/olympia/browse/views.py:249 src/olympia/search/forms.py:86
 msgid "Top Rated"
 msgstr ""
 
@@ -1945,38 +1946,38 @@ msgstr ""
 msgid "Extensions"
 msgstr ""
 
-#: src/olympia/amo/templates/amo/site_nav.html:45
+#: src/olympia/amo/templates/amo/site_nav.html:44
 msgid "Want more customization? Try <b>Complete Themes</b>"
 msgstr ""
 
-#: src/olympia/amo/templates/amo/site_nav.html:56 src/olympia/bandwagon/views.py:96
+#: src/olympia/amo/templates/amo/site_nav.html:54 src/olympia/bandwagon/views.py:96
 msgid "Most Followers"
 msgstr ""
 
-#: src/olympia/amo/templates/amo/site_nav.html:68 src/olympia/bandwagon/templates/bandwagon/impala/collection_sidebar.html:16
+#: src/olympia/amo/templates/amo/site_nav.html:66 src/olympia/bandwagon/templates/bandwagon/impala/collection_sidebar.html:16
 #: src/olympia/bandwagon/templates/bandwagon/includes/collection_sidebar.html:18
 msgid "Collections I've Made"
 msgstr ""
 
-#: src/olympia/amo/templates/amo/site_nav.html:70 src/olympia/bandwagon/templates/bandwagon/user_listing.html:4 src/olympia/bandwagon/templates/bandwagon/impala/collection_sidebar.html:13
+#: src/olympia/amo/templates/amo/site_nav.html:68 src/olympia/bandwagon/templates/bandwagon/user_listing.html:4 src/olympia/bandwagon/templates/bandwagon/impala/collection_sidebar.html:13
 #: src/olympia/bandwagon/templates/bandwagon/includes/collection_sidebar.html:15
 msgid "Collections I'm Following"
 msgstr ""
 
-#: src/olympia/amo/templates/amo/site_nav.html:73 src/olympia/bandwagon/templates/bandwagon/impala/collection_sidebar.html:18
-#: src/olympia/bandwagon/templates/bandwagon/includes/collection_sidebar.html:20 src/olympia/users/models.py:512
+#: src/olympia/amo/templates/amo/site_nav.html:71 src/olympia/bandwagon/templates/bandwagon/impala/collection_sidebar.html:18
+#: src/olympia/bandwagon/templates/bandwagon/includes/collection_sidebar.html:20 src/olympia/users/models.py:521
 msgid "My Favorite Add-ons"
 msgstr ""
 
-#: src/olympia/amo/templates/amo/site_nav.html:78
+#: src/olympia/amo/templates/amo/site_nav.html:76
 msgid "More&hellip;"
 msgstr ""
 
-#: src/olympia/amo/templates/amo/site_nav.html:82
+#: src/olympia/amo/templates/amo/site_nav.html:80
 msgid "Add-ons for Mobile"
 msgstr ""
 
-#: src/olympia/amo/templates/amo/site_nav.html:86 src/olympia/browse/feeds.py:207 src/olympia/browse/templates/browse/search_tools.html:3 src/olympia/constants/base.py:176
+#: src/olympia/amo/templates/amo/site_nav.html:84 src/olympia/browse/feeds.py:207 src/olympia/browse/templates/browse/search_tools.html:3 src/olympia/constants/base.py:176
 #: src/olympia/templates/menu_links.html:10
 msgid "Search Tools"
 msgstr ""
@@ -1992,7 +1993,7 @@ msgid "Jump to first page"
 msgstr ""
 
 #: src/olympia/amo/templates/amo/impala/paginator.html:22 src/olympia/amo/templates/amo/mobile/impala_paginator.html:12 src/olympia/discovery/templates/discovery/pane.html:44
-#: src/olympia/discovery/templates/discovery/addons/detail.html:38 src/olympia/stats/templates/stats/stats.html:164
+#: src/olympia/discovery/templates/discovery/addons/detail.html:38 src/olympia/stats/templates/stats/stats.html:166
 msgid "Previous"
 msgstr ""
 
@@ -2015,30 +2016,49 @@ msgid_plural "Page {n}"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/olympia/amo/templates/services/install.html:38
-#, python-format
-msgid "If you are not prompted to install %(addon_name)s in a moment, please <a href=\"%(addon_xpi)s\">click here</a>."
-msgstr ""
-
-#: src/olympia/amo/tests/test_messages.py:57 src/olympia/amo/tests/test_messages.py:58 src/olympia/reviews/forms.py:25 src/olympia/reviews/forms.py:50 src/olympia/reviews/templates/reviews/add.html:56
+#: src/olympia/amo/tests/test_messages.py:56 src/olympia/amo/tests/test_messages.py:57 src/olympia/reviews/forms.py:25 src/olympia/reviews/forms.py:50 src/olympia/reviews/templates/reviews/add.html:56
 #: src/olympia/reviews/templates/reviews/reply.html:30
 msgid "Title"
 msgstr ""
 
-#: src/olympia/amo/tests/test_messages.py:57 src/olympia/amo/tests/test_messages.py:58
+#: src/olympia/amo/tests/test_messages.py:56 src/olympia/amo/tests/test_messages.py:57
 msgid "Body"
 msgstr ""
 
-#: src/olympia/amo/tests/test_messages.py:59
+#: src/olympia/amo/tests/test_messages.py:58
 msgid "Another Title"
 msgstr ""
 
-#: src/olympia/amo/tests/test_messages.py:59
+#: src/olympia/amo/tests/test_messages.py:58
 msgid "Another Body"
 msgstr ""
 
-#: src/olympia/api/views.py:255
-msgid "Not implemented yet."
+#: src/olympia/api/authentication.py:76
+msgid "Signature has expired."
+msgstr ""
+
+#: src/olympia/api/authentication.py:79
+msgid "Error decoding signature."
+msgstr ""
+
+#: src/olympia/api/authentication.py:82
+msgid "Invalid JWT Token."
+msgstr ""
+
+#: src/olympia/api/authentication.py:130
+msgid "Invalid Authorization header. No credentials provided."
+msgstr ""
+
+#: src/olympia/api/authentication.py:133
+msgid "Invalid Authorization header. Credentials string should not contain spaces."
+msgstr ""
+
+#: src/olympia/api/fields.py:29
+msgid "The field must have a length of at least {num} characters."
+msgstr ""
+
+#: src/olympia/api/fields.py:31
+msgid "The language code {lang_code} is invalid."
 msgstr ""
 
 #: src/olympia/applications/views.py:39 src/olympia/applications/templates/applications/appversions.html:3
@@ -2057,7 +2077,7 @@ msgstr ""
 msgid "Add-ons submitted to Mozilla Add-ons must have a manifest file with at least one of the below applications supported. Only the versions listed below are allowed for these applications."
 msgstr ""
 
-#: src/olympia/applications/templates/applications/appversions.html:25
+#: src/olympia/applications/templates/applications/appversions.html:25 src/olympia/editors/helpers.py:361
 msgid "GUID"
 msgstr ""
 
@@ -2171,8 +2191,8 @@ msgstr ""
 msgid "Remove from favorites"
 msgstr ""
 
-#: src/olympia/bandwagon/views.py:98 src/olympia/bandwagon/views.py:191 src/olympia/browse/views.py:58 src/olympia/browse/views.py:69 src/olympia/browse/views.py:458 src/olympia/devhub/views.py:74
-#: src/olympia/devhub/views.py:82 src/olympia/devhub/templates/devhub/addons/edit/basic.html:20 src/olympia/editors/templates/editors/leaderboard.html:24
+#: src/olympia/bandwagon/views.py:98 src/olympia/bandwagon/views.py:191 src/olympia/browse/views.py:58 src/olympia/browse/views.py:69 src/olympia/browse/views.py:425 src/olympia/devhub/views.py:72
+#: src/olympia/devhub/views.py:80 src/olympia/devhub/templates/devhub/addons/edit/basic.html:20 src/olympia/editors/templates/editors/leaderboard.html:24
 #: src/olympia/editors/templates/editors/themes/queue_list.html:48 src/olympia/search/forms.py:17 src/olympia/search/forms.py:89 src/olympia/users/templates/users/vcard.html:5
 msgid "Name"
 msgstr ""
@@ -2181,7 +2201,7 @@ msgstr ""
 msgid "Recently Popular"
 msgstr ""
 
-#: src/olympia/bandwagon/views.py:189 src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:18
+#: src/olympia/bandwagon/views.py:189 src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:16
 msgid "Added"
 msgstr ""
 
@@ -2195,7 +2215,7 @@ msgstr ""
 
 #: src/olympia/bandwagon/views.py:316
 #, python-format
-msgid "Your new collection is shown below. You can <ahref=\"%(url)s\">edit additional settings</a> if you'dlike."
+msgid "Your new collection is shown below. You can <a href=\"%(url)s\">edit additional settings</a> if you'd like."
 msgstr ""
 
 #: src/olympia/bandwagon/views.py:322
@@ -2323,8 +2343,8 @@ msgid_plural "%(num)s Add-ons in this Collection"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/olympia/bandwagon/templates/bandwagon/collection_detail.html:125 src/olympia/compat/templates/compat/index.html:25 src/olympia/compat/templates/compat/reporter_detail.html:29
-#: src/olympia/files/templates/files/viewer.html:29 src/olympia/templates/amo_footer.html:17 src/olympia/templates/includes/lang_switcher.html:10
+#: src/olympia/bandwagon/templates/bandwagon/collection_detail.html:125 src/olympia/compat/templates/compat/reporter_detail.html:29 src/olympia/files/templates/files/viewer.html:29
+#: src/olympia/templates/amo_footer.html:17 src/olympia/templates/includes/lang_switcher.html:10
 msgid "Go"
 msgstr ""
 
@@ -2491,7 +2511,7 @@ msgid "Remove this user as a contributor"
 msgstr ""
 
 #: src/olympia/bandwagon/templates/bandwagon/edit_contributors.html:18 src/olympia/bandwagon/templates/bandwagon/edit_contributors.html:43
-#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:20 src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:48
+#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:18 src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:46
 #: src/olympia/devhub/templates/devhub/addons/ajax_compat_update.html:19
 msgid "Remove"
 msgstr ""
@@ -2539,7 +2559,7 @@ msgid "<b>Warning:</b> By changing the owner of this collection, you will no lon
 msgstr ""
 
 #: src/olympia/bandwagon/templates/bandwagon/edit_contributors.html:83 src/olympia/devhub/templates/devhub/addons/forms_shared/media.html:157
-#: src/olympia/devhub/templates/devhub/addons/submit/describe.html:69 src/olympia/devhub/templates/devhub/addons/submit/license.html:60 src/olympia/devhub/templates/devhub/addons/submit/upload.html:78
+#: src/olympia/devhub/templates/devhub/addons/submit/describe.html:69 src/olympia/devhub/templates/devhub/addons/submit/license.html:60 src/olympia/devhub/templates/devhub/addons/submit/upload.html:70
 #: src/olympia/devhub/templates/devhub/payments/tier.html:17 src/olympia/editors/templates/editors/themes/themes.html:111 src/olympia/editors/templates/editors/themes/themes.html:128
 #: src/olympia/editors/templates/editors/themes/themes.html:134 src/olympia/editors/templates/editors/themes/themes.html:141 src/olympia/users/templates/users/fxa_migration_prompt_content.html:10
 #: src/olympia/users/templates/users/login_form.html:42 src/olympia/users/templates/users/mobile/login.html:57
@@ -2622,31 +2642,31 @@ msgid "Add-ons in Your Collection"
 msgstr ""
 
 #: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:4
-msgid ""
-"To include an add-on in this collection, enter its name in the box below and hit enter.  You can also use the <strong>Add to Collection</strong> links throughout the site to include add-ons later."
+msgid "To include an add-on in this collection, enter its name in the box below and hit enter."
 msgstr ""
 
-#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:17 src/olympia/constants/base.py:400 src/olympia/devhub/templates/devhub/addons/activity.html:62
+#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:15 src/olympia/constants/base.py:400 src/olympia/devhub/templates/devhub/addons/activity.html:62
+#: src/olympia/editors/helpers.py:273 src/olympia/editors/helpers.py:360
 msgid "Add-on"
 msgstr ""
 
-#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:26
+#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:24
 msgid "Enter the name of the add-on to include"
 msgstr ""
 
-#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:28
+#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:26
 msgid "Add to Collection"
 msgstr ""
 
-#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:45 src/olympia/editors/helpers.py:936 src/olympia/editors/helpers.py:956
+#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:43 src/olympia/editors/helpers.py:1016 src/olympia/editors/helpers.py:1036
 msgid "Pending"
 msgstr ""
 
-#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:47
+#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:45
 msgid "Add a comment"
 msgstr ""
 
-#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:48
+#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:46
 msgid "Remove this add-on from the collection"
 msgstr ""
 
@@ -2753,12 +2773,12 @@ msgstr ""
 msgid "Most Users"
 msgstr ""
 
-#: src/olympia/browse/views.py:61 src/olympia/browse/views.py:72 src/olympia/browse/views.py:279 src/olympia/browse/templates/browse/personas/mobile/category_landing.html:63
+#: src/olympia/browse/views.py:61 src/olympia/browse/views.py:72 src/olympia/browse/views.py:246 src/olympia/browse/templates/browse/personas/mobile/category_landing.html:63
 #: src/olympia/discovery/templates/discovery/pane.html:67 src/olympia/search/forms.py:92
 msgid "Up & Coming"
 msgstr ""
 
-#: src/olympia/browse/views.py:460 src/olympia/devhub/views.py:76 src/olympia/devhub/views.py:83 src/olympia/discovery/templates/discovery/addons/detail.html:66
+#: src/olympia/browse/views.py:427 src/olympia/devhub/views.py:74 src/olympia/devhub/views.py:81 src/olympia/discovery/templates/discovery/addons/detail.html:66
 msgid "Created"
 msgstr ""
 
@@ -2946,8 +2966,8 @@ msgid_plural "See all %(cnt)s extensions in %(name)s &raquo;"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/olympia/browse/templates/browse/mobile/extensions.html:13 src/olympia/compat/templates/compat/index.html:82 src/olympia/devhub/templates/devhub/devhub_search.html:24
-#: src/olympia/devhub/templates/devhub/addons/activity.html:47 src/olympia/search/templates/search/no_results.html:4 src/olympia/search/templates/search/mobile/results.html:36
+#: src/olympia/browse/templates/browse/mobile/extensions.html:13 src/olympia/devhub/templates/devhub/devhub_search.html:24 src/olympia/devhub/templates/devhub/addons/activity.html:47
+#: src/olympia/search/templates/search/no_results.html:4 src/olympia/search/templates/search/mobile/results.html:36
 msgid "No results found."
 msgstr ""
 
@@ -3032,7 +3052,7 @@ msgstr ""
 msgid "All"
 msgstr ""
 
-#: src/olympia/compat/forms.py:22 src/olympia/search/views.py:525
+#: src/olympia/compat/forms.py:22 src/olympia/editors/templates/editors/base.html:69 src/olympia/search/views.py:518
 msgid "All Add-ons"
 msgstr ""
 
@@ -3042,53 +3062,6 @@ msgstr ""
 
 #: src/olympia/compat/forms.py:24
 msgid "Non-binary"
-msgstr ""
-
-#. Review points sources other than add-ons and themes.
-#: src/olympia/compat/views.py:87 src/olympia/constants/base.py:388 src/olympia/devhub/forms.py:162 src/olympia/editors/templates/editors/performance.html:75
-msgid "Other"
-msgstr ""
-
-#: src/olympia/compat/templates/compat/index.html:4
-msgid "Add-on Compatibility Report for {app} {version}"
-msgstr ""
-
-#: src/olympia/compat/templates/compat/index.html:11
-msgid "{app} {version} Compatibility"
-msgstr ""
-
-#: src/olympia/compat/templates/compat/index.html:17
-#, python-format
-msgid "Top 95%% compatible with previous version"
-msgstr ""
-
-#: src/olympia/compat/templates/compat/index.html:18
-#, python-format
-msgid "Top 95%% of all add-ons"
-msgstr ""
-
-#: src/olympia/compat/templates/compat/index.html:19
-msgid "All active add-ons"
-msgstr ""
-
-#: src/olympia/compat/templates/compat/index.html:23 src/olympia/constants/base.py:401
-msgid "App"
-msgstr ""
-
-#: src/olympia/compat/templates/compat/index.html:55
-msgid "Details for add-ons compatible with previous version:"
-msgstr ""
-
-#: src/olympia/compat/templates/compat/index.html:57
-msgid "Show all versions"
-msgstr ""
-
-#: src/olympia/compat/templates/compat/index.html:59
-msgid "Details for add-ons compatible with all versions:"
-msgstr ""
-
-#: src/olympia/compat/templates/compat/index.html:61
-msgid "Show previous version only"
 msgstr ""
 
 #: src/olympia/compat/templates/compat/reporter.html:3
@@ -3142,8 +3115,8 @@ msgstr ""
 msgid "Report Type"
 msgstr ""
 
-#: src/olympia/compat/templates/compat/reporter_detail.html:47 src/olympia/devhub/forms.py:784 src/olympia/devhub/templates/devhub/addons/ajax_compat_update.html:17 src/olympia/editors/forms.py:108
-#: src/olympia/zadmin/forms.py:45
+#: src/olympia/compat/templates/compat/reporter_detail.html:47 src/olympia/devhub/forms.py:785 src/olympia/devhub/templates/devhub/addons/ajax_compat_update.html:17 src/olympia/editors/forms.py:108
+#: src/olympia/editors/forms.py:248 src/olympia/zadmin/forms.py:45
 msgid "Application"
 msgstr ""
 
@@ -3231,7 +3204,8 @@ msgstr ""
 msgid "Preliminarily Reviewed and Awaiting Full Review"
 msgstr ""
 
-#: src/olympia/constants/base.py:33 src/olympia/editors/helpers.py:924 src/olympia/editors/templates/editors/themes/history_table.html:34
+#: src/olympia/constants/base.py:33 src/olympia/editors/forms.py:258 src/olympia/editors/helpers.py:73 src/olympia/editors/helpers.py:1004
+#: src/olympia/editors/templates/editors/themes/history_table.html:34
 msgid "Deleted"
 msgstr ""
 
@@ -3328,6 +3302,11 @@ msgstr ""
 msgid "Ask before users can download this add-on"
 msgstr ""
 
+#. Review points sources other than add-ons and themes.
+#: src/olympia/constants/base.py:388 src/olympia/devhub/forms.py:162 src/olympia/editors/templates/editors/performance.html:75
+msgid "Other"
+msgstr ""
+
 #: src/olympia/constants/base.py:389
 msgid "Exception"
 msgstr ""
@@ -3338,6 +3317,10 @@ msgstr ""
 
 #: src/olympia/constants/base.py:391
 msgid "Change"
+msgstr ""
+
+#: src/olympia/constants/base.py:401
+msgid "App"
 msgstr ""
 
 #: src/olympia/constants/base.py:402
@@ -3488,7 +3471,7 @@ msgstr ""
 msgid "Duplicate"
 msgstr ""
 
-#: src/olympia/constants/editors.py:17 src/olympia/editors/helpers.py:502 src/olympia/editors/templates/editors/themes/queue.html:71 src/olympia/editors/templates/editors/themes/themes.html:94
+#: src/olympia/constants/editors.py:17 src/olympia/editors/helpers.py:575 src/olympia/editors/templates/editors/themes/queue.html:71 src/olympia/editors/templates/editors/themes/themes.html:94
 msgid "Reject"
 msgstr ""
 
@@ -3588,7 +3571,7 @@ msgstr ""
 msgid "Android"
 msgstr ""
 
-#: src/olympia/core/apps.py:19
+#: src/olympia/core/apps.py:21
 msgid "Core"
 msgstr ""
 
@@ -3722,7 +3705,7 @@ msgid "Submit my add-on for manual review."
 msgstr ""
 
 #: src/olympia/devhub/forms.py:537
-msgid "Do not list my add-on on this site (beta)"
+msgid "Do not list my add-on on this site"
 msgstr ""
 
 #: src/olympia/devhub/forms.py:538
@@ -3755,46 +3738,46 @@ msgstr ""
 
 #: src/olympia/devhub/forms.py:592
 #, python-format
-msgid "Version %s already exists"
+msgid "Version %s already exists, or was uploaded before."
 msgstr ""
 
-#: src/olympia/devhub/forms.py:604
+#: src/olympia/devhub/forms.py:605
 msgid "Select a valid choice. That choice is not one of the available choices."
 msgstr ""
 
-#: src/olympia/devhub/forms.py:610
+#: src/olympia/devhub/forms.py:611
 msgid "A file with a version ending with a|alpha|b|beta and an optional number is detected as beta."
 msgstr ""
 
-#: src/olympia/devhub/forms.py:633
+#: src/olympia/devhub/forms.py:634
 msgid "You cannot upload any more files for this version."
 msgstr ""
 
-#: src/olympia/devhub/forms.py:639
+#: src/olympia/devhub/forms.py:640
 msgid "Version doesn't match"
 msgstr ""
 
-#: src/olympia/devhub/forms.py:668
+#: src/olympia/devhub/forms.py:669
 msgid "You cannot delete a file once the review process has started.  You must delete the whole version."
 msgstr ""
 
-#: src/olympia/devhub/forms.py:688
+#: src/olympia/devhub/forms.py:689
 msgid "The platform All cannot be combined with specific platforms."
 msgstr ""
 
-#: src/olympia/devhub/forms.py:693
+#: src/olympia/devhub/forms.py:694
 msgid "A platform can only be chosen once."
 msgstr ""
 
-#: src/olympia/devhub/forms.py:706
+#: src/olympia/devhub/forms.py:707
 msgid "A review type must be selected."
 msgstr ""
 
-#: src/olympia/devhub/forms.py:788 src/olympia/editors/forms.py:114 src/olympia/zadmin/forms.py:49 src/olympia/zadmin/forms.py:52
+#: src/olympia/devhub/forms.py:789 src/olympia/editors/forms.py:114 src/olympia/editors/forms.py:254 src/olympia/zadmin/forms.py:49 src/olympia/zadmin/forms.py:52
 msgid "Select an application first"
 msgstr ""
 
-#: src/olympia/devhub/forms.py:840
+#: src/olympia/devhub/forms.py:841
 msgid "There cannot be more than 3 required add-ons."
 msgstr ""
 
@@ -3828,76 +3811,76 @@ msgstr[1] ""
 msgid "Review"
 msgstr ""
 
-#: src/olympia/devhub/tasks.py:551
+#: src/olympia/devhub/tasks.py:583
 #, python-format
 msgid "%s responded with %s (%s)."
 msgstr ""
 
-#: src/olympia/devhub/tasks.py:555
+#: src/olympia/devhub/tasks.py:587
 #, python-format
 msgid "Connection to \"%s\" timed out."
 msgstr ""
 
-#: src/olympia/devhub/tasks.py:557
+#: src/olympia/devhub/tasks.py:589
 #, python-format
 msgid "Could not contact host at \"%s\"."
 msgstr ""
 
-#: src/olympia/devhub/utils.py:104
+#: src/olympia/devhub/utils.py:105
 #, python-format
 msgid "Validation generated too many errors/warnings so %s messages were truncated. After addressing the visible messages, you'll be able to see the others."
 msgstr ""
 
-#: src/olympia/devhub/views.py:183
+#: src/olympia/devhub/views.py:181
 msgid "All My Add-ons"
 msgstr ""
 
-#: src/olympia/devhub/views.py:210
+#: src/olympia/devhub/views.py:208
 msgid "All Activity"
 msgstr ""
 
-#: src/olympia/devhub/views.py:211
+#: src/olympia/devhub/views.py:209
 msgid "Add-on Updates"
 msgstr ""
 
-#: src/olympia/devhub/views.py:212
+#: src/olympia/devhub/views.py:210
 msgid "Add-on Status"
 msgstr ""
 
-#: src/olympia/devhub/views.py:213
+#: src/olympia/devhub/views.py:211
 msgid "User Collections"
 msgstr ""
 
-#: src/olympia/devhub/views.py:214 src/olympia/devhub/templates/devhub/docs/policies-maintenance.html:68 src/olympia/pages/templates/pages/dev_faq.html:38
+#: src/olympia/devhub/views.py:212 src/olympia/devhub/templates/devhub/docs/policies-maintenance.html:68 src/olympia/pages/templates/pages/dev_faq.html:38
 #: src/olympia/pages/templates/pages/dev_faq.html:484
 msgid "User Reviews"
 msgstr ""
 
-#: src/olympia/devhub/views.py:327 src/olympia/devhub/views.py:331 src/olympia/devhub/views.py:484 src/olympia/devhub/views.py:513 src/olympia/devhub/views.py:564 src/olympia/devhub/views.py:1150
+#: src/olympia/devhub/views.py:325 src/olympia/devhub/views.py:329 src/olympia/devhub/views.py:484 src/olympia/devhub/views.py:513 src/olympia/devhub/views.py:564 src/olympia/devhub/views.py:1156
 msgid "Changes successfully saved."
 msgstr ""
 
-#: src/olympia/devhub/views.py:334 src/olympia/devhub/views.py:1631
+#: src/olympia/devhub/views.py:332 src/olympia/devhub/views.py:1637
 msgid "Please check the form for errors."
 msgstr ""
 
-#: src/olympia/devhub/views.py:346
+#: src/olympia/devhub/views.py:344
 msgid "Add-on cannot be deleted. Disable this add-on instead."
 msgstr ""
 
-#: src/olympia/devhub/views.py:356
+#: src/olympia/devhub/views.py:354
 msgid "Theme deleted."
 msgstr ""
 
-#: src/olympia/devhub/views.py:356
+#: src/olympia/devhub/views.py:354
 msgid "Add-on deleted."
 msgstr ""
 
-#: src/olympia/devhub/views.py:362
+#: src/olympia/devhub/views.py:360
 msgid "URL name was incorrect. Theme was not deleted."
 msgstr ""
 
-#: src/olympia/devhub/views.py:367
+#: src/olympia/devhub/views.py:365
 msgid "URL name was incorrect. Add-on was not deleted."
 msgstr ""
 
@@ -3925,7 +3908,7 @@ msgstr ""
 msgid "Check Add-on Compatibility"
 msgstr ""
 
-#: src/olympia/devhub/views.py:808 src/olympia/signing/views.py:90
+#: src/olympia/devhub/views.py:808 src/olympia/signing/views.py:95
 msgid "You cannot submit this type of add-on"
 msgstr ""
 
@@ -3955,33 +3938,33 @@ msgstr ""
 msgid "There was an error uploading your preview."
 msgstr ""
 
-#: src/olympia/devhub/views.py:1189
+#: src/olympia/devhub/views.py:1195
 #, python-format
 msgid "Version %s disabled."
 msgstr ""
 
-#: src/olympia/devhub/views.py:1193
+#: src/olympia/devhub/views.py:1199
 #, python-format
 msgid "Version %s deleted."
 msgstr ""
 
-#: src/olympia/devhub/views.py:1203
+#: src/olympia/devhub/views.py:1209
 msgid "This upload has failed validation, and may lack complete validation results. Please take due care when reviewing it."
 msgstr ""
 
-#: src/olympia/devhub/views.py:1677
+#: src/olympia/devhub/views.py:1683
 msgid "Preliminary Review Requested."
 msgstr ""
 
-#: src/olympia/devhub/views.py:1678
+#: src/olympia/devhub/views.py:1684
 msgid "Full Review Requested."
 msgstr ""
 
-#: src/olympia/devhub/views.py:1779
+#: src/olympia/devhub/views.py:1783
 msgid "Your old credentials were revoked and are no longer valid. Be sure to update all API clients with the new credentials."
 msgstr ""
 
-#: src/olympia/devhub/views.py:1797
+#: src/olympia/devhub/views.py:1801
 msgid "New API key created"
 msgstr ""
 
@@ -4011,7 +3994,7 @@ msgstr ""
 msgid "{0} :: Search"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/devhub_search.html:6 src/olympia/devhub/templates/devhub/search.html:8 src/olympia/editors/forms.py:435 src/olympia/editors/forms.py:437
+#: src/olympia/devhub/templates/devhub/devhub_search.html:6 src/olympia/devhub/templates/devhub/search.html:8 src/olympia/editors/forms.py:534 src/olympia/editors/forms.py:536
 #: src/olympia/editors/templates/editors/queue.html:27 src/olympia/editors/templates/editors/themes/queue_list.html:14 src/olympia/search/templates/search/collections.html:17
 #: src/olympia/search/templates/search/personas.html:18 src/olympia/search/templates/search/results.html:18 src/olympia/search/templates/search/mobile/results.html:8
 #: src/olympia/templates/search.html:14 src/olympia/templates/impala/search.html:18
@@ -4071,12 +4054,12 @@ msgstr ""
 msgid "Start Making Add-ons"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/index.html:86 src/olympia/devhub/templates/devhub/addons/listing/items.html:25 src/olympia/devhub/templates/devhub/includes/addon_details.html:15
+#: src/olympia/devhub/templates/devhub/index.html:86 src/olympia/devhub/templates/devhub/addons/listing/items.html:25 src/olympia/devhub/templates/devhub/includes/addon_details.html:20
 #: src/olympia/devhub/templates/devhub/personas/edit.html:43
 msgid "Status:"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/index.html:90 src/olympia/devhub/templates/devhub/includes/addon_details.html:100
+#: src/olympia/devhub/templates/devhub/index.html:90 src/olympia/devhub/templates/devhub/includes/addon_details.html:87
 msgid "Visibility:"
 msgstr ""
 
@@ -4084,11 +4067,11 @@ msgstr ""
 msgid "Latest Version:"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/index.html:109 src/olympia/devhub/templates/devhub/includes/addon_details.html:145 src/olympia/devhub/templates/devhub/personas/edit.html:49
+#: src/olympia/devhub/templates/devhub/index.html:109 src/olympia/devhub/templates/devhub/includes/addon_details.html:131 src/olympia/devhub/templates/devhub/personas/edit.html:49
 msgid "Queue Position:"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/index.html:110 src/olympia/devhub/templates/devhub/includes/addon_details.html:146 src/olympia/devhub/templates/devhub/personas/edit.html:50
+#: src/olympia/devhub/templates/devhub/index.html:110 src/olympia/devhub/templates/devhub/includes/addon_details.html:132 src/olympia/devhub/templates/devhub/personas/edit.html:50
 #, python-format
 msgid "%(position)s of %(total)s"
 msgstr ""
@@ -4190,16 +4173,6 @@ msgstr ""
 msgid "Do you want your add-on to be distributed on this site?"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/validate_addon.html:49 src/olympia/devhub/templates/devhub/addons/submit/upload.html:30 src/olympia/devhub/templates/devhub/versions/add_file_modal.html:14
-#: src/olympia/devhub/templates/devhub/versions/add_file_modal.html:53 src/olympia/devhub/templates/devhub/versions/list.html:298
-msgid "Warning:"
-msgstr ""
-
-#: src/olympia/devhub/templates/devhub/validate_addon.html:50 src/olympia/devhub/templates/devhub/addons/submit/upload.html:31
-#, python-format
-msgid "Submission of unlisted add-ons for signing is currently in an open beta. Please <a href=\"%(url)s\" target=\"_blank\">report any bugs</a> that you encounter."
-msgstr ""
-
 #. first parameter is a filename like lorem-ipsum-1.0.2.xpi
 #: src/olympia/devhub/templates/devhub/validation.html:5
 msgid "Validation Results for {0}"
@@ -4274,7 +4247,7 @@ msgstr ""
 msgid "Update Compatibility"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/addons/ajax_compat_update.html:4
+#: src/olympia/devhub/templates/devhub/addons/ajax_compat_update.html:4 src/olympia/devhub/templates/devhub/versions/edit.html:45
 msgid "Adjusting application information here will allow users to install your add-on even if the install manifest in the package indicates that the add-on is incompatible."
 msgstr ""
 
@@ -4286,9 +4259,9 @@ msgstr ""
 msgid "Add Another Application&hellip;"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/addons/ajax_compat_update.html:38 src/olympia/devhub/templates/devhub/addons/owner.html:86 src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:46
-#: src/olympia/devhub/templates/devhub/versions/list.html:351 src/olympia/devhub/templates/devhub/versions/list.html:353 src/olympia/templates/impala/base.html:132
-#: src/olympia/templates/impala/base.html:143 src/olympia/templates/impala/base.html:161 src/olympia/templates/impala/base.html:171
+#: src/olympia/devhub/templates/devhub/addons/ajax_compat_update.html:38 src/olympia/devhub/templates/devhub/addons/owner.html:86 src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:45
+#: src/olympia/devhub/templates/devhub/versions/list.html:349 src/olympia/devhub/templates/devhub/versions/list.html:351 src/olympia/templates/impala/base.html:129
+#: src/olympia/templates/impala/base.html:140 src/olympia/templates/impala/base.html:158 src/olympia/templates/impala/base.html:168
 msgid "Close"
 msgstr ""
 
@@ -4322,7 +4295,7 @@ msgstr ""
 msgid "Manage Authors & License"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/addons/owner.html:29 src/olympia/editors/templates/editors/review.html:270
+#: src/olympia/devhub/templates/devhub/addons/owner.html:29 src/olympia/editors/helpers.py:362 src/olympia/editors/templates/editors/review.html:270
 msgid "Authors"
 msgstr ""
 
@@ -4391,17 +4364,11 @@ msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/basic.html:52
 msgid ""
-"A short explanation of your add-on's basic\n"
-"                          functionality that is displayed in search and browse\n"
-"                          listings, as well as at the top of your add-on's\n"
-"                          details page. It is only relevant for listed add-ons."
+"A short explanation of your add-on's basic functionality that is displayed in search and browse listings, as well as at the top of your add-on's details page. It is only relevant for listed add-ons."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/basic.html:73
-msgid ""
-"Categories are the primary way users browse through add-ons.\n"
-"                        Choose any that fit your add-on's functionality for the most\n"
-"                        exposure. It is only relevant for listed add-ons."
+msgid "Categories are the primary way users browse through add-ons. Choose any that fit your add-on's functionality for the most exposure. It is only relevant for listed add-ons."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/basic.html:90
@@ -4411,11 +4378,7 @@ msgid ""
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/basic.html:119
-msgid ""
-"Tags help users find your add-on and should be short\n"
-"                        descriptors such as tabs, toolbar, or twitter.  You\n"
-"                        may have a maximum of {0} tags. It is only relevant\n"
-"                        for listed add-ons."
+msgid "Tags help users find your add-on and should be short descriptors such as tabs, toolbar, or twitter. You may have a maximum of {0} tags. It is only relevant for listed add-ons."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/basic.html:129 src/olympia/devhub/templates/devhub/personas/edit.html:97 src/olympia/devhub/templates/devhub/personas/submit.html:46
@@ -4443,11 +4406,7 @@ msgid "Add-on Details for {0}"
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/details.html:22
-msgid ""
-"A longer explanation of features,\n"
-"                          functionality, and other relevant information. This\n"
-"                          field is only displayed on the add-on's details\n"
-"                          page. It is only relevant for listed add-ons."
+msgid "A longer explanation of features, functionality, and other relevant information. This field is only displayed on the add-on's details page. It is only relevant for listed add-ons."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/details.html:44 src/olympia/translations/templates/translations/trans-menu.html:13
@@ -4455,10 +4414,7 @@ msgid "Default Locale"
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/details.html:45
-msgid ""
-"Information about your add-on is displayed in this locale\n"
-"                        unless you override it with a locale-specific translation.\n"
-"                        It is only relevant for listed add-ons."
+msgid "Information about your add-on is displayed in this locale unless you override it with a locale-specific translation. It is only relevant for listed add-ons."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/details.html:61 src/olympia/users/forms.py:311 src/olympia/users/templates/users/edit.html:122 src/olympia/users/templates/users/register.html:57
@@ -4468,10 +4424,8 @@ msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/details.html:63
 msgid ""
-"If your add-on has another homepage, enter its\n"
-"                          address here. If your website is localized into other\n"
-"                          languages multiple translations of this field can be\n"
-"                          added. It is only relevant for listed add-ons."
+"If your add-on has another homepage, enter its address here. If your website is localized into other languages multiple translations of this field can be added. It is only relevant for listed add-"
+"ons."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/media.html:3
@@ -4489,19 +4443,14 @@ msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/support.html:22
 msgid ""
-"If you wish to display an e-mail address for support\n"
-"                          inquiries, enter it here. If you have different\n"
-"                          addresses for each language multiple translations of\n"
-"                          this field can be added. It is only relevant for\n"
-"                          listed add-ons."
+"If you wish to display an e-mail address for support inquiries, enter it here. If you have different addresses for each language multiple translations of this field can be added. It is only "
+"relevant for listed add-ons."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/support.html:45
 msgid ""
-"If your add-on has a support website or forum, enter\n"
-"                          its address here. If your website is localized into\n"
-"                          other languages, multiple translations of this field can\n"
-"                          be added. It is only relevant for listed add-ons."
+"If your add-on has a support website or forum, enter its address here. If your website is localized into other languages, multiple translations of this field can be added. It is only relevant for "
+"listed add-ons."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:6
@@ -4515,11 +4464,8 @@ msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:23
 msgid ""
-"Any information end users may want to know that isn't\n"
-"                          necessarily applicable to the add-on summary or description.\n"
-"                          Common uses include listing known major bugs, information on\n"
-"                          how to report bugs, anticipated release date of a new version,\n"
-"                          etc. It is only relevant for listed add-ons."
+"Any information end users may want to know that isn't necessarily applicable to the add-on summary or description. Common uses include listing known major bugs, information on how to report bugs, "
+"anticipated release date of a new version, etc. It is only relevant for listed add-ons."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:46
@@ -4531,9 +4477,7 @@ msgid "Add-on Flags"
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:69
-msgid ""
-"These flags are used to classify add-ons. It is only\n"
-"                        relevant for listed add-ons."
+msgid "These flags are used to classify add-ons. It is only relevant for listed add-ons."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:74
@@ -4549,9 +4493,7 @@ msgid "View Source?"
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:90
-msgid ""
-"Whether the source of your add-on can be displayed in our\n"
-"                        online viewer. It is only relevant for listed add-ons."
+msgid "Whether the source of your add-on can be displayed in our online viewer. It is only relevant for listed add-ons."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:94
@@ -4567,10 +4509,7 @@ msgid "Public Stats?"
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:102
-msgid ""
-"Whether the download and usage stats of your add-on can\n"
-"                        be displayed in our online viewer.\n"
-"                        It is only relevant for listed add-ons."
+msgid "Whether the download and usage stats of your add-on can be displayed in our online viewer. It is only relevant for listed add-ons."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:107
@@ -4586,10 +4525,7 @@ msgid "Upgrade SDK?"
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:116
-msgid ""
-"If selected, we will try to automatically upgrade your\n"
-"                        add-on when a new version of the SDK is released.\n"
-"                        It is only relevant for listed add-ons."
+msgid "If selected, we will try to automatically upgrade your add-on when a new version of the SDK is released. It is only relevant for listed add-ons."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:121
@@ -4640,10 +4576,8 @@ msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/forms_shared/media.html:16
 msgid ""
-"Upload an icon for your add-on or choose from one of ours. The\n"
-"                      icon is displayed nearly everywhere your add-on is. Uploaded images\n"
-"                      must be one of the following image types: .png, .jpg.\n"
-"                      It is only relevant for listed add-ons."
+"Upload an icon for your add-on or choose from one of ours. The icon is displayed nearly everywhere your add-on is. Uploaded images must be one of the following image types: .png, .jpg. It is only "
+"relevant for listed add-ons."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/forms_shared/media.html:25
@@ -4656,9 +4590,7 @@ msgid "32x32px"
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/forms_shared/media.html:39
-msgid ""
-"Used in listings of add-ons, like search results\n"
-"                            and featured add-ons."
+msgid "Used in listings of add-ons, like search results and featured add-ons."
 msgstr ""
 
 #. The size of the icon
@@ -4753,16 +4685,14 @@ msgid "Deleting your add-on will permanently remove it from the site and prevent
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:24
-msgid ""
-"Enter the following text confirm your decision:\n"
-"           {slug}"
+msgid "Enter the following text confirm your decision: {slug}"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:34
+#: src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:33
 msgid "Please tell us why you are deleting your theme:"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:36
+#: src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:35
 msgid "Please tell us why you are deleting your add-on:"
 msgstr ""
 
@@ -4799,8 +4729,8 @@ msgstr ""
 msgid "Daily statistics on downloads and users."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/addons/listing/item_actions.html:45 src/olympia/stats/templates/stats/stats.html:75 src/olympia/stats/templates/stats/stats.html:79
-#: src/olympia/stats/templates/stats/stats.html:81
+#: src/olympia/devhub/templates/devhub/addons/listing/item_actions.html:45 src/olympia/stats/templates/stats/stats.html:31 src/olympia/stats/templates/stats/stats.html:35
+#: src/olympia/stats/templates/stats/stats.html:37
 msgid "Statistics"
 msgstr ""
 
@@ -4919,10 +4849,7 @@ msgid "Your add-on has been submitted to the Full Review queue."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/submit/done.html:18
-msgid ""
-"You'll receive an email once it has been reviewed by an editor. In\n"
-"          the meantime, you and your friends can install it directly from its\n"
-"          details page:"
+msgid "You'll receive an email once it has been reviewed by an editor. In the meantime, you and your friends can install it directly from its details page:"
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/submit/done.html:27 src/olympia/devhub/templates/devhub/addons/submit/done.html:77 src/olympia/devhub/templates/devhub/personas/submit_done.html:16
@@ -5128,11 +5055,11 @@ msgstr ""
 msgid "Use the fields below to upload your add-on package and select any platform restrictions. After upload, a series of automated validation tests will be run on your file."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/addons/submit/upload.html:59 src/olympia/devhub/templates/devhub/versions/add_file_modal.html:39
+#: src/olympia/devhub/templates/devhub/addons/submit/upload.html:51 src/olympia/devhub/templates/devhub/versions/add_file_modal.html:28
 msgid "Which platforms is this file compatible with?"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/addons/submit/upload.html:67 src/olympia/devhub/templates/devhub/versions/add_file_modal.html:65
+#: src/olympia/devhub/templates/devhub/addons/submit/upload.html:59 src/olympia/devhub/templates/devhub/versions/add_file_modal.html:45
 msgid "Administrative overrides"
 msgstr ""
 
@@ -5242,8 +5169,8 @@ msgstr ""
 
 #: src/olympia/devhub/templates/devhub/docs/policies-contact.html:44
 msgid ""
-"If you've found a problem with the site, we'd love to fix it. Please <a href=\"https://github.com/mozilla/olympia/issues\">file a bug report</a> in GitHub, including the location of the problem and "
-"how you encountered it."
+"If you've found a problem with the site, we'd love to fix it. Please <a href=\"https://github.com/mozilla/addons/issues/new\">file a bug report</a> in GitHub, including the location of the problem "
+"and how you encountered it."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/docs/policies-maintenance.html:3 src/olympia/devhub/templates/devhub/docs/policies-maintenance.html:7
@@ -5810,7 +5737,7 @@ msgstr ""
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:282
 msgid ""
-"Add-ons that store or otherwise handle browsing data must support <a href=\"https://developer.mozilla.org/En/Supporting_private_browsing_mode\">Private Browsing Mode</a>.  During a Private Browsing "
+"Add-ons that store or otherwise handle browsing data must support <a href=\"https://developer.mozilla.org/En/Supporting_private_browsing_mode\">Private Browsing Mode</a>. During a Private Browsing "
 "session, no browsing data can be written to disk, and all of this data must be cleared when Firefox quits or the Private Browsing session ends."
 msgstr ""
 
@@ -5975,129 +5902,95 @@ msgstr ""
 msgid "How to get in touch with us regarding these policies or your add-on."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:6
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:10
 msgid "You have disabled this add-on"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:20
-msgid ""
-"Your add-on's listing is disabled and is not showing\n"
-"                             anywhere in our gallery or update service."
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:24
+msgid "Your add-on's listing is disabled and is not showing anywhere in our gallery or update service."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:25
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:27
 msgid "Please complete your add-on."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:29
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:30
 msgid "You will receive an email when the review is complete."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:34
-msgid ""
-"You will receive an email when the review is complete. Until\n"
-"                             then, your add-on is not listed in our gallery but can be\n"
-"                             accessed directly from its details page."
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:33
+msgid "You will receive an email when the review is complete. Until then, your add-on is not listed in our gallery but can be accessed directly from its details page."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:38 src/olympia/devhub/templates/devhub/includes/addon_details.html:48
-msgid ""
-"You will receive an email when the review is\n"
-"                             complete and your add-on is signed."
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:37 src/olympia/devhub/templates/devhub/includes/addon_details.html:45
+msgid "You will receive an email when the review is complete and your add-on is signed."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:44
-msgid ""
-"You will receive an email when the review is complete. Until\n"
-"                             then, your add-on is not listed in our gallery but can be\n"
-"                             accessed directly from its details page. "
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:41
+msgid "You will receive an email when the review is complete. Until then, your add-on is not listed in our gallery but can be accessed directly from its details page. "
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:54
-msgid ""
-"Your add-on is displayed in our gallery and users are\n"
-"                             receiving automatic updates."
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:49
+msgid "Your add-on is displayed in our gallery and users are receiving automatic updates."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:57
-msgid ""
-"Your add-on has been signed and can be bundled with an\n"
-"                             application installer."
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:52
+msgid "Your add-on has been signed and can be bundled with an application installer."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:63
-msgid ""
-"Your add-on was disabled by a site administrator and is no\n"
-"                             longer shown in our gallery. If you have any questions,\n"
-"                             please email amo-admins@mozilla.org."
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:56
+msgid "Your add-on was disabled by a site administrator and is no longer shown in our gallery. If you have any questions, please email amo-admins@mozilla.org."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:70
-msgid ""
-"Your add-on is displayed in our gallery as experimental\n"
-"                             and users are receiving automatic updates. Some features\n"
-"                             are unavailable to your add-on."
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:62
+msgid "Your add-on is displayed in our gallery as experimental and users are receiving automatic updates. Some features are unavailable to your add-on."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:74
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:66
 msgid "Your add-on has been signed."
 msgstr ""
 
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:69
+msgid ""
+"You will receive an email when the full review is complete. Until then, your add-on is displayed in our gallery as experimental and users are receiving automatic updates. Some features are "
+"unavailable to your add-on."
+msgstr ""
+
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:74
+msgid "You will receive an email when the full review is complete, making you able to bundle your add-on with an application installer."
+msgstr ""
+
 #: src/olympia/devhub/templates/devhub/includes/addon_details.html:79
-msgid ""
-"You will receive an email when the full review is complete.\n"
-"                             Until then, your add-on is displayed in our gallery as\n"
-"                             experimental and users are receiving automatic updates.\n"
-"                             Some features are unavailable to your add-on."
+msgid "All add-ons hosted in our gallery must now be reviewed by an editor. If you wish to continue hosting your add-on, please click to select a review process."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:84
-msgid ""
-"You will receive an email when the full review is\n"
-"                             complete, making you able to bundle your add-on with an\n"
-"                             application installer."
-msgstr ""
-
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:91
-msgid ""
-"All add-ons hosted in our gallery must now be reviewed by an\n"
-"                             editor. If you wish to continue hosting your add-on, please\n"
-"                             click to select a review process."
-msgstr ""
-
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:113
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:100
 msgid "Current Version:"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:115
-msgid ""
-"This is the version of your add-on that will\n"
-"                                           be installed if someone clicks the Install\n"
-"                                           button on addons.mozilla.org. It is only\n"
-"                                           relevant for listed add-ons."
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:102
+msgid "This is the version of your add-on that will be installed if someone clicks the Install button on addons.mozilla.org. It is only relevant for listed add-ons."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:123
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:110
 msgid "Created:"
 msgstr ""
 
 #. {0} is a date. dennis-ignore: E201
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:125 src/olympia/devhub/templates/devhub/includes/addon_details.html:131
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:112 src/olympia/devhub/templates/devhub/includes/addon_details.html:118
 #, python-format
 msgid "%%b %%e, %%Y"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:136
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:123
 msgid "Next Version:"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:138
-msgid ""
-"This is the newest uploaded version, however\n"
-"                                           it isn’t live on the site yet."
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:125
+msgid "This is the newest uploaded version, however it isn’t live on the site yet."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:144 src/olympia/devhub/templates/devhub/versions/list.html:30
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:130 src/olympia/devhub/templates/devhub/versions/list.html:30
 msgid "Queues are not reviewed strictly in order"
 msgstr ""
 
@@ -6165,9 +6058,7 @@ msgid "View the blog &#9658;"
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/includes/license_form.html:6
-msgid ""
-"Please choose a license appropriate for the rights you grant on your source code.\n"
-"                  It is only relevant for listed add-ons."
+msgid "Please choose a license appropriate for the rights you grant on your source code. It is only relevant for listed add-ons."
 msgstr ""
 
 #. {0} is a list of HTML tags.
@@ -6194,14 +6085,11 @@ msgstr[1] ""
 #: src/olympia/devhub/templates/devhub/includes/policy_form.html:4
 msgid ""
 "Users will be required to accept the following End-User License Agreement (EULA) prior to installing your add-on. The presence of a EULA significantly affects the number of downloads an add-on "
-"receives. Please note that a EULA is not the same as a code license, such as the GPL or MPL.\n"
-"                It is only relevant for listed add-ons."
+"receives. Please note that a EULA is not the same as a code license, such as the GPL or MPL.It is only relevant for listed add-ons."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/policy_form.html:21
-msgid ""
-"If your add-on transmits any data from the user's computer, a privacy policy is required that explains what data is sent and how it is used.\n"
-"                It is only relevant for listed add-ons."
+#: src/olympia/devhub/templates/devhub/includes/policy_form.html:24
+msgid "If your add-on transmits any data from the user's computer, a privacy policy is required that explains what data is sent and how it is used. It is only relevant for listed add-ons."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/includes/source_form_field.html:2
@@ -6369,12 +6257,8 @@ msgstr ""
 msgid "Add some tags to describe your Theme."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/personas/edit.html:106
-msgid ""
-"A short explanation of your theme's\n"
-"                                basic functionality that is displayed in\n"
-"                                search and browse listings, as well as at\n"
-"                                the top of your theme's details page."
+#: src/olympia/devhub/templates/devhub/personas/edit.html:106 src/olympia/devhub/templates/devhub/personas/submit.html:54
+msgid "A short explanation of your theme's basic functionality that is displayed in search and browse listings, as well as at the top of your theme's details page."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/personas/edit.html:122 src/olympia/devhub/templates/devhub/personas/submit.html:68
@@ -6444,7 +6328,7 @@ msgid "Upon upload and form submission, the AMO Team will review your updated de
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/personas/edit.html:241
-msgid "Your previously resubmitted design,  which is under pending review."
+msgid "Your previously resubmitted design, which is under pending review."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/personas/edit.html:245
@@ -6511,14 +6395,6 @@ msgstr ""
 
 #: src/olympia/devhub/templates/devhub/personas/submit.html:33
 msgid "Give your Theme a name."
-msgstr ""
-
-#: src/olympia/devhub/templates/devhub/personas/submit.html:54
-msgid ""
-"A short explanation of your theme's\n"
-"                                      basic functionality that is displayed in\n"
-"                                      search and browse listings, as well as at\n"
-"                                      the top of your theme's details page."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/personas/submit.html:198
@@ -6595,30 +6471,16 @@ msgstr ""
 msgid "Files added to reviewed versions must be reviewed before they will be available for download."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/add_file_modal.html:15
-#, python-format
-msgid ""
-"Submission of updates to unlisted add-ons for signing is currently in an open beta. Manual review may still be required for a large number of add-ons. Please <a href=\"%(url)s\" target=\"_blank"
-"\">report any bugs</a> that you encounter."
-msgstr ""
-
-#: src/olympia/devhub/templates/devhub/versions/add_file_modal.html:35
+#: src/olympia/devhub/templates/devhub/versions/add_file_modal.html:24
 msgid "Select the target platform for this file."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/add_file_modal.html:46
+#: src/olympia/devhub/templates/devhub/versions/add_file_modal.html:35
 msgid "Which review type would you like to nominate for?"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/add_file_modal.html:51
+#: src/olympia/devhub/templates/devhub/versions/add_file_modal.html:40
 msgid "Only publish this version to my beta channel."
-msgstr ""
-
-#: src/olympia/devhub/templates/devhub/versions/add_file_modal.html:54
-#, python-format
-msgid ""
-"The behavior of the beta channel has changed to accommodate <a href=\"%(addon_signing_url)s\" target=\"_blank\">mandatory add-on signing</a>. The new process is currently in an open beta, and may "
-"change significantly in the near future. Please <a href=\"%(issues_url)s\" target=\"_blank\">report any bugs</a> that you encounter."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/versions/edit.html:5
@@ -6642,19 +6504,10 @@ msgstr ""
 msgid "Upload Another File"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/edit.html:45
-msgid ""
-"Adjusting application information here will allow users to install your\n"
-"                          add-on even if the install manifest in the package indicates that the\n"
-"                          add-on is incompatible."
-msgstr ""
-
 #: src/olympia/devhub/templates/devhub/versions/edit.html:74
 msgid ""
-"Information about changes in this release, new features,\n"
-"                              known bugs, and other useful information specific to this\n"
-"                              release/version. This information is also shown in the\n"
-"                              Add-ons Manager when updating."
+"Information about changes in this release, new features, known bugs, and other useful information specific to this release/version. This information is also shown in the Add-ons Manager when "
+"updating."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/versions/edit.html:99
@@ -6666,10 +6519,7 @@ msgid "Notes for Reviewers"
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/versions/edit.html:114
-msgid ""
-"Optionally, enter any information that may be useful\n"
-"                              to the Editor reviewing this add-on, such as test\n"
-"                              account information."
+msgid "Optionally, enter any information that may be useful to the Editor reviewing this add-on, such as test account information."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/versions/edit.html:127
@@ -6747,7 +6597,7 @@ msgstr ""
 msgid "Request Preliminary Review"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:80 src/olympia/devhub/templates/devhub/versions/list.html:327 src/olympia/devhub/templates/devhub/versions/list.html:350
+#: src/olympia/devhub/templates/devhub/versions/list.html:80 src/olympia/devhub/templates/devhub/versions/list.html:325 src/olympia/devhub/templates/devhub/versions/list.html:348
 msgid "Cancel Review Request"
 msgstr ""
 
@@ -6776,7 +6626,7 @@ msgid "Unlisted:"
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/versions/list.html:114
-msgid "Not distributed on {0}. Developers will upload new versions for signing and distribute the add-ons on their own. (beta)"
+msgid "Not distributed on {0}. Developers will upload new versions for signing and distribute the add-ons on their own."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/versions/list.html:122
@@ -6839,81 +6689,73 @@ msgid "<strong>Important:</strong> Once a version has been deleted, you may not 
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/versions/list.html:230
-msgid ""
-"Deleting a version which has already been reviewed\n"
-"               may also cause a significant delay in the review of\n"
-"               your next update."
-msgstr ""
-
-#: src/olympia/devhub/templates/devhub/versions/list.html:233
 msgid "Are you sure you wish to delete this version?"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:238
+#: src/olympia/devhub/templates/devhub/versions/list.html:235
 msgid "Delete Version"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:240
+#: src/olympia/devhub/templates/devhub/versions/list.html:237
 msgid "Disable Version"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:247
+#: src/olympia/devhub/templates/devhub/versions/list.html:244
 msgid "Add a new Version"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:249
+#: src/olympia/devhub/templates/devhub/versions/list.html:246
 msgid "Add Version"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:256 src/olympia/devhub/templates/devhub/versions/list.html:274
+#: src/olympia/devhub/templates/devhub/versions/list.html:253 src/olympia/devhub/templates/devhub/versions/list.html:279
 msgid "Hide Add-on"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:259
+#: src/olympia/devhub/templates/devhub/versions/list.html:256
 msgid "Hiding your add-on will prevent it from appearing anywhere in our gallery and will stop users from receiving automatic updates."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:265
+#: src/olympia/devhub/templates/devhub/versions/list.html:263
+msgid "The files awaiting review will be disabled and you will need to upload new versions."
+msgstr ""
+
+#: src/olympia/devhub/templates/devhub/versions/list.html:270
 msgid "Are you sure you wish to hide your add-on?"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:286 src/olympia/devhub/templates/devhub/versions/list.html:315
+#: src/olympia/devhub/templates/devhub/versions/list.html:291 src/olympia/devhub/templates/devhub/versions/list.html:313
 msgid "Unlist Add-on"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:289
+#: src/olympia/devhub/templates/devhub/versions/list.html:294
 #, python-format
 msgid ""
 "Unlisting your add-on will make it (and each of its versions/files) invisible on this website. It won't show up in searches, won't have a public facing page, and won't be updated automatically for "
-"current users.  It is recommended for unlisted add-ons to provide a custom <a href=\"%(update_url)s\" target=\"_blank\">updateURL</a> in their manifest file for automatic updates."
+"current users. It is recommended for unlisted add-ons to provide a custom <a href=\"%(update_url)s\" target=\"_blank\">updateURL</a> in their manifest file for automatic updates."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:299
-#, python-format
-msgid "Switching add-ons to unlisted is currently in an open beta. Please <a href=\"%(url)s\" target=\"_blank\">report any bugs</a> that you encounter."
-msgstr ""
-
-#: src/olympia/devhub/templates/devhub/versions/list.html:305
+#: src/olympia/devhub/templates/devhub/versions/list.html:303
 msgid "Unlisting an add-on is irreversible!"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:305
+#: src/olympia/devhub/templates/devhub/versions/list.html:303
 msgid "An unlisted add-on cannot be switched to be listed."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:307
+#: src/olympia/devhub/templates/devhub/versions/list.html:305
 msgid "Are you sure you wish to unlist your add-on?"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:330
+#: src/olympia/devhub/templates/devhub/versions/list.html:328
 msgid "Canceling your review request will leave your add-on as preliminarily reviewed."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:335
+#: src/olympia/devhub/templates/devhub/versions/list.html:333
 msgid "Canceling your review request will mark your add-on incomplete. If you do not complete your add-on after several days by re-requesting review, it will be deleted."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:343
+#: src/olympia/devhub/templates/devhub/versions/list.html:341
 msgid "Are you sure you wish to cancel your review request?"
 msgstr ""
 
@@ -7252,19 +7094,19 @@ msgstr ""
 msgid "Search by add-on name / author email"
 msgstr ""
 
-#: src/olympia/editors/forms.py:103
+#: src/olympia/editors/forms.py:103 src/olympia/editors/forms.py:244 src/olympia/editors/forms.py:257
 msgid "yes"
 msgstr ""
 
-#: src/olympia/editors/forms.py:104
+#: src/olympia/editors/forms.py:104 src/olympia/editors/forms.py:244 src/olympia/editors/forms.py:257
 msgid "no"
 msgstr ""
 
-#: src/olympia/editors/forms.py:105
+#: src/olympia/editors/forms.py:105 src/olympia/editors/forms.py:245
 msgid "Admin Flag"
 msgstr ""
 
-#: src/olympia/editors/forms.py:113
+#: src/olympia/editors/forms.py:113 src/olympia/editors/forms.py:253
 msgid "Max. Version"
 msgstr ""
 
@@ -7276,55 +7118,59 @@ msgstr ""
 msgid "Add-on Types"
 msgstr ""
 
-#: src/olympia/editors/forms.py:126 src/olympia/editors/helpers.py:267
+#: src/olympia/editors/forms.py:126 src/olympia/editors/helpers.py:279
 msgid "Platforms"
 msgstr ""
 
+#: src/olympia/editors/forms.py:237
+msgid "Search by add-on name / author email / guid"
+msgstr ""
+
 #. L10n: 0 = platform, 1 = filename, 2 = status message
-#: src/olympia/editors/forms.py:238
+#: src/olympia/editors/forms.py:342
 #, python-format
 msgid "<strong>%s</strong> &middot; %s &middot; %s"
 msgstr ""
 
-#: src/olympia/editors/forms.py:252
+#: src/olympia/editors/forms.py:356
 msgid "Comments:"
 msgstr ""
 
-#: src/olympia/editors/forms.py:256
+#: src/olympia/editors/forms.py:360
 msgid "Operating systems:"
 msgstr ""
 
-#: src/olympia/editors/forms.py:258
+#: src/olympia/editors/forms.py:362
 msgid "Applications:"
 msgstr ""
 
-#: src/olympia/editors/forms.py:260
+#: src/olympia/editors/forms.py:364
 msgid "Notify me the next time this add-on is updated. (Subsequent updates will not generate an email)"
 msgstr ""
 
-#: src/olympia/editors/forms.py:265
+#: src/olympia/editors/forms.py:369
 msgid "Clear Admin Review Flag"
 msgstr ""
 
-#: src/olympia/editors/forms.py:267
+#: src/olympia/editors/forms.py:371
 msgid "Clear more info requested flag"
 msgstr ""
 
-#: src/olympia/editors/forms.py:281
+#: src/olympia/editors/forms.py:385
 msgid "Choose a canned response..."
 msgstr ""
 
 #. L10n: Description of what can be searched for.
-#: src/olympia/editors/forms.py:324
+#: src/olympia/editors/forms.py:423
 msgid "theme name"
 msgstr ""
 
-#: src/olympia/editors/forms.py:350
+#: src/olympia/editors/forms.py:449
 msgid "Someone else is reviewing this theme."
 msgstr ""
 
 #. L10n: Description of what can be searched for.
-#: src/olympia/editors/forms.py:447
+#: src/olympia/editors/forms.py:546
 msgid "app, reviewer, or comment"
 msgstr ""
 
@@ -7340,246 +7186,264 @@ msgstr ""
 msgid "Rejected or Unreviewed"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:123 src/olympia/editors/helpers.py:136
+#: src/olympia/editors/helpers.py:125 src/olympia/editors/helpers.py:138
 msgid "Queue"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:124 src/olympia/editors/templates/editors/base.html:50 src/olympia/editors/templates/editors/base.html:65
+#: src/olympia/editors/helpers.py:126 src/olympia/editors/templates/editors/base.html:50 src/olympia/editors/templates/editors/base.html:65
 msgid "Pending Updates"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:125 src/olympia/editors/templates/editors/base.html:48 src/olympia/editors/templates/editors/base.html:63
+#: src/olympia/editors/helpers.py:127 src/olympia/editors/templates/editors/base.html:48 src/olympia/editors/templates/editors/base.html:63
 msgid "Full Reviews"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:126 src/olympia/editors/templates/editors/base.html:52 src/olympia/editors/templates/editors/base.html:67
+#: src/olympia/editors/helpers.py:128 src/olympia/editors/templates/editors/base.html:52 src/olympia/editors/templates/editors/base.html:67
 msgid "Preliminary Reviews"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:127 src/olympia/editors/templates/editors/base.html:54
+#: src/olympia/editors/helpers.py:129 src/olympia/editors/templates/editors/base.html:54
 msgid "Moderated Reviews"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:128 src/olympia/editors/templates/editors/base.html:46
+#: src/olympia/editors/helpers.py:130 src/olympia/editors/templates/editors/base.html:46
 msgid "Fast Track"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:130
+#: src/olympia/editors/helpers.py:132
 msgid "Pending Themes"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:131 src/olympia/editors/templates/editors/themes/queue.html:4
+#: src/olympia/editors/helpers.py:133 src/olympia/editors/templates/editors/themes/queue.html:4
 msgid "Flagged Themes"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:132
+#: src/olympia/editors/helpers.py:134
 msgid "Update Themes"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:137
+#: src/olympia/editors/helpers.py:139
 msgid "Unlisted Pending Updates"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:138
+#: src/olympia/editors/helpers.py:140
 msgid "Unlisted Full Reviews"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:139
+#: src/olympia/editors/helpers.py:141
 msgid "Unlisted Preliminary Reviews"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:170
+#: src/olympia/editors/helpers.py:142
+msgid "Unlisted All Add-ons"
+msgstr ""
+
+#: src/olympia/editors/helpers.py:173
 msgid "Fast Track ({0})"
 msgid_plural "Fast Track ({0})"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/olympia/editors/helpers.py:175
+#: src/olympia/editors/helpers.py:178
 msgid "Full Review ({0})"
 msgid_plural "Full Reviews ({0})"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/olympia/editors/helpers.py:180
+#: src/olympia/editors/helpers.py:183
 msgid "Pending Update ({0})"
 msgid_plural "Pending Updates ({0})"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/olympia/editors/helpers.py:185
+#: src/olympia/editors/helpers.py:188
 msgid "Preliminary Review ({0})"
 msgid_plural "Preliminary Reviews ({0})"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/olympia/editors/helpers.py:190
+#: src/olympia/editors/helpers.py:193
 msgid "Moderated Review ({0})"
 msgid_plural "Moderated Reviews ({0})"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/olympia/editors/helpers.py:196
+#: src/olympia/editors/helpers.py:199
 msgid "Unlisted Full Review ({0})"
 msgid_plural "Unlisted Full Reviews ({0})"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/olympia/editors/helpers.py:201
+#: src/olympia/editors/helpers.py:204
 msgid "Unlisted Pending Update ({0})"
 msgid_plural "Unlisted Pending Updates ({0})"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/olympia/editors/helpers.py:206
+#: src/olympia/editors/helpers.py:209
 msgid "Unlisted Preliminary Review ({0})"
 msgid_plural "Unlisted Preliminary Reviews ({0})"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/olympia/editors/helpers.py:261
-msgid "Addon"
-msgstr ""
+#: src/olympia/editors/helpers.py:214
+msgid "Unlisted All Add-ons ({0})"
+msgid_plural "Unlisted All Add-ons ({0})"
+msgstr[0] ""
+msgstr[1] ""
 
-#: src/olympia/editors/helpers.py:262
+#: src/olympia/editors/helpers.py:274
 msgid "Type"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:263
+#: src/olympia/editors/helpers.py:275
 msgid "Waiting Time"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:264 src/olympia/editors/templates/editors/review.html:285
+#: src/olympia/editors/helpers.py:276 src/olympia/editors/templates/editors/review.html:285
 msgid "Flags"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:265
+#: src/olympia/editors/helpers.py:277
 msgid "Applications"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:270
+#: src/olympia/editors/helpers.py:282
 msgid "Additional"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:285
+#: src/olympia/editors/helpers.py:302
 msgid "Site Specific"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:287
+#: src/olympia/editors/helpers.py:304
 msgid "Requires External Software"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:289
+#: src/olympia/editors/helpers.py:306
 msgid "Binary Components"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:313
+#: src/olympia/editors/helpers.py:339
 msgid "moments ago"
 msgstr ""
 
 #. L10n: first argument is number of minutes
-#: src/olympia/editors/helpers.py:316
+#: src/olympia/editors/helpers.py:342
 msgid "{0} minute"
 msgid_plural "{0} minutes"
 msgstr[0] ""
 msgstr[1] ""
 
 #. L10n: first argument is number of hours
-#: src/olympia/editors/helpers.py:320
+#: src/olympia/editors/helpers.py:346
 msgid "{0} hour"
 msgid_plural "{0} hours"
 msgstr[0] ""
 msgstr[1] ""
 
 #. L10n: first argument is number of days
-#: src/olympia/editors/helpers.py:324
+#: src/olympia/editors/helpers.py:350
 msgid "{0} day"
 msgid_plural "{0} days"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/olympia/editors/helpers.py:488
+#: src/olympia/editors/helpers.py:364
+msgid "Last Review"
+msgstr ""
+
+#: src/olympia/editors/helpers.py:366
+msgid "Last Update"
+msgstr ""
+
+#: src/olympia/editors/helpers.py:387
+msgid "No Reviews"
+msgstr ""
+
+#: src/olympia/editors/helpers.py:561
 msgid "Push to public"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:490
+#: src/olympia/editors/helpers.py:563
 msgid "Grant full review"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:505
+#: src/olympia/editors/helpers.py:578
 msgid "Request more information"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:508
+#: src/olympia/editors/helpers.py:581
 msgid "Request super-review"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:519
+#: src/olympia/editors/helpers.py:592
 msgid "Grant preliminary review"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:520
+#: src/olympia/editors/helpers.py:593
 msgid "This will mark the files as preliminarily reviewed."
 msgstr ""
 
-#: src/olympia/editors/helpers.py:522
+#: src/olympia/editors/helpers.py:595
 msgid "Use this form to request more information from the author. They will receive an email and be able to answer here. You will be notified by email when they reply."
 msgstr ""
 
-#: src/olympia/editors/helpers.py:526
+#: src/olympia/editors/helpers.py:599
 msgid ""
 "If you have concerns about this add-on's security, copyright issues, or other concerns that an administrator should look into, enter your comments in the area below. They will be sent to "
 "administrators, not the author."
 msgstr ""
 
-#: src/olympia/editors/helpers.py:532
+#: src/olympia/editors/helpers.py:605
 msgid "This will reject the add-on and remove it from the review queue."
 msgstr ""
 
-#: src/olympia/editors/helpers.py:534
-msgid "Make a comment on this version.  The author won't be able to see this."
+#: src/olympia/editors/helpers.py:607
+msgid "Make a comment on this version. The author won't be able to see this."
 msgstr ""
 
-#: src/olympia/editors/helpers.py:538
+#: src/olympia/editors/helpers.py:611
 msgid "This will reject the files and remove them from the review queue."
 msgstr ""
 
-#: src/olympia/editors/helpers.py:542
+#: src/olympia/editors/helpers.py:615
 msgid "This will mark the add-on as preliminarily reviewed. Future versions will undergo preliminary review."
 msgstr ""
 
-#: src/olympia/editors/helpers.py:547
+#: src/olympia/editors/helpers.py:620
 msgid "This will mark the files as preliminarily reviewed. Future versions will undergo preliminary review."
 msgstr ""
 
-#: src/olympia/editors/helpers.py:552
+#: src/olympia/editors/helpers.py:625
 msgid "Retain preliminary review"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:553
+#: src/olympia/editors/helpers.py:626
 msgid "This will retain the add-on as preliminarily reviewed. Future versions will undergo preliminary review."
 msgstr ""
 
-#: src/olympia/editors/helpers.py:558
+#: src/olympia/editors/helpers.py:631
 msgid "This will approve a sandboxed version of a public add-on to appear on the public side."
 msgstr ""
 
-#: src/olympia/editors/helpers.py:561
+#: src/olympia/editors/helpers.py:634
 msgid "This will reject a version of a public add-on and remove it from the queue."
 msgstr ""
 
-#: src/olympia/editors/helpers.py:564
+#: src/olympia/editors/helpers.py:637
 msgid "This will mark the add-on and its most recent version and files as public. Future versions will go into the sandbox until they are reviewed by an editor."
 msgstr ""
 
-#: src/olympia/editors/helpers.py:637
+#: src/olympia/editors/helpers.py:714
 msgid "add-on"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:940 src/olympia/editors/helpers.py:960
+#: src/olympia/editors/helpers.py:1020 src/olympia/editors/helpers.py:1040
 msgid "Flagged"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:944 src/olympia/editors/helpers.py:963
+#: src/olympia/editors/helpers.py:1024 src/olympia/editors/helpers.py:1043
 msgid "Updates"
 msgstr ""
 
@@ -7631,56 +7495,56 @@ msgstr ""
 msgid "A question about your Theme submission"
 msgstr ""
 
-#: src/olympia/editors/views.py:144
+#: src/olympia/editors/views.py:146
 msgid "New Add-ons (Under 5 days)"
 msgstr ""
 
-#: src/olympia/editors/views.py:145
+#: src/olympia/editors/views.py:147
 msgid "Passable (5 to 10 days)"
 msgstr ""
 
-#: src/olympia/editors/views.py:146
+#: src/olympia/editors/views.py:148
 msgid "Overdue (Over 10 days)"
 msgstr ""
 
-#: src/olympia/editors/views.py:532
+#: src/olympia/editors/views.py:539
 msgid "An unknown error occurred"
 msgstr ""
 
-#: src/olympia/editors/views.py:587
+#: src/olympia/editors/views.py:592
 msgid "Self-reviews are not allowed."
 msgstr ""
 
-#: src/olympia/editors/views.py:609
+#: src/olympia/editors/views.py:613
 msgid "Review successfully processed."
 msgstr ""
 
-#: src/olympia/editors/views.py:807
+#: src/olympia/editors/views.py:812
 msgid "was approved"
 msgstr ""
 
-#: src/olympia/editors/views.py:808
+#: src/olympia/editors/views.py:813
 msgid "given preliminary review"
 msgstr ""
 
-#: src/olympia/editors/views.py:809
+#: src/olympia/editors/views.py:814
 msgid "rejected"
 msgstr ""
 
-#: src/olympia/editors/views.py:810
+#: src/olympia/editors/views.py:815
 msgctxt "editors_review_history_nominated_adminreview"
 msgid "escalated"
 msgstr ""
 
-#: src/olympia/editors/views.py:812
+#: src/olympia/editors/views.py:817
 msgid "needs more information"
 msgstr ""
 
-#: src/olympia/editors/views.py:813
+#: src/olympia/editors/views.py:818
 msgid "needs super review"
 msgstr ""
 
-#: src/olympia/editors/views.py:814
+#: src/olympia/editors/views.py:819
 msgid "commented"
 msgstr ""
 
@@ -7725,28 +7589,28 @@ msgstr ""
 msgid "Unlisted Queues"
 msgstr ""
 
-#: src/olympia/editors/templates/editors/base.html:72 src/olympia/editors/templates/editors/performance.html:6
+#: src/olympia/editors/templates/editors/base.html:74 src/olympia/editors/templates/editors/performance.html:6
 msgid "Performance"
 msgstr ""
 
-#: src/olympia/editors/templates/editors/base.html:75 src/olympia/editors/templates/editors/themes/base.html:19 src/olympia/editors/templates/editors/themes/base.html:38
+#: src/olympia/editors/templates/editors/base.html:77 src/olympia/editors/templates/editors/themes/base.html:19 src/olympia/editors/templates/editors/themes/base.html:38
 msgid "Logs"
 msgstr ""
 
-#: src/olympia/editors/templates/editors/base.html:78 src/olympia/editors/templates/editors/reviewlog.html:4 src/olympia/editors/templates/editors/reviewlog.html:27
+#: src/olympia/editors/templates/editors/base.html:80 src/olympia/editors/templates/editors/reviewlog.html:4 src/olympia/editors/templates/editors/reviewlog.html:27
 msgid "Add-on Review Log"
 msgstr ""
 
-#: src/olympia/editors/templates/editors/base.html:80 src/olympia/editors/templates/editors/eventlog.html:4 src/olympia/editors/templates/editors/eventlog.html:8
+#: src/olympia/editors/templates/editors/base.html:82 src/olympia/editors/templates/editors/eventlog.html:4 src/olympia/editors/templates/editors/eventlog.html:8
 #: src/olympia/editors/templates/editors/eventlog_detail.html:4
 msgid "Moderated Review Log"
 msgstr ""
 
-#: src/olympia/editors/templates/editors/base.html:82 src/olympia/editors/templates/editors/beta_signed_log.html:4 src/olympia/editors/templates/editors/beta_signed_log.html:8
+#: src/olympia/editors/templates/editors/base.html:84 src/olympia/editors/templates/editors/beta_signed_log.html:4 src/olympia/editors/templates/editors/beta_signed_log.html:8
 msgid "Signed Beta Files Log"
 msgstr ""
 
-#: src/olympia/editors/templates/editors/base.html:87 src/olympia/editors/templates/editors/includes/daily-message.html:4
+#: src/olympia/editors/templates/editors/base.html:89 src/olympia/editors/templates/editors/includes/daily-message.html:4
 msgid "Announcement"
 msgstr ""
 
@@ -7967,45 +7831,45 @@ msgstr ""
 msgid "clear search"
 msgstr ""
 
-#: src/olympia/editors/templates/editors/queue.html:72 src/olympia/editors/templates/editors/queue.html:122
+#: src/olympia/editors/templates/editors/queue.html:78 src/olympia/editors/templates/editors/queue.html:128
 msgid "Process Reviews"
 msgstr ""
 
-#: src/olympia/editors/templates/editors/queue.html:80
+#: src/olympia/editors/templates/editors/queue.html:86
 msgid "Moderation actions:"
 msgstr ""
 
-#: src/olympia/editors/templates/editors/queue.html:90
+#: src/olympia/editors/templates/editors/queue.html:96
 #, python-format
 msgid "by %(user)s on %(date)s %(stars)s (%(locale)s)"
 msgstr ""
 
-#: src/olympia/editors/templates/editors/queue.html:106
+#: src/olympia/editors/templates/editors/queue.html:112
 #, python-format
 msgid "<strong>%(reason)s</strong> <span class=\"light\">Flagged by %(user)s on %(date)s</span>"
 msgstr ""
 
-#: src/olympia/editors/templates/editors/queue.html:119
-msgid "All reviews have been moderated.  Good work!"
+#: src/olympia/editors/templates/editors/queue.html:125
+msgid "All reviews have been moderated. Good work!"
 msgstr ""
 
-#: src/olympia/editors/templates/editors/queue.html:161
+#: src/olympia/editors/templates/editors/queue.html:167
 msgid "Version Notes / Notes for Reviewer"
 msgstr ""
 
-#: src/olympia/editors/templates/editors/queue.html:169
+#: src/olympia/editors/templates/editors/queue.html:175
 msgid "There are currently no add-ons of this type to review."
 msgstr ""
 
-#: src/olympia/editors/templates/editors/queue.html:181 src/olympia/editors/templates/editors/themes/queue_list.html:85
+#: src/olympia/editors/templates/editors/queue.html:187 src/olympia/editors/templates/editors/themes/queue_list.html:85
 msgid "Helpful Links:"
 msgstr ""
 
-#: src/olympia/editors/templates/editors/queue.html:182
+#: src/olympia/editors/templates/editors/queue.html:188
 msgid "Add-on Policy"
 msgstr ""
 
-#: src/olympia/editors/templates/editors/queue.html:184
+#: src/olympia/editors/templates/editors/queue.html:190
 msgid "Editors' Guide"
 msgstr ""
 
@@ -8068,10 +7932,7 @@ msgid "<strong>Warning!</strong> Another user was viewing this page before you."
 msgstr ""
 
 #: src/olympia/editors/templates/editors/review.html:237
-msgid ""
-"The whiteboard is the place to exchange information relevant to\n"
-"               this addon (whatever the version), between the developer and the\n"
-"               editor. This is visible and editable by both."
+msgid "The whiteboard is the place to exchange information relevant to this addon (whatever the version), between the developer and the editor. This is visible and editable by both."
 msgstr ""
 
 #: src/olympia/editors/templates/editors/review.html:241
@@ -8345,7 +8206,7 @@ msgstr ""
 msgid "Describe your reason for flagging"
 msgstr ""
 
-#: src/olympia/files/forms.py:88
+#: src/olympia/files/forms.py:90
 msgid "Cannot diff a version against itself"
 msgstr ""
 
@@ -8380,51 +8241,51 @@ msgstr ""
 msgid "There was an error accessing file %s."
 msgstr ""
 
-#: src/olympia/files/utils.py:343
+#: src/olympia/files/utils.py:340
 msgid "Could not parse uploaded file."
 msgstr ""
 
-#: src/olympia/files/utils.py:380
+#: src/olympia/files/utils.py:377
 msgid "Invalid file name in archive: {0}"
 msgstr ""
 
-#: src/olympia/files/utils.py:388
+#: src/olympia/files/utils.py:385
 msgid "File exceeding size limit in archive: {0}"
 msgstr ""
 
-#: src/olympia/files/utils.py:439
+#: src/olympia/files/utils.py:436
 msgid "Invalid archive."
 msgstr ""
 
-#: src/olympia/files/utils.py:529 src/olympia/files/utils.py:532
+#: src/olympia/files/utils.py:526 src/olympia/files/utils.py:529
 msgid "Could not parse the manifest file."
 msgstr ""
 
-#: src/olympia/files/utils.py:551
+#: src/olympia/files/utils.py:548
 msgid "Could not find an add-on ID."
 msgstr ""
 
-#: src/olympia/files/utils.py:554
+#: src/olympia/files/utils.py:551
 msgid "Add-on ID must be 64 characters or less."
 msgstr ""
 
-#: src/olympia/files/utils.py:556
+#: src/olympia/files/utils.py:553
 msgid "Add-on ID doesn't match add-on."
 msgstr ""
 
-#: src/olympia/files/utils.py:564
+#: src/olympia/files/utils.py:561
 msgid "Duplicate add-on ID found."
 msgstr ""
 
-#: src/olympia/files/utils.py:567
+#: src/olympia/files/utils.py:564
 msgid "Version numbers should have fewer than 32 characters."
 msgstr ""
 
-#: src/olympia/files/utils.py:570
+#: src/olympia/files/utils.py:567
 msgid "Version numbers should only contain letters, numbers, and these punctuation characters: +*.-_."
 msgstr ""
 
-#: src/olympia/files/utils.py:587
+#: src/olympia/files/utils.py:584
 msgid "<em:type> doesn't match add-on"
 msgstr ""
 
@@ -8523,6 +8384,10 @@ msgstr ""
 
 #: src/olympia/files/templates/files/viewer.html:134
 msgid "Fetching file."
+msgstr ""
+
+#: src/olympia/legacy_api/views.py:255
+msgid "Not implemented yet."
 msgstr ""
 
 #: src/olympia/lib/constants.py:6
@@ -9181,10 +9046,6 @@ msgstr ""
 msgid "Zimbabwe Dollar"
 msgstr ""
 
-#: src/olympia/lib/video/ffmpeg.py:112 src/olympia/lib/video/totem.py:81
-msgid "Videos must be in WebM."
-msgstr ""
-
 #: src/olympia/pages/templates/pages/about.lhtml:3 src/olympia/pages/templates/pages/about.lhtml:10
 msgid "About Mozilla Add-ons"
 msgstr ""
@@ -9196,7 +9057,7 @@ msgstr ""
 #: src/olympia/pages/templates/pages/about.lhtml:13
 msgid ""
 "addons.mozilla.org, commonly known as \"AMO\", is Mozilla's official site for add-ons to Mozilla software, such as Firefox, Thunderbird, and SeaMonkey. Add-ons let you add new features and change "
-"the way your browser or application works.  Take a look around and explore the thousands of ways to customize the way you do things online."
+"the way your browser or application works. Take a look around and explore the thousands of ways to customize the way you do things online."
 msgstr ""
 
 #: src/olympia/pages/templates/pages/about.lhtml:19
@@ -9541,7 +9402,7 @@ msgstr ""
 msgid ""
 "Yes. It's possible, but some of the functionality provided by these libraries are available through XPCOM, XUL, and JavaScript. In addition, authors should take care if libraries modify primitive "
 "object prototypes (String.prototype, Date.prototype, etc.) and/or define global functions (eg. the $ function). These are prone to cause conflict with other add-ons, in particular if different add-"
-"ons use different versions of libraries and so on. Developers need to be very, very careful with using them.  Mozilla does not offer documentation on using them to build add-ons."
+"ons use different versions of libraries and so on. Developers need to be very, very careful with using them. Mozilla does not offer documentation on using them to build add-ons."
 msgstr ""
 
 #: src/olympia/pages/templates/pages/dev_faq.html:165
@@ -9655,8 +9516,8 @@ msgstr ""
 #, python-format
 msgid ""
 "Yes. Many developers choose to host their own add-ons. Choosing to host your add-on on <a href=\"%(amo_url)s\">Mozilla's add-on site</a>, though, allows for much greater exposure to your add-on due "
-"to the large volume of visitors to the site.  <a href=\"%(md_url)s\">mozdev.org</a> offers free project hosting for Mozilla applications and extensions providing developers with tools to help "
-"manage source code, version control, bug tracking and documentation."
+"to the large volume of visitors to the site. <a href=\"%(md_url)s\">mozdev.org</a> offers free project hosting for Mozilla applications and extensions providing developers with tools to help manage "
+"source code, version control, bug tracking and documentation."
 msgstr ""
 
 #: src/olympia/pages/templates/pages/dev_faq.html:277
@@ -9704,7 +9565,7 @@ msgstr ""
 #: src/olympia/pages/templates/pages/dev_faq.html:314
 #, python-format
 msgid ""
-"Yes. Mozilla's <a href=\"%(p_url)s\">Add-on Policy</a> describes what is an acceptable submission. This policy is subject to change without notice.  In addition, the AMO editorial team uses the <a "
+"Yes. Mozilla's <a href=\"%(p_url)s\">Add-on Policy</a> describes what is an acceptable submission. This policy is subject to change without notice. In addition, the AMO editorial team uses the <a "
 "href=\"%(g_url)s\">Editors Reviewing Guide</a> to ensure that your add-on meets specific guidelines for functionality and security."
 msgstr ""
 
@@ -9821,7 +9682,7 @@ msgstr ""
 #: src/olympia/pages/templates/pages/dev_faq.html:434
 #, python-format
 msgid ""
-"This is why it's very important to read the <a href=\"%(g_url)s\">Editors Reviewing Guide</a> to ensure that your add-on is setup as expected.  It's also a good idea to read the blog post, <a href="
+"This is why it's very important to read the <a href=\"%(g_url)s\">Editors Reviewing Guide</a> to ensure that your add-on is setup as expected. It's also a good idea to read the blog post, <a href="
 "\"%(blog_url)s\">Successfully Getting your Add-on Reviewed</a> which provides excellent insight into ensuring a smooth review of your add-on."
 msgstr ""
 
@@ -9928,7 +9789,7 @@ msgstr ""
 
 #: src/olympia/pages/templates/pages/dev_faq.html:572
 msgid ""
-"Free Software Foundation provides short summaries of the key open source licenses, including whether the license qualifies as a free software license or a copyleft license.  Also includes a "
+"Free Software Foundation provides short summaries of the key open source licenses, including whether the license qualifies as a free software license or a copyleft license. Also includes a "
 "discussion of what constitutes a free software license or a copyleft license (e.g., a Copyleft license is a general method for making a program or other work free, and requiring all modified and "
 "extended versions of the program to be free as well.)"
 msgstr ""
@@ -10106,19 +9967,13 @@ msgid "Add-on Gallery"
 msgstr ""
 
 #: src/olympia/pages/templates/pages/faq.html:171
-msgid ""
-"How do I choose between add-ons that seem to do the same\n"
-"    thing?"
+msgid "How do I choose between add-ons that seem to do the same thing?"
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:173
+#: src/olympia/pages/templates/pages/faq.html:172
 msgid ""
-"There are often several add-ons that have similar features. To\n"
-"    figure out which is right for you, read the entire description of the\n"
-"    add-on and view its screenshots. If there are still several in the running,\n"
-"    read through the add-on's ratings, user reviews, and statistics to see\n"
-"    which is most liked by other users. Remember that you can also just try\n"
-"    out both and see which you like better."
+"There are often several add-ons that have similar features. To figure out which is right for you, read the entire description of the add-on and view its screenshots. If there are still several in "
+"the running, read through the add-on's ratings, user reviews, and statistics to see which is most liked by other users. Remember that you can also just try out both and see which you like better."
 msgstr ""
 
 #: src/olympia/pages/templates/pages/faq.html:180
@@ -10159,80 +10014,67 @@ msgid "How much do add-ons cost to purchase?"
 msgstr ""
 
 #: src/olympia/pages/templates/pages/faq.html:207
-msgid ""
-"Add-ons hosted in our gallery are free unless clearly marked\n"
-"    otherwise."
+msgid "Add-ons hosted in our gallery are free unless clearly marked otherwise."
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:210
+#: src/olympia/pages/templates/pages/faq.html:209
 msgid "What does it mean when an add-on asks for contributions?"
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:211
+#: src/olympia/pages/templates/pages/faq.html:210
 msgid ""
-"Some add-on authors request users who enjoy an add-on to\n"
-"        contribute to its development by making a monetary contribution. These\n"
-"        contributions go directly to the developer unless a third party is\n"
-"        indicated, such as the non-profit Mozilla Foundation."
+"Some add-on authors request users who enjoy an add-on to contribute to its development by making a monetary contribution. These contributions go directly to the developer unless a third party is "
+"indicated, such as the non-profit Mozilla Foundation."
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:216
+#: src/olympia/pages/templates/pages/faq.html:215
 msgid "What are beta add-ons?"
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:218
+#: src/olympia/pages/templates/pages/faq.html:217
 msgid ""
-"Beta add-ons are unreviewed versions which represent the\n"
-"        latest work of an add-on author. While different authors have different\n"
-"        standards for beta code quality, you should assume that these add-ons\n"
-"        are less stable than the general add-on releases."
+"Beta add-ons are unreviewed versions which represent the latest work of an add-on author. While different authors have different standards for beta code quality, you should assume that these add-"
+"ons are less stable than the general add-on releases."
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:222
+#: src/olympia/pages/templates/pages/faq.html:221
 msgid ""
 "Please note that when you install an add-on from the \"Beta Version\" section of an add-on's listing, you will continue to receive updates for that add-on as they become available. Like the initial "
 "version you installed, all beta releases are unreviewed by Mozilla and may harm your computer."
 msgstr ""
 
+#: src/olympia/pages/templates/pages/faq.html:228
+msgid "What does it mean when an add-on is flagged as slow?"
+msgstr ""
+
 #: src/olympia/pages/templates/pages/faq.html:229
-msgid ""
-"What does it mean when an add-on is flagged as\n"
-"    slow?"
+msgid "Most add-ons load code and resources at the same time Firefox is starting up. In most cases the impact in start-up time is minimal, but some add-ons can cause a noticeable slowdown."
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:231
-msgid ""
-"Most add-ons load code and resources at the same time Firefox\n"
-"        is starting up. In most cases the impact in start-up time is minimal,\n"
-"        but some add-ons can cause a noticeable slowdown."
-msgstr ""
-
-#: src/olympia/pages/templates/pages/faq.html:236
+#: src/olympia/pages/templates/pages/faq.html:234
 msgid "How do I report an inappropriate or spam user review?"
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:237
+#: src/olympia/pages/templates/pages/faq.html:235
 msgid ""
-"To report a user review of an add-on, log in with your account\n"
-"    and visit the add-on's reviews page. Find the review you wish to report,\n"
-"    click \"Report this review\" and select a reason. Our editorial team will\n"
-"    investigate the review and take appropriate action."
+"To report a user review of an add-on, log in with your account and visit the add-on's reviews page. Find the review you wish to report, click \"Report this review\" and select a reason. Our "
+"editorial team will investigate the review and take appropriate action."
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:242
+#: src/olympia/pages/templates/pages/faq.html:240
 msgid "How do I report a bug or contact the Mozilla Add-ons team?"
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:243
+#: src/olympia/pages/templates/pages/faq.html:241
 #, python-format
 msgid "Please visit our <a href=\"%(contact_url)s\">Contact page</a>."
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:246
+#: src/olympia/pages/templates/pages/faq.html:244
 msgid "What is a Source Code License?"
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:247
+#: src/olympia/pages/templates/pages/faq.html:245
 #, python-format
 msgid ""
 "The source code used to create an add-on is an exclusive copyright of the add-on author, unless otherwise declared in a source code license. Many add-ons on this site have <a href=\"%(url)s\" lang="
@@ -10240,60 +10082,60 @@ msgid ""
 "the GPL or BSD licenses instead of making up their own."
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:256
+#: src/olympia/pages/templates/pages/faq.html:254
 #, python-format
 msgid "Firefox and other Mozilla software are <a href=\"%(url)s\">open source</a>."
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:264
+#: src/olympia/pages/templates/pages/faq.html:262
 msgid "Collections and Favorites"
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:267
+#: src/olympia/pages/templates/pages/faq.html:265
 msgid "What is a collection?"
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:268
+#: src/olympia/pages/templates/pages/faq.html:266
 msgid "Collections are groups of related add-ons created by users to share."
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:270
+#: src/olympia/pages/templates/pages/faq.html:268
 msgid "What is the My Favorites collection?"
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:271
+#: src/olympia/pages/templates/pages/faq.html:269
 msgid "Favorite add-ons are add-ons that you have bookmarked to easily get back to later. You can add an add-on to your favorites collection by clicking \"Add to favorites\" on its details page."
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:275 src/olympia/templates/menu_links.html:13 src/olympia/templates/impala/header_title.html:17
+#: src/olympia/pages/templates/pages/faq.html:273 src/olympia/templates/menu_links.html:13 src/olympia/templates/impala/header_title.html:17
 msgid "Mobile Add-ons"
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:278
+#: src/olympia/pages/templates/pages/faq.html:276
 msgid "What are mobile add-ons?"
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:279
+#: src/olympia/pages/templates/pages/faq.html:277
 #, python-format
 msgid ""
 "Mobile add-ons work with <a href=\"%(mobile_url)s\">Firefox for Mobile</a> and add or modify functionality just like desktop add-ons. You can find add-ons that work with Firefox for Mobile in our "
 "<a href=\"%(gallery_url)s\">gallery</a>."
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:288
+#: src/olympia/pages/templates/pages/faq.html:286
 msgid "Developer Topics"
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:289
+#: src/olympia/pages/templates/pages/faq.html:287
 #, python-format
 msgid "Please see our <a href=\"%(faq_url)s\">Developer FAQ</a> and <a href=\"%(hub_url)s\">Developer Hub</a> for answers to add-on developer-related questions."
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:294
+#: src/olympia/pages/templates/pages/faq.html:292
 msgid "Still have questions?"
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:295
+#: src/olympia/pages/templates/pages/faq.html:293
 #, python-format
 msgid "For general Firefox support, visit our <a href=\"%(sumo_url)s\">support website</a>. For general add-on and website questions, visit our <a href=\"%(forum_url)s\">forum</a>."
 msgstr ""
@@ -10431,7 +10273,7 @@ msgstr ""
 
 #: src/olympia/pages/templates/pages/sunbird.html:29
 msgid ""
-"Development on the Sunbird project has halted and its final release was on March 30, 2010.  We've been proud to host Sunbird add-ons on this site but as the project is no longer maintained we have "
+"Development on the Sunbird project has halted and its final release was on March 30, 2010. We've been proud to host Sunbird add-ons on this site but as the project is no longer maintained we have "
 "disabled our support for the add-ons."
 msgstr ""
 
@@ -10509,7 +10351,7 @@ msgstr ""
 #, python-format
 msgid ""
 "<h2>Keep these tips in mind:</h2> <ul> <li> Write like you're telling a friend about your experience with the add-on. Give specifics and helpful details, such as what features you liked and/or "
-"disliked, how easy to use it is, and any disadvantages it has.  Avoid generic language such as calling it \"Great\" or \"Bad\" unless you can give reasons why you believe this is so. </li> <li> "
+"disliked, how easy to use it is, and any disadvantages it has. Avoid generic language such as calling it \"Great\" or \"Bad\" unless you can give reasons why you believe this is so. </li> <li> "
 "Please do not post bug reports in reviews. We do not make your email address available to add-on developers and they may need to contact you to help resolve your issue. See the <a href=\"%(support)s"
 "\">support section</a> to find out where to get assistance for this add-on. </li> <li>Please keep reviews clean, avoid the use of improper language and do not post any personal information. </li> </"
 "ul> <p>Please read the <a href=\"%(guide)s\" target=\"_blank\">Review Guidelines</a> for more detail about user add-on reviews.</p>"
@@ -10745,16 +10587,16 @@ msgstr ""
 
 #. L10n: {0} is an application, such as Firefox. This means "any version of
 #. Firefox."
-#: src/olympia/search/views.py:554
+#: src/olympia/search/views.py:547
 msgid "Any {0}"
 msgstr ""
 
 #. L10n: "All Systems" means show everything regardless of platform.
-#: src/olympia/search/views.py:589
+#: src/olympia/search/views.py:582
 msgid "All Systems"
 msgstr ""
 
-#: src/olympia/search/views.py:600
+#: src/olympia/search/views.py:593
 msgid "All Tags"
 msgstr ""
 
@@ -10928,31 +10770,31 @@ msgstr ""
 msgid "Share this Collection"
 msgstr ""
 
-#: src/olympia/signing/views.py:30 src/olympia/templates/base.html:75 src/olympia/templates/impala/base.html:115
+#: src/olympia/signing/views.py:33 src/olympia/templates/base.html:71 src/olympia/templates/impala/base.html:112
 msgid "Some features are temporarily disabled while we perform website maintenance. We'll be back to full capacity shortly."
 msgstr ""
 
-#: src/olympia/signing/views.py:53
+#: src/olympia/signing/views.py:56
 msgid "Could not find add-on with id \"{}\"."
 msgstr ""
 
-#: src/olympia/signing/views.py:67
+#: src/olympia/signing/views.py:70
 msgid "You do not own this addon."
 msgstr ""
 
-#: src/olympia/signing/views.py:82
+#: src/olympia/signing/views.py:87
 msgid "Missing \"upload\" key in multipart file data."
 msgstr ""
 
-#: src/olympia/signing/views.py:96
+#: src/olympia/signing/views.py:101
 msgid "Version does not match the manifest file."
 msgstr ""
 
-#: src/olympia/signing/views.py:100
+#: src/olympia/signing/views.py:105
 msgid "Version already exists."
 msgstr ""
 
-#: src/olympia/signing/views.py:136
+#: src/olympia/signing/views.py:141
 msgid "No uploaded file for that addon and version."
 msgstr ""
 
@@ -11065,89 +10907,89 @@ msgstr ""
 msgid "Statistics Dashboard :: Add-ons for {0}"
 msgstr ""
 
-#: src/olympia/stats/templates/stats/stats.html:30
-msgid "Controls:"
-msgstr ""
-
-#: src/olympia/stats/templates/stats/stats.html:33
-msgid "reset zoom"
-msgstr ""
-
-#: src/olympia/stats/templates/stats/stats.html:40
-msgid "Group by:"
-msgstr ""
-
-#: src/olympia/stats/templates/stats/stats.html:42
-msgid "day"
-msgstr ""
-
-#: src/olympia/stats/templates/stats/stats.html:45
-msgid "week"
-msgstr ""
-
-#: src/olympia/stats/templates/stats/stats.html:48
-msgid "month"
-msgstr ""
-
-#: src/olympia/stats/templates/stats/stats.html:54
-msgid "For last:"
-msgstr ""
-
-#: src/olympia/stats/templates/stats/stats.html:57
-msgid "7 days"
-msgstr ""
-
-#: src/olympia/stats/templates/stats/stats.html:60
-msgid "30 days"
-msgstr ""
-
-#: src/olympia/stats/templates/stats/stats.html:63
-msgid "90 days"
-msgstr ""
-
-#: src/olympia/stats/templates/stats/stats.html:66
-msgid "365 days"
-msgstr ""
-
-#: src/olympia/stats/templates/stats/stats.html:69
-msgid "Custom..."
-msgstr ""
-
 #. {0} is an add-on name
-#: src/olympia/stats/templates/stats/stats.html:88 src/olympia/stats/templates/stats/stats.html:91
+#: src/olympia/stats/templates/stats/stats.html:44 src/olympia/stats/templates/stats/stats.html:47
 msgid "Statistics for {0}"
 msgstr ""
 
-#: src/olympia/stats/templates/stats/stats.html:94
+#: src/olympia/stats/templates/stats/stats.html:50
 msgid "Statistics Dashboard"
 msgstr ""
 
-#: src/olympia/stats/templates/stats/stats.html:104
+#: src/olympia/stats/templates/stats/stats.html:57
+msgid "Controls:"
+msgstr ""
+
+#: src/olympia/stats/templates/stats/stats.html:60
+msgid "reset zoom"
+msgstr ""
+
+#: src/olympia/stats/templates/stats/stats.html:67
+msgid "Group by:"
+msgstr ""
+
+#: src/olympia/stats/templates/stats/stats.html:69
+msgid "day"
+msgstr ""
+
+#: src/olympia/stats/templates/stats/stats.html:72
+msgid "week"
+msgstr ""
+
+#: src/olympia/stats/templates/stats/stats.html:75
+msgid "month"
+msgstr ""
+
+#: src/olympia/stats/templates/stats/stats.html:81
+msgid "For last:"
+msgstr ""
+
+#: src/olympia/stats/templates/stats/stats.html:84
+msgid "7 days"
+msgstr ""
+
+#: src/olympia/stats/templates/stats/stats.html:87
+msgid "30 days"
+msgstr ""
+
+#: src/olympia/stats/templates/stats/stats.html:90
+msgid "90 days"
+msgstr ""
+
+#: src/olympia/stats/templates/stats/stats.html:93
+msgid "365 days"
+msgstr ""
+
+#: src/olympia/stats/templates/stats/stats.html:96
+msgid "Custom..."
+msgstr ""
+
+#: src/olympia/stats/templates/stats/stats.html:106
 msgid "Statistics processing is currently disabled, so recent data is unavailable. The statistics are still being collected and this page will be updated soon with the missing data."
 msgstr ""
 
-#: src/olympia/stats/templates/stats/stats.html:110
+#: src/olympia/stats/templates/stats/stats.html:112
 msgid "Loading the latest data&hellip;"
 msgstr ""
 
-#: src/olympia/stats/templates/stats/stats.html:142 src/olympia/stats/templates/stats/reports/overview.html:25 src/olympia/stats/templates/stats/reports/overview.html:37
+#: src/olympia/stats/templates/stats/stats.html:144 src/olympia/stats/templates/stats/reports/overview.html:25 src/olympia/stats/templates/stats/reports/overview.html:37
 #: src/olympia/stats/templates/stats/reports/overview.html:49
 msgid "No data available."
 msgstr ""
 
-#: src/olympia/stats/templates/stats/stats.html:177
+#: src/olympia/stats/templates/stats/stats.html:179
 msgid "This dashboard is currently <b>public</b>."
 msgstr ""
 
-#: src/olympia/stats/templates/stats/stats.html:179
+#: src/olympia/stats/templates/stats/stats.html:181
 msgid "Contribution stats are currently <b>private</b>."
 msgstr ""
 
-#: src/olympia/stats/templates/stats/stats.html:182
+#: src/olympia/stats/templates/stats/stats.html:184
 msgid "This dashboard is currently <b>private</b>."
 msgstr ""
 
-#: src/olympia/stats/templates/stats/stats.html:185
+#: src/olympia/stats/templates/stats/stats.html:187
 msgid "Change settings."
 msgstr ""
 
@@ -11299,15 +11141,6 @@ msgstr ""
 msgid "Application versions by Date"
 msgstr ""
 
-#: src/olympia/tags/templates/tags/top_cloud.html:4
-msgid "Top {0} Tags"
-msgstr ""
-
-#. {0} is the current application name
-#: src/olympia/tags/templates/tags/top_cloud.html:14
-msgid "{0} Top Tags"
-msgstr ""
-
 #: src/olympia/templates/amo_footer.html:6 src/olympia/templates/includes/lang_switcher.html:2
 msgid "Other languages"
 msgstr ""
@@ -11316,11 +11149,11 @@ msgstr ""
 msgid "Mozilla Add-ons"
 msgstr ""
 
-#: src/olympia/templates/base.html:91 src/olympia/templates/impala/base.html:81
+#: src/olympia/templates/base.html:89 src/olympia/templates/impala/base.html:78
 msgid "Find add-ons for other applications"
 msgstr ""
 
-#: src/olympia/templates/base.html:92 src/olympia/templates/impala/base.html:81
+#: src/olympia/templates/base.html:90 src/olympia/templates/impala/base.html:78
 msgid "Other Applications"
 msgstr ""
 
@@ -11345,7 +11178,7 @@ msgid "View Mobile Site"
 msgstr ""
 
 #: src/olympia/templates/copyright.html:7
-msgid "Site Status "
+msgid "Site Status"
 msgstr ""
 
 #: src/olympia/templates/footer.html:3
@@ -11445,35 +11278,35 @@ msgstr ""
 msgid "<a href=\"%(reg)s\">Register</a> or <a href=\"%(login)s\">Log in</a>"
 msgstr ""
 
-#: src/olympia/templates/impala/base.html:126
+#: src/olympia/templates/impala/base.html:123
 #, python-format
 msgid "To try the thousands of add-ons available here, download <a href=\"%(url)s\">Mozilla Firefox</a>, a fast, free way to surf the Web!"
 msgstr ""
 
-#: src/olympia/templates/impala/base.html:138
+#: src/olympia/templates/impala/base.html:135
 #, python-format
 msgid "Add-ons is switching to Firefox Accounts for login. <a href=\"%(url)s\" class=\"fxa-login\">Sign in now to transfer your account.</a>"
 msgstr ""
 
 #. {0} is an application, such as Firefox.
-#: src/olympia/templates/impala/base.html:148
+#: src/olympia/templates/impala/base.html:145
 msgid "Welcome to {0} Add-ons."
 msgstr ""
 
-#: src/olympia/templates/impala/base.html:151
+#: src/olympia/templates/impala/base.html:148
 msgid "Choose from thousands of extra features and styles to make Firefox your own."
 msgstr ""
 
-#: src/olympia/templates/impala/base.html:156
+#: src/olympia/templates/impala/base.html:153
 #, python-format
 msgid "Add extra features and styles to make %(app)s your own."
 msgstr ""
 
-#: src/olympia/templates/impala/base.html:164
+#: src/olympia/templates/impala/base.html:161
 msgid "On the go?"
 msgstr ""
 
-#: src/olympia/templates/impala/base.html:166
+#: src/olympia/templates/impala/base.html:163
 msgid "Check out our <a class=\"mobile-link\" href=\"#\">Mobile Add-ons site</a>."
 msgstr ""
 
@@ -11697,19 +11530,19 @@ msgstr ""
 
 #. L10n: {id} will be something like "13ad6a", just a random number
 #. to differentiate this user from other anonymous users.
-#: src/olympia/users/models.py:353
+#: src/olympia/users/models.py:362
 msgid "Anonymous user {id}"
 msgstr ""
 
-#: src/olympia/users/models.py:410
+#: src/olympia/users/models.py:419
 msgid "Your account has been restricted"
 msgstr ""
 
-#: src/olympia/users/models.py:480
+#: src/olympia/users/models.py:489
 msgid "Please confirm your email address"
 msgstr ""
 
-#: src/olympia/users/models.py:506
+#: src/olympia/users/models.py:515
 msgid "My Mobile Add-ons"
 msgstr ""
 
@@ -11986,7 +11819,7 @@ msgstr ""
 
 #: src/olympia/users/templates/users/edit.html:70
 #, python-format
-msgid "Change your password.  If you forgot your password, you can <a href=\"%(reset_url)s\">use the reset form</a>."
+msgid "Change your password. If you forgot your password, you can <a href=\"%(reset_url)s\">use the reset form</a>."
 msgstr ""
 
 #: src/olympia/users/templates/users/edit.html:76
@@ -12006,7 +11839,7 @@ msgid "Profile"
 msgstr ""
 
 #: src/olympia/users/templates/users/edit.html:100
-msgid "Give us a bit more information about yourself.  All these fields are optional, but they'll help other users get to know you better."
+msgid "Give us a bit more information about yourself. All these fields are optional, but they'll help other users get to know you better."
 msgstr ""
 
 #: src/olympia/users/templates/users/edit.html:124
@@ -12222,7 +12055,7 @@ msgid "Confirm password"
 msgstr ""
 
 #: src/olympia/users/templates/users/pwreset_confirm.html:47
-msgid "The password reset link was invalid, possibly because it has already been used.  Please request a new password reset."
+msgid "The password reset link was invalid, possibly because it has already been used. Please request a new password reset."
 msgstr ""
 
 #: src/olympia/users/templates/users/pwreset_request.html:15
@@ -12408,7 +12241,7 @@ msgstr ""
 
 #: src/olympia/users/templates/users/unsubscribe.html:30
 #, python-format
-msgid "Unfortunately, we weren't able to unsubscribe you.  The link you clicked is invalid. However, you can unsubscribe still unsubscribe on your <a href=\"%(edit_url)s\">edit profile page</a>."
+msgid "Unfortunately, we weren't able to unsubscribe you. The link you clicked is invalid. However, you can unsubscribe still unsubscribe on your <a href=\"%(edit_url)s\">edit profile page</a>."
 msgstr ""
 
 #: src/olympia/users/templates/users/vcard.html:2
@@ -12462,15 +12295,15 @@ msgstr ""
 msgid "Version History with Changelogs"
 msgstr ""
 
-#: src/olympia/versions/models.py:314
+#: src/olympia/versions/models.py:313
 msgid "Add-on uses binary components."
 msgstr ""
 
-#: src/olympia/versions/models.py:317
+#: src/olympia/versions/models.py:316
 msgid "Add-on has opted into strict compatibility checking."
 msgstr ""
 
-#: src/olympia/versions/models.py:715
+#: src/olympia/versions/models.py:711
 msgid "{app} {min} and later"
 msgstr ""
 
@@ -12545,4 +12378,8 @@ msgstr ""
 
 #: src/olympia/zadmin/forms.py:105
 msgid "Log emails instead of sending"
+msgstr ""
+
+#: src/olympia/zadmin/forms.py:215
+msgid "Deleted versions can`t be changed."
 msgstr ""

--- a/locale/bn_IN/LC_MESSAGES/djangojs.po
+++ b/locale/bn_IN/LC_MESSAGES/djangojs.po
@@ -3,1213 +3,1234 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2016-02-24 21:23+0000\n"
+"POT-Creation-Date: 2016-04-18 15:47+0000\n"
 "PO-Revision-Date: 2016-03-02 15:58+0000\n"
 "Last-Translator: Abhyudaya Chatterjee <chatterjeeabhyudaya@gmail.com>\n"
 "Language-Team: Bengali\n"
+"Language: \n"
 "MIME-Version: 1.0\n"
-"Content-Type: text/plain; charset=utf-8\n"
+"Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Generated-By: Babel 2.2.0\n"
 
-#: static/js/common/ratingwidget.js:31
+#: static/js/common-all.js:1426 static/js/impala-all.js:1511 static/js/zamboni/discovery-all.js:12598 static/js/zamboni/init.js:28 static/js/zamboni/mobile-all.js:14945
+msgid "This feature is temporarily disabled while we perform website maintenance. Please check back a little later."
+msgstr "আমরা ওয়েবসাইট রক্ষণাবেক্ষণের জন্য যখন এই বৈশিষ্ট্যটি অস্থায়ীভাবে নিষ্ক্রিয় করা হয়. একটু পরে আবার চেক করুন"
+
+#. L10n: {0} is an app name like Firefox.
+#: static/js/common-all.js:1837 static/js/impala-all.js:1922 static/js/zamboni/buttons.js:73 static/js/zamboni/discovery-all.js:13108
+msgid "Accept and Install"
+msgstr ""
+
+#: static/js/common-all.js:1837 static/js/impala-all.js:1922 static/js/zamboni/buttons.js:73 static/js/zamboni/discovery-all.js:13108
+msgid "Add to {0}"
+msgstr ""
+
+#: static/js/common-all.js:1842 static/js/impala-all.js:1927 static/js/zamboni/buttons.js:78 static/js/zamboni/discovery-all.js:13113
+msgid "Download Now"
+msgstr ""
+
+#: static/js/common-all.js:1883 static/js/impala-all.js:1968 static/js/zamboni/buttons.js:119 static/js/zamboni/discovery-all.js:13154
+msgid "Add-on has not been updated to support default-to-compatible."
+msgstr ""
+
+#: static/js/common-all.js:1888 static/js/impala-all.js:1973 static/js/zamboni/buttons.js:124 static/js/zamboni/discovery-all.js:13159
+msgid "You need to be using Firefox 10.0 or higher."
+msgstr ""
+
+#: static/js/common-all.js:1900 static/js/impala-all.js:1985 static/js/zamboni/buttons.js:136 static/js/zamboni/discovery-all.js:13171
+msgid "Mozilla has marked this version as incompatible with your Firefox version."
+msgstr ""
+
+#. L10n: {0} is an platform like Windows or Linux.
+#: static/js/common-all.js:1981 static/js/impala-all.js:2066 static/js/zamboni/buttons.js:217 static/js/zamboni/discovery-all.js:13252
+msgid "Install for {0} anyway"
+msgstr ""
+
+#: static/js/common-all.js:1981 static/js/impala-all.js:2066 static/js/zamboni/buttons.js:217 static/js/zamboni/discovery-all.js:13252
+msgid "Download for {0} anyway"
+msgstr ""
+
+#: static/js/common-all.js:2038 static/js/impala-all.js:2123 static/js/zamboni/buttons.js:274 static/js/zamboni/discovery-all.js:13309
+msgid "Not available for your platform"
+msgstr ""
+
+#. L10n: {0} is an app name, {1} is the app version.
+#: static/js/common-all.js:2049 static/js/common-all.js:2086 static/js/impala-all.js:2134 static/js/impala-all.js:2171 static/js/zamboni/buttons.js:286 static/js/zamboni/buttons.js:324
+#: static/js/zamboni/discovery-all.js:13320 static/js/zamboni/discovery-all.js:13357
+msgid "Not available for {0} {1}"
+msgstr ""
+
+#: static/js/common-all.js:2112 static/js/impala-all.js:2197 static/js/zamboni/buttons.js:351 static/js/zamboni/discovery-all.js:13383
+msgid "Works with {app} {min} - {max}"
+msgstr ""
+
+#: static/js/common-all.js:2114 static/js/impala-all.js:2199 static/js/zamboni/buttons.js:353 static/js/zamboni/discovery-all.js:13385
+msgid "View other versions"
+msgstr ""
+
+#: static/js/common-all.js:2162 static/js/impala-all.js:2247 static/js/zamboni/buttons.js:401 static/js/zamboni/discovery-all.js:13433
+msgid "Only with Firefox — Get Firefox Now!"
+msgstr ""
+
+#: static/js/common-all.js:2278 static/js/impala-all.js:2363 static/js/zamboni/buttons.js:517 static/js/zamboni/discovery-all.js:13549 static/js/zamboni/mobile-all.js:15177
+#: static/js/zamboni/mobile/buttons.js:43
+msgid "Sorry, you need a Mozilla-based browser (such as Firefox) to install a search plugin."
+msgstr ""
+
+#: static/js/common-all.js:9088 static/js/impala-all.js:9649 static/js/zamboni/global.js:410
+msgid "Loading..."
+msgstr ""
+
+#. L10n: {0} is the number of characters left.
+#: static/js/common-all.js:9152 static/js/impala-all.js:9713 static/js/zamboni/global.js:474
+msgid "<b>{0}</b> character left."
+msgid_plural "<b>{0}</b> characters left."
+msgstr[0] ""
+msgstr[1] ""
+
+#: static/js/common-all.js:9589 static/js/common-min.js:6 static/js/impala-all.js:10052 static/js/impala-min.js:6 static/js/common/ratingwidget.js:31 static/js/zamboni/mobile-all.js:16123
+#: static/js/zamboni/mobile-min.js:6
 msgid "{0} star"
 msgid_plural "{0} stars"
 msgstr[0] "{0} তারা"
 msgstr[1] "{0} তারাগুলি"
 
-#: static/js/common/upload-addon.js:41 static/js/common/upload-image.js:128
+#: static/js/common-all.js:9676 static/js/common-min.js:6 static/js/impala-all.js:10139 static/js/impala-min.js:6 static/js/zamboni/l10n.js:45
+msgid "Remove this localization"
+msgstr ""
+
+#: static/js/common-all.js:10193 static/js/common-min.js:6 static/js/impala-all.js:10674 static/js/impala-min.js:6 static/js/zamboni/discovery-all.js:13678
+msgid "close"
+msgstr ""
+
+#: static/js/common-all.js:10860 static/js/common-min.js:6 static/js/impala-all.js:11481 static/js/impala-min.js:6 static/js/impala/reviews.js:23 static/js/zamboni/reviews.js:18
+msgid "Flagged for review"
+msgstr ""
+
+#: static/js/common-all.js:10876 static/js/common-min.js:6 static/js/impala-all.js:11498 static/js/impala-min.js:6 static/js/impala/reviews.js:40 static/js/zamboni/reviews.js:34
+msgid "Your input is required"
+msgstr ""
+
+#: static/js/common-all.js:10945 static/js/common-min.js:6 static/js/impala-all.js:11610 static/js/impala-min.js:7 static/js/impala/reviews.js:152 static/js/zamboni/reviews.js:103
+msgid "Marked for deletion"
+msgstr ""
+
+#: static/js/common-all.js:11573 static/js/common-min.js:7 static/js/impala-all.js:13809 static/js/impala-min.js:8 static/js/zamboni/collections.js:229
+msgid "Adding to Favorites&hellip;"
+msgstr ""
+
+#: static/js/common-all.js:11576 static/js/common-min.js:7 static/js/impala-all.js:13812 static/js/impala-min.js:8 static/js/zamboni/collections.js:232
+msgid "Removing Favorite&hellip;"
+msgstr ""
+
+#: static/js/common-all.js:11579 static/js/common-min.js:7 static/js/impala-all.js:13815 static/js/impala-min.js:8 static/js/zamboni/collections.js:235
+msgid "Add to Favorites"
+msgstr ""
+
+#: static/js/common-all.js:11582 static/js/common-min.js:7 static/js/impala-all.js:13818 static/js/impala-min.js:8 static/js/zamboni/collections.js:238
+msgid "Remove from Favorites"
+msgstr ""
+
+#: static/js/common-all.js:11647 static/js/common-min.js:7 static/js/impala-all.js:13883 static/js/impala-min.js:8 static/js/zamboni/collections.js:303
+msgid "Pending"
+msgstr ""
+
+#: static/js/common-all.js:11648 static/js/common-min.js:7 static/js/impala-all.js:13884 static/js/impala-min.js:8 static/js/zamboni/collections.js:304
+msgid "Add a comment"
+msgstr ""
+
+#: static/js/common-all.js:11648 static/js/common-min.js:7 static/js/impala-all.js:13884 static/js/impala-min.js:8 static/js/zamboni/collections.js:304
+msgid "Comment"
+msgstr "মন্তব্য"
+
+#: static/js/common-all.js:11649 static/js/common-min.js:7 static/js/impala-all.js:13885 static/js/impala-min.js:8 static/js/zamboni/collections.js:305
+msgid "Remove this add-on from the collection"
+msgstr ""
+
+#: static/js/common-all.js:11649 static/js/common-all.js:11678 static/js/common-min.js:7 static/js/impala-all.js:13885 static/js/impala-all.js:13914 static/js/impala-min.js:8
+#: static/js/zamboni/collections.js:305 static/js/zamboni/collections.js:334
+msgid "Remove"
+msgstr ""
+
+#: static/js/common-all.js:11678 static/js/common-min.js:7 static/js/impala-all.js:13914 static/js/impala-min.js:8 static/js/zamboni/collections.js:334
+msgid "Remove this user as a contributor"
+msgstr ""
+
+#: static/js/common-all.js:11690 static/js/common-min.js:7 static/js/impala-all.js:13926 static/js/impala-min.js:8 static/js/zamboni/collections.js:346
+msgid "An email address is required."
+msgstr ""
+
+#: static/js/common-all.js:11708 static/js/common-min.js:7 static/js/impala-all.js:13944 static/js/impala-min.js:8 static/js/zamboni/collections.js:364
+msgid "You cannot add yourself as a contributor."
+msgstr ""
+
+#: static/js/common-all.js:11710 static/js/common-min.js:7 static/js/impala-all.js:13946 static/js/impala-min.js:8 static/js/zamboni/collections.js:366
+msgid "You have already added that user."
+msgstr ""
+
+#: static/js/common-all.js:11917 static/js/common-min.js:7 static/js/impala-all.js:14153 static/js/impala-min.js:8 static/js/zamboni/collections.js:573
+msgid "Add to favorites"
+msgstr ""
+
+#: static/js/common-all.js:11921 static/js/common-min.js:7 static/js/impala-all.js:14157 static/js/impala-min.js:8 static/js/zamboni/collections.js:577
+msgid "Remove from favorites"
+msgstr ""
+
+#: static/js/common-all.js:11939 static/js/common-min.js:7 static/js/impala-all.js:14175 static/js/impala-all.js:14233 static/js/impala-min.js:8 static/js/impala/collections.js:10
+#: static/js/zamboni/collections.js:595
+msgid "Follow this Collection"
+msgstr ""
+
+#: static/js/common-all.js:11948 static/js/common-min.js:7 static/js/impala-all.js:14184 static/js/impala-min.js:8 static/js/zamboni/collections.js:604
+msgid "Stop following"
+msgstr ""
+
+#: static/js/common-all.js:12096 static/js/common-min.js:7 static/js/zamboni/password-strength.js:20
+msgid "Password strength:"
+msgstr ""
+
+#: static/js/common-all.js:12102 static/js/common-min.js:7 static/js/zamboni/password-strength.js:26
+msgid "At least {0} character left."
+msgid_plural "At least {0} characters left."
+msgstr[0] ""
+msgstr[1] ""
+
+#: static/js/common-all.js:12286 static/js/common-min.js:7 static/js/impala-all.js:14632 static/js/impala-min.js:8 static/js/impala/suggestions.js:39
+msgid "Search themes for <b>{0}</b>"
+msgstr ""
+
+#: static/js/common-all.js:12288 static/js/common-min.js:7 static/js/impala-all.js:14634 static/js/impala-min.js:8 static/js/impala/suggestions.js:41
+msgid "Search apps for <b>{0}</b>"
+msgstr ""
+
+#: static/js/common-all.js:12290 static/js/common-min.js:7 static/js/impala-all.js:14636 static/js/impala-min.js:8 static/js/impala/suggestions.js:43
+msgid "Search add-ons for <b>{0}</b>"
+msgstr ""
+
+#: static/js/common-all.js:12521 static/js/common-min.js:7 static/js/impala-all.js:14867 static/js/impala-min.js:8 static/js/impala/site_suggestions.js:46
+msgid "Category"
+msgstr ""
+
+#. L10n: {0} is an app name.
+#: static/js/impala-all.js:11632 static/js/impala-min.js:7 static/js/impala/listing.js:11 static/js/zamboni/themes.js:13
+msgid "This theme is incompatible with your version of {0}"
+msgstr ""
+
+#: static/js/impala-all.js:12146 static/js/impala-all.js:14331 static/js/impala-min.js:7 static/js/impala-min.js:8 static/js/common/upload-image.js:97 static/js/impala/users.js:51
+#: static/js/zamboni/devhub-all.js:894 static/js/zamboni/devhub-min.js:1
+msgid "Images must be either PNG or JPG."
+msgstr ""
+
+#: static/js/impala-all.js:12150 static/js/impala-min.js:7 static/js/common/upload-image.js:101 static/js/zamboni/devhub-all.js:898 static/js/zamboni/devhub-min.js:1
+msgid "Videos must be in WebM."
+msgstr ""
+
+#: static/js/impala-all.js:12177 static/js/impala-min.js:7 static/js/common/upload-addon.js:41 static/js/common/upload-image.js:128 static/js/zamboni/devhub-all.js:272
+#: static/js/zamboni/devhub-all.js:925 static/js/zamboni/devhub-min.js:1
 msgid "There was a problem contacting the server."
 msgstr "সার্ভারের সঙ্গে সংযোগে একটি সমস্যা পাওয়া গেছে।"
 
-#: static/js/common/upload-addon.js:69
+#: static/js/impala-all.js:13298 static/js/impala-min.js:7 static/js/impala/persona_creation.js:60
+msgid "All Rights Reserved"
+msgstr ""
+
+#: static/js/impala-all.js:13302 static/js/impala-min.js:7 static/js/impala/persona_creation.js:64
+msgid "Creative Commons Attribution 3.0"
+msgstr ""
+
+#: static/js/impala-all.js:13307 static/js/impala-min.js:7 static/js/impala/persona_creation.js:69
+msgid "Creative Commons Attribution-NonCommercial 3.0"
+msgstr ""
+
+#: static/js/impala-all.js:13312 static/js/impala-min.js:7 static/js/impala/persona_creation.js:74
+msgid "Creative Commons Attribution-NonCommercial-NoDerivs 3.0"
+msgstr ""
+
+#: static/js/impala-all.js:13317 static/js/impala-min.js:7 static/js/impala/persona_creation.js:79
+msgid "Creative Commons Attribution-NonCommercial-Share Alike 3.0"
+msgstr ""
+
+#: static/js/impala-all.js:13322 static/js/impala-min.js:7 static/js/impala/persona_creation.js:84
+msgid "Creative Commons Attribution-NoDerivs 3.0"
+msgstr ""
+
+#: static/js/impala-all.js:13327 static/js/impala-min.js:7 static/js/impala/persona_creation.js:89
+msgid "Creative Commons Attribution-ShareAlike 3.0"
+msgstr ""
+
+#: static/js/impala-all.js:13530 static/js/impala-min.js:7 static/js/impala/persona_creation.js:292
+msgid "Your Theme's Name"
+msgstr ""
+
+#: static/js/impala-all.js:14242 static/js/impala-min.js:8 static/js/impala/collections.js:19
+msgid "Stop Following"
+msgstr ""
+
+#: static/js/impala-all.js:14243 static/js/impala-min.js:8 static/js/impala/collections.js:20
+msgid "Following"
+msgstr ""
+
+#: static/js/impala-all.js:14313 static/js/impala-min.js:8 static/js/impala/users.js:33
+msgid "use original"
+msgstr ""
+
+#: static/js/impala-all.js:14523 static/js/impala-min.js:8 static/js/impala/search.js:114
+msgid "Updating results&hellip;"
+msgstr ""
+
+#: static/js/common/upload-addon.js:69 static/js/zamboni/devhub-all.js:300 static/js/zamboni/devhub-min.js:1
 msgid "Select a file..."
 msgstr "একটি ফাইল নির্বাচন করুন..."
 
-#: static/js/common/upload-addon.js:70
+#: static/js/common/upload-addon.js:70 static/js/zamboni/devhub-all.js:301 static/js/zamboni/devhub-min.js:1
 msgid "Your add-on should end with .xpi, .jar or .xml"
 msgstr "আপনার add-on গুলি .xpi, .jar অথবা .xml দিয়ে শেষ করুন"
 
 #. L10n: {0} is the percent of the file that has been uploaded.
-#: static/js/common/upload-addon.js:104
+#: static/js/common/upload-addon.js:104 static/js/zamboni/devhub-all.js:335 static/js/zamboni/devhub-min.js:1
 #, python-format
 msgid "{0}% complete"
 msgstr "{0}% পূর্ণ"
 
 #. L10n: "{bytes uploaded} of {total filesize}".
-#: static/js/common/upload-addon.js:107
+#: static/js/common/upload-addon.js:107 static/js/zamboni/devhub-all.js:338 static/js/zamboni/devhub-min.js:1
 msgid "{0} of {1}"
 msgstr "{0} এর {1}"
 
-#: static/js/common/upload-addon.js:140
+#: static/js/common/upload-addon.js:140 static/js/zamboni/devhub-all.js:371 static/js/zamboni/devhub-min.js:1
 msgid "Cancel"
 msgstr "বাতিল করুন"
 
-#: static/js/common/upload-addon.js:162
+#: static/js/common/upload-addon.js:162 static/js/zamboni/devhub-all.js:393 static/js/zamboni/devhub-min.js:1
 msgid "Uploading {0}"
 msgstr "আপলোড হচ্ছে {0}"
 
-#: static/js/common/upload-addon.js:189
+#: static/js/common/upload-addon.js:189 static/js/zamboni/devhub-all.js:420 static/js/zamboni/devhub-min.js:1
 msgid "Error with {0}"
 msgstr "{0} এর সঙ্গে ভুল"
 
-#: static/js/common/upload-addon.js:194
+#: static/js/common/upload-addon.js:194 static/js/zamboni/devhub-all.js:425 static/js/zamboni/devhub-min.js:1
 msgid "Your add-on failed validation with {0} error."
 msgid_plural "Your add-on failed validation with {0} errors."
 msgstr[0] "আপনার add-on টি অসফল হয়েছে {0} সমস্যার সঙ্গে।"
 msgstr[1] "আপনার add-on টি অসফল হয়েছে {0} সমস্যার সঙ্গে।"
 
-#: static/js/common/upload-addon.js:208
+#: static/js/common/upload-addon.js:208 static/js/zamboni/devhub-all.js:439 static/js/zamboni/devhub-min.js:1
 msgid "&hellip;and {0} more"
 msgid_plural "&hellip;and {0} more"
 msgstr[0] "&hellip;এবং অরও {0}"
 msgstr[1] "&hellip;এবং আরও {0}"
 
-#: static/js/common/upload-addon.js:222 static/js/common/upload-addon.js:512
+#: static/js/common/upload-addon.js:222 static/js/common/upload-addon.js:497 static/js/zamboni/devhub-all.js:453 static/js/zamboni/devhub-all.js:743 static/js/zamboni/devhub-min.js:1
 msgid "See full validation report"
 msgstr "ভালিডেশনের সম্পূর্ণ প্রতিবেদনটি পরুন"
 
-#: static/js/common/upload-addon.js:234
+#: static/js/common/upload-addon.js:234 static/js/zamboni/devhub-all.js:465 static/js/zamboni/devhub-min.js:1
 msgid "Validating {0}"
 msgstr "ভ্যালিডেট করা হচ্ছে {0}"
 
 #. L10n: first argument is an HTTP status code
-#: static/js/common/upload-addon.js:273
+#: static/js/common/upload-addon.js:273 static/js/zamboni/devhub-all.js:504 static/js/zamboni/devhub-min.js:1
 msgid "Received an empty response from the server; status: {0}"
 msgstr ""
 
-#: static/js/common/upload-addon.js:373
+#: static/js/common/upload-addon.js:370 static/js/zamboni/devhub-all.js:604 static/js/zamboni/devhub-min.js:1
 msgid "Unexpected server error while validating."
 msgstr ""
 
-#: static/js/common/upload-addon.js:412
+#: static/js/common/upload-addon.js:409 static/js/zamboni/devhub-all.js:643 static/js/zamboni/devhub-min.js:1
 msgid "Finished validating {0}"
 msgstr ""
 
-#: static/js/common/upload-addon.js:418
+#: static/js/common/upload-addon.js:415 static/js/zamboni/devhub-all.js:649 static/js/zamboni/devhub-min.js:1
 msgid "Your add-on validation timed out, it will be manually reviewed."
 msgstr ""
 
-#: static/js/common/upload-addon.js:421
+#: static/js/common/upload-addon.js:418 static/js/zamboni/devhub-all.js:652 static/js/zamboni/devhub-min.js:1
 msgid "Your add-on was validated with no errors and {0} warning."
 msgid_plural "Your add-on was validated with no errors and {0} warnings."
 msgstr[0] ""
 msgstr[1] ""
 
-#: static/js/common/upload-addon.js:426
+#: static/js/common/upload-addon.js:423 static/js/zamboni/devhub-all.js:657 static/js/zamboni/devhub-min.js:1
 msgid "Your add-on was validated with no errors and {0} message."
 msgid_plural "Your add-on was validated with no errors and {0} messages."
 msgstr[0] ""
 msgstr[1] ""
 
-#: static/js/common/upload-addon.js:431
+#: static/js/common/upload-addon.js:428 static/js/zamboni/devhub-all.js:662 static/js/zamboni/devhub-min.js:1
 msgid "Your add-on was validated with no errors or warnings."
 msgstr ""
 
-#: static/js/common/upload-addon.js:446
+#: static/js/common/upload-addon.js:443 static/js/zamboni/devhub-all.js:677 static/js/zamboni/devhub-min.js:1
 msgid "Your submission will be automatically signed."
 msgstr ""
 
-#: static/js/common/upload-addon.js:465
+#: static/js/common/upload-addon.js:450 static/js/zamboni/devhub-all.js:696 static/js/zamboni/devhub-min.js:1
 msgid "Include detailed version notes (this can be done in the next step)."
 msgstr ""
 
-#: static/js/common/upload-addon.js:466
+#: static/js/common/upload-addon.js:451 static/js/zamboni/devhub-all.js:697 static/js/zamboni/devhub-min.js:1
 msgid "If your add-on requires an account to a website in order to be fully tested, include a test username and password in the Notes to Reviewer (this can be done in the next step)."
 msgstr ""
 
-#: static/js/common/upload-addon.js:467
+#: static/js/common/upload-addon.js:452 static/js/zamboni/devhub-all.js:698 static/js/zamboni/devhub-min.js:1
 msgid "If your add-on is intended for a limited audience you should choose Preliminary Review instead of Full Review."
 msgstr ""
 
-#: static/js/common/upload-addon.js:480
+#: static/js/common/upload-addon.js:465 static/js/zamboni/devhub-all.js:711 static/js/zamboni/devhub-min.js:1
 msgid "Add-on submission checklist"
 msgstr ""
 
-#: static/js/common/upload-addon.js:481
+#: static/js/common/upload-addon.js:466 static/js/zamboni/devhub-all.js:712 static/js/zamboni/devhub-min.js:1
 msgid "Please verify the following points before finalizing your submission. This will minimize delays or misunderstanding during the review process:"
 msgstr ""
 
-#: static/js/common/upload-addon.js:483
+#: static/js/common/upload-addon.js:468 static/js/zamboni/devhub-all.js:714 static/js/zamboni/devhub-min.js:1
 msgid ""
 "Compiled binaries, as well as minified or obfuscated scripts (excluding known libraries) need to have their sources submitted separately for review. Make sure that you use the source code upload "
 "field to avoid having your submission rejected."
 msgstr ""
 
-#: static/js/common/upload-addon.js:501
+#: static/js/common/upload-addon.js:486 static/js/zamboni/devhub-all.js:732 static/js/zamboni/devhub-min.js:1
 msgid "The validation process found these issues that can lead to rejections:"
 msgstr ""
 
-#: static/js/common/upload-addon.js:518
+#: static/js/common/upload-addon.js:503 static/js/zamboni/devhub-all.js:749 static/js/zamboni/devhub-min.js:1
 msgid "If you are unfamiliar with the add-ons review process, you can read about it here."
 msgstr ""
 
-#: static/js/common/upload-addon.js:555
+#: static/js/common/upload-addon.js:540 static/js/zamboni/devhub-all.js:786 static/js/zamboni/devhub-min.js:1
 msgid "Sorry, no supported platform has been found."
 msgstr ""
 
-#: static/js/common/upload-base.js:57
+#: static/js/common/upload-base.js:57 static/js/zamboni/devhub-all.js:187 static/js/zamboni/devhub-min.js:1
 msgid "The filetype you uploaded isn't recognized."
 msgstr ""
 
-#: static/js/common/upload-base.js:79
+#: static/js/common/upload-base.js:79 static/js/zamboni/devhub-all.js:209 static/js/zamboni/devhub-min.js:1
 msgid "You cancelled the upload."
 msgstr ""
 
-#: static/js/common/upload-image.js:97 static/js/impala/users.js:51
-msgid "Images must be either PNG or JPG."
-msgstr ""
-
-#: static/js/common/upload-image.js:101
-msgid "Videos must be in WebM."
-msgstr ""
-
-#: static/js/impala/collections.js:10 static/js/zamboni/collections.js:595
-msgid "Follow this Collection"
-msgstr ""
-
-#: static/js/impala/collections.js:19
-msgid "Stop Following"
-msgstr ""
-
-#: static/js/impala/collections.js:20
-msgid "Following"
-msgstr ""
-
-#. L10n: {0} is an app name.
-#: static/js/impala/listing.js:11 static/js/zamboni/themes.js:13
-msgid "This theme is incompatible with your version of {0}"
-msgstr ""
-
-#: static/js/impala/persona_creation.js:60
-msgid "All Rights Reserved"
-msgstr ""
-
-#: static/js/impala/persona_creation.js:64
-msgid "Creative Commons Attribution 3.0"
-msgstr ""
-
-#: static/js/impala/persona_creation.js:69
-msgid "Creative Commons Attribution-NonCommercial 3.0"
-msgstr ""
-
-#: static/js/impala/persona_creation.js:74
-msgid "Creative Commons Attribution-NonCommercial-NoDerivs 3.0"
-msgstr ""
-
-#: static/js/impala/persona_creation.js:79
-msgid "Creative Commons Attribution-NonCommercial-Share Alike 3.0"
-msgstr ""
-
-#: static/js/impala/persona_creation.js:84
-msgid "Creative Commons Attribution-NoDerivs 3.0"
-msgstr ""
-
-#: static/js/impala/persona_creation.js:89
-msgid "Creative Commons Attribution-ShareAlike 3.0"
-msgstr ""
-
-#: static/js/impala/persona_creation.js:292
-msgid "Your Theme's Name"
-msgstr ""
-
-#: static/js/impala/reviews.js:23 static/js/zamboni/reviews.js:18
-msgid "Flagged for review"
-msgstr ""
-
-#: static/js/impala/reviews.js:40 static/js/zamboni/reviews.js:34
-msgid "Your input is required"
-msgstr ""
-
-#: static/js/impala/reviews.js:152 static/js/zamboni/reviews.js:103
-msgid "Marked for deletion"
-msgstr ""
-
-#: static/js/impala/search.js:114
-msgid "Updating results&hellip;"
-msgstr ""
-
-#: static/js/impala/site_suggestions.js:46
-msgid "Category"
-msgstr ""
-
-#: static/js/impala/suggestions.js:39
-msgid "Search themes for <b>{0}</b>"
-msgstr ""
-
-#: static/js/impala/suggestions.js:41
-msgid "Search apps for <b>{0}</b>"
-msgstr ""
-
-#: static/js/impala/suggestions.js:43
-msgid "Search add-ons for <b>{0}</b>"
-msgstr ""
-
-#: static/js/impala/users.js:33
-msgid "use original"
-msgstr ""
-
-#: static/js/impala/stats/chart.js:267
+#: static/js/impala/stats/chart.js:267 static/js/zamboni/stats-all.js:16898 static/js/zamboni/stats-min.js:5
 msgid "Week of {0}"
 msgstr ""
 
-#: static/js/impala/stats/chart.js:269
+#: static/js/impala/stats/chart.js:269 static/js/zamboni/stats-all.js:16900 static/js/zamboni/stats-min.js:5
 msgid " downloads"
 msgstr ""
 
-#: static/js/impala/stats/chart.js:270
+#: static/js/impala/stats/chart.js:270 static/js/zamboni/stats-all.js:16901 static/js/zamboni/stats-min.js:5
 msgid "{0} users"
 msgstr ""
 
-#: static/js/impala/stats/chart.js:271
+#: static/js/impala/stats/chart.js:271 static/js/zamboni/stats-all.js:16902 static/js/zamboni/stats-min.js:5
 msgid "{0} add-ons"
 msgstr ""
 
-#: static/js/impala/stats/chart.js:272
+#: static/js/impala/stats/chart.js:272 static/js/zamboni/stats-all.js:16903 static/js/zamboni/stats-min.js:5
 msgid "{0} collections"
 msgstr ""
 
-#: static/js/impala/stats/chart.js:273
+#: static/js/impala/stats/chart.js:273 static/js/zamboni/stats-all.js:16904 static/js/zamboni/stats-min.js:5
 msgid "{0} reviews"
 msgstr ""
 
-#: static/js/impala/stats/chart.js:275
+#: static/js/impala/stats/chart.js:275 static/js/zamboni/stats-all.js:16906 static/js/zamboni/stats-min.js:5
 msgid "{0} sales"
 msgstr ""
 
-#: static/js/impala/stats/chart.js:276
+#: static/js/impala/stats/chart.js:276 static/js/zamboni/stats-all.js:16907 static/js/zamboni/stats-min.js:5
 msgid "{0} refunds"
 msgstr ""
 
-#: static/js/impala/stats/chart.js:277
+#: static/js/impala/stats/chart.js:277 static/js/zamboni/stats-all.js:16908 static/js/zamboni/stats-min.js:5
 msgid "{0} installs"
 msgstr ""
 
-#: static/js/impala/stats/chart.js:369 static/js/impala/stats/csv_keys.js:3 static/js/impala/stats/csv_keys.js:109
+#: static/js/impala/stats/chart.js:369 static/js/impala/stats/csv_keys.js:3 static/js/impala/stats/csv_keys.js:109 static/js/zamboni/stats-all.js:15284 static/js/zamboni/stats-all.js:15390
+#: static/js/zamboni/stats-all.js:17000 static/js/zamboni/stats-min.js:4 static/js/zamboni/stats-min.js:5
 msgid "Downloads"
 msgstr ""
 
-#: static/js/impala/stats/chart.js:379 static/js/impala/stats/csv_keys.js:6 static/js/impala/stats/csv_keys.js:110
+#: static/js/impala/stats/chart.js:379 static/js/impala/stats/csv_keys.js:6 static/js/impala/stats/csv_keys.js:110 static/js/zamboni/stats-all.js:15287 static/js/zamboni/stats-all.js:15391
+#: static/js/zamboni/stats-all.js:17010 static/js/zamboni/stats-min.js:4 static/js/zamboni/stats-min.js:5
 msgid "Daily Users"
 msgstr ""
 
-#: static/js/impala/stats/chart.js:410
+#: static/js/impala/stats/chart.js:410 static/js/zamboni/stats-all.js:17041 static/js/zamboni/stats-min.js:5
 msgid "Amount, in USD"
 msgstr ""
 
-#: static/js/impala/stats/chart.js:421 static/js/impala/stats/csv_keys.js:104
+#: static/js/impala/stats/chart.js:421 static/js/impala/stats/csv_keys.js:104 static/js/zamboni/stats-all.js:15385 static/js/zamboni/stats-all.js:17052 static/js/zamboni/stats-min.js:5
 msgid "Number of Contributions"
 msgstr ""
 
-#: static/js/impala/stats/chart.js:447
+#: static/js/impala/stats/chart.js:447 static/js/zamboni/stats-all.js:17078 static/js/zamboni/stats-min.js:5
 msgid "More Info..."
 msgstr ""
 
 #. L10n: {0} is an ISO-formatted date.
-#: static/js/impala/stats/chart.js:451
+#: static/js/impala/stats/chart.js:451 static/js/zamboni/stats-all.js:17082 static/js/zamboni/stats-min.js:5
 msgid "Details for {0}"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:9
+#: static/js/impala/stats/csv_keys.js:9 static/js/zamboni/stats-all.js:15290 static/js/zamboni/stats-min.js:4
 msgid "Collections Created"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:12
+#: static/js/impala/stats/csv_keys.js:12 static/js/zamboni/stats-all.js:15293 static/js/zamboni/stats-min.js:4
 msgid "Add-ons in Use"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:15
+#: static/js/impala/stats/csv_keys.js:15 static/js/zamboni/stats-all.js:15296 static/js/zamboni/stats-min.js:4
 msgid "Add-ons Created"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:18
+#: static/js/impala/stats/csv_keys.js:18 static/js/zamboni/stats-all.js:15299 static/js/zamboni/stats-min.js:4
 msgid "Add-ons Downloaded"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:21
+#: static/js/impala/stats/csv_keys.js:21 static/js/zamboni/stats-all.js:15302 static/js/zamboni/stats-min.js:4
 msgid "Add-ons Updated"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:24
+#: static/js/impala/stats/csv_keys.js:24 static/js/zamboni/stats-all.js:15305 static/js/zamboni/stats-min.js:4
 msgid "Reviews Written"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:27
+#: static/js/impala/stats/csv_keys.js:27 static/js/zamboni/stats-all.js:15308 static/js/zamboni/stats-min.js:4
 msgid "User Signups"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:30
+#: static/js/impala/stats/csv_keys.js:30 static/js/zamboni/stats-all.js:15311 static/js/zamboni/stats-min.js:4
 msgid "Subscribers"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:33
+#: static/js/impala/stats/csv_keys.js:33 static/js/zamboni/stats-all.js:15314 static/js/zamboni/stats-min.js:4
 msgid "Ratings"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:36 static/js/impala/stats/csv_keys.js:114
+#: static/js/impala/stats/csv_keys.js:36 static/js/impala/stats/csv_keys.js:114 static/js/zamboni/stats-all.js:15317 static/js/zamboni/stats-all.js:15395 static/js/zamboni/stats-min.js:4
+#: static/js/zamboni/stats-min.js:5
 msgid "Sales"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:39 static/js/impala/stats/csv_keys.js:113
+#: static/js/impala/stats/csv_keys.js:39 static/js/impala/stats/csv_keys.js:113 static/js/zamboni/stats-all.js:15320 static/js/zamboni/stats-all.js:15394 static/js/zamboni/stats-min.js:4
+#: static/js/zamboni/stats-min.js:5
 msgid "Installs"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:42
+#: static/js/impala/stats/csv_keys.js:42 static/js/zamboni/stats-all.js:15323 static/js/zamboni/stats-min.js:4
 msgid "Unknown"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:43
+#: static/js/impala/stats/csv_keys.js:43 static/js/zamboni/stats-all.js:15324 static/js/zamboni/stats-min.js:4
 msgid "Add-ons Manager"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:44
+#: static/js/impala/stats/csv_keys.js:44 static/js/zamboni/stats-all.js:15325 static/js/zamboni/stats-min.js:4
 msgid "Add-ons Manager Promo"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:45
+#: static/js/impala/stats/csv_keys.js:45 static/js/zamboni/stats-all.js:15326 static/js/zamboni/stats-min.js:4
 msgid "Add-ons Manager Featured"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:46
+#: static/js/impala/stats/csv_keys.js:46 static/js/zamboni/stats-all.js:15327 static/js/zamboni/stats-min.js:4
 msgid "Add-ons Manager Learn More"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:47
+#: static/js/impala/stats/csv_keys.js:47 static/js/zamboni/stats-all.js:15328 static/js/zamboni/stats-min.js:4
 msgid "Search Suggestions"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:48
+#: static/js/impala/stats/csv_keys.js:48 static/js/zamboni/stats-all.js:15329 static/js/zamboni/stats-min.js:4
 msgid "Search Results"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:49 static/js/impala/stats/csv_keys.js:50 static/js/impala/stats/csv_keys.js:51
+#: static/js/impala/stats/csv_keys.js:49 static/js/impala/stats/csv_keys.js:50 static/js/impala/stats/csv_keys.js:51 static/js/zamboni/stats-all.js:15330 static/js/zamboni/stats-all.js:15331
+#: static/js/zamboni/stats-all.js:15332 static/js/zamboni/stats-min.js:4
 msgid "Homepage Promo"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:52 static/js/impala/stats/csv_keys.js:53
+#: static/js/impala/stats/csv_keys.js:52 static/js/impala/stats/csv_keys.js:53 static/js/zamboni/stats-all.js:15333 static/js/zamboni/stats-all.js:15334 static/js/zamboni/stats-min.js:4
 msgid "Homepage Featured"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:54 static/js/impala/stats/csv_keys.js:55
+#: static/js/impala/stats/csv_keys.js:54 static/js/impala/stats/csv_keys.js:55 static/js/zamboni/stats-all.js:15335 static/js/zamboni/stats-all.js:15336 static/js/zamboni/stats-min.js:4
 msgid "Homepage Up and Coming"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:56
+#: static/js/impala/stats/csv_keys.js:56 static/js/zamboni/stats-all.js:15337 static/js/zamboni/stats-min.js:4
 msgid "Homepage Most Popular"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:57 static/js/impala/stats/csv_keys.js:59
+#: static/js/impala/stats/csv_keys.js:57 static/js/impala/stats/csv_keys.js:59 static/js/zamboni/stats-all.js:15338 static/js/zamboni/stats-all.js:15340 static/js/zamboni/stats-min.js:4
 msgid "Detail Page"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:58 static/js/impala/stats/csv_keys.js:60
+#: static/js/impala/stats/csv_keys.js:58 static/js/impala/stats/csv_keys.js:60 static/js/zamboni/stats-all.js:15339 static/js/zamboni/stats-all.js:15341 static/js/zamboni/stats-min.js:4
 msgid "Detail Page (bottom)"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:61
+#: static/js/impala/stats/csv_keys.js:61 static/js/zamboni/stats-all.js:15342 static/js/zamboni/stats-min.js:4
 msgid "Detail Page (Development Channel)"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:62 static/js/impala/stats/csv_keys.js:63 static/js/impala/stats/csv_keys.js:64
+#: static/js/impala/stats/csv_keys.js:62 static/js/impala/stats/csv_keys.js:63 static/js/impala/stats/csv_keys.js:64 static/js/zamboni/stats-all.js:15343 static/js/zamboni/stats-all.js:15344
+#: static/js/zamboni/stats-all.js:15345 static/js/zamboni/stats-min.js:4
 msgid "Often Used With"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:65 static/js/impala/stats/csv_keys.js:66
+#: static/js/impala/stats/csv_keys.js:65 static/js/impala/stats/csv_keys.js:66 static/js/zamboni/stats-all.js:15346 static/js/zamboni/stats-all.js:15347 static/js/zamboni/stats-min.js:4
 msgid "Others By Author"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:67 static/js/impala/stats/csv_keys.js:68
+#: static/js/impala/stats/csv_keys.js:67 static/js/impala/stats/csv_keys.js:68 static/js/zamboni/stats-all.js:15348 static/js/zamboni/stats-all.js:15349 static/js/zamboni/stats-min.js:4
 msgid "Dependencies"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:69 static/js/impala/stats/csv_keys.js:70
+#: static/js/impala/stats/csv_keys.js:69 static/js/impala/stats/csv_keys.js:70 static/js/zamboni/stats-all.js:15350 static/js/zamboni/stats-all.js:15351 static/js/zamboni/stats-min.js:4
 msgid "Upsell"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:71
+#: static/js/impala/stats/csv_keys.js:71 static/js/zamboni/stats-all.js:15352 static/js/zamboni/stats-min.js:4
 msgid "Meet the Developer"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:72
+#: static/js/impala/stats/csv_keys.js:72 static/js/zamboni/stats-all.js:15353 static/js/zamboni/stats-min.js:4
 msgid "User Profile"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:73
+#: static/js/impala/stats/csv_keys.js:73 static/js/zamboni/stats-all.js:15354 static/js/zamboni/stats-min.js:4
 msgid "Version History"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:75
+#: static/js/impala/stats/csv_keys.js:75 static/js/zamboni/stats-all.js:15356 static/js/zamboni/stats-min.js:4
 msgid "Sharing"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:76
+#: static/js/impala/stats/csv_keys.js:76 static/js/zamboni/stats-all.js:15357 static/js/zamboni/stats-min.js:4
 msgid "Category Pages"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:77
+#: static/js/impala/stats/csv_keys.js:77 static/js/zamboni/stats-all.js:15358 static/js/zamboni/stats-min.js:4
 msgid "Collections"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:78 static/js/impala/stats/csv_keys.js:79
+#: static/js/impala/stats/csv_keys.js:78 static/js/impala/stats/csv_keys.js:79 static/js/zamboni/stats-all.js:15359 static/js/zamboni/stats-all.js:15360 static/js/zamboni/stats-min.js:4
 msgid "Category Landing Featured Carousel"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:80 static/js/impala/stats/csv_keys.js:81
+#: static/js/impala/stats/csv_keys.js:80 static/js/impala/stats/csv_keys.js:81 static/js/zamboni/stats-all.js:15361 static/js/zamboni/stats-all.js:15362 static/js/zamboni/stats-min.js:4
 msgid "Category Landing Top Rated"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:82 static/js/impala/stats/csv_keys.js:83
+#: static/js/impala/stats/csv_keys.js:82 static/js/impala/stats/csv_keys.js:83 static/js/zamboni/stats-all.js:15363 static/js/zamboni/stats-all.js:15364 static/js/zamboni/stats-min.js:5
 msgid "Category Landing Most Popular"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:84 static/js/impala/stats/csv_keys.js:85
+#: static/js/impala/stats/csv_keys.js:84 static/js/impala/stats/csv_keys.js:85 static/js/zamboni/stats-all.js:15365 static/js/zamboni/stats-all.js:15366 static/js/zamboni/stats-min.js:5
 msgid "Category Landing Recently Added"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:86 static/js/impala/stats/csv_keys.js:87
+#: static/js/impala/stats/csv_keys.js:86 static/js/impala/stats/csv_keys.js:87 static/js/zamboni/stats-all.js:15367 static/js/zamboni/stats-all.js:15368 static/js/zamboni/stats-min.js:5
 msgid "Browse Listing Featured Sort"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:88 static/js/impala/stats/csv_keys.js:89
+#: static/js/impala/stats/csv_keys.js:88 static/js/impala/stats/csv_keys.js:89 static/js/zamboni/stats-all.js:15369 static/js/zamboni/stats-all.js:15370 static/js/zamboni/stats-min.js:5
 msgid "Browse Listing Users Sort"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:90 static/js/impala/stats/csv_keys.js:91
+#: static/js/impala/stats/csv_keys.js:90 static/js/impala/stats/csv_keys.js:91 static/js/zamboni/stats-all.js:15371 static/js/zamboni/stats-all.js:15372 static/js/zamboni/stats-min.js:5
 msgid "Browse Listing Rating Sort"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:92 static/js/impala/stats/csv_keys.js:93
+#: static/js/impala/stats/csv_keys.js:92 static/js/impala/stats/csv_keys.js:93 static/js/zamboni/stats-all.js:15373 static/js/zamboni/stats-all.js:15374 static/js/zamboni/stats-min.js:5
 msgid "Browse Listing Created Sort"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:94 static/js/impala/stats/csv_keys.js:95
+#: static/js/impala/stats/csv_keys.js:94 static/js/impala/stats/csv_keys.js:95 static/js/zamboni/stats-all.js:15375 static/js/zamboni/stats-all.js:15376 static/js/zamboni/stats-min.js:5
 msgid "Browse Listing Name Sort"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:96 static/js/impala/stats/csv_keys.js:97
+#: static/js/impala/stats/csv_keys.js:96 static/js/impala/stats/csv_keys.js:97 static/js/zamboni/stats-all.js:15377 static/js/zamboni/stats-all.js:15378 static/js/zamboni/stats-min.js:5
 msgid "Browse Listing Popular Sort"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:98 static/js/impala/stats/csv_keys.js:99
+#: static/js/impala/stats/csv_keys.js:98 static/js/impala/stats/csv_keys.js:99 static/js/zamboni/stats-all.js:15379 static/js/zamboni/stats-all.js:15380 static/js/zamboni/stats-min.js:5
 msgid "Browse Listing Updated Sort"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:100 static/js/impala/stats/csv_keys.js:101
+#: static/js/impala/stats/csv_keys.js:100 static/js/impala/stats/csv_keys.js:101 static/js/zamboni/stats-all.js:15381 static/js/zamboni/stats-all.js:15382 static/js/zamboni/stats-min.js:5
 msgid "Browse Listing Up and Coming Sort"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:105
+#: static/js/impala/stats/csv_keys.js:105 static/js/zamboni/stats-all.js:15386 static/js/zamboni/stats-min.js:5
 msgid "Total Amount Contributed"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:106
+#: static/js/impala/stats/csv_keys.js:106 static/js/zamboni/stats-all.js:15387 static/js/zamboni/stats-min.js:5
 msgid "Average Contribution"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:115
+#: static/js/impala/stats/csv_keys.js:115 static/js/zamboni/stats-all.js:15396 static/js/zamboni/stats-min.js:5
 msgid "Usage"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:118
+#: static/js/impala/stats/csv_keys.js:118 static/js/zamboni/stats-all.js:15399 static/js/zamboni/stats-min.js:5
 msgid "Firefox"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:119
+#: static/js/impala/stats/csv_keys.js:119 static/js/zamboni/stats-all.js:15400 static/js/zamboni/stats-min.js:5
 msgid "Mozilla"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:120
+#: static/js/impala/stats/csv_keys.js:120 static/js/zamboni/stats-all.js:15401 static/js/zamboni/stats-min.js:5
 msgid "Thunderbird"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:121
+#: static/js/impala/stats/csv_keys.js:121 static/js/zamboni/stats-all.js:15402 static/js/zamboni/stats-min.js:5
 msgid "Sunbird"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:122
+#: static/js/impala/stats/csv_keys.js:122 static/js/zamboni/stats-all.js:15403 static/js/zamboni/stats-min.js:5
 msgid "SeaMonkey"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:123
+#: static/js/impala/stats/csv_keys.js:123 static/js/zamboni/stats-all.js:15404 static/js/zamboni/stats-min.js:5
 msgid "Fennec"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:124
+#: static/js/impala/stats/csv_keys.js:124 static/js/zamboni/stats-all.js:15405 static/js/zamboni/stats-min.js:5
 msgid "Android"
 msgstr ""
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:129
+#: static/js/impala/stats/csv_keys.js:129 static/js/zamboni/stats-all.js:15410 static/js/zamboni/stats-min.js:5
 msgid "Downloads and Daily Users, last {0} days"
 msgstr ""
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:131
+#: static/js/impala/stats/csv_keys.js:131 static/js/zamboni/stats-all.js:15412 static/js/zamboni/stats-min.js:5
 msgid "Downloads and Daily Users from {0} to {1}"
 msgstr ""
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:135
+#: static/js/impala/stats/csv_keys.js:135 static/js/zamboni/stats-all.js:15416 static/js/zamboni/stats-min.js:5
 msgid "Installs and Daily Users, last {0} days"
 msgstr ""
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:137
+#: static/js/impala/stats/csv_keys.js:137 static/js/zamboni/stats-all.js:15418 static/js/zamboni/stats-min.js:5
 msgid "Installs and Daily Users from {0} to {1}"
 msgstr ""
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:141
+#: static/js/impala/stats/csv_keys.js:141 static/js/zamboni/stats-all.js:15422 static/js/zamboni/stats-min.js:5
 msgid "Downloads, last {0} days"
 msgstr ""
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:143
+#: static/js/impala/stats/csv_keys.js:143 static/js/zamboni/stats-all.js:15424 static/js/zamboni/stats-min.js:5
 msgid "Downloads from {0} to {1}"
 msgstr ""
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:147
+#: static/js/impala/stats/csv_keys.js:147 static/js/zamboni/stats-all.js:15428 static/js/zamboni/stats-min.js:5
 msgid "Daily Users, last {0} days"
 msgstr ""
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:149
+#: static/js/impala/stats/csv_keys.js:149 static/js/zamboni/stats-all.js:15430 static/js/zamboni/stats-min.js:5
 msgid "Daily Users from {0} to {1}"
 msgstr ""
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:153
+#: static/js/impala/stats/csv_keys.js:153 static/js/zamboni/stats-all.js:15434 static/js/zamboni/stats-min.js:5
 msgid "Applications, last {0} days"
 msgstr ""
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:155
+#: static/js/impala/stats/csv_keys.js:155 static/js/zamboni/stats-all.js:15436 static/js/zamboni/stats-min.js:5
 msgid "Applications from {0} to {1}"
 msgstr ""
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:159
+#: static/js/impala/stats/csv_keys.js:159 static/js/zamboni/stats-all.js:15440 static/js/zamboni/stats-min.js:5
 msgid "Platforms, last {0} days"
 msgstr ""
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:161
+#: static/js/impala/stats/csv_keys.js:161 static/js/zamboni/stats-all.js:15442 static/js/zamboni/stats-min.js:5
 msgid "Platforms from {0} to {1}"
 msgstr ""
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:165
+#: static/js/impala/stats/csv_keys.js:165 static/js/zamboni/stats-all.js:15446 static/js/zamboni/stats-min.js:5
 msgid "Languages, last {0} days"
 msgstr ""
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:167
+#: static/js/impala/stats/csv_keys.js:167 static/js/zamboni/stats-all.js:15448 static/js/zamboni/stats-min.js:5
 msgid "Languages from {0} to {1}"
 msgstr ""
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:171
+#: static/js/impala/stats/csv_keys.js:171 static/js/zamboni/stats-all.js:15452 static/js/zamboni/stats-min.js:5
 msgid "Add-on Versions, last {0} days"
 msgstr ""
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:173
+#: static/js/impala/stats/csv_keys.js:173 static/js/zamboni/stats-all.js:15454 static/js/zamboni/stats-min.js:5
 msgid "Add-on Versions from {0} to {1}"
 msgstr ""
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:177
+#: static/js/impala/stats/csv_keys.js:177 static/js/zamboni/stats-all.js:15458 static/js/zamboni/stats-min.js:5
 msgid "Add-on Status, last {0} days"
 msgstr ""
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:179
+#: static/js/impala/stats/csv_keys.js:179 static/js/zamboni/stats-all.js:15460 static/js/zamboni/stats-min.js:5
 msgid "Add-on Status from {0} to {1}"
 msgstr ""
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:183
+#: static/js/impala/stats/csv_keys.js:183 static/js/zamboni/stats-all.js:15464 static/js/zamboni/stats-min.js:5
 msgid "Download Sources, last {0} days"
 msgstr ""
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:185
+#: static/js/impala/stats/csv_keys.js:185 static/js/zamboni/stats-all.js:15466 static/js/zamboni/stats-min.js:5
 msgid "Download Sources from {0} to {1}"
 msgstr ""
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:189
+#: static/js/impala/stats/csv_keys.js:189 static/js/zamboni/stats-all.js:15470 static/js/zamboni/stats-min.js:5
 msgid "Contributions, last {0} days"
 msgstr ""
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:191
+#: static/js/impala/stats/csv_keys.js:191 static/js/zamboni/stats-all.js:15472 static/js/zamboni/stats-min.js:5
 msgid "Contributions from {0} to {1}"
 msgstr ""
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:195
+#: static/js/impala/stats/csv_keys.js:195 static/js/zamboni/stats-all.js:15476 static/js/zamboni/stats-min.js:5
 msgid "Site Metrics, last {0} days"
 msgstr ""
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:197
+#: static/js/impala/stats/csv_keys.js:197 static/js/zamboni/stats-all.js:15478 static/js/zamboni/stats-min.js:5
 msgid "Site Metrics from {0} to {1}"
 msgstr ""
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:201
+#: static/js/impala/stats/csv_keys.js:201 static/js/zamboni/stats-all.js:15482 static/js/zamboni/stats-min.js:5
 msgid "Add-ons in Use, last {0} days"
 msgstr ""
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:203
+#: static/js/impala/stats/csv_keys.js:203 static/js/zamboni/stats-all.js:15484 static/js/zamboni/stats-min.js:5
 msgid "Add-ons in Use from {0} to {1}"
 msgstr ""
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:207
+#: static/js/impala/stats/csv_keys.js:207 static/js/zamboni/stats-all.js:15488 static/js/zamboni/stats-min.js:5
 msgid "Add-ons Downloaded, last {0} days"
 msgstr ""
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:209
+#: static/js/impala/stats/csv_keys.js:209 static/js/zamboni/stats-all.js:15490 static/js/zamboni/stats-min.js:5
 msgid "Add-ons Downloaded from {0} to {1}"
 msgstr ""
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:213
+#: static/js/impala/stats/csv_keys.js:213 static/js/zamboni/stats-all.js:15494 static/js/zamboni/stats-min.js:5
 msgid "Add-ons Created, last {0} days"
 msgstr ""
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:215
+#: static/js/impala/stats/csv_keys.js:215 static/js/zamboni/stats-all.js:15496 static/js/zamboni/stats-min.js:5
 msgid "Add-ons Created from {0} to {1}"
 msgstr ""
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:219
+#: static/js/impala/stats/csv_keys.js:219 static/js/zamboni/stats-all.js:15500 static/js/zamboni/stats-min.js:5
 msgid "Add-ons Updated, last {0} days"
 msgstr ""
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:221
+#: static/js/impala/stats/csv_keys.js:221 static/js/zamboni/stats-all.js:15502 static/js/zamboni/stats-min.js:5
 msgid "Add-ons Updated from {0} to {1}"
 msgstr ""
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:225
+#: static/js/impala/stats/csv_keys.js:225 static/js/zamboni/stats-all.js:15506 static/js/zamboni/stats-min.js:5
 msgid "Reviews Written, last {0} days"
 msgstr ""
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:227
+#: static/js/impala/stats/csv_keys.js:227 static/js/zamboni/stats-all.js:15508 static/js/zamboni/stats-min.js:5
 msgid "Reviews Written from {0} to {1}"
 msgstr ""
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:231
+#: static/js/impala/stats/csv_keys.js:231 static/js/zamboni/stats-all.js:15512 static/js/zamboni/stats-min.js:5
 msgid "User Signups, last {0} days"
 msgstr ""
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:233
+#: static/js/impala/stats/csv_keys.js:233 static/js/zamboni/stats-all.js:15514 static/js/zamboni/stats-min.js:5
 msgid "User Signups from {0} to {1}"
 msgstr ""
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:237
+#: static/js/impala/stats/csv_keys.js:237 static/js/zamboni/stats-all.js:15518 static/js/zamboni/stats-min.js:5
 msgid "Collections Created, last {0} days"
 msgstr ""
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:239
+#: static/js/impala/stats/csv_keys.js:239 static/js/zamboni/stats-all.js:15520 static/js/zamboni/stats-min.js:5
 msgid "Collections Created from {0} to {1}"
 msgstr ""
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:243
+#: static/js/impala/stats/csv_keys.js:243 static/js/zamboni/stats-all.js:15524 static/js/zamboni/stats-min.js:5
 msgid "Subscribers, last {0} days"
 msgstr ""
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:245
+#: static/js/impala/stats/csv_keys.js:245 static/js/zamboni/stats-all.js:15526 static/js/zamboni/stats-min.js:5
 msgid "Subscribers from {0} to {1}"
 msgstr ""
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:249
+#: static/js/impala/stats/csv_keys.js:249 static/js/zamboni/stats-all.js:15530 static/js/zamboni/stats-min.js:5
 msgid "Ratings, last {0} days"
 msgstr ""
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:251
+#: static/js/impala/stats/csv_keys.js:251 static/js/zamboni/stats-all.js:15532 static/js/zamboni/stats-min.js:5
 msgid "Ratings from {0} to {1}"
 msgstr ""
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:255
+#: static/js/impala/stats/csv_keys.js:255 static/js/zamboni/stats-all.js:15536 static/js/zamboni/stats-min.js:5
 msgid "Sales, last {0} days"
 msgstr ""
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:257
+#: static/js/impala/stats/csv_keys.js:257 static/js/zamboni/stats-all.js:15538 static/js/zamboni/stats-min.js:5
 msgid "Sales from {0} to {1}"
 msgstr ""
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:261
+#: static/js/impala/stats/csv_keys.js:261 static/js/zamboni/stats-all.js:15542 static/js/zamboni/stats-min.js:5
 msgid "Installs, last {0} days"
 msgstr ""
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:263
+#: static/js/impala/stats/csv_keys.js:263 static/js/zamboni/stats-all.js:15544 static/js/zamboni/stats-min.js:5
 msgid "Installs from {0} to {1}"
 msgstr ""
 
 #. L10n: {0} and {1} are integers.
-#: static/js/impala/stats/csv_keys.js:269
+#: static/js/impala/stats/csv_keys.js:269 static/js/zamboni/stats-all.js:15550 static/js/zamboni/stats-min.js:5
 msgid "<b>{0}</b> in last {1} days"
 msgstr ""
 
 #. L10n: {0} is an integer and {1} and {2} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:271 static/js/impala/stats/csv_keys.js:277
+#: static/js/impala/stats/csv_keys.js:271 static/js/impala/stats/csv_keys.js:277 static/js/zamboni/stats-all.js:15552 static/js/zamboni/stats-all.js:15558 static/js/zamboni/stats-min.js:5
 msgid "<b>{0}</b> from {1} to {2}"
 msgstr ""
 
 #. L10n: {0} and {1} are integers.
-#: static/js/impala/stats/csv_keys.js:275
+#: static/js/impala/stats/csv_keys.js:275 static/js/zamboni/stats-all.js:15556 static/js/zamboni/stats-min.js:5
 msgid "<b>{0}</b> average in last {1} days"
 msgstr ""
 
-#: static/js/impala/stats/overview.js:19
+#: static/js/impala/stats/overview.js:19 static/js/zamboni/stats-all.js:16469 static/js/zamboni/stats-min.js:5
 msgid "No data available."
 msgstr ""
 
-#: static/js/impala/stats/table.js:74
+#: static/js/impala/stats/table.js:74 static/js/zamboni/stats-all.js:17209 static/js/zamboni/stats-min.js:5
 msgid "Date"
 msgstr ""
 
-#: static/js/impala/stats/topchart.js:96
+#: static/js/impala/stats/topchart.js:96 static/js/zamboni/stats-all.js:16600 static/js/zamboni/stats-min.js:5
 msgid "Other"
 msgstr ""
 
-#: static/js/zamboni/admin_validation.js:24 static/js/zamboni/devhub.js:1229 static/js/zamboni/editors.js:295
+#: static/js/zamboni/admin-all.js:180 static/js/zamboni/admin-min.js:1 static/js/zamboni/admin_validation.js:24 static/js/zamboni/devhub-all.js:2408 static/js/zamboni/devhub-min.js:2
+#: static/js/zamboni/devhub.js:1229 static/js/zamboni/editors-all.js:15576 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:295
 msgid "Select an application first"
 msgstr ""
 
-#: static/js/zamboni/admin_validation.js:51
+#: static/js/zamboni/admin-all.js:207 static/js/zamboni/admin-min.js:1 static/js/zamboni/admin_validation.js:51
 msgid "Set {0} add-on to a max version of {1} and email the author."
 msgid_plural "Set {0} add-ons to a max version of {1} and email the authors."
 msgstr[0] ""
 msgstr[1] ""
 
-#: static/js/zamboni/admin_validation.js:54
+#: static/js/zamboni/admin-all.js:210 static/js/zamboni/admin-min.js:1 static/js/zamboni/admin_validation.js:54
 msgid "Email author of {2} add-on which failed validation."
 msgid_plural "Email authors of {2} add-ons which failed validation."
 msgstr[0] ""
 msgstr[1] ""
 
-#. L10n: {0} is an app name like Firefox.
-#: static/js/zamboni/buttons.js:66
-msgid "Accept and Install"
-msgstr ""
-
-#: static/js/zamboni/buttons.js:66
-msgid "Add to {0}"
-msgstr ""
-
-#: static/js/zamboni/buttons.js:71
-msgid "Download Now"
-msgstr ""
-
-#: static/js/zamboni/buttons.js:112
-msgid "Add-on has not been updated to support default-to-compatible."
-msgstr ""
-
-#: static/js/zamboni/buttons.js:117
-msgid "You need to be using Firefox 10.0 or higher."
-msgstr ""
-
-#: static/js/zamboni/buttons.js:129
-msgid "Mozilla has marked this version as incompatible with your Firefox version."
-msgstr ""
-
-#. L10n: {0} is an platform like Windows or Linux.
-#: static/js/zamboni/buttons.js:210
-msgid "Install for {0} anyway"
-msgstr ""
-
-#: static/js/zamboni/buttons.js:210
-msgid "Download for {0} anyway"
-msgstr ""
-
-#: static/js/zamboni/buttons.js:267
-msgid "Not available for your platform"
-msgstr ""
-
-#. L10n: {0} is an app name, {1} is the app version.
-#: static/js/zamboni/buttons.js:278 static/js/zamboni/buttons.js:315
-msgid "Not available for {0} {1}"
-msgstr ""
-
-#: static/js/zamboni/buttons.js:341
-msgid "Works with {app} {min} - {max}"
-msgstr ""
-
-#: static/js/zamboni/buttons.js:343
-msgid "View other versions"
-msgstr ""
-
-#: static/js/zamboni/buttons.js:391
-msgid "Only with Firefox — Get Firefox Now!"
-msgstr ""
-
-#: static/js/zamboni/buttons.js:507 static/js/zamboni/mobile/buttons.js:43
-msgid "Sorry, you need a Mozilla-based browser (such as Firefox) to install a search plugin."
-msgstr ""
-
-#: static/js/zamboni/collections.js:229
-msgid "Adding to Favorites&hellip;"
-msgstr ""
-
-#: static/js/zamboni/collections.js:232
-msgid "Removing Favorite&hellip;"
-msgstr ""
-
-#: static/js/zamboni/collections.js:235
-msgid "Add to Favorites"
-msgstr ""
-
-#: static/js/zamboni/collections.js:238
-msgid "Remove from Favorites"
-msgstr ""
-
-#: static/js/zamboni/collections.js:303
-msgid "Pending"
-msgstr ""
-
-#: static/js/zamboni/collections.js:304
-msgid "Add a comment"
-msgstr ""
-
-#: static/js/zamboni/collections.js:304
-msgid "Comment"
-msgstr "মন্তব্য"
-
-#: static/js/zamboni/collections.js:305
-msgid "Remove this add-on from the collection"
-msgstr ""
-
-#: static/js/zamboni/collections.js:305 static/js/zamboni/collections.js:334
-msgid "Remove"
-msgstr ""
-
-#: static/js/zamboni/collections.js:334
-msgid "Remove this user as a contributor"
-msgstr ""
-
-#: static/js/zamboni/collections.js:346
-msgid "An email address is required."
-msgstr ""
-
-#: static/js/zamboni/collections.js:364
-msgid "You cannot add yourself as a contributor."
-msgstr ""
-
-#: static/js/zamboni/collections.js:366
-msgid "You have already added that user."
-msgstr ""
-
-#: static/js/zamboni/collections.js:573
-msgid "Add to favorites"
-msgstr ""
-
-#: static/js/zamboni/collections.js:577
-msgid "Remove from favorites"
-msgstr ""
-
-#: static/js/zamboni/collections.js:604
-msgid "Stop following"
-msgstr ""
-
-#: static/js/zamboni/devhub.js:110
+#: static/js/zamboni/devhub-all.js:1289 static/js/zamboni/devhub-min.js:1 static/js/zamboni/devhub.js:110
 msgid "Your browser does not support the video tag"
 msgstr ""
 
-#: static/js/zamboni/devhub.js:371
+#: static/js/zamboni/devhub-all.js:1550 static/js/zamboni/devhub-min.js:1 static/js/zamboni/devhub.js:371
 msgid "Changes Saved"
 msgstr ""
 
-#: static/js/zamboni/devhub.js:387
+#: static/js/zamboni/devhub-all.js:1566 static/js/zamboni/devhub-min.js:1 static/js/zamboni/devhub.js:387
 msgid "Enter a new author's email address"
 msgstr ""
 
-#: static/js/zamboni/devhub.js:536
+#: static/js/zamboni/devhub-all.js:1715 static/js/zamboni/devhub-min.js:1 static/js/zamboni/devhub.js:536
 msgid "There was an error uploading your file."
 msgstr ""
 
-#: static/js/zamboni/devhub.js:681
+#: static/js/zamboni/devhub-all.js:1860 static/js/zamboni/devhub-min.js:1 static/js/zamboni/devhub.js:681
 msgid "{files} file"
 msgid_plural "{files} files"
 msgstr[0] ""
 msgstr[1] ""
 
-#: static/js/zamboni/devhub.js:684
+#: static/js/zamboni/devhub-all.js:1863 static/js/zamboni/devhub-min.js:1 static/js/zamboni/devhub.js:684
 msgid "{reviews} user review"
 msgid_plural "{reviews} user reviews"
 msgstr[0] ""
 msgstr[1] ""
 
-#: static/js/zamboni/devhub.js:796
+#: static/js/zamboni/devhub-all.js:1975 static/js/zamboni/devhub-min.js:2 static/js/zamboni/devhub.js:796
 msgid "Learn more"
 msgstr ""
 
-#: static/js/zamboni/devhub.js:800
+#: static/js/zamboni/devhub-all.js:1979 static/js/zamboni/devhub-min.js:2 static/js/zamboni/devhub.js:800
 msgid "Example"
 msgstr ""
 
-#: static/js/zamboni/devhub.js:1130
+#: static/js/zamboni/devhub-all.js:2309 static/js/zamboni/devhub-min.js:2 static/js/zamboni/devhub.js:1130
 msgid "Image changes being processed"
 msgstr ""
 
-#: static/js/zamboni/devhub.js:1280
+#: static/js/zamboni/devhub-all.js:2459 static/js/zamboni/devhub-min.js:2 static/js/zamboni/devhub.js:1280
 msgid "Must be a valid e-mail address."
+msgstr ""
+
+#: static/js/zamboni/devhub-all.js:2613 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:80
+msgid "All tests passed successfully."
+msgstr ""
+
+#: static/js/zamboni/devhub-all.js:2616 static/js/zamboni/devhub-all.js:3011 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:83 static/js/zamboni/validator.js:478
+msgid "These tests were not run."
+msgstr ""
+
+#: static/js/zamboni/devhub-all.js:2664 static/js/zamboni/devhub-all.js:2677 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:131 static/js/zamboni/validator.js:144
+msgid "Tests"
+msgstr ""
+
+#: static/js/zamboni/devhub-all.js:2779 static/js/zamboni/devhub-all.js:3108 static/js/zamboni/devhub-all.js:3127 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:246
+#: static/js/zamboni/validator.js:575 static/js/zamboni/validator.js:594
+msgid "Error"
+msgstr ""
+
+#: static/js/zamboni/devhub-all.js:2780 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:247
+msgid "Warning"
+msgstr ""
+
+#: static/js/zamboni/devhub-all.js:2794 static/js/zamboni/devhub-min.js:2 static/js/zamboni/files-all.js:5657 static/js/zamboni/files-min.js:3 static/js/zamboni/files.js:411
+#: static/js/zamboni/validator.js:261
+msgid "Ignore this message in future updates"
+msgstr ""
+
+#: static/js/zamboni/devhub-all.js:2817 static/js/zamboni/devhub-min.js:2 static/js/zamboni/files-all.js:5663 static/js/zamboni/files-min.js:3 static/js/zamboni/files.js:417
+#: static/js/zamboni/validator.js:284
+msgid "Severity for automated signing:"
+msgstr ""
+
+#: static/js/zamboni/devhub-all.js:2832 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:299
+msgid "Suggestions for passing automated signing:"
+msgstr ""
+
+#: static/js/zamboni/devhub-all.js:2920 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:387
+msgid "Compatibility Tests"
+msgstr ""
+
+#: static/js/zamboni/devhub-all.js:2999 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:466
+msgid "Add-on failed validation."
+msgstr ""
+
+#: static/js/zamboni/devhub-all.js:3001 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:468
+msgid "Add-on passed validation."
+msgstr ""
+
+#: static/js/zamboni/devhub-all.js:3014 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:481
+msgid "{0} error"
+msgid_plural "{0} errors"
+msgstr[0] ""
+msgstr[1] ""
+
+#: static/js/zamboni/devhub-all.js:3016 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:483
+msgid "{0} warning"
+msgid_plural "{0} warnings"
+msgstr[0] ""
+msgstr[1] ""
+
+#: static/js/zamboni/devhub-all.js:3018 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:485
+msgid "{0} notice"
+msgid_plural "{0} notices"
+msgstr[0] ""
+msgstr[1] ""
+
+#: static/js/zamboni/devhub-all.js:3110 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:577
+msgid "Validation task could not complete or completed with errors"
+msgstr ""
+
+#: static/js/zamboni/devhub-all.js:3128 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:595
+msgid "Internal server error"
 msgstr ""
 
 #: static/js/zamboni/devhub_search.js:8
 msgid "No results found."
 msgstr ""
 
-#: static/js/zamboni/editors.js:121
+#: static/js/zamboni/editors-all.js:15402 static/js/zamboni/editors-min.js:4 static/js/zamboni/editors.js:121
 msgid "{name} was viewing this page first."
 msgstr ""
 
-#: static/js/zamboni/editors.js:171
+#: static/js/zamboni/editors-all.js:15452 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:171
 msgid "Receipt checked by app."
 msgstr ""
 
-#: static/js/zamboni/editors.js:173
+#: static/js/zamboni/editors-all.js:15454 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:173
 msgid "Receipt was not checked by app."
 msgstr ""
 
-#: static/js/zamboni/editors.js:244
+#: static/js/zamboni/editors-all.js:15525 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:244
 msgid "{name} was viewing this add-on first."
 msgstr ""
 
-#: static/js/zamboni/editors.js:255
+#: static/js/zamboni/editors-all.js:15536 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:255
 msgid "Loading&hellip;"
 msgstr ""
 
-#: static/js/zamboni/editors.js:260
+#: static/js/zamboni/editors-all.js:15541 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:260
 msgid "Version Notes"
 msgstr ""
 
-#: static/js/zamboni/editors.js:265
+#: static/js/zamboni/editors-all.js:15546 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:265
 msgid "Notes for Reviewers"
 msgstr ""
 
-#: static/js/zamboni/editors.js:270
+#: static/js/zamboni/editors-all.js:15551 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:270
 msgid "No version notes found"
 msgstr ""
 
-#: static/js/zamboni/editors.js:330
+#: static/js/zamboni/editors-all.js:15611 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:330
 msgid "Average Reviews"
 msgstr ""
 
-#: static/js/zamboni/editors.js:386
+#: static/js/zamboni/editors-all.js:15667 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:386
 msgid "Number of Reviews"
 msgstr ""
 
-#: static/js/zamboni/editors.js:445
+#: static/js/zamboni/editors-all.js:15726 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:445
 msgid "Error loading translation"
 msgstr ""
 
-#: static/js/zamboni/files.js:411 static/js/zamboni/validator.js:261
-msgid "Ignore this message in future updates"
-msgstr ""
-
-#: static/js/zamboni/files.js:417 static/js/zamboni/validator.js:284
-msgid "Severity for automated signing:"
-msgstr ""
-
-#: static/js/zamboni/global.js:410
-msgid "Loading..."
-msgstr ""
-
-#. L10n: {0} is the number of characters left.
-#: static/js/zamboni/global.js:474
-msgid "<b>{0}</b> character left."
-msgid_plural "<b>{0}</b> characters left."
-msgstr[0] ""
-msgstr[1] ""
-
-#: static/js/zamboni/init.js:28
-msgid "This feature is temporarily disabled while we perform website maintenance. Please check back a little later."
-msgstr "আমরা ওয়েবসাইট রক্ষণাবেক্ষণের জন্য যখন এই বৈশিষ্ট্যটি অস্থায়ীভাবে নিষ্ক্রিয় করা হয়. একটু পরে আবার চেক করুন"
-
-#: static/js/zamboni/l10n.js:45
-msgid "Remove this localization"
-msgstr ""
-
-#: static/js/zamboni/password-strength.js:20
-msgid "Password strength:"
-msgstr ""
-
-#: static/js/zamboni/password-strength.js:26
-msgid "At least {0} character left."
-msgid_plural "At least {0} characters left."
-msgstr[0] ""
-msgstr[1] ""
-
-#: static/js/zamboni/themes_review.js:176
-msgid "Requested Info"
-msgstr ""
-
-#: static/js/zamboni/themes_review.js:177
-msgid "Flagged"
-msgstr ""
-
-#: static/js/zamboni/themes_review.js:178
-msgid "Duplicate"
-msgstr ""
-
-#: static/js/zamboni/themes_review.js:179
-msgid "Rejected"
-msgstr ""
-
-#: static/js/zamboni/themes_review.js:180
-msgid "Approved"
-msgstr ""
-
-#: static/js/zamboni/themes_review.js:424
-msgid "No results found"
-msgstr ""
-
-#: static/js/zamboni/themes_review_templates.js:31
+#: static/js/zamboni/editors-all.js:15975 static/js/zamboni/editors-min.js:5 static/js/zamboni/themes_review_templates.js:31
 msgid "Theme"
 msgstr ""
 
-#: static/js/zamboni/themes_review_templates.js:33
+#: static/js/zamboni/editors-all.js:15977 static/js/zamboni/editors-min.js:5 static/js/zamboni/themes_review_templates.js:33
 msgid "Reviewer"
 msgstr ""
 
-#: static/js/zamboni/themes_review_templates.js:35
+#: static/js/zamboni/editors-all.js:15979 static/js/zamboni/editors-min.js:5 static/js/zamboni/themes_review_templates.js:35
 msgid "Status"
 msgstr ""
 
-#: static/js/zamboni/validator.js:80
-msgid "All tests passed successfully."
+#: static/js/zamboni/editors-all.js:16196 static/js/zamboni/editors-min.js:5 static/js/zamboni/themes_review.js:176
+msgid "Requested Info"
 msgstr ""
 
-#: static/js/zamboni/validator.js:83 static/js/zamboni/validator.js:478
-msgid "These tests were not run."
+#: static/js/zamboni/editors-all.js:16197 static/js/zamboni/editors-min.js:5 static/js/zamboni/themes_review.js:177
+msgid "Flagged"
 msgstr ""
 
-#: static/js/zamboni/validator.js:131 static/js/zamboni/validator.js:144
-msgid "Tests"
+#: static/js/zamboni/editors-all.js:16198 static/js/zamboni/editors-min.js:5 static/js/zamboni/themes_review.js:178
+msgid "Duplicate"
 msgstr ""
 
-#: static/js/zamboni/validator.js:246 static/js/zamboni/validator.js:575 static/js/zamboni/validator.js:594
-msgid "Error"
+#: static/js/zamboni/editors-all.js:16199 static/js/zamboni/editors-min.js:5 static/js/zamboni/themes_review.js:179
+msgid "Rejected"
 msgstr ""
 
-#: static/js/zamboni/validator.js:247
-msgid "Warning"
+#: static/js/zamboni/editors-all.js:16200 static/js/zamboni/editors-min.js:5 static/js/zamboni/themes_review.js:180
+msgid "Approved"
 msgstr ""
 
-#: static/js/zamboni/validator.js:299
-msgid "Suggestions for passing automated signing:"
+#: static/js/zamboni/editors-all.js:16444 static/js/zamboni/editors-min.js:5 static/js/zamboni/themes_review.js:424
+msgid "No results found"
 msgstr ""
 
-#: static/js/zamboni/validator.js:387
-msgid "Compatibility Tests"
-msgstr ""
-
-#: static/js/zamboni/validator.js:466
-msgid "Add-on failed validation."
-msgstr ""
-
-#: static/js/zamboni/validator.js:468
-msgid "Add-on passed validation."
-msgstr ""
-
-#: static/js/zamboni/validator.js:481
-msgid "{0} error"
-msgid_plural "{0} errors"
-msgstr[0] ""
-msgstr[1] ""
-
-#: static/js/zamboni/validator.js:483
-msgid "{0} warning"
-msgid_plural "{0} warnings"
-msgstr[0] ""
-msgstr[1] ""
-
-#: static/js/zamboni/validator.js:485
-msgid "{0} notice"
-msgid_plural "{0} notices"
-msgstr[0] ""
-msgstr[1] ""
-
-#: static/js/zamboni/validator.js:577
-msgid "Validation task could not complete or completed with errors"
-msgstr ""
-
-#: static/js/zamboni/validator.js:595
-msgid "Internal server error"
-msgstr ""
-
-#: static/js/zamboni/mobile/buttons.js:52
+#: static/js/zamboni/mobile-all.js:15186 static/js/zamboni/mobile/buttons.js:52
 msgid "Not Updated for {0} {1}"
 msgstr ""
 
-#: static/js/zamboni/mobile/buttons.js:53
+#: static/js/zamboni/mobile-all.js:15187 static/js/zamboni/mobile/buttons.js:53
 msgid "Requires Newer Version of {0}"
 msgstr ""
 
-#: static/js/zamboni/mobile/buttons.js:54
+#: static/js/zamboni/mobile-all.js:15188 static/js/zamboni/mobile/buttons.js:54
 msgid "Unreviewed"
 msgstr ""
 
-#: static/js/zamboni/mobile/buttons.js:55
+#: static/js/zamboni/mobile-all.js:15189 static/js/zamboni/mobile/buttons.js:55
 msgid "Experimental <span>(Learn More)</span>"
 msgstr ""
 
-#: static/js/zamboni/mobile/buttons.js:56 static/js/zamboni/mobile/buttons.js:57
+#: static/js/zamboni/mobile-all.js:15190 static/js/zamboni/mobile-all.js:15191 static/js/zamboni/mobile/buttons.js:56 static/js/zamboni/mobile/buttons.js:57
 msgid "Not Available for {0}"
 msgstr ""
 
-#: static/js/zamboni/mobile/buttons.js:58
+#: static/js/zamboni/mobile-all.js:15192 static/js/zamboni/mobile/buttons.js:58
 msgid "Experimental"
 msgstr ""
 
-#: static/js/zamboni/mobile/buttons.js:59
+#: static/js/zamboni/mobile-all.js:15193 static/js/zamboni/mobile/buttons.js:59
 msgid "Themes Require Newer Version of {0}"
 msgstr ""
 
-#: static/js/zamboni/mobile/buttons.js:60
+#: static/js/zamboni/mobile-all.js:15194 static/js/zamboni/mobile/buttons.js:60
 msgid "Themes Require {0}"
 msgstr ""
 
-#: static/js/zamboni/mobile/buttons.js:105
+#: static/js/zamboni/mobile-all.js:15239 static/js/zamboni/mobile/buttons.js:105
 msgid "Installing..."
 msgstr ""
 
-#: static/js/zamboni/mobile/buttons.js:125
+#: static/js/zamboni/mobile-all.js:15259 static/js/zamboni/mobile/buttons.js:125
 msgid "This add-on has been preliminarily reviewed by Mozilla."
 msgstr ""
 
-#: static/js/zamboni/mobile/buttons.js:250
+#: static/js/zamboni/mobile-all.js:15384 static/js/zamboni/mobile/buttons.js:250
 msgid "Keep it"
 msgstr ""
 
-#: static/js/zamboni/mobile/general.js:344
+#: static/js/zamboni/mobile-all.js:16049 static/js/zamboni/mobile-min.js:6 static/js/zamboni/mobile/general.js:344
 msgid "You're trying it on!"
 msgstr ""
 
-#: static/js/zamboni/mobile/general.js:356
+#: static/js/zamboni/mobile-all.js:16061 static/js/zamboni/mobile-min.js:6 static/js/zamboni/mobile/general.js:356
 msgid "Added to Firefox"
 msgstr ""
-

--- a/locale/bs/LC_MESSAGES/django.po
+++ b/locale/bs/LC_MESSAGES/django.po
@@ -3,69 +3,70 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2016-02-24 21:23+0000\n"
+"POT-Creation-Date: 2016-04-18 15:47+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
+"Language: \n"
 "MIME-Version: 1.0\n"
-"Content-Type: text/plain; charset=utf-8\n"
+"Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Generated-By: Babel 2.2.0\n"
 
-#: src/olympia/accounts/views.py:52
+#: src/olympia/accounts/views.py:54
 msgid "Your log in attempt could not be parsed. Please try again."
 msgstr ""
 
-#: src/olympia/accounts/views.py:54
+#: src/olympia/accounts/views.py:56
 msgid "Your Firefox Account could not be found. Please try again."
 msgstr ""
 
-#: src/olympia/accounts/views.py:55
+#: src/olympia/accounts/views.py:57
 msgid "You could not be logged in. Please try again."
 msgstr ""
 
-#: src/olympia/accounts/views.py:57
+#: src/olympia/accounts/views.py:59
 msgid "Your account has already been migrated to Firefox Accounts."
 msgstr ""
 
-#: src/olympia/accounts/views.py:59
+#: src/olympia/accounts/views.py:61
 msgid "Your Firefox Account already exists on this site."
 msgstr ""
 
-#: src/olympia/accounts/views.py:108
+#: src/olympia/accounts/views.py:110
 msgid "Great job!"
 msgstr ""
 
-#: src/olympia/accounts/views.py:109
+#: src/olympia/accounts/views.py:111
 msgid "You can now log in to Add-ons with your Firefox Account."
 msgstr ""
 
-#: src/olympia/accounts/views.py:121
+#: src/olympia/accounts/views.py:123
 msgid "Need help?"
 msgstr ""
 
-#: src/olympia/addons/buttons.py:180
+#: src/olympia/addons/buttons.py:177
 msgid "Download Now"
 msgstr ""
 
-#: src/olympia/addons/buttons.py:182
+#: src/olympia/addons/buttons.py:179
 msgid "Download"
 msgstr ""
 
 #. L10n: please keep &nbsp; in the string so &rarr; does not wrap.
-#: src/olympia/addons/buttons.py:186
+#: src/olympia/addons/buttons.py:183
 msgid "Continue to Download&nbsp;&rarr;"
 msgstr ""
 
-#: src/olympia/addons/buttons.py:202 src/olympia/addons/helpers.py:35 src/olympia/addons/views.py:319 src/olympia/addons/templates/addons/impala/details.html:114
+#: src/olympia/addons/buttons.py:199 src/olympia/addons/helpers.py:35 src/olympia/addons/views.py:333 src/olympia/addons/templates/addons/impala/details.html:111
 #: src/olympia/addons/templates/addons/impala/listing/items.html:17 src/olympia/addons/templates/addons/mobile/home.html:40 src/olympia/amo/templates/amo/side_nav.html:6
-#: src/olympia/amo/templates/amo/side_nav.html:10 src/olympia/amo/templates/amo/site_nav.html:2 src/olympia/amo/templates/amo/site_nav.html:55 src/olympia/bandwagon/views.py:95
-#: src/olympia/browse/views.py:54 src/olympia/browse/views.py:68 src/olympia/browse/views.py:235 src/olympia/browse/templates/browse/impala/category_landing.html:22
+#: src/olympia/amo/templates/amo/side_nav.html:10 src/olympia/amo/templates/amo/site_nav.html:2 src/olympia/amo/templates/amo/site_nav.html:53 src/olympia/bandwagon/views.py:95
+#: src/olympia/browse/views.py:54 src/olympia/browse/views.py:68 src/olympia/browse/views.py:202 src/olympia/browse/templates/browse/impala/category_landing.html:22
 #: src/olympia/browse/templates/browse/personas/mobile/category_landing.html:26
 msgid "Featured"
 msgstr ""
 
-#: src/olympia/addons/buttons.py:221
+#: src/olympia/addons/buttons.py:218
 msgid "Add to {0}"
 msgstr ""
 
@@ -113,39 +114,39 @@ msgid_plural "All tags must be at least {0} characters."
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/olympia/addons/forms.py:234
+#: src/olympia/addons/forms.py:238
 msgid "Categories cannot be changed while your add-on is featured for this application."
 msgstr ""
 
 #. L10n: {0} is the number of categories.
-#: src/olympia/addons/forms.py:238
+#: src/olympia/addons/forms.py:242
 msgid "You can have only {0} category."
 msgid_plural "You can have only {0} categories."
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/olympia/addons/forms.py:246
+#: src/olympia/addons/forms.py:250
 msgid "The miscellaneous category cannot be combined with additional categories."
 msgstr ""
 
-#: src/olympia/addons/forms.py:369
+#: src/olympia/addons/forms.py:374
 #, python-format
 msgid "Before changing your default locale you must have a name, summary, and description in that locale. You are missing %s."
 msgstr ""
 
-#: src/olympia/addons/forms.py:484 src/olympia/addons/forms.py:575
+#: src/olympia/addons/forms.py:455 src/olympia/addons/forms.py:546
 msgid "A license must be selected."
 msgstr ""
 
-#: src/olympia/addons/forms.py:556
+#: src/olympia/addons/forms.py:527
 msgid "Give Your Theme a Name."
 msgstr ""
 
-#: src/olympia/addons/forms.py:562 src/olympia/devhub/templates/devhub/personas/submit.html:53
+#: src/olympia/addons/forms.py:533 src/olympia/devhub/templates/devhub/personas/submit.html:53
 msgid "Describe your Theme."
 msgstr ""
 
-#: src/olympia/addons/forms.py:704
+#: src/olympia/addons/forms.py:675
 msgid "Enter a new author's email address"
 msgstr ""
 
@@ -153,37 +154,37 @@ msgstr ""
 msgid "Not Reviewed"
 msgstr ""
 
-#: src/olympia/addons/models.py:301
+#: src/olympia/addons/models.py:298
 msgid "Users have the option of contributing more or less than this amount."
 msgstr ""
 
-#: src/olympia/addons/models.py:309
-msgid "Users will always be asked in the Add-ons Manager (Firefox 4 and above)"
+#: src/olympia/addons/models.py:306
+msgid "Users will always be asked in the Add-ons Manager (Firefox 4 and above). Only applies to desktop."
 msgstr ""
 
-#: src/olympia/addons/models.py:1804 src/olympia/addons/templates/addons/details_box.html:55 src/olympia/devhub/templates/devhub/index.html:92
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:102
+#: src/olympia/addons/models.py:1802 src/olympia/addons/templates/addons/details_box.html:55 src/olympia/devhub/templates/devhub/index.html:92
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:89
 msgid "Listed"
 msgstr ""
 
-#: src/olympia/addons/views.py:320 src/olympia/browse/templates/browse/personas/mobile/category_landing.html:27
+#: src/olympia/addons/views.py:334 src/olympia/browse/templates/browse/personas/mobile/category_landing.html:27
 msgid "Popular"
 msgstr ""
 
-#: src/olympia/addons/views.py:321 src/olympia/browse/views.py:238 src/olympia/browse/views.py:280 src/olympia/browse/views.py:482
+#: src/olympia/addons/views.py:335 src/olympia/browse/views.py:205 src/olympia/browse/views.py:247 src/olympia/browse/views.py:449
 msgid "Recently Added"
 msgstr ""
 
-#: src/olympia/addons/views.py:322 src/olympia/bandwagon/views.py:99 src/olympia/browse/views.py:60 src/olympia/browse/views.py:71 src/olympia/search/forms.py:16 src/olympia/search/forms.py:91
+#: src/olympia/addons/views.py:336 src/olympia/bandwagon/views.py:99 src/olympia/browse/views.py:60 src/olympia/browse/views.py:71 src/olympia/search/forms.py:16 src/olympia/search/forms.py:91
 msgid "Recently Updated"
 msgstr ""
 
 #. l10n: {0} is the addon name
-#: src/olympia/addons/views.py:520
+#: src/olympia/addons/views.py:534
 msgid "Contribution for {0}"
 msgstr ""
 
-#: src/olympia/addons/views.py:613
+#: src/olympia/addons/views.py:627
 msgid "Abuse reported."
 msgstr ""
 
@@ -250,9 +251,9 @@ msgstr ""
 #: src/olympia/devhub/templates/devhub/addons/ajax_compat_update.html:36 src/olympia/devhub/templates/devhub/addons/profile.html:44 src/olympia/devhub/templates/devhub/addons/edit/admin.html:101
 #: src/olympia/devhub/templates/devhub/addons/edit/basic.html:152 src/olympia/devhub/templates/devhub/addons/edit/details.html:85 src/olympia/devhub/templates/devhub/addons/edit/support.html:67
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:166 src/olympia/devhub/templates/devhub/addons/forms_shared/media.html:149
-#: src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:44 src/olympia/devhub/templates/devhub/versions/add_file_modal.html:78 src/olympia/devhub/templates/devhub/versions/edit.html:139
-#: src/olympia/devhub/templates/devhub/versions/list.html:242 src/olympia/devhub/templates/devhub/versions/list.html:276 src/olympia/devhub/templates/devhub/versions/list.html:317
-#: src/olympia/devhub/templates/devhub/versions/list.html:351 src/olympia/reviews/templates/reviews/edit_review.html:16 src/olympia/translations/templates/translations/trans-menu.html:50
+#: src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:43 src/olympia/devhub/templates/devhub/versions/add_file_modal.html:58 src/olympia/devhub/templates/devhub/versions/edit.html:139
+#: src/olympia/devhub/templates/devhub/versions/list.html:239 src/olympia/devhub/templates/devhub/versions/list.html:281 src/olympia/devhub/templates/devhub/versions/list.html:315
+#: src/olympia/devhub/templates/devhub/versions/list.html:349 src/olympia/reviews/templates/reviews/edit_review.html:16 src/olympia/translations/templates/translations/trans-menu.html:50
 #: src/olympia/translations/templates/translations/trans-menu.html:62
 msgid "or"
 msgstr ""
@@ -363,7 +364,7 @@ msgid "Add-on Information for {0}"
 msgstr ""
 
 #: src/olympia/addons/templates/addons/details_box.html:30 src/olympia/addons/templates/addons/persona_detail_table.html:3 src/olympia/addons/templates/addons/mobile/details.html:63
-#: src/olympia/addons/templates/addons/mobile/persona_detail_table.html:7 src/olympia/browse/views.py:459 src/olympia/devhub/views.py:75
+#: src/olympia/addons/templates/addons/mobile/persona_detail_table.html:7 src/olympia/browse/views.py:426 src/olympia/devhub/views.py:73
 msgid "Updated"
 msgstr ""
 
@@ -382,11 +383,11 @@ msgstr ""
 msgid "Visibility"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/details_box.html:57 src/olympia/devhub/templates/devhub/index.html:94 src/olympia/devhub/templates/devhub/includes/addon_details.html:104
+#: src/olympia/addons/templates/addons/details_box.html:57 src/olympia/devhub/templates/devhub/index.html:94 src/olympia/devhub/templates/devhub/includes/addon_details.html:91
 msgid "Hidden"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/details_box.html:59 src/olympia/devhub/templates/devhub/index.html:96 src/olympia/devhub/templates/devhub/includes/addon_details.html:106
+#: src/olympia/addons/templates/addons/details_box.html:59 src/olympia/devhub/templates/devhub/index.html:96 src/olympia/devhub/templates/devhub/includes/addon_details.html:93
 msgid "Unlisted"
 msgstr ""
 
@@ -394,13 +395,13 @@ msgstr ""
 msgid "Required Add-ons"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/details_box.html:81 src/olympia/addons/templates/addons/persona_detail_table.html:15 src/olympia/browse/views.py:462 src/olympia/devhub/views.py:78
-#: src/olympia/devhub/views.py:85 src/olympia/discovery/templates/discovery/addons/detail.html:57 src/olympia/reviews/forms.py:62 src/olympia/reviews/templates/reviews/add.html:57
+#: src/olympia/addons/templates/addons/details_box.html:81 src/olympia/addons/templates/addons/persona_detail_table.html:15 src/olympia/browse/views.py:429 src/olympia/devhub/views.py:76
+#: src/olympia/devhub/views.py:83 src/olympia/discovery/templates/discovery/addons/detail.html:57 src/olympia/reviews/forms.py:62 src/olympia/reviews/templates/reviews/add.html:57
 #: src/olympia/reviews/templates/reviews/mobile/review_list.html:18
 msgid "Rating"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/details_box.html:85 src/olympia/browse/views.py:461 src/olympia/devhub/views.py:77 src/olympia/devhub/views.py:84
+#: src/olympia/addons/templates/addons/details_box.html:85 src/olympia/browse/views.py:428 src/olympia/devhub/views.py:75 src/olympia/devhub/views.py:82
 #: src/olympia/stats/templates/stats/addon_report_menu.html:8 src/olympia/stats/templates/stats/collection_report_menu.html:18
 msgid "Downloads"
 msgstr ""
@@ -420,7 +421,7 @@ msgstr ""
 
 #. The Privacy Policy for this add-on.
 #: src/olympia/addons/templates/addons/details_box.html:121 src/olympia/addons/templates/addons/privacy.html:19 src/olympia/addons/templates/addons/privacy.html:23
-#: src/olympia/addons/templates/addons/impala/button.html:43 src/olympia/addons/templates/addons/impala/details.html:307 src/olympia/devhub/templates/devhub/includes/policy_form.html:20
+#: src/olympia/addons/templates/addons/impala/button.html:43 src/olympia/addons/templates/addons/impala/details.html:312 src/olympia/devhub/templates/devhub/includes/policy_form.html:23
 #: src/olympia/templates/mobile/base_addons.html:87
 msgid "Privacy Policy"
 msgstr ""
@@ -445,7 +446,7 @@ msgstr ""
 msgid "Developer Comments"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/details_box.html:199 src/olympia/addons/templates/addons/impala/details.html:259
+#: src/olympia/addons/templates/addons/details_box.html:199 src/olympia/addons/templates/addons/impala/details.html:264
 msgid "Development Channel"
 msgstr ""
 
@@ -465,7 +466,7 @@ msgid ""
 "developer. To stop receiving development updates, reinstall the default version from the link above."
 msgstr ""
 
-#: src/olympia/addons/templates/addons/details_box.html:220 src/olympia/addons/templates/addons/impala/details.html:278
+#: src/olympia/addons/templates/addons/details_box.html:220 src/olympia/addons/templates/addons/impala/details.html:283
 msgid "Version {0}:"
 msgstr ""
 
@@ -484,7 +485,7 @@ msgid "End-User License Agreement for {0}"
 msgstr ""
 
 #: src/olympia/addons/templates/addons/eula.html:17 src/olympia/addons/templates/addons/eula.html:21 src/olympia/addons/templates/addons/impala/button.html:48
-#: src/olympia/addons/templates/addons/impala/details.html:316 src/olympia/devhub/templates/devhub/includes/policy_form.html:3 src/olympia/discovery/templates/discovery/addons/eula.html:11
+#: src/olympia/addons/templates/addons/impala/details.html:321 src/olympia/devhub/templates/devhub/includes/policy_form.html:3 src/olympia/discovery/templates/discovery/addons/eula.html:11
 msgid "End-User License Agreement"
 msgstr ""
 
@@ -501,7 +502,7 @@ msgstr ""
 msgid "Add-ons for {0}"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/home.html:10 src/olympia/addons/templates/addons/home.html:51 src/olympia/browse/templates/browse/impala/base_listing.html:11
+#: src/olympia/addons/templates/addons/home.html:10 src/olympia/addons/templates/addons/home.html:53 src/olympia/browse/templates/browse/impala/base_listing.html:11
 msgid "Featured Extensions"
 msgstr ""
 
@@ -509,29 +510,29 @@ msgstr ""
 msgid "Popular Extensions"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/home.html:42 src/olympia/amo/templates/amo/side_nav.html:3 src/olympia/amo/templates/amo/side_nav.html:11 src/olympia/amo/templates/amo/site_nav.html:3
-#: src/olympia/amo/templates/amo/site_nav.html:25 src/olympia/browse/views.py:236 src/olympia/browse/views.py:281 src/olympia/browse/views.py:481
+#: src/olympia/addons/templates/addons/home.html:44 src/olympia/amo/templates/amo/side_nav.html:3 src/olympia/amo/templates/amo/side_nav.html:11 src/olympia/amo/templates/amo/site_nav.html:3
+#: src/olympia/amo/templates/amo/site_nav.html:25 src/olympia/browse/views.py:203 src/olympia/browse/views.py:248 src/olympia/browse/views.py:448
 msgid "Most Popular"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/home.html:43
+#: src/olympia/addons/templates/addons/home.html:45
 msgid "All »"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/home.html:52 src/olympia/addons/templates/addons/home.html:61 src/olympia/addons/templates/addons/home.html:70 src/olympia/addons/templates/addons/home.html:78
+#: src/olympia/addons/templates/addons/home.html:54 src/olympia/addons/templates/addons/home.html:63 src/olympia/addons/templates/addons/home.html:72 src/olympia/addons/templates/addons/home.html:80
 #: src/olympia/browse/templates/browse/impala/category_landing.html:36
 msgid "See all »"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/home.html:60
+#: src/olympia/addons/templates/addons/home.html:62
 msgid "Up &amp; Coming Extensions"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/home.html:69 src/olympia/browse/templates/browse/personas/category_landing.html:61 src/olympia/discovery/templates/discovery/pane.html:74
+#: src/olympia/addons/templates/addons/home.html:71 src/olympia/browse/templates/browse/personas/category_landing.html:61 src/olympia/discovery/templates/discovery/pane.html:74
 msgid "Featured Themes"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/home.html:77 src/olympia/bandwagon/templates/bandwagon/impala/collection_listing.html:5
+#: src/olympia/addons/templates/addons/home.html:79 src/olympia/bandwagon/templates/bandwagon/impala/collection_listing.html:5
 msgid "Featured Collections"
 msgstr ""
 
@@ -549,7 +550,7 @@ msgid "Updated {0}"
 msgstr ""
 
 #. {0} is a date.
-#: src/olympia/addons/templates/addons/macros.html:10 src/olympia/addons/templates/addons/macros.html:69 src/olympia/addons/templates/addons/persona_preview.html:21
+#: src/olympia/addons/templates/addons/macros.html:10 src/olympia/addons/templates/addons/macros.html:69 src/olympia/addons/templates/addons/persona_preview.html:22
 #: src/olympia/addons/templates/addons/listing/items_mobile.html:44 src/olympia/addons/templates/addons/listing/macros.html:39
 #: src/olympia/bandwagon/templates/bandwagon/collection_listing_items.html:37 src/olympia/bandwagon/templates/bandwagon/impala/collection_listing_items.html:37
 msgid "Added {0}"
@@ -570,15 +571,14 @@ msgstr[0] ""
 msgstr[1] ""
 
 #. {0} is the number of downloads.
-#: src/olympia/addons/templates/addons/macros.html:53 src/olympia/addons/templates/addons/impala/details.html:61
+#: src/olympia/addons/templates/addons/macros.html:53 src/olympia/addons/templates/addons/impala/details.html:59
 msgid "{0} weekly download"
 msgid_plural "{0} weekly downloads"
 msgstr[0] ""
 msgstr[1] ""
 
 #. {0} is the number of users.
-#: src/olympia/addons/templates/addons/macros.html:61 src/olympia/addons/templates/addons/impala/details.html:54 src/olympia/compat/templates/compat/index.html:71
-#: src/olympia/zadmin/templates/zadmin/compat.html:67
+#: src/olympia/addons/templates/addons/macros.html:61 src/olympia/addons/templates/addons/impala/details.html:52 src/olympia/zadmin/templates/zadmin/compat.html:67
 msgid "{0} user"
 msgid_plural "{0} users"
 msgstr[0] ""
@@ -596,7 +596,7 @@ msgstr ""
 msgid "Return to the addon."
 msgstr ""
 
-#: src/olympia/addons/templates/addons/persona_detail.html:17 src/olympia/addons/templates/addons/impala/details.html:106 src/olympia/addons/templates/addons/mobile/details.html:23
+#: src/olympia/addons/templates/addons/persona_detail.html:17 src/olympia/addons/templates/addons/impala/details.html:103 src/olympia/addons/templates/addons/mobile/details.html:23
 #: src/olympia/addons/templates/addons/mobile/persona_detail.html:21 src/olympia/discovery/templates/discovery/addons/base.html:27 src/olympia/editors/templates/editors/review.html:31
 msgid "by"
 msgstr ""
@@ -640,34 +640,35 @@ msgstr ""
 msgid "License"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/persona_preview.html:12 src/olympia/constants/base.py:48
+#: src/olympia/addons/templates/addons/persona_preview.html:13 src/olympia/constants/base.py:48
 msgid "Awaiting Review"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/persona_preview.html:14 src/olympia/amo/log.py:180 src/olympia/constants/base.py:42 src/olympia/editors/helpers.py:62
+#: src/olympia/addons/templates/addons/persona_preview.html:15 src/olympia/amo/log.py:180 src/olympia/constants/base.py:42 src/olympia/editors/helpers.py:62
 msgid "Rejected"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/persona_preview.html:16 src/olympia/amo/log.py:159
+#: src/olympia/addons/templates/addons/persona_preview.html:17 src/olympia/amo/log.py:159
 msgid "Approved"
 msgstr ""
 
 #. {0} is the number of users.
-#: src/olympia/addons/templates/addons/persona_preview.html:26 src/olympia/addons/templates/addons/listing/items_mobile.html:36 src/olympia/addons/templates/addons/listing/macros.html:31
+#: src/olympia/addons/templates/addons/persona_preview.html:27 src/olympia/addons/templates/addons/listing/items_mobile.html:36 src/olympia/addons/templates/addons/listing/macros.html:31
 msgid "<strong>{0}</strong> user"
 msgid_plural "<strong>{0}</strong> users"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/olympia/addons/templates/addons/persona_preview.html:40
+#: src/olympia/addons/templates/addons/persona_preview.html:41
 msgid "Hover to Preview"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/persona_preview.html:46 src/olympia/addons/templates/addons/persona_preview.html:48 src/olympia/reviews/templates/reviews/add.html:15
+#: src/olympia/addons/templates/addons/persona_preview.html:47 src/olympia/addons/templates/addons/persona_preview.html:49 src/olympia/addons/templates/addons/persona_preview.html:97
+#: src/olympia/reviews/templates/reviews/add.html:15
 msgid "Add"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/persona_preview.html:57 src/olympia/bandwagon/templates/bandwagon/ajax_new.html:16 src/olympia/bandwagon/templates/bandwagon/edit.html:19
+#: src/olympia/addons/templates/addons/persona_preview.html:58 src/olympia/bandwagon/templates/bandwagon/ajax_new.html:16 src/olympia/bandwagon/templates/bandwagon/edit.html:19
 #: src/olympia/bandwagon/templates/bandwagon/includes/addedit.html:19 src/olympia/devhub/templates/devhub/addons/edit/admin.html:13 src/olympia/devhub/templates/devhub/addons/edit/basic.html:10
 #: src/olympia/devhub/templates/devhub/addons/edit/details.html:8 src/olympia/devhub/templates/devhub/addons/edit/media.html:6 src/olympia/devhub/templates/devhub/addons/edit/support.html:8
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:9 src/olympia/devhub/templates/devhub/addons/submit/describe.html:29 src/olympia/editors/templates/editors/review.html:257
@@ -676,21 +677,21 @@ msgstr ""
 
 #. For datetime formatting, see the table on
 #. http://docs.python.org/library/datetime.html#strftime-and-strptime-behavior
-#: src/olympia/addons/templates/addons/persona_preview.html:66
+#: src/olympia/addons/templates/addons/persona_preview.html:67
 #, python-format
 msgid "%%Y-%%m-%%d"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/persona_preview.html:67
+#: src/olympia/addons/templates/addons/persona_preview.html:68
 msgid "by {0} on {1}"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/persona_preview.html:75 src/olympia/reviews/helpers.py:17 src/olympia/reviews/templates/reviews/review_list.html:63
+#: src/olympia/addons/templates/addons/persona_preview.html:76 src/olympia/reviews/helpers.py:17 src/olympia/reviews/templates/reviews/review_list.html:63
 #: src/olympia/reviews/templates/reviews/reviews_link.html:21 src/olympia/reviews/templates/reviews/impala/reviews_link.html:16
 msgid "Not yet rated"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/persona_preview.html:78
+#: src/olympia/addons/templates/addons/persona_preview.html:79
 msgid "<b>{0}</b> users"
 msgstr ""
 
@@ -703,7 +704,7 @@ msgid "Learn more about Firefox"
 msgstr ""
 
 #: src/olympia/addons/templates/addons/popups.html:22
-msgid "or <b><a class=\"installer\" href=\"{url}\">download anyway</a></b>"
+msgid "or <b><a class=\"button installer\" href=\"{url}\">download anyway</a></b>"
 msgstr ""
 
 #: src/olympia/addons/templates/addons/popups.html:26
@@ -802,7 +803,7 @@ msgid ""
 msgstr ""
 
 #: src/olympia/addons/templates/addons/report_abuse.html:6 src/olympia/addons/templates/addons/report_abuse_full.html:10 src/olympia/addons/templates/addons/impala/details-more.html:23
-#: src/olympia/addons/templates/addons/impala/details.html:328
+#: src/olympia/addons/templates/addons/impala/details.html:333
 msgid "Report Abuse"
 msgstr ""
 
@@ -821,9 +822,9 @@ msgstr ""
 #: src/olympia/devhub/templates/devhub/addons/ajax_compat_update.html:36 src/olympia/devhub/templates/devhub/addons/profile.html:44 src/olympia/devhub/templates/devhub/addons/edit/admin.html:104
 #: src/olympia/devhub/templates/devhub/addons/edit/basic.html:155 src/olympia/devhub/templates/devhub/addons/edit/details.html:88 src/olympia/devhub/templates/devhub/addons/edit/support.html:70
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:169 src/olympia/devhub/templates/devhub/addons/forms_shared/media.html:152
-#: src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:44 src/olympia/devhub/templates/devhub/personas/edit.html:222 src/olympia/devhub/templates/devhub/versions/add_file_modal.html:79
-#: src/olympia/devhub/templates/devhub/versions/edit.html:140 src/olympia/devhub/templates/devhub/versions/list.html:208 src/olympia/devhub/templates/devhub/versions/list.html:242
-#: src/olympia/devhub/templates/devhub/versions/list.html:276 src/olympia/devhub/templates/devhub/versions/list.html:317 src/olympia/reviews/templates/reviews/edit_review.html:16
+#: src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:43 src/olympia/devhub/templates/devhub/personas/edit.html:222 src/olympia/devhub/templates/devhub/versions/add_file_modal.html:59
+#: src/olympia/devhub/templates/devhub/versions/edit.html:140 src/olympia/devhub/templates/devhub/versions/list.html:208 src/olympia/devhub/templates/devhub/versions/list.html:239
+#: src/olympia/devhub/templates/devhub/versions/list.html:281 src/olympia/devhub/templates/devhub/versions/list.html:315 src/olympia/reviews/templates/reviews/edit_review.html:16
 #: src/olympia/translations/templates/translations/trans-menu.html:50 src/olympia/translations/templates/translations/trans-menu.html:62 src/olympia/zadmin/templates/zadmin/validation.html:105
 msgid "Cancel"
 msgstr ""
@@ -868,7 +869,7 @@ msgstr ""
 msgid "Review Guidelines"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/review_list_box.html:5 src/olympia/addons/templates/addons/impala/details-more.html:27 src/olympia/editors/helpers.py:921
+#: src/olympia/addons/templates/addons/review_list_box.html:5 src/olympia/addons/templates/addons/impala/details-more.html:27 src/olympia/editors/helpers.py:1001
 #: src/olympia/reviews/templates/reviews/add.html:14 src/olympia/reviews/templates/reviews/reply.html:14 src/olympia/reviews/templates/reviews/review_list.html:19
 #: src/olympia/reviews/templates/reviews/mobile/review_list.html:26
 msgid "Reviews"
@@ -959,119 +960,119 @@ msgid_plural "Other add-ons by these authors"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/olympia/addons/templates/addons/impala/details.html:41
+#: src/olympia/addons/templates/addons/impala/details.html:39
 #, python-format
 msgid "<span itemprop=\"ratingCount\">%(num)s</span> user review"
 msgid_plural "<span itemprop=\"ratingCount\">%(num)s</span> user reviews"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/olympia/addons/templates/addons/impala/details.html:69
+#: src/olympia/addons/templates/addons/impala/details.html:66
 msgid "View statistics"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/impala/details.html:84
+#: src/olympia/addons/templates/addons/impala/details.html:81
 msgid "Manage"
 msgstr ""
 
 #. {0} is an add-on name.
-#: src/olympia/addons/templates/addons/impala/details.html:96
+#: src/olympia/addons/templates/addons/impala/details.html:93
 msgid "Icon of {0}"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/impala/details.html:103 src/olympia/addons/templates/addons/impala/listing/items.html:14
+#: src/olympia/addons/templates/addons/impala/details.html:100 src/olympia/addons/templates/addons/impala/listing/items.html:14
 msgid "No Restart"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/impala/details.html:127
+#: src/olympia/addons/templates/addons/impala/details.html:124
 #, python-format
 msgid "Meet the Developer: <a href=\"%(url)s\">%(name)s</a>"
 msgid_plural "<a href=\"%(url)s\">Meet the Developers</a>"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/olympia/addons/templates/addons/impala/details.html:137
+#: src/olympia/addons/templates/addons/impala/details.html:134
 msgid "Learn why {0} was created and find out what's next for this add-on."
 msgstr ""
 
 #. {0} is an index.
-#: src/olympia/addons/templates/addons/impala/details.html:156
+#: src/olympia/addons/templates/addons/impala/details.html:161
 msgid "Add-on screenshot #{0}"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/impala/details.html:182
+#: src/olympia/addons/templates/addons/impala/details.html:187
 msgid "Add-on home page"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/impala/details.html:185
+#: src/olympia/addons/templates/addons/impala/details.html:190
 msgid "Support site"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/impala/details.html:189
+#: src/olympia/addons/templates/addons/impala/details.html:194
 msgid "Support E-mail"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/impala/details.html:194 src/olympia/devhub/models.py:378 src/olympia/devhub/templates/devhub/versions/list.html:12
+#: src/olympia/addons/templates/addons/impala/details.html:199 src/olympia/devhub/models.py:378 src/olympia/devhub/templates/devhub/versions/list.html:12
 #: src/olympia/versions/templates/versions/version.html:6 src/olympia/versions/templates/versions/mobile/version.html:6
 msgid "Version {0}"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/impala/details.html:194
+#: src/olympia/addons/templates/addons/impala/details.html:199
 msgid "Info"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/impala/details.html:195 src/olympia/devhub/templates/devhub/includes/addon_details.html:129
+#: src/olympia/addons/templates/addons/impala/details.html:200 src/olympia/devhub/templates/devhub/includes/addon_details.html:116
 msgid "Last Updated:"
-msgstr ""
-
-#: src/olympia/addons/templates/addons/impala/details.html:200
-#, python-format
-msgid "Released under <a target=\"_blank\" href=\"%(url)s\">%(name)s</a>"
-msgstr ""
-
-#: src/olympia/addons/templates/addons/impala/details.html:201 src/olympia/addons/templates/addons/impala/details.html:206 src/olympia/amo/helpers.py:398 src/olympia/devhub/forms.py:142
-#: src/olympia/devhub/forms.py:173 src/olympia/versions/templates/versions/version.html:40 src/olympia/versions/templates/versions/version.html:45
-msgid "Custom License"
 msgstr ""
 
 #: src/olympia/addons/templates/addons/impala/details.html:205
 #, python-format
+msgid "Released under <a target=\"_blank\" href=\"%(url)s\">%(name)s</a>"
+msgstr ""
+
+#: src/olympia/addons/templates/addons/impala/details.html:206 src/olympia/addons/templates/addons/impala/details.html:211 src/olympia/amo/helpers.py:398 src/olympia/devhub/forms.py:142
+#: src/olympia/devhub/forms.py:173 src/olympia/versions/templates/versions/version.html:40 src/olympia/versions/templates/versions/version.html:45
+msgid "Custom License"
+msgstr ""
+
+#: src/olympia/addons/templates/addons/impala/details.html:210
+#, python-format
 msgid "Released under <a href=\"%(url)s\">%(name)s</a>"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/impala/details.html:217
+#: src/olympia/addons/templates/addons/impala/details.html:222
 msgid "About this Add-on"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/impala/details.html:233
+#: src/olympia/addons/templates/addons/impala/details.html:238
 msgid "Developer’s Comments"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/impala/details.html:243
+#: src/olympia/addons/templates/addons/impala/details.html:248
 msgid "Version Information"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/impala/details.html:250
+#: src/olympia/addons/templates/addons/impala/details.html:255
 msgid "See complete version history"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/impala/details.html:262
+#: src/olympia/addons/templates/addons/impala/details.html:267
 msgid ""
 "The Development Channel lets you test an experimental new version of this add-on before it's released to the general public. Once you install the development version, you will continue to get "
 "updates from this channel. To stop receiving development updates, reinstall the default version from the link above."
 msgstr ""
 
-#: src/olympia/addons/templates/addons/impala/details.html:272
+#: src/olympia/addons/templates/addons/impala/details.html:277
 msgid "<strong>Caution:</strong> Development versions of this add-on have not been reviewed by Mozilla."
 msgstr ""
 
-#: src/olympia/addons/templates/addons/impala/details.html:287
+#: src/olympia/addons/templates/addons/impala/details.html:292
 msgid "See complete development channel history"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/impala/details.html:306 src/olympia/addons/templates/addons/impala/details.html:315 src/olympia/addons/templates/addons/impala/details.html:327
+#: src/olympia/addons/templates/addons/impala/details.html:311 src/olympia/addons/templates/addons/impala/details.html:320 src/olympia/addons/templates/addons/impala/details.html:332
 #: src/olympia/addons/templates/addons/impala/review_add_box.html:4 src/olympia/stats/templates/stats/popup.html:2 src/olympia/stats/templates/stats/popup.html:8
-#: src/olympia/stats/templates/stats/stats.html:202 src/olympia/users/templates/users/profile.html:119
+#: src/olympia/stats/templates/stats/stats.html:204 src/olympia/users/templates/users/profile.html:119
 msgid "close"
 msgstr ""
 
@@ -1127,15 +1128,11 @@ msgstr ""
 msgid "Source Code License"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/impala/persona_grid.html:16 src/olympia/addons/templates/addons/impala/toplist.html:6
-msgid "{0} users"
-msgstr ""
-
 #: src/olympia/addons/templates/addons/impala/review_list_box.html:19 src/olympia/reviews/templates/reviews/review.html:40
 msgid "permalink"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/impala/review_list_box.html:23 src/olympia/editors/templates/editors/queue.html:98 src/olympia/reviews/templates/reviews/review.html:44
+#: src/olympia/addons/templates/addons/impala/review_list_box.html:23 src/olympia/editors/templates/editors/queue.html:104 src/olympia/reviews/templates/reviews/review.html:44
 msgid "translate"
 msgstr ""
 
@@ -1154,6 +1151,10 @@ msgstr ""
 msgid "Be the first!"
 msgstr ""
 
+#: src/olympia/addons/templates/addons/impala/toplist.html:6
+msgid "{0} users"
+msgstr ""
+
 #: src/olympia/addons/templates/addons/impala/listing/sorter.html:14 src/olympia/devhub/templates/devhub/addons/listing/item_actions.html:49
 msgid "More"
 msgstr ""
@@ -1166,7 +1167,7 @@ msgstr ""
 msgid "My Add-ons"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/includes/dashboard_tabs.html:6 src/olympia/amo/context_processors.py:51
+#: src/olympia/addons/templates/addons/includes/dashboard_tabs.html:6 src/olympia/amo/context_processors.py:50
 msgid "My Themes"
 msgstr ""
 
@@ -1221,7 +1222,7 @@ msgstr ""
 msgid "Weekly Downloads"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/mobile/details.html:99 src/olympia/compat/templates/compat/reporter_detail.html:46 src/olympia/devhub/forms.py:787
+#: src/olympia/addons/templates/addons/mobile/details.html:99 src/olympia/compat/templates/compat/reporter_detail.html:46 src/olympia/devhub/forms.py:788
 #: src/olympia/devhub/templates/devhub/versions/list.html:163
 msgid "Version"
 msgstr ""
@@ -1305,7 +1306,7 @@ msgstr ""
 #: src/olympia/browse/templates/browse/personas/category_landing.html:21 src/olympia/browse/templates/browse/personas/category_landing.html:23
 #: src/olympia/browse/templates/browse/personas/category_landing.html:38 src/olympia/browse/templates/browse/personas/grid.html:7 src/olympia/browse/templates/browse/personas/grid.html:11
 #: src/olympia/browse/templates/browse/personas/mobile/base.html:7 src/olympia/browse/templates/browse/personas/mobile/category_landing.html:19 src/olympia/constants/base.py:180
-#: src/olympia/devhub/templates/devhub/personas/submit.html:13 src/olympia/editors/helpers.py:105 src/olympia/editors/templates/editors/base.html:26
+#: src/olympia/devhub/templates/devhub/personas/submit.html:13 src/olympia/editors/helpers.py:107 src/olympia/editors/templates/editors/base.html:26
 #: src/olympia/editors/templates/editors/performance.html:73 src/olympia/search/templates/search/personas.html:39 src/olympia/templates/menu_links.html:9
 msgid "Themes"
 msgstr ""
@@ -1326,7 +1327,7 @@ msgstr ""
 msgid "Highest Rated"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/mobile/home.html:74 src/olympia/amo/templates/amo/side_nav.html:5 src/olympia/amo/templates/amo/site_nav.html:27 src/olympia/amo/templates/amo/site_nav.html:57
+#: src/olympia/addons/templates/addons/mobile/home.html:74 src/olympia/amo/templates/amo/side_nav.html:5 src/olympia/amo/templates/amo/site_nav.html:27 src/olympia/amo/templates/amo/site_nav.html:55
 #: src/olympia/bandwagon/views.py:97 src/olympia/browse/views.py:57 src/olympia/browse/views.py:67 src/olympia/browse/templates/browse/personas/mobile/category_landing.html:65
 #: src/olympia/search/forms.py:15 src/olympia/search/forms.py:87
 msgid "Newest"
@@ -1340,90 +1341,90 @@ msgstr ""
 msgid "Theme Info &raquo;"
 msgstr ""
 
-#: src/olympia/amo/context_processors.py:39 src/olympia/devhub/templates/devhub/nav.html:43
+#: src/olympia/amo/context_processors.py:37 src/olympia/devhub/templates/devhub/nav.html:43
 msgid "Tools"
 msgstr ""
 
-#: src/olympia/amo/context_processors.py:48 src/olympia/discovery/templates/discovery/pane_account.html:8 src/olympia/users/templates/users/includes/navigation.html:2
+#: src/olympia/amo/context_processors.py:47 src/olympia/discovery/templates/discovery/pane_account.html:8 src/olympia/users/templates/users/includes/navigation.html:2
 msgid "My Profile"
 msgstr ""
 
-#: src/olympia/amo/context_processors.py:54 src/olympia/users/templates/users/edit.html:5 src/olympia/users/templates/users/includes/navigation.html:3
+#: src/olympia/amo/context_processors.py:53 src/olympia/users/templates/users/edit.html:5 src/olympia/users/templates/users/includes/navigation.html:3
 msgid "Account Settings"
 msgstr ""
 
-#: src/olympia/amo/context_processors.py:57 src/olympia/discovery/templates/discovery/pane_account.html:11 src/olympia/users/templates/users/profile.html:83
+#: src/olympia/amo/context_processors.py:56 src/olympia/discovery/templates/discovery/pane_account.html:11 src/olympia/users/templates/users/profile.html:83
 #: src/olympia/users/templates/users/includes/navigation.html:4
 msgid "My Collections"
 msgstr ""
 
-#: src/olympia/amo/context_processors.py:62 src/olympia/discovery/templates/discovery/pane_account.html:10 src/olympia/users/templates/users/includes/navigation.html:7
+#: src/olympia/amo/context_processors.py:61 src/olympia/discovery/templates/discovery/pane_account.html:10 src/olympia/users/templates/users/includes/navigation.html:7
 msgid "My Favorites"
 msgstr ""
 
-#: src/olympia/amo/context_processors.py:67 src/olympia/discovery/templates/discovery/pane_account.html:13 src/olympia/templates/impala/user_login.html:14
+#: src/olympia/amo/context_processors.py:66 src/olympia/discovery/templates/discovery/pane_account.html:13 src/olympia/templates/impala/user_login.html:14
 #: src/olympia/templates/mobile/header_auth.html:5
 msgid "Log out"
 msgstr ""
 
-#: src/olympia/amo/context_processors.py:72 src/olympia/devhub/templates/devhub/addons/dashboard.html:4
+#: src/olympia/amo/context_processors.py:71 src/olympia/devhub/templates/devhub/addons/dashboard.html:4
 msgid "Manage My Submissions"
 msgstr ""
 
-#: src/olympia/amo/context_processors.py:75 src/olympia/devhub/templates/devhub/nav.html:27 src/olympia/devhub/templates/devhub/addons/dashboard.html:25
+#: src/olympia/amo/context_processors.py:74 src/olympia/devhub/templates/devhub/nav.html:27 src/olympia/devhub/templates/devhub/addons/dashboard.html:25
 #: src/olympia/devhub/templates/devhub/addons/submit/base.html:4
 msgid "Submit a New Add-on"
 msgstr ""
 
-#: src/olympia/amo/context_processors.py:77 src/olympia/browse/templates/browse/personas/base.html:50 src/olympia/devhub/templates/devhub/index.html:24
+#: src/olympia/amo/context_processors.py:76 src/olympia/browse/templates/browse/personas/base.html:50 src/olympia/devhub/templates/devhub/index.html:24
 #: src/olympia/devhub/templates/devhub/addons/dashboard.html:29
 msgid "Submit a New Theme"
 msgstr ""
 
-#: src/olympia/amo/context_processors.py:79 src/olympia/amo/templates/amo/site_nav.html:87 src/olympia/devhub/helpers.py:36 src/olympia/devhub/helpers.py:68 src/olympia/devhub/helpers.py:102
+#: src/olympia/amo/context_processors.py:78 src/olympia/amo/templates/amo/site_nav.html:85 src/olympia/devhub/helpers.py:36 src/olympia/devhub/helpers.py:68 src/olympia/devhub/helpers.py:102
 #: src/olympia/templates/footer.html:6 src/olympia/templates/menu_links.html:14
 msgid "Developer Hub"
 msgstr ""
 
-#: src/olympia/amo/context_processors.py:83 src/olympia/devhub/views.py:1792
+#: src/olympia/amo/context_processors.py:81 src/olympia/devhub/views.py:1796
 msgid "Manage API Keys"
 msgstr ""
 
-#: src/olympia/amo/context_processors.py:88 src/olympia/editors/helpers.py:82 src/olympia/editors/helpers.py:102 src/olympia/editors/templates/editors/base.html:10
+#: src/olympia/amo/context_processors.py:86 src/olympia/editors/helpers.py:84 src/olympia/editors/helpers.py:104 src/olympia/editors/templates/editors/base.html:10
 msgid "Editor Tools"
 msgstr ""
 
-#: src/olympia/amo/context_processors.py:92
+#: src/olympia/amo/context_processors.py:90
 msgid "Admin Tools"
 msgstr ""
 
-#: src/olympia/amo/fields.py:15
+#: src/olympia/amo/fields.py:20
 msgid "Incorrect, please try again."
 msgstr ""
 
-#: src/olympia/amo/fields.py:16
+#: src/olympia/amo/fields.py:21
 msgid "Error verifying input, please try again."
 msgstr ""
 
-#: src/olympia/amo/fields.py:32
+#: src/olympia/amo/fields.py:37
 msgid "This must be a valid hex color code, such as #000000."
 msgstr ""
 
-#: src/olympia/amo/fields.py:58
+#: src/olympia/amo/fields.py:63
 msgid "Enter at least one value."
 msgstr ""
 
-#: src/olympia/amo/helpers.py:162 src/olympia/amo/templates/amo/site_nav.html:61 src/olympia/bandwagon/templates/bandwagon/add.html:9
+#: src/olympia/amo/helpers.py:162 src/olympia/amo/templates/amo/site_nav.html:59 src/olympia/bandwagon/templates/bandwagon/add.html:9
 #: src/olympia/bandwagon/templates/bandwagon/collection_detail.html:15 src/olympia/bandwagon/templates/bandwagon/delete.html:9 src/olympia/bandwagon/templates/bandwagon/edit.html:15
 #: src/olympia/bandwagon/templates/bandwagon/user_listing.html:18 src/olympia/bandwagon/templates/bandwagon/user_listing.html:21
 #: src/olympia/bandwagon/templates/bandwagon/impala/collection_listing.html:12 src/olympia/bandwagon/templates/bandwagon/impala/collection_listing.html:20
 #: src/olympia/bandwagon/templates/bandwagon/impala/collection_listing.html:24 src/olympia/bandwagon/templates/bandwagon/impala/collection_sidebar.html:3
 #: src/olympia/bandwagon/templates/bandwagon/includes/collection_sidebar.html:2 src/olympia/bandwagon/templates/bandwagon/mobile/collection_listing.html:3
-#: src/olympia/stats/templates/stats/stats.html:77 src/olympia/templates/menu_links.html:12
+#: src/olympia/stats/templates/stats/stats.html:33 src/olympia/templates/menu_links.html:12
 msgid "Collections"
 msgstr ""
 
-#: src/olympia/amo/helpers.py:171 src/olympia/amo/templates/amo/site_nav.html:85 src/olympia/browse/templates/browse/language_tools.html:3
+#: src/olympia/amo/helpers.py:171 src/olympia/amo/templates/amo/site_nav.html:83 src/olympia/browse/templates/browse/language_tools.html:3
 msgid "Dictionaries & Language Packs"
 msgstr ""
 
@@ -1575,8 +1576,8 @@ msgstr ""
 msgid "Comment on {addon} {version}."
 msgstr ""
 
-#: src/olympia/amo/log.py:236 src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:19 src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:47
-#: src/olympia/editors/helpers.py:511 src/olympia/editors/templates/editors/themes/history_table.html:11
+#: src/olympia/amo/log.py:236 src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:17 src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:45
+#: src/olympia/editors/helpers.py:584 src/olympia/editors/templates/editors/themes/history_table.html:11
 msgid "Comment"
 msgstr ""
 
@@ -1899,7 +1900,7 @@ msgstr ""
 #: src/olympia/amo/templates/amo/mobile/paginator.html:14 src/olympia/amo/templates/amo/mobile/paginator.html:16 src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:51
 #: src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:65 src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:78
 #: src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:91 src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:104
-#: src/olympia/discovery/templates/discovery/pane.html:45 src/olympia/discovery/templates/discovery/addons/detail.html:39 src/olympia/stats/templates/stats/stats.html:167
+#: src/olympia/discovery/templates/discovery/pane.html:45 src/olympia/discovery/templates/discovery/addons/detail.html:39 src/olympia/stats/templates/stats/stats.html:169
 msgid "Next"
 msgstr ""
 
@@ -1931,7 +1932,7 @@ msgid ""
 msgstr ""
 
 #: src/olympia/amo/templates/amo/side_nav.html:4 src/olympia/amo/templates/amo/side_nav.html:12 src/olympia/amo/templates/amo/site_nav.html:4 src/olympia/amo/templates/amo/site_nav.html:26
-#: src/olympia/browse/views.py:56 src/olympia/browse/views.py:66 src/olympia/browse/views.py:237 src/olympia/browse/views.py:282 src/olympia/search/forms.py:86
+#: src/olympia/browse/views.py:56 src/olympia/browse/views.py:66 src/olympia/browse/views.py:204 src/olympia/browse/views.py:249 src/olympia/search/forms.py:86
 msgid "Top Rated"
 msgstr ""
 
@@ -1945,38 +1946,38 @@ msgstr ""
 msgid "Extensions"
 msgstr ""
 
-#: src/olympia/amo/templates/amo/site_nav.html:45
+#: src/olympia/amo/templates/amo/site_nav.html:44
 msgid "Want more customization? Try <b>Complete Themes</b>"
 msgstr ""
 
-#: src/olympia/amo/templates/amo/site_nav.html:56 src/olympia/bandwagon/views.py:96
+#: src/olympia/amo/templates/amo/site_nav.html:54 src/olympia/bandwagon/views.py:96
 msgid "Most Followers"
 msgstr ""
 
-#: src/olympia/amo/templates/amo/site_nav.html:68 src/olympia/bandwagon/templates/bandwagon/impala/collection_sidebar.html:16
+#: src/olympia/amo/templates/amo/site_nav.html:66 src/olympia/bandwagon/templates/bandwagon/impala/collection_sidebar.html:16
 #: src/olympia/bandwagon/templates/bandwagon/includes/collection_sidebar.html:18
 msgid "Collections I've Made"
 msgstr ""
 
-#: src/olympia/amo/templates/amo/site_nav.html:70 src/olympia/bandwagon/templates/bandwagon/user_listing.html:4 src/olympia/bandwagon/templates/bandwagon/impala/collection_sidebar.html:13
+#: src/olympia/amo/templates/amo/site_nav.html:68 src/olympia/bandwagon/templates/bandwagon/user_listing.html:4 src/olympia/bandwagon/templates/bandwagon/impala/collection_sidebar.html:13
 #: src/olympia/bandwagon/templates/bandwagon/includes/collection_sidebar.html:15
 msgid "Collections I'm Following"
 msgstr ""
 
-#: src/olympia/amo/templates/amo/site_nav.html:73 src/olympia/bandwagon/templates/bandwagon/impala/collection_sidebar.html:18
-#: src/olympia/bandwagon/templates/bandwagon/includes/collection_sidebar.html:20 src/olympia/users/models.py:512
+#: src/olympia/amo/templates/amo/site_nav.html:71 src/olympia/bandwagon/templates/bandwagon/impala/collection_sidebar.html:18
+#: src/olympia/bandwagon/templates/bandwagon/includes/collection_sidebar.html:20 src/olympia/users/models.py:521
 msgid "My Favorite Add-ons"
 msgstr ""
 
-#: src/olympia/amo/templates/amo/site_nav.html:78
+#: src/olympia/amo/templates/amo/site_nav.html:76
 msgid "More&hellip;"
 msgstr ""
 
-#: src/olympia/amo/templates/amo/site_nav.html:82
+#: src/olympia/amo/templates/amo/site_nav.html:80
 msgid "Add-ons for Mobile"
 msgstr ""
 
-#: src/olympia/amo/templates/amo/site_nav.html:86 src/olympia/browse/feeds.py:207 src/olympia/browse/templates/browse/search_tools.html:3 src/olympia/constants/base.py:176
+#: src/olympia/amo/templates/amo/site_nav.html:84 src/olympia/browse/feeds.py:207 src/olympia/browse/templates/browse/search_tools.html:3 src/olympia/constants/base.py:176
 #: src/olympia/templates/menu_links.html:10
 msgid "Search Tools"
 msgstr ""
@@ -1992,7 +1993,7 @@ msgid "Jump to first page"
 msgstr ""
 
 #: src/olympia/amo/templates/amo/impala/paginator.html:22 src/olympia/amo/templates/amo/mobile/impala_paginator.html:12 src/olympia/discovery/templates/discovery/pane.html:44
-#: src/olympia/discovery/templates/discovery/addons/detail.html:38 src/olympia/stats/templates/stats/stats.html:164
+#: src/olympia/discovery/templates/discovery/addons/detail.html:38 src/olympia/stats/templates/stats/stats.html:166
 msgid "Previous"
 msgstr ""
 
@@ -2015,30 +2016,49 @@ msgid_plural "Page {n}"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/olympia/amo/templates/services/install.html:38
-#, python-format
-msgid "If you are not prompted to install %(addon_name)s in a moment, please <a href=\"%(addon_xpi)s\">click here</a>."
-msgstr ""
-
-#: src/olympia/amo/tests/test_messages.py:57 src/olympia/amo/tests/test_messages.py:58 src/olympia/reviews/forms.py:25 src/olympia/reviews/forms.py:50 src/olympia/reviews/templates/reviews/add.html:56
+#: src/olympia/amo/tests/test_messages.py:56 src/olympia/amo/tests/test_messages.py:57 src/olympia/reviews/forms.py:25 src/olympia/reviews/forms.py:50 src/olympia/reviews/templates/reviews/add.html:56
 #: src/olympia/reviews/templates/reviews/reply.html:30
 msgid "Title"
 msgstr ""
 
-#: src/olympia/amo/tests/test_messages.py:57 src/olympia/amo/tests/test_messages.py:58
+#: src/olympia/amo/tests/test_messages.py:56 src/olympia/amo/tests/test_messages.py:57
 msgid "Body"
 msgstr ""
 
-#: src/olympia/amo/tests/test_messages.py:59
+#: src/olympia/amo/tests/test_messages.py:58
 msgid "Another Title"
 msgstr ""
 
-#: src/olympia/amo/tests/test_messages.py:59
+#: src/olympia/amo/tests/test_messages.py:58
 msgid "Another Body"
 msgstr ""
 
-#: src/olympia/api/views.py:255
-msgid "Not implemented yet."
+#: src/olympia/api/authentication.py:76
+msgid "Signature has expired."
+msgstr ""
+
+#: src/olympia/api/authentication.py:79
+msgid "Error decoding signature."
+msgstr ""
+
+#: src/olympia/api/authentication.py:82
+msgid "Invalid JWT Token."
+msgstr ""
+
+#: src/olympia/api/authentication.py:130
+msgid "Invalid Authorization header. No credentials provided."
+msgstr ""
+
+#: src/olympia/api/authentication.py:133
+msgid "Invalid Authorization header. Credentials string should not contain spaces."
+msgstr ""
+
+#: src/olympia/api/fields.py:29
+msgid "The field must have a length of at least {num} characters."
+msgstr ""
+
+#: src/olympia/api/fields.py:31
+msgid "The language code {lang_code} is invalid."
 msgstr ""
 
 #: src/olympia/applications/views.py:39 src/olympia/applications/templates/applications/appversions.html:3
@@ -2057,7 +2077,7 @@ msgstr ""
 msgid "Add-ons submitted to Mozilla Add-ons must have a manifest file with at least one of the below applications supported. Only the versions listed below are allowed for these applications."
 msgstr ""
 
-#: src/olympia/applications/templates/applications/appversions.html:25
+#: src/olympia/applications/templates/applications/appversions.html:25 src/olympia/editors/helpers.py:361
 msgid "GUID"
 msgstr ""
 
@@ -2171,8 +2191,8 @@ msgstr ""
 msgid "Remove from favorites"
 msgstr ""
 
-#: src/olympia/bandwagon/views.py:98 src/olympia/bandwagon/views.py:191 src/olympia/browse/views.py:58 src/olympia/browse/views.py:69 src/olympia/browse/views.py:458 src/olympia/devhub/views.py:74
-#: src/olympia/devhub/views.py:82 src/olympia/devhub/templates/devhub/addons/edit/basic.html:20 src/olympia/editors/templates/editors/leaderboard.html:24
+#: src/olympia/bandwagon/views.py:98 src/olympia/bandwagon/views.py:191 src/olympia/browse/views.py:58 src/olympia/browse/views.py:69 src/olympia/browse/views.py:425 src/olympia/devhub/views.py:72
+#: src/olympia/devhub/views.py:80 src/olympia/devhub/templates/devhub/addons/edit/basic.html:20 src/olympia/editors/templates/editors/leaderboard.html:24
 #: src/olympia/editors/templates/editors/themes/queue_list.html:48 src/olympia/search/forms.py:17 src/olympia/search/forms.py:89 src/olympia/users/templates/users/vcard.html:5
 msgid "Name"
 msgstr ""
@@ -2181,7 +2201,7 @@ msgstr ""
 msgid "Recently Popular"
 msgstr ""
 
-#: src/olympia/bandwagon/views.py:189 src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:18
+#: src/olympia/bandwagon/views.py:189 src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:16
 msgid "Added"
 msgstr ""
 
@@ -2195,7 +2215,7 @@ msgstr ""
 
 #: src/olympia/bandwagon/views.py:316
 #, python-format
-msgid "Your new collection is shown below. You can <ahref=\"%(url)s\">edit additional settings</a> if you'dlike."
+msgid "Your new collection is shown below. You can <a href=\"%(url)s\">edit additional settings</a> if you'd like."
 msgstr ""
 
 #: src/olympia/bandwagon/views.py:322
@@ -2323,8 +2343,8 @@ msgid_plural "%(num)s Add-ons in this Collection"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/olympia/bandwagon/templates/bandwagon/collection_detail.html:125 src/olympia/compat/templates/compat/index.html:25 src/olympia/compat/templates/compat/reporter_detail.html:29
-#: src/olympia/files/templates/files/viewer.html:29 src/olympia/templates/amo_footer.html:17 src/olympia/templates/includes/lang_switcher.html:10
+#: src/olympia/bandwagon/templates/bandwagon/collection_detail.html:125 src/olympia/compat/templates/compat/reporter_detail.html:29 src/olympia/files/templates/files/viewer.html:29
+#: src/olympia/templates/amo_footer.html:17 src/olympia/templates/includes/lang_switcher.html:10
 msgid "Go"
 msgstr ""
 
@@ -2491,7 +2511,7 @@ msgid "Remove this user as a contributor"
 msgstr ""
 
 #: src/olympia/bandwagon/templates/bandwagon/edit_contributors.html:18 src/olympia/bandwagon/templates/bandwagon/edit_contributors.html:43
-#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:20 src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:48
+#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:18 src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:46
 #: src/olympia/devhub/templates/devhub/addons/ajax_compat_update.html:19
 msgid "Remove"
 msgstr ""
@@ -2539,7 +2559,7 @@ msgid "<b>Warning:</b> By changing the owner of this collection, you will no lon
 msgstr ""
 
 #: src/olympia/bandwagon/templates/bandwagon/edit_contributors.html:83 src/olympia/devhub/templates/devhub/addons/forms_shared/media.html:157
-#: src/olympia/devhub/templates/devhub/addons/submit/describe.html:69 src/olympia/devhub/templates/devhub/addons/submit/license.html:60 src/olympia/devhub/templates/devhub/addons/submit/upload.html:78
+#: src/olympia/devhub/templates/devhub/addons/submit/describe.html:69 src/olympia/devhub/templates/devhub/addons/submit/license.html:60 src/olympia/devhub/templates/devhub/addons/submit/upload.html:70
 #: src/olympia/devhub/templates/devhub/payments/tier.html:17 src/olympia/editors/templates/editors/themes/themes.html:111 src/olympia/editors/templates/editors/themes/themes.html:128
 #: src/olympia/editors/templates/editors/themes/themes.html:134 src/olympia/editors/templates/editors/themes/themes.html:141 src/olympia/users/templates/users/fxa_migration_prompt_content.html:10
 #: src/olympia/users/templates/users/login_form.html:42 src/olympia/users/templates/users/mobile/login.html:57
@@ -2622,31 +2642,31 @@ msgid "Add-ons in Your Collection"
 msgstr ""
 
 #: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:4
-msgid ""
-"To include an add-on in this collection, enter its name in the box below and hit enter.  You can also use the <strong>Add to Collection</strong> links throughout the site to include add-ons later."
+msgid "To include an add-on in this collection, enter its name in the box below and hit enter."
 msgstr ""
 
-#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:17 src/olympia/constants/base.py:400 src/olympia/devhub/templates/devhub/addons/activity.html:62
+#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:15 src/olympia/constants/base.py:400 src/olympia/devhub/templates/devhub/addons/activity.html:62
+#: src/olympia/editors/helpers.py:273 src/olympia/editors/helpers.py:360
 msgid "Add-on"
 msgstr ""
 
-#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:26
+#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:24
 msgid "Enter the name of the add-on to include"
 msgstr ""
 
-#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:28
+#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:26
 msgid "Add to Collection"
 msgstr ""
 
-#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:45 src/olympia/editors/helpers.py:936 src/olympia/editors/helpers.py:956
+#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:43 src/olympia/editors/helpers.py:1016 src/olympia/editors/helpers.py:1036
 msgid "Pending"
 msgstr ""
 
-#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:47
+#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:45
 msgid "Add a comment"
 msgstr ""
 
-#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:48
+#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:46
 msgid "Remove this add-on from the collection"
 msgstr ""
 
@@ -2753,12 +2773,12 @@ msgstr ""
 msgid "Most Users"
 msgstr ""
 
-#: src/olympia/browse/views.py:61 src/olympia/browse/views.py:72 src/olympia/browse/views.py:279 src/olympia/browse/templates/browse/personas/mobile/category_landing.html:63
+#: src/olympia/browse/views.py:61 src/olympia/browse/views.py:72 src/olympia/browse/views.py:246 src/olympia/browse/templates/browse/personas/mobile/category_landing.html:63
 #: src/olympia/discovery/templates/discovery/pane.html:67 src/olympia/search/forms.py:92
 msgid "Up & Coming"
 msgstr ""
 
-#: src/olympia/browse/views.py:460 src/olympia/devhub/views.py:76 src/olympia/devhub/views.py:83 src/olympia/discovery/templates/discovery/addons/detail.html:66
+#: src/olympia/browse/views.py:427 src/olympia/devhub/views.py:74 src/olympia/devhub/views.py:81 src/olympia/discovery/templates/discovery/addons/detail.html:66
 msgid "Created"
 msgstr ""
 
@@ -2946,8 +2966,8 @@ msgid_plural "See all %(cnt)s extensions in %(name)s &raquo;"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/olympia/browse/templates/browse/mobile/extensions.html:13 src/olympia/compat/templates/compat/index.html:82 src/olympia/devhub/templates/devhub/devhub_search.html:24
-#: src/olympia/devhub/templates/devhub/addons/activity.html:47 src/olympia/search/templates/search/no_results.html:4 src/olympia/search/templates/search/mobile/results.html:36
+#: src/olympia/browse/templates/browse/mobile/extensions.html:13 src/olympia/devhub/templates/devhub/devhub_search.html:24 src/olympia/devhub/templates/devhub/addons/activity.html:47
+#: src/olympia/search/templates/search/no_results.html:4 src/olympia/search/templates/search/mobile/results.html:36
 msgid "No results found."
 msgstr ""
 
@@ -3032,7 +3052,7 @@ msgstr ""
 msgid "All"
 msgstr ""
 
-#: src/olympia/compat/forms.py:22 src/olympia/search/views.py:525
+#: src/olympia/compat/forms.py:22 src/olympia/editors/templates/editors/base.html:69 src/olympia/search/views.py:518
 msgid "All Add-ons"
 msgstr ""
 
@@ -3042,53 +3062,6 @@ msgstr ""
 
 #: src/olympia/compat/forms.py:24
 msgid "Non-binary"
-msgstr ""
-
-#. Review points sources other than add-ons and themes.
-#: src/olympia/compat/views.py:87 src/olympia/constants/base.py:388 src/olympia/devhub/forms.py:162 src/olympia/editors/templates/editors/performance.html:75
-msgid "Other"
-msgstr ""
-
-#: src/olympia/compat/templates/compat/index.html:4
-msgid "Add-on Compatibility Report for {app} {version}"
-msgstr ""
-
-#: src/olympia/compat/templates/compat/index.html:11
-msgid "{app} {version} Compatibility"
-msgstr ""
-
-#: src/olympia/compat/templates/compat/index.html:17
-#, python-format
-msgid "Top 95%% compatible with previous version"
-msgstr ""
-
-#: src/olympia/compat/templates/compat/index.html:18
-#, python-format
-msgid "Top 95%% of all add-ons"
-msgstr ""
-
-#: src/olympia/compat/templates/compat/index.html:19
-msgid "All active add-ons"
-msgstr ""
-
-#: src/olympia/compat/templates/compat/index.html:23 src/olympia/constants/base.py:401
-msgid "App"
-msgstr ""
-
-#: src/olympia/compat/templates/compat/index.html:55
-msgid "Details for add-ons compatible with previous version:"
-msgstr ""
-
-#: src/olympia/compat/templates/compat/index.html:57
-msgid "Show all versions"
-msgstr ""
-
-#: src/olympia/compat/templates/compat/index.html:59
-msgid "Details for add-ons compatible with all versions:"
-msgstr ""
-
-#: src/olympia/compat/templates/compat/index.html:61
-msgid "Show previous version only"
 msgstr ""
 
 #: src/olympia/compat/templates/compat/reporter.html:3
@@ -3142,8 +3115,8 @@ msgstr ""
 msgid "Report Type"
 msgstr ""
 
-#: src/olympia/compat/templates/compat/reporter_detail.html:47 src/olympia/devhub/forms.py:784 src/olympia/devhub/templates/devhub/addons/ajax_compat_update.html:17 src/olympia/editors/forms.py:108
-#: src/olympia/zadmin/forms.py:45
+#: src/olympia/compat/templates/compat/reporter_detail.html:47 src/olympia/devhub/forms.py:785 src/olympia/devhub/templates/devhub/addons/ajax_compat_update.html:17 src/olympia/editors/forms.py:108
+#: src/olympia/editors/forms.py:248 src/olympia/zadmin/forms.py:45
 msgid "Application"
 msgstr ""
 
@@ -3231,7 +3204,8 @@ msgstr ""
 msgid "Preliminarily Reviewed and Awaiting Full Review"
 msgstr ""
 
-#: src/olympia/constants/base.py:33 src/olympia/editors/helpers.py:924 src/olympia/editors/templates/editors/themes/history_table.html:34
+#: src/olympia/constants/base.py:33 src/olympia/editors/forms.py:258 src/olympia/editors/helpers.py:73 src/olympia/editors/helpers.py:1004
+#: src/olympia/editors/templates/editors/themes/history_table.html:34
 msgid "Deleted"
 msgstr ""
 
@@ -3328,6 +3302,11 @@ msgstr ""
 msgid "Ask before users can download this add-on"
 msgstr ""
 
+#. Review points sources other than add-ons and themes.
+#: src/olympia/constants/base.py:388 src/olympia/devhub/forms.py:162 src/olympia/editors/templates/editors/performance.html:75
+msgid "Other"
+msgstr ""
+
 #: src/olympia/constants/base.py:389
 msgid "Exception"
 msgstr ""
@@ -3338,6 +3317,10 @@ msgstr ""
 
 #: src/olympia/constants/base.py:391
 msgid "Change"
+msgstr ""
+
+#: src/olympia/constants/base.py:401
+msgid "App"
 msgstr ""
 
 #: src/olympia/constants/base.py:402
@@ -3488,7 +3471,7 @@ msgstr ""
 msgid "Duplicate"
 msgstr ""
 
-#: src/olympia/constants/editors.py:17 src/olympia/editors/helpers.py:502 src/olympia/editors/templates/editors/themes/queue.html:71 src/olympia/editors/templates/editors/themes/themes.html:94
+#: src/olympia/constants/editors.py:17 src/olympia/editors/helpers.py:575 src/olympia/editors/templates/editors/themes/queue.html:71 src/olympia/editors/templates/editors/themes/themes.html:94
 msgid "Reject"
 msgstr ""
 
@@ -3588,7 +3571,7 @@ msgstr ""
 msgid "Android"
 msgstr ""
 
-#: src/olympia/core/apps.py:19
+#: src/olympia/core/apps.py:21
 msgid "Core"
 msgstr ""
 
@@ -3722,7 +3705,7 @@ msgid "Submit my add-on for manual review."
 msgstr ""
 
 #: src/olympia/devhub/forms.py:537
-msgid "Do not list my add-on on this site (beta)"
+msgid "Do not list my add-on on this site"
 msgstr ""
 
 #: src/olympia/devhub/forms.py:538
@@ -3755,46 +3738,46 @@ msgstr ""
 
 #: src/olympia/devhub/forms.py:592
 #, python-format
-msgid "Version %s already exists"
+msgid "Version %s already exists, or was uploaded before."
 msgstr ""
 
-#: src/olympia/devhub/forms.py:604
+#: src/olympia/devhub/forms.py:605
 msgid "Select a valid choice. That choice is not one of the available choices."
 msgstr ""
 
-#: src/olympia/devhub/forms.py:610
+#: src/olympia/devhub/forms.py:611
 msgid "A file with a version ending with a|alpha|b|beta and an optional number is detected as beta."
 msgstr ""
 
-#: src/olympia/devhub/forms.py:633
+#: src/olympia/devhub/forms.py:634
 msgid "You cannot upload any more files for this version."
 msgstr ""
 
-#: src/olympia/devhub/forms.py:639
+#: src/olympia/devhub/forms.py:640
 msgid "Version doesn't match"
 msgstr ""
 
-#: src/olympia/devhub/forms.py:668
+#: src/olympia/devhub/forms.py:669
 msgid "You cannot delete a file once the review process has started.  You must delete the whole version."
 msgstr ""
 
-#: src/olympia/devhub/forms.py:688
+#: src/olympia/devhub/forms.py:689
 msgid "The platform All cannot be combined with specific platforms."
 msgstr ""
 
-#: src/olympia/devhub/forms.py:693
+#: src/olympia/devhub/forms.py:694
 msgid "A platform can only be chosen once."
 msgstr ""
 
-#: src/olympia/devhub/forms.py:706
+#: src/olympia/devhub/forms.py:707
 msgid "A review type must be selected."
 msgstr ""
 
-#: src/olympia/devhub/forms.py:788 src/olympia/editors/forms.py:114 src/olympia/zadmin/forms.py:49 src/olympia/zadmin/forms.py:52
+#: src/olympia/devhub/forms.py:789 src/olympia/editors/forms.py:114 src/olympia/editors/forms.py:254 src/olympia/zadmin/forms.py:49 src/olympia/zadmin/forms.py:52
 msgid "Select an application first"
 msgstr ""
 
-#: src/olympia/devhub/forms.py:840
+#: src/olympia/devhub/forms.py:841
 msgid "There cannot be more than 3 required add-ons."
 msgstr ""
 
@@ -3828,76 +3811,76 @@ msgstr[1] ""
 msgid "Review"
 msgstr ""
 
-#: src/olympia/devhub/tasks.py:551
+#: src/olympia/devhub/tasks.py:583
 #, python-format
 msgid "%s responded with %s (%s)."
 msgstr ""
 
-#: src/olympia/devhub/tasks.py:555
+#: src/olympia/devhub/tasks.py:587
 #, python-format
 msgid "Connection to \"%s\" timed out."
 msgstr ""
 
-#: src/olympia/devhub/tasks.py:557
+#: src/olympia/devhub/tasks.py:589
 #, python-format
 msgid "Could not contact host at \"%s\"."
 msgstr ""
 
-#: src/olympia/devhub/utils.py:104
+#: src/olympia/devhub/utils.py:105
 #, python-format
 msgid "Validation generated too many errors/warnings so %s messages were truncated. After addressing the visible messages, you'll be able to see the others."
 msgstr ""
 
-#: src/olympia/devhub/views.py:183
+#: src/olympia/devhub/views.py:181
 msgid "All My Add-ons"
 msgstr ""
 
-#: src/olympia/devhub/views.py:210
+#: src/olympia/devhub/views.py:208
 msgid "All Activity"
 msgstr ""
 
-#: src/olympia/devhub/views.py:211
+#: src/olympia/devhub/views.py:209
 msgid "Add-on Updates"
 msgstr ""
 
-#: src/olympia/devhub/views.py:212
+#: src/olympia/devhub/views.py:210
 msgid "Add-on Status"
 msgstr ""
 
-#: src/olympia/devhub/views.py:213
+#: src/olympia/devhub/views.py:211
 msgid "User Collections"
 msgstr ""
 
-#: src/olympia/devhub/views.py:214 src/olympia/devhub/templates/devhub/docs/policies-maintenance.html:68 src/olympia/pages/templates/pages/dev_faq.html:38
+#: src/olympia/devhub/views.py:212 src/olympia/devhub/templates/devhub/docs/policies-maintenance.html:68 src/olympia/pages/templates/pages/dev_faq.html:38
 #: src/olympia/pages/templates/pages/dev_faq.html:484
 msgid "User Reviews"
 msgstr ""
 
-#: src/olympia/devhub/views.py:327 src/olympia/devhub/views.py:331 src/olympia/devhub/views.py:484 src/olympia/devhub/views.py:513 src/olympia/devhub/views.py:564 src/olympia/devhub/views.py:1150
+#: src/olympia/devhub/views.py:325 src/olympia/devhub/views.py:329 src/olympia/devhub/views.py:484 src/olympia/devhub/views.py:513 src/olympia/devhub/views.py:564 src/olympia/devhub/views.py:1156
 msgid "Changes successfully saved."
 msgstr ""
 
-#: src/olympia/devhub/views.py:334 src/olympia/devhub/views.py:1631
+#: src/olympia/devhub/views.py:332 src/olympia/devhub/views.py:1637
 msgid "Please check the form for errors."
 msgstr ""
 
-#: src/olympia/devhub/views.py:346
+#: src/olympia/devhub/views.py:344
 msgid "Add-on cannot be deleted. Disable this add-on instead."
 msgstr ""
 
-#: src/olympia/devhub/views.py:356
+#: src/olympia/devhub/views.py:354
 msgid "Theme deleted."
 msgstr ""
 
-#: src/olympia/devhub/views.py:356
+#: src/olympia/devhub/views.py:354
 msgid "Add-on deleted."
 msgstr ""
 
-#: src/olympia/devhub/views.py:362
+#: src/olympia/devhub/views.py:360
 msgid "URL name was incorrect. Theme was not deleted."
 msgstr ""
 
-#: src/olympia/devhub/views.py:367
+#: src/olympia/devhub/views.py:365
 msgid "URL name was incorrect. Add-on was not deleted."
 msgstr ""
 
@@ -3925,7 +3908,7 @@ msgstr ""
 msgid "Check Add-on Compatibility"
 msgstr ""
 
-#: src/olympia/devhub/views.py:808 src/olympia/signing/views.py:90
+#: src/olympia/devhub/views.py:808 src/olympia/signing/views.py:95
 msgid "You cannot submit this type of add-on"
 msgstr ""
 
@@ -3955,33 +3938,33 @@ msgstr ""
 msgid "There was an error uploading your preview."
 msgstr ""
 
-#: src/olympia/devhub/views.py:1189
+#: src/olympia/devhub/views.py:1195
 #, python-format
 msgid "Version %s disabled."
 msgstr ""
 
-#: src/olympia/devhub/views.py:1193
+#: src/olympia/devhub/views.py:1199
 #, python-format
 msgid "Version %s deleted."
 msgstr ""
 
-#: src/olympia/devhub/views.py:1203
+#: src/olympia/devhub/views.py:1209
 msgid "This upload has failed validation, and may lack complete validation results. Please take due care when reviewing it."
 msgstr ""
 
-#: src/olympia/devhub/views.py:1677
+#: src/olympia/devhub/views.py:1683
 msgid "Preliminary Review Requested."
 msgstr ""
 
-#: src/olympia/devhub/views.py:1678
+#: src/olympia/devhub/views.py:1684
 msgid "Full Review Requested."
 msgstr ""
 
-#: src/olympia/devhub/views.py:1779
+#: src/olympia/devhub/views.py:1783
 msgid "Your old credentials were revoked and are no longer valid. Be sure to update all API clients with the new credentials."
 msgstr ""
 
-#: src/olympia/devhub/views.py:1797
+#: src/olympia/devhub/views.py:1801
 msgid "New API key created"
 msgstr ""
 
@@ -4011,7 +3994,7 @@ msgstr ""
 msgid "{0} :: Search"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/devhub_search.html:6 src/olympia/devhub/templates/devhub/search.html:8 src/olympia/editors/forms.py:435 src/olympia/editors/forms.py:437
+#: src/olympia/devhub/templates/devhub/devhub_search.html:6 src/olympia/devhub/templates/devhub/search.html:8 src/olympia/editors/forms.py:534 src/olympia/editors/forms.py:536
 #: src/olympia/editors/templates/editors/queue.html:27 src/olympia/editors/templates/editors/themes/queue_list.html:14 src/olympia/search/templates/search/collections.html:17
 #: src/olympia/search/templates/search/personas.html:18 src/olympia/search/templates/search/results.html:18 src/olympia/search/templates/search/mobile/results.html:8
 #: src/olympia/templates/search.html:14 src/olympia/templates/impala/search.html:18
@@ -4071,12 +4054,12 @@ msgstr ""
 msgid "Start Making Add-ons"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/index.html:86 src/olympia/devhub/templates/devhub/addons/listing/items.html:25 src/olympia/devhub/templates/devhub/includes/addon_details.html:15
+#: src/olympia/devhub/templates/devhub/index.html:86 src/olympia/devhub/templates/devhub/addons/listing/items.html:25 src/olympia/devhub/templates/devhub/includes/addon_details.html:20
 #: src/olympia/devhub/templates/devhub/personas/edit.html:43
 msgid "Status:"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/index.html:90 src/olympia/devhub/templates/devhub/includes/addon_details.html:100
+#: src/olympia/devhub/templates/devhub/index.html:90 src/olympia/devhub/templates/devhub/includes/addon_details.html:87
 msgid "Visibility:"
 msgstr ""
 
@@ -4084,11 +4067,11 @@ msgstr ""
 msgid "Latest Version:"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/index.html:109 src/olympia/devhub/templates/devhub/includes/addon_details.html:145 src/olympia/devhub/templates/devhub/personas/edit.html:49
+#: src/olympia/devhub/templates/devhub/index.html:109 src/olympia/devhub/templates/devhub/includes/addon_details.html:131 src/olympia/devhub/templates/devhub/personas/edit.html:49
 msgid "Queue Position:"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/index.html:110 src/olympia/devhub/templates/devhub/includes/addon_details.html:146 src/olympia/devhub/templates/devhub/personas/edit.html:50
+#: src/olympia/devhub/templates/devhub/index.html:110 src/olympia/devhub/templates/devhub/includes/addon_details.html:132 src/olympia/devhub/templates/devhub/personas/edit.html:50
 #, python-format
 msgid "%(position)s of %(total)s"
 msgstr ""
@@ -4190,16 +4173,6 @@ msgstr ""
 msgid "Do you want your add-on to be distributed on this site?"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/validate_addon.html:49 src/olympia/devhub/templates/devhub/addons/submit/upload.html:30 src/olympia/devhub/templates/devhub/versions/add_file_modal.html:14
-#: src/olympia/devhub/templates/devhub/versions/add_file_modal.html:53 src/olympia/devhub/templates/devhub/versions/list.html:298
-msgid "Warning:"
-msgstr ""
-
-#: src/olympia/devhub/templates/devhub/validate_addon.html:50 src/olympia/devhub/templates/devhub/addons/submit/upload.html:31
-#, python-format
-msgid "Submission of unlisted add-ons for signing is currently in an open beta. Please <a href=\"%(url)s\" target=\"_blank\">report any bugs</a> that you encounter."
-msgstr ""
-
 #. first parameter is a filename like lorem-ipsum-1.0.2.xpi
 #: src/olympia/devhub/templates/devhub/validation.html:5
 msgid "Validation Results for {0}"
@@ -4274,7 +4247,7 @@ msgstr ""
 msgid "Update Compatibility"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/addons/ajax_compat_update.html:4
+#: src/olympia/devhub/templates/devhub/addons/ajax_compat_update.html:4 src/olympia/devhub/templates/devhub/versions/edit.html:45
 msgid "Adjusting application information here will allow users to install your add-on even if the install manifest in the package indicates that the add-on is incompatible."
 msgstr ""
 
@@ -4286,9 +4259,9 @@ msgstr ""
 msgid "Add Another Application&hellip;"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/addons/ajax_compat_update.html:38 src/olympia/devhub/templates/devhub/addons/owner.html:86 src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:46
-#: src/olympia/devhub/templates/devhub/versions/list.html:351 src/olympia/devhub/templates/devhub/versions/list.html:353 src/olympia/templates/impala/base.html:132
-#: src/olympia/templates/impala/base.html:143 src/olympia/templates/impala/base.html:161 src/olympia/templates/impala/base.html:171
+#: src/olympia/devhub/templates/devhub/addons/ajax_compat_update.html:38 src/olympia/devhub/templates/devhub/addons/owner.html:86 src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:45
+#: src/olympia/devhub/templates/devhub/versions/list.html:349 src/olympia/devhub/templates/devhub/versions/list.html:351 src/olympia/templates/impala/base.html:129
+#: src/olympia/templates/impala/base.html:140 src/olympia/templates/impala/base.html:158 src/olympia/templates/impala/base.html:168
 msgid "Close"
 msgstr ""
 
@@ -4322,7 +4295,7 @@ msgstr ""
 msgid "Manage Authors & License"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/addons/owner.html:29 src/olympia/editors/templates/editors/review.html:270
+#: src/olympia/devhub/templates/devhub/addons/owner.html:29 src/olympia/editors/helpers.py:362 src/olympia/editors/templates/editors/review.html:270
 msgid "Authors"
 msgstr ""
 
@@ -4391,17 +4364,11 @@ msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/basic.html:52
 msgid ""
-"A short explanation of your add-on's basic\n"
-"                          functionality that is displayed in search and browse\n"
-"                          listings, as well as at the top of your add-on's\n"
-"                          details page. It is only relevant for listed add-ons."
+"A short explanation of your add-on's basic functionality that is displayed in search and browse listings, as well as at the top of your add-on's details page. It is only relevant for listed add-ons."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/basic.html:73
-msgid ""
-"Categories are the primary way users browse through add-ons.\n"
-"                        Choose any that fit your add-on's functionality for the most\n"
-"                        exposure. It is only relevant for listed add-ons."
+msgid "Categories are the primary way users browse through add-ons. Choose any that fit your add-on's functionality for the most exposure. It is only relevant for listed add-ons."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/basic.html:90
@@ -4411,11 +4378,7 @@ msgid ""
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/basic.html:119
-msgid ""
-"Tags help users find your add-on and should be short\n"
-"                        descriptors such as tabs, toolbar, or twitter.  You\n"
-"                        may have a maximum of {0} tags. It is only relevant\n"
-"                        for listed add-ons."
+msgid "Tags help users find your add-on and should be short descriptors such as tabs, toolbar, or twitter. You may have a maximum of {0} tags. It is only relevant for listed add-ons."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/basic.html:129 src/olympia/devhub/templates/devhub/personas/edit.html:97 src/olympia/devhub/templates/devhub/personas/submit.html:46
@@ -4443,11 +4406,7 @@ msgid "Add-on Details for {0}"
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/details.html:22
-msgid ""
-"A longer explanation of features,\n"
-"                          functionality, and other relevant information. This\n"
-"                          field is only displayed on the add-on's details\n"
-"                          page. It is only relevant for listed add-ons."
+msgid "A longer explanation of features, functionality, and other relevant information. This field is only displayed on the add-on's details page. It is only relevant for listed add-ons."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/details.html:44 src/olympia/translations/templates/translations/trans-menu.html:13
@@ -4455,10 +4414,7 @@ msgid "Default Locale"
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/details.html:45
-msgid ""
-"Information about your add-on is displayed in this locale\n"
-"                        unless you override it with a locale-specific translation.\n"
-"                        It is only relevant for listed add-ons."
+msgid "Information about your add-on is displayed in this locale unless you override it with a locale-specific translation. It is only relevant for listed add-ons."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/details.html:61 src/olympia/users/forms.py:311 src/olympia/users/templates/users/edit.html:122 src/olympia/users/templates/users/register.html:57
@@ -4468,10 +4424,8 @@ msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/details.html:63
 msgid ""
-"If your add-on has another homepage, enter its\n"
-"                          address here. If your website is localized into other\n"
-"                          languages multiple translations of this field can be\n"
-"                          added. It is only relevant for listed add-ons."
+"If your add-on has another homepage, enter its address here. If your website is localized into other languages multiple translations of this field can be added. It is only relevant for listed add-"
+"ons."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/media.html:3
@@ -4489,19 +4443,14 @@ msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/support.html:22
 msgid ""
-"If you wish to display an e-mail address for support\n"
-"                          inquiries, enter it here. If you have different\n"
-"                          addresses for each language multiple translations of\n"
-"                          this field can be added. It is only relevant for\n"
-"                          listed add-ons."
+"If you wish to display an e-mail address for support inquiries, enter it here. If you have different addresses for each language multiple translations of this field can be added. It is only "
+"relevant for listed add-ons."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/support.html:45
 msgid ""
-"If your add-on has a support website or forum, enter\n"
-"                          its address here. If your website is localized into\n"
-"                          other languages, multiple translations of this field can\n"
-"                          be added. It is only relevant for listed add-ons."
+"If your add-on has a support website or forum, enter its address here. If your website is localized into other languages, multiple translations of this field can be added. It is only relevant for "
+"listed add-ons."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:6
@@ -4515,11 +4464,8 @@ msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:23
 msgid ""
-"Any information end users may want to know that isn't\n"
-"                          necessarily applicable to the add-on summary or description.\n"
-"                          Common uses include listing known major bugs, information on\n"
-"                          how to report bugs, anticipated release date of a new version,\n"
-"                          etc. It is only relevant for listed add-ons."
+"Any information end users may want to know that isn't necessarily applicable to the add-on summary or description. Common uses include listing known major bugs, information on how to report bugs, "
+"anticipated release date of a new version, etc. It is only relevant for listed add-ons."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:46
@@ -4531,9 +4477,7 @@ msgid "Add-on Flags"
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:69
-msgid ""
-"These flags are used to classify add-ons. It is only\n"
-"                        relevant for listed add-ons."
+msgid "These flags are used to classify add-ons. It is only relevant for listed add-ons."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:74
@@ -4549,9 +4493,7 @@ msgid "View Source?"
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:90
-msgid ""
-"Whether the source of your add-on can be displayed in our\n"
-"                        online viewer. It is only relevant for listed add-ons."
+msgid "Whether the source of your add-on can be displayed in our online viewer. It is only relevant for listed add-ons."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:94
@@ -4567,10 +4509,7 @@ msgid "Public Stats?"
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:102
-msgid ""
-"Whether the download and usage stats of your add-on can\n"
-"                        be displayed in our online viewer.\n"
-"                        It is only relevant for listed add-ons."
+msgid "Whether the download and usage stats of your add-on can be displayed in our online viewer. It is only relevant for listed add-ons."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:107
@@ -4586,10 +4525,7 @@ msgid "Upgrade SDK?"
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:116
-msgid ""
-"If selected, we will try to automatically upgrade your\n"
-"                        add-on when a new version of the SDK is released.\n"
-"                        It is only relevant for listed add-ons."
+msgid "If selected, we will try to automatically upgrade your add-on when a new version of the SDK is released. It is only relevant for listed add-ons."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:121
@@ -4640,10 +4576,8 @@ msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/forms_shared/media.html:16
 msgid ""
-"Upload an icon for your add-on or choose from one of ours. The\n"
-"                      icon is displayed nearly everywhere your add-on is. Uploaded images\n"
-"                      must be one of the following image types: .png, .jpg.\n"
-"                      It is only relevant for listed add-ons."
+"Upload an icon for your add-on or choose from one of ours. The icon is displayed nearly everywhere your add-on is. Uploaded images must be one of the following image types: .png, .jpg. It is only "
+"relevant for listed add-ons."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/forms_shared/media.html:25
@@ -4656,9 +4590,7 @@ msgid "32x32px"
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/forms_shared/media.html:39
-msgid ""
-"Used in listings of add-ons, like search results\n"
-"                            and featured add-ons."
+msgid "Used in listings of add-ons, like search results and featured add-ons."
 msgstr ""
 
 #. The size of the icon
@@ -4753,16 +4685,14 @@ msgid "Deleting your add-on will permanently remove it from the site and prevent
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:24
-msgid ""
-"Enter the following text confirm your decision:\n"
-"           {slug}"
+msgid "Enter the following text confirm your decision: {slug}"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:34
+#: src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:33
 msgid "Please tell us why you are deleting your theme:"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:36
+#: src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:35
 msgid "Please tell us why you are deleting your add-on:"
 msgstr ""
 
@@ -4799,8 +4729,8 @@ msgstr ""
 msgid "Daily statistics on downloads and users."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/addons/listing/item_actions.html:45 src/olympia/stats/templates/stats/stats.html:75 src/olympia/stats/templates/stats/stats.html:79
-#: src/olympia/stats/templates/stats/stats.html:81
+#: src/olympia/devhub/templates/devhub/addons/listing/item_actions.html:45 src/olympia/stats/templates/stats/stats.html:31 src/olympia/stats/templates/stats/stats.html:35
+#: src/olympia/stats/templates/stats/stats.html:37
 msgid "Statistics"
 msgstr ""
 
@@ -4919,10 +4849,7 @@ msgid "Your add-on has been submitted to the Full Review queue."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/submit/done.html:18
-msgid ""
-"You'll receive an email once it has been reviewed by an editor. In\n"
-"          the meantime, you and your friends can install it directly from its\n"
-"          details page:"
+msgid "You'll receive an email once it has been reviewed by an editor. In the meantime, you and your friends can install it directly from its details page:"
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/submit/done.html:27 src/olympia/devhub/templates/devhub/addons/submit/done.html:77 src/olympia/devhub/templates/devhub/personas/submit_done.html:16
@@ -5128,11 +5055,11 @@ msgstr ""
 msgid "Use the fields below to upload your add-on package and select any platform restrictions. After upload, a series of automated validation tests will be run on your file."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/addons/submit/upload.html:59 src/olympia/devhub/templates/devhub/versions/add_file_modal.html:39
+#: src/olympia/devhub/templates/devhub/addons/submit/upload.html:51 src/olympia/devhub/templates/devhub/versions/add_file_modal.html:28
 msgid "Which platforms is this file compatible with?"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/addons/submit/upload.html:67 src/olympia/devhub/templates/devhub/versions/add_file_modal.html:65
+#: src/olympia/devhub/templates/devhub/addons/submit/upload.html:59 src/olympia/devhub/templates/devhub/versions/add_file_modal.html:45
 msgid "Administrative overrides"
 msgstr ""
 
@@ -5242,8 +5169,8 @@ msgstr ""
 
 #: src/olympia/devhub/templates/devhub/docs/policies-contact.html:44
 msgid ""
-"If you've found a problem with the site, we'd love to fix it. Please <a href=\"https://github.com/mozilla/olympia/issues\">file a bug report</a> in GitHub, including the location of the problem and "
-"how you encountered it."
+"If you've found a problem with the site, we'd love to fix it. Please <a href=\"https://github.com/mozilla/addons/issues/new\">file a bug report</a> in GitHub, including the location of the problem "
+"and how you encountered it."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/docs/policies-maintenance.html:3 src/olympia/devhub/templates/devhub/docs/policies-maintenance.html:7
@@ -5810,7 +5737,7 @@ msgstr ""
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:282
 msgid ""
-"Add-ons that store or otherwise handle browsing data must support <a href=\"https://developer.mozilla.org/En/Supporting_private_browsing_mode\">Private Browsing Mode</a>.  During a Private Browsing "
+"Add-ons that store or otherwise handle browsing data must support <a href=\"https://developer.mozilla.org/En/Supporting_private_browsing_mode\">Private Browsing Mode</a>. During a Private Browsing "
 "session, no browsing data can be written to disk, and all of this data must be cleared when Firefox quits or the Private Browsing session ends."
 msgstr ""
 
@@ -5975,129 +5902,95 @@ msgstr ""
 msgid "How to get in touch with us regarding these policies or your add-on."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:6
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:10
 msgid "You have disabled this add-on"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:20
-msgid ""
-"Your add-on's listing is disabled and is not showing\n"
-"                             anywhere in our gallery or update service."
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:24
+msgid "Your add-on's listing is disabled and is not showing anywhere in our gallery or update service."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:25
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:27
 msgid "Please complete your add-on."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:29
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:30
 msgid "You will receive an email when the review is complete."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:34
-msgid ""
-"You will receive an email when the review is complete. Until\n"
-"                             then, your add-on is not listed in our gallery but can be\n"
-"                             accessed directly from its details page."
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:33
+msgid "You will receive an email when the review is complete. Until then, your add-on is not listed in our gallery but can be accessed directly from its details page."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:38 src/olympia/devhub/templates/devhub/includes/addon_details.html:48
-msgid ""
-"You will receive an email when the review is\n"
-"                             complete and your add-on is signed."
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:37 src/olympia/devhub/templates/devhub/includes/addon_details.html:45
+msgid "You will receive an email when the review is complete and your add-on is signed."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:44
-msgid ""
-"You will receive an email when the review is complete. Until\n"
-"                             then, your add-on is not listed in our gallery but can be\n"
-"                             accessed directly from its details page. "
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:41
+msgid "You will receive an email when the review is complete. Until then, your add-on is not listed in our gallery but can be accessed directly from its details page. "
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:54
-msgid ""
-"Your add-on is displayed in our gallery and users are\n"
-"                             receiving automatic updates."
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:49
+msgid "Your add-on is displayed in our gallery and users are receiving automatic updates."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:57
-msgid ""
-"Your add-on has been signed and can be bundled with an\n"
-"                             application installer."
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:52
+msgid "Your add-on has been signed and can be bundled with an application installer."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:63
-msgid ""
-"Your add-on was disabled by a site administrator and is no\n"
-"                             longer shown in our gallery. If you have any questions,\n"
-"                             please email amo-admins@mozilla.org."
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:56
+msgid "Your add-on was disabled by a site administrator and is no longer shown in our gallery. If you have any questions, please email amo-admins@mozilla.org."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:70
-msgid ""
-"Your add-on is displayed in our gallery as experimental\n"
-"                             and users are receiving automatic updates. Some features\n"
-"                             are unavailable to your add-on."
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:62
+msgid "Your add-on is displayed in our gallery as experimental and users are receiving automatic updates. Some features are unavailable to your add-on."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:74
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:66
 msgid "Your add-on has been signed."
 msgstr ""
 
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:69
+msgid ""
+"You will receive an email when the full review is complete. Until then, your add-on is displayed in our gallery as experimental and users are receiving automatic updates. Some features are "
+"unavailable to your add-on."
+msgstr ""
+
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:74
+msgid "You will receive an email when the full review is complete, making you able to bundle your add-on with an application installer."
+msgstr ""
+
 #: src/olympia/devhub/templates/devhub/includes/addon_details.html:79
-msgid ""
-"You will receive an email when the full review is complete.\n"
-"                             Until then, your add-on is displayed in our gallery as\n"
-"                             experimental and users are receiving automatic updates.\n"
-"                             Some features are unavailable to your add-on."
+msgid "All add-ons hosted in our gallery must now be reviewed by an editor. If you wish to continue hosting your add-on, please click to select a review process."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:84
-msgid ""
-"You will receive an email when the full review is\n"
-"                             complete, making you able to bundle your add-on with an\n"
-"                             application installer."
-msgstr ""
-
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:91
-msgid ""
-"All add-ons hosted in our gallery must now be reviewed by an\n"
-"                             editor. If you wish to continue hosting your add-on, please\n"
-"                             click to select a review process."
-msgstr ""
-
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:113
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:100
 msgid "Current Version:"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:115
-msgid ""
-"This is the version of your add-on that will\n"
-"                                           be installed if someone clicks the Install\n"
-"                                           button on addons.mozilla.org. It is only\n"
-"                                           relevant for listed add-ons."
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:102
+msgid "This is the version of your add-on that will be installed if someone clicks the Install button on addons.mozilla.org. It is only relevant for listed add-ons."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:123
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:110
 msgid "Created:"
 msgstr ""
 
 #. {0} is a date. dennis-ignore: E201
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:125 src/olympia/devhub/templates/devhub/includes/addon_details.html:131
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:112 src/olympia/devhub/templates/devhub/includes/addon_details.html:118
 #, python-format
 msgid "%%b %%e, %%Y"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:136
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:123
 msgid "Next Version:"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:138
-msgid ""
-"This is the newest uploaded version, however\n"
-"                                           it isn’t live on the site yet."
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:125
+msgid "This is the newest uploaded version, however it isn’t live on the site yet."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:144 src/olympia/devhub/templates/devhub/versions/list.html:30
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:130 src/olympia/devhub/templates/devhub/versions/list.html:30
 msgid "Queues are not reviewed strictly in order"
 msgstr ""
 
@@ -6165,9 +6058,7 @@ msgid "View the blog &#9658;"
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/includes/license_form.html:6
-msgid ""
-"Please choose a license appropriate for the rights you grant on your source code.\n"
-"                  It is only relevant for listed add-ons."
+msgid "Please choose a license appropriate for the rights you grant on your source code. It is only relevant for listed add-ons."
 msgstr ""
 
 #. {0} is a list of HTML tags.
@@ -6194,14 +6085,11 @@ msgstr[1] ""
 #: src/olympia/devhub/templates/devhub/includes/policy_form.html:4
 msgid ""
 "Users will be required to accept the following End-User License Agreement (EULA) prior to installing your add-on. The presence of a EULA significantly affects the number of downloads an add-on "
-"receives. Please note that a EULA is not the same as a code license, such as the GPL or MPL.\n"
-"                It is only relevant for listed add-ons."
+"receives. Please note that a EULA is not the same as a code license, such as the GPL or MPL.It is only relevant for listed add-ons."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/policy_form.html:21
-msgid ""
-"If your add-on transmits any data from the user's computer, a privacy policy is required that explains what data is sent and how it is used.\n"
-"                It is only relevant for listed add-ons."
+#: src/olympia/devhub/templates/devhub/includes/policy_form.html:24
+msgid "If your add-on transmits any data from the user's computer, a privacy policy is required that explains what data is sent and how it is used. It is only relevant for listed add-ons."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/includes/source_form_field.html:2
@@ -6369,12 +6257,8 @@ msgstr ""
 msgid "Add some tags to describe your Theme."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/personas/edit.html:106
-msgid ""
-"A short explanation of your theme's\n"
-"                                basic functionality that is displayed in\n"
-"                                search and browse listings, as well as at\n"
-"                                the top of your theme's details page."
+#: src/olympia/devhub/templates/devhub/personas/edit.html:106 src/olympia/devhub/templates/devhub/personas/submit.html:54
+msgid "A short explanation of your theme's basic functionality that is displayed in search and browse listings, as well as at the top of your theme's details page."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/personas/edit.html:122 src/olympia/devhub/templates/devhub/personas/submit.html:68
@@ -6444,7 +6328,7 @@ msgid "Upon upload and form submission, the AMO Team will review your updated de
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/personas/edit.html:241
-msgid "Your previously resubmitted design,  which is under pending review."
+msgid "Your previously resubmitted design, which is under pending review."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/personas/edit.html:245
@@ -6511,14 +6395,6 @@ msgstr ""
 
 #: src/olympia/devhub/templates/devhub/personas/submit.html:33
 msgid "Give your Theme a name."
-msgstr ""
-
-#: src/olympia/devhub/templates/devhub/personas/submit.html:54
-msgid ""
-"A short explanation of your theme's\n"
-"                                      basic functionality that is displayed in\n"
-"                                      search and browse listings, as well as at\n"
-"                                      the top of your theme's details page."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/personas/submit.html:198
@@ -6595,30 +6471,16 @@ msgstr ""
 msgid "Files added to reviewed versions must be reviewed before they will be available for download."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/add_file_modal.html:15
-#, python-format
-msgid ""
-"Submission of updates to unlisted add-ons for signing is currently in an open beta. Manual review may still be required for a large number of add-ons. Please <a href=\"%(url)s\" target=\"_blank"
-"\">report any bugs</a> that you encounter."
-msgstr ""
-
-#: src/olympia/devhub/templates/devhub/versions/add_file_modal.html:35
+#: src/olympia/devhub/templates/devhub/versions/add_file_modal.html:24
 msgid "Select the target platform for this file."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/add_file_modal.html:46
+#: src/olympia/devhub/templates/devhub/versions/add_file_modal.html:35
 msgid "Which review type would you like to nominate for?"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/add_file_modal.html:51
+#: src/olympia/devhub/templates/devhub/versions/add_file_modal.html:40
 msgid "Only publish this version to my beta channel."
-msgstr ""
-
-#: src/olympia/devhub/templates/devhub/versions/add_file_modal.html:54
-#, python-format
-msgid ""
-"The behavior of the beta channel has changed to accommodate <a href=\"%(addon_signing_url)s\" target=\"_blank\">mandatory add-on signing</a>. The new process is currently in an open beta, and may "
-"change significantly in the near future. Please <a href=\"%(issues_url)s\" target=\"_blank\">report any bugs</a> that you encounter."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/versions/edit.html:5
@@ -6642,19 +6504,10 @@ msgstr ""
 msgid "Upload Another File"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/edit.html:45
-msgid ""
-"Adjusting application information here will allow users to install your\n"
-"                          add-on even if the install manifest in the package indicates that the\n"
-"                          add-on is incompatible."
-msgstr ""
-
 #: src/olympia/devhub/templates/devhub/versions/edit.html:74
 msgid ""
-"Information about changes in this release, new features,\n"
-"                              known bugs, and other useful information specific to this\n"
-"                              release/version. This information is also shown in the\n"
-"                              Add-ons Manager when updating."
+"Information about changes in this release, new features, known bugs, and other useful information specific to this release/version. This information is also shown in the Add-ons Manager when "
+"updating."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/versions/edit.html:99
@@ -6666,10 +6519,7 @@ msgid "Notes for Reviewers"
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/versions/edit.html:114
-msgid ""
-"Optionally, enter any information that may be useful\n"
-"                              to the Editor reviewing this add-on, such as test\n"
-"                              account information."
+msgid "Optionally, enter any information that may be useful to the Editor reviewing this add-on, such as test account information."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/versions/edit.html:127
@@ -6747,7 +6597,7 @@ msgstr ""
 msgid "Request Preliminary Review"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:80 src/olympia/devhub/templates/devhub/versions/list.html:327 src/olympia/devhub/templates/devhub/versions/list.html:350
+#: src/olympia/devhub/templates/devhub/versions/list.html:80 src/olympia/devhub/templates/devhub/versions/list.html:325 src/olympia/devhub/templates/devhub/versions/list.html:348
 msgid "Cancel Review Request"
 msgstr ""
 
@@ -6776,7 +6626,7 @@ msgid "Unlisted:"
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/versions/list.html:114
-msgid "Not distributed on {0}. Developers will upload new versions for signing and distribute the add-ons on their own. (beta)"
+msgid "Not distributed on {0}. Developers will upload new versions for signing and distribute the add-ons on their own."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/versions/list.html:122
@@ -6839,81 +6689,73 @@ msgid "<strong>Important:</strong> Once a version has been deleted, you may not 
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/versions/list.html:230
-msgid ""
-"Deleting a version which has already been reviewed\n"
-"               may also cause a significant delay in the review of\n"
-"               your next update."
-msgstr ""
-
-#: src/olympia/devhub/templates/devhub/versions/list.html:233
 msgid "Are you sure you wish to delete this version?"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:238
+#: src/olympia/devhub/templates/devhub/versions/list.html:235
 msgid "Delete Version"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:240
+#: src/olympia/devhub/templates/devhub/versions/list.html:237
 msgid "Disable Version"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:247
+#: src/olympia/devhub/templates/devhub/versions/list.html:244
 msgid "Add a new Version"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:249
+#: src/olympia/devhub/templates/devhub/versions/list.html:246
 msgid "Add Version"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:256 src/olympia/devhub/templates/devhub/versions/list.html:274
+#: src/olympia/devhub/templates/devhub/versions/list.html:253 src/olympia/devhub/templates/devhub/versions/list.html:279
 msgid "Hide Add-on"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:259
+#: src/olympia/devhub/templates/devhub/versions/list.html:256
 msgid "Hiding your add-on will prevent it from appearing anywhere in our gallery and will stop users from receiving automatic updates."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:265
+#: src/olympia/devhub/templates/devhub/versions/list.html:263
+msgid "The files awaiting review will be disabled and you will need to upload new versions."
+msgstr ""
+
+#: src/olympia/devhub/templates/devhub/versions/list.html:270
 msgid "Are you sure you wish to hide your add-on?"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:286 src/olympia/devhub/templates/devhub/versions/list.html:315
+#: src/olympia/devhub/templates/devhub/versions/list.html:291 src/olympia/devhub/templates/devhub/versions/list.html:313
 msgid "Unlist Add-on"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:289
+#: src/olympia/devhub/templates/devhub/versions/list.html:294
 #, python-format
 msgid ""
 "Unlisting your add-on will make it (and each of its versions/files) invisible on this website. It won't show up in searches, won't have a public facing page, and won't be updated automatically for "
-"current users.  It is recommended for unlisted add-ons to provide a custom <a href=\"%(update_url)s\" target=\"_blank\">updateURL</a> in their manifest file for automatic updates."
+"current users. It is recommended for unlisted add-ons to provide a custom <a href=\"%(update_url)s\" target=\"_blank\">updateURL</a> in their manifest file for automatic updates."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:299
-#, python-format
-msgid "Switching add-ons to unlisted is currently in an open beta. Please <a href=\"%(url)s\" target=\"_blank\">report any bugs</a> that you encounter."
-msgstr ""
-
-#: src/olympia/devhub/templates/devhub/versions/list.html:305
+#: src/olympia/devhub/templates/devhub/versions/list.html:303
 msgid "Unlisting an add-on is irreversible!"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:305
+#: src/olympia/devhub/templates/devhub/versions/list.html:303
 msgid "An unlisted add-on cannot be switched to be listed."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:307
+#: src/olympia/devhub/templates/devhub/versions/list.html:305
 msgid "Are you sure you wish to unlist your add-on?"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:330
+#: src/olympia/devhub/templates/devhub/versions/list.html:328
 msgid "Canceling your review request will leave your add-on as preliminarily reviewed."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:335
+#: src/olympia/devhub/templates/devhub/versions/list.html:333
 msgid "Canceling your review request will mark your add-on incomplete. If you do not complete your add-on after several days by re-requesting review, it will be deleted."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:343
+#: src/olympia/devhub/templates/devhub/versions/list.html:341
 msgid "Are you sure you wish to cancel your review request?"
 msgstr ""
 
@@ -7252,19 +7094,19 @@ msgstr ""
 msgid "Search by add-on name / author email"
 msgstr ""
 
-#: src/olympia/editors/forms.py:103
+#: src/olympia/editors/forms.py:103 src/olympia/editors/forms.py:244 src/olympia/editors/forms.py:257
 msgid "yes"
 msgstr ""
 
-#: src/olympia/editors/forms.py:104
+#: src/olympia/editors/forms.py:104 src/olympia/editors/forms.py:244 src/olympia/editors/forms.py:257
 msgid "no"
 msgstr ""
 
-#: src/olympia/editors/forms.py:105
+#: src/olympia/editors/forms.py:105 src/olympia/editors/forms.py:245
 msgid "Admin Flag"
 msgstr ""
 
-#: src/olympia/editors/forms.py:113
+#: src/olympia/editors/forms.py:113 src/olympia/editors/forms.py:253
 msgid "Max. Version"
 msgstr ""
 
@@ -7276,55 +7118,59 @@ msgstr ""
 msgid "Add-on Types"
 msgstr ""
 
-#: src/olympia/editors/forms.py:126 src/olympia/editors/helpers.py:267
+#: src/olympia/editors/forms.py:126 src/olympia/editors/helpers.py:279
 msgid "Platforms"
 msgstr ""
 
+#: src/olympia/editors/forms.py:237
+msgid "Search by add-on name / author email / guid"
+msgstr ""
+
 #. L10n: 0 = platform, 1 = filename, 2 = status message
-#: src/olympia/editors/forms.py:238
+#: src/olympia/editors/forms.py:342
 #, python-format
 msgid "<strong>%s</strong> &middot; %s &middot; %s"
 msgstr ""
 
-#: src/olympia/editors/forms.py:252
+#: src/olympia/editors/forms.py:356
 msgid "Comments:"
 msgstr ""
 
-#: src/olympia/editors/forms.py:256
+#: src/olympia/editors/forms.py:360
 msgid "Operating systems:"
 msgstr ""
 
-#: src/olympia/editors/forms.py:258
+#: src/olympia/editors/forms.py:362
 msgid "Applications:"
 msgstr ""
 
-#: src/olympia/editors/forms.py:260
+#: src/olympia/editors/forms.py:364
 msgid "Notify me the next time this add-on is updated. (Subsequent updates will not generate an email)"
 msgstr ""
 
-#: src/olympia/editors/forms.py:265
+#: src/olympia/editors/forms.py:369
 msgid "Clear Admin Review Flag"
 msgstr ""
 
-#: src/olympia/editors/forms.py:267
+#: src/olympia/editors/forms.py:371
 msgid "Clear more info requested flag"
 msgstr ""
 
-#: src/olympia/editors/forms.py:281
+#: src/olympia/editors/forms.py:385
 msgid "Choose a canned response..."
 msgstr ""
 
 #. L10n: Description of what can be searched for.
-#: src/olympia/editors/forms.py:324
+#: src/olympia/editors/forms.py:423
 msgid "theme name"
 msgstr ""
 
-#: src/olympia/editors/forms.py:350
+#: src/olympia/editors/forms.py:449
 msgid "Someone else is reviewing this theme."
 msgstr ""
 
 #. L10n: Description of what can be searched for.
-#: src/olympia/editors/forms.py:447
+#: src/olympia/editors/forms.py:546
 msgid "app, reviewer, or comment"
 msgstr ""
 
@@ -7340,246 +7186,264 @@ msgstr ""
 msgid "Rejected or Unreviewed"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:123 src/olympia/editors/helpers.py:136
+#: src/olympia/editors/helpers.py:125 src/olympia/editors/helpers.py:138
 msgid "Queue"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:124 src/olympia/editors/templates/editors/base.html:50 src/olympia/editors/templates/editors/base.html:65
+#: src/olympia/editors/helpers.py:126 src/olympia/editors/templates/editors/base.html:50 src/olympia/editors/templates/editors/base.html:65
 msgid "Pending Updates"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:125 src/olympia/editors/templates/editors/base.html:48 src/olympia/editors/templates/editors/base.html:63
+#: src/olympia/editors/helpers.py:127 src/olympia/editors/templates/editors/base.html:48 src/olympia/editors/templates/editors/base.html:63
 msgid "Full Reviews"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:126 src/olympia/editors/templates/editors/base.html:52 src/olympia/editors/templates/editors/base.html:67
+#: src/olympia/editors/helpers.py:128 src/olympia/editors/templates/editors/base.html:52 src/olympia/editors/templates/editors/base.html:67
 msgid "Preliminary Reviews"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:127 src/olympia/editors/templates/editors/base.html:54
+#: src/olympia/editors/helpers.py:129 src/olympia/editors/templates/editors/base.html:54
 msgid "Moderated Reviews"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:128 src/olympia/editors/templates/editors/base.html:46
+#: src/olympia/editors/helpers.py:130 src/olympia/editors/templates/editors/base.html:46
 msgid "Fast Track"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:130
+#: src/olympia/editors/helpers.py:132
 msgid "Pending Themes"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:131 src/olympia/editors/templates/editors/themes/queue.html:4
+#: src/olympia/editors/helpers.py:133 src/olympia/editors/templates/editors/themes/queue.html:4
 msgid "Flagged Themes"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:132
+#: src/olympia/editors/helpers.py:134
 msgid "Update Themes"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:137
+#: src/olympia/editors/helpers.py:139
 msgid "Unlisted Pending Updates"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:138
+#: src/olympia/editors/helpers.py:140
 msgid "Unlisted Full Reviews"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:139
+#: src/olympia/editors/helpers.py:141
 msgid "Unlisted Preliminary Reviews"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:170
+#: src/olympia/editors/helpers.py:142
+msgid "Unlisted All Add-ons"
+msgstr ""
+
+#: src/olympia/editors/helpers.py:173
 msgid "Fast Track ({0})"
 msgid_plural "Fast Track ({0})"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/olympia/editors/helpers.py:175
+#: src/olympia/editors/helpers.py:178
 msgid "Full Review ({0})"
 msgid_plural "Full Reviews ({0})"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/olympia/editors/helpers.py:180
+#: src/olympia/editors/helpers.py:183
 msgid "Pending Update ({0})"
 msgid_plural "Pending Updates ({0})"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/olympia/editors/helpers.py:185
+#: src/olympia/editors/helpers.py:188
 msgid "Preliminary Review ({0})"
 msgid_plural "Preliminary Reviews ({0})"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/olympia/editors/helpers.py:190
+#: src/olympia/editors/helpers.py:193
 msgid "Moderated Review ({0})"
 msgid_plural "Moderated Reviews ({0})"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/olympia/editors/helpers.py:196
+#: src/olympia/editors/helpers.py:199
 msgid "Unlisted Full Review ({0})"
 msgid_plural "Unlisted Full Reviews ({0})"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/olympia/editors/helpers.py:201
+#: src/olympia/editors/helpers.py:204
 msgid "Unlisted Pending Update ({0})"
 msgid_plural "Unlisted Pending Updates ({0})"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/olympia/editors/helpers.py:206
+#: src/olympia/editors/helpers.py:209
 msgid "Unlisted Preliminary Review ({0})"
 msgid_plural "Unlisted Preliminary Reviews ({0})"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/olympia/editors/helpers.py:261
-msgid "Addon"
-msgstr ""
+#: src/olympia/editors/helpers.py:214
+msgid "Unlisted All Add-ons ({0})"
+msgid_plural "Unlisted All Add-ons ({0})"
+msgstr[0] ""
+msgstr[1] ""
 
-#: src/olympia/editors/helpers.py:262
+#: src/olympia/editors/helpers.py:274
 msgid "Type"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:263
+#: src/olympia/editors/helpers.py:275
 msgid "Waiting Time"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:264 src/olympia/editors/templates/editors/review.html:285
+#: src/olympia/editors/helpers.py:276 src/olympia/editors/templates/editors/review.html:285
 msgid "Flags"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:265
+#: src/olympia/editors/helpers.py:277
 msgid "Applications"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:270
+#: src/olympia/editors/helpers.py:282
 msgid "Additional"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:285
+#: src/olympia/editors/helpers.py:302
 msgid "Site Specific"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:287
+#: src/olympia/editors/helpers.py:304
 msgid "Requires External Software"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:289
+#: src/olympia/editors/helpers.py:306
 msgid "Binary Components"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:313
+#: src/olympia/editors/helpers.py:339
 msgid "moments ago"
 msgstr ""
 
 #. L10n: first argument is number of minutes
-#: src/olympia/editors/helpers.py:316
+#: src/olympia/editors/helpers.py:342
 msgid "{0} minute"
 msgid_plural "{0} minutes"
 msgstr[0] ""
 msgstr[1] ""
 
 #. L10n: first argument is number of hours
-#: src/olympia/editors/helpers.py:320
+#: src/olympia/editors/helpers.py:346
 msgid "{0} hour"
 msgid_plural "{0} hours"
 msgstr[0] ""
 msgstr[1] ""
 
 #. L10n: first argument is number of days
-#: src/olympia/editors/helpers.py:324
+#: src/olympia/editors/helpers.py:350
 msgid "{0} day"
 msgid_plural "{0} days"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/olympia/editors/helpers.py:488
+#: src/olympia/editors/helpers.py:364
+msgid "Last Review"
+msgstr ""
+
+#: src/olympia/editors/helpers.py:366
+msgid "Last Update"
+msgstr ""
+
+#: src/olympia/editors/helpers.py:387
+msgid "No Reviews"
+msgstr ""
+
+#: src/olympia/editors/helpers.py:561
 msgid "Push to public"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:490
+#: src/olympia/editors/helpers.py:563
 msgid "Grant full review"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:505
+#: src/olympia/editors/helpers.py:578
 msgid "Request more information"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:508
+#: src/olympia/editors/helpers.py:581
 msgid "Request super-review"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:519
+#: src/olympia/editors/helpers.py:592
 msgid "Grant preliminary review"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:520
+#: src/olympia/editors/helpers.py:593
 msgid "This will mark the files as preliminarily reviewed."
 msgstr ""
 
-#: src/olympia/editors/helpers.py:522
+#: src/olympia/editors/helpers.py:595
 msgid "Use this form to request more information from the author. They will receive an email and be able to answer here. You will be notified by email when they reply."
 msgstr ""
 
-#: src/olympia/editors/helpers.py:526
+#: src/olympia/editors/helpers.py:599
 msgid ""
 "If you have concerns about this add-on's security, copyright issues, or other concerns that an administrator should look into, enter your comments in the area below. They will be sent to "
 "administrators, not the author."
 msgstr ""
 
-#: src/olympia/editors/helpers.py:532
+#: src/olympia/editors/helpers.py:605
 msgid "This will reject the add-on and remove it from the review queue."
 msgstr ""
 
-#: src/olympia/editors/helpers.py:534
-msgid "Make a comment on this version.  The author won't be able to see this."
+#: src/olympia/editors/helpers.py:607
+msgid "Make a comment on this version. The author won't be able to see this."
 msgstr ""
 
-#: src/olympia/editors/helpers.py:538
+#: src/olympia/editors/helpers.py:611
 msgid "This will reject the files and remove them from the review queue."
 msgstr ""
 
-#: src/olympia/editors/helpers.py:542
+#: src/olympia/editors/helpers.py:615
 msgid "This will mark the add-on as preliminarily reviewed. Future versions will undergo preliminary review."
 msgstr ""
 
-#: src/olympia/editors/helpers.py:547
+#: src/olympia/editors/helpers.py:620
 msgid "This will mark the files as preliminarily reviewed. Future versions will undergo preliminary review."
 msgstr ""
 
-#: src/olympia/editors/helpers.py:552
+#: src/olympia/editors/helpers.py:625
 msgid "Retain preliminary review"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:553
+#: src/olympia/editors/helpers.py:626
 msgid "This will retain the add-on as preliminarily reviewed. Future versions will undergo preliminary review."
 msgstr ""
 
-#: src/olympia/editors/helpers.py:558
+#: src/olympia/editors/helpers.py:631
 msgid "This will approve a sandboxed version of a public add-on to appear on the public side."
 msgstr ""
 
-#: src/olympia/editors/helpers.py:561
+#: src/olympia/editors/helpers.py:634
 msgid "This will reject a version of a public add-on and remove it from the queue."
 msgstr ""
 
-#: src/olympia/editors/helpers.py:564
+#: src/olympia/editors/helpers.py:637
 msgid "This will mark the add-on and its most recent version and files as public. Future versions will go into the sandbox until they are reviewed by an editor."
 msgstr ""
 
-#: src/olympia/editors/helpers.py:637
+#: src/olympia/editors/helpers.py:714
 msgid "add-on"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:940 src/olympia/editors/helpers.py:960
+#: src/olympia/editors/helpers.py:1020 src/olympia/editors/helpers.py:1040
 msgid "Flagged"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:944 src/olympia/editors/helpers.py:963
+#: src/olympia/editors/helpers.py:1024 src/olympia/editors/helpers.py:1043
 msgid "Updates"
 msgstr ""
 
@@ -7631,56 +7495,56 @@ msgstr ""
 msgid "A question about your Theme submission"
 msgstr ""
 
-#: src/olympia/editors/views.py:144
+#: src/olympia/editors/views.py:146
 msgid "New Add-ons (Under 5 days)"
 msgstr ""
 
-#: src/olympia/editors/views.py:145
+#: src/olympia/editors/views.py:147
 msgid "Passable (5 to 10 days)"
 msgstr ""
 
-#: src/olympia/editors/views.py:146
+#: src/olympia/editors/views.py:148
 msgid "Overdue (Over 10 days)"
 msgstr ""
 
-#: src/olympia/editors/views.py:532
+#: src/olympia/editors/views.py:539
 msgid "An unknown error occurred"
 msgstr ""
 
-#: src/olympia/editors/views.py:587
+#: src/olympia/editors/views.py:592
 msgid "Self-reviews are not allowed."
 msgstr ""
 
-#: src/olympia/editors/views.py:609
+#: src/olympia/editors/views.py:613
 msgid "Review successfully processed."
 msgstr ""
 
-#: src/olympia/editors/views.py:807
+#: src/olympia/editors/views.py:812
 msgid "was approved"
 msgstr ""
 
-#: src/olympia/editors/views.py:808
+#: src/olympia/editors/views.py:813
 msgid "given preliminary review"
 msgstr ""
 
-#: src/olympia/editors/views.py:809
+#: src/olympia/editors/views.py:814
 msgid "rejected"
 msgstr ""
 
-#: src/olympia/editors/views.py:810
+#: src/olympia/editors/views.py:815
 msgctxt "editors_review_history_nominated_adminreview"
 msgid "escalated"
 msgstr ""
 
-#: src/olympia/editors/views.py:812
+#: src/olympia/editors/views.py:817
 msgid "needs more information"
 msgstr ""
 
-#: src/olympia/editors/views.py:813
+#: src/olympia/editors/views.py:818
 msgid "needs super review"
 msgstr ""
 
-#: src/olympia/editors/views.py:814
+#: src/olympia/editors/views.py:819
 msgid "commented"
 msgstr ""
 
@@ -7725,28 +7589,28 @@ msgstr ""
 msgid "Unlisted Queues"
 msgstr ""
 
-#: src/olympia/editors/templates/editors/base.html:72 src/olympia/editors/templates/editors/performance.html:6
+#: src/olympia/editors/templates/editors/base.html:74 src/olympia/editors/templates/editors/performance.html:6
 msgid "Performance"
 msgstr ""
 
-#: src/olympia/editors/templates/editors/base.html:75 src/olympia/editors/templates/editors/themes/base.html:19 src/olympia/editors/templates/editors/themes/base.html:38
+#: src/olympia/editors/templates/editors/base.html:77 src/olympia/editors/templates/editors/themes/base.html:19 src/olympia/editors/templates/editors/themes/base.html:38
 msgid "Logs"
 msgstr ""
 
-#: src/olympia/editors/templates/editors/base.html:78 src/olympia/editors/templates/editors/reviewlog.html:4 src/olympia/editors/templates/editors/reviewlog.html:27
+#: src/olympia/editors/templates/editors/base.html:80 src/olympia/editors/templates/editors/reviewlog.html:4 src/olympia/editors/templates/editors/reviewlog.html:27
 msgid "Add-on Review Log"
 msgstr ""
 
-#: src/olympia/editors/templates/editors/base.html:80 src/olympia/editors/templates/editors/eventlog.html:4 src/olympia/editors/templates/editors/eventlog.html:8
+#: src/olympia/editors/templates/editors/base.html:82 src/olympia/editors/templates/editors/eventlog.html:4 src/olympia/editors/templates/editors/eventlog.html:8
 #: src/olympia/editors/templates/editors/eventlog_detail.html:4
 msgid "Moderated Review Log"
 msgstr ""
 
-#: src/olympia/editors/templates/editors/base.html:82 src/olympia/editors/templates/editors/beta_signed_log.html:4 src/olympia/editors/templates/editors/beta_signed_log.html:8
+#: src/olympia/editors/templates/editors/base.html:84 src/olympia/editors/templates/editors/beta_signed_log.html:4 src/olympia/editors/templates/editors/beta_signed_log.html:8
 msgid "Signed Beta Files Log"
 msgstr ""
 
-#: src/olympia/editors/templates/editors/base.html:87 src/olympia/editors/templates/editors/includes/daily-message.html:4
+#: src/olympia/editors/templates/editors/base.html:89 src/olympia/editors/templates/editors/includes/daily-message.html:4
 msgid "Announcement"
 msgstr ""
 
@@ -7967,45 +7831,45 @@ msgstr ""
 msgid "clear search"
 msgstr ""
 
-#: src/olympia/editors/templates/editors/queue.html:72 src/olympia/editors/templates/editors/queue.html:122
+#: src/olympia/editors/templates/editors/queue.html:78 src/olympia/editors/templates/editors/queue.html:128
 msgid "Process Reviews"
 msgstr ""
 
-#: src/olympia/editors/templates/editors/queue.html:80
+#: src/olympia/editors/templates/editors/queue.html:86
 msgid "Moderation actions:"
 msgstr ""
 
-#: src/olympia/editors/templates/editors/queue.html:90
+#: src/olympia/editors/templates/editors/queue.html:96
 #, python-format
 msgid "by %(user)s on %(date)s %(stars)s (%(locale)s)"
 msgstr ""
 
-#: src/olympia/editors/templates/editors/queue.html:106
+#: src/olympia/editors/templates/editors/queue.html:112
 #, python-format
 msgid "<strong>%(reason)s</strong> <span class=\"light\">Flagged by %(user)s on %(date)s</span>"
 msgstr ""
 
-#: src/olympia/editors/templates/editors/queue.html:119
-msgid "All reviews have been moderated.  Good work!"
+#: src/olympia/editors/templates/editors/queue.html:125
+msgid "All reviews have been moderated. Good work!"
 msgstr ""
 
-#: src/olympia/editors/templates/editors/queue.html:161
+#: src/olympia/editors/templates/editors/queue.html:167
 msgid "Version Notes / Notes for Reviewer"
 msgstr ""
 
-#: src/olympia/editors/templates/editors/queue.html:169
+#: src/olympia/editors/templates/editors/queue.html:175
 msgid "There are currently no add-ons of this type to review."
 msgstr ""
 
-#: src/olympia/editors/templates/editors/queue.html:181 src/olympia/editors/templates/editors/themes/queue_list.html:85
+#: src/olympia/editors/templates/editors/queue.html:187 src/olympia/editors/templates/editors/themes/queue_list.html:85
 msgid "Helpful Links:"
 msgstr ""
 
-#: src/olympia/editors/templates/editors/queue.html:182
+#: src/olympia/editors/templates/editors/queue.html:188
 msgid "Add-on Policy"
 msgstr ""
 
-#: src/olympia/editors/templates/editors/queue.html:184
+#: src/olympia/editors/templates/editors/queue.html:190
 msgid "Editors' Guide"
 msgstr ""
 
@@ -8068,10 +7932,7 @@ msgid "<strong>Warning!</strong> Another user was viewing this page before you."
 msgstr ""
 
 #: src/olympia/editors/templates/editors/review.html:237
-msgid ""
-"The whiteboard is the place to exchange information relevant to\n"
-"               this addon (whatever the version), between the developer and the\n"
-"               editor. This is visible and editable by both."
+msgid "The whiteboard is the place to exchange information relevant to this addon (whatever the version), between the developer and the editor. This is visible and editable by both."
 msgstr ""
 
 #: src/olympia/editors/templates/editors/review.html:241
@@ -8345,7 +8206,7 @@ msgstr ""
 msgid "Describe your reason for flagging"
 msgstr ""
 
-#: src/olympia/files/forms.py:88
+#: src/olympia/files/forms.py:90
 msgid "Cannot diff a version against itself"
 msgstr ""
 
@@ -8380,51 +8241,51 @@ msgstr ""
 msgid "There was an error accessing file %s."
 msgstr ""
 
-#: src/olympia/files/utils.py:343
+#: src/olympia/files/utils.py:340
 msgid "Could not parse uploaded file."
 msgstr ""
 
-#: src/olympia/files/utils.py:380
+#: src/olympia/files/utils.py:377
 msgid "Invalid file name in archive: {0}"
 msgstr ""
 
-#: src/olympia/files/utils.py:388
+#: src/olympia/files/utils.py:385
 msgid "File exceeding size limit in archive: {0}"
 msgstr ""
 
-#: src/olympia/files/utils.py:439
+#: src/olympia/files/utils.py:436
 msgid "Invalid archive."
 msgstr ""
 
-#: src/olympia/files/utils.py:529 src/olympia/files/utils.py:532
+#: src/olympia/files/utils.py:526 src/olympia/files/utils.py:529
 msgid "Could not parse the manifest file."
 msgstr ""
 
-#: src/olympia/files/utils.py:551
+#: src/olympia/files/utils.py:548
 msgid "Could not find an add-on ID."
 msgstr ""
 
-#: src/olympia/files/utils.py:554
+#: src/olympia/files/utils.py:551
 msgid "Add-on ID must be 64 characters or less."
 msgstr ""
 
-#: src/olympia/files/utils.py:556
+#: src/olympia/files/utils.py:553
 msgid "Add-on ID doesn't match add-on."
 msgstr ""
 
-#: src/olympia/files/utils.py:564
+#: src/olympia/files/utils.py:561
 msgid "Duplicate add-on ID found."
 msgstr ""
 
-#: src/olympia/files/utils.py:567
+#: src/olympia/files/utils.py:564
 msgid "Version numbers should have fewer than 32 characters."
 msgstr ""
 
-#: src/olympia/files/utils.py:570
+#: src/olympia/files/utils.py:567
 msgid "Version numbers should only contain letters, numbers, and these punctuation characters: +*.-_."
 msgstr ""
 
-#: src/olympia/files/utils.py:587
+#: src/olympia/files/utils.py:584
 msgid "<em:type> doesn't match add-on"
 msgstr ""
 
@@ -8523,6 +8384,10 @@ msgstr ""
 
 #: src/olympia/files/templates/files/viewer.html:134
 msgid "Fetching file."
+msgstr ""
+
+#: src/olympia/legacy_api/views.py:255
+msgid "Not implemented yet."
 msgstr ""
 
 #: src/olympia/lib/constants.py:6
@@ -9181,10 +9046,6 @@ msgstr ""
 msgid "Zimbabwe Dollar"
 msgstr ""
 
-#: src/olympia/lib/video/ffmpeg.py:112 src/olympia/lib/video/totem.py:81
-msgid "Videos must be in WebM."
-msgstr ""
-
 #: src/olympia/pages/templates/pages/about.lhtml:3 src/olympia/pages/templates/pages/about.lhtml:10
 msgid "About Mozilla Add-ons"
 msgstr ""
@@ -9196,7 +9057,7 @@ msgstr ""
 #: src/olympia/pages/templates/pages/about.lhtml:13
 msgid ""
 "addons.mozilla.org, commonly known as \"AMO\", is Mozilla's official site for add-ons to Mozilla software, such as Firefox, Thunderbird, and SeaMonkey. Add-ons let you add new features and change "
-"the way your browser or application works.  Take a look around and explore the thousands of ways to customize the way you do things online."
+"the way your browser or application works. Take a look around and explore the thousands of ways to customize the way you do things online."
 msgstr ""
 
 #: src/olympia/pages/templates/pages/about.lhtml:19
@@ -9541,7 +9402,7 @@ msgstr ""
 msgid ""
 "Yes. It's possible, but some of the functionality provided by these libraries are available through XPCOM, XUL, and JavaScript. In addition, authors should take care if libraries modify primitive "
 "object prototypes (String.prototype, Date.prototype, etc.) and/or define global functions (eg. the $ function). These are prone to cause conflict with other add-ons, in particular if different add-"
-"ons use different versions of libraries and so on. Developers need to be very, very careful with using them.  Mozilla does not offer documentation on using them to build add-ons."
+"ons use different versions of libraries and so on. Developers need to be very, very careful with using them. Mozilla does not offer documentation on using them to build add-ons."
 msgstr ""
 
 #: src/olympia/pages/templates/pages/dev_faq.html:165
@@ -9655,8 +9516,8 @@ msgstr ""
 #, python-format
 msgid ""
 "Yes. Many developers choose to host their own add-ons. Choosing to host your add-on on <a href=\"%(amo_url)s\">Mozilla's add-on site</a>, though, allows for much greater exposure to your add-on due "
-"to the large volume of visitors to the site.  <a href=\"%(md_url)s\">mozdev.org</a> offers free project hosting for Mozilla applications and extensions providing developers with tools to help "
-"manage source code, version control, bug tracking and documentation."
+"to the large volume of visitors to the site. <a href=\"%(md_url)s\">mozdev.org</a> offers free project hosting for Mozilla applications and extensions providing developers with tools to help manage "
+"source code, version control, bug tracking and documentation."
 msgstr ""
 
 #: src/olympia/pages/templates/pages/dev_faq.html:277
@@ -9704,7 +9565,7 @@ msgstr ""
 #: src/olympia/pages/templates/pages/dev_faq.html:314
 #, python-format
 msgid ""
-"Yes. Mozilla's <a href=\"%(p_url)s\">Add-on Policy</a> describes what is an acceptable submission. This policy is subject to change without notice.  In addition, the AMO editorial team uses the <a "
+"Yes. Mozilla's <a href=\"%(p_url)s\">Add-on Policy</a> describes what is an acceptable submission. This policy is subject to change without notice. In addition, the AMO editorial team uses the <a "
 "href=\"%(g_url)s\">Editors Reviewing Guide</a> to ensure that your add-on meets specific guidelines for functionality and security."
 msgstr ""
 
@@ -9821,7 +9682,7 @@ msgstr ""
 #: src/olympia/pages/templates/pages/dev_faq.html:434
 #, python-format
 msgid ""
-"This is why it's very important to read the <a href=\"%(g_url)s\">Editors Reviewing Guide</a> to ensure that your add-on is setup as expected.  It's also a good idea to read the blog post, <a href="
+"This is why it's very important to read the <a href=\"%(g_url)s\">Editors Reviewing Guide</a> to ensure that your add-on is setup as expected. It's also a good idea to read the blog post, <a href="
 "\"%(blog_url)s\">Successfully Getting your Add-on Reviewed</a> which provides excellent insight into ensuring a smooth review of your add-on."
 msgstr ""
 
@@ -9928,7 +9789,7 @@ msgstr ""
 
 #: src/olympia/pages/templates/pages/dev_faq.html:572
 msgid ""
-"Free Software Foundation provides short summaries of the key open source licenses, including whether the license qualifies as a free software license or a copyleft license.  Also includes a "
+"Free Software Foundation provides short summaries of the key open source licenses, including whether the license qualifies as a free software license or a copyleft license. Also includes a "
 "discussion of what constitutes a free software license or a copyleft license (e.g., a Copyleft license is a general method for making a program or other work free, and requiring all modified and "
 "extended versions of the program to be free as well.)"
 msgstr ""
@@ -10106,19 +9967,13 @@ msgid "Add-on Gallery"
 msgstr ""
 
 #: src/olympia/pages/templates/pages/faq.html:171
-msgid ""
-"How do I choose between add-ons that seem to do the same\n"
-"    thing?"
+msgid "How do I choose between add-ons that seem to do the same thing?"
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:173
+#: src/olympia/pages/templates/pages/faq.html:172
 msgid ""
-"There are often several add-ons that have similar features. To\n"
-"    figure out which is right for you, read the entire description of the\n"
-"    add-on and view its screenshots. If there are still several in the running,\n"
-"    read through the add-on's ratings, user reviews, and statistics to see\n"
-"    which is most liked by other users. Remember that you can also just try\n"
-"    out both and see which you like better."
+"There are often several add-ons that have similar features. To figure out which is right for you, read the entire description of the add-on and view its screenshots. If there are still several in "
+"the running, read through the add-on's ratings, user reviews, and statistics to see which is most liked by other users. Remember that you can also just try out both and see which you like better."
 msgstr ""
 
 #: src/olympia/pages/templates/pages/faq.html:180
@@ -10159,80 +10014,67 @@ msgid "How much do add-ons cost to purchase?"
 msgstr ""
 
 #: src/olympia/pages/templates/pages/faq.html:207
-msgid ""
-"Add-ons hosted in our gallery are free unless clearly marked\n"
-"    otherwise."
+msgid "Add-ons hosted in our gallery are free unless clearly marked otherwise."
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:210
+#: src/olympia/pages/templates/pages/faq.html:209
 msgid "What does it mean when an add-on asks for contributions?"
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:211
+#: src/olympia/pages/templates/pages/faq.html:210
 msgid ""
-"Some add-on authors request users who enjoy an add-on to\n"
-"        contribute to its development by making a monetary contribution. These\n"
-"        contributions go directly to the developer unless a third party is\n"
-"        indicated, such as the non-profit Mozilla Foundation."
+"Some add-on authors request users who enjoy an add-on to contribute to its development by making a monetary contribution. These contributions go directly to the developer unless a third party is "
+"indicated, such as the non-profit Mozilla Foundation."
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:216
+#: src/olympia/pages/templates/pages/faq.html:215
 msgid "What are beta add-ons?"
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:218
+#: src/olympia/pages/templates/pages/faq.html:217
 msgid ""
-"Beta add-ons are unreviewed versions which represent the\n"
-"        latest work of an add-on author. While different authors have different\n"
-"        standards for beta code quality, you should assume that these add-ons\n"
-"        are less stable than the general add-on releases."
+"Beta add-ons are unreviewed versions which represent the latest work of an add-on author. While different authors have different standards for beta code quality, you should assume that these add-"
+"ons are less stable than the general add-on releases."
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:222
+#: src/olympia/pages/templates/pages/faq.html:221
 msgid ""
 "Please note that when you install an add-on from the \"Beta Version\" section of an add-on's listing, you will continue to receive updates for that add-on as they become available. Like the initial "
 "version you installed, all beta releases are unreviewed by Mozilla and may harm your computer."
 msgstr ""
 
+#: src/olympia/pages/templates/pages/faq.html:228
+msgid "What does it mean when an add-on is flagged as slow?"
+msgstr ""
+
 #: src/olympia/pages/templates/pages/faq.html:229
-msgid ""
-"What does it mean when an add-on is flagged as\n"
-"    slow?"
+msgid "Most add-ons load code and resources at the same time Firefox is starting up. In most cases the impact in start-up time is minimal, but some add-ons can cause a noticeable slowdown."
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:231
-msgid ""
-"Most add-ons load code and resources at the same time Firefox\n"
-"        is starting up. In most cases the impact in start-up time is minimal,\n"
-"        but some add-ons can cause a noticeable slowdown."
-msgstr ""
-
-#: src/olympia/pages/templates/pages/faq.html:236
+#: src/olympia/pages/templates/pages/faq.html:234
 msgid "How do I report an inappropriate or spam user review?"
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:237
+#: src/olympia/pages/templates/pages/faq.html:235
 msgid ""
-"To report a user review of an add-on, log in with your account\n"
-"    and visit the add-on's reviews page. Find the review you wish to report,\n"
-"    click \"Report this review\" and select a reason. Our editorial team will\n"
-"    investigate the review and take appropriate action."
+"To report a user review of an add-on, log in with your account and visit the add-on's reviews page. Find the review you wish to report, click \"Report this review\" and select a reason. Our "
+"editorial team will investigate the review and take appropriate action."
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:242
+#: src/olympia/pages/templates/pages/faq.html:240
 msgid "How do I report a bug or contact the Mozilla Add-ons team?"
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:243
+#: src/olympia/pages/templates/pages/faq.html:241
 #, python-format
 msgid "Please visit our <a href=\"%(contact_url)s\">Contact page</a>."
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:246
+#: src/olympia/pages/templates/pages/faq.html:244
 msgid "What is a Source Code License?"
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:247
+#: src/olympia/pages/templates/pages/faq.html:245
 #, python-format
 msgid ""
 "The source code used to create an add-on is an exclusive copyright of the add-on author, unless otherwise declared in a source code license. Many add-ons on this site have <a href=\"%(url)s\" lang="
@@ -10240,60 +10082,60 @@ msgid ""
 "the GPL or BSD licenses instead of making up their own."
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:256
+#: src/olympia/pages/templates/pages/faq.html:254
 #, python-format
 msgid "Firefox and other Mozilla software are <a href=\"%(url)s\">open source</a>."
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:264
+#: src/olympia/pages/templates/pages/faq.html:262
 msgid "Collections and Favorites"
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:267
+#: src/olympia/pages/templates/pages/faq.html:265
 msgid "What is a collection?"
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:268
+#: src/olympia/pages/templates/pages/faq.html:266
 msgid "Collections are groups of related add-ons created by users to share."
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:270
+#: src/olympia/pages/templates/pages/faq.html:268
 msgid "What is the My Favorites collection?"
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:271
+#: src/olympia/pages/templates/pages/faq.html:269
 msgid "Favorite add-ons are add-ons that you have bookmarked to easily get back to later. You can add an add-on to your favorites collection by clicking \"Add to favorites\" on its details page."
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:275 src/olympia/templates/menu_links.html:13 src/olympia/templates/impala/header_title.html:17
+#: src/olympia/pages/templates/pages/faq.html:273 src/olympia/templates/menu_links.html:13 src/olympia/templates/impala/header_title.html:17
 msgid "Mobile Add-ons"
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:278
+#: src/olympia/pages/templates/pages/faq.html:276
 msgid "What are mobile add-ons?"
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:279
+#: src/olympia/pages/templates/pages/faq.html:277
 #, python-format
 msgid ""
 "Mobile add-ons work with <a href=\"%(mobile_url)s\">Firefox for Mobile</a> and add or modify functionality just like desktop add-ons. You can find add-ons that work with Firefox for Mobile in our "
 "<a href=\"%(gallery_url)s\">gallery</a>."
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:288
+#: src/olympia/pages/templates/pages/faq.html:286
 msgid "Developer Topics"
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:289
+#: src/olympia/pages/templates/pages/faq.html:287
 #, python-format
 msgid "Please see our <a href=\"%(faq_url)s\">Developer FAQ</a> and <a href=\"%(hub_url)s\">Developer Hub</a> for answers to add-on developer-related questions."
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:294
+#: src/olympia/pages/templates/pages/faq.html:292
 msgid "Still have questions?"
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:295
+#: src/olympia/pages/templates/pages/faq.html:293
 #, python-format
 msgid "For general Firefox support, visit our <a href=\"%(sumo_url)s\">support website</a>. For general add-on and website questions, visit our <a href=\"%(forum_url)s\">forum</a>."
 msgstr ""
@@ -10431,7 +10273,7 @@ msgstr ""
 
 #: src/olympia/pages/templates/pages/sunbird.html:29
 msgid ""
-"Development on the Sunbird project has halted and its final release was on March 30, 2010.  We've been proud to host Sunbird add-ons on this site but as the project is no longer maintained we have "
+"Development on the Sunbird project has halted and its final release was on March 30, 2010. We've been proud to host Sunbird add-ons on this site but as the project is no longer maintained we have "
 "disabled our support for the add-ons."
 msgstr ""
 
@@ -10509,7 +10351,7 @@ msgstr ""
 #, python-format
 msgid ""
 "<h2>Keep these tips in mind:</h2> <ul> <li> Write like you're telling a friend about your experience with the add-on. Give specifics and helpful details, such as what features you liked and/or "
-"disliked, how easy to use it is, and any disadvantages it has.  Avoid generic language such as calling it \"Great\" or \"Bad\" unless you can give reasons why you believe this is so. </li> <li> "
+"disliked, how easy to use it is, and any disadvantages it has. Avoid generic language such as calling it \"Great\" or \"Bad\" unless you can give reasons why you believe this is so. </li> <li> "
 "Please do not post bug reports in reviews. We do not make your email address available to add-on developers and they may need to contact you to help resolve your issue. See the <a href=\"%(support)s"
 "\">support section</a> to find out where to get assistance for this add-on. </li> <li>Please keep reviews clean, avoid the use of improper language and do not post any personal information. </li> </"
 "ul> <p>Please read the <a href=\"%(guide)s\" target=\"_blank\">Review Guidelines</a> for more detail about user add-on reviews.</p>"
@@ -10745,16 +10587,16 @@ msgstr ""
 
 #. L10n: {0} is an application, such as Firefox. This means "any version of
 #. Firefox."
-#: src/olympia/search/views.py:554
+#: src/olympia/search/views.py:547
 msgid "Any {0}"
 msgstr ""
 
 #. L10n: "All Systems" means show everything regardless of platform.
-#: src/olympia/search/views.py:589
+#: src/olympia/search/views.py:582
 msgid "All Systems"
 msgstr ""
 
-#: src/olympia/search/views.py:600
+#: src/olympia/search/views.py:593
 msgid "All Tags"
 msgstr ""
 
@@ -10928,31 +10770,31 @@ msgstr ""
 msgid "Share this Collection"
 msgstr ""
 
-#: src/olympia/signing/views.py:30 src/olympia/templates/base.html:75 src/olympia/templates/impala/base.html:115
+#: src/olympia/signing/views.py:33 src/olympia/templates/base.html:71 src/olympia/templates/impala/base.html:112
 msgid "Some features are temporarily disabled while we perform website maintenance. We'll be back to full capacity shortly."
 msgstr ""
 
-#: src/olympia/signing/views.py:53
+#: src/olympia/signing/views.py:56
 msgid "Could not find add-on with id \"{}\"."
 msgstr ""
 
-#: src/olympia/signing/views.py:67
+#: src/olympia/signing/views.py:70
 msgid "You do not own this addon."
 msgstr ""
 
-#: src/olympia/signing/views.py:82
+#: src/olympia/signing/views.py:87
 msgid "Missing \"upload\" key in multipart file data."
 msgstr ""
 
-#: src/olympia/signing/views.py:96
+#: src/olympia/signing/views.py:101
 msgid "Version does not match the manifest file."
 msgstr ""
 
-#: src/olympia/signing/views.py:100
+#: src/olympia/signing/views.py:105
 msgid "Version already exists."
 msgstr ""
 
-#: src/olympia/signing/views.py:136
+#: src/olympia/signing/views.py:141
 msgid "No uploaded file for that addon and version."
 msgstr ""
 
@@ -11065,89 +10907,89 @@ msgstr ""
 msgid "Statistics Dashboard :: Add-ons for {0}"
 msgstr ""
 
-#: src/olympia/stats/templates/stats/stats.html:30
-msgid "Controls:"
-msgstr ""
-
-#: src/olympia/stats/templates/stats/stats.html:33
-msgid "reset zoom"
-msgstr ""
-
-#: src/olympia/stats/templates/stats/stats.html:40
-msgid "Group by:"
-msgstr ""
-
-#: src/olympia/stats/templates/stats/stats.html:42
-msgid "day"
-msgstr ""
-
-#: src/olympia/stats/templates/stats/stats.html:45
-msgid "week"
-msgstr ""
-
-#: src/olympia/stats/templates/stats/stats.html:48
-msgid "month"
-msgstr ""
-
-#: src/olympia/stats/templates/stats/stats.html:54
-msgid "For last:"
-msgstr ""
-
-#: src/olympia/stats/templates/stats/stats.html:57
-msgid "7 days"
-msgstr ""
-
-#: src/olympia/stats/templates/stats/stats.html:60
-msgid "30 days"
-msgstr ""
-
-#: src/olympia/stats/templates/stats/stats.html:63
-msgid "90 days"
-msgstr ""
-
-#: src/olympia/stats/templates/stats/stats.html:66
-msgid "365 days"
-msgstr ""
-
-#: src/olympia/stats/templates/stats/stats.html:69
-msgid "Custom..."
-msgstr ""
-
 #. {0} is an add-on name
-#: src/olympia/stats/templates/stats/stats.html:88 src/olympia/stats/templates/stats/stats.html:91
+#: src/olympia/stats/templates/stats/stats.html:44 src/olympia/stats/templates/stats/stats.html:47
 msgid "Statistics for {0}"
 msgstr ""
 
-#: src/olympia/stats/templates/stats/stats.html:94
+#: src/olympia/stats/templates/stats/stats.html:50
 msgid "Statistics Dashboard"
 msgstr ""
 
-#: src/olympia/stats/templates/stats/stats.html:104
+#: src/olympia/stats/templates/stats/stats.html:57
+msgid "Controls:"
+msgstr ""
+
+#: src/olympia/stats/templates/stats/stats.html:60
+msgid "reset zoom"
+msgstr ""
+
+#: src/olympia/stats/templates/stats/stats.html:67
+msgid "Group by:"
+msgstr ""
+
+#: src/olympia/stats/templates/stats/stats.html:69
+msgid "day"
+msgstr ""
+
+#: src/olympia/stats/templates/stats/stats.html:72
+msgid "week"
+msgstr ""
+
+#: src/olympia/stats/templates/stats/stats.html:75
+msgid "month"
+msgstr ""
+
+#: src/olympia/stats/templates/stats/stats.html:81
+msgid "For last:"
+msgstr ""
+
+#: src/olympia/stats/templates/stats/stats.html:84
+msgid "7 days"
+msgstr ""
+
+#: src/olympia/stats/templates/stats/stats.html:87
+msgid "30 days"
+msgstr ""
+
+#: src/olympia/stats/templates/stats/stats.html:90
+msgid "90 days"
+msgstr ""
+
+#: src/olympia/stats/templates/stats/stats.html:93
+msgid "365 days"
+msgstr ""
+
+#: src/olympia/stats/templates/stats/stats.html:96
+msgid "Custom..."
+msgstr ""
+
+#: src/olympia/stats/templates/stats/stats.html:106
 msgid "Statistics processing is currently disabled, so recent data is unavailable. The statistics are still being collected and this page will be updated soon with the missing data."
 msgstr ""
 
-#: src/olympia/stats/templates/stats/stats.html:110
+#: src/olympia/stats/templates/stats/stats.html:112
 msgid "Loading the latest data&hellip;"
 msgstr ""
 
-#: src/olympia/stats/templates/stats/stats.html:142 src/olympia/stats/templates/stats/reports/overview.html:25 src/olympia/stats/templates/stats/reports/overview.html:37
+#: src/olympia/stats/templates/stats/stats.html:144 src/olympia/stats/templates/stats/reports/overview.html:25 src/olympia/stats/templates/stats/reports/overview.html:37
 #: src/olympia/stats/templates/stats/reports/overview.html:49
 msgid "No data available."
 msgstr ""
 
-#: src/olympia/stats/templates/stats/stats.html:177
+#: src/olympia/stats/templates/stats/stats.html:179
 msgid "This dashboard is currently <b>public</b>."
 msgstr ""
 
-#: src/olympia/stats/templates/stats/stats.html:179
+#: src/olympia/stats/templates/stats/stats.html:181
 msgid "Contribution stats are currently <b>private</b>."
 msgstr ""
 
-#: src/olympia/stats/templates/stats/stats.html:182
+#: src/olympia/stats/templates/stats/stats.html:184
 msgid "This dashboard is currently <b>private</b>."
 msgstr ""
 
-#: src/olympia/stats/templates/stats/stats.html:185
+#: src/olympia/stats/templates/stats/stats.html:187
 msgid "Change settings."
 msgstr ""
 
@@ -11299,15 +11141,6 @@ msgstr ""
 msgid "Application versions by Date"
 msgstr ""
 
-#: src/olympia/tags/templates/tags/top_cloud.html:4
-msgid "Top {0} Tags"
-msgstr ""
-
-#. {0} is the current application name
-#: src/olympia/tags/templates/tags/top_cloud.html:14
-msgid "{0} Top Tags"
-msgstr ""
-
 #: src/olympia/templates/amo_footer.html:6 src/olympia/templates/includes/lang_switcher.html:2
 msgid "Other languages"
 msgstr ""
@@ -11316,11 +11149,11 @@ msgstr ""
 msgid "Mozilla Add-ons"
 msgstr ""
 
-#: src/olympia/templates/base.html:91 src/olympia/templates/impala/base.html:81
+#: src/olympia/templates/base.html:89 src/olympia/templates/impala/base.html:78
 msgid "Find add-ons for other applications"
 msgstr ""
 
-#: src/olympia/templates/base.html:92 src/olympia/templates/impala/base.html:81
+#: src/olympia/templates/base.html:90 src/olympia/templates/impala/base.html:78
 msgid "Other Applications"
 msgstr ""
 
@@ -11345,7 +11178,7 @@ msgid "View Mobile Site"
 msgstr ""
 
 #: src/olympia/templates/copyright.html:7
-msgid "Site Status "
+msgid "Site Status"
 msgstr ""
 
 #: src/olympia/templates/footer.html:3
@@ -11445,35 +11278,35 @@ msgstr ""
 msgid "<a href=\"%(reg)s\">Register</a> or <a href=\"%(login)s\">Log in</a>"
 msgstr ""
 
-#: src/olympia/templates/impala/base.html:126
+#: src/olympia/templates/impala/base.html:123
 #, python-format
 msgid "To try the thousands of add-ons available here, download <a href=\"%(url)s\">Mozilla Firefox</a>, a fast, free way to surf the Web!"
 msgstr ""
 
-#: src/olympia/templates/impala/base.html:138
+#: src/olympia/templates/impala/base.html:135
 #, python-format
 msgid "Add-ons is switching to Firefox Accounts for login. <a href=\"%(url)s\" class=\"fxa-login\">Sign in now to transfer your account.</a>"
 msgstr ""
 
 #. {0} is an application, such as Firefox.
-#: src/olympia/templates/impala/base.html:148
+#: src/olympia/templates/impala/base.html:145
 msgid "Welcome to {0} Add-ons."
 msgstr ""
 
-#: src/olympia/templates/impala/base.html:151
+#: src/olympia/templates/impala/base.html:148
 msgid "Choose from thousands of extra features and styles to make Firefox your own."
 msgstr ""
 
-#: src/olympia/templates/impala/base.html:156
+#: src/olympia/templates/impala/base.html:153
 #, python-format
 msgid "Add extra features and styles to make %(app)s your own."
 msgstr ""
 
-#: src/olympia/templates/impala/base.html:164
+#: src/olympia/templates/impala/base.html:161
 msgid "On the go?"
 msgstr ""
 
-#: src/olympia/templates/impala/base.html:166
+#: src/olympia/templates/impala/base.html:163
 msgid "Check out our <a class=\"mobile-link\" href=\"#\">Mobile Add-ons site</a>."
 msgstr ""
 
@@ -11697,19 +11530,19 @@ msgstr ""
 
 #. L10n: {id} will be something like "13ad6a", just a random number
 #. to differentiate this user from other anonymous users.
-#: src/olympia/users/models.py:353
+#: src/olympia/users/models.py:362
 msgid "Anonymous user {id}"
 msgstr ""
 
-#: src/olympia/users/models.py:410
+#: src/olympia/users/models.py:419
 msgid "Your account has been restricted"
 msgstr ""
 
-#: src/olympia/users/models.py:480
+#: src/olympia/users/models.py:489
 msgid "Please confirm your email address"
 msgstr ""
 
-#: src/olympia/users/models.py:506
+#: src/olympia/users/models.py:515
 msgid "My Mobile Add-ons"
 msgstr ""
 
@@ -11986,7 +11819,7 @@ msgstr ""
 
 #: src/olympia/users/templates/users/edit.html:70
 #, python-format
-msgid "Change your password.  If you forgot your password, you can <a href=\"%(reset_url)s\">use the reset form</a>."
+msgid "Change your password. If you forgot your password, you can <a href=\"%(reset_url)s\">use the reset form</a>."
 msgstr ""
 
 #: src/olympia/users/templates/users/edit.html:76
@@ -12006,7 +11839,7 @@ msgid "Profile"
 msgstr ""
 
 #: src/olympia/users/templates/users/edit.html:100
-msgid "Give us a bit more information about yourself.  All these fields are optional, but they'll help other users get to know you better."
+msgid "Give us a bit more information about yourself. All these fields are optional, but they'll help other users get to know you better."
 msgstr ""
 
 #: src/olympia/users/templates/users/edit.html:124
@@ -12222,7 +12055,7 @@ msgid "Confirm password"
 msgstr ""
 
 #: src/olympia/users/templates/users/pwreset_confirm.html:47
-msgid "The password reset link was invalid, possibly because it has already been used.  Please request a new password reset."
+msgid "The password reset link was invalid, possibly because it has already been used. Please request a new password reset."
 msgstr ""
 
 #: src/olympia/users/templates/users/pwreset_request.html:15
@@ -12408,7 +12241,7 @@ msgstr ""
 
 #: src/olympia/users/templates/users/unsubscribe.html:30
 #, python-format
-msgid "Unfortunately, we weren't able to unsubscribe you.  The link you clicked is invalid. However, you can unsubscribe still unsubscribe on your <a href=\"%(edit_url)s\">edit profile page</a>."
+msgid "Unfortunately, we weren't able to unsubscribe you. The link you clicked is invalid. However, you can unsubscribe still unsubscribe on your <a href=\"%(edit_url)s\">edit profile page</a>."
 msgstr ""
 
 #: src/olympia/users/templates/users/vcard.html:2
@@ -12462,15 +12295,15 @@ msgstr ""
 msgid "Version History with Changelogs"
 msgstr ""
 
-#: src/olympia/versions/models.py:314
+#: src/olympia/versions/models.py:313
 msgid "Add-on uses binary components."
 msgstr ""
 
-#: src/olympia/versions/models.py:317
+#: src/olympia/versions/models.py:316
 msgid "Add-on has opted into strict compatibility checking."
 msgstr ""
 
-#: src/olympia/versions/models.py:715
+#: src/olympia/versions/models.py:711
 msgid "{app} {min} and later"
 msgstr ""
 
@@ -12545,4 +12378,8 @@ msgstr ""
 
 #: src/olympia/zadmin/forms.py:105
 msgid "Log emails instead of sending"
+msgstr ""
+
+#: src/olympia/zadmin/forms.py:215
+msgid "Deleted versions can`t be changed."
 msgstr ""

--- a/locale/bs/LC_MESSAGES/djangojs.po
+++ b/locale/bs/LC_MESSAGES/djangojs.po
@@ -1,1216 +1,1236 @@
-
 #, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2016-02-24 21:23+0000\n"
+"POT-Creation-Date: 2016-04-18 15:47+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
+"Language: \n"
 "MIME-Version: 1.0\n"
-"Content-Type: text/plain; charset=utf-8\n"
+"Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Generated-By: Babel 2.2.0\n"
 
-#: static/js/common/ratingwidget.js:31
+#: static/js/common-all.js:1426 static/js/impala-all.js:1511 static/js/zamboni/discovery-all.js:12598 static/js/zamboni/init.js:28 static/js/zamboni/mobile-all.js:14945
+msgid "This feature is temporarily disabled while we perform website maintenance. Please check back a little later."
+msgstr ""
+
+#. L10n: {0} is an app name like Firefox.
+#: static/js/common-all.js:1837 static/js/impala-all.js:1922 static/js/zamboni/buttons.js:73 static/js/zamboni/discovery-all.js:13108
+msgid "Accept and Install"
+msgstr ""
+
+#: static/js/common-all.js:1837 static/js/impala-all.js:1922 static/js/zamboni/buttons.js:73 static/js/zamboni/discovery-all.js:13108
+msgid "Add to {0}"
+msgstr ""
+
+#: static/js/common-all.js:1842 static/js/impala-all.js:1927 static/js/zamboni/buttons.js:78 static/js/zamboni/discovery-all.js:13113
+msgid "Download Now"
+msgstr ""
+
+#: static/js/common-all.js:1883 static/js/impala-all.js:1968 static/js/zamboni/buttons.js:119 static/js/zamboni/discovery-all.js:13154
+msgid "Add-on has not been updated to support default-to-compatible."
+msgstr ""
+
+#: static/js/common-all.js:1888 static/js/impala-all.js:1973 static/js/zamboni/buttons.js:124 static/js/zamboni/discovery-all.js:13159
+msgid "You need to be using Firefox 10.0 or higher."
+msgstr ""
+
+#: static/js/common-all.js:1900 static/js/impala-all.js:1985 static/js/zamboni/buttons.js:136 static/js/zamboni/discovery-all.js:13171
+msgid "Mozilla has marked this version as incompatible with your Firefox version."
+msgstr ""
+
+#. L10n: {0} is an platform like Windows or Linux.
+#: static/js/common-all.js:1981 static/js/impala-all.js:2066 static/js/zamboni/buttons.js:217 static/js/zamboni/discovery-all.js:13252
+msgid "Install for {0} anyway"
+msgstr ""
+
+#: static/js/common-all.js:1981 static/js/impala-all.js:2066 static/js/zamboni/buttons.js:217 static/js/zamboni/discovery-all.js:13252
+msgid "Download for {0} anyway"
+msgstr ""
+
+#: static/js/common-all.js:2038 static/js/impala-all.js:2123 static/js/zamboni/buttons.js:274 static/js/zamboni/discovery-all.js:13309
+msgid "Not available for your platform"
+msgstr ""
+
+#. L10n: {0} is an app name, {1} is the app version.
+#: static/js/common-all.js:2049 static/js/common-all.js:2086 static/js/impala-all.js:2134 static/js/impala-all.js:2171 static/js/zamboni/buttons.js:286 static/js/zamboni/buttons.js:324
+#: static/js/zamboni/discovery-all.js:13320 static/js/zamboni/discovery-all.js:13357
+msgid "Not available for {0} {1}"
+msgstr ""
+
+#: static/js/common-all.js:2112 static/js/impala-all.js:2197 static/js/zamboni/buttons.js:351 static/js/zamboni/discovery-all.js:13383
+msgid "Works with {app} {min} - {max}"
+msgstr ""
+
+#: static/js/common-all.js:2114 static/js/impala-all.js:2199 static/js/zamboni/buttons.js:353 static/js/zamboni/discovery-all.js:13385
+msgid "View other versions"
+msgstr ""
+
+#: static/js/common-all.js:2162 static/js/impala-all.js:2247 static/js/zamboni/buttons.js:401 static/js/zamboni/discovery-all.js:13433
+msgid "Only with Firefox — Get Firefox Now!"
+msgstr ""
+
+#: static/js/common-all.js:2278 static/js/impala-all.js:2363 static/js/zamboni/buttons.js:517 static/js/zamboni/discovery-all.js:13549 static/js/zamboni/mobile-all.js:15177
+#: static/js/zamboni/mobile/buttons.js:43
+msgid "Sorry, you need a Mozilla-based browser (such as Firefox) to install a search plugin."
+msgstr ""
+
+#: static/js/common-all.js:9088 static/js/impala-all.js:9649 static/js/zamboni/global.js:410
+msgid "Loading..."
+msgstr ""
+
+#. L10n: {0} is the number of characters left.
+#: static/js/common-all.js:9152 static/js/impala-all.js:9713 static/js/zamboni/global.js:474
+msgid "<b>{0}</b> character left."
+msgid_plural "<b>{0}</b> characters left."
+msgstr[0] ""
+msgstr[1] ""
+
+#: static/js/common-all.js:9589 static/js/common-min.js:6 static/js/impala-all.js:10052 static/js/impala-min.js:6 static/js/common/ratingwidget.js:31 static/js/zamboni/mobile-all.js:16123
+#: static/js/zamboni/mobile-min.js:6
 msgid "{0} star"
 msgid_plural "{0} stars"
 msgstr[0] ""
 msgstr[1] ""
 
-#: static/js/common/upload-addon.js:41 static/js/common/upload-image.js:128
+#: static/js/common-all.js:9676 static/js/common-min.js:6 static/js/impala-all.js:10139 static/js/impala-min.js:6 static/js/zamboni/l10n.js:45
+msgid "Remove this localization"
+msgstr ""
+
+#: static/js/common-all.js:10193 static/js/common-min.js:6 static/js/impala-all.js:10674 static/js/impala-min.js:6 static/js/zamboni/discovery-all.js:13678
+msgid "close"
+msgstr ""
+
+#: static/js/common-all.js:10860 static/js/common-min.js:6 static/js/impala-all.js:11481 static/js/impala-min.js:6 static/js/impala/reviews.js:23 static/js/zamboni/reviews.js:18
+msgid "Flagged for review"
+msgstr ""
+
+#: static/js/common-all.js:10876 static/js/common-min.js:6 static/js/impala-all.js:11498 static/js/impala-min.js:6 static/js/impala/reviews.js:40 static/js/zamboni/reviews.js:34
+msgid "Your input is required"
+msgstr ""
+
+#: static/js/common-all.js:10945 static/js/common-min.js:6 static/js/impala-all.js:11610 static/js/impala-min.js:7 static/js/impala/reviews.js:152 static/js/zamboni/reviews.js:103
+msgid "Marked for deletion"
+msgstr ""
+
+#: static/js/common-all.js:11573 static/js/common-min.js:7 static/js/impala-all.js:13809 static/js/impala-min.js:8 static/js/zamboni/collections.js:229
+msgid "Adding to Favorites&hellip;"
+msgstr ""
+
+#: static/js/common-all.js:11576 static/js/common-min.js:7 static/js/impala-all.js:13812 static/js/impala-min.js:8 static/js/zamboni/collections.js:232
+msgid "Removing Favorite&hellip;"
+msgstr ""
+
+#: static/js/common-all.js:11579 static/js/common-min.js:7 static/js/impala-all.js:13815 static/js/impala-min.js:8 static/js/zamboni/collections.js:235
+msgid "Add to Favorites"
+msgstr ""
+
+#: static/js/common-all.js:11582 static/js/common-min.js:7 static/js/impala-all.js:13818 static/js/impala-min.js:8 static/js/zamboni/collections.js:238
+msgid "Remove from Favorites"
+msgstr ""
+
+#: static/js/common-all.js:11647 static/js/common-min.js:7 static/js/impala-all.js:13883 static/js/impala-min.js:8 static/js/zamboni/collections.js:303
+msgid "Pending"
+msgstr ""
+
+#: static/js/common-all.js:11648 static/js/common-min.js:7 static/js/impala-all.js:13884 static/js/impala-min.js:8 static/js/zamboni/collections.js:304
+msgid "Add a comment"
+msgstr ""
+
+#: static/js/common-all.js:11648 static/js/common-min.js:7 static/js/impala-all.js:13884 static/js/impala-min.js:8 static/js/zamboni/collections.js:304
+msgid "Comment"
+msgstr ""
+
+#: static/js/common-all.js:11649 static/js/common-min.js:7 static/js/impala-all.js:13885 static/js/impala-min.js:8 static/js/zamboni/collections.js:305
+msgid "Remove this add-on from the collection"
+msgstr ""
+
+#: static/js/common-all.js:11649 static/js/common-all.js:11678 static/js/common-min.js:7 static/js/impala-all.js:13885 static/js/impala-all.js:13914 static/js/impala-min.js:8
+#: static/js/zamboni/collections.js:305 static/js/zamboni/collections.js:334
+msgid "Remove"
+msgstr ""
+
+#: static/js/common-all.js:11678 static/js/common-min.js:7 static/js/impala-all.js:13914 static/js/impala-min.js:8 static/js/zamboni/collections.js:334
+msgid "Remove this user as a contributor"
+msgstr ""
+
+#: static/js/common-all.js:11690 static/js/common-min.js:7 static/js/impala-all.js:13926 static/js/impala-min.js:8 static/js/zamboni/collections.js:346
+msgid "An email address is required."
+msgstr ""
+
+#: static/js/common-all.js:11708 static/js/common-min.js:7 static/js/impala-all.js:13944 static/js/impala-min.js:8 static/js/zamboni/collections.js:364
+msgid "You cannot add yourself as a contributor."
+msgstr ""
+
+#: static/js/common-all.js:11710 static/js/common-min.js:7 static/js/impala-all.js:13946 static/js/impala-min.js:8 static/js/zamboni/collections.js:366
+msgid "You have already added that user."
+msgstr ""
+
+#: static/js/common-all.js:11917 static/js/common-min.js:7 static/js/impala-all.js:14153 static/js/impala-min.js:8 static/js/zamboni/collections.js:573
+msgid "Add to favorites"
+msgstr ""
+
+#: static/js/common-all.js:11921 static/js/common-min.js:7 static/js/impala-all.js:14157 static/js/impala-min.js:8 static/js/zamboni/collections.js:577
+msgid "Remove from favorites"
+msgstr ""
+
+#: static/js/common-all.js:11939 static/js/common-min.js:7 static/js/impala-all.js:14175 static/js/impala-all.js:14233 static/js/impala-min.js:8 static/js/impala/collections.js:10
+#: static/js/zamboni/collections.js:595
+msgid "Follow this Collection"
+msgstr ""
+
+#: static/js/common-all.js:11948 static/js/common-min.js:7 static/js/impala-all.js:14184 static/js/impala-min.js:8 static/js/zamboni/collections.js:604
+msgid "Stop following"
+msgstr ""
+
+#: static/js/common-all.js:12096 static/js/common-min.js:7 static/js/zamboni/password-strength.js:20
+msgid "Password strength:"
+msgstr ""
+
+#: static/js/common-all.js:12102 static/js/common-min.js:7 static/js/zamboni/password-strength.js:26
+msgid "At least {0} character left."
+msgid_plural "At least {0} characters left."
+msgstr[0] ""
+msgstr[1] ""
+
+#: static/js/common-all.js:12286 static/js/common-min.js:7 static/js/impala-all.js:14632 static/js/impala-min.js:8 static/js/impala/suggestions.js:39
+msgid "Search themes for <b>{0}</b>"
+msgstr ""
+
+#: static/js/common-all.js:12288 static/js/common-min.js:7 static/js/impala-all.js:14634 static/js/impala-min.js:8 static/js/impala/suggestions.js:41
+msgid "Search apps for <b>{0}</b>"
+msgstr ""
+
+#: static/js/common-all.js:12290 static/js/common-min.js:7 static/js/impala-all.js:14636 static/js/impala-min.js:8 static/js/impala/suggestions.js:43
+msgid "Search add-ons for <b>{0}</b>"
+msgstr ""
+
+#: static/js/common-all.js:12521 static/js/common-min.js:7 static/js/impala-all.js:14867 static/js/impala-min.js:8 static/js/impala/site_suggestions.js:46
+msgid "Category"
+msgstr ""
+
+#. L10n: {0} is an app name.
+#: static/js/impala-all.js:11632 static/js/impala-min.js:7 static/js/impala/listing.js:11 static/js/zamboni/themes.js:13
+msgid "This theme is incompatible with your version of {0}"
+msgstr ""
+
+#: static/js/impala-all.js:12146 static/js/impala-all.js:14331 static/js/impala-min.js:7 static/js/impala-min.js:8 static/js/common/upload-image.js:97 static/js/impala/users.js:51
+#: static/js/zamboni/devhub-all.js:894 static/js/zamboni/devhub-min.js:1
+msgid "Images must be either PNG or JPG."
+msgstr ""
+
+#: static/js/impala-all.js:12150 static/js/impala-min.js:7 static/js/common/upload-image.js:101 static/js/zamboni/devhub-all.js:898 static/js/zamboni/devhub-min.js:1
+msgid "Videos must be in WebM."
+msgstr ""
+
+#: static/js/impala-all.js:12177 static/js/impala-min.js:7 static/js/common/upload-addon.js:41 static/js/common/upload-image.js:128 static/js/zamboni/devhub-all.js:272
+#: static/js/zamboni/devhub-all.js:925 static/js/zamboni/devhub-min.js:1
 msgid "There was a problem contacting the server."
 msgstr ""
 
-#: static/js/common/upload-addon.js:69
+#: static/js/impala-all.js:13298 static/js/impala-min.js:7 static/js/impala/persona_creation.js:60
+msgid "All Rights Reserved"
+msgstr ""
+
+#: static/js/impala-all.js:13302 static/js/impala-min.js:7 static/js/impala/persona_creation.js:64
+msgid "Creative Commons Attribution 3.0"
+msgstr ""
+
+#: static/js/impala-all.js:13307 static/js/impala-min.js:7 static/js/impala/persona_creation.js:69
+msgid "Creative Commons Attribution-NonCommercial 3.0"
+msgstr ""
+
+#: static/js/impala-all.js:13312 static/js/impala-min.js:7 static/js/impala/persona_creation.js:74
+msgid "Creative Commons Attribution-NonCommercial-NoDerivs 3.0"
+msgstr ""
+
+#: static/js/impala-all.js:13317 static/js/impala-min.js:7 static/js/impala/persona_creation.js:79
+msgid "Creative Commons Attribution-NonCommercial-Share Alike 3.0"
+msgstr ""
+
+#: static/js/impala-all.js:13322 static/js/impala-min.js:7 static/js/impala/persona_creation.js:84
+msgid "Creative Commons Attribution-NoDerivs 3.0"
+msgstr ""
+
+#: static/js/impala-all.js:13327 static/js/impala-min.js:7 static/js/impala/persona_creation.js:89
+msgid "Creative Commons Attribution-ShareAlike 3.0"
+msgstr ""
+
+#: static/js/impala-all.js:13530 static/js/impala-min.js:7 static/js/impala/persona_creation.js:292
+msgid "Your Theme's Name"
+msgstr ""
+
+#: static/js/impala-all.js:14242 static/js/impala-min.js:8 static/js/impala/collections.js:19
+msgid "Stop Following"
+msgstr ""
+
+#: static/js/impala-all.js:14243 static/js/impala-min.js:8 static/js/impala/collections.js:20
+msgid "Following"
+msgstr ""
+
+#: static/js/impala-all.js:14313 static/js/impala-min.js:8 static/js/impala/users.js:33
+msgid "use original"
+msgstr ""
+
+#: static/js/impala-all.js:14523 static/js/impala-min.js:8 static/js/impala/search.js:114
+msgid "Updating results&hellip;"
+msgstr ""
+
+#: static/js/common/upload-addon.js:69 static/js/zamboni/devhub-all.js:300 static/js/zamboni/devhub-min.js:1
 msgid "Select a file..."
 msgstr ""
 
-#: static/js/common/upload-addon.js:70
+#: static/js/common/upload-addon.js:70 static/js/zamboni/devhub-all.js:301 static/js/zamboni/devhub-min.js:1
 msgid "Your add-on should end with .xpi, .jar or .xml"
 msgstr ""
 
 #. L10n: {0} is the percent of the file that has been uploaded.
-#: static/js/common/upload-addon.js:104
+#: static/js/common/upload-addon.js:104 static/js/zamboni/devhub-all.js:335 static/js/zamboni/devhub-min.js:1
 #, python-format
 msgid "{0}% complete"
 msgstr ""
 
 #. L10n: "{bytes uploaded} of {total filesize}".
-#: static/js/common/upload-addon.js:107
+#: static/js/common/upload-addon.js:107 static/js/zamboni/devhub-all.js:338 static/js/zamboni/devhub-min.js:1
 msgid "{0} of {1}"
 msgstr ""
 
-#: static/js/common/upload-addon.js:140
+#: static/js/common/upload-addon.js:140 static/js/zamboni/devhub-all.js:371 static/js/zamboni/devhub-min.js:1
 msgid "Cancel"
 msgstr ""
 
-#: static/js/common/upload-addon.js:162
+#: static/js/common/upload-addon.js:162 static/js/zamboni/devhub-all.js:393 static/js/zamboni/devhub-min.js:1
 msgid "Uploading {0}"
 msgstr ""
 
-#: static/js/common/upload-addon.js:189
+#: static/js/common/upload-addon.js:189 static/js/zamboni/devhub-all.js:420 static/js/zamboni/devhub-min.js:1
 msgid "Error with {0}"
 msgstr ""
 
-#: static/js/common/upload-addon.js:194
+#: static/js/common/upload-addon.js:194 static/js/zamboni/devhub-all.js:425 static/js/zamboni/devhub-min.js:1
 msgid "Your add-on failed validation with {0} error."
 msgid_plural "Your add-on failed validation with {0} errors."
 msgstr[0] ""
 msgstr[1] ""
 
-#: static/js/common/upload-addon.js:208
+#: static/js/common/upload-addon.js:208 static/js/zamboni/devhub-all.js:439 static/js/zamboni/devhub-min.js:1
 msgid "&hellip;and {0} more"
 msgid_plural "&hellip;and {0} more"
 msgstr[0] ""
 msgstr[1] ""
 
-#: static/js/common/upload-addon.js:222 static/js/common/upload-addon.js:512
+#: static/js/common/upload-addon.js:222 static/js/common/upload-addon.js:497 static/js/zamboni/devhub-all.js:453 static/js/zamboni/devhub-all.js:743 static/js/zamboni/devhub-min.js:1
 msgid "See full validation report"
 msgstr ""
 
-#: static/js/common/upload-addon.js:234
+#: static/js/common/upload-addon.js:234 static/js/zamboni/devhub-all.js:465 static/js/zamboni/devhub-min.js:1
 msgid "Validating {0}"
 msgstr ""
 
 #. L10n: first argument is an HTTP status code
-#: static/js/common/upload-addon.js:273
+#: static/js/common/upload-addon.js:273 static/js/zamboni/devhub-all.js:504 static/js/zamboni/devhub-min.js:1
 msgid "Received an empty response from the server; status: {0}"
 msgstr ""
 
-#: static/js/common/upload-addon.js:373
+#: static/js/common/upload-addon.js:370 static/js/zamboni/devhub-all.js:604 static/js/zamboni/devhub-min.js:1
 msgid "Unexpected server error while validating."
 msgstr ""
 
-#: static/js/common/upload-addon.js:412
+#: static/js/common/upload-addon.js:409 static/js/zamboni/devhub-all.js:643 static/js/zamboni/devhub-min.js:1
 msgid "Finished validating {0}"
 msgstr ""
 
-#: static/js/common/upload-addon.js:418
+#: static/js/common/upload-addon.js:415 static/js/zamboni/devhub-all.js:649 static/js/zamboni/devhub-min.js:1
 msgid "Your add-on validation timed out, it will be manually reviewed."
 msgstr ""
 
-#: static/js/common/upload-addon.js:421
+#: static/js/common/upload-addon.js:418 static/js/zamboni/devhub-all.js:652 static/js/zamboni/devhub-min.js:1
 msgid "Your add-on was validated with no errors and {0} warning."
 msgid_plural "Your add-on was validated with no errors and {0} warnings."
 msgstr[0] ""
 msgstr[1] ""
 
-#: static/js/common/upload-addon.js:426
+#: static/js/common/upload-addon.js:423 static/js/zamboni/devhub-all.js:657 static/js/zamboni/devhub-min.js:1
 msgid "Your add-on was validated with no errors and {0} message."
 msgid_plural "Your add-on was validated with no errors and {0} messages."
 msgstr[0] ""
 msgstr[1] ""
 
-#: static/js/common/upload-addon.js:431
+#: static/js/common/upload-addon.js:428 static/js/zamboni/devhub-all.js:662 static/js/zamboni/devhub-min.js:1
 msgid "Your add-on was validated with no errors or warnings."
 msgstr ""
 
-#: static/js/common/upload-addon.js:446
+#: static/js/common/upload-addon.js:443 static/js/zamboni/devhub-all.js:677 static/js/zamboni/devhub-min.js:1
 msgid "Your submission will be automatically signed."
 msgstr ""
 
-#: static/js/common/upload-addon.js:465
+#: static/js/common/upload-addon.js:450 static/js/zamboni/devhub-all.js:696 static/js/zamboni/devhub-min.js:1
 msgid "Include detailed version notes (this can be done in the next step)."
 msgstr ""
 
-#: static/js/common/upload-addon.js:466
+#: static/js/common/upload-addon.js:451 static/js/zamboni/devhub-all.js:697 static/js/zamboni/devhub-min.js:1
 msgid "If your add-on requires an account to a website in order to be fully tested, include a test username and password in the Notes to Reviewer (this can be done in the next step)."
 msgstr ""
 
-#: static/js/common/upload-addon.js:467
+#: static/js/common/upload-addon.js:452 static/js/zamboni/devhub-all.js:698 static/js/zamboni/devhub-min.js:1
 msgid "If your add-on is intended for a limited audience you should choose Preliminary Review instead of Full Review."
 msgstr ""
 
-#: static/js/common/upload-addon.js:480
+#: static/js/common/upload-addon.js:465 static/js/zamboni/devhub-all.js:711 static/js/zamboni/devhub-min.js:1
 msgid "Add-on submission checklist"
 msgstr ""
 
-#: static/js/common/upload-addon.js:481
+#: static/js/common/upload-addon.js:466 static/js/zamboni/devhub-all.js:712 static/js/zamboni/devhub-min.js:1
 msgid "Please verify the following points before finalizing your submission. This will minimize delays or misunderstanding during the review process:"
 msgstr ""
 
-#: static/js/common/upload-addon.js:483
+#: static/js/common/upload-addon.js:468 static/js/zamboni/devhub-all.js:714 static/js/zamboni/devhub-min.js:1
 msgid ""
 "Compiled binaries, as well as minified or obfuscated scripts (excluding known libraries) need to have their sources submitted separately for review. Make sure that you use the source code upload "
 "field to avoid having your submission rejected."
 msgstr ""
 
-#: static/js/common/upload-addon.js:501
+#: static/js/common/upload-addon.js:486 static/js/zamboni/devhub-all.js:732 static/js/zamboni/devhub-min.js:1
 msgid "The validation process found these issues that can lead to rejections:"
 msgstr ""
 
-#: static/js/common/upload-addon.js:518
+#: static/js/common/upload-addon.js:503 static/js/zamboni/devhub-all.js:749 static/js/zamboni/devhub-min.js:1
 msgid "If you are unfamiliar with the add-ons review process, you can read about it here."
 msgstr ""
 
-#: static/js/common/upload-addon.js:555
+#: static/js/common/upload-addon.js:540 static/js/zamboni/devhub-all.js:786 static/js/zamboni/devhub-min.js:1
 msgid "Sorry, no supported platform has been found."
 msgstr ""
 
-#: static/js/common/upload-base.js:57
+#: static/js/common/upload-base.js:57 static/js/zamboni/devhub-all.js:187 static/js/zamboni/devhub-min.js:1
 msgid "The filetype you uploaded isn't recognized."
 msgstr ""
 
-#: static/js/common/upload-base.js:79
+#: static/js/common/upload-base.js:79 static/js/zamboni/devhub-all.js:209 static/js/zamboni/devhub-min.js:1
 msgid "You cancelled the upload."
 msgstr ""
 
-#: static/js/common/upload-image.js:97 static/js/impala/users.js:51
-msgid "Images must be either PNG or JPG."
-msgstr ""
-
-#: static/js/common/upload-image.js:101
-msgid "Videos must be in WebM."
-msgstr ""
-
-#: static/js/impala/collections.js:10 static/js/zamboni/collections.js:595
-msgid "Follow this Collection"
-msgstr ""
-
-#: static/js/impala/collections.js:19
-msgid "Stop Following"
-msgstr ""
-
-#: static/js/impala/collections.js:20
-msgid "Following"
-msgstr ""
-
-#. L10n: {0} is an app name.
-#: static/js/impala/listing.js:11 static/js/zamboni/themes.js:13
-msgid "This theme is incompatible with your version of {0}"
-msgstr ""
-
-#: static/js/impala/persona_creation.js:60
-msgid "All Rights Reserved"
-msgstr ""
-
-#: static/js/impala/persona_creation.js:64
-msgid "Creative Commons Attribution 3.0"
-msgstr ""
-
-#: static/js/impala/persona_creation.js:69
-msgid "Creative Commons Attribution-NonCommercial 3.0"
-msgstr ""
-
-#: static/js/impala/persona_creation.js:74
-msgid "Creative Commons Attribution-NonCommercial-NoDerivs 3.0"
-msgstr ""
-
-#: static/js/impala/persona_creation.js:79
-msgid "Creative Commons Attribution-NonCommercial-Share Alike 3.0"
-msgstr ""
-
-#: static/js/impala/persona_creation.js:84
-msgid "Creative Commons Attribution-NoDerivs 3.0"
-msgstr ""
-
-#: static/js/impala/persona_creation.js:89
-msgid "Creative Commons Attribution-ShareAlike 3.0"
-msgstr ""
-
-#: static/js/impala/persona_creation.js:292
-msgid "Your Theme's Name"
-msgstr ""
-
-#: static/js/impala/reviews.js:23 static/js/zamboni/reviews.js:18
-msgid "Flagged for review"
-msgstr ""
-
-#: static/js/impala/reviews.js:40 static/js/zamboni/reviews.js:34
-msgid "Your input is required"
-msgstr ""
-
-#: static/js/impala/reviews.js:152 static/js/zamboni/reviews.js:103
-msgid "Marked for deletion"
-msgstr ""
-
-#: static/js/impala/search.js:114
-msgid "Updating results&hellip;"
-msgstr ""
-
-#: static/js/impala/site_suggestions.js:46
-msgid "Category"
-msgstr ""
-
-#: static/js/impala/suggestions.js:39
-msgid "Search themes for <b>{0}</b>"
-msgstr ""
-
-#: static/js/impala/suggestions.js:41
-msgid "Search apps for <b>{0}</b>"
-msgstr ""
-
-#: static/js/impala/suggestions.js:43
-msgid "Search add-ons for <b>{0}</b>"
-msgstr ""
-
-#: static/js/impala/users.js:33
-msgid "use original"
-msgstr ""
-
-#: static/js/impala/stats/chart.js:267
+#: static/js/impala/stats/chart.js:267 static/js/zamboni/stats-all.js:16898 static/js/zamboni/stats-min.js:5
 msgid "Week of {0}"
 msgstr ""
 
-#: static/js/impala/stats/chart.js:269
+#: static/js/impala/stats/chart.js:269 static/js/zamboni/stats-all.js:16900 static/js/zamboni/stats-min.js:5
 msgid " downloads"
 msgstr ""
 
-#: static/js/impala/stats/chart.js:270
+#: static/js/impala/stats/chart.js:270 static/js/zamboni/stats-all.js:16901 static/js/zamboni/stats-min.js:5
 msgid "{0} users"
 msgstr ""
 
-#: static/js/impala/stats/chart.js:271
+#: static/js/impala/stats/chart.js:271 static/js/zamboni/stats-all.js:16902 static/js/zamboni/stats-min.js:5
 msgid "{0} add-ons"
 msgstr ""
 
-#: static/js/impala/stats/chart.js:272
+#: static/js/impala/stats/chart.js:272 static/js/zamboni/stats-all.js:16903 static/js/zamboni/stats-min.js:5
 msgid "{0} collections"
 msgstr ""
 
-#: static/js/impala/stats/chart.js:273
+#: static/js/impala/stats/chart.js:273 static/js/zamboni/stats-all.js:16904 static/js/zamboni/stats-min.js:5
 msgid "{0} reviews"
 msgstr ""
 
-#: static/js/impala/stats/chart.js:275
+#: static/js/impala/stats/chart.js:275 static/js/zamboni/stats-all.js:16906 static/js/zamboni/stats-min.js:5
 msgid "{0} sales"
 msgstr ""
 
-#: static/js/impala/stats/chart.js:276
+#: static/js/impala/stats/chart.js:276 static/js/zamboni/stats-all.js:16907 static/js/zamboni/stats-min.js:5
 msgid "{0} refunds"
 msgstr ""
 
-#: static/js/impala/stats/chart.js:277
+#: static/js/impala/stats/chart.js:277 static/js/zamboni/stats-all.js:16908 static/js/zamboni/stats-min.js:5
 msgid "{0} installs"
 msgstr ""
 
-#: static/js/impala/stats/chart.js:369 static/js/impala/stats/csv_keys.js:3 static/js/impala/stats/csv_keys.js:109
+#: static/js/impala/stats/chart.js:369 static/js/impala/stats/csv_keys.js:3 static/js/impala/stats/csv_keys.js:109 static/js/zamboni/stats-all.js:15284 static/js/zamboni/stats-all.js:15390
+#: static/js/zamboni/stats-all.js:17000 static/js/zamboni/stats-min.js:4 static/js/zamboni/stats-min.js:5
 msgid "Downloads"
 msgstr ""
 
-#: static/js/impala/stats/chart.js:379 static/js/impala/stats/csv_keys.js:6 static/js/impala/stats/csv_keys.js:110
+#: static/js/impala/stats/chart.js:379 static/js/impala/stats/csv_keys.js:6 static/js/impala/stats/csv_keys.js:110 static/js/zamboni/stats-all.js:15287 static/js/zamboni/stats-all.js:15391
+#: static/js/zamboni/stats-all.js:17010 static/js/zamboni/stats-min.js:4 static/js/zamboni/stats-min.js:5
 msgid "Daily Users"
 msgstr ""
 
-#: static/js/impala/stats/chart.js:410
+#: static/js/impala/stats/chart.js:410 static/js/zamboni/stats-all.js:17041 static/js/zamboni/stats-min.js:5
 msgid "Amount, in USD"
 msgstr ""
 
-#: static/js/impala/stats/chart.js:421 static/js/impala/stats/csv_keys.js:104
+#: static/js/impala/stats/chart.js:421 static/js/impala/stats/csv_keys.js:104 static/js/zamboni/stats-all.js:15385 static/js/zamboni/stats-all.js:17052 static/js/zamboni/stats-min.js:5
 msgid "Number of Contributions"
 msgstr ""
 
-#: static/js/impala/stats/chart.js:447
+#: static/js/impala/stats/chart.js:447 static/js/zamboni/stats-all.js:17078 static/js/zamboni/stats-min.js:5
 msgid "More Info..."
 msgstr ""
 
 #. L10n: {0} is an ISO-formatted date.
-#: static/js/impala/stats/chart.js:451
+#: static/js/impala/stats/chart.js:451 static/js/zamboni/stats-all.js:17082 static/js/zamboni/stats-min.js:5
 msgid "Details for {0}"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:9
+#: static/js/impala/stats/csv_keys.js:9 static/js/zamboni/stats-all.js:15290 static/js/zamboni/stats-min.js:4
 msgid "Collections Created"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:12
+#: static/js/impala/stats/csv_keys.js:12 static/js/zamboni/stats-all.js:15293 static/js/zamboni/stats-min.js:4
 msgid "Add-ons in Use"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:15
+#: static/js/impala/stats/csv_keys.js:15 static/js/zamboni/stats-all.js:15296 static/js/zamboni/stats-min.js:4
 msgid "Add-ons Created"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:18
+#: static/js/impala/stats/csv_keys.js:18 static/js/zamboni/stats-all.js:15299 static/js/zamboni/stats-min.js:4
 msgid "Add-ons Downloaded"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:21
+#: static/js/impala/stats/csv_keys.js:21 static/js/zamboni/stats-all.js:15302 static/js/zamboni/stats-min.js:4
 msgid "Add-ons Updated"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:24
+#: static/js/impala/stats/csv_keys.js:24 static/js/zamboni/stats-all.js:15305 static/js/zamboni/stats-min.js:4
 msgid "Reviews Written"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:27
+#: static/js/impala/stats/csv_keys.js:27 static/js/zamboni/stats-all.js:15308 static/js/zamboni/stats-min.js:4
 msgid "User Signups"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:30
+#: static/js/impala/stats/csv_keys.js:30 static/js/zamboni/stats-all.js:15311 static/js/zamboni/stats-min.js:4
 msgid "Subscribers"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:33
+#: static/js/impala/stats/csv_keys.js:33 static/js/zamboni/stats-all.js:15314 static/js/zamboni/stats-min.js:4
 msgid "Ratings"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:36 static/js/impala/stats/csv_keys.js:114
+#: static/js/impala/stats/csv_keys.js:36 static/js/impala/stats/csv_keys.js:114 static/js/zamboni/stats-all.js:15317 static/js/zamboni/stats-all.js:15395 static/js/zamboni/stats-min.js:4
+#: static/js/zamboni/stats-min.js:5
 msgid "Sales"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:39 static/js/impala/stats/csv_keys.js:113
+#: static/js/impala/stats/csv_keys.js:39 static/js/impala/stats/csv_keys.js:113 static/js/zamboni/stats-all.js:15320 static/js/zamboni/stats-all.js:15394 static/js/zamboni/stats-min.js:4
+#: static/js/zamboni/stats-min.js:5
 msgid "Installs"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:42
+#: static/js/impala/stats/csv_keys.js:42 static/js/zamboni/stats-all.js:15323 static/js/zamboni/stats-min.js:4
 msgid "Unknown"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:43
+#: static/js/impala/stats/csv_keys.js:43 static/js/zamboni/stats-all.js:15324 static/js/zamboni/stats-min.js:4
 msgid "Add-ons Manager"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:44
+#: static/js/impala/stats/csv_keys.js:44 static/js/zamboni/stats-all.js:15325 static/js/zamboni/stats-min.js:4
 msgid "Add-ons Manager Promo"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:45
+#: static/js/impala/stats/csv_keys.js:45 static/js/zamboni/stats-all.js:15326 static/js/zamboni/stats-min.js:4
 msgid "Add-ons Manager Featured"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:46
+#: static/js/impala/stats/csv_keys.js:46 static/js/zamboni/stats-all.js:15327 static/js/zamboni/stats-min.js:4
 msgid "Add-ons Manager Learn More"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:47
+#: static/js/impala/stats/csv_keys.js:47 static/js/zamboni/stats-all.js:15328 static/js/zamboni/stats-min.js:4
 msgid "Search Suggestions"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:48
+#: static/js/impala/stats/csv_keys.js:48 static/js/zamboni/stats-all.js:15329 static/js/zamboni/stats-min.js:4
 msgid "Search Results"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:49 static/js/impala/stats/csv_keys.js:50 static/js/impala/stats/csv_keys.js:51
+#: static/js/impala/stats/csv_keys.js:49 static/js/impala/stats/csv_keys.js:50 static/js/impala/stats/csv_keys.js:51 static/js/zamboni/stats-all.js:15330 static/js/zamboni/stats-all.js:15331
+#: static/js/zamboni/stats-all.js:15332 static/js/zamboni/stats-min.js:4
 msgid "Homepage Promo"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:52 static/js/impala/stats/csv_keys.js:53
+#: static/js/impala/stats/csv_keys.js:52 static/js/impala/stats/csv_keys.js:53 static/js/zamboni/stats-all.js:15333 static/js/zamboni/stats-all.js:15334 static/js/zamboni/stats-min.js:4
 msgid "Homepage Featured"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:54 static/js/impala/stats/csv_keys.js:55
+#: static/js/impala/stats/csv_keys.js:54 static/js/impala/stats/csv_keys.js:55 static/js/zamboni/stats-all.js:15335 static/js/zamboni/stats-all.js:15336 static/js/zamboni/stats-min.js:4
 msgid "Homepage Up and Coming"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:56
+#: static/js/impala/stats/csv_keys.js:56 static/js/zamboni/stats-all.js:15337 static/js/zamboni/stats-min.js:4
 msgid "Homepage Most Popular"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:57 static/js/impala/stats/csv_keys.js:59
+#: static/js/impala/stats/csv_keys.js:57 static/js/impala/stats/csv_keys.js:59 static/js/zamboni/stats-all.js:15338 static/js/zamboni/stats-all.js:15340 static/js/zamboni/stats-min.js:4
 msgid "Detail Page"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:58 static/js/impala/stats/csv_keys.js:60
+#: static/js/impala/stats/csv_keys.js:58 static/js/impala/stats/csv_keys.js:60 static/js/zamboni/stats-all.js:15339 static/js/zamboni/stats-all.js:15341 static/js/zamboni/stats-min.js:4
 msgid "Detail Page (bottom)"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:61
+#: static/js/impala/stats/csv_keys.js:61 static/js/zamboni/stats-all.js:15342 static/js/zamboni/stats-min.js:4
 msgid "Detail Page (Development Channel)"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:62 static/js/impala/stats/csv_keys.js:63 static/js/impala/stats/csv_keys.js:64
+#: static/js/impala/stats/csv_keys.js:62 static/js/impala/stats/csv_keys.js:63 static/js/impala/stats/csv_keys.js:64 static/js/zamboni/stats-all.js:15343 static/js/zamboni/stats-all.js:15344
+#: static/js/zamboni/stats-all.js:15345 static/js/zamboni/stats-min.js:4
 msgid "Often Used With"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:65 static/js/impala/stats/csv_keys.js:66
+#: static/js/impala/stats/csv_keys.js:65 static/js/impala/stats/csv_keys.js:66 static/js/zamboni/stats-all.js:15346 static/js/zamboni/stats-all.js:15347 static/js/zamboni/stats-min.js:4
 msgid "Others By Author"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:67 static/js/impala/stats/csv_keys.js:68
+#: static/js/impala/stats/csv_keys.js:67 static/js/impala/stats/csv_keys.js:68 static/js/zamboni/stats-all.js:15348 static/js/zamboni/stats-all.js:15349 static/js/zamboni/stats-min.js:4
 msgid "Dependencies"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:69 static/js/impala/stats/csv_keys.js:70
+#: static/js/impala/stats/csv_keys.js:69 static/js/impala/stats/csv_keys.js:70 static/js/zamboni/stats-all.js:15350 static/js/zamboni/stats-all.js:15351 static/js/zamboni/stats-min.js:4
 msgid "Upsell"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:71
+#: static/js/impala/stats/csv_keys.js:71 static/js/zamboni/stats-all.js:15352 static/js/zamboni/stats-min.js:4
 msgid "Meet the Developer"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:72
+#: static/js/impala/stats/csv_keys.js:72 static/js/zamboni/stats-all.js:15353 static/js/zamboni/stats-min.js:4
 msgid "User Profile"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:73
+#: static/js/impala/stats/csv_keys.js:73 static/js/zamboni/stats-all.js:15354 static/js/zamboni/stats-min.js:4
 msgid "Version History"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:75
+#: static/js/impala/stats/csv_keys.js:75 static/js/zamboni/stats-all.js:15356 static/js/zamboni/stats-min.js:4
 msgid "Sharing"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:76
+#: static/js/impala/stats/csv_keys.js:76 static/js/zamboni/stats-all.js:15357 static/js/zamboni/stats-min.js:4
 msgid "Category Pages"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:77
+#: static/js/impala/stats/csv_keys.js:77 static/js/zamboni/stats-all.js:15358 static/js/zamboni/stats-min.js:4
 msgid "Collections"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:78 static/js/impala/stats/csv_keys.js:79
+#: static/js/impala/stats/csv_keys.js:78 static/js/impala/stats/csv_keys.js:79 static/js/zamboni/stats-all.js:15359 static/js/zamboni/stats-all.js:15360 static/js/zamboni/stats-min.js:4
 msgid "Category Landing Featured Carousel"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:80 static/js/impala/stats/csv_keys.js:81
+#: static/js/impala/stats/csv_keys.js:80 static/js/impala/stats/csv_keys.js:81 static/js/zamboni/stats-all.js:15361 static/js/zamboni/stats-all.js:15362 static/js/zamboni/stats-min.js:4
 msgid "Category Landing Top Rated"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:82 static/js/impala/stats/csv_keys.js:83
+#: static/js/impala/stats/csv_keys.js:82 static/js/impala/stats/csv_keys.js:83 static/js/zamboni/stats-all.js:15363 static/js/zamboni/stats-all.js:15364 static/js/zamboni/stats-min.js:5
 msgid "Category Landing Most Popular"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:84 static/js/impala/stats/csv_keys.js:85
+#: static/js/impala/stats/csv_keys.js:84 static/js/impala/stats/csv_keys.js:85 static/js/zamboni/stats-all.js:15365 static/js/zamboni/stats-all.js:15366 static/js/zamboni/stats-min.js:5
 msgid "Category Landing Recently Added"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:86 static/js/impala/stats/csv_keys.js:87
+#: static/js/impala/stats/csv_keys.js:86 static/js/impala/stats/csv_keys.js:87 static/js/zamboni/stats-all.js:15367 static/js/zamboni/stats-all.js:15368 static/js/zamboni/stats-min.js:5
 msgid "Browse Listing Featured Sort"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:88 static/js/impala/stats/csv_keys.js:89
+#: static/js/impala/stats/csv_keys.js:88 static/js/impala/stats/csv_keys.js:89 static/js/zamboni/stats-all.js:15369 static/js/zamboni/stats-all.js:15370 static/js/zamboni/stats-min.js:5
 msgid "Browse Listing Users Sort"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:90 static/js/impala/stats/csv_keys.js:91
+#: static/js/impala/stats/csv_keys.js:90 static/js/impala/stats/csv_keys.js:91 static/js/zamboni/stats-all.js:15371 static/js/zamboni/stats-all.js:15372 static/js/zamboni/stats-min.js:5
 msgid "Browse Listing Rating Sort"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:92 static/js/impala/stats/csv_keys.js:93
+#: static/js/impala/stats/csv_keys.js:92 static/js/impala/stats/csv_keys.js:93 static/js/zamboni/stats-all.js:15373 static/js/zamboni/stats-all.js:15374 static/js/zamboni/stats-min.js:5
 msgid "Browse Listing Created Sort"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:94 static/js/impala/stats/csv_keys.js:95
+#: static/js/impala/stats/csv_keys.js:94 static/js/impala/stats/csv_keys.js:95 static/js/zamboni/stats-all.js:15375 static/js/zamboni/stats-all.js:15376 static/js/zamboni/stats-min.js:5
 msgid "Browse Listing Name Sort"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:96 static/js/impala/stats/csv_keys.js:97
+#: static/js/impala/stats/csv_keys.js:96 static/js/impala/stats/csv_keys.js:97 static/js/zamboni/stats-all.js:15377 static/js/zamboni/stats-all.js:15378 static/js/zamboni/stats-min.js:5
 msgid "Browse Listing Popular Sort"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:98 static/js/impala/stats/csv_keys.js:99
+#: static/js/impala/stats/csv_keys.js:98 static/js/impala/stats/csv_keys.js:99 static/js/zamboni/stats-all.js:15379 static/js/zamboni/stats-all.js:15380 static/js/zamboni/stats-min.js:5
 msgid "Browse Listing Updated Sort"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:100 static/js/impala/stats/csv_keys.js:101
+#: static/js/impala/stats/csv_keys.js:100 static/js/impala/stats/csv_keys.js:101 static/js/zamboni/stats-all.js:15381 static/js/zamboni/stats-all.js:15382 static/js/zamboni/stats-min.js:5
 msgid "Browse Listing Up and Coming Sort"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:105
+#: static/js/impala/stats/csv_keys.js:105 static/js/zamboni/stats-all.js:15386 static/js/zamboni/stats-min.js:5
 msgid "Total Amount Contributed"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:106
+#: static/js/impala/stats/csv_keys.js:106 static/js/zamboni/stats-all.js:15387 static/js/zamboni/stats-min.js:5
 msgid "Average Contribution"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:115
+#: static/js/impala/stats/csv_keys.js:115 static/js/zamboni/stats-all.js:15396 static/js/zamboni/stats-min.js:5
 msgid "Usage"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:118
+#: static/js/impala/stats/csv_keys.js:118 static/js/zamboni/stats-all.js:15399 static/js/zamboni/stats-min.js:5
 msgid "Firefox"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:119
+#: static/js/impala/stats/csv_keys.js:119 static/js/zamboni/stats-all.js:15400 static/js/zamboni/stats-min.js:5
 msgid "Mozilla"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:120
+#: static/js/impala/stats/csv_keys.js:120 static/js/zamboni/stats-all.js:15401 static/js/zamboni/stats-min.js:5
 msgid "Thunderbird"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:121
+#: static/js/impala/stats/csv_keys.js:121 static/js/zamboni/stats-all.js:15402 static/js/zamboni/stats-min.js:5
 msgid "Sunbird"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:122
+#: static/js/impala/stats/csv_keys.js:122 static/js/zamboni/stats-all.js:15403 static/js/zamboni/stats-min.js:5
 msgid "SeaMonkey"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:123
+#: static/js/impala/stats/csv_keys.js:123 static/js/zamboni/stats-all.js:15404 static/js/zamboni/stats-min.js:5
 msgid "Fennec"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:124
+#: static/js/impala/stats/csv_keys.js:124 static/js/zamboni/stats-all.js:15405 static/js/zamboni/stats-min.js:5
 msgid "Android"
 msgstr ""
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:129
+#: static/js/impala/stats/csv_keys.js:129 static/js/zamboni/stats-all.js:15410 static/js/zamboni/stats-min.js:5
 msgid "Downloads and Daily Users, last {0} days"
 msgstr ""
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:131
+#: static/js/impala/stats/csv_keys.js:131 static/js/zamboni/stats-all.js:15412 static/js/zamboni/stats-min.js:5
 msgid "Downloads and Daily Users from {0} to {1}"
 msgstr ""
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:135
+#: static/js/impala/stats/csv_keys.js:135 static/js/zamboni/stats-all.js:15416 static/js/zamboni/stats-min.js:5
 msgid "Installs and Daily Users, last {0} days"
 msgstr ""
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:137
+#: static/js/impala/stats/csv_keys.js:137 static/js/zamboni/stats-all.js:15418 static/js/zamboni/stats-min.js:5
 msgid "Installs and Daily Users from {0} to {1}"
 msgstr ""
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:141
+#: static/js/impala/stats/csv_keys.js:141 static/js/zamboni/stats-all.js:15422 static/js/zamboni/stats-min.js:5
 msgid "Downloads, last {0} days"
 msgstr ""
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:143
+#: static/js/impala/stats/csv_keys.js:143 static/js/zamboni/stats-all.js:15424 static/js/zamboni/stats-min.js:5
 msgid "Downloads from {0} to {1}"
 msgstr ""
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:147
+#: static/js/impala/stats/csv_keys.js:147 static/js/zamboni/stats-all.js:15428 static/js/zamboni/stats-min.js:5
 msgid "Daily Users, last {0} days"
 msgstr ""
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:149
+#: static/js/impala/stats/csv_keys.js:149 static/js/zamboni/stats-all.js:15430 static/js/zamboni/stats-min.js:5
 msgid "Daily Users from {0} to {1}"
 msgstr ""
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:153
+#: static/js/impala/stats/csv_keys.js:153 static/js/zamboni/stats-all.js:15434 static/js/zamboni/stats-min.js:5
 msgid "Applications, last {0} days"
 msgstr ""
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:155
+#: static/js/impala/stats/csv_keys.js:155 static/js/zamboni/stats-all.js:15436 static/js/zamboni/stats-min.js:5
 msgid "Applications from {0} to {1}"
 msgstr ""
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:159
+#: static/js/impala/stats/csv_keys.js:159 static/js/zamboni/stats-all.js:15440 static/js/zamboni/stats-min.js:5
 msgid "Platforms, last {0} days"
 msgstr ""
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:161
+#: static/js/impala/stats/csv_keys.js:161 static/js/zamboni/stats-all.js:15442 static/js/zamboni/stats-min.js:5
 msgid "Platforms from {0} to {1}"
 msgstr ""
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:165
+#: static/js/impala/stats/csv_keys.js:165 static/js/zamboni/stats-all.js:15446 static/js/zamboni/stats-min.js:5
 msgid "Languages, last {0} days"
 msgstr ""
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:167
+#: static/js/impala/stats/csv_keys.js:167 static/js/zamboni/stats-all.js:15448 static/js/zamboni/stats-min.js:5
 msgid "Languages from {0} to {1}"
 msgstr ""
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:171
+#: static/js/impala/stats/csv_keys.js:171 static/js/zamboni/stats-all.js:15452 static/js/zamboni/stats-min.js:5
 msgid "Add-on Versions, last {0} days"
 msgstr ""
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:173
+#: static/js/impala/stats/csv_keys.js:173 static/js/zamboni/stats-all.js:15454 static/js/zamboni/stats-min.js:5
 msgid "Add-on Versions from {0} to {1}"
 msgstr ""
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:177
+#: static/js/impala/stats/csv_keys.js:177 static/js/zamboni/stats-all.js:15458 static/js/zamboni/stats-min.js:5
 msgid "Add-on Status, last {0} days"
 msgstr ""
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:179
+#: static/js/impala/stats/csv_keys.js:179 static/js/zamboni/stats-all.js:15460 static/js/zamboni/stats-min.js:5
 msgid "Add-on Status from {0} to {1}"
 msgstr ""
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:183
+#: static/js/impala/stats/csv_keys.js:183 static/js/zamboni/stats-all.js:15464 static/js/zamboni/stats-min.js:5
 msgid "Download Sources, last {0} days"
 msgstr ""
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:185
+#: static/js/impala/stats/csv_keys.js:185 static/js/zamboni/stats-all.js:15466 static/js/zamboni/stats-min.js:5
 msgid "Download Sources from {0} to {1}"
 msgstr ""
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:189
+#: static/js/impala/stats/csv_keys.js:189 static/js/zamboni/stats-all.js:15470 static/js/zamboni/stats-min.js:5
 msgid "Contributions, last {0} days"
 msgstr ""
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:191
+#: static/js/impala/stats/csv_keys.js:191 static/js/zamboni/stats-all.js:15472 static/js/zamboni/stats-min.js:5
 msgid "Contributions from {0} to {1}"
 msgstr ""
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:195
+#: static/js/impala/stats/csv_keys.js:195 static/js/zamboni/stats-all.js:15476 static/js/zamboni/stats-min.js:5
 msgid "Site Metrics, last {0} days"
 msgstr ""
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:197
+#: static/js/impala/stats/csv_keys.js:197 static/js/zamboni/stats-all.js:15478 static/js/zamboni/stats-min.js:5
 msgid "Site Metrics from {0} to {1}"
 msgstr ""
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:201
+#: static/js/impala/stats/csv_keys.js:201 static/js/zamboni/stats-all.js:15482 static/js/zamboni/stats-min.js:5
 msgid "Add-ons in Use, last {0} days"
 msgstr ""
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:203
+#: static/js/impala/stats/csv_keys.js:203 static/js/zamboni/stats-all.js:15484 static/js/zamboni/stats-min.js:5
 msgid "Add-ons in Use from {0} to {1}"
 msgstr ""
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:207
+#: static/js/impala/stats/csv_keys.js:207 static/js/zamboni/stats-all.js:15488 static/js/zamboni/stats-min.js:5
 msgid "Add-ons Downloaded, last {0} days"
 msgstr ""
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:209
+#: static/js/impala/stats/csv_keys.js:209 static/js/zamboni/stats-all.js:15490 static/js/zamboni/stats-min.js:5
 msgid "Add-ons Downloaded from {0} to {1}"
 msgstr ""
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:213
+#: static/js/impala/stats/csv_keys.js:213 static/js/zamboni/stats-all.js:15494 static/js/zamboni/stats-min.js:5
 msgid "Add-ons Created, last {0} days"
 msgstr ""
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:215
+#: static/js/impala/stats/csv_keys.js:215 static/js/zamboni/stats-all.js:15496 static/js/zamboni/stats-min.js:5
 msgid "Add-ons Created from {0} to {1}"
 msgstr ""
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:219
+#: static/js/impala/stats/csv_keys.js:219 static/js/zamboni/stats-all.js:15500 static/js/zamboni/stats-min.js:5
 msgid "Add-ons Updated, last {0} days"
 msgstr ""
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:221
+#: static/js/impala/stats/csv_keys.js:221 static/js/zamboni/stats-all.js:15502 static/js/zamboni/stats-min.js:5
 msgid "Add-ons Updated from {0} to {1}"
 msgstr ""
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:225
+#: static/js/impala/stats/csv_keys.js:225 static/js/zamboni/stats-all.js:15506 static/js/zamboni/stats-min.js:5
 msgid "Reviews Written, last {0} days"
 msgstr ""
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:227
+#: static/js/impala/stats/csv_keys.js:227 static/js/zamboni/stats-all.js:15508 static/js/zamboni/stats-min.js:5
 msgid "Reviews Written from {0} to {1}"
 msgstr ""
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:231
+#: static/js/impala/stats/csv_keys.js:231 static/js/zamboni/stats-all.js:15512 static/js/zamboni/stats-min.js:5
 msgid "User Signups, last {0} days"
 msgstr ""
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:233
+#: static/js/impala/stats/csv_keys.js:233 static/js/zamboni/stats-all.js:15514 static/js/zamboni/stats-min.js:5
 msgid "User Signups from {0} to {1}"
 msgstr ""
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:237
+#: static/js/impala/stats/csv_keys.js:237 static/js/zamboni/stats-all.js:15518 static/js/zamboni/stats-min.js:5
 msgid "Collections Created, last {0} days"
 msgstr ""
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:239
+#: static/js/impala/stats/csv_keys.js:239 static/js/zamboni/stats-all.js:15520 static/js/zamboni/stats-min.js:5
 msgid "Collections Created from {0} to {1}"
 msgstr ""
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:243
+#: static/js/impala/stats/csv_keys.js:243 static/js/zamboni/stats-all.js:15524 static/js/zamboni/stats-min.js:5
 msgid "Subscribers, last {0} days"
 msgstr ""
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:245
+#: static/js/impala/stats/csv_keys.js:245 static/js/zamboni/stats-all.js:15526 static/js/zamboni/stats-min.js:5
 msgid "Subscribers from {0} to {1}"
 msgstr ""
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:249
+#: static/js/impala/stats/csv_keys.js:249 static/js/zamboni/stats-all.js:15530 static/js/zamboni/stats-min.js:5
 msgid "Ratings, last {0} days"
 msgstr ""
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:251
+#: static/js/impala/stats/csv_keys.js:251 static/js/zamboni/stats-all.js:15532 static/js/zamboni/stats-min.js:5
 msgid "Ratings from {0} to {1}"
 msgstr ""
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:255
+#: static/js/impala/stats/csv_keys.js:255 static/js/zamboni/stats-all.js:15536 static/js/zamboni/stats-min.js:5
 msgid "Sales, last {0} days"
 msgstr ""
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:257
+#: static/js/impala/stats/csv_keys.js:257 static/js/zamboni/stats-all.js:15538 static/js/zamboni/stats-min.js:5
 msgid "Sales from {0} to {1}"
 msgstr ""
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:261
+#: static/js/impala/stats/csv_keys.js:261 static/js/zamboni/stats-all.js:15542 static/js/zamboni/stats-min.js:5
 msgid "Installs, last {0} days"
 msgstr ""
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:263
+#: static/js/impala/stats/csv_keys.js:263 static/js/zamboni/stats-all.js:15544 static/js/zamboni/stats-min.js:5
 msgid "Installs from {0} to {1}"
 msgstr ""
 
 #. L10n: {0} and {1} are integers.
-#: static/js/impala/stats/csv_keys.js:269
+#: static/js/impala/stats/csv_keys.js:269 static/js/zamboni/stats-all.js:15550 static/js/zamboni/stats-min.js:5
 msgid "<b>{0}</b> in last {1} days"
 msgstr ""
 
 #. L10n: {0} is an integer and {1} and {2} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:271 static/js/impala/stats/csv_keys.js:277
+#: static/js/impala/stats/csv_keys.js:271 static/js/impala/stats/csv_keys.js:277 static/js/zamboni/stats-all.js:15552 static/js/zamboni/stats-all.js:15558 static/js/zamboni/stats-min.js:5
 msgid "<b>{0}</b> from {1} to {2}"
 msgstr ""
 
 #. L10n: {0} and {1} are integers.
-#: static/js/impala/stats/csv_keys.js:275
+#: static/js/impala/stats/csv_keys.js:275 static/js/zamboni/stats-all.js:15556 static/js/zamboni/stats-min.js:5
 msgid "<b>{0}</b> average in last {1} days"
 msgstr ""
 
-#: static/js/impala/stats/overview.js:19
+#: static/js/impala/stats/overview.js:19 static/js/zamboni/stats-all.js:16469 static/js/zamboni/stats-min.js:5
 msgid "No data available."
 msgstr ""
 
-#: static/js/impala/stats/table.js:74
+#: static/js/impala/stats/table.js:74 static/js/zamboni/stats-all.js:17209 static/js/zamboni/stats-min.js:5
 msgid "Date"
 msgstr ""
 
-#: static/js/impala/stats/topchart.js:96
+#: static/js/impala/stats/topchart.js:96 static/js/zamboni/stats-all.js:16600 static/js/zamboni/stats-min.js:5
 msgid "Other"
 msgstr ""
 
-#: static/js/zamboni/admin_validation.js:24 static/js/zamboni/devhub.js:1229 static/js/zamboni/editors.js:295
+#: static/js/zamboni/admin-all.js:180 static/js/zamboni/admin-min.js:1 static/js/zamboni/admin_validation.js:24 static/js/zamboni/devhub-all.js:2408 static/js/zamboni/devhub-min.js:2
+#: static/js/zamboni/devhub.js:1229 static/js/zamboni/editors-all.js:15576 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:295
 msgid "Select an application first"
 msgstr ""
 
-#: static/js/zamboni/admin_validation.js:51
+#: static/js/zamboni/admin-all.js:207 static/js/zamboni/admin-min.js:1 static/js/zamboni/admin_validation.js:51
 msgid "Set {0} add-on to a max version of {1} and email the author."
 msgid_plural "Set {0} add-ons to a max version of {1} and email the authors."
 msgstr[0] ""
 msgstr[1] ""
 
-#: static/js/zamboni/admin_validation.js:54
+#: static/js/zamboni/admin-all.js:210 static/js/zamboni/admin-min.js:1 static/js/zamboni/admin_validation.js:54
 msgid "Email author of {2} add-on which failed validation."
 msgid_plural "Email authors of {2} add-ons which failed validation."
 msgstr[0] ""
 msgstr[1] ""
 
-#. L10n: {0} is an app name like Firefox.
-#: static/js/zamboni/buttons.js:66
-msgid "Accept and Install"
-msgstr ""
-
-#: static/js/zamboni/buttons.js:66
-msgid "Add to {0}"
-msgstr ""
-
-#: static/js/zamboni/buttons.js:71
-msgid "Download Now"
-msgstr ""
-
-#: static/js/zamboni/buttons.js:112
-msgid "Add-on has not been updated to support default-to-compatible."
-msgstr ""
-
-#: static/js/zamboni/buttons.js:117
-msgid "You need to be using Firefox 10.0 or higher."
-msgstr ""
-
-#: static/js/zamboni/buttons.js:129
-msgid "Mozilla has marked this version as incompatible with your Firefox version."
-msgstr ""
-
-#. L10n: {0} is an platform like Windows or Linux.
-#: static/js/zamboni/buttons.js:210
-msgid "Install for {0} anyway"
-msgstr ""
-
-#: static/js/zamboni/buttons.js:210
-msgid "Download for {0} anyway"
-msgstr ""
-
-#: static/js/zamboni/buttons.js:267
-msgid "Not available for your platform"
-msgstr ""
-
-#. L10n: {0} is an app name, {1} is the app version.
-#: static/js/zamboni/buttons.js:278 static/js/zamboni/buttons.js:315
-msgid "Not available for {0} {1}"
-msgstr ""
-
-#: static/js/zamboni/buttons.js:341
-msgid "Works with {app} {min} - {max}"
-msgstr ""
-
-#: static/js/zamboni/buttons.js:343
-msgid "View other versions"
-msgstr ""
-
-#: static/js/zamboni/buttons.js:391
-msgid "Only with Firefox — Get Firefox Now!"
-msgstr ""
-
-#: static/js/zamboni/buttons.js:507 static/js/zamboni/mobile/buttons.js:43
-msgid "Sorry, you need a Mozilla-based browser (such as Firefox) to install a search plugin."
-msgstr ""
-
-#: static/js/zamboni/collections.js:229
-msgid "Adding to Favorites&hellip;"
-msgstr ""
-
-#: static/js/zamboni/collections.js:232
-msgid "Removing Favorite&hellip;"
-msgstr ""
-
-#: static/js/zamboni/collections.js:235
-msgid "Add to Favorites"
-msgstr ""
-
-#: static/js/zamboni/collections.js:238
-msgid "Remove from Favorites"
-msgstr ""
-
-#: static/js/zamboni/collections.js:303
-msgid "Pending"
-msgstr ""
-
-#: static/js/zamboni/collections.js:304
-msgid "Add a comment"
-msgstr ""
-
-#: static/js/zamboni/collections.js:304
-msgid "Comment"
-msgstr ""
-
-#: static/js/zamboni/collections.js:305
-msgid "Remove this add-on from the collection"
-msgstr ""
-
-#: static/js/zamboni/collections.js:305 static/js/zamboni/collections.js:334
-msgid "Remove"
-msgstr ""
-
-#: static/js/zamboni/collections.js:334
-msgid "Remove this user as a contributor"
-msgstr ""
-
-#: static/js/zamboni/collections.js:346
-msgid "An email address is required."
-msgstr ""
-
-#: static/js/zamboni/collections.js:364
-msgid "You cannot add yourself as a contributor."
-msgstr ""
-
-#: static/js/zamboni/collections.js:366
-msgid "You have already added that user."
-msgstr ""
-
-#: static/js/zamboni/collections.js:573
-msgid "Add to favorites"
-msgstr ""
-
-#: static/js/zamboni/collections.js:577
-msgid "Remove from favorites"
-msgstr ""
-
-#: static/js/zamboni/collections.js:604
-msgid "Stop following"
-msgstr ""
-
-#: static/js/zamboni/devhub.js:110
+#: static/js/zamboni/devhub-all.js:1289 static/js/zamboni/devhub-min.js:1 static/js/zamboni/devhub.js:110
 msgid "Your browser does not support the video tag"
 msgstr ""
 
-#: static/js/zamboni/devhub.js:371
+#: static/js/zamboni/devhub-all.js:1550 static/js/zamboni/devhub-min.js:1 static/js/zamboni/devhub.js:371
 msgid "Changes Saved"
 msgstr ""
 
-#: static/js/zamboni/devhub.js:387
+#: static/js/zamboni/devhub-all.js:1566 static/js/zamboni/devhub-min.js:1 static/js/zamboni/devhub.js:387
 msgid "Enter a new author's email address"
 msgstr ""
 
-#: static/js/zamboni/devhub.js:536
+#: static/js/zamboni/devhub-all.js:1715 static/js/zamboni/devhub-min.js:1 static/js/zamboni/devhub.js:536
 msgid "There was an error uploading your file."
 msgstr ""
 
-#: static/js/zamboni/devhub.js:681
+#: static/js/zamboni/devhub-all.js:1860 static/js/zamboni/devhub-min.js:1 static/js/zamboni/devhub.js:681
 msgid "{files} file"
 msgid_plural "{files} files"
 msgstr[0] ""
 msgstr[1] ""
 
-#: static/js/zamboni/devhub.js:684
+#: static/js/zamboni/devhub-all.js:1863 static/js/zamboni/devhub-min.js:1 static/js/zamboni/devhub.js:684
 msgid "{reviews} user review"
 msgid_plural "{reviews} user reviews"
 msgstr[0] ""
 msgstr[1] ""
 
-#: static/js/zamboni/devhub.js:796
+#: static/js/zamboni/devhub-all.js:1975 static/js/zamboni/devhub-min.js:2 static/js/zamboni/devhub.js:796
 msgid "Learn more"
 msgstr ""
 
-#: static/js/zamboni/devhub.js:800
+#: static/js/zamboni/devhub-all.js:1979 static/js/zamboni/devhub-min.js:2 static/js/zamboni/devhub.js:800
 msgid "Example"
 msgstr ""
 
-#: static/js/zamboni/devhub.js:1130
+#: static/js/zamboni/devhub-all.js:2309 static/js/zamboni/devhub-min.js:2 static/js/zamboni/devhub.js:1130
 msgid "Image changes being processed"
 msgstr ""
 
-#: static/js/zamboni/devhub.js:1280
+#: static/js/zamboni/devhub-all.js:2459 static/js/zamboni/devhub-min.js:2 static/js/zamboni/devhub.js:1280
 msgid "Must be a valid e-mail address."
+msgstr ""
+
+#: static/js/zamboni/devhub-all.js:2613 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:80
+msgid "All tests passed successfully."
+msgstr ""
+
+#: static/js/zamboni/devhub-all.js:2616 static/js/zamboni/devhub-all.js:3011 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:83 static/js/zamboni/validator.js:478
+msgid "These tests were not run."
+msgstr ""
+
+#: static/js/zamboni/devhub-all.js:2664 static/js/zamboni/devhub-all.js:2677 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:131 static/js/zamboni/validator.js:144
+msgid "Tests"
+msgstr ""
+
+#: static/js/zamboni/devhub-all.js:2779 static/js/zamboni/devhub-all.js:3108 static/js/zamboni/devhub-all.js:3127 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:246
+#: static/js/zamboni/validator.js:575 static/js/zamboni/validator.js:594
+msgid "Error"
+msgstr ""
+
+#: static/js/zamboni/devhub-all.js:2780 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:247
+msgid "Warning"
+msgstr ""
+
+#: static/js/zamboni/devhub-all.js:2794 static/js/zamboni/devhub-min.js:2 static/js/zamboni/files-all.js:5657 static/js/zamboni/files-min.js:3 static/js/zamboni/files.js:411
+#: static/js/zamboni/validator.js:261
+msgid "Ignore this message in future updates"
+msgstr ""
+
+#: static/js/zamboni/devhub-all.js:2817 static/js/zamboni/devhub-min.js:2 static/js/zamboni/files-all.js:5663 static/js/zamboni/files-min.js:3 static/js/zamboni/files.js:417
+#: static/js/zamboni/validator.js:284
+msgid "Severity for automated signing:"
+msgstr ""
+
+#: static/js/zamboni/devhub-all.js:2832 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:299
+msgid "Suggestions for passing automated signing:"
+msgstr ""
+
+#: static/js/zamboni/devhub-all.js:2920 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:387
+msgid "Compatibility Tests"
+msgstr ""
+
+#: static/js/zamboni/devhub-all.js:2999 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:466
+msgid "Add-on failed validation."
+msgstr ""
+
+#: static/js/zamboni/devhub-all.js:3001 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:468
+msgid "Add-on passed validation."
+msgstr ""
+
+#: static/js/zamboni/devhub-all.js:3014 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:481
+msgid "{0} error"
+msgid_plural "{0} errors"
+msgstr[0] ""
+msgstr[1] ""
+
+#: static/js/zamboni/devhub-all.js:3016 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:483
+msgid "{0} warning"
+msgid_plural "{0} warnings"
+msgstr[0] ""
+msgstr[1] ""
+
+#: static/js/zamboni/devhub-all.js:3018 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:485
+msgid "{0} notice"
+msgid_plural "{0} notices"
+msgstr[0] ""
+msgstr[1] ""
+
+#: static/js/zamboni/devhub-all.js:3110 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:577
+msgid "Validation task could not complete or completed with errors"
+msgstr ""
+
+#: static/js/zamboni/devhub-all.js:3128 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:595
+msgid "Internal server error"
 msgstr ""
 
 #: static/js/zamboni/devhub_search.js:8
 msgid "No results found."
 msgstr ""
 
-#: static/js/zamboni/editors.js:121
+#: static/js/zamboni/editors-all.js:15402 static/js/zamboni/editors-min.js:4 static/js/zamboni/editors.js:121
 msgid "{name} was viewing this page first."
 msgstr ""
 
-#: static/js/zamboni/editors.js:171
+#: static/js/zamboni/editors-all.js:15452 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:171
 msgid "Receipt checked by app."
 msgstr ""
 
-#: static/js/zamboni/editors.js:173
+#: static/js/zamboni/editors-all.js:15454 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:173
 msgid "Receipt was not checked by app."
 msgstr ""
 
-#: static/js/zamboni/editors.js:244
+#: static/js/zamboni/editors-all.js:15525 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:244
 msgid "{name} was viewing this add-on first."
 msgstr ""
 
-#: static/js/zamboni/editors.js:255
+#: static/js/zamboni/editors-all.js:15536 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:255
 msgid "Loading&hellip;"
 msgstr ""
 
-#: static/js/zamboni/editors.js:260
+#: static/js/zamboni/editors-all.js:15541 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:260
 msgid "Version Notes"
 msgstr ""
 
-#: static/js/zamboni/editors.js:265
+#: static/js/zamboni/editors-all.js:15546 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:265
 msgid "Notes for Reviewers"
 msgstr ""
 
-#: static/js/zamboni/editors.js:270
+#: static/js/zamboni/editors-all.js:15551 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:270
 msgid "No version notes found"
 msgstr ""
 
-#: static/js/zamboni/editors.js:330
+#: static/js/zamboni/editors-all.js:15611 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:330
 msgid "Average Reviews"
 msgstr ""
 
-#: static/js/zamboni/editors.js:386
+#: static/js/zamboni/editors-all.js:15667 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:386
 msgid "Number of Reviews"
 msgstr ""
 
-#: static/js/zamboni/editors.js:445
+#: static/js/zamboni/editors-all.js:15726 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:445
 msgid "Error loading translation"
 msgstr ""
 
-#: static/js/zamboni/files.js:411 static/js/zamboni/validator.js:261
-msgid "Ignore this message in future updates"
-msgstr ""
-
-#: static/js/zamboni/files.js:417 static/js/zamboni/validator.js:284
-msgid "Severity for automated signing:"
-msgstr ""
-
-#: static/js/zamboni/global.js:410
-msgid "Loading..."
-msgstr ""
-
-#. L10n: {0} is the number of characters left.
-#: static/js/zamboni/global.js:474
-msgid "<b>{0}</b> character left."
-msgid_plural "<b>{0}</b> characters left."
-msgstr[0] ""
-msgstr[1] ""
-
-#: static/js/zamboni/init.js:28
-msgid "This feature is temporarily disabled while we perform website maintenance. Please check back a little later."
-msgstr ""
-
-#: static/js/zamboni/l10n.js:45
-msgid "Remove this localization"
-msgstr ""
-
-#: static/js/zamboni/password-strength.js:20
-msgid "Password strength:"
-msgstr ""
-
-#: static/js/zamboni/password-strength.js:26
-msgid "At least {0} character left."
-msgid_plural "At least {0} characters left."
-msgstr[0] ""
-msgstr[1] ""
-
-#: static/js/zamboni/themes_review.js:176
-msgid "Requested Info"
-msgstr ""
-
-#: static/js/zamboni/themes_review.js:177
-msgid "Flagged"
-msgstr ""
-
-#: static/js/zamboni/themes_review.js:178
-msgid "Duplicate"
-msgstr ""
-
-#: static/js/zamboni/themes_review.js:179
-msgid "Rejected"
-msgstr ""
-
-#: static/js/zamboni/themes_review.js:180
-msgid "Approved"
-msgstr ""
-
-#: static/js/zamboni/themes_review.js:424
-msgid "No results found"
-msgstr ""
-
-#: static/js/zamboni/themes_review_templates.js:31
+#: static/js/zamboni/editors-all.js:15975 static/js/zamboni/editors-min.js:5 static/js/zamboni/themes_review_templates.js:31
 msgid "Theme"
 msgstr ""
 
-#: static/js/zamboni/themes_review_templates.js:33
+#: static/js/zamboni/editors-all.js:15977 static/js/zamboni/editors-min.js:5 static/js/zamboni/themes_review_templates.js:33
 msgid "Reviewer"
 msgstr ""
 
-#: static/js/zamboni/themes_review_templates.js:35
+#: static/js/zamboni/editors-all.js:15979 static/js/zamboni/editors-min.js:5 static/js/zamboni/themes_review_templates.js:35
 msgid "Status"
 msgstr ""
 
-#: static/js/zamboni/validator.js:80
-msgid "All tests passed successfully."
+#: static/js/zamboni/editors-all.js:16196 static/js/zamboni/editors-min.js:5 static/js/zamboni/themes_review.js:176
+msgid "Requested Info"
 msgstr ""
 
-#: static/js/zamboni/validator.js:83 static/js/zamboni/validator.js:478
-msgid "These tests were not run."
+#: static/js/zamboni/editors-all.js:16197 static/js/zamboni/editors-min.js:5 static/js/zamboni/themes_review.js:177
+msgid "Flagged"
 msgstr ""
 
-#: static/js/zamboni/validator.js:131 static/js/zamboni/validator.js:144
-msgid "Tests"
+#: static/js/zamboni/editors-all.js:16198 static/js/zamboni/editors-min.js:5 static/js/zamboni/themes_review.js:178
+msgid "Duplicate"
 msgstr ""
 
-#: static/js/zamboni/validator.js:246 static/js/zamboni/validator.js:575 static/js/zamboni/validator.js:594
-msgid "Error"
+#: static/js/zamboni/editors-all.js:16199 static/js/zamboni/editors-min.js:5 static/js/zamboni/themes_review.js:179
+msgid "Rejected"
 msgstr ""
 
-#: static/js/zamboni/validator.js:247
-msgid "Warning"
+#: static/js/zamboni/editors-all.js:16200 static/js/zamboni/editors-min.js:5 static/js/zamboni/themes_review.js:180
+msgid "Approved"
 msgstr ""
 
-#: static/js/zamboni/validator.js:299
-msgid "Suggestions for passing automated signing:"
+#: static/js/zamboni/editors-all.js:16444 static/js/zamboni/editors-min.js:5 static/js/zamboni/themes_review.js:424
+msgid "No results found"
 msgstr ""
 
-#: static/js/zamboni/validator.js:387
-msgid "Compatibility Tests"
-msgstr ""
-
-#: static/js/zamboni/validator.js:466
-msgid "Add-on failed validation."
-msgstr ""
-
-#: static/js/zamboni/validator.js:468
-msgid "Add-on passed validation."
-msgstr ""
-
-#: static/js/zamboni/validator.js:481
-msgid "{0} error"
-msgid_plural "{0} errors"
-msgstr[0] ""
-msgstr[1] ""
-
-#: static/js/zamboni/validator.js:483
-msgid "{0} warning"
-msgid_plural "{0} warnings"
-msgstr[0] ""
-msgstr[1] ""
-
-#: static/js/zamboni/validator.js:485
-msgid "{0} notice"
-msgid_plural "{0} notices"
-msgstr[0] ""
-msgstr[1] ""
-
-#: static/js/zamboni/validator.js:577
-msgid "Validation task could not complete or completed with errors"
-msgstr ""
-
-#: static/js/zamboni/validator.js:595
-msgid "Internal server error"
-msgstr ""
-
-#: static/js/zamboni/mobile/buttons.js:52
+#: static/js/zamboni/mobile-all.js:15186 static/js/zamboni/mobile/buttons.js:52
 msgid "Not Updated for {0} {1}"
 msgstr ""
 
-#: static/js/zamboni/mobile/buttons.js:53
+#: static/js/zamboni/mobile-all.js:15187 static/js/zamboni/mobile/buttons.js:53
 msgid "Requires Newer Version of {0}"
 msgstr ""
 
-#: static/js/zamboni/mobile/buttons.js:54
+#: static/js/zamboni/mobile-all.js:15188 static/js/zamboni/mobile/buttons.js:54
 msgid "Unreviewed"
 msgstr ""
 
-#: static/js/zamboni/mobile/buttons.js:55
+#: static/js/zamboni/mobile-all.js:15189 static/js/zamboni/mobile/buttons.js:55
 msgid "Experimental <span>(Learn More)</span>"
 msgstr ""
 
-#: static/js/zamboni/mobile/buttons.js:56 static/js/zamboni/mobile/buttons.js:57
+#: static/js/zamboni/mobile-all.js:15190 static/js/zamboni/mobile-all.js:15191 static/js/zamboni/mobile/buttons.js:56 static/js/zamboni/mobile/buttons.js:57
 msgid "Not Available for {0}"
 msgstr ""
 
-#: static/js/zamboni/mobile/buttons.js:58
+#: static/js/zamboni/mobile-all.js:15192 static/js/zamboni/mobile/buttons.js:58
 msgid "Experimental"
 msgstr ""
 
-#: static/js/zamboni/mobile/buttons.js:59
+#: static/js/zamboni/mobile-all.js:15193 static/js/zamboni/mobile/buttons.js:59
 msgid "Themes Require Newer Version of {0}"
 msgstr ""
 
-#: static/js/zamboni/mobile/buttons.js:60
+#: static/js/zamboni/mobile-all.js:15194 static/js/zamboni/mobile/buttons.js:60
 msgid "Themes Require {0}"
 msgstr ""
 
-#: static/js/zamboni/mobile/buttons.js:105
+#: static/js/zamboni/mobile-all.js:15239 static/js/zamboni/mobile/buttons.js:105
 msgid "Installing..."
 msgstr ""
 
-#: static/js/zamboni/mobile/buttons.js:125
+#: static/js/zamboni/mobile-all.js:15259 static/js/zamboni/mobile/buttons.js:125
 msgid "This add-on has been preliminarily reviewed by Mozilla."
 msgstr ""
 
-#: static/js/zamboni/mobile/buttons.js:250
+#: static/js/zamboni/mobile-all.js:15384 static/js/zamboni/mobile/buttons.js:250
 msgid "Keep it"
 msgstr ""
 
-#: static/js/zamboni/mobile/general.js:344
+#: static/js/zamboni/mobile-all.js:16049 static/js/zamboni/mobile-min.js:6 static/js/zamboni/mobile/general.js:344
 msgid "You're trying it on!"
 msgstr ""
 
-#: static/js/zamboni/mobile/general.js:356
+#: static/js/zamboni/mobile-all.js:16061 static/js/zamboni/mobile-min.js:6 static/js/zamboni/mobile/general.js:356
 msgid "Added to Firefox"
 msgstr ""
-

--- a/locale/ca/LC_MESSAGES/django.po
+++ b/locale/ca/LC_MESSAGES/django.po
@@ -10,44 +10,45 @@ msgid ""
 msgstr ""
 "Project-Id-Version:  c\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2016-02-24 21:23+0000\n"
+"POT-Creation-Date: 2016-04-18 15:47+0000\n"
 "PO-Revision-Date: 2013-10-23 18:28+0000\n"
 "Last-Translator: Toni <toniher@softcatala.org>\n"
 "Language-Team: Catalan <mozilla@llistes.softcatala.org>\n"
+"Language: ca\n"
 "MIME-Version: 1.0\n"
-"Content-Type: text/plain; charset=utf-8\n"
+"Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Generated-By: Babel 2.2.0\n"
 
-#: src/olympia/accounts/views.py:52
+#: src/olympia/accounts/views.py:54
 msgid "Your log in attempt could not be parsed. Please try again."
 msgstr ""
 
-#: src/olympia/accounts/views.py:54
+#: src/olympia/accounts/views.py:56
 msgid "Your Firefox Account could not be found. Please try again."
 msgstr ""
 
-#: src/olympia/accounts/views.py:55
+#: src/olympia/accounts/views.py:57
 msgid "You could not be logged in. Please try again."
 msgstr ""
 
-#: src/olympia/accounts/views.py:57
+#: src/olympia/accounts/views.py:59
 msgid "Your account has already been migrated to Firefox Accounts."
 msgstr ""
 
-#: src/olympia/accounts/views.py:59
+#: src/olympia/accounts/views.py:61
 msgid "Your Firefox Account already exists on this site."
 msgstr ""
 
-#: src/olympia/accounts/views.py:108
+#: src/olympia/accounts/views.py:110
 msgid "Great job!"
 msgstr ""
 
-#: src/olympia/accounts/views.py:109
+#: src/olympia/accounts/views.py:111
 msgid "You can now log in to Add-ons with your Firefox Account."
 msgstr ""
 
-#: src/olympia/accounts/views.py:121
+#: src/olympia/accounts/views.py:123
 msgid "Need help?"
 msgstr ""
 
@@ -55,28 +56,28 @@ msgstr ""
 # %$1s is an optional string that only appears if the add-on is only available for
 # a certain platform.  Examples:  (Windows)  or  (Linux)
 # Note that the parentheses are included in the string. :(
-#: src/olympia/addons/buttons.py:180
+#: src/olympia/addons/buttons.py:177
 msgid "Download Now"
 msgstr "Baixa'l ara"
 
-#: src/olympia/addons/buttons.py:182
+#: src/olympia/addons/buttons.py:179
 msgid "Download"
 msgstr "Baixa"
 
 #. L10n: please keep &nbsp; in the string so &rarr; does not wrap.
-#: src/olympia/addons/buttons.py:186
+#: src/olympia/addons/buttons.py:183
 msgid "Continue to Download&nbsp;&rarr;"
 msgstr "Continua amb la baixada&nbsp;&rarr;"
 
-#: src/olympia/addons/buttons.py:202 src/olympia/addons/helpers.py:35 src/olympia/addons/views.py:319 src/olympia/addons/templates/addons/impala/details.html:114
+#: src/olympia/addons/buttons.py:199 src/olympia/addons/helpers.py:35 src/olympia/addons/views.py:333 src/olympia/addons/templates/addons/impala/details.html:111
 #: src/olympia/addons/templates/addons/impala/listing/items.html:17 src/olympia/addons/templates/addons/mobile/home.html:40 src/olympia/amo/templates/amo/side_nav.html:6
-#: src/olympia/amo/templates/amo/side_nav.html:10 src/olympia/amo/templates/amo/site_nav.html:2 src/olympia/amo/templates/amo/site_nav.html:55 src/olympia/bandwagon/views.py:95
-#: src/olympia/browse/views.py:54 src/olympia/browse/views.py:68 src/olympia/browse/views.py:235 src/olympia/browse/templates/browse/impala/category_landing.html:22
+#: src/olympia/amo/templates/amo/side_nav.html:10 src/olympia/amo/templates/amo/site_nav.html:2 src/olympia/amo/templates/amo/site_nav.html:53 src/olympia/bandwagon/views.py:95
+#: src/olympia/browse/views.py:54 src/olympia/browse/views.py:68 src/olympia/browse/views.py:202 src/olympia/browse/templates/browse/impala/category_landing.html:22
 #: src/olympia/browse/templates/browse/personas/mobile/category_landing.html:26
 msgid "Featured"
 msgstr "Destacat"
 
-#: src/olympia/addons/buttons.py:221
+#: src/olympia/addons/buttons.py:218
 msgid "Add to {0}"
 msgstr "Afegeix al {0}"
 
@@ -124,39 +125,39 @@ msgid_plural "All tags must be at least {0} characters."
 msgstr[0] "Totes les etiquetes han de tenir com a mínim {0} caràcter."
 msgstr[1] "Totes les etiquetes han de tenir com a mínim {0} caràcters."
 
-#: src/olympia/addons/forms.py:234
+#: src/olympia/addons/forms.py:238
 msgid "Categories cannot be changed while your add-on is featured for this application."
 msgstr "No es poden canviar les categories mentre el vostre complement estigui destacat per a aquesta aplicació."
 
 #. L10n: {0} is the number of categories.
-#: src/olympia/addons/forms.py:238
+#: src/olympia/addons/forms.py:242
 msgid "You can have only {0} category."
 msgid_plural "You can have only {0} categories."
 msgstr[0] "Només podeu tenir {0} categoria."
 msgstr[1] "Només podeu tenir {0} categories."
 
-#: src/olympia/addons/forms.py:246
+#: src/olympia/addons/forms.py:250
 msgid "The miscellaneous category cannot be combined with additional categories."
 msgstr "La categoria miscel·lànea no es pot combinar amb altres categories."
 
-#: src/olympia/addons/forms.py:369
+#: src/olympia/addons/forms.py:374
 #, python-format
 msgid "Before changing your default locale you must have a name, summary, and description in that locale. You are missing %s."
 msgstr "Abans de canviar la vostra llengua per defecte heu d'escriure un nom, un resum, i una descripció en aquella llengua. Us falta escriure %s."
 
-#: src/olympia/addons/forms.py:484 src/olympia/addons/forms.py:575
+#: src/olympia/addons/forms.py:455 src/olympia/addons/forms.py:546
 msgid "A license must be selected."
 msgstr "Cal seleccionar una llicència."
 
-#: src/olympia/addons/forms.py:556
+#: src/olympia/addons/forms.py:527
 msgid "Give Your Theme a Name."
 msgstr ""
 
-#: src/olympia/addons/forms.py:562 src/olympia/devhub/templates/devhub/personas/submit.html:53
+#: src/olympia/addons/forms.py:533 src/olympia/devhub/templates/devhub/personas/submit.html:53
 msgid "Describe your Theme."
 msgstr ""
 
-#: src/olympia/addons/forms.py:704
+#: src/olympia/addons/forms.py:675
 msgid "Enter a new author's email address"
 msgstr ""
 
@@ -164,39 +165,39 @@ msgstr ""
 msgid "Not Reviewed"
 msgstr "No s'ha revisat"
 
-#: src/olympia/addons/models.py:301
+#: src/olympia/addons/models.py:298
 msgid "Users have the option of contributing more or less than this amount."
 msgstr "Els usuaris tenen l'opció de contribuir amb una quantitat més gran o més petita que aquesta."
 
-#: src/olympia/addons/models.py:309
-msgid "Users will always be asked in the Add-ons Manager (Firefox 4 and above)"
-msgstr "El Gestor de complements (Firefox 4 i superior) ho demanarà als usuaris sempre"
+#: src/olympia/addons/models.py:306
+msgid "Users will always be asked in the Add-ons Manager (Firefox 4 and above). Only applies to desktop."
+msgstr ""
 
 # Column name in a table.
-#: src/olympia/addons/models.py:1804 src/olympia/addons/templates/addons/details_box.html:55 src/olympia/devhub/templates/devhub/index.html:92
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:102
+#: src/olympia/addons/models.py:1802 src/olympia/addons/templates/addons/details_box.html:55 src/olympia/devhub/templates/devhub/index.html:92
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:89
 msgid "Listed"
 msgstr "Llistat"
 
-#: src/olympia/addons/views.py:320 src/olympia/browse/templates/browse/personas/mobile/category_landing.html:27
+#: src/olympia/addons/views.py:334 src/olympia/browse/templates/browse/personas/mobile/category_landing.html:27
 msgid "Popular"
 msgstr "Popular"
 
-#: src/olympia/addons/views.py:321 src/olympia/browse/views.py:238 src/olympia/browse/views.py:280 src/olympia/browse/views.py:482
+#: src/olympia/addons/views.py:335 src/olympia/browse/views.py:205 src/olympia/browse/views.py:247 src/olympia/browse/views.py:449
 msgid "Recently Added"
 msgstr "Afegit recentment"
 
-#: src/olympia/addons/views.py:322 src/olympia/bandwagon/views.py:99 src/olympia/browse/views.py:60 src/olympia/browse/views.py:71 src/olympia/search/forms.py:16 src/olympia/search/forms.py:91
+#: src/olympia/addons/views.py:336 src/olympia/bandwagon/views.py:99 src/olympia/browse/views.py:60 src/olympia/browse/views.py:71 src/olympia/search/forms.py:16 src/olympia/search/forms.py:91
 msgid "Recently Updated"
 msgstr "Actualitzat recentment"
 
 # %1 is an add-on name.
 #. l10n: {0} is the addon name
-#: src/olympia/addons/views.py:520
+#: src/olympia/addons/views.py:534
 msgid "Contribution for {0}"
 msgstr "Contribució per a {0}"
 
-#: src/olympia/addons/views.py:613
+#: src/olympia/addons/views.py:627
 msgid "Abuse reported."
 msgstr "S'ha informat d'un abús."
 
@@ -267,9 +268,9 @@ msgstr "Contribuïu-hi"
 #: src/olympia/devhub/templates/devhub/addons/ajax_compat_update.html:36 src/olympia/devhub/templates/devhub/addons/profile.html:44 src/olympia/devhub/templates/devhub/addons/edit/admin.html:101
 #: src/olympia/devhub/templates/devhub/addons/edit/basic.html:152 src/olympia/devhub/templates/devhub/addons/edit/details.html:85 src/olympia/devhub/templates/devhub/addons/edit/support.html:67
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:166 src/olympia/devhub/templates/devhub/addons/forms_shared/media.html:149
-#: src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:44 src/olympia/devhub/templates/devhub/versions/add_file_modal.html:78 src/olympia/devhub/templates/devhub/versions/edit.html:139
-#: src/olympia/devhub/templates/devhub/versions/list.html:242 src/olympia/devhub/templates/devhub/versions/list.html:276 src/olympia/devhub/templates/devhub/versions/list.html:317
-#: src/olympia/devhub/templates/devhub/versions/list.html:351 src/olympia/reviews/templates/reviews/edit_review.html:16 src/olympia/translations/templates/translations/trans-menu.html:50
+#: src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:43 src/olympia/devhub/templates/devhub/versions/add_file_modal.html:58 src/olympia/devhub/templates/devhub/versions/edit.html:139
+#: src/olympia/devhub/templates/devhub/versions/list.html:239 src/olympia/devhub/templates/devhub/versions/list.html:281 src/olympia/devhub/templates/devhub/versions/list.html:315
+#: src/olympia/devhub/templates/devhub/versions/list.html:349 src/olympia/reviews/templates/reviews/edit_review.html:16 src/olympia/translations/templates/translations/trans-menu.html:50
 #: src/olympia/translations/templates/translations/trans-menu.html:62
 msgid "or"
 msgstr "o"
@@ -307,19 +308,20 @@ msgstr "Ajudeu a continuar el desenvolupament de <strong>%(addon_name)s</strong>
 
 #: src/olympia/addons/templates/addons/contributions_lightbox.html:15
 #, python-format
-msgid "To show your support for <b>%(addon_name)s</b>, the developer asks that you make a donation to the <a href=\"%(charity_url)s\">%(charity_name)s</a> through <a href=\"%(paypal_url)s\">PayPal</a>."
+msgid ""
+"To show your support for <b>%(addon_name)s</b>, the developer asks that you make a donation to the <a href=\"%(charity_url)s\">%(charity_name)s</a> through <a href=\"%(paypal_url)s\">PayPal</a>."
 msgstr ""
-"Per a demostrar el vostre suport a <b>%(addon_name)s</b>, el desenvolupador us demana que feu un donatiu a <a href=\"%(charity_url)s\">%(charity_name)s</a> mitjançant <a "
-"href=\"%(paypal_url)s\">PayPal</a>."
+"Per a demostrar el vostre suport a <b>%(addon_name)s</b>, el desenvolupador us demana que feu un donatiu a <a href=\"%(charity_url)s\">%(charity_name)s</a> mitjançant <a href=\"%(paypal_url)s"
+"\">PayPal</a>."
 
 #: src/olympia/addons/templates/addons/contributions_lightbox.html:21
 #, python-format
 msgid ""
-"To show your support for <b>%(addon_name)s</b>, the developer asks that you make a small contribution to <a href=\"%(charity_url)s\">%(charity_name)s</a> through <a "
-"href=\"%(paypal_url)s\">PayPal</a>."
+"To show your support for <b>%(addon_name)s</b>, the developer asks that you make a small contribution to <a href=\"%(charity_url)s\">%(charity_name)s</a> through <a href=\"%(paypal_url)s\">PayPal</"
+"a>."
 msgstr ""
-"Per mostrar el vostre suport a <b>%(addon_name)s</b>, el desenvolupador us demana que feu un petit donatiu a <a href=\"%(charity_url)s\">%(charity_name)s</a> mitjançant <a "
-"href=\"%(paypal_url)s\">PayPal</a>."
+"Per mostrar el vostre suport a <b>%(addon_name)s</b>, el desenvolupador us demana que feu un petit donatiu a <a href=\"%(charity_url)s\">%(charity_name)s</a> mitjançant <a href=\"%(paypal_url)s"
+"\">PayPal</a>."
 
 #: src/olympia/addons/templates/addons/contributions_lightbox.html:30
 msgid "How much would you like to contribute?"
@@ -384,7 +386,7 @@ msgid "Add-on Information for {0}"
 msgstr "Informació del complement {0}"
 
 #: src/olympia/addons/templates/addons/details_box.html:30 src/olympia/addons/templates/addons/persona_detail_table.html:3 src/olympia/addons/templates/addons/mobile/details.html:63
-#: src/olympia/addons/templates/addons/mobile/persona_detail_table.html:7 src/olympia/browse/views.py:459 src/olympia/devhub/views.py:75
+#: src/olympia/addons/templates/addons/mobile/persona_detail_table.html:7 src/olympia/browse/views.py:426 src/olympia/devhub/views.py:73
 msgid "Updated"
 msgstr "Actualitzat"
 
@@ -403,11 +405,11 @@ msgstr "Funciona amb"
 msgid "Visibility"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/details_box.html:57 src/olympia/devhub/templates/devhub/index.html:94 src/olympia/devhub/templates/devhub/includes/addon_details.html:104
+#: src/olympia/addons/templates/addons/details_box.html:57 src/olympia/devhub/templates/devhub/index.html:94 src/olympia/devhub/templates/devhub/includes/addon_details.html:91
 msgid "Hidden"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/details_box.html:59 src/olympia/devhub/templates/devhub/index.html:96 src/olympia/devhub/templates/devhub/includes/addon_details.html:106
+#: src/olympia/addons/templates/addons/details_box.html:59 src/olympia/devhub/templates/devhub/index.html:96 src/olympia/devhub/templates/devhub/includes/addon_details.html:93
 msgid "Unlisted"
 msgstr ""
 
@@ -415,13 +417,13 @@ msgstr ""
 msgid "Required Add-ons"
 msgstr "Complements necessaris"
 
-#: src/olympia/addons/templates/addons/details_box.html:81 src/olympia/addons/templates/addons/persona_detail_table.html:15 src/olympia/browse/views.py:462 src/olympia/devhub/views.py:78
-#: src/olympia/devhub/views.py:85 src/olympia/discovery/templates/discovery/addons/detail.html:57 src/olympia/reviews/forms.py:62 src/olympia/reviews/templates/reviews/add.html:57
+#: src/olympia/addons/templates/addons/details_box.html:81 src/olympia/addons/templates/addons/persona_detail_table.html:15 src/olympia/browse/views.py:429 src/olympia/devhub/views.py:76
+#: src/olympia/devhub/views.py:83 src/olympia/discovery/templates/discovery/addons/detail.html:57 src/olympia/reviews/forms.py:62 src/olympia/reviews/templates/reviews/add.html:57
 #: src/olympia/reviews/templates/reviews/mobile/review_list.html:18
 msgid "Rating"
 msgstr "Valoració"
 
-#: src/olympia/addons/templates/addons/details_box.html:85 src/olympia/browse/views.py:461 src/olympia/devhub/views.py:77 src/olympia/devhub/views.py:84
+#: src/olympia/addons/templates/addons/details_box.html:85 src/olympia/browse/views.py:428 src/olympia/devhub/views.py:75 src/olympia/devhub/views.py:82
 #: src/olympia/stats/templates/stats/addon_report_menu.html:8 src/olympia/stats/templates/stats/collection_report_menu.html:18
 msgid "Downloads"
 msgstr "Baixades"
@@ -441,7 +443,7 @@ msgstr "Informes d'abús"
 
 #. The Privacy Policy for this add-on.
 #: src/olympia/addons/templates/addons/details_box.html:121 src/olympia/addons/templates/addons/privacy.html:19 src/olympia/addons/templates/addons/privacy.html:23
-#: src/olympia/addons/templates/addons/impala/button.html:43 src/olympia/addons/templates/addons/impala/details.html:307 src/olympia/devhub/templates/devhub/includes/policy_form.html:20
+#: src/olympia/addons/templates/addons/impala/button.html:43 src/olympia/addons/templates/addons/impala/details.html:312 src/olympia/devhub/templates/devhub/includes/policy_form.html:23
 #: src/olympia/templates/mobile/base_addons.html:87
 msgid "Privacy Policy"
 msgstr "Política de privadesa"
@@ -466,7 +468,7 @@ msgstr "Galeria d'imatges"
 msgid "Developer Comments"
 msgstr "Comentaris del desenvolupador"
 
-#: src/olympia/addons/templates/addons/details_box.html:199 src/olympia/addons/templates/addons/impala/details.html:259
+#: src/olympia/addons/templates/addons/details_box.html:199 src/olympia/addons/templates/addons/impala/details.html:264
 msgid "Development Channel"
 msgstr "Canal de desenvolupament"
 
@@ -487,16 +489,16 @@ msgid ""
 "<strong>Caution:</strong> Development versions of this add-on have not been reviewed by Mozilla. Once you install a development version you will continue to receive development updates from this "
 "developer. To stop receiving development updates, reinstall the default version from the link above."
 msgstr ""
-"<strong>Atenció:</strong> Mozilla no revisa les versions de desenvolupament d'aquest complement. Un cop instal·leu una versió de desenvolupament, continuareu rebent actualitzacions del complement a"
-" mesura que el desenvolupador les publiqui. Si voleu parar de rebre actualitzacions de desenvolupament, torneu a instal·lar la versió estable amb l'enllaç anterior."
+"<strong>Atenció:</strong> Mozilla no revisa les versions de desenvolupament d'aquest complement. Un cop instal·leu una versió de desenvolupament, continuareu rebent actualitzacions del complement a "
+"mesura que el desenvolupador les publiqui. Si voleu parar de rebre actualitzacions de desenvolupament, torneu a instal·lar la versió estable amb l'enllaç anterior."
 
-#: src/olympia/addons/templates/addons/details_box.html:220 src/olympia/addons/templates/addons/impala/details.html:278
+#: src/olympia/addons/templates/addons/details_box.html:220 src/olympia/addons/templates/addons/impala/details.html:283
 msgid "Version {0}:"
 msgstr "Versió {0}:"
 
 #: src/olympia/addons/templates/addons/details_box.html:234
-msgid "Nothing to see here! The developer did not include any details."
-msgstr "Res a veure-hi! El desenvolupador no hi ha inclòs cap detall."
+msgid "Nothing to see here!  The developer did not include any details."
+msgstr ""
 
 #: src/olympia/addons/templates/addons/details_box.html:251 src/olympia/devhub/templates/devhub/versions/edit.html:73 src/olympia/editors/templates/editors/review.html:98
 msgid "Version Notes"
@@ -509,7 +511,7 @@ msgid "End-User License Agreement for {0}"
 msgstr "Acord de llicència de l'usuari final del complement {0}"
 
 #: src/olympia/addons/templates/addons/eula.html:17 src/olympia/addons/templates/addons/eula.html:21 src/olympia/addons/templates/addons/impala/button.html:48
-#: src/olympia/addons/templates/addons/impala/details.html:316 src/olympia/devhub/templates/devhub/includes/policy_form.html:3 src/olympia/discovery/templates/discovery/addons/eula.html:11
+#: src/olympia/addons/templates/addons/impala/details.html:321 src/olympia/devhub/templates/devhub/includes/policy_form.html:3 src/olympia/discovery/templates/discovery/addons/eula.html:11
 msgid "End-User License Agreement"
 msgstr "Acord de llicència de l'usuari final"
 
@@ -529,7 +531,7 @@ msgstr "Torna a {0}..."
 msgid "Add-ons for {0}"
 msgstr "Complements del {0} "
 
-#: src/olympia/addons/templates/addons/home.html:10 src/olympia/addons/templates/addons/home.html:51 src/olympia/browse/templates/browse/impala/base_listing.html:11
+#: src/olympia/addons/templates/addons/home.html:10 src/olympia/addons/templates/addons/home.html:53 src/olympia/browse/templates/browse/impala/base_listing.html:11
 msgid "Featured Extensions"
 msgstr "Extensions destacades"
 
@@ -537,29 +539,29 @@ msgstr "Extensions destacades"
 msgid "Popular Extensions"
 msgstr "Extensions populars"
 
-#: src/olympia/addons/templates/addons/home.html:42 src/olympia/amo/templates/amo/side_nav.html:3 src/olympia/amo/templates/amo/side_nav.html:11 src/olympia/amo/templates/amo/site_nav.html:3
-#: src/olympia/amo/templates/amo/site_nav.html:25 src/olympia/browse/views.py:236 src/olympia/browse/views.py:281 src/olympia/browse/views.py:481
+#: src/olympia/addons/templates/addons/home.html:44 src/olympia/amo/templates/amo/side_nav.html:3 src/olympia/amo/templates/amo/side_nav.html:11 src/olympia/amo/templates/amo/site_nav.html:3
+#: src/olympia/amo/templates/amo/site_nav.html:25 src/olympia/browse/views.py:203 src/olympia/browse/views.py:248 src/olympia/browse/views.py:448
 msgid "Most Popular"
 msgstr "Més popular"
 
-#: src/olympia/addons/templates/addons/home.html:43
+#: src/olympia/addons/templates/addons/home.html:45
 msgid "All »"
 msgstr "Tot »"
 
-#: src/olympia/addons/templates/addons/home.html:52 src/olympia/addons/templates/addons/home.html:61 src/olympia/addons/templates/addons/home.html:70 src/olympia/addons/templates/addons/home.html:78
+#: src/olympia/addons/templates/addons/home.html:54 src/olympia/addons/templates/addons/home.html:63 src/olympia/addons/templates/addons/home.html:72 src/olympia/addons/templates/addons/home.html:80
 #: src/olympia/browse/templates/browse/impala/category_landing.html:36
 msgid "See all »"
 msgstr "Vegeu-ho tot »"
 
-#: src/olympia/addons/templates/addons/home.html:60
+#: src/olympia/addons/templates/addons/home.html:62
 msgid "Up &amp; Coming Extensions"
 msgstr "Properes extensions"
 
-#: src/olympia/addons/templates/addons/home.html:69 src/olympia/browse/templates/browse/personas/category_landing.html:61 src/olympia/discovery/templates/discovery/pane.html:74
+#: src/olympia/addons/templates/addons/home.html:71 src/olympia/browse/templates/browse/personas/category_landing.html:61 src/olympia/discovery/templates/discovery/pane.html:74
 msgid "Featured Themes"
 msgstr "Temes destacats"
 
-#: src/olympia/addons/templates/addons/home.html:77 src/olympia/bandwagon/templates/bandwagon/impala/collection_listing.html:5
+#: src/olympia/addons/templates/addons/home.html:79 src/olympia/bandwagon/templates/bandwagon/impala/collection_listing.html:5
 msgid "Featured Collections"
 msgstr "Col·leccions destacades"
 
@@ -577,9 +579,9 @@ msgid "Updated {0}"
 msgstr "Actualitzat {0}"
 
 #. {0} is a date.
-#: src/olympia/addons/templates/addons/macros.html:10 src/olympia/addons/templates/addons/macros.html:69 src/olympia/addons/templates/addons/persona_preview.html:21
-#: src/olympia/addons/templates/addons/listing/items_mobile.html:44 src/olympia/addons/templates/addons/listing/macros.html:39 src/olympia/bandwagon/templates/bandwagon/collection_listing_items.html:37
-#: src/olympia/bandwagon/templates/bandwagon/impala/collection_listing_items.html:37
+#: src/olympia/addons/templates/addons/macros.html:10 src/olympia/addons/templates/addons/macros.html:69 src/olympia/addons/templates/addons/persona_preview.html:22
+#: src/olympia/addons/templates/addons/listing/items_mobile.html:44 src/olympia/addons/templates/addons/listing/macros.html:39
+#: src/olympia/bandwagon/templates/bandwagon/collection_listing_items.html:37 src/olympia/bandwagon/templates/bandwagon/impala/collection_listing_items.html:37
 msgid "Added {0}"
 msgstr "S'ha afegit {0}"
 
@@ -598,15 +600,14 @@ msgstr[0] "%(num)s usuari"
 msgstr[1] "%(num)s usuaris"
 
 #. {0} is the number of downloads.
-#: src/olympia/addons/templates/addons/macros.html:53 src/olympia/addons/templates/addons/impala/details.html:61
+#: src/olympia/addons/templates/addons/macros.html:53 src/olympia/addons/templates/addons/impala/details.html:59
 msgid "{0} weekly download"
 msgid_plural "{0} weekly downloads"
 msgstr[0] "{0} baixada setmanal"
 msgstr[1] "{0} baixades setmanals"
 
 #. {0} is the number of users.
-#: src/olympia/addons/templates/addons/macros.html:61 src/olympia/addons/templates/addons/impala/details.html:54 src/olympia/compat/templates/compat/index.html:71
-#: src/olympia/zadmin/templates/zadmin/compat.html:67
+#: src/olympia/addons/templates/addons/macros.html:61 src/olympia/addons/templates/addons/impala/details.html:52 src/olympia/zadmin/templates/zadmin/compat.html:67
 msgid "{0} user"
 msgid_plural "{0} users"
 msgstr[0] "{0} usuari"
@@ -624,7 +625,7 @@ msgstr "El pagament s'ha realitzat correctament"
 msgid "Return to the addon."
 msgstr "Torna al complement."
 
-#: src/olympia/addons/templates/addons/persona_detail.html:17 src/olympia/addons/templates/addons/impala/details.html:106 src/olympia/addons/templates/addons/mobile/details.html:23
+#: src/olympia/addons/templates/addons/persona_detail.html:17 src/olympia/addons/templates/addons/impala/details.html:103 src/olympia/addons/templates/addons/mobile/details.html:23
 #: src/olympia/addons/templates/addons/mobile/persona_detail.html:21 src/olympia/discovery/templates/discovery/addons/base.html:27 src/olympia/editors/templates/editors/review.html:31
 msgid "by"
 msgstr "per"
@@ -668,34 +669,35 @@ msgstr "Usuaris diaris"
 msgid "License"
 msgstr "Llicència"
 
-#: src/olympia/addons/templates/addons/persona_preview.html:12 src/olympia/constants/base.py:48
+#: src/olympia/addons/templates/addons/persona_preview.html:13 src/olympia/constants/base.py:48
 msgid "Awaiting Review"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/persona_preview.html:14 src/olympia/amo/log.py:180 src/olympia/constants/base.py:42 src/olympia/editors/helpers.py:62
+#: src/olympia/addons/templates/addons/persona_preview.html:15 src/olympia/amo/log.py:180 src/olympia/constants/base.py:42 src/olympia/editors/helpers.py:62
 msgid "Rejected"
 msgstr "Rebutjat"
 
-#: src/olympia/addons/templates/addons/persona_preview.html:16 src/olympia/amo/log.py:159
+#: src/olympia/addons/templates/addons/persona_preview.html:17 src/olympia/amo/log.py:159
 msgid "Approved"
 msgstr "Aprovat"
 
 #. {0} is the number of users.
-#: src/olympia/addons/templates/addons/persona_preview.html:26 src/olympia/addons/templates/addons/listing/items_mobile.html:36 src/olympia/addons/templates/addons/listing/macros.html:31
+#: src/olympia/addons/templates/addons/persona_preview.html:27 src/olympia/addons/templates/addons/listing/items_mobile.html:36 src/olympia/addons/templates/addons/listing/macros.html:31
 msgid "<strong>{0}</strong> user"
 msgid_plural "<strong>{0}</strong> users"
 msgstr[0] "<strong>{0}</strong> usuari"
 msgstr[1] "<strong>{0}</strong> usuaris"
 
-#: src/olympia/addons/templates/addons/persona_preview.html:40
+#: src/olympia/addons/templates/addons/persona_preview.html:41
 msgid "Hover to Preview"
 msgstr "Passeu per sobre per veure una previsualització"
 
-#: src/olympia/addons/templates/addons/persona_preview.html:46 src/olympia/addons/templates/addons/persona_preview.html:48 src/olympia/reviews/templates/reviews/add.html:15
+#: src/olympia/addons/templates/addons/persona_preview.html:47 src/olympia/addons/templates/addons/persona_preview.html:49 src/olympia/addons/templates/addons/persona_preview.html:97
+#: src/olympia/reviews/templates/reviews/add.html:15
 msgid "Add"
 msgstr "Afegeix"
 
-#: src/olympia/addons/templates/addons/persona_preview.html:57 src/olympia/bandwagon/templates/bandwagon/ajax_new.html:16 src/olympia/bandwagon/templates/bandwagon/edit.html:19
+#: src/olympia/addons/templates/addons/persona_preview.html:58 src/olympia/bandwagon/templates/bandwagon/ajax_new.html:16 src/olympia/bandwagon/templates/bandwagon/edit.html:19
 #: src/olympia/bandwagon/templates/bandwagon/includes/addedit.html:19 src/olympia/devhub/templates/devhub/addons/edit/admin.html:13 src/olympia/devhub/templates/devhub/addons/edit/basic.html:10
 #: src/olympia/devhub/templates/devhub/addons/edit/details.html:8 src/olympia/devhub/templates/devhub/addons/edit/media.html:6 src/olympia/devhub/templates/devhub/addons/edit/support.html:8
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:9 src/olympia/devhub/templates/devhub/addons/submit/describe.html:29 src/olympia/editors/templates/editors/review.html:257
@@ -704,21 +706,21 @@ msgstr "Edita"
 
 #. For datetime formatting, see the table on
 #. http://docs.python.org/library/datetime.html#strftime-and-strptime-behavior
-#: src/olympia/addons/templates/addons/persona_preview.html:66
+#: src/olympia/addons/templates/addons/persona_preview.html:67
 #, python-format
 msgid "%%Y-%%m-%%d"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/persona_preview.html:67
+#: src/olympia/addons/templates/addons/persona_preview.html:68
 msgid "by {0} on {1}"
 msgstr "per {0} el {1}"
 
-#: src/olympia/addons/templates/addons/persona_preview.html:75 src/olympia/reviews/helpers.py:17 src/olympia/reviews/templates/reviews/review_list.html:63
+#: src/olympia/addons/templates/addons/persona_preview.html:76 src/olympia/reviews/helpers.py:17 src/olympia/reviews/templates/reviews/review_list.html:63
 #: src/olympia/reviews/templates/reviews/reviews_link.html:21 src/olympia/reviews/templates/reviews/impala/reviews_link.html:16
 msgid "Not yet rated"
 msgstr "Encara no s'ha valorat"
 
-#: src/olympia/addons/templates/addons/persona_preview.html:78
+#: src/olympia/addons/templates/addons/persona_preview.html:79
 msgid "<b>{0}</b> users"
 msgstr "<b>{0}</b> usuaris"
 
@@ -732,8 +734,8 @@ msgid "Learn more about Firefox"
 msgstr "Més informació sobre el Firefox"
 
 #: src/olympia/addons/templates/addons/popups.html:22
-msgid "or <b><a class=\"installer\" href=\"{url}\">download anyway</a></b>"
-msgstr "o <b><a class=\"installer\" href=\"{url}\">baixa'l igualment</a></b>"
+msgid "or <b><a class=\"button installer\" href=\"{url}\">download anyway</a></b>"
+msgstr ""
 
 #: src/olympia/addons/templates/addons/popups.html:26
 msgid ""
@@ -826,13 +828,14 @@ msgid "QR code for add-on"
 msgstr "Codi QR del complement"
 
 #: src/olympia/addons/templates/addons/qr_code.html:6
-msgid "Want {0} on your mobile Firefox? Scan this QR code to install directly to your phone. (You'll need a QR reader. Search your phone's marketplace if don't have one.)"
+msgid ""
+"Want {0} on your mobile Firefox?  Scan this QR code to install directly\n"
+"  to your phone.  (You'll need a QR reader.  Search your phone's marketplace if\n"
+"  don't have one.)"
 msgstr ""
-"Voleu instal·lar {0} al Firefox del mòbil? Escanegeu aquest codi QR per instal·lar-lo directament al vostre mòbil. (Necessitareu un lector QR. Cerqueu-lo a la galeria d'aplicacions del vostre mòbil"
-" si no en teniu cap.)"
 
 #: src/olympia/addons/templates/addons/report_abuse.html:6 src/olympia/addons/templates/addons/report_abuse_full.html:10 src/olympia/addons/templates/addons/impala/details-more.html:23
-#: src/olympia/addons/templates/addons/impala/details.html:328
+#: src/olympia/addons/templates/addons/impala/details.html:333
 msgid "Report Abuse"
 msgstr "Denuncieu un abús"
 
@@ -853,9 +856,9 @@ msgstr "Envieu un informe"
 #: src/olympia/devhub/templates/devhub/addons/ajax_compat_update.html:36 src/olympia/devhub/templates/devhub/addons/profile.html:44 src/olympia/devhub/templates/devhub/addons/edit/admin.html:104
 #: src/olympia/devhub/templates/devhub/addons/edit/basic.html:155 src/olympia/devhub/templates/devhub/addons/edit/details.html:88 src/olympia/devhub/templates/devhub/addons/edit/support.html:70
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:169 src/olympia/devhub/templates/devhub/addons/forms_shared/media.html:152
-#: src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:44 src/olympia/devhub/templates/devhub/personas/edit.html:222 src/olympia/devhub/templates/devhub/versions/add_file_modal.html:79
-#: src/olympia/devhub/templates/devhub/versions/edit.html:140 src/olympia/devhub/templates/devhub/versions/list.html:208 src/olympia/devhub/templates/devhub/versions/list.html:242
-#: src/olympia/devhub/templates/devhub/versions/list.html:276 src/olympia/devhub/templates/devhub/versions/list.html:317 src/olympia/reviews/templates/reviews/edit_review.html:16
+#: src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:43 src/olympia/devhub/templates/devhub/personas/edit.html:222 src/olympia/devhub/templates/devhub/versions/add_file_modal.html:59
+#: src/olympia/devhub/templates/devhub/versions/edit.html:140 src/olympia/devhub/templates/devhub/versions/list.html:208 src/olympia/devhub/templates/devhub/versions/list.html:239
+#: src/olympia/devhub/templates/devhub/versions/list.html:281 src/olympia/devhub/templates/devhub/versions/list.html:315 src/olympia/reviews/templates/reviews/edit_review.html:16
 #: src/olympia/translations/templates/translations/trans-menu.html:50 src/olympia/translations/templates/translations/trans-menu.html:62 src/olympia/zadmin/templates/zadmin/validation.html:105
 msgid "Cancel"
 msgstr "Cancel·la"
@@ -904,7 +907,7 @@ msgstr "Vegeu la <a href=\"%(support)s\">secció d'ajuda</a> per saber on podeu 
 msgid "Review Guidelines"
 msgstr "Guia per a la revisió"
 
-#: src/olympia/addons/templates/addons/review_list_box.html:5 src/olympia/addons/templates/addons/impala/details-more.html:27 src/olympia/editors/helpers.py:921
+#: src/olympia/addons/templates/addons/review_list_box.html:5 src/olympia/addons/templates/addons/impala/details-more.html:27 src/olympia/editors/helpers.py:1001
 #: src/olympia/reviews/templates/reviews/add.html:14 src/olympia/reviews/templates/reviews/reply.html:14 src/olympia/reviews/templates/reviews/review_list.html:19
 #: src/olympia/reviews/templates/reviews/mobile/review_list.html:26
 msgid "Reviews"
@@ -998,31 +1001,31 @@ msgid_plural "Other add-ons by these authors"
 msgstr[0] "Altres complements fets per %(author)s"
 msgstr[1] "Altres complements fets per aquests autors"
 
-#: src/olympia/addons/templates/addons/impala/details.html:41
+#: src/olympia/addons/templates/addons/impala/details.html:39
 #, python-format
 msgid "<span itemprop=\"ratingCount\">%(num)s</span> user review"
 msgid_plural "<span itemprop=\"ratingCount\">%(num)s</span> user reviews"
 msgstr[0] "<span itemprop=\"ratingCount\">%(num)s</span> valoració d'usuari"
 msgstr[1] "<span itemprop=\"ratingCount\">%(num)s</span>  valoracions d'usuari"
 
-#: src/olympia/addons/templates/addons/impala/details.html:69
+#: src/olympia/addons/templates/addons/impala/details.html:66
 msgid "View statistics"
 msgstr "Mostra les estadístiques"
 
-#: src/olympia/addons/templates/addons/impala/details.html:84
+#: src/olympia/addons/templates/addons/impala/details.html:81
 msgid "Manage"
 msgstr "Gestiona"
 
 #. {0} is an add-on name.
-#: src/olympia/addons/templates/addons/impala/details.html:96
+#: src/olympia/addons/templates/addons/impala/details.html:93
 msgid "Icon of {0}"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/impala/details.html:103 src/olympia/addons/templates/addons/impala/listing/items.html:14
+#: src/olympia/addons/templates/addons/impala/details.html:100 src/olympia/addons/templates/addons/impala/listing/items.html:14
 msgid "No Restart"
 msgstr "Sense reinici"
 
-#: src/olympia/addons/templates/addons/impala/details.html:127
+#: src/olympia/addons/templates/addons/impala/details.html:124
 #, fuzzy, python-format
 msgid "Meet the Developer: <a href=\"%(url)s\">%(name)s</a>"
 msgid_plural "<a href=\"%(url)s\">Meet the Developers</a>"
@@ -1030,72 +1033,72 @@ msgstr[0] "Conegueu el desenvolupador: <a href=\"%(url)s\">%(name)s</a>"
 msgstr[1] "<a href=\"%(url)s\">Conegueu els desenvolupadors</a>"
 
 # {0} is an add-on name.
-#: src/olympia/addons/templates/addons/impala/details.html:137
+#: src/olympia/addons/templates/addons/impala/details.html:134
 msgid "Learn why {0} was created and find out what's next for this add-on."
 msgstr "Informeu-vos de per què es va crear {0} i quins plans hi ha per a aquest complement."
 
 #. {0} is an index.
-#: src/olympia/addons/templates/addons/impala/details.html:156
+#: src/olympia/addons/templates/addons/impala/details.html:161
 msgid "Add-on screenshot #{0}"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/impala/details.html:182
+#: src/olympia/addons/templates/addons/impala/details.html:187
 msgid "Add-on home page"
 msgstr "Pàgina d'inici del complement"
 
-#: src/olympia/addons/templates/addons/impala/details.html:185
+#: src/olympia/addons/templates/addons/impala/details.html:190
 msgid "Support site"
 msgstr "Lloc d'assistència"
 
-#: src/olympia/addons/templates/addons/impala/details.html:189
+#: src/olympia/addons/templates/addons/impala/details.html:194
 msgid "Support E-mail"
 msgstr "Adreça electrònica d'assistència"
 
-#: src/olympia/addons/templates/addons/impala/details.html:194 src/olympia/devhub/models.py:378 src/olympia/devhub/templates/devhub/versions/list.html:12
+#: src/olympia/addons/templates/addons/impala/details.html:199 src/olympia/devhub/models.py:378 src/olympia/devhub/templates/devhub/versions/list.html:12
 #: src/olympia/versions/templates/versions/version.html:6 src/olympia/versions/templates/versions/mobile/version.html:6
 msgid "Version {0}"
 msgstr "Versió {0}"
 
-#: src/olympia/addons/templates/addons/impala/details.html:194
+#: src/olympia/addons/templates/addons/impala/details.html:199
 msgid "Info"
 msgstr "Informació"
 
-#: src/olympia/addons/templates/addons/impala/details.html:195 src/olympia/devhub/templates/devhub/includes/addon_details.html:129
+#: src/olympia/addons/templates/addons/impala/details.html:200 src/olympia/devhub/templates/devhub/includes/addon_details.html:116
 msgid "Last Updated:"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/impala/details.html:200
+#: src/olympia/addons/templates/addons/impala/details.html:205
 #, python-format
 msgid "Released under <a target=\"_blank\" href=\"%(url)s\">%(name)s</a>"
 msgstr "Publicat sota <a target=\"_blank\" href=\"%(url)s\">%(name)s</a>"
 
-#: src/olympia/addons/templates/addons/impala/details.html:201 src/olympia/addons/templates/addons/impala/details.html:206 src/olympia/amo/helpers.py:398 src/olympia/devhub/forms.py:142
+#: src/olympia/addons/templates/addons/impala/details.html:206 src/olympia/addons/templates/addons/impala/details.html:211 src/olympia/amo/helpers.py:398 src/olympia/devhub/forms.py:142
 #: src/olympia/devhub/forms.py:173 src/olympia/versions/templates/versions/version.html:40 src/olympia/versions/templates/versions/version.html:45
 msgid "Custom License"
 msgstr "Llicència particular"
 
-#: src/olympia/addons/templates/addons/impala/details.html:205
+#: src/olympia/addons/templates/addons/impala/details.html:210
 #, python-format
 msgid "Released under <a href=\"%(url)s\">%(name)s</a>"
 msgstr "Publicat sota <a href=\"%(url)s\">%(name)s</a>"
 
-#: src/olympia/addons/templates/addons/impala/details.html:217
+#: src/olympia/addons/templates/addons/impala/details.html:222
 msgid "About this Add-on"
 msgstr "Quant al complement"
 
-#: src/olympia/addons/templates/addons/impala/details.html:233
+#: src/olympia/addons/templates/addons/impala/details.html:238
 msgid "Developer’s Comments"
 msgstr "Comentaris del desenvolupador"
 
-#: src/olympia/addons/templates/addons/impala/details.html:243
+#: src/olympia/addons/templates/addons/impala/details.html:248
 msgid "Version Information"
 msgstr "Informació de la versió"
 
-#: src/olympia/addons/templates/addons/impala/details.html:250
+#: src/olympia/addons/templates/addons/impala/details.html:255
 msgid "See complete version history"
 msgstr "Vegeu l'historial complet de versions"
 
-#: src/olympia/addons/templates/addons/impala/details.html:262
+#: src/olympia/addons/templates/addons/impala/details.html:267
 msgid ""
 "The Development Channel lets you test an experimental new version of this add-on before it's released to the general public. Once you install the development version, you will continue to get "
 "updates from this channel. To stop receiving development updates, reinstall the default version from the link above."
@@ -1103,17 +1106,17 @@ msgstr ""
 "El Canal de desenvolupament us permet provar una versió experimental d'aquest complement abans que estigui disponible per al públic general. Un cop hagueu instal·lat la versió de desenvolupament, "
 "podreu obtenir actualitzacions a través d'aquest canal. Per deixar d'obtenir les actualitzacions de desenvolupament, torneu a instal·lar la versió per defecte fent servir l'enllaç de més amunt."
 
-#: src/olympia/addons/templates/addons/impala/details.html:272
+#: src/olympia/addons/templates/addons/impala/details.html:277
 msgid "<strong>Caution:</strong> Development versions of this add-on have not been reviewed by Mozilla."
 msgstr ""
 
-#: src/olympia/addons/templates/addons/impala/details.html:287
+#: src/olympia/addons/templates/addons/impala/details.html:292
 msgid "See complete development channel history"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/impala/details.html:306 src/olympia/addons/templates/addons/impala/details.html:315 src/olympia/addons/templates/addons/impala/details.html:327
+#: src/olympia/addons/templates/addons/impala/details.html:311 src/olympia/addons/templates/addons/impala/details.html:320 src/olympia/addons/templates/addons/impala/details.html:332
 #: src/olympia/addons/templates/addons/impala/review_add_box.html:4 src/olympia/stats/templates/stats/popup.html:2 src/olympia/stats/templates/stats/popup.html:8
-#: src/olympia/stats/templates/stats/stats.html:202 src/olympia/users/templates/users/profile.html:119
+#: src/olympia/stats/templates/stats/stats.html:204 src/olympia/users/templates/users/profile.html:119
 msgid "close"
 msgstr "tanca"
 
@@ -1172,15 +1175,11 @@ msgstr "Llicència del codi font de {addon}"
 msgid "Source Code License"
 msgstr "Llicència del codi font"
 
-#: src/olympia/addons/templates/addons/impala/persona_grid.html:16 src/olympia/addons/templates/addons/impala/toplist.html:6
-msgid "{0} users"
-msgstr "{0} usuaris"
-
 #: src/olympia/addons/templates/addons/impala/review_list_box.html:19 src/olympia/reviews/templates/reviews/review.html:40
 msgid "permalink"
 msgstr "enllaç permanent"
 
-#: src/olympia/addons/templates/addons/impala/review_list_box.html:23 src/olympia/editors/templates/editors/queue.html:98 src/olympia/reviews/templates/reviews/review.html:44
+#: src/olympia/addons/templates/addons/impala/review_list_box.html:23 src/olympia/editors/templates/editors/queue.html:104 src/olympia/reviews/templates/reviews/review.html:44
 msgid "translate"
 msgstr ""
 
@@ -1199,6 +1198,10 @@ msgstr "Aquest complement encara no ha estat valorat."
 msgid "Be the first!"
 msgstr "Sigueu el primer!"
 
+#: src/olympia/addons/templates/addons/impala/toplist.html:6
+msgid "{0} users"
+msgstr "{0} usuaris"
+
 # This is a separator between the graphical [contribute] button and the
 # graphical [download now] button
 #: src/olympia/addons/templates/addons/impala/listing/sorter.html:14 src/olympia/devhub/templates/devhub/addons/listing/item_actions.html:49
@@ -1213,7 +1216,7 @@ msgstr "Afegeix a la col·lecció"
 msgid "My Add-ons"
 msgstr "Els meus complements"
 
-#: src/olympia/addons/templates/addons/includes/dashboard_tabs.html:6 src/olympia/amo/context_processors.py:51
+#: src/olympia/addons/templates/addons/includes/dashboard_tabs.html:6 src/olympia/amo/context_processors.py:50
 msgid "My Themes"
 msgstr ""
 
@@ -1268,7 +1271,7 @@ msgstr "Usuaris"
 msgid "Weekly Downloads"
 msgstr "Baixades setmanals"
 
-#: src/olympia/addons/templates/addons/mobile/details.html:99 src/olympia/compat/templates/compat/reporter_detail.html:46 src/olympia/devhub/forms.py:787
+#: src/olympia/addons/templates/addons/mobile/details.html:99 src/olympia/compat/templates/compat/reporter_detail.html:46 src/olympia/devhub/forms.py:788
 #: src/olympia/devhub/templates/devhub/versions/list.html:163
 msgid "Version"
 msgstr "Versió"
@@ -1325,8 +1328,9 @@ msgid "Return to the {0} Add-ons homepage"
 msgstr "Torna a la pàgina principal dels complements {0}"
 
 #: src/olympia/addons/templates/addons/mobile/home.html:21 src/olympia/amo/helpers.py:237 src/olympia/bandwagon/templates/bandwagon/edit.html:34 src/olympia/discovery/templates/discovery/pane.html:92
-#: src/olympia/editors/templates/editors/base.html:21 src/olympia/editors/templates/editors/performance.html:72 src/olympia/templates/menu_links.html:4 src/olympia/templates/impala/header_title.html:13
-#: src/olympia/templates/impala/header_title.html:15 src/olympia/templates/impala/header_title.html:19 src/olympia/templates/impala/header_title.html:23 src/olympia/templates/mobile/base_addons.html:47
+#: src/olympia/editors/templates/editors/base.html:21 src/olympia/editors/templates/editors/performance.html:72 src/olympia/templates/menu_links.html:4
+#: src/olympia/templates/impala/header_title.html:13 src/olympia/templates/impala/header_title.html:15 src/olympia/templates/impala/header_title.html:19
+#: src/olympia/templates/impala/header_title.html:23 src/olympia/templates/mobile/base_addons.html:47
 msgid "Add-ons"
 msgstr "Complements"
 
@@ -1349,11 +1353,12 @@ msgstr ""
 
 #. {0} is a category name. Ex: "Sports"
 #. {0} is a category name, such as Nature.
-#: src/olympia/addons/templates/addons/mobile/home.html:43 src/olympia/amo/templates/amo/site_nav.html:32 src/olympia/browse/feeds.py:107 src/olympia/browse/templates/browse/impala/base_listing.html:38
-#: src/olympia/browse/templates/browse/personas/base.html:6 src/olympia/browse/templates/browse/personas/base.html:42 src/olympia/browse/templates/browse/personas/category_landing.html:21
-#: src/olympia/browse/templates/browse/personas/category_landing.html:23 src/olympia/browse/templates/browse/personas/category_landing.html:38 src/olympia/browse/templates/browse/personas/grid.html:7
-#: src/olympia/browse/templates/browse/personas/grid.html:11 src/olympia/browse/templates/browse/personas/mobile/base.html:7 src/olympia/browse/templates/browse/personas/mobile/category_landing.html:19
-#: src/olympia/constants/base.py:180 src/olympia/devhub/templates/devhub/personas/submit.html:13 src/olympia/editors/helpers.py:105 src/olympia/editors/templates/editors/base.html:26
+#: src/olympia/addons/templates/addons/mobile/home.html:43 src/olympia/amo/templates/amo/site_nav.html:32 src/olympia/browse/feeds.py:107
+#: src/olympia/browse/templates/browse/impala/base_listing.html:38 src/olympia/browse/templates/browse/personas/base.html:6 src/olympia/browse/templates/browse/personas/base.html:42
+#: src/olympia/browse/templates/browse/personas/category_landing.html:21 src/olympia/browse/templates/browse/personas/category_landing.html:23
+#: src/olympia/browse/templates/browse/personas/category_landing.html:38 src/olympia/browse/templates/browse/personas/grid.html:7 src/olympia/browse/templates/browse/personas/grid.html:11
+#: src/olympia/browse/templates/browse/personas/mobile/base.html:7 src/olympia/browse/templates/browse/personas/mobile/category_landing.html:19 src/olympia/constants/base.py:180
+#: src/olympia/devhub/templates/devhub/personas/submit.html:13 src/olympia/editors/helpers.py:107 src/olympia/editors/templates/editors/base.html:26
 #: src/olympia/editors/templates/editors/performance.html:73 src/olympia/search/templates/search/personas.html:39 src/olympia/templates/menu_links.html:9
 msgid "Themes"
 msgstr "Temes"
@@ -1374,7 +1379,7 @@ msgstr "Més complements"
 msgid "Highest Rated"
 msgstr "Puntuació més alta"
 
-#: src/olympia/addons/templates/addons/mobile/home.html:74 src/olympia/amo/templates/amo/side_nav.html:5 src/olympia/amo/templates/amo/site_nav.html:27 src/olympia/amo/templates/amo/site_nav.html:57
+#: src/olympia/addons/templates/addons/mobile/home.html:74 src/olympia/amo/templates/amo/side_nav.html:5 src/olympia/amo/templates/amo/site_nav.html:27 src/olympia/amo/templates/amo/site_nav.html:55
 #: src/olympia/bandwagon/views.py:97 src/olympia/browse/views.py:57 src/olympia/browse/views.py:67 src/olympia/browse/templates/browse/personas/mobile/category_landing.html:65
 #: src/olympia/search/forms.py:15 src/olympia/search/forms.py:87
 msgid "Newest"
@@ -1388,88 +1393,90 @@ msgstr "Proveu-ho!"
 msgid "Theme Info &raquo;"
 msgstr ""
 
-#: src/olympia/amo/context_processors.py:39 src/olympia/devhub/templates/devhub/nav.html:43
+#: src/olympia/amo/context_processors.py:37 src/olympia/devhub/templates/devhub/nav.html:43
 msgid "Tools"
 msgstr "Eines"
 
-#: src/olympia/amo/context_processors.py:48 src/olympia/discovery/templates/discovery/pane_account.html:8 src/olympia/users/templates/users/includes/navigation.html:2
+#: src/olympia/amo/context_processors.py:47 src/olympia/discovery/templates/discovery/pane_account.html:8 src/olympia/users/templates/users/includes/navigation.html:2
 msgid "My Profile"
 msgstr "El meu perfil"
 
-#: src/olympia/amo/context_processors.py:54 src/olympia/users/templates/users/edit.html:5 src/olympia/users/templates/users/includes/navigation.html:3
+#: src/olympia/amo/context_processors.py:53 src/olympia/users/templates/users/edit.html:5 src/olympia/users/templates/users/includes/navigation.html:3
 msgid "Account Settings"
 msgstr "Configuració del compte"
 
-#: src/olympia/amo/context_processors.py:57 src/olympia/discovery/templates/discovery/pane_account.html:11 src/olympia/users/templates/users/profile.html:83
+#: src/olympia/amo/context_processors.py:56 src/olympia/discovery/templates/discovery/pane_account.html:11 src/olympia/users/templates/users/profile.html:83
 #: src/olympia/users/templates/users/includes/navigation.html:4
 msgid "My Collections"
 msgstr "Les meves col·leccions"
 
-#: src/olympia/amo/context_processors.py:62 src/olympia/discovery/templates/discovery/pane_account.html:10 src/olympia/users/templates/users/includes/navigation.html:7
+#: src/olympia/amo/context_processors.py:61 src/olympia/discovery/templates/discovery/pane_account.html:10 src/olympia/users/templates/users/includes/navigation.html:7
 msgid "My Favorites"
 msgstr "Les meves preferides"
 
-#: src/olympia/amo/context_processors.py:67 src/olympia/discovery/templates/discovery/pane_account.html:13 src/olympia/templates/impala/user_login.html:14 src/olympia/templates/mobile/header_auth.html:5
+#: src/olympia/amo/context_processors.py:66 src/olympia/discovery/templates/discovery/pane_account.html:13 src/olympia/templates/impala/user_login.html:14
+#: src/olympia/templates/mobile/header_auth.html:5
 msgid "Log out"
 msgstr "Surt"
 
-#: src/olympia/amo/context_processors.py:72 src/olympia/devhub/templates/devhub/addons/dashboard.html:4
+#: src/olympia/amo/context_processors.py:71 src/olympia/devhub/templates/devhub/addons/dashboard.html:4
 msgid "Manage My Submissions"
 msgstr ""
 
-#: src/olympia/amo/context_processors.py:75 src/olympia/devhub/templates/devhub/nav.html:27 src/olympia/devhub/templates/devhub/addons/dashboard.html:25
+#: src/olympia/amo/context_processors.py:74 src/olympia/devhub/templates/devhub/nav.html:27 src/olympia/devhub/templates/devhub/addons/dashboard.html:25
 #: src/olympia/devhub/templates/devhub/addons/submit/base.html:4
 msgid "Submit a New Add-on"
 msgstr "Envia un complement nou"
 
-#: src/olympia/amo/context_processors.py:77 src/olympia/browse/templates/browse/personas/base.html:50 src/olympia/devhub/templates/devhub/index.html:24
+#: src/olympia/amo/context_processors.py:76 src/olympia/browse/templates/browse/personas/base.html:50 src/olympia/devhub/templates/devhub/index.html:24
 #: src/olympia/devhub/templates/devhub/addons/dashboard.html:29
 msgid "Submit a New Theme"
 msgstr ""
 
-#: src/olympia/amo/context_processors.py:79 src/olympia/amo/templates/amo/site_nav.html:87 src/olympia/devhub/helpers.py:36 src/olympia/devhub/helpers.py:68 src/olympia/devhub/helpers.py:102
+#: src/olympia/amo/context_processors.py:78 src/olympia/amo/templates/amo/site_nav.html:85 src/olympia/devhub/helpers.py:36 src/olympia/devhub/helpers.py:68 src/olympia/devhub/helpers.py:102
 #: src/olympia/templates/footer.html:6 src/olympia/templates/menu_links.html:14
 msgid "Developer Hub"
 msgstr "Centre de desenvolupadors"
 
-#: src/olympia/amo/context_processors.py:83 src/olympia/devhub/views.py:1792
+#: src/olympia/amo/context_processors.py:81 src/olympia/devhub/views.py:1796
 msgid "Manage API Keys"
 msgstr ""
 
-#: src/olympia/amo/context_processors.py:88 src/olympia/editors/helpers.py:82 src/olympia/editors/helpers.py:102 src/olympia/editors/templates/editors/base.html:10
+#: src/olympia/amo/context_processors.py:86 src/olympia/editors/helpers.py:84 src/olympia/editors/helpers.py:104 src/olympia/editors/templates/editors/base.html:10
 msgid "Editor Tools"
 msgstr "Eines de l'editor"
 
-#: src/olympia/amo/context_processors.py:92
+#: src/olympia/amo/context_processors.py:90
 msgid "Admin Tools"
 msgstr "Eines de l'administrador"
 
-#: src/olympia/amo/fields.py:15
+#: src/olympia/amo/fields.py:20
 msgid "Incorrect, please try again."
 msgstr ""
 
-#: src/olympia/amo/fields.py:16
+#: src/olympia/amo/fields.py:21
 msgid "Error verifying input, please try again."
 msgstr ""
 
-#: src/olympia/amo/fields.py:32
+#: src/olympia/amo/fields.py:37
 msgid "This must be a valid hex color code, such as #000000."
 msgstr "Cal que sigui un codi de color hexadecimal vàlid, com ara #000000."
 
-#: src/olympia/amo/fields.py:58
+#: src/olympia/amo/fields.py:63
 msgid "Enter at least one value."
 msgstr ""
 
-#: src/olympia/amo/helpers.py:162 src/olympia/amo/templates/amo/site_nav.html:61 src/olympia/bandwagon/templates/bandwagon/add.html:9 src/olympia/bandwagon/templates/bandwagon/collection_detail.html:15
-#: src/olympia/bandwagon/templates/bandwagon/delete.html:9 src/olympia/bandwagon/templates/bandwagon/edit.html:15 src/olympia/bandwagon/templates/bandwagon/user_listing.html:18
-#: src/olympia/bandwagon/templates/bandwagon/user_listing.html:21 src/olympia/bandwagon/templates/bandwagon/impala/collection_listing.html:12
-#: src/olympia/bandwagon/templates/bandwagon/impala/collection_listing.html:20 src/olympia/bandwagon/templates/bandwagon/impala/collection_listing.html:24
-#: src/olympia/bandwagon/templates/bandwagon/impala/collection_sidebar.html:3 src/olympia/bandwagon/templates/bandwagon/includes/collection_sidebar.html:2
-#: src/olympia/bandwagon/templates/bandwagon/mobile/collection_listing.html:3 src/olympia/stats/templates/stats/stats.html:77 src/olympia/templates/menu_links.html:12
+#: src/olympia/amo/helpers.py:162 src/olympia/amo/templates/amo/site_nav.html:59 src/olympia/bandwagon/templates/bandwagon/add.html:9
+#: src/olympia/bandwagon/templates/bandwagon/collection_detail.html:15 src/olympia/bandwagon/templates/bandwagon/delete.html:9 src/olympia/bandwagon/templates/bandwagon/edit.html:15
+#: src/olympia/bandwagon/templates/bandwagon/user_listing.html:18 src/olympia/bandwagon/templates/bandwagon/user_listing.html:21
+#: src/olympia/bandwagon/templates/bandwagon/impala/collection_listing.html:12 src/olympia/bandwagon/templates/bandwagon/impala/collection_listing.html:20
+#: src/olympia/bandwagon/templates/bandwagon/impala/collection_listing.html:24 src/olympia/bandwagon/templates/bandwagon/impala/collection_sidebar.html:3
+#: src/olympia/bandwagon/templates/bandwagon/includes/collection_sidebar.html:2 src/olympia/bandwagon/templates/bandwagon/mobile/collection_listing.html:3
+#: src/olympia/stats/templates/stats/stats.html:33 src/olympia/templates/menu_links.html:12
 msgid "Collections"
 msgstr "Col·leccions"
 
-#: src/olympia/amo/helpers.py:171 src/olympia/amo/templates/amo/site_nav.html:85 src/olympia/browse/templates/browse/language_tools.html:3
+#: src/olympia/amo/helpers.py:171 src/olympia/amo/templates/amo/site_nav.html:83 src/olympia/browse/templates/browse/language_tools.html:3
 msgid "Dictionaries & Language Packs"
 msgstr "Diccionaris i paquets d'idioma"
 
@@ -1622,8 +1629,8 @@ msgstr "S'ha sol·licitat una superrevisió"
 msgid "Comment on {addon} {version}."
 msgstr "Comentari sobre {addon} {version}."
 
-#: src/olympia/amo/log.py:236 src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:19 src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:47
-#: src/olympia/editors/helpers.py:511 src/olympia/editors/templates/editors/themes/history_table.html:11
+#: src/olympia/amo/log.py:236 src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:17 src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:45
+#: src/olympia/editors/helpers.py:584 src/olympia/editors/templates/editors/themes/history_table.html:11
 msgid "Comment"
 msgstr "Comentari"
 
@@ -1910,18 +1917,18 @@ msgstr "No s'ha trobat"
 #, python-format
 msgid ""
 "<h1>We're sorry, but we can't find what you're looking for.</h1> <p> The page or file you requested wasn't found on our site. It's possible that you clicked a link that's out of date, or typed in "
-"the address incorrectly. </p> <ul> <li>If you typed in the address, please double check the spelling.</li> <li> If you followed a link from somewhere, please let us know at <a "
-"href=\"mailto:webmaster@mozilla.com\">webmaster@mozilla.com</a>. Tell us where you came from and what you were looking for, and we'll do our best to fix it. </li> </ul> <p>Or you can just jump over"
-" to some of the popular pages on our website.</p> <ul> <li>Are you interested in a <a href=\"%(rec)s\">list of featured add-ons</a>?</li> <li> Do you want to <a href=\"%(search)s\">search for add-"
-"ons</a>? You may go to the <a href=\"%(search)s\">search page</a> or just use the search field above. </li> <li> If you prefer to start over, just go to the <a href=\"%(home)s\">add-ons front "
-"page</a>. </li> </ul>"
+"the address incorrectly. </p> <ul> <li>If you typed in the address, please double check the spelling.</li> <li> If you followed a link from somewhere, please let us know at <a href=\"mailto:"
+"webmaster@mozilla.com\">webmaster@mozilla.com</a>. Tell us where you came from and what you were looking for, and we'll do our best to fix it. </li> </ul> <p>Or you can just jump over to some of "
+"the popular pages on our website.</p> <ul> <li>Are you interested in a <a href=\"%(rec)s\">list of featured add-ons</a>?</li> <li> Do you want to <a href=\"%(search)s\">search for add-ons</a>? You "
+"may go to the <a href=\"%(search)s\">search page</a> or just use the search field above. </li> <li> If you prefer to start over, just go to the <a href=\"%(home)s\">add-ons front page</a>. </li> </"
+"ul>"
 msgstr ""
 "<h1>Ho sentim molt, però no s'ha trobat el que cercàveu.</h1> <p> La pàgina o el fitxer que demaneu no està al nostre web. Potser que hàgiu clicat un enllaç que està desactualitzat o que hàgiu "
-"teclejat una adreça incorrecta. </p> <ul> <li>Si heu teclajat una adreça, comproveu que sigui correcte.</li> <li> Si heu clicat un enllaç i us ha portat aquí, feu-nos-ho saber a <a "
-"href=\"mailto:webmaster@mozilla.com\">webmaster@mozilla.com</a>. Expliqueu-nos d'on veniu i què cercàveu i nosaltres farem tot el possible per arreglar-ho. </li> </ul> <p>Sinó, podeu saltar cap a "
-"una altra pàgina nostre web.</p> <ul> <li>Esteu interessats en la <a href=\"%(rec)s\">llista de complements destacats</a>?</li> <li> Voleu <a href=\"%(search)s\">cercar complements</a>? podeu anar "
-"a la <a href=\"%(search)s\">pàgina de cerca</a> o bé podeu utilitzar el camp de cerca que podeu veure a la part superior. </li> <li>Si voleu anar a l'inici, aneu a <a href=\"%(home)s\">pàgina "
-"principal dels complements</a>. </li> </ul>"
+"teclejat una adreça incorrecta. </p> <ul> <li>Si heu teclajat una adreça, comproveu que sigui correcte.</li> <li> Si heu clicat un enllaç i us ha portat aquí, feu-nos-ho saber a <a href=\"mailto:"
+"webmaster@mozilla.com\">webmaster@mozilla.com</a>. Expliqueu-nos d'on veniu i què cercàveu i nosaltres farem tot el possible per arreglar-ho. </li> </ul> <p>Sinó, podeu saltar cap a una altra "
+"pàgina nostre web.</p> <ul> <li>Esteu interessats en la <a href=\"%(rec)s\">llista de complements destacats</a>?</li> <li> Voleu <a href=\"%(search)s\">cercar complements</a>? podeu anar a la <a "
+"href=\"%(search)s\">pàgina de cerca</a> o bé podeu utilitzar el camp de cerca que podeu veure a la part superior. </li> <li>Si voleu anar a l'inici, aneu a <a href=\"%(home)s\">pàgina principal "
+"dels complements</a>. </li> </ul>"
 
 #: src/olympia/amo/templates/amo/500.html:3
 msgid "Oops"
@@ -1929,8 +1936,8 @@ msgstr "Ups"
 
 #: src/olympia/amo/templates/amo/500.html:6
 #, python-format
-msgid "<h1>Oops! We had an error.</h1> <p>We'll get to fixing that soon.</p> <p> You can try refreshing the page, or head back to the <a href=\"%(home)s\">Add-ons homepage</a>. </p>"
-msgstr "<h1>S'ha produït un error.</h1> <p>Estem treballant per solucionar-lo.</p> <p>Proveu d'actualitzar la pàgina o bé torneu a la <a href=\"%(home)s\">pàgina principal de l'Add-ons</a>. </p>"
+msgid "<h1>Oops!  We had an error.</h1> <p>We'll get to fixing that soon.</p> <p> You can try refreshing the page, or head back to the <a href=\"%(home)s\">Add-ons homepage</a>. </p>"
+msgstr ""
 
 #: src/olympia/amo/templates/amo/license_link.html:10
 msgid "Some rights reserved"
@@ -1952,7 +1959,7 @@ msgstr "Anterior"
 #: src/olympia/amo/templates/amo/mobile/paginator.html:14 src/olympia/amo/templates/amo/mobile/paginator.html:16 src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:51
 #: src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:65 src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:78
 #: src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:91 src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:104
-#: src/olympia/discovery/templates/discovery/pane.html:45 src/olympia/discovery/templates/discovery/addons/detail.html:39 src/olympia/stats/templates/stats/stats.html:167
+#: src/olympia/discovery/templates/discovery/pane.html:45 src/olympia/discovery/templates/discovery/addons/detail.html:39 src/olympia/stats/templates/stats/stats.html:169
 msgid "Next"
 msgstr "Següent"
 
@@ -1984,7 +1991,7 @@ msgid ""
 msgstr ""
 
 #: src/olympia/amo/templates/amo/side_nav.html:4 src/olympia/amo/templates/amo/side_nav.html:12 src/olympia/amo/templates/amo/site_nav.html:4 src/olympia/amo/templates/amo/site_nav.html:26
-#: src/olympia/browse/views.py:56 src/olympia/browse/views.py:66 src/olympia/browse/views.py:237 src/olympia/browse/views.py:282 src/olympia/search/forms.py:86
+#: src/olympia/browse/views.py:56 src/olympia/browse/views.py:66 src/olympia/browse/views.py:204 src/olympia/browse/views.py:249 src/olympia/search/forms.py:86
 msgid "Top Rated"
 msgstr "Més ben valorat"
 
@@ -1999,37 +2006,38 @@ msgstr "Exploreu"
 msgid "Extensions"
 msgstr "Extensions"
 
-#: src/olympia/amo/templates/amo/site_nav.html:45
+#: src/olympia/amo/templates/amo/site_nav.html:44
 msgid "Want more customization? Try <b>Complete Themes</b>"
 msgstr ""
 
-#: src/olympia/amo/templates/amo/site_nav.html:56 src/olympia/bandwagon/views.py:96
+#: src/olympia/amo/templates/amo/site_nav.html:54 src/olympia/bandwagon/views.py:96
 msgid "Most Followers"
 msgstr "Més seguidors"
 
-#: src/olympia/amo/templates/amo/site_nav.html:68 src/olympia/bandwagon/templates/bandwagon/impala/collection_sidebar.html:16 src/olympia/bandwagon/templates/bandwagon/includes/collection_sidebar.html:18
+#: src/olympia/amo/templates/amo/site_nav.html:66 src/olympia/bandwagon/templates/bandwagon/impala/collection_sidebar.html:16
+#: src/olympia/bandwagon/templates/bandwagon/includes/collection_sidebar.html:18
 msgid "Collections I've Made"
 msgstr "Les meves col·leccions"
 
-#: src/olympia/amo/templates/amo/site_nav.html:70 src/olympia/bandwagon/templates/bandwagon/user_listing.html:4 src/olympia/bandwagon/templates/bandwagon/impala/collection_sidebar.html:13
+#: src/olympia/amo/templates/amo/site_nav.html:68 src/olympia/bandwagon/templates/bandwagon/user_listing.html:4 src/olympia/bandwagon/templates/bandwagon/impala/collection_sidebar.html:13
 #: src/olympia/bandwagon/templates/bandwagon/includes/collection_sidebar.html:15
 msgid "Collections I'm Following"
 msgstr "Les col·leccions que segueixo"
 
-#: src/olympia/amo/templates/amo/site_nav.html:73 src/olympia/bandwagon/templates/bandwagon/impala/collection_sidebar.html:18 src/olympia/bandwagon/templates/bandwagon/includes/collection_sidebar.html:20
-#: src/olympia/users/models.py:512
+#: src/olympia/amo/templates/amo/site_nav.html:71 src/olympia/bandwagon/templates/bandwagon/impala/collection_sidebar.html:18
+#: src/olympia/bandwagon/templates/bandwagon/includes/collection_sidebar.html:20 src/olympia/users/models.py:521
 msgid "My Favorite Add-ons"
 msgstr "Els meus complements preferits"
 
-#: src/olympia/amo/templates/amo/site_nav.html:78
+#: src/olympia/amo/templates/amo/site_nav.html:76
 msgid "More&hellip;"
 msgstr "Més&hellip;"
 
-#: src/olympia/amo/templates/amo/site_nav.html:82
+#: src/olympia/amo/templates/amo/site_nav.html:80
 msgid "Add-ons for Mobile"
 msgstr "Complements per a mòbils"
 
-#: src/olympia/amo/templates/amo/site_nav.html:86 src/olympia/browse/feeds.py:207 src/olympia/browse/templates/browse/search_tools.html:3 src/olympia/constants/base.py:176
+#: src/olympia/amo/templates/amo/site_nav.html:84 src/olympia/browse/feeds.py:207 src/olympia/browse/templates/browse/search_tools.html:3 src/olympia/constants/base.py:176
 #: src/olympia/templates/menu_links.html:10
 msgid "Search Tools"
 msgstr "Eines de cerca"
@@ -2045,7 +2053,7 @@ msgid "Jump to first page"
 msgstr "Vés a la primera pàgina"
 
 #: src/olympia/amo/templates/amo/impala/paginator.html:22 src/olympia/amo/templates/amo/mobile/impala_paginator.html:12 src/olympia/discovery/templates/discovery/pane.html:44
-#: src/olympia/discovery/templates/discovery/addons/detail.html:38 src/olympia/stats/templates/stats/stats.html:164
+#: src/olympia/discovery/templates/discovery/addons/detail.html:38 src/olympia/stats/templates/stats/stats.html:166
 msgid "Previous"
 msgstr "Anterior"
 
@@ -2068,31 +2076,50 @@ msgid_plural "Page {n}"
 msgstr[0] "Pàgina {n}"
 msgstr[1] "Pàgina {n}"
 
-#: src/olympia/amo/templates/services/install.html:38
-#, python-format
-msgid "If you are not prompted to install %(addon_name)s in a moment, please <a href=\"%(addon_xpi)s\">click here</a>."
-msgstr "Si no comença la instal·lació del %(addon_name)s en uns instants, feu clic <a href=\"%(addon_xpi)s\">aquí</a>."
-
-#: src/olympia/amo/tests/test_messages.py:57 src/olympia/amo/tests/test_messages.py:58 src/olympia/reviews/forms.py:25 src/olympia/reviews/forms.py:50 src/olympia/reviews/templates/reviews/add.html:56
+#: src/olympia/amo/tests/test_messages.py:56 src/olympia/amo/tests/test_messages.py:57 src/olympia/reviews/forms.py:25 src/olympia/reviews/forms.py:50 src/olympia/reviews/templates/reviews/add.html:56
 #: src/olympia/reviews/templates/reviews/reply.html:30
 msgid "Title"
 msgstr ""
 
-#: src/olympia/amo/tests/test_messages.py:57 src/olympia/amo/tests/test_messages.py:58
+#: src/olympia/amo/tests/test_messages.py:56 src/olympia/amo/tests/test_messages.py:57
 msgid "Body"
 msgstr ""
 
-#: src/olympia/amo/tests/test_messages.py:59
+#: src/olympia/amo/tests/test_messages.py:58
 msgid "Another Title"
 msgstr ""
 
-#: src/olympia/amo/tests/test_messages.py:59
+#: src/olympia/amo/tests/test_messages.py:58
 msgid "Another Body"
 msgstr ""
 
-#: src/olympia/api/views.py:255
-msgid "Not implemented yet."
-msgstr "No s'ha implementat encara."
+#: src/olympia/api/authentication.py:76
+msgid "Signature has expired."
+msgstr ""
+
+#: src/olympia/api/authentication.py:79
+msgid "Error decoding signature."
+msgstr ""
+
+#: src/olympia/api/authentication.py:82
+msgid "Invalid JWT Token."
+msgstr ""
+
+#: src/olympia/api/authentication.py:130
+msgid "Invalid Authorization header. No credentials provided."
+msgstr ""
+
+#: src/olympia/api/authentication.py:133
+msgid "Invalid Authorization header. Credentials string should not contain spaces."
+msgstr ""
+
+#: src/olympia/api/fields.py:29
+msgid "The field must have a length of at least {num} characters."
+msgstr ""
+
+#: src/olympia/api/fields.py:31
+msgid "The language code {lang_code} is invalid."
+msgstr ""
 
 #: src/olympia/applications/views.py:39 src/olympia/applications/templates/applications/appversions.html:3
 msgid "Application Versions"
@@ -2110,7 +2137,7 @@ msgstr "Versions d'aplicació vàlides"
 msgid "Add-ons submitted to Mozilla Add-ons must have a manifest file with at least one of the below applications supported. Only the versions listed below are allowed for these applications."
 msgstr ""
 
-#: src/olympia/applications/templates/applications/appversions.html:25
+#: src/olympia/applications/templates/applications/appversions.html:25 src/olympia/editors/helpers.py:361
 msgid "GUID"
 msgstr "GUID"
 
@@ -2224,8 +2251,8 @@ msgstr "Preferides"
 msgid "Remove from favorites"
 msgstr "Suprimeix dels preferits"
 
-#: src/olympia/bandwagon/views.py:98 src/olympia/bandwagon/views.py:191 src/olympia/browse/views.py:58 src/olympia/browse/views.py:69 src/olympia/browse/views.py:458 src/olympia/devhub/views.py:74
-#: src/olympia/devhub/views.py:82 src/olympia/devhub/templates/devhub/addons/edit/basic.html:20 src/olympia/editors/templates/editors/leaderboard.html:24
+#: src/olympia/bandwagon/views.py:98 src/olympia/bandwagon/views.py:191 src/olympia/browse/views.py:58 src/olympia/browse/views.py:69 src/olympia/browse/views.py:425 src/olympia/devhub/views.py:72
+#: src/olympia/devhub/views.py:80 src/olympia/devhub/templates/devhub/addons/edit/basic.html:20 src/olympia/editors/templates/editors/leaderboard.html:24
 #: src/olympia/editors/templates/editors/themes/queue_list.html:48 src/olympia/search/forms.py:17 src/olympia/search/forms.py:89 src/olympia/users/templates/users/vcard.html:5
 msgid "Name"
 msgstr "Nom"
@@ -2234,7 +2261,7 @@ msgstr "Nom"
 msgid "Recently Popular"
 msgstr "Popular recentment"
 
-#: src/olympia/bandwagon/views.py:189 src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:18
+#: src/olympia/bandwagon/views.py:189 src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:16
 msgid "Added"
 msgstr "S'ha afegit"
 
@@ -2248,7 +2275,7 @@ msgstr "S'ha creat la col·lecció!"
 
 #: src/olympia/bandwagon/views.py:316
 #, python-format
-msgid "Your new collection is shown below. You can <ahref=\"%(url)s\">edit additional settings</a> if you'dlike."
+msgid "Your new collection is shown below. You can <a href=\"%(url)s\">edit additional settings</a> if you'd like."
 msgstr ""
 
 #: src/olympia/bandwagon/views.py:322
@@ -2376,8 +2403,8 @@ msgid_plural "%(num)s Add-ons in this Collection"
 msgstr[0] "%(num)s complement en aquesta coŀlecció"
 msgstr[1] "%(num)s complements en aquesta coŀlecció"
 
-#: src/olympia/bandwagon/templates/bandwagon/collection_detail.html:125 src/olympia/compat/templates/compat/index.html:25 src/olympia/compat/templates/compat/reporter_detail.html:29
-#: src/olympia/files/templates/files/viewer.html:29 src/olympia/templates/amo_footer.html:17 src/olympia/templates/includes/lang_switcher.html:10
+#: src/olympia/bandwagon/templates/bandwagon/collection_detail.html:125 src/olympia/compat/templates/compat/reporter_detail.html:29 src/olympia/files/templates/files/viewer.html:29
+#: src/olympia/templates/amo_footer.html:17 src/olympia/templates/includes/lang_switcher.html:10
 msgid "Go"
 msgstr "D'acord"
 
@@ -2411,11 +2438,9 @@ msgstr ""
 
 #: src/olympia/bandwagon/templates/bandwagon/collection_detail.html:186
 msgid ""
-"Add-ons that you mark as favorites using the <b>Add to Favorites</b> feature appear below. This collection is currently <b>private</b>, which means only you can see it. If you would like everyone "
+"Add-ons that you mark as favorites using the <b>Add to Favorites</b> feature appear below. This collection is currently <b>private</b>, which means only you can see it.  If you would like everyone "
 "to be able to see your favorites, click the button below to make it public."
 msgstr ""
-"Add-ons that you mark as favorites using the <b>Add to Favorites</b> feature appear below. This collection is currently <b>private</b>, which means only you can see it. If you would like everyone "
-"to be able to see your favorites, click the button below to make it public."
 
 #: src/olympia/bandwagon/templates/bandwagon/collection_detail.html:196
 msgid "My favorite add-ons"
@@ -2551,7 +2576,7 @@ msgid "Remove this user as a contributor"
 msgstr "Suprimeix aquest usuari dels coŀlaboradors"
 
 #: src/olympia/bandwagon/templates/bandwagon/edit_contributors.html:18 src/olympia/bandwagon/templates/bandwagon/edit_contributors.html:43
-#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:20 src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:48
+#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:18 src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:46
 #: src/olympia/devhub/templates/devhub/addons/ajax_compat_update.html:19
 msgid "Remove"
 msgstr "Suprimeix"
@@ -2562,11 +2587,9 @@ msgstr "Coŀlaboradors de la coŀlecció"
 
 #: src/olympia/bandwagon/templates/bandwagon/edit_contributors.html:26
 msgid ""
-"You can add multiple contributors to this collection. A contributor can add and remove add-ons from this collection, but cannot change its name or description. To add a contributor, enter their "
+"You can add multiple contributors to this collection.  A contributor can add and remove add-ons from this collection, but cannot change its name or description.  To add a contributor, enter their "
 "email in the box below. Contributors must have a Mozilla Add-ons account."
 msgstr ""
-"You can add multiple contributors to this collection. A contributor can add and remove add-ons from this collection, but cannot change its name or description. To add a contributor, enter their "
-"email in the box below. Contributors must have a Mozilla Add-ons account."
 
 #: src/olympia/bandwagon/templates/bandwagon/edit_contributors.html:40
 msgid "User"
@@ -2602,7 +2625,7 @@ msgid "<b>Warning:</b> By changing the owner of this collection, you will no lon
 msgstr "<b>Warning:</b> By changing the owner of this collection, you will no longer be able to edit it. You will only be able to add and remove add-ons from it."
 
 #: src/olympia/bandwagon/templates/bandwagon/edit_contributors.html:83 src/olympia/devhub/templates/devhub/addons/forms_shared/media.html:157
-#: src/olympia/devhub/templates/devhub/addons/submit/describe.html:69 src/olympia/devhub/templates/devhub/addons/submit/license.html:60 src/olympia/devhub/templates/devhub/addons/submit/upload.html:78
+#: src/olympia/devhub/templates/devhub/addons/submit/describe.html:69 src/olympia/devhub/templates/devhub/addons/submit/license.html:60 src/olympia/devhub/templates/devhub/addons/submit/upload.html:70
 #: src/olympia/devhub/templates/devhub/payments/tier.html:17 src/olympia/editors/templates/editors/themes/themes.html:111 src/olympia/editors/templates/editors/themes/themes.html:128
 #: src/olympia/editors/templates/editors/themes/themes.html:134 src/olympia/editors/templates/editors/themes/themes.html:141 src/olympia/users/templates/users/fxa_migration_prompt_content.html:10
 #: src/olympia/users/templates/users/login_form.html:42 src/olympia/users/templates/users/mobile/login.html:57
@@ -2674,44 +2697,43 @@ msgid "Reset"
 msgstr "Restaura"
 
 #: src/olympia/bandwagon/templates/bandwagon/includes/addedit.html:53
-msgid "PNG and JPG supported. Image will be resized to 32x32."
-msgstr "Es permet PNG i JPG. Es canviarà la mida de la imatge a 32x32."
+msgid "PNG and JPG supported.  Image will be resized to 32x32."
+msgstr ""
 
 #: src/olympia/bandwagon/templates/bandwagon/includes/addedit_errors.html:3
-msgid "There are errors in this form. Please correct them below."
-msgstr "Hi ha errors en el formulari. Corregiu-los a continuació."
+msgid "There are errors in this form.  Please correct them below."
+msgstr ""
 
 #: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:2
 msgid "Add-ons in Your Collection"
 msgstr "Complements de la vostra coŀlecció"
 
 #: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:4
-msgid "To include an add-on in this collection, enter its name in the box below and hit enter. You can also use the <strong>Add to Collection</strong> links throughout the site to include add-ons later."
+msgid "To include an add-on in this collection, enter its name in the box below and hit enter."
 msgstr ""
-"Per incloure un complement a la coŀlecció, escriviu el nom al camp següent i premeu Retorn. També podeu utilitzar els enllaços <strong>Afegeix a la coŀlecció</strong> que trobareu als complements "
-"del web."
 
-#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:17 src/olympia/constants/base.py:400 src/olympia/devhub/templates/devhub/addons/activity.html:62
+#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:15 src/olympia/constants/base.py:400 src/olympia/devhub/templates/devhub/addons/activity.html:62
+#: src/olympia/editors/helpers.py:273 src/olympia/editors/helpers.py:360
 msgid "Add-on"
 msgstr "Complement"
 
-#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:26
+#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:24
 msgid "Enter the name of the add-on to include"
 msgstr "Enter the name of the add-on to include"
 
-#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:28
+#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:26
 msgid "Add to Collection"
 msgstr "Afegeix a la col·lecció"
 
-#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:45 src/olympia/editors/helpers.py:936 src/olympia/editors/helpers.py:956
+#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:43 src/olympia/editors/helpers.py:1016 src/olympia/editors/helpers.py:1036
 msgid "Pending"
 msgstr "Pending"
 
-#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:47
+#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:45
 msgid "Add a comment"
 msgstr "Afegeix un comentari"
 
-#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:48
+#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:46
 msgid "Remove this add-on from the collection"
 msgstr "Suprimeix aquest complement de la coŀlecció"
 
@@ -2760,10 +2782,8 @@ msgstr "El connectors problemàtics s'inhabilitaran automàticament i no es podr
 #, python-format
 msgid ""
 "When Mozilla becomes aware of add-ons, plugins, or other third-party software that seriously compromises %(app)s security, stability, or performance and meets <a href=\"%(criteria)s\">certain "
-"criteria</a>, the software may be blocked from general use. For more information, please read <a href=\"%(support)s\">this support article</a>."
+"criteria</a>, the software may be blocked from general use.  For more information, please read <a href=\"%(support)s\">this support article</a>."
 msgstr ""
-"Quan Mozilla descobreig que un complement, un connector o un programa d'altri afecta seriosament a la seguretat, l'estabilitat o el rendiment del %(app)s i, a més a més, reuneix uns <a "
-"href=\"%(criteria)s\">determinats criteris</a>, pot ser que es decideixi bloquejar-lo. Per més informació, llegiu <a href=\"%(support)s\">el següent article</a>."
 
 #: src/olympia/blocklist/templates/blocklist/blocked_detail.html:44
 #, python-format
@@ -2820,12 +2840,12 @@ msgstr "Eines de cerca"
 msgid "Most Users"
 msgstr "Amb més usuaris"
 
-#: src/olympia/browse/views.py:61 src/olympia/browse/views.py:72 src/olympia/browse/views.py:279 src/olympia/browse/templates/browse/personas/mobile/category_landing.html:63
+#: src/olympia/browse/views.py:61 src/olympia/browse/views.py:72 src/olympia/browse/views.py:246 src/olympia/browse/templates/browse/personas/mobile/category_landing.html:63
 #: src/olympia/discovery/templates/discovery/pane.html:67 src/olympia/search/forms.py:92
 msgid "Up & Coming"
 msgstr "Novetats"
 
-#: src/olympia/browse/views.py:460 src/olympia/devhub/views.py:76 src/olympia/devhub/views.py:83 src/olympia/discovery/templates/discovery/addons/detail.html:66
+#: src/olympia/browse/views.py:427 src/olympia/devhub/views.py:74 src/olympia/devhub/views.py:81 src/olympia/discovery/templates/discovery/addons/detail.html:66
 msgid "Created"
 msgstr "Creat"
 
@@ -3016,8 +3036,8 @@ msgid_plural "See all %(cnt)s extensions in %(name)s &raquo;"
 msgstr[0] "Mostra %(cnt)s complement a %(name)s &raquo;"
 msgstr[1] "Mostra tots els %(cnt)s complements a %(name)s &raquo;"
 
-#: src/olympia/browse/templates/browse/mobile/extensions.html:13 src/olympia/compat/templates/compat/index.html:82 src/olympia/devhub/templates/devhub/devhub_search.html:24
-#: src/olympia/devhub/templates/devhub/addons/activity.html:47 src/olympia/search/templates/search/no_results.html:4 src/olympia/search/templates/search/mobile/results.html:36
+#: src/olympia/browse/templates/browse/mobile/extensions.html:13 src/olympia/devhub/templates/devhub/devhub_search.html:24 src/olympia/devhub/templates/devhub/addons/activity.html:47
+#: src/olympia/search/templates/search/no_results.html:4 src/olympia/search/templates/search/mobile/results.html:36
 msgid "No results found."
 msgstr "No s'han trobat resultats."
 
@@ -3102,7 +3122,7 @@ msgstr ""
 msgid "All"
 msgstr "Tots"
 
-#: src/olympia/compat/forms.py:22 src/olympia/search/views.py:525
+#: src/olympia/compat/forms.py:22 src/olympia/editors/templates/editors/base.html:69 src/olympia/search/views.py:518
 msgid "All Add-ons"
 msgstr "Tots els complements"
 
@@ -3113,53 +3133,6 @@ msgstr "Binari"
 #: src/olympia/compat/forms.py:24
 msgid "Non-binary"
 msgstr "No binari"
-
-#. Review points sources other than add-ons and themes.
-#: src/olympia/compat/views.py:87 src/olympia/constants/base.py:388 src/olympia/devhub/forms.py:162 src/olympia/editors/templates/editors/performance.html:75
-msgid "Other"
-msgstr "Altre"
-
-#: src/olympia/compat/templates/compat/index.html:4
-msgid "Add-on Compatibility Report for {app} {version}"
-msgstr "Informe de la compatibilitat del complement {app} {version}"
-
-#: src/olympia/compat/templates/compat/index.html:11
-msgid "{app} {version} Compatibility"
-msgstr "Compatibilitat amb {app} {version}"
-
-#: src/olympia/compat/templates/compat/index.html:17
-#, python-format
-msgid "Top 95%% compatible with previous version"
-msgstr ""
-
-#: src/olympia/compat/templates/compat/index.html:18
-#, python-format
-msgid "Top 95%% of all add-ons"
-msgstr ""
-
-#: src/olympia/compat/templates/compat/index.html:19
-msgid "All active add-ons"
-msgstr "Tots els complements actius"
-
-#: src/olympia/compat/templates/compat/index.html:23 src/olympia/constants/base.py:401
-msgid "App"
-msgstr "Aplicació"
-
-#: src/olympia/compat/templates/compat/index.html:55
-msgid "Details for add-ons compatible with previous version:"
-msgstr "Més informació dels complements compatibles amb la versió anterior:"
-
-#: src/olympia/compat/templates/compat/index.html:57
-msgid "Show all versions"
-msgstr "Mostra totes les versions"
-
-#: src/olympia/compat/templates/compat/index.html:59
-msgid "Details for add-ons compatible with all versions:"
-msgstr "Detalls dels complements compatibles amb totes les versions:"
-
-#: src/olympia/compat/templates/compat/index.html:61
-msgid "Show previous version only"
-msgstr "Mostra només la versió anterior"
 
 #: src/olympia/compat/templates/compat/reporter.html:3
 msgid "Add-on Compatibility Reports"
@@ -3214,8 +3187,8 @@ msgstr "Filtra per aplicació"
 msgid "Report Type"
 msgstr "Tipus d'informe"
 
-#: src/olympia/compat/templates/compat/reporter_detail.html:47 src/olympia/devhub/forms.py:784 src/olympia/devhub/templates/devhub/addons/ajax_compat_update.html:17 src/olympia/editors/forms.py:108
-#: src/olympia/zadmin/forms.py:45
+#: src/olympia/compat/templates/compat/reporter_detail.html:47 src/olympia/devhub/forms.py:785 src/olympia/devhub/templates/devhub/addons/ajax_compat_update.html:17 src/olympia/editors/forms.py:108
+#: src/olympia/editors/forms.py:248 src/olympia/zadmin/forms.py:45
 msgid "Application"
 msgstr "Aplicació"
 
@@ -3303,7 +3276,8 @@ msgstr "S'ha fet la revisió preliminar"
 msgid "Preliminarily Reviewed and Awaiting Full Review"
 msgstr "S'ha fet la revisió preliminar i s'està fent la final"
 
-#: src/olympia/constants/base.py:33 src/olympia/editors/helpers.py:924 src/olympia/editors/templates/editors/themes/history_table.html:34
+#: src/olympia/constants/base.py:33 src/olympia/editors/forms.py:258 src/olympia/editors/helpers.py:73 src/olympia/editors/helpers.py:1004
+#: src/olympia/editors/templates/editors/themes/history_table.html:34
 msgid "Deleted"
 msgstr "Eliminat"
 
@@ -3404,6 +3378,11 @@ msgstr "Demana-ho després d'iniciar la baixada d'aquest complement"
 msgid "Ask before users can download this add-on"
 msgstr "Demana-ho abans que els usuaris puguin baixar aquest complement"
 
+#. Review points sources other than add-ons and themes.
+#: src/olympia/constants/base.py:388 src/olympia/devhub/forms.py:162 src/olympia/editors/templates/editors/performance.html:75
+msgid "Other"
+msgstr "Altre"
+
 #: src/olympia/constants/base.py:389
 msgid "Exception"
 msgstr "Excepció"
@@ -3415,6 +3394,10 @@ msgstr "Versió"
 #: src/olympia/constants/base.py:391
 msgid "Change"
 msgstr "Canvi"
+
+#: src/olympia/constants/base.py:401
+msgid "App"
+msgstr "Aplicació"
 
 #: src/olympia/constants/base.py:402
 msgid "Persona"
@@ -3564,7 +3547,7 @@ msgstr ""
 msgid "Duplicate"
 msgstr ""
 
-#: src/olympia/constants/editors.py:17 src/olympia/editors/helpers.py:502 src/olympia/editors/templates/editors/themes/queue.html:71 src/olympia/editors/templates/editors/themes/themes.html:94
+#: src/olympia/constants/editors.py:17 src/olympia/editors/helpers.py:575 src/olympia/editors/templates/editors/themes/queue.html:71 src/olympia/editors/templates/editors/themes/themes.html:94
 msgid "Reject"
 msgstr "Rebutja'l"
 
@@ -3664,7 +3647,7 @@ msgstr "Solaris"
 msgid "Android"
 msgstr "Android"
 
-#: src/olympia/core/apps.py:19
+#: src/olympia/core/apps.py:21
 msgid "Core"
 msgstr ""
 
@@ -3798,7 +3781,7 @@ msgid "Submit my add-on for manual review."
 msgstr ""
 
 #: src/olympia/devhub/forms.py:537
-msgid "Do not list my add-on on this site (beta)"
+msgid "Do not list my add-on on this site"
 msgstr ""
 
 #: src/olympia/devhub/forms.py:538
@@ -3831,46 +3814,46 @@ msgstr ""
 
 #: src/olympia/devhub/forms.py:592
 #, python-format
-msgid "Version %s already exists"
-msgstr "La versió %s ja existeix"
+msgid "Version %s already exists, or was uploaded before."
+msgstr ""
 
-#: src/olympia/devhub/forms.py:604
+#: src/olympia/devhub/forms.py:605
 msgid "Select a valid choice. That choice is not one of the available choices."
 msgstr ""
 
-#: src/olympia/devhub/forms.py:610
+#: src/olympia/devhub/forms.py:611
 msgid "A file with a version ending with a|alpha|b|beta and an optional number is detected as beta."
 msgstr ""
 
-#: src/olympia/devhub/forms.py:633
+#: src/olympia/devhub/forms.py:634
 msgid "You cannot upload any more files for this version."
 msgstr "No podeu pujar més fitxers per a aquesta versió."
 
-#: src/olympia/devhub/forms.py:639
+#: src/olympia/devhub/forms.py:640
 msgid "Version doesn't match"
 msgstr "La versió no és correcta"
 
-#: src/olympia/devhub/forms.py:668
-msgid "You cannot delete a file once the review process has started. You must delete the whole version."
-msgstr "No es pot suprimir un fitxer una vegada iniciat el procés de revisió. Heu de suprimir la versió completa."
+#: src/olympia/devhub/forms.py:669
+msgid "You cannot delete a file once the review process has started.  You must delete the whole version."
+msgstr ""
 
-#: src/olympia/devhub/forms.py:688
+#: src/olympia/devhub/forms.py:689
 msgid "The platform All cannot be combined with specific platforms."
 msgstr "La plataforma Totes no es pot combinar amb plataformes específiques."
 
-#: src/olympia/devhub/forms.py:693
+#: src/olympia/devhub/forms.py:694
 msgid "A platform can only be chosen once."
 msgstr "Només es pot seleccionar la plataforma una vegada."
 
-#: src/olympia/devhub/forms.py:706
+#: src/olympia/devhub/forms.py:707
 msgid "A review type must be selected."
 msgstr "Cal seleccionar un tipus de valoració."
 
-#: src/olympia/devhub/forms.py:788 src/olympia/editors/forms.py:114 src/olympia/zadmin/forms.py:49 src/olympia/zadmin/forms.py:52
+#: src/olympia/devhub/forms.py:789 src/olympia/editors/forms.py:114 src/olympia/editors/forms.py:254 src/olympia/zadmin/forms.py:49 src/olympia/zadmin/forms.py:52
 msgid "Select an application first"
 msgstr "Primer cal que seleccioneu una aplicació"
 
-#: src/olympia/devhub/forms.py:840
+#: src/olympia/devhub/forms.py:841
 msgid "There cannot be more than 3 required add-ons."
 msgstr "No es pot requerir més de 3 complements."
 
@@ -3906,77 +3889,77 @@ msgstr[1] "{0} avisos"
 msgid "Review"
 msgstr "Comentari"
 
-#: src/olympia/devhub/tasks.py:551
+#: src/olympia/devhub/tasks.py:583
 #, python-format
 msgid "%s responded with %s (%s)."
 msgstr "%s ha respòs amb %s (%s)."
 
-#: src/olympia/devhub/tasks.py:555
+#: src/olympia/devhub/tasks.py:587
 #, python-format
 msgid "Connection to \"%s\" timed out."
 msgstr "S'ha esgotat el temps de connexió a «%s»."
 
-#: src/olympia/devhub/tasks.py:557
+#: src/olympia/devhub/tasks.py:589
 #, python-format
 msgid "Could not contact host at \"%s\"."
 msgstr "No s'ha pogut contactar amb el servidor central a «%s»."
 
-#: src/olympia/devhub/utils.py:104
+#: src/olympia/devhub/utils.py:105
 #, python-format
 msgid "Validation generated too many errors/warnings so %s messages were truncated. After addressing the visible messages, you'll be able to see the others."
 msgstr ""
 
-#: src/olympia/devhub/views.py:183
+#: src/olympia/devhub/views.py:181
 msgid "All My Add-ons"
 msgstr "Tots els meus complements"
 
-#: src/olympia/devhub/views.py:210
+#: src/olympia/devhub/views.py:208
 msgid "All Activity"
 msgstr "Tota l'activitat"
 
-#: src/olympia/devhub/views.py:211
+#: src/olympia/devhub/views.py:209
 msgid "Add-on Updates"
 msgstr "Actualitzacions del complement"
 
-#: src/olympia/devhub/views.py:212
+#: src/olympia/devhub/views.py:210
 msgid "Add-on Status"
 msgstr "Estat del complement"
 
 # {0} is the name of the collection
-#: src/olympia/devhub/views.py:213
+#: src/olympia/devhub/views.py:211
 msgid "User Collections"
 msgstr "Coŀleccions dels usuaris"
 
-#: src/olympia/devhub/views.py:214 src/olympia/devhub/templates/devhub/docs/policies-maintenance.html:68 src/olympia/pages/templates/pages/dev_faq.html:38
+#: src/olympia/devhub/views.py:212 src/olympia/devhub/templates/devhub/docs/policies-maintenance.html:68 src/olympia/pages/templates/pages/dev_faq.html:38
 #: src/olympia/pages/templates/pages/dev_faq.html:484
 msgid "User Reviews"
 msgstr "Comentaris dels usuaris"
 
-#: src/olympia/devhub/views.py:327 src/olympia/devhub/views.py:331 src/olympia/devhub/views.py:484 src/olympia/devhub/views.py:513 src/olympia/devhub/views.py:564 src/olympia/devhub/views.py:1150
+#: src/olympia/devhub/views.py:325 src/olympia/devhub/views.py:329 src/olympia/devhub/views.py:484 src/olympia/devhub/views.py:513 src/olympia/devhub/views.py:564 src/olympia/devhub/views.py:1156
 msgid "Changes successfully saved."
 msgstr "S'han desat els canvis correctament."
 
-#: src/olympia/devhub/views.py:334 src/olympia/devhub/views.py:1631
+#: src/olympia/devhub/views.py:332 src/olympia/devhub/views.py:1637
 msgid "Please check the form for errors."
 msgstr ""
 
-#: src/olympia/devhub/views.py:346
+#: src/olympia/devhub/views.py:344
 msgid "Add-on cannot be deleted. Disable this add-on instead."
 msgstr "No es pot suprimir el complement. Mireu d'inhabilitar-lo."
 
-#: src/olympia/devhub/views.py:356
+#: src/olympia/devhub/views.py:354
 msgid "Theme deleted."
 msgstr ""
 
-#: src/olympia/devhub/views.py:356
+#: src/olympia/devhub/views.py:354
 msgid "Add-on deleted."
 msgstr "S'ha suprimit el complement"
 
-#: src/olympia/devhub/views.py:362
+#: src/olympia/devhub/views.py:360
 msgid "URL name was incorrect. Theme was not deleted."
 msgstr ""
 
-#: src/olympia/devhub/views.py:367
+#: src/olympia/devhub/views.py:365
 msgid "URL name was incorrect. Add-on was not deleted."
 msgstr ""
 
@@ -4004,7 +3987,7 @@ msgstr "Valida el complement"
 msgid "Check Add-on Compatibility"
 msgstr "Comprova la compatibilitat del complement"
 
-#: src/olympia/devhub/views.py:808 src/olympia/signing/views.py:90
+#: src/olympia/devhub/views.py:808 src/olympia/signing/views.py:95
 msgid "You cannot submit this type of add-on"
 msgstr ""
 
@@ -4034,33 +4017,33 @@ msgstr "La imatge ha de tenir exactament {0} píxels d'amplada i {1} píxels d'a
 msgid "There was an error uploading your preview."
 msgstr "S'ha produït un error quan es pujava la previsualització."
 
-#: src/olympia/devhub/views.py:1189
+#: src/olympia/devhub/views.py:1195
 #, python-format
 msgid "Version %s disabled."
 msgstr ""
 
-#: src/olympia/devhub/views.py:1193
+#: src/olympia/devhub/views.py:1199
 #, python-format
 msgid "Version %s deleted."
 msgstr "S'ha suprimit la versió %s."
 
-#: src/olympia/devhub/views.py:1203
+#: src/olympia/devhub/views.py:1209
 msgid "This upload has failed validation, and may lack complete validation results. Please take due care when reviewing it."
 msgstr ""
 
-#: src/olympia/devhub/views.py:1677
+#: src/olympia/devhub/views.py:1683
 msgid "Preliminary Review Requested."
 msgstr "S'ha demant una revisió preliminar."
 
-#: src/olympia/devhub/views.py:1678
+#: src/olympia/devhub/views.py:1684
 msgid "Full Review Requested."
 msgstr "S'ha demant una revisió final."
 
-#: src/olympia/devhub/views.py:1779
+#: src/olympia/devhub/views.py:1783
 msgid "Your old credentials were revoked and are no longer valid. Be sure to update all API clients with the new credentials."
 msgstr ""
 
-#: src/olympia/devhub/views.py:1797
+#: src/olympia/devhub/views.py:1801
 msgid "New API key created"
 msgstr ""
 
@@ -4090,10 +4073,10 @@ msgstr "Torna als complements"
 msgid "{0} :: Search"
 msgstr "{0} :: Cerca"
 
-#: src/olympia/devhub/templates/devhub/devhub_search.html:6 src/olympia/devhub/templates/devhub/search.html:8 src/olympia/editors/forms.py:435 src/olympia/editors/forms.py:437
+#: src/olympia/devhub/templates/devhub/devhub_search.html:6 src/olympia/devhub/templates/devhub/search.html:8 src/olympia/editors/forms.py:534 src/olympia/editors/forms.py:536
 #: src/olympia/editors/templates/editors/queue.html:27 src/olympia/editors/templates/editors/themes/queue_list.html:14 src/olympia/search/templates/search/collections.html:17
-#: src/olympia/search/templates/search/personas.html:18 src/olympia/search/templates/search/results.html:18 src/olympia/search/templates/search/mobile/results.html:8 src/olympia/templates/search.html:14
-#: src/olympia/templates/impala/search.html:18
+#: src/olympia/search/templates/search/personas.html:18 src/olympia/search/templates/search/results.html:18 src/olympia/search/templates/search/mobile/results.html:8
+#: src/olympia/templates/search.html:14 src/olympia/templates/impala/search.html:18
 msgid "Search"
 msgstr "Cerca"
 
@@ -4137,9 +4120,9 @@ msgstr ""
 
 #: src/olympia/devhub/templates/devhub/index.html:41
 msgid ""
-"Add-ons let millions of Firefox users enhance and customize their browsing experience. If you're a Web developer and know <a href=\"https://developer.mozilla.org/docs/Web/HTML\">HTML</a>, <a "
-"href=\"https://developer.mozilla.org/docs/Web/JavaScript\">JavaScript</a>, and <a href=\"https://developer.mozilla.org/docs/Web/CSS\">CSS</a>, you already have all the necessary skills to make a "
-"great add-on."
+"Add-ons let millions of Firefox users enhance and customize their browsing experience. If you're a Web developer and know <a href=\"https://developer.mozilla.org/docs/Web/HTML\">HTML</a>, <a href="
+"\"https://developer.mozilla.org/docs/Web/JavaScript\">JavaScript</a>, and <a href=\"https://developer.mozilla.org/docs/Web/CSS\">CSS</a>, you already have all the necessary skills to make a great "
+"add-on."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/index.html:51
@@ -4150,12 +4133,12 @@ msgstr ""
 msgid "Start Making Add-ons"
 msgstr "Comenceu a crear complements"
 
-#: src/olympia/devhub/templates/devhub/index.html:86 src/olympia/devhub/templates/devhub/addons/listing/items.html:25 src/olympia/devhub/templates/devhub/includes/addon_details.html:15
+#: src/olympia/devhub/templates/devhub/index.html:86 src/olympia/devhub/templates/devhub/addons/listing/items.html:25 src/olympia/devhub/templates/devhub/includes/addon_details.html:20
 #: src/olympia/devhub/templates/devhub/personas/edit.html:43
 msgid "Status:"
 msgstr "Estat:"
 
-#: src/olympia/devhub/templates/devhub/index.html:90 src/olympia/devhub/templates/devhub/includes/addon_details.html:100
+#: src/olympia/devhub/templates/devhub/index.html:90 src/olympia/devhub/templates/devhub/includes/addon_details.html:87
 msgid "Visibility:"
 msgstr ""
 
@@ -4163,11 +4146,11 @@ msgstr ""
 msgid "Latest Version:"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/index.html:109 src/olympia/devhub/templates/devhub/includes/addon_details.html:145 src/olympia/devhub/templates/devhub/personas/edit.html:49
+#: src/olympia/devhub/templates/devhub/index.html:109 src/olympia/devhub/templates/devhub/includes/addon_details.html:131 src/olympia/devhub/templates/devhub/personas/edit.html:49
 msgid "Queue Position:"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/index.html:110 src/olympia/devhub/templates/devhub/includes/addon_details.html:146 src/olympia/devhub/templates/devhub/personas/edit.html:50
+#: src/olympia/devhub/templates/devhub/index.html:110 src/olympia/devhub/templates/devhub/includes/addon_details.html:132 src/olympia/devhub/templates/devhub/personas/edit.html:50
 #, python-format
 msgid "%(position)s of %(total)s"
 msgstr ""
@@ -4269,16 +4252,6 @@ msgstr ""
 msgid "Do you want your add-on to be distributed on this site?"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/validate_addon.html:49 src/olympia/devhub/templates/devhub/addons/submit/upload.html:30 src/olympia/devhub/templates/devhub/versions/add_file_modal.html:14
-#: src/olympia/devhub/templates/devhub/versions/add_file_modal.html:53 src/olympia/devhub/templates/devhub/versions/list.html:298
-msgid "Warning:"
-msgstr ""
-
-#: src/olympia/devhub/templates/devhub/validate_addon.html:50 src/olympia/devhub/templates/devhub/addons/submit/upload.html:31
-#, python-format
-msgid "Submission of unlisted add-ons for signing is currently in an open beta. Please <a href=\"%(url)s\" target=\"_blank\">report any bugs</a> that you encounter."
-msgstr ""
-
 #. first parameter is a filename like lorem-ipsum-1.0.2.xpi
 #: src/olympia/devhub/templates/devhub/validation.html:5
 msgid "Validation Results for {0}"
@@ -4339,11 +4312,11 @@ msgstr ""
 #: src/olympia/devhub/templates/devhub/addons/ajax_compat_error.html:15
 #, python-format
 msgid ""
-"<a href=\"#\" class=\"button compat-update\" data-updateurl=\"%(update_url)s\">Update Compatibility</a> <a href=\"%(version_url)s\" class=\"button\">Upload New Version</a> or <a href=\"#\" "
-"class=\"close\">Ignore</a>"
+"<a href=\"#\" class=\"button compat-update\" data-updateurl=\"%(update_url)s\">Update Compatibility</a> <a href=\"%(version_url)s\" class=\"button\">Upload New Version</a> or <a href=\"#\" class="
+"\"close\">Ignore</a>"
 msgstr ""
-"<a href=\"#\" class=\"button compat-update\" data-updateurl=\"%(update_url)s\">Actualitza la compatibilitat</a> <a href=\"%(version_url)s\" class=\"button\">Puja una altra versió</a> or <a "
-"href=\"#\" class=\"close\">Ignora</a>"
+"<a href=\"#\" class=\"button compat-update\" data-updateurl=\"%(update_url)s\">Actualitza la compatibilitat</a> <a href=\"%(version_url)s\" class=\"button\">Puja una altra versió</a> or <a href=\"#"
+"\" class=\"close\">Ignora</a>"
 
 #: src/olympia/devhub/templates/devhub/addons/ajax_compat_status.html:5
 msgid "View and update application compatibility ranges."
@@ -4357,7 +4330,7 @@ msgstr "Compatibilitat"
 msgid "Update Compatibility"
 msgstr "Actualitza la compatibilitat"
 
-#: src/olympia/devhub/templates/devhub/addons/ajax_compat_update.html:4
+#: src/olympia/devhub/templates/devhub/addons/ajax_compat_update.html:4 src/olympia/devhub/templates/devhub/versions/edit.html:45
 msgid "Adjusting application information here will allow users to install your add-on even if the install manifest in the package indicates that the add-on is incompatible."
 msgstr ""
 "Si ajusteu la informació de l'aplicació aquí, permetreu que els usuaris instal·lin els vostre complement fins i tot quan el manifest de la instal·lació del paquet indiqui que el complement és "
@@ -4371,9 +4344,9 @@ msgstr "Versions disponibles"
 msgid "Add Another Application&hellip;"
 msgstr "Afegeix una altra aplicació&hellip;"
 
-#: src/olympia/devhub/templates/devhub/addons/ajax_compat_update.html:38 src/olympia/devhub/templates/devhub/addons/owner.html:86 src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:46
-#: src/olympia/devhub/templates/devhub/versions/list.html:351 src/olympia/devhub/templates/devhub/versions/list.html:353 src/olympia/templates/impala/base.html:132
-#: src/olympia/templates/impala/base.html:143 src/olympia/templates/impala/base.html:161 src/olympia/templates/impala/base.html:171
+#: src/olympia/devhub/templates/devhub/addons/ajax_compat_update.html:38 src/olympia/devhub/templates/devhub/addons/owner.html:86 src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:45
+#: src/olympia/devhub/templates/devhub/versions/list.html:349 src/olympia/devhub/templates/devhub/versions/list.html:351 src/olympia/templates/impala/base.html:129
+#: src/olympia/templates/impala/base.html:140 src/olympia/templates/impala/base.html:158 src/olympia/templates/impala/base.html:168
 msgid "Close"
 msgstr "Tanca"
 
@@ -4407,7 +4380,7 @@ msgstr "Cap"
 msgid "Manage Authors & License"
 msgstr "Gestiona els autors i la llicència"
 
-#: src/olympia/devhub/templates/devhub/addons/owner.html:29 src/olympia/editors/templates/editors/review.html:270
+#: src/olympia/devhub/templates/devhub/addons/owner.html:29 src/olympia/editors/helpers.py:362 src/olympia/editors/templates/editors/review.html:270
 msgid "Authors"
 msgstr "Autors"
 
@@ -4476,30 +4449,21 @@ msgstr "Resum"
 
 #: src/olympia/devhub/templates/devhub/addons/edit/basic.html:52
 msgid ""
-"A short explanation of your add-on's basic\n"
-"                          functionality that is displayed in search and browse\n"
-"                          listings, as well as at the top of your add-on's\n"
-"                          details page. It is only relevant for listed add-ons."
+"A short explanation of your add-on's basic functionality that is displayed in search and browse listings, as well as at the top of your add-on's details page. It is only relevant for listed add-ons."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/basic.html:73
-msgid ""
-"Categories are the primary way users browse through add-ons.\n"
-"                        Choose any that fit your add-on's functionality for the most\n"
-"                        exposure. It is only relevant for listed add-ons."
+msgid "Categories are the primary way users browse through add-ons. Choose any that fit your add-on's functionality for the most exposure. It is only relevant for listed add-ons."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/basic.html:90
 #, python-format
-msgid "Categories cannot be changed while your add-on is featured for this application. Please email <a href=\"mailto:%(email)s\">%(email)s</a> if there is a reason you need to modify your categories."
+msgid ""
+"Categories cannot be changed while your add-on is featured for this application. Please email <a href=\"mailto:%(email)s\">%(email)s</a> if there is a reason you need to modify your categories."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/basic.html:119
-msgid ""
-"Tags help users find your add-on and should be short\n"
-"                        descriptors such as tabs, toolbar, or twitter.  You\n"
-"                        may have a maximum of {0} tags. It is only relevant\n"
-"                        for listed add-ons."
+msgid "Tags help users find your add-on and should be short descriptors such as tabs, toolbar, or twitter. You may have a maximum of {0} tags. It is only relevant for listed add-ons."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/basic.html:129 src/olympia/devhub/templates/devhub/personas/edit.html:97 src/olympia/devhub/templates/devhub/personas/submit.html:46
@@ -4529,11 +4493,7 @@ msgid "Add-on Details for {0}"
 msgstr "Detalls del complement {0}"
 
 #: src/olympia/devhub/templates/devhub/addons/edit/details.html:22
-msgid ""
-"A longer explanation of features,\n"
-"                          functionality, and other relevant information. This\n"
-"                          field is only displayed on the add-on's details\n"
-"                          page. It is only relevant for listed add-ons."
+msgid "A longer explanation of features, functionality, and other relevant information. This field is only displayed on the add-on's details page. It is only relevant for listed add-ons."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/details.html:44 src/olympia/translations/templates/translations/trans-menu.html:13
@@ -4541,10 +4501,7 @@ msgid "Default Locale"
 msgstr "Idioma per defecte"
 
 #: src/olympia/devhub/templates/devhub/addons/edit/details.html:45
-msgid ""
-"Information about your add-on is displayed in this locale\n"
-"                        unless you override it with a locale-specific translation.\n"
-"                        It is only relevant for listed add-ons."
+msgid "Information about your add-on is displayed in this locale unless you override it with a locale-specific translation. It is only relevant for listed add-ons."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/details.html:61 src/olympia/users/forms.py:311 src/olympia/users/templates/users/edit.html:122 src/olympia/users/templates/users/register.html:57
@@ -4554,10 +4511,8 @@ msgstr "Pàgina d'inici"
 
 #: src/olympia/devhub/templates/devhub/addons/edit/details.html:63
 msgid ""
-"If your add-on has another homepage, enter its\n"
-"                          address here. If your website is localized into other\n"
-"                          languages multiple translations of this field can be\n"
-"                          added. It is only relevant for listed add-ons."
+"If your add-on has another homepage, enter its address here. If your website is localized into other languages multiple translations of this field can be added. It is only relevant for listed add-"
+"ons."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/media.html:3
@@ -4575,19 +4530,14 @@ msgstr "Informació d'ajuda per a {0}"
 
 #: src/olympia/devhub/templates/devhub/addons/edit/support.html:22
 msgid ""
-"If you wish to display an e-mail address for support\n"
-"                          inquiries, enter it here. If you have different\n"
-"                          addresses for each language multiple translations of\n"
-"                          this field can be added. It is only relevant for\n"
-"                          listed add-ons."
+"If you wish to display an e-mail address for support inquiries, enter it here. If you have different addresses for each language multiple translations of this field can be added. It is only "
+"relevant for listed add-ons."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/support.html:45
 msgid ""
-"If your add-on has a support website or forum, enter\n"
-"                          its address here. If your website is localized into\n"
-"                          other languages, multiple translations of this field can\n"
-"                          be added. It is only relevant for listed add-ons."
+"If your add-on has a support website or forum, enter its address here. If your website is localized into other languages, multiple translations of this field can be added. It is only relevant for "
+"listed add-ons."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:6
@@ -4601,11 +4551,8 @@ msgstr "Detalls tècnics de {0}"
 
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:23
 msgid ""
-"Any information end users may want to know that isn't\n"
-"                          necessarily applicable to the add-on summary or description.\n"
-"                          Common uses include listing known major bugs, information on\n"
-"                          how to report bugs, anticipated release date of a new version,\n"
-"                          etc. It is only relevant for listed add-ons."
+"Any information end users may want to know that isn't necessarily applicable to the add-on summary or description. Common uses include listing known major bugs, information on how to report bugs, "
+"anticipated release date of a new version, etc. It is only relevant for listed add-ons."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:46
@@ -4617,9 +4564,7 @@ msgid "Add-on Flags"
 msgstr "Indicadors del complement"
 
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:69
-msgid ""
-"These flags are used to classify add-ons. It is only\n"
-"                        relevant for listed add-ons."
+msgid "These flags are used to classify add-ons. It is only relevant for listed add-ons."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:74
@@ -4635,9 +4580,7 @@ msgid "View Source?"
 msgstr "Voleu veure'n el codi?"
 
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:90
-msgid ""
-"Whether the source of your add-on can be displayed in our\n"
-"                        online viewer. It is only relevant for listed add-ons."
+msgid "Whether the source of your add-on can be displayed in our online viewer. It is only relevant for listed add-ons."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:94
@@ -4653,10 +4596,7 @@ msgid "Public Stats?"
 msgstr "Estadístiques públiques?"
 
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:102
-msgid ""
-"Whether the download and usage stats of your add-on can\n"
-"                        be displayed in our online viewer.\n"
-"                        It is only relevant for listed add-ons."
+msgid "Whether the download and usage stats of your add-on can be displayed in our online viewer. It is only relevant for listed add-ons."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:107
@@ -4672,10 +4612,7 @@ msgid "Upgrade SDK?"
 msgstr "S'actualitza l'SDK?"
 
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:116
-msgid ""
-"If selected, we will try to automatically upgrade your\n"
-"                        add-on when a new version of the SDK is released.\n"
-"                        It is only relevant for listed add-ons."
+msgid "If selected, we will try to automatically upgrade your add-on when a new version of the SDK is released. It is only relevant for listed add-ons."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:121
@@ -4726,10 +4663,8 @@ msgstr "Icona del complement"
 
 #: src/olympia/devhub/templates/devhub/addons/forms_shared/media.html:16
 msgid ""
-"Upload an icon for your add-on or choose from one of ours. The\n"
-"                      icon is displayed nearly everywhere your add-on is. Uploaded images\n"
-"                      must be one of the following image types: .png, .jpg.\n"
-"                      It is only relevant for listed add-ons."
+"Upload an icon for your add-on or choose from one of ours. The icon is displayed nearly everywhere your add-on is. Uploaded images must be one of the following image types: .png, .jpg. It is only "
+"relevant for listed add-ons."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/forms_shared/media.html:25
@@ -4837,16 +4772,14 @@ msgid "Deleting your add-on will permanently remove it from the site and prevent
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:24
-msgid ""
-"Enter the following text confirm your decision:\n"
-"           {slug}"
+msgid "Enter the following text confirm your decision: {slug}"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:34
+#: src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:33
 msgid "Please tell us why you are deleting your theme:"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:36
+#: src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:35
 msgid "Please tell us why you are deleting your add-on:"
 msgstr ""
 
@@ -4883,13 +4816,13 @@ msgstr "Versió nova"
 msgid "Daily statistics on downloads and users."
 msgstr "Estadístiques diàries en les baixades i usuaris."
 
-#: src/olympia/devhub/templates/devhub/addons/listing/item_actions.html:45 src/olympia/stats/templates/stats/stats.html:75 src/olympia/stats/templates/stats/stats.html:79
-#: src/olympia/stats/templates/stats/stats.html:81
+#: src/olympia/devhub/templates/devhub/addons/listing/item_actions.html:45 src/olympia/stats/templates/stats/stats.html:31 src/olympia/stats/templates/stats/stats.html:35
+#: src/olympia/stats/templates/stats/stats.html:37
 msgid "Statistics"
 msgstr "Estadístiques"
 
-#: src/olympia/devhub/templates/devhub/addons/listing/item_actions.html:54 src/olympia/devhub/templates/devhub/includes/addons_edit_nav.html:5 src/olympia/devhub/templates/devhub/payments/payments.html:3
-#: src/olympia/devhub/templates/devhub/payments/tier.html:4
+#: src/olympia/devhub/templates/devhub/addons/listing/item_actions.html:54 src/olympia/devhub/templates/devhub/includes/addons_edit_nav.html:5
+#: src/olympia/devhub/templates/devhub/payments/payments.html:3 src/olympia/devhub/templates/devhub/payments/tier.html:4
 msgid "Manage Payments"
 msgstr "Gestiona les donacions"
 
@@ -5073,7 +5006,8 @@ msgstr "Pas 5. Selecció de la llicència"
 
 #: src/olympia/devhub/templates/devhub/addons/submit/license.html:9
 msgid "We require all add-ons to indicate the terms under which their source code is licensed. Please select a license from the list below or enter a custom license."
-msgstr "És un requiist que tots els complements indiquin amb quina la llicència es publica el codi font del complement. Seleccioneu una llicència de la llista següent o introduïu una llicència propia."
+msgstr ""
+"És un requiist que tots els complements indiquin amb quina la llicència es publica el codi font del complement. Seleccioneu una llicència de la llista següent o introduïu una llicència propia."
 
 #: src/olympia/devhub/templates/devhub/addons/submit/license.html:18
 msgid "Select a license for your add-on:"
@@ -5214,11 +5148,11 @@ msgstr ""
 "Utilitzeu els camps següents per pujar el paquet amb el vostre comlement i seleccioneu les restriccions de plataforma. Després de pujar-lo, es realitzaran una sèria de validacions i proves "
 "automàtiques."
 
-#: src/olympia/devhub/templates/devhub/addons/submit/upload.html:59 src/olympia/devhub/templates/devhub/versions/add_file_modal.html:39
+#: src/olympia/devhub/templates/devhub/addons/submit/upload.html:51 src/olympia/devhub/templates/devhub/versions/add_file_modal.html:28
 msgid "Which platforms is this file compatible with?"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/addons/submit/upload.html:67 src/olympia/devhub/templates/devhub/versions/add_file_modal.html:65
+#: src/olympia/devhub/templates/devhub/addons/submit/upload.html:59 src/olympia/devhub/templates/devhub/versions/add_file_modal.html:45
 msgid "Administrative overrides"
 msgstr ""
 
@@ -5246,8 +5180,8 @@ msgstr ""
 #: src/olympia/devhub/templates/devhub/api/key.html:37
 #, python-format
 msgid ""
-"To make API requests, send a <a href=\"%(jwt_url)s\">JSON Web Token (JWT)</a> as the authorization header. You'll need to generate a JWT for every request as explained in the <a "
-"href=\"%(docs_url)s\">API documentation</a>."
+"To make API requests, send a <a href=\"%(jwt_url)s\">JSON Web Token (JWT)</a> as the authorization header. You'll need to generate a JWT for every request as explained in the <a href=\"%(docs_url)s"
+"\">API documentation</a>."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/api/key.html:47
@@ -5267,8 +5201,8 @@ msgstr ""
 msgid "Generate new credentials"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/docs/policies-agreement.html:3 src/olympia/devhub/templates/devhub/docs/policies-agreement.html:7 src/olympia/devhub/templates/devhub/docs/policies-agreement.html:9
-#: src/olympia/devhub/templates/devhub/docs/policies.html:24 src/olympia/devhub/templates/devhub/docs/policies.html:103
+#: src/olympia/devhub/templates/devhub/docs/policies-agreement.html:3 src/olympia/devhub/templates/devhub/docs/policies-agreement.html:7
+#: src/olympia/devhub/templates/devhub/docs/policies-agreement.html:9 src/olympia/devhub/templates/devhub/docs/policies.html:24 src/olympia/devhub/templates/devhub/docs/policies.html:103
 msgid "Developer Agreement"
 msgstr "Acord del desenvolupador"
 
@@ -5302,8 +5236,8 @@ msgstr ""
 #: src/olympia/devhub/templates/devhub/docs/policies-contact.html:26
 #, python-format
 msgid ""
-"If you have a question about an Editor's review of an add-on or want to report a policy violation, please email %(mail_editors)s. <strong>Almost all add-on reports fall under this "
-"category.</strong> Please be sure to include a link to the add-on in question and a detailed description of your question or comment."
+"If you have a question about an Editor's review of an add-on or want to report a policy violation, please email %(mail_editors)s. <strong>Almost all add-on reports fall under this category.</"
+"strong> Please be sure to include a link to the add-on in question and a detailed description of your question or comment."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/docs/policies-contact.html:31
@@ -5318,8 +5252,8 @@ msgstr ""
 #, python-format
 msgid ""
 "If you have discovered a security vulnerability in an add-on, even if it is not hosted here, Mozilla is very interested in your discovery and will work with the add-on developer to correct the "
-"issue as soon as possible. Add-on security issues can be reported <a href=\"http://www.mozilla.org/projects/security/security-bugs-policy.html\">confidentially</a> in <a "
-"href=\"%(link_bugzilla)s\">Bugzilla</a> or by emailing %(mail_admins)s."
+"issue as soon as possible. Add-on security issues can be reported <a href=\"http://www.mozilla.org/projects/security/security-bugs-policy.html\">confidentially</a> in <a href=\"%(link_bugzilla)s"
+"\">Bugzilla</a> or by emailing %(mail_admins)s."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/docs/policies-contact.html:42
@@ -5328,8 +5262,8 @@ msgstr ""
 
 #: src/olympia/devhub/templates/devhub/docs/policies-contact.html:44
 msgid ""
-"If you've found a problem with the site, we'd love to fix it. Please <a href=\"https://github.com/mozilla/olympia/issues\">file a bug report</a> in GitHub, including the location of the problem and"
-" how you encountered it."
+"If you've found a problem with the site, we'd love to fix it. Please <a href=\"https://github.com/mozilla/addons/issues/new\">file a bug report</a> in GitHub, including the location of the problem "
+"and how you encountered it."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/docs/policies-maintenance.html:3 src/olympia/devhub/templates/devhub/docs/policies-maintenance.html:7
@@ -5343,9 +5277,9 @@ msgstr ""
 
 #: src/olympia/devhub/templates/devhub/docs/policies-maintenance.html:12
 msgid ""
-"Developers are encouraged to submit updates to their add-ons to fix bugs, add features, and otherwise improve their product. New versions of an add-on must have a <a "
-"href=\"https://developer.mozilla.org/en/Toolkit_version_format\">higher version number</a> and can be submitted through the Developer Tools provided. There is no limit to the number of versions "
-"that can be submitted, but please remember that versions must be reviewed by an editor."
+"Developers are encouraged to submit updates to their add-ons to fix bugs, add features, and otherwise improve their product. New versions of an add-on must have a <a href=\"https://developer."
+"mozilla.org/en/Toolkit_version_format\">higher version number</a> and can be submitted through the Developer Tools provided. There is no limit to the number of versions that can be submitted, but "
+"please remember that versions must be reviewed by an editor."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/docs/policies-maintenance.html:18
@@ -5408,8 +5342,8 @@ msgstr ""
 
 #: src/olympia/devhub/templates/devhub/docs/policies-maintenance.html:70
 msgid ""
-"Mozilla encourages its users to offer feedback on their experiences when using an add-on. This allows other users to determine if the add-on is stable and useful. It also provides valuable feedback"
-" to developers, allowing them to continuously improve their add-on to meet user needs."
+"Mozilla encourages its users to offer feedback on their experiences when using an add-on. This allows other users to determine if the add-on is stable and useful. It also provides valuable feedback "
+"to developers, allowing them to continuously improve their add-on to meet user needs."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/docs/policies-maintenance.html:76
@@ -5458,7 +5392,8 @@ msgid ""
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/docs/policies-recommended.html:19
-msgid "Featured add-ons are chosen by the Featured Add-ons Advisory Board, a small group of add-on developers and fans from the Mozilla community who have volunteered to review and vote on nominations."
+msgid ""
+"Featured add-ons are chosen by the Featured Add-ons Advisory Board, a small group of add-on developers and fans from the Mozilla community who have volunteered to review and vote on nominations."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/docs/policies-recommended.html:25
@@ -5642,9 +5577,9 @@ msgstr ""
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:31
 msgid ""
-"Detailed descriptions of each option are below. After selecting a review process at submission, the add-on will be placed in the queue. Add-ons are reviewed by the <a "
-"href=\"https://wiki.mozilla.org/AMO:Editors\">AMO Editors</a>, a group of talented developers that volunteer to help the Mozilla project by reviewing add-ons to ensure a stable and safe experience "
-"for users. Developers will receive an email with any updates throughout the review process."
+"Detailed descriptions of each option are below. After selecting a review process at submission, the add-on will be placed in the queue. Add-ons are reviewed by the <a href=\"https://wiki.mozilla."
+"org/AMO:Editors\">AMO Editors</a>, a group of talented developers that volunteer to help the Mozilla project by reviewing add-ons to ensure a stable and safe experience for users. Developers will "
+"receive an email with any updates throughout the review process."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:37
@@ -5655,8 +5590,8 @@ msgstr ""
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:44
 msgid ""
-"Full reviews are appropriate for add-ons that are well-tested, stable, fast, and have wide appeal to our users. If you aren't confident that your add-on meets that criteria, please consider working"
-" out the kinks while in preliminary review and accumulating user feedback first."
+"Full reviews are appropriate for add-ons that are well-tested, stable, fast, and have wide appeal to our users. If you aren't confident that your add-on meets that criteria, please consider working "
+"out the kinks while in preliminary review and accumulating user feedback first."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:50
@@ -5751,8 +5686,8 @@ msgstr ""
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:123
 #, python-format
 msgid ""
-"Many of the above restrictions are tested automatically by an extension scanner that will flag suspicious add-ons for editor review. You can read more about this scanner in the <a "
-"href=\"%(link_validation)s\">Validation Help</a> document."
+"Many of the above restrictions are tested automatically by an extension scanner that will flag suspicious add-ons for editor review. You can read more about this scanner in the <a href="
+"\"%(link_validation)s\">Validation Help</a> document."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:129
@@ -5773,8 +5708,8 @@ msgstr ""
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:142
 msgid ""
-"Subsequent versions of the add-on will automatically be placed in the full review queue. Until the review is completed, the new version will only be displayed on the Version History page of the "
-"add-on. Once reviewed, the version will be updated across the site and deployed through the automatic update service."
+"Subsequent versions of the add-on will automatically be placed in the full review queue. Until the review is completed, the new version will only be displayed on the Version History page of the add-"
+"on. Once reviewed, the version will be updated across the site and deployed through the automatic update service."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:148
@@ -5876,9 +5811,9 @@ msgstr ""
 msgid ""
 "<p> Whenever an add-on includes any unexpected* feature that </p> <ul> <li>compromises user privacy or security (like sending data to third parties),</li> <li>changes default settings like the "
 "homepage or search engine, or</li> <li>changes settings or features in other add-ons or deactivates them altogether</li> </ul> <p>the features must adhere to the following requirements:</p> <ul> "
-"<li>The add-on description must clearly state what changes the add-on makes.</li> <li>All changes must be opt-in, meaning the user must take non-default action to enact the change.</li> <li>The "
-"opt-in dialog must clearly state the name of the add-on requesting the change.</li> <li>Uninstalling the add-on restores the user's original settings if they were changed.</li> </ul> <p>*Unexpected"
-" features are those that are unrelated to the add-on's primary function.</p>"
+"<li>The add-on description must clearly state what changes the add-on makes.</li> <li>All changes must be opt-in, meaning the user must take non-default action to enact the change.</li> <li>The opt-"
+"in dialog must clearly state the name of the add-on requesting the change.</li> <li>Uninstalling the add-on restores the user's original settings if they were changed.</li> </ul> <p>*Unexpected "
+"features are those that are unrelated to the add-on's primary function.</p>"
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:268
@@ -5895,8 +5830,8 @@ msgstr ""
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:282
 msgid ""
-"Add-ons that store or otherwise handle browsing data must support <a href=\"https://developer.mozilla.org/En/Supporting_private_browsing_mode\">Private Browsing Mode</a>.  During a Private Browsing"
-" session, no browsing data can be written to disk, and all of this data must be cleared when Firefox quits or the Private Browsing session ends."
+"Add-ons that store or otherwise handle browsing data must support <a href=\"https://developer.mozilla.org/En/Supporting_private_browsing_mode\">Private Browsing Mode</a>. During a Private Browsing "
+"session, no browsing data can be written to disk, and all of this data must be cleared when Firefox quits or the Private Browsing session ends."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:287
@@ -5939,10 +5874,10 @@ msgstr ""
 
 #: src/olympia/devhub/templates/devhub/docs/policies-submission.html:25
 msgid ""
-"<strong>Is the add-on clearly and accurately described?</strong> It's of the utmost importance to us that users get what they expect when they try a new add-on. Your add-on name should be clear and"
-" concise, and you should refrain from using special characters or numbers to get higher search rankings or for decorative purposes. Your description should provide details about what the add-on "
-"does, how a user should take advantage of it, and what the user should expect when they install it. Links to external documents for detailed instructions are fine, but the description itself should"
-" cover the basics and leave users confident that they know what they'll get. Also, it is important that you maintain version notes appropriately as you improve and change your add-on. Users should "
+"<strong>Is the add-on clearly and accurately described?</strong> It's of the utmost importance to us that users get what they expect when they try a new add-on. Your add-on name should be clear and "
+"concise, and you should refrain from using special characters or numbers to get higher search rankings or for decorative purposes. Your description should provide details about what the add-on "
+"does, how a user should take advantage of it, and what the user should expect when they install it. Links to external documents for detailed instructions are fine, but the description itself should "
+"cover the basics and leave users confident that they know what they'll get. Also, it is important that you maintain version notes appropriately as you improve and change your add-on. Users should "
 "be able to see what's new in an add-on they may have tried previously, and should be made aware of changes that might affect their current use of the add-on when they update."
 msgstr ""
 
@@ -5956,8 +5891,8 @@ msgstr ""
 #: src/olympia/devhub/templates/devhub/docs/policies-submission.html:37
 msgid ""
 "<strong>Has the add-on been well-tested, and is it free of obvious or serious defects?</strong> One important thing that we look for when considering an add-on is whether its user reviews indicate "
-"that it has received thorough testing, and that it doesn't have serious problems or negative impacts on the browser. If reviewers report problems such as major performance issues, crashes, frequent"
-" problems using the functions of the add-on, or spamming of messages to the error console, you should take those reports to heart, and re-submit your add-on after you've addressed them as best you "
+"that it has received thorough testing, and that it doesn't have serious problems or negative impacts on the browser. If reviewers report problems such as major performance issues, crashes, frequent "
+"problems using the functions of the add-on, or spamming of messages to the error console, you should take those reports to heart, and re-submit your add-on after you've addressed them as best you "
 "can. We don't expect you to perfectly optimize or have zero bugs &mdash; Firefox itself undergoes constant improvement in these areas &mdash; but we do want you to take reasonable efforts to "
 "minimize downsides, and to clearly call out cases where users may be surprised by those that remain."
 msgstr ""
@@ -5965,8 +5900,8 @@ msgstr ""
 #: src/olympia/devhub/templates/devhub/docs/policies-submission.html:43
 msgid ""
 "<strong>Do the add-on and add-on author both treat the user respectfully?</strong> Your software should not intrude on the user unnecessarily, try to trick the user, or conceal any of its "
-"activities from the user. Users (or even non-users) are sometimes rude in their comments, and while we will do our best to filter out inaccurate reviews as they're reported to us, we do expect that"
-" authors will avoid retaliating with rudeness of their own."
+"activities from the user. Users (or even non-users) are sometimes rude in their comments, and while we will do our best to filter out inaccurate reviews as they're reported to us, we do expect that "
+"authors will avoid retaliating with rudeness of their own."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/docs/policies-submission.html:49
@@ -5977,8 +5912,8 @@ msgstr ""
 
 #: src/olympia/devhub/templates/devhub/docs/policies-submission.html:55
 msgid ""
-"We are constantly looking at ways to improve the organization of the site to better accommodate add-ons that are exemplary in other ways, but are aimed at only a small community of potential users."
-" Correctly categorizing and maintaining the metadata of your add-on will help us figure out how we can surface more of those sorts of add-ons to people who are most likely to benefit from them."
+"We are constantly looking at ways to improve the organization of the site to better accommodate add-ons that are exemplary in other ways, but are aimed at only a small community of potential users. "
+"Correctly categorizing and maintaining the metadata of your add-on will help us figure out how we can surface more of those sorts of add-ons to people who are most likely to benefit from them."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/docs/policies-submission.html:61
@@ -5989,8 +5924,8 @@ msgstr ""
 
 #: src/olympia/devhub/templates/devhub/docs/policies-submission.html:67
 msgid ""
-"<strong>Is the add-on free of unlicensed trademarks and copyrights?</strong> Though you may mean no harm to the holder of a trademark, or the owner of a copyrighted work, we can't host add-ons that"
-" infringe on trademarks or copyrights. If you don't have permission to use a trademarked name or image, please do not submit your add-on to us. If your add-on includes code that is copyrighted by "
+"<strong>Is the add-on free of unlicensed trademarks and copyrights?</strong> Though you may mean no harm to the holder of a trademark, or the owner of a copyrighted work, we can't host add-ons that "
+"infringe on trademarks or copyrights. If you don't have permission to use a trademarked name or image, please do not submit your add-on to us. If your add-on includes code that is copyrighted by "
 "someone else, and is not licensed to you to use in your add-on, please do not submit your add-on to us."
 msgstr ""
 
@@ -6014,8 +5949,8 @@ msgstr ""
 
 #: src/olympia/devhub/templates/devhub/docs/policies-submission.html:86
 msgid ""
-"Selecting an appropriate license for your add-on is a very important step in the submission process. A license specifies the rights you grant on your source code and is important in protecting your"
-" intellectual property."
+"Selecting an appropriate license for your add-on is a very important step in the submission process. A license specifies the rights you grant on your source code and is important in protecting your "
+"intellectual property."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/docs/policies-submission.html:92
@@ -6060,68 +5995,57 @@ msgstr ""
 msgid "How to get in touch with us regarding these policies or your add-on."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:6
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:10
 msgid "You have disabled this add-on"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:20
-msgid ""
-"Your add-on's listing is disabled and is not showing\n"
-"                             anywhere in our gallery or update service."
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:24
+msgid "Your add-on's listing is disabled and is not showing anywhere in our gallery or update service."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:25
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:27
 msgid "Please complete your add-on."
 msgstr "Completeu el vostre complement"
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:29
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:30
 msgid "You will receive an email when the review is complete."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:34
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:33
 msgid "You will receive an email when the review is complete. Until then, your add-on is not listed in our gallery but can be accessed directly from its details page."
 msgstr ""
 "Rebreu un correu quan la revisió hagi finalitzat. Mentrestant, el vostre complement no apareixerà en les llistes de la nostra galeria però podreu accedir-hi directament des de la pàgina del detall "
 "del complement."
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:38 src/olympia/devhub/templates/devhub/includes/addon_details.html:48
-msgid ""
-"You will receive an email when the review is\n"
-"                             complete and your add-on is signed."
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:37 src/olympia/devhub/templates/devhub/includes/addon_details.html:45
+msgid "You will receive an email when the review is complete and your add-on is signed."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:44
-msgid "You will receive an email when the review is complete. Until then, your add-on is not listed in our gallery but can be accessed directly from its details page."
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:41
+msgid "You will receive an email when the review is complete. Until then, your add-on is not listed in our gallery but can be accessed directly from its details page. "
 msgstr ""
-"Rebreu un correu quan la revisió hagi finalitzat. Mentrestant, el vostre complement no apareixerà en les llistes de la nostra galeria però podreu accedir-hi directament des de la pàgina del detall "
-"del complement."
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:54
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:49
 msgid "Your add-on is displayed in our gallery and users are receiving automatic updates."
 msgstr "El vostre complement s'està mostrant a la nostra galeria i els usuaris estan rebent actualitzacions automàtiques."
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:57
-msgid ""
-"Your add-on has been signed and can be bundled with an\n"
-"                             application installer."
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:52
+msgid "Your add-on has been signed and can be bundled with an application installer."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:63
-msgid ""
-"Your add-on was disabled by a site administrator and is no\n"
-"                             longer shown in our gallery. If you have any questions,\n"
-"                             please email amo-admins@mozilla.org."
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:56
+msgid "Your add-on was disabled by a site administrator and is no longer shown in our gallery. If you have any questions, please email amo-admins@mozilla.org."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:70
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:62
 msgid "Your add-on is displayed in our gallery as experimental and users are receiving automatic updates. Some features are unavailable to your add-on."
 msgstr "El vostre complement apareix a les nostres galeria com a experimental i els usuari estan rebent actualitzacions automàtiques. Però algunes funcionalitats no estan disponibles."
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:74
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:66
 msgid "Your add-on has been signed."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:79
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:69
 msgid ""
 "You will receive an email when the full review is complete. Until then, your add-on is displayed in our gallery as experimental and users are receiving automatic updates. Some features are "
 "unavailable to your add-on."
@@ -6129,53 +6053,41 @@ msgstr ""
 "Rebreu un correu quan la revisió final hagi finalitzat. Mentrestant, el vostre complement apareixerà a les llistes de la nostra galeria però com a  complement experimental i els usuari rebran "
 "actualitzacions automàtiques. Tot i així algunes funcionalitats no estaran disponibles."
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:84
-msgid ""
-"You will receive an email when the full review is\n"
-"                             complete, making you able to bundle your add-on with an\n"
-"                             application installer."
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:74
+msgid "You will receive an email when the full review is complete, making you able to bundle your add-on with an application installer."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:91
-msgid ""
-"All add-ons hosted in our gallery must now be reviewed by an\n"
-"                             editor. If you wish to continue hosting your add-on, please\n"
-"                             click to select a review process."
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:79
+msgid "All add-ons hosted in our gallery must now be reviewed by an editor. If you wish to continue hosting your add-on, please click to select a review process."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:113
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:100
 msgid "Current Version:"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:115
-msgid ""
-"This is the version of your add-on that will\n"
-"                                           be installed if someone clicks the Install\n"
-"                                           button on addons.mozilla.org. It is only\n"
-"                                           relevant for listed add-ons."
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:102
+msgid "This is the version of your add-on that will be installed if someone clicks the Install button on addons.mozilla.org. It is only relevant for listed add-ons."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:123
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:110
 msgid "Created:"
 msgstr ""
 
 #. {0} is a date. dennis-ignore: E201
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:125 src/olympia/devhub/templates/devhub/includes/addon_details.html:131
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:112 src/olympia/devhub/templates/devhub/includes/addon_details.html:118
 #, python-format
 msgid "%%b %%e, %%Y"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:136
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:123
 msgid "Next Version:"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:138
-msgid ""
-"This is the newest uploaded version, however\n"
-"                                           it isn’t live on the site yet."
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:125
+msgid "This is the newest uploaded version, however it isn’t live on the site yet."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:144 src/olympia/devhub/templates/devhub/versions/list.html:30
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:130 src/olympia/devhub/templates/devhub/versions/list.html:30
 msgid "Queues are not reviewed strictly in order"
 msgstr ""
 
@@ -6245,9 +6157,7 @@ msgid "View the blog &#9658;"
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/includes/license_form.html:6
-msgid ""
-"Please choose a license appropriate for the rights you grant on your source code.\n"
-"                  It is only relevant for listed add-ons."
+msgid "Please choose a license appropriate for the rights you grant on your source code. It is only relevant for listed add-ons."
 msgstr ""
 
 #. {0} is a list of HTML tags.
@@ -6274,14 +6184,11 @@ msgstr[1] "Seleccioneu <b>com a molt {0}</b> categories del {1} per aquest compl
 #: src/olympia/devhub/templates/devhub/includes/policy_form.html:4
 msgid ""
 "Users will be required to accept the following End-User License Agreement (EULA) prior to installing your add-on. The presence of a EULA significantly affects the number of downloads an add-on "
-"receives. Please note that a EULA is not the same as a code license, such as the GPL or MPL.\n"
-"                It is only relevant for listed add-ons."
+"receives. Please note that a EULA is not the same as a code license, such as the GPL or MPL.It is only relevant for listed add-ons."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/policy_form.html:21
-msgid ""
-"If your add-on transmits any data from the user's computer, a privacy policy is required that explains what data is sent and how it is used.\n"
-"                It is only relevant for listed add-ons."
+#: src/olympia/devhub/templates/devhub/includes/policy_form.html:24
+msgid "If your add-on transmits any data from the user's computer, a privacy policy is required that explains what data is sent and how it is used. It is only relevant for listed add-ons."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/includes/source_form_field.html:2
@@ -6417,8 +6324,8 @@ msgstr "Enviarem un correu electrònic als usuaris que hagin contribuït amb el 
 
 #: src/olympia/devhub/templates/devhub/payments/voluntary.html:49
 msgid ""
-"We recommend thanking the user and telling them how much you appreciate their support. You might also want to tell them about what's next for your add-on and about any other add-ons you've made for"
-" them to try."
+"We recommend thanking the user and telling them how much you appreciate their support. You might also want to tell them about what's next for your add-on and about any other add-ons you've made for "
+"them to try."
 msgstr ""
 "Us recomanem que agraïu la contribució dels usuaris explicant-lis com esteu de contents per la seva ajuda. També els podeu explicar quins plans teniu pel vostre complement i quins altres "
 "complements heu fet, per si els volen provar."
@@ -6451,12 +6358,8 @@ msgstr ""
 msgid "Add some tags to describe your Theme."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/personas/edit.html:106
-msgid ""
-"A short explanation of your theme's\n"
-"                                basic functionality that is displayed in\n"
-"                                search and browse listings, as well as at\n"
-"                                the top of your theme's details page."
+#: src/olympia/devhub/templates/devhub/personas/edit.html:106 src/olympia/devhub/templates/devhub/personas/submit.html:54
+msgid "A short explanation of your theme's basic functionality that is displayed in search and browse listings, as well as at the top of your theme's details page."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/personas/edit.html:122 src/olympia/devhub/templates/devhub/personas/submit.html:68
@@ -6526,7 +6429,7 @@ msgid "Upon upload and form submission, the AMO Team will review your updated de
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/personas/edit.html:241
-msgid "Your previously resubmitted design,  which is under pending review."
+msgid "Your previously resubmitted design, which is under pending review."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/personas/edit.html:245
@@ -6593,14 +6496,6 @@ msgstr ""
 
 #: src/olympia/devhub/templates/devhub/personas/submit.html:33
 msgid "Give your Theme a name."
-msgstr ""
-
-#: src/olympia/devhub/templates/devhub/personas/submit.html:54
-msgid ""
-"A short explanation of your theme's\n"
-"                                      basic functionality that is displayed in\n"
-"                                      search and browse listings, as well as at\n"
-"                                      the top of your theme's details page."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/personas/submit.html:198
@@ -6677,30 +6572,16 @@ msgstr "Seleccioneu una imatge diferent per al peu"
 msgid "Files added to reviewed versions must be reviewed before they will be available for download."
 msgstr "Els fitxes que s'afegeixen a les versions revisades s'han de revisar abans que es publiquin i es puguin baixar. "
 
-#: src/olympia/devhub/templates/devhub/versions/add_file_modal.html:15
-#, python-format
-msgid ""
-"Submission of updates to unlisted add-ons for signing is currently in an open beta. Manual review may still be required for a large number of add-ons. Please <a href=\"%(url)s\" "
-"target=\"_blank\">report any bugs</a> that you encounter."
-msgstr ""
-
-#: src/olympia/devhub/templates/devhub/versions/add_file_modal.html:35
+#: src/olympia/devhub/templates/devhub/versions/add_file_modal.html:24
 msgid "Select the target platform for this file."
 msgstr "Seleccioneu una plataforma per a aquest fitxer."
 
-#: src/olympia/devhub/templates/devhub/versions/add_file_modal.html:46
+#: src/olympia/devhub/templates/devhub/versions/add_file_modal.html:35
 msgid "Which review type would you like to nominate for?"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/add_file_modal.html:51
+#: src/olympia/devhub/templates/devhub/versions/add_file_modal.html:40
 msgid "Only publish this version to my beta channel."
-msgstr ""
-
-#: src/olympia/devhub/templates/devhub/versions/add_file_modal.html:54
-#, python-format
-msgid ""
-"The behavior of the beta channel has changed to accommodate <a href=\"%(addon_signing_url)s\" target=\"_blank\">mandatory add-on signing</a>. The new process is currently in an open beta, and may "
-"change significantly in the near future. Please <a href=\"%(issues_url)s\" target=\"_blank\">report any bugs</a> that you encounter."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/versions/edit.html:5
@@ -6724,12 +6605,6 @@ msgstr "Fitxers"
 #: src/olympia/devhub/templates/devhub/versions/edit.html:38
 msgid "Upload Another File"
 msgstr "Puja un altre fitxer"
-
-#: src/olympia/devhub/templates/devhub/versions/edit.html:45
-msgid "Adjusting application information here will allow users to install your add-on even if the install manifest in the package indicates that the add-on is incompatible."
-msgstr ""
-"Si ajusteu la informació de l'aplicació aquí, permetreu que els usuaris instal·lin els vostre complement fins i tot quan el manifest de la instal·lació del paquet indiqui que el complement és "
-"incompatible. "
 
 #: src/olympia/devhub/templates/devhub/versions/edit.html:74
 msgid ""
@@ -6826,7 +6701,7 @@ msgstr "Demana una revisió final"
 msgid "Request Preliminary Review"
 msgstr "Demana una revisió preliminar"
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:80 src/olympia/devhub/templates/devhub/versions/list.html:327 src/olympia/devhub/templates/devhub/versions/list.html:350
+#: src/olympia/devhub/templates/devhub/versions/list.html:80 src/olympia/devhub/templates/devhub/versions/list.html:325 src/olympia/devhub/templates/devhub/versions/list.html:348
 msgid "Cancel Review Request"
 msgstr "Cancel·lació de la petició de revisió"
 
@@ -6855,7 +6730,7 @@ msgid "Unlisted:"
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/versions/list.html:114
-msgid "Not distributed on {0}. Developers will upload new versions for signing and distribute the add-ons on their own. (beta)"
+msgid "Not distributed on {0}. Developers will upload new versions for signing and distribute the add-ons on their own."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/versions/list.html:122
@@ -6906,7 +6781,8 @@ msgid "Delete Version {version}"
 msgstr "Suprimeix la versió {version}"
 
 #: src/olympia/devhub/templates/devhub/versions/list.html:218
-msgid "You are about to delete the current version of your add-on. This may cause your add-on status to change, or your listing to lose public visibility, if this is the only public version of your add-on."
+msgid ""
+"You are about to delete the current version of your add-on. This may cause your add-on status to change, or your listing to lose public visibility, if this is the only public version of your add-on."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/versions/list.html:219
@@ -6918,81 +6794,73 @@ msgid "<strong>Important:</strong> Once a version has been deleted, you may not 
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/versions/list.html:230
-msgid ""
-"Deleting a version which has already been reviewed\n"
-"               may also cause a significant delay in the review of\n"
-"               your next update."
-msgstr ""
-
-#: src/olympia/devhub/templates/devhub/versions/list.html:233
 msgid "Are you sure you wish to delete this version?"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:238
+#: src/olympia/devhub/templates/devhub/versions/list.html:235
 msgid "Delete Version"
 msgstr "Suprimeix la versió"
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:240
+#: src/olympia/devhub/templates/devhub/versions/list.html:237
 msgid "Disable Version"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:247
+#: src/olympia/devhub/templates/devhub/versions/list.html:244
 msgid "Add a new Version"
 msgstr "Afegeix una versió nova"
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:249
+#: src/olympia/devhub/templates/devhub/versions/list.html:246
 msgid "Add Version"
 msgstr "Afegeix la versió"
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:256 src/olympia/devhub/templates/devhub/versions/list.html:274
+#: src/olympia/devhub/templates/devhub/versions/list.html:253 src/olympia/devhub/templates/devhub/versions/list.html:279
 msgid "Hide Add-on"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:259
+#: src/olympia/devhub/templates/devhub/versions/list.html:256
 msgid "Hiding your add-on will prevent it from appearing anywhere in our gallery and will stop users from receiving automatic updates."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:265
+#: src/olympia/devhub/templates/devhub/versions/list.html:263
+msgid "The files awaiting review will be disabled and you will need to upload new versions."
+msgstr ""
+
+#: src/olympia/devhub/templates/devhub/versions/list.html:270
 msgid "Are you sure you wish to hide your add-on?"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:286 src/olympia/devhub/templates/devhub/versions/list.html:315
+#: src/olympia/devhub/templates/devhub/versions/list.html:291 src/olympia/devhub/templates/devhub/versions/list.html:313
 msgid "Unlist Add-on"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:289
+#: src/olympia/devhub/templates/devhub/versions/list.html:294
 #, python-format
 msgid ""
 "Unlisting your add-on will make it (and each of its versions/files) invisible on this website. It won't show up in searches, won't have a public facing page, and won't be updated automatically for "
-"current users.  It is recommended for unlisted add-ons to provide a custom <a href=\"%(update_url)s\" target=\"_blank\">updateURL</a> in their manifest file for automatic updates."
+"current users. It is recommended for unlisted add-ons to provide a custom <a href=\"%(update_url)s\" target=\"_blank\">updateURL</a> in their manifest file for automatic updates."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:299
-#, python-format
-msgid "Switching add-ons to unlisted is currently in an open beta. Please <a href=\"%(url)s\" target=\"_blank\">report any bugs</a> that you encounter."
-msgstr ""
-
-#: src/olympia/devhub/templates/devhub/versions/list.html:305
+#: src/olympia/devhub/templates/devhub/versions/list.html:303
 msgid "Unlisting an add-on is irreversible!"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:305
+#: src/olympia/devhub/templates/devhub/versions/list.html:303
 msgid "An unlisted add-on cannot be switched to be listed."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:307
+#: src/olympia/devhub/templates/devhub/versions/list.html:305
 msgid "Are you sure you wish to unlist your add-on?"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:330
+#: src/olympia/devhub/templates/devhub/versions/list.html:328
 msgid "Canceling your review request will leave your add-on as preliminarily reviewed."
 msgstr "Si cancel·leu la vostra petició de revisió el vostre complement quedarà com a revisat preliminarment."
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:335
+#: src/olympia/devhub/templates/devhub/versions/list.html:333
 msgid "Canceling your review request will mark your add-on incomplete. If you do not complete your add-on after several days by re-requesting review, it will be deleted."
 msgstr "Si cancel·leu la vostra petició de revisió el vostre complement quedarà incomplet. I si no torneu a demanar una revisió, d'aquí pocs dies es suprimirà el vostre complement."
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:343
+#: src/olympia/devhub/templates/devhub/versions/list.html:341
 msgid "Are you sure you wish to cancel your review request?"
 msgstr "Voleu cancel·lar la vostra petició de revisió?"
 
@@ -7335,19 +7203,19 @@ msgstr ""
 msgid "Search by add-on name / author email"
 msgstr "Cerca per nom de complement o adreça electrònica de l'autor"
 
-#: src/olympia/editors/forms.py:103
+#: src/olympia/editors/forms.py:103 src/olympia/editors/forms.py:244 src/olympia/editors/forms.py:257
 msgid "yes"
 msgstr "sí"
 
-#: src/olympia/editors/forms.py:104
+#: src/olympia/editors/forms.py:104 src/olympia/editors/forms.py:244 src/olympia/editors/forms.py:257
 msgid "no"
 msgstr "no"
 
-#: src/olympia/editors/forms.py:105
+#: src/olympia/editors/forms.py:105 src/olympia/editors/forms.py:245
 msgid "Admin Flag"
 msgstr "Marca de l'admin"
 
-#: src/olympia/editors/forms.py:113
+#: src/olympia/editors/forms.py:113 src/olympia/editors/forms.py:253
 msgid "Max. Version"
 msgstr "Versió màx."
 
@@ -7359,55 +7227,59 @@ msgstr "Dies des de la publicació"
 msgid "Add-on Types"
 msgstr "Tipus de complements"
 
-#: src/olympia/editors/forms.py:126 src/olympia/editors/helpers.py:267
+#: src/olympia/editors/forms.py:126 src/olympia/editors/helpers.py:279
 msgid "Platforms"
 msgstr "Plataformes"
 
+#: src/olympia/editors/forms.py:237
+msgid "Search by add-on name / author email / guid"
+msgstr ""
+
 #. L10n: 0 = platform, 1 = filename, 2 = status message
-#: src/olympia/editors/forms.py:238
+#: src/olympia/editors/forms.py:342
 #, python-format
 msgid "<strong>%s</strong> &middot; %s &middot; %s"
 msgstr "<strong>%s</strong> &middot; %s &middot; %s"
 
-#: src/olympia/editors/forms.py:252
+#: src/olympia/editors/forms.py:356
 msgid "Comments:"
 msgstr "Comentaris:"
 
-#: src/olympia/editors/forms.py:256
+#: src/olympia/editors/forms.py:360
 msgid "Operating systems:"
 msgstr "Sistemes operatius:"
 
-#: src/olympia/editors/forms.py:258
+#: src/olympia/editors/forms.py:362
 msgid "Applications:"
 msgstr "Aplicacions:"
 
-#: src/olympia/editors/forms.py:260
+#: src/olympia/editors/forms.py:364
 msgid "Notify me the next time this add-on is updated. (Subsequent updates will not generate an email)"
 msgstr "Quan es torni a actualitzar aquest complement, notifica-m'ho. (A partir d'ara les actualitzacions no generaran un correu electrònic)"
 
-#: src/olympia/editors/forms.py:265
+#: src/olympia/editors/forms.py:369
 msgid "Clear Admin Review Flag"
 msgstr ""
 
-#: src/olympia/editors/forms.py:267
+#: src/olympia/editors/forms.py:371
 msgid "Clear more info requested flag"
 msgstr ""
 
-#: src/olympia/editors/forms.py:281
+#: src/olympia/editors/forms.py:385
 msgid "Choose a canned response..."
 msgstr "Escolliu una resposta predefinida..."
 
 #. L10n: Description of what can be searched for.
-#: src/olympia/editors/forms.py:324
+#: src/olympia/editors/forms.py:423
 msgid "theme name"
 msgstr ""
 
-#: src/olympia/editors/forms.py:350
+#: src/olympia/editors/forms.py:449
 msgid "Someone else is reviewing this theme."
 msgstr ""
 
 #. L10n: Description of what can be searched for.
-#: src/olympia/editors/forms.py:447
+#: src/olympia/editors/forms.py:546
 msgid "app, reviewer, or comment"
 msgstr ""
 
@@ -7423,192 +7295,210 @@ msgstr "Està pendent d'una revisió preliminar"
 msgid "Rejected or Unreviewed"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:123 src/olympia/editors/helpers.py:136
+#: src/olympia/editors/helpers.py:125 src/olympia/editors/helpers.py:138
 msgid "Queue"
 msgstr "Cua"
 
-#: src/olympia/editors/helpers.py:124 src/olympia/editors/templates/editors/base.html:50 src/olympia/editors/templates/editors/base.html:65
+#: src/olympia/editors/helpers.py:126 src/olympia/editors/templates/editors/base.html:50 src/olympia/editors/templates/editors/base.html:65
 msgid "Pending Updates"
 msgstr "Actualitzacions pendents"
 
-#: src/olympia/editors/helpers.py:125 src/olympia/editors/templates/editors/base.html:48 src/olympia/editors/templates/editors/base.html:63
+#: src/olympia/editors/helpers.py:127 src/olympia/editors/templates/editors/base.html:48 src/olympia/editors/templates/editors/base.html:63
 msgid "Full Reviews"
 msgstr "Revisions finals"
 
-#: src/olympia/editors/helpers.py:126 src/olympia/editors/templates/editors/base.html:52 src/olympia/editors/templates/editors/base.html:67
+#: src/olympia/editors/helpers.py:128 src/olympia/editors/templates/editors/base.html:52 src/olympia/editors/templates/editors/base.html:67
 msgid "Preliminary Reviews"
 msgstr "Revisions preliminars"
 
-#: src/olympia/editors/helpers.py:127 src/olympia/editors/templates/editors/base.html:54
+#: src/olympia/editors/helpers.py:129 src/olympia/editors/templates/editors/base.html:54
 msgid "Moderated Reviews"
 msgstr "Revisions moderades"
 
-#: src/olympia/editors/helpers.py:128 src/olympia/editors/templates/editors/base.html:46
+#: src/olympia/editors/helpers.py:130 src/olympia/editors/templates/editors/base.html:46
 msgid "Fast Track"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:130
+#: src/olympia/editors/helpers.py:132
 msgid "Pending Themes"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:131 src/olympia/editors/templates/editors/themes/queue.html:4
+#: src/olympia/editors/helpers.py:133 src/olympia/editors/templates/editors/themes/queue.html:4
 msgid "Flagged Themes"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:132
+#: src/olympia/editors/helpers.py:134
 msgid "Update Themes"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:137
+#: src/olympia/editors/helpers.py:139
 msgid "Unlisted Pending Updates"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:138
+#: src/olympia/editors/helpers.py:140
 msgid "Unlisted Full Reviews"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:139
+#: src/olympia/editors/helpers.py:141
 msgid "Unlisted Preliminary Reviews"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:170
+#: src/olympia/editors/helpers.py:142
+msgid "Unlisted All Add-ons"
+msgstr ""
+
+#: src/olympia/editors/helpers.py:173
 msgid "Fast Track ({0})"
 msgid_plural "Fast Track ({0})"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/olympia/editors/helpers.py:175
+#: src/olympia/editors/helpers.py:178
 msgid "Full Review ({0})"
 msgid_plural "Full Reviews ({0})"
 msgstr[0] "Revisió final ({0})"
 msgstr[1] "Revisions finals ({0})"
 
-#: src/olympia/editors/helpers.py:180
+#: src/olympia/editors/helpers.py:183
 msgid "Pending Update ({0})"
 msgid_plural "Pending Updates ({0})"
 msgstr[0] "Actualització pendent ({0})"
 msgstr[1] "Actualitzacions pendents ({0})"
 
-#: src/olympia/editors/helpers.py:185
+#: src/olympia/editors/helpers.py:188
 msgid "Preliminary Review ({0})"
 msgid_plural "Preliminary Reviews ({0})"
 msgstr[0] "Revisió preliminar ({0})"
 msgstr[1] "Revisions preliminars ({0})"
 
-#: src/olympia/editors/helpers.py:190
+#: src/olympia/editors/helpers.py:193
 msgid "Moderated Review ({0})"
 msgid_plural "Moderated Reviews ({0})"
 msgstr[0] "Revisió moderada ({0})"
 msgstr[1] "Revisions moderades ({0})"
 
-#: src/olympia/editors/helpers.py:196
+#: src/olympia/editors/helpers.py:199
 msgid "Unlisted Full Review ({0})"
 msgid_plural "Unlisted Full Reviews ({0})"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/olympia/editors/helpers.py:201
+#: src/olympia/editors/helpers.py:204
 msgid "Unlisted Pending Update ({0})"
 msgid_plural "Unlisted Pending Updates ({0})"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/olympia/editors/helpers.py:206
+#: src/olympia/editors/helpers.py:209
 msgid "Unlisted Preliminary Review ({0})"
 msgid_plural "Unlisted Preliminary Reviews ({0})"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/olympia/editors/helpers.py:261
-msgid "Addon"
-msgstr "Complements"
+#: src/olympia/editors/helpers.py:214
+msgid "Unlisted All Add-ons ({0})"
+msgid_plural "Unlisted All Add-ons ({0})"
+msgstr[0] ""
+msgstr[1] ""
 
-#: src/olympia/editors/helpers.py:262
+#: src/olympia/editors/helpers.py:274
 msgid "Type"
 msgstr "Tipus"
 
-#: src/olympia/editors/helpers.py:263
+#: src/olympia/editors/helpers.py:275
 msgid "Waiting Time"
 msgstr "Temps d'espera"
 
-#: src/olympia/editors/helpers.py:264 src/olympia/editors/templates/editors/review.html:285
+#: src/olympia/editors/helpers.py:276 src/olympia/editors/templates/editors/review.html:285
 msgid "Flags"
 msgstr "Indicadors"
 
-#: src/olympia/editors/helpers.py:265
+#: src/olympia/editors/helpers.py:277
 msgid "Applications"
 msgstr "Aplicacions"
 
-#: src/olympia/editors/helpers.py:270
+#: src/olympia/editors/helpers.py:282
 msgid "Additional"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:285
+#: src/olympia/editors/helpers.py:302
 msgid "Site Specific"
 msgstr "Lloc específic"
 
-#: src/olympia/editors/helpers.py:287
+#: src/olympia/editors/helpers.py:304
 msgid "Requires External Software"
 msgstr "Requereix programari extern"
 
-#: src/olympia/editors/helpers.py:289
+#: src/olympia/editors/helpers.py:306
 msgid "Binary Components"
 msgstr "Components binaris"
 
-#: src/olympia/editors/helpers.py:313
+#: src/olympia/editors/helpers.py:339
 msgid "moments ago"
 msgstr "fa uns moments"
 
 #. L10n: first argument is number of minutes
-#: src/olympia/editors/helpers.py:316
+#: src/olympia/editors/helpers.py:342
 msgid "{0} minute"
 msgid_plural "{0} minutes"
 msgstr[0] "{0} minut"
 msgstr[1] "{0} minuts"
 
 #. L10n: first argument is number of hours
-#: src/olympia/editors/helpers.py:320
+#: src/olympia/editors/helpers.py:346
 msgid "{0} hour"
 msgid_plural "{0} hours"
 msgstr[0] "{0} hora"
 msgstr[1] "{0} hores"
 
 #. L10n: first argument is number of days
-#: src/olympia/editors/helpers.py:324
+#: src/olympia/editors/helpers.py:350
 msgid "{0} day"
 msgid_plural "{0} days"
 msgstr[0] "{0} dia"
 msgstr[1] "{0} dies"
 
-#: src/olympia/editors/helpers.py:488
+#: src/olympia/editors/helpers.py:364
+msgid "Last Review"
+msgstr ""
+
+#: src/olympia/editors/helpers.py:366
+msgid "Last Update"
+msgstr ""
+
+#: src/olympia/editors/helpers.py:387
+msgid "No Reviews"
+msgstr ""
+
+#: src/olympia/editors/helpers.py:561
 msgid "Push to public"
 msgstr "Publica-ho"
 
-#: src/olympia/editors/helpers.py:490
+#: src/olympia/editors/helpers.py:563
 msgid "Grant full review"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:505
+#: src/olympia/editors/helpers.py:578
 msgid "Request more information"
 msgstr "Sol·licita més informació"
 
-#: src/olympia/editors/helpers.py:508
+#: src/olympia/editors/helpers.py:581
 msgid "Request super-review"
 msgstr "Sol·licita una super-revisió"
 
-#: src/olympia/editors/helpers.py:519
+#: src/olympia/editors/helpers.py:592
 msgid "Grant preliminary review"
 msgstr "Dóna permís per una revisió preliminar"
 
-#: src/olympia/editors/helpers.py:520
+#: src/olympia/editors/helpers.py:593
 msgid "This will mark the files as preliminarily reviewed."
 msgstr ""
 
-#: src/olympia/editors/helpers.py:522
+#: src/olympia/editors/helpers.py:595
 msgid "Use this form to request more information from the author. They will receive an email and be able to answer here. You will be notified by email when they reply."
 msgstr "Utilitzeu aquest formulari per sol·licitar més informació dels autors. Els autors rebran un correu, i quan us responguin rebreu una notificació per correu."
 
-#: src/olympia/editors/helpers.py:526
+#: src/olympia/editors/helpers.py:599
 msgid ""
 "If you have concerns about this add-on's security, copyright issues, or other concerns that an administrator should look into, enter your comments in the area below. They will be sent to "
 "administrators, not the author."
@@ -7616,55 +7506,55 @@ msgstr ""
 "Si teniu cap queixa del complement pel què fa a seguretat, copyright o altres temes on calgui l'atenció d'un administrador, introduïu els vostres comentaris al quadre següent. Aquests comentaris "
 "s'enviaran als administradors i no a als autors."
 
-#: src/olympia/editors/helpers.py:532
+#: src/olympia/editors/helpers.py:605
 msgid "This will reject the add-on and remove it from the review queue."
 msgstr "Rebutja el complement i el suprimeix de la cua de revisió."
 
-#: src/olympia/editors/helpers.py:534
-msgid "Make a comment on this version.  The author won't be able to see this."
+#: src/olympia/editors/helpers.py:607
+msgid "Make a comment on this version. The author won't be able to see this."
 msgstr ""
 
-#: src/olympia/editors/helpers.py:538
+#: src/olympia/editors/helpers.py:611
 msgid "This will reject the files and remove them from the review queue."
 msgstr "Rebutja els fitxers i els suprimeix de la cua de revisió."
 
-#: src/olympia/editors/helpers.py:542
+#: src/olympia/editors/helpers.py:615
 msgid "This will mark the add-on as preliminarily reviewed. Future versions will undergo preliminary review."
 msgstr "Marca el complement per indicar que ha passat la revisió preliminar. Les versions futures també hauran de passar una revisió preliminar."
 
-#: src/olympia/editors/helpers.py:547
+#: src/olympia/editors/helpers.py:620
 msgid "This will mark the files as preliminarily reviewed. Future versions will undergo preliminary review."
 msgstr "Marca el complement per indicar que ha passat la revisió final. Les versions futures també hauran de passar una revisió final."
 
-#: src/olympia/editors/helpers.py:552
+#: src/olympia/editors/helpers.py:625
 msgid "Retain preliminary review"
 msgstr "Reté la revisió preliminar"
 
-#: src/olympia/editors/helpers.py:553
+#: src/olympia/editors/helpers.py:626
 msgid "This will retain the add-on as preliminarily reviewed. Future versions will undergo preliminary review."
 msgstr "Reté el complement com a reviat preliminarment. Les versions futures també hauran de passar una revisió preliminar."
 
-#: src/olympia/editors/helpers.py:558
+#: src/olympia/editors/helpers.py:631
 msgid "This will approve a sandboxed version of a public add-on to appear on the public side."
 msgstr "Aprova la versió en l'entorn de proves d'un complement que ja és públic per tal que la versió de proves passi a la part pública."
 
-#: src/olympia/editors/helpers.py:561
+#: src/olympia/editors/helpers.py:634
 msgid "This will reject a version of a public add-on and remove it from the queue."
 msgstr "Rebutja la versió de l'entorn de proves d'un complement que ja és públic i la suprimeix de la cua."
 
-#: src/olympia/editors/helpers.py:564
+#: src/olympia/editors/helpers.py:637
 msgid "This will mark the add-on and its most recent version and files as public. Future versions will go into the sandbox until they are reviewed by an editor."
 msgstr "Publica el complement, la versió més recent i els seus fitxers. Les versions futures passaran per l'entorn de proves abans de passar al públic, després de ser revisades per un editor."
 
-#: src/olympia/editors/helpers.py:637
+#: src/olympia/editors/helpers.py:714
 msgid "add-on"
 msgstr "complement"
 
-#: src/olympia/editors/helpers.py:940 src/olympia/editors/helpers.py:960
+#: src/olympia/editors/helpers.py:1020 src/olympia/editors/helpers.py:1040
 msgid "Flagged"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:944 src/olympia/editors/helpers.py:963
+#: src/olympia/editors/helpers.py:1024 src/olympia/editors/helpers.py:1043
 msgid "Updates"
 msgstr ""
 
@@ -7716,56 +7606,56 @@ msgstr ""
 msgid "A question about your Theme submission"
 msgstr ""
 
-#: src/olympia/editors/views.py:144
+#: src/olympia/editors/views.py:146
 msgid "New Add-ons (Under 5 days)"
 msgstr "Complements nous (menys de 5 dies)"
 
-#: src/olympia/editors/views.py:145
+#: src/olympia/editors/views.py:147
 msgid "Passable (5 to 10 days)"
 msgstr ""
 
-#: src/olympia/editors/views.py:146
+#: src/olympia/editors/views.py:148
 msgid "Overdue (Over 10 days)"
 msgstr ""
 
-#: src/olympia/editors/views.py:532
+#: src/olympia/editors/views.py:539
 msgid "An unknown error occurred"
 msgstr ""
 
-#: src/olympia/editors/views.py:587
+#: src/olympia/editors/views.py:592
 msgid "Self-reviews are not allowed."
 msgstr "No es permeten fer revisions d'un mateix."
 
-#: src/olympia/editors/views.py:609
+#: src/olympia/editors/views.py:613
 msgid "Review successfully processed."
 msgstr "La revisió s'ha processat correctament."
 
-#: src/olympia/editors/views.py:807
+#: src/olympia/editors/views.py:812
 msgid "was approved"
 msgstr "va ser aprovada"
 
-#: src/olympia/editors/views.py:808
+#: src/olympia/editors/views.py:813
 msgid "given preliminary review"
 msgstr "va passar la revisió preliminjar"
 
-#: src/olympia/editors/views.py:809
+#: src/olympia/editors/views.py:814
 msgid "rejected"
 msgstr "va ser rebutjada"
 
-#: src/olympia/editors/views.py:810
+#: src/olympia/editors/views.py:815
 msgctxt "editors_review_history_nominated_adminreview"
 msgid "escalated"
 msgstr "va ser escalada"
 
-#: src/olympia/editors/views.py:812
+#: src/olympia/editors/views.py:817
 msgid "needs more information"
 msgstr "necessita més informació"
 
-#: src/olympia/editors/views.py:813
+#: src/olympia/editors/views.py:818
 msgid "needs super review"
 msgstr "necessita una super-revisió"
 
-#: src/olympia/editors/views.py:814
+#: src/olympia/editors/views.py:819
 msgid "commented"
 msgstr ""
 
@@ -7810,31 +7700,31 @@ msgstr "Cues"
 msgid "Unlisted Queues"
 msgstr ""
 
-#: src/olympia/editors/templates/editors/base.html:72 src/olympia/editors/templates/editors/performance.html:6
+#: src/olympia/editors/templates/editors/base.html:74 src/olympia/editors/templates/editors/performance.html:6
 msgid "Performance"
 msgstr "Eficiència"
 
-#: src/olympia/editors/templates/editors/base.html:75 src/olympia/editors/templates/editors/themes/base.html:19 src/olympia/editors/templates/editors/themes/base.html:38
+#: src/olympia/editors/templates/editors/base.html:77 src/olympia/editors/templates/editors/themes/base.html:19 src/olympia/editors/templates/editors/themes/base.html:38
 msgid "Logs"
 msgstr "Registre"
 
-#: src/olympia/editors/templates/editors/base.html:78 src/olympia/editors/templates/editors/reviewlog.html:4 src/olympia/editors/templates/editors/reviewlog.html:27
+#: src/olympia/editors/templates/editors/base.html:80 src/olympia/editors/templates/editors/reviewlog.html:4 src/olympia/editors/templates/editors/reviewlog.html:27
 msgid "Add-on Review Log"
 msgstr ""
 
 # 80%
 # 100%
-#: src/olympia/editors/templates/editors/base.html:80 src/olympia/editors/templates/editors/eventlog.html:4 src/olympia/editors/templates/editors/eventlog.html:8
+#: src/olympia/editors/templates/editors/base.html:82 src/olympia/editors/templates/editors/eventlog.html:4 src/olympia/editors/templates/editors/eventlog.html:8
 #: src/olympia/editors/templates/editors/eventlog_detail.html:4
 #, fuzzy
 msgid "Moderated Review Log"
 msgstr "Revisions moderades"
 
-#: src/olympia/editors/templates/editors/base.html:82 src/olympia/editors/templates/editors/beta_signed_log.html:4 src/olympia/editors/templates/editors/beta_signed_log.html:8
+#: src/olympia/editors/templates/editors/base.html:84 src/olympia/editors/templates/editors/beta_signed_log.html:4 src/olympia/editors/templates/editors/beta_signed_log.html:8
 msgid "Signed Beta Files Log"
 msgstr ""
 
-#: src/olympia/editors/templates/editors/base.html:87 src/olympia/editors/templates/editors/includes/daily-message.html:4
+#: src/olympia/editors/templates/editors/base.html:89 src/olympia/editors/templates/editors/includes/daily-message.html:4
 msgid "Announcement"
 msgstr "Anunci"
 
@@ -8071,45 +7961,45 @@ msgstr "Cerca avançada"
 msgid "clear search"
 msgstr "neteja la cerca"
 
-#: src/olympia/editors/templates/editors/queue.html:72 src/olympia/editors/templates/editors/queue.html:122
+#: src/olympia/editors/templates/editors/queue.html:78 src/olympia/editors/templates/editors/queue.html:128
 msgid "Process Reviews"
 msgstr "Processa les revisions"
 
-#: src/olympia/editors/templates/editors/queue.html:80
+#: src/olympia/editors/templates/editors/queue.html:86
 msgid "Moderation actions:"
 msgstr "Accions de moderació:"
 
-#: src/olympia/editors/templates/editors/queue.html:90
+#: src/olympia/editors/templates/editors/queue.html:96
 #, python-format
 msgid "by %(user)s on %(date)s %(stars)s (%(locale)s)"
 msgstr "per en/la %(user)s el %(date)s %(stars)s (%(locale)s)"
 
-#: src/olympia/editors/templates/editors/queue.html:106
+#: src/olympia/editors/templates/editors/queue.html:112
 #, python-format
 msgid "<strong>%(reason)s</strong> <span class=\"light\">Flagged by %(user)s on %(date)s</span>"
 msgstr "<strong>%(reason)s</strong> <span class=\"light\">denunciada per %(user)s el %(date)s</span>"
 
-#: src/olympia/editors/templates/editors/queue.html:119
+#: src/olympia/editors/templates/editors/queue.html:125
 msgid "All reviews have been moderated. Good work!"
 msgstr "S'han moderat totes les revisions. Bona feina! "
 
-#: src/olympia/editors/templates/editors/queue.html:161
+#: src/olympia/editors/templates/editors/queue.html:167
 msgid "Version Notes / Notes for Reviewer"
 msgstr ""
 
-#: src/olympia/editors/templates/editors/queue.html:169
+#: src/olympia/editors/templates/editors/queue.html:175
 msgid "There are currently no add-ons of this type to review."
 msgstr "Ara per ara, no s'ha de moderar cap complement d'aquest tipus."
 
-#: src/olympia/editors/templates/editors/queue.html:181 src/olympia/editors/templates/editors/themes/queue_list.html:85
+#: src/olympia/editors/templates/editors/queue.html:187 src/olympia/editors/templates/editors/themes/queue_list.html:85
 msgid "Helpful Links:"
 msgstr "Enllaços útils:"
 
-#: src/olympia/editors/templates/editors/queue.html:182
+#: src/olympia/editors/templates/editors/queue.html:188
 msgid "Add-on Policy"
 msgstr "Normes del complement"
 
-#: src/olympia/editors/templates/editors/queue.html:184
+#: src/olympia/editors/templates/editors/queue.html:190
 msgid "Editors' Guide"
 msgstr "Guia dels editors"
 
@@ -8172,10 +8062,7 @@ msgid "<strong>Warning!</strong> Another user was viewing this page before you."
 msgstr ""
 
 #: src/olympia/editors/templates/editors/review.html:237
-msgid ""
-"The whiteboard is the place to exchange information relevant to\n"
-"               this addon (whatever the version), between the developer and the\n"
-"               editor. This is visible and editable by both."
+msgid "The whiteboard is the place to exchange information relevant to this addon (whatever the version), between the developer and the editor. This is visible and editable by both."
 msgstr ""
 
 #: src/olympia/editors/templates/editors/review.html:241
@@ -8276,8 +8163,9 @@ msgstr ""
 msgid "You have <span>{0}</span> points."
 msgstr ""
 
-#: src/olympia/editors/templates/editors/includes/search_results_themes.html:6 src/olympia/editors/templates/editors/themes/history_table.html:7 src/olympia/editors/templates/editors/themes/logs.html:19
-#: src/olympia/editors/templates/editors/themes/queue_list.html:49 src/olympia/editors/templates/editors/themes/single.html:26 src/olympia/editors/templates/editors/themes/themes.html:45
+#: src/olympia/editors/templates/editors/includes/search_results_themes.html:6 src/olympia/editors/templates/editors/themes/history_table.html:7
+#: src/olympia/editors/templates/editors/themes/logs.html:19 src/olympia/editors/templates/editors/themes/queue_list.html:49 src/olympia/editors/templates/editors/themes/single.html:26
+#: src/olympia/editors/templates/editors/themes/themes.html:45
 msgid "Reviewer"
 msgstr ""
 
@@ -8448,7 +8336,7 @@ msgstr ""
 msgid "Describe your reason for flagging"
 msgstr ""
 
-#: src/olympia/files/forms.py:88
+#: src/olympia/files/forms.py:90
 msgid "Cannot diff a version against itself"
 msgstr ""
 
@@ -8483,51 +8371,51 @@ msgstr "S'ha produït un error en accedir al fitxer %s. %s."
 msgid "There was an error accessing file %s."
 msgstr "S'ha produït un error en accedir al fitxer %s."
 
-#: src/olympia/files/utils.py:343
+#: src/olympia/files/utils.py:340
 msgid "Could not parse uploaded file."
 msgstr ""
 
-#: src/olympia/files/utils.py:380
+#: src/olympia/files/utils.py:377
 msgid "Invalid file name in archive: {0}"
 msgstr ""
 
-#: src/olympia/files/utils.py:388
+#: src/olympia/files/utils.py:385
 msgid "File exceeding size limit in archive: {0}"
 msgstr ""
 
-#: src/olympia/files/utils.py:439
+#: src/olympia/files/utils.py:436
 msgid "Invalid archive."
 msgstr "Arxiu invàlid."
 
-#: src/olympia/files/utils.py:529 src/olympia/files/utils.py:532
+#: src/olympia/files/utils.py:526 src/olympia/files/utils.py:529
 msgid "Could not parse the manifest file."
 msgstr ""
 
-#: src/olympia/files/utils.py:551
+#: src/olympia/files/utils.py:548
 msgid "Could not find an add-on ID."
 msgstr ""
 
-#: src/olympia/files/utils.py:554
+#: src/olympia/files/utils.py:551
 msgid "Add-on ID must be 64 characters or less."
 msgstr ""
 
-#: src/olympia/files/utils.py:556
+#: src/olympia/files/utils.py:553
 msgid "Add-on ID doesn't match add-on."
 msgstr ""
 
-#: src/olympia/files/utils.py:564
+#: src/olympia/files/utils.py:561
 msgid "Duplicate add-on ID found."
 msgstr ""
 
-#: src/olympia/files/utils.py:567
+#: src/olympia/files/utils.py:564
 msgid "Version numbers should have fewer than 32 characters."
 msgstr "Els números de versió haurien de tenir menys de 32 caràcters."
 
-#: src/olympia/files/utils.py:570
+#: src/olympia/files/utils.py:567
 msgid "Version numbers should only contain letters, numbers, and these punctuation characters: +*.-_."
 msgstr "El número de versió només permet lletres, números i els següents signes de puntuació: +*.-_."
 
-#: src/olympia/files/utils.py:587
+#: src/olympia/files/utils.py:584
 msgid "<em:type> doesn't match add-on"
 msgstr "<em:type> no es correspon amb el complment"
 
@@ -8637,6 +8525,10 @@ msgstr "No s'ha trobat cap fitxer per pujar"
 #: src/olympia/files/templates/files/viewer.html:134
 msgid "Fetching file."
 msgstr "S'està analitzant el fitxer."
+
+#: src/olympia/legacy_api/views.py:255
+msgid "Not implemented yet."
+msgstr "No s'ha implementat encara."
 
 #: src/olympia/lib/constants.py:6
 msgid "United Arab Emirates Dirham"
@@ -9294,10 +9186,6 @@ msgstr ""
 msgid "Zimbabwe Dollar"
 msgstr ""
 
-#: src/olympia/lib/video/ffmpeg.py:112 src/olympia/lib/video/totem.py:81
-msgid "Videos must be in WebM."
-msgstr ""
-
 #: src/olympia/pages/templates/pages/about.lhtml:3 src/olympia/pages/templates/pages/about.lhtml:10
 msgid "About Mozilla Add-ons"
 msgstr ""
@@ -9309,7 +9197,7 @@ msgstr ""
 #: src/olympia/pages/templates/pages/about.lhtml:13
 msgid ""
 "addons.mozilla.org, commonly known as \"AMO\", is Mozilla's official site for add-ons to Mozilla software, such as Firefox, Thunderbird, and SeaMonkey. Add-ons let you add new features and change "
-"the way your browser or application works.  Take a look around and explore the thousands of ways to customize the way you do things online."
+"the way your browser or application works. Take a look around and explore the thousands of ways to customize the way you do things online."
 msgstr ""
 
 #: src/olympia/pages/templates/pages/about.lhtml:19
@@ -9365,7 +9253,8 @@ msgstr ""
 
 #: src/olympia/pages/templates/pages/about.lhtml:49
 #, python-format
-msgid "Help improve this website. It's open source, and you can file bugs and submit patches. <a href=\"%(url)s\"> GitHub</a> contains all of our current bugs, legacy bugs can still be found in Bugzilla."
+msgid ""
+"Help improve this website. It's open source, and you can file bugs and submit patches. <a href=\"%(url)s\"> GitHub</a> contains all of our current bugs, legacy bugs can still be found in Bugzilla."
 msgstr ""
 
 #: src/olympia/pages/templates/pages/about.lhtml:55
@@ -9408,8 +9297,8 @@ msgstr ""
 #: src/olympia/pages/templates/pages/about.lhtml:77
 #, python-format
 msgid ""
-"Over the years, many people have contributed to this website, including both volunteers from the community and a dedicated AMO team. A list of significant contributors can be found on our <a "
-"href=\"%(url)s\"> Site Credits</a> page."
+"Over the years, many people have contributed to this website, including both volunteers from the community and a dedicated AMO team. A list of significant contributors can be found on our <a href="
+"\"%(url)s\"> Site Credits</a> page."
 msgstr ""
 
 #: src/olympia/pages/templates/pages/acr_firstrun.html:4
@@ -9443,8 +9332,8 @@ msgstr ""
 #: src/olympia/pages/templates/pages/acr_firstrun.html:61
 #, python-format
 msgid ""
-"If you upgrade to a new version of Firefox or update your add-ons, your reports for the old versions will be hidden to allow you to test the new version. If you have any questions, please ask in <a"
-" href=\"%(url)s\">our forums</a>."
+"If you upgrade to a new version of Firefox or update your add-ons, your reports for the old versions will be hidden to allow you to test the new version. If you have any questions, please ask in <a "
+"href=\"%(url)s\">our forums</a>."
 msgstr ""
 
 #: src/olympia/pages/templates/pages/acr_firstrun.html:69
@@ -9508,8 +9397,8 @@ msgstr ""
 
 #: src/olympia/pages/templates/pages/credits.html:61
 msgid ""
-"Some pages use elements of <a href=\"http://shop.highsoft.com/highcharts.html\">Highcharts</a> (non-commercial), licensed under a <a href=\"http://creativecommons.org/licenses/by-nc/3.0/\">Creative"
-" Commons Attribution-NonCommercial 3.0 License</a>."
+"Some pages use elements of <a href=\"http://shop.highsoft.com/highcharts.html\">Highcharts</a> (non-commercial), licensed under a <a href=\"http://creativecommons.org/licenses/by-nc/3.0/\">Creative "
+"Commons Attribution-NonCommercial 3.0 License</a>."
 msgstr ""
 
 #: src/olympia/pages/templates/pages/credits.html:65
@@ -9641,7 +9530,8 @@ msgstr ""
 
 #: src/olympia/pages/templates/pages/dev_faq.html:143
 #, python-format
-msgid "Yes. You can use Mozilla's <a href=\"%(url)s\">XPCOM component object model</a> to enhance your add-ons. XPCOM components be used and implemented in JavaScript, Java, and Python in addition to C++."
+msgid ""
+"Yes. You can use Mozilla's <a href=\"%(url)s\">XPCOM component object model</a> to enhance your add-ons. XPCOM components be used and implemented in JavaScript, Java, and Python in addition to C++."
 msgstr ""
 
 #: src/olympia/pages/templates/pages/dev_faq.html:150
@@ -9652,7 +9542,7 @@ msgstr ""
 msgid ""
 "Yes. It's possible, but some of the functionality provided by these libraries are available through XPCOM, XUL, and JavaScript. In addition, authors should take care if libraries modify primitive "
 "object prototypes (String.prototype, Date.prototype, etc.) and/or define global functions (eg. the $ function). These are prone to cause conflict with other add-ons, in particular if different add-"
-"ons use different versions of libraries and so on. Developers need to be very, very careful with using them.  Mozilla does not offer documentation on using them to build add-ons."
+"ons use different versions of libraries and so on. Developers need to be very, very careful with using them. Mozilla does not offer documentation on using them to build add-ons."
 msgstr ""
 
 #: src/olympia/pages/templates/pages/dev_faq.html:165
@@ -9682,8 +9572,8 @@ msgstr ""
 #: src/olympia/pages/templates/pages/dev_faq.html:187
 #, python-format
 msgid ""
-"Poorly written extensions can have a severe impact on the browsing experience, including on the overall performance of Firefox itself. The following page contains many good <a "
-"href=\"%(url)s\">guides</a> that help you improve performance, whether you're developing core Mozilla code or an add-on."
+"Poorly written extensions can have a severe impact on the browsing experience, including on the overall performance of Firefox itself. The following page contains many good <a href=\"%(url)s"
+"\">guides</a> that help you improve performance, whether you're developing core Mozilla code or an add-on."
 msgstr ""
 
 #: src/olympia/pages/templates/pages/dev_faq.html:195
@@ -9754,8 +9644,8 @@ msgstr ""
 #: src/olympia/pages/templates/pages/dev_faq.html:248
 #, python-format
 msgid ""
-"Yes. You may find 3rd party developers via the <a href=\"%(forum_url)s\">Add-ons forum</a>, <a href=\"%(list_url)s\">mozilla.jobs list</a>, <a href=\"%(mz_url)s\">mozillaZine forums</a> or <a "
-"href=\"%(wiki_url)s\">the Mozilla Wiki</a>. Please note that Mozilla does not offer developer recommendations."
+"Yes. You may find 3rd party developers via the <a href=\"%(forum_url)s\">Add-ons forum</a>, <a href=\"%(list_url)s\">mozilla.jobs list</a>, <a href=\"%(mz_url)s\">mozillaZine forums</a> or <a href="
+"\"%(wiki_url)s\">the Mozilla Wiki</a>. Please note that Mozilla does not offer developer recommendations."
 msgstr ""
 
 #: src/olympia/pages/templates/pages/dev_faq.html:263
@@ -9765,9 +9655,9 @@ msgstr ""
 #: src/olympia/pages/templates/pages/dev_faq.html:265
 #, python-format
 msgid ""
-"Yes. Many developers choose to host their own add-ons. Choosing to host your add-on on <a href=\"%(amo_url)s\">Mozilla's add-on site</a>, though, allows for much greater exposure to your add-on due"
-" to the large volume of visitors to the site.  <a href=\"%(md_url)s\">mozdev.org</a> offers free project hosting for Mozilla applications and extensions providing developers with tools to help "
-"manage source code, version control, bug tracking and documentation."
+"Yes. Many developers choose to host their own add-ons. Choosing to host your add-on on <a href=\"%(amo_url)s\">Mozilla's add-on site</a>, though, allows for much greater exposure to your add-on due "
+"to the large volume of visitors to the site. <a href=\"%(md_url)s\">mozdev.org</a> offers free project hosting for Mozilla applications and extensions providing developers with tools to help manage "
+"source code, version control, bug tracking and documentation."
 msgstr ""
 
 #: src/olympia/pages/templates/pages/dev_faq.html:277
@@ -9815,7 +9705,7 @@ msgstr ""
 #: src/olympia/pages/templates/pages/dev_faq.html:314
 #, python-format
 msgid ""
-"Yes. Mozilla's <a href=\"%(p_url)s\">Add-on Policy</a> describes what is an acceptable submission. This policy is subject to change without notice.  In addition, the AMO editorial team uses the <a "
+"Yes. Mozilla's <a href=\"%(p_url)s\">Add-on Policy</a> describes what is an acceptable submission. This policy is subject to change without notice. In addition, the AMO editorial team uses the <a "
 "href=\"%(g_url)s\">Editors Reviewing Guide</a> to ensure that your add-on meets specific guidelines for functionality and security."
 msgstr ""
 
@@ -9844,8 +9734,8 @@ msgstr ""
 
 #: src/olympia/pages/templates/pages/dev_faq.html:346
 msgid ""
-"The choice of category is dependent on what type of audience you are targeting and the functionality of your add-on. If you're unsure of which category your add-on falls into, please choose "
-"\"Other\". The AMO team may re-categorize your add-on if it's determined that it's better suited in a different category."
+"The choice of category is dependent on what type of audience you are targeting and the functionality of your add-on. If you're unsure of which category your add-on falls into, please choose \"Other"
+"\". The AMO team may re-categorize your add-on if it's determined that it's better suited in a different category."
 msgstr ""
 
 #: src/olympia/pages/templates/pages/dev_faq.html:355
@@ -9879,8 +9769,8 @@ msgstr ""
 #: src/olympia/pages/templates/pages/dev_faq.html:385
 #, python-format
 msgid ""
-"All add-ons submitted, whether new or updated, are reviewed to ensure that Mozilla users have a stable and safe experience. All add-ons submissions are reviewed using the guidelines outlined in the"
-" <a href=\"%(url)s\">Editors Reviewing Guide</a>."
+"All add-ons submitted, whether new or updated, are reviewed to ensure that Mozilla users have a stable and safe experience. All add-ons submissions are reviewed using the guidelines outlined in the "
+"<a href=\"%(url)s\">Editors Reviewing Guide</a>."
 msgstr ""
 
 #: src/olympia/pages/templates/pages/dev_faq.html:393
@@ -9932,8 +9822,8 @@ msgstr ""
 #: src/olympia/pages/templates/pages/dev_faq.html:434
 #, python-format
 msgid ""
-"This is why it's very important to read the <a href=\"%(g_url)s\">Editors Reviewing Guide</a> to ensure that your add-on is setup as expected.  It's also a good idea to read the blog post, <a "
-"href=\"%(blog_url)s\">Successfully Getting your Add-on Reviewed</a> which provides excellent insight into ensuring a smooth review of your add-on."
+"This is why it's very important to read the <a href=\"%(g_url)s\">Editors Reviewing Guide</a> to ensure that your add-on is setup as expected. It's also a good idea to read the blog post, <a href="
+"\"%(blog_url)s\">Successfully Getting your Add-on Reviewed</a> which provides excellent insight into ensuring a smooth review of your add-on."
 msgstr ""
 
 #: src/olympia/pages/templates/pages/dev_faq.html:446
@@ -9949,7 +9839,8 @@ msgid "How can I see how many active users are using my add-on?"
 msgstr ""
 
 #: src/olympia/pages/templates/pages/dev_faq.html:457
-msgid "The Statistics Dashboard found in the Developer Tools dashboard provides information that can help you determine how many users have been actively using your add-on since you've submitted it to AMO."
+msgid ""
+"The Statistics Dashboard found in the Developer Tools dashboard provides information that can help you determine how many users have been actively using your add-on since you've submitted it to AMO."
 msgstr ""
 
 #: src/olympia/pages/templates/pages/dev_faq.html:464
@@ -10038,7 +9929,7 @@ msgstr ""
 
 #: src/olympia/pages/templates/pages/dev_faq.html:572
 msgid ""
-"Free Software Foundation provides short summaries of the key open source licenses, including whether the license qualifies as a free software license or a copyleft license.  Also includes a "
+"Free Software Foundation provides short summaries of the key open source licenses, including whether the license qualifies as a free software license or a copyleft license. Also includes a "
 "discussion of what constitutes a free software license or a copyleft license (e.g., a Copyleft license is a general method for making a program or other work free, and requiring all modified and "
 "extended versions of the program to be free as well.)"
 msgstr ""
@@ -10083,15 +9974,13 @@ msgstr "Funcionarà els complements amb el meu navegador o amb la meva aplicaci�
 #: src/olympia/pages/templates/pages/faq.html:27
 #, python-format
 msgid ""
-"Add-ons listed in this gallery only work with Mozilla-based applications, such as <a href=\"%(getfirefox_url)s\">Firefox</a>, <a href=\"%(getmobile_url)s\">Firefox Mobile</a>, <a "
-"href=\"%(getseamonkey_url)s\">SeaMonkey</a>, and <a href=\"%(getthunderbird_url)s\">Thunderbird</a>. However, not all add-ons work with each of those applications or every version of those "
-"applications. Each add-on specifies which applications and versions it works with, such as Firefox 2.0 - 3.6.*. For Firefox add-ons, the install buttons will indicate whether the add-on is "
-"compatible or not."
+"Add-ons listed in this gallery only work with Mozilla-based applications, such as <a href=\"%(getfirefox_url)s\">Firefox</a>, <a href=\"%(getmobile_url)s\">Firefox Mobile</a>, <a href="
+"\"%(getseamonkey_url)s\">SeaMonkey</a>, and <a href=\"%(getthunderbird_url)s\">Thunderbird</a>. However, not all add-ons work with each of those applications or every version of those applications. "
+"Each add-on specifies which applications and versions it works with, such as Firefox 2.0 - 3.6.*. For Firefox add-ons, the install buttons will indicate whether the add-on is compatible or not."
 msgstr ""
-"Add-ons listed in this gallery only work with Mozilla-based applications, such as <a href=\"%(getfirefox_url)s\">Firefox</a>, <a href=\"%(getmobile_url)s\">Firefox Mobile</a>, <a "
-"href=\"%(getseamonkey_url)s\">SeaMonkey</a>, and <a href=\"%(getthunderbird_url)s\">Thunderbird</a>. However, not all add-ons work with each of those applications or every version of those "
-"applications. Each add-on specifies which applications and versions it works with, such as Firefox 2.0 - 3.6.*. For Firefox add-ons, the install buttons will indicate whether the add-on is "
-"compatible or not."
+"Add-ons listed in this gallery only work with Mozilla-based applications, such as <a href=\"%(getfirefox_url)s\">Firefox</a>, <a href=\"%(getmobile_url)s\">Firefox Mobile</a>, <a href="
+"\"%(getseamonkey_url)s\">SeaMonkey</a>, and <a href=\"%(getthunderbird_url)s\">Thunderbird</a>. However, not all add-ons work with each of those applications or every version of those applications. "
+"Each add-on specifies which applications and versions it works with, such as Firefox 2.0 - 3.6.*. For Firefox add-ons, the install buttons will indicate whether the add-on is compatible or not."
 
 #: src/olympia/pages/templates/pages/faq.html:42
 msgid "What are the different types of add-ons?"
@@ -10155,8 +10044,8 @@ msgstr "Com es poden instal·lar complements sense haver de reiniciar el Firefox
 #: src/olympia/pages/templates/pages/faq.html:101
 #, python-format
 msgid ""
-"In Firefox, add-ons marked with \"No restart required\" can be installed without restarting. These add-ons have been created using the <a href=\"%(sdk_url)s\">Add-on SDK</a> or <a "
-"href=\"%(bootstrap_url)s\">bootstrapping</a>. Other add-ons will still require a restart before you can use them."
+"In Firefox, add-ons marked with \"No restart required\" can be installed without restarting. These add-ons have been created using the <a href=\"%(sdk_url)s\">Add-on SDK</a> or <a href="
+"\"%(bootstrap_url)s\">bootstrapping</a>. Other add-ons will still require a restart before you can use them."
 msgstr ""
 
 #: src/olympia/pages/templates/pages/faq.html:110
@@ -10167,8 +10056,8 @@ msgstr "Com s'actualitzen els complements?"
 #, python-format
 msgid ""
 "Add-ons, unlike plugins, are automatically checked for updates once every day. In Firefox, updates are automatically installed by default. Versions of Firefox prior to 4 (and other applications) "
-"will alert you that updates to your add-ons are available. <a href=\"%(plugin_url)s\">Plugins</a> are not currently automatically checked for updates, so be sure to regularly visit the <a "
-"href=\"%(plugincheck_url)s\">Plugin Check</a> page to stay up-to-date."
+"will alert you that updates to your add-ons are available. <a href=\"%(plugin_url)s\">Plugins</a> are not currently automatically checked for updates, so be sure to regularly visit the <a href="
+"\"%(plugincheck_url)s\">Plugin Check</a> page to stay up-to-date."
 msgstr ""
 
 #: src/olympia/pages/templates/pages/faq.html:122
@@ -10178,13 +10067,13 @@ msgstr "Instaŀlar complements és segur?"
 #: src/olympia/pages/templates/pages/faq.html:123
 #, python-format
 msgid ""
-"Unless clearly marked otherwise, add-ons available from this gallery have been checked and approved by Mozilla's team of editors and are safe to install. We recommend that you only install approved"
-" add-ons. If you wish to install unapproved add-ons or add-ons from third-party websites, use caution as these add-ons may harm your computer or violate your privacy. <a "
-"href=\"%(learnmore_url)s\">Learn more about our approval process</a>"
+"Unless clearly marked otherwise, add-ons available from this gallery have been checked and approved by Mozilla's team of editors and are safe to install. We recommend that you only install approved "
+"add-ons. If you wish to install unapproved add-ons or add-ons from third-party websites, use caution as these add-ons may harm your computer or violate your privacy. <a href=\"%(learnmore_url)s"
+"\">Learn more about our approval process</a>"
 msgstr ""
-"Unless clearly marked otherwise, add-ons available from this gallery have been checked and approved by Mozilla's team of editors and are safe to install. We recommend that you only install approved"
-" add-ons. If you wish to install unapproved add-ons or add-ons from third-party websites, use caution as these add-ons may harm your computer or violate your privacy. <a "
-"href=\"%(learnmore_url)s\">Learn more about our approval process</a>"
+"Unless clearly marked otherwise, add-ons available from this gallery have been checked and approved by Mozilla's team of editors and are safe to install. We recommend that you only install approved "
+"add-ons. If you wish to install unapproved add-ons or add-ons from third-party websites, use caution as these add-ons may harm your computer or violate your privacy. <a href=\"%(learnmore_url)s"
+"\">Learn more about our approval process</a>"
 
 #: src/olympia/pages/templates/pages/faq.html:133
 #, python-format
@@ -10207,12 +10096,12 @@ msgstr "%(app_name)s told me an add-on isn't compatible. Is there a way I can st
 #, python-format
 msgid ""
 "If an add-on isn't compatible with your version of %(app_name)s, it is usually either because your version of %(app_name)s is outdated or the add-on author has not yet updated the add-on to be "
-"compatible with a newer version you are using. Mozilla does not recommend trying to circumvent these compatibility checks, as they can lead to browser instability or in some cases loss of data. For"
-" users who are testing out alpha or beta versions of Firefox, we offer the <a href=\"%(acr_url)s\">Add-on Compatibility Reporter</a> to help add-on developers update their compatibility."
+"compatible with a newer version you are using. Mozilla does not recommend trying to circumvent these compatibility checks, as they can lead to browser instability or in some cases loss of data. For "
+"users who are testing out alpha or beta versions of Firefox, we offer the <a href=\"%(acr_url)s\">Add-on Compatibility Reporter</a> to help add-on developers update their compatibility."
 msgstr ""
 "If an add-on isn't compatible with your version of %(app_name)s, it is usually either because your version of %(app_name)s is outdated or the add-on author has not yet updated the add-on to be "
-"compatible with a newer version you are using. Mozilla does not recommend trying to circumvent these compatibility checks, as they can lead to browser instability or in some cases loss of data. For"
-" users who are testing out alpha or beta versions of Firefox, we offer the <a href=\"%(acr_url)s\">Add-on Compatibility Reporter</a> to help add-on developers update their compatibility."
+"compatible with a newer version you are using. Mozilla does not recommend trying to circumvent these compatibility checks, as they can lead to browser instability or in some cases loss of data. For "
+"users who are testing out alpha or beta versions of Firefox, we offer the <a href=\"%(acr_url)s\">Add-on Compatibility Reporter</a> to help add-on developers update their compatibility."
 
 #: src/olympia/pages/templates/pages/faq.html:156
 msgid "What if I have problems with an add-on?"
@@ -10237,7 +10126,7 @@ msgstr "Galeria de complements"
 msgid "How do I choose between add-ons that seem to do the same thing?"
 msgstr "Com puc saber quin complement he d'escollir quan n'hi ha dos que semblen que faran el mateix?"
 
-#: src/olympia/pages/templates/pages/faq.html:173
+#: src/olympia/pages/templates/pages/faq.html:172
 msgid ""
 "There are often several add-ons that have similar features. To figure out which is right for you, read the entire description of the add-on and view its screenshots. If there are still several in "
 "the running, read through the add-on's ratings, user reviews, and statistics to see which is most liked by other users. Remember that you can also just try out both and see which you like better."
@@ -10263,8 +10152,8 @@ msgstr "Què vol dir que un complement és \"experimental\" o que \"ha passat un
 #: src/olympia/pages/templates/pages/faq.html:188
 #, python-format
 msgid ""
-"Experimental add-ons have been checked by our editors to make sure they don't have security problems, but they may still have bugs or not work properly. Use caution when installing experimental "
-"add-ons and uninstall the add-on immediately if you notice problems. <a href=\"%(url)s\">Learn more about our review process</a></dd>"
+"Experimental add-ons have been checked by our editors to make sure they don't have security problems, but they may still have bugs or not work properly. Use caution when installing experimental add-"
+"ons and uninstall the add-on immediately if you notice problems. <a href=\"%(url)s\">Learn more about our review process</a></dd>"
 msgstr ""
 "Els complements experimentals han estat revisats pels editors, però només per assegurar-se que no tenen problemes de seguertat. Tot i així pot ser que els complements tinguin altres tipus de "
 "problemes o no funcionin prou bé. Tingueu precaució quan instal·leu complements experimentals. Si noteu cap problema desinstal·leu-los immediatament. <a href=\"%(url)s\">Més informació sobre el "
@@ -10281,8 +10170,8 @@ msgid ""
 "as they could harm your computer or violate your privacy. We recommend that you only install reviewed add-ons. <a href=\"%(url)s\">Learn more about our review process</a></dd>"
 msgstr ""
 "Tots els complements disponibles públicament a la nostra galeria han estat revisats per un editor, però tot i així podeu rebre un enllaç directe a un complement complement que encara no ha estat "
-"revisat. Aneu en compte amb aquests complements, ja que poden fer malbé el vostre ordinador o violar la vostra privacitat. Us recomanem que només us instal·leu els complements revisats. <a "
-"href=\"%(url)s\">Més informació sobre el nostre procés de revisió</a></dd>"
+"revisat. Aneu en compte amb aquests complements, ja que poden fer malbé el vostre ordinador o violar la vostra privacitat. Us recomanem que només us instal·leu els complements revisats. <a href="
+"\"%(url)s\">Més informació sobre el nostre procés de revisió</a></dd>"
 
 #: src/olympia/pages/templates/pages/faq.html:206
 msgid "How much do add-ons cost to purchase?"
@@ -10292,11 +10181,11 @@ msgstr "How much do add-ons cost to purchase?"
 msgid "Add-ons hosted in our gallery are free unless clearly marked otherwise."
 msgstr "Add-ons hosted in our gallery are free unless clearly marked otherwise."
 
-#: src/olympia/pages/templates/pages/faq.html:210
+#: src/olympia/pages/templates/pages/faq.html:209
 msgid "What does it mean when an add-on asks for contributions?"
 msgstr "What does it mean when an add-on asks for contributions?"
 
-#: src/olympia/pages/templates/pages/faq.html:211
+#: src/olympia/pages/templates/pages/faq.html:210
 msgid ""
 "Some add-on authors request users who enjoy an add-on to contribute to its development by making a monetary contribution. These contributions go directly to the developer unless a third party is "
 "indicated, such as the non-profit Mozilla Foundation."
@@ -10304,11 +10193,11 @@ msgstr ""
 "Alguns autors de complements demanen als seus usuaris si volen ajudar econòmicament i fer una petita contribució per al desenvolupament del complement. Aquesta contribució va directametn al "
 "desenvolupador a no ser que s'indiqui que ha d'anar a favor d'un tercer, com per exemple una organització sense ànim de lucre com la Fundació Mozilla."
 
-#: src/olympia/pages/templates/pages/faq.html:216
+#: src/olympia/pages/templates/pages/faq.html:215
 msgid "What are beta add-ons?"
 msgstr "Què són els complements Beta?"
 
-#: src/olympia/pages/templates/pages/faq.html:218
+#: src/olympia/pages/templates/pages/faq.html:217
 msgid ""
 "Beta add-ons are unreviewed versions which represent the latest work of an add-on author. While different authors have different standards for beta code quality, you should assume that these add-"
 "ons are less stable than the general add-on releases."
@@ -10316,30 +10205,27 @@ msgstr ""
 "Els complements Beta són complements que encara no han estat revisats i que representen la última versió en què l'autor està treballant. Ja que cada autor tindrà una forma diferent de valorar "
 "l'estat de la qualitat, heu de tenir present que aquests complements són menys estables que una versió normal ben acabada."
 
-#: src/olympia/pages/templates/pages/faq.html:222
+#: src/olympia/pages/templates/pages/faq.html:221
 msgid ""
-"Please note that when you install an add-on from the \"Beta Version\" section of an add-on's listing, you will continue to receive updates for that add-on as they become available. Like the initial"
-" version you installed, all beta releases are unreviewed by Mozilla and may harm your computer."
+"Please note that when you install an add-on from the \"Beta Version\" section of an add-on's listing, you will continue to receive updates for that add-on as they become available. Like the initial "
+"version you installed, all beta releases are unreviewed by Mozilla and may harm your computer."
 msgstr ""
 "Heu de tenir present que quan us instaŀleu un complement de la secció de versions beta, continuareu rebent actualitzacions del complement. Però de la mateixa manera que la versió beta no va ser "
 "revisada, les seves actualitzacions tampoc i poden fer malbé el vostre ordinador."
 
-#: src/olympia/pages/templates/pages/faq.html:229
+#: src/olympia/pages/templates/pages/faq.html:228
 msgid "What does it mean when an add-on is flagged as slow?"
 msgstr "Què vol dir quan s'indica que un complement és lent?"
 
-#: src/olympia/pages/templates/pages/faq.html:231
-msgid ""
-"Most add-ons load code and resources at the same time Firefox\n"
-"        is starting up. In most cases the impact in start-up time is minimal,\n"
-"        but some add-ons can cause a noticeable slowdown."
+#: src/olympia/pages/templates/pages/faq.html:229
+msgid "Most add-ons load code and resources at the same time Firefox is starting up. In most cases the impact in start-up time is minimal, but some add-ons can cause a noticeable slowdown."
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:236
+#: src/olympia/pages/templates/pages/faq.html:234
 msgid "How do I report an inappropriate or spam user review?"
 msgstr "How do I report an inappropriate or spam user review?"
 
-#: src/olympia/pages/templates/pages/faq.html:237
+#: src/olympia/pages/templates/pages/faq.html:235
 msgid ""
 "To report a user review of an add-on, log in with your account and visit the add-on's reviews page. Find the review you wish to report, click \"Report this review\" and select a reason. Our "
 "editorial team will investigate the review and take appropriate action."
@@ -10347,64 +10233,64 @@ msgstr ""
 "To report a user review of an add-on, log in with your account and visit the add-on's reviews page. Find the review you wish to report, click \"Report this review\" and select a reason. Our "
 "editorial team will investigate the review and take appropriate action."
 
-#: src/olympia/pages/templates/pages/faq.html:242
+#: src/olympia/pages/templates/pages/faq.html:240
 msgid "How do I report a bug or contact the Mozilla Add-ons team?"
 msgstr "How do I report a bug or contact the Mozilla Add-ons team?"
 
-#: src/olympia/pages/templates/pages/faq.html:243
+#: src/olympia/pages/templates/pages/faq.html:241
 #, python-format
 msgid "Please visit our <a href=\"%(contact_url)s\">Contact page</a>."
 msgstr "Visiteu la nostra <a href=\"%(contact_url)s\">pàgina de contacte</a>"
 
-#: src/olympia/pages/templates/pages/faq.html:246
+#: src/olympia/pages/templates/pages/faq.html:244
 msgid "What is a Source Code License?"
 msgstr "Què és una llicència de codi font?"
 
-#: src/olympia/pages/templates/pages/faq.html:247
+#: src/olympia/pages/templates/pages/faq.html:245
 #, python-format
 msgid ""
-"The source code used to create an add-on is an exclusive copyright of the add-on author, unless otherwise declared in a source code license. Many add-ons on this site have <a href=\"%(url)s\" "
-"lang=\"en\">open source licenses</a> that make the source code publicly available for copy and reuse under conditions determined by the author. Most authors choose widely known open source licenses"
-" like the GPL or BSD licenses instead of making up their own."
+"The source code used to create an add-on is an exclusive copyright of the add-on author, unless otherwise declared in a source code license. Many add-ons on this site have <a href=\"%(url)s\" lang="
+"\"en\">open source licenses</a> that make the source code publicly available for copy and reuse under conditions determined by the author. Most authors choose widely known open source licenses like "
+"the GPL or BSD licenses instead of making up their own."
 msgstr ""
 "El codi font que s'ha fet servir per crear un complement és un copyright exclusiu de l'autor del complement, a no ser que es declari una llicència de codi obert. Molts complement d'aquest lloc web "
 "tenen <a href=\"%(url)s\" lang=\"en\">llicències de codi obert</a>, que fan que el codi font estigui disponible públicament per copiar i reutilitzar sota les condicions determinades per l'autor. "
 "Molts autors decideixen utilitzar llicències de codi obert famoses, com la GPS o la BSD, en comptes de fer-se'n una a mida."
 
-#: src/olympia/pages/templates/pages/faq.html:256
+#: src/olympia/pages/templates/pages/faq.html:254
 #, python-format
 msgid "Firefox and other Mozilla software are <a href=\"%(url)s\">open source</a>."
 msgstr "El Firefox i els demés programes de Mozilla són <a href=\"%(url)s\">codi obert</a>."
 
-#: src/olympia/pages/templates/pages/faq.html:264
+#: src/olympia/pages/templates/pages/faq.html:262
 msgid "Collections and Favorites"
 msgstr "Coŀleccions i preferits"
 
-#: src/olympia/pages/templates/pages/faq.html:267
+#: src/olympia/pages/templates/pages/faq.html:265
 msgid "What is a collection?"
 msgstr "Què és una coŀlecció?"
 
-#: src/olympia/pages/templates/pages/faq.html:268
+#: src/olympia/pages/templates/pages/faq.html:266
 msgid "Collections are groups of related add-ons created by users to share."
 msgstr "Les coŀleccions són agrupacions de complements que els mateixos usuaris creen per a compartir-les."
 
-#: src/olympia/pages/templates/pages/faq.html:270
+#: src/olympia/pages/templates/pages/faq.html:268
 msgid "What is the My Favorites collection?"
 msgstr "Què són les meves coŀleccions preferides?"
 
-#: src/olympia/pages/templates/pages/faq.html:271
+#: src/olympia/pages/templates/pages/faq.html:269
 msgid "Favorite add-ons are add-ons that you have bookmarked to easily get back to later. You can add an add-on to your favorites collection by clicking \"Add to favorites\" on its details page."
 msgstr "Favorite add-ons are add-ons that you have bookmarked to easily get back to later. You can add an add-on to your favorites collection by clicking \"Add to favorites\" on its details page."
 
-#: src/olympia/pages/templates/pages/faq.html:275 src/olympia/templates/menu_links.html:13 src/olympia/templates/impala/header_title.html:17
+#: src/olympia/pages/templates/pages/faq.html:273 src/olympia/templates/menu_links.html:13 src/olympia/templates/impala/header_title.html:17
 msgid "Mobile Add-ons"
 msgstr "Complements per a mòbils"
 
-#: src/olympia/pages/templates/pages/faq.html:278
+#: src/olympia/pages/templates/pages/faq.html:276
 msgid "What are mobile add-ons?"
 msgstr "Què són els complements per a mòbils?"
 
-#: src/olympia/pages/templates/pages/faq.html:279
+#: src/olympia/pages/templates/pages/faq.html:277
 #, python-format
 msgid ""
 "Mobile add-ons work with <a href=\"%(mobile_url)s\">Firefox for Mobile</a> and add or modify functionality just like desktop add-ons. You can find add-ons that work with Firefox for Mobile in our "
@@ -10413,20 +10299,20 @@ msgstr ""
 "Mobile add-ons work with <a href=\"%(mobile_url)s\">Firefox for Mobile</a> and add or modify functionality just like desktop add-ons. You can find add-ons that work with Firefox for Mobile in our "
 "<a href=\"%(gallery_url)s\">gallery</a>."
 
-#: src/olympia/pages/templates/pages/faq.html:288
+#: src/olympia/pages/templates/pages/faq.html:286
 msgid "Developer Topics"
 msgstr "Temes del desenvolupador"
 
-#: src/olympia/pages/templates/pages/faq.html:289
+#: src/olympia/pages/templates/pages/faq.html:287
 #, python-format
 msgid "Please see our <a href=\"%(faq_url)s\">Developer FAQ</a> and <a href=\"%(hub_url)s\">Developer Hub</a> for answers to add-on developer-related questions."
 msgstr "Please see our <a href=\"%(faq_url)s\">Developer FAQ</a> and <a href=\"%(hub_url)s\">Developer Hub</a> for answers to add-on developer-related questions."
 
-#: src/olympia/pages/templates/pages/faq.html:294
+#: src/olympia/pages/templates/pages/faq.html:292
 msgid "Still have questions?"
 msgstr "Encara teniu preguntes?"
 
-#: src/olympia/pages/templates/pages/faq.html:295
+#: src/olympia/pages/templates/pages/faq.html:293
 #, python-format
 msgid "For general Firefox support, visit our <a href=\"%(sumo_url)s\">support website</a>. For general add-on and website questions, visit our <a href=\"%(forum_url)s\">forum</a>."
 msgstr "For general Firefox support, visit our <a href=\"%(sumo_url)s\">support website</a>. For general add-on and website questions, visit our <a href=\"%(forum_url)s\">forum</a>."
@@ -10564,7 +10450,7 @@ msgstr ""
 
 #: src/olympia/pages/templates/pages/sunbird.html:29
 msgid ""
-"Development on the Sunbird project has halted and its final release was on March 30, 2010.  We've been proud to host Sunbird add-ons on this site but as the project is no longer maintained we have "
+"Development on the Sunbird project has halted and its final release was on March 30, 2010. We've been proud to host Sunbird add-ons on this site but as the project is no longer maintained we have "
 "disabled our support for the add-ons."
 msgstr ""
 
@@ -10642,10 +10528,10 @@ msgstr "Afegeix un comentari al {0}"
 #, python-format
 msgid ""
 "<h2>Keep these tips in mind:</h2> <ul> <li> Write like you're telling a friend about your experience with the add-on. Give specifics and helpful details, such as what features you liked and/or "
-"disliked, how easy to use it is, and any disadvantages it has.  Avoid generic language such as calling it \"Great\" or \"Bad\" unless you can give reasons why you believe this is so. </li> <li> "
-"Please do not post bug reports in reviews. We do not make your email address available to add-on developers and they may need to contact you to help resolve your issue. See the <a "
-"href=\"%(support)s\">support section</a> to find out where to get assistance for this add-on. </li> <li>Please keep reviews clean, avoid the use of improper language and do not post any personal "
-"information. </li> </ul> <p>Please read the <a href=\"%(guide)s\" target=\"_blank\">Review Guidelines</a> for more detail about user add-on reviews.</p>"
+"disliked, how easy to use it is, and any disadvantages it has. Avoid generic language such as calling it \"Great\" or \"Bad\" unless you can give reasons why you believe this is so. </li> <li> "
+"Please do not post bug reports in reviews. We do not make your email address available to add-on developers and they may need to contact you to help resolve your issue. See the <a href=\"%(support)s"
+"\">support section</a> to find out where to get assistance for this add-on. </li> <li>Please keep reviews clean, avoid the use of improper language and do not post any personal information. </li> </"
+"ul> <p>Please read the <a href=\"%(guide)s\" target=\"_blank\">Review Guidelines</a> for more detail about user add-on reviews.</p>"
 msgstr ""
 
 #: src/olympia/reviews/templates/reviews/reply.html:4
@@ -10900,16 +10786,16 @@ msgstr "Complements del {0}"
 
 #. L10n: {0} is an application, such as Firefox. This means "any version of
 #. Firefox."
-#: src/olympia/search/views.py:554
+#: src/olympia/search/views.py:547
 msgid "Any {0}"
 msgstr "Qualsevol {0}"
 
 #. L10n: "All Systems" means show everything regardless of platform.
-#: src/olympia/search/views.py:589
+#: src/olympia/search/views.py:582
 msgid "All Systems"
 msgstr "Tots els sistemes"
 
-#: src/olympia/search/views.py:600
+#: src/olympia/search/views.py:593
 msgid "All Tags"
 msgstr "Totes les etiquetes"
 
@@ -11083,31 +10969,31 @@ msgstr "Comparteix aquest complement"
 msgid "Share this Collection"
 msgstr "Comparteix aquesta coŀlecció"
 
-#: src/olympia/signing/views.py:30 src/olympia/templates/base.html:75 src/olympia/templates/impala/base.html:115
+#: src/olympia/signing/views.py:33 src/olympia/templates/base.html:71 src/olympia/templates/impala/base.html:112
 msgid "Some features are temporarily disabled while we perform website maintenance. We'll be back to full capacity shortly."
 msgstr "Algunes característiques s'han inhabilitat temporalment mentre fem tasques de manteniment del lloc web. Tornarem a la plena capacitat aviat."
 
-#: src/olympia/signing/views.py:53
+#: src/olympia/signing/views.py:56
 msgid "Could not find add-on with id \"{}\"."
 msgstr ""
 
-#: src/olympia/signing/views.py:67
+#: src/olympia/signing/views.py:70
 msgid "You do not own this addon."
 msgstr ""
 
-#: src/olympia/signing/views.py:82
+#: src/olympia/signing/views.py:87
 msgid "Missing \"upload\" key in multipart file data."
 msgstr ""
 
-#: src/olympia/signing/views.py:96
+#: src/olympia/signing/views.py:101
 msgid "Version does not match the manifest file."
 msgstr ""
 
-#: src/olympia/signing/views.py:100
+#: src/olympia/signing/views.py:105
 msgid "Version already exists."
 msgstr ""
 
-#: src/olympia/signing/views.py:136
+#: src/olympia/signing/views.py:141
 msgid "No uploaded file for that addon and version."
 msgstr ""
 
@@ -11220,89 +11106,89 @@ msgstr ""
 msgid "Statistics Dashboard :: Add-ons for {0}"
 msgstr ""
 
-#: src/olympia/stats/templates/stats/stats.html:30
-msgid "Controls:"
-msgstr ""
-
-#: src/olympia/stats/templates/stats/stats.html:33
-msgid "reset zoom"
-msgstr ""
-
-#: src/olympia/stats/templates/stats/stats.html:40
-msgid "Group by:"
-msgstr "Agrupa per:"
-
-#: src/olympia/stats/templates/stats/stats.html:42
-msgid "day"
-msgstr "dia"
-
-#: src/olympia/stats/templates/stats/stats.html:45
-msgid "week"
-msgstr "setmana"
-
-#: src/olympia/stats/templates/stats/stats.html:48
-msgid "month"
-msgstr "mes"
-
-#: src/olympia/stats/templates/stats/stats.html:54
-msgid "For last:"
-msgstr ""
-
-#: src/olympia/stats/templates/stats/stats.html:57
-msgid "7 days"
-msgstr "7 dies"
-
-#: src/olympia/stats/templates/stats/stats.html:60
-msgid "30 days"
-msgstr "30 dies"
-
-#: src/olympia/stats/templates/stats/stats.html:63
-msgid "90 days"
-msgstr "90 dies"
-
-#: src/olympia/stats/templates/stats/stats.html:66
-msgid "365 days"
-msgstr "365 dies"
-
-#: src/olympia/stats/templates/stats/stats.html:69
-msgid "Custom..."
-msgstr ""
-
 #. {0} is an add-on name
-#: src/olympia/stats/templates/stats/stats.html:88 src/olympia/stats/templates/stats/stats.html:91
+#: src/olympia/stats/templates/stats/stats.html:44 src/olympia/stats/templates/stats/stats.html:47
 msgid "Statistics for {0}"
 msgstr "Estadístiques de {0}"
 
-#: src/olympia/stats/templates/stats/stats.html:94
+#: src/olympia/stats/templates/stats/stats.html:50
 msgid "Statistics Dashboard"
 msgstr ""
 
-#: src/olympia/stats/templates/stats/stats.html:104
+#: src/olympia/stats/templates/stats/stats.html:57
+msgid "Controls:"
+msgstr ""
+
+#: src/olympia/stats/templates/stats/stats.html:60
+msgid "reset zoom"
+msgstr ""
+
+#: src/olympia/stats/templates/stats/stats.html:67
+msgid "Group by:"
+msgstr "Agrupa per:"
+
+#: src/olympia/stats/templates/stats/stats.html:69
+msgid "day"
+msgstr "dia"
+
+#: src/olympia/stats/templates/stats/stats.html:72
+msgid "week"
+msgstr "setmana"
+
+#: src/olympia/stats/templates/stats/stats.html:75
+msgid "month"
+msgstr "mes"
+
+#: src/olympia/stats/templates/stats/stats.html:81
+msgid "For last:"
+msgstr ""
+
+#: src/olympia/stats/templates/stats/stats.html:84
+msgid "7 days"
+msgstr "7 dies"
+
+#: src/olympia/stats/templates/stats/stats.html:87
+msgid "30 days"
+msgstr "30 dies"
+
+#: src/olympia/stats/templates/stats/stats.html:90
+msgid "90 days"
+msgstr "90 dies"
+
+#: src/olympia/stats/templates/stats/stats.html:93
+msgid "365 days"
+msgstr "365 dies"
+
+#: src/olympia/stats/templates/stats/stats.html:96
+msgid "Custom..."
+msgstr ""
+
+#: src/olympia/stats/templates/stats/stats.html:106
 msgid "Statistics processing is currently disabled, so recent data is unavailable. The statistics are still being collected and this page will be updated soon with the missing data."
 msgstr ""
 
-#: src/olympia/stats/templates/stats/stats.html:110
+#: src/olympia/stats/templates/stats/stats.html:112
 msgid "Loading the latest data&hellip;"
 msgstr "S'està carregant les últimes dades&hellip;"
 
-#: src/olympia/stats/templates/stats/stats.html:142 src/olympia/stats/templates/stats/reports/overview.html:25 src/olympia/stats/templates/stats/reports/overview.html:37
+#: src/olympia/stats/templates/stats/stats.html:144 src/olympia/stats/templates/stats/reports/overview.html:25 src/olympia/stats/templates/stats/reports/overview.html:37
 #: src/olympia/stats/templates/stats/reports/overview.html:49
 msgid "No data available."
 msgstr ""
 
-#: src/olympia/stats/templates/stats/stats.html:177
+#: src/olympia/stats/templates/stats/stats.html:179
 msgid "This dashboard is currently <b>public</b>."
 msgstr ""
 
-#: src/olympia/stats/templates/stats/stats.html:179
+#: src/olympia/stats/templates/stats/stats.html:181
 msgid "Contribution stats are currently <b>private</b>."
 msgstr ""
 
-#: src/olympia/stats/templates/stats/stats.html:182
+#: src/olympia/stats/templates/stats/stats.html:184
 msgid "This dashboard is currently <b>private</b>."
 msgstr ""
 
-#: src/olympia/stats/templates/stats/stats.html:185
+#: src/olympia/stats/templates/stats/stats.html:187
 msgid "Change settings."
 msgstr ""
 
@@ -11412,10 +11298,10 @@ msgstr ""
 #, python-format
 msgid ""
 "<h2>Tracking external sources</h2> <p> If you link to your add-on's details page or directly to its file from an external site, such as your blog or website, you can append a parameter to be "
-"tracked as an additional download source on this page. For example, the following links would appear as sourced by your blog: <dl> <dt>Add-on Details Page</dt> "
-"<dd>https://addons.mozilla.org/addon/%(slug)s?src=<b>external-blog</b></dd> <dt>Direct File Link</dt> <dd>https://addons.mozilla.org/downloads/latest/%(id)s/addon-%(id)s-latest.xpi?src=<b>external-"
-"blog</b></dd> </dl> <p> Only src parameters that begin with \"external-\" will be tracked, up to 61 additional characters. Any text after \"external-\" can be used to describe the source, such as "
-"\"external-blog\", \"external-sidebar\", \"external-campaign225\", etc. The following URL-safe characters are allowed: <code>a-z A-Z - . _ ~ %% +</code>"
+"tracked as an additional download source on this page. For example, the following links would appear as sourced by your blog: <dl> <dt>Add-on Details Page</dt> <dd>https://addons.mozilla.org/addon/"
+"%(slug)s?src=<b>external-blog</b></dd> <dt>Direct File Link</dt> <dd>https://addons.mozilla.org/downloads/latest/%(id)s/addon-%(id)s-latest.xpi?src=<b>external-blog</b></dd> </dl> <p> Only src "
+"parameters that begin with \"external-\" will be tracked, up to 61 additional characters. Any text after \"external-\" can be used to describe the source, such as \"external-blog\", \"external-"
+"sidebar\", \"external-campaign225\", etc. The following URL-safe characters are allowed: <code>a-z A-Z - . _ ~ %% +</code>"
 msgstr ""
 
 #: src/olympia/stats/templates/stats/reports/statuses.html:3
@@ -11442,8 +11328,8 @@ msgstr ""
 
 #: src/olympia/stats/templates/stats/reports/usage.html:20
 msgid ""
-"<h2>What are daily users?</h2> <p> Add-ons downloaded from this site check for updates once per day. The total number of these update pings is known as Active Daily Users. Daily users can be broken"
-" down by add-on version, operating system, add-on status, application, and locale. </p>"
+"<h2>What are daily users?</h2> <p> Add-ons downloaded from this site check for updates once per day. The total number of these update pings is known as Active Daily Users. Daily users can be broken "
+"down by add-on version, operating system, add-on status, application, and locale. </p>"
 msgstr ""
 
 #: src/olympia/stats/templates/stats/reports/users_created.html:3
@@ -11454,17 +11340,6 @@ msgstr ""
 msgid "Application versions by Date"
 msgstr "Versions de l'aplicació per data"
 
-# {0} is a number
-#: src/olympia/tags/templates/tags/top_cloud.html:4
-msgid "Top {0} Tags"
-msgstr "Les {0} millors etiquetes"
-
-# {0} is a number.  This is referring to the total number of passing tests.
-#. {0} is the current application name
-#: src/olympia/tags/templates/tags/top_cloud.html:14
-msgid "{0} Top Tags"
-msgstr "Les 10 primeres etiquetes de {0}"
-
 #: src/olympia/templates/amo_footer.html:6 src/olympia/templates/includes/lang_switcher.html:2
 msgid "Other languages"
 msgstr "Altres idiomes"
@@ -11473,11 +11348,11 @@ msgstr "Altres idiomes"
 msgid "Mozilla Add-ons"
 msgstr "Complements de Mozilla"
 
-#: src/olympia/templates/base.html:91 src/olympia/templates/impala/base.html:81
+#: src/olympia/templates/base.html:89 src/olympia/templates/impala/base.html:78
 msgid "Find add-ons for other applications"
 msgstr "Trobareu complements per a altres aplicacions"
 
-#: src/olympia/templates/base.html:92 src/olympia/templates/impala/base.html:81
+#: src/olympia/templates/base.html:90 src/olympia/templates/impala/base.html:78
 msgid "Other Applications"
 msgstr "Altres aplicacions"
 
@@ -11502,7 +11377,7 @@ msgid "View Mobile Site"
 msgstr "Vés al web per a Mòbils"
 
 #: src/olympia/templates/copyright.html:7
-msgid "Site Status "
+msgid "Site Status"
 msgstr ""
 
 #: src/olympia/templates/footer.html:3
@@ -11604,35 +11479,35 @@ msgstr "Benvingut, {0}"
 msgid "<a href=\"%(reg)s\">Register</a> or <a href=\"%(login)s\">Log in</a>"
 msgstr "<a href=\"%(reg)s\">Registreu-vos</a> o <a href=\"%(login)s\">inicieu una sessió</a>"
 
-#: src/olympia/templates/impala/base.html:126
+#: src/olympia/templates/impala/base.html:123
 #, python-format
 msgid "To try the thousands of add-ons available here, download <a href=\"%(url)s\">Mozilla Firefox</a>, a fast, free way to surf the Web!"
 msgstr "Per provar els milers de complements disponibles, baixeu el <a href=\"%(url)s\">Mozilla Firefox</a>, una manera ràpida i gratuïta de navegar per Internet!"
 
-#: src/olympia/templates/impala/base.html:138
+#: src/olympia/templates/impala/base.html:135
 #, python-format
 msgid "Add-ons is switching to Firefox Accounts for login. <a href=\"%(url)s\" class=\"fxa-login\">Sign in now to transfer your account.</a>"
 msgstr ""
 
 #. {0} is an application, such as Firefox.
-#: src/olympia/templates/impala/base.html:148
+#: src/olympia/templates/impala/base.html:145
 msgid "Welcome to {0} Add-ons."
 msgstr "Benvingut a complements de {0}."
 
-#: src/olympia/templates/impala/base.html:151
+#: src/olympia/templates/impala/base.html:148
 msgid "Choose from thousands of extra features and styles to make Firefox your own."
 msgstr ""
 
-#: src/olympia/templates/impala/base.html:156
+#: src/olympia/templates/impala/base.html:153
 #, python-format
 msgid "Add extra features and styles to make %(app)s your own."
 msgstr ""
 
-#: src/olympia/templates/impala/base.html:164
+#: src/olympia/templates/impala/base.html:161
 msgid "On the go?"
 msgstr ""
 
-#: src/olympia/templates/impala/base.html:166
+#: src/olympia/templates/impala/base.html:163
 msgid "Check out our <a class=\"mobile-link\" href=\"#\">Mobile Add-ons site</a>."
 msgstr "Consulteu el nostre web de <a class=\"mobile-link\" href=\"#\">complements per a dispositius mòbils</a>."
 
@@ -11856,19 +11731,19 @@ msgstr "No hi ha cap usuari amb una adreça de correu."
 
 #. L10n: {id} will be something like "13ad6a", just a random number
 #. to differentiate this user from other anonymous users.
-#: src/olympia/users/models.py:353
+#: src/olympia/users/models.py:362
 msgid "Anonymous user {id}"
 msgstr ""
 
-#: src/olympia/users/models.py:410
+#: src/olympia/users/models.py:419
 msgid "Your account has been restricted"
 msgstr ""
 
-#: src/olympia/users/models.py:480
+#: src/olympia/users/models.py:489
 msgid "Please confirm your email address"
 msgstr "Confirmeu la vostra adreça de correu"
 
-#: src/olympia/users/models.py:506
+#: src/olympia/users/models.py:515
 msgid "My Mobile Add-ons"
 msgstr "Els meus complements per a mòbils"
 
@@ -12150,7 +12025,7 @@ msgstr "Contrasenya"
 
 #: src/olympia/users/templates/users/edit.html:70
 #, python-format
-msgid "Change your password.  If you forgot your password, you can <a href=\"%(reset_url)s\">use the reset form</a>."
+msgid "Change your password. If you forgot your password, you can <a href=\"%(reset_url)s\">use the reset form</a>."
 msgstr ""
 
 #: src/olympia/users/templates/users/edit.html:76
@@ -12402,8 +12277,10 @@ msgid "Send password reset link"
 msgstr "Envia l'enllaç per a recuperar la contrasenya"
 
 #: src/olympia/users/templates/users/pwreset_sent.html:10
-msgid "An email has been sent to the requested account with further information. If you do not receive an email then please confirm you have entered the same email address used during account registration."
-msgstr "An email has been sent to the requested account with further information. If you do not receive an email then please confirm you have entered the same email address used during account registration."
+msgid ""
+"An email has been sent to the requested account with further information. If you do not receive an email then please confirm you have entered the same email address used during account registration."
+msgstr ""
+"An email has been sent to the requested account with further information. If you do not receive an email then please confirm you have entered the same email address used during account registration."
 
 #: src/olympia/users/templates/users/register.html:4
 msgid "New User Registration"
@@ -12575,7 +12452,7 @@ msgstr "No s'ha pogut eliminar la subspcripció"
 
 #: src/olympia/users/templates/users/unsubscribe.html:30
 #, python-format
-msgid "Unfortunately, we weren't able to unsubscribe you.  The link you clicked is invalid. However, you can unsubscribe still unsubscribe on your <a href=\"%(edit_url)s\">edit profile page</a>."
+msgid "Unfortunately, we weren't able to unsubscribe you. The link you clicked is invalid. However, you can unsubscribe still unsubscribe on your <a href=\"%(edit_url)s\">edit profile page</a>."
 msgstr ""
 
 #: src/olympia/users/templates/users/vcard.html:2
@@ -12629,15 +12506,15 @@ msgstr "Històric de versions del %s"
 msgid "Version History with Changelogs"
 msgstr "Historial de versions amb el registre de canvis"
 
-#: src/olympia/versions/models.py:314
+#: src/olympia/versions/models.py:313
 msgid "Add-on uses binary components."
 msgstr ""
 
-#: src/olympia/versions/models.py:317
+#: src/olympia/versions/models.py:316
 msgid "Add-on has opted into strict compatibility checking."
 msgstr ""
 
-#: src/olympia/versions/models.py:715
+#: src/olympia/versions/models.py:711
 msgid "{app} {min} and later"
 msgstr ""
 
@@ -12715,3 +12592,6 @@ msgstr "Envia un correu en finalitzar"
 msgid "Log emails instead of sending"
 msgstr ""
 
+#: src/olympia/zadmin/forms.py:215
+msgid "Deleted versions can`t be changed."
+msgstr ""

--- a/locale/ca/LC_MESSAGES/djangojs.po
+++ b/locale/ca/LC_MESSAGES/djangojs.po
@@ -1,1215 +1,1235 @@
-
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2016-02-24 21:23+0000\n"
+"POT-Creation-Date: 2016-04-18 15:47+0000\n"
 "PO-Revision-Date: 2012-06-22 09:07+0200\n"
 "Last-Translator: Toni <toniher@softcatala.org>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
+"Language: \n"
 "MIME-Version: 1.0\n"
-"Content-Type: text/plain; charset=utf-8\n"
+"Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Generated-By: Babel 2.2.0\n"
 
-#: static/js/common/ratingwidget.js:31
-msgid "{0} star"
-msgid_plural "{0} stars"
-msgstr[0] "{0} estrella"
-msgstr[1] "{0} estrelles"
-
-#: static/js/common/upload-addon.js:41 static/js/common/upload-image.js:128
-msgid "There was a problem contacting the server."
-msgstr "S'ha produït un problema en contactar amb el servidor."
-
-#: static/js/common/upload-addon.js:69
-msgid "Select a file..."
-msgstr "Seleccioneu un fitxer..."
-
-#: static/js/common/upload-addon.js:70
-msgid "Your add-on should end with .xpi, .jar or .xml"
-msgstr "El vostre complement ha d'acabar amb .xpi, .jar o .xml"
-
-#. L10n: {0} is the percent of the file that has been uploaded.
-#: static/js/common/upload-addon.js:104
-#, python-format
-msgid "{0}% complete"
-msgstr "{0}% completat"
-
-#. L10n: "{bytes uploaded} of {total filesize}".
-#: static/js/common/upload-addon.js:107
-msgid "{0} of {1}"
-msgstr "{0} de {1}"
-
-#: static/js/common/upload-addon.js:140
-msgid "Cancel"
-msgstr "Cancel·la"
-
-#: static/js/common/upload-addon.js:162
-msgid "Uploading {0}"
-msgstr "S'està pujant {0}"
-
-#: static/js/common/upload-addon.js:189
-msgid "Error with {0}"
-msgstr "Error amb {0}"
-
-#: static/js/common/upload-addon.js:194
-msgid "Your add-on failed validation with {0} error."
-msgid_plural "Your add-on failed validation with {0} errors."
-msgstr[0] "El vostre complement no ha passat la validació i ha generat {0} error."
-msgstr[1] "El vostre complement no ha passat la validació i ha generat {0} errors."
-
-#: static/js/common/upload-addon.js:208
-msgid "&hellip;and {0} more"
-msgid_plural "&hellip;and {0} more"
-msgstr[0] "&hellip;i {0} altres"
-msgstr[1] "&hellip;i {0} altres"
-
-#: static/js/common/upload-addon.js:222 static/js/common/upload-addon.js:512
-msgid "See full validation report"
-msgstr "Consulteu l'informe de validació complet"
-
-#: static/js/common/upload-addon.js:234
-msgid "Validating {0}"
-msgstr "S'està validant {0}"
-
-#. L10n: first argument is an HTTP status code
-#: static/js/common/upload-addon.js:273
-msgid "Received an empty response from the server; status: {0}"
-msgstr "S'ha rebut una resposta buida des del servidor; l'estat: {0}"
-
-#: static/js/common/upload-addon.js:373
-msgid "Unexpected server error while validating."
-msgstr "S'ha produït un error del servidor inesperat durant la validació."
-
-#: static/js/common/upload-addon.js:412
-msgid "Finished validating {0}"
-msgstr "Ha finalitzat la validació de {0}"
-
-#: static/js/common/upload-addon.js:418
-msgid "Your add-on validation timed out, it will be manually reviewed."
-msgstr ""
-
-#: static/js/common/upload-addon.js:421
-msgid "Your add-on was validated with no errors and {0} warning."
-msgid_plural "Your add-on was validated with no errors and {0} warnings."
-msgstr[0] ""
-msgstr[1] ""
-
-#: static/js/common/upload-addon.js:426
-msgid "Your add-on was validated with no errors and {0} message."
-msgid_plural "Your add-on was validated with no errors and {0} messages."
-msgstr[0] ""
-msgstr[1] ""
-
-#: static/js/common/upload-addon.js:431
-msgid "Your add-on was validated with no errors or warnings."
-msgstr ""
-
-#: static/js/common/upload-addon.js:446
-msgid "Your submission will be automatically signed."
-msgstr ""
-
-#: static/js/common/upload-addon.js:465
-msgid "Include detailed version notes (this can be done in the next step)."
-msgstr ""
-
-#: static/js/common/upload-addon.js:466
-msgid "If your add-on requires an account to a website in order to be fully tested, include a test username and password in the Notes to Reviewer (this can be done in the next step)."
-msgstr ""
-
-#: static/js/common/upload-addon.js:467
-msgid "If your add-on is intended for a limited audience you should choose Preliminary Review instead of Full Review."
-msgstr ""
-
-#: static/js/common/upload-addon.js:480
-msgid "Add-on submission checklist"
-msgstr ""
-
-#: static/js/common/upload-addon.js:481
-msgid "Please verify the following points before finalizing your submission. This will minimize delays or misunderstanding during the review process:"
-msgstr ""
-
-#: static/js/common/upload-addon.js:483
-msgid ""
-"Compiled binaries, as well as minified or obfuscated scripts (excluding known libraries) need to have their sources submitted separately for review. Make sure that you use the source code upload "
-"field to avoid having your submission rejected."
-msgstr ""
-
-#: static/js/common/upload-addon.js:501
-msgid "The validation process found these issues that can lead to rejections:"
-msgstr ""
-
-#: static/js/common/upload-addon.js:518
-msgid "If you are unfamiliar with the add-ons review process, you can read about it here."
-msgstr ""
-
-#: static/js/common/upload-addon.js:555
-msgid "Sorry, no supported platform has been found."
-msgstr ""
-
-#: static/js/common/upload-base.js:57
-msgid "The filetype you uploaded isn't recognized."
-msgstr "El tipus de fitxer que heu pujat no es pot reconèixer."
-
-#: static/js/common/upload-base.js:79
-msgid "You cancelled the upload."
-msgstr "Heu cancel·lat la pujada."
-
-#: static/js/common/upload-image.js:97 static/js/impala/users.js:51
-msgid "Images must be either PNG or JPG."
-msgstr "Les imatges han de ser PNG o JPG."
-
-#: static/js/common/upload-image.js:101
-msgid "Videos must be in WebM."
-msgstr ""
-
-#: static/js/impala/collections.js:10 static/js/zamboni/collections.js:595
-msgid "Follow this Collection"
-msgstr "Segueix aquesta col·lecció"
-
-#: static/js/impala/collections.js:19
-msgid "Stop Following"
-msgstr "Deixa de seguir"
-
-#: static/js/impala/collections.js:20
-msgid "Following"
-msgstr "S'està seguint"
-
-#. L10n: {0} is an app name.
-#: static/js/impala/listing.js:11 static/js/zamboni/themes.js:13
-msgid "This theme is incompatible with your version of {0}"
-msgstr "Aquest tema és incompatible amb la vostra versió de {0}"
-
-#: static/js/impala/persona_creation.js:60
-msgid "All Rights Reserved"
-msgstr "Tots els drets reservats"
-
-#: static/js/impala/persona_creation.js:64
-msgid "Creative Commons Attribution 3.0"
-msgstr "Creative Commons Reconeixement 3.0"
-
-#: static/js/impala/persona_creation.js:69
-msgid "Creative Commons Attribution-NonCommercial 3.0"
-msgstr "Creative Commons Reconeixement-NoComercial 3.0"
-
-#: static/js/impala/persona_creation.js:74
-msgid "Creative Commons Attribution-NonCommercial-NoDerivs 3.0"
-msgstr "Creative Commons Reconeixement-NoComercial-NoDerivats 3.0"
-
-#: static/js/impala/persona_creation.js:79
-msgid "Creative Commons Attribution-NonCommercial-Share Alike 3.0"
-msgstr "Creative Commons Reconeixement-NoComercial-CompartirIgual 3.0"
-
-#: static/js/impala/persona_creation.js:84
-msgid "Creative Commons Attribution-NoDerivs 3.0"
-msgstr "Creative Commons Reconeixement-NoDerivats 3.0"
-
-#: static/js/impala/persona_creation.js:89
-msgid "Creative Commons Attribution-ShareAlike 3.0"
-msgstr "Creative Commons Reconeixement-CompartirIgual 3.0"
-
-#: static/js/impala/persona_creation.js:292
-msgid "Your Theme's Name"
-msgstr ""
-
-#: static/js/impala/reviews.js:23 static/js/zamboni/reviews.js:18
-msgid "Flagged for review"
-msgstr "Marcat per revisar"
-
-#: static/js/impala/reviews.js:40 static/js/zamboni/reviews.js:34
-msgid "Your input is required"
-msgstr "Cal una entrada"
-
-#: static/js/impala/reviews.js:152 static/js/zamboni/reviews.js:103
-msgid "Marked for deletion"
-msgstr "Marcat per eliminar"
-
-#: static/js/impala/search.js:114
-msgid "Updating results&hellip;"
-msgstr "S'estan actualitzant els resultats&hellip;"
-
-#: static/js/impala/site_suggestions.js:46
-msgid "Category"
-msgstr "Categoria"
-
-#: static/js/impala/suggestions.js:39
-msgid "Search themes for <b>{0}</b>"
-msgstr ""
-
-#: static/js/impala/suggestions.js:41
-msgid "Search apps for <b>{0}</b>"
-msgstr "Cerca aplicacions que continguen <b>{0}</b>"
-
-#: static/js/impala/suggestions.js:43
-msgid "Search add-ons for <b>{0}</b>"
-msgstr "Cerca complements que continguen <b>{0}</b>"
-
-#: static/js/impala/users.js:33
-msgid "use original"
-msgstr "utilitza l'original"
-
-#: static/js/impala/stats/chart.js:267
-msgid "Week of {0}"
-msgstr "Setmana de {0}"
-
-#: static/js/impala/stats/chart.js:269
-msgid " downloads"
-msgstr ""
-
-#: static/js/impala/stats/chart.js:270
-msgid "{0} users"
-msgstr "{0} usuaris"
-
-#: static/js/impala/stats/chart.js:271
-msgid "{0} add-ons"
-msgstr "{0} complements"
-
-#: static/js/impala/stats/chart.js:272
-msgid "{0} collections"
-msgstr "{0} col·leccions"
-
-#: static/js/impala/stats/chart.js:273
-msgid "{0} reviews"
-msgstr "{0} valoracions"
-
-#: static/js/impala/stats/chart.js:275
-msgid "{0} sales"
-msgstr "{0} vendes"
-
-#: static/js/impala/stats/chart.js:276
-msgid "{0} refunds"
-msgstr "{0} reemborsaments"
-
-#: static/js/impala/stats/chart.js:277
-msgid "{0} installs"
-msgstr "{0} instal·lacions"
-
-#: static/js/impala/stats/chart.js:369 static/js/impala/stats/csv_keys.js:3 static/js/impala/stats/csv_keys.js:109
-msgid "Downloads"
-msgstr "Baixades"
-
-#: static/js/impala/stats/chart.js:379 static/js/impala/stats/csv_keys.js:6 static/js/impala/stats/csv_keys.js:110
-msgid "Daily Users"
-msgstr "Usuaris diaris"
-
-#: static/js/impala/stats/chart.js:410
-msgid "Amount, in USD"
-msgstr "Quantitat, en USD"
-
-#: static/js/impala/stats/chart.js:421 static/js/impala/stats/csv_keys.js:104
-msgid "Number of Contributions"
-msgstr "Nombre de contribucions"
-
-#: static/js/impala/stats/chart.js:447
-msgid "More Info..."
-msgstr "Més informació..."
-
-#. L10n: {0} is an ISO-formatted date.
-#: static/js/impala/stats/chart.js:451
-msgid "Details for {0}"
-msgstr "Detalls de {0}"
-
-#: static/js/impala/stats/csv_keys.js:9
-msgid "Collections Created"
-msgstr "Col·leccions creades"
-
-#: static/js/impala/stats/csv_keys.js:12
-msgid "Add-ons in Use"
-msgstr "Complements en ús"
-
-#: static/js/impala/stats/csv_keys.js:15
-msgid "Add-ons Created"
-msgstr "Complements creats"
-
-#: static/js/impala/stats/csv_keys.js:18
-msgid "Add-ons Downloaded"
-msgstr "Complements baixats"
-
-#: static/js/impala/stats/csv_keys.js:21
-msgid "Add-ons Updated"
-msgstr "Complements actualitzats"
-
-#: static/js/impala/stats/csv_keys.js:24
-msgid "Reviews Written"
-msgstr "Valoracions escrites"
-
-#: static/js/impala/stats/csv_keys.js:27
-msgid "User Signups"
-msgstr "Registres d'usuari"
-
-#: static/js/impala/stats/csv_keys.js:30
-msgid "Subscribers"
-msgstr "Subscriptors"
-
-#: static/js/impala/stats/csv_keys.js:33
-msgid "Ratings"
-msgstr "Puntuació"
-
-#: static/js/impala/stats/csv_keys.js:36 static/js/impala/stats/csv_keys.js:114
-msgid "Sales"
-msgstr "Vendes"
-
-#: static/js/impala/stats/csv_keys.js:39 static/js/impala/stats/csv_keys.js:113
-msgid "Installs"
-msgstr "Instal·lacions"
-
-#: static/js/impala/stats/csv_keys.js:42
-msgid "Unknown"
-msgstr "Desconegut"
-
-#: static/js/impala/stats/csv_keys.js:43
-msgid "Add-ons Manager"
-msgstr "Gestor de complements"
-
-#: static/js/impala/stats/csv_keys.js:44
-msgid "Add-ons Manager Promo"
-msgstr ""
-
-#: static/js/impala/stats/csv_keys.js:45
-msgid "Add-ons Manager Featured"
-msgstr ""
-
-#: static/js/impala/stats/csv_keys.js:46
-msgid "Add-ons Manager Learn More"
-msgstr ""
-
-#: static/js/impala/stats/csv_keys.js:47
-msgid "Search Suggestions"
-msgstr ""
-
-#: static/js/impala/stats/csv_keys.js:48
-msgid "Search Results"
-msgstr "Resultats de cerca"
-
-#: static/js/impala/stats/csv_keys.js:49 static/js/impala/stats/csv_keys.js:50 static/js/impala/stats/csv_keys.js:51
-msgid "Homepage Promo"
-msgstr "Promo de la pàgina principal"
-
-#: static/js/impala/stats/csv_keys.js:52 static/js/impala/stats/csv_keys.js:53
-msgid "Homepage Featured"
-msgstr "Destacat de la pàgina principal"
-
-#: static/js/impala/stats/csv_keys.js:54 static/js/impala/stats/csv_keys.js:55
-msgid "Homepage Up and Coming"
-msgstr "Recents a la pàgina principal"
-
-#: static/js/impala/stats/csv_keys.js:56
-msgid "Homepage Most Popular"
-msgstr "Els més populars a la pàgina principal"
-
-#: static/js/impala/stats/csv_keys.js:57 static/js/impala/stats/csv_keys.js:59
-msgid "Detail Page"
-msgstr "Pàgina de detalls"
-
-#: static/js/impala/stats/csv_keys.js:58 static/js/impala/stats/csv_keys.js:60
-msgid "Detail Page (bottom)"
-msgstr "Pàgina de detalls (avall)"
-
-#: static/js/impala/stats/csv_keys.js:61
-msgid "Detail Page (Development Channel)"
-msgstr "Pàgina de detalls (canal de desenvolupament)"
-
-#: static/js/impala/stats/csv_keys.js:62 static/js/impala/stats/csv_keys.js:63 static/js/impala/stats/csv_keys.js:64
-msgid "Often Used With"
-msgstr "S'utilitza sovint amb"
-
-#: static/js/impala/stats/csv_keys.js:65 static/js/impala/stats/csv_keys.js:66
-msgid "Others By Author"
-msgstr "Altres de l'autor"
-
-#: static/js/impala/stats/csv_keys.js:67 static/js/impala/stats/csv_keys.js:68
-msgid "Dependencies"
-msgstr "Dependències"
-
-#: static/js/impala/stats/csv_keys.js:69 static/js/impala/stats/csv_keys.js:70
-msgid "Upsell"
-msgstr "Promocions"
-
-#: static/js/impala/stats/csv_keys.js:71
-msgid "Meet the Developer"
-msgstr ""
-
-#: static/js/impala/stats/csv_keys.js:72
-msgid "User Profile"
-msgstr ""
-
-#: static/js/impala/stats/csv_keys.js:73
-msgid "Version History"
-msgstr ""
-
-#: static/js/impala/stats/csv_keys.js:75
-msgid "Sharing"
-msgstr "Compartint"
-
-#: static/js/impala/stats/csv_keys.js:76
-msgid "Category Pages"
-msgstr "Pàgines de categoria"
-
-#: static/js/impala/stats/csv_keys.js:77
-msgid "Collections"
-msgstr "Col·leccions"
-
-#: static/js/impala/stats/csv_keys.js:78 static/js/impala/stats/csv_keys.js:79
-msgid "Category Landing Featured Carousel"
-msgstr "Carrusel de destacats que arriben a la categoria"
-
-#: static/js/impala/stats/csv_keys.js:80 static/js/impala/stats/csv_keys.js:81
-msgid "Category Landing Top Rated"
-msgstr "Els més ben valorats que arriben a la categoria"
-
-#: static/js/impala/stats/csv_keys.js:82 static/js/impala/stats/csv_keys.js:83
-msgid "Category Landing Most Popular"
-msgstr "Els més populars que arriben a la categoria"
-
-#: static/js/impala/stats/csv_keys.js:84 static/js/impala/stats/csv_keys.js:85
-msgid "Category Landing Recently Added"
-msgstr "Els afegits més recentment que arriben a la categoria"
-
-#: static/js/impala/stats/csv_keys.js:86 static/js/impala/stats/csv_keys.js:87
-msgid "Browse Listing Featured Sort"
-msgstr "Navega la llista per destacats"
-
-#: static/js/impala/stats/csv_keys.js:88 static/js/impala/stats/csv_keys.js:89
-msgid "Browse Listing Users Sort"
-msgstr "Navega la llista per usuaris"
-
-#: static/js/impala/stats/csv_keys.js:90 static/js/impala/stats/csv_keys.js:91
-msgid "Browse Listing Rating Sort"
-msgstr "Navega la llista per més valorats"
-
-#: static/js/impala/stats/csv_keys.js:92 static/js/impala/stats/csv_keys.js:93
-msgid "Browse Listing Created Sort"
-msgstr "Navega la llista per data de creació"
-
-#: static/js/impala/stats/csv_keys.js:94 static/js/impala/stats/csv_keys.js:95
-msgid "Browse Listing Name Sort"
-msgstr "Navega la llista per nom"
-
-#: static/js/impala/stats/csv_keys.js:96 static/js/impala/stats/csv_keys.js:97
-msgid "Browse Listing Popular Sort"
-msgstr "Navega la llista per popularitat"
-
-#: static/js/impala/stats/csv_keys.js:98 static/js/impala/stats/csv_keys.js:99
-msgid "Browse Listing Updated Sort"
-msgstr "Navega la llista per més recents"
-
-#: static/js/impala/stats/csv_keys.js:100 static/js/impala/stats/csv_keys.js:101
-msgid "Browse Listing Up and Coming Sort"
-msgstr "Navega la llista per properes novetats"
-
-#: static/js/impala/stats/csv_keys.js:105
-msgid "Total Amount Contributed"
-msgstr "Quantitat total contribuïda"
-
-#: static/js/impala/stats/csv_keys.js:106
-msgid "Average Contribution"
-msgstr "Contribució mitja"
-
-#: static/js/impala/stats/csv_keys.js:115
-msgid "Usage"
-msgstr "Ús"
-
-#: static/js/impala/stats/csv_keys.js:118
-msgid "Firefox"
-msgstr "Firefox"
-
-#: static/js/impala/stats/csv_keys.js:119
-msgid "Mozilla"
-msgstr "Mozilla"
-
-#: static/js/impala/stats/csv_keys.js:120
-msgid "Thunderbird"
-msgstr "Thunderbird"
-
-#: static/js/impala/stats/csv_keys.js:121
-msgid "Sunbird"
-msgstr "Sunbird"
-
-#: static/js/impala/stats/csv_keys.js:122
-msgid "SeaMonkey"
-msgstr "SeaMonkey"
-
-#: static/js/impala/stats/csv_keys.js:123
-msgid "Fennec"
-msgstr "Fennec"
-
-#: static/js/impala/stats/csv_keys.js:124
-msgid "Android"
-msgstr ""
-
-#. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:129
-msgid "Downloads and Daily Users, last {0} days"
-msgstr "Baixades i usuaris diaris, darrers {0} dies"
-
-#. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:131
-msgid "Downloads and Daily Users from {0} to {1}"
-msgstr "Baixades i usuaris diaris des del {0} al {1}"
-
-#. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:135
-msgid "Installs and Daily Users, last {0} days"
-msgstr "Instal·lacions i usuaris diaris, darrers {0} dies"
-
-#. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:137
-msgid "Installs and Daily Users from {0} to {1}"
-msgstr "Instal·lacions i usuaris diaris entre el {0} i el {1}"
-
-#. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:141
-msgid "Downloads, last {0} days"
-msgstr "Baixades, darrers {0} dies"
-
-#. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:143
-msgid "Downloads from {0} to {1}"
-msgstr "Baixades des del {0} al {1}"
-
-#. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:147
-msgid "Daily Users, last {0} days"
-msgstr "Usuaris diaris, darrers {0} dies"
-
-#. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:149
-msgid "Daily Users from {0} to {1}"
-msgstr "Usuaris diaris des del {0} al {1}"
-
-#. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:153
-msgid "Applications, last {0} days"
-msgstr "Aplicacions, darrers {0} dies"
-
-#. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:155
-msgid "Applications from {0} to {1}"
-msgstr "Aplicacions del {0} a {1}"
-
-#. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:159
-msgid "Platforms, last {0} days"
-msgstr "Plataformes, darrers {0} dies"
-
-#. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:161
-msgid "Platforms from {0} to {1}"
-msgstr "Plataformes des del {0} al {1}"
-
-#. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:165
-msgid "Languages, last {0} days"
-msgstr "Llengües, darrers {0} dies"
-
-#. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:167
-msgid "Languages from {0} to {1}"
-msgstr "Llengües des del {0} al {1}"
-
-#. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:171
-msgid "Add-on Versions, last {0} days"
-msgstr "Versions del complement, els darrers {0} dies"
-
-#. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:173
-msgid "Add-on Versions from {0} to {1}"
-msgstr "Versions del complement des del {0} al {1}"
-
-#. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:177
-msgid "Add-on Status, last {0} days"
-msgstr "Estat del complement, darrers {0} dies"
-
-#. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:179
-msgid "Add-on Status from {0} to {1}"
-msgstr "Estat del complement des del {0} al {1}"
-
-#. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:183
-msgid "Download Sources, last {0} days"
-msgstr "Fonts de baixada, darrers {0} dies"
-
-#. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:185
-msgid "Download Sources from {0} to {1}"
-msgstr "Fonts de baixades des del {0} al {1}"
-
-#. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:189
-msgid "Contributions, last {0} days"
-msgstr "Contribucions, darrers {0} dies"
-
-#. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:191
-msgid "Contributions from {0} to {1}"
-msgstr "Contribucions des del {0} al {1}"
-
-#. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:195
-msgid "Site Metrics, last {0} days"
-msgstr "Dades de la pàgina, darrers {0} dies"
-
-#. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:197
-msgid "Site Metrics from {0} to {1}"
-msgstr "Dades de la pàgina del {0} al {1}"
-
-#. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:201
-msgid "Add-ons in Use, last {0} days"
-msgstr "Complements en ús els darrers {0} dies"
-
-#. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:203
-msgid "Add-ons in Use from {0} to {1}"
-msgstr "Complements en ús del {0} al {1}"
-
-#. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:207
-msgid "Add-ons Downloaded, last {0} days"
-msgstr "Complements baixats els darrers {0} dies"
-
-#. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:209
-msgid "Add-ons Downloaded from {0} to {1}"
-msgstr "Complements baixats del {0} al {1}"
-
-#. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:213
-msgid "Add-ons Created, last {0} days"
-msgstr "Complements creats els darrers {0} dies"
-
-#. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:215
-msgid "Add-ons Created from {0} to {1}"
-msgstr "Complements creats del {0} al {1}"
-
-#. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:219
-msgid "Add-ons Updated, last {0} days"
-msgstr "Complements actualitzats els darrers {0} dies"
-
-#. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:221
-msgid "Add-ons Updated from {0} to {1}"
-msgstr "Complements actualitzats del {0} al {1}"
-
-#. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:225
-msgid "Reviews Written, last {0} days"
-msgstr "Valoracions escrites els darrers {0} dies"
-
-#. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:227
-msgid "Reviews Written from {0} to {1}"
-msgstr "Valoracions escrites del {0} al {1}"
-
-#. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:231
-msgid "User Signups, last {0} days"
-msgstr "Registres d'usuari els darrers {0} dies"
-
-#. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:233
-msgid "User Signups from {0} to {1}"
-msgstr "Registres d'usuari del {0} al {1}"
-
-#. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:237
-msgid "Collections Created, last {0} days"
-msgstr "Col·leccions creades els darrers {0} dies"
-
-#. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:239
-msgid "Collections Created from {0} to {1}"
-msgstr "Col·leccions creades del {0} al {1}"
-
-#. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:243
-msgid "Subscribers, last {0} days"
-msgstr "Subscriptors els darrers {0} dies"
-
-#. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:245
-msgid "Subscribers from {0} to {1}"
-msgstr "Subscriptors del {0} al {1}"
-
-#. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:249
-msgid "Ratings, last {0} days"
-msgstr "Valoracions dels darrers {0} dies"
-
-#. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:251
-msgid "Ratings from {0} to {1}"
-msgstr "Valoracions del {0} al {1}"
-
-#. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:255
-msgid "Sales, last {0} days"
-msgstr "Vendes dels darrers {0} dies"
-
-#. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:257
-msgid "Sales from {0} to {1}"
-msgstr "Vendes del {0} al {1}"
-
-#. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:261
-msgid "Installs, last {0} days"
-msgstr "Instal·lacions dels darrers {0} dies"
-
-#. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:263
-msgid "Installs from {0} to {1}"
-msgstr "Instal·lacions del {0} al {1}"
-
-#. L10n: {0} and {1} are integers.
-#: static/js/impala/stats/csv_keys.js:269
-msgid "<b>{0}</b> in last {1} days"
-msgstr "<b>{0}</b> en els darrers {1} dies"
-
-#. L10n: {0} is an integer and {1} and {2} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:271 static/js/impala/stats/csv_keys.js:277
-msgid "<b>{0}</b> from {1} to {2}"
-msgstr "<b>{0}</b> des del {1} al {2}"
-
-#. L10n: {0} and {1} are integers.
-#: static/js/impala/stats/csv_keys.js:275
-msgid "<b>{0}</b> average in last {1} days"
-msgstr "<b>{0}</b> de mitjana en els darrers {1} dies"
-
-#: static/js/impala/stats/overview.js:19
-msgid "No data available."
-msgstr "No hi ha dades disponibles."
-
-#: static/js/impala/stats/table.js:74
-msgid "Date"
-msgstr "Data"
-
-#: static/js/impala/stats/topchart.js:96
-msgid "Other"
-msgstr "Altres"
-
-#: static/js/zamboni/admin_validation.js:24 static/js/zamboni/devhub.js:1229 static/js/zamboni/editors.js:295
-msgid "Select an application first"
-msgstr "Primer cal que seleccioneu una aplicació"
-
-#: static/js/zamboni/admin_validation.js:51
-msgid "Set {0} add-on to a max version of {1} and email the author."
-msgid_plural "Set {0} add-ons to a max version of {1} and email the authors."
-msgstr[0] "Defineix el complement {0} a la versió màxima de {1} i envia un missatge a l'autor."
-msgstr[1] "Defineix els complements {0} a la versió màxima de {1} i envia uns missatges als autors."
-
-#: static/js/zamboni/admin_validation.js:54
-msgid "Email author of {2} add-on which failed validation."
-msgid_plural "Email authors of {2} add-ons which failed validation."
-msgstr[0] ""
-msgstr[1] ""
+#: static/js/common-all.js:1426 static/js/impala-all.js:1511 static/js/zamboni/discovery-all.js:12598 static/js/zamboni/init.js:28 static/js/zamboni/mobile-all.js:14945
+msgid "This feature is temporarily disabled while we perform website maintenance. Please check back a little later."
+msgstr "Aquesta funció s'ha desactivat temporalment per a tasques de manteniment del lloc web. Torneu més tard."
 
 #. L10n: {0} is an app name like Firefox.
-#: static/js/zamboni/buttons.js:66
+#: static/js/common-all.js:1837 static/js/impala-all.js:1922 static/js/zamboni/buttons.js:73 static/js/zamboni/discovery-all.js:13108
 msgid "Accept and Install"
 msgstr "Accepta i instal·la"
 
-#: static/js/zamboni/buttons.js:66
+#: static/js/common-all.js:1837 static/js/impala-all.js:1922 static/js/zamboni/buttons.js:73 static/js/zamboni/discovery-all.js:13108
 msgid "Add to {0}"
 msgstr "Afegeix al {0}"
 
-#: static/js/zamboni/buttons.js:71
+#: static/js/common-all.js:1842 static/js/impala-all.js:1927 static/js/zamboni/buttons.js:78 static/js/zamboni/discovery-all.js:13113
 msgid "Download Now"
 msgstr "Baixa-ho ara"
 
-#: static/js/zamboni/buttons.js:112
+#: static/js/common-all.js:1883 static/js/impala-all.js:1968 static/js/zamboni/buttons.js:119 static/js/zamboni/discovery-all.js:13154
 msgid "Add-on has not been updated to support default-to-compatible."
 msgstr "El complement no ha estat actualitzat per acceptar la compatibilitat per defecte."
 
-#: static/js/zamboni/buttons.js:117
+#: static/js/common-all.js:1888 static/js/impala-all.js:1973 static/js/zamboni/buttons.js:124 static/js/zamboni/discovery-all.js:13159
 msgid "You need to be using Firefox 10.0 or higher."
 msgstr "Heu de fer servir el Firefox 10.0 o superior."
 
-#: static/js/zamboni/buttons.js:129
+#: static/js/common-all.js:1900 static/js/impala-all.js:1985 static/js/zamboni/buttons.js:136 static/js/zamboni/discovery-all.js:13171
 msgid "Mozilla has marked this version as incompatible with your Firefox version."
 msgstr "Mozilla ha marcat aquesta versió com a incompatible amb la vostra versió del Firefox."
 
 #. L10n: {0} is an platform like Windows or Linux.
-#: static/js/zamboni/buttons.js:210
+#: static/js/common-all.js:1981 static/js/impala-all.js:2066 static/js/zamboni/buttons.js:217 static/js/zamboni/discovery-all.js:13252
 msgid "Install for {0} anyway"
 msgstr "Instal·la al {0} de totes maneres"
 
-#: static/js/zamboni/buttons.js:210
+#: static/js/common-all.js:1981 static/js/impala-all.js:2066 static/js/zamboni/buttons.js:217 static/js/zamboni/discovery-all.js:13252
 msgid "Download for {0} anyway"
 msgstr "Baixa per al {0} de totes maneres"
 
-#: static/js/zamboni/buttons.js:267
+#: static/js/common-all.js:2038 static/js/impala-all.js:2123 static/js/zamboni/buttons.js:274 static/js/zamboni/discovery-all.js:13309
 msgid "Not available for your platform"
 msgstr "No està disponible per a la vostra plataforma"
 
 #. L10n: {0} is an app name, {1} is the app version.
-#: static/js/zamboni/buttons.js:278 static/js/zamboni/buttons.js:315
+#: static/js/common-all.js:2049 static/js/common-all.js:2086 static/js/impala-all.js:2134 static/js/impala-all.js:2171 static/js/zamboni/buttons.js:286 static/js/zamboni/buttons.js:324
+#: static/js/zamboni/discovery-all.js:13320 static/js/zamboni/discovery-all.js:13357
 msgid "Not available for {0} {1}"
 msgstr "No està disponible per al {0} {1}"
 
-#: static/js/zamboni/buttons.js:341
+#: static/js/common-all.js:2112 static/js/impala-all.js:2197 static/js/zamboni/buttons.js:351 static/js/zamboni/discovery-all.js:13383
 msgid "Works with {app} {min} - {max}"
 msgstr "Funciona amb {app} {min} - {max}"
 
-#: static/js/zamboni/buttons.js:343
+#: static/js/common-all.js:2114 static/js/impala-all.js:2199 static/js/zamboni/buttons.js:353 static/js/zamboni/discovery-all.js:13385
 msgid "View other versions"
 msgstr "Vegeu altres versions"
 
-#: static/js/zamboni/buttons.js:391
+#: static/js/common-all.js:2162 static/js/impala-all.js:2247 static/js/zamboni/buttons.js:401 static/js/zamboni/discovery-all.js:13433
 msgid "Only with Firefox — Get Firefox Now!"
 msgstr ""
 
-#: static/js/zamboni/buttons.js:507 static/js/zamboni/mobile/buttons.js:43
+#: static/js/common-all.js:2278 static/js/impala-all.js:2363 static/js/zamboni/buttons.js:517 static/js/zamboni/discovery-all.js:13549 static/js/zamboni/mobile-all.js:15177
+#: static/js/zamboni/mobile/buttons.js:43
 msgid "Sorry, you need a Mozilla-based browser (such as Firefox) to install a search plugin."
 msgstr "Ho sentim, necessiteu un navegador basat en Mozilla (com ara el Firefox) per instal·lar un connector de cerca."
 
-#: static/js/zamboni/collections.js:229
-msgid "Adding to Favorites&hellip;"
-msgstr "S'està afegint als preferits&hellip;"
-
-#: static/js/zamboni/collections.js:232
-msgid "Removing Favorite&hellip;"
-msgstr "S'estan eliminant el preferit&hellip;"
-
-#: static/js/zamboni/collections.js:235
-msgid "Add to Favorites"
-msgstr "Afegeix als preferits"
-
-#: static/js/zamboni/collections.js:238
-msgid "Remove from Favorites"
-msgstr "Suprimeix dels preferits"
-
-#: static/js/zamboni/collections.js:303
-msgid "Pending"
-msgstr "Pendent"
-
-#: static/js/zamboni/collections.js:304
-msgid "Add a comment"
-msgstr "Afegeix un comentari"
-
-#: static/js/zamboni/collections.js:304
-msgid "Comment"
-msgstr "Comentari"
-
-#: static/js/zamboni/collections.js:305
-msgid "Remove this add-on from the collection"
-msgstr "Suprimeix aquest complement de la col·lecció"
-
-#: static/js/zamboni/collections.js:305 static/js/zamboni/collections.js:334
-msgid "Remove"
-msgstr "Suprimeix"
-
-#: static/js/zamboni/collections.js:334
-msgid "Remove this user as a contributor"
-msgstr "Suprimeix aquest usuari dels col·laboradors"
-
-#: static/js/zamboni/collections.js:346
-msgid "An email address is required."
-msgstr "Cal una adreça electrònica."
-
-#: static/js/zamboni/collections.js:364
-msgid "You cannot add yourself as a contributor."
-msgstr "No es pot afegir un mateix com a col·laborador."
-
-#: static/js/zamboni/collections.js:366
-msgid "You have already added that user."
-msgstr "Ja heu afegit aquest usuari."
-
-#: static/js/zamboni/collections.js:573
-msgid "Add to favorites"
-msgstr "Afegeix als preferits"
-
-#: static/js/zamboni/collections.js:577
-msgid "Remove from favorites"
-msgstr "Suprimeix dels preferits"
-
-#: static/js/zamboni/collections.js:604
-msgid "Stop following"
-msgstr "Deixa de seguir"
-
-#: static/js/zamboni/devhub.js:110
-msgid "Your browser does not support the video tag"
-msgstr "El vostre navegador no admet l'etiqueta de vídeo"
-
-#: static/js/zamboni/devhub.js:371
-msgid "Changes Saved"
-msgstr "S'han desat els canvis"
-
-#: static/js/zamboni/devhub.js:387
-msgid "Enter a new author's email address"
-msgstr "Introduïu una nova adreça electrònica d'autor"
-
-#: static/js/zamboni/devhub.js:536
-msgid "There was an error uploading your file."
-msgstr "S'ha produït un error en pujar el fitxer."
-
-#: static/js/zamboni/devhub.js:681
-msgid "{files} file"
-msgid_plural "{files} files"
-msgstr[0] "{files} fitxer"
-msgstr[1] "{files} fitxers"
-
-#: static/js/zamboni/devhub.js:684
-msgid "{reviews} user review"
-msgid_plural "{reviews} user reviews"
-msgstr[0] ""
-msgstr[1] ""
-
-#: static/js/zamboni/devhub.js:796
-msgid "Learn more"
-msgstr "Més informació"
-
-#: static/js/zamboni/devhub.js:800
-msgid "Example"
-msgstr "Exemple"
-
-#: static/js/zamboni/devhub.js:1130
-msgid "Image changes being processed"
-msgstr "S'estan processant els canvis a la imatge"
-
-#: static/js/zamboni/devhub.js:1280
-msgid "Must be a valid e-mail address."
-msgstr "Cal que sigui una adreça electrònica vàlida."
-
-#: static/js/zamboni/devhub_search.js:8
-msgid "No results found."
-msgstr "No s'ha trobat cap resultat."
-
-#: static/js/zamboni/editors.js:121
-msgid "{name} was viewing this page first."
-msgstr "{name} ha visitat aquesta pàgina per primer cop."
-
-#: static/js/zamboni/editors.js:171
-msgid "Receipt checked by app."
-msgstr "L'aplicació ha revisat el rebut."
-
-#: static/js/zamboni/editors.js:173
-msgid "Receipt was not checked by app."
-msgstr "L'aplicació no ha revisat el rebut."
-
-#: static/js/zamboni/editors.js:244
-msgid "{name} was viewing this add-on first."
-msgstr "{name} estava mirant aquest complement primer."
-
-#: static/js/zamboni/editors.js:255
-msgid "Loading&hellip;"
-msgstr "S'està carregant&hellip;"
-
-#: static/js/zamboni/editors.js:260
-msgid "Version Notes"
-msgstr "Notes de la versió"
-
-#: static/js/zamboni/editors.js:265
-msgid "Notes for Reviewers"
-msgstr "Notes per als revisors"
-
-#: static/js/zamboni/editors.js:270
-msgid "No version notes found"
-msgstr "No s'han trobat les notes de la versió"
-
-#: static/js/zamboni/editors.js:330
-msgid "Average Reviews"
-msgstr ""
-
-#: static/js/zamboni/editors.js:386
-msgid "Number of Reviews"
-msgstr ""
-
-#: static/js/zamboni/editors.js:445
-msgid "Error loading translation"
-msgstr ""
-
-#: static/js/zamboni/files.js:411 static/js/zamboni/validator.js:261
-msgid "Ignore this message in future updates"
-msgstr ""
-
-#: static/js/zamboni/files.js:417 static/js/zamboni/validator.js:284
-msgid "Severity for automated signing:"
-msgstr ""
-
-#: static/js/zamboni/global.js:410
+#: static/js/common-all.js:9088 static/js/impala-all.js:9649 static/js/zamboni/global.js:410
 msgid "Loading..."
 msgstr "S'està carregant..."
 
 #. L10n: {0} is the number of characters left.
-#: static/js/zamboni/global.js:474
+#: static/js/common-all.js:9152 static/js/impala-all.js:9713 static/js/zamboni/global.js:474
 msgid "<b>{0}</b> character left."
 msgid_plural "<b>{0}</b> characters left."
 msgstr[0] "<b>{0}</b> caràcter restant."
 msgstr[1] "<b>{0}</b> caràcters restants."
 
-#: static/js/zamboni/init.js:28
-msgid "This feature is temporarily disabled while we perform website maintenance. Please check back a little later."
-msgstr "Aquesta funció s'ha desactivat temporalment per a tasques de manteniment del lloc web. Torneu més tard."
+#: static/js/common-all.js:9589 static/js/common-min.js:6 static/js/impala-all.js:10052 static/js/impala-min.js:6 static/js/common/ratingwidget.js:31 static/js/zamboni/mobile-all.js:16123
+#: static/js/zamboni/mobile-min.js:6
+msgid "{0} star"
+msgid_plural "{0} stars"
+msgstr[0] "{0} estrella"
+msgstr[1] "{0} estrelles"
 
-#: static/js/zamboni/l10n.js:45
+#: static/js/common-all.js:9676 static/js/common-min.js:6 static/js/impala-all.js:10139 static/js/impala-min.js:6 static/js/zamboni/l10n.js:45
 msgid "Remove this localization"
 msgstr "Retira aquesta localització"
 
-#: static/js/zamboni/password-strength.js:20
+#: static/js/common-all.js:10193 static/js/common-min.js:6 static/js/impala-all.js:10674 static/js/impala-min.js:6 static/js/zamboni/discovery-all.js:13678
+msgid "close"
+msgstr ""
+
+#: static/js/common-all.js:10860 static/js/common-min.js:6 static/js/impala-all.js:11481 static/js/impala-min.js:6 static/js/impala/reviews.js:23 static/js/zamboni/reviews.js:18
+msgid "Flagged for review"
+msgstr "Marcat per revisar"
+
+#: static/js/common-all.js:10876 static/js/common-min.js:6 static/js/impala-all.js:11498 static/js/impala-min.js:6 static/js/impala/reviews.js:40 static/js/zamboni/reviews.js:34
+msgid "Your input is required"
+msgstr "Cal una entrada"
+
+#: static/js/common-all.js:10945 static/js/common-min.js:6 static/js/impala-all.js:11610 static/js/impala-min.js:7 static/js/impala/reviews.js:152 static/js/zamboni/reviews.js:103
+msgid "Marked for deletion"
+msgstr "Marcat per eliminar"
+
+#: static/js/common-all.js:11573 static/js/common-min.js:7 static/js/impala-all.js:13809 static/js/impala-min.js:8 static/js/zamboni/collections.js:229
+msgid "Adding to Favorites&hellip;"
+msgstr "S'està afegint als preferits&hellip;"
+
+#: static/js/common-all.js:11576 static/js/common-min.js:7 static/js/impala-all.js:13812 static/js/impala-min.js:8 static/js/zamboni/collections.js:232
+msgid "Removing Favorite&hellip;"
+msgstr "S'estan eliminant el preferit&hellip;"
+
+#: static/js/common-all.js:11579 static/js/common-min.js:7 static/js/impala-all.js:13815 static/js/impala-min.js:8 static/js/zamboni/collections.js:235
+msgid "Add to Favorites"
+msgstr "Afegeix als preferits"
+
+#: static/js/common-all.js:11582 static/js/common-min.js:7 static/js/impala-all.js:13818 static/js/impala-min.js:8 static/js/zamboni/collections.js:238
+msgid "Remove from Favorites"
+msgstr "Suprimeix dels preferits"
+
+#: static/js/common-all.js:11647 static/js/common-min.js:7 static/js/impala-all.js:13883 static/js/impala-min.js:8 static/js/zamboni/collections.js:303
+msgid "Pending"
+msgstr "Pendent"
+
+#: static/js/common-all.js:11648 static/js/common-min.js:7 static/js/impala-all.js:13884 static/js/impala-min.js:8 static/js/zamboni/collections.js:304
+msgid "Add a comment"
+msgstr "Afegeix un comentari"
+
+#: static/js/common-all.js:11648 static/js/common-min.js:7 static/js/impala-all.js:13884 static/js/impala-min.js:8 static/js/zamboni/collections.js:304
+msgid "Comment"
+msgstr "Comentari"
+
+#: static/js/common-all.js:11649 static/js/common-min.js:7 static/js/impala-all.js:13885 static/js/impala-min.js:8 static/js/zamboni/collections.js:305
+msgid "Remove this add-on from the collection"
+msgstr "Suprimeix aquest complement de la col·lecció"
+
+#: static/js/common-all.js:11649 static/js/common-all.js:11678 static/js/common-min.js:7 static/js/impala-all.js:13885 static/js/impala-all.js:13914 static/js/impala-min.js:8
+#: static/js/zamboni/collections.js:305 static/js/zamboni/collections.js:334
+msgid "Remove"
+msgstr "Suprimeix"
+
+#: static/js/common-all.js:11678 static/js/common-min.js:7 static/js/impala-all.js:13914 static/js/impala-min.js:8 static/js/zamboni/collections.js:334
+msgid "Remove this user as a contributor"
+msgstr "Suprimeix aquest usuari dels col·laboradors"
+
+#: static/js/common-all.js:11690 static/js/common-min.js:7 static/js/impala-all.js:13926 static/js/impala-min.js:8 static/js/zamboni/collections.js:346
+msgid "An email address is required."
+msgstr "Cal una adreça electrònica."
+
+#: static/js/common-all.js:11708 static/js/common-min.js:7 static/js/impala-all.js:13944 static/js/impala-min.js:8 static/js/zamboni/collections.js:364
+msgid "You cannot add yourself as a contributor."
+msgstr "No es pot afegir un mateix com a col·laborador."
+
+#: static/js/common-all.js:11710 static/js/common-min.js:7 static/js/impala-all.js:13946 static/js/impala-min.js:8 static/js/zamboni/collections.js:366
+msgid "You have already added that user."
+msgstr "Ja heu afegit aquest usuari."
+
+#: static/js/common-all.js:11917 static/js/common-min.js:7 static/js/impala-all.js:14153 static/js/impala-min.js:8 static/js/zamboni/collections.js:573
+msgid "Add to favorites"
+msgstr "Afegeix als preferits"
+
+#: static/js/common-all.js:11921 static/js/common-min.js:7 static/js/impala-all.js:14157 static/js/impala-min.js:8 static/js/zamboni/collections.js:577
+msgid "Remove from favorites"
+msgstr "Suprimeix dels preferits"
+
+#: static/js/common-all.js:11939 static/js/common-min.js:7 static/js/impala-all.js:14175 static/js/impala-all.js:14233 static/js/impala-min.js:8 static/js/impala/collections.js:10
+#: static/js/zamboni/collections.js:595
+msgid "Follow this Collection"
+msgstr "Segueix aquesta col·lecció"
+
+#: static/js/common-all.js:11948 static/js/common-min.js:7 static/js/impala-all.js:14184 static/js/impala-min.js:8 static/js/zamboni/collections.js:604
+msgid "Stop following"
+msgstr "Deixa de seguir"
+
+#: static/js/common-all.js:12096 static/js/common-min.js:7 static/js/zamboni/password-strength.js:20
 msgid "Password strength:"
 msgstr "Seguretat de la contrasenya:"
 
-#: static/js/zamboni/password-strength.js:26
+#: static/js/common-all.js:12102 static/js/common-min.js:7 static/js/zamboni/password-strength.js:26
 msgid "At least {0} character left."
 msgid_plural "At least {0} characters left."
 msgstr[0] "Falta almenys {0} caràcter."
 msgstr[1] "Falten almenys {0} caràcters."
 
-#: static/js/zamboni/themes_review.js:176
-msgid "Requested Info"
+#: static/js/common-all.js:12286 static/js/common-min.js:7 static/js/impala-all.js:14632 static/js/impala-min.js:8 static/js/impala/suggestions.js:39
+msgid "Search themes for <b>{0}</b>"
 msgstr ""
 
-#: static/js/zamboni/themes_review.js:177
-msgid "Flagged"
+#: static/js/common-all.js:12288 static/js/common-min.js:7 static/js/impala-all.js:14634 static/js/impala-min.js:8 static/js/impala/suggestions.js:41
+msgid "Search apps for <b>{0}</b>"
+msgstr "Cerca aplicacions que continguen <b>{0}</b>"
+
+#: static/js/common-all.js:12290 static/js/common-min.js:7 static/js/impala-all.js:14636 static/js/impala-min.js:8 static/js/impala/suggestions.js:43
+msgid "Search add-ons for <b>{0}</b>"
+msgstr "Cerca complements que continguen <b>{0}</b>"
+
+#: static/js/common-all.js:12521 static/js/common-min.js:7 static/js/impala-all.js:14867 static/js/impala-min.js:8 static/js/impala/site_suggestions.js:46
+msgid "Category"
+msgstr "Categoria"
+
+#. L10n: {0} is an app name.
+#: static/js/impala-all.js:11632 static/js/impala-min.js:7 static/js/impala/listing.js:11 static/js/zamboni/themes.js:13
+msgid "This theme is incompatible with your version of {0}"
+msgstr "Aquest tema és incompatible amb la vostra versió de {0}"
+
+#: static/js/impala-all.js:12146 static/js/impala-all.js:14331 static/js/impala-min.js:7 static/js/impala-min.js:8 static/js/common/upload-image.js:97 static/js/impala/users.js:51
+#: static/js/zamboni/devhub-all.js:894 static/js/zamboni/devhub-min.js:1
+msgid "Images must be either PNG or JPG."
+msgstr "Les imatges han de ser PNG o JPG."
+
+#: static/js/impala-all.js:12150 static/js/impala-min.js:7 static/js/common/upload-image.js:101 static/js/zamboni/devhub-all.js:898 static/js/zamboni/devhub-min.js:1
+msgid "Videos must be in WebM."
 msgstr ""
 
-#: static/js/zamboni/themes_review.js:178
-msgid "Duplicate"
+#: static/js/impala-all.js:12177 static/js/impala-min.js:7 static/js/common/upload-addon.js:41 static/js/common/upload-image.js:128 static/js/zamboni/devhub-all.js:272
+#: static/js/zamboni/devhub-all.js:925 static/js/zamboni/devhub-min.js:1
+msgid "There was a problem contacting the server."
+msgstr "S'ha produït un problema en contactar amb el servidor."
+
+#: static/js/impala-all.js:13298 static/js/impala-min.js:7 static/js/impala/persona_creation.js:60
+msgid "All Rights Reserved"
+msgstr "Tots els drets reservats"
+
+#: static/js/impala-all.js:13302 static/js/impala-min.js:7 static/js/impala/persona_creation.js:64
+msgid "Creative Commons Attribution 3.0"
+msgstr "Creative Commons Reconeixement 3.0"
+
+#: static/js/impala-all.js:13307 static/js/impala-min.js:7 static/js/impala/persona_creation.js:69
+msgid "Creative Commons Attribution-NonCommercial 3.0"
+msgstr "Creative Commons Reconeixement-NoComercial 3.0"
+
+#: static/js/impala-all.js:13312 static/js/impala-min.js:7 static/js/impala/persona_creation.js:74
+msgid "Creative Commons Attribution-NonCommercial-NoDerivs 3.0"
+msgstr "Creative Commons Reconeixement-NoComercial-NoDerivats 3.0"
+
+#: static/js/impala-all.js:13317 static/js/impala-min.js:7 static/js/impala/persona_creation.js:79
+msgid "Creative Commons Attribution-NonCommercial-Share Alike 3.0"
+msgstr "Creative Commons Reconeixement-NoComercial-CompartirIgual 3.0"
+
+#: static/js/impala-all.js:13322 static/js/impala-min.js:7 static/js/impala/persona_creation.js:84
+msgid "Creative Commons Attribution-NoDerivs 3.0"
+msgstr "Creative Commons Reconeixement-NoDerivats 3.0"
+
+#: static/js/impala-all.js:13327 static/js/impala-min.js:7 static/js/impala/persona_creation.js:89
+msgid "Creative Commons Attribution-ShareAlike 3.0"
+msgstr "Creative Commons Reconeixement-CompartirIgual 3.0"
+
+#: static/js/impala-all.js:13530 static/js/impala-min.js:7 static/js/impala/persona_creation.js:292
+msgid "Your Theme's Name"
 msgstr ""
 
-#: static/js/zamboni/themes_review.js:179
-msgid "Rejected"
+#: static/js/impala-all.js:14242 static/js/impala-min.js:8 static/js/impala/collections.js:19
+msgid "Stop Following"
+msgstr "Deixa de seguir"
+
+#: static/js/impala-all.js:14243 static/js/impala-min.js:8 static/js/impala/collections.js:20
+msgid "Following"
+msgstr "S'està seguint"
+
+#: static/js/impala-all.js:14313 static/js/impala-min.js:8 static/js/impala/users.js:33
+msgid "use original"
+msgstr "utilitza l'original"
+
+#: static/js/impala-all.js:14523 static/js/impala-min.js:8 static/js/impala/search.js:114
+msgid "Updating results&hellip;"
+msgstr "S'estan actualitzant els resultats&hellip;"
+
+#: static/js/common/upload-addon.js:69 static/js/zamboni/devhub-all.js:300 static/js/zamboni/devhub-min.js:1
+msgid "Select a file..."
+msgstr "Seleccioneu un fitxer..."
+
+#: static/js/common/upload-addon.js:70 static/js/zamboni/devhub-all.js:301 static/js/zamboni/devhub-min.js:1
+msgid "Your add-on should end with .xpi, .jar or .xml"
+msgstr "El vostre complement ha d'acabar amb .xpi, .jar o .xml"
+
+#. L10n: {0} is the percent of the file that has been uploaded.
+#: static/js/common/upload-addon.js:104 static/js/zamboni/devhub-all.js:335 static/js/zamboni/devhub-min.js:1
+#, python-format
+msgid "{0}% complete"
+msgstr "{0}% completat"
+
+#. L10n: "{bytes uploaded} of {total filesize}".
+#: static/js/common/upload-addon.js:107 static/js/zamboni/devhub-all.js:338 static/js/zamboni/devhub-min.js:1
+msgid "{0} of {1}"
+msgstr "{0} de {1}"
+
+#: static/js/common/upload-addon.js:140 static/js/zamboni/devhub-all.js:371 static/js/zamboni/devhub-min.js:1
+msgid "Cancel"
+msgstr "Cancel·la"
+
+#: static/js/common/upload-addon.js:162 static/js/zamboni/devhub-all.js:393 static/js/zamboni/devhub-min.js:1
+msgid "Uploading {0}"
+msgstr "S'està pujant {0}"
+
+#: static/js/common/upload-addon.js:189 static/js/zamboni/devhub-all.js:420 static/js/zamboni/devhub-min.js:1
+msgid "Error with {0}"
+msgstr "Error amb {0}"
+
+#: static/js/common/upload-addon.js:194 static/js/zamboni/devhub-all.js:425 static/js/zamboni/devhub-min.js:1
+msgid "Your add-on failed validation with {0} error."
+msgid_plural "Your add-on failed validation with {0} errors."
+msgstr[0] "El vostre complement no ha passat la validació i ha generat {0} error."
+msgstr[1] "El vostre complement no ha passat la validació i ha generat {0} errors."
+
+#: static/js/common/upload-addon.js:208 static/js/zamboni/devhub-all.js:439 static/js/zamboni/devhub-min.js:1
+msgid "&hellip;and {0} more"
+msgid_plural "&hellip;and {0} more"
+msgstr[0] "&hellip;i {0} altres"
+msgstr[1] "&hellip;i {0} altres"
+
+#: static/js/common/upload-addon.js:222 static/js/common/upload-addon.js:497 static/js/zamboni/devhub-all.js:453 static/js/zamboni/devhub-all.js:743 static/js/zamboni/devhub-min.js:1
+msgid "See full validation report"
+msgstr "Consulteu l'informe de validació complet"
+
+#: static/js/common/upload-addon.js:234 static/js/zamboni/devhub-all.js:465 static/js/zamboni/devhub-min.js:1
+msgid "Validating {0}"
+msgstr "S'està validant {0}"
+
+#. L10n: first argument is an HTTP status code
+#: static/js/common/upload-addon.js:273 static/js/zamboni/devhub-all.js:504 static/js/zamboni/devhub-min.js:1
+msgid "Received an empty response from the server; status: {0}"
+msgstr "S'ha rebut una resposta buida des del servidor; l'estat: {0}"
+
+#: static/js/common/upload-addon.js:370 static/js/zamboni/devhub-all.js:604 static/js/zamboni/devhub-min.js:1
+msgid "Unexpected server error while validating."
+msgstr "S'ha produït un error del servidor inesperat durant la validació."
+
+#: static/js/common/upload-addon.js:409 static/js/zamboni/devhub-all.js:643 static/js/zamboni/devhub-min.js:1
+msgid "Finished validating {0}"
+msgstr "Ha finalitzat la validació de {0}"
+
+#: static/js/common/upload-addon.js:415 static/js/zamboni/devhub-all.js:649 static/js/zamboni/devhub-min.js:1
+msgid "Your add-on validation timed out, it will be manually reviewed."
 msgstr ""
 
-#: static/js/zamboni/themes_review.js:180
-msgid "Approved"
+#: static/js/common/upload-addon.js:418 static/js/zamboni/devhub-all.js:652 static/js/zamboni/devhub-min.js:1
+msgid "Your add-on was validated with no errors and {0} warning."
+msgid_plural "Your add-on was validated with no errors and {0} warnings."
+msgstr[0] ""
+msgstr[1] ""
+
+#: static/js/common/upload-addon.js:423 static/js/zamboni/devhub-all.js:657 static/js/zamboni/devhub-min.js:1
+msgid "Your add-on was validated with no errors and {0} message."
+msgid_plural "Your add-on was validated with no errors and {0} messages."
+msgstr[0] ""
+msgstr[1] ""
+
+#: static/js/common/upload-addon.js:428 static/js/zamboni/devhub-all.js:662 static/js/zamboni/devhub-min.js:1
+msgid "Your add-on was validated with no errors or warnings."
 msgstr ""
 
-#: static/js/zamboni/themes_review.js:424
-msgid "No results found"
+#: static/js/common/upload-addon.js:443 static/js/zamboni/devhub-all.js:677 static/js/zamboni/devhub-min.js:1
+msgid "Your submission will be automatically signed."
 msgstr ""
 
-#: static/js/zamboni/themes_review_templates.js:31
-msgid "Theme"
+#: static/js/common/upload-addon.js:450 static/js/zamboni/devhub-all.js:696 static/js/zamboni/devhub-min.js:1
+msgid "Include detailed version notes (this can be done in the next step)."
 msgstr ""
 
-#: static/js/zamboni/themes_review_templates.js:33
-msgid "Reviewer"
+#: static/js/common/upload-addon.js:451 static/js/zamboni/devhub-all.js:697 static/js/zamboni/devhub-min.js:1
+msgid "If your add-on requires an account to a website in order to be fully tested, include a test username and password in the Notes to Reviewer (this can be done in the next step)."
 msgstr ""
 
-#: static/js/zamboni/themes_review_templates.js:35
-msgid "Status"
+#: static/js/common/upload-addon.js:452 static/js/zamboni/devhub-all.js:698 static/js/zamboni/devhub-min.js:1
+msgid "If your add-on is intended for a limited audience you should choose Preliminary Review instead of Full Review."
 msgstr ""
 
-#: static/js/zamboni/validator.js:80
+#: static/js/common/upload-addon.js:465 static/js/zamboni/devhub-all.js:711 static/js/zamboni/devhub-min.js:1
+msgid "Add-on submission checklist"
+msgstr ""
+
+#: static/js/common/upload-addon.js:466 static/js/zamboni/devhub-all.js:712 static/js/zamboni/devhub-min.js:1
+msgid "Please verify the following points before finalizing your submission. This will minimize delays or misunderstanding during the review process:"
+msgstr ""
+
+#: static/js/common/upload-addon.js:468 static/js/zamboni/devhub-all.js:714 static/js/zamboni/devhub-min.js:1
+msgid ""
+"Compiled binaries, as well as minified or obfuscated scripts (excluding known libraries) need to have their sources submitted separately for review. Make sure that you use the source code upload "
+"field to avoid having your submission rejected."
+msgstr ""
+
+#: static/js/common/upload-addon.js:486 static/js/zamboni/devhub-all.js:732 static/js/zamboni/devhub-min.js:1
+msgid "The validation process found these issues that can lead to rejections:"
+msgstr ""
+
+#: static/js/common/upload-addon.js:503 static/js/zamboni/devhub-all.js:749 static/js/zamboni/devhub-min.js:1
+msgid "If you are unfamiliar with the add-ons review process, you can read about it here."
+msgstr ""
+
+#: static/js/common/upload-addon.js:540 static/js/zamboni/devhub-all.js:786 static/js/zamboni/devhub-min.js:1
+msgid "Sorry, no supported platform has been found."
+msgstr ""
+
+#: static/js/common/upload-base.js:57 static/js/zamboni/devhub-all.js:187 static/js/zamboni/devhub-min.js:1
+msgid "The filetype you uploaded isn't recognized."
+msgstr "El tipus de fitxer que heu pujat no es pot reconèixer."
+
+#: static/js/common/upload-base.js:79 static/js/zamboni/devhub-all.js:209 static/js/zamboni/devhub-min.js:1
+msgid "You cancelled the upload."
+msgstr "Heu cancel·lat la pujada."
+
+#: static/js/impala/stats/chart.js:267 static/js/zamboni/stats-all.js:16898 static/js/zamboni/stats-min.js:5
+msgid "Week of {0}"
+msgstr "Setmana de {0}"
+
+#: static/js/impala/stats/chart.js:269 static/js/zamboni/stats-all.js:16900 static/js/zamboni/stats-min.js:5
+msgid " downloads"
+msgstr ""
+
+#: static/js/impala/stats/chart.js:270 static/js/zamboni/stats-all.js:16901 static/js/zamboni/stats-min.js:5
+msgid "{0} users"
+msgstr "{0} usuaris"
+
+#: static/js/impala/stats/chart.js:271 static/js/zamboni/stats-all.js:16902 static/js/zamboni/stats-min.js:5
+msgid "{0} add-ons"
+msgstr "{0} complements"
+
+#: static/js/impala/stats/chart.js:272 static/js/zamboni/stats-all.js:16903 static/js/zamboni/stats-min.js:5
+msgid "{0} collections"
+msgstr "{0} col·leccions"
+
+#: static/js/impala/stats/chart.js:273 static/js/zamboni/stats-all.js:16904 static/js/zamboni/stats-min.js:5
+msgid "{0} reviews"
+msgstr "{0} valoracions"
+
+#: static/js/impala/stats/chart.js:275 static/js/zamboni/stats-all.js:16906 static/js/zamboni/stats-min.js:5
+msgid "{0} sales"
+msgstr "{0} vendes"
+
+#: static/js/impala/stats/chart.js:276 static/js/zamboni/stats-all.js:16907 static/js/zamboni/stats-min.js:5
+msgid "{0} refunds"
+msgstr "{0} reemborsaments"
+
+#: static/js/impala/stats/chart.js:277 static/js/zamboni/stats-all.js:16908 static/js/zamboni/stats-min.js:5
+msgid "{0} installs"
+msgstr "{0} instal·lacions"
+
+#: static/js/impala/stats/chart.js:369 static/js/impala/stats/csv_keys.js:3 static/js/impala/stats/csv_keys.js:109 static/js/zamboni/stats-all.js:15284 static/js/zamboni/stats-all.js:15390
+#: static/js/zamboni/stats-all.js:17000 static/js/zamboni/stats-min.js:4 static/js/zamboni/stats-min.js:5
+msgid "Downloads"
+msgstr "Baixades"
+
+#: static/js/impala/stats/chart.js:379 static/js/impala/stats/csv_keys.js:6 static/js/impala/stats/csv_keys.js:110 static/js/zamboni/stats-all.js:15287 static/js/zamboni/stats-all.js:15391
+#: static/js/zamboni/stats-all.js:17010 static/js/zamboni/stats-min.js:4 static/js/zamboni/stats-min.js:5
+msgid "Daily Users"
+msgstr "Usuaris diaris"
+
+#: static/js/impala/stats/chart.js:410 static/js/zamboni/stats-all.js:17041 static/js/zamboni/stats-min.js:5
+msgid "Amount, in USD"
+msgstr "Quantitat, en USD"
+
+#: static/js/impala/stats/chart.js:421 static/js/impala/stats/csv_keys.js:104 static/js/zamboni/stats-all.js:15385 static/js/zamboni/stats-all.js:17052 static/js/zamboni/stats-min.js:5
+msgid "Number of Contributions"
+msgstr "Nombre de contribucions"
+
+#: static/js/impala/stats/chart.js:447 static/js/zamboni/stats-all.js:17078 static/js/zamboni/stats-min.js:5
+msgid "More Info..."
+msgstr "Més informació..."
+
+#. L10n: {0} is an ISO-formatted date.
+#: static/js/impala/stats/chart.js:451 static/js/zamboni/stats-all.js:17082 static/js/zamboni/stats-min.js:5
+msgid "Details for {0}"
+msgstr "Detalls de {0}"
+
+#: static/js/impala/stats/csv_keys.js:9 static/js/zamboni/stats-all.js:15290 static/js/zamboni/stats-min.js:4
+msgid "Collections Created"
+msgstr "Col·leccions creades"
+
+#: static/js/impala/stats/csv_keys.js:12 static/js/zamboni/stats-all.js:15293 static/js/zamboni/stats-min.js:4
+msgid "Add-ons in Use"
+msgstr "Complements en ús"
+
+#: static/js/impala/stats/csv_keys.js:15 static/js/zamboni/stats-all.js:15296 static/js/zamboni/stats-min.js:4
+msgid "Add-ons Created"
+msgstr "Complements creats"
+
+#: static/js/impala/stats/csv_keys.js:18 static/js/zamboni/stats-all.js:15299 static/js/zamboni/stats-min.js:4
+msgid "Add-ons Downloaded"
+msgstr "Complements baixats"
+
+#: static/js/impala/stats/csv_keys.js:21 static/js/zamboni/stats-all.js:15302 static/js/zamboni/stats-min.js:4
+msgid "Add-ons Updated"
+msgstr "Complements actualitzats"
+
+#: static/js/impala/stats/csv_keys.js:24 static/js/zamboni/stats-all.js:15305 static/js/zamboni/stats-min.js:4
+msgid "Reviews Written"
+msgstr "Valoracions escrites"
+
+#: static/js/impala/stats/csv_keys.js:27 static/js/zamboni/stats-all.js:15308 static/js/zamboni/stats-min.js:4
+msgid "User Signups"
+msgstr "Registres d'usuari"
+
+#: static/js/impala/stats/csv_keys.js:30 static/js/zamboni/stats-all.js:15311 static/js/zamboni/stats-min.js:4
+msgid "Subscribers"
+msgstr "Subscriptors"
+
+#: static/js/impala/stats/csv_keys.js:33 static/js/zamboni/stats-all.js:15314 static/js/zamboni/stats-min.js:4
+msgid "Ratings"
+msgstr "Puntuació"
+
+#: static/js/impala/stats/csv_keys.js:36 static/js/impala/stats/csv_keys.js:114 static/js/zamboni/stats-all.js:15317 static/js/zamboni/stats-all.js:15395 static/js/zamboni/stats-min.js:4
+#: static/js/zamboni/stats-min.js:5
+msgid "Sales"
+msgstr "Vendes"
+
+#: static/js/impala/stats/csv_keys.js:39 static/js/impala/stats/csv_keys.js:113 static/js/zamboni/stats-all.js:15320 static/js/zamboni/stats-all.js:15394 static/js/zamboni/stats-min.js:4
+#: static/js/zamboni/stats-min.js:5
+msgid "Installs"
+msgstr "Instal·lacions"
+
+#: static/js/impala/stats/csv_keys.js:42 static/js/zamboni/stats-all.js:15323 static/js/zamboni/stats-min.js:4
+msgid "Unknown"
+msgstr "Desconegut"
+
+#: static/js/impala/stats/csv_keys.js:43 static/js/zamboni/stats-all.js:15324 static/js/zamboni/stats-min.js:4
+msgid "Add-ons Manager"
+msgstr "Gestor de complements"
+
+#: static/js/impala/stats/csv_keys.js:44 static/js/zamboni/stats-all.js:15325 static/js/zamboni/stats-min.js:4
+msgid "Add-ons Manager Promo"
+msgstr ""
+
+#: static/js/impala/stats/csv_keys.js:45 static/js/zamboni/stats-all.js:15326 static/js/zamboni/stats-min.js:4
+msgid "Add-ons Manager Featured"
+msgstr ""
+
+#: static/js/impala/stats/csv_keys.js:46 static/js/zamboni/stats-all.js:15327 static/js/zamboni/stats-min.js:4
+msgid "Add-ons Manager Learn More"
+msgstr ""
+
+#: static/js/impala/stats/csv_keys.js:47 static/js/zamboni/stats-all.js:15328 static/js/zamboni/stats-min.js:4
+msgid "Search Suggestions"
+msgstr ""
+
+#: static/js/impala/stats/csv_keys.js:48 static/js/zamboni/stats-all.js:15329 static/js/zamboni/stats-min.js:4
+msgid "Search Results"
+msgstr "Resultats de cerca"
+
+#: static/js/impala/stats/csv_keys.js:49 static/js/impala/stats/csv_keys.js:50 static/js/impala/stats/csv_keys.js:51 static/js/zamboni/stats-all.js:15330 static/js/zamboni/stats-all.js:15331
+#: static/js/zamboni/stats-all.js:15332 static/js/zamboni/stats-min.js:4
+msgid "Homepage Promo"
+msgstr "Promo de la pàgina principal"
+
+#: static/js/impala/stats/csv_keys.js:52 static/js/impala/stats/csv_keys.js:53 static/js/zamboni/stats-all.js:15333 static/js/zamboni/stats-all.js:15334 static/js/zamboni/stats-min.js:4
+msgid "Homepage Featured"
+msgstr "Destacat de la pàgina principal"
+
+#: static/js/impala/stats/csv_keys.js:54 static/js/impala/stats/csv_keys.js:55 static/js/zamboni/stats-all.js:15335 static/js/zamboni/stats-all.js:15336 static/js/zamboni/stats-min.js:4
+msgid "Homepage Up and Coming"
+msgstr "Recents a la pàgina principal"
+
+#: static/js/impala/stats/csv_keys.js:56 static/js/zamboni/stats-all.js:15337 static/js/zamboni/stats-min.js:4
+msgid "Homepage Most Popular"
+msgstr "Els més populars a la pàgina principal"
+
+#: static/js/impala/stats/csv_keys.js:57 static/js/impala/stats/csv_keys.js:59 static/js/zamboni/stats-all.js:15338 static/js/zamboni/stats-all.js:15340 static/js/zamboni/stats-min.js:4
+msgid "Detail Page"
+msgstr "Pàgina de detalls"
+
+#: static/js/impala/stats/csv_keys.js:58 static/js/impala/stats/csv_keys.js:60 static/js/zamboni/stats-all.js:15339 static/js/zamboni/stats-all.js:15341 static/js/zamboni/stats-min.js:4
+msgid "Detail Page (bottom)"
+msgstr "Pàgina de detalls (avall)"
+
+#: static/js/impala/stats/csv_keys.js:61 static/js/zamboni/stats-all.js:15342 static/js/zamboni/stats-min.js:4
+msgid "Detail Page (Development Channel)"
+msgstr "Pàgina de detalls (canal de desenvolupament)"
+
+#: static/js/impala/stats/csv_keys.js:62 static/js/impala/stats/csv_keys.js:63 static/js/impala/stats/csv_keys.js:64 static/js/zamboni/stats-all.js:15343 static/js/zamboni/stats-all.js:15344
+#: static/js/zamboni/stats-all.js:15345 static/js/zamboni/stats-min.js:4
+msgid "Often Used With"
+msgstr "S'utilitza sovint amb"
+
+#: static/js/impala/stats/csv_keys.js:65 static/js/impala/stats/csv_keys.js:66 static/js/zamboni/stats-all.js:15346 static/js/zamboni/stats-all.js:15347 static/js/zamboni/stats-min.js:4
+msgid "Others By Author"
+msgstr "Altres de l'autor"
+
+#: static/js/impala/stats/csv_keys.js:67 static/js/impala/stats/csv_keys.js:68 static/js/zamboni/stats-all.js:15348 static/js/zamboni/stats-all.js:15349 static/js/zamboni/stats-min.js:4
+msgid "Dependencies"
+msgstr "Dependències"
+
+#: static/js/impala/stats/csv_keys.js:69 static/js/impala/stats/csv_keys.js:70 static/js/zamboni/stats-all.js:15350 static/js/zamboni/stats-all.js:15351 static/js/zamboni/stats-min.js:4
+msgid "Upsell"
+msgstr "Promocions"
+
+#: static/js/impala/stats/csv_keys.js:71 static/js/zamboni/stats-all.js:15352 static/js/zamboni/stats-min.js:4
+msgid "Meet the Developer"
+msgstr ""
+
+#: static/js/impala/stats/csv_keys.js:72 static/js/zamboni/stats-all.js:15353 static/js/zamboni/stats-min.js:4
+msgid "User Profile"
+msgstr ""
+
+#: static/js/impala/stats/csv_keys.js:73 static/js/zamboni/stats-all.js:15354 static/js/zamboni/stats-min.js:4
+msgid "Version History"
+msgstr ""
+
+#: static/js/impala/stats/csv_keys.js:75 static/js/zamboni/stats-all.js:15356 static/js/zamboni/stats-min.js:4
+msgid "Sharing"
+msgstr "Compartint"
+
+#: static/js/impala/stats/csv_keys.js:76 static/js/zamboni/stats-all.js:15357 static/js/zamboni/stats-min.js:4
+msgid "Category Pages"
+msgstr "Pàgines de categoria"
+
+#: static/js/impala/stats/csv_keys.js:77 static/js/zamboni/stats-all.js:15358 static/js/zamboni/stats-min.js:4
+msgid "Collections"
+msgstr "Col·leccions"
+
+#: static/js/impala/stats/csv_keys.js:78 static/js/impala/stats/csv_keys.js:79 static/js/zamboni/stats-all.js:15359 static/js/zamboni/stats-all.js:15360 static/js/zamboni/stats-min.js:4
+msgid "Category Landing Featured Carousel"
+msgstr "Carrusel de destacats que arriben a la categoria"
+
+#: static/js/impala/stats/csv_keys.js:80 static/js/impala/stats/csv_keys.js:81 static/js/zamboni/stats-all.js:15361 static/js/zamboni/stats-all.js:15362 static/js/zamboni/stats-min.js:4
+msgid "Category Landing Top Rated"
+msgstr "Els més ben valorats que arriben a la categoria"
+
+#: static/js/impala/stats/csv_keys.js:82 static/js/impala/stats/csv_keys.js:83 static/js/zamboni/stats-all.js:15363 static/js/zamboni/stats-all.js:15364 static/js/zamboni/stats-min.js:5
+msgid "Category Landing Most Popular"
+msgstr "Els més populars que arriben a la categoria"
+
+#: static/js/impala/stats/csv_keys.js:84 static/js/impala/stats/csv_keys.js:85 static/js/zamboni/stats-all.js:15365 static/js/zamboni/stats-all.js:15366 static/js/zamboni/stats-min.js:5
+msgid "Category Landing Recently Added"
+msgstr "Els afegits més recentment que arriben a la categoria"
+
+#: static/js/impala/stats/csv_keys.js:86 static/js/impala/stats/csv_keys.js:87 static/js/zamboni/stats-all.js:15367 static/js/zamboni/stats-all.js:15368 static/js/zamboni/stats-min.js:5
+msgid "Browse Listing Featured Sort"
+msgstr "Navega la llista per destacats"
+
+#: static/js/impala/stats/csv_keys.js:88 static/js/impala/stats/csv_keys.js:89 static/js/zamboni/stats-all.js:15369 static/js/zamboni/stats-all.js:15370 static/js/zamboni/stats-min.js:5
+msgid "Browse Listing Users Sort"
+msgstr "Navega la llista per usuaris"
+
+#: static/js/impala/stats/csv_keys.js:90 static/js/impala/stats/csv_keys.js:91 static/js/zamboni/stats-all.js:15371 static/js/zamboni/stats-all.js:15372 static/js/zamboni/stats-min.js:5
+msgid "Browse Listing Rating Sort"
+msgstr "Navega la llista per més valorats"
+
+#: static/js/impala/stats/csv_keys.js:92 static/js/impala/stats/csv_keys.js:93 static/js/zamboni/stats-all.js:15373 static/js/zamboni/stats-all.js:15374 static/js/zamboni/stats-min.js:5
+msgid "Browse Listing Created Sort"
+msgstr "Navega la llista per data de creació"
+
+#: static/js/impala/stats/csv_keys.js:94 static/js/impala/stats/csv_keys.js:95 static/js/zamboni/stats-all.js:15375 static/js/zamboni/stats-all.js:15376 static/js/zamboni/stats-min.js:5
+msgid "Browse Listing Name Sort"
+msgstr "Navega la llista per nom"
+
+#: static/js/impala/stats/csv_keys.js:96 static/js/impala/stats/csv_keys.js:97 static/js/zamboni/stats-all.js:15377 static/js/zamboni/stats-all.js:15378 static/js/zamboni/stats-min.js:5
+msgid "Browse Listing Popular Sort"
+msgstr "Navega la llista per popularitat"
+
+#: static/js/impala/stats/csv_keys.js:98 static/js/impala/stats/csv_keys.js:99 static/js/zamboni/stats-all.js:15379 static/js/zamboni/stats-all.js:15380 static/js/zamboni/stats-min.js:5
+msgid "Browse Listing Updated Sort"
+msgstr "Navega la llista per més recents"
+
+#: static/js/impala/stats/csv_keys.js:100 static/js/impala/stats/csv_keys.js:101 static/js/zamboni/stats-all.js:15381 static/js/zamboni/stats-all.js:15382 static/js/zamboni/stats-min.js:5
+msgid "Browse Listing Up and Coming Sort"
+msgstr "Navega la llista per properes novetats"
+
+#: static/js/impala/stats/csv_keys.js:105 static/js/zamboni/stats-all.js:15386 static/js/zamboni/stats-min.js:5
+msgid "Total Amount Contributed"
+msgstr "Quantitat total contribuïda"
+
+#: static/js/impala/stats/csv_keys.js:106 static/js/zamboni/stats-all.js:15387 static/js/zamboni/stats-min.js:5
+msgid "Average Contribution"
+msgstr "Contribució mitja"
+
+#: static/js/impala/stats/csv_keys.js:115 static/js/zamboni/stats-all.js:15396 static/js/zamboni/stats-min.js:5
+msgid "Usage"
+msgstr "Ús"
+
+#: static/js/impala/stats/csv_keys.js:118 static/js/zamboni/stats-all.js:15399 static/js/zamboni/stats-min.js:5
+msgid "Firefox"
+msgstr "Firefox"
+
+#: static/js/impala/stats/csv_keys.js:119 static/js/zamboni/stats-all.js:15400 static/js/zamboni/stats-min.js:5
+msgid "Mozilla"
+msgstr "Mozilla"
+
+#: static/js/impala/stats/csv_keys.js:120 static/js/zamboni/stats-all.js:15401 static/js/zamboni/stats-min.js:5
+msgid "Thunderbird"
+msgstr "Thunderbird"
+
+#: static/js/impala/stats/csv_keys.js:121 static/js/zamboni/stats-all.js:15402 static/js/zamboni/stats-min.js:5
+msgid "Sunbird"
+msgstr "Sunbird"
+
+#: static/js/impala/stats/csv_keys.js:122 static/js/zamboni/stats-all.js:15403 static/js/zamboni/stats-min.js:5
+msgid "SeaMonkey"
+msgstr "SeaMonkey"
+
+#: static/js/impala/stats/csv_keys.js:123 static/js/zamboni/stats-all.js:15404 static/js/zamboni/stats-min.js:5
+msgid "Fennec"
+msgstr "Fennec"
+
+#: static/js/impala/stats/csv_keys.js:124 static/js/zamboni/stats-all.js:15405 static/js/zamboni/stats-min.js:5
+msgid "Android"
+msgstr ""
+
+#. L10n: {0} is an integer.
+#: static/js/impala/stats/csv_keys.js:129 static/js/zamboni/stats-all.js:15410 static/js/zamboni/stats-min.js:5
+msgid "Downloads and Daily Users, last {0} days"
+msgstr "Baixades i usuaris diaris, darrers {0} dies"
+
+#. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
+#: static/js/impala/stats/csv_keys.js:131 static/js/zamboni/stats-all.js:15412 static/js/zamboni/stats-min.js:5
+msgid "Downloads and Daily Users from {0} to {1}"
+msgstr "Baixades i usuaris diaris des del {0} al {1}"
+
+#. L10n: {0} is an integer.
+#: static/js/impala/stats/csv_keys.js:135 static/js/zamboni/stats-all.js:15416 static/js/zamboni/stats-min.js:5
+msgid "Installs and Daily Users, last {0} days"
+msgstr "Instal·lacions i usuaris diaris, darrers {0} dies"
+
+#. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
+#: static/js/impala/stats/csv_keys.js:137 static/js/zamboni/stats-all.js:15418 static/js/zamboni/stats-min.js:5
+msgid "Installs and Daily Users from {0} to {1}"
+msgstr "Instal·lacions i usuaris diaris entre el {0} i el {1}"
+
+#. L10n: {0} is an integer.
+#: static/js/impala/stats/csv_keys.js:141 static/js/zamboni/stats-all.js:15422 static/js/zamboni/stats-min.js:5
+msgid "Downloads, last {0} days"
+msgstr "Baixades, darrers {0} dies"
+
+#. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
+#: static/js/impala/stats/csv_keys.js:143 static/js/zamboni/stats-all.js:15424 static/js/zamboni/stats-min.js:5
+msgid "Downloads from {0} to {1}"
+msgstr "Baixades des del {0} al {1}"
+
+#. L10n: {0} is an integer.
+#: static/js/impala/stats/csv_keys.js:147 static/js/zamboni/stats-all.js:15428 static/js/zamboni/stats-min.js:5
+msgid "Daily Users, last {0} days"
+msgstr "Usuaris diaris, darrers {0} dies"
+
+#. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
+#: static/js/impala/stats/csv_keys.js:149 static/js/zamboni/stats-all.js:15430 static/js/zamboni/stats-min.js:5
+msgid "Daily Users from {0} to {1}"
+msgstr "Usuaris diaris des del {0} al {1}"
+
+#. L10n: {0} is an integer.
+#: static/js/impala/stats/csv_keys.js:153 static/js/zamboni/stats-all.js:15434 static/js/zamboni/stats-min.js:5
+msgid "Applications, last {0} days"
+msgstr "Aplicacions, darrers {0} dies"
+
+#. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
+#: static/js/impala/stats/csv_keys.js:155 static/js/zamboni/stats-all.js:15436 static/js/zamboni/stats-min.js:5
+msgid "Applications from {0} to {1}"
+msgstr "Aplicacions del {0} a {1}"
+
+#. L10n: {0} is an integer.
+#: static/js/impala/stats/csv_keys.js:159 static/js/zamboni/stats-all.js:15440 static/js/zamboni/stats-min.js:5
+msgid "Platforms, last {0} days"
+msgstr "Plataformes, darrers {0} dies"
+
+#. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
+#: static/js/impala/stats/csv_keys.js:161 static/js/zamboni/stats-all.js:15442 static/js/zamboni/stats-min.js:5
+msgid "Platforms from {0} to {1}"
+msgstr "Plataformes des del {0} al {1}"
+
+#. L10n: {0} is an integer.
+#: static/js/impala/stats/csv_keys.js:165 static/js/zamboni/stats-all.js:15446 static/js/zamboni/stats-min.js:5
+msgid "Languages, last {0} days"
+msgstr "Llengües, darrers {0} dies"
+
+#. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
+#: static/js/impala/stats/csv_keys.js:167 static/js/zamboni/stats-all.js:15448 static/js/zamboni/stats-min.js:5
+msgid "Languages from {0} to {1}"
+msgstr "Llengües des del {0} al {1}"
+
+#. L10n: {0} is an integer.
+#: static/js/impala/stats/csv_keys.js:171 static/js/zamboni/stats-all.js:15452 static/js/zamboni/stats-min.js:5
+msgid "Add-on Versions, last {0} days"
+msgstr "Versions del complement, els darrers {0} dies"
+
+#. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
+#: static/js/impala/stats/csv_keys.js:173 static/js/zamboni/stats-all.js:15454 static/js/zamboni/stats-min.js:5
+msgid "Add-on Versions from {0} to {1}"
+msgstr "Versions del complement des del {0} al {1}"
+
+#. L10n: {0} is an integer.
+#: static/js/impala/stats/csv_keys.js:177 static/js/zamboni/stats-all.js:15458 static/js/zamboni/stats-min.js:5
+msgid "Add-on Status, last {0} days"
+msgstr "Estat del complement, darrers {0} dies"
+
+#. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
+#: static/js/impala/stats/csv_keys.js:179 static/js/zamboni/stats-all.js:15460 static/js/zamboni/stats-min.js:5
+msgid "Add-on Status from {0} to {1}"
+msgstr "Estat del complement des del {0} al {1}"
+
+#. L10n: {0} is an integer.
+#: static/js/impala/stats/csv_keys.js:183 static/js/zamboni/stats-all.js:15464 static/js/zamboni/stats-min.js:5
+msgid "Download Sources, last {0} days"
+msgstr "Fonts de baixada, darrers {0} dies"
+
+#. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
+#: static/js/impala/stats/csv_keys.js:185 static/js/zamboni/stats-all.js:15466 static/js/zamboni/stats-min.js:5
+msgid "Download Sources from {0} to {1}"
+msgstr "Fonts de baixades des del {0} al {1}"
+
+#. L10n: {0} is an integer.
+#: static/js/impala/stats/csv_keys.js:189 static/js/zamboni/stats-all.js:15470 static/js/zamboni/stats-min.js:5
+msgid "Contributions, last {0} days"
+msgstr "Contribucions, darrers {0} dies"
+
+#. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
+#: static/js/impala/stats/csv_keys.js:191 static/js/zamboni/stats-all.js:15472 static/js/zamboni/stats-min.js:5
+msgid "Contributions from {0} to {1}"
+msgstr "Contribucions des del {0} al {1}"
+
+#. L10n: {0} is an integer.
+#: static/js/impala/stats/csv_keys.js:195 static/js/zamboni/stats-all.js:15476 static/js/zamboni/stats-min.js:5
+msgid "Site Metrics, last {0} days"
+msgstr "Dades de la pàgina, darrers {0} dies"
+
+#. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
+#: static/js/impala/stats/csv_keys.js:197 static/js/zamboni/stats-all.js:15478 static/js/zamboni/stats-min.js:5
+msgid "Site Metrics from {0} to {1}"
+msgstr "Dades de la pàgina del {0} al {1}"
+
+#. L10n: {0} is an integer.
+#: static/js/impala/stats/csv_keys.js:201 static/js/zamboni/stats-all.js:15482 static/js/zamboni/stats-min.js:5
+msgid "Add-ons in Use, last {0} days"
+msgstr "Complements en ús els darrers {0} dies"
+
+#. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
+#: static/js/impala/stats/csv_keys.js:203 static/js/zamboni/stats-all.js:15484 static/js/zamboni/stats-min.js:5
+msgid "Add-ons in Use from {0} to {1}"
+msgstr "Complements en ús del {0} al {1}"
+
+#. L10n: {0} is an integer.
+#: static/js/impala/stats/csv_keys.js:207 static/js/zamboni/stats-all.js:15488 static/js/zamboni/stats-min.js:5
+msgid "Add-ons Downloaded, last {0} days"
+msgstr "Complements baixats els darrers {0} dies"
+
+#. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
+#: static/js/impala/stats/csv_keys.js:209 static/js/zamboni/stats-all.js:15490 static/js/zamboni/stats-min.js:5
+msgid "Add-ons Downloaded from {0} to {1}"
+msgstr "Complements baixats del {0} al {1}"
+
+#. L10n: {0} is an integer.
+#: static/js/impala/stats/csv_keys.js:213 static/js/zamboni/stats-all.js:15494 static/js/zamboni/stats-min.js:5
+msgid "Add-ons Created, last {0} days"
+msgstr "Complements creats els darrers {0} dies"
+
+#. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
+#: static/js/impala/stats/csv_keys.js:215 static/js/zamboni/stats-all.js:15496 static/js/zamboni/stats-min.js:5
+msgid "Add-ons Created from {0} to {1}"
+msgstr "Complements creats del {0} al {1}"
+
+#. L10n: {0} is an integer.
+#: static/js/impala/stats/csv_keys.js:219 static/js/zamboni/stats-all.js:15500 static/js/zamboni/stats-min.js:5
+msgid "Add-ons Updated, last {0} days"
+msgstr "Complements actualitzats els darrers {0} dies"
+
+#. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
+#: static/js/impala/stats/csv_keys.js:221 static/js/zamboni/stats-all.js:15502 static/js/zamboni/stats-min.js:5
+msgid "Add-ons Updated from {0} to {1}"
+msgstr "Complements actualitzats del {0} al {1}"
+
+#. L10n: {0} is an integer.
+#: static/js/impala/stats/csv_keys.js:225 static/js/zamboni/stats-all.js:15506 static/js/zamboni/stats-min.js:5
+msgid "Reviews Written, last {0} days"
+msgstr "Valoracions escrites els darrers {0} dies"
+
+#. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
+#: static/js/impala/stats/csv_keys.js:227 static/js/zamboni/stats-all.js:15508 static/js/zamboni/stats-min.js:5
+msgid "Reviews Written from {0} to {1}"
+msgstr "Valoracions escrites del {0} al {1}"
+
+#. L10n: {0} is an integer.
+#: static/js/impala/stats/csv_keys.js:231 static/js/zamboni/stats-all.js:15512 static/js/zamboni/stats-min.js:5
+msgid "User Signups, last {0} days"
+msgstr "Registres d'usuari els darrers {0} dies"
+
+#. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
+#: static/js/impala/stats/csv_keys.js:233 static/js/zamboni/stats-all.js:15514 static/js/zamboni/stats-min.js:5
+msgid "User Signups from {0} to {1}"
+msgstr "Registres d'usuari del {0} al {1}"
+
+#. L10n: {0} is an integer.
+#: static/js/impala/stats/csv_keys.js:237 static/js/zamboni/stats-all.js:15518 static/js/zamboni/stats-min.js:5
+msgid "Collections Created, last {0} days"
+msgstr "Col·leccions creades els darrers {0} dies"
+
+#. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
+#: static/js/impala/stats/csv_keys.js:239 static/js/zamboni/stats-all.js:15520 static/js/zamboni/stats-min.js:5
+msgid "Collections Created from {0} to {1}"
+msgstr "Col·leccions creades del {0} al {1}"
+
+#. L10n: {0} is an integer.
+#: static/js/impala/stats/csv_keys.js:243 static/js/zamboni/stats-all.js:15524 static/js/zamboni/stats-min.js:5
+msgid "Subscribers, last {0} days"
+msgstr "Subscriptors els darrers {0} dies"
+
+#. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
+#: static/js/impala/stats/csv_keys.js:245 static/js/zamboni/stats-all.js:15526 static/js/zamboni/stats-min.js:5
+msgid "Subscribers from {0} to {1}"
+msgstr "Subscriptors del {0} al {1}"
+
+#. L10n: {0} is an integer.
+#: static/js/impala/stats/csv_keys.js:249 static/js/zamboni/stats-all.js:15530 static/js/zamboni/stats-min.js:5
+msgid "Ratings, last {0} days"
+msgstr "Valoracions dels darrers {0} dies"
+
+#. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
+#: static/js/impala/stats/csv_keys.js:251 static/js/zamboni/stats-all.js:15532 static/js/zamboni/stats-min.js:5
+msgid "Ratings from {0} to {1}"
+msgstr "Valoracions del {0} al {1}"
+
+#. L10n: {0} is an integer.
+#: static/js/impala/stats/csv_keys.js:255 static/js/zamboni/stats-all.js:15536 static/js/zamboni/stats-min.js:5
+msgid "Sales, last {0} days"
+msgstr "Vendes dels darrers {0} dies"
+
+#. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
+#: static/js/impala/stats/csv_keys.js:257 static/js/zamboni/stats-all.js:15538 static/js/zamboni/stats-min.js:5
+msgid "Sales from {0} to {1}"
+msgstr "Vendes del {0} al {1}"
+
+#. L10n: {0} is an integer.
+#: static/js/impala/stats/csv_keys.js:261 static/js/zamboni/stats-all.js:15542 static/js/zamboni/stats-min.js:5
+msgid "Installs, last {0} days"
+msgstr "Instal·lacions dels darrers {0} dies"
+
+#. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
+#: static/js/impala/stats/csv_keys.js:263 static/js/zamboni/stats-all.js:15544 static/js/zamboni/stats-min.js:5
+msgid "Installs from {0} to {1}"
+msgstr "Instal·lacions del {0} al {1}"
+
+#. L10n: {0} and {1} are integers.
+#: static/js/impala/stats/csv_keys.js:269 static/js/zamboni/stats-all.js:15550 static/js/zamboni/stats-min.js:5
+msgid "<b>{0}</b> in last {1} days"
+msgstr "<b>{0}</b> en els darrers {1} dies"
+
+#. L10n: {0} is an integer and {1} and {2} are dates in YYYY-MM-DD format.
+#: static/js/impala/stats/csv_keys.js:271 static/js/impala/stats/csv_keys.js:277 static/js/zamboni/stats-all.js:15552 static/js/zamboni/stats-all.js:15558 static/js/zamboni/stats-min.js:5
+msgid "<b>{0}</b> from {1} to {2}"
+msgstr "<b>{0}</b> des del {1} al {2}"
+
+#. L10n: {0} and {1} are integers.
+#: static/js/impala/stats/csv_keys.js:275 static/js/zamboni/stats-all.js:15556 static/js/zamboni/stats-min.js:5
+msgid "<b>{0}</b> average in last {1} days"
+msgstr "<b>{0}</b> de mitjana en els darrers {1} dies"
+
+#: static/js/impala/stats/overview.js:19 static/js/zamboni/stats-all.js:16469 static/js/zamboni/stats-min.js:5
+msgid "No data available."
+msgstr "No hi ha dades disponibles."
+
+#: static/js/impala/stats/table.js:74 static/js/zamboni/stats-all.js:17209 static/js/zamboni/stats-min.js:5
+msgid "Date"
+msgstr "Data"
+
+#: static/js/impala/stats/topchart.js:96 static/js/zamboni/stats-all.js:16600 static/js/zamboni/stats-min.js:5
+msgid "Other"
+msgstr "Altres"
+
+#: static/js/zamboni/admin-all.js:180 static/js/zamboni/admin-min.js:1 static/js/zamboni/admin_validation.js:24 static/js/zamboni/devhub-all.js:2408 static/js/zamboni/devhub-min.js:2
+#: static/js/zamboni/devhub.js:1229 static/js/zamboni/editors-all.js:15576 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:295
+msgid "Select an application first"
+msgstr "Primer cal que seleccioneu una aplicació"
+
+#: static/js/zamboni/admin-all.js:207 static/js/zamboni/admin-min.js:1 static/js/zamboni/admin_validation.js:51
+msgid "Set {0} add-on to a max version of {1} and email the author."
+msgid_plural "Set {0} add-ons to a max version of {1} and email the authors."
+msgstr[0] "Defineix el complement {0} a la versió màxima de {1} i envia un missatge a l'autor."
+msgstr[1] "Defineix els complements {0} a la versió màxima de {1} i envia uns missatges als autors."
+
+#: static/js/zamboni/admin-all.js:210 static/js/zamboni/admin-min.js:1 static/js/zamboni/admin_validation.js:54
+msgid "Email author of {2} add-on which failed validation."
+msgid_plural "Email authors of {2} add-ons which failed validation."
+msgstr[0] ""
+msgstr[1] ""
+
+#: static/js/zamboni/devhub-all.js:1289 static/js/zamboni/devhub-min.js:1 static/js/zamboni/devhub.js:110
+msgid "Your browser does not support the video tag"
+msgstr "El vostre navegador no admet l'etiqueta de vídeo"
+
+#: static/js/zamboni/devhub-all.js:1550 static/js/zamboni/devhub-min.js:1 static/js/zamboni/devhub.js:371
+msgid "Changes Saved"
+msgstr "S'han desat els canvis"
+
+#: static/js/zamboni/devhub-all.js:1566 static/js/zamboni/devhub-min.js:1 static/js/zamboni/devhub.js:387
+msgid "Enter a new author's email address"
+msgstr "Introduïu una nova adreça electrònica d'autor"
+
+#: static/js/zamboni/devhub-all.js:1715 static/js/zamboni/devhub-min.js:1 static/js/zamboni/devhub.js:536
+msgid "There was an error uploading your file."
+msgstr "S'ha produït un error en pujar el fitxer."
+
+#: static/js/zamboni/devhub-all.js:1860 static/js/zamboni/devhub-min.js:1 static/js/zamboni/devhub.js:681
+msgid "{files} file"
+msgid_plural "{files} files"
+msgstr[0] "{files} fitxer"
+msgstr[1] "{files} fitxers"
+
+#: static/js/zamboni/devhub-all.js:1863 static/js/zamboni/devhub-min.js:1 static/js/zamboni/devhub.js:684
+msgid "{reviews} user review"
+msgid_plural "{reviews} user reviews"
+msgstr[0] ""
+msgstr[1] ""
+
+#: static/js/zamboni/devhub-all.js:1975 static/js/zamboni/devhub-min.js:2 static/js/zamboni/devhub.js:796
+msgid "Learn more"
+msgstr "Més informació"
+
+#: static/js/zamboni/devhub-all.js:1979 static/js/zamboni/devhub-min.js:2 static/js/zamboni/devhub.js:800
+msgid "Example"
+msgstr "Exemple"
+
+#: static/js/zamboni/devhub-all.js:2309 static/js/zamboni/devhub-min.js:2 static/js/zamboni/devhub.js:1130
+msgid "Image changes being processed"
+msgstr "S'estan processant els canvis a la imatge"
+
+#: static/js/zamboni/devhub-all.js:2459 static/js/zamboni/devhub-min.js:2 static/js/zamboni/devhub.js:1280
+msgid "Must be a valid e-mail address."
+msgstr "Cal que sigui una adreça electrònica vàlida."
+
+#: static/js/zamboni/devhub-all.js:2613 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:80
 msgid "All tests passed successfully."
 msgstr "S'han superat tots els tests amb èxit."
 
-#: static/js/zamboni/validator.js:83 static/js/zamboni/validator.js:478
+#: static/js/zamboni/devhub-all.js:2616 static/js/zamboni/devhub-all.js:3011 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:83 static/js/zamboni/validator.js:478
 msgid "These tests were not run."
 msgstr "Aquests tests no s'han executat."
 
-#: static/js/zamboni/validator.js:131 static/js/zamboni/validator.js:144
+#: static/js/zamboni/devhub-all.js:2664 static/js/zamboni/devhub-all.js:2677 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:131 static/js/zamboni/validator.js:144
 msgid "Tests"
 msgstr "Tests"
 
-#: static/js/zamboni/validator.js:246 static/js/zamboni/validator.js:575 static/js/zamboni/validator.js:594
+#: static/js/zamboni/devhub-all.js:2779 static/js/zamboni/devhub-all.js:3108 static/js/zamboni/devhub-all.js:3127 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:246
+#: static/js/zamboni/validator.js:575 static/js/zamboni/validator.js:594
 msgid "Error"
 msgstr "Error"
 
-#: static/js/zamboni/validator.js:247
+#: static/js/zamboni/devhub-all.js:2780 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:247
 msgid "Warning"
 msgstr "Avís"
 
-#: static/js/zamboni/validator.js:299
+#: static/js/zamboni/devhub-all.js:2794 static/js/zamboni/devhub-min.js:2 static/js/zamboni/files-all.js:5657 static/js/zamboni/files-min.js:3 static/js/zamboni/files.js:411
+#: static/js/zamboni/validator.js:261
+msgid "Ignore this message in future updates"
+msgstr ""
+
+#: static/js/zamboni/devhub-all.js:2817 static/js/zamboni/devhub-min.js:2 static/js/zamboni/files-all.js:5663 static/js/zamboni/files-min.js:3 static/js/zamboni/files.js:417
+#: static/js/zamboni/validator.js:284
+msgid "Severity for automated signing:"
+msgstr ""
+
+#: static/js/zamboni/devhub-all.js:2832 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:299
 msgid "Suggestions for passing automated signing:"
 msgstr ""
 
-#: static/js/zamboni/validator.js:387
+#: static/js/zamboni/devhub-all.js:2920 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:387
 msgid "Compatibility Tests"
 msgstr "Proves de compatibilitat"
 
-#: static/js/zamboni/validator.js:466
+#: static/js/zamboni/devhub-all.js:2999 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:466
 msgid "Add-on failed validation."
 msgstr "El complement no ha passat la validació."
 
-#: static/js/zamboni/validator.js:468
+#: static/js/zamboni/devhub-all.js:3001 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:468
 msgid "Add-on passed validation."
 msgstr "El complement ha passat la validació."
 
-#: static/js/zamboni/validator.js:481
+#: static/js/zamboni/devhub-all.js:3014 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:481
 msgid "{0} error"
 msgid_plural "{0} errors"
 msgstr[0] "{0} error"
 msgstr[1] "{0} errors"
 
-#: static/js/zamboni/validator.js:483
+#: static/js/zamboni/devhub-all.js:3016 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:483
 msgid "{0} warning"
 msgid_plural "{0} warnings"
 msgstr[0] "{0} avís"
 msgstr[1] "{0} avisos"
 
-#: static/js/zamboni/validator.js:485
+#: static/js/zamboni/devhub-all.js:3018 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:485
 msgid "{0} notice"
 msgid_plural "{0} notices"
 msgstr[0] ""
 msgstr[1] ""
 
-#: static/js/zamboni/validator.js:577
+#: static/js/zamboni/devhub-all.js:3110 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:577
 msgid "Validation task could not complete or completed with errors"
 msgstr "El procés de validació no s'ha pogut completar o s'ha completat amb errors"
 
-#: static/js/zamboni/validator.js:595
+#: static/js/zamboni/devhub-all.js:3128 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:595
 msgid "Internal server error"
 msgstr "Error intern del servidor"
 
-#: static/js/zamboni/mobile/buttons.js:52
+#: static/js/zamboni/devhub_search.js:8
+msgid "No results found."
+msgstr "No s'ha trobat cap resultat."
+
+#: static/js/zamboni/editors-all.js:15402 static/js/zamboni/editors-min.js:4 static/js/zamboni/editors.js:121
+msgid "{name} was viewing this page first."
+msgstr "{name} ha visitat aquesta pàgina per primer cop."
+
+#: static/js/zamboni/editors-all.js:15452 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:171
+msgid "Receipt checked by app."
+msgstr "L'aplicació ha revisat el rebut."
+
+#: static/js/zamboni/editors-all.js:15454 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:173
+msgid "Receipt was not checked by app."
+msgstr "L'aplicació no ha revisat el rebut."
+
+#: static/js/zamboni/editors-all.js:15525 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:244
+msgid "{name} was viewing this add-on first."
+msgstr "{name} estava mirant aquest complement primer."
+
+#: static/js/zamboni/editors-all.js:15536 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:255
+msgid "Loading&hellip;"
+msgstr "S'està carregant&hellip;"
+
+#: static/js/zamboni/editors-all.js:15541 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:260
+msgid "Version Notes"
+msgstr "Notes de la versió"
+
+#: static/js/zamboni/editors-all.js:15546 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:265
+msgid "Notes for Reviewers"
+msgstr "Notes per als revisors"
+
+#: static/js/zamboni/editors-all.js:15551 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:270
+msgid "No version notes found"
+msgstr "No s'han trobat les notes de la versió"
+
+#: static/js/zamboni/editors-all.js:15611 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:330
+msgid "Average Reviews"
+msgstr ""
+
+#: static/js/zamboni/editors-all.js:15667 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:386
+msgid "Number of Reviews"
+msgstr ""
+
+#: static/js/zamboni/editors-all.js:15726 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:445
+msgid "Error loading translation"
+msgstr ""
+
+#: static/js/zamboni/editors-all.js:15975 static/js/zamboni/editors-min.js:5 static/js/zamboni/themes_review_templates.js:31
+msgid "Theme"
+msgstr ""
+
+#: static/js/zamboni/editors-all.js:15977 static/js/zamboni/editors-min.js:5 static/js/zamboni/themes_review_templates.js:33
+msgid "Reviewer"
+msgstr ""
+
+#: static/js/zamboni/editors-all.js:15979 static/js/zamboni/editors-min.js:5 static/js/zamboni/themes_review_templates.js:35
+msgid "Status"
+msgstr ""
+
+#: static/js/zamboni/editors-all.js:16196 static/js/zamboni/editors-min.js:5 static/js/zamboni/themes_review.js:176
+msgid "Requested Info"
+msgstr ""
+
+#: static/js/zamboni/editors-all.js:16197 static/js/zamboni/editors-min.js:5 static/js/zamboni/themes_review.js:177
+msgid "Flagged"
+msgstr ""
+
+#: static/js/zamboni/editors-all.js:16198 static/js/zamboni/editors-min.js:5 static/js/zamboni/themes_review.js:178
+msgid "Duplicate"
+msgstr ""
+
+#: static/js/zamboni/editors-all.js:16199 static/js/zamboni/editors-min.js:5 static/js/zamboni/themes_review.js:179
+msgid "Rejected"
+msgstr ""
+
+#: static/js/zamboni/editors-all.js:16200 static/js/zamboni/editors-min.js:5 static/js/zamboni/themes_review.js:180
+msgid "Approved"
+msgstr ""
+
+#: static/js/zamboni/editors-all.js:16444 static/js/zamboni/editors-min.js:5 static/js/zamboni/themes_review.js:424
+msgid "No results found"
+msgstr ""
+
+#: static/js/zamboni/mobile-all.js:15186 static/js/zamboni/mobile/buttons.js:52
 msgid "Not Updated for {0} {1}"
 msgstr "No actualitzat per a {0} {1}"
 
-#: static/js/zamboni/mobile/buttons.js:53
+#: static/js/zamboni/mobile-all.js:15187 static/js/zamboni/mobile/buttons.js:53
 msgid "Requires Newer Version of {0}"
 msgstr "Requereix una nova versió de {0}"
 
-#: static/js/zamboni/mobile/buttons.js:54
+#: static/js/zamboni/mobile-all.js:15188 static/js/zamboni/mobile/buttons.js:54
 msgid "Unreviewed"
 msgstr "No revisat"
 
-#: static/js/zamboni/mobile/buttons.js:55
+#: static/js/zamboni/mobile-all.js:15189 static/js/zamboni/mobile/buttons.js:55
 msgid "Experimental <span>(Learn More)</span>"
 msgstr "Experimental <span>(més informació)</span>"
 
-#: static/js/zamboni/mobile/buttons.js:56 static/js/zamboni/mobile/buttons.js:57
+#: static/js/zamboni/mobile-all.js:15190 static/js/zamboni/mobile-all.js:15191 static/js/zamboni/mobile/buttons.js:56 static/js/zamboni/mobile/buttons.js:57
 msgid "Not Available for {0}"
 msgstr "No disponible per a {0}"
 
-#: static/js/zamboni/mobile/buttons.js:58
+#: static/js/zamboni/mobile-all.js:15192 static/js/zamboni/mobile/buttons.js:58
 msgid "Experimental"
 msgstr "Experimental"
 
-#: static/js/zamboni/mobile/buttons.js:59
+#: static/js/zamboni/mobile-all.js:15193 static/js/zamboni/mobile/buttons.js:59
 msgid "Themes Require Newer Version of {0}"
 msgstr ""
 
-#: static/js/zamboni/mobile/buttons.js:60
+#: static/js/zamboni/mobile-all.js:15194 static/js/zamboni/mobile/buttons.js:60
 msgid "Themes Require {0}"
 msgstr ""
 
-#: static/js/zamboni/mobile/buttons.js:105
+#: static/js/zamboni/mobile-all.js:15239 static/js/zamboni/mobile/buttons.js:105
 msgid "Installing..."
 msgstr "S'està instal·lant..."
 
-#: static/js/zamboni/mobile/buttons.js:125
+#: static/js/zamboni/mobile-all.js:15259 static/js/zamboni/mobile/buttons.js:125
 msgid "This add-on has been preliminarily reviewed by Mozilla."
 msgstr "Aquest complement ha estat revisat de manera preliminar per Mozilla."
 
-#: static/js/zamboni/mobile/buttons.js:250
+#: static/js/zamboni/mobile-all.js:15384 static/js/zamboni/mobile/buttons.js:250
 msgid "Keep it"
 msgstr "Conserva-ho"
 
-#: static/js/zamboni/mobile/general.js:344
+#: static/js/zamboni/mobile-all.js:16049 static/js/zamboni/mobile-min.js:6 static/js/zamboni/mobile/general.js:344
 msgid "You're trying it on!"
 msgstr "Ho esteu provant!"
 
-#: static/js/zamboni/mobile/general.js:356
+#: static/js/zamboni/mobile-all.js:16061 static/js/zamboni/mobile-min.js:6 static/js/zamboni/mobile/general.js:356
 msgid "Added to Firefox"
 msgstr "S'ha afegit al Firefox"
-

--- a/locale/cs/LC_MESSAGES/django.po
+++ b/locale/cs/LC_MESSAGES/django.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: REMORA 0.1\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2016-02-24 21:23+0000\n"
+"POT-Creation-Date: 2016-04-18 15:40+0000\n"
 "PO-Revision-Date: 2016-03-21 17:31+0000\n"
 "Last-Translator: Michal Stanke <mstanke@mozilla.cz>\n"
 "Language-Team: Mozilla.cz <info@mozilla.cz>\n"
@@ -17,60 +17,60 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Generated-By: Babel 2.2.0\n"
 
-#: src/olympia/accounts/views.py:52
+#: src/olympia/accounts/views.py:54
 msgid "Your log in attempt could not be parsed. Please try again."
 msgstr "Váš pokus o přihlášení se nepodařilo zpracovat. Zkuste to prosím znovu."
 
-#: src/olympia/accounts/views.py:54
+#: src/olympia/accounts/views.py:56
 msgid "Your Firefox Account could not be found. Please try again."
 msgstr "Váš účet Firefox Account nebyl nalezen. Zkuste to prosím znovu."
 
-#: src/olympia/accounts/views.py:55
+#: src/olympia/accounts/views.py:57
 msgid "You could not be logged in. Please try again."
 msgstr "Přihlášení se nezdařilo. Zkuste to prosím znovu."
 
-#: src/olympia/accounts/views.py:57
+#: src/olympia/accounts/views.py:59
 msgid "Your account has already been migrated to Firefox Accounts."
 msgstr "Váš účet již byl převeden na účet Firefox Account."
 
-#: src/olympia/accounts/views.py:59
+#: src/olympia/accounts/views.py:61
 msgid "Your Firefox Account already exists on this site."
 msgstr "Váš účet Firefox Account je již na této stránce používán."
 
-#: src/olympia/accounts/views.py:108
+#: src/olympia/accounts/views.py:110
 msgid "Great job!"
 msgstr "Skvěle!"
 
-#: src/olympia/accounts/views.py:109
+#: src/olympia/accounts/views.py:111
 msgid "You can now log in to Add-ons with your Firefox Account."
 msgstr "Nyní se můžete na serveru s doplňky přihlašovat pomocí svého účtu Firefox Account."
 
-#: src/olympia/accounts/views.py:121
+#: src/olympia/accounts/views.py:123
 msgid "Need help?"
 msgstr "Potřebujete pomoci?"
 
-#: src/olympia/addons/buttons.py:180
+#: src/olympia/addons/buttons.py:177
 msgid "Download Now"
 msgstr "Stáhnout"
 
-#: src/olympia/addons/buttons.py:182
+#: src/olympia/addons/buttons.py:179
 msgid "Download"
 msgstr "Stáhnout"
 
 #. L10n: please keep &nbsp; in the string so &rarr; does not wrap.
-#: src/olympia/addons/buttons.py:186
+#: src/olympia/addons/buttons.py:183
 msgid "Continue to Download&nbsp;&rarr;"
 msgstr "Přejít na stažení&nbsp;&rarr;"
 
-#: src/olympia/addons/buttons.py:202 src/olympia/addons/helpers.py:35 src/olympia/addons/views.py:319 src/olympia/addons/templates/addons/impala/details.html:114
+#: src/olympia/addons/buttons.py:199 src/olympia/addons/helpers.py:35 src/olympia/addons/views.py:333 src/olympia/addons/templates/addons/impala/details.html:111
 #: src/olympia/addons/templates/addons/impala/listing/items.html:17 src/olympia/addons/templates/addons/mobile/home.html:40 src/olympia/amo/templates/amo/side_nav.html:6
-#: src/olympia/amo/templates/amo/side_nav.html:10 src/olympia/amo/templates/amo/site_nav.html:2 src/olympia/amo/templates/amo/site_nav.html:55 src/olympia/bandwagon/views.py:95
-#: src/olympia/browse/views.py:54 src/olympia/browse/views.py:68 src/olympia/browse/views.py:235 src/olympia/browse/templates/browse/impala/category_landing.html:22
+#: src/olympia/amo/templates/amo/side_nav.html:10 src/olympia/amo/templates/amo/site_nav.html:2 src/olympia/amo/templates/amo/site_nav.html:53 src/olympia/bandwagon/views.py:95
+#: src/olympia/browse/views.py:54 src/olympia/browse/views.py:68 src/olympia/browse/views.py:202 src/olympia/browse/templates/browse/impala/category_landing.html:22
 #: src/olympia/browse/templates/browse/personas/mobile/category_landing.html:26
 msgid "Featured"
 msgstr "Doporučené"
 
-#: src/olympia/addons/buttons.py:221
+#: src/olympia/addons/buttons.py:218
 msgid "Add to {0}"
 msgstr "Přidat do aplikace {0}"
 
@@ -93,7 +93,6 @@ msgid "Invalid tag: {0}"
 msgid_plural "Invalid tags: {0}"
 msgstr[0] "Neplatný štítek: {0}"
 msgstr[1] "Neplatné štítky: {0}"
-msgstr[2] "Neplatné štítky: {0}"
 
 #. L10n: {0} is a single tag or a comma-separated list of tags.
 #: src/olympia/addons/forms.py:103
@@ -101,14 +100,12 @@ msgid "\"{0}\" is a reserved tag and cannot be used."
 msgid_plural "\"{0}\" are reserved tags and cannot be used."
 msgstr[0] "\"{0}\" je rezervovaný štítek, který nemůžete použít."
 msgstr[1] "\"{0}\" jsou rezervované štítky, které nemůžete použít."
-msgstr[2] "\"{0}\" jsou rezervované štítky, které nemůžete použít."
 
 #: src/olympia/addons/forms.py:111
 msgid "You have {0} too many tags."
 msgid_plural "You have {0} too many tags."
 msgstr[0] "Máte příliš mnoho štítků: {0}"
 msgstr[1] "Máte příliš mnoho štítků: {0}"
-msgstr[2] "Máte příliš mnoho štítků: {0}"
 
 #: src/olympia/addons/forms.py:117
 #, python-format
@@ -120,42 +117,40 @@ msgid "All tags must be at least {0} character."
 msgid_plural "All tags must be at least {0} characters."
 msgstr[0] "Všechny štítky musí mít alespoň {0} znak."
 msgstr[1] "Všechny štítky musí mít alespoň {0} znaky."
-msgstr[2] "Všechny štítky musí mít alespoň {0} znaků."
 
-#: src/olympia/addons/forms.py:234
+#: src/olympia/addons/forms.py:238
 msgid "Categories cannot be changed while your add-on is featured for this application."
 msgstr "V době, kdy je váš doplněk pro tuto aplikaci veden jako doporučený, nemůžete změnit jeho umístění v kategoriích."
 
 #. L10n: {0} is the number of categories.
-#: src/olympia/addons/forms.py:238
+#: src/olympia/addons/forms.py:242
 msgid "You can have only {0} category."
 msgid_plural "You can have only {0} categories."
 msgstr[0] "Smíte být pouze v {0} kategorii."
 msgstr[1] "Smíte být pouze v {0} kategoriích."
-msgstr[2] "Smíte být pouze v {0} kategoriích."
 
-#: src/olympia/addons/forms.py:246
+#: src/olympia/addons/forms.py:250
 msgid "The miscellaneous category cannot be combined with additional categories."
 msgstr "Kategorie Různé nemůže být kombinována s jinými kategoriemi."
 
-#: src/olympia/addons/forms.py:369
+#: src/olympia/addons/forms.py:374
 #, python-format
 msgid "Before changing your default locale you must have a name, summary, and description in that locale. You are missing %s."
 msgstr "Dříve, než změníte výchozí jazyk, musíte mít v tomto jazyce vyplněno jméno, shrnutí a popis. Aktuálně vám chybí %s."
 
-#: src/olympia/addons/forms.py:484 src/olympia/addons/forms.py:575
+#: src/olympia/addons/forms.py:455 src/olympia/addons/forms.py:546
 msgid "A license must be selected."
 msgstr "Musí být zvolena licence."
 
-#: src/olympia/addons/forms.py:556
+#: src/olympia/addons/forms.py:527
 msgid "Give Your Theme a Name."
 msgstr "Napište název motivu."
 
-#: src/olympia/addons/forms.py:562 src/olympia/devhub/templates/devhub/personas/submit.html:53
+#: src/olympia/addons/forms.py:533 src/olympia/devhub/templates/devhub/personas/submit.html:53
 msgid "Describe your Theme."
 msgstr "Popište svůj motiv."
 
-#: src/olympia/addons/forms.py:704
+#: src/olympia/addons/forms.py:675
 msgid "Enter a new author's email address"
 msgstr "Vložte novou e-mailovou adresu autora"
 
@@ -163,39 +158,39 @@ msgstr "Vložte novou e-mailovou adresu autora"
 msgid "Not Reviewed"
 msgstr "Nezkontrolovaný"
 
-#: src/olympia/addons/models.py:301
+#: src/olympia/addons/models.py:298
 msgid "Users have the option of contributing more or less than this amount."
 msgstr "Uživatelé mají možnost přispět více nebo méně než je tato částka."
 
-#: src/olympia/addons/models.py:309
-msgid "Users will always be asked in the Add-ons Manager (Firefox 4 and above)"
-msgstr "Uživatelé budou vždy žádáni ve Správci doplňků (Firefox 4 a vyšší)"
+#: src/olympia/addons/models.py:306
+msgid "Users will always be asked in the Add-ons Manager (Firefox 4 and above). Only applies to desktop."
+msgstr ""
 
 # Column name in a table.
-#: src/olympia/addons/models.py:1804 src/olympia/addons/templates/addons/details_box.html:55 src/olympia/devhub/templates/devhub/index.html:92
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:102
+#: src/olympia/addons/models.py:1802 src/olympia/addons/templates/addons/details_box.html:55 src/olympia/devhub/templates/devhub/index.html:92
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:89
 msgid "Listed"
 msgstr "Zobrazení"
 
-#: src/olympia/addons/views.py:320 src/olympia/browse/templates/browse/personas/mobile/category_landing.html:27
+#: src/olympia/addons/views.py:334 src/olympia/browse/templates/browse/personas/mobile/category_landing.html:27
 msgid "Popular"
 msgstr "Populární"
 
-#: src/olympia/addons/views.py:321 src/olympia/browse/views.py:238 src/olympia/browse/views.py:280 src/olympia/browse/views.py:482
+#: src/olympia/addons/views.py:335 src/olympia/browse/views.py:205 src/olympia/browse/views.py:247 src/olympia/browse/views.py:449
 msgid "Recently Added"
 msgstr "Nedávno přidané"
 
-#: src/olympia/addons/views.py:322 src/olympia/bandwagon/views.py:99 src/olympia/browse/views.py:60 src/olympia/browse/views.py:71 src/olympia/search/forms.py:16 src/olympia/search/forms.py:91
+#: src/olympia/addons/views.py:336 src/olympia/bandwagon/views.py:99 src/olympia/browse/views.py:60 src/olympia/browse/views.py:71 src/olympia/search/forms.py:16 src/olympia/search/forms.py:91
 msgid "Recently Updated"
 msgstr "Nedávno aktualizované"
 
 # %1 is an add-on name.
 #. l10n: {0} is the addon name
-#: src/olympia/addons/views.py:520
+#: src/olympia/addons/views.py:534
 msgid "Contribution for {0}"
 msgstr "Příspěvek k {0}"
 
-#: src/olympia/addons/views.py:613
+#: src/olympia/addons/views.py:627
 msgid "Abuse reported."
 msgstr "Zneužití bylo nahlášeno."
 
@@ -264,9 +259,9 @@ msgstr "Přispět"
 #: src/olympia/devhub/templates/devhub/addons/ajax_compat_update.html:36 src/olympia/devhub/templates/devhub/addons/profile.html:44 src/olympia/devhub/templates/devhub/addons/edit/admin.html:101
 #: src/olympia/devhub/templates/devhub/addons/edit/basic.html:152 src/olympia/devhub/templates/devhub/addons/edit/details.html:85 src/olympia/devhub/templates/devhub/addons/edit/support.html:67
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:166 src/olympia/devhub/templates/devhub/addons/forms_shared/media.html:149
-#: src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:44 src/olympia/devhub/templates/devhub/versions/add_file_modal.html:78 src/olympia/devhub/templates/devhub/versions/edit.html:139
-#: src/olympia/devhub/templates/devhub/versions/list.html:242 src/olympia/devhub/templates/devhub/versions/list.html:276 src/olympia/devhub/templates/devhub/versions/list.html:317
-#: src/olympia/devhub/templates/devhub/versions/list.html:351 src/olympia/reviews/templates/reviews/edit_review.html:16 src/olympia/translations/templates/translations/trans-menu.html:50
+#: src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:43 src/olympia/devhub/templates/devhub/versions/add_file_modal.html:58 src/olympia/devhub/templates/devhub/versions/edit.html:139
+#: src/olympia/devhub/templates/devhub/versions/list.html:239 src/olympia/devhub/templates/devhub/versions/list.html:281 src/olympia/devhub/templates/devhub/versions/list.html:315
+#: src/olympia/devhub/templates/devhub/versions/list.html:349 src/olympia/reviews/templates/reviews/edit_review.html:16 src/olympia/translations/templates/translations/trans-menu.html:50
 #: src/olympia/translations/templates/translations/trans-menu.html:62
 msgid "or"
 msgstr "nebo"
@@ -335,8 +330,7 @@ msgstr "Částka příspěvku musí být číslo."
 msgid "A one-time suggested contribution of {0}"
 msgstr "Jednorázový navržený příspěvek {0}"
 
-#. {0} is a currency symbol (e.g., $),                    {1} is an amount
-#. input
+#. {0} is a currency symbol (e.g., $),                    {1} is an amount input
 #. field
 #: src/olympia/addons/templates/addons/contributions_lightbox.html:64
 msgid "A one-time contribution of {0} {1}"
@@ -377,7 +371,7 @@ msgid "Add-on Information for {0}"
 msgstr "Informace o doplňku {0}"
 
 #: src/olympia/addons/templates/addons/details_box.html:30 src/olympia/addons/templates/addons/persona_detail_table.html:3 src/olympia/addons/templates/addons/mobile/details.html:63
-#: src/olympia/addons/templates/addons/mobile/persona_detail_table.html:7 src/olympia/browse/views.py:459 src/olympia/devhub/views.py:75
+#: src/olympia/addons/templates/addons/mobile/persona_detail_table.html:7 src/olympia/browse/views.py:426 src/olympia/devhub/views.py:74
 msgid "Updated"
 msgstr "Aktualizováno"
 
@@ -396,11 +390,11 @@ msgstr "Podporuje"
 msgid "Visibility"
 msgstr "Viditelnost"
 
-#: src/olympia/addons/templates/addons/details_box.html:57 src/olympia/devhub/templates/devhub/index.html:94 src/olympia/devhub/templates/devhub/includes/addon_details.html:104
+#: src/olympia/addons/templates/addons/details_box.html:57 src/olympia/devhub/templates/devhub/index.html:94 src/olympia/devhub/templates/devhub/includes/addon_details.html:91
 msgid "Hidden"
 msgstr "Skryto"
 
-#: src/olympia/addons/templates/addons/details_box.html:59 src/olympia/devhub/templates/devhub/index.html:96 src/olympia/devhub/templates/devhub/includes/addon_details.html:106
+#: src/olympia/addons/templates/addons/details_box.html:59 src/olympia/devhub/templates/devhub/index.html:96 src/olympia/devhub/templates/devhub/includes/addon_details.html:93
 msgid "Unlisted"
 msgstr "Není v seznamu"
 
@@ -408,13 +402,13 @@ msgstr "Není v seznamu"
 msgid "Required Add-ons"
 msgstr "Vyžadované doplňky"
 
-#: src/olympia/addons/templates/addons/details_box.html:81 src/olympia/addons/templates/addons/persona_detail_table.html:15 src/olympia/browse/views.py:462 src/olympia/devhub/views.py:78
-#: src/olympia/devhub/views.py:85 src/olympia/discovery/templates/discovery/addons/detail.html:57 src/olympia/reviews/forms.py:62 src/olympia/reviews/templates/reviews/add.html:57
+#: src/olympia/addons/templates/addons/details_box.html:81 src/olympia/addons/templates/addons/persona_detail_table.html:15 src/olympia/browse/views.py:429 src/olympia/devhub/views.py:77
+#: src/olympia/devhub/views.py:84 src/olympia/discovery/templates/discovery/addons/detail.html:57 src/olympia/reviews/forms.py:62 src/olympia/reviews/templates/reviews/add.html:57
 #: src/olympia/reviews/templates/reviews/mobile/review_list.html:18
 msgid "Rating"
 msgstr "Hodnocení"
 
-#: src/olympia/addons/templates/addons/details_box.html:85 src/olympia/browse/views.py:461 src/olympia/devhub/views.py:77 src/olympia/devhub/views.py:84
+#: src/olympia/addons/templates/addons/details_box.html:85 src/olympia/browse/views.py:428 src/olympia/devhub/views.py:76 src/olympia/devhub/views.py:83
 #: src/olympia/stats/templates/stats/addon_report_menu.html:8 src/olympia/stats/templates/stats/collection_report_menu.html:18
 msgid "Downloads"
 msgstr "Stažení"
@@ -434,7 +428,7 @@ msgstr "Hlášená zneužití"
 
 #. The Privacy Policy for this add-on.
 #: src/olympia/addons/templates/addons/details_box.html:121 src/olympia/addons/templates/addons/privacy.html:19 src/olympia/addons/templates/addons/privacy.html:23
-#: src/olympia/addons/templates/addons/impala/button.html:43 src/olympia/addons/templates/addons/impala/details.html:307 src/olympia/devhub/templates/devhub/includes/policy_form.html:20
+#: src/olympia/addons/templates/addons/impala/button.html:43 src/olympia/addons/templates/addons/impala/details.html:312 src/olympia/devhub/templates/devhub/includes/policy_form.html:23
 #: src/olympia/templates/mobile/base_addons.html:87
 msgid "Privacy Policy"
 msgstr "Zásady ochrany soukromí"
@@ -459,7 +453,7 @@ msgstr "Galerie obrázků"
 msgid "Developer Comments"
 msgstr "Komentáře vývojáře"
 
-#: src/olympia/addons/templates/addons/details_box.html:199 src/olympia/addons/templates/addons/impala/details.html:259
+#: src/olympia/addons/templates/addons/details_box.html:199 src/olympia/addons/templates/addons/impala/details.html:264
 msgid "Development Channel"
 msgstr "Kanál s vývojovými verzemi"
 
@@ -483,12 +477,12 @@ msgstr ""
 "<strong>Upozornění:</strong> Vývojové verze tohoto doplňku nebyly Mozillou zkontrolovány. Jakmile si jednou nainstalujete vývojovou verzi, budete od vývojáře automaticky získávat aktualizace "
 "vývojové verze. Pro ukončení získávání vývojových verzí si nainstalujte standardní verzi z odkazu výše."
 
-#: src/olympia/addons/templates/addons/details_box.html:220 src/olympia/addons/templates/addons/impala/details.html:278
+#: src/olympia/addons/templates/addons/details_box.html:220 src/olympia/addons/templates/addons/impala/details.html:283
 msgid "Version {0}:"
 msgstr "Verze {0}:"
 
 #: src/olympia/addons/templates/addons/details_box.html:234
-msgid "Nothing to see here!  The developer did not include any details."
+msgid "Nothing to see here! The developer did not include any details."
 msgstr "Zde není nic k vidění! Vývojář neposkytl žádné detaily."
 
 #: src/olympia/addons/templates/addons/details_box.html:251 src/olympia/devhub/templates/devhub/versions/edit.html:73 src/olympia/editors/templates/editors/review.html:98
@@ -502,7 +496,7 @@ msgid "End-User License Agreement for {0}"
 msgstr "Koncové licenční ujednání pro {0}"
 
 #: src/olympia/addons/templates/addons/eula.html:17 src/olympia/addons/templates/addons/eula.html:21 src/olympia/addons/templates/addons/impala/button.html:48
-#: src/olympia/addons/templates/addons/impala/details.html:316 src/olympia/devhub/templates/devhub/includes/policy_form.html:3 src/olympia/discovery/templates/discovery/addons/eula.html:11
+#: src/olympia/addons/templates/addons/impala/details.html:321 src/olympia/devhub/templates/devhub/includes/policy_form.html:3 src/olympia/discovery/templates/discovery/addons/eula.html:11
 msgid "End-User License Agreement"
 msgstr "Licenční smlouva s koncovým uživatelem"
 
@@ -522,7 +516,7 @@ msgstr "Zpět na {0}…"
 msgid "Add-ons for {0}"
 msgstr "Doplňky aplikace {0}"
 
-#: src/olympia/addons/templates/addons/home.html:10 src/olympia/addons/templates/addons/home.html:51 src/olympia/browse/templates/browse/impala/base_listing.html:11
+#: src/olympia/addons/templates/addons/home.html:10 src/olympia/addons/templates/addons/home.html:53 src/olympia/browse/templates/browse/impala/base_listing.html:11
 msgid "Featured Extensions"
 msgstr "Doporučené doplňky"
 
@@ -530,29 +524,29 @@ msgstr "Doporučené doplňky"
 msgid "Popular Extensions"
 msgstr "Populární rozšíření"
 
-#: src/olympia/addons/templates/addons/home.html:42 src/olympia/amo/templates/amo/side_nav.html:3 src/olympia/amo/templates/amo/side_nav.html:11 src/olympia/amo/templates/amo/site_nav.html:3
-#: src/olympia/amo/templates/amo/site_nav.html:25 src/olympia/browse/views.py:236 src/olympia/browse/views.py:281 src/olympia/browse/views.py:481
+#: src/olympia/addons/templates/addons/home.html:44 src/olympia/amo/templates/amo/side_nav.html:3 src/olympia/amo/templates/amo/side_nav.html:11 src/olympia/amo/templates/amo/site_nav.html:3
+#: src/olympia/amo/templates/amo/site_nav.html:25 src/olympia/browse/views.py:203 src/olympia/browse/views.py:248 src/olympia/browse/views.py:448
 msgid "Most Popular"
 msgstr "Nejpopulárnější"
 
-#: src/olympia/addons/templates/addons/home.html:43
+#: src/olympia/addons/templates/addons/home.html:45
 msgid "All »"
 msgstr "Vše »"
 
-#: src/olympia/addons/templates/addons/home.html:52 src/olympia/addons/templates/addons/home.html:61 src/olympia/addons/templates/addons/home.html:70 src/olympia/addons/templates/addons/home.html:78
+#: src/olympia/addons/templates/addons/home.html:54 src/olympia/addons/templates/addons/home.html:63 src/olympia/addons/templates/addons/home.html:72 src/olympia/addons/templates/addons/home.html:80
 #: src/olympia/browse/templates/browse/impala/category_landing.html:36
 msgid "See all »"
 msgstr "Zobrazit vše »"
 
-#: src/olympia/addons/templates/addons/home.html:60
+#: src/olympia/addons/templates/addons/home.html:62
 msgid "Up &amp; Coming Extensions"
 msgstr "Úspěšná rozšíření"
 
-#: src/olympia/addons/templates/addons/home.html:69 src/olympia/browse/templates/browse/personas/category_landing.html:61 src/olympia/discovery/templates/discovery/pane.html:74
+#: src/olympia/addons/templates/addons/home.html:71 src/olympia/browse/templates/browse/personas/category_landing.html:61 src/olympia/discovery/templates/discovery/pane.html:74
 msgid "Featured Themes"
 msgstr "Doporučené motivy vzhledu"
 
-#: src/olympia/addons/templates/addons/home.html:77 src/olympia/bandwagon/templates/bandwagon/impala/collection_listing.html:5
+#: src/olympia/addons/templates/addons/home.html:79 src/olympia/bandwagon/templates/bandwagon/impala/collection_listing.html:5
 msgid "Featured Collections"
 msgstr "Doporučené sbírky"
 
@@ -570,7 +564,7 @@ msgid "Updated {0}"
 msgstr "Akualizováno {0}"
 
 #. {0} is a date.
-#: src/olympia/addons/templates/addons/macros.html:10 src/olympia/addons/templates/addons/macros.html:69 src/olympia/addons/templates/addons/persona_preview.html:21
+#: src/olympia/addons/templates/addons/macros.html:10 src/olympia/addons/templates/addons/macros.html:69 src/olympia/addons/templates/addons/persona_preview.html:22
 #: src/olympia/addons/templates/addons/listing/items_mobile.html:44 src/olympia/addons/templates/addons/listing/macros.html:39 src/olympia/bandwagon/templates/bandwagon/collection_listing_items.html:37
 #: src/olympia/bandwagon/templates/bandwagon/impala/collection_listing_items.html:37
 msgid "Added {0}"
@@ -582,7 +576,6 @@ msgid "%(num)s weekly download"
 msgid_plural "%(num)s weekly downloads"
 msgstr[0] "%(num)s stažení týdně"
 msgstr[1] "%(num)s stažení týdně"
-msgstr[2] "%(num)s stažení týdně"
 
 #: src/olympia/addons/templates/addons/macros.html:28
 #, python-format
@@ -590,24 +583,20 @@ msgid "%(num)s user"
 msgid_plural "%(num)s users"
 msgstr[0] "%(num)s uživatel"
 msgstr[1] "%(num)s uživatelé"
-msgstr[2] "%(num)s uživatelů"
 
 #. {0} is the number of downloads.
-#: src/olympia/addons/templates/addons/macros.html:53 src/olympia/addons/templates/addons/impala/details.html:61
+#: src/olympia/addons/templates/addons/macros.html:53 src/olympia/addons/templates/addons/impala/details.html:59
 msgid "{0} weekly download"
 msgid_plural "{0} weekly downloads"
 msgstr[0] "{0} stažení týdně"
 msgstr[1] "{0} stažení týdně"
-msgstr[2] "{0} stažení týdně"
 
 #. {0} is the number of users.
-#: src/olympia/addons/templates/addons/macros.html:61 src/olympia/addons/templates/addons/impala/details.html:54 src/olympia/compat/templates/compat/index.html:71
-#: src/olympia/zadmin/templates/zadmin/compat.html:67
+#: src/olympia/addons/templates/addons/macros.html:61 src/olympia/addons/templates/addons/impala/details.html:52 src/olympia/zadmin/templates/zadmin/compat.html:67
 msgid "{0} user"
 msgid_plural "{0} users"
 msgstr[0] "{0} uživatel"
 msgstr[1] "{0} uživatelé"
-msgstr[2] "{0} uživatelů"
 
 #: src/olympia/addons/templates/addons/paypal_result.html:12
 msgid "Payment cancelled"
@@ -621,7 +610,7 @@ msgstr "Platba dokončena"
 msgid "Return to the addon."
 msgstr "Zpět na doplněk."
 
-#: src/olympia/addons/templates/addons/persona_detail.html:17 src/olympia/addons/templates/addons/impala/details.html:106 src/olympia/addons/templates/addons/mobile/details.html:23
+#: src/olympia/addons/templates/addons/persona_detail.html:17 src/olympia/addons/templates/addons/impala/details.html:103 src/olympia/addons/templates/addons/mobile/details.html:23
 #: src/olympia/addons/templates/addons/mobile/persona_detail.html:21 src/olympia/discovery/templates/discovery/addons/base.html:27 src/olympia/editors/templates/editors/review.html:31
 msgid "by"
 msgstr "od"
@@ -665,35 +654,35 @@ msgstr "Denních uživatelů"
 msgid "License"
 msgstr "Licence"
 
-#: src/olympia/addons/templates/addons/persona_preview.html:12 src/olympia/constants/base.py:48
+#: src/olympia/addons/templates/addons/persona_preview.html:13 src/olympia/constants/base.py:48
 msgid "Awaiting Review"
 msgstr "Čeká na kontrolu"
 
-#: src/olympia/addons/templates/addons/persona_preview.html:14 src/olympia/amo/log.py:180 src/olympia/constants/base.py:42 src/olympia/editors/helpers.py:62
+#: src/olympia/addons/templates/addons/persona_preview.html:15 src/olympia/amo/log.py:180 src/olympia/constants/base.py:42 src/olympia/editors/helpers.py:62
 msgid "Rejected"
 msgstr "Zamítnuto"
 
-#: src/olympia/addons/templates/addons/persona_preview.html:16 src/olympia/amo/log.py:159
+#: src/olympia/addons/templates/addons/persona_preview.html:17 src/olympia/amo/log.py:159
 msgid "Approved"
 msgstr "Schváleno"
 
 #. {0} is the number of users.
-#: src/olympia/addons/templates/addons/persona_preview.html:26 src/olympia/addons/templates/addons/listing/items_mobile.html:36 src/olympia/addons/templates/addons/listing/macros.html:31
+#: src/olympia/addons/templates/addons/persona_preview.html:27 src/olympia/addons/templates/addons/listing/items_mobile.html:36 src/olympia/addons/templates/addons/listing/macros.html:31
 msgid "<strong>{0}</strong> user"
 msgid_plural "<strong>{0}</strong> users"
 msgstr[0] "<strong>{0}</strong> uživatel"
 msgstr[1] "<strong>{0}</strong> uživatelé"
-msgstr[2] "<strong>{0}</strong> uživatelů"
 
-#: src/olympia/addons/templates/addons/persona_preview.html:40
+#: src/olympia/addons/templates/addons/persona_preview.html:41
 msgid "Hover to Preview"
 msgstr "Pro náhled přejeďte myší"
 
-#: src/olympia/addons/templates/addons/persona_preview.html:46 src/olympia/addons/templates/addons/persona_preview.html:48 src/olympia/reviews/templates/reviews/add.html:15
+#: src/olympia/addons/templates/addons/persona_preview.html:47 src/olympia/addons/templates/addons/persona_preview.html:49 src/olympia/addons/templates/addons/persona_preview.html:97
+#: src/olympia/reviews/templates/reviews/add.html:15
 msgid "Add"
 msgstr "Přidat"
 
-#: src/olympia/addons/templates/addons/persona_preview.html:57 src/olympia/bandwagon/templates/bandwagon/ajax_new.html:16 src/olympia/bandwagon/templates/bandwagon/edit.html:19
+#: src/olympia/addons/templates/addons/persona_preview.html:58 src/olympia/bandwagon/templates/bandwagon/ajax_new.html:16 src/olympia/bandwagon/templates/bandwagon/edit.html:19
 #: src/olympia/bandwagon/templates/bandwagon/includes/addedit.html:19 src/olympia/devhub/templates/devhub/addons/edit/admin.html:13 src/olympia/devhub/templates/devhub/addons/edit/basic.html:10
 #: src/olympia/devhub/templates/devhub/addons/edit/details.html:8 src/olympia/devhub/templates/devhub/addons/edit/media.html:6 src/olympia/devhub/templates/devhub/addons/edit/support.html:8
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:9 src/olympia/devhub/templates/devhub/addons/submit/describe.html:29 src/olympia/editors/templates/editors/review.html:257
@@ -702,21 +691,21 @@ msgstr "Upravit"
 
 #. For datetime formatting, see the table on
 #. http://docs.python.org/library/datetime.html#strftime-and-strptime-behavior
-#: src/olympia/addons/templates/addons/persona_preview.html:66
+#: src/olympia/addons/templates/addons/persona_preview.html:67
 #, python-format
 msgid "%%Y-%%m-%%d"
 msgstr "%%d.%%m.%%Y"
 
-#: src/olympia/addons/templates/addons/persona_preview.html:67
+#: src/olympia/addons/templates/addons/persona_preview.html:68
 msgid "by {0} on {1}"
 msgstr "uživatelem {0} dne {1}"
 
-#: src/olympia/addons/templates/addons/persona_preview.html:75 src/olympia/reviews/helpers.py:17 src/olympia/reviews/templates/reviews/review_list.html:63
+#: src/olympia/addons/templates/addons/persona_preview.html:76 src/olympia/reviews/helpers.py:17 src/olympia/reviews/templates/reviews/review_list.html:63
 #: src/olympia/reviews/templates/reviews/reviews_link.html:21 src/olympia/reviews/templates/reviews/impala/reviews_link.html:16
 msgid "Not yet rated"
 msgstr "Nehodnoceno"
 
-#: src/olympia/addons/templates/addons/persona_preview.html:78
+#: src/olympia/addons/templates/addons/persona_preview.html:79
 msgid "<b>{0}</b> users"
 msgstr "<b>{0}</b> uživatelů"
 
@@ -729,8 +718,8 @@ msgid "Learn more about Firefox"
 msgstr "Dozvědět se více o Firefoxu"
 
 #: src/olympia/addons/templates/addons/popups.html:22
-msgid "or <b><a class=\"installer\" href=\"{url}\">download anyway</a></b>"
-msgstr "nebo <b><a class=\"installer\" href=\"{url}\">přesto stáhnout</a></b>"
+msgid "or <b><a class=\"button installer\" href=\"{url}\">download anyway</a></b>"
+msgstr ""
 
 #: src/olympia/addons/templates/addons/popups.html:26
 msgid ""
@@ -791,11 +780,11 @@ msgstr "Persona vyžaduje %(app)s %(new_version)s. Aktuálně používáte %(app
 
 #: src/olympia/addons/templates/addons/popups.html:108
 msgid ""
-"<strong>Caution:</strong> This add-on has not been reviewed by Mozilla and can't be installed on release versions of Firefox 43 and above.  Be careful when installing third-party software that "
-"might harm your computer."
+"<strong>Caution:</strong> This add-on has not been reviewed by Mozilla and can't be installed on release versions of Firefox 43 and above. Be careful when installing third-party software that might"
+" harm your computer."
 msgstr ""
-"<strong>Varování:</strong> Tento doplněk nebyl zkontrolován Mozillou a nemůže být nainstalován do Firefoxu verze 43 a vyšší. Buďte opatrní při instalaci softwaru třetích stran, který může být "
-"škodlivý pro váš počítač."
+"<strong>Varování:</strong> Tento doplněk nebyl zkontrolován Mozillou a nemůže být nainstalován na Firefox verze 43 a vyšší. Při instalaci softwaru třetích stran buďte opatrní, jelikož takový "
+"software může poškodit váš počítač."
 
 #: src/olympia/addons/templates/addons/popups.html:120
 msgid "<strong>Please note:</strong> This add-on is not compatible with your operating system."
@@ -825,14 +814,11 @@ msgid "QR code for add-on"
 msgstr "QR kód doplňku"
 
 #: src/olympia/addons/templates/addons/qr_code.html:6
-msgid ""
-"Want {0} on your mobile Firefox?  Scan this QR code to install directly\n"
-"  to your phone.  (You'll need a QR reader.  Search your phone's marketplace if\n"
-"  don't have one.)"
+msgid "Want {0} on your mobile Firefox? Scan this QR code to install directly to your phone. (You'll need a QR reader. Search your phone's marketplace if don't have one.)"
 msgstr "Chcete {0} do své mobilní verze Firefoxu? Pro přímou instalaci si sejměte tento QR kód. (Budete potřebovat čtečku QR kódu. Pokud ji nemáte, podívejte se do obchodu s aplikacemi pro váš telefon.)"
 
 #: src/olympia/addons/templates/addons/report_abuse.html:6 src/olympia/addons/templates/addons/report_abuse_full.html:10 src/olympia/addons/templates/addons/impala/details-more.html:23
-#: src/olympia/addons/templates/addons/impala/details.html:328
+#: src/olympia/addons/templates/addons/impala/details.html:333
 msgid "Report Abuse"
 msgstr "Nahlásit zneužití"
 
@@ -853,9 +839,9 @@ msgstr "Odeslat hlášení"
 #: src/olympia/devhub/templates/devhub/addons/ajax_compat_update.html:36 src/olympia/devhub/templates/devhub/addons/profile.html:44 src/olympia/devhub/templates/devhub/addons/edit/admin.html:104
 #: src/olympia/devhub/templates/devhub/addons/edit/basic.html:155 src/olympia/devhub/templates/devhub/addons/edit/details.html:88 src/olympia/devhub/templates/devhub/addons/edit/support.html:70
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:169 src/olympia/devhub/templates/devhub/addons/forms_shared/media.html:152
-#: src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:44 src/olympia/devhub/templates/devhub/personas/edit.html:222 src/olympia/devhub/templates/devhub/versions/add_file_modal.html:79
-#: src/olympia/devhub/templates/devhub/versions/edit.html:140 src/olympia/devhub/templates/devhub/versions/list.html:208 src/olympia/devhub/templates/devhub/versions/list.html:242
-#: src/olympia/devhub/templates/devhub/versions/list.html:276 src/olympia/devhub/templates/devhub/versions/list.html:317 src/olympia/reviews/templates/reviews/edit_review.html:16
+#: src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:43 src/olympia/devhub/templates/devhub/personas/edit.html:222 src/olympia/devhub/templates/devhub/versions/add_file_modal.html:59
+#: src/olympia/devhub/templates/devhub/versions/edit.html:140 src/olympia/devhub/templates/devhub/versions/list.html:208 src/olympia/devhub/templates/devhub/versions/list.html:239
+#: src/olympia/devhub/templates/devhub/versions/list.html:281 src/olympia/devhub/templates/devhub/versions/list.html:315 src/olympia/reviews/templates/reviews/edit_review.html:16
 #: src/olympia/translations/templates/translations/trans-menu.html:50 src/olympia/translations/templates/translations/trans-menu.html:62 src/olympia/zadmin/templates/zadmin/validation.html:105
 msgid "Cancel"
 msgstr "Zrušit"
@@ -900,7 +886,7 @@ msgstr "Podívejte se na <a href=\"%(support)s\">sekci podpory</a>, kde naleznet
 msgid "Review Guidelines"
 msgstr "Příručka recenzenta"
 
-#: src/olympia/addons/templates/addons/review_list_box.html:5 src/olympia/addons/templates/addons/impala/details-more.html:27 src/olympia/editors/helpers.py:921
+#: src/olympia/addons/templates/addons/review_list_box.html:5 src/olympia/addons/templates/addons/impala/details-more.html:27 src/olympia/editors/helpers.py:1001
 #: src/olympia/reviews/templates/reviews/add.html:14 src/olympia/reviews/templates/reviews/reply.html:14 src/olympia/reviews/templates/reviews/review_list.html:19
 #: src/olympia/reviews/templates/reviews/mobile/review_list.html:26
 msgid "Reviews"
@@ -921,7 +907,6 @@ msgid "See all reviews of this add-on"
 msgid_plural "See all %(cnt)s reviews of this add-on"
 msgstr[0] "Zobrazit všechny recenze tohoto doplňku"
 msgstr[1] "Zobrazit %(cnt)s recenze tohoto doplňku"
-msgstr[2] "Zobrazit %(cnt)s recenzí tohoto doplňku"
 
 #: src/olympia/addons/templates/addons/tags_box.html:3 src/olympia/devhub/templates/devhub/addons/edit/basic.html:118
 msgid "Tags"
@@ -991,108 +976,105 @@ msgid "Other add-ons by %(author)s"
 msgid_plural "Other add-ons by these authors"
 msgstr[0] "Ostatní doplňky autora %(author)s"
 msgstr[1] "Ostatní doplňky těchto autorů"
-msgstr[2] "Ostatní doplňky těchto autorů"
 
-#: src/olympia/addons/templates/addons/impala/details.html:41
+#: src/olympia/addons/templates/addons/impala/details.html:39
 #, python-format
 msgid "<span itemprop=\"ratingCount\">%(num)s</span> user review"
 msgid_plural "<span itemprop=\"ratingCount\">%(num)s</span> user reviews"
 msgstr[0] "<span itemprop=\"ratingCount\">%(num)s</span> recenze"
 msgstr[1] "<span itemprop=\"ratingCount\">%(num)s</span> recenze"
-msgstr[2] "<span itemprop=\"ratingCount\">%(num)s</span> recenzí"
 
-#: src/olympia/addons/templates/addons/impala/details.html:69
+#: src/olympia/addons/templates/addons/impala/details.html:66
 msgid "View statistics"
 msgstr "Zobrazit statistiky"
 
-#: src/olympia/addons/templates/addons/impala/details.html:84
+#: src/olympia/addons/templates/addons/impala/details.html:81
 msgid "Manage"
 msgstr "Správa"
 
 #. {0} is an add-on name.
-#: src/olympia/addons/templates/addons/impala/details.html:96
+#: src/olympia/addons/templates/addons/impala/details.html:93
 msgid "Icon of {0}"
 msgstr "Ikona doplňku {0}"
 
-#: src/olympia/addons/templates/addons/impala/details.html:103 src/olympia/addons/templates/addons/impala/listing/items.html:14
+#: src/olympia/addons/templates/addons/impala/details.html:100 src/olympia/addons/templates/addons/impala/listing/items.html:14
 msgid "No Restart"
 msgstr "Nevyžaduje restart"
 
-#: src/olympia/addons/templates/addons/impala/details.html:127
+#: src/olympia/addons/templates/addons/impala/details.html:124
 #, python-format
 msgid "Meet the Developer: <a href=\"%(url)s\">%(name)s</a>"
 msgid_plural "<a href=\"%(url)s\">Meet the Developers</a>"
 msgstr[0] "Seznamte se s vývojářem: <a href=\"%(url)s\">%(name)s</a>"
 msgstr[1] "<a href=\"%(url)s\">Seznamte se s vývojáři</a>"
-msgstr[2] "<a href=\"%(url)s\">Seznamte se s vývojáři</a>"
 
 # {0} is an add-on name.
-#: src/olympia/addons/templates/addons/impala/details.html:137
+#: src/olympia/addons/templates/addons/impala/details.html:134
 msgid "Learn why {0} was created and find out what's next for this add-on."
 msgstr "Přečtěte si, proč byl doplněk {0} vytvořen a co dalšího je plánováno."
 
 #. {0} is an index.
-#: src/olympia/addons/templates/addons/impala/details.html:156
+#: src/olympia/addons/templates/addons/impala/details.html:161
 msgid "Add-on screenshot #{0}"
 msgstr "Obrázek doplňku #{0}"
 
-#: src/olympia/addons/templates/addons/impala/details.html:182
+#: src/olympia/addons/templates/addons/impala/details.html:187
 msgid "Add-on home page"
 msgstr "Domovská stránka"
 
-#: src/olympia/addons/templates/addons/impala/details.html:185
+#: src/olympia/addons/templates/addons/impala/details.html:190
 msgid "Support site"
 msgstr "Stránka podpory"
 
-#: src/olympia/addons/templates/addons/impala/details.html:189
+#: src/olympia/addons/templates/addons/impala/details.html:194
 msgid "Support E-mail"
 msgstr "E-mail podpory"
 
-#: src/olympia/addons/templates/addons/impala/details.html:194 src/olympia/devhub/models.py:378 src/olympia/devhub/templates/devhub/versions/list.html:12
+#: src/olympia/addons/templates/addons/impala/details.html:199 src/olympia/devhub/models.py:378 src/olympia/devhub/templates/devhub/versions/list.html:12
 #: src/olympia/versions/templates/versions/version.html:6 src/olympia/versions/templates/versions/mobile/version.html:6
 msgid "Version {0}"
 msgstr "Verze {0}"
 
-#: src/olympia/addons/templates/addons/impala/details.html:194
+#: src/olympia/addons/templates/addons/impala/details.html:199
 msgid "Info"
 msgstr "Informace"
 
-#: src/olympia/addons/templates/addons/impala/details.html:195 src/olympia/devhub/templates/devhub/includes/addon_details.html:129
+#: src/olympia/addons/templates/addons/impala/details.html:200 src/olympia/devhub/templates/devhub/includes/addon_details.html:116
 msgid "Last Updated:"
 msgstr "Naposledy aktualizován:"
 
-#: src/olympia/addons/templates/addons/impala/details.html:200
+#: src/olympia/addons/templates/addons/impala/details.html:205
 #, python-format
 msgid "Released under <a target=\"_blank\" href=\"%(url)s\">%(name)s</a>"
 msgstr "Uvolněno pod <a target=\"_blank\" href=\"%(url)s\">%(name)s</a>"
 
-#: src/olympia/addons/templates/addons/impala/details.html:201 src/olympia/addons/templates/addons/impala/details.html:206 src/olympia/amo/helpers.py:398 src/olympia/devhub/forms.py:142
+#: src/olympia/addons/templates/addons/impala/details.html:206 src/olympia/addons/templates/addons/impala/details.html:211 src/olympia/amo/helpers.py:398 src/olympia/devhub/forms.py:142
 #: src/olympia/devhub/forms.py:173 src/olympia/versions/templates/versions/version.html:40 src/olympia/versions/templates/versions/version.html:45
 msgid "Custom License"
 msgstr "Vlastní licence"
 
-#: src/olympia/addons/templates/addons/impala/details.html:205
+#: src/olympia/addons/templates/addons/impala/details.html:210
 #, python-format
 msgid "Released under <a href=\"%(url)s\">%(name)s</a>"
 msgstr "Vydáno pod <a href=\"%(url)s\">%(name)s</a>"
 
-#: src/olympia/addons/templates/addons/impala/details.html:217
+#: src/olympia/addons/templates/addons/impala/details.html:222
 msgid "About this Add-on"
 msgstr "O doplňku"
 
-#: src/olympia/addons/templates/addons/impala/details.html:233
+#: src/olympia/addons/templates/addons/impala/details.html:238
 msgid "Developer’s Comments"
 msgstr "Poznámky vývojáře"
 
-#: src/olympia/addons/templates/addons/impala/details.html:243
+#: src/olympia/addons/templates/addons/impala/details.html:248
 msgid "Version Information"
 msgstr "Informace o verzi"
 
-#: src/olympia/addons/templates/addons/impala/details.html:250
+#: src/olympia/addons/templates/addons/impala/details.html:255
 msgid "See complete version history"
 msgstr "Zobrazit celou historii verzí"
 
-#: src/olympia/addons/templates/addons/impala/details.html:262
+#: src/olympia/addons/templates/addons/impala/details.html:267
 msgid ""
 "The Development Channel lets you test an experimental new version of this add-on before it's released to the general public. Once you install the development version, you will continue to get "
 "updates from this channel. To stop receiving development updates, reinstall the default version from the link above."
@@ -1100,17 +1082,17 @@ msgstr ""
 "Kanál vývojových verzí vám umožňuje testovat experimentální nové verze tohoto doplňku dříve, než budou veřejně dostupné. Jakmile jednou nainstalujete vývojovou verzi, budete nadále dostávat "
 "aktualizace z tohoto kanálu. Pro ukončení získávání vývojových verzí si nainstalujte stabilní verzi odkázanou výše."
 
-#: src/olympia/addons/templates/addons/impala/details.html:272
+#: src/olympia/addons/templates/addons/impala/details.html:277
 msgid "<strong>Caution:</strong> Development versions of this add-on have not been reviewed by Mozilla."
 msgstr "<strong>Varování:</strong> Vývojové verze tohoto doplňku nebyly zkontrolovány Mozillou."
 
-#: src/olympia/addons/templates/addons/impala/details.html:287
+#: src/olympia/addons/templates/addons/impala/details.html:292
 msgid "See complete development channel history"
 msgstr "Zobrazit úplnou historii vývoje"
 
-#: src/olympia/addons/templates/addons/impala/details.html:306 src/olympia/addons/templates/addons/impala/details.html:315 src/olympia/addons/templates/addons/impala/details.html:327
+#: src/olympia/addons/templates/addons/impala/details.html:311 src/olympia/addons/templates/addons/impala/details.html:320 src/olympia/addons/templates/addons/impala/details.html:332
 #: src/olympia/addons/templates/addons/impala/review_add_box.html:4 src/olympia/stats/templates/stats/popup.html:2 src/olympia/stats/templates/stats/popup.html:8
-#: src/olympia/stats/templates/stats/stats.html:202 src/olympia/users/templates/users/profile.html:119
+#: src/olympia/stats/templates/stats/stats.html:204 src/olympia/users/templates/users/profile.html:119
 msgid "close"
 msgstr "zavřít"
 
@@ -1144,7 +1126,6 @@ msgid "About the Developer"
 msgid_plural "About the Developers"
 msgstr[0] "O vývojáři"
 msgstr[1] "O vývojářích"
-msgstr[2] "O vývojářích"
 
 #: src/olympia/addons/templates/addons/impala/developers.html:96 src/olympia/users/templates/users/edit.html:130 src/olympia/users/templates/users/profile.html:26
 msgid "No Photo"
@@ -1170,15 +1151,11 @@ msgstr "Licence zdrojového kódu doplňku {addon}"
 msgid "Source Code License"
 msgstr "Licence zdrojového kódu"
 
-#: src/olympia/addons/templates/addons/impala/persona_grid.html:16 src/olympia/addons/templates/addons/impala/toplist.html:6
-msgid "{0} users"
-msgstr "{0} uživatelů"
-
 #: src/olympia/addons/templates/addons/impala/review_list_box.html:19 src/olympia/reviews/templates/reviews/review.html:40
 msgid "permalink"
 msgstr "trvalý odkaz"
 
-#: src/olympia/addons/templates/addons/impala/review_list_box.html:23 src/olympia/editors/templates/editors/queue.html:98 src/olympia/reviews/templates/reviews/review.html:44
+#: src/olympia/addons/templates/addons/impala/review_list_box.html:23 src/olympia/editors/templates/editors/queue.html:104 src/olympia/reviews/templates/reviews/review.html:44
 msgid "translate"
 msgstr "přeložit"
 
@@ -1188,7 +1165,6 @@ msgid "See all user reviews"
 msgid_plural "See all %(cnt)s user reviews"
 msgstr[0] "Zobrazit všechny recenze uživatelů"
 msgstr[1] "Zobrazit %(cnt)s recenze uživatelů"
-msgstr[2] "Zobrazit %(cnt)s recenzí uživatelů"
 
 #: src/olympia/addons/templates/addons/impala/review_list_box.html:47 src/olympia/reviews/templates/reviews/review_list.html:84
 msgid "This add-on has not yet been reviewed."
@@ -1197,6 +1173,10 @@ msgstr "Doplněk dosud nebyl recenzován."
 #: src/olympia/addons/templates/addons/impala/review_list_box.html:50
 msgid "Be the first!"
 msgstr "Buďte první!"
+
+#: src/olympia/addons/templates/addons/impala/toplist.html:6
+msgid "{0} users"
+msgstr "{0} uživatelů"
 
 #: src/olympia/addons/templates/addons/impala/listing/sorter.html:14 src/olympia/devhub/templates/devhub/addons/listing/item_actions.html:49
 msgid "More"
@@ -1210,7 +1190,7 @@ msgstr "Přidat do sbírky"
 msgid "My Add-ons"
 msgstr "Mé doplňky"
 
-#: src/olympia/addons/templates/addons/includes/dashboard_tabs.html:6 src/olympia/amo/context_processors.py:51
+#: src/olympia/addons/templates/addons/includes/dashboard_tabs.html:6 src/olympia/amo/context_processors.py:52
 msgid "My Themes"
 msgstr "Mé motivy vzhledu"
 
@@ -1252,7 +1232,6 @@ msgid "<strong>{0}</strong> weekly download"
 msgid_plural "<strong>{0}</strong> weekly downloads"
 msgstr[0] "<strong>{0}</strong> stažení týdně"
 msgstr[1] "<strong>{0}</strong> stažení týdně"
-msgstr[2] "<strong>{0}</strong> stažení týdně"
 
 #: src/olympia/addons/templates/addons/mobile/details.html:32
 msgid "Read More"
@@ -1266,7 +1245,7 @@ msgstr "Uživatelé"
 msgid "Weekly Downloads"
 msgstr "Týdenní stažení"
 
-#: src/olympia/addons/templates/addons/mobile/details.html:99 src/olympia/compat/templates/compat/reporter_detail.html:46 src/olympia/devhub/forms.py:787
+#: src/olympia/addons/templates/addons/mobile/details.html:99 src/olympia/compat/templates/compat/reporter_detail.html:46 src/olympia/devhub/forms.py:788
 #: src/olympia/devhub/templates/devhub/versions/list.html:163
 msgid "Version"
 msgstr "Verze"
@@ -1351,7 +1330,7 @@ msgstr ""
 #: src/olympia/browse/templates/browse/personas/base.html:6 src/olympia/browse/templates/browse/personas/base.html:42 src/olympia/browse/templates/browse/personas/category_landing.html:21
 #: src/olympia/browse/templates/browse/personas/category_landing.html:23 src/olympia/browse/templates/browse/personas/category_landing.html:38 src/olympia/browse/templates/browse/personas/grid.html:7
 #: src/olympia/browse/templates/browse/personas/grid.html:11 src/olympia/browse/templates/browse/personas/mobile/base.html:7 src/olympia/browse/templates/browse/personas/mobile/category_landing.html:19
-#: src/olympia/constants/base.py:180 src/olympia/devhub/templates/devhub/personas/submit.html:13 src/olympia/editors/helpers.py:105 src/olympia/editors/templates/editors/base.html:26
+#: src/olympia/constants/base.py:180 src/olympia/devhub/templates/devhub/personas/submit.html:13 src/olympia/editors/helpers.py:107 src/olympia/editors/templates/editors/base.html:26
 #: src/olympia/editors/templates/editors/performance.html:73 src/olympia/search/templates/search/personas.html:39 src/olympia/templates/menu_links.html:9
 msgid "Themes"
 msgstr "Motivy vzhledu"
@@ -1372,7 +1351,7 @@ msgstr "Více doplňků"
 msgid "Highest Rated"
 msgstr "Nejvýše hodnocené"
 
-#: src/olympia/addons/templates/addons/mobile/home.html:74 src/olympia/amo/templates/amo/side_nav.html:5 src/olympia/amo/templates/amo/site_nav.html:27 src/olympia/amo/templates/amo/site_nav.html:57
+#: src/olympia/addons/templates/addons/mobile/home.html:74 src/olympia/amo/templates/amo/side_nav.html:5 src/olympia/amo/templates/amo/site_nav.html:27 src/olympia/amo/templates/amo/site_nav.html:55
 #: src/olympia/bandwagon/views.py:97 src/olympia/browse/views.py:57 src/olympia/browse/views.py:67 src/olympia/browse/templates/browse/personas/mobile/category_landing.html:65
 #: src/olympia/search/forms.py:15 src/olympia/search/forms.py:87
 msgid "Newest"
@@ -1390,84 +1369,84 @@ msgstr "Informace o motivu &raquo;"
 msgid "Tools"
 msgstr "Nástroje"
 
-#: src/olympia/amo/context_processors.py:48 src/olympia/discovery/templates/discovery/pane_account.html:8 src/olympia/users/templates/users/includes/navigation.html:2
+#: src/olympia/amo/context_processors.py:49 src/olympia/discovery/templates/discovery/pane_account.html:8 src/olympia/users/templates/users/includes/navigation.html:2
 msgid "My Profile"
 msgstr "Můj účet"
 
-#: src/olympia/amo/context_processors.py:54 src/olympia/users/templates/users/edit.html:5 src/olympia/users/templates/users/includes/navigation.html:3
+#: src/olympia/amo/context_processors.py:55 src/olympia/users/templates/users/edit.html:5 src/olympia/users/templates/users/includes/navigation.html:3
 msgid "Account Settings"
 msgstr "Nastavení účtu"
 
-#: src/olympia/amo/context_processors.py:57 src/olympia/discovery/templates/discovery/pane_account.html:11 src/olympia/users/templates/users/profile.html:83
+#: src/olympia/amo/context_processors.py:58 src/olympia/discovery/templates/discovery/pane_account.html:11 src/olympia/users/templates/users/profile.html:83
 #: src/olympia/users/templates/users/includes/navigation.html:4
 msgid "My Collections"
 msgstr "Mé sbírky"
 
-#: src/olympia/amo/context_processors.py:62 src/olympia/discovery/templates/discovery/pane_account.html:10 src/olympia/users/templates/users/includes/navigation.html:7
+#: src/olympia/amo/context_processors.py:63 src/olympia/discovery/templates/discovery/pane_account.html:10 src/olympia/users/templates/users/includes/navigation.html:7
 msgid "My Favorites"
 msgstr "Mé oblíbené"
 
-#: src/olympia/amo/context_processors.py:67 src/olympia/discovery/templates/discovery/pane_account.html:13 src/olympia/templates/impala/user_login.html:14 src/olympia/templates/mobile/header_auth.html:5
+#: src/olympia/amo/context_processors.py:68 src/olympia/discovery/templates/discovery/pane_account.html:13 src/olympia/templates/impala/user_login.html:14 src/olympia/templates/mobile/header_auth.html:5
 msgid "Log out"
 msgstr "Odhlášení"
 
-#: src/olympia/amo/context_processors.py:72 src/olympia/devhub/templates/devhub/addons/dashboard.html:4
+#: src/olympia/amo/context_processors.py:73 src/olympia/devhub/templates/devhub/addons/dashboard.html:4
 msgid "Manage My Submissions"
 msgstr "Správa mých příspěvků"
 
-#: src/olympia/amo/context_processors.py:75 src/olympia/devhub/templates/devhub/nav.html:27 src/olympia/devhub/templates/devhub/addons/dashboard.html:25
+#: src/olympia/amo/context_processors.py:76 src/olympia/devhub/templates/devhub/nav.html:27 src/olympia/devhub/templates/devhub/addons/dashboard.html:25
 #: src/olympia/devhub/templates/devhub/addons/submit/base.html:4
 msgid "Submit a New Add-on"
 msgstr "Přidání nového doplňku"
 
-#: src/olympia/amo/context_processors.py:77 src/olympia/browse/templates/browse/personas/base.html:50 src/olympia/devhub/templates/devhub/index.html:24
+#: src/olympia/amo/context_processors.py:78 src/olympia/browse/templates/browse/personas/base.html:50 src/olympia/devhub/templates/devhub/index.html:24
 #: src/olympia/devhub/templates/devhub/addons/dashboard.html:29
 msgid "Submit a New Theme"
 msgstr "Přidání nového motivu"
 
-#: src/olympia/amo/context_processors.py:79 src/olympia/amo/templates/amo/site_nav.html:87 src/olympia/devhub/helpers.py:36 src/olympia/devhub/helpers.py:68 src/olympia/devhub/helpers.py:102
+#: src/olympia/amo/context_processors.py:80 src/olympia/amo/templates/amo/site_nav.html:85 src/olympia/devhub/helpers.py:36 src/olympia/devhub/helpers.py:68 src/olympia/devhub/helpers.py:102
 #: src/olympia/templates/footer.html:6 src/olympia/templates/menu_links.html:14
 msgid "Developer Hub"
 msgstr "Pro vývojáře"
 
-#: src/olympia/amo/context_processors.py:83 src/olympia/devhub/views.py:1792
+#: src/olympia/amo/context_processors.py:84 src/olympia/devhub/views.py:1799
 msgid "Manage API Keys"
 msgstr "Spravovat API klíče"
 
-#: src/olympia/amo/context_processors.py:88 src/olympia/editors/helpers.py:82 src/olympia/editors/helpers.py:102 src/olympia/editors/templates/editors/base.html:10
+#: src/olympia/amo/context_processors.py:89 src/olympia/editors/helpers.py:84 src/olympia/editors/helpers.py:104 src/olympia/editors/templates/editors/base.html:10
 msgid "Editor Tools"
 msgstr "Nástroje redaktora"
 
-#: src/olympia/amo/context_processors.py:92
+#: src/olympia/amo/context_processors.py:93
 msgid "Admin Tools"
 msgstr "Nástroje administrátora"
 
-#: src/olympia/amo/fields.py:15
+#: src/olympia/amo/fields.py:20
 msgid "Incorrect, please try again."
 msgstr "Neplatné, zkuste to prosím znovu."
 
-#: src/olympia/amo/fields.py:16
+#: src/olympia/amo/fields.py:21
 msgid "Error verifying input, please try again."
 msgstr "Chyba při kontrole vstupu, zkuste to prosím znovu."
 
-#: src/olympia/amo/fields.py:32
+#: src/olympia/amo/fields.py:37
 msgid "This must be a valid hex color code, such as #000000."
 msgstr "Musí se jednat o platnou barvu v hexa formátu, například #000000."
 
-#: src/olympia/amo/fields.py:58
+#: src/olympia/amo/fields.py:63
 msgid "Enter at least one value."
 msgstr "Vložte nejméně jednu hodnotu."
 
-#: src/olympia/amo/helpers.py:162 src/olympia/amo/templates/amo/site_nav.html:61 src/olympia/bandwagon/templates/bandwagon/add.html:9 src/olympia/bandwagon/templates/bandwagon/collection_detail.html:15
+#: src/olympia/amo/helpers.py:162 src/olympia/amo/templates/amo/site_nav.html:59 src/olympia/bandwagon/templates/bandwagon/add.html:9 src/olympia/bandwagon/templates/bandwagon/collection_detail.html:15
 #: src/olympia/bandwagon/templates/bandwagon/delete.html:9 src/olympia/bandwagon/templates/bandwagon/edit.html:15 src/olympia/bandwagon/templates/bandwagon/user_listing.html:18
 #: src/olympia/bandwagon/templates/bandwagon/user_listing.html:21 src/olympia/bandwagon/templates/bandwagon/impala/collection_listing.html:12
 #: src/olympia/bandwagon/templates/bandwagon/impala/collection_listing.html:20 src/olympia/bandwagon/templates/bandwagon/impala/collection_listing.html:24
 #: src/olympia/bandwagon/templates/bandwagon/impala/collection_sidebar.html:3 src/olympia/bandwagon/templates/bandwagon/includes/collection_sidebar.html:2
-#: src/olympia/bandwagon/templates/bandwagon/mobile/collection_listing.html:3 src/olympia/stats/templates/stats/stats.html:77 src/olympia/templates/menu_links.html:12
+#: src/olympia/bandwagon/templates/bandwagon/mobile/collection_listing.html:3 src/olympia/stats/templates/stats/stats.html:33 src/olympia/templates/menu_links.html:12
 msgid "Collections"
 msgstr "Sbírky"
 
-#: src/olympia/amo/helpers.py:171 src/olympia/amo/templates/amo/site_nav.html:85 src/olympia/browse/templates/browse/language_tools.html:3
+#: src/olympia/amo/helpers.py:171 src/olympia/amo/templates/amo/site_nav.html:83 src/olympia/browse/templates/browse/language_tools.html:3
 msgid "Dictionaries & Language Packs"
 msgstr "Slovníky a jazykové balíčky"
 
@@ -1619,8 +1598,8 @@ msgstr "Vyžádána kontrola administrátorem"
 msgid "Comment on {addon} {version}."
 msgstr "Komentář u doplňku {addon} {version}."
 
-#: src/olympia/amo/log.py:236 src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:19 src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:47
-#: src/olympia/editors/helpers.py:511 src/olympia/editors/templates/editors/themes/history_table.html:11
+#: src/olympia/amo/log.py:236 src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:17 src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:45
+#: src/olympia/editors/helpers.py:584 src/olympia/editors/templates/editors/themes/history_table.html:11
 msgid "Comment"
 msgstr "Komentář"
 
@@ -1773,8 +1752,8 @@ msgid "Reviewer escalation"
 msgstr "Postoupení na detailní kontrolu"
 
 #: src/olympia/amo/log.py:442
-msgid "Video removed from {addon} because of a problem with the video. "
-msgstr "Video bylo od doplňku {addon} odebráno, protože se u tohoto videa vyskytl problém. "
+msgid "Video removed from {addon} because of a problem with the video."
+msgstr "Video bylo od doplňku {addon} odebráno, protože se u tohoto videa vyskytl problém."
 
 #: src/olympia/amo/log.py:444
 msgid "Video removed"
@@ -1926,7 +1905,7 @@ msgstr "Jejda"
 
 #: src/olympia/amo/templates/amo/500.html:6
 #, python-format
-msgid "<h1>Oops!  We had an error.</h1> <p>We'll get to fixing that soon.</p> <p> You can try refreshing the page, or head back to the <a href=\"%(home)s\">Add-ons homepage</a>. </p>"
+msgid "<h1>Oops! We had an error.</h1> <p>We'll get to fixing that soon.</p> <p> You can try refreshing the page, or head back to the <a href=\"%(home)s\">Add-ons homepage</a>. </p>"
 msgstr "<h1>Oops! Nastala chyba.</h1> <p>Brzy to opravíme.</p> <p> Můžete zkusit obnovit stránku či přejít zpět na <a href=\"%(home)s\">domovskou stránku doplňků</a>. </p>"
 
 #: src/olympia/amo/templates/amo/license_link.html:10
@@ -1949,7 +1928,7 @@ msgstr "Předchozí"
 #: src/olympia/amo/templates/amo/mobile/paginator.html:14 src/olympia/amo/templates/amo/mobile/paginator.html:16 src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:51
 #: src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:65 src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:78
 #: src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:91 src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:104
-#: src/olympia/discovery/templates/discovery/pane.html:45 src/olympia/discovery/templates/discovery/addons/detail.html:39 src/olympia/stats/templates/stats/stats.html:167
+#: src/olympia/discovery/templates/discovery/pane.html:45 src/olympia/discovery/templates/discovery/addons/detail.html:39 src/olympia/stats/templates/stats/stats.html:169
 msgid "Next"
 msgstr "Další"
 
@@ -1983,7 +1962,7 @@ msgstr ""
 "id=\"recaptcha_different\">zkusit jiná slova</a> nebo <a href=\"#\" id=\"recaptcha_audio\">jiný typ ověření</a>. </p>"
 
 #: src/olympia/amo/templates/amo/side_nav.html:4 src/olympia/amo/templates/amo/side_nav.html:12 src/olympia/amo/templates/amo/site_nav.html:4 src/olympia/amo/templates/amo/site_nav.html:26
-#: src/olympia/browse/views.py:56 src/olympia/browse/views.py:66 src/olympia/browse/views.py:237 src/olympia/browse/views.py:282 src/olympia/search/forms.py:86
+#: src/olympia/browse/views.py:56 src/olympia/browse/views.py:66 src/olympia/browse/views.py:204 src/olympia/browse/views.py:249 src/olympia/search/forms.py:86
 msgid "Top Rated"
 msgstr "Nejlépe hodnocené"
 
@@ -1998,37 +1977,37 @@ msgstr "Procházet"
 msgid "Extensions"
 msgstr "Rozšíření"
 
-#: src/olympia/amo/templates/amo/site_nav.html:45
+#: src/olympia/amo/templates/amo/site_nav.html:44
 msgid "Want more customization? Try <b>Complete Themes</b>"
 msgstr "Chcete větší přizpůsobení? Vyzkoušejte <b>plné motivy</b>"
 
-#: src/olympia/amo/templates/amo/site_nav.html:56 src/olympia/bandwagon/views.py:96
+#: src/olympia/amo/templates/amo/site_nav.html:54 src/olympia/bandwagon/views.py:96
 msgid "Most Followers"
 msgstr "Nejvíce odebírané"
 
-#: src/olympia/amo/templates/amo/site_nav.html:68 src/olympia/bandwagon/templates/bandwagon/impala/collection_sidebar.html:16 src/olympia/bandwagon/templates/bandwagon/includes/collection_sidebar.html:18
+#: src/olympia/amo/templates/amo/site_nav.html:66 src/olympia/bandwagon/templates/bandwagon/impala/collection_sidebar.html:16 src/olympia/bandwagon/templates/bandwagon/includes/collection_sidebar.html:18
 msgid "Collections I've Made"
 msgstr "Sbírky, které jsem vytvořili"
 
-#: src/olympia/amo/templates/amo/site_nav.html:70 src/olympia/bandwagon/templates/bandwagon/user_listing.html:4 src/olympia/bandwagon/templates/bandwagon/impala/collection_sidebar.html:13
+#: src/olympia/amo/templates/amo/site_nav.html:68 src/olympia/bandwagon/templates/bandwagon/user_listing.html:4 src/olympia/bandwagon/templates/bandwagon/impala/collection_sidebar.html:13
 #: src/olympia/bandwagon/templates/bandwagon/includes/collection_sidebar.html:15
 msgid "Collections I'm Following"
 msgstr "Sbírky, které sleduji"
 
-#: src/olympia/amo/templates/amo/site_nav.html:73 src/olympia/bandwagon/templates/bandwagon/impala/collection_sidebar.html:18 src/olympia/bandwagon/templates/bandwagon/includes/collection_sidebar.html:20
-#: src/olympia/users/models.py:512
+#: src/olympia/amo/templates/amo/site_nav.html:71 src/olympia/bandwagon/templates/bandwagon/impala/collection_sidebar.html:18 src/olympia/bandwagon/templates/bandwagon/includes/collection_sidebar.html:20
+#: src/olympia/users/models.py:521
 msgid "My Favorite Add-ons"
 msgstr "Mé oblíbené doplňky"
 
-#: src/olympia/amo/templates/amo/site_nav.html:78
+#: src/olympia/amo/templates/amo/site_nav.html:76
 msgid "More&hellip;"
 msgstr "Více&hellip;"
 
-#: src/olympia/amo/templates/amo/site_nav.html:82
+#: src/olympia/amo/templates/amo/site_nav.html:80
 msgid "Add-ons for Mobile"
 msgstr "Doplňky pro mobily"
 
-#: src/olympia/amo/templates/amo/site_nav.html:86 src/olympia/browse/feeds.py:207 src/olympia/browse/templates/browse/search_tools.html:3 src/olympia/constants/base.py:176
+#: src/olympia/amo/templates/amo/site_nav.html:84 src/olympia/browse/feeds.py:207 src/olympia/browse/templates/browse/search_tools.html:3 src/olympia/constants/base.py:176
 #: src/olympia/templates/menu_links.html:10
 msgid "Search Tools"
 msgstr "Nástroje pro vyhledávání"
@@ -2044,7 +2023,7 @@ msgid "Jump to first page"
 msgstr "Přejít na první stránku"
 
 #: src/olympia/amo/templates/amo/impala/paginator.html:22 src/olympia/amo/templates/amo/mobile/impala_paginator.html:12 src/olympia/discovery/templates/discovery/pane.html:44
-#: src/olympia/discovery/templates/discovery/addons/detail.html:38 src/olympia/stats/templates/stats/stats.html:164
+#: src/olympia/discovery/templates/discovery/addons/detail.html:38 src/olympia/stats/templates/stats/stats.html:166
 msgid "Previous"
 msgstr "Předchozí"
 
@@ -2054,7 +2033,7 @@ msgstr "Jít na poslední stranu"
 
 #. First and second arguments are the result range (e.g., 1-20);
 #. third argument is the number of total results (e.g., 1,000).
-#. third
+#. First and second arguments are the result range (e.g., 1-20);              third
 #. argument is the number of total results (e.g., 1,000).
 #: src/olympia/amo/templates/amo/impala/paginator.html:36 src/olympia/amo/templates/amo/mobile/impala_paginator.html:38
 #, python-format
@@ -2066,33 +2045,51 @@ msgid "Page {n}"
 msgid_plural "Page {n}"
 msgstr[0] "Stránka {n}"
 msgstr[1] "Stránka {n}"
-msgstr[2] "Stránka {n}"
 
-#: src/olympia/amo/templates/services/install.html:38
-#, python-format
-msgid "If you are not prompted to install %(addon_name)s in a moment, please <a href=\"%(addon_xpi)s\">click here</a>."
-msgstr "Pokud vám není doplněk %(addon_name)s během chvíle nabídnut k instalaci, klepněte prosím <a href=\"%(addon_xpi)s\">zde</a>."
-
-#: src/olympia/amo/tests/test_messages.py:57 src/olympia/amo/tests/test_messages.py:58 src/olympia/reviews/forms.py:25 src/olympia/reviews/forms.py:50 src/olympia/reviews/templates/reviews/add.html:56
+#: src/olympia/amo/tests/test_messages.py:56 src/olympia/amo/tests/test_messages.py:57 src/olympia/reviews/forms.py:25 src/olympia/reviews/forms.py:50 src/olympia/reviews/templates/reviews/add.html:56
 #: src/olympia/reviews/templates/reviews/reply.html:30
 msgid "Title"
 msgstr "Nadpis"
 
-#: src/olympia/amo/tests/test_messages.py:57 src/olympia/amo/tests/test_messages.py:58
+#: src/olympia/amo/tests/test_messages.py:56 src/olympia/amo/tests/test_messages.py:57
 msgid "Body"
 msgstr "Tělo"
 
-#: src/olympia/amo/tests/test_messages.py:59
+#: src/olympia/amo/tests/test_messages.py:58
 msgid "Another Title"
 msgstr "Další nadpis"
 
-#: src/olympia/amo/tests/test_messages.py:59
+#: src/olympia/amo/tests/test_messages.py:58
 msgid "Another Body"
 msgstr "Další tělo"
 
-#: src/olympia/api/views.py:255
-msgid "Not implemented yet."
-msgstr "Dosud není implementováno."
+#: src/olympia/api/authentication.py:76
+msgid "Signature has expired."
+msgstr ""
+
+#: src/olympia/api/authentication.py:79
+msgid "Error decoding signature."
+msgstr ""
+
+#: src/olympia/api/authentication.py:82
+msgid "Invalid JWT Token."
+msgstr ""
+
+#: src/olympia/api/authentication.py:130
+msgid "Invalid Authorization header. No credentials provided."
+msgstr ""
+
+#: src/olympia/api/authentication.py:133
+msgid "Invalid Authorization header. Credentials string should not contain spaces."
+msgstr ""
+
+#: src/olympia/api/fields.py:29
+msgid "The field must have a length of at least {num} characters."
+msgstr ""
+
+#: src/olympia/api/fields.py:31
+msgid "The language code {lang_code} is invalid."
+msgstr ""
 
 #: src/olympia/applications/views.py:39 src/olympia/applications/templates/applications/appversions.html:3
 msgid "Application Versions"
@@ -2110,7 +2107,7 @@ msgstr "Platné verze aplikace"
 msgid "Add-ons submitted to Mozilla Add-ons must have a manifest file with at least one of the below applications supported. Only the versions listed below are allowed for these applications."
 msgstr "Doplňky nahrávané na server s doplňky Mozilla musí obsahovat manifest soubor s alespoň jednou podporovanou aplikací uvedenou níže. Uvedeny jsou také povolené verze těchto aplikací."
 
-#: src/olympia/applications/templates/applications/appversions.html:25
+#: src/olympia/applications/templates/applications/appversions.html:25 src/olympia/editors/helpers.py:361
 msgid "GUID"
 msgstr "GUID"
 
@@ -2187,11 +2184,11 @@ msgstr "Odkazy nejsou povoleny."
 msgid "This url is already in use by another collection"
 msgstr "Tato URL je používána jinou sbírkou"
 
-#: src/olympia/bandwagon/forms.py:197 src/olympia/devhub/views.py:1049
+#: src/olympia/bandwagon/forms.py:197 src/olympia/devhub/views.py:1050
 msgid "Icons must be either PNG or JPG."
 msgstr "Ikona musí být ve formátu PNG či JPG."
 
-#: src/olympia/bandwagon/forms.py:202 src/olympia/devhub/views.py:1067 src/olympia/users/forms.py:476
+#: src/olympia/bandwagon/forms.py:202 src/olympia/devhub/views.py:1068 src/olympia/users/forms.py:476
 #, python-format
 msgid "Please use images smaller than %dMB."
 msgstr "Používejte prosím obrázky menší než %dMB."
@@ -2224,8 +2221,8 @@ msgstr "Doporučené"
 msgid "Remove from favorites"
 msgstr "Odebrat z oblíbených"
 
-#: src/olympia/bandwagon/views.py:98 src/olympia/bandwagon/views.py:191 src/olympia/browse/views.py:58 src/olympia/browse/views.py:69 src/olympia/browse/views.py:458 src/olympia/devhub/views.py:74
-#: src/olympia/devhub/views.py:82 src/olympia/devhub/templates/devhub/addons/edit/basic.html:20 src/olympia/editors/templates/editors/leaderboard.html:24
+#: src/olympia/bandwagon/views.py:98 src/olympia/bandwagon/views.py:191 src/olympia/browse/views.py:58 src/olympia/browse/views.py:69 src/olympia/browse/views.py:425 src/olympia/devhub/views.py:73
+#: src/olympia/devhub/views.py:81 src/olympia/devhub/templates/devhub/addons/edit/basic.html:20 src/olympia/editors/templates/editors/leaderboard.html:24
 #: src/olympia/editors/templates/editors/themes/queue_list.html:48 src/olympia/search/forms.py:17 src/olympia/search/forms.py:89 src/olympia/users/templates/users/vcard.html:5
 msgid "Name"
 msgstr "Jméno"
@@ -2234,7 +2231,7 @@ msgstr "Jméno"
 msgid "Recently Popular"
 msgstr "Poslední populární"
 
-#: src/olympia/bandwagon/views.py:189 src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:18
+#: src/olympia/bandwagon/views.py:189 src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:16
 msgid "Added"
 msgstr "Přidáno"
 
@@ -2248,7 +2245,7 @@ msgstr "Sbírka byla vytvořena!"
 
 #: src/olympia/bandwagon/views.py:316
 #, python-format
-msgid "Your new collection is shown below. You can <ahref=\"%(url)s\">edit additional settings</a> if you'dlike."
+msgid "Your new collection is shown below. You can <a href=\"%(url)s\">edit additional settings</a> if you'd like."
 msgstr "Nová sbírka je zobrazena níže. Nyní můžete, pokud chcete, <a href=\"%(url)s\">upravit její další vlastnosti</a>."
 
 #: src/olympia/bandwagon/views.py:322
@@ -2329,7 +2326,6 @@ msgid "<span>%(num)s</span> follower"
 msgid_plural "<span>%(num)s</span> followers"
 msgstr[0] "<span>%(num)s</span> odběratel"
 msgstr[1] "<span>%(num)s</span> odběratelé"
-msgstr[2] "<span>%(num)s</span> odběratelů"
 
 #: src/olympia/bandwagon/templates/bandwagon/collection_detail.html:54
 msgid "About this Collection"
@@ -2369,7 +2365,6 @@ msgid "%(num)s Theme in this Collection"
 msgid_plural "%(num)s Themes in this Collection"
 msgstr[0] "%(num)s motiv v této sbírce"
 msgstr[1] "%(num)s motivy v této sbírce"
-msgstr[2] "%(num)s motivů v této sbírce"
 
 #: src/olympia/bandwagon/templates/bandwagon/collection_detail.html:111
 #, python-format
@@ -2377,10 +2372,9 @@ msgid "%(num)s Add-on in this Collection"
 msgid_plural "%(num)s Add-ons in this Collection"
 msgstr[0] "V této sbírce je %(num)s doplňků"
 msgstr[1] "V této sbírce jsou %(num)s doplňky"
-msgstr[2] "V této sbírce je %(num)s doplňků"
 
-#: src/olympia/bandwagon/templates/bandwagon/collection_detail.html:125 src/olympia/compat/templates/compat/index.html:25 src/olympia/compat/templates/compat/reporter_detail.html:29
-#: src/olympia/files/templates/files/viewer.html:29 src/olympia/templates/amo_footer.html:17 src/olympia/templates/includes/lang_switcher.html:10
+#: src/olympia/bandwagon/templates/bandwagon/collection_detail.html:125 src/olympia/compat/templates/compat/reporter_detail.html:29 src/olympia/files/templates/files/viewer.html:29
+#: src/olympia/templates/amo_footer.html:17 src/olympia/templates/includes/lang_switcher.html:10
 msgid "Go"
 msgstr "Přejít"
 
@@ -2430,7 +2424,6 @@ msgid "<span>%(addons)s</span> add-on"
 msgid_plural "<span>%(addons)s</span> add-ons"
 msgstr[0] "<span>%(addons)s</span> doplněk"
 msgstr[1] "<span>%(addons)s</span> doplňky"
-msgstr[2] "<span>%(addons)s</span> doplňků"
 
 #: src/olympia/bandwagon/templates/bandwagon/collection_grid.html:32
 #, python-format
@@ -2438,11 +2431,10 @@ msgid "<span>%(followers)s</span> follower"
 msgid_plural "<span>%(followers)s</span> followers"
 msgstr[0] "<span>%(followers)s</span> odběratel"
 msgstr[1] "<span>%(followers)s</span> odběratelé"
-msgstr[2] "<span>%(followers)s</span> odběratelů"
 
-#. People "follow" collections to get notified of updates.
-#. Like
+#. People "follow" collections to get notified of updates.                    Like
 #. Twitter followers.
+#. People "follow" collections to get notified of updates.
 #. Like Twitter followers.
 #: src/olympia/bandwagon/templates/bandwagon/collection_listing_items.html:10 src/olympia/bandwagon/templates/bandwagon/impala/collection_listing_items.html:18
 #, python-format
@@ -2450,10 +2442,8 @@ msgid "%(num)s weekly follower"
 msgid_plural "%(num)s weekly followers"
 msgstr[0] "%(num)s týdenní odběratel"
 msgstr[1] "%(num)s týdenní odběratelé"
-msgstr[2] "%(num)s týdenních odběratelů"
 
-#. People "follow" collections to get notified of updates.
-#. Like
+#. People "follow" collections to get notified of updates.                    Like
 #. Twitter followers.
 #: src/olympia/bandwagon/templates/bandwagon/collection_listing_items.html:18
 #, python-format
@@ -2461,11 +2451,10 @@ msgid "%(num)s monthly follower"
 msgid_plural "%(num)s monthly followers"
 msgstr[0] "%(num)s měsíční odběratel"
 msgstr[1] "%(num)s měsíční odběratelé"
-msgstr[2] "%(num)s měsíčních odběratelů"
 
-#. People "follow" collections to get notified of updates.
-#. Like
+#. People "follow" collections to get notified of updates.                    Like
 #. Twitter followers.
+#. People "follow" collections to get notified of updates.
 #. Like Twitter followers.
 #: src/olympia/bandwagon/templates/bandwagon/collection_listing_items.html:26 src/olympia/bandwagon/templates/bandwagon/impala/collection_listing_items.html:26
 #, python-format
@@ -2473,7 +2462,6 @@ msgid "%(num)s follower"
 msgid_plural "%(num)s followers"
 msgstr[0] "%(num)s odběratel"
 msgstr[1] "%(num)s odběratelé"
-msgstr[2] "%(num)s odběratelů"
 
 #: src/olympia/bandwagon/templates/bandwagon/collection_listing_items.html:56 src/olympia/bandwagon/templates/bandwagon/impala/collection_listing_items.html:9
 #: src/olympia/devhub/templates/devhub/personas/edit.html:27
@@ -2558,7 +2546,7 @@ msgid "Remove this user as a contributor"
 msgstr "Odstranit tohoto uživatele z odběratelů"
 
 #: src/olympia/bandwagon/templates/bandwagon/edit_contributors.html:18 src/olympia/bandwagon/templates/bandwagon/edit_contributors.html:43
-#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:20 src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:48
+#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:18 src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:46
 #: src/olympia/devhub/templates/devhub/addons/ajax_compat_update.html:19
 msgid "Remove"
 msgstr "Odebrat"
@@ -2609,7 +2597,7 @@ msgid "<b>Warning:</b> By changing the owner of this collection, you will no lon
 msgstr "<b>Varování:</b> Změnou vlastníka této sbírky, ztratíte možnost její úpravy. Budete moci pouze přidávat či odebírat doplňky."
 
 #: src/olympia/bandwagon/templates/bandwagon/edit_contributors.html:83 src/olympia/devhub/templates/devhub/addons/forms_shared/media.html:157
-#: src/olympia/devhub/templates/devhub/addons/submit/describe.html:69 src/olympia/devhub/templates/devhub/addons/submit/license.html:60 src/olympia/devhub/templates/devhub/addons/submit/upload.html:78
+#: src/olympia/devhub/templates/devhub/addons/submit/describe.html:69 src/olympia/devhub/templates/devhub/addons/submit/license.html:60 src/olympia/devhub/templates/devhub/addons/submit/upload.html:70
 #: src/olympia/devhub/templates/devhub/payments/tier.html:17 src/olympia/editors/templates/editors/themes/themes.html:111 src/olympia/editors/templates/editors/themes/themes.html:128
 #: src/olympia/editors/templates/editors/themes/themes.html:134 src/olympia/editors/templates/editors/themes/themes.html:141 src/olympia/users/templates/users/fxa_migration_prompt_content.html:10
 #: src/olympia/users/templates/users/login_form.html:42 src/olympia/users/templates/users/mobile/login.html:57
@@ -2680,42 +2668,43 @@ msgid "Reset"
 msgstr "Obnovit"
 
 #: src/olympia/bandwagon/templates/bandwagon/includes/addedit.html:53
-msgid "PNG and JPG supported.  Image will be resized to 32x32."
-msgstr "Podporované formáty jsou PNG a JPG. Obrázky budou upraveny na rozměry 32x32."
+msgid "PNG and JPG supported. Image will be resized to 32x32."
+msgstr "Podporované formáty jsou PNG a JPG. Obrázky budou upraveny na rozměry 32x32."
 
 #: src/olympia/bandwagon/templates/bandwagon/includes/addedit_errors.html:3
-msgid "There are errors in this form.  Please correct them below."
-msgstr "V tomto formuláři se vyskytly chyby. Níže je prosím opravte."
+msgid "There are errors in this form. Please correct them below."
+msgstr "V tomto formuláři se vyskytly chyby. Níže je prosím opravte."
 
 #: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:2
 msgid "Add-ons in Your Collection"
 msgstr "Doplňky ve vaší sbírce"
 
 #: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:4
-msgid "To include an add-on in this collection, enter its name in the box below and hit enter. You can also use the <strong>Add to Collection</strong> links throughout the site to include add-ons later."
-msgstr "Pro přidání doplňku do sbírky vložte jeho jméno do pole níže a stiskněte klávesu Enter. Doplňky též můžete přidat později klepnutím na odkaz <strong>Přidat do sbírky</strong> na stránce doplňku."
+msgid "To include an add-on in this collection, enter its name in the box below and hit enter."
+msgstr ""
 
-#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:17 src/olympia/constants/base.py:400 src/olympia/devhub/templates/devhub/addons/activity.html:62
+#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:15 src/olympia/constants/base.py:400 src/olympia/devhub/templates/devhub/addons/activity.html:62
+#: src/olympia/editors/helpers.py:273 src/olympia/editors/helpers.py:360
 msgid "Add-on"
 msgstr "Doplněk"
 
-#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:26
+#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:24
 msgid "Enter the name of the add-on to include"
 msgstr "Zadejte jméno doplňku, který chcete vložit"
 
-#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:28
+#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:26
 msgid "Add to Collection"
 msgstr "Přidat do sbírky"
 
-#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:45 src/olympia/editors/helpers.py:936 src/olympia/editors/helpers.py:956
+#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:43 src/olympia/editors/helpers.py:1016 src/olympia/editors/helpers.py:1036
 msgid "Pending"
 msgstr "Čeká"
 
-#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:47
+#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:45
 msgid "Add a comment"
 msgstr "Přidat komentář"
 
-#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:48
+#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:46
 msgid "Remove this add-on from the collection"
 msgstr "Odebrat doplněk ze sbírky"
 
@@ -2824,12 +2813,12 @@ msgstr "Nástroje pro vyhledávání"
 msgid "Most Users"
 msgstr "Nejvíce uživatelů"
 
-#: src/olympia/browse/views.py:61 src/olympia/browse/views.py:72 src/olympia/browse/views.py:279 src/olympia/browse/templates/browse/personas/mobile/category_landing.html:63
+#: src/olympia/browse/views.py:61 src/olympia/browse/views.py:72 src/olympia/browse/views.py:246 src/olympia/browse/templates/browse/personas/mobile/category_landing.html:63
 #: src/olympia/discovery/templates/discovery/pane.html:67 src/olympia/search/forms.py:92
 msgid "Up & Coming"
 msgstr "Žádané"
 
-#: src/olympia/browse/views.py:460 src/olympia/devhub/views.py:76 src/olympia/devhub/views.py:83 src/olympia/discovery/templates/discovery/addons/detail.html:66
+#: src/olympia/browse/views.py:427 src/olympia/devhub/views.py:75 src/olympia/devhub/views.py:82 src/olympia/discovery/templates/discovery/addons/detail.html:66
 msgid "Created"
 msgstr "Vytvořeno"
 
@@ -2910,7 +2899,6 @@ msgid "<b>{0}</b> add-on"
 msgid_plural "<b>{0}</b> add-ons"
 msgstr[0] "<b>{0}</b> doplněk"
 msgstr[1] "<b>{0}</b> doplňky"
-msgstr[2] "<b>{0}</b> doplňků"
 
 #: src/olympia/browse/templates/browse/search_tools.html:61
 msgid "Search Extensions"
@@ -3017,10 +3005,9 @@ msgid "See the %(cnt)s extension in %(name)s &raquo;"
 msgid_plural "See all %(cnt)s extensions in %(name)s &raquo;"
 msgstr[0] "Zobrazit %(cnt)s rozšíření v %(name)s &raquo;"
 msgstr[1] "Zobrazit %(cnt)s rozšíření v %(name)s &raquo;"
-msgstr[2] "Zobrazit všechna %(cnt)s rozšíření v %(name)s &raquo;"
 
-#: src/olympia/browse/templates/browse/mobile/extensions.html:13 src/olympia/compat/templates/compat/index.html:82 src/olympia/devhub/templates/devhub/devhub_search.html:24
-#: src/olympia/devhub/templates/devhub/addons/activity.html:47 src/olympia/search/templates/search/no_results.html:4 src/olympia/search/templates/search/mobile/results.html:36
+#: src/olympia/browse/templates/browse/mobile/extensions.html:13 src/olympia/devhub/templates/devhub/devhub_search.html:24 src/olympia/devhub/templates/devhub/addons/activity.html:47
+#: src/olympia/search/templates/search/no_results.html:4 src/olympia/search/templates/search/mobile/results.html:36
 msgid "No results found."
 msgstr "Nic nebylo nalezeno."
 
@@ -3105,7 +3092,7 @@ msgstr "&laquo; Všechny motivy"
 msgid "All"
 msgstr "Vše"
 
-#: src/olympia/compat/forms.py:22 src/olympia/search/views.py:525
+#: src/olympia/compat/forms.py:22 src/olympia/editors/templates/editors/base.html:69 src/olympia/search/views.py:518
 msgid "All Add-ons"
 msgstr "Všechny doplňky"
 
@@ -3116,53 +3103,6 @@ msgstr "S binární komponentou"
 #: src/olympia/compat/forms.py:24
 msgid "Non-binary"
 msgstr "Bez binárních komponent"
-
-#. Review points sources other than add-ons and themes.
-#: src/olympia/compat/views.py:87 src/olympia/constants/base.py:388 src/olympia/devhub/forms.py:162 src/olympia/editors/templates/editors/performance.html:75
-msgid "Other"
-msgstr "Jiné"
-
-#: src/olympia/compat/templates/compat/index.html:4
-msgid "Add-on Compatibility Report for {app} {version}"
-msgstr "Přehled kompatibility doplňků pro {app} {version}"
-
-#: src/olympia/compat/templates/compat/index.html:11
-msgid "{app} {version} Compatibility"
-msgstr "Kompatibilita s aplikací {app} {version}"
-
-#: src/olympia/compat/templates/compat/index.html:17
-#, python-format
-msgid "Top 95%% compatible with previous version"
-msgstr "95 %% nejpopulárnějších z předchozí verze"
-
-#: src/olympia/compat/templates/compat/index.html:18
-#, python-format
-msgid "Top 95%% of all add-ons"
-msgstr "95 %% ze všech doplňků"
-
-#: src/olympia/compat/templates/compat/index.html:19
-msgid "All active add-ons"
-msgstr "Všechny aktivní doplňky"
-
-#: src/olympia/compat/templates/compat/index.html:23 src/olympia/constants/base.py:401
-msgid "App"
-msgstr "Aplikace"
-
-#: src/olympia/compat/templates/compat/index.html:55
-msgid "Details for add-ons compatible with previous version:"
-msgstr "Detailní informace pro doplňky, které byly kompatibilní s předchozí verzí:"
-
-#: src/olympia/compat/templates/compat/index.html:57
-msgid "Show all versions"
-msgstr "Zobrazit všechny verze"
-
-#: src/olympia/compat/templates/compat/index.html:59
-msgid "Details for add-ons compatible with all versions:"
-msgstr "Detaily pro doplňky, které jsou kompatibilní se všemi verzemi:"
-
-#: src/olympia/compat/templates/compat/index.html:61
-msgid "Show previous version only"
-msgstr "Zobrazit pouze předchozí verzi"
 
 #: src/olympia/compat/templates/compat/reporter.html:3
 msgid "Add-on Compatibility Reports"
@@ -3198,14 +3138,12 @@ msgid "{0} success report"
 msgid_plural "{0} success reports"
 msgstr[0] "{0} pozitivní hlášení"
 msgstr[1] "{0} pozitivní hlášení"
-msgstr[2] "{0} pozitivních hlášení"
 
 #: src/olympia/compat/templates/compat/reporter_detail.html:17
 msgid "{0} problem report"
 msgid_plural "{0} problem reports"
 msgstr[0] "{0} hlášení problému"
 msgstr[1] "{0} hlášené problémy"
-msgstr[2] "{0} hlášení problémů"
 
 #: src/olympia/compat/templates/compat/reporter_detail.html:21 src/olympia/users/templates/users/profile.html:70
 msgid "View all"
@@ -3219,8 +3157,8 @@ msgstr "Filtrace dle aplikace"
 msgid "Report Type"
 msgstr "Typ hlášení"
 
-#: src/olympia/compat/templates/compat/reporter_detail.html:47 src/olympia/devhub/forms.py:784 src/olympia/devhub/templates/devhub/addons/ajax_compat_update.html:17 src/olympia/editors/forms.py:108
-#: src/olympia/zadmin/forms.py:45
+#: src/olympia/compat/templates/compat/reporter_detail.html:47 src/olympia/devhub/forms.py:785 src/olympia/devhub/templates/devhub/addons/ajax_compat_update.html:17 src/olympia/editors/forms.py:108
+#: src/olympia/editors/forms.py:248 src/olympia/zadmin/forms.py:45
 msgid "Application"
 msgstr "Aplikace"
 
@@ -3308,7 +3246,8 @@ msgstr "Předběžná kontrola"
 msgid "Preliminarily Reviewed and Awaiting Full Review"
 msgstr "Předběžně zkontrolován a čeká na plnou kontrolu"
 
-#: src/olympia/constants/base.py:33 src/olympia/editors/helpers.py:924 src/olympia/editors/templates/editors/themes/history_table.html:34
+#: src/olympia/constants/base.py:33 src/olympia/editors/forms.py:258 src/olympia/editors/helpers.py:73 src/olympia/editors/helpers.py:1004
+#: src/olympia/editors/templates/editors/themes/history_table.html:34
 msgid "Deleted"
 msgstr "Smazáno"
 
@@ -3408,6 +3347,11 @@ msgstr "Žádat uživatele po začátku stahování doplňku"
 msgid "Ask before users can download this add-on"
 msgstr "Žádat dříve, než mohou uživatelé stáhnout doplněk"
 
+#. Review points sources other than add-ons and themes.
+#: src/olympia/constants/base.py:388 src/olympia/devhub/forms.py:162 src/olympia/editors/templates/editors/performance.html:75
+msgid "Other"
+msgstr "Jiné"
+
 #: src/olympia/constants/base.py:389
 msgid "Exception"
 msgstr "Výjimka"
@@ -3419,6 +3363,10 @@ msgstr "Vydání"
 #: src/olympia/constants/base.py:391
 msgid "Change"
 msgstr "Změna"
+
+#: src/olympia/constants/base.py:401
+msgid "App"
+msgstr "Aplikace"
 
 #: src/olympia/constants/base.py:402
 msgid "Persona"
@@ -3568,7 +3516,7 @@ msgstr "Označit"
 msgid "Duplicate"
 msgstr "Duplicitní"
 
-#: src/olympia/constants/editors.py:17 src/olympia/editors/helpers.py:502 src/olympia/editors/templates/editors/themes/queue.html:71 src/olympia/editors/templates/editors/themes/themes.html:94
+#: src/olympia/constants/editors.py:17 src/olympia/editors/helpers.py:575 src/olympia/editors/templates/editors/themes/queue.html:71 src/olympia/editors/templates/editors/themes/themes.html:94
 msgid "Reject"
 msgstr "Zamítnout"
 
@@ -3668,7 +3616,7 @@ msgstr "Solaris"
 msgid "Android"
 msgstr "Android"
 
-#: src/olympia/core/apps.py:19
+#: src/olympia/core/apps.py:21
 msgid "Core"
 msgstr "Jádro"
 
@@ -3802,8 +3750,8 @@ msgid "Submit my add-on for manual review."
 msgstr "Odeslat doplněk k ruční kontrole."
 
 #: src/olympia/devhub/forms.py:537
-msgid "Do not list my add-on on this site (beta)"
-msgstr "Nezveřejňovat můj doplněk na této stránce (beta)"
+msgid "Do not list my add-on on this site"
+msgstr ""
 
 #: src/olympia/devhub/forms.py:538
 msgid "Check this option if you intend to distribute your add-on on your own and only need it to be signed by Mozilla."
@@ -3835,46 +3783,46 @@ msgstr "Soubory s verzí končící na a|alpha|b|beta|pre|rc a případné čís
 
 #: src/olympia/devhub/forms.py:592
 #, python-format
-msgid "Version %s already exists"
-msgstr "Verze %s již existuje"
+msgid "Version %s already exists, or was uploaded before."
+msgstr ""
 
-#: src/olympia/devhub/forms.py:604
+#: src/olympia/devhub/forms.py:605
 msgid "Select a valid choice. That choice is not one of the available choices."
 msgstr "Zvolte platnou hodnotu. Tato volba není jednou z dostupných možností."
 
-#: src/olympia/devhub/forms.py:610
+#: src/olympia/devhub/forms.py:611
 msgid "A file with a version ending with a|alpha|b|beta and an optional number is detected as beta."
 msgstr "Soubor s verzí, která končí na a|alpha|b|beta a volitelným číslem je detekován jako betaverze."
 
-#: src/olympia/devhub/forms.py:633
+#: src/olympia/devhub/forms.py:634
 msgid "You cannot upload any more files for this version."
 msgstr "K této verzi nemůžete nahrát více souborů."
 
-#: src/olympia/devhub/forms.py:639
+#: src/olympia/devhub/forms.py:640
 msgid "Version doesn't match"
 msgstr "Verze neodpovídá"
 
-#: src/olympia/devhub/forms.py:668
-msgid "You cannot delete a file once the review process has started.  You must delete the whole version."
-msgstr "Nemůžete smazat soubor v době, kdy byl proces kontroly zahájen.  Musíte smazat celou verzi."
+#: src/olympia/devhub/forms.py:669
+msgid "You cannot delete a file once the review process has started. You must delete the whole version."
+msgstr "Nemůžete smazat soubor v době, kdy byl proces kontroly zahájen. Musíte smazat celou verzi."
 
-#: src/olympia/devhub/forms.py:688
+#: src/olympia/devhub/forms.py:689
 msgid "The platform All cannot be combined with specific platforms."
 msgstr "Volba pro všechny platformy nemůže být kombinována s konkrétními platformami."
 
-#: src/olympia/devhub/forms.py:693
+#: src/olympia/devhub/forms.py:694
 msgid "A platform can only be chosen once."
 msgstr "Platforma může být zvolena pouze jednou."
 
-#: src/olympia/devhub/forms.py:706
+#: src/olympia/devhub/forms.py:707
 msgid "A review type must be selected."
 msgstr "Typ kontroly musí být zvolen."
 
-#: src/olympia/devhub/forms.py:788 src/olympia/editors/forms.py:114 src/olympia/zadmin/forms.py:49 src/olympia/zadmin/forms.py:52
+#: src/olympia/devhub/forms.py:789 src/olympia/editors/forms.py:114 src/olympia/editors/forms.py:254 src/olympia/zadmin/forms.py:49 src/olympia/zadmin/forms.py:52
 msgid "Select an application first"
 msgstr "Prvně zvolte aplikaci"
 
-#: src/olympia/devhub/forms.py:840
+#: src/olympia/devhub/forms.py:841
 msgid "There cannot be more than 3 required add-ons."
 msgstr "Nemůžete mít více než 3 vyžadované doplňky."
 
@@ -3897,7 +3845,6 @@ msgid "{0} error"
 msgid_plural "{0} errors"
 msgstr[0] "{0} chyba"
 msgstr[1] "{0} chyby"
-msgstr[2] "{0} chyb"
 
 # {0} is a number
 #. L10n: first parameter is the number of warnings
@@ -3906,166 +3853,165 @@ msgid "{0} warning"
 msgid_plural "{0} warnings"
 msgstr[0] "{0} varování"
 msgstr[1] "{0} varování"
-msgstr[2] "{0} varování"
 
 #: src/olympia/devhub/models.py:375 src/olympia/reviews/templates/reviews/add.html:58
 msgid "Review"
 msgstr "Recenze"
 
-#: src/olympia/devhub/tasks.py:551
+#: src/olympia/devhub/tasks.py:583
 #, python-format
 msgid "%s responded with %s (%s)."
 msgstr "%s odpověděl(a) %s (%s)."
 
-#: src/olympia/devhub/tasks.py:555
+#: src/olympia/devhub/tasks.py:587
 #, python-format
 msgid "Connection to \"%s\" timed out."
 msgstr "Při připojování k \"%s\" vypršel čas spojení."
 
-#: src/olympia/devhub/tasks.py:557
+#: src/olympia/devhub/tasks.py:589
 #, python-format
 msgid "Could not contact host at \"%s\"."
 msgstr "Nepodařilo se kontaktovat host \"%s\"."
 
-#: src/olympia/devhub/utils.py:104
+#: src/olympia/devhub/utils.py:105
 #, python-format
 msgid "Validation generated too many errors/warnings so %s messages were truncated. After addressing the visible messages, you'll be able to see the others."
 msgstr "Kontrola vygenerovala příliš mnoho chyb/varování a %s zpráv tak není zobrazeno. Po opravení zobrazených nedostatků budete moci vidět další."
 
-#: src/olympia/devhub/views.py:183
+#: src/olympia/devhub/views.py:182
 msgid "All My Add-ons"
 msgstr "Všechny mé doplňky"
 
-#: src/olympia/devhub/views.py:210
+#: src/olympia/devhub/views.py:209
 msgid "All Activity"
 msgstr "Všechny aktivity"
 
-#: src/olympia/devhub/views.py:211
+#: src/olympia/devhub/views.py:210
 msgid "Add-on Updates"
 msgstr "Aktualizace doplňku"
 
-#: src/olympia/devhub/views.py:212
+#: src/olympia/devhub/views.py:211
 msgid "Add-on Status"
 msgstr "Stav doplňku"
 
-#: src/olympia/devhub/views.py:213
+#: src/olympia/devhub/views.py:212
 msgid "User Collections"
 msgstr "Sbírky uživatele"
 
-#: src/olympia/devhub/views.py:214 src/olympia/devhub/templates/devhub/docs/policies-maintenance.html:68 src/olympia/pages/templates/pages/dev_faq.html:38
+#: src/olympia/devhub/views.py:213 src/olympia/devhub/templates/devhub/docs/policies-maintenance.html:68 src/olympia/pages/templates/pages/dev_faq.html:38
 #: src/olympia/pages/templates/pages/dev_faq.html:484
 msgid "User Reviews"
 msgstr "Recenze uživatelů"
 
-#: src/olympia/devhub/views.py:327 src/olympia/devhub/views.py:331 src/olympia/devhub/views.py:484 src/olympia/devhub/views.py:513 src/olympia/devhub/views.py:564 src/olympia/devhub/views.py:1150
+#: src/olympia/devhub/views.py:326 src/olympia/devhub/views.py:330 src/olympia/devhub/views.py:485 src/olympia/devhub/views.py:514 src/olympia/devhub/views.py:565 src/olympia/devhub/views.py:1157
 msgid "Changes successfully saved."
 msgstr "Změny byly úspěšně uloženy."
 
-#: src/olympia/devhub/views.py:334 src/olympia/devhub/views.py:1631
+#: src/olympia/devhub/views.py:333 src/olympia/devhub/views.py:1638
 msgid "Please check the form for errors."
 msgstr "Zkontrolujte prosím chyby ve formuláři."
 
-#: src/olympia/devhub/views.py:346
+#: src/olympia/devhub/views.py:345
 msgid "Add-on cannot be deleted. Disable this add-on instead."
 msgstr "Doplněk nemůže být smazán. Na místo toho jej zakažte."
 
-#: src/olympia/devhub/views.py:356
+#: src/olympia/devhub/views.py:355
 msgid "Theme deleted."
 msgstr "Motiv byl smazán."
 
-#: src/olympia/devhub/views.py:356
+#: src/olympia/devhub/views.py:355
 msgid "Add-on deleted."
 msgstr "Doplněk smazán."
 
-#: src/olympia/devhub/views.py:362
+#: src/olympia/devhub/views.py:361
 msgid "URL name was incorrect. Theme was not deleted."
 msgstr "Nesprávný název URL. Motiv nebyl smazán."
 
-#: src/olympia/devhub/views.py:367
+#: src/olympia/devhub/views.py:366
 msgid "URL name was incorrect. Add-on was not deleted."
 msgstr "Nesprávný název URL. Doplněk nebyl smazán."
 
-#: src/olympia/devhub/views.py:449
+#: src/olympia/devhub/views.py:450
 msgid "An author has been added to your add-on"
 msgstr "Autor byl k vašem doplňku přidán"
 
-#: src/olympia/devhub/views.py:456
+#: src/olympia/devhub/views.py:457
 msgid "An author has a role changed on your add-on"
 msgstr "U vašeho doplňku autor změnil roli"
 
-#: src/olympia/devhub/views.py:476
+#: src/olympia/devhub/views.py:477
 msgid "An author has been removed from your add-on"
 msgstr "Autor byl u vašeho doplňku odebrán"
 
-#: src/olympia/devhub/views.py:519
+#: src/olympia/devhub/views.py:520
 msgid "There were errors in your submission."
 msgstr "V rámci vašeho odeslání se vyskytly chyby."
 
-#: src/olympia/devhub/views.py:583
+#: src/olympia/devhub/views.py:584
 msgid "Validate Add-on"
 msgstr "Kontrola doplňku"
 
-#: src/olympia/devhub/views.py:594
+#: src/olympia/devhub/views.py:595
 msgid "Check Add-on Compatibility"
 msgstr "Kontrola kompatibility doplňku"
 
-#: src/olympia/devhub/views.py:808 src/olympia/signing/views.py:90
+#: src/olympia/devhub/views.py:809 src/olympia/signing/views.py:95
 msgid "You cannot submit this type of add-on"
 msgstr "Přidávání tohoto typu doplňku není povoleno"
 
-#: src/olympia/devhub/views.py:1051 src/olympia/users/forms.py:471
+#: src/olympia/devhub/views.py:1052 src/olympia/users/forms.py:471
 msgid "Images must be either PNG or JPG."
 msgstr "Obrázky musí být ve formátech PNG či JPG."
 
-#: src/olympia/devhub/views.py:1055
+#: src/olympia/devhub/views.py:1056
 msgid "Icons cannot be animated."
 msgstr "Ikony nemohou být animované."
 
-#: src/olympia/devhub/views.py:1057
+#: src/olympia/devhub/views.py:1058
 msgid "Images cannot be animated."
 msgstr "Obrázky nemohou být animované."
 
-#: src/olympia/devhub/views.py:1070
+#: src/olympia/devhub/views.py:1071
 #, python-format
 msgid "Images cannot be larger than %dKB."
 msgstr "Obrázky nemohou být větší než %d kb."
 
 #. L10n: {0} is an image width (in pixels), {1} is a height.
-#: src/olympia/devhub/views.py:1080
+#: src/olympia/devhub/views.py:1081
 msgid "Image must be exactly {0} pixels wide and {1} pixels tall."
 msgstr "Obrázek musí být přesně {0} pixelů široký a {1} pixelů vysoký."
 
-#: src/olympia/devhub/views.py:1087
+#: src/olympia/devhub/views.py:1088
 msgid "There was an error uploading your preview."
 msgstr "Při nahrávání obrázku se vyskytla chyba."
 
-#: src/olympia/devhub/views.py:1189
+#: src/olympia/devhub/views.py:1196
 #, python-format
 msgid "Version %s disabled."
 msgstr "Verze %s je zakázána."
 
-#: src/olympia/devhub/views.py:1193
+#: src/olympia/devhub/views.py:1200
 #, python-format
 msgid "Version %s deleted."
 msgstr "Verze %s byla smazána."
 
-#: src/olympia/devhub/views.py:1203
+#: src/olympia/devhub/views.py:1210
 msgid "This upload has failed validation, and may lack complete validation results. Please take due care when reviewing it."
 msgstr "Při nahrávání selhala kontrola a výsledky kontroly tak mohou být nekompletní. Věnujte tomu při kontrole zvláštní péči."
 
-#: src/olympia/devhub/views.py:1677
+#: src/olympia/devhub/views.py:1684
 msgid "Preliminary Review Requested."
 msgstr "Vyžádána předběžná kontrola."
 
-#: src/olympia/devhub/views.py:1678
+#: src/olympia/devhub/views.py:1685
 msgid "Full Review Requested."
 msgstr "Vyžádána plná kontrola."
 
-#: src/olympia/devhub/views.py:1779
+#: src/olympia/devhub/views.py:1786
 msgid "Your old credentials were revoked and are no longer valid. Be sure to update all API clients with the new credentials."
 msgstr "Vaše stará pověření byla revokována a již nejsou nadále platné. Aktualizujte prosím všechny API klienty novými pověřeními."
 
-#: src/olympia/devhub/views.py:1797
+#: src/olympia/devhub/views.py:1804
 msgid "New API key created"
 msgstr "Nový API klíč byl vytvořen"
 
@@ -4095,7 +4041,7 @@ msgstr "Zpět na doplňky"
 msgid "{0} :: Search"
 msgstr "{0} :: Vyhledávání"
 
-#: src/olympia/devhub/templates/devhub/devhub_search.html:6 src/olympia/devhub/templates/devhub/search.html:8 src/olympia/editors/forms.py:435 src/olympia/editors/forms.py:437
+#: src/olympia/devhub/templates/devhub/devhub_search.html:6 src/olympia/devhub/templates/devhub/search.html:8 src/olympia/editors/forms.py:534 src/olympia/editors/forms.py:536
 #: src/olympia/editors/templates/editors/queue.html:27 src/olympia/editors/templates/editors/themes/queue_list.html:14 src/olympia/search/templates/search/collections.html:17
 #: src/olympia/search/templates/search/personas.html:18 src/olympia/search/templates/search/results.html:18 src/olympia/search/templates/search/mobile/results.html:8 src/olympia/templates/search.html:14
 #: src/olympia/templates/impala/search.html:18
@@ -4158,12 +4104,12 @@ msgstr "Podívejte se na <a href=\"https://developer.mozilla.org/Add-ons\">Mozil
 msgid "Start Making Add-ons"
 msgstr "Začít vytvářet doplňky"
 
-#: src/olympia/devhub/templates/devhub/index.html:86 src/olympia/devhub/templates/devhub/addons/listing/items.html:25 src/olympia/devhub/templates/devhub/includes/addon_details.html:15
+#: src/olympia/devhub/templates/devhub/index.html:86 src/olympia/devhub/templates/devhub/addons/listing/items.html:25 src/olympia/devhub/templates/devhub/includes/addon_details.html:20
 #: src/olympia/devhub/templates/devhub/personas/edit.html:43
 msgid "Status:"
 msgstr "Stav:"
 
-#: src/olympia/devhub/templates/devhub/index.html:90 src/olympia/devhub/templates/devhub/includes/addon_details.html:100
+#: src/olympia/devhub/templates/devhub/index.html:90 src/olympia/devhub/templates/devhub/includes/addon_details.html:87
 msgid "Visibility:"
 msgstr "Viditelnost:"
 
@@ -4171,11 +4117,11 @@ msgstr "Viditelnost:"
 msgid "Latest Version:"
 msgstr "Poslední verze:"
 
-#: src/olympia/devhub/templates/devhub/index.html:109 src/olympia/devhub/templates/devhub/includes/addon_details.html:145 src/olympia/devhub/templates/devhub/personas/edit.html:49
+#: src/olympia/devhub/templates/devhub/index.html:109 src/olympia/devhub/templates/devhub/includes/addon_details.html:131 src/olympia/devhub/templates/devhub/personas/edit.html:49
 msgid "Queue Position:"
 msgstr "Pozice ve frontě:"
 
-#: src/olympia/devhub/templates/devhub/index.html:110 src/olympia/devhub/templates/devhub/includes/addon_details.html:146 src/olympia/devhub/templates/devhub/personas/edit.html:50
+#: src/olympia/devhub/templates/devhub/index.html:110 src/olympia/devhub/templates/devhub/includes/addon_details.html:132 src/olympia/devhub/templates/devhub/personas/edit.html:50
 #, python-format
 msgid "%(position)s of %(total)s"
 msgstr "%(position)s z %(total)s"
@@ -4277,16 +4223,6 @@ msgstr "Po nahrání bude na vašem souboru spuštěna sada automatizovaných te
 msgid "Do you want your add-on to be distributed on this site?"
 msgstr "Chcete hostovat svůj doplněk na tomto serveru?"
 
-#: src/olympia/devhub/templates/devhub/validate_addon.html:49 src/olympia/devhub/templates/devhub/addons/submit/upload.html:30 src/olympia/devhub/templates/devhub/versions/add_file_modal.html:14
-#: src/olympia/devhub/templates/devhub/versions/add_file_modal.html:53 src/olympia/devhub/templates/devhub/versions/list.html:298
-msgid "Warning:"
-msgstr "Varování:"
-
-#: src/olympia/devhub/templates/devhub/validate_addon.html:50 src/olympia/devhub/templates/devhub/addons/submit/upload.html:31
-#, python-format
-msgid "Submission of unlisted add-ons for signing is currently in an open beta. Please <a href=\"%(url)s\" target=\"_blank\">report any bugs</a> that you encounter."
-msgstr "Přidávání neveřejných doplňků je momentálně ve stavu otevřené bety. <a href=\"%(url)s\" target=\"_blank\">Nahlaste</a> prosím jakékoli chyby, na které narazíte."
-
 #. first parameter is a filename like lorem-ipsum-1.0.2.xpi
 #: src/olympia/devhub/templates/devhub/validation.html:5
 msgid "Validation Results for {0}"
@@ -4365,7 +4301,7 @@ msgstr "Kompatibilita"
 msgid "Update Compatibility"
 msgstr "Aktualizace kompatibility"
 
-#: src/olympia/devhub/templates/devhub/addons/ajax_compat_update.html:4
+#: src/olympia/devhub/templates/devhub/addons/ajax_compat_update.html:4 src/olympia/devhub/templates/devhub/versions/edit.html:45
 msgid "Adjusting application information here will allow users to install your add-on even if the install manifest in the package indicates that the add-on is incompatible."
 msgstr "Zde upravené informace o aplikaci umožní uživatelům instalovat doplněk i tehdy, když instalační manifest v balíčku uvádí, že je doplněk nekompatibilní."
 
@@ -4377,9 +4313,9 @@ msgstr "Podporované verze"
 msgid "Add Another Application&hellip;"
 msgstr "Přidat další aplikaci&hellip;"
 
-#: src/olympia/devhub/templates/devhub/addons/ajax_compat_update.html:38 src/olympia/devhub/templates/devhub/addons/owner.html:86 src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:46
-#: src/olympia/devhub/templates/devhub/versions/list.html:351 src/olympia/devhub/templates/devhub/versions/list.html:353 src/olympia/templates/impala/base.html:132
-#: src/olympia/templates/impala/base.html:143 src/olympia/templates/impala/base.html:161 src/olympia/templates/impala/base.html:171
+#: src/olympia/devhub/templates/devhub/addons/ajax_compat_update.html:38 src/olympia/devhub/templates/devhub/addons/owner.html:86 src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:45
+#: src/olympia/devhub/templates/devhub/versions/list.html:349 src/olympia/devhub/templates/devhub/versions/list.html:351 src/olympia/templates/impala/base.html:129
+#: src/olympia/templates/impala/base.html:140 src/olympia/templates/impala/base.html:158 src/olympia/templates/impala/base.html:168
 msgid "Close"
 msgstr "Zavřít"
 
@@ -4398,7 +4334,6 @@ msgid "<b>{0}</b> theme"
 msgid_plural "<b>{0}</b> themes"
 msgstr[0] "<b>{0}</b> motiv"
 msgstr[1] "<b>{0}</b> motivy"
-msgstr[2] "<b>{0}</b> motivů"
 
 #: src/olympia/devhub/templates/devhub/addons/edit.html:3 src/olympia/devhub/templates/devhub/addons/listing/item_actions.html:25
 #: src/olympia/devhub/templates/devhub/addons/listing/item_actions_theme.html:7 src/olympia/devhub/templates/devhub/includes/addons_edit_nav.html:2
@@ -4414,7 +4349,7 @@ msgstr "Žádné"
 msgid "Manage Authors & License"
 msgstr "Správa autorů a licence"
 
-#: src/olympia/devhub/templates/devhub/addons/owner.html:29 src/olympia/editors/templates/editors/review.html:270
+#: src/olympia/devhub/templates/devhub/addons/owner.html:29 src/olympia/editors/helpers.py:362 src/olympia/editors/templates/editors/review.html:270
 msgid "Authors"
 msgstr "Autoři"
 
@@ -4510,7 +4445,6 @@ msgid "Comma-separated, minimum of {0} character."
 msgid_plural "Comma-separated, minimum of {0} characters."
 msgstr[0] "Hodnoty jsou odděleny čárou, minimálně {0} znak."
 msgstr[1] "Hodnoty jsou odděleny čárou, minimálně {0} znaky."
-msgstr[2] "Hodnoty jsou odděleny čárou, minimálně {0} znaků."
 
 #: src/olympia/devhub/templates/devhub/addons/edit/basic.html:132 src/olympia/devhub/templates/devhub/personas/edit.html:100 src/olympia/devhub/templates/devhub/personas/submit.html:49
 msgid "Example: dark, cinema, noir. Limit 20."
@@ -4521,7 +4455,6 @@ msgid "Reserved tag:"
 msgid_plural "Reserved tags:"
 msgstr[0] "Rezervovaný štítek:"
 msgstr[1] "Rezervované štítky:"
-msgstr[2] "Rezervované štítky:"
 
 #: src/olympia/devhub/templates/devhub/addons/edit/details.html:5
 msgid "Add-on Details"
@@ -4607,9 +4540,7 @@ msgid "Add-on Flags"
 msgstr "Příznaky doplňku"
 
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:69
-msgid ""
-"These flags are used to classify add-ons. It is only\n"
-"                        relevant for listed add-ons."
+msgid "These flags are used to classify add-ons. It is only relevant for listed add-ons."
 msgstr "Tyto příznaky jsou použity k zařazení doplňku. Relevantní pouze pro zveřejněné doplňky."
 
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:74
@@ -4625,9 +4556,7 @@ msgid "View Source?"
 msgstr "Zobrazit zdrojový kód?"
 
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:90
-msgid ""
-"Whether the source of your add-on can be displayed in our\n"
-"                        online viewer. It is only relevant for listed add-ons."
+msgid "Whether the source of your add-on can be displayed in our online viewer. It is only relevant for listed add-ons."
 msgstr "Určuje, zda může být zdrojový k doplňku zobrazen v našem online prohlížeči. Relevantní pouze pro zveřejněné doplňky."
 
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:94
@@ -4643,10 +4572,7 @@ msgid "Public Stats?"
 msgstr "Veřejné statistiky?"
 
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:102
-msgid ""
-"Whether the download and usage stats of your add-on can\n"
-"                        be displayed in our online viewer.\n"
-"                        It is only relevant for listed add-ons."
+msgid "Whether the download and usage stats of your add-on can be displayed in our online viewer. It is only relevant for listed add-ons."
 msgstr "Určuje, zda mohou být statistiky použití zobrazeny v našem online prohlížeči. Relevantní pouze pro zveřejněné doplňky."
 
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:107
@@ -4731,9 +4657,7 @@ msgid "32x32px"
 msgstr "32 x 32px"
 
 #: src/olympia/devhub/templates/devhub/addons/forms_shared/media.html:39
-msgid ""
-"Used in listings of add-ons, like search results\n"
-"                            and featured add-ons."
+msgid "Used in listings of add-ons, like search results and featured add-ons."
 msgstr "Použita v seznamech doplňků jako jsou výsledky vyhledávání či doporučené doplňky."
 
 #. The size of the icon
@@ -4828,16 +4752,14 @@ msgid "Deleting your add-on will permanently remove it from the site and prevent
 msgstr "Smazáním doplňku jej nenávratně odstraníte z této stránky a zabráníte komukoliv v použití jeho GUID."
 
 #: src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:24
-msgid ""
-"Enter the following text confirm your decision:\n"
-"           {slug}"
+msgid "Enter the following text confirm your decision: {slug}"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:34
+#: src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:33
 msgid "Please tell us why you are deleting your theme:"
 msgstr "Řekněte nám prosím, proč mažete svůj motiv:"
 
-#: src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:36
+#: src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:35
 msgid "Please tell us why you are deleting your add-on:"
 msgstr "Řekněte nám prosím, proč mažete svůj doplněk:"
 
@@ -4874,8 +4796,8 @@ msgstr "Nová verze"
 msgid "Daily statistics on downloads and users."
 msgstr "Denní statistiky o počtech stažení a uživatelích."
 
-#: src/olympia/devhub/templates/devhub/addons/listing/item_actions.html:45 src/olympia/stats/templates/stats/stats.html:75 src/olympia/stats/templates/stats/stats.html:79
-#: src/olympia/stats/templates/stats/stats.html:81
+#: src/olympia/devhub/templates/devhub/addons/listing/item_actions.html:45 src/olympia/stats/templates/stats/stats.html:31 src/olympia/stats/templates/stats/stats.html:35
+#: src/olympia/stats/templates/stats/stats.html:37
 msgid "Statistics"
 msgstr "Statistiky"
 
@@ -4936,7 +4858,6 @@ msgid "<strong>{0}</strong> active user"
 msgid_plural "<strong>{0}</strong> active users"
 msgstr[0] "<strong>{0}</strong> aktivní uživatel"
 msgstr[1] "<strong>{0}</strong> aktivní uživatelé"
-msgstr[2] "<strong>{0}</strong> aktivních uživatelů"
 
 #: src/olympia/devhub/templates/devhub/addons/submit/base.html:11
 msgid "Submit Add-on"
@@ -4995,10 +4916,7 @@ msgid "Your add-on has been submitted to the Full Review queue."
 msgstr "Váš doplněk byl odeslán do fronty na plnou kontrolu."
 
 #: src/olympia/devhub/templates/devhub/addons/submit/done.html:18
-msgid ""
-"You'll receive an email once it has been reviewed by an editor. In\n"
-"          the meantime, you and your friends can install it directly from its\n"
-"          details page:"
+msgid "You'll receive an email once it has been reviewed by an editor. In the meantime, you and your friends can install it directly from its details page:"
 msgstr "Jakmile bude doplněk zkontrolován redaktorem, obdržíte e-mail. V mezičase si ho můžete vy a vaši přátelé nainstalovat přímo ze stránky detailu:"
 
 #: src/olympia/devhub/templates/devhub/addons/submit/done.html:27 src/olympia/devhub/templates/devhub/addons/submit/done.html:77 src/olympia/devhub/templates/devhub/personas/submit_done.html:16
@@ -5206,11 +5124,11 @@ msgstr "Krok 2. Nahrání doplňku"
 msgid "Use the fields below to upload your add-on package and select any platform restrictions. After upload, a series of automated validation tests will be run on your file."
 msgstr "Pro nahrání balíčku se svým doplňkem a omezení cílových platforem použijte pole níže. Po nahrání bude spuštěna skupina automatizovaných testů, které váš balíček zkontrolují."
 
-#: src/olympia/devhub/templates/devhub/addons/submit/upload.html:59 src/olympia/devhub/templates/devhub/versions/add_file_modal.html:39
+#: src/olympia/devhub/templates/devhub/addons/submit/upload.html:51 src/olympia/devhub/templates/devhub/versions/add_file_modal.html:28
 msgid "Which platforms is this file compatible with?"
 msgstr "S kterými platformami je tento soubor kompatibilní?"
 
-#: src/olympia/devhub/templates/devhub/addons/submit/upload.html:67 src/olympia/devhub/templates/devhub/versions/add_file_modal.html:65
+#: src/olympia/devhub/templates/devhub/addons/submit/upload.html:59 src/olympia/devhub/templates/devhub/versions/add_file_modal.html:45
 msgid "Administrative overrides"
 msgstr "Změny při administraci"
 
@@ -5329,11 +5247,9 @@ msgstr "Funkcionalita webu a vývoj"
 
 #: src/olympia/devhub/templates/devhub/docs/policies-contact.html:44
 msgid ""
-"If you've found a problem with the site, we'd love to fix it. Please <a href=\"https://github.com/mozilla/olympia/issues\">file a bug report</a> in GitHub, including the location of the problem and"
-" how you encountered it."
+"If you've found a problem with the site, we'd love to fix it. Please <a href=\"https://github.com/mozilla/addons/issues/new\">file a bug report</a> in GitHub, including the location of the problem "
+"and how you encountered it."
 msgstr ""
-"Pokud jste nalezli problém s webem, rádi jej opravíme. <a href=\"https://github.com/mozilla/olympia/issues\">Nahlaste jej</a> prosím na GitHubu spolu s informací, kde se problém vyskytl a jak jej "
-"lze zreprodukovat."
 
 #: src/olympia/devhub/templates/devhub/docs/policies-maintenance.html:3 src/olympia/devhub/templates/devhub/docs/policies-maintenance.html:7
 #: src/olympia/devhub/templates/devhub/docs/policies-maintenance.html:8
@@ -6195,63 +6111,55 @@ msgstr "Zásady používání služby pro odeslání vaší práce na tento web.
 msgid "How to get in touch with us regarding these policies or your add-on."
 msgstr "Jak se s námi spojit v případě otázek týkajících se těchto zásad či doplňku."
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:6
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:10
 msgid "You have disabled this add-on"
 msgstr "Zakázali jste tento doplněk"
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:20
-msgid ""
-"Your add-on's listing is disabled and is not showing\n"
-"                             anywhere in our gallery or update service."
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:24
+msgid "Your add-on's listing is disabled and is not showing anywhere in our gallery or update service."
 msgstr "Stránka vašeho doplňku je zakázána a není tak k dispozici kdekoliv v naší galerii či aktualizační službě."
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:25
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:27
 msgid "Please complete your add-on."
 msgstr "Dokončete prosím svůj doplněk."
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:29
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:30
 msgid "You will receive an email when the review is complete."
 msgstr "Po dokončení kontroly obdržíte e-mail."
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:34
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:33
 msgid "You will receive an email when the review is complete. Until then, your add-on is not listed in our gallery but can be accessed directly from its details page."
 msgstr "Až bude kontrola dokončena, bude vám zaslán e-mail. Do té doby není váš doplněk umístěn v seznamech doplňků, ale je dostupný přímo na stránce s informacemi o doplňku."
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:38 src/olympia/devhub/templates/devhub/includes/addon_details.html:48
-msgid ""
-"You will receive an email when the review is\n"
-"                             complete and your add-on is signed."
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:37 src/olympia/devhub/templates/devhub/includes/addon_details.html:45
+msgid "You will receive an email when the review is complete and your add-on is signed."
 msgstr "Jakmile bude kontrola dokončena a váš doplněk podepsán, budete informováni e-mailem."
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:44
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:41
 msgid "You will receive an email when the review is complete. Until then, your add-on is not listed in our gallery but can be accessed directly from its details page."
 msgstr "Až bude kontrola dokončena, bude vám zaslán e-mail. Do té doby není váš doplněk umístěn v seznamech doplňků, ale je dostupný přímo na stránce s informacemi o doplňku."
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:54
-msgid ""
-"Your add-on is displayed in our gallery and users are\n"
-"                             receiving automatic updates."
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:49
+msgid "Your add-on is displayed in our gallery and users are receiving automatic updates."
 msgstr "Váš doplněk je zobrazen v naší galerii a uživatelé k němu získávají aktualizace."
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:57
-msgid ""
-"Your add-on has been signed and can be bundled with an\n"
-"                             application installer."
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:52
+msgid "Your add-on has been signed and can be bundled with an application installer."
 msgstr "Váš doplněk byl podepsán a může být přibalen k instalátoru aplikace."
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:63
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:56
 msgid "Your add-on was disabled by a site administrator and is no longer shown in our gallery. If you have any questions, please email amo-admins@mozilla.org."
 msgstr "Váš doplněk byl zakázán správcem stránky a již není na našich stránkách dostupný. Máte-li nějaké dotazy, pošlete e-mail na amo-admins@mozilla.org."
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:70
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:62
 msgid "Your add-on is displayed in our gallery as experimental and users are receiving automatic updates. Some features are unavailable to your add-on."
 msgstr "Váš doplněk je zobrazen v naší galerii jako experimentální a uživatele k němu mohou získávat automatické aktualizace. Některé funkce však pro váš doplněk nejsou dostupné."
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:74
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:66
 msgid "Your add-on has been signed."
 msgstr "Váš doplněk byl podepsán."
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:79
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:69
 msgid ""
 "You will receive an email when the full review is complete. Until then, your add-on is displayed in our gallery as experimental and users are receiving automatic updates. Some features are "
 "unavailable to your add-on."
@@ -6259,41 +6167,41 @@ msgstr ""
 "Jakmile bude plná kontrola hotova, obdržíte e-mail. Do té doby bude váš doplněk zobrazen v naší galerii jako experimentální a uživatelé k němu budou získávat aktualizace. Některé funkce však pro "
 "váš doplněk nebudou dostupné."
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:84
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:74
 msgid "You will receive an email when the full review is complete, making you able to bundle your add-on with an application installer."
 msgstr "Jakmile bude plná kontrola hotova a vy budete moci přibalit svůj doplněk k instalátoru, obdržíte e-mail."
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:91
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:79
 msgid "All add-ons hosted in our gallery must now be reviewed by an editor. If you wish to continue hosting your add-on, please click to select a review process."
 msgstr "Všechny doplňky hostované v naší galerii musí projít kontrolou redaktora. Pokud si přejete pokračovat v hostování svého doplňku, zvolte klepnutím typ procesu kontroly."
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:113
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:100
 msgid "Current Version:"
 msgstr "Aktuální verze:"
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:115
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:102
 msgid "This is the version of your add-on that will be installed if someone clicks the Install button on addons.mozilla.org. It is only relevant for listed add-ons."
 msgstr "Toto je verze doplňku, která bude nainstalována, když někdo klikne na tlačítko Nainstalovat na stránkách addons.mozilla.org. Relevantní pouze pro zveřejněné doplňky."
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:123
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:110
 msgid "Created:"
 msgstr "Vytvořeno:"
 
 #. {0} is a date. dennis-ignore: E201
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:125 src/olympia/devhub/templates/devhub/includes/addon_details.html:131
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:112 src/olympia/devhub/templates/devhub/includes/addon_details.html:118
 #, python-format
 msgid "%%b %%e, %%Y"
 msgstr "%%b. %%e %%Y"
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:136
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:123
 msgid "Next Version:"
 msgstr "Příští verze:"
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:138
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:125
 msgid "This is the newest uploaded version, however it isn’t live on the site yet."
 msgstr "Toto je nejnovější nahraná veze, nicméně zatím nebyla na stránkách uveřejněna."
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:144 src/olympia/devhub/templates/devhub/versions/list.html:30
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:130 src/olympia/devhub/templates/devhub/versions/list.html:30
 msgid "Queues are not reviewed strictly in order"
 msgstr "Fronty nejsou striktně procházeny dle pořadí"
 
@@ -6363,9 +6271,7 @@ msgid "View the blog &#9658;"
 msgstr "Zobrazit blog &#9658;"
 
 #: src/olympia/devhub/templates/devhub/includes/license_form.html:6
-msgid ""
-"Please choose a license appropriate for the rights you grant on your source code.\n"
-"                  It is only relevant for listed add-ons."
+msgid "Please choose a license appropriate for the rights you grant on your source code. It is only relevant for listed add-ons."
 msgstr "Vyberte prosím vhodnou licenci vzhledem k právům, která chcete poskytnout ke svému zdrojovému kódu. Relevantní pouze pro zveřejněné doplňky."
 
 #. {0} is a list of HTML tags.
@@ -6381,25 +6287,21 @@ msgstr "Některé HTML je podporováno."
 msgid "Remove this application"
 msgstr "Odebrat tuto aplikaci"
 
-#. {0} is the maximum number of add-on categories allowed.                {1}
-#. is
+#. {0} is the maximum number of add-on categories allowed.                {1} is
 #. the application name.
 #: src/olympia/devhub/templates/devhub/includes/macros.html:70
 msgid "Select <b>up to {0}</b> {1} category for this add-on:"
 msgid_plural "Select <b>up to {0}</b> {1} categories for this add-on:"
 msgstr[0] "Zvolte <b>{0}</b> kategorii pro aplikaci {1}, v které bude doplněk dostupný:"
 msgstr[1] "Zvolte <b>až {0}</b> kategorie pro aplikaci {1}, v které bude doplněk dostupný:"
-msgstr[2] "Zvolte <b>až {0}</b> kategorií pro aplikaci {1}, v které bude doplněk dostupný:"
 
 #: src/olympia/devhub/templates/devhub/includes/policy_form.html:4
 msgid ""
 "Users will be required to accept the following End-User License Agreement (EULA) prior to installing your add-on. The presence of a EULA significantly affects the number of downloads an add-on "
-"receives. Please note that a EULA is not the same as a code license, such as the GPL or MPL. It is only relevant for listed add-ons."
+"receives. Please note that a EULA is not the same as a code license, such as the GPL or MPL.It is only relevant for listed add-ons."
 msgstr ""
-"Uživatelé budou muset souhlasit s licenční smlouvou (EULA) než budou moci nainstalovat váš doplněk. Přítomnost licenční smlouvy výrazně ovlivňuje počet stažení doplňku. Mějte na paměti, že EULA "
-"není náhradou licencí kódu jako GPL či MPL. Relevantní pouze pro zveřejněné doplňky."
 
-#: src/olympia/devhub/templates/devhub/includes/policy_form.html:21
+#: src/olympia/devhub/templates/devhub/includes/policy_form.html:24
 msgid "If your add-on transmits any data from the user's computer, a privacy policy is required that explains what data is sent and how it is used. It is only relevant for listed add-ons."
 msgstr "Přenáší-li doplněk data z počítače uživatele, je nutné v zásadách ochrany soukromí vysvětlit, jaká data jsou odesílána a jak jsou použita. Relevantní pouze pro zveřejněné doplňky."
 
@@ -6568,7 +6470,7 @@ msgstr "Zvolte kategorii, která nejlépe popisuje váš motiv."
 msgid "Add some tags to describe your Theme."
 msgstr "Přidejte štítky, které popisují váš motiv."
 
-#: src/olympia/devhub/templates/devhub/personas/edit.html:106
+#: src/olympia/devhub/templates/devhub/personas/edit.html:106 src/olympia/devhub/templates/devhub/personas/submit.html:54
 msgid "A short explanation of your theme's basic functionality that is displayed in search and browse listings, as well as at the top of your theme's details page."
 msgstr "Krátký popis vašeho motivu, který je zobrazen ve vyhledávání, přehledu v kategorii či přímo na stránce detailu motivu."
 
@@ -6639,7 +6541,7 @@ msgid "Upon upload and form submission, the AMO Team will review your updated de
 msgstr "Po nahrání a odeslání provede tým AMO kontrolu vámi aktualizovaného vzhledu. Váš aktuální vzhled bude v mezidobí stále k dispozici na webu."
 
 #: src/olympia/devhub/templates/devhub/personas/edit.html:241
-msgid "Your previously resubmitted design,  which is under pending review."
+msgid "Your previously resubmitted design, which is under pending review."
 msgstr "Vámi dříve odeslaný vzhled, který čeká na kontrolu."
 
 #: src/olympia/devhub/templates/devhub/personas/edit.html:245
@@ -6707,10 +6609,6 @@ msgstr "Motivy vám dávají možnost si snadno přizpůsobit vzhled svého Fire
 #: src/olympia/devhub/templates/devhub/personas/submit.html:33
 msgid "Give your Theme a name."
 msgstr "Dejte vašemu motivu jméno."
-
-#: src/olympia/devhub/templates/devhub/personas/submit.html:54
-msgid "A short explanation of your theme's basic functionality that is displayed in search and browse listings, as well as at the top of your theme's details page."
-msgstr "Krátký popis vašeho motivu, který je zobrazen ve vyhledávání, přehledu v kategorii či přímo na stránce detailu motivu."
 
 #: src/olympia/devhub/templates/devhub/personas/submit.html:198
 #, python-format
@@ -6788,35 +6686,17 @@ msgstr "Vybrat jiný obrázek patičky"
 msgid "Files added to reviewed versions must be reviewed before they will be available for download."
 msgstr "Soubory přidané ke zkontrolovaným verzím musí být zkontrolovány dříve, než budou dostupné ke stažení."
 
-#: src/olympia/devhub/templates/devhub/versions/add_file_modal.html:15
-#, python-format
-msgid ""
-"Submission of updates to unlisted add-ons for signing is currently in an open beta. Manual review may still be required for a large number of add-ons. Please <a href=\"%(url)s\" "
-"target=\"_blank\">report any bugs</a> that you encounter."
-msgstr ""
-"Odesílání aktualizací nezveřejněných doplňků k automatickému podepisování je ve stádiu otevřené bety. Pro velké množství doplňků může být stále vyžadována ruční kontrola. <a href=\"%(url)s\" "
-"target=\"_blank\">Nahlaste</a> prosím všechny chyby, na který narazíte."
-
-#: src/olympia/devhub/templates/devhub/versions/add_file_modal.html:35
+#: src/olympia/devhub/templates/devhub/versions/add_file_modal.html:24
 msgid "Select the target platform for this file."
 msgstr "Zvolte cílovou platformu souboru."
 
-#: src/olympia/devhub/templates/devhub/versions/add_file_modal.html:46
+#: src/olympia/devhub/templates/devhub/versions/add_file_modal.html:35
 msgid "Which review type would you like to nominate for?"
 msgstr "Pro jaký typ kontroly byste rádi provedli nominaci?"
 
-#: src/olympia/devhub/templates/devhub/versions/add_file_modal.html:51
+#: src/olympia/devhub/templates/devhub/versions/add_file_modal.html:40
 msgid "Only publish this version to my beta channel."
 msgstr "Tuto verzi publikovat pouze v mém beta kanálu."
-
-#: src/olympia/devhub/templates/devhub/versions/add_file_modal.html:54
-#, python-format
-msgid ""
-"The behavior of the beta channel has changed to accommodate <a href=\"%(addon_signing_url)s\" target=\"_blank\">mandatory add-on signing</a>. The new process is currently in an open beta, and may "
-"change significantly in the near future. Please <a href=\"%(issues_url)s\" target=\"_blank\">report any bugs</a> that you encounter."
-msgstr ""
-"Chování beta kanálu bylo změněno, aby odpovídalo <a href=\"%(addon_signing_url)s\" target=\"_blank\">povinnému podepisování doplňků</a>. Nový proces je ve fázi otevřeného testování a může se v "
-"budoucnu změnit. <a href=\"%(issues_url)s\" target=\"_blank\">Nahlaste nám prosím jakékoliv chyby</a>, kterých si všimnete."
 
 #: src/olympia/devhub/templates/devhub/versions/edit.html:5
 msgid "Manage Version {0}"
@@ -6839,10 +6719,6 @@ msgstr "Soubory"
 #: src/olympia/devhub/templates/devhub/versions/edit.html:38
 msgid "Upload Another File"
 msgstr "Nahrát další soubor"
-
-#: src/olympia/devhub/templates/devhub/versions/edit.html:45
-msgid "Adjusting application information here will allow users to install your add-on even if the install manifest in the package indicates that the add-on is incompatible."
-msgstr "Zde upravené informace o aplikaci umožní uživatelům instalovat doplněk i tehdy, když instalační manifest v balíčku uvádí, že je doplněk nekompatibilní."
 
 #: src/olympia/devhub/templates/devhub/versions/edit.html:74
 msgid ""
@@ -6913,7 +6789,6 @@ msgid "{0} file"
 msgid_plural "{0} files"
 msgstr[0] "{0} soubor"
 msgstr[1] "{0} soubory"
-msgstr[2] "{0} souborů"
 
 #: src/olympia/devhub/templates/devhub/versions/list.html:25
 msgid "0 files"
@@ -6940,7 +6815,7 @@ msgstr "Požádat o plnou kontrolu"
 msgid "Request Preliminary Review"
 msgstr "Požádat o předběžnou kontrolu"
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:80 src/olympia/devhub/templates/devhub/versions/list.html:327 src/olympia/devhub/templates/devhub/versions/list.html:350
+#: src/olympia/devhub/templates/devhub/versions/list.html:80 src/olympia/devhub/templates/devhub/versions/list.html:325 src/olympia/devhub/templates/devhub/versions/list.html:348
 msgid "Cancel Review Request"
 msgstr "Zrušit žádost o kontrolu"
 
@@ -6969,8 +6844,8 @@ msgid "Unlisted:"
 msgstr "Nazařezený:"
 
 #: src/olympia/devhub/templates/devhub/versions/list.html:114
-msgid "Not distributed on {0}. Developers will upload new versions for signing and distribute the add-ons on their own. (beta)"
-msgstr "Není distribuováno na {0}. Vývojáři budou nahrávat nové verze k podepsání a budou distribuovat doplněk sami. (beta)"
+msgid "Not distributed on {0}. Developers will upload new versions for signing and distribute the add-ons on their own."
+msgstr ""
 
 #: src/olympia/devhub/templates/devhub/versions/list.html:122
 msgid "Current versions"
@@ -7034,81 +6909,73 @@ msgid "<strong>Important:</strong> Once a version has been deleted, you may not 
 msgstr "<strong>Důležité:</strong> Jakmile je verze smazána, nemůžete nahrát novou verzi se stejným číslem verze."
 
 #: src/olympia/devhub/templates/devhub/versions/list.html:230
-msgid ""
-"Deleting a version which has already been reviewed\n"
-"               may also cause a significant delay in the review of\n"
-"               your next update."
-msgstr "Smazání verze, která již byla zkontrolována, může způsobit zdržení při kontrole vaší příští aktualizace."
-
-#: src/olympia/devhub/templates/devhub/versions/list.html:233
 msgid "Are you sure you wish to delete this version?"
 msgstr "Opravdu chcete smazat tuto verzi?"
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:238
+#: src/olympia/devhub/templates/devhub/versions/list.html:235
 msgid "Delete Version"
 msgstr "Smazat verzi"
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:240
+#: src/olympia/devhub/templates/devhub/versions/list.html:237
 msgid "Disable Version"
 msgstr "Zakázat verzi"
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:247
+#: src/olympia/devhub/templates/devhub/versions/list.html:244
 msgid "Add a new Version"
 msgstr "Přidání nové verze"
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:249
+#: src/olympia/devhub/templates/devhub/versions/list.html:246
 msgid "Add Version"
 msgstr "Přidat verzi"
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:256 src/olympia/devhub/templates/devhub/versions/list.html:274
+#: src/olympia/devhub/templates/devhub/versions/list.html:253 src/olympia/devhub/templates/devhub/versions/list.html:279
 msgid "Hide Add-on"
 msgstr "Skrýt doplněk"
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:259
+#: src/olympia/devhub/templates/devhub/versions/list.html:256
 msgid "Hiding your add-on will prevent it from appearing anywhere in our gallery and will stop users from receiving automatic updates."
 msgstr "Skrytím svého doplňku zabráníte, aby se zobrazoval kdekoliv v naší galerie, a uživatelům přestanou být instalovány automatická aktualizace."
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:265
+#: src/olympia/devhub/templates/devhub/versions/list.html:263
+msgid "The files awaiting review will be disabled and you will need to upload new versions."
+msgstr ""
+
+#: src/olympia/devhub/templates/devhub/versions/list.html:270
 msgid "Are you sure you wish to hide your add-on?"
 msgstr "Opravdu chcete skrýt svůj doplněk?"
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:286 src/olympia/devhub/templates/devhub/versions/list.html:315
+#: src/olympia/devhub/templates/devhub/versions/list.html:291 src/olympia/devhub/templates/devhub/versions/list.html:313
 msgid "Unlist Add-on"
 msgstr "Zrušit zveřejnění doplňku"
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:289
+#: src/olympia/devhub/templates/devhub/versions/list.html:294
 #, python-format
 msgid ""
 "Unlisting your add-on will make it (and each of its versions/files) invisible on this website. It won't show up in searches, won't have a public facing page, and won't be updated automatically for "
-"current users.  It is recommended for unlisted add-ons to provide a custom <a href=\"%(update_url)s\" target=\"_blank\">updateURL</a> in their manifest file for automatic updates."
+"current users. It is recommended for unlisted add-ons to provide a custom <a href=\"%(update_url)s\" target=\"_blank\">updateURL</a> in their manifest file for automatic updates."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:299
-#, python-format
-msgid "Switching add-ons to unlisted is currently in an open beta. Please <a href=\"%(url)s\" target=\"_blank\">report any bugs</a> that you encounter."
-msgstr "Změna stavu doplňku na neveřejný je aktuálně ve fázi otevřené bety. <a href=\"%(url)s\" target=\"_blank\">Nahlaste</a> prosím jakékoli chyby, na které narazíte."
-
-#: src/olympia/devhub/templates/devhub/versions/list.html:305
+#: src/olympia/devhub/templates/devhub/versions/list.html:303
 msgid "Unlisting an add-on is irreversible!"
 msgstr "Změna stavu doplňku na neveřejný je nevratná!"
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:305
+#: src/olympia/devhub/templates/devhub/versions/list.html:303
 msgid "An unlisted add-on cannot be switched to be listed."
 msgstr "Neveřejný doplněk nelze změnit na veřejný."
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:307
+#: src/olympia/devhub/templates/devhub/versions/list.html:305
 msgid "Are you sure you wish to unlist your add-on?"
 msgstr "Opravdu chcete zrušit zařazení svého doplňku v seznamech?"
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:330
+#: src/olympia/devhub/templates/devhub/versions/list.html:328
 msgid "Canceling your review request will leave your add-on as preliminarily reviewed."
 msgstr "Zrušením vaší žádosti o kontrolu ponecháte svůj doplněk předběžně zkontrolovaným."
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:335
+#: src/olympia/devhub/templates/devhub/versions/list.html:333
 msgid "Canceling your review request will mark your add-on incomplete. If you do not complete your add-on after several days by re-requesting review, it will be deleted."
 msgstr "Zrušením vaší žádosti o kontrolu označíte svůj doplněk jako nekompletní. Pokud svůj doplněk během několika dní nedokončíte opětovnou žádostí o kontrolu, bude smazán."
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:343
+#: src/olympia/devhub/templates/devhub/versions/list.html:341
 msgid "Are you sure you wish to cancel your review request?"
 msgstr "Opravdu chcete zrušit vaši žádost o kontrolu?"
 
@@ -7449,19 +7316,19 @@ msgstr "doplněk, recenze nebo komentář"
 msgid "Search by add-on name / author email"
 msgstr "Hledat dle jména doplňku / e-mailu autora"
 
-#: src/olympia/editors/forms.py:103
+#: src/olympia/editors/forms.py:103 src/olympia/editors/forms.py:244 src/olympia/editors/forms.py:257
 msgid "yes"
 msgstr "ano"
 
-#: src/olympia/editors/forms.py:104
+#: src/olympia/editors/forms.py:104 src/olympia/editors/forms.py:244 src/olympia/editors/forms.py:257
 msgid "no"
 msgstr "ne"
 
-#: src/olympia/editors/forms.py:105
+#: src/olympia/editors/forms.py:105 src/olympia/editors/forms.py:245
 msgid "Admin Flag"
 msgstr "Kontrola administrátorem"
 
-#: src/olympia/editors/forms.py:113
+#: src/olympia/editors/forms.py:113 src/olympia/editors/forms.py:253
 msgid "Max. Version"
 msgstr "Max. verze"
 
@@ -7473,55 +7340,59 @@ msgstr "Dní od odeslání"
 msgid "Add-on Types"
 msgstr "Typy doplňků"
 
-#: src/olympia/editors/forms.py:126 src/olympia/editors/helpers.py:267
+#: src/olympia/editors/forms.py:126 src/olympia/editors/helpers.py:279
 msgid "Platforms"
 msgstr "Platformy"
 
+#: src/olympia/editors/forms.py:237
+msgid "Search by add-on name / author email / guid"
+msgstr ""
+
 #. L10n: 0 = platform, 1 = filename, 2 = status message
-#: src/olympia/editors/forms.py:238
+#: src/olympia/editors/forms.py:342
 #, python-format
 msgid "<strong>%s</strong> &middot; %s &middot; %s"
 msgstr "<strong>%s</strong> &middot; %s &middot; %s"
 
-#: src/olympia/editors/forms.py:252
+#: src/olympia/editors/forms.py:356
 msgid "Comments:"
 msgstr "Komentář:"
 
-#: src/olympia/editors/forms.py:256
+#: src/olympia/editors/forms.py:360
 msgid "Operating systems:"
 msgstr "Operační systémy:"
 
-#: src/olympia/editors/forms.py:258
+#: src/olympia/editors/forms.py:362
 msgid "Applications:"
 msgstr "Aplikace:"
 
-#: src/olympia/editors/forms.py:260
+#: src/olympia/editors/forms.py:364
 msgid "Notify me the next time this add-on is updated. (Subsequent updates will not generate an email)"
 msgstr "Upozornit mě příště, když je doplněk aktualizován (následné aktualizace nebudou generovat e-mail)"
 
-#: src/olympia/editors/forms.py:265
+#: src/olympia/editors/forms.py:369
 msgid "Clear Admin Review Flag"
 msgstr "Vymazat příznat kontroly administrátorem"
 
-#: src/olympia/editors/forms.py:267
+#: src/olympia/editors/forms.py:371
 msgid "Clear more info requested flag"
 msgstr "Zrušit požadavek na více informací"
 
-#: src/olympia/editors/forms.py:281
+#: src/olympia/editors/forms.py:385
 msgid "Choose a canned response..."
 msgstr "Volba předpřipravené odpovědi..."
 
 #. L10n: Description of what can be searched for.
-#: src/olympia/editors/forms.py:324
+#: src/olympia/editors/forms.py:423
 msgid "theme name"
 msgstr "jméno motivu"
 
-#: src/olympia/editors/forms.py:350
+#: src/olympia/editors/forms.py:449
 msgid "Someone else is reviewing this theme."
 msgstr "Někdo jiný aktuálně kontroluje tento motiv."
 
 #. L10n: Description of what can be searched for.
-#: src/olympia/editors/forms.py:447
+#: src/olympia/editors/forms.py:546
 msgid "app, reviewer, or comment"
 msgstr "aplikace, recenze nebo komentář"
 
@@ -7537,203 +7408,210 @@ msgstr "Čeká na předběžnou kontrolu"
 msgid "Rejected or Unreviewed"
 msgstr "Zamítnuté nebo nezkontrolované"
 
-#: src/olympia/editors/helpers.py:123 src/olympia/editors/helpers.py:136
+#: src/olympia/editors/helpers.py:125 src/olympia/editors/helpers.py:138
 msgid "Queue"
 msgstr "Fronta"
 
-#: src/olympia/editors/helpers.py:124 src/olympia/editors/templates/editors/base.html:50 src/olympia/editors/templates/editors/base.html:65
+#: src/olympia/editors/helpers.py:126 src/olympia/editors/templates/editors/base.html:50 src/olympia/editors/templates/editors/base.html:65
 msgid "Pending Updates"
 msgstr "Čekající aktualizace"
 
-#: src/olympia/editors/helpers.py:125 src/olympia/editors/templates/editors/base.html:48 src/olympia/editors/templates/editors/base.html:63
+#: src/olympia/editors/helpers.py:127 src/olympia/editors/templates/editors/base.html:48 src/olympia/editors/templates/editors/base.html:63
 msgid "Full Reviews"
 msgstr "Plné kontroly"
 
-#: src/olympia/editors/helpers.py:126 src/olympia/editors/templates/editors/base.html:52 src/olympia/editors/templates/editors/base.html:67
+#: src/olympia/editors/helpers.py:128 src/olympia/editors/templates/editors/base.html:52 src/olympia/editors/templates/editors/base.html:67
 msgid "Preliminary Reviews"
 msgstr "Předběžné kontroly"
 
-#: src/olympia/editors/helpers.py:127 src/olympia/editors/templates/editors/base.html:54
+#: src/olympia/editors/helpers.py:129 src/olympia/editors/templates/editors/base.html:54
 msgid "Moderated Reviews"
 msgstr "Moderované recenze"
 
-#: src/olympia/editors/helpers.py:128 src/olympia/editors/templates/editors/base.html:46
+#: src/olympia/editors/helpers.py:130 src/olympia/editors/templates/editors/base.html:46
 msgid "Fast Track"
 msgstr "Rychlá kontrola"
 
-#: src/olympia/editors/helpers.py:130
+#: src/olympia/editors/helpers.py:132
 msgid "Pending Themes"
 msgstr "Čekající motivy"
 
-#: src/olympia/editors/helpers.py:131 src/olympia/editors/templates/editors/themes/queue.html:4
+#: src/olympia/editors/helpers.py:133 src/olympia/editors/templates/editors/themes/queue.html:4
 msgid "Flagged Themes"
 msgstr "Označené motivy"
 
-#: src/olympia/editors/helpers.py:132
+#: src/olympia/editors/helpers.py:134
 msgid "Update Themes"
 msgstr "Aktualizace motivů"
 
-#: src/olympia/editors/helpers.py:137
+#: src/olympia/editors/helpers.py:139
 msgid "Unlisted Pending Updates"
 msgstr "Čekající nezařazené aktualizace"
 
-#: src/olympia/editors/helpers.py:138
+#: src/olympia/editors/helpers.py:140
 msgid "Unlisted Full Reviews"
 msgstr "Nezařazené plné kontroly"
 
-#: src/olympia/editors/helpers.py:139
+#: src/olympia/editors/helpers.py:141
 msgid "Unlisted Preliminary Reviews"
 msgstr "Nezařazené předběžné kontroly"
 
-#: src/olympia/editors/helpers.py:170
+#: src/olympia/editors/helpers.py:142
+msgid "Unlisted All Add-ons"
+msgstr ""
+
+#: src/olympia/editors/helpers.py:173
 msgid "Fast Track ({0})"
 msgid_plural "Fast Track ({0})"
 msgstr[0] "Rychlá kontrola ({0})"
 msgstr[1] "Rychlá kontrola ({0})"
-msgstr[2] "Rychlá kontrola ({0})"
 
-#: src/olympia/editors/helpers.py:175
+#: src/olympia/editors/helpers.py:178
 msgid "Full Review ({0})"
 msgid_plural "Full Reviews ({0})"
 msgstr[0] "Plné kontroly ({0})"
 msgstr[1] "Plné kontroly ({0})"
-msgstr[2] "Plné kontroly ({0})"
 
-#: src/olympia/editors/helpers.py:180
+#: src/olympia/editors/helpers.py:183
 msgid "Pending Update ({0})"
 msgid_plural "Pending Updates ({0})"
 msgstr[0] "Čekající aktualizace ({0})"
 msgstr[1] "Čekající aktualizace ({0})"
-msgstr[2] "Čekající aktualizace ({0})"
 
-#: src/olympia/editors/helpers.py:185
+#: src/olympia/editors/helpers.py:188
 msgid "Preliminary Review ({0})"
 msgid_plural "Preliminary Reviews ({0})"
 msgstr[0] "Předběžné kontroly ({0})"
 msgstr[1] "Předběžné kontroly ({0})"
-msgstr[2] "Předběžné kontroly ({0})"
 
-#: src/olympia/editors/helpers.py:190
+#: src/olympia/editors/helpers.py:193
 msgid "Moderated Review ({0})"
 msgid_plural "Moderated Reviews ({0})"
 msgstr[0] "Moderované recenze ({0})"
 msgstr[1] "Moderované recenze ({0})"
-msgstr[2] "Moderované recenze ({0})"
 
-#: src/olympia/editors/helpers.py:196
+#: src/olympia/editors/helpers.py:199
 msgid "Unlisted Full Review ({0})"
 msgid_plural "Unlisted Full Reviews ({0})"
 msgstr[0] "Neřazená plná kontrola ({0})"
 msgstr[1] "Neřazené plné kontroly ({0})"
-msgstr[2] "Neřazené plné kontroly ({0})"
 
-#: src/olympia/editors/helpers.py:201
+#: src/olympia/editors/helpers.py:204
 msgid "Unlisted Pending Update ({0})"
 msgid_plural "Unlisted Pending Updates ({0})"
 msgstr[0] "Čekající nezařezaná aktualizace ({0})"
 msgstr[1] "Čekající nezařezané aktualizace ({0})"
-msgstr[2] "Čekající nezařezané aktualizace ({0})"
 
-#: src/olympia/editors/helpers.py:206
+#: src/olympia/editors/helpers.py:209
 msgid "Unlisted Preliminary Review ({0})"
 msgid_plural "Unlisted Preliminary Reviews ({0})"
 msgstr[0] "Nezařazená předběžná kontrola ({0})"
 msgstr[1] "Nezařazené předběžné kontroly ({0})"
-msgstr[2] "Nezařazené předběžné kontroly ({0})"
 
-#: src/olympia/editors/helpers.py:261
-msgid "Addon"
-msgstr "Doplněk"
+#: src/olympia/editors/helpers.py:214
+msgid "Unlisted All Add-ons ({0})"
+msgid_plural "Unlisted All Add-ons ({0})"
+msgstr[0] ""
+msgstr[1] ""
 
-#: src/olympia/editors/helpers.py:262
+#: src/olympia/editors/helpers.py:274
 msgid "Type"
 msgstr "Typ"
 
-#: src/olympia/editors/helpers.py:263
+#: src/olympia/editors/helpers.py:275
 msgid "Waiting Time"
 msgstr "Doba čekání"
 
-#: src/olympia/editors/helpers.py:264 src/olympia/editors/templates/editors/review.html:285
+#: src/olympia/editors/helpers.py:276 src/olympia/editors/templates/editors/review.html:285
 msgid "Flags"
 msgstr "Atributy"
 
-#: src/olympia/editors/helpers.py:265
+#: src/olympia/editors/helpers.py:277
 msgid "Applications"
 msgstr "Aplikace"
 
-#: src/olympia/editors/helpers.py:270
+#: src/olympia/editors/helpers.py:282
 msgid "Additional"
 msgstr "Další"
 
-#: src/olympia/editors/helpers.py:285
+#: src/olympia/editors/helpers.py:302
 msgid "Site Specific"
 msgstr "Pro konkrétní web"
 
-#: src/olympia/editors/helpers.py:287
+#: src/olympia/editors/helpers.py:304
 msgid "Requires External Software"
 msgstr "Vyžaduje externí software"
 
-#: src/olympia/editors/helpers.py:289
+#: src/olympia/editors/helpers.py:306
 msgid "Binary Components"
 msgstr "Binární komponenty"
 
-#: src/olympia/editors/helpers.py:313
+#: src/olympia/editors/helpers.py:339
 msgid "moments ago"
 msgstr "před chvílí"
 
 #. L10n: first argument is number of minutes
-#: src/olympia/editors/helpers.py:316
+#: src/olympia/editors/helpers.py:342
 msgid "{0} minute"
 msgid_plural "{0} minutes"
 msgstr[0] "{0} minuta"
 msgstr[1] "{0} minuty"
-msgstr[2] "{0} minut"
 
 #. L10n: first argument is number of hours
-#: src/olympia/editors/helpers.py:320
+#: src/olympia/editors/helpers.py:346
 msgid "{0} hour"
 msgid_plural "{0} hours"
 msgstr[0] "{0} hodina"
 msgstr[1] "{0} hodiny"
-msgstr[2] "{0} hodin"
 
 #. L10n: first argument is number of days
-#: src/olympia/editors/helpers.py:324
+#: src/olympia/editors/helpers.py:350
 msgid "{0} day"
 msgid_plural "{0} days"
 msgstr[0] "{0} den"
 msgstr[1] "{0} dny"
-msgstr[2] "{0} dnů"
 
-#: src/olympia/editors/helpers.py:488
+#: src/olympia/editors/helpers.py:364
+msgid "Last Review"
+msgstr ""
+
+#: src/olympia/editors/helpers.py:366
+msgid "Last Update"
+msgstr ""
+
+#: src/olympia/editors/helpers.py:387
+msgid "No Reviews"
+msgstr ""
+
+#: src/olympia/editors/helpers.py:561
 msgid "Push to public"
 msgstr "Schválit"
 
-#: src/olympia/editors/helpers.py:490
+#: src/olympia/editors/helpers.py:563
 msgid "Grant full review"
 msgstr "Udělit plnou kontrolu"
 
-#: src/olympia/editors/helpers.py:505
+#: src/olympia/editors/helpers.py:578
 msgid "Request more information"
 msgstr "Vyžádat více informací"
 
-#: src/olympia/editors/helpers.py:508
+#: src/olympia/editors/helpers.py:581
 msgid "Request super-review"
 msgstr "Vyžádat kontrolu administrátorem"
 
-#: src/olympia/editors/helpers.py:519
+#: src/olympia/editors/helpers.py:592
 msgid "Grant preliminary review"
 msgstr "Udělit předběžnou kontrolu"
 
-#: src/olympia/editors/helpers.py:520
+#: src/olympia/editors/helpers.py:593
 msgid "This will mark the files as preliminarily reviewed."
 msgstr "Označí soubory jako předběžně schválené."
 
-#: src/olympia/editors/helpers.py:522
+#: src/olympia/editors/helpers.py:595
 msgid "Use this form to request more information from the author. They will receive an email and be able to answer here. You will be notified by email when they reply."
 msgstr "Použijte tento formulář pro získání více informací o autorovi. Ten obdrží e-mail a bude zde schopen odpovědět. Až odpoví, budete na to e-mailem upozorněni."
 
-#: src/olympia/editors/helpers.py:526
+#: src/olympia/editors/helpers.py:599
 msgid ""
 "If you have concerns about this add-on's security, copyright issues, or other concerns that an administrator should look into, enter your comments in the area below. They will be sent to "
 "administrators, not the author."
@@ -7741,55 +7619,55 @@ msgstr ""
 "Pokud máte pochybnosti o bezpečnosti doplňku, zaregistrovali jste porušení copyrightu či jiné problémy, o kterých by měl administrátor vědět, vložte svůj komentář do pole níže. Bude poslán "
 "administrátorům, nikoliv autorovi."
 
-#: src/olympia/editors/helpers.py:532
+#: src/olympia/editors/helpers.py:605
 msgid "This will reject the add-on and remove it from the review queue."
 msgstr "Zamítne doplněk a odstraní jej z fronty na kontrolu."
 
-#: src/olympia/editors/helpers.py:534
-msgid "Make a comment on this version.  The author won't be able to see this."
+#: src/olympia/editors/helpers.py:607
+msgid "Make a comment on this version. The author won't be able to see this."
 msgstr "Přidejte komentář k této verzi. Autor jej nebude vidět."
 
-#: src/olympia/editors/helpers.py:538
+#: src/olympia/editors/helpers.py:611
 msgid "This will reject the files and remove them from the review queue."
 msgstr "Zamítne soubory a odstraní je z fronty na kontrolu."
 
-#: src/olympia/editors/helpers.py:542
+#: src/olympia/editors/helpers.py:615
 msgid "This will mark the add-on as preliminarily reviewed. Future versions will undergo preliminary review."
 msgstr "Označí doplněk jako předběžně kontrolovaný. Příští verze budou opět procházet předběžnou kontrolou."
 
-#: src/olympia/editors/helpers.py:547
+#: src/olympia/editors/helpers.py:620
 msgid "This will mark the files as preliminarily reviewed. Future versions will undergo preliminary review."
 msgstr "Označí soubory jako předběžně kontrolované. Příští verze budou opět přocházet předběžnou kontrolou."
 
-#: src/olympia/editors/helpers.py:552
+#: src/olympia/editors/helpers.py:625
 msgid "Retain preliminary review"
 msgstr "Zamítnout předběžnou kontrolu"
 
-#: src/olympia/editors/helpers.py:553
+#: src/olympia/editors/helpers.py:626
 msgid "This will retain the add-on as preliminarily reviewed. Future versions will undergo preliminary review."
 msgstr "Zamítne předběžnou kontrolu doplňku. Příští verze budou opět procházet předběžnou kontrolou."
 
-#: src/olympia/editors/helpers.py:558
+#: src/olympia/editors/helpers.py:631
 msgid "This will approve a sandboxed version of a public add-on to appear on the public side."
 msgstr "Schválí verzi veřejného doplňku a ta se tak bude veřejná."
 
-#: src/olympia/editors/helpers.py:561
+#: src/olympia/editors/helpers.py:634
 msgid "This will reject a version of a public add-on and remove it from the queue."
 msgstr "Zamítne verzi veřejného doplňku a odstraní ji z fronty."
 
-#: src/olympia/editors/helpers.py:564
+#: src/olympia/editors/helpers.py:637
 msgid "This will mark the add-on and its most recent version and files as public. Future versions will go into the sandbox until they are reviewed by an editor."
 msgstr "Označí doplněk a jeho poslední verzi a soubory jako veřejné. Budoucí verze budou umístěny na pískovišti do té doby, dokud nebudou zkontrolovány redaktorem."
 
-#: src/olympia/editors/helpers.py:637
+#: src/olympia/editors/helpers.py:714
 msgid "add-on"
 msgstr "doplněk"
 
-#: src/olympia/editors/helpers.py:940 src/olympia/editors/helpers.py:960
+#: src/olympia/editors/helpers.py:1020 src/olympia/editors/helpers.py:1040
 msgid "Flagged"
 msgstr "Označeno"
 
-#: src/olympia/editors/helpers.py:944 src/olympia/editors/helpers.py:963
+#: src/olympia/editors/helpers.py:1024 src/olympia/editors/helpers.py:1043
 msgid "Updates"
 msgstr "Aktualizace"
 
@@ -7841,56 +7719,56 @@ msgstr "Odeslání motivu označeno pro kontrolu"
 msgid "A question about your Theme submission"
 msgstr "Otázka k vašemu odeslání motivu"
 
-#: src/olympia/editors/views.py:144
+#: src/olympia/editors/views.py:146
 msgid "New Add-ons (Under 5 days)"
 msgstr "Nové doplňky (pod 58 dní)"
 
-#: src/olympia/editors/views.py:145
+#: src/olympia/editors/views.py:147
 msgid "Passable (5 to 10 days)"
 msgstr "Snesitelné (5 až 10 dní)"
 
-#: src/olympia/editors/views.py:146
+#: src/olympia/editors/views.py:148
 msgid "Overdue (Over 10 days)"
 msgstr "S prodlevou (více než 10 dní)"
 
-#: src/olympia/editors/views.py:532
+#: src/olympia/editors/views.py:539
 msgid "An unknown error occurred"
 msgstr "Nastala neznámá chyba"
 
-#: src/olympia/editors/views.py:587
+#: src/olympia/editors/views.py:592
 msgid "Self-reviews are not allowed."
 msgstr "Kontrola vlastních doplňků není povolena."
 
-#: src/olympia/editors/views.py:609
+#: src/olympia/editors/views.py:613
 msgid "Review successfully processed."
 msgstr "Kontrola úspěšně provedena."
 
-#: src/olympia/editors/views.py:807
+#: src/olympia/editors/views.py:812
 msgid "was approved"
 msgstr "byl schválen"
 
-#: src/olympia/editors/views.py:808
+#: src/olympia/editors/views.py:813
 msgid "given preliminary review"
 msgstr "byl předběžně zkontrolován"
 
-#: src/olympia/editors/views.py:809
+#: src/olympia/editors/views.py:814
 msgid "rejected"
 msgstr "zamítnuto"
 
-#: src/olympia/editors/views.py:810
+#: src/olympia/editors/views.py:815
 msgctxt "editors_review_history_nominated_adminreview"
 msgid "escalated"
 msgstr "bude detailně zkontrolován"
 
-#: src/olympia/editors/views.py:812
+#: src/olympia/editors/views.py:817
 msgid "needs more information"
 msgstr "potřeba více informací"
 
-#: src/olympia/editors/views.py:813
+#: src/olympia/editors/views.py:818
 msgid "needs super review"
 msgstr "potřebuje kontrolu administrátory"
 
-#: src/olympia/editors/views.py:814
+#: src/olympia/editors/views.py:819
 msgid "commented"
 msgstr "okomentováno"
 
@@ -7899,7 +7777,6 @@ msgid "{0} theme review successfully processed (+{1} points, {2} total)."
 msgid_plural "{0} theme reviews successfully processed (+{1} points, {2} total)."
 msgstr[0] "{0} motiv úspěšně zpracován (+{1} bodů, {2} celkem)."
 msgstr[1] "{0} motivy úspěšně zpracovány (+{1} bodů, {2} celkem)."
-msgstr[2] "{0} motivů úspěšně zpracováno (+{1} bodů, {2} celkem)."
 
 #: src/olympia/editors/views_themes.py:341
 msgid "Your theme locks have successfully been released. Other reviewers may now review those released themes. You may have to refresh the page to see the changes reflected in the table below."
@@ -7936,28 +7813,28 @@ msgstr "Fronty"
 msgid "Unlisted Queues"
 msgstr "Nezařazené fronty"
 
-#: src/olympia/editors/templates/editors/base.html:72 src/olympia/editors/templates/editors/performance.html:6
+#: src/olympia/editors/templates/editors/base.html:74 src/olympia/editors/templates/editors/performance.html:6
 msgid "Performance"
 msgstr "Výkon"
 
-#: src/olympia/editors/templates/editors/base.html:75 src/olympia/editors/templates/editors/themes/base.html:19 src/olympia/editors/templates/editors/themes/base.html:38
+#: src/olympia/editors/templates/editors/base.html:77 src/olympia/editors/templates/editors/themes/base.html:19 src/olympia/editors/templates/editors/themes/base.html:38
 msgid "Logs"
 msgstr "Záznamy"
 
-#: src/olympia/editors/templates/editors/base.html:78 src/olympia/editors/templates/editors/reviewlog.html:4 src/olympia/editors/templates/editors/reviewlog.html:27
+#: src/olympia/editors/templates/editors/base.html:80 src/olympia/editors/templates/editors/reviewlog.html:4 src/olympia/editors/templates/editors/reviewlog.html:27
 msgid "Add-on Review Log"
 msgstr "Seznam kontrol doplňků"
 
-#: src/olympia/editors/templates/editors/base.html:80 src/olympia/editors/templates/editors/eventlog.html:4 src/olympia/editors/templates/editors/eventlog.html:8
+#: src/olympia/editors/templates/editors/base.html:82 src/olympia/editors/templates/editors/eventlog.html:4 src/olympia/editors/templates/editors/eventlog.html:8
 #: src/olympia/editors/templates/editors/eventlog_detail.html:4
 msgid "Moderated Review Log"
 msgstr "Seznam moderovaných recenzí"
 
-#: src/olympia/editors/templates/editors/base.html:82 src/olympia/editors/templates/editors/beta_signed_log.html:4 src/olympia/editors/templates/editors/beta_signed_log.html:8
+#: src/olympia/editors/templates/editors/base.html:84 src/olympia/editors/templates/editors/beta_signed_log.html:4 src/olympia/editors/templates/editors/beta_signed_log.html:8
 msgid "Signed Beta Files Log"
 msgstr "Žurnál podepsaných beta souborů"
 
-#: src/olympia/editors/templates/editors/base.html:87 src/olympia/editors/templates/editors/includes/daily-message.html:4
+#: src/olympia/editors/templates/editors/base.html:89 src/olympia/editors/templates/editors/includes/daily-message.html:4
 msgid "Announcement"
 msgstr "Oznámení"
 
@@ -8017,21 +7894,18 @@ msgid "Full Review ({num})"
 msgid_plural "Full Reviews ({num})"
 msgstr[0] "Plná kontrola ({num})"
 msgstr[1] "Plná kontrola ({num})"
-msgstr[2] "Plná kontrola ({num})"
 
 #: src/olympia/editors/templates/editors/home.html:18
 msgid "Pending Update ({num})"
 msgid_plural "Pending Updates ({num})"
 msgstr[0] "Čekající aktualizace ({num})"
 msgstr[1] "Čekající aktualizace ({num})"
-msgstr[2] "Čekající aktualizace ({num})"
 
 #: src/olympia/editors/templates/editors/home.html:25
 msgid "Preliminary Review ({num})"
 msgid_plural "Preliminary Reviews ({num})"
 msgstr[0] "Předběžná kontrola ({num})"
 msgstr[1] "Předběžná kontrola ({num})"
-msgstr[2] "Předběžná kontrola ({num})"
 
 #: src/olympia/editors/templates/editors/home.html:36 src/olympia/editors/templates/editors/home.html:86
 msgid "Current waiting times:"
@@ -8042,7 +7916,6 @@ msgid "{0} add-on"
 msgid_plural "{0} add-ons"
 msgstr[0] "{0} doplněk"
 msgstr[1] "{0} doplňky"
-msgstr[2] "{0} doplňků"
 
 #: src/olympia/editors/templates/editors/home.html:45 src/olympia/editors/templates/editors/home.html:95
 #, python-format
@@ -8054,21 +7927,18 @@ msgid "Unlisted Full Review ({num})"
 msgid_plural "Unlisted Full Reviews ({num})"
 msgstr[0] "Nezařazená plná kontrola ({num})"
 msgstr[1] "Nezařazené plné kontroly ({num})"
-msgstr[2] "Nezařazené plné kontroly ({num})"
 
 #: src/olympia/editors/templates/editors/home.html:68
 msgid "Unlisted Pending Update ({num})"
 msgid_plural "Unlisted Pending Updates ({num})"
 msgstr[0] "Čekající nezařezaná aktualizace ({num})"
 msgstr[1] "Čekající nezařezané aktualizace ({num})"
-msgstr[2] "Čekající nezařezané aktualizace ({num})"
 
 #: src/olympia/editors/templates/editors/home.html:75
 msgid "Unlisted Preliminary Review ({num})"
 msgid_plural "Unlisted Preliminary Reviews ({num})"
 msgstr[0] "Nezařazená předběžná kontrola ({num})"
 msgstr[1] "Nezařazené předběžné kontroly ({num})"
-msgstr[2] "Nezařazené předběžné kontroly ({num})"
 
 #: src/olympia/editors/templates/editors/home.html:109 src/olympia/editors/templates/editors/performance.html:37 src/olympia/editors/templates/editors/themes/home.html:54
 msgid "Total Reviews"
@@ -8092,7 +7962,6 @@ msgid "Moderated Review ({num})"
 msgid_plural "Moderated Reviews ({num})"
 msgstr[0] "Moderování recenzí ({num})"
 msgstr[1] "Moderování recenzí ({num})"
-msgstr[2] "Moderování recenzí ({num})"
 
 #: src/olympia/editors/templates/editors/leaderboard.html:3 src/olympia/editors/templates/editors/includes/reviewers_score_bar.html:56
 msgid "Reviewer Leaderboard"
@@ -8188,45 +8057,45 @@ msgstr "Rozšířené vyhledávání"
 msgid "clear search"
 msgstr "vymazat hledání"
 
-#: src/olympia/editors/templates/editors/queue.html:72 src/olympia/editors/templates/editors/queue.html:122
+#: src/olympia/editors/templates/editors/queue.html:78 src/olympia/editors/templates/editors/queue.html:128
 msgid "Process Reviews"
 msgstr "Provést kontrolu"
 
-#: src/olympia/editors/templates/editors/queue.html:80
+#: src/olympia/editors/templates/editors/queue.html:86
 msgid "Moderation actions:"
 msgstr "Akce moderátora:"
 
-#: src/olympia/editors/templates/editors/queue.html:90
+#: src/olympia/editors/templates/editors/queue.html:96
 #, python-format
 msgid "by %(user)s on %(date)s %(stars)s (%(locale)s)"
 msgstr "od %(user)s dne %(date)s %(stars)s (%(locale)s)"
 
-#: src/olympia/editors/templates/editors/queue.html:106
+#: src/olympia/editors/templates/editors/queue.html:112
 #, python-format
 msgid "<strong>%(reason)s</strong> <span class=\"light\">Flagged by %(user)s on %(date)s</span>"
 msgstr "<strong>%(reason)s</strong> <span class=\"light\">Označil uživatel %(user)s dne %(date)s</span>"
 
-#: src/olympia/editors/templates/editors/queue.html:119
-msgid "All reviews have been moderated.  Good work!"
+#: src/olympia/editors/templates/editors/queue.html:125
+msgid "All reviews have been moderated. Good work!"
 msgstr "Všechny recenze byly zkontrolovány. Skvělá práce!"
 
-#: src/olympia/editors/templates/editors/queue.html:161
+#: src/olympia/editors/templates/editors/queue.html:167
 msgid "Version Notes / Notes for Reviewer"
 msgstr "Poznámky k verzi / Poznámky pro redaktora"
 
-#: src/olympia/editors/templates/editors/queue.html:169
+#: src/olympia/editors/templates/editors/queue.html:175
 msgid "There are currently no add-ons of this type to review."
 msgstr "Aktuálně zde nejsou na kontrolu žádné doplňky tohoto typu."
 
-#: src/olympia/editors/templates/editors/queue.html:181 src/olympia/editors/templates/editors/themes/queue_list.html:85
+#: src/olympia/editors/templates/editors/queue.html:187 src/olympia/editors/templates/editors/themes/queue_list.html:85
 msgid "Helpful Links:"
 msgstr "Užitečné odkazy:"
 
-#: src/olympia/editors/templates/editors/queue.html:182
+#: src/olympia/editors/templates/editors/queue.html:188
 msgid "Add-on Policy"
 msgstr "Zásady pro doplňky"
 
-#: src/olympia/editors/templates/editors/queue.html:184
+#: src/olympia/editors/templates/editors/queue.html:190
 msgid "Editors' Guide"
 msgstr "Průvodce redaktora"
 
@@ -8432,21 +8301,18 @@ msgid "{num} Pending Theme Review"
 msgid_plural "{num} Pending Theme Reviews"
 msgstr[0] "{num} čekajících kontrol na motivy"
 msgstr[1] "{num} čekající kontroly na motivy"
-msgstr[2] "{num} čekajících kontrol na motivy"
 
 #: src/olympia/editors/templates/editors/themes/home.html:27
 msgid "{num} Flagged Review"
 msgid_plural "{num} Flagged Reviews"
 msgstr[0] "{num} označená recenze"
 msgstr[1] "{num} označené recenze"
-msgstr[2] "{num} označených recenzí"
 
 #: src/olympia/editors/templates/editors/themes/home.html:34
 msgid "{num} Update"
 msgid_plural "{num} Updates"
 msgstr[0] "{num} aktualizace"
 msgstr[1] "{num} aktualizace"
-msgstr[2] "{num} aktualizací"
 
 #: src/olympia/editors/templates/editors/themes/logs.html:4
 msgid "Theme Review Log"
@@ -8565,7 +8431,7 @@ msgstr "Položit otázku umělci"
 msgid "Describe your reason for flagging"
 msgstr "Popište váš důvod pro označení"
 
-#: src/olympia/files/forms.py:88
+#: src/olympia/files/forms.py:90
 msgid "Cannot diff a version against itself"
 msgstr "Nelze porovnat verzi proti sama sobě"
 
@@ -8600,51 +8466,51 @@ msgstr "Při přístupu k souboru %s došlo k chybě. %s."
 msgid "There was an error accessing file %s."
 msgstr "Při přístupu k souboru %s došlo k chybě."
 
-#: src/olympia/files/utils.py:343
+#: src/olympia/files/utils.py:340
 msgid "Could not parse uploaded file."
 msgstr "Nepodařilo se zpracovat nahrávaný soubor."
 
-#: src/olympia/files/utils.py:380
+#: src/olympia/files/utils.py:377
 msgid "Invalid file name in archive: {0}"
 msgstr "Neplatné jméno souboru v archivu: {0}"
 
-#: src/olympia/files/utils.py:388
+#: src/olympia/files/utils.py:385
 msgid "File exceeding size limit in archive: {0}"
 msgstr "Překročena velikost souboru v archivu: {0}"
 
-#: src/olympia/files/utils.py:439
+#: src/olympia/files/utils.py:436
 msgid "Invalid archive."
 msgstr "Neplatný archiv."
 
-#: src/olympia/files/utils.py:529 src/olympia/files/utils.py:532
+#: src/olympia/files/utils.py:526 src/olympia/files/utils.py:529
 msgid "Could not parse the manifest file."
 msgstr "Nepodařilo se zpracovat manifest soubor."
 
-#: src/olympia/files/utils.py:551
+#: src/olympia/files/utils.py:548
 msgid "Could not find an add-on ID."
 msgstr "ID doplňku nelze nalézt."
 
-#: src/olympia/files/utils.py:554
+#: src/olympia/files/utils.py:551
 msgid "Add-on ID must be 64 characters or less."
 msgstr "ID doplňku může být maximálně 64 znaků dlouhé."
 
-#: src/olympia/files/utils.py:556
+#: src/olympia/files/utils.py:553
 msgid "Add-on ID doesn't match add-on."
 msgstr "ID doplňku neodpovídá doplňku."
 
-#: src/olympia/files/utils.py:564
+#: src/olympia/files/utils.py:561
 msgid "Duplicate add-on ID found."
 msgstr "Nalezeno duplicitní ID doplňku."
 
-#: src/olympia/files/utils.py:567
+#: src/olympia/files/utils.py:564
 msgid "Version numbers should have fewer than 32 characters."
 msgstr "Čísla verzí by měly mít méně než 32 znaků."
 
-#: src/olympia/files/utils.py:570
+#: src/olympia/files/utils.py:567
 msgid "Version numbers should only contain letters, numbers, and these punctuation characters: +*.-_."
 msgstr "Čísla verzí by měla obsahovat pouze základní znaky, čísla a následující speciální znaky: +*.-_."
 
-#: src/olympia/files/utils.py:587
+#: src/olympia/files/utils.py:584
 msgid "<em:type> doesn't match add-on"
 msgstr "<em:type> neodpovídá doplňku"
 
@@ -8744,6 +8610,10 @@ msgstr "V nahraném souboru se nenachází žádné soubory."
 #: src/olympia/files/templates/files/viewer.html:134
 msgid "Fetching file."
 msgstr "Probíhá stahování souboru."
+
+#: src/olympia/legacy_api/views.py:255
+msgid "Not implemented yet."
+msgstr "Dosud není implementováno."
 
 #: src/olympia/lib/constants.py:6
 msgid "United Arab Emirates Dirham"
@@ -9400,10 +9270,6 @@ msgstr "Zambijská kwacha"
 #: src/olympia/lib/constants.py:169
 msgid "Zimbabwe Dollar"
 msgstr "Zimbabwský dolar"
-
-#: src/olympia/lib/video/ffmpeg.py:112 src/olympia/lib/video/totem.py:81
-msgid "Videos must be in WebM."
-msgstr "Videa musí být ve formátu WebM."
 
 #: src/olympia/pages/templates/pages/about.lhtml:3 src/olympia/pages/templates/pages/about.lhtml:10
 msgid "About Mozilla Add-ons"
@@ -10426,12 +10292,10 @@ msgid "Add-on Gallery"
 msgstr "Galerie doplňků"
 
 #: src/olympia/pages/templates/pages/faq.html:171
-msgid ""
-"How do I choose between add-ons that seem to do the same\n"
-"    thing?"
+msgid "How do I choose between add-ons that seem to do the same thing?"
 msgstr "Jak si mám vybrat mezi doplňky, které dělají tu samou věc?"
 
-#: src/olympia/pages/templates/pages/faq.html:173
+#: src/olympia/pages/templates/pages/faq.html:172
 msgid ""
 "There are often several add-ons that have similar features. To figure out which is right for you, read the entire description of the add-on and view its screenshots. If there are still several in "
 "the running, read through the add-on's ratings, user reviews, and statistics to see which is most liked by other users. Remember that you can also just try out both and see which you like better."
@@ -10484,16 +10348,14 @@ msgid "How much do add-ons cost to purchase?"
 msgstr "Kolik doplňky stojí?"
 
 #: src/olympia/pages/templates/pages/faq.html:207
-msgid ""
-"Add-ons hosted in our gallery are free unless clearly marked\n"
-"    otherwise."
+msgid "Add-ons hosted in our gallery are free unless clearly marked otherwise."
 msgstr "Pokud není jasně řečeno jinak, jsou hostované doplňky dostupné zdarma."
 
-#: src/olympia/pages/templates/pages/faq.html:210
+#: src/olympia/pages/templates/pages/faq.html:209
 msgid "What does it mean when an add-on asks for contributions?"
 msgstr "Co znamená, když autor doplňku žádá o příspěvek?"
 
-#: src/olympia/pages/templates/pages/faq.html:211
+#: src/olympia/pages/templates/pages/faq.html:210
 msgid ""
 "Some add-on authors request users who enjoy an add-on to contribute to its development by making a monetary contribution. These contributions go directly to the developer unless a third party is "
 "indicated, such as the non-profit Mozilla Foundation."
@@ -10501,11 +10363,11 @@ msgstr ""
 "Někteří autoři doplňků mohou žádat uživatele, kteří mají doplněk rádi, o finanční příspěvky na další vývoj. Tyto příspěvky jdou přímo vývojáři, pokud není uvedena třetí strana, například nezisková "
 "nadace Mozilla Foundation."
 
-#: src/olympia/pages/templates/pages/faq.html:216
+#: src/olympia/pages/templates/pages/faq.html:215
 msgid "What are beta add-ons?"
 msgstr "Co jsou betaverze doplňků?"
 
-#: src/olympia/pages/templates/pages/faq.html:218
+#: src/olympia/pages/templates/pages/faq.html:217
 msgid ""
 "Beta add-ons are unreviewed versions which represent the latest work of an add-on author. While different authors have different standards for beta code quality, you should assume that these add-"
 "ons are less stable than the general add-on releases."
@@ -10513,7 +10375,7 @@ msgstr ""
 "Betaverze doplňků jsou nekontrolované verze, které obsahují poslední novinky, které autor doplňku připravil. Každý autor pohlíží na kvalitu betaverzí rozdílně, ale obecně byste měli předpokládat, "
 "že tyto doplňky mají horší stabilitu než ty, které jsou standardně vydávány."
 
-#: src/olympia/pages/templates/pages/faq.html:222
+#: src/olympia/pages/templates/pages/faq.html:221
 msgid ""
 "Please note that when you install an add-on from the \"Beta Version\" section of an add-on's listing, you will continue to receive updates for that add-on as they become available. Like the initial"
 " version you installed, all beta releases are unreviewed by Mozilla and may harm your computer."
@@ -10521,21 +10383,19 @@ msgstr ""
 "Mějte prosím na paměti, že když si nainstalujete doplněk ze sekce \"betaverze\" na stránce doplňku, budete i nadále dostávat aktualizace doplňku, jakmile budou dostupné. Obdobně jako v případě "
 "instalované verze nebudou všechny instalované berze kontrolovány Mozillou a mohou tak poškodit váš počítač."
 
-#: src/olympia/pages/templates/pages/faq.html:229
-msgid ""
-"What does it mean when an add-on is flagged as\n"
-"    slow?"
+#: src/olympia/pages/templates/pages/faq.html:228
+msgid "What does it mean when an add-on is flagged as slow?"
 msgstr "Co znamená, když je doplněk označen jako pomalý?"
 
-#: src/olympia/pages/templates/pages/faq.html:231
+#: src/olympia/pages/templates/pages/faq.html:229
 msgid "Most add-ons load code and resources at the same time Firefox is starting up. In most cases the impact in start-up time is minimal, but some add-ons can cause a noticeable slowdown."
 msgstr "Většina doplňků načítá svůj kód a zdroje při načítání Firefoxu. Ve většině případů je dopad na rychlost spouštění minimální, ale některé doplňky mohou způsobit znatelné zpomalení."
 
-#: src/olympia/pages/templates/pages/faq.html:236
+#: src/olympia/pages/templates/pages/faq.html:234
 msgid "How do I report an inappropriate or spam user review?"
 msgstr "Jak mohu nahlásit nevhodnou recenzi uživatele či nevyžádaný příspěvek?"
 
-#: src/olympia/pages/templates/pages/faq.html:237
+#: src/olympia/pages/templates/pages/faq.html:235
 msgid ""
 "To report a user review of an add-on, log in with your account and visit the add-on's reviews page. Find the review you wish to report, click \"Report this review\" and select a reason. Our "
 "editorial team will investigate the review and take appropriate action."
@@ -10543,20 +10403,20 @@ msgstr ""
 "Pro nahlášení uživatelské recenze doplňku se přihlaste ke svému účtu a navštivte stránku s recenzemi doplňku. Nalezněte recenzi, kterou si přejete nahlásit, klepněte na odkaz \"Nahlásit recenzi\" a"
 " zvolte důvod. Náš tým redaktorů se poté bude touto recenzí zabývat a provede odpovídající reakci."
 
-#: src/olympia/pages/templates/pages/faq.html:242
+#: src/olympia/pages/templates/pages/faq.html:240
 msgid "How do I report a bug or contact the Mozilla Add-ons team?"
 msgstr "Jak mohu nahlásit chybu či kontaktovat tým serveru Doplňky Mozilly?"
 
-#: src/olympia/pages/templates/pages/faq.html:243
+#: src/olympia/pages/templates/pages/faq.html:241
 #, python-format
 msgid "Please visit our <a href=\"%(contact_url)s\">Contact page</a>."
 msgstr "Navštivte prosím naši <a href=\"%(contact_url)s\">kontaktní stránku</a>."
 
-#: src/olympia/pages/templates/pages/faq.html:246
+#: src/olympia/pages/templates/pages/faq.html:244
 msgid "What is a Source Code License?"
 msgstr "Pod jakou licencí je zdrojový kód dostupný?"
 
-#: src/olympia/pages/templates/pages/faq.html:247
+#: src/olympia/pages/templates/pages/faq.html:245
 #, python-format
 msgid ""
 "The source code used to create an add-on is an exclusive copyright of the add-on author, unless otherwise declared in a source code license. Many add-ons on this site have <a href=\"%(url)s\" "
@@ -10567,40 +10427,40 @@ msgstr ""
 "lang=\"en\">open source licencí</a>, která dává zdrojový kód veřejně k dispozici pro kopírování a opětovné použití pod podmínkami řečenými autorem. Většina autorů nevytváří vlastní licence, ale "
 "volí široce rozšířené open source licence jako je GPL či BSD."
 
-#: src/olympia/pages/templates/pages/faq.html:256
+#: src/olympia/pages/templates/pages/faq.html:254
 #, python-format
 msgid "Firefox and other Mozilla software are <a href=\"%(url)s\">open source</a>."
 msgstr "Firefox a ostatní aplikace Mozilla jsou <a href=\"%(url)s\">open source</a>."
 
-#: src/olympia/pages/templates/pages/faq.html:264
+#: src/olympia/pages/templates/pages/faq.html:262
 msgid "Collections and Favorites"
 msgstr "Sbírky a oblíbené"
 
-#: src/olympia/pages/templates/pages/faq.html:267
+#: src/olympia/pages/templates/pages/faq.html:265
 msgid "What is a collection?"
 msgstr "Co je sbírka?"
 
-#: src/olympia/pages/templates/pages/faq.html:268
+#: src/olympia/pages/templates/pages/faq.html:266
 msgid "Collections are groups of related add-ons created by users to share."
 msgstr "Sbírky jsou sdílené skupiny podobných doplňků, které byly vytvořeny uživately."
 
-#: src/olympia/pages/templates/pages/faq.html:270
+#: src/olympia/pages/templates/pages/faq.html:268
 msgid "What is the My Favorites collection?"
 msgstr "Co je má oblíbená sbírka?"
 
-#: src/olympia/pages/templates/pages/faq.html:271
+#: src/olympia/pages/templates/pages/faq.html:269
 msgid "Favorite add-ons are add-ons that you have bookmarked to easily get back to later. You can add an add-on to your favorites collection by clicking \"Add to favorites\" on its details page."
 msgstr "Oblíbené doplňky jsou doplňky, které jste si přidali do záložek pro pozdější snadné nalezení. Doplněk můžete přidat do své oblíbené sbírky klepnutím na \"Přidat do oblíbených\" na stránce doplňku."
 
-#: src/olympia/pages/templates/pages/faq.html:275 src/olympia/templates/menu_links.html:13 src/olympia/templates/impala/header_title.html:17
+#: src/olympia/pages/templates/pages/faq.html:273 src/olympia/templates/menu_links.html:13 src/olympia/templates/impala/header_title.html:17
 msgid "Mobile Add-ons"
 msgstr "Doplňky pro mobily"
 
-#: src/olympia/pages/templates/pages/faq.html:278
+#: src/olympia/pages/templates/pages/faq.html:276
 msgid "What are mobile add-ons?"
 msgstr "Co jsou mobilní doplňky?"
 
-#: src/olympia/pages/templates/pages/faq.html:279
+#: src/olympia/pages/templates/pages/faq.html:277
 #, python-format
 msgid ""
 "Mobile add-ons work with <a href=\"%(mobile_url)s\">Firefox for Mobile</a> and add or modify functionality just like desktop add-ons. You can find add-ons that work with Firefox for Mobile in our "
@@ -10609,20 +10469,20 @@ msgstr ""
 "Mobilní doplňky fungují ve <a href=\"%(mobile_url)s\">Firefoxu pro mobilní zařízení</a> a přidávají či upravují funkcionalitu stejným způsobem, jako doplňky pro desktopovou verzi. Doplňky, které "
 "fungují ve Firefoxu pro mobilní zařízení, můžete nalézt v <a href=\"%(gallery_url)s\">naší galerii</a>."
 
-#: src/olympia/pages/templates/pages/faq.html:288
+#: src/olympia/pages/templates/pages/faq.html:286
 msgid "Developer Topics"
 msgstr "Témata pro vývojáře"
 
-#: src/olympia/pages/templates/pages/faq.html:289
+#: src/olympia/pages/templates/pages/faq.html:287
 #, python-format
 msgid "Please see our <a href=\"%(faq_url)s\">Developer FAQ</a> and <a href=\"%(hub_url)s\">Developer Hub</a> for answers to add-on developer-related questions."
 msgstr "Pro otázky týkající se vývoje doplňků navšivte <a href=\"%(faq_url)s\">často kladené otázky pro vývojáře</a> a <a href=\"%(hub_url)s\">Centrum pro vývojáře</a>."
 
-#: src/olympia/pages/templates/pages/faq.html:294
+#: src/olympia/pages/templates/pages/faq.html:292
 msgid "Still have questions?"
 msgstr "Stále máte otázky?"
 
-#: src/olympia/pages/templates/pages/faq.html:295
+#: src/olympia/pages/templates/pages/faq.html:293
 #, python-format
 msgid "For general Firefox support, visit our <a href=\"%(sumo_url)s\">support website</a>. For general add-on and website questions, visit our <a href=\"%(forum_url)s\">forum</a>."
 msgstr "Pro obecnou podporu Firefoxu navšivte naše <a href=\"%(sumo_url)s\">stránky podpory</a>. Pro obecné otázky týkající se doplňků a tohoto webu navšivte <a href=\"%(forum_url)s\">naše fórum</a>."
@@ -10901,7 +10761,6 @@ msgid "This user has a <a href=\"%(user_review_url)s\">previous review</a> of th
 msgid_plural "This user has <a href=\"%(user_review_url)s\">%(cnt)s previous reviews</a> of this add-on."
 msgstr[0] "Tento uživatel má <a href=\"%(user_review_url)s\">jednu dřívější recenzi</a> tohoto doplňku."
 msgstr[1] "Tento uživatel má <a href=\"%(user_review_url)s\">%(cnt)s předchozí recenze</a> tohoto doplňku."
-msgstr[2] "Tento uživatel má <a href=\"%(user_review_url)s\">%(cnt)s předchozích recenzí</a> tohoto doplňku."
 
 #: src/olympia/reviews/templates/reviews/review.html:62
 #, python-format
@@ -10948,7 +10807,6 @@ msgid "<b>{0}</b> review for this add-on"
 msgid_plural "<b>{0}</b> reviews for this add-on"
 msgstr[0] "<b>{0}</b> recenze tohoto doplňku"
 msgstr[1] "<b>{0}</b> recenze tohoto doplňku"
-msgstr[2] "<b>{0}</b> recenzí tohoto doplňku"
 
 #. {0} is a developer's name.
 #: src/olympia/reviews/templates/reviews/review_list.html:33
@@ -10961,7 +10819,6 @@ msgid "Review for %(addon)s by %(user)s"
 msgid_plural "Reviews for %(addon)s by %(user)s"
 msgstr[0] "Recenze %(addon)s od uživatele %(user)s"
 msgstr[1] "Recenze %(addon)s od uživatele %(user)s"
-msgstr[2] "Recenze %(addon)s od uživatele %(user)s"
 
 #: src/olympia/reviews/templates/reviews/review_list.html:42
 msgid "No reviews found."
@@ -10985,7 +10842,6 @@ msgid "{num} review"
 msgid_plural "{num} reviews"
 msgstr[0] "{num} recenze"
 msgstr[1] "{num} recenze"
-msgstr[2] "{num} recenzí"
 
 #: src/olympia/reviews/templates/reviews/impala/reviews_rating.html:1
 msgid "Rated {0} out of 5 stars"
@@ -11013,7 +10869,6 @@ msgid "Average from {0} Rating"
 msgid_plural "Average from {0} Ratings"
 msgstr[0] "Průměr z {0} hodnocení"
 msgstr[1] "Průměr z {0} hodnocení"
-msgstr[2] "Průměr z {0} hodnocení"
 
 #: src/olympia/reviews/templates/reviews/mobile/review_list.html:34
 #, python-format
@@ -11030,7 +10885,6 @@ msgid "See All Reviews"
 msgid_plural "See All %(cnt)s Reviews"
 msgstr[0] "Zobrazit všechny recenze"
 msgstr[1] "Zobrazit %(cnt)s recenze"
-msgstr[2] "Zobrazit %(cnt)s recenzí"
 
 #: src/olympia/search/forms.py:11
 msgid "Most popular this week"
@@ -11111,16 +10965,16 @@ msgstr "Doplňky pro {0}"
 
 #. L10n: {0} is an application, such as Firefox. This means "any version of
 #. Firefox."
-#: src/olympia/search/views.py:554
+#: src/olympia/search/views.py:547
 msgid "Any {0}"
 msgstr "Libovolný {0}"
 
 #. L10n: "All Systems" means show everything regardless of platform.
-#: src/olympia/search/views.py:589
+#: src/olympia/search/views.py:582
 msgid "All Systems"
 msgstr "Všechny systémy"
 
-#: src/olympia/search/views.py:600
+#: src/olympia/search/views.py:593
 msgid "All Tags"
 msgstr "Všechny štítky"
 
@@ -11165,7 +11019,6 @@ msgid "<b>{0}</b> matching result"
 msgid_plural "<b>{0}</b> matching results"
 msgstr[0] "<b>{0}</b> výsledek hledání"
 msgstr[1] "<b>{0}</b> výsledky hledání"
-msgstr[2] "<b>{0}</b> výsledků hledání"
 
 #: src/olympia/search/templates/search/results.html:67
 msgid "Filter Results"
@@ -11188,7 +11041,6 @@ msgid "{0} post"
 msgid_plural "{0} posts"
 msgstr[0] "{0} příspěvek"
 msgstr[1] "{0} příspěvky"
-msgstr[2] "{0} příspěvků"
 
 #: src/olympia/sharing/__init__.py:20
 msgid "Post to Facebook"
@@ -11199,7 +11051,6 @@ msgid "{0} Like"
 msgid_plural "{0} Likes"
 msgstr[0] "{0} like"
 msgstr[1] "{0} liky"
-msgstr[2] "{0} liků"
 
 #: src/olympia/sharing/__init__.py:30
 msgid "Tweet on Twitter"
@@ -11210,7 +11061,6 @@ msgid "{0} tweet"
 msgid_plural "{0} tweets"
 msgstr[0] "{0} tweet"
 msgstr[1] "{0} tweety"
-msgstr[2] "{0} tweetů"
 
 #: src/olympia/sharing/__init__.py:40
 msgid "Share on g+"
@@ -11245,7 +11095,6 @@ msgid "{0} post on localservice1"
 msgid_plural "{0} posts on localservice1"
 msgstr[0] "{0} post on localservice1"
 msgstr[1] "{0} posts on localservice1"
-msgstr[2] "{0} posts on localservice1"
 
 #. L10n: Only change if you have reason! wiki.mozilla.org/AMO:Localizers
 #: src/olympia/sharing/__init__.py:76
@@ -11268,7 +11117,6 @@ msgid "{0} post on localservice2"
 msgid_plural "{0} posts on localservice2"
 msgstr[0] "{0} post on localservice2"
 msgstr[1] "{0} posts on localservice2"
-msgstr[2] "{0} posts on localservice2"
 
 #. L10n: Only change if you have reason! wiki.mozilla.org/AMO:Localizers
 #: src/olympia/sharing/__init__.py:91
@@ -11291,7 +11139,6 @@ msgid "{0} post on localservice3"
 msgid_plural "{0} posts on localservice3"
 msgstr[0] "{0} post on localservice3"
 msgstr[1] "{0} posts on localservice3"
-msgstr[2] "{0} posts on localservice3"
 
 #: src/olympia/sharing/templates/sharing/sharing_widget.html:2
 msgid "Share this Add-on"
@@ -11301,31 +11148,31 @@ msgstr "Sdílet doplněk"
 msgid "Share this Collection"
 msgstr "Sdílet sbírku"
 
-#: src/olympia/signing/views.py:30 src/olympia/templates/base.html:75 src/olympia/templates/impala/base.html:115
+#: src/olympia/signing/views.py:33 src/olympia/templates/base.html:71 src/olympia/templates/impala/base.html:112
 msgid "Some features are temporarily disabled while we perform website maintenance. We'll be back to full capacity shortly."
 msgstr "Některá funkčnost je v průběhu údržby webu dočasně nedostupná. Brzy opět poběžíme naplno."
 
-#: src/olympia/signing/views.py:53
+#: src/olympia/signing/views.py:56
 msgid "Could not find add-on with id \"{}\"."
 msgstr "Doplněk s id \"{}\" nebyl nalezen."
 
-#: src/olympia/signing/views.py:67
+#: src/olympia/signing/views.py:70
 msgid "You do not own this addon."
 msgstr "Tento doplněk nevlastníte."
 
-#: src/olympia/signing/views.py:82
+#: src/olympia/signing/views.py:87
 msgid "Missing \"upload\" key in multipart file data."
 msgstr "Chybí klíč \"upload\" v multipart části dat."
 
-#: src/olympia/signing/views.py:96
+#: src/olympia/signing/views.py:101
 msgid "Version does not match the manifest file."
 msgstr "Verze neodpovídá manifest souboru."
 
-#: src/olympia/signing/views.py:100
+#: src/olympia/signing/views.py:105
 msgid "Version already exists."
 msgstr "Tato verze již existuje."
 
-#: src/olympia/signing/views.py:136
+#: src/olympia/signing/views.py:141
 msgid "No uploaded file for that addon and version."
 msgstr "Pro tuto verzi doplňku nebyl nahrán žádný soubor."
 
@@ -11438,89 +11285,89 @@ msgstr "{0} :: Nástěnka statistik"
 msgid "Statistics Dashboard :: Add-ons for {0}"
 msgstr "Nástěnka statistik :: Doplňky pro {0}"
 
-#: src/olympia/stats/templates/stats/stats.html:30
-msgid "Controls:"
-msgstr "Ovládání:"
-
-#: src/olympia/stats/templates/stats/stats.html:33
-msgid "reset zoom"
-msgstr "obnovit velikost"
-
-#: src/olympia/stats/templates/stats/stats.html:40
-msgid "Group by:"
-msgstr "Seskupit dle:"
-
-#: src/olympia/stats/templates/stats/stats.html:42
-msgid "day"
-msgstr "den"
-
-#: src/olympia/stats/templates/stats/stats.html:45
-msgid "week"
-msgstr "týden"
-
-#: src/olympia/stats/templates/stats/stats.html:48
-msgid "month"
-msgstr "měsíc"
-
-#: src/olympia/stats/templates/stats/stats.html:54
-msgid "For last:"
-msgstr "Pro posledních:"
-
-#: src/olympia/stats/templates/stats/stats.html:57
-msgid "7 days"
-msgstr "7 dní"
-
-#: src/olympia/stats/templates/stats/stats.html:60
-msgid "30 days"
-msgstr "30 dní"
-
-#: src/olympia/stats/templates/stats/stats.html:63
-msgid "90 days"
-msgstr "90 dní"
-
-#: src/olympia/stats/templates/stats/stats.html:66
-msgid "365 days"
-msgstr "365 dní"
-
-#: src/olympia/stats/templates/stats/stats.html:69
-msgid "Custom..."
-msgstr "Vlastní..."
-
 #. {0} is an add-on name
-#: src/olympia/stats/templates/stats/stats.html:88 src/olympia/stats/templates/stats/stats.html:91
+#: src/olympia/stats/templates/stats/stats.html:44 src/olympia/stats/templates/stats/stats.html:47
 msgid "Statistics for {0}"
 msgstr "Statistiky doplňku {0}"
 
-#: src/olympia/stats/templates/stats/stats.html:94
+#: src/olympia/stats/templates/stats/stats.html:50
 msgid "Statistics Dashboard"
 msgstr "Nástěnka statistik"
 
-#: src/olympia/stats/templates/stats/stats.html:104
+#: src/olympia/stats/templates/stats/stats.html:57
+msgid "Controls:"
+msgstr "Ovládání:"
+
+#: src/olympia/stats/templates/stats/stats.html:60
+msgid "reset zoom"
+msgstr "obnovit velikost"
+
+#: src/olympia/stats/templates/stats/stats.html:67
+msgid "Group by:"
+msgstr "Seskupit dle:"
+
+#: src/olympia/stats/templates/stats/stats.html:69
+msgid "day"
+msgstr "den"
+
+#: src/olympia/stats/templates/stats/stats.html:72
+msgid "week"
+msgstr "týden"
+
+#: src/olympia/stats/templates/stats/stats.html:75
+msgid "month"
+msgstr "měsíc"
+
+#: src/olympia/stats/templates/stats/stats.html:81
+msgid "For last:"
+msgstr "Pro posledních:"
+
+#: src/olympia/stats/templates/stats/stats.html:84
+msgid "7 days"
+msgstr "7 dní"
+
+#: src/olympia/stats/templates/stats/stats.html:87
+msgid "30 days"
+msgstr "30 dní"
+
+#: src/olympia/stats/templates/stats/stats.html:90
+msgid "90 days"
+msgstr "90 dní"
+
+#: src/olympia/stats/templates/stats/stats.html:93
+msgid "365 days"
+msgstr "365 dní"
+
+#: src/olympia/stats/templates/stats/stats.html:96
+msgid "Custom..."
+msgstr "Vlastní..."
+
+#: src/olympia/stats/templates/stats/stats.html:106
 msgid "Statistics processing is currently disabled, so recent data is unavailable. The statistics are still being collected and this page will be updated soon with the missing data."
 msgstr "Zpracování statistik je momentálně zakázáno a aktuální data nejsou dostupná. Statistiky jsou ale nadále sbírány a tato stránka bude brzy o chybějící data doplněna."
 
-#: src/olympia/stats/templates/stats/stats.html:110
+#: src/olympia/stats/templates/stats/stats.html:112
 msgid "Loading the latest data&hellip;"
 msgstr "Načítají se poslední data&hellip;"
 
-#: src/olympia/stats/templates/stats/stats.html:142 src/olympia/stats/templates/stats/reports/overview.html:25 src/olympia/stats/templates/stats/reports/overview.html:37
+#: src/olympia/stats/templates/stats/stats.html:144 src/olympia/stats/templates/stats/reports/overview.html:25 src/olympia/stats/templates/stats/reports/overview.html:37
 #: src/olympia/stats/templates/stats/reports/overview.html:49
 msgid "No data available."
 msgstr "Nejsou dostupná žádná data."
 
-#: src/olympia/stats/templates/stats/stats.html:177
+#: src/olympia/stats/templates/stats/stats.html:179
 msgid "This dashboard is currently <b>public</b>."
 msgstr "Nástěnka je aktuálně <b>veřejná</b>."
 
-#: src/olympia/stats/templates/stats/stats.html:179
+#: src/olympia/stats/templates/stats/stats.html:181
 msgid "Contribution stats are currently <b>private</b>."
 msgstr "Statistiky příspívání jsou aktuálně <b>soukromé</b>."
 
-#: src/olympia/stats/templates/stats/stats.html:182
+#: src/olympia/stats/templates/stats/stats.html:184
 msgid "This dashboard is currently <b>private</b>."
 msgstr "Tato nástěnka je aktuálně <b>soukromá</b>."
 
-#: src/olympia/stats/templates/stats/stats.html:185
+#: src/olympia/stats/templates/stats/stats.html:187
 msgid "Change settings."
 msgstr "Změnit nastavení."
 
@@ -11683,15 +11530,6 @@ msgstr "Přihlášení uživatelé dle data"
 msgid "Application versions by Date"
 msgstr "Verze aplikace dle data"
 
-#: src/olympia/tags/templates/tags/top_cloud.html:4
-msgid "Top {0} Tags"
-msgstr "Top {0} štítků"
-
-#. {0} is the current application name
-#: src/olympia/tags/templates/tags/top_cloud.html:14
-msgid "{0} Top Tags"
-msgstr "Nejpopulárnější štítky pro {0}"
-
 #: src/olympia/templates/amo_footer.html:6 src/olympia/templates/includes/lang_switcher.html:2
 msgid "Other languages"
 msgstr "Ostatní jazyky"
@@ -11700,11 +11538,11 @@ msgstr "Ostatní jazyky"
 msgid "Mozilla Add-ons"
 msgstr "Doplňky Mozilly"
 
-#: src/olympia/templates/base.html:91 src/olympia/templates/impala/base.html:81
+#: src/olympia/templates/base.html:89 src/olympia/templates/impala/base.html:78
 msgid "Find add-ons for other applications"
 msgstr "Zobrazí doplňky pro ostatní aplikace"
 
-#: src/olympia/templates/base.html:92 src/olympia/templates/impala/base.html:81
+#: src/olympia/templates/base.html:90 src/olympia/templates/impala/base.html:78
 msgid "Other Applications"
 msgstr "Ostatní aplikace"
 
@@ -11729,7 +11567,7 @@ msgid "View Mobile Site"
 msgstr "Zobrazit mobilní verzi"
 
 #: src/olympia/templates/copyright.html:7
-msgid "Site Status "
+msgid "Site Status"
 msgstr "Stav stránky "
 
 #: src/olympia/templates/footer.html:3
@@ -11831,35 +11669,35 @@ msgstr "Vítejte uživateli {0}"
 msgid "<a href=\"%(reg)s\">Register</a> or <a href=\"%(login)s\">Log in</a>"
 msgstr "<a href=\"%(reg)s\">Registrace</a> nebo <a href=\"%(login)s\">přihlášení</a>"
 
-#: src/olympia/templates/impala/base.html:126
+#: src/olympia/templates/impala/base.html:123
 #, python-format
 msgid "To try the thousands of add-ons available here, download <a href=\"%(url)s\">Mozilla Firefox</a>, a fast, free way to surf the Web!"
 msgstr "Vyzkoušejte si tisíce doplňků, které jsou zde dostupné. Stáhněte si <a href=\"%(url)s\">Mozilla Firefox</a>, rychlý a zdarma dostupný způsob, jak prohlížet web!"
 
-#: src/olympia/templates/impala/base.html:138
+#: src/olympia/templates/impala/base.html:135
 #, python-format
 msgid "Add-ons is switching to Firefox Accounts for login. <a href=\"%(url)s\" class=\"fxa-login\">Sign in now to transfer your account.</a>"
 msgstr "Doplňky budou již brzy používat pro přihlašování Firefox Accounts. <a href=\"%(url)s\" class=\"fxa-login\">Přihlaste se pro převod svého účtu</a>"
 
 #. {0} is an application, such as Firefox.
-#: src/olympia/templates/impala/base.html:148
+#: src/olympia/templates/impala/base.html:145
 msgid "Welcome to {0} Add-ons."
 msgstr "Vítejte na serveru Doplňky pro {0}."
 
-#: src/olympia/templates/impala/base.html:151
+#: src/olympia/templates/impala/base.html:148
 msgid "Choose from thousands of extra features and styles to make Firefox your own."
 msgstr "Zvolte si z tisíců balíčků funkcí a stylů, které vám přizpůsobí Firefox dle vašich potřeb."
 
-#: src/olympia/templates/impala/base.html:156
+#: src/olympia/templates/impala/base.html:153
 #, python-format
 msgid "Add extra features and styles to make %(app)s your own."
 msgstr "Přidejte si funkce a styly, které učiní %(app)s podle vašich představ."
 
-#: src/olympia/templates/impala/base.html:164
+#: src/olympia/templates/impala/base.html:161
 msgid "On the go?"
 msgstr "Na cestách?"
 
-#: src/olympia/templates/impala/base.html:166
+#: src/olympia/templates/impala/base.html:163
 msgid "Check out our <a class=\"mobile-link\" href=\"#\">Mobile Add-ons site</a>."
 msgstr "Vyzkoušejte si naši <a class=\"mobile-link\" href=\"#\">mobilní verzi webu</a>."
 
@@ -12083,19 +11921,19 @@ msgstr "Nebyl nalezen uživatel, který by měl tento e-mail."
 
 #. L10n: {id} will be something like "13ad6a", just a random number
 #. to differentiate this user from other anonymous users.
-#: src/olympia/users/models.py:353
+#: src/olympia/users/models.py:362
 msgid "Anonymous user {id}"
 msgstr "Anonymní uživatel {id}"
 
-#: src/olympia/users/models.py:410
+#: src/olympia/users/models.py:419
 msgid "Your account has been restricted"
 msgstr "Váš účet byl omezen"
 
-#: src/olympia/users/models.py:480
+#: src/olympia/users/models.py:489
 msgid "Please confirm your email address"
 msgstr "Potvrďte prosím svou e-mailovou adresu"
 
-#: src/olympia/users/models.py:506
+#: src/olympia/users/models.py:515
 msgid "My Mobile Add-ons"
 msgstr "Mé mobilní doplňky"
 
@@ -12379,7 +12217,7 @@ msgstr "Heslo"
 
 #: src/olympia/users/templates/users/edit.html:70
 #, python-format
-msgid "Change your password.  If you forgot your password, you can <a href=\"%(reset_url)s\">use the reset form</a>."
+msgid "Change your password. If you forgot your password, you can <a href=\"%(reset_url)s\">use the reset form</a>."
 msgstr "Změna vašeho hesla. Pokud zapomenete své heslo, můžete <a href=\"%(reset_url)s\">použít formulář na vyresetování</a>."
 
 #: src/olympia/users/templates/users/edit.html:76
@@ -12399,7 +12237,7 @@ msgid "Profile"
 msgstr "Profil"
 
 #: src/olympia/users/templates/users/edit.html:100
-msgid "Give us a bit more information about yourself.  All these fields are optional, but they'll help other users get to know you better."
+msgid "Give us a bit more information about yourself. All these fields are optional, but they'll help other users get to know you better."
 msgstr "Poskytněte o sobě více informací. Všechna tato pole jsou volitelná, ale pomohou ostatním uživatelům vás lépe poznat."
 
 #: src/olympia/users/templates/users/edit.html:124
@@ -12619,7 +12457,7 @@ msgid "Confirm password"
 msgstr "Heslo znova"
 
 #: src/olympia/users/templates/users/pwreset_confirm.html:47
-msgid "The password reset link was invalid, possibly because it has already been used.  Please request a new password reset."
+msgid "The password reset link was invalid, possibly because it has already been used. Please request a new password reset."
 msgstr "Odkaz na obnovu hesla je neplatný, možná proto, že již byl použit. Požádejte prosím o obnovu hesla znovu."
 
 #: src/olympia/users/templates/users/pwreset_request.html:15
@@ -12839,7 +12677,6 @@ msgid "%(num)s theme"
 msgid_plural "%(num)s themes"
 msgstr[0] "%(num)s motiv"
 msgstr[1] "%(num)s motivy"
-msgstr[2] "%(num)s motivů"
 
 #: src/olympia/users/templates/users/vcard.html:62
 #, python-format
@@ -12847,7 +12684,6 @@ msgid "%(num)s add-on"
 msgid_plural "%(num)s add-ons"
 msgstr[0] "%(num)s doplněk"
 msgstr[1] "%(num)s doplňky"
-msgstr[2] "%(num)s doplňků"
 
 #: src/olympia/users/templates/users/vcard.html:75
 msgid "Average rating of developer's add-ons"
@@ -12862,15 +12698,15 @@ msgstr "Historie verzí pro %s"
 msgid "Version History with Changelogs"
 msgstr "Historie verzí s popisem změn"
 
-#: src/olympia/versions/models.py:314
+#: src/olympia/versions/models.py:313
 msgid "Add-on uses binary components."
 msgstr "Doplněk obsahuje binární komponenty."
 
-#: src/olympia/versions/models.py:317
+#: src/olympia/versions/models.py:316
 msgid "Add-on has opted into strict compatibility checking."
 msgstr "Doplněk má nastavení striktní kontrolu kompatibility."
 
-#: src/olympia/versions/models.py:715
+#: src/olympia/versions/models.py:711
 msgid "{app} {min} and later"
 msgstr "{app} {min} a novější"
 
@@ -12909,7 +12745,6 @@ msgid "<b>{0}</b> version"
 msgid_plural "<b>{0}</b> versions"
 msgstr[0] "<b>{0}</b> verze"
 msgstr[1] "<b>{0}</b> verze"
-msgstr[2] "<b>{0}</b> verzí"
 
 #: src/olympia/versions/templates/versions/version_list.html:35 src/olympia/versions/templates/versions/mobile/version_list.html:14
 msgid "Be careful with old versions!"
@@ -12948,4 +12783,8 @@ msgstr "Po dokončení zaslat e-mail"
 #: src/olympia/zadmin/forms.py:105
 msgid "Log emails instead of sending"
 msgstr "Logovat e-maily na místo jejich odesílání"
+
+#: src/olympia/zadmin/forms.py:215
+msgid "Deleted versions can`t be changed."
+msgstr ""
 

--- a/locale/cs/LC_MESSAGES/djangojs.po
+++ b/locale/cs/LC_MESSAGES/djangojs.po
@@ -1,1285 +1,1239 @@
-# 
+#
 msgid ""
 msgstr ""
 "Project-Id-Version: REMORA 0.1\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2016-02-24 21:23+0000\n"
+"POT-Creation-Date: 2016-04-18 15:47+0000\n"
 "PO-Revision-Date: 2016-04-13 15:01+0000\n"
 "Last-Translator: Tomáš Zelina <zelitomas@gmail.com>\n"
 "Language-Team: Mozilla.cz <info@mozilla.cz>\n"
-"Language: cs\n"
+"Language: \n"
 "MIME-Version: 1.0\n"
-"Content-Type: text/plain; charset=utf-8\n"
+"Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=3; plural=(n==1) ? 0 : (n>=2 && n<=4) ? 1 : 2;\n"
 "Generated-By: Babel 2.2.0\n"
-"X-Generator: Pontoon\n"
 
-#: static/js/common/ratingwidget.js:31
+#: static/js/common-all.js:1426 static/js/impala-all.js:1511 static/js/zamboni/discovery-all.js:12598 static/js/zamboni/init.js:28 static/js/zamboni/mobile-all.js:14945
+msgid "This feature is temporarily disabled while we perform website maintenance. Please check back a little later."
+msgstr "Tato funkce je dočasně zakázána, protože provádíme údržbu webu. Zkuste to prosím o chvíli později."
+
+#. L10n: {0} is an app name like Firefox.
+#: static/js/common-all.js:1837 static/js/impala-all.js:1922 static/js/zamboni/buttons.js:73 static/js/zamboni/discovery-all.js:13108
+msgid "Accept and Install"
+msgstr "Souhlasím a instalovat"
+
+#: static/js/common-all.js:1837 static/js/impala-all.js:1922 static/js/zamboni/buttons.js:73 static/js/zamboni/discovery-all.js:13108
+msgid "Add to {0}"
+msgstr "Přidat do aplikace {0}"
+
+#: static/js/common-all.js:1842 static/js/impala-all.js:1927 static/js/zamboni/buttons.js:78 static/js/zamboni/discovery-all.js:13113
+msgid "Download Now"
+msgstr "Stáhnout"
+
+#: static/js/common-all.js:1883 static/js/impala-all.js:1968 static/js/zamboni/buttons.js:119 static/js/zamboni/discovery-all.js:13154
+msgid "Add-on has not been updated to support default-to-compatible."
+msgstr "Doplněk nebyl aktualizován tak, aby byl ve výchozím nastavení kompatibilní."
+
+#: static/js/common-all.js:1888 static/js/impala-all.js:1973 static/js/zamboni/buttons.js:124 static/js/zamboni/discovery-all.js:13159
+msgid "You need to be using Firefox 10.0 or higher."
+msgstr "Je potřeba, abyste používali Firefox 10.0 či vyšší."
+
+#: static/js/common-all.js:1900 static/js/impala-all.js:1985 static/js/zamboni/buttons.js:136 static/js/zamboni/discovery-all.js:13171
+msgid "Mozilla has marked this version as incompatible with your Firefox version."
+msgstr "Mozilla označila tuto verzi jako nekompatibilní s vaší verzí Firefoxu."
+
+#. L10n: {0} is an platform like Windows or Linux.
+#: static/js/common-all.js:1981 static/js/impala-all.js:2066 static/js/zamboni/buttons.js:217 static/js/zamboni/discovery-all.js:13252
+msgid "Install for {0} anyway"
+msgstr "Přesto nainstalovat do aplikace {0}"
+
+#: static/js/common-all.js:1981 static/js/impala-all.js:2066 static/js/zamboni/buttons.js:217 static/js/zamboni/discovery-all.js:13252
+msgid "Download for {0} anyway"
+msgstr "Přesto stáhnout pro aplikaci {0}"
+
+#: static/js/common-all.js:2038 static/js/impala-all.js:2123 static/js/zamboni/buttons.js:274 static/js/zamboni/discovery-all.js:13309
+msgid "Not available for your platform"
+msgstr "Není dostupné pro vaši platformu"
+
+#. L10n: {0} is an app name, {1} is the app version.
+#: static/js/common-all.js:2049 static/js/common-all.js:2086 static/js/impala-all.js:2134 static/js/impala-all.js:2171 static/js/zamboni/buttons.js:286 static/js/zamboni/buttons.js:324
+#: static/js/zamboni/discovery-all.js:13320 static/js/zamboni/discovery-all.js:13357
+msgid "Not available for {0} {1}"
+msgstr "Není dostupné pro {0} {1}"
+
+#: static/js/common-all.js:2112 static/js/impala-all.js:2197 static/js/zamboni/buttons.js:351 static/js/zamboni/discovery-all.js:13383
+msgid "Works with {app} {min} - {max}"
+msgstr "Funguje s aplikací {app} {min} - {max}"
+
+#: static/js/common-all.js:2114 static/js/impala-all.js:2199 static/js/zamboni/buttons.js:353 static/js/zamboni/discovery-all.js:13385
+msgid "View other versions"
+msgstr "Zobrazit ostatní verze"
+
+#: static/js/common-all.js:2162 static/js/impala-all.js:2247 static/js/zamboni/buttons.js:401 static/js/zamboni/discovery-all.js:13433
+msgid "Only with Firefox — Get Firefox Now!"
+msgstr "Pouze pro Firefox — získejte Firefox nyní!"
+
+#: static/js/common-all.js:2278 static/js/impala-all.js:2363 static/js/zamboni/buttons.js:517 static/js/zamboni/discovery-all.js:13549 static/js/zamboni/mobile-all.js:15177
+#: static/js/zamboni/mobile/buttons.js:43
+msgid "Sorry, you need a Mozilla-based browser (such as Firefox) to install a search plugin."
+msgstr "Omlouváme se, ale pro instalaci vyhledávacího modulu potřebujete prohlížeč postavený na Mozille (jako například Firefox)."
+
+#: static/js/common-all.js:9088 static/js/impala-all.js:9649 static/js/zamboni/global.js:410
+msgid "Loading..."
+msgstr "Probíhá načítání..."
+
+#. L10n: {0} is the number of characters left.
+#: static/js/common-all.js:9152 static/js/impala-all.js:9713 static/js/zamboni/global.js:474
+msgid "<b>{0}</b> character left."
+msgid_plural "<b>{0}</b> characters left."
+msgstr[0] "Zbývá <b>{0}</b> znak."
+msgstr[1] "Zbývají <b>{0}</b> znaky."
+
+#: static/js/common-all.js:9589 static/js/common-min.js:6 static/js/impala-all.js:10052 static/js/impala-min.js:6 static/js/common/ratingwidget.js:31 static/js/zamboni/mobile-all.js:16123
+#: static/js/zamboni/mobile-min.js:6
 msgid "{0} star"
 msgid_plural "{0} stars"
 msgstr[0] "{0} hvězdička"
 msgstr[1] "{0} hvězdičky"
-msgstr[2] "{0} hvězdiček"
 
-#: static/js/common/upload-addon.js:41 static/js/common/upload-image.js:128
+#: static/js/common-all.js:9676 static/js/common-min.js:6 static/js/impala-all.js:10139 static/js/impala-min.js:6 static/js/zamboni/l10n.js:45
+msgid "Remove this localization"
+msgstr "Odebrat lokalizaci"
+
+#: static/js/common-all.js:10193 static/js/common-min.js:6 static/js/impala-all.js:10674 static/js/impala-min.js:6 static/js/zamboni/discovery-all.js:13678
+msgid "close"
+msgstr ""
+
+#: static/js/common-all.js:10860 static/js/common-min.js:6 static/js/impala-all.js:11481 static/js/impala-min.js:6 static/js/impala/reviews.js:23 static/js/zamboni/reviews.js:18
+msgid "Flagged for review"
+msgstr "Označeno na kontrolu"
+
+#: static/js/common-all.js:10876 static/js/common-min.js:6 static/js/impala-all.js:11498 static/js/impala-min.js:6 static/js/impala/reviews.js:40 static/js/zamboni/reviews.js:34
+msgid "Your input is required"
+msgstr "Je vyžadována vaše akce"
+
+#: static/js/common-all.js:10945 static/js/common-min.js:6 static/js/impala-all.js:11610 static/js/impala-min.js:7 static/js/impala/reviews.js:152 static/js/zamboni/reviews.js:103
+msgid "Marked for deletion"
+msgstr "Označeno pro smazání"
+
+#: static/js/common-all.js:11573 static/js/common-min.js:7 static/js/impala-all.js:13809 static/js/impala-min.js:8 static/js/zamboni/collections.js:229
+msgid "Adding to Favorites&hellip;"
+msgstr "Přidání k oblíbeným&hellip;"
+
+#: static/js/common-all.js:11576 static/js/common-min.js:7 static/js/impala-all.js:13812 static/js/impala-min.js:8 static/js/zamboni/collections.js:232
+msgid "Removing Favorite&hellip;"
+msgstr "Odebrání z oblíbených&hellip;"
+
+#: static/js/common-all.js:11579 static/js/common-min.js:7 static/js/impala-all.js:13815 static/js/impala-min.js:8 static/js/zamboni/collections.js:235
+msgid "Add to Favorites"
+msgstr "Přidat k oblíbeným"
+
+#: static/js/common-all.js:11582 static/js/common-min.js:7 static/js/impala-all.js:13818 static/js/impala-min.js:8 static/js/zamboni/collections.js:238
+msgid "Remove from Favorites"
+msgstr "Odebrat z oblíbených"
+
+#: static/js/common-all.js:11647 static/js/common-min.js:7 static/js/impala-all.js:13883 static/js/impala-min.js:8 static/js/zamboni/collections.js:303
+msgid "Pending"
+msgstr "Čekající"
+
+#: static/js/common-all.js:11648 static/js/common-min.js:7 static/js/impala-all.js:13884 static/js/impala-min.js:8 static/js/zamboni/collections.js:304
+msgid "Add a comment"
+msgstr "Přidat komentář"
+
+#: static/js/common-all.js:11648 static/js/common-min.js:7 static/js/impala-all.js:13884 static/js/impala-min.js:8 static/js/zamboni/collections.js:304
+msgid "Comment"
+msgstr "Komentář"
+
+#: static/js/common-all.js:11649 static/js/common-min.js:7 static/js/impala-all.js:13885 static/js/impala-min.js:8 static/js/zamboni/collections.js:305
+msgid "Remove this add-on from the collection"
+msgstr "Odebrat tento doplněk z kolekce"
+
+#: static/js/common-all.js:11649 static/js/common-all.js:11678 static/js/common-min.js:7 static/js/impala-all.js:13885 static/js/impala-all.js:13914 static/js/impala-min.js:8
+#: static/js/zamboni/collections.js:305 static/js/zamboni/collections.js:334
+msgid "Remove"
+msgstr "Odebrat"
+
+#: static/js/common-all.js:11678 static/js/common-min.js:7 static/js/impala-all.js:13914 static/js/impala-min.js:8 static/js/zamboni/collections.js:334
+msgid "Remove this user as a contributor"
+msgstr "Odebrat tohoto uživatele z přispěvatelů"
+
+#: static/js/common-all.js:11690 static/js/common-min.js:7 static/js/impala-all.js:13926 static/js/impala-min.js:8 static/js/zamboni/collections.js:346
+msgid "An email address is required."
+msgstr "E-mailová adresa je vyžadována."
+
+#: static/js/common-all.js:11708 static/js/common-min.js:7 static/js/impala-all.js:13944 static/js/impala-min.js:8 static/js/zamboni/collections.js:364
+msgid "You cannot add yourself as a contributor."
+msgstr "Nemůžete jako přispěvatele přidat sami sebe."
+
+#: static/js/common-all.js:11710 static/js/common-min.js:7 static/js/impala-all.js:13946 static/js/impala-min.js:8 static/js/zamboni/collections.js:366
+msgid "You have already added that user."
+msgstr "Již jste tohoto uživatele přidali."
+
+#: static/js/common-all.js:11917 static/js/common-min.js:7 static/js/impala-all.js:14153 static/js/impala-min.js:8 static/js/zamboni/collections.js:573
+msgid "Add to favorites"
+msgstr "Přidat k oblíbeným"
+
+#: static/js/common-all.js:11921 static/js/common-min.js:7 static/js/impala-all.js:14157 static/js/impala-min.js:8 static/js/zamboni/collections.js:577
+msgid "Remove from favorites"
+msgstr "Odebrat z oblíbených"
+
+#: static/js/common-all.js:11939 static/js/common-min.js:7 static/js/impala-all.js:14175 static/js/impala-all.js:14233 static/js/impala-min.js:8 static/js/impala/collections.js:10
+#: static/js/zamboni/collections.js:595
+msgid "Follow this Collection"
+msgstr "Sledovat kolekci"
+
+#: static/js/common-all.js:11948 static/js/common-min.js:7 static/js/impala-all.js:14184 static/js/impala-min.js:8 static/js/zamboni/collections.js:604
+msgid "Stop following"
+msgstr "Ukončit sledování"
+
+#: static/js/common-all.js:12096 static/js/common-min.js:7 static/js/zamboni/password-strength.js:20
+msgid "Password strength:"
+msgstr "Síla hesla:"
+
+#: static/js/common-all.js:12102 static/js/common-min.js:7 static/js/zamboni/password-strength.js:26
+msgid "At least {0} character left."
+msgid_plural "At least {0} characters left."
+msgstr[0] "Zbývá {0} znak."
+msgstr[1] "Zbývají {0} znaky."
+
+#: static/js/common-all.js:12286 static/js/common-min.js:7 static/js/impala-all.js:14632 static/js/impala-min.js:8 static/js/impala/suggestions.js:39
+msgid "Search themes for <b>{0}</b>"
+msgstr "Vyhledávání motivů dle <b>{0}</b>"
+
+#: static/js/common-all.js:12288 static/js/common-min.js:7 static/js/impala-all.js:14634 static/js/impala-min.js:8 static/js/impala/suggestions.js:41
+msgid "Search apps for <b>{0}</b>"
+msgstr "Vyhledávání aplikací pro <b>{0}</b>"
+
+#: static/js/common-all.js:12290 static/js/common-min.js:7 static/js/impala-all.js:14636 static/js/impala-min.js:8 static/js/impala/suggestions.js:43
+msgid "Search add-ons for <b>{0}</b>"
+msgstr "Vyhledávání doplňků pro <b>{0}</b>"
+
+#: static/js/common-all.js:12521 static/js/common-min.js:7 static/js/impala-all.js:14867 static/js/impala-min.js:8 static/js/impala/site_suggestions.js:46
+msgid "Category"
+msgstr "Kategorie"
+
+#. L10n: {0} is an app name.
+#: static/js/impala-all.js:11632 static/js/impala-min.js:7 static/js/impala/listing.js:11 static/js/zamboni/themes.js:13
+msgid "This theme is incompatible with your version of {0}"
+msgstr "Motiv vzhledu je s touto verzí aplikace {0} nekompatibilní"
+
+#: static/js/impala-all.js:12146 static/js/impala-all.js:14331 static/js/impala-min.js:7 static/js/impala-min.js:8 static/js/common/upload-image.js:97 static/js/impala/users.js:51
+#: static/js/zamboni/devhub-all.js:894 static/js/zamboni/devhub-min.js:1
+msgid "Images must be either PNG or JPG."
+msgstr "Obrázky musí být v PNG či JPG."
+
+#: static/js/impala-all.js:12150 static/js/impala-min.js:7 static/js/common/upload-image.js:101 static/js/zamboni/devhub-all.js:898 static/js/zamboni/devhub-min.js:1
+msgid "Videos must be in WebM."
+msgstr "Videa musí být ve formátu WebM."
+
+#: static/js/impala-all.js:12177 static/js/impala-min.js:7 static/js/common/upload-addon.js:41 static/js/common/upload-image.js:128 static/js/zamboni/devhub-all.js:272
+#: static/js/zamboni/devhub-all.js:925 static/js/zamboni/devhub-min.js:1
 msgid "There was a problem contacting the server."
 msgstr "Vyskytl se problém při kontaktování serveru."
 
-#: static/js/common/upload-addon.js:69
+#: static/js/impala-all.js:13298 static/js/impala-min.js:7 static/js/impala/persona_creation.js:60
+msgid "All Rights Reserved"
+msgstr "Všechna práva vyhrazena"
+
+#: static/js/impala-all.js:13302 static/js/impala-min.js:7 static/js/impala/persona_creation.js:64
+msgid "Creative Commons Attribution 3.0"
+msgstr "Creative Commons Attribution 3.0"
+
+#: static/js/impala-all.js:13307 static/js/impala-min.js:7 static/js/impala/persona_creation.js:69
+msgid "Creative Commons Attribution-NonCommercial 3.0"
+msgstr "Creative Commons Attribution-NonCommercial 3.0"
+
+#: static/js/impala-all.js:13312 static/js/impala-min.js:7 static/js/impala/persona_creation.js:74
+msgid "Creative Commons Attribution-NonCommercial-NoDerivs 3.0"
+msgstr "Creative Commons Attribution-NonCommercial-NoDerivs 3.0"
+
+#: static/js/impala-all.js:13317 static/js/impala-min.js:7 static/js/impala/persona_creation.js:79
+msgid "Creative Commons Attribution-NonCommercial-Share Alike 3.0"
+msgstr "Creative Commons Attribution-NonCommercial-Share Alike 3.0"
+
+#: static/js/impala-all.js:13322 static/js/impala-min.js:7 static/js/impala/persona_creation.js:84
+msgid "Creative Commons Attribution-NoDerivs 3.0"
+msgstr "Creative Commons Attribution-NoDerivs 3.0"
+
+#: static/js/impala-all.js:13327 static/js/impala-min.js:7 static/js/impala/persona_creation.js:89
+msgid "Creative Commons Attribution-ShareAlike 3.0"
+msgstr "Creative Commons Attribution-ShareAlike 3.0"
+
+#: static/js/impala-all.js:13530 static/js/impala-min.js:7 static/js/impala/persona_creation.js:292
+msgid "Your Theme's Name"
+msgstr "Jméno vašeho motivu"
+
+#: static/js/impala-all.js:14242 static/js/impala-min.js:8 static/js/impala/collections.js:19
+msgid "Stop Following"
+msgstr "Ukončit sledování"
+
+#: static/js/impala-all.js:14243 static/js/impala-min.js:8 static/js/impala/collections.js:20
+msgid "Following"
+msgstr "Začít sledovat"
+
+#: static/js/impala-all.js:14313 static/js/impala-min.js:8 static/js/impala/users.js:33
+msgid "use original"
+msgstr "použít originál"
+
+#: static/js/impala-all.js:14523 static/js/impala-min.js:8 static/js/impala/search.js:114
+msgid "Updating results&hellip;"
+msgstr "Probíhá aktualizace výsledků&hellip;"
+
+#: static/js/common/upload-addon.js:69 static/js/zamboni/devhub-all.js:300 static/js/zamboni/devhub-min.js:1
 msgid "Select a file..."
 msgstr "Volba souboru..."
 
-#: static/js/common/upload-addon.js:70
+#: static/js/common/upload-addon.js:70 static/js/zamboni/devhub-all.js:301 static/js/zamboni/devhub-min.js:1
 msgid "Your add-on should end with .xpi, .jar or .xml"
 msgstr "Váš doplněk by měl končit příponou .xpi, .jar nebo .xml"
 
 #. L10n: {0} is the percent of the file that has been uploaded.
-#: static/js/common/upload-addon.js:104
+#: static/js/common/upload-addon.js:104 static/js/zamboni/devhub-all.js:335 static/js/zamboni/devhub-min.js:1
 #, python-format
 msgid "{0}% complete"
 msgstr "{0}% dokončeno"
 
 #. L10n: "{bytes uploaded} of {total filesize}".
-#: static/js/common/upload-addon.js:107
+#: static/js/common/upload-addon.js:107 static/js/zamboni/devhub-all.js:338 static/js/zamboni/devhub-min.js:1
 msgid "{0} of {1}"
 msgstr "{0} z {1}"
 
-#: static/js/common/upload-addon.js:140
+#: static/js/common/upload-addon.js:140 static/js/zamboni/devhub-all.js:371 static/js/zamboni/devhub-min.js:1
 msgid "Cancel"
 msgstr "Zrušit"
 
-#: static/js/common/upload-addon.js:162
+#: static/js/common/upload-addon.js:162 static/js/zamboni/devhub-all.js:393 static/js/zamboni/devhub-min.js:1
 msgid "Uploading {0}"
 msgstr "Probíhá nahrávání {0}"
 
-#: static/js/common/upload-addon.js:189
+#: static/js/common/upload-addon.js:189 static/js/zamboni/devhub-all.js:420 static/js/zamboni/devhub-min.js:1
 msgid "Error with {0}"
 msgstr "Chyba s {0}"
 
-#: static/js/common/upload-addon.js:194
+#: static/js/common/upload-addon.js:194 static/js/zamboni/devhub-all.js:425 static/js/zamboni/devhub-min.js:1
 msgid "Your add-on failed validation with {0} error."
 msgid_plural "Your add-on failed validation with {0} errors."
 msgstr[0] "Váš doplněk neprošel kontrolou s {0} chybou."
 msgstr[1] "Váš doplněk neprošel kontrolou s {0} chybami."
-msgstr[2] "Váš doplněk neprošel kontrolou s {0} chybami."
 
-#: static/js/common/upload-addon.js:208
+#: static/js/common/upload-addon.js:208 static/js/zamboni/devhub-all.js:439 static/js/zamboni/devhub-min.js:1
 msgid "&hellip;and {0} more"
 msgid_plural "&hellip;and {0} more"
 msgstr[0] "&hellip;a {0} další"
 msgstr[1] "&hellip;a {0} další"
-msgstr[2] "&hellip;a {0} další"
 
-#: static/js/common/upload-addon.js:222 static/js/common/upload-addon.js:512
+#: static/js/common/upload-addon.js:222 static/js/common/upload-addon.js:497 static/js/zamboni/devhub-all.js:453 static/js/zamboni/devhub-all.js:743 static/js/zamboni/devhub-min.js:1
 msgid "See full validation report"
 msgstr "Zobrazit podrobný report"
 
-#: static/js/common/upload-addon.js:234
+#: static/js/common/upload-addon.js:234 static/js/zamboni/devhub-all.js:465 static/js/zamboni/devhub-min.js:1
 msgid "Validating {0}"
 msgstr "Probíhá kontrola {0}"
 
 #. L10n: first argument is an HTTP status code
-#: static/js/common/upload-addon.js:273
+#: static/js/common/upload-addon.js:273 static/js/zamboni/devhub-all.js:504 static/js/zamboni/devhub-min.js:1
 msgid "Received an empty response from the server; status: {0}"
 msgstr "Obdržena prázdná odpověď ze serveru; status: {0}"
 
-#: static/js/common/upload-addon.js:373
+#: static/js/common/upload-addon.js:370 static/js/zamboni/devhub-all.js:604 static/js/zamboni/devhub-min.js:1
 msgid "Unexpected server error while validating."
 msgstr "Při kontrole nastala neočekávaná chyba serveru."
 
-#: static/js/common/upload-addon.js:412
+#: static/js/common/upload-addon.js:409 static/js/zamboni/devhub-all.js:643 static/js/zamboni/devhub-min.js:1
 msgid "Finished validating {0}"
 msgstr "Dokončena kontrola {0}"
 
-#: static/js/common/upload-addon.js:418
+#: static/js/common/upload-addon.js:415 static/js/zamboni/devhub-all.js:649 static/js/zamboni/devhub-min.js:1
 msgid "Your add-on validation timed out, it will be manually reviewed."
 msgstr "Validace vašeho doplňku vypršela, doplněk bude manuálně zkontrolován."
 
-#: static/js/common/upload-addon.js:421
+#: static/js/common/upload-addon.js:418 static/js/zamboni/devhub-all.js:652 static/js/zamboni/devhub-min.js:1
 msgid "Your add-on was validated with no errors and {0} warning."
 msgid_plural "Your add-on was validated with no errors and {0} warnings."
 msgstr[0] "Váš doplněk byl zkontrolován bez chyb a s {0} varováním."
 msgstr[1] "Váš doplněk byl zkontrolován bez chyb a s {0} varováními."
-msgstr[2] "Váš doplněk byl zkontrolován bez chyb a s {0} varováními."
 
-#: static/js/common/upload-addon.js:426
+#: static/js/common/upload-addon.js:423 static/js/zamboni/devhub-all.js:657 static/js/zamboni/devhub-min.js:1
 msgid "Your add-on was validated with no errors and {0} message."
 msgid_plural "Your add-on was validated with no errors and {0} messages."
 msgstr[0] "Váš doplněk byl zkontrolován bez chyb a s {0} varováním."
 msgstr[1] "Váš doplněk byl zkontrolován bez chyb a s {0} varováními."
-msgstr[2] "Váš doplněk byl zkontrolován bez chyb a s {0} varováními."
 
-#: static/js/common/upload-addon.js:431
+#: static/js/common/upload-addon.js:428 static/js/zamboni/devhub-all.js:662 static/js/zamboni/devhub-min.js:1
 msgid "Your add-on was validated with no errors or warnings."
 msgstr "Váš doplněk byl zkontrolován bez chyb či varování."
 
-#: static/js/common/upload-addon.js:446
+#: static/js/common/upload-addon.js:443 static/js/zamboni/devhub-all.js:677 static/js/zamboni/devhub-min.js:1
 msgid "Your submission will be automatically signed."
 msgstr "Odeslaný doplněk bude automaticky podepsán."
 
-#: static/js/common/upload-addon.js:465
+#: static/js/common/upload-addon.js:450 static/js/zamboni/devhub-all.js:696 static/js/zamboni/devhub-min.js:1
 msgid "Include detailed version notes (this can be done in the next step)."
 msgstr "Zahrnout podrobné poznámky k verzi (lze nastavit v příštím kroku)."
 
-#: static/js/common/upload-addon.js:466
-msgid ""
-"If your add-on requires an account to a website in order to be fully tested,"
-" include a test username and password in the Notes to Reviewer (this can be "
-"done in the next step)."
-msgstr ""
-"Pokud váš doplněk vyžaduje účet na webovém serveru pro možnost plné "
-"kontroly, vložte prosím uživatelské jméno a heslo do poznámky pro redaktora "
-"(lze provést v příštím kroku)."
+#: static/js/common/upload-addon.js:451 static/js/zamboni/devhub-all.js:697 static/js/zamboni/devhub-min.js:1
+msgid "If your add-on requires an account to a website in order to be fully tested, include a test username and password in the Notes to Reviewer (this can be done in the next step)."
+msgstr "Pokud váš doplněk vyžaduje účet na webovém serveru pro možnost plné kontroly, vložte prosím uživatelské jméno a heslo do poznámky pro redaktora (lze provést v příštím kroku)."
 
-#: static/js/common/upload-addon.js:467
-msgid ""
-"If your add-on is intended for a limited audience you should choose "
-"Preliminary Review instead of Full Review."
-msgstr ""
-"Pokud je váš doplněk určen pro omezený počet uživatelů, měli byste zvolit "
-"předběžnou kontrolu na místo té plné."
+#: static/js/common/upload-addon.js:452 static/js/zamboni/devhub-all.js:698 static/js/zamboni/devhub-min.js:1
+msgid "If your add-on is intended for a limited audience you should choose Preliminary Review instead of Full Review."
+msgstr "Pokud je váš doplněk určen pro omezený počet uživatelů, měli byste zvolit předběžnou kontrolu na místo té plné."
 
-#: static/js/common/upload-addon.js:480
+#: static/js/common/upload-addon.js:465 static/js/zamboni/devhub-all.js:711 static/js/zamboni/devhub-min.js:1
 msgid "Add-on submission checklist"
 msgstr "Seznam odeslaných doplňků ke kontrole"
 
-#: static/js/common/upload-addon.js:481
-msgid ""
-"Please verify the following points before finalizing your submission. This "
-"will minimize delays or misunderstanding during the review process:"
-msgstr ""
-"Zkontrolujte prosím následující body před odesláním doplňku ke kontrole. "
-"Pomůže tím zrychlit a předejít případnému nedorozumění při procesu kontroly:"
+#: static/js/common/upload-addon.js:466 static/js/zamboni/devhub-all.js:712 static/js/zamboni/devhub-min.js:1
+msgid "Please verify the following points before finalizing your submission. This will minimize delays or misunderstanding during the review process:"
+msgstr "Zkontrolujte prosím následující body před odesláním doplňku ke kontrole. Pomůže tím zrychlit a předejít případnému nedorozumění při procesu kontroly:"
 
-#: static/js/common/upload-addon.js:483
+#: static/js/common/upload-addon.js:468 static/js/zamboni/devhub-all.js:714 static/js/zamboni/devhub-min.js:1
 msgid ""
-"Compiled binaries, as well as minified or obfuscated scripts (excluding "
-"known libraries) need to have their sources submitted separately for review."
-" Make sure that you use the source code upload field to avoid having your "
-"submission rejected."
+"Compiled binaries, as well as minified or obfuscated scripts (excluding known libraries) need to have their sources submitted separately for review. Make sure that you use the source code upload "
+"field to avoid having your submission rejected."
 msgstr ""
-"Zkompilované binární součásti stejně jako obfuscované skripty (vyjma známých"
-" knihoven) musí mít předložené zdrojové soubory ke kontrole odděleně. "
-"Ujistěte se, že jste použili pole pro nahrání zdrojových kódů, aby nedošlo k"
-" zamítnutí kontroly."
+"Zkompilované binární součásti stejně jako obfuscované skripty (vyjma známých knihoven) musí mít předložené zdrojové soubory ke kontrole odděleně. Ujistěte se, že jste použili pole pro nahrání "
+"zdrojových kódů, aby nedošlo k zamítnutí kontroly."
 
-#: static/js/common/upload-addon.js:501
+#: static/js/common/upload-addon.js:486 static/js/zamboni/devhub-all.js:732 static/js/zamboni/devhub-min.js:1
 msgid "The validation process found these issues that can lead to rejections:"
-msgstr ""
-"Proces kontroly zjistil tyto možné nedostatky, které mohou vést k zamítnutí "
-"kontroly:"
+msgstr "Proces kontroly zjistil tyto možné nedostatky, které mohou vést k zamítnutí kontroly:"
 
-#: static/js/common/upload-addon.js:518
-msgid ""
-"If you are unfamiliar with the add-ons review process, you can read about it"
-" here."
-msgstr ""
-"Pokud ještě nevíte, jak probíhá proces kontroly, můžete si o něm zde "
-"přečíst."
+#: static/js/common/upload-addon.js:503 static/js/zamboni/devhub-all.js:749 static/js/zamboni/devhub-min.js:1
+msgid "If you are unfamiliar with the add-ons review process, you can read about it here."
+msgstr "Pokud ještě nevíte, jak probíhá proces kontroly, můžete si o něm zde přečíst."
 
-#: static/js/common/upload-addon.js:555
+#: static/js/common/upload-addon.js:540 static/js/zamboni/devhub-all.js:786 static/js/zamboni/devhub-min.js:1
 msgid "Sorry, no supported platform has been found."
 msgstr "Omlouváme se, ale nebyla nalezena podporovaná platforma."
 
-#: static/js/common/upload-base.js:57
+#: static/js/common/upload-base.js:57 static/js/zamboni/devhub-all.js:187 static/js/zamboni/devhub-min.js:1
 msgid "The filetype you uploaded isn't recognized."
 msgstr "Typ souboru, který jste nahráli, nebyl rozpoznán."
 
-#: static/js/common/upload-base.js:79
+#: static/js/common/upload-base.js:79 static/js/zamboni/devhub-all.js:209 static/js/zamboni/devhub-min.js:1
 msgid "You cancelled the upload."
 msgstr "Zrušili jste nahrávání."
 
-#: static/js/common/upload-image.js:97 static/js/impala/users.js:51
-msgid "Images must be either PNG or JPG."
-msgstr "Obrázky musí být v PNG či JPG."
-
-#: static/js/common/upload-image.js:101
-msgid "Videos must be in WebM."
-msgstr "Videa musí být ve formátu WebM."
-
-#: static/js/impala/collections.js:10 static/js/zamboni/collections.js:595
-msgid "Follow this Collection"
-msgstr "Sledovat kolekci"
-
-#: static/js/impala/collections.js:19
-msgid "Stop Following"
-msgstr "Ukončit sledování"
-
-#: static/js/impala/collections.js:20
-msgid "Following"
-msgstr "Začít sledovat"
-
-#. L10n: {0} is an app name.
-#: static/js/impala/listing.js:11 static/js/zamboni/themes.js:13
-msgid "This theme is incompatible with your version of {0}"
-msgstr "Motiv vzhledu je s touto verzí aplikace {0} nekompatibilní"
-
-#: static/js/impala/persona_creation.js:60
-msgid "All Rights Reserved"
-msgstr "Všechna práva vyhrazena"
-
-#: static/js/impala/persona_creation.js:64
-msgid "Creative Commons Attribution 3.0"
-msgstr "Creative Commons Attribution 3.0"
-
-#: static/js/impala/persona_creation.js:69
-msgid "Creative Commons Attribution-NonCommercial 3.0"
-msgstr "Creative Commons Attribution-NonCommercial 3.0"
-
-#: static/js/impala/persona_creation.js:74
-msgid "Creative Commons Attribution-NonCommercial-NoDerivs 3.0"
-msgstr "Creative Commons Attribution-NonCommercial-NoDerivs 3.0"
-
-#: static/js/impala/persona_creation.js:79
-msgid "Creative Commons Attribution-NonCommercial-Share Alike 3.0"
-msgstr "Creative Commons Attribution-NonCommercial-Share Alike 3.0"
-
-#: static/js/impala/persona_creation.js:84
-msgid "Creative Commons Attribution-NoDerivs 3.0"
-msgstr "Creative Commons Attribution-NoDerivs 3.0"
-
-#: static/js/impala/persona_creation.js:89
-msgid "Creative Commons Attribution-ShareAlike 3.0"
-msgstr "Creative Commons Attribution-ShareAlike 3.0"
-
-#: static/js/impala/persona_creation.js:292
-msgid "Your Theme's Name"
-msgstr "Jméno vašeho motivu"
-
-#: static/js/impala/reviews.js:23 static/js/zamboni/reviews.js:18
-msgid "Flagged for review"
-msgstr "Označeno na kontrolu"
-
-#: static/js/impala/reviews.js:40 static/js/zamboni/reviews.js:34
-msgid "Your input is required"
-msgstr "Je vyžadována vaše akce"
-
-#: static/js/impala/reviews.js:152 static/js/zamboni/reviews.js:103
-msgid "Marked for deletion"
-msgstr "Označeno pro smazání"
-
-#: static/js/impala/search.js:114
-msgid "Updating results&hellip;"
-msgstr "Probíhá aktualizace výsledků&hellip;"
-
-#: static/js/impala/site_suggestions.js:46
-msgid "Category"
-msgstr "Kategorie"
-
-#: static/js/impala/suggestions.js:39
-msgid "Search themes for <b>{0}</b>"
-msgstr "Vyhledávání motivů dle <b>{0}</b>"
-
-#: static/js/impala/suggestions.js:41
-msgid "Search apps for <b>{0}</b>"
-msgstr "Vyhledávání aplikací pro <b>{0}</b>"
-
-#: static/js/impala/suggestions.js:43
-msgid "Search add-ons for <b>{0}</b>"
-msgstr "Vyhledávání doplňků pro <b>{0}</b>"
-
-#: static/js/impala/users.js:33
-msgid "use original"
-msgstr "použít originál"
-
-#: static/js/impala/stats/chart.js:267
+#: static/js/impala/stats/chart.js:267 static/js/zamboni/stats-all.js:16898 static/js/zamboni/stats-min.js:5
 msgid "Week of {0}"
 msgstr "Týden {0}"
 
-#: static/js/impala/stats/chart.js:269
+#: static/js/impala/stats/chart.js:269 static/js/zamboni/stats-all.js:16900 static/js/zamboni/stats-min.js:5
 msgid " downloads"
-msgstr " stažení"
+msgstr ""
 
-#: static/js/impala/stats/chart.js:270
+#: static/js/impala/stats/chart.js:270 static/js/zamboni/stats-all.js:16901 static/js/zamboni/stats-min.js:5
 msgid "{0} users"
 msgstr "{0} uživatelů"
 
-#: static/js/impala/stats/chart.js:271
+#: static/js/impala/stats/chart.js:271 static/js/zamboni/stats-all.js:16902 static/js/zamboni/stats-min.js:5
 msgid "{0} add-ons"
 msgstr "{0} doplňků"
 
-#: static/js/impala/stats/chart.js:272
+#: static/js/impala/stats/chart.js:272 static/js/zamboni/stats-all.js:16903 static/js/zamboni/stats-min.js:5
 msgid "{0} collections"
 msgstr "{0} sbírek"
 
-#: static/js/impala/stats/chart.js:273
+#: static/js/impala/stats/chart.js:273 static/js/zamboni/stats-all.js:16904 static/js/zamboni/stats-min.js:5
 msgid "{0} reviews"
 msgstr "{0} recenzí"
 
-#: static/js/impala/stats/chart.js:275
+#: static/js/impala/stats/chart.js:275 static/js/zamboni/stats-all.js:16906 static/js/zamboni/stats-min.js:5
 msgid "{0} sales"
 msgstr "{0} prodejů"
 
-#: static/js/impala/stats/chart.js:276
+#: static/js/impala/stats/chart.js:276 static/js/zamboni/stats-all.js:16907 static/js/zamboni/stats-min.js:5
 msgid "{0} refunds"
 msgstr "{0} vrácení plateb"
 
-#: static/js/impala/stats/chart.js:277
+#: static/js/impala/stats/chart.js:277 static/js/zamboni/stats-all.js:16908 static/js/zamboni/stats-min.js:5
 msgid "{0} installs"
 msgstr "{0} instalací"
 
-#: static/js/impala/stats/chart.js:369 static/js/impala/stats/csv_keys.js:3
-#: static/js/impala/stats/csv_keys.js:109
+#: static/js/impala/stats/chart.js:369 static/js/impala/stats/csv_keys.js:3 static/js/impala/stats/csv_keys.js:109 static/js/zamboni/stats-all.js:15284 static/js/zamboni/stats-all.js:15390
+#: static/js/zamboni/stats-all.js:17000 static/js/zamboni/stats-min.js:4 static/js/zamboni/stats-min.js:5
 msgid "Downloads"
 msgstr "Stažení"
 
-#: static/js/impala/stats/chart.js:379 static/js/impala/stats/csv_keys.js:6
-#: static/js/impala/stats/csv_keys.js:110
+#: static/js/impala/stats/chart.js:379 static/js/impala/stats/csv_keys.js:6 static/js/impala/stats/csv_keys.js:110 static/js/zamboni/stats-all.js:15287 static/js/zamboni/stats-all.js:15391
+#: static/js/zamboni/stats-all.js:17010 static/js/zamboni/stats-min.js:4 static/js/zamboni/stats-min.js:5
 msgid "Daily Users"
 msgstr "Denní uživatelé"
 
-#: static/js/impala/stats/chart.js:410
+#: static/js/impala/stats/chart.js:410 static/js/zamboni/stats-all.js:17041 static/js/zamboni/stats-min.js:5
 msgid "Amount, in USD"
 msgstr "Množství, v USD"
 
-#: static/js/impala/stats/chart.js:421 static/js/impala/stats/csv_keys.js:104
+#: static/js/impala/stats/chart.js:421 static/js/impala/stats/csv_keys.js:104 static/js/zamboni/stats-all.js:15385 static/js/zamboni/stats-all.js:17052 static/js/zamboni/stats-min.js:5
 msgid "Number of Contributions"
 msgstr "Počet příspěvků"
 
-#: static/js/impala/stats/chart.js:447
+#: static/js/impala/stats/chart.js:447 static/js/zamboni/stats-all.js:17078 static/js/zamboni/stats-min.js:5
 msgid "More Info..."
 msgstr "Více informací..."
 
 #. L10n: {0} is an ISO-formatted date.
-#: static/js/impala/stats/chart.js:451
+#: static/js/impala/stats/chart.js:451 static/js/zamboni/stats-all.js:17082 static/js/zamboni/stats-min.js:5
 msgid "Details for {0}"
 msgstr "Detaily pro {0}"
 
-#: static/js/impala/stats/csv_keys.js:9
+#: static/js/impala/stats/csv_keys.js:9 static/js/zamboni/stats-all.js:15290 static/js/zamboni/stats-min.js:4
 msgid "Collections Created"
 msgstr "Vytvořené sbírky"
 
-#: static/js/impala/stats/csv_keys.js:12
+#: static/js/impala/stats/csv_keys.js:12 static/js/zamboni/stats-all.js:15293 static/js/zamboni/stats-min.js:4
 msgid "Add-ons in Use"
 msgstr "Používané doplňky"
 
-#: static/js/impala/stats/csv_keys.js:15
+#: static/js/impala/stats/csv_keys.js:15 static/js/zamboni/stats-all.js:15296 static/js/zamboni/stats-min.js:4
 msgid "Add-ons Created"
 msgstr "Vytvořené doplňky"
 
-#: static/js/impala/stats/csv_keys.js:18
+#: static/js/impala/stats/csv_keys.js:18 static/js/zamboni/stats-all.js:15299 static/js/zamboni/stats-min.js:4
 msgid "Add-ons Downloaded"
 msgstr "Stažené doplňky"
 
-#: static/js/impala/stats/csv_keys.js:21
+#: static/js/impala/stats/csv_keys.js:21 static/js/zamboni/stats-all.js:15302 static/js/zamboni/stats-min.js:4
 msgid "Add-ons Updated"
 msgstr "Aktualizované doplňky"
 
-#: static/js/impala/stats/csv_keys.js:24
+#: static/js/impala/stats/csv_keys.js:24 static/js/zamboni/stats-all.js:15305 static/js/zamboni/stats-min.js:4
 msgid "Reviews Written"
 msgstr "Napsané recenze"
 
-#: static/js/impala/stats/csv_keys.js:27
+#: static/js/impala/stats/csv_keys.js:27 static/js/zamboni/stats-all.js:15308 static/js/zamboni/stats-min.js:4
 msgid "User Signups"
 msgstr "Přihlášení uživatelé"
 
-#: static/js/impala/stats/csv_keys.js:30
+#: static/js/impala/stats/csv_keys.js:30 static/js/zamboni/stats-all.js:15311 static/js/zamboni/stats-min.js:4
 msgid "Subscribers"
 msgstr "Odběry"
 
-#: static/js/impala/stats/csv_keys.js:33
+#: static/js/impala/stats/csv_keys.js:33 static/js/zamboni/stats-all.js:15314 static/js/zamboni/stats-min.js:4
 msgid "Ratings"
 msgstr "Hodnocení"
 
-#: static/js/impala/stats/csv_keys.js:36
-#: static/js/impala/stats/csv_keys.js:114
+#: static/js/impala/stats/csv_keys.js:36 static/js/impala/stats/csv_keys.js:114 static/js/zamboni/stats-all.js:15317 static/js/zamboni/stats-all.js:15395 static/js/zamboni/stats-min.js:4
+#: static/js/zamboni/stats-min.js:5
 msgid "Sales"
 msgstr "Prodeje"
 
-#: static/js/impala/stats/csv_keys.js:39
-#: static/js/impala/stats/csv_keys.js:113
+#: static/js/impala/stats/csv_keys.js:39 static/js/impala/stats/csv_keys.js:113 static/js/zamboni/stats-all.js:15320 static/js/zamboni/stats-all.js:15394 static/js/zamboni/stats-min.js:4
+#: static/js/zamboni/stats-min.js:5
 msgid "Installs"
 msgstr "Instalace"
 
-#: static/js/impala/stats/csv_keys.js:42
+#: static/js/impala/stats/csv_keys.js:42 static/js/zamboni/stats-all.js:15323 static/js/zamboni/stats-min.js:4
 msgid "Unknown"
 msgstr "Neznámé"
 
-#: static/js/impala/stats/csv_keys.js:43
+#: static/js/impala/stats/csv_keys.js:43 static/js/zamboni/stats-all.js:15324 static/js/zamboni/stats-min.js:4
 msgid "Add-ons Manager"
 msgstr "Správce doplňků"
 
-#: static/js/impala/stats/csv_keys.js:44
+#: static/js/impala/stats/csv_keys.js:44 static/js/zamboni/stats-all.js:15325 static/js/zamboni/stats-min.js:4
 msgid "Add-ons Manager Promo"
 msgstr "Propagace ve správci doplňků"
 
-#: static/js/impala/stats/csv_keys.js:45
+#: static/js/impala/stats/csv_keys.js:45 static/js/zamboni/stats-all.js:15326 static/js/zamboni/stats-min.js:4
 msgid "Add-ons Manager Featured"
 msgstr "Doporučeno ve správci doplňků"
 
-#: static/js/impala/stats/csv_keys.js:46
+#: static/js/impala/stats/csv_keys.js:46 static/js/zamboni/stats-all.js:15327 static/js/zamboni/stats-min.js:4
 msgid "Add-ons Manager Learn More"
 msgstr "Zjistit více ve správci doplňků"
 
-#: static/js/impala/stats/csv_keys.js:47
+#: static/js/impala/stats/csv_keys.js:47 static/js/zamboni/stats-all.js:15328 static/js/zamboni/stats-min.js:4
 msgid "Search Suggestions"
 msgstr "Návrhy našeptávače"
 
-#: static/js/impala/stats/csv_keys.js:48
+#: static/js/impala/stats/csv_keys.js:48 static/js/zamboni/stats-all.js:15329 static/js/zamboni/stats-min.js:4
 msgid "Search Results"
 msgstr "Výsledky vyhledávání"
 
-#: static/js/impala/stats/csv_keys.js:49 static/js/impala/stats/csv_keys.js:50
-#: static/js/impala/stats/csv_keys.js:51
+#: static/js/impala/stats/csv_keys.js:49 static/js/impala/stats/csv_keys.js:50 static/js/impala/stats/csv_keys.js:51 static/js/zamboni/stats-all.js:15330 static/js/zamboni/stats-all.js:15331
+#: static/js/zamboni/stats-all.js:15332 static/js/zamboni/stats-min.js:4
 msgid "Homepage Promo"
 msgstr "Domovská stránka (propagace)"
 
-#: static/js/impala/stats/csv_keys.js:52 static/js/impala/stats/csv_keys.js:53
+#: static/js/impala/stats/csv_keys.js:52 static/js/impala/stats/csv_keys.js:53 static/js/zamboni/stats-all.js:15333 static/js/zamboni/stats-all.js:15334 static/js/zamboni/stats-min.js:4
 msgid "Homepage Featured"
 msgstr "Domovská stránka (doporučené)"
 
-#: static/js/impala/stats/csv_keys.js:54 static/js/impala/stats/csv_keys.js:55
+#: static/js/impala/stats/csv_keys.js:54 static/js/impala/stats/csv_keys.js:55 static/js/zamboni/stats-all.js:15335 static/js/zamboni/stats-all.js:15336 static/js/zamboni/stats-min.js:4
 msgid "Homepage Up and Coming"
 msgstr "Domovská stránka (zajímavé)"
 
-#: static/js/impala/stats/csv_keys.js:56
+#: static/js/impala/stats/csv_keys.js:56 static/js/zamboni/stats-all.js:15337 static/js/zamboni/stats-min.js:4
 msgid "Homepage Most Popular"
 msgstr "Domovská stránka (populární)"
 
-#: static/js/impala/stats/csv_keys.js:57 static/js/impala/stats/csv_keys.js:59
+#: static/js/impala/stats/csv_keys.js:57 static/js/impala/stats/csv_keys.js:59 static/js/zamboni/stats-all.js:15338 static/js/zamboni/stats-all.js:15340 static/js/zamboni/stats-min.js:4
 msgid "Detail Page"
 msgstr "Stránka detailu"
 
-#: static/js/impala/stats/csv_keys.js:58 static/js/impala/stats/csv_keys.js:60
+#: static/js/impala/stats/csv_keys.js:58 static/js/impala/stats/csv_keys.js:60 static/js/zamboni/stats-all.js:15339 static/js/zamboni/stats-all.js:15341 static/js/zamboni/stats-min.js:4
 msgid "Detail Page (bottom)"
 msgstr "Stránka detailu (dole)"
 
-#: static/js/impala/stats/csv_keys.js:61
+#: static/js/impala/stats/csv_keys.js:61 static/js/zamboni/stats-all.js:15342 static/js/zamboni/stats-min.js:4
 msgid "Detail Page (Development Channel)"
 msgstr "Stránka detailu (vývojářský kanál)"
 
-#: static/js/impala/stats/csv_keys.js:62 static/js/impala/stats/csv_keys.js:63
-#: static/js/impala/stats/csv_keys.js:64
+#: static/js/impala/stats/csv_keys.js:62 static/js/impala/stats/csv_keys.js:63 static/js/impala/stats/csv_keys.js:64 static/js/zamboni/stats-all.js:15343 static/js/zamboni/stats-all.js:15344
+#: static/js/zamboni/stats-all.js:15345 static/js/zamboni/stats-min.js:4
 msgid "Often Used With"
 msgstr "Často používán spolu"
 
-#: static/js/impala/stats/csv_keys.js:65 static/js/impala/stats/csv_keys.js:66
+#: static/js/impala/stats/csv_keys.js:65 static/js/impala/stats/csv_keys.js:66 static/js/zamboni/stats-all.js:15346 static/js/zamboni/stats-all.js:15347 static/js/zamboni/stats-min.js:4
 msgid "Others By Author"
 msgstr "Ostatní aplikace autora"
 
-#: static/js/impala/stats/csv_keys.js:67 static/js/impala/stats/csv_keys.js:68
+#: static/js/impala/stats/csv_keys.js:67 static/js/impala/stats/csv_keys.js:68 static/js/zamboni/stats-all.js:15348 static/js/zamboni/stats-all.js:15349 static/js/zamboni/stats-min.js:4
 msgid "Dependencies"
 msgstr "Závislosti"
 
-#: static/js/impala/stats/csv_keys.js:69 static/js/impala/stats/csv_keys.js:70
+#: static/js/impala/stats/csv_keys.js:69 static/js/impala/stats/csv_keys.js:70 static/js/zamboni/stats-all.js:15350 static/js/zamboni/stats-all.js:15351 static/js/zamboni/stats-min.js:4
 msgid "Upsell"
 msgstr "Přechod na placenou variantu"
 
-#: static/js/impala/stats/csv_keys.js:71
+#: static/js/impala/stats/csv_keys.js:71 static/js/zamboni/stats-all.js:15352 static/js/zamboni/stats-min.js:4
 msgid "Meet the Developer"
 msgstr "Poznejte vývojáře"
 
-#: static/js/impala/stats/csv_keys.js:72
+#: static/js/impala/stats/csv_keys.js:72 static/js/zamboni/stats-all.js:15353 static/js/zamboni/stats-min.js:4
 msgid "User Profile"
 msgstr "Profil uživatele"
 
-#: static/js/impala/stats/csv_keys.js:73
+#: static/js/impala/stats/csv_keys.js:73 static/js/zamboni/stats-all.js:15354 static/js/zamboni/stats-min.js:4
 msgid "Version History"
 msgstr "Historie verzí"
 
-#: static/js/impala/stats/csv_keys.js:75
+#: static/js/impala/stats/csv_keys.js:75 static/js/zamboni/stats-all.js:15356 static/js/zamboni/stats-min.js:4
 msgid "Sharing"
 msgstr "Sdílení"
 
-#: static/js/impala/stats/csv_keys.js:76
+#: static/js/impala/stats/csv_keys.js:76 static/js/zamboni/stats-all.js:15357 static/js/zamboni/stats-min.js:4
 msgid "Category Pages"
 msgstr "Stránky kategorií"
 
-#: static/js/impala/stats/csv_keys.js:77
+#: static/js/impala/stats/csv_keys.js:77 static/js/zamboni/stats-all.js:15358 static/js/zamboni/stats-min.js:4
 msgid "Collections"
 msgstr "Sbírky"
 
-#: static/js/impala/stats/csv_keys.js:78 static/js/impala/stats/csv_keys.js:79
+#: static/js/impala/stats/csv_keys.js:78 static/js/impala/stats/csv_keys.js:79 static/js/zamboni/stats-all.js:15359 static/js/zamboni/stats-all.js:15360 static/js/zamboni/stats-min.js:4
 msgid "Category Landing Featured Carousel"
 msgstr "Kategorie s doporučenými doplňky"
 
-#: static/js/impala/stats/csv_keys.js:80 static/js/impala/stats/csv_keys.js:81
+#: static/js/impala/stats/csv_keys.js:80 static/js/impala/stats/csv_keys.js:81 static/js/zamboni/stats-all.js:15361 static/js/zamboni/stats-all.js:15362 static/js/zamboni/stats-min.js:4
 msgid "Category Landing Top Rated"
 msgstr "Kategorie nejlépe hodnocených"
 
-#: static/js/impala/stats/csv_keys.js:82 static/js/impala/stats/csv_keys.js:83
+#: static/js/impala/stats/csv_keys.js:82 static/js/impala/stats/csv_keys.js:83 static/js/zamboni/stats-all.js:15363 static/js/zamboni/stats-all.js:15364 static/js/zamboni/stats-min.js:5
 msgid "Category Landing Most Popular"
 msgstr "Kategorie nejvíce populárních"
 
-#: static/js/impala/stats/csv_keys.js:84 static/js/impala/stats/csv_keys.js:85
+#: static/js/impala/stats/csv_keys.js:84 static/js/impala/stats/csv_keys.js:85 static/js/zamboni/stats-all.js:15365 static/js/zamboni/stats-all.js:15366 static/js/zamboni/stats-min.js:5
 msgid "Category Landing Recently Added"
 msgstr "Kategorie naposledy přidaných"
 
-#: static/js/impala/stats/csv_keys.js:86 static/js/impala/stats/csv_keys.js:87
+#: static/js/impala/stats/csv_keys.js:86 static/js/impala/stats/csv_keys.js:87 static/js/zamboni/stats-all.js:15367 static/js/zamboni/stats-all.js:15368 static/js/zamboni/stats-min.js:5
 msgid "Browse Listing Featured Sort"
 msgstr "Seznam doplňků dle oblíbenosti"
 
-#: static/js/impala/stats/csv_keys.js:88 static/js/impala/stats/csv_keys.js:89
+#: static/js/impala/stats/csv_keys.js:88 static/js/impala/stats/csv_keys.js:89 static/js/zamboni/stats-all.js:15369 static/js/zamboni/stats-all.js:15370 static/js/zamboni/stats-min.js:5
 msgid "Browse Listing Users Sort"
 msgstr "Seznam doplňků dle počtu uživatelů"
 
-#: static/js/impala/stats/csv_keys.js:90 static/js/impala/stats/csv_keys.js:91
+#: static/js/impala/stats/csv_keys.js:90 static/js/impala/stats/csv_keys.js:91 static/js/zamboni/stats-all.js:15371 static/js/zamboni/stats-all.js:15372 static/js/zamboni/stats-min.js:5
 msgid "Browse Listing Rating Sort"
 msgstr "Seznam doplňků dle hodnocení"
 
-#: static/js/impala/stats/csv_keys.js:92 static/js/impala/stats/csv_keys.js:93
+#: static/js/impala/stats/csv_keys.js:92 static/js/impala/stats/csv_keys.js:93 static/js/zamboni/stats-all.js:15373 static/js/zamboni/stats-all.js:15374 static/js/zamboni/stats-min.js:5
 msgid "Browse Listing Created Sort"
 msgstr "Seznam doplňků dle data vytvoření"
 
-#: static/js/impala/stats/csv_keys.js:94 static/js/impala/stats/csv_keys.js:95
+#: static/js/impala/stats/csv_keys.js:94 static/js/impala/stats/csv_keys.js:95 static/js/zamboni/stats-all.js:15375 static/js/zamboni/stats-all.js:15376 static/js/zamboni/stats-min.js:5
 msgid "Browse Listing Name Sort"
 msgstr "Seznam doplňků dle jména"
 
-#: static/js/impala/stats/csv_keys.js:96 static/js/impala/stats/csv_keys.js:97
+#: static/js/impala/stats/csv_keys.js:96 static/js/impala/stats/csv_keys.js:97 static/js/zamboni/stats-all.js:15377 static/js/zamboni/stats-all.js:15378 static/js/zamboni/stats-min.js:5
 msgid "Browse Listing Popular Sort"
 msgstr "Seznam doplňků dle popularity"
 
-#: static/js/impala/stats/csv_keys.js:98 static/js/impala/stats/csv_keys.js:99
+#: static/js/impala/stats/csv_keys.js:98 static/js/impala/stats/csv_keys.js:99 static/js/zamboni/stats-all.js:15379 static/js/zamboni/stats-all.js:15380 static/js/zamboni/stats-min.js:5
 msgid "Browse Listing Updated Sort"
 msgstr "Seznam doplňků dle data aktualizace"
 
-#: static/js/impala/stats/csv_keys.js:100
-#: static/js/impala/stats/csv_keys.js:101
+#: static/js/impala/stats/csv_keys.js:100 static/js/impala/stats/csv_keys.js:101 static/js/zamboni/stats-all.js:15381 static/js/zamboni/stats-all.js:15382 static/js/zamboni/stats-min.js:5
 msgid "Browse Listing Up and Coming Sort"
 msgstr "Seznam doplňků dle žádanosti"
 
-#: static/js/impala/stats/csv_keys.js:105
+#: static/js/impala/stats/csv_keys.js:105 static/js/zamboni/stats-all.js:15386 static/js/zamboni/stats-min.js:5
 msgid "Total Amount Contributed"
 msgstr "Celkově přispěno"
 
-#: static/js/impala/stats/csv_keys.js:106
+#: static/js/impala/stats/csv_keys.js:106 static/js/zamboni/stats-all.js:15387 static/js/zamboni/stats-min.js:5
 msgid "Average Contribution"
 msgstr "Průměrný příspěvek"
 
-#: static/js/impala/stats/csv_keys.js:115
+#: static/js/impala/stats/csv_keys.js:115 static/js/zamboni/stats-all.js:15396 static/js/zamboni/stats-min.js:5
 msgid "Usage"
 msgstr "Používání"
 
-#: static/js/impala/stats/csv_keys.js:118
+#: static/js/impala/stats/csv_keys.js:118 static/js/zamboni/stats-all.js:15399 static/js/zamboni/stats-min.js:5
 msgid "Firefox"
 msgstr "Firefox"
 
-#: static/js/impala/stats/csv_keys.js:119
+#: static/js/impala/stats/csv_keys.js:119 static/js/zamboni/stats-all.js:15400 static/js/zamboni/stats-min.js:5
 msgid "Mozilla"
 msgstr "Mozilla"
 
-#: static/js/impala/stats/csv_keys.js:120
+#: static/js/impala/stats/csv_keys.js:120 static/js/zamboni/stats-all.js:15401 static/js/zamboni/stats-min.js:5
 msgid "Thunderbird"
 msgstr "Thunderbird"
 
-#: static/js/impala/stats/csv_keys.js:121
+#: static/js/impala/stats/csv_keys.js:121 static/js/zamboni/stats-all.js:15402 static/js/zamboni/stats-min.js:5
 msgid "Sunbird"
 msgstr "Sunbird"
 
-#: static/js/impala/stats/csv_keys.js:122
+#: static/js/impala/stats/csv_keys.js:122 static/js/zamboni/stats-all.js:15403 static/js/zamboni/stats-min.js:5
 msgid "SeaMonkey"
 msgstr "SeaMonkey"
 
-#: static/js/impala/stats/csv_keys.js:123
+#: static/js/impala/stats/csv_keys.js:123 static/js/zamboni/stats-all.js:15404 static/js/zamboni/stats-min.js:5
 msgid "Fennec"
 msgstr "Fennec"
 
-#: static/js/impala/stats/csv_keys.js:124
+#: static/js/impala/stats/csv_keys.js:124 static/js/zamboni/stats-all.js:15405 static/js/zamboni/stats-min.js:5
 msgid "Android"
 msgstr "Android"
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:129
+#: static/js/impala/stats/csv_keys.js:129 static/js/zamboni/stats-all.js:15410 static/js/zamboni/stats-min.js:5
 msgid "Downloads and Daily Users, last {0} days"
 msgstr "Stažení a denní uživatelé, posledních {0} dní"
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:131
+#: static/js/impala/stats/csv_keys.js:131 static/js/zamboni/stats-all.js:15412 static/js/zamboni/stats-min.js:5
 msgid "Downloads and Daily Users from {0} to {1}"
 msgstr "Počty stažení a denní uživatelé od {0} do {1}"
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:135
+#: static/js/impala/stats/csv_keys.js:135 static/js/zamboni/stats-all.js:15416 static/js/zamboni/stats-min.js:5
 msgid "Installs and Daily Users, last {0} days"
 msgstr "Instalace a denní uživatelé, posledních {0} dní"
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:137
+#: static/js/impala/stats/csv_keys.js:137 static/js/zamboni/stats-all.js:15418 static/js/zamboni/stats-min.js:5
 msgid "Installs and Daily Users from {0} to {1}"
 msgstr "Instalace a denní uživatelé od {0} do {1}"
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:141
+#: static/js/impala/stats/csv_keys.js:141 static/js/zamboni/stats-all.js:15422 static/js/zamboni/stats-min.js:5
 msgid "Downloads, last {0} days"
 msgstr "Stažení, posledních {0} dní"
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:143
+#: static/js/impala/stats/csv_keys.js:143 static/js/zamboni/stats-all.js:15424 static/js/zamboni/stats-min.js:5
 msgid "Downloads from {0} to {1}"
 msgstr "Počty stažení od {0} do {1}"
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:147
+#: static/js/impala/stats/csv_keys.js:147 static/js/zamboni/stats-all.js:15428 static/js/zamboni/stats-min.js:5
 msgid "Daily Users, last {0} days"
 msgstr "Denní uživatelé, posledních {0} dní"
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:149
+#: static/js/impala/stats/csv_keys.js:149 static/js/zamboni/stats-all.js:15430 static/js/zamboni/stats-min.js:5
 msgid "Daily Users from {0} to {1}"
 msgstr "Denní uživatelé od {0} do {1}"
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:153
+#: static/js/impala/stats/csv_keys.js:153 static/js/zamboni/stats-all.js:15434 static/js/zamboni/stats-min.js:5
 msgid "Applications, last {0} days"
 msgstr "Aplikace, poslední {0} dní"
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:155
+#: static/js/impala/stats/csv_keys.js:155 static/js/zamboni/stats-all.js:15436 static/js/zamboni/stats-min.js:5
 msgid "Applications from {0} to {1}"
 msgstr "Aplikace od {0} do {1}"
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:159
+#: static/js/impala/stats/csv_keys.js:159 static/js/zamboni/stats-all.js:15440 static/js/zamboni/stats-min.js:5
 msgid "Platforms, last {0} days"
 msgstr "Platformy, posledních {0} dní"
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:161
+#: static/js/impala/stats/csv_keys.js:161 static/js/zamboni/stats-all.js:15442 static/js/zamboni/stats-min.js:5
 msgid "Platforms from {0} to {1}"
 msgstr "Platformy od {0} do {1}"
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:165
+#: static/js/impala/stats/csv_keys.js:165 static/js/zamboni/stats-all.js:15446 static/js/zamboni/stats-min.js:5
 msgid "Languages, last {0} days"
 msgstr "Jazyky, poslední {0} dní"
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:167
+#: static/js/impala/stats/csv_keys.js:167 static/js/zamboni/stats-all.js:15448 static/js/zamboni/stats-min.js:5
 msgid "Languages from {0} to {1}"
 msgstr "Jazyky od {0} do {1}"
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:171
+#: static/js/impala/stats/csv_keys.js:171 static/js/zamboni/stats-all.js:15452 static/js/zamboni/stats-min.js:5
 msgid "Add-on Versions, last {0} days"
 msgstr "Verze doplňku, posledních {0} dní"
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:173
+#: static/js/impala/stats/csv_keys.js:173 static/js/zamboni/stats-all.js:15454 static/js/zamboni/stats-min.js:5
 msgid "Add-on Versions from {0} to {1}"
 msgstr "Verze doplňku od {0} do {1}"
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:177
+#: static/js/impala/stats/csv_keys.js:177 static/js/zamboni/stats-all.js:15458 static/js/zamboni/stats-min.js:5
 msgid "Add-on Status, last {0} days"
 msgstr "Stav doplňku, posledních {0} dní"
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:179
+#: static/js/impala/stats/csv_keys.js:179 static/js/zamboni/stats-all.js:15460 static/js/zamboni/stats-min.js:5
 msgid "Add-on Status from {0} to {1}"
 msgstr "Stav doplňku od {0} do {1}"
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:183
+#: static/js/impala/stats/csv_keys.js:183 static/js/zamboni/stats-all.js:15464 static/js/zamboni/stats-min.js:5
 msgid "Download Sources, last {0} days"
 msgstr "Zdroje stažení, posledních {0} dní"
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:185
+#: static/js/impala/stats/csv_keys.js:185 static/js/zamboni/stats-all.js:15466 static/js/zamboni/stats-min.js:5
 msgid "Download Sources from {0} to {1}"
 msgstr "Zdroje stažení od {0} do {1}"
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:189
+#: static/js/impala/stats/csv_keys.js:189 static/js/zamboni/stats-all.js:15470 static/js/zamboni/stats-min.js:5
 msgid "Contributions, last {0} days"
 msgstr "Příspěvky, posledních {0} dní"
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:191
+#: static/js/impala/stats/csv_keys.js:191 static/js/zamboni/stats-all.js:15472 static/js/zamboni/stats-min.js:5
 msgid "Contributions from {0} to {1}"
 msgstr "Přispěvatelé od {0} do {1}"
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:195
+#: static/js/impala/stats/csv_keys.js:195 static/js/zamboni/stats-all.js:15476 static/js/zamboni/stats-min.js:5
 msgid "Site Metrics, last {0} days"
 msgstr "Statistika webu, posledních {0} dní"
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:197
+#: static/js/impala/stats/csv_keys.js:197 static/js/zamboni/stats-all.js:15478 static/js/zamboni/stats-min.js:5
 msgid "Site Metrics from {0} to {1}"
 msgstr "Statistika webu od {0} do {1}"
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:201
+#: static/js/impala/stats/csv_keys.js:201 static/js/zamboni/stats-all.js:15482 static/js/zamboni/stats-min.js:5
 msgid "Add-ons in Use, last {0} days"
 msgstr "Používané doplňky, posledních {0} dní"
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:203
+#: static/js/impala/stats/csv_keys.js:203 static/js/zamboni/stats-all.js:15484 static/js/zamboni/stats-min.js:5
 msgid "Add-ons in Use from {0} to {1}"
 msgstr "Používané doplňky od {0} do {1}"
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:207
+#: static/js/impala/stats/csv_keys.js:207 static/js/zamboni/stats-all.js:15488 static/js/zamboni/stats-min.js:5
 msgid "Add-ons Downloaded, last {0} days"
 msgstr "Stažené doplňky, posledních {0} dní"
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:209
+#: static/js/impala/stats/csv_keys.js:209 static/js/zamboni/stats-all.js:15490 static/js/zamboni/stats-min.js:5
 msgid "Add-ons Downloaded from {0} to {1}"
 msgstr "Stažené doplňky od {0} do {1}"
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:213
+#: static/js/impala/stats/csv_keys.js:213 static/js/zamboni/stats-all.js:15494 static/js/zamboni/stats-min.js:5
 msgid "Add-ons Created, last {0} days"
 msgstr "Vytvořené doplňky, posledních {0} dní"
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:215
+#: static/js/impala/stats/csv_keys.js:215 static/js/zamboni/stats-all.js:15496 static/js/zamboni/stats-min.js:5
 msgid "Add-ons Created from {0} to {1}"
 msgstr "Doplňky vytvořené od {0} do {1}"
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:219
+#: static/js/impala/stats/csv_keys.js:219 static/js/zamboni/stats-all.js:15500 static/js/zamboni/stats-min.js:5
 msgid "Add-ons Updated, last {0} days"
 msgstr "Aktualizované doplňky, posledních {0} dní"
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:221
+#: static/js/impala/stats/csv_keys.js:221 static/js/zamboni/stats-all.js:15502 static/js/zamboni/stats-min.js:5
 msgid "Add-ons Updated from {0} to {1}"
 msgstr "Aktualizované doplňk od {0} do {1}"
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:225
+#: static/js/impala/stats/csv_keys.js:225 static/js/zamboni/stats-all.js:15506 static/js/zamboni/stats-min.js:5
 msgid "Reviews Written, last {0} days"
 msgstr "Napsané recenze, posledních {0} dní"
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:227
+#: static/js/impala/stats/csv_keys.js:227 static/js/zamboni/stats-all.js:15508 static/js/zamboni/stats-min.js:5
 msgid "Reviews Written from {0} to {1}"
 msgstr "Napsané recenze od {0} do {1}"
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:231
+#: static/js/impala/stats/csv_keys.js:231 static/js/zamboni/stats-all.js:15512 static/js/zamboni/stats-min.js:5
 msgid "User Signups, last {0} days"
 msgstr "Přihlášení uživatele, poseldních {0} dní"
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:233
+#: static/js/impala/stats/csv_keys.js:233 static/js/zamboni/stats-all.js:15514 static/js/zamboni/stats-min.js:5
 msgid "User Signups from {0} to {1}"
 msgstr "Přihlášení uživatele od {0} do {1}"
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:237
+#: static/js/impala/stats/csv_keys.js:237 static/js/zamboni/stats-all.js:15518 static/js/zamboni/stats-min.js:5
 msgid "Collections Created, last {0} days"
 msgstr "Vytvořené sbírky, posledních {0} dní"
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:239
+#: static/js/impala/stats/csv_keys.js:239 static/js/zamboni/stats-all.js:15520 static/js/zamboni/stats-min.js:5
 msgid "Collections Created from {0} to {1}"
 msgstr "Vytvořené sbírky od {0} do {1}"
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:243
+#: static/js/impala/stats/csv_keys.js:243 static/js/zamboni/stats-all.js:15524 static/js/zamboni/stats-min.js:5
 msgid "Subscribers, last {0} days"
 msgstr "Odběry, posledních {0} dní"
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:245
+#: static/js/impala/stats/csv_keys.js:245 static/js/zamboni/stats-all.js:15526 static/js/zamboni/stats-min.js:5
 msgid "Subscribers from {0} to {1}"
 msgstr "Odběry od {0} do {1}"
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:249
+#: static/js/impala/stats/csv_keys.js:249 static/js/zamboni/stats-all.js:15530 static/js/zamboni/stats-min.js:5
 msgid "Ratings, last {0} days"
 msgstr "Hodnocení, posledních {0} dní"
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:251
+#: static/js/impala/stats/csv_keys.js:251 static/js/zamboni/stats-all.js:15532 static/js/zamboni/stats-min.js:5
 msgid "Ratings from {0} to {1}"
 msgstr "Hodnocení od {0} do {1}"
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:255
+#: static/js/impala/stats/csv_keys.js:255 static/js/zamboni/stats-all.js:15536 static/js/zamboni/stats-min.js:5
 msgid "Sales, last {0} days"
 msgstr "Prodeje, posledních {0} dní"
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:257
+#: static/js/impala/stats/csv_keys.js:257 static/js/zamboni/stats-all.js:15538 static/js/zamboni/stats-min.js:5
 msgid "Sales from {0} to {1}"
 msgstr "Prodeje od {0} do {1}"
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:261
+#: static/js/impala/stats/csv_keys.js:261 static/js/zamboni/stats-all.js:15542 static/js/zamboni/stats-min.js:5
 msgid "Installs, last {0} days"
 msgstr "Instalace, posledních {0} dní"
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:263
+#: static/js/impala/stats/csv_keys.js:263 static/js/zamboni/stats-all.js:15544 static/js/zamboni/stats-min.js:5
 msgid "Installs from {0} to {1}"
 msgstr "Instalace od {0} do {1}"
 
 #. L10n: {0} and {1} are integers.
-#: static/js/impala/stats/csv_keys.js:269
+#: static/js/impala/stats/csv_keys.js:269 static/js/zamboni/stats-all.js:15550 static/js/zamboni/stats-min.js:5
 msgid "<b>{0}</b> in last {1} days"
 msgstr "<b>{0}</b> v posledních {1} dnech"
 
 #. L10n: {0} is an integer and {1} and {2} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:271
-#: static/js/impala/stats/csv_keys.js:277
+#: static/js/impala/stats/csv_keys.js:271 static/js/impala/stats/csv_keys.js:277 static/js/zamboni/stats-all.js:15552 static/js/zamboni/stats-all.js:15558 static/js/zamboni/stats-min.js:5
 msgid "<b>{0}</b> from {1} to {2}"
 msgstr "<b>{0}</b> od {1} do {2}"
 
 #. L10n: {0} and {1} are integers.
-#: static/js/impala/stats/csv_keys.js:275
+#: static/js/impala/stats/csv_keys.js:275 static/js/zamboni/stats-all.js:15556 static/js/zamboni/stats-min.js:5
 msgid "<b>{0}</b> average in last {1} days"
 msgstr "průměrně <b>{0}</b> v posledních {1} dnech"
 
-#: static/js/impala/stats/overview.js:19
+#: static/js/impala/stats/overview.js:19 static/js/zamboni/stats-all.js:16469 static/js/zamboni/stats-min.js:5
 msgid "No data available."
 msgstr "Data nejsou dostupná."
 
-#: static/js/impala/stats/table.js:74
+#: static/js/impala/stats/table.js:74 static/js/zamboni/stats-all.js:17209 static/js/zamboni/stats-min.js:5
 msgid "Date"
 msgstr "Datum"
 
-#: static/js/impala/stats/topchart.js:96
+#: static/js/impala/stats/topchart.js:96 static/js/zamboni/stats-all.js:16600 static/js/zamboni/stats-min.js:5
 msgid "Other"
 msgstr "Jiné"
 
-#: static/js/zamboni/admin_validation.js:24 static/js/zamboni/devhub.js:1229
-#: static/js/zamboni/editors.js:295
+#: static/js/zamboni/admin-all.js:180 static/js/zamboni/admin-min.js:1 static/js/zamboni/admin_validation.js:24 static/js/zamboni/devhub-all.js:2408 static/js/zamboni/devhub-min.js:2
+#: static/js/zamboni/devhub.js:1229 static/js/zamboni/editors-all.js:15576 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:295
 msgid "Select an application first"
 msgstr "Prvně zvolte aplikaci"
 
-#: static/js/zamboni/admin_validation.js:51
+#: static/js/zamboni/admin-all.js:207 static/js/zamboni/admin-min.js:1 static/js/zamboni/admin_validation.js:51
 msgid "Set {0} add-on to a max version of {1} and email the author."
 msgid_plural "Set {0} add-ons to a max version of {1} and email the authors."
-msgstr[0] ""
-"Nastavit u {0} doplňku podporu pro maximální verzi aplikace {1} a poslat "
-"e-mail autorovi."
-msgstr[1] ""
-"Nastavit u {0} doplňků podporu pro maximální verzi aplikace {1} a poslat "
-"e-mail autorům."
-msgstr[2] ""
-"Nastavit u {0} doplňků podporu pro maximální verzi aplikace {1} a poslat "
-"e-mail autorům."
+msgstr[0] "Nastavit u {0} doplňku podporu pro maximální verzi aplikace {1} a poslat e-mail autorovi."
+msgstr[1] "Nastavit u {0} doplňků podporu pro maximální verzi aplikace {1} a poslat e-mail autorům."
 
-#: static/js/zamboni/admin_validation.js:54
+#: static/js/zamboni/admin-all.js:210 static/js/zamboni/admin-min.js:1 static/js/zamboni/admin_validation.js:54
 msgid "Email author of {2} add-on which failed validation."
 msgid_plural "Email authors of {2} add-ons which failed validation."
 msgstr[0] "Poslat e-mail autorovi {2} doplňku, u kterého selhala kontrola."
 msgstr[1] "Poslat e-mail autorům {2} doplňků, u kterých selhala kontrola."
-msgstr[2] "Poslat e-mail autorům {2} doplňků, u kterých selhala kontrola."
 
-#. L10n: {0} is an app name like Firefox.
-#: static/js/zamboni/buttons.js:66
-msgid "Accept and Install"
-msgstr "Souhlasím a instalovat"
-
-#: static/js/zamboni/buttons.js:66
-msgid "Add to {0}"
-msgstr "Přidat do aplikace {0}"
-
-#: static/js/zamboni/buttons.js:71
-msgid "Download Now"
-msgstr "Stáhnout"
-
-#: static/js/zamboni/buttons.js:112
-msgid "Add-on has not been updated to support default-to-compatible."
-msgstr ""
-"Doplněk nebyl aktualizován tak, aby byl ve výchozím nastavení kompatibilní."
-
-#: static/js/zamboni/buttons.js:117
-msgid "You need to be using Firefox 10.0 or higher."
-msgstr "Je potřeba, abyste používali Firefox 10.0 či vyšší."
-
-#: static/js/zamboni/buttons.js:129
-msgid ""
-"Mozilla has marked this version as incompatible with your Firefox version."
-msgstr ""
-"Mozilla označila tuto verzi jako nekompatibilní s vaší verzí Firefoxu."
-
-#. L10n: {0} is an platform like Windows or Linux.
-#: static/js/zamboni/buttons.js:210
-msgid "Install for {0} anyway"
-msgstr "Přesto nainstalovat do aplikace {0}"
-
-#: static/js/zamboni/buttons.js:210
-msgid "Download for {0} anyway"
-msgstr "Přesto stáhnout pro aplikaci {0}"
-
-#: static/js/zamboni/buttons.js:267
-msgid "Not available for your platform"
-msgstr "Není dostupné pro vaši platformu"
-
-#. L10n: {0} is an app name, {1} is the app version.
-#: static/js/zamboni/buttons.js:278 static/js/zamboni/buttons.js:315
-msgid "Not available for {0} {1}"
-msgstr "Není dostupné pro {0} {1}"
-
-#: static/js/zamboni/buttons.js:341
-msgid "Works with {app} {min} - {max}"
-msgstr "Funguje s aplikací {app} {min} - {max}"
-
-#: static/js/zamboni/buttons.js:343
-msgid "View other versions"
-msgstr "Zobrazit ostatní verze"
-
-#: static/js/zamboni/buttons.js:391
-msgid "Only with Firefox — Get Firefox Now!"
-msgstr "Pouze pro Firefox — získejte Firefox nyní!"
-
-#: static/js/zamboni/buttons.js:507 static/js/zamboni/mobile/buttons.js:43
-msgid ""
-"Sorry, you need a Mozilla-based browser (such as Firefox) to install a "
-"search plugin."
-msgstr ""
-"Omlouváme se, ale pro instalaci vyhledávacího modulu potřebujete prohlížeč "
-"postavený na Mozille (jako například Firefox)."
-
-#: static/js/zamboni/collections.js:229
-msgid "Adding to Favorites&hellip;"
-msgstr "Přidání k oblíbeným&hellip;"
-
-#: static/js/zamboni/collections.js:232
-msgid "Removing Favorite&hellip;"
-msgstr "Odebrání z oblíbených&hellip;"
-
-#: static/js/zamboni/collections.js:235
-msgid "Add to Favorites"
-msgstr "Přidat k oblíbeným"
-
-#: static/js/zamboni/collections.js:238
-msgid "Remove from Favorites"
-msgstr "Odebrat z oblíbených"
-
-#: static/js/zamboni/collections.js:303
-msgid "Pending"
-msgstr "Čekající"
-
-#: static/js/zamboni/collections.js:304
-msgid "Add a comment"
-msgstr "Přidat komentář"
-
-#: static/js/zamboni/collections.js:304
-msgid "Comment"
-msgstr "Komentář"
-
-#: static/js/zamboni/collections.js:305
-msgid "Remove this add-on from the collection"
-msgstr "Odebrat tento doplněk z kolekce"
-
-#: static/js/zamboni/collections.js:305 static/js/zamboni/collections.js:334
-msgid "Remove"
-msgstr "Odebrat"
-
-#: static/js/zamboni/collections.js:334
-msgid "Remove this user as a contributor"
-msgstr "Odebrat tohoto uživatele z přispěvatelů"
-
-#: static/js/zamboni/collections.js:346
-msgid "An email address is required."
-msgstr "E-mailová adresa je vyžadována."
-
-#: static/js/zamboni/collections.js:364
-msgid "You cannot add yourself as a contributor."
-msgstr "Nemůžete jako přispěvatele přidat sami sebe."
-
-#: static/js/zamboni/collections.js:366
-msgid "You have already added that user."
-msgstr "Již jste tohoto uživatele přidali."
-
-#: static/js/zamboni/collections.js:573
-msgid "Add to favorites"
-msgstr "Přidat k oblíbeným"
-
-#: static/js/zamboni/collections.js:577
-msgid "Remove from favorites"
-msgstr "Odebrat z oblíbených"
-
-#: static/js/zamboni/collections.js:604
-msgid "Stop following"
-msgstr "Ukončit sledování"
-
-#: static/js/zamboni/devhub.js:110
+#: static/js/zamboni/devhub-all.js:1289 static/js/zamboni/devhub-min.js:1 static/js/zamboni/devhub.js:110
 msgid "Your browser does not support the video tag"
 msgstr "Váš prohlížeč nepodporuje značku video"
 
-#: static/js/zamboni/devhub.js:371
+#: static/js/zamboni/devhub-all.js:1550 static/js/zamboni/devhub-min.js:1 static/js/zamboni/devhub.js:371
 msgid "Changes Saved"
 msgstr "Změny uloženy"
 
-#: static/js/zamboni/devhub.js:387
+#: static/js/zamboni/devhub-all.js:1566 static/js/zamboni/devhub-min.js:1 static/js/zamboni/devhub.js:387
 msgid "Enter a new author's email address"
 msgstr "Vložte novou e-mailovou adresu autora"
 
-#: static/js/zamboni/devhub.js:536
+#: static/js/zamboni/devhub-all.js:1715 static/js/zamboni/devhub-min.js:1 static/js/zamboni/devhub.js:536
 msgid "There was an error uploading your file."
 msgstr "Při nahrávání vašeho souboru se vyskytl problém."
 
-#: static/js/zamboni/devhub.js:681
+#: static/js/zamboni/devhub-all.js:1860 static/js/zamboni/devhub-min.js:1 static/js/zamboni/devhub.js:681
 msgid "{files} file"
 msgid_plural "{files} files"
 msgstr[0] "{files} soubor"
 msgstr[1] "{files} soubory"
-msgstr[2] "{files} souborů"
 
-#: static/js/zamboni/devhub.js:684
+#: static/js/zamboni/devhub-all.js:1863 static/js/zamboni/devhub-min.js:1 static/js/zamboni/devhub.js:684
 msgid "{reviews} user review"
 msgid_plural "{reviews} user reviews"
 msgstr[0] "{reviews} recenze uživatele"
 msgstr[1] "{reviews} recenze uživatele"
-msgstr[2] "{reviews} recenzí uživatele"
 
-#: static/js/zamboni/devhub.js:796
+#: static/js/zamboni/devhub-all.js:1975 static/js/zamboni/devhub-min.js:2 static/js/zamboni/devhub.js:796
 msgid "Learn more"
 msgstr "Dozvědět se více"
 
-#: static/js/zamboni/devhub.js:800
+#: static/js/zamboni/devhub-all.js:1979 static/js/zamboni/devhub-min.js:2 static/js/zamboni/devhub.js:800
 msgid "Example"
 msgstr "Příklad"
 
-#: static/js/zamboni/devhub.js:1130
+#: static/js/zamboni/devhub-all.js:2309 static/js/zamboni/devhub-min.js:2 static/js/zamboni/devhub.js:1130
 msgid "Image changes being processed"
 msgstr "Jsou prováděny změny obrázku"
 
-#: static/js/zamboni/devhub.js:1280
+#: static/js/zamboni/devhub-all.js:2459 static/js/zamboni/devhub-min.js:2 static/js/zamboni/devhub.js:1280
 msgid "Must be a valid e-mail address."
 msgstr "Musí se jednat o platnou e-mailovou adresu."
+
+#: static/js/zamboni/devhub-all.js:2613 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:80
+msgid "All tests passed successfully."
+msgstr "Všechny testy prošly úspěšně."
+
+#: static/js/zamboni/devhub-all.js:2616 static/js/zamboni/devhub-all.js:3011 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:83 static/js/zamboni/validator.js:478
+msgid "These tests were not run."
+msgstr "Testy nebyly spuštěny."
+
+#: static/js/zamboni/devhub-all.js:2664 static/js/zamboni/devhub-all.js:2677 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:131 static/js/zamboni/validator.js:144
+msgid "Tests"
+msgstr "Testy"
+
+#: static/js/zamboni/devhub-all.js:2779 static/js/zamboni/devhub-all.js:3108 static/js/zamboni/devhub-all.js:3127 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:246
+#: static/js/zamboni/validator.js:575 static/js/zamboni/validator.js:594
+msgid "Error"
+msgstr "Chyba"
+
+#: static/js/zamboni/devhub-all.js:2780 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:247
+msgid "Warning"
+msgstr "Varování"
+
+#: static/js/zamboni/devhub-all.js:2794 static/js/zamboni/devhub-min.js:2 static/js/zamboni/files-all.js:5657 static/js/zamboni/files-min.js:3 static/js/zamboni/files.js:411
+#: static/js/zamboni/validator.js:261
+msgid "Ignore this message in future updates"
+msgstr "Ignorovat tuto zprávu při budoucích aktualizacích"
+
+#: static/js/zamboni/devhub-all.js:2817 static/js/zamboni/devhub-min.js:2 static/js/zamboni/files-all.js:5663 static/js/zamboni/files-min.js:3 static/js/zamboni/files.js:417
+#: static/js/zamboni/validator.js:284
+msgid "Severity for automated signing:"
+msgstr "Závažnost pro automatické podepisování:"
+
+#: static/js/zamboni/devhub-all.js:2832 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:299
+msgid "Suggestions for passing automated signing:"
+msgstr "Doporučení k úspěšnému dokončení automatického podepsání:"
+
+#: static/js/zamboni/devhub-all.js:2920 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:387
+msgid "Compatibility Tests"
+msgstr "Testy kompatibility"
+
+#: static/js/zamboni/devhub-all.js:2999 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:466
+msgid "Add-on failed validation."
+msgstr "Doplněk prošel kontrolou s chybami."
+
+#: static/js/zamboni/devhub-all.js:3001 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:468
+msgid "Add-on passed validation."
+msgstr "Doplněk úspěšně prošel kontrolou."
+
+#: static/js/zamboni/devhub-all.js:3014 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:481
+msgid "{0} error"
+msgid_plural "{0} errors"
+msgstr[0] "{0} chyba"
+msgstr[1] "{0} chyby"
+
+#: static/js/zamboni/devhub-all.js:3016 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:483
+msgid "{0} warning"
+msgid_plural "{0} warnings"
+msgstr[0] "{0} varování"
+msgstr[1] "{0} varování"
+
+#: static/js/zamboni/devhub-all.js:3018 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:485
+msgid "{0} notice"
+msgid_plural "{0} notices"
+msgstr[0] "{0} upozornění"
+msgstr[1] "{0} upozornění"
+
+#: static/js/zamboni/devhub-all.js:3110 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:577
+msgid "Validation task could not complete or completed with errors"
+msgstr "Proces kontroly nemohl být dokončen nebo skončil s chybami"
+
+#: static/js/zamboni/devhub-all.js:3128 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:595
+msgid "Internal server error"
+msgstr "Interní chyba serveru"
 
 #: static/js/zamboni/devhub_search.js:8
 msgid "No results found."
 msgstr "Nebyly nalezeny žádné výsledky."
 
-#: static/js/zamboni/editors.js:121
+#: static/js/zamboni/editors-all.js:15402 static/js/zamboni/editors-min.js:4 static/js/zamboni/editors.js:121
 msgid "{name} was viewing this page first."
 msgstr "Uživatel {name} shlédl tuto stránku jako první."
 
-#: static/js/zamboni/editors.js:171
+#: static/js/zamboni/editors-all.js:15452 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:171
 msgid "Receipt checked by app."
 msgstr "Potvrzení bylo aplikací zkontrolováno."
 
-#: static/js/zamboni/editors.js:173
+#: static/js/zamboni/editors-all.js:15454 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:173
 msgid "Receipt was not checked by app."
 msgstr "Potvrzení nebylo aplikací zkontrolováno."
 
-#: static/js/zamboni/editors.js:244
+#: static/js/zamboni/editors-all.js:15525 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:244
 msgid "{name} was viewing this add-on first."
 msgstr "{name} prohlédl tento doplněk jako první."
 
-#: static/js/zamboni/editors.js:255
+#: static/js/zamboni/editors-all.js:15536 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:255
 msgid "Loading&hellip;"
 msgstr "Načítání&hellip;"
 
-#: static/js/zamboni/editors.js:260
+#: static/js/zamboni/editors-all.js:15541 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:260
 msgid "Version Notes"
 msgstr "Poznámky k verzi"
 
-#: static/js/zamboni/editors.js:265
+#: static/js/zamboni/editors-all.js:15546 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:265
 msgid "Notes for Reviewers"
 msgstr "Poznámky pro redaktory"
 
-#: static/js/zamboni/editors.js:270
+#: static/js/zamboni/editors-all.js:15551 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:270
 msgid "No version notes found"
 msgstr "Nebyla nalezena žádná verze poznámek"
 
-#: static/js/zamboni/editors.js:330
+#: static/js/zamboni/editors-all.js:15611 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:330
 msgid "Average Reviews"
 msgstr "Průměrné hodnocení"
 
-#: static/js/zamboni/editors.js:386
+#: static/js/zamboni/editors-all.js:15667 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:386
 msgid "Number of Reviews"
 msgstr "Počet hodnocení"
 
-#: static/js/zamboni/editors.js:445
+#: static/js/zamboni/editors-all.js:15726 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:445
 msgid "Error loading translation"
 msgstr "Chyba při načítání překladu"
 
-#: static/js/zamboni/files.js:411 static/js/zamboni/validator.js:261
-msgid "Ignore this message in future updates"
-msgstr "Ignorovat tuto zprávu při budoucích aktualizacích"
-
-#: static/js/zamboni/files.js:417 static/js/zamboni/validator.js:284
-msgid "Severity for automated signing:"
-msgstr "Závažnost pro automatické podepisování:"
-
-#: static/js/zamboni/global.js:410
-msgid "Loading..."
-msgstr "Probíhá načítání..."
-
-#. L10n: {0} is the number of characters left.
-#: static/js/zamboni/global.js:474
-msgid "<b>{0}</b> character left."
-msgid_plural "<b>{0}</b> characters left."
-msgstr[0] "Zbývá <b>{0}</b> znak."
-msgstr[1] "Zbývají <b>{0}</b> znaky."
-msgstr[2] "Zbývá <b>{0}</b> znaků."
-
-#: static/js/zamboni/init.js:28
-msgid ""
-"This feature is temporarily disabled while we perform website maintenance. "
-"Please check back a little later."
-msgstr ""
-"Tato funkce je dočasně zakázána, protože provádíme údržbu webu. Zkuste to "
-"prosím o chvíli později."
-
-#: static/js/zamboni/l10n.js:45
-msgid "Remove this localization"
-msgstr "Odebrat lokalizaci"
-
-#: static/js/zamboni/password-strength.js:20
-msgid "Password strength:"
-msgstr "Síla hesla:"
-
-#: static/js/zamboni/password-strength.js:26
-msgid "At least {0} character left."
-msgid_plural "At least {0} characters left."
-msgstr[0] "Zbývá {0} znak."
-msgstr[1] "Zbývají {0} znaky."
-msgstr[2] "Zbývá {0} znaků."
-
-#: static/js/zamboni/themes_review.js:176
-msgid "Requested Info"
-msgstr "Požadovány informace"
-
-#: static/js/zamboni/themes_review.js:177
-msgid "Flagged"
-msgstr "Označené"
-
-#: static/js/zamboni/themes_review.js:178
-msgid "Duplicate"
-msgstr "Duplicitní"
-
-#: static/js/zamboni/themes_review.js:179
-msgid "Rejected"
-msgstr "Zamítnuto"
-
-#: static/js/zamboni/themes_review.js:180
-msgid "Approved"
-msgstr "Schváleno"
-
-#: static/js/zamboni/themes_review.js:424
-msgid "No results found"
-msgstr "Nebyly nalezeny žádné výsledky"
-
-#: static/js/zamboni/themes_review_templates.js:31
+#: static/js/zamboni/editors-all.js:15975 static/js/zamboni/editors-min.js:5 static/js/zamboni/themes_review_templates.js:31
 msgid "Theme"
 msgstr "Motiv"
 
-#: static/js/zamboni/themes_review_templates.js:33
+#: static/js/zamboni/editors-all.js:15977 static/js/zamboni/editors-min.js:5 static/js/zamboni/themes_review_templates.js:33
 msgid "Reviewer"
 msgstr "Redaktor"
 
-#: static/js/zamboni/themes_review_templates.js:35
+#: static/js/zamboni/editors-all.js:15979 static/js/zamboni/editors-min.js:5 static/js/zamboni/themes_review_templates.js:35
 msgid "Status"
 msgstr "Stav"
 
-#: static/js/zamboni/validator.js:80
-msgid "All tests passed successfully."
-msgstr "Všechny testy prošly úspěšně."
+#: static/js/zamboni/editors-all.js:16196 static/js/zamboni/editors-min.js:5 static/js/zamboni/themes_review.js:176
+msgid "Requested Info"
+msgstr "Požadovány informace"
 
-#: static/js/zamboni/validator.js:83 static/js/zamboni/validator.js:478
-msgid "These tests were not run."
-msgstr "Testy nebyly spuštěny."
+#: static/js/zamboni/editors-all.js:16197 static/js/zamboni/editors-min.js:5 static/js/zamboni/themes_review.js:177
+msgid "Flagged"
+msgstr "Označené"
 
-#: static/js/zamboni/validator.js:131 static/js/zamboni/validator.js:144
-msgid "Tests"
-msgstr "Testy"
+#: static/js/zamboni/editors-all.js:16198 static/js/zamboni/editors-min.js:5 static/js/zamboni/themes_review.js:178
+msgid "Duplicate"
+msgstr "Duplicitní"
 
-#: static/js/zamboni/validator.js:246 static/js/zamboni/validator.js:575
-#: static/js/zamboni/validator.js:594
-msgid "Error"
-msgstr "Chyba"
+#: static/js/zamboni/editors-all.js:16199 static/js/zamboni/editors-min.js:5 static/js/zamboni/themes_review.js:179
+msgid "Rejected"
+msgstr "Zamítnuto"
 
-#: static/js/zamboni/validator.js:247
-msgid "Warning"
-msgstr "Varování"
+#: static/js/zamboni/editors-all.js:16200 static/js/zamboni/editors-min.js:5 static/js/zamboni/themes_review.js:180
+msgid "Approved"
+msgstr "Schváleno"
 
-#: static/js/zamboni/validator.js:299
-msgid "Suggestions for passing automated signing:"
-msgstr "Doporučení k úspěšnému dokončení automatického podepsání:"
+#: static/js/zamboni/editors-all.js:16444 static/js/zamboni/editors-min.js:5 static/js/zamboni/themes_review.js:424
+msgid "No results found"
+msgstr "Nebyly nalezeny žádné výsledky"
 
-#: static/js/zamboni/validator.js:387
-msgid "Compatibility Tests"
-msgstr "Testy kompatibility"
-
-#: static/js/zamboni/validator.js:466
-msgid "Add-on failed validation."
-msgstr "Doplněk prošel kontrolou s chybami."
-
-#: static/js/zamboni/validator.js:468
-msgid "Add-on passed validation."
-msgstr "Doplněk úspěšně prošel kontrolou."
-
-#: static/js/zamboni/validator.js:481
-msgid "{0} error"
-msgid_plural "{0} errors"
-msgstr[0] "{0} chyba"
-msgstr[1] "{0} chyby"
-msgstr[2] "{0} chyb"
-
-#: static/js/zamboni/validator.js:483
-msgid "{0} warning"
-msgid_plural "{0} warnings"
-msgstr[0] "{0} varování"
-msgstr[1] "{0} varování"
-msgstr[2] "{0} varování"
-
-#: static/js/zamboni/validator.js:485
-msgid "{0} notice"
-msgid_plural "{0} notices"
-msgstr[0] "{0} upozornění"
-msgstr[1] "{0} upozornění"
-msgstr[2] "{0} upozornění"
-
-#: static/js/zamboni/validator.js:577
-msgid "Validation task could not complete or completed with errors"
-msgstr "Proces kontroly nemohl být dokončen nebo skončil s chybami"
-
-#: static/js/zamboni/validator.js:595
-msgid "Internal server error"
-msgstr "Interní chyba serveru"
-
-#: static/js/zamboni/mobile/buttons.js:52
+#: static/js/zamboni/mobile-all.js:15186 static/js/zamboni/mobile/buttons.js:52
 msgid "Not Updated for {0} {1}"
 msgstr "Není aktualizován pro {0} {1}"
 
-#: static/js/zamboni/mobile/buttons.js:53
+#: static/js/zamboni/mobile-all.js:15187 static/js/zamboni/mobile/buttons.js:53
 msgid "Requires Newer Version of {0}"
 msgstr "Je vyžadována novější verze {0}"
 
-#: static/js/zamboni/mobile/buttons.js:54
+#: static/js/zamboni/mobile-all.js:15188 static/js/zamboni/mobile/buttons.js:54
 msgid "Unreviewed"
 msgstr "Nezkontrolovaný"
 
-#: static/js/zamboni/mobile/buttons.js:55
+#: static/js/zamboni/mobile-all.js:15189 static/js/zamboni/mobile/buttons.js:55
 msgid "Experimental <span>(Learn More)</span>"
 msgstr "Experimentální <span>(Dozvědět se více)</span>"
 
-#: static/js/zamboni/mobile/buttons.js:56
-#: static/js/zamboni/mobile/buttons.js:57
+#: static/js/zamboni/mobile-all.js:15190 static/js/zamboni/mobile-all.js:15191 static/js/zamboni/mobile/buttons.js:56 static/js/zamboni/mobile/buttons.js:57
 msgid "Not Available for {0}"
 msgstr "Není dostupný pro {0}"
 
-#: static/js/zamboni/mobile/buttons.js:58
+#: static/js/zamboni/mobile-all.js:15192 static/js/zamboni/mobile/buttons.js:58
 msgid "Experimental"
 msgstr "Experimentální"
 
-#: static/js/zamboni/mobile/buttons.js:59
+#: static/js/zamboni/mobile-all.js:15193 static/js/zamboni/mobile/buttons.js:59
 msgid "Themes Require Newer Version of {0}"
 msgstr "Motivy vyžadují novější verzi {0}"
 
-#: static/js/zamboni/mobile/buttons.js:60
+#: static/js/zamboni/mobile-all.js:15194 static/js/zamboni/mobile/buttons.js:60
 msgid "Themes Require {0}"
 msgstr "Motivy vyžadují {0}"
 
-#: static/js/zamboni/mobile/buttons.js:105
+#: static/js/zamboni/mobile-all.js:15239 static/js/zamboni/mobile/buttons.js:105
 msgid "Installing..."
 msgstr "Probíhá instalace..."
 
-#: static/js/zamboni/mobile/buttons.js:125
+#: static/js/zamboni/mobile-all.js:15259 static/js/zamboni/mobile/buttons.js:125
 msgid "This add-on has been preliminarily reviewed by Mozilla."
 msgstr "Doplněk byl Mozillou předběžně zkontrolován."
 
-#: static/js/zamboni/mobile/buttons.js:250
+#: static/js/zamboni/mobile-all.js:15384 static/js/zamboni/mobile/buttons.js:250
 msgid "Keep it"
 msgstr "Ponechat"
 
-#: static/js/zamboni/mobile/general.js:344
+#: static/js/zamboni/mobile-all.js:16049 static/js/zamboni/mobile-min.js:6 static/js/zamboni/mobile/general.js:344
 msgid "You're trying it on!"
 msgstr "Nyní ji máte na vyzkoušení!"
 
-#: static/js/zamboni/mobile/general.js:356
+#: static/js/zamboni/mobile-all.js:16061 static/js/zamboni/mobile-min.js:6 static/js/zamboni/mobile/general.js:356
 msgid "Added to Firefox"
 msgstr "Přidáno do Firefoxu"

--- a/locale/cy/LC_MESSAGES/django.po
+++ b/locale/cy/LC_MESSAGES/django.po
@@ -6,69 +6,70 @@ msgid ""
 msgstr ""
 "Project-Id-Version: REMORA 0.1\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2016-02-24 21:23+0000\n"
+"POT-Creation-Date: 2016-04-18 15:47+0000\n"
 "PO-Revision-Date: 2008-06-01 16:39+0000\n"
 "Last-Translator: Rhoslyn Prys <post@meddal.com>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
+"Language: \n"
 "MIME-Version: 1.0\n"
-"Content-Type: text/plain; charset=utf-8\n"
+"Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Generated-By: Babel 2.2.0\n"
 
-#: src/olympia/accounts/views.py:52
+#: src/olympia/accounts/views.py:54
 msgid "Your log in attempt could not be parsed. Please try again."
 msgstr ""
 
-#: src/olympia/accounts/views.py:54
+#: src/olympia/accounts/views.py:56
 msgid "Your Firefox Account could not be found. Please try again."
 msgstr ""
 
-#: src/olympia/accounts/views.py:55
+#: src/olympia/accounts/views.py:57
 msgid "You could not be logged in. Please try again."
 msgstr ""
 
-#: src/olympia/accounts/views.py:57
+#: src/olympia/accounts/views.py:59
 msgid "Your account has already been migrated to Firefox Accounts."
 msgstr ""
 
-#: src/olympia/accounts/views.py:59
+#: src/olympia/accounts/views.py:61
 msgid "Your Firefox Account already exists on this site."
 msgstr ""
 
-#: src/olympia/accounts/views.py:108
+#: src/olympia/accounts/views.py:110
 msgid "Great job!"
 msgstr ""
 
-#: src/olympia/accounts/views.py:109
+#: src/olympia/accounts/views.py:111
 msgid "You can now log in to Add-ons with your Firefox Account."
 msgstr ""
 
-#: src/olympia/accounts/views.py:121
+#: src/olympia/accounts/views.py:123
 msgid "Need help?"
 msgstr ""
 
-#: src/olympia/addons/buttons.py:180
+#: src/olympia/addons/buttons.py:177
 msgid "Download Now"
 msgstr ""
 
-#: src/olympia/addons/buttons.py:182
+#: src/olympia/addons/buttons.py:179
 msgid "Download"
 msgstr ""
 
 #. L10n: please keep &nbsp; in the string so &rarr; does not wrap.
-#: src/olympia/addons/buttons.py:186
+#: src/olympia/addons/buttons.py:183
 msgid "Continue to Download&nbsp;&rarr;"
 msgstr ""
 
-#: src/olympia/addons/buttons.py:202 src/olympia/addons/helpers.py:35 src/olympia/addons/views.py:319 src/olympia/addons/templates/addons/impala/details.html:114
+#: src/olympia/addons/buttons.py:199 src/olympia/addons/helpers.py:35 src/olympia/addons/views.py:333 src/olympia/addons/templates/addons/impala/details.html:111
 #: src/olympia/addons/templates/addons/impala/listing/items.html:17 src/olympia/addons/templates/addons/mobile/home.html:40 src/olympia/amo/templates/amo/side_nav.html:6
-#: src/olympia/amo/templates/amo/side_nav.html:10 src/olympia/amo/templates/amo/site_nav.html:2 src/olympia/amo/templates/amo/site_nav.html:55 src/olympia/bandwagon/views.py:95
-#: src/olympia/browse/views.py:54 src/olympia/browse/views.py:68 src/olympia/browse/views.py:235 src/olympia/browse/templates/browse/impala/category_landing.html:22
+#: src/olympia/amo/templates/amo/side_nav.html:10 src/olympia/amo/templates/amo/site_nav.html:2 src/olympia/amo/templates/amo/site_nav.html:53 src/olympia/bandwagon/views.py:95
+#: src/olympia/browse/views.py:54 src/olympia/browse/views.py:68 src/olympia/browse/views.py:202 src/olympia/browse/templates/browse/impala/category_landing.html:22
 #: src/olympia/browse/templates/browse/personas/mobile/category_landing.html:26
 msgid "Featured"
 msgstr ""
 
-#: src/olympia/addons/buttons.py:221
+#: src/olympia/addons/buttons.py:218
 msgid "Add to {0}"
 msgstr ""
 
@@ -91,8 +92,6 @@ msgid "Invalid tag: {0}"
 msgid_plural "Invalid tags: {0}"
 msgstr[0] ""
 msgstr[1] ""
-msgstr[2] ""
-msgstr[3] ""
 
 #. L10n: {0} is a single tag or a comma-separated list of tags.
 #: src/olympia/addons/forms.py:103
@@ -100,16 +99,12 @@ msgid "\"{0}\" is a reserved tag and cannot be used."
 msgid_plural "\"{0}\" are reserved tags and cannot be used."
 msgstr[0] ""
 msgstr[1] ""
-msgstr[2] ""
-msgstr[3] ""
 
 #: src/olympia/addons/forms.py:111
 msgid "You have {0} too many tags."
 msgid_plural "You have {0} too many tags."
 msgstr[0] ""
 msgstr[1] ""
-msgstr[2] ""
-msgstr[3] ""
 
 #: src/olympia/addons/forms.py:117
 #, python-format
@@ -121,44 +116,40 @@ msgid "All tags must be at least {0} character."
 msgid_plural "All tags must be at least {0} characters."
 msgstr[0] ""
 msgstr[1] ""
-msgstr[2] ""
-msgstr[3] ""
 
-#: src/olympia/addons/forms.py:234
+#: src/olympia/addons/forms.py:238
 msgid "Categories cannot be changed while your add-on is featured for this application."
 msgstr ""
 
 #. L10n: {0} is the number of categories.
-#: src/olympia/addons/forms.py:238
+#: src/olympia/addons/forms.py:242
 msgid "You can have only {0} category."
 msgid_plural "You can have only {0} categories."
 msgstr[0] ""
 msgstr[1] ""
-msgstr[2] ""
-msgstr[3] ""
 
-#: src/olympia/addons/forms.py:246
+#: src/olympia/addons/forms.py:250
 msgid "The miscellaneous category cannot be combined with additional categories."
 msgstr ""
 
-#: src/olympia/addons/forms.py:369
+#: src/olympia/addons/forms.py:374
 #, python-format
 msgid "Before changing your default locale you must have a name, summary, and description in that locale. You are missing %s."
 msgstr ""
 
-#: src/olympia/addons/forms.py:484 src/olympia/addons/forms.py:575
+#: src/olympia/addons/forms.py:455 src/olympia/addons/forms.py:546
 msgid "A license must be selected."
 msgstr ""
 
-#: src/olympia/addons/forms.py:556
+#: src/olympia/addons/forms.py:527
 msgid "Give Your Theme a Name."
 msgstr ""
 
-#: src/olympia/addons/forms.py:562 src/olympia/devhub/templates/devhub/personas/submit.html:53
+#: src/olympia/addons/forms.py:533 src/olympia/devhub/templates/devhub/personas/submit.html:53
 msgid "Describe your Theme."
 msgstr ""
 
-#: src/olympia/addons/forms.py:704
+#: src/olympia/addons/forms.py:675
 msgid "Enter a new author's email address"
 msgstr ""
 
@@ -166,39 +157,39 @@ msgstr ""
 msgid "Not Reviewed"
 msgstr ""
 
-#: src/olympia/addons/models.py:301
+#: src/olympia/addons/models.py:298
 msgid "Users have the option of contributing more or less than this amount."
 msgstr "Users have the option of contributing more or less than this amount."
 
-#: src/olympia/addons/models.py:309
-msgid "Users will always be asked in the Add-ons Manager (Firefox 4 and above)"
+#: src/olympia/addons/models.py:306
+msgid "Users will always be asked in the Add-ons Manager (Firefox 4 and above). Only applies to desktop."
 msgstr ""
 
 # Column name in a table.
-#: src/olympia/addons/models.py:1804 src/olympia/addons/templates/addons/details_box.html:55 src/olympia/devhub/templates/devhub/index.html:92
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:102
+#: src/olympia/addons/models.py:1802 src/olympia/addons/templates/addons/details_box.html:55 src/olympia/devhub/templates/devhub/index.html:92
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:89
 msgid "Listed"
 msgstr "Listed"
 
-#: src/olympia/addons/views.py:320 src/olympia/browse/templates/browse/personas/mobile/category_landing.html:27
+#: src/olympia/addons/views.py:334 src/olympia/browse/templates/browse/personas/mobile/category_landing.html:27
 msgid "Popular"
 msgstr ""
 
-#: src/olympia/addons/views.py:321 src/olympia/browse/views.py:238 src/olympia/browse/views.py:280 src/olympia/browse/views.py:482
+#: src/olympia/addons/views.py:335 src/olympia/browse/views.py:205 src/olympia/browse/views.py:247 src/olympia/browse/views.py:449
 msgid "Recently Added"
 msgstr "Recently Added"
 
-#: src/olympia/addons/views.py:322 src/olympia/bandwagon/views.py:99 src/olympia/browse/views.py:60 src/olympia/browse/views.py:71 src/olympia/search/forms.py:16 src/olympia/search/forms.py:91
+#: src/olympia/addons/views.py:336 src/olympia/bandwagon/views.py:99 src/olympia/browse/views.py:60 src/olympia/browse/views.py:71 src/olympia/search/forms.py:16 src/olympia/search/forms.py:91
 msgid "Recently Updated"
 msgstr ""
 
 # %1 is an add-on name.
 #. l10n: {0} is the addon name
-#: src/olympia/addons/views.py:520
+#: src/olympia/addons/views.py:534
 msgid "Contribution for {0}"
 msgstr "Contribution for {0}"
 
-#: src/olympia/addons/views.py:613
+#: src/olympia/addons/views.py:627
 msgid "Abuse reported."
 msgstr ""
 
@@ -267,9 +258,9 @@ msgstr "Contribute"
 #: src/olympia/devhub/templates/devhub/addons/ajax_compat_update.html:36 src/olympia/devhub/templates/devhub/addons/profile.html:44 src/olympia/devhub/templates/devhub/addons/edit/admin.html:101
 #: src/olympia/devhub/templates/devhub/addons/edit/basic.html:152 src/olympia/devhub/templates/devhub/addons/edit/details.html:85 src/olympia/devhub/templates/devhub/addons/edit/support.html:67
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:166 src/olympia/devhub/templates/devhub/addons/forms_shared/media.html:149
-#: src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:44 src/olympia/devhub/templates/devhub/versions/add_file_modal.html:78 src/olympia/devhub/templates/devhub/versions/edit.html:139
-#: src/olympia/devhub/templates/devhub/versions/list.html:242 src/olympia/devhub/templates/devhub/versions/list.html:276 src/olympia/devhub/templates/devhub/versions/list.html:317
-#: src/olympia/devhub/templates/devhub/versions/list.html:351 src/olympia/reviews/templates/reviews/edit_review.html:16 src/olympia/translations/templates/translations/trans-menu.html:50
+#: src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:43 src/olympia/devhub/templates/devhub/versions/add_file_modal.html:58 src/olympia/devhub/templates/devhub/versions/edit.html:139
+#: src/olympia/devhub/templates/devhub/versions/list.html:239 src/olympia/devhub/templates/devhub/versions/list.html:281 src/olympia/devhub/templates/devhub/versions/list.html:315
+#: src/olympia/devhub/templates/devhub/versions/list.html:349 src/olympia/reviews/templates/reviews/edit_review.html:16 src/olympia/translations/templates/translations/trans-menu.html:50
 #: src/olympia/translations/templates/translations/trans-menu.html:62
 msgid "or"
 msgstr "or"
@@ -380,7 +371,7 @@ msgid "Add-on Information for {0}"
 msgstr ""
 
 #: src/olympia/addons/templates/addons/details_box.html:30 src/olympia/addons/templates/addons/persona_detail_table.html:3 src/olympia/addons/templates/addons/mobile/details.html:63
-#: src/olympia/addons/templates/addons/mobile/persona_detail_table.html:7 src/olympia/browse/views.py:459 src/olympia/devhub/views.py:75
+#: src/olympia/addons/templates/addons/mobile/persona_detail_table.html:7 src/olympia/browse/views.py:426 src/olympia/devhub/views.py:73
 msgid "Updated"
 msgstr "Updated"
 
@@ -399,11 +390,11 @@ msgstr "Works with"
 msgid "Visibility"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/details_box.html:57 src/olympia/devhub/templates/devhub/index.html:94 src/olympia/devhub/templates/devhub/includes/addon_details.html:104
+#: src/olympia/addons/templates/addons/details_box.html:57 src/olympia/devhub/templates/devhub/index.html:94 src/olympia/devhub/templates/devhub/includes/addon_details.html:91
 msgid "Hidden"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/details_box.html:59 src/olympia/devhub/templates/devhub/index.html:96 src/olympia/devhub/templates/devhub/includes/addon_details.html:106
+#: src/olympia/addons/templates/addons/details_box.html:59 src/olympia/devhub/templates/devhub/index.html:96 src/olympia/devhub/templates/devhub/includes/addon_details.html:93
 msgid "Unlisted"
 msgstr ""
 
@@ -411,13 +402,13 @@ msgstr ""
 msgid "Required Add-ons"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/details_box.html:81 src/olympia/addons/templates/addons/persona_detail_table.html:15 src/olympia/browse/views.py:462 src/olympia/devhub/views.py:78
-#: src/olympia/devhub/views.py:85 src/olympia/discovery/templates/discovery/addons/detail.html:57 src/olympia/reviews/forms.py:62 src/olympia/reviews/templates/reviews/add.html:57
+#: src/olympia/addons/templates/addons/details_box.html:81 src/olympia/addons/templates/addons/persona_detail_table.html:15 src/olympia/browse/views.py:429 src/olympia/devhub/views.py:76
+#: src/olympia/devhub/views.py:83 src/olympia/discovery/templates/discovery/addons/detail.html:57 src/olympia/reviews/forms.py:62 src/olympia/reviews/templates/reviews/add.html:57
 #: src/olympia/reviews/templates/reviews/mobile/review_list.html:18
 msgid "Rating"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/details_box.html:85 src/olympia/browse/views.py:461 src/olympia/devhub/views.py:77 src/olympia/devhub/views.py:84
+#: src/olympia/addons/templates/addons/details_box.html:85 src/olympia/browse/views.py:428 src/olympia/devhub/views.py:75 src/olympia/devhub/views.py:82
 #: src/olympia/stats/templates/stats/addon_report_menu.html:8 src/olympia/stats/templates/stats/collection_report_menu.html:18
 msgid "Downloads"
 msgstr ""
@@ -437,7 +428,7 @@ msgstr ""
 
 #. The Privacy Policy for this add-on.
 #: src/olympia/addons/templates/addons/details_box.html:121 src/olympia/addons/templates/addons/privacy.html:19 src/olympia/addons/templates/addons/privacy.html:23
-#: src/olympia/addons/templates/addons/impala/button.html:43 src/olympia/addons/templates/addons/impala/details.html:307 src/olympia/devhub/templates/devhub/includes/policy_form.html:20
+#: src/olympia/addons/templates/addons/impala/button.html:43 src/olympia/addons/templates/addons/impala/details.html:312 src/olympia/devhub/templates/devhub/includes/policy_form.html:23
 #: src/olympia/templates/mobile/base_addons.html:87
 msgid "Privacy Policy"
 msgstr ""
@@ -462,7 +453,7 @@ msgstr "Image Gallery"
 msgid "Developer Comments"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/details_box.html:199 src/olympia/addons/templates/addons/impala/details.html:259
+#: src/olympia/addons/templates/addons/details_box.html:199 src/olympia/addons/templates/addons/impala/details.html:264
 msgid "Development Channel"
 msgstr ""
 
@@ -482,7 +473,7 @@ msgid ""
 "developer. To stop receiving development updates, reinstall the default version from the link above."
 msgstr ""
 
-#: src/olympia/addons/templates/addons/details_box.html:220 src/olympia/addons/templates/addons/impala/details.html:278
+#: src/olympia/addons/templates/addons/details_box.html:220 src/olympia/addons/templates/addons/impala/details.html:283
 msgid "Version {0}:"
 msgstr ""
 
@@ -501,7 +492,7 @@ msgid "End-User License Agreement for {0}"
 msgstr ""
 
 #: src/olympia/addons/templates/addons/eula.html:17 src/olympia/addons/templates/addons/eula.html:21 src/olympia/addons/templates/addons/impala/button.html:48
-#: src/olympia/addons/templates/addons/impala/details.html:316 src/olympia/devhub/templates/devhub/includes/policy_form.html:3 src/olympia/discovery/templates/discovery/addons/eula.html:11
+#: src/olympia/addons/templates/addons/impala/details.html:321 src/olympia/devhub/templates/devhub/includes/policy_form.html:3 src/olympia/discovery/templates/discovery/addons/eula.html:11
 msgid "End-User License Agreement"
 msgstr "End-User License Agreement"
 
@@ -521,7 +512,7 @@ msgstr ""
 msgid "Add-ons for {0}"
 msgstr "{0} Ychwanegyn"
 
-#: src/olympia/addons/templates/addons/home.html:10 src/olympia/addons/templates/addons/home.html:51 src/olympia/browse/templates/browse/impala/base_listing.html:11
+#: src/olympia/addons/templates/addons/home.html:10 src/olympia/addons/templates/addons/home.html:53 src/olympia/browse/templates/browse/impala/base_listing.html:11
 msgid "Featured Extensions"
 msgstr ""
 
@@ -529,29 +520,29 @@ msgstr ""
 msgid "Popular Extensions"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/home.html:42 src/olympia/amo/templates/amo/side_nav.html:3 src/olympia/amo/templates/amo/side_nav.html:11 src/olympia/amo/templates/amo/site_nav.html:3
-#: src/olympia/amo/templates/amo/site_nav.html:25 src/olympia/browse/views.py:236 src/olympia/browse/views.py:281 src/olympia/browse/views.py:481
+#: src/olympia/addons/templates/addons/home.html:44 src/olympia/amo/templates/amo/side_nav.html:3 src/olympia/amo/templates/amo/side_nav.html:11 src/olympia/amo/templates/amo/site_nav.html:3
+#: src/olympia/amo/templates/amo/site_nav.html:25 src/olympia/browse/views.py:203 src/olympia/browse/views.py:248 src/olympia/browse/views.py:448
 msgid "Most Popular"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/home.html:43
+#: src/olympia/addons/templates/addons/home.html:45
 msgid "All »"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/home.html:52 src/olympia/addons/templates/addons/home.html:61 src/olympia/addons/templates/addons/home.html:70 src/olympia/addons/templates/addons/home.html:78
+#: src/olympia/addons/templates/addons/home.html:54 src/olympia/addons/templates/addons/home.html:63 src/olympia/addons/templates/addons/home.html:72 src/olympia/addons/templates/addons/home.html:80
 #: src/olympia/browse/templates/browse/impala/category_landing.html:36
 msgid "See all »"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/home.html:60
+#: src/olympia/addons/templates/addons/home.html:62
 msgid "Up &amp; Coming Extensions"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/home.html:69 src/olympia/browse/templates/browse/personas/category_landing.html:61 src/olympia/discovery/templates/discovery/pane.html:74
+#: src/olympia/addons/templates/addons/home.html:71 src/olympia/browse/templates/browse/personas/category_landing.html:61 src/olympia/discovery/templates/discovery/pane.html:74
 msgid "Featured Themes"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/home.html:77 src/olympia/bandwagon/templates/bandwagon/impala/collection_listing.html:5
+#: src/olympia/addons/templates/addons/home.html:79 src/olympia/bandwagon/templates/bandwagon/impala/collection_listing.html:5
 msgid "Featured Collections"
 msgstr ""
 
@@ -569,7 +560,7 @@ msgid "Updated {0}"
 msgstr ""
 
 #. {0} is a date.
-#: src/olympia/addons/templates/addons/macros.html:10 src/olympia/addons/templates/addons/macros.html:69 src/olympia/addons/templates/addons/persona_preview.html:21
+#: src/olympia/addons/templates/addons/macros.html:10 src/olympia/addons/templates/addons/macros.html:69 src/olympia/addons/templates/addons/persona_preview.html:22
 #: src/olympia/addons/templates/addons/listing/items_mobile.html:44 src/olympia/addons/templates/addons/listing/macros.html:39
 #: src/olympia/bandwagon/templates/bandwagon/collection_listing_items.html:37 src/olympia/bandwagon/templates/bandwagon/impala/collection_listing_items.html:37
 msgid "Added {0}"
@@ -581,8 +572,6 @@ msgid "%(num)s weekly download"
 msgid_plural "%(num)s weekly downloads"
 msgstr[0] ""
 msgstr[1] ""
-msgstr[2] ""
-msgstr[3] ""
 
 #: src/olympia/addons/templates/addons/macros.html:28
 #, python-format
@@ -590,27 +579,20 @@ msgid "%(num)s user"
 msgid_plural "%(num)s users"
 msgstr[0] ""
 msgstr[1] ""
-msgstr[2] ""
-msgstr[3] ""
 
 #. {0} is the number of downloads.
-#: src/olympia/addons/templates/addons/macros.html:53 src/olympia/addons/templates/addons/impala/details.html:61
+#: src/olympia/addons/templates/addons/macros.html:53 src/olympia/addons/templates/addons/impala/details.html:59
 msgid "{0} weekly download"
 msgid_plural "{0} weekly downloads"
 msgstr[0] ""
 msgstr[1] ""
-msgstr[2] ""
-msgstr[3] ""
 
 #. {0} is the number of users.
-#: src/olympia/addons/templates/addons/macros.html:61 src/olympia/addons/templates/addons/impala/details.html:54 src/olympia/compat/templates/compat/index.html:71
-#: src/olympia/zadmin/templates/zadmin/compat.html:67
+#: src/olympia/addons/templates/addons/macros.html:61 src/olympia/addons/templates/addons/impala/details.html:52 src/olympia/zadmin/templates/zadmin/compat.html:67
 msgid "{0} user"
 msgid_plural "{0} users"
 msgstr[0] ""
 msgstr[1] ""
-msgstr[2] ""
-msgstr[3] ""
 
 #: src/olympia/addons/templates/addons/paypal_result.html:12
 msgid "Payment cancelled"
@@ -624,7 +606,7 @@ msgstr ""
 msgid "Return to the addon."
 msgstr ""
 
-#: src/olympia/addons/templates/addons/persona_detail.html:17 src/olympia/addons/templates/addons/impala/details.html:106 src/olympia/addons/templates/addons/mobile/details.html:23
+#: src/olympia/addons/templates/addons/persona_detail.html:17 src/olympia/addons/templates/addons/impala/details.html:103 src/olympia/addons/templates/addons/mobile/details.html:23
 #: src/olympia/addons/templates/addons/mobile/persona_detail.html:21 src/olympia/discovery/templates/discovery/addons/base.html:27 src/olympia/editors/templates/editors/review.html:31
 msgid "by"
 msgstr "gan"
@@ -668,36 +650,35 @@ msgstr ""
 msgid "License"
 msgstr "License"
 
-#: src/olympia/addons/templates/addons/persona_preview.html:12 src/olympia/constants/base.py:48
+#: src/olympia/addons/templates/addons/persona_preview.html:13 src/olympia/constants/base.py:48
 msgid "Awaiting Review"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/persona_preview.html:14 src/olympia/amo/log.py:180 src/olympia/constants/base.py:42 src/olympia/editors/helpers.py:62
+#: src/olympia/addons/templates/addons/persona_preview.html:15 src/olympia/amo/log.py:180 src/olympia/constants/base.py:42 src/olympia/editors/helpers.py:62
 msgid "Rejected"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/persona_preview.html:16 src/olympia/amo/log.py:159
+#: src/olympia/addons/templates/addons/persona_preview.html:17 src/olympia/amo/log.py:159
 msgid "Approved"
 msgstr ""
 
 #. {0} is the number of users.
-#: src/olympia/addons/templates/addons/persona_preview.html:26 src/olympia/addons/templates/addons/listing/items_mobile.html:36 src/olympia/addons/templates/addons/listing/macros.html:31
+#: src/olympia/addons/templates/addons/persona_preview.html:27 src/olympia/addons/templates/addons/listing/items_mobile.html:36 src/olympia/addons/templates/addons/listing/macros.html:31
 msgid "<strong>{0}</strong> user"
 msgid_plural "<strong>{0}</strong> users"
 msgstr[0] ""
 msgstr[1] ""
-msgstr[2] ""
-msgstr[3] ""
 
-#: src/olympia/addons/templates/addons/persona_preview.html:40
+#: src/olympia/addons/templates/addons/persona_preview.html:41
 msgid "Hover to Preview"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/persona_preview.html:46 src/olympia/addons/templates/addons/persona_preview.html:48 src/olympia/reviews/templates/reviews/add.html:15
+#: src/olympia/addons/templates/addons/persona_preview.html:47 src/olympia/addons/templates/addons/persona_preview.html:49 src/olympia/addons/templates/addons/persona_preview.html:97
+#: src/olympia/reviews/templates/reviews/add.html:15
 msgid "Add"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/persona_preview.html:57 src/olympia/bandwagon/templates/bandwagon/ajax_new.html:16 src/olympia/bandwagon/templates/bandwagon/edit.html:19
+#: src/olympia/addons/templates/addons/persona_preview.html:58 src/olympia/bandwagon/templates/bandwagon/ajax_new.html:16 src/olympia/bandwagon/templates/bandwagon/edit.html:19
 #: src/olympia/bandwagon/templates/bandwagon/includes/addedit.html:19 src/olympia/devhub/templates/devhub/addons/edit/admin.html:13 src/olympia/devhub/templates/devhub/addons/edit/basic.html:10
 #: src/olympia/devhub/templates/devhub/addons/edit/details.html:8 src/olympia/devhub/templates/devhub/addons/edit/media.html:6 src/olympia/devhub/templates/devhub/addons/edit/support.html:8
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:9 src/olympia/devhub/templates/devhub/addons/submit/describe.html:29 src/olympia/editors/templates/editors/review.html:257
@@ -706,21 +687,21 @@ msgstr ""
 
 #. For datetime formatting, see the table on
 #. http://docs.python.org/library/datetime.html#strftime-and-strptime-behavior
-#: src/olympia/addons/templates/addons/persona_preview.html:66
+#: src/olympia/addons/templates/addons/persona_preview.html:67
 #, python-format
 msgid "%%Y-%%m-%%d"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/persona_preview.html:67
+#: src/olympia/addons/templates/addons/persona_preview.html:68
 msgid "by {0} on {1}"
 msgstr "gan {0} ynghylch {1}"
 
-#: src/olympia/addons/templates/addons/persona_preview.html:75 src/olympia/reviews/helpers.py:17 src/olympia/reviews/templates/reviews/review_list.html:63
+#: src/olympia/addons/templates/addons/persona_preview.html:76 src/olympia/reviews/helpers.py:17 src/olympia/reviews/templates/reviews/review_list.html:63
 #: src/olympia/reviews/templates/reviews/reviews_link.html:21 src/olympia/reviews/templates/reviews/impala/reviews_link.html:16
 msgid "Not yet rated"
 msgstr "Heb ei raddio eto"
 
-#: src/olympia/addons/templates/addons/persona_preview.html:78
+#: src/olympia/addons/templates/addons/persona_preview.html:79
 msgid "<b>{0}</b> users"
 msgstr ""
 
@@ -733,7 +714,7 @@ msgid "Learn more about Firefox"
 msgstr ""
 
 #: src/olympia/addons/templates/addons/popups.html:22
-msgid "or <b><a class=\"installer\" href=\"{url}\">download anyway</a></b>"
+msgid "or <b><a class=\"button installer\" href=\"{url}\">download anyway</a></b>"
 msgstr ""
 
 #: src/olympia/addons/templates/addons/popups.html:26
@@ -832,7 +813,7 @@ msgid ""
 msgstr ""
 
 #: src/olympia/addons/templates/addons/report_abuse.html:6 src/olympia/addons/templates/addons/report_abuse_full.html:10 src/olympia/addons/templates/addons/impala/details-more.html:23
-#: src/olympia/addons/templates/addons/impala/details.html:328
+#: src/olympia/addons/templates/addons/impala/details.html:333
 msgid "Report Abuse"
 msgstr ""
 
@@ -851,9 +832,9 @@ msgstr ""
 #: src/olympia/devhub/templates/devhub/addons/ajax_compat_update.html:36 src/olympia/devhub/templates/devhub/addons/profile.html:44 src/olympia/devhub/templates/devhub/addons/edit/admin.html:104
 #: src/olympia/devhub/templates/devhub/addons/edit/basic.html:155 src/olympia/devhub/templates/devhub/addons/edit/details.html:88 src/olympia/devhub/templates/devhub/addons/edit/support.html:70
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:169 src/olympia/devhub/templates/devhub/addons/forms_shared/media.html:152
-#: src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:44 src/olympia/devhub/templates/devhub/personas/edit.html:222 src/olympia/devhub/templates/devhub/versions/add_file_modal.html:79
-#: src/olympia/devhub/templates/devhub/versions/edit.html:140 src/olympia/devhub/templates/devhub/versions/list.html:208 src/olympia/devhub/templates/devhub/versions/list.html:242
-#: src/olympia/devhub/templates/devhub/versions/list.html:276 src/olympia/devhub/templates/devhub/versions/list.html:317 src/olympia/reviews/templates/reviews/edit_review.html:16
+#: src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:43 src/olympia/devhub/templates/devhub/personas/edit.html:222 src/olympia/devhub/templates/devhub/versions/add_file_modal.html:59
+#: src/olympia/devhub/templates/devhub/versions/edit.html:140 src/olympia/devhub/templates/devhub/versions/list.html:208 src/olympia/devhub/templates/devhub/versions/list.html:239
+#: src/olympia/devhub/templates/devhub/versions/list.html:281 src/olympia/devhub/templates/devhub/versions/list.html:315 src/olympia/reviews/templates/reviews/edit_review.html:16
 #: src/olympia/translations/templates/translations/trans-menu.html:50 src/olympia/translations/templates/translations/trans-menu.html:62 src/olympia/zadmin/templates/zadmin/validation.html:105
 msgid "Cancel"
 msgstr ""
@@ -898,7 +879,7 @@ msgstr ""
 msgid "Review Guidelines"
 msgstr "Review Guidelines"
 
-#: src/olympia/addons/templates/addons/review_list_box.html:5 src/olympia/addons/templates/addons/impala/details-more.html:27 src/olympia/editors/helpers.py:921
+#: src/olympia/addons/templates/addons/review_list_box.html:5 src/olympia/addons/templates/addons/impala/details-more.html:27 src/olympia/editors/helpers.py:1001
 #: src/olympia/reviews/templates/reviews/add.html:14 src/olympia/reviews/templates/reviews/reply.html:14 src/olympia/reviews/templates/reviews/review_list.html:19
 #: src/olympia/reviews/templates/reviews/mobile/review_list.html:26
 msgid "Reviews"
@@ -919,8 +900,6 @@ msgid "See all reviews of this add-on"
 msgid_plural "See all %(cnt)s reviews of this add-on"
 msgstr[0] ""
 msgstr[1] ""
-msgstr[2] ""
-msgstr[3] ""
 
 #: src/olympia/addons/templates/addons/tags_box.html:3 src/olympia/devhub/templates/devhub/addons/edit/basic.html:118
 msgid "Tags"
@@ -990,127 +969,121 @@ msgid "Other add-ons by %(author)s"
 msgid_plural "Other add-ons by these authors"
 msgstr[0] ""
 msgstr[1] ""
-msgstr[2] ""
-msgstr[3] ""
 
-#: src/olympia/addons/templates/addons/impala/details.html:41
+#: src/olympia/addons/templates/addons/impala/details.html:39
 #, python-format
 msgid "<span itemprop=\"ratingCount\">%(num)s</span> user review"
 msgid_plural "<span itemprop=\"ratingCount\">%(num)s</span> user reviews"
 msgstr[0] ""
 msgstr[1] ""
-msgstr[2] ""
-msgstr[3] ""
 
-#: src/olympia/addons/templates/addons/impala/details.html:69
+#: src/olympia/addons/templates/addons/impala/details.html:66
 msgid "View statistics"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/impala/details.html:84
+#: src/olympia/addons/templates/addons/impala/details.html:81
 msgid "Manage"
 msgstr ""
 
 #. {0} is an add-on name.
-#: src/olympia/addons/templates/addons/impala/details.html:96
+#: src/olympia/addons/templates/addons/impala/details.html:93
 msgid "Icon of {0}"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/impala/details.html:103 src/olympia/addons/templates/addons/impala/listing/items.html:14
+#: src/olympia/addons/templates/addons/impala/details.html:100 src/olympia/addons/templates/addons/impala/listing/items.html:14
 msgid "No Restart"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/impala/details.html:127
+#: src/olympia/addons/templates/addons/impala/details.html:124
 #, python-format
 msgid "Meet the Developer: <a href=\"%(url)s\">%(name)s</a>"
 msgid_plural "<a href=\"%(url)s\">Meet the Developers</a>"
 msgstr[0] ""
 msgstr[1] ""
-msgstr[2] ""
-msgstr[3] ""
 
 # {0} is an add-on name.
-#: src/olympia/addons/templates/addons/impala/details.html:137
+#: src/olympia/addons/templates/addons/impala/details.html:134
 msgid "Learn why {0} was created and find out what's next for this add-on."
 msgstr "Learn why {0} was created and find out what's next for this add-on."
 
 #. {0} is an index.
-#: src/olympia/addons/templates/addons/impala/details.html:156
+#: src/olympia/addons/templates/addons/impala/details.html:161
 msgid "Add-on screenshot #{0}"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/impala/details.html:182
+#: src/olympia/addons/templates/addons/impala/details.html:187
 msgid "Add-on home page"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/impala/details.html:185
+#: src/olympia/addons/templates/addons/impala/details.html:190
 msgid "Support site"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/impala/details.html:189
+#: src/olympia/addons/templates/addons/impala/details.html:194
 msgid "Support E-mail"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/impala/details.html:194 src/olympia/devhub/models.py:378 src/olympia/devhub/templates/devhub/versions/list.html:12
+#: src/olympia/addons/templates/addons/impala/details.html:199 src/olympia/devhub/models.py:378 src/olympia/devhub/templates/devhub/versions/list.html:12
 #: src/olympia/versions/templates/versions/version.html:6 src/olympia/versions/templates/versions/mobile/version.html:6
 msgid "Version {0}"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/impala/details.html:194
+#: src/olympia/addons/templates/addons/impala/details.html:199
 msgid "Info"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/impala/details.html:195 src/olympia/devhub/templates/devhub/includes/addon_details.html:129
+#: src/olympia/addons/templates/addons/impala/details.html:200 src/olympia/devhub/templates/devhub/includes/addon_details.html:116
 msgid "Last Updated:"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/impala/details.html:200
+#: src/olympia/addons/templates/addons/impala/details.html:205
 #, python-format
 msgid "Released under <a target=\"_blank\" href=\"%(url)s\">%(name)s</a>"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/impala/details.html:201 src/olympia/addons/templates/addons/impala/details.html:206 src/olympia/amo/helpers.py:398 src/olympia/devhub/forms.py:142
+#: src/olympia/addons/templates/addons/impala/details.html:206 src/olympia/addons/templates/addons/impala/details.html:211 src/olympia/amo/helpers.py:398 src/olympia/devhub/forms.py:142
 #: src/olympia/devhub/forms.py:173 src/olympia/versions/templates/versions/version.html:40 src/olympia/versions/templates/versions/version.html:45
 msgid "Custom License"
 msgstr "Custom License"
 
-#: src/olympia/addons/templates/addons/impala/details.html:205
+#: src/olympia/addons/templates/addons/impala/details.html:210
 #, python-format
 msgid "Released under <a href=\"%(url)s\">%(name)s</a>"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/impala/details.html:217
+#: src/olympia/addons/templates/addons/impala/details.html:222
 msgid "About this Add-on"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/impala/details.html:233
+#: src/olympia/addons/templates/addons/impala/details.html:238
 msgid "Developer’s Comments"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/impala/details.html:243
+#: src/olympia/addons/templates/addons/impala/details.html:248
 msgid "Version Information"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/impala/details.html:250
+#: src/olympia/addons/templates/addons/impala/details.html:255
 msgid "See complete version history"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/impala/details.html:262
+#: src/olympia/addons/templates/addons/impala/details.html:267
 msgid ""
 "The Development Channel lets you test an experimental new version of this add-on before it's released to the general public. Once you install the development version, you will continue to get "
 "updates from this channel. To stop receiving development updates, reinstall the default version from the link above."
 msgstr ""
 
-#: src/olympia/addons/templates/addons/impala/details.html:272
+#: src/olympia/addons/templates/addons/impala/details.html:277
 msgid "<strong>Caution:</strong> Development versions of this add-on have not been reviewed by Mozilla."
 msgstr ""
 
-#: src/olympia/addons/templates/addons/impala/details.html:287
+#: src/olympia/addons/templates/addons/impala/details.html:292
 msgid "See complete development channel history"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/impala/details.html:306 src/olympia/addons/templates/addons/impala/details.html:315 src/olympia/addons/templates/addons/impala/details.html:327
+#: src/olympia/addons/templates/addons/impala/details.html:311 src/olympia/addons/templates/addons/impala/details.html:320 src/olympia/addons/templates/addons/impala/details.html:332
 #: src/olympia/addons/templates/addons/impala/review_add_box.html:4 src/olympia/stats/templates/stats/popup.html:2 src/olympia/stats/templates/stats/popup.html:8
-#: src/olympia/stats/templates/stats/stats.html:202 src/olympia/users/templates/users/profile.html:119
+#: src/olympia/stats/templates/stats/stats.html:204 src/olympia/users/templates/users/profile.html:119
 msgid "close"
 msgstr ""
 
@@ -1144,8 +1117,6 @@ msgid "About the Developer"
 msgid_plural "About the Developers"
 msgstr[0] ""
 msgstr[1] ""
-msgstr[2] ""
-msgstr[3] ""
 
 #: src/olympia/addons/templates/addons/impala/developers.html:96 src/olympia/users/templates/users/edit.html:130 src/olympia/users/templates/users/profile.html:26
 msgid "No Photo"
@@ -1171,15 +1142,11 @@ msgstr ""
 msgid "Source Code License"
 msgstr "Source Code License"
 
-#: src/olympia/addons/templates/addons/impala/persona_grid.html:16 src/olympia/addons/templates/addons/impala/toplist.html:6
-msgid "{0} users"
-msgstr ""
-
 #: src/olympia/addons/templates/addons/impala/review_list_box.html:19 src/olympia/reviews/templates/reviews/review.html:40
 msgid "permalink"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/impala/review_list_box.html:23 src/olympia/editors/templates/editors/queue.html:98 src/olympia/reviews/templates/reviews/review.html:44
+#: src/olympia/addons/templates/addons/impala/review_list_box.html:23 src/olympia/editors/templates/editors/queue.html:104 src/olympia/reviews/templates/reviews/review.html:44
 msgid "translate"
 msgstr ""
 
@@ -1189,8 +1156,6 @@ msgid "See all user reviews"
 msgid_plural "See all %(cnt)s user reviews"
 msgstr[0] ""
 msgstr[1] ""
-msgstr[2] ""
-msgstr[3] ""
 
 #: src/olympia/addons/templates/addons/impala/review_list_box.html:47 src/olympia/reviews/templates/reviews/review_list.html:84
 msgid "This add-on has not yet been reviewed."
@@ -1198,6 +1163,10 @@ msgstr ""
 
 #: src/olympia/addons/templates/addons/impala/review_list_box.html:50
 msgid "Be the first!"
+msgstr ""
+
+#: src/olympia/addons/templates/addons/impala/toplist.html:6
+msgid "{0} users"
 msgstr ""
 
 #: src/olympia/addons/templates/addons/impala/listing/sorter.html:14 src/olympia/devhub/templates/devhub/addons/listing/item_actions.html:49
@@ -1212,7 +1181,7 @@ msgstr ""
 msgid "My Add-ons"
 msgstr "Fy Ychwanegion"
 
-#: src/olympia/addons/templates/addons/includes/dashboard_tabs.html:6 src/olympia/amo/context_processors.py:51
+#: src/olympia/addons/templates/addons/includes/dashboard_tabs.html:6 src/olympia/amo/context_processors.py:50
 msgid "My Themes"
 msgstr ""
 
@@ -1254,8 +1223,6 @@ msgid "<strong>{0}</strong> weekly download"
 msgid_plural "<strong>{0}</strong> weekly downloads"
 msgstr[0] ""
 msgstr[1] ""
-msgstr[2] ""
-msgstr[3] ""
 
 #: src/olympia/addons/templates/addons/mobile/details.html:32
 msgid "Read More"
@@ -1269,7 +1236,7 @@ msgstr ""
 msgid "Weekly Downloads"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/mobile/details.html:99 src/olympia/compat/templates/compat/reporter_detail.html:46 src/olympia/devhub/forms.py:787
+#: src/olympia/addons/templates/addons/mobile/details.html:99 src/olympia/compat/templates/compat/reporter_detail.html:46 src/olympia/devhub/forms.py:788
 #: src/olympia/devhub/templates/devhub/versions/list.html:163
 msgid "Version"
 msgstr "Version"
@@ -1354,7 +1321,7 @@ msgstr ""
 #: src/olympia/browse/templates/browse/personas/category_landing.html:21 src/olympia/browse/templates/browse/personas/category_landing.html:23
 #: src/olympia/browse/templates/browse/personas/category_landing.html:38 src/olympia/browse/templates/browse/personas/grid.html:7 src/olympia/browse/templates/browse/personas/grid.html:11
 #: src/olympia/browse/templates/browse/personas/mobile/base.html:7 src/olympia/browse/templates/browse/personas/mobile/category_landing.html:19 src/olympia/constants/base.py:180
-#: src/olympia/devhub/templates/devhub/personas/submit.html:13 src/olympia/editors/helpers.py:105 src/olympia/editors/templates/editors/base.html:26
+#: src/olympia/devhub/templates/devhub/personas/submit.html:13 src/olympia/editors/helpers.py:107 src/olympia/editors/templates/editors/base.html:26
 #: src/olympia/editors/templates/editors/performance.html:73 src/olympia/search/templates/search/personas.html:39 src/olympia/templates/menu_links.html:9
 msgid "Themes"
 msgstr ""
@@ -1375,7 +1342,7 @@ msgstr ""
 msgid "Highest Rated"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/mobile/home.html:74 src/olympia/amo/templates/amo/side_nav.html:5 src/olympia/amo/templates/amo/site_nav.html:27 src/olympia/amo/templates/amo/site_nav.html:57
+#: src/olympia/addons/templates/addons/mobile/home.html:74 src/olympia/amo/templates/amo/side_nav.html:5 src/olympia/amo/templates/amo/site_nav.html:27 src/olympia/amo/templates/amo/site_nav.html:55
 #: src/olympia/bandwagon/views.py:97 src/olympia/browse/views.py:57 src/olympia/browse/views.py:67 src/olympia/browse/templates/browse/personas/mobile/category_landing.html:65
 #: src/olympia/search/forms.py:15 src/olympia/search/forms.py:87
 msgid "Newest"
@@ -1389,90 +1356,90 @@ msgstr ""
 msgid "Theme Info &raquo;"
 msgstr ""
 
-#: src/olympia/amo/context_processors.py:39 src/olympia/devhub/templates/devhub/nav.html:43
+#: src/olympia/amo/context_processors.py:37 src/olympia/devhub/templates/devhub/nav.html:43
 msgid "Tools"
 msgstr "Tools"
 
-#: src/olympia/amo/context_processors.py:48 src/olympia/discovery/templates/discovery/pane_account.html:8 src/olympia/users/templates/users/includes/navigation.html:2
+#: src/olympia/amo/context_processors.py:47 src/olympia/discovery/templates/discovery/pane_account.html:8 src/olympia/users/templates/users/includes/navigation.html:2
 msgid "My Profile"
 msgstr ""
 
-#: src/olympia/amo/context_processors.py:54 src/olympia/users/templates/users/edit.html:5 src/olympia/users/templates/users/includes/navigation.html:3
+#: src/olympia/amo/context_processors.py:53 src/olympia/users/templates/users/edit.html:5 src/olympia/users/templates/users/includes/navigation.html:3
 msgid "Account Settings"
 msgstr ""
 
-#: src/olympia/amo/context_processors.py:57 src/olympia/discovery/templates/discovery/pane_account.html:11 src/olympia/users/templates/users/profile.html:83
+#: src/olympia/amo/context_processors.py:56 src/olympia/discovery/templates/discovery/pane_account.html:11 src/olympia/users/templates/users/profile.html:83
 #: src/olympia/users/templates/users/includes/navigation.html:4
 msgid "My Collections"
 msgstr "My Collections"
 
-#: src/olympia/amo/context_processors.py:62 src/olympia/discovery/templates/discovery/pane_account.html:10 src/olympia/users/templates/users/includes/navigation.html:7
+#: src/olympia/amo/context_processors.py:61 src/olympia/discovery/templates/discovery/pane_account.html:10 src/olympia/users/templates/users/includes/navigation.html:7
 msgid "My Favorites"
 msgstr "My Favorites"
 
-#: src/olympia/amo/context_processors.py:67 src/olympia/discovery/templates/discovery/pane_account.html:13 src/olympia/templates/impala/user_login.html:14
+#: src/olympia/amo/context_processors.py:66 src/olympia/discovery/templates/discovery/pane_account.html:13 src/olympia/templates/impala/user_login.html:14
 #: src/olympia/templates/mobile/header_auth.html:5
 msgid "Log out"
 msgstr "Allgofnodi"
 
-#: src/olympia/amo/context_processors.py:72 src/olympia/devhub/templates/devhub/addons/dashboard.html:4
+#: src/olympia/amo/context_processors.py:71 src/olympia/devhub/templates/devhub/addons/dashboard.html:4
 msgid "Manage My Submissions"
 msgstr ""
 
-#: src/olympia/amo/context_processors.py:75 src/olympia/devhub/templates/devhub/nav.html:27 src/olympia/devhub/templates/devhub/addons/dashboard.html:25
+#: src/olympia/amo/context_processors.py:74 src/olympia/devhub/templates/devhub/nav.html:27 src/olympia/devhub/templates/devhub/addons/dashboard.html:25
 #: src/olympia/devhub/templates/devhub/addons/submit/base.html:4
 msgid "Submit a New Add-on"
 msgstr ""
 
-#: src/olympia/amo/context_processors.py:77 src/olympia/browse/templates/browse/personas/base.html:50 src/olympia/devhub/templates/devhub/index.html:24
+#: src/olympia/amo/context_processors.py:76 src/olympia/browse/templates/browse/personas/base.html:50 src/olympia/devhub/templates/devhub/index.html:24
 #: src/olympia/devhub/templates/devhub/addons/dashboard.html:29
 msgid "Submit a New Theme"
 msgstr ""
 
-#: src/olympia/amo/context_processors.py:79 src/olympia/amo/templates/amo/site_nav.html:87 src/olympia/devhub/helpers.py:36 src/olympia/devhub/helpers.py:68 src/olympia/devhub/helpers.py:102
+#: src/olympia/amo/context_processors.py:78 src/olympia/amo/templates/amo/site_nav.html:85 src/olympia/devhub/helpers.py:36 src/olympia/devhub/helpers.py:68 src/olympia/devhub/helpers.py:102
 #: src/olympia/templates/footer.html:6 src/olympia/templates/menu_links.html:14
 msgid "Developer Hub"
 msgstr ""
 
-#: src/olympia/amo/context_processors.py:83 src/olympia/devhub/views.py:1792
+#: src/olympia/amo/context_processors.py:81 src/olympia/devhub/views.py:1796
 msgid "Manage API Keys"
 msgstr ""
 
-#: src/olympia/amo/context_processors.py:88 src/olympia/editors/helpers.py:82 src/olympia/editors/helpers.py:102 src/olympia/editors/templates/editors/base.html:10
+#: src/olympia/amo/context_processors.py:86 src/olympia/editors/helpers.py:84 src/olympia/editors/helpers.py:104 src/olympia/editors/templates/editors/base.html:10
 msgid "Editor Tools"
 msgstr ""
 
-#: src/olympia/amo/context_processors.py:92
+#: src/olympia/amo/context_processors.py:90
 msgid "Admin Tools"
 msgstr ""
 
-#: src/olympia/amo/fields.py:15
+#: src/olympia/amo/fields.py:20
 msgid "Incorrect, please try again."
 msgstr ""
 
-#: src/olympia/amo/fields.py:16
+#: src/olympia/amo/fields.py:21
 msgid "Error verifying input, please try again."
 msgstr ""
 
-#: src/olympia/amo/fields.py:32
+#: src/olympia/amo/fields.py:37
 msgid "This must be a valid hex color code, such as #000000."
 msgstr ""
 
-#: src/olympia/amo/fields.py:58
+#: src/olympia/amo/fields.py:63
 msgid "Enter at least one value."
 msgstr ""
 
-#: src/olympia/amo/helpers.py:162 src/olympia/amo/templates/amo/site_nav.html:61 src/olympia/bandwagon/templates/bandwagon/add.html:9
+#: src/olympia/amo/helpers.py:162 src/olympia/amo/templates/amo/site_nav.html:59 src/olympia/bandwagon/templates/bandwagon/add.html:9
 #: src/olympia/bandwagon/templates/bandwagon/collection_detail.html:15 src/olympia/bandwagon/templates/bandwagon/delete.html:9 src/olympia/bandwagon/templates/bandwagon/edit.html:15
 #: src/olympia/bandwagon/templates/bandwagon/user_listing.html:18 src/olympia/bandwagon/templates/bandwagon/user_listing.html:21
 #: src/olympia/bandwagon/templates/bandwagon/impala/collection_listing.html:12 src/olympia/bandwagon/templates/bandwagon/impala/collection_listing.html:20
 #: src/olympia/bandwagon/templates/bandwagon/impala/collection_listing.html:24 src/olympia/bandwagon/templates/bandwagon/impala/collection_sidebar.html:3
 #: src/olympia/bandwagon/templates/bandwagon/includes/collection_sidebar.html:2 src/olympia/bandwagon/templates/bandwagon/mobile/collection_listing.html:3
-#: src/olympia/stats/templates/stats/stats.html:77 src/olympia/templates/menu_links.html:12
+#: src/olympia/stats/templates/stats/stats.html:33 src/olympia/templates/menu_links.html:12
 msgid "Collections"
 msgstr "Collections"
 
-#: src/olympia/amo/helpers.py:171 src/olympia/amo/templates/amo/site_nav.html:85 src/olympia/browse/templates/browse/language_tools.html:3
+#: src/olympia/amo/helpers.py:171 src/olympia/amo/templates/amo/site_nav.html:83 src/olympia/browse/templates/browse/language_tools.html:3
 msgid "Dictionaries & Language Packs"
 msgstr ""
 
@@ -1624,8 +1591,8 @@ msgstr ""
 msgid "Comment on {addon} {version}."
 msgstr ""
 
-#: src/olympia/amo/log.py:236 src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:19 src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:47
-#: src/olympia/editors/helpers.py:511 src/olympia/editors/templates/editors/themes/history_table.html:11
+#: src/olympia/amo/log.py:236 src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:17 src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:45
+#: src/olympia/editors/helpers.py:584 src/olympia/editors/templates/editors/themes/history_table.html:11
 msgid "Comment"
 msgstr ""
 
@@ -1948,7 +1915,7 @@ msgstr "Prev"
 #: src/olympia/amo/templates/amo/mobile/paginator.html:14 src/olympia/amo/templates/amo/mobile/paginator.html:16 src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:51
 #: src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:65 src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:78
 #: src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:91 src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:104
-#: src/olympia/discovery/templates/discovery/pane.html:45 src/olympia/discovery/templates/discovery/addons/detail.html:39 src/olympia/stats/templates/stats/stats.html:167
+#: src/olympia/discovery/templates/discovery/pane.html:45 src/olympia/discovery/templates/discovery/addons/detail.html:39 src/olympia/stats/templates/stats/stats.html:169
 msgid "Next"
 msgstr "Next"
 
@@ -1980,7 +1947,7 @@ msgid ""
 msgstr ""
 
 #: src/olympia/amo/templates/amo/side_nav.html:4 src/olympia/amo/templates/amo/side_nav.html:12 src/olympia/amo/templates/amo/site_nav.html:4 src/olympia/amo/templates/amo/site_nav.html:26
-#: src/olympia/browse/views.py:56 src/olympia/browse/views.py:66 src/olympia/browse/views.py:237 src/olympia/browse/views.py:282 src/olympia/search/forms.py:86
+#: src/olympia/browse/views.py:56 src/olympia/browse/views.py:66 src/olympia/browse/views.py:204 src/olympia/browse/views.py:249 src/olympia/search/forms.py:86
 msgid "Top Rated"
 msgstr "Top Rated"
 
@@ -1995,38 +1962,38 @@ msgstr ""
 msgid "Extensions"
 msgstr "Extensions"
 
-#: src/olympia/amo/templates/amo/site_nav.html:45
+#: src/olympia/amo/templates/amo/site_nav.html:44
 msgid "Want more customization? Try <b>Complete Themes</b>"
 msgstr ""
 
-#: src/olympia/amo/templates/amo/site_nav.html:56 src/olympia/bandwagon/views.py:96
+#: src/olympia/amo/templates/amo/site_nav.html:54 src/olympia/bandwagon/views.py:96
 msgid "Most Followers"
 msgstr ""
 
-#: src/olympia/amo/templates/amo/site_nav.html:68 src/olympia/bandwagon/templates/bandwagon/impala/collection_sidebar.html:16
+#: src/olympia/amo/templates/amo/site_nav.html:66 src/olympia/bandwagon/templates/bandwagon/impala/collection_sidebar.html:16
 #: src/olympia/bandwagon/templates/bandwagon/includes/collection_sidebar.html:18
 msgid "Collections I've Made"
 msgstr ""
 
-#: src/olympia/amo/templates/amo/site_nav.html:70 src/olympia/bandwagon/templates/bandwagon/user_listing.html:4 src/olympia/bandwagon/templates/bandwagon/impala/collection_sidebar.html:13
+#: src/olympia/amo/templates/amo/site_nav.html:68 src/olympia/bandwagon/templates/bandwagon/user_listing.html:4 src/olympia/bandwagon/templates/bandwagon/impala/collection_sidebar.html:13
 #: src/olympia/bandwagon/templates/bandwagon/includes/collection_sidebar.html:15
 msgid "Collections I'm Following"
 msgstr ""
 
-#: src/olympia/amo/templates/amo/site_nav.html:73 src/olympia/bandwagon/templates/bandwagon/impala/collection_sidebar.html:18
-#: src/olympia/bandwagon/templates/bandwagon/includes/collection_sidebar.html:20 src/olympia/users/models.py:512
+#: src/olympia/amo/templates/amo/site_nav.html:71 src/olympia/bandwagon/templates/bandwagon/impala/collection_sidebar.html:18
+#: src/olympia/bandwagon/templates/bandwagon/includes/collection_sidebar.html:20 src/olympia/users/models.py:521
 msgid "My Favorite Add-ons"
 msgstr ""
 
-#: src/olympia/amo/templates/amo/site_nav.html:78
+#: src/olympia/amo/templates/amo/site_nav.html:76
 msgid "More&hellip;"
 msgstr ""
 
-#: src/olympia/amo/templates/amo/site_nav.html:82
+#: src/olympia/amo/templates/amo/site_nav.html:80
 msgid "Add-ons for Mobile"
 msgstr ""
 
-#: src/olympia/amo/templates/amo/site_nav.html:86 src/olympia/browse/feeds.py:207 src/olympia/browse/templates/browse/search_tools.html:3 src/olympia/constants/base.py:176
+#: src/olympia/amo/templates/amo/site_nav.html:84 src/olympia/browse/feeds.py:207 src/olympia/browse/templates/browse/search_tools.html:3 src/olympia/constants/base.py:176
 #: src/olympia/templates/menu_links.html:10
 msgid "Search Tools"
 msgstr ""
@@ -2042,7 +2009,7 @@ msgid "Jump to first page"
 msgstr ""
 
 #: src/olympia/amo/templates/amo/impala/paginator.html:22 src/olympia/amo/templates/amo/mobile/impala_paginator.html:12 src/olympia/discovery/templates/discovery/pane.html:44
-#: src/olympia/discovery/templates/discovery/addons/detail.html:38 src/olympia/stats/templates/stats/stats.html:164
+#: src/olympia/discovery/templates/discovery/addons/detail.html:38 src/olympia/stats/templates/stats/stats.html:166
 msgid "Previous"
 msgstr ""
 
@@ -2064,33 +2031,50 @@ msgid "Page {n}"
 msgid_plural "Page {n}"
 msgstr[0] ""
 msgstr[1] ""
-msgstr[2] ""
-msgstr[3] ""
 
-#: src/olympia/amo/templates/services/install.html:38
-#, python-format
-msgid "If you are not prompted to install %(addon_name)s in a moment, please <a href=\"%(addon_xpi)s\">click here</a>."
-msgstr ""
-
-#: src/olympia/amo/tests/test_messages.py:57 src/olympia/amo/tests/test_messages.py:58 src/olympia/reviews/forms.py:25 src/olympia/reviews/forms.py:50 src/olympia/reviews/templates/reviews/add.html:56
+#: src/olympia/amo/tests/test_messages.py:56 src/olympia/amo/tests/test_messages.py:57 src/olympia/reviews/forms.py:25 src/olympia/reviews/forms.py:50 src/olympia/reviews/templates/reviews/add.html:56
 #: src/olympia/reviews/templates/reviews/reply.html:30
 msgid "Title"
 msgstr ""
 
-#: src/olympia/amo/tests/test_messages.py:57 src/olympia/amo/tests/test_messages.py:58
+#: src/olympia/amo/tests/test_messages.py:56 src/olympia/amo/tests/test_messages.py:57
 msgid "Body"
 msgstr ""
 
-#: src/olympia/amo/tests/test_messages.py:59
+#: src/olympia/amo/tests/test_messages.py:58
 msgid "Another Title"
 msgstr ""
 
-#: src/olympia/amo/tests/test_messages.py:59
+#: src/olympia/amo/tests/test_messages.py:58
 msgid "Another Body"
 msgstr ""
 
-#: src/olympia/api/views.py:255
-msgid "Not implemented yet."
+#: src/olympia/api/authentication.py:76
+msgid "Signature has expired."
+msgstr ""
+
+#: src/olympia/api/authentication.py:79
+msgid "Error decoding signature."
+msgstr ""
+
+#: src/olympia/api/authentication.py:82
+msgid "Invalid JWT Token."
+msgstr ""
+
+#: src/olympia/api/authentication.py:130
+msgid "Invalid Authorization header. No credentials provided."
+msgstr ""
+
+#: src/olympia/api/authentication.py:133
+msgid "Invalid Authorization header. Credentials string should not contain spaces."
+msgstr ""
+
+#: src/olympia/api/fields.py:29
+msgid "The field must have a length of at least {num} characters."
+msgstr ""
+
+#: src/olympia/api/fields.py:31
+msgid "The language code {lang_code} is invalid."
 msgstr ""
 
 #: src/olympia/applications/views.py:39 src/olympia/applications/templates/applications/appversions.html:3
@@ -2109,7 +2093,7 @@ msgstr "Fersiynau Rhaglenni Dilys"
 msgid "Add-ons submitted to Mozilla Add-ons must have a manifest file with at least one of the below applications supported. Only the versions listed below are allowed for these applications."
 msgstr ""
 
-#: src/olympia/applications/templates/applications/appversions.html:25
+#: src/olympia/applications/templates/applications/appversions.html:25 src/olympia/editors/helpers.py:361
 msgid "GUID"
 msgstr "GUID"
 
@@ -2223,8 +2207,8 @@ msgstr ""
 msgid "Remove from favorites"
 msgstr ""
 
-#: src/olympia/bandwagon/views.py:98 src/olympia/bandwagon/views.py:191 src/olympia/browse/views.py:58 src/olympia/browse/views.py:69 src/olympia/browse/views.py:458 src/olympia/devhub/views.py:74
-#: src/olympia/devhub/views.py:82 src/olympia/devhub/templates/devhub/addons/edit/basic.html:20 src/olympia/editors/templates/editors/leaderboard.html:24
+#: src/olympia/bandwagon/views.py:98 src/olympia/bandwagon/views.py:191 src/olympia/browse/views.py:58 src/olympia/browse/views.py:69 src/olympia/browse/views.py:425 src/olympia/devhub/views.py:72
+#: src/olympia/devhub/views.py:80 src/olympia/devhub/templates/devhub/addons/edit/basic.html:20 src/olympia/editors/templates/editors/leaderboard.html:24
 #: src/olympia/editors/templates/editors/themes/queue_list.html:48 src/olympia/search/forms.py:17 src/olympia/search/forms.py:89 src/olympia/users/templates/users/vcard.html:5
 msgid "Name"
 msgstr ""
@@ -2233,7 +2217,7 @@ msgstr ""
 msgid "Recently Popular"
 msgstr ""
 
-#: src/olympia/bandwagon/views.py:189 src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:18
+#: src/olympia/bandwagon/views.py:189 src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:16
 msgid "Added"
 msgstr ""
 
@@ -2247,7 +2231,7 @@ msgstr ""
 
 #: src/olympia/bandwagon/views.py:316
 #, python-format
-msgid "Your new collection is shown below. You can <ahref=\"%(url)s\">edit additional settings</a> if you'dlike."
+msgid "Your new collection is shown below. You can <a href=\"%(url)s\">edit additional settings</a> if you'd like."
 msgstr ""
 
 #: src/olympia/bandwagon/views.py:322
@@ -2328,8 +2312,6 @@ msgid "<span>%(num)s</span> follower"
 msgid_plural "<span>%(num)s</span> followers"
 msgstr[0] ""
 msgstr[1] ""
-msgstr[2] ""
-msgstr[3] ""
 
 #: src/olympia/bandwagon/templates/bandwagon/collection_detail.html:54
 msgid "About this Collection"
@@ -2369,8 +2351,6 @@ msgid "%(num)s Theme in this Collection"
 msgid_plural "%(num)s Themes in this Collection"
 msgstr[0] ""
 msgstr[1] ""
-msgstr[2] ""
-msgstr[3] ""
 
 #: src/olympia/bandwagon/templates/bandwagon/collection_detail.html:111
 #, python-format
@@ -2378,11 +2358,9 @@ msgid "%(num)s Add-on in this Collection"
 msgid_plural "%(num)s Add-ons in this Collection"
 msgstr[0] ""
 msgstr[1] ""
-msgstr[2] ""
-msgstr[3] ""
 
-#: src/olympia/bandwagon/templates/bandwagon/collection_detail.html:125 src/olympia/compat/templates/compat/index.html:25 src/olympia/compat/templates/compat/reporter_detail.html:29
-#: src/olympia/files/templates/files/viewer.html:29 src/olympia/templates/amo_footer.html:17 src/olympia/templates/includes/lang_switcher.html:10
+#: src/olympia/bandwagon/templates/bandwagon/collection_detail.html:125 src/olympia/compat/templates/compat/reporter_detail.html:29 src/olympia/files/templates/files/viewer.html:29
+#: src/olympia/templates/amo_footer.html:17 src/olympia/templates/includes/lang_switcher.html:10
 msgid "Go"
 msgstr ""
 
@@ -2428,8 +2406,6 @@ msgid "<span>%(addons)s</span> add-on"
 msgid_plural "<span>%(addons)s</span> add-ons"
 msgstr[0] ""
 msgstr[1] ""
-msgstr[2] ""
-msgstr[3] ""
 
 #: src/olympia/bandwagon/templates/bandwagon/collection_grid.html:32
 #, python-format
@@ -2437,8 +2413,6 @@ msgid "<span>%(followers)s</span> follower"
 msgid_plural "<span>%(followers)s</span> followers"
 msgstr[0] ""
 msgstr[1] ""
-msgstr[2] ""
-msgstr[3] ""
 
 #. People "follow" collections to get notified of updates.                    Like
 #. Twitter followers.
@@ -2450,8 +2424,6 @@ msgid "%(num)s weekly follower"
 msgid_plural "%(num)s weekly followers"
 msgstr[0] ""
 msgstr[1] ""
-msgstr[2] ""
-msgstr[3] ""
 
 #. People "follow" collections to get notified of updates.                    Like
 #. Twitter followers.
@@ -2461,8 +2433,6 @@ msgid "%(num)s monthly follower"
 msgid_plural "%(num)s monthly followers"
 msgstr[0] ""
 msgstr[1] ""
-msgstr[2] ""
-msgstr[3] ""
 
 #. People "follow" collections to get notified of updates.                    Like
 #. Twitter followers.
@@ -2474,8 +2444,6 @@ msgid "%(num)s follower"
 msgid_plural "%(num)s followers"
 msgstr[0] ""
 msgstr[1] ""
-msgstr[2] ""
-msgstr[3] ""
 
 #: src/olympia/bandwagon/templates/bandwagon/collection_listing_items.html:56 src/olympia/bandwagon/templates/bandwagon/impala/collection_listing_items.html:9
 #: src/olympia/devhub/templates/devhub/personas/edit.html:27
@@ -2560,7 +2528,7 @@ msgid "Remove this user as a contributor"
 msgstr ""
 
 #: src/olympia/bandwagon/templates/bandwagon/edit_contributors.html:18 src/olympia/bandwagon/templates/bandwagon/edit_contributors.html:43
-#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:20 src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:48
+#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:18 src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:46
 #: src/olympia/devhub/templates/devhub/addons/ajax_compat_update.html:19
 msgid "Remove"
 msgstr ""
@@ -2609,7 +2577,7 @@ msgid "<b>Warning:</b> By changing the owner of this collection, you will no lon
 msgstr ""
 
 #: src/olympia/bandwagon/templates/bandwagon/edit_contributors.html:83 src/olympia/devhub/templates/devhub/addons/forms_shared/media.html:157
-#: src/olympia/devhub/templates/devhub/addons/submit/describe.html:69 src/olympia/devhub/templates/devhub/addons/submit/license.html:60 src/olympia/devhub/templates/devhub/addons/submit/upload.html:78
+#: src/olympia/devhub/templates/devhub/addons/submit/describe.html:69 src/olympia/devhub/templates/devhub/addons/submit/license.html:60 src/olympia/devhub/templates/devhub/addons/submit/upload.html:70
 #: src/olympia/devhub/templates/devhub/payments/tier.html:17 src/olympia/editors/templates/editors/themes/themes.html:111 src/olympia/editors/templates/editors/themes/themes.html:128
 #: src/olympia/editors/templates/editors/themes/themes.html:134 src/olympia/editors/templates/editors/themes/themes.html:141 src/olympia/users/templates/users/fxa_migration_prompt_content.html:10
 #: src/olympia/users/templates/users/login_form.html:42 src/olympia/users/templates/users/mobile/login.html:57
@@ -2692,31 +2660,31 @@ msgid "Add-ons in Your Collection"
 msgstr ""
 
 #: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:4
-msgid ""
-"To include an add-on in this collection, enter its name in the box below and hit enter.  You can also use the <strong>Add to Collection</strong> links throughout the site to include add-ons later."
+msgid "To include an add-on in this collection, enter its name in the box below and hit enter."
 msgstr ""
 
-#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:17 src/olympia/constants/base.py:400 src/olympia/devhub/templates/devhub/addons/activity.html:62
+#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:15 src/olympia/constants/base.py:400 src/olympia/devhub/templates/devhub/addons/activity.html:62
+#: src/olympia/editors/helpers.py:273 src/olympia/editors/helpers.py:360
 msgid "Add-on"
 msgstr ""
 
-#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:26
+#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:24
 msgid "Enter the name of the add-on to include"
 msgstr ""
 
-#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:28
+#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:26
 msgid "Add to Collection"
 msgstr "Add to Collection"
 
-#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:45 src/olympia/editors/helpers.py:936 src/olympia/editors/helpers.py:956
+#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:43 src/olympia/editors/helpers.py:1016 src/olympia/editors/helpers.py:1036
 msgid "Pending"
 msgstr ""
 
-#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:47
+#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:45
 msgid "Add a comment"
 msgstr ""
 
-#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:48
+#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:46
 msgid "Remove this add-on from the collection"
 msgstr ""
 
@@ -2823,12 +2791,12 @@ msgstr ""
 msgid "Most Users"
 msgstr ""
 
-#: src/olympia/browse/views.py:61 src/olympia/browse/views.py:72 src/olympia/browse/views.py:279 src/olympia/browse/templates/browse/personas/mobile/category_landing.html:63
+#: src/olympia/browse/views.py:61 src/olympia/browse/views.py:72 src/olympia/browse/views.py:246 src/olympia/browse/templates/browse/personas/mobile/category_landing.html:63
 #: src/olympia/discovery/templates/discovery/pane.html:67 src/olympia/search/forms.py:92
 msgid "Up & Coming"
 msgstr ""
 
-#: src/olympia/browse/views.py:460 src/olympia/devhub/views.py:76 src/olympia/devhub/views.py:83 src/olympia/discovery/templates/discovery/addons/detail.html:66
+#: src/olympia/browse/views.py:427 src/olympia/devhub/views.py:74 src/olympia/devhub/views.py:81 src/olympia/discovery/templates/discovery/addons/detail.html:66
 msgid "Created"
 msgstr "Created"
 
@@ -2909,8 +2877,6 @@ msgid "<b>{0}</b> add-on"
 msgid_plural "<b>{0}</b> add-ons"
 msgstr[0] ""
 msgstr[1] ""
-msgstr[2] ""
-msgstr[3] ""
 
 #: src/olympia/browse/templates/browse/search_tools.html:61
 msgid "Search Extensions"
@@ -3017,11 +2983,9 @@ msgid "See the %(cnt)s extension in %(name)s &raquo;"
 msgid_plural "See all %(cnt)s extensions in %(name)s &raquo;"
 msgstr[0] ""
 msgstr[1] ""
-msgstr[2] ""
-msgstr[3] ""
 
-#: src/olympia/browse/templates/browse/mobile/extensions.html:13 src/olympia/compat/templates/compat/index.html:82 src/olympia/devhub/templates/devhub/devhub_search.html:24
-#: src/olympia/devhub/templates/devhub/addons/activity.html:47 src/olympia/search/templates/search/no_results.html:4 src/olympia/search/templates/search/mobile/results.html:36
+#: src/olympia/browse/templates/browse/mobile/extensions.html:13 src/olympia/devhub/templates/devhub/devhub_search.html:24 src/olympia/devhub/templates/devhub/addons/activity.html:47
+#: src/olympia/search/templates/search/no_results.html:4 src/olympia/search/templates/search/mobile/results.html:36
 msgid "No results found."
 msgstr "Heb ganfod canlyniad"
 
@@ -3106,7 +3070,7 @@ msgstr ""
 msgid "All"
 msgstr ""
 
-#: src/olympia/compat/forms.py:22 src/olympia/search/views.py:525
+#: src/olympia/compat/forms.py:22 src/olympia/editors/templates/editors/base.html:69 src/olympia/search/views.py:518
 msgid "All Add-ons"
 msgstr ""
 
@@ -3116,53 +3080,6 @@ msgstr ""
 
 #: src/olympia/compat/forms.py:24
 msgid "Non-binary"
-msgstr ""
-
-#. Review points sources other than add-ons and themes.
-#: src/olympia/compat/views.py:87 src/olympia/constants/base.py:388 src/olympia/devhub/forms.py:162 src/olympia/editors/templates/editors/performance.html:75
-msgid "Other"
-msgstr "Other"
-
-#: src/olympia/compat/templates/compat/index.html:4
-msgid "Add-on Compatibility Report for {app} {version}"
-msgstr ""
-
-#: src/olympia/compat/templates/compat/index.html:11
-msgid "{app} {version} Compatibility"
-msgstr ""
-
-#: src/olympia/compat/templates/compat/index.html:17
-#, python-format
-msgid "Top 95%% compatible with previous version"
-msgstr ""
-
-#: src/olympia/compat/templates/compat/index.html:18
-#, python-format
-msgid "Top 95%% of all add-ons"
-msgstr ""
-
-#: src/olympia/compat/templates/compat/index.html:19
-msgid "All active add-ons"
-msgstr ""
-
-#: src/olympia/compat/templates/compat/index.html:23 src/olympia/constants/base.py:401
-msgid "App"
-msgstr ""
-
-#: src/olympia/compat/templates/compat/index.html:55
-msgid "Details for add-ons compatible with previous version:"
-msgstr ""
-
-#: src/olympia/compat/templates/compat/index.html:57
-msgid "Show all versions"
-msgstr ""
-
-#: src/olympia/compat/templates/compat/index.html:59
-msgid "Details for add-ons compatible with all versions:"
-msgstr ""
-
-#: src/olympia/compat/templates/compat/index.html:61
-msgid "Show previous version only"
 msgstr ""
 
 #: src/olympia/compat/templates/compat/reporter.html:3
@@ -3197,16 +3114,12 @@ msgid "{0} success report"
 msgid_plural "{0} success reports"
 msgstr[0] ""
 msgstr[1] ""
-msgstr[2] ""
-msgstr[3] ""
 
 #: src/olympia/compat/templates/compat/reporter_detail.html:17
 msgid "{0} problem report"
 msgid_plural "{0} problem reports"
 msgstr[0] ""
 msgstr[1] ""
-msgstr[2] ""
-msgstr[3] ""
 
 #: src/olympia/compat/templates/compat/reporter_detail.html:21 src/olympia/users/templates/users/profile.html:70
 msgid "View all"
@@ -3220,8 +3133,8 @@ msgstr ""
 msgid "Report Type"
 msgstr ""
 
-#: src/olympia/compat/templates/compat/reporter_detail.html:47 src/olympia/devhub/forms.py:784 src/olympia/devhub/templates/devhub/addons/ajax_compat_update.html:17 src/olympia/editors/forms.py:108
-#: src/olympia/zadmin/forms.py:45
+#: src/olympia/compat/templates/compat/reporter_detail.html:47 src/olympia/devhub/forms.py:785 src/olympia/devhub/templates/devhub/addons/ajax_compat_update.html:17 src/olympia/editors/forms.py:108
+#: src/olympia/editors/forms.py:248 src/olympia/zadmin/forms.py:45
 msgid "Application"
 msgstr ""
 
@@ -3309,7 +3222,8 @@ msgstr ""
 msgid "Preliminarily Reviewed and Awaiting Full Review"
 msgstr ""
 
-#: src/olympia/constants/base.py:33 src/olympia/editors/helpers.py:924 src/olympia/editors/templates/editors/themes/history_table.html:34
+#: src/olympia/constants/base.py:33 src/olympia/editors/forms.py:258 src/olympia/editors/helpers.py:73 src/olympia/editors/helpers.py:1004
+#: src/olympia/editors/templates/editors/themes/history_table.html:34
 msgid "Deleted"
 msgstr ""
 
@@ -3409,6 +3323,11 @@ msgstr ""
 msgid "Ask before users can download this add-on"
 msgstr ""
 
+#. Review points sources other than add-ons and themes.
+#: src/olympia/constants/base.py:388 src/olympia/devhub/forms.py:162 src/olympia/editors/templates/editors/performance.html:75
+msgid "Other"
+msgstr "Other"
+
 #: src/olympia/constants/base.py:389
 msgid "Exception"
 msgstr ""
@@ -3419,6 +3338,10 @@ msgstr ""
 
 #: src/olympia/constants/base.py:391
 msgid "Change"
+msgstr ""
+
+#: src/olympia/constants/base.py:401
+msgid "App"
 msgstr ""
 
 #: src/olympia/constants/base.py:402
@@ -3569,7 +3492,7 @@ msgstr ""
 msgid "Duplicate"
 msgstr ""
 
-#: src/olympia/constants/editors.py:17 src/olympia/editors/helpers.py:502 src/olympia/editors/templates/editors/themes/queue.html:71 src/olympia/editors/templates/editors/themes/themes.html:94
+#: src/olympia/constants/editors.py:17 src/olympia/editors/helpers.py:575 src/olympia/editors/templates/editors/themes/queue.html:71 src/olympia/editors/templates/editors/themes/themes.html:94
 msgid "Reject"
 msgstr ""
 
@@ -3669,7 +3592,7 @@ msgstr ""
 msgid "Android"
 msgstr ""
 
-#: src/olympia/core/apps.py:19
+#: src/olympia/core/apps.py:21
 msgid "Core"
 msgstr ""
 
@@ -3803,7 +3726,7 @@ msgid "Submit my add-on for manual review."
 msgstr ""
 
 #: src/olympia/devhub/forms.py:537
-msgid "Do not list my add-on on this site (beta)"
+msgid "Do not list my add-on on this site"
 msgstr ""
 
 #: src/olympia/devhub/forms.py:538
@@ -3836,46 +3759,46 @@ msgstr ""
 
 #: src/olympia/devhub/forms.py:592
 #, python-format
-msgid "Version %s already exists"
+msgid "Version %s already exists, or was uploaded before."
 msgstr ""
 
-#: src/olympia/devhub/forms.py:604
+#: src/olympia/devhub/forms.py:605
 msgid "Select a valid choice. That choice is not one of the available choices."
 msgstr ""
 
-#: src/olympia/devhub/forms.py:610
+#: src/olympia/devhub/forms.py:611
 msgid "A file with a version ending with a|alpha|b|beta and an optional number is detected as beta."
 msgstr ""
 
-#: src/olympia/devhub/forms.py:633
+#: src/olympia/devhub/forms.py:634
 msgid "You cannot upload any more files for this version."
 msgstr ""
 
-#: src/olympia/devhub/forms.py:639
+#: src/olympia/devhub/forms.py:640
 msgid "Version doesn't match"
 msgstr ""
 
-#: src/olympia/devhub/forms.py:668
+#: src/olympia/devhub/forms.py:669
 msgid "You cannot delete a file once the review process has started.  You must delete the whole version."
 msgstr ""
 
-#: src/olympia/devhub/forms.py:688
+#: src/olympia/devhub/forms.py:689
 msgid "The platform All cannot be combined with specific platforms."
 msgstr ""
 
-#: src/olympia/devhub/forms.py:693
+#: src/olympia/devhub/forms.py:694
 msgid "A platform can only be chosen once."
 msgstr ""
 
-#: src/olympia/devhub/forms.py:706
+#: src/olympia/devhub/forms.py:707
 msgid "A review type must be selected."
 msgstr ""
 
-#: src/olympia/devhub/forms.py:788 src/olympia/editors/forms.py:114 src/olympia/zadmin/forms.py:49 src/olympia/zadmin/forms.py:52
+#: src/olympia/devhub/forms.py:789 src/olympia/editors/forms.py:114 src/olympia/editors/forms.py:254 src/olympia/zadmin/forms.py:49 src/olympia/zadmin/forms.py:52
 msgid "Select an application first"
 msgstr ""
 
-#: src/olympia/devhub/forms.py:840
+#: src/olympia/devhub/forms.py:841
 msgid "There cannot be more than 3 required add-ons."
 msgstr ""
 
@@ -3898,8 +3821,6 @@ msgid "{0} error"
 msgid_plural "{0} errors"
 msgstr[0] "{0} error"
 msgstr[1] "{0} errors"
-msgstr[2] ""
-msgstr[3] ""
 
 # {0} is a number
 #. L10n: first parameter is the number of warnings
@@ -3908,83 +3829,81 @@ msgid "{0} warning"
 msgid_plural "{0} warnings"
 msgstr[0] "{0} warning"
 msgstr[1] "{0} warnings"
-msgstr[2] ""
-msgstr[3] ""
 
 #: src/olympia/devhub/models.py:375 src/olympia/reviews/templates/reviews/add.html:58
 msgid "Review"
 msgstr "Review"
 
-#: src/olympia/devhub/tasks.py:551
+#: src/olympia/devhub/tasks.py:583
 #, python-format
 msgid "%s responded with %s (%s)."
 msgstr ""
 
-#: src/olympia/devhub/tasks.py:555
+#: src/olympia/devhub/tasks.py:587
 #, python-format
 msgid "Connection to \"%s\" timed out."
 msgstr ""
 
-#: src/olympia/devhub/tasks.py:557
+#: src/olympia/devhub/tasks.py:589
 #, python-format
 msgid "Could not contact host at \"%s\"."
 msgstr ""
 
-#: src/olympia/devhub/utils.py:104
+#: src/olympia/devhub/utils.py:105
 #, python-format
 msgid "Validation generated too many errors/warnings so %s messages were truncated. After addressing the visible messages, you'll be able to see the others."
 msgstr ""
 
-#: src/olympia/devhub/views.py:183
+#: src/olympia/devhub/views.py:181
 msgid "All My Add-ons"
 msgstr ""
 
-#: src/olympia/devhub/views.py:210
+#: src/olympia/devhub/views.py:208
 msgid "All Activity"
 msgstr ""
 
-#: src/olympia/devhub/views.py:211
+#: src/olympia/devhub/views.py:209
 msgid "Add-on Updates"
 msgstr ""
 
-#: src/olympia/devhub/views.py:212
+#: src/olympia/devhub/views.py:210
 msgid "Add-on Status"
 msgstr ""
 
-#: src/olympia/devhub/views.py:213
+#: src/olympia/devhub/views.py:211
 msgid "User Collections"
 msgstr ""
 
-#: src/olympia/devhub/views.py:214 src/olympia/devhub/templates/devhub/docs/policies-maintenance.html:68 src/olympia/pages/templates/pages/dev_faq.html:38
+#: src/olympia/devhub/views.py:212 src/olympia/devhub/templates/devhub/docs/policies-maintenance.html:68 src/olympia/pages/templates/pages/dev_faq.html:38
 #: src/olympia/pages/templates/pages/dev_faq.html:484
 msgid "User Reviews"
 msgstr ""
 
-#: src/olympia/devhub/views.py:327 src/olympia/devhub/views.py:331 src/olympia/devhub/views.py:484 src/olympia/devhub/views.py:513 src/olympia/devhub/views.py:564 src/olympia/devhub/views.py:1150
+#: src/olympia/devhub/views.py:325 src/olympia/devhub/views.py:329 src/olympia/devhub/views.py:484 src/olympia/devhub/views.py:513 src/olympia/devhub/views.py:564 src/olympia/devhub/views.py:1156
 msgid "Changes successfully saved."
 msgstr ""
 
-#: src/olympia/devhub/views.py:334 src/olympia/devhub/views.py:1631
+#: src/olympia/devhub/views.py:332 src/olympia/devhub/views.py:1637
 msgid "Please check the form for errors."
 msgstr ""
 
-#: src/olympia/devhub/views.py:346
+#: src/olympia/devhub/views.py:344
 msgid "Add-on cannot be deleted. Disable this add-on instead."
 msgstr ""
 
-#: src/olympia/devhub/views.py:356
+#: src/olympia/devhub/views.py:354
 msgid "Theme deleted."
 msgstr ""
 
-#: src/olympia/devhub/views.py:356
+#: src/olympia/devhub/views.py:354
 msgid "Add-on deleted."
 msgstr ""
 
-#: src/olympia/devhub/views.py:362
+#: src/olympia/devhub/views.py:360
 msgid "URL name was incorrect. Theme was not deleted."
 msgstr ""
 
-#: src/olympia/devhub/views.py:367
+#: src/olympia/devhub/views.py:365
 msgid "URL name was incorrect. Add-on was not deleted."
 msgstr ""
 
@@ -4012,7 +3931,7 @@ msgstr ""
 msgid "Check Add-on Compatibility"
 msgstr ""
 
-#: src/olympia/devhub/views.py:808 src/olympia/signing/views.py:90
+#: src/olympia/devhub/views.py:808 src/olympia/signing/views.py:95
 msgid "You cannot submit this type of add-on"
 msgstr ""
 
@@ -4042,33 +3961,33 @@ msgstr ""
 msgid "There was an error uploading your preview."
 msgstr ""
 
-#: src/olympia/devhub/views.py:1189
+#: src/olympia/devhub/views.py:1195
 #, python-format
 msgid "Version %s disabled."
 msgstr ""
 
-#: src/olympia/devhub/views.py:1193
+#: src/olympia/devhub/views.py:1199
 #, python-format
 msgid "Version %s deleted."
 msgstr ""
 
-#: src/olympia/devhub/views.py:1203
+#: src/olympia/devhub/views.py:1209
 msgid "This upload has failed validation, and may lack complete validation results. Please take due care when reviewing it."
 msgstr ""
 
-#: src/olympia/devhub/views.py:1677
+#: src/olympia/devhub/views.py:1683
 msgid "Preliminary Review Requested."
 msgstr ""
 
-#: src/olympia/devhub/views.py:1678
+#: src/olympia/devhub/views.py:1684
 msgid "Full Review Requested."
 msgstr ""
 
-#: src/olympia/devhub/views.py:1779
+#: src/olympia/devhub/views.py:1783
 msgid "Your old credentials were revoked and are no longer valid. Be sure to update all API clients with the new credentials."
 msgstr ""
 
-#: src/olympia/devhub/views.py:1797
+#: src/olympia/devhub/views.py:1801
 msgid "New API key created"
 msgstr ""
 
@@ -4098,7 +4017,7 @@ msgstr ""
 msgid "{0} :: Search"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/devhub_search.html:6 src/olympia/devhub/templates/devhub/search.html:8 src/olympia/editors/forms.py:435 src/olympia/editors/forms.py:437
+#: src/olympia/devhub/templates/devhub/devhub_search.html:6 src/olympia/devhub/templates/devhub/search.html:8 src/olympia/editors/forms.py:534 src/olympia/editors/forms.py:536
 #: src/olympia/editors/templates/editors/queue.html:27 src/olympia/editors/templates/editors/themes/queue_list.html:14 src/olympia/search/templates/search/collections.html:17
 #: src/olympia/search/templates/search/personas.html:18 src/olympia/search/templates/search/results.html:18 src/olympia/search/templates/search/mobile/results.html:8
 #: src/olympia/templates/search.html:14 src/olympia/templates/impala/search.html:18
@@ -4158,12 +4077,12 @@ msgstr ""
 msgid "Start Making Add-ons"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/index.html:86 src/olympia/devhub/templates/devhub/addons/listing/items.html:25 src/olympia/devhub/templates/devhub/includes/addon_details.html:15
+#: src/olympia/devhub/templates/devhub/index.html:86 src/olympia/devhub/templates/devhub/addons/listing/items.html:25 src/olympia/devhub/templates/devhub/includes/addon_details.html:20
 #: src/olympia/devhub/templates/devhub/personas/edit.html:43
 msgid "Status:"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/index.html:90 src/olympia/devhub/templates/devhub/includes/addon_details.html:100
+#: src/olympia/devhub/templates/devhub/index.html:90 src/olympia/devhub/templates/devhub/includes/addon_details.html:87
 msgid "Visibility:"
 msgstr ""
 
@@ -4171,11 +4090,11 @@ msgstr ""
 msgid "Latest Version:"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/index.html:109 src/olympia/devhub/templates/devhub/includes/addon_details.html:145 src/olympia/devhub/templates/devhub/personas/edit.html:49
+#: src/olympia/devhub/templates/devhub/index.html:109 src/olympia/devhub/templates/devhub/includes/addon_details.html:131 src/olympia/devhub/templates/devhub/personas/edit.html:49
 msgid "Queue Position:"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/index.html:110 src/olympia/devhub/templates/devhub/includes/addon_details.html:146 src/olympia/devhub/templates/devhub/personas/edit.html:50
+#: src/olympia/devhub/templates/devhub/index.html:110 src/olympia/devhub/templates/devhub/includes/addon_details.html:132 src/olympia/devhub/templates/devhub/personas/edit.html:50
 #, python-format
 msgid "%(position)s of %(total)s"
 msgstr ""
@@ -4277,16 +4196,6 @@ msgstr ""
 msgid "Do you want your add-on to be distributed on this site?"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/validate_addon.html:49 src/olympia/devhub/templates/devhub/addons/submit/upload.html:30 src/olympia/devhub/templates/devhub/versions/add_file_modal.html:14
-#: src/olympia/devhub/templates/devhub/versions/add_file_modal.html:53 src/olympia/devhub/templates/devhub/versions/list.html:298
-msgid "Warning:"
-msgstr ""
-
-#: src/olympia/devhub/templates/devhub/validate_addon.html:50 src/olympia/devhub/templates/devhub/addons/submit/upload.html:31
-#, python-format
-msgid "Submission of unlisted add-ons for signing is currently in an open beta. Please <a href=\"%(url)s\" target=\"_blank\">report any bugs</a> that you encounter."
-msgstr ""
-
 #. first parameter is a filename like lorem-ipsum-1.0.2.xpi
 #: src/olympia/devhub/templates/devhub/validation.html:5
 msgid "Validation Results for {0}"
@@ -4361,7 +4270,7 @@ msgstr ""
 msgid "Update Compatibility"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/addons/ajax_compat_update.html:4
+#: src/olympia/devhub/templates/devhub/addons/ajax_compat_update.html:4 src/olympia/devhub/templates/devhub/versions/edit.html:45
 msgid "Adjusting application information here will allow users to install your add-on even if the install manifest in the package indicates that the add-on is incompatible."
 msgstr ""
 
@@ -4373,9 +4282,9 @@ msgstr ""
 msgid "Add Another Application&hellip;"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/addons/ajax_compat_update.html:38 src/olympia/devhub/templates/devhub/addons/owner.html:86 src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:46
-#: src/olympia/devhub/templates/devhub/versions/list.html:351 src/olympia/devhub/templates/devhub/versions/list.html:353 src/olympia/templates/impala/base.html:132
-#: src/olympia/templates/impala/base.html:143 src/olympia/templates/impala/base.html:161 src/olympia/templates/impala/base.html:171
+#: src/olympia/devhub/templates/devhub/addons/ajax_compat_update.html:38 src/olympia/devhub/templates/devhub/addons/owner.html:86 src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:45
+#: src/olympia/devhub/templates/devhub/versions/list.html:349 src/olympia/devhub/templates/devhub/versions/list.html:351 src/olympia/templates/impala/base.html:129
+#: src/olympia/templates/impala/base.html:140 src/olympia/templates/impala/base.html:158 src/olympia/templates/impala/base.html:168
 msgid "Close"
 msgstr ""
 
@@ -4394,8 +4303,6 @@ msgid "<b>{0}</b> theme"
 msgid_plural "<b>{0}</b> themes"
 msgstr[0] ""
 msgstr[1] ""
-msgstr[2] ""
-msgstr[3] ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit.html:3 src/olympia/devhub/templates/devhub/addons/listing/item_actions.html:25
 #: src/olympia/devhub/templates/devhub/addons/listing/item_actions_theme.html:7 src/olympia/devhub/templates/devhub/includes/addons_edit_nav.html:2
@@ -4411,7 +4318,7 @@ msgstr ""
 msgid "Manage Authors & License"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/addons/owner.html:29 src/olympia/editors/templates/editors/review.html:270
+#: src/olympia/devhub/templates/devhub/addons/owner.html:29 src/olympia/editors/helpers.py:362 src/olympia/editors/templates/editors/review.html:270
 msgid "Authors"
 msgstr "Authors"
 
@@ -4480,17 +4387,11 @@ msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/basic.html:52
 msgid ""
-"A short explanation of your add-on's basic\n"
-"                          functionality that is displayed in search and browse\n"
-"                          listings, as well as at the top of your add-on's\n"
-"                          details page. It is only relevant for listed add-ons."
+"A short explanation of your add-on's basic functionality that is displayed in search and browse listings, as well as at the top of your add-on's details page. It is only relevant for listed add-ons."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/basic.html:73
-msgid ""
-"Categories are the primary way users browse through add-ons.\n"
-"                        Choose any that fit your add-on's functionality for the most\n"
-"                        exposure. It is only relevant for listed add-ons."
+msgid "Categories are the primary way users browse through add-ons. Choose any that fit your add-on's functionality for the most exposure. It is only relevant for listed add-ons."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/basic.html:90
@@ -4500,11 +4401,7 @@ msgid ""
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/basic.html:119
-msgid ""
-"Tags help users find your add-on and should be short\n"
-"                        descriptors such as tabs, toolbar, or twitter.  You\n"
-"                        may have a maximum of {0} tags. It is only relevant\n"
-"                        for listed add-ons."
+msgid "Tags help users find your add-on and should be short descriptors such as tabs, toolbar, or twitter. You may have a maximum of {0} tags. It is only relevant for listed add-ons."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/basic.html:129 src/olympia/devhub/templates/devhub/personas/edit.html:97 src/olympia/devhub/templates/devhub/personas/submit.html:46
@@ -4512,8 +4409,6 @@ msgid "Comma-separated, minimum of {0} character."
 msgid_plural "Comma-separated, minimum of {0} characters."
 msgstr[0] ""
 msgstr[1] ""
-msgstr[2] ""
-msgstr[3] ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/basic.html:132 src/olympia/devhub/templates/devhub/personas/edit.html:100 src/olympia/devhub/templates/devhub/personas/submit.html:49
 msgid "Example: dark, cinema, noir. Limit 20."
@@ -4524,8 +4419,6 @@ msgid "Reserved tag:"
 msgid_plural "Reserved tags:"
 msgstr[0] ""
 msgstr[1] ""
-msgstr[2] ""
-msgstr[3] ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/details.html:5
 msgid "Add-on Details"
@@ -4536,11 +4429,7 @@ msgid "Add-on Details for {0}"
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/details.html:22
-msgid ""
-"A longer explanation of features,\n"
-"                          functionality, and other relevant information. This\n"
-"                          field is only displayed on the add-on's details\n"
-"                          page. It is only relevant for listed add-ons."
+msgid "A longer explanation of features, functionality, and other relevant information. This field is only displayed on the add-on's details page. It is only relevant for listed add-ons."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/details.html:44 src/olympia/translations/templates/translations/trans-menu.html:13
@@ -4548,10 +4437,7 @@ msgid "Default Locale"
 msgstr "Default Locale"
 
 #: src/olympia/devhub/templates/devhub/addons/edit/details.html:45
-msgid ""
-"Information about your add-on is displayed in this locale\n"
-"                        unless you override it with a locale-specific translation.\n"
-"                        It is only relevant for listed add-ons."
+msgid "Information about your add-on is displayed in this locale unless you override it with a locale-specific translation. It is only relevant for listed add-ons."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/details.html:61 src/olympia/users/forms.py:311 src/olympia/users/templates/users/edit.html:122 src/olympia/users/templates/users/register.html:57
@@ -4561,10 +4447,8 @@ msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/details.html:63
 msgid ""
-"If your add-on has another homepage, enter its\n"
-"                          address here. If your website is localized into other\n"
-"                          languages multiple translations of this field can be\n"
-"                          added. It is only relevant for listed add-ons."
+"If your add-on has another homepage, enter its address here. If your website is localized into other languages multiple translations of this field can be added. It is only relevant for listed add-"
+"ons."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/media.html:3
@@ -4582,19 +4466,14 @@ msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/support.html:22
 msgid ""
-"If you wish to display an e-mail address for support\n"
-"                          inquiries, enter it here. If you have different\n"
-"                          addresses for each language multiple translations of\n"
-"                          this field can be added. It is only relevant for\n"
-"                          listed add-ons."
+"If you wish to display an e-mail address for support inquiries, enter it here. If you have different addresses for each language multiple translations of this field can be added. It is only "
+"relevant for listed add-ons."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/support.html:45
 msgid ""
-"If your add-on has a support website or forum, enter\n"
-"                          its address here. If your website is localized into\n"
-"                          other languages, multiple translations of this field can\n"
-"                          be added. It is only relevant for listed add-ons."
+"If your add-on has a support website or forum, enter its address here. If your website is localized into other languages, multiple translations of this field can be added. It is only relevant for "
+"listed add-ons."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:6
@@ -4608,11 +4487,8 @@ msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:23
 msgid ""
-"Any information end users may want to know that isn't\n"
-"                          necessarily applicable to the add-on summary or description.\n"
-"                          Common uses include listing known major bugs, information on\n"
-"                          how to report bugs, anticipated release date of a new version,\n"
-"                          etc. It is only relevant for listed add-ons."
+"Any information end users may want to know that isn't necessarily applicable to the add-on summary or description. Common uses include listing known major bugs, information on how to report bugs, "
+"anticipated release date of a new version, etc. It is only relevant for listed add-ons."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:46
@@ -4624,9 +4500,7 @@ msgid "Add-on Flags"
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:69
-msgid ""
-"These flags are used to classify add-ons. It is only\n"
-"                        relevant for listed add-ons."
+msgid "These flags are used to classify add-ons. It is only relevant for listed add-ons."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:74
@@ -4642,9 +4516,7 @@ msgid "View Source?"
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:90
-msgid ""
-"Whether the source of your add-on can be displayed in our\n"
-"                        online viewer. It is only relevant for listed add-ons."
+msgid "Whether the source of your add-on can be displayed in our online viewer. It is only relevant for listed add-ons."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:94
@@ -4660,10 +4532,7 @@ msgid "Public Stats?"
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:102
-msgid ""
-"Whether the download and usage stats of your add-on can\n"
-"                        be displayed in our online viewer.\n"
-"                        It is only relevant for listed add-ons."
+msgid "Whether the download and usage stats of your add-on can be displayed in our online viewer. It is only relevant for listed add-ons."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:107
@@ -4679,10 +4548,7 @@ msgid "Upgrade SDK?"
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:116
-msgid ""
-"If selected, we will try to automatically upgrade your\n"
-"                        add-on when a new version of the SDK is released.\n"
-"                        It is only relevant for listed add-ons."
+msgid "If selected, we will try to automatically upgrade your add-on when a new version of the SDK is released. It is only relevant for listed add-ons."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:121
@@ -4733,10 +4599,8 @@ msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/forms_shared/media.html:16
 msgid ""
-"Upload an icon for your add-on or choose from one of ours. The\n"
-"                      icon is displayed nearly everywhere your add-on is. Uploaded images\n"
-"                      must be one of the following image types: .png, .jpg.\n"
-"                      It is only relevant for listed add-ons."
+"Upload an icon for your add-on or choose from one of ours. The icon is displayed nearly everywhere your add-on is. Uploaded images must be one of the following image types: .png, .jpg. It is only "
+"relevant for listed add-ons."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/forms_shared/media.html:25
@@ -4749,9 +4613,7 @@ msgid "32x32px"
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/forms_shared/media.html:39
-msgid ""
-"Used in listings of add-ons, like search results\n"
-"                            and featured add-ons."
+msgid "Used in listings of add-ons, like search results and featured add-ons."
 msgstr ""
 
 #. The size of the icon
@@ -4846,16 +4708,14 @@ msgid "Deleting your add-on will permanently remove it from the site and prevent
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:24
-msgid ""
-"Enter the following text confirm your decision:\n"
-"           {slug}"
+msgid "Enter the following text confirm your decision: {slug}"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:34
+#: src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:33
 msgid "Please tell us why you are deleting your theme:"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:36
+#: src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:35
 msgid "Please tell us why you are deleting your add-on:"
 msgstr ""
 
@@ -4892,8 +4752,8 @@ msgstr "New Version"
 msgid "Daily statistics on downloads and users."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/addons/listing/item_actions.html:45 src/olympia/stats/templates/stats/stats.html:75 src/olympia/stats/templates/stats/stats.html:79
-#: src/olympia/stats/templates/stats/stats.html:81
+#: src/olympia/devhub/templates/devhub/addons/listing/item_actions.html:45 src/olympia/stats/templates/stats/stats.html:31 src/olympia/stats/templates/stats/stats.html:35
+#: src/olympia/stats/templates/stats/stats.html:37
 msgid "Statistics"
 msgstr "Statistics"
 
@@ -4954,8 +4814,6 @@ msgid "<strong>{0}</strong> active user"
 msgid_plural "<strong>{0}</strong> active users"
 msgstr[0] ""
 msgstr[1] ""
-msgstr[2] ""
-msgstr[3] ""
 
 #: src/olympia/devhub/templates/devhub/addons/submit/base.html:11
 msgid "Submit Add-on"
@@ -5014,10 +4872,7 @@ msgid "Your add-on has been submitted to the Full Review queue."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/submit/done.html:18
-msgid ""
-"You'll receive an email once it has been reviewed by an editor. In\n"
-"          the meantime, you and your friends can install it directly from its\n"
-"          details page:"
+msgid "You'll receive an email once it has been reviewed by an editor. In the meantime, you and your friends can install it directly from its details page:"
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/submit/done.html:27 src/olympia/devhub/templates/devhub/addons/submit/done.html:77 src/olympia/devhub/templates/devhub/personas/submit_done.html:16
@@ -5223,11 +5078,11 @@ msgstr ""
 msgid "Use the fields below to upload your add-on package and select any platform restrictions. After upload, a series of automated validation tests will be run on your file."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/addons/submit/upload.html:59 src/olympia/devhub/templates/devhub/versions/add_file_modal.html:39
+#: src/olympia/devhub/templates/devhub/addons/submit/upload.html:51 src/olympia/devhub/templates/devhub/versions/add_file_modal.html:28
 msgid "Which platforms is this file compatible with?"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/addons/submit/upload.html:67 src/olympia/devhub/templates/devhub/versions/add_file_modal.html:65
+#: src/olympia/devhub/templates/devhub/addons/submit/upload.html:59 src/olympia/devhub/templates/devhub/versions/add_file_modal.html:45
 msgid "Administrative overrides"
 msgstr ""
 
@@ -5337,8 +5192,8 @@ msgstr ""
 
 #: src/olympia/devhub/templates/devhub/docs/policies-contact.html:44
 msgid ""
-"If you've found a problem with the site, we'd love to fix it. Please <a href=\"https://github.com/mozilla/olympia/issues\">file a bug report</a> in GitHub, including the location of the problem and "
-"how you encountered it."
+"If you've found a problem with the site, we'd love to fix it. Please <a href=\"https://github.com/mozilla/addons/issues/new\">file a bug report</a> in GitHub, including the location of the problem "
+"and how you encountered it."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/docs/policies-maintenance.html:3 src/olympia/devhub/templates/devhub/docs/policies-maintenance.html:7
@@ -5905,7 +5760,7 @@ msgstr ""
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:282
 msgid ""
-"Add-ons that store or otherwise handle browsing data must support <a href=\"https://developer.mozilla.org/En/Supporting_private_browsing_mode\">Private Browsing Mode</a>.  During a Private Browsing "
+"Add-ons that store or otherwise handle browsing data must support <a href=\"https://developer.mozilla.org/En/Supporting_private_browsing_mode\">Private Browsing Mode</a>. During a Private Browsing "
 "session, no browsing data can be written to disk, and all of this data must be cleared when Firefox quits or the Private Browsing session ends."
 msgstr ""
 
@@ -6070,129 +5925,95 @@ msgstr ""
 msgid "How to get in touch with us regarding these policies or your add-on."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:6
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:10
 msgid "You have disabled this add-on"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:20
-msgid ""
-"Your add-on's listing is disabled and is not showing\n"
-"                             anywhere in our gallery or update service."
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:24
+msgid "Your add-on's listing is disabled and is not showing anywhere in our gallery or update service."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:25
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:27
 msgid "Please complete your add-on."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:29
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:30
 msgid "You will receive an email when the review is complete."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:34
-msgid ""
-"You will receive an email when the review is complete. Until\n"
-"                             then, your add-on is not listed in our gallery but can be\n"
-"                             accessed directly from its details page."
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:33
+msgid "You will receive an email when the review is complete. Until then, your add-on is not listed in our gallery but can be accessed directly from its details page."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:38 src/olympia/devhub/templates/devhub/includes/addon_details.html:48
-msgid ""
-"You will receive an email when the review is\n"
-"                             complete and your add-on is signed."
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:37 src/olympia/devhub/templates/devhub/includes/addon_details.html:45
+msgid "You will receive an email when the review is complete and your add-on is signed."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:44
-msgid ""
-"You will receive an email when the review is complete. Until\n"
-"                             then, your add-on is not listed in our gallery but can be\n"
-"                             accessed directly from its details page. "
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:41
+msgid "You will receive an email when the review is complete. Until then, your add-on is not listed in our gallery but can be accessed directly from its details page. "
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:54
-msgid ""
-"Your add-on is displayed in our gallery and users are\n"
-"                             receiving automatic updates."
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:49
+msgid "Your add-on is displayed in our gallery and users are receiving automatic updates."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:57
-msgid ""
-"Your add-on has been signed and can be bundled with an\n"
-"                             application installer."
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:52
+msgid "Your add-on has been signed and can be bundled with an application installer."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:63
-msgid ""
-"Your add-on was disabled by a site administrator and is no\n"
-"                             longer shown in our gallery. If you have any questions,\n"
-"                             please email amo-admins@mozilla.org."
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:56
+msgid "Your add-on was disabled by a site administrator and is no longer shown in our gallery. If you have any questions, please email amo-admins@mozilla.org."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:70
-msgid ""
-"Your add-on is displayed in our gallery as experimental\n"
-"                             and users are receiving automatic updates. Some features\n"
-"                             are unavailable to your add-on."
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:62
+msgid "Your add-on is displayed in our gallery as experimental and users are receiving automatic updates. Some features are unavailable to your add-on."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:74
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:66
 msgid "Your add-on has been signed."
 msgstr ""
 
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:69
+msgid ""
+"You will receive an email when the full review is complete. Until then, your add-on is displayed in our gallery as experimental and users are receiving automatic updates. Some features are "
+"unavailable to your add-on."
+msgstr ""
+
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:74
+msgid "You will receive an email when the full review is complete, making you able to bundle your add-on with an application installer."
+msgstr ""
+
 #: src/olympia/devhub/templates/devhub/includes/addon_details.html:79
-msgid ""
-"You will receive an email when the full review is complete.\n"
-"                             Until then, your add-on is displayed in our gallery as\n"
-"                             experimental and users are receiving automatic updates.\n"
-"                             Some features are unavailable to your add-on."
+msgid "All add-ons hosted in our gallery must now be reviewed by an editor. If you wish to continue hosting your add-on, please click to select a review process."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:84
-msgid ""
-"You will receive an email when the full review is\n"
-"                             complete, making you able to bundle your add-on with an\n"
-"                             application installer."
-msgstr ""
-
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:91
-msgid ""
-"All add-ons hosted in our gallery must now be reviewed by an\n"
-"                             editor. If you wish to continue hosting your add-on, please\n"
-"                             click to select a review process."
-msgstr ""
-
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:113
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:100
 msgid "Current Version:"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:115
-msgid ""
-"This is the version of your add-on that will\n"
-"                                           be installed if someone clicks the Install\n"
-"                                           button on addons.mozilla.org. It is only\n"
-"                                           relevant for listed add-ons."
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:102
+msgid "This is the version of your add-on that will be installed if someone clicks the Install button on addons.mozilla.org. It is only relevant for listed add-ons."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:123
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:110
 msgid "Created:"
 msgstr ""
 
 #. {0} is a date. dennis-ignore: E201
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:125 src/olympia/devhub/templates/devhub/includes/addon_details.html:131
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:112 src/olympia/devhub/templates/devhub/includes/addon_details.html:118
 #, python-format
 msgid "%%b %%e, %%Y"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:136
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:123
 msgid "Next Version:"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:138
-msgid ""
-"This is the newest uploaded version, however\n"
-"                                           it isn’t live on the site yet."
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:125
+msgid "This is the newest uploaded version, however it isn’t live on the site yet."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:144 src/olympia/devhub/templates/devhub/versions/list.html:30
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:130 src/olympia/devhub/templates/devhub/versions/list.html:30
 msgid "Queues are not reviewed strictly in order"
 msgstr ""
 
@@ -6260,9 +6081,7 @@ msgid "View the blog &#9658;"
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/includes/license_form.html:6
-msgid ""
-"Please choose a license appropriate for the rights you grant on your source code.\n"
-"                  It is only relevant for listed add-ons."
+msgid "Please choose a license appropriate for the rights you grant on your source code. It is only relevant for listed add-ons."
 msgstr ""
 
 #. {0} is a list of HTML tags.
@@ -6285,20 +6104,15 @@ msgid "Select <b>up to {0}</b> {1} category for this add-on:"
 msgid_plural "Select <b>up to {0}</b> {1} categories for this add-on:"
 msgstr[0] ""
 msgstr[1] ""
-msgstr[2] ""
-msgstr[3] ""
 
 #: src/olympia/devhub/templates/devhub/includes/policy_form.html:4
 msgid ""
 "Users will be required to accept the following End-User License Agreement (EULA) prior to installing your add-on. The presence of a EULA significantly affects the number of downloads an add-on "
-"receives. Please note that a EULA is not the same as a code license, such as the GPL or MPL.\n"
-"                It is only relevant for listed add-ons."
+"receives. Please note that a EULA is not the same as a code license, such as the GPL or MPL.It is only relevant for listed add-ons."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/policy_form.html:21
-msgid ""
-"If your add-on transmits any data from the user's computer, a privacy policy is required that explains what data is sent and how it is used.\n"
-"                It is only relevant for listed add-ons."
+#: src/olympia/devhub/templates/devhub/includes/policy_form.html:24
+msgid "If your add-on transmits any data from the user's computer, a privacy policy is required that explains what data is sent and how it is used. It is only relevant for listed add-ons."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/includes/source_form_field.html:2
@@ -6466,12 +6280,8 @@ msgstr ""
 msgid "Add some tags to describe your Theme."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/personas/edit.html:106
-msgid ""
-"A short explanation of your theme's\n"
-"                                basic functionality that is displayed in\n"
-"                                search and browse listings, as well as at\n"
-"                                the top of your theme's details page."
+#: src/olympia/devhub/templates/devhub/personas/edit.html:106 src/olympia/devhub/templates/devhub/personas/submit.html:54
+msgid "A short explanation of your theme's basic functionality that is displayed in search and browse listings, as well as at the top of your theme's details page."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/personas/edit.html:122 src/olympia/devhub/templates/devhub/personas/submit.html:68
@@ -6541,7 +6351,7 @@ msgid "Upon upload and form submission, the AMO Team will review your updated de
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/personas/edit.html:241
-msgid "Your previously resubmitted design,  which is under pending review."
+msgid "Your previously resubmitted design, which is under pending review."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/personas/edit.html:245
@@ -6608,14 +6418,6 @@ msgstr ""
 
 #: src/olympia/devhub/templates/devhub/personas/submit.html:33
 msgid "Give your Theme a name."
-msgstr ""
-
-#: src/olympia/devhub/templates/devhub/personas/submit.html:54
-msgid ""
-"A short explanation of your theme's\n"
-"                                      basic functionality that is displayed in\n"
-"                                      search and browse listings, as well as at\n"
-"                                      the top of your theme's details page."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/personas/submit.html:198
@@ -6692,30 +6494,16 @@ msgstr ""
 msgid "Files added to reviewed versions must be reviewed before they will be available for download."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/add_file_modal.html:15
-#, python-format
-msgid ""
-"Submission of updates to unlisted add-ons for signing is currently in an open beta. Manual review may still be required for a large number of add-ons. Please <a href=\"%(url)s\" target=\"_blank"
-"\">report any bugs</a> that you encounter."
-msgstr ""
-
-#: src/olympia/devhub/templates/devhub/versions/add_file_modal.html:35
+#: src/olympia/devhub/templates/devhub/versions/add_file_modal.html:24
 msgid "Select the target platform for this file."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/add_file_modal.html:46
+#: src/olympia/devhub/templates/devhub/versions/add_file_modal.html:35
 msgid "Which review type would you like to nominate for?"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/add_file_modal.html:51
+#: src/olympia/devhub/templates/devhub/versions/add_file_modal.html:40
 msgid "Only publish this version to my beta channel."
-msgstr ""
-
-#: src/olympia/devhub/templates/devhub/versions/add_file_modal.html:54
-#, python-format
-msgid ""
-"The behavior of the beta channel has changed to accommodate <a href=\"%(addon_signing_url)s\" target=\"_blank\">mandatory add-on signing</a>. The new process is currently in an open beta, and may "
-"change significantly in the near future. Please <a href=\"%(issues_url)s\" target=\"_blank\">report any bugs</a> that you encounter."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/versions/edit.html:5
@@ -6740,19 +6528,10 @@ msgstr ""
 msgid "Upload Another File"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/edit.html:45
-msgid ""
-"Adjusting application information here will allow users to install your\n"
-"                          add-on even if the install manifest in the package indicates that the\n"
-"                          add-on is incompatible."
-msgstr ""
-
 #: src/olympia/devhub/templates/devhub/versions/edit.html:74
 msgid ""
-"Information about changes in this release, new features,\n"
-"                              known bugs, and other useful information specific to this\n"
-"                              release/version. This information is also shown in the\n"
-"                              Add-ons Manager when updating."
+"Information about changes in this release, new features, known bugs, and other useful information specific to this release/version. This information is also shown in the Add-ons Manager when "
+"updating."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/versions/edit.html:99
@@ -6764,10 +6543,7 @@ msgid "Notes for Reviewers"
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/versions/edit.html:114
-msgid ""
-"Optionally, enter any information that may be useful\n"
-"                              to the Editor reviewing this add-on, such as test\n"
-"                              account information."
+msgid "Optionally, enter any information that may be useful to the Editor reviewing this add-on, such as test account information."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/versions/edit.html:127
@@ -6819,8 +6595,6 @@ msgid "{0} file"
 msgid_plural "{0} files"
 msgstr[0] ""
 msgstr[1] ""
-msgstr[2] ""
-msgstr[3] ""
 
 #: src/olympia/devhub/templates/devhub/versions/list.html:25
 msgid "0 files"
@@ -6847,7 +6621,7 @@ msgstr ""
 msgid "Request Preliminary Review"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:80 src/olympia/devhub/templates/devhub/versions/list.html:327 src/olympia/devhub/templates/devhub/versions/list.html:350
+#: src/olympia/devhub/templates/devhub/versions/list.html:80 src/olympia/devhub/templates/devhub/versions/list.html:325 src/olympia/devhub/templates/devhub/versions/list.html:348
 msgid "Cancel Review Request"
 msgstr ""
 
@@ -6876,7 +6650,7 @@ msgid "Unlisted:"
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/versions/list.html:114
-msgid "Not distributed on {0}. Developers will upload new versions for signing and distribute the add-ons on their own. (beta)"
+msgid "Not distributed on {0}. Developers will upload new versions for signing and distribute the add-ons on their own."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/versions/list.html:122
@@ -6940,81 +6714,73 @@ msgid "<strong>Important:</strong> Once a version has been deleted, you may not 
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/versions/list.html:230
-msgid ""
-"Deleting a version which has already been reviewed\n"
-"               may also cause a significant delay in the review of\n"
-"               your next update."
-msgstr ""
-
-#: src/olympia/devhub/templates/devhub/versions/list.html:233
 msgid "Are you sure you wish to delete this version?"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:238
+#: src/olympia/devhub/templates/devhub/versions/list.html:235
 msgid "Delete Version"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:240
+#: src/olympia/devhub/templates/devhub/versions/list.html:237
 msgid "Disable Version"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:247
+#: src/olympia/devhub/templates/devhub/versions/list.html:244
 msgid "Add a new Version"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:249
+#: src/olympia/devhub/templates/devhub/versions/list.html:246
 msgid "Add Version"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:256 src/olympia/devhub/templates/devhub/versions/list.html:274
+#: src/olympia/devhub/templates/devhub/versions/list.html:253 src/olympia/devhub/templates/devhub/versions/list.html:279
 msgid "Hide Add-on"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:259
+#: src/olympia/devhub/templates/devhub/versions/list.html:256
 msgid "Hiding your add-on will prevent it from appearing anywhere in our gallery and will stop users from receiving automatic updates."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:265
+#: src/olympia/devhub/templates/devhub/versions/list.html:263
+msgid "The files awaiting review will be disabled and you will need to upload new versions."
+msgstr ""
+
+#: src/olympia/devhub/templates/devhub/versions/list.html:270
 msgid "Are you sure you wish to hide your add-on?"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:286 src/olympia/devhub/templates/devhub/versions/list.html:315
+#: src/olympia/devhub/templates/devhub/versions/list.html:291 src/olympia/devhub/templates/devhub/versions/list.html:313
 msgid "Unlist Add-on"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:289
+#: src/olympia/devhub/templates/devhub/versions/list.html:294
 #, python-format
 msgid ""
 "Unlisting your add-on will make it (and each of its versions/files) invisible on this website. It won't show up in searches, won't have a public facing page, and won't be updated automatically for "
-"current users.  It is recommended for unlisted add-ons to provide a custom <a href=\"%(update_url)s\" target=\"_blank\">updateURL</a> in their manifest file for automatic updates."
+"current users. It is recommended for unlisted add-ons to provide a custom <a href=\"%(update_url)s\" target=\"_blank\">updateURL</a> in their manifest file for automatic updates."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:299
-#, python-format
-msgid "Switching add-ons to unlisted is currently in an open beta. Please <a href=\"%(url)s\" target=\"_blank\">report any bugs</a> that you encounter."
-msgstr ""
-
-#: src/olympia/devhub/templates/devhub/versions/list.html:305
+#: src/olympia/devhub/templates/devhub/versions/list.html:303
 msgid "Unlisting an add-on is irreversible!"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:305
+#: src/olympia/devhub/templates/devhub/versions/list.html:303
 msgid "An unlisted add-on cannot be switched to be listed."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:307
+#: src/olympia/devhub/templates/devhub/versions/list.html:305
 msgid "Are you sure you wish to unlist your add-on?"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:330
+#: src/olympia/devhub/templates/devhub/versions/list.html:328
 msgid "Canceling your review request will leave your add-on as preliminarily reviewed."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:335
+#: src/olympia/devhub/templates/devhub/versions/list.html:333
 msgid "Canceling your review request will mark your add-on incomplete. If you do not complete your add-on after several days by re-requesting review, it will be deleted."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:343
+#: src/olympia/devhub/templates/devhub/versions/list.html:341
 msgid "Are you sure you wish to cancel your review request?"
 msgstr ""
 
@@ -7353,19 +7119,19 @@ msgstr ""
 msgid "Search by add-on name / author email"
 msgstr ""
 
-#: src/olympia/editors/forms.py:103
+#: src/olympia/editors/forms.py:103 src/olympia/editors/forms.py:244 src/olympia/editors/forms.py:257
 msgid "yes"
 msgstr ""
 
-#: src/olympia/editors/forms.py:104
+#: src/olympia/editors/forms.py:104 src/olympia/editors/forms.py:244 src/olympia/editors/forms.py:257
 msgid "no"
 msgstr ""
 
-#: src/olympia/editors/forms.py:105
+#: src/olympia/editors/forms.py:105 src/olympia/editors/forms.py:245
 msgid "Admin Flag"
 msgstr ""
 
-#: src/olympia/editors/forms.py:113
+#: src/olympia/editors/forms.py:113 src/olympia/editors/forms.py:253
 msgid "Max. Version"
 msgstr ""
 
@@ -7377,55 +7143,59 @@ msgstr ""
 msgid "Add-on Types"
 msgstr ""
 
-#: src/olympia/editors/forms.py:126 src/olympia/editors/helpers.py:267
+#: src/olympia/editors/forms.py:126 src/olympia/editors/helpers.py:279
 msgid "Platforms"
 msgstr "Platforms"
 
+#: src/olympia/editors/forms.py:237
+msgid "Search by add-on name / author email / guid"
+msgstr ""
+
 #. L10n: 0 = platform, 1 = filename, 2 = status message
-#: src/olympia/editors/forms.py:238
+#: src/olympia/editors/forms.py:342
 #, python-format
 msgid "<strong>%s</strong> &middot; %s &middot; %s"
 msgstr ""
 
-#: src/olympia/editors/forms.py:252
+#: src/olympia/editors/forms.py:356
 msgid "Comments:"
 msgstr ""
 
-#: src/olympia/editors/forms.py:256
+#: src/olympia/editors/forms.py:360
 msgid "Operating systems:"
 msgstr ""
 
-#: src/olympia/editors/forms.py:258
+#: src/olympia/editors/forms.py:362
 msgid "Applications:"
 msgstr ""
 
-#: src/olympia/editors/forms.py:260
+#: src/olympia/editors/forms.py:364
 msgid "Notify me the next time this add-on is updated. (Subsequent updates will not generate an email)"
 msgstr ""
 
-#: src/olympia/editors/forms.py:265
+#: src/olympia/editors/forms.py:369
 msgid "Clear Admin Review Flag"
 msgstr ""
 
-#: src/olympia/editors/forms.py:267
+#: src/olympia/editors/forms.py:371
 msgid "Clear more info requested flag"
 msgstr ""
 
-#: src/olympia/editors/forms.py:281
+#: src/olympia/editors/forms.py:385
 msgid "Choose a canned response..."
 msgstr ""
 
 #. L10n: Description of what can be searched for.
-#: src/olympia/editors/forms.py:324
+#: src/olympia/editors/forms.py:423
 msgid "theme name"
 msgstr ""
 
-#: src/olympia/editors/forms.py:350
+#: src/olympia/editors/forms.py:449
 msgid "Someone else is reviewing this theme."
 msgstr ""
 
 #. L10n: Description of what can be searched for.
-#: src/olympia/editors/forms.py:447
+#: src/olympia/editors/forms.py:546
 msgid "app, reviewer, or comment"
 msgstr ""
 
@@ -7441,268 +7211,264 @@ msgstr ""
 msgid "Rejected or Unreviewed"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:123 src/olympia/editors/helpers.py:136
+#: src/olympia/editors/helpers.py:125 src/olympia/editors/helpers.py:138
 msgid "Queue"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:124 src/olympia/editors/templates/editors/base.html:50 src/olympia/editors/templates/editors/base.html:65
+#: src/olympia/editors/helpers.py:126 src/olympia/editors/templates/editors/base.html:50 src/olympia/editors/templates/editors/base.html:65
 msgid "Pending Updates"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:125 src/olympia/editors/templates/editors/base.html:48 src/olympia/editors/templates/editors/base.html:63
+#: src/olympia/editors/helpers.py:127 src/olympia/editors/templates/editors/base.html:48 src/olympia/editors/templates/editors/base.html:63
 msgid "Full Reviews"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:126 src/olympia/editors/templates/editors/base.html:52 src/olympia/editors/templates/editors/base.html:67
+#: src/olympia/editors/helpers.py:128 src/olympia/editors/templates/editors/base.html:52 src/olympia/editors/templates/editors/base.html:67
 msgid "Preliminary Reviews"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:127 src/olympia/editors/templates/editors/base.html:54
+#: src/olympia/editors/helpers.py:129 src/olympia/editors/templates/editors/base.html:54
 msgid "Moderated Reviews"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:128 src/olympia/editors/templates/editors/base.html:46
+#: src/olympia/editors/helpers.py:130 src/olympia/editors/templates/editors/base.html:46
 msgid "Fast Track"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:130
+#: src/olympia/editors/helpers.py:132
 msgid "Pending Themes"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:131 src/olympia/editors/templates/editors/themes/queue.html:4
+#: src/olympia/editors/helpers.py:133 src/olympia/editors/templates/editors/themes/queue.html:4
 msgid "Flagged Themes"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:132
+#: src/olympia/editors/helpers.py:134
 msgid "Update Themes"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:137
+#: src/olympia/editors/helpers.py:139
 msgid "Unlisted Pending Updates"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:138
+#: src/olympia/editors/helpers.py:140
 msgid "Unlisted Full Reviews"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:139
+#: src/olympia/editors/helpers.py:141
 msgid "Unlisted Preliminary Reviews"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:170
+#: src/olympia/editors/helpers.py:142
+msgid "Unlisted All Add-ons"
+msgstr ""
+
+#: src/olympia/editors/helpers.py:173
 msgid "Fast Track ({0})"
 msgid_plural "Fast Track ({0})"
 msgstr[0] ""
 msgstr[1] ""
-msgstr[2] ""
-msgstr[3] ""
 
-#: src/olympia/editors/helpers.py:175
+#: src/olympia/editors/helpers.py:178
 msgid "Full Review ({0})"
 msgid_plural "Full Reviews ({0})"
 msgstr[0] ""
 msgstr[1] ""
-msgstr[2] ""
-msgstr[3] ""
 
-#: src/olympia/editors/helpers.py:180
+#: src/olympia/editors/helpers.py:183
 msgid "Pending Update ({0})"
 msgid_plural "Pending Updates ({0})"
 msgstr[0] ""
 msgstr[1] ""
-msgstr[2] ""
-msgstr[3] ""
 
-#: src/olympia/editors/helpers.py:185
+#: src/olympia/editors/helpers.py:188
 msgid "Preliminary Review ({0})"
 msgid_plural "Preliminary Reviews ({0})"
 msgstr[0] ""
 msgstr[1] ""
-msgstr[2] ""
-msgstr[3] ""
 
-#: src/olympia/editors/helpers.py:190
+#: src/olympia/editors/helpers.py:193
 msgid "Moderated Review ({0})"
 msgid_plural "Moderated Reviews ({0})"
 msgstr[0] ""
 msgstr[1] ""
-msgstr[2] ""
-msgstr[3] ""
 
-#: src/olympia/editors/helpers.py:196
+#: src/olympia/editors/helpers.py:199
 msgid "Unlisted Full Review ({0})"
 msgid_plural "Unlisted Full Reviews ({0})"
 msgstr[0] ""
 msgstr[1] ""
-msgstr[2] ""
-msgstr[3] ""
 
-#: src/olympia/editors/helpers.py:201
+#: src/olympia/editors/helpers.py:204
 msgid "Unlisted Pending Update ({0})"
 msgid_plural "Unlisted Pending Updates ({0})"
 msgstr[0] ""
 msgstr[1] ""
-msgstr[2] ""
-msgstr[3] ""
 
-#: src/olympia/editors/helpers.py:206
+#: src/olympia/editors/helpers.py:209
 msgid "Unlisted Preliminary Review ({0})"
 msgid_plural "Unlisted Preliminary Reviews ({0})"
 msgstr[0] ""
 msgstr[1] ""
-msgstr[2] ""
-msgstr[3] ""
 
-#: src/olympia/editors/helpers.py:261
-msgid "Addon"
-msgstr ""
+#: src/olympia/editors/helpers.py:214
+msgid "Unlisted All Add-ons ({0})"
+msgid_plural "Unlisted All Add-ons ({0})"
+msgstr[0] ""
+msgstr[1] ""
 
-#: src/olympia/editors/helpers.py:262
+#: src/olympia/editors/helpers.py:274
 msgid "Type"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:263
+#: src/olympia/editors/helpers.py:275
 msgid "Waiting Time"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:264 src/olympia/editors/templates/editors/review.html:285
+#: src/olympia/editors/helpers.py:276 src/olympia/editors/templates/editors/review.html:285
 msgid "Flags"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:265
+#: src/olympia/editors/helpers.py:277
 msgid "Applications"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:270
+#: src/olympia/editors/helpers.py:282
 msgid "Additional"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:285
+#: src/olympia/editors/helpers.py:302
 msgid "Site Specific"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:287
+#: src/olympia/editors/helpers.py:304
 msgid "Requires External Software"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:289
+#: src/olympia/editors/helpers.py:306
 msgid "Binary Components"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:313
+#: src/olympia/editors/helpers.py:339
 msgid "moments ago"
 msgstr ""
 
 #. L10n: first argument is number of minutes
-#: src/olympia/editors/helpers.py:316
+#: src/olympia/editors/helpers.py:342
 msgid "{0} minute"
 msgid_plural "{0} minutes"
 msgstr[0] ""
 msgstr[1] ""
-msgstr[2] ""
-msgstr[3] ""
 
 #. L10n: first argument is number of hours
-#: src/olympia/editors/helpers.py:320
+#: src/olympia/editors/helpers.py:346
 msgid "{0} hour"
 msgid_plural "{0} hours"
 msgstr[0] ""
 msgstr[1] ""
-msgstr[2] ""
-msgstr[3] ""
 
 #. L10n: first argument is number of days
-#: src/olympia/editors/helpers.py:324
+#: src/olympia/editors/helpers.py:350
 msgid "{0} day"
 msgid_plural "{0} days"
 msgstr[0] ""
 msgstr[1] ""
-msgstr[2] ""
-msgstr[3] ""
 
-#: src/olympia/editors/helpers.py:488
+#: src/olympia/editors/helpers.py:364
+msgid "Last Review"
+msgstr ""
+
+#: src/olympia/editors/helpers.py:366
+msgid "Last Update"
+msgstr ""
+
+#: src/olympia/editors/helpers.py:387
+msgid "No Reviews"
+msgstr ""
+
+#: src/olympia/editors/helpers.py:561
 msgid "Push to public"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:490
+#: src/olympia/editors/helpers.py:563
 msgid "Grant full review"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:505
+#: src/olympia/editors/helpers.py:578
 msgid "Request more information"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:508
+#: src/olympia/editors/helpers.py:581
 msgid "Request super-review"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:519
+#: src/olympia/editors/helpers.py:592
 msgid "Grant preliminary review"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:520
+#: src/olympia/editors/helpers.py:593
 msgid "This will mark the files as preliminarily reviewed."
 msgstr ""
 
-#: src/olympia/editors/helpers.py:522
+#: src/olympia/editors/helpers.py:595
 msgid "Use this form to request more information from the author. They will receive an email and be able to answer here. You will be notified by email when they reply."
 msgstr ""
 
-#: src/olympia/editors/helpers.py:526
+#: src/olympia/editors/helpers.py:599
 msgid ""
 "If you have concerns about this add-on's security, copyright issues, or other concerns that an administrator should look into, enter your comments in the area below. They will be sent to "
 "administrators, not the author."
 msgstr ""
 
-#: src/olympia/editors/helpers.py:532
+#: src/olympia/editors/helpers.py:605
 msgid "This will reject the add-on and remove it from the review queue."
 msgstr ""
 
-#: src/olympia/editors/helpers.py:534
-msgid "Make a comment on this version.  The author won't be able to see this."
+#: src/olympia/editors/helpers.py:607
+msgid "Make a comment on this version. The author won't be able to see this."
 msgstr ""
 
-#: src/olympia/editors/helpers.py:538
+#: src/olympia/editors/helpers.py:611
 msgid "This will reject the files and remove them from the review queue."
 msgstr ""
 
-#: src/olympia/editors/helpers.py:542
+#: src/olympia/editors/helpers.py:615
 msgid "This will mark the add-on as preliminarily reviewed. Future versions will undergo preliminary review."
 msgstr ""
 
-#: src/olympia/editors/helpers.py:547
+#: src/olympia/editors/helpers.py:620
 msgid "This will mark the files as preliminarily reviewed. Future versions will undergo preliminary review."
 msgstr ""
 
-#: src/olympia/editors/helpers.py:552
+#: src/olympia/editors/helpers.py:625
 msgid "Retain preliminary review"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:553
+#: src/olympia/editors/helpers.py:626
 msgid "This will retain the add-on as preliminarily reviewed. Future versions will undergo preliminary review."
 msgstr ""
 
-#: src/olympia/editors/helpers.py:558
+#: src/olympia/editors/helpers.py:631
 msgid "This will approve a sandboxed version of a public add-on to appear on the public side."
 msgstr ""
 
-#: src/olympia/editors/helpers.py:561
+#: src/olympia/editors/helpers.py:634
 msgid "This will reject a version of a public add-on and remove it from the queue."
 msgstr ""
 
-#: src/olympia/editors/helpers.py:564
+#: src/olympia/editors/helpers.py:637
 msgid "This will mark the add-on and its most recent version and files as public. Future versions will go into the sandbox until they are reviewed by an editor."
 msgstr ""
 
-#: src/olympia/editors/helpers.py:637
+#: src/olympia/editors/helpers.py:714
 msgid "add-on"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:940 src/olympia/editors/helpers.py:960
+#: src/olympia/editors/helpers.py:1020 src/olympia/editors/helpers.py:1040
 msgid "Flagged"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:944 src/olympia/editors/helpers.py:963
+#: src/olympia/editors/helpers.py:1024 src/olympia/editors/helpers.py:1043
 msgid "Updates"
 msgstr ""
 
@@ -7754,56 +7520,56 @@ msgstr ""
 msgid "A question about your Theme submission"
 msgstr ""
 
-#: src/olympia/editors/views.py:144
+#: src/olympia/editors/views.py:146
 msgid "New Add-ons (Under 5 days)"
 msgstr ""
 
-#: src/olympia/editors/views.py:145
+#: src/olympia/editors/views.py:147
 msgid "Passable (5 to 10 days)"
 msgstr ""
 
-#: src/olympia/editors/views.py:146
+#: src/olympia/editors/views.py:148
 msgid "Overdue (Over 10 days)"
 msgstr ""
 
-#: src/olympia/editors/views.py:532
+#: src/olympia/editors/views.py:539
 msgid "An unknown error occurred"
 msgstr ""
 
-#: src/olympia/editors/views.py:587
+#: src/olympia/editors/views.py:592
 msgid "Self-reviews are not allowed."
 msgstr ""
 
-#: src/olympia/editors/views.py:609
+#: src/olympia/editors/views.py:613
 msgid "Review successfully processed."
 msgstr ""
 
-#: src/olympia/editors/views.py:807
+#: src/olympia/editors/views.py:812
 msgid "was approved"
 msgstr ""
 
-#: src/olympia/editors/views.py:808
+#: src/olympia/editors/views.py:813
 msgid "given preliminary review"
 msgstr ""
 
-#: src/olympia/editors/views.py:809
+#: src/olympia/editors/views.py:814
 msgid "rejected"
 msgstr ""
 
-#: src/olympia/editors/views.py:810
+#: src/olympia/editors/views.py:815
 msgctxt "editors_review_history_nominated_adminreview"
 msgid "escalated"
 msgstr ""
 
-#: src/olympia/editors/views.py:812
+#: src/olympia/editors/views.py:817
 msgid "needs more information"
 msgstr ""
 
-#: src/olympia/editors/views.py:813
+#: src/olympia/editors/views.py:818
 msgid "needs super review"
 msgstr ""
 
-#: src/olympia/editors/views.py:814
+#: src/olympia/editors/views.py:819
 msgid "commented"
 msgstr ""
 
@@ -7812,8 +7578,6 @@ msgid "{0} theme review successfully processed (+{1} points, {2} total)."
 msgid_plural "{0} theme reviews successfully processed (+{1} points, {2} total)."
 msgstr[0] ""
 msgstr[1] ""
-msgstr[2] ""
-msgstr[3] ""
 
 #: src/olympia/editors/views_themes.py:341
 msgid "Your theme locks have successfully been released. Other reviewers may now review those released themes. You may have to refresh the page to see the changes reflected in the table below."
@@ -7850,28 +7614,28 @@ msgstr ""
 msgid "Unlisted Queues"
 msgstr ""
 
-#: src/olympia/editors/templates/editors/base.html:72 src/olympia/editors/templates/editors/performance.html:6
+#: src/olympia/editors/templates/editors/base.html:74 src/olympia/editors/templates/editors/performance.html:6
 msgid "Performance"
 msgstr "Performance"
 
-#: src/olympia/editors/templates/editors/base.html:75 src/olympia/editors/templates/editors/themes/base.html:19 src/olympia/editors/templates/editors/themes/base.html:38
+#: src/olympia/editors/templates/editors/base.html:77 src/olympia/editors/templates/editors/themes/base.html:19 src/olympia/editors/templates/editors/themes/base.html:38
 msgid "Logs"
 msgstr ""
 
-#: src/olympia/editors/templates/editors/base.html:78 src/olympia/editors/templates/editors/reviewlog.html:4 src/olympia/editors/templates/editors/reviewlog.html:27
+#: src/olympia/editors/templates/editors/base.html:80 src/olympia/editors/templates/editors/reviewlog.html:4 src/olympia/editors/templates/editors/reviewlog.html:27
 msgid "Add-on Review Log"
 msgstr ""
 
-#: src/olympia/editors/templates/editors/base.html:80 src/olympia/editors/templates/editors/eventlog.html:4 src/olympia/editors/templates/editors/eventlog.html:8
+#: src/olympia/editors/templates/editors/base.html:82 src/olympia/editors/templates/editors/eventlog.html:4 src/olympia/editors/templates/editors/eventlog.html:8
 #: src/olympia/editors/templates/editors/eventlog_detail.html:4
 msgid "Moderated Review Log"
 msgstr ""
 
-#: src/olympia/editors/templates/editors/base.html:82 src/olympia/editors/templates/editors/beta_signed_log.html:4 src/olympia/editors/templates/editors/beta_signed_log.html:8
+#: src/olympia/editors/templates/editors/base.html:84 src/olympia/editors/templates/editors/beta_signed_log.html:4 src/olympia/editors/templates/editors/beta_signed_log.html:8
 msgid "Signed Beta Files Log"
 msgstr ""
 
-#: src/olympia/editors/templates/editors/base.html:87 src/olympia/editors/templates/editors/includes/daily-message.html:4
+#: src/olympia/editors/templates/editors/base.html:89 src/olympia/editors/templates/editors/includes/daily-message.html:4
 msgid "Announcement"
 msgstr ""
 
@@ -7931,24 +7695,18 @@ msgid "Full Review ({num})"
 msgid_plural "Full Reviews ({num})"
 msgstr[0] ""
 msgstr[1] ""
-msgstr[2] ""
-msgstr[3] ""
 
 #: src/olympia/editors/templates/editors/home.html:18
 msgid "Pending Update ({num})"
 msgid_plural "Pending Updates ({num})"
 msgstr[0] ""
 msgstr[1] ""
-msgstr[2] ""
-msgstr[3] ""
 
 #: src/olympia/editors/templates/editors/home.html:25
 msgid "Preliminary Review ({num})"
 msgid_plural "Preliminary Reviews ({num})"
 msgstr[0] ""
 msgstr[1] ""
-msgstr[2] ""
-msgstr[3] ""
 
 #: src/olympia/editors/templates/editors/home.html:36 src/olympia/editors/templates/editors/home.html:86
 msgid "Current waiting times:"
@@ -7959,8 +7717,6 @@ msgid "{0} add-on"
 msgid_plural "{0} add-ons"
 msgstr[0] ""
 msgstr[1] ""
-msgstr[2] ""
-msgstr[3] ""
 
 #: src/olympia/editors/templates/editors/home.html:45 src/olympia/editors/templates/editors/home.html:95
 #, python-format
@@ -7972,24 +7728,18 @@ msgid "Unlisted Full Review ({num})"
 msgid_plural "Unlisted Full Reviews ({num})"
 msgstr[0] ""
 msgstr[1] ""
-msgstr[2] ""
-msgstr[3] ""
 
 #: src/olympia/editors/templates/editors/home.html:68
 msgid "Unlisted Pending Update ({num})"
 msgid_plural "Unlisted Pending Updates ({num})"
 msgstr[0] ""
 msgstr[1] ""
-msgstr[2] ""
-msgstr[3] ""
 
 #: src/olympia/editors/templates/editors/home.html:75
 msgid "Unlisted Preliminary Review ({num})"
 msgid_plural "Unlisted Preliminary Reviews ({num})"
 msgstr[0] ""
 msgstr[1] ""
-msgstr[2] ""
-msgstr[3] ""
 
 #: src/olympia/editors/templates/editors/home.html:109 src/olympia/editors/templates/editors/performance.html:37 src/olympia/editors/templates/editors/themes/home.html:54
 msgid "Total Reviews"
@@ -8013,8 +7763,6 @@ msgid "Moderated Review ({num})"
 msgid_plural "Moderated Reviews ({num})"
 msgstr[0] ""
 msgstr[1] ""
-msgstr[2] ""
-msgstr[3] ""
 
 #: src/olympia/editors/templates/editors/leaderboard.html:3 src/olympia/editors/templates/editors/includes/reviewers_score_bar.html:56
 msgid "Reviewer Leaderboard"
@@ -8108,45 +7856,45 @@ msgstr ""
 msgid "clear search"
 msgstr ""
 
-#: src/olympia/editors/templates/editors/queue.html:72 src/olympia/editors/templates/editors/queue.html:122
+#: src/olympia/editors/templates/editors/queue.html:78 src/olympia/editors/templates/editors/queue.html:128
 msgid "Process Reviews"
 msgstr ""
 
-#: src/olympia/editors/templates/editors/queue.html:80
+#: src/olympia/editors/templates/editors/queue.html:86
 msgid "Moderation actions:"
 msgstr ""
 
-#: src/olympia/editors/templates/editors/queue.html:90
+#: src/olympia/editors/templates/editors/queue.html:96
 #, python-format
 msgid "by %(user)s on %(date)s %(stars)s (%(locale)s)"
 msgstr ""
 
-#: src/olympia/editors/templates/editors/queue.html:106
+#: src/olympia/editors/templates/editors/queue.html:112
 #, python-format
 msgid "<strong>%(reason)s</strong> <span class=\"light\">Flagged by %(user)s on %(date)s</span>"
 msgstr ""
 
-#: src/olympia/editors/templates/editors/queue.html:119
-msgid "All reviews have been moderated.  Good work!"
+#: src/olympia/editors/templates/editors/queue.html:125
+msgid "All reviews have been moderated. Good work!"
 msgstr ""
 
-#: src/olympia/editors/templates/editors/queue.html:161
+#: src/olympia/editors/templates/editors/queue.html:167
 msgid "Version Notes / Notes for Reviewer"
 msgstr ""
 
-#: src/olympia/editors/templates/editors/queue.html:169
+#: src/olympia/editors/templates/editors/queue.html:175
 msgid "There are currently no add-ons of this type to review."
 msgstr ""
 
-#: src/olympia/editors/templates/editors/queue.html:181 src/olympia/editors/templates/editors/themes/queue_list.html:85
+#: src/olympia/editors/templates/editors/queue.html:187 src/olympia/editors/templates/editors/themes/queue_list.html:85
 msgid "Helpful Links:"
 msgstr ""
 
-#: src/olympia/editors/templates/editors/queue.html:182
+#: src/olympia/editors/templates/editors/queue.html:188
 msgid "Add-on Policy"
 msgstr ""
 
-#: src/olympia/editors/templates/editors/queue.html:184
+#: src/olympia/editors/templates/editors/queue.html:190
 msgid "Editors' Guide"
 msgstr ""
 
@@ -8209,10 +7957,7 @@ msgid "<strong>Warning!</strong> Another user was viewing this page before you."
 msgstr ""
 
 #: src/olympia/editors/templates/editors/review.html:237
-msgid ""
-"The whiteboard is the place to exchange information relevant to\n"
-"               this addon (whatever the version), between the developer and the\n"
-"               editor. This is visible and editable by both."
+msgid "The whiteboard is the place to exchange information relevant to this addon (whatever the version), between the developer and the editor. This is visible and editable by both."
 msgstr ""
 
 #: src/olympia/editors/templates/editors/review.html:241
@@ -8356,24 +8101,18 @@ msgid "{num} Pending Theme Review"
 msgid_plural "{num} Pending Theme Reviews"
 msgstr[0] ""
 msgstr[1] ""
-msgstr[2] ""
-msgstr[3] ""
 
 #: src/olympia/editors/templates/editors/themes/home.html:27
 msgid "{num} Flagged Review"
 msgid_plural "{num} Flagged Reviews"
 msgstr[0] ""
 msgstr[1] ""
-msgstr[2] ""
-msgstr[3] ""
 
 #: src/olympia/editors/templates/editors/themes/home.html:34
 msgid "{num} Update"
 msgid_plural "{num} Updates"
 msgstr[0] ""
 msgstr[1] ""
-msgstr[2] ""
-msgstr[3] ""
 
 #: src/olympia/editors/templates/editors/themes/logs.html:4
 msgid "Theme Review Log"
@@ -8492,7 +8231,7 @@ msgstr ""
 msgid "Describe your reason for flagging"
 msgstr ""
 
-#: src/olympia/files/forms.py:88
+#: src/olympia/files/forms.py:90
 msgid "Cannot diff a version against itself"
 msgstr ""
 
@@ -8527,51 +8266,51 @@ msgstr ""
 msgid "There was an error accessing file %s."
 msgstr ""
 
-#: src/olympia/files/utils.py:343
+#: src/olympia/files/utils.py:340
 msgid "Could not parse uploaded file."
 msgstr ""
 
-#: src/olympia/files/utils.py:380
+#: src/olympia/files/utils.py:377
 msgid "Invalid file name in archive: {0}"
 msgstr ""
 
-#: src/olympia/files/utils.py:388
+#: src/olympia/files/utils.py:385
 msgid "File exceeding size limit in archive: {0}"
 msgstr ""
 
-#: src/olympia/files/utils.py:439
+#: src/olympia/files/utils.py:436
 msgid "Invalid archive."
 msgstr ""
 
-#: src/olympia/files/utils.py:529 src/olympia/files/utils.py:532
+#: src/olympia/files/utils.py:526 src/olympia/files/utils.py:529
 msgid "Could not parse the manifest file."
 msgstr ""
 
-#: src/olympia/files/utils.py:551
+#: src/olympia/files/utils.py:548
 msgid "Could not find an add-on ID."
 msgstr ""
 
-#: src/olympia/files/utils.py:554
+#: src/olympia/files/utils.py:551
 msgid "Add-on ID must be 64 characters or less."
 msgstr ""
 
-#: src/olympia/files/utils.py:556
+#: src/olympia/files/utils.py:553
 msgid "Add-on ID doesn't match add-on."
 msgstr ""
 
-#: src/olympia/files/utils.py:564
+#: src/olympia/files/utils.py:561
 msgid "Duplicate add-on ID found."
 msgstr ""
 
-#: src/olympia/files/utils.py:567
+#: src/olympia/files/utils.py:564
 msgid "Version numbers should have fewer than 32 characters."
 msgstr ""
 
-#: src/olympia/files/utils.py:570
+#: src/olympia/files/utils.py:567
 msgid "Version numbers should only contain letters, numbers, and these punctuation characters: +*.-_."
 msgstr ""
 
-#: src/olympia/files/utils.py:587
+#: src/olympia/files/utils.py:584
 msgid "<em:type> doesn't match add-on"
 msgstr ""
 
@@ -8670,6 +8409,10 @@ msgstr ""
 
 #: src/olympia/files/templates/files/viewer.html:134
 msgid "Fetching file."
+msgstr ""
+
+#: src/olympia/legacy_api/views.py:255
+msgid "Not implemented yet."
 msgstr ""
 
 #: src/olympia/lib/constants.py:6
@@ -9328,10 +9071,6 @@ msgstr ""
 msgid "Zimbabwe Dollar"
 msgstr ""
 
-#: src/olympia/lib/video/ffmpeg.py:112 src/olympia/lib/video/totem.py:81
-msgid "Videos must be in WebM."
-msgstr ""
-
 #: src/olympia/pages/templates/pages/about.lhtml:3 src/olympia/pages/templates/pages/about.lhtml:10
 msgid "About Mozilla Add-ons"
 msgstr ""
@@ -9343,7 +9082,7 @@ msgstr ""
 #: src/olympia/pages/templates/pages/about.lhtml:13
 msgid ""
 "addons.mozilla.org, commonly known as \"AMO\", is Mozilla's official site for add-ons to Mozilla software, such as Firefox, Thunderbird, and SeaMonkey. Add-ons let you add new features and change "
-"the way your browser or application works.  Take a look around and explore the thousands of ways to customize the way you do things online."
+"the way your browser or application works. Take a look around and explore the thousands of ways to customize the way you do things online."
 msgstr ""
 
 #: src/olympia/pages/templates/pages/about.lhtml:19
@@ -9688,7 +9427,7 @@ msgstr ""
 msgid ""
 "Yes. It's possible, but some of the functionality provided by these libraries are available through XPCOM, XUL, and JavaScript. In addition, authors should take care if libraries modify primitive "
 "object prototypes (String.prototype, Date.prototype, etc.) and/or define global functions (eg. the $ function). These are prone to cause conflict with other add-ons, in particular if different add-"
-"ons use different versions of libraries and so on. Developers need to be very, very careful with using them.  Mozilla does not offer documentation on using them to build add-ons."
+"ons use different versions of libraries and so on. Developers need to be very, very careful with using them. Mozilla does not offer documentation on using them to build add-ons."
 msgstr ""
 
 #: src/olympia/pages/templates/pages/dev_faq.html:165
@@ -9802,8 +9541,8 @@ msgstr ""
 #, python-format
 msgid ""
 "Yes. Many developers choose to host their own add-ons. Choosing to host your add-on on <a href=\"%(amo_url)s\">Mozilla's add-on site</a>, though, allows for much greater exposure to your add-on due "
-"to the large volume of visitors to the site.  <a href=\"%(md_url)s\">mozdev.org</a> offers free project hosting for Mozilla applications and extensions providing developers with tools to help "
-"manage source code, version control, bug tracking and documentation."
+"to the large volume of visitors to the site. <a href=\"%(md_url)s\">mozdev.org</a> offers free project hosting for Mozilla applications and extensions providing developers with tools to help manage "
+"source code, version control, bug tracking and documentation."
 msgstr ""
 
 #: src/olympia/pages/templates/pages/dev_faq.html:277
@@ -9851,7 +9590,7 @@ msgstr ""
 #: src/olympia/pages/templates/pages/dev_faq.html:314
 #, python-format
 msgid ""
-"Yes. Mozilla's <a href=\"%(p_url)s\">Add-on Policy</a> describes what is an acceptable submission. This policy is subject to change without notice.  In addition, the AMO editorial team uses the <a "
+"Yes. Mozilla's <a href=\"%(p_url)s\">Add-on Policy</a> describes what is an acceptable submission. This policy is subject to change without notice. In addition, the AMO editorial team uses the <a "
 "href=\"%(g_url)s\">Editors Reviewing Guide</a> to ensure that your add-on meets specific guidelines for functionality and security."
 msgstr ""
 
@@ -9968,7 +9707,7 @@ msgstr ""
 #: src/olympia/pages/templates/pages/dev_faq.html:434
 #, python-format
 msgid ""
-"This is why it's very important to read the <a href=\"%(g_url)s\">Editors Reviewing Guide</a> to ensure that your add-on is setup as expected.  It's also a good idea to read the blog post, <a href="
+"This is why it's very important to read the <a href=\"%(g_url)s\">Editors Reviewing Guide</a> to ensure that your add-on is setup as expected. It's also a good idea to read the blog post, <a href="
 "\"%(blog_url)s\">Successfully Getting your Add-on Reviewed</a> which provides excellent insight into ensuring a smooth review of your add-on."
 msgstr ""
 
@@ -10075,7 +9814,7 @@ msgstr ""
 
 #: src/olympia/pages/templates/pages/dev_faq.html:572
 msgid ""
-"Free Software Foundation provides short summaries of the key open source licenses, including whether the license qualifies as a free software license or a copyleft license.  Also includes a "
+"Free Software Foundation provides short summaries of the key open source licenses, including whether the license qualifies as a free software license or a copyleft license. Also includes a "
 "discussion of what constitutes a free software license or a copyleft license (e.g., a Copyleft license is a general method for making a program or other work free, and requiring all modified and "
 "extended versions of the program to be free as well.)"
 msgstr ""
@@ -10253,19 +9992,13 @@ msgid "Add-on Gallery"
 msgstr ""
 
 #: src/olympia/pages/templates/pages/faq.html:171
-msgid ""
-"How do I choose between add-ons that seem to do the same\n"
-"    thing?"
+msgid "How do I choose between add-ons that seem to do the same thing?"
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:173
+#: src/olympia/pages/templates/pages/faq.html:172
 msgid ""
-"There are often several add-ons that have similar features. To\n"
-"    figure out which is right for you, read the entire description of the\n"
-"    add-on and view its screenshots. If there are still several in the running,\n"
-"    read through the add-on's ratings, user reviews, and statistics to see\n"
-"    which is most liked by other users. Remember that you can also just try\n"
-"    out both and see which you like better."
+"There are often several add-ons that have similar features. To figure out which is right for you, read the entire description of the add-on and view its screenshots. If there are still several in "
+"the running, read through the add-on's ratings, user reviews, and statistics to see which is most liked by other users. Remember that you can also just try out both and see which you like better."
 msgstr ""
 
 #: src/olympia/pages/templates/pages/faq.html:180
@@ -10306,80 +10039,67 @@ msgid "How much do add-ons cost to purchase?"
 msgstr ""
 
 #: src/olympia/pages/templates/pages/faq.html:207
-msgid ""
-"Add-ons hosted in our gallery are free unless clearly marked\n"
-"    otherwise."
+msgid "Add-ons hosted in our gallery are free unless clearly marked otherwise."
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:210
+#: src/olympia/pages/templates/pages/faq.html:209
 msgid "What does it mean when an add-on asks for contributions?"
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:211
+#: src/olympia/pages/templates/pages/faq.html:210
 msgid ""
-"Some add-on authors request users who enjoy an add-on to\n"
-"        contribute to its development by making a monetary contribution. These\n"
-"        contributions go directly to the developer unless a third party is\n"
-"        indicated, such as the non-profit Mozilla Foundation."
+"Some add-on authors request users who enjoy an add-on to contribute to its development by making a monetary contribution. These contributions go directly to the developer unless a third party is "
+"indicated, such as the non-profit Mozilla Foundation."
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:216
+#: src/olympia/pages/templates/pages/faq.html:215
 msgid "What are beta add-ons?"
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:218
+#: src/olympia/pages/templates/pages/faq.html:217
 msgid ""
-"Beta add-ons are unreviewed versions which represent the\n"
-"        latest work of an add-on author. While different authors have different\n"
-"        standards for beta code quality, you should assume that these add-ons\n"
-"        are less stable than the general add-on releases."
+"Beta add-ons are unreviewed versions which represent the latest work of an add-on author. While different authors have different standards for beta code quality, you should assume that these add-"
+"ons are less stable than the general add-on releases."
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:222
+#: src/olympia/pages/templates/pages/faq.html:221
 msgid ""
 "Please note that when you install an add-on from the \"Beta Version\" section of an add-on's listing, you will continue to receive updates for that add-on as they become available. Like the initial "
 "version you installed, all beta releases are unreviewed by Mozilla and may harm your computer."
 msgstr ""
 
+#: src/olympia/pages/templates/pages/faq.html:228
+msgid "What does it mean when an add-on is flagged as slow?"
+msgstr ""
+
 #: src/olympia/pages/templates/pages/faq.html:229
-msgid ""
-"What does it mean when an add-on is flagged as\n"
-"    slow?"
+msgid "Most add-ons load code and resources at the same time Firefox is starting up. In most cases the impact in start-up time is minimal, but some add-ons can cause a noticeable slowdown."
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:231
-msgid ""
-"Most add-ons load code and resources at the same time Firefox\n"
-"        is starting up. In most cases the impact in start-up time is minimal,\n"
-"        but some add-ons can cause a noticeable slowdown."
-msgstr ""
-
-#: src/olympia/pages/templates/pages/faq.html:236
+#: src/olympia/pages/templates/pages/faq.html:234
 msgid "How do I report an inappropriate or spam user review?"
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:237
+#: src/olympia/pages/templates/pages/faq.html:235
 msgid ""
-"To report a user review of an add-on, log in with your account\n"
-"    and visit the add-on's reviews page. Find the review you wish to report,\n"
-"    click \"Report this review\" and select a reason. Our editorial team will\n"
-"    investigate the review and take appropriate action."
+"To report a user review of an add-on, log in with your account and visit the add-on's reviews page. Find the review you wish to report, click \"Report this review\" and select a reason. Our "
+"editorial team will investigate the review and take appropriate action."
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:242
+#: src/olympia/pages/templates/pages/faq.html:240
 msgid "How do I report a bug or contact the Mozilla Add-ons team?"
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:243
+#: src/olympia/pages/templates/pages/faq.html:241
 #, python-format
 msgid "Please visit our <a href=\"%(contact_url)s\">Contact page</a>."
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:246
+#: src/olympia/pages/templates/pages/faq.html:244
 msgid "What is a Source Code License?"
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:247
+#: src/olympia/pages/templates/pages/faq.html:245
 #, python-format
 msgid ""
 "The source code used to create an add-on is an exclusive copyright of the add-on author, unless otherwise declared in a source code license. Many add-ons on this site have <a href=\"%(url)s\" lang="
@@ -10387,60 +10107,60 @@ msgid ""
 "the GPL or BSD licenses instead of making up their own."
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:256
+#: src/olympia/pages/templates/pages/faq.html:254
 #, python-format
 msgid "Firefox and other Mozilla software are <a href=\"%(url)s\">open source</a>."
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:264
+#: src/olympia/pages/templates/pages/faq.html:262
 msgid "Collections and Favorites"
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:267
+#: src/olympia/pages/templates/pages/faq.html:265
 msgid "What is a collection?"
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:268
+#: src/olympia/pages/templates/pages/faq.html:266
 msgid "Collections are groups of related add-ons created by users to share."
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:270
+#: src/olympia/pages/templates/pages/faq.html:268
 msgid "What is the My Favorites collection?"
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:271
+#: src/olympia/pages/templates/pages/faq.html:269
 msgid "Favorite add-ons are add-ons that you have bookmarked to easily get back to later. You can add an add-on to your favorites collection by clicking \"Add to favorites\" on its details page."
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:275 src/olympia/templates/menu_links.html:13 src/olympia/templates/impala/header_title.html:17
+#: src/olympia/pages/templates/pages/faq.html:273 src/olympia/templates/menu_links.html:13 src/olympia/templates/impala/header_title.html:17
 msgid "Mobile Add-ons"
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:278
+#: src/olympia/pages/templates/pages/faq.html:276
 msgid "What are mobile add-ons?"
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:279
+#: src/olympia/pages/templates/pages/faq.html:277
 #, python-format
 msgid ""
 "Mobile add-ons work with <a href=\"%(mobile_url)s\">Firefox for Mobile</a> and add or modify functionality just like desktop add-ons. You can find add-ons that work with Firefox for Mobile in our "
 "<a href=\"%(gallery_url)s\">gallery</a>."
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:288
+#: src/olympia/pages/templates/pages/faq.html:286
 msgid "Developer Topics"
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:289
+#: src/olympia/pages/templates/pages/faq.html:287
 #, python-format
 msgid "Please see our <a href=\"%(faq_url)s\">Developer FAQ</a> and <a href=\"%(hub_url)s\">Developer Hub</a> for answers to add-on developer-related questions."
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:294
+#: src/olympia/pages/templates/pages/faq.html:292
 msgid "Still have questions?"
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:295
+#: src/olympia/pages/templates/pages/faq.html:293
 #, python-format
 msgid "For general Firefox support, visit our <a href=\"%(sumo_url)s\">support website</a>. For general add-on and website questions, visit our <a href=\"%(forum_url)s\">forum</a>."
 msgstr ""
@@ -10578,7 +10298,7 @@ msgstr ""
 
 #: src/olympia/pages/templates/pages/sunbird.html:29
 msgid ""
-"Development on the Sunbird project has halted and its final release was on March 30, 2010.  We've been proud to host Sunbird add-ons on this site but as the project is no longer maintained we have "
+"Development on the Sunbird project has halted and its final release was on March 30, 2010. We've been proud to host Sunbird add-ons on this site but as the project is no longer maintained we have "
 "disabled our support for the add-ons."
 msgstr ""
 
@@ -10656,7 +10376,7 @@ msgstr ""
 #, python-format
 msgid ""
 "<h2>Keep these tips in mind:</h2> <ul> <li> Write like you're telling a friend about your experience with the add-on. Give specifics and helpful details, such as what features you liked and/or "
-"disliked, how easy to use it is, and any disadvantages it has.  Avoid generic language such as calling it \"Great\" or \"Bad\" unless you can give reasons why you believe this is so. </li> <li> "
+"disliked, how easy to use it is, and any disadvantages it has. Avoid generic language such as calling it \"Great\" or \"Bad\" unless you can give reasons why you believe this is so. </li> <li> "
 "Please do not post bug reports in reviews. We do not make your email address available to add-on developers and they may need to contact you to help resolve your issue. See the <a href=\"%(support)s"
 "\">support section</a> to find out where to get assistance for this add-on. </li> <li>Please keep reviews clean, avoid the use of improper language and do not post any personal information. </li> </"
 "ul> <p>Please read the <a href=\"%(guide)s\" target=\"_blank\">Review Guidelines</a> for more detail about user add-on reviews.</p>"
@@ -10704,8 +10424,6 @@ msgid "This user has a <a href=\"%(user_review_url)s\">previous review</a> of th
 msgid_plural "This user has <a href=\"%(user_review_url)s\">%(cnt)s previous reviews</a> of this add-on."
 msgstr[0] ""
 msgstr[1] ""
-msgstr[2] ""
-msgstr[3] ""
 
 #: src/olympia/reviews/templates/reviews/review.html:62
 #, python-format
@@ -10752,8 +10470,6 @@ msgid "<b>{0}</b> review for this add-on"
 msgid_plural "<b>{0}</b> reviews for this add-on"
 msgstr[0] ""
 msgstr[1] ""
-msgstr[2] ""
-msgstr[3] ""
 
 #. {0} is a developer's name.
 #: src/olympia/reviews/templates/reviews/review_list.html:33
@@ -10766,8 +10482,6 @@ msgid "Review for %(addon)s by %(user)s"
 msgid_plural "Reviews for %(addon)s by %(user)s"
 msgstr[0] ""
 msgstr[1] ""
-msgstr[2] ""
-msgstr[3] ""
 
 #: src/olympia/reviews/templates/reviews/review_list.html:42
 msgid "No reviews found."
@@ -10791,8 +10505,6 @@ msgid "{num} review"
 msgid_plural "{num} reviews"
 msgstr[0] ""
 msgstr[1] ""
-msgstr[2] ""
-msgstr[3] ""
 
 #: src/olympia/reviews/templates/reviews/impala/reviews_rating.html:1
 msgid "Rated {0} out of 5 stars"
@@ -10820,8 +10532,6 @@ msgid "Average from {0} Rating"
 msgid_plural "Average from {0} Ratings"
 msgstr[0] ""
 msgstr[1] ""
-msgstr[2] ""
-msgstr[3] ""
 
 #: src/olympia/reviews/templates/reviews/mobile/review_list.html:34
 #, python-format
@@ -10838,8 +10548,6 @@ msgid "See All Reviews"
 msgid_plural "See All %(cnt)s Reviews"
 msgstr[0] ""
 msgstr[1] ""
-msgstr[2] ""
-msgstr[3] ""
 
 #: src/olympia/search/forms.py:11
 msgid "Most popular this week"
@@ -10920,16 +10628,16 @@ msgstr ""
 
 #. L10n: {0} is an application, such as Firefox. This means "any version of
 #. Firefox."
-#: src/olympia/search/views.py:554
+#: src/olympia/search/views.py:547
 msgid "Any {0}"
 msgstr ""
 
 #. L10n: "All Systems" means show everything regardless of platform.
-#: src/olympia/search/views.py:589
+#: src/olympia/search/views.py:582
 msgid "All Systems"
 msgstr ""
 
-#: src/olympia/search/views.py:600
+#: src/olympia/search/views.py:593
 msgid "All Tags"
 msgstr ""
 
@@ -10974,8 +10682,6 @@ msgid "<b>{0}</b> matching result"
 msgid_plural "<b>{0}</b> matching results"
 msgstr[0] ""
 msgstr[1] ""
-msgstr[2] ""
-msgstr[3] ""
 
 #: src/olympia/search/templates/search/results.html:67
 msgid "Filter Results"
@@ -10998,8 +10704,6 @@ msgid "{0} post"
 msgid_plural "{0} posts"
 msgstr[0] ""
 msgstr[1] ""
-msgstr[2] ""
-msgstr[3] ""
 
 #: src/olympia/sharing/__init__.py:20
 msgid "Post to Facebook"
@@ -11010,8 +10714,6 @@ msgid "{0} Like"
 msgid_plural "{0} Likes"
 msgstr[0] ""
 msgstr[1] ""
-msgstr[2] ""
-msgstr[3] ""
 
 #: src/olympia/sharing/__init__.py:30
 msgid "Tweet on Twitter"
@@ -11022,8 +10724,6 @@ msgid "{0} tweet"
 msgid_plural "{0} tweets"
 msgstr[0] ""
 msgstr[1] ""
-msgstr[2] ""
-msgstr[3] ""
 
 #: src/olympia/sharing/__init__.py:40
 msgid "Share on g+"
@@ -11058,8 +10758,6 @@ msgid "{0} post on localservice1"
 msgid_plural "{0} posts on localservice1"
 msgstr[0] ""
 msgstr[1] ""
-msgstr[2] ""
-msgstr[3] ""
 
 #. L10n: Only change if you have reason! wiki.mozilla.org/AMO:Localizers
 #: src/olympia/sharing/__init__.py:76
@@ -11082,8 +10780,6 @@ msgid "{0} post on localservice2"
 msgid_plural "{0} posts on localservice2"
 msgstr[0] ""
 msgstr[1] ""
-msgstr[2] ""
-msgstr[3] ""
 
 #. L10n: Only change if you have reason! wiki.mozilla.org/AMO:Localizers
 #: src/olympia/sharing/__init__.py:91
@@ -11106,8 +10802,6 @@ msgid "{0} post on localservice3"
 msgid_plural "{0} posts on localservice3"
 msgstr[0] ""
 msgstr[1] ""
-msgstr[2] ""
-msgstr[3] ""
 
 #: src/olympia/sharing/templates/sharing/sharing_widget.html:2
 msgid "Share this Add-on"
@@ -11117,31 +10811,31 @@ msgstr "Share this Add-on"
 msgid "Share this Collection"
 msgstr "Create Collection"
 
-#: src/olympia/signing/views.py:30 src/olympia/templates/base.html:75 src/olympia/templates/impala/base.html:115
+#: src/olympia/signing/views.py:33 src/olympia/templates/base.html:71 src/olympia/templates/impala/base.html:112
 msgid "Some features are temporarily disabled while we perform website maintenance. We'll be back to full capacity shortly."
 msgstr ""
 
-#: src/olympia/signing/views.py:53
+#: src/olympia/signing/views.py:56
 msgid "Could not find add-on with id \"{}\"."
 msgstr ""
 
-#: src/olympia/signing/views.py:67
+#: src/olympia/signing/views.py:70
 msgid "You do not own this addon."
 msgstr ""
 
-#: src/olympia/signing/views.py:82
+#: src/olympia/signing/views.py:87
 msgid "Missing \"upload\" key in multipart file data."
 msgstr ""
 
-#: src/olympia/signing/views.py:96
+#: src/olympia/signing/views.py:101
 msgid "Version does not match the manifest file."
 msgstr ""
 
-#: src/olympia/signing/views.py:100
+#: src/olympia/signing/views.py:105
 msgid "Version already exists."
 msgstr ""
 
-#: src/olympia/signing/views.py:136
+#: src/olympia/signing/views.py:141
 msgid "No uploaded file for that addon and version."
 msgstr ""
 
@@ -11254,89 +10948,89 @@ msgstr ""
 msgid "Statistics Dashboard :: Add-ons for {0}"
 msgstr ""
 
-#: src/olympia/stats/templates/stats/stats.html:30
-msgid "Controls:"
-msgstr ""
-
-#: src/olympia/stats/templates/stats/stats.html:33
-msgid "reset zoom"
-msgstr ""
-
-#: src/olympia/stats/templates/stats/stats.html:40
-msgid "Group by:"
-msgstr ""
-
-#: src/olympia/stats/templates/stats/stats.html:42
-msgid "day"
-msgstr ""
-
-#: src/olympia/stats/templates/stats/stats.html:45
-msgid "week"
-msgstr ""
-
-#: src/olympia/stats/templates/stats/stats.html:48
-msgid "month"
-msgstr ""
-
-#: src/olympia/stats/templates/stats/stats.html:54
-msgid "For last:"
-msgstr ""
-
-#: src/olympia/stats/templates/stats/stats.html:57
-msgid "7 days"
-msgstr ""
-
-#: src/olympia/stats/templates/stats/stats.html:60
-msgid "30 days"
-msgstr ""
-
-#: src/olympia/stats/templates/stats/stats.html:63
-msgid "90 days"
-msgstr ""
-
-#: src/olympia/stats/templates/stats/stats.html:66
-msgid "365 days"
-msgstr ""
-
-#: src/olympia/stats/templates/stats/stats.html:69
-msgid "Custom..."
-msgstr ""
-
 #. {0} is an add-on name
-#: src/olympia/stats/templates/stats/stats.html:88 src/olympia/stats/templates/stats/stats.html:91
+#: src/olympia/stats/templates/stats/stats.html:44 src/olympia/stats/templates/stats/stats.html:47
 msgid "Statistics for {0}"
 msgstr "Ystadegau {0}"
 
-#: src/olympia/stats/templates/stats/stats.html:94
+#: src/olympia/stats/templates/stats/stats.html:50
 msgid "Statistics Dashboard"
 msgstr ""
 
-#: src/olympia/stats/templates/stats/stats.html:104
+#: src/olympia/stats/templates/stats/stats.html:57
+msgid "Controls:"
+msgstr ""
+
+#: src/olympia/stats/templates/stats/stats.html:60
+msgid "reset zoom"
+msgstr ""
+
+#: src/olympia/stats/templates/stats/stats.html:67
+msgid "Group by:"
+msgstr ""
+
+#: src/olympia/stats/templates/stats/stats.html:69
+msgid "day"
+msgstr ""
+
+#: src/olympia/stats/templates/stats/stats.html:72
+msgid "week"
+msgstr ""
+
+#: src/olympia/stats/templates/stats/stats.html:75
+msgid "month"
+msgstr ""
+
+#: src/olympia/stats/templates/stats/stats.html:81
+msgid "For last:"
+msgstr ""
+
+#: src/olympia/stats/templates/stats/stats.html:84
+msgid "7 days"
+msgstr ""
+
+#: src/olympia/stats/templates/stats/stats.html:87
+msgid "30 days"
+msgstr ""
+
+#: src/olympia/stats/templates/stats/stats.html:90
+msgid "90 days"
+msgstr ""
+
+#: src/olympia/stats/templates/stats/stats.html:93
+msgid "365 days"
+msgstr ""
+
+#: src/olympia/stats/templates/stats/stats.html:96
+msgid "Custom..."
+msgstr ""
+
+#: src/olympia/stats/templates/stats/stats.html:106
 msgid "Statistics processing is currently disabled, so recent data is unavailable. The statistics are still being collected and this page will be updated soon with the missing data."
 msgstr ""
 
-#: src/olympia/stats/templates/stats/stats.html:110
+#: src/olympia/stats/templates/stats/stats.html:112
 msgid "Loading the latest data&hellip;"
 msgstr ""
 
-#: src/olympia/stats/templates/stats/stats.html:142 src/olympia/stats/templates/stats/reports/overview.html:25 src/olympia/stats/templates/stats/reports/overview.html:37
+#: src/olympia/stats/templates/stats/stats.html:144 src/olympia/stats/templates/stats/reports/overview.html:25 src/olympia/stats/templates/stats/reports/overview.html:37
 #: src/olympia/stats/templates/stats/reports/overview.html:49
 msgid "No data available."
 msgstr ""
 
-#: src/olympia/stats/templates/stats/stats.html:177
+#: src/olympia/stats/templates/stats/stats.html:179
 msgid "This dashboard is currently <b>public</b>."
 msgstr ""
 
-#: src/olympia/stats/templates/stats/stats.html:179
+#: src/olympia/stats/templates/stats/stats.html:181
 msgid "Contribution stats are currently <b>private</b>."
 msgstr ""
 
-#: src/olympia/stats/templates/stats/stats.html:182
+#: src/olympia/stats/templates/stats/stats.html:184
 msgid "This dashboard is currently <b>private</b>."
 msgstr ""
 
-#: src/olympia/stats/templates/stats/stats.html:185
+#: src/olympia/stats/templates/stats/stats.html:187
 msgid "Change settings."
 msgstr ""
 
@@ -11488,16 +11182,6 @@ msgstr ""
 msgid "Application versions by Date"
 msgstr ""
 
-# {0} is a number
-#: src/olympia/tags/templates/tags/top_cloud.html:4
-msgid "Top {0} Tags"
-msgstr "Top {0} Tags"
-
-#. {0} is the current application name
-#: src/olympia/tags/templates/tags/top_cloud.html:14
-msgid "{0} Top Tags"
-msgstr ""
-
 #: src/olympia/templates/amo_footer.html:6 src/olympia/templates/includes/lang_switcher.html:2
 msgid "Other languages"
 msgstr ""
@@ -11506,11 +11190,11 @@ msgstr ""
 msgid "Mozilla Add-ons"
 msgstr ""
 
-#: src/olympia/templates/base.html:91 src/olympia/templates/impala/base.html:81
+#: src/olympia/templates/base.html:89 src/olympia/templates/impala/base.html:78
 msgid "Find add-ons for other applications"
 msgstr "Find add-ons for other applications"
 
-#: src/olympia/templates/base.html:92 src/olympia/templates/impala/base.html:81
+#: src/olympia/templates/base.html:90 src/olympia/templates/impala/base.html:78
 msgid "Other Applications"
 msgstr "Rhaglenni Eraill"
 
@@ -11535,7 +11219,7 @@ msgid "View Mobile Site"
 msgstr ""
 
 #: src/olympia/templates/copyright.html:7
-msgid "Site Status "
+msgid "Site Status"
 msgstr ""
 
 #: src/olympia/templates/footer.html:3
@@ -11637,35 +11321,35 @@ msgstr ""
 msgid "<a href=\"%(reg)s\">Register</a> or <a href=\"%(login)s\">Log in</a>"
 msgstr ""
 
-#: src/olympia/templates/impala/base.html:126
+#: src/olympia/templates/impala/base.html:123
 #, python-format
 msgid "To try the thousands of add-ons available here, download <a href=\"%(url)s\">Mozilla Firefox</a>, a fast, free way to surf the Web!"
 msgstr ""
 
-#: src/olympia/templates/impala/base.html:138
+#: src/olympia/templates/impala/base.html:135
 #, python-format
 msgid "Add-ons is switching to Firefox Accounts for login. <a href=\"%(url)s\" class=\"fxa-login\">Sign in now to transfer your account.</a>"
 msgstr ""
 
 #. {0} is an application, such as Firefox.
-#: src/olympia/templates/impala/base.html:148
+#: src/olympia/templates/impala/base.html:145
 msgid "Welcome to {0} Add-ons."
 msgstr ""
 
-#: src/olympia/templates/impala/base.html:151
+#: src/olympia/templates/impala/base.html:148
 msgid "Choose from thousands of extra features and styles to make Firefox your own."
 msgstr ""
 
-#: src/olympia/templates/impala/base.html:156
+#: src/olympia/templates/impala/base.html:153
 #, python-format
 msgid "Add extra features and styles to make %(app)s your own."
 msgstr ""
 
-#: src/olympia/templates/impala/base.html:164
+#: src/olympia/templates/impala/base.html:161
 msgid "On the go?"
 msgstr ""
 
-#: src/olympia/templates/impala/base.html:166
+#: src/olympia/templates/impala/base.html:163
 msgid "Check out our <a class=\"mobile-link\" href=\"#\">Mobile Add-ons site</a>."
 msgstr ""
 
@@ -11889,19 +11573,19 @@ msgstr ""
 
 #. L10n: {id} will be something like "13ad6a", just a random number
 #. to differentiate this user from other anonymous users.
-#: src/olympia/users/models.py:353
+#: src/olympia/users/models.py:362
 msgid "Anonymous user {id}"
 msgstr ""
 
-#: src/olympia/users/models.py:410
+#: src/olympia/users/models.py:419
 msgid "Your account has been restricted"
 msgstr ""
 
-#: src/olympia/users/models.py:480
+#: src/olympia/users/models.py:489
 msgid "Please confirm your email address"
 msgstr ""
 
-#: src/olympia/users/models.py:506
+#: src/olympia/users/models.py:515
 msgid "My Mobile Add-ons"
 msgstr ""
 
@@ -12179,7 +11863,7 @@ msgstr "Cyfrinair"
 
 #: src/olympia/users/templates/users/edit.html:70
 #, python-format
-msgid "Change your password.  If you forgot your password, you can <a href=\"%(reset_url)s\">use the reset form</a>."
+msgid "Change your password. If you forgot your password, you can <a href=\"%(reset_url)s\">use the reset form</a>."
 msgstr ""
 
 #: src/olympia/users/templates/users/edit.html:76
@@ -12199,7 +11883,7 @@ msgid "Profile"
 msgstr ""
 
 #: src/olympia/users/templates/users/edit.html:100
-msgid "Give us a bit more information about yourself.  All these fields are optional, but they'll help other users get to know you better."
+msgid "Give us a bit more information about yourself. All these fields are optional, but they'll help other users get to know you better."
 msgstr ""
 
 #: src/olympia/users/templates/users/edit.html:124
@@ -12419,7 +12103,7 @@ msgid "Confirm password"
 msgstr "Cadarnhau'r cyfrinair"
 
 #: src/olympia/users/templates/users/pwreset_confirm.html:47
-msgid "The password reset link was invalid, possibly because it has already been used.  Please request a new password reset."
+msgid "The password reset link was invalid, possibly because it has already been used. Please request a new password reset."
 msgstr ""
 
 #: src/olympia/users/templates/users/pwreset_request.html:15
@@ -12605,7 +12289,7 @@ msgstr ""
 
 #: src/olympia/users/templates/users/unsubscribe.html:30
 #, python-format
-msgid "Unfortunately, we weren't able to unsubscribe you.  The link you clicked is invalid. However, you can unsubscribe still unsubscribe on your <a href=\"%(edit_url)s\">edit profile page</a>."
+msgid "Unfortunately, we weren't able to unsubscribe you. The link you clicked is invalid. However, you can unsubscribe still unsubscribe on your <a href=\"%(edit_url)s\">edit profile page</a>."
 msgstr ""
 
 #: src/olympia/users/templates/users/vcard.html:2
@@ -12638,8 +12322,6 @@ msgid "%(num)s theme"
 msgid_plural "%(num)s themes"
 msgstr[0] ""
 msgstr[1] ""
-msgstr[2] ""
-msgstr[3] ""
 
 #: src/olympia/users/templates/users/vcard.html:62
 #, python-format
@@ -12647,8 +12329,6 @@ msgid "%(num)s add-on"
 msgid_plural "%(num)s add-ons"
 msgstr[0] ""
 msgstr[1] ""
-msgstr[2] ""
-msgstr[3] ""
 
 #: src/olympia/users/templates/users/vcard.html:75
 msgid "Average rating of developer's add-ons"
@@ -12663,15 +12343,15 @@ msgstr ""
 msgid "Version History with Changelogs"
 msgstr "Hanes y Fersiwn a'r Cofnodion Newid"
 
-#: src/olympia/versions/models.py:314
+#: src/olympia/versions/models.py:313
 msgid "Add-on uses binary components."
 msgstr ""
 
-#: src/olympia/versions/models.py:317
+#: src/olympia/versions/models.py:316
 msgid "Add-on has opted into strict compatibility checking."
 msgstr ""
 
-#: src/olympia/versions/models.py:715
+#: src/olympia/versions/models.py:711
 msgid "{app} {min} and later"
 msgstr ""
 
@@ -12710,8 +12390,6 @@ msgid "<b>{0}</b> version"
 msgid_plural "<b>{0}</b> versions"
 msgstr[0] ""
 msgstr[1] ""
-msgstr[2] ""
-msgstr[3] ""
 
 #: src/olympia/versions/templates/versions/version_list.html:35 src/olympia/versions/templates/versions/mobile/version_list.html:14
 msgid "Be careful with old versions!"
@@ -12749,4 +12427,8 @@ msgstr ""
 
 #: src/olympia/zadmin/forms.py:105
 msgid "Log emails instead of sending"
+msgstr ""
+
+#: src/olympia/zadmin/forms.py:215
+msgid "Deleted versions can`t be changed."
 msgstr ""

--- a/locale/cy/LC_MESSAGES/djangojs.po
+++ b/locale/cy/LC_MESSAGES/djangojs.po
@@ -3,1241 +3,1234 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2016-02-24 21:23+0000\n"
+"POT-Creation-Date: 2016-04-18 15:47+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
+"Language: \n"
 "MIME-Version: 1.0\n"
-"Content-Type: text/plain; charset=utf-8\n"
+"Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Generated-By: Babel 2.2.0\n"
 
-#: static/js/common/ratingwidget.js:31
+#: static/js/common-all.js:1426 static/js/impala-all.js:1511 static/js/zamboni/discovery-all.js:12598 static/js/zamboni/init.js:28 static/js/zamboni/mobile-all.js:14945
+msgid "This feature is temporarily disabled while we perform website maintenance. Please check back a little later."
+msgstr ""
+
+#. L10n: {0} is an app name like Firefox.
+#: static/js/common-all.js:1837 static/js/impala-all.js:1922 static/js/zamboni/buttons.js:73 static/js/zamboni/discovery-all.js:13108
+msgid "Accept and Install"
+msgstr ""
+
+#: static/js/common-all.js:1837 static/js/impala-all.js:1922 static/js/zamboni/buttons.js:73 static/js/zamboni/discovery-all.js:13108
+msgid "Add to {0}"
+msgstr ""
+
+#: static/js/common-all.js:1842 static/js/impala-all.js:1927 static/js/zamboni/buttons.js:78 static/js/zamboni/discovery-all.js:13113
+msgid "Download Now"
+msgstr ""
+
+#: static/js/common-all.js:1883 static/js/impala-all.js:1968 static/js/zamboni/buttons.js:119 static/js/zamboni/discovery-all.js:13154
+msgid "Add-on has not been updated to support default-to-compatible."
+msgstr ""
+
+#: static/js/common-all.js:1888 static/js/impala-all.js:1973 static/js/zamboni/buttons.js:124 static/js/zamboni/discovery-all.js:13159
+msgid "You need to be using Firefox 10.0 or higher."
+msgstr ""
+
+#: static/js/common-all.js:1900 static/js/impala-all.js:1985 static/js/zamboni/buttons.js:136 static/js/zamboni/discovery-all.js:13171
+msgid "Mozilla has marked this version as incompatible with your Firefox version."
+msgstr ""
+
+#. L10n: {0} is an platform like Windows or Linux.
+#: static/js/common-all.js:1981 static/js/impala-all.js:2066 static/js/zamboni/buttons.js:217 static/js/zamboni/discovery-all.js:13252
+msgid "Install for {0} anyway"
+msgstr ""
+
+#: static/js/common-all.js:1981 static/js/impala-all.js:2066 static/js/zamboni/buttons.js:217 static/js/zamboni/discovery-all.js:13252
+msgid "Download for {0} anyway"
+msgstr ""
+
+#: static/js/common-all.js:2038 static/js/impala-all.js:2123 static/js/zamboni/buttons.js:274 static/js/zamboni/discovery-all.js:13309
+msgid "Not available for your platform"
+msgstr ""
+
+#. L10n: {0} is an app name, {1} is the app version.
+#: static/js/common-all.js:2049 static/js/common-all.js:2086 static/js/impala-all.js:2134 static/js/impala-all.js:2171 static/js/zamboni/buttons.js:286 static/js/zamboni/buttons.js:324
+#: static/js/zamboni/discovery-all.js:13320 static/js/zamboni/discovery-all.js:13357
+msgid "Not available for {0} {1}"
+msgstr ""
+
+#: static/js/common-all.js:2112 static/js/impala-all.js:2197 static/js/zamboni/buttons.js:351 static/js/zamboni/discovery-all.js:13383
+msgid "Works with {app} {min} - {max}"
+msgstr ""
+
+#: static/js/common-all.js:2114 static/js/impala-all.js:2199 static/js/zamboni/buttons.js:353 static/js/zamboni/discovery-all.js:13385
+msgid "View other versions"
+msgstr ""
+
+#: static/js/common-all.js:2162 static/js/impala-all.js:2247 static/js/zamboni/buttons.js:401 static/js/zamboni/discovery-all.js:13433
+msgid "Only with Firefox — Get Firefox Now!"
+msgstr ""
+
+#: static/js/common-all.js:2278 static/js/impala-all.js:2363 static/js/zamboni/buttons.js:517 static/js/zamboni/discovery-all.js:13549 static/js/zamboni/mobile-all.js:15177
+#: static/js/zamboni/mobile/buttons.js:43
+msgid "Sorry, you need a Mozilla-based browser (such as Firefox) to install a search plugin."
+msgstr ""
+
+#: static/js/common-all.js:9088 static/js/impala-all.js:9649 static/js/zamboni/global.js:410
+msgid "Loading..."
+msgstr ""
+
+#. L10n: {0} is the number of characters left.
+#: static/js/common-all.js:9152 static/js/impala-all.js:9713 static/js/zamboni/global.js:474
+msgid "<b>{0}</b> character left."
+msgid_plural "<b>{0}</b> characters left."
+msgstr[0] ""
+msgstr[1] ""
+
+#: static/js/common-all.js:9589 static/js/common-min.js:6 static/js/impala-all.js:10052 static/js/impala-min.js:6 static/js/common/ratingwidget.js:31 static/js/zamboni/mobile-all.js:16123
+#: static/js/zamboni/mobile-min.js:6
 msgid "{0} star"
 msgid_plural "{0} stars"
 msgstr[0] ""
 msgstr[1] ""
-msgstr[2] ""
-msgstr[3] ""
 
-#: static/js/common/upload-addon.js:41 static/js/common/upload-image.js:128
+#: static/js/common-all.js:9676 static/js/common-min.js:6 static/js/impala-all.js:10139 static/js/impala-min.js:6 static/js/zamboni/l10n.js:45
+msgid "Remove this localization"
+msgstr ""
+
+#: static/js/common-all.js:10193 static/js/common-min.js:6 static/js/impala-all.js:10674 static/js/impala-min.js:6 static/js/zamboni/discovery-all.js:13678
+msgid "close"
+msgstr ""
+
+#: static/js/common-all.js:10860 static/js/common-min.js:6 static/js/impala-all.js:11481 static/js/impala-min.js:6 static/js/impala/reviews.js:23 static/js/zamboni/reviews.js:18
+msgid "Flagged for review"
+msgstr ""
+
+#: static/js/common-all.js:10876 static/js/common-min.js:6 static/js/impala-all.js:11498 static/js/impala-min.js:6 static/js/impala/reviews.js:40 static/js/zamboni/reviews.js:34
+msgid "Your input is required"
+msgstr ""
+
+#: static/js/common-all.js:10945 static/js/common-min.js:6 static/js/impala-all.js:11610 static/js/impala-min.js:7 static/js/impala/reviews.js:152 static/js/zamboni/reviews.js:103
+msgid "Marked for deletion"
+msgstr ""
+
+#: static/js/common-all.js:11573 static/js/common-min.js:7 static/js/impala-all.js:13809 static/js/impala-min.js:8 static/js/zamboni/collections.js:229
+msgid "Adding to Favorites&hellip;"
+msgstr ""
+
+#: static/js/common-all.js:11576 static/js/common-min.js:7 static/js/impala-all.js:13812 static/js/impala-min.js:8 static/js/zamboni/collections.js:232
+msgid "Removing Favorite&hellip;"
+msgstr ""
+
+#: static/js/common-all.js:11579 static/js/common-min.js:7 static/js/impala-all.js:13815 static/js/impala-min.js:8 static/js/zamboni/collections.js:235
+msgid "Add to Favorites"
+msgstr ""
+
+#: static/js/common-all.js:11582 static/js/common-min.js:7 static/js/impala-all.js:13818 static/js/impala-min.js:8 static/js/zamboni/collections.js:238
+msgid "Remove from Favorites"
+msgstr ""
+
+#: static/js/common-all.js:11647 static/js/common-min.js:7 static/js/impala-all.js:13883 static/js/impala-min.js:8 static/js/zamboni/collections.js:303
+msgid "Pending"
+msgstr ""
+
+#: static/js/common-all.js:11648 static/js/common-min.js:7 static/js/impala-all.js:13884 static/js/impala-min.js:8 static/js/zamboni/collections.js:304
+msgid "Add a comment"
+msgstr ""
+
+#: static/js/common-all.js:11648 static/js/common-min.js:7 static/js/impala-all.js:13884 static/js/impala-min.js:8 static/js/zamboni/collections.js:304
+msgid "Comment"
+msgstr ""
+
+#: static/js/common-all.js:11649 static/js/common-min.js:7 static/js/impala-all.js:13885 static/js/impala-min.js:8 static/js/zamboni/collections.js:305
+msgid "Remove this add-on from the collection"
+msgstr ""
+
+#: static/js/common-all.js:11649 static/js/common-all.js:11678 static/js/common-min.js:7 static/js/impala-all.js:13885 static/js/impala-all.js:13914 static/js/impala-min.js:8
+#: static/js/zamboni/collections.js:305 static/js/zamboni/collections.js:334
+msgid "Remove"
+msgstr ""
+
+#: static/js/common-all.js:11678 static/js/common-min.js:7 static/js/impala-all.js:13914 static/js/impala-min.js:8 static/js/zamboni/collections.js:334
+msgid "Remove this user as a contributor"
+msgstr ""
+
+#: static/js/common-all.js:11690 static/js/common-min.js:7 static/js/impala-all.js:13926 static/js/impala-min.js:8 static/js/zamboni/collections.js:346
+msgid "An email address is required."
+msgstr ""
+
+#: static/js/common-all.js:11708 static/js/common-min.js:7 static/js/impala-all.js:13944 static/js/impala-min.js:8 static/js/zamboni/collections.js:364
+msgid "You cannot add yourself as a contributor."
+msgstr ""
+
+#: static/js/common-all.js:11710 static/js/common-min.js:7 static/js/impala-all.js:13946 static/js/impala-min.js:8 static/js/zamboni/collections.js:366
+msgid "You have already added that user."
+msgstr ""
+
+#: static/js/common-all.js:11917 static/js/common-min.js:7 static/js/impala-all.js:14153 static/js/impala-min.js:8 static/js/zamboni/collections.js:573
+msgid "Add to favorites"
+msgstr ""
+
+#: static/js/common-all.js:11921 static/js/common-min.js:7 static/js/impala-all.js:14157 static/js/impala-min.js:8 static/js/zamboni/collections.js:577
+msgid "Remove from favorites"
+msgstr ""
+
+#: static/js/common-all.js:11939 static/js/common-min.js:7 static/js/impala-all.js:14175 static/js/impala-all.js:14233 static/js/impala-min.js:8 static/js/impala/collections.js:10
+#: static/js/zamboni/collections.js:595
+msgid "Follow this Collection"
+msgstr ""
+
+#: static/js/common-all.js:11948 static/js/common-min.js:7 static/js/impala-all.js:14184 static/js/impala-min.js:8 static/js/zamboni/collections.js:604
+msgid "Stop following"
+msgstr ""
+
+#: static/js/common-all.js:12096 static/js/common-min.js:7 static/js/zamboni/password-strength.js:20
+msgid "Password strength:"
+msgstr ""
+
+#: static/js/common-all.js:12102 static/js/common-min.js:7 static/js/zamboni/password-strength.js:26
+msgid "At least {0} character left."
+msgid_plural "At least {0} characters left."
+msgstr[0] ""
+msgstr[1] ""
+
+#: static/js/common-all.js:12286 static/js/common-min.js:7 static/js/impala-all.js:14632 static/js/impala-min.js:8 static/js/impala/suggestions.js:39
+msgid "Search themes for <b>{0}</b>"
+msgstr ""
+
+#: static/js/common-all.js:12288 static/js/common-min.js:7 static/js/impala-all.js:14634 static/js/impala-min.js:8 static/js/impala/suggestions.js:41
+msgid "Search apps for <b>{0}</b>"
+msgstr ""
+
+#: static/js/common-all.js:12290 static/js/common-min.js:7 static/js/impala-all.js:14636 static/js/impala-min.js:8 static/js/impala/suggestions.js:43
+msgid "Search add-ons for <b>{0}</b>"
+msgstr ""
+
+#: static/js/common-all.js:12521 static/js/common-min.js:7 static/js/impala-all.js:14867 static/js/impala-min.js:8 static/js/impala/site_suggestions.js:46
+msgid "Category"
+msgstr ""
+
+#. L10n: {0} is an app name.
+#: static/js/impala-all.js:11632 static/js/impala-min.js:7 static/js/impala/listing.js:11 static/js/zamboni/themes.js:13
+msgid "This theme is incompatible with your version of {0}"
+msgstr ""
+
+#: static/js/impala-all.js:12146 static/js/impala-all.js:14331 static/js/impala-min.js:7 static/js/impala-min.js:8 static/js/common/upload-image.js:97 static/js/impala/users.js:51
+#: static/js/zamboni/devhub-all.js:894 static/js/zamboni/devhub-min.js:1
+msgid "Images must be either PNG or JPG."
+msgstr ""
+
+#: static/js/impala-all.js:12150 static/js/impala-min.js:7 static/js/common/upload-image.js:101 static/js/zamboni/devhub-all.js:898 static/js/zamboni/devhub-min.js:1
+msgid "Videos must be in WebM."
+msgstr ""
+
+#: static/js/impala-all.js:12177 static/js/impala-min.js:7 static/js/common/upload-addon.js:41 static/js/common/upload-image.js:128 static/js/zamboni/devhub-all.js:272
+#: static/js/zamboni/devhub-all.js:925 static/js/zamboni/devhub-min.js:1
 msgid "There was a problem contacting the server."
 msgstr ""
 
-#: static/js/common/upload-addon.js:69
+#: static/js/impala-all.js:13298 static/js/impala-min.js:7 static/js/impala/persona_creation.js:60
+msgid "All Rights Reserved"
+msgstr ""
+
+#: static/js/impala-all.js:13302 static/js/impala-min.js:7 static/js/impala/persona_creation.js:64
+msgid "Creative Commons Attribution 3.0"
+msgstr ""
+
+#: static/js/impala-all.js:13307 static/js/impala-min.js:7 static/js/impala/persona_creation.js:69
+msgid "Creative Commons Attribution-NonCommercial 3.0"
+msgstr ""
+
+#: static/js/impala-all.js:13312 static/js/impala-min.js:7 static/js/impala/persona_creation.js:74
+msgid "Creative Commons Attribution-NonCommercial-NoDerivs 3.0"
+msgstr ""
+
+#: static/js/impala-all.js:13317 static/js/impala-min.js:7 static/js/impala/persona_creation.js:79
+msgid "Creative Commons Attribution-NonCommercial-Share Alike 3.0"
+msgstr ""
+
+#: static/js/impala-all.js:13322 static/js/impala-min.js:7 static/js/impala/persona_creation.js:84
+msgid "Creative Commons Attribution-NoDerivs 3.0"
+msgstr ""
+
+#: static/js/impala-all.js:13327 static/js/impala-min.js:7 static/js/impala/persona_creation.js:89
+msgid "Creative Commons Attribution-ShareAlike 3.0"
+msgstr ""
+
+#: static/js/impala-all.js:13530 static/js/impala-min.js:7 static/js/impala/persona_creation.js:292
+msgid "Your Theme's Name"
+msgstr ""
+
+#: static/js/impala-all.js:14242 static/js/impala-min.js:8 static/js/impala/collections.js:19
+msgid "Stop Following"
+msgstr ""
+
+#: static/js/impala-all.js:14243 static/js/impala-min.js:8 static/js/impala/collections.js:20
+msgid "Following"
+msgstr ""
+
+#: static/js/impala-all.js:14313 static/js/impala-min.js:8 static/js/impala/users.js:33
+msgid "use original"
+msgstr ""
+
+#: static/js/impala-all.js:14523 static/js/impala-min.js:8 static/js/impala/search.js:114
+msgid "Updating results&hellip;"
+msgstr ""
+
+#: static/js/common/upload-addon.js:69 static/js/zamboni/devhub-all.js:300 static/js/zamboni/devhub-min.js:1
 msgid "Select a file..."
 msgstr ""
 
-#: static/js/common/upload-addon.js:70
+#: static/js/common/upload-addon.js:70 static/js/zamboni/devhub-all.js:301 static/js/zamboni/devhub-min.js:1
 msgid "Your add-on should end with .xpi, .jar or .xml"
 msgstr ""
 
 #. L10n: {0} is the percent of the file that has been uploaded.
-#: static/js/common/upload-addon.js:104
+#: static/js/common/upload-addon.js:104 static/js/zamboni/devhub-all.js:335 static/js/zamboni/devhub-min.js:1
 #, python-format
 msgid "{0}% complete"
 msgstr ""
 
 #. L10n: "{bytes uploaded} of {total filesize}".
-#: static/js/common/upload-addon.js:107
+#: static/js/common/upload-addon.js:107 static/js/zamboni/devhub-all.js:338 static/js/zamboni/devhub-min.js:1
 msgid "{0} of {1}"
 msgstr ""
 
-#: static/js/common/upload-addon.js:140
+#: static/js/common/upload-addon.js:140 static/js/zamboni/devhub-all.js:371 static/js/zamboni/devhub-min.js:1
 msgid "Cancel"
 msgstr ""
 
-#: static/js/common/upload-addon.js:162
+#: static/js/common/upload-addon.js:162 static/js/zamboni/devhub-all.js:393 static/js/zamboni/devhub-min.js:1
 msgid "Uploading {0}"
 msgstr ""
 
-#: static/js/common/upload-addon.js:189
+#: static/js/common/upload-addon.js:189 static/js/zamboni/devhub-all.js:420 static/js/zamboni/devhub-min.js:1
 msgid "Error with {0}"
 msgstr ""
 
-#: static/js/common/upload-addon.js:194
+#: static/js/common/upload-addon.js:194 static/js/zamboni/devhub-all.js:425 static/js/zamboni/devhub-min.js:1
 msgid "Your add-on failed validation with {0} error."
 msgid_plural "Your add-on failed validation with {0} errors."
 msgstr[0] ""
 msgstr[1] ""
-msgstr[2] ""
-msgstr[3] ""
 
-#: static/js/common/upload-addon.js:208
+#: static/js/common/upload-addon.js:208 static/js/zamboni/devhub-all.js:439 static/js/zamboni/devhub-min.js:1
 msgid "&hellip;and {0} more"
 msgid_plural "&hellip;and {0} more"
 msgstr[0] ""
 msgstr[1] ""
-msgstr[2] ""
-msgstr[3] ""
 
-#: static/js/common/upload-addon.js:222 static/js/common/upload-addon.js:512
+#: static/js/common/upload-addon.js:222 static/js/common/upload-addon.js:497 static/js/zamboni/devhub-all.js:453 static/js/zamboni/devhub-all.js:743 static/js/zamboni/devhub-min.js:1
 msgid "See full validation report"
 msgstr ""
 
-#: static/js/common/upload-addon.js:234
+#: static/js/common/upload-addon.js:234 static/js/zamboni/devhub-all.js:465 static/js/zamboni/devhub-min.js:1
 msgid "Validating {0}"
 msgstr ""
 
 #. L10n: first argument is an HTTP status code
-#: static/js/common/upload-addon.js:273
+#: static/js/common/upload-addon.js:273 static/js/zamboni/devhub-all.js:504 static/js/zamboni/devhub-min.js:1
 msgid "Received an empty response from the server; status: {0}"
 msgstr ""
 
-#: static/js/common/upload-addon.js:373
+#: static/js/common/upload-addon.js:370 static/js/zamboni/devhub-all.js:604 static/js/zamboni/devhub-min.js:1
 msgid "Unexpected server error while validating."
 msgstr ""
 
-#: static/js/common/upload-addon.js:412
+#: static/js/common/upload-addon.js:409 static/js/zamboni/devhub-all.js:643 static/js/zamboni/devhub-min.js:1
 msgid "Finished validating {0}"
 msgstr ""
 
-#: static/js/common/upload-addon.js:418
+#: static/js/common/upload-addon.js:415 static/js/zamboni/devhub-all.js:649 static/js/zamboni/devhub-min.js:1
 msgid "Your add-on validation timed out, it will be manually reviewed."
 msgstr ""
 
-#: static/js/common/upload-addon.js:421
+#: static/js/common/upload-addon.js:418 static/js/zamboni/devhub-all.js:652 static/js/zamboni/devhub-min.js:1
 msgid "Your add-on was validated with no errors and {0} warning."
 msgid_plural "Your add-on was validated with no errors and {0} warnings."
 msgstr[0] ""
 msgstr[1] ""
-msgstr[2] ""
-msgstr[3] ""
 
-#: static/js/common/upload-addon.js:426
+#: static/js/common/upload-addon.js:423 static/js/zamboni/devhub-all.js:657 static/js/zamboni/devhub-min.js:1
 msgid "Your add-on was validated with no errors and {0} message."
 msgid_plural "Your add-on was validated with no errors and {0} messages."
 msgstr[0] ""
 msgstr[1] ""
-msgstr[2] ""
-msgstr[3] ""
 
-#: static/js/common/upload-addon.js:431
+#: static/js/common/upload-addon.js:428 static/js/zamboni/devhub-all.js:662 static/js/zamboni/devhub-min.js:1
 msgid "Your add-on was validated with no errors or warnings."
 msgstr ""
 
-#: static/js/common/upload-addon.js:446
+#: static/js/common/upload-addon.js:443 static/js/zamboni/devhub-all.js:677 static/js/zamboni/devhub-min.js:1
 msgid "Your submission will be automatically signed."
 msgstr ""
 
-#: static/js/common/upload-addon.js:465
+#: static/js/common/upload-addon.js:450 static/js/zamboni/devhub-all.js:696 static/js/zamboni/devhub-min.js:1
 msgid "Include detailed version notes (this can be done in the next step)."
 msgstr ""
 
-#: static/js/common/upload-addon.js:466
+#: static/js/common/upload-addon.js:451 static/js/zamboni/devhub-all.js:697 static/js/zamboni/devhub-min.js:1
 msgid "If your add-on requires an account to a website in order to be fully tested, include a test username and password in the Notes to Reviewer (this can be done in the next step)."
 msgstr ""
 
-#: static/js/common/upload-addon.js:467
+#: static/js/common/upload-addon.js:452 static/js/zamboni/devhub-all.js:698 static/js/zamboni/devhub-min.js:1
 msgid "If your add-on is intended for a limited audience you should choose Preliminary Review instead of Full Review."
 msgstr ""
 
-#: static/js/common/upload-addon.js:480
+#: static/js/common/upload-addon.js:465 static/js/zamboni/devhub-all.js:711 static/js/zamboni/devhub-min.js:1
 msgid "Add-on submission checklist"
 msgstr ""
 
-#: static/js/common/upload-addon.js:481
+#: static/js/common/upload-addon.js:466 static/js/zamboni/devhub-all.js:712 static/js/zamboni/devhub-min.js:1
 msgid "Please verify the following points before finalizing your submission. This will minimize delays or misunderstanding during the review process:"
 msgstr ""
 
-#: static/js/common/upload-addon.js:483
+#: static/js/common/upload-addon.js:468 static/js/zamboni/devhub-all.js:714 static/js/zamboni/devhub-min.js:1
 msgid ""
 "Compiled binaries, as well as minified or obfuscated scripts (excluding known libraries) need to have their sources submitted separately for review. Make sure that you use the source code upload "
 "field to avoid having your submission rejected."
 msgstr ""
 
-#: static/js/common/upload-addon.js:501
+#: static/js/common/upload-addon.js:486 static/js/zamboni/devhub-all.js:732 static/js/zamboni/devhub-min.js:1
 msgid "The validation process found these issues that can lead to rejections:"
 msgstr ""
 
-#: static/js/common/upload-addon.js:518
+#: static/js/common/upload-addon.js:503 static/js/zamboni/devhub-all.js:749 static/js/zamboni/devhub-min.js:1
 msgid "If you are unfamiliar with the add-ons review process, you can read about it here."
 msgstr ""
 
-#: static/js/common/upload-addon.js:555
+#: static/js/common/upload-addon.js:540 static/js/zamboni/devhub-all.js:786 static/js/zamboni/devhub-min.js:1
 msgid "Sorry, no supported platform has been found."
 msgstr ""
 
-#: static/js/common/upload-base.js:57
+#: static/js/common/upload-base.js:57 static/js/zamboni/devhub-all.js:187 static/js/zamboni/devhub-min.js:1
 msgid "The filetype you uploaded isn't recognized."
 msgstr ""
 
-#: static/js/common/upload-base.js:79
+#: static/js/common/upload-base.js:79 static/js/zamboni/devhub-all.js:209 static/js/zamboni/devhub-min.js:1
 msgid "You cancelled the upload."
 msgstr ""
 
-#: static/js/common/upload-image.js:97 static/js/impala/users.js:51
-msgid "Images must be either PNG or JPG."
-msgstr ""
-
-#: static/js/common/upload-image.js:101
-msgid "Videos must be in WebM."
-msgstr ""
-
-#: static/js/impala/collections.js:10 static/js/zamboni/collections.js:595
-msgid "Follow this Collection"
-msgstr ""
-
-#: static/js/impala/collections.js:19
-msgid "Stop Following"
-msgstr ""
-
-#: static/js/impala/collections.js:20
-msgid "Following"
-msgstr ""
-
-#. L10n: {0} is an app name.
-#: static/js/impala/listing.js:11 static/js/zamboni/themes.js:13
-msgid "This theme is incompatible with your version of {0}"
-msgstr ""
-
-#: static/js/impala/persona_creation.js:60
-msgid "All Rights Reserved"
-msgstr ""
-
-#: static/js/impala/persona_creation.js:64
-msgid "Creative Commons Attribution 3.0"
-msgstr ""
-
-#: static/js/impala/persona_creation.js:69
-msgid "Creative Commons Attribution-NonCommercial 3.0"
-msgstr ""
-
-#: static/js/impala/persona_creation.js:74
-msgid "Creative Commons Attribution-NonCommercial-NoDerivs 3.0"
-msgstr ""
-
-#: static/js/impala/persona_creation.js:79
-msgid "Creative Commons Attribution-NonCommercial-Share Alike 3.0"
-msgstr ""
-
-#: static/js/impala/persona_creation.js:84
-msgid "Creative Commons Attribution-NoDerivs 3.0"
-msgstr ""
-
-#: static/js/impala/persona_creation.js:89
-msgid "Creative Commons Attribution-ShareAlike 3.0"
-msgstr ""
-
-#: static/js/impala/persona_creation.js:292
-msgid "Your Theme's Name"
-msgstr ""
-
-#: static/js/impala/reviews.js:23 static/js/zamboni/reviews.js:18
-msgid "Flagged for review"
-msgstr ""
-
-#: static/js/impala/reviews.js:40 static/js/zamboni/reviews.js:34
-msgid "Your input is required"
-msgstr ""
-
-#: static/js/impala/reviews.js:152 static/js/zamboni/reviews.js:103
-msgid "Marked for deletion"
-msgstr ""
-
-#: static/js/impala/search.js:114
-msgid "Updating results&hellip;"
-msgstr ""
-
-#: static/js/impala/site_suggestions.js:46
-msgid "Category"
-msgstr ""
-
-#: static/js/impala/suggestions.js:39
-msgid "Search themes for <b>{0}</b>"
-msgstr ""
-
-#: static/js/impala/suggestions.js:41
-msgid "Search apps for <b>{0}</b>"
-msgstr ""
-
-#: static/js/impala/suggestions.js:43
-msgid "Search add-ons for <b>{0}</b>"
-msgstr ""
-
-#: static/js/impala/users.js:33
-msgid "use original"
-msgstr ""
-
-#: static/js/impala/stats/chart.js:267
+#: static/js/impala/stats/chart.js:267 static/js/zamboni/stats-all.js:16898 static/js/zamboni/stats-min.js:5
 msgid "Week of {0}"
 msgstr ""
 
-#: static/js/impala/stats/chart.js:269
+#: static/js/impala/stats/chart.js:269 static/js/zamboni/stats-all.js:16900 static/js/zamboni/stats-min.js:5
 msgid " downloads"
 msgstr ""
 
-#: static/js/impala/stats/chart.js:270
+#: static/js/impala/stats/chart.js:270 static/js/zamboni/stats-all.js:16901 static/js/zamboni/stats-min.js:5
 msgid "{0} users"
 msgstr ""
 
-#: static/js/impala/stats/chart.js:271
+#: static/js/impala/stats/chart.js:271 static/js/zamboni/stats-all.js:16902 static/js/zamboni/stats-min.js:5
 msgid "{0} add-ons"
 msgstr ""
 
-#: static/js/impala/stats/chart.js:272
+#: static/js/impala/stats/chart.js:272 static/js/zamboni/stats-all.js:16903 static/js/zamboni/stats-min.js:5
 msgid "{0} collections"
 msgstr ""
 
-#: static/js/impala/stats/chart.js:273
+#: static/js/impala/stats/chart.js:273 static/js/zamboni/stats-all.js:16904 static/js/zamboni/stats-min.js:5
 msgid "{0} reviews"
 msgstr ""
 
-#: static/js/impala/stats/chart.js:275
+#: static/js/impala/stats/chart.js:275 static/js/zamboni/stats-all.js:16906 static/js/zamboni/stats-min.js:5
 msgid "{0} sales"
 msgstr ""
 
-#: static/js/impala/stats/chart.js:276
+#: static/js/impala/stats/chart.js:276 static/js/zamboni/stats-all.js:16907 static/js/zamboni/stats-min.js:5
 msgid "{0} refunds"
 msgstr ""
 
-#: static/js/impala/stats/chart.js:277
+#: static/js/impala/stats/chart.js:277 static/js/zamboni/stats-all.js:16908 static/js/zamboni/stats-min.js:5
 msgid "{0} installs"
 msgstr ""
 
-#: static/js/impala/stats/chart.js:369 static/js/impala/stats/csv_keys.js:3 static/js/impala/stats/csv_keys.js:109
+#: static/js/impala/stats/chart.js:369 static/js/impala/stats/csv_keys.js:3 static/js/impala/stats/csv_keys.js:109 static/js/zamboni/stats-all.js:15284 static/js/zamboni/stats-all.js:15390
+#: static/js/zamboni/stats-all.js:17000 static/js/zamboni/stats-min.js:4 static/js/zamboni/stats-min.js:5
 msgid "Downloads"
 msgstr ""
 
-#: static/js/impala/stats/chart.js:379 static/js/impala/stats/csv_keys.js:6 static/js/impala/stats/csv_keys.js:110
+#: static/js/impala/stats/chart.js:379 static/js/impala/stats/csv_keys.js:6 static/js/impala/stats/csv_keys.js:110 static/js/zamboni/stats-all.js:15287 static/js/zamboni/stats-all.js:15391
+#: static/js/zamboni/stats-all.js:17010 static/js/zamboni/stats-min.js:4 static/js/zamboni/stats-min.js:5
 msgid "Daily Users"
 msgstr ""
 
-#: static/js/impala/stats/chart.js:410
+#: static/js/impala/stats/chart.js:410 static/js/zamboni/stats-all.js:17041 static/js/zamboni/stats-min.js:5
 msgid "Amount, in USD"
 msgstr ""
 
-#: static/js/impala/stats/chart.js:421 static/js/impala/stats/csv_keys.js:104
+#: static/js/impala/stats/chart.js:421 static/js/impala/stats/csv_keys.js:104 static/js/zamboni/stats-all.js:15385 static/js/zamboni/stats-all.js:17052 static/js/zamboni/stats-min.js:5
 msgid "Number of Contributions"
 msgstr ""
 
-#: static/js/impala/stats/chart.js:447
+#: static/js/impala/stats/chart.js:447 static/js/zamboni/stats-all.js:17078 static/js/zamboni/stats-min.js:5
 msgid "More Info..."
 msgstr ""
 
 #. L10n: {0} is an ISO-formatted date.
-#: static/js/impala/stats/chart.js:451
+#: static/js/impala/stats/chart.js:451 static/js/zamboni/stats-all.js:17082 static/js/zamboni/stats-min.js:5
 msgid "Details for {0}"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:9
+#: static/js/impala/stats/csv_keys.js:9 static/js/zamboni/stats-all.js:15290 static/js/zamboni/stats-min.js:4
 msgid "Collections Created"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:12
+#: static/js/impala/stats/csv_keys.js:12 static/js/zamboni/stats-all.js:15293 static/js/zamboni/stats-min.js:4
 msgid "Add-ons in Use"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:15
+#: static/js/impala/stats/csv_keys.js:15 static/js/zamboni/stats-all.js:15296 static/js/zamboni/stats-min.js:4
 msgid "Add-ons Created"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:18
+#: static/js/impala/stats/csv_keys.js:18 static/js/zamboni/stats-all.js:15299 static/js/zamboni/stats-min.js:4
 msgid "Add-ons Downloaded"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:21
+#: static/js/impala/stats/csv_keys.js:21 static/js/zamboni/stats-all.js:15302 static/js/zamboni/stats-min.js:4
 msgid "Add-ons Updated"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:24
+#: static/js/impala/stats/csv_keys.js:24 static/js/zamboni/stats-all.js:15305 static/js/zamboni/stats-min.js:4
 msgid "Reviews Written"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:27
+#: static/js/impala/stats/csv_keys.js:27 static/js/zamboni/stats-all.js:15308 static/js/zamboni/stats-min.js:4
 msgid "User Signups"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:30
+#: static/js/impala/stats/csv_keys.js:30 static/js/zamboni/stats-all.js:15311 static/js/zamboni/stats-min.js:4
 msgid "Subscribers"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:33
+#: static/js/impala/stats/csv_keys.js:33 static/js/zamboni/stats-all.js:15314 static/js/zamboni/stats-min.js:4
 msgid "Ratings"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:36 static/js/impala/stats/csv_keys.js:114
+#: static/js/impala/stats/csv_keys.js:36 static/js/impala/stats/csv_keys.js:114 static/js/zamboni/stats-all.js:15317 static/js/zamboni/stats-all.js:15395 static/js/zamboni/stats-min.js:4
+#: static/js/zamboni/stats-min.js:5
 msgid "Sales"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:39 static/js/impala/stats/csv_keys.js:113
+#: static/js/impala/stats/csv_keys.js:39 static/js/impala/stats/csv_keys.js:113 static/js/zamboni/stats-all.js:15320 static/js/zamboni/stats-all.js:15394 static/js/zamboni/stats-min.js:4
+#: static/js/zamboni/stats-min.js:5
 msgid "Installs"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:42
+#: static/js/impala/stats/csv_keys.js:42 static/js/zamboni/stats-all.js:15323 static/js/zamboni/stats-min.js:4
 msgid "Unknown"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:43
+#: static/js/impala/stats/csv_keys.js:43 static/js/zamboni/stats-all.js:15324 static/js/zamboni/stats-min.js:4
 msgid "Add-ons Manager"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:44
+#: static/js/impala/stats/csv_keys.js:44 static/js/zamboni/stats-all.js:15325 static/js/zamboni/stats-min.js:4
 msgid "Add-ons Manager Promo"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:45
+#: static/js/impala/stats/csv_keys.js:45 static/js/zamboni/stats-all.js:15326 static/js/zamboni/stats-min.js:4
 msgid "Add-ons Manager Featured"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:46
+#: static/js/impala/stats/csv_keys.js:46 static/js/zamboni/stats-all.js:15327 static/js/zamboni/stats-min.js:4
 msgid "Add-ons Manager Learn More"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:47
+#: static/js/impala/stats/csv_keys.js:47 static/js/zamboni/stats-all.js:15328 static/js/zamboni/stats-min.js:4
 msgid "Search Suggestions"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:48
+#: static/js/impala/stats/csv_keys.js:48 static/js/zamboni/stats-all.js:15329 static/js/zamboni/stats-min.js:4
 msgid "Search Results"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:49 static/js/impala/stats/csv_keys.js:50 static/js/impala/stats/csv_keys.js:51
+#: static/js/impala/stats/csv_keys.js:49 static/js/impala/stats/csv_keys.js:50 static/js/impala/stats/csv_keys.js:51 static/js/zamboni/stats-all.js:15330 static/js/zamboni/stats-all.js:15331
+#: static/js/zamboni/stats-all.js:15332 static/js/zamboni/stats-min.js:4
 msgid "Homepage Promo"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:52 static/js/impala/stats/csv_keys.js:53
+#: static/js/impala/stats/csv_keys.js:52 static/js/impala/stats/csv_keys.js:53 static/js/zamboni/stats-all.js:15333 static/js/zamboni/stats-all.js:15334 static/js/zamboni/stats-min.js:4
 msgid "Homepage Featured"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:54 static/js/impala/stats/csv_keys.js:55
+#: static/js/impala/stats/csv_keys.js:54 static/js/impala/stats/csv_keys.js:55 static/js/zamboni/stats-all.js:15335 static/js/zamboni/stats-all.js:15336 static/js/zamboni/stats-min.js:4
 msgid "Homepage Up and Coming"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:56
+#: static/js/impala/stats/csv_keys.js:56 static/js/zamboni/stats-all.js:15337 static/js/zamboni/stats-min.js:4
 msgid "Homepage Most Popular"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:57 static/js/impala/stats/csv_keys.js:59
+#: static/js/impala/stats/csv_keys.js:57 static/js/impala/stats/csv_keys.js:59 static/js/zamboni/stats-all.js:15338 static/js/zamboni/stats-all.js:15340 static/js/zamboni/stats-min.js:4
 msgid "Detail Page"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:58 static/js/impala/stats/csv_keys.js:60
+#: static/js/impala/stats/csv_keys.js:58 static/js/impala/stats/csv_keys.js:60 static/js/zamboni/stats-all.js:15339 static/js/zamboni/stats-all.js:15341 static/js/zamboni/stats-min.js:4
 msgid "Detail Page (bottom)"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:61
+#: static/js/impala/stats/csv_keys.js:61 static/js/zamboni/stats-all.js:15342 static/js/zamboni/stats-min.js:4
 msgid "Detail Page (Development Channel)"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:62 static/js/impala/stats/csv_keys.js:63 static/js/impala/stats/csv_keys.js:64
+#: static/js/impala/stats/csv_keys.js:62 static/js/impala/stats/csv_keys.js:63 static/js/impala/stats/csv_keys.js:64 static/js/zamboni/stats-all.js:15343 static/js/zamboni/stats-all.js:15344
+#: static/js/zamboni/stats-all.js:15345 static/js/zamboni/stats-min.js:4
 msgid "Often Used With"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:65 static/js/impala/stats/csv_keys.js:66
+#: static/js/impala/stats/csv_keys.js:65 static/js/impala/stats/csv_keys.js:66 static/js/zamboni/stats-all.js:15346 static/js/zamboni/stats-all.js:15347 static/js/zamboni/stats-min.js:4
 msgid "Others By Author"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:67 static/js/impala/stats/csv_keys.js:68
+#: static/js/impala/stats/csv_keys.js:67 static/js/impala/stats/csv_keys.js:68 static/js/zamboni/stats-all.js:15348 static/js/zamboni/stats-all.js:15349 static/js/zamboni/stats-min.js:4
 msgid "Dependencies"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:69 static/js/impala/stats/csv_keys.js:70
+#: static/js/impala/stats/csv_keys.js:69 static/js/impala/stats/csv_keys.js:70 static/js/zamboni/stats-all.js:15350 static/js/zamboni/stats-all.js:15351 static/js/zamboni/stats-min.js:4
 msgid "Upsell"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:71
+#: static/js/impala/stats/csv_keys.js:71 static/js/zamboni/stats-all.js:15352 static/js/zamboni/stats-min.js:4
 msgid "Meet the Developer"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:72
+#: static/js/impala/stats/csv_keys.js:72 static/js/zamboni/stats-all.js:15353 static/js/zamboni/stats-min.js:4
 msgid "User Profile"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:73
+#: static/js/impala/stats/csv_keys.js:73 static/js/zamboni/stats-all.js:15354 static/js/zamboni/stats-min.js:4
 msgid "Version History"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:75
+#: static/js/impala/stats/csv_keys.js:75 static/js/zamboni/stats-all.js:15356 static/js/zamboni/stats-min.js:4
 msgid "Sharing"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:76
+#: static/js/impala/stats/csv_keys.js:76 static/js/zamboni/stats-all.js:15357 static/js/zamboni/stats-min.js:4
 msgid "Category Pages"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:77
+#: static/js/impala/stats/csv_keys.js:77 static/js/zamboni/stats-all.js:15358 static/js/zamboni/stats-min.js:4
 msgid "Collections"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:78 static/js/impala/stats/csv_keys.js:79
+#: static/js/impala/stats/csv_keys.js:78 static/js/impala/stats/csv_keys.js:79 static/js/zamboni/stats-all.js:15359 static/js/zamboni/stats-all.js:15360 static/js/zamboni/stats-min.js:4
 msgid "Category Landing Featured Carousel"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:80 static/js/impala/stats/csv_keys.js:81
+#: static/js/impala/stats/csv_keys.js:80 static/js/impala/stats/csv_keys.js:81 static/js/zamboni/stats-all.js:15361 static/js/zamboni/stats-all.js:15362 static/js/zamboni/stats-min.js:4
 msgid "Category Landing Top Rated"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:82 static/js/impala/stats/csv_keys.js:83
+#: static/js/impala/stats/csv_keys.js:82 static/js/impala/stats/csv_keys.js:83 static/js/zamboni/stats-all.js:15363 static/js/zamboni/stats-all.js:15364 static/js/zamboni/stats-min.js:5
 msgid "Category Landing Most Popular"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:84 static/js/impala/stats/csv_keys.js:85
+#: static/js/impala/stats/csv_keys.js:84 static/js/impala/stats/csv_keys.js:85 static/js/zamboni/stats-all.js:15365 static/js/zamboni/stats-all.js:15366 static/js/zamboni/stats-min.js:5
 msgid "Category Landing Recently Added"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:86 static/js/impala/stats/csv_keys.js:87
+#: static/js/impala/stats/csv_keys.js:86 static/js/impala/stats/csv_keys.js:87 static/js/zamboni/stats-all.js:15367 static/js/zamboni/stats-all.js:15368 static/js/zamboni/stats-min.js:5
 msgid "Browse Listing Featured Sort"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:88 static/js/impala/stats/csv_keys.js:89
+#: static/js/impala/stats/csv_keys.js:88 static/js/impala/stats/csv_keys.js:89 static/js/zamboni/stats-all.js:15369 static/js/zamboni/stats-all.js:15370 static/js/zamboni/stats-min.js:5
 msgid "Browse Listing Users Sort"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:90 static/js/impala/stats/csv_keys.js:91
+#: static/js/impala/stats/csv_keys.js:90 static/js/impala/stats/csv_keys.js:91 static/js/zamboni/stats-all.js:15371 static/js/zamboni/stats-all.js:15372 static/js/zamboni/stats-min.js:5
 msgid "Browse Listing Rating Sort"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:92 static/js/impala/stats/csv_keys.js:93
+#: static/js/impala/stats/csv_keys.js:92 static/js/impala/stats/csv_keys.js:93 static/js/zamboni/stats-all.js:15373 static/js/zamboni/stats-all.js:15374 static/js/zamboni/stats-min.js:5
 msgid "Browse Listing Created Sort"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:94 static/js/impala/stats/csv_keys.js:95
+#: static/js/impala/stats/csv_keys.js:94 static/js/impala/stats/csv_keys.js:95 static/js/zamboni/stats-all.js:15375 static/js/zamboni/stats-all.js:15376 static/js/zamboni/stats-min.js:5
 msgid "Browse Listing Name Sort"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:96 static/js/impala/stats/csv_keys.js:97
+#: static/js/impala/stats/csv_keys.js:96 static/js/impala/stats/csv_keys.js:97 static/js/zamboni/stats-all.js:15377 static/js/zamboni/stats-all.js:15378 static/js/zamboni/stats-min.js:5
 msgid "Browse Listing Popular Sort"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:98 static/js/impala/stats/csv_keys.js:99
+#: static/js/impala/stats/csv_keys.js:98 static/js/impala/stats/csv_keys.js:99 static/js/zamboni/stats-all.js:15379 static/js/zamboni/stats-all.js:15380 static/js/zamboni/stats-min.js:5
 msgid "Browse Listing Updated Sort"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:100 static/js/impala/stats/csv_keys.js:101
+#: static/js/impala/stats/csv_keys.js:100 static/js/impala/stats/csv_keys.js:101 static/js/zamboni/stats-all.js:15381 static/js/zamboni/stats-all.js:15382 static/js/zamboni/stats-min.js:5
 msgid "Browse Listing Up and Coming Sort"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:105
+#: static/js/impala/stats/csv_keys.js:105 static/js/zamboni/stats-all.js:15386 static/js/zamboni/stats-min.js:5
 msgid "Total Amount Contributed"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:106
+#: static/js/impala/stats/csv_keys.js:106 static/js/zamboni/stats-all.js:15387 static/js/zamboni/stats-min.js:5
 msgid "Average Contribution"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:115
+#: static/js/impala/stats/csv_keys.js:115 static/js/zamboni/stats-all.js:15396 static/js/zamboni/stats-min.js:5
 msgid "Usage"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:118
+#: static/js/impala/stats/csv_keys.js:118 static/js/zamboni/stats-all.js:15399 static/js/zamboni/stats-min.js:5
 msgid "Firefox"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:119
+#: static/js/impala/stats/csv_keys.js:119 static/js/zamboni/stats-all.js:15400 static/js/zamboni/stats-min.js:5
 msgid "Mozilla"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:120
+#: static/js/impala/stats/csv_keys.js:120 static/js/zamboni/stats-all.js:15401 static/js/zamboni/stats-min.js:5
 msgid "Thunderbird"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:121
+#: static/js/impala/stats/csv_keys.js:121 static/js/zamboni/stats-all.js:15402 static/js/zamboni/stats-min.js:5
 msgid "Sunbird"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:122
+#: static/js/impala/stats/csv_keys.js:122 static/js/zamboni/stats-all.js:15403 static/js/zamboni/stats-min.js:5
 msgid "SeaMonkey"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:123
+#: static/js/impala/stats/csv_keys.js:123 static/js/zamboni/stats-all.js:15404 static/js/zamboni/stats-min.js:5
 msgid "Fennec"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:124
+#: static/js/impala/stats/csv_keys.js:124 static/js/zamboni/stats-all.js:15405 static/js/zamboni/stats-min.js:5
 msgid "Android"
 msgstr ""
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:129
+#: static/js/impala/stats/csv_keys.js:129 static/js/zamboni/stats-all.js:15410 static/js/zamboni/stats-min.js:5
 msgid "Downloads and Daily Users, last {0} days"
 msgstr ""
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:131
+#: static/js/impala/stats/csv_keys.js:131 static/js/zamboni/stats-all.js:15412 static/js/zamboni/stats-min.js:5
 msgid "Downloads and Daily Users from {0} to {1}"
 msgstr ""
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:135
+#: static/js/impala/stats/csv_keys.js:135 static/js/zamboni/stats-all.js:15416 static/js/zamboni/stats-min.js:5
 msgid "Installs and Daily Users, last {0} days"
 msgstr ""
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:137
+#: static/js/impala/stats/csv_keys.js:137 static/js/zamboni/stats-all.js:15418 static/js/zamboni/stats-min.js:5
 msgid "Installs and Daily Users from {0} to {1}"
 msgstr ""
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:141
+#: static/js/impala/stats/csv_keys.js:141 static/js/zamboni/stats-all.js:15422 static/js/zamboni/stats-min.js:5
 msgid "Downloads, last {0} days"
 msgstr ""
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:143
+#: static/js/impala/stats/csv_keys.js:143 static/js/zamboni/stats-all.js:15424 static/js/zamboni/stats-min.js:5
 msgid "Downloads from {0} to {1}"
 msgstr ""
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:147
+#: static/js/impala/stats/csv_keys.js:147 static/js/zamboni/stats-all.js:15428 static/js/zamboni/stats-min.js:5
 msgid "Daily Users, last {0} days"
 msgstr ""
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:149
+#: static/js/impala/stats/csv_keys.js:149 static/js/zamboni/stats-all.js:15430 static/js/zamboni/stats-min.js:5
 msgid "Daily Users from {0} to {1}"
 msgstr ""
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:153
+#: static/js/impala/stats/csv_keys.js:153 static/js/zamboni/stats-all.js:15434 static/js/zamboni/stats-min.js:5
 msgid "Applications, last {0} days"
 msgstr ""
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:155
+#: static/js/impala/stats/csv_keys.js:155 static/js/zamboni/stats-all.js:15436 static/js/zamboni/stats-min.js:5
 msgid "Applications from {0} to {1}"
 msgstr ""
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:159
+#: static/js/impala/stats/csv_keys.js:159 static/js/zamboni/stats-all.js:15440 static/js/zamboni/stats-min.js:5
 msgid "Platforms, last {0} days"
 msgstr ""
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:161
+#: static/js/impala/stats/csv_keys.js:161 static/js/zamboni/stats-all.js:15442 static/js/zamboni/stats-min.js:5
 msgid "Platforms from {0} to {1}"
 msgstr ""
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:165
+#: static/js/impala/stats/csv_keys.js:165 static/js/zamboni/stats-all.js:15446 static/js/zamboni/stats-min.js:5
 msgid "Languages, last {0} days"
 msgstr ""
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:167
+#: static/js/impala/stats/csv_keys.js:167 static/js/zamboni/stats-all.js:15448 static/js/zamboni/stats-min.js:5
 msgid "Languages from {0} to {1}"
 msgstr ""
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:171
+#: static/js/impala/stats/csv_keys.js:171 static/js/zamboni/stats-all.js:15452 static/js/zamboni/stats-min.js:5
 msgid "Add-on Versions, last {0} days"
 msgstr ""
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:173
+#: static/js/impala/stats/csv_keys.js:173 static/js/zamboni/stats-all.js:15454 static/js/zamboni/stats-min.js:5
 msgid "Add-on Versions from {0} to {1}"
 msgstr ""
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:177
+#: static/js/impala/stats/csv_keys.js:177 static/js/zamboni/stats-all.js:15458 static/js/zamboni/stats-min.js:5
 msgid "Add-on Status, last {0} days"
 msgstr ""
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:179
+#: static/js/impala/stats/csv_keys.js:179 static/js/zamboni/stats-all.js:15460 static/js/zamboni/stats-min.js:5
 msgid "Add-on Status from {0} to {1}"
 msgstr ""
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:183
+#: static/js/impala/stats/csv_keys.js:183 static/js/zamboni/stats-all.js:15464 static/js/zamboni/stats-min.js:5
 msgid "Download Sources, last {0} days"
 msgstr ""
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:185
+#: static/js/impala/stats/csv_keys.js:185 static/js/zamboni/stats-all.js:15466 static/js/zamboni/stats-min.js:5
 msgid "Download Sources from {0} to {1}"
 msgstr ""
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:189
+#: static/js/impala/stats/csv_keys.js:189 static/js/zamboni/stats-all.js:15470 static/js/zamboni/stats-min.js:5
 msgid "Contributions, last {0} days"
 msgstr ""
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:191
+#: static/js/impala/stats/csv_keys.js:191 static/js/zamboni/stats-all.js:15472 static/js/zamboni/stats-min.js:5
 msgid "Contributions from {0} to {1}"
 msgstr ""
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:195
+#: static/js/impala/stats/csv_keys.js:195 static/js/zamboni/stats-all.js:15476 static/js/zamboni/stats-min.js:5
 msgid "Site Metrics, last {0} days"
 msgstr ""
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:197
+#: static/js/impala/stats/csv_keys.js:197 static/js/zamboni/stats-all.js:15478 static/js/zamboni/stats-min.js:5
 msgid "Site Metrics from {0} to {1}"
 msgstr ""
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:201
+#: static/js/impala/stats/csv_keys.js:201 static/js/zamboni/stats-all.js:15482 static/js/zamboni/stats-min.js:5
 msgid "Add-ons in Use, last {0} days"
 msgstr ""
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:203
+#: static/js/impala/stats/csv_keys.js:203 static/js/zamboni/stats-all.js:15484 static/js/zamboni/stats-min.js:5
 msgid "Add-ons in Use from {0} to {1}"
 msgstr ""
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:207
+#: static/js/impala/stats/csv_keys.js:207 static/js/zamboni/stats-all.js:15488 static/js/zamboni/stats-min.js:5
 msgid "Add-ons Downloaded, last {0} days"
 msgstr ""
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:209
+#: static/js/impala/stats/csv_keys.js:209 static/js/zamboni/stats-all.js:15490 static/js/zamboni/stats-min.js:5
 msgid "Add-ons Downloaded from {0} to {1}"
 msgstr ""
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:213
+#: static/js/impala/stats/csv_keys.js:213 static/js/zamboni/stats-all.js:15494 static/js/zamboni/stats-min.js:5
 msgid "Add-ons Created, last {0} days"
 msgstr ""
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:215
+#: static/js/impala/stats/csv_keys.js:215 static/js/zamboni/stats-all.js:15496 static/js/zamboni/stats-min.js:5
 msgid "Add-ons Created from {0} to {1}"
 msgstr ""
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:219
+#: static/js/impala/stats/csv_keys.js:219 static/js/zamboni/stats-all.js:15500 static/js/zamboni/stats-min.js:5
 msgid "Add-ons Updated, last {0} days"
 msgstr ""
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:221
+#: static/js/impala/stats/csv_keys.js:221 static/js/zamboni/stats-all.js:15502 static/js/zamboni/stats-min.js:5
 msgid "Add-ons Updated from {0} to {1}"
 msgstr ""
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:225
+#: static/js/impala/stats/csv_keys.js:225 static/js/zamboni/stats-all.js:15506 static/js/zamboni/stats-min.js:5
 msgid "Reviews Written, last {0} days"
 msgstr ""
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:227
+#: static/js/impala/stats/csv_keys.js:227 static/js/zamboni/stats-all.js:15508 static/js/zamboni/stats-min.js:5
 msgid "Reviews Written from {0} to {1}"
 msgstr ""
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:231
+#: static/js/impala/stats/csv_keys.js:231 static/js/zamboni/stats-all.js:15512 static/js/zamboni/stats-min.js:5
 msgid "User Signups, last {0} days"
 msgstr ""
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:233
+#: static/js/impala/stats/csv_keys.js:233 static/js/zamboni/stats-all.js:15514 static/js/zamboni/stats-min.js:5
 msgid "User Signups from {0} to {1}"
 msgstr ""
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:237
+#: static/js/impala/stats/csv_keys.js:237 static/js/zamboni/stats-all.js:15518 static/js/zamboni/stats-min.js:5
 msgid "Collections Created, last {0} days"
 msgstr ""
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:239
+#: static/js/impala/stats/csv_keys.js:239 static/js/zamboni/stats-all.js:15520 static/js/zamboni/stats-min.js:5
 msgid "Collections Created from {0} to {1}"
 msgstr ""
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:243
+#: static/js/impala/stats/csv_keys.js:243 static/js/zamboni/stats-all.js:15524 static/js/zamboni/stats-min.js:5
 msgid "Subscribers, last {0} days"
 msgstr ""
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:245
+#: static/js/impala/stats/csv_keys.js:245 static/js/zamboni/stats-all.js:15526 static/js/zamboni/stats-min.js:5
 msgid "Subscribers from {0} to {1}"
 msgstr ""
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:249
+#: static/js/impala/stats/csv_keys.js:249 static/js/zamboni/stats-all.js:15530 static/js/zamboni/stats-min.js:5
 msgid "Ratings, last {0} days"
 msgstr ""
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:251
+#: static/js/impala/stats/csv_keys.js:251 static/js/zamboni/stats-all.js:15532 static/js/zamboni/stats-min.js:5
 msgid "Ratings from {0} to {1}"
 msgstr ""
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:255
+#: static/js/impala/stats/csv_keys.js:255 static/js/zamboni/stats-all.js:15536 static/js/zamboni/stats-min.js:5
 msgid "Sales, last {0} days"
 msgstr ""
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:257
+#: static/js/impala/stats/csv_keys.js:257 static/js/zamboni/stats-all.js:15538 static/js/zamboni/stats-min.js:5
 msgid "Sales from {0} to {1}"
 msgstr ""
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:261
+#: static/js/impala/stats/csv_keys.js:261 static/js/zamboni/stats-all.js:15542 static/js/zamboni/stats-min.js:5
 msgid "Installs, last {0} days"
 msgstr ""
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:263
+#: static/js/impala/stats/csv_keys.js:263 static/js/zamboni/stats-all.js:15544 static/js/zamboni/stats-min.js:5
 msgid "Installs from {0} to {1}"
 msgstr ""
 
 #. L10n: {0} and {1} are integers.
-#: static/js/impala/stats/csv_keys.js:269
+#: static/js/impala/stats/csv_keys.js:269 static/js/zamboni/stats-all.js:15550 static/js/zamboni/stats-min.js:5
 msgid "<b>{0}</b> in last {1} days"
 msgstr ""
 
 #. L10n: {0} is an integer and {1} and {2} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:271 static/js/impala/stats/csv_keys.js:277
+#: static/js/impala/stats/csv_keys.js:271 static/js/impala/stats/csv_keys.js:277 static/js/zamboni/stats-all.js:15552 static/js/zamboni/stats-all.js:15558 static/js/zamboni/stats-min.js:5
 msgid "<b>{0}</b> from {1} to {2}"
 msgstr ""
 
 #. L10n: {0} and {1} are integers.
-#: static/js/impala/stats/csv_keys.js:275
+#: static/js/impala/stats/csv_keys.js:275 static/js/zamboni/stats-all.js:15556 static/js/zamboni/stats-min.js:5
 msgid "<b>{0}</b> average in last {1} days"
 msgstr ""
 
-#: static/js/impala/stats/overview.js:19
+#: static/js/impala/stats/overview.js:19 static/js/zamboni/stats-all.js:16469 static/js/zamboni/stats-min.js:5
 msgid "No data available."
 msgstr ""
 
-#: static/js/impala/stats/table.js:74
+#: static/js/impala/stats/table.js:74 static/js/zamboni/stats-all.js:17209 static/js/zamboni/stats-min.js:5
 msgid "Date"
 msgstr ""
 
-#: static/js/impala/stats/topchart.js:96
+#: static/js/impala/stats/topchart.js:96 static/js/zamboni/stats-all.js:16600 static/js/zamboni/stats-min.js:5
 msgid "Other"
 msgstr ""
 
-#: static/js/zamboni/admin_validation.js:24 static/js/zamboni/devhub.js:1229 static/js/zamboni/editors.js:295
+#: static/js/zamboni/admin-all.js:180 static/js/zamboni/admin-min.js:1 static/js/zamboni/admin_validation.js:24 static/js/zamboni/devhub-all.js:2408 static/js/zamboni/devhub-min.js:2
+#: static/js/zamboni/devhub.js:1229 static/js/zamboni/editors-all.js:15576 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:295
 msgid "Select an application first"
 msgstr ""
 
-#: static/js/zamboni/admin_validation.js:51
+#: static/js/zamboni/admin-all.js:207 static/js/zamboni/admin-min.js:1 static/js/zamboni/admin_validation.js:51
 msgid "Set {0} add-on to a max version of {1} and email the author."
 msgid_plural "Set {0} add-ons to a max version of {1} and email the authors."
 msgstr[0] ""
 msgstr[1] ""
-msgstr[2] ""
-msgstr[3] ""
 
-#: static/js/zamboni/admin_validation.js:54
+#: static/js/zamboni/admin-all.js:210 static/js/zamboni/admin-min.js:1 static/js/zamboni/admin_validation.js:54
 msgid "Email author of {2} add-on which failed validation."
 msgid_plural "Email authors of {2} add-ons which failed validation."
 msgstr[0] ""
 msgstr[1] ""
-msgstr[2] ""
-msgstr[3] ""
 
-#. L10n: {0} is an app name like Firefox.
-#: static/js/zamboni/buttons.js:66
-msgid "Accept and Install"
-msgstr ""
-
-#: static/js/zamboni/buttons.js:66
-msgid "Add to {0}"
-msgstr ""
-
-#: static/js/zamboni/buttons.js:71
-msgid "Download Now"
-msgstr ""
-
-#: static/js/zamboni/buttons.js:112
-msgid "Add-on has not been updated to support default-to-compatible."
-msgstr ""
-
-#: static/js/zamboni/buttons.js:117
-msgid "You need to be using Firefox 10.0 or higher."
-msgstr ""
-
-#: static/js/zamboni/buttons.js:129
-msgid "Mozilla has marked this version as incompatible with your Firefox version."
-msgstr ""
-
-#. L10n: {0} is an platform like Windows or Linux.
-#: static/js/zamboni/buttons.js:210
-msgid "Install for {0} anyway"
-msgstr ""
-
-#: static/js/zamboni/buttons.js:210
-msgid "Download for {0} anyway"
-msgstr ""
-
-#: static/js/zamboni/buttons.js:267
-msgid "Not available for your platform"
-msgstr ""
-
-#. L10n: {0} is an app name, {1} is the app version.
-#: static/js/zamboni/buttons.js:278 static/js/zamboni/buttons.js:315
-msgid "Not available for {0} {1}"
-msgstr ""
-
-#: static/js/zamboni/buttons.js:341
-msgid "Works with {app} {min} - {max}"
-msgstr ""
-
-#: static/js/zamboni/buttons.js:343
-msgid "View other versions"
-msgstr ""
-
-#: static/js/zamboni/buttons.js:391
-msgid "Only with Firefox — Get Firefox Now!"
-msgstr ""
-
-#: static/js/zamboni/buttons.js:507 static/js/zamboni/mobile/buttons.js:43
-msgid "Sorry, you need a Mozilla-based browser (such as Firefox) to install a search plugin."
-msgstr ""
-
-#: static/js/zamboni/collections.js:229
-msgid "Adding to Favorites&hellip;"
-msgstr ""
-
-#: static/js/zamboni/collections.js:232
-msgid "Removing Favorite&hellip;"
-msgstr ""
-
-#: static/js/zamboni/collections.js:235
-msgid "Add to Favorites"
-msgstr ""
-
-#: static/js/zamboni/collections.js:238
-msgid "Remove from Favorites"
-msgstr ""
-
-#: static/js/zamboni/collections.js:303
-msgid "Pending"
-msgstr ""
-
-#: static/js/zamboni/collections.js:304
-msgid "Add a comment"
-msgstr ""
-
-#: static/js/zamboni/collections.js:304
-msgid "Comment"
-msgstr ""
-
-#: static/js/zamboni/collections.js:305
-msgid "Remove this add-on from the collection"
-msgstr ""
-
-#: static/js/zamboni/collections.js:305 static/js/zamboni/collections.js:334
-msgid "Remove"
-msgstr ""
-
-#: static/js/zamboni/collections.js:334
-msgid "Remove this user as a contributor"
-msgstr ""
-
-#: static/js/zamboni/collections.js:346
-msgid "An email address is required."
-msgstr ""
-
-#: static/js/zamboni/collections.js:364
-msgid "You cannot add yourself as a contributor."
-msgstr ""
-
-#: static/js/zamboni/collections.js:366
-msgid "You have already added that user."
-msgstr ""
-
-#: static/js/zamboni/collections.js:573
-msgid "Add to favorites"
-msgstr ""
-
-#: static/js/zamboni/collections.js:577
-msgid "Remove from favorites"
-msgstr ""
-
-#: static/js/zamboni/collections.js:604
-msgid "Stop following"
-msgstr ""
-
-#: static/js/zamboni/devhub.js:110
+#: static/js/zamboni/devhub-all.js:1289 static/js/zamboni/devhub-min.js:1 static/js/zamboni/devhub.js:110
 msgid "Your browser does not support the video tag"
 msgstr ""
 
-#: static/js/zamboni/devhub.js:371
+#: static/js/zamboni/devhub-all.js:1550 static/js/zamboni/devhub-min.js:1 static/js/zamboni/devhub.js:371
 msgid "Changes Saved"
 msgstr ""
 
-#: static/js/zamboni/devhub.js:387
+#: static/js/zamboni/devhub-all.js:1566 static/js/zamboni/devhub-min.js:1 static/js/zamboni/devhub.js:387
 msgid "Enter a new author's email address"
 msgstr ""
 
-#: static/js/zamboni/devhub.js:536
+#: static/js/zamboni/devhub-all.js:1715 static/js/zamboni/devhub-min.js:1 static/js/zamboni/devhub.js:536
 msgid "There was an error uploading your file."
 msgstr ""
 
-#: static/js/zamboni/devhub.js:681
+#: static/js/zamboni/devhub-all.js:1860 static/js/zamboni/devhub-min.js:1 static/js/zamboni/devhub.js:681
 msgid "{files} file"
 msgid_plural "{files} files"
 msgstr[0] ""
 msgstr[1] ""
-msgstr[2] ""
-msgstr[3] ""
 
-#: static/js/zamboni/devhub.js:684
+#: static/js/zamboni/devhub-all.js:1863 static/js/zamboni/devhub-min.js:1 static/js/zamboni/devhub.js:684
 msgid "{reviews} user review"
 msgid_plural "{reviews} user reviews"
 msgstr[0] ""
 msgstr[1] ""
-msgstr[2] ""
-msgstr[3] ""
 
-#: static/js/zamboni/devhub.js:796
+#: static/js/zamboni/devhub-all.js:1975 static/js/zamboni/devhub-min.js:2 static/js/zamboni/devhub.js:796
 msgid "Learn more"
 msgstr ""
 
-#: static/js/zamboni/devhub.js:800
+#: static/js/zamboni/devhub-all.js:1979 static/js/zamboni/devhub-min.js:2 static/js/zamboni/devhub.js:800
 msgid "Example"
 msgstr ""
 
-#: static/js/zamboni/devhub.js:1130
+#: static/js/zamboni/devhub-all.js:2309 static/js/zamboni/devhub-min.js:2 static/js/zamboni/devhub.js:1130
 msgid "Image changes being processed"
 msgstr ""
 
-#: static/js/zamboni/devhub.js:1280
+#: static/js/zamboni/devhub-all.js:2459 static/js/zamboni/devhub-min.js:2 static/js/zamboni/devhub.js:1280
 msgid "Must be a valid e-mail address."
+msgstr ""
+
+#: static/js/zamboni/devhub-all.js:2613 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:80
+msgid "All tests passed successfully."
+msgstr ""
+
+#: static/js/zamboni/devhub-all.js:2616 static/js/zamboni/devhub-all.js:3011 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:83 static/js/zamboni/validator.js:478
+msgid "These tests were not run."
+msgstr ""
+
+#: static/js/zamboni/devhub-all.js:2664 static/js/zamboni/devhub-all.js:2677 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:131 static/js/zamboni/validator.js:144
+msgid "Tests"
+msgstr ""
+
+#: static/js/zamboni/devhub-all.js:2779 static/js/zamboni/devhub-all.js:3108 static/js/zamboni/devhub-all.js:3127 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:246
+#: static/js/zamboni/validator.js:575 static/js/zamboni/validator.js:594
+msgid "Error"
+msgstr ""
+
+#: static/js/zamboni/devhub-all.js:2780 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:247
+msgid "Warning"
+msgstr ""
+
+#: static/js/zamboni/devhub-all.js:2794 static/js/zamboni/devhub-min.js:2 static/js/zamboni/files-all.js:5657 static/js/zamboni/files-min.js:3 static/js/zamboni/files.js:411
+#: static/js/zamboni/validator.js:261
+msgid "Ignore this message in future updates"
+msgstr ""
+
+#: static/js/zamboni/devhub-all.js:2817 static/js/zamboni/devhub-min.js:2 static/js/zamboni/files-all.js:5663 static/js/zamboni/files-min.js:3 static/js/zamboni/files.js:417
+#: static/js/zamboni/validator.js:284
+msgid "Severity for automated signing:"
+msgstr ""
+
+#: static/js/zamboni/devhub-all.js:2832 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:299
+msgid "Suggestions for passing automated signing:"
+msgstr ""
+
+#: static/js/zamboni/devhub-all.js:2920 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:387
+msgid "Compatibility Tests"
+msgstr ""
+
+#: static/js/zamboni/devhub-all.js:2999 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:466
+msgid "Add-on failed validation."
+msgstr ""
+
+#: static/js/zamboni/devhub-all.js:3001 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:468
+msgid "Add-on passed validation."
+msgstr ""
+
+#: static/js/zamboni/devhub-all.js:3014 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:481
+msgid "{0} error"
+msgid_plural "{0} errors"
+msgstr[0] ""
+msgstr[1] ""
+
+#: static/js/zamboni/devhub-all.js:3016 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:483
+msgid "{0} warning"
+msgid_plural "{0} warnings"
+msgstr[0] ""
+msgstr[1] ""
+
+#: static/js/zamboni/devhub-all.js:3018 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:485
+msgid "{0} notice"
+msgid_plural "{0} notices"
+msgstr[0] ""
+msgstr[1] ""
+
+#: static/js/zamboni/devhub-all.js:3110 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:577
+msgid "Validation task could not complete or completed with errors"
+msgstr ""
+
+#: static/js/zamboni/devhub-all.js:3128 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:595
+msgid "Internal server error"
 msgstr ""
 
 #: static/js/zamboni/devhub_search.js:8
 msgid "No results found."
 msgstr ""
 
-#: static/js/zamboni/editors.js:121
+#: static/js/zamboni/editors-all.js:15402 static/js/zamboni/editors-min.js:4 static/js/zamboni/editors.js:121
 msgid "{name} was viewing this page first."
 msgstr ""
 
-#: static/js/zamboni/editors.js:171
+#: static/js/zamboni/editors-all.js:15452 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:171
 msgid "Receipt checked by app."
 msgstr ""
 
-#: static/js/zamboni/editors.js:173
+#: static/js/zamboni/editors-all.js:15454 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:173
 msgid "Receipt was not checked by app."
 msgstr ""
 
-#: static/js/zamboni/editors.js:244
+#: static/js/zamboni/editors-all.js:15525 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:244
 msgid "{name} was viewing this add-on first."
 msgstr ""
 
-#: static/js/zamboni/editors.js:255
+#: static/js/zamboni/editors-all.js:15536 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:255
 msgid "Loading&hellip;"
 msgstr ""
 
-#: static/js/zamboni/editors.js:260
+#: static/js/zamboni/editors-all.js:15541 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:260
 msgid "Version Notes"
 msgstr ""
 
-#: static/js/zamboni/editors.js:265
+#: static/js/zamboni/editors-all.js:15546 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:265
 msgid "Notes for Reviewers"
 msgstr ""
 
-#: static/js/zamboni/editors.js:270
+#: static/js/zamboni/editors-all.js:15551 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:270
 msgid "No version notes found"
 msgstr ""
 
-#: static/js/zamboni/editors.js:330
+#: static/js/zamboni/editors-all.js:15611 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:330
 msgid "Average Reviews"
 msgstr ""
 
-#: static/js/zamboni/editors.js:386
+#: static/js/zamboni/editors-all.js:15667 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:386
 msgid "Number of Reviews"
 msgstr ""
 
-#: static/js/zamboni/editors.js:445
+#: static/js/zamboni/editors-all.js:15726 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:445
 msgid "Error loading translation"
 msgstr ""
 
-#: static/js/zamboni/files.js:411 static/js/zamboni/validator.js:261
-msgid "Ignore this message in future updates"
-msgstr ""
-
-#: static/js/zamboni/files.js:417 static/js/zamboni/validator.js:284
-msgid "Severity for automated signing:"
-msgstr ""
-
-#: static/js/zamboni/global.js:410
-msgid "Loading..."
-msgstr ""
-
-#. L10n: {0} is the number of characters left.
-#: static/js/zamboni/global.js:474
-msgid "<b>{0}</b> character left."
-msgid_plural "<b>{0}</b> characters left."
-msgstr[0] ""
-msgstr[1] ""
-msgstr[2] ""
-msgstr[3] ""
-
-#: static/js/zamboni/init.js:28
-msgid "This feature is temporarily disabled while we perform website maintenance. Please check back a little later."
-msgstr ""
-
-#: static/js/zamboni/l10n.js:45
-msgid "Remove this localization"
-msgstr ""
-
-#: static/js/zamboni/password-strength.js:20
-msgid "Password strength:"
-msgstr ""
-
-#: static/js/zamboni/password-strength.js:26
-msgid "At least {0} character left."
-msgid_plural "At least {0} characters left."
-msgstr[0] ""
-msgstr[1] ""
-msgstr[2] ""
-msgstr[3] ""
-
-#: static/js/zamboni/themes_review.js:176
-msgid "Requested Info"
-msgstr ""
-
-#: static/js/zamboni/themes_review.js:177
-msgid "Flagged"
-msgstr ""
-
-#: static/js/zamboni/themes_review.js:178
-msgid "Duplicate"
-msgstr ""
-
-#: static/js/zamboni/themes_review.js:179
-msgid "Rejected"
-msgstr ""
-
-#: static/js/zamboni/themes_review.js:180
-msgid "Approved"
-msgstr ""
-
-#: static/js/zamboni/themes_review.js:424
-msgid "No results found"
-msgstr ""
-
-#: static/js/zamboni/themes_review_templates.js:31
+#: static/js/zamboni/editors-all.js:15975 static/js/zamboni/editors-min.js:5 static/js/zamboni/themes_review_templates.js:31
 msgid "Theme"
 msgstr ""
 
-#: static/js/zamboni/themes_review_templates.js:33
+#: static/js/zamboni/editors-all.js:15977 static/js/zamboni/editors-min.js:5 static/js/zamboni/themes_review_templates.js:33
 msgid "Reviewer"
 msgstr ""
 
-#: static/js/zamboni/themes_review_templates.js:35
+#: static/js/zamboni/editors-all.js:15979 static/js/zamboni/editors-min.js:5 static/js/zamboni/themes_review_templates.js:35
 msgid "Status"
 msgstr ""
 
-#: static/js/zamboni/validator.js:80
-msgid "All tests passed successfully."
+#: static/js/zamboni/editors-all.js:16196 static/js/zamboni/editors-min.js:5 static/js/zamboni/themes_review.js:176
+msgid "Requested Info"
 msgstr ""
 
-#: static/js/zamboni/validator.js:83 static/js/zamboni/validator.js:478
-msgid "These tests were not run."
+#: static/js/zamboni/editors-all.js:16197 static/js/zamboni/editors-min.js:5 static/js/zamboni/themes_review.js:177
+msgid "Flagged"
 msgstr ""
 
-#: static/js/zamboni/validator.js:131 static/js/zamboni/validator.js:144
-msgid "Tests"
+#: static/js/zamboni/editors-all.js:16198 static/js/zamboni/editors-min.js:5 static/js/zamboni/themes_review.js:178
+msgid "Duplicate"
 msgstr ""
 
-#: static/js/zamboni/validator.js:246 static/js/zamboni/validator.js:575 static/js/zamboni/validator.js:594
-msgid "Error"
+#: static/js/zamboni/editors-all.js:16199 static/js/zamboni/editors-min.js:5 static/js/zamboni/themes_review.js:179
+msgid "Rejected"
 msgstr ""
 
-#: static/js/zamboni/validator.js:247
-msgid "Warning"
+#: static/js/zamboni/editors-all.js:16200 static/js/zamboni/editors-min.js:5 static/js/zamboni/themes_review.js:180
+msgid "Approved"
 msgstr ""
 
-#: static/js/zamboni/validator.js:299
-msgid "Suggestions for passing automated signing:"
+#: static/js/zamboni/editors-all.js:16444 static/js/zamboni/editors-min.js:5 static/js/zamboni/themes_review.js:424
+msgid "No results found"
 msgstr ""
 
-#: static/js/zamboni/validator.js:387
-msgid "Compatibility Tests"
-msgstr ""
-
-#: static/js/zamboni/validator.js:466
-msgid "Add-on failed validation."
-msgstr ""
-
-#: static/js/zamboni/validator.js:468
-msgid "Add-on passed validation."
-msgstr ""
-
-#: static/js/zamboni/validator.js:481
-msgid "{0} error"
-msgid_plural "{0} errors"
-msgstr[0] ""
-msgstr[1] ""
-msgstr[2] ""
-msgstr[3] ""
-
-#: static/js/zamboni/validator.js:483
-msgid "{0} warning"
-msgid_plural "{0} warnings"
-msgstr[0] ""
-msgstr[1] ""
-msgstr[2] ""
-msgstr[3] ""
-
-#: static/js/zamboni/validator.js:485
-msgid "{0} notice"
-msgid_plural "{0} notices"
-msgstr[0] ""
-msgstr[1] ""
-msgstr[2] ""
-msgstr[3] ""
-
-#: static/js/zamboni/validator.js:577
-msgid "Validation task could not complete or completed with errors"
-msgstr ""
-
-#: static/js/zamboni/validator.js:595
-msgid "Internal server error"
-msgstr ""
-
-#: static/js/zamboni/mobile/buttons.js:52
+#: static/js/zamboni/mobile-all.js:15186 static/js/zamboni/mobile/buttons.js:52
 msgid "Not Updated for {0} {1}"
 msgstr ""
 
-#: static/js/zamboni/mobile/buttons.js:53
+#: static/js/zamboni/mobile-all.js:15187 static/js/zamboni/mobile/buttons.js:53
 msgid "Requires Newer Version of {0}"
 msgstr ""
 
-#: static/js/zamboni/mobile/buttons.js:54
+#: static/js/zamboni/mobile-all.js:15188 static/js/zamboni/mobile/buttons.js:54
 msgid "Unreviewed"
 msgstr ""
 
-#: static/js/zamboni/mobile/buttons.js:55
+#: static/js/zamboni/mobile-all.js:15189 static/js/zamboni/mobile/buttons.js:55
 msgid "Experimental <span>(Learn More)</span>"
 msgstr ""
 
-#: static/js/zamboni/mobile/buttons.js:56 static/js/zamboni/mobile/buttons.js:57
+#: static/js/zamboni/mobile-all.js:15190 static/js/zamboni/mobile-all.js:15191 static/js/zamboni/mobile/buttons.js:56 static/js/zamboni/mobile/buttons.js:57
 msgid "Not Available for {0}"
 msgstr ""
 
-#: static/js/zamboni/mobile/buttons.js:58
+#: static/js/zamboni/mobile-all.js:15192 static/js/zamboni/mobile/buttons.js:58
 msgid "Experimental"
 msgstr ""
 
-#: static/js/zamboni/mobile/buttons.js:59
+#: static/js/zamboni/mobile-all.js:15193 static/js/zamboni/mobile/buttons.js:59
 msgid "Themes Require Newer Version of {0}"
 msgstr ""
 
-#: static/js/zamboni/mobile/buttons.js:60
+#: static/js/zamboni/mobile-all.js:15194 static/js/zamboni/mobile/buttons.js:60
 msgid "Themes Require {0}"
 msgstr ""
 
-#: static/js/zamboni/mobile/buttons.js:105
+#: static/js/zamboni/mobile-all.js:15239 static/js/zamboni/mobile/buttons.js:105
 msgid "Installing..."
 msgstr ""
 
-#: static/js/zamboni/mobile/buttons.js:125
+#: static/js/zamboni/mobile-all.js:15259 static/js/zamboni/mobile/buttons.js:125
 msgid "This add-on has been preliminarily reviewed by Mozilla."
 msgstr ""
 
-#: static/js/zamboni/mobile/buttons.js:250
+#: static/js/zamboni/mobile-all.js:15384 static/js/zamboni/mobile/buttons.js:250
 msgid "Keep it"
 msgstr ""
 
-#: static/js/zamboni/mobile/general.js:344
+#: static/js/zamboni/mobile-all.js:16049 static/js/zamboni/mobile-min.js:6 static/js/zamboni/mobile/general.js:344
 msgid "You're trying it on!"
 msgstr ""
 
-#: static/js/zamboni/mobile/general.js:356
+#: static/js/zamboni/mobile-all.js:16061 static/js/zamboni/mobile-min.js:6 static/js/zamboni/mobile/general.js:356
 msgid "Added to Firefox"
 msgstr ""
-

--- a/locale/da/LC_MESSAGES/django.po
+++ b/locale/da/LC_MESSAGES/django.po
@@ -6,69 +6,70 @@ msgid ""
 msgstr ""
 "Project-Id-Version:  addons\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2016-02-24 21:23+0000\n"
+"POT-Creation-Date: 2016-04-18 15:47+0000\n"
 "PO-Revision-Date: 2016-03-20 22:11+0000\n"
 "Last-Translator: joergenr <joergenr@stofanet.dk>\n"
 "Language-Team: MozillaDanmark\n"
+"Language: \n"
 "MIME-Version: 1.0\n"
-"Content-Type: text/plain; charset=utf-8\n"
+"Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Generated-By: Babel 2.2.0\n"
 
-#: src/olympia/accounts/views.py:52
+#: src/olympia/accounts/views.py:54
 msgid "Your log in attempt could not be parsed. Please try again."
 msgstr "Dit forsøg på at logge ind kunne ikke fortolkes. Prøv igen."
 
-#: src/olympia/accounts/views.py:54
+#: src/olympia/accounts/views.py:56
 msgid "Your Firefox Account could not be found. Please try again."
 msgstr "Din Firefox-konto kunne ikke findes. Prøv igen."
 
-#: src/olympia/accounts/views.py:55
+#: src/olympia/accounts/views.py:57
 msgid "You could not be logged in. Please try again."
 msgstr "Du kunne ikke logges ind. Prøv igen."
 
-#: src/olympia/accounts/views.py:57
+#: src/olympia/accounts/views.py:59
 msgid "Your account has already been migrated to Firefox Accounts."
 msgstr "Din konto er allerede blevet overflyttet til Firefox-konti."
 
-#: src/olympia/accounts/views.py:59
+#: src/olympia/accounts/views.py:61
 msgid "Your Firefox Account already exists on this site."
 msgstr "Din Firefox-konto findes allerede på dette websted."
 
-#: src/olympia/accounts/views.py:108
+#: src/olympia/accounts/views.py:110
 msgid "Great job!"
 msgstr "Godt klaret!"
 
-#: src/olympia/accounts/views.py:109
+#: src/olympia/accounts/views.py:111
 msgid "You can now log in to Add-ons with your Firefox Account."
 msgstr "Nu kan du logge ind på Mozilla-tilføjelser med din Firefox-konto."
 
-#: src/olympia/accounts/views.py:121
+#: src/olympia/accounts/views.py:123
 msgid "Need help?"
 msgstr "Har du brug for hjælp?"
 
-#: src/olympia/addons/buttons.py:180
+#: src/olympia/addons/buttons.py:177
 msgid "Download Now"
 msgstr "Download nu"
 
-#: src/olympia/addons/buttons.py:182
+#: src/olympia/addons/buttons.py:179
 msgid "Download"
 msgstr "Download"
 
 #. L10n: please keep &nbsp; in the string so &rarr; does not wrap.
-#: src/olympia/addons/buttons.py:186
+#: src/olympia/addons/buttons.py:183
 msgid "Continue to Download&nbsp;&rarr;"
 msgstr "Fortsæt med at downloade&nbsp;&rarr;"
 
-#: src/olympia/addons/buttons.py:202 src/olympia/addons/helpers.py:35 src/olympia/addons/views.py:319 src/olympia/addons/templates/addons/impala/details.html:114
+#: src/olympia/addons/buttons.py:199 src/olympia/addons/helpers.py:35 src/olympia/addons/views.py:333 src/olympia/addons/templates/addons/impala/details.html:111
 #: src/olympia/addons/templates/addons/impala/listing/items.html:17 src/olympia/addons/templates/addons/mobile/home.html:40 src/olympia/amo/templates/amo/side_nav.html:6
-#: src/olympia/amo/templates/amo/side_nav.html:10 src/olympia/amo/templates/amo/site_nav.html:2 src/olympia/amo/templates/amo/site_nav.html:55 src/olympia/bandwagon/views.py:95
-#: src/olympia/browse/views.py:54 src/olympia/browse/views.py:68 src/olympia/browse/views.py:235 src/olympia/browse/templates/browse/impala/category_landing.html:22
+#: src/olympia/amo/templates/amo/side_nav.html:10 src/olympia/amo/templates/amo/site_nav.html:2 src/olympia/amo/templates/amo/site_nav.html:53 src/olympia/bandwagon/views.py:95
+#: src/olympia/browse/views.py:54 src/olympia/browse/views.py:68 src/olympia/browse/views.py:202 src/olympia/browse/templates/browse/impala/category_landing.html:22
 #: src/olympia/browse/templates/browse/personas/mobile/category_landing.html:26
 msgid "Featured"
 msgstr "Udvalgte"
 
-#: src/olympia/addons/buttons.py:221
+#: src/olympia/addons/buttons.py:218
 msgid "Add to {0}"
 msgstr "Føj til {0}"
 
@@ -116,39 +117,39 @@ msgid_plural "All tags must be at least {0} characters."
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/olympia/addons/forms.py:234
+#: src/olympia/addons/forms.py:238
 msgid "Categories cannot be changed while your add-on is featured for this application."
 msgstr ""
 
 #. L10n: {0} is the number of categories.
-#: src/olympia/addons/forms.py:238
+#: src/olympia/addons/forms.py:242
 msgid "You can have only {0} category."
 msgid_plural "You can have only {0} categories."
 msgstr[0] "Du kan kun have {0} kategori."
 msgstr[1] "Du kan kun have {0} kategorier."
 
-#: src/olympia/addons/forms.py:246
+#: src/olympia/addons/forms.py:250
 msgid "The miscellaneous category cannot be combined with additional categories."
 msgstr ""
 
-#: src/olympia/addons/forms.py:369
+#: src/olympia/addons/forms.py:374
 #, python-format
 msgid "Before changing your default locale you must have a name, summary, and description in that locale. You are missing %s."
 msgstr ""
 
-#: src/olympia/addons/forms.py:484 src/olympia/addons/forms.py:575
+#: src/olympia/addons/forms.py:455 src/olympia/addons/forms.py:546
 msgid "A license must be selected."
 msgstr ""
 
-#: src/olympia/addons/forms.py:556
+#: src/olympia/addons/forms.py:527
 msgid "Give Your Theme a Name."
 msgstr ""
 
-#: src/olympia/addons/forms.py:562 src/olympia/devhub/templates/devhub/personas/submit.html:53
+#: src/olympia/addons/forms.py:533 src/olympia/devhub/templates/devhub/personas/submit.html:53
 msgid "Describe your Theme."
 msgstr ""
 
-#: src/olympia/addons/forms.py:704
+#: src/olympia/addons/forms.py:675
 msgid "Enter a new author's email address"
 msgstr ""
 
@@ -156,39 +157,39 @@ msgstr ""
 msgid "Not Reviewed"
 msgstr "Ikke anmeldt"
 
-#: src/olympia/addons/models.py:301
+#: src/olympia/addons/models.py:298
 msgid "Users have the option of contributing more or less than this amount."
 msgstr "Brugere har mulighed for, at bidrage med beløb større eller mindre end dette."
 
-#: src/olympia/addons/models.py:309
-msgid "Users will always be asked in the Add-ons Manager (Firefox 4 and above)"
-msgstr "Brugere vil altid blive spurgt i fanebladet Tilføjelser (Firefox 4 og nyere)"
+#: src/olympia/addons/models.py:306
+msgid "Users will always be asked in the Add-ons Manager (Firefox 4 and above). Only applies to desktop."
+msgstr ""
 
 # Column name in a table.
-#: src/olympia/addons/models.py:1804 src/olympia/addons/templates/addons/details_box.html:55 src/olympia/devhub/templates/devhub/index.html:92
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:102
+#: src/olympia/addons/models.py:1802 src/olympia/addons/templates/addons/details_box.html:55 src/olympia/devhub/templates/devhub/index.html:92
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:89
 msgid "Listed"
 msgstr "Listet"
 
-#: src/olympia/addons/views.py:320 src/olympia/browse/templates/browse/personas/mobile/category_landing.html:27
+#: src/olympia/addons/views.py:334 src/olympia/browse/templates/browse/personas/mobile/category_landing.html:27
 msgid "Popular"
 msgstr "Populære"
 
-#: src/olympia/addons/views.py:321 src/olympia/browse/views.py:238 src/olympia/browse/views.py:280 src/olympia/browse/views.py:482
+#: src/olympia/addons/views.py:335 src/olympia/browse/views.py:205 src/olympia/browse/views.py:247 src/olympia/browse/views.py:449
 msgid "Recently Added"
 msgstr "Tilføjet for nylig"
 
-#: src/olympia/addons/views.py:322 src/olympia/bandwagon/views.py:99 src/olympia/browse/views.py:60 src/olympia/browse/views.py:71 src/olympia/search/forms.py:16 src/olympia/search/forms.py:91
+#: src/olympia/addons/views.py:336 src/olympia/bandwagon/views.py:99 src/olympia/browse/views.py:60 src/olympia/browse/views.py:71 src/olympia/search/forms.py:16 src/olympia/search/forms.py:91
 msgid "Recently Updated"
 msgstr "Opdateret for nylig"
 
 # %1 is an add-on name.
 #. l10n: {0} is the addon name
-#: src/olympia/addons/views.py:520
+#: src/olympia/addons/views.py:534
 msgid "Contribution for {0}"
 msgstr "Bidrag til {0}"
 
-#: src/olympia/addons/views.py:613
+#: src/olympia/addons/views.py:627
 msgid "Abuse reported."
 msgstr "Misbrug rapporteret."
 
@@ -257,9 +258,9 @@ msgstr "Bidrag"
 #: src/olympia/devhub/templates/devhub/addons/ajax_compat_update.html:36 src/olympia/devhub/templates/devhub/addons/profile.html:44 src/olympia/devhub/templates/devhub/addons/edit/admin.html:101
 #: src/olympia/devhub/templates/devhub/addons/edit/basic.html:152 src/olympia/devhub/templates/devhub/addons/edit/details.html:85 src/olympia/devhub/templates/devhub/addons/edit/support.html:67
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:166 src/olympia/devhub/templates/devhub/addons/forms_shared/media.html:149
-#: src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:44 src/olympia/devhub/templates/devhub/versions/add_file_modal.html:78 src/olympia/devhub/templates/devhub/versions/edit.html:139
-#: src/olympia/devhub/templates/devhub/versions/list.html:242 src/olympia/devhub/templates/devhub/versions/list.html:276 src/olympia/devhub/templates/devhub/versions/list.html:317
-#: src/olympia/devhub/templates/devhub/versions/list.html:351 src/olympia/reviews/templates/reviews/edit_review.html:16 src/olympia/translations/templates/translations/trans-menu.html:50
+#: src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:43 src/olympia/devhub/templates/devhub/versions/add_file_modal.html:58 src/olympia/devhub/templates/devhub/versions/edit.html:139
+#: src/olympia/devhub/templates/devhub/versions/list.html:239 src/olympia/devhub/templates/devhub/versions/list.html:281 src/olympia/devhub/templates/devhub/versions/list.html:315
+#: src/olympia/devhub/templates/devhub/versions/list.html:349 src/olympia/reviews/templates/reviews/edit_review.html:16 src/olympia/translations/templates/translations/trans-menu.html:50
 #: src/olympia/translations/templates/translations/trans-menu.html:62
 msgid "or"
 msgstr "eller"
@@ -329,8 +330,7 @@ msgstr "Beløbet skal være et tal."
 msgid "A one-time suggested contribution of {0}"
 msgstr "Et foreslået engangsbidrag på {0}"
 
-#. {0} is a currency symbol (e.g., $),                    {1} is an amount
-#. input
+#. {0} is a currency symbol (e.g., $),                    {1} is an amount input
 #. field
 #: src/olympia/addons/templates/addons/contributions_lightbox.html:64
 msgid "A one-time contribution of {0} {1}"
@@ -371,7 +371,7 @@ msgid "Add-on Information for {0}"
 msgstr "Tilføjelsesinformation for {0}"
 
 #: src/olympia/addons/templates/addons/details_box.html:30 src/olympia/addons/templates/addons/persona_detail_table.html:3 src/olympia/addons/templates/addons/mobile/details.html:63
-#: src/olympia/addons/templates/addons/mobile/persona_detail_table.html:7 src/olympia/browse/views.py:459 src/olympia/devhub/views.py:75
+#: src/olympia/addons/templates/addons/mobile/persona_detail_table.html:7 src/olympia/browse/views.py:426 src/olympia/devhub/views.py:73
 msgid "Updated"
 msgstr "Opdateret"
 
@@ -390,11 +390,11 @@ msgstr "Virker med"
 msgid "Visibility"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/details_box.html:57 src/olympia/devhub/templates/devhub/index.html:94 src/olympia/devhub/templates/devhub/includes/addon_details.html:104
+#: src/olympia/addons/templates/addons/details_box.html:57 src/olympia/devhub/templates/devhub/index.html:94 src/olympia/devhub/templates/devhub/includes/addon_details.html:91
 msgid "Hidden"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/details_box.html:59 src/olympia/devhub/templates/devhub/index.html:96 src/olympia/devhub/templates/devhub/includes/addon_details.html:106
+#: src/olympia/addons/templates/addons/details_box.html:59 src/olympia/devhub/templates/devhub/index.html:96 src/olympia/devhub/templates/devhub/includes/addon_details.html:93
 msgid "Unlisted"
 msgstr ""
 
@@ -402,13 +402,13 @@ msgstr ""
 msgid "Required Add-ons"
 msgstr "Påkrævede tilføjelser"
 
-#: src/olympia/addons/templates/addons/details_box.html:81 src/olympia/addons/templates/addons/persona_detail_table.html:15 src/olympia/browse/views.py:462 src/olympia/devhub/views.py:78
-#: src/olympia/devhub/views.py:85 src/olympia/discovery/templates/discovery/addons/detail.html:57 src/olympia/reviews/forms.py:62 src/olympia/reviews/templates/reviews/add.html:57
+#: src/olympia/addons/templates/addons/details_box.html:81 src/olympia/addons/templates/addons/persona_detail_table.html:15 src/olympia/browse/views.py:429 src/olympia/devhub/views.py:76
+#: src/olympia/devhub/views.py:83 src/olympia/discovery/templates/discovery/addons/detail.html:57 src/olympia/reviews/forms.py:62 src/olympia/reviews/templates/reviews/add.html:57
 #: src/olympia/reviews/templates/reviews/mobile/review_list.html:18
 msgid "Rating"
 msgstr "Bedømmelse"
 
-#: src/olympia/addons/templates/addons/details_box.html:85 src/olympia/browse/views.py:461 src/olympia/devhub/views.py:77 src/olympia/devhub/views.py:84
+#: src/olympia/addons/templates/addons/details_box.html:85 src/olympia/browse/views.py:428 src/olympia/devhub/views.py:75 src/olympia/devhub/views.py:82
 #: src/olympia/stats/templates/stats/addon_report_menu.html:8 src/olympia/stats/templates/stats/collection_report_menu.html:18
 msgid "Downloads"
 msgstr "Downloads"
@@ -428,7 +428,7 @@ msgstr "Rapporter om misbrug"
 
 #. The Privacy Policy for this add-on.
 #: src/olympia/addons/templates/addons/details_box.html:121 src/olympia/addons/templates/addons/privacy.html:19 src/olympia/addons/templates/addons/privacy.html:23
-#: src/olympia/addons/templates/addons/impala/button.html:43 src/olympia/addons/templates/addons/impala/details.html:307 src/olympia/devhub/templates/devhub/includes/policy_form.html:20
+#: src/olympia/addons/templates/addons/impala/button.html:43 src/olympia/addons/templates/addons/impala/details.html:312 src/olympia/devhub/templates/devhub/includes/policy_form.html:23
 #: src/olympia/templates/mobile/base_addons.html:87
 msgid "Privacy Policy"
 msgstr "Privatlivspolitik"
@@ -453,7 +453,7 @@ msgstr "Billedgalleri"
 msgid "Developer Comments"
 msgstr "Udviklers kommentarer"
 
-#: src/olympia/addons/templates/addons/details_box.html:199 src/olympia/addons/templates/addons/impala/details.html:259
+#: src/olympia/addons/templates/addons/details_box.html:199 src/olympia/addons/templates/addons/impala/details.html:264
 msgid "Development Channel"
 msgstr "Udviklingskanal"
 
@@ -477,13 +477,13 @@ msgstr ""
 "<strong>Pas på:</strong> Udviklingsversioner af denne tilføjelse er ikke blevet godkendt af Mozilla. Når du har installeret en udviklingsversion, vil du fortsætte med at modtage "
 "udviklingsopdateringer fra denne udvikler. For at stoppe modtagelsen af udviklingsopdateringer, skal du geninstallere standardversionen fra linket ovenover."
 
-#: src/olympia/addons/templates/addons/details_box.html:220 src/olympia/addons/templates/addons/impala/details.html:278
+#: src/olympia/addons/templates/addons/details_box.html:220 src/olympia/addons/templates/addons/impala/details.html:283
 msgid "Version {0}:"
 msgstr "Version {0}:"
 
 #: src/olympia/addons/templates/addons/details_box.html:234
 msgid "Nothing to see here!  The developer did not include any details."
-msgstr "Intet at se her! Udvikleren har ikke inkluderet nogle detaljer."
+msgstr ""
 
 #: src/olympia/addons/templates/addons/details_box.html:251 src/olympia/devhub/templates/devhub/versions/edit.html:73 src/olympia/editors/templates/editors/review.html:98
 msgid "Version Notes"
@@ -496,7 +496,7 @@ msgid "End-User License Agreement for {0}"
 msgstr "Licensaftale for slutbrugere for {0}"
 
 #: src/olympia/addons/templates/addons/eula.html:17 src/olympia/addons/templates/addons/eula.html:21 src/olympia/addons/templates/addons/impala/button.html:48
-#: src/olympia/addons/templates/addons/impala/details.html:316 src/olympia/devhub/templates/devhub/includes/policy_form.html:3 src/olympia/discovery/templates/discovery/addons/eula.html:11
+#: src/olympia/addons/templates/addons/impala/details.html:321 src/olympia/devhub/templates/devhub/includes/policy_form.html:3 src/olympia/discovery/templates/discovery/addons/eula.html:11
 msgid "End-User License Agreement"
 msgstr "Licensaftale for slutbrugere"
 
@@ -516,7 +516,7 @@ msgstr "Tilbage til {0}…"
 msgid "Add-ons for {0}"
 msgstr "Tilføjelser til {0}"
 
-#: src/olympia/addons/templates/addons/home.html:10 src/olympia/addons/templates/addons/home.html:51 src/olympia/browse/templates/browse/impala/base_listing.html:11
+#: src/olympia/addons/templates/addons/home.html:10 src/olympia/addons/templates/addons/home.html:53 src/olympia/browse/templates/browse/impala/base_listing.html:11
 msgid "Featured Extensions"
 msgstr "Udvalgte udvidelser"
 
@@ -524,29 +524,29 @@ msgstr "Udvalgte udvidelser"
 msgid "Popular Extensions"
 msgstr "Populære udvidelser"
 
-#: src/olympia/addons/templates/addons/home.html:42 src/olympia/amo/templates/amo/side_nav.html:3 src/olympia/amo/templates/amo/side_nav.html:11 src/olympia/amo/templates/amo/site_nav.html:3
-#: src/olympia/amo/templates/amo/site_nav.html:25 src/olympia/browse/views.py:236 src/olympia/browse/views.py:281 src/olympia/browse/views.py:481
+#: src/olympia/addons/templates/addons/home.html:44 src/olympia/amo/templates/amo/side_nav.html:3 src/olympia/amo/templates/amo/side_nav.html:11 src/olympia/amo/templates/amo/site_nav.html:3
+#: src/olympia/amo/templates/amo/site_nav.html:25 src/olympia/browse/views.py:203 src/olympia/browse/views.py:248 src/olympia/browse/views.py:448
 msgid "Most Popular"
 msgstr "Mest populære"
 
-#: src/olympia/addons/templates/addons/home.html:43
+#: src/olympia/addons/templates/addons/home.html:45
 msgid "All »"
 msgstr "Alle »"
 
-#: src/olympia/addons/templates/addons/home.html:52 src/olympia/addons/templates/addons/home.html:61 src/olympia/addons/templates/addons/home.html:70 src/olympia/addons/templates/addons/home.html:78
+#: src/olympia/addons/templates/addons/home.html:54 src/olympia/addons/templates/addons/home.html:63 src/olympia/addons/templates/addons/home.html:72 src/olympia/addons/templates/addons/home.html:80
 #: src/olympia/browse/templates/browse/impala/category_landing.html:36
 msgid "See all »"
 msgstr "Se alle »"
 
-#: src/olympia/addons/templates/addons/home.html:60
+#: src/olympia/addons/templates/addons/home.html:62
 msgid "Up &amp; Coming Extensions"
 msgstr "Up &amp; Coming udvidelser"
 
-#: src/olympia/addons/templates/addons/home.html:69 src/olympia/browse/templates/browse/personas/category_landing.html:61 src/olympia/discovery/templates/discovery/pane.html:74
+#: src/olympia/addons/templates/addons/home.html:71 src/olympia/browse/templates/browse/personas/category_landing.html:61 src/olympia/discovery/templates/discovery/pane.html:74
 msgid "Featured Themes"
 msgstr "Udvalgte temaer"
 
-#: src/olympia/addons/templates/addons/home.html:77 src/olympia/bandwagon/templates/bandwagon/impala/collection_listing.html:5
+#: src/olympia/addons/templates/addons/home.html:79 src/olympia/bandwagon/templates/bandwagon/impala/collection_listing.html:5
 msgid "Featured Collections"
 msgstr "Udvalgte samlinger"
 
@@ -564,7 +564,7 @@ msgid "Updated {0}"
 msgstr "Opdateret {0}"
 
 #. {0} is a date.
-#: src/olympia/addons/templates/addons/macros.html:10 src/olympia/addons/templates/addons/macros.html:69 src/olympia/addons/templates/addons/persona_preview.html:21
+#: src/olympia/addons/templates/addons/macros.html:10 src/olympia/addons/templates/addons/macros.html:69 src/olympia/addons/templates/addons/persona_preview.html:22
 #: src/olympia/addons/templates/addons/listing/items_mobile.html:44 src/olympia/addons/templates/addons/listing/macros.html:39
 #: src/olympia/bandwagon/templates/bandwagon/collection_listing_items.html:37 src/olympia/bandwagon/templates/bandwagon/impala/collection_listing_items.html:37
 msgid "Added {0}"
@@ -585,15 +585,14 @@ msgstr[0] "%(num)s bruger"
 msgstr[1] "%(num)s brugere"
 
 #. {0} is the number of downloads.
-#: src/olympia/addons/templates/addons/macros.html:53 src/olympia/addons/templates/addons/impala/details.html:61
+#: src/olympia/addons/templates/addons/macros.html:53 src/olympia/addons/templates/addons/impala/details.html:59
 msgid "{0} weekly download"
 msgid_plural "{0} weekly downloads"
 msgstr[0] "{0} ugentlig download"
 msgstr[1] "{0} ugentlige downloads"
 
 #. {0} is the number of users.
-#: src/olympia/addons/templates/addons/macros.html:61 src/olympia/addons/templates/addons/impala/details.html:54 src/olympia/compat/templates/compat/index.html:71
-#: src/olympia/zadmin/templates/zadmin/compat.html:67
+#: src/olympia/addons/templates/addons/macros.html:61 src/olympia/addons/templates/addons/impala/details.html:52 src/olympia/zadmin/templates/zadmin/compat.html:67
 msgid "{0} user"
 msgid_plural "{0} users"
 msgstr[0] "{0} bruger"
@@ -611,7 +610,7 @@ msgstr "Betaling gennemført"
 msgid "Return to the addon."
 msgstr "Tilbage til tilføjelsen."
 
-#: src/olympia/addons/templates/addons/persona_detail.html:17 src/olympia/addons/templates/addons/impala/details.html:106 src/olympia/addons/templates/addons/mobile/details.html:23
+#: src/olympia/addons/templates/addons/persona_detail.html:17 src/olympia/addons/templates/addons/impala/details.html:103 src/olympia/addons/templates/addons/mobile/details.html:23
 #: src/olympia/addons/templates/addons/mobile/persona_detail.html:21 src/olympia/discovery/templates/discovery/addons/base.html:27 src/olympia/editors/templates/editors/review.html:31
 msgid "by"
 msgstr "af"
@@ -655,34 +654,35 @@ msgstr "Daglige brugere"
 msgid "License"
 msgstr "Licens"
 
-#: src/olympia/addons/templates/addons/persona_preview.html:12 src/olympia/constants/base.py:48
+#: src/olympia/addons/templates/addons/persona_preview.html:13 src/olympia/constants/base.py:48
 msgid "Awaiting Review"
 msgstr "Afventer godkendelse"
 
-#: src/olympia/addons/templates/addons/persona_preview.html:14 src/olympia/amo/log.py:180 src/olympia/constants/base.py:42 src/olympia/editors/helpers.py:62
+#: src/olympia/addons/templates/addons/persona_preview.html:15 src/olympia/amo/log.py:180 src/olympia/constants/base.py:42 src/olympia/editors/helpers.py:62
 msgid "Rejected"
 msgstr "Afvist"
 
-#: src/olympia/addons/templates/addons/persona_preview.html:16 src/olympia/amo/log.py:159
+#: src/olympia/addons/templates/addons/persona_preview.html:17 src/olympia/amo/log.py:159
 msgid "Approved"
 msgstr "Godkendt"
 
 #. {0} is the number of users.
-#: src/olympia/addons/templates/addons/persona_preview.html:26 src/olympia/addons/templates/addons/listing/items_mobile.html:36 src/olympia/addons/templates/addons/listing/macros.html:31
+#: src/olympia/addons/templates/addons/persona_preview.html:27 src/olympia/addons/templates/addons/listing/items_mobile.html:36 src/olympia/addons/templates/addons/listing/macros.html:31
 msgid "<strong>{0}</strong> user"
 msgid_plural "<strong>{0}</strong> users"
 msgstr[0] "<strong>{0}</strong> bruger"
 msgstr[1] "<strong>{0}</strong> brugere"
 
-#: src/olympia/addons/templates/addons/persona_preview.html:40
+#: src/olympia/addons/templates/addons/persona_preview.html:41
 msgid "Hover to Preview"
 msgstr "Hold markøren over for eksempel"
 
-#: src/olympia/addons/templates/addons/persona_preview.html:46 src/olympia/addons/templates/addons/persona_preview.html:48 src/olympia/reviews/templates/reviews/add.html:15
+#: src/olympia/addons/templates/addons/persona_preview.html:47 src/olympia/addons/templates/addons/persona_preview.html:49 src/olympia/addons/templates/addons/persona_preview.html:97
+#: src/olympia/reviews/templates/reviews/add.html:15
 msgid "Add"
 msgstr "Tilføj"
 
-#: src/olympia/addons/templates/addons/persona_preview.html:57 src/olympia/bandwagon/templates/bandwagon/ajax_new.html:16 src/olympia/bandwagon/templates/bandwagon/edit.html:19
+#: src/olympia/addons/templates/addons/persona_preview.html:58 src/olympia/bandwagon/templates/bandwagon/ajax_new.html:16 src/olympia/bandwagon/templates/bandwagon/edit.html:19
 #: src/olympia/bandwagon/templates/bandwagon/includes/addedit.html:19 src/olympia/devhub/templates/devhub/addons/edit/admin.html:13 src/olympia/devhub/templates/devhub/addons/edit/basic.html:10
 #: src/olympia/devhub/templates/devhub/addons/edit/details.html:8 src/olympia/devhub/templates/devhub/addons/edit/media.html:6 src/olympia/devhub/templates/devhub/addons/edit/support.html:8
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:9 src/olympia/devhub/templates/devhub/addons/submit/describe.html:29 src/olympia/editors/templates/editors/review.html:257
@@ -691,21 +691,21 @@ msgstr "Rediger"
 
 #. For datetime formatting, see the table on
 #. http://docs.python.org/library/datetime.html#strftime-and-strptime-behavior
-#: src/olympia/addons/templates/addons/persona_preview.html:66
+#: src/olympia/addons/templates/addons/persona_preview.html:67
 #, python-format
 msgid "%%Y-%%m-%%d"
 msgstr "%%d. %%m %%Y"
 
-#: src/olympia/addons/templates/addons/persona_preview.html:67
+#: src/olympia/addons/templates/addons/persona_preview.html:68
 msgid "by {0} on {1}"
 msgstr "af {0} den {1}"
 
-#: src/olympia/addons/templates/addons/persona_preview.html:75 src/olympia/reviews/helpers.py:17 src/olympia/reviews/templates/reviews/review_list.html:63
+#: src/olympia/addons/templates/addons/persona_preview.html:76 src/olympia/reviews/helpers.py:17 src/olympia/reviews/templates/reviews/review_list.html:63
 #: src/olympia/reviews/templates/reviews/reviews_link.html:21 src/olympia/reviews/templates/reviews/impala/reviews_link.html:16
 msgid "Not yet rated"
 msgstr "Ikke bedømt endnu"
 
-#: src/olympia/addons/templates/addons/persona_preview.html:78
+#: src/olympia/addons/templates/addons/persona_preview.html:79
 msgid "<b>{0}</b> users"
 msgstr "<b>{0}</b> brugere"
 
@@ -718,8 +718,8 @@ msgid "Learn more about Firefox"
 msgstr "Læs mere om Firefox"
 
 #: src/olympia/addons/templates/addons/popups.html:22
-msgid "or <b><a class=\"installer\" href=\"{url}\">download anyway</a></b>"
-msgstr "eller <b><a class=\"installer\" href=\"{url}\">download alligevel</a></b>"
+msgid "or <b><a class=\"button installer\" href=\"{url}\">download anyway</a></b>"
+msgstr ""
 
 #: src/olympia/addons/templates/addons/popups.html:26
 msgid ""
@@ -812,11 +812,14 @@ msgid "QR code for add-on"
 msgstr "QR-kode til tilføjelse"
 
 #: src/olympia/addons/templates/addons/qr_code.html:6
-msgid "Want {0} on your mobile Firefox? Scan this QR code to install directly to your phone. (You'll need a QR reader. Search your phone's marketplace if don't have one.)"
-msgstr "Ønsker du {0} på Mobilen? Skan denne QR-kode for at installere direkte på din telefon. (Det er nødvendigt med en QR-læser. Søg på din telefons app-marked hvis du ikke har en.)"
+msgid ""
+"Want {0} on your mobile Firefox?  Scan this QR code to install directly\n"
+"  to your phone.  (You'll need a QR reader.  Search your phone's marketplace if\n"
+"  don't have one.)"
+msgstr ""
 
 #: src/olympia/addons/templates/addons/report_abuse.html:6 src/olympia/addons/templates/addons/report_abuse_full.html:10 src/olympia/addons/templates/addons/impala/details-more.html:23
-#: src/olympia/addons/templates/addons/impala/details.html:328
+#: src/olympia/addons/templates/addons/impala/details.html:333
 msgid "Report Abuse"
 msgstr "Rapportér misbrug"
 
@@ -837,9 +840,9 @@ msgstr "Send rapport"
 #: src/olympia/devhub/templates/devhub/addons/ajax_compat_update.html:36 src/olympia/devhub/templates/devhub/addons/profile.html:44 src/olympia/devhub/templates/devhub/addons/edit/admin.html:104
 #: src/olympia/devhub/templates/devhub/addons/edit/basic.html:155 src/olympia/devhub/templates/devhub/addons/edit/details.html:88 src/olympia/devhub/templates/devhub/addons/edit/support.html:70
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:169 src/olympia/devhub/templates/devhub/addons/forms_shared/media.html:152
-#: src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:44 src/olympia/devhub/templates/devhub/personas/edit.html:222 src/olympia/devhub/templates/devhub/versions/add_file_modal.html:79
-#: src/olympia/devhub/templates/devhub/versions/edit.html:140 src/olympia/devhub/templates/devhub/versions/list.html:208 src/olympia/devhub/templates/devhub/versions/list.html:242
-#: src/olympia/devhub/templates/devhub/versions/list.html:276 src/olympia/devhub/templates/devhub/versions/list.html:317 src/olympia/reviews/templates/reviews/edit_review.html:16
+#: src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:43 src/olympia/devhub/templates/devhub/personas/edit.html:222 src/olympia/devhub/templates/devhub/versions/add_file_modal.html:59
+#: src/olympia/devhub/templates/devhub/versions/edit.html:140 src/olympia/devhub/templates/devhub/versions/list.html:208 src/olympia/devhub/templates/devhub/versions/list.html:239
+#: src/olympia/devhub/templates/devhub/versions/list.html:281 src/olympia/devhub/templates/devhub/versions/list.html:315 src/olympia/reviews/templates/reviews/edit_review.html:16
 #: src/olympia/translations/templates/translations/trans-menu.html:50 src/olympia/translations/templates/translations/trans-menu.html:62 src/olympia/zadmin/templates/zadmin/validation.html:105
 msgid "Cancel"
 msgstr "Annuller"
@@ -884,7 +887,7 @@ msgstr "Se <a href=\"%(support)s\">support-afsnittet</a> for at finde ud af, hvo
 msgid "Review Guidelines"
 msgstr "Retningslinjer for anmeldelser"
 
-#: src/olympia/addons/templates/addons/review_list_box.html:5 src/olympia/addons/templates/addons/impala/details-more.html:27 src/olympia/editors/helpers.py:921
+#: src/olympia/addons/templates/addons/review_list_box.html:5 src/olympia/addons/templates/addons/impala/details-more.html:27 src/olympia/editors/helpers.py:1001
 #: src/olympia/reviews/templates/reviews/add.html:14 src/olympia/reviews/templates/reviews/reply.html:14 src/olympia/reviews/templates/reviews/review_list.html:19
 #: src/olympia/reviews/templates/reviews/mobile/review_list.html:26
 msgid "Reviews"
@@ -975,31 +978,31 @@ msgid_plural "Other add-ons by these authors"
 msgstr[0] "Andre tilføjelser af %(author)s"
 msgstr[1] ""
 
-#: src/olympia/addons/templates/addons/impala/details.html:41
+#: src/olympia/addons/templates/addons/impala/details.html:39
 #, python-format
 msgid "<span itemprop=\"ratingCount\">%(num)s</span> user review"
 msgid_plural "<span itemprop=\"ratingCount\">%(num)s</span> user reviews"
 msgstr[0] "<span itemprop=\"ratingCount\">%(num)s</span> brugeranmeldelse"
 msgstr[1] "<span itemprop=\"ratingCount\">%(num)s</span> brugeranmeldelser"
 
-#: src/olympia/addons/templates/addons/impala/details.html:69
+#: src/olympia/addons/templates/addons/impala/details.html:66
 msgid "View statistics"
 msgstr "Vis statistik"
 
-#: src/olympia/addons/templates/addons/impala/details.html:84
+#: src/olympia/addons/templates/addons/impala/details.html:81
 msgid "Manage"
 msgstr "Administrer"
 
 #. {0} is an add-on name.
-#: src/olympia/addons/templates/addons/impala/details.html:96
+#: src/olympia/addons/templates/addons/impala/details.html:93
 msgid "Icon of {0}"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/impala/details.html:103 src/olympia/addons/templates/addons/impala/listing/items.html:14
+#: src/olympia/addons/templates/addons/impala/details.html:100 src/olympia/addons/templates/addons/impala/listing/items.html:14
 msgid "No Restart"
 msgstr "Ingen genstart"
 
-#: src/olympia/addons/templates/addons/impala/details.html:127
+#: src/olympia/addons/templates/addons/impala/details.html:124
 #, python-format
 msgid "Meet the Developer: <a href=\"%(url)s\">%(name)s</a>"
 msgid_plural "<a href=\"%(url)s\">Meet the Developers</a>"
@@ -1007,72 +1010,72 @@ msgstr[0] "Mød udvikleren: <a href=\"%(url)s\">%(name)s</a>"
 msgstr[1] ""
 
 # {0} is an add-on name.
-#: src/olympia/addons/templates/addons/impala/details.html:137
+#: src/olympia/addons/templates/addons/impala/details.html:134
 msgid "Learn why {0} was created and find out what's next for this add-on."
 msgstr "Find ud af, hvorfor {0} blev lavet, og hvad der bliver det næste for denne tilføjelse."
 
 #. {0} is an index.
-#: src/olympia/addons/templates/addons/impala/details.html:156
+#: src/olympia/addons/templates/addons/impala/details.html:161
 msgid "Add-on screenshot #{0}"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/impala/details.html:182
+#: src/olympia/addons/templates/addons/impala/details.html:187
 msgid "Add-on home page"
 msgstr "Tilføjelsens hjemmeside"
 
-#: src/olympia/addons/templates/addons/impala/details.html:185
+#: src/olympia/addons/templates/addons/impala/details.html:190
 msgid "Support site"
 msgstr "Supportwebsted"
 
-#: src/olympia/addons/templates/addons/impala/details.html:189
+#: src/olympia/addons/templates/addons/impala/details.html:194
 msgid "Support E-mail"
 msgstr "Supportmail"
 
-#: src/olympia/addons/templates/addons/impala/details.html:194 src/olympia/devhub/models.py:378 src/olympia/devhub/templates/devhub/versions/list.html:12
+#: src/olympia/addons/templates/addons/impala/details.html:199 src/olympia/devhub/models.py:378 src/olympia/devhub/templates/devhub/versions/list.html:12
 #: src/olympia/versions/templates/versions/version.html:6 src/olympia/versions/templates/versions/mobile/version.html:6
 msgid "Version {0}"
 msgstr "Version {0}"
 
-#: src/olympia/addons/templates/addons/impala/details.html:194
+#: src/olympia/addons/templates/addons/impala/details.html:199
 msgid "Info"
 msgstr "Info"
 
-#: src/olympia/addons/templates/addons/impala/details.html:195 src/olympia/devhub/templates/devhub/includes/addon_details.html:129
+#: src/olympia/addons/templates/addons/impala/details.html:200 src/olympia/devhub/templates/devhub/includes/addon_details.html:116
 msgid "Last Updated:"
 msgstr "Senest opdateret:"
 
-#: src/olympia/addons/templates/addons/impala/details.html:200
+#: src/olympia/addons/templates/addons/impala/details.html:205
 #, python-format
 msgid "Released under <a target=\"_blank\" href=\"%(url)s\">%(name)s</a>"
 msgstr "Udgivet under <a target=\"_blank\" href=\"%(url)s\">%(name)s</a>"
 
-#: src/olympia/addons/templates/addons/impala/details.html:201 src/olympia/addons/templates/addons/impala/details.html:206 src/olympia/amo/helpers.py:398 src/olympia/devhub/forms.py:142
+#: src/olympia/addons/templates/addons/impala/details.html:206 src/olympia/addons/templates/addons/impala/details.html:211 src/olympia/amo/helpers.py:398 src/olympia/devhub/forms.py:142
 #: src/olympia/devhub/forms.py:173 src/olympia/versions/templates/versions/version.html:40 src/olympia/versions/templates/versions/version.html:45
 msgid "Custom License"
 msgstr "Anden licens"
 
-#: src/olympia/addons/templates/addons/impala/details.html:205
+#: src/olympia/addons/templates/addons/impala/details.html:210
 #, python-format
 msgid "Released under <a href=\"%(url)s\">%(name)s</a>"
 msgstr "Udgivet under <a href=\"%(url)s\">%(name)s</a>"
 
-#: src/olympia/addons/templates/addons/impala/details.html:217
+#: src/olympia/addons/templates/addons/impala/details.html:222
 msgid "About this Add-on"
 msgstr "Om denne tilføjelse"
 
-#: src/olympia/addons/templates/addons/impala/details.html:233
+#: src/olympia/addons/templates/addons/impala/details.html:238
 msgid "Developer’s Comments"
 msgstr "Udviklerens kommentarer"
 
-#: src/olympia/addons/templates/addons/impala/details.html:243
+#: src/olympia/addons/templates/addons/impala/details.html:248
 msgid "Version Information"
 msgstr "Versionshistorik"
 
-#: src/olympia/addons/templates/addons/impala/details.html:250
+#: src/olympia/addons/templates/addons/impala/details.html:255
 msgid "See complete version history"
 msgstr "Se hele versionshistorikken"
 
-#: src/olympia/addons/templates/addons/impala/details.html:262
+#: src/olympia/addons/templates/addons/impala/details.html:267
 msgid ""
 "The Development Channel lets you test an experimental new version of this add-on before it's released to the general public. Once you install the development version, you will continue to get "
 "updates from this channel. To stop receiving development updates, reinstall the default version from the link above."
@@ -1080,17 +1083,17 @@ msgstr ""
 "Udviklingskanalen giver dig mulighed for at teste en eksperimentel ny version af denne tilføjelse, før den udgives til den brede offentlighed. Når først du har installeret udviklingsversionen, vil "
 "du fortsætte med at få opdateringer fra denne kanal. For at stoppe modtagelsen af udviklingsopdateringer, skal du geninstallere standardversionen fra linket ovenover."
 
-#: src/olympia/addons/templates/addons/impala/details.html:272
+#: src/olympia/addons/templates/addons/impala/details.html:277
 msgid "<strong>Caution:</strong> Development versions of this add-on have not been reviewed by Mozilla."
 msgstr "<strong>Advarsel:</strong> Udviklingsversioner af denne tilføjelse er ikke blevet godkendt af Mozilla."
 
-#: src/olympia/addons/templates/addons/impala/details.html:287
+#: src/olympia/addons/templates/addons/impala/details.html:292
 msgid "See complete development channel history"
 msgstr "Se hele historikken for udviklingskanalen"
 
-#: src/olympia/addons/templates/addons/impala/details.html:306 src/olympia/addons/templates/addons/impala/details.html:315 src/olympia/addons/templates/addons/impala/details.html:327
+#: src/olympia/addons/templates/addons/impala/details.html:311 src/olympia/addons/templates/addons/impala/details.html:320 src/olympia/addons/templates/addons/impala/details.html:332
 #: src/olympia/addons/templates/addons/impala/review_add_box.html:4 src/olympia/stats/templates/stats/popup.html:2 src/olympia/stats/templates/stats/popup.html:8
-#: src/olympia/stats/templates/stats/stats.html:202 src/olympia/users/templates/users/profile.html:119
+#: src/olympia/stats/templates/stats/stats.html:204 src/olympia/users/templates/users/profile.html:119
 msgid "close"
 msgstr "luk"
 
@@ -1149,15 +1152,11 @@ msgstr "Licens for kildekode til {addon}"
 msgid "Source Code License"
 msgstr "Licens for kildekode"
 
-#: src/olympia/addons/templates/addons/impala/persona_grid.html:16 src/olympia/addons/templates/addons/impala/toplist.html:6
-msgid "{0} users"
-msgstr "{0} brugere"
-
 #: src/olympia/addons/templates/addons/impala/review_list_box.html:19 src/olympia/reviews/templates/reviews/review.html:40
 msgid "permalink"
 msgstr "permalink"
 
-#: src/olympia/addons/templates/addons/impala/review_list_box.html:23 src/olympia/editors/templates/editors/queue.html:98 src/olympia/reviews/templates/reviews/review.html:44
+#: src/olympia/addons/templates/addons/impala/review_list_box.html:23 src/olympia/editors/templates/editors/queue.html:104 src/olympia/reviews/templates/reviews/review.html:44
 msgid "translate"
 msgstr "oversæt"
 
@@ -1176,6 +1175,10 @@ msgstr "Denne tilføjelse er endnu ikke blevet anmeldt."
 msgid "Be the first!"
 msgstr "Vær den første!"
 
+#: src/olympia/addons/templates/addons/impala/toplist.html:6
+msgid "{0} users"
+msgstr "{0} brugere"
+
 #: src/olympia/addons/templates/addons/impala/listing/sorter.html:14 src/olympia/devhub/templates/devhub/addons/listing/item_actions.html:49
 msgid "More"
 msgstr "Flere"
@@ -1188,7 +1191,7 @@ msgstr "Føj til samling"
 msgid "My Add-ons"
 msgstr "Mine tilføjelser"
 
-#: src/olympia/addons/templates/addons/includes/dashboard_tabs.html:6 src/olympia/amo/context_processors.py:51
+#: src/olympia/addons/templates/addons/includes/dashboard_tabs.html:6 src/olympia/amo/context_processors.py:50
 msgid "My Themes"
 msgstr "Mine temaer"
 
@@ -1243,7 +1246,7 @@ msgstr "Brugere"
 msgid "Weekly Downloads"
 msgstr "Ugentlige downloads"
 
-#: src/olympia/addons/templates/addons/mobile/details.html:99 src/olympia/compat/templates/compat/reporter_detail.html:46 src/olympia/devhub/forms.py:787
+#: src/olympia/addons/templates/addons/mobile/details.html:99 src/olympia/compat/templates/compat/reporter_detail.html:46 src/olympia/devhub/forms.py:788
 #: src/olympia/devhub/templates/devhub/versions/list.html:163
 msgid "Version"
 msgstr "Version"
@@ -1330,7 +1333,7 @@ msgstr ""
 #: src/olympia/browse/templates/browse/personas/category_landing.html:21 src/olympia/browse/templates/browse/personas/category_landing.html:23
 #: src/olympia/browse/templates/browse/personas/category_landing.html:38 src/olympia/browse/templates/browse/personas/grid.html:7 src/olympia/browse/templates/browse/personas/grid.html:11
 #: src/olympia/browse/templates/browse/personas/mobile/base.html:7 src/olympia/browse/templates/browse/personas/mobile/category_landing.html:19 src/olympia/constants/base.py:180
-#: src/olympia/devhub/templates/devhub/personas/submit.html:13 src/olympia/editors/helpers.py:105 src/olympia/editors/templates/editors/base.html:26
+#: src/olympia/devhub/templates/devhub/personas/submit.html:13 src/olympia/editors/helpers.py:107 src/olympia/editors/templates/editors/base.html:26
 #: src/olympia/editors/templates/editors/performance.html:73 src/olympia/search/templates/search/personas.html:39 src/olympia/templates/menu_links.html:9
 msgid "Themes"
 msgstr "Temaer"
@@ -1351,7 +1354,7 @@ msgstr "Flere tilføjelser"
 msgid "Highest Rated"
 msgstr "Bedste bedømmelser"
 
-#: src/olympia/addons/templates/addons/mobile/home.html:74 src/olympia/amo/templates/amo/side_nav.html:5 src/olympia/amo/templates/amo/site_nav.html:27 src/olympia/amo/templates/amo/site_nav.html:57
+#: src/olympia/addons/templates/addons/mobile/home.html:74 src/olympia/amo/templates/amo/side_nav.html:5 src/olympia/amo/templates/amo/site_nav.html:27 src/olympia/amo/templates/amo/site_nav.html:55
 #: src/olympia/bandwagon/views.py:97 src/olympia/browse/views.py:57 src/olympia/browse/views.py:67 src/olympia/browse/templates/browse/personas/mobile/category_landing.html:65
 #: src/olympia/search/forms.py:15 src/olympia/search/forms.py:87
 msgid "Newest"
@@ -1365,90 +1368,90 @@ msgstr "Prøv den!"
 msgid "Theme Info &raquo;"
 msgstr "Temainfo &raquo;"
 
-#: src/olympia/amo/context_processors.py:39 src/olympia/devhub/templates/devhub/nav.html:43
+#: src/olympia/amo/context_processors.py:37 src/olympia/devhub/templates/devhub/nav.html:43
 msgid "Tools"
 msgstr "Værktøjer"
 
-#: src/olympia/amo/context_processors.py:48 src/olympia/discovery/templates/discovery/pane_account.html:8 src/olympia/users/templates/users/includes/navigation.html:2
+#: src/olympia/amo/context_processors.py:47 src/olympia/discovery/templates/discovery/pane_account.html:8 src/olympia/users/templates/users/includes/navigation.html:2
 msgid "My Profile"
 msgstr "Min profil"
 
-#: src/olympia/amo/context_processors.py:54 src/olympia/users/templates/users/edit.html:5 src/olympia/users/templates/users/includes/navigation.html:3
+#: src/olympia/amo/context_processors.py:53 src/olympia/users/templates/users/edit.html:5 src/olympia/users/templates/users/includes/navigation.html:3
 msgid "Account Settings"
 msgstr "Kontoindstillinger"
 
-#: src/olympia/amo/context_processors.py:57 src/olympia/discovery/templates/discovery/pane_account.html:11 src/olympia/users/templates/users/profile.html:83
+#: src/olympia/amo/context_processors.py:56 src/olympia/discovery/templates/discovery/pane_account.html:11 src/olympia/users/templates/users/profile.html:83
 #: src/olympia/users/templates/users/includes/navigation.html:4
 msgid "My Collections"
 msgstr "Mine samlinger"
 
-#: src/olympia/amo/context_processors.py:62 src/olympia/discovery/templates/discovery/pane_account.html:10 src/olympia/users/templates/users/includes/navigation.html:7
+#: src/olympia/amo/context_processors.py:61 src/olympia/discovery/templates/discovery/pane_account.html:10 src/olympia/users/templates/users/includes/navigation.html:7
 msgid "My Favorites"
 msgstr "Mine favoritter"
 
-#: src/olympia/amo/context_processors.py:67 src/olympia/discovery/templates/discovery/pane_account.html:13 src/olympia/templates/impala/user_login.html:14
+#: src/olympia/amo/context_processors.py:66 src/olympia/discovery/templates/discovery/pane_account.html:13 src/olympia/templates/impala/user_login.html:14
 #: src/olympia/templates/mobile/header_auth.html:5
 msgid "Log out"
 msgstr "Log ud"
 
-#: src/olympia/amo/context_processors.py:72 src/olympia/devhub/templates/devhub/addons/dashboard.html:4
+#: src/olympia/amo/context_processors.py:71 src/olympia/devhub/templates/devhub/addons/dashboard.html:4
 msgid "Manage My Submissions"
 msgstr "Administrer mine bidrag"
 
-#: src/olympia/amo/context_processors.py:75 src/olympia/devhub/templates/devhub/nav.html:27 src/olympia/devhub/templates/devhub/addons/dashboard.html:25
+#: src/olympia/amo/context_processors.py:74 src/olympia/devhub/templates/devhub/nav.html:27 src/olympia/devhub/templates/devhub/addons/dashboard.html:25
 #: src/olympia/devhub/templates/devhub/addons/submit/base.html:4
 msgid "Submit a New Add-on"
 msgstr "Indsend en ny tilføjelse"
 
-#: src/olympia/amo/context_processors.py:77 src/olympia/browse/templates/browse/personas/base.html:50 src/olympia/devhub/templates/devhub/index.html:24
+#: src/olympia/amo/context_processors.py:76 src/olympia/browse/templates/browse/personas/base.html:50 src/olympia/devhub/templates/devhub/index.html:24
 #: src/olympia/devhub/templates/devhub/addons/dashboard.html:29
 msgid "Submit a New Theme"
 msgstr "Indsend et nyt tema"
 
-#: src/olympia/amo/context_processors.py:79 src/olympia/amo/templates/amo/site_nav.html:87 src/olympia/devhub/helpers.py:36 src/olympia/devhub/helpers.py:68 src/olympia/devhub/helpers.py:102
+#: src/olympia/amo/context_processors.py:78 src/olympia/amo/templates/amo/site_nav.html:85 src/olympia/devhub/helpers.py:36 src/olympia/devhub/helpers.py:68 src/olympia/devhub/helpers.py:102
 #: src/olympia/templates/footer.html:6 src/olympia/templates/menu_links.html:14
 msgid "Developer Hub"
 msgstr "Udviklercentral"
 
-#: src/olympia/amo/context_processors.py:83 src/olympia/devhub/views.py:1792
+#: src/olympia/amo/context_processors.py:81 src/olympia/devhub/views.py:1796
 msgid "Manage API Keys"
 msgstr ""
 
-#: src/olympia/amo/context_processors.py:88 src/olympia/editors/helpers.py:82 src/olympia/editors/helpers.py:102 src/olympia/editors/templates/editors/base.html:10
+#: src/olympia/amo/context_processors.py:86 src/olympia/editors/helpers.py:84 src/olympia/editors/helpers.py:104 src/olympia/editors/templates/editors/base.html:10
 msgid "Editor Tools"
 msgstr ""
 
-#: src/olympia/amo/context_processors.py:92
+#: src/olympia/amo/context_processors.py:90
 msgid "Admin Tools"
 msgstr "Admin-værktøjer"
 
-#: src/olympia/amo/fields.py:15
+#: src/olympia/amo/fields.py:20
 msgid "Incorrect, please try again."
 msgstr ""
 
-#: src/olympia/amo/fields.py:16
+#: src/olympia/amo/fields.py:21
 msgid "Error verifying input, please try again."
 msgstr ""
 
-#: src/olympia/amo/fields.py:32
+#: src/olympia/amo/fields.py:37
 msgid "This must be a valid hex color code, such as #000000."
 msgstr ""
 
-#: src/olympia/amo/fields.py:58
+#: src/olympia/amo/fields.py:63
 msgid "Enter at least one value."
 msgstr ""
 
-#: src/olympia/amo/helpers.py:162 src/olympia/amo/templates/amo/site_nav.html:61 src/olympia/bandwagon/templates/bandwagon/add.html:9
+#: src/olympia/amo/helpers.py:162 src/olympia/amo/templates/amo/site_nav.html:59 src/olympia/bandwagon/templates/bandwagon/add.html:9
 #: src/olympia/bandwagon/templates/bandwagon/collection_detail.html:15 src/olympia/bandwagon/templates/bandwagon/delete.html:9 src/olympia/bandwagon/templates/bandwagon/edit.html:15
 #: src/olympia/bandwagon/templates/bandwagon/user_listing.html:18 src/olympia/bandwagon/templates/bandwagon/user_listing.html:21
 #: src/olympia/bandwagon/templates/bandwagon/impala/collection_listing.html:12 src/olympia/bandwagon/templates/bandwagon/impala/collection_listing.html:20
 #: src/olympia/bandwagon/templates/bandwagon/impala/collection_listing.html:24 src/olympia/bandwagon/templates/bandwagon/impala/collection_sidebar.html:3
 #: src/olympia/bandwagon/templates/bandwagon/includes/collection_sidebar.html:2 src/olympia/bandwagon/templates/bandwagon/mobile/collection_listing.html:3
-#: src/olympia/stats/templates/stats/stats.html:77 src/olympia/templates/menu_links.html:12
+#: src/olympia/stats/templates/stats/stats.html:33 src/olympia/templates/menu_links.html:12
 msgid "Collections"
 msgstr "Samlinger"
 
-#: src/olympia/amo/helpers.py:171 src/olympia/amo/templates/amo/site_nav.html:85 src/olympia/browse/templates/browse/language_tools.html:3
+#: src/olympia/amo/helpers.py:171 src/olympia/amo/templates/amo/site_nav.html:83 src/olympia/browse/templates/browse/language_tools.html:3
 msgid "Dictionaries & Language Packs"
 msgstr "Ordbøger & sprogpakker"
 
@@ -1600,8 +1603,8 @@ msgstr ""
 msgid "Comment on {addon} {version}."
 msgstr ""
 
-#: src/olympia/amo/log.py:236 src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:19 src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:47
-#: src/olympia/editors/helpers.py:511 src/olympia/editors/templates/editors/themes/history_table.html:11
+#: src/olympia/amo/log.py:236 src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:17 src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:45
+#: src/olympia/editors/helpers.py:584 src/olympia/editors/templates/editors/themes/history_table.html:11
 msgid "Comment"
 msgstr "Kommentar"
 
@@ -1908,7 +1911,7 @@ msgstr "Ups"
 #: src/olympia/amo/templates/amo/500.html:6
 #, python-format
 msgid "<h1>Oops!  We had an error.</h1> <p>We'll get to fixing that soon.</p> <p> You can try refreshing the page, or head back to the <a href=\"%(home)s\">Add-ons homepage</a>. </p>"
-msgstr "<h1>Hovsa! Vi har haft en fejl.</h1> <p>Den vil vi få rettet snart.</p> <p> Du kan prøve at genindlæse siden eller gå tilbage til <a href=\"%(home)s\">siden med tilføjelser</a>. </p>"
+msgstr ""
 
 #: src/olympia/amo/templates/amo/license_link.html:10
 msgid "Some rights reserved"
@@ -1930,7 +1933,7 @@ msgstr "Forrige"
 #: src/olympia/amo/templates/amo/mobile/paginator.html:14 src/olympia/amo/templates/amo/mobile/paginator.html:16 src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:51
 #: src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:65 src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:78
 #: src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:91 src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:104
-#: src/olympia/discovery/templates/discovery/pane.html:45 src/olympia/discovery/templates/discovery/addons/detail.html:39 src/olympia/stats/templates/stats/stats.html:167
+#: src/olympia/discovery/templates/discovery/pane.html:45 src/olympia/discovery/templates/discovery/addons/detail.html:39 src/olympia/stats/templates/stats/stats.html:169
 msgid "Next"
 msgstr "Næste"
 
@@ -1964,7 +1967,7 @@ msgstr ""
 "\"recaptcha_different\">prøve andre ord</a> eller <a href=\"#\" id=\"recaptcha_audio\">prøve en anden metode</a> i stedet for. </p>"
 
 #: src/olympia/amo/templates/amo/side_nav.html:4 src/olympia/amo/templates/amo/side_nav.html:12 src/olympia/amo/templates/amo/site_nav.html:4 src/olympia/amo/templates/amo/site_nav.html:26
-#: src/olympia/browse/views.py:56 src/olympia/browse/views.py:66 src/olympia/browse/views.py:237 src/olympia/browse/views.py:282 src/olympia/search/forms.py:86
+#: src/olympia/browse/views.py:56 src/olympia/browse/views.py:66 src/olympia/browse/views.py:204 src/olympia/browse/views.py:249 src/olympia/search/forms.py:86
 msgid "Top Rated"
 msgstr "Bedst bedømte"
 
@@ -1979,38 +1982,38 @@ msgstr "Udforsk"
 msgid "Extensions"
 msgstr "Udvidelser"
 
-#: src/olympia/amo/templates/amo/site_nav.html:45
+#: src/olympia/amo/templates/amo/site_nav.html:44
 msgid "Want more customization? Try <b>Complete Themes</b>"
 msgstr "Vil du have mere tilpasning? Prøv <b>udvidede temaer</b>"
 
-#: src/olympia/amo/templates/amo/site_nav.html:56 src/olympia/bandwagon/views.py:96
+#: src/olympia/amo/templates/amo/site_nav.html:54 src/olympia/bandwagon/views.py:96
 msgid "Most Followers"
 msgstr "Flest følgere"
 
-#: src/olympia/amo/templates/amo/site_nav.html:68 src/olympia/bandwagon/templates/bandwagon/impala/collection_sidebar.html:16
+#: src/olympia/amo/templates/amo/site_nav.html:66 src/olympia/bandwagon/templates/bandwagon/impala/collection_sidebar.html:16
 #: src/olympia/bandwagon/templates/bandwagon/includes/collection_sidebar.html:18
 msgid "Collections I've Made"
 msgstr "Samlinger jeg har lavet"
 
-#: src/olympia/amo/templates/amo/site_nav.html:70 src/olympia/bandwagon/templates/bandwagon/user_listing.html:4 src/olympia/bandwagon/templates/bandwagon/impala/collection_sidebar.html:13
+#: src/olympia/amo/templates/amo/site_nav.html:68 src/olympia/bandwagon/templates/bandwagon/user_listing.html:4 src/olympia/bandwagon/templates/bandwagon/impala/collection_sidebar.html:13
 #: src/olympia/bandwagon/templates/bandwagon/includes/collection_sidebar.html:15
 msgid "Collections I'm Following"
 msgstr "Samlinger jeg følger"
 
-#: src/olympia/amo/templates/amo/site_nav.html:73 src/olympia/bandwagon/templates/bandwagon/impala/collection_sidebar.html:18
-#: src/olympia/bandwagon/templates/bandwagon/includes/collection_sidebar.html:20 src/olympia/users/models.py:512
+#: src/olympia/amo/templates/amo/site_nav.html:71 src/olympia/bandwagon/templates/bandwagon/impala/collection_sidebar.html:18
+#: src/olympia/bandwagon/templates/bandwagon/includes/collection_sidebar.html:20 src/olympia/users/models.py:521
 msgid "My Favorite Add-ons"
 msgstr "Mine favorittilføjelser"
 
-#: src/olympia/amo/templates/amo/site_nav.html:78
+#: src/olympia/amo/templates/amo/site_nav.html:76
 msgid "More&hellip;"
 msgstr "Flere&hellip;"
 
-#: src/olympia/amo/templates/amo/site_nav.html:82
+#: src/olympia/amo/templates/amo/site_nav.html:80
 msgid "Add-ons for Mobile"
 msgstr "Tilføjelser til Mobilen"
 
-#: src/olympia/amo/templates/amo/site_nav.html:86 src/olympia/browse/feeds.py:207 src/olympia/browse/templates/browse/search_tools.html:3 src/olympia/constants/base.py:176
+#: src/olympia/amo/templates/amo/site_nav.html:84 src/olympia/browse/feeds.py:207 src/olympia/browse/templates/browse/search_tools.html:3 src/olympia/constants/base.py:176
 #: src/olympia/templates/menu_links.html:10
 msgid "Search Tools"
 msgstr "Søgning"
@@ -2026,7 +2029,7 @@ msgid "Jump to first page"
 msgstr "Hop til første side"
 
 #: src/olympia/amo/templates/amo/impala/paginator.html:22 src/olympia/amo/templates/amo/mobile/impala_paginator.html:12 src/olympia/discovery/templates/discovery/pane.html:44
-#: src/olympia/discovery/templates/discovery/addons/detail.html:38 src/olympia/stats/templates/stats/stats.html:164
+#: src/olympia/discovery/templates/discovery/addons/detail.html:38 src/olympia/stats/templates/stats/stats.html:166
 msgid "Previous"
 msgstr "Forrige"
 
@@ -2036,7 +2039,7 @@ msgstr "Hop til sidste side"
 
 #. First and second arguments are the result range (e.g., 1-20);
 #. third argument is the number of total results (e.g., 1,000).
-#. third
+#. First and second arguments are the result range (e.g., 1-20);              third
 #. argument is the number of total results (e.g., 1,000).
 #: src/olympia/amo/templates/amo/impala/paginator.html:36 src/olympia/amo/templates/amo/mobile/impala_paginator.html:38
 #, python-format
@@ -2049,31 +2052,50 @@ msgid_plural "Page {n}"
 msgstr[0] "Side {n}"
 msgstr[1] "Side {n}"
 
-#: src/olympia/amo/templates/services/install.html:38
-#, python-format
-msgid "If you are not prompted to install %(addon_name)s in a moment, please <a href=\"%(addon_xpi)s\">click here</a>."
-msgstr "Hvis du ikke bliver bedt om at installere %(addon_name)s om et øjeblik, så <a href=\"%(addon_xpi)s\">klik her</a>."
-
-#: src/olympia/amo/tests/test_messages.py:57 src/olympia/amo/tests/test_messages.py:58 src/olympia/reviews/forms.py:25 src/olympia/reviews/forms.py:50 src/olympia/reviews/templates/reviews/add.html:56
+#: src/olympia/amo/tests/test_messages.py:56 src/olympia/amo/tests/test_messages.py:57 src/olympia/reviews/forms.py:25 src/olympia/reviews/forms.py:50 src/olympia/reviews/templates/reviews/add.html:56
 #: src/olympia/reviews/templates/reviews/reply.html:30
 msgid "Title"
 msgstr "Titel"
 
-#: src/olympia/amo/tests/test_messages.py:57 src/olympia/amo/tests/test_messages.py:58
+#: src/olympia/amo/tests/test_messages.py:56 src/olympia/amo/tests/test_messages.py:57
 msgid "Body"
 msgstr "Indhold"
 
-#: src/olympia/amo/tests/test_messages.py:59
+#: src/olympia/amo/tests/test_messages.py:58
 msgid "Another Title"
 msgstr ""
 
-#: src/olympia/amo/tests/test_messages.py:59
+#: src/olympia/amo/tests/test_messages.py:58
 msgid "Another Body"
 msgstr ""
 
-#: src/olympia/api/views.py:255
-msgid "Not implemented yet."
-msgstr "Endnu ikke implementeret."
+#: src/olympia/api/authentication.py:76
+msgid "Signature has expired."
+msgstr ""
+
+#: src/olympia/api/authentication.py:79
+msgid "Error decoding signature."
+msgstr ""
+
+#: src/olympia/api/authentication.py:82
+msgid "Invalid JWT Token."
+msgstr ""
+
+#: src/olympia/api/authentication.py:130
+msgid "Invalid Authorization header. No credentials provided."
+msgstr ""
+
+#: src/olympia/api/authentication.py:133
+msgid "Invalid Authorization header. Credentials string should not contain spaces."
+msgstr ""
+
+#: src/olympia/api/fields.py:29
+msgid "The field must have a length of at least {num} characters."
+msgstr ""
+
+#: src/olympia/api/fields.py:31
+msgid "The language code {lang_code} is invalid."
+msgstr ""
 
 #: src/olympia/applications/views.py:39 src/olympia/applications/templates/applications/appversions.html:3
 msgid "Application Versions"
@@ -2091,7 +2113,7 @@ msgstr "Gyldige programversioner"
 msgid "Add-ons submitted to Mozilla Add-ons must have a manifest file with at least one of the below applications supported. Only the versions listed below are allowed for these applications."
 msgstr ""
 
-#: src/olympia/applications/templates/applications/appversions.html:25
+#: src/olympia/applications/templates/applications/appversions.html:25 src/olympia/editors/helpers.py:361
 msgid "GUID"
 msgstr "GUID"
 
@@ -2205,8 +2227,8 @@ msgstr "Favorit"
 msgid "Remove from favorites"
 msgstr "Fjern fra favoritter"
 
-#: src/olympia/bandwagon/views.py:98 src/olympia/bandwagon/views.py:191 src/olympia/browse/views.py:58 src/olympia/browse/views.py:69 src/olympia/browse/views.py:458 src/olympia/devhub/views.py:74
-#: src/olympia/devhub/views.py:82 src/olympia/devhub/templates/devhub/addons/edit/basic.html:20 src/olympia/editors/templates/editors/leaderboard.html:24
+#: src/olympia/bandwagon/views.py:98 src/olympia/bandwagon/views.py:191 src/olympia/browse/views.py:58 src/olympia/browse/views.py:69 src/olympia/browse/views.py:425 src/olympia/devhub/views.py:72
+#: src/olympia/devhub/views.py:80 src/olympia/devhub/templates/devhub/addons/edit/basic.html:20 src/olympia/editors/templates/editors/leaderboard.html:24
 #: src/olympia/editors/templates/editors/themes/queue_list.html:48 src/olympia/search/forms.py:17 src/olympia/search/forms.py:89 src/olympia/users/templates/users/vcard.html:5
 msgid "Name"
 msgstr "Navn"
@@ -2215,7 +2237,7 @@ msgstr "Navn"
 msgid "Recently Popular"
 msgstr "Seneste populære"
 
-#: src/olympia/bandwagon/views.py:189 src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:18
+#: src/olympia/bandwagon/views.py:189 src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:16
 msgid "Added"
 msgstr "Tilføjet"
 
@@ -2229,7 +2251,7 @@ msgstr "Samling oprettet!"
 
 #: src/olympia/bandwagon/views.py:316
 #, python-format
-msgid "Your new collection is shown below. You can <ahref=\"%(url)s\">edit additional settings</a> if you'dlike."
+msgid "Your new collection is shown below. You can <a href=\"%(url)s\">edit additional settings</a> if you'd like."
 msgstr ""
 
 #: src/olympia/bandwagon/views.py:322
@@ -2357,8 +2379,8 @@ msgid_plural "%(num)s Add-ons in this Collection"
 msgstr[0] "%(num)s tilføjelse i denne samling"
 msgstr[1] "%(num)s tilføjelser i denne samling"
 
-#: src/olympia/bandwagon/templates/bandwagon/collection_detail.html:125 src/olympia/compat/templates/compat/index.html:25 src/olympia/compat/templates/compat/reporter_detail.html:29
-#: src/olympia/files/templates/files/viewer.html:29 src/olympia/templates/amo_footer.html:17 src/olympia/templates/includes/lang_switcher.html:10
+#: src/olympia/bandwagon/templates/bandwagon/collection_detail.html:125 src/olympia/compat/templates/compat/reporter_detail.html:29 src/olympia/files/templates/files/viewer.html:29
+#: src/olympia/templates/amo_footer.html:17 src/olympia/templates/includes/lang_switcher.html:10
 msgid "Go"
 msgstr "Skift"
 
@@ -2392,11 +2414,9 @@ msgstr ""
 
 #: src/olympia/bandwagon/templates/bandwagon/collection_detail.html:186
 msgid ""
-"Add-ons that you mark as favorites using the <b>Add to Favorites</b> feature appear below. This collection is currently <b>private</b>, which means only you can see it. If you would like everyone "
+"Add-ons that you mark as favorites using the <b>Add to Favorites</b> feature appear below. This collection is currently <b>private</b>, which means only you can see it.  If you would like everyone "
 "to be able to see your favorites, click the button below to make it public."
 msgstr ""
-"Tilføjelser, som du markerer som favoritter ved hjælp af funktionen <b>Føj til favoritter</b> vises nedenfor. Denne samling er i øjeblikket <b>privat</b>, hvilket betyder, at kun du kan se den. "
-"Hvis du ønsker alle at være i stand til at se dine favoritter, skal du trykke på knappen nedenfor for at gøre den offentligt."
 
 #: src/olympia/bandwagon/templates/bandwagon/collection_detail.html:196
 msgid "My favorite add-ons"
@@ -2416,9 +2436,9 @@ msgid_plural "<span>%(followers)s</span> followers"
 msgstr[0] "<span>%(followers)s</span> følger"
 msgstr[1] "<span>%(followers)s</span> følgere"
 
-#. People "follow" collections to get notified of updates.
-#. Like
+#. People "follow" collections to get notified of updates.                    Like
 #. Twitter followers.
+#. People "follow" collections to get notified of updates.
 #. Like Twitter followers.
 #: src/olympia/bandwagon/templates/bandwagon/collection_listing_items.html:10 src/olympia/bandwagon/templates/bandwagon/impala/collection_listing_items.html:18
 #, python-format
@@ -2427,8 +2447,7 @@ msgid_plural "%(num)s weekly followers"
 msgstr[0] "%(num)s ugentlig følger"
 msgstr[1] "%(num)s ugentlige følgere"
 
-#. People "follow" collections to get notified of updates.
-#. Like
+#. People "follow" collections to get notified of updates.                    Like
 #. Twitter followers.
 #: src/olympia/bandwagon/templates/bandwagon/collection_listing_items.html:18
 #, python-format
@@ -2437,9 +2456,9 @@ msgid_plural "%(num)s monthly followers"
 msgstr[0] "%(num)s månedlig følger"
 msgstr[1] "%(num)s månedlige følgere"
 
-#. People "follow" collections to get notified of updates.
-#. Like
+#. People "follow" collections to get notified of updates.                    Like
 #. Twitter followers.
+#. People "follow" collections to get notified of updates.
 #. Like Twitter followers.
 #: src/olympia/bandwagon/templates/bandwagon/collection_listing_items.html:26 src/olympia/bandwagon/templates/bandwagon/impala/collection_listing_items.html:26
 #, python-format
@@ -2531,7 +2550,7 @@ msgid "Remove this user as a contributor"
 msgstr "Fjern denne bruger som en bidragsyder"
 
 #: src/olympia/bandwagon/templates/bandwagon/edit_contributors.html:18 src/olympia/bandwagon/templates/bandwagon/edit_contributors.html:43
-#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:20 src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:48
+#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:18 src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:46
 #: src/olympia/devhub/templates/devhub/addons/ajax_compat_update.html:19
 msgid "Remove"
 msgstr "Fjern"
@@ -2542,11 +2561,9 @@ msgstr "Samlings bidragsydere"
 
 #: src/olympia/bandwagon/templates/bandwagon/edit_contributors.html:26
 msgid ""
-"You can add multiple contributors to this collection. A contributor can add and remove add-ons from this collection, but cannot change its name or description. To add a contributor, enter their "
+"You can add multiple contributors to this collection.  A contributor can add and remove add-ons from this collection, but cannot change its name or description.  To add a contributor, enter their "
 "email in the box below. Contributors must have a Mozilla Add-ons account."
 msgstr ""
-"Du kan tilføje flere bidragsydere til denne samling. En bidragsyder kan tilføje og fjerne tilføjelser fra denne samling, men kan ikke ændre dens navn eller beskrivelse. For at tilføje en "
-"bidragsyder, indtast vedkommendes mailadresse i feltet nedenunder. Bidragsydere skal tilføjelseskonto hos Mozilla."
 
 #: src/olympia/bandwagon/templates/bandwagon/edit_contributors.html:40
 msgid "User"
@@ -2582,7 +2599,7 @@ msgid "<b>Warning:</b> By changing the owner of this collection, you will no lon
 msgstr "<b>Advarsel:</b> Når du skifter ejer på på denne samling, kan du ikke længere redigere den. Du vil kun være i stand til at tilføje og fjerne tilføjelser fra den."
 
 #: src/olympia/bandwagon/templates/bandwagon/edit_contributors.html:83 src/olympia/devhub/templates/devhub/addons/forms_shared/media.html:157
-#: src/olympia/devhub/templates/devhub/addons/submit/describe.html:69 src/olympia/devhub/templates/devhub/addons/submit/license.html:60 src/olympia/devhub/templates/devhub/addons/submit/upload.html:78
+#: src/olympia/devhub/templates/devhub/addons/submit/describe.html:69 src/olympia/devhub/templates/devhub/addons/submit/license.html:60 src/olympia/devhub/templates/devhub/addons/submit/upload.html:70
 #: src/olympia/devhub/templates/devhub/payments/tier.html:17 src/olympia/editors/templates/editors/themes/themes.html:111 src/olympia/editors/templates/editors/themes/themes.html:128
 #: src/olympia/editors/templates/editors/themes/themes.html:134 src/olympia/editors/templates/editors/themes/themes.html:141 src/olympia/users/templates/users/fxa_migration_prompt_content.html:10
 #: src/olympia/users/templates/users/login_form.html:42 src/olympia/users/templates/users/mobile/login.html:57
@@ -2653,45 +2670,43 @@ msgid "Reset"
 msgstr "Nulstil"
 
 #: src/olympia/bandwagon/templates/bandwagon/includes/addedit.html:53
-msgid "PNG and JPG supported. Image will be resized to 32x32."
-msgstr "PNG og JPG er understøttet. Billede bliver lavet til 32x32."
+msgid "PNG and JPG supported.  Image will be resized to 32x32."
+msgstr ""
 
 #: src/olympia/bandwagon/templates/bandwagon/includes/addedit_errors.html:3
-msgid "There are errors in this form. Please correct them below."
-msgstr "Der er fejl i denne formular. Ret dem nedenunder."
+msgid "There are errors in this form.  Please correct them below."
+msgstr ""
 
 #: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:2
 msgid "Add-ons in Your Collection"
 msgstr "Tilføjelser i din samling"
 
 #: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:4
-msgid ""
-"To include an add-on in this collection, enter its name in the box below and hit enter. You can also use the <strong>Add to Collection</strong> links throughout the site to include add-ons later."
+msgid "To include an add-on in this collection, enter its name in the box below and hit enter."
 msgstr ""
-"For at inkludere en tilføjelse i denne samling, skal du indtast tilføjelsens navn i feltet nedenunder og trykke på tasten Enter. Du kan også bruge links med <strong>Føj til samling</strong> for at "
-"inkludere tilføjelser senere."
 
-#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:17 src/olympia/constants/base.py:400 src/olympia/devhub/templates/devhub/addons/activity.html:62
+#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:15 src/olympia/constants/base.py:400 src/olympia/devhub/templates/devhub/addons/activity.html:62
+#: src/olympia/editors/helpers.py:273 src/olympia/editors/helpers.py:360
 msgid "Add-on"
 msgstr "Tilføjelse"
 
-#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:26
+#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:24
 msgid "Enter the name of the add-on to include"
 msgstr "Indtast navnet på tilføjelsen du vil inkludere"
 
-#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:28
+#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:26
 msgid "Add to Collection"
 msgstr "Føj til samling"
 
-#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:45 src/olympia/editors/helpers.py:936 src/olympia/editors/helpers.py:956
+#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:43 src/olympia/editors/helpers.py:1016 src/olympia/editors/helpers.py:1036
 msgid "Pending"
 msgstr "Under behandling"
 
-#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:47
+#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:45
 msgid "Add a comment"
 msgstr "Tilføj en kommentar"
 
-#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:48
+#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:46
 msgid "Remove this add-on from the collection"
 msgstr "Fjern denne tilføjelse fra samlingen"
 
@@ -2740,10 +2755,8 @@ msgstr "Den problematiske tilføjelse eller plugin bliver automatisk deaktiveret
 #, python-format
 msgid ""
 "When Mozilla becomes aware of add-ons, plugins, or other third-party software that seriously compromises %(app)s security, stability, or performance and meets <a href=\"%(criteria)s\">certain "
-"criteria</a>, the software may be blocked from general use. For more information, please read <a href=\"%(support)s\">this support article</a>."
+"criteria</a>, the software may be blocked from general use.  For more information, please read <a href=\"%(support)s\">this support article</a>."
 msgstr ""
-"Når Mozilla bliver opmærksom på tilføjelser, plugins eller andet tredjeparts-software, der alvorligt kompromitterer %(app)s sikkerhed, stabilitet eller ydelse, og opfylder <a href=\"%(criteria)s"
-"\">visse kriterier</a>, kan softwaren blive blokeret for generel brug. For mere information, læs <a href=\"%(support)s\">denne support-artikel</a>."
 
 #: src/olympia/blocklist/templates/blocklist/blocked_detail.html:44
 #, python-format
@@ -2800,12 +2813,12 @@ msgstr "Søgning"
 msgid "Most Users"
 msgstr "Flest brugere"
 
-#: src/olympia/browse/views.py:61 src/olympia/browse/views.py:72 src/olympia/browse/views.py:279 src/olympia/browse/templates/browse/personas/mobile/category_landing.html:63
+#: src/olympia/browse/views.py:61 src/olympia/browse/views.py:72 src/olympia/browse/views.py:246 src/olympia/browse/templates/browse/personas/mobile/category_landing.html:63
 #: src/olympia/discovery/templates/discovery/pane.html:67 src/olympia/search/forms.py:92
 msgid "Up & Coming"
 msgstr "Up & Coming"
 
-#: src/olympia/browse/views.py:460 src/olympia/devhub/views.py:76 src/olympia/devhub/views.py:83 src/olympia/discovery/templates/discovery/addons/detail.html:66
+#: src/olympia/browse/views.py:427 src/olympia/devhub/views.py:74 src/olympia/devhub/views.py:81 src/olympia/discovery/templates/discovery/addons/detail.html:66
 msgid "Created"
 msgstr "Lavet"
 
@@ -2993,8 +3006,8 @@ msgid_plural "See all %(cnt)s extensions in %(name)s &raquo;"
 msgstr[0] "Se den %(cnt)s udvidelse i kategorien %(name)s &raquo;"
 msgstr[1] "Se alle %(cnt)s udvidelser i kategorien %(name)s &raquo;"
 
-#: src/olympia/browse/templates/browse/mobile/extensions.html:13 src/olympia/compat/templates/compat/index.html:82 src/olympia/devhub/templates/devhub/devhub_search.html:24
-#: src/olympia/devhub/templates/devhub/addons/activity.html:47 src/olympia/search/templates/search/no_results.html:4 src/olympia/search/templates/search/mobile/results.html:36
+#: src/olympia/browse/templates/browse/mobile/extensions.html:13 src/olympia/devhub/templates/devhub/devhub_search.html:24 src/olympia/devhub/templates/devhub/addons/activity.html:47
+#: src/olympia/search/templates/search/no_results.html:4 src/olympia/search/templates/search/mobile/results.html:36
 msgid "No results found."
 msgstr "Ingen resultater fundet."
 
@@ -3079,7 +3092,7 @@ msgstr "&laquo; Alle temaer"
 msgid "All"
 msgstr "Alle"
 
-#: src/olympia/compat/forms.py:22 src/olympia/search/views.py:525
+#: src/olympia/compat/forms.py:22 src/olympia/editors/templates/editors/base.html:69 src/olympia/search/views.py:518
 msgid "All Add-ons"
 msgstr "Alle tilføjelser"
 
@@ -3090,53 +3103,6 @@ msgstr "Binær"
 #: src/olympia/compat/forms.py:24
 msgid "Non-binary"
 msgstr "Ikke-binær"
-
-#. Review points sources other than add-ons and themes.
-#: src/olympia/compat/views.py:87 src/olympia/constants/base.py:388 src/olympia/devhub/forms.py:162 src/olympia/editors/templates/editors/performance.html:75
-msgid "Other"
-msgstr "Anden"
-
-#: src/olympia/compat/templates/compat/index.html:4
-msgid "Add-on Compatibility Report for {app} {version}"
-msgstr "Tilføjelse kompatibilitetsrapport for {app} {version}"
-
-#: src/olympia/compat/templates/compat/index.html:11
-msgid "{app} {version} Compatibility"
-msgstr "{app} {version} kompabilitet"
-
-#: src/olympia/compat/templates/compat/index.html:17
-#, python-format
-msgid "Top 95%% compatible with previous version"
-msgstr ""
-
-#: src/olympia/compat/templates/compat/index.html:18
-#, python-format
-msgid "Top 95%% of all add-ons"
-msgstr ""
-
-#: src/olympia/compat/templates/compat/index.html:19
-msgid "All active add-ons"
-msgstr "Alle aktive tilføjelser"
-
-#: src/olympia/compat/templates/compat/index.html:23 src/olympia/constants/base.py:401
-msgid "App"
-msgstr "App"
-
-#: src/olympia/compat/templates/compat/index.html:55
-msgid "Details for add-ons compatible with previous version:"
-msgstr "Detaljer for tilføjelser kompatible med forrige version:"
-
-#: src/olympia/compat/templates/compat/index.html:57
-msgid "Show all versions"
-msgstr "Vis alle versioner"
-
-#: src/olympia/compat/templates/compat/index.html:59
-msgid "Details for add-ons compatible with all versions:"
-msgstr "Detaljer for tilføjelser kompatible med alle versioner:"
-
-#: src/olympia/compat/templates/compat/index.html:61
-msgid "Show previous version only"
-msgstr "Vis kun tidligere version"
 
 #: src/olympia/compat/templates/compat/reporter.html:3
 msgid "Add-on Compatibility Reports"
@@ -3191,8 +3157,8 @@ msgstr "Filtrer efter program"
 msgid "Report Type"
 msgstr "Rapporttype"
 
-#: src/olympia/compat/templates/compat/reporter_detail.html:47 src/olympia/devhub/forms.py:784 src/olympia/devhub/templates/devhub/addons/ajax_compat_update.html:17 src/olympia/editors/forms.py:108
-#: src/olympia/zadmin/forms.py:45
+#: src/olympia/compat/templates/compat/reporter_detail.html:47 src/olympia/devhub/forms.py:785 src/olympia/devhub/templates/devhub/addons/ajax_compat_update.html:17 src/olympia/editors/forms.py:108
+#: src/olympia/editors/forms.py:248 src/olympia/zadmin/forms.py:45
 msgid "Application"
 msgstr "Program"
 
@@ -3280,7 +3246,8 @@ msgstr ""
 msgid "Preliminarily Reviewed and Awaiting Full Review"
 msgstr ""
 
-#: src/olympia/constants/base.py:33 src/olympia/editors/helpers.py:924 src/olympia/editors/templates/editors/themes/history_table.html:34
+#: src/olympia/constants/base.py:33 src/olympia/editors/forms.py:258 src/olympia/editors/helpers.py:73 src/olympia/editors/helpers.py:1004
+#: src/olympia/editors/templates/editors/themes/history_table.html:34
 msgid "Deleted"
 msgstr ""
 
@@ -3380,6 +3347,11 @@ msgstr ""
 msgid "Ask before users can download this add-on"
 msgstr ""
 
+#. Review points sources other than add-ons and themes.
+#: src/olympia/constants/base.py:388 src/olympia/devhub/forms.py:162 src/olympia/editors/templates/editors/performance.html:75
+msgid "Other"
+msgstr "Anden"
+
 #: src/olympia/constants/base.py:389
 msgid "Exception"
 msgstr ""
@@ -3391,6 +3363,10 @@ msgstr ""
 #: src/olympia/constants/base.py:391
 msgid "Change"
 msgstr ""
+
+#: src/olympia/constants/base.py:401
+msgid "App"
+msgstr "App"
 
 #: src/olympia/constants/base.py:402
 msgid "Persona"
@@ -3540,7 +3516,7 @@ msgstr ""
 msgid "Duplicate"
 msgstr ""
 
-#: src/olympia/constants/editors.py:17 src/olympia/editors/helpers.py:502 src/olympia/editors/templates/editors/themes/queue.html:71 src/olympia/editors/templates/editors/themes/themes.html:94
+#: src/olympia/constants/editors.py:17 src/olympia/editors/helpers.py:575 src/olympia/editors/templates/editors/themes/queue.html:71 src/olympia/editors/templates/editors/themes/themes.html:94
 msgid "Reject"
 msgstr ""
 
@@ -3640,7 +3616,7 @@ msgstr "Solaris"
 msgid "Android"
 msgstr "Android"
 
-#: src/olympia/core/apps.py:19
+#: src/olympia/core/apps.py:21
 msgid "Core"
 msgstr ""
 
@@ -3774,7 +3750,7 @@ msgid "Submit my add-on for manual review."
 msgstr ""
 
 #: src/olympia/devhub/forms.py:537
-msgid "Do not list my add-on on this site (beta)"
+msgid "Do not list my add-on on this site"
 msgstr ""
 
 #: src/olympia/devhub/forms.py:538
@@ -3807,46 +3783,46 @@ msgstr ""
 
 #: src/olympia/devhub/forms.py:592
 #, python-format
-msgid "Version %s already exists"
+msgid "Version %s already exists, or was uploaded before."
 msgstr ""
 
-#: src/olympia/devhub/forms.py:604
+#: src/olympia/devhub/forms.py:605
 msgid "Select a valid choice. That choice is not one of the available choices."
 msgstr ""
 
-#: src/olympia/devhub/forms.py:610
+#: src/olympia/devhub/forms.py:611
 msgid "A file with a version ending with a|alpha|b|beta and an optional number is detected as beta."
 msgstr ""
 
-#: src/olympia/devhub/forms.py:633
+#: src/olympia/devhub/forms.py:634
 msgid "You cannot upload any more files for this version."
 msgstr ""
 
-#: src/olympia/devhub/forms.py:639
+#: src/olympia/devhub/forms.py:640
 msgid "Version doesn't match"
 msgstr ""
 
-#: src/olympia/devhub/forms.py:668
+#: src/olympia/devhub/forms.py:669
 msgid "You cannot delete a file once the review process has started.  You must delete the whole version."
 msgstr ""
 
-#: src/olympia/devhub/forms.py:688
+#: src/olympia/devhub/forms.py:689
 msgid "The platform All cannot be combined with specific platforms."
 msgstr ""
 
-#: src/olympia/devhub/forms.py:693
+#: src/olympia/devhub/forms.py:694
 msgid "A platform can only be chosen once."
 msgstr ""
 
-#: src/olympia/devhub/forms.py:706
+#: src/olympia/devhub/forms.py:707
 msgid "A review type must be selected."
 msgstr ""
 
-#: src/olympia/devhub/forms.py:788 src/olympia/editors/forms.py:114 src/olympia/zadmin/forms.py:49 src/olympia/zadmin/forms.py:52
+#: src/olympia/devhub/forms.py:789 src/olympia/editors/forms.py:114 src/olympia/editors/forms.py:254 src/olympia/zadmin/forms.py:49 src/olympia/zadmin/forms.py:52
 msgid "Select an application first"
 msgstr ""
 
-#: src/olympia/devhub/forms.py:840
+#: src/olympia/devhub/forms.py:841
 msgid "There cannot be more than 3 required add-ons."
 msgstr ""
 
@@ -3882,76 +3858,76 @@ msgstr[1] "{0} advarsler"
 msgid "Review"
 msgstr "Anmeldelse"
 
-#: src/olympia/devhub/tasks.py:551
+#: src/olympia/devhub/tasks.py:583
 #, python-format
 msgid "%s responded with %s (%s)."
 msgstr ""
 
-#: src/olympia/devhub/tasks.py:555
+#: src/olympia/devhub/tasks.py:587
 #, python-format
 msgid "Connection to \"%s\" timed out."
 msgstr "Forbindelsen til \"%s\" løb ud."
 
-#: src/olympia/devhub/tasks.py:557
+#: src/olympia/devhub/tasks.py:589
 #, python-format
 msgid "Could not contact host at \"%s\"."
 msgstr ""
 
-#: src/olympia/devhub/utils.py:104
+#: src/olympia/devhub/utils.py:105
 #, python-format
 msgid "Validation generated too many errors/warnings so %s messages were truncated. After addressing the visible messages, you'll be able to see the others."
 msgstr ""
 
-#: src/olympia/devhub/views.py:183
+#: src/olympia/devhub/views.py:181
 msgid "All My Add-ons"
 msgstr "Alle mine tilføjelser"
 
-#: src/olympia/devhub/views.py:210
+#: src/olympia/devhub/views.py:208
 msgid "All Activity"
 msgstr ""
 
-#: src/olympia/devhub/views.py:211
+#: src/olympia/devhub/views.py:209
 msgid "Add-on Updates"
 msgstr ""
 
-#: src/olympia/devhub/views.py:212
+#: src/olympia/devhub/views.py:210
 msgid "Add-on Status"
 msgstr ""
 
-#: src/olympia/devhub/views.py:213
+#: src/olympia/devhub/views.py:211
 msgid "User Collections"
 msgstr "Brugersamlinger"
 
-#: src/olympia/devhub/views.py:214 src/olympia/devhub/templates/devhub/docs/policies-maintenance.html:68 src/olympia/pages/templates/pages/dev_faq.html:38
+#: src/olympia/devhub/views.py:212 src/olympia/devhub/templates/devhub/docs/policies-maintenance.html:68 src/olympia/pages/templates/pages/dev_faq.html:38
 #: src/olympia/pages/templates/pages/dev_faq.html:484
 msgid "User Reviews"
 msgstr "Brugeranmeldelser"
 
-#: src/olympia/devhub/views.py:327 src/olympia/devhub/views.py:331 src/olympia/devhub/views.py:484 src/olympia/devhub/views.py:513 src/olympia/devhub/views.py:564 src/olympia/devhub/views.py:1150
+#: src/olympia/devhub/views.py:325 src/olympia/devhub/views.py:329 src/olympia/devhub/views.py:484 src/olympia/devhub/views.py:513 src/olympia/devhub/views.py:564 src/olympia/devhub/views.py:1156
 msgid "Changes successfully saved."
 msgstr "Ændringer gemt korrekt."
 
-#: src/olympia/devhub/views.py:334 src/olympia/devhub/views.py:1631
+#: src/olympia/devhub/views.py:332 src/olympia/devhub/views.py:1637
 msgid "Please check the form for errors."
 msgstr ""
 
-#: src/olympia/devhub/views.py:346
+#: src/olympia/devhub/views.py:344
 msgid "Add-on cannot be deleted. Disable this add-on instead."
 msgstr ""
 
-#: src/olympia/devhub/views.py:356
+#: src/olympia/devhub/views.py:354
 msgid "Theme deleted."
 msgstr ""
 
-#: src/olympia/devhub/views.py:356
+#: src/olympia/devhub/views.py:354
 msgid "Add-on deleted."
 msgstr ""
 
-#: src/olympia/devhub/views.py:362
+#: src/olympia/devhub/views.py:360
 msgid "URL name was incorrect. Theme was not deleted."
 msgstr ""
 
-#: src/olympia/devhub/views.py:367
+#: src/olympia/devhub/views.py:365
 msgid "URL name was incorrect. Add-on was not deleted."
 msgstr ""
 
@@ -3979,7 +3955,7 @@ msgstr ""
 msgid "Check Add-on Compatibility"
 msgstr ""
 
-#: src/olympia/devhub/views.py:808 src/olympia/signing/views.py:90
+#: src/olympia/devhub/views.py:808 src/olympia/signing/views.py:95
 msgid "You cannot submit this type of add-on"
 msgstr ""
 
@@ -4009,33 +3985,33 @@ msgstr "Billedet skal være præcist {0} pixels bredt og {1} pixels højt."
 msgid "There was an error uploading your preview."
 msgstr ""
 
-#: src/olympia/devhub/views.py:1189
+#: src/olympia/devhub/views.py:1195
 #, python-format
 msgid "Version %s disabled."
 msgstr ""
 
-#: src/olympia/devhub/views.py:1193
+#: src/olympia/devhub/views.py:1199
 #, python-format
 msgid "Version %s deleted."
 msgstr ""
 
-#: src/olympia/devhub/views.py:1203
+#: src/olympia/devhub/views.py:1209
 msgid "This upload has failed validation, and may lack complete validation results. Please take due care when reviewing it."
 msgstr ""
 
-#: src/olympia/devhub/views.py:1677
+#: src/olympia/devhub/views.py:1683
 msgid "Preliminary Review Requested."
 msgstr ""
 
-#: src/olympia/devhub/views.py:1678
+#: src/olympia/devhub/views.py:1684
 msgid "Full Review Requested."
 msgstr ""
 
-#: src/olympia/devhub/views.py:1779
+#: src/olympia/devhub/views.py:1783
 msgid "Your old credentials were revoked and are no longer valid. Be sure to update all API clients with the new credentials."
 msgstr ""
 
-#: src/olympia/devhub/views.py:1797
+#: src/olympia/devhub/views.py:1801
 msgid "New API key created"
 msgstr ""
 
@@ -4065,7 +4041,7 @@ msgstr "Tilbage til tilføjelser"
 msgid "{0} :: Search"
 msgstr "{0} :: Søgning"
 
-#: src/olympia/devhub/templates/devhub/devhub_search.html:6 src/olympia/devhub/templates/devhub/search.html:8 src/olympia/editors/forms.py:435 src/olympia/editors/forms.py:437
+#: src/olympia/devhub/templates/devhub/devhub_search.html:6 src/olympia/devhub/templates/devhub/search.html:8 src/olympia/editors/forms.py:534 src/olympia/editors/forms.py:536
 #: src/olympia/editors/templates/editors/queue.html:27 src/olympia/editors/templates/editors/themes/queue_list.html:14 src/olympia/search/templates/search/collections.html:17
 #: src/olympia/search/templates/search/personas.html:18 src/olympia/search/templates/search/results.html:18 src/olympia/search/templates/search/mobile/results.html:8
 #: src/olympia/templates/search.html:14 src/olympia/templates/impala/search.html:18
@@ -4125,12 +4101,12 @@ msgstr ""
 msgid "Start Making Add-ons"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/index.html:86 src/olympia/devhub/templates/devhub/addons/listing/items.html:25 src/olympia/devhub/templates/devhub/includes/addon_details.html:15
+#: src/olympia/devhub/templates/devhub/index.html:86 src/olympia/devhub/templates/devhub/addons/listing/items.html:25 src/olympia/devhub/templates/devhub/includes/addon_details.html:20
 #: src/olympia/devhub/templates/devhub/personas/edit.html:43
 msgid "Status:"
 msgstr "Status:"
 
-#: src/olympia/devhub/templates/devhub/index.html:90 src/olympia/devhub/templates/devhub/includes/addon_details.html:100
+#: src/olympia/devhub/templates/devhub/index.html:90 src/olympia/devhub/templates/devhub/includes/addon_details.html:87
 msgid "Visibility:"
 msgstr ""
 
@@ -4138,11 +4114,11 @@ msgstr ""
 msgid "Latest Version:"
 msgstr "Seneste version:"
 
-#: src/olympia/devhub/templates/devhub/index.html:109 src/olympia/devhub/templates/devhub/includes/addon_details.html:145 src/olympia/devhub/templates/devhub/personas/edit.html:49
+#: src/olympia/devhub/templates/devhub/index.html:109 src/olympia/devhub/templates/devhub/includes/addon_details.html:131 src/olympia/devhub/templates/devhub/personas/edit.html:49
 msgid "Queue Position:"
 msgstr "Placering i kø:"
 
-#: src/olympia/devhub/templates/devhub/index.html:110 src/olympia/devhub/templates/devhub/includes/addon_details.html:146 src/olympia/devhub/templates/devhub/personas/edit.html:50
+#: src/olympia/devhub/templates/devhub/index.html:110 src/olympia/devhub/templates/devhub/includes/addon_details.html:132 src/olympia/devhub/templates/devhub/personas/edit.html:50
 #, python-format
 msgid "%(position)s of %(total)s"
 msgstr "%(position)s af %(total)s"
@@ -4244,16 +4220,6 @@ msgstr ""
 msgid "Do you want your add-on to be distributed on this site?"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/validate_addon.html:49 src/olympia/devhub/templates/devhub/addons/submit/upload.html:30 src/olympia/devhub/templates/devhub/versions/add_file_modal.html:14
-#: src/olympia/devhub/templates/devhub/versions/add_file_modal.html:53 src/olympia/devhub/templates/devhub/versions/list.html:298
-msgid "Warning:"
-msgstr ""
-
-#: src/olympia/devhub/templates/devhub/validate_addon.html:50 src/olympia/devhub/templates/devhub/addons/submit/upload.html:31
-#, python-format
-msgid "Submission of unlisted add-ons for signing is currently in an open beta. Please <a href=\"%(url)s\" target=\"_blank\">report any bugs</a> that you encounter."
-msgstr ""
-
 #. first parameter is a filename like lorem-ipsum-1.0.2.xpi
 #: src/olympia/devhub/templates/devhub/validation.html:5
 msgid "Validation Results for {0}"
@@ -4328,7 +4294,7 @@ msgstr "Kompatibilitet"
 msgid "Update Compatibility"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/addons/ajax_compat_update.html:4
+#: src/olympia/devhub/templates/devhub/addons/ajax_compat_update.html:4 src/olympia/devhub/templates/devhub/versions/edit.html:45
 msgid "Adjusting application information here will allow users to install your add-on even if the install manifest in the package indicates that the add-on is incompatible."
 msgstr ""
 
@@ -4340,9 +4306,9 @@ msgstr ""
 msgid "Add Another Application&hellip;"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/addons/ajax_compat_update.html:38 src/olympia/devhub/templates/devhub/addons/owner.html:86 src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:46
-#: src/olympia/devhub/templates/devhub/versions/list.html:351 src/olympia/devhub/templates/devhub/versions/list.html:353 src/olympia/templates/impala/base.html:132
-#: src/olympia/templates/impala/base.html:143 src/olympia/templates/impala/base.html:161 src/olympia/templates/impala/base.html:171
+#: src/olympia/devhub/templates/devhub/addons/ajax_compat_update.html:38 src/olympia/devhub/templates/devhub/addons/owner.html:86 src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:45
+#: src/olympia/devhub/templates/devhub/versions/list.html:349 src/olympia/devhub/templates/devhub/versions/list.html:351 src/olympia/templates/impala/base.html:129
+#: src/olympia/templates/impala/base.html:140 src/olympia/templates/impala/base.html:158 src/olympia/templates/impala/base.html:168
 msgid "Close"
 msgstr "Luk"
 
@@ -4376,7 +4342,7 @@ msgstr "Ingen"
 msgid "Manage Authors & License"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/addons/owner.html:29 src/olympia/editors/templates/editors/review.html:270
+#: src/olympia/devhub/templates/devhub/addons/owner.html:29 src/olympia/editors/helpers.py:362 src/olympia/editors/templates/editors/review.html:270
 msgid "Authors"
 msgstr "Authors"
 
@@ -4445,17 +4411,11 @@ msgstr "Summary"
 
 #: src/olympia/devhub/templates/devhub/addons/edit/basic.html:52
 msgid ""
-"A short explanation of your add-on's basic\n"
-"                          functionality that is displayed in search and browse\n"
-"                          listings, as well as at the top of your add-on's\n"
-"                          details page. It is only relevant for listed add-ons."
+"A short explanation of your add-on's basic functionality that is displayed in search and browse listings, as well as at the top of your add-on's details page. It is only relevant for listed add-ons."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/basic.html:73
-msgid ""
-"Categories are the primary way users browse through add-ons.\n"
-"                        Choose any that fit your add-on's functionality for the most\n"
-"                        exposure. It is only relevant for listed add-ons."
+msgid "Categories are the primary way users browse through add-ons. Choose any that fit your add-on's functionality for the most exposure. It is only relevant for listed add-ons."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/basic.html:90
@@ -4465,11 +4425,7 @@ msgid ""
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/basic.html:119
-msgid ""
-"Tags help users find your add-on and should be short\n"
-"                        descriptors such as tabs, toolbar, or twitter.  You\n"
-"                        may have a maximum of {0} tags. It is only relevant\n"
-"                        for listed add-ons."
+msgid "Tags help users find your add-on and should be short descriptors such as tabs, toolbar, or twitter. You may have a maximum of {0} tags. It is only relevant for listed add-ons."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/basic.html:129 src/olympia/devhub/templates/devhub/personas/edit.html:97 src/olympia/devhub/templates/devhub/personas/submit.html:46
@@ -4497,11 +4453,7 @@ msgid "Add-on Details for {0}"
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/details.html:22
-msgid ""
-"A longer explanation of features,\n"
-"                          functionality, and other relevant information. This\n"
-"                          field is only displayed on the add-on's details\n"
-"                          page. It is only relevant for listed add-ons."
+msgid "A longer explanation of features, functionality, and other relevant information. This field is only displayed on the add-on's details page. It is only relevant for listed add-ons."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/details.html:44 src/olympia/translations/templates/translations/trans-menu.html:13
@@ -4509,10 +4461,7 @@ msgid "Default Locale"
 msgstr "Default Locale"
 
 #: src/olympia/devhub/templates/devhub/addons/edit/details.html:45
-msgid ""
-"Information about your add-on is displayed in this locale\n"
-"                        unless you override it with a locale-specific translation.\n"
-"                        It is only relevant for listed add-ons."
+msgid "Information about your add-on is displayed in this locale unless you override it with a locale-specific translation. It is only relevant for listed add-ons."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/details.html:61 src/olympia/users/forms.py:311 src/olympia/users/templates/users/edit.html:122 src/olympia/users/templates/users/register.html:57
@@ -4522,10 +4471,8 @@ msgstr "Hjemmeside"
 
 #: src/olympia/devhub/templates/devhub/addons/edit/details.html:63
 msgid ""
-"If your add-on has another homepage, enter its\n"
-"                          address here. If your website is localized into other\n"
-"                          languages multiple translations of this field can be\n"
-"                          added. It is only relevant for listed add-ons."
+"If your add-on has another homepage, enter its address here. If your website is localized into other languages multiple translations of this field can be added. It is only relevant for listed add-"
+"ons."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/media.html:3
@@ -4543,19 +4490,14 @@ msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/support.html:22
 msgid ""
-"If you wish to display an e-mail address for support\n"
-"                          inquiries, enter it here. If you have different\n"
-"                          addresses for each language multiple translations of\n"
-"                          this field can be added. It is only relevant for\n"
-"                          listed add-ons."
+"If you wish to display an e-mail address for support inquiries, enter it here. If you have different addresses for each language multiple translations of this field can be added. It is only "
+"relevant for listed add-ons."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/support.html:45
 msgid ""
-"If your add-on has a support website or forum, enter\n"
-"                          its address here. If your website is localized into\n"
-"                          other languages, multiple translations of this field can\n"
-"                          be added. It is only relevant for listed add-ons."
+"If your add-on has a support website or forum, enter its address here. If your website is localized into other languages, multiple translations of this field can be added. It is only relevant for "
+"listed add-ons."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:6
@@ -4569,11 +4511,8 @@ msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:23
 msgid ""
-"Any information end users may want to know that isn't\n"
-"                          necessarily applicable to the add-on summary or description.\n"
-"                          Common uses include listing known major bugs, information on\n"
-"                          how to report bugs, anticipated release date of a new version,\n"
-"                          etc. It is only relevant for listed add-ons."
+"Any information end users may want to know that isn't necessarily applicable to the add-on summary or description. Common uses include listing known major bugs, information on how to report bugs, "
+"anticipated release date of a new version, etc. It is only relevant for listed add-ons."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:46
@@ -4585,9 +4524,7 @@ msgid "Add-on Flags"
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:69
-msgid ""
-"These flags are used to classify add-ons. It is only\n"
-"                        relevant for listed add-ons."
+msgid "These flags are used to classify add-ons. It is only relevant for listed add-ons."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:74
@@ -4603,9 +4540,7 @@ msgid "View Source?"
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:90
-msgid ""
-"Whether the source of your add-on can be displayed in our\n"
-"                        online viewer. It is only relevant for listed add-ons."
+msgid "Whether the source of your add-on can be displayed in our online viewer. It is only relevant for listed add-ons."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:94
@@ -4621,10 +4556,7 @@ msgid "Public Stats?"
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:102
-msgid ""
-"Whether the download and usage stats of your add-on can\n"
-"                        be displayed in our online viewer.\n"
-"                        It is only relevant for listed add-ons."
+msgid "Whether the download and usage stats of your add-on can be displayed in our online viewer. It is only relevant for listed add-ons."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:107
@@ -4640,10 +4572,7 @@ msgid "Upgrade SDK?"
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:116
-msgid ""
-"If selected, we will try to automatically upgrade your\n"
-"                        add-on when a new version of the SDK is released.\n"
-"                        It is only relevant for listed add-ons."
+msgid "If selected, we will try to automatically upgrade your add-on when a new version of the SDK is released. It is only relevant for listed add-ons."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:121
@@ -4694,10 +4623,8 @@ msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/forms_shared/media.html:16
 msgid ""
-"Upload an icon for your add-on or choose from one of ours. The\n"
-"                      icon is displayed nearly everywhere your add-on is. Uploaded images\n"
-"                      must be one of the following image types: .png, .jpg.\n"
-"                      It is only relevant for listed add-ons."
+"Upload an icon for your add-on or choose from one of ours. The icon is displayed nearly everywhere your add-on is. Uploaded images must be one of the following image types: .png, .jpg. It is only "
+"relevant for listed add-ons."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/forms_shared/media.html:25
@@ -4710,9 +4637,7 @@ msgid "32x32px"
 msgstr "32x32px"
 
 #: src/olympia/devhub/templates/devhub/addons/forms_shared/media.html:39
-msgid ""
-"Used in listings of add-ons, like search results\n"
-"                            and featured add-ons."
+msgid "Used in listings of add-ons, like search results and featured add-ons."
 msgstr ""
 
 #. The size of the icon
@@ -4807,16 +4732,14 @@ msgid "Deleting your add-on will permanently remove it from the site and prevent
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:24
-msgid ""
-"Enter the following text confirm your decision:\n"
-"           {slug}"
+msgid "Enter the following text confirm your decision: {slug}"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:34
+#: src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:33
 msgid "Please tell us why you are deleting your theme:"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:36
+#: src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:35
 msgid "Please tell us why you are deleting your add-on:"
 msgstr ""
 
@@ -4853,8 +4776,8 @@ msgstr "New Version"
 msgid "Daily statistics on downloads and users."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/addons/listing/item_actions.html:45 src/olympia/stats/templates/stats/stats.html:75 src/olympia/stats/templates/stats/stats.html:79
-#: src/olympia/stats/templates/stats/stats.html:81
+#: src/olympia/devhub/templates/devhub/addons/listing/item_actions.html:45 src/olympia/stats/templates/stats/stats.html:31 src/olympia/stats/templates/stats/stats.html:35
+#: src/olympia/stats/templates/stats/stats.html:37
 msgid "Statistics"
 msgstr "Statistik"
 
@@ -4973,10 +4896,7 @@ msgid "Your add-on has been submitted to the Full Review queue."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/submit/done.html:18
-msgid ""
-"You'll receive an email once it has been reviewed by an editor. In\n"
-"          the meantime, you and your friends can install it directly from its\n"
-"          details page:"
+msgid "You'll receive an email once it has been reviewed by an editor. In the meantime, you and your friends can install it directly from its details page:"
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/submit/done.html:27 src/olympia/devhub/templates/devhub/addons/submit/done.html:77 src/olympia/devhub/templates/devhub/personas/submit_done.html:16
@@ -5182,11 +5102,11 @@ msgstr ""
 msgid "Use the fields below to upload your add-on package and select any platform restrictions. After upload, a series of automated validation tests will be run on your file."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/addons/submit/upload.html:59 src/olympia/devhub/templates/devhub/versions/add_file_modal.html:39
+#: src/olympia/devhub/templates/devhub/addons/submit/upload.html:51 src/olympia/devhub/templates/devhub/versions/add_file_modal.html:28
 msgid "Which platforms is this file compatible with?"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/addons/submit/upload.html:67 src/olympia/devhub/templates/devhub/versions/add_file_modal.html:65
+#: src/olympia/devhub/templates/devhub/addons/submit/upload.html:59 src/olympia/devhub/templates/devhub/versions/add_file_modal.html:45
 msgid "Administrative overrides"
 msgstr ""
 
@@ -5296,8 +5216,8 @@ msgstr ""
 
 #: src/olympia/devhub/templates/devhub/docs/policies-contact.html:44
 msgid ""
-"If you've found a problem with the site, we'd love to fix it. Please <a href=\"https://github.com/mozilla/olympia/issues\">file a bug report</a> in GitHub, including the location of the problem and "
-"how you encountered it."
+"If you've found a problem with the site, we'd love to fix it. Please <a href=\"https://github.com/mozilla/addons/issues/new\">file a bug report</a> in GitHub, including the location of the problem "
+"and how you encountered it."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/docs/policies-maintenance.html:3 src/olympia/devhub/templates/devhub/docs/policies-maintenance.html:7
@@ -5864,7 +5784,7 @@ msgstr "Privat browsing-tilstand"
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:282
 msgid ""
-"Add-ons that store or otherwise handle browsing data must support <a href=\"https://developer.mozilla.org/En/Supporting_private_browsing_mode\">Private Browsing Mode</a>.  During a Private Browsing "
+"Add-ons that store or otherwise handle browsing data must support <a href=\"https://developer.mozilla.org/En/Supporting_private_browsing_mode\">Private Browsing Mode</a>. During a Private Browsing "
 "session, no browsing data can be written to disk, and all of this data must be cleared when Firefox quits or the Private Browsing session ends."
 msgstr ""
 
@@ -6029,129 +5949,95 @@ msgstr ""
 msgid "How to get in touch with us regarding these policies or your add-on."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:6
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:10
 msgid "You have disabled this add-on"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:20
-msgid ""
-"Your add-on's listing is disabled and is not showing\n"
-"                             anywhere in our gallery or update service."
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:24
+msgid "Your add-on's listing is disabled and is not showing anywhere in our gallery or update service."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:25
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:27
 msgid "Please complete your add-on."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:29
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:30
 msgid "You will receive an email when the review is complete."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:34
-msgid ""
-"You will receive an email when the review is complete. Until\n"
-"                             then, your add-on is not listed in our gallery but can be\n"
-"                             accessed directly from its details page."
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:33
+msgid "You will receive an email when the review is complete. Until then, your add-on is not listed in our gallery but can be accessed directly from its details page."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:38 src/olympia/devhub/templates/devhub/includes/addon_details.html:48
-msgid ""
-"You will receive an email when the review is\n"
-"                             complete and your add-on is signed."
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:37 src/olympia/devhub/templates/devhub/includes/addon_details.html:45
+msgid "You will receive an email when the review is complete and your add-on is signed."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:44
-msgid ""
-"You will receive an email when the review is complete. Until\n"
-"                             then, your add-on is not listed in our gallery but can be\n"
-"                             accessed directly from its details page. "
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:41
+msgid "You will receive an email when the review is complete. Until then, your add-on is not listed in our gallery but can be accessed directly from its details page. "
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:54
-msgid ""
-"Your add-on is displayed in our gallery and users are\n"
-"                             receiving automatic updates."
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:49
+msgid "Your add-on is displayed in our gallery and users are receiving automatic updates."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:57
-msgid ""
-"Your add-on has been signed and can be bundled with an\n"
-"                             application installer."
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:52
+msgid "Your add-on has been signed and can be bundled with an application installer."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:63
-msgid ""
-"Your add-on was disabled by a site administrator and is no\n"
-"                             longer shown in our gallery. If you have any questions,\n"
-"                             please email amo-admins@mozilla.org."
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:56
+msgid "Your add-on was disabled by a site administrator and is no longer shown in our gallery. If you have any questions, please email amo-admins@mozilla.org."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:70
-msgid ""
-"Your add-on is displayed in our gallery as experimental\n"
-"                             and users are receiving automatic updates. Some features\n"
-"                             are unavailable to your add-on."
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:62
+msgid "Your add-on is displayed in our gallery as experimental and users are receiving automatic updates. Some features are unavailable to your add-on."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:74
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:66
 msgid "Your add-on has been signed."
 msgstr ""
 
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:69
+msgid ""
+"You will receive an email when the full review is complete. Until then, your add-on is displayed in our gallery as experimental and users are receiving automatic updates. Some features are "
+"unavailable to your add-on."
+msgstr ""
+
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:74
+msgid "You will receive an email when the full review is complete, making you able to bundle your add-on with an application installer."
+msgstr ""
+
 #: src/olympia/devhub/templates/devhub/includes/addon_details.html:79
-msgid ""
-"You will receive an email when the full review is complete.\n"
-"                             Until then, your add-on is displayed in our gallery as\n"
-"                             experimental and users are receiving automatic updates.\n"
-"                             Some features are unavailable to your add-on."
+msgid "All add-ons hosted in our gallery must now be reviewed by an editor. If you wish to continue hosting your add-on, please click to select a review process."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:84
-msgid ""
-"You will receive an email when the full review is\n"
-"                             complete, making you able to bundle your add-on with an\n"
-"                             application installer."
-msgstr ""
-
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:91
-msgid ""
-"All add-ons hosted in our gallery must now be reviewed by an\n"
-"                             editor. If you wish to continue hosting your add-on, please\n"
-"                             click to select a review process."
-msgstr ""
-
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:113
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:100
 msgid "Current Version:"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:115
-msgid ""
-"This is the version of your add-on that will\n"
-"                                           be installed if someone clicks the Install\n"
-"                                           button on addons.mozilla.org. It is only\n"
-"                                           relevant for listed add-ons."
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:102
+msgid "This is the version of your add-on that will be installed if someone clicks the Install button on addons.mozilla.org. It is only relevant for listed add-ons."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:123
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:110
 msgid "Created:"
 msgstr ""
 
 #. {0} is a date. dennis-ignore: E201
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:125 src/olympia/devhub/templates/devhub/includes/addon_details.html:131
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:112 src/olympia/devhub/templates/devhub/includes/addon_details.html:118
 #, python-format
 msgid "%%b %%e, %%Y"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:136
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:123
 msgid "Next Version:"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:138
-msgid ""
-"This is the newest uploaded version, however\n"
-"                                           it isn’t live on the site yet."
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:125
+msgid "This is the newest uploaded version, however it isn’t live on the site yet."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:144 src/olympia/devhub/templates/devhub/versions/list.html:30
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:130 src/olympia/devhub/templates/devhub/versions/list.html:30
 msgid "Queues are not reviewed strictly in order"
 msgstr ""
 
@@ -6219,9 +6105,7 @@ msgid "View the blog &#9658;"
 msgstr "Læs bloggen &#9658;"
 
 #: src/olympia/devhub/templates/devhub/includes/license_form.html:6
-msgid ""
-"Please choose a license appropriate for the rights you grant on your source code.\n"
-"                  It is only relevant for listed add-ons."
+msgid "Please choose a license appropriate for the rights you grant on your source code. It is only relevant for listed add-ons."
 msgstr ""
 
 #. {0} is a list of HTML tags.
@@ -6237,8 +6121,7 @@ msgstr "Noget HTML understøttes."
 msgid "Remove this application"
 msgstr ""
 
-#. {0} is the maximum number of add-on categories allowed.                {1}
-#. is
+#. {0} is the maximum number of add-on categories allowed.                {1} is
 #. the application name.
 #: src/olympia/devhub/templates/devhub/includes/macros.html:70
 msgid "Select <b>up to {0}</b> {1} category for this add-on:"
@@ -6249,14 +6132,11 @@ msgstr[1] ""
 #: src/olympia/devhub/templates/devhub/includes/policy_form.html:4
 msgid ""
 "Users will be required to accept the following End-User License Agreement (EULA) prior to installing your add-on. The presence of a EULA significantly affects the number of downloads an add-on "
-"receives. Please note that a EULA is not the same as a code license, such as the GPL or MPL.\n"
-"                It is only relevant for listed add-ons."
+"receives. Please note that a EULA is not the same as a code license, such as the GPL or MPL.It is only relevant for listed add-ons."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/policy_form.html:21
-msgid ""
-"If your add-on transmits any data from the user's computer, a privacy policy is required that explains what data is sent and how it is used.\n"
-"                It is only relevant for listed add-ons."
+#: src/olympia/devhub/templates/devhub/includes/policy_form.html:24
+msgid "If your add-on transmits any data from the user's computer, a privacy policy is required that explains what data is sent and how it is used. It is only relevant for listed add-ons."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/includes/source_form_field.html:2
@@ -6424,12 +6304,8 @@ msgstr ""
 msgid "Add some tags to describe your Theme."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/personas/edit.html:106
-msgid ""
-"A short explanation of your theme's\n"
-"                                basic functionality that is displayed in\n"
-"                                search and browse listings, as well as at\n"
-"                                the top of your theme's details page."
+#: src/olympia/devhub/templates/devhub/personas/edit.html:106 src/olympia/devhub/templates/devhub/personas/submit.html:54
+msgid "A short explanation of your theme's basic functionality that is displayed in search and browse listings, as well as at the top of your theme's details page."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/personas/edit.html:122 src/olympia/devhub/templates/devhub/personas/submit.html:68
@@ -6499,7 +6375,7 @@ msgid "Upon upload and form submission, the AMO Team will review your updated de
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/personas/edit.html:241
-msgid "Your previously resubmitted design,  which is under pending review."
+msgid "Your previously resubmitted design, which is under pending review."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/personas/edit.html:245
@@ -6566,14 +6442,6 @@ msgstr ""
 
 #: src/olympia/devhub/templates/devhub/personas/submit.html:33
 msgid "Give your Theme a name."
-msgstr ""
-
-#: src/olympia/devhub/templates/devhub/personas/submit.html:54
-msgid ""
-"A short explanation of your theme's\n"
-"                                      basic functionality that is displayed in\n"
-"                                      search and browse listings, as well as at\n"
-"                                      the top of your theme's details page."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/personas/submit.html:198
@@ -6650,30 +6518,16 @@ msgstr ""
 msgid "Files added to reviewed versions must be reviewed before they will be available for download."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/add_file_modal.html:15
-#, python-format
-msgid ""
-"Submission of updates to unlisted add-ons for signing is currently in an open beta. Manual review may still be required for a large number of add-ons. Please <a href=\"%(url)s\" target=\"_blank"
-"\">report any bugs</a> that you encounter."
-msgstr ""
-
-#: src/olympia/devhub/templates/devhub/versions/add_file_modal.html:35
+#: src/olympia/devhub/templates/devhub/versions/add_file_modal.html:24
 msgid "Select the target platform for this file."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/add_file_modal.html:46
+#: src/olympia/devhub/templates/devhub/versions/add_file_modal.html:35
 msgid "Which review type would you like to nominate for?"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/add_file_modal.html:51
+#: src/olympia/devhub/templates/devhub/versions/add_file_modal.html:40
 msgid "Only publish this version to my beta channel."
-msgstr ""
-
-#: src/olympia/devhub/templates/devhub/versions/add_file_modal.html:54
-#, python-format
-msgid ""
-"The behavior of the beta channel has changed to accommodate <a href=\"%(addon_signing_url)s\" target=\"_blank\">mandatory add-on signing</a>. The new process is currently in an open beta, and may "
-"change significantly in the near future. Please <a href=\"%(issues_url)s\" target=\"_blank\">report any bugs</a> that you encounter."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/versions/edit.html:5
@@ -6698,19 +6552,10 @@ msgstr ""
 msgid "Upload Another File"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/edit.html:45
-msgid ""
-"Adjusting application information here will allow users to install your\n"
-"                          add-on even if the install manifest in the package indicates that the\n"
-"                          add-on is incompatible."
-msgstr ""
-
 #: src/olympia/devhub/templates/devhub/versions/edit.html:74
 msgid ""
-"Information about changes in this release, new features,\n"
-"                              known bugs, and other useful information specific to this\n"
-"                              release/version. This information is also shown in the\n"
-"                              Add-ons Manager when updating."
+"Information about changes in this release, new features, known bugs, and other useful information specific to this release/version. This information is also shown in the Add-ons Manager when "
+"updating."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/versions/edit.html:99
@@ -6722,10 +6567,7 @@ msgid "Notes for Reviewers"
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/versions/edit.html:114
-msgid ""
-"Optionally, enter any information that may be useful\n"
-"                              to the Editor reviewing this add-on, such as test\n"
-"                              account information."
+msgid "Optionally, enter any information that may be useful to the Editor reviewing this add-on, such as test account information."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/versions/edit.html:127
@@ -6803,7 +6645,7 @@ msgstr ""
 msgid "Request Preliminary Review"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:80 src/olympia/devhub/templates/devhub/versions/list.html:327 src/olympia/devhub/templates/devhub/versions/list.html:350
+#: src/olympia/devhub/templates/devhub/versions/list.html:80 src/olympia/devhub/templates/devhub/versions/list.html:325 src/olympia/devhub/templates/devhub/versions/list.html:348
 msgid "Cancel Review Request"
 msgstr ""
 
@@ -6832,7 +6674,7 @@ msgid "Unlisted:"
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/versions/list.html:114
-msgid "Not distributed on {0}. Developers will upload new versions for signing and distribute the add-ons on their own. (beta)"
+msgid "Not distributed on {0}. Developers will upload new versions for signing and distribute the add-ons on their own."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/versions/list.html:122
@@ -6896,81 +6738,73 @@ msgid "<strong>Important:</strong> Once a version has been deleted, you may not 
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/versions/list.html:230
-msgid ""
-"Deleting a version which has already been reviewed\n"
-"               may also cause a significant delay in the review of\n"
-"               your next update."
-msgstr ""
-
-#: src/olympia/devhub/templates/devhub/versions/list.html:233
 msgid "Are you sure you wish to delete this version?"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:238
+#: src/olympia/devhub/templates/devhub/versions/list.html:235
 msgid "Delete Version"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:240
+#: src/olympia/devhub/templates/devhub/versions/list.html:237
 msgid "Disable Version"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:247
+#: src/olympia/devhub/templates/devhub/versions/list.html:244
 msgid "Add a new Version"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:249
+#: src/olympia/devhub/templates/devhub/versions/list.html:246
 msgid "Add Version"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:256 src/olympia/devhub/templates/devhub/versions/list.html:274
+#: src/olympia/devhub/templates/devhub/versions/list.html:253 src/olympia/devhub/templates/devhub/versions/list.html:279
 msgid "Hide Add-on"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:259
+#: src/olympia/devhub/templates/devhub/versions/list.html:256
 msgid "Hiding your add-on will prevent it from appearing anywhere in our gallery and will stop users from receiving automatic updates."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:265
+#: src/olympia/devhub/templates/devhub/versions/list.html:263
+msgid "The files awaiting review will be disabled and you will need to upload new versions."
+msgstr ""
+
+#: src/olympia/devhub/templates/devhub/versions/list.html:270
 msgid "Are you sure you wish to hide your add-on?"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:286 src/olympia/devhub/templates/devhub/versions/list.html:315
+#: src/olympia/devhub/templates/devhub/versions/list.html:291 src/olympia/devhub/templates/devhub/versions/list.html:313
 msgid "Unlist Add-on"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:289
+#: src/olympia/devhub/templates/devhub/versions/list.html:294
 #, python-format
 msgid ""
 "Unlisting your add-on will make it (and each of its versions/files) invisible on this website. It won't show up in searches, won't have a public facing page, and won't be updated automatically for "
-"current users.  It is recommended for unlisted add-ons to provide a custom <a href=\"%(update_url)s\" target=\"_blank\">updateURL</a> in their manifest file for automatic updates."
+"current users. It is recommended for unlisted add-ons to provide a custom <a href=\"%(update_url)s\" target=\"_blank\">updateURL</a> in their manifest file for automatic updates."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:299
-#, python-format
-msgid "Switching add-ons to unlisted is currently in an open beta. Please <a href=\"%(url)s\" target=\"_blank\">report any bugs</a> that you encounter."
-msgstr ""
-
-#: src/olympia/devhub/templates/devhub/versions/list.html:305
+#: src/olympia/devhub/templates/devhub/versions/list.html:303
 msgid "Unlisting an add-on is irreversible!"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:305
+#: src/olympia/devhub/templates/devhub/versions/list.html:303
 msgid "An unlisted add-on cannot be switched to be listed."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:307
+#: src/olympia/devhub/templates/devhub/versions/list.html:305
 msgid "Are you sure you wish to unlist your add-on?"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:330
+#: src/olympia/devhub/templates/devhub/versions/list.html:328
 msgid "Canceling your review request will leave your add-on as preliminarily reviewed."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:335
+#: src/olympia/devhub/templates/devhub/versions/list.html:333
 msgid "Canceling your review request will mark your add-on incomplete. If you do not complete your add-on after several days by re-requesting review, it will be deleted."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:343
+#: src/olympia/devhub/templates/devhub/versions/list.html:341
 msgid "Are you sure you wish to cancel your review request?"
 msgstr ""
 
@@ -7313,19 +7147,19 @@ msgstr ""
 msgid "Search by add-on name / author email"
 msgstr ""
 
-#: src/olympia/editors/forms.py:103
+#: src/olympia/editors/forms.py:103 src/olympia/editors/forms.py:244 src/olympia/editors/forms.py:257
 msgid "yes"
 msgstr "ja"
 
-#: src/olympia/editors/forms.py:104
+#: src/olympia/editors/forms.py:104 src/olympia/editors/forms.py:244 src/olympia/editors/forms.py:257
 msgid "no"
 msgstr "nej"
 
-#: src/olympia/editors/forms.py:105
+#: src/olympia/editors/forms.py:105 src/olympia/editors/forms.py:245
 msgid "Admin Flag"
 msgstr ""
 
-#: src/olympia/editors/forms.py:113
+#: src/olympia/editors/forms.py:113 src/olympia/editors/forms.py:253
 msgid "Max. Version"
 msgstr ""
 
@@ -7337,55 +7171,59 @@ msgstr ""
 msgid "Add-on Types"
 msgstr ""
 
-#: src/olympia/editors/forms.py:126 src/olympia/editors/helpers.py:267
+#: src/olympia/editors/forms.py:126 src/olympia/editors/helpers.py:279
 msgid "Platforms"
 msgstr "Platforme"
 
+#: src/olympia/editors/forms.py:237
+msgid "Search by add-on name / author email / guid"
+msgstr ""
+
 #. L10n: 0 = platform, 1 = filename, 2 = status message
-#: src/olympia/editors/forms.py:238
+#: src/olympia/editors/forms.py:342
 #, python-format
 msgid "<strong>%s</strong> &middot; %s &middot; %s"
 msgstr ""
 
-#: src/olympia/editors/forms.py:252
+#: src/olympia/editors/forms.py:356
 msgid "Comments:"
 msgstr "Kommentarer:"
 
-#: src/olympia/editors/forms.py:256
+#: src/olympia/editors/forms.py:360
 msgid "Operating systems:"
 msgstr "Styresystemer:"
 
-#: src/olympia/editors/forms.py:258
+#: src/olympia/editors/forms.py:362
 msgid "Applications:"
 msgstr "Programmer:"
 
-#: src/olympia/editors/forms.py:260
+#: src/olympia/editors/forms.py:364
 msgid "Notify me the next time this add-on is updated. (Subsequent updates will not generate an email)"
 msgstr "Giv mig besked næste gang denne tilføjelse bliver opdateret. (Efterfølgende opdateringer vil ikke generere en mail)"
 
-#: src/olympia/editors/forms.py:265
+#: src/olympia/editors/forms.py:369
 msgid "Clear Admin Review Flag"
 msgstr ""
 
-#: src/olympia/editors/forms.py:267
+#: src/olympia/editors/forms.py:371
 msgid "Clear more info requested flag"
 msgstr ""
 
-#: src/olympia/editors/forms.py:281
+#: src/olympia/editors/forms.py:385
 msgid "Choose a canned response..."
 msgstr ""
 
 #. L10n: Description of what can be searched for.
-#: src/olympia/editors/forms.py:324
+#: src/olympia/editors/forms.py:423
 msgid "theme name"
 msgstr ""
 
-#: src/olympia/editors/forms.py:350
+#: src/olympia/editors/forms.py:449
 msgid "Someone else is reviewing this theme."
 msgstr ""
 
 #. L10n: Description of what can be searched for.
-#: src/olympia/editors/forms.py:447
+#: src/olympia/editors/forms.py:546
 msgid "app, reviewer, or comment"
 msgstr "app, anmelder eller kommentar"
 
@@ -7401,246 +7239,264 @@ msgstr ""
 msgid "Rejected or Unreviewed"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:123 src/olympia/editors/helpers.py:136
+#: src/olympia/editors/helpers.py:125 src/olympia/editors/helpers.py:138
 msgid "Queue"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:124 src/olympia/editors/templates/editors/base.html:50 src/olympia/editors/templates/editors/base.html:65
+#: src/olympia/editors/helpers.py:126 src/olympia/editors/templates/editors/base.html:50 src/olympia/editors/templates/editors/base.html:65
 msgid "Pending Updates"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:125 src/olympia/editors/templates/editors/base.html:48 src/olympia/editors/templates/editors/base.html:63
+#: src/olympia/editors/helpers.py:127 src/olympia/editors/templates/editors/base.html:48 src/olympia/editors/templates/editors/base.html:63
 msgid "Full Reviews"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:126 src/olympia/editors/templates/editors/base.html:52 src/olympia/editors/templates/editors/base.html:67
+#: src/olympia/editors/helpers.py:128 src/olympia/editors/templates/editors/base.html:52 src/olympia/editors/templates/editors/base.html:67
 msgid "Preliminary Reviews"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:127 src/olympia/editors/templates/editors/base.html:54
+#: src/olympia/editors/helpers.py:129 src/olympia/editors/templates/editors/base.html:54
 msgid "Moderated Reviews"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:128 src/olympia/editors/templates/editors/base.html:46
+#: src/olympia/editors/helpers.py:130 src/olympia/editors/templates/editors/base.html:46
 msgid "Fast Track"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:130
+#: src/olympia/editors/helpers.py:132
 msgid "Pending Themes"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:131 src/olympia/editors/templates/editors/themes/queue.html:4
+#: src/olympia/editors/helpers.py:133 src/olympia/editors/templates/editors/themes/queue.html:4
 msgid "Flagged Themes"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:132
+#: src/olympia/editors/helpers.py:134
 msgid "Update Themes"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:137
+#: src/olympia/editors/helpers.py:139
 msgid "Unlisted Pending Updates"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:138
+#: src/olympia/editors/helpers.py:140
 msgid "Unlisted Full Reviews"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:139
+#: src/olympia/editors/helpers.py:141
 msgid "Unlisted Preliminary Reviews"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:170
+#: src/olympia/editors/helpers.py:142
+msgid "Unlisted All Add-ons"
+msgstr ""
+
+#: src/olympia/editors/helpers.py:173
 msgid "Fast Track ({0})"
 msgid_plural "Fast Track ({0})"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/olympia/editors/helpers.py:175
+#: src/olympia/editors/helpers.py:178
 msgid "Full Review ({0})"
 msgid_plural "Full Reviews ({0})"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/olympia/editors/helpers.py:180
+#: src/olympia/editors/helpers.py:183
 msgid "Pending Update ({0})"
 msgid_plural "Pending Updates ({0})"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/olympia/editors/helpers.py:185
+#: src/olympia/editors/helpers.py:188
 msgid "Preliminary Review ({0})"
 msgid_plural "Preliminary Reviews ({0})"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/olympia/editors/helpers.py:190
+#: src/olympia/editors/helpers.py:193
 msgid "Moderated Review ({0})"
 msgid_plural "Moderated Reviews ({0})"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/olympia/editors/helpers.py:196
+#: src/olympia/editors/helpers.py:199
 msgid "Unlisted Full Review ({0})"
 msgid_plural "Unlisted Full Reviews ({0})"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/olympia/editors/helpers.py:201
+#: src/olympia/editors/helpers.py:204
 msgid "Unlisted Pending Update ({0})"
 msgid_plural "Unlisted Pending Updates ({0})"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/olympia/editors/helpers.py:206
+#: src/olympia/editors/helpers.py:209
 msgid "Unlisted Preliminary Review ({0})"
 msgid_plural "Unlisted Preliminary Reviews ({0})"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/olympia/editors/helpers.py:261
-msgid "Addon"
-msgstr ""
+#: src/olympia/editors/helpers.py:214
+msgid "Unlisted All Add-ons ({0})"
+msgid_plural "Unlisted All Add-ons ({0})"
+msgstr[0] ""
+msgstr[1] ""
 
-#: src/olympia/editors/helpers.py:262
+#: src/olympia/editors/helpers.py:274
 msgid "Type"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:263
+#: src/olympia/editors/helpers.py:275
 msgid "Waiting Time"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:264 src/olympia/editors/templates/editors/review.html:285
+#: src/olympia/editors/helpers.py:276 src/olympia/editors/templates/editors/review.html:285
 msgid "Flags"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:265
+#: src/olympia/editors/helpers.py:277
 msgid "Applications"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:270
+#: src/olympia/editors/helpers.py:282
 msgid "Additional"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:285
+#: src/olympia/editors/helpers.py:302
 msgid "Site Specific"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:287
+#: src/olympia/editors/helpers.py:304
 msgid "Requires External Software"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:289
+#: src/olympia/editors/helpers.py:306
 msgid "Binary Components"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:313
+#: src/olympia/editors/helpers.py:339
 msgid "moments ago"
 msgstr ""
 
 #. L10n: first argument is number of minutes
-#: src/olympia/editors/helpers.py:316
+#: src/olympia/editors/helpers.py:342
 msgid "{0} minute"
 msgid_plural "{0} minutes"
 msgstr[0] ""
 msgstr[1] ""
 
 #. L10n: first argument is number of hours
-#: src/olympia/editors/helpers.py:320
+#: src/olympia/editors/helpers.py:346
 msgid "{0} hour"
 msgid_plural "{0} hours"
 msgstr[0] ""
 msgstr[1] ""
 
 #. L10n: first argument is number of days
-#: src/olympia/editors/helpers.py:324
+#: src/olympia/editors/helpers.py:350
 msgid "{0} day"
 msgid_plural "{0} days"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/olympia/editors/helpers.py:488
+#: src/olympia/editors/helpers.py:364
+msgid "Last Review"
+msgstr ""
+
+#: src/olympia/editors/helpers.py:366
+msgid "Last Update"
+msgstr ""
+
+#: src/olympia/editors/helpers.py:387
+msgid "No Reviews"
+msgstr ""
+
+#: src/olympia/editors/helpers.py:561
 msgid "Push to public"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:490
+#: src/olympia/editors/helpers.py:563
 msgid "Grant full review"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:505
+#: src/olympia/editors/helpers.py:578
 msgid "Request more information"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:508
+#: src/olympia/editors/helpers.py:581
 msgid "Request super-review"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:519
+#: src/olympia/editors/helpers.py:592
 msgid "Grant preliminary review"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:520
+#: src/olympia/editors/helpers.py:593
 msgid "This will mark the files as preliminarily reviewed."
 msgstr ""
 
-#: src/olympia/editors/helpers.py:522
+#: src/olympia/editors/helpers.py:595
 msgid "Use this form to request more information from the author. They will receive an email and be able to answer here. You will be notified by email when they reply."
 msgstr ""
 
-#: src/olympia/editors/helpers.py:526
+#: src/olympia/editors/helpers.py:599
 msgid ""
 "If you have concerns about this add-on's security, copyright issues, or other concerns that an administrator should look into, enter your comments in the area below. They will be sent to "
 "administrators, not the author."
 msgstr ""
 
-#: src/olympia/editors/helpers.py:532
+#: src/olympia/editors/helpers.py:605
 msgid "This will reject the add-on and remove it from the review queue."
 msgstr ""
 
-#: src/olympia/editors/helpers.py:534
-msgid "Make a comment on this version.  The author won't be able to see this."
+#: src/olympia/editors/helpers.py:607
+msgid "Make a comment on this version. The author won't be able to see this."
 msgstr ""
 
-#: src/olympia/editors/helpers.py:538
+#: src/olympia/editors/helpers.py:611
 msgid "This will reject the files and remove them from the review queue."
 msgstr ""
 
-#: src/olympia/editors/helpers.py:542
+#: src/olympia/editors/helpers.py:615
 msgid "This will mark the add-on as preliminarily reviewed. Future versions will undergo preliminary review."
 msgstr ""
 
-#: src/olympia/editors/helpers.py:547
+#: src/olympia/editors/helpers.py:620
 msgid "This will mark the files as preliminarily reviewed. Future versions will undergo preliminary review."
 msgstr ""
 
-#: src/olympia/editors/helpers.py:552
+#: src/olympia/editors/helpers.py:625
 msgid "Retain preliminary review"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:553
+#: src/olympia/editors/helpers.py:626
 msgid "This will retain the add-on as preliminarily reviewed. Future versions will undergo preliminary review."
 msgstr ""
 
-#: src/olympia/editors/helpers.py:558
+#: src/olympia/editors/helpers.py:631
 msgid "This will approve a sandboxed version of a public add-on to appear on the public side."
 msgstr ""
 
-#: src/olympia/editors/helpers.py:561
+#: src/olympia/editors/helpers.py:634
 msgid "This will reject a version of a public add-on and remove it from the queue."
 msgstr ""
 
-#: src/olympia/editors/helpers.py:564
+#: src/olympia/editors/helpers.py:637
 msgid "This will mark the add-on and its most recent version and files as public. Future versions will go into the sandbox until they are reviewed by an editor."
 msgstr ""
 
-#: src/olympia/editors/helpers.py:637
+#: src/olympia/editors/helpers.py:714
 msgid "add-on"
 msgstr "tilføjelse"
 
-#: src/olympia/editors/helpers.py:940 src/olympia/editors/helpers.py:960
+#: src/olympia/editors/helpers.py:1020 src/olympia/editors/helpers.py:1040
 msgid "Flagged"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:944 src/olympia/editors/helpers.py:963
+#: src/olympia/editors/helpers.py:1024 src/olympia/editors/helpers.py:1043
 msgid "Updates"
 msgstr ""
 
@@ -7692,56 +7548,56 @@ msgstr ""
 msgid "A question about your Theme submission"
 msgstr ""
 
-#: src/olympia/editors/views.py:144
+#: src/olympia/editors/views.py:146
 msgid "New Add-ons (Under 5 days)"
 msgstr ""
 
-#: src/olympia/editors/views.py:145
+#: src/olympia/editors/views.py:147
 msgid "Passable (5 to 10 days)"
 msgstr ""
 
-#: src/olympia/editors/views.py:146
+#: src/olympia/editors/views.py:148
 msgid "Overdue (Over 10 days)"
 msgstr ""
 
-#: src/olympia/editors/views.py:532
+#: src/olympia/editors/views.py:539
 msgid "An unknown error occurred"
 msgstr ""
 
-#: src/olympia/editors/views.py:587
+#: src/olympia/editors/views.py:592
 msgid "Self-reviews are not allowed."
 msgstr ""
 
-#: src/olympia/editors/views.py:609
+#: src/olympia/editors/views.py:613
 msgid "Review successfully processed."
 msgstr ""
 
-#: src/olympia/editors/views.py:807
+#: src/olympia/editors/views.py:812
 msgid "was approved"
 msgstr "blev godkendt"
 
-#: src/olympia/editors/views.py:808
+#: src/olympia/editors/views.py:813
 msgid "given preliminary review"
 msgstr ""
 
-#: src/olympia/editors/views.py:809
+#: src/olympia/editors/views.py:814
 msgid "rejected"
 msgstr "afvist"
 
-#: src/olympia/editors/views.py:810
+#: src/olympia/editors/views.py:815
 msgctxt "editors_review_history_nominated_adminreview"
 msgid "escalated"
 msgstr ""
 
-#: src/olympia/editors/views.py:812
+#: src/olympia/editors/views.py:817
 msgid "needs more information"
 msgstr ""
 
-#: src/olympia/editors/views.py:813
+#: src/olympia/editors/views.py:818
 msgid "needs super review"
 msgstr ""
 
-#: src/olympia/editors/views.py:814
+#: src/olympia/editors/views.py:819
 msgid "commented"
 msgstr ""
 
@@ -7786,28 +7642,28 @@ msgstr "Queues"
 msgid "Unlisted Queues"
 msgstr ""
 
-#: src/olympia/editors/templates/editors/base.html:72 src/olympia/editors/templates/editors/performance.html:6
+#: src/olympia/editors/templates/editors/base.html:74 src/olympia/editors/templates/editors/performance.html:6
 msgid "Performance"
 msgstr "Ydelse"
 
-#: src/olympia/editors/templates/editors/base.html:75 src/olympia/editors/templates/editors/themes/base.html:19 src/olympia/editors/templates/editors/themes/base.html:38
+#: src/olympia/editors/templates/editors/base.html:77 src/olympia/editors/templates/editors/themes/base.html:19 src/olympia/editors/templates/editors/themes/base.html:38
 msgid "Logs"
 msgstr "Logs"
 
-#: src/olympia/editors/templates/editors/base.html:78 src/olympia/editors/templates/editors/reviewlog.html:4 src/olympia/editors/templates/editors/reviewlog.html:27
+#: src/olympia/editors/templates/editors/base.html:80 src/olympia/editors/templates/editors/reviewlog.html:4 src/olympia/editors/templates/editors/reviewlog.html:27
 msgid "Add-on Review Log"
 msgstr ""
 
-#: src/olympia/editors/templates/editors/base.html:80 src/olympia/editors/templates/editors/eventlog.html:4 src/olympia/editors/templates/editors/eventlog.html:8
+#: src/olympia/editors/templates/editors/base.html:82 src/olympia/editors/templates/editors/eventlog.html:4 src/olympia/editors/templates/editors/eventlog.html:8
 #: src/olympia/editors/templates/editors/eventlog_detail.html:4
 msgid "Moderated Review Log"
 msgstr ""
 
-#: src/olympia/editors/templates/editors/base.html:82 src/olympia/editors/templates/editors/beta_signed_log.html:4 src/olympia/editors/templates/editors/beta_signed_log.html:8
+#: src/olympia/editors/templates/editors/base.html:84 src/olympia/editors/templates/editors/beta_signed_log.html:4 src/olympia/editors/templates/editors/beta_signed_log.html:8
 msgid "Signed Beta Files Log"
 msgstr ""
 
-#: src/olympia/editors/templates/editors/base.html:87 src/olympia/editors/templates/editors/includes/daily-message.html:4
+#: src/olympia/editors/templates/editors/base.html:89 src/olympia/editors/templates/editors/includes/daily-message.html:4
 msgid "Announcement"
 msgstr ""
 
@@ -8028,45 +7884,45 @@ msgstr "Avanceret søgning"
 msgid "clear search"
 msgstr "ryd søgning"
 
-#: src/olympia/editors/templates/editors/queue.html:72 src/olympia/editors/templates/editors/queue.html:122
+#: src/olympia/editors/templates/editors/queue.html:78 src/olympia/editors/templates/editors/queue.html:128
 msgid "Process Reviews"
 msgstr ""
 
-#: src/olympia/editors/templates/editors/queue.html:80
+#: src/olympia/editors/templates/editors/queue.html:86
 msgid "Moderation actions:"
 msgstr ""
 
-#: src/olympia/editors/templates/editors/queue.html:90
+#: src/olympia/editors/templates/editors/queue.html:96
 #, python-format
 msgid "by %(user)s on %(date)s %(stars)s (%(locale)s)"
 msgstr ""
 
-#: src/olympia/editors/templates/editors/queue.html:106
+#: src/olympia/editors/templates/editors/queue.html:112
 #, python-format
 msgid "<strong>%(reason)s</strong> <span class=\"light\">Flagged by %(user)s on %(date)s</span>"
 msgstr ""
 
-#: src/olympia/editors/templates/editors/queue.html:119
-msgid "All reviews have been moderated.  Good work!"
+#: src/olympia/editors/templates/editors/queue.html:125
+msgid "All reviews have been moderated. Good work!"
 msgstr ""
 
-#: src/olympia/editors/templates/editors/queue.html:161
+#: src/olympia/editors/templates/editors/queue.html:167
 msgid "Version Notes / Notes for Reviewer"
 msgstr ""
 
-#: src/olympia/editors/templates/editors/queue.html:169
+#: src/olympia/editors/templates/editors/queue.html:175
 msgid "There are currently no add-ons of this type to review."
 msgstr ""
 
-#: src/olympia/editors/templates/editors/queue.html:181 src/olympia/editors/templates/editors/themes/queue_list.html:85
+#: src/olympia/editors/templates/editors/queue.html:187 src/olympia/editors/templates/editors/themes/queue_list.html:85
 msgid "Helpful Links:"
 msgstr ""
 
-#: src/olympia/editors/templates/editors/queue.html:182
+#: src/olympia/editors/templates/editors/queue.html:188
 msgid "Add-on Policy"
 msgstr ""
 
-#: src/olympia/editors/templates/editors/queue.html:184
+#: src/olympia/editors/templates/editors/queue.html:190
 msgid "Editors' Guide"
 msgstr ""
 
@@ -8129,10 +7985,7 @@ msgid "<strong>Warning!</strong> Another user was viewing this page before you."
 msgstr ""
 
 #: src/olympia/editors/templates/editors/review.html:237
-msgid ""
-"The whiteboard is the place to exchange information relevant to\n"
-"               this addon (whatever the version), between the developer and the\n"
-"               editor. This is visible and editable by both."
+msgid "The whiteboard is the place to exchange information relevant to this addon (whatever the version), between the developer and the editor. This is visible and editable by both."
 msgstr ""
 
 #: src/olympia/editors/templates/editors/review.html:241
@@ -8406,7 +8259,7 @@ msgstr ""
 msgid "Describe your reason for flagging"
 msgstr ""
 
-#: src/olympia/files/forms.py:88
+#: src/olympia/files/forms.py:90
 msgid "Cannot diff a version against itself"
 msgstr ""
 
@@ -8441,51 +8294,51 @@ msgstr ""
 msgid "There was an error accessing file %s."
 msgstr ""
 
-#: src/olympia/files/utils.py:343
+#: src/olympia/files/utils.py:340
 msgid "Could not parse uploaded file."
 msgstr ""
 
-#: src/olympia/files/utils.py:380
+#: src/olympia/files/utils.py:377
 msgid "Invalid file name in archive: {0}"
 msgstr ""
 
-#: src/olympia/files/utils.py:388
+#: src/olympia/files/utils.py:385
 msgid "File exceeding size limit in archive: {0}"
 msgstr ""
 
-#: src/olympia/files/utils.py:439
+#: src/olympia/files/utils.py:436
 msgid "Invalid archive."
 msgstr ""
 
-#: src/olympia/files/utils.py:529 src/olympia/files/utils.py:532
+#: src/olympia/files/utils.py:526 src/olympia/files/utils.py:529
 msgid "Could not parse the manifest file."
 msgstr ""
 
-#: src/olympia/files/utils.py:551
+#: src/olympia/files/utils.py:548
 msgid "Could not find an add-on ID."
 msgstr ""
 
-#: src/olympia/files/utils.py:554
+#: src/olympia/files/utils.py:551
 msgid "Add-on ID must be 64 characters or less."
 msgstr ""
 
-#: src/olympia/files/utils.py:556
+#: src/olympia/files/utils.py:553
 msgid "Add-on ID doesn't match add-on."
 msgstr ""
 
-#: src/olympia/files/utils.py:564
+#: src/olympia/files/utils.py:561
 msgid "Duplicate add-on ID found."
 msgstr ""
 
-#: src/olympia/files/utils.py:567
+#: src/olympia/files/utils.py:564
 msgid "Version numbers should have fewer than 32 characters."
 msgstr ""
 
-#: src/olympia/files/utils.py:570
+#: src/olympia/files/utils.py:567
 msgid "Version numbers should only contain letters, numbers, and these punctuation characters: +*.-_."
 msgstr ""
 
-#: src/olympia/files/utils.py:587
+#: src/olympia/files/utils.py:584
 msgid "<em:type> doesn't match add-on"
 msgstr ""
 
@@ -8585,6 +8438,10 @@ msgstr ""
 #: src/olympia/files/templates/files/viewer.html:134
 msgid "Fetching file."
 msgstr ""
+
+#: src/olympia/legacy_api/views.py:255
+msgid "Not implemented yet."
+msgstr "Endnu ikke implementeret."
 
 #: src/olympia/lib/constants.py:6
 msgid "United Arab Emirates Dirham"
@@ -9242,10 +9099,6 @@ msgstr ""
 msgid "Zimbabwe Dollar"
 msgstr ""
 
-#: src/olympia/lib/video/ffmpeg.py:112 src/olympia/lib/video/totem.py:81
-msgid "Videos must be in WebM."
-msgstr ""
-
 #: src/olympia/pages/templates/pages/about.lhtml:3 src/olympia/pages/templates/pages/about.lhtml:10
 msgid "About Mozilla Add-ons"
 msgstr "Om Mozilla-tilføjelser"
@@ -9257,7 +9110,7 @@ msgstr "Hvad er dette websted?"
 #: src/olympia/pages/templates/pages/about.lhtml:13
 msgid ""
 "addons.mozilla.org, commonly known as \"AMO\", is Mozilla's official site for add-ons to Mozilla software, such as Firefox, Thunderbird, and SeaMonkey. Add-ons let you add new features and change "
-"the way your browser or application works.  Take a look around and explore the thousands of ways to customize the way you do things online."
+"the way your browser or application works. Take a look around and explore the thousands of ways to customize the way you do things online."
 msgstr ""
 "addons.mozilla.org, almindeligvis kendt som \"AMO\", er Mozillas officielle websted for tilføjelser til Mozilla-programmer såsom Firefox, Thunderbird og SeaMonkey. Med tilføjelser kan du tilføje "
 "nye funktioner og ændre måden, hvorpå din browser fungerer. Se dig omkring og udforsk de tusindvis af måder, du kan tilpasse, hvordan du gør ting på nettet."
@@ -9628,7 +9481,7 @@ msgstr ""
 msgid ""
 "Yes. It's possible, but some of the functionality provided by these libraries are available through XPCOM, XUL, and JavaScript. In addition, authors should take care if libraries modify primitive "
 "object prototypes (String.prototype, Date.prototype, etc.) and/or define global functions (eg. the $ function). These are prone to cause conflict with other add-ons, in particular if different add-"
-"ons use different versions of libraries and so on. Developers need to be very, very careful with using them.  Mozilla does not offer documentation on using them to build add-ons."
+"ons use different versions of libraries and so on. Developers need to be very, very careful with using them. Mozilla does not offer documentation on using them to build add-ons."
 msgstr ""
 
 #: src/olympia/pages/templates/pages/dev_faq.html:165
@@ -9742,8 +9595,8 @@ msgstr ""
 #, python-format
 msgid ""
 "Yes. Many developers choose to host their own add-ons. Choosing to host your add-on on <a href=\"%(amo_url)s\">Mozilla's add-on site</a>, though, allows for much greater exposure to your add-on due "
-"to the large volume of visitors to the site.  <a href=\"%(md_url)s\">mozdev.org</a> offers free project hosting for Mozilla applications and extensions providing developers with tools to help "
-"manage source code, version control, bug tracking and documentation."
+"to the large volume of visitors to the site. <a href=\"%(md_url)s\">mozdev.org</a> offers free project hosting for Mozilla applications and extensions providing developers with tools to help manage "
+"source code, version control, bug tracking and documentation."
 msgstr ""
 
 #: src/olympia/pages/templates/pages/dev_faq.html:277
@@ -9791,7 +9644,7 @@ msgstr ""
 #: src/olympia/pages/templates/pages/dev_faq.html:314
 #, python-format
 msgid ""
-"Yes. Mozilla's <a href=\"%(p_url)s\">Add-on Policy</a> describes what is an acceptable submission. This policy is subject to change without notice.  In addition, the AMO editorial team uses the <a "
+"Yes. Mozilla's <a href=\"%(p_url)s\">Add-on Policy</a> describes what is an acceptable submission. This policy is subject to change without notice. In addition, the AMO editorial team uses the <a "
 "href=\"%(g_url)s\">Editors Reviewing Guide</a> to ensure that your add-on meets specific guidelines for functionality and security."
 msgstr ""
 
@@ -9908,7 +9761,7 @@ msgstr ""
 #: src/olympia/pages/templates/pages/dev_faq.html:434
 #, python-format
 msgid ""
-"This is why it's very important to read the <a href=\"%(g_url)s\">Editors Reviewing Guide</a> to ensure that your add-on is setup as expected.  It's also a good idea to read the blog post, <a href="
+"This is why it's very important to read the <a href=\"%(g_url)s\">Editors Reviewing Guide</a> to ensure that your add-on is setup as expected. It's also a good idea to read the blog post, <a href="
 "\"%(blog_url)s\">Successfully Getting your Add-on Reviewed</a> which provides excellent insight into ensuring a smooth review of your add-on."
 msgstr ""
 
@@ -10015,7 +9868,7 @@ msgstr ""
 
 #: src/olympia/pages/templates/pages/dev_faq.html:572
 msgid ""
-"Free Software Foundation provides short summaries of the key open source licenses, including whether the license qualifies as a free software license or a copyleft license.  Also includes a "
+"Free Software Foundation provides short summaries of the key open source licenses, including whether the license qualifies as a free software license or a copyleft license. Also includes a "
 "discussion of what constitutes a free software license or a copyleft license (e.g., a Copyleft license is a general method for making a program or other work free, and requiring all modified and "
 "extended versions of the program to be free as well.)"
 msgstr ""
@@ -10223,7 +10076,7 @@ msgstr "Mozillas tilføjelser"
 msgid "How do I choose between add-ons that seem to do the same thing?"
 msgstr "Hvordan vælger jeg mellem tilføjelser, der ser ud til at gøre det samme?"
 
-#: src/olympia/pages/templates/pages/faq.html:173
+#: src/olympia/pages/templates/pages/faq.html:172
 msgid ""
 "There are often several add-ons that have similar features. To figure out which is right for you, read the entire description of the add-on and view its screenshots. If there are still several in "
 "the running, read through the add-on's ratings, user reviews, and statistics to see which is most liked by other users. Remember that you can also just try out both and see which you like better."
@@ -10277,40 +10130,34 @@ msgid "How much do add-ons cost to purchase?"
 msgstr "Hvad koster tilføjelser?"
 
 #: src/olympia/pages/templates/pages/faq.html:207
-msgid ""
-"Add-ons hosted in our gallery are free unless clearly marked\n"
-"    otherwise."
+msgid "Add-ons hosted in our gallery are free unless clearly marked otherwise."
 msgstr "Tilføjelser på vores websted er gratis, med mindre andet er tydeligt angivet."
 
-#: src/olympia/pages/templates/pages/faq.html:210
+#: src/olympia/pages/templates/pages/faq.html:209
 msgid "What does it mean when an add-on asks for contributions?"
 msgstr "Hvad betyder det, når en tilføjelse beder om bidrag?"
 
-#: src/olympia/pages/templates/pages/faq.html:211
+#: src/olympia/pages/templates/pages/faq.html:210
 msgid ""
-"Some add-on authors request users who enjoy an add-on to\n"
-"        contribute to its development by making a monetary contribution. These\n"
-"        contributions go directly to the developer unless a third party is\n"
-"        indicated, such as the non-profit Mozilla Foundation."
+"Some add-on authors request users who enjoy an add-on to contribute to its development by making a monetary contribution. These contributions go directly to the developer unless a third party is "
+"indicated, such as the non-profit Mozilla Foundation."
 msgstr ""
 "Nogle udviklere af tilføjelser anmoder brugere, der godt kan lide en tilføjelse, om at bidrage til dens udvikling ved at give et økonomisk bidrag. Disse bidrag går direkte til udvikleren, medmindre "
 "tredjepart er angivet, såsom den almennyttige Mozilla Foundation."
 
-#: src/olympia/pages/templates/pages/faq.html:216
+#: src/olympia/pages/templates/pages/faq.html:215
 msgid "What are beta add-ons?"
 msgstr "Hvad er beta-tilføjelser?"
 
-#: src/olympia/pages/templates/pages/faq.html:218
+#: src/olympia/pages/templates/pages/faq.html:217
 msgid ""
-"Beta add-ons are unreviewed versions which represent the\n"
-"        latest work of an add-on author. While different authors have different\n"
-"        standards for beta code quality, you should assume that these add-ons\n"
-"        are less stable than the general add-on releases."
+"Beta add-ons are unreviewed versions which represent the latest work of an add-on author. While different authors have different standards for beta code quality, you should assume that these add-"
+"ons are less stable than the general add-on releases."
 msgstr ""
 "Beta-tilføjelser er ikke-godkendte versioner, som repræsenterer det seneste arbejde fra en udvikler. Udviklere har forskellige standarder for kvaliteten af beta-kode, men du bør gå ud fra, at disse "
 "tilføjelser er mindre stabile end de almindelige udgivelser."
 
-#: src/olympia/pages/templates/pages/faq.html:222
+#: src/olympia/pages/templates/pages/faq.html:221
 msgid ""
 "Please note that when you install an add-on from the \"Beta Version\" section of an add-on's listing, you will continue to receive updates for that add-on as they become available. Like the initial "
 "version you installed, all beta releases are unreviewed by Mozilla and may harm your computer."
@@ -10318,49 +10165,42 @@ msgstr ""
 "Vær opmærksom på, at hvis du installerer en \"betaversion\" af en tilføjelse, vil du automatisk få den opdateret, når der udsendes nye betaversioner. Ligesom den oprindelige betaversion, du "
 "installerede, er efterfølgende betaversioner ikke blevet godkendt af Mozilla, og de kan derfor skade din computer."
 
-#: src/olympia/pages/templates/pages/faq.html:229
-msgid ""
-"What does it mean when an add-on is flagged as\n"
-"    slow?"
+#: src/olympia/pages/templates/pages/faq.html:228
+msgid "What does it mean when an add-on is flagged as slow?"
 msgstr "Hvad betyder det, når en tilføjelse er markeret som langsom?"
 
-#: src/olympia/pages/templates/pages/faq.html:231
-msgid ""
-"Most add-ons load code and resources at the same time Firefox\n"
-"        is starting up. In most cases the impact in start-up time is minimal,\n"
-"        but some add-ons can cause a noticeable slowdown."
+#: src/olympia/pages/templates/pages/faq.html:229
+msgid "Most add-ons load code and resources at the same time Firefox is starting up. In most cases the impact in start-up time is minimal, but some add-ons can cause a noticeable slowdown."
 msgstr ""
 "De fleste tilføjelser indlæser kode og ressourcer samtidig med, at Firefox startes. I de fleste tilfælde er påvirkningen af opstartstiden minimal, men nogle tilføjelser kan forårsage en mærkbar "
 "nedsat hastighed."
 
-#: src/olympia/pages/templates/pages/faq.html:236
+#: src/olympia/pages/templates/pages/faq.html:234
 msgid "How do I report an inappropriate or spam user review?"
 msgstr "Hvordan kan jeg rapportere en upassende brugeranmeldelse eller spam?"
 
-#: src/olympia/pages/templates/pages/faq.html:237
+#: src/olympia/pages/templates/pages/faq.html:235
 msgid ""
-"To report a user review of an add-on, log in with your account\n"
-"    and visit the add-on's reviews page. Find the review you wish to report,\n"
-"    click \"Report this review\" and select a reason. Our editorial team will\n"
-"    investigate the review and take appropriate action."
+"To report a user review of an add-on, log in with your account and visit the add-on's reviews page. Find the review you wish to report, click \"Report this review\" and select a reason. Our "
+"editorial team will investigate the review and take appropriate action."
 msgstr ""
 "For at rapportere en brugeranmeldelse af en tilføjelse, skal du logge ind på din konto og gå til tilføjelsens side med anmeldelser. Find den anmeldelse du vil rapportere, klik på \"Rapporter denne "
 "anmeldelse\" og vælg en årsag. Vores redaktion vil undersøge anmeldelsen og træffe passende foranstaltninger."
 
-#: src/olympia/pages/templates/pages/faq.html:242
+#: src/olympia/pages/templates/pages/faq.html:240
 msgid "How do I report a bug or contact the Mozilla Add-ons team?"
 msgstr "Hvordan rapporterer jeg en fejl eller kontakter holdet bag Mozilla-tilføjelser?"
 
-#: src/olympia/pages/templates/pages/faq.html:243
+#: src/olympia/pages/templates/pages/faq.html:241
 #, python-format
 msgid "Please visit our <a href=\"%(contact_url)s\">Contact page</a>."
 msgstr "Besøg vores <a href=\"%(contact_url)s\">kontaktside</a>."
 
-#: src/olympia/pages/templates/pages/faq.html:246
+#: src/olympia/pages/templates/pages/faq.html:244
 msgid "What is a Source Code License?"
 msgstr "Hvad er en licens for kildekode?"
 
-#: src/olympia/pages/templates/pages/faq.html:247
+#: src/olympia/pages/templates/pages/faq.html:245
 #, python-format
 msgid ""
 "The source code used to create an add-on is an exclusive copyright of the add-on author, unless otherwise declared in a source code license. Many add-ons on this site have <a href=\"%(url)s\" lang="
@@ -10371,42 +10211,42 @@ msgstr ""
 "\">open source-licenser</a>, som tillader alle at kopiere og genbruge kildekoden under visse betingelser. De fleste udviklere vælger kendte licenser som GPL eller BSD i stedet for at lave deres "
 "egne licenser."
 
-#: src/olympia/pages/templates/pages/faq.html:256
+#: src/olympia/pages/templates/pages/faq.html:254
 #, python-format
 msgid "Firefox and other Mozilla software are <a href=\"%(url)s\">open source</a>."
 msgstr "Firefox og andre Mozilla-programmer er <a href=\"%(url)s\">open source</a>."
 
-#: src/olympia/pages/templates/pages/faq.html:264
+#: src/olympia/pages/templates/pages/faq.html:262
 msgid "Collections and Favorites"
 msgstr "Samlinger og favoritter"
 
-#: src/olympia/pages/templates/pages/faq.html:267
+#: src/olympia/pages/templates/pages/faq.html:265
 msgid "What is a collection?"
 msgstr "Hvad er en samling?"
 
-#: src/olympia/pages/templates/pages/faq.html:268
+#: src/olympia/pages/templates/pages/faq.html:266
 msgid "Collections are groups of related add-ons created by users to share."
 msgstr "Samlinger er pakker med relaterede tilføjelser, som andre brugere har oprettet for at gøre det nemmere for dig."
 
-#: src/olympia/pages/templates/pages/faq.html:270
+#: src/olympia/pages/templates/pages/faq.html:268
 msgid "What is the My Favorites collection?"
 msgstr "Hvad er Min favoritsamling?"
 
-#: src/olympia/pages/templates/pages/faq.html:271
+#: src/olympia/pages/templates/pages/faq.html:269
 msgid "Favorite add-ons are add-ons that you have bookmarked to easily get back to later. You can add an add-on to your favorites collection by clicking \"Add to favorites\" on its details page."
 msgstr ""
 "Favorittilføjelser er tilføjelser, som du har bogmærket, så du nemt kan vende tilbage til dem senere. Du kan føje en tilføjelse til din favoritsamling ved at klikke på \"Føj til favoritter\" på "
 "dens side med detaljer."
 
-#: src/olympia/pages/templates/pages/faq.html:275 src/olympia/templates/menu_links.html:13 src/olympia/templates/impala/header_title.html:17
+#: src/olympia/pages/templates/pages/faq.html:273 src/olympia/templates/menu_links.html:13 src/olympia/templates/impala/header_title.html:17
 msgid "Mobile Add-ons"
 msgstr "Tilføjelser til Mobilen"
 
-#: src/olympia/pages/templates/pages/faq.html:278
+#: src/olympia/pages/templates/pages/faq.html:276
 msgid "What are mobile add-ons?"
 msgstr "Hvad er tilføjelser til Mobilen?"
 
-#: src/olympia/pages/templates/pages/faq.html:279
+#: src/olympia/pages/templates/pages/faq.html:277
 #, python-format
 msgid ""
 "Mobile add-ons work with <a href=\"%(mobile_url)s\">Firefox for Mobile</a> and add or modify functionality just like desktop add-ons. You can find add-ons that work with Firefox for Mobile in our "
@@ -10415,20 +10255,20 @@ msgstr ""
 "Tilføjelser til Mobilen kan installeres i <a href=\"%(mobile_url)s\">Mobilen</a>. De kan tilføje eller forbedre funktionalitet, ligesom tilføjelser til den almindelige Firefox. Du kan finde "
 "tilføjelser til Mobilen på <a href=\"%(gallery_url)s\">webstedet med Mozillas tilføjelser</a>."
 
-#: src/olympia/pages/templates/pages/faq.html:288
+#: src/olympia/pages/templates/pages/faq.html:286
 msgid "Developer Topics"
 msgstr "For udviklere"
 
-#: src/olympia/pages/templates/pages/faq.html:289
+#: src/olympia/pages/templates/pages/faq.html:287
 #, python-format
 msgid "Please see our <a href=\"%(faq_url)s\">Developer FAQ</a> and <a href=\"%(hub_url)s\">Developer Hub</a> for answers to add-on developer-related questions."
 msgstr "Hvis du som udvikler har spørgsmål om fremstillingen af tilføjelser, så læs vores <a href=\"%(faq_url)s\">OSS for udviklere</a> og <a href=\"%(hub_url)s\">udviklercentral</a>."
 
-#: src/olympia/pages/templates/pages/faq.html:294
+#: src/olympia/pages/templates/pages/faq.html:292
 msgid "Still have questions?"
 msgstr "Har du stadig spørgsmål?"
 
-#: src/olympia/pages/templates/pages/faq.html:295
+#: src/olympia/pages/templates/pages/faq.html:293
 #, python-format
 msgid "For general Firefox support, visit our <a href=\"%(sumo_url)s\">support website</a>. For general add-on and website questions, visit our <a href=\"%(forum_url)s\">forum</a>."
 msgstr ""
@@ -10907,16 +10747,16 @@ msgstr "{0}-tilføjelser"
 
 #. L10n: {0} is an application, such as Firefox. This means "any version of
 #. Firefox."
-#: src/olympia/search/views.py:554
+#: src/olympia/search/views.py:547
 msgid "Any {0}"
 msgstr "Alle versioner af {0}"
 
 #. L10n: "All Systems" means show everything regardless of platform.
-#: src/olympia/search/views.py:589
+#: src/olympia/search/views.py:582
 msgid "All Systems"
 msgstr "Alle systemer"
 
-#: src/olympia/search/views.py:600
+#: src/olympia/search/views.py:593
 msgid "All Tags"
 msgstr "Alle mærkater"
 
@@ -11090,31 +10930,31 @@ msgstr "Del denne tilføjelse"
 msgid "Share this Collection"
 msgstr "Del denne samling"
 
-#: src/olympia/signing/views.py:30 src/olympia/templates/base.html:75 src/olympia/templates/impala/base.html:115
+#: src/olympia/signing/views.py:33 src/olympia/templates/base.html:71 src/olympia/templates/impala/base.html:112
 msgid "Some features are temporarily disabled while we perform website maintenance. We'll be back to full capacity shortly."
 msgstr "Nogle funktioner er midlertidig deaktiveret mens vi udfører vedligholdelse af webstedet. Vi vil være tilbage med fuld kapacitet om kort tid."
 
-#: src/olympia/signing/views.py:53
+#: src/olympia/signing/views.py:56
 msgid "Could not find add-on with id \"{}\"."
 msgstr ""
 
-#: src/olympia/signing/views.py:67
+#: src/olympia/signing/views.py:70
 msgid "You do not own this addon."
 msgstr ""
 
-#: src/olympia/signing/views.py:82
+#: src/olympia/signing/views.py:87
 msgid "Missing \"upload\" key in multipart file data."
 msgstr ""
 
-#: src/olympia/signing/views.py:96
+#: src/olympia/signing/views.py:101
 msgid "Version does not match the manifest file."
 msgstr ""
 
-#: src/olympia/signing/views.py:100
+#: src/olympia/signing/views.py:105
 msgid "Version already exists."
 msgstr ""
 
-#: src/olympia/signing/views.py:136
+#: src/olympia/signing/views.py:141
 msgid "No uploaded file for that addon and version."
 msgstr ""
 
@@ -11227,90 +11067,90 @@ msgstr "{0} :: Statistikpanel"
 msgid "Statistics Dashboard :: Add-ons for {0}"
 msgstr "Statistikpanel :: Tilføjelser til {0}"
 
-#: src/olympia/stats/templates/stats/stats.html:30
-msgid "Controls:"
-msgstr ""
-
-#: src/olympia/stats/templates/stats/stats.html:33
-msgid "reset zoom"
-msgstr "nulstil zoom"
-
-#: src/olympia/stats/templates/stats/stats.html:40
-msgid "Group by:"
-msgstr "Gruppér efter:"
-
-#: src/olympia/stats/templates/stats/stats.html:42
-msgid "day"
-msgstr "dag"
-
-#: src/olympia/stats/templates/stats/stats.html:45
-msgid "week"
-msgstr "uge"
-
-#: src/olympia/stats/templates/stats/stats.html:48
-msgid "month"
-msgstr "måned"
-
-#: src/olympia/stats/templates/stats/stats.html:54
-msgid "For last:"
-msgstr "De seneste:"
-
-#: src/olympia/stats/templates/stats/stats.html:57
-msgid "7 days"
-msgstr "7 dage"
-
-#: src/olympia/stats/templates/stats/stats.html:60
-msgid "30 days"
-msgstr "30 dage"
-
-#: src/olympia/stats/templates/stats/stats.html:63
-msgid "90 days"
-msgstr "90 dage"
-
-#: src/olympia/stats/templates/stats/stats.html:66
-msgid "365 days"
-msgstr "365 dage"
-
-#: src/olympia/stats/templates/stats/stats.html:69
-msgid "Custom..."
-msgstr "Tilpas…"
-
 # %1 is the name of a collection
 #. {0} is an add-on name
-#: src/olympia/stats/templates/stats/stats.html:88 src/olympia/stats/templates/stats/stats.html:91
+#: src/olympia/stats/templates/stats/stats.html:44 src/olympia/stats/templates/stats/stats.html:47
 msgid "Statistics for {0}"
 msgstr "Statistik for {0}"
 
-#: src/olympia/stats/templates/stats/stats.html:94
+#: src/olympia/stats/templates/stats/stats.html:50
 msgid "Statistics Dashboard"
 msgstr "Statistikpanel"
 
-#: src/olympia/stats/templates/stats/stats.html:104
+#: src/olympia/stats/templates/stats/stats.html:57
+msgid "Controls:"
+msgstr ""
+
+#: src/olympia/stats/templates/stats/stats.html:60
+msgid "reset zoom"
+msgstr "nulstil zoom"
+
+#: src/olympia/stats/templates/stats/stats.html:67
+msgid "Group by:"
+msgstr "Gruppér efter:"
+
+#: src/olympia/stats/templates/stats/stats.html:69
+msgid "day"
+msgstr "dag"
+
+#: src/olympia/stats/templates/stats/stats.html:72
+msgid "week"
+msgstr "uge"
+
+#: src/olympia/stats/templates/stats/stats.html:75
+msgid "month"
+msgstr "måned"
+
+#: src/olympia/stats/templates/stats/stats.html:81
+msgid "For last:"
+msgstr "De seneste:"
+
+#: src/olympia/stats/templates/stats/stats.html:84
+msgid "7 days"
+msgstr "7 dage"
+
+#: src/olympia/stats/templates/stats/stats.html:87
+msgid "30 days"
+msgstr "30 dage"
+
+#: src/olympia/stats/templates/stats/stats.html:90
+msgid "90 days"
+msgstr "90 dage"
+
+#: src/olympia/stats/templates/stats/stats.html:93
+msgid "365 days"
+msgstr "365 dage"
+
+#: src/olympia/stats/templates/stats/stats.html:96
+msgid "Custom..."
+msgstr "Tilpas…"
+
+#: src/olympia/stats/templates/stats/stats.html:106
 msgid "Statistics processing is currently disabled, so recent data is unavailable. The statistics are still being collected and this page will be updated soon with the missing data."
 msgstr ""
 
-#: src/olympia/stats/templates/stats/stats.html:110
+#: src/olympia/stats/templates/stats/stats.html:112
 msgid "Loading the latest data&hellip;"
 msgstr "Indlæser de seneste data&hellip;"
 
-#: src/olympia/stats/templates/stats/stats.html:142 src/olympia/stats/templates/stats/reports/overview.html:25 src/olympia/stats/templates/stats/reports/overview.html:37
+#: src/olympia/stats/templates/stats/stats.html:144 src/olympia/stats/templates/stats/reports/overview.html:25 src/olympia/stats/templates/stats/reports/overview.html:37
 #: src/olympia/stats/templates/stats/reports/overview.html:49
 msgid "No data available."
 msgstr "Ingen data tilgængelig."
 
-#: src/olympia/stats/templates/stats/stats.html:177
+#: src/olympia/stats/templates/stats/stats.html:179
 msgid "This dashboard is currently <b>public</b>."
 msgstr "Dette panel er i øjeblikket <b>offentligt</b>."
 
-#: src/olympia/stats/templates/stats/stats.html:179
+#: src/olympia/stats/templates/stats/stats.html:181
 msgid "Contribution stats are currently <b>private</b>."
 msgstr "Bidragsstatistikker er i øjeblikket <b>private</b>."
 
-#: src/olympia/stats/templates/stats/stats.html:182
+#: src/olympia/stats/templates/stats/stats.html:184
 msgid "This dashboard is currently <b>private</b>."
 msgstr "Dette panel er i øjeblikket <b>privat</b>."
 
-#: src/olympia/stats/templates/stats/stats.html:185
+#: src/olympia/stats/templates/stats/stats.html:187
 msgid "Change settings."
 msgstr "Skift indstillinger."
 
@@ -11462,15 +11302,6 @@ msgstr ""
 msgid "Application versions by Date"
 msgstr "Programversioner efter dato"
 
-#: src/olympia/tags/templates/tags/top_cloud.html:4
-msgid "Top {0} Tags"
-msgstr ""
-
-#. {0} is the current application name
-#: src/olympia/tags/templates/tags/top_cloud.html:14
-msgid "{0} Top Tags"
-msgstr "{0} - mest brugte mærkater"
-
 #: src/olympia/templates/amo_footer.html:6 src/olympia/templates/includes/lang_switcher.html:2
 msgid "Other languages"
 msgstr "Andre sprog"
@@ -11479,11 +11310,11 @@ msgstr "Andre sprog"
 msgid "Mozilla Add-ons"
 msgstr "Mozilla-tilføjelser"
 
-#: src/olympia/templates/base.html:91 src/olympia/templates/impala/base.html:81
+#: src/olympia/templates/base.html:89 src/olympia/templates/impala/base.html:78
 msgid "Find add-ons for other applications"
 msgstr "Find tilføjelser til andre programmer"
 
-#: src/olympia/templates/base.html:92 src/olympia/templates/impala/base.html:81
+#: src/olympia/templates/base.html:90 src/olympia/templates/impala/base.html:78
 msgid "Other Applications"
 msgstr "Andre programmer"
 
@@ -11508,7 +11339,7 @@ msgid "View Mobile Site"
 msgstr "Vis mobiludgaven"
 
 #: src/olympia/templates/copyright.html:7
-msgid "Site Status "
+msgid "Site Status"
 msgstr ""
 
 #: src/olympia/templates/footer.html:3
@@ -11610,35 +11441,35 @@ msgstr "Velkommen, {0}"
 msgid "<a href=\"%(reg)s\">Register</a> or <a href=\"%(login)s\">Log in</a>"
 msgstr "<a href=\"%(reg)s\">Registrer dig</a> eller <a href=\"%(login)s\">Log ind</a>"
 
-#: src/olympia/templates/impala/base.html:126
+#: src/olympia/templates/impala/base.html:123
 #, python-format
 msgid "To try the thousands of add-ons available here, download <a href=\"%(url)s\">Mozilla Firefox</a>, a fast, free way to surf the Web!"
 msgstr "Hvis du vil prøve de tusindvis af tilføjelser der er tilgængelige her, hent <a href=\"%(url)s\">Mozilla Firefox</a>, en hurtig, gratis måde at surfe på nettet!"
 
-#: src/olympia/templates/impala/base.html:138
+#: src/olympia/templates/impala/base.html:135
 #, python-format
 msgid "Add-ons is switching to Firefox Accounts for login. <a href=\"%(url)s\" class=\"fxa-login\">Sign in now to transfer your account.</a>"
 msgstr "Tilføjelser skifter til Firefox-konti til login. <a href=\"%(url)s\" class=\"fxa-login\">Log ind nu for at overføre din konto.</a>"
 
 #. {0} is an application, such as Firefox.
-#: src/olympia/templates/impala/base.html:148
+#: src/olympia/templates/impala/base.html:145
 msgid "Welcome to {0} Add-ons."
 msgstr "Velkommen til tilføjelser til {0}."
 
-#: src/olympia/templates/impala/base.html:151
+#: src/olympia/templates/impala/base.html:148
 msgid "Choose from thousands of extra features and styles to make Firefox your own."
 msgstr "Vælg mellem tusindvis af yderligere funktioner og temaer, som kan gøre Firefox til din egen."
 
-#: src/olympia/templates/impala/base.html:156
+#: src/olympia/templates/impala/base.html:153
 #, python-format
 msgid "Add extra features and styles to make %(app)s your own."
 msgstr "Tilføj yderligere funktioner og temaer for at gøre %(app)s til din helt egen."
 
-#: src/olympia/templates/impala/base.html:164
+#: src/olympia/templates/impala/base.html:161
 msgid "On the go?"
 msgstr "På farten?"
 
-#: src/olympia/templates/impala/base.html:166
+#: src/olympia/templates/impala/base.html:163
 msgid "Check out our <a class=\"mobile-link\" href=\"#\">Mobile Add-ons site</a>."
 msgstr "Tjek vores <a class=\"mobile-link\" href=\"#\">tilføjelsesside til Mobilen</a>."
 
@@ -11863,19 +11694,19 @@ msgstr "Ingen bruger med denne mailadresse."
 
 #. L10n: {id} will be something like "13ad6a", just a random number
 #. to differentiate this user from other anonymous users.
-#: src/olympia/users/models.py:353
+#: src/olympia/users/models.py:362
 msgid "Anonymous user {id}"
 msgstr ""
 
-#: src/olympia/users/models.py:410
+#: src/olympia/users/models.py:419
 msgid "Your account has been restricted"
 msgstr "Din konto er blevet begrænset"
 
-#: src/olympia/users/models.py:480
+#: src/olympia/users/models.py:489
 msgid "Please confirm your email address"
 msgstr "Bekræft din mailadresse"
 
-#: src/olympia/users/models.py:506
+#: src/olympia/users/models.py:515
 msgid "My Mobile Add-ons"
 msgstr "Mine tilføjelser til Mobilen"
 
@@ -12157,7 +11988,7 @@ msgstr "Adgangskode"
 
 #: src/olympia/users/templates/users/edit.html:70
 #, python-format
-msgid "Change your password.  If you forgot your password, you can <a href=\"%(reset_url)s\">use the reset form</a>."
+msgid "Change your password. If you forgot your password, you can <a href=\"%(reset_url)s\">use the reset form</a>."
 msgstr "Skift din adgangskode. Hvis du har glemt din adgangskode, kan du <a href=\"%(reset_url)s\">bruge nulstillingsformularen</a>."
 
 #: src/olympia/users/templates/users/edit.html:76
@@ -12177,7 +12008,7 @@ msgid "Profile"
 msgstr "Profil"
 
 #: src/olympia/users/templates/users/edit.html:100
-msgid "Give us a bit more information about yourself.  All these fields are optional, but they'll help other users get to know you better."
+msgid "Give us a bit more information about yourself. All these fields are optional, but they'll help other users get to know you better."
 msgstr "Skriv lidt mere om dig selv. Alle disse felter er valgfrie, men de vil hjælpe andre med at lære dig bedre at kende."
 
 #: src/olympia/users/templates/users/edit.html:124
@@ -12397,7 +12228,7 @@ msgid "Confirm password"
 msgstr "Bekræft adgangskode"
 
 #: src/olympia/users/templates/users/pwreset_confirm.html:47
-msgid "The password reset link was invalid, possibly because it has already been used.  Please request a new password reset."
+msgid "The password reset link was invalid, possibly because it has already been used. Please request a new password reset."
 msgstr "Linket til nulstilling af adgangskode er ugyldigt, muligvis fordi det allerede er blevet anvendt. Bed om en nye nulstilling af adgangskode."
 
 #: src/olympia/users/templates/users/pwreset_request.html:15
@@ -12639,15 +12470,15 @@ msgstr "%s versionshistorik"
 msgid "Version History with Changelogs"
 msgstr "Versionshistorik med beskrivelse af ændringer"
 
-#: src/olympia/versions/models.py:314
+#: src/olympia/versions/models.py:313
 msgid "Add-on uses binary components."
 msgstr ""
 
-#: src/olympia/versions/models.py:317
+#: src/olympia/versions/models.py:316
 msgid "Add-on has opted into strict compatibility checking."
 msgstr ""
 
-#: src/olympia/versions/models.py:715
+#: src/olympia/versions/models.py:711
 msgid "{app} {min} and later"
 msgstr "{app} {min} og nyere"
 
@@ -12723,4 +12554,8 @@ msgstr ""
 
 #: src/olympia/zadmin/forms.py:105
 msgid "Log emails instead of sending"
+msgstr ""
+
+#: src/olympia/zadmin/forms.py:215
+msgid "Deleted versions can`t be changed."
 msgstr ""

--- a/locale/da/LC_MESSAGES/djangojs.po
+++ b/locale/da/LC_MESSAGES/djangojs.po
@@ -3,1213 +3,1234 @@ msgid ""
 msgstr ""
 "Project-Id-Version:  Ad-dons\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2016-02-24 21:23+0000\n"
+"POT-Creation-Date: 2016-04-18 15:47+0000\n"
 "PO-Revision-Date: 2016-03-20 16:03+0000\n"
 "Last-Translator: joergenr <joergenr@stofanet.dk>\n"
 "Language-Team: MozillaDanmark <joergenr@stofanet.dk>\n"
+"Language: \n"
 "MIME-Version: 1.0\n"
-"Content-Type: text/plain; charset=utf-8\n"
+"Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Generated-By: Babel 2.2.0\n"
 
-#: static/js/common/ratingwidget.js:31
-msgid "{0} star"
-msgid_plural "{0} stars"
-msgstr[0] "{0} stjerne"
-msgstr[1] "{0} stjerner"
-
-#: static/js/common/upload-addon.js:41 static/js/common/upload-image.js:128
-msgid "There was a problem contacting the server."
-msgstr "Der opstod et problem med at kontakte serveren."
-
-#: static/js/common/upload-addon.js:69
-msgid "Select a file..."
-msgstr "Vælg en fil..."
-
-#: static/js/common/upload-addon.js:70
-msgid "Your add-on should end with .xpi, .jar or .xml"
-msgstr ""
-
-#. L10n: {0} is the percent of the file that has been uploaded.
-#: static/js/common/upload-addon.js:104
-#, python-format
-msgid "{0}% complete"
-msgstr "{0}% fuldført"
-
-#. L10n: "{bytes uploaded} of {total filesize}".
-#: static/js/common/upload-addon.js:107
-msgid "{0} of {1}"
-msgstr "{0} af {1}"
-
-#: static/js/common/upload-addon.js:140
-msgid "Cancel"
-msgstr "Annuller"
-
-#: static/js/common/upload-addon.js:162
-msgid "Uploading {0}"
-msgstr "Uploader {0}"
-
-#: static/js/common/upload-addon.js:189
-msgid "Error with {0}"
-msgstr ""
-
-#: static/js/common/upload-addon.js:194
-msgid "Your add-on failed validation with {0} error."
-msgid_plural "Your add-on failed validation with {0} errors."
-msgstr[0] ""
-msgstr[1] ""
-
-#: static/js/common/upload-addon.js:208
-msgid "&hellip;and {0} more"
-msgid_plural "&hellip;and {0} more"
-msgstr[0] ""
-msgstr[1] ""
-
-#: static/js/common/upload-addon.js:222 static/js/common/upload-addon.js:512
-msgid "See full validation report"
-msgstr ""
-
-#: static/js/common/upload-addon.js:234
-msgid "Validating {0}"
-msgstr ""
-
-#. L10n: first argument is an HTTP status code
-#: static/js/common/upload-addon.js:273
-msgid "Received an empty response from the server; status: {0}"
-msgstr ""
-
-#: static/js/common/upload-addon.js:373
-msgid "Unexpected server error while validating."
-msgstr ""
-
-#: static/js/common/upload-addon.js:412
-msgid "Finished validating {0}"
-msgstr ""
-
-#: static/js/common/upload-addon.js:418
-msgid "Your add-on validation timed out, it will be manually reviewed."
-msgstr ""
-
-#: static/js/common/upload-addon.js:421
-msgid "Your add-on was validated with no errors and {0} warning."
-msgid_plural "Your add-on was validated with no errors and {0} warnings."
-msgstr[0] ""
-msgstr[1] ""
-
-#: static/js/common/upload-addon.js:426
-msgid "Your add-on was validated with no errors and {0} message."
-msgid_plural "Your add-on was validated with no errors and {0} messages."
-msgstr[0] ""
-msgstr[1] ""
-
-#: static/js/common/upload-addon.js:431
-msgid "Your add-on was validated with no errors or warnings."
-msgstr ""
-
-#: static/js/common/upload-addon.js:446
-msgid "Your submission will be automatically signed."
-msgstr ""
-
-#: static/js/common/upload-addon.js:465
-msgid "Include detailed version notes (this can be done in the next step)."
-msgstr ""
-
-#: static/js/common/upload-addon.js:466
-msgid "If your add-on requires an account to a website in order to be fully tested, include a test username and password in the Notes to Reviewer (this can be done in the next step)."
-msgstr ""
-
-#: static/js/common/upload-addon.js:467
-msgid "If your add-on is intended for a limited audience you should choose Preliminary Review instead of Full Review."
-msgstr ""
-
-#: static/js/common/upload-addon.js:480
-msgid "Add-on submission checklist"
-msgstr ""
-
-#: static/js/common/upload-addon.js:481
-msgid "Please verify the following points before finalizing your submission. This will minimize delays or misunderstanding during the review process:"
-msgstr ""
-
-#: static/js/common/upload-addon.js:483
-msgid ""
-"Compiled binaries, as well as minified or obfuscated scripts (excluding known libraries) need to have their sources submitted separately for review. Make sure that you use the source code upload "
-"field to avoid having your submission rejected."
-msgstr ""
-
-#: static/js/common/upload-addon.js:501
-msgid "The validation process found these issues that can lead to rejections:"
-msgstr ""
-
-#: static/js/common/upload-addon.js:518
-msgid "If you are unfamiliar with the add-ons review process, you can read about it here."
-msgstr ""
-
-#: static/js/common/upload-addon.js:555
-msgid "Sorry, no supported platform has been found."
-msgstr ""
-
-#: static/js/common/upload-base.js:57
-msgid "The filetype you uploaded isn't recognized."
-msgstr ""
-
-#: static/js/common/upload-base.js:79
-msgid "You cancelled the upload."
-msgstr ""
-
-#: static/js/common/upload-image.js:97 static/js/impala/users.js:51
-msgid "Images must be either PNG or JPG."
-msgstr "Billeder skal enten være PNG eller JPG."
-
-#: static/js/common/upload-image.js:101
-msgid "Videos must be in WebM."
-msgstr ""
-
-#: static/js/impala/collections.js:10 static/js/zamboni/collections.js:595
-msgid "Follow this Collection"
-msgstr "Følg denne samling"
-
-#: static/js/impala/collections.js:19
-msgid "Stop Following"
-msgstr "Stop med at følge"
-
-#: static/js/impala/collections.js:20
-msgid "Following"
-msgstr "Følg"
-
-#. L10n: {0} is an app name.
-#: static/js/impala/listing.js:11 static/js/zamboni/themes.js:13
-msgid "This theme is incompatible with your version of {0}"
-msgstr "Dette tema er ikke kompatibelt med din version af {0}"
-
-#: static/js/impala/persona_creation.js:60
-msgid "All Rights Reserved"
-msgstr "Alle rettigheder forbeholdes"
-
-#: static/js/impala/persona_creation.js:64
-msgid "Creative Commons Attribution 3.0"
-msgstr "Creative Commons Attribution 3.0"
-
-#: static/js/impala/persona_creation.js:69
-msgid "Creative Commons Attribution-NonCommercial 3.0"
-msgstr "Creative Commons Attribution-NonCommercial 3.0"
-
-#: static/js/impala/persona_creation.js:74
-msgid "Creative Commons Attribution-NonCommercial-NoDerivs 3.0"
-msgstr "Creative Commons Attribution-NonCommercial-NoDerivs 3.0"
-
-#: static/js/impala/persona_creation.js:79
-msgid "Creative Commons Attribution-NonCommercial-Share Alike 3.0"
-msgstr "Creative Commons Attribution-NonCommercial-Share Alike 3.0"
-
-#: static/js/impala/persona_creation.js:84
-msgid "Creative Commons Attribution-NoDerivs 3.0"
-msgstr "Creative Commons Attribution-NoDerivs 3.0"
-
-#: static/js/impala/persona_creation.js:89
-msgid "Creative Commons Attribution-ShareAlike 3.0"
-msgstr "Creative Commons Attribution-ShareAlike 3.0"
-
-#: static/js/impala/persona_creation.js:292
-msgid "Your Theme's Name"
-msgstr "Dit temas navn"
-
-#: static/js/impala/reviews.js:23 static/js/zamboni/reviews.js:18
-msgid "Flagged for review"
-msgstr ""
-
-#: static/js/impala/reviews.js:40 static/js/zamboni/reviews.js:34
-msgid "Your input is required"
-msgstr "Dit input er påkrævet"
-
-#: static/js/impala/reviews.js:152 static/js/zamboni/reviews.js:103
-msgid "Marked for deletion"
-msgstr "Markeret til sletning"
-
-#: static/js/impala/search.js:114
-msgid "Updating results&hellip;"
-msgstr "Opdaterer resultater&hellip;"
-
-#: static/js/impala/site_suggestions.js:46
-msgid "Category"
-msgstr "Kategori"
-
-#: static/js/impala/suggestions.js:39
-msgid "Search themes for <b>{0}</b>"
-msgstr "Søg i temaer efter <b>{0}</b>"
-
-#: static/js/impala/suggestions.js:41
-msgid "Search apps for <b>{0}</b>"
-msgstr "Søg i apps efter <b>{0}</b>"
-
-#: static/js/impala/suggestions.js:43
-msgid "Search add-ons for <b>{0}</b>"
-msgstr "Søg i tilføjelser efter <b>{0}</b>"
-
-#: static/js/impala/users.js:33
-msgid "use original"
-msgstr ""
-
-#: static/js/impala/stats/chart.js:267
-msgid "Week of {0}"
-msgstr "Uge {0}"
-
-#: static/js/impala/stats/chart.js:269
-msgid " downloads"
-msgstr " downloads"
-
-#: static/js/impala/stats/chart.js:270
-msgid "{0} users"
-msgstr "{0} brugere"
-
-#: static/js/impala/stats/chart.js:271
-msgid "{0} add-ons"
-msgstr "{0} tilføjelser"
-
-#: static/js/impala/stats/chart.js:272
-msgid "{0} collections"
-msgstr "{0} samlinger"
-
-#: static/js/impala/stats/chart.js:273
-msgid "{0} reviews"
-msgstr "{0} anmeldelser"
-
-#: static/js/impala/stats/chart.js:275
-msgid "{0} sales"
-msgstr "{0} salg"
-
-#: static/js/impala/stats/chart.js:276
-msgid "{0} refunds"
-msgstr "{0} refunderinger"
-
-#: static/js/impala/stats/chart.js:277
-msgid "{0} installs"
-msgstr "{0} installeringer"
-
-#: static/js/impala/stats/chart.js:369 static/js/impala/stats/csv_keys.js:3 static/js/impala/stats/csv_keys.js:109
-msgid "Downloads"
-msgstr "Downloads"
-
-#: static/js/impala/stats/chart.js:379 static/js/impala/stats/csv_keys.js:6 static/js/impala/stats/csv_keys.js:110
-msgid "Daily Users"
-msgstr "Daglige brugere"
-
-#: static/js/impala/stats/chart.js:410
-msgid "Amount, in USD"
-msgstr "Beløb i USD"
-
-#: static/js/impala/stats/chart.js:421 static/js/impala/stats/csv_keys.js:104
-msgid "Number of Contributions"
-msgstr "Antal bidrag"
-
-#: static/js/impala/stats/chart.js:447
-msgid "More Info..."
-msgstr "Mere info..."
-
-#. L10n: {0} is an ISO-formatted date.
-#: static/js/impala/stats/chart.js:451
-msgid "Details for {0}"
-msgstr "Detaljer for {0}"
-
-#: static/js/impala/stats/csv_keys.js:9
-msgid "Collections Created"
-msgstr "Samling oprettet"
-
-#: static/js/impala/stats/csv_keys.js:12
-msgid "Add-ons in Use"
-msgstr ""
-
-#: static/js/impala/stats/csv_keys.js:15
-msgid "Add-ons Created"
-msgstr ""
-
-#: static/js/impala/stats/csv_keys.js:18
-msgid "Add-ons Downloaded"
-msgstr ""
-
-#: static/js/impala/stats/csv_keys.js:21
-msgid "Add-ons Updated"
-msgstr ""
-
-#: static/js/impala/stats/csv_keys.js:24
-msgid "Reviews Written"
-msgstr ""
-
-#: static/js/impala/stats/csv_keys.js:27
-msgid "User Signups"
-msgstr ""
-
-#: static/js/impala/stats/csv_keys.js:30
-msgid "Subscribers"
-msgstr "Abonnenter"
-
-#: static/js/impala/stats/csv_keys.js:33
-msgid "Ratings"
-msgstr "Bedømmelser"
-
-#: static/js/impala/stats/csv_keys.js:36 static/js/impala/stats/csv_keys.js:114
-msgid "Sales"
-msgstr "Salg"
-
-#: static/js/impala/stats/csv_keys.js:39 static/js/impala/stats/csv_keys.js:113
-msgid "Installs"
-msgstr "Installeringer"
-
-#: static/js/impala/stats/csv_keys.js:42
-msgid "Unknown"
-msgstr "Ukendt"
-
-#: static/js/impala/stats/csv_keys.js:43
-msgid "Add-ons Manager"
-msgstr "Fanebladet Tilføjelser"
-
-#: static/js/impala/stats/csv_keys.js:44
-msgid "Add-ons Manager Promo"
-msgstr ""
-
-#: static/js/impala/stats/csv_keys.js:45
-msgid "Add-ons Manager Featured"
-msgstr ""
-
-#: static/js/impala/stats/csv_keys.js:46
-msgid "Add-ons Manager Learn More"
-msgstr ""
-
-#: static/js/impala/stats/csv_keys.js:47
-msgid "Search Suggestions"
-msgstr ""
-
-#: static/js/impala/stats/csv_keys.js:48
-msgid "Search Results"
-msgstr "Søgeresultater"
-
-#: static/js/impala/stats/csv_keys.js:49 static/js/impala/stats/csv_keys.js:50 static/js/impala/stats/csv_keys.js:51
-msgid "Homepage Promo"
-msgstr ""
-
-#: static/js/impala/stats/csv_keys.js:52 static/js/impala/stats/csv_keys.js:53
-msgid "Homepage Featured"
-msgstr ""
-
-#: static/js/impala/stats/csv_keys.js:54 static/js/impala/stats/csv_keys.js:55
-msgid "Homepage Up and Coming"
-msgstr ""
-
-#: static/js/impala/stats/csv_keys.js:56
-msgid "Homepage Most Popular"
-msgstr ""
-
-#: static/js/impala/stats/csv_keys.js:57 static/js/impala/stats/csv_keys.js:59
-msgid "Detail Page"
-msgstr ""
-
-#: static/js/impala/stats/csv_keys.js:58 static/js/impala/stats/csv_keys.js:60
-msgid "Detail Page (bottom)"
-msgstr ""
-
-#: static/js/impala/stats/csv_keys.js:61
-msgid "Detail Page (Development Channel)"
-msgstr ""
-
-#: static/js/impala/stats/csv_keys.js:62 static/js/impala/stats/csv_keys.js:63 static/js/impala/stats/csv_keys.js:64
-msgid "Often Used With"
-msgstr "Ofte anvendt sammen med"
-
-#: static/js/impala/stats/csv_keys.js:65 static/js/impala/stats/csv_keys.js:66
-msgid "Others By Author"
-msgstr "Andre af udvikleren"
-
-#: static/js/impala/stats/csv_keys.js:67 static/js/impala/stats/csv_keys.js:68
-msgid "Dependencies"
-msgstr ""
-
-#: static/js/impala/stats/csv_keys.js:69 static/js/impala/stats/csv_keys.js:70
-msgid "Upsell"
-msgstr ""
-
-#: static/js/impala/stats/csv_keys.js:71
-msgid "Meet the Developer"
-msgstr ""
-
-#: static/js/impala/stats/csv_keys.js:72
-msgid "User Profile"
-msgstr ""
-
-#: static/js/impala/stats/csv_keys.js:73
-msgid "Version History"
-msgstr ""
-
-#: static/js/impala/stats/csv_keys.js:75
-msgid "Sharing"
-msgstr ""
-
-#: static/js/impala/stats/csv_keys.js:76
-msgid "Category Pages"
-msgstr ""
-
-#: static/js/impala/stats/csv_keys.js:77
-msgid "Collections"
-msgstr "Samlinger"
-
-#: static/js/impala/stats/csv_keys.js:78 static/js/impala/stats/csv_keys.js:79
-msgid "Category Landing Featured Carousel"
-msgstr ""
-
-#: static/js/impala/stats/csv_keys.js:80 static/js/impala/stats/csv_keys.js:81
-msgid "Category Landing Top Rated"
-msgstr ""
-
-#: static/js/impala/stats/csv_keys.js:82 static/js/impala/stats/csv_keys.js:83
-msgid "Category Landing Most Popular"
-msgstr ""
-
-#: static/js/impala/stats/csv_keys.js:84 static/js/impala/stats/csv_keys.js:85
-msgid "Category Landing Recently Added"
-msgstr ""
-
-#: static/js/impala/stats/csv_keys.js:86 static/js/impala/stats/csv_keys.js:87
-msgid "Browse Listing Featured Sort"
-msgstr ""
-
-#: static/js/impala/stats/csv_keys.js:88 static/js/impala/stats/csv_keys.js:89
-msgid "Browse Listing Users Sort"
-msgstr ""
-
-#: static/js/impala/stats/csv_keys.js:90 static/js/impala/stats/csv_keys.js:91
-msgid "Browse Listing Rating Sort"
-msgstr ""
-
-#: static/js/impala/stats/csv_keys.js:92 static/js/impala/stats/csv_keys.js:93
-msgid "Browse Listing Created Sort"
-msgstr ""
-
-#: static/js/impala/stats/csv_keys.js:94 static/js/impala/stats/csv_keys.js:95
-msgid "Browse Listing Name Sort"
-msgstr ""
-
-#: static/js/impala/stats/csv_keys.js:96 static/js/impala/stats/csv_keys.js:97
-msgid "Browse Listing Popular Sort"
-msgstr ""
-
-#: static/js/impala/stats/csv_keys.js:98 static/js/impala/stats/csv_keys.js:99
-msgid "Browse Listing Updated Sort"
-msgstr ""
-
-#: static/js/impala/stats/csv_keys.js:100 static/js/impala/stats/csv_keys.js:101
-msgid "Browse Listing Up and Coming Sort"
-msgstr ""
-
-#: static/js/impala/stats/csv_keys.js:105
-msgid "Total Amount Contributed"
-msgstr "Samlet beløb bidraget"
-
-#: static/js/impala/stats/csv_keys.js:106
-msgid "Average Contribution"
-msgstr "Gennemsnitligt bidrag"
-
-#: static/js/impala/stats/csv_keys.js:115
-msgid "Usage"
-msgstr "Brug"
-
-#: static/js/impala/stats/csv_keys.js:118
-msgid "Firefox"
-msgstr "Firefox"
-
-#: static/js/impala/stats/csv_keys.js:119
-msgid "Mozilla"
-msgstr "Mozilla"
-
-#: static/js/impala/stats/csv_keys.js:120
-msgid "Thunderbird"
-msgstr "Thunderbird"
-
-#: static/js/impala/stats/csv_keys.js:121
-msgid "Sunbird"
-msgstr "Sunbird"
-
-#: static/js/impala/stats/csv_keys.js:122
-msgid "SeaMonkey"
-msgstr "SeaMonkey"
-
-#: static/js/impala/stats/csv_keys.js:123
-msgid "Fennec"
-msgstr "Mobilen"
-
-#: static/js/impala/stats/csv_keys.js:124
-msgid "Android"
-msgstr "Android"
-
-#. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:129
-msgid "Downloads and Daily Users, last {0} days"
-msgstr "Downloads og daglige brugere, de seneste {0} dage"
-
-#. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:131
-msgid "Downloads and Daily Users from {0} to {1}"
-msgstr "Downloads and og daglige brugere fra {0} til {1}"
-
-#. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:135
-msgid "Installs and Daily Users, last {0} days"
-msgstr "Installeringer og daglige brugere, de seneste {0} dage"
-
-#. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:137
-msgid "Installs and Daily Users from {0} to {1}"
-msgstr "Installeringer og daglige brugere fra den {0} til den {1}"
-
-#. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:141
-msgid "Downloads, last {0} days"
-msgstr "Downloads, de seneste {0} dage"
-
-#. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:143
-msgid "Downloads from {0} to {1}"
-msgstr "Downloads fra {0} til {1}"
-
-#. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:147
-msgid "Daily Users, last {0} days"
-msgstr "Daglige brugere, de seneste {0} dage"
-
-#. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:149
-msgid "Daily Users from {0} to {1}"
-msgstr "Daglige brugere fra {0} til {1}"
-
-#. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:153
-msgid "Applications, last {0} days"
-msgstr "Programmer, de seneste {0} dage"
-
-#. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:155
-msgid "Applications from {0} to {1}"
-msgstr "Programmer fra {0} til {1}"
-
-#. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:159
-msgid "Platforms, last {0} days"
-msgstr "Platforme, de seneste {0} dage"
-
-#. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:161
-msgid "Platforms from {0} to {1}"
-msgstr "Platforme fra {0} til {1}"
-
-#. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:165
-msgid "Languages, last {0} days"
-msgstr "Sprog, de seneste {0} dage"
-
-#. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:167
-msgid "Languages from {0} to {1}"
-msgstr "Sprog fra {0} til {1}"
-
-#. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:171
-msgid "Add-on Versions, last {0} days"
-msgstr "Versioner, de seneste {0} dage"
-
-#. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:173
-msgid "Add-on Versions from {0} to {1}"
-msgstr "Versioner fra {0} til {1}"
-
-#. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:177
-msgid "Add-on Status, last {0} days"
-msgstr "Status, de seneste {0} dage"
-
-#. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:179
-msgid "Add-on Status from {0} to {1}"
-msgstr "Status fra {0} til {1}"
-
-#. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:183
-msgid "Download Sources, last {0} days"
-msgstr "Download-kilder, de seneste {0} dage"
-
-#. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:185
-msgid "Download Sources from {0} to {1}"
-msgstr "Download-kilder fra {0} til {1}"
-
-#. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:189
-msgid "Contributions, last {0} days"
-msgstr "Bidrag, de seneste {0} dage"
-
-#. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:191
-msgid "Contributions from {0} to {1}"
-msgstr "Bidrag fra {0} til {1}"
-
-#. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:195
-msgid "Site Metrics, last {0} days"
-msgstr "Webstedsmålinger, de seneste {0} dage"
-
-#. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:197
-msgid "Site Metrics from {0} to {1}"
-msgstr "Webstedsmålinger fra den {0} til den {1}"
-
-#. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:201
-msgid "Add-ons in Use, last {0} days"
-msgstr "Tilføjelser i brug, de seneste {0} dage"
-
-#. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:203
-msgid "Add-ons in Use from {0} to {1}"
-msgstr "Tilføjelser i brug fra den {0} til den {1}"
-
-#. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:207
-msgid "Add-ons Downloaded, last {0} days"
-msgstr "Tilføjelser downloaded, de seneste {0} dage"
-
-#. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:209
-msgid "Add-ons Downloaded from {0} to {1}"
-msgstr "Tilføjelser downloaded fra den {0} til den {1}"
-
-#. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:213
-msgid "Add-ons Created, last {0} days"
-msgstr "Tilføjelser lavet, de seneste {0} dage"
-
-#. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:215
-msgid "Add-ons Created from {0} to {1}"
-msgstr "Tilføjelser lavet fra den {0} til den {1}"
-
-#. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:219
-msgid "Add-ons Updated, last {0} days"
-msgstr "Tilføjelser opdateret"
-
-#. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:221
-msgid "Add-ons Updated from {0} to {1}"
-msgstr "Tilføjelser opdateret fra den {0} til den {1}"
-
-#. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:225
-msgid "Reviews Written, last {0} days"
-msgstr "Anmeldelser skrevet, de seneste {0} dage"
-
-#. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:227
-msgid "Reviews Written from {0} to {1}"
-msgstr "Anmeldelser skrevet fra den {0} til den {1}"
-
-#. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:231
-msgid "User Signups, last {0} days"
-msgstr ""
-
-#. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:233
-msgid "User Signups from {0} to {1}"
-msgstr ""
-
-#. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:237
-msgid "Collections Created, last {0} days"
-msgstr "Samlinger oprettet, de seneste {0} dage"
-
-#. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:239
-msgid "Collections Created from {0} to {1}"
-msgstr "Samlinger oprettet far den {0} til den {1}"
-
-#. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:243
-msgid "Subscribers, last {0} days"
-msgstr "Abonnenter, de seneste {0} dage"
-
-#. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:245
-msgid "Subscribers from {0} to {1}"
-msgstr ""
-
-#. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:249
-msgid "Ratings, last {0} days"
-msgstr "Bedømmelser, de seneste {0} dage"
-
-#. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:251
-msgid "Ratings from {0} to {1}"
-msgstr "Bedømmelser fra den {0} til den {1}"
-
-#. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:255
-msgid "Sales, last {0} days"
-msgstr "Salg, de seneste {0} dage"
-
-#. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:257
-msgid "Sales from {0} to {1}"
-msgstr "Salg fra den {0} til den {1}"
-
-#. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:261
-msgid "Installs, last {0} days"
-msgstr "Installeringer, de seneste {0} dage"
-
-#. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:263
-msgid "Installs from {0} to {1}"
-msgstr "Installeringer fra den {0} til den {1}"
-
-#. L10n: {0} and {1} are integers.
-#: static/js/impala/stats/csv_keys.js:269
-msgid "<b>{0}</b> in last {1} days"
-msgstr "<b>{0}</b> i de seneste {1} dage"
-
-#. L10n: {0} is an integer and {1} and {2} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:271 static/js/impala/stats/csv_keys.js:277
-msgid "<b>{0}</b> from {1} to {2}"
-msgstr "<b>{0}</b> fra {1} til {2}"
-
-#. L10n: {0} and {1} are integers.
-#: static/js/impala/stats/csv_keys.js:275
-msgid "<b>{0}</b> average in last {1} days"
-msgstr "<b>{0}</b> i genemsnit i de seneste {1} dage"
-
-#: static/js/impala/stats/overview.js:19
-msgid "No data available."
-msgstr "Ingen data tilgængelig."
-
-#: static/js/impala/stats/table.js:74
-msgid "Date"
-msgstr "Dato"
-
-#: static/js/impala/stats/topchart.js:96
-msgid "Other"
-msgstr "Andre"
-
-#: static/js/zamboni/admin_validation.js:24 static/js/zamboni/devhub.js:1229 static/js/zamboni/editors.js:295
-msgid "Select an application first"
-msgstr "Vælg et program først"
-
-#: static/js/zamboni/admin_validation.js:51
-msgid "Set {0} add-on to a max version of {1} and email the author."
-msgid_plural "Set {0} add-ons to a max version of {1} and email the authors."
-msgstr[0] ""
-msgstr[1] ""
-
-#: static/js/zamboni/admin_validation.js:54
-msgid "Email author of {2} add-on which failed validation."
-msgid_plural "Email authors of {2} add-ons which failed validation."
-msgstr[0] ""
-msgstr[1] ""
+#: static/js/common-all.js:1426 static/js/impala-all.js:1511 static/js/zamboni/discovery-all.js:12598 static/js/zamboni/init.js:28 static/js/zamboni/mobile-all.js:14945
+msgid "This feature is temporarily disabled while we perform website maintenance. Please check back a little later."
+msgstr "Denne funktion er midlertidig ude af drift mens vi udfører vedligeholdelse af webstedet. Prøv igen lidt senere."
 
 #. L10n: {0} is an app name like Firefox.
-#: static/js/zamboni/buttons.js:66
+#: static/js/common-all.js:1837 static/js/impala-all.js:1922 static/js/zamboni/buttons.js:73 static/js/zamboni/discovery-all.js:13108
 msgid "Accept and Install"
 msgstr "Accepter og installer"
 
-#: static/js/zamboni/buttons.js:66
+#: static/js/common-all.js:1837 static/js/impala-all.js:1922 static/js/zamboni/buttons.js:73 static/js/zamboni/discovery-all.js:13108
 msgid "Add to {0}"
 msgstr "Føj til {0}"
 
-#: static/js/zamboni/buttons.js:71
+#: static/js/common-all.js:1842 static/js/impala-all.js:1927 static/js/zamboni/buttons.js:78 static/js/zamboni/discovery-all.js:13113
 msgid "Download Now"
 msgstr "Download nu"
 
-#: static/js/zamboni/buttons.js:112
+#: static/js/common-all.js:1883 static/js/impala-all.js:1968 static/js/zamboni/buttons.js:119 static/js/zamboni/discovery-all.js:13154
 msgid "Add-on has not been updated to support default-to-compatible."
 msgstr ""
 
-#: static/js/zamboni/buttons.js:117
+#: static/js/common-all.js:1888 static/js/impala-all.js:1973 static/js/zamboni/buttons.js:124 static/js/zamboni/discovery-all.js:13159
 msgid "You need to be using Firefox 10.0 or higher."
 msgstr "Du nødt til at bruge Firefox 10.0 eller højere."
 
-#: static/js/zamboni/buttons.js:129
+#: static/js/common-all.js:1900 static/js/impala-all.js:1985 static/js/zamboni/buttons.js:136 static/js/zamboni/discovery-all.js:13171
 msgid "Mozilla has marked this version as incompatible with your Firefox version."
 msgstr "Mozilla har markeret denne version som værende inkompatibel med din Firefox-version."
 
 #. L10n: {0} is an platform like Windows or Linux.
-#: static/js/zamboni/buttons.js:210
+#: static/js/common-all.js:1981 static/js/impala-all.js:2066 static/js/zamboni/buttons.js:217 static/js/zamboni/discovery-all.js:13252
 msgid "Install for {0} anyway"
 msgstr "Installer til {0} alligevel"
 
-#: static/js/zamboni/buttons.js:210
+#: static/js/common-all.js:1981 static/js/impala-all.js:2066 static/js/zamboni/buttons.js:217 static/js/zamboni/discovery-all.js:13252
 msgid "Download for {0} anyway"
 msgstr "Download til {0} alligevel"
 
-#: static/js/zamboni/buttons.js:267
+#: static/js/common-all.js:2038 static/js/impala-all.js:2123 static/js/zamboni/buttons.js:274 static/js/zamboni/discovery-all.js:13309
 msgid "Not available for your platform"
 msgstr "Er ikke tilgængelig til din platform"
 
 #. L10n: {0} is an app name, {1} is the app version.
-#: static/js/zamboni/buttons.js:278 static/js/zamboni/buttons.js:315
+#: static/js/common-all.js:2049 static/js/common-all.js:2086 static/js/impala-all.js:2134 static/js/impala-all.js:2171 static/js/zamboni/buttons.js:286 static/js/zamboni/buttons.js:324
+#: static/js/zamboni/discovery-all.js:13320 static/js/zamboni/discovery-all.js:13357
 msgid "Not available for {0} {1}"
 msgstr "Er ikke tilgængelig til {0} {1}"
 
-#: static/js/zamboni/buttons.js:341
+#: static/js/common-all.js:2112 static/js/impala-all.js:2197 static/js/zamboni/buttons.js:351 static/js/zamboni/discovery-all.js:13383
 msgid "Works with {app} {min} - {max}"
 msgstr "Virker med {app} {min} - {max}"
 
-#: static/js/zamboni/buttons.js:343
+#: static/js/common-all.js:2114 static/js/impala-all.js:2199 static/js/zamboni/buttons.js:353 static/js/zamboni/discovery-all.js:13385
 msgid "View other versions"
 msgstr "Vis andre versioner"
 
-#: static/js/zamboni/buttons.js:391
+#: static/js/common-all.js:2162 static/js/impala-all.js:2247 static/js/zamboni/buttons.js:401 static/js/zamboni/discovery-all.js:13433
 msgid "Only with Firefox — Get Firefox Now!"
 msgstr "Kun med Firefox — Hent Firefox nu!"
 
-#: static/js/zamboni/buttons.js:507 static/js/zamboni/mobile/buttons.js:43
+#: static/js/common-all.js:2278 static/js/impala-all.js:2363 static/js/zamboni/buttons.js:517 static/js/zamboni/discovery-all.js:13549 static/js/zamboni/mobile-all.js:15177
+#: static/js/zamboni/mobile/buttons.js:43
 msgid "Sorry, you need a Mozilla-based browser (such as Firefox) to install a search plugin."
 msgstr "Beklager, du behøver en Mozilla-baseret browser (såsom Firefox) for at installere et søge-plugin."
 
-#: static/js/zamboni/collections.js:229
-msgid "Adding to Favorites&hellip;"
-msgstr "Føjer til favoritter&hellip;"
-
-#: static/js/zamboni/collections.js:232
-msgid "Removing Favorite&hellip;"
-msgstr "Fjerner fra favoritter&hellip;"
-
-#: static/js/zamboni/collections.js:235
-msgid "Add to Favorites"
-msgstr "Føj til favoritter"
-
-#: static/js/zamboni/collections.js:238
-msgid "Remove from Favorites"
-msgstr "Fjern fra favoritter"
-
-#: static/js/zamboni/collections.js:303
-msgid "Pending"
-msgstr ""
-
-#: static/js/zamboni/collections.js:304
-msgid "Add a comment"
-msgstr "Tilføj en kommentar"
-
-#: static/js/zamboni/collections.js:304
-msgid "Comment"
-msgstr "Kommentar"
-
-#: static/js/zamboni/collections.js:305
-msgid "Remove this add-on from the collection"
-msgstr "Fjern denne tilføjelse fra samlingen"
-
-#: static/js/zamboni/collections.js:305 static/js/zamboni/collections.js:334
-msgid "Remove"
-msgstr "Fjern"
-
-#: static/js/zamboni/collections.js:334
-msgid "Remove this user as a contributor"
-msgstr "Fjern denne bruger som bidragyder"
-
-#: static/js/zamboni/collections.js:346
-msgid "An email address is required."
-msgstr "En mailadresse er påkrævet."
-
-#: static/js/zamboni/collections.js:364
-msgid "You cannot add yourself as a contributor."
-msgstr ""
-
-#: static/js/zamboni/collections.js:366
-msgid "You have already added that user."
-msgstr "Du har allerede tilføjet den bruger."
-
-#: static/js/zamboni/collections.js:573
-msgid "Add to favorites"
-msgstr "Føj til favoritter"
-
-#: static/js/zamboni/collections.js:577
-msgid "Remove from favorites"
-msgstr "Fjern fra favoritter"
-
-#: static/js/zamboni/collections.js:604
-msgid "Stop following"
-msgstr "Stop med at følge"
-
-#: static/js/zamboni/devhub.js:110
-msgid "Your browser does not support the video tag"
-msgstr "Din browser understøtter ikke denne video-tag"
-
-#: static/js/zamboni/devhub.js:371
-msgid "Changes Saved"
-msgstr "Ændringer gemt"
-
-#: static/js/zamboni/devhub.js:387
-msgid "Enter a new author's email address"
-msgstr ""
-
-#: static/js/zamboni/devhub.js:536
-msgid "There was an error uploading your file."
-msgstr ""
-
-#: static/js/zamboni/devhub.js:681
-msgid "{files} file"
-msgid_plural "{files} files"
-msgstr[0] "{files} fil"
-msgstr[1] "{files} filer"
-
-#: static/js/zamboni/devhub.js:684
-msgid "{reviews} user review"
-msgid_plural "{reviews} user reviews"
-msgstr[0] ""
-msgstr[1] ""
-
-#: static/js/zamboni/devhub.js:796
-msgid "Learn more"
-msgstr "Lær mere"
-
-#: static/js/zamboni/devhub.js:800
-msgid "Example"
-msgstr "Eksempel"
-
-#: static/js/zamboni/devhub.js:1130
-msgid "Image changes being processed"
-msgstr ""
-
-#: static/js/zamboni/devhub.js:1280
-msgid "Must be a valid e-mail address."
-msgstr "Skal være en gyldig mailadresse."
-
-#: static/js/zamboni/devhub_search.js:8
-msgid "No results found."
-msgstr "Ingen resultater fundet."
-
-#: static/js/zamboni/editors.js:121
-msgid "{name} was viewing this page first."
-msgstr ""
-
-#: static/js/zamboni/editors.js:171
-msgid "Receipt checked by app."
-msgstr ""
-
-#: static/js/zamboni/editors.js:173
-msgid "Receipt was not checked by app."
-msgstr ""
-
-#: static/js/zamboni/editors.js:244
-msgid "{name} was viewing this add-on first."
-msgstr ""
-
-#: static/js/zamboni/editors.js:255
-msgid "Loading&hellip;"
-msgstr "Indlæser&hellip;"
-
-#: static/js/zamboni/editors.js:260
-msgid "Version Notes"
-msgstr "Versionsbemærkninger"
-
-#: static/js/zamboni/editors.js:265
-msgid "Notes for Reviewers"
-msgstr ""
-
-#: static/js/zamboni/editors.js:270
-msgid "No version notes found"
-msgstr "Ingen versionsbemærkninger fundet"
-
-#: static/js/zamboni/editors.js:330
-msgid "Average Reviews"
-msgstr ""
-
-#: static/js/zamboni/editors.js:386
-msgid "Number of Reviews"
-msgstr ""
-
-#: static/js/zamboni/editors.js:445
-msgid "Error loading translation"
-msgstr ""
-
-#: static/js/zamboni/files.js:411 static/js/zamboni/validator.js:261
-msgid "Ignore this message in future updates"
-msgstr ""
-
-#: static/js/zamboni/files.js:417 static/js/zamboni/validator.js:284
-msgid "Severity for automated signing:"
-msgstr ""
-
-#: static/js/zamboni/global.js:410
+#: static/js/common-all.js:9088 static/js/impala-all.js:9649 static/js/zamboni/global.js:410
 msgid "Loading..."
 msgstr "Indlæser..."
 
 #. L10n: {0} is the number of characters left.
-#: static/js/zamboni/global.js:474
+#: static/js/common-all.js:9152 static/js/impala-all.js:9713 static/js/zamboni/global.js:474
 msgid "<b>{0}</b> character left."
 msgid_plural "<b>{0}</b> characters left."
 msgstr[0] "<b>{0}</b> tegn tilbage."
 msgstr[1] "<b>{0}</b> tegn tilbage."
 
-#: static/js/zamboni/init.js:28
-msgid "This feature is temporarily disabled while we perform website maintenance. Please check back a little later."
-msgstr "Denne funktion er midlertidig ude af drift mens vi udfører vedligeholdelse af webstedet. Prøv igen lidt senere."
+#: static/js/common-all.js:9589 static/js/common-min.js:6 static/js/impala-all.js:10052 static/js/impala-min.js:6 static/js/common/ratingwidget.js:31 static/js/zamboni/mobile-all.js:16123
+#: static/js/zamboni/mobile-min.js:6
+msgid "{0} star"
+msgid_plural "{0} stars"
+msgstr[0] "{0} stjerne"
+msgstr[1] "{0} stjerner"
 
-#: static/js/zamboni/l10n.js:45
+#: static/js/common-all.js:9676 static/js/common-min.js:6 static/js/impala-all.js:10139 static/js/impala-min.js:6 static/js/zamboni/l10n.js:45
 msgid "Remove this localization"
 msgstr ""
 
-#: static/js/zamboni/password-strength.js:20
+#: static/js/common-all.js:10193 static/js/common-min.js:6 static/js/impala-all.js:10674 static/js/impala-min.js:6 static/js/zamboni/discovery-all.js:13678
+msgid "close"
+msgstr ""
+
+#: static/js/common-all.js:10860 static/js/common-min.js:6 static/js/impala-all.js:11481 static/js/impala-min.js:6 static/js/impala/reviews.js:23 static/js/zamboni/reviews.js:18
+msgid "Flagged for review"
+msgstr ""
+
+#: static/js/common-all.js:10876 static/js/common-min.js:6 static/js/impala-all.js:11498 static/js/impala-min.js:6 static/js/impala/reviews.js:40 static/js/zamboni/reviews.js:34
+msgid "Your input is required"
+msgstr "Dit input er påkrævet"
+
+#: static/js/common-all.js:10945 static/js/common-min.js:6 static/js/impala-all.js:11610 static/js/impala-min.js:7 static/js/impala/reviews.js:152 static/js/zamboni/reviews.js:103
+msgid "Marked for deletion"
+msgstr "Markeret til sletning"
+
+#: static/js/common-all.js:11573 static/js/common-min.js:7 static/js/impala-all.js:13809 static/js/impala-min.js:8 static/js/zamboni/collections.js:229
+msgid "Adding to Favorites&hellip;"
+msgstr "Føjer til favoritter&hellip;"
+
+#: static/js/common-all.js:11576 static/js/common-min.js:7 static/js/impala-all.js:13812 static/js/impala-min.js:8 static/js/zamboni/collections.js:232
+msgid "Removing Favorite&hellip;"
+msgstr "Fjerner fra favoritter&hellip;"
+
+#: static/js/common-all.js:11579 static/js/common-min.js:7 static/js/impala-all.js:13815 static/js/impala-min.js:8 static/js/zamboni/collections.js:235
+msgid "Add to Favorites"
+msgstr "Føj til favoritter"
+
+#: static/js/common-all.js:11582 static/js/common-min.js:7 static/js/impala-all.js:13818 static/js/impala-min.js:8 static/js/zamboni/collections.js:238
+msgid "Remove from Favorites"
+msgstr "Fjern fra favoritter"
+
+#: static/js/common-all.js:11647 static/js/common-min.js:7 static/js/impala-all.js:13883 static/js/impala-min.js:8 static/js/zamboni/collections.js:303
+msgid "Pending"
+msgstr ""
+
+#: static/js/common-all.js:11648 static/js/common-min.js:7 static/js/impala-all.js:13884 static/js/impala-min.js:8 static/js/zamboni/collections.js:304
+msgid "Add a comment"
+msgstr "Tilføj en kommentar"
+
+#: static/js/common-all.js:11648 static/js/common-min.js:7 static/js/impala-all.js:13884 static/js/impala-min.js:8 static/js/zamboni/collections.js:304
+msgid "Comment"
+msgstr "Kommentar"
+
+#: static/js/common-all.js:11649 static/js/common-min.js:7 static/js/impala-all.js:13885 static/js/impala-min.js:8 static/js/zamboni/collections.js:305
+msgid "Remove this add-on from the collection"
+msgstr "Fjern denne tilføjelse fra samlingen"
+
+#: static/js/common-all.js:11649 static/js/common-all.js:11678 static/js/common-min.js:7 static/js/impala-all.js:13885 static/js/impala-all.js:13914 static/js/impala-min.js:8
+#: static/js/zamboni/collections.js:305 static/js/zamboni/collections.js:334
+msgid "Remove"
+msgstr "Fjern"
+
+#: static/js/common-all.js:11678 static/js/common-min.js:7 static/js/impala-all.js:13914 static/js/impala-min.js:8 static/js/zamboni/collections.js:334
+msgid "Remove this user as a contributor"
+msgstr "Fjern denne bruger som bidragyder"
+
+#: static/js/common-all.js:11690 static/js/common-min.js:7 static/js/impala-all.js:13926 static/js/impala-min.js:8 static/js/zamboni/collections.js:346
+msgid "An email address is required."
+msgstr "En mailadresse er påkrævet."
+
+#: static/js/common-all.js:11708 static/js/common-min.js:7 static/js/impala-all.js:13944 static/js/impala-min.js:8 static/js/zamboni/collections.js:364
+msgid "You cannot add yourself as a contributor."
+msgstr ""
+
+#: static/js/common-all.js:11710 static/js/common-min.js:7 static/js/impala-all.js:13946 static/js/impala-min.js:8 static/js/zamboni/collections.js:366
+msgid "You have already added that user."
+msgstr "Du har allerede tilføjet den bruger."
+
+#: static/js/common-all.js:11917 static/js/common-min.js:7 static/js/impala-all.js:14153 static/js/impala-min.js:8 static/js/zamboni/collections.js:573
+msgid "Add to favorites"
+msgstr "Føj til favoritter"
+
+#: static/js/common-all.js:11921 static/js/common-min.js:7 static/js/impala-all.js:14157 static/js/impala-min.js:8 static/js/zamboni/collections.js:577
+msgid "Remove from favorites"
+msgstr "Fjern fra favoritter"
+
+#: static/js/common-all.js:11939 static/js/common-min.js:7 static/js/impala-all.js:14175 static/js/impala-all.js:14233 static/js/impala-min.js:8 static/js/impala/collections.js:10
+#: static/js/zamboni/collections.js:595
+msgid "Follow this Collection"
+msgstr "Følg denne samling"
+
+#: static/js/common-all.js:11948 static/js/common-min.js:7 static/js/impala-all.js:14184 static/js/impala-min.js:8 static/js/zamboni/collections.js:604
+msgid "Stop following"
+msgstr "Stop med at følge"
+
+#: static/js/common-all.js:12096 static/js/common-min.js:7 static/js/zamboni/password-strength.js:20
 msgid "Password strength:"
 msgstr "Adgangskodens styrke:"
 
-#: static/js/zamboni/password-strength.js:26
+#: static/js/common-all.js:12102 static/js/common-min.js:7 static/js/zamboni/password-strength.js:26
 msgid "At least {0} character left."
 msgid_plural "At least {0} characters left."
 msgstr[0] "Mindst {0} tegn tilbage."
 msgstr[1] "Mindst {0} tegn tilbage."
 
-#: static/js/zamboni/themes_review.js:176
-msgid "Requested Info"
+#: static/js/common-all.js:12286 static/js/common-min.js:7 static/js/impala-all.js:14632 static/js/impala-min.js:8 static/js/impala/suggestions.js:39
+msgid "Search themes for <b>{0}</b>"
+msgstr "Søg i temaer efter <b>{0}</b>"
+
+#: static/js/common-all.js:12288 static/js/common-min.js:7 static/js/impala-all.js:14634 static/js/impala-min.js:8 static/js/impala/suggestions.js:41
+msgid "Search apps for <b>{0}</b>"
+msgstr "Søg i apps efter <b>{0}</b>"
+
+#: static/js/common-all.js:12290 static/js/common-min.js:7 static/js/impala-all.js:14636 static/js/impala-min.js:8 static/js/impala/suggestions.js:43
+msgid "Search add-ons for <b>{0}</b>"
+msgstr "Søg i tilføjelser efter <b>{0}</b>"
+
+#: static/js/common-all.js:12521 static/js/common-min.js:7 static/js/impala-all.js:14867 static/js/impala-min.js:8 static/js/impala/site_suggestions.js:46
+msgid "Category"
+msgstr "Kategori"
+
+#. L10n: {0} is an app name.
+#: static/js/impala-all.js:11632 static/js/impala-min.js:7 static/js/impala/listing.js:11 static/js/zamboni/themes.js:13
+msgid "This theme is incompatible with your version of {0}"
+msgstr "Dette tema er ikke kompatibelt med din version af {0}"
+
+#: static/js/impala-all.js:12146 static/js/impala-all.js:14331 static/js/impala-min.js:7 static/js/impala-min.js:8 static/js/common/upload-image.js:97 static/js/impala/users.js:51
+#: static/js/zamboni/devhub-all.js:894 static/js/zamboni/devhub-min.js:1
+msgid "Images must be either PNG or JPG."
+msgstr "Billeder skal enten være PNG eller JPG."
+
+#: static/js/impala-all.js:12150 static/js/impala-min.js:7 static/js/common/upload-image.js:101 static/js/zamboni/devhub-all.js:898 static/js/zamboni/devhub-min.js:1
+msgid "Videos must be in WebM."
 msgstr ""
 
-#: static/js/zamboni/themes_review.js:177
-msgid "Flagged"
+#: static/js/impala-all.js:12177 static/js/impala-min.js:7 static/js/common/upload-addon.js:41 static/js/common/upload-image.js:128 static/js/zamboni/devhub-all.js:272
+#: static/js/zamboni/devhub-all.js:925 static/js/zamboni/devhub-min.js:1
+msgid "There was a problem contacting the server."
+msgstr "Der opstod et problem med at kontakte serveren."
+
+#: static/js/impala-all.js:13298 static/js/impala-min.js:7 static/js/impala/persona_creation.js:60
+msgid "All Rights Reserved"
+msgstr "Alle rettigheder forbeholdes"
+
+#: static/js/impala-all.js:13302 static/js/impala-min.js:7 static/js/impala/persona_creation.js:64
+msgid "Creative Commons Attribution 3.0"
+msgstr "Creative Commons Attribution 3.0"
+
+#: static/js/impala-all.js:13307 static/js/impala-min.js:7 static/js/impala/persona_creation.js:69
+msgid "Creative Commons Attribution-NonCommercial 3.0"
+msgstr "Creative Commons Attribution-NonCommercial 3.0"
+
+#: static/js/impala-all.js:13312 static/js/impala-min.js:7 static/js/impala/persona_creation.js:74
+msgid "Creative Commons Attribution-NonCommercial-NoDerivs 3.0"
+msgstr "Creative Commons Attribution-NonCommercial-NoDerivs 3.0"
+
+#: static/js/impala-all.js:13317 static/js/impala-min.js:7 static/js/impala/persona_creation.js:79
+msgid "Creative Commons Attribution-NonCommercial-Share Alike 3.0"
+msgstr "Creative Commons Attribution-NonCommercial-Share Alike 3.0"
+
+#: static/js/impala-all.js:13322 static/js/impala-min.js:7 static/js/impala/persona_creation.js:84
+msgid "Creative Commons Attribution-NoDerivs 3.0"
+msgstr "Creative Commons Attribution-NoDerivs 3.0"
+
+#: static/js/impala-all.js:13327 static/js/impala-min.js:7 static/js/impala/persona_creation.js:89
+msgid "Creative Commons Attribution-ShareAlike 3.0"
+msgstr "Creative Commons Attribution-ShareAlike 3.0"
+
+#: static/js/impala-all.js:13530 static/js/impala-min.js:7 static/js/impala/persona_creation.js:292
+msgid "Your Theme's Name"
+msgstr "Dit temas navn"
+
+#: static/js/impala-all.js:14242 static/js/impala-min.js:8 static/js/impala/collections.js:19
+msgid "Stop Following"
+msgstr "Stop med at følge"
+
+#: static/js/impala-all.js:14243 static/js/impala-min.js:8 static/js/impala/collections.js:20
+msgid "Following"
+msgstr "Følg"
+
+#: static/js/impala-all.js:14313 static/js/impala-min.js:8 static/js/impala/users.js:33
+msgid "use original"
 msgstr ""
 
-#: static/js/zamboni/themes_review.js:178
-msgid "Duplicate"
+#: static/js/impala-all.js:14523 static/js/impala-min.js:8 static/js/impala/search.js:114
+msgid "Updating results&hellip;"
+msgstr "Opdaterer resultater&hellip;"
+
+#: static/js/common/upload-addon.js:69 static/js/zamboni/devhub-all.js:300 static/js/zamboni/devhub-min.js:1
+msgid "Select a file..."
+msgstr "Vælg en fil..."
+
+#: static/js/common/upload-addon.js:70 static/js/zamboni/devhub-all.js:301 static/js/zamboni/devhub-min.js:1
+msgid "Your add-on should end with .xpi, .jar or .xml"
 msgstr ""
 
-#: static/js/zamboni/themes_review.js:179
-msgid "Rejected"
+#. L10n: {0} is the percent of the file that has been uploaded.
+#: static/js/common/upload-addon.js:104 static/js/zamboni/devhub-all.js:335 static/js/zamboni/devhub-min.js:1
+#, python-format
+msgid "{0}% complete"
+msgstr "{0}% fuldført"
+
+#. L10n: "{bytes uploaded} of {total filesize}".
+#: static/js/common/upload-addon.js:107 static/js/zamboni/devhub-all.js:338 static/js/zamboni/devhub-min.js:1
+msgid "{0} of {1}"
+msgstr "{0} af {1}"
+
+#: static/js/common/upload-addon.js:140 static/js/zamboni/devhub-all.js:371 static/js/zamboni/devhub-min.js:1
+msgid "Cancel"
+msgstr "Annuller"
+
+#: static/js/common/upload-addon.js:162 static/js/zamboni/devhub-all.js:393 static/js/zamboni/devhub-min.js:1
+msgid "Uploading {0}"
+msgstr "Uploader {0}"
+
+#: static/js/common/upload-addon.js:189 static/js/zamboni/devhub-all.js:420 static/js/zamboni/devhub-min.js:1
+msgid "Error with {0}"
 msgstr ""
 
-#: static/js/zamboni/themes_review.js:180
-msgid "Approved"
+#: static/js/common/upload-addon.js:194 static/js/zamboni/devhub-all.js:425 static/js/zamboni/devhub-min.js:1
+msgid "Your add-on failed validation with {0} error."
+msgid_plural "Your add-on failed validation with {0} errors."
+msgstr[0] ""
+msgstr[1] ""
+
+#: static/js/common/upload-addon.js:208 static/js/zamboni/devhub-all.js:439 static/js/zamboni/devhub-min.js:1
+msgid "&hellip;and {0} more"
+msgid_plural "&hellip;and {0} more"
+msgstr[0] ""
+msgstr[1] ""
+
+#: static/js/common/upload-addon.js:222 static/js/common/upload-addon.js:497 static/js/zamboni/devhub-all.js:453 static/js/zamboni/devhub-all.js:743 static/js/zamboni/devhub-min.js:1
+msgid "See full validation report"
 msgstr ""
 
-#: static/js/zamboni/themes_review.js:424
-msgid "No results found"
+#: static/js/common/upload-addon.js:234 static/js/zamboni/devhub-all.js:465 static/js/zamboni/devhub-min.js:1
+msgid "Validating {0}"
 msgstr ""
 
-#: static/js/zamboni/themes_review_templates.js:31
-msgid "Theme"
+#. L10n: first argument is an HTTP status code
+#: static/js/common/upload-addon.js:273 static/js/zamboni/devhub-all.js:504 static/js/zamboni/devhub-min.js:1
+msgid "Received an empty response from the server; status: {0}"
 msgstr ""
 
-#: static/js/zamboni/themes_review_templates.js:33
-msgid "Reviewer"
+#: static/js/common/upload-addon.js:370 static/js/zamboni/devhub-all.js:604 static/js/zamboni/devhub-min.js:1
+msgid "Unexpected server error while validating."
 msgstr ""
 
-#: static/js/zamboni/themes_review_templates.js:35
-msgid "Status"
+#: static/js/common/upload-addon.js:409 static/js/zamboni/devhub-all.js:643 static/js/zamboni/devhub-min.js:1
+msgid "Finished validating {0}"
 msgstr ""
 
-#: static/js/zamboni/validator.js:80
+#: static/js/common/upload-addon.js:415 static/js/zamboni/devhub-all.js:649 static/js/zamboni/devhub-min.js:1
+msgid "Your add-on validation timed out, it will be manually reviewed."
+msgstr ""
+
+#: static/js/common/upload-addon.js:418 static/js/zamboni/devhub-all.js:652 static/js/zamboni/devhub-min.js:1
+msgid "Your add-on was validated with no errors and {0} warning."
+msgid_plural "Your add-on was validated with no errors and {0} warnings."
+msgstr[0] ""
+msgstr[1] ""
+
+#: static/js/common/upload-addon.js:423 static/js/zamboni/devhub-all.js:657 static/js/zamboni/devhub-min.js:1
+msgid "Your add-on was validated with no errors and {0} message."
+msgid_plural "Your add-on was validated with no errors and {0} messages."
+msgstr[0] ""
+msgstr[1] ""
+
+#: static/js/common/upload-addon.js:428 static/js/zamboni/devhub-all.js:662 static/js/zamboni/devhub-min.js:1
+msgid "Your add-on was validated with no errors or warnings."
+msgstr ""
+
+#: static/js/common/upload-addon.js:443 static/js/zamboni/devhub-all.js:677 static/js/zamboni/devhub-min.js:1
+msgid "Your submission will be automatically signed."
+msgstr ""
+
+#: static/js/common/upload-addon.js:450 static/js/zamboni/devhub-all.js:696 static/js/zamboni/devhub-min.js:1
+msgid "Include detailed version notes (this can be done in the next step)."
+msgstr ""
+
+#: static/js/common/upload-addon.js:451 static/js/zamboni/devhub-all.js:697 static/js/zamboni/devhub-min.js:1
+msgid "If your add-on requires an account to a website in order to be fully tested, include a test username and password in the Notes to Reviewer (this can be done in the next step)."
+msgstr ""
+
+#: static/js/common/upload-addon.js:452 static/js/zamboni/devhub-all.js:698 static/js/zamboni/devhub-min.js:1
+msgid "If your add-on is intended for a limited audience you should choose Preliminary Review instead of Full Review."
+msgstr ""
+
+#: static/js/common/upload-addon.js:465 static/js/zamboni/devhub-all.js:711 static/js/zamboni/devhub-min.js:1
+msgid "Add-on submission checklist"
+msgstr ""
+
+#: static/js/common/upload-addon.js:466 static/js/zamboni/devhub-all.js:712 static/js/zamboni/devhub-min.js:1
+msgid "Please verify the following points before finalizing your submission. This will minimize delays or misunderstanding during the review process:"
+msgstr ""
+
+#: static/js/common/upload-addon.js:468 static/js/zamboni/devhub-all.js:714 static/js/zamboni/devhub-min.js:1
+msgid ""
+"Compiled binaries, as well as minified or obfuscated scripts (excluding known libraries) need to have their sources submitted separately for review. Make sure that you use the source code upload "
+"field to avoid having your submission rejected."
+msgstr ""
+
+#: static/js/common/upload-addon.js:486 static/js/zamboni/devhub-all.js:732 static/js/zamboni/devhub-min.js:1
+msgid "The validation process found these issues that can lead to rejections:"
+msgstr ""
+
+#: static/js/common/upload-addon.js:503 static/js/zamboni/devhub-all.js:749 static/js/zamboni/devhub-min.js:1
+msgid "If you are unfamiliar with the add-ons review process, you can read about it here."
+msgstr ""
+
+#: static/js/common/upload-addon.js:540 static/js/zamboni/devhub-all.js:786 static/js/zamboni/devhub-min.js:1
+msgid "Sorry, no supported platform has been found."
+msgstr ""
+
+#: static/js/common/upload-base.js:57 static/js/zamboni/devhub-all.js:187 static/js/zamboni/devhub-min.js:1
+msgid "The filetype you uploaded isn't recognized."
+msgstr ""
+
+#: static/js/common/upload-base.js:79 static/js/zamboni/devhub-all.js:209 static/js/zamboni/devhub-min.js:1
+msgid "You cancelled the upload."
+msgstr ""
+
+#: static/js/impala/stats/chart.js:267 static/js/zamboni/stats-all.js:16898 static/js/zamboni/stats-min.js:5
+msgid "Week of {0}"
+msgstr "Uge {0}"
+
+#: static/js/impala/stats/chart.js:269 static/js/zamboni/stats-all.js:16900 static/js/zamboni/stats-min.js:5
+msgid " downloads"
+msgstr ""
+
+#: static/js/impala/stats/chart.js:270 static/js/zamboni/stats-all.js:16901 static/js/zamboni/stats-min.js:5
+msgid "{0} users"
+msgstr "{0} brugere"
+
+#: static/js/impala/stats/chart.js:271 static/js/zamboni/stats-all.js:16902 static/js/zamboni/stats-min.js:5
+msgid "{0} add-ons"
+msgstr "{0} tilføjelser"
+
+#: static/js/impala/stats/chart.js:272 static/js/zamboni/stats-all.js:16903 static/js/zamboni/stats-min.js:5
+msgid "{0} collections"
+msgstr "{0} samlinger"
+
+#: static/js/impala/stats/chart.js:273 static/js/zamboni/stats-all.js:16904 static/js/zamboni/stats-min.js:5
+msgid "{0} reviews"
+msgstr "{0} anmeldelser"
+
+#: static/js/impala/stats/chart.js:275 static/js/zamboni/stats-all.js:16906 static/js/zamboni/stats-min.js:5
+msgid "{0} sales"
+msgstr "{0} salg"
+
+#: static/js/impala/stats/chart.js:276 static/js/zamboni/stats-all.js:16907 static/js/zamboni/stats-min.js:5
+msgid "{0} refunds"
+msgstr "{0} refunderinger"
+
+#: static/js/impala/stats/chart.js:277 static/js/zamboni/stats-all.js:16908 static/js/zamboni/stats-min.js:5
+msgid "{0} installs"
+msgstr "{0} installeringer"
+
+#: static/js/impala/stats/chart.js:369 static/js/impala/stats/csv_keys.js:3 static/js/impala/stats/csv_keys.js:109 static/js/zamboni/stats-all.js:15284 static/js/zamboni/stats-all.js:15390
+#: static/js/zamboni/stats-all.js:17000 static/js/zamboni/stats-min.js:4 static/js/zamboni/stats-min.js:5
+msgid "Downloads"
+msgstr "Downloads"
+
+#: static/js/impala/stats/chart.js:379 static/js/impala/stats/csv_keys.js:6 static/js/impala/stats/csv_keys.js:110 static/js/zamboni/stats-all.js:15287 static/js/zamboni/stats-all.js:15391
+#: static/js/zamboni/stats-all.js:17010 static/js/zamboni/stats-min.js:4 static/js/zamboni/stats-min.js:5
+msgid "Daily Users"
+msgstr "Daglige brugere"
+
+#: static/js/impala/stats/chart.js:410 static/js/zamboni/stats-all.js:17041 static/js/zamboni/stats-min.js:5
+msgid "Amount, in USD"
+msgstr "Beløb i USD"
+
+#: static/js/impala/stats/chart.js:421 static/js/impala/stats/csv_keys.js:104 static/js/zamboni/stats-all.js:15385 static/js/zamboni/stats-all.js:17052 static/js/zamboni/stats-min.js:5
+msgid "Number of Contributions"
+msgstr "Antal bidrag"
+
+#: static/js/impala/stats/chart.js:447 static/js/zamboni/stats-all.js:17078 static/js/zamboni/stats-min.js:5
+msgid "More Info..."
+msgstr "Mere info..."
+
+#. L10n: {0} is an ISO-formatted date.
+#: static/js/impala/stats/chart.js:451 static/js/zamboni/stats-all.js:17082 static/js/zamboni/stats-min.js:5
+msgid "Details for {0}"
+msgstr "Detaljer for {0}"
+
+#: static/js/impala/stats/csv_keys.js:9 static/js/zamboni/stats-all.js:15290 static/js/zamboni/stats-min.js:4
+msgid "Collections Created"
+msgstr "Samling oprettet"
+
+#: static/js/impala/stats/csv_keys.js:12 static/js/zamboni/stats-all.js:15293 static/js/zamboni/stats-min.js:4
+msgid "Add-ons in Use"
+msgstr ""
+
+#: static/js/impala/stats/csv_keys.js:15 static/js/zamboni/stats-all.js:15296 static/js/zamboni/stats-min.js:4
+msgid "Add-ons Created"
+msgstr ""
+
+#: static/js/impala/stats/csv_keys.js:18 static/js/zamboni/stats-all.js:15299 static/js/zamboni/stats-min.js:4
+msgid "Add-ons Downloaded"
+msgstr ""
+
+#: static/js/impala/stats/csv_keys.js:21 static/js/zamboni/stats-all.js:15302 static/js/zamboni/stats-min.js:4
+msgid "Add-ons Updated"
+msgstr ""
+
+#: static/js/impala/stats/csv_keys.js:24 static/js/zamboni/stats-all.js:15305 static/js/zamboni/stats-min.js:4
+msgid "Reviews Written"
+msgstr ""
+
+#: static/js/impala/stats/csv_keys.js:27 static/js/zamboni/stats-all.js:15308 static/js/zamboni/stats-min.js:4
+msgid "User Signups"
+msgstr ""
+
+#: static/js/impala/stats/csv_keys.js:30 static/js/zamboni/stats-all.js:15311 static/js/zamboni/stats-min.js:4
+msgid "Subscribers"
+msgstr "Abonnenter"
+
+#: static/js/impala/stats/csv_keys.js:33 static/js/zamboni/stats-all.js:15314 static/js/zamboni/stats-min.js:4
+msgid "Ratings"
+msgstr "Bedømmelser"
+
+#: static/js/impala/stats/csv_keys.js:36 static/js/impala/stats/csv_keys.js:114 static/js/zamboni/stats-all.js:15317 static/js/zamboni/stats-all.js:15395 static/js/zamboni/stats-min.js:4
+#: static/js/zamboni/stats-min.js:5
+msgid "Sales"
+msgstr "Salg"
+
+#: static/js/impala/stats/csv_keys.js:39 static/js/impala/stats/csv_keys.js:113 static/js/zamboni/stats-all.js:15320 static/js/zamboni/stats-all.js:15394 static/js/zamboni/stats-min.js:4
+#: static/js/zamboni/stats-min.js:5
+msgid "Installs"
+msgstr "Installeringer"
+
+#: static/js/impala/stats/csv_keys.js:42 static/js/zamboni/stats-all.js:15323 static/js/zamboni/stats-min.js:4
+msgid "Unknown"
+msgstr "Ukendt"
+
+#: static/js/impala/stats/csv_keys.js:43 static/js/zamboni/stats-all.js:15324 static/js/zamboni/stats-min.js:4
+msgid "Add-ons Manager"
+msgstr "Fanebladet Tilføjelser"
+
+#: static/js/impala/stats/csv_keys.js:44 static/js/zamboni/stats-all.js:15325 static/js/zamboni/stats-min.js:4
+msgid "Add-ons Manager Promo"
+msgstr ""
+
+#: static/js/impala/stats/csv_keys.js:45 static/js/zamboni/stats-all.js:15326 static/js/zamboni/stats-min.js:4
+msgid "Add-ons Manager Featured"
+msgstr ""
+
+#: static/js/impala/stats/csv_keys.js:46 static/js/zamboni/stats-all.js:15327 static/js/zamboni/stats-min.js:4
+msgid "Add-ons Manager Learn More"
+msgstr ""
+
+#: static/js/impala/stats/csv_keys.js:47 static/js/zamboni/stats-all.js:15328 static/js/zamboni/stats-min.js:4
+msgid "Search Suggestions"
+msgstr ""
+
+#: static/js/impala/stats/csv_keys.js:48 static/js/zamboni/stats-all.js:15329 static/js/zamboni/stats-min.js:4
+msgid "Search Results"
+msgstr "Søgeresultater"
+
+#: static/js/impala/stats/csv_keys.js:49 static/js/impala/stats/csv_keys.js:50 static/js/impala/stats/csv_keys.js:51 static/js/zamboni/stats-all.js:15330 static/js/zamboni/stats-all.js:15331
+#: static/js/zamboni/stats-all.js:15332 static/js/zamboni/stats-min.js:4
+msgid "Homepage Promo"
+msgstr ""
+
+#: static/js/impala/stats/csv_keys.js:52 static/js/impala/stats/csv_keys.js:53 static/js/zamboni/stats-all.js:15333 static/js/zamboni/stats-all.js:15334 static/js/zamboni/stats-min.js:4
+msgid "Homepage Featured"
+msgstr ""
+
+#: static/js/impala/stats/csv_keys.js:54 static/js/impala/stats/csv_keys.js:55 static/js/zamboni/stats-all.js:15335 static/js/zamboni/stats-all.js:15336 static/js/zamboni/stats-min.js:4
+msgid "Homepage Up and Coming"
+msgstr ""
+
+#: static/js/impala/stats/csv_keys.js:56 static/js/zamboni/stats-all.js:15337 static/js/zamboni/stats-min.js:4
+msgid "Homepage Most Popular"
+msgstr ""
+
+#: static/js/impala/stats/csv_keys.js:57 static/js/impala/stats/csv_keys.js:59 static/js/zamboni/stats-all.js:15338 static/js/zamboni/stats-all.js:15340 static/js/zamboni/stats-min.js:4
+msgid "Detail Page"
+msgstr ""
+
+#: static/js/impala/stats/csv_keys.js:58 static/js/impala/stats/csv_keys.js:60 static/js/zamboni/stats-all.js:15339 static/js/zamboni/stats-all.js:15341 static/js/zamboni/stats-min.js:4
+msgid "Detail Page (bottom)"
+msgstr ""
+
+#: static/js/impala/stats/csv_keys.js:61 static/js/zamboni/stats-all.js:15342 static/js/zamboni/stats-min.js:4
+msgid "Detail Page (Development Channel)"
+msgstr ""
+
+#: static/js/impala/stats/csv_keys.js:62 static/js/impala/stats/csv_keys.js:63 static/js/impala/stats/csv_keys.js:64 static/js/zamboni/stats-all.js:15343 static/js/zamboni/stats-all.js:15344
+#: static/js/zamboni/stats-all.js:15345 static/js/zamboni/stats-min.js:4
+msgid "Often Used With"
+msgstr "Ofte anvendt sammen med"
+
+#: static/js/impala/stats/csv_keys.js:65 static/js/impala/stats/csv_keys.js:66 static/js/zamboni/stats-all.js:15346 static/js/zamboni/stats-all.js:15347 static/js/zamboni/stats-min.js:4
+msgid "Others By Author"
+msgstr "Andre af udvikleren"
+
+#: static/js/impala/stats/csv_keys.js:67 static/js/impala/stats/csv_keys.js:68 static/js/zamboni/stats-all.js:15348 static/js/zamboni/stats-all.js:15349 static/js/zamboni/stats-min.js:4
+msgid "Dependencies"
+msgstr ""
+
+#: static/js/impala/stats/csv_keys.js:69 static/js/impala/stats/csv_keys.js:70 static/js/zamboni/stats-all.js:15350 static/js/zamboni/stats-all.js:15351 static/js/zamboni/stats-min.js:4
+msgid "Upsell"
+msgstr ""
+
+#: static/js/impala/stats/csv_keys.js:71 static/js/zamboni/stats-all.js:15352 static/js/zamboni/stats-min.js:4
+msgid "Meet the Developer"
+msgstr ""
+
+#: static/js/impala/stats/csv_keys.js:72 static/js/zamboni/stats-all.js:15353 static/js/zamboni/stats-min.js:4
+msgid "User Profile"
+msgstr ""
+
+#: static/js/impala/stats/csv_keys.js:73 static/js/zamboni/stats-all.js:15354 static/js/zamboni/stats-min.js:4
+msgid "Version History"
+msgstr ""
+
+#: static/js/impala/stats/csv_keys.js:75 static/js/zamboni/stats-all.js:15356 static/js/zamboni/stats-min.js:4
+msgid "Sharing"
+msgstr ""
+
+#: static/js/impala/stats/csv_keys.js:76 static/js/zamboni/stats-all.js:15357 static/js/zamboni/stats-min.js:4
+msgid "Category Pages"
+msgstr ""
+
+#: static/js/impala/stats/csv_keys.js:77 static/js/zamboni/stats-all.js:15358 static/js/zamboni/stats-min.js:4
+msgid "Collections"
+msgstr "Samlinger"
+
+#: static/js/impala/stats/csv_keys.js:78 static/js/impala/stats/csv_keys.js:79 static/js/zamboni/stats-all.js:15359 static/js/zamboni/stats-all.js:15360 static/js/zamboni/stats-min.js:4
+msgid "Category Landing Featured Carousel"
+msgstr ""
+
+#: static/js/impala/stats/csv_keys.js:80 static/js/impala/stats/csv_keys.js:81 static/js/zamboni/stats-all.js:15361 static/js/zamboni/stats-all.js:15362 static/js/zamboni/stats-min.js:4
+msgid "Category Landing Top Rated"
+msgstr ""
+
+#: static/js/impala/stats/csv_keys.js:82 static/js/impala/stats/csv_keys.js:83 static/js/zamboni/stats-all.js:15363 static/js/zamboni/stats-all.js:15364 static/js/zamboni/stats-min.js:5
+msgid "Category Landing Most Popular"
+msgstr ""
+
+#: static/js/impala/stats/csv_keys.js:84 static/js/impala/stats/csv_keys.js:85 static/js/zamboni/stats-all.js:15365 static/js/zamboni/stats-all.js:15366 static/js/zamboni/stats-min.js:5
+msgid "Category Landing Recently Added"
+msgstr ""
+
+#: static/js/impala/stats/csv_keys.js:86 static/js/impala/stats/csv_keys.js:87 static/js/zamboni/stats-all.js:15367 static/js/zamboni/stats-all.js:15368 static/js/zamboni/stats-min.js:5
+msgid "Browse Listing Featured Sort"
+msgstr ""
+
+#: static/js/impala/stats/csv_keys.js:88 static/js/impala/stats/csv_keys.js:89 static/js/zamboni/stats-all.js:15369 static/js/zamboni/stats-all.js:15370 static/js/zamboni/stats-min.js:5
+msgid "Browse Listing Users Sort"
+msgstr ""
+
+#: static/js/impala/stats/csv_keys.js:90 static/js/impala/stats/csv_keys.js:91 static/js/zamboni/stats-all.js:15371 static/js/zamboni/stats-all.js:15372 static/js/zamboni/stats-min.js:5
+msgid "Browse Listing Rating Sort"
+msgstr ""
+
+#: static/js/impala/stats/csv_keys.js:92 static/js/impala/stats/csv_keys.js:93 static/js/zamboni/stats-all.js:15373 static/js/zamboni/stats-all.js:15374 static/js/zamboni/stats-min.js:5
+msgid "Browse Listing Created Sort"
+msgstr ""
+
+#: static/js/impala/stats/csv_keys.js:94 static/js/impala/stats/csv_keys.js:95 static/js/zamboni/stats-all.js:15375 static/js/zamboni/stats-all.js:15376 static/js/zamboni/stats-min.js:5
+msgid "Browse Listing Name Sort"
+msgstr ""
+
+#: static/js/impala/stats/csv_keys.js:96 static/js/impala/stats/csv_keys.js:97 static/js/zamboni/stats-all.js:15377 static/js/zamboni/stats-all.js:15378 static/js/zamboni/stats-min.js:5
+msgid "Browse Listing Popular Sort"
+msgstr ""
+
+#: static/js/impala/stats/csv_keys.js:98 static/js/impala/stats/csv_keys.js:99 static/js/zamboni/stats-all.js:15379 static/js/zamboni/stats-all.js:15380 static/js/zamboni/stats-min.js:5
+msgid "Browse Listing Updated Sort"
+msgstr ""
+
+#: static/js/impala/stats/csv_keys.js:100 static/js/impala/stats/csv_keys.js:101 static/js/zamboni/stats-all.js:15381 static/js/zamboni/stats-all.js:15382 static/js/zamboni/stats-min.js:5
+msgid "Browse Listing Up and Coming Sort"
+msgstr ""
+
+#: static/js/impala/stats/csv_keys.js:105 static/js/zamboni/stats-all.js:15386 static/js/zamboni/stats-min.js:5
+msgid "Total Amount Contributed"
+msgstr "Samlet beløb bidraget"
+
+#: static/js/impala/stats/csv_keys.js:106 static/js/zamboni/stats-all.js:15387 static/js/zamboni/stats-min.js:5
+msgid "Average Contribution"
+msgstr "Gennemsnitligt bidrag"
+
+#: static/js/impala/stats/csv_keys.js:115 static/js/zamboni/stats-all.js:15396 static/js/zamboni/stats-min.js:5
+msgid "Usage"
+msgstr "Brug"
+
+#: static/js/impala/stats/csv_keys.js:118 static/js/zamboni/stats-all.js:15399 static/js/zamboni/stats-min.js:5
+msgid "Firefox"
+msgstr "Firefox"
+
+#: static/js/impala/stats/csv_keys.js:119 static/js/zamboni/stats-all.js:15400 static/js/zamboni/stats-min.js:5
+msgid "Mozilla"
+msgstr "Mozilla"
+
+#: static/js/impala/stats/csv_keys.js:120 static/js/zamboni/stats-all.js:15401 static/js/zamboni/stats-min.js:5
+msgid "Thunderbird"
+msgstr "Thunderbird"
+
+#: static/js/impala/stats/csv_keys.js:121 static/js/zamboni/stats-all.js:15402 static/js/zamboni/stats-min.js:5
+msgid "Sunbird"
+msgstr "Sunbird"
+
+#: static/js/impala/stats/csv_keys.js:122 static/js/zamboni/stats-all.js:15403 static/js/zamboni/stats-min.js:5
+msgid "SeaMonkey"
+msgstr "SeaMonkey"
+
+#: static/js/impala/stats/csv_keys.js:123 static/js/zamboni/stats-all.js:15404 static/js/zamboni/stats-min.js:5
+msgid "Fennec"
+msgstr "Mobilen"
+
+#: static/js/impala/stats/csv_keys.js:124 static/js/zamboni/stats-all.js:15405 static/js/zamboni/stats-min.js:5
+msgid "Android"
+msgstr "Android"
+
+#. L10n: {0} is an integer.
+#: static/js/impala/stats/csv_keys.js:129 static/js/zamboni/stats-all.js:15410 static/js/zamboni/stats-min.js:5
+msgid "Downloads and Daily Users, last {0} days"
+msgstr "Downloads og daglige brugere, de seneste {0} dage"
+
+#. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
+#: static/js/impala/stats/csv_keys.js:131 static/js/zamboni/stats-all.js:15412 static/js/zamboni/stats-min.js:5
+msgid "Downloads and Daily Users from {0} to {1}"
+msgstr "Downloads and og daglige brugere fra {0} til {1}"
+
+#. L10n: {0} is an integer.
+#: static/js/impala/stats/csv_keys.js:135 static/js/zamboni/stats-all.js:15416 static/js/zamboni/stats-min.js:5
+msgid "Installs and Daily Users, last {0} days"
+msgstr "Installeringer og daglige brugere, de seneste {0} dage"
+
+#. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
+#: static/js/impala/stats/csv_keys.js:137 static/js/zamboni/stats-all.js:15418 static/js/zamboni/stats-min.js:5
+msgid "Installs and Daily Users from {0} to {1}"
+msgstr "Installeringer og daglige brugere fra den {0} til den {1}"
+
+#. L10n: {0} is an integer.
+#: static/js/impala/stats/csv_keys.js:141 static/js/zamboni/stats-all.js:15422 static/js/zamboni/stats-min.js:5
+msgid "Downloads, last {0} days"
+msgstr "Downloads, de seneste {0} dage"
+
+#. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
+#: static/js/impala/stats/csv_keys.js:143 static/js/zamboni/stats-all.js:15424 static/js/zamboni/stats-min.js:5
+msgid "Downloads from {0} to {1}"
+msgstr "Downloads fra {0} til {1}"
+
+#. L10n: {0} is an integer.
+#: static/js/impala/stats/csv_keys.js:147 static/js/zamboni/stats-all.js:15428 static/js/zamboni/stats-min.js:5
+msgid "Daily Users, last {0} days"
+msgstr "Daglige brugere, de seneste {0} dage"
+
+#. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
+#: static/js/impala/stats/csv_keys.js:149 static/js/zamboni/stats-all.js:15430 static/js/zamboni/stats-min.js:5
+msgid "Daily Users from {0} to {1}"
+msgstr "Daglige brugere fra {0} til {1}"
+
+#. L10n: {0} is an integer.
+#: static/js/impala/stats/csv_keys.js:153 static/js/zamboni/stats-all.js:15434 static/js/zamboni/stats-min.js:5
+msgid "Applications, last {0} days"
+msgstr "Programmer, de seneste {0} dage"
+
+#. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
+#: static/js/impala/stats/csv_keys.js:155 static/js/zamboni/stats-all.js:15436 static/js/zamboni/stats-min.js:5
+msgid "Applications from {0} to {1}"
+msgstr "Programmer fra {0} til {1}"
+
+#. L10n: {0} is an integer.
+#: static/js/impala/stats/csv_keys.js:159 static/js/zamboni/stats-all.js:15440 static/js/zamboni/stats-min.js:5
+msgid "Platforms, last {0} days"
+msgstr "Platforme, de seneste {0} dage"
+
+#. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
+#: static/js/impala/stats/csv_keys.js:161 static/js/zamboni/stats-all.js:15442 static/js/zamboni/stats-min.js:5
+msgid "Platforms from {0} to {1}"
+msgstr "Platforme fra {0} til {1}"
+
+#. L10n: {0} is an integer.
+#: static/js/impala/stats/csv_keys.js:165 static/js/zamboni/stats-all.js:15446 static/js/zamboni/stats-min.js:5
+msgid "Languages, last {0} days"
+msgstr "Sprog, de seneste {0} dage"
+
+#. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
+#: static/js/impala/stats/csv_keys.js:167 static/js/zamboni/stats-all.js:15448 static/js/zamboni/stats-min.js:5
+msgid "Languages from {0} to {1}"
+msgstr "Sprog fra {0} til {1}"
+
+#. L10n: {0} is an integer.
+#: static/js/impala/stats/csv_keys.js:171 static/js/zamboni/stats-all.js:15452 static/js/zamboni/stats-min.js:5
+msgid "Add-on Versions, last {0} days"
+msgstr "Versioner, de seneste {0} dage"
+
+#. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
+#: static/js/impala/stats/csv_keys.js:173 static/js/zamboni/stats-all.js:15454 static/js/zamboni/stats-min.js:5
+msgid "Add-on Versions from {0} to {1}"
+msgstr "Versioner fra {0} til {1}"
+
+#. L10n: {0} is an integer.
+#: static/js/impala/stats/csv_keys.js:177 static/js/zamboni/stats-all.js:15458 static/js/zamboni/stats-min.js:5
+msgid "Add-on Status, last {0} days"
+msgstr "Status, de seneste {0} dage"
+
+#. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
+#: static/js/impala/stats/csv_keys.js:179 static/js/zamboni/stats-all.js:15460 static/js/zamboni/stats-min.js:5
+msgid "Add-on Status from {0} to {1}"
+msgstr "Status fra {0} til {1}"
+
+#. L10n: {0} is an integer.
+#: static/js/impala/stats/csv_keys.js:183 static/js/zamboni/stats-all.js:15464 static/js/zamboni/stats-min.js:5
+msgid "Download Sources, last {0} days"
+msgstr "Download-kilder, de seneste {0} dage"
+
+#. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
+#: static/js/impala/stats/csv_keys.js:185 static/js/zamboni/stats-all.js:15466 static/js/zamboni/stats-min.js:5
+msgid "Download Sources from {0} to {1}"
+msgstr "Download-kilder fra {0} til {1}"
+
+#. L10n: {0} is an integer.
+#: static/js/impala/stats/csv_keys.js:189 static/js/zamboni/stats-all.js:15470 static/js/zamboni/stats-min.js:5
+msgid "Contributions, last {0} days"
+msgstr "Bidrag, de seneste {0} dage"
+
+#. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
+#: static/js/impala/stats/csv_keys.js:191 static/js/zamboni/stats-all.js:15472 static/js/zamboni/stats-min.js:5
+msgid "Contributions from {0} to {1}"
+msgstr "Bidrag fra {0} til {1}"
+
+#. L10n: {0} is an integer.
+#: static/js/impala/stats/csv_keys.js:195 static/js/zamboni/stats-all.js:15476 static/js/zamboni/stats-min.js:5
+msgid "Site Metrics, last {0} days"
+msgstr "Webstedsmålinger, de seneste {0} dage"
+
+#. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
+#: static/js/impala/stats/csv_keys.js:197 static/js/zamboni/stats-all.js:15478 static/js/zamboni/stats-min.js:5
+msgid "Site Metrics from {0} to {1}"
+msgstr "Webstedsmålinger fra den {0} til den {1}"
+
+#. L10n: {0} is an integer.
+#: static/js/impala/stats/csv_keys.js:201 static/js/zamboni/stats-all.js:15482 static/js/zamboni/stats-min.js:5
+msgid "Add-ons in Use, last {0} days"
+msgstr "Tilføjelser i brug, de seneste {0} dage"
+
+#. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
+#: static/js/impala/stats/csv_keys.js:203 static/js/zamboni/stats-all.js:15484 static/js/zamboni/stats-min.js:5
+msgid "Add-ons in Use from {0} to {1}"
+msgstr "Tilføjelser i brug fra den {0} til den {1}"
+
+#. L10n: {0} is an integer.
+#: static/js/impala/stats/csv_keys.js:207 static/js/zamboni/stats-all.js:15488 static/js/zamboni/stats-min.js:5
+msgid "Add-ons Downloaded, last {0} days"
+msgstr "Tilføjelser downloaded, de seneste {0} dage"
+
+#. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
+#: static/js/impala/stats/csv_keys.js:209 static/js/zamboni/stats-all.js:15490 static/js/zamboni/stats-min.js:5
+msgid "Add-ons Downloaded from {0} to {1}"
+msgstr "Tilføjelser downloaded fra den {0} til den {1}"
+
+#. L10n: {0} is an integer.
+#: static/js/impala/stats/csv_keys.js:213 static/js/zamboni/stats-all.js:15494 static/js/zamboni/stats-min.js:5
+msgid "Add-ons Created, last {0} days"
+msgstr "Tilføjelser lavet, de seneste {0} dage"
+
+#. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
+#: static/js/impala/stats/csv_keys.js:215 static/js/zamboni/stats-all.js:15496 static/js/zamboni/stats-min.js:5
+msgid "Add-ons Created from {0} to {1}"
+msgstr "Tilføjelser lavet fra den {0} til den {1}"
+
+#. L10n: {0} is an integer.
+#: static/js/impala/stats/csv_keys.js:219 static/js/zamboni/stats-all.js:15500 static/js/zamboni/stats-min.js:5
+msgid "Add-ons Updated, last {0} days"
+msgstr "Tilføjelser opdateret"
+
+#. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
+#: static/js/impala/stats/csv_keys.js:221 static/js/zamboni/stats-all.js:15502 static/js/zamboni/stats-min.js:5
+msgid "Add-ons Updated from {0} to {1}"
+msgstr "Tilføjelser opdateret fra den {0} til den {1}"
+
+#. L10n: {0} is an integer.
+#: static/js/impala/stats/csv_keys.js:225 static/js/zamboni/stats-all.js:15506 static/js/zamboni/stats-min.js:5
+msgid "Reviews Written, last {0} days"
+msgstr "Anmeldelser skrevet, de seneste {0} dage"
+
+#. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
+#: static/js/impala/stats/csv_keys.js:227 static/js/zamboni/stats-all.js:15508 static/js/zamboni/stats-min.js:5
+msgid "Reviews Written from {0} to {1}"
+msgstr "Anmeldelser skrevet fra den {0} til den {1}"
+
+#. L10n: {0} is an integer.
+#: static/js/impala/stats/csv_keys.js:231 static/js/zamboni/stats-all.js:15512 static/js/zamboni/stats-min.js:5
+msgid "User Signups, last {0} days"
+msgstr ""
+
+#. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
+#: static/js/impala/stats/csv_keys.js:233 static/js/zamboni/stats-all.js:15514 static/js/zamboni/stats-min.js:5
+msgid "User Signups from {0} to {1}"
+msgstr ""
+
+#. L10n: {0} is an integer.
+#: static/js/impala/stats/csv_keys.js:237 static/js/zamboni/stats-all.js:15518 static/js/zamboni/stats-min.js:5
+msgid "Collections Created, last {0} days"
+msgstr "Samlinger oprettet, de seneste {0} dage"
+
+#. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
+#: static/js/impala/stats/csv_keys.js:239 static/js/zamboni/stats-all.js:15520 static/js/zamboni/stats-min.js:5
+msgid "Collections Created from {0} to {1}"
+msgstr "Samlinger oprettet far den {0} til den {1}"
+
+#. L10n: {0} is an integer.
+#: static/js/impala/stats/csv_keys.js:243 static/js/zamboni/stats-all.js:15524 static/js/zamboni/stats-min.js:5
+msgid "Subscribers, last {0} days"
+msgstr "Abonnenter, de seneste {0} dage"
+
+#. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
+#: static/js/impala/stats/csv_keys.js:245 static/js/zamboni/stats-all.js:15526 static/js/zamboni/stats-min.js:5
+msgid "Subscribers from {0} to {1}"
+msgstr ""
+
+#. L10n: {0} is an integer.
+#: static/js/impala/stats/csv_keys.js:249 static/js/zamboni/stats-all.js:15530 static/js/zamboni/stats-min.js:5
+msgid "Ratings, last {0} days"
+msgstr "Bedømmelser, de seneste {0} dage"
+
+#. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
+#: static/js/impala/stats/csv_keys.js:251 static/js/zamboni/stats-all.js:15532 static/js/zamboni/stats-min.js:5
+msgid "Ratings from {0} to {1}"
+msgstr "Bedømmelser fra den {0} til den {1}"
+
+#. L10n: {0} is an integer.
+#: static/js/impala/stats/csv_keys.js:255 static/js/zamboni/stats-all.js:15536 static/js/zamboni/stats-min.js:5
+msgid "Sales, last {0} days"
+msgstr "Salg, de seneste {0} dage"
+
+#. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
+#: static/js/impala/stats/csv_keys.js:257 static/js/zamboni/stats-all.js:15538 static/js/zamboni/stats-min.js:5
+msgid "Sales from {0} to {1}"
+msgstr "Salg fra den {0} til den {1}"
+
+#. L10n: {0} is an integer.
+#: static/js/impala/stats/csv_keys.js:261 static/js/zamboni/stats-all.js:15542 static/js/zamboni/stats-min.js:5
+msgid "Installs, last {0} days"
+msgstr "Installeringer, de seneste {0} dage"
+
+#. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
+#: static/js/impala/stats/csv_keys.js:263 static/js/zamboni/stats-all.js:15544 static/js/zamboni/stats-min.js:5
+msgid "Installs from {0} to {1}"
+msgstr "Installeringer fra den {0} til den {1}"
+
+#. L10n: {0} and {1} are integers.
+#: static/js/impala/stats/csv_keys.js:269 static/js/zamboni/stats-all.js:15550 static/js/zamboni/stats-min.js:5
+msgid "<b>{0}</b> in last {1} days"
+msgstr "<b>{0}</b> i de seneste {1} dage"
+
+#. L10n: {0} is an integer and {1} and {2} are dates in YYYY-MM-DD format.
+#: static/js/impala/stats/csv_keys.js:271 static/js/impala/stats/csv_keys.js:277 static/js/zamboni/stats-all.js:15552 static/js/zamboni/stats-all.js:15558 static/js/zamboni/stats-min.js:5
+msgid "<b>{0}</b> from {1} to {2}"
+msgstr "<b>{0}</b> fra {1} til {2}"
+
+#. L10n: {0} and {1} are integers.
+#: static/js/impala/stats/csv_keys.js:275 static/js/zamboni/stats-all.js:15556 static/js/zamboni/stats-min.js:5
+msgid "<b>{0}</b> average in last {1} days"
+msgstr "<b>{0}</b> i genemsnit i de seneste {1} dage"
+
+#: static/js/impala/stats/overview.js:19 static/js/zamboni/stats-all.js:16469 static/js/zamboni/stats-min.js:5
+msgid "No data available."
+msgstr "Ingen data tilgængelig."
+
+#: static/js/impala/stats/table.js:74 static/js/zamboni/stats-all.js:17209 static/js/zamboni/stats-min.js:5
+msgid "Date"
+msgstr "Dato"
+
+#: static/js/impala/stats/topchart.js:96 static/js/zamboni/stats-all.js:16600 static/js/zamboni/stats-min.js:5
+msgid "Other"
+msgstr "Andre"
+
+#: static/js/zamboni/admin-all.js:180 static/js/zamboni/admin-min.js:1 static/js/zamboni/admin_validation.js:24 static/js/zamboni/devhub-all.js:2408 static/js/zamboni/devhub-min.js:2
+#: static/js/zamboni/devhub.js:1229 static/js/zamboni/editors-all.js:15576 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:295
+msgid "Select an application first"
+msgstr "Vælg et program først"
+
+#: static/js/zamboni/admin-all.js:207 static/js/zamboni/admin-min.js:1 static/js/zamboni/admin_validation.js:51
+msgid "Set {0} add-on to a max version of {1} and email the author."
+msgid_plural "Set {0} add-ons to a max version of {1} and email the authors."
+msgstr[0] ""
+msgstr[1] ""
+
+#: static/js/zamboni/admin-all.js:210 static/js/zamboni/admin-min.js:1 static/js/zamboni/admin_validation.js:54
+msgid "Email author of {2} add-on which failed validation."
+msgid_plural "Email authors of {2} add-ons which failed validation."
+msgstr[0] ""
+msgstr[1] ""
+
+#: static/js/zamboni/devhub-all.js:1289 static/js/zamboni/devhub-min.js:1 static/js/zamboni/devhub.js:110
+msgid "Your browser does not support the video tag"
+msgstr "Din browser understøtter ikke denne video-tag"
+
+#: static/js/zamboni/devhub-all.js:1550 static/js/zamboni/devhub-min.js:1 static/js/zamboni/devhub.js:371
+msgid "Changes Saved"
+msgstr "Ændringer gemt"
+
+#: static/js/zamboni/devhub-all.js:1566 static/js/zamboni/devhub-min.js:1 static/js/zamboni/devhub.js:387
+msgid "Enter a new author's email address"
+msgstr ""
+
+#: static/js/zamboni/devhub-all.js:1715 static/js/zamboni/devhub-min.js:1 static/js/zamboni/devhub.js:536
+msgid "There was an error uploading your file."
+msgstr ""
+
+#: static/js/zamboni/devhub-all.js:1860 static/js/zamboni/devhub-min.js:1 static/js/zamboni/devhub.js:681
+msgid "{files} file"
+msgid_plural "{files} files"
+msgstr[0] "{files} fil"
+msgstr[1] "{files} filer"
+
+#: static/js/zamboni/devhub-all.js:1863 static/js/zamboni/devhub-min.js:1 static/js/zamboni/devhub.js:684
+msgid "{reviews} user review"
+msgid_plural "{reviews} user reviews"
+msgstr[0] ""
+msgstr[1] ""
+
+#: static/js/zamboni/devhub-all.js:1975 static/js/zamboni/devhub-min.js:2 static/js/zamboni/devhub.js:796
+msgid "Learn more"
+msgstr "Lær mere"
+
+#: static/js/zamboni/devhub-all.js:1979 static/js/zamboni/devhub-min.js:2 static/js/zamboni/devhub.js:800
+msgid "Example"
+msgstr "Eksempel"
+
+#: static/js/zamboni/devhub-all.js:2309 static/js/zamboni/devhub-min.js:2 static/js/zamboni/devhub.js:1130
+msgid "Image changes being processed"
+msgstr ""
+
+#: static/js/zamboni/devhub-all.js:2459 static/js/zamboni/devhub-min.js:2 static/js/zamboni/devhub.js:1280
+msgid "Must be a valid e-mail address."
+msgstr "Skal være en gyldig mailadresse."
+
+#: static/js/zamboni/devhub-all.js:2613 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:80
 msgid "All tests passed successfully."
 msgstr ""
 
-#: static/js/zamboni/validator.js:83 static/js/zamboni/validator.js:478
+#: static/js/zamboni/devhub-all.js:2616 static/js/zamboni/devhub-all.js:3011 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:83 static/js/zamboni/validator.js:478
 msgid "These tests were not run."
 msgstr ""
 
-#: static/js/zamboni/validator.js:131 static/js/zamboni/validator.js:144
+#: static/js/zamboni/devhub-all.js:2664 static/js/zamboni/devhub-all.js:2677 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:131 static/js/zamboni/validator.js:144
 msgid "Tests"
 msgstr "Tests"
 
-#: static/js/zamboni/validator.js:246 static/js/zamboni/validator.js:575 static/js/zamboni/validator.js:594
+#: static/js/zamboni/devhub-all.js:2779 static/js/zamboni/devhub-all.js:3108 static/js/zamboni/devhub-all.js:3127 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:246
+#: static/js/zamboni/validator.js:575 static/js/zamboni/validator.js:594
 msgid "Error"
 msgstr "Fejl"
 
-#: static/js/zamboni/validator.js:247
+#: static/js/zamboni/devhub-all.js:2780 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:247
 msgid "Warning"
 msgstr "Advarsel"
 
-#: static/js/zamboni/validator.js:299
+#: static/js/zamboni/devhub-all.js:2794 static/js/zamboni/devhub-min.js:2 static/js/zamboni/files-all.js:5657 static/js/zamboni/files-min.js:3 static/js/zamboni/files.js:411
+#: static/js/zamboni/validator.js:261
+msgid "Ignore this message in future updates"
+msgstr ""
+
+#: static/js/zamboni/devhub-all.js:2817 static/js/zamboni/devhub-min.js:2 static/js/zamboni/files-all.js:5663 static/js/zamboni/files-min.js:3 static/js/zamboni/files.js:417
+#: static/js/zamboni/validator.js:284
+msgid "Severity for automated signing:"
+msgstr ""
+
+#: static/js/zamboni/devhub-all.js:2832 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:299
 msgid "Suggestions for passing automated signing:"
 msgstr ""
 
-#: static/js/zamboni/validator.js:387
+#: static/js/zamboni/devhub-all.js:2920 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:387
 msgid "Compatibility Tests"
 msgstr "Kompatibilitetstest"
 
-#: static/js/zamboni/validator.js:466
+#: static/js/zamboni/devhub-all.js:2999 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:466
 msgid "Add-on failed validation."
 msgstr ""
 
-#: static/js/zamboni/validator.js:468
+#: static/js/zamboni/devhub-all.js:3001 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:468
 msgid "Add-on passed validation."
 msgstr ""
 
-#: static/js/zamboni/validator.js:481
+#: static/js/zamboni/devhub-all.js:3014 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:481
 msgid "{0} error"
 msgid_plural "{0} errors"
 msgstr[0] "{0} fejl"
 msgstr[1] "{0} fejl"
 
-#: static/js/zamboni/validator.js:483
+#: static/js/zamboni/devhub-all.js:3016 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:483
 msgid "{0} warning"
 msgid_plural "{0} warnings"
 msgstr[0] "{0} advarsel"
 msgstr[1] "{0} advarsler"
 
-#: static/js/zamboni/validator.js:485
+#: static/js/zamboni/devhub-all.js:3018 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:485
 msgid "{0} notice"
 msgid_plural "{0} notices"
 msgstr[0] "{0} bemærkning"
 msgstr[1] "{0} bemærkninger"
 
-#: static/js/zamboni/validator.js:577
+#: static/js/zamboni/devhub-all.js:3110 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:577
 msgid "Validation task could not complete or completed with errors"
 msgstr ""
 
-#: static/js/zamboni/validator.js:595
+#: static/js/zamboni/devhub-all.js:3128 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:595
 msgid "Internal server error"
 msgstr "Intern serverfejl"
 
-#: static/js/zamboni/mobile/buttons.js:52
+#: static/js/zamboni/devhub_search.js:8
+msgid "No results found."
+msgstr "Ingen resultater fundet."
+
+#: static/js/zamboni/editors-all.js:15402 static/js/zamboni/editors-min.js:4 static/js/zamboni/editors.js:121
+msgid "{name} was viewing this page first."
+msgstr ""
+
+#: static/js/zamboni/editors-all.js:15452 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:171
+msgid "Receipt checked by app."
+msgstr ""
+
+#: static/js/zamboni/editors-all.js:15454 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:173
+msgid "Receipt was not checked by app."
+msgstr ""
+
+#: static/js/zamboni/editors-all.js:15525 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:244
+msgid "{name} was viewing this add-on first."
+msgstr ""
+
+#: static/js/zamboni/editors-all.js:15536 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:255
+msgid "Loading&hellip;"
+msgstr "Indlæser&hellip;"
+
+#: static/js/zamboni/editors-all.js:15541 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:260
+msgid "Version Notes"
+msgstr "Versionsbemærkninger"
+
+#: static/js/zamboni/editors-all.js:15546 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:265
+msgid "Notes for Reviewers"
+msgstr ""
+
+#: static/js/zamboni/editors-all.js:15551 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:270
+msgid "No version notes found"
+msgstr "Ingen versionsbemærkninger fundet"
+
+#: static/js/zamboni/editors-all.js:15611 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:330
+msgid "Average Reviews"
+msgstr ""
+
+#: static/js/zamboni/editors-all.js:15667 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:386
+msgid "Number of Reviews"
+msgstr ""
+
+#: static/js/zamboni/editors-all.js:15726 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:445
+msgid "Error loading translation"
+msgstr ""
+
+#: static/js/zamboni/editors-all.js:15975 static/js/zamboni/editors-min.js:5 static/js/zamboni/themes_review_templates.js:31
+msgid "Theme"
+msgstr ""
+
+#: static/js/zamboni/editors-all.js:15977 static/js/zamboni/editors-min.js:5 static/js/zamboni/themes_review_templates.js:33
+msgid "Reviewer"
+msgstr ""
+
+#: static/js/zamboni/editors-all.js:15979 static/js/zamboni/editors-min.js:5 static/js/zamboni/themes_review_templates.js:35
+msgid "Status"
+msgstr ""
+
+#: static/js/zamboni/editors-all.js:16196 static/js/zamboni/editors-min.js:5 static/js/zamboni/themes_review.js:176
+msgid "Requested Info"
+msgstr ""
+
+#: static/js/zamboni/editors-all.js:16197 static/js/zamboni/editors-min.js:5 static/js/zamboni/themes_review.js:177
+msgid "Flagged"
+msgstr ""
+
+#: static/js/zamboni/editors-all.js:16198 static/js/zamboni/editors-min.js:5 static/js/zamboni/themes_review.js:178
+msgid "Duplicate"
+msgstr ""
+
+#: static/js/zamboni/editors-all.js:16199 static/js/zamboni/editors-min.js:5 static/js/zamboni/themes_review.js:179
+msgid "Rejected"
+msgstr ""
+
+#: static/js/zamboni/editors-all.js:16200 static/js/zamboni/editors-min.js:5 static/js/zamboni/themes_review.js:180
+msgid "Approved"
+msgstr ""
+
+#: static/js/zamboni/editors-all.js:16444 static/js/zamboni/editors-min.js:5 static/js/zamboni/themes_review.js:424
+msgid "No results found"
+msgstr ""
+
+#: static/js/zamboni/mobile-all.js:15186 static/js/zamboni/mobile/buttons.js:52
 msgid "Not Updated for {0} {1}"
 msgstr "Ikke opdateret til {0} {1}"
 
-#: static/js/zamboni/mobile/buttons.js:53
+#: static/js/zamboni/mobile-all.js:15187 static/js/zamboni/mobile/buttons.js:53
 msgid "Requires Newer Version of {0}"
 msgstr "Kræver en nyere version af {0}"
 
-#: static/js/zamboni/mobile/buttons.js:54
+#: static/js/zamboni/mobile-all.js:15188 static/js/zamboni/mobile/buttons.js:54
 msgid "Unreviewed"
 msgstr ""
 
-#: static/js/zamboni/mobile/buttons.js:55
+#: static/js/zamboni/mobile-all.js:15189 static/js/zamboni/mobile/buttons.js:55
 msgid "Experimental <span>(Learn More)</span>"
 msgstr "Eksperimentel <span>(Lær mere)</span>"
 
-#: static/js/zamboni/mobile/buttons.js:56 static/js/zamboni/mobile/buttons.js:57
+#: static/js/zamboni/mobile-all.js:15190 static/js/zamboni/mobile-all.js:15191 static/js/zamboni/mobile/buttons.js:56 static/js/zamboni/mobile/buttons.js:57
 msgid "Not Available for {0}"
 msgstr "Er ikke tilgængelig til {0}"
 
-#: static/js/zamboni/mobile/buttons.js:58
+#: static/js/zamboni/mobile-all.js:15192 static/js/zamboni/mobile/buttons.js:58
 msgid "Experimental"
 msgstr "Eksperimentel"
 
-#: static/js/zamboni/mobile/buttons.js:59
+#: static/js/zamboni/mobile-all.js:15193 static/js/zamboni/mobile/buttons.js:59
 msgid "Themes Require Newer Version of {0}"
 msgstr "Temaer kræver nyere version af {0}"
 
-#: static/js/zamboni/mobile/buttons.js:60
+#: static/js/zamboni/mobile-all.js:15194 static/js/zamboni/mobile/buttons.js:60
 msgid "Themes Require {0}"
 msgstr "Temaer kræver {0}"
 
-#: static/js/zamboni/mobile/buttons.js:105
+#: static/js/zamboni/mobile-all.js:15239 static/js/zamboni/mobile/buttons.js:105
 msgid "Installing..."
 msgstr "Installerer..."
 
-#: static/js/zamboni/mobile/buttons.js:125
+#: static/js/zamboni/mobile-all.js:15259 static/js/zamboni/mobile/buttons.js:125
 msgid "This add-on has been preliminarily reviewed by Mozilla."
 msgstr "Denne tilføjelse er blevet midlertidigt godkendt af Mozilla."
 
-#: static/js/zamboni/mobile/buttons.js:250
+#: static/js/zamboni/mobile-all.js:15384 static/js/zamboni/mobile/buttons.js:250
 msgid "Keep it"
 msgstr "Behold den"
 
-#: static/js/zamboni/mobile/general.js:344
+#: static/js/zamboni/mobile-all.js:16049 static/js/zamboni/mobile-min.js:6 static/js/zamboni/mobile/general.js:344
 msgid "You're trying it on!"
 msgstr "Du prøver den!"
 
-#: static/js/zamboni/mobile/general.js:356
+#: static/js/zamboni/mobile-all.js:16061 static/js/zamboni/mobile-min.js:6 static/js/zamboni/mobile/general.js:356
 msgid "Added to Firefox"
 msgstr "Føjet til Firefox"
-

--- a/locale/dbg/LC_MESSAGES/django.po
+++ b/locale/dbg/LC_MESSAGES/django.po
@@ -3,69 +3,70 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT 1.0\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2016-02-24 21:23+0000\n"
+"POT-Creation-Date: 2016-04-18 15:47+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
+"Language: \n"
 "MIME-Version: 1.0\n"
-"Content-Type: text/plain; charset=utf-8\n"
+"Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Generated-By: Babel 2.2.0\n"
 
-#: src/olympia/accounts/views.py:52
+#: src/olympia/accounts/views.py:54
 msgid "Your log in attempt could not be parsed. Please try again."
 msgstr "Ẏǿŭř ŀǿɠ īƞ ȧŧŧḗḿƥŧ ƈǿŭŀḓ ƞǿŧ ƀḗ ƥȧřşḗḓ. Ƥŀḗȧşḗ ŧřẏ ȧɠȧīƞ."
 
-#: src/olympia/accounts/views.py:54
+#: src/olympia/accounts/views.py:56
 msgid "Your Firefox Account could not be found. Please try again."
 msgstr "Ẏǿŭř Ƒīřḗƒǿẋ Ȧƈƈǿŭƞŧ ƈǿŭŀḓ ƞǿŧ ƀḗ ƒǿŭƞḓ. Ƥŀḗȧşḗ ŧřẏ ȧɠȧīƞ."
 
-#: src/olympia/accounts/views.py:55
+#: src/olympia/accounts/views.py:57
 msgid "You could not be logged in. Please try again."
 msgstr "Ẏǿŭ ƈǿŭŀḓ ƞǿŧ ƀḗ ŀǿɠɠḗḓ īƞ. Ƥŀḗȧşḗ ŧřẏ ȧɠȧīƞ."
 
-#: src/olympia/accounts/views.py:57
+#: src/olympia/accounts/views.py:59
 msgid "Your account has already been migrated to Firefox Accounts."
 msgstr "Ẏǿŭř ȧƈƈǿŭƞŧ ħȧş ȧŀřḗȧḓẏ ƀḗḗƞ ḿīɠřȧŧḗḓ ŧǿ Ƒīřḗƒǿẋ Ȧƈƈǿŭƞŧş."
 
-#: src/olympia/accounts/views.py:59
+#: src/olympia/accounts/views.py:61
 msgid "Your Firefox Account already exists on this site."
 msgstr "Ẏǿŭř Ƒīřḗƒǿẋ Ȧƈƈǿŭƞŧ ȧŀřḗȧḓẏ ḗẋīşŧş ǿƞ ŧħīş şīŧḗ."
 
-#: src/olympia/accounts/views.py:108
+#: src/olympia/accounts/views.py:110
 msgid "Great job!"
 msgstr "Ɠřḗȧŧ ĵǿƀ!"
 
-#: src/olympia/accounts/views.py:109
+#: src/olympia/accounts/views.py:111
 msgid "You can now log in to Add-ons with your Firefox Account."
 msgstr "Ẏǿŭ ƈȧƞ ƞǿẇ ŀǿɠ īƞ ŧǿ Ȧḓḓ-ǿƞş ẇīŧħ ẏǿŭř Ƒīřḗƒǿẋ Ȧƈƈǿŭƞŧ."
 
-#: src/olympia/accounts/views.py:121
+#: src/olympia/accounts/views.py:123
 msgid "Need help?"
 msgstr "Ƞḗḗḓ ħḗŀƥ?"
 
-#: src/olympia/addons/buttons.py:180
+#: src/olympia/addons/buttons.py:177
 msgid "Download Now"
 msgstr "Ḓǿẇƞŀǿȧḓ Ƞǿẇ"
 
-#: src/olympia/addons/buttons.py:182
+#: src/olympia/addons/buttons.py:179
 msgid "Download"
 msgstr "Ḓǿẇƞŀǿȧḓ"
 
 #. L10n: please keep &nbsp; in the string so &rarr; does not wrap.
-#: src/olympia/addons/buttons.py:186
+#: src/olympia/addons/buttons.py:183
 msgid "Continue to Download&nbsp;&rarr;"
 msgstr "Ƈǿƞŧīƞŭḗ ŧǿ Ḓǿẇƞŀǿȧḓ&nbsp;&rarr;"
 
-#: src/olympia/addons/buttons.py:202 src/olympia/addons/helpers.py:35 src/olympia/addons/views.py:319 src/olympia/addons/templates/addons/impala/details.html:114
+#: src/olympia/addons/buttons.py:199 src/olympia/addons/helpers.py:35 src/olympia/addons/views.py:333 src/olympia/addons/templates/addons/impala/details.html:111
 #: src/olympia/addons/templates/addons/impala/listing/items.html:17 src/olympia/addons/templates/addons/mobile/home.html:40 src/olympia/amo/templates/amo/side_nav.html:6
-#: src/olympia/amo/templates/amo/side_nav.html:10 src/olympia/amo/templates/amo/site_nav.html:2 src/olympia/amo/templates/amo/site_nav.html:55 src/olympia/bandwagon/views.py:95
-#: src/olympia/browse/views.py:54 src/olympia/browse/views.py:68 src/olympia/browse/views.py:235 src/olympia/browse/templates/browse/impala/category_landing.html:22
+#: src/olympia/amo/templates/amo/side_nav.html:10 src/olympia/amo/templates/amo/site_nav.html:2 src/olympia/amo/templates/amo/site_nav.html:53 src/olympia/bandwagon/views.py:95
+#: src/olympia/browse/views.py:54 src/olympia/browse/views.py:68 src/olympia/browse/views.py:202 src/olympia/browse/templates/browse/impala/category_landing.html:22
 #: src/olympia/browse/templates/browse/personas/mobile/category_landing.html:26
 msgid "Featured"
 msgstr "Ƒḗȧŧŭřḗḓ"
 
-#: src/olympia/addons/buttons.py:221
+#: src/olympia/addons/buttons.py:218
 msgid "Add to {0}"
 msgstr "Ȧḓḓ ŧǿ {0}"
 
@@ -113,39 +114,39 @@ msgid_plural "All tags must be at least {0} characters."
 msgstr[0] "Ȧŀŀ ŧȧɠş ḿŭşŧ ƀḗ ȧŧ ŀḗȧşŧ {0} ƈħȧřȧƈŧḗř."
 msgstr[1] "Ȧŀŀ ŧȧɠş ḿŭşŧ ƀḗ ȧŧ ŀḗȧşŧ {0} ƈħȧřȧƈŧḗřş."
 
-#: src/olympia/addons/forms.py:234
+#: src/olympia/addons/forms.py:238
 msgid "Categories cannot be changed while your add-on is featured for this application."
 msgstr "Ƈȧŧḗɠǿřīḗş ƈȧƞƞǿŧ ƀḗ ƈħȧƞɠḗḓ ẇħīŀḗ ẏǿŭř ȧḓḓ-ǿƞ īş ƒḗȧŧŭřḗḓ ƒǿř ŧħīş ȧƥƥŀīƈȧŧīǿƞ."
 
 #. L10n: {0} is the number of categories.
-#: src/olympia/addons/forms.py:238
+#: src/olympia/addons/forms.py:242
 msgid "You can have only {0} category."
 msgid_plural "You can have only {0} categories."
 msgstr[0] "Ẏǿŭ ƈȧƞ ħȧṽḗ ǿƞŀẏ {0} ƈȧŧḗɠǿřẏ."
 msgstr[1] "Ẏǿŭ ƈȧƞ ħȧṽḗ ǿƞŀẏ {0} ƈȧŧḗɠǿřīḗş."
 
-#: src/olympia/addons/forms.py:246
+#: src/olympia/addons/forms.py:250
 msgid "The miscellaneous category cannot be combined with additional categories."
 msgstr "Ŧħḗ ḿīşƈḗŀŀȧƞḗǿŭş ƈȧŧḗɠǿřẏ ƈȧƞƞǿŧ ƀḗ ƈǿḿƀīƞḗḓ ẇīŧħ ȧḓḓīŧīǿƞȧŀ ƈȧŧḗɠǿřīḗş."
 
-#: src/olympia/addons/forms.py:369
+#: src/olympia/addons/forms.py:374
 #, python-format
 msgid "Before changing your default locale you must have a name, summary, and description in that locale. You are missing %s."
 msgstr "Ɓḗƒǿřḗ ƈħȧƞɠīƞɠ ẏǿŭř ḓḗƒȧŭŀŧ ŀǿƈȧŀḗ ẏǿŭ ḿŭşŧ ħȧṽḗ ȧ ƞȧḿḗ, şŭḿḿȧřẏ, ȧƞḓ ḓḗşƈřīƥŧīǿƞ īƞ ŧħȧŧ ŀǿƈȧŀḗ. Ẏǿŭ ȧřḗ ḿīşşīƞɠ %s."
 
-#: src/olympia/addons/forms.py:484 src/olympia/addons/forms.py:575
+#: src/olympia/addons/forms.py:455 src/olympia/addons/forms.py:546
 msgid "A license must be selected."
 msgstr "Ȧ ŀīƈḗƞşḗ ḿŭşŧ ƀḗ şḗŀḗƈŧḗḓ."
 
-#: src/olympia/addons/forms.py:556
+#: src/olympia/addons/forms.py:527
 msgid "Give Your Theme a Name."
 msgstr "Ɠīṽḗ Ẏǿŭř Ŧħḗḿḗ ȧ Ƞȧḿḗ."
 
-#: src/olympia/addons/forms.py:562 src/olympia/devhub/templates/devhub/personas/submit.html:53
+#: src/olympia/addons/forms.py:533 src/olympia/devhub/templates/devhub/personas/submit.html:53
 msgid "Describe your Theme."
 msgstr "Ḓḗşƈřīƀḗ ẏǿŭř Ŧħḗḿḗ."
 
-#: src/olympia/addons/forms.py:704
+#: src/olympia/addons/forms.py:675
 msgid "Enter a new author's email address"
 msgstr "Ḗƞŧḗř ȧ ƞḗẇ ȧŭŧħǿř'ş ḗḿȧīŀ ȧḓḓřḗşş"
 
@@ -153,37 +154,37 @@ msgstr "Ḗƞŧḗř ȧ ƞḗẇ ȧŭŧħǿř'ş ḗḿȧīŀ ȧḓḓřḗşş"
 msgid "Not Reviewed"
 msgstr "Ƞǿŧ Řḗṽīḗẇḗḓ"
 
-#: src/olympia/addons/models.py:301
+#: src/olympia/addons/models.py:298
 msgid "Users have the option of contributing more or less than this amount."
 msgstr "Ŭşḗřş ħȧṽḗ ŧħḗ ǿƥŧīǿƞ ǿƒ ƈǿƞŧřīƀŭŧīƞɠ ḿǿřḗ ǿř ŀḗşş ŧħȧƞ ŧħīş ȧḿǿŭƞŧ."
 
-#: src/olympia/addons/models.py:309
-msgid "Users will always be asked in the Add-ons Manager (Firefox 4 and above)"
-msgstr "Ŭşḗřş ẇīŀŀ ȧŀẇȧẏş ƀḗ ȧşķḗḓ īƞ ŧħḗ Ȧḓḓ-ǿƞş Ḿȧƞȧɠḗř (Ƒīřḗƒǿẋ 4 ȧƞḓ ȧƀǿṽḗ)"
+#: src/olympia/addons/models.py:306
+msgid "Users will always be asked in the Add-ons Manager (Firefox 4 and above). Only applies to desktop."
+msgstr ""
 
-#: src/olympia/addons/models.py:1804 src/olympia/addons/templates/addons/details_box.html:55 src/olympia/devhub/templates/devhub/index.html:92
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:102
+#: src/olympia/addons/models.py:1802 src/olympia/addons/templates/addons/details_box.html:55 src/olympia/devhub/templates/devhub/index.html:92
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:89
 msgid "Listed"
 msgstr "Ŀīşŧḗḓ"
 
-#: src/olympia/addons/views.py:320 src/olympia/browse/templates/browse/personas/mobile/category_landing.html:27
+#: src/olympia/addons/views.py:334 src/olympia/browse/templates/browse/personas/mobile/category_landing.html:27
 msgid "Popular"
 msgstr "Ƥǿƥŭŀȧř"
 
-#: src/olympia/addons/views.py:321 src/olympia/browse/views.py:238 src/olympia/browse/views.py:280 src/olympia/browse/views.py:482
+#: src/olympia/addons/views.py:335 src/olympia/browse/views.py:205 src/olympia/browse/views.py:247 src/olympia/browse/views.py:449
 msgid "Recently Added"
 msgstr "Řḗƈḗƞŧŀẏ Ȧḓḓḗḓ"
 
-#: src/olympia/addons/views.py:322 src/olympia/bandwagon/views.py:99 src/olympia/browse/views.py:60 src/olympia/browse/views.py:71 src/olympia/search/forms.py:16 src/olympia/search/forms.py:91
+#: src/olympia/addons/views.py:336 src/olympia/bandwagon/views.py:99 src/olympia/browse/views.py:60 src/olympia/browse/views.py:71 src/olympia/search/forms.py:16 src/olympia/search/forms.py:91
 msgid "Recently Updated"
 msgstr "Řḗƈḗƞŧŀẏ Ŭƥḓȧŧḗḓ"
 
 #. l10n: {0} is the addon name
-#: src/olympia/addons/views.py:520
+#: src/olympia/addons/views.py:534
 msgid "Contribution for {0}"
 msgstr "Ƈǿƞŧřīƀŭŧīǿƞ ƒǿř {0}"
 
-#: src/olympia/addons/views.py:613
+#: src/olympia/addons/views.py:627
 msgid "Abuse reported."
 msgstr "Ȧƀŭşḗ řḗƥǿřŧḗḓ."
 
@@ -250,9 +251,9 @@ msgstr "Ƈǿƞŧřīƀŭŧḗ"
 #: src/olympia/devhub/templates/devhub/addons/ajax_compat_update.html:36 src/olympia/devhub/templates/devhub/addons/profile.html:44 src/olympia/devhub/templates/devhub/addons/edit/admin.html:101
 #: src/olympia/devhub/templates/devhub/addons/edit/basic.html:152 src/olympia/devhub/templates/devhub/addons/edit/details.html:85 src/olympia/devhub/templates/devhub/addons/edit/support.html:67
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:166 src/olympia/devhub/templates/devhub/addons/forms_shared/media.html:149
-#: src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:44 src/olympia/devhub/templates/devhub/versions/add_file_modal.html:78 src/olympia/devhub/templates/devhub/versions/edit.html:139
-#: src/olympia/devhub/templates/devhub/versions/list.html:242 src/olympia/devhub/templates/devhub/versions/list.html:276 src/olympia/devhub/templates/devhub/versions/list.html:317
-#: src/olympia/devhub/templates/devhub/versions/list.html:351 src/olympia/reviews/templates/reviews/edit_review.html:16 src/olympia/translations/templates/translations/trans-menu.html:50
+#: src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:43 src/olympia/devhub/templates/devhub/versions/add_file_modal.html:58 src/olympia/devhub/templates/devhub/versions/edit.html:139
+#: src/olympia/devhub/templates/devhub/versions/list.html:239 src/olympia/devhub/templates/devhub/versions/list.html:281 src/olympia/devhub/templates/devhub/versions/list.html:315
+#: src/olympia/devhub/templates/devhub/versions/list.html:349 src/olympia/reviews/templates/reviews/edit_review.html:16 src/olympia/translations/templates/translations/trans-menu.html:50
 #: src/olympia/translations/templates/translations/trans-menu.html:62
 msgid "or"
 msgstr "ǿř"
@@ -366,7 +367,7 @@ msgid "Add-on Information for {0}"
 msgstr "Ȧḓḓ-ǿƞ Īƞƒǿřḿȧŧīǿƞ ƒǿř {0}"
 
 #: src/olympia/addons/templates/addons/details_box.html:30 src/olympia/addons/templates/addons/persona_detail_table.html:3 src/olympia/addons/templates/addons/mobile/details.html:63
-#: src/olympia/addons/templates/addons/mobile/persona_detail_table.html:7 src/olympia/browse/views.py:459 src/olympia/devhub/views.py:75
+#: src/olympia/addons/templates/addons/mobile/persona_detail_table.html:7 src/olympia/browse/views.py:426 src/olympia/devhub/views.py:73
 msgid "Updated"
 msgstr "Ŭƥḓȧŧḗḓ"
 
@@ -385,11 +386,11 @@ msgstr "Ẇǿřķş ẇīŧħ"
 msgid "Visibility"
 msgstr "Ṽīşīƀīŀīŧẏ"
 
-#: src/olympia/addons/templates/addons/details_box.html:57 src/olympia/devhub/templates/devhub/index.html:94 src/olympia/devhub/templates/devhub/includes/addon_details.html:104
+#: src/olympia/addons/templates/addons/details_box.html:57 src/olympia/devhub/templates/devhub/index.html:94 src/olympia/devhub/templates/devhub/includes/addon_details.html:91
 msgid "Hidden"
 msgstr "Ħīḓḓḗƞ"
 
-#: src/olympia/addons/templates/addons/details_box.html:59 src/olympia/devhub/templates/devhub/index.html:96 src/olympia/devhub/templates/devhub/includes/addon_details.html:106
+#: src/olympia/addons/templates/addons/details_box.html:59 src/olympia/devhub/templates/devhub/index.html:96 src/olympia/devhub/templates/devhub/includes/addon_details.html:93
 msgid "Unlisted"
 msgstr "Ŭƞŀīşŧḗḓ"
 
@@ -397,13 +398,13 @@ msgstr "Ŭƞŀīşŧḗḓ"
 msgid "Required Add-ons"
 msgstr "Řḗɋŭīřḗḓ Ȧḓḓ-ǿƞş"
 
-#: src/olympia/addons/templates/addons/details_box.html:81 src/olympia/addons/templates/addons/persona_detail_table.html:15 src/olympia/browse/views.py:462 src/olympia/devhub/views.py:78
-#: src/olympia/devhub/views.py:85 src/olympia/discovery/templates/discovery/addons/detail.html:57 src/olympia/reviews/forms.py:62 src/olympia/reviews/templates/reviews/add.html:57
+#: src/olympia/addons/templates/addons/details_box.html:81 src/olympia/addons/templates/addons/persona_detail_table.html:15 src/olympia/browse/views.py:429 src/olympia/devhub/views.py:76
+#: src/olympia/devhub/views.py:83 src/olympia/discovery/templates/discovery/addons/detail.html:57 src/olympia/reviews/forms.py:62 src/olympia/reviews/templates/reviews/add.html:57
 #: src/olympia/reviews/templates/reviews/mobile/review_list.html:18
 msgid "Rating"
 msgstr "Řȧŧīƞɠ"
 
-#: src/olympia/addons/templates/addons/details_box.html:85 src/olympia/browse/views.py:461 src/olympia/devhub/views.py:77 src/olympia/devhub/views.py:84
+#: src/olympia/addons/templates/addons/details_box.html:85 src/olympia/browse/views.py:428 src/olympia/devhub/views.py:75 src/olympia/devhub/views.py:82
 #: src/olympia/stats/templates/stats/addon_report_menu.html:8 src/olympia/stats/templates/stats/collection_report_menu.html:18
 msgid "Downloads"
 msgstr "Ḓǿẇƞŀǿȧḓş"
@@ -423,7 +424,7 @@ msgstr "Ȧƀŭşḗ Řḗƥǿřŧş"
 
 #. The Privacy Policy for this add-on.
 #: src/olympia/addons/templates/addons/details_box.html:121 src/olympia/addons/templates/addons/privacy.html:19 src/olympia/addons/templates/addons/privacy.html:23
-#: src/olympia/addons/templates/addons/impala/button.html:43 src/olympia/addons/templates/addons/impala/details.html:307 src/olympia/devhub/templates/devhub/includes/policy_form.html:20
+#: src/olympia/addons/templates/addons/impala/button.html:43 src/olympia/addons/templates/addons/impala/details.html:312 src/olympia/devhub/templates/devhub/includes/policy_form.html:23
 #: src/olympia/templates/mobile/base_addons.html:87
 msgid "Privacy Policy"
 msgstr "Ƥřīṽȧƈẏ Ƥǿŀīƈẏ"
@@ -448,7 +449,7 @@ msgstr "Īḿȧɠḗ Ɠȧŀŀḗřẏ"
 msgid "Developer Comments"
 msgstr "Ḓḗṽḗŀǿƥḗř Ƈǿḿḿḗƞŧş"
 
-#: src/olympia/addons/templates/addons/details_box.html:199 src/olympia/addons/templates/addons/impala/details.html:259
+#: src/olympia/addons/templates/addons/details_box.html:199 src/olympia/addons/templates/addons/impala/details.html:264
 msgid "Development Channel"
 msgstr "Ḓḗṽḗŀǿƥḿḗƞŧ Ƈħȧƞƞḗŀ"
 
@@ -472,13 +473,13 @@ msgstr ""
 "<strong>Ƈȧŭŧīǿƞ:</strong> Ḓḗṽḗŀǿƥḿḗƞŧ ṽḗřşīǿƞş ǿƒ ŧħīş ȧḓḓ-ǿƞ ħȧṽḗ ƞǿŧ ƀḗḗƞ řḗṽīḗẇḗḓ ƀẏ Ḿǿzīŀŀȧ. Ǿƞƈḗ ẏǿŭ īƞşŧȧŀŀ ȧ ḓḗṽḗŀǿƥḿḗƞŧ ṽḗřşīǿƞ ẏǿŭ ẇīŀŀ ƈǿƞŧīƞŭḗ ŧǿ řḗƈḗīṽḗ ḓḗṽḗŀǿƥḿḗƞŧ ŭƥḓȧŧḗş ƒřǿḿ ŧħīş "
 "ḓḗṽḗŀǿƥḗř. Ŧǿ şŧǿƥ řḗƈḗīṽīƞɠ ḓḗṽḗŀǿƥḿḗƞŧ ŭƥḓȧŧḗş, řḗīƞşŧȧŀŀ ŧħḗ ḓḗƒȧŭŀŧ ṽḗřşīǿƞ ƒřǿḿ ŧħḗ ŀīƞķ ȧƀǿṽḗ."
 
-#: src/olympia/addons/templates/addons/details_box.html:220 src/olympia/addons/templates/addons/impala/details.html:278
+#: src/olympia/addons/templates/addons/details_box.html:220 src/olympia/addons/templates/addons/impala/details.html:283
 msgid "Version {0}:"
 msgstr "Ṽḗřşīǿƞ {0}:"
 
 #: src/olympia/addons/templates/addons/details_box.html:234
 msgid "Nothing to see here!  The developer did not include any details."
-msgstr "Ƞǿŧħīƞɠ ŧǿ şḗḗ ħḗřḗ!  Ŧħḗ ḓḗṽḗŀǿƥḗř ḓīḓ ƞǿŧ īƞƈŀŭḓḗ ȧƞẏ ḓḗŧȧīŀş."
+msgstr ""
 
 #: src/olympia/addons/templates/addons/details_box.html:251 src/olympia/devhub/templates/devhub/versions/edit.html:73 src/olympia/editors/templates/editors/review.html:98
 msgid "Version Notes"
@@ -491,7 +492,7 @@ msgid "End-User License Agreement for {0}"
 msgstr "Ḗƞḓ-Ŭşḗř Ŀīƈḗƞşḗ Ȧɠřḗḗḿḗƞŧ ƒǿř {0}"
 
 #: src/olympia/addons/templates/addons/eula.html:17 src/olympia/addons/templates/addons/eula.html:21 src/olympia/addons/templates/addons/impala/button.html:48
-#: src/olympia/addons/templates/addons/impala/details.html:316 src/olympia/devhub/templates/devhub/includes/policy_form.html:3 src/olympia/discovery/templates/discovery/addons/eula.html:11
+#: src/olympia/addons/templates/addons/impala/details.html:321 src/olympia/devhub/templates/devhub/includes/policy_form.html:3 src/olympia/discovery/templates/discovery/addons/eula.html:11
 msgid "End-User License Agreement"
 msgstr "Ḗƞḓ-Ŭşḗř Ŀīƈḗƞşḗ Ȧɠřḗḗḿḗƞŧ"
 
@@ -508,7 +509,7 @@ msgstr "Ɓȧƈķ ŧǿ {0}…"
 msgid "Add-ons for {0}"
 msgstr "Ȧḓḓ-ǿƞş ƒǿř {0}"
 
-#: src/olympia/addons/templates/addons/home.html:10 src/olympia/addons/templates/addons/home.html:51 src/olympia/browse/templates/browse/impala/base_listing.html:11
+#: src/olympia/addons/templates/addons/home.html:10 src/olympia/addons/templates/addons/home.html:53 src/olympia/browse/templates/browse/impala/base_listing.html:11
 msgid "Featured Extensions"
 msgstr "Ƒḗȧŧŭřḗḓ Ḗẋŧḗƞşīǿƞş"
 
@@ -516,29 +517,29 @@ msgstr "Ƒḗȧŧŭřḗḓ Ḗẋŧḗƞşīǿƞş"
 msgid "Popular Extensions"
 msgstr "Ƥǿƥŭŀȧř Ḗẋŧḗƞşīǿƞş"
 
-#: src/olympia/addons/templates/addons/home.html:42 src/olympia/amo/templates/amo/side_nav.html:3 src/olympia/amo/templates/amo/side_nav.html:11 src/olympia/amo/templates/amo/site_nav.html:3
-#: src/olympia/amo/templates/amo/site_nav.html:25 src/olympia/browse/views.py:236 src/olympia/browse/views.py:281 src/olympia/browse/views.py:481
+#: src/olympia/addons/templates/addons/home.html:44 src/olympia/amo/templates/amo/side_nav.html:3 src/olympia/amo/templates/amo/side_nav.html:11 src/olympia/amo/templates/amo/site_nav.html:3
+#: src/olympia/amo/templates/amo/site_nav.html:25 src/olympia/browse/views.py:203 src/olympia/browse/views.py:248 src/olympia/browse/views.py:448
 msgid "Most Popular"
 msgstr "Ḿǿşŧ Ƥǿƥŭŀȧř"
 
-#: src/olympia/addons/templates/addons/home.html:43
+#: src/olympia/addons/templates/addons/home.html:45
 msgid "All »"
 msgstr "Ȧŀŀ »"
 
-#: src/olympia/addons/templates/addons/home.html:52 src/olympia/addons/templates/addons/home.html:61 src/olympia/addons/templates/addons/home.html:70 src/olympia/addons/templates/addons/home.html:78
+#: src/olympia/addons/templates/addons/home.html:54 src/olympia/addons/templates/addons/home.html:63 src/olympia/addons/templates/addons/home.html:72 src/olympia/addons/templates/addons/home.html:80
 #: src/olympia/browse/templates/browse/impala/category_landing.html:36
 msgid "See all »"
 msgstr "Şḗḗ ȧŀŀ »"
 
-#: src/olympia/addons/templates/addons/home.html:60
+#: src/olympia/addons/templates/addons/home.html:62
 msgid "Up &amp; Coming Extensions"
 msgstr "Ŭƥ &amp; Ƈǿḿīƞɠ Ḗẋŧḗƞşīǿƞş"
 
-#: src/olympia/addons/templates/addons/home.html:69 src/olympia/browse/templates/browse/personas/category_landing.html:61 src/olympia/discovery/templates/discovery/pane.html:74
+#: src/olympia/addons/templates/addons/home.html:71 src/olympia/browse/templates/browse/personas/category_landing.html:61 src/olympia/discovery/templates/discovery/pane.html:74
 msgid "Featured Themes"
 msgstr "Ƒḗȧŧŭřḗḓ Ŧħḗḿḗş"
 
-#: src/olympia/addons/templates/addons/home.html:77 src/olympia/bandwagon/templates/bandwagon/impala/collection_listing.html:5
+#: src/olympia/addons/templates/addons/home.html:79 src/olympia/bandwagon/templates/bandwagon/impala/collection_listing.html:5
 msgid "Featured Collections"
 msgstr "Ƒḗȧŧŭřḗḓ Ƈǿŀŀḗƈŧīǿƞş"
 
@@ -556,7 +557,7 @@ msgid "Updated {0}"
 msgstr "Ŭƥḓȧŧḗḓ {0}"
 
 #. {0} is a date.
-#: src/olympia/addons/templates/addons/macros.html:10 src/olympia/addons/templates/addons/macros.html:69 src/olympia/addons/templates/addons/persona_preview.html:21
+#: src/olympia/addons/templates/addons/macros.html:10 src/olympia/addons/templates/addons/macros.html:69 src/olympia/addons/templates/addons/persona_preview.html:22
 #: src/olympia/addons/templates/addons/listing/items_mobile.html:44 src/olympia/addons/templates/addons/listing/macros.html:39
 #: src/olympia/bandwagon/templates/bandwagon/collection_listing_items.html:37 src/olympia/bandwagon/templates/bandwagon/impala/collection_listing_items.html:37
 msgid "Added {0}"
@@ -577,15 +578,14 @@ msgstr[0] "%(num)s ŭşḗř"
 msgstr[1] "%(num)s ŭşḗřş"
 
 #. {0} is the number of downloads.
-#: src/olympia/addons/templates/addons/macros.html:53 src/olympia/addons/templates/addons/impala/details.html:61
+#: src/olympia/addons/templates/addons/macros.html:53 src/olympia/addons/templates/addons/impala/details.html:59
 msgid "{0} weekly download"
 msgid_plural "{0} weekly downloads"
 msgstr[0] "{0} ẇḗḗķŀẏ ḓǿẇƞŀǿȧḓ"
 msgstr[1] "{0} ẇḗḗķŀẏ ḓǿẇƞŀǿȧḓş"
 
 #. {0} is the number of users.
-#: src/olympia/addons/templates/addons/macros.html:61 src/olympia/addons/templates/addons/impala/details.html:54 src/olympia/compat/templates/compat/index.html:71
-#: src/olympia/zadmin/templates/zadmin/compat.html:67
+#: src/olympia/addons/templates/addons/macros.html:61 src/olympia/addons/templates/addons/impala/details.html:52 src/olympia/zadmin/templates/zadmin/compat.html:67
 msgid "{0} user"
 msgid_plural "{0} users"
 msgstr[0] "{0} ŭşḗř"
@@ -603,7 +603,7 @@ msgstr "Ƥȧẏḿḗƞŧ ƈǿḿƥŀḗŧḗḓ"
 msgid "Return to the addon."
 msgstr "Řḗŧŭřƞ ŧǿ ŧħḗ ȧḓḓǿƞ."
 
-#: src/olympia/addons/templates/addons/persona_detail.html:17 src/olympia/addons/templates/addons/impala/details.html:106 src/olympia/addons/templates/addons/mobile/details.html:23
+#: src/olympia/addons/templates/addons/persona_detail.html:17 src/olympia/addons/templates/addons/impala/details.html:103 src/olympia/addons/templates/addons/mobile/details.html:23
 #: src/olympia/addons/templates/addons/mobile/persona_detail.html:21 src/olympia/discovery/templates/discovery/addons/base.html:27 src/olympia/editors/templates/editors/review.html:31
 msgid "by"
 msgstr "ƀẏ"
@@ -647,34 +647,35 @@ msgstr "Ḓȧīŀẏ Ŭşḗřş"
 msgid "License"
 msgstr "Ŀīƈḗƞşḗ"
 
-#: src/olympia/addons/templates/addons/persona_preview.html:12 src/olympia/constants/base.py:48
+#: src/olympia/addons/templates/addons/persona_preview.html:13 src/olympia/constants/base.py:48
 msgid "Awaiting Review"
 msgstr "Ȧẇȧīŧīƞɠ Řḗṽīḗẇ"
 
-#: src/olympia/addons/templates/addons/persona_preview.html:14 src/olympia/amo/log.py:180 src/olympia/constants/base.py:42 src/olympia/editors/helpers.py:62
+#: src/olympia/addons/templates/addons/persona_preview.html:15 src/olympia/amo/log.py:180 src/olympia/constants/base.py:42 src/olympia/editors/helpers.py:62
 msgid "Rejected"
 msgstr "Řḗĵḗƈŧḗḓ"
 
-#: src/olympia/addons/templates/addons/persona_preview.html:16 src/olympia/amo/log.py:159
+#: src/olympia/addons/templates/addons/persona_preview.html:17 src/olympia/amo/log.py:159
 msgid "Approved"
 msgstr "Ȧƥƥřǿṽḗḓ"
 
 #. {0} is the number of users.
-#: src/olympia/addons/templates/addons/persona_preview.html:26 src/olympia/addons/templates/addons/listing/items_mobile.html:36 src/olympia/addons/templates/addons/listing/macros.html:31
+#: src/olympia/addons/templates/addons/persona_preview.html:27 src/olympia/addons/templates/addons/listing/items_mobile.html:36 src/olympia/addons/templates/addons/listing/macros.html:31
 msgid "<strong>{0}</strong> user"
 msgid_plural "<strong>{0}</strong> users"
 msgstr[0] "<strong>{0}</strong> ŭşḗř"
 msgstr[1] "<strong>{0}</strong> ŭşḗřş"
 
-#: src/olympia/addons/templates/addons/persona_preview.html:40
+#: src/olympia/addons/templates/addons/persona_preview.html:41
 msgid "Hover to Preview"
 msgstr "Ħǿṽḗř ŧǿ Ƥřḗṽīḗẇ"
 
-#: src/olympia/addons/templates/addons/persona_preview.html:46 src/olympia/addons/templates/addons/persona_preview.html:48 src/olympia/reviews/templates/reviews/add.html:15
+#: src/olympia/addons/templates/addons/persona_preview.html:47 src/olympia/addons/templates/addons/persona_preview.html:49 src/olympia/addons/templates/addons/persona_preview.html:97
+#: src/olympia/reviews/templates/reviews/add.html:15
 msgid "Add"
 msgstr "Ȧḓḓ"
 
-#: src/olympia/addons/templates/addons/persona_preview.html:57 src/olympia/bandwagon/templates/bandwagon/ajax_new.html:16 src/olympia/bandwagon/templates/bandwagon/edit.html:19
+#: src/olympia/addons/templates/addons/persona_preview.html:58 src/olympia/bandwagon/templates/bandwagon/ajax_new.html:16 src/olympia/bandwagon/templates/bandwagon/edit.html:19
 #: src/olympia/bandwagon/templates/bandwagon/includes/addedit.html:19 src/olympia/devhub/templates/devhub/addons/edit/admin.html:13 src/olympia/devhub/templates/devhub/addons/edit/basic.html:10
 #: src/olympia/devhub/templates/devhub/addons/edit/details.html:8 src/olympia/devhub/templates/devhub/addons/edit/media.html:6 src/olympia/devhub/templates/devhub/addons/edit/support.html:8
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:9 src/olympia/devhub/templates/devhub/addons/submit/describe.html:29 src/olympia/editors/templates/editors/review.html:257
@@ -683,21 +684,21 @@ msgstr "Ḗḓīŧ"
 
 #. For datetime formatting, see the table on
 #. http://docs.python.org/library/datetime.html#strftime-and-strptime-behavior
-#: src/olympia/addons/templates/addons/persona_preview.html:66
+#: src/olympia/addons/templates/addons/persona_preview.html:67
 #, python-format
 msgid "%%Y-%%m-%%d"
 msgstr "%%Ẏ-%%ḿ-%%ḓ"
 
-#: src/olympia/addons/templates/addons/persona_preview.html:67
+#: src/olympia/addons/templates/addons/persona_preview.html:68
 msgid "by {0} on {1}"
 msgstr "ƀẏ {0} ǿƞ {1}"
 
-#: src/olympia/addons/templates/addons/persona_preview.html:75 src/olympia/reviews/helpers.py:17 src/olympia/reviews/templates/reviews/review_list.html:63
+#: src/olympia/addons/templates/addons/persona_preview.html:76 src/olympia/reviews/helpers.py:17 src/olympia/reviews/templates/reviews/review_list.html:63
 #: src/olympia/reviews/templates/reviews/reviews_link.html:21 src/olympia/reviews/templates/reviews/impala/reviews_link.html:16
 msgid "Not yet rated"
 msgstr "Ƞǿŧ ẏḗŧ řȧŧḗḓ"
 
-#: src/olympia/addons/templates/addons/persona_preview.html:78
+#: src/olympia/addons/templates/addons/persona_preview.html:79
 msgid "<b>{0}</b> users"
 msgstr "<b>{0}</b> ŭşḗřş"
 
@@ -710,8 +711,8 @@ msgid "Learn more about Firefox"
 msgstr "Ŀḗȧřƞ ḿǿřḗ ȧƀǿŭŧ Ƒīřḗƒǿẋ"
 
 #: src/olympia/addons/templates/addons/popups.html:22
-msgid "or <b><a class=\"installer\" href=\"{url}\">download anyway</a></b>"
-msgstr "ǿř <b><a class=\"installer\" href=\"{url}\">ḓǿẇƞŀǿȧḓ ȧƞẏẇȧẏ</a></b>"
+msgid "or <b><a class=\"button installer\" href=\"{url}\">download anyway</a></b>"
+msgstr ""
 
 #: src/olympia/addons/templates/addons/popups.html:26
 msgid ""
@@ -775,8 +776,6 @@ msgid ""
 "<strong>Caution:</strong> This add-on has not been reviewed by Mozilla and can't be installed on release versions of Firefox 43 and above.  Be careful when installing third-party software that "
 "might harm your computer."
 msgstr ""
-"<strong>Ƈȧŭŧīǿƞ:</strong> Ŧħīş ȧḓḓ-ǿƞ ħȧş ƞǿŧ ƀḗḗƞ řḗṽīḗẇḗḓ ƀẏ Ḿǿzīŀŀȧ ȧƞḓ ƈȧƞ'ŧ ƀḗ īƞşŧȧŀŀḗḓ ǿƞ řḗŀḗȧşḗ ṽḗřşīǿƞş ǿƒ Ƒīřḗƒǿẋ 43 ȧƞḓ ȧƀǿṽḗ.  Ɓḗ ƈȧřḗƒŭŀ ẇħḗƞ īƞşŧȧŀŀīƞɠ ŧħīřḓ-ƥȧřŧẏ şǿƒŧẇȧřḗ ŧħȧŧ "
-"ḿīɠħŧ ħȧřḿ ẏǿŭř ƈǿḿƥŭŧḗř."
 
 #: src/olympia/addons/templates/addons/popups.html:120
 msgid "<strong>Please note:</strong> This add-on is not compatible with your operating system."
@@ -811,12 +810,9 @@ msgid ""
 "  to your phone.  (You'll need a QR reader.  Search your phone's marketplace if\n"
 "  don't have one.)"
 msgstr ""
-"Ẇȧƞŧ {0} ǿƞ ẏǿŭř ḿǿƀīŀḗ Ƒīřḗƒǿẋ?  Şƈȧƞ ŧħīş ɊŘ ƈǿḓḗ ŧǿ īƞşŧȧŀŀ ḓīřḗƈŧŀẏ\n"
-"  ŧǿ ẏǿŭř ƥħǿƞḗ.  (Ẏǿŭ'ŀŀ ƞḗḗḓ ȧ ɊŘ řḗȧḓḗř.  Şḗȧřƈħ ẏǿŭř ƥħǿƞḗ'ş ḿȧřķḗŧƥŀȧƈḗ īƒ\n"
-"  ḓǿƞ'ŧ ħȧṽḗ ǿƞḗ.)"
 
 #: src/olympia/addons/templates/addons/report_abuse.html:6 src/olympia/addons/templates/addons/report_abuse_full.html:10 src/olympia/addons/templates/addons/impala/details-more.html:23
-#: src/olympia/addons/templates/addons/impala/details.html:328
+#: src/olympia/addons/templates/addons/impala/details.html:333
 msgid "Report Abuse"
 msgstr "Řḗƥǿřŧ Ȧƀŭşḗ"
 
@@ -837,9 +833,9 @@ msgstr "Şḗƞḓ Řḗƥǿřŧ"
 #: src/olympia/devhub/templates/devhub/addons/ajax_compat_update.html:36 src/olympia/devhub/templates/devhub/addons/profile.html:44 src/olympia/devhub/templates/devhub/addons/edit/admin.html:104
 #: src/olympia/devhub/templates/devhub/addons/edit/basic.html:155 src/olympia/devhub/templates/devhub/addons/edit/details.html:88 src/olympia/devhub/templates/devhub/addons/edit/support.html:70
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:169 src/olympia/devhub/templates/devhub/addons/forms_shared/media.html:152
-#: src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:44 src/olympia/devhub/templates/devhub/personas/edit.html:222 src/olympia/devhub/templates/devhub/versions/add_file_modal.html:79
-#: src/olympia/devhub/templates/devhub/versions/edit.html:140 src/olympia/devhub/templates/devhub/versions/list.html:208 src/olympia/devhub/templates/devhub/versions/list.html:242
-#: src/olympia/devhub/templates/devhub/versions/list.html:276 src/olympia/devhub/templates/devhub/versions/list.html:317 src/olympia/reviews/templates/reviews/edit_review.html:16
+#: src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:43 src/olympia/devhub/templates/devhub/personas/edit.html:222 src/olympia/devhub/templates/devhub/versions/add_file_modal.html:59
+#: src/olympia/devhub/templates/devhub/versions/edit.html:140 src/olympia/devhub/templates/devhub/versions/list.html:208 src/olympia/devhub/templates/devhub/versions/list.html:239
+#: src/olympia/devhub/templates/devhub/versions/list.html:281 src/olympia/devhub/templates/devhub/versions/list.html:315 src/olympia/reviews/templates/reviews/edit_review.html:16
 #: src/olympia/translations/templates/translations/trans-menu.html:50 src/olympia/translations/templates/translations/trans-menu.html:62 src/olympia/zadmin/templates/zadmin/validation.html:105
 msgid "Cancel"
 msgstr "Ƈȧƞƈḗŀ"
@@ -884,7 +880,7 @@ msgstr "Şḗḗ ŧħḗ <a href=\"%(support)s\">şŭƥƥǿřŧ şḗƈŧīǿƞ<
 msgid "Review Guidelines"
 msgstr "Řḗṽīḗẇ Ɠŭīḓḗŀīƞḗş"
 
-#: src/olympia/addons/templates/addons/review_list_box.html:5 src/olympia/addons/templates/addons/impala/details-more.html:27 src/olympia/editors/helpers.py:921
+#: src/olympia/addons/templates/addons/review_list_box.html:5 src/olympia/addons/templates/addons/impala/details-more.html:27 src/olympia/editors/helpers.py:1001
 #: src/olympia/reviews/templates/reviews/add.html:14 src/olympia/reviews/templates/reviews/reply.html:14 src/olympia/reviews/templates/reviews/review_list.html:19
 #: src/olympia/reviews/templates/reviews/mobile/review_list.html:26
 msgid "Reviews"
@@ -975,103 +971,103 @@ msgid_plural "Other add-ons by these authors"
 msgstr[0] "Ǿŧħḗř ȧḓḓ-ǿƞş ƀẏ %(author)s"
 msgstr[1] "Ǿŧħḗř ȧḓḓ-ǿƞş ƀẏ ŧħḗşḗ ȧŭŧħǿřş"
 
-#: src/olympia/addons/templates/addons/impala/details.html:41
+#: src/olympia/addons/templates/addons/impala/details.html:39
 #, python-format
 msgid "<span itemprop=\"ratingCount\">%(num)s</span> user review"
 msgid_plural "<span itemprop=\"ratingCount\">%(num)s</span> user reviews"
 msgstr[0] "<span itemprop=\"ratingCount\">%(num)s</span> ŭşḗř řḗṽīḗẇ"
 msgstr[1] "<span itemprop=\"ratingCount\">%(num)s</span> ŭşḗř řḗṽīḗẇş"
 
-#: src/olympia/addons/templates/addons/impala/details.html:69
+#: src/olympia/addons/templates/addons/impala/details.html:66
 msgid "View statistics"
 msgstr "Ṽīḗẇ şŧȧŧīşŧīƈş"
 
-#: src/olympia/addons/templates/addons/impala/details.html:84
+#: src/olympia/addons/templates/addons/impala/details.html:81
 msgid "Manage"
 msgstr "Ḿȧƞȧɠḗ"
 
 #. {0} is an add-on name.
-#: src/olympia/addons/templates/addons/impala/details.html:96
+#: src/olympia/addons/templates/addons/impala/details.html:93
 msgid "Icon of {0}"
 msgstr "Īƈǿƞ ǿƒ {0}"
 
-#: src/olympia/addons/templates/addons/impala/details.html:103 src/olympia/addons/templates/addons/impala/listing/items.html:14
+#: src/olympia/addons/templates/addons/impala/details.html:100 src/olympia/addons/templates/addons/impala/listing/items.html:14
 msgid "No Restart"
 msgstr "Ƞǿ Řḗşŧȧřŧ"
 
-#: src/olympia/addons/templates/addons/impala/details.html:127
+#: src/olympia/addons/templates/addons/impala/details.html:124
 #, python-format
 msgid "Meet the Developer: <a href=\"%(url)s\">%(name)s</a>"
 msgid_plural "<a href=\"%(url)s\">Meet the Developers</a>"
 msgstr[0] "Ḿḗḗŧ ŧħḗ Ḓḗṽḗŀǿƥḗř: <a href=\"%(url)s\">%(name)s</a>"
 msgstr[1] "<a href=\"%(url)s\">Ḿḗḗŧ ŧħḗ Ḓḗṽḗŀǿƥḗřş</a>"
 
-#: src/olympia/addons/templates/addons/impala/details.html:137
+#: src/olympia/addons/templates/addons/impala/details.html:134
 msgid "Learn why {0} was created and find out what's next for this add-on."
 msgstr "Ŀḗȧřƞ ẇħẏ {0} ẇȧş ƈřḗȧŧḗḓ ȧƞḓ ƒīƞḓ ǿŭŧ ẇħȧŧ'ş ƞḗẋŧ ƒǿř ŧħīş ȧḓḓ-ǿƞ."
 
 #. {0} is an index.
-#: src/olympia/addons/templates/addons/impala/details.html:156
+#: src/olympia/addons/templates/addons/impala/details.html:161
 msgid "Add-on screenshot #{0}"
 msgstr "Ȧḓḓ-ǿƞ şƈřḗḗƞşħǿŧ #{0}"
 
-#: src/olympia/addons/templates/addons/impala/details.html:182
+#: src/olympia/addons/templates/addons/impala/details.html:187
 msgid "Add-on home page"
 msgstr "Ȧḓḓ-ǿƞ ħǿḿḗ ƥȧɠḗ"
 
-#: src/olympia/addons/templates/addons/impala/details.html:185
+#: src/olympia/addons/templates/addons/impala/details.html:190
 msgid "Support site"
 msgstr "Şŭƥƥǿřŧ şīŧḗ"
 
-#: src/olympia/addons/templates/addons/impala/details.html:189
+#: src/olympia/addons/templates/addons/impala/details.html:194
 msgid "Support E-mail"
 msgstr "Şŭƥƥǿřŧ Ḗ-ḿȧīŀ"
 
-#: src/olympia/addons/templates/addons/impala/details.html:194 src/olympia/devhub/models.py:378 src/olympia/devhub/templates/devhub/versions/list.html:12
+#: src/olympia/addons/templates/addons/impala/details.html:199 src/olympia/devhub/models.py:378 src/olympia/devhub/templates/devhub/versions/list.html:12
 #: src/olympia/versions/templates/versions/version.html:6 src/olympia/versions/templates/versions/mobile/version.html:6
 msgid "Version {0}"
 msgstr "Ṽḗřşīǿƞ {0}"
 
-#: src/olympia/addons/templates/addons/impala/details.html:194
+#: src/olympia/addons/templates/addons/impala/details.html:199
 msgid "Info"
 msgstr "Īƞƒǿ"
 
-#: src/olympia/addons/templates/addons/impala/details.html:195 src/olympia/devhub/templates/devhub/includes/addon_details.html:129
+#: src/olympia/addons/templates/addons/impala/details.html:200 src/olympia/devhub/templates/devhub/includes/addon_details.html:116
 msgid "Last Updated:"
 msgstr "Ŀȧşŧ Ŭƥḓȧŧḗḓ:"
 
-#: src/olympia/addons/templates/addons/impala/details.html:200
+#: src/olympia/addons/templates/addons/impala/details.html:205
 #, python-format
 msgid "Released under <a target=\"_blank\" href=\"%(url)s\">%(name)s</a>"
 msgstr "Řḗŀḗȧşḗḓ ŭƞḓḗř <a target=\"_blank\" href=\"%(url)s\">%(name)s</a>"
 
-#: src/olympia/addons/templates/addons/impala/details.html:201 src/olympia/addons/templates/addons/impala/details.html:206 src/olympia/amo/helpers.py:398 src/olympia/devhub/forms.py:142
+#: src/olympia/addons/templates/addons/impala/details.html:206 src/olympia/addons/templates/addons/impala/details.html:211 src/olympia/amo/helpers.py:398 src/olympia/devhub/forms.py:142
 #: src/olympia/devhub/forms.py:173 src/olympia/versions/templates/versions/version.html:40 src/olympia/versions/templates/versions/version.html:45
 msgid "Custom License"
 msgstr "Ƈŭşŧǿḿ Ŀīƈḗƞşḗ"
 
-#: src/olympia/addons/templates/addons/impala/details.html:205
+#: src/olympia/addons/templates/addons/impala/details.html:210
 #, python-format
 msgid "Released under <a href=\"%(url)s\">%(name)s</a>"
 msgstr "Řḗŀḗȧşḗḓ ŭƞḓḗř <a href=\"%(url)s\">%(name)s</a>"
 
-#: src/olympia/addons/templates/addons/impala/details.html:217
+#: src/olympia/addons/templates/addons/impala/details.html:222
 msgid "About this Add-on"
 msgstr "Ȧƀǿŭŧ ŧħīş Ȧḓḓ-ǿƞ"
 
-#: src/olympia/addons/templates/addons/impala/details.html:233
+#: src/olympia/addons/templates/addons/impala/details.html:238
 msgid "Developer’s Comments"
 msgstr "Ḓḗṽḗŀǿƥḗř’ş Ƈǿḿḿḗƞŧş"
 
-#: src/olympia/addons/templates/addons/impala/details.html:243
+#: src/olympia/addons/templates/addons/impala/details.html:248
 msgid "Version Information"
 msgstr "Ṽḗřşīǿƞ Īƞƒǿřḿȧŧīǿƞ"
 
-#: src/olympia/addons/templates/addons/impala/details.html:250
+#: src/olympia/addons/templates/addons/impala/details.html:255
 msgid "See complete version history"
 msgstr "Şḗḗ ƈǿḿƥŀḗŧḗ ṽḗřşīǿƞ ħīşŧǿřẏ"
 
-#: src/olympia/addons/templates/addons/impala/details.html:262
+#: src/olympia/addons/templates/addons/impala/details.html:267
 msgid ""
 "The Development Channel lets you test an experimental new version of this add-on before it's released to the general public. Once you install the development version, you will continue to get "
 "updates from this channel. To stop receiving development updates, reinstall the default version from the link above."
@@ -1079,17 +1075,17 @@ msgstr ""
 "Ŧħḗ Ḓḗṽḗŀǿƥḿḗƞŧ Ƈħȧƞƞḗŀ ŀḗŧş ẏǿŭ ŧḗşŧ ȧƞ ḗẋƥḗřīḿḗƞŧȧŀ ƞḗẇ ṽḗřşīǿƞ ǿƒ ŧħīş ȧḓḓ-ǿƞ ƀḗƒǿřḗ īŧ'ş řḗŀḗȧşḗḓ ŧǿ ŧħḗ ɠḗƞḗřȧŀ ƥŭƀŀīƈ. Ǿƞƈḗ ẏǿŭ īƞşŧȧŀŀ ŧħḗ ḓḗṽḗŀǿƥḿḗƞŧ ṽḗřşīǿƞ, ẏǿŭ ẇīŀŀ ƈǿƞŧīƞŭḗ ŧǿ ɠḗŧ "
 "ŭƥḓȧŧḗş ƒřǿḿ ŧħīş ƈħȧƞƞḗŀ. Ŧǿ şŧǿƥ řḗƈḗīṽīƞɠ ḓḗṽḗŀǿƥḿḗƞŧ ŭƥḓȧŧḗş, řḗīƞşŧȧŀŀ ŧħḗ ḓḗƒȧŭŀŧ ṽḗřşīǿƞ ƒřǿḿ ŧħḗ ŀīƞķ ȧƀǿṽḗ."
 
-#: src/olympia/addons/templates/addons/impala/details.html:272
+#: src/olympia/addons/templates/addons/impala/details.html:277
 msgid "<strong>Caution:</strong> Development versions of this add-on have not been reviewed by Mozilla."
 msgstr "<strong>Ƈȧŭŧīǿƞ:</strong> Ḓḗṽḗŀǿƥḿḗƞŧ ṽḗřşīǿƞş ǿƒ ŧħīş ȧḓḓ-ǿƞ ħȧṽḗ ƞǿŧ ƀḗḗƞ řḗṽīḗẇḗḓ ƀẏ Ḿǿzīŀŀȧ."
 
-#: src/olympia/addons/templates/addons/impala/details.html:287
+#: src/olympia/addons/templates/addons/impala/details.html:292
 msgid "See complete development channel history"
 msgstr "Şḗḗ ƈǿḿƥŀḗŧḗ ḓḗṽḗŀǿƥḿḗƞŧ ƈħȧƞƞḗŀ ħīşŧǿřẏ"
 
-#: src/olympia/addons/templates/addons/impala/details.html:306 src/olympia/addons/templates/addons/impala/details.html:315 src/olympia/addons/templates/addons/impala/details.html:327
+#: src/olympia/addons/templates/addons/impala/details.html:311 src/olympia/addons/templates/addons/impala/details.html:320 src/olympia/addons/templates/addons/impala/details.html:332
 #: src/olympia/addons/templates/addons/impala/review_add_box.html:4 src/olympia/stats/templates/stats/popup.html:2 src/olympia/stats/templates/stats/popup.html:8
-#: src/olympia/stats/templates/stats/stats.html:202 src/olympia/users/templates/users/profile.html:119
+#: src/olympia/stats/templates/stats/stats.html:204 src/olympia/users/templates/users/profile.html:119
 msgid "close"
 msgstr "ƈŀǿşḗ"
 
@@ -1145,15 +1141,11 @@ msgstr "Şǿŭřƈḗ Ƈǿḓḗ Ŀīƈḗƞşḗ ƒǿř {ȧḓḓǿƞ}"
 msgid "Source Code License"
 msgstr "Şǿŭřƈḗ Ƈǿḓḗ Ŀīƈḗƞşḗ"
 
-#: src/olympia/addons/templates/addons/impala/persona_grid.html:16 src/olympia/addons/templates/addons/impala/toplist.html:6
-msgid "{0} users"
-msgstr "{0} ŭşḗřş"
-
 #: src/olympia/addons/templates/addons/impala/review_list_box.html:19 src/olympia/reviews/templates/reviews/review.html:40
 msgid "permalink"
 msgstr "ƥḗřḿȧŀīƞķ"
 
-#: src/olympia/addons/templates/addons/impala/review_list_box.html:23 src/olympia/editors/templates/editors/queue.html:98 src/olympia/reviews/templates/reviews/review.html:44
+#: src/olympia/addons/templates/addons/impala/review_list_box.html:23 src/olympia/editors/templates/editors/queue.html:104 src/olympia/reviews/templates/reviews/review.html:44
 msgid "translate"
 msgstr "ŧřȧƞşŀȧŧḗ"
 
@@ -1172,6 +1164,10 @@ msgstr "Ŧħīş ȧḓḓ-ǿƞ ħȧş ƞǿŧ ẏḗŧ ƀḗḗƞ řḗṽīḗ�
 msgid "Be the first!"
 msgstr "Ɓḗ ŧħḗ ƒīřşŧ!"
 
+#: src/olympia/addons/templates/addons/impala/toplist.html:6
+msgid "{0} users"
+msgstr "{0} ŭşḗřş"
+
 #: src/olympia/addons/templates/addons/impala/listing/sorter.html:14 src/olympia/devhub/templates/devhub/addons/listing/item_actions.html:49
 msgid "More"
 msgstr "Ḿǿřḗ"
@@ -1184,7 +1180,7 @@ msgstr "Ȧḓḓ ŧǿ ƈǿŀŀḗƈŧīǿƞ"
 msgid "My Add-ons"
 msgstr "Ḿẏ Ȧḓḓ-ǿƞş"
 
-#: src/olympia/addons/templates/addons/includes/dashboard_tabs.html:6 src/olympia/amo/context_processors.py:51
+#: src/olympia/addons/templates/addons/includes/dashboard_tabs.html:6 src/olympia/amo/context_processors.py:50
 msgid "My Themes"
 msgstr "Ḿẏ Ŧħḗḿḗş"
 
@@ -1239,7 +1235,7 @@ msgstr "Ŭşḗřş"
 msgid "Weekly Downloads"
 msgstr "Ẇḗḗķŀẏ Ḓǿẇƞŀǿȧḓş"
 
-#: src/olympia/addons/templates/addons/mobile/details.html:99 src/olympia/compat/templates/compat/reporter_detail.html:46 src/olympia/devhub/forms.py:787
+#: src/olympia/addons/templates/addons/mobile/details.html:99 src/olympia/compat/templates/compat/reporter_detail.html:46 src/olympia/devhub/forms.py:788
 #: src/olympia/devhub/templates/devhub/versions/list.html:163
 msgid "Version"
 msgstr "Ṽḗřşīǿƞ"
@@ -1325,7 +1321,7 @@ msgstr ""
 #: src/olympia/browse/templates/browse/personas/category_landing.html:21 src/olympia/browse/templates/browse/personas/category_landing.html:23
 #: src/olympia/browse/templates/browse/personas/category_landing.html:38 src/olympia/browse/templates/browse/personas/grid.html:7 src/olympia/browse/templates/browse/personas/grid.html:11
 #: src/olympia/browse/templates/browse/personas/mobile/base.html:7 src/olympia/browse/templates/browse/personas/mobile/category_landing.html:19 src/olympia/constants/base.py:180
-#: src/olympia/devhub/templates/devhub/personas/submit.html:13 src/olympia/editors/helpers.py:105 src/olympia/editors/templates/editors/base.html:26
+#: src/olympia/devhub/templates/devhub/personas/submit.html:13 src/olympia/editors/helpers.py:107 src/olympia/editors/templates/editors/base.html:26
 #: src/olympia/editors/templates/editors/performance.html:73 src/olympia/search/templates/search/personas.html:39 src/olympia/templates/menu_links.html:9
 msgid "Themes"
 msgstr "Ŧħḗḿḗş"
@@ -1346,7 +1342,7 @@ msgstr "Ḿǿřḗ Ȧḓḓ-ǿƞş"
 msgid "Highest Rated"
 msgstr "Ħīɠħḗşŧ Řȧŧḗḓ"
 
-#: src/olympia/addons/templates/addons/mobile/home.html:74 src/olympia/amo/templates/amo/side_nav.html:5 src/olympia/amo/templates/amo/site_nav.html:27 src/olympia/amo/templates/amo/site_nav.html:57
+#: src/olympia/addons/templates/addons/mobile/home.html:74 src/olympia/amo/templates/amo/side_nav.html:5 src/olympia/amo/templates/amo/site_nav.html:27 src/olympia/amo/templates/amo/site_nav.html:55
 #: src/olympia/bandwagon/views.py:97 src/olympia/browse/views.py:57 src/olympia/browse/views.py:67 src/olympia/browse/templates/browse/personas/mobile/category_landing.html:65
 #: src/olympia/search/forms.py:15 src/olympia/search/forms.py:87
 msgid "Newest"
@@ -1360,90 +1356,90 @@ msgstr "Ŧřẏ īŧ ǿƞ!"
 msgid "Theme Info &raquo;"
 msgstr "Ŧħḗḿḗ Īƞƒǿ &raquo;"
 
-#: src/olympia/amo/context_processors.py:39 src/olympia/devhub/templates/devhub/nav.html:43
+#: src/olympia/amo/context_processors.py:37 src/olympia/devhub/templates/devhub/nav.html:43
 msgid "Tools"
 msgstr "Ŧǿǿŀş"
 
-#: src/olympia/amo/context_processors.py:48 src/olympia/discovery/templates/discovery/pane_account.html:8 src/olympia/users/templates/users/includes/navigation.html:2
+#: src/olympia/amo/context_processors.py:47 src/olympia/discovery/templates/discovery/pane_account.html:8 src/olympia/users/templates/users/includes/navigation.html:2
 msgid "My Profile"
 msgstr "Ḿẏ Ƥřǿƒīŀḗ"
 
-#: src/olympia/amo/context_processors.py:54 src/olympia/users/templates/users/edit.html:5 src/olympia/users/templates/users/includes/navigation.html:3
+#: src/olympia/amo/context_processors.py:53 src/olympia/users/templates/users/edit.html:5 src/olympia/users/templates/users/includes/navigation.html:3
 msgid "Account Settings"
 msgstr "Ȧƈƈǿŭƞŧ Şḗŧŧīƞɠş"
 
-#: src/olympia/amo/context_processors.py:57 src/olympia/discovery/templates/discovery/pane_account.html:11 src/olympia/users/templates/users/profile.html:83
+#: src/olympia/amo/context_processors.py:56 src/olympia/discovery/templates/discovery/pane_account.html:11 src/olympia/users/templates/users/profile.html:83
 #: src/olympia/users/templates/users/includes/navigation.html:4
 msgid "My Collections"
 msgstr "Ḿẏ Ƈǿŀŀḗƈŧīǿƞş"
 
-#: src/olympia/amo/context_processors.py:62 src/olympia/discovery/templates/discovery/pane_account.html:10 src/olympia/users/templates/users/includes/navigation.html:7
+#: src/olympia/amo/context_processors.py:61 src/olympia/discovery/templates/discovery/pane_account.html:10 src/olympia/users/templates/users/includes/navigation.html:7
 msgid "My Favorites"
 msgstr "Ḿẏ Ƒȧṽǿřīŧḗş"
 
-#: src/olympia/amo/context_processors.py:67 src/olympia/discovery/templates/discovery/pane_account.html:13 src/olympia/templates/impala/user_login.html:14
+#: src/olympia/amo/context_processors.py:66 src/olympia/discovery/templates/discovery/pane_account.html:13 src/olympia/templates/impala/user_login.html:14
 #: src/olympia/templates/mobile/header_auth.html:5
 msgid "Log out"
 msgstr "Ŀǿɠ ǿŭŧ"
 
-#: src/olympia/amo/context_processors.py:72 src/olympia/devhub/templates/devhub/addons/dashboard.html:4
+#: src/olympia/amo/context_processors.py:71 src/olympia/devhub/templates/devhub/addons/dashboard.html:4
 msgid "Manage My Submissions"
 msgstr "Ḿȧƞȧɠḗ Ḿẏ Şŭƀḿīşşīǿƞş"
 
-#: src/olympia/amo/context_processors.py:75 src/olympia/devhub/templates/devhub/nav.html:27 src/olympia/devhub/templates/devhub/addons/dashboard.html:25
+#: src/olympia/amo/context_processors.py:74 src/olympia/devhub/templates/devhub/nav.html:27 src/olympia/devhub/templates/devhub/addons/dashboard.html:25
 #: src/olympia/devhub/templates/devhub/addons/submit/base.html:4
 msgid "Submit a New Add-on"
 msgstr "Şŭƀḿīŧ ȧ Ƞḗẇ Ȧḓḓ-ǿƞ"
 
-#: src/olympia/amo/context_processors.py:77 src/olympia/browse/templates/browse/personas/base.html:50 src/olympia/devhub/templates/devhub/index.html:24
+#: src/olympia/amo/context_processors.py:76 src/olympia/browse/templates/browse/personas/base.html:50 src/olympia/devhub/templates/devhub/index.html:24
 #: src/olympia/devhub/templates/devhub/addons/dashboard.html:29
 msgid "Submit a New Theme"
 msgstr "Şŭƀḿīŧ ȧ Ƞḗẇ Ŧħḗḿḗ"
 
-#: src/olympia/amo/context_processors.py:79 src/olympia/amo/templates/amo/site_nav.html:87 src/olympia/devhub/helpers.py:36 src/olympia/devhub/helpers.py:68 src/olympia/devhub/helpers.py:102
+#: src/olympia/amo/context_processors.py:78 src/olympia/amo/templates/amo/site_nav.html:85 src/olympia/devhub/helpers.py:36 src/olympia/devhub/helpers.py:68 src/olympia/devhub/helpers.py:102
 #: src/olympia/templates/footer.html:6 src/olympia/templates/menu_links.html:14
 msgid "Developer Hub"
 msgstr "Ḓḗṽḗŀǿƥḗř Ħŭƀ"
 
-#: src/olympia/amo/context_processors.py:83 src/olympia/devhub/views.py:1792
+#: src/olympia/amo/context_processors.py:81 src/olympia/devhub/views.py:1796
 msgid "Manage API Keys"
 msgstr "Ḿȧƞȧɠḗ ȦƤĪ Ķḗẏş"
 
-#: src/olympia/amo/context_processors.py:88 src/olympia/editors/helpers.py:82 src/olympia/editors/helpers.py:102 src/olympia/editors/templates/editors/base.html:10
+#: src/olympia/amo/context_processors.py:86 src/olympia/editors/helpers.py:84 src/olympia/editors/helpers.py:104 src/olympia/editors/templates/editors/base.html:10
 msgid "Editor Tools"
 msgstr "Ḗḓīŧǿř Ŧǿǿŀş"
 
-#: src/olympia/amo/context_processors.py:92
+#: src/olympia/amo/context_processors.py:90
 msgid "Admin Tools"
 msgstr "Ȧḓḿīƞ Ŧǿǿŀş"
 
-#: src/olympia/amo/fields.py:15
+#: src/olympia/amo/fields.py:20
 msgid "Incorrect, please try again."
 msgstr "Īƞƈǿřřḗƈŧ, ƥŀḗȧşḗ ŧřẏ ȧɠȧīƞ."
 
-#: src/olympia/amo/fields.py:16
+#: src/olympia/amo/fields.py:21
 msgid "Error verifying input, please try again."
 msgstr "Ḗřřǿř ṽḗřīƒẏīƞɠ īƞƥŭŧ, ƥŀḗȧşḗ ŧřẏ ȧɠȧīƞ."
 
-#: src/olympia/amo/fields.py:32
+#: src/olympia/amo/fields.py:37
 msgid "This must be a valid hex color code, such as #000000."
 msgstr "Ŧħīş ḿŭşŧ ƀḗ ȧ ṽȧŀīḓ ħḗẋ ƈǿŀǿř ƈǿḓḗ, şŭƈħ ȧş #000000."
 
-#: src/olympia/amo/fields.py:58
+#: src/olympia/amo/fields.py:63
 msgid "Enter at least one value."
 msgstr "Ḗƞŧḗř ȧŧ ŀḗȧşŧ ǿƞḗ ṽȧŀŭḗ."
 
-#: src/olympia/amo/helpers.py:162 src/olympia/amo/templates/amo/site_nav.html:61 src/olympia/bandwagon/templates/bandwagon/add.html:9
+#: src/olympia/amo/helpers.py:162 src/olympia/amo/templates/amo/site_nav.html:59 src/olympia/bandwagon/templates/bandwagon/add.html:9
 #: src/olympia/bandwagon/templates/bandwagon/collection_detail.html:15 src/olympia/bandwagon/templates/bandwagon/delete.html:9 src/olympia/bandwagon/templates/bandwagon/edit.html:15
 #: src/olympia/bandwagon/templates/bandwagon/user_listing.html:18 src/olympia/bandwagon/templates/bandwagon/user_listing.html:21
 #: src/olympia/bandwagon/templates/bandwagon/impala/collection_listing.html:12 src/olympia/bandwagon/templates/bandwagon/impala/collection_listing.html:20
 #: src/olympia/bandwagon/templates/bandwagon/impala/collection_listing.html:24 src/olympia/bandwagon/templates/bandwagon/impala/collection_sidebar.html:3
 #: src/olympia/bandwagon/templates/bandwagon/includes/collection_sidebar.html:2 src/olympia/bandwagon/templates/bandwagon/mobile/collection_listing.html:3
-#: src/olympia/stats/templates/stats/stats.html:77 src/olympia/templates/menu_links.html:12
+#: src/olympia/stats/templates/stats/stats.html:33 src/olympia/templates/menu_links.html:12
 msgid "Collections"
 msgstr "Ƈǿŀŀḗƈŧīǿƞş"
 
-#: src/olympia/amo/helpers.py:171 src/olympia/amo/templates/amo/site_nav.html:85 src/olympia/browse/templates/browse/language_tools.html:3
+#: src/olympia/amo/helpers.py:171 src/olympia/amo/templates/amo/site_nav.html:83 src/olympia/browse/templates/browse/language_tools.html:3
 msgid "Dictionaries & Language Packs"
 msgstr "Ḓīƈŧīǿƞȧřīḗş & Ŀȧƞɠŭȧɠḗ Ƥȧƈķş"
 
@@ -1595,8 +1591,8 @@ msgstr "Şŭƥḗř řḗṽīḗẇ řḗɋŭḗşŧḗḓ"
 msgid "Comment on {addon} {version}."
 msgstr "Ƈǿḿḿḗƞŧ ǿƞ {ȧḓḓǿƞ} {ṽḗřşīǿƞ}."
 
-#: src/olympia/amo/log.py:236 src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:19 src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:47
-#: src/olympia/editors/helpers.py:511 src/olympia/editors/templates/editors/themes/history_table.html:11
+#: src/olympia/amo/log.py:236 src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:17 src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:45
+#: src/olympia/editors/helpers.py:584 src/olympia/editors/templates/editors/themes/history_table.html:11
 msgid "Comment"
 msgstr "Ƈǿḿḿḗƞŧ"
 
@@ -1750,7 +1746,7 @@ msgstr "Řḗṽīḗẇḗř ḗşƈȧŀȧŧīǿƞ"
 
 #: src/olympia/amo/log.py:442
 msgid "Video removed from {addon} because of a problem with the video. "
-msgstr "Ṽīḓḗǿ řḗḿǿṽḗḓ ƒřǿḿ {ȧḓḓǿƞ} ƀḗƈȧŭşḗ ǿƒ ȧ ƥřǿƀŀḗḿ ẇīŧħ ŧħḗ ṽīḓḗǿ. "
+msgstr ""
 
 #: src/olympia/amo/log.py:444
 msgid "Video removed"
@@ -1903,7 +1899,7 @@ msgstr "Ǿǿƥş"
 #: src/olympia/amo/templates/amo/500.html:6
 #, python-format
 msgid "<h1>Oops!  We had an error.</h1> <p>We'll get to fixing that soon.</p> <p> You can try refreshing the page, or head back to the <a href=\"%(home)s\">Add-ons homepage</a>. </p>"
-msgstr "<h1>Ǿǿƥş!  Ẇḗ ħȧḓ ȧƞ ḗřřǿř.</h1> <p>Ẇḗ'ŀŀ ɠḗŧ ŧǿ ƒīẋīƞɠ ŧħȧŧ şǿǿƞ.</p> <p> Ẏǿŭ ƈȧƞ ŧřẏ řḗƒřḗşħīƞɠ ŧħḗ ƥȧɠḗ, ǿř ħḗȧḓ ƀȧƈķ ŧǿ ŧħḗ <a href=\"%(home)s\">Ȧḓḓ-ǿƞş ħǿḿḗƥȧɠḗ</a>. </p>"
+msgstr ""
 
 #: src/olympia/amo/templates/amo/license_link.html:10
 msgid "Some rights reserved"
@@ -1925,7 +1921,7 @@ msgstr "Ƥřḗṽ"
 #: src/olympia/amo/templates/amo/mobile/paginator.html:14 src/olympia/amo/templates/amo/mobile/paginator.html:16 src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:51
 #: src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:65 src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:78
 #: src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:91 src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:104
-#: src/olympia/discovery/templates/discovery/pane.html:45 src/olympia/discovery/templates/discovery/addons/detail.html:39 src/olympia/stats/templates/stats/stats.html:167
+#: src/olympia/discovery/templates/discovery/pane.html:45 src/olympia/discovery/templates/discovery/addons/detail.html:39 src/olympia/stats/templates/stats/stats.html:169
 msgid "Next"
 msgstr "Ƞḗẋŧ"
 
@@ -1959,7 +1955,7 @@ msgstr ""
 "ḓīƒƒḗřḗƞŧ ẇǿřḓş</a> ǿř <a href=\"#\" id=\"recaptcha_audio\">ŧřẏ ȧ ḓīƒƒḗřḗƞŧ ŧẏƥḗ ǿƒ ƈħȧŀŀḗƞɠḗ</a> īƞşŧḗȧḓ. </p>"
 
 #: src/olympia/amo/templates/amo/side_nav.html:4 src/olympia/amo/templates/amo/side_nav.html:12 src/olympia/amo/templates/amo/site_nav.html:4 src/olympia/amo/templates/amo/site_nav.html:26
-#: src/olympia/browse/views.py:56 src/olympia/browse/views.py:66 src/olympia/browse/views.py:237 src/olympia/browse/views.py:282 src/olympia/search/forms.py:86
+#: src/olympia/browse/views.py:56 src/olympia/browse/views.py:66 src/olympia/browse/views.py:204 src/olympia/browse/views.py:249 src/olympia/search/forms.py:86
 msgid "Top Rated"
 msgstr "Ŧǿƥ Řȧŧḗḓ"
 
@@ -1973,38 +1969,38 @@ msgstr "Ḗẋƥŀǿřḗ"
 msgid "Extensions"
 msgstr "Ḗẋŧḗƞşīǿƞş"
 
-#: src/olympia/amo/templates/amo/site_nav.html:45
+#: src/olympia/amo/templates/amo/site_nav.html:44
 msgid "Want more customization? Try <b>Complete Themes</b>"
 msgstr "Ẇȧƞŧ ḿǿřḗ ƈŭşŧǿḿīzȧŧīǿƞ? Ŧřẏ <b>Ƈǿḿƥŀḗŧḗ Ŧħḗḿḗş</b>"
 
-#: src/olympia/amo/templates/amo/site_nav.html:56 src/olympia/bandwagon/views.py:96
+#: src/olympia/amo/templates/amo/site_nav.html:54 src/olympia/bandwagon/views.py:96
 msgid "Most Followers"
 msgstr "Ḿǿşŧ Ƒǿŀŀǿẇḗřş"
 
-#: src/olympia/amo/templates/amo/site_nav.html:68 src/olympia/bandwagon/templates/bandwagon/impala/collection_sidebar.html:16
+#: src/olympia/amo/templates/amo/site_nav.html:66 src/olympia/bandwagon/templates/bandwagon/impala/collection_sidebar.html:16
 #: src/olympia/bandwagon/templates/bandwagon/includes/collection_sidebar.html:18
 msgid "Collections I've Made"
 msgstr "Ƈǿŀŀḗƈŧīǿƞş Ī'ṽḗ Ḿȧḓḗ"
 
-#: src/olympia/amo/templates/amo/site_nav.html:70 src/olympia/bandwagon/templates/bandwagon/user_listing.html:4 src/olympia/bandwagon/templates/bandwagon/impala/collection_sidebar.html:13
+#: src/olympia/amo/templates/amo/site_nav.html:68 src/olympia/bandwagon/templates/bandwagon/user_listing.html:4 src/olympia/bandwagon/templates/bandwagon/impala/collection_sidebar.html:13
 #: src/olympia/bandwagon/templates/bandwagon/includes/collection_sidebar.html:15
 msgid "Collections I'm Following"
 msgstr "Ƈǿŀŀḗƈŧīǿƞş Ī'ḿ Ƒǿŀŀǿẇīƞɠ"
 
-#: src/olympia/amo/templates/amo/site_nav.html:73 src/olympia/bandwagon/templates/bandwagon/impala/collection_sidebar.html:18
-#: src/olympia/bandwagon/templates/bandwagon/includes/collection_sidebar.html:20 src/olympia/users/models.py:512
+#: src/olympia/amo/templates/amo/site_nav.html:71 src/olympia/bandwagon/templates/bandwagon/impala/collection_sidebar.html:18
+#: src/olympia/bandwagon/templates/bandwagon/includes/collection_sidebar.html:20 src/olympia/users/models.py:521
 msgid "My Favorite Add-ons"
 msgstr "Ḿẏ Ƒȧṽǿřīŧḗ Ȧḓḓ-ǿƞş"
 
-#: src/olympia/amo/templates/amo/site_nav.html:78
+#: src/olympia/amo/templates/amo/site_nav.html:76
 msgid "More&hellip;"
 msgstr "Ḿǿřḗ&hellip;"
 
-#: src/olympia/amo/templates/amo/site_nav.html:82
+#: src/olympia/amo/templates/amo/site_nav.html:80
 msgid "Add-ons for Mobile"
 msgstr "Ȧḓḓ-ǿƞş ƒǿř Ḿǿƀīŀḗ"
 
-#: src/olympia/amo/templates/amo/site_nav.html:86 src/olympia/browse/feeds.py:207 src/olympia/browse/templates/browse/search_tools.html:3 src/olympia/constants/base.py:176
+#: src/olympia/amo/templates/amo/site_nav.html:84 src/olympia/browse/feeds.py:207 src/olympia/browse/templates/browse/search_tools.html:3 src/olympia/constants/base.py:176
 #: src/olympia/templates/menu_links.html:10
 msgid "Search Tools"
 msgstr "Şḗȧřƈħ Ŧǿǿŀş"
@@ -2020,7 +2016,7 @@ msgid "Jump to first page"
 msgstr "Ĵŭḿƥ ŧǿ ƒīřşŧ ƥȧɠḗ"
 
 #: src/olympia/amo/templates/amo/impala/paginator.html:22 src/olympia/amo/templates/amo/mobile/impala_paginator.html:12 src/olympia/discovery/templates/discovery/pane.html:44
-#: src/olympia/discovery/templates/discovery/addons/detail.html:38 src/olympia/stats/templates/stats/stats.html:164
+#: src/olympia/discovery/templates/discovery/addons/detail.html:38 src/olympia/stats/templates/stats/stats.html:166
 msgid "Previous"
 msgstr "Ƥřḗṽīǿŭş"
 
@@ -2043,31 +2039,50 @@ msgid_plural "Page {n}"
 msgstr[0] "Ƥȧɠḗ {ƞ}"
 msgstr[1] "Ƥȧɠḗ {ƞ}"
 
-#: src/olympia/amo/templates/services/install.html:38
-#, python-format
-msgid "If you are not prompted to install %(addon_name)s in a moment, please <a href=\"%(addon_xpi)s\">click here</a>."
-msgstr "Īƒ ẏǿŭ ȧřḗ ƞǿŧ ƥřǿḿƥŧḗḓ ŧǿ īƞşŧȧŀŀ %(addon_name)s īƞ ȧ ḿǿḿḗƞŧ, ƥŀḗȧşḗ <a href=\"%(addon_xpi)s\">ƈŀīƈķ ħḗřḗ</a>."
-
-#: src/olympia/amo/tests/test_messages.py:57 src/olympia/amo/tests/test_messages.py:58 src/olympia/reviews/forms.py:25 src/olympia/reviews/forms.py:50 src/olympia/reviews/templates/reviews/add.html:56
+#: src/olympia/amo/tests/test_messages.py:56 src/olympia/amo/tests/test_messages.py:57 src/olympia/reviews/forms.py:25 src/olympia/reviews/forms.py:50 src/olympia/reviews/templates/reviews/add.html:56
 #: src/olympia/reviews/templates/reviews/reply.html:30
 msgid "Title"
 msgstr "Ŧīŧŀḗ"
 
-#: src/olympia/amo/tests/test_messages.py:57 src/olympia/amo/tests/test_messages.py:58
+#: src/olympia/amo/tests/test_messages.py:56 src/olympia/amo/tests/test_messages.py:57
 msgid "Body"
 msgstr "Ɓǿḓẏ"
 
-#: src/olympia/amo/tests/test_messages.py:59
+#: src/olympia/amo/tests/test_messages.py:58
 msgid "Another Title"
 msgstr "Ȧƞǿŧħḗř Ŧīŧŀḗ"
 
-#: src/olympia/amo/tests/test_messages.py:59
+#: src/olympia/amo/tests/test_messages.py:58
 msgid "Another Body"
 msgstr "Ȧƞǿŧħḗř Ɓǿḓẏ"
 
-#: src/olympia/api/views.py:255
-msgid "Not implemented yet."
-msgstr "Ƞǿŧ īḿƥŀḗḿḗƞŧḗḓ ẏḗŧ."
+#: src/olympia/api/authentication.py:76
+msgid "Signature has expired."
+msgstr ""
+
+#: src/olympia/api/authentication.py:79
+msgid "Error decoding signature."
+msgstr ""
+
+#: src/olympia/api/authentication.py:82
+msgid "Invalid JWT Token."
+msgstr ""
+
+#: src/olympia/api/authentication.py:130
+msgid "Invalid Authorization header. No credentials provided."
+msgstr ""
+
+#: src/olympia/api/authentication.py:133
+msgid "Invalid Authorization header. Credentials string should not contain spaces."
+msgstr ""
+
+#: src/olympia/api/fields.py:29
+msgid "The field must have a length of at least {num} characters."
+msgstr ""
+
+#: src/olympia/api/fields.py:31
+msgid "The language code {lang_code} is invalid."
+msgstr ""
 
 #: src/olympia/applications/views.py:39 src/olympia/applications/templates/applications/appversions.html:3
 msgid "Application Versions"
@@ -2085,7 +2100,7 @@ msgstr "Ṽȧŀīḓ Ȧƥƥŀīƈȧŧīǿƞ Ṽḗřşīǿƞş"
 msgid "Add-ons submitted to Mozilla Add-ons must have a manifest file with at least one of the below applications supported. Only the versions listed below are allowed for these applications."
 msgstr "Ȧḓḓ-ǿƞş şŭƀḿīŧŧḗḓ ŧǿ Ḿǿzīŀŀȧ Ȧḓḓ-ǿƞş ḿŭşŧ ħȧṽḗ ȧ ḿȧƞīƒḗşŧ ƒīŀḗ ẇīŧħ ȧŧ ŀḗȧşŧ ǿƞḗ ǿƒ ŧħḗ ƀḗŀǿẇ ȧƥƥŀīƈȧŧīǿƞş şŭƥƥǿřŧḗḓ. Ǿƞŀẏ ŧħḗ ṽḗřşīǿƞş ŀīşŧḗḓ ƀḗŀǿẇ ȧřḗ ȧŀŀǿẇḗḓ ƒǿř ŧħḗşḗ ȧƥƥŀīƈȧŧīǿƞş."
 
-#: src/olympia/applications/templates/applications/appversions.html:25
+#: src/olympia/applications/templates/applications/appversions.html:25 src/olympia/editors/helpers.py:361
 msgid "GUID"
 msgstr "ƓŬĪḒ"
 
@@ -2199,8 +2214,8 @@ msgstr "Ƒȧṽǿřīŧḗ"
 msgid "Remove from favorites"
 msgstr "Řḗḿǿṽḗ ƒřǿḿ ƒȧṽǿřīŧḗş"
 
-#: src/olympia/bandwagon/views.py:98 src/olympia/bandwagon/views.py:191 src/olympia/browse/views.py:58 src/olympia/browse/views.py:69 src/olympia/browse/views.py:458 src/olympia/devhub/views.py:74
-#: src/olympia/devhub/views.py:82 src/olympia/devhub/templates/devhub/addons/edit/basic.html:20 src/olympia/editors/templates/editors/leaderboard.html:24
+#: src/olympia/bandwagon/views.py:98 src/olympia/bandwagon/views.py:191 src/olympia/browse/views.py:58 src/olympia/browse/views.py:69 src/olympia/browse/views.py:425 src/olympia/devhub/views.py:72
+#: src/olympia/devhub/views.py:80 src/olympia/devhub/templates/devhub/addons/edit/basic.html:20 src/olympia/editors/templates/editors/leaderboard.html:24
 #: src/olympia/editors/templates/editors/themes/queue_list.html:48 src/olympia/search/forms.py:17 src/olympia/search/forms.py:89 src/olympia/users/templates/users/vcard.html:5
 msgid "Name"
 msgstr "Ƞȧḿḗ"
@@ -2209,7 +2224,7 @@ msgstr "Ƞȧḿḗ"
 msgid "Recently Popular"
 msgstr "Řḗƈḗƞŧŀẏ Ƥǿƥŭŀȧř"
 
-#: src/olympia/bandwagon/views.py:189 src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:18
+#: src/olympia/bandwagon/views.py:189 src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:16
 msgid "Added"
 msgstr "Ȧḓḓḗḓ"
 
@@ -2223,8 +2238,8 @@ msgstr "Ƈǿŀŀḗƈŧīǿƞ ƈřḗȧŧḗḓ!"
 
 #: src/olympia/bandwagon/views.py:316
 #, python-format
-msgid "Your new collection is shown below. You can <ahref=\"%(url)s\">edit additional settings</a> if you'dlike."
-msgstr "Ẏǿŭř ƞḗẇ ƈǿŀŀḗƈŧīǿƞ īş şħǿẇƞ ƀḗŀǿẇ. Ẏǿŭ ƈȧƞ <ȧħřḗƒ=\"%(url)s\">ḗḓīŧ ȧḓḓīŧīǿƞȧŀ şḗŧŧīƞɠş</a> īƒ ẏǿŭ'ḓŀīķḗ."
+msgid "Your new collection is shown below. You can <a href=\"%(url)s\">edit additional settings</a> if you'd like."
+msgstr ""
 
 #: src/olympia/bandwagon/views.py:322
 msgid "Collection updated!"
@@ -2351,8 +2366,8 @@ msgid_plural "%(num)s Add-ons in this Collection"
 msgstr[0] "%(num)s Ȧḓḓ-ǿƞ īƞ ŧħīş Ƈǿŀŀḗƈŧīǿƞ"
 msgstr[1] "%(num)s Ȧḓḓ-ǿƞş īƞ ŧħīş Ƈǿŀŀḗƈŧīǿƞ"
 
-#: src/olympia/bandwagon/templates/bandwagon/collection_detail.html:125 src/olympia/compat/templates/compat/index.html:25 src/olympia/compat/templates/compat/reporter_detail.html:29
-#: src/olympia/files/templates/files/viewer.html:29 src/olympia/templates/amo_footer.html:17 src/olympia/templates/includes/lang_switcher.html:10
+#: src/olympia/bandwagon/templates/bandwagon/collection_detail.html:125 src/olympia/compat/templates/compat/reporter_detail.html:29 src/olympia/files/templates/files/viewer.html:29
+#: src/olympia/templates/amo_footer.html:17 src/olympia/templates/includes/lang_switcher.html:10
 msgid "Go"
 msgstr "Ɠǿ"
 
@@ -2389,8 +2404,6 @@ msgid ""
 "Add-ons that you mark as favorites using the <b>Add to Favorites</b> feature appear below. This collection is currently <b>private</b>, which means only you can see it.  If you would like everyone "
 "to be able to see your favorites, click the button below to make it public."
 msgstr ""
-"Ȧḓḓ-ǿƞş ŧħȧŧ ẏǿŭ ḿȧřķ ȧş ƒȧṽǿřīŧḗş ŭşīƞɠ ŧħḗ <b>Ȧḓḓ ŧǿ Ƒȧṽǿřīŧḗş</b> ƒḗȧŧŭřḗ ȧƥƥḗȧř ƀḗŀǿẇ. Ŧħīş ƈǿŀŀḗƈŧīǿƞ īş ƈŭřřḗƞŧŀẏ <b>ƥřīṽȧŧḗ</b>, ẇħīƈħ ḿḗȧƞş ǿƞŀẏ ẏǿŭ ƈȧƞ şḗḗ īŧ.  Īƒ ẏǿŭ ẇǿŭŀḓ ŀīķḗ ḗṽḗřẏǿƞḗ "
-"ŧǿ ƀḗ ȧƀŀḗ ŧǿ şḗḗ ẏǿŭř ƒȧṽǿřīŧḗş, ƈŀīƈķ ŧħḗ ƀŭŧŧǿƞ ƀḗŀǿẇ ŧǿ ḿȧķḗ īŧ ƥŭƀŀīƈ."
 
 #: src/olympia/bandwagon/templates/bandwagon/collection_detail.html:196
 msgid "My favorite add-ons"
@@ -2523,7 +2536,7 @@ msgid "Remove this user as a contributor"
 msgstr "Řḗḿǿṽḗ ŧħīş ŭşḗř ȧş ȧ ƈǿƞŧřīƀŭŧǿř"
 
 #: src/olympia/bandwagon/templates/bandwagon/edit_contributors.html:18 src/olympia/bandwagon/templates/bandwagon/edit_contributors.html:43
-#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:20 src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:48
+#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:18 src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:46
 #: src/olympia/devhub/templates/devhub/addons/ajax_compat_update.html:19
 msgid "Remove"
 msgstr "Řḗḿǿṽḗ"
@@ -2537,8 +2550,6 @@ msgid ""
 "You can add multiple contributors to this collection.  A contributor can add and remove add-ons from this collection, but cannot change its name or description.  To add a contributor, enter their "
 "email in the box below. Contributors must have a Mozilla Add-ons account."
 msgstr ""
-"Ẏǿŭ ƈȧƞ ȧḓḓ ḿŭŀŧīƥŀḗ ƈǿƞŧřīƀŭŧǿřş ŧǿ ŧħīş ƈǿŀŀḗƈŧīǿƞ.  Ȧ ƈǿƞŧřīƀŭŧǿř ƈȧƞ ȧḓḓ ȧƞḓ řḗḿǿṽḗ ȧḓḓ-ǿƞş ƒřǿḿ ŧħīş ƈǿŀŀḗƈŧīǿƞ, ƀŭŧ ƈȧƞƞǿŧ ƈħȧƞɠḗ īŧş ƞȧḿḗ ǿř ḓḗşƈřīƥŧīǿƞ.  Ŧǿ ȧḓḓ ȧ ƈǿƞŧřīƀŭŧǿř, ḗƞŧḗř ŧħḗīř "
-"ḗḿȧīŀ īƞ ŧħḗ ƀǿẋ ƀḗŀǿẇ. Ƈǿƞŧřīƀŭŧǿřş ḿŭşŧ ħȧṽḗ ȧ Ḿǿzīŀŀȧ Ȧḓḓ-ǿƞş ȧƈƈǿŭƞŧ."
 
 #: src/olympia/bandwagon/templates/bandwagon/edit_contributors.html:40
 msgid "User"
@@ -2573,7 +2584,7 @@ msgid "<b>Warning:</b> By changing the owner of this collection, you will no lon
 msgstr "<b>Ẇȧřƞīƞɠ:</b> Ɓẏ ƈħȧƞɠīƞɠ ŧħḗ ǿẇƞḗř ǿƒ ŧħīş ƈǿŀŀḗƈŧīǿƞ, ẏǿŭ ẇīŀŀ ƞǿ ŀǿƞɠḗř ƀḗ ȧƀŀḗ ŧǿ ḗḓīŧ īŧ. Ẏǿŭ ẇīŀŀ ǿƞŀẏ ƀḗ ȧƀŀḗ ŧǿ ȧḓḓ ȧƞḓ řḗḿǿṽḗ ȧḓḓ-ǿƞş ƒřǿḿ īŧ."
 
 #: src/olympia/bandwagon/templates/bandwagon/edit_contributors.html:83 src/olympia/devhub/templates/devhub/addons/forms_shared/media.html:157
-#: src/olympia/devhub/templates/devhub/addons/submit/describe.html:69 src/olympia/devhub/templates/devhub/addons/submit/license.html:60 src/olympia/devhub/templates/devhub/addons/submit/upload.html:78
+#: src/olympia/devhub/templates/devhub/addons/submit/describe.html:69 src/olympia/devhub/templates/devhub/addons/submit/license.html:60 src/olympia/devhub/templates/devhub/addons/submit/upload.html:70
 #: src/olympia/devhub/templates/devhub/payments/tier.html:17 src/olympia/editors/templates/editors/themes/themes.html:111 src/olympia/editors/templates/editors/themes/themes.html:128
 #: src/olympia/editors/templates/editors/themes/themes.html:134 src/olympia/editors/templates/editors/themes/themes.html:141 src/olympia/users/templates/users/fxa_migration_prompt_content.html:10
 #: src/olympia/users/templates/users/login_form.html:42 src/olympia/users/templates/users/mobile/login.html:57
@@ -2645,43 +2656,42 @@ msgstr "Řḗşḗŧ"
 
 #: src/olympia/bandwagon/templates/bandwagon/includes/addedit.html:53
 msgid "PNG and JPG supported.  Image will be resized to 32x32."
-msgstr "ƤȠƓ ȧƞḓ ĴƤƓ şŭƥƥǿřŧḗḓ.  Īḿȧɠḗ ẇīŀŀ ƀḗ řḗşīzḗḓ ŧǿ 32ẋ32."
+msgstr ""
 
 #: src/olympia/bandwagon/templates/bandwagon/includes/addedit_errors.html:3
 msgid "There are errors in this form.  Please correct them below."
-msgstr "Ŧħḗřḗ ȧřḗ ḗřřǿřş īƞ ŧħīş ƒǿřḿ.  Ƥŀḗȧşḗ ƈǿřřḗƈŧ ŧħḗḿ ƀḗŀǿẇ."
+msgstr ""
 
 #: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:2
 msgid "Add-ons in Your Collection"
 msgstr "Ȧḓḓ-ǿƞş īƞ Ẏǿŭř Ƈǿŀŀḗƈŧīǿƞ"
 
 #: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:4
-msgid ""
-"To include an add-on in this collection, enter its name in the box below and hit enter.  You can also use the <strong>Add to Collection</strong> links throughout the site to include add-ons later."
+msgid "To include an add-on in this collection, enter its name in the box below and hit enter."
 msgstr ""
-"Ŧǿ īƞƈŀŭḓḗ ȧƞ ȧḓḓ-ǿƞ īƞ ŧħīş ƈǿŀŀḗƈŧīǿƞ, ḗƞŧḗř īŧş ƞȧḿḗ īƞ ŧħḗ ƀǿẋ ƀḗŀǿẇ ȧƞḓ ħīŧ ḗƞŧḗř.  Ẏǿŭ ƈȧƞ ȧŀşǿ ŭşḗ ŧħḗ <strong>Ȧḓḓ ŧǿ Ƈǿŀŀḗƈŧīǿƞ</strong> ŀīƞķş ŧħřǿŭɠħǿŭŧ ŧħḗ şīŧḗ ŧǿ īƞƈŀŭḓḗ ȧḓḓ-ǿƞş ŀȧŧḗř."
 
-#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:17 src/olympia/constants/base.py:400 src/olympia/devhub/templates/devhub/addons/activity.html:62
+#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:15 src/olympia/constants/base.py:400 src/olympia/devhub/templates/devhub/addons/activity.html:62
+#: src/olympia/editors/helpers.py:273 src/olympia/editors/helpers.py:360
 msgid "Add-on"
 msgstr "Ȧḓḓ-ǿƞ"
 
-#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:26
+#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:24
 msgid "Enter the name of the add-on to include"
 msgstr "Ḗƞŧḗř ŧħḗ ƞȧḿḗ ǿƒ ŧħḗ ȧḓḓ-ǿƞ ŧǿ īƞƈŀŭḓḗ"
 
-#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:28
+#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:26
 msgid "Add to Collection"
 msgstr "Ȧḓḓ ŧǿ Ƈǿŀŀḗƈŧīǿƞ"
 
-#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:45 src/olympia/editors/helpers.py:936 src/olympia/editors/helpers.py:956
+#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:43 src/olympia/editors/helpers.py:1016 src/olympia/editors/helpers.py:1036
 msgid "Pending"
 msgstr "Ƥḗƞḓīƞɠ"
 
-#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:47
+#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:45
 msgid "Add a comment"
 msgstr "Ȧḓḓ ȧ ƈǿḿḿḗƞŧ"
 
-#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:48
+#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:46
 msgid "Remove this add-on from the collection"
 msgstr "Řḗḿǿṽḗ ŧħīş ȧḓḓ-ǿƞ ƒřǿḿ ŧħḗ ƈǿŀŀḗƈŧīǿƞ"
 
@@ -2732,8 +2742,6 @@ msgid ""
 "When Mozilla becomes aware of add-ons, plugins, or other third-party software that seriously compromises %(app)s security, stability, or performance and meets <a href=\"%(criteria)s\">certain "
 "criteria</a>, the software may be blocked from general use.  For more information, please read <a href=\"%(support)s\">this support article</a>."
 msgstr ""
-"Ẇħḗƞ Ḿǿzīŀŀȧ ƀḗƈǿḿḗş ȧẇȧřḗ ǿƒ ȧḓḓ-ǿƞş, ƥŀŭɠīƞş, ǿř ǿŧħḗř ŧħīřḓ-ƥȧřŧẏ şǿƒŧẇȧřḗ ŧħȧŧ şḗřīǿŭşŀẏ ƈǿḿƥřǿḿīşḗş %(app)s şḗƈŭřīŧẏ, şŧȧƀīŀīŧẏ, ǿř ƥḗřƒǿřḿȧƞƈḗ ȧƞḓ ḿḗḗŧş <a href=\"%(criteria)s\">ƈḗřŧȧīƞ "
-"ƈřīŧḗřīȧ</a>, ŧħḗ şǿƒŧẇȧřḗ ḿȧẏ ƀḗ ƀŀǿƈķḗḓ ƒřǿḿ ɠḗƞḗřȧŀ ŭşḗ.  Ƒǿř ḿǿřḗ īƞƒǿřḿȧŧīǿƞ, ƥŀḗȧşḗ řḗȧḓ <a href=\"%(support)s\">ŧħīş şŭƥƥǿřŧ ȧřŧīƈŀḗ</a>."
 
 #: src/olympia/blocklist/templates/blocklist/blocked_detail.html:44
 #, python-format
@@ -2790,12 +2798,12 @@ msgstr "Şḗȧřƈħ ŧǿǿŀş"
 msgid "Most Users"
 msgstr "Ḿǿşŧ Ŭşḗřş"
 
-#: src/olympia/browse/views.py:61 src/olympia/browse/views.py:72 src/olympia/browse/views.py:279 src/olympia/browse/templates/browse/personas/mobile/category_landing.html:63
+#: src/olympia/browse/views.py:61 src/olympia/browse/views.py:72 src/olympia/browse/views.py:246 src/olympia/browse/templates/browse/personas/mobile/category_landing.html:63
 #: src/olympia/discovery/templates/discovery/pane.html:67 src/olympia/search/forms.py:92
 msgid "Up & Coming"
 msgstr "Ŭƥ & Ƈǿḿīƞɠ"
 
-#: src/olympia/browse/views.py:460 src/olympia/devhub/views.py:76 src/olympia/devhub/views.py:83 src/olympia/discovery/templates/discovery/addons/detail.html:66
+#: src/olympia/browse/views.py:427 src/olympia/devhub/views.py:74 src/olympia/devhub/views.py:81 src/olympia/discovery/templates/discovery/addons/detail.html:66
 msgid "Created"
 msgstr "Ƈřḗȧŧḗḓ"
 
@@ -2983,8 +2991,8 @@ msgid_plural "See all %(cnt)s extensions in %(name)s &raquo;"
 msgstr[0] "Şḗḗ ŧħḗ %(cnt)s ḗẋŧḗƞşīǿƞ īƞ %(name)s &raquo;"
 msgstr[1] "Şḗḗ ȧŀŀ %(cnt)s ḗẋŧḗƞşīǿƞş īƞ %(name)s &raquo;"
 
-#: src/olympia/browse/templates/browse/mobile/extensions.html:13 src/olympia/compat/templates/compat/index.html:82 src/olympia/devhub/templates/devhub/devhub_search.html:24
-#: src/olympia/devhub/templates/devhub/addons/activity.html:47 src/olympia/search/templates/search/no_results.html:4 src/olympia/search/templates/search/mobile/results.html:36
+#: src/olympia/browse/templates/browse/mobile/extensions.html:13 src/olympia/devhub/templates/devhub/devhub_search.html:24 src/olympia/devhub/templates/devhub/addons/activity.html:47
+#: src/olympia/search/templates/search/no_results.html:4 src/olympia/search/templates/search/mobile/results.html:36
 msgid "No results found."
 msgstr "Ƞǿ řḗşŭŀŧş ƒǿŭƞḓ."
 
@@ -3069,7 +3077,7 @@ msgstr "&laquo; Ȧŀŀ Ŧħḗḿḗş"
 msgid "All"
 msgstr "Ȧŀŀ"
 
-#: src/olympia/compat/forms.py:22 src/olympia/search/views.py:525
+#: src/olympia/compat/forms.py:22 src/olympia/editors/templates/editors/base.html:69 src/olympia/search/views.py:518
 msgid "All Add-ons"
 msgstr "Ȧŀŀ Ȧḓḓ-ǿƞş"
 
@@ -3080,53 +3088,6 @@ msgstr "Ɓīƞȧřẏ"
 #: src/olympia/compat/forms.py:24
 msgid "Non-binary"
 msgstr "Ƞǿƞ-ƀīƞȧřẏ"
-
-#. Review points sources other than add-ons and themes.
-#: src/olympia/compat/views.py:87 src/olympia/constants/base.py:388 src/olympia/devhub/forms.py:162 src/olympia/editors/templates/editors/performance.html:75
-msgid "Other"
-msgstr "Ǿŧħḗř"
-
-#: src/olympia/compat/templates/compat/index.html:4
-msgid "Add-on Compatibility Report for {app} {version}"
-msgstr "Ȧḓḓ-ǿƞ Ƈǿḿƥȧŧīƀīŀīŧẏ Řḗƥǿřŧ ƒǿř {ȧƥƥ} {ṽḗřşīǿƞ}"
-
-#: src/olympia/compat/templates/compat/index.html:11
-msgid "{app} {version} Compatibility"
-msgstr "{ȧƥƥ} {ṽḗřşīǿƞ} Ƈǿḿƥȧŧīƀīŀīŧẏ"
-
-#: src/olympia/compat/templates/compat/index.html:17
-#, python-format
-msgid "Top 95%% compatible with previous version"
-msgstr "Ŧǿƥ 95%% ƈǿḿƥȧŧīƀŀḗ ẇīŧħ ƥřḗṽīǿŭş ṽḗřşīǿƞ"
-
-#: src/olympia/compat/templates/compat/index.html:18
-#, python-format
-msgid "Top 95%% of all add-ons"
-msgstr "Ŧǿƥ 95%% ǿƒ ȧŀŀ ȧḓḓ-ǿƞş"
-
-#: src/olympia/compat/templates/compat/index.html:19
-msgid "All active add-ons"
-msgstr "Ȧŀŀ ȧƈŧīṽḗ ȧḓḓ-ǿƞş"
-
-#: src/olympia/compat/templates/compat/index.html:23 src/olympia/constants/base.py:401
-msgid "App"
-msgstr "Ȧƥƥ"
-
-#: src/olympia/compat/templates/compat/index.html:55
-msgid "Details for add-ons compatible with previous version:"
-msgstr "Ḓḗŧȧīŀş ƒǿř ȧḓḓ-ǿƞş ƈǿḿƥȧŧīƀŀḗ ẇīŧħ ƥřḗṽīǿŭş ṽḗřşīǿƞ:"
-
-#: src/olympia/compat/templates/compat/index.html:57
-msgid "Show all versions"
-msgstr "Şħǿẇ ȧŀŀ ṽḗřşīǿƞş"
-
-#: src/olympia/compat/templates/compat/index.html:59
-msgid "Details for add-ons compatible with all versions:"
-msgstr "Ḓḗŧȧīŀş ƒǿř ȧḓḓ-ǿƞş ƈǿḿƥȧŧīƀŀḗ ẇīŧħ ȧŀŀ ṽḗřşīǿƞş:"
-
-#: src/olympia/compat/templates/compat/index.html:61
-msgid "Show previous version only"
-msgstr "Şħǿẇ ƥřḗṽīǿŭş ṽḗřşīǿƞ ǿƞŀẏ"
 
 #: src/olympia/compat/templates/compat/reporter.html:3
 msgid "Add-on Compatibility Reports"
@@ -3181,8 +3142,8 @@ msgstr "Ƒīŀŧḗř ƀẏ Ȧƥƥŀīƈȧŧīǿƞ"
 msgid "Report Type"
 msgstr "Řḗƥǿřŧ Ŧẏƥḗ"
 
-#: src/olympia/compat/templates/compat/reporter_detail.html:47 src/olympia/devhub/forms.py:784 src/olympia/devhub/templates/devhub/addons/ajax_compat_update.html:17 src/olympia/editors/forms.py:108
-#: src/olympia/zadmin/forms.py:45
+#: src/olympia/compat/templates/compat/reporter_detail.html:47 src/olympia/devhub/forms.py:785 src/olympia/devhub/templates/devhub/addons/ajax_compat_update.html:17 src/olympia/editors/forms.py:108
+#: src/olympia/editors/forms.py:248 src/olympia/zadmin/forms.py:45
 msgid "Application"
 msgstr "Ȧƥƥŀīƈȧŧīǿƞ"
 
@@ -3270,7 +3231,8 @@ msgstr "Ƥřḗŀīḿīƞȧřīŀẏ Řḗṽīḗẇḗḓ"
 msgid "Preliminarily Reviewed and Awaiting Full Review"
 msgstr "Ƥřḗŀīḿīƞȧřīŀẏ Řḗṽīḗẇḗḓ ȧƞḓ Ȧẇȧīŧīƞɠ Ƒŭŀŀ Řḗṽīḗẇ"
 
-#: src/olympia/constants/base.py:33 src/olympia/editors/helpers.py:924 src/olympia/editors/templates/editors/themes/history_table.html:34
+#: src/olympia/constants/base.py:33 src/olympia/editors/forms.py:258 src/olympia/editors/helpers.py:73 src/olympia/editors/helpers.py:1004
+#: src/olympia/editors/templates/editors/themes/history_table.html:34
 msgid "Deleted"
 msgstr "Ḓḗŀḗŧḗḓ"
 
@@ -3367,6 +3329,11 @@ msgstr "Ȧşķ ȧƒŧḗř ŭşḗřş şŧȧřŧ ḓǿẇƞŀǿȧḓīƞɠ ŧħ
 msgid "Ask before users can download this add-on"
 msgstr "Ȧşķ ƀḗƒǿřḗ ŭşḗřş ƈȧƞ ḓǿẇƞŀǿȧḓ ŧħīş ȧḓḓ-ǿƞ"
 
+#. Review points sources other than add-ons and themes.
+#: src/olympia/constants/base.py:388 src/olympia/devhub/forms.py:162 src/olympia/editors/templates/editors/performance.html:75
+msgid "Other"
+msgstr "Ǿŧħḗř"
+
 #: src/olympia/constants/base.py:389
 msgid "Exception"
 msgstr "Ḗẋƈḗƥŧīǿƞ"
@@ -3378,6 +3345,10 @@ msgstr "Řḗŀḗȧşḗ"
 #: src/olympia/constants/base.py:391
 msgid "Change"
 msgstr "Ƈħȧƞɠḗ"
+
+#: src/olympia/constants/base.py:401
+msgid "App"
+msgstr "Ȧƥƥ"
 
 #: src/olympia/constants/base.py:402
 msgid "Persona"
@@ -3527,7 +3498,7 @@ msgstr "Ƒŀȧɠ"
 msgid "Duplicate"
 msgstr "Ḓŭƥŀīƈȧŧḗ"
 
-#: src/olympia/constants/editors.py:17 src/olympia/editors/helpers.py:502 src/olympia/editors/templates/editors/themes/queue.html:71 src/olympia/editors/templates/editors/themes/themes.html:94
+#: src/olympia/constants/editors.py:17 src/olympia/editors/helpers.py:575 src/olympia/editors/templates/editors/themes/queue.html:71 src/olympia/editors/templates/editors/themes/themes.html:94
 msgid "Reject"
 msgstr "Řḗĵḗƈŧ"
 
@@ -3627,7 +3598,7 @@ msgstr "Şǿŀȧřīş"
 msgid "Android"
 msgstr "Ȧƞḓřǿīḓ"
 
-#: src/olympia/core/apps.py:19
+#: src/olympia/core/apps.py:21
 msgid "Core"
 msgstr "Ƈǿřḗ"
 
@@ -3761,8 +3732,8 @@ msgid "Submit my add-on for manual review."
 msgstr "Şŭƀḿīŧ ḿẏ ȧḓḓ-ǿƞ ƒǿř ḿȧƞŭȧŀ řḗṽīḗẇ."
 
 #: src/olympia/devhub/forms.py:537
-msgid "Do not list my add-on on this site (beta)"
-msgstr "Ḓǿ ƞǿŧ ŀīşŧ ḿẏ ȧḓḓ-ǿƞ ǿƞ ŧħīş şīŧḗ (ƀḗŧȧ)"
+msgid "Do not list my add-on on this site"
+msgstr ""
 
 #: src/olympia/devhub/forms.py:538
 msgid "Check this option if you intend to distribute your add-on on your own and only need it to be signed by Mozilla."
@@ -3794,46 +3765,46 @@ msgstr "Ȧ ƒīŀḗ ẇīŧħ ȧ ṽḗřşīǿƞ ḗƞḓīƞɠ ẇīŧħ ȧ|�
 
 #: src/olympia/devhub/forms.py:592
 #, python-format
-msgid "Version %s already exists"
-msgstr "Ṽḗřşīǿƞ %s ȧŀřḗȧḓẏ ḗẋīşŧş"
+msgid "Version %s already exists, or was uploaded before."
+msgstr ""
 
-#: src/olympia/devhub/forms.py:604
+#: src/olympia/devhub/forms.py:605
 msgid "Select a valid choice. That choice is not one of the available choices."
 msgstr "Şḗŀḗƈŧ ȧ ṽȧŀīḓ ƈħǿīƈḗ. Ŧħȧŧ ƈħǿīƈḗ īş ƞǿŧ ǿƞḗ ǿƒ ŧħḗ ȧṽȧīŀȧƀŀḗ ƈħǿīƈḗş."
 
-#: src/olympia/devhub/forms.py:610
+#: src/olympia/devhub/forms.py:611
 msgid "A file with a version ending with a|alpha|b|beta and an optional number is detected as beta."
 msgstr "Ȧ ƒīŀḗ ẇīŧħ ȧ ṽḗřşīǿƞ ḗƞḓīƞɠ ẇīŧħ ȧ|ȧŀƥħȧ|ƀ|ƀḗŧȧ ȧƞḓ ȧƞ ǿƥŧīǿƞȧŀ ƞŭḿƀḗř īş ḓḗŧḗƈŧḗḓ ȧş ƀḗŧȧ."
 
-#: src/olympia/devhub/forms.py:633
+#: src/olympia/devhub/forms.py:634
 msgid "You cannot upload any more files for this version."
 msgstr "Ẏǿŭ ƈȧƞƞǿŧ ŭƥŀǿȧḓ ȧƞẏ ḿǿřḗ ƒīŀḗş ƒǿř ŧħīş ṽḗřşīǿƞ."
 
-#: src/olympia/devhub/forms.py:639
+#: src/olympia/devhub/forms.py:640
 msgid "Version doesn't match"
 msgstr "Ṽḗřşīǿƞ ḓǿḗşƞ'ŧ ḿȧŧƈħ"
 
-#: src/olympia/devhub/forms.py:668
+#: src/olympia/devhub/forms.py:669
 msgid "You cannot delete a file once the review process has started.  You must delete the whole version."
-msgstr "Ẏǿŭ ƈȧƞƞǿŧ ḓḗŀḗŧḗ ȧ ƒīŀḗ ǿƞƈḗ ŧħḗ řḗṽīḗẇ ƥřǿƈḗşş ħȧş şŧȧřŧḗḓ.  Ẏǿŭ ḿŭşŧ ḓḗŀḗŧḗ ŧħḗ ẇħǿŀḗ ṽḗřşīǿƞ."
+msgstr ""
 
-#: src/olympia/devhub/forms.py:688
+#: src/olympia/devhub/forms.py:689
 msgid "The platform All cannot be combined with specific platforms."
 msgstr "Ŧħḗ ƥŀȧŧƒǿřḿ Ȧŀŀ ƈȧƞƞǿŧ ƀḗ ƈǿḿƀīƞḗḓ ẇīŧħ şƥḗƈīƒīƈ ƥŀȧŧƒǿřḿş."
 
-#: src/olympia/devhub/forms.py:693
+#: src/olympia/devhub/forms.py:694
 msgid "A platform can only be chosen once."
 msgstr "Ȧ ƥŀȧŧƒǿřḿ ƈȧƞ ǿƞŀẏ ƀḗ ƈħǿşḗƞ ǿƞƈḗ."
 
-#: src/olympia/devhub/forms.py:706
+#: src/olympia/devhub/forms.py:707
 msgid "A review type must be selected."
 msgstr "Ȧ řḗṽīḗẇ ŧẏƥḗ ḿŭşŧ ƀḗ şḗŀḗƈŧḗḓ."
 
-#: src/olympia/devhub/forms.py:788 src/olympia/editors/forms.py:114 src/olympia/zadmin/forms.py:49 src/olympia/zadmin/forms.py:52
+#: src/olympia/devhub/forms.py:789 src/olympia/editors/forms.py:114 src/olympia/editors/forms.py:254 src/olympia/zadmin/forms.py:49 src/olympia/zadmin/forms.py:52
 msgid "Select an application first"
 msgstr "Şḗŀḗƈŧ ȧƞ ȧƥƥŀīƈȧŧīǿƞ ƒīřşŧ"
 
-#: src/olympia/devhub/forms.py:840
+#: src/olympia/devhub/forms.py:841
 msgid "There cannot be more than 3 required add-ons."
 msgstr "Ŧħḗřḗ ƈȧƞƞǿŧ ƀḗ ḿǿřḗ ŧħȧƞ 3 řḗɋŭīřḗḓ ȧḓḓ-ǿƞş."
 
@@ -3867,76 +3838,76 @@ msgstr[1] "{0} ẇȧřƞīƞɠş"
 msgid "Review"
 msgstr "Řḗṽīḗẇ"
 
-#: src/olympia/devhub/tasks.py:551
+#: src/olympia/devhub/tasks.py:583
 #, python-format
 msgid "%s responded with %s (%s)."
 msgstr "%s řḗşƥǿƞḓḗḓ ẇīŧħ %s (%s)."
 
-#: src/olympia/devhub/tasks.py:555
+#: src/olympia/devhub/tasks.py:587
 #, python-format
 msgid "Connection to \"%s\" timed out."
 msgstr "Ƈǿƞƞḗƈŧīǿƞ ŧǿ \"%s\" ŧīḿḗḓ ǿŭŧ."
 
-#: src/olympia/devhub/tasks.py:557
+#: src/olympia/devhub/tasks.py:589
 #, python-format
 msgid "Could not contact host at \"%s\"."
 msgstr "Ƈǿŭŀḓ ƞǿŧ ƈǿƞŧȧƈŧ ħǿşŧ ȧŧ \"%s\"."
 
-#: src/olympia/devhub/utils.py:104
+#: src/olympia/devhub/utils.py:105
 #, python-format
 msgid "Validation generated too many errors/warnings so %s messages were truncated. After addressing the visible messages, you'll be able to see the others."
 msgstr "Ṽȧŀīḓȧŧīǿƞ ɠḗƞḗřȧŧḗḓ ŧǿǿ ḿȧƞẏ ḗřřǿřş/warnings şǿ %s ḿḗşşȧɠḗş ẇḗřḗ ŧřŭƞƈȧŧḗḓ. Ȧƒŧḗř ȧḓḓřḗşşīƞɠ ŧħḗ ṽīşīƀŀḗ ḿḗşşȧɠḗş, ẏǿŭ'ŀŀ ƀḗ ȧƀŀḗ ŧǿ şḗḗ ŧħḗ ǿŧħḗřş."
 
-#: src/olympia/devhub/views.py:183
+#: src/olympia/devhub/views.py:181
 msgid "All My Add-ons"
 msgstr "Ȧŀŀ Ḿẏ Ȧḓḓ-ǿƞş"
 
-#: src/olympia/devhub/views.py:210
+#: src/olympia/devhub/views.py:208
 msgid "All Activity"
 msgstr "Ȧŀŀ Ȧƈŧīṽīŧẏ"
 
-#: src/olympia/devhub/views.py:211
+#: src/olympia/devhub/views.py:209
 msgid "Add-on Updates"
 msgstr "Ȧḓḓ-ǿƞ Ŭƥḓȧŧḗş"
 
-#: src/olympia/devhub/views.py:212
+#: src/olympia/devhub/views.py:210
 msgid "Add-on Status"
 msgstr "Ȧḓḓ-ǿƞ Şŧȧŧŭş"
 
-#: src/olympia/devhub/views.py:213
+#: src/olympia/devhub/views.py:211
 msgid "User Collections"
 msgstr "Ŭşḗř Ƈǿŀŀḗƈŧīǿƞş"
 
-#: src/olympia/devhub/views.py:214 src/olympia/devhub/templates/devhub/docs/policies-maintenance.html:68 src/olympia/pages/templates/pages/dev_faq.html:38
+#: src/olympia/devhub/views.py:212 src/olympia/devhub/templates/devhub/docs/policies-maintenance.html:68 src/olympia/pages/templates/pages/dev_faq.html:38
 #: src/olympia/pages/templates/pages/dev_faq.html:484
 msgid "User Reviews"
 msgstr "Ŭşḗř Řḗṽīḗẇş"
 
-#: src/olympia/devhub/views.py:327 src/olympia/devhub/views.py:331 src/olympia/devhub/views.py:484 src/olympia/devhub/views.py:513 src/olympia/devhub/views.py:564 src/olympia/devhub/views.py:1150
+#: src/olympia/devhub/views.py:325 src/olympia/devhub/views.py:329 src/olympia/devhub/views.py:484 src/olympia/devhub/views.py:513 src/olympia/devhub/views.py:564 src/olympia/devhub/views.py:1156
 msgid "Changes successfully saved."
 msgstr "Ƈħȧƞɠḗş şŭƈƈḗşşƒŭŀŀẏ şȧṽḗḓ."
 
-#: src/olympia/devhub/views.py:334 src/olympia/devhub/views.py:1631
+#: src/olympia/devhub/views.py:332 src/olympia/devhub/views.py:1637
 msgid "Please check the form for errors."
 msgstr "Ƥŀḗȧşḗ ƈħḗƈķ ŧħḗ ƒǿřḿ ƒǿř ḗřřǿřş."
 
-#: src/olympia/devhub/views.py:346
+#: src/olympia/devhub/views.py:344
 msgid "Add-on cannot be deleted. Disable this add-on instead."
 msgstr "Ȧḓḓ-ǿƞ ƈȧƞƞǿŧ ƀḗ ḓḗŀḗŧḗḓ. Ḓīşȧƀŀḗ ŧħīş ȧḓḓ-ǿƞ īƞşŧḗȧḓ."
 
-#: src/olympia/devhub/views.py:356
+#: src/olympia/devhub/views.py:354
 msgid "Theme deleted."
 msgstr "Ŧħḗḿḗ ḓḗŀḗŧḗḓ."
 
-#: src/olympia/devhub/views.py:356
+#: src/olympia/devhub/views.py:354
 msgid "Add-on deleted."
 msgstr "Ȧḓḓ-ǿƞ ḓḗŀḗŧḗḓ."
 
-#: src/olympia/devhub/views.py:362
+#: src/olympia/devhub/views.py:360
 msgid "URL name was incorrect. Theme was not deleted."
 msgstr "ŬŘĿ ƞȧḿḗ ẇȧş īƞƈǿřřḗƈŧ. Ŧħḗḿḗ ẇȧş ƞǿŧ ḓḗŀḗŧḗḓ."
 
-#: src/olympia/devhub/views.py:367
+#: src/olympia/devhub/views.py:365
 msgid "URL name was incorrect. Add-on was not deleted."
 msgstr "ŬŘĿ ƞȧḿḗ ẇȧş īƞƈǿřřḗƈŧ. Ȧḓḓ-ǿƞ ẇȧş ƞǿŧ ḓḗŀḗŧḗḓ."
 
@@ -3964,7 +3935,7 @@ msgstr "Ṽȧŀīḓȧŧḗ Ȧḓḓ-ǿƞ"
 msgid "Check Add-on Compatibility"
 msgstr "Ƈħḗƈķ Ȧḓḓ-ǿƞ Ƈǿḿƥȧŧīƀīŀīŧẏ"
 
-#: src/olympia/devhub/views.py:808 src/olympia/signing/views.py:90
+#: src/olympia/devhub/views.py:808 src/olympia/signing/views.py:95
 msgid "You cannot submit this type of add-on"
 msgstr "Ẏǿŭ ƈȧƞƞǿŧ şŭƀḿīŧ ŧħīş ŧẏƥḗ ǿƒ ȧḓḓ-ǿƞ"
 
@@ -3994,33 +3965,33 @@ msgstr "Īḿȧɠḗ ḿŭşŧ ƀḗ ḗẋȧƈŧŀẏ {0} ƥīẋḗŀş ẇī�
 msgid "There was an error uploading your preview."
 msgstr "Ŧħḗřḗ ẇȧş ȧƞ ḗřřǿř ŭƥŀǿȧḓīƞɠ ẏǿŭř ƥřḗṽīḗẇ."
 
-#: src/olympia/devhub/views.py:1189
+#: src/olympia/devhub/views.py:1195
 #, python-format
 msgid "Version %s disabled."
 msgstr "Ṽḗřşīǿƞ %s ḓīşȧƀŀḗḓ."
 
-#: src/olympia/devhub/views.py:1193
+#: src/olympia/devhub/views.py:1199
 #, python-format
 msgid "Version %s deleted."
 msgstr "Ṽḗřşīǿƞ %s ḓḗŀḗŧḗḓ."
 
-#: src/olympia/devhub/views.py:1203
+#: src/olympia/devhub/views.py:1209
 msgid "This upload has failed validation, and may lack complete validation results. Please take due care when reviewing it."
 msgstr "Ŧħīş ŭƥŀǿȧḓ ħȧş ƒȧīŀḗḓ ṽȧŀīḓȧŧīǿƞ, ȧƞḓ ḿȧẏ ŀȧƈķ ƈǿḿƥŀḗŧḗ ṽȧŀīḓȧŧīǿƞ řḗşŭŀŧş. Ƥŀḗȧşḗ ŧȧķḗ ḓŭḗ ƈȧřḗ ẇħḗƞ řḗṽīḗẇīƞɠ īŧ."
 
-#: src/olympia/devhub/views.py:1677
+#: src/olympia/devhub/views.py:1683
 msgid "Preliminary Review Requested."
 msgstr "Ƥřḗŀīḿīƞȧřẏ Řḗṽīḗẇ Řḗɋŭḗşŧḗḓ."
 
-#: src/olympia/devhub/views.py:1678
+#: src/olympia/devhub/views.py:1684
 msgid "Full Review Requested."
 msgstr "Ƒŭŀŀ Řḗṽīḗẇ Řḗɋŭḗşŧḗḓ."
 
-#: src/olympia/devhub/views.py:1779
+#: src/olympia/devhub/views.py:1783
 msgid "Your old credentials were revoked and are no longer valid. Be sure to update all API clients with the new credentials."
 msgstr "Ẏǿŭř ǿŀḓ ƈřḗḓḗƞŧīȧŀş ẇḗřḗ řḗṽǿķḗḓ ȧƞḓ ȧřḗ ƞǿ ŀǿƞɠḗř ṽȧŀīḓ. Ɓḗ şŭřḗ ŧǿ ŭƥḓȧŧḗ ȧŀŀ ȦƤĪ ƈŀīḗƞŧş ẇīŧħ ŧħḗ ƞḗẇ ƈřḗḓḗƞŧīȧŀş."
 
-#: src/olympia/devhub/views.py:1797
+#: src/olympia/devhub/views.py:1801
 msgid "New API key created"
 msgstr "Ƞḗẇ ȦƤĪ ķḗẏ ƈřḗȧŧḗḓ"
 
@@ -4050,7 +4021,7 @@ msgstr "Ɓȧƈķ ŧǿ Ȧḓḓ-ǿƞş"
 msgid "{0} :: Search"
 msgstr "{0} :: Şḗȧřƈħ"
 
-#: src/olympia/devhub/templates/devhub/devhub_search.html:6 src/olympia/devhub/templates/devhub/search.html:8 src/olympia/editors/forms.py:435 src/olympia/editors/forms.py:437
+#: src/olympia/devhub/templates/devhub/devhub_search.html:6 src/olympia/devhub/templates/devhub/search.html:8 src/olympia/editors/forms.py:534 src/olympia/editors/forms.py:536
 #: src/olympia/editors/templates/editors/queue.html:27 src/olympia/editors/templates/editors/themes/queue_list.html:14 src/olympia/search/templates/search/collections.html:17
 #: src/olympia/search/templates/search/personas.html:18 src/olympia/search/templates/search/results.html:18 src/olympia/search/templates/search/mobile/results.html:8
 #: src/olympia/templates/search.html:14 src/olympia/templates/impala/search.html:18
@@ -4113,12 +4084,12 @@ msgstr "Ħḗȧḓ ǿṽḗř ŧǿ ŧħḗ <a href=\"https://developer.mozilla.o
 msgid "Start Making Add-ons"
 msgstr "Şŧȧřŧ Ḿȧķīƞɠ Ȧḓḓ-ǿƞş"
 
-#: src/olympia/devhub/templates/devhub/index.html:86 src/olympia/devhub/templates/devhub/addons/listing/items.html:25 src/olympia/devhub/templates/devhub/includes/addon_details.html:15
+#: src/olympia/devhub/templates/devhub/index.html:86 src/olympia/devhub/templates/devhub/addons/listing/items.html:25 src/olympia/devhub/templates/devhub/includes/addon_details.html:20
 #: src/olympia/devhub/templates/devhub/personas/edit.html:43
 msgid "Status:"
 msgstr "Şŧȧŧŭş:"
 
-#: src/olympia/devhub/templates/devhub/index.html:90 src/olympia/devhub/templates/devhub/includes/addon_details.html:100
+#: src/olympia/devhub/templates/devhub/index.html:90 src/olympia/devhub/templates/devhub/includes/addon_details.html:87
 msgid "Visibility:"
 msgstr "Ṽīşīƀīŀīŧẏ:"
 
@@ -4126,11 +4097,11 @@ msgstr "Ṽīşīƀīŀīŧẏ:"
 msgid "Latest Version:"
 msgstr "Ŀȧŧḗşŧ Ṽḗřşīǿƞ:"
 
-#: src/olympia/devhub/templates/devhub/index.html:109 src/olympia/devhub/templates/devhub/includes/addon_details.html:145 src/olympia/devhub/templates/devhub/personas/edit.html:49
+#: src/olympia/devhub/templates/devhub/index.html:109 src/olympia/devhub/templates/devhub/includes/addon_details.html:131 src/olympia/devhub/templates/devhub/personas/edit.html:49
 msgid "Queue Position:"
 msgstr "Ɋŭḗŭḗ Ƥǿşīŧīǿƞ:"
 
-#: src/olympia/devhub/templates/devhub/index.html:110 src/olympia/devhub/templates/devhub/includes/addon_details.html:146 src/olympia/devhub/templates/devhub/personas/edit.html:50
+#: src/olympia/devhub/templates/devhub/index.html:110 src/olympia/devhub/templates/devhub/includes/addon_details.html:132 src/olympia/devhub/templates/devhub/personas/edit.html:50
 #, python-format
 msgid "%(position)s of %(total)s"
 msgstr "%(position)s ǿƒ %(total)s"
@@ -4232,16 +4203,6 @@ msgstr "Ȧƒŧḗř ŭƥŀǿȧḓ, ȧ şḗřīḗş ǿƒ ȧŭŧǿḿȧŧḗḓ 
 msgid "Do you want your add-on to be distributed on this site?"
 msgstr "Ḓǿ ẏǿŭ ẇȧƞŧ ẏǿŭř ȧḓḓ-ǿƞ ŧǿ ƀḗ ḓīşŧřīƀŭŧḗḓ ǿƞ ŧħīş şīŧḗ?"
 
-#: src/olympia/devhub/templates/devhub/validate_addon.html:49 src/olympia/devhub/templates/devhub/addons/submit/upload.html:30 src/olympia/devhub/templates/devhub/versions/add_file_modal.html:14
-#: src/olympia/devhub/templates/devhub/versions/add_file_modal.html:53 src/olympia/devhub/templates/devhub/versions/list.html:298
-msgid "Warning:"
-msgstr "Ẇȧřƞīƞɠ:"
-
-#: src/olympia/devhub/templates/devhub/validate_addon.html:50 src/olympia/devhub/templates/devhub/addons/submit/upload.html:31
-#, python-format
-msgid "Submission of unlisted add-ons for signing is currently in an open beta. Please <a href=\"%(url)s\" target=\"_blank\">report any bugs</a> that you encounter."
-msgstr "Şŭƀḿīşşīǿƞ ǿƒ ŭƞŀīşŧḗḓ ȧḓḓ-ǿƞş ƒǿř şīɠƞīƞɠ īş ƈŭřřḗƞŧŀẏ īƞ ȧƞ ǿƥḗƞ ƀḗŧȧ. Ƥŀḗȧşḗ <a href=\"%(url)s\" target=\"_blank\">řḗƥǿřŧ ȧƞẏ ƀŭɠş</a> ŧħȧŧ ẏǿŭ ḗƞƈǿŭƞŧḗř."
-
 #. first parameter is a filename like lorem-ipsum-1.0.2.xpi
 #: src/olympia/devhub/templates/devhub/validation.html:5
 msgid "Validation Results for {0}"
@@ -4320,7 +4281,7 @@ msgstr "Ƈǿḿƥȧŧīƀīŀīŧẏ"
 msgid "Update Compatibility"
 msgstr "Ŭƥḓȧŧḗ Ƈǿḿƥȧŧīƀīŀīŧẏ"
 
-#: src/olympia/devhub/templates/devhub/addons/ajax_compat_update.html:4
+#: src/olympia/devhub/templates/devhub/addons/ajax_compat_update.html:4 src/olympia/devhub/templates/devhub/versions/edit.html:45
 msgid "Adjusting application information here will allow users to install your add-on even if the install manifest in the package indicates that the add-on is incompatible."
 msgstr "Ȧḓĵŭşŧīƞɠ ȧƥƥŀīƈȧŧīǿƞ īƞƒǿřḿȧŧīǿƞ ħḗřḗ ẇīŀŀ ȧŀŀǿẇ ŭşḗřş ŧǿ īƞşŧȧŀŀ ẏǿŭř ȧḓḓ-ǿƞ ḗṽḗƞ īƒ ŧħḗ īƞşŧȧŀŀ ḿȧƞīƒḗşŧ īƞ ŧħḗ ƥȧƈķȧɠḗ īƞḓīƈȧŧḗş ŧħȧŧ ŧħḗ ȧḓḓ-ǿƞ īş īƞƈǿḿƥȧŧīƀŀḗ."
 
@@ -4332,9 +4293,9 @@ msgstr "Şŭƥƥǿřŧḗḓ Ṽḗřşīǿƞş"
 msgid "Add Another Application&hellip;"
 msgstr "Ȧḓḓ Ȧƞǿŧħḗř Ȧƥƥŀīƈȧŧīǿƞ&hellip;"
 
-#: src/olympia/devhub/templates/devhub/addons/ajax_compat_update.html:38 src/olympia/devhub/templates/devhub/addons/owner.html:86 src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:46
-#: src/olympia/devhub/templates/devhub/versions/list.html:351 src/olympia/devhub/templates/devhub/versions/list.html:353 src/olympia/templates/impala/base.html:132
-#: src/olympia/templates/impala/base.html:143 src/olympia/templates/impala/base.html:161 src/olympia/templates/impala/base.html:171
+#: src/olympia/devhub/templates/devhub/addons/ajax_compat_update.html:38 src/olympia/devhub/templates/devhub/addons/owner.html:86 src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:45
+#: src/olympia/devhub/templates/devhub/versions/list.html:349 src/olympia/devhub/templates/devhub/versions/list.html:351 src/olympia/templates/impala/base.html:129
+#: src/olympia/templates/impala/base.html:140 src/olympia/templates/impala/base.html:158 src/olympia/templates/impala/base.html:168
 msgid "Close"
 msgstr "Ƈŀǿşḗ"
 
@@ -4368,7 +4329,7 @@ msgstr "Ƞǿƞḗ"
 msgid "Manage Authors & License"
 msgstr "Ḿȧƞȧɠḗ Ȧŭŧħǿřş & Ŀīƈḗƞşḗ"
 
-#: src/olympia/devhub/templates/devhub/addons/owner.html:29 src/olympia/editors/templates/editors/review.html:270
+#: src/olympia/devhub/templates/devhub/addons/owner.html:29 src/olympia/editors/helpers.py:362 src/olympia/editors/templates/editors/review.html:270
 msgid "Authors"
 msgstr "Ȧŭŧħǿřş"
 
@@ -4440,10 +4401,7 @@ msgstr "Şŭḿḿȧřẏ"
 
 #: src/olympia/devhub/templates/devhub/addons/edit/basic.html:52
 msgid ""
-"A short explanation of your add-on's basic\n"
-"                          functionality that is displayed in search and browse\n"
-"                          listings, as well as at the top of your add-on's\n"
-"                          details page. It is only relevant for listed add-ons."
+"A short explanation of your add-on's basic functionality that is displayed in search and browse listings, as well as at the top of your add-on's details page. It is only relevant for listed add-ons."
 msgstr ""
 "Ȧ şħǿřŧ ḗẋƥŀȧƞȧŧīǿƞ ǿƒ ẏǿŭř ȧḓḓ-ǿƞ'ş ƀȧşīƈ\n"
 "                          ƒŭƞƈŧīǿƞȧŀīŧẏ ŧħȧŧ īş ḓīşƥŀȧẏḗḓ īƞ şḗȧřƈħ ȧƞḓ ƀřǿẇşḗ\n"
@@ -4451,10 +4409,7 @@ msgstr ""
 "                          ḓḗŧȧīŀş ƥȧɠḗ. Īŧ īş ǿƞŀẏ řḗŀḗṽȧƞŧ ƒǿř ŀīşŧḗḓ ȧḓḓ-ǿƞş."
 
 #: src/olympia/devhub/templates/devhub/addons/edit/basic.html:73
-msgid ""
-"Categories are the primary way users browse through add-ons.\n"
-"                        Choose any that fit your add-on's functionality for the most\n"
-"                        exposure. It is only relevant for listed add-ons."
+msgid "Categories are the primary way users browse through add-ons. Choose any that fit your add-on's functionality for the most exposure. It is only relevant for listed add-ons."
 msgstr ""
 "Ƈȧŧḗɠǿřīḗş ȧřḗ ŧħḗ ƥřīḿȧřẏ ẇȧẏ ŭşḗřş ƀřǿẇşḗ ŧħřǿŭɠħ ȧḓḓ-ǿƞş.\n"
 "                        Ƈħǿǿşḗ ȧƞẏ ŧħȧŧ ƒīŧ ẏǿŭř ȧḓḓ-ǿƞ'ş ƒŭƞƈŧīǿƞȧŀīŧẏ ƒǿř ŧħḗ ḿǿşŧ\n"
@@ -4468,11 +4423,7 @@ msgstr ""
 "Ƈȧŧḗɠǿřīḗş ƈȧƞƞǿŧ ƀḗ ƈħȧƞɠḗḓ ẇħīŀḗ ẏǿŭř ȧḓḓ-ǿƞ īş ƒḗȧŧŭřḗḓ ƒǿř ŧħīş ȧƥƥŀīƈȧŧīǿƞ. Ƥŀḗȧşḗ ḗḿȧīŀ <a href=\"mailto:%(email)s\">%(email)s</a> īƒ ŧħḗřḗ īş ȧ řḗȧşǿƞ ẏǿŭ ƞḗḗḓ ŧǿ ḿǿḓīƒẏ ẏǿŭř ƈȧŧḗɠǿřīḗş."
 
 #: src/olympia/devhub/templates/devhub/addons/edit/basic.html:119
-msgid ""
-"Tags help users find your add-on and should be short\n"
-"                        descriptors such as tabs, toolbar, or twitter.  You\n"
-"                        may have a maximum of {0} tags. It is only relevant\n"
-"                        for listed add-ons."
+msgid "Tags help users find your add-on and should be short descriptors such as tabs, toolbar, or twitter. You may have a maximum of {0} tags. It is only relevant for listed add-ons."
 msgstr ""
 "Ŧȧɠş ħḗŀƥ ŭşḗřş ƒīƞḓ ẏǿŭř ȧḓḓ-ǿƞ ȧƞḓ şħǿŭŀḓ ƀḗ şħǿřŧ\n"
 "                        ḓḗşƈřīƥŧǿřş şŭƈħ ȧş ŧȧƀş, ŧǿǿŀƀȧř, ǿř ŧẇīŧŧḗř.  Ẏǿŭ\n"
@@ -4504,11 +4455,7 @@ msgid "Add-on Details for {0}"
 msgstr "Ȧḓḓ-ǿƞ Ḓḗŧȧīŀş ƒǿř {0}"
 
 #: src/olympia/devhub/templates/devhub/addons/edit/details.html:22
-msgid ""
-"A longer explanation of features,\n"
-"                          functionality, and other relevant information. This\n"
-"                          field is only displayed on the add-on's details\n"
-"                          page. It is only relevant for listed add-ons."
+msgid "A longer explanation of features, functionality, and other relevant information. This field is only displayed on the add-on's details page. It is only relevant for listed add-ons."
 msgstr ""
 "Ȧ ŀǿƞɠḗř ḗẋƥŀȧƞȧŧīǿƞ ǿƒ ƒḗȧŧŭřḗş,\n"
 "                          ƒŭƞƈŧīǿƞȧŀīŧẏ, ȧƞḓ ǿŧħḗř řḗŀḗṽȧƞŧ īƞƒǿřḿȧŧīǿƞ. Ŧħīş\n"
@@ -4520,10 +4467,7 @@ msgid "Default Locale"
 msgstr "Ḓḗƒȧŭŀŧ Ŀǿƈȧŀḗ"
 
 #: src/olympia/devhub/templates/devhub/addons/edit/details.html:45
-msgid ""
-"Information about your add-on is displayed in this locale\n"
-"                        unless you override it with a locale-specific translation.\n"
-"                        It is only relevant for listed add-ons."
+msgid "Information about your add-on is displayed in this locale unless you override it with a locale-specific translation. It is only relevant for listed add-ons."
 msgstr ""
 "Īƞƒǿřḿȧŧīǿƞ ȧƀǿŭŧ ẏǿŭř ȧḓḓ-ǿƞ īş ḓīşƥŀȧẏḗḓ īƞ ŧħīş ŀǿƈȧŀḗ\n"
 "                        ŭƞŀḗşş ẏǿŭ ǿṽḗřřīḓḗ īŧ ẇīŧħ ȧ ŀǿƈȧŀḗ-şƥḗƈīƒīƈ ŧřȧƞşŀȧŧīǿƞ.\n"
@@ -4536,10 +4480,8 @@ msgstr "Ħǿḿḗƥȧɠḗ"
 
 #: src/olympia/devhub/templates/devhub/addons/edit/details.html:63
 msgid ""
-"If your add-on has another homepage, enter its\n"
-"                          address here. If your website is localized into other\n"
-"                          languages multiple translations of this field can be\n"
-"                          added. It is only relevant for listed add-ons."
+"If your add-on has another homepage, enter its address here. If your website is localized into other languages multiple translations of this field can be added. It is only relevant for listed add-"
+"ons."
 msgstr ""
 "Īƒ ẏǿŭř ȧḓḓ-ǿƞ ħȧş ȧƞǿŧħḗř ħǿḿḗƥȧɠḗ, ḗƞŧḗř īŧş\n"
 "                          ȧḓḓřḗşş ħḗřḗ. Īƒ ẏǿŭř ẇḗƀşīŧḗ īş ŀǿƈȧŀīzḗḓ īƞŧǿ ǿŧħḗř\n"
@@ -4561,11 +4503,8 @@ msgstr "Şŭƥƥǿřŧ Īƞƒǿřḿȧŧīǿƞ ƒǿř {0}"
 
 #: src/olympia/devhub/templates/devhub/addons/edit/support.html:22
 msgid ""
-"If you wish to display an e-mail address for support\n"
-"                          inquiries, enter it here. If you have different\n"
-"                          addresses for each language multiple translations of\n"
-"                          this field can be added. It is only relevant for\n"
-"                          listed add-ons."
+"If you wish to display an e-mail address for support inquiries, enter it here. If you have different addresses for each language multiple translations of this field can be added. It is only "
+"relevant for listed add-ons."
 msgstr ""
 "Īƒ ẏǿŭ ẇīşħ ŧǿ ḓīşƥŀȧẏ ȧƞ ḗ-ḿȧīŀ ȧḓḓřḗşş ƒǿř şŭƥƥǿřŧ\n"
 "                          īƞɋŭīřīḗş, ḗƞŧḗř īŧ ħḗřḗ. Īƒ ẏǿŭ ħȧṽḗ ḓīƒƒḗřḗƞŧ\n"
@@ -4575,10 +4514,8 @@ msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/support.html:45
 msgid ""
-"If your add-on has a support website or forum, enter\n"
-"                          its address here. If your website is localized into\n"
-"                          other languages, multiple translations of this field can\n"
-"                          be added. It is only relevant for listed add-ons."
+"If your add-on has a support website or forum, enter its address here. If your website is localized into other languages, multiple translations of this field can be added. It is only relevant for "
+"listed add-ons."
 msgstr ""
 "Īƒ ẏǿŭř ȧḓḓ-ǿƞ ħȧş ȧ şŭƥƥǿřŧ ẇḗƀşīŧḗ ǿř ƒǿřŭḿ, ḗƞŧḗř\n"
 "                          īŧş ȧḓḓřḗşş ħḗřḗ. Īƒ ẏǿŭř ẇḗƀşīŧḗ īş ŀǿƈȧŀīzḗḓ īƞŧǿ\n"
@@ -4596,11 +4533,8 @@ msgstr "Ŧḗƈħƞīƈȧŀ Ḓḗŧȧīŀş ƒǿř {0}"
 
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:23
 msgid ""
-"Any information end users may want to know that isn't\n"
-"                          necessarily applicable to the add-on summary or description.\n"
-"                          Common uses include listing known major bugs, information on\n"
-"                          how to report bugs, anticipated release date of a new version,\n"
-"                          etc. It is only relevant for listed add-ons."
+"Any information end users may want to know that isn't necessarily applicable to the add-on summary or description. Common uses include listing known major bugs, information on how to report bugs, "
+"anticipated release date of a new version, etc. It is only relevant for listed add-ons."
 msgstr ""
 "Ȧƞẏ īƞƒǿřḿȧŧīǿƞ ḗƞḓ ŭşḗřş ḿȧẏ ẇȧƞŧ ŧǿ ķƞǿẇ ŧħȧŧ īşƞ'ŧ\n"
 "                          ƞḗƈḗşşȧřīŀẏ ȧƥƥŀīƈȧƀŀḗ ŧǿ ŧħḗ ȧḓḓ-ǿƞ şŭḿḿȧřẏ ǿř ḓḗşƈřīƥŧīǿƞ.\n"
@@ -4617,9 +4551,7 @@ msgid "Add-on Flags"
 msgstr "Ȧḓḓ-ǿƞ Ƒŀȧɠş"
 
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:69
-msgid ""
-"These flags are used to classify add-ons. It is only\n"
-"                        relevant for listed add-ons."
+msgid "These flags are used to classify add-ons. It is only relevant for listed add-ons."
 msgstr ""
 "Ŧħḗşḗ ƒŀȧɠş ȧřḗ ŭşḗḓ ŧǿ ƈŀȧşşīƒẏ ȧḓḓ-ǿƞş. Īŧ īş ǿƞŀẏ\n"
 "                        řḗŀḗṽȧƞŧ ƒǿř ŀīşŧḗḓ ȧḓḓ-ǿƞş."
@@ -4637,9 +4569,7 @@ msgid "View Source?"
 msgstr "Ṽīḗẇ Şǿŭřƈḗ?"
 
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:90
-msgid ""
-"Whether the source of your add-on can be displayed in our\n"
-"                        online viewer. It is only relevant for listed add-ons."
+msgid "Whether the source of your add-on can be displayed in our online viewer. It is only relevant for listed add-ons."
 msgstr ""
 "Ẇħḗŧħḗř ŧħḗ şǿŭřƈḗ ǿƒ ẏǿŭř ȧḓḓ-ǿƞ ƈȧƞ ƀḗ ḓīşƥŀȧẏḗḓ īƞ ǿŭř\n"
 "                        ǿƞŀīƞḗ ṽīḗẇḗř. Īŧ īş ǿƞŀẏ řḗŀḗṽȧƞŧ ƒǿř ŀīşŧḗḓ ȧḓḓ-ǿƞş."
@@ -4657,10 +4587,7 @@ msgid "Public Stats?"
 msgstr "Ƥŭƀŀīƈ Şŧȧŧş?"
 
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:102
-msgid ""
-"Whether the download and usage stats of your add-on can\n"
-"                        be displayed in our online viewer.\n"
-"                        It is only relevant for listed add-ons."
+msgid "Whether the download and usage stats of your add-on can be displayed in our online viewer. It is only relevant for listed add-ons."
 msgstr ""
 "Ẇħḗŧħḗř ŧħḗ ḓǿẇƞŀǿȧḓ ȧƞḓ ŭşȧɠḗ şŧȧŧş ǿƒ ẏǿŭř ȧḓḓ-ǿƞ ƈȧƞ\n"
 "                        ƀḗ ḓīşƥŀȧẏḗḓ īƞ ǿŭř ǿƞŀīƞḗ ṽīḗẇḗř.\n"
@@ -4679,10 +4606,7 @@ msgid "Upgrade SDK?"
 msgstr "Ŭƥɠřȧḓḗ ŞḒĶ?"
 
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:116
-msgid ""
-"If selected, we will try to automatically upgrade your\n"
-"                        add-on when a new version of the SDK is released.\n"
-"                        It is only relevant for listed add-ons."
+msgid "If selected, we will try to automatically upgrade your add-on when a new version of the SDK is released. It is only relevant for listed add-ons."
 msgstr ""
 "Īƒ şḗŀḗƈŧḗḓ, ẇḗ ẇīŀŀ ŧřẏ ŧǿ ȧŭŧǿḿȧŧīƈȧŀŀẏ ŭƥɠřȧḓḗ ẏǿŭř\n"
 "                        ȧḓḓ-ǿƞ ẇħḗƞ ȧ ƞḗẇ ṽḗřşīǿƞ ǿƒ ŧħḗ ŞḒĶ īş řḗŀḗȧşḗḓ.\n"
@@ -4738,10 +4662,8 @@ msgstr "Ȧḓḓ-ǿƞ īƈǿƞ"
 
 #: src/olympia/devhub/templates/devhub/addons/forms_shared/media.html:16
 msgid ""
-"Upload an icon for your add-on or choose from one of ours. The\n"
-"                      icon is displayed nearly everywhere your add-on is. Uploaded images\n"
-"                      must be one of the following image types: .png, .jpg.\n"
-"                      It is only relevant for listed add-ons."
+"Upload an icon for your add-on or choose from one of ours. The icon is displayed nearly everywhere your add-on is. Uploaded images must be one of the following image types: .png, .jpg. It is only "
+"relevant for listed add-ons."
 msgstr ""
 "Ŭƥŀǿȧḓ ȧƞ īƈǿƞ ƒǿř ẏǿŭř ȧḓḓ-ǿƞ ǿř ƈħǿǿşḗ ƒřǿḿ ǿƞḗ ǿƒ ǿŭřş. Ŧħḗ\n"
 "                      īƈǿƞ īş ḓīşƥŀȧẏḗḓ ƞḗȧřŀẏ ḗṽḗřẏẇħḗřḗ ẏǿŭř ȧḓḓ-ǿƞ īş. Ŭƥŀǿȧḓḗḓ īḿȧɠḗş\n"
@@ -4758,9 +4680,7 @@ msgid "32x32px"
 msgstr "32ẋ32ƥẋ"
 
 #: src/olympia/devhub/templates/devhub/addons/forms_shared/media.html:39
-msgid ""
-"Used in listings of add-ons, like search results\n"
-"                            and featured add-ons."
+msgid "Used in listings of add-ons, like search results and featured add-ons."
 msgstr ""
 "Ŭşḗḓ īƞ ŀīşŧīƞɠş ǿƒ ȧḓḓ-ǿƞş, ŀīķḗ şḗȧřƈħ řḗşŭŀŧş\n"
 "                            ȧƞḓ ƒḗȧŧŭřḗḓ ȧḓḓ-ǿƞş."
@@ -4857,18 +4777,16 @@ msgid "Deleting your add-on will permanently remove it from the site and prevent
 msgstr "Ḓḗŀḗŧīƞɠ ẏǿŭř ȧḓḓ-ǿƞ ẇīŀŀ ƥḗřḿȧƞḗƞŧŀẏ řḗḿǿṽḗ īŧ ƒřǿḿ ŧħḗ şīŧḗ ȧƞḓ ƥřḗṽḗƞŧ īŧş ƓŬĪḒ ƒřǿḿ ƀḗīƞɠ şŭƀḿīŧŧḗḓ ȧɠȧīƞ ƀẏ ǿŧħḗřş."
 
 #: src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:24
-msgid ""
-"Enter the following text confirm your decision:\n"
-"           {slug}"
+msgid "Enter the following text confirm your decision: {slug}"
 msgstr ""
 "Ḗƞŧḗř ŧħḗ ƒǿŀŀǿẇīƞɠ ŧḗẋŧ ƈǿƞƒīřḿ ẏǿŭř ḓḗƈīşīǿƞ:\n"
 "           {şŀŭɠ}"
 
-#: src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:34
+#: src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:33
 msgid "Please tell us why you are deleting your theme:"
 msgstr "Ƥŀḗȧşḗ ŧḗŀŀ ŭş ẇħẏ ẏǿŭ ȧřḗ ḓḗŀḗŧīƞɠ ẏǿŭř ŧħḗḿḗ:"
 
-#: src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:36
+#: src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:35
 msgid "Please tell us why you are deleting your add-on:"
 msgstr "Ƥŀḗȧşḗ ŧḗŀŀ ŭş ẇħẏ ẏǿŭ ȧřḗ ḓḗŀḗŧīƞɠ ẏǿŭř ȧḓḓ-ǿƞ:"
 
@@ -4905,8 +4823,8 @@ msgstr "Ƞḗẇ Ṽḗřşīǿƞ"
 msgid "Daily statistics on downloads and users."
 msgstr "Ḓȧīŀẏ şŧȧŧīşŧīƈş ǿƞ ḓǿẇƞŀǿȧḓş ȧƞḓ ŭşḗřş."
 
-#: src/olympia/devhub/templates/devhub/addons/listing/item_actions.html:45 src/olympia/stats/templates/stats/stats.html:75 src/olympia/stats/templates/stats/stats.html:79
-#: src/olympia/stats/templates/stats/stats.html:81
+#: src/olympia/devhub/templates/devhub/addons/listing/item_actions.html:45 src/olympia/stats/templates/stats/stats.html:31 src/olympia/stats/templates/stats/stats.html:35
+#: src/olympia/stats/templates/stats/stats.html:37
 msgid "Statistics"
 msgstr "Şŧȧŧīşŧīƈş"
 
@@ -5025,10 +4943,7 @@ msgid "Your add-on has been submitted to the Full Review queue."
 msgstr "Ẏǿŭř ȧḓḓ-ǿƞ ħȧş ƀḗḗƞ şŭƀḿīŧŧḗḓ ŧǿ ŧħḗ Ƒŭŀŀ Řḗṽīḗẇ ɋŭḗŭḗ."
 
 #: src/olympia/devhub/templates/devhub/addons/submit/done.html:18
-msgid ""
-"You'll receive an email once it has been reviewed by an editor. In\n"
-"          the meantime, you and your friends can install it directly from its\n"
-"          details page:"
+msgid "You'll receive an email once it has been reviewed by an editor. In the meantime, you and your friends can install it directly from its details page:"
 msgstr ""
 "Ẏǿŭ'ŀŀ řḗƈḗīṽḗ ȧƞ ḗḿȧīŀ ǿƞƈḗ īŧ ħȧş ƀḗḗƞ řḗṽīḗẇḗḓ ƀẏ ȧƞ ḗḓīŧǿř. Īƞ\n"
 "          ŧħḗ ḿḗȧƞŧīḿḗ, ẏǿŭ ȧƞḓ ẏǿŭř ƒřīḗƞḓş ƈȧƞ īƞşŧȧŀŀ īŧ ḓīřḗƈŧŀẏ ƒřǿḿ īŧş\n"
@@ -5241,11 +5156,11 @@ msgstr "Şŧḗƥ 2. Ŭƥŀǿȧḓ Ẏǿŭř Ȧḓḓ-ǿƞ"
 msgid "Use the fields below to upload your add-on package and select any platform restrictions. After upload, a series of automated validation tests will be run on your file."
 msgstr "Ŭşḗ ŧħḗ ƒīḗŀḓş ƀḗŀǿẇ ŧǿ ŭƥŀǿȧḓ ẏǿŭř ȧḓḓ-ǿƞ ƥȧƈķȧɠḗ ȧƞḓ şḗŀḗƈŧ ȧƞẏ ƥŀȧŧƒǿřḿ řḗşŧřīƈŧīǿƞş. Ȧƒŧḗř ŭƥŀǿȧḓ, ȧ şḗřīḗş ǿƒ ȧŭŧǿḿȧŧḗḓ ṽȧŀīḓȧŧīǿƞ ŧḗşŧş ẇīŀŀ ƀḗ řŭƞ ǿƞ ẏǿŭř ƒīŀḗ."
 
-#: src/olympia/devhub/templates/devhub/addons/submit/upload.html:59 src/olympia/devhub/templates/devhub/versions/add_file_modal.html:39
+#: src/olympia/devhub/templates/devhub/addons/submit/upload.html:51 src/olympia/devhub/templates/devhub/versions/add_file_modal.html:28
 msgid "Which platforms is this file compatible with?"
 msgstr "Ẇħīƈħ ƥŀȧŧƒǿřḿş īş ŧħīş ƒīŀḗ ƈǿḿƥȧŧīƀŀḗ ẇīŧħ?"
 
-#: src/olympia/devhub/templates/devhub/addons/submit/upload.html:67 src/olympia/devhub/templates/devhub/versions/add_file_modal.html:65
+#: src/olympia/devhub/templates/devhub/addons/submit/upload.html:59 src/olympia/devhub/templates/devhub/versions/add_file_modal.html:45
 msgid "Administrative overrides"
 msgstr "Ȧḓḿīƞīşŧřȧŧīṽḗ ǿṽḗřřīḓḗş"
 
@@ -5364,11 +5279,9 @@ msgstr "Ẇḗƀşīŧḗ Ƒŭƞƈŧīǿƞȧŀīŧẏ & Ḓḗṽḗŀǿƥḿḗ
 
 #: src/olympia/devhub/templates/devhub/docs/policies-contact.html:44
 msgid ""
-"If you've found a problem with the site, we'd love to fix it. Please <a href=\"https://github.com/mozilla/olympia/issues\">file a bug report</a> in GitHub, including the location of the problem and "
-"how you encountered it."
+"If you've found a problem with the site, we'd love to fix it. Please <a href=\"https://github.com/mozilla/addons/issues/new\">file a bug report</a> in GitHub, including the location of the problem "
+"and how you encountered it."
 msgstr ""
-"Īƒ ẏǿŭ'ṽḗ ƒǿŭƞḓ ȧ ƥřǿƀŀḗḿ ẇīŧħ ŧħḗ şīŧḗ, ẇḗ'ḓ ŀǿṽḗ ŧǿ ƒīẋ īŧ. Ƥŀḗȧşḗ <a href=\"https://github.com/mozilla/olympia/issues\">ƒīŀḗ ȧ ƀŭɠ řḗƥǿřŧ</a> īƞ ƓīŧĦŭƀ, īƞƈŀŭḓīƞɠ ŧħḗ ŀǿƈȧŧīǿƞ ǿƒ ŧħḗ ƥřǿƀŀḗḿ ȧƞḓ "
-"ħǿẇ ẏǿŭ ḗƞƈǿŭƞŧḗřḗḓ īŧ."
 
 #: src/olympia/devhub/templates/devhub/docs/policies-maintenance.html:3 src/olympia/devhub/templates/devhub/docs/policies-maintenance.html:7
 #: src/olympia/devhub/templates/devhub/docs/policies-maintenance.html:8
@@ -6021,7 +5934,7 @@ msgstr "Ƥřīṽȧŧḗ Ɓřǿẇşīƞɠ Ḿǿḓḗ"
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:282
 msgid ""
-"Add-ons that store or otherwise handle browsing data must support <a href=\"https://developer.mozilla.org/En/Supporting_private_browsing_mode\">Private Browsing Mode</a>.  During a Private Browsing "
+"Add-ons that store or otherwise handle browsing data must support <a href=\"https://developer.mozilla.org/En/Supporting_private_browsing_mode\">Private Browsing Mode</a>. During a Private Browsing "
 "session, no browsing data can be written to disk, and all of this data must be cleared when Firefox quits or the Private Browsing session ends."
 msgstr ""
 "Ȧḓḓ-ǿƞş ŧħȧŧ şŧǿřḗ ǿř ǿŧħḗřẇīşḗ ħȧƞḓŀḗ ƀřǿẇşīƞɠ ḓȧŧȧ ḿŭşŧ şŭƥƥǿřŧ <a href=\"https://developer.mozilla.org/En/Supporting_private_browsing_mode\">Ƥřīṽȧŧḗ Ɓřǿẇşīƞɠ Ḿǿḓḗ</a>.  Ḓŭřīƞɠ ȧ Ƥřīṽȧŧḗ Ɓřǿẇşīƞɠ "
@@ -6232,165 +6145,128 @@ msgstr "Ŧḗřḿş ǿƒ Şḗřṽīƈḗ ƒǿř şŭƀḿīŧŧīƞɠ ẏǿŭ
 msgid "How to get in touch with us regarding these policies or your add-on."
 msgstr "Ħǿẇ ŧǿ ɠḗŧ īƞ ŧǿŭƈħ ẇīŧħ ŭş řḗɠȧřḓīƞɠ ŧħḗşḗ ƥǿŀīƈīḗş ǿř ẏǿŭř ȧḓḓ-ǿƞ."
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:6
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:10
 msgid "You have disabled this add-on"
 msgstr "Ẏǿŭ ħȧṽḗ ḓīşȧƀŀḗḓ ŧħīş ȧḓḓ-ǿƞ"
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:20
-msgid ""
-"Your add-on's listing is disabled and is not showing\n"
-"                             anywhere in our gallery or update service."
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:24
+msgid "Your add-on's listing is disabled and is not showing anywhere in our gallery or update service."
 msgstr ""
 "Ẏǿŭř ȧḓḓ-ǿƞ'ş ŀīşŧīƞɠ īş ḓīşȧƀŀḗḓ ȧƞḓ īş ƞǿŧ şħǿẇīƞɠ\n"
 "                             ȧƞẏẇħḗřḗ īƞ ǿŭř ɠȧŀŀḗřẏ ǿř ŭƥḓȧŧḗ şḗřṽīƈḗ."
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:25
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:27
 msgid "Please complete your add-on."
 msgstr "Ƥŀḗȧşḗ ƈǿḿƥŀḗŧḗ ẏǿŭř ȧḓḓ-ǿƞ."
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:29
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:30
 msgid "You will receive an email when the review is complete."
 msgstr "Ẏǿŭ ẇīŀŀ řḗƈḗīṽḗ ȧƞ ḗḿȧīŀ ẇħḗƞ ŧħḗ řḗṽīḗẇ īş ƈǿḿƥŀḗŧḗ."
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:34
-msgid ""
-"You will receive an email when the review is complete. Until\n"
-"                             then, your add-on is not listed in our gallery but can be\n"
-"                             accessed directly from its details page."
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:33
+msgid "You will receive an email when the review is complete. Until then, your add-on is not listed in our gallery but can be accessed directly from its details page."
 msgstr ""
 "Ẏǿŭ ẇīŀŀ řḗƈḗīṽḗ ȧƞ ḗḿȧīŀ ẇħḗƞ ŧħḗ řḗṽīḗẇ īş ƈǿḿƥŀḗŧḗ. Ŭƞŧīŀ\n"
 "                             ŧħḗƞ, ẏǿŭř ȧḓḓ-ǿƞ īş ƞǿŧ ŀīşŧḗḓ īƞ ǿŭř ɠȧŀŀḗřẏ ƀŭŧ ƈȧƞ ƀḗ\n"
 "                             ȧƈƈḗşşḗḓ ḓīřḗƈŧŀẏ ƒřǿḿ īŧş ḓḗŧȧīŀş ƥȧɠḗ."
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:38 src/olympia/devhub/templates/devhub/includes/addon_details.html:48
-msgid ""
-"You will receive an email when the review is\n"
-"                             complete and your add-on is signed."
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:37 src/olympia/devhub/templates/devhub/includes/addon_details.html:45
+msgid "You will receive an email when the review is complete and your add-on is signed."
 msgstr ""
 "Ẏǿŭ ẇīŀŀ řḗƈḗīṽḗ ȧƞ ḗḿȧīŀ ẇħḗƞ ŧħḗ řḗṽīḗẇ īş\n"
 "                             ƈǿḿƥŀḗŧḗ ȧƞḓ ẏǿŭř ȧḓḓ-ǿƞ īş şīɠƞḗḓ."
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:44
-msgid ""
-"You will receive an email when the review is complete. Until\n"
-"                             then, your add-on is not listed in our gallery but can be\n"
-"                             accessed directly from its details page. "
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:41
+msgid "You will receive an email when the review is complete. Until then, your add-on is not listed in our gallery but can be accessed directly from its details page. "
 msgstr ""
-"Ẏǿŭ ẇīŀŀ řḗƈḗīṽḗ ȧƞ ḗḿȧīŀ ẇħḗƞ ŧħḗ řḗṽīḗẇ īş ƈǿḿƥŀḗŧḗ. Ŭƞŧīŀ\n"
-"                             ŧħḗƞ, ẏǿŭř ȧḓḓ-ǿƞ īş ƞǿŧ ŀīşŧḗḓ īƞ ǿŭř ɠȧŀŀḗřẏ ƀŭŧ ƈȧƞ ƀḗ\n"
-"                             ȧƈƈḗşşḗḓ ḓīřḗƈŧŀẏ ƒřǿḿ īŧş ḓḗŧȧīŀş ƥȧɠḗ. "
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:54
-msgid ""
-"Your add-on is displayed in our gallery and users are\n"
-"                             receiving automatic updates."
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:49
+msgid "Your add-on is displayed in our gallery and users are receiving automatic updates."
 msgstr ""
 "Ẏǿŭř ȧḓḓ-ǿƞ īş ḓīşƥŀȧẏḗḓ īƞ ǿŭř ɠȧŀŀḗřẏ ȧƞḓ ŭşḗřş ȧřḗ\n"
 "                             řḗƈḗīṽīƞɠ ȧŭŧǿḿȧŧīƈ ŭƥḓȧŧḗş."
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:57
-msgid ""
-"Your add-on has been signed and can be bundled with an\n"
-"                             application installer."
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:52
+msgid "Your add-on has been signed and can be bundled with an application installer."
 msgstr ""
 "Ẏǿŭř ȧḓḓ-ǿƞ ħȧş ƀḗḗƞ şīɠƞḗḓ ȧƞḓ ƈȧƞ ƀḗ ƀŭƞḓŀḗḓ ẇīŧħ ȧƞ\n"
 "                             ȧƥƥŀīƈȧŧīǿƞ īƞşŧȧŀŀḗř."
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:63
-msgid ""
-"Your add-on was disabled by a site administrator and is no\n"
-"                             longer shown in our gallery. If you have any questions,\n"
-"                             please email amo-admins@mozilla.org."
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:56
+msgid "Your add-on was disabled by a site administrator and is no longer shown in our gallery. If you have any questions, please email amo-admins@mozilla.org."
 msgstr ""
 "Ẏǿŭř ȧḓḓ-ǿƞ ẇȧş ḓīşȧƀŀḗḓ ƀẏ ȧ şīŧḗ ȧḓḿīƞīşŧřȧŧǿř ȧƞḓ īş ƞǿ\n"
 "                             ŀǿƞɠḗř şħǿẇƞ īƞ ǿŭř ɠȧŀŀḗřẏ. Īƒ ẏǿŭ ħȧṽḗ ȧƞẏ ɋŭḗşŧīǿƞş,\n"
 "                             ƥŀḗȧşḗ ḗḿȧīŀ amo-admins@mozilla.org."
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:70
-msgid ""
-"Your add-on is displayed in our gallery as experimental\n"
-"                             and users are receiving automatic updates. Some features\n"
-"                             are unavailable to your add-on."
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:62
+msgid "Your add-on is displayed in our gallery as experimental and users are receiving automatic updates. Some features are unavailable to your add-on."
 msgstr ""
 "Ẏǿŭř ȧḓḓ-ǿƞ īş ḓīşƥŀȧẏḗḓ īƞ ǿŭř ɠȧŀŀḗřẏ ȧş ḗẋƥḗřīḿḗƞŧȧŀ\n"
 "                             ȧƞḓ ŭşḗřş ȧřḗ řḗƈḗīṽīƞɠ ȧŭŧǿḿȧŧīƈ ŭƥḓȧŧḗş. Şǿḿḗ ƒḗȧŧŭřḗş\n"
 "                             ȧřḗ ŭƞȧṽȧīŀȧƀŀḗ ŧǿ ẏǿŭř ȧḓḓ-ǿƞ."
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:74
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:66
 msgid "Your add-on has been signed."
 msgstr "Ẏǿŭř ȧḓḓ-ǿƞ ħȧş ƀḗḗƞ şīɠƞḗḓ."
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:79
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:69
 msgid ""
-"You will receive an email when the full review is complete.\n"
-"                             Until then, your add-on is displayed in our gallery as\n"
-"                             experimental and users are receiving automatic updates.\n"
-"                             Some features are unavailable to your add-on."
+"You will receive an email when the full review is complete. Until then, your add-on is displayed in our gallery as experimental and users are receiving automatic updates. Some features are "
+"unavailable to your add-on."
 msgstr ""
 "Ẏǿŭ ẇīŀŀ řḗƈḗīṽḗ ȧƞ ḗḿȧīŀ ẇħḗƞ ŧħḗ ƒŭŀŀ řḗṽīḗẇ īş ƈǿḿƥŀḗŧḗ.\n"
 "                             Ŭƞŧīŀ ŧħḗƞ, ẏǿŭř ȧḓḓ-ǿƞ īş ḓīşƥŀȧẏḗḓ īƞ ǿŭř ɠȧŀŀḗřẏ ȧş\n"
 "                             ḗẋƥḗřīḿḗƞŧȧŀ ȧƞḓ ŭşḗřş ȧřḗ řḗƈḗīṽīƞɠ ȧŭŧǿḿȧŧīƈ ŭƥḓȧŧḗş.\n"
 "                             Şǿḿḗ ƒḗȧŧŭřḗş ȧřḗ ŭƞȧṽȧīŀȧƀŀḗ ŧǿ ẏǿŭř ȧḓḓ-ǿƞ."
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:84
-msgid ""
-"You will receive an email when the full review is\n"
-"                             complete, making you able to bundle your add-on with an\n"
-"                             application installer."
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:74
+msgid "You will receive an email when the full review is complete, making you able to bundle your add-on with an application installer."
 msgstr ""
 "Ẏǿŭ ẇīŀŀ řḗƈḗīṽḗ ȧƞ ḗḿȧīŀ ẇħḗƞ ŧħḗ ƒŭŀŀ řḗṽīḗẇ īş\n"
 "                             ƈǿḿƥŀḗŧḗ, ḿȧķīƞɠ ẏǿŭ ȧƀŀḗ ŧǿ ƀŭƞḓŀḗ ẏǿŭř ȧḓḓ-ǿƞ ẇīŧħ ȧƞ\n"
 "                             ȧƥƥŀīƈȧŧīǿƞ īƞşŧȧŀŀḗř."
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:91
-msgid ""
-"All add-ons hosted in our gallery must now be reviewed by an\n"
-"                             editor. If you wish to continue hosting your add-on, please\n"
-"                             click to select a review process."
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:79
+msgid "All add-ons hosted in our gallery must now be reviewed by an editor. If you wish to continue hosting your add-on, please click to select a review process."
 msgstr ""
 "Ȧŀŀ ȧḓḓ-ǿƞş ħǿşŧḗḓ īƞ ǿŭř ɠȧŀŀḗřẏ ḿŭşŧ ƞǿẇ ƀḗ řḗṽīḗẇḗḓ ƀẏ ȧƞ\n"
 "                             ḗḓīŧǿř. Īƒ ẏǿŭ ẇīşħ ŧǿ ƈǿƞŧīƞŭḗ ħǿşŧīƞɠ ẏǿŭř ȧḓḓ-ǿƞ, ƥŀḗȧşḗ\n"
 "                             ƈŀīƈķ ŧǿ şḗŀḗƈŧ ȧ řḗṽīḗẇ ƥřǿƈḗşş."
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:113
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:100
 msgid "Current Version:"
 msgstr "Ƈŭřřḗƞŧ Ṽḗřşīǿƞ:"
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:115
-msgid ""
-"This is the version of your add-on that will\n"
-"                                           be installed if someone clicks the Install\n"
-"                                           button on addons.mozilla.org. It is only\n"
-"                                           relevant for listed add-ons."
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:102
+msgid "This is the version of your add-on that will be installed if someone clicks the Install button on addons.mozilla.org. It is only relevant for listed add-ons."
 msgstr ""
 "Ŧħīş īş ŧħḗ ṽḗřşīǿƞ ǿƒ ẏǿŭř ȧḓḓ-ǿƞ ŧħȧŧ ẇīŀŀ\n"
 "                                           ƀḗ īƞşŧȧŀŀḗḓ īƒ şǿḿḗǿƞḗ ƈŀīƈķş ŧħḗ Īƞşŧȧŀŀ\n"
 "                                           ƀŭŧŧǿƞ ǿƞ ȧḓḓǿƞş.ḿǿzīŀŀȧ.ǿřɠ. Īŧ īş ǿƞŀẏ\n"
 "                                           řḗŀḗṽȧƞŧ ƒǿř ŀīşŧḗḓ ȧḓḓ-ǿƞş."
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:123
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:110
 msgid "Created:"
 msgstr "Ƈřḗȧŧḗḓ:"
 
 #. {0} is a date. dennis-ignore: E201
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:125 src/olympia/devhub/templates/devhub/includes/addon_details.html:131
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:112 src/olympia/devhub/templates/devhub/includes/addon_details.html:118
 #, python-format
 msgid "%%b %%e, %%Y"
 msgstr "%%ƀ %%ḗ, %%Ẏ"
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:136
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:123
 msgid "Next Version:"
 msgstr "Ƞḗẋŧ Ṽḗřşīǿƞ:"
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:138
-msgid ""
-"This is the newest uploaded version, however\n"
-"                                           it isn’t live on the site yet."
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:125
+msgid "This is the newest uploaded version, however it isn’t live on the site yet."
 msgstr ""
 "Ŧħīş īş ŧħḗ ƞḗẇḗşŧ ŭƥŀǿȧḓḗḓ ṽḗřşīǿƞ, ħǿẇḗṽḗř\n"
 "                                           īŧ īşƞ’ŧ ŀīṽḗ ǿƞ ŧħḗ şīŧḗ ẏḗŧ."
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:144 src/olympia/devhub/templates/devhub/versions/list.html:30
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:130 src/olympia/devhub/templates/devhub/versions/list.html:30
 msgid "Queues are not reviewed strictly in order"
 msgstr "Ɋŭḗŭḗş ȧřḗ ƞǿŧ řḗṽīḗẇḗḓ şŧřīƈŧŀẏ īƞ ǿřḓḗř"
 
@@ -6460,9 +6336,7 @@ msgid "View the blog &#9658;"
 msgstr "Ṽīḗẇ ŧħḗ ƀŀǿɠ &#9658;"
 
 #: src/olympia/devhub/templates/devhub/includes/license_form.html:6
-msgid ""
-"Please choose a license appropriate for the rights you grant on your source code.\n"
-"                  It is only relevant for listed add-ons."
+msgid "Please choose a license appropriate for the rights you grant on your source code. It is only relevant for listed add-ons."
 msgstr ""
 "Ƥŀḗȧşḗ ƈħǿǿşḗ ȧ ŀīƈḗƞşḗ ȧƥƥřǿƥřīȧŧḗ ƒǿř ŧħḗ řīɠħŧş ẏǿŭ ɠřȧƞŧ ǿƞ ẏǿŭř şǿŭřƈḗ ƈǿḓḗ.\n"
 "                  Īŧ īş ǿƞŀẏ řḗŀḗṽȧƞŧ ƒǿř ŀīşŧḗḓ ȧḓḓ-ǿƞş."
@@ -6491,17 +6365,11 @@ msgstr[1] "Şḗŀḗƈŧ <b>ŭƥ ŧǿ {0}</b> {1} ƈȧŧḗɠǿřīḗş ƒǿř
 #: src/olympia/devhub/templates/devhub/includes/policy_form.html:4
 msgid ""
 "Users will be required to accept the following End-User License Agreement (EULA) prior to installing your add-on. The presence of a EULA significantly affects the number of downloads an add-on "
-"receives. Please note that a EULA is not the same as a code license, such as the GPL or MPL.\n"
-"                It is only relevant for listed add-ons."
+"receives. Please note that a EULA is not the same as a code license, such as the GPL or MPL.It is only relevant for listed add-ons."
 msgstr ""
-"Ŭşḗřş ẇīŀŀ ƀḗ řḗɋŭīřḗḓ ŧǿ ȧƈƈḗƥŧ ŧħḗ ƒǿŀŀǿẇīƞɠ Ḗƞḓ-Ŭşḗř Ŀīƈḗƞşḗ Ȧɠřḗḗḿḗƞŧ (ḖŬĿȦ) ƥřīǿř ŧǿ īƞşŧȧŀŀīƞɠ ẏǿŭř ȧḓḓ-ǿƞ. Ŧħḗ ƥřḗşḗƞƈḗ ǿƒ ȧ ḖŬĿȦ şīɠƞīƒīƈȧƞŧŀẏ ȧƒƒḗƈŧş ŧħḗ ƞŭḿƀḗř ǿƒ ḓǿẇƞŀǿȧḓş ȧƞ ȧḓḓ-ǿƞ "
-"řḗƈḗīṽḗş. Ƥŀḗȧşḗ ƞǿŧḗ ŧħȧŧ ȧ ḖŬĿȦ īş ƞǿŧ ŧħḗ şȧḿḗ ȧş ȧ ƈǿḓḗ ŀīƈḗƞşḗ, şŭƈħ ȧş ŧħḗ ƓƤĿ ǿř ḾƤĿ.\n"
-"                Īŧ īş ǿƞŀẏ řḗŀḗṽȧƞŧ ƒǿř ŀīşŧḗḓ ȧḓḓ-ǿƞş."
 
-#: src/olympia/devhub/templates/devhub/includes/policy_form.html:21
-msgid ""
-"If your add-on transmits any data from the user's computer, a privacy policy is required that explains what data is sent and how it is used.\n"
-"                It is only relevant for listed add-ons."
+#: src/olympia/devhub/templates/devhub/includes/policy_form.html:24
+msgid "If your add-on transmits any data from the user's computer, a privacy policy is required that explains what data is sent and how it is used. It is only relevant for listed add-ons."
 msgstr ""
 "Īƒ ẏǿŭř ȧḓḓ-ǿƞ ŧřȧƞşḿīŧş ȧƞẏ ḓȧŧȧ ƒřǿḿ ŧħḗ ŭşḗř'ş ƈǿḿƥŭŧḗř, ȧ ƥřīṽȧƈẏ ƥǿŀīƈẏ īş řḗɋŭīřḗḓ ŧħȧŧ ḗẋƥŀȧīƞş ẇħȧŧ ḓȧŧȧ īş şḗƞŧ ȧƞḓ ħǿẇ īŧ īş ŭşḗḓ.\n"
 "                Īŧ īş ǿƞŀẏ řḗŀḗṽȧƞŧ ƒǿř ŀīşŧḗḓ ȧḓḓ-ǿƞş."
@@ -6673,12 +6541,8 @@ msgstr "Şḗŀḗƈŧ ŧħḗ ƈȧŧḗɠǿřẏ ŧħȧŧ ƀḗşŧ ḓḗşƈ�
 msgid "Add some tags to describe your Theme."
 msgstr "Ȧḓḓ şǿḿḗ ŧȧɠş ŧǿ ḓḗşƈřīƀḗ ẏǿŭř Ŧħḗḿḗ."
 
-#: src/olympia/devhub/templates/devhub/personas/edit.html:106
-msgid ""
-"A short explanation of your theme's\n"
-"                                basic functionality that is displayed in\n"
-"                                search and browse listings, as well as at\n"
-"                                the top of your theme's details page."
+#: src/olympia/devhub/templates/devhub/personas/edit.html:106 src/olympia/devhub/templates/devhub/personas/submit.html:54
+msgid "A short explanation of your theme's basic functionality that is displayed in search and browse listings, as well as at the top of your theme's details page."
 msgstr ""
 "Ȧ şħǿřŧ ḗẋƥŀȧƞȧŧīǿƞ ǿƒ ẏǿŭř ŧħḗḿḗ'ş\n"
 "                                ƀȧşīƈ ƒŭƞƈŧīǿƞȧŀīŧẏ ŧħȧŧ īş ḓīşƥŀȧẏḗḓ īƞ\n"
@@ -6752,7 +6616,7 @@ msgid "Upon upload and form submission, the AMO Team will review your updated de
 msgstr "Ŭƥǿƞ ŭƥŀǿȧḓ ȧƞḓ ƒǿřḿ şŭƀḿīşşīǿƞ, ŧħḗ ȦḾǾ Ŧḗȧḿ ẇīŀŀ řḗṽīḗẇ ẏǿŭř ŭƥḓȧŧḗḓ ḓḗşīɠƞ. Ẏǿŭř ƈŭřřḗƞŧ ḓḗşīɠƞ ẇīŀŀ şŧīŀŀ ƀḗ ƥŭƀŀīƈ īƞ ŧħḗ ḿḗȧƞŧīḿḗ."
 
 #: src/olympia/devhub/templates/devhub/personas/edit.html:241
-msgid "Your previously resubmitted design,  which is under pending review."
+msgid "Your previously resubmitted design, which is under pending review."
 msgstr "Ẏǿŭř ƥřḗṽīǿŭşŀẏ řḗşŭƀḿīŧŧḗḓ ḓḗşīɠƞ,  ẇħīƈħ īş ŭƞḓḗř ƥḗƞḓīƞɠ řḗṽīḗẇ."
 
 #: src/olympia/devhub/templates/devhub/personas/edit.html:245
@@ -6820,18 +6684,6 @@ msgstr "Ɓȧƈķɠřǿŭƞḓ ŧħḗḿḗş ŀḗŧ ẏǿŭ ḗȧşīŀẏ ƥ�
 #: src/olympia/devhub/templates/devhub/personas/submit.html:33
 msgid "Give your Theme a name."
 msgstr "Ɠīṽḗ ẏǿŭř Ŧħḗḿḗ ȧ ƞȧḿḗ."
-
-#: src/olympia/devhub/templates/devhub/personas/submit.html:54
-msgid ""
-"A short explanation of your theme's\n"
-"                                      basic functionality that is displayed in\n"
-"                                      search and browse listings, as well as at\n"
-"                                      the top of your theme's details page."
-msgstr ""
-"Ȧ şħǿřŧ ḗẋƥŀȧƞȧŧīǿƞ ǿƒ ẏǿŭř ŧħḗḿḗ'ş\n"
-"                                      ƀȧşīƈ ƒŭƞƈŧīǿƞȧŀīŧẏ ŧħȧŧ īş ḓīşƥŀȧẏḗḓ īƞ\n"
-"                                      şḗȧřƈħ ȧƞḓ ƀřǿẇşḗ ŀīşŧīƞɠş, ȧş ẇḗŀŀ ȧş ȧŧ\n"
-"                                      ŧħḗ ŧǿƥ ǿƒ ẏǿŭř ŧħḗḿḗ'ş ḓḗŧȧīŀş ƥȧɠḗ."
 
 #: src/olympia/devhub/templates/devhub/personas/submit.html:198
 #, python-format
@@ -6909,35 +6761,17 @@ msgstr "Şḗŀḗƈŧ ȧ ḓīƒƒḗřḗƞŧ ƒǿǿŧḗř īḿȧɠḗ"
 msgid "Files added to reviewed versions must be reviewed before they will be available for download."
 msgstr "Ƒīŀḗş ȧḓḓḗḓ ŧǿ řḗṽīḗẇḗḓ ṽḗřşīǿƞş ḿŭşŧ ƀḗ řḗṽīḗẇḗḓ ƀḗƒǿřḗ ŧħḗẏ ẇīŀŀ ƀḗ ȧṽȧīŀȧƀŀḗ ƒǿř ḓǿẇƞŀǿȧḓ."
 
-#: src/olympia/devhub/templates/devhub/versions/add_file_modal.html:15
-#, python-format
-msgid ""
-"Submission of updates to unlisted add-ons for signing is currently in an open beta. Manual review may still be required for a large number of add-ons. Please <a href=\"%(url)s\" target=\"_blank"
-"\">report any bugs</a> that you encounter."
-msgstr ""
-"Şŭƀḿīşşīǿƞ ǿƒ ŭƥḓȧŧḗş ŧǿ ŭƞŀīşŧḗḓ ȧḓḓ-ǿƞş ƒǿř şīɠƞīƞɠ īş ƈŭřřḗƞŧŀẏ īƞ ȧƞ ǿƥḗƞ ƀḗŧȧ. Ḿȧƞŭȧŀ řḗṽīḗẇ ḿȧẏ şŧīŀŀ ƀḗ řḗɋŭīřḗḓ ƒǿř ȧ ŀȧřɠḗ ƞŭḿƀḗř ǿƒ ȧḓḓ-ǿƞş. Ƥŀḗȧşḗ <a href=\"%(url)s\" target=\"_blank"
-"\">řḗƥǿřŧ ȧƞẏ ƀŭɠş</a> ŧħȧŧ ẏǿŭ ḗƞƈǿŭƞŧḗř."
-
-#: src/olympia/devhub/templates/devhub/versions/add_file_modal.html:35
+#: src/olympia/devhub/templates/devhub/versions/add_file_modal.html:24
 msgid "Select the target platform for this file."
 msgstr "Şḗŀḗƈŧ ŧħḗ ŧȧřɠḗŧ ƥŀȧŧƒǿřḿ ƒǿř ŧħīş ƒīŀḗ."
 
-#: src/olympia/devhub/templates/devhub/versions/add_file_modal.html:46
+#: src/olympia/devhub/templates/devhub/versions/add_file_modal.html:35
 msgid "Which review type would you like to nominate for?"
 msgstr "Ẇħīƈħ řḗṽīḗẇ ŧẏƥḗ ẇǿŭŀḓ ẏǿŭ ŀīķḗ ŧǿ ƞǿḿīƞȧŧḗ ƒǿř?"
 
-#: src/olympia/devhub/templates/devhub/versions/add_file_modal.html:51
+#: src/olympia/devhub/templates/devhub/versions/add_file_modal.html:40
 msgid "Only publish this version to my beta channel."
 msgstr "Ǿƞŀẏ ƥŭƀŀīşħ ŧħīş ṽḗřşīǿƞ ŧǿ ḿẏ ƀḗŧȧ ƈħȧƞƞḗŀ."
-
-#: src/olympia/devhub/templates/devhub/versions/add_file_modal.html:54
-#, python-format
-msgid ""
-"The behavior of the beta channel has changed to accommodate <a href=\"%(addon_signing_url)s\" target=\"_blank\">mandatory add-on signing</a>. The new process is currently in an open beta, and may "
-"change significantly in the near future. Please <a href=\"%(issues_url)s\" target=\"_blank\">report any bugs</a> that you encounter."
-msgstr ""
-"Ŧħḗ ƀḗħȧṽīǿř ǿƒ ŧħḗ ƀḗŧȧ ƈħȧƞƞḗŀ ħȧş ƈħȧƞɠḗḓ ŧǿ ȧƈƈǿḿḿǿḓȧŧḗ <a href=\"%(addon_signing_url)s\" target=\"_blank\">ḿȧƞḓȧŧǿřẏ ȧḓḓ-ǿƞ şīɠƞīƞɠ</a>. Ŧħḗ ƞḗẇ ƥřǿƈḗşş īş ƈŭřřḗƞŧŀẏ īƞ ȧƞ ǿƥḗƞ ƀḗŧȧ, ȧƞḓ ḿȧẏ "
-"ƈħȧƞɠḗ şīɠƞīƒīƈȧƞŧŀẏ īƞ ŧħḗ ƞḗȧř ƒŭŧŭřḗ. Ƥŀḗȧşḗ <a href=\"%(issues_url)s\" target=\"_blank\">řḗƥǿřŧ ȧƞẏ ƀŭɠş</a> ŧħȧŧ ẏǿŭ ḗƞƈǿŭƞŧḗř."
 
 #: src/olympia/devhub/templates/devhub/versions/edit.html:5
 msgid "Manage Version {0}"
@@ -6960,22 +6794,10 @@ msgstr "Ƒīŀḗş"
 msgid "Upload Another File"
 msgstr "Ŭƥŀǿȧḓ Ȧƞǿŧħḗř Ƒīŀḗ"
 
-#: src/olympia/devhub/templates/devhub/versions/edit.html:45
-msgid ""
-"Adjusting application information here will allow users to install your\n"
-"                          add-on even if the install manifest in the package indicates that the\n"
-"                          add-on is incompatible."
-msgstr ""
-"Ȧḓĵŭşŧīƞɠ ȧƥƥŀīƈȧŧīǿƞ īƞƒǿřḿȧŧīǿƞ ħḗřḗ ẇīŀŀ ȧŀŀǿẇ ŭşḗřş ŧǿ īƞşŧȧŀŀ ẏǿŭř\n"
-"                          ȧḓḓ-ǿƞ ḗṽḗƞ īƒ ŧħḗ īƞşŧȧŀŀ ḿȧƞīƒḗşŧ īƞ ŧħḗ ƥȧƈķȧɠḗ īƞḓīƈȧŧḗş ŧħȧŧ ŧħḗ\n"
-"                          ȧḓḓ-ǿƞ īş īƞƈǿḿƥȧŧīƀŀḗ."
-
 #: src/olympia/devhub/templates/devhub/versions/edit.html:74
 msgid ""
-"Information about changes in this release, new features,\n"
-"                              known bugs, and other useful information specific to this\n"
-"                              release/version. This information is also shown in the\n"
-"                              Add-ons Manager when updating."
+"Information about changes in this release, new features, known bugs, and other useful information specific to this release/version. This information is also shown in the Add-ons Manager when "
+"updating."
 msgstr ""
 "Īƞƒǿřḿȧŧīǿƞ ȧƀǿŭŧ ƈħȧƞɠḗş īƞ ŧħīş řḗŀḗȧşḗ, ƞḗẇ ƒḗȧŧŭřḗş,\n"
 "                              ķƞǿẇƞ ƀŭɠş, ȧƞḓ ǿŧħḗř ŭşḗƒŭŀ īƞƒǿřḿȧŧīǿƞ şƥḗƈīƒīƈ ŧǿ ŧħīş\n"
@@ -6991,10 +6813,7 @@ msgid "Notes for Reviewers"
 msgstr "Ƞǿŧḗş ƒǿř Řḗṽīḗẇḗřş"
 
 #: src/olympia/devhub/templates/devhub/versions/edit.html:114
-msgid ""
-"Optionally, enter any information that may be useful\n"
-"                              to the Editor reviewing this add-on, such as test\n"
-"                              account information."
+msgid "Optionally, enter any information that may be useful to the Editor reviewing this add-on, such as test account information."
 msgstr ""
 "Ǿƥŧīǿƞȧŀŀẏ, ḗƞŧḗř ȧƞẏ īƞƒǿřḿȧŧīǿƞ ŧħȧŧ ḿȧẏ ƀḗ ŭşḗƒŭŀ\n"
 "                              ŧǿ ŧħḗ Ḗḓīŧǿř řḗṽīḗẇīƞɠ ŧħīş ȧḓḓ-ǿƞ, şŭƈħ ȧş ŧḗşŧ\n"
@@ -7075,7 +6894,7 @@ msgstr "Řḗɋŭḗşŧ Ƒŭŀŀ Řḗṽīḗẇ"
 msgid "Request Preliminary Review"
 msgstr "Řḗɋŭḗşŧ Ƥřḗŀīḿīƞȧřẏ Řḗṽīḗẇ"
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:80 src/olympia/devhub/templates/devhub/versions/list.html:327 src/olympia/devhub/templates/devhub/versions/list.html:350
+#: src/olympia/devhub/templates/devhub/versions/list.html:80 src/olympia/devhub/templates/devhub/versions/list.html:325 src/olympia/devhub/templates/devhub/versions/list.html:348
 msgid "Cancel Review Request"
 msgstr "Ƈȧƞƈḗŀ Řḗṽīḗẇ Řḗɋŭḗşŧ"
 
@@ -7104,8 +6923,8 @@ msgid "Unlisted:"
 msgstr "Ŭƞŀīşŧḗḓ:"
 
 #: src/olympia/devhub/templates/devhub/versions/list.html:114
-msgid "Not distributed on {0}. Developers will upload new versions for signing and distribute the add-ons on their own. (beta)"
-msgstr "Ƞǿŧ ḓīşŧřīƀŭŧḗḓ ǿƞ {0}. Ḓḗṽḗŀǿƥḗřş ẇīŀŀ ŭƥŀǿȧḓ ƞḗẇ ṽḗřşīǿƞş ƒǿř şīɠƞīƞɠ ȧƞḓ ḓīşŧřīƀŭŧḗ ŧħḗ ȧḓḓ-ǿƞş ǿƞ ŧħḗīř ǿẇƞ. (ƀḗŧȧ)"
+msgid "Not distributed on {0}. Developers will upload new versions for signing and distribute the add-ons on their own."
+msgstr ""
 
 #: src/olympia/devhub/templates/devhub/versions/list.html:122
 msgid "Current versions"
@@ -7168,86 +6987,75 @@ msgid "<strong>Important:</strong> Once a version has been deleted, you may not 
 msgstr "<strong>Īḿƥǿřŧȧƞŧ:</strong> Ǿƞƈḗ ȧ ṽḗřşīǿƞ ħȧş ƀḗḗƞ ḓḗŀḗŧḗḓ, ẏǿŭ ḿȧẏ ƞǿŧ ŭƥŀǿȧḓ ȧ ƞḗẇ ṽḗřşīǿƞ ẇīŧħ ŧħḗ şȧḿḗ ṽḗřşīǿƞ ƞŭḿƀḗř."
 
 #: src/olympia/devhub/templates/devhub/versions/list.html:230
-msgid ""
-"Deleting a version which has already been reviewed\n"
-"               may also cause a significant delay in the review of\n"
-"               your next update."
-msgstr ""
-"Ḓḗŀḗŧīƞɠ ȧ ṽḗřşīǿƞ ẇħīƈħ ħȧş ȧŀřḗȧḓẏ ƀḗḗƞ řḗṽīḗẇḗḓ\n"
-"               ḿȧẏ ȧŀşǿ ƈȧŭşḗ ȧ şīɠƞīƒīƈȧƞŧ ḓḗŀȧẏ īƞ ŧħḗ řḗṽīḗẇ ǿƒ\n"
-"               ẏǿŭř ƞḗẋŧ ŭƥḓȧŧḗ."
-
-#: src/olympia/devhub/templates/devhub/versions/list.html:233
 msgid "Are you sure you wish to delete this version?"
 msgstr "Ȧřḗ ẏǿŭ şŭřḗ ẏǿŭ ẇīşħ ŧǿ ḓḗŀḗŧḗ ŧħīş ṽḗřşīǿƞ?"
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:238
+#: src/olympia/devhub/templates/devhub/versions/list.html:235
 msgid "Delete Version"
 msgstr "Ḓḗŀḗŧḗ Ṽḗřşīǿƞ"
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:240
+#: src/olympia/devhub/templates/devhub/versions/list.html:237
 msgid "Disable Version"
 msgstr "Ḓīşȧƀŀḗ Ṽḗřşīǿƞ"
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:247
+#: src/olympia/devhub/templates/devhub/versions/list.html:244
 msgid "Add a new Version"
 msgstr "Ȧḓḓ ȧ ƞḗẇ Ṽḗřşīǿƞ"
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:249
+#: src/olympia/devhub/templates/devhub/versions/list.html:246
 msgid "Add Version"
 msgstr "Ȧḓḓ Ṽḗřşīǿƞ"
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:256 src/olympia/devhub/templates/devhub/versions/list.html:274
+#: src/olympia/devhub/templates/devhub/versions/list.html:253 src/olympia/devhub/templates/devhub/versions/list.html:279
 msgid "Hide Add-on"
 msgstr "Ħīḓḗ Ȧḓḓ-ǿƞ"
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:259
+#: src/olympia/devhub/templates/devhub/versions/list.html:256
 msgid "Hiding your add-on will prevent it from appearing anywhere in our gallery and will stop users from receiving automatic updates."
 msgstr "Ħīḓīƞɠ ẏǿŭř ȧḓḓ-ǿƞ ẇīŀŀ ƥřḗṽḗƞŧ īŧ ƒřǿḿ ȧƥƥḗȧřīƞɠ ȧƞẏẇħḗřḗ īƞ ǿŭř ɠȧŀŀḗřẏ ȧƞḓ ẇīŀŀ şŧǿƥ ŭşḗřş ƒřǿḿ řḗƈḗīṽīƞɠ ȧŭŧǿḿȧŧīƈ ŭƥḓȧŧḗş."
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:265
+#: src/olympia/devhub/templates/devhub/versions/list.html:263
+msgid "The files awaiting review will be disabled and you will need to upload new versions."
+msgstr ""
+
+#: src/olympia/devhub/templates/devhub/versions/list.html:270
 msgid "Are you sure you wish to hide your add-on?"
 msgstr "Ȧřḗ ẏǿŭ şŭřḗ ẏǿŭ ẇīşħ ŧǿ ħīḓḗ ẏǿŭř ȧḓḓ-ǿƞ?"
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:286 src/olympia/devhub/templates/devhub/versions/list.html:315
+#: src/olympia/devhub/templates/devhub/versions/list.html:291 src/olympia/devhub/templates/devhub/versions/list.html:313
 msgid "Unlist Add-on"
 msgstr "Ŭƞŀīşŧ Ȧḓḓ-ǿƞ"
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:289
+#: src/olympia/devhub/templates/devhub/versions/list.html:294
 #, python-format
 msgid ""
 "Unlisting your add-on will make it (and each of its versions/files) invisible on this website. It won't show up in searches, won't have a public facing page, and won't be updated automatically for "
-"current users.  It is recommended for unlisted add-ons to provide a custom <a href=\"%(update_url)s\" target=\"_blank\">updateURL</a> in their manifest file for automatic updates."
+"current users. It is recommended for unlisted add-ons to provide a custom <a href=\"%(update_url)s\" target=\"_blank\">updateURL</a> in their manifest file for automatic updates."
 msgstr ""
 "Ŭƞŀīşŧīƞɠ ẏǿŭř ȧḓḓ-ǿƞ ẇīŀŀ ḿȧķḗ īŧ (ȧƞḓ ḗȧƈħ ǿƒ īŧş ṽḗřşīǿƞş/files) īƞṽīşīƀŀḗ ǿƞ ŧħīş ẇḗƀşīŧḗ. Īŧ ẇǿƞ'ŧ şħǿẇ ŭƥ īƞ şḗȧřƈħḗş, ẇǿƞ'ŧ ħȧṽḗ ȧ ƥŭƀŀīƈ ƒȧƈīƞɠ ƥȧɠḗ, ȧƞḓ ẇǿƞ'ŧ ƀḗ ŭƥḓȧŧḗḓ ȧŭŧǿḿȧŧīƈȧŀŀẏ ƒǿř "
 "ƈŭřřḗƞŧ ŭşḗřş.  Īŧ īş řḗƈǿḿḿḗƞḓḗḓ ƒǿř ŭƞŀīşŧḗḓ ȧḓḓ-ǿƞş ŧǿ ƥřǿṽīḓḗ ȧ ƈŭşŧǿḿ <a href=\"%(update_url)s\" target=\"_blank\">ŭƥḓȧŧḗŬŘĿ</a> īƞ ŧħḗīř ḿȧƞīƒḗşŧ ƒīŀḗ ƒǿř ȧŭŧǿḿȧŧīƈ ŭƥḓȧŧḗş."
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:299
-#, python-format
-msgid "Switching add-ons to unlisted is currently in an open beta. Please <a href=\"%(url)s\" target=\"_blank\">report any bugs</a> that you encounter."
-msgstr "Şẇīŧƈħīƞɠ ȧḓḓ-ǿƞş ŧǿ ŭƞŀīşŧḗḓ īş ƈŭřřḗƞŧŀẏ īƞ ȧƞ ǿƥḗƞ ƀḗŧȧ. Ƥŀḗȧşḗ <a href=\"%(url)s\" target=\"_blank\">řḗƥǿřŧ ȧƞẏ ƀŭɠş</a> ŧħȧŧ ẏǿŭ ḗƞƈǿŭƞŧḗř."
-
-#: src/olympia/devhub/templates/devhub/versions/list.html:305
+#: src/olympia/devhub/templates/devhub/versions/list.html:303
 msgid "Unlisting an add-on is irreversible!"
 msgstr "Ŭƞŀīşŧīƞɠ ȧƞ ȧḓḓ-ǿƞ īş īřřḗṽḗřşīƀŀḗ!"
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:305
+#: src/olympia/devhub/templates/devhub/versions/list.html:303
 msgid "An unlisted add-on cannot be switched to be listed."
 msgstr "Ȧƞ ŭƞŀīşŧḗḓ ȧḓḓ-ǿƞ ƈȧƞƞǿŧ ƀḗ şẇīŧƈħḗḓ ŧǿ ƀḗ ŀīşŧḗḓ."
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:307
+#: src/olympia/devhub/templates/devhub/versions/list.html:305
 msgid "Are you sure you wish to unlist your add-on?"
 msgstr "Ȧřḗ ẏǿŭ şŭřḗ ẏǿŭ ẇīşħ ŧǿ ŭƞŀīşŧ ẏǿŭř ȧḓḓ-ǿƞ?"
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:330
+#: src/olympia/devhub/templates/devhub/versions/list.html:328
 msgid "Canceling your review request will leave your add-on as preliminarily reviewed."
 msgstr "Ƈȧƞƈḗŀīƞɠ ẏǿŭř řḗṽīḗẇ řḗɋŭḗşŧ ẇīŀŀ ŀḗȧṽḗ ẏǿŭř ȧḓḓ-ǿƞ ȧş ƥřḗŀīḿīƞȧřīŀẏ řḗṽīḗẇḗḓ."
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:335
+#: src/olympia/devhub/templates/devhub/versions/list.html:333
 msgid "Canceling your review request will mark your add-on incomplete. If you do not complete your add-on after several days by re-requesting review, it will be deleted."
 msgstr "Ƈȧƞƈḗŀīƞɠ ẏǿŭř řḗṽīḗẇ řḗɋŭḗşŧ ẇīŀŀ ḿȧřķ ẏǿŭř ȧḓḓ-ǿƞ īƞƈǿḿƥŀḗŧḗ. Īƒ ẏǿŭ ḓǿ ƞǿŧ ƈǿḿƥŀḗŧḗ ẏǿŭř ȧḓḓ-ǿƞ ȧƒŧḗř şḗṽḗřȧŀ ḓȧẏş ƀẏ řḗ-řḗɋŭḗşŧīƞɠ řḗṽīḗẇ, īŧ ẇīŀŀ ƀḗ ḓḗŀḗŧḗḓ."
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:343
+#: src/olympia/devhub/templates/devhub/versions/list.html:341
 msgid "Are you sure you wish to cancel your review request?"
 msgstr "Ȧřḗ ẏǿŭ şŭřḗ ẏǿŭ ẇīşħ ŧǿ ƈȧƞƈḗŀ ẏǿŭř řḗṽīḗẇ řḗɋŭḗşŧ?"
 
@@ -7586,19 +7394,19 @@ msgstr "ȧḓḓ-ǿƞ, ḗḓīŧǿř ǿř ƈǿḿḿḗƞŧ"
 msgid "Search by add-on name / author email"
 msgstr "Şḗȧřƈħ ƀẏ ȧḓḓ-ǿƞ ƞȧḿḗ / ȧŭŧħǿř ḗḿȧīŀ"
 
-#: src/olympia/editors/forms.py:103
+#: src/olympia/editors/forms.py:103 src/olympia/editors/forms.py:244 src/olympia/editors/forms.py:257
 msgid "yes"
 msgstr "ẏḗş"
 
-#: src/olympia/editors/forms.py:104
+#: src/olympia/editors/forms.py:104 src/olympia/editors/forms.py:244 src/olympia/editors/forms.py:257
 msgid "no"
 msgstr "ƞǿ"
 
-#: src/olympia/editors/forms.py:105
+#: src/olympia/editors/forms.py:105 src/olympia/editors/forms.py:245
 msgid "Admin Flag"
 msgstr "Ȧḓḿīƞ Ƒŀȧɠ"
 
-#: src/olympia/editors/forms.py:113
+#: src/olympia/editors/forms.py:113 src/olympia/editors/forms.py:253
 msgid "Max. Version"
 msgstr "Ḿȧẋ. Ṽḗřşīǿƞ"
 
@@ -7610,55 +7418,59 @@ msgstr "Ḓȧẏş Şīƞƈḗ Şŭƀḿīşşīǿƞ"
 msgid "Add-on Types"
 msgstr "Ȧḓḓ-ǿƞ Ŧẏƥḗş"
 
-#: src/olympia/editors/forms.py:126 src/olympia/editors/helpers.py:267
+#: src/olympia/editors/forms.py:126 src/olympia/editors/helpers.py:279
 msgid "Platforms"
 msgstr "Ƥŀȧŧƒǿřḿş"
 
+#: src/olympia/editors/forms.py:237
+msgid "Search by add-on name / author email / guid"
+msgstr ""
+
 #. L10n: 0 = platform, 1 = filename, 2 = status message
-#: src/olympia/editors/forms.py:238
+#: src/olympia/editors/forms.py:342
 #, python-format
 msgid "<strong>%s</strong> &middot; %s &middot; %s"
 msgstr "<strong>%s</strong> &middot; %s &middot; %s"
 
-#: src/olympia/editors/forms.py:252
+#: src/olympia/editors/forms.py:356
 msgid "Comments:"
 msgstr "Ƈǿḿḿḗƞŧş:"
 
-#: src/olympia/editors/forms.py:256
+#: src/olympia/editors/forms.py:360
 msgid "Operating systems:"
 msgstr "Ǿƥḗřȧŧīƞɠ şẏşŧḗḿş:"
 
-#: src/olympia/editors/forms.py:258
+#: src/olympia/editors/forms.py:362
 msgid "Applications:"
 msgstr "Ȧƥƥŀīƈȧŧīǿƞş:"
 
-#: src/olympia/editors/forms.py:260
+#: src/olympia/editors/forms.py:364
 msgid "Notify me the next time this add-on is updated. (Subsequent updates will not generate an email)"
 msgstr "Ƞǿŧīƒẏ ḿḗ ŧħḗ ƞḗẋŧ ŧīḿḗ ŧħīş ȧḓḓ-ǿƞ īş ŭƥḓȧŧḗḓ. (Şŭƀşḗɋŭḗƞŧ ŭƥḓȧŧḗş ẇīŀŀ ƞǿŧ ɠḗƞḗřȧŧḗ ȧƞ ḗḿȧīŀ)"
 
-#: src/olympia/editors/forms.py:265
+#: src/olympia/editors/forms.py:369
 msgid "Clear Admin Review Flag"
 msgstr "Ƈŀḗȧř Ȧḓḿīƞ Řḗṽīḗẇ Ƒŀȧɠ"
 
-#: src/olympia/editors/forms.py:267
+#: src/olympia/editors/forms.py:371
 msgid "Clear more info requested flag"
 msgstr "Ƈŀḗȧř ḿǿřḗ īƞƒǿ řḗɋŭḗşŧḗḓ ƒŀȧɠ"
 
-#: src/olympia/editors/forms.py:281
+#: src/olympia/editors/forms.py:385
 msgid "Choose a canned response..."
 msgstr "Ƈħǿǿşḗ ȧ ƈȧƞƞḗḓ řḗşƥǿƞşḗ..."
 
 #. L10n: Description of what can be searched for.
-#: src/olympia/editors/forms.py:324
+#: src/olympia/editors/forms.py:423
 msgid "theme name"
 msgstr "ŧħḗḿḗ ƞȧḿḗ"
 
-#: src/olympia/editors/forms.py:350
+#: src/olympia/editors/forms.py:449
 msgid "Someone else is reviewing this theme."
 msgstr "Şǿḿḗǿƞḗ ḗŀşḗ īş řḗṽīḗẇīƞɠ ŧħīş ŧħḗḿḗ."
 
 #. L10n: Description of what can be searched for.
-#: src/olympia/editors/forms.py:447
+#: src/olympia/editors/forms.py:546
 msgid "app, reviewer, or comment"
 msgstr "ȧƥƥ, řḗṽīḗẇḗř, ǿř ƈǿḿḿḗƞŧ"
 
@@ -7674,192 +7486,210 @@ msgstr "Ƥḗƞḓīƞɠ Ƥřḗŀīḿīƞȧřẏ Řḗṽīḗẇ"
 msgid "Rejected or Unreviewed"
 msgstr "Řḗĵḗƈŧḗḓ ǿř Ŭƞřḗṽīḗẇḗḓ"
 
-#: src/olympia/editors/helpers.py:123 src/olympia/editors/helpers.py:136
+#: src/olympia/editors/helpers.py:125 src/olympia/editors/helpers.py:138
 msgid "Queue"
 msgstr "Ɋŭḗŭḗ"
 
-#: src/olympia/editors/helpers.py:124 src/olympia/editors/templates/editors/base.html:50 src/olympia/editors/templates/editors/base.html:65
+#: src/olympia/editors/helpers.py:126 src/olympia/editors/templates/editors/base.html:50 src/olympia/editors/templates/editors/base.html:65
 msgid "Pending Updates"
 msgstr "Ƥḗƞḓīƞɠ Ŭƥḓȧŧḗş"
 
-#: src/olympia/editors/helpers.py:125 src/olympia/editors/templates/editors/base.html:48 src/olympia/editors/templates/editors/base.html:63
+#: src/olympia/editors/helpers.py:127 src/olympia/editors/templates/editors/base.html:48 src/olympia/editors/templates/editors/base.html:63
 msgid "Full Reviews"
 msgstr "Ƒŭŀŀ Řḗṽīḗẇş"
 
-#: src/olympia/editors/helpers.py:126 src/olympia/editors/templates/editors/base.html:52 src/olympia/editors/templates/editors/base.html:67
+#: src/olympia/editors/helpers.py:128 src/olympia/editors/templates/editors/base.html:52 src/olympia/editors/templates/editors/base.html:67
 msgid "Preliminary Reviews"
 msgstr "Ƥřḗŀīḿīƞȧřẏ Řḗṽīḗẇş"
 
-#: src/olympia/editors/helpers.py:127 src/olympia/editors/templates/editors/base.html:54
+#: src/olympia/editors/helpers.py:129 src/olympia/editors/templates/editors/base.html:54
 msgid "Moderated Reviews"
 msgstr "Ḿǿḓḗřȧŧḗḓ Řḗṽīḗẇş"
 
-#: src/olympia/editors/helpers.py:128 src/olympia/editors/templates/editors/base.html:46
+#: src/olympia/editors/helpers.py:130 src/olympia/editors/templates/editors/base.html:46
 msgid "Fast Track"
 msgstr "Ƒȧşŧ Ŧřȧƈķ"
 
-#: src/olympia/editors/helpers.py:130
+#: src/olympia/editors/helpers.py:132
 msgid "Pending Themes"
 msgstr "Ƥḗƞḓīƞɠ Ŧħḗḿḗş"
 
-#: src/olympia/editors/helpers.py:131 src/olympia/editors/templates/editors/themes/queue.html:4
+#: src/olympia/editors/helpers.py:133 src/olympia/editors/templates/editors/themes/queue.html:4
 msgid "Flagged Themes"
 msgstr "Ƒŀȧɠɠḗḓ Ŧħḗḿḗş"
 
-#: src/olympia/editors/helpers.py:132
+#: src/olympia/editors/helpers.py:134
 msgid "Update Themes"
 msgstr "Ŭƥḓȧŧḗ Ŧħḗḿḗş"
 
-#: src/olympia/editors/helpers.py:137
+#: src/olympia/editors/helpers.py:139
 msgid "Unlisted Pending Updates"
 msgstr "Ŭƞŀīşŧḗḓ Ƥḗƞḓīƞɠ Ŭƥḓȧŧḗş"
 
-#: src/olympia/editors/helpers.py:138
+#: src/olympia/editors/helpers.py:140
 msgid "Unlisted Full Reviews"
 msgstr "Ŭƞŀīşŧḗḓ Ƒŭŀŀ Řḗṽīḗẇş"
 
-#: src/olympia/editors/helpers.py:139
+#: src/olympia/editors/helpers.py:141
 msgid "Unlisted Preliminary Reviews"
 msgstr "Ŭƞŀīşŧḗḓ Ƥřḗŀīḿīƞȧřẏ Řḗṽīḗẇş"
 
-#: src/olympia/editors/helpers.py:170
+#: src/olympia/editors/helpers.py:142
+msgid "Unlisted All Add-ons"
+msgstr ""
+
+#: src/olympia/editors/helpers.py:173
 msgid "Fast Track ({0})"
 msgid_plural "Fast Track ({0})"
 msgstr[0] "Ƒȧşŧ Ŧřȧƈķ ({0})"
 msgstr[1] "Ƒȧşŧ Ŧřȧƈķ ({0})"
 
-#: src/olympia/editors/helpers.py:175
+#: src/olympia/editors/helpers.py:178
 msgid "Full Review ({0})"
 msgid_plural "Full Reviews ({0})"
 msgstr[0] "Ƒŭŀŀ Řḗṽīḗẇ ({0})"
 msgstr[1] "Ƒŭŀŀ Řḗṽīḗẇş ({0})"
 
-#: src/olympia/editors/helpers.py:180
+#: src/olympia/editors/helpers.py:183
 msgid "Pending Update ({0})"
 msgid_plural "Pending Updates ({0})"
 msgstr[0] "Ƥḗƞḓīƞɠ Ŭƥḓȧŧḗ ({0})"
 msgstr[1] "Ƥḗƞḓīƞɠ Ŭƥḓȧŧḗş ({0})"
 
-#: src/olympia/editors/helpers.py:185
+#: src/olympia/editors/helpers.py:188
 msgid "Preliminary Review ({0})"
 msgid_plural "Preliminary Reviews ({0})"
 msgstr[0] "Ƥřḗŀīḿīƞȧřẏ Řḗṽīḗẇ ({0})"
 msgstr[1] "Ƥřḗŀīḿīƞȧřẏ Řḗṽīḗẇş ({0})"
 
-#: src/olympia/editors/helpers.py:190
+#: src/olympia/editors/helpers.py:193
 msgid "Moderated Review ({0})"
 msgid_plural "Moderated Reviews ({0})"
 msgstr[0] "Ḿǿḓḗřȧŧḗḓ Řḗṽīḗẇ ({0})"
 msgstr[1] "Ḿǿḓḗřȧŧḗḓ Řḗṽīḗẇş ({0})"
 
-#: src/olympia/editors/helpers.py:196
+#: src/olympia/editors/helpers.py:199
 msgid "Unlisted Full Review ({0})"
 msgid_plural "Unlisted Full Reviews ({0})"
 msgstr[0] "Ŭƞŀīşŧḗḓ Ƒŭŀŀ Řḗṽīḗẇ ({0})"
 msgstr[1] "Ŭƞŀīşŧḗḓ Ƒŭŀŀ Řḗṽīḗẇş ({0})"
 
-#: src/olympia/editors/helpers.py:201
+#: src/olympia/editors/helpers.py:204
 msgid "Unlisted Pending Update ({0})"
 msgid_plural "Unlisted Pending Updates ({0})"
 msgstr[0] "Ŭƞŀīşŧḗḓ Ƥḗƞḓīƞɠ Ŭƥḓȧŧḗ ({0})"
 msgstr[1] "Ŭƞŀīşŧḗḓ Ƥḗƞḓīƞɠ Ŭƥḓȧŧḗş ({0})"
 
-#: src/olympia/editors/helpers.py:206
+#: src/olympia/editors/helpers.py:209
 msgid "Unlisted Preliminary Review ({0})"
 msgid_plural "Unlisted Preliminary Reviews ({0})"
 msgstr[0] "Ŭƞŀīşŧḗḓ Ƥřḗŀīḿīƞȧřẏ Řḗṽīḗẇ ({0})"
 msgstr[1] "Ŭƞŀīşŧḗḓ Ƥřḗŀīḿīƞȧřẏ Řḗṽīḗẇş ({0})"
 
-#: src/olympia/editors/helpers.py:261
-msgid "Addon"
-msgstr "Ȧḓḓǿƞ"
+#: src/olympia/editors/helpers.py:214
+msgid "Unlisted All Add-ons ({0})"
+msgid_plural "Unlisted All Add-ons ({0})"
+msgstr[0] ""
+msgstr[1] ""
 
-#: src/olympia/editors/helpers.py:262
+#: src/olympia/editors/helpers.py:274
 msgid "Type"
 msgstr "Ŧẏƥḗ"
 
-#: src/olympia/editors/helpers.py:263
+#: src/olympia/editors/helpers.py:275
 msgid "Waiting Time"
 msgstr "Ẇȧīŧīƞɠ Ŧīḿḗ"
 
-#: src/olympia/editors/helpers.py:264 src/olympia/editors/templates/editors/review.html:285
+#: src/olympia/editors/helpers.py:276 src/olympia/editors/templates/editors/review.html:285
 msgid "Flags"
 msgstr "Ƒŀȧɠş"
 
-#: src/olympia/editors/helpers.py:265
+#: src/olympia/editors/helpers.py:277
 msgid "Applications"
 msgstr "Ȧƥƥŀīƈȧŧīǿƞş"
 
-#: src/olympia/editors/helpers.py:270
+#: src/olympia/editors/helpers.py:282
 msgid "Additional"
 msgstr "Ȧḓḓīŧīǿƞȧŀ"
 
-#: src/olympia/editors/helpers.py:285
+#: src/olympia/editors/helpers.py:302
 msgid "Site Specific"
 msgstr "Şīŧḗ Şƥḗƈīƒīƈ"
 
-#: src/olympia/editors/helpers.py:287
+#: src/olympia/editors/helpers.py:304
 msgid "Requires External Software"
 msgstr "Řḗɋŭīřḗş Ḗẋŧḗřƞȧŀ Şǿƒŧẇȧřḗ"
 
-#: src/olympia/editors/helpers.py:289
+#: src/olympia/editors/helpers.py:306
 msgid "Binary Components"
 msgstr "Ɓīƞȧřẏ Ƈǿḿƥǿƞḗƞŧş"
 
-#: src/olympia/editors/helpers.py:313
+#: src/olympia/editors/helpers.py:339
 msgid "moments ago"
 msgstr "ḿǿḿḗƞŧş ȧɠǿ"
 
 #. L10n: first argument is number of minutes
-#: src/olympia/editors/helpers.py:316
+#: src/olympia/editors/helpers.py:342
 msgid "{0} minute"
 msgid_plural "{0} minutes"
 msgstr[0] "{0} ḿīƞŭŧḗ"
 msgstr[1] "{0} ḿīƞŭŧḗş"
 
 #. L10n: first argument is number of hours
-#: src/olympia/editors/helpers.py:320
+#: src/olympia/editors/helpers.py:346
 msgid "{0} hour"
 msgid_plural "{0} hours"
 msgstr[0] "{0} ħǿŭř"
 msgstr[1] "{0} ħǿŭřş"
 
 #. L10n: first argument is number of days
-#: src/olympia/editors/helpers.py:324
+#: src/olympia/editors/helpers.py:350
 msgid "{0} day"
 msgid_plural "{0} days"
 msgstr[0] "{0} ḓȧẏ"
 msgstr[1] "{0} ḓȧẏş"
 
-#: src/olympia/editors/helpers.py:488
+#: src/olympia/editors/helpers.py:364
+msgid "Last Review"
+msgstr ""
+
+#: src/olympia/editors/helpers.py:366
+msgid "Last Update"
+msgstr ""
+
+#: src/olympia/editors/helpers.py:387
+msgid "No Reviews"
+msgstr ""
+
+#: src/olympia/editors/helpers.py:561
 msgid "Push to public"
 msgstr "Ƥŭşħ ŧǿ ƥŭƀŀīƈ"
 
-#: src/olympia/editors/helpers.py:490
+#: src/olympia/editors/helpers.py:563
 msgid "Grant full review"
 msgstr "Ɠřȧƞŧ ƒŭŀŀ řḗṽīḗẇ"
 
-#: src/olympia/editors/helpers.py:505
+#: src/olympia/editors/helpers.py:578
 msgid "Request more information"
 msgstr "Řḗɋŭḗşŧ ḿǿřḗ īƞƒǿřḿȧŧīǿƞ"
 
-#: src/olympia/editors/helpers.py:508
+#: src/olympia/editors/helpers.py:581
 msgid "Request super-review"
 msgstr "Řḗɋŭḗşŧ şŭƥḗř-řḗṽīḗẇ"
 
-#: src/olympia/editors/helpers.py:519
+#: src/olympia/editors/helpers.py:592
 msgid "Grant preliminary review"
 msgstr "Ɠřȧƞŧ ƥřḗŀīḿīƞȧřẏ řḗṽīḗẇ"
 
-#: src/olympia/editors/helpers.py:520
+#: src/olympia/editors/helpers.py:593
 msgid "This will mark the files as preliminarily reviewed."
 msgstr "Ŧħīş ẇīŀŀ ḿȧřķ ŧħḗ ƒīŀḗş ȧş ƥřḗŀīḿīƞȧřīŀẏ řḗṽīḗẇḗḓ."
 
-#: src/olympia/editors/helpers.py:522
+#: src/olympia/editors/helpers.py:595
 msgid "Use this form to request more information from the author. They will receive an email and be able to answer here. You will be notified by email when they reply."
 msgstr "Ŭşḗ ŧħīş ƒǿřḿ ŧǿ řḗɋŭḗşŧ ḿǿřḗ īƞƒǿřḿȧŧīǿƞ ƒřǿḿ ŧħḗ ȧŭŧħǿř. Ŧħḗẏ ẇīŀŀ řḗƈḗīṽḗ ȧƞ ḗḿȧīŀ ȧƞḓ ƀḗ ȧƀŀḗ ŧǿ ȧƞşẇḗř ħḗřḗ. Ẏǿŭ ẇīŀŀ ƀḗ ƞǿŧīƒīḗḓ ƀẏ ḗḿȧīŀ ẇħḗƞ ŧħḗẏ řḗƥŀẏ."
 
-#: src/olympia/editors/helpers.py:526
+#: src/olympia/editors/helpers.py:599
 msgid ""
 "If you have concerns about this add-on's security, copyright issues, or other concerns that an administrator should look into, enter your comments in the area below. They will be sent to "
 "administrators, not the author."
@@ -7867,55 +7697,55 @@ msgstr ""
 "Īƒ ẏǿŭ ħȧṽḗ ƈǿƞƈḗřƞş ȧƀǿŭŧ ŧħīş ȧḓḓ-ǿƞ'ş şḗƈŭřīŧẏ, ƈǿƥẏřīɠħŧ īşşŭḗş, ǿř ǿŧħḗř ƈǿƞƈḗřƞş ŧħȧŧ ȧƞ ȧḓḿīƞīşŧřȧŧǿř şħǿŭŀḓ ŀǿǿķ īƞŧǿ, ḗƞŧḗř ẏǿŭř ƈǿḿḿḗƞŧş īƞ ŧħḗ ȧřḗȧ ƀḗŀǿẇ. Ŧħḗẏ ẇīŀŀ ƀḗ şḗƞŧ ŧǿ "
 "ȧḓḿīƞīşŧřȧŧǿřş, ƞǿŧ ŧħḗ ȧŭŧħǿř."
 
-#: src/olympia/editors/helpers.py:532
+#: src/olympia/editors/helpers.py:605
 msgid "This will reject the add-on and remove it from the review queue."
 msgstr "Ŧħīş ẇīŀŀ řḗĵḗƈŧ ŧħḗ ȧḓḓ-ǿƞ ȧƞḓ řḗḿǿṽḗ īŧ ƒřǿḿ ŧħḗ řḗṽīḗẇ ɋŭḗŭḗ."
 
-#: src/olympia/editors/helpers.py:534
-msgid "Make a comment on this version.  The author won't be able to see this."
+#: src/olympia/editors/helpers.py:607
+msgid "Make a comment on this version. The author won't be able to see this."
 msgstr "Ḿȧķḗ ȧ ƈǿḿḿḗƞŧ ǿƞ ŧħīş ṽḗřşīǿƞ.  Ŧħḗ ȧŭŧħǿř ẇǿƞ'ŧ ƀḗ ȧƀŀḗ ŧǿ şḗḗ ŧħīş."
 
-#: src/olympia/editors/helpers.py:538
+#: src/olympia/editors/helpers.py:611
 msgid "This will reject the files and remove them from the review queue."
 msgstr "Ŧħīş ẇīŀŀ řḗĵḗƈŧ ŧħḗ ƒīŀḗş ȧƞḓ řḗḿǿṽḗ ŧħḗḿ ƒřǿḿ ŧħḗ řḗṽīḗẇ ɋŭḗŭḗ."
 
-#: src/olympia/editors/helpers.py:542
+#: src/olympia/editors/helpers.py:615
 msgid "This will mark the add-on as preliminarily reviewed. Future versions will undergo preliminary review."
 msgstr "Ŧħīş ẇīŀŀ ḿȧřķ ŧħḗ ȧḓḓ-ǿƞ ȧş ƥřḗŀīḿīƞȧřīŀẏ řḗṽīḗẇḗḓ. Ƒŭŧŭřḗ ṽḗřşīǿƞş ẇīŀŀ ŭƞḓḗřɠǿ ƥřḗŀīḿīƞȧřẏ řḗṽīḗẇ."
 
-#: src/olympia/editors/helpers.py:547
+#: src/olympia/editors/helpers.py:620
 msgid "This will mark the files as preliminarily reviewed. Future versions will undergo preliminary review."
 msgstr "Ŧħīş ẇīŀŀ ḿȧřķ ŧħḗ ƒīŀḗş ȧş ƥřḗŀīḿīƞȧřīŀẏ řḗṽīḗẇḗḓ. Ƒŭŧŭřḗ ṽḗřşīǿƞş ẇīŀŀ ŭƞḓḗřɠǿ ƥřḗŀīḿīƞȧřẏ řḗṽīḗẇ."
 
-#: src/olympia/editors/helpers.py:552
+#: src/olympia/editors/helpers.py:625
 msgid "Retain preliminary review"
 msgstr "Řḗŧȧīƞ ƥřḗŀīḿīƞȧřẏ řḗṽīḗẇ"
 
-#: src/olympia/editors/helpers.py:553
+#: src/olympia/editors/helpers.py:626
 msgid "This will retain the add-on as preliminarily reviewed. Future versions will undergo preliminary review."
 msgstr "Ŧħīş ẇīŀŀ řḗŧȧīƞ ŧħḗ ȧḓḓ-ǿƞ ȧş ƥřḗŀīḿīƞȧřīŀẏ řḗṽīḗẇḗḓ. Ƒŭŧŭřḗ ṽḗřşīǿƞş ẇīŀŀ ŭƞḓḗřɠǿ ƥřḗŀīḿīƞȧřẏ řḗṽīḗẇ."
 
-#: src/olympia/editors/helpers.py:558
+#: src/olympia/editors/helpers.py:631
 msgid "This will approve a sandboxed version of a public add-on to appear on the public side."
 msgstr "Ŧħīş ẇīŀŀ ȧƥƥřǿṽḗ ȧ şȧƞḓƀǿẋḗḓ ṽḗřşīǿƞ ǿƒ ȧ ƥŭƀŀīƈ ȧḓḓ-ǿƞ ŧǿ ȧƥƥḗȧř ǿƞ ŧħḗ ƥŭƀŀīƈ şīḓḗ."
 
-#: src/olympia/editors/helpers.py:561
+#: src/olympia/editors/helpers.py:634
 msgid "This will reject a version of a public add-on and remove it from the queue."
 msgstr "Ŧħīş ẇīŀŀ řḗĵḗƈŧ ȧ ṽḗřşīǿƞ ǿƒ ȧ ƥŭƀŀīƈ ȧḓḓ-ǿƞ ȧƞḓ řḗḿǿṽḗ īŧ ƒřǿḿ ŧħḗ ɋŭḗŭḗ."
 
-#: src/olympia/editors/helpers.py:564
+#: src/olympia/editors/helpers.py:637
 msgid "This will mark the add-on and its most recent version and files as public. Future versions will go into the sandbox until they are reviewed by an editor."
 msgstr "Ŧħīş ẇīŀŀ ḿȧřķ ŧħḗ ȧḓḓ-ǿƞ ȧƞḓ īŧş ḿǿşŧ řḗƈḗƞŧ ṽḗřşīǿƞ ȧƞḓ ƒīŀḗş ȧş ƥŭƀŀīƈ. Ƒŭŧŭřḗ ṽḗřşīǿƞş ẇīŀŀ ɠǿ īƞŧǿ ŧħḗ şȧƞḓƀǿẋ ŭƞŧīŀ ŧħḗẏ ȧřḗ řḗṽīḗẇḗḓ ƀẏ ȧƞ ḗḓīŧǿř."
 
-#: src/olympia/editors/helpers.py:637
+#: src/olympia/editors/helpers.py:714
 msgid "add-on"
 msgstr "ȧḓḓ-ǿƞ"
 
-#: src/olympia/editors/helpers.py:940 src/olympia/editors/helpers.py:960
+#: src/olympia/editors/helpers.py:1020 src/olympia/editors/helpers.py:1040
 msgid "Flagged"
 msgstr "Ƒŀȧɠɠḗḓ"
 
-#: src/olympia/editors/helpers.py:944 src/olympia/editors/helpers.py:963
+#: src/olympia/editors/helpers.py:1024 src/olympia/editors/helpers.py:1043
 msgid "Updates"
 msgstr "Ŭƥḓȧŧḗş"
 
@@ -7967,56 +7797,56 @@ msgstr "Ŧħḗḿḗ şŭƀḿīşşīǿƞ ƒŀȧɠɠḗḓ ƒǿř řḗṽī�
 msgid "A question about your Theme submission"
 msgstr "Ȧ ɋŭḗşŧīǿƞ ȧƀǿŭŧ ẏǿŭř Ŧħḗḿḗ şŭƀḿīşşīǿƞ"
 
-#: src/olympia/editors/views.py:144
+#: src/olympia/editors/views.py:146
 msgid "New Add-ons (Under 5 days)"
 msgstr "Ƞḗẇ Ȧḓḓ-ǿƞş (Ŭƞḓḗř 5 ḓȧẏş)"
 
-#: src/olympia/editors/views.py:145
+#: src/olympia/editors/views.py:147
 msgid "Passable (5 to 10 days)"
 msgstr "Ƥȧşşȧƀŀḗ (5 ŧǿ 10 ḓȧẏş)"
 
-#: src/olympia/editors/views.py:146
+#: src/olympia/editors/views.py:148
 msgid "Overdue (Over 10 days)"
 msgstr "Ǿṽḗřḓŭḗ (Ǿṽḗř 10 ḓȧẏş)"
 
-#: src/olympia/editors/views.py:532
+#: src/olympia/editors/views.py:539
 msgid "An unknown error occurred"
 msgstr "Ȧƞ ŭƞķƞǿẇƞ ḗřřǿř ǿƈƈŭřřḗḓ"
 
-#: src/olympia/editors/views.py:587
+#: src/olympia/editors/views.py:592
 msgid "Self-reviews are not allowed."
 msgstr "Şḗŀƒ-řḗṽīḗẇş ȧřḗ ƞǿŧ ȧŀŀǿẇḗḓ."
 
-#: src/olympia/editors/views.py:609
+#: src/olympia/editors/views.py:613
 msgid "Review successfully processed."
 msgstr "Řḗṽīḗẇ şŭƈƈḗşşƒŭŀŀẏ ƥřǿƈḗşşḗḓ."
 
-#: src/olympia/editors/views.py:807
+#: src/olympia/editors/views.py:812
 msgid "was approved"
 msgstr "ẇȧş ȧƥƥřǿṽḗḓ"
 
-#: src/olympia/editors/views.py:808
+#: src/olympia/editors/views.py:813
 msgid "given preliminary review"
 msgstr "ɠīṽḗƞ ƥřḗŀīḿīƞȧřẏ řḗṽīḗẇ"
 
-#: src/olympia/editors/views.py:809
+#: src/olympia/editors/views.py:814
 msgid "rejected"
 msgstr "řḗĵḗƈŧḗḓ"
 
-#: src/olympia/editors/views.py:810
+#: src/olympia/editors/views.py:815
 msgctxt "editors_review_history_nominated_adminreview"
 msgid "escalated"
 msgstr "ḗşƈȧŀȧŧḗḓ"
 
-#: src/olympia/editors/views.py:812
+#: src/olympia/editors/views.py:817
 msgid "needs more information"
 msgstr "ƞḗḗḓş ḿǿřḗ īƞƒǿřḿȧŧīǿƞ"
 
-#: src/olympia/editors/views.py:813
+#: src/olympia/editors/views.py:818
 msgid "needs super review"
 msgstr "ƞḗḗḓş şŭƥḗř řḗṽīḗẇ"
 
-#: src/olympia/editors/views.py:814
+#: src/olympia/editors/views.py:819
 msgid "commented"
 msgstr "ƈǿḿḿḗƞŧḗḓ"
 
@@ -8061,28 +7891,28 @@ msgstr "Ɋŭḗŭḗş"
 msgid "Unlisted Queues"
 msgstr "Ŭƞŀīşŧḗḓ Ɋŭḗŭḗş"
 
-#: src/olympia/editors/templates/editors/base.html:72 src/olympia/editors/templates/editors/performance.html:6
+#: src/olympia/editors/templates/editors/base.html:74 src/olympia/editors/templates/editors/performance.html:6
 msgid "Performance"
 msgstr "Ƥḗřƒǿřḿȧƞƈḗ"
 
-#: src/olympia/editors/templates/editors/base.html:75 src/olympia/editors/templates/editors/themes/base.html:19 src/olympia/editors/templates/editors/themes/base.html:38
+#: src/olympia/editors/templates/editors/base.html:77 src/olympia/editors/templates/editors/themes/base.html:19 src/olympia/editors/templates/editors/themes/base.html:38
 msgid "Logs"
 msgstr "Ŀǿɠş"
 
-#: src/olympia/editors/templates/editors/base.html:78 src/olympia/editors/templates/editors/reviewlog.html:4 src/olympia/editors/templates/editors/reviewlog.html:27
+#: src/olympia/editors/templates/editors/base.html:80 src/olympia/editors/templates/editors/reviewlog.html:4 src/olympia/editors/templates/editors/reviewlog.html:27
 msgid "Add-on Review Log"
 msgstr "Ȧḓḓ-ǿƞ Řḗṽīḗẇ Ŀǿɠ"
 
-#: src/olympia/editors/templates/editors/base.html:80 src/olympia/editors/templates/editors/eventlog.html:4 src/olympia/editors/templates/editors/eventlog.html:8
+#: src/olympia/editors/templates/editors/base.html:82 src/olympia/editors/templates/editors/eventlog.html:4 src/olympia/editors/templates/editors/eventlog.html:8
 #: src/olympia/editors/templates/editors/eventlog_detail.html:4
 msgid "Moderated Review Log"
 msgstr "Ḿǿḓḗřȧŧḗḓ Řḗṽīḗẇ Ŀǿɠ"
 
-#: src/olympia/editors/templates/editors/base.html:82 src/olympia/editors/templates/editors/beta_signed_log.html:4 src/olympia/editors/templates/editors/beta_signed_log.html:8
+#: src/olympia/editors/templates/editors/base.html:84 src/olympia/editors/templates/editors/beta_signed_log.html:4 src/olympia/editors/templates/editors/beta_signed_log.html:8
 msgid "Signed Beta Files Log"
 msgstr "Şīɠƞḗḓ Ɓḗŧȧ Ƒīŀḗş Ŀǿɠ"
 
-#: src/olympia/editors/templates/editors/base.html:87 src/olympia/editors/templates/editors/includes/daily-message.html:4
+#: src/olympia/editors/templates/editors/base.html:89 src/olympia/editors/templates/editors/includes/daily-message.html:4
 msgid "Announcement"
 msgstr "Ȧƞƞǿŭƞƈḗḿḗƞŧ"
 
@@ -8303,45 +8133,45 @@ msgstr "Ȧḓṽȧƞƈḗḓ Şḗȧřƈħ"
 msgid "clear search"
 msgstr "ƈŀḗȧř şḗȧřƈħ"
 
-#: src/olympia/editors/templates/editors/queue.html:72 src/olympia/editors/templates/editors/queue.html:122
+#: src/olympia/editors/templates/editors/queue.html:78 src/olympia/editors/templates/editors/queue.html:128
 msgid "Process Reviews"
 msgstr "Ƥřǿƈḗşş Řḗṽīḗẇş"
 
-#: src/olympia/editors/templates/editors/queue.html:80
+#: src/olympia/editors/templates/editors/queue.html:86
 msgid "Moderation actions:"
 msgstr "Ḿǿḓḗřȧŧīǿƞ ȧƈŧīǿƞş:"
 
-#: src/olympia/editors/templates/editors/queue.html:90
+#: src/olympia/editors/templates/editors/queue.html:96
 #, python-format
 msgid "by %(user)s on %(date)s %(stars)s (%(locale)s)"
 msgstr "ƀẏ %(user)s ǿƞ %(date)s %(stars)s (%(locale)s)"
 
-#: src/olympia/editors/templates/editors/queue.html:106
+#: src/olympia/editors/templates/editors/queue.html:112
 #, python-format
 msgid "<strong>%(reason)s</strong> <span class=\"light\">Flagged by %(user)s on %(date)s</span>"
 msgstr "<strong>%(reason)s</strong> <span class=\"light\">Ƒŀȧɠɠḗḓ ƀẏ %(user)s ǿƞ %(date)s</span>"
 
-#: src/olympia/editors/templates/editors/queue.html:119
-msgid "All reviews have been moderated.  Good work!"
+#: src/olympia/editors/templates/editors/queue.html:125
+msgid "All reviews have been moderated. Good work!"
 msgstr "Ȧŀŀ řḗṽīḗẇş ħȧṽḗ ƀḗḗƞ ḿǿḓḗřȧŧḗḓ.  Ɠǿǿḓ ẇǿřķ!"
 
-#: src/olympia/editors/templates/editors/queue.html:161
+#: src/olympia/editors/templates/editors/queue.html:167
 msgid "Version Notes / Notes for Reviewer"
 msgstr "Ṽḗřşīǿƞ Ƞǿŧḗş / Ƞǿŧḗş ƒǿř Řḗṽīḗẇḗř"
 
-#: src/olympia/editors/templates/editors/queue.html:169
+#: src/olympia/editors/templates/editors/queue.html:175
 msgid "There are currently no add-ons of this type to review."
 msgstr "Ŧħḗřḗ ȧřḗ ƈŭřřḗƞŧŀẏ ƞǿ ȧḓḓ-ǿƞş ǿƒ ŧħīş ŧẏƥḗ ŧǿ řḗṽīḗẇ."
 
-#: src/olympia/editors/templates/editors/queue.html:181 src/olympia/editors/templates/editors/themes/queue_list.html:85
+#: src/olympia/editors/templates/editors/queue.html:187 src/olympia/editors/templates/editors/themes/queue_list.html:85
 msgid "Helpful Links:"
 msgstr "Ħḗŀƥƒŭŀ Ŀīƞķş:"
 
-#: src/olympia/editors/templates/editors/queue.html:182
+#: src/olympia/editors/templates/editors/queue.html:188
 msgid "Add-on Policy"
 msgstr "Ȧḓḓ-ǿƞ Ƥǿŀīƈẏ"
 
-#: src/olympia/editors/templates/editors/queue.html:184
+#: src/olympia/editors/templates/editors/queue.html:190
 msgid "Editors' Guide"
 msgstr "Ḗḓīŧǿřş' Ɠŭīḓḗ"
 
@@ -8404,10 +8234,7 @@ msgid "<strong>Warning!</strong> Another user was viewing this page before you."
 msgstr "<strong>Ẇȧřƞīƞɠ!</strong> Ȧƞǿŧħḗř ŭşḗř ẇȧş ṽīḗẇīƞɠ ŧħīş ƥȧɠḗ ƀḗƒǿřḗ ẏǿŭ."
 
 #: src/olympia/editors/templates/editors/review.html:237
-msgid ""
-"The whiteboard is the place to exchange information relevant to\n"
-"               this addon (whatever the version), between the developer and the\n"
-"               editor. This is visible and editable by both."
+msgid "The whiteboard is the place to exchange information relevant to this addon (whatever the version), between the developer and the editor. This is visible and editable by both."
 msgstr ""
 "Ŧħḗ ẇħīŧḗƀǿȧřḓ īş ŧħḗ ƥŀȧƈḗ ŧǿ ḗẋƈħȧƞɠḗ īƞƒǿřḿȧŧīǿƞ řḗŀḗṽȧƞŧ ŧǿ\n"
 "               ŧħīş ȧḓḓǿƞ (ẇħȧŧḗṽḗř ŧħḗ ṽḗřşīǿƞ), ƀḗŧẇḗḗƞ ŧħḗ ḓḗṽḗŀǿƥḗř ȧƞḓ ŧħḗ\n"
@@ -8684,7 +8511,7 @@ msgstr "Ȧşķ ȧ ɋŭḗşŧīǿƞ ŧǿ ŧħḗ ȧřŧīşŧ"
 msgid "Describe your reason for flagging"
 msgstr "Ḓḗşƈřīƀḗ ẏǿŭř řḗȧşǿƞ ƒǿř ƒŀȧɠɠīƞɠ"
 
-#: src/olympia/files/forms.py:88
+#: src/olympia/files/forms.py:90
 msgid "Cannot diff a version against itself"
 msgstr "Ƈȧƞƞǿŧ ḓīƒƒ ȧ ṽḗřşīǿƞ ȧɠȧīƞşŧ īŧşḗŀƒ"
 
@@ -8719,51 +8546,51 @@ msgstr "Ŧħḗřḗ ẇȧş ȧƞ ḗřřǿř ȧƈƈḗşşīƞɠ ƒīŀḗ %s. 
 msgid "There was an error accessing file %s."
 msgstr "Ŧħḗřḗ ẇȧş ȧƞ ḗřřǿř ȧƈƈḗşşīƞɠ ƒīŀḗ %s."
 
-#: src/olympia/files/utils.py:343
+#: src/olympia/files/utils.py:340
 msgid "Could not parse uploaded file."
 msgstr "Ƈǿŭŀḓ ƞǿŧ ƥȧřşḗ ŭƥŀǿȧḓḗḓ ƒīŀḗ."
 
-#: src/olympia/files/utils.py:380
+#: src/olympia/files/utils.py:377
 msgid "Invalid file name in archive: {0}"
 msgstr "Īƞṽȧŀīḓ ƒīŀḗ ƞȧḿḗ īƞ ȧřƈħīṽḗ: {0}"
 
-#: src/olympia/files/utils.py:388
+#: src/olympia/files/utils.py:385
 msgid "File exceeding size limit in archive: {0}"
 msgstr "Ƒīŀḗ ḗẋƈḗḗḓīƞɠ şīzḗ ŀīḿīŧ īƞ ȧřƈħīṽḗ: {0}"
 
-#: src/olympia/files/utils.py:439
+#: src/olympia/files/utils.py:436
 msgid "Invalid archive."
 msgstr "Īƞṽȧŀīḓ ȧřƈħīṽḗ."
 
-#: src/olympia/files/utils.py:529 src/olympia/files/utils.py:532
+#: src/olympia/files/utils.py:526 src/olympia/files/utils.py:529
 msgid "Could not parse the manifest file."
 msgstr "Ƈǿŭŀḓ ƞǿŧ ƥȧřşḗ ŧħḗ ḿȧƞīƒḗşŧ ƒīŀḗ."
 
-#: src/olympia/files/utils.py:551
+#: src/olympia/files/utils.py:548
 msgid "Could not find an add-on ID."
 msgstr "Ƈǿŭŀḓ ƞǿŧ ƒīƞḓ ȧƞ ȧḓḓ-ǿƞ ĪḒ."
 
-#: src/olympia/files/utils.py:554
+#: src/olympia/files/utils.py:551
 msgid "Add-on ID must be 64 characters or less."
 msgstr "Ȧḓḓ-ǿƞ ĪḒ ḿŭşŧ ƀḗ 64 ƈħȧřȧƈŧḗřş ǿř ŀḗşş."
 
-#: src/olympia/files/utils.py:556
+#: src/olympia/files/utils.py:553
 msgid "Add-on ID doesn't match add-on."
 msgstr "Ȧḓḓ-ǿƞ ĪḒ ḓǿḗşƞ'ŧ ḿȧŧƈħ ȧḓḓ-ǿƞ."
 
-#: src/olympia/files/utils.py:564
+#: src/olympia/files/utils.py:561
 msgid "Duplicate add-on ID found."
 msgstr "Ḓŭƥŀīƈȧŧḗ ȧḓḓ-ǿƞ ĪḒ ƒǿŭƞḓ."
 
-#: src/olympia/files/utils.py:567
+#: src/olympia/files/utils.py:564
 msgid "Version numbers should have fewer than 32 characters."
 msgstr "Ṽḗřşīǿƞ ƞŭḿƀḗřş şħǿŭŀḓ ħȧṽḗ ƒḗẇḗř ŧħȧƞ 32 ƈħȧřȧƈŧḗřş."
 
-#: src/olympia/files/utils.py:570
+#: src/olympia/files/utils.py:567
 msgid "Version numbers should only contain letters, numbers, and these punctuation characters: +*.-_."
 msgstr "Ṽḗřşīǿƞ ƞŭḿƀḗřş şħǿŭŀḓ ǿƞŀẏ ƈǿƞŧȧīƞ ŀḗŧŧḗřş, ƞŭḿƀḗřş, ȧƞḓ ŧħḗşḗ ƥŭƞƈŧŭȧŧīǿƞ ƈħȧřȧƈŧḗřş: +*.-_."
 
-#: src/olympia/files/utils.py:587
+#: src/olympia/files/utils.py:584
 msgid "<em:type> doesn't match add-on"
 msgstr "<em:type> ḓǿḗşƞ'ŧ ḿȧŧƈħ ȧḓḓ-ǿƞ"
 
@@ -8863,6 +8690,10 @@ msgstr "Ƞǿ ƒīŀḗş īƞ ŧħḗ ŭƥŀǿȧḓḗḓ ƒīŀḗ."
 #: src/olympia/files/templates/files/viewer.html:134
 msgid "Fetching file."
 msgstr "Ƒḗŧƈħīƞɠ ƒīŀḗ."
+
+#: src/olympia/legacy_api/views.py:255
+msgid "Not implemented yet."
+msgstr "Ƞǿŧ īḿƥŀḗḿḗƞŧḗḓ ẏḗŧ."
 
 #: src/olympia/lib/constants.py:6
 msgid "United Arab Emirates Dirham"
@@ -9520,10 +9351,6 @@ msgstr "Ẑȧḿƀīȧ Ķẇȧƈħȧ"
 msgid "Zimbabwe Dollar"
 msgstr "Ẑīḿƀȧƀẇḗ Ḓǿŀŀȧř"
 
-#: src/olympia/lib/video/ffmpeg.py:112 src/olympia/lib/video/totem.py:81
-msgid "Videos must be in WebM."
-msgstr "Ṽīḓḗǿş ḿŭşŧ ƀḗ īƞ ẆḗƀḾ."
-
 #: src/olympia/pages/templates/pages/about.lhtml:3 src/olympia/pages/templates/pages/about.lhtml:10
 msgid "About Mozilla Add-ons"
 msgstr "Ȧƀǿŭŧ Ḿǿzīŀŀȧ Ȧḓḓ-ǿƞş"
@@ -9535,7 +9362,7 @@ msgstr "Ẇħȧŧ īş ŧħīş ẇḗƀşīŧḗ?"
 #: src/olympia/pages/templates/pages/about.lhtml:13
 msgid ""
 "addons.mozilla.org, commonly known as \"AMO\", is Mozilla's official site for add-ons to Mozilla software, such as Firefox, Thunderbird, and SeaMonkey. Add-ons let you add new features and change "
-"the way your browser or application works.  Take a look around and explore the thousands of ways to customize the way you do things online."
+"the way your browser or application works. Take a look around and explore the thousands of ways to customize the way you do things online."
 msgstr ""
 "ȧḓḓǿƞş.ḿǿzīŀŀȧ.ǿřɠ, ƈǿḿḿǿƞŀẏ ķƞǿẇƞ ȧş \"ȦḾǾ\", īş Ḿǿzīŀŀȧ'ş ǿƒƒīƈīȧŀ şīŧḗ ƒǿř ȧḓḓ-ǿƞş ŧǿ Ḿǿzīŀŀȧ şǿƒŧẇȧřḗ, şŭƈħ ȧş Ƒīřḗƒǿẋ, Ŧħŭƞḓḗřƀīřḓ, ȧƞḓ ŞḗȧḾǿƞķḗẏ. Ȧḓḓ-ǿƞş ŀḗŧ ẏǿŭ ȧḓḓ ƞḗẇ ƒḗȧŧŭřḗş ȧƞḓ ƈħȧƞɠḗ "
 "ŧħḗ ẇȧẏ ẏǿŭř ƀřǿẇşḗř ǿř ȧƥƥŀīƈȧŧīǿƞ ẇǿřķş.  Ŧȧķḗ ȧ ŀǿǿķ ȧřǿŭƞḓ ȧƞḓ ḗẋƥŀǿřḗ ŧħḗ ŧħǿŭşȧƞḓş ǿƒ ẇȧẏş ŧǿ ƈŭşŧǿḿīzḗ ŧħḗ ẇȧẏ ẏǿŭ ḓǿ ŧħīƞɠş ǿƞŀīƞḗ."
@@ -9914,7 +9741,7 @@ msgstr "Ƈȧƞ Ī ŭşḗ ȧ ĴȧṽȧŞƈřīƥŧ ŀīƀřȧřẏ ŀīķḗ ĵ�
 msgid ""
 "Yes. It's possible, but some of the functionality provided by these libraries are available through XPCOM, XUL, and JavaScript. In addition, authors should take care if libraries modify primitive "
 "object prototypes (String.prototype, Date.prototype, etc.) and/or define global functions (eg. the $ function). These are prone to cause conflict with other add-ons, in particular if different add-"
-"ons use different versions of libraries and so on. Developers need to be very, very careful with using them.  Mozilla does not offer documentation on using them to build add-ons."
+"ons use different versions of libraries and so on. Developers need to be very, very careful with using them. Mozilla does not offer documentation on using them to build add-ons."
 msgstr ""
 "Ẏḗş. Īŧ'ş ƥǿşşīƀŀḗ, ƀŭŧ şǿḿḗ ǿƒ ŧħḗ ƒŭƞƈŧīǿƞȧŀīŧẏ ƥřǿṽīḓḗḓ ƀẏ ŧħḗşḗ ŀīƀřȧřīḗş ȧřḗ ȧṽȧīŀȧƀŀḗ ŧħřǿŭɠħ ẊƤƇǾḾ, ẊŬĿ, ȧƞḓ ĴȧṽȧŞƈřīƥŧ. Īƞ ȧḓḓīŧīǿƞ, ȧŭŧħǿřş şħǿŭŀḓ ŧȧķḗ ƈȧřḗ īƒ ŀīƀřȧřīḗş ḿǿḓīƒẏ ƥřīḿīŧīṽḗ "
 "ǿƀĵḗƈŧ ƥřǿŧǿŧẏƥḗş (Şŧřīƞɠ.ƥřǿŧǿŧẏƥḗ, Ḓȧŧḗ.ƥřǿŧǿŧẏƥḗ, ḗŧƈ.) ȧƞḓ/ǿř ḓḗƒīƞḗ ɠŀǿƀȧŀ ƒŭƞƈŧīǿƞş (ḗɠ. ŧħḗ $ ƒŭƞƈŧīǿƞ). Ŧħḗşḗ ȧřḗ ƥřǿƞḗ ŧǿ ƈȧŭşḗ ƈǿƞƒŀīƈŧ ẇīŧħ ǿŧħḗř ȧḓḓ-ǿƞş, īƞ ƥȧřŧīƈŭŀȧř īƒ ḓīƒƒḗřḗƞŧ ȧḓḓ-"
@@ -10040,8 +9867,8 @@ msgstr "Ƈȧƞ Ī ħǿşŧ ḿẏ ǿẇƞ ȧḓḓ-ǿƞ?"
 #, python-format
 msgid ""
 "Yes. Many developers choose to host their own add-ons. Choosing to host your add-on on <a href=\"%(amo_url)s\">Mozilla's add-on site</a>, though, allows for much greater exposure to your add-on due "
-"to the large volume of visitors to the site.  <a href=\"%(md_url)s\">mozdev.org</a> offers free project hosting for Mozilla applications and extensions providing developers with tools to help "
-"manage source code, version control, bug tracking and documentation."
+"to the large volume of visitors to the site. <a href=\"%(md_url)s\">mozdev.org</a> offers free project hosting for Mozilla applications and extensions providing developers with tools to help manage "
+"source code, version control, bug tracking and documentation."
 msgstr ""
 "Ẏḗş. Ḿȧƞẏ ḓḗṽḗŀǿƥḗřş ƈħǿǿşḗ ŧǿ ħǿşŧ ŧħḗīř ǿẇƞ ȧḓḓ-ǿƞş. Ƈħǿǿşīƞɠ ŧǿ ħǿşŧ ẏǿŭř ȧḓḓ-ǿƞ ǿƞ <a href=\"%(amo_url)s\">Ḿǿzīŀŀȧ'ş ȧḓḓ-ǿƞ şīŧḗ</a>, ŧħǿŭɠħ, ȧŀŀǿẇş ƒǿř ḿŭƈħ ɠřḗȧŧḗř ḗẋƥǿşŭřḗ ŧǿ ẏǿŭř ȧḓḓ-ǿƞ ḓŭḗ "
 "ŧǿ ŧħḗ ŀȧřɠḗ ṽǿŀŭḿḗ ǿƒ ṽīşīŧǿřş ŧǿ ŧħḗ şīŧḗ.  <a href=\"%(md_url)s\">ḿǿzḓḗṽ.ǿřɠ</a> ǿƒƒḗřş ƒřḗḗ ƥřǿĵḗƈŧ ħǿşŧīƞɠ ƒǿř Ḿǿzīŀŀȧ ȧƥƥŀīƈȧŧīǿƞş ȧƞḓ ḗẋŧḗƞşīǿƞş ƥřǿṽīḓīƞɠ ḓḗṽḗŀǿƥḗřş ẇīŧħ ŧǿǿŀş ŧǿ ħḗŀƥ "
@@ -10096,7 +9923,7 @@ msgstr "Ḓǿḗş Ḿǿzīŀŀȧ ħȧṽḗ ȧ ƥǿŀīƈẏ īƞ ƥŀȧƈḗ �
 #: src/olympia/pages/templates/pages/dev_faq.html:314
 #, python-format
 msgid ""
-"Yes. Mozilla's <a href=\"%(p_url)s\">Add-on Policy</a> describes what is an acceptable submission. This policy is subject to change without notice.  In addition, the AMO editorial team uses the <a "
+"Yes. Mozilla's <a href=\"%(p_url)s\">Add-on Policy</a> describes what is an acceptable submission. This policy is subject to change without notice. In addition, the AMO editorial team uses the <a "
 "href=\"%(g_url)s\">Editors Reviewing Guide</a> to ensure that your add-on meets specific guidelines for functionality and security."
 msgstr ""
 "Ẏḗş. Ḿǿzīŀŀȧ'ş <a href=\"%(p_url)s\">Ȧḓḓ-ǿƞ Ƥǿŀīƈẏ</a> ḓḗşƈřīƀḗş ẇħȧŧ īş ȧƞ ȧƈƈḗƥŧȧƀŀḗ şŭƀḿīşşīǿƞ. Ŧħīş ƥǿŀīƈẏ īş şŭƀĵḗƈŧ ŧǿ ƈħȧƞɠḗ ẇīŧħǿŭŧ ƞǿŧīƈḗ.  Īƞ ȧḓḓīŧīǿƞ, ŧħḗ ȦḾǾ ḗḓīŧǿřīȧŀ ŧḗȧḿ ŭşḗş ŧħḗ <a "
@@ -10226,7 +10053,7 @@ msgstr "ƞŭḿƀḗř ǿƒ ƥřǿƀŀḗḿ ȧřḗȧş ḓīşƈǿṽḗřḗ�
 #: src/olympia/pages/templates/pages/dev_faq.html:434
 #, python-format
 msgid ""
-"This is why it's very important to read the <a href=\"%(g_url)s\">Editors Reviewing Guide</a> to ensure that your add-on is setup as expected.  It's also a good idea to read the blog post, <a href="
+"This is why it's very important to read the <a href=\"%(g_url)s\">Editors Reviewing Guide</a> to ensure that your add-on is setup as expected. It's also a good idea to read the blog post, <a href="
 "\"%(blog_url)s\">Successfully Getting your Add-on Reviewed</a> which provides excellent insight into ensuring a smooth review of your add-on."
 msgstr ""
 "Ŧħīş īş ẇħẏ īŧ'ş ṽḗřẏ īḿƥǿřŧȧƞŧ ŧǿ řḗȧḓ ŧħḗ <a href=\"%(g_url)s\">Ḗḓīŧǿřş Řḗṽīḗẇīƞɠ Ɠŭīḓḗ</a> ŧǿ ḗƞşŭřḗ ŧħȧŧ ẏǿŭř ȧḓḓ-ǿƞ īş şḗŧŭƥ ȧş ḗẋƥḗƈŧḗḓ.  Īŧ'ş ȧŀşǿ ȧ ɠǿǿḓ īḓḗȧ ŧǿ řḗȧḓ ŧħḗ ƀŀǿɠ ƥǿşŧ, <a href="
@@ -10344,7 +10171,7 @@ msgstr "Ȧ ŧȧƀŀḗ şŭḿḿȧřīzīƞɠ ȧƞḓ ƈǿḿƥȧřīƞɠ ħǿ�
 
 #: src/olympia/pages/templates/pages/dev_faq.html:572
 msgid ""
-"Free Software Foundation provides short summaries of the key open source licenses, including whether the license qualifies as a free software license or a copyleft license.  Also includes a "
+"Free Software Foundation provides short summaries of the key open source licenses, including whether the license qualifies as a free software license or a copyleft license. Also includes a "
 "discussion of what constitutes a free software license or a copyleft license (e.g., a Copyleft license is a general method for making a program or other work free, and requiring all modified and "
 "extended versions of the program to be free as well.)"
 msgstr ""
@@ -10551,21 +10378,15 @@ msgid "Add-on Gallery"
 msgstr "Ȧḓḓ-ǿƞ Ɠȧŀŀḗřẏ"
 
 #: src/olympia/pages/templates/pages/faq.html:171
-msgid ""
-"How do I choose between add-ons that seem to do the same\n"
-"    thing?"
+msgid "How do I choose between add-ons that seem to do the same thing?"
 msgstr ""
 "Ħǿẇ ḓǿ Ī ƈħǿǿşḗ ƀḗŧẇḗḗƞ ȧḓḓ-ǿƞş ŧħȧŧ şḗḗḿ ŧǿ ḓǿ ŧħḗ şȧḿḗ\n"
 "    ŧħīƞɠ?"
 
-#: src/olympia/pages/templates/pages/faq.html:173
+#: src/olympia/pages/templates/pages/faq.html:172
 msgid ""
-"There are often several add-ons that have similar features. To\n"
-"    figure out which is right for you, read the entire description of the\n"
-"    add-on and view its screenshots. If there are still several in the running,\n"
-"    read through the add-on's ratings, user reviews, and statistics to see\n"
-"    which is most liked by other users. Remember that you can also just try\n"
-"    out both and see which you like better."
+"There are often several add-ons that have similar features. To figure out which is right for you, read the entire description of the add-on and view its screenshots. If there are still several in "
+"the running, read through the add-on's ratings, user reviews, and statistics to see which is most liked by other users. Remember that you can also just try out both and see which you like better."
 msgstr ""
 "Ŧħḗřḗ ȧřḗ ǿƒŧḗƞ şḗṽḗřȧŀ ȧḓḓ-ǿƞş ŧħȧŧ ħȧṽḗ şīḿīŀȧř ƒḗȧŧŭřḗş. Ŧǿ\n"
 "    ƒīɠŭřḗ ǿŭŧ ẇħīƈħ īş řīɠħŧ ƒǿř ẏǿŭ, řḗȧḓ ŧħḗ ḗƞŧīřḗ ḓḗşƈřīƥŧīǿƞ ǿƒ ŧħḗ\n"
@@ -10618,46 +10439,40 @@ msgid "How much do add-ons cost to purchase?"
 msgstr "Ħǿẇ ḿŭƈħ ḓǿ ȧḓḓ-ǿƞş ƈǿşŧ ŧǿ ƥŭřƈħȧşḗ?"
 
 #: src/olympia/pages/templates/pages/faq.html:207
-msgid ""
-"Add-ons hosted in our gallery are free unless clearly marked\n"
-"    otherwise."
+msgid "Add-ons hosted in our gallery are free unless clearly marked otherwise."
 msgstr ""
 "Ȧḓḓ-ǿƞş ħǿşŧḗḓ īƞ ǿŭř ɠȧŀŀḗřẏ ȧřḗ ƒřḗḗ ŭƞŀḗşş ƈŀḗȧřŀẏ ḿȧřķḗḓ\n"
 "    ǿŧħḗřẇīşḗ."
 
-#: src/olympia/pages/templates/pages/faq.html:210
+#: src/olympia/pages/templates/pages/faq.html:209
 msgid "What does it mean when an add-on asks for contributions?"
 msgstr "Ẇħȧŧ ḓǿḗş īŧ ḿḗȧƞ ẇħḗƞ ȧƞ ȧḓḓ-ǿƞ ȧşķş ƒǿř ƈǿƞŧřīƀŭŧīǿƞş?"
 
-#: src/olympia/pages/templates/pages/faq.html:211
+#: src/olympia/pages/templates/pages/faq.html:210
 msgid ""
-"Some add-on authors request users who enjoy an add-on to\n"
-"        contribute to its development by making a monetary contribution. These\n"
-"        contributions go directly to the developer unless a third party is\n"
-"        indicated, such as the non-profit Mozilla Foundation."
+"Some add-on authors request users who enjoy an add-on to contribute to its development by making a monetary contribution. These contributions go directly to the developer unless a third party is "
+"indicated, such as the non-profit Mozilla Foundation."
 msgstr ""
 "Şǿḿḗ ȧḓḓ-ǿƞ ȧŭŧħǿřş řḗɋŭḗşŧ ŭşḗřş ẇħǿ ḗƞĵǿẏ ȧƞ ȧḓḓ-ǿƞ ŧǿ\n"
 "        ƈǿƞŧřīƀŭŧḗ ŧǿ īŧş ḓḗṽḗŀǿƥḿḗƞŧ ƀẏ ḿȧķīƞɠ ȧ ḿǿƞḗŧȧřẏ ƈǿƞŧřīƀŭŧīǿƞ. Ŧħḗşḗ\n"
 "        ƈǿƞŧřīƀŭŧīǿƞş ɠǿ ḓīřḗƈŧŀẏ ŧǿ ŧħḗ ḓḗṽḗŀǿƥḗř ŭƞŀḗşş ȧ ŧħīřḓ ƥȧřŧẏ īş\n"
 "        īƞḓīƈȧŧḗḓ, şŭƈħ ȧş ŧħḗ ƞǿƞ-ƥřǿƒīŧ Ḿǿzīŀŀȧ Ƒǿŭƞḓȧŧīǿƞ."
 
-#: src/olympia/pages/templates/pages/faq.html:216
+#: src/olympia/pages/templates/pages/faq.html:215
 msgid "What are beta add-ons?"
 msgstr "Ẇħȧŧ ȧřḗ ƀḗŧȧ ȧḓḓ-ǿƞş?"
 
-#: src/olympia/pages/templates/pages/faq.html:218
+#: src/olympia/pages/templates/pages/faq.html:217
 msgid ""
-"Beta add-ons are unreviewed versions which represent the\n"
-"        latest work of an add-on author. While different authors have different\n"
-"        standards for beta code quality, you should assume that these add-ons\n"
-"        are less stable than the general add-on releases."
+"Beta add-ons are unreviewed versions which represent the latest work of an add-on author. While different authors have different standards for beta code quality, you should assume that these add-"
+"ons are less stable than the general add-on releases."
 msgstr ""
 "Ɓḗŧȧ ȧḓḓ-ǿƞş ȧřḗ ŭƞřḗṽīḗẇḗḓ ṽḗřşīǿƞş ẇħīƈħ řḗƥřḗşḗƞŧ ŧħḗ\n"
 "        ŀȧŧḗşŧ ẇǿřķ ǿƒ ȧƞ ȧḓḓ-ǿƞ ȧŭŧħǿř. Ẇħīŀḗ ḓīƒƒḗřḗƞŧ ȧŭŧħǿřş ħȧṽḗ ḓīƒƒḗřḗƞŧ\n"
 "        şŧȧƞḓȧřḓş ƒǿř ƀḗŧȧ ƈǿḓḗ ɋŭȧŀīŧẏ, ẏǿŭ şħǿŭŀḓ ȧşşŭḿḗ ŧħȧŧ ŧħḗşḗ ȧḓḓ-ǿƞş\n"
 "        ȧřḗ ŀḗşş şŧȧƀŀḗ ŧħȧƞ ŧħḗ ɠḗƞḗřȧŀ ȧḓḓ-ǿƞ řḗŀḗȧşḗş."
 
-#: src/olympia/pages/templates/pages/faq.html:222
+#: src/olympia/pages/templates/pages/faq.html:221
 msgid ""
 "Please note that when you install an add-on from the \"Beta Version\" section of an add-on's listing, you will continue to receive updates for that add-on as they become available. Like the initial "
 "version you installed, all beta releases are unreviewed by Mozilla and may harm your computer."
@@ -10665,54 +10480,47 @@ msgstr ""
 "Ƥŀḗȧşḗ ƞǿŧḗ ŧħȧŧ ẇħḗƞ ẏǿŭ īƞşŧȧŀŀ ȧƞ ȧḓḓ-ǿƞ ƒřǿḿ ŧħḗ \"Ɓḗŧȧ Ṽḗřşīǿƞ\" şḗƈŧīǿƞ ǿƒ ȧƞ ȧḓḓ-ǿƞ'ş ŀīşŧīƞɠ, ẏǿŭ ẇīŀŀ ƈǿƞŧīƞŭḗ ŧǿ řḗƈḗīṽḗ ŭƥḓȧŧḗş ƒǿř ŧħȧŧ ȧḓḓ-ǿƞ ȧş ŧħḗẏ ƀḗƈǿḿḗ ȧṽȧīŀȧƀŀḗ. Ŀīķḗ ŧħḗ īƞīŧīȧŀ "
 "ṽḗřşīǿƞ ẏǿŭ īƞşŧȧŀŀḗḓ, ȧŀŀ ƀḗŧȧ řḗŀḗȧşḗş ȧřḗ ŭƞřḗṽīḗẇḗḓ ƀẏ Ḿǿzīŀŀȧ ȧƞḓ ḿȧẏ ħȧřḿ ẏǿŭř ƈǿḿƥŭŧḗř."
 
-#: src/olympia/pages/templates/pages/faq.html:229
-msgid ""
-"What does it mean when an add-on is flagged as\n"
-"    slow?"
+#: src/olympia/pages/templates/pages/faq.html:228
+msgid "What does it mean when an add-on is flagged as slow?"
 msgstr ""
 "Ẇħȧŧ ḓǿḗş īŧ ḿḗȧƞ ẇħḗƞ ȧƞ ȧḓḓ-ǿƞ īş ƒŀȧɠɠḗḓ ȧş\n"
 "    şŀǿẇ?"
 
-#: src/olympia/pages/templates/pages/faq.html:231
-msgid ""
-"Most add-ons load code and resources at the same time Firefox\n"
-"        is starting up. In most cases the impact in start-up time is minimal,\n"
-"        but some add-ons can cause a noticeable slowdown."
+#: src/olympia/pages/templates/pages/faq.html:229
+msgid "Most add-ons load code and resources at the same time Firefox is starting up. In most cases the impact in start-up time is minimal, but some add-ons can cause a noticeable slowdown."
 msgstr ""
 "Ḿǿşŧ ȧḓḓ-ǿƞş ŀǿȧḓ ƈǿḓḗ ȧƞḓ řḗşǿŭřƈḗş ȧŧ ŧħḗ şȧḿḗ ŧīḿḗ Ƒīřḗƒǿẋ\n"
 "        īş şŧȧřŧīƞɠ ŭƥ. Īƞ ḿǿşŧ ƈȧşḗş ŧħḗ īḿƥȧƈŧ īƞ şŧȧřŧ-ŭƥ ŧīḿḗ īş ḿīƞīḿȧŀ,\n"
 "        ƀŭŧ şǿḿḗ ȧḓḓ-ǿƞş ƈȧƞ ƈȧŭşḗ ȧ ƞǿŧīƈḗȧƀŀḗ şŀǿẇḓǿẇƞ."
 
-#: src/olympia/pages/templates/pages/faq.html:236
+#: src/olympia/pages/templates/pages/faq.html:234
 msgid "How do I report an inappropriate or spam user review?"
 msgstr "Ħǿẇ ḓǿ Ī řḗƥǿřŧ ȧƞ īƞȧƥƥřǿƥřīȧŧḗ ǿř şƥȧḿ ŭşḗř řḗṽīḗẇ?"
 
-#: src/olympia/pages/templates/pages/faq.html:237
+#: src/olympia/pages/templates/pages/faq.html:235
 msgid ""
-"To report a user review of an add-on, log in with your account\n"
-"    and visit the add-on's reviews page. Find the review you wish to report,\n"
-"    click \"Report this review\" and select a reason. Our editorial team will\n"
-"    investigate the review and take appropriate action."
+"To report a user review of an add-on, log in with your account and visit the add-on's reviews page. Find the review you wish to report, click \"Report this review\" and select a reason. Our "
+"editorial team will investigate the review and take appropriate action."
 msgstr ""
 "Ŧǿ řḗƥǿřŧ ȧ ŭşḗř řḗṽīḗẇ ǿƒ ȧƞ ȧḓḓ-ǿƞ, ŀǿɠ īƞ ẇīŧħ ẏǿŭř ȧƈƈǿŭƞŧ\n"
 "    ȧƞḓ ṽīşīŧ ŧħḗ ȧḓḓ-ǿƞ'ş řḗṽīḗẇş ƥȧɠḗ. Ƒīƞḓ ŧħḗ řḗṽīḗẇ ẏǿŭ ẇīşħ ŧǿ řḗƥǿřŧ,\n"
 "    ƈŀīƈķ \"Řḗƥǿřŧ ŧħīş řḗṽīḗẇ\" ȧƞḓ şḗŀḗƈŧ ȧ řḗȧşǿƞ. Ǿŭř ḗḓīŧǿřīȧŀ ŧḗȧḿ ẇīŀŀ\n"
 "    īƞṽḗşŧīɠȧŧḗ ŧħḗ řḗṽīḗẇ ȧƞḓ ŧȧķḗ ȧƥƥřǿƥřīȧŧḗ ȧƈŧīǿƞ."
 
-#: src/olympia/pages/templates/pages/faq.html:242
+#: src/olympia/pages/templates/pages/faq.html:240
 msgid "How do I report a bug or contact the Mozilla Add-ons team?"
 msgstr "Ħǿẇ ḓǿ Ī řḗƥǿřŧ ȧ ƀŭɠ ǿř ƈǿƞŧȧƈŧ ŧħḗ Ḿǿzīŀŀȧ Ȧḓḓ-ǿƞş ŧḗȧḿ?"
 
-#: src/olympia/pages/templates/pages/faq.html:243
+#: src/olympia/pages/templates/pages/faq.html:241
 #, python-format
 msgid "Please visit our <a href=\"%(contact_url)s\">Contact page</a>."
 msgstr "Ƥŀḗȧşḗ ṽīşīŧ ǿŭř <a href=\"%(contact_url)s\">Ƈǿƞŧȧƈŧ ƥȧɠḗ</a>."
 
-#: src/olympia/pages/templates/pages/faq.html:246
+#: src/olympia/pages/templates/pages/faq.html:244
 msgid "What is a Source Code License?"
 msgstr "Ẇħȧŧ īş ȧ Şǿŭřƈḗ Ƈǿḓḗ Ŀīƈḗƞşḗ?"
 
-#: src/olympia/pages/templates/pages/faq.html:247
+#: src/olympia/pages/templates/pages/faq.html:245
 #, python-format
 msgid ""
 "The source code used to create an add-on is an exclusive copyright of the add-on author, unless otherwise declared in a source code license. Many add-ons on this site have <a href=\"%(url)s\" lang="
@@ -10723,40 +10531,40 @@ msgstr ""
 "\"en\">ǿƥḗƞ şǿŭřƈḗ ŀīƈḗƞşḗş</a> ŧħȧŧ ḿȧķḗ ŧħḗ şǿŭřƈḗ ƈǿḓḗ ƥŭƀŀīƈŀẏ ȧṽȧīŀȧƀŀḗ ƒǿř ƈǿƥẏ ȧƞḓ řḗŭşḗ ŭƞḓḗř ƈǿƞḓīŧīǿƞş ḓḗŧḗřḿīƞḗḓ ƀẏ ŧħḗ ȧŭŧħǿř. Ḿǿşŧ ȧŭŧħǿřş ƈħǿǿşḗ ẇīḓḗŀẏ ķƞǿẇƞ ǿƥḗƞ şǿŭřƈḗ ŀīƈḗƞşḗş ŀīķḗ "
 "ŧħḗ ƓƤĿ ǿř ƁŞḒ ŀīƈḗƞşḗş īƞşŧḗȧḓ ǿƒ ḿȧķīƞɠ ŭƥ ŧħḗīř ǿẇƞ."
 
-#: src/olympia/pages/templates/pages/faq.html:256
+#: src/olympia/pages/templates/pages/faq.html:254
 #, python-format
 msgid "Firefox and other Mozilla software are <a href=\"%(url)s\">open source</a>."
 msgstr "Ƒīřḗƒǿẋ ȧƞḓ ǿŧħḗř Ḿǿzīŀŀȧ şǿƒŧẇȧřḗ ȧřḗ <a href=\"%(url)s\">ǿƥḗƞ şǿŭřƈḗ</a>."
 
-#: src/olympia/pages/templates/pages/faq.html:264
+#: src/olympia/pages/templates/pages/faq.html:262
 msgid "Collections and Favorites"
 msgstr "Ƈǿŀŀḗƈŧīǿƞş ȧƞḓ Ƒȧṽǿřīŧḗş"
 
-#: src/olympia/pages/templates/pages/faq.html:267
+#: src/olympia/pages/templates/pages/faq.html:265
 msgid "What is a collection?"
 msgstr "Ẇħȧŧ īş ȧ ƈǿŀŀḗƈŧīǿƞ?"
 
-#: src/olympia/pages/templates/pages/faq.html:268
+#: src/olympia/pages/templates/pages/faq.html:266
 msgid "Collections are groups of related add-ons created by users to share."
 msgstr "Ƈǿŀŀḗƈŧīǿƞş ȧřḗ ɠřǿŭƥş ǿƒ řḗŀȧŧḗḓ ȧḓḓ-ǿƞş ƈřḗȧŧḗḓ ƀẏ ŭşḗřş ŧǿ şħȧřḗ."
 
-#: src/olympia/pages/templates/pages/faq.html:270
+#: src/olympia/pages/templates/pages/faq.html:268
 msgid "What is the My Favorites collection?"
 msgstr "Ẇħȧŧ īş ŧħḗ Ḿẏ Ƒȧṽǿřīŧḗş ƈǿŀŀḗƈŧīǿƞ?"
 
-#: src/olympia/pages/templates/pages/faq.html:271
+#: src/olympia/pages/templates/pages/faq.html:269
 msgid "Favorite add-ons are add-ons that you have bookmarked to easily get back to later. You can add an add-on to your favorites collection by clicking \"Add to favorites\" on its details page."
 msgstr "Ƒȧṽǿřīŧḗ ȧḓḓ-ǿƞş ȧřḗ ȧḓḓ-ǿƞş ŧħȧŧ ẏǿŭ ħȧṽḗ ƀǿǿķḿȧřķḗḓ ŧǿ ḗȧşīŀẏ ɠḗŧ ƀȧƈķ ŧǿ ŀȧŧḗř. Ẏǿŭ ƈȧƞ ȧḓḓ ȧƞ ȧḓḓ-ǿƞ ŧǿ ẏǿŭř ƒȧṽǿřīŧḗş ƈǿŀŀḗƈŧīǿƞ ƀẏ ƈŀīƈķīƞɠ \"Ȧḓḓ ŧǿ ƒȧṽǿřīŧḗş\" ǿƞ īŧş ḓḗŧȧīŀş ƥȧɠḗ."
 
-#: src/olympia/pages/templates/pages/faq.html:275 src/olympia/templates/menu_links.html:13 src/olympia/templates/impala/header_title.html:17
+#: src/olympia/pages/templates/pages/faq.html:273 src/olympia/templates/menu_links.html:13 src/olympia/templates/impala/header_title.html:17
 msgid "Mobile Add-ons"
 msgstr "Ḿǿƀīŀḗ Ȧḓḓ-ǿƞş"
 
-#: src/olympia/pages/templates/pages/faq.html:278
+#: src/olympia/pages/templates/pages/faq.html:276
 msgid "What are mobile add-ons?"
 msgstr "Ẇħȧŧ ȧřḗ ḿǿƀīŀḗ ȧḓḓ-ǿƞş?"
 
-#: src/olympia/pages/templates/pages/faq.html:279
+#: src/olympia/pages/templates/pages/faq.html:277
 #, python-format
 msgid ""
 "Mobile add-ons work with <a href=\"%(mobile_url)s\">Firefox for Mobile</a> and add or modify functionality just like desktop add-ons. You can find add-ons that work with Firefox for Mobile in our "
@@ -10765,20 +10573,20 @@ msgstr ""
 "Ḿǿƀīŀḗ ȧḓḓ-ǿƞş ẇǿřķ ẇīŧħ <a href=\"%(mobile_url)s\">Ƒīřḗƒǿẋ ƒǿř Ḿǿƀīŀḗ</a> ȧƞḓ ȧḓḓ ǿř ḿǿḓīƒẏ ƒŭƞƈŧīǿƞȧŀīŧẏ ĵŭşŧ ŀīķḗ ḓḗşķŧǿƥ ȧḓḓ-ǿƞş. Ẏǿŭ ƈȧƞ ƒīƞḓ ȧḓḓ-ǿƞş ŧħȧŧ ẇǿřķ ẇīŧħ Ƒīřḗƒǿẋ ƒǿř Ḿǿƀīŀḗ īƞ ǿŭř "
 "<a href=\"%(gallery_url)s\">ɠȧŀŀḗřẏ</a>."
 
-#: src/olympia/pages/templates/pages/faq.html:288
+#: src/olympia/pages/templates/pages/faq.html:286
 msgid "Developer Topics"
 msgstr "Ḓḗṽḗŀǿƥḗř Ŧǿƥīƈş"
 
-#: src/olympia/pages/templates/pages/faq.html:289
+#: src/olympia/pages/templates/pages/faq.html:287
 #, python-format
 msgid "Please see our <a href=\"%(faq_url)s\">Developer FAQ</a> and <a href=\"%(hub_url)s\">Developer Hub</a> for answers to add-on developer-related questions."
 msgstr "Ƥŀḗȧşḗ şḗḗ ǿŭř <a href=\"%(faq_url)s\">Ḓḗṽḗŀǿƥḗř ƑȦɊ</a> ȧƞḓ <a href=\"%(hub_url)s\">Ḓḗṽḗŀǿƥḗř Ħŭƀ</a> ƒǿř ȧƞşẇḗřş ŧǿ ȧḓḓ-ǿƞ ḓḗṽḗŀǿƥḗř-řḗŀȧŧḗḓ ɋŭḗşŧīǿƞş."
 
-#: src/olympia/pages/templates/pages/faq.html:294
+#: src/olympia/pages/templates/pages/faq.html:292
 msgid "Still have questions?"
 msgstr "Şŧīŀŀ ħȧṽḗ ɋŭḗşŧīǿƞş?"
 
-#: src/olympia/pages/templates/pages/faq.html:295
+#: src/olympia/pages/templates/pages/faq.html:293
 #, python-format
 msgid "For general Firefox support, visit our <a href=\"%(sumo_url)s\">support website</a>. For general add-on and website questions, visit our <a href=\"%(forum_url)s\">forum</a>."
 msgstr "Ƒǿř ɠḗƞḗřȧŀ Ƒīřḗƒǿẋ şŭƥƥǿřŧ, ṽīşīŧ ǿŭř <a href=\"%(sumo_url)s\">şŭƥƥǿřŧ ẇḗƀşīŧḗ</a>. Ƒǿř ɠḗƞḗřȧŀ ȧḓḓ-ǿƞ ȧƞḓ ẇḗƀşīŧḗ ɋŭḗşŧīǿƞş, ṽīşīŧ ǿŭř <a href=\"%(forum_url)s\">ƒǿřŭḿ</a>."
@@ -10926,7 +10734,7 @@ msgstr "Şŭƞƀīřḓ ħȧş řḗŧīřḗḓ"
 
 #: src/olympia/pages/templates/pages/sunbird.html:29
 msgid ""
-"Development on the Sunbird project has halted and its final release was on March 30, 2010.  We've been proud to host Sunbird add-ons on this site but as the project is no longer maintained we have "
+"Development on the Sunbird project has halted and its final release was on March 30, 2010. We've been proud to host Sunbird add-ons on this site but as the project is no longer maintained we have "
 "disabled our support for the add-ons."
 msgstr ""
 "Ḓḗṽḗŀǿƥḿḗƞŧ ǿƞ ŧħḗ Şŭƞƀīřḓ ƥřǿĵḗƈŧ ħȧş ħȧŀŧḗḓ ȧƞḓ īŧş ƒīƞȧŀ řḗŀḗȧşḗ ẇȧş ǿƞ Ḿȧřƈħ 30, 2010.  Ẇḗ'ṽḗ ƀḗḗƞ ƥřǿŭḓ ŧǿ ħǿşŧ Şŭƞƀīřḓ ȧḓḓ-ǿƞş ǿƞ ŧħīş şīŧḗ ƀŭŧ ȧş ŧħḗ ƥřǿĵḗƈŧ īş ƞǿ ŀǿƞɠḗř ḿȧīƞŧȧīƞḗḓ ẇḗ ħȧṽḗ "
@@ -11006,7 +10814,7 @@ msgstr "Ȧḓḓ ȧ řḗṽīḗẇ ƒǿř {0}"
 #, python-format
 msgid ""
 "<h2>Keep these tips in mind:</h2> <ul> <li> Write like you're telling a friend about your experience with the add-on. Give specifics and helpful details, such as what features you liked and/or "
-"disliked, how easy to use it is, and any disadvantages it has.  Avoid generic language such as calling it \"Great\" or \"Bad\" unless you can give reasons why you believe this is so. </li> <li> "
+"disliked, how easy to use it is, and any disadvantages it has. Avoid generic language such as calling it \"Great\" or \"Bad\" unless you can give reasons why you believe this is so. </li> <li> "
 "Please do not post bug reports in reviews. We do not make your email address available to add-on developers and they may need to contact you to help resolve your issue. See the <a href=\"%(support)s"
 "\">support section</a> to find out where to get assistance for this add-on. </li> <li>Please keep reviews clean, avoid the use of improper language and do not post any personal information. </li> </"
 "ul> <p>Please read the <a href=\"%(guide)s\" target=\"_blank\">Review Guidelines</a> for more detail about user add-on reviews.</p>"
@@ -11247,16 +11055,16 @@ msgstr "{0} Ȧḓḓ-ǿƞş"
 
 #. L10n: {0} is an application, such as Firefox. This means "any version of
 #. Firefox."
-#: src/olympia/search/views.py:554
+#: src/olympia/search/views.py:547
 msgid "Any {0}"
 msgstr "Ȧƞẏ {0}"
 
 #. L10n: "All Systems" means show everything regardless of platform.
-#: src/olympia/search/views.py:589
+#: src/olympia/search/views.py:582
 msgid "All Systems"
 msgstr "Ȧŀŀ Şẏşŧḗḿş"
 
-#: src/olympia/search/views.py:600
+#: src/olympia/search/views.py:593
 msgid "All Tags"
 msgstr "Ȧŀŀ Ŧȧɠş"
 
@@ -11430,31 +11238,31 @@ msgstr "Şħȧřḗ ŧħīş Ȧḓḓ-ǿƞ"
 msgid "Share this Collection"
 msgstr "Şħȧřḗ ŧħīş Ƈǿŀŀḗƈŧīǿƞ"
 
-#: src/olympia/signing/views.py:30 src/olympia/templates/base.html:75 src/olympia/templates/impala/base.html:115
+#: src/olympia/signing/views.py:33 src/olympia/templates/base.html:71 src/olympia/templates/impala/base.html:112
 msgid "Some features are temporarily disabled while we perform website maintenance. We'll be back to full capacity shortly."
 msgstr "Şǿḿḗ ƒḗȧŧŭřḗş ȧřḗ ŧḗḿƥǿřȧřīŀẏ ḓīşȧƀŀḗḓ ẇħīŀḗ ẇḗ ƥḗřƒǿřḿ ẇḗƀşīŧḗ ḿȧīƞŧḗƞȧƞƈḗ. Ẇḗ'ŀŀ ƀḗ ƀȧƈķ ŧǿ ƒŭŀŀ ƈȧƥȧƈīŧẏ şħǿřŧŀẏ."
 
-#: src/olympia/signing/views.py:53
+#: src/olympia/signing/views.py:56
 msgid "Could not find add-on with id \"{}\"."
 msgstr "Ƈǿŭŀḓ ƞǿŧ ƒīƞḓ ȧḓḓ-ǿƞ ẇīŧħ īḓ \"{}\"."
 
-#: src/olympia/signing/views.py:67
+#: src/olympia/signing/views.py:70
 msgid "You do not own this addon."
 msgstr "Ẏǿŭ ḓǿ ƞǿŧ ǿẇƞ ŧħīş ȧḓḓǿƞ."
 
-#: src/olympia/signing/views.py:82
+#: src/olympia/signing/views.py:87
 msgid "Missing \"upload\" key in multipart file data."
 msgstr "Ḿīşşīƞɠ \"ŭƥŀǿȧḓ\" ķḗẏ īƞ ḿŭŀŧīƥȧřŧ ƒīŀḗ ḓȧŧȧ."
 
-#: src/olympia/signing/views.py:96
+#: src/olympia/signing/views.py:101
 msgid "Version does not match the manifest file."
 msgstr "Ṽḗřşīǿƞ ḓǿḗş ƞǿŧ ḿȧŧƈħ ŧħḗ ḿȧƞīƒḗşŧ ƒīŀḗ."
 
-#: src/olympia/signing/views.py:100
+#: src/olympia/signing/views.py:105
 msgid "Version already exists."
 msgstr "Ṽḗřşīǿƞ ȧŀřḗȧḓẏ ḗẋīşŧş."
 
-#: src/olympia/signing/views.py:136
+#: src/olympia/signing/views.py:141
 msgid "No uploaded file for that addon and version."
 msgstr "Ƞǿ ŭƥŀǿȧḓḗḓ ƒīŀḗ ƒǿř ŧħȧŧ ȧḓḓǿƞ ȧƞḓ ṽḗřşīǿƞ."
 
@@ -11567,89 +11375,89 @@ msgstr "{0} :: Şŧȧŧīşŧīƈş Ḓȧşħƀǿȧřḓ"
 msgid "Statistics Dashboard :: Add-ons for {0}"
 msgstr "Şŧȧŧīşŧīƈş Ḓȧşħƀǿȧřḓ :: Ȧḓḓ-ǿƞş ƒǿř {0}"
 
-#: src/olympia/stats/templates/stats/stats.html:30
-msgid "Controls:"
-msgstr "Ƈǿƞŧřǿŀş:"
-
-#: src/olympia/stats/templates/stats/stats.html:33
-msgid "reset zoom"
-msgstr "řḗşḗŧ zǿǿḿ"
-
-#: src/olympia/stats/templates/stats/stats.html:40
-msgid "Group by:"
-msgstr "Ɠřǿŭƥ ƀẏ:"
-
-#: src/olympia/stats/templates/stats/stats.html:42
-msgid "day"
-msgstr "ḓȧẏ"
-
-#: src/olympia/stats/templates/stats/stats.html:45
-msgid "week"
-msgstr "ẇḗḗķ"
-
-#: src/olympia/stats/templates/stats/stats.html:48
-msgid "month"
-msgstr "ḿǿƞŧħ"
-
-#: src/olympia/stats/templates/stats/stats.html:54
-msgid "For last:"
-msgstr "Ƒǿř ŀȧşŧ:"
-
-#: src/olympia/stats/templates/stats/stats.html:57
-msgid "7 days"
-msgstr "7 ḓȧẏş"
-
-#: src/olympia/stats/templates/stats/stats.html:60
-msgid "30 days"
-msgstr "30 ḓȧẏş"
-
-#: src/olympia/stats/templates/stats/stats.html:63
-msgid "90 days"
-msgstr "90 ḓȧẏş"
-
-#: src/olympia/stats/templates/stats/stats.html:66
-msgid "365 days"
-msgstr "365 ḓȧẏş"
-
-#: src/olympia/stats/templates/stats/stats.html:69
-msgid "Custom..."
-msgstr "Ƈŭşŧǿḿ..."
-
 #. {0} is an add-on name
-#: src/olympia/stats/templates/stats/stats.html:88 src/olympia/stats/templates/stats/stats.html:91
+#: src/olympia/stats/templates/stats/stats.html:44 src/olympia/stats/templates/stats/stats.html:47
 msgid "Statistics for {0}"
 msgstr "Şŧȧŧīşŧīƈş ƒǿř {0}"
 
-#: src/olympia/stats/templates/stats/stats.html:94
+#: src/olympia/stats/templates/stats/stats.html:50
 msgid "Statistics Dashboard"
 msgstr "Şŧȧŧīşŧīƈş Ḓȧşħƀǿȧřḓ"
 
-#: src/olympia/stats/templates/stats/stats.html:104
+#: src/olympia/stats/templates/stats/stats.html:57
+msgid "Controls:"
+msgstr "Ƈǿƞŧřǿŀş:"
+
+#: src/olympia/stats/templates/stats/stats.html:60
+msgid "reset zoom"
+msgstr "řḗşḗŧ zǿǿḿ"
+
+#: src/olympia/stats/templates/stats/stats.html:67
+msgid "Group by:"
+msgstr "Ɠřǿŭƥ ƀẏ:"
+
+#: src/olympia/stats/templates/stats/stats.html:69
+msgid "day"
+msgstr "ḓȧẏ"
+
+#: src/olympia/stats/templates/stats/stats.html:72
+msgid "week"
+msgstr "ẇḗḗķ"
+
+#: src/olympia/stats/templates/stats/stats.html:75
+msgid "month"
+msgstr "ḿǿƞŧħ"
+
+#: src/olympia/stats/templates/stats/stats.html:81
+msgid "For last:"
+msgstr "Ƒǿř ŀȧşŧ:"
+
+#: src/olympia/stats/templates/stats/stats.html:84
+msgid "7 days"
+msgstr "7 ḓȧẏş"
+
+#: src/olympia/stats/templates/stats/stats.html:87
+msgid "30 days"
+msgstr "30 ḓȧẏş"
+
+#: src/olympia/stats/templates/stats/stats.html:90
+msgid "90 days"
+msgstr "90 ḓȧẏş"
+
+#: src/olympia/stats/templates/stats/stats.html:93
+msgid "365 days"
+msgstr "365 ḓȧẏş"
+
+#: src/olympia/stats/templates/stats/stats.html:96
+msgid "Custom..."
+msgstr "Ƈŭşŧǿḿ..."
+
+#: src/olympia/stats/templates/stats/stats.html:106
 msgid "Statistics processing is currently disabled, so recent data is unavailable. The statistics are still being collected and this page will be updated soon with the missing data."
 msgstr "Şŧȧŧīşŧīƈş ƥřǿƈḗşşīƞɠ īş ƈŭřřḗƞŧŀẏ ḓīşȧƀŀḗḓ, şǿ řḗƈḗƞŧ ḓȧŧȧ īş ŭƞȧṽȧīŀȧƀŀḗ. Ŧħḗ şŧȧŧīşŧīƈş ȧřḗ şŧīŀŀ ƀḗīƞɠ ƈǿŀŀḗƈŧḗḓ ȧƞḓ ŧħīş ƥȧɠḗ ẇīŀŀ ƀḗ ŭƥḓȧŧḗḓ şǿǿƞ ẇīŧħ ŧħḗ ḿīşşīƞɠ ḓȧŧȧ."
 
-#: src/olympia/stats/templates/stats/stats.html:110
+#: src/olympia/stats/templates/stats/stats.html:112
 msgid "Loading the latest data&hellip;"
 msgstr "Ŀǿȧḓīƞɠ ŧħḗ ŀȧŧḗşŧ ḓȧŧȧ&hellip;"
 
-#: src/olympia/stats/templates/stats/stats.html:142 src/olympia/stats/templates/stats/reports/overview.html:25 src/olympia/stats/templates/stats/reports/overview.html:37
+#: src/olympia/stats/templates/stats/stats.html:144 src/olympia/stats/templates/stats/reports/overview.html:25 src/olympia/stats/templates/stats/reports/overview.html:37
 #: src/olympia/stats/templates/stats/reports/overview.html:49
 msgid "No data available."
 msgstr "Ƞǿ ḓȧŧȧ ȧṽȧīŀȧƀŀḗ."
 
-#: src/olympia/stats/templates/stats/stats.html:177
+#: src/olympia/stats/templates/stats/stats.html:179
 msgid "This dashboard is currently <b>public</b>."
 msgstr "Ŧħīş ḓȧşħƀǿȧřḓ īş ƈŭřřḗƞŧŀẏ <b>ƥŭƀŀīƈ</b>."
 
-#: src/olympia/stats/templates/stats/stats.html:179
+#: src/olympia/stats/templates/stats/stats.html:181
 msgid "Contribution stats are currently <b>private</b>."
 msgstr "Ƈǿƞŧřīƀŭŧīǿƞ şŧȧŧş ȧřḗ ƈŭřřḗƞŧŀẏ <b>ƥřīṽȧŧḗ</b>."
 
-#: src/olympia/stats/templates/stats/stats.html:182
+#: src/olympia/stats/templates/stats/stats.html:184
 msgid "This dashboard is currently <b>private</b>."
 msgstr "Ŧħīş ḓȧşħƀǿȧřḓ īş ƈŭřřḗƞŧŀẏ <b>ƥřīṽȧŧḗ</b>."
 
-#: src/olympia/stats/templates/stats/stats.html:185
+#: src/olympia/stats/templates/stats/stats.html:187
 msgid "Change settings."
 msgstr "Ƈħȧƞɠḗ şḗŧŧīƞɠş."
 
@@ -11812,15 +11620,6 @@ msgstr "Ŭşḗř Şīɠƞŭƥş ƀẏ Ḓȧŧḗ"
 msgid "Application versions by Date"
 msgstr "Ȧƥƥŀīƈȧŧīǿƞ ṽḗřşīǿƞş ƀẏ Ḓȧŧḗ"
 
-#: src/olympia/tags/templates/tags/top_cloud.html:4
-msgid "Top {0} Tags"
-msgstr "Ŧǿƥ {0} Ŧȧɠş"
-
-#. {0} is the current application name
-#: src/olympia/tags/templates/tags/top_cloud.html:14
-msgid "{0} Top Tags"
-msgstr "{0} Ŧǿƥ Ŧȧɠş"
-
 #: src/olympia/templates/amo_footer.html:6 src/olympia/templates/includes/lang_switcher.html:2
 msgid "Other languages"
 msgstr "Ǿŧħḗř ŀȧƞɠŭȧɠḗş"
@@ -11829,11 +11628,11 @@ msgstr "Ǿŧħḗř ŀȧƞɠŭȧɠḗş"
 msgid "Mozilla Add-ons"
 msgstr "Ḿǿzīŀŀȧ Ȧḓḓ-ǿƞş"
 
-#: src/olympia/templates/base.html:91 src/olympia/templates/impala/base.html:81
+#: src/olympia/templates/base.html:89 src/olympia/templates/impala/base.html:78
 msgid "Find add-ons for other applications"
 msgstr "Ƒīƞḓ ȧḓḓ-ǿƞş ƒǿř ǿŧħḗř ȧƥƥŀīƈȧŧīǿƞş"
 
-#: src/olympia/templates/base.html:92 src/olympia/templates/impala/base.html:81
+#: src/olympia/templates/base.html:90 src/olympia/templates/impala/base.html:78
 msgid "Other Applications"
 msgstr "Ǿŧħḗř Ȧƥƥŀīƈȧŧīǿƞş"
 
@@ -11858,7 +11657,7 @@ msgid "View Mobile Site"
 msgstr "Ṽīḗẇ Ḿǿƀīŀḗ Şīŧḗ"
 
 #: src/olympia/templates/copyright.html:7
-msgid "Site Status "
+msgid "Site Status"
 msgstr "Şīŧḗ Şŧȧŧŭş "
 
 #: src/olympia/templates/footer.html:3
@@ -11958,35 +11757,35 @@ msgstr "Ẇḗŀƈǿḿḗ, {0}"
 msgid "<a href=\"%(reg)s\">Register</a> or <a href=\"%(login)s\">Log in</a>"
 msgstr "<a href=\"%(reg)s\">Řḗɠīşŧḗř</a> ǿř <a href=\"%(login)s\">Ŀǿɠ īƞ</a>"
 
-#: src/olympia/templates/impala/base.html:126
+#: src/olympia/templates/impala/base.html:123
 #, python-format
 msgid "To try the thousands of add-ons available here, download <a href=\"%(url)s\">Mozilla Firefox</a>, a fast, free way to surf the Web!"
 msgstr "Ŧǿ ŧřẏ ŧħḗ ŧħǿŭşȧƞḓş ǿƒ ȧḓḓ-ǿƞş ȧṽȧīŀȧƀŀḗ ħḗřḗ, ḓǿẇƞŀǿȧḓ <a href=\"%(url)s\">Ḿǿzīŀŀȧ Ƒīřḗƒǿẋ</a>, ȧ ƒȧşŧ, ƒřḗḗ ẇȧẏ ŧǿ şŭřƒ ŧħḗ Ẇḗƀ!"
 
-#: src/olympia/templates/impala/base.html:138
+#: src/olympia/templates/impala/base.html:135
 #, python-format
 msgid "Add-ons is switching to Firefox Accounts for login. <a href=\"%(url)s\" class=\"fxa-login\">Sign in now to transfer your account.</a>"
 msgstr "Ȧḓḓ-ǿƞş īş şẇīŧƈħīƞɠ ŧǿ Ƒīřḗƒǿẋ Ȧƈƈǿŭƞŧş ƒǿř ŀǿɠīƞ. <a href=\"%(url)s\" class=\"fxa-login\">Şīɠƞ īƞ ƞǿẇ ŧǿ ŧřȧƞşƒḗř ẏǿŭř ȧƈƈǿŭƞŧ.</a>"
 
 #. {0} is an application, such as Firefox.
-#: src/olympia/templates/impala/base.html:148
+#: src/olympia/templates/impala/base.html:145
 msgid "Welcome to {0} Add-ons."
 msgstr "Ẇḗŀƈǿḿḗ ŧǿ {0} Ȧḓḓ-ǿƞş."
 
-#: src/olympia/templates/impala/base.html:151
+#: src/olympia/templates/impala/base.html:148
 msgid "Choose from thousands of extra features and styles to make Firefox your own."
 msgstr "Ƈħǿǿşḗ ƒřǿḿ ŧħǿŭşȧƞḓş ǿƒ ḗẋŧřȧ ƒḗȧŧŭřḗş ȧƞḓ şŧẏŀḗş ŧǿ ḿȧķḗ Ƒīřḗƒǿẋ ẏǿŭř ǿẇƞ."
 
-#: src/olympia/templates/impala/base.html:156
+#: src/olympia/templates/impala/base.html:153
 #, python-format
 msgid "Add extra features and styles to make %(app)s your own."
 msgstr "Ȧḓḓ ḗẋŧřȧ ƒḗȧŧŭřḗş ȧƞḓ şŧẏŀḗş ŧǿ ḿȧķḗ %(app)s ẏǿŭř ǿẇƞ."
 
-#: src/olympia/templates/impala/base.html:164
+#: src/olympia/templates/impala/base.html:161
 msgid "On the go?"
 msgstr "Ǿƞ ŧħḗ ɠǿ?"
 
-#: src/olympia/templates/impala/base.html:166
+#: src/olympia/templates/impala/base.html:163
 msgid "Check out our <a class=\"mobile-link\" href=\"#\">Mobile Add-ons site</a>."
 msgstr "Ƈħḗƈķ ǿŭŧ ǿŭř <a class=\"mobile-link\" href=\"#\">Ḿǿƀīŀḗ Ȧḓḓ-ǿƞş şīŧḗ</a>."
 
@@ -12210,19 +12009,19 @@ msgstr "Ƞǿ ŭşḗř ẇīŧħ ŧħȧŧ ḗḿȧīŀ."
 
 #. L10n: {id} will be something like "13ad6a", just a random number
 #. to differentiate this user from other anonymous users.
-#: src/olympia/users/models.py:353
+#: src/olympia/users/models.py:362
 msgid "Anonymous user {id}"
 msgstr "Ȧƞǿƞẏḿǿŭş ŭşḗř {īḓ}"
 
-#: src/olympia/users/models.py:410
+#: src/olympia/users/models.py:419
 msgid "Your account has been restricted"
 msgstr "Ẏǿŭř ȧƈƈǿŭƞŧ ħȧş ƀḗḗƞ řḗşŧřīƈŧḗḓ"
 
-#: src/olympia/users/models.py:480
+#: src/olympia/users/models.py:489
 msgid "Please confirm your email address"
 msgstr "Ƥŀḗȧşḗ ƈǿƞƒīřḿ ẏǿŭř ḗḿȧīŀ ȧḓḓřḗşş"
 
-#: src/olympia/users/models.py:506
+#: src/olympia/users/models.py:515
 msgid "My Mobile Add-ons"
 msgstr "Ḿẏ Ḿǿƀīŀḗ Ȧḓḓ-ǿƞş"
 
@@ -12505,7 +12304,7 @@ msgstr "Ƥȧşşẇǿřḓ"
 
 #: src/olympia/users/templates/users/edit.html:70
 #, python-format
-msgid "Change your password.  If you forgot your password, you can <a href=\"%(reset_url)s\">use the reset form</a>."
+msgid "Change your password. If you forgot your password, you can <a href=\"%(reset_url)s\">use the reset form</a>."
 msgstr "Ƈħȧƞɠḗ ẏǿŭř ƥȧşşẇǿřḓ.  Īƒ ẏǿŭ ƒǿřɠǿŧ ẏǿŭř ƥȧşşẇǿřḓ, ẏǿŭ ƈȧƞ <a href=\"%(reset_url)s\">ŭşḗ ŧħḗ řḗşḗŧ ƒǿřḿ</a>."
 
 #: src/olympia/users/templates/users/edit.html:76
@@ -12525,7 +12324,7 @@ msgid "Profile"
 msgstr "Ƥřǿƒīŀḗ"
 
 #: src/olympia/users/templates/users/edit.html:100
-msgid "Give us a bit more information about yourself.  All these fields are optional, but they'll help other users get to know you better."
+msgid "Give us a bit more information about yourself. All these fields are optional, but they'll help other users get to know you better."
 msgstr "Ɠīṽḗ ŭş ȧ ƀīŧ ḿǿřḗ īƞƒǿřḿȧŧīǿƞ ȧƀǿŭŧ ẏǿŭřşḗŀƒ.  Ȧŀŀ ŧħḗşḗ ƒīḗŀḓş ȧřḗ ǿƥŧīǿƞȧŀ, ƀŭŧ ŧħḗẏ'ŀŀ ħḗŀƥ ǿŧħḗř ŭşḗřş ɠḗŧ ŧǿ ķƞǿẇ ẏǿŭ ƀḗŧŧḗř."
 
 #: src/olympia/users/templates/users/edit.html:124
@@ -12741,7 +12540,7 @@ msgid "Confirm password"
 msgstr "Ƈǿƞƒīřḿ ƥȧşşẇǿřḓ"
 
 #: src/olympia/users/templates/users/pwreset_confirm.html:47
-msgid "The password reset link was invalid, possibly because it has already been used.  Please request a new password reset."
+msgid "The password reset link was invalid, possibly because it has already been used. Please request a new password reset."
 msgstr "Ŧħḗ ƥȧşşẇǿřḓ řḗşḗŧ ŀīƞķ ẇȧş īƞṽȧŀīḓ, ƥǿşşīƀŀẏ ƀḗƈȧŭşḗ īŧ ħȧş ȧŀřḗȧḓẏ ƀḗḗƞ ŭşḗḓ.  Ƥŀḗȧşḗ řḗɋŭḗşŧ ȧ ƞḗẇ ƥȧşşẇǿřḓ řḗşḗŧ."
 
 #: src/olympia/users/templates/users/pwreset_request.html:15
@@ -12930,7 +12729,7 @@ msgstr "Ẇḗ ƈǿŭŀḓ ƞǿŧ ŭƞşŭƀşƈřīƀḗ ẏǿŭ"
 
 #: src/olympia/users/templates/users/unsubscribe.html:30
 #, python-format
-msgid "Unfortunately, we weren't able to unsubscribe you.  The link you clicked is invalid. However, you can unsubscribe still unsubscribe on your <a href=\"%(edit_url)s\">edit profile page</a>."
+msgid "Unfortunately, we weren't able to unsubscribe you. The link you clicked is invalid. However, you can unsubscribe still unsubscribe on your <a href=\"%(edit_url)s\">edit profile page</a>."
 msgstr "Ŭƞƒǿřŧŭƞȧŧḗŀẏ, ẇḗ ẇḗřḗƞ'ŧ ȧƀŀḗ ŧǿ ŭƞşŭƀşƈřīƀḗ ẏǿŭ.  Ŧħḗ ŀīƞķ ẏǿŭ ƈŀīƈķḗḓ īş īƞṽȧŀīḓ. Ħǿẇḗṽḗř, ẏǿŭ ƈȧƞ ŭƞşŭƀşƈřīƀḗ şŧīŀŀ ŭƞşŭƀşƈřīƀḗ ǿƞ ẏǿŭř <a href=\"%(edit_url)s\">ḗḓīŧ ƥřǿƒīŀḗ ƥȧɠḗ</a>."
 
 #: src/olympia/users/templates/users/vcard.html:2
@@ -12984,15 +12783,15 @@ msgstr "%s Ṽḗřşīǿƞ Ħīşŧǿřẏ"
 msgid "Version History with Changelogs"
 msgstr "Ṽḗřşīǿƞ Ħīşŧǿřẏ ẇīŧħ Ƈħȧƞɠḗŀǿɠş"
 
-#: src/olympia/versions/models.py:314
+#: src/olympia/versions/models.py:313
 msgid "Add-on uses binary components."
 msgstr "Ȧḓḓ-ǿƞ ŭşḗş ƀīƞȧřẏ ƈǿḿƥǿƞḗƞŧş."
 
-#: src/olympia/versions/models.py:317
+#: src/olympia/versions/models.py:316
 msgid "Add-on has opted into strict compatibility checking."
 msgstr "Ȧḓḓ-ǿƞ ħȧş ǿƥŧḗḓ īƞŧǿ şŧřīƈŧ ƈǿḿƥȧŧīƀīŀīŧẏ ƈħḗƈķīƞɠ."
 
-#: src/olympia/versions/models.py:715
+#: src/olympia/versions/models.py:711
 msgid "{app} {min} and later"
 msgstr "{ȧƥƥ} {ḿīƞ} ȧƞḓ ŀȧŧḗř"
 
@@ -13068,3 +12867,7 @@ msgstr "Ḗḿȧīŀ ẇħḗƞ ƒīƞīşħḗḓ"
 #: src/olympia/zadmin/forms.py:105
 msgid "Log emails instead of sending"
 msgstr "Ŀǿɠ ḗḿȧīŀş īƞşŧḗȧḓ ǿƒ şḗƞḓīƞɠ"
+
+#: src/olympia/zadmin/forms.py:215
+msgid "Deleted versions can`t be changed."
+msgstr ""

--- a/locale/dbg/LC_MESSAGES/djangojs.po
+++ b/locale/dbg/LC_MESSAGES/djangojs.po
@@ -1,137 +1,393 @@
-
 #, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT 1.0\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2016-02-24 21:23+0000\n"
+"POT-Creation-Date: 2016-04-18 15:47+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
+"Language: \n"
 "MIME-Version: 1.0\n"
-"Content-Type: text/plain; charset=utf-8\n"
+"Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Generated-By: Babel 2.2.0\n"
 
-#: static/js/common/ratingwidget.js:31
+#: static/js/common-all.js:1426 static/js/impala-all.js:1511 static/js/zamboni/discovery-all.js:12598 static/js/zamboni/init.js:28 static/js/zamboni/mobile-all.js:14945
+msgid "This feature is temporarily disabled while we perform website maintenance. Please check back a little later."
+msgstr "Ŧħīş ƒḗȧŧŭřḗ īş ŧḗḿƥǿřȧřīŀẏ ḓīşȧƀŀḗḓ ẇħīŀḗ ẇḗ ƥḗřƒǿřḿ ẇḗƀşīŧḗ ḿȧīƞŧḗƞȧƞƈḗ. Ƥŀḗȧşḗ ƈħḗƈķ ƀȧƈķ ȧ ŀīŧŧŀḗ ŀȧŧḗř."
+
+#. L10n: {0} is an app name like Firefox.
+#: static/js/common-all.js:1837 static/js/impala-all.js:1922 static/js/zamboni/buttons.js:73 static/js/zamboni/discovery-all.js:13108
+msgid "Accept and Install"
+msgstr "Ȧƈƈḗƥŧ ȧƞḓ Īƞşŧȧŀŀ"
+
+#: static/js/common-all.js:1837 static/js/impala-all.js:1922 static/js/zamboni/buttons.js:73 static/js/zamboni/discovery-all.js:13108
+msgid "Add to {0}"
+msgstr "Ȧḓḓ ŧǿ {0}"
+
+#: static/js/common-all.js:1842 static/js/impala-all.js:1927 static/js/zamboni/buttons.js:78 static/js/zamboni/discovery-all.js:13113
+msgid "Download Now"
+msgstr "Ḓǿẇƞŀǿȧḓ Ƞǿẇ"
+
+#: static/js/common-all.js:1883 static/js/impala-all.js:1968 static/js/zamboni/buttons.js:119 static/js/zamboni/discovery-all.js:13154
+msgid "Add-on has not been updated to support default-to-compatible."
+msgstr "Ȧḓḓ-ǿƞ ħȧş ƞǿŧ ƀḗḗƞ ŭƥḓȧŧḗḓ ŧǿ şŭƥƥǿřŧ ḓḗƒȧŭŀŧ-ŧǿ-ƈǿḿƥȧŧīƀŀḗ."
+
+#: static/js/common-all.js:1888 static/js/impala-all.js:1973 static/js/zamboni/buttons.js:124 static/js/zamboni/discovery-all.js:13159
+msgid "You need to be using Firefox 10.0 or higher."
+msgstr "Ẏǿŭ ƞḗḗḓ ŧǿ ƀḗ ŭşīƞɠ Ƒīřḗƒǿẋ 10.0 ǿř ħīɠħḗř."
+
+#: static/js/common-all.js:1900 static/js/impala-all.js:1985 static/js/zamboni/buttons.js:136 static/js/zamboni/discovery-all.js:13171
+msgid "Mozilla has marked this version as incompatible with your Firefox version."
+msgstr "Ḿǿzīŀŀȧ ħȧş ḿȧřķḗḓ ŧħīş ṽḗřşīǿƞ ȧş īƞƈǿḿƥȧŧīƀŀḗ ẇīŧħ ẏǿŭř Ƒīřḗƒǿẋ ṽḗřşīǿƞ."
+
+#. L10n: {0} is an platform like Windows or Linux.
+#: static/js/common-all.js:1981 static/js/impala-all.js:2066 static/js/zamboni/buttons.js:217 static/js/zamboni/discovery-all.js:13252
+msgid "Install for {0} anyway"
+msgstr "Īƞşŧȧŀŀ ƒǿř {0} ȧƞẏẇȧẏ"
+
+#: static/js/common-all.js:1981 static/js/impala-all.js:2066 static/js/zamboni/buttons.js:217 static/js/zamboni/discovery-all.js:13252
+msgid "Download for {0} anyway"
+msgstr "Ḓǿẇƞŀǿȧḓ ƒǿř {0} ȧƞẏẇȧẏ"
+
+#: static/js/common-all.js:2038 static/js/impala-all.js:2123 static/js/zamboni/buttons.js:274 static/js/zamboni/discovery-all.js:13309
+msgid "Not available for your platform"
+msgstr "Ƞǿŧ ȧṽȧīŀȧƀŀḗ ƒǿř ẏǿŭř ƥŀȧŧƒǿřḿ"
+
+#. L10n: {0} is an app name, {1} is the app version.
+#: static/js/common-all.js:2049 static/js/common-all.js:2086 static/js/impala-all.js:2134 static/js/impala-all.js:2171 static/js/zamboni/buttons.js:286 static/js/zamboni/buttons.js:324
+#: static/js/zamboni/discovery-all.js:13320 static/js/zamboni/discovery-all.js:13357
+msgid "Not available for {0} {1}"
+msgstr "Ƞǿŧ ȧṽȧīŀȧƀŀḗ ƒǿř {0} {1}"
+
+#: static/js/common-all.js:2112 static/js/impala-all.js:2197 static/js/zamboni/buttons.js:351 static/js/zamboni/discovery-all.js:13383
+msgid "Works with {app} {min} - {max}"
+msgstr "Ẇǿřķş ẇīŧħ {ȧƥƥ} {ḿīƞ} - {ḿȧẋ}"
+
+#: static/js/common-all.js:2114 static/js/impala-all.js:2199 static/js/zamboni/buttons.js:353 static/js/zamboni/discovery-all.js:13385
+msgid "View other versions"
+msgstr "Ṽīḗẇ ǿŧħḗř ṽḗřşīǿƞş"
+
+#: static/js/common-all.js:2162 static/js/impala-all.js:2247 static/js/zamboni/buttons.js:401 static/js/zamboni/discovery-all.js:13433
+msgid "Only with Firefox — Get Firefox Now!"
+msgstr "Ǿƞŀẏ ẇīŧħ Ƒīřḗƒǿẋ — Ɠḗŧ Ƒīřḗƒǿẋ Ƞǿẇ!"
+
+#: static/js/common-all.js:2278 static/js/impala-all.js:2363 static/js/zamboni/buttons.js:517 static/js/zamboni/discovery-all.js:13549 static/js/zamboni/mobile-all.js:15177
+#: static/js/zamboni/mobile/buttons.js:43
+msgid "Sorry, you need a Mozilla-based browser (such as Firefox) to install a search plugin."
+msgstr "Şǿřřẏ, ẏǿŭ ƞḗḗḓ ȧ Ḿǿzīŀŀȧ-ƀȧşḗḓ ƀřǿẇşḗř (şŭƈħ ȧş Ƒīřḗƒǿẋ) ŧǿ īƞşŧȧŀŀ ȧ şḗȧřƈħ ƥŀŭɠīƞ."
+
+#: static/js/common-all.js:9088 static/js/impala-all.js:9649 static/js/zamboni/global.js:410
+msgid "Loading..."
+msgstr "Ŀǿȧḓīƞɠ..."
+
+#. L10n: {0} is the number of characters left.
+#: static/js/common-all.js:9152 static/js/impala-all.js:9713 static/js/zamboni/global.js:474
+msgid "<b>{0}</b> character left."
+msgid_plural "<b>{0}</b> characters left."
+msgstr[0] "<b>{0}</b> ƈħȧřȧƈŧḗř ŀḗƒŧ."
+msgstr[1] "<b>{0}</b> ƈħȧřȧƈŧḗřş ŀḗƒŧ."
+
+#: static/js/common-all.js:9589 static/js/common-min.js:6 static/js/impala-all.js:10052 static/js/impala-min.js:6 static/js/common/ratingwidget.js:31 static/js/zamboni/mobile-all.js:16123
+#: static/js/zamboni/mobile-min.js:6
 msgid "{0} star"
 msgid_plural "{0} stars"
 msgstr[0] "{0} şŧȧř"
 msgstr[1] "{0} şŧȧřş"
 
-#: static/js/common/upload-addon.js:41 static/js/common/upload-image.js:128
+#: static/js/common-all.js:9676 static/js/common-min.js:6 static/js/impala-all.js:10139 static/js/impala-min.js:6 static/js/zamboni/l10n.js:45
+msgid "Remove this localization"
+msgstr "Řḗḿǿṽḗ ŧħīş ŀǿƈȧŀīzȧŧīǿƞ"
+
+#: static/js/common-all.js:10193 static/js/common-min.js:6 static/js/impala-all.js:10674 static/js/impala-min.js:6 static/js/zamboni/discovery-all.js:13678
+msgid "close"
+msgstr ""
+
+#: static/js/common-all.js:10860 static/js/common-min.js:6 static/js/impala-all.js:11481 static/js/impala-min.js:6 static/js/impala/reviews.js:23 static/js/zamboni/reviews.js:18
+msgid "Flagged for review"
+msgstr "Ƒŀȧɠɠḗḓ ƒǿř řḗṽīḗẇ"
+
+#: static/js/common-all.js:10876 static/js/common-min.js:6 static/js/impala-all.js:11498 static/js/impala-min.js:6 static/js/impala/reviews.js:40 static/js/zamboni/reviews.js:34
+msgid "Your input is required"
+msgstr "Ẏǿŭř īƞƥŭŧ īş řḗɋŭīřḗḓ"
+
+#: static/js/common-all.js:10945 static/js/common-min.js:6 static/js/impala-all.js:11610 static/js/impala-min.js:7 static/js/impala/reviews.js:152 static/js/zamboni/reviews.js:103
+msgid "Marked for deletion"
+msgstr "Ḿȧřķḗḓ ƒǿř ḓḗŀḗŧīǿƞ"
+
+#: static/js/common-all.js:11573 static/js/common-min.js:7 static/js/impala-all.js:13809 static/js/impala-min.js:8 static/js/zamboni/collections.js:229
+msgid "Adding to Favorites&hellip;"
+msgstr "Ȧḓḓīƞɠ ŧǿ Ƒȧṽǿřīŧḗş&hellip;"
+
+#: static/js/common-all.js:11576 static/js/common-min.js:7 static/js/impala-all.js:13812 static/js/impala-min.js:8 static/js/zamboni/collections.js:232
+msgid "Removing Favorite&hellip;"
+msgstr "Řḗḿǿṽīƞɠ Ƒȧṽǿřīŧḗ&hellip;"
+
+#: static/js/common-all.js:11579 static/js/common-min.js:7 static/js/impala-all.js:13815 static/js/impala-min.js:8 static/js/zamboni/collections.js:235
+msgid "Add to Favorites"
+msgstr "Ȧḓḓ ŧǿ Ƒȧṽǿřīŧḗş"
+
+#: static/js/common-all.js:11582 static/js/common-min.js:7 static/js/impala-all.js:13818 static/js/impala-min.js:8 static/js/zamboni/collections.js:238
+msgid "Remove from Favorites"
+msgstr "Řḗḿǿṽḗ ƒřǿḿ Ƒȧṽǿřīŧḗş"
+
+#: static/js/common-all.js:11647 static/js/common-min.js:7 static/js/impala-all.js:13883 static/js/impala-min.js:8 static/js/zamboni/collections.js:303
+msgid "Pending"
+msgstr "Ƥḗƞḓīƞɠ"
+
+#: static/js/common-all.js:11648 static/js/common-min.js:7 static/js/impala-all.js:13884 static/js/impala-min.js:8 static/js/zamboni/collections.js:304
+msgid "Add a comment"
+msgstr "Ȧḓḓ ȧ ƈǿḿḿḗƞŧ"
+
+#: static/js/common-all.js:11648 static/js/common-min.js:7 static/js/impala-all.js:13884 static/js/impala-min.js:8 static/js/zamboni/collections.js:304
+msgid "Comment"
+msgstr "Ƈǿḿḿḗƞŧ"
+
+#: static/js/common-all.js:11649 static/js/common-min.js:7 static/js/impala-all.js:13885 static/js/impala-min.js:8 static/js/zamboni/collections.js:305
+msgid "Remove this add-on from the collection"
+msgstr "Řḗḿǿṽḗ ŧħīş ȧḓḓ-ǿƞ ƒřǿḿ ŧħḗ ƈǿŀŀḗƈŧīǿƞ"
+
+#: static/js/common-all.js:11649 static/js/common-all.js:11678 static/js/common-min.js:7 static/js/impala-all.js:13885 static/js/impala-all.js:13914 static/js/impala-min.js:8
+#: static/js/zamboni/collections.js:305 static/js/zamboni/collections.js:334
+msgid "Remove"
+msgstr "Řḗḿǿṽḗ"
+
+#: static/js/common-all.js:11678 static/js/common-min.js:7 static/js/impala-all.js:13914 static/js/impala-min.js:8 static/js/zamboni/collections.js:334
+msgid "Remove this user as a contributor"
+msgstr "Řḗḿǿṽḗ ŧħīş ŭşḗř ȧş ȧ ƈǿƞŧřīƀŭŧǿř"
+
+#: static/js/common-all.js:11690 static/js/common-min.js:7 static/js/impala-all.js:13926 static/js/impala-min.js:8 static/js/zamboni/collections.js:346
+msgid "An email address is required."
+msgstr "Ȧƞ ḗḿȧīŀ ȧḓḓřḗşş īş řḗɋŭīřḗḓ."
+
+#: static/js/common-all.js:11708 static/js/common-min.js:7 static/js/impala-all.js:13944 static/js/impala-min.js:8 static/js/zamboni/collections.js:364
+msgid "You cannot add yourself as a contributor."
+msgstr "Ẏǿŭ ƈȧƞƞǿŧ ȧḓḓ ẏǿŭřşḗŀƒ ȧş ȧ ƈǿƞŧřīƀŭŧǿř."
+
+#: static/js/common-all.js:11710 static/js/common-min.js:7 static/js/impala-all.js:13946 static/js/impala-min.js:8 static/js/zamboni/collections.js:366
+msgid "You have already added that user."
+msgstr "Ẏǿŭ ħȧṽḗ ȧŀřḗȧḓẏ ȧḓḓḗḓ ŧħȧŧ ŭşḗř."
+
+#: static/js/common-all.js:11917 static/js/common-min.js:7 static/js/impala-all.js:14153 static/js/impala-min.js:8 static/js/zamboni/collections.js:573
+msgid "Add to favorites"
+msgstr "Ȧḓḓ ŧǿ ƒȧṽǿřīŧḗş"
+
+#: static/js/common-all.js:11921 static/js/common-min.js:7 static/js/impala-all.js:14157 static/js/impala-min.js:8 static/js/zamboni/collections.js:577
+msgid "Remove from favorites"
+msgstr "Řḗḿǿṽḗ ƒřǿḿ ƒȧṽǿřīŧḗş"
+
+#: static/js/common-all.js:11939 static/js/common-min.js:7 static/js/impala-all.js:14175 static/js/impala-all.js:14233 static/js/impala-min.js:8 static/js/impala/collections.js:10
+#: static/js/zamboni/collections.js:595
+msgid "Follow this Collection"
+msgstr "Ƒǿŀŀǿẇ ŧħīş Ƈǿŀŀḗƈŧīǿƞ"
+
+#: static/js/common-all.js:11948 static/js/common-min.js:7 static/js/impala-all.js:14184 static/js/impala-min.js:8 static/js/zamboni/collections.js:604
+msgid "Stop following"
+msgstr "Şŧǿƥ ƒǿŀŀǿẇīƞɠ"
+
+#: static/js/common-all.js:12096 static/js/common-min.js:7 static/js/zamboni/password-strength.js:20
+msgid "Password strength:"
+msgstr "Ƥȧşşẇǿřḓ şŧřḗƞɠŧħ:"
+
+#: static/js/common-all.js:12102 static/js/common-min.js:7 static/js/zamboni/password-strength.js:26
+msgid "At least {0} character left."
+msgid_plural "At least {0} characters left."
+msgstr[0] "Ȧŧ ŀḗȧşŧ {0} ƈħȧřȧƈŧḗř ŀḗƒŧ."
+msgstr[1] "Ȧŧ ŀḗȧşŧ {0} ƈħȧřȧƈŧḗřş ŀḗƒŧ."
+
+#: static/js/common-all.js:12286 static/js/common-min.js:7 static/js/impala-all.js:14632 static/js/impala-min.js:8 static/js/impala/suggestions.js:39
+msgid "Search themes for <b>{0}</b>"
+msgstr "Şḗȧřƈħ ŧħḗḿḗş ƒǿř <b>{0}</b>"
+
+#: static/js/common-all.js:12288 static/js/common-min.js:7 static/js/impala-all.js:14634 static/js/impala-min.js:8 static/js/impala/suggestions.js:41
+msgid "Search apps for <b>{0}</b>"
+msgstr "Şḗȧřƈħ ȧƥƥş ƒǿř <b>{0}</b>"
+
+#: static/js/common-all.js:12290 static/js/common-min.js:7 static/js/impala-all.js:14636 static/js/impala-min.js:8 static/js/impala/suggestions.js:43
+msgid "Search add-ons for <b>{0}</b>"
+msgstr "Şḗȧřƈħ ȧḓḓ-ǿƞş ƒǿř <b>{0}</b>"
+
+#: static/js/common-all.js:12521 static/js/common-min.js:7 static/js/impala-all.js:14867 static/js/impala-min.js:8 static/js/impala/site_suggestions.js:46
+msgid "Category"
+msgstr "Ƈȧŧḗɠǿřẏ"
+
+#. L10n: {0} is an app name.
+#: static/js/impala-all.js:11632 static/js/impala-min.js:7 static/js/impala/listing.js:11 static/js/zamboni/themes.js:13
+msgid "This theme is incompatible with your version of {0}"
+msgstr "Ŧħīş ŧħḗḿḗ īş īƞƈǿḿƥȧŧīƀŀḗ ẇīŧħ ẏǿŭř ṽḗřşīǿƞ ǿƒ {0}"
+
+#: static/js/impala-all.js:12146 static/js/impala-all.js:14331 static/js/impala-min.js:7 static/js/impala-min.js:8 static/js/common/upload-image.js:97 static/js/impala/users.js:51
+#: static/js/zamboni/devhub-all.js:894 static/js/zamboni/devhub-min.js:1
+msgid "Images must be either PNG or JPG."
+msgstr "Īḿȧɠḗş ḿŭşŧ ƀḗ ḗīŧħḗř ƤȠƓ ǿř ĴƤƓ."
+
+#: static/js/impala-all.js:12150 static/js/impala-min.js:7 static/js/common/upload-image.js:101 static/js/zamboni/devhub-all.js:898 static/js/zamboni/devhub-min.js:1
+msgid "Videos must be in WebM."
+msgstr "Ṽīḓḗǿş ḿŭşŧ ƀḗ īƞ ẆḗƀḾ."
+
+#: static/js/impala-all.js:12177 static/js/impala-min.js:7 static/js/common/upload-addon.js:41 static/js/common/upload-image.js:128 static/js/zamboni/devhub-all.js:272
+#: static/js/zamboni/devhub-all.js:925 static/js/zamboni/devhub-min.js:1
 msgid "There was a problem contacting the server."
 msgstr "Ŧħḗřḗ ẇȧş ȧ ƥřǿƀŀḗḿ ƈǿƞŧȧƈŧīƞɠ ŧħḗ şḗřṽḗř."
 
-#: static/js/common/upload-addon.js:69
+#: static/js/impala-all.js:13298 static/js/impala-min.js:7 static/js/impala/persona_creation.js:60
+msgid "All Rights Reserved"
+msgstr "Ȧŀŀ Řīɠħŧş Řḗşḗřṽḗḓ"
+
+#: static/js/impala-all.js:13302 static/js/impala-min.js:7 static/js/impala/persona_creation.js:64
+msgid "Creative Commons Attribution 3.0"
+msgstr "Ƈřḗȧŧīṽḗ Ƈǿḿḿǿƞş Ȧŧŧřīƀŭŧīǿƞ 3.0"
+
+#: static/js/impala-all.js:13307 static/js/impala-min.js:7 static/js/impala/persona_creation.js:69
+msgid "Creative Commons Attribution-NonCommercial 3.0"
+msgstr "Ƈřḗȧŧīṽḗ Ƈǿḿḿǿƞş Ȧŧŧřīƀŭŧīǿƞ-ȠǿƞƇǿḿḿḗřƈīȧŀ 3.0"
+
+#: static/js/impala-all.js:13312 static/js/impala-min.js:7 static/js/impala/persona_creation.js:74
+msgid "Creative Commons Attribution-NonCommercial-NoDerivs 3.0"
+msgstr "Ƈřḗȧŧīṽḗ Ƈǿḿḿǿƞş Ȧŧŧřīƀŭŧīǿƞ-ȠǿƞƇǿḿḿḗřƈīȧŀ-ȠǿḒḗřīṽş 3.0"
+
+#: static/js/impala-all.js:13317 static/js/impala-min.js:7 static/js/impala/persona_creation.js:79
+msgid "Creative Commons Attribution-NonCommercial-Share Alike 3.0"
+msgstr "Ƈřḗȧŧīṽḗ Ƈǿḿḿǿƞş Ȧŧŧřīƀŭŧīǿƞ-ȠǿƞƇǿḿḿḗřƈīȧŀ-Şħȧřḗ Ȧŀīķḗ 3.0"
+
+#: static/js/impala-all.js:13322 static/js/impala-min.js:7 static/js/impala/persona_creation.js:84
+msgid "Creative Commons Attribution-NoDerivs 3.0"
+msgstr "Ƈřḗȧŧīṽḗ Ƈǿḿḿǿƞş Ȧŧŧřīƀŭŧīǿƞ-ȠǿḒḗřīṽş 3.0"
+
+#: static/js/impala-all.js:13327 static/js/impala-min.js:7 static/js/impala/persona_creation.js:89
+msgid "Creative Commons Attribution-ShareAlike 3.0"
+msgstr "Ƈřḗȧŧīṽḗ Ƈǿḿḿǿƞş Ȧŧŧřīƀŭŧīǿƞ-ŞħȧřḗȦŀīķḗ 3.0"
+
+#: static/js/impala-all.js:13530 static/js/impala-min.js:7 static/js/impala/persona_creation.js:292
+msgid "Your Theme's Name"
+msgstr "Ẏǿŭř Ŧħḗḿḗ'ş Ƞȧḿḗ"
+
+#: static/js/impala-all.js:14242 static/js/impala-min.js:8 static/js/impala/collections.js:19
+msgid "Stop Following"
+msgstr "Şŧǿƥ Ƒǿŀŀǿẇīƞɠ"
+
+#: static/js/impala-all.js:14243 static/js/impala-min.js:8 static/js/impala/collections.js:20
+msgid "Following"
+msgstr "Ƒǿŀŀǿẇīƞɠ"
+
+#: static/js/impala-all.js:14313 static/js/impala-min.js:8 static/js/impala/users.js:33
+msgid "use original"
+msgstr "ŭşḗ ǿřīɠīƞȧŀ"
+
+#: static/js/impala-all.js:14523 static/js/impala-min.js:8 static/js/impala/search.js:114
+msgid "Updating results&hellip;"
+msgstr "Ŭƥḓȧŧīƞɠ řḗşŭŀŧş&hellip;"
+
+#: static/js/common/upload-addon.js:69 static/js/zamboni/devhub-all.js:300 static/js/zamboni/devhub-min.js:1
 msgid "Select a file..."
 msgstr "Şḗŀḗƈŧ ȧ ƒīŀḗ..."
 
-#: static/js/common/upload-addon.js:70
+#: static/js/common/upload-addon.js:70 static/js/zamboni/devhub-all.js:301 static/js/zamboni/devhub-min.js:1
 msgid "Your add-on should end with .xpi, .jar or .xml"
 msgstr "Ẏǿŭř ȧḓḓ-ǿƞ şħǿŭŀḓ ḗƞḓ ẇīŧħ .ẋƥī, .ĵȧř ǿř .ẋḿŀ"
 
 #. L10n: {0} is the percent of the file that has been uploaded.
-#: static/js/common/upload-addon.js:104
+#: static/js/common/upload-addon.js:104 static/js/zamboni/devhub-all.js:335 static/js/zamboni/devhub-min.js:1
 #, python-format
 msgid "{0}% complete"
 msgstr "{0}% cǿḿƥŀḗŧḗ"
 
 #. L10n: "{bytes uploaded} of {total filesize}".
-#: static/js/common/upload-addon.js:107
+#: static/js/common/upload-addon.js:107 static/js/zamboni/devhub-all.js:338 static/js/zamboni/devhub-min.js:1
 msgid "{0} of {1}"
 msgstr "{0} ǿƒ {1}"
 
-#: static/js/common/upload-addon.js:140
+#: static/js/common/upload-addon.js:140 static/js/zamboni/devhub-all.js:371 static/js/zamboni/devhub-min.js:1
 msgid "Cancel"
 msgstr "Ƈȧƞƈḗŀ"
 
-#: static/js/common/upload-addon.js:162
+#: static/js/common/upload-addon.js:162 static/js/zamboni/devhub-all.js:393 static/js/zamboni/devhub-min.js:1
 msgid "Uploading {0}"
 msgstr "Ŭƥŀǿȧḓīƞɠ {0}"
 
-#: static/js/common/upload-addon.js:189
+#: static/js/common/upload-addon.js:189 static/js/zamboni/devhub-all.js:420 static/js/zamboni/devhub-min.js:1
 msgid "Error with {0}"
 msgstr "Ḗřřǿř ẇīŧħ {0}"
 
-#: static/js/common/upload-addon.js:194
+#: static/js/common/upload-addon.js:194 static/js/zamboni/devhub-all.js:425 static/js/zamboni/devhub-min.js:1
 msgid "Your add-on failed validation with {0} error."
 msgid_plural "Your add-on failed validation with {0} errors."
 msgstr[0] "Ẏǿŭř ȧḓḓ-ǿƞ ƒȧīŀḗḓ ṽȧŀīḓȧŧīǿƞ ẇīŧħ {0} ḗřřǿř."
 msgstr[1] "Ẏǿŭř ȧḓḓ-ǿƞ ƒȧīŀḗḓ ṽȧŀīḓȧŧīǿƞ ẇīŧħ {0} ḗřřǿřş."
 
-#: static/js/common/upload-addon.js:208
+#: static/js/common/upload-addon.js:208 static/js/zamboni/devhub-all.js:439 static/js/zamboni/devhub-min.js:1
 msgid "&hellip;and {0} more"
 msgid_plural "&hellip;and {0} more"
 msgstr[0] "&hellip;ȧƞḓ {0} ḿǿřḗ"
 msgstr[1] "&hellip;ȧƞḓ {0} ḿǿřḗ"
 
-#: static/js/common/upload-addon.js:222 static/js/common/upload-addon.js:512
+#: static/js/common/upload-addon.js:222 static/js/common/upload-addon.js:497 static/js/zamboni/devhub-all.js:453 static/js/zamboni/devhub-all.js:743 static/js/zamboni/devhub-min.js:1
 msgid "See full validation report"
 msgstr "Şḗḗ ƒŭŀŀ ṽȧŀīḓȧŧīǿƞ řḗƥǿřŧ"
 
-#: static/js/common/upload-addon.js:234
+#: static/js/common/upload-addon.js:234 static/js/zamboni/devhub-all.js:465 static/js/zamboni/devhub-min.js:1
 msgid "Validating {0}"
 msgstr "Ṽȧŀīḓȧŧīƞɠ {0}"
 
 #. L10n: first argument is an HTTP status code
-#: static/js/common/upload-addon.js:273
+#: static/js/common/upload-addon.js:273 static/js/zamboni/devhub-all.js:504 static/js/zamboni/devhub-min.js:1
 msgid "Received an empty response from the server; status: {0}"
 msgstr "Řḗƈḗīṽḗḓ ȧƞ ḗḿƥŧẏ řḗşƥǿƞşḗ ƒřǿḿ ŧħḗ şḗřṽḗř; şŧȧŧŭş: {0}"
 
-#: static/js/common/upload-addon.js:373
+#: static/js/common/upload-addon.js:370 static/js/zamboni/devhub-all.js:604 static/js/zamboni/devhub-min.js:1
 msgid "Unexpected server error while validating."
 msgstr "Ŭƞḗẋƥḗƈŧḗḓ şḗřṽḗř ḗřřǿř ẇħīŀḗ ṽȧŀīḓȧŧīƞɠ."
 
-#: static/js/common/upload-addon.js:412
+#: static/js/common/upload-addon.js:409 static/js/zamboni/devhub-all.js:643 static/js/zamboni/devhub-min.js:1
 msgid "Finished validating {0}"
 msgstr "Ƒīƞīşħḗḓ ṽȧŀīḓȧŧīƞɠ {0}"
 
-#: static/js/common/upload-addon.js:418
+#: static/js/common/upload-addon.js:415 static/js/zamboni/devhub-all.js:649 static/js/zamboni/devhub-min.js:1
 msgid "Your add-on validation timed out, it will be manually reviewed."
 msgstr "Ẏǿŭř ȧḓḓ-ǿƞ ṽȧŀīḓȧŧīǿƞ ŧīḿḗḓ ǿŭŧ, īŧ ẇīŀŀ ƀḗ ḿȧƞŭȧŀŀẏ řḗṽīḗẇḗḓ."
 
-#: static/js/common/upload-addon.js:421
+#: static/js/common/upload-addon.js:418 static/js/zamboni/devhub-all.js:652 static/js/zamboni/devhub-min.js:1
 msgid "Your add-on was validated with no errors and {0} warning."
 msgid_plural "Your add-on was validated with no errors and {0} warnings."
 msgstr[0] "Ẏǿŭř ȧḓḓ-ǿƞ ẇȧş ṽȧŀīḓȧŧḗḓ ẇīŧħ ƞǿ ḗřřǿřş ȧƞḓ {0} ẇȧřƞīƞɠ."
 msgstr[1] "Ẏǿŭř ȧḓḓ-ǿƞ ẇȧş ṽȧŀīḓȧŧḗḓ ẇīŧħ ƞǿ ḗřřǿřş ȧƞḓ {0} ẇȧřƞīƞɠş."
 
-#: static/js/common/upload-addon.js:426
+#: static/js/common/upload-addon.js:423 static/js/zamboni/devhub-all.js:657 static/js/zamboni/devhub-min.js:1
 msgid "Your add-on was validated with no errors and {0} message."
 msgid_plural "Your add-on was validated with no errors and {0} messages."
 msgstr[0] "Ẏǿŭř ȧḓḓ-ǿƞ ẇȧş ṽȧŀīḓȧŧḗḓ ẇīŧħ ƞǿ ḗřřǿřş ȧƞḓ {0} ḿḗşşȧɠḗ."
 msgstr[1] "Ẏǿŭř ȧḓḓ-ǿƞ ẇȧş ṽȧŀīḓȧŧḗḓ ẇīŧħ ƞǿ ḗřřǿřş ȧƞḓ {0} ḿḗşşȧɠḗş."
 
-#: static/js/common/upload-addon.js:431
+#: static/js/common/upload-addon.js:428 static/js/zamboni/devhub-all.js:662 static/js/zamboni/devhub-min.js:1
 msgid "Your add-on was validated with no errors or warnings."
 msgstr "Ẏǿŭř ȧḓḓ-ǿƞ ẇȧş ṽȧŀīḓȧŧḗḓ ẇīŧħ ƞǿ ḗřřǿřş ǿř ẇȧřƞīƞɠş."
 
-#: static/js/common/upload-addon.js:446
+#: static/js/common/upload-addon.js:443 static/js/zamboni/devhub-all.js:677 static/js/zamboni/devhub-min.js:1
 msgid "Your submission will be automatically signed."
 msgstr "Ẏǿŭř şŭƀḿīşşīǿƞ ẇīŀŀ ƀḗ ȧŭŧǿḿȧŧīƈȧŀŀẏ şīɠƞḗḓ."
 
-#: static/js/common/upload-addon.js:465
+#: static/js/common/upload-addon.js:450 static/js/zamboni/devhub-all.js:696 static/js/zamboni/devhub-min.js:1
 msgid "Include detailed version notes (this can be done in the next step)."
 msgstr "Īƞƈŀŭḓḗ ḓḗŧȧīŀḗḓ ṽḗřşīǿƞ ƞǿŧḗş (ŧħīş ƈȧƞ ƀḗ ḓǿƞḗ īƞ ŧħḗ ƞḗẋŧ şŧḗƥ)."
 
-#: static/js/common/upload-addon.js:466
+#: static/js/common/upload-addon.js:451 static/js/zamboni/devhub-all.js:697 static/js/zamboni/devhub-min.js:1
 msgid "If your add-on requires an account to a website in order to be fully tested, include a test username and password in the Notes to Reviewer (this can be done in the next step)."
 msgstr "Īƒ ẏǿŭř ȧḓḓ-ǿƞ řḗɋŭīřḗş ȧƞ ȧƈƈǿŭƞŧ ŧǿ ȧ ẇḗƀşīŧḗ īƞ ǿřḓḗř ŧǿ ƀḗ ƒŭŀŀẏ ŧḗşŧḗḓ, īƞƈŀŭḓḗ ȧ ŧḗşŧ ŭşḗřƞȧḿḗ ȧƞḓ ƥȧşşẇǿřḓ īƞ ŧħḗ Ƞǿŧḗş ŧǿ Řḗṽīḗẇḗř (ŧħīş ƈȧƞ ƀḗ ḓǿƞḗ īƞ ŧħḗ ƞḗẋŧ şŧḗƥ)."
 
-#: static/js/common/upload-addon.js:467
+#: static/js/common/upload-addon.js:452 static/js/zamboni/devhub-all.js:698 static/js/zamboni/devhub-min.js:1
 msgid "If your add-on is intended for a limited audience you should choose Preliminary Review instead of Full Review."
 msgstr "Īƒ ẏǿŭř ȧḓḓ-ǿƞ īş īƞŧḗƞḓḗḓ ƒǿř ȧ ŀīḿīŧḗḓ ȧŭḓīḗƞƈḗ ẏǿŭ şħǿŭŀḓ ƈħǿǿşḗ Ƥřḗŀīḿīƞȧřẏ Řḗṽīḗẇ īƞşŧḗȧḓ ǿƒ Ƒŭŀŀ Řḗṽīḗẇ."
 
-#: static/js/common/upload-addon.js:480
+#: static/js/common/upload-addon.js:465 static/js/zamboni/devhub-all.js:711 static/js/zamboni/devhub-min.js:1
 msgid "Add-on submission checklist"
 msgstr "Ȧḓḓ-ǿƞ şŭƀḿīşşīǿƞ ƈħḗƈķŀīşŧ"
 
-#: static/js/common/upload-addon.js:481
+#: static/js/common/upload-addon.js:466 static/js/zamboni/devhub-all.js:712 static/js/zamboni/devhub-min.js:1
 msgid "Please verify the following points before finalizing your submission. This will minimize delays or misunderstanding during the review process:"
 msgstr "Ƥŀḗȧşḗ ṽḗřīƒẏ ŧħḗ ƒǿŀŀǿẇīƞɠ ƥǿīƞŧş ƀḗƒǿřḗ ƒīƞȧŀīzīƞɠ ẏǿŭř şŭƀḿīşşīǿƞ. Ŧħīş ẇīŀŀ ḿīƞīḿīzḗ ḓḗŀȧẏş ǿř ḿīşŭƞḓḗřşŧȧƞḓīƞɠ ḓŭřīƞɠ ŧħḗ řḗṽīḗẇ ƥřǿƈḗşş:"
 
-#: static/js/common/upload-addon.js:483
+#: static/js/common/upload-addon.js:468 static/js/zamboni/devhub-all.js:714 static/js/zamboni/devhub-min.js:1
 msgid ""
 "Compiled binaries, as well as minified or obfuscated scripts (excluding known libraries) need to have their sources submitted separately for review. Make sure that you use the source code upload "
 "field to avoid having your submission rejected."
@@ -139,1080 +395,844 @@ msgstr ""
 "Ƈǿḿƥīŀḗḓ ƀīƞȧřīḗş, ȧş ẇḗŀŀ ȧş ḿīƞīƒīḗḓ ǿř ǿƀƒŭşƈȧŧḗḓ şƈřīƥŧş (ḗẋƈŀŭḓīƞɠ ķƞǿẇƞ ŀīƀřȧřīḗş) ƞḗḗḓ ŧǿ ħȧṽḗ ŧħḗīř şǿŭřƈḗş şŭƀḿīŧŧḗḓ şḗƥȧřȧŧḗŀẏ ƒǿř řḗṽīḗẇ. Ḿȧķḗ şŭřḗ ŧħȧŧ ẏǿŭ ŭşḗ ŧħḗ şǿŭřƈḗ ƈǿḓḗ ŭƥŀǿȧḓ "
 "ƒīḗŀḓ ŧǿ ȧṽǿīḓ ħȧṽīƞɠ ẏǿŭř şŭƀḿīşşīǿƞ řḗĵḗƈŧḗḓ."
 
-#: static/js/common/upload-addon.js:501
+#: static/js/common/upload-addon.js:486 static/js/zamboni/devhub-all.js:732 static/js/zamboni/devhub-min.js:1
 msgid "The validation process found these issues that can lead to rejections:"
 msgstr "Ŧħḗ ṽȧŀīḓȧŧīǿƞ ƥřǿƈḗşş ƒǿŭƞḓ ŧħḗşḗ īşşŭḗş ŧħȧŧ ƈȧƞ ŀḗȧḓ ŧǿ řḗĵḗƈŧīǿƞş:"
 
-#: static/js/common/upload-addon.js:518
+#: static/js/common/upload-addon.js:503 static/js/zamboni/devhub-all.js:749 static/js/zamboni/devhub-min.js:1
 msgid "If you are unfamiliar with the add-ons review process, you can read about it here."
 msgstr "Īƒ ẏǿŭ ȧřḗ ŭƞƒȧḿīŀīȧř ẇīŧħ ŧħḗ ȧḓḓ-ǿƞş řḗṽīḗẇ ƥřǿƈḗşş, ẏǿŭ ƈȧƞ řḗȧḓ ȧƀǿŭŧ īŧ ħḗřḗ."
 
-#: static/js/common/upload-addon.js:555
+#: static/js/common/upload-addon.js:540 static/js/zamboni/devhub-all.js:786 static/js/zamboni/devhub-min.js:1
 msgid "Sorry, no supported platform has been found."
 msgstr "Şǿřřẏ, ƞǿ şŭƥƥǿřŧḗḓ ƥŀȧŧƒǿřḿ ħȧş ƀḗḗƞ ƒǿŭƞḓ."
 
-#: static/js/common/upload-base.js:57
+#: static/js/common/upload-base.js:57 static/js/zamboni/devhub-all.js:187 static/js/zamboni/devhub-min.js:1
 msgid "The filetype you uploaded isn't recognized."
 msgstr "Ŧħḗ ƒīŀḗŧẏƥḗ ẏǿŭ ŭƥŀǿȧḓḗḓ īşƞ'ŧ řḗƈǿɠƞīzḗḓ."
 
-#: static/js/common/upload-base.js:79
+#: static/js/common/upload-base.js:79 static/js/zamboni/devhub-all.js:209 static/js/zamboni/devhub-min.js:1
 msgid "You cancelled the upload."
 msgstr "Ẏǿŭ ƈȧƞƈḗŀŀḗḓ ŧħḗ ŭƥŀǿȧḓ."
 
-#: static/js/common/upload-image.js:97 static/js/impala/users.js:51
-msgid "Images must be either PNG or JPG."
-msgstr "Īḿȧɠḗş ḿŭşŧ ƀḗ ḗīŧħḗř ƤȠƓ ǿř ĴƤƓ."
-
-#: static/js/common/upload-image.js:101
-msgid "Videos must be in WebM."
-msgstr "Ṽīḓḗǿş ḿŭşŧ ƀḗ īƞ ẆḗƀḾ."
-
-#: static/js/impala/collections.js:10 static/js/zamboni/collections.js:595
-msgid "Follow this Collection"
-msgstr "Ƒǿŀŀǿẇ ŧħīş Ƈǿŀŀḗƈŧīǿƞ"
-
-#: static/js/impala/collections.js:19
-msgid "Stop Following"
-msgstr "Şŧǿƥ Ƒǿŀŀǿẇīƞɠ"
-
-#: static/js/impala/collections.js:20
-msgid "Following"
-msgstr "Ƒǿŀŀǿẇīƞɠ"
-
-#. L10n: {0} is an app name.
-#: static/js/impala/listing.js:11 static/js/zamboni/themes.js:13
-msgid "This theme is incompatible with your version of {0}"
-msgstr "Ŧħīş ŧħḗḿḗ īş īƞƈǿḿƥȧŧīƀŀḗ ẇīŧħ ẏǿŭř ṽḗřşīǿƞ ǿƒ {0}"
-
-#: static/js/impala/persona_creation.js:60
-msgid "All Rights Reserved"
-msgstr "Ȧŀŀ Řīɠħŧş Řḗşḗřṽḗḓ"
-
-#: static/js/impala/persona_creation.js:64
-msgid "Creative Commons Attribution 3.0"
-msgstr "Ƈřḗȧŧīṽḗ Ƈǿḿḿǿƞş Ȧŧŧřīƀŭŧīǿƞ 3.0"
-
-#: static/js/impala/persona_creation.js:69
-msgid "Creative Commons Attribution-NonCommercial 3.0"
-msgstr "Ƈřḗȧŧīṽḗ Ƈǿḿḿǿƞş Ȧŧŧřīƀŭŧīǿƞ-ȠǿƞƇǿḿḿḗřƈīȧŀ 3.0"
-
-#: static/js/impala/persona_creation.js:74
-msgid "Creative Commons Attribution-NonCommercial-NoDerivs 3.0"
-msgstr "Ƈřḗȧŧīṽḗ Ƈǿḿḿǿƞş Ȧŧŧřīƀŭŧīǿƞ-ȠǿƞƇǿḿḿḗřƈīȧŀ-ȠǿḒḗřīṽş 3.0"
-
-#: static/js/impala/persona_creation.js:79
-msgid "Creative Commons Attribution-NonCommercial-Share Alike 3.0"
-msgstr "Ƈřḗȧŧīṽḗ Ƈǿḿḿǿƞş Ȧŧŧřīƀŭŧīǿƞ-ȠǿƞƇǿḿḿḗřƈīȧŀ-Şħȧřḗ Ȧŀīķḗ 3.0"
-
-#: static/js/impala/persona_creation.js:84
-msgid "Creative Commons Attribution-NoDerivs 3.0"
-msgstr "Ƈřḗȧŧīṽḗ Ƈǿḿḿǿƞş Ȧŧŧřīƀŭŧīǿƞ-ȠǿḒḗřīṽş 3.0"
-
-#: static/js/impala/persona_creation.js:89
-msgid "Creative Commons Attribution-ShareAlike 3.0"
-msgstr "Ƈřḗȧŧīṽḗ Ƈǿḿḿǿƞş Ȧŧŧřīƀŭŧīǿƞ-ŞħȧřḗȦŀīķḗ 3.0"
-
-#: static/js/impala/persona_creation.js:292
-msgid "Your Theme's Name"
-msgstr "Ẏǿŭř Ŧħḗḿḗ'ş Ƞȧḿḗ"
-
-#: static/js/impala/reviews.js:23 static/js/zamboni/reviews.js:18
-msgid "Flagged for review"
-msgstr "Ƒŀȧɠɠḗḓ ƒǿř řḗṽīḗẇ"
-
-#: static/js/impala/reviews.js:40 static/js/zamboni/reviews.js:34
-msgid "Your input is required"
-msgstr "Ẏǿŭř īƞƥŭŧ īş řḗɋŭīřḗḓ"
-
-#: static/js/impala/reviews.js:152 static/js/zamboni/reviews.js:103
-msgid "Marked for deletion"
-msgstr "Ḿȧřķḗḓ ƒǿř ḓḗŀḗŧīǿƞ"
-
-#: static/js/impala/search.js:114
-msgid "Updating results&hellip;"
-msgstr "Ŭƥḓȧŧīƞɠ řḗşŭŀŧş&hellip;"
-
-#: static/js/impala/site_suggestions.js:46
-msgid "Category"
-msgstr "Ƈȧŧḗɠǿřẏ"
-
-#: static/js/impala/suggestions.js:39
-msgid "Search themes for <b>{0}</b>"
-msgstr "Şḗȧřƈħ ŧħḗḿḗş ƒǿř <b>{0}</b>"
-
-#: static/js/impala/suggestions.js:41
-msgid "Search apps for <b>{0}</b>"
-msgstr "Şḗȧřƈħ ȧƥƥş ƒǿř <b>{0}</b>"
-
-#: static/js/impala/suggestions.js:43
-msgid "Search add-ons for <b>{0}</b>"
-msgstr "Şḗȧřƈħ ȧḓḓ-ǿƞş ƒǿř <b>{0}</b>"
-
-#: static/js/impala/users.js:33
-msgid "use original"
-msgstr "ŭşḗ ǿřīɠīƞȧŀ"
-
-#: static/js/impala/stats/chart.js:267
+#: static/js/impala/stats/chart.js:267 static/js/zamboni/stats-all.js:16898 static/js/zamboni/stats-min.js:5
 msgid "Week of {0}"
 msgstr "Ẇḗḗķ ǿƒ {0}"
 
-#: static/js/impala/stats/chart.js:269
+#: static/js/impala/stats/chart.js:269 static/js/zamboni/stats-all.js:16900 static/js/zamboni/stats-min.js:5
 msgid " downloads"
-msgstr " ḓǿẇƞŀǿȧḓş"
+msgstr ""
 
-#: static/js/impala/stats/chart.js:270
+#: static/js/impala/stats/chart.js:270 static/js/zamboni/stats-all.js:16901 static/js/zamboni/stats-min.js:5
 msgid "{0} users"
 msgstr "{0} ŭşḗřş"
 
-#: static/js/impala/stats/chart.js:271
+#: static/js/impala/stats/chart.js:271 static/js/zamboni/stats-all.js:16902 static/js/zamboni/stats-min.js:5
 msgid "{0} add-ons"
 msgstr "{0} ȧḓḓ-ǿƞş"
 
-#: static/js/impala/stats/chart.js:272
+#: static/js/impala/stats/chart.js:272 static/js/zamboni/stats-all.js:16903 static/js/zamboni/stats-min.js:5
 msgid "{0} collections"
 msgstr "{0} ƈǿŀŀḗƈŧīǿƞş"
 
-#: static/js/impala/stats/chart.js:273
+#: static/js/impala/stats/chart.js:273 static/js/zamboni/stats-all.js:16904 static/js/zamboni/stats-min.js:5
 msgid "{0} reviews"
 msgstr "{0} řḗṽīḗẇş"
 
-#: static/js/impala/stats/chart.js:275
+#: static/js/impala/stats/chart.js:275 static/js/zamboni/stats-all.js:16906 static/js/zamboni/stats-min.js:5
 msgid "{0} sales"
 msgstr "{0} şȧŀḗş"
 
-#: static/js/impala/stats/chart.js:276
+#: static/js/impala/stats/chart.js:276 static/js/zamboni/stats-all.js:16907 static/js/zamboni/stats-min.js:5
 msgid "{0} refunds"
 msgstr "{0} řḗƒŭƞḓş"
 
-#: static/js/impala/stats/chart.js:277
+#: static/js/impala/stats/chart.js:277 static/js/zamboni/stats-all.js:16908 static/js/zamboni/stats-min.js:5
 msgid "{0} installs"
 msgstr "{0} īƞşŧȧŀŀş"
 
-#: static/js/impala/stats/chart.js:369 static/js/impala/stats/csv_keys.js:3 static/js/impala/stats/csv_keys.js:109
+#: static/js/impala/stats/chart.js:369 static/js/impala/stats/csv_keys.js:3 static/js/impala/stats/csv_keys.js:109 static/js/zamboni/stats-all.js:15284 static/js/zamboni/stats-all.js:15390
+#: static/js/zamboni/stats-all.js:17000 static/js/zamboni/stats-min.js:4 static/js/zamboni/stats-min.js:5
 msgid "Downloads"
 msgstr "Ḓǿẇƞŀǿȧḓş"
 
-#: static/js/impala/stats/chart.js:379 static/js/impala/stats/csv_keys.js:6 static/js/impala/stats/csv_keys.js:110
+#: static/js/impala/stats/chart.js:379 static/js/impala/stats/csv_keys.js:6 static/js/impala/stats/csv_keys.js:110 static/js/zamboni/stats-all.js:15287 static/js/zamboni/stats-all.js:15391
+#: static/js/zamboni/stats-all.js:17010 static/js/zamboni/stats-min.js:4 static/js/zamboni/stats-min.js:5
 msgid "Daily Users"
 msgstr "Ḓȧīŀẏ Ŭşḗřş"
 
-#: static/js/impala/stats/chart.js:410
+#: static/js/impala/stats/chart.js:410 static/js/zamboni/stats-all.js:17041 static/js/zamboni/stats-min.js:5
 msgid "Amount, in USD"
 msgstr "Ȧḿǿŭƞŧ, īƞ ŬŞḒ"
 
-#: static/js/impala/stats/chart.js:421 static/js/impala/stats/csv_keys.js:104
+#: static/js/impala/stats/chart.js:421 static/js/impala/stats/csv_keys.js:104 static/js/zamboni/stats-all.js:15385 static/js/zamboni/stats-all.js:17052 static/js/zamboni/stats-min.js:5
 msgid "Number of Contributions"
 msgstr "Ƞŭḿƀḗř ǿƒ Ƈǿƞŧřīƀŭŧīǿƞş"
 
-#: static/js/impala/stats/chart.js:447
+#: static/js/impala/stats/chart.js:447 static/js/zamboni/stats-all.js:17078 static/js/zamboni/stats-min.js:5
 msgid "More Info..."
 msgstr "Ḿǿřḗ Īƞƒǿ..."
 
 #. L10n: {0} is an ISO-formatted date.
-#: static/js/impala/stats/chart.js:451
+#: static/js/impala/stats/chart.js:451 static/js/zamboni/stats-all.js:17082 static/js/zamboni/stats-min.js:5
 msgid "Details for {0}"
 msgstr "Ḓḗŧȧīŀş ƒǿř {0}"
 
-#: static/js/impala/stats/csv_keys.js:9
+#: static/js/impala/stats/csv_keys.js:9 static/js/zamboni/stats-all.js:15290 static/js/zamboni/stats-min.js:4
 msgid "Collections Created"
 msgstr "Ƈǿŀŀḗƈŧīǿƞş Ƈřḗȧŧḗḓ"
 
-#: static/js/impala/stats/csv_keys.js:12
+#: static/js/impala/stats/csv_keys.js:12 static/js/zamboni/stats-all.js:15293 static/js/zamboni/stats-min.js:4
 msgid "Add-ons in Use"
 msgstr "Ȧḓḓ-ǿƞş īƞ Ŭşḗ"
 
-#: static/js/impala/stats/csv_keys.js:15
+#: static/js/impala/stats/csv_keys.js:15 static/js/zamboni/stats-all.js:15296 static/js/zamboni/stats-min.js:4
 msgid "Add-ons Created"
 msgstr "Ȧḓḓ-ǿƞş Ƈřḗȧŧḗḓ"
 
-#: static/js/impala/stats/csv_keys.js:18
+#: static/js/impala/stats/csv_keys.js:18 static/js/zamboni/stats-all.js:15299 static/js/zamboni/stats-min.js:4
 msgid "Add-ons Downloaded"
 msgstr "Ȧḓḓ-ǿƞş Ḓǿẇƞŀǿȧḓḗḓ"
 
-#: static/js/impala/stats/csv_keys.js:21
+#: static/js/impala/stats/csv_keys.js:21 static/js/zamboni/stats-all.js:15302 static/js/zamboni/stats-min.js:4
 msgid "Add-ons Updated"
 msgstr "Ȧḓḓ-ǿƞş Ŭƥḓȧŧḗḓ"
 
-#: static/js/impala/stats/csv_keys.js:24
+#: static/js/impala/stats/csv_keys.js:24 static/js/zamboni/stats-all.js:15305 static/js/zamboni/stats-min.js:4
 msgid "Reviews Written"
 msgstr "Řḗṽīḗẇş Ẇřīŧŧḗƞ"
 
-#: static/js/impala/stats/csv_keys.js:27
+#: static/js/impala/stats/csv_keys.js:27 static/js/zamboni/stats-all.js:15308 static/js/zamboni/stats-min.js:4
 msgid "User Signups"
 msgstr "Ŭşḗř Şīɠƞŭƥş"
 
-#: static/js/impala/stats/csv_keys.js:30
+#: static/js/impala/stats/csv_keys.js:30 static/js/zamboni/stats-all.js:15311 static/js/zamboni/stats-min.js:4
 msgid "Subscribers"
 msgstr "Şŭƀşƈřīƀḗřş"
 
-#: static/js/impala/stats/csv_keys.js:33
+#: static/js/impala/stats/csv_keys.js:33 static/js/zamboni/stats-all.js:15314 static/js/zamboni/stats-min.js:4
 msgid "Ratings"
 msgstr "Řȧŧīƞɠş"
 
-#: static/js/impala/stats/csv_keys.js:36 static/js/impala/stats/csv_keys.js:114
+#: static/js/impala/stats/csv_keys.js:36 static/js/impala/stats/csv_keys.js:114 static/js/zamboni/stats-all.js:15317 static/js/zamboni/stats-all.js:15395 static/js/zamboni/stats-min.js:4
+#: static/js/zamboni/stats-min.js:5
 msgid "Sales"
 msgstr "Şȧŀḗş"
 
-#: static/js/impala/stats/csv_keys.js:39 static/js/impala/stats/csv_keys.js:113
+#: static/js/impala/stats/csv_keys.js:39 static/js/impala/stats/csv_keys.js:113 static/js/zamboni/stats-all.js:15320 static/js/zamboni/stats-all.js:15394 static/js/zamboni/stats-min.js:4
+#: static/js/zamboni/stats-min.js:5
 msgid "Installs"
 msgstr "Īƞşŧȧŀŀş"
 
-#: static/js/impala/stats/csv_keys.js:42
+#: static/js/impala/stats/csv_keys.js:42 static/js/zamboni/stats-all.js:15323 static/js/zamboni/stats-min.js:4
 msgid "Unknown"
 msgstr "Ŭƞķƞǿẇƞ"
 
-#: static/js/impala/stats/csv_keys.js:43
+#: static/js/impala/stats/csv_keys.js:43 static/js/zamboni/stats-all.js:15324 static/js/zamboni/stats-min.js:4
 msgid "Add-ons Manager"
 msgstr "Ȧḓḓ-ǿƞş Ḿȧƞȧɠḗř"
 
-#: static/js/impala/stats/csv_keys.js:44
+#: static/js/impala/stats/csv_keys.js:44 static/js/zamboni/stats-all.js:15325 static/js/zamboni/stats-min.js:4
 msgid "Add-ons Manager Promo"
 msgstr "Ȧḓḓ-ǿƞş Ḿȧƞȧɠḗř Ƥřǿḿǿ"
 
-#: static/js/impala/stats/csv_keys.js:45
+#: static/js/impala/stats/csv_keys.js:45 static/js/zamboni/stats-all.js:15326 static/js/zamboni/stats-min.js:4
 msgid "Add-ons Manager Featured"
 msgstr "Ȧḓḓ-ǿƞş Ḿȧƞȧɠḗř Ƒḗȧŧŭřḗḓ"
 
-#: static/js/impala/stats/csv_keys.js:46
+#: static/js/impala/stats/csv_keys.js:46 static/js/zamboni/stats-all.js:15327 static/js/zamboni/stats-min.js:4
 msgid "Add-ons Manager Learn More"
 msgstr "Ȧḓḓ-ǿƞş Ḿȧƞȧɠḗř Ŀḗȧřƞ Ḿǿřḗ"
 
-#: static/js/impala/stats/csv_keys.js:47
+#: static/js/impala/stats/csv_keys.js:47 static/js/zamboni/stats-all.js:15328 static/js/zamboni/stats-min.js:4
 msgid "Search Suggestions"
 msgstr "Şḗȧřƈħ Şŭɠɠḗşŧīǿƞş"
 
-#: static/js/impala/stats/csv_keys.js:48
+#: static/js/impala/stats/csv_keys.js:48 static/js/zamboni/stats-all.js:15329 static/js/zamboni/stats-min.js:4
 msgid "Search Results"
 msgstr "Şḗȧřƈħ Řḗşŭŀŧş"
 
-#: static/js/impala/stats/csv_keys.js:49 static/js/impala/stats/csv_keys.js:50 static/js/impala/stats/csv_keys.js:51
+#: static/js/impala/stats/csv_keys.js:49 static/js/impala/stats/csv_keys.js:50 static/js/impala/stats/csv_keys.js:51 static/js/zamboni/stats-all.js:15330 static/js/zamboni/stats-all.js:15331
+#: static/js/zamboni/stats-all.js:15332 static/js/zamboni/stats-min.js:4
 msgid "Homepage Promo"
 msgstr "Ħǿḿḗƥȧɠḗ Ƥřǿḿǿ"
 
-#: static/js/impala/stats/csv_keys.js:52 static/js/impala/stats/csv_keys.js:53
+#: static/js/impala/stats/csv_keys.js:52 static/js/impala/stats/csv_keys.js:53 static/js/zamboni/stats-all.js:15333 static/js/zamboni/stats-all.js:15334 static/js/zamboni/stats-min.js:4
 msgid "Homepage Featured"
 msgstr "Ħǿḿḗƥȧɠḗ Ƒḗȧŧŭřḗḓ"
 
-#: static/js/impala/stats/csv_keys.js:54 static/js/impala/stats/csv_keys.js:55
+#: static/js/impala/stats/csv_keys.js:54 static/js/impala/stats/csv_keys.js:55 static/js/zamboni/stats-all.js:15335 static/js/zamboni/stats-all.js:15336 static/js/zamboni/stats-min.js:4
 msgid "Homepage Up and Coming"
 msgstr "Ħǿḿḗƥȧɠḗ Ŭƥ ȧƞḓ Ƈǿḿīƞɠ"
 
-#: static/js/impala/stats/csv_keys.js:56
+#: static/js/impala/stats/csv_keys.js:56 static/js/zamboni/stats-all.js:15337 static/js/zamboni/stats-min.js:4
 msgid "Homepage Most Popular"
 msgstr "Ħǿḿḗƥȧɠḗ Ḿǿşŧ Ƥǿƥŭŀȧř"
 
-#: static/js/impala/stats/csv_keys.js:57 static/js/impala/stats/csv_keys.js:59
+#: static/js/impala/stats/csv_keys.js:57 static/js/impala/stats/csv_keys.js:59 static/js/zamboni/stats-all.js:15338 static/js/zamboni/stats-all.js:15340 static/js/zamboni/stats-min.js:4
 msgid "Detail Page"
 msgstr "Ḓḗŧȧīŀ Ƥȧɠḗ"
 
-#: static/js/impala/stats/csv_keys.js:58 static/js/impala/stats/csv_keys.js:60
+#: static/js/impala/stats/csv_keys.js:58 static/js/impala/stats/csv_keys.js:60 static/js/zamboni/stats-all.js:15339 static/js/zamboni/stats-all.js:15341 static/js/zamboni/stats-min.js:4
 msgid "Detail Page (bottom)"
 msgstr "Ḓḗŧȧīŀ Ƥȧɠḗ (ƀǿŧŧǿḿ)"
 
-#: static/js/impala/stats/csv_keys.js:61
+#: static/js/impala/stats/csv_keys.js:61 static/js/zamboni/stats-all.js:15342 static/js/zamboni/stats-min.js:4
 msgid "Detail Page (Development Channel)"
 msgstr "Ḓḗŧȧīŀ Ƥȧɠḗ (Ḓḗṽḗŀǿƥḿḗƞŧ Ƈħȧƞƞḗŀ)"
 
-#: static/js/impala/stats/csv_keys.js:62 static/js/impala/stats/csv_keys.js:63 static/js/impala/stats/csv_keys.js:64
+#: static/js/impala/stats/csv_keys.js:62 static/js/impala/stats/csv_keys.js:63 static/js/impala/stats/csv_keys.js:64 static/js/zamboni/stats-all.js:15343 static/js/zamboni/stats-all.js:15344
+#: static/js/zamboni/stats-all.js:15345 static/js/zamboni/stats-min.js:4
 msgid "Often Used With"
 msgstr "Ǿƒŧḗƞ Ŭşḗḓ Ẇīŧħ"
 
-#: static/js/impala/stats/csv_keys.js:65 static/js/impala/stats/csv_keys.js:66
+#: static/js/impala/stats/csv_keys.js:65 static/js/impala/stats/csv_keys.js:66 static/js/zamboni/stats-all.js:15346 static/js/zamboni/stats-all.js:15347 static/js/zamboni/stats-min.js:4
 msgid "Others By Author"
 msgstr "Ǿŧħḗřş Ɓẏ Ȧŭŧħǿř"
 
-#: static/js/impala/stats/csv_keys.js:67 static/js/impala/stats/csv_keys.js:68
+#: static/js/impala/stats/csv_keys.js:67 static/js/impala/stats/csv_keys.js:68 static/js/zamboni/stats-all.js:15348 static/js/zamboni/stats-all.js:15349 static/js/zamboni/stats-min.js:4
 msgid "Dependencies"
 msgstr "Ḓḗƥḗƞḓḗƞƈīḗş"
 
-#: static/js/impala/stats/csv_keys.js:69 static/js/impala/stats/csv_keys.js:70
+#: static/js/impala/stats/csv_keys.js:69 static/js/impala/stats/csv_keys.js:70 static/js/zamboni/stats-all.js:15350 static/js/zamboni/stats-all.js:15351 static/js/zamboni/stats-min.js:4
 msgid "Upsell"
 msgstr "Ŭƥşḗŀŀ"
 
-#: static/js/impala/stats/csv_keys.js:71
+#: static/js/impala/stats/csv_keys.js:71 static/js/zamboni/stats-all.js:15352 static/js/zamboni/stats-min.js:4
 msgid "Meet the Developer"
 msgstr "Ḿḗḗŧ ŧħḗ Ḓḗṽḗŀǿƥḗř"
 
-#: static/js/impala/stats/csv_keys.js:72
+#: static/js/impala/stats/csv_keys.js:72 static/js/zamboni/stats-all.js:15353 static/js/zamboni/stats-min.js:4
 msgid "User Profile"
 msgstr "Ŭşḗř Ƥřǿƒīŀḗ"
 
-#: static/js/impala/stats/csv_keys.js:73
+#: static/js/impala/stats/csv_keys.js:73 static/js/zamboni/stats-all.js:15354 static/js/zamboni/stats-min.js:4
 msgid "Version History"
 msgstr "Ṽḗřşīǿƞ Ħīşŧǿřẏ"
 
-#: static/js/impala/stats/csv_keys.js:75
+#: static/js/impala/stats/csv_keys.js:75 static/js/zamboni/stats-all.js:15356 static/js/zamboni/stats-min.js:4
 msgid "Sharing"
 msgstr "Şħȧřīƞɠ"
 
-#: static/js/impala/stats/csv_keys.js:76
+#: static/js/impala/stats/csv_keys.js:76 static/js/zamboni/stats-all.js:15357 static/js/zamboni/stats-min.js:4
 msgid "Category Pages"
 msgstr "Ƈȧŧḗɠǿřẏ Ƥȧɠḗş"
 
-#: static/js/impala/stats/csv_keys.js:77
+#: static/js/impala/stats/csv_keys.js:77 static/js/zamboni/stats-all.js:15358 static/js/zamboni/stats-min.js:4
 msgid "Collections"
 msgstr "Ƈǿŀŀḗƈŧīǿƞş"
 
-#: static/js/impala/stats/csv_keys.js:78 static/js/impala/stats/csv_keys.js:79
+#: static/js/impala/stats/csv_keys.js:78 static/js/impala/stats/csv_keys.js:79 static/js/zamboni/stats-all.js:15359 static/js/zamboni/stats-all.js:15360 static/js/zamboni/stats-min.js:4
 msgid "Category Landing Featured Carousel"
 msgstr "Ƈȧŧḗɠǿřẏ Ŀȧƞḓīƞɠ Ƒḗȧŧŭřḗḓ Ƈȧřǿŭşḗŀ"
 
-#: static/js/impala/stats/csv_keys.js:80 static/js/impala/stats/csv_keys.js:81
+#: static/js/impala/stats/csv_keys.js:80 static/js/impala/stats/csv_keys.js:81 static/js/zamboni/stats-all.js:15361 static/js/zamboni/stats-all.js:15362 static/js/zamboni/stats-min.js:4
 msgid "Category Landing Top Rated"
 msgstr "Ƈȧŧḗɠǿřẏ Ŀȧƞḓīƞɠ Ŧǿƥ Řȧŧḗḓ"
 
-#: static/js/impala/stats/csv_keys.js:82 static/js/impala/stats/csv_keys.js:83
+#: static/js/impala/stats/csv_keys.js:82 static/js/impala/stats/csv_keys.js:83 static/js/zamboni/stats-all.js:15363 static/js/zamboni/stats-all.js:15364 static/js/zamboni/stats-min.js:5
 msgid "Category Landing Most Popular"
 msgstr "Ƈȧŧḗɠǿřẏ Ŀȧƞḓīƞɠ Ḿǿşŧ Ƥǿƥŭŀȧř"
 
-#: static/js/impala/stats/csv_keys.js:84 static/js/impala/stats/csv_keys.js:85
+#: static/js/impala/stats/csv_keys.js:84 static/js/impala/stats/csv_keys.js:85 static/js/zamboni/stats-all.js:15365 static/js/zamboni/stats-all.js:15366 static/js/zamboni/stats-min.js:5
 msgid "Category Landing Recently Added"
 msgstr "Ƈȧŧḗɠǿřẏ Ŀȧƞḓīƞɠ Řḗƈḗƞŧŀẏ Ȧḓḓḗḓ"
 
-#: static/js/impala/stats/csv_keys.js:86 static/js/impala/stats/csv_keys.js:87
+#: static/js/impala/stats/csv_keys.js:86 static/js/impala/stats/csv_keys.js:87 static/js/zamboni/stats-all.js:15367 static/js/zamboni/stats-all.js:15368 static/js/zamboni/stats-min.js:5
 msgid "Browse Listing Featured Sort"
 msgstr "Ɓřǿẇşḗ Ŀīşŧīƞɠ Ƒḗȧŧŭřḗḓ Şǿřŧ"
 
-#: static/js/impala/stats/csv_keys.js:88 static/js/impala/stats/csv_keys.js:89
+#: static/js/impala/stats/csv_keys.js:88 static/js/impala/stats/csv_keys.js:89 static/js/zamboni/stats-all.js:15369 static/js/zamboni/stats-all.js:15370 static/js/zamboni/stats-min.js:5
 msgid "Browse Listing Users Sort"
 msgstr "Ɓřǿẇşḗ Ŀīşŧīƞɠ Ŭşḗřş Şǿřŧ"
 
-#: static/js/impala/stats/csv_keys.js:90 static/js/impala/stats/csv_keys.js:91
+#: static/js/impala/stats/csv_keys.js:90 static/js/impala/stats/csv_keys.js:91 static/js/zamboni/stats-all.js:15371 static/js/zamboni/stats-all.js:15372 static/js/zamboni/stats-min.js:5
 msgid "Browse Listing Rating Sort"
 msgstr "Ɓřǿẇşḗ Ŀīşŧīƞɠ Řȧŧīƞɠ Şǿřŧ"
 
-#: static/js/impala/stats/csv_keys.js:92 static/js/impala/stats/csv_keys.js:93
+#: static/js/impala/stats/csv_keys.js:92 static/js/impala/stats/csv_keys.js:93 static/js/zamboni/stats-all.js:15373 static/js/zamboni/stats-all.js:15374 static/js/zamboni/stats-min.js:5
 msgid "Browse Listing Created Sort"
 msgstr "Ɓřǿẇşḗ Ŀīşŧīƞɠ Ƈřḗȧŧḗḓ Şǿřŧ"
 
-#: static/js/impala/stats/csv_keys.js:94 static/js/impala/stats/csv_keys.js:95
+#: static/js/impala/stats/csv_keys.js:94 static/js/impala/stats/csv_keys.js:95 static/js/zamboni/stats-all.js:15375 static/js/zamboni/stats-all.js:15376 static/js/zamboni/stats-min.js:5
 msgid "Browse Listing Name Sort"
 msgstr "Ɓřǿẇşḗ Ŀīşŧīƞɠ Ƞȧḿḗ Şǿřŧ"
 
-#: static/js/impala/stats/csv_keys.js:96 static/js/impala/stats/csv_keys.js:97
+#: static/js/impala/stats/csv_keys.js:96 static/js/impala/stats/csv_keys.js:97 static/js/zamboni/stats-all.js:15377 static/js/zamboni/stats-all.js:15378 static/js/zamboni/stats-min.js:5
 msgid "Browse Listing Popular Sort"
 msgstr "Ɓřǿẇşḗ Ŀīşŧīƞɠ Ƥǿƥŭŀȧř Şǿřŧ"
 
-#: static/js/impala/stats/csv_keys.js:98 static/js/impala/stats/csv_keys.js:99
+#: static/js/impala/stats/csv_keys.js:98 static/js/impala/stats/csv_keys.js:99 static/js/zamboni/stats-all.js:15379 static/js/zamboni/stats-all.js:15380 static/js/zamboni/stats-min.js:5
 msgid "Browse Listing Updated Sort"
 msgstr "Ɓřǿẇşḗ Ŀīşŧīƞɠ Ŭƥḓȧŧḗḓ Şǿřŧ"
 
-#: static/js/impala/stats/csv_keys.js:100 static/js/impala/stats/csv_keys.js:101
+#: static/js/impala/stats/csv_keys.js:100 static/js/impala/stats/csv_keys.js:101 static/js/zamboni/stats-all.js:15381 static/js/zamboni/stats-all.js:15382 static/js/zamboni/stats-min.js:5
 msgid "Browse Listing Up and Coming Sort"
 msgstr "Ɓřǿẇşḗ Ŀīşŧīƞɠ Ŭƥ ȧƞḓ Ƈǿḿīƞɠ Şǿřŧ"
 
-#: static/js/impala/stats/csv_keys.js:105
+#: static/js/impala/stats/csv_keys.js:105 static/js/zamboni/stats-all.js:15386 static/js/zamboni/stats-min.js:5
 msgid "Total Amount Contributed"
 msgstr "Ŧǿŧȧŀ Ȧḿǿŭƞŧ Ƈǿƞŧřīƀŭŧḗḓ"
 
-#: static/js/impala/stats/csv_keys.js:106
+#: static/js/impala/stats/csv_keys.js:106 static/js/zamboni/stats-all.js:15387 static/js/zamboni/stats-min.js:5
 msgid "Average Contribution"
 msgstr "Ȧṽḗřȧɠḗ Ƈǿƞŧřīƀŭŧīǿƞ"
 
-#: static/js/impala/stats/csv_keys.js:115
+#: static/js/impala/stats/csv_keys.js:115 static/js/zamboni/stats-all.js:15396 static/js/zamboni/stats-min.js:5
 msgid "Usage"
 msgstr "Ŭşȧɠḗ"
 
-#: static/js/impala/stats/csv_keys.js:118
+#: static/js/impala/stats/csv_keys.js:118 static/js/zamboni/stats-all.js:15399 static/js/zamboni/stats-min.js:5
 msgid "Firefox"
 msgstr "Ƒīřḗƒǿẋ"
 
-#: static/js/impala/stats/csv_keys.js:119
+#: static/js/impala/stats/csv_keys.js:119 static/js/zamboni/stats-all.js:15400 static/js/zamboni/stats-min.js:5
 msgid "Mozilla"
 msgstr "Ḿǿzīŀŀȧ"
 
-#: static/js/impala/stats/csv_keys.js:120
+#: static/js/impala/stats/csv_keys.js:120 static/js/zamboni/stats-all.js:15401 static/js/zamboni/stats-min.js:5
 msgid "Thunderbird"
 msgstr "Ŧħŭƞḓḗřƀīřḓ"
 
-#: static/js/impala/stats/csv_keys.js:121
+#: static/js/impala/stats/csv_keys.js:121 static/js/zamboni/stats-all.js:15402 static/js/zamboni/stats-min.js:5
 msgid "Sunbird"
 msgstr "Şŭƞƀīřḓ"
 
-#: static/js/impala/stats/csv_keys.js:122
+#: static/js/impala/stats/csv_keys.js:122 static/js/zamboni/stats-all.js:15403 static/js/zamboni/stats-min.js:5
 msgid "SeaMonkey"
 msgstr "ŞḗȧḾǿƞķḗẏ"
 
-#: static/js/impala/stats/csv_keys.js:123
+#: static/js/impala/stats/csv_keys.js:123 static/js/zamboni/stats-all.js:15404 static/js/zamboni/stats-min.js:5
 msgid "Fennec"
 msgstr "Ƒḗƞƞḗƈ"
 
-#: static/js/impala/stats/csv_keys.js:124
+#: static/js/impala/stats/csv_keys.js:124 static/js/zamboni/stats-all.js:15405 static/js/zamboni/stats-min.js:5
 msgid "Android"
 msgstr "Ȧƞḓřǿīḓ"
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:129
+#: static/js/impala/stats/csv_keys.js:129 static/js/zamboni/stats-all.js:15410 static/js/zamboni/stats-min.js:5
 msgid "Downloads and Daily Users, last {0} days"
 msgstr "Ḓǿẇƞŀǿȧḓş ȧƞḓ Ḓȧīŀẏ Ŭşḗřş, ŀȧşŧ {0} ḓȧẏş"
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:131
+#: static/js/impala/stats/csv_keys.js:131 static/js/zamboni/stats-all.js:15412 static/js/zamboni/stats-min.js:5
 msgid "Downloads and Daily Users from {0} to {1}"
 msgstr "Ḓǿẇƞŀǿȧḓş ȧƞḓ Ḓȧīŀẏ Ŭşḗřş ƒřǿḿ {0} ŧǿ {1}"
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:135
+#: static/js/impala/stats/csv_keys.js:135 static/js/zamboni/stats-all.js:15416 static/js/zamboni/stats-min.js:5
 msgid "Installs and Daily Users, last {0} days"
 msgstr "Īƞşŧȧŀŀş ȧƞḓ Ḓȧīŀẏ Ŭşḗřş, ŀȧşŧ {0} ḓȧẏş"
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:137
+#: static/js/impala/stats/csv_keys.js:137 static/js/zamboni/stats-all.js:15418 static/js/zamboni/stats-min.js:5
 msgid "Installs and Daily Users from {0} to {1}"
 msgstr "Īƞşŧȧŀŀş ȧƞḓ Ḓȧīŀẏ Ŭşḗřş ƒřǿḿ {0} ŧǿ {1}"
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:141
+#: static/js/impala/stats/csv_keys.js:141 static/js/zamboni/stats-all.js:15422 static/js/zamboni/stats-min.js:5
 msgid "Downloads, last {0} days"
 msgstr "Ḓǿẇƞŀǿȧḓş, ŀȧşŧ {0} ḓȧẏş"
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:143
+#: static/js/impala/stats/csv_keys.js:143 static/js/zamboni/stats-all.js:15424 static/js/zamboni/stats-min.js:5
 msgid "Downloads from {0} to {1}"
 msgstr "Ḓǿẇƞŀǿȧḓş ƒřǿḿ {0} ŧǿ {1}"
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:147
+#: static/js/impala/stats/csv_keys.js:147 static/js/zamboni/stats-all.js:15428 static/js/zamboni/stats-min.js:5
 msgid "Daily Users, last {0} days"
 msgstr "Ḓȧīŀẏ Ŭşḗřş, ŀȧşŧ {0} ḓȧẏş"
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:149
+#: static/js/impala/stats/csv_keys.js:149 static/js/zamboni/stats-all.js:15430 static/js/zamboni/stats-min.js:5
 msgid "Daily Users from {0} to {1}"
 msgstr "Ḓȧīŀẏ Ŭşḗřş ƒřǿḿ {0} ŧǿ {1}"
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:153
+#: static/js/impala/stats/csv_keys.js:153 static/js/zamboni/stats-all.js:15434 static/js/zamboni/stats-min.js:5
 msgid "Applications, last {0} days"
 msgstr "Ȧƥƥŀīƈȧŧīǿƞş, ŀȧşŧ {0} ḓȧẏş"
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:155
+#: static/js/impala/stats/csv_keys.js:155 static/js/zamboni/stats-all.js:15436 static/js/zamboni/stats-min.js:5
 msgid "Applications from {0} to {1}"
 msgstr "Ȧƥƥŀīƈȧŧīǿƞş ƒřǿḿ {0} ŧǿ {1}"
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:159
+#: static/js/impala/stats/csv_keys.js:159 static/js/zamboni/stats-all.js:15440 static/js/zamboni/stats-min.js:5
 msgid "Platforms, last {0} days"
 msgstr "Ƥŀȧŧƒǿřḿş, ŀȧşŧ {0} ḓȧẏş"
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:161
+#: static/js/impala/stats/csv_keys.js:161 static/js/zamboni/stats-all.js:15442 static/js/zamboni/stats-min.js:5
 msgid "Platforms from {0} to {1}"
 msgstr "Ƥŀȧŧƒǿřḿş ƒřǿḿ {0} ŧǿ {1}"
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:165
+#: static/js/impala/stats/csv_keys.js:165 static/js/zamboni/stats-all.js:15446 static/js/zamboni/stats-min.js:5
 msgid "Languages, last {0} days"
 msgstr "Ŀȧƞɠŭȧɠḗş, ŀȧşŧ {0} ḓȧẏş"
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:167
+#: static/js/impala/stats/csv_keys.js:167 static/js/zamboni/stats-all.js:15448 static/js/zamboni/stats-min.js:5
 msgid "Languages from {0} to {1}"
 msgstr "Ŀȧƞɠŭȧɠḗş ƒřǿḿ {0} ŧǿ {1}"
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:171
+#: static/js/impala/stats/csv_keys.js:171 static/js/zamboni/stats-all.js:15452 static/js/zamboni/stats-min.js:5
 msgid "Add-on Versions, last {0} days"
 msgstr "Ȧḓḓ-ǿƞ Ṽḗřşīǿƞş, ŀȧşŧ {0} ḓȧẏş"
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:173
+#: static/js/impala/stats/csv_keys.js:173 static/js/zamboni/stats-all.js:15454 static/js/zamboni/stats-min.js:5
 msgid "Add-on Versions from {0} to {1}"
 msgstr "Ȧḓḓ-ǿƞ Ṽḗřşīǿƞş ƒřǿḿ {0} ŧǿ {1}"
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:177
+#: static/js/impala/stats/csv_keys.js:177 static/js/zamboni/stats-all.js:15458 static/js/zamboni/stats-min.js:5
 msgid "Add-on Status, last {0} days"
 msgstr "Ȧḓḓ-ǿƞ Şŧȧŧŭş, ŀȧşŧ {0} ḓȧẏş"
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:179
+#: static/js/impala/stats/csv_keys.js:179 static/js/zamboni/stats-all.js:15460 static/js/zamboni/stats-min.js:5
 msgid "Add-on Status from {0} to {1}"
 msgstr "Ȧḓḓ-ǿƞ Şŧȧŧŭş ƒřǿḿ {0} ŧǿ {1}"
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:183
+#: static/js/impala/stats/csv_keys.js:183 static/js/zamboni/stats-all.js:15464 static/js/zamboni/stats-min.js:5
 msgid "Download Sources, last {0} days"
 msgstr "Ḓǿẇƞŀǿȧḓ Şǿŭřƈḗş, ŀȧşŧ {0} ḓȧẏş"
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:185
+#: static/js/impala/stats/csv_keys.js:185 static/js/zamboni/stats-all.js:15466 static/js/zamboni/stats-min.js:5
 msgid "Download Sources from {0} to {1}"
 msgstr "Ḓǿẇƞŀǿȧḓ Şǿŭřƈḗş ƒřǿḿ {0} ŧǿ {1}"
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:189
+#: static/js/impala/stats/csv_keys.js:189 static/js/zamboni/stats-all.js:15470 static/js/zamboni/stats-min.js:5
 msgid "Contributions, last {0} days"
 msgstr "Ƈǿƞŧřīƀŭŧīǿƞş, ŀȧşŧ {0} ḓȧẏş"
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:191
+#: static/js/impala/stats/csv_keys.js:191 static/js/zamboni/stats-all.js:15472 static/js/zamboni/stats-min.js:5
 msgid "Contributions from {0} to {1}"
 msgstr "Ƈǿƞŧřīƀŭŧīǿƞş ƒřǿḿ {0} ŧǿ {1}"
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:195
+#: static/js/impala/stats/csv_keys.js:195 static/js/zamboni/stats-all.js:15476 static/js/zamboni/stats-min.js:5
 msgid "Site Metrics, last {0} days"
 msgstr "Şīŧḗ Ḿḗŧřīƈş, ŀȧşŧ {0} ḓȧẏş"
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:197
+#: static/js/impala/stats/csv_keys.js:197 static/js/zamboni/stats-all.js:15478 static/js/zamboni/stats-min.js:5
 msgid "Site Metrics from {0} to {1}"
 msgstr "Şīŧḗ Ḿḗŧřīƈş ƒřǿḿ {0} ŧǿ {1}"
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:201
+#: static/js/impala/stats/csv_keys.js:201 static/js/zamboni/stats-all.js:15482 static/js/zamboni/stats-min.js:5
 msgid "Add-ons in Use, last {0} days"
 msgstr "Ȧḓḓ-ǿƞş īƞ Ŭşḗ, ŀȧşŧ {0} ḓȧẏş"
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:203
+#: static/js/impala/stats/csv_keys.js:203 static/js/zamboni/stats-all.js:15484 static/js/zamboni/stats-min.js:5
 msgid "Add-ons in Use from {0} to {1}"
 msgstr "Ȧḓḓ-ǿƞş īƞ Ŭşḗ ƒřǿḿ {0} ŧǿ {1}"
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:207
+#: static/js/impala/stats/csv_keys.js:207 static/js/zamboni/stats-all.js:15488 static/js/zamboni/stats-min.js:5
 msgid "Add-ons Downloaded, last {0} days"
 msgstr "Ȧḓḓ-ǿƞş Ḓǿẇƞŀǿȧḓḗḓ, ŀȧşŧ {0} ḓȧẏş"
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:209
+#: static/js/impala/stats/csv_keys.js:209 static/js/zamboni/stats-all.js:15490 static/js/zamboni/stats-min.js:5
 msgid "Add-ons Downloaded from {0} to {1}"
 msgstr "Ȧḓḓ-ǿƞş Ḓǿẇƞŀǿȧḓḗḓ ƒřǿḿ {0} ŧǿ {1}"
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:213
+#: static/js/impala/stats/csv_keys.js:213 static/js/zamboni/stats-all.js:15494 static/js/zamboni/stats-min.js:5
 msgid "Add-ons Created, last {0} days"
 msgstr "Ȧḓḓ-ǿƞş Ƈřḗȧŧḗḓ, ŀȧşŧ {0} ḓȧẏş"
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:215
+#: static/js/impala/stats/csv_keys.js:215 static/js/zamboni/stats-all.js:15496 static/js/zamboni/stats-min.js:5
 msgid "Add-ons Created from {0} to {1}"
 msgstr "Ȧḓḓ-ǿƞş Ƈřḗȧŧḗḓ ƒřǿḿ {0} ŧǿ {1}"
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:219
+#: static/js/impala/stats/csv_keys.js:219 static/js/zamboni/stats-all.js:15500 static/js/zamboni/stats-min.js:5
 msgid "Add-ons Updated, last {0} days"
 msgstr "Ȧḓḓ-ǿƞş Ŭƥḓȧŧḗḓ, ŀȧşŧ {0} ḓȧẏş"
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:221
+#: static/js/impala/stats/csv_keys.js:221 static/js/zamboni/stats-all.js:15502 static/js/zamboni/stats-min.js:5
 msgid "Add-ons Updated from {0} to {1}"
 msgstr "Ȧḓḓ-ǿƞş Ŭƥḓȧŧḗḓ ƒřǿḿ {0} ŧǿ {1}"
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:225
+#: static/js/impala/stats/csv_keys.js:225 static/js/zamboni/stats-all.js:15506 static/js/zamboni/stats-min.js:5
 msgid "Reviews Written, last {0} days"
 msgstr "Řḗṽīḗẇş Ẇřīŧŧḗƞ, ŀȧşŧ {0} ḓȧẏş"
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:227
+#: static/js/impala/stats/csv_keys.js:227 static/js/zamboni/stats-all.js:15508 static/js/zamboni/stats-min.js:5
 msgid "Reviews Written from {0} to {1}"
 msgstr "Řḗṽīḗẇş Ẇřīŧŧḗƞ ƒřǿḿ {0} ŧǿ {1}"
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:231
+#: static/js/impala/stats/csv_keys.js:231 static/js/zamboni/stats-all.js:15512 static/js/zamboni/stats-min.js:5
 msgid "User Signups, last {0} days"
 msgstr "Ŭşḗř Şīɠƞŭƥş, ŀȧşŧ {0} ḓȧẏş"
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:233
+#: static/js/impala/stats/csv_keys.js:233 static/js/zamboni/stats-all.js:15514 static/js/zamboni/stats-min.js:5
 msgid "User Signups from {0} to {1}"
 msgstr "Ŭşḗř Şīɠƞŭƥş ƒřǿḿ {0} ŧǿ {1}"
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:237
+#: static/js/impala/stats/csv_keys.js:237 static/js/zamboni/stats-all.js:15518 static/js/zamboni/stats-min.js:5
 msgid "Collections Created, last {0} days"
 msgstr "Ƈǿŀŀḗƈŧīǿƞş Ƈřḗȧŧḗḓ, ŀȧşŧ {0} ḓȧẏş"
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:239
+#: static/js/impala/stats/csv_keys.js:239 static/js/zamboni/stats-all.js:15520 static/js/zamboni/stats-min.js:5
 msgid "Collections Created from {0} to {1}"
 msgstr "Ƈǿŀŀḗƈŧīǿƞş Ƈřḗȧŧḗḓ ƒřǿḿ {0} ŧǿ {1}"
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:243
+#: static/js/impala/stats/csv_keys.js:243 static/js/zamboni/stats-all.js:15524 static/js/zamboni/stats-min.js:5
 msgid "Subscribers, last {0} days"
 msgstr "Şŭƀşƈřīƀḗřş, ŀȧşŧ {0} ḓȧẏş"
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:245
+#: static/js/impala/stats/csv_keys.js:245 static/js/zamboni/stats-all.js:15526 static/js/zamboni/stats-min.js:5
 msgid "Subscribers from {0} to {1}"
 msgstr "Şŭƀşƈřīƀḗřş ƒřǿḿ {0} ŧǿ {1}"
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:249
+#: static/js/impala/stats/csv_keys.js:249 static/js/zamboni/stats-all.js:15530 static/js/zamboni/stats-min.js:5
 msgid "Ratings, last {0} days"
 msgstr "Řȧŧīƞɠş, ŀȧşŧ {0} ḓȧẏş"
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:251
+#: static/js/impala/stats/csv_keys.js:251 static/js/zamboni/stats-all.js:15532 static/js/zamboni/stats-min.js:5
 msgid "Ratings from {0} to {1}"
 msgstr "Řȧŧīƞɠş ƒřǿḿ {0} ŧǿ {1}"
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:255
+#: static/js/impala/stats/csv_keys.js:255 static/js/zamboni/stats-all.js:15536 static/js/zamboni/stats-min.js:5
 msgid "Sales, last {0} days"
 msgstr "Şȧŀḗş, ŀȧşŧ {0} ḓȧẏş"
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:257
+#: static/js/impala/stats/csv_keys.js:257 static/js/zamboni/stats-all.js:15538 static/js/zamboni/stats-min.js:5
 msgid "Sales from {0} to {1}"
 msgstr "Şȧŀḗş ƒřǿḿ {0} ŧǿ {1}"
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:261
+#: static/js/impala/stats/csv_keys.js:261 static/js/zamboni/stats-all.js:15542 static/js/zamboni/stats-min.js:5
 msgid "Installs, last {0} days"
 msgstr "Īƞşŧȧŀŀş, ŀȧşŧ {0} ḓȧẏş"
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:263
+#: static/js/impala/stats/csv_keys.js:263 static/js/zamboni/stats-all.js:15544 static/js/zamboni/stats-min.js:5
 msgid "Installs from {0} to {1}"
 msgstr "Īƞşŧȧŀŀş ƒřǿḿ {0} ŧǿ {1}"
 
 #. L10n: {0} and {1} are integers.
-#: static/js/impala/stats/csv_keys.js:269
+#: static/js/impala/stats/csv_keys.js:269 static/js/zamboni/stats-all.js:15550 static/js/zamboni/stats-min.js:5
 msgid "<b>{0}</b> in last {1} days"
 msgstr "<b>{0}</b> īƞ ŀȧşŧ {1} ḓȧẏş"
 
 #. L10n: {0} is an integer and {1} and {2} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:271 static/js/impala/stats/csv_keys.js:277
+#: static/js/impala/stats/csv_keys.js:271 static/js/impala/stats/csv_keys.js:277 static/js/zamboni/stats-all.js:15552 static/js/zamboni/stats-all.js:15558 static/js/zamboni/stats-min.js:5
 msgid "<b>{0}</b> from {1} to {2}"
 msgstr "<b>{0}</b> ƒřǿḿ {1} ŧǿ {2}"
 
 #. L10n: {0} and {1} are integers.
-#: static/js/impala/stats/csv_keys.js:275
+#: static/js/impala/stats/csv_keys.js:275 static/js/zamboni/stats-all.js:15556 static/js/zamboni/stats-min.js:5
 msgid "<b>{0}</b> average in last {1} days"
 msgstr "<b>{0}</b> ȧṽḗřȧɠḗ īƞ ŀȧşŧ {1} ḓȧẏş"
 
-#: static/js/impala/stats/overview.js:19
+#: static/js/impala/stats/overview.js:19 static/js/zamboni/stats-all.js:16469 static/js/zamboni/stats-min.js:5
 msgid "No data available."
 msgstr "Ƞǿ ḓȧŧȧ ȧṽȧīŀȧƀŀḗ."
 
-#: static/js/impala/stats/table.js:74
+#: static/js/impala/stats/table.js:74 static/js/zamboni/stats-all.js:17209 static/js/zamboni/stats-min.js:5
 msgid "Date"
 msgstr "Ḓȧŧḗ"
 
-#: static/js/impala/stats/topchart.js:96
+#: static/js/impala/stats/topchart.js:96 static/js/zamboni/stats-all.js:16600 static/js/zamboni/stats-min.js:5
 msgid "Other"
 msgstr "Ǿŧħḗř"
 
-#: static/js/zamboni/admin_validation.js:24 static/js/zamboni/devhub.js:1229 static/js/zamboni/editors.js:295
+#: static/js/zamboni/admin-all.js:180 static/js/zamboni/admin-min.js:1 static/js/zamboni/admin_validation.js:24 static/js/zamboni/devhub-all.js:2408 static/js/zamboni/devhub-min.js:2
+#: static/js/zamboni/devhub.js:1229 static/js/zamboni/editors-all.js:15576 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:295
 msgid "Select an application first"
 msgstr "Şḗŀḗƈŧ ȧƞ ȧƥƥŀīƈȧŧīǿƞ ƒīřşŧ"
 
-#: static/js/zamboni/admin_validation.js:51
+#: static/js/zamboni/admin-all.js:207 static/js/zamboni/admin-min.js:1 static/js/zamboni/admin_validation.js:51
 msgid "Set {0} add-on to a max version of {1} and email the author."
 msgid_plural "Set {0} add-ons to a max version of {1} and email the authors."
 msgstr[0] "Şḗŧ {0} ȧḓḓ-ǿƞ ŧǿ ȧ ḿȧẋ ṽḗřşīǿƞ ǿƒ {1} ȧƞḓ ḗḿȧīŀ ŧħḗ ȧŭŧħǿř."
 msgstr[1] "Şḗŧ {0} ȧḓḓ-ǿƞş ŧǿ ȧ ḿȧẋ ṽḗřşīǿƞ ǿƒ {1} ȧƞḓ ḗḿȧīŀ ŧħḗ ȧŭŧħǿřş."
 
-#: static/js/zamboni/admin_validation.js:54
+#: static/js/zamboni/admin-all.js:210 static/js/zamboni/admin-min.js:1 static/js/zamboni/admin_validation.js:54
 msgid "Email author of {2} add-on which failed validation."
 msgid_plural "Email authors of {2} add-ons which failed validation."
 msgstr[0] "Ḗḿȧīŀ ȧŭŧħǿř ǿƒ {2} ȧḓḓ-ǿƞ ẇħīƈħ ƒȧīŀḗḓ ṽȧŀīḓȧŧīǿƞ."
 msgstr[1] "Ḗḿȧīŀ ȧŭŧħǿřş ǿƒ {2} ȧḓḓ-ǿƞş ẇħīƈħ ƒȧīŀḗḓ ṽȧŀīḓȧŧīǿƞ."
 
-#. L10n: {0} is an app name like Firefox.
-#: static/js/zamboni/buttons.js:66
-msgid "Accept and Install"
-msgstr "Ȧƈƈḗƥŧ ȧƞḓ Īƞşŧȧŀŀ"
-
-#: static/js/zamboni/buttons.js:66
-msgid "Add to {0}"
-msgstr "Ȧḓḓ ŧǿ {0}"
-
-#: static/js/zamboni/buttons.js:71
-msgid "Download Now"
-msgstr "Ḓǿẇƞŀǿȧḓ Ƞǿẇ"
-
-#: static/js/zamboni/buttons.js:112
-msgid "Add-on has not been updated to support default-to-compatible."
-msgstr "Ȧḓḓ-ǿƞ ħȧş ƞǿŧ ƀḗḗƞ ŭƥḓȧŧḗḓ ŧǿ şŭƥƥǿřŧ ḓḗƒȧŭŀŧ-ŧǿ-ƈǿḿƥȧŧīƀŀḗ."
-
-#: static/js/zamboni/buttons.js:117
-msgid "You need to be using Firefox 10.0 or higher."
-msgstr "Ẏǿŭ ƞḗḗḓ ŧǿ ƀḗ ŭşīƞɠ Ƒīřḗƒǿẋ 10.0 ǿř ħīɠħḗř."
-
-#: static/js/zamboni/buttons.js:129
-msgid "Mozilla has marked this version as incompatible with your Firefox version."
-msgstr "Ḿǿzīŀŀȧ ħȧş ḿȧřķḗḓ ŧħīş ṽḗřşīǿƞ ȧş īƞƈǿḿƥȧŧīƀŀḗ ẇīŧħ ẏǿŭř Ƒīřḗƒǿẋ ṽḗřşīǿƞ."
-
-#. L10n: {0} is an platform like Windows or Linux.
-#: static/js/zamboni/buttons.js:210
-msgid "Install for {0} anyway"
-msgstr "Īƞşŧȧŀŀ ƒǿř {0} ȧƞẏẇȧẏ"
-
-#: static/js/zamboni/buttons.js:210
-msgid "Download for {0} anyway"
-msgstr "Ḓǿẇƞŀǿȧḓ ƒǿř {0} ȧƞẏẇȧẏ"
-
-#: static/js/zamboni/buttons.js:267
-msgid "Not available for your platform"
-msgstr "Ƞǿŧ ȧṽȧīŀȧƀŀḗ ƒǿř ẏǿŭř ƥŀȧŧƒǿřḿ"
-
-#. L10n: {0} is an app name, {1} is the app version.
-#: static/js/zamboni/buttons.js:278 static/js/zamboni/buttons.js:315
-msgid "Not available for {0} {1}"
-msgstr "Ƞǿŧ ȧṽȧīŀȧƀŀḗ ƒǿř {0} {1}"
-
-#: static/js/zamboni/buttons.js:341
-msgid "Works with {app} {min} - {max}"
-msgstr "Ẇǿřķş ẇīŧħ {ȧƥƥ} {ḿīƞ} - {ḿȧẋ}"
-
-#: static/js/zamboni/buttons.js:343
-msgid "View other versions"
-msgstr "Ṽīḗẇ ǿŧħḗř ṽḗřşīǿƞş"
-
-#: static/js/zamboni/buttons.js:391
-msgid "Only with Firefox — Get Firefox Now!"
-msgstr "Ǿƞŀẏ ẇīŧħ Ƒīřḗƒǿẋ — Ɠḗŧ Ƒīřḗƒǿẋ Ƞǿẇ!"
-
-#: static/js/zamboni/buttons.js:507 static/js/zamboni/mobile/buttons.js:43
-msgid "Sorry, you need a Mozilla-based browser (such as Firefox) to install a search plugin."
-msgstr "Şǿřřẏ, ẏǿŭ ƞḗḗḓ ȧ Ḿǿzīŀŀȧ-ƀȧşḗḓ ƀřǿẇşḗř (şŭƈħ ȧş Ƒīřḗƒǿẋ) ŧǿ īƞşŧȧŀŀ ȧ şḗȧřƈħ ƥŀŭɠīƞ."
-
-#: static/js/zamboni/collections.js:229
-msgid "Adding to Favorites&hellip;"
-msgstr "Ȧḓḓīƞɠ ŧǿ Ƒȧṽǿřīŧḗş&hellip;"
-
-#: static/js/zamboni/collections.js:232
-msgid "Removing Favorite&hellip;"
-msgstr "Řḗḿǿṽīƞɠ Ƒȧṽǿřīŧḗ&hellip;"
-
-#: static/js/zamboni/collections.js:235
-msgid "Add to Favorites"
-msgstr "Ȧḓḓ ŧǿ Ƒȧṽǿřīŧḗş"
-
-#: static/js/zamboni/collections.js:238
-msgid "Remove from Favorites"
-msgstr "Řḗḿǿṽḗ ƒřǿḿ Ƒȧṽǿřīŧḗş"
-
-#: static/js/zamboni/collections.js:303
-msgid "Pending"
-msgstr "Ƥḗƞḓīƞɠ"
-
-#: static/js/zamboni/collections.js:304
-msgid "Add a comment"
-msgstr "Ȧḓḓ ȧ ƈǿḿḿḗƞŧ"
-
-#: static/js/zamboni/collections.js:304
-msgid "Comment"
-msgstr "Ƈǿḿḿḗƞŧ"
-
-#: static/js/zamboni/collections.js:305
-msgid "Remove this add-on from the collection"
-msgstr "Řḗḿǿṽḗ ŧħīş ȧḓḓ-ǿƞ ƒřǿḿ ŧħḗ ƈǿŀŀḗƈŧīǿƞ"
-
-#: static/js/zamboni/collections.js:305 static/js/zamboni/collections.js:334
-msgid "Remove"
-msgstr "Řḗḿǿṽḗ"
-
-#: static/js/zamboni/collections.js:334
-msgid "Remove this user as a contributor"
-msgstr "Řḗḿǿṽḗ ŧħīş ŭşḗř ȧş ȧ ƈǿƞŧřīƀŭŧǿř"
-
-#: static/js/zamboni/collections.js:346
-msgid "An email address is required."
-msgstr "Ȧƞ ḗḿȧīŀ ȧḓḓřḗşş īş řḗɋŭīřḗḓ."
-
-#: static/js/zamboni/collections.js:364
-msgid "You cannot add yourself as a contributor."
-msgstr "Ẏǿŭ ƈȧƞƞǿŧ ȧḓḓ ẏǿŭřşḗŀƒ ȧş ȧ ƈǿƞŧřīƀŭŧǿř."
-
-#: static/js/zamboni/collections.js:366
-msgid "You have already added that user."
-msgstr "Ẏǿŭ ħȧṽḗ ȧŀřḗȧḓẏ ȧḓḓḗḓ ŧħȧŧ ŭşḗř."
-
-#: static/js/zamboni/collections.js:573
-msgid "Add to favorites"
-msgstr "Ȧḓḓ ŧǿ ƒȧṽǿřīŧḗş"
-
-#: static/js/zamboni/collections.js:577
-msgid "Remove from favorites"
-msgstr "Řḗḿǿṽḗ ƒřǿḿ ƒȧṽǿřīŧḗş"
-
-#: static/js/zamboni/collections.js:604
-msgid "Stop following"
-msgstr "Şŧǿƥ ƒǿŀŀǿẇīƞɠ"
-
-#: static/js/zamboni/devhub.js:110
+#: static/js/zamboni/devhub-all.js:1289 static/js/zamboni/devhub-min.js:1 static/js/zamboni/devhub.js:110
 msgid "Your browser does not support the video tag"
 msgstr "Ẏǿŭř ƀřǿẇşḗř ḓǿḗş ƞǿŧ şŭƥƥǿřŧ ŧħḗ ṽīḓḗǿ ŧȧɠ"
 
-#: static/js/zamboni/devhub.js:371
+#: static/js/zamboni/devhub-all.js:1550 static/js/zamboni/devhub-min.js:1 static/js/zamboni/devhub.js:371
 msgid "Changes Saved"
 msgstr "Ƈħȧƞɠḗş Şȧṽḗḓ"
 
-#: static/js/zamboni/devhub.js:387
+#: static/js/zamboni/devhub-all.js:1566 static/js/zamboni/devhub-min.js:1 static/js/zamboni/devhub.js:387
 msgid "Enter a new author's email address"
 msgstr "Ḗƞŧḗř ȧ ƞḗẇ ȧŭŧħǿř'ş ḗḿȧīŀ ȧḓḓřḗşş"
 
-#: static/js/zamboni/devhub.js:536
+#: static/js/zamboni/devhub-all.js:1715 static/js/zamboni/devhub-min.js:1 static/js/zamboni/devhub.js:536
 msgid "There was an error uploading your file."
 msgstr "Ŧħḗřḗ ẇȧş ȧƞ ḗřřǿř ŭƥŀǿȧḓīƞɠ ẏǿŭř ƒīŀḗ."
 
-#: static/js/zamboni/devhub.js:681
+#: static/js/zamboni/devhub-all.js:1860 static/js/zamboni/devhub-min.js:1 static/js/zamboni/devhub.js:681
 msgid "{files} file"
 msgid_plural "{files} files"
 msgstr[0] "{ƒīŀḗş} ƒīŀḗ"
 msgstr[1] "{ƒīŀḗş} ƒīŀḗş"
 
-#: static/js/zamboni/devhub.js:684
+#: static/js/zamboni/devhub-all.js:1863 static/js/zamboni/devhub-min.js:1 static/js/zamboni/devhub.js:684
 msgid "{reviews} user review"
 msgid_plural "{reviews} user reviews"
 msgstr[0] "{řḗṽīḗẇş} ŭşḗř řḗṽīḗẇ"
 msgstr[1] "{řḗṽīḗẇş} ŭşḗř řḗṽīḗẇş"
 
-#: static/js/zamboni/devhub.js:796
+#: static/js/zamboni/devhub-all.js:1975 static/js/zamboni/devhub-min.js:2 static/js/zamboni/devhub.js:796
 msgid "Learn more"
 msgstr "Ŀḗȧřƞ ḿǿřḗ"
 
-#: static/js/zamboni/devhub.js:800
+#: static/js/zamboni/devhub-all.js:1979 static/js/zamboni/devhub-min.js:2 static/js/zamboni/devhub.js:800
 msgid "Example"
 msgstr "Ḗẋȧḿƥŀḗ"
 
-#: static/js/zamboni/devhub.js:1130
+#: static/js/zamboni/devhub-all.js:2309 static/js/zamboni/devhub-min.js:2 static/js/zamboni/devhub.js:1130
 msgid "Image changes being processed"
 msgstr "Īḿȧɠḗ ƈħȧƞɠḗş ƀḗīƞɠ ƥřǿƈḗşşḗḓ"
 
-#: static/js/zamboni/devhub.js:1280
+#: static/js/zamboni/devhub-all.js:2459 static/js/zamboni/devhub-min.js:2 static/js/zamboni/devhub.js:1280
 msgid "Must be a valid e-mail address."
 msgstr "Ḿŭşŧ ƀḗ ȧ ṽȧŀīḓ ḗ-ḿȧīŀ ȧḓḓřḗşş."
 
-#: static/js/zamboni/devhub_search.js:8
-msgid "No results found."
-msgstr "Ƞǿ řḗşŭŀŧş ƒǿŭƞḓ."
-
-#: static/js/zamboni/editors.js:121
-msgid "{name} was viewing this page first."
-msgstr "{ƞȧḿḗ} ẇȧş ṽīḗẇīƞɠ ŧħīş ƥȧɠḗ ƒīřşŧ."
-
-#: static/js/zamboni/editors.js:171
-msgid "Receipt checked by app."
-msgstr "Řḗƈḗīƥŧ ƈħḗƈķḗḓ ƀẏ ȧƥƥ."
-
-#: static/js/zamboni/editors.js:173
-msgid "Receipt was not checked by app."
-msgstr "Řḗƈḗīƥŧ ẇȧş ƞǿŧ ƈħḗƈķḗḓ ƀẏ ȧƥƥ."
-
-#: static/js/zamboni/editors.js:244
-msgid "{name} was viewing this add-on first."
-msgstr "{ƞȧḿḗ} ẇȧş ṽīḗẇīƞɠ ŧħīş ȧḓḓ-ǿƞ ƒīřşŧ."
-
-#: static/js/zamboni/editors.js:255
-msgid "Loading&hellip;"
-msgstr "Ŀǿȧḓīƞɠ&hellip;"
-
-#: static/js/zamboni/editors.js:260
-msgid "Version Notes"
-msgstr "Ṽḗřşīǿƞ Ƞǿŧḗş"
-
-#: static/js/zamboni/editors.js:265
-msgid "Notes for Reviewers"
-msgstr "Ƞǿŧḗş ƒǿř Řḗṽīḗẇḗřş"
-
-#: static/js/zamboni/editors.js:270
-msgid "No version notes found"
-msgstr "Ƞǿ ṽḗřşīǿƞ ƞǿŧḗş ƒǿŭƞḓ"
-
-#: static/js/zamboni/editors.js:330
-msgid "Average Reviews"
-msgstr "Ȧṽḗřȧɠḗ Řḗṽīḗẇş"
-
-#: static/js/zamboni/editors.js:386
-msgid "Number of Reviews"
-msgstr "Ƞŭḿƀḗř ǿƒ Řḗṽīḗẇş"
-
-#: static/js/zamboni/editors.js:445
-msgid "Error loading translation"
-msgstr "Ḗřřǿř ŀǿȧḓīƞɠ ŧřȧƞşŀȧŧīǿƞ"
-
-#: static/js/zamboni/files.js:411 static/js/zamboni/validator.js:261
-msgid "Ignore this message in future updates"
-msgstr "Īɠƞǿřḗ ŧħīş ḿḗşşȧɠḗ īƞ ƒŭŧŭřḗ ŭƥḓȧŧḗş"
-
-#: static/js/zamboni/files.js:417 static/js/zamboni/validator.js:284
-msgid "Severity for automated signing:"
-msgstr "Şḗṽḗřīŧẏ ƒǿř ȧŭŧǿḿȧŧḗḓ şīɠƞīƞɠ:"
-
-#: static/js/zamboni/global.js:410
-msgid "Loading..."
-msgstr "Ŀǿȧḓīƞɠ..."
-
-#. L10n: {0} is the number of characters left.
-#: static/js/zamboni/global.js:474
-msgid "<b>{0}</b> character left."
-msgid_plural "<b>{0}</b> characters left."
-msgstr[0] "<b>{0}</b> ƈħȧřȧƈŧḗř ŀḗƒŧ."
-msgstr[1] "<b>{0}</b> ƈħȧřȧƈŧḗřş ŀḗƒŧ."
-
-#: static/js/zamboni/init.js:28
-msgid "This feature is temporarily disabled while we perform website maintenance. Please check back a little later."
-msgstr "Ŧħīş ƒḗȧŧŭřḗ īş ŧḗḿƥǿřȧřīŀẏ ḓīşȧƀŀḗḓ ẇħīŀḗ ẇḗ ƥḗřƒǿřḿ ẇḗƀşīŧḗ ḿȧīƞŧḗƞȧƞƈḗ. Ƥŀḗȧşḗ ƈħḗƈķ ƀȧƈķ ȧ ŀīŧŧŀḗ ŀȧŧḗř."
-
-#: static/js/zamboni/l10n.js:45
-msgid "Remove this localization"
-msgstr "Řḗḿǿṽḗ ŧħīş ŀǿƈȧŀīzȧŧīǿƞ"
-
-#: static/js/zamboni/password-strength.js:20
-msgid "Password strength:"
-msgstr "Ƥȧşşẇǿřḓ şŧřḗƞɠŧħ:"
-
-#: static/js/zamboni/password-strength.js:26
-msgid "At least {0} character left."
-msgid_plural "At least {0} characters left."
-msgstr[0] "Ȧŧ ŀḗȧşŧ {0} ƈħȧřȧƈŧḗř ŀḗƒŧ."
-msgstr[1] "Ȧŧ ŀḗȧşŧ {0} ƈħȧřȧƈŧḗřş ŀḗƒŧ."
-
-#: static/js/zamboni/themes_review.js:176
-msgid "Requested Info"
-msgstr "Řḗɋŭḗşŧḗḓ Īƞƒǿ"
-
-#: static/js/zamboni/themes_review.js:177
-msgid "Flagged"
-msgstr "Ƒŀȧɠɠḗḓ"
-
-#: static/js/zamboni/themes_review.js:178
-msgid "Duplicate"
-msgstr "Ḓŭƥŀīƈȧŧḗ"
-
-#: static/js/zamboni/themes_review.js:179
-msgid "Rejected"
-msgstr "Řḗĵḗƈŧḗḓ"
-
-#: static/js/zamboni/themes_review.js:180
-msgid "Approved"
-msgstr "Ȧƥƥřǿṽḗḓ"
-
-#: static/js/zamboni/themes_review.js:424
-msgid "No results found"
-msgstr "Ƞǿ řḗşŭŀŧş ƒǿŭƞḓ"
-
-#: static/js/zamboni/themes_review_templates.js:31
-msgid "Theme"
-msgstr "Ŧħḗḿḗ"
-
-#: static/js/zamboni/themes_review_templates.js:33
-msgid "Reviewer"
-msgstr "Řḗṽīḗẇḗř"
-
-#: static/js/zamboni/themes_review_templates.js:35
-msgid "Status"
-msgstr "Şŧȧŧŭş"
-
-#: static/js/zamboni/validator.js:80
+#: static/js/zamboni/devhub-all.js:2613 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:80
 msgid "All tests passed successfully."
 msgstr "Ȧŀŀ ŧḗşŧş ƥȧşşḗḓ şŭƈƈḗşşƒŭŀŀẏ."
 
-#: static/js/zamboni/validator.js:83 static/js/zamboni/validator.js:478
+#: static/js/zamboni/devhub-all.js:2616 static/js/zamboni/devhub-all.js:3011 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:83 static/js/zamboni/validator.js:478
 msgid "These tests were not run."
 msgstr "Ŧħḗşḗ ŧḗşŧş ẇḗřḗ ƞǿŧ řŭƞ."
 
-#: static/js/zamboni/validator.js:131 static/js/zamboni/validator.js:144
+#: static/js/zamboni/devhub-all.js:2664 static/js/zamboni/devhub-all.js:2677 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:131 static/js/zamboni/validator.js:144
 msgid "Tests"
 msgstr "Ŧḗşŧş"
 
-#: static/js/zamboni/validator.js:246 static/js/zamboni/validator.js:575 static/js/zamboni/validator.js:594
+#: static/js/zamboni/devhub-all.js:2779 static/js/zamboni/devhub-all.js:3108 static/js/zamboni/devhub-all.js:3127 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:246
+#: static/js/zamboni/validator.js:575 static/js/zamboni/validator.js:594
 msgid "Error"
 msgstr "Ḗřřǿř"
 
-#: static/js/zamboni/validator.js:247
+#: static/js/zamboni/devhub-all.js:2780 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:247
 msgid "Warning"
 msgstr "Ẇȧřƞīƞɠ"
 
-#: static/js/zamboni/validator.js:299
+#: static/js/zamboni/devhub-all.js:2794 static/js/zamboni/devhub-min.js:2 static/js/zamboni/files-all.js:5657 static/js/zamboni/files-min.js:3 static/js/zamboni/files.js:411
+#: static/js/zamboni/validator.js:261
+msgid "Ignore this message in future updates"
+msgstr "Īɠƞǿřḗ ŧħīş ḿḗşşȧɠḗ īƞ ƒŭŧŭřḗ ŭƥḓȧŧḗş"
+
+#: static/js/zamboni/devhub-all.js:2817 static/js/zamboni/devhub-min.js:2 static/js/zamboni/files-all.js:5663 static/js/zamboni/files-min.js:3 static/js/zamboni/files.js:417
+#: static/js/zamboni/validator.js:284
+msgid "Severity for automated signing:"
+msgstr "Şḗṽḗřīŧẏ ƒǿř ȧŭŧǿḿȧŧḗḓ şīɠƞīƞɠ:"
+
+#: static/js/zamboni/devhub-all.js:2832 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:299
 msgid "Suggestions for passing automated signing:"
 msgstr "Şŭɠɠḗşŧīǿƞş ƒǿř ƥȧşşīƞɠ ȧŭŧǿḿȧŧḗḓ şīɠƞīƞɠ:"
 
-#: static/js/zamboni/validator.js:387
+#: static/js/zamboni/devhub-all.js:2920 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:387
 msgid "Compatibility Tests"
 msgstr "Ƈǿḿƥȧŧīƀīŀīŧẏ Ŧḗşŧş"
 
-#: static/js/zamboni/validator.js:466
+#: static/js/zamboni/devhub-all.js:2999 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:466
 msgid "Add-on failed validation."
 msgstr "Ȧḓḓ-ǿƞ ƒȧīŀḗḓ ṽȧŀīḓȧŧīǿƞ."
 
-#: static/js/zamboni/validator.js:468
+#: static/js/zamboni/devhub-all.js:3001 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:468
 msgid "Add-on passed validation."
 msgstr "Ȧḓḓ-ǿƞ ƥȧşşḗḓ ṽȧŀīḓȧŧīǿƞ."
 
-#: static/js/zamboni/validator.js:481
+#: static/js/zamboni/devhub-all.js:3014 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:481
 msgid "{0} error"
 msgid_plural "{0} errors"
 msgstr[0] "{0} ḗřřǿř"
 msgstr[1] "{0} ḗřřǿřş"
 
-#: static/js/zamboni/validator.js:483
+#: static/js/zamboni/devhub-all.js:3016 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:483
 msgid "{0} warning"
 msgid_plural "{0} warnings"
 msgstr[0] "{0} ẇȧřƞīƞɠ"
 msgstr[1] "{0} ẇȧřƞīƞɠş"
 
-#: static/js/zamboni/validator.js:485
+#: static/js/zamboni/devhub-all.js:3018 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:485
 msgid "{0} notice"
 msgid_plural "{0} notices"
 msgstr[0] "{0} ƞǿŧīƈḗ"
 msgstr[1] "{0} ƞǿŧīƈḗş"
 
-#: static/js/zamboni/validator.js:577
+#: static/js/zamboni/devhub-all.js:3110 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:577
 msgid "Validation task could not complete or completed with errors"
 msgstr "Ṽȧŀīḓȧŧīǿƞ ŧȧşķ ƈǿŭŀḓ ƞǿŧ ƈǿḿƥŀḗŧḗ ǿř ƈǿḿƥŀḗŧḗḓ ẇīŧħ ḗřřǿřş"
 
-#: static/js/zamboni/validator.js:595
+#: static/js/zamboni/devhub-all.js:3128 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:595
 msgid "Internal server error"
 msgstr "Īƞŧḗřƞȧŀ şḗřṽḗř ḗřřǿř"
 
-#: static/js/zamboni/mobile/buttons.js:52
+#: static/js/zamboni/devhub_search.js:8
+msgid "No results found."
+msgstr "Ƞǿ řḗşŭŀŧş ƒǿŭƞḓ."
+
+#: static/js/zamboni/editors-all.js:15402 static/js/zamboni/editors-min.js:4 static/js/zamboni/editors.js:121
+msgid "{name} was viewing this page first."
+msgstr "{ƞȧḿḗ} ẇȧş ṽīḗẇīƞɠ ŧħīş ƥȧɠḗ ƒīřşŧ."
+
+#: static/js/zamboni/editors-all.js:15452 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:171
+msgid "Receipt checked by app."
+msgstr "Řḗƈḗīƥŧ ƈħḗƈķḗḓ ƀẏ ȧƥƥ."
+
+#: static/js/zamboni/editors-all.js:15454 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:173
+msgid "Receipt was not checked by app."
+msgstr "Řḗƈḗīƥŧ ẇȧş ƞǿŧ ƈħḗƈķḗḓ ƀẏ ȧƥƥ."
+
+#: static/js/zamboni/editors-all.js:15525 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:244
+msgid "{name} was viewing this add-on first."
+msgstr "{ƞȧḿḗ} ẇȧş ṽīḗẇīƞɠ ŧħīş ȧḓḓ-ǿƞ ƒīřşŧ."
+
+#: static/js/zamboni/editors-all.js:15536 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:255
+msgid "Loading&hellip;"
+msgstr "Ŀǿȧḓīƞɠ&hellip;"
+
+#: static/js/zamboni/editors-all.js:15541 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:260
+msgid "Version Notes"
+msgstr "Ṽḗřşīǿƞ Ƞǿŧḗş"
+
+#: static/js/zamboni/editors-all.js:15546 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:265
+msgid "Notes for Reviewers"
+msgstr "Ƞǿŧḗş ƒǿř Řḗṽīḗẇḗřş"
+
+#: static/js/zamboni/editors-all.js:15551 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:270
+msgid "No version notes found"
+msgstr "Ƞǿ ṽḗřşīǿƞ ƞǿŧḗş ƒǿŭƞḓ"
+
+#: static/js/zamboni/editors-all.js:15611 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:330
+msgid "Average Reviews"
+msgstr "Ȧṽḗřȧɠḗ Řḗṽīḗẇş"
+
+#: static/js/zamboni/editors-all.js:15667 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:386
+msgid "Number of Reviews"
+msgstr "Ƞŭḿƀḗř ǿƒ Řḗṽīḗẇş"
+
+#: static/js/zamboni/editors-all.js:15726 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:445
+msgid "Error loading translation"
+msgstr "Ḗřřǿř ŀǿȧḓīƞɠ ŧřȧƞşŀȧŧīǿƞ"
+
+#: static/js/zamboni/editors-all.js:15975 static/js/zamboni/editors-min.js:5 static/js/zamboni/themes_review_templates.js:31
+msgid "Theme"
+msgstr "Ŧħḗḿḗ"
+
+#: static/js/zamboni/editors-all.js:15977 static/js/zamboni/editors-min.js:5 static/js/zamboni/themes_review_templates.js:33
+msgid "Reviewer"
+msgstr "Řḗṽīḗẇḗř"
+
+#: static/js/zamboni/editors-all.js:15979 static/js/zamboni/editors-min.js:5 static/js/zamboni/themes_review_templates.js:35
+msgid "Status"
+msgstr "Şŧȧŧŭş"
+
+#: static/js/zamboni/editors-all.js:16196 static/js/zamboni/editors-min.js:5 static/js/zamboni/themes_review.js:176
+msgid "Requested Info"
+msgstr "Řḗɋŭḗşŧḗḓ Īƞƒǿ"
+
+#: static/js/zamboni/editors-all.js:16197 static/js/zamboni/editors-min.js:5 static/js/zamboni/themes_review.js:177
+msgid "Flagged"
+msgstr "Ƒŀȧɠɠḗḓ"
+
+#: static/js/zamboni/editors-all.js:16198 static/js/zamboni/editors-min.js:5 static/js/zamboni/themes_review.js:178
+msgid "Duplicate"
+msgstr "Ḓŭƥŀīƈȧŧḗ"
+
+#: static/js/zamboni/editors-all.js:16199 static/js/zamboni/editors-min.js:5 static/js/zamboni/themes_review.js:179
+msgid "Rejected"
+msgstr "Řḗĵḗƈŧḗḓ"
+
+#: static/js/zamboni/editors-all.js:16200 static/js/zamboni/editors-min.js:5 static/js/zamboni/themes_review.js:180
+msgid "Approved"
+msgstr "Ȧƥƥřǿṽḗḓ"
+
+#: static/js/zamboni/editors-all.js:16444 static/js/zamboni/editors-min.js:5 static/js/zamboni/themes_review.js:424
+msgid "No results found"
+msgstr "Ƞǿ řḗşŭŀŧş ƒǿŭƞḓ"
+
+#: static/js/zamboni/mobile-all.js:15186 static/js/zamboni/mobile/buttons.js:52
 msgid "Not Updated for {0} {1}"
 msgstr "Ƞǿŧ Ŭƥḓȧŧḗḓ ƒǿř {0} {1}"
 
-#: static/js/zamboni/mobile/buttons.js:53
+#: static/js/zamboni/mobile-all.js:15187 static/js/zamboni/mobile/buttons.js:53
 msgid "Requires Newer Version of {0}"
 msgstr "Řḗɋŭīřḗş Ƞḗẇḗř Ṽḗřşīǿƞ ǿƒ {0}"
 
-#: static/js/zamboni/mobile/buttons.js:54
+#: static/js/zamboni/mobile-all.js:15188 static/js/zamboni/mobile/buttons.js:54
 msgid "Unreviewed"
 msgstr "Ŭƞřḗṽīḗẇḗḓ"
 
-#: static/js/zamboni/mobile/buttons.js:55
+#: static/js/zamboni/mobile-all.js:15189 static/js/zamboni/mobile/buttons.js:55
 msgid "Experimental <span>(Learn More)</span>"
 msgstr "Ḗẋƥḗřīḿḗƞŧȧŀ <span>(Ŀḗȧřƞ Ḿǿřḗ)</span>"
 
-#: static/js/zamboni/mobile/buttons.js:56 static/js/zamboni/mobile/buttons.js:57
+#: static/js/zamboni/mobile-all.js:15190 static/js/zamboni/mobile-all.js:15191 static/js/zamboni/mobile/buttons.js:56 static/js/zamboni/mobile/buttons.js:57
 msgid "Not Available for {0}"
 msgstr "Ƞǿŧ Ȧṽȧīŀȧƀŀḗ ƒǿř {0}"
 
-#: static/js/zamboni/mobile/buttons.js:58
+#: static/js/zamboni/mobile-all.js:15192 static/js/zamboni/mobile/buttons.js:58
 msgid "Experimental"
 msgstr "Ḗẋƥḗřīḿḗƞŧȧŀ"
 
-#: static/js/zamboni/mobile/buttons.js:59
+#: static/js/zamboni/mobile-all.js:15193 static/js/zamboni/mobile/buttons.js:59
 msgid "Themes Require Newer Version of {0}"
 msgstr "Ŧħḗḿḗş Řḗɋŭīřḗ Ƞḗẇḗř Ṽḗřşīǿƞ ǿƒ {0}"
 
-#: static/js/zamboni/mobile/buttons.js:60
+#: static/js/zamboni/mobile-all.js:15194 static/js/zamboni/mobile/buttons.js:60
 msgid "Themes Require {0}"
 msgstr "Ŧħḗḿḗş Řḗɋŭīřḗ {0}"
 
-#: static/js/zamboni/mobile/buttons.js:105
+#: static/js/zamboni/mobile-all.js:15239 static/js/zamboni/mobile/buttons.js:105
 msgid "Installing..."
 msgstr "Īƞşŧȧŀŀīƞɠ..."
 
-#: static/js/zamboni/mobile/buttons.js:125
+#: static/js/zamboni/mobile-all.js:15259 static/js/zamboni/mobile/buttons.js:125
 msgid "This add-on has been preliminarily reviewed by Mozilla."
 msgstr "Ŧħīş ȧḓḓ-ǿƞ ħȧş ƀḗḗƞ ƥřḗŀīḿīƞȧřīŀẏ řḗṽīḗẇḗḓ ƀẏ Ḿǿzīŀŀȧ."
 
-#: static/js/zamboni/mobile/buttons.js:250
+#: static/js/zamboni/mobile-all.js:15384 static/js/zamboni/mobile/buttons.js:250
 msgid "Keep it"
 msgstr "Ķḗḗƥ īŧ"
 
-#: static/js/zamboni/mobile/general.js:344
+#: static/js/zamboni/mobile-all.js:16049 static/js/zamboni/mobile-min.js:6 static/js/zamboni/mobile/general.js:344
 msgid "You're trying it on!"
 msgstr "Ẏǿŭ'řḗ ŧřẏīƞɠ īŧ ǿƞ!"
 
-#: static/js/zamboni/mobile/general.js:356
+#: static/js/zamboni/mobile-all.js:16061 static/js/zamboni/mobile-min.js:6 static/js/zamboni/mobile/general.js:356
 msgid "Added to Firefox"
 msgstr "Ȧḓḓḗḓ ŧǿ Ƒīřḗƒǿẋ"
-

--- a/locale/de/LC_MESSAGES/django.po
+++ b/locale/de/LC_MESSAGES/django.po
@@ -3,69 +3,70 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2016-02-24 21:23+0000\n"
+"POT-Creation-Date: 2016-04-18 15:47+0000\n"
 "PO-Revision-Date: 2016-02-25 08:37+0000\n"
 "Last-Translator: Michael Köhler <michael.koehler1@gmx.de>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
+"Language: \n"
 "MIME-Version: 1.0\n"
-"Content-Type: text/plain; charset=utf-8\n"
+"Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Generated-By: Babel 2.2.0\n"
 
-#: src/olympia/accounts/views.py:52
+#: src/olympia/accounts/views.py:54
 msgid "Your log in attempt could not be parsed. Please try again."
 msgstr "Ihr Anmeldeversuch konnte nicht verarbeitet werden. Bitte versuchen Sie es erneut."
 
-#: src/olympia/accounts/views.py:54
+#: src/olympia/accounts/views.py:56
 msgid "Your Firefox Account could not be found. Please try again."
 msgstr "Ihr Firefox-Konto wurde nicht gefunden. Bitte versuchen Sie es erneut."
 
-#: src/olympia/accounts/views.py:55
+#: src/olympia/accounts/views.py:57
 msgid "You could not be logged in. Please try again."
 msgstr "Ihre Anmeldung ist fehlgeschlagen. Bitte versuchen Sie es erneut."
 
-#: src/olympia/accounts/views.py:57
+#: src/olympia/accounts/views.py:59
 msgid "Your account has already been migrated to Firefox Accounts."
 msgstr "Ihr Benutzerkonto wurde bereits zu den Firefox-Konten umgezogen."
 
-#: src/olympia/accounts/views.py:59
+#: src/olympia/accounts/views.py:61
 msgid "Your Firefox Account already exists on this site."
 msgstr "Ihr Firefox-Konto existiert auf dieser Website bereits."
 
-#: src/olympia/accounts/views.py:108
+#: src/olympia/accounts/views.py:110
 msgid "Great job!"
 msgstr "Gut gemacht!"
 
-#: src/olympia/accounts/views.py:109
+#: src/olympia/accounts/views.py:111
 msgid "You can now log in to Add-ons with your Firefox Account."
 msgstr "Sie können Sie jetzt mit Ihrem Firefox-Konto auf der Add-ons-Website anmelden."
 
-#: src/olympia/accounts/views.py:121
+#: src/olympia/accounts/views.py:123
 msgid "Need help?"
 msgstr "Benötigen Sie Hilfe?"
 
-#: src/olympia/addons/buttons.py:180
+#: src/olympia/addons/buttons.py:177
 msgid "Download Now"
 msgstr "Jetzt herunterladen"
 
-#: src/olympia/addons/buttons.py:182
+#: src/olympia/addons/buttons.py:179
 msgid "Download"
 msgstr "Herunterladen"
 
 #. L10n: please keep &nbsp; in the string so &rarr; does not wrap.
-#: src/olympia/addons/buttons.py:186
+#: src/olympia/addons/buttons.py:183
 msgid "Continue to Download&nbsp;&rarr;"
 msgstr "Weiter zum Download&nbsp;&rarr;"
 
-#: src/olympia/addons/buttons.py:202 src/olympia/addons/helpers.py:35 src/olympia/addons/views.py:319 src/olympia/addons/templates/addons/impala/details.html:114
+#: src/olympia/addons/buttons.py:199 src/olympia/addons/helpers.py:35 src/olympia/addons/views.py:333 src/olympia/addons/templates/addons/impala/details.html:111
 #: src/olympia/addons/templates/addons/impala/listing/items.html:17 src/olympia/addons/templates/addons/mobile/home.html:40 src/olympia/amo/templates/amo/side_nav.html:6
-#: src/olympia/amo/templates/amo/side_nav.html:10 src/olympia/amo/templates/amo/site_nav.html:2 src/olympia/amo/templates/amo/site_nav.html:55 src/olympia/bandwagon/views.py:95
-#: src/olympia/browse/views.py:54 src/olympia/browse/views.py:68 src/olympia/browse/views.py:235 src/olympia/browse/templates/browse/impala/category_landing.html:22
+#: src/olympia/amo/templates/amo/side_nav.html:10 src/olympia/amo/templates/amo/site_nav.html:2 src/olympia/amo/templates/amo/site_nav.html:53 src/olympia/bandwagon/views.py:95
+#: src/olympia/browse/views.py:54 src/olympia/browse/views.py:68 src/olympia/browse/views.py:202 src/olympia/browse/templates/browse/impala/category_landing.html:22
 #: src/olympia/browse/templates/browse/personas/mobile/category_landing.html:26
 msgid "Featured"
 msgstr "Vorgestellt"
 
-#: src/olympia/addons/buttons.py:221
+#: src/olympia/addons/buttons.py:218
 msgid "Add to {0}"
 msgstr "Zu {0} hinzufügen"
 
@@ -113,39 +114,39 @@ msgid_plural "All tags must be at least {0} characters."
 msgstr[0] "Alle Schlagwörter müssen aus mindestens {0} Zeichen bestehen."
 msgstr[1] "Alle Schlagwörter müssen aus mindestens {0} Zeichen bestehen."
 
-#: src/olympia/addons/forms.py:234
+#: src/olympia/addons/forms.py:238
 msgid "Categories cannot be changed while your add-on is featured for this application."
 msgstr "Kategorien können nicht geändert werden, während Ihr Add-on für diese Anwendung vorgestellt wird."
 
 #. L10n: {0} is the number of categories.
-#: src/olympia/addons/forms.py:238
+#: src/olympia/addons/forms.py:242
 msgid "You can have only {0} category."
 msgid_plural "You can have only {0} categories."
 msgstr[0] "Sie können nur {0} Kategorie auswählen."
 msgstr[1] "Sie können nur {0} Kategorien auswählen."
 
-#: src/olympia/addons/forms.py:246
+#: src/olympia/addons/forms.py:250
 msgid "The miscellaneous category cannot be combined with additional categories."
 msgstr "Die Kategorie „Verschiedenes“ kann nicht mit anderen Kategorien kombiniert werden."
 
-#: src/olympia/addons/forms.py:369
+#: src/olympia/addons/forms.py:374
 #, python-format
 msgid "Before changing your default locale you must have a name, summary, and description in that locale. You are missing %s."
 msgstr "Bevor Sie Ihre Standardsprache ändern, müssen Sie in dieser Sprache einen Namen, eine Zusammenfassung und eine Beschreibung haben. Es fehlt noch %s."
 
-#: src/olympia/addons/forms.py:484 src/olympia/addons/forms.py:575
+#: src/olympia/addons/forms.py:455 src/olympia/addons/forms.py:546
 msgid "A license must be selected."
 msgstr "Es muss eine Lizenz ausgewählt werden."
 
-#: src/olympia/addons/forms.py:556
+#: src/olympia/addons/forms.py:527
 msgid "Give Your Theme a Name."
 msgstr "Geben Sie Ihrem Theme einen Namen."
 
-#: src/olympia/addons/forms.py:562 src/olympia/devhub/templates/devhub/personas/submit.html:53
+#: src/olympia/addons/forms.py:533 src/olympia/devhub/templates/devhub/personas/submit.html:53
 msgid "Describe your Theme."
 msgstr "Beschreiben Sie Ihr Theme."
 
-#: src/olympia/addons/forms.py:704
+#: src/olympia/addons/forms.py:675
 msgid "Enter a new author's email address"
 msgstr "Geben Sie eine neue E-Mail-Adresse des Autors ein"
 
@@ -153,39 +154,39 @@ msgstr "Geben Sie eine neue E-Mail-Adresse des Autors ein"
 msgid "Not Reviewed"
 msgstr "Noch nicht freigegeben"
 
-#: src/olympia/addons/models.py:301
+#: src/olympia/addons/models.py:298
 msgid "Users have the option of contributing more or less than this amount."
 msgstr "Benutzer können mehr, aber auch weniger als diesen Betrag beitragen."
 
-#: src/olympia/addons/models.py:309
-msgid "Users will always be asked in the Add-ons Manager (Firefox 4 and above)"
-msgstr "Benutzer werden im Add-ons-Manager (in Firefox 4 und später) immer gefragt."
+#: src/olympia/addons/models.py:306
+msgid "Users will always be asked in the Add-ons Manager (Firefox 4 and above). Only applies to desktop."
+msgstr ""
 
 # Column name in a table.
-#: src/olympia/addons/models.py:1804 src/olympia/addons/templates/addons/details_box.html:55 src/olympia/devhub/templates/devhub/index.html:92
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:102
+#: src/olympia/addons/models.py:1802 src/olympia/addons/templates/addons/details_box.html:55 src/olympia/devhub/templates/devhub/index.html:92
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:89
 msgid "Listed"
 msgstr "Angezeigt"
 
-#: src/olympia/addons/views.py:320 src/olympia/browse/templates/browse/personas/mobile/category_landing.html:27
+#: src/olympia/addons/views.py:334 src/olympia/browse/templates/browse/personas/mobile/category_landing.html:27
 msgid "Popular"
 msgstr "Beliebt"
 
-#: src/olympia/addons/views.py:321 src/olympia/browse/views.py:238 src/olympia/browse/views.py:280 src/olympia/browse/views.py:482
+#: src/olympia/addons/views.py:335 src/olympia/browse/views.py:205 src/olympia/browse/views.py:247 src/olympia/browse/views.py:449
 msgid "Recently Added"
 msgstr "Neu hinzugefügt"
 
-#: src/olympia/addons/views.py:322 src/olympia/bandwagon/views.py:99 src/olympia/browse/views.py:60 src/olympia/browse/views.py:71 src/olympia/search/forms.py:16 src/olympia/search/forms.py:91
+#: src/olympia/addons/views.py:336 src/olympia/bandwagon/views.py:99 src/olympia/browse/views.py:60 src/olympia/browse/views.py:71 src/olympia/search/forms.py:16 src/olympia/search/forms.py:91
 msgid "Recently Updated"
 msgstr "Zuletzt aktualisiert"
 
 # %1 is an add-on name.
 #. l10n: {0} is the addon name
-#: src/olympia/addons/views.py:520
+#: src/olympia/addons/views.py:534
 msgid "Contribution for {0}"
 msgstr "Spende für {0}"
 
-#: src/olympia/addons/views.py:613
+#: src/olympia/addons/views.py:627
 msgid "Abuse reported."
 msgstr "Missbrauch gemeldet."
 
@@ -254,9 +255,9 @@ msgstr "Einen Beitrag leisten"
 #: src/olympia/devhub/templates/devhub/addons/ajax_compat_update.html:36 src/olympia/devhub/templates/devhub/addons/profile.html:44 src/olympia/devhub/templates/devhub/addons/edit/admin.html:101
 #: src/olympia/devhub/templates/devhub/addons/edit/basic.html:152 src/olympia/devhub/templates/devhub/addons/edit/details.html:85 src/olympia/devhub/templates/devhub/addons/edit/support.html:67
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:166 src/olympia/devhub/templates/devhub/addons/forms_shared/media.html:149
-#: src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:44 src/olympia/devhub/templates/devhub/versions/add_file_modal.html:78 src/olympia/devhub/templates/devhub/versions/edit.html:139
-#: src/olympia/devhub/templates/devhub/versions/list.html:242 src/olympia/devhub/templates/devhub/versions/list.html:276 src/olympia/devhub/templates/devhub/versions/list.html:317
-#: src/olympia/devhub/templates/devhub/versions/list.html:351 src/olympia/reviews/templates/reviews/edit_review.html:16 src/olympia/translations/templates/translations/trans-menu.html:50
+#: src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:43 src/olympia/devhub/templates/devhub/versions/add_file_modal.html:58 src/olympia/devhub/templates/devhub/versions/edit.html:139
+#: src/olympia/devhub/templates/devhub/versions/list.html:239 src/olympia/devhub/templates/devhub/versions/list.html:281 src/olympia/devhub/templates/devhub/versions/list.html:315
+#: src/olympia/devhub/templates/devhub/versions/list.html:349 src/olympia/reviews/templates/reviews/edit_review.html:16 src/olympia/translations/templates/translations/trans-menu.html:50
 #: src/olympia/translations/templates/translations/trans-menu.html:62
 msgid "or"
 msgstr "oder"
@@ -330,8 +331,7 @@ msgstr "Die Spendenmenge muss eine Zahl sein."
 msgid "A one-time suggested contribution of {0}"
 msgstr "Eine einmalige Spende in der vorgeschlagenen Höhe von {0}"
 
-#. {0} is a currency symbol (e.g., $),                    {1} is an amount
-#. input
+#. {0} is a currency symbol (e.g., $),                    {1} is an amount input
 #. field
 #: src/olympia/addons/templates/addons/contributions_lightbox.html:64
 msgid "A one-time contribution of {0} {1}"
@@ -372,7 +372,7 @@ msgid "Add-on Information for {0}"
 msgstr "Add-on-Informationen für {0}"
 
 #: src/olympia/addons/templates/addons/details_box.html:30 src/olympia/addons/templates/addons/persona_detail_table.html:3 src/olympia/addons/templates/addons/mobile/details.html:63
-#: src/olympia/addons/templates/addons/mobile/persona_detail_table.html:7 src/olympia/browse/views.py:459 src/olympia/devhub/views.py:75
+#: src/olympia/addons/templates/addons/mobile/persona_detail_table.html:7 src/olympia/browse/views.py:426 src/olympia/devhub/views.py:73
 msgid "Updated"
 msgstr "Aktualisiert"
 
@@ -391,11 +391,11 @@ msgstr "Funktioniert mit"
 msgid "Visibility"
 msgstr "Sichtbarkeit"
 
-#: src/olympia/addons/templates/addons/details_box.html:57 src/olympia/devhub/templates/devhub/index.html:94 src/olympia/devhub/templates/devhub/includes/addon_details.html:104
+#: src/olympia/addons/templates/addons/details_box.html:57 src/olympia/devhub/templates/devhub/index.html:94 src/olympia/devhub/templates/devhub/includes/addon_details.html:91
 msgid "Hidden"
 msgstr "Versteckt"
 
-#: src/olympia/addons/templates/addons/details_box.html:59 src/olympia/devhub/templates/devhub/index.html:96 src/olympia/devhub/templates/devhub/includes/addon_details.html:106
+#: src/olympia/addons/templates/addons/details_box.html:59 src/olympia/devhub/templates/devhub/index.html:96 src/olympia/devhub/templates/devhub/includes/addon_details.html:93
 msgid "Unlisted"
 msgstr "Nicht gelistet"
 
@@ -403,13 +403,13 @@ msgstr "Nicht gelistet"
 msgid "Required Add-ons"
 msgstr "Erforderliche Add-ons"
 
-#: src/olympia/addons/templates/addons/details_box.html:81 src/olympia/addons/templates/addons/persona_detail_table.html:15 src/olympia/browse/views.py:462 src/olympia/devhub/views.py:78
-#: src/olympia/devhub/views.py:85 src/olympia/discovery/templates/discovery/addons/detail.html:57 src/olympia/reviews/forms.py:62 src/olympia/reviews/templates/reviews/add.html:57
+#: src/olympia/addons/templates/addons/details_box.html:81 src/olympia/addons/templates/addons/persona_detail_table.html:15 src/olympia/browse/views.py:429 src/olympia/devhub/views.py:76
+#: src/olympia/devhub/views.py:83 src/olympia/discovery/templates/discovery/addons/detail.html:57 src/olympia/reviews/forms.py:62 src/olympia/reviews/templates/reviews/add.html:57
 #: src/olympia/reviews/templates/reviews/mobile/review_list.html:18
 msgid "Rating"
 msgstr "Bewertung"
 
-#: src/olympia/addons/templates/addons/details_box.html:85 src/olympia/browse/views.py:461 src/olympia/devhub/views.py:77 src/olympia/devhub/views.py:84
+#: src/olympia/addons/templates/addons/details_box.html:85 src/olympia/browse/views.py:428 src/olympia/devhub/views.py:75 src/olympia/devhub/views.py:82
 #: src/olympia/stats/templates/stats/addon_report_menu.html:8 src/olympia/stats/templates/stats/collection_report_menu.html:18
 msgid "Downloads"
 msgstr "Downloads"
@@ -429,7 +429,7 @@ msgstr "Missbrauchsmeldungen"
 
 #. The Privacy Policy for this add-on.
 #: src/olympia/addons/templates/addons/details_box.html:121 src/olympia/addons/templates/addons/privacy.html:19 src/olympia/addons/templates/addons/privacy.html:23
-#: src/olympia/addons/templates/addons/impala/button.html:43 src/olympia/addons/templates/addons/impala/details.html:307 src/olympia/devhub/templates/devhub/includes/policy_form.html:20
+#: src/olympia/addons/templates/addons/impala/button.html:43 src/olympia/addons/templates/addons/impala/details.html:312 src/olympia/devhub/templates/devhub/includes/policy_form.html:23
 #: src/olympia/templates/mobile/base_addons.html:87
 msgid "Privacy Policy"
 msgstr "Datenschutzerklärung"
@@ -454,7 +454,7 @@ msgstr "Bildergalerie"
 msgid "Developer Comments"
 msgstr "Entwickler-Kommentare"
 
-#: src/olympia/addons/templates/addons/details_box.html:199 src/olympia/addons/templates/addons/impala/details.html:259
+#: src/olympia/addons/templates/addons/details_box.html:199 src/olympia/addons/templates/addons/impala/details.html:264
 msgid "Development Channel"
 msgstr "Entwicklerecke"
 
@@ -478,13 +478,13 @@ msgstr ""
 "<strong>Warnung:</strong> Entwicklerversionen dieses Add-ons wurden nicht von Mozilla überprüft. Wenn Sie eine Entwicklerversion installieren, erhalten Sie weiterhin Updates von diesem Entwickler. "
 "Um keine weiteren Entwickler-Updates zu erhalten, installieren Sie wieder die Standardversion über obigen Link."
 
-#: src/olympia/addons/templates/addons/details_box.html:220 src/olympia/addons/templates/addons/impala/details.html:278
+#: src/olympia/addons/templates/addons/details_box.html:220 src/olympia/addons/templates/addons/impala/details.html:283
 msgid "Version {0}:"
 msgstr "Version {0}:"
 
 #: src/olympia/addons/templates/addons/details_box.html:234
 msgid "Nothing to see here!  The developer did not include any details."
-msgstr "Hier gibt es nichts zu sehen! Der Entwickler hat keine Details angegeben."
+msgstr ""
 
 #: src/olympia/addons/templates/addons/details_box.html:251 src/olympia/devhub/templates/devhub/versions/edit.html:73 src/olympia/editors/templates/editors/review.html:98
 msgid "Version Notes"
@@ -497,7 +497,7 @@ msgid "End-User License Agreement for {0}"
 msgstr "Endbenutzer-Lizenzvereinbarung für {0}"
 
 #: src/olympia/addons/templates/addons/eula.html:17 src/olympia/addons/templates/addons/eula.html:21 src/olympia/addons/templates/addons/impala/button.html:48
-#: src/olympia/addons/templates/addons/impala/details.html:316 src/olympia/devhub/templates/devhub/includes/policy_form.html:3 src/olympia/discovery/templates/discovery/addons/eula.html:11
+#: src/olympia/addons/templates/addons/impala/details.html:321 src/olympia/devhub/templates/devhub/includes/policy_form.html:3 src/olympia/discovery/templates/discovery/addons/eula.html:11
 msgid "End-User License Agreement"
 msgstr "Endbenutzer-Lizenzvereinbarung"
 
@@ -517,7 +517,7 @@ msgstr "Zurück zu {0}…"
 msgid "Add-ons for {0}"
 msgstr "Add-ons für {0}"
 
-#: src/olympia/addons/templates/addons/home.html:10 src/olympia/addons/templates/addons/home.html:51 src/olympia/browse/templates/browse/impala/base_listing.html:11
+#: src/olympia/addons/templates/addons/home.html:10 src/olympia/addons/templates/addons/home.html:53 src/olympia/browse/templates/browse/impala/base_listing.html:11
 msgid "Featured Extensions"
 msgstr "Vorgestellte Erweiterungen"
 
@@ -525,29 +525,29 @@ msgstr "Vorgestellte Erweiterungen"
 msgid "Popular Extensions"
 msgstr "Beliebte Erweiterungen"
 
-#: src/olympia/addons/templates/addons/home.html:42 src/olympia/amo/templates/amo/side_nav.html:3 src/olympia/amo/templates/amo/side_nav.html:11 src/olympia/amo/templates/amo/site_nav.html:3
-#: src/olympia/amo/templates/amo/site_nav.html:25 src/olympia/browse/views.py:236 src/olympia/browse/views.py:281 src/olympia/browse/views.py:481
+#: src/olympia/addons/templates/addons/home.html:44 src/olympia/amo/templates/amo/side_nav.html:3 src/olympia/amo/templates/amo/side_nav.html:11 src/olympia/amo/templates/amo/site_nav.html:3
+#: src/olympia/amo/templates/amo/site_nav.html:25 src/olympia/browse/views.py:203 src/olympia/browse/views.py:248 src/olympia/browse/views.py:448
 msgid "Most Popular"
 msgstr "Beliebteste"
 
-#: src/olympia/addons/templates/addons/home.html:43
+#: src/olympia/addons/templates/addons/home.html:45
 msgid "All »"
 msgstr "Alle »"
 
-#: src/olympia/addons/templates/addons/home.html:52 src/olympia/addons/templates/addons/home.html:61 src/olympia/addons/templates/addons/home.html:70 src/olympia/addons/templates/addons/home.html:78
+#: src/olympia/addons/templates/addons/home.html:54 src/olympia/addons/templates/addons/home.html:63 src/olympia/addons/templates/addons/home.html:72 src/olympia/addons/templates/addons/home.html:80
 #: src/olympia/browse/templates/browse/impala/category_landing.html:36
 msgid "See all »"
 msgstr "Alle ansehen »"
 
-#: src/olympia/addons/templates/addons/home.html:60
+#: src/olympia/addons/templates/addons/home.html:62
 msgid "Up &amp; Coming Extensions"
 msgstr "Aufstrebende Erweiterungen"
 
-#: src/olympia/addons/templates/addons/home.html:69 src/olympia/browse/templates/browse/personas/category_landing.html:61 src/olympia/discovery/templates/discovery/pane.html:74
+#: src/olympia/addons/templates/addons/home.html:71 src/olympia/browse/templates/browse/personas/category_landing.html:61 src/olympia/discovery/templates/discovery/pane.html:74
 msgid "Featured Themes"
 msgstr "Vorgestellte Themes"
 
-#: src/olympia/addons/templates/addons/home.html:77 src/olympia/bandwagon/templates/bandwagon/impala/collection_listing.html:5
+#: src/olympia/addons/templates/addons/home.html:79 src/olympia/bandwagon/templates/bandwagon/impala/collection_listing.html:5
 msgid "Featured Collections"
 msgstr "Vorgestellte Sammlungen"
 
@@ -565,7 +565,7 @@ msgid "Updated {0}"
 msgstr "Aktualisiert am {0}"
 
 #. {0} is a date.
-#: src/olympia/addons/templates/addons/macros.html:10 src/olympia/addons/templates/addons/macros.html:69 src/olympia/addons/templates/addons/persona_preview.html:21
+#: src/olympia/addons/templates/addons/macros.html:10 src/olympia/addons/templates/addons/macros.html:69 src/olympia/addons/templates/addons/persona_preview.html:22
 #: src/olympia/addons/templates/addons/listing/items_mobile.html:44 src/olympia/addons/templates/addons/listing/macros.html:39
 #: src/olympia/bandwagon/templates/bandwagon/collection_listing_items.html:37 src/olympia/bandwagon/templates/bandwagon/impala/collection_listing_items.html:37
 msgid "Added {0}"
@@ -586,15 +586,14 @@ msgstr[0] "%(num)s Benutzer"
 msgstr[1] "%(num)s Benutzer"
 
 #. {0} is the number of downloads.
-#: src/olympia/addons/templates/addons/macros.html:53 src/olympia/addons/templates/addons/impala/details.html:61
+#: src/olympia/addons/templates/addons/macros.html:53 src/olympia/addons/templates/addons/impala/details.html:59
 msgid "{0} weekly download"
 msgid_plural "{0} weekly downloads"
 msgstr[0] "{0} wöchentlicher Download"
 msgstr[1] "{0} wöchentliche Downloads"
 
 #. {0} is the number of users.
-#: src/olympia/addons/templates/addons/macros.html:61 src/olympia/addons/templates/addons/impala/details.html:54 src/olympia/compat/templates/compat/index.html:71
-#: src/olympia/zadmin/templates/zadmin/compat.html:67
+#: src/olympia/addons/templates/addons/macros.html:61 src/olympia/addons/templates/addons/impala/details.html:52 src/olympia/zadmin/templates/zadmin/compat.html:67
 msgid "{0} user"
 msgid_plural "{0} users"
 msgstr[0] "{0} Benutzer"
@@ -612,7 +611,7 @@ msgstr "Zahlung abgeschlossen"
 msgid "Return to the addon."
 msgstr "Zurück zum Add-on."
 
-#: src/olympia/addons/templates/addons/persona_detail.html:17 src/olympia/addons/templates/addons/impala/details.html:106 src/olympia/addons/templates/addons/mobile/details.html:23
+#: src/olympia/addons/templates/addons/persona_detail.html:17 src/olympia/addons/templates/addons/impala/details.html:103 src/olympia/addons/templates/addons/mobile/details.html:23
 #: src/olympia/addons/templates/addons/mobile/persona_detail.html:21 src/olympia/discovery/templates/discovery/addons/base.html:27 src/olympia/editors/templates/editors/review.html:31
 msgid "by"
 msgstr "von"
@@ -656,34 +655,35 @@ msgstr "Tägliche Benutzer"
 msgid "License"
 msgstr "Lizenz"
 
-#: src/olympia/addons/templates/addons/persona_preview.html:12 src/olympia/constants/base.py:48
+#: src/olympia/addons/templates/addons/persona_preview.html:13 src/olympia/constants/base.py:48
 msgid "Awaiting Review"
 msgstr "Wartet auf Überprüfung"
 
-#: src/olympia/addons/templates/addons/persona_preview.html:14 src/olympia/amo/log.py:180 src/olympia/constants/base.py:42 src/olympia/editors/helpers.py:62
+#: src/olympia/addons/templates/addons/persona_preview.html:15 src/olympia/amo/log.py:180 src/olympia/constants/base.py:42 src/olympia/editors/helpers.py:62
 msgid "Rejected"
 msgstr "Abgewiesen"
 
-#: src/olympia/addons/templates/addons/persona_preview.html:16 src/olympia/amo/log.py:159
+#: src/olympia/addons/templates/addons/persona_preview.html:17 src/olympia/amo/log.py:159
 msgid "Approved"
 msgstr "Freigeschaltet"
 
 #. {0} is the number of users.
-#: src/olympia/addons/templates/addons/persona_preview.html:26 src/olympia/addons/templates/addons/listing/items_mobile.html:36 src/olympia/addons/templates/addons/listing/macros.html:31
+#: src/olympia/addons/templates/addons/persona_preview.html:27 src/olympia/addons/templates/addons/listing/items_mobile.html:36 src/olympia/addons/templates/addons/listing/macros.html:31
 msgid "<strong>{0}</strong> user"
 msgid_plural "<strong>{0}</strong> users"
 msgstr[0] "<strong>{0}</strong> Benutzer"
 msgstr[1] "<strong>{0}</strong> Benutzer"
 
-#: src/olympia/addons/templates/addons/persona_preview.html:40
+#: src/olympia/addons/templates/addons/persona_preview.html:41
 msgid "Hover to Preview"
 msgstr "Zur Vorschau Mauszeiger darüberhalten"
 
-#: src/olympia/addons/templates/addons/persona_preview.html:46 src/olympia/addons/templates/addons/persona_preview.html:48 src/olympia/reviews/templates/reviews/add.html:15
+#: src/olympia/addons/templates/addons/persona_preview.html:47 src/olympia/addons/templates/addons/persona_preview.html:49 src/olympia/addons/templates/addons/persona_preview.html:97
+#: src/olympia/reviews/templates/reviews/add.html:15
 msgid "Add"
 msgstr "Hinzufügen"
 
-#: src/olympia/addons/templates/addons/persona_preview.html:57 src/olympia/bandwagon/templates/bandwagon/ajax_new.html:16 src/olympia/bandwagon/templates/bandwagon/edit.html:19
+#: src/olympia/addons/templates/addons/persona_preview.html:58 src/olympia/bandwagon/templates/bandwagon/ajax_new.html:16 src/olympia/bandwagon/templates/bandwagon/edit.html:19
 #: src/olympia/bandwagon/templates/bandwagon/includes/addedit.html:19 src/olympia/devhub/templates/devhub/addons/edit/admin.html:13 src/olympia/devhub/templates/devhub/addons/edit/basic.html:10
 #: src/olympia/devhub/templates/devhub/addons/edit/details.html:8 src/olympia/devhub/templates/devhub/addons/edit/media.html:6 src/olympia/devhub/templates/devhub/addons/edit/support.html:8
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:9 src/olympia/devhub/templates/devhub/addons/submit/describe.html:29 src/olympia/editors/templates/editors/review.html:257
@@ -692,21 +692,21 @@ msgstr "Bearbeiten"
 
 #. For datetime formatting, see the table on
 #. http://docs.python.org/library/datetime.html#strftime-and-strptime-behavior
-#: src/olympia/addons/templates/addons/persona_preview.html:66
+#: src/olympia/addons/templates/addons/persona_preview.html:67
 #, python-format
 msgid "%%Y-%%m-%%d"
 msgstr "%%d. %%m. %%Y"
 
-#: src/olympia/addons/templates/addons/persona_preview.html:67
+#: src/olympia/addons/templates/addons/persona_preview.html:68
 msgid "by {0} on {1}"
 msgstr "von {0} am {1}"
 
-#: src/olympia/addons/templates/addons/persona_preview.html:75 src/olympia/reviews/helpers.py:17 src/olympia/reviews/templates/reviews/review_list.html:63
+#: src/olympia/addons/templates/addons/persona_preview.html:76 src/olympia/reviews/helpers.py:17 src/olympia/reviews/templates/reviews/review_list.html:63
 #: src/olympia/reviews/templates/reviews/reviews_link.html:21 src/olympia/reviews/templates/reviews/impala/reviews_link.html:16
 msgid "Not yet rated"
 msgstr "Noch nicht bewertet"
 
-#: src/olympia/addons/templates/addons/persona_preview.html:78
+#: src/olympia/addons/templates/addons/persona_preview.html:79
 msgid "<b>{0}</b> users"
 msgstr "<b>{0}</b> Benutzer"
 
@@ -719,8 +719,8 @@ msgid "Learn more about Firefox"
 msgstr "Lernen Sie mehr über Firefox"
 
 #: src/olympia/addons/templates/addons/popups.html:22
-msgid "or <b><a class=\"installer\" href=\"{url}\">download anyway</a></b>"
-msgstr "oder <b><a class=\"installer\" href=\"{url}\">trotzdem herunterladen</a></b>"
+msgid "or <b><a class=\"button installer\" href=\"{url}\">download anyway</a></b>"
+msgstr ""
 
 #: src/olympia/addons/templates/addons/popups.html:26
 msgid ""
@@ -784,8 +784,6 @@ msgid ""
 "<strong>Caution:</strong> This add-on has not been reviewed by Mozilla and can't be installed on release versions of Firefox 43 and above.  Be careful when installing third-party software that "
 "might harm your computer."
 msgstr ""
-"<strong>Achtung:</strong> Dieses Add-on wurde nicht von Mozilla überprüft und kann in Firefox 43 und neuer nicht installiert werden. Seien Sie vorsichtig, wenn Sie Drittsoftware installieren, die "
-"Ihrem Computer schaden könnte."
 
 #: src/olympia/addons/templates/addons/popups.html:120
 msgid "<strong>Please note:</strong> This add-on is not compatible with your operating system."
@@ -820,11 +818,9 @@ msgid ""
 "  to your phone.  (You'll need a QR reader.  Search your phone's marketplace if\n"
 "  don't have one.)"
 msgstr ""
-"Möchten Sie {0} auf Ihrem mobilen Firefox? Scannen Sie diesen QR-Code zur direkten Installation auf Ihrem Hand. (Sie benötigen einen QR-Leser. Durchsuchen Sie den Marktplatz Ihres Handys, wenn Sie "
-"keinen haben.)"
 
 #: src/olympia/addons/templates/addons/report_abuse.html:6 src/olympia/addons/templates/addons/report_abuse_full.html:10 src/olympia/addons/templates/addons/impala/details-more.html:23
-#: src/olympia/addons/templates/addons/impala/details.html:328
+#: src/olympia/addons/templates/addons/impala/details.html:333
 msgid "Report Abuse"
 msgstr "Missbrauch melden"
 
@@ -845,9 +841,9 @@ msgstr "Bericht absenden"
 #: src/olympia/devhub/templates/devhub/addons/ajax_compat_update.html:36 src/olympia/devhub/templates/devhub/addons/profile.html:44 src/olympia/devhub/templates/devhub/addons/edit/admin.html:104
 #: src/olympia/devhub/templates/devhub/addons/edit/basic.html:155 src/olympia/devhub/templates/devhub/addons/edit/details.html:88 src/olympia/devhub/templates/devhub/addons/edit/support.html:70
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:169 src/olympia/devhub/templates/devhub/addons/forms_shared/media.html:152
-#: src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:44 src/olympia/devhub/templates/devhub/personas/edit.html:222 src/olympia/devhub/templates/devhub/versions/add_file_modal.html:79
-#: src/olympia/devhub/templates/devhub/versions/edit.html:140 src/olympia/devhub/templates/devhub/versions/list.html:208 src/olympia/devhub/templates/devhub/versions/list.html:242
-#: src/olympia/devhub/templates/devhub/versions/list.html:276 src/olympia/devhub/templates/devhub/versions/list.html:317 src/olympia/reviews/templates/reviews/edit_review.html:16
+#: src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:43 src/olympia/devhub/templates/devhub/personas/edit.html:222 src/olympia/devhub/templates/devhub/versions/add_file_modal.html:59
+#: src/olympia/devhub/templates/devhub/versions/edit.html:140 src/olympia/devhub/templates/devhub/versions/list.html:208 src/olympia/devhub/templates/devhub/versions/list.html:239
+#: src/olympia/devhub/templates/devhub/versions/list.html:281 src/olympia/devhub/templates/devhub/versions/list.html:315 src/olympia/reviews/templates/reviews/edit_review.html:16
 #: src/olympia/translations/templates/translations/trans-menu.html:50 src/olympia/translations/templates/translations/trans-menu.html:62 src/olympia/zadmin/templates/zadmin/validation.html:105
 msgid "Cancel"
 msgstr "Abbrechen"
@@ -894,7 +890,7 @@ msgstr "Schauen Sie im Abschnitt <a href=\"%(support)s\">Support</a> nach, wo Si
 msgid "Review Guidelines"
 msgstr "Bewertungsleitfaden"
 
-#: src/olympia/addons/templates/addons/review_list_box.html:5 src/olympia/addons/templates/addons/impala/details-more.html:27 src/olympia/editors/helpers.py:921
+#: src/olympia/addons/templates/addons/review_list_box.html:5 src/olympia/addons/templates/addons/impala/details-more.html:27 src/olympia/editors/helpers.py:1001
 #: src/olympia/reviews/templates/reviews/add.html:14 src/olympia/reviews/templates/reviews/reply.html:14 src/olympia/reviews/templates/reviews/review_list.html:19
 #: src/olympia/reviews/templates/reviews/mobile/review_list.html:26
 msgid "Reviews"
@@ -985,31 +981,31 @@ msgid_plural "Other add-ons by these authors"
 msgstr[0] "Weitere Add-ons von %(author)s"
 msgstr[1] "Weitere Add-ons von diesen Autoren"
 
-#: src/olympia/addons/templates/addons/impala/details.html:41
+#: src/olympia/addons/templates/addons/impala/details.html:39
 #, python-format
 msgid "<span itemprop=\"ratingCount\">%(num)s</span> user review"
 msgid_plural "<span itemprop=\"ratingCount\">%(num)s</span> user reviews"
 msgstr[0] "<span itemprop=\"ratingCount\">%(num)s</span> Benutzerbewertung"
 msgstr[1] "<span itemprop=\"ratingCount\">%(num)s</span> Benutzerbewertungen"
 
-#: src/olympia/addons/templates/addons/impala/details.html:69
+#: src/olympia/addons/templates/addons/impala/details.html:66
 msgid "View statistics"
 msgstr "Statistiken ansehen"
 
-#: src/olympia/addons/templates/addons/impala/details.html:84
+#: src/olympia/addons/templates/addons/impala/details.html:81
 msgid "Manage"
 msgstr "Verwalten"
 
 #. {0} is an add-on name.
-#: src/olympia/addons/templates/addons/impala/details.html:96
+#: src/olympia/addons/templates/addons/impala/details.html:93
 msgid "Icon of {0}"
 msgstr "Symbol von {0}"
 
-#: src/olympia/addons/templates/addons/impala/details.html:103 src/olympia/addons/templates/addons/impala/listing/items.html:14
+#: src/olympia/addons/templates/addons/impala/details.html:100 src/olympia/addons/templates/addons/impala/listing/items.html:14
 msgid "No Restart"
 msgstr "Kein Neustart"
 
-#: src/olympia/addons/templates/addons/impala/details.html:127
+#: src/olympia/addons/templates/addons/impala/details.html:124
 #, python-format
 msgid "Meet the Developer: <a href=\"%(url)s\">%(name)s</a>"
 msgid_plural "<a href=\"%(url)s\">Meet the Developers</a>"
@@ -1017,72 +1013,72 @@ msgstr[0] "Lernen Sie den Entwickler kennen: <a href=\"%(url)s\">%(name)s</a>"
 msgstr[1] "<a href=\"%(url)s\">Lernen Sie die Entwickler kennen</a>"
 
 # {0} is an add-on name.
-#: src/olympia/addons/templates/addons/impala/details.html:137
+#: src/olympia/addons/templates/addons/impala/details.html:134
 msgid "Learn why {0} was created and find out what's next for this add-on."
 msgstr "Lesen Sie, warum „{0}“ geschaffen wurde, und finden Sie heraus, was für dieses Add-on als nächstes kommt."
 
 #. {0} is an index.
-#: src/olympia/addons/templates/addons/impala/details.html:156
+#: src/olympia/addons/templates/addons/impala/details.html:161
 msgid "Add-on screenshot #{0}"
 msgstr "Add-on-Screenshot #{0}"
 
-#: src/olympia/addons/templates/addons/impala/details.html:182
+#: src/olympia/addons/templates/addons/impala/details.html:187
 msgid "Add-on home page"
 msgstr "Add-on-Homepage"
 
-#: src/olympia/addons/templates/addons/impala/details.html:185
+#: src/olympia/addons/templates/addons/impala/details.html:190
 msgid "Support site"
 msgstr "Hilfeseite"
 
-#: src/olympia/addons/templates/addons/impala/details.html:189
+#: src/olympia/addons/templates/addons/impala/details.html:194
 msgid "Support E-mail"
 msgstr "E-Mail-Adresse für Hilfestellungen"
 
-#: src/olympia/addons/templates/addons/impala/details.html:194 src/olympia/devhub/models.py:378 src/olympia/devhub/templates/devhub/versions/list.html:12
+#: src/olympia/addons/templates/addons/impala/details.html:199 src/olympia/devhub/models.py:378 src/olympia/devhub/templates/devhub/versions/list.html:12
 #: src/olympia/versions/templates/versions/version.html:6 src/olympia/versions/templates/versions/mobile/version.html:6
 msgid "Version {0}"
 msgstr "Version {0}"
 
-#: src/olympia/addons/templates/addons/impala/details.html:194
+#: src/olympia/addons/templates/addons/impala/details.html:199
 msgid "Info"
 msgstr "Info"
 
-#: src/olympia/addons/templates/addons/impala/details.html:195 src/olympia/devhub/templates/devhub/includes/addon_details.html:129
+#: src/olympia/addons/templates/addons/impala/details.html:200 src/olympia/devhub/templates/devhub/includes/addon_details.html:116
 msgid "Last Updated:"
 msgstr "Zuletzt aktualisiert:"
 
-#: src/olympia/addons/templates/addons/impala/details.html:200
+#: src/olympia/addons/templates/addons/impala/details.html:205
 #, python-format
 msgid "Released under <a target=\"_blank\" href=\"%(url)s\">%(name)s</a>"
 msgstr "Veröffentlicht unter <a target=\"_blank\" href=\"%(url)s\">%(name)s</a>"
 
-#: src/olympia/addons/templates/addons/impala/details.html:201 src/olympia/addons/templates/addons/impala/details.html:206 src/olympia/amo/helpers.py:398 src/olympia/devhub/forms.py:142
+#: src/olympia/addons/templates/addons/impala/details.html:206 src/olympia/addons/templates/addons/impala/details.html:211 src/olympia/amo/helpers.py:398 src/olympia/devhub/forms.py:142
 #: src/olympia/devhub/forms.py:173 src/olympia/versions/templates/versions/version.html:40 src/olympia/versions/templates/versions/version.html:45
 msgid "Custom License"
 msgstr "Benutzerdefinierte Lizenz"
 
-#: src/olympia/addons/templates/addons/impala/details.html:205
+#: src/olympia/addons/templates/addons/impala/details.html:210
 #, python-format
 msgid "Released under <a href=\"%(url)s\">%(name)s</a>"
 msgstr "Veröffentlicht unter <a href=\"%(url)s\">%(name)s</a>"
 
-#: src/olympia/addons/templates/addons/impala/details.html:217
+#: src/olympia/addons/templates/addons/impala/details.html:222
 msgid "About this Add-on"
 msgstr "Über dieses Add-on"
 
-#: src/olympia/addons/templates/addons/impala/details.html:233
+#: src/olympia/addons/templates/addons/impala/details.html:238
 msgid "Developer’s Comments"
 msgstr "Kommentare des Entwicklers"
 
-#: src/olympia/addons/templates/addons/impala/details.html:243
+#: src/olympia/addons/templates/addons/impala/details.html:248
 msgid "Version Information"
 msgstr "Versionshinweise"
 
-#: src/olympia/addons/templates/addons/impala/details.html:250
+#: src/olympia/addons/templates/addons/impala/details.html:255
 msgid "See complete version history"
 msgstr "Die vollständige Versionsgeschichte ansehen"
 
-#: src/olympia/addons/templates/addons/impala/details.html:262
+#: src/olympia/addons/templates/addons/impala/details.html:267
 msgid ""
 "The Development Channel lets you test an experimental new version of this add-on before it's released to the general public. Once you install the development version, you will continue to get "
 "updates from this channel. To stop receiving development updates, reinstall the default version from the link above."
@@ -1090,17 +1086,17 @@ msgstr ""
 "Der Entwicklerkanal ermöglicht es Ihnen, eine experimentelle neue Version dieses Add-ons zu testen, bevor es der Öffentlichkeit zur Verfügung gestellt wird. Sobald Sie die Entwicklerversion "
 "installieren, erhalten Sie weiter Updates über diesen Kanal. Wenn Sie keine Updates der Entwicklerversion mehr erhalten möchten, installieren Sie die normale Version über obigen Link neu."
 
-#: src/olympia/addons/templates/addons/impala/details.html:272
+#: src/olympia/addons/templates/addons/impala/details.html:277
 msgid "<strong>Caution:</strong> Development versions of this add-on have not been reviewed by Mozilla."
 msgstr "<strong>Achtung:</strong> Entwicklerversionen dieses Add-ons wurden nicht von Mozilla überprüft."
 
-#: src/olympia/addons/templates/addons/impala/details.html:287
+#: src/olympia/addons/templates/addons/impala/details.html:292
 msgid "See complete development channel history"
 msgstr "Die vollständige Versionsgeschichte des Entwicklerkanals ansehen"
 
-#: src/olympia/addons/templates/addons/impala/details.html:306 src/olympia/addons/templates/addons/impala/details.html:315 src/olympia/addons/templates/addons/impala/details.html:327
+#: src/olympia/addons/templates/addons/impala/details.html:311 src/olympia/addons/templates/addons/impala/details.html:320 src/olympia/addons/templates/addons/impala/details.html:332
 #: src/olympia/addons/templates/addons/impala/review_add_box.html:4 src/olympia/stats/templates/stats/popup.html:2 src/olympia/stats/templates/stats/popup.html:8
-#: src/olympia/stats/templates/stats/stats.html:202 src/olympia/users/templates/users/profile.html:119
+#: src/olympia/stats/templates/stats/stats.html:204 src/olympia/users/templates/users/profile.html:119
 msgid "close"
 msgstr "Schließen"
 
@@ -1159,15 +1155,11 @@ msgstr "Quelltext-Lizenz für {addon}"
 msgid "Source Code License"
 msgstr "Quellcode-Lizenz"
 
-#: src/olympia/addons/templates/addons/impala/persona_grid.html:16 src/olympia/addons/templates/addons/impala/toplist.html:6
-msgid "{0} users"
-msgstr "{0} Benutzer"
-
 #: src/olympia/addons/templates/addons/impala/review_list_box.html:19 src/olympia/reviews/templates/reviews/review.html:40
 msgid "permalink"
 msgstr "Permanentlink"
 
-#: src/olympia/addons/templates/addons/impala/review_list_box.html:23 src/olympia/editors/templates/editors/queue.html:98 src/olympia/reviews/templates/reviews/review.html:44
+#: src/olympia/addons/templates/addons/impala/review_list_box.html:23 src/olympia/editors/templates/editors/queue.html:104 src/olympia/reviews/templates/reviews/review.html:44
 msgid "translate"
 msgstr "Übersetzen"
 
@@ -1186,6 +1178,10 @@ msgstr "Dieses Add-on wurde noch nicht bewertet."
 msgid "Be the first!"
 msgstr "Seien Sie der Erste!"
 
+#: src/olympia/addons/templates/addons/impala/toplist.html:6
+msgid "{0} users"
+msgstr "{0} Benutzer"
+
 #: src/olympia/addons/templates/addons/impala/listing/sorter.html:14 src/olympia/devhub/templates/devhub/addons/listing/item_actions.html:49
 msgid "More"
 msgstr "Mehr"
@@ -1198,7 +1194,7 @@ msgstr "Zur Sammlung hinzufügen"
 msgid "My Add-ons"
 msgstr "Meine Add-ons"
 
-#: src/olympia/addons/templates/addons/includes/dashboard_tabs.html:6 src/olympia/amo/context_processors.py:51
+#: src/olympia/addons/templates/addons/includes/dashboard_tabs.html:6 src/olympia/amo/context_processors.py:50
 msgid "My Themes"
 msgstr "Meine Themes"
 
@@ -1253,7 +1249,7 @@ msgstr "Benutzer"
 msgid "Weekly Downloads"
 msgstr "Wöchentliche Downloads"
 
-#: src/olympia/addons/templates/addons/mobile/details.html:99 src/olympia/compat/templates/compat/reporter_detail.html:46 src/olympia/devhub/forms.py:787
+#: src/olympia/addons/templates/addons/mobile/details.html:99 src/olympia/compat/templates/compat/reporter_detail.html:46 src/olympia/devhub/forms.py:788
 #: src/olympia/devhub/templates/devhub/versions/list.html:163
 msgid "Version"
 msgstr "Version"
@@ -1340,7 +1336,7 @@ msgstr ""
 #: src/olympia/browse/templates/browse/personas/category_landing.html:21 src/olympia/browse/templates/browse/personas/category_landing.html:23
 #: src/olympia/browse/templates/browse/personas/category_landing.html:38 src/olympia/browse/templates/browse/personas/grid.html:7 src/olympia/browse/templates/browse/personas/grid.html:11
 #: src/olympia/browse/templates/browse/personas/mobile/base.html:7 src/olympia/browse/templates/browse/personas/mobile/category_landing.html:19 src/olympia/constants/base.py:180
-#: src/olympia/devhub/templates/devhub/personas/submit.html:13 src/olympia/editors/helpers.py:105 src/olympia/editors/templates/editors/base.html:26
+#: src/olympia/devhub/templates/devhub/personas/submit.html:13 src/olympia/editors/helpers.py:107 src/olympia/editors/templates/editors/base.html:26
 #: src/olympia/editors/templates/editors/performance.html:73 src/olympia/search/templates/search/personas.html:39 src/olympia/templates/menu_links.html:9
 msgid "Themes"
 msgstr "Themes"
@@ -1361,7 +1357,7 @@ msgstr "Weitere Add-ons"
 msgid "Highest Rated"
 msgstr "Am höchsten bewertet"
 
-#: src/olympia/addons/templates/addons/mobile/home.html:74 src/olympia/amo/templates/amo/side_nav.html:5 src/olympia/amo/templates/amo/site_nav.html:27 src/olympia/amo/templates/amo/site_nav.html:57
+#: src/olympia/addons/templates/addons/mobile/home.html:74 src/olympia/amo/templates/amo/side_nav.html:5 src/olympia/amo/templates/amo/site_nav.html:27 src/olympia/amo/templates/amo/site_nav.html:55
 #: src/olympia/bandwagon/views.py:97 src/olympia/browse/views.py:57 src/olympia/browse/views.py:67 src/olympia/browse/templates/browse/personas/mobile/category_landing.html:65
 #: src/olympia/search/forms.py:15 src/olympia/search/forms.py:87
 msgid "Newest"
@@ -1375,90 +1371,90 @@ msgstr "Probieren Sie es an!"
 msgid "Theme Info &raquo;"
 msgstr "Theme-Informationen &raquo;"
 
-#: src/olympia/amo/context_processors.py:39 src/olympia/devhub/templates/devhub/nav.html:43
+#: src/olympia/amo/context_processors.py:37 src/olympia/devhub/templates/devhub/nav.html:43
 msgid "Tools"
 msgstr "Werkzeuge"
 
-#: src/olympia/amo/context_processors.py:48 src/olympia/discovery/templates/discovery/pane_account.html:8 src/olympia/users/templates/users/includes/navigation.html:2
+#: src/olympia/amo/context_processors.py:47 src/olympia/discovery/templates/discovery/pane_account.html:8 src/olympia/users/templates/users/includes/navigation.html:2
 msgid "My Profile"
 msgstr "Mein Profil"
 
-#: src/olympia/amo/context_processors.py:54 src/olympia/users/templates/users/edit.html:5 src/olympia/users/templates/users/includes/navigation.html:3
+#: src/olympia/amo/context_processors.py:53 src/olympia/users/templates/users/edit.html:5 src/olympia/users/templates/users/includes/navigation.html:3
 msgid "Account Settings"
 msgstr "Benutzer-Einstellungen"
 
-#: src/olympia/amo/context_processors.py:57 src/olympia/discovery/templates/discovery/pane_account.html:11 src/olympia/users/templates/users/profile.html:83
+#: src/olympia/amo/context_processors.py:56 src/olympia/discovery/templates/discovery/pane_account.html:11 src/olympia/users/templates/users/profile.html:83
 #: src/olympia/users/templates/users/includes/navigation.html:4
 msgid "My Collections"
 msgstr "Eigene Sammlungen"
 
-#: src/olympia/amo/context_processors.py:62 src/olympia/discovery/templates/discovery/pane_account.html:10 src/olympia/users/templates/users/includes/navigation.html:7
+#: src/olympia/amo/context_processors.py:61 src/olympia/discovery/templates/discovery/pane_account.html:10 src/olympia/users/templates/users/includes/navigation.html:7
 msgid "My Favorites"
 msgstr "Meine Favoriten"
 
-#: src/olympia/amo/context_processors.py:67 src/olympia/discovery/templates/discovery/pane_account.html:13 src/olympia/templates/impala/user_login.html:14
+#: src/olympia/amo/context_processors.py:66 src/olympia/discovery/templates/discovery/pane_account.html:13 src/olympia/templates/impala/user_login.html:14
 #: src/olympia/templates/mobile/header_auth.html:5
 msgid "Log out"
 msgstr "Abmelden"
 
-#: src/olympia/amo/context_processors.py:72 src/olympia/devhub/templates/devhub/addons/dashboard.html:4
+#: src/olympia/amo/context_processors.py:71 src/olympia/devhub/templates/devhub/addons/dashboard.html:4
 msgid "Manage My Submissions"
 msgstr "Meine Einreichungen verwalten"
 
-#: src/olympia/amo/context_processors.py:75 src/olympia/devhub/templates/devhub/nav.html:27 src/olympia/devhub/templates/devhub/addons/dashboard.html:25
+#: src/olympia/amo/context_processors.py:74 src/olympia/devhub/templates/devhub/nav.html:27 src/olympia/devhub/templates/devhub/addons/dashboard.html:25
 #: src/olympia/devhub/templates/devhub/addons/submit/base.html:4
 msgid "Submit a New Add-on"
 msgstr "Ein neues Add-on hochladen"
 
-#: src/olympia/amo/context_processors.py:77 src/olympia/browse/templates/browse/personas/base.html:50 src/olympia/devhub/templates/devhub/index.html:24
+#: src/olympia/amo/context_processors.py:76 src/olympia/browse/templates/browse/personas/base.html:50 src/olympia/devhub/templates/devhub/index.html:24
 #: src/olympia/devhub/templates/devhub/addons/dashboard.html:29
 msgid "Submit a New Theme"
 msgstr "Ein neues Theme übermitteln"
 
-#: src/olympia/amo/context_processors.py:79 src/olympia/amo/templates/amo/site_nav.html:87 src/olympia/devhub/helpers.py:36 src/olympia/devhub/helpers.py:68 src/olympia/devhub/helpers.py:102
+#: src/olympia/amo/context_processors.py:78 src/olympia/amo/templates/amo/site_nav.html:85 src/olympia/devhub/helpers.py:36 src/olympia/devhub/helpers.py:68 src/olympia/devhub/helpers.py:102
 #: src/olympia/templates/footer.html:6 src/olympia/templates/menu_links.html:14
 msgid "Developer Hub"
 msgstr "Entwickler-Zentrum"
 
-#: src/olympia/amo/context_processors.py:83 src/olympia/devhub/views.py:1792
+#: src/olympia/amo/context_processors.py:81 src/olympia/devhub/views.py:1796
 msgid "Manage API Keys"
 msgstr "API-Schlüssel verwalten"
 
-#: src/olympia/amo/context_processors.py:88 src/olympia/editors/helpers.py:82 src/olympia/editors/helpers.py:102 src/olympia/editors/templates/editors/base.html:10
+#: src/olympia/amo/context_processors.py:86 src/olympia/editors/helpers.py:84 src/olympia/editors/helpers.py:104 src/olympia/editors/templates/editors/base.html:10
 msgid "Editor Tools"
 msgstr "Moderatoren-Werkzeuge"
 
-#: src/olympia/amo/context_processors.py:92
+#: src/olympia/amo/context_processors.py:90
 msgid "Admin Tools"
 msgstr "Admin-Werkzeuge"
 
-#: src/olympia/amo/fields.py:15
+#: src/olympia/amo/fields.py:20
 msgid "Incorrect, please try again."
 msgstr "Fehler, bitte erneut versuchen."
 
-#: src/olympia/amo/fields.py:16
+#: src/olympia/amo/fields.py:21
 msgid "Error verifying input, please try again."
 msgstr "Fehler beim Verifizieren der Eingabe, bitte erneut versuchen."
 
-#: src/olympia/amo/fields.py:32
+#: src/olympia/amo/fields.py:37
 msgid "This must be a valid hex color code, such as #000000."
 msgstr "Das muss ein gültiger hexadezimaler Farbcode sein, wie #000000."
 
-#: src/olympia/amo/fields.py:58
+#: src/olympia/amo/fields.py:63
 msgid "Enter at least one value."
 msgstr "Geben Sie mindestens einen Wert ein."
 
-#: src/olympia/amo/helpers.py:162 src/olympia/amo/templates/amo/site_nav.html:61 src/olympia/bandwagon/templates/bandwagon/add.html:9
+#: src/olympia/amo/helpers.py:162 src/olympia/amo/templates/amo/site_nav.html:59 src/olympia/bandwagon/templates/bandwagon/add.html:9
 #: src/olympia/bandwagon/templates/bandwagon/collection_detail.html:15 src/olympia/bandwagon/templates/bandwagon/delete.html:9 src/olympia/bandwagon/templates/bandwagon/edit.html:15
 #: src/olympia/bandwagon/templates/bandwagon/user_listing.html:18 src/olympia/bandwagon/templates/bandwagon/user_listing.html:21
 #: src/olympia/bandwagon/templates/bandwagon/impala/collection_listing.html:12 src/olympia/bandwagon/templates/bandwagon/impala/collection_listing.html:20
 #: src/olympia/bandwagon/templates/bandwagon/impala/collection_listing.html:24 src/olympia/bandwagon/templates/bandwagon/impala/collection_sidebar.html:3
 #: src/olympia/bandwagon/templates/bandwagon/includes/collection_sidebar.html:2 src/olympia/bandwagon/templates/bandwagon/mobile/collection_listing.html:3
-#: src/olympia/stats/templates/stats/stats.html:77 src/olympia/templates/menu_links.html:12
+#: src/olympia/stats/templates/stats/stats.html:33 src/olympia/templates/menu_links.html:12
 msgid "Collections"
 msgstr "Sammlungen"
 
-#: src/olympia/amo/helpers.py:171 src/olympia/amo/templates/amo/site_nav.html:85 src/olympia/browse/templates/browse/language_tools.html:3
+#: src/olympia/amo/helpers.py:171 src/olympia/amo/templates/amo/site_nav.html:83 src/olympia/browse/templates/browse/language_tools.html:3
 msgid "Dictionaries & Language Packs"
 msgstr "Wörterbücher & Sprachpakete"
 
@@ -1610,8 +1606,8 @@ msgstr "Super-Freigabe angefordert"
 msgid "Comment on {addon} {version}."
 msgstr "Kommentar zu {addon} {version}."
 
-#: src/olympia/amo/log.py:236 src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:19 src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:47
-#: src/olympia/editors/helpers.py:511 src/olympia/editors/templates/editors/themes/history_table.html:11
+#: src/olympia/amo/log.py:236 src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:17 src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:45
+#: src/olympia/editors/helpers.py:584 src/olympia/editors/templates/editors/themes/history_table.html:11
 msgid "Comment"
 msgstr "Kommentar"
 
@@ -1765,7 +1761,7 @@ msgstr "Weitergabe an nächsthöhere Stelle durch Überprüfer"
 
 #: src/olympia/amo/log.py:442
 msgid "Video removed from {addon} because of a problem with the video. "
-msgstr "Video von {addon} entfernt, weil es ein Problem mit dem Video gab."
+msgstr ""
 
 #: src/olympia/amo/log.py:444
 msgid "Video removed"
@@ -1920,8 +1916,6 @@ msgstr "Hoppla"
 #, python-format
 msgid "<h1>Oops!  We had an error.</h1> <p>We'll get to fixing that soon.</p> <p> You can try refreshing the page, or head back to the <a href=\"%(home)s\">Add-ons homepage</a>. </p>"
 msgstr ""
-"<h1>Hoppla! Ein Fehler ist aufgetreten.</h1> <p>Wir beheben ihn schnellstmöglich.</p> <p>Sie können versuchen, die Seite zu aktualisieren oder zur <a href=\"%(home)s\">Startseite von Add-on</a> "
-"gehen.</p>"
 
 #: src/olympia/amo/templates/amo/license_link.html:10
 msgid "Some rights reserved"
@@ -1943,7 +1937,7 @@ msgstr "Vorherige Seite"
 #: src/olympia/amo/templates/amo/mobile/paginator.html:14 src/olympia/amo/templates/amo/mobile/paginator.html:16 src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:51
 #: src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:65 src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:78
 #: src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:91 src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:104
-#: src/olympia/discovery/templates/discovery/pane.html:45 src/olympia/discovery/templates/discovery/addons/detail.html:39 src/olympia/stats/templates/stats/stats.html:167
+#: src/olympia/discovery/templates/discovery/pane.html:45 src/olympia/discovery/templates/discovery/addons/detail.html:39 src/olympia/stats/templates/stats/stats.html:169
 msgid "Next"
 msgstr "Nächste Seite"
 
@@ -1978,7 +1972,7 @@ msgstr ""
 "\"recaptcha_different\">mit anderen Wörtern versuchen</a> oder <a href=\"#\" id=\"recaptcha_audio\">eine andere Art der Aufgabe ausprobieren</a>. </p>"
 
 #: src/olympia/amo/templates/amo/side_nav.html:4 src/olympia/amo/templates/amo/side_nav.html:12 src/olympia/amo/templates/amo/site_nav.html:4 src/olympia/amo/templates/amo/site_nav.html:26
-#: src/olympia/browse/views.py:56 src/olympia/browse/views.py:66 src/olympia/browse/views.py:237 src/olympia/browse/views.py:282 src/olympia/search/forms.py:86
+#: src/olympia/browse/views.py:56 src/olympia/browse/views.py:66 src/olympia/browse/views.py:204 src/olympia/browse/views.py:249 src/olympia/search/forms.py:86
 msgid "Top Rated"
 msgstr "Am höchsten bewertet"
 
@@ -1993,38 +1987,38 @@ msgstr "Erkunden"
 msgid "Extensions"
 msgstr "Erweiterungen"
 
-#: src/olympia/amo/templates/amo/site_nav.html:45
+#: src/olympia/amo/templates/amo/site_nav.html:44
 msgid "Want more customization? Try <b>Complete Themes</b>"
 msgstr "Möchten Sie noch mehr Anpassungen? Probieren Sie <b>Vollständige Themes</b> aus."
 
-#: src/olympia/amo/templates/amo/site_nav.html:56 src/olympia/bandwagon/views.py:96
+#: src/olympia/amo/templates/amo/site_nav.html:54 src/olympia/bandwagon/views.py:96
 msgid "Most Followers"
 msgstr "Meiste Beobachter"
 
-#: src/olympia/amo/templates/amo/site_nav.html:68 src/olympia/bandwagon/templates/bandwagon/impala/collection_sidebar.html:16
+#: src/olympia/amo/templates/amo/site_nav.html:66 src/olympia/bandwagon/templates/bandwagon/impala/collection_sidebar.html:16
 #: src/olympia/bandwagon/templates/bandwagon/includes/collection_sidebar.html:18
 msgid "Collections I've Made"
 msgstr "Von mir erstellte Sammlungen"
 
-#: src/olympia/amo/templates/amo/site_nav.html:70 src/olympia/bandwagon/templates/bandwagon/user_listing.html:4 src/olympia/bandwagon/templates/bandwagon/impala/collection_sidebar.html:13
+#: src/olympia/amo/templates/amo/site_nav.html:68 src/olympia/bandwagon/templates/bandwagon/user_listing.html:4 src/olympia/bandwagon/templates/bandwagon/impala/collection_sidebar.html:13
 #: src/olympia/bandwagon/templates/bandwagon/includes/collection_sidebar.html:15
 msgid "Collections I'm Following"
 msgstr "Sammlungen, denen ich folge"
 
-#: src/olympia/amo/templates/amo/site_nav.html:73 src/olympia/bandwagon/templates/bandwagon/impala/collection_sidebar.html:18
-#: src/olympia/bandwagon/templates/bandwagon/includes/collection_sidebar.html:20 src/olympia/users/models.py:512
+#: src/olympia/amo/templates/amo/site_nav.html:71 src/olympia/bandwagon/templates/bandwagon/impala/collection_sidebar.html:18
+#: src/olympia/bandwagon/templates/bandwagon/includes/collection_sidebar.html:20 src/olympia/users/models.py:521
 msgid "My Favorite Add-ons"
 msgstr "Meine bevorzugten Add-ons"
 
-#: src/olympia/amo/templates/amo/site_nav.html:78
+#: src/olympia/amo/templates/amo/site_nav.html:76
 msgid "More&hellip;"
 msgstr "Mehr&hellip;"
 
-#: src/olympia/amo/templates/amo/site_nav.html:82
+#: src/olympia/amo/templates/amo/site_nav.html:80
 msgid "Add-ons for Mobile"
 msgstr "Add-ons für Firefox Mobile"
 
-#: src/olympia/amo/templates/amo/site_nav.html:86 src/olympia/browse/feeds.py:207 src/olympia/browse/templates/browse/search_tools.html:3 src/olympia/constants/base.py:176
+#: src/olympia/amo/templates/amo/site_nav.html:84 src/olympia/browse/feeds.py:207 src/olympia/browse/templates/browse/search_tools.html:3 src/olympia/constants/base.py:176
 #: src/olympia/templates/menu_links.html:10
 msgid "Search Tools"
 msgstr "Suchwerkzeuge"
@@ -2040,7 +2034,7 @@ msgid "Jump to first page"
 msgstr "Zur ersten Seite springen"
 
 #: src/olympia/amo/templates/amo/impala/paginator.html:22 src/olympia/amo/templates/amo/mobile/impala_paginator.html:12 src/olympia/discovery/templates/discovery/pane.html:44
-#: src/olympia/discovery/templates/discovery/addons/detail.html:38 src/olympia/stats/templates/stats/stats.html:164
+#: src/olympia/discovery/templates/discovery/addons/detail.html:38 src/olympia/stats/templates/stats/stats.html:166
 msgid "Previous"
 msgstr "Vorherige"
 
@@ -2050,7 +2044,7 @@ msgstr "Zur letzten Seite springen"
 
 #. First and second arguments are the result range (e.g., 1-20);
 #. third argument is the number of total results (e.g., 1,000).
-#. third
+#. First and second arguments are the result range (e.g., 1-20);              third
 #. argument is the number of total results (e.g., 1,000).
 #: src/olympia/amo/templates/amo/impala/paginator.html:36 src/olympia/amo/templates/amo/mobile/impala_paginator.html:38
 #, python-format
@@ -2063,31 +2057,50 @@ msgid_plural "Page {n}"
 msgstr[0] "Seite {n}"
 msgstr[1] "Seite {n}"
 
-#: src/olympia/amo/templates/services/install.html:38
-#, python-format
-msgid "If you are not prompted to install %(addon_name)s in a moment, please <a href=\"%(addon_xpi)s\">click here</a>."
-msgstr "Wenn in Kürze keine Aufforderung zur Installation von %(addon_name)s erscheint, <a href=\"%(addon_xpi)s\">klicken Sie bitte hier</a>."
-
-#: src/olympia/amo/tests/test_messages.py:57 src/olympia/amo/tests/test_messages.py:58 src/olympia/reviews/forms.py:25 src/olympia/reviews/forms.py:50 src/olympia/reviews/templates/reviews/add.html:56
+#: src/olympia/amo/tests/test_messages.py:56 src/olympia/amo/tests/test_messages.py:57 src/olympia/reviews/forms.py:25 src/olympia/reviews/forms.py:50 src/olympia/reviews/templates/reviews/add.html:56
 #: src/olympia/reviews/templates/reviews/reply.html:30
 msgid "Title"
 msgstr "Titel"
 
-#: src/olympia/amo/tests/test_messages.py:57 src/olympia/amo/tests/test_messages.py:58
+#: src/olympia/amo/tests/test_messages.py:56 src/olympia/amo/tests/test_messages.py:57
 msgid "Body"
 msgstr "Inhalt"
 
-#: src/olympia/amo/tests/test_messages.py:59
+#: src/olympia/amo/tests/test_messages.py:58
 msgid "Another Title"
 msgstr "Weiterer Titel"
 
-#: src/olympia/amo/tests/test_messages.py:59
+#: src/olympia/amo/tests/test_messages.py:58
 msgid "Another Body"
 msgstr "Weiterer Inhalt"
 
-#: src/olympia/api/views.py:255
-msgid "Not implemented yet."
-msgstr "Noch nicht implementiert."
+#: src/olympia/api/authentication.py:76
+msgid "Signature has expired."
+msgstr ""
+
+#: src/olympia/api/authentication.py:79
+msgid "Error decoding signature."
+msgstr ""
+
+#: src/olympia/api/authentication.py:82
+msgid "Invalid JWT Token."
+msgstr ""
+
+#: src/olympia/api/authentication.py:130
+msgid "Invalid Authorization header. No credentials provided."
+msgstr ""
+
+#: src/olympia/api/authentication.py:133
+msgid "Invalid Authorization header. Credentials string should not contain spaces."
+msgstr ""
+
+#: src/olympia/api/fields.py:29
+msgid "The field must have a length of at least {num} characters."
+msgstr ""
+
+#: src/olympia/api/fields.py:31
+msgid "The language code {lang_code} is invalid."
+msgstr ""
 
 #: src/olympia/applications/views.py:39 src/olympia/applications/templates/applications/appversions.html:3
 msgid "Application Versions"
@@ -2107,7 +2120,7 @@ msgstr ""
 "Bei Mozilla Add-ons eingereichte Add-ons müssen eine Manifest-Datei haben, dabei muss mindestens eine der folgenden Anwendungen unterstützt werden. Nur die im Folgenden aufgeführten Versionen sind "
 "für diese Anwendungen zugelassen."
 
-#: src/olympia/applications/templates/applications/appversions.html:25
+#: src/olympia/applications/templates/applications/appversions.html:25 src/olympia/editors/helpers.py:361
 msgid "GUID"
 msgstr "GUID"
 
@@ -2221,8 +2234,8 @@ msgstr "Favorit"
 msgid "Remove from favorites"
 msgstr "Aus den Favoriten entfernen"
 
-#: src/olympia/bandwagon/views.py:98 src/olympia/bandwagon/views.py:191 src/olympia/browse/views.py:58 src/olympia/browse/views.py:69 src/olympia/browse/views.py:458 src/olympia/devhub/views.py:74
-#: src/olympia/devhub/views.py:82 src/olympia/devhub/templates/devhub/addons/edit/basic.html:20 src/olympia/editors/templates/editors/leaderboard.html:24
+#: src/olympia/bandwagon/views.py:98 src/olympia/bandwagon/views.py:191 src/olympia/browse/views.py:58 src/olympia/browse/views.py:69 src/olympia/browse/views.py:425 src/olympia/devhub/views.py:72
+#: src/olympia/devhub/views.py:80 src/olympia/devhub/templates/devhub/addons/edit/basic.html:20 src/olympia/editors/templates/editors/leaderboard.html:24
 #: src/olympia/editors/templates/editors/themes/queue_list.html:48 src/olympia/search/forms.py:17 src/olympia/search/forms.py:89 src/olympia/users/templates/users/vcard.html:5
 msgid "Name"
 msgstr "Name"
@@ -2231,7 +2244,7 @@ msgstr "Name"
 msgid "Recently Popular"
 msgstr "Neueste beliebte"
 
-#: src/olympia/bandwagon/views.py:189 src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:18
+#: src/olympia/bandwagon/views.py:189 src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:16
 msgid "Added"
 msgstr "Hinzugefügt"
 
@@ -2245,8 +2258,8 @@ msgstr "Sammlung erstellt!"
 
 #: src/olympia/bandwagon/views.py:316
 #, python-format
-msgid "Your new collection is shown below. You can <ahref=\"%(url)s\">edit additional settings</a> if you'dlike."
-msgstr "Ihre neue Sammlung wird im Folgenden angezeigt. Sie können <a href=\"%(url)s\">weitere Einstellungen bearbeiten</a>, wenn Sie möchten."
+msgid "Your new collection is shown below. You can <a href=\"%(url)s\">edit additional settings</a> if you'd like."
+msgstr ""
 
 #: src/olympia/bandwagon/views.py:322
 msgid "Collection updated!"
@@ -2373,8 +2386,8 @@ msgid_plural "%(num)s Add-ons in this Collection"
 msgstr[0] "%(num)s Add-on in dieser Sammlung"
 msgstr[1] "%(num)s Add-ons in dieser Sammlung"
 
-#: src/olympia/bandwagon/templates/bandwagon/collection_detail.html:125 src/olympia/compat/templates/compat/index.html:25 src/olympia/compat/templates/compat/reporter_detail.html:29
-#: src/olympia/files/templates/files/viewer.html:29 src/olympia/templates/amo_footer.html:17 src/olympia/templates/includes/lang_switcher.html:10
+#: src/olympia/bandwagon/templates/bandwagon/collection_detail.html:125 src/olympia/compat/templates/compat/reporter_detail.html:29 src/olympia/files/templates/files/viewer.html:29
+#: src/olympia/templates/amo_footer.html:17 src/olympia/templates/includes/lang_switcher.html:10
 msgid "Go"
 msgstr "Los"
 
@@ -2411,8 +2424,6 @@ msgid ""
 "Add-ons that you mark as favorites using the <b>Add to Favorites</b> feature appear below. This collection is currently <b>private</b>, which means only you can see it.  If you would like everyone "
 "to be able to see your favorites, click the button below to make it public."
 msgstr ""
-"Add-ons, die Sie mit <b>Zu Favoriten hinzufügen</b> als Ihre Favoriten markieren, werden hier unten angezeigt. Diese Sammlung ist momentan <b>privat</b>, das bedeutet, dass nur Sie sie sehen "
-"können. Wenn Sie wollen, dass jeder Ihre Favoriten sehen kann, klicken Sie auf die unten stehende Schaltfläche, um die Sammlung öffentlich zu machen."
 
 #: src/olympia/bandwagon/templates/bandwagon/collection_detail.html:196
 msgid "My favorite add-ons"
@@ -2432,9 +2443,9 @@ msgid_plural "<span>%(followers)s</span> followers"
 msgstr[0] "<span>%(followers)s</span> Beobachter"
 msgstr[1] "<span>%(followers)s</span> Beobachter"
 
-#. People "follow" collections to get notified of updates.
-#. Like
+#. People "follow" collections to get notified of updates.                    Like
 #. Twitter followers.
+#. People "follow" collections to get notified of updates.
 #. Like Twitter followers.
 #: src/olympia/bandwagon/templates/bandwagon/collection_listing_items.html:10 src/olympia/bandwagon/templates/bandwagon/impala/collection_listing_items.html:18
 #, python-format
@@ -2443,8 +2454,7 @@ msgid_plural "%(num)s weekly followers"
 msgstr[0] "%(num)s wöchentliche Beobachter"
 msgstr[1] "%(num)s wöchentliche Beobachter"
 
-#. People "follow" collections to get notified of updates.
-#. Like
+#. People "follow" collections to get notified of updates.                    Like
 #. Twitter followers.
 #: src/olympia/bandwagon/templates/bandwagon/collection_listing_items.html:18
 #, python-format
@@ -2453,9 +2463,9 @@ msgid_plural "%(num)s monthly followers"
 msgstr[0] "%(num)s monatliche Beobachter"
 msgstr[1] "%(num)s monatliche Beobachter"
 
-#. People "follow" collections to get notified of updates.
-#. Like
+#. People "follow" collections to get notified of updates.                    Like
 #. Twitter followers.
+#. People "follow" collections to get notified of updates.
 #. Like Twitter followers.
 #: src/olympia/bandwagon/templates/bandwagon/collection_listing_items.html:26 src/olympia/bandwagon/templates/bandwagon/impala/collection_listing_items.html:26
 #, python-format
@@ -2547,7 +2557,7 @@ msgid "Remove this user as a contributor"
 msgstr "Diesen Benutzer als Mitwirkende(n) entfernen"
 
 #: src/olympia/bandwagon/templates/bandwagon/edit_contributors.html:18 src/olympia/bandwagon/templates/bandwagon/edit_contributors.html:43
-#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:20 src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:48
+#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:18 src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:46
 #: src/olympia/devhub/templates/devhub/addons/ajax_compat_update.html:19
 msgid "Remove"
 msgstr "Entfernen"
@@ -2561,8 +2571,6 @@ msgid ""
 "You can add multiple contributors to this collection.  A contributor can add and remove add-ons from this collection, but cannot change its name or description.  To add a contributor, enter their "
 "email in the box below. Contributors must have a Mozilla Add-ons account."
 msgstr ""
-"Sie können mehrere Mitwirkende zu dieser Sammlung hinzufügen. Ein Mitwirkender kann Add-ons zu dieser Sammlung hinzufügen und daraus entfernen, aber weder Name noch Beschreibung ändern. Um einen "
-"Mitwirkenden hinzuzufügen, geben Sie im untenstehenden Feld seine E-Mail-Adresse ein. Mitwirkende müssen ein Benutzerkonto auf Mozilla Add-ons besitzen."
 
 #: src/olympia/bandwagon/templates/bandwagon/edit_contributors.html:40
 msgid "User"
@@ -2598,7 +2606,7 @@ msgid "<b>Warning:</b> By changing the owner of this collection, you will no lon
 msgstr "<b>Achtung:</b> Wenn Sie den Besitzer dieser Sammlung ändern, können Sie sie nicht mehr bearbeiten. Sie können dann nur noch Add-ons hinzufügen und entfernen."
 
 #: src/olympia/bandwagon/templates/bandwagon/edit_contributors.html:83 src/olympia/devhub/templates/devhub/addons/forms_shared/media.html:157
-#: src/olympia/devhub/templates/devhub/addons/submit/describe.html:69 src/olympia/devhub/templates/devhub/addons/submit/license.html:60 src/olympia/devhub/templates/devhub/addons/submit/upload.html:78
+#: src/olympia/devhub/templates/devhub/addons/submit/describe.html:69 src/olympia/devhub/templates/devhub/addons/submit/license.html:60 src/olympia/devhub/templates/devhub/addons/submit/upload.html:70
 #: src/olympia/devhub/templates/devhub/payments/tier.html:17 src/olympia/editors/templates/editors/themes/themes.html:111 src/olympia/editors/templates/editors/themes/themes.html:128
 #: src/olympia/editors/templates/editors/themes/themes.html:134 src/olympia/editors/templates/editors/themes/themes.html:141 src/olympia/users/templates/users/fxa_migration_prompt_content.html:10
 #: src/olympia/users/templates/users/login_form.html:42 src/olympia/users/templates/users/mobile/login.html:57
@@ -2672,44 +2680,42 @@ msgstr "Zurücksetzen"
 
 #: src/olympia/bandwagon/templates/bandwagon/includes/addedit.html:53
 msgid "PNG and JPG supported.  Image will be resized to 32x32."
-msgstr "PNG und JPG werden unterstützt. Grafik wird auf 32×32 angepasst."
+msgstr ""
 
 #: src/olympia/bandwagon/templates/bandwagon/includes/addedit_errors.html:3
 msgid "There are errors in this form.  Please correct them below."
-msgstr "Dieses Formular enthält Fehler. Bitte korrigieren Sie sie im Folgenden."
+msgstr ""
 
 #: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:2
 msgid "Add-ons in Your Collection"
 msgstr "Add-ons in Ihrer Sammlung"
 
 #: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:4
-msgid ""
-"To include an add-on in this collection, enter its name in the box below and hit enter.  You can also use the <strong>Add to Collection</strong> links throughout the site to include add-ons later."
+msgid "To include an add-on in this collection, enter its name in the box below and hit enter."
 msgstr ""
-"Um ein Add-on in diese Sammlung einzuschließen, geben Sie im folgenden Feld seinen Namen ein und drücken Sie die Eingabetaste. Sie können auch die Links <strong>Zur Sammlung hinzufügen</strong> auf "
-"der Website nutzen, um später Add-ons hinzuzufügen."
 
-#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:17 src/olympia/constants/base.py:400 src/olympia/devhub/templates/devhub/addons/activity.html:62
+#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:15 src/olympia/constants/base.py:400 src/olympia/devhub/templates/devhub/addons/activity.html:62
+#: src/olympia/editors/helpers.py:273 src/olympia/editors/helpers.py:360
 msgid "Add-on"
 msgstr "Add-on"
 
-#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:26
+#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:24
 msgid "Enter the name of the add-on to include"
 msgstr "Geben Sie den Namen des einzufügenden Add-ons ein"
 
-#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:28
+#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:26
 msgid "Add to Collection"
 msgstr "Zur Sammlung hinzufügen"
 
-#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:45 src/olympia/editors/helpers.py:936 src/olympia/editors/helpers.py:956
+#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:43 src/olympia/editors/helpers.py:1016 src/olympia/editors/helpers.py:1036
 msgid "Pending"
 msgstr "Ausstehend"
 
-#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:47
+#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:45
 msgid "Add a comment"
 msgstr "Kommentar hinzufügen"
 
-#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:48
+#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:46
 msgid "Remove this add-on from the collection"
 msgstr "Dieses Add-on aus der Sammlung entfernen"
 
@@ -2760,8 +2766,6 @@ msgid ""
 "When Mozilla becomes aware of add-ons, plugins, or other third-party software that seriously compromises %(app)s security, stability, or performance and meets <a href=\"%(criteria)s\">certain "
 "criteria</a>, the software may be blocked from general use.  For more information, please read <a href=\"%(support)s\">this support article</a>."
 msgstr ""
-"Wenn Mozilla von Add-ons, Plugins oder anderer Drittsoftware erfährt, die wesentlich die Sicherheit, Stabilität und Leistung von %(app)s beeinträchtigt und <a href=\"%(criteria)s\">gewisse "
-"Kriterien</a> erfüllt, kann die Software von der Verwendung ausgeschlossen werden. Weitere Informationen finden Sie in <a href=\"%(support)s\">diesem Hilfeartikel</a>."
 
 #: src/olympia/blocklist/templates/blocklist/blocked_detail.html:44
 #, python-format
@@ -2818,12 +2822,12 @@ msgstr "Suchwerkzeuge"
 msgid "Most Users"
 msgstr "Meiste Anwender"
 
-#: src/olympia/browse/views.py:61 src/olympia/browse/views.py:72 src/olympia/browse/views.py:279 src/olympia/browse/templates/browse/personas/mobile/category_landing.html:63
+#: src/olympia/browse/views.py:61 src/olympia/browse/views.py:72 src/olympia/browse/views.py:246 src/olympia/browse/templates/browse/personas/mobile/category_landing.html:63
 #: src/olympia/discovery/templates/discovery/pane.html:67 src/olympia/search/forms.py:92
 msgid "Up & Coming"
 msgstr "Neu & aufstrebend"
 
-#: src/olympia/browse/views.py:460 src/olympia/devhub/views.py:76 src/olympia/devhub/views.py:83 src/olympia/discovery/templates/discovery/addons/detail.html:66
+#: src/olympia/browse/views.py:427 src/olympia/devhub/views.py:74 src/olympia/devhub/views.py:81 src/olympia/discovery/templates/discovery/addons/detail.html:66
 msgid "Created"
 msgstr "Angelegt"
 
@@ -3011,8 +3015,8 @@ msgid_plural "See all %(cnt)s extensions in %(name)s &raquo;"
 msgstr[0] "Sehen Sie sich die %(cnt)s Erweiterung in %(name)s an »"
 msgstr[1] "Sehen Sie sich die %(cnt)s Erweiterungen in %(name)s an »"
 
-#: src/olympia/browse/templates/browse/mobile/extensions.html:13 src/olympia/compat/templates/compat/index.html:82 src/olympia/devhub/templates/devhub/devhub_search.html:24
-#: src/olympia/devhub/templates/devhub/addons/activity.html:47 src/olympia/search/templates/search/no_results.html:4 src/olympia/search/templates/search/mobile/results.html:36
+#: src/olympia/browse/templates/browse/mobile/extensions.html:13 src/olympia/devhub/templates/devhub/devhub_search.html:24 src/olympia/devhub/templates/devhub/addons/activity.html:47
+#: src/olympia/search/templates/search/no_results.html:4 src/olympia/search/templates/search/mobile/results.html:36
 msgid "No results found."
 msgstr "Es wurde nichts gefunden."
 
@@ -3101,7 +3105,7 @@ msgstr "&laquo; Alle Themes"
 msgid "All"
 msgstr "Alle"
 
-#: src/olympia/compat/forms.py:22 src/olympia/search/views.py:525
+#: src/olympia/compat/forms.py:22 src/olympia/editors/templates/editors/base.html:69 src/olympia/search/views.py:518
 msgid "All Add-ons"
 msgstr "Alle Add-ons"
 
@@ -3112,53 +3116,6 @@ msgstr "Binär"
 #: src/olympia/compat/forms.py:24
 msgid "Non-binary"
 msgstr "Nicht-binär"
-
-#. Review points sources other than add-ons and themes.
-#: src/olympia/compat/views.py:87 src/olympia/constants/base.py:388 src/olympia/devhub/forms.py:162 src/olympia/editors/templates/editors/performance.html:75
-msgid "Other"
-msgstr "andere"
-
-#: src/olympia/compat/templates/compat/index.html:4
-msgid "Add-on Compatibility Report for {app} {version}"
-msgstr "Add-on-Kompatibilitätsbericht für {app} {version}"
-
-#: src/olympia/compat/templates/compat/index.html:11
-msgid "{app} {version} Compatibility"
-msgstr "Kompatibilität zu {app} {version}"
-
-#: src/olympia/compat/templates/compat/index.html:17
-#, python-format
-msgid "Top 95%% compatible with previous version"
-msgstr "Wichtigste 95%%, die mit vorheriger Version kompatibel sind"
-
-#: src/olympia/compat/templates/compat/index.html:18
-#, python-format
-msgid "Top 95%% of all add-ons"
-msgstr "Wichtigste 95%% aller Add-ons"
-
-#: src/olympia/compat/templates/compat/index.html:19
-msgid "All active add-ons"
-msgstr "Alle aktiven Add-ons"
-
-#: src/olympia/compat/templates/compat/index.html:23 src/olympia/constants/base.py:401
-msgid "App"
-msgstr "App"
-
-#: src/olympia/compat/templates/compat/index.html:55
-msgid "Details for add-ons compatible with previous version:"
-msgstr "Details für Add-ons, die mit vorherigen Versionen kompatibel waren:"
-
-#: src/olympia/compat/templates/compat/index.html:57
-msgid "Show all versions"
-msgstr "Alle Versionen anzeigen"
-
-#: src/olympia/compat/templates/compat/index.html:59
-msgid "Details for add-ons compatible with all versions:"
-msgstr "Details für Add-ons, die mit allen Versionen kompatibel sind:"
-
-#: src/olympia/compat/templates/compat/index.html:61
-msgid "Show previous version only"
-msgstr "Nur vorherige Version anzeigen"
 
 #: src/olympia/compat/templates/compat/reporter.html:3
 msgid "Add-on Compatibility Reports"
@@ -3213,8 +3170,8 @@ msgstr "Nach Anwendung filtern"
 msgid "Report Type"
 msgstr "Typ melden"
 
-#: src/olympia/compat/templates/compat/reporter_detail.html:47 src/olympia/devhub/forms.py:784 src/olympia/devhub/templates/devhub/addons/ajax_compat_update.html:17 src/olympia/editors/forms.py:108
-#: src/olympia/zadmin/forms.py:45
+#: src/olympia/compat/templates/compat/reporter_detail.html:47 src/olympia/devhub/forms.py:785 src/olympia/devhub/templates/devhub/addons/ajax_compat_update.html:17 src/olympia/editors/forms.py:108
+#: src/olympia/editors/forms.py:248 src/olympia/zadmin/forms.py:45
 msgid "Application"
 msgstr "Anwendung"
 
@@ -3302,7 +3259,8 @@ msgstr "Vorläufig freigegeben"
 msgid "Preliminarily Reviewed and Awaiting Full Review"
 msgstr "Vorläufig freigegeben und wartet auf vollständige Überprüfung"
 
-#: src/olympia/constants/base.py:33 src/olympia/editors/helpers.py:924 src/olympia/editors/templates/editors/themes/history_table.html:34
+#: src/olympia/constants/base.py:33 src/olympia/editors/forms.py:258 src/olympia/editors/helpers.py:73 src/olympia/editors/helpers.py:1004
+#: src/olympia/editors/templates/editors/themes/history_table.html:34
 msgid "Deleted"
 msgstr "Gelöscht"
 
@@ -3402,6 +3360,11 @@ msgstr "Fragen, nachdem der Nutzer den Download dieses Add-ons gestartet hat"
 msgid "Ask before users can download this add-on"
 msgstr "Fragen, bevor Nutzer dieses Add-on herunterladen können"
 
+#. Review points sources other than add-ons and themes.
+#: src/olympia/constants/base.py:388 src/olympia/devhub/forms.py:162 src/olympia/editors/templates/editors/performance.html:75
+msgid "Other"
+msgstr "andere"
+
 #: src/olympia/constants/base.py:389
 msgid "Exception"
 msgstr "Ausnahme"
@@ -3413,6 +3376,10 @@ msgstr "Veröffentlichung"
 #: src/olympia/constants/base.py:391
 msgid "Change"
 msgstr "Änderung"
+
+#: src/olympia/constants/base.py:401
+msgid "App"
+msgstr "App"
 
 #: src/olympia/constants/base.py:402
 msgid "Persona"
@@ -3562,7 +3529,7 @@ msgstr "Markieren"
 msgid "Duplicate"
 msgstr "Doppelt"
 
-#: src/olympia/constants/editors.py:17 src/olympia/editors/helpers.py:502 src/olympia/editors/templates/editors/themes/queue.html:71 src/olympia/editors/templates/editors/themes/themes.html:94
+#: src/olympia/constants/editors.py:17 src/olympia/editors/helpers.py:575 src/olympia/editors/templates/editors/themes/queue.html:71 src/olympia/editors/templates/editors/themes/themes.html:94
 msgid "Reject"
 msgstr "Ablehnen"
 
@@ -3662,7 +3629,7 @@ msgstr "Solaris"
 msgid "Android"
 msgstr "Android"
 
-#: src/olympia/core/apps.py:19
+#: src/olympia/core/apps.py:21
 msgid "Core"
 msgstr "Kern"
 
@@ -3796,8 +3763,8 @@ msgid "Submit my add-on for manual review."
 msgstr "Mein Add-on zur manuellen Überprüfung einreichen."
 
 #: src/olympia/devhub/forms.py:537
-msgid "Do not list my add-on on this site (beta)"
-msgstr "Mein Add-on nicht auf dieser Website auflisten (Beta)"
+msgid "Do not list my add-on on this site"
+msgstr ""
 
 #: src/olympia/devhub/forms.py:538
 msgid "Check this option if you intend to distribute your add-on on your own and only need it to be signed by Mozilla."
@@ -3829,46 +3796,46 @@ msgstr "Eine Datei mit einer Version, die auf a|alpha|b|beta|pre|rc und einer op
 
 #: src/olympia/devhub/forms.py:592
 #, python-format
-msgid "Version %s already exists"
-msgstr "Version %s existiert bereits."
+msgid "Version %s already exists, or was uploaded before."
+msgstr ""
 
-#: src/olympia/devhub/forms.py:604
+#: src/olympia/devhub/forms.py:605
 msgid "Select a valid choice. That choice is not one of the available choices."
 msgstr "Treffen Sie eine gültige Wahl. Diese Wahl gehört nicht zu den verfügbaren Möglichkeiten."
 
-#: src/olympia/devhub/forms.py:610
+#: src/olympia/devhub/forms.py:611
 msgid "A file with a version ending with a|alpha|b|beta and an optional number is detected as beta."
 msgstr "Eine Datei mit einer Version, die auf a|alpha|b|beta und einer optionalen Zahl endet, wird als Beta erkannt."
 
-#: src/olympia/devhub/forms.py:633
+#: src/olympia/devhub/forms.py:634
 msgid "You cannot upload any more files for this version."
 msgstr "Sie können für diese Version keine weiteren Dateien hochladen."
 
-#: src/olympia/devhub/forms.py:639
+#: src/olympia/devhub/forms.py:640
 msgid "Version doesn't match"
 msgstr "Version passt nicht"
 
-#: src/olympia/devhub/forms.py:668
+#: src/olympia/devhub/forms.py:669
 msgid "You cannot delete a file once the review process has started.  You must delete the whole version."
-msgstr "Sie können eine Datei nicht löschen, wenn der Überprüfungsprozess begonnen hat. Sie müssen Sie gesamte Version löschen."
+msgstr ""
 
-#: src/olympia/devhub/forms.py:688
+#: src/olympia/devhub/forms.py:689
 msgid "The platform All cannot be combined with specific platforms."
 msgstr "Die Plattform Alle kann nicht mit bestimmten Plattformen kombiniert werden."
 
-#: src/olympia/devhub/forms.py:693
+#: src/olympia/devhub/forms.py:694
 msgid "A platform can only be chosen once."
 msgstr "Eine Plattform kann nur ein einziges Mal gewählt werden."
 
-#: src/olympia/devhub/forms.py:706
+#: src/olympia/devhub/forms.py:707
 msgid "A review type must be selected."
 msgstr "Es muss ein Überprüfungstyp ausgewählt werden."
 
-#: src/olympia/devhub/forms.py:788 src/olympia/editors/forms.py:114 src/olympia/zadmin/forms.py:49 src/olympia/zadmin/forms.py:52
+#: src/olympia/devhub/forms.py:789 src/olympia/editors/forms.py:114 src/olympia/editors/forms.py:254 src/olympia/zadmin/forms.py:49 src/olympia/zadmin/forms.py:52
 msgid "Select an application first"
 msgstr "Wählen Sie zuerst eine Anwendung"
 
-#: src/olympia/devhub/forms.py:840
+#: src/olympia/devhub/forms.py:841
 msgid "There cannot be more than 3 required add-ons."
 msgstr "Es dürfen nicht mehr als 3 Add-ons erforderlich sein."
 
@@ -3902,76 +3869,76 @@ msgstr[1] "{0} Warnungen"
 msgid "Review"
 msgstr "Bewertung"
 
-#: src/olympia/devhub/tasks.py:551
+#: src/olympia/devhub/tasks.py:583
 #, python-format
 msgid "%s responded with %s (%s)."
 msgstr "%s hat mit %s (%s) geantwortet."
 
-#: src/olympia/devhub/tasks.py:555
+#: src/olympia/devhub/tasks.py:587
 #, python-format
 msgid "Connection to \"%s\" timed out."
 msgstr "Zeitüberschreitung bei der Verbindung mit \"%s\"."
 
-#: src/olympia/devhub/tasks.py:557
+#: src/olympia/devhub/tasks.py:589
 #, python-format
 msgid "Could not contact host at \"%s\"."
 msgstr "Host unter \"%s\" konnte nicht erreicht werden."
 
-#: src/olympia/devhub/utils.py:104
+#: src/olympia/devhub/utils.py:105
 #, python-format
 msgid "Validation generated too many errors/warnings so %s messages were truncated. After addressing the visible messages, you'll be able to see the others."
 msgstr "Die Überprüfung hat zu viele Fehler/Warnungen ergeben, daher wurden %s Nachrichten abgetrennt. Wenn Sie die sichtbaren Nachrichten abgearbeitet haben, können Sie die anderen sehen."
 
-#: src/olympia/devhub/views.py:183
+#: src/olympia/devhub/views.py:181
 msgid "All My Add-ons"
 msgstr "Alle meine Add-ons"
 
-#: src/olympia/devhub/views.py:210
+#: src/olympia/devhub/views.py:208
 msgid "All Activity"
 msgstr "Alle Aktivitäten"
 
-#: src/olympia/devhub/views.py:211
+#: src/olympia/devhub/views.py:209
 msgid "Add-on Updates"
 msgstr "Add-on-Updates"
 
-#: src/olympia/devhub/views.py:212
+#: src/olympia/devhub/views.py:210
 msgid "Add-on Status"
 msgstr "Add-on-Status"
 
-#: src/olympia/devhub/views.py:213
+#: src/olympia/devhub/views.py:211
 msgid "User Collections"
 msgstr "Benutzer-Sammlungen"
 
-#: src/olympia/devhub/views.py:214 src/olympia/devhub/templates/devhub/docs/policies-maintenance.html:68 src/olympia/pages/templates/pages/dev_faq.html:38
+#: src/olympia/devhub/views.py:212 src/olympia/devhub/templates/devhub/docs/policies-maintenance.html:68 src/olympia/pages/templates/pages/dev_faq.html:38
 #: src/olympia/pages/templates/pages/dev_faq.html:484
 msgid "User Reviews"
 msgstr "Benutzer-Bewertungen"
 
-#: src/olympia/devhub/views.py:327 src/olympia/devhub/views.py:331 src/olympia/devhub/views.py:484 src/olympia/devhub/views.py:513 src/olympia/devhub/views.py:564 src/olympia/devhub/views.py:1150
+#: src/olympia/devhub/views.py:325 src/olympia/devhub/views.py:329 src/olympia/devhub/views.py:484 src/olympia/devhub/views.py:513 src/olympia/devhub/views.py:564 src/olympia/devhub/views.py:1156
 msgid "Changes successfully saved."
 msgstr "Änderungen erfolgreich gespeichert."
 
-#: src/olympia/devhub/views.py:334 src/olympia/devhub/views.py:1631
+#: src/olympia/devhub/views.py:332 src/olympia/devhub/views.py:1637
 msgid "Please check the form for errors."
 msgstr "Bitte prüfen Sie das Formular auf Fehler."
 
-#: src/olympia/devhub/views.py:346
+#: src/olympia/devhub/views.py:344
 msgid "Add-on cannot be deleted. Disable this add-on instead."
 msgstr "Add-on kann nicht gelöscht werden. Deaktivieren Sie dieses Add-on stattdessen."
 
-#: src/olympia/devhub/views.py:356
+#: src/olympia/devhub/views.py:354
 msgid "Theme deleted."
 msgstr "Theme gelöscht."
 
-#: src/olympia/devhub/views.py:356
+#: src/olympia/devhub/views.py:354
 msgid "Add-on deleted."
 msgstr "Add-on gelöscht"
 
-#: src/olympia/devhub/views.py:362
+#: src/olympia/devhub/views.py:360
 msgid "URL name was incorrect. Theme was not deleted."
 msgstr "Adressname war falsch. Theme wurde nicht gelöscht."
 
-#: src/olympia/devhub/views.py:367
+#: src/olympia/devhub/views.py:365
 msgid "URL name was incorrect. Add-on was not deleted."
 msgstr "Adressname war falsch. Add-on wurde nicht gelöscht."
 
@@ -3999,7 +3966,7 @@ msgstr "Add-on überprüfen"
 msgid "Check Add-on Compatibility"
 msgstr "Add-on-Kompatibilität prüfen"
 
-#: src/olympia/devhub/views.py:808 src/olympia/signing/views.py:90
+#: src/olympia/devhub/views.py:808 src/olympia/signing/views.py:95
 msgid "You cannot submit this type of add-on"
 msgstr "Sie können kein Add-on dieses Typs einreichen"
 
@@ -4029,33 +3996,33 @@ msgstr "Grafik muss genau {0} Pixel breit und {1} Pixel hoch sein."
 msgid "There was an error uploading your preview."
 msgstr "Beim Hochladen Ihrer Vorschau ist ein Fehler aufgetreten."
 
-#: src/olympia/devhub/views.py:1189
+#: src/olympia/devhub/views.py:1195
 #, python-format
 msgid "Version %s disabled."
 msgstr "Version %s deaktiviert."
 
-#: src/olympia/devhub/views.py:1193
+#: src/olympia/devhub/views.py:1199
 #, python-format
 msgid "Version %s deleted."
 msgstr "Version %s gelöscht."
 
-#: src/olympia/devhub/views.py:1203
+#: src/olympia/devhub/views.py:1209
 msgid "This upload has failed validation, and may lack complete validation results. Please take due care when reviewing it."
 msgstr "Dieser Upload hat die Validierung nicht bestanden und hat möglicherweise keine vollständigen Validierungsergebnisse. Bitte achten Sie darauf, wenn Sie ihn überprüfen."
 
-#: src/olympia/devhub/views.py:1677
+#: src/olympia/devhub/views.py:1683
 msgid "Preliminary Review Requested."
 msgstr "Vorläufige Freigabe angefordert."
 
-#: src/olympia/devhub/views.py:1678
+#: src/olympia/devhub/views.py:1684
 msgid "Full Review Requested."
 msgstr "Vollständige Überprüfung angefordert."
 
-#: src/olympia/devhub/views.py:1779
+#: src/olympia/devhub/views.py:1783
 msgid "Your old credentials were revoked and are no longer valid. Be sure to update all API clients with the new credentials."
 msgstr "Ihre alten Daten wurden widerrufen und sind nicht mehr gültig. Aktualisieren Sie unbedingt alle API-Clients mit den neuen Daten."
 
-#: src/olympia/devhub/views.py:1797
+#: src/olympia/devhub/views.py:1801
 msgid "New API key created"
 msgstr "Neuer API-Schlüssel erstellt"
 
@@ -4087,7 +4054,7 @@ msgstr "Zurück zu Add-ons"
 msgid "{0} :: Search"
 msgstr "{0} :: Suche"
 
-#: src/olympia/devhub/templates/devhub/devhub_search.html:6 src/olympia/devhub/templates/devhub/search.html:8 src/olympia/editors/forms.py:435 src/olympia/editors/forms.py:437
+#: src/olympia/devhub/templates/devhub/devhub_search.html:6 src/olympia/devhub/templates/devhub/search.html:8 src/olympia/editors/forms.py:534 src/olympia/editors/forms.py:536
 #: src/olympia/editors/templates/editors/queue.html:27 src/olympia/editors/templates/editors/themes/queue_list.html:14 src/olympia/search/templates/search/collections.html:17
 #: src/olympia/search/templates/search/personas.html:18 src/olympia/search/templates/search/results.html:18 src/olympia/search/templates/search/mobile/results.html:8
 #: src/olympia/templates/search.html:14 src/olympia/templates/impala/search.html:18
@@ -4150,12 +4117,12 @@ msgstr "Gehen Sie rüber zum <a href=\"https://developer.mozilla.org/Add-ons\">M
 msgid "Start Making Add-ons"
 msgstr "Fangen Sie an, Add-ons zu entwickeln"
 
-#: src/olympia/devhub/templates/devhub/index.html:86 src/olympia/devhub/templates/devhub/addons/listing/items.html:25 src/olympia/devhub/templates/devhub/includes/addon_details.html:15
+#: src/olympia/devhub/templates/devhub/index.html:86 src/olympia/devhub/templates/devhub/addons/listing/items.html:25 src/olympia/devhub/templates/devhub/includes/addon_details.html:20
 #: src/olympia/devhub/templates/devhub/personas/edit.html:43
 msgid "Status:"
 msgstr "Status:"
 
-#: src/olympia/devhub/templates/devhub/index.html:90 src/olympia/devhub/templates/devhub/includes/addon_details.html:100
+#: src/olympia/devhub/templates/devhub/index.html:90 src/olympia/devhub/templates/devhub/includes/addon_details.html:87
 msgid "Visibility:"
 msgstr "Sichtbarkeit:"
 
@@ -4163,11 +4130,11 @@ msgstr "Sichtbarkeit:"
 msgid "Latest Version:"
 msgstr "Neueste Version:"
 
-#: src/olympia/devhub/templates/devhub/index.html:109 src/olympia/devhub/templates/devhub/includes/addon_details.html:145 src/olympia/devhub/templates/devhub/personas/edit.html:49
+#: src/olympia/devhub/templates/devhub/index.html:109 src/olympia/devhub/templates/devhub/includes/addon_details.html:131 src/olympia/devhub/templates/devhub/personas/edit.html:49
 msgid "Queue Position:"
 msgstr "Position in der Warteschlange:"
 
-#: src/olympia/devhub/templates/devhub/index.html:110 src/olympia/devhub/templates/devhub/includes/addon_details.html:146 src/olympia/devhub/templates/devhub/personas/edit.html:50
+#: src/olympia/devhub/templates/devhub/index.html:110 src/olympia/devhub/templates/devhub/includes/addon_details.html:132 src/olympia/devhub/templates/devhub/personas/edit.html:50
 #, python-format
 msgid "%(position)s of %(total)s"
 msgstr "%(position)s von %(total)s"
@@ -4269,16 +4236,6 @@ msgstr "Nach dem Upload wird Ihre Datei einer Reihe automatischer Validierungste
 msgid "Do you want your add-on to be distributed on this site?"
 msgstr "Möchten Sie, dass Ihr Add-on über diese Website verteilt wird?"
 
-#: src/olympia/devhub/templates/devhub/validate_addon.html:49 src/olympia/devhub/templates/devhub/addons/submit/upload.html:30 src/olympia/devhub/templates/devhub/versions/add_file_modal.html:14
-#: src/olympia/devhub/templates/devhub/versions/add_file_modal.html:53 src/olympia/devhub/templates/devhub/versions/list.html:298
-msgid "Warning:"
-msgstr "Warnung:"
-
-#: src/olympia/devhub/templates/devhub/validate_addon.html:50 src/olympia/devhub/templates/devhub/addons/submit/upload.html:31
-#, python-format
-msgid "Submission of unlisted add-ons for signing is currently in an open beta. Please <a href=\"%(url)s\" target=\"_blank\">report any bugs</a> that you encounter."
-msgstr "Die Einreichung ungelisteter Add-ons zur Signierung befindet sich aktuell in der offenen Beta-Phase. Bitte <a href=\"%(url)s\" target=\"_blank\">melden Sie Fehler</a>, auf die Sie stoßen."
-
 #. first parameter is a filename like lorem-ipsum-1.0.2.xpi
 #: src/olympia/devhub/templates/devhub/validation.html:5
 msgid "Validation Results for {0}"
@@ -4357,7 +4314,7 @@ msgstr "Kompatibilität"
 msgid "Update Compatibility"
 msgstr "Kompatibilität aktualisieren"
 
-#: src/olympia/devhub/templates/devhub/addons/ajax_compat_update.html:4
+#: src/olympia/devhub/templates/devhub/addons/ajax_compat_update.html:4 src/olympia/devhub/templates/devhub/versions/edit.html:45
 msgid "Adjusting application information here will allow users to install your add-on even if the install manifest in the package indicates that the add-on is incompatible."
 msgstr "Eine Anpassung der Anwendungsinformationen hier ermöglicht es Anwendern, Ihr Add-on zu installieren, auch wenn es laut Installationsmanifest im Paket inkompatibel ist."
 
@@ -4369,9 +4326,9 @@ msgstr "Unterstützte Versionen"
 msgid "Add Another Application&hellip;"
 msgstr "Eine weitere Anwendung hinzufügen &hellip;"
 
-#: src/olympia/devhub/templates/devhub/addons/ajax_compat_update.html:38 src/olympia/devhub/templates/devhub/addons/owner.html:86 src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:46
-#: src/olympia/devhub/templates/devhub/versions/list.html:351 src/olympia/devhub/templates/devhub/versions/list.html:353 src/olympia/templates/impala/base.html:132
-#: src/olympia/templates/impala/base.html:143 src/olympia/templates/impala/base.html:161 src/olympia/templates/impala/base.html:171
+#: src/olympia/devhub/templates/devhub/addons/ajax_compat_update.html:38 src/olympia/devhub/templates/devhub/addons/owner.html:86 src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:45
+#: src/olympia/devhub/templates/devhub/versions/list.html:349 src/olympia/devhub/templates/devhub/versions/list.html:351 src/olympia/templates/impala/base.html:129
+#: src/olympia/templates/impala/base.html:140 src/olympia/templates/impala/base.html:158 src/olympia/templates/impala/base.html:168
 msgid "Close"
 msgstr "Schließen"
 
@@ -4405,7 +4362,7 @@ msgstr "Keine"
 msgid "Manage Authors & License"
 msgstr "Autoren und Lizenz verwalten"
 
-#: src/olympia/devhub/templates/devhub/addons/owner.html:29 src/olympia/editors/templates/editors/review.html:270
+#: src/olympia/devhub/templates/devhub/addons/owner.html:29 src/olympia/editors/helpers.py:362 src/olympia/editors/templates/editors/review.html:270
 msgid "Authors"
 msgstr "Autoren"
 
@@ -4477,19 +4434,13 @@ msgstr "Zusammenfassung"
 
 #: src/olympia/devhub/templates/devhub/addons/edit/basic.html:52
 msgid ""
-"A short explanation of your add-on's basic\n"
-"                          functionality that is displayed in search and browse\n"
-"                          listings, as well as at the top of your add-on's\n"
-"                          details page. It is only relevant for listed add-ons."
+"A short explanation of your add-on's basic functionality that is displayed in search and browse listings, as well as at the top of your add-on's details page. It is only relevant for listed add-ons."
 msgstr ""
 "Eine kurze Erklärung der wichtigsten Funktionen Ihres Add-ons, die in Suchergebnissen und Listen angezeigt wird, sowie oben auf der Detailseite Ihres Add-ons. Dies ist nur für gelistete Add-ons "
 "wichtig."
 
 #: src/olympia/devhub/templates/devhub/addons/edit/basic.html:73
-msgid ""
-"Categories are the primary way users browse through add-ons.\n"
-"                        Choose any that fit your add-on's functionality for the most\n"
-"                        exposure. It is only relevant for listed add-ons."
+msgid "Categories are the primary way users browse through add-ons. Choose any that fit your add-on's functionality for the most exposure. It is only relevant for listed add-ons."
 msgstr ""
 "Kategorien sind die wichtigste Möglichkeit, mit der Nutzer Add-ons durchsuchen. Wählen Sie die aus, die am besten zu den Funktionen Ihres Add-ons passen, um möglichst viele Interessenten zu "
 "erreichen. Dies ist nur für gelistete Add-ons wichtig."
@@ -4503,11 +4454,7 @@ msgstr ""
 "gibt, Ihre Kategorien zu verändern."
 
 #: src/olympia/devhub/templates/devhub/addons/edit/basic.html:119
-msgid ""
-"Tags help users find your add-on and should be short\n"
-"                        descriptors such as tabs, toolbar, or twitter.  You\n"
-"                        may have a maximum of {0} tags. It is only relevant\n"
-"                        for listed add-ons."
+msgid "Tags help users find your add-on and should be short descriptors such as tabs, toolbar, or twitter. You may have a maximum of {0} tags. It is only relevant for listed add-ons."
 msgstr ""
 "Schlagwörter helfen Nutzern, Ihre Add-ons zu finden. Sie sollten aus kurzen Beschreibungen wie „Tabs“, „Symbolleiste“ oder „Twitter“ bestehen. Sie können maximal {0} Schlagwörter angeben. Dies ist "
 "nur für gelistete Add-ons wichtig."
@@ -4537,11 +4484,7 @@ msgid "Add-on Details for {0}"
 msgstr "Add-on-Details für {0}"
 
 #: src/olympia/devhub/templates/devhub/addons/edit/details.html:22
-msgid ""
-"A longer explanation of features,\n"
-"                          functionality, and other relevant information. This\n"
-"                          field is only displayed on the add-on's details\n"
-"                          page. It is only relevant for listed add-ons."
+msgid "A longer explanation of features, functionality, and other relevant information. This field is only displayed on the add-on's details page. It is only relevant for listed add-ons."
 msgstr "Eine längere Erklärung der Funktionen und anderer wichtiger Informationen. Dieses Feld wird nur auf der Detailseite des Add-ons angezeigt. Dies ist nur für gelistete Add-ons wichtig."
 
 #: src/olympia/devhub/templates/devhub/addons/edit/details.html:44 src/olympia/translations/templates/translations/trans-menu.html:13
@@ -4549,10 +4492,7 @@ msgid "Default Locale"
 msgstr "Standard-Sprache"
 
 #: src/olympia/devhub/templates/devhub/addons/edit/details.html:45
-msgid ""
-"Information about your add-on is displayed in this locale\n"
-"                        unless you override it with a locale-specific translation.\n"
-"                        It is only relevant for listed add-ons."
+msgid "Information about your add-on is displayed in this locale unless you override it with a locale-specific translation. It is only relevant for listed add-ons."
 msgstr "Informationen über Ihr Add-on wird in dieser Sprache angezeigt, es sei denn, Sie geben eine Übersetzung für eine bestimmte Sprache an. Dies ist nur für gelistete Add-ons wichtig."
 
 #: src/olympia/devhub/templates/devhub/addons/edit/details.html:61 src/olympia/users/forms.py:311 src/olympia/users/templates/users/edit.html:122 src/olympia/users/templates/users/register.html:57
@@ -4562,10 +4502,8 @@ msgstr "Homepage"
 
 #: src/olympia/devhub/templates/devhub/addons/edit/details.html:63
 msgid ""
-"If your add-on has another homepage, enter its\n"
-"                          address here. If your website is localized into other\n"
-"                          languages multiple translations of this field can be\n"
-"                          added. It is only relevant for listed add-ons."
+"If your add-on has another homepage, enter its address here. If your website is localized into other languages multiple translations of this field can be added. It is only relevant for listed add-"
+"ons."
 msgstr ""
 "Wenn Ihr Add-on eine weitere Homepage besitzt, können Sie hie die Adresse eingeben. Wenn Ihre Website in mehrere Sprachen übersetzt wurde, können mehrere Übersetzungen dieses Feldes angegeben "
 "werden. Dies ist nur für gelistete Add-ons wichtig."
@@ -4585,21 +4523,16 @@ msgstr "Support-Information für {0}"
 
 #: src/olympia/devhub/templates/devhub/addons/edit/support.html:22
 msgid ""
-"If you wish to display an e-mail address for support\n"
-"                          inquiries, enter it here. If you have different\n"
-"                          addresses for each language multiple translations of\n"
-"                          this field can be added. It is only relevant for\n"
-"                          listed add-ons."
+"If you wish to display an e-mail address for support inquiries, enter it here. If you have different addresses for each language multiple translations of this field can be added. It is only "
+"relevant for listed add-ons."
 msgstr ""
 "Wenn Sie eine E-Mail-Adresse für Hilfsanfragen angeben wollen, können Sie dies hier tun. Wenn Sie unterschiedliche Adressen für jede Sprache haben, können Sie mehrere Übersetzungen dieses Feldes "
 "hinzufügen. Dies ist nur für gelistete Add-ons wichtig."
 
 #: src/olympia/devhub/templates/devhub/addons/edit/support.html:45
 msgid ""
-"If your add-on has a support website or forum, enter\n"
-"                          its address here. If your website is localized into\n"
-"                          other languages, multiple translations of this field can\n"
-"                          be added. It is only relevant for listed add-ons."
+"If your add-on has a support website or forum, enter its address here. If your website is localized into other languages, multiple translations of this field can be added. It is only relevant for "
+"listed add-ons."
 msgstr ""
 "Wenn Ihre App eine Hilfe-Website oder ein -Forum hat, geben Sie hier die Adresse ein. Wenn Ihre Website in andere Sprachen übersetzt wurde, können in diesem Feld mehrere Übersetzungen hinzugefügt "
 "werden. Dies ist nur für gelistete Add-ons wichtig."
@@ -4615,11 +4548,8 @@ msgstr "Technische Details für {0}"
 
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:23
 msgid ""
-"Any information end users may want to know that isn't\n"
-"                          necessarily applicable to the add-on summary or description.\n"
-"                          Common uses include listing known major bugs, information on\n"
-"                          how to report bugs, anticipated release date of a new version,\n"
-"                          etc. It is only relevant for listed add-ons."
+"Any information end users may want to know that isn't necessarily applicable to the add-on summary or description. Common uses include listing known major bugs, information on how to report bugs, "
+"anticipated release date of a new version, etc. It is only relevant for listed add-ons."
 msgstr ""
 "Informationen, die für Nutzer vielleicht wichtig sind, aber nicht unbedingt in die Zusammenfassung oder Beschreibung des Add-ons gehören. Typische Verwendungen sind bekannte Fehler, Informationen "
 "zur Meldung von Fehlern, das erwartete Erscheinungsdatum einer neuen Version, usw. Dies ist nur für gelistete Add-ons wichtig."
@@ -4633,9 +4563,7 @@ msgid "Add-on Flags"
 msgstr "Add-on-Markierungen"
 
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:69
-msgid ""
-"These flags are used to classify add-ons. It is only\n"
-"                        relevant for listed add-ons."
+msgid "These flags are used to classify add-ons. It is only relevant for listed add-ons."
 msgstr "Mit diesen Markierungen können Add-ons klassifiziert werden. Dies ist nur für gelistete Add-ons wichtig."
 
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:74
@@ -4651,9 +4579,7 @@ msgid "View Source?"
 msgstr "Quelltext ansehen?"
 
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:90
-msgid ""
-"Whether the source of your add-on can be displayed in our\n"
-"                        online viewer. It is only relevant for listed add-ons."
+msgid "Whether the source of your add-on can be displayed in our online viewer. It is only relevant for listed add-ons."
 msgstr "Ob der Quelltext Ihres Add-ons in unserem Online-Betrachter angezeigt werden kann. Dies ist nur für gelistete Add-ons wichtig."
 
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:94
@@ -4669,10 +4595,7 @@ msgid "Public Stats?"
 msgstr "Öffentliche Statistiken?"
 
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:102
-msgid ""
-"Whether the download and usage stats of your add-on can\n"
-"                        be displayed in our online viewer.\n"
-"                        It is only relevant for listed add-ons."
+msgid "Whether the download and usage stats of your add-on can be displayed in our online viewer. It is only relevant for listed add-ons."
 msgstr "Ob die Download- und Nutzungsstatistiken Ihres Add-ons in unserem Online-Betrachter angezeigt werden können. Dies ist nur für gelistete Add-ons wichtig."
 
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:107
@@ -4688,10 +4611,7 @@ msgid "Upgrade SDK?"
 msgstr "SDK aktualisieren?"
 
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:116
-msgid ""
-"If selected, we will try to automatically upgrade your\n"
-"                        add-on when a new version of the SDK is released.\n"
-"                        It is only relevant for listed add-ons."
+msgid "If selected, we will try to automatically upgrade your add-on when a new version of the SDK is released. It is only relevant for listed add-ons."
 msgstr "Wenn dies ausgewählt ist, werden wir automatisch versuchen, Ihr Add-on zu aktualisieren, wenn eine neue Version des SDK erscheint. Dies ist nur für gelistete Add-ons wichtig."
 
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:121
@@ -4744,10 +4664,8 @@ msgstr "Add-on-Symbol"
 
 #: src/olympia/devhub/templates/devhub/addons/forms_shared/media.html:16
 msgid ""
-"Upload an icon for your add-on or choose from one of ours. The\n"
-"                      icon is displayed nearly everywhere your add-on is. Uploaded images\n"
-"                      must be one of the following image types: .png, .jpg.\n"
-"                      It is only relevant for listed add-ons."
+"Upload an icon for your add-on or choose from one of ours. The icon is displayed nearly everywhere your add-on is. Uploaded images must be one of the following image types: .png, .jpg. It is only "
+"relevant for listed add-ons."
 msgstr ""
 "Laden Sie ein Symbol für Ihr Add-on hoch oder wählen Sie eines von unseren. Dieses Symbol wird nahezu überall angezeigt, wo Ihr Add-on ist. Hochgeladene Grafiken müssen zu den folgenden Grafiktypen "
 "gehören: .png, .jpg. Dies ist nur für gelistete Add-ons wichtig."
@@ -4762,9 +4680,7 @@ msgid "32x32px"
 msgstr "32x32px"
 
 #: src/olympia/devhub/templates/devhub/addons/forms_shared/media.html:39
-msgid ""
-"Used in listings of add-ons, like search results\n"
-"                            and featured add-ons."
+msgid "Used in listings of add-ons, like search results and featured add-ons."
 msgstr "Verwendung in Add-on-Listen, wie Suchergebnissen und vorgestellte Add-ons."
 
 #. The size of the icon
@@ -4859,16 +4775,14 @@ msgid "Deleting your add-on will permanently remove it from the site and prevent
 msgstr "Wenn Ihr Add-on gelöscht wird, wird es dauerhaft von dieser Website entfernt und seine GUID kann nicht mehr von anderen eingereicht werden."
 
 #: src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:24
-msgid ""
-"Enter the following text confirm your decision:\n"
-"           {slug}"
+msgid "Enter the following text confirm your decision: {slug}"
 msgstr "Geben Sie den folgenden Text ein, um Ihre Entscheidung zu bestätigen: {slug}"
 
-#: src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:34
+#: src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:33
 msgid "Please tell us why you are deleting your theme:"
 msgstr "Bitte teilen Sie uns mit, warum Sie Ihr Theme löschen:"
 
-#: src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:36
+#: src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:35
 msgid "Please tell us why you are deleting your add-on:"
 msgstr "Bitte teilen Sie uns mit, warum Sie Ihr Add-on löschen:"
 
@@ -4905,8 +4819,8 @@ msgstr "Neue Version"
 msgid "Daily statistics on downloads and users."
 msgstr "Tägliche Statistiken über Downloads und Benutzer."
 
-#: src/olympia/devhub/templates/devhub/addons/listing/item_actions.html:45 src/olympia/stats/templates/stats/stats.html:75 src/olympia/stats/templates/stats/stats.html:79
-#: src/olympia/stats/templates/stats/stats.html:81
+#: src/olympia/devhub/templates/devhub/addons/listing/item_actions.html:45 src/olympia/stats/templates/stats/stats.html:31 src/olympia/stats/templates/stats/stats.html:35
+#: src/olympia/stats/templates/stats/stats.html:37
 msgid "Statistics"
 msgstr "Statistiken"
 
@@ -5025,10 +4939,7 @@ msgid "Your add-on has been submitted to the Full Review queue."
 msgstr "Ihr Add-on wurde in die Warteschlange für die vollständige Freigabe aufgenommen."
 
 #: src/olympia/devhub/templates/devhub/addons/submit/done.html:18
-msgid ""
-"You'll receive an email once it has been reviewed by an editor. In\n"
-"          the meantime, you and your friends can install it directly from its\n"
-"          details page:"
+msgid "You'll receive an email once it has been reviewed by an editor. In the meantime, you and your friends can install it directly from its details page:"
 msgstr "Sie erhalten eine Benachrichtigung per E-Mail, sobald es von einem Redakteur überprüft wurde. Bis dahin können Sie und Ihre Freunde es direkt von seiner Detailseite installieren:"
 
 #: src/olympia/devhub/templates/devhub/addons/submit/done.html:27 src/olympia/devhub/templates/devhub/addons/submit/done.html:77 src/olympia/devhub/templates/devhub/personas/submit_done.html:16
@@ -5239,11 +5150,11 @@ msgid "Use the fields below to upload your add-on package and select any platfor
 msgstr ""
 "Verwenden Sie die folgenden Felder, um Ihr Add-on-Paket hochzuladen und Plattformbeschränkungen auszuwählen. Nach dem Hochladen wird Ihre Datei mehreren automatischen Validierungstests unterzogen."
 
-#: src/olympia/devhub/templates/devhub/addons/submit/upload.html:59 src/olympia/devhub/templates/devhub/versions/add_file_modal.html:39
+#: src/olympia/devhub/templates/devhub/addons/submit/upload.html:51 src/olympia/devhub/templates/devhub/versions/add_file_modal.html:28
 msgid "Which platforms is this file compatible with?"
 msgstr "Mit welchen Plattformen ist diese Datei kompatibel?"
 
-#: src/olympia/devhub/templates/devhub/addons/submit/upload.html:67 src/olympia/devhub/templates/devhub/versions/add_file_modal.html:65
+#: src/olympia/devhub/templates/devhub/addons/submit/upload.html:59 src/olympia/devhub/templates/devhub/versions/add_file_modal.html:45
 msgid "Administrative overrides"
 msgstr "Überschreibungen durch Administratoren"
 
@@ -5362,11 +5273,9 @@ msgstr "Funktionalität & Entwicklung der Website"
 
 #: src/olympia/devhub/templates/devhub/docs/policies-contact.html:44
 msgid ""
-"If you've found a problem with the site, we'd love to fix it. Please <a href=\"https://github.com/mozilla/olympia/issues\">file a bug report</a> in GitHub, including the location of the problem and "
-"how you encountered it."
+"If you've found a problem with the site, we'd love to fix it. Please <a href=\"https://github.com/mozilla/addons/issues/new\">file a bug report</a> in GitHub, including the location of the problem "
+"and how you encountered it."
 msgstr ""
-"Wenn Sie auf ein Problem mit der Website stoßen, beheben wir das gerne. Bitte <a href=\"https://github.com/mozilla/olympia/issues\">schreiben Sie einen Fehlerbericht</a> auf GitHub. Nennen Sie "
-"dabei den Fundort des Problems und beschreiben Sie, wie Sie darauf gestoßen sind."
 
 #: src/olympia/devhub/templates/devhub/docs/policies-maintenance.html:3 src/olympia/devhub/templates/devhub/docs/policies-maintenance.html:7
 #: src/olympia/devhub/templates/devhub/docs/policies-maintenance.html:8
@@ -6036,7 +5945,7 @@ msgstr "Privater Modus"
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:282
 msgid ""
-"Add-ons that store or otherwise handle browsing data must support <a href=\"https://developer.mozilla.org/En/Supporting_private_browsing_mode\">Private Browsing Mode</a>.  During a Private Browsing "
+"Add-ons that store or otherwise handle browsing data must support <a href=\"https://developer.mozilla.org/En/Supporting_private_browsing_mode\">Private Browsing Mode</a>. During a Private Browsing "
 "session, no browsing data can be written to disk, and all of this data must be cleared when Firefox quits or the Private Browsing session ends."
 msgstr ""
 "Add-ons, die Surf-Daten speichern oder anderweitig verarbeiten, müssen den <a href=\"https://developer.mozilla.org/En/Supporting_private_browsing_mode\">privaten Modus</a> unterstützen. Beim Surfen "
@@ -6256,134 +6165,100 @@ msgstr "Nutzungsbedingungne für das Einreichen Ihrer Arbeit. Entwickler müssen
 msgid "How to get in touch with us regarding these policies or your add-on."
 msgstr "Wie Sie uns mit Fragen zu diesen Regeln oder Ihrem Add-on kontaktieren können."
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:6
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:10
 msgid "You have disabled this add-on"
 msgstr "Sie haben dieses Add-on deaktiviert"
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:20
-msgid ""
-"Your add-on's listing is disabled and is not showing\n"
-"                             anywhere in our gallery or update service."
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:24
+msgid "Your add-on's listing is disabled and is not showing anywhere in our gallery or update service."
 msgstr "Ihr Add-on-Listeneintrag wurde deaktiviert und wird nirgendwo in unserer Galerie oder beim Update-Dienst angezeigt."
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:25
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:27
 msgid "Please complete your add-on."
 msgstr "Bitte vervollständigen Sie Ihr Add-on."
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:29
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:30
 msgid "You will receive an email when the review is complete."
 msgstr "Sie erhalten eine E-Mail, wenn die Überprüfung abgeschlossen wurde."
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:34
-msgid ""
-"You will receive an email when the review is complete. Until\n"
-"                             then, your add-on is not listed in our gallery but can be\n"
-"                             accessed directly from its details page."
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:33
+msgid "You will receive an email when the review is complete. Until then, your add-on is not listed in our gallery but can be accessed directly from its details page."
 msgstr "Sie erhalten eine E-Mail, wenn die Überprüfung abgeschlossen ist. Bis dahin ist Ihr Add-on nicht in unserer Galerie aufgelistet, ist aber direkt über seine Detailseite zugänglich."
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:38 src/olympia/devhub/templates/devhub/includes/addon_details.html:48
-msgid ""
-"You will receive an email when the review is\n"
-"                             complete and your add-on is signed."
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:37 src/olympia/devhub/templates/devhub/includes/addon_details.html:45
+msgid "You will receive an email when the review is complete and your add-on is signed."
 msgstr "Sie erhalten eine E-Mail, wenn die Überprüfung abgeschlossen wurde und Ihr Add-on signiert ist."
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:44
-msgid ""
-"You will receive an email when the review is complete. Until\n"
-"                             then, your add-on is not listed in our gallery but can be\n"
-"                             accessed directly from its details page. "
-msgstr "Sie erhalten eine E-Mail, wenn die Überprüfung abgeschlossen ist. Bis dahin ist Ihr Add-on nicht in unserer Galerie aufgelistet, ist aber direkt über seine Detailseite zugänglich."
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:41
+msgid "You will receive an email when the review is complete. Until then, your add-on is not listed in our gallery but can be accessed directly from its details page. "
+msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:54
-msgid ""
-"Your add-on is displayed in our gallery and users are\n"
-"                             receiving automatic updates."
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:49
+msgid "Your add-on is displayed in our gallery and users are receiving automatic updates."
 msgstr "Ihr Add-on wird in unserer Galerie angezeigt und die Nutzer erhalten automatische Updates."
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:57
-msgid ""
-"Your add-on has been signed and can be bundled with an\n"
-"                             application installer."
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:52
+msgid "Your add-on has been signed and can be bundled with an application installer."
 msgstr "Ihr Add-on wurde signiert und kann mit einem Anwendungsinstallationsprogramm kombiniert werden."
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:63
-msgid ""
-"Your add-on was disabled by a site administrator and is no\n"
-"                             longer shown in our gallery. If you have any questions,\n"
-"                             please email amo-admins@mozilla.org."
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:56
+msgid "Your add-on was disabled by a site administrator and is no longer shown in our gallery. If you have any questions, please email amo-admins@mozilla.org."
 msgstr ""
 "Ihr Add-on wurde von einem Administrator dieser Website deaktiviert und wird nicht mehr in unserer Galerie angezeigt. Wenn Sie Fragen haben, schreiben Sie bitte eine E-Mail an amo-admins@mozilla."
 "org."
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:70
-msgid ""
-"Your add-on is displayed in our gallery as experimental\n"
-"                             and users are receiving automatic updates. Some features\n"
-"                             are unavailable to your add-on."
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:62
+msgid "Your add-on is displayed in our gallery as experimental and users are receiving automatic updates. Some features are unavailable to your add-on."
 msgstr "Ihr Add-on wird in unserer Galerie als experimentell angezeigt und Nutzer erhalten automatische Updates. Eine Funktionen stehen für Ihr Add-on nicht zur Verfügung."
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:74
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:66
 msgid "Your add-on has been signed."
 msgstr "Ihr Add-on wurde signiert."
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:79
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:69
 msgid ""
-"You will receive an email when the full review is complete.\n"
-"                             Until then, your add-on is displayed in our gallery as\n"
-"                             experimental and users are receiving automatic updates.\n"
-"                             Some features are unavailable to your add-on."
+"You will receive an email when the full review is complete. Until then, your add-on is displayed in our gallery as experimental and users are receiving automatic updates. Some features are "
+"unavailable to your add-on."
 msgstr ""
 "Sie erhalten eine E-Mail, wenn die vollständige Überprüfung abgeschlossen ist. Bis dahin wird Ihr Add-on in unserer Galerie als experimentell angezeigt und Nutzer erhalten automatische Updates. "
 "Einige Funktionen stehen für Ihr Add-on nicht zur Verfügung."
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:84
-msgid ""
-"You will receive an email when the full review is\n"
-"                             complete, making you able to bundle your add-on with an\n"
-"                             application installer."
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:74
+msgid "You will receive an email when the full review is complete, making you able to bundle your add-on with an application installer."
 msgstr "Sie erhalten eine E-Mail, wenn die vollständige Überprüfung abgeschlossen wurde, und Ihr Add-on mit einem Anwendungsinstallationsprogramm kombiniert werden kann."
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:91
-msgid ""
-"All add-ons hosted in our gallery must now be reviewed by an\n"
-"                             editor. If you wish to continue hosting your add-on, please\n"
-"                             click to select a review process."
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:79
+msgid "All add-ons hosted in our gallery must now be reviewed by an editor. If you wish to continue hosting your add-on, please click to select a review process."
 msgstr ""
 "Alle in unserer Galerie gehosteten Add-ons müssen jetzt von einem Redakteur überprüft werden. Wenn Ihr Add-on weiter gehostet erden soll, wählen Sie per Klick bitte einen Überprüfungsprozess aus."
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:113
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:100
 msgid "Current Version:"
 msgstr "Aktuelle Version:"
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:115
-msgid ""
-"This is the version of your add-on that will\n"
-"                                           be installed if someone clicks the Install\n"
-"                                           button on addons.mozilla.org. It is only\n"
-"                                           relevant for listed add-ons."
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:102
+msgid "This is the version of your add-on that will be installed if someone clicks the Install button on addons.mozilla.org. It is only relevant for listed add-ons."
 msgstr "Dies ist die Version Ihres Add-ons, die installiert wird, wenn jemand auf die Installationsschaltfläche auf add-ons.mozilla.org klickt. Dies ist nur für gelistete Add-ons wichtig."
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:123
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:110
 msgid "Created:"
 msgstr "Erstellt:"
 
 #. {0} is a date. dennis-ignore: E201
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:125 src/olympia/devhub/templates/devhub/includes/addon_details.html:131
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:112 src/olympia/devhub/templates/devhub/includes/addon_details.html:118
 #, python-format
 msgid "%%b %%e, %%Y"
 msgstr "%%d %%b %%Y"
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:136
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:123
 msgid "Next Version:"
 msgstr "Nächste Version:"
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:138
-msgid ""
-"This is the newest uploaded version, however\n"
-"                                           it isn’t live on the site yet."
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:125
+msgid "This is the newest uploaded version, however it isn’t live on the site yet."
 msgstr "Dies ist die neueste hochgeladene Version, Sie ist aber noch nicht auf der Website zu sehen."
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:144 src/olympia/devhub/templates/devhub/versions/list.html:30
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:130 src/olympia/devhub/templates/devhub/versions/list.html:30
 msgid "Queues are not reviewed strictly in order"
 msgstr "Die Warteschlange wird nicht streng nach Reihenfolge überprüft"
 
@@ -6453,9 +6328,7 @@ msgid "View the blog &#9658;"
 msgstr "Lesen Sie den Blog ►"
 
 #: src/olympia/devhub/templates/devhub/includes/license_form.html:6
-msgid ""
-"Please choose a license appropriate for the rights you grant on your source code.\n"
-"                  It is only relevant for listed add-ons."
+msgid "Please choose a license appropriate for the rights you grant on your source code. It is only relevant for listed add-ons."
 msgstr "Bitte wählen Sie eine Lizenz, die zu den Rechten passt, die Sie an Ihrem Quelltext einräumen wollen. Dies ist nur für gelistete Add-ons wichtig."
 
 #. {0} is a list of HTML tags.
@@ -6471,8 +6344,7 @@ msgstr "HTML wird teilweise unterstützt"
 msgid "Remove this application"
 msgstr "Diese App entfernen"
 
-#. {0} is the maximum number of add-on categories allowed.                {1}
-#. is
+#. {0} is the maximum number of add-on categories allowed.                {1} is
 #. the application name.
 #: src/olympia/devhub/templates/devhub/includes/macros.html:70
 msgid "Select <b>up to {0}</b> {1} category for this add-on:"
@@ -6483,16 +6355,11 @@ msgstr[1] "Wählen Sie <b>bis zu {0}</b> {1} Kategorien für dieses Add-on:"
 #: src/olympia/devhub/templates/devhub/includes/policy_form.html:4
 msgid ""
 "Users will be required to accept the following End-User License Agreement (EULA) prior to installing your add-on. The presence of a EULA significantly affects the number of downloads an add-on "
-"receives. Please note that a EULA is not the same as a code license, such as the GPL or MPL.\n"
-"                It is only relevant for listed add-ons."
+"receives. Please note that a EULA is not the same as a code license, such as the GPL or MPL.It is only relevant for listed add-ons."
 msgstr ""
-"Nutzer müssen die folgende Endbenutzer-Lizenzvereinbarung (EULA) akzeptieren, bevor Sie Ihr Add-on installieren. Eine EULA hat starke Auswirkungen auf die Zahl der Downloads eines Add-ons. Bitte "
-"beachten Sie, dass eine EULA etwas anderes ist, als eine Quelltextlizenz, wie GPL oder MPL. Dies ist nur für gelistete Add-ons wichtig."
 
-#: src/olympia/devhub/templates/devhub/includes/policy_form.html:21
-msgid ""
-"If your add-on transmits any data from the user's computer, a privacy policy is required that explains what data is sent and how it is used.\n"
-"                It is only relevant for listed add-ons."
+#: src/olympia/devhub/templates/devhub/includes/policy_form.html:24
+msgid "If your add-on transmits any data from the user's computer, a privacy policy is required that explains what data is sent and how it is used. It is only relevant for listed add-ons."
 msgstr ""
 "Wenn Ihr Add-on Daten vom Computer des Benutzers überträgt, muss eine Datenschutzerklärung angegeben werden, die die gesendeten Daten und deren Verwendung beschreibt. Dies ist nur für gelistete Add-"
 "ons wichtig."
@@ -6664,12 +6531,8 @@ msgstr "Wählen Sie die Kategorie aus, die Ihr Theme am besten beschreibt."
 msgid "Add some tags to describe your Theme."
 msgstr "Fügen Sie ein paar Schlagwörter hinzu, um Ihr Theme zu beschreiben."
 
-#: src/olympia/devhub/templates/devhub/personas/edit.html:106
-msgid ""
-"A short explanation of your theme's\n"
-"                                basic functionality that is displayed in\n"
-"                                search and browse listings, as well as at\n"
-"                                the top of your theme's details page."
+#: src/olympia/devhub/templates/devhub/personas/edit.html:106 src/olympia/devhub/templates/devhub/personas/submit.html:54
+msgid "A short explanation of your theme's basic functionality that is displayed in search and browse listings, as well as at the top of your theme's details page."
 msgstr "Eine kurze Erklärung der wichtigsten Funktionen Ihres Themes, die in Suchergebnissen und Listen angezeigt wird, sowie oben auf der Detailseite Ihres Themes."
 
 #: src/olympia/devhub/templates/devhub/personas/edit.html:122 src/olympia/devhub/templates/devhub/personas/submit.html:68
@@ -6739,7 +6602,7 @@ msgid "Upon upload and form submission, the AMO Team will review your updated de
 msgstr "Sobald der Upload abgeschlossen und das Formular abgesendet ist, wird das AMO-Team Ihr aktualisiertes Design überprüfen. Ihr aktuelles Design ist währenddessen weiter verfügbar."
 
 #: src/olympia/devhub/templates/devhub/personas/edit.html:241
-msgid "Your previously resubmitted design,  which is under pending review."
+msgid "Your previously resubmitted design, which is under pending review."
 msgstr "Ihr zuvor erneut eingereichtes Design, das auf Überprüfung wartet."
 
 #: src/olympia/devhub/templates/devhub/personas/edit.html:245
@@ -6809,14 +6672,6 @@ msgstr ""
 #: src/olympia/devhub/templates/devhub/personas/submit.html:33
 msgid "Give your Theme a name."
 msgstr "Geben Sie Ihrem Theme einen Namen."
-
-#: src/olympia/devhub/templates/devhub/personas/submit.html:54
-msgid ""
-"A short explanation of your theme's\n"
-"                                      basic functionality that is displayed in\n"
-"                                      search and browse listings, as well as at\n"
-"                                      the top of your theme's details page."
-msgstr "Eine kurze Erklärung der wichtigsten Funktionen Ihres Themes, die in Suchergebnissen und Listen angezeigt wird, sowie oben auf der Detailseite Ihres Themes."
 
 #: src/olympia/devhub/templates/devhub/personas/submit.html:198
 #, python-format
@@ -6894,35 +6749,17 @@ msgstr "Wählen Sie eine andere Grafik für die Fußzeile"
 msgid "Files added to reviewed versions must be reviewed before they will be available for download."
 msgstr "Dateien, die zu geprüften Versionen hinzugefügt werden, müssen geprüft werden, bevor sie zum Download bereitstehen."
 
-#: src/olympia/devhub/templates/devhub/versions/add_file_modal.html:15
-#, python-format
-msgid ""
-"Submission of updates to unlisted add-ons for signing is currently in an open beta. Manual review may still be required for a large number of add-ons. Please <a href=\"%(url)s\" target=\"_blank"
-"\">report any bugs</a> that you encounter."
-msgstr ""
-"Die Einreichung ungelisteter Add-ons zur Signierung befindet sich aktuell in der offenen Beta-Phase. Für viele Add-ons ist möglicherweise noch eine manuelle Überprüfung erforderlich. Bitte<a href="
-"\"%(url)s\" target=\"_blank\">melden Sie Fehler</a>, auf die Sie stoßen."
-
-#: src/olympia/devhub/templates/devhub/versions/add_file_modal.html:35
+#: src/olympia/devhub/templates/devhub/versions/add_file_modal.html:24
 msgid "Select the target platform for this file."
 msgstr "Wählen Sie die Zielplattform für diese Datei."
 
-#: src/olympia/devhub/templates/devhub/versions/add_file_modal.html:46
+#: src/olympia/devhub/templates/devhub/versions/add_file_modal.html:35
 msgid "Which review type would you like to nominate for?"
 msgstr "Für welchen Überprüfungstyp möchten Sie dies nominieren?"
 
-#: src/olympia/devhub/templates/devhub/versions/add_file_modal.html:51
+#: src/olympia/devhub/templates/devhub/versions/add_file_modal.html:40
 msgid "Only publish this version to my beta channel."
 msgstr "Diese Version nur auf meinem Beta-Kanal veröffentlichen."
-
-#: src/olympia/devhub/templates/devhub/versions/add_file_modal.html:54
-#, python-format
-msgid ""
-"The behavior of the beta channel has changed to accommodate <a href=\"%(addon_signing_url)s\" target=\"_blank\">mandatory add-on signing</a>. The new process is currently in an open beta, and may "
-"change significantly in the near future. Please <a href=\"%(issues_url)s\" target=\"_blank\">report any bugs</a> that you encounter."
-msgstr ""
-"Das Verhalten des Beta-Kanals wurde geändert, um die <a href=\"%(addon_signing_url)s\" target=\"_blank\">verpflichtende Signierung von Add-ons</a> zu berücksichtigen. Dieser neue Prozess befindet "
-"sich derzeit in der offenen Beta-Phase und kann sich in naher Zukunft wesentlich ändern. Bitte <a href=\"%(issues_url)s\" target=\"_blank\">melden Sie alle Fehler</a>, auf die Sie stoßen."
 
 #: src/olympia/devhub/templates/devhub/versions/edit.html:5
 msgid "Manage Version {0}"
@@ -6946,19 +6783,10 @@ msgstr "Dateien"
 msgid "Upload Another File"
 msgstr "Eine weitere Datei hochladen"
 
-#: src/olympia/devhub/templates/devhub/versions/edit.html:45
-msgid ""
-"Adjusting application information here will allow users to install your\n"
-"                          add-on even if the install manifest in the package indicates that the\n"
-"                          add-on is incompatible."
-msgstr "Wenn Sie die Informationen hier anpassen, können Nutzer Ihr Add-on sogar dann installieren, wenn das Manifest im Paket anzeigt, dass das Add-on inkompatibel ist."
-
 #: src/olympia/devhub/templates/devhub/versions/edit.html:74
 msgid ""
-"Information about changes in this release, new features,\n"
-"                              known bugs, and other useful information specific to this\n"
-"                              release/version. This information is also shown in the\n"
-"                              Add-ons Manager when updating."
+"Information about changes in this release, new features, known bugs, and other useful information specific to this release/version. This information is also shown in the Add-ons Manager when "
+"updating."
 msgstr ""
 "Informationen über Änderungen in dieser Version, neue Funktionen, bekannte Probleme und andere nützliche Hinweise zu dieser Version. Diese Informationen werden auch bei der Aktualisierung im Add-"
 "ons-Manager angezeigt."
@@ -6972,10 +6800,7 @@ msgid "Notes for Reviewers"
 msgstr "Anmerkungen für Kontrolleure"
 
 #: src/olympia/devhub/templates/devhub/versions/edit.html:114
-msgid ""
-"Optionally, enter any information that may be useful\n"
-"                              to the Editor reviewing this add-on, such as test\n"
-"                              account information."
+msgid "Optionally, enter any information that may be useful to the Editor reviewing this add-on, such as test account information."
 msgstr "Optional können Sie auch andere Informationen eintragen, die für den Prüfer dieses Add-ons hilfreich sein können, wie Informationen zu Testbenutzerkonten."
 
 #: src/olympia/devhub/templates/devhub/versions/edit.html:127
@@ -7053,7 +6878,7 @@ msgstr "Vollständige Überprüfung anfordern"
 msgid "Request Preliminary Review"
 msgstr "Vorläufige Freigabe anfordern"
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:80 src/olympia/devhub/templates/devhub/versions/list.html:327 src/olympia/devhub/templates/devhub/versions/list.html:350
+#: src/olympia/devhub/templates/devhub/versions/list.html:80 src/olympia/devhub/templates/devhub/versions/list.html:325 src/olympia/devhub/templates/devhub/versions/list.html:348
 msgid "Cancel Review Request"
 msgstr "Überprüfungsanforderung abbrechen"
 
@@ -7082,8 +6907,8 @@ msgid "Unlisted:"
 msgstr "Nicht gelistet:"
 
 #: src/olympia/devhub/templates/devhub/versions/list.html:114
-msgid "Not distributed on {0}. Developers will upload new versions for signing and distribute the add-ons on their own. (beta)"
-msgstr "Wird nicht auf {0} verteilt. Entwickler laden neue Versionen zur Signierung hoch und verteilen die Add-ons selbstständig. (Beta)"
+msgid "Not distributed on {0}. Developers will upload new versions for signing and distribute the add-ons on their own."
+msgstr ""
 
 #: src/olympia/devhub/templates/devhub/versions/list.html:122
 msgid "Current versions"
@@ -7150,86 +6975,78 @@ msgid "<strong>Important:</strong> Once a version has been deleted, you may not 
 msgstr "<strong>Wichtig:</strong> Sobald eine Version gelöscht wurde, dürfen Sie keine neue Version mit der gleichen Versionsnummer hochladen."
 
 #: src/olympia/devhub/templates/devhub/versions/list.html:230
-msgid ""
-"Deleting a version which has already been reviewed\n"
-"               may also cause a significant delay in the review of\n"
-"               your next update."
-msgstr "Wenn Sie eine bereits überprüfte Version löschen, kann diese zu wesentlichen Verzögerungen bei der Überprüfung Ihres nächsten Updates führen."
-
-#: src/olympia/devhub/templates/devhub/versions/list.html:233
 msgid "Are you sure you wish to delete this version?"
 msgstr "Möchten Sie diese Version wirklich löschen?"
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:238
+#: src/olympia/devhub/templates/devhub/versions/list.html:235
 msgid "Delete Version"
 msgstr "Version löschen"
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:240
+#: src/olympia/devhub/templates/devhub/versions/list.html:237
 msgid "Disable Version"
 msgstr "Version deaktivieren"
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:247
+#: src/olympia/devhub/templates/devhub/versions/list.html:244
 msgid "Add a new Version"
 msgstr "Neue Version hinzufügen"
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:249
+#: src/olympia/devhub/templates/devhub/versions/list.html:246
 msgid "Add Version"
 msgstr "Version hinzufügen"
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:256 src/olympia/devhub/templates/devhub/versions/list.html:274
+#: src/olympia/devhub/templates/devhub/versions/list.html:253 src/olympia/devhub/templates/devhub/versions/list.html:279
 msgid "Hide Add-on"
 msgstr "Add-on verstecken"
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:259
+#: src/olympia/devhub/templates/devhub/versions/list.html:256
 msgid "Hiding your add-on will prevent it from appearing anywhere in our gallery and will stop users from receiving automatic updates."
 msgstr "Wenn Sie Ihr Add-on verstecken, erscheint es nicht mehr in unserer Galerie und Nutzer erhalten keine automatischen Updates mehr."
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:265
+#: src/olympia/devhub/templates/devhub/versions/list.html:263
+msgid "The files awaiting review will be disabled and you will need to upload new versions."
+msgstr ""
+
+#: src/olympia/devhub/templates/devhub/versions/list.html:270
 msgid "Are you sure you wish to hide your add-on?"
 msgstr "Soll Ihr Add-on wirklich versteckt werden?"
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:286 src/olympia/devhub/templates/devhub/versions/list.html:315
+#: src/olympia/devhub/templates/devhub/versions/list.html:291 src/olympia/devhub/templates/devhub/versions/list.html:313
 msgid "Unlist Add-on"
 msgstr "Add-on nicht mehr auflisten"
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:289
+#: src/olympia/devhub/templates/devhub/versions/list.html:294
 #, python-format
 msgid ""
 "Unlisting your add-on will make it (and each of its versions/files) invisible on this website. It won't show up in searches, won't have a public facing page, and won't be updated automatically for "
-"current users.  It is recommended for unlisted add-ons to provide a custom <a href=\"%(update_url)s\" target=\"_blank\">updateURL</a> in their manifest file for automatic updates."
+"current users. It is recommended for unlisted add-ons to provide a custom <a href=\"%(update_url)s\" target=\"_blank\">updateURL</a> in their manifest file for automatic updates."
 msgstr ""
 "Wenn Sie die Auflistung Ihres Add-on deaktivieren wird es (und seine Versionen/Dateien) auf dieser Website nicht mehr angezeigt. Es erscheint nicht in Suchergebnissen, hat keine öffentliche Seite "
 "und wird für aktuelle Nutzer nicht mehr automatisch aktualisiert. Wir empfehlen, in ungelisteten Add-ons für automatische Updates eine angepasste <a href=\"%(update_url)s\" target=\"_blank"
 "\">updateURL</a> im Manifest anzugeben."
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:299
-#, python-format
-msgid "Switching add-ons to unlisted is currently in an open beta. Please <a href=\"%(url)s\" target=\"_blank\">report any bugs</a> that you encounter."
-msgstr "Die Umschaltung von Add-ons auf ungelistet befindet sich derzeit in einer offenen Beta-Phase. Bitte <a href=\"%(url)s\" target=\"_blank\">melden Sie alle Fehler</a>, auf die Sie stoßen."
-
-#: src/olympia/devhub/templates/devhub/versions/list.html:305
+#: src/olympia/devhub/templates/devhub/versions/list.html:303
 msgid "Unlisting an add-on is irreversible!"
 msgstr "Das Entfernen der Auflistung eines Add-ons kann nicht rückgängig gemacht werden!"
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:305
+#: src/olympia/devhub/templates/devhub/versions/list.html:303
 msgid "An unlisted add-on cannot be switched to be listed."
 msgstr "Ein nicht gelistetes Add-on kann nicht auf „gelistet“ umgeschaltet werden."
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:307
+#: src/olympia/devhub/templates/devhub/versions/list.html:305
 msgid "Are you sure you wish to unlist your add-on?"
 msgstr "Soll Ihr Add- on wirklich nicht mehr aufgelistet werden?"
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:330
+#: src/olympia/devhub/templates/devhub/versions/list.html:328
 msgid "Canceling your review request will leave your add-on as preliminarily reviewed."
 msgstr "Wenn Sie Ihre Überprüfungsanfrage abbrechen, bleibt Ihr Add-on vorläufig geprüft."
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:335
+#: src/olympia/devhub/templates/devhub/versions/list.html:333
 msgid "Canceling your review request will mark your add-on incomplete. If you do not complete your add-on after several days by re-requesting review, it will be deleted."
 msgstr ""
 "Wenn Sie Ihre Überprüfungsanfrage abbrechen, wird Ihr Add-on als unvollständig gekennzeichnet. Wen Sie Ihr Add-on nicht nach einigen Tagen vervollständigen, indem Sie die Überprüfungsanfrage neu "
 "stellen, wird es gelöscht."
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:343
+#: src/olympia/devhub/templates/devhub/versions/list.html:341
 msgid "Are you sure you wish to cancel your review request?"
 msgstr "Möchten Sie Ihre Überprüfungsanfrage wirklich löschen?"
 
@@ -7572,19 +7389,19 @@ msgstr "Add-on, Redakteur oder Kommentar"
 msgid "Search by add-on name / author email"
 msgstr "Nach Add-on-Name/E-Mail-Adresse des Autors suchen"
 
-#: src/olympia/editors/forms.py:103
+#: src/olympia/editors/forms.py:103 src/olympia/editors/forms.py:244 src/olympia/editors/forms.py:257
 msgid "yes"
 msgstr "Ja"
 
-#: src/olympia/editors/forms.py:104
+#: src/olympia/editors/forms.py:104 src/olympia/editors/forms.py:244 src/olympia/editors/forms.py:257
 msgid "no"
 msgstr "Nein"
 
-#: src/olympia/editors/forms.py:105
+#: src/olympia/editors/forms.py:105 src/olympia/editors/forms.py:245
 msgid "Admin Flag"
 msgstr "Admin-Markierung"
 
-#: src/olympia/editors/forms.py:113
+#: src/olympia/editors/forms.py:113 src/olympia/editors/forms.py:253
 msgid "Max. Version"
 msgstr "Kompatibel bis zu"
 
@@ -7596,55 +7413,59 @@ msgstr "Tage seit Einreichung"
 msgid "Add-on Types"
 msgstr "Add-on-Typen"
 
-#: src/olympia/editors/forms.py:126 src/olympia/editors/helpers.py:267
+#: src/olympia/editors/forms.py:126 src/olympia/editors/helpers.py:279
 msgid "Platforms"
 msgstr "Betriebssystem"
 
+#: src/olympia/editors/forms.py:237
+msgid "Search by add-on name / author email / guid"
+msgstr ""
+
 #. L10n: 0 = platform, 1 = filename, 2 = status message
-#: src/olympia/editors/forms.py:238
+#: src/olympia/editors/forms.py:342
 #, python-format
 msgid "<strong>%s</strong> &middot; %s &middot; %s"
 msgstr "<strong>%s</strong> · %s · %s"
 
-#: src/olympia/editors/forms.py:252
+#: src/olympia/editors/forms.py:356
 msgid "Comments:"
 msgstr "Kommentare:"
 
-#: src/olympia/editors/forms.py:256
+#: src/olympia/editors/forms.py:360
 msgid "Operating systems:"
 msgstr "Betriebssysteme:"
 
-#: src/olympia/editors/forms.py:258
+#: src/olympia/editors/forms.py:362
 msgid "Applications:"
 msgstr "Anwendungen:"
 
-#: src/olympia/editors/forms.py:260
+#: src/olympia/editors/forms.py:364
 msgid "Notify me the next time this add-on is updated. (Subsequent updates will not generate an email)"
 msgstr "Mich beim nächsten Mal benachrichtigen, wenn dieses Add-on aktualisiert wird (folgende Updates werden keine E-Mail erzeugen)"
 
-#: src/olympia/editors/forms.py:265
+#: src/olympia/editors/forms.py:369
 msgid "Clear Admin Review Flag"
 msgstr "Markierung für Admin-Überprüfung löschen"
 
-#: src/olympia/editors/forms.py:267
+#: src/olympia/editors/forms.py:371
 msgid "Clear more info requested flag"
 msgstr "Markierung „Weitere Informationen anfordern“ entfernen"
 
-#: src/olympia/editors/forms.py:281
+#: src/olympia/editors/forms.py:385
 msgid "Choose a canned response..."
 msgstr "Eine fertige Antwort auswählen …"
 
 #. L10n: Description of what can be searched for.
-#: src/olympia/editors/forms.py:324
+#: src/olympia/editors/forms.py:423
 msgid "theme name"
 msgstr "Name des Themes"
 
-#: src/olympia/editors/forms.py:350
+#: src/olympia/editors/forms.py:449
 msgid "Someone else is reviewing this theme."
 msgstr "Jemand anderes überprüft dieses Theme."
 
 #. L10n: Description of what can be searched for.
-#: src/olympia/editors/forms.py:447
+#: src/olympia/editors/forms.py:546
 msgid "app, reviewer, or comment"
 msgstr "App, Kontrolleur oder Kommentar"
 
@@ -7660,193 +7481,211 @@ msgstr "Wartet auf vorläufige Überprüfung"
 msgid "Rejected or Unreviewed"
 msgstr "Abgelehnt oder nicht überprüt"
 
-#: src/olympia/editors/helpers.py:123 src/olympia/editors/helpers.py:136
+#: src/olympia/editors/helpers.py:125 src/olympia/editors/helpers.py:138
 msgid "Queue"
 msgstr "Warteschlange"
 
-#: src/olympia/editors/helpers.py:124 src/olympia/editors/templates/editors/base.html:50 src/olympia/editors/templates/editors/base.html:65
+#: src/olympia/editors/helpers.py:126 src/olympia/editors/templates/editors/base.html:50 src/olympia/editors/templates/editors/base.html:65
 msgid "Pending Updates"
 msgstr "Ausstehende Aktualisierungen"
 
-#: src/olympia/editors/helpers.py:125 src/olympia/editors/templates/editors/base.html:48 src/olympia/editors/templates/editors/base.html:63
+#: src/olympia/editors/helpers.py:127 src/olympia/editors/templates/editors/base.html:48 src/olympia/editors/templates/editors/base.html:63
 msgid "Full Reviews"
 msgstr "Vollständige Überprüfungen"
 
-#: src/olympia/editors/helpers.py:126 src/olympia/editors/templates/editors/base.html:52 src/olympia/editors/templates/editors/base.html:67
+#: src/olympia/editors/helpers.py:128 src/olympia/editors/templates/editors/base.html:52 src/olympia/editors/templates/editors/base.html:67
 msgid "Preliminary Reviews"
 msgstr "Vorläufige Überprüfungen"
 
-#: src/olympia/editors/helpers.py:127 src/olympia/editors/templates/editors/base.html:54
+#: src/olympia/editors/helpers.py:129 src/olympia/editors/templates/editors/base.html:54
 msgid "Moderated Reviews"
 msgstr "Moderierte Überprüfungen"
 
-#: src/olympia/editors/helpers.py:128 src/olympia/editors/templates/editors/base.html:46
+#: src/olympia/editors/helpers.py:130 src/olympia/editors/templates/editors/base.html:46
 msgid "Fast Track"
 msgstr "Schnellüberprüfung"
 
-#: src/olympia/editors/helpers.py:130
+#: src/olympia/editors/helpers.py:132
 msgid "Pending Themes"
 msgstr "Ausstehende Themes"
 
-#: src/olympia/editors/helpers.py:131 src/olympia/editors/templates/editors/themes/queue.html:4
+#: src/olympia/editors/helpers.py:133 src/olympia/editors/templates/editors/themes/queue.html:4
 msgid "Flagged Themes"
 msgstr "Markierte Themes"
 
-#: src/olympia/editors/helpers.py:132
+#: src/olympia/editors/helpers.py:134
 msgid "Update Themes"
 msgstr "Themes aktualisieren"
 
-#: src/olympia/editors/helpers.py:137
+#: src/olympia/editors/helpers.py:139
 msgid "Unlisted Pending Updates"
 msgstr "Ausstehende Aktualisierungen nicht aufgeführter Add-ons"
 
-#: src/olympia/editors/helpers.py:138
+#: src/olympia/editors/helpers.py:140
 msgid "Unlisted Full Reviews"
 msgstr "Vollständige Überprüfungen nicht aufgeführter Add-ons"
 
-#: src/olympia/editors/helpers.py:139
+#: src/olympia/editors/helpers.py:141
 msgid "Unlisted Preliminary Reviews"
 msgstr "Vorläufige Überprüfungen nicht aufgeführter Add-ons"
 
-#: src/olympia/editors/helpers.py:170
+#: src/olympia/editors/helpers.py:142
+msgid "Unlisted All Add-ons"
+msgstr ""
+
+#: src/olympia/editors/helpers.py:173
 msgid "Fast Track ({0})"
 msgid_plural "Fast Track ({0})"
 msgstr[0] "Schnellüberprüfung ({0})"
 msgstr[1] "Schnellüberprüfungen ({0})"
 
-#: src/olympia/editors/helpers.py:175
+#: src/olympia/editors/helpers.py:178
 msgid "Full Review ({0})"
 msgid_plural "Full Reviews ({0})"
 msgstr[0] "Vollständige Überprüfung ({0})"
 msgstr[1] "Vollständige Überprüfungen ({0})"
 
-#: src/olympia/editors/helpers.py:180
+#: src/olympia/editors/helpers.py:183
 msgid "Pending Update ({0})"
 msgid_plural "Pending Updates ({0})"
 msgstr[0] "Ausstehende Aktualisierung ({0})"
 msgstr[1] "Ausstehende Aktualisierungen ({0})"
 
-#: src/olympia/editors/helpers.py:185
+#: src/olympia/editors/helpers.py:188
 msgid "Preliminary Review ({0})"
 msgid_plural "Preliminary Reviews ({0})"
 msgstr[0] "Vorläufige Freigabe ({0})"
 msgstr[1] "Vorläufige Freigaben ({0})"
 
-#: src/olympia/editors/helpers.py:190
+#: src/olympia/editors/helpers.py:193
 msgid "Moderated Review ({0})"
 msgid_plural "Moderated Reviews ({0})"
 msgstr[0] "Vollständige Überprüfung nicht aufgeführter Add-ons ({0})"
 msgstr[1] "Vollständige Überprüfungen nicht aufgeführter Add-ons ({0})"
 
-#: src/olympia/editors/helpers.py:196
+#: src/olympia/editors/helpers.py:199
 msgid "Unlisted Full Review ({0})"
 msgid_plural "Unlisted Full Reviews ({0})"
 msgstr[0] "Vollständige Überprüfung nicht aufgeführter Add-ons ({0})"
 msgstr[1] "Vollständige Überprüfungen nicht aufgeführter Add-ons ({0})"
 
-#: src/olympia/editors/helpers.py:201
+#: src/olympia/editors/helpers.py:204
 msgid "Unlisted Pending Update ({0})"
 msgid_plural "Unlisted Pending Updates ({0})"
 msgstr[0] "Ausstehende Aktualisierung nicht aufgeführter Add-ons ({0})"
 msgstr[1] "Ausstehende Aktualisierungen nicht aufgeführter Add-ons ({0})"
 
-#: src/olympia/editors/helpers.py:206
+#: src/olympia/editors/helpers.py:209
 msgid "Unlisted Preliminary Review ({0})"
 msgid_plural "Unlisted Preliminary Reviews ({0})"
 msgstr[0] "Vorläufige Überprüfung nicht aufgeführter Add-ons ({0})"
 msgstr[1] "Vorläufige Überprüfungen nicht aufgeführter Add-ons ({0})"
 
-#: src/olympia/editors/helpers.py:261
-msgid "Addon"
-msgstr "Add-on"
+#: src/olympia/editors/helpers.py:214
+msgid "Unlisted All Add-ons ({0})"
+msgid_plural "Unlisted All Add-ons ({0})"
+msgstr[0] ""
+msgstr[1] ""
 
-#: src/olympia/editors/helpers.py:262
+#: src/olympia/editors/helpers.py:274
 msgid "Type"
 msgstr "Typ"
 
-#: src/olympia/editors/helpers.py:263
+#: src/olympia/editors/helpers.py:275
 msgid "Waiting Time"
 msgstr "Wartezeit"
 
-#: src/olympia/editors/helpers.py:264 src/olympia/editors/templates/editors/review.html:285
+#: src/olympia/editors/helpers.py:276 src/olympia/editors/templates/editors/review.html:285
 msgid "Flags"
 msgstr "Markierungen"
 
-#: src/olympia/editors/helpers.py:265
+#: src/olympia/editors/helpers.py:277
 msgid "Applications"
 msgstr "Anwendungen"
 
-#: src/olympia/editors/helpers.py:270
+#: src/olympia/editors/helpers.py:282
 msgid "Additional"
 msgstr "Zusätzlich"
 
-#: src/olympia/editors/helpers.py:285
+#: src/olympia/editors/helpers.py:302
 msgid "Site Specific"
 msgstr "Seitenabhängig"
 
-#: src/olympia/editors/helpers.py:287
+#: src/olympia/editors/helpers.py:304
 msgid "Requires External Software"
 msgstr "Benötigt externe Programme"
 
-#: src/olympia/editors/helpers.py:289
+#: src/olympia/editors/helpers.py:306
 msgid "Binary Components"
 msgstr "Binärkomponenten"
 
-#: src/olympia/editors/helpers.py:313
+#: src/olympia/editors/helpers.py:339
 msgid "moments ago"
 msgstr "Vor wenigen Augenblicken"
 
 #. L10n: first argument is number of minutes
-#: src/olympia/editors/helpers.py:316
+#: src/olympia/editors/helpers.py:342
 msgid "{0} minute"
 msgid_plural "{0} minutes"
 msgstr[0] "{0} Minute"
 msgstr[1] "{0} Minuten"
 
 #. L10n: first argument is number of hours
-#: src/olympia/editors/helpers.py:320
+#: src/olympia/editors/helpers.py:346
 msgid "{0} hour"
 msgid_plural "{0} hours"
 msgstr[0] "{0} Stunde"
 msgstr[1] "{0} Stunden"
 
 #. L10n: first argument is number of days
-#: src/olympia/editors/helpers.py:324
+#: src/olympia/editors/helpers.py:350
 msgid "{0} day"
 msgid_plural "{0} days"
 msgstr[0] "{0} Tag"
 msgstr[1] "{0} Tage"
 
-#: src/olympia/editors/helpers.py:488
+#: src/olympia/editors/helpers.py:364
+msgid "Last Review"
+msgstr ""
+
+#: src/olympia/editors/helpers.py:366
+msgid "Last Update"
+msgstr ""
+
+#: src/olympia/editors/helpers.py:387
+msgid "No Reviews"
+msgstr ""
+
+#: src/olympia/editors/helpers.py:561
 msgid "Push to public"
 msgstr "Öffentlich machen"
 
-#: src/olympia/editors/helpers.py:490
+#: src/olympia/editors/helpers.py:563
 msgid "Grant full review"
 msgstr "Vollständige Überprüfung geben"
 
-#: src/olympia/editors/helpers.py:505
+#: src/olympia/editors/helpers.py:578
 msgid "Request more information"
 msgstr "Weitere Informationen anfordern"
 
-#: src/olympia/editors/helpers.py:508
+#: src/olympia/editors/helpers.py:581
 msgid "Request super-review"
 msgstr "Super-Überprüfung anfordnern"
 
-#: src/olympia/editors/helpers.py:519
+#: src/olympia/editors/helpers.py:592
 msgid "Grant preliminary review"
 msgstr "Vorläufige Freigabe gewähren"
 
-#: src/olympia/editors/helpers.py:520
+#: src/olympia/editors/helpers.py:593
 msgid "This will mark the files as preliminarily reviewed."
 msgstr "Dadurch werden die Dateien als vorläufig freigegeben markiert."
 
-#: src/olympia/editors/helpers.py:522
+#: src/olympia/editors/helpers.py:595
 msgid "Use this form to request more information from the author. They will receive an email and be able to answer here. You will be notified by email when they reply."
 msgstr ""
 "Verwenden Sie dieses Formular, um weitere Informationen vom Autor anzufordnern. Sie erhalten eine Nachricht und können hier antworten. Sie verwenden per E-Mail informiert, wenn sie antoworten."
 
-#: src/olympia/editors/helpers.py:526
+#: src/olympia/editors/helpers.py:599
 msgid ""
 "If you have concerns about this add-on's security, copyright issues, or other concerns that an administrator should look into, enter your comments in the area below. They will be sent to "
 "administrators, not the author."
@@ -7854,55 +7693,55 @@ msgstr ""
 "Wenn Sie Bedenken zur Sicherheit des Add-ons, Urheberrechtsprobleme oder andere Bedenken haben, die sich ein Administrator ansehen sollte, geben Sie im folgenden Bereich Ihre Kommentare ein. Diese "
 "werden an Administratoren geschickt, nicht an den Autor."
 
-#: src/olympia/editors/helpers.py:532
+#: src/olympia/editors/helpers.py:605
 msgid "This will reject the add-on and remove it from the review queue."
 msgstr "Dies lehnt das Add-on ab und entfernt es aus der Warteschlange für Überprüfungen."
 
-#: src/olympia/editors/helpers.py:534
-msgid "Make a comment on this version.  The author won't be able to see this."
+#: src/olympia/editors/helpers.py:607
+msgid "Make a comment on this version. The author won't be able to see this."
 msgstr "Geben Sie einen Kommentar zu dieser Version ab. Der Autor kann ihn nicht sehen."
 
-#: src/olympia/editors/helpers.py:538
+#: src/olympia/editors/helpers.py:611
 msgid "This will reject the files and remove them from the review queue."
 msgstr "Dies lehnt die Dateien ab und entfernt sie aus der Warteschlange für Überprüfungen."
 
-#: src/olympia/editors/helpers.py:542
+#: src/olympia/editors/helpers.py:615
 msgid "This will mark the add-on as preliminarily reviewed. Future versions will undergo preliminary review."
 msgstr "Dies markiert das Add-on als vorläufig überprüft. Zukünftige Versionen werden vorläufig überprüft."
 
-#: src/olympia/editors/helpers.py:547
+#: src/olympia/editors/helpers.py:620
 msgid "This will mark the files as preliminarily reviewed. Future versions will undergo preliminary review."
 msgstr "Dies markiert die Dateien als vorläufig überprüft. Zukünftige Versionen werden vorläufig überprüft."
 
-#: src/olympia/editors/helpers.py:552
+#: src/olympia/editors/helpers.py:625
 msgid "Retain preliminary review"
 msgstr "Vorläufige Überprüfung beibehalten"
 
-#: src/olympia/editors/helpers.py:553
+#: src/olympia/editors/helpers.py:626
 msgid "This will retain the add-on as preliminarily reviewed. Future versions will undergo preliminary review."
 msgstr "Dies behält die vorläufige Überprüfung des Add-ons bei. Zukünftige Versionen werden vorläufig überprüft."
 
-#: src/olympia/editors/helpers.py:558
+#: src/olympia/editors/helpers.py:631
 msgid "This will approve a sandboxed version of a public add-on to appear on the public side."
 msgstr "Dies schaltet eine im Sandkasten befindliche Version eines öffentlichen Add-ons frei, so dass sie im öffentlichen Bereich erscheint."
 
-#: src/olympia/editors/helpers.py:561
+#: src/olympia/editors/helpers.py:634
 msgid "This will reject a version of a public add-on and remove it from the queue."
 msgstr "Dies lehnt eine Version eines öffentlichen Add-ons ab und entfernt sie aus der Warteschlange."
 
-#: src/olympia/editors/helpers.py:564
+#: src/olympia/editors/helpers.py:637
 msgid "This will mark the add-on and its most recent version and files as public. Future versions will go into the sandbox until they are reviewed by an editor."
 msgstr "Dies markiert das Add-on und seine neueste Version und seine Dateien als öffentlich. Zukünftige Versionen landen im Sandkasten, bis sie von einem Redakteur überprüft werden."
 
-#: src/olympia/editors/helpers.py:637
+#: src/olympia/editors/helpers.py:714
 msgid "add-on"
 msgstr "Add-on"
 
-#: src/olympia/editors/helpers.py:940 src/olympia/editors/helpers.py:960
+#: src/olympia/editors/helpers.py:1020 src/olympia/editors/helpers.py:1040
 msgid "Flagged"
 msgstr "Markiert"
 
-#: src/olympia/editors/helpers.py:944 src/olympia/editors/helpers.py:963
+#: src/olympia/editors/helpers.py:1024 src/olympia/editors/helpers.py:1043
 msgid "Updates"
 msgstr "Aktualisierungen"
 
@@ -7954,56 +7793,56 @@ msgstr "Theme-Übermittlung zur Überprüfung markiert"
 msgid "A question about your Theme submission"
 msgstr "Eine Frage zu Ihrer Theme-Übermittlung"
 
-#: src/olympia/editors/views.py:144
+#: src/olympia/editors/views.py:146
 msgid "New Add-ons (Under 5 days)"
 msgstr "Neue Add-ons (unter 5 Tagen)"
 
-#: src/olympia/editors/views.py:145
+#: src/olympia/editors/views.py:147
 msgid "Passable (5 to 10 days)"
 msgstr "Annehmbar (5 bis 10 Tage)"
 
-#: src/olympia/editors/views.py:146
+#: src/olympia/editors/views.py:148
 msgid "Overdue (Over 10 days)"
 msgstr "Überfällig (Über 10 Tage)"
 
-#: src/olympia/editors/views.py:532
+#: src/olympia/editors/views.py:539
 msgid "An unknown error occurred"
 msgstr "Ein unbekannter Fehler ist aufgetreten"
 
-#: src/olympia/editors/views.py:587
+#: src/olympia/editors/views.py:592
 msgid "Self-reviews are not allowed."
 msgstr "Selbstüberprüfungen sind nicht erlaubt."
 
-#: src/olympia/editors/views.py:609
+#: src/olympia/editors/views.py:613
 msgid "Review successfully processed."
 msgstr "Überprüfung erfolgreich verarbeitet."
 
-#: src/olympia/editors/views.py:807
+#: src/olympia/editors/views.py:812
 msgid "was approved"
 msgstr "wurde freigegeben"
 
-#: src/olympia/editors/views.py:808
+#: src/olympia/editors/views.py:813
 msgid "given preliminary review"
 msgstr "wurde vorläufig überprüft"
 
-#: src/olympia/editors/views.py:809
+#: src/olympia/editors/views.py:814
 msgid "rejected"
 msgstr "abgelehnt"
 
-#: src/olympia/editors/views.py:810
+#: src/olympia/editors/views.py:815
 msgctxt "editors_review_history_nominated_adminreview"
 msgid "escalated"
 msgstr "weitergereicht"
 
-#: src/olympia/editors/views.py:812
+#: src/olympia/editors/views.py:817
 msgid "needs more information"
 msgstr "benötigt weitere Informationen"
 
-#: src/olympia/editors/views.py:813
+#: src/olympia/editors/views.py:818
 msgid "needs super review"
 msgstr "benötigt Super-Überprüfung"
 
-#: src/olympia/editors/views.py:814
+#: src/olympia/editors/views.py:819
 msgid "commented"
 msgstr "kommentiert"
 
@@ -8050,28 +7889,28 @@ msgstr "Listen"
 msgid "Unlisted Queues"
 msgstr "Warteschlangen für nicht aufgeführte Add-ons"
 
-#: src/olympia/editors/templates/editors/base.html:72 src/olympia/editors/templates/editors/performance.html:6
+#: src/olympia/editors/templates/editors/base.html:74 src/olympia/editors/templates/editors/performance.html:6
 msgid "Performance"
 msgstr "Leistung"
 
-#: src/olympia/editors/templates/editors/base.html:75 src/olympia/editors/templates/editors/themes/base.html:19 src/olympia/editors/templates/editors/themes/base.html:38
+#: src/olympia/editors/templates/editors/base.html:77 src/olympia/editors/templates/editors/themes/base.html:19 src/olympia/editors/templates/editors/themes/base.html:38
 msgid "Logs"
 msgstr "Logs"
 
-#: src/olympia/editors/templates/editors/base.html:78 src/olympia/editors/templates/editors/reviewlog.html:4 src/olympia/editors/templates/editors/reviewlog.html:27
+#: src/olympia/editors/templates/editors/base.html:80 src/olympia/editors/templates/editors/reviewlog.html:4 src/olympia/editors/templates/editors/reviewlog.html:27
 msgid "Add-on Review Log"
 msgstr "Logbuch der Add-on-Überprüfungen"
 
-#: src/olympia/editors/templates/editors/base.html:80 src/olympia/editors/templates/editors/eventlog.html:4 src/olympia/editors/templates/editors/eventlog.html:8
+#: src/olympia/editors/templates/editors/base.html:82 src/olympia/editors/templates/editors/eventlog.html:4 src/olympia/editors/templates/editors/eventlog.html:8
 #: src/olympia/editors/templates/editors/eventlog_detail.html:4
 msgid "Moderated Review Log"
 msgstr "Logbuch der moderierten Überprüfungen"
 
-#: src/olympia/editors/templates/editors/base.html:82 src/olympia/editors/templates/editors/beta_signed_log.html:4 src/olympia/editors/templates/editors/beta_signed_log.html:8
+#: src/olympia/editors/templates/editors/base.html:84 src/olympia/editors/templates/editors/beta_signed_log.html:4 src/olympia/editors/templates/editors/beta_signed_log.html:8
 msgid "Signed Beta Files Log"
 msgstr "Protokoll signierter Beta-Dateien"
 
-#: src/olympia/editors/templates/editors/base.html:87 src/olympia/editors/templates/editors/includes/daily-message.html:4
+#: src/olympia/editors/templates/editors/base.html:89 src/olympia/editors/templates/editors/includes/daily-message.html:4
 msgid "Announcement"
 msgstr "Ankündigung"
 
@@ -8292,45 +8131,45 @@ msgstr "Erweiterte Suche"
 msgid "clear search"
 msgstr "Suche löschen"
 
-#: src/olympia/editors/templates/editors/queue.html:72 src/olympia/editors/templates/editors/queue.html:122
+#: src/olympia/editors/templates/editors/queue.html:78 src/olympia/editors/templates/editors/queue.html:128
 msgid "Process Reviews"
 msgstr "Überprüfungen verarbeiten"
 
-#: src/olympia/editors/templates/editors/queue.html:80
+#: src/olympia/editors/templates/editors/queue.html:86
 msgid "Moderation actions:"
 msgstr "Moderator-Aktionen:"
 
-#: src/olympia/editors/templates/editors/queue.html:90
+#: src/olympia/editors/templates/editors/queue.html:96
 #, python-format
 msgid "by %(user)s on %(date)s %(stars)s (%(locale)s)"
 msgstr "von %(user)s am %(date)s %(stars)s (%(locale)s)"
 
-#: src/olympia/editors/templates/editors/queue.html:106
+#: src/olympia/editors/templates/editors/queue.html:112
 #, python-format
 msgid "<strong>%(reason)s</strong> <span class=\"light\">Flagged by %(user)s on %(date)s</span>"
 msgstr "<strong>%(reason)s</strong> <span class=\"light\">Markiert von %(user)s am %(date)s</span>"
 
-#: src/olympia/editors/templates/editors/queue.html:119
-msgid "All reviews have been moderated.  Good work!"
+#: src/olympia/editors/templates/editors/queue.html:125
+msgid "All reviews have been moderated. Good work!"
 msgstr "Alle Bewertungen wurden moderiert. Gute Arbeit!"
 
-#: src/olympia/editors/templates/editors/queue.html:161
+#: src/olympia/editors/templates/editors/queue.html:167
 msgid "Version Notes / Notes for Reviewer"
 msgstr "Versionshinweise / Hinweise für Überprüfer"
 
-#: src/olympia/editors/templates/editors/queue.html:169
+#: src/olympia/editors/templates/editors/queue.html:175
 msgid "There are currently no add-ons of this type to review."
 msgstr "Es gibt derzeit keine Add-ons dieses Typs, die überprüft werden müssen."
 
-#: src/olympia/editors/templates/editors/queue.html:181 src/olympia/editors/templates/editors/themes/queue_list.html:85
+#: src/olympia/editors/templates/editors/queue.html:187 src/olympia/editors/templates/editors/themes/queue_list.html:85
 msgid "Helpful Links:"
 msgstr "Hilfreiche Links:"
 
-#: src/olympia/editors/templates/editors/queue.html:182
+#: src/olympia/editors/templates/editors/queue.html:188
 msgid "Add-on Policy"
 msgstr "Rechtliche Hinweise zum Add-on"
 
-#: src/olympia/editors/templates/editors/queue.html:184
+#: src/olympia/editors/templates/editors/queue.html:190
 msgid "Editors' Guide"
 msgstr "Moderatorenhandbuch"
 
@@ -8393,10 +8232,7 @@ msgid "<strong>Warning!</strong> Another user was viewing this page before you."
 msgstr "<strong>Warnung!</strong> Ein anderer Benutzer hat vor Ihnen diese Seite angesehen."
 
 #: src/olympia/editors/templates/editors/review.html:237
-msgid ""
-"The whiteboard is the place to exchange information relevant to\n"
-"               this addon (whatever the version), between the developer and the\n"
-"               editor. This is visible and editable by both."
+msgid "The whiteboard is the place to exchange information relevant to this addon (whatever the version), between the developer and the editor. This is visible and editable by both."
 msgstr "In den Hinweisen können Sie und der Redakteur für Ihr Add-on relevante Informationen austauschen, unabhängig von der Version. Dies kann von beiden Seiten angesehen und bearbeitet werden."
 
 #: src/olympia/editors/templates/editors/review.html:241
@@ -8670,7 +8506,7 @@ msgstr "Stellen Sie dem Künstler eine Frage"
 msgid "Describe your reason for flagging"
 msgstr "Beschreiben Sie Ihren Grund für die Kennzeichnung"
 
-#: src/olympia/files/forms.py:88
+#: src/olympia/files/forms.py:90
 msgid "Cannot diff a version against itself"
 msgstr "Eine Version kann nicht mit sich selbst verglichen werden"
 
@@ -8705,51 +8541,51 @@ msgstr "Beim Zugriff auf die Datei %s ist ein Fehler aufgetreten. %s"
 msgid "There was an error accessing file %s."
 msgstr "Beim Zugriff auf die Datei %s ist ein Fehler aufgetreten."
 
-#: src/olympia/files/utils.py:343
+#: src/olympia/files/utils.py:340
 msgid "Could not parse uploaded file."
 msgstr "Hochgeladene Datei konnte nicht geparst werden."
 
-#: src/olympia/files/utils.py:380
+#: src/olympia/files/utils.py:377
 msgid "Invalid file name in archive: {0}"
 msgstr "Ungültiger Dateiname im Archiv: {0}"
 
-#: src/olympia/files/utils.py:388
+#: src/olympia/files/utils.py:385
 msgid "File exceeding size limit in archive: {0}"
 msgstr "Datei überschreitet Größenbeschränkung im Archiv: {0}"
 
-#: src/olympia/files/utils.py:439
+#: src/olympia/files/utils.py:436
 msgid "Invalid archive."
 msgstr "Ungültiges Archiv."
 
-#: src/olympia/files/utils.py:529 src/olympia/files/utils.py:532
+#: src/olympia/files/utils.py:526 src/olympia/files/utils.py:529
 msgid "Could not parse the manifest file."
 msgstr "Manifest-Datei konnte nicht verarbeitet werden."
 
-#: src/olympia/files/utils.py:551
+#: src/olympia/files/utils.py:548
 msgid "Could not find an add-on ID."
 msgstr "Es wurde keine Add-on-ID gefunden."
 
-#: src/olympia/files/utils.py:554
+#: src/olympia/files/utils.py:551
 msgid "Add-on ID must be 64 characters or less."
 msgstr "Add-on-ID darf höchstens 64 Zeichen lang sein."
 
-#: src/olympia/files/utils.py:556
+#: src/olympia/files/utils.py:553
 msgid "Add-on ID doesn't match add-on."
 msgstr "Add-on-ID passt nicht zum Add-on."
 
-#: src/olympia/files/utils.py:564
+#: src/olympia/files/utils.py:561
 msgid "Duplicate add-on ID found."
 msgstr "Doppelte Add-on-ID gefunden."
 
-#: src/olympia/files/utils.py:567
+#: src/olympia/files/utils.py:564
 msgid "Version numbers should have fewer than 32 characters."
 msgstr "Versionsnummern sollten weniger als 32 Zeichen haben."
 
-#: src/olympia/files/utils.py:570
+#: src/olympia/files/utils.py:567
 msgid "Version numbers should only contain letters, numbers, and these punctuation characters: +*.-_."
 msgstr "Versionsnummern sollten nur Buchstaben, Zahlen und diese Zeichen enthalten: +*.-_."
 
-#: src/olympia/files/utils.py:587
+#: src/olympia/files/utils.py:584
 msgid "<em:type> doesn't match add-on"
 msgstr "<em:type> passt nicht zum Add-on"
 
@@ -8849,6 +8685,10 @@ msgstr "Keine Dateien in der hochgeladenen Datei"
 #: src/olympia/files/templates/files/viewer.html:134
 msgid "Fetching file."
 msgstr "Datei wird geholt."
+
+#: src/olympia/legacy_api/views.py:255
+msgid "Not implemented yet."
+msgstr "Noch nicht implementiert."
 
 #: src/olympia/lib/constants.py:6
 msgid "United Arab Emirates Dirham"
@@ -9506,10 +9346,6 @@ msgstr "Sambischer Kwacha"
 msgid "Zimbabwe Dollar"
 msgstr "Zimbabwe-Dollar"
 
-#: src/olympia/lib/video/ffmpeg.py:112 src/olympia/lib/video/totem.py:81
-msgid "Videos must be in WebM."
-msgstr "Videos müssen im WebM-Format vorliegen."
-
 #: src/olympia/pages/templates/pages/about.lhtml:3 src/olympia/pages/templates/pages/about.lhtml:10
 msgid "About Mozilla Add-ons"
 msgstr "Über Mozilla Add-ons"
@@ -9521,7 +9357,7 @@ msgstr "Was ist diese Website?"
 #: src/olympia/pages/templates/pages/about.lhtml:13
 msgid ""
 "addons.mozilla.org, commonly known as \"AMO\", is Mozilla's official site for add-ons to Mozilla software, such as Firefox, Thunderbird, and SeaMonkey. Add-ons let you add new features and change "
-"the way your browser or application works.  Take a look around and explore the thousands of ways to customize the way you do things online."
+"the way your browser or application works. Take a look around and explore the thousands of ways to customize the way you do things online."
 msgstr ""
 "addons.mozilla.org, üblicherweise „AMO“ genannt, ist Mozillas offizielle Website für Add-ons für Mozilla-Software, wie Firefox, Thunderbird und SeaMonkey. Mit Add-ons können Sie Ihrem Browser neue "
 "Funktionen hinzufügen und die Funktionsweise Ihrer Anwendung anpassen. Sehen Sie sich um und entdecken Sie die tausenden von Möglichkeiten, Ihre Online-Aktivitäten anzupassen."
@@ -9905,7 +9741,7 @@ msgstr "Kann ich eine JavaScript-Bibliothek wie jQuery, MooTools oder Prototype 
 msgid ""
 "Yes. It's possible, but some of the functionality provided by these libraries are available through XPCOM, XUL, and JavaScript. In addition, authors should take care if libraries modify primitive "
 "object prototypes (String.prototype, Date.prototype, etc.) and/or define global functions (eg. the $ function). These are prone to cause conflict with other add-ons, in particular if different add-"
-"ons use different versions of libraries and so on. Developers need to be very, very careful with using them.  Mozilla does not offer documentation on using them to build add-ons."
+"ons use different versions of libraries and so on. Developers need to be very, very careful with using them. Mozilla does not offer documentation on using them to build add-ons."
 msgstr ""
 "Ja. Es ist möglich, aber einige der von diesen Bibliotheken bereitgestellten Funktionen sind über XPCOM, XUL und JavaScript verfügbar. Außerdem müssen Autoren aufpassen, wenn Bibliotheken primitive "
 "Objektprototypen (String.prototype, Date.prototype usw.) modifizieren und/oder globale Funktionen (wie die $-Funktion) definieren. Dies verursacht häufig Probleme mit anderen Add-ons, besonders, "
@@ -10033,8 +9869,8 @@ msgstr "Kann ich mein Add-on selbst hosten?"
 #, python-format
 msgid ""
 "Yes. Many developers choose to host their own add-ons. Choosing to host your add-on on <a href=\"%(amo_url)s\">Mozilla's add-on site</a>, though, allows for much greater exposure to your add-on due "
-"to the large volume of visitors to the site.  <a href=\"%(md_url)s\">mozdev.org</a> offers free project hosting for Mozilla applications and extensions providing developers with tools to help "
-"manage source code, version control, bug tracking and documentation."
+"to the large volume of visitors to the site. <a href=\"%(md_url)s\">mozdev.org</a> offers free project hosting for Mozilla applications and extensions providing developers with tools to help manage "
+"source code, version control, bug tracking and documentation."
 msgstr ""
 "Ja. Viele Entwickler hosten Ihre Add-on selbst. Wenn Sie Ihr Add-on auf <a href=\"%(amo_url)s\">Mozillas Add-on-Website</a> hosten, habe Sie durch die vielen Besucher auf dieser Website aber mehr "
 "Reichweite. <a href=\"%(md_url)s\">mozdev.org</a> bietet kostenloses Hosting für Projekte für Mozilla-Anwendungen und -Erweiterungen und bietet Entwicklern Werkzeuge, mit denen sie Quelltext und "
@@ -10090,7 +9926,7 @@ msgstr "Hat Mozilla eine Richtlinie dazu, was eine akzeptable Einreichung ist?"
 #: src/olympia/pages/templates/pages/dev_faq.html:314
 #, python-format
 msgid ""
-"Yes. Mozilla's <a href=\"%(p_url)s\">Add-on Policy</a> describes what is an acceptable submission. This policy is subject to change without notice.  In addition, the AMO editorial team uses the <a "
+"Yes. Mozilla's <a href=\"%(p_url)s\">Add-on Policy</a> describes what is an acceptable submission. This policy is subject to change without notice. In addition, the AMO editorial team uses the <a "
 "href=\"%(g_url)s\">Editors Reviewing Guide</a> to ensure that your add-on meets specific guidelines for functionality and security."
 msgstr ""
 "Ja. Mozillas <a href=\"%(p_url)s\">Add-on-Richtlinien</a> beschreiben, welche Einreichungen erlaubt sind. Diese Richtlinien können sich ohne Benachrichtigung ändern. Außerdem nutzt das AMO-"
@@ -10226,7 +10062,7 @@ msgstr "Anzahl der gefundenen Problembereiche"
 #: src/olympia/pages/templates/pages/dev_faq.html:434
 #, python-format
 msgid ""
-"This is why it's very important to read the <a href=\"%(g_url)s\">Editors Reviewing Guide</a> to ensure that your add-on is setup as expected.  It's also a good idea to read the blog post, <a href="
+"This is why it's very important to read the <a href=\"%(g_url)s\">Editors Reviewing Guide</a> to ensure that your add-on is setup as expected. It's also a good idea to read the blog post, <a href="
 "\"%(blog_url)s\">Successfully Getting your Add-on Reviewed</a> which provides excellent insight into ensuring a smooth review of your add-on."
 msgstr ""
 "Deswegen ist es wichtig, den <a href=\"%(g_url)s\">Überprüfungsleitfaden für Redakteure</a> zu lesen, damit Ihr Add-on wie erwartet eingerichtet wird. Auch das Lesen des Blog-Beitrags <a href="
@@ -10346,7 +10182,7 @@ msgstr ""
 
 #: src/olympia/pages/templates/pages/dev_faq.html:572
 msgid ""
-"Free Software Foundation provides short summaries of the key open source licenses, including whether the license qualifies as a free software license or a copyleft license.  Also includes a "
+"Free Software Foundation provides short summaries of the key open source licenses, including whether the license qualifies as a free software license or a copyleft license. Also includes a "
 "discussion of what constitutes a free software license or a copyleft license (e.g., a Copyleft license is a general method for making a program or other work free, and requiring all modified and "
 "extended versions of the program to be free as well.)"
 msgstr ""
@@ -10560,19 +10396,13 @@ msgid "Add-on Gallery"
 msgstr "Add-on-Galerie"
 
 #: src/olympia/pages/templates/pages/faq.html:171
-msgid ""
-"How do I choose between add-ons that seem to do the same\n"
-"    thing?"
+msgid "How do I choose between add-ons that seem to do the same thing?"
 msgstr "Wie wähle ich zwischen Add-ons, die scheinbar das gleiche tun?"
 
-#: src/olympia/pages/templates/pages/faq.html:173
+#: src/olympia/pages/templates/pages/faq.html:172
 msgid ""
-"There are often several add-ons that have similar features. To\n"
-"    figure out which is right for you, read the entire description of the\n"
-"    add-on and view its screenshots. If there are still several in the running,\n"
-"    read through the add-on's ratings, user reviews, and statistics to see\n"
-"    which is most liked by other users. Remember that you can also just try\n"
-"    out both and see which you like better."
+"There are often several add-ons that have similar features. To figure out which is right for you, read the entire description of the add-on and view its screenshots. If there are still several in "
+"the running, read through the add-on's ratings, user reviews, and statistics to see which is most liked by other users. Remember that you can also just try out both and see which you like better."
 msgstr ""
 "Oftmals gibt es Add-ons, die ähnliche Funktionen haben. Um das richtige zu finden, lesen Sie die ganze Beschreibung des Add-ons und betrachten Sie die Screenshots. Wenn dann immer noch mehrere im "
 "Rennen sind, lesen Sie die Bewertungen, Meinungen von Nutzern und Statistiken des Add-ons, um zu sehen, welches beliebter ist. Sie können auch einfach beide ausprobieren und dann entscheiden, "
@@ -10624,40 +10454,34 @@ msgid "How much do add-ons cost to purchase?"
 msgstr "Was kosten Add-ons?"
 
 #: src/olympia/pages/templates/pages/faq.html:207
-msgid ""
-"Add-ons hosted in our gallery are free unless clearly marked\n"
-"    otherwise."
+msgid "Add-ons hosted in our gallery are free unless clearly marked otherwise."
 msgstr "In unserer Galerie gehostete Add-ons sind frei, sofern nicht eindeutig anderes vermerkt ist."
 
-#: src/olympia/pages/templates/pages/faq.html:210
+#: src/olympia/pages/templates/pages/faq.html:209
 msgid "What does it mean when an add-on asks for contributions?"
 msgstr "Was bedeutet es, wenn ein Add-on um Spenden bittet?"
 
-#: src/olympia/pages/templates/pages/faq.html:211
+#: src/olympia/pages/templates/pages/faq.html:210
 msgid ""
-"Some add-on authors request users who enjoy an add-on to\n"
-"        contribute to its development by making a monetary contribution. These\n"
-"        contributions go directly to the developer unless a third party is\n"
-"        indicated, such as the non-profit Mozilla Foundation."
+"Some add-on authors request users who enjoy an add-on to contribute to its development by making a monetary contribution. These contributions go directly to the developer unless a third party is "
+"indicated, such as the non-profit Mozilla Foundation."
 msgstr ""
 "Manche Add-on-Autoren bitten Nutzer, die ein Add-on nützlich finden, die Entwicklung finanziell zu unterstützen. Diese Spenden gehen direkt an den Entwickler, es sei denn es ist ein Dritter "
 "angegeben, wie die gemeinnützige Mozilla Foundation."
 
-#: src/olympia/pages/templates/pages/faq.html:216
+#: src/olympia/pages/templates/pages/faq.html:215
 msgid "What are beta add-ons?"
 msgstr "Was sind Add-ons in der Betaphase?"
 
-#: src/olympia/pages/templates/pages/faq.html:218
+#: src/olympia/pages/templates/pages/faq.html:217
 msgid ""
-"Beta add-ons are unreviewed versions which represent the\n"
-"        latest work of an add-on author. While different authors have different\n"
-"        standards for beta code quality, you should assume that these add-ons\n"
-"        are less stable than the general add-on releases."
+"Beta add-ons are unreviewed versions which represent the latest work of an add-on author. While different authors have different standards for beta code quality, you should assume that these add-"
+"ons are less stable than the general add-on releases."
 msgstr ""
 "Beta-Add-ons sind nicht überprüfte Versionen, die die neueste Arbeit eines Add-on-Autors darstellen. Je nach Autor unterscheidet sich die Qualität von Beta-Quelltext, aber Sie sollten davon "
 "ausgehen, dass diese Add-ons üblicherweise weniger stabil sind, als fertige Versionen."
 
-#: src/olympia/pages/templates/pages/faq.html:222
+#: src/olympia/pages/templates/pages/faq.html:221
 msgid ""
 "Please note that when you install an add-on from the \"Beta Version\" section of an add-on's listing, you will continue to receive updates for that add-on as they become available. Like the initial "
 "version you installed, all beta releases are unreviewed by Mozilla and may harm your computer."
@@ -10665,48 +10489,41 @@ msgstr ""
 "Bitte beachten Sie, dass Sie bei der Installation der \"Beta-Version\" eines Add-ons weiterhin Updates für dieses Add-on erhalten, wenn sie verfügbar sind. Ebenso wie die Version, die Sie "
 "installiert haben, sind auch alle anderen Beta-Veröffentlichungen nicht von Mozilla geprüft und können Ihren Computer beschädigen."
 
-#: src/olympia/pages/templates/pages/faq.html:229
-msgid ""
-"What does it mean when an add-on is flagged as\n"
-"    slow?"
+#: src/olympia/pages/templates/pages/faq.html:228
+msgid "What does it mean when an add-on is flagged as slow?"
 msgstr "Was bedeutet es, wenn ein Add-on als langsam gekennzeichnet ist?"
 
-#: src/olympia/pages/templates/pages/faq.html:231
-msgid ""
-"Most add-ons load code and resources at the same time Firefox\n"
-"        is starting up. In most cases the impact in start-up time is minimal,\n"
-"        but some add-ons can cause a noticeable slowdown."
+#: src/olympia/pages/templates/pages/faq.html:229
+msgid "Most add-ons load code and resources at the same time Firefox is starting up. In most cases the impact in start-up time is minimal, but some add-ons can cause a noticeable slowdown."
 msgstr ""
 "Die meisten Add-ons laden Quelltext und Ressourcen während Firefox startet. Meistens hat dies nur wenige Auswirkungen auf die Startzeit, aber manche Add-ons führen zu merklichen Verzögerungen."
 
-#: src/olympia/pages/templates/pages/faq.html:236
+#: src/olympia/pages/templates/pages/faq.html:234
 msgid "How do I report an inappropriate or spam user review?"
 msgstr "Wie melde ich eine unpassende Bewertung oder Spam?"
 
-#: src/olympia/pages/templates/pages/faq.html:237
+#: src/olympia/pages/templates/pages/faq.html:235
 msgid ""
-"To report a user review of an add-on, log in with your account\n"
-"    and visit the add-on's reviews page. Find the review you wish to report,\n"
-"    click \"Report this review\" and select a reason. Our editorial team will\n"
-"    investigate the review and take appropriate action."
+"To report a user review of an add-on, log in with your account and visit the add-on's reviews page. Find the review you wish to report, click \"Report this review\" and select a reason. Our "
+"editorial team will investigate the review and take appropriate action."
 msgstr ""
 "Um eine Benutzerbewertung eines Add-ons zu melden, melden Sie sich mit Ihrem Benutzerkonto an und öffnen Sie die Seite mit den Bewertungen. Suche die die betreffende Bewertung, klicken Sie auf "
 "„Diese Bewertung als unpassend markieren“ und wählen Sie einen Grund aus. Unser Redakteursteam überprüft die Meldung und handelt entsprechend."
 
-#: src/olympia/pages/templates/pages/faq.html:242
+#: src/olympia/pages/templates/pages/faq.html:240
 msgid "How do I report a bug or contact the Mozilla Add-ons team?"
 msgstr "Wie melde ich einen Bug oder kontaktiere das Mozilla-Add-ons-Team?"
 
-#: src/olympia/pages/templates/pages/faq.html:243
+#: src/olympia/pages/templates/pages/faq.html:241
 #, python-format
 msgid "Please visit our <a href=\"%(contact_url)s\">Contact page</a>."
 msgstr "Bitte besuchen Sie unsere <a href=\"%(contact_url)s\">Kontakt-Seite</a>."
 
-#: src/olympia/pages/templates/pages/faq.html:246
+#: src/olympia/pages/templates/pages/faq.html:244
 msgid "What is a Source Code License?"
 msgstr "Was ist eine Quelltext-Lizenz?"
 
-#: src/olympia/pages/templates/pages/faq.html:247
+#: src/olympia/pages/templates/pages/faq.html:245
 #, python-format
 msgid ""
 "The source code used to create an add-on is an exclusive copyright of the add-on author, unless otherwise declared in a source code license. Many add-ons on this site have <a href=\"%(url)s\" lang="
@@ -10717,42 +10534,42 @@ msgstr ""
 "ons auf dieser Webseite haben eine <a href=\"%(url)s\" lang=\"de\">Open-Source-Lizenz</a>, die den Quelltext öffentlich zur Verfügung stellt, so dass er unter den vom Autor angegebenen Bedingungen "
 "kopiert und weiterverwendet werden kann. Viele Autoren entscheiden sich für gut bekannte Open-Source-Lizenzen wie die GPL- oder BSD-Lizenzen, anstatt ihre eigene zu erstellen."
 
-#: src/olympia/pages/templates/pages/faq.html:256
+#: src/olympia/pages/templates/pages/faq.html:254
 #, python-format
 msgid "Firefox and other Mozilla software are <a href=\"%(url)s\">open source</a>."
 msgstr "Firefox und andere Mozilla-Programme sind <a href=\"%(url)s\">Open-Source</a>."
 
-#: src/olympia/pages/templates/pages/faq.html:264
+#: src/olympia/pages/templates/pages/faq.html:262
 msgid "Collections and Favorites"
 msgstr "Sammlungen und Favoriten"
 
-#: src/olympia/pages/templates/pages/faq.html:267
+#: src/olympia/pages/templates/pages/faq.html:265
 msgid "What is a collection?"
 msgstr "Was ist eine Sammlung?"
 
-#: src/olympia/pages/templates/pages/faq.html:268
+#: src/olympia/pages/templates/pages/faq.html:266
 msgid "Collections are groups of related add-ons created by users to share."
 msgstr "Sammlungen sind Gruppen von Add-ons, die Benutzer angelegt haben, um sie mit anderen zu teilen."
 
-#: src/olympia/pages/templates/pages/faq.html:270
+#: src/olympia/pages/templates/pages/faq.html:268
 msgid "What is the My Favorites collection?"
 msgstr "Was ist die \"Meine Favoriten\"-Sammlung?"
 
-#: src/olympia/pages/templates/pages/faq.html:271
+#: src/olympia/pages/templates/pages/faq.html:269
 msgid "Favorite add-ons are add-ons that you have bookmarked to easily get back to later. You can add an add-on to your favorites collection by clicking \"Add to favorites\" on its details page."
 msgstr ""
 "Lieblings-Add-ons sind Add-ons, die Sie mit einem Lesezeichen versehen haben, um sie später schnell wiederzufinden. Sie können ein Add-on zu Ihrer Lieblingsliste hinzufügen, indem Sie \"zu "
 "Favoriten hinzufügen\" auf dessen Details-Seite klicken."
 
-#: src/olympia/pages/templates/pages/faq.html:275 src/olympia/templates/menu_links.html:13 src/olympia/templates/impala/header_title.html:17
+#: src/olympia/pages/templates/pages/faq.html:273 src/olympia/templates/menu_links.html:13 src/olympia/templates/impala/header_title.html:17
 msgid "Mobile Add-ons"
 msgstr "Mobile Add-ons"
 
-#: src/olympia/pages/templates/pages/faq.html:278
+#: src/olympia/pages/templates/pages/faq.html:276
 msgid "What are mobile add-ons?"
 msgstr "Was sind mobile Add-ons?"
 
-#: src/olympia/pages/templates/pages/faq.html:279
+#: src/olympia/pages/templates/pages/faq.html:277
 #, python-format
 msgid ""
 "Mobile add-ons work with <a href=\"%(mobile_url)s\">Firefox for Mobile</a> and add or modify functionality just like desktop add-ons. You can find add-ons that work with Firefox for Mobile in our "
@@ -10761,20 +10578,20 @@ msgstr ""
 "Mobile add-ons funktionieren mit <a href=\"%(mobile_url)s\">Firefox für Mobile</a> und fügen Funktionen hinzu bzw. verändern sie genau so wie Desktop-Add-ons. Sie können Add-ons, die mit Firefox "
 "für Mobile kompatibel sind, in unserer <a href=\"%(gallery_url)s\">Galerie</a> finden."
 
-#: src/olympia/pages/templates/pages/faq.html:288
+#: src/olympia/pages/templates/pages/faq.html:286
 msgid "Developer Topics"
 msgstr "Entwickler-Themen"
 
-#: src/olympia/pages/templates/pages/faq.html:289
+#: src/olympia/pages/templates/pages/faq.html:287
 #, python-format
 msgid "Please see our <a href=\"%(faq_url)s\">Developer FAQ</a> and <a href=\"%(hub_url)s\">Developer Hub</a> for answers to add-on developer-related questions."
 msgstr "Bitte lesen Sie unsere <a href=\"%(faq_url)s\">Developer FAQ</a> und unseren <a href=\"%(hub_url)s\">Developer Hub</a> für Antworten auf Fragen von Add-on-Entwicklern."
 
-#: src/olympia/pages/templates/pages/faq.html:294
+#: src/olympia/pages/templates/pages/faq.html:292
 msgid "Still have questions?"
 msgstr "Haben Sie immer noch Fragen?"
 
-#: src/olympia/pages/templates/pages/faq.html:295
+#: src/olympia/pages/templates/pages/faq.html:293
 #, python-format
 msgid "For general Firefox support, visit our <a href=\"%(sumo_url)s\">support website</a>. For general add-on and website questions, visit our <a href=\"%(forum_url)s\">forum</a>."
 msgstr ""
@@ -10927,7 +10744,7 @@ msgstr "Sunbird wurde eingestellt"
 
 #: src/olympia/pages/templates/pages/sunbird.html:29
 msgid ""
-"Development on the Sunbird project has halted and its final release was on March 30, 2010.  We've been proud to host Sunbird add-ons on this site but as the project is no longer maintained we have "
+"Development on the Sunbird project has halted and its final release was on March 30, 2010. We've been proud to host Sunbird add-ons on this site but as the project is no longer maintained we have "
 "disabled our support for the add-ons."
 msgstr ""
 "Die Entwicklung des Sunbird-Projekts wurde eingestellt und die letzte Version erschien am 30. März 2010. Wir haben gerne Sunbird-Add-ons angeboten, aber da das Projekt nicht mehr betreut wird, "
@@ -11007,7 +10824,7 @@ msgstr "Eine Bewertung für {0} schreiben"
 #, python-format
 msgid ""
 "<h2>Keep these tips in mind:</h2> <ul> <li> Write like you're telling a friend about your experience with the add-on. Give specifics and helpful details, such as what features you liked and/or "
-"disliked, how easy to use it is, and any disadvantages it has.  Avoid generic language such as calling it \"Great\" or \"Bad\" unless you can give reasons why you believe this is so. </li> <li> "
+"disliked, how easy to use it is, and any disadvantages it has. Avoid generic language such as calling it \"Great\" or \"Bad\" unless you can give reasons why you believe this is so. </li> <li> "
 "Please do not post bug reports in reviews. We do not make your email address available to add-on developers and they may need to contact you to help resolve your issue. See the <a href=\"%(support)s"
 "\">support section</a> to find out where to get assistance for this add-on. </li> <li>Please keep reviews clean, avoid the use of improper language and do not post any personal information. </li> </"
 "ul> <p>Please read the <a href=\"%(guide)s\" target=\"_blank\">Review Guidelines</a> for more detail about user add-on reviews.</p>"
@@ -11265,16 +11082,16 @@ msgstr "{0} Add-ons"
 
 #. L10n: {0} is an application, such as Firefox. This means "any version of
 #. Firefox."
-#: src/olympia/search/views.py:554
+#: src/olympia/search/views.py:547
 msgid "Any {0}"
 msgstr "Alle Versionen von {0}"
 
 #. L10n: "All Systems" means show everything regardless of platform.
-#: src/olympia/search/views.py:589
+#: src/olympia/search/views.py:582
 msgid "All Systems"
 msgstr "Alle Systeme"
 
-#: src/olympia/search/views.py:600
+#: src/olympia/search/views.py:593
 msgid "All Tags"
 msgstr "Alle Schlagwörter"
 
@@ -11448,31 +11265,31 @@ msgstr "Dieses Add-on weiterempfehlen"
 msgid "Share this Collection"
 msgstr "Diese Sammlung weiterempfehlen"
 
-#: src/olympia/signing/views.py:30 src/olympia/templates/base.html:75 src/olympia/templates/impala/base.html:115
+#: src/olympia/signing/views.py:33 src/olympia/templates/base.html:71 src/olympia/templates/impala/base.html:112
 msgid "Some features are temporarily disabled while we perform website maintenance. We'll be back to full capacity shortly."
 msgstr "Einige Funktionen sind während der Wartungsarbeiten an dieser Website vorübergehend abgeschaltet. Wir werden die volle Funktionsfähigkeit bald wiederherstellen."
 
-#: src/olympia/signing/views.py:53
+#: src/olympia/signing/views.py:56
 msgid "Could not find add-on with id \"{}\"."
 msgstr "Es wurde kein Add-on mit der ID „{}“ gefunden."
 
-#: src/olympia/signing/views.py:67
+#: src/olympia/signing/views.py:70
 msgid "You do not own this addon."
 msgstr "Sie sind nicht der Besitzer dieses Add-ons."
 
-#: src/olympia/signing/views.py:82
+#: src/olympia/signing/views.py:87
 msgid "Missing \"upload\" key in multipart file data."
 msgstr "Fehlender „Upload“-Schlüssel in mehrteiligen Dateidaten."
 
-#: src/olympia/signing/views.py:96
+#: src/olympia/signing/views.py:101
 msgid "Version does not match the manifest file."
 msgstr "Version passt nicht zur Manifest-Datei."
 
-#: src/olympia/signing/views.py:100
+#: src/olympia/signing/views.py:105
 msgid "Version already exists."
 msgstr "Version existiert bereits."
 
-#: src/olympia/signing/views.py:136
+#: src/olympia/signing/views.py:141
 msgid "No uploaded file for that addon and version."
 msgstr "Keine hochgeladene Datei für dieses Add-on und diese Version."
 
@@ -11585,89 +11402,89 @@ msgstr "{0} :: Statistik-Übersicht"
 msgid "Statistics Dashboard :: Add-ons for {0}"
 msgstr "Statistik-Übersicht :: Add-ons für {0}"
 
-#: src/olympia/stats/templates/stats/stats.html:30
-msgid "Controls:"
-msgstr "Steuerung:"
-
-#: src/olympia/stats/templates/stats/stats.html:33
-msgid "reset zoom"
-msgstr "Zoom zurücksetzen"
-
-#: src/olympia/stats/templates/stats/stats.html:40
-msgid "Group by:"
-msgstr "Gruppieren nach:"
-
-#: src/olympia/stats/templates/stats/stats.html:42
-msgid "day"
-msgstr "Tag"
-
-#: src/olympia/stats/templates/stats/stats.html:45
-msgid "week"
-msgstr "Woche"
-
-#: src/olympia/stats/templates/stats/stats.html:48
-msgid "month"
-msgstr "Monat"
-
-#: src/olympia/stats/templates/stats/stats.html:54
-msgid "For last:"
-msgstr "Für die letzten:"
-
-#: src/olympia/stats/templates/stats/stats.html:57
-msgid "7 days"
-msgstr "7 Tage"
-
-#: src/olympia/stats/templates/stats/stats.html:60
-msgid "30 days"
-msgstr "30 Tage"
-
-#: src/olympia/stats/templates/stats/stats.html:63
-msgid "90 days"
-msgstr "90 Tage"
-
-#: src/olympia/stats/templates/stats/stats.html:66
-msgid "365 days"
-msgstr "365 Tage"
-
-#: src/olympia/stats/templates/stats/stats.html:69
-msgid "Custom..."
-msgstr "Benutzerdefiniert …"
-
 #. {0} is an add-on name
-#: src/olympia/stats/templates/stats/stats.html:88 src/olympia/stats/templates/stats/stats.html:91
+#: src/olympia/stats/templates/stats/stats.html:44 src/olympia/stats/templates/stats/stats.html:47
 msgid "Statistics for {0}"
 msgstr "Statistiken für {0}"
 
-#: src/olympia/stats/templates/stats/stats.html:94
+#: src/olympia/stats/templates/stats/stats.html:50
 msgid "Statistics Dashboard"
 msgstr "Statistische Übersicht"
 
-#: src/olympia/stats/templates/stats/stats.html:104
+#: src/olympia/stats/templates/stats/stats.html:57
+msgid "Controls:"
+msgstr "Steuerung:"
+
+#: src/olympia/stats/templates/stats/stats.html:60
+msgid "reset zoom"
+msgstr "Zoom zurücksetzen"
+
+#: src/olympia/stats/templates/stats/stats.html:67
+msgid "Group by:"
+msgstr "Gruppieren nach:"
+
+#: src/olympia/stats/templates/stats/stats.html:69
+msgid "day"
+msgstr "Tag"
+
+#: src/olympia/stats/templates/stats/stats.html:72
+msgid "week"
+msgstr "Woche"
+
+#: src/olympia/stats/templates/stats/stats.html:75
+msgid "month"
+msgstr "Monat"
+
+#: src/olympia/stats/templates/stats/stats.html:81
+msgid "For last:"
+msgstr "Für die letzten:"
+
+#: src/olympia/stats/templates/stats/stats.html:84
+msgid "7 days"
+msgstr "7 Tage"
+
+#: src/olympia/stats/templates/stats/stats.html:87
+msgid "30 days"
+msgstr "30 Tage"
+
+#: src/olympia/stats/templates/stats/stats.html:90
+msgid "90 days"
+msgstr "90 Tage"
+
+#: src/olympia/stats/templates/stats/stats.html:93
+msgid "365 days"
+msgstr "365 Tage"
+
+#: src/olympia/stats/templates/stats/stats.html:96
+msgid "Custom..."
+msgstr "Benutzerdefiniert …"
+
+#: src/olympia/stats/templates/stats/stats.html:106
 msgid "Statistics processing is currently disabled, so recent data is unavailable. The statistics are still being collected and this page will be updated soon with the missing data."
 msgstr "Die Statistikverarbeitung ist aktuell deaktiviert, daher sind die neuen Daten nicht verfügbar. Die Statistik wird dennoch erstellt und diese Seite wird bald durch die fehlenden Daten ergänzt."
 
-#: src/olympia/stats/templates/stats/stats.html:110
+#: src/olympia/stats/templates/stats/stats.html:112
 msgid "Loading the latest data&hellip;"
 msgstr "Die neuesten Daten werden geladen&hellip;"
 
-#: src/olympia/stats/templates/stats/stats.html:142 src/olympia/stats/templates/stats/reports/overview.html:25 src/olympia/stats/templates/stats/reports/overview.html:37
+#: src/olympia/stats/templates/stats/stats.html:144 src/olympia/stats/templates/stats/reports/overview.html:25 src/olympia/stats/templates/stats/reports/overview.html:37
 #: src/olympia/stats/templates/stats/reports/overview.html:49
 msgid "No data available."
 msgstr "Keine Daten verfügbar."
 
-#: src/olympia/stats/templates/stats/stats.html:177
+#: src/olympia/stats/templates/stats/stats.html:179
 msgid "This dashboard is currently <b>public</b>."
 msgstr "Diese Übersicht ist derzeit <b>öffentlich</b>."
 
-#: src/olympia/stats/templates/stats/stats.html:179
+#: src/olympia/stats/templates/stats/stats.html:181
 msgid "Contribution stats are currently <b>private</b>."
 msgstr "Spendenstatistiken sind derzeit <b>privat</b>."
 
-#: src/olympia/stats/templates/stats/stats.html:182
+#: src/olympia/stats/templates/stats/stats.html:184
 msgid "This dashboard is currently <b>private</b>."
 msgstr "Diese Übersicht ist derzeit <b>privat</b>."
 
-#: src/olympia/stats/templates/stats/stats.html:185
+#: src/olympia/stats/templates/stats/stats.html:187
 msgid "Change settings."
 msgstr "Einstellungen ändern."
 
@@ -11831,15 +11648,6 @@ msgstr "Registrierte Benutzer nach Datum"
 msgid "Application versions by Date"
 msgstr "App-Versionen nach Datum"
 
-#: src/olympia/tags/templates/tags/top_cloud.html:4
-msgid "Top {0} Tags"
-msgstr "Die {0} beliebtesten Tags"
-
-#. {0} is the current application name
-#: src/olympia/tags/templates/tags/top_cloud.html:14
-msgid "{0} Top Tags"
-msgstr "Beliebteste Tags für {0}"
-
 #: src/olympia/templates/amo_footer.html:6 src/olympia/templates/includes/lang_switcher.html:2
 msgid "Other languages"
 msgstr "Andere Sprachen"
@@ -11848,11 +11656,11 @@ msgstr "Andere Sprachen"
 msgid "Mozilla Add-ons"
 msgstr "Mozilla Add-ons"
 
-#: src/olympia/templates/base.html:91 src/olympia/templates/impala/base.html:81
+#: src/olympia/templates/base.html:89 src/olympia/templates/impala/base.html:78
 msgid "Find add-ons for other applications"
 msgstr "Add-ons für andere Anwendungen finden"
 
-#: src/olympia/templates/base.html:92 src/olympia/templates/impala/base.html:81
+#: src/olympia/templates/base.html:90 src/olympia/templates/impala/base.html:78
 msgid "Other Applications"
 msgstr "Andere Anwendungen"
 
@@ -11877,7 +11685,7 @@ msgid "View Mobile Site"
 msgstr "Zur mobilen Version"
 
 #: src/olympia/templates/copyright.html:7
-msgid "Site Status "
+msgid "Site Status"
 msgstr "Status der Website"
 
 #: src/olympia/templates/footer.html:3
@@ -11979,35 +11787,35 @@ msgstr "Willkommen, {0}"
 msgid "<a href=\"%(reg)s\">Register</a> or <a href=\"%(login)s\">Log in</a>"
 msgstr "<a href=\"%(reg)s\">Neu registrieren</a> oder <a href=\"%(login)s\">anmelden</a>"
 
-#: src/olympia/templates/impala/base.html:126
+#: src/olympia/templates/impala/base.html:123
 #, python-format
 msgid "To try the thousands of add-ons available here, download <a href=\"%(url)s\">Mozilla Firefox</a>, a fast, free way to surf the Web!"
 msgstr "Um die Tausenden von hier verfügbaren Add-ons auszuprobieren, laden Sie <a href=\"%(url)s\">Mozilla Firefox</a> herunter, eine schnelle, kostenlose Möglichkeit, im Internet zu surfen!"
 
-#: src/olympia/templates/impala/base.html:138
+#: src/olympia/templates/impala/base.html:135
 #, python-format
 msgid "Add-ons is switching to Firefox Accounts for login. <a href=\"%(url)s\" class=\"fxa-login\">Sign in now to transfer your account.</a>"
 msgstr "Add-ons wechselt zur Anmeldung auf Firefox-Konten. <a href=\"%(url)s\" class=\"fxa-login\">Melden Sie sich jetzt an, um Ihr Konto zu übertragen.</a>"
 
 #. {0} is an application, such as Firefox.
-#: src/olympia/templates/impala/base.html:148
+#: src/olympia/templates/impala/base.html:145
 msgid "Welcome to {0} Add-ons."
 msgstr "Willkommen bei den {0}-Add-ons."
 
-#: src/olympia/templates/impala/base.html:151
+#: src/olympia/templates/impala/base.html:148
 msgid "Choose from thousands of extra features and styles to make Firefox your own."
 msgstr "Wählen Sie aus Tausenden von Zusatzfunktionen und Stilen, um sich Firefox zu Eigen zu machen."
 
-#: src/olympia/templates/impala/base.html:156
+#: src/olympia/templates/impala/base.html:153
 #, python-format
 msgid "Add extra features and styles to make %(app)s your own."
 msgstr "Fügen Sie Zusatzfunktionen und Stile hinzu, um sich %(app)s zu Eigen zu machen."
 
-#: src/olympia/templates/impala/base.html:164
+#: src/olympia/templates/impala/base.html:161
 msgid "On the go?"
 msgstr "Unterwegs?"
 
-#: src/olympia/templates/impala/base.html:166
+#: src/olympia/templates/impala/base.html:163
 msgid "Check out our <a class=\"mobile-link\" href=\"#\">Mobile Add-ons site</a>."
 msgstr "Sehen Sie sich unsere <a class=\"mobile-link\" href=\"#\">Website für Firefox-Mobile-Add-ons</a> an."
 
@@ -12233,19 +12041,19 @@ msgstr "Kein Benutzer mit dieser E-Mail-Adresse."
 
 #. L10n: {id} will be something like "13ad6a", just a random number
 #. to differentiate this user from other anonymous users.
-#: src/olympia/users/models.py:353
+#: src/olympia/users/models.py:362
 msgid "Anonymous user {id}"
 msgstr "Anonymer Nutzer {id}"
 
-#: src/olympia/users/models.py:410
+#: src/olympia/users/models.py:419
 msgid "Your account has been restricted"
 msgstr "Ihr Benutzerkonto wurde eingeschränkt"
 
-#: src/olympia/users/models.py:480
+#: src/olympia/users/models.py:489
 msgid "Please confirm your email address"
 msgstr "Bitte bestätigen Sie Ihre E-Mail-Adresse"
 
-#: src/olympia/users/models.py:506
+#: src/olympia/users/models.py:515
 msgid "My Mobile Add-ons"
 msgstr "Meine mobile Add-ons"
 
@@ -12531,7 +12339,7 @@ msgstr "Passwort"
 
 #: src/olympia/users/templates/users/edit.html:70
 #, python-format
-msgid "Change your password.  If you forgot your password, you can <a href=\"%(reset_url)s\">use the reset form</a>."
+msgid "Change your password. If you forgot your password, you can <a href=\"%(reset_url)s\">use the reset form</a>."
 msgstr "Ändern Sie Ihr Passwort. Wenn Sie Ihr Passwort vergessen haben, <a href=\"%(reset_url)s\">verwenden Sie das Formular zum Zurücksetzen.</a>"
 
 #: src/olympia/users/templates/users/edit.html:76
@@ -12551,7 +12359,7 @@ msgid "Profile"
 msgstr "Profil"
 
 #: src/olympia/users/templates/users/edit.html:100
-msgid "Give us a bit more information about yourself.  All these fields are optional, but they'll help other users get to know you better."
+msgid "Give us a bit more information about yourself. All these fields are optional, but they'll help other users get to know you better."
 msgstr "Erzählen Sie uns etwas mehr über Sie. Diese Felder sind optional, helfen anderen Nutzern aber, Sie besser kennenzulernen."
 
 #: src/olympia/users/templates/users/edit.html:124
@@ -12771,7 +12579,7 @@ msgid "Confirm password"
 msgstr "Passwort bestätigen"
 
 #: src/olympia/users/templates/users/pwreset_confirm.html:47
-msgid "The password reset link was invalid, possibly because it has already been used.  Please request a new password reset."
+msgid "The password reset link was invalid, possibly because it has already been used. Please request a new password reset."
 msgstr "Der Link zum Zurücksetzen des Passworts war ungültig, womöglich wurde er bereits verwendet. Bitte fordern Sie das Zurücksetzen des Passworts erneut an."
 
 #: src/olympia/users/templates/users/pwreset_request.html:15
@@ -12961,7 +12769,7 @@ msgstr "Wir konnten Ihr Abonnement nicht aufhebne"
 
 #: src/olympia/users/templates/users/unsubscribe.html:30
 #, python-format
-msgid "Unfortunately, we weren't able to unsubscribe you.  The link you clicked is invalid. However, you can unsubscribe still unsubscribe on your <a href=\"%(edit_url)s\">edit profile page</a>."
+msgid "Unfortunately, we weren't able to unsubscribe you. The link you clicked is invalid. However, you can unsubscribe still unsubscribe on your <a href=\"%(edit_url)s\">edit profile page</a>."
 msgstr ""
 "Leider funktionierte das Abbestellen des Abonnements nicht. Der angeklickte Link war ungültig. Sie können sich über Ihre <a href=\"%(edit_url)s\">Profil-bearbeiten-Seite</a> aber ebenfalls abmelden."
 
@@ -13016,15 +12824,15 @@ msgstr "%s Versionsgeschichte"
 msgid "Version History with Changelogs"
 msgstr "Versionsgeschichte mit Entwickler-Kommentaren"
 
-#: src/olympia/versions/models.py:314
+#: src/olympia/versions/models.py:313
 msgid "Add-on uses binary components."
 msgstr "Add-on verwendet binäre Komponenten."
 
-#: src/olympia/versions/models.py:317
+#: src/olympia/versions/models.py:316
 msgid "Add-on has opted into strict compatibility checking."
 msgstr "Add-on hat strikten Kompatibilitätstest aktiviert."
 
-#: src/olympia/versions/models.py:715
+#: src/olympia/versions/models.py:711
 msgid "{app} {min} and later"
 msgstr "{app} {min} und neuer"
 
@@ -13101,3 +12909,7 @@ msgstr "E-Mail senden, wenn abgeschlossen"
 #: src/olympia/zadmin/forms.py:105
 msgid "Log emails instead of sending"
 msgstr "E-Mails aufzeichnen und nicht versenden"
+
+#: src/olympia/zadmin/forms.py:215
+msgid "Deleted versions can`t be changed."
+msgstr ""

--- a/locale/de/LC_MESSAGES/djangojs.po
+++ b/locale/de/LC_MESSAGES/djangojs.po
@@ -1,1283 +1,1241 @@
-# 
+#
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2016-02-24 21:23+0000\n"
+"POT-Creation-Date: 2016-04-18 15:47+0000\n"
 "PO-Revision-Date: 2016-04-05 04:16+0000\n"
 "Last-Translator: paul.trevor <paul.trevor@gmx.de>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
-"Language: de\n"
+"Language: \n"
 "MIME-Version: 1.0\n"
-"Content-Type: text/plain; charset=utf-8\n"
+"Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 "Generated-By: Babel 2.2.0\n"
-"X-Generator: Pontoon\n"
 
-#: static/js/common/ratingwidget.js:31
-msgid "{0} star"
-msgid_plural "{0} stars"
-msgstr[0] "{0} Stern"
-msgstr[1] "{0} Sterne"
-
-#: static/js/common/upload-addon.js:41 static/js/common/upload-image.js:128
-msgid "There was a problem contacting the server."
-msgstr "Beim Kontaktieren des Servers ist ein Fehler aufgetreten."
-
-#: static/js/common/upload-addon.js:69
-msgid "Select a file..."
-msgstr "Wählen Sie eine Datei aus…"
-
-#: static/js/common/upload-addon.js:70
-msgid "Your add-on should end with .xpi, .jar or .xml"
-msgstr "Ihr Add-on sollte eine der Dateiendungen .xpi, .jar oder .xml haben"
-
-#. L10n: {0} is the percent of the file that has been uploaded.
-#: static/js/common/upload-addon.js:104
-#, python-format
-msgid "{0}% complete"
-msgstr "{0}% abgeschlossen"
-
-#. L10n: "{bytes uploaded} of {total filesize}".
-#: static/js/common/upload-addon.js:107
-msgid "{0} of {1}"
-msgstr "{0} von {1}"
-
-#: static/js/common/upload-addon.js:140
-msgid "Cancel"
-msgstr "Abbrechen"
-
-#: static/js/common/upload-addon.js:162
-msgid "Uploading {0}"
-msgstr "{0} wird hochgeladen"
-
-#: static/js/common/upload-addon.js:189
-msgid "Error with {0}"
-msgstr "Fehler bei {0}"
-
-#: static/js/common/upload-addon.js:194
-msgid "Your add-on failed validation with {0} error."
-msgid_plural "Your add-on failed validation with {0} errors."
-msgstr[0] "Ihr Add-on ist bei der Überprüfung mit {0} Fehler durchgefallen."
-msgstr[1] "Ihr Add-on ist bei der Überprüfung mit {0} Fehlern durchgefallen."
-
-#: static/js/common/upload-addon.js:208
-msgid "&hellip;and {0} more"
-msgid_plural "&hellip;and {0} more"
-msgstr[0] "&hellip; und {0} weiterer"
-msgstr[1] "&hellip; und {0} weitere"
-
-#: static/js/common/upload-addon.js:222 static/js/common/upload-addon.js:512
-msgid "See full validation report"
-msgstr "Vollständigen Überprüfungsbericht lesen"
-
-#: static/js/common/upload-addon.js:234
-msgid "Validating {0}"
-msgstr "Überprüfung von {0}"
-
-#. L10n: first argument is an HTTP status code
-#: static/js/common/upload-addon.js:273
-msgid "Received an empty response from the server; status: {0}"
-msgstr "Leere Antwort vom Server erhalten; Status: {0}"
-
-#: static/js/common/upload-addon.js:373
-msgid "Unexpected server error while validating."
-msgstr "Unerwarteter Server-Fehler bei der Überprüfung."
-
-#: static/js/common/upload-addon.js:412
-msgid "Finished validating {0}"
-msgstr "Überprüfung abgeschlossen {0}"
-
-#: static/js/common/upload-addon.js:418
-msgid "Your add-on validation timed out, it will be manually reviewed."
-msgstr ""
-"Zeitüberschreitung bei Ihrer Add-on-Validierung, es gibt eine manuelle "
-"Überprüfung."
-
-#: static/js/common/upload-addon.js:421
-msgid "Your add-on was validated with no errors and {0} warning."
-msgid_plural "Your add-on was validated with no errors and {0} warnings."
-msgstr[0] "Ihr Add-on wurde ohne Fehler und {0} Warnung validiert."
-msgstr[1] "Ihr Add-on wurde ohne Fehler und {0} Warnungen validiert."
-
-#: static/js/common/upload-addon.js:426
-msgid "Your add-on was validated with no errors and {0} message."
-msgid_plural "Your add-on was validated with no errors and {0} messages."
-msgstr[0] "Ihr Add-on wurde ohne Fehler und mit {0} Hinweis validiert."
-msgstr[1] "Ihr Add-on wurde ohne Fehler und mit {0} Hinweisen validiert."
-
-#: static/js/common/upload-addon.js:431
-msgid "Your add-on was validated with no errors or warnings."
-msgstr "Ihr Add-on wurde ohne Fehler und Hinweise validiert."
-
-#: static/js/common/upload-addon.js:446
-msgid "Your submission will be automatically signed."
-msgstr "Ihre Einreichung wird automatisch signiert."
-
-#: static/js/common/upload-addon.js:465
-msgid "Include detailed version notes (this can be done in the next step)."
-msgstr ""
-"Fügen Sie detaillierte Versionshinweise hinzu (dies kann im nächsten Schritt"
-" geschehen)."
-
-#: static/js/common/upload-addon.js:466
-msgid ""
-"If your add-on requires an account to a website in order to be fully tested,"
-" include a test username and password in the Notes to Reviewer (this can be "
-"done in the next step)."
-msgstr ""
-"Wenn Ihr Add-on ein Benutzerkonto bei einer Webseite benötigt, um "
-"vollständig getestet zu werden, fügen Sie in den Hinweisen an den Überprüfer"
-" Benutzername und Passwort eines Testkontos hinzu (dies kann im nächsten "
-"Schritt geschehen)."
-
-#: static/js/common/upload-addon.js:467
-msgid ""
-"If your add-on is intended for a limited audience you should choose "
-"Preliminary Review instead of Full Review."
-msgstr ""
-"Wenn Ihr Add-on für eine begrenzte Nutzergruppe gedacht ist, sollten Sie "
-"„Vorläufige Überprüfung“ anstelle von „Vollständige Überprüfung“ wählen."
-
-#: static/js/common/upload-addon.js:480
-msgid "Add-on submission checklist"
-msgstr "Checkliste für Add-on-Einreichung"
-
-#: static/js/common/upload-addon.js:481
-msgid ""
-"Please verify the following points before finalizing your submission. This "
-"will minimize delays or misunderstanding during the review process:"
-msgstr ""
-"Bitte überprüfen Sie die folgenden Punkte, bevor Sie Ihre Einreichung "
-"abschließen. Dies minimiert Verzögerungen oder Missverständnisse während des"
-" Überprüfungsprozesses:"
-
-#: static/js/common/upload-addon.js:483
-msgid ""
-"Compiled binaries, as well as minified or obfuscated scripts (excluding "
-"known libraries) need to have their sources submitted separately for review."
-" Make sure that you use the source code upload field to avoid having your "
-"submission rejected."
-msgstr ""
-"Von kompilierten Binärdateien sowie verkürzten oder verschleierten Skripten "
-"(außer bekannten Bibliotheken) müssen die Quelltexte getrennt zur "
-"Überprüfung eingereicht werden. Verwenden Sie unbedingt das Feld zum "
-"Hochladen von Quelltext, damit Ihre Einreichung nicht abgelehnt wird."
-
-#: static/js/common/upload-addon.js:501
-msgid "The validation process found these issues that can lead to rejections:"
-msgstr ""
-"Der Validierungsprozess stellte folgende Probleme fest, die zur Ablehnung "
-"führen könnten:"
-
-#: static/js/common/upload-addon.js:518
-msgid ""
-"If you are unfamiliar with the add-ons review process, you can read about it"
-" here."
-msgstr ""
-"Wenn Ihnen der Prozess der Add-on-Überprüfung unbekannt ist, finden Sie hier"
-" weitere Informationen darüber."
-
-#: static/js/common/upload-addon.js:555
-msgid "Sorry, no supported platform has been found."
-msgstr "Es tut uns leid, es wurde keine unterstützte Plattform gefunden."
-
-#: static/js/common/upload-base.js:57
-msgid "The filetype you uploaded isn't recognized."
-msgstr "Der Dateityp, den Sie hochgeladen haben, wurde nicht erkannt."
-
-#: static/js/common/upload-base.js:79
-msgid "You cancelled the upload."
-msgstr "Sie haben das Hochladen abgebrochen."
-
-#: static/js/common/upload-image.js:97 static/js/impala/users.js:51
-msgid "Images must be either PNG or JPG."
-msgstr "Grafiken müssen entweder PNG oder JPG sein."
-
-#: static/js/common/upload-image.js:101
-msgid "Videos must be in WebM."
-msgstr "Videos müssen im WebM-Format sein."
-
-#: static/js/impala/collections.js:10 static/js/zamboni/collections.js:595
-msgid "Follow this Collection"
-msgstr "Dieser Sammlung folgen"
-
-#: static/js/impala/collections.js:19
-msgid "Stop Following"
-msgstr "Nicht mehr folgen"
-
-#: static/js/impala/collections.js:20
-msgid "Following"
-msgstr "Folgen"
-
-#. L10n: {0} is an app name.
-#: static/js/impala/listing.js:11 static/js/zamboni/themes.js:13
-msgid "This theme is incompatible with your version of {0}"
-msgstr "Dieses Theme ist mit Ihrer Version von {0} nicht kompatibel"
-
-#: static/js/impala/persona_creation.js:60
-msgid "All Rights Reserved"
-msgstr "Alle Rechte vorbehalten"
-
-#: static/js/impala/persona_creation.js:64
-msgid "Creative Commons Attribution 3.0"
-msgstr "Creative Commons Attribution 3.0"
-
-#: static/js/impala/persona_creation.js:69
-msgid "Creative Commons Attribution-NonCommercial 3.0"
-msgstr "Creative Commons Attribution-NonCommercial 3.0"
-
-#: static/js/impala/persona_creation.js:74
-msgid "Creative Commons Attribution-NonCommercial-NoDerivs 3.0"
-msgstr "Creative Commons Attribution-NonCommercial-NoDerivs 3.0"
-
-#: static/js/impala/persona_creation.js:79
-msgid "Creative Commons Attribution-NonCommercial-Share Alike 3.0"
-msgstr "Creative Commons Attribution-NonCommercial-Share Alike 3.0"
-
-#: static/js/impala/persona_creation.js:84
-msgid "Creative Commons Attribution-NoDerivs 3.0"
-msgstr "Creative Commons Attribution-NoDerivs 3.0"
-
-#: static/js/impala/persona_creation.js:89
-msgid "Creative Commons Attribution-ShareAlike 3.0"
-msgstr "Creative Commons Attribution-ShareAlike 3.0"
-
-#: static/js/impala/persona_creation.js:292
-msgid "Your Theme's Name"
-msgstr "Name Ihres Themes"
-
-#: static/js/impala/reviews.js:23 static/js/zamboni/reviews.js:18
-msgid "Flagged for review"
-msgstr "Zur Überprüfung markiert"
-
-#: static/js/impala/reviews.js:40 static/js/zamboni/reviews.js:34
-msgid "Your input is required"
-msgstr "Ihre Eingabe wird benötigt"
-
-#: static/js/impala/reviews.js:152 static/js/zamboni/reviews.js:103
-msgid "Marked for deletion"
-msgstr "Zum Löschen markiert"
-
-#: static/js/impala/search.js:114
-msgid "Updating results&hellip;"
-msgstr "Ergebnisse werden aktualisiert …"
-
-#: static/js/impala/site_suggestions.js:46
-msgid "Category"
-msgstr "Kategorie"
-
-#: static/js/impala/suggestions.js:39
-msgid "Search themes for <b>{0}</b>"
-msgstr "Suche nach Themes für <b>{0}</b>"
-
-#: static/js/impala/suggestions.js:41
-msgid "Search apps for <b>{0}</b>"
-msgstr "Apps suchen für <b>{0}</b>"
-
-#: static/js/impala/suggestions.js:43
-msgid "Search add-ons for <b>{0}</b>"
-msgstr "Add-ons suchen für <b>{0}</b>"
-
-#: static/js/impala/users.js:33
-msgid "use original"
-msgstr "Original verwenden"
-
-#: static/js/impala/stats/chart.js:267
-msgid "Week of {0}"
-msgstr "Woche von {0}"
-
-#: static/js/impala/stats/chart.js:269
-msgid " downloads"
-msgstr "Downloads"
-
-#: static/js/impala/stats/chart.js:270
-msgid "{0} users"
-msgstr "{0} Benutzer"
-
-#: static/js/impala/stats/chart.js:271
-msgid "{0} add-ons"
-msgstr "{0} Add-ons"
-
-#: static/js/impala/stats/chart.js:272
-msgid "{0} collections"
-msgstr "{0} Sammlungen"
-
-#: static/js/impala/stats/chart.js:273
-msgid "{0} reviews"
-msgstr "{0} Bewertungen"
-
-#: static/js/impala/stats/chart.js:275
-msgid "{0} sales"
-msgstr "{0} Verkäufe"
-
-#: static/js/impala/stats/chart.js:276
-msgid "{0} refunds"
-msgstr "{0} Erstattungen"
-
-#: static/js/impala/stats/chart.js:277
-msgid "{0} installs"
-msgstr "{0} Installationen"
-
-#: static/js/impala/stats/chart.js:369 static/js/impala/stats/csv_keys.js:3
-#: static/js/impala/stats/csv_keys.js:109
-msgid "Downloads"
-msgstr "Downloads"
-
-#: static/js/impala/stats/chart.js:379 static/js/impala/stats/csv_keys.js:6
-#: static/js/impala/stats/csv_keys.js:110
-msgid "Daily Users"
-msgstr "Tägliche Benutzer"
-
-#: static/js/impala/stats/chart.js:410
-msgid "Amount, in USD"
-msgstr "Betrag in US$"
-
-#: static/js/impala/stats/chart.js:421 static/js/impala/stats/csv_keys.js:104
-msgid "Number of Contributions"
-msgstr "Zahl der Beiträge"
-
-#: static/js/impala/stats/chart.js:447
-msgid "More Info..."
-msgstr "Weitere Informationen …"
-
-#. L10n: {0} is an ISO-formatted date.
-#: static/js/impala/stats/chart.js:451
-msgid "Details for {0}"
-msgstr "Details zu {0}"
-
-#: static/js/impala/stats/csv_keys.js:9
-msgid "Collections Created"
-msgstr "Erstellte Sammlungen"
-
-#: static/js/impala/stats/csv_keys.js:12
-msgid "Add-ons in Use"
-msgstr "Verwendete Add-ons"
-
-#: static/js/impala/stats/csv_keys.js:15
-msgid "Add-ons Created"
-msgstr "Erstellte Add-ons"
-
-#: static/js/impala/stats/csv_keys.js:18
-msgid "Add-ons Downloaded"
-msgstr "Heruntergeladene Add-ons"
-
-#: static/js/impala/stats/csv_keys.js:21
-msgid "Add-ons Updated"
-msgstr "Aktualisierte Add-ons"
-
-#: static/js/impala/stats/csv_keys.js:24
-msgid "Reviews Written"
-msgstr "Geschriebene Bewertungen"
-
-#: static/js/impala/stats/csv_keys.js:27
-msgid "User Signups"
-msgstr "Registrierte Benutzer"
-
-#: static/js/impala/stats/csv_keys.js:30
-msgid "Subscribers"
-msgstr "Abonnenten"
-
-#: static/js/impala/stats/csv_keys.js:33
-msgid "Ratings"
-msgstr "Bewertungen"
-
-#: static/js/impala/stats/csv_keys.js:36
-#: static/js/impala/stats/csv_keys.js:114
-msgid "Sales"
-msgstr "Verkäufe"
-
-#: static/js/impala/stats/csv_keys.js:39
-#: static/js/impala/stats/csv_keys.js:113
-msgid "Installs"
-msgstr "Installationen"
-
-#: static/js/impala/stats/csv_keys.js:42
-msgid "Unknown"
-msgstr "Unbekannt"
-
-#: static/js/impala/stats/csv_keys.js:43
-msgid "Add-ons Manager"
-msgstr "Add-ons-Manager"
-
-#: static/js/impala/stats/csv_keys.js:44
-msgid "Add-ons Manager Promo"
-msgstr "Add-ons-Manager „Promo“"
-
-#: static/js/impala/stats/csv_keys.js:45
-msgid "Add-ons Manager Featured"
-msgstr "Add-ons-Manager „Vorgestellt“"
-
-#: static/js/impala/stats/csv_keys.js:46
-msgid "Add-ons Manager Learn More"
-msgstr "Add-ons-Manager „Mehr erfahren“"
-
-#: static/js/impala/stats/csv_keys.js:47
-msgid "Search Suggestions"
-msgstr "Suchvorschläge"
-
-#: static/js/impala/stats/csv_keys.js:48
-msgid "Search Results"
-msgstr "Suchergebnisse"
-
-#: static/js/impala/stats/csv_keys.js:49 static/js/impala/stats/csv_keys.js:50
-#: static/js/impala/stats/csv_keys.js:51
-msgid "Homepage Promo"
-msgstr "Startseite „Promo“"
-
-#: static/js/impala/stats/csv_keys.js:52 static/js/impala/stats/csv_keys.js:53
-msgid "Homepage Featured"
-msgstr "Startseite „Vorgestellt“"
-
-#: static/js/impala/stats/csv_keys.js:54 static/js/impala/stats/csv_keys.js:55
-msgid "Homepage Up and Coming"
-msgstr "Startseite „Aufstrebend“"
-
-#: static/js/impala/stats/csv_keys.js:56
-msgid "Homepage Most Popular"
-msgstr "Startseite „Beliebteste“"
-
-#: static/js/impala/stats/csv_keys.js:57 static/js/impala/stats/csv_keys.js:59
-msgid "Detail Page"
-msgstr "Detailseite"
-
-#: static/js/impala/stats/csv_keys.js:58 static/js/impala/stats/csv_keys.js:60
-msgid "Detail Page (bottom)"
-msgstr "Detailseite (Ende)"
-
-#: static/js/impala/stats/csv_keys.js:61
-msgid "Detail Page (Development Channel)"
-msgstr "Detailseite (Entwicklerkanal)"
-
-#: static/js/impala/stats/csv_keys.js:62 static/js/impala/stats/csv_keys.js:63
-#: static/js/impala/stats/csv_keys.js:64
-msgid "Often Used With"
-msgstr "Oft verwendet mit"
-
-#: static/js/impala/stats/csv_keys.js:65 static/js/impala/stats/csv_keys.js:66
-msgid "Others By Author"
-msgstr "Andere von diesem Autor"
-
-#: static/js/impala/stats/csv_keys.js:67 static/js/impala/stats/csv_keys.js:68
-msgid "Dependencies"
-msgstr "Abhängigkeiten"
-
-#: static/js/impala/stats/csv_keys.js:69 static/js/impala/stats/csv_keys.js:70
-msgid "Upsell"
-msgstr "Zusatzverkäufe"
-
-#: static/js/impala/stats/csv_keys.js:71
-msgid "Meet the Developer"
-msgstr "Lernen Sie den Entwickler kennen"
-
-#: static/js/impala/stats/csv_keys.js:72
-msgid "User Profile"
-msgstr "Benutzerprofil"
-
-#: static/js/impala/stats/csv_keys.js:73
-msgid "Version History"
-msgstr "Versionsgeschichte"
-
-#: static/js/impala/stats/csv_keys.js:75
-msgid "Sharing"
-msgstr "Weitergeben"
-
-#: static/js/impala/stats/csv_keys.js:76
-msgid "Category Pages"
-msgstr "Kategorieseiten"
-
-#: static/js/impala/stats/csv_keys.js:77
-msgid "Collections"
-msgstr "Sammlungen"
-
-#: static/js/impala/stats/csv_keys.js:78 static/js/impala/stats/csv_keys.js:79
-msgid "Category Landing Featured Carousel"
-msgstr "Kategorie-Übersicht „Karussell der Vorgestellten“"
-
-#: static/js/impala/stats/csv_keys.js:80 static/js/impala/stats/csv_keys.js:81
-msgid "Category Landing Top Rated"
-msgstr "Kategorie-Übersicht „Höchste Bewertung“"
-
-#: static/js/impala/stats/csv_keys.js:82 static/js/impala/stats/csv_keys.js:83
-msgid "Category Landing Most Popular"
-msgstr "Kategorie-Übersicht „Beliebteste“"
-
-#: static/js/impala/stats/csv_keys.js:84 static/js/impala/stats/csv_keys.js:85
-msgid "Category Landing Recently Added"
-msgstr "Kategorie-Übersicht „Zuletzt hinzugefügt“"
-
-#: static/js/impala/stats/csv_keys.js:86 static/js/impala/stats/csv_keys.js:87
-msgid "Browse Listing Featured Sort"
-msgstr "Auflistung durchsuchen „Sortiert nach Vorgestellt“"
-
-#: static/js/impala/stats/csv_keys.js:88 static/js/impala/stats/csv_keys.js:89
-msgid "Browse Listing Users Sort"
-msgstr "Auflistung durchsuchen „Sortiert nach Benutzern“"
-
-#: static/js/impala/stats/csv_keys.js:90 static/js/impala/stats/csv_keys.js:91
-msgid "Browse Listing Rating Sort"
-msgstr "Auflistung durchsuchen „Sortiert nach Bewertung“"
-
-#: static/js/impala/stats/csv_keys.js:92 static/js/impala/stats/csv_keys.js:93
-msgid "Browse Listing Created Sort"
-msgstr "Auflistung durchsuchen „Sortiert nach Erstellt“"
-
-#: static/js/impala/stats/csv_keys.js:94 static/js/impala/stats/csv_keys.js:95
-msgid "Browse Listing Name Sort"
-msgstr "Auflistung durchsuchen „Sortiert nach Name“"
-
-#: static/js/impala/stats/csv_keys.js:96 static/js/impala/stats/csv_keys.js:97
-msgid "Browse Listing Popular Sort"
-msgstr "Auflistung durchsuchen „Sortiert nach Beliebtheit“"
-
-#: static/js/impala/stats/csv_keys.js:98 static/js/impala/stats/csv_keys.js:99
-msgid "Browse Listing Updated Sort"
-msgstr "Auflistung durchsuchen „Sortiert nach Aktualisiert“"
-
-#: static/js/impala/stats/csv_keys.js:100
-#: static/js/impala/stats/csv_keys.js:101
-msgid "Browse Listing Up and Coming Sort"
-msgstr "Auflistung durchsuchen „Sortiert nach Aufstrebende“"
-
-#: static/js/impala/stats/csv_keys.js:105
-msgid "Total Amount Contributed"
-msgstr "Insgesamt gespendeter Betrag"
-
-#: static/js/impala/stats/csv_keys.js:106
-msgid "Average Contribution"
-msgstr "Durchschnittlich gespendeter Betrag"
-
-#: static/js/impala/stats/csv_keys.js:115
-msgid "Usage"
-msgstr "Verwendung"
-
-#: static/js/impala/stats/csv_keys.js:118
-msgid "Firefox"
-msgstr "Firefox"
-
-#: static/js/impala/stats/csv_keys.js:119
-msgid "Mozilla"
-msgstr "Mozilla"
-
-#: static/js/impala/stats/csv_keys.js:120
-msgid "Thunderbird"
-msgstr "Thunderbird"
-
-#: static/js/impala/stats/csv_keys.js:121
-msgid "Sunbird"
-msgstr "Sunbird"
-
-#: static/js/impala/stats/csv_keys.js:122
-msgid "SeaMonkey"
-msgstr "SeaMonkey"
-
-#: static/js/impala/stats/csv_keys.js:123
-msgid "Fennec"
-msgstr "Fennec"
-
-#: static/js/impala/stats/csv_keys.js:124
-msgid "Android"
-msgstr "Android"
-
-#. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:129
-msgid "Downloads and Daily Users, last {0} days"
-msgstr "Downloads und tägliche Benutzer, letzte {0} Tage"
-
-#. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:131
-msgid "Downloads and Daily Users from {0} to {1}"
-msgstr "Downloads und tägliche Benutzer von {0} bis {1}"
-
-#. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:135
-msgid "Installs and Daily Users, last {0} days"
-msgstr "Installationen und tägliche Benutzer, letzte {0} Tage"
-
-#. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:137
-msgid "Installs and Daily Users from {0} to {1}"
-msgstr "Installationen und tägliche Benutzer von {0} bis {1}"
-
-#. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:141
-msgid "Downloads, last {0} days"
-msgstr "Downloads in den letzten {0} Tagen"
-
-#. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:143
-msgid "Downloads from {0} to {1}"
-msgstr "Downloads von {0} bis {1}"
-
-#. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:147
-msgid "Daily Users, last {0} days"
-msgstr "Tägliche Benutzer in den letzten {0} Tagen"
-
-#. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:149
-msgid "Daily Users from {0} to {1}"
-msgstr "Tägliche Benutzer von {0} bis {1}"
-
-#. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:153
-msgid "Applications, last {0} days"
-msgstr "Apps in den letzten {0} Tagen"
-
-#. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:155
-msgid "Applications from {0} to {1}"
-msgstr "Apps von {0} bis {1}"
-
-#. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:159
-msgid "Platforms, last {0} days"
-msgstr "Plattformen in den letzten {0} Tagen"
-
-#. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:161
-msgid "Platforms from {0} to {1}"
-msgstr "Plattformen von {0} bis {1}"
-
-#. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:165
-msgid "Languages, last {0} days"
-msgstr "Sprachen in den letzten {0} Tagen"
-
-#. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:167
-msgid "Languages from {0} to {1}"
-msgstr "Sprachen von {0} bis {1}"
-
-#. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:171
-msgid "Add-on Versions, last {0} days"
-msgstr "Add-on-Versionen in den letzten {0} Tagen"
-
-#. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:173
-msgid "Add-on Versions from {0} to {1}"
-msgstr "Add-on-Versionen von {0} bis {1}"
-
-#. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:177
-msgid "Add-on Status, last {0} days"
-msgstr "Add-on-Status in den letzten {0} Tagen"
-
-#. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:179
-msgid "Add-on Status from {0} to {1}"
-msgstr "Add-on-Status von {0} bis {1}"
-
-#. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:183
-msgid "Download Sources, last {0} days"
-msgstr "Download-Quellen in den letzten {0} Tagen"
-
-#. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:185
-msgid "Download Sources from {0} to {1}"
-msgstr "Download-Quellen von {0} bis {1}"
-
-#. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:189
-msgid "Contributions, last {0} days"
-msgstr "Spenden in den letzten {0} Tagen"
-
-#. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:191
-msgid "Contributions from {0} to {1}"
-msgstr "Spenden von {0} bis {1}"
-
-#. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:195
-msgid "Site Metrics, last {0} days"
-msgstr "Website-Statistiken, letzte {0} Tage"
-
-#. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:197
-msgid "Site Metrics from {0} to {1}"
-msgstr "Website-Statistiken von {0} bis {1}"
-
-#. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:201
-msgid "Add-ons in Use, last {0} days"
-msgstr "Verwendete Add-ons, letzte {0} Tage"
-
-#. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:203
-msgid "Add-ons in Use from {0} to {1}"
-msgstr "Verwendete Add-ons von {0} bis {1}"
-
-#. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:207
-msgid "Add-ons Downloaded, last {0} days"
-msgstr "Heruntergeladene Add-ons, letzte {0} Tage"
-
-#. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:209
-msgid "Add-ons Downloaded from {0} to {1}"
-msgstr "Heruntergeladene Add-ons von {0} bis {1}"
-
-#. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:213
-msgid "Add-ons Created, last {0} days"
-msgstr "Erstellte Add-ons, letzte {0} Tage"
-
-#. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:215
-msgid "Add-ons Created from {0} to {1}"
-msgstr "Erstellte Add-ons von {0} bis {1}"
-
-#. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:219
-msgid "Add-ons Updated, last {0} days"
-msgstr "Aktualisierte Add-ons, letzte {0} Tage"
-
-#. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:221
-msgid "Add-ons Updated from {0} to {1}"
-msgstr "Aktualisierte Add-ons von {0} bis {1}"
-
-#. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:225
-msgid "Reviews Written, last {0} days"
-msgstr "Geschriebene Bewertungen, letzte {0} Tage"
-
-#. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:227
-msgid "Reviews Written from {0} to {1}"
-msgstr "Geschriebene Bewertungen von {0} bis {1}"
-
-#. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:231
-msgid "User Signups, last {0} days"
-msgstr "Registrierte Benutzer, letzte {0} Tage"
-
-#. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:233
-msgid "User Signups from {0} to {1}"
-msgstr "Registrierte Benutzer von {0} bis {1}"
-
-#. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:237
-msgid "Collections Created, last {0} days"
-msgstr "Erstellte Sammlungen, letzte {0} Tage"
-
-#. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:239
-msgid "Collections Created from {0} to {1}"
-msgstr "Erstellte Sammlungen von {0} bis {1}"
-
-#. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:243
-msgid "Subscribers, last {0} days"
-msgstr "Abonnenten, letzte {0} Tage"
-
-#. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:245
-msgid "Subscribers from {0} to {1}"
-msgstr "Abonnenten von {0} bis {1}"
-
-#. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:249
-msgid "Ratings, last {0} days"
-msgstr "Bewertungen, letzte {0} Tage"
-
-#. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:251
-msgid "Ratings from {0} to {1}"
-msgstr "Bewertungen von {0} bis {1}"
-
-#. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:255
-msgid "Sales, last {0} days"
-msgstr "Verkäufe, letzte {0} Tage"
-
-#. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:257
-msgid "Sales from {0} to {1}"
-msgstr "Verkäufe von {0} bis {1}"
-
-#. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:261
-msgid "Installs, last {0} days"
-msgstr "Installationen, letzte {0} Tage"
-
-#. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:263
-msgid "Installs from {0} to {1}"
-msgstr "Installationen von {0} bis {1}"
-
-#. L10n: {0} and {1} are integers.
-#: static/js/impala/stats/csv_keys.js:269
-msgid "<b>{0}</b> in last {1} days"
-msgstr "<b>{0}</b> in den letzten {1} Tagen"
-
-#. L10n: {0} is an integer and {1} and {2} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:271
-#: static/js/impala/stats/csv_keys.js:277
-msgid "<b>{0}</b> from {1} to {2}"
-msgstr "<b>{0}</b> von {1} bis {2}"
-
-#. L10n: {0} and {1} are integers.
-#: static/js/impala/stats/csv_keys.js:275
-msgid "<b>{0}</b> average in last {1} days"
-msgstr "Durchschnittlich <b>{0}</b> in den letzten {1} Tagen"
-
-#: static/js/impala/stats/overview.js:19
-msgid "No data available."
-msgstr "Keine Daten verfügbar"
-
-#: static/js/impala/stats/table.js:74
-msgid "Date"
-msgstr "Datum"
-
-#: static/js/impala/stats/topchart.js:96
-msgid "Other"
-msgstr "Andere"
-
-#: static/js/zamboni/admin_validation.js:24 static/js/zamboni/devhub.js:1229
-#: static/js/zamboni/editors.js:295
-msgid "Select an application first"
-msgstr "Wählen Sie zuerst eine Anwendung aus"
-
-#: static/js/zamboni/admin_validation.js:51
-msgid "Set {0} add-on to a max version of {1} and email the author."
-msgid_plural "Set {0} add-ons to a max version of {1} and email the authors."
-msgstr[0] ""
-"{0} Add-on auf eine Max-Version von {1} setzen und Autor per E-Mail "
-"benachrichtigen."
-msgstr[1] ""
-"{0} Add-ons auf eine Max-Version von {1} setzen und Autoren per E-Mail "
-"benachrichtigen."
-
-#: static/js/zamboni/admin_validation.js:54
-msgid "Email author of {2} add-on which failed validation."
-msgid_plural "Email authors of {2} add-ons which failed validation."
-msgstr[0] ""
-"Autor von {2} Add-on, deren Validierung fehlgeschlagen ist, per E-Mail "
-"benachrichtigen."
-msgstr[1] ""
-"Autoren von {2} Add-ons, deren Validierung fehlgeschlagen ist, per E-Mail "
-"benachrichtigen."
+#: static/js/common-all.js:1426 static/js/impala-all.js:1511 static/js/zamboni/discovery-all.js:12598 static/js/zamboni/init.js:28 static/js/zamboni/mobile-all.js:14945
+msgid "This feature is temporarily disabled while we perform website maintenance. Please check back a little later."
+msgstr "Diese Funktion wurde zeitweilig deaktiviert, während wir Wartungsarbeiten an der Website durchführen. Bitte versuchen Sie es später erneut."
 
 #. L10n: {0} is an app name like Firefox.
-#: static/js/zamboni/buttons.js:66
+#: static/js/common-all.js:1837 static/js/impala-all.js:1922 static/js/zamboni/buttons.js:73 static/js/zamboni/discovery-all.js:13108
 msgid "Accept and Install"
 msgstr "Akzeptieren und installieren"
 
-#: static/js/zamboni/buttons.js:66
+#: static/js/common-all.js:1837 static/js/impala-all.js:1922 static/js/zamboni/buttons.js:73 static/js/zamboni/discovery-all.js:13108
 msgid "Add to {0}"
 msgstr "Zu {0} hinzufügen"
 
-#: static/js/zamboni/buttons.js:71
+#: static/js/common-all.js:1842 static/js/impala-all.js:1927 static/js/zamboni/buttons.js:78 static/js/zamboni/discovery-all.js:13113
 msgid "Download Now"
 msgstr "Jetzt herunterladen"
 
-#: static/js/zamboni/buttons.js:112
+#: static/js/common-all.js:1883 static/js/impala-all.js:1968 static/js/zamboni/buttons.js:119 static/js/zamboni/discovery-all.js:13154
 msgid "Add-on has not been updated to support default-to-compatible."
-msgstr ""
-"Add-on wurde nicht aktualisiert, um standardmäßige Kompatibilität zu "
-"unterstützen."
+msgstr "Add-on wurde nicht aktualisiert, um standardmäßige Kompatibilität zu unterstützen."
 
-#: static/js/zamboni/buttons.js:117
+#: static/js/common-all.js:1888 static/js/impala-all.js:1973 static/js/zamboni/buttons.js:124 static/js/zamboni/discovery-all.js:13159
 msgid "You need to be using Firefox 10.0 or higher."
 msgstr "Sie müssen Firefox 10.0 oder höher verwenden."
 
-#: static/js/zamboni/buttons.js:129
-msgid ""
-"Mozilla has marked this version as incompatible with your Firefox version."
-msgstr ""
-"Mozilla hat diese Version als mit Ihrer Firefox-Version inkompatibel "
-"markiert."
+#: static/js/common-all.js:1900 static/js/impala-all.js:1985 static/js/zamboni/buttons.js:136 static/js/zamboni/discovery-all.js:13171
+msgid "Mozilla has marked this version as incompatible with your Firefox version."
+msgstr "Mozilla hat diese Version als mit Ihrer Firefox-Version inkompatibel markiert."
 
 #. L10n: {0} is an platform like Windows or Linux.
-#: static/js/zamboni/buttons.js:210
+#: static/js/common-all.js:1981 static/js/impala-all.js:2066 static/js/zamboni/buttons.js:217 static/js/zamboni/discovery-all.js:13252
 msgid "Install for {0} anyway"
 msgstr "Trotzdem für {0} installieren"
 
-#: static/js/zamboni/buttons.js:210
+#: static/js/common-all.js:1981 static/js/impala-all.js:2066 static/js/zamboni/buttons.js:217 static/js/zamboni/discovery-all.js:13252
 msgid "Download for {0} anyway"
 msgstr "Trotzdem für {0} herunterladen"
 
-#: static/js/zamboni/buttons.js:267
+#: static/js/common-all.js:2038 static/js/impala-all.js:2123 static/js/zamboni/buttons.js:274 static/js/zamboni/discovery-all.js:13309
 msgid "Not available for your platform"
 msgstr "Nicht verfügbar für Ihre Plattform"
 
 #. L10n: {0} is an app name, {1} is the app version.
-#: static/js/zamboni/buttons.js:278 static/js/zamboni/buttons.js:315
+#: static/js/common-all.js:2049 static/js/common-all.js:2086 static/js/impala-all.js:2134 static/js/impala-all.js:2171 static/js/zamboni/buttons.js:286 static/js/zamboni/buttons.js:324
+#: static/js/zamboni/discovery-all.js:13320 static/js/zamboni/discovery-all.js:13357
 msgid "Not available for {0} {1}"
 msgstr "Nicht verfügbar für {0} {1}"
 
-#: static/js/zamboni/buttons.js:341
+#: static/js/common-all.js:2112 static/js/impala-all.js:2197 static/js/zamboni/buttons.js:351 static/js/zamboni/discovery-all.js:13383
 msgid "Works with {app} {min} - {max}"
 msgstr "Kompatibel mit {app} {min} - {max}"
 
-#: static/js/zamboni/buttons.js:343
+#: static/js/common-all.js:2114 static/js/impala-all.js:2199 static/js/zamboni/buttons.js:353 static/js/zamboni/discovery-all.js:13385
 msgid "View other versions"
 msgstr "Andere Versionen ansehen"
 
-#: static/js/zamboni/buttons.js:391
+#: static/js/common-all.js:2162 static/js/impala-all.js:2247 static/js/zamboni/buttons.js:401 static/js/zamboni/discovery-all.js:13433
 msgid "Only with Firefox — Get Firefox Now!"
 msgstr "Nur in Firefox – Laden Sie Firefox jetzt herunter!"
 
-#: static/js/zamboni/buttons.js:507 static/js/zamboni/mobile/buttons.js:43
-msgid ""
-"Sorry, you need a Mozilla-based browser (such as Firefox) to install a "
-"search plugin."
-msgstr ""
-"Es tut uns leid, Sie benötigen einen Mozilla-basierten Browser (wie "
-"Firefox), um ein Such-Plugin zu installieren."
+#: static/js/common-all.js:2278 static/js/impala-all.js:2363 static/js/zamboni/buttons.js:517 static/js/zamboni/discovery-all.js:13549 static/js/zamboni/mobile-all.js:15177
+#: static/js/zamboni/mobile/buttons.js:43
+msgid "Sorry, you need a Mozilla-based browser (such as Firefox) to install a search plugin."
+msgstr "Es tut uns leid, Sie benötigen einen Mozilla-basierten Browser (wie Firefox), um ein Such-Plugin zu installieren."
 
-#: static/js/zamboni/collections.js:229
-msgid "Adding to Favorites&hellip;"
-msgstr "Wird zu Favoriten hinzugefügt …"
-
-#: static/js/zamboni/collections.js:232
-msgid "Removing Favorite&hellip;"
-msgstr "Favorit wird entfernt …"
-
-#: static/js/zamboni/collections.js:235
-msgid "Add to Favorites"
-msgstr "Zu Favoriten hinzufügen"
-
-#: static/js/zamboni/collections.js:238
-msgid "Remove from Favorites"
-msgstr "Aus Favoriten entfernen"
-
-#: static/js/zamboni/collections.js:303
-msgid "Pending"
-msgstr "Ausstehend"
-
-#: static/js/zamboni/collections.js:304
-msgid "Add a comment"
-msgstr "Einen Kommentar hinzufügen"
-
-#: static/js/zamboni/collections.js:304
-msgid "Comment"
-msgstr "Kommentar"
-
-#: static/js/zamboni/collections.js:305
-msgid "Remove this add-on from the collection"
-msgstr "Dieses Add-on aus der Sammlung entfernen"
-
-#: static/js/zamboni/collections.js:305 static/js/zamboni/collections.js:334
-msgid "Remove"
-msgstr "Entfernen"
-
-#: static/js/zamboni/collections.js:334
-msgid "Remove this user as a contributor"
-msgstr "Diesen Benutzer als Mitwirkenden entfernen"
-
-#: static/js/zamboni/collections.js:346
-msgid "An email address is required."
-msgstr "Eine E-Mail-Adresse ist erforderlich."
-
-#: static/js/zamboni/collections.js:364
-msgid "You cannot add yourself as a contributor."
-msgstr "Sie können sich nicht selbst als Mitwirkenden hinzufügen."
-
-#: static/js/zamboni/collections.js:366
-msgid "You have already added that user."
-msgstr "Sie haben diesen Benutzer bereits hinzugefügt."
-
-#: static/js/zamboni/collections.js:573
-msgid "Add to favorites"
-msgstr "Zu Favoriten hinzufügen"
-
-#: static/js/zamboni/collections.js:577
-msgid "Remove from favorites"
-msgstr "Aus Favoriten entfernen"
-
-#: static/js/zamboni/collections.js:604
-msgid "Stop following"
-msgstr "Nicht mehr folgen"
-
-#: static/js/zamboni/devhub.js:110
-msgid "Your browser does not support the video tag"
-msgstr "Ihr Browser unterstützt den Video-Tag nicht"
-
-#: static/js/zamboni/devhub.js:371
-msgid "Changes Saved"
-msgstr "Änderungen gespeichert"
-
-#: static/js/zamboni/devhub.js:387
-msgid "Enter a new author's email address"
-msgstr "Geben Sie eine neue E-Mail-Adresse des Autors ein"
-
-#: static/js/zamboni/devhub.js:536
-msgid "There was an error uploading your file."
-msgstr "Beim Hochladen Ihrer Datei ist ein Fehler aufgetreten."
-
-#: static/js/zamboni/devhub.js:681
-msgid "{files} file"
-msgid_plural "{files} files"
-msgstr[0] "{files} Datei"
-msgstr[1] "{files} Dateien"
-
-#: static/js/zamboni/devhub.js:684
-msgid "{reviews} user review"
-msgid_plural "{reviews} user reviews"
-msgstr[0] "{reviews} Benutzerbewertung"
-msgstr[1] "{reviews} Benutzerbewertungen"
-
-#: static/js/zamboni/devhub.js:796
-msgid "Learn more"
-msgstr "Erfahren Sie mehr"
-
-#: static/js/zamboni/devhub.js:800
-msgid "Example"
-msgstr "Beispiel"
-
-#: static/js/zamboni/devhub.js:1130
-msgid "Image changes being processed"
-msgstr "Grafikänderungen werden angewendet"
-
-#: static/js/zamboni/devhub.js:1280
-msgid "Must be a valid e-mail address."
-msgstr "Muss eine gültige E-Mail-Adresse sein."
-
-#: static/js/zamboni/devhub_search.js:8
-msgid "No results found."
-msgstr "Keine Ergebnisse gefunden."
-
-#: static/js/zamboni/editors.js:121
-msgid "{name} was viewing this page first."
-msgstr "{name} hat diese Seite zuerst angesehen."
-
-#: static/js/zamboni/editors.js:171
-msgid "Receipt checked by app."
-msgstr "Quittung wurde von App überprüft."
-
-#: static/js/zamboni/editors.js:173
-msgid "Receipt was not checked by app."
-msgstr "Quittung wurde nicht von App überprüft."
-
-#: static/js/zamboni/editors.js:244
-msgid "{name} was viewing this add-on first."
-msgstr "{name} hat sich dieses Add-on zuerst angesehen."
-
-#: static/js/zamboni/editors.js:255
-msgid "Loading&hellip;"
-msgstr "Wird geladen &hellip;"
-
-#: static/js/zamboni/editors.js:260
-msgid "Version Notes"
-msgstr "Versionshinweise"
-
-#: static/js/zamboni/editors.js:265
-msgid "Notes for Reviewers"
-msgstr "Hinweise für Überprüfer"
-
-#: static/js/zamboni/editors.js:270
-msgid "No version notes found"
-msgstr "Keine Kommentare zur Version gefunden"
-
-#: static/js/zamboni/editors.js:330
-msgid "Average Reviews"
-msgstr "Durchschnittliche Bewertungen"
-
-#: static/js/zamboni/editors.js:386
-msgid "Number of Reviews"
-msgstr "Anzahl der Bewertungen"
-
-#: static/js/zamboni/editors.js:445
-msgid "Error loading translation"
-msgstr "Fehler beim Laden der Übersetzung"
-
-#: static/js/zamboni/files.js:411 static/js/zamboni/validator.js:261
-msgid "Ignore this message in future updates"
-msgstr "Diese Nachricht bei zukünftigen Updates ignorieren"
-
-#: static/js/zamboni/files.js:417 static/js/zamboni/validator.js:284
-msgid "Severity for automated signing:"
-msgstr "Dringlichkeit für automatische Signierung:"
-
-#: static/js/zamboni/global.js:410
+#: static/js/common-all.js:9088 static/js/impala-all.js:9649 static/js/zamboni/global.js:410
 msgid "Loading..."
 msgstr "Laden …"
 
 #. L10n: {0} is the number of characters left.
-#: static/js/zamboni/global.js:474
+#: static/js/common-all.js:9152 static/js/impala-all.js:9713 static/js/zamboni/global.js:474
 msgid "<b>{0}</b> character left."
 msgid_plural "<b>{0}</b> characters left."
 msgstr[0] "Noch <b>{0}</b> Zeichen übrig"
 msgstr[1] "Noch <b>{0}</b> Zeichen übrig"
 
-#: static/js/zamboni/init.js:28
-msgid ""
-"This feature is temporarily disabled while we perform website maintenance. "
-"Please check back a little later."
-msgstr ""
-"Diese Funktion wurde zeitweilig deaktiviert, während wir Wartungsarbeiten an"
-" der Website durchführen. Bitte versuchen Sie es später erneut."
+#: static/js/common-all.js:9589 static/js/common-min.js:6 static/js/impala-all.js:10052 static/js/impala-min.js:6 static/js/common/ratingwidget.js:31 static/js/zamboni/mobile-all.js:16123
+#: static/js/zamboni/mobile-min.js:6
+msgid "{0} star"
+msgid_plural "{0} stars"
+msgstr[0] "{0} Stern"
+msgstr[1] "{0} Sterne"
 
-#: static/js/zamboni/l10n.js:45
+#: static/js/common-all.js:9676 static/js/common-min.js:6 static/js/impala-all.js:10139 static/js/impala-min.js:6 static/js/zamboni/l10n.js:45
 msgid "Remove this localization"
 msgstr "Diese Übersetzung entfernen"
 
-#: static/js/zamboni/password-strength.js:20
+#: static/js/common-all.js:10193 static/js/common-min.js:6 static/js/impala-all.js:10674 static/js/impala-min.js:6 static/js/zamboni/discovery-all.js:13678
+msgid "close"
+msgstr ""
+
+#: static/js/common-all.js:10860 static/js/common-min.js:6 static/js/impala-all.js:11481 static/js/impala-min.js:6 static/js/impala/reviews.js:23 static/js/zamboni/reviews.js:18
+msgid "Flagged for review"
+msgstr "Zur Überprüfung markiert"
+
+#: static/js/common-all.js:10876 static/js/common-min.js:6 static/js/impala-all.js:11498 static/js/impala-min.js:6 static/js/impala/reviews.js:40 static/js/zamboni/reviews.js:34
+msgid "Your input is required"
+msgstr "Ihre Eingabe wird benötigt"
+
+#: static/js/common-all.js:10945 static/js/common-min.js:6 static/js/impala-all.js:11610 static/js/impala-min.js:7 static/js/impala/reviews.js:152 static/js/zamboni/reviews.js:103
+msgid "Marked for deletion"
+msgstr "Zum Löschen markiert"
+
+#: static/js/common-all.js:11573 static/js/common-min.js:7 static/js/impala-all.js:13809 static/js/impala-min.js:8 static/js/zamboni/collections.js:229
+msgid "Adding to Favorites&hellip;"
+msgstr "Wird zu Favoriten hinzugefügt …"
+
+#: static/js/common-all.js:11576 static/js/common-min.js:7 static/js/impala-all.js:13812 static/js/impala-min.js:8 static/js/zamboni/collections.js:232
+msgid "Removing Favorite&hellip;"
+msgstr "Favorit wird entfernt …"
+
+#: static/js/common-all.js:11579 static/js/common-min.js:7 static/js/impala-all.js:13815 static/js/impala-min.js:8 static/js/zamboni/collections.js:235
+msgid "Add to Favorites"
+msgstr "Zu Favoriten hinzufügen"
+
+#: static/js/common-all.js:11582 static/js/common-min.js:7 static/js/impala-all.js:13818 static/js/impala-min.js:8 static/js/zamboni/collections.js:238
+msgid "Remove from Favorites"
+msgstr "Aus Favoriten entfernen"
+
+#: static/js/common-all.js:11647 static/js/common-min.js:7 static/js/impala-all.js:13883 static/js/impala-min.js:8 static/js/zamboni/collections.js:303
+msgid "Pending"
+msgstr "Ausstehend"
+
+#: static/js/common-all.js:11648 static/js/common-min.js:7 static/js/impala-all.js:13884 static/js/impala-min.js:8 static/js/zamboni/collections.js:304
+msgid "Add a comment"
+msgstr "Einen Kommentar hinzufügen"
+
+#: static/js/common-all.js:11648 static/js/common-min.js:7 static/js/impala-all.js:13884 static/js/impala-min.js:8 static/js/zamboni/collections.js:304
+msgid "Comment"
+msgstr "Kommentar"
+
+#: static/js/common-all.js:11649 static/js/common-min.js:7 static/js/impala-all.js:13885 static/js/impala-min.js:8 static/js/zamboni/collections.js:305
+msgid "Remove this add-on from the collection"
+msgstr "Dieses Add-on aus der Sammlung entfernen"
+
+#: static/js/common-all.js:11649 static/js/common-all.js:11678 static/js/common-min.js:7 static/js/impala-all.js:13885 static/js/impala-all.js:13914 static/js/impala-min.js:8
+#: static/js/zamboni/collections.js:305 static/js/zamboni/collections.js:334
+msgid "Remove"
+msgstr "Entfernen"
+
+#: static/js/common-all.js:11678 static/js/common-min.js:7 static/js/impala-all.js:13914 static/js/impala-min.js:8 static/js/zamboni/collections.js:334
+msgid "Remove this user as a contributor"
+msgstr "Diesen Benutzer als Mitwirkenden entfernen"
+
+#: static/js/common-all.js:11690 static/js/common-min.js:7 static/js/impala-all.js:13926 static/js/impala-min.js:8 static/js/zamboni/collections.js:346
+msgid "An email address is required."
+msgstr "Eine E-Mail-Adresse ist erforderlich."
+
+#: static/js/common-all.js:11708 static/js/common-min.js:7 static/js/impala-all.js:13944 static/js/impala-min.js:8 static/js/zamboni/collections.js:364
+msgid "You cannot add yourself as a contributor."
+msgstr "Sie können sich nicht selbst als Mitwirkenden hinzufügen."
+
+#: static/js/common-all.js:11710 static/js/common-min.js:7 static/js/impala-all.js:13946 static/js/impala-min.js:8 static/js/zamboni/collections.js:366
+msgid "You have already added that user."
+msgstr "Sie haben diesen Benutzer bereits hinzugefügt."
+
+#: static/js/common-all.js:11917 static/js/common-min.js:7 static/js/impala-all.js:14153 static/js/impala-min.js:8 static/js/zamboni/collections.js:573
+msgid "Add to favorites"
+msgstr "Zu Favoriten hinzufügen"
+
+#: static/js/common-all.js:11921 static/js/common-min.js:7 static/js/impala-all.js:14157 static/js/impala-min.js:8 static/js/zamboni/collections.js:577
+msgid "Remove from favorites"
+msgstr "Aus Favoriten entfernen"
+
+#: static/js/common-all.js:11939 static/js/common-min.js:7 static/js/impala-all.js:14175 static/js/impala-all.js:14233 static/js/impala-min.js:8 static/js/impala/collections.js:10
+#: static/js/zamboni/collections.js:595
+msgid "Follow this Collection"
+msgstr "Dieser Sammlung folgen"
+
+#: static/js/common-all.js:11948 static/js/common-min.js:7 static/js/impala-all.js:14184 static/js/impala-min.js:8 static/js/zamboni/collections.js:604
+msgid "Stop following"
+msgstr "Nicht mehr folgen"
+
+#: static/js/common-all.js:12096 static/js/common-min.js:7 static/js/zamboni/password-strength.js:20
 msgid "Password strength:"
 msgstr "Passwort-Stärke:"
 
-#: static/js/zamboni/password-strength.js:26
+#: static/js/common-all.js:12102 static/js/common-min.js:7 static/js/zamboni/password-strength.js:26
 msgid "At least {0} character left."
 msgid_plural "At least {0} characters left."
 msgstr[0] "Mindestens {0} Zeichen übrig."
 msgstr[1] "Mindestens {0} Zeichen übrig."
 
-#: static/js/zamboni/themes_review.js:176
-msgid "Requested Info"
-msgstr "Informationen angefordert"
+#: static/js/common-all.js:12286 static/js/common-min.js:7 static/js/impala-all.js:14632 static/js/impala-min.js:8 static/js/impala/suggestions.js:39
+msgid "Search themes for <b>{0}</b>"
+msgstr "Suche nach Themes für <b>{0}</b>"
 
-#: static/js/zamboni/themes_review.js:177
-msgid "Flagged"
-msgstr "Markiert"
+#: static/js/common-all.js:12288 static/js/common-min.js:7 static/js/impala-all.js:14634 static/js/impala-min.js:8 static/js/impala/suggestions.js:41
+msgid "Search apps for <b>{0}</b>"
+msgstr "Apps suchen für <b>{0}</b>"
 
-#: static/js/zamboni/themes_review.js:178
-msgid "Duplicate"
-msgstr "Duplikat"
+#: static/js/common-all.js:12290 static/js/common-min.js:7 static/js/impala-all.js:14636 static/js/impala-min.js:8 static/js/impala/suggestions.js:43
+msgid "Search add-ons for <b>{0}</b>"
+msgstr "Add-ons suchen für <b>{0}</b>"
 
-#: static/js/zamboni/themes_review.js:179
-msgid "Rejected"
-msgstr "Abgelehnt"
+#: static/js/common-all.js:12521 static/js/common-min.js:7 static/js/impala-all.js:14867 static/js/impala-min.js:8 static/js/impala/site_suggestions.js:46
+msgid "Category"
+msgstr "Kategorie"
 
-#: static/js/zamboni/themes_review.js:180
-msgid "Approved"
-msgstr "Freigeschaltet"
+#. L10n: {0} is an app name.
+#: static/js/impala-all.js:11632 static/js/impala-min.js:7 static/js/impala/listing.js:11 static/js/zamboni/themes.js:13
+msgid "This theme is incompatible with your version of {0}"
+msgstr "Dieses Theme ist mit Ihrer Version von {0} nicht kompatibel"
 
-#: static/js/zamboni/themes_review.js:424
-msgid "No results found"
-msgstr "Keine Ergebnisse gefunden"
+#: static/js/impala-all.js:12146 static/js/impala-all.js:14331 static/js/impala-min.js:7 static/js/impala-min.js:8 static/js/common/upload-image.js:97 static/js/impala/users.js:51
+#: static/js/zamboni/devhub-all.js:894 static/js/zamboni/devhub-min.js:1
+msgid "Images must be either PNG or JPG."
+msgstr "Grafiken müssen entweder PNG oder JPG sein."
 
-#: static/js/zamboni/themes_review_templates.js:31
-msgid "Theme"
-msgstr "Theme"
+#: static/js/impala-all.js:12150 static/js/impala-min.js:7 static/js/common/upload-image.js:101 static/js/zamboni/devhub-all.js:898 static/js/zamboni/devhub-min.js:1
+msgid "Videos must be in WebM."
+msgstr "Videos müssen im WebM-Format sein."
 
-#: static/js/zamboni/themes_review_templates.js:33
-msgid "Reviewer"
-msgstr "Überprüfer"
+#: static/js/impala-all.js:12177 static/js/impala-min.js:7 static/js/common/upload-addon.js:41 static/js/common/upload-image.js:128 static/js/zamboni/devhub-all.js:272
+#: static/js/zamboni/devhub-all.js:925 static/js/zamboni/devhub-min.js:1
+msgid "There was a problem contacting the server."
+msgstr "Beim Kontaktieren des Servers ist ein Fehler aufgetreten."
 
-#: static/js/zamboni/themes_review_templates.js:35
-msgid "Status"
-msgstr "Status"
+#: static/js/impala-all.js:13298 static/js/impala-min.js:7 static/js/impala/persona_creation.js:60
+msgid "All Rights Reserved"
+msgstr "Alle Rechte vorbehalten"
 
-#: static/js/zamboni/validator.js:80
+#: static/js/impala-all.js:13302 static/js/impala-min.js:7 static/js/impala/persona_creation.js:64
+msgid "Creative Commons Attribution 3.0"
+msgstr "Creative Commons Attribution 3.0"
+
+#: static/js/impala-all.js:13307 static/js/impala-min.js:7 static/js/impala/persona_creation.js:69
+msgid "Creative Commons Attribution-NonCommercial 3.0"
+msgstr "Creative Commons Attribution-NonCommercial 3.0"
+
+#: static/js/impala-all.js:13312 static/js/impala-min.js:7 static/js/impala/persona_creation.js:74
+msgid "Creative Commons Attribution-NonCommercial-NoDerivs 3.0"
+msgstr "Creative Commons Attribution-NonCommercial-NoDerivs 3.0"
+
+#: static/js/impala-all.js:13317 static/js/impala-min.js:7 static/js/impala/persona_creation.js:79
+msgid "Creative Commons Attribution-NonCommercial-Share Alike 3.0"
+msgstr "Creative Commons Attribution-NonCommercial-Share Alike 3.0"
+
+#: static/js/impala-all.js:13322 static/js/impala-min.js:7 static/js/impala/persona_creation.js:84
+msgid "Creative Commons Attribution-NoDerivs 3.0"
+msgstr "Creative Commons Attribution-NoDerivs 3.0"
+
+#: static/js/impala-all.js:13327 static/js/impala-min.js:7 static/js/impala/persona_creation.js:89
+msgid "Creative Commons Attribution-ShareAlike 3.0"
+msgstr "Creative Commons Attribution-ShareAlike 3.0"
+
+#: static/js/impala-all.js:13530 static/js/impala-min.js:7 static/js/impala/persona_creation.js:292
+msgid "Your Theme's Name"
+msgstr "Name Ihres Themes"
+
+#: static/js/impala-all.js:14242 static/js/impala-min.js:8 static/js/impala/collections.js:19
+msgid "Stop Following"
+msgstr "Nicht mehr folgen"
+
+#: static/js/impala-all.js:14243 static/js/impala-min.js:8 static/js/impala/collections.js:20
+msgid "Following"
+msgstr "Folgen"
+
+#: static/js/impala-all.js:14313 static/js/impala-min.js:8 static/js/impala/users.js:33
+msgid "use original"
+msgstr "Original verwenden"
+
+#: static/js/impala-all.js:14523 static/js/impala-min.js:8 static/js/impala/search.js:114
+msgid "Updating results&hellip;"
+msgstr "Ergebnisse werden aktualisiert …"
+
+#: static/js/common/upload-addon.js:69 static/js/zamboni/devhub-all.js:300 static/js/zamboni/devhub-min.js:1
+msgid "Select a file..."
+msgstr "Wählen Sie eine Datei aus…"
+
+#: static/js/common/upload-addon.js:70 static/js/zamboni/devhub-all.js:301 static/js/zamboni/devhub-min.js:1
+msgid "Your add-on should end with .xpi, .jar or .xml"
+msgstr "Ihr Add-on sollte eine der Dateiendungen .xpi, .jar oder .xml haben"
+
+#. L10n: {0} is the percent of the file that has been uploaded.
+#: static/js/common/upload-addon.js:104 static/js/zamboni/devhub-all.js:335 static/js/zamboni/devhub-min.js:1
+#, python-format
+msgid "{0}% complete"
+msgstr "{0}% abgeschlossen"
+
+#. L10n: "{bytes uploaded} of {total filesize}".
+#: static/js/common/upload-addon.js:107 static/js/zamboni/devhub-all.js:338 static/js/zamboni/devhub-min.js:1
+msgid "{0} of {1}"
+msgstr "{0} von {1}"
+
+#: static/js/common/upload-addon.js:140 static/js/zamboni/devhub-all.js:371 static/js/zamboni/devhub-min.js:1
+msgid "Cancel"
+msgstr "Abbrechen"
+
+#: static/js/common/upload-addon.js:162 static/js/zamboni/devhub-all.js:393 static/js/zamboni/devhub-min.js:1
+msgid "Uploading {0}"
+msgstr "{0} wird hochgeladen"
+
+#: static/js/common/upload-addon.js:189 static/js/zamboni/devhub-all.js:420 static/js/zamboni/devhub-min.js:1
+msgid "Error with {0}"
+msgstr "Fehler bei {0}"
+
+#: static/js/common/upload-addon.js:194 static/js/zamboni/devhub-all.js:425 static/js/zamboni/devhub-min.js:1
+msgid "Your add-on failed validation with {0} error."
+msgid_plural "Your add-on failed validation with {0} errors."
+msgstr[0] "Ihr Add-on ist bei der Überprüfung mit {0} Fehler durchgefallen."
+msgstr[1] "Ihr Add-on ist bei der Überprüfung mit {0} Fehlern durchgefallen."
+
+#: static/js/common/upload-addon.js:208 static/js/zamboni/devhub-all.js:439 static/js/zamboni/devhub-min.js:1
+msgid "&hellip;and {0} more"
+msgid_plural "&hellip;and {0} more"
+msgstr[0] "&hellip; und {0} weiterer"
+msgstr[1] "&hellip; und {0} weitere"
+
+#: static/js/common/upload-addon.js:222 static/js/common/upload-addon.js:497 static/js/zamboni/devhub-all.js:453 static/js/zamboni/devhub-all.js:743 static/js/zamboni/devhub-min.js:1
+msgid "See full validation report"
+msgstr "Vollständigen Überprüfungsbericht lesen"
+
+#: static/js/common/upload-addon.js:234 static/js/zamboni/devhub-all.js:465 static/js/zamboni/devhub-min.js:1
+msgid "Validating {0}"
+msgstr "Überprüfung von {0}"
+
+#. L10n: first argument is an HTTP status code
+#: static/js/common/upload-addon.js:273 static/js/zamboni/devhub-all.js:504 static/js/zamboni/devhub-min.js:1
+msgid "Received an empty response from the server; status: {0}"
+msgstr "Leere Antwort vom Server erhalten; Status: {0}"
+
+#: static/js/common/upload-addon.js:370 static/js/zamboni/devhub-all.js:604 static/js/zamboni/devhub-min.js:1
+msgid "Unexpected server error while validating."
+msgstr "Unerwarteter Server-Fehler bei der Überprüfung."
+
+#: static/js/common/upload-addon.js:409 static/js/zamboni/devhub-all.js:643 static/js/zamboni/devhub-min.js:1
+msgid "Finished validating {0}"
+msgstr "Überprüfung abgeschlossen {0}"
+
+#: static/js/common/upload-addon.js:415 static/js/zamboni/devhub-all.js:649 static/js/zamboni/devhub-min.js:1
+msgid "Your add-on validation timed out, it will be manually reviewed."
+msgstr "Zeitüberschreitung bei Ihrer Add-on-Validierung, es gibt eine manuelle Überprüfung."
+
+#: static/js/common/upload-addon.js:418 static/js/zamboni/devhub-all.js:652 static/js/zamboni/devhub-min.js:1
+msgid "Your add-on was validated with no errors and {0} warning."
+msgid_plural "Your add-on was validated with no errors and {0} warnings."
+msgstr[0] "Ihr Add-on wurde ohne Fehler und {0} Warnung validiert."
+msgstr[1] "Ihr Add-on wurde ohne Fehler und {0} Warnungen validiert."
+
+#: static/js/common/upload-addon.js:423 static/js/zamboni/devhub-all.js:657 static/js/zamboni/devhub-min.js:1
+msgid "Your add-on was validated with no errors and {0} message."
+msgid_plural "Your add-on was validated with no errors and {0} messages."
+msgstr[0] "Ihr Add-on wurde ohne Fehler und mit {0} Hinweis validiert."
+msgstr[1] "Ihr Add-on wurde ohne Fehler und mit {0} Hinweisen validiert."
+
+#: static/js/common/upload-addon.js:428 static/js/zamboni/devhub-all.js:662 static/js/zamboni/devhub-min.js:1
+msgid "Your add-on was validated with no errors or warnings."
+msgstr "Ihr Add-on wurde ohne Fehler und Hinweise validiert."
+
+#: static/js/common/upload-addon.js:443 static/js/zamboni/devhub-all.js:677 static/js/zamboni/devhub-min.js:1
+msgid "Your submission will be automatically signed."
+msgstr "Ihre Einreichung wird automatisch signiert."
+
+#: static/js/common/upload-addon.js:450 static/js/zamboni/devhub-all.js:696 static/js/zamboni/devhub-min.js:1
+msgid "Include detailed version notes (this can be done in the next step)."
+msgstr "Fügen Sie detaillierte Versionshinweise hinzu (dies kann im nächsten Schritt geschehen)."
+
+#: static/js/common/upload-addon.js:451 static/js/zamboni/devhub-all.js:697 static/js/zamboni/devhub-min.js:1
+msgid "If your add-on requires an account to a website in order to be fully tested, include a test username and password in the Notes to Reviewer (this can be done in the next step)."
+msgstr ""
+"Wenn Ihr Add-on ein Benutzerkonto bei einer Webseite benötigt, um vollständig getestet zu werden, fügen Sie in den Hinweisen an den Überprüfer Benutzername und Passwort eines Testkontos hinzu (dies "
+"kann im nächsten Schritt geschehen)."
+
+#: static/js/common/upload-addon.js:452 static/js/zamboni/devhub-all.js:698 static/js/zamboni/devhub-min.js:1
+msgid "If your add-on is intended for a limited audience you should choose Preliminary Review instead of Full Review."
+msgstr "Wenn Ihr Add-on für eine begrenzte Nutzergruppe gedacht ist, sollten Sie „Vorläufige Überprüfung“ anstelle von „Vollständige Überprüfung“ wählen."
+
+#: static/js/common/upload-addon.js:465 static/js/zamboni/devhub-all.js:711 static/js/zamboni/devhub-min.js:1
+msgid "Add-on submission checklist"
+msgstr "Checkliste für Add-on-Einreichung"
+
+#: static/js/common/upload-addon.js:466 static/js/zamboni/devhub-all.js:712 static/js/zamboni/devhub-min.js:1
+msgid "Please verify the following points before finalizing your submission. This will minimize delays or misunderstanding during the review process:"
+msgstr "Bitte überprüfen Sie die folgenden Punkte, bevor Sie Ihre Einreichung abschließen. Dies minimiert Verzögerungen oder Missverständnisse während des Überprüfungsprozesses:"
+
+#: static/js/common/upload-addon.js:468 static/js/zamboni/devhub-all.js:714 static/js/zamboni/devhub-min.js:1
+msgid ""
+"Compiled binaries, as well as minified or obfuscated scripts (excluding known libraries) need to have their sources submitted separately for review. Make sure that you use the source code upload "
+"field to avoid having your submission rejected."
+msgstr ""
+"Von kompilierten Binärdateien sowie verkürzten oder verschleierten Skripten (außer bekannten Bibliotheken) müssen die Quelltexte getrennt zur Überprüfung eingereicht werden. Verwenden Sie unbedingt "
+"das Feld zum Hochladen von Quelltext, damit Ihre Einreichung nicht abgelehnt wird."
+
+#: static/js/common/upload-addon.js:486 static/js/zamboni/devhub-all.js:732 static/js/zamboni/devhub-min.js:1
+msgid "The validation process found these issues that can lead to rejections:"
+msgstr "Der Validierungsprozess stellte folgende Probleme fest, die zur Ablehnung führen könnten:"
+
+#: static/js/common/upload-addon.js:503 static/js/zamboni/devhub-all.js:749 static/js/zamboni/devhub-min.js:1
+msgid "If you are unfamiliar with the add-ons review process, you can read about it here."
+msgstr "Wenn Ihnen der Prozess der Add-on-Überprüfung unbekannt ist, finden Sie hier weitere Informationen darüber."
+
+#: static/js/common/upload-addon.js:540 static/js/zamboni/devhub-all.js:786 static/js/zamboni/devhub-min.js:1
+msgid "Sorry, no supported platform has been found."
+msgstr "Es tut uns leid, es wurde keine unterstützte Plattform gefunden."
+
+#: static/js/common/upload-base.js:57 static/js/zamboni/devhub-all.js:187 static/js/zamboni/devhub-min.js:1
+msgid "The filetype you uploaded isn't recognized."
+msgstr "Der Dateityp, den Sie hochgeladen haben, wurde nicht erkannt."
+
+#: static/js/common/upload-base.js:79 static/js/zamboni/devhub-all.js:209 static/js/zamboni/devhub-min.js:1
+msgid "You cancelled the upload."
+msgstr "Sie haben das Hochladen abgebrochen."
+
+#: static/js/impala/stats/chart.js:267 static/js/zamboni/stats-all.js:16898 static/js/zamboni/stats-min.js:5
+msgid "Week of {0}"
+msgstr "Woche von {0}"
+
+#: static/js/impala/stats/chart.js:269 static/js/zamboni/stats-all.js:16900 static/js/zamboni/stats-min.js:5
+msgid " downloads"
+msgstr ""
+
+#: static/js/impala/stats/chart.js:270 static/js/zamboni/stats-all.js:16901 static/js/zamboni/stats-min.js:5
+msgid "{0} users"
+msgstr "{0} Benutzer"
+
+#: static/js/impala/stats/chart.js:271 static/js/zamboni/stats-all.js:16902 static/js/zamboni/stats-min.js:5
+msgid "{0} add-ons"
+msgstr "{0} Add-ons"
+
+#: static/js/impala/stats/chart.js:272 static/js/zamboni/stats-all.js:16903 static/js/zamboni/stats-min.js:5
+msgid "{0} collections"
+msgstr "{0} Sammlungen"
+
+#: static/js/impala/stats/chart.js:273 static/js/zamboni/stats-all.js:16904 static/js/zamboni/stats-min.js:5
+msgid "{0} reviews"
+msgstr "{0} Bewertungen"
+
+#: static/js/impala/stats/chart.js:275 static/js/zamboni/stats-all.js:16906 static/js/zamboni/stats-min.js:5
+msgid "{0} sales"
+msgstr "{0} Verkäufe"
+
+#: static/js/impala/stats/chart.js:276 static/js/zamboni/stats-all.js:16907 static/js/zamboni/stats-min.js:5
+msgid "{0} refunds"
+msgstr "{0} Erstattungen"
+
+#: static/js/impala/stats/chart.js:277 static/js/zamboni/stats-all.js:16908 static/js/zamboni/stats-min.js:5
+msgid "{0} installs"
+msgstr "{0} Installationen"
+
+#: static/js/impala/stats/chart.js:369 static/js/impala/stats/csv_keys.js:3 static/js/impala/stats/csv_keys.js:109 static/js/zamboni/stats-all.js:15284 static/js/zamboni/stats-all.js:15390
+#: static/js/zamboni/stats-all.js:17000 static/js/zamboni/stats-min.js:4 static/js/zamboni/stats-min.js:5
+msgid "Downloads"
+msgstr "Downloads"
+
+#: static/js/impala/stats/chart.js:379 static/js/impala/stats/csv_keys.js:6 static/js/impala/stats/csv_keys.js:110 static/js/zamboni/stats-all.js:15287 static/js/zamboni/stats-all.js:15391
+#: static/js/zamboni/stats-all.js:17010 static/js/zamboni/stats-min.js:4 static/js/zamboni/stats-min.js:5
+msgid "Daily Users"
+msgstr "Tägliche Benutzer"
+
+#: static/js/impala/stats/chart.js:410 static/js/zamboni/stats-all.js:17041 static/js/zamboni/stats-min.js:5
+msgid "Amount, in USD"
+msgstr "Betrag in US$"
+
+#: static/js/impala/stats/chart.js:421 static/js/impala/stats/csv_keys.js:104 static/js/zamboni/stats-all.js:15385 static/js/zamboni/stats-all.js:17052 static/js/zamboni/stats-min.js:5
+msgid "Number of Contributions"
+msgstr "Zahl der Beiträge"
+
+#: static/js/impala/stats/chart.js:447 static/js/zamboni/stats-all.js:17078 static/js/zamboni/stats-min.js:5
+msgid "More Info..."
+msgstr "Weitere Informationen …"
+
+#. L10n: {0} is an ISO-formatted date.
+#: static/js/impala/stats/chart.js:451 static/js/zamboni/stats-all.js:17082 static/js/zamboni/stats-min.js:5
+msgid "Details for {0}"
+msgstr "Details zu {0}"
+
+#: static/js/impala/stats/csv_keys.js:9 static/js/zamboni/stats-all.js:15290 static/js/zamboni/stats-min.js:4
+msgid "Collections Created"
+msgstr "Erstellte Sammlungen"
+
+#: static/js/impala/stats/csv_keys.js:12 static/js/zamboni/stats-all.js:15293 static/js/zamboni/stats-min.js:4
+msgid "Add-ons in Use"
+msgstr "Verwendete Add-ons"
+
+#: static/js/impala/stats/csv_keys.js:15 static/js/zamboni/stats-all.js:15296 static/js/zamboni/stats-min.js:4
+msgid "Add-ons Created"
+msgstr "Erstellte Add-ons"
+
+#: static/js/impala/stats/csv_keys.js:18 static/js/zamboni/stats-all.js:15299 static/js/zamboni/stats-min.js:4
+msgid "Add-ons Downloaded"
+msgstr "Heruntergeladene Add-ons"
+
+#: static/js/impala/stats/csv_keys.js:21 static/js/zamboni/stats-all.js:15302 static/js/zamboni/stats-min.js:4
+msgid "Add-ons Updated"
+msgstr "Aktualisierte Add-ons"
+
+#: static/js/impala/stats/csv_keys.js:24 static/js/zamboni/stats-all.js:15305 static/js/zamboni/stats-min.js:4
+msgid "Reviews Written"
+msgstr "Geschriebene Bewertungen"
+
+#: static/js/impala/stats/csv_keys.js:27 static/js/zamboni/stats-all.js:15308 static/js/zamboni/stats-min.js:4
+msgid "User Signups"
+msgstr "Registrierte Benutzer"
+
+#: static/js/impala/stats/csv_keys.js:30 static/js/zamboni/stats-all.js:15311 static/js/zamboni/stats-min.js:4
+msgid "Subscribers"
+msgstr "Abonnenten"
+
+#: static/js/impala/stats/csv_keys.js:33 static/js/zamboni/stats-all.js:15314 static/js/zamboni/stats-min.js:4
+msgid "Ratings"
+msgstr "Bewertungen"
+
+#: static/js/impala/stats/csv_keys.js:36 static/js/impala/stats/csv_keys.js:114 static/js/zamboni/stats-all.js:15317 static/js/zamboni/stats-all.js:15395 static/js/zamboni/stats-min.js:4
+#: static/js/zamboni/stats-min.js:5
+msgid "Sales"
+msgstr "Verkäufe"
+
+#: static/js/impala/stats/csv_keys.js:39 static/js/impala/stats/csv_keys.js:113 static/js/zamboni/stats-all.js:15320 static/js/zamboni/stats-all.js:15394 static/js/zamboni/stats-min.js:4
+#: static/js/zamboni/stats-min.js:5
+msgid "Installs"
+msgstr "Installationen"
+
+#: static/js/impala/stats/csv_keys.js:42 static/js/zamboni/stats-all.js:15323 static/js/zamboni/stats-min.js:4
+msgid "Unknown"
+msgstr "Unbekannt"
+
+#: static/js/impala/stats/csv_keys.js:43 static/js/zamboni/stats-all.js:15324 static/js/zamboni/stats-min.js:4
+msgid "Add-ons Manager"
+msgstr "Add-ons-Manager"
+
+#: static/js/impala/stats/csv_keys.js:44 static/js/zamboni/stats-all.js:15325 static/js/zamboni/stats-min.js:4
+msgid "Add-ons Manager Promo"
+msgstr "Add-ons-Manager „Promo“"
+
+#: static/js/impala/stats/csv_keys.js:45 static/js/zamboni/stats-all.js:15326 static/js/zamboni/stats-min.js:4
+msgid "Add-ons Manager Featured"
+msgstr "Add-ons-Manager „Vorgestellt“"
+
+#: static/js/impala/stats/csv_keys.js:46 static/js/zamboni/stats-all.js:15327 static/js/zamboni/stats-min.js:4
+msgid "Add-ons Manager Learn More"
+msgstr "Add-ons-Manager „Mehr erfahren“"
+
+#: static/js/impala/stats/csv_keys.js:47 static/js/zamboni/stats-all.js:15328 static/js/zamboni/stats-min.js:4
+msgid "Search Suggestions"
+msgstr "Suchvorschläge"
+
+#: static/js/impala/stats/csv_keys.js:48 static/js/zamboni/stats-all.js:15329 static/js/zamboni/stats-min.js:4
+msgid "Search Results"
+msgstr "Suchergebnisse"
+
+#: static/js/impala/stats/csv_keys.js:49 static/js/impala/stats/csv_keys.js:50 static/js/impala/stats/csv_keys.js:51 static/js/zamboni/stats-all.js:15330 static/js/zamboni/stats-all.js:15331
+#: static/js/zamboni/stats-all.js:15332 static/js/zamboni/stats-min.js:4
+msgid "Homepage Promo"
+msgstr "Startseite „Promo“"
+
+#: static/js/impala/stats/csv_keys.js:52 static/js/impala/stats/csv_keys.js:53 static/js/zamboni/stats-all.js:15333 static/js/zamboni/stats-all.js:15334 static/js/zamboni/stats-min.js:4
+msgid "Homepage Featured"
+msgstr "Startseite „Vorgestellt“"
+
+#: static/js/impala/stats/csv_keys.js:54 static/js/impala/stats/csv_keys.js:55 static/js/zamboni/stats-all.js:15335 static/js/zamboni/stats-all.js:15336 static/js/zamboni/stats-min.js:4
+msgid "Homepage Up and Coming"
+msgstr "Startseite „Aufstrebend“"
+
+#: static/js/impala/stats/csv_keys.js:56 static/js/zamboni/stats-all.js:15337 static/js/zamboni/stats-min.js:4
+msgid "Homepage Most Popular"
+msgstr "Startseite „Beliebteste“"
+
+#: static/js/impala/stats/csv_keys.js:57 static/js/impala/stats/csv_keys.js:59 static/js/zamboni/stats-all.js:15338 static/js/zamboni/stats-all.js:15340 static/js/zamboni/stats-min.js:4
+msgid "Detail Page"
+msgstr "Detailseite"
+
+#: static/js/impala/stats/csv_keys.js:58 static/js/impala/stats/csv_keys.js:60 static/js/zamboni/stats-all.js:15339 static/js/zamboni/stats-all.js:15341 static/js/zamboni/stats-min.js:4
+msgid "Detail Page (bottom)"
+msgstr "Detailseite (Ende)"
+
+#: static/js/impala/stats/csv_keys.js:61 static/js/zamboni/stats-all.js:15342 static/js/zamboni/stats-min.js:4
+msgid "Detail Page (Development Channel)"
+msgstr "Detailseite (Entwicklerkanal)"
+
+#: static/js/impala/stats/csv_keys.js:62 static/js/impala/stats/csv_keys.js:63 static/js/impala/stats/csv_keys.js:64 static/js/zamboni/stats-all.js:15343 static/js/zamboni/stats-all.js:15344
+#: static/js/zamboni/stats-all.js:15345 static/js/zamboni/stats-min.js:4
+msgid "Often Used With"
+msgstr "Oft verwendet mit"
+
+#: static/js/impala/stats/csv_keys.js:65 static/js/impala/stats/csv_keys.js:66 static/js/zamboni/stats-all.js:15346 static/js/zamboni/stats-all.js:15347 static/js/zamboni/stats-min.js:4
+msgid "Others By Author"
+msgstr "Andere von diesem Autor"
+
+#: static/js/impala/stats/csv_keys.js:67 static/js/impala/stats/csv_keys.js:68 static/js/zamboni/stats-all.js:15348 static/js/zamboni/stats-all.js:15349 static/js/zamboni/stats-min.js:4
+msgid "Dependencies"
+msgstr "Abhängigkeiten"
+
+#: static/js/impala/stats/csv_keys.js:69 static/js/impala/stats/csv_keys.js:70 static/js/zamboni/stats-all.js:15350 static/js/zamboni/stats-all.js:15351 static/js/zamboni/stats-min.js:4
+msgid "Upsell"
+msgstr "Zusatzverkäufe"
+
+#: static/js/impala/stats/csv_keys.js:71 static/js/zamboni/stats-all.js:15352 static/js/zamboni/stats-min.js:4
+msgid "Meet the Developer"
+msgstr "Lernen Sie den Entwickler kennen"
+
+#: static/js/impala/stats/csv_keys.js:72 static/js/zamboni/stats-all.js:15353 static/js/zamboni/stats-min.js:4
+msgid "User Profile"
+msgstr "Benutzerprofil"
+
+#: static/js/impala/stats/csv_keys.js:73 static/js/zamboni/stats-all.js:15354 static/js/zamboni/stats-min.js:4
+msgid "Version History"
+msgstr "Versionsgeschichte"
+
+#: static/js/impala/stats/csv_keys.js:75 static/js/zamboni/stats-all.js:15356 static/js/zamboni/stats-min.js:4
+msgid "Sharing"
+msgstr "Weitergeben"
+
+#: static/js/impala/stats/csv_keys.js:76 static/js/zamboni/stats-all.js:15357 static/js/zamboni/stats-min.js:4
+msgid "Category Pages"
+msgstr "Kategorieseiten"
+
+#: static/js/impala/stats/csv_keys.js:77 static/js/zamboni/stats-all.js:15358 static/js/zamboni/stats-min.js:4
+msgid "Collections"
+msgstr "Sammlungen"
+
+#: static/js/impala/stats/csv_keys.js:78 static/js/impala/stats/csv_keys.js:79 static/js/zamboni/stats-all.js:15359 static/js/zamboni/stats-all.js:15360 static/js/zamboni/stats-min.js:4
+msgid "Category Landing Featured Carousel"
+msgstr "Kategorie-Übersicht „Karussell der Vorgestellten“"
+
+#: static/js/impala/stats/csv_keys.js:80 static/js/impala/stats/csv_keys.js:81 static/js/zamboni/stats-all.js:15361 static/js/zamboni/stats-all.js:15362 static/js/zamboni/stats-min.js:4
+msgid "Category Landing Top Rated"
+msgstr "Kategorie-Übersicht „Höchste Bewertung“"
+
+#: static/js/impala/stats/csv_keys.js:82 static/js/impala/stats/csv_keys.js:83 static/js/zamboni/stats-all.js:15363 static/js/zamboni/stats-all.js:15364 static/js/zamboni/stats-min.js:5
+msgid "Category Landing Most Popular"
+msgstr "Kategorie-Übersicht „Beliebteste“"
+
+#: static/js/impala/stats/csv_keys.js:84 static/js/impala/stats/csv_keys.js:85 static/js/zamboni/stats-all.js:15365 static/js/zamboni/stats-all.js:15366 static/js/zamboni/stats-min.js:5
+msgid "Category Landing Recently Added"
+msgstr "Kategorie-Übersicht „Zuletzt hinzugefügt“"
+
+#: static/js/impala/stats/csv_keys.js:86 static/js/impala/stats/csv_keys.js:87 static/js/zamboni/stats-all.js:15367 static/js/zamboni/stats-all.js:15368 static/js/zamboni/stats-min.js:5
+msgid "Browse Listing Featured Sort"
+msgstr "Auflistung durchsuchen „Sortiert nach Vorgestellt“"
+
+#: static/js/impala/stats/csv_keys.js:88 static/js/impala/stats/csv_keys.js:89 static/js/zamboni/stats-all.js:15369 static/js/zamboni/stats-all.js:15370 static/js/zamboni/stats-min.js:5
+msgid "Browse Listing Users Sort"
+msgstr "Auflistung durchsuchen „Sortiert nach Benutzern“"
+
+#: static/js/impala/stats/csv_keys.js:90 static/js/impala/stats/csv_keys.js:91 static/js/zamboni/stats-all.js:15371 static/js/zamboni/stats-all.js:15372 static/js/zamboni/stats-min.js:5
+msgid "Browse Listing Rating Sort"
+msgstr "Auflistung durchsuchen „Sortiert nach Bewertung“"
+
+#: static/js/impala/stats/csv_keys.js:92 static/js/impala/stats/csv_keys.js:93 static/js/zamboni/stats-all.js:15373 static/js/zamboni/stats-all.js:15374 static/js/zamboni/stats-min.js:5
+msgid "Browse Listing Created Sort"
+msgstr "Auflistung durchsuchen „Sortiert nach Erstellt“"
+
+#: static/js/impala/stats/csv_keys.js:94 static/js/impala/stats/csv_keys.js:95 static/js/zamboni/stats-all.js:15375 static/js/zamboni/stats-all.js:15376 static/js/zamboni/stats-min.js:5
+msgid "Browse Listing Name Sort"
+msgstr "Auflistung durchsuchen „Sortiert nach Name“"
+
+#: static/js/impala/stats/csv_keys.js:96 static/js/impala/stats/csv_keys.js:97 static/js/zamboni/stats-all.js:15377 static/js/zamboni/stats-all.js:15378 static/js/zamboni/stats-min.js:5
+msgid "Browse Listing Popular Sort"
+msgstr "Auflistung durchsuchen „Sortiert nach Beliebtheit“"
+
+#: static/js/impala/stats/csv_keys.js:98 static/js/impala/stats/csv_keys.js:99 static/js/zamboni/stats-all.js:15379 static/js/zamboni/stats-all.js:15380 static/js/zamboni/stats-min.js:5
+msgid "Browse Listing Updated Sort"
+msgstr "Auflistung durchsuchen „Sortiert nach Aktualisiert“"
+
+#: static/js/impala/stats/csv_keys.js:100 static/js/impala/stats/csv_keys.js:101 static/js/zamboni/stats-all.js:15381 static/js/zamboni/stats-all.js:15382 static/js/zamboni/stats-min.js:5
+msgid "Browse Listing Up and Coming Sort"
+msgstr "Auflistung durchsuchen „Sortiert nach Aufstrebende“"
+
+#: static/js/impala/stats/csv_keys.js:105 static/js/zamboni/stats-all.js:15386 static/js/zamboni/stats-min.js:5
+msgid "Total Amount Contributed"
+msgstr "Insgesamt gespendeter Betrag"
+
+#: static/js/impala/stats/csv_keys.js:106 static/js/zamboni/stats-all.js:15387 static/js/zamboni/stats-min.js:5
+msgid "Average Contribution"
+msgstr "Durchschnittlich gespendeter Betrag"
+
+#: static/js/impala/stats/csv_keys.js:115 static/js/zamboni/stats-all.js:15396 static/js/zamboni/stats-min.js:5
+msgid "Usage"
+msgstr "Verwendung"
+
+#: static/js/impala/stats/csv_keys.js:118 static/js/zamboni/stats-all.js:15399 static/js/zamboni/stats-min.js:5
+msgid "Firefox"
+msgstr "Firefox"
+
+#: static/js/impala/stats/csv_keys.js:119 static/js/zamboni/stats-all.js:15400 static/js/zamboni/stats-min.js:5
+msgid "Mozilla"
+msgstr "Mozilla"
+
+#: static/js/impala/stats/csv_keys.js:120 static/js/zamboni/stats-all.js:15401 static/js/zamboni/stats-min.js:5
+msgid "Thunderbird"
+msgstr "Thunderbird"
+
+#: static/js/impala/stats/csv_keys.js:121 static/js/zamboni/stats-all.js:15402 static/js/zamboni/stats-min.js:5
+msgid "Sunbird"
+msgstr "Sunbird"
+
+#: static/js/impala/stats/csv_keys.js:122 static/js/zamboni/stats-all.js:15403 static/js/zamboni/stats-min.js:5
+msgid "SeaMonkey"
+msgstr "SeaMonkey"
+
+#: static/js/impala/stats/csv_keys.js:123 static/js/zamboni/stats-all.js:15404 static/js/zamboni/stats-min.js:5
+msgid "Fennec"
+msgstr "Fennec"
+
+#: static/js/impala/stats/csv_keys.js:124 static/js/zamboni/stats-all.js:15405 static/js/zamboni/stats-min.js:5
+msgid "Android"
+msgstr "Android"
+
+#. L10n: {0} is an integer.
+#: static/js/impala/stats/csv_keys.js:129 static/js/zamboni/stats-all.js:15410 static/js/zamboni/stats-min.js:5
+msgid "Downloads and Daily Users, last {0} days"
+msgstr "Downloads und tägliche Benutzer, letzte {0} Tage"
+
+#. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
+#: static/js/impala/stats/csv_keys.js:131 static/js/zamboni/stats-all.js:15412 static/js/zamboni/stats-min.js:5
+msgid "Downloads and Daily Users from {0} to {1}"
+msgstr "Downloads und tägliche Benutzer von {0} bis {1}"
+
+#. L10n: {0} is an integer.
+#: static/js/impala/stats/csv_keys.js:135 static/js/zamboni/stats-all.js:15416 static/js/zamboni/stats-min.js:5
+msgid "Installs and Daily Users, last {0} days"
+msgstr "Installationen und tägliche Benutzer, letzte {0} Tage"
+
+#. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
+#: static/js/impala/stats/csv_keys.js:137 static/js/zamboni/stats-all.js:15418 static/js/zamboni/stats-min.js:5
+msgid "Installs and Daily Users from {0} to {1}"
+msgstr "Installationen und tägliche Benutzer von {0} bis {1}"
+
+#. L10n: {0} is an integer.
+#: static/js/impala/stats/csv_keys.js:141 static/js/zamboni/stats-all.js:15422 static/js/zamboni/stats-min.js:5
+msgid "Downloads, last {0} days"
+msgstr "Downloads in den letzten {0} Tagen"
+
+#. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
+#: static/js/impala/stats/csv_keys.js:143 static/js/zamboni/stats-all.js:15424 static/js/zamboni/stats-min.js:5
+msgid "Downloads from {0} to {1}"
+msgstr "Downloads von {0} bis {1}"
+
+#. L10n: {0} is an integer.
+#: static/js/impala/stats/csv_keys.js:147 static/js/zamboni/stats-all.js:15428 static/js/zamboni/stats-min.js:5
+msgid "Daily Users, last {0} days"
+msgstr "Tägliche Benutzer in den letzten {0} Tagen"
+
+#. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
+#: static/js/impala/stats/csv_keys.js:149 static/js/zamboni/stats-all.js:15430 static/js/zamboni/stats-min.js:5
+msgid "Daily Users from {0} to {1}"
+msgstr "Tägliche Benutzer von {0} bis {1}"
+
+#. L10n: {0} is an integer.
+#: static/js/impala/stats/csv_keys.js:153 static/js/zamboni/stats-all.js:15434 static/js/zamboni/stats-min.js:5
+msgid "Applications, last {0} days"
+msgstr "Apps in den letzten {0} Tagen"
+
+#. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
+#: static/js/impala/stats/csv_keys.js:155 static/js/zamboni/stats-all.js:15436 static/js/zamboni/stats-min.js:5
+msgid "Applications from {0} to {1}"
+msgstr "Apps von {0} bis {1}"
+
+#. L10n: {0} is an integer.
+#: static/js/impala/stats/csv_keys.js:159 static/js/zamboni/stats-all.js:15440 static/js/zamboni/stats-min.js:5
+msgid "Platforms, last {0} days"
+msgstr "Plattformen in den letzten {0} Tagen"
+
+#. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
+#: static/js/impala/stats/csv_keys.js:161 static/js/zamboni/stats-all.js:15442 static/js/zamboni/stats-min.js:5
+msgid "Platforms from {0} to {1}"
+msgstr "Plattformen von {0} bis {1}"
+
+#. L10n: {0} is an integer.
+#: static/js/impala/stats/csv_keys.js:165 static/js/zamboni/stats-all.js:15446 static/js/zamboni/stats-min.js:5
+msgid "Languages, last {0} days"
+msgstr "Sprachen in den letzten {0} Tagen"
+
+#. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
+#: static/js/impala/stats/csv_keys.js:167 static/js/zamboni/stats-all.js:15448 static/js/zamboni/stats-min.js:5
+msgid "Languages from {0} to {1}"
+msgstr "Sprachen von {0} bis {1}"
+
+#. L10n: {0} is an integer.
+#: static/js/impala/stats/csv_keys.js:171 static/js/zamboni/stats-all.js:15452 static/js/zamboni/stats-min.js:5
+msgid "Add-on Versions, last {0} days"
+msgstr "Add-on-Versionen in den letzten {0} Tagen"
+
+#. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
+#: static/js/impala/stats/csv_keys.js:173 static/js/zamboni/stats-all.js:15454 static/js/zamboni/stats-min.js:5
+msgid "Add-on Versions from {0} to {1}"
+msgstr "Add-on-Versionen von {0} bis {1}"
+
+#. L10n: {0} is an integer.
+#: static/js/impala/stats/csv_keys.js:177 static/js/zamboni/stats-all.js:15458 static/js/zamboni/stats-min.js:5
+msgid "Add-on Status, last {0} days"
+msgstr "Add-on-Status in den letzten {0} Tagen"
+
+#. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
+#: static/js/impala/stats/csv_keys.js:179 static/js/zamboni/stats-all.js:15460 static/js/zamboni/stats-min.js:5
+msgid "Add-on Status from {0} to {1}"
+msgstr "Add-on-Status von {0} bis {1}"
+
+#. L10n: {0} is an integer.
+#: static/js/impala/stats/csv_keys.js:183 static/js/zamboni/stats-all.js:15464 static/js/zamboni/stats-min.js:5
+msgid "Download Sources, last {0} days"
+msgstr "Download-Quellen in den letzten {0} Tagen"
+
+#. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
+#: static/js/impala/stats/csv_keys.js:185 static/js/zamboni/stats-all.js:15466 static/js/zamboni/stats-min.js:5
+msgid "Download Sources from {0} to {1}"
+msgstr "Download-Quellen von {0} bis {1}"
+
+#. L10n: {0} is an integer.
+#: static/js/impala/stats/csv_keys.js:189 static/js/zamboni/stats-all.js:15470 static/js/zamboni/stats-min.js:5
+msgid "Contributions, last {0} days"
+msgstr "Spenden in den letzten {0} Tagen"
+
+#. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
+#: static/js/impala/stats/csv_keys.js:191 static/js/zamboni/stats-all.js:15472 static/js/zamboni/stats-min.js:5
+msgid "Contributions from {0} to {1}"
+msgstr "Spenden von {0} bis {1}"
+
+#. L10n: {0} is an integer.
+#: static/js/impala/stats/csv_keys.js:195 static/js/zamboni/stats-all.js:15476 static/js/zamboni/stats-min.js:5
+msgid "Site Metrics, last {0} days"
+msgstr "Website-Statistiken, letzte {0} Tage"
+
+#. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
+#: static/js/impala/stats/csv_keys.js:197 static/js/zamboni/stats-all.js:15478 static/js/zamboni/stats-min.js:5
+msgid "Site Metrics from {0} to {1}"
+msgstr "Website-Statistiken von {0} bis {1}"
+
+#. L10n: {0} is an integer.
+#: static/js/impala/stats/csv_keys.js:201 static/js/zamboni/stats-all.js:15482 static/js/zamboni/stats-min.js:5
+msgid "Add-ons in Use, last {0} days"
+msgstr "Verwendete Add-ons, letzte {0} Tage"
+
+#. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
+#: static/js/impala/stats/csv_keys.js:203 static/js/zamboni/stats-all.js:15484 static/js/zamboni/stats-min.js:5
+msgid "Add-ons in Use from {0} to {1}"
+msgstr "Verwendete Add-ons von {0} bis {1}"
+
+#. L10n: {0} is an integer.
+#: static/js/impala/stats/csv_keys.js:207 static/js/zamboni/stats-all.js:15488 static/js/zamboni/stats-min.js:5
+msgid "Add-ons Downloaded, last {0} days"
+msgstr "Heruntergeladene Add-ons, letzte {0} Tage"
+
+#. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
+#: static/js/impala/stats/csv_keys.js:209 static/js/zamboni/stats-all.js:15490 static/js/zamboni/stats-min.js:5
+msgid "Add-ons Downloaded from {0} to {1}"
+msgstr "Heruntergeladene Add-ons von {0} bis {1}"
+
+#. L10n: {0} is an integer.
+#: static/js/impala/stats/csv_keys.js:213 static/js/zamboni/stats-all.js:15494 static/js/zamboni/stats-min.js:5
+msgid "Add-ons Created, last {0} days"
+msgstr "Erstellte Add-ons, letzte {0} Tage"
+
+#. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
+#: static/js/impala/stats/csv_keys.js:215 static/js/zamboni/stats-all.js:15496 static/js/zamboni/stats-min.js:5
+msgid "Add-ons Created from {0} to {1}"
+msgstr "Erstellte Add-ons von {0} bis {1}"
+
+#. L10n: {0} is an integer.
+#: static/js/impala/stats/csv_keys.js:219 static/js/zamboni/stats-all.js:15500 static/js/zamboni/stats-min.js:5
+msgid "Add-ons Updated, last {0} days"
+msgstr "Aktualisierte Add-ons, letzte {0} Tage"
+
+#. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
+#: static/js/impala/stats/csv_keys.js:221 static/js/zamboni/stats-all.js:15502 static/js/zamboni/stats-min.js:5
+msgid "Add-ons Updated from {0} to {1}"
+msgstr "Aktualisierte Add-ons von {0} bis {1}"
+
+#. L10n: {0} is an integer.
+#: static/js/impala/stats/csv_keys.js:225 static/js/zamboni/stats-all.js:15506 static/js/zamboni/stats-min.js:5
+msgid "Reviews Written, last {0} days"
+msgstr "Geschriebene Bewertungen, letzte {0} Tage"
+
+#. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
+#: static/js/impala/stats/csv_keys.js:227 static/js/zamboni/stats-all.js:15508 static/js/zamboni/stats-min.js:5
+msgid "Reviews Written from {0} to {1}"
+msgstr "Geschriebene Bewertungen von {0} bis {1}"
+
+#. L10n: {0} is an integer.
+#: static/js/impala/stats/csv_keys.js:231 static/js/zamboni/stats-all.js:15512 static/js/zamboni/stats-min.js:5
+msgid "User Signups, last {0} days"
+msgstr "Registrierte Benutzer, letzte {0} Tage"
+
+#. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
+#: static/js/impala/stats/csv_keys.js:233 static/js/zamboni/stats-all.js:15514 static/js/zamboni/stats-min.js:5
+msgid "User Signups from {0} to {1}"
+msgstr "Registrierte Benutzer von {0} bis {1}"
+
+#. L10n: {0} is an integer.
+#: static/js/impala/stats/csv_keys.js:237 static/js/zamboni/stats-all.js:15518 static/js/zamboni/stats-min.js:5
+msgid "Collections Created, last {0} days"
+msgstr "Erstellte Sammlungen, letzte {0} Tage"
+
+#. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
+#: static/js/impala/stats/csv_keys.js:239 static/js/zamboni/stats-all.js:15520 static/js/zamboni/stats-min.js:5
+msgid "Collections Created from {0} to {1}"
+msgstr "Erstellte Sammlungen von {0} bis {1}"
+
+#. L10n: {0} is an integer.
+#: static/js/impala/stats/csv_keys.js:243 static/js/zamboni/stats-all.js:15524 static/js/zamboni/stats-min.js:5
+msgid "Subscribers, last {0} days"
+msgstr "Abonnenten, letzte {0} Tage"
+
+#. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
+#: static/js/impala/stats/csv_keys.js:245 static/js/zamboni/stats-all.js:15526 static/js/zamboni/stats-min.js:5
+msgid "Subscribers from {0} to {1}"
+msgstr "Abonnenten von {0} bis {1}"
+
+#. L10n: {0} is an integer.
+#: static/js/impala/stats/csv_keys.js:249 static/js/zamboni/stats-all.js:15530 static/js/zamboni/stats-min.js:5
+msgid "Ratings, last {0} days"
+msgstr "Bewertungen, letzte {0} Tage"
+
+#. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
+#: static/js/impala/stats/csv_keys.js:251 static/js/zamboni/stats-all.js:15532 static/js/zamboni/stats-min.js:5
+msgid "Ratings from {0} to {1}"
+msgstr "Bewertungen von {0} bis {1}"
+
+#. L10n: {0} is an integer.
+#: static/js/impala/stats/csv_keys.js:255 static/js/zamboni/stats-all.js:15536 static/js/zamboni/stats-min.js:5
+msgid "Sales, last {0} days"
+msgstr "Verkäufe, letzte {0} Tage"
+
+#. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
+#: static/js/impala/stats/csv_keys.js:257 static/js/zamboni/stats-all.js:15538 static/js/zamboni/stats-min.js:5
+msgid "Sales from {0} to {1}"
+msgstr "Verkäufe von {0} bis {1}"
+
+#. L10n: {0} is an integer.
+#: static/js/impala/stats/csv_keys.js:261 static/js/zamboni/stats-all.js:15542 static/js/zamboni/stats-min.js:5
+msgid "Installs, last {0} days"
+msgstr "Installationen, letzte {0} Tage"
+
+#. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
+#: static/js/impala/stats/csv_keys.js:263 static/js/zamboni/stats-all.js:15544 static/js/zamboni/stats-min.js:5
+msgid "Installs from {0} to {1}"
+msgstr "Installationen von {0} bis {1}"
+
+#. L10n: {0} and {1} are integers.
+#: static/js/impala/stats/csv_keys.js:269 static/js/zamboni/stats-all.js:15550 static/js/zamboni/stats-min.js:5
+msgid "<b>{0}</b> in last {1} days"
+msgstr "<b>{0}</b> in den letzten {1} Tagen"
+
+#. L10n: {0} is an integer and {1} and {2} are dates in YYYY-MM-DD format.
+#: static/js/impala/stats/csv_keys.js:271 static/js/impala/stats/csv_keys.js:277 static/js/zamboni/stats-all.js:15552 static/js/zamboni/stats-all.js:15558 static/js/zamboni/stats-min.js:5
+msgid "<b>{0}</b> from {1} to {2}"
+msgstr "<b>{0}</b> von {1} bis {2}"
+
+#. L10n: {0} and {1} are integers.
+#: static/js/impala/stats/csv_keys.js:275 static/js/zamboni/stats-all.js:15556 static/js/zamboni/stats-min.js:5
+msgid "<b>{0}</b> average in last {1} days"
+msgstr "Durchschnittlich <b>{0}</b> in den letzten {1} Tagen"
+
+#: static/js/impala/stats/overview.js:19 static/js/zamboni/stats-all.js:16469 static/js/zamboni/stats-min.js:5
+msgid "No data available."
+msgstr "Keine Daten verfügbar"
+
+#: static/js/impala/stats/table.js:74 static/js/zamboni/stats-all.js:17209 static/js/zamboni/stats-min.js:5
+msgid "Date"
+msgstr "Datum"
+
+#: static/js/impala/stats/topchart.js:96 static/js/zamboni/stats-all.js:16600 static/js/zamboni/stats-min.js:5
+msgid "Other"
+msgstr "Andere"
+
+#: static/js/zamboni/admin-all.js:180 static/js/zamboni/admin-min.js:1 static/js/zamboni/admin_validation.js:24 static/js/zamboni/devhub-all.js:2408 static/js/zamboni/devhub-min.js:2
+#: static/js/zamboni/devhub.js:1229 static/js/zamboni/editors-all.js:15576 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:295
+msgid "Select an application first"
+msgstr "Wählen Sie zuerst eine Anwendung aus"
+
+#: static/js/zamboni/admin-all.js:207 static/js/zamboni/admin-min.js:1 static/js/zamboni/admin_validation.js:51
+msgid "Set {0} add-on to a max version of {1} and email the author."
+msgid_plural "Set {0} add-ons to a max version of {1} and email the authors."
+msgstr[0] "{0} Add-on auf eine Max-Version von {1} setzen und Autor per E-Mail benachrichtigen."
+msgstr[1] "{0} Add-ons auf eine Max-Version von {1} setzen und Autoren per E-Mail benachrichtigen."
+
+#: static/js/zamboni/admin-all.js:210 static/js/zamboni/admin-min.js:1 static/js/zamboni/admin_validation.js:54
+msgid "Email author of {2} add-on which failed validation."
+msgid_plural "Email authors of {2} add-ons which failed validation."
+msgstr[0] "Autor von {2} Add-on, deren Validierung fehlgeschlagen ist, per E-Mail benachrichtigen."
+msgstr[1] "Autoren von {2} Add-ons, deren Validierung fehlgeschlagen ist, per E-Mail benachrichtigen."
+
+#: static/js/zamboni/devhub-all.js:1289 static/js/zamboni/devhub-min.js:1 static/js/zamboni/devhub.js:110
+msgid "Your browser does not support the video tag"
+msgstr "Ihr Browser unterstützt den Video-Tag nicht"
+
+#: static/js/zamboni/devhub-all.js:1550 static/js/zamboni/devhub-min.js:1 static/js/zamboni/devhub.js:371
+msgid "Changes Saved"
+msgstr "Änderungen gespeichert"
+
+#: static/js/zamboni/devhub-all.js:1566 static/js/zamboni/devhub-min.js:1 static/js/zamboni/devhub.js:387
+msgid "Enter a new author's email address"
+msgstr "Geben Sie eine neue E-Mail-Adresse des Autors ein"
+
+#: static/js/zamboni/devhub-all.js:1715 static/js/zamboni/devhub-min.js:1 static/js/zamboni/devhub.js:536
+msgid "There was an error uploading your file."
+msgstr "Beim Hochladen Ihrer Datei ist ein Fehler aufgetreten."
+
+#: static/js/zamboni/devhub-all.js:1860 static/js/zamboni/devhub-min.js:1 static/js/zamboni/devhub.js:681
+msgid "{files} file"
+msgid_plural "{files} files"
+msgstr[0] "{files} Datei"
+msgstr[1] "{files} Dateien"
+
+#: static/js/zamboni/devhub-all.js:1863 static/js/zamboni/devhub-min.js:1 static/js/zamboni/devhub.js:684
+msgid "{reviews} user review"
+msgid_plural "{reviews} user reviews"
+msgstr[0] "{reviews} Benutzerbewertung"
+msgstr[1] "{reviews} Benutzerbewertungen"
+
+#: static/js/zamboni/devhub-all.js:1975 static/js/zamboni/devhub-min.js:2 static/js/zamboni/devhub.js:796
+msgid "Learn more"
+msgstr "Erfahren Sie mehr"
+
+#: static/js/zamboni/devhub-all.js:1979 static/js/zamboni/devhub-min.js:2 static/js/zamboni/devhub.js:800
+msgid "Example"
+msgstr "Beispiel"
+
+#: static/js/zamboni/devhub-all.js:2309 static/js/zamboni/devhub-min.js:2 static/js/zamboni/devhub.js:1130
+msgid "Image changes being processed"
+msgstr "Grafikänderungen werden angewendet"
+
+#: static/js/zamboni/devhub-all.js:2459 static/js/zamboni/devhub-min.js:2 static/js/zamboni/devhub.js:1280
+msgid "Must be a valid e-mail address."
+msgstr "Muss eine gültige E-Mail-Adresse sein."
+
+#: static/js/zamboni/devhub-all.js:2613 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:80
 msgid "All tests passed successfully."
 msgstr "Alle Tests wurden erfolgreich durchgeführt."
 
-#: static/js/zamboni/validator.js:83 static/js/zamboni/validator.js:478
+#: static/js/zamboni/devhub-all.js:2616 static/js/zamboni/devhub-all.js:3011 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:83 static/js/zamboni/validator.js:478
 msgid "These tests were not run."
 msgstr "Diese Tests wurden nicht durchgeführt."
 
-#: static/js/zamboni/validator.js:131 static/js/zamboni/validator.js:144
+#: static/js/zamboni/devhub-all.js:2664 static/js/zamboni/devhub-all.js:2677 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:131 static/js/zamboni/validator.js:144
 msgid "Tests"
 msgstr "Tests"
 
-#: static/js/zamboni/validator.js:246 static/js/zamboni/validator.js:575
-#: static/js/zamboni/validator.js:594
+#: static/js/zamboni/devhub-all.js:2779 static/js/zamboni/devhub-all.js:3108 static/js/zamboni/devhub-all.js:3127 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:246
+#: static/js/zamboni/validator.js:575 static/js/zamboni/validator.js:594
 msgid "Error"
 msgstr "Fehler"
 
-#: static/js/zamboni/validator.js:247
+#: static/js/zamboni/devhub-all.js:2780 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:247
 msgid "Warning"
 msgstr "Warnung"
 
-#: static/js/zamboni/validator.js:299
+#: static/js/zamboni/devhub-all.js:2794 static/js/zamboni/devhub-min.js:2 static/js/zamboni/files-all.js:5657 static/js/zamboni/files-min.js:3 static/js/zamboni/files.js:411
+#: static/js/zamboni/validator.js:261
+msgid "Ignore this message in future updates"
+msgstr "Diese Nachricht bei zukünftigen Updates ignorieren"
+
+#: static/js/zamboni/devhub-all.js:2817 static/js/zamboni/devhub-min.js:2 static/js/zamboni/files-all.js:5663 static/js/zamboni/files-min.js:3 static/js/zamboni/files.js:417
+#: static/js/zamboni/validator.js:284
+msgid "Severity for automated signing:"
+msgstr "Dringlichkeit für automatische Signierung:"
+
+#: static/js/zamboni/devhub-all.js:2832 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:299
 msgid "Suggestions for passing automated signing:"
 msgstr "Vorschläge für Bestehen der automatischen Signierung:"
 
-#: static/js/zamboni/validator.js:387
+#: static/js/zamboni/devhub-all.js:2920 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:387
 msgid "Compatibility Tests"
 msgstr "Kompatibilitätstests"
 
-#: static/js/zamboni/validator.js:466
+#: static/js/zamboni/devhub-all.js:2999 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:466
 msgid "Add-on failed validation."
 msgstr "Add-on hat die Überprüfung nicht bestanden."
 
-#: static/js/zamboni/validator.js:468
+#: static/js/zamboni/devhub-all.js:3001 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:468
 msgid "Add-on passed validation."
 msgstr "Add-on hat die Überprüfung bestanden."
 
-#: static/js/zamboni/validator.js:481
+#: static/js/zamboni/devhub-all.js:3014 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:481
 msgid "{0} error"
 msgid_plural "{0} errors"
 msgstr[0] "{0} Fehler"
 msgstr[1] "{0} Fehler"
 
-#: static/js/zamboni/validator.js:483
+#: static/js/zamboni/devhub-all.js:3016 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:483
 msgid "{0} warning"
 msgid_plural "{0} warnings"
 msgstr[0] "{0} Warnung"
 msgstr[1] "{0} Warnungen"
 
-#: static/js/zamboni/validator.js:485
+#: static/js/zamboni/devhub-all.js:3018 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:485
 msgid "{0} notice"
 msgid_plural "{0} notices"
 msgstr[0] "{0} Nachricht"
 msgstr[1] "{0} Nachrichten"
 
-#: static/js/zamboni/validator.js:577
+#: static/js/zamboni/devhub-all.js:3110 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:577
 msgid "Validation task could not complete or completed with errors"
-msgstr ""
-"Überprüfung konnte nicht abgeschlossen werden oder wurde mit Fehlern "
-"abgeschlossen"
+msgstr "Überprüfung konnte nicht abgeschlossen werden oder wurde mit Fehlern abgeschlossen"
 
-#: static/js/zamboni/validator.js:595
+#: static/js/zamboni/devhub-all.js:3128 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:595
 msgid "Internal server error"
 msgstr "Interner Serverfehler"
 
-#: static/js/zamboni/mobile/buttons.js:52
+#: static/js/zamboni/devhub_search.js:8
+msgid "No results found."
+msgstr "Keine Ergebnisse gefunden."
+
+#: static/js/zamboni/editors-all.js:15402 static/js/zamboni/editors-min.js:4 static/js/zamboni/editors.js:121
+msgid "{name} was viewing this page first."
+msgstr "{name} hat diese Seite zuerst angesehen."
+
+#: static/js/zamboni/editors-all.js:15452 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:171
+msgid "Receipt checked by app."
+msgstr "Quittung wurde von App überprüft."
+
+#: static/js/zamboni/editors-all.js:15454 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:173
+msgid "Receipt was not checked by app."
+msgstr "Quittung wurde nicht von App überprüft."
+
+#: static/js/zamboni/editors-all.js:15525 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:244
+msgid "{name} was viewing this add-on first."
+msgstr "{name} hat sich dieses Add-on zuerst angesehen."
+
+#: static/js/zamboni/editors-all.js:15536 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:255
+msgid "Loading&hellip;"
+msgstr "Wird geladen &hellip;"
+
+#: static/js/zamboni/editors-all.js:15541 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:260
+msgid "Version Notes"
+msgstr "Versionshinweise"
+
+#: static/js/zamboni/editors-all.js:15546 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:265
+msgid "Notes for Reviewers"
+msgstr "Hinweise für Überprüfer"
+
+#: static/js/zamboni/editors-all.js:15551 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:270
+msgid "No version notes found"
+msgstr "Keine Kommentare zur Version gefunden"
+
+#: static/js/zamboni/editors-all.js:15611 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:330
+msgid "Average Reviews"
+msgstr "Durchschnittliche Bewertungen"
+
+#: static/js/zamboni/editors-all.js:15667 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:386
+msgid "Number of Reviews"
+msgstr "Anzahl der Bewertungen"
+
+#: static/js/zamboni/editors-all.js:15726 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:445
+msgid "Error loading translation"
+msgstr "Fehler beim Laden der Übersetzung"
+
+#: static/js/zamboni/editors-all.js:15975 static/js/zamboni/editors-min.js:5 static/js/zamboni/themes_review_templates.js:31
+msgid "Theme"
+msgstr "Theme"
+
+#: static/js/zamboni/editors-all.js:15977 static/js/zamboni/editors-min.js:5 static/js/zamboni/themes_review_templates.js:33
+msgid "Reviewer"
+msgstr "Überprüfer"
+
+#: static/js/zamboni/editors-all.js:15979 static/js/zamboni/editors-min.js:5 static/js/zamboni/themes_review_templates.js:35
+msgid "Status"
+msgstr "Status"
+
+#: static/js/zamboni/editors-all.js:16196 static/js/zamboni/editors-min.js:5 static/js/zamboni/themes_review.js:176
+msgid "Requested Info"
+msgstr "Informationen angefordert"
+
+#: static/js/zamboni/editors-all.js:16197 static/js/zamboni/editors-min.js:5 static/js/zamboni/themes_review.js:177
+msgid "Flagged"
+msgstr "Markiert"
+
+#: static/js/zamboni/editors-all.js:16198 static/js/zamboni/editors-min.js:5 static/js/zamboni/themes_review.js:178
+msgid "Duplicate"
+msgstr "Duplikat"
+
+#: static/js/zamboni/editors-all.js:16199 static/js/zamboni/editors-min.js:5 static/js/zamboni/themes_review.js:179
+msgid "Rejected"
+msgstr "Abgelehnt"
+
+#: static/js/zamboni/editors-all.js:16200 static/js/zamboni/editors-min.js:5 static/js/zamboni/themes_review.js:180
+msgid "Approved"
+msgstr "Freigeschaltet"
+
+#: static/js/zamboni/editors-all.js:16444 static/js/zamboni/editors-min.js:5 static/js/zamboni/themes_review.js:424
+msgid "No results found"
+msgstr "Keine Ergebnisse gefunden"
+
+#: static/js/zamboni/mobile-all.js:15186 static/js/zamboni/mobile/buttons.js:52
 msgid "Not Updated for {0} {1}"
 msgstr "Nicht aktualisiert für {0} {1}"
 
-#: static/js/zamboni/mobile/buttons.js:53
+#: static/js/zamboni/mobile-all.js:15187 static/js/zamboni/mobile/buttons.js:53
 msgid "Requires Newer Version of {0}"
 msgstr "Neuere Version von {0} wird benötigt"
 
-#: static/js/zamboni/mobile/buttons.js:54
+#: static/js/zamboni/mobile-all.js:15188 static/js/zamboni/mobile/buttons.js:54
 msgid "Unreviewed"
 msgstr "Nicht bewertet"
 
-#: static/js/zamboni/mobile/buttons.js:55
+#: static/js/zamboni/mobile-all.js:15189 static/js/zamboni/mobile/buttons.js:55
 msgid "Experimental <span>(Learn More)</span>"
 msgstr "Experimentell <span>(Erfahren Sie mehr)</span>"
 
-#: static/js/zamboni/mobile/buttons.js:56
-#: static/js/zamboni/mobile/buttons.js:57
+#: static/js/zamboni/mobile-all.js:15190 static/js/zamboni/mobile-all.js:15191 static/js/zamboni/mobile/buttons.js:56 static/js/zamboni/mobile/buttons.js:57
 msgid "Not Available for {0}"
 msgstr "Nicht verfügbar für {0}"
 
-#: static/js/zamboni/mobile/buttons.js:58
+#: static/js/zamboni/mobile-all.js:15192 static/js/zamboni/mobile/buttons.js:58
 msgid "Experimental"
 msgstr "Experimentell"
 
-#: static/js/zamboni/mobile/buttons.js:59
+#: static/js/zamboni/mobile-all.js:15193 static/js/zamboni/mobile/buttons.js:59
 msgid "Themes Require Newer Version of {0}"
 msgstr "Themes benötigen eine neuere Version von {0}"
 
-#: static/js/zamboni/mobile/buttons.js:60
+#: static/js/zamboni/mobile-all.js:15194 static/js/zamboni/mobile/buttons.js:60
 msgid "Themes Require {0}"
 msgstr "Themes benötigen {0}"
 
-#: static/js/zamboni/mobile/buttons.js:105
+#: static/js/zamboni/mobile-all.js:15239 static/js/zamboni/mobile/buttons.js:105
 msgid "Installing..."
 msgstr "Wird installiert …"
 
-#: static/js/zamboni/mobile/buttons.js:125
+#: static/js/zamboni/mobile-all.js:15259 static/js/zamboni/mobile/buttons.js:125
 msgid "This add-on has been preliminarily reviewed by Mozilla."
 msgstr "Dieses Add-on wurde vorläufig von Mozilla freigegeben."
 
-#: static/js/zamboni/mobile/buttons.js:250
+#: static/js/zamboni/mobile-all.js:15384 static/js/zamboni/mobile/buttons.js:250
 msgid "Keep it"
 msgstr "Behalten"
 
-#: static/js/zamboni/mobile/general.js:344
+#: static/js/zamboni/mobile-all.js:16049 static/js/zamboni/mobile-min.js:6 static/js/zamboni/mobile/general.js:344
 msgid "You're trying it on!"
 msgstr "Sie probieren es an!"
 
-#: static/js/zamboni/mobile/general.js:356
+#: static/js/zamboni/mobile-all.js:16061 static/js/zamboni/mobile-min.js:6 static/js/zamboni/mobile/general.js:356
 msgid "Added to Firefox"
 msgstr "Zu Firefox hinzugefügt"

--- a/locale/dsb/LC_MESSAGES/django.po
+++ b/locale/dsb/LC_MESSAGES/django.po
@@ -1,16 +1,16 @@
-# 
+#
 #, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT 1.0\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2016-04-11 14:21+0000\n"
+"POT-Creation-Date: 2016-04-18 15:47+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
 "Language: dsb\n"
 "MIME-Version: 1.0\n"
-"Content-Type: text/plain; charset=utf-8\n"
+"Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=4; plural=(n%100==1 ? 0 : n%100==2 ? 1 : n%100==3 || n%100==4 ? 2 : 3);\n"
 "Generated-By: Babel 2.2.0\n"
@@ -48,36 +48,28 @@ msgstr ""
 msgid "Need help?"
 msgstr ""
 
-#: src/olympia/addons/buttons.py:180
+#: src/olympia/addons/buttons.py:177
 msgid "Download Now"
 msgstr ""
 
-#: src/olympia/addons/buttons.py:182
+#: src/olympia/addons/buttons.py:179
 msgid "Download"
 msgstr ""
 
 #. L10n: please keep &nbsp; in the string so &rarr; does not wrap.
-#: src/olympia/addons/buttons.py:186
+#: src/olympia/addons/buttons.py:183
 msgid "Continue to Download&nbsp;&rarr;"
 msgstr ""
 
-#: src/olympia/addons/buttons.py:202 src/olympia/addons/helpers.py:35
-#: src/olympia/addons/views.py:332
-#: src/olympia/addons/templates/addons/impala/details.html:111
-#: src/olympia/addons/templates/addons/impala/listing/items.html:17
-#: src/olympia/addons/templates/addons/mobile/home.html:40
-#: src/olympia/amo/templates/amo/side_nav.html:6
-#: src/olympia/amo/templates/amo/side_nav.html:10
-#: src/olympia/amo/templates/amo/site_nav.html:2
-#: src/olympia/amo/templates/amo/site_nav.html:53
-#: src/olympia/bandwagon/views.py:95 src/olympia/browse/views.py:54
-#: src/olympia/browse/views.py:68 src/olympia/browse/views.py:235
-#: src/olympia/browse/templates/browse/impala/category_landing.html:22
+#: src/olympia/addons/buttons.py:199 src/olympia/addons/helpers.py:35 src/olympia/addons/views.py:333 src/olympia/addons/templates/addons/impala/details.html:111
+#: src/olympia/addons/templates/addons/impala/listing/items.html:17 src/olympia/addons/templates/addons/mobile/home.html:40 src/olympia/amo/templates/amo/side_nav.html:6
+#: src/olympia/amo/templates/amo/side_nav.html:10 src/olympia/amo/templates/amo/site_nav.html:2 src/olympia/amo/templates/amo/site_nav.html:53 src/olympia/bandwagon/views.py:95
+#: src/olympia/browse/views.py:54 src/olympia/browse/views.py:68 src/olympia/browse/views.py:202 src/olympia/browse/templates/browse/impala/category_landing.html:22
 #: src/olympia/browse/templates/browse/personas/mobile/category_landing.html:26
 msgid "Featured"
 msgstr ""
 
-#: src/olympia/addons/buttons.py:221
+#: src/olympia/addons/buttons.py:218
 msgid "Add to {0}"
 msgstr ""
 
@@ -122,8 +114,7 @@ msgstr[3] ""
 
 #: src/olympia/addons/forms.py:117
 #, python-format
-msgid ""
-"All tags must be %s characters or less after invalid characters are removed."
+msgid "All tags must be %s characters or less after invalid characters are removed."
 msgstr ""
 
 #: src/olympia/addons/forms.py:121
@@ -135,9 +126,7 @@ msgstr[2] ""
 msgstr[3] ""
 
 #: src/olympia/addons/forms.py:238
-msgid ""
-"Categories cannot be changed while your add-on is featured for this "
-"application."
+msgid "Categories cannot be changed while your add-on is featured for this application."
 msgstr ""
 
 #. L10n: {0} is the number of categories.
@@ -150,15 +139,12 @@ msgstr[2] ""
 msgstr[3] ""
 
 #: src/olympia/addons/forms.py:250
-msgid ""
-"The miscellaneous category cannot be combined with additional categories."
+msgid "The miscellaneous category cannot be combined with additional categories."
 msgstr ""
 
 #: src/olympia/addons/forms.py:374
 #, python-format
-msgid ""
-"Before changing your default locale you must have a name, summary, and "
-"description in that locale. You are missing %s."
+msgid "Before changing your default locale you must have a name, summary, and description in that locale. You are missing %s."
 msgstr ""
 
 #: src/olympia/addons/forms.py:455 src/olympia/addons/forms.py:546
@@ -169,8 +155,7 @@ msgstr ""
 msgid "Give Your Theme a Name."
 msgstr ""
 
-#: src/olympia/addons/forms.py:533
-#: src/olympia/devhub/templates/devhub/personas/submit.html:53
+#: src/olympia/addons/forms.py:533 src/olympia/devhub/templates/devhub/personas/submit.html:53
 msgid "Describe your Theme."
 msgstr ""
 
@@ -187,40 +172,32 @@ msgid "Users have the option of contributing more or less than this amount."
 msgstr ""
 
 #: src/olympia/addons/models.py:306
-msgid ""
-"Users will always be asked in the Add-ons Manager (Firefox 4 and above). "
-"Only applies to desktop."
+msgid "Users will always be asked in the Add-ons Manager (Firefox 4 and above). Only applies to desktop."
 msgstr ""
 
-#: src/olympia/addons/models.py:1800
-#: src/olympia/addons/templates/addons/details_box.html:55
-#: src/olympia/devhub/templates/devhub/index.html:92
+#: src/olympia/addons/models.py:1802 src/olympia/addons/templates/addons/details_box.html:55 src/olympia/devhub/templates/devhub/index.html:92
 #: src/olympia/devhub/templates/devhub/includes/addon_details.html:89
 msgid "Listed"
 msgstr ""
 
-#: src/olympia/addons/views.py:333
-#: src/olympia/browse/templates/browse/personas/mobile/category_landing.html:27
+#: src/olympia/addons/views.py:334 src/olympia/browse/templates/browse/personas/mobile/category_landing.html:27
 msgid "Popular"
 msgstr ""
 
-#: src/olympia/addons/views.py:334 src/olympia/browse/views.py:238
-#: src/olympia/browse/views.py:280 src/olympia/browse/views.py:482
+#: src/olympia/addons/views.py:335 src/olympia/browse/views.py:205 src/olympia/browse/views.py:247 src/olympia/browse/views.py:449
 msgid "Recently Added"
 msgstr ""
 
-#: src/olympia/addons/views.py:335 src/olympia/bandwagon/views.py:99
-#: src/olympia/browse/views.py:60 src/olympia/browse/views.py:71
-#: src/olympia/search/forms.py:16 src/olympia/search/forms.py:91
+#: src/olympia/addons/views.py:336 src/olympia/bandwagon/views.py:99 src/olympia/browse/views.py:60 src/olympia/browse/views.py:71 src/olympia/search/forms.py:16 src/olympia/search/forms.py:91
 msgid "Recently Updated"
 msgstr ""
 
 #. l10n: {0} is the addon name
-#: src/olympia/addons/views.py:533
+#: src/olympia/addons/views.py:534
 msgid "Contribution for {0}"
 msgstr ""
 
-#: src/olympia/addons/views.py:626
+#: src/olympia/addons/views.py:627
 msgid "Abuse reported."
 msgstr ""
 
@@ -228,104 +205,68 @@ msgstr ""
 msgid "My add-on doesn't fit into any of the categories"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/button.html:27
-#: src/olympia/addons/templates/addons/impala/button.html:11
-#: src/olympia/addons/templates/addons/mobile/button.html:11
+#: src/olympia/addons/templates/addons/button.html:27 src/olympia/addons/templates/addons/impala/button.html:11 src/olympia/addons/templates/addons/mobile/button.html:11
 msgid "No compatible versions"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/button.html:35
-#: src/olympia/addons/templates/addons/impala/button.html:19
+#: src/olympia/addons/templates/addons/button.html:35 src/olympia/addons/templates/addons/impala/button.html:19
 msgid "Added to Mobile"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/button.html:37
-#: src/olympia/addons/templates/addons/impala/button.html:21
+#: src/olympia/addons/templates/addons/button.html:37 src/olympia/addons/templates/addons/impala/button.html:21
 msgid "Add to Mobile"
 msgstr ""
 
 #. {0} is a platform name like Windows or Mac OS X.
-#: src/olympia/addons/templates/addons/button.html:66
-#: src/olympia/addons/templates/addons/includes/install_button.html:19
+#: src/olympia/addons/templates/addons/button.html:66 src/olympia/addons/templates/addons/includes/install_button.html:19
 msgid "for {0}"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/button.html:82
-#: src/olympia/addons/templates/addons/mobile/button.html:23
+#: src/olympia/addons/templates/addons/button.html:82 src/olympia/addons/templates/addons/mobile/button.html:23
 msgid "View privacy policy"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/button.html:87
-#: src/olympia/addons/templates/addons/details_box.html:133
-#: src/olympia/addons/templates/addons/mobile/button.html:28
+#: src/olympia/addons/templates/addons/button.html:87 src/olympia/addons/templates/addons/details_box.html:133 src/olympia/addons/templates/addons/mobile/button.html:28
 #: src/olympia/discovery/templates/discovery/addons/detail.html:28
 msgid "View End-User License Agreement"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/button.html:92
-#: src/olympia/addons/templates/addons/impala/button.html:54
+#: src/olympia/addons/templates/addons/button.html:92 src/olympia/addons/templates/addons/impala/button.html:54
 #, python-format
-msgid ""
-"This add-on has not been reviewed by Mozilla. <a href=\"%(url)s\">Learn "
-"more</a>"
+msgid "This add-on has not been reviewed by Mozilla. <a href=\"%(url)s\">Learn more</a>"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/button.html:97
-#: src/olympia/addons/templates/addons/impala/button.html:60
+#: src/olympia/addons/templates/addons/button.html:97 src/olympia/addons/templates/addons/impala/button.html:60
 #, python-format
-msgid ""
-"This add-on has been preliminarily reviewed by Mozilla. <a "
-"href=\"%(url)s\">Learn more</a>"
+msgid "This add-on has been preliminarily reviewed by Mozilla. <a href=\"%(url)s\">Learn more</a>"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/contribution.html:11
-#: src/olympia/addons/templates/addons/impala/developers.html:44
-msgid ""
-"The developer of this add-on asks that you help support its continued "
-"development by making a small contribution."
+#: src/olympia/addons/templates/addons/contribution.html:11 src/olympia/addons/templates/addons/impala/developers.html:44
+msgid "The developer of this add-on asks that you help support its continued development by making a small contribution."
 msgstr ""
 
 #: src/olympia/addons/templates/addons/contribution.html:14
 #, python-format
-msgid ""
-"The developer of this add-on asks that you show your support by making a "
-"donation to the <a href=\"%(charity_url)s\">%(charity_name)s</a>."
+msgid "The developer of this add-on asks that you show your support by making a donation to the <a href=\"%(charity_url)s\">%(charity_name)s</a>."
 msgstr ""
 
 #: src/olympia/addons/templates/addons/contribution.html:19
 #, python-format
-msgid ""
-"The developer of this add-on asks that you show your support by making a "
-"small contribution to <a href=\"%(charity_url)s\">%(charity_name)s</a>."
+msgid "The developer of this add-on asks that you show your support by making a small contribution to <a href=\"%(charity_url)s\">%(charity_name)s</a>."
 msgstr ""
 
-#: src/olympia/addons/templates/addons/contribution.html:30
-#: src/olympia/addons/templates/addons/impala/contribution.html:18
-#: src/olympia/templates/menu_links.html:25
+#: src/olympia/addons/templates/addons/contribution.html:30 src/olympia/addons/templates/addons/impala/contribution.html:18 src/olympia/templates/menu_links.html:25
 msgid "Contribute"
 msgstr ""
 
 #. Click Contribute button OR Install button
-#: src/olympia/addons/templates/addons/contribution.html:34
-#: src/olympia/addons/templates/addons/report_abuse.html:26
-#: src/olympia/addons/templates/addons/impala/contribution.html:32
-#: src/olympia/devhub/templates/devhub/addons/ajax_compat_update.html:36
-#: src/olympia/devhub/templates/devhub/addons/profile.html:44
-#: src/olympia/devhub/templates/devhub/addons/edit/admin.html:101
-#: src/olympia/devhub/templates/devhub/addons/edit/basic.html:152
-#: src/olympia/devhub/templates/devhub/addons/edit/details.html:85
-#: src/olympia/devhub/templates/devhub/addons/edit/support.html:67
-#: src/olympia/devhub/templates/devhub/addons/edit/technical.html:166
-#: src/olympia/devhub/templates/devhub/addons/forms_shared/media.html:149
-#: src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:43
-#: src/olympia/devhub/templates/devhub/versions/add_file_modal.html:57
-#: src/olympia/devhub/templates/devhub/versions/edit.html:139
-#: src/olympia/devhub/templates/devhub/versions/list.html:239
-#: src/olympia/devhub/templates/devhub/versions/list.html:281
-#: src/olympia/devhub/templates/devhub/versions/list.html:315
-#: src/olympia/devhub/templates/devhub/versions/list.html:349
-#: src/olympia/reviews/templates/reviews/edit_review.html:16
-#: src/olympia/translations/templates/translations/trans-menu.html:50
+#: src/olympia/addons/templates/addons/contribution.html:34 src/olympia/addons/templates/addons/report_abuse.html:26 src/olympia/addons/templates/addons/impala/contribution.html:32
+#: src/olympia/devhub/templates/devhub/addons/ajax_compat_update.html:36 src/olympia/devhub/templates/devhub/addons/profile.html:44 src/olympia/devhub/templates/devhub/addons/edit/admin.html:101
+#: src/olympia/devhub/templates/devhub/addons/edit/basic.html:152 src/olympia/devhub/templates/devhub/addons/edit/details.html:85 src/olympia/devhub/templates/devhub/addons/edit/support.html:67
+#: src/olympia/devhub/templates/devhub/addons/edit/technical.html:166 src/olympia/devhub/templates/devhub/addons/forms_shared/media.html:149
+#: src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:43 src/olympia/devhub/templates/devhub/versions/add_file_modal.html:58 src/olympia/devhub/templates/devhub/versions/edit.html:139
+#: src/olympia/devhub/templates/devhub/versions/list.html:239 src/olympia/devhub/templates/devhub/versions/list.html:281 src/olympia/devhub/templates/devhub/versions/list.html:315
+#: src/olympia/devhub/templates/devhub/versions/list.html:349 src/olympia/reviews/templates/reviews/edit_review.html:16 src/olympia/translations/templates/translations/trans-menu.html:50
 #: src/olympia/translations/templates/translations/trans-menu.html:62
 msgid "or"
 msgstr ""
@@ -334,32 +275,22 @@ msgstr ""
 msgid "Suggested Contribution: {0}"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/contribution.html:48
-#: src/olympia/amo/templates/amo/recaptcha.html:5
-#: src/olympia/versions/templates/versions/version.html:52
+#: src/olympia/addons/templates/addons/contribution.html:48 src/olympia/amo/templates/amo/recaptcha.html:5 src/olympia/versions/templates/versions/version.html:52
 msgid "What's this?"
 msgstr ""
 
 #: src/olympia/addons/templates/addons/contribution.html:63
 #, python-format
-msgid ""
-"The developer of this add-on would like you to consider making a donation to"
-" the <a href=\"%(charity_url)s\">%(charity_name)s</a> if you enjoy using it."
+msgid "The developer of this add-on would like you to consider making a donation to the <a href=\"%(charity_url)s\">%(charity_name)s</a> if you enjoy using it."
 msgstr ""
 
 #: src/olympia/addons/templates/addons/contribution.html:69
 #, python-format
-msgid ""
-"The developer of this add-on would like you to consider making a small "
-"contribution to <a href=\"%(charity_url)s\">%(charity_name)s</a> if you "
-"enjoy using it."
+msgid "The developer of this add-on would like you to consider making a small contribution to <a href=\"%(charity_url)s\">%(charity_name)s</a> if you enjoy using it."
 msgstr ""
 
 #: src/olympia/addons/templates/addons/contribution.html:76
-msgid ""
-"Mozilla is committed to supporting a vibrant and healthy developer "
-"ecosystem. Your optional contribution helps sustain further development of "
-"this add-on."
+msgid "Mozilla is committed to supporting a vibrant and healthy developer ecosystem. Your optional contribution helps sustain further development of this add-on."
 msgstr ""
 
 #: src/olympia/addons/templates/addons/contributions_lightbox.html:5
@@ -368,26 +299,20 @@ msgstr ""
 
 #: src/olympia/addons/templates/addons/contributions_lightbox.html:9
 #, python-format
-msgid ""
-"Help support the continued development of <strong>%(addon_name)s</strong> by"
-" making a small contribution through <a href=\"%(paypal_url)s\">PayPal</a>."
+msgid "Help support the continued development of <strong>%(addon_name)s</strong> by making a small contribution through <a href=\"%(paypal_url)s\">PayPal</a>."
 msgstr ""
 
 #: src/olympia/addons/templates/addons/contributions_lightbox.html:15
 #, python-format
 msgid ""
-"To show your support for <b>%(addon_name)s</b>, the developer asks that you "
-"make a donation to the <a href=\"%(charity_url)s\">%(charity_name)s</a> "
-"through <a href=\"%(paypal_url)s\">PayPal</a>."
+"To show your support for <b>%(addon_name)s</b>, the developer asks that you make a donation to the <a href=\"%(charity_url)s\">%(charity_name)s</a> through <a href=\"%(paypal_url)s\">PayPal</a>."
 msgstr ""
 
 #: src/olympia/addons/templates/addons/contributions_lightbox.html:21
 #, python-format
 msgid ""
-"To show your support for <b>%(addon_name)s</b>, the developer asks that you "
-"make a small contribution to <a "
-"href=\"%(charity_url)s\">%(charity_name)s</a> through <a "
-"href=\"%(paypal_url)s\">PayPal</a>."
+"To show your support for <b>%(addon_name)s</b>, the developer asks that you make a small contribution to <a href=\"%(charity_url)s\">%(charity_name)s</a> through <a href=\"%(paypal_url)s\">PayPal</"
+"a>."
 msgstr ""
 
 #: src/olympia/addons/templates/addons/contributions_lightbox.html:30
@@ -411,8 +336,7 @@ msgstr ""
 msgid "A one-time suggested contribution of {0}"
 msgstr ""
 
-#. {0} is a currency symbol (e.g., $),                    {1} is an amount
-#. input
+#. {0} is a currency symbol (e.g., $),                    {1} is an amount input
 #. field
 #: src/olympia/addons/templates/addons/contributions_lightbox.html:64
 msgid "A one-time contribution of {0} {1}"
@@ -422,11 +346,8 @@ msgstr ""
 msgid "Leave a comment or request with your contribution."
 msgstr ""
 
-#: src/olympia/addons/templates/addons/contributions_lightbox.html:74
-#: src/olympia/bandwagon/templates/bandwagon/ajax_new.html:20
-#: src/olympia/bandwagon/templates/bandwagon/includes/addedit.html:37
-#: src/olympia/reviews/templates/reviews/mobile/add_form.html:13
-#: src/olympia/templates/includes/forms.html:10
+#: src/olympia/addons/templates/addons/contributions_lightbox.html:74 src/olympia/bandwagon/templates/bandwagon/ajax_new.html:20 src/olympia/bandwagon/templates/bandwagon/includes/addedit.html:37
+#: src/olympia/reviews/templates/reviews/mobile/add_form.html:13 src/olympia/templates/includes/forms.html:10
 msgid "(optional)"
 msgstr ""
 
@@ -446,36 +367,27 @@ msgstr ""
 msgid "Contribution made, thank you."
 msgstr ""
 
-#: src/olympia/addons/templates/addons/details_box.html:10
-#: src/olympia/discovery/templates/discovery/addons/detail.html:19
+#: src/olympia/addons/templates/addons/details_box.html:10 src/olympia/discovery/templates/discovery/addons/detail.html:19
 msgid "No restart required"
 msgstr ""
 
 #. This is a caption for a table. {0} is an add-on name.
-#: src/olympia/addons/templates/addons/details_box.html:26
-#: src/olympia/addons/templates/addons/includes/persona.html:9
+#: src/olympia/addons/templates/addons/details_box.html:26 src/olympia/addons/templates/addons/includes/persona.html:9
 msgid "Add-on Information for {0}"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/details_box.html:30
-#: src/olympia/addons/templates/addons/persona_detail_table.html:3
-#: src/olympia/addons/templates/addons/mobile/details.html:63
-#: src/olympia/addons/templates/addons/mobile/persona_detail_table.html:7
-#: src/olympia/browse/views.py:459 src/olympia/devhub/views.py:75
+#: src/olympia/addons/templates/addons/details_box.html:30 src/olympia/addons/templates/addons/persona_detail_table.html:3 src/olympia/addons/templates/addons/mobile/details.html:63
+#: src/olympia/addons/templates/addons/mobile/persona_detail_table.html:7 src/olympia/browse/views.py:426 src/olympia/devhub/views.py:73
 msgid "Updated"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/details_box.html:38
-#: src/olympia/addons/templates/addons/mobile/details.html:71
-#: src/olympia/devhub/templates/devhub/addons/edit/support.html:43
+#: src/olympia/addons/templates/addons/details_box.html:38 src/olympia/addons/templates/addons/mobile/details.html:71 src/olympia/devhub/templates/devhub/addons/edit/support.html:43
 #: src/olympia/discovery/templates/discovery/addons/detail.html:77
 msgid "Website"
 msgstr ""
 
 #. This refers to this version's compatible applications, such as Firefox 8.0
-#: src/olympia/addons/templates/addons/details_box.html:47
-#: src/olympia/addons/templates/addons/mobile/details.html:80
-#: src/olympia/search/templates/search/results.html:72
+#: src/olympia/addons/templates/addons/details_box.html:47 src/olympia/addons/templates/addons/mobile/details.html:80 src/olympia/search/templates/search/results.html:72
 #: src/olympia/versions/templates/versions/version.html:21
 msgid "Works with"
 msgstr ""
@@ -484,45 +396,30 @@ msgstr ""
 msgid "Visibility"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/details_box.html:57
-#: src/olympia/devhub/templates/devhub/index.html:94
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:91
+#: src/olympia/addons/templates/addons/details_box.html:57 src/olympia/devhub/templates/devhub/index.html:94 src/olympia/devhub/templates/devhub/includes/addon_details.html:91
 msgid "Hidden"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/details_box.html:59
-#: src/olympia/devhub/templates/devhub/index.html:96
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:93
+#: src/olympia/addons/templates/addons/details_box.html:59 src/olympia/devhub/templates/devhub/index.html:96 src/olympia/devhub/templates/devhub/includes/addon_details.html:93
 msgid "Unlisted"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/details_box.html:67
-#: src/olympia/devhub/templates/devhub/addons/edit/technical.html:44
+#: src/olympia/addons/templates/addons/details_box.html:67 src/olympia/devhub/templates/devhub/addons/edit/technical.html:44
 msgid "Required Add-ons"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/details_box.html:81
-#: src/olympia/addons/templates/addons/persona_detail_table.html:15
-#: src/olympia/browse/views.py:462 src/olympia/devhub/views.py:78
-#: src/olympia/devhub/views.py:85
-#: src/olympia/discovery/templates/discovery/addons/detail.html:57
-#: src/olympia/reviews/forms.py:62
-#: src/olympia/reviews/templates/reviews/add.html:57
+#: src/olympia/addons/templates/addons/details_box.html:81 src/olympia/addons/templates/addons/persona_detail_table.html:15 src/olympia/browse/views.py:429 src/olympia/devhub/views.py:76
+#: src/olympia/devhub/views.py:83 src/olympia/discovery/templates/discovery/addons/detail.html:57 src/olympia/reviews/forms.py:62 src/olympia/reviews/templates/reviews/add.html:57
 #: src/olympia/reviews/templates/reviews/mobile/review_list.html:18
 msgid "Rating"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/details_box.html:85
-#: src/olympia/browse/views.py:461 src/olympia/devhub/views.py:77
-#: src/olympia/devhub/views.py:84
-#: src/olympia/stats/templates/stats/addon_report_menu.html:8
-#: src/olympia/stats/templates/stats/collection_report_menu.html:18
+#: src/olympia/addons/templates/addons/details_box.html:85 src/olympia/browse/views.py:428 src/olympia/devhub/views.py:75 src/olympia/devhub/views.py:82
+#: src/olympia/stats/templates/stats/addon_report_menu.html:8 src/olympia/stats/templates/stats/collection_report_menu.html:18
 msgid "Downloads"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/details_box.html:91
-#: src/olympia/addons/templates/addons/details_box.html:103
-#: src/olympia/devhub/templates/devhub/addons/listing/item_actions_theme.html:17
+#: src/olympia/addons/templates/addons/details_box.html:91 src/olympia/addons/templates/addons/details_box.html:103 src/olympia/devhub/templates/devhub/addons/listing/item_actions_theme.html:17
 #: src/olympia/devhub/templates/devhub/personas/edit.html:60
 msgid "View Statistics"
 msgstr ""
@@ -536,18 +433,13 @@ msgid "Abuse Reports"
 msgstr ""
 
 #. The Privacy Policy for this add-on.
-#: src/olympia/addons/templates/addons/details_box.html:121
-#: src/olympia/addons/templates/addons/privacy.html:19
-#: src/olympia/addons/templates/addons/privacy.html:23
-#: src/olympia/addons/templates/addons/impala/button.html:43
-#: src/olympia/addons/templates/addons/impala/details.html:312
-#: src/olympia/devhub/templates/devhub/includes/policy_form.html:23
+#: src/olympia/addons/templates/addons/details_box.html:121 src/olympia/addons/templates/addons/privacy.html:19 src/olympia/addons/templates/addons/privacy.html:23
+#: src/olympia/addons/templates/addons/impala/button.html:43 src/olympia/addons/templates/addons/impala/details.html:312 src/olympia/devhub/templates/devhub/includes/policy_form.html:23
 #: src/olympia/templates/mobile/base_addons.html:87
 msgid "Privacy Policy"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/details_box.html:124
-#: src/olympia/discovery/templates/discovery/addons/detail.html:24
+#: src/olympia/addons/templates/addons/details_box.html:124 src/olympia/discovery/templates/discovery/addons/detail.html:24
 msgid "View Privacy Policy"
 msgstr ""
 
@@ -555,8 +447,7 @@ msgstr ""
 msgid "EULA"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/details_box.html:171
-#: src/olympia/addons/templates/addons/details_box.html:231
+#: src/olympia/addons/templates/addons/details_box.html:171 src/olympia/addons/templates/addons/details_box.html:231
 msgid "More about this add-on"
 msgstr ""
 
@@ -564,22 +455,18 @@ msgstr ""
 msgid "Image Gallery"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/details_box.html:190
-#: src/olympia/devhub/templates/devhub/addons/edit/technical.html:21
+#: src/olympia/addons/templates/addons/details_box.html:190 src/olympia/devhub/templates/devhub/addons/edit/technical.html:21
 msgid "Developer Comments"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/details_box.html:199
-#: src/olympia/addons/templates/addons/impala/details.html:264
+#: src/olympia/addons/templates/addons/details_box.html:199 src/olympia/addons/templates/addons/impala/details.html:264
 msgid "Development Channel"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/details_box.html:202
-#: src/olympia/addons/templates/addons/mobile/details.html:124
+#: src/olympia/addons/templates/addons/details_box.html:202 src/olympia/addons/templates/addons/mobile/details.html:124
 msgid ""
-"The Development Channel lets you test an experimental new version of this "
-"add-on before it's released to the general public. Once you install the "
-"development version, you will continue to get updates from this channel."
+"The Development Channel lets you test an experimental new version of this add-on before it's released to the general public. Once you install the development version, you will continue to get "
+"updates from this channel."
 msgstr ""
 
 #: src/olympia/addons/templates/addons/details_box.html:207
@@ -588,15 +475,11 @@ msgstr ""
 
 #: src/olympia/addons/templates/addons/details_box.html:211
 msgid ""
-"<strong>Caution:</strong> Development versions of this add-on have not been "
-"reviewed by Mozilla. Once you install a development version you will "
-"continue to receive development updates from this developer. To stop "
-"receiving development updates, reinstall the default version from the link "
-"above."
+"<strong>Caution:</strong> Development versions of this add-on have not been reviewed by Mozilla. Once you install a development version you will continue to receive development updates from this "
+"developer. To stop receiving development updates, reinstall the default version from the link above."
 msgstr ""
 
-#: src/olympia/addons/templates/addons/details_box.html:220
-#: src/olympia/addons/templates/addons/impala/details.html:283
+#: src/olympia/addons/templates/addons/details_box.html:220 src/olympia/addons/templates/addons/impala/details.html:283
 msgid "Version {0}:"
 msgstr ""
 
@@ -604,50 +487,35 @@ msgstr ""
 msgid "Nothing to see here!  The developer did not include any details."
 msgstr ""
 
-#: src/olympia/addons/templates/addons/details_box.html:251
-#: src/olympia/devhub/templates/devhub/versions/edit.html:73
-#: src/olympia/editors/templates/editors/review.html:98
+#: src/olympia/addons/templates/addons/details_box.html:251 src/olympia/devhub/templates/devhub/versions/edit.html:73 src/olympia/editors/templates/editors/review.html:98
 msgid "Version Notes"
 msgstr ""
 
 #. {0} is the name of the add-on.
 #. {0} is the name of the add-on
-#: src/olympia/addons/templates/addons/eula.html:6
-#: src/olympia/discovery/templates/discovery/addons/eula.html:5
+#: src/olympia/addons/templates/addons/eula.html:6 src/olympia/discovery/templates/discovery/addons/eula.html:5
 msgid "End-User License Agreement for {0}"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/eula.html:17
-#: src/olympia/addons/templates/addons/eula.html:21
-#: src/olympia/addons/templates/addons/impala/button.html:48
-#: src/olympia/addons/templates/addons/impala/details.html:321
-#: src/olympia/devhub/templates/devhub/includes/policy_form.html:3
-#: src/olympia/discovery/templates/discovery/addons/eula.html:11
+#: src/olympia/addons/templates/addons/eula.html:17 src/olympia/addons/templates/addons/eula.html:21 src/olympia/addons/templates/addons/impala/button.html:48
+#: src/olympia/addons/templates/addons/impala/details.html:321 src/olympia/devhub/templates/devhub/includes/policy_form.html:3 src/olympia/discovery/templates/discovery/addons/eula.html:11
 msgid "End-User License Agreement"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/eula.html:23
-#: src/olympia/discovery/templates/discovery/addons/eula.html:13
+#: src/olympia/addons/templates/addons/eula.html:23 src/olympia/discovery/templates/discovery/addons/eula.html:13
 #, python-format
-msgid ""
-"%(addon_name)s requires that you accept the following End-User License "
-"Agreement before installation can proceed:"
+msgid "%(addon_name)s requires that you accept the following End-User License Agreement before installation can proceed:"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/eula.html:34
-#: src/olympia/addons/templates/addons/privacy.html:26
+#: src/olympia/addons/templates/addons/eula.html:34 src/olympia/addons/templates/addons/privacy.html:26
 msgid "Back to {0}…"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/home.html:3
-#: src/olympia/addons/templates/addons/mobile/home.html:3
-#: src/olympia/amo/helpers.py:235
+#: src/olympia/addons/templates/addons/home.html:3 src/olympia/addons/templates/addons/mobile/home.html:3 src/olympia/amo/helpers.py:235
 msgid "Add-ons for {0}"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/home.html:10
-#: src/olympia/addons/templates/addons/home.html:53
-#: src/olympia/browse/templates/browse/impala/base_listing.html:11
+#: src/olympia/addons/templates/addons/home.html:10 src/olympia/addons/templates/addons/home.html:53 src/olympia/browse/templates/browse/impala/base_listing.html:11
 msgid "Featured Extensions"
 msgstr ""
 
@@ -655,13 +523,8 @@ msgstr ""
 msgid "Popular Extensions"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/home.html:44
-#: src/olympia/amo/templates/amo/side_nav.html:3
-#: src/olympia/amo/templates/amo/side_nav.html:11
-#: src/olympia/amo/templates/amo/site_nav.html:3
-#: src/olympia/amo/templates/amo/site_nav.html:25
-#: src/olympia/browse/views.py:236 src/olympia/browse/views.py:281
-#: src/olympia/browse/views.py:481
+#: src/olympia/addons/templates/addons/home.html:44 src/olympia/amo/templates/amo/side_nav.html:3 src/olympia/amo/templates/amo/side_nav.html:11 src/olympia/amo/templates/amo/site_nav.html:3
+#: src/olympia/amo/templates/amo/site_nav.html:25 src/olympia/browse/views.py:203 src/olympia/browse/views.py:248 src/olympia/browse/views.py:448
 msgid "Most Popular"
 msgstr ""
 
@@ -669,10 +532,7 @@ msgstr ""
 msgid "All »"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/home.html:54
-#: src/olympia/addons/templates/addons/home.html:63
-#: src/olympia/addons/templates/addons/home.html:72
-#: src/olympia/addons/templates/addons/home.html:80
+#: src/olympia/addons/templates/addons/home.html:54 src/olympia/addons/templates/addons/home.html:63 src/olympia/addons/templates/addons/home.html:72 src/olympia/addons/templates/addons/home.html:80
 #: src/olympia/browse/templates/browse/impala/category_landing.html:36
 msgid "See all »"
 msgstr ""
@@ -681,44 +541,31 @@ msgstr ""
 msgid "Up &amp; Coming Extensions"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/home.html:71
-#: src/olympia/browse/templates/browse/personas/category_landing.html:61
-#: src/olympia/discovery/templates/discovery/pane.html:74
+#: src/olympia/addons/templates/addons/home.html:71 src/olympia/browse/templates/browse/personas/category_landing.html:61 src/olympia/discovery/templates/discovery/pane.html:74
 msgid "Featured Themes"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/home.html:79
-#: src/olympia/bandwagon/templates/bandwagon/impala/collection_listing.html:5
+#: src/olympia/addons/templates/addons/home.html:79 src/olympia/bandwagon/templates/bandwagon/impala/collection_listing.html:5
 msgid "Featured Collections"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/listing_header.html:3
-#: src/olympia/addons/templates/addons/impala/listing/sorter.html:2
-#: src/olympia/amo/templates/amo/mobile/sort_by.html:2
+#: src/olympia/addons/templates/addons/listing_header.html:3 src/olympia/addons/templates/addons/impala/listing/sorter.html:2 src/olympia/amo/templates/amo/mobile/sort_by.html:2
 #: src/olympia/bandwagon/templates/bandwagon/collection_detail.html:118
 msgid "Sort by:"
 msgstr ""
 
 #. {0} is a date.
 #. {0} is a date
-#: src/olympia/addons/templates/addons/macros.html:7
-#: src/olympia/addons/templates/addons/macros.html:72
-#: src/olympia/addons/templates/addons/listing/items_mobile.html:48
-#: src/olympia/addons/templates/addons/listing/macros.html:42
-#: src/olympia/bandwagon/templates/bandwagon/collection_detail.html:50
-#: src/olympia/bandwagon/templates/bandwagon/collection_listing_items.html:40
-#: src/olympia/bandwagon/templates/bandwagon/impala/collection_listing_items.html:40
+#: src/olympia/addons/templates/addons/macros.html:7 src/olympia/addons/templates/addons/macros.html:72 src/olympia/addons/templates/addons/listing/items_mobile.html:48
+#: src/olympia/addons/templates/addons/listing/macros.html:42 src/olympia/bandwagon/templates/bandwagon/collection_detail.html:50
+#: src/olympia/bandwagon/templates/bandwagon/collection_listing_items.html:40 src/olympia/bandwagon/templates/bandwagon/impala/collection_listing_items.html:40
 msgid "Updated {0}"
 msgstr ""
 
 #. {0} is a date.
-#: src/olympia/addons/templates/addons/macros.html:10
-#: src/olympia/addons/templates/addons/macros.html:69
-#: src/olympia/addons/templates/addons/persona_preview.html:22
-#: src/olympia/addons/templates/addons/listing/items_mobile.html:44
-#: src/olympia/addons/templates/addons/listing/macros.html:39
-#: src/olympia/bandwagon/templates/bandwagon/collection_listing_items.html:37
-#: src/olympia/bandwagon/templates/bandwagon/impala/collection_listing_items.html:37
+#: src/olympia/addons/templates/addons/macros.html:10 src/olympia/addons/templates/addons/macros.html:69 src/olympia/addons/templates/addons/persona_preview.html:22
+#: src/olympia/addons/templates/addons/listing/items_mobile.html:44 src/olympia/addons/templates/addons/listing/macros.html:39
+#: src/olympia/bandwagon/templates/bandwagon/collection_listing_items.html:37 src/olympia/bandwagon/templates/bandwagon/impala/collection_listing_items.html:37
 msgid "Added {0}"
 msgstr ""
 
@@ -741,8 +588,7 @@ msgstr[2] ""
 msgstr[3] ""
 
 #. {0} is the number of downloads.
-#: src/olympia/addons/templates/addons/macros.html:53
-#: src/olympia/addons/templates/addons/impala/details.html:59
+#: src/olympia/addons/templates/addons/macros.html:53 src/olympia/addons/templates/addons/impala/details.html:59
 msgid "{0} weekly download"
 msgid_plural "{0} weekly downloads"
 msgstr[0] ""
@@ -751,9 +597,7 @@ msgstr[2] ""
 msgstr[3] ""
 
 #. {0} is the number of users.
-#: src/olympia/addons/templates/addons/macros.html:61
-#: src/olympia/addons/templates/addons/impala/details.html:52
-#: src/olympia/zadmin/templates/zadmin/compat.html:67
+#: src/olympia/addons/templates/addons/macros.html:61 src/olympia/addons/templates/addons/impala/details.html:52 src/olympia/zadmin/templates/zadmin/compat.html:67
 msgid "{0} user"
 msgid_plural "{0} users"
 msgstr[0] ""
@@ -773,12 +617,8 @@ msgstr ""
 msgid "Return to the addon."
 msgstr ""
 
-#: src/olympia/addons/templates/addons/persona_detail.html:17
-#: src/olympia/addons/templates/addons/impala/details.html:103
-#: src/olympia/addons/templates/addons/mobile/details.html:23
-#: src/olympia/addons/templates/addons/mobile/persona_detail.html:21
-#: src/olympia/discovery/templates/discovery/addons/base.html:27
-#: src/olympia/editors/templates/editors/review.html:31
+#: src/olympia/addons/templates/addons/persona_detail.html:17 src/olympia/addons/templates/addons/impala/details.html:103 src/olympia/addons/templates/addons/mobile/details.html:23
+#: src/olympia/addons/templates/addons/mobile/persona_detail.html:21 src/olympia/discovery/templates/discovery/addons/base.html:27 src/olympia/editors/templates/editors/review.html:31
 msgid "by"
 msgstr ""
 
@@ -788,8 +628,7 @@ msgid "More {0} Themes"
 msgstr ""
 
 #. {0} is a category name, such as Nature
-#: src/olympia/addons/templates/addons/persona_detail.html:39
-#: src/olympia/addons/templates/addons/mobile/persona_detail.html:66
+#: src/olympia/addons/templates/addons/persona_detail.html:39 src/olympia/addons/templates/addons/mobile/persona_detail.html:66
 msgid "See all {0} Themes"
 msgstr ""
 
@@ -797,65 +636,45 @@ msgstr ""
 msgid "More by this Artist"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/persona_detail.html:52
-#: src/olympia/addons/templates/addons/mobile/persona_detail.html:49
+#: src/olympia/addons/templates/addons/persona_detail.html:52 src/olympia/addons/templates/addons/mobile/persona_detail.html:49
 msgid "See all Themes by this Artist"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/persona_detail.html:71
-#: src/olympia/addons/templates/addons/mobile/home.html:42
-#: src/olympia/amo/templates/amo/side_nav.html:22
-#: src/olympia/browse/templates/browse/personas/mobile/category_landing.html:28
-#: src/olympia/devhub/templates/devhub/addons/edit/basic.html:72
-#: src/olympia/editors/templates/editors/review.html:277
-#: src/olympia/editors/templates/editors/themes/themes.html:34
-#: src/olympia/templates/categories.html:7
+#: src/olympia/addons/templates/addons/persona_detail.html:71 src/olympia/addons/templates/addons/mobile/home.html:42 src/olympia/amo/templates/amo/side_nav.html:22
+#: src/olympia/browse/templates/browse/personas/mobile/category_landing.html:28 src/olympia/devhub/templates/devhub/addons/edit/basic.html:72 src/olympia/editors/templates/editors/review.html:277
+#: src/olympia/editors/templates/editors/themes/themes.html:34 src/olympia/templates/categories.html:7
 msgid "Categories"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/persona_detail_table.html:10
-#: src/olympia/addons/templates/addons/mobile/persona_detail_table.html:3
-#: src/olympia/editors/templates/editors/themes/deleted.html:19
+#: src/olympia/addons/templates/addons/persona_detail_table.html:10 src/olympia/addons/templates/addons/mobile/persona_detail_table.html:3 src/olympia/editors/templates/editors/themes/deleted.html:19
 #: src/olympia/editors/templates/editors/themes/themes.html:25
 msgid "Artist"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/persona_detail_table.html:19
-#: src/olympia/addons/templates/addons/mobile/persona_detail_table.html:14
-#: src/olympia/stats/templates/stats/addon_report_menu.html:17
+#: src/olympia/addons/templates/addons/persona_detail_table.html:19 src/olympia/addons/templates/addons/mobile/persona_detail_table.html:14 src/olympia/stats/templates/stats/addon_report_menu.html:17
 msgid "Daily Users"
 msgstr ""
 
 #. The License for this add-on.
-#: src/olympia/addons/templates/addons/persona_detail_table.html:26
-#: src/olympia/addons/templates/addons/impala/license.html:17
-#: src/olympia/addons/templates/addons/mobile/persona_detail_table.html:21
-#: src/olympia/devhub/templates/devhub/includes/license_form.html:5
-#: src/olympia/devhub/templates/devhub/versions/edit.html:89
-#: src/olympia/editors/templates/editors/themes/themes.html:41
+#: src/olympia/addons/templates/addons/persona_detail_table.html:26 src/olympia/addons/templates/addons/impala/license.html:17 src/olympia/addons/templates/addons/mobile/persona_detail_table.html:21
+#: src/olympia/devhub/templates/devhub/includes/license_form.html:5 src/olympia/devhub/templates/devhub/versions/edit.html:89 src/olympia/editors/templates/editors/themes/themes.html:41
 msgid "License"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/persona_preview.html:13
-#: src/olympia/constants/base.py:48
+#: src/olympia/addons/templates/addons/persona_preview.html:13 src/olympia/constants/base.py:48
 msgid "Awaiting Review"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/persona_preview.html:15
-#: src/olympia/amo/log.py:180 src/olympia/constants/base.py:42
-#: src/olympia/editors/helpers.py:62
+#: src/olympia/addons/templates/addons/persona_preview.html:15 src/olympia/amo/log.py:180 src/olympia/constants/base.py:42 src/olympia/editors/helpers.py:62
 msgid "Rejected"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/persona_preview.html:17
-#: src/olympia/amo/log.py:159
+#: src/olympia/addons/templates/addons/persona_preview.html:17 src/olympia/amo/log.py:159
 msgid "Approved"
 msgstr ""
 
 #. {0} is the number of users.
-#: src/olympia/addons/templates/addons/persona_preview.html:27
-#: src/olympia/addons/templates/addons/listing/items_mobile.html:36
-#: src/olympia/addons/templates/addons/listing/macros.html:31
+#: src/olympia/addons/templates/addons/persona_preview.html:27 src/olympia/addons/templates/addons/listing/items_mobile.html:36 src/olympia/addons/templates/addons/listing/macros.html:31
 msgid "<strong>{0}</strong> user"
 msgid_plural "<strong>{0}</strong> users"
 msgstr[0] ""
@@ -867,24 +686,15 @@ msgstr[3] ""
 msgid "Hover to Preview"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/persona_preview.html:47
-#: src/olympia/addons/templates/addons/persona_preview.html:49
+#: src/olympia/addons/templates/addons/persona_preview.html:47 src/olympia/addons/templates/addons/persona_preview.html:49 src/olympia/addons/templates/addons/persona_preview.html:97
 #: src/olympia/reviews/templates/reviews/add.html:15
 msgid "Add"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/persona_preview.html:58
-#: src/olympia/bandwagon/templates/bandwagon/ajax_new.html:16
-#: src/olympia/bandwagon/templates/bandwagon/edit.html:19
-#: src/olympia/bandwagon/templates/bandwagon/includes/addedit.html:19
-#: src/olympia/devhub/templates/devhub/addons/edit/admin.html:13
-#: src/olympia/devhub/templates/devhub/addons/edit/basic.html:10
-#: src/olympia/devhub/templates/devhub/addons/edit/details.html:8
-#: src/olympia/devhub/templates/devhub/addons/edit/media.html:6
-#: src/olympia/devhub/templates/devhub/addons/edit/support.html:8
-#: src/olympia/devhub/templates/devhub/addons/edit/technical.html:9
-#: src/olympia/devhub/templates/devhub/addons/submit/describe.html:29
-#: src/olympia/editors/templates/editors/review.html:257
+#: src/olympia/addons/templates/addons/persona_preview.html:58 src/olympia/bandwagon/templates/bandwagon/ajax_new.html:16 src/olympia/bandwagon/templates/bandwagon/edit.html:19
+#: src/olympia/bandwagon/templates/bandwagon/includes/addedit.html:19 src/olympia/devhub/templates/devhub/addons/edit/admin.html:13 src/olympia/devhub/templates/devhub/addons/edit/basic.html:10
+#: src/olympia/devhub/templates/devhub/addons/edit/details.html:8 src/olympia/devhub/templates/devhub/addons/edit/media.html:6 src/olympia/devhub/templates/devhub/addons/edit/support.html:8
+#: src/olympia/devhub/templates/devhub/addons/edit/technical.html:9 src/olympia/devhub/templates/devhub/addons/submit/describe.html:29 src/olympia/editors/templates/editors/review.html:257
 msgid "Edit"
 msgstr ""
 
@@ -899,11 +709,8 @@ msgstr ""
 msgid "by {0} on {1}"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/persona_preview.html:76
-#: src/olympia/reviews/helpers.py:17
-#: src/olympia/reviews/templates/reviews/review_list.html:63
-#: src/olympia/reviews/templates/reviews/reviews_link.html:21
-#: src/olympia/reviews/templates/reviews/impala/reviews_link.html:16
+#: src/olympia/addons/templates/addons/persona_preview.html:76 src/olympia/reviews/helpers.py:17 src/olympia/reviews/templates/reviews/review_list.html:63
+#: src/olympia/reviews/templates/reviews/reviews_link.html:21 src/olympia/reviews/templates/reviews/impala/reviews_link.html:16
 msgid "Not yet rated"
 msgstr ""
 
@@ -912,33 +719,25 @@ msgid "<b>{0}</b> users"
 msgstr ""
 
 #: src/olympia/addons/templates/addons/popups.html:17
-msgid ""
-"To install this add-on and thousands more, <b>get Firefox</b>, a free and "
-"open web browser from Mozilla."
+msgid "To install this add-on and thousands more, <b>get Firefox</b>, a free and open web browser from Mozilla."
 msgstr ""
 
-#: src/olympia/addons/templates/addons/popups.html:21
-#: src/olympia/addons/templates/addons/popups.html:52
+#: src/olympia/addons/templates/addons/popups.html:21 src/olympia/addons/templates/addons/popups.html:52
 msgid "Learn more about Firefox"
 msgstr ""
 
 #: src/olympia/addons/templates/addons/popups.html:22
-msgid "or <b><a class=\"installer\" href=\"{url}\">download anyway</a></b>"
+msgid "or <b><a class=\"button installer\" href=\"{url}\">download anyway</a></b>"
 msgstr ""
 
 #: src/olympia/addons/templates/addons/popups.html:26
 msgid ""
-"<strong>How to Install in Thunderbird</strong> <ol> <li>Download and save "
-"the file to your hard disk.</li> <li>In Mozilla Thunderbird, open Add-ons "
-"from the Tools menu.</li> <li>From the options button next to the add-on "
-"search field, select \"Install Add-on From File...\" and locate the "
-"downloaded add-on.</li> </ol>"
+"<strong>How to Install in Thunderbird</strong> <ol> <li>Download and save the file to your hard disk.</li> <li>In Mozilla Thunderbird, open Add-ons from the Tools menu.</li> <li>From the options "
+"button next to the add-on search field, select \"Install Add-on From File...\" and locate the downloaded add-on.</li> </ol>"
 msgstr ""
 
 #: src/olympia/addons/templates/addons/popups.html:41
-msgid ""
-"To install this Theme, <b>get Thunderbird</b>, a free and open source email "
-"client from Mozilla Messaging and install the Personas Plus add-on."
+msgid "To install this Theme, <b>get Thunderbird</b>, a free and open source email client from Mozilla Messaging and install the Personas Plus add-on."
 msgstr ""
 
 #: src/olympia/addons/templates/addons/popups.html:46
@@ -946,9 +745,7 @@ msgid "Learn more about Thunderbird"
 msgstr ""
 
 #: src/olympia/addons/templates/addons/popups.html:48
-msgid ""
-"To install this Theme and thousands more, <b>get Firefox</b>, a free and "
-"open web browser from Mozilla."
+msgid "To install this Theme and thousands more, <b>get Firefox</b>, a free and open web browser from Mozilla."
 msgstr ""
 
 #: src/olympia/addons/templates/addons/popups.html:60
@@ -956,15 +753,12 @@ msgstr ""
 msgid "This add-on has not been updated to work with your version of %(app)s."
 msgstr ""
 
-#: src/olympia/addons/templates/addons/popups.html:63
-#: src/olympia/addons/templates/addons/popups.html:140
-#: src/olympia/addons/templates/addons/popups.html:150
+#: src/olympia/addons/templates/addons/popups.html:63 src/olympia/addons/templates/addons/popups.html:140 src/olympia/addons/templates/addons/popups.html:150
 msgid "Install Anyway"
 msgstr ""
 
 #: src/olympia/addons/templates/addons/popups.html:71
-msgid ""
-"This add-on requires a version of Firefox that has not been released yet."
+msgid "This add-on requires a version of Firefox that has not been released yet."
 msgstr ""
 
 #: src/olympia/addons/templates/addons/popups.html:74
@@ -973,14 +767,11 @@ msgstr ""
 
 #: src/olympia/addons/templates/addons/popups.html:77
 #, python-format
-msgid ""
-"This add-on requires %(app)s {new_version}. You are currently using %(app)s "
-"{old_version}."
+msgid "This add-on requires %(app)s {new_version}. You are currently using %(app)s {old_version}."
 msgstr ""
 
 #. {0} is an app name, like Firefox.
-#: src/olympia/addons/templates/addons/popups.html:82
-#: src/olympia/addons/templates/addons/popups.html:101
+#: src/olympia/addons/templates/addons/popups.html:82 src/olympia/addons/templates/addons/popups.html:101
 msgid "Upgrade {0}"
 msgstr ""
 
@@ -991,34 +782,25 @@ msgstr ""
 
 #: src/olympia/addons/templates/addons/popups.html:96
 #, python-format
-msgid ""
-"This Persona requires %(app)s %(new_version)s. You are currently using "
-"%(app)s {old_version}."
+msgid "This Persona requires %(app)s %(new_version)s. You are currently using %(app)s {old_version}."
 msgstr ""
 
 #: src/olympia/addons/templates/addons/popups.html:108
 msgid ""
-"<strong>Caution:</strong> This add-on has not been reviewed by Mozilla and "
-"can't be installed on release versions of Firefox 43 and above.  Be careful "
-"when installing third-party software that might harm your computer."
+"<strong>Caution:</strong> This add-on has not been reviewed by Mozilla and can't be installed on release versions of Firefox 43 and above.  Be careful when installing third-party software that "
+"might harm your computer."
 msgstr ""
 
 #: src/olympia/addons/templates/addons/popups.html:120
-msgid ""
-"<strong>Please note:</strong> This add-on is not compatible with your "
-"operating system."
+msgid "<strong>Please note:</strong> This add-on is not compatible with your operating system."
 msgstr ""
 
-#: src/olympia/addons/templates/addons/popups.html:136
-#: src/olympia/addons/templates/addons/impala/button.html:70
+#: src/olympia/addons/templates/addons/popups.html:136 src/olympia/addons/templates/addons/impala/button.html:70
 #, python-format
-msgid ""
-"This add-on is not compatible with your version of %(app)s because of the "
-"following:"
+msgid "This add-on is not compatible with your version of %(app)s because of the following:"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/popups.html:141
-#: src/olympia/addons/templates/addons/popups.html:151
+#: src/olympia/addons/templates/addons/popups.html:141 src/olympia/addons/templates/addons/popups.html:151
 msgid "View other versions"
 msgstr ""
 
@@ -1043,9 +825,7 @@ msgid ""
 "  don't have one.)"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/report_abuse.html:6
-#: src/olympia/addons/templates/addons/report_abuse_full.html:10
-#: src/olympia/addons/templates/addons/impala/details-more.html:23
+#: src/olympia/addons/templates/addons/report_abuse.html:6 src/olympia/addons/templates/addons/report_abuse_full.html:10 src/olympia/addons/templates/addons/impala/details-more.html:23
 #: src/olympia/addons/templates/addons/impala/details.html:333
 msgid "Report Abuse"
 msgstr ""
@@ -1053,121 +833,77 @@ msgstr ""
 #: src/olympia/addons/templates/addons/report_abuse.html:10
 #, python-format
 msgid ""
-"If you suspect this add-on violates <a href=\"%(url)s\">our policies</a> or "
-"has security or privacy issues, please use the form below to describe your "
-"concerns. Please do not use this form for any other reason."
+"If you suspect this add-on violates <a href=\"%(url)s\">our policies</a> or has security or privacy issues, please use the form below to describe your concerns. Please do not use this form for any "
+"other reason."
 msgstr ""
 
-#: src/olympia/addons/templates/addons/report_abuse.html:24
-#: src/olympia/users/templates/users/report_abuse.html:19
+#: src/olympia/addons/templates/addons/report_abuse.html:24 src/olympia/users/templates/users/report_abuse.html:19
 msgid "Send Report"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/report_abuse.html:26
-#: src/olympia/addons/templates/addons/mobile/eula.html:16
-#: src/olympia/addons/templates/addons/mobile/persona_confirm.html:7
-#: src/olympia/devhub/templates/devhub/addons/ajax_compat_update.html:36
-#: src/olympia/devhub/templates/devhub/addons/profile.html:44
-#: src/olympia/devhub/templates/devhub/addons/edit/admin.html:104
-#: src/olympia/devhub/templates/devhub/addons/edit/basic.html:155
-#: src/olympia/devhub/templates/devhub/addons/edit/details.html:88
-#: src/olympia/devhub/templates/devhub/addons/edit/support.html:70
-#: src/olympia/devhub/templates/devhub/addons/edit/technical.html:169
-#: src/olympia/devhub/templates/devhub/addons/forms_shared/media.html:152
-#: src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:43
-#: src/olympia/devhub/templates/devhub/personas/edit.html:222
-#: src/olympia/devhub/templates/devhub/versions/add_file_modal.html:58
-#: src/olympia/devhub/templates/devhub/versions/edit.html:140
-#: src/olympia/devhub/templates/devhub/versions/list.html:208
-#: src/olympia/devhub/templates/devhub/versions/list.html:239
-#: src/olympia/devhub/templates/devhub/versions/list.html:281
-#: src/olympia/devhub/templates/devhub/versions/list.html:315
-#: src/olympia/reviews/templates/reviews/edit_review.html:16
-#: src/olympia/translations/templates/translations/trans-menu.html:50
-#: src/olympia/translations/templates/translations/trans-menu.html:62
-#: src/olympia/zadmin/templates/zadmin/validation.html:105
+#: src/olympia/addons/templates/addons/report_abuse.html:26 src/olympia/addons/templates/addons/mobile/eula.html:16 src/olympia/addons/templates/addons/mobile/persona_confirm.html:7
+#: src/olympia/devhub/templates/devhub/addons/ajax_compat_update.html:36 src/olympia/devhub/templates/devhub/addons/profile.html:44 src/olympia/devhub/templates/devhub/addons/edit/admin.html:104
+#: src/olympia/devhub/templates/devhub/addons/edit/basic.html:155 src/olympia/devhub/templates/devhub/addons/edit/details.html:88 src/olympia/devhub/templates/devhub/addons/edit/support.html:70
+#: src/olympia/devhub/templates/devhub/addons/edit/technical.html:169 src/olympia/devhub/templates/devhub/addons/forms_shared/media.html:152
+#: src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:43 src/olympia/devhub/templates/devhub/personas/edit.html:222 src/olympia/devhub/templates/devhub/versions/add_file_modal.html:59
+#: src/olympia/devhub/templates/devhub/versions/edit.html:140 src/olympia/devhub/templates/devhub/versions/list.html:208 src/olympia/devhub/templates/devhub/versions/list.html:239
+#: src/olympia/devhub/templates/devhub/versions/list.html:281 src/olympia/devhub/templates/devhub/versions/list.html:315 src/olympia/reviews/templates/reviews/edit_review.html:16
+#: src/olympia/translations/templates/translations/trans-menu.html:50 src/olympia/translations/templates/translations/trans-menu.html:62 src/olympia/zadmin/templates/zadmin/validation.html:105
 msgid "Cancel"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/review_add_box.html:3
-#: src/olympia/addons/templates/addons/impala/review_add_box.html:5
+#: src/olympia/addons/templates/addons/review_add_box.html:3 src/olympia/addons/templates/addons/impala/review_add_box.html:5
 msgid "What do you think?"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/review_add_box.html:7
-#: src/olympia/addons/templates/addons/impala/review_add_box.html:9
+#: src/olympia/addons/templates/addons/review_add_box.html:7 src/olympia/addons/templates/addons/impala/review_add_box.html:9
 #, python-format
 msgid "Please <a href=\"%(login)s\">log in</a> to submit a review"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/review_add_box.html:16
-#: src/olympia/addons/templates/addons/impala/review_add_box.html:18
-#: src/olympia/reviews/templates/reviews/mobile/add_form.html:13
+#: src/olympia/addons/templates/addons/review_add_box.html:16 src/olympia/addons/templates/addons/impala/review_add_box.html:18 src/olympia/reviews/templates/reviews/mobile/add_form.html:13
 msgid "Title:"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/review_add_box.html:17
-#: src/olympia/addons/templates/addons/impala/review_add_box.html:19
-#: src/olympia/reviews/templates/reviews/mobile/add_form.html:17
+#: src/olympia/addons/templates/addons/review_add_box.html:17 src/olympia/addons/templates/addons/impala/review_add_box.html:19 src/olympia/reviews/templates/reviews/mobile/add_form.html:17
 msgid "Review:"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/review_add_box.html:18
-#: src/olympia/addons/templates/addons/impala/review_add_box.html:20
-#: src/olympia/reviews/templates/reviews/mobile/add_form.html:16
+#: src/olympia/addons/templates/addons/review_add_box.html:18 src/olympia/addons/templates/addons/impala/review_add_box.html:20 src/olympia/reviews/templates/reviews/mobile/add_form.html:16
 msgid "Rating:"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/review_add_box.html:19
-#: src/olympia/addons/templates/addons/impala/review_add_box.html:21
-#: src/olympia/reviews/templates/reviews/add.html:63
-#: src/olympia/reviews/templates/reviews/edit_review.html:15
-#: src/olympia/reviews/templates/reviews/mobile/add_form.html:18
+#: src/olympia/addons/templates/addons/review_add_box.html:19 src/olympia/addons/templates/addons/impala/review_add_box.html:21 src/olympia/reviews/templates/reviews/add.html:63
+#: src/olympia/reviews/templates/reviews/edit_review.html:15 src/olympia/reviews/templates/reviews/mobile/add_form.html:18
 msgid "Submit review"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/review_add_box.html:24
-#: src/olympia/addons/templates/addons/impala/review_add_box.html:26
-msgid ""
-"Please do not post bug reports in reviews. We do not make your email address"
-" available to add-on developers and they may need to contact you to help "
-"resolve your issue."
+#: src/olympia/addons/templates/addons/review_add_box.html:24 src/olympia/addons/templates/addons/impala/review_add_box.html:26
+msgid "Please do not post bug reports in reviews. We do not make your email address available to add-on developers and they may need to contact you to help resolve your issue."
 msgstr ""
 
-#: src/olympia/addons/templates/addons/review_add_box.html:32
-#: src/olympia/addons/templates/addons/impala/review_add_box.html:35
+#: src/olympia/addons/templates/addons/review_add_box.html:32 src/olympia/addons/templates/addons/impala/review_add_box.html:35
 #, python-format
-msgid ""
-"See the <a href=\"%(support)s\">support section</a> to find out where to get"
-" assistance for this add-on."
+msgid "See the <a href=\"%(support)s\">support section</a> to find out where to get assistance for this add-on."
 msgstr ""
 
-#: src/olympia/addons/templates/addons/review_add_box.html:38
-#: src/olympia/addons/templates/addons/impala/review_add_box.html:42
-#: src/olympia/pages/templates/pages/review_guide.html:3
+#: src/olympia/addons/templates/addons/review_add_box.html:38 src/olympia/addons/templates/addons/impala/review_add_box.html:42 src/olympia/pages/templates/pages/review_guide.html:3
 #: src/olympia/pages/templates/pages/review_guide.html:44
 msgid "Review Guidelines"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/review_list_box.html:5
-#: src/olympia/addons/templates/addons/impala/details-more.html:27
-#: src/olympia/editors/helpers.py:997
-#: src/olympia/reviews/templates/reviews/add.html:14
-#: src/olympia/reviews/templates/reviews/reply.html:14
-#: src/olympia/reviews/templates/reviews/review_list.html:19
+#: src/olympia/addons/templates/addons/review_list_box.html:5 src/olympia/addons/templates/addons/impala/details-more.html:27 src/olympia/editors/helpers.py:1001
+#: src/olympia/reviews/templates/reviews/add.html:14 src/olympia/reviews/templates/reviews/reply.html:14 src/olympia/reviews/templates/reviews/review_list.html:19
 #: src/olympia/reviews/templates/reviews/mobile/review_list.html:26
 msgid "Reviews"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/review_list_box.html:14
-#: src/olympia/addons/templates/addons/impala/review_list_box.html:14
-#: src/olympia/reviews/templates/reviews/review.html:30
+#: src/olympia/addons/templates/addons/review_list_box.html:14 src/olympia/addons/templates/addons/impala/review_list_box.html:14 src/olympia/reviews/templates/reviews/review.html:30
 #, python-format
 msgid "by %(user)s on %(date)s"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/review_list_box.html:19
-#: src/olympia/addons/templates/addons/impala/review_list_box.html:29
+#: src/olympia/addons/templates/addons/review_list_box.html:19 src/olympia/addons/templates/addons/impala/review_list_box.html:29
 msgid "Show the developer's reply to this review"
 msgstr ""
 
@@ -1180,21 +916,16 @@ msgstr[1] ""
 msgstr[2] ""
 msgstr[3] ""
 
-#: src/olympia/addons/templates/addons/tags_box.html:3
-#: src/olympia/devhub/templates/devhub/addons/edit/basic.html:118
+#: src/olympia/addons/templates/addons/tags_box.html:3 src/olympia/devhub/templates/devhub/addons/edit/basic.html:118
 msgid "Tags"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/impala/addon_hovercard.html:7
-#: src/olympia/addons/templates/addons/impala/addon_hovercard.html:9
+#: src/olympia/addons/templates/addons/impala/addon_hovercard.html:7 src/olympia/addons/templates/addons/impala/addon_hovercard.html:9
 msgid "Icon for {0}"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/impala/addon_hovercard.html:34
-#: src/olympia/addons/templates/addons/impala/featured_grid.html:26
-#: src/olympia/addons/templates/addons/impala/theme_grid.html:22
-#: src/olympia/bandwagon/templates/bandwagon/collection_detail.html:31
-#: src/olympia/users/templates/users/helpers/addon_users_list.html:7
+#: src/olympia/addons/templates/addons/impala/addon_hovercard.html:34 src/olympia/addons/templates/addons/impala/featured_grid.html:26 src/olympia/addons/templates/addons/impala/theme_grid.html:22
+#: src/olympia/bandwagon/templates/bandwagon/collection_detail.html:31 src/olympia/users/templates/users/helpers/addon_users_list.html:7
 #, python-format
 msgid "by %(users)s"
 msgstr ""
@@ -1214,25 +945,17 @@ msgstr ""
 
 #: src/olympia/addons/templates/addons/impala/contribution.html:43
 #, python-format
-msgid ""
-"The <a href=\"%(meet_url)s\">developer of this add-on</a> asks that you help"
-" support its continued development by making a small contribution."
+msgid "The <a href=\"%(meet_url)s\">developer of this add-on</a> asks that you help support its continued development by making a small contribution."
 msgstr ""
 
 #: src/olympia/addons/templates/addons/impala/contribution.html:48
 #, python-format
-msgid ""
-"The <a href=\"%(meet_url)s\">developer of this add-on</a> asks that you show"
-" your support by making a donation to the <a "
-"href=\"%(charity_url)s\">%(charity_name)s</a>."
+msgid "The <a href=\"%(meet_url)s\">developer of this add-on</a> asks that you show your support by making a donation to the <a href=\"%(charity_url)s\">%(charity_name)s</a>."
 msgstr ""
 
 #: src/olympia/addons/templates/addons/impala/contribution.html:53
 #, python-format
-msgid ""
-"The <a href=\"%(meet_url)s\">developer of this add-on</a> asks that you show"
-" your support by making a small contribution to <a "
-"href=\"%(charity_url)s\">%(charity_name)s</a>."
+msgid "The <a href=\"%(meet_url)s\">developer of this add-on</a> asks that you show your support by making a small contribution to <a href=\"%(charity_url)s\">%(charity_name)s</a>."
 msgstr ""
 
 #: src/olympia/addons/templates/addons/impala/dependencies_note.html:4
@@ -1286,8 +1009,7 @@ msgstr ""
 msgid "Icon of {0}"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/impala/details.html:100
-#: src/olympia/addons/templates/addons/impala/listing/items.html:14
+#: src/olympia/addons/templates/addons/impala/details.html:100 src/olympia/addons/templates/addons/impala/listing/items.html:14
 msgid "No Restart"
 msgstr ""
 
@@ -1321,11 +1043,8 @@ msgstr ""
 msgid "Support E-mail"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/impala/details.html:199
-#: src/olympia/devhub/models.py:378
-#: src/olympia/devhub/templates/devhub/versions/list.html:12
-#: src/olympia/versions/templates/versions/version.html:6
-#: src/olympia/versions/templates/versions/mobile/version.html:6
+#: src/olympia/addons/templates/addons/impala/details.html:199 src/olympia/devhub/models.py:378 src/olympia/devhub/templates/devhub/versions/list.html:12
+#: src/olympia/versions/templates/versions/version.html:6 src/olympia/versions/templates/versions/mobile/version.html:6
 msgid "Version {0}"
 msgstr ""
 
@@ -1333,8 +1052,7 @@ msgstr ""
 msgid "Info"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/impala/details.html:200
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:116
+#: src/olympia/addons/templates/addons/impala/details.html:200 src/olympia/devhub/templates/devhub/includes/addon_details.html:116
 msgid "Last Updated:"
 msgstr ""
 
@@ -1343,12 +1061,8 @@ msgstr ""
 msgid "Released under <a target=\"_blank\" href=\"%(url)s\">%(name)s</a>"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/impala/details.html:206
-#: src/olympia/addons/templates/addons/impala/details.html:211
-#: src/olympia/amo/helpers.py:398 src/olympia/devhub/forms.py:142
-#: src/olympia/devhub/forms.py:173
-#: src/olympia/versions/templates/versions/version.html:40
-#: src/olympia/versions/templates/versions/version.html:45
+#: src/olympia/addons/templates/addons/impala/details.html:206 src/olympia/addons/templates/addons/impala/details.html:211 src/olympia/amo/helpers.py:398 src/olympia/devhub/forms.py:142
+#: src/olympia/devhub/forms.py:173 src/olympia/versions/templates/versions/version.html:40 src/olympia/versions/templates/versions/version.html:45
 msgid "Custom License"
 msgstr ""
 
@@ -1375,31 +1089,21 @@ msgstr ""
 
 #: src/olympia/addons/templates/addons/impala/details.html:267
 msgid ""
-"The Development Channel lets you test an experimental new version of this "
-"add-on before it's released to the general public. Once you install the "
-"development version, you will continue to get updates from this channel. To "
-"stop receiving development updates, reinstall the default version from the "
-"link above."
+"The Development Channel lets you test an experimental new version of this add-on before it's released to the general public. Once you install the development version, you will continue to get "
+"updates from this channel. To stop receiving development updates, reinstall the default version from the link above."
 msgstr ""
 
 #: src/olympia/addons/templates/addons/impala/details.html:277
-msgid ""
-"<strong>Caution:</strong> Development versions of this add-on have not been "
-"reviewed by Mozilla."
+msgid "<strong>Caution:</strong> Development versions of this add-on have not been reviewed by Mozilla."
 msgstr ""
 
 #: src/olympia/addons/templates/addons/impala/details.html:292
 msgid "See complete development channel history"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/impala/details.html:311
-#: src/olympia/addons/templates/addons/impala/details.html:320
-#: src/olympia/addons/templates/addons/impala/details.html:332
-#: src/olympia/addons/templates/addons/impala/review_add_box.html:4
-#: src/olympia/stats/templates/stats/popup.html:2
-#: src/olympia/stats/templates/stats/popup.html:8
-#: src/olympia/stats/templates/stats/stats.html:202
-#: src/olympia/users/templates/users/profile.html:119
+#: src/olympia/addons/templates/addons/impala/details.html:311 src/olympia/addons/templates/addons/impala/details.html:320 src/olympia/addons/templates/addons/impala/details.html:332
+#: src/olympia/addons/templates/addons/impala/review_add_box.html:4 src/olympia/stats/templates/stats/popup.html:2 src/olympia/stats/templates/stats/popup.html:8
+#: src/olympia/stats/templates/stats/stats.html:204 src/olympia/users/templates/users/profile.html:119
 msgid "close"
 msgstr ""
 
@@ -1414,9 +1118,7 @@ msgid "Meet the {0} Developer"
 msgstr ""
 
 #: src/olympia/addons/templates/addons/impala/developers.html:41
-msgid ""
-"Before downloading this add-on, please consider supporting the development "
-"of this add-on by making a small contribution."
+msgid "Before downloading this add-on, please consider supporting the development of this add-on by making a small contribution."
 msgstr ""
 
 #: src/olympia/addons/templates/addons/impala/developers.html:80
@@ -1435,9 +1137,7 @@ msgstr[1] ""
 msgstr[2] ""
 msgstr[3] ""
 
-#: src/olympia/addons/templates/addons/impala/developers.html:96
-#: src/olympia/users/templates/users/edit.html:130
-#: src/olympia/users/templates/users/profile.html:26
+#: src/olympia/addons/templates/addons/impala/developers.html:96 src/olympia/users/templates/users/edit.html:130 src/olympia/users/templates/users/profile.html:26
 msgid "No Photo"
 msgstr ""
 
@@ -1457,19 +1157,15 @@ msgstr ""
 msgid "Source Code License for {addon}"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/impala/license.html:21
-#: src/olympia/versions/templates/versions/mobile/version.html:18
+#: src/olympia/addons/templates/addons/impala/license.html:21 src/olympia/versions/templates/versions/mobile/version.html:18
 msgid "Source Code License"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/impala/review_list_box.html:19
-#: src/olympia/reviews/templates/reviews/review.html:40
+#: src/olympia/addons/templates/addons/impala/review_list_box.html:19 src/olympia/reviews/templates/reviews/review.html:40
 msgid "permalink"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/impala/review_list_box.html:23
-#: src/olympia/editors/templates/editors/queue.html:98
-#: src/olympia/reviews/templates/reviews/review.html:44
+#: src/olympia/addons/templates/addons/impala/review_list_box.html:23 src/olympia/editors/templates/editors/queue.html:104 src/olympia/reviews/templates/reviews/review.html:44
 msgid "translate"
 msgstr ""
 
@@ -1482,8 +1178,7 @@ msgstr[1] ""
 msgstr[2] ""
 msgstr[3] ""
 
-#: src/olympia/addons/templates/addons/impala/review_list_box.html:47
-#: src/olympia/reviews/templates/reviews/review_list.html:84
+#: src/olympia/addons/templates/addons/impala/review_list_box.html:47 src/olympia/reviews/templates/reviews/review_list.html:84
 msgid "This add-on has not yet been reviewed."
 msgstr ""
 
@@ -1495,24 +1190,19 @@ msgstr ""
 msgid "{0} users"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/impala/listing/sorter.html:14
-#: src/olympia/devhub/templates/devhub/addons/listing/item_actions.html:49
+#: src/olympia/addons/templates/addons/impala/listing/sorter.html:14 src/olympia/devhub/templates/devhub/addons/listing/item_actions.html:49
 msgid "More"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/includes/collection_add_widget.html:7
-#: src/olympia/addons/templates/addons/includes/collection_add_widget.html:10
+#: src/olympia/addons/templates/addons/includes/collection_add_widget.html:7 src/olympia/addons/templates/addons/includes/collection_add_widget.html:10
 msgid "Add to collection"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/includes/dashboard_tabs.html:4
-#: src/olympia/devhub/templates/devhub/index.html:73
-#: src/olympia/devhub/templates/devhub/nav.html:14
+#: src/olympia/addons/templates/addons/includes/dashboard_tabs.html:4 src/olympia/devhub/templates/devhub/index.html:73 src/olympia/devhub/templates/devhub/nav.html:14
 msgid "My Add-ons"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/includes/dashboard_tabs.html:6
-#: src/olympia/amo/context_processors.py:52
+#: src/olympia/addons/templates/addons/includes/dashboard_tabs.html:6 src/olympia/amo/context_processors.py:50
 msgid "My Themes"
 msgstr ""
 
@@ -1528,8 +1218,7 @@ msgstr ""
 msgid "Approve / Reject"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/includes/persona.html:25
-#: src/olympia/editors/templates/editors/themes/single.html:43
+#: src/olympia/addons/templates/addons/includes/persona.html:25 src/olympia/editors/templates/editors/themes/single.html:43
 msgid "Review History"
 msgstr ""
 
@@ -1550,9 +1239,7 @@ msgid "Not Yet Rated"
 msgstr ""
 
 #. {0} is the number of downloads.
-#: src/olympia/addons/templates/addons/listing/items_mobile.html:27
-#: src/olympia/addons/templates/addons/listing/macros.html:24
-#: src/olympia/devhub/templates/devhub/addons/listing/macros.html:15
+#: src/olympia/addons/templates/addons/listing/items_mobile.html:27 src/olympia/addons/templates/addons/listing/macros.html:24 src/olympia/devhub/templates/devhub/addons/listing/macros.html:15
 msgid "<strong>{0}</strong> weekly download"
 msgid_plural "<strong>{0}</strong> weekly downloads"
 msgstr[0] ""
@@ -1568,15 +1255,11 @@ msgstr ""
 msgid "Users"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/mobile/details.html:92
-#: src/olympia/browse/views.py:59 src/olympia/browse/views.py:70
-#: src/olympia/search/forms.py:90
+#: src/olympia/addons/templates/addons/mobile/details.html:92 src/olympia/browse/views.py:59 src/olympia/browse/views.py:70 src/olympia/search/forms.py:90
 msgid "Weekly Downloads"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/mobile/details.html:99
-#: src/olympia/compat/templates/compat/reporter_detail.html:46
-#: src/olympia/devhub/forms.py:779
+#: src/olympia/addons/templates/addons/mobile/details.html:99 src/olympia/compat/templates/compat/reporter_detail.html:46 src/olympia/devhub/forms.py:788
 #: src/olympia/devhub/templates/devhub/versions/list.html:163
 msgid "Version"
 msgstr ""
@@ -1612,45 +1295,29 @@ msgstr ""
 
 #: src/olympia/addons/templates/addons/mobile/eula.html:5
 #, python-format
-msgid ""
-"%(name)s requires that you accept the following End-User License Agreement "
-"before installation can proceed:"
+msgid "%(name)s requires that you accept the following End-User License Agreement before installation can proceed:"
 msgstr ""
 
 #: src/olympia/addons/templates/addons/mobile/eula.html:15
 msgid "Accept"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/mobile/home.html:10
-#: src/olympia/templates/mobile/base_addons.html:53
+#: src/olympia/addons/templates/addons/mobile/home.html:10 src/olympia/templates/mobile/base_addons.html:53
 msgid "Add-ons are not currently available on Firefox for iOS."
 msgstr ""
 
-#: src/olympia/addons/templates/addons/mobile/home.html:12
-#: src/olympia/templates/mobile/base_addons.html:55
-msgid ""
-"You need Firefox to install add-ons. <a "
-"href=\"http://mozilla.com/mobile\">Learn More&nbsp;&raquo;</a>"
+#: src/olympia/addons/templates/addons/mobile/home.html:12 src/olympia/templates/mobile/base_addons.html:55
+msgid "You need Firefox to install add-ons. <a href=\"http://mozilla.com/mobile\">Learn More&nbsp;&raquo;</a>"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/mobile/home.html:19
-#: src/olympia/templates/header_title.html:4
-#: src/olympia/templates/impala/header_title.html:3
+#: src/olympia/addons/templates/addons/mobile/home.html:19 src/olympia/templates/header_title.html:4 src/olympia/templates/impala/header_title.html:3
 msgid "Return to the {0} Add-ons homepage"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/mobile/home.html:21
-#: src/olympia/amo/helpers.py:237
-#: src/olympia/bandwagon/templates/bandwagon/edit.html:34
-#: src/olympia/discovery/templates/discovery/pane.html:92
-#: src/olympia/editors/templates/editors/base.html:21
-#: src/olympia/editors/templates/editors/performance.html:72
-#: src/olympia/templates/menu_links.html:4
-#: src/olympia/templates/impala/header_title.html:13
-#: src/olympia/templates/impala/header_title.html:15
-#: src/olympia/templates/impala/header_title.html:19
-#: src/olympia/templates/impala/header_title.html:23
-#: src/olympia/templates/mobile/base_addons.html:47
+#: src/olympia/addons/templates/addons/mobile/home.html:21 src/olympia/amo/helpers.py:237 src/olympia/bandwagon/templates/bandwagon/edit.html:34 src/olympia/discovery/templates/discovery/pane.html:92
+#: src/olympia/editors/templates/editors/base.html:21 src/olympia/editors/templates/editors/performance.html:72 src/olympia/templates/menu_links.html:4
+#: src/olympia/templates/impala/header_title.html:13 src/olympia/templates/impala/header_title.html:15 src/olympia/templates/impala/header_title.html:19
+#: src/olympia/templates/impala/header_title.html:23 src/olympia/templates/mobile/base_addons.html:47
 msgid "Add-ons"
 msgstr ""
 
@@ -1658,44 +1325,26 @@ msgstr ""
 msgid "Easy ways to personalize."
 msgstr ""
 
-#: src/olympia/addons/templates/addons/mobile/home.html:24
-#: src/olympia/devhub/templates/devhub/addons/submit/done.html:47
-#: src/olympia/discovery/templates/discovery/pane.html:34
-#: src/olympia/discovery/templates/discovery/addons/detail.html:16
-#: src/olympia/discovery/templates/discovery/modules/featured.html:21
-#: src/olympia/discovery/templates/discovery/modules/monthly.html:22
+#: src/olympia/addons/templates/addons/mobile/home.html:24 src/olympia/devhub/templates/devhub/addons/submit/done.html:47 src/olympia/discovery/templates/discovery/pane.html:34
+#: src/olympia/discovery/templates/discovery/addons/detail.html:16 src/olympia/discovery/templates/discovery/modules/featured.html:21 src/olympia/discovery/templates/discovery/modules/monthly.html:22
 msgid "Learn More"
 msgstr ""
 
 #: src/olympia/addons/templates/addons/mobile/home.html:26
 msgid ""
-"Add-ons are applications that let you personalize Firefox with extra "
-"functionality and style. Whether you mistype the name of a website or can't "
-"read a busy page, there's an add-on to improve your on-the-go browsing."
+"Add-ons are applications that let you personalize Firefox with extra functionality and style. Whether you mistype the name of a website or can't read a busy page, there's an add-on to improve your "
+"on-the-go browsing."
 msgstr ""
 
 #. {0} is a category name. Ex: "Sports"
 #. {0} is a category name, such as Nature.
-#: src/olympia/addons/templates/addons/mobile/home.html:43
-#: src/olympia/amo/templates/amo/site_nav.html:32
-#: src/olympia/browse/feeds.py:107
-#: src/olympia/browse/templates/browse/impala/base_listing.html:38
-#: src/olympia/browse/templates/browse/personas/base.html:6
-#: src/olympia/browse/templates/browse/personas/base.html:42
-#: src/olympia/browse/templates/browse/personas/category_landing.html:21
-#: src/olympia/browse/templates/browse/personas/category_landing.html:23
-#: src/olympia/browse/templates/browse/personas/category_landing.html:38
-#: src/olympia/browse/templates/browse/personas/grid.html:7
-#: src/olympia/browse/templates/browse/personas/grid.html:11
-#: src/olympia/browse/templates/browse/personas/mobile/base.html:7
-#: src/olympia/browse/templates/browse/personas/mobile/category_landing.html:19
-#: src/olympia/constants/base.py:180
-#: src/olympia/devhub/templates/devhub/personas/submit.html:13
-#: src/olympia/editors/helpers.py:107
-#: src/olympia/editors/templates/editors/base.html:26
-#: src/olympia/editors/templates/editors/performance.html:73
-#: src/olympia/search/templates/search/personas.html:39
-#: src/olympia/templates/menu_links.html:9
+#: src/olympia/addons/templates/addons/mobile/home.html:43 src/olympia/amo/templates/amo/site_nav.html:32 src/olympia/browse/feeds.py:107
+#: src/olympia/browse/templates/browse/impala/base_listing.html:38 src/olympia/browse/templates/browse/personas/base.html:6 src/olympia/browse/templates/browse/personas/base.html:42
+#: src/olympia/browse/templates/browse/personas/category_landing.html:21 src/olympia/browse/templates/browse/personas/category_landing.html:23
+#: src/olympia/browse/templates/browse/personas/category_landing.html:38 src/olympia/browse/templates/browse/personas/grid.html:7 src/olympia/browse/templates/browse/personas/grid.html:11
+#: src/olympia/browse/templates/browse/personas/mobile/base.html:7 src/olympia/browse/templates/browse/personas/mobile/category_landing.html:19 src/olympia/constants/base.py:180
+#: src/olympia/devhub/templates/devhub/personas/submit.html:13 src/olympia/editors/helpers.py:107 src/olympia/editors/templates/editors/base.html:26
+#: src/olympia/editors/templates/editors/performance.html:73 src/olympia/search/templates/search/personas.html:39 src/olympia/templates/menu_links.html:9
 msgid "Themes"
 msgstr ""
 
@@ -1711,19 +1360,12 @@ msgstr ""
 msgid "More Add-ons"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/mobile/home.html:72
-#: src/olympia/browse/templates/browse/personas/mobile/category_landing.html:64
-#: src/olympia/search/forms.py:14
+#: src/olympia/addons/templates/addons/mobile/home.html:72 src/olympia/browse/templates/browse/personas/mobile/category_landing.html:64 src/olympia/search/forms.py:14
 msgid "Highest Rated"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/mobile/home.html:74
-#: src/olympia/amo/templates/amo/side_nav.html:5
-#: src/olympia/amo/templates/amo/site_nav.html:27
-#: src/olympia/amo/templates/amo/site_nav.html:55
-#: src/olympia/bandwagon/views.py:97 src/olympia/browse/views.py:57
-#: src/olympia/browse/views.py:67
-#: src/olympia/browse/templates/browse/personas/mobile/category_landing.html:65
+#: src/olympia/addons/templates/addons/mobile/home.html:74 src/olympia/amo/templates/amo/side_nav.html:5 src/olympia/amo/templates/amo/site_nav.html:27 src/olympia/amo/templates/amo/site_nav.html:55
+#: src/olympia/bandwagon/views.py:97 src/olympia/browse/views.py:57 src/olympia/browse/views.py:67 src/olympia/browse/templates/browse/personas/mobile/category_landing.html:65
 #: src/olympia/search/forms.py:15 src/olympia/search/forms.py:87
 msgid "Newest"
 msgstr ""
@@ -1736,81 +1378,60 @@ msgstr ""
 msgid "Theme Info &raquo;"
 msgstr ""
 
-#: src/olympia/amo/context_processors.py:39
-#: src/olympia/devhub/templates/devhub/nav.html:43
+#: src/olympia/amo/context_processors.py:37 src/olympia/devhub/templates/devhub/nav.html:43
 msgid "Tools"
 msgstr ""
 
-#: src/olympia/amo/context_processors.py:49
-#: src/olympia/discovery/templates/discovery/pane_account.html:8
-#: src/olympia/users/templates/users/includes/navigation.html:2
+#: src/olympia/amo/context_processors.py:47 src/olympia/discovery/templates/discovery/pane_account.html:8 src/olympia/users/templates/users/includes/navigation.html:2
 msgid "My Profile"
 msgstr ""
 
-#: src/olympia/amo/context_processors.py:55
-#: src/olympia/users/templates/users/edit.html:5
-#: src/olympia/users/templates/users/includes/navigation.html:3
+#: src/olympia/amo/context_processors.py:53 src/olympia/users/templates/users/edit.html:5 src/olympia/users/templates/users/includes/navigation.html:3
 msgid "Account Settings"
 msgstr ""
 
-#: src/olympia/amo/context_processors.py:58
-#: src/olympia/discovery/templates/discovery/pane_account.html:11
-#: src/olympia/users/templates/users/profile.html:83
+#: src/olympia/amo/context_processors.py:56 src/olympia/discovery/templates/discovery/pane_account.html:11 src/olympia/users/templates/users/profile.html:83
 #: src/olympia/users/templates/users/includes/navigation.html:4
 msgid "My Collections"
 msgstr ""
 
-#: src/olympia/amo/context_processors.py:63
-#: src/olympia/discovery/templates/discovery/pane_account.html:10
-#: src/olympia/users/templates/users/includes/navigation.html:7
+#: src/olympia/amo/context_processors.py:61 src/olympia/discovery/templates/discovery/pane_account.html:10 src/olympia/users/templates/users/includes/navigation.html:7
 msgid "My Favorites"
 msgstr ""
 
-#: src/olympia/amo/context_processors.py:68
-#: src/olympia/discovery/templates/discovery/pane_account.html:13
-#: src/olympia/templates/impala/user_login.html:14
+#: src/olympia/amo/context_processors.py:66 src/olympia/discovery/templates/discovery/pane_account.html:13 src/olympia/templates/impala/user_login.html:14
 #: src/olympia/templates/mobile/header_auth.html:5
 msgid "Log out"
 msgstr ""
 
-#: src/olympia/amo/context_processors.py:73
-#: src/olympia/devhub/templates/devhub/addons/dashboard.html:4
+#: src/olympia/amo/context_processors.py:71 src/olympia/devhub/templates/devhub/addons/dashboard.html:4
 msgid "Manage My Submissions"
 msgstr ""
 
-#: src/olympia/amo/context_processors.py:76
-#: src/olympia/devhub/templates/devhub/nav.html:27
-#: src/olympia/devhub/templates/devhub/addons/dashboard.html:25
+#: src/olympia/amo/context_processors.py:74 src/olympia/devhub/templates/devhub/nav.html:27 src/olympia/devhub/templates/devhub/addons/dashboard.html:25
 #: src/olympia/devhub/templates/devhub/addons/submit/base.html:4
 msgid "Submit a New Add-on"
 msgstr ""
 
-#: src/olympia/amo/context_processors.py:78
-#: src/olympia/browse/templates/browse/personas/base.html:50
-#: src/olympia/devhub/templates/devhub/index.html:24
+#: src/olympia/amo/context_processors.py:76 src/olympia/browse/templates/browse/personas/base.html:50 src/olympia/devhub/templates/devhub/index.html:24
 #: src/olympia/devhub/templates/devhub/addons/dashboard.html:29
 msgid "Submit a New Theme"
 msgstr ""
 
-#: src/olympia/amo/context_processors.py:80
-#: src/olympia/amo/templates/amo/site_nav.html:85
-#: src/olympia/devhub/helpers.py:36 src/olympia/devhub/helpers.py:68
-#: src/olympia/devhub/helpers.py:102 src/olympia/templates/footer.html:6
-#: src/olympia/templates/menu_links.html:14
+#: src/olympia/amo/context_processors.py:78 src/olympia/amo/templates/amo/site_nav.html:85 src/olympia/devhub/helpers.py:36 src/olympia/devhub/helpers.py:68 src/olympia/devhub/helpers.py:102
+#: src/olympia/templates/footer.html:6 src/olympia/templates/menu_links.html:14
 msgid "Developer Hub"
 msgstr ""
 
-#: src/olympia/amo/context_processors.py:84 src/olympia/devhub/views.py:1795
+#: src/olympia/amo/context_processors.py:81 src/olympia/devhub/views.py:1796
 msgid "Manage API Keys"
 msgstr ""
 
-#: src/olympia/amo/context_processors.py:89 src/olympia/editors/helpers.py:84
-#: src/olympia/editors/helpers.py:104
-#: src/olympia/editors/templates/editors/base.html:10
+#: src/olympia/amo/context_processors.py:86 src/olympia/editors/helpers.py:84 src/olympia/editors/helpers.py:104 src/olympia/editors/templates/editors/base.html:10
 msgid "Editor Tools"
 msgstr ""
 
-#: src/olympia/amo/context_processors.py:93
+#: src/olympia/amo/context_processors.py:90
 msgid "Admin Tools"
 msgstr ""
 
@@ -1830,28 +1451,17 @@ msgstr ""
 msgid "Enter at least one value."
 msgstr ""
 
-#: src/olympia/amo/helpers.py:162
-#: src/olympia/amo/templates/amo/site_nav.html:59
-#: src/olympia/bandwagon/templates/bandwagon/add.html:9
-#: src/olympia/bandwagon/templates/bandwagon/collection_detail.html:15
-#: src/olympia/bandwagon/templates/bandwagon/delete.html:9
-#: src/olympia/bandwagon/templates/bandwagon/edit.html:15
-#: src/olympia/bandwagon/templates/bandwagon/user_listing.html:18
-#: src/olympia/bandwagon/templates/bandwagon/user_listing.html:21
-#: src/olympia/bandwagon/templates/bandwagon/impala/collection_listing.html:12
-#: src/olympia/bandwagon/templates/bandwagon/impala/collection_listing.html:20
-#: src/olympia/bandwagon/templates/bandwagon/impala/collection_listing.html:24
-#: src/olympia/bandwagon/templates/bandwagon/impala/collection_sidebar.html:3
-#: src/olympia/bandwagon/templates/bandwagon/includes/collection_sidebar.html:2
-#: src/olympia/bandwagon/templates/bandwagon/mobile/collection_listing.html:3
-#: src/olympia/stats/templates/stats/stats.html:77
-#: src/olympia/templates/menu_links.html:12
+#: src/olympia/amo/helpers.py:162 src/olympia/amo/templates/amo/site_nav.html:59 src/olympia/bandwagon/templates/bandwagon/add.html:9
+#: src/olympia/bandwagon/templates/bandwagon/collection_detail.html:15 src/olympia/bandwagon/templates/bandwagon/delete.html:9 src/olympia/bandwagon/templates/bandwagon/edit.html:15
+#: src/olympia/bandwagon/templates/bandwagon/user_listing.html:18 src/olympia/bandwagon/templates/bandwagon/user_listing.html:21
+#: src/olympia/bandwagon/templates/bandwagon/impala/collection_listing.html:12 src/olympia/bandwagon/templates/bandwagon/impala/collection_listing.html:20
+#: src/olympia/bandwagon/templates/bandwagon/impala/collection_listing.html:24 src/olympia/bandwagon/templates/bandwagon/impala/collection_sidebar.html:3
+#: src/olympia/bandwagon/templates/bandwagon/includes/collection_sidebar.html:2 src/olympia/bandwagon/templates/bandwagon/mobile/collection_listing.html:3
+#: src/olympia/stats/templates/stats/stats.html:33 src/olympia/templates/menu_links.html:12
 msgid "Collections"
 msgstr ""
 
-#: src/olympia/amo/helpers.py:171
-#: src/olympia/amo/templates/amo/site_nav.html:83
-#: src/olympia/browse/templates/browse/language_tools.html:3
+#: src/olympia/amo/helpers.py:171 src/olympia/amo/templates/amo/site_nav.html:83 src/olympia/browse/templates/browse/language_tools.html:3
 msgid "Dictionaries & Language Packs"
 msgstr ""
 
@@ -2003,11 +1613,8 @@ msgstr ""
 msgid "Comment on {addon} {version}."
 msgstr ""
 
-#: src/olympia/amo/log.py:236
-#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:19
-#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:47
-#: src/olympia/editors/helpers.py:580
-#: src/olympia/editors/templates/editors/themes/history_table.html:11
+#: src/olympia/amo/log.py:236 src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:17 src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:45
+#: src/olympia/editors/helpers.py:584 src/olympia/editors/templates/editors/themes/history_table.html:11
 msgid "Comment"
 msgstr ""
 
@@ -2265,10 +1872,7 @@ msgstr ""
 msgid "{addon} unlisted."
 msgstr ""
 
-#: src/olympia/amo/log.py:592 src/olympia/amo/log.py:598
-#: src/olympia/amo/log.py:612 src/olympia/amo/log.py:618
-#: src/olympia/amo/log.py:624 src/olympia/amo/log.py:630
-#: src/olympia/amo/log.py:636
+#: src/olympia/amo/log.py:592 src/olympia/amo/log.py:598 src/olympia/amo/log.py:612 src/olympia/amo/log.py:618 src/olympia/amo/log.py:624 src/olympia/amo/log.py:630 src/olympia/amo/log.py:636
 msgid "{file} was signed."
 msgstr ""
 
@@ -2282,15 +1886,11 @@ msgid "Not allowed"
 msgstr ""
 
 #: src/olympia/amo/templates/amo/403.html:7
-msgid ""
-"<h1>Oops! Not allowed.</h1> <p>You tried to do something that you weren't "
-"allowed to.</p>"
+msgid "<h1>Oops! Not allowed.</h1> <p>You tried to do something that you weren't allowed to.</p>"
 msgstr ""
 
 #: src/olympia/amo/templates/amo/403.html:12
-msgid ""
-"<p>Try going back to the previous page, refreshing and then trying "
-"again.</p>"
+msgid "<p>Try going back to the previous page, refreshing and then trying again.</p>"
 msgstr ""
 
 #: src/olympia/amo/templates/amo/404.html:3
@@ -2300,20 +1900,12 @@ msgstr ""
 #: src/olympia/amo/templates/amo/404.html:6
 #, python-format
 msgid ""
-"<h1>We're sorry, but we can't find what you're looking for.</h1> <p> The "
-"page or file you requested wasn't found on our site. It's possible that you "
-"clicked a link that's out of date, or typed in the address incorrectly. </p>"
-" <ul> <li>If you typed in the address, please double check the "
-"spelling.</li> <li> If you followed a link from somewhere, please let us "
-"know at <a href=\"mailto:webmaster@mozilla.com\">webmaster@mozilla.com</a>. "
-"Tell us where you came from and what you were looking for, and we'll do our "
-"best to fix it. </li> </ul> <p>Or you can just jump over to some of the "
-"popular pages on our website.</p> <ul> <li>Are you interested in a <a "
-"href=\"%(rec)s\">list of featured add-ons</a>?</li> <li> Do you want to <a "
-"href=\"%(search)s\">search for add-ons</a>? You may go to the <a "
-"href=\"%(search)s\">search page</a> or just use the search field above. "
-"</li> <li> If you prefer to start over, just go to the <a href=\"%(home)s"
-"\">add-ons front page</a>. </li> </ul>"
+"<h1>We're sorry, but we can't find what you're looking for.</h1> <p> The page or file you requested wasn't found on our site. It's possible that you clicked a link that's out of date, or typed in "
+"the address incorrectly. </p> <ul> <li>If you typed in the address, please double check the spelling.</li> <li> If you followed a link from somewhere, please let us know at <a href=\"mailto:"
+"webmaster@mozilla.com\">webmaster@mozilla.com</a>. Tell us where you came from and what you were looking for, and we'll do our best to fix it. </li> </ul> <p>Or you can just jump over to some of "
+"the popular pages on our website.</p> <ul> <li>Are you interested in a <a href=\"%(rec)s\">list of featured add-ons</a>?</li> <li> Do you want to <a href=\"%(search)s\">search for add-ons</a>? You "
+"may go to the <a href=\"%(search)s\">search page</a> or just use the search field above. </li> <li> If you prefer to start over, just go to the <a href=\"%(home)s\">add-ons front page</a>. </li> </"
+"ul>"
 msgstr ""
 
 #: src/olympia/amo/templates/amo/500.html:3
@@ -2322,72 +1914,48 @@ msgstr ""
 
 #: src/olympia/amo/templates/amo/500.html:6
 #, python-format
-msgid ""
-"<h1>Oops!  We had an error.</h1> <p>We'll get to fixing that soon.</p> <p> "
-"You can try refreshing the page, or head back to the <a href=\"%(home)s"
-"\">Add-ons homepage</a>. </p>"
+msgid "<h1>Oops!  We had an error.</h1> <p>We'll get to fixing that soon.</p> <p> You can try refreshing the page, or head back to the <a href=\"%(home)s\">Add-ons homepage</a>. </p>"
 msgstr ""
 
 #: src/olympia/amo/templates/amo/license_link.html:10
 msgid "Some rights reserved"
 msgstr ""
 
-#: src/olympia/amo/templates/amo/no_results.html:1
-#: src/olympia/editors/templates/editors/includes/search_results_themes.html:26
+#: src/olympia/amo/templates/amo/no_results.html:1 src/olympia/editors/templates/editors/includes/search_results_themes.html:26
 msgid "No results found"
 msgstr ""
 
 #. abbreviation of 'previous'
-#: src/olympia/amo/templates/amo/paginator.html:6
-#: src/olympia/amo/templates/amo/mobile/paginator.html:4
-#: src/olympia/amo/templates/amo/mobile/paginator.html:6
-#: src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:49
-#: src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:63
-#: src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:76
-#: src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:89
+#: src/olympia/amo/templates/amo/paginator.html:6 src/olympia/amo/templates/amo/mobile/paginator.html:4 src/olympia/amo/templates/amo/mobile/paginator.html:6
+#: src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:49 src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:63
+#: src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:76 src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:89
 #: src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:102
 msgid "Prev"
 msgstr ""
 
-#: src/olympia/amo/templates/amo/paginator.html:26
-#: src/olympia/amo/templates/amo/impala/paginator.html:26
-#: src/olympia/amo/templates/amo/mobile/impala_paginator.html:16
-#: src/olympia/amo/templates/amo/mobile/paginator.html:14
-#: src/olympia/amo/templates/amo/mobile/paginator.html:16
-#: src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:51
-#: src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:65
-#: src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:78
-#: src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:91
-#: src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:104
-#: src/olympia/discovery/templates/discovery/pane.html:45
-#: src/olympia/discovery/templates/discovery/addons/detail.html:39
-#: src/olympia/stats/templates/stats/stats.html:167
+#: src/olympia/amo/templates/amo/paginator.html:26 src/olympia/amo/templates/amo/impala/paginator.html:26 src/olympia/amo/templates/amo/mobile/impala_paginator.html:16
+#: src/olympia/amo/templates/amo/mobile/paginator.html:14 src/olympia/amo/templates/amo/mobile/paginator.html:16 src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:51
+#: src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:65 src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:78
+#: src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:91 src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:104
+#: src/olympia/discovery/templates/discovery/pane.html:45 src/olympia/discovery/templates/discovery/addons/detail.html:39 src/olympia/stats/templates/stats/stats.html:169
 msgid "Next"
 msgstr ""
 
-#: src/olympia/amo/templates/amo/paginator.html:32
-#: src/olympia/editors/templates/editors/includes/paginator_history.html:11
+#: src/olympia/amo/templates/amo/paginator.html:32 src/olympia/editors/templates/editors/includes/paginator_history.html:11
 #, python-format
-msgid ""
-"Results <strong>%(begin)s</strong>&ndash;<strong>%(end)s</strong> of "
-"<strong>%(count)s</strong>"
+msgid "Results <strong>%(begin)s</strong>&ndash;<strong>%(end)s</strong> of <strong>%(count)s</strong>"
 msgstr ""
 
-#: src/olympia/amo/templates/amo/read-only.html:3
-#: src/olympia/amo/templates/amo/read-only.html:7
+#: src/olympia/amo/templates/amo/read-only.html:3 src/olympia/amo/templates/amo/read-only.html:7
 msgid "Maintenance in progress"
 msgstr ""
 
 #: src/olympia/amo/templates/amo/read-only.html:9
-msgid ""
-"This feature is temporarily disabled while we perform website maintenance. "
-"Please use your browser's Back button and try again a little later."
+msgid "This feature is temporarily disabled while we perform website maintenance. Please use your browser's Back button and try again a little later."
 msgstr ""
 
 #: src/olympia/amo/templates/amo/read-only.html:14
-msgid ""
-"Some features on this page are temporarily disabled while we perform website"
-" maintenance. Please try again a little later."
+msgid "Some features on this page are temporarily disabled while we perform website maintenance. Please try again a little later."
 msgstr ""
 
 #: src/olympia/amo/templates/amo/recaptcha.html:4
@@ -2396,20 +1964,12 @@ msgstr ""
 
 #: src/olympia/amo/templates/amo/recaptcha.html:8
 msgid ""
-"<p> Please enter <strong>all the words</strong> below, <strong>separated by "
-"a space if necessary</strong>. </p> <p> If this is hard to read, you can <a "
-"href=\"#\" id=\"recaptcha_different\">try different words</a> or <a "
-"href=\"#\" id=\"recaptcha_audio\">try a different type of challenge</a> "
-"instead. </p>"
+"<p> Please enter <strong>all the words</strong> below, <strong>separated by a space if necessary</strong>. </p> <p> If this is hard to read, you can <a href=\"#\" id=\"recaptcha_different\">try "
+"different words</a> or <a href=\"#\" id=\"recaptcha_audio\">try a different type of challenge</a> instead. </p>"
 msgstr ""
 
-#: src/olympia/amo/templates/amo/side_nav.html:4
-#: src/olympia/amo/templates/amo/side_nav.html:12
-#: src/olympia/amo/templates/amo/site_nav.html:4
-#: src/olympia/amo/templates/amo/site_nav.html:26
-#: src/olympia/browse/views.py:56 src/olympia/browse/views.py:66
-#: src/olympia/browse/views.py:237 src/olympia/browse/views.py:282
-#: src/olympia/search/forms.py:86
+#: src/olympia/amo/templates/amo/side_nav.html:4 src/olympia/amo/templates/amo/side_nav.html:12 src/olympia/amo/templates/amo/site_nav.html:4 src/olympia/amo/templates/amo/site_nav.html:26
+#: src/olympia/browse/views.py:56 src/olympia/browse/views.py:66 src/olympia/browse/views.py:204 src/olympia/browse/views.py:249 src/olympia/search/forms.py:86
 msgid "Top Rated"
 msgstr ""
 
@@ -2417,12 +1977,8 @@ msgstr ""
 msgid "Explore"
 msgstr ""
 
-#: src/olympia/amo/templates/amo/site_nav.html:23
-#: src/olympia/browse/feeds.py:65 src/olympia/browse/feeds.py:78
-#: src/olympia/browse/feeds.py:92 src/olympia/browse/feeds.py:100
-#: src/olympia/browse/templates/browse/base_listing.html:7
-#: src/olympia/browse/templates/browse/creatured.html:10
-#: src/olympia/browse/templates/browse/impala/base_listing.html:37
+#: src/olympia/amo/templates/amo/site_nav.html:23 src/olympia/browse/feeds.py:65 src/olympia/browse/feeds.py:78 src/olympia/browse/feeds.py:92 src/olympia/browse/feeds.py:100
+#: src/olympia/browse/templates/browse/base_listing.html:7 src/olympia/browse/templates/browse/creatured.html:10 src/olympia/browse/templates/browse/impala/base_listing.html:37
 #: src/olympia/constants/base.py:173 src/olympia/templates/menu_links.html:8
 msgid "Extensions"
 msgstr ""
@@ -2431,28 +1987,22 @@ msgstr ""
 msgid "Want more customization? Try <b>Complete Themes</b>"
 msgstr ""
 
-#: src/olympia/amo/templates/amo/site_nav.html:54
-#: src/olympia/bandwagon/views.py:96
+#: src/olympia/amo/templates/amo/site_nav.html:54 src/olympia/bandwagon/views.py:96
 msgid "Most Followers"
 msgstr ""
 
-#: src/olympia/amo/templates/amo/site_nav.html:66
-#: src/olympia/bandwagon/templates/bandwagon/impala/collection_sidebar.html:16
+#: src/olympia/amo/templates/amo/site_nav.html:66 src/olympia/bandwagon/templates/bandwagon/impala/collection_sidebar.html:16
 #: src/olympia/bandwagon/templates/bandwagon/includes/collection_sidebar.html:18
 msgid "Collections I've Made"
 msgstr ""
 
-#: src/olympia/amo/templates/amo/site_nav.html:68
-#: src/olympia/bandwagon/templates/bandwagon/user_listing.html:4
-#: src/olympia/bandwagon/templates/bandwagon/impala/collection_sidebar.html:13
+#: src/olympia/amo/templates/amo/site_nav.html:68 src/olympia/bandwagon/templates/bandwagon/user_listing.html:4 src/olympia/bandwagon/templates/bandwagon/impala/collection_sidebar.html:13
 #: src/olympia/bandwagon/templates/bandwagon/includes/collection_sidebar.html:15
 msgid "Collections I'm Following"
 msgstr ""
 
-#: src/olympia/amo/templates/amo/site_nav.html:71
-#: src/olympia/bandwagon/templates/bandwagon/impala/collection_sidebar.html:18
-#: src/olympia/bandwagon/templates/bandwagon/includes/collection_sidebar.html:20
-#: src/olympia/users/models.py:521
+#: src/olympia/amo/templates/amo/site_nav.html:71 src/olympia/bandwagon/templates/bandwagon/impala/collection_sidebar.html:18
+#: src/olympia/bandwagon/templates/bandwagon/includes/collection_sidebar.html:20 src/olympia/users/models.py:521
 msgid "My Favorite Add-ons"
 msgstr ""
 
@@ -2464,32 +2014,23 @@ msgstr ""
 msgid "Add-ons for Mobile"
 msgstr ""
 
-#: src/olympia/amo/templates/amo/site_nav.html:84
-#: src/olympia/browse/feeds.py:207
-#: src/olympia/browse/templates/browse/search_tools.html:3
-#: src/olympia/constants/base.py:176 src/olympia/templates/menu_links.html:10
+#: src/olympia/amo/templates/amo/site_nav.html:84 src/olympia/browse/feeds.py:207 src/olympia/browse/templates/browse/search_tools.html:3 src/olympia/constants/base.py:176
+#: src/olympia/templates/menu_links.html:10
 msgid "Search Tools"
 msgstr ""
 
 #. This is a page range (e.g., Page 1 of 50).
-#: src/olympia/amo/templates/amo/impala/paginator.html:5
-#: src/olympia/amo/templates/amo/mobile/impala_paginator.html:26
+#: src/olympia/amo/templates/amo/impala/paginator.html:5 src/olympia/amo/templates/amo/mobile/impala_paginator.html:26
 #, python-format
-msgid ""
-"Page <a href=\"%(current_pg_url)s\">%(current_pg)s</a> of <a "
-"href=\"%(last_pg_url)s\">%(last_pg)s</a>"
+msgid "Page <a href=\"%(current_pg_url)s\">%(current_pg)s</a> of <a href=\"%(last_pg_url)s\">%(last_pg)s</a>"
 msgstr ""
 
-#: src/olympia/amo/templates/amo/impala/paginator.html:16
-#: src/olympia/amo/templates/amo/mobile/impala_paginator.html:6
+#: src/olympia/amo/templates/amo/impala/paginator.html:16 src/olympia/amo/templates/amo/mobile/impala_paginator.html:6
 msgid "Jump to first page"
 msgstr ""
 
-#: src/olympia/amo/templates/amo/impala/paginator.html:22
-#: src/olympia/amo/templates/amo/mobile/impala_paginator.html:12
-#: src/olympia/discovery/templates/discovery/pane.html:44
-#: src/olympia/discovery/templates/discovery/addons/detail.html:38
-#: src/olympia/stats/templates/stats/stats.html:164
+#: src/olympia/amo/templates/amo/impala/paginator.html:22 src/olympia/amo/templates/amo/mobile/impala_paginator.html:12 src/olympia/discovery/templates/discovery/pane.html:44
+#: src/olympia/discovery/templates/discovery/addons/detail.html:38 src/olympia/stats/templates/stats/stats.html:166
 msgid "Previous"
 msgstr ""
 
@@ -2499,11 +2040,9 @@ msgstr ""
 
 #. First and second arguments are the result range (e.g., 1-20);
 #. third argument is the number of total results (e.g., 1,000).
-#. First and second arguments are the result range (e.g., 1-20);
-#. third
+#. First and second arguments are the result range (e.g., 1-20);              third
 #. argument is the number of total results (e.g., 1,000).
-#: src/olympia/amo/templates/amo/impala/paginator.html:36
-#: src/olympia/amo/templates/amo/mobile/impala_paginator.html:38
+#: src/olympia/amo/templates/amo/impala/paginator.html:36 src/olympia/amo/templates/amo/mobile/impala_paginator.html:38
 #, python-format
 msgid "Showing <b>%(begin)s</b>&ndash;<b>%(end)s</b> of <b>%(count)s</b>"
 msgstr ""
@@ -2516,16 +2055,12 @@ msgstr[1] ""
 msgstr[2] ""
 msgstr[3] ""
 
-#: src/olympia/amo/tests/test_messages.py:56
-#: src/olympia/amo/tests/test_messages.py:57 src/olympia/reviews/forms.py:25
-#: src/olympia/reviews/forms.py:50
-#: src/olympia/reviews/templates/reviews/add.html:56
+#: src/olympia/amo/tests/test_messages.py:56 src/olympia/amo/tests/test_messages.py:57 src/olympia/reviews/forms.py:25 src/olympia/reviews/forms.py:50 src/olympia/reviews/templates/reviews/add.html:56
 #: src/olympia/reviews/templates/reviews/reply.html:30
 msgid "Title"
 msgstr ""
 
-#: src/olympia/amo/tests/test_messages.py:56
-#: src/olympia/amo/tests/test_messages.py:57
+#: src/olympia/amo/tests/test_messages.py:56 src/olympia/amo/tests/test_messages.py:57
 msgid "Body"
 msgstr ""
 
@@ -2554,8 +2089,7 @@ msgid "Invalid Authorization header. No credentials provided."
 msgstr ""
 
 #: src/olympia/api/authentication.py:133
-msgid ""
-"Invalid Authorization header. Credentials string should not contain spaces."
+msgid "Invalid Authorization header. Credentials string should not contain spaces."
 msgstr ""
 
 #: src/olympia/api/fields.py:29
@@ -2566,8 +2100,7 @@ msgstr ""
 msgid "The language code {lang_code} is invalid."
 msgstr ""
 
-#: src/olympia/applications/views.py:39
-#: src/olympia/applications/templates/applications/appversions.html:3
+#: src/olympia/applications/views.py:39 src/olympia/applications/templates/applications/appversions.html:3
 msgid "Application Versions"
 msgstr ""
 
@@ -2580,20 +2113,15 @@ msgid "Valid Application Versions"
 msgstr ""
 
 #: src/olympia/applications/templates/applications/appversions.html:12
-msgid ""
-"Add-ons submitted to Mozilla Add-ons must have a manifest file with at least"
-" one of the below applications supported. Only the versions listed below are"
-" allowed for these applications."
+msgid "Add-ons submitted to Mozilla Add-ons must have a manifest file with at least one of the below applications supported. Only the versions listed below are allowed for these applications."
 msgstr ""
 
-#: src/olympia/applications/templates/applications/appversions.html:25
-#: src/olympia/editors/helpers.py:361
+#: src/olympia/applications/templates/applications/appversions.html:25 src/olympia/editors/helpers.py:361
 msgid "GUID"
 msgstr ""
 
 #. {0} is an add-on name.
-#: src/olympia/applications/templates/applications/appversions.html:26
-#: src/olympia/versions/templates/versions/version_list.html:23
+#: src/olympia/applications/templates/applications/appversions.html:26 src/olympia/versions/templates/versions/version_list.html:23
 msgid "Versions"
 msgstr ""
 
@@ -2603,10 +2131,7 @@ msgstr ""
 
 #: src/olympia/applications/templates/applications/appversions.html:31
 #, python-format
-msgid ""
-"If your supported application does not require a manifest file, you still "
-"must include one with the required properties as specified <a "
-"href=\"%(url)s\">here</a>."
+msgid "If your supported application does not require a manifest file, you still must include one with the required properties as specified <a href=\"%(url)s\">here</a>."
 msgstr ""
 
 #. L10n: {0} is 'Add-ons for <app>'.
@@ -2615,10 +2140,8 @@ msgstr ""
 msgid "Collections :: %s"
 msgstr ""
 
-#: src/olympia/bandwagon/feeds.py:50
-#: src/olympia/bandwagon/templates/bandwagon/collection_detail.html:137
-msgid ""
-"Collections are groups of related add-ons that anyone can create and share."
+#: src/olympia/bandwagon/feeds.py:50 src/olympia/bandwagon/templates/bandwagon/collection_detail.html:137
+msgid "Collections are groups of related add-ons that anyone can create and share."
 msgstr ""
 
 #. L10n: {0} is a collection name, {1} is 'Add-ons for <app>'.
@@ -2670,12 +2193,11 @@ msgstr ""
 msgid "This url is already in use by another collection"
 msgstr ""
 
-#: src/olympia/bandwagon/forms.py:197 src/olympia/devhub/views.py:1053
+#: src/olympia/bandwagon/forms.py:197 src/olympia/devhub/views.py:1049
 msgid "Icons must be either PNG or JPG."
 msgstr ""
 
-#: src/olympia/bandwagon/forms.py:202 src/olympia/devhub/views.py:1071
-#: src/olympia/users/forms.py:476
+#: src/olympia/bandwagon/forms.py:202 src/olympia/devhub/views.py:1067 src/olympia/users/forms.py:476
 #, python-format
 msgid "Please use images smaller than %dMB."
 msgstr ""
@@ -2696,8 +2218,7 @@ msgstr ""
 msgid "Log in to vote for this collection"
 msgstr ""
 
-#: src/olympia/bandwagon/helpers.py:123
-#: src/olympia/bandwagon/templates/bandwagon/favorites_widget.html:2
+#: src/olympia/bandwagon/helpers.py:123 src/olympia/bandwagon/templates/bandwagon/favorites_widget.html:2
 msgid "Add to favorites"
 msgstr ""
 
@@ -2705,20 +2226,13 @@ msgstr ""
 msgid "Favorite"
 msgstr ""
 
-#: src/olympia/bandwagon/helpers.py:124
-#: src/olympia/bandwagon/templates/bandwagon/favorites_widget.html:2
+#: src/olympia/bandwagon/helpers.py:124 src/olympia/bandwagon/templates/bandwagon/favorites_widget.html:2
 msgid "Remove from favorites"
 msgstr ""
 
-#: src/olympia/bandwagon/views.py:98 src/olympia/bandwagon/views.py:191
-#: src/olympia/browse/views.py:58 src/olympia/browse/views.py:69
-#: src/olympia/browse/views.py:458 src/olympia/devhub/views.py:74
-#: src/olympia/devhub/views.py:82
-#: src/olympia/devhub/templates/devhub/addons/edit/basic.html:20
-#: src/olympia/editors/templates/editors/leaderboard.html:24
-#: src/olympia/editors/templates/editors/themes/queue_list.html:48
-#: src/olympia/search/forms.py:17 src/olympia/search/forms.py:89
-#: src/olympia/users/templates/users/vcard.html:5
+#: src/olympia/bandwagon/views.py:98 src/olympia/bandwagon/views.py:191 src/olympia/browse/views.py:58 src/olympia/browse/views.py:69 src/olympia/browse/views.py:425 src/olympia/devhub/views.py:72
+#: src/olympia/devhub/views.py:80 src/olympia/devhub/templates/devhub/addons/edit/basic.html:20 src/olympia/editors/templates/editors/leaderboard.html:24
+#: src/olympia/editors/templates/editors/themes/queue_list.html:48 src/olympia/search/forms.py:17 src/olympia/search/forms.py:89 src/olympia/users/templates/users/vcard.html:5
 msgid "Name"
 msgstr ""
 
@@ -2726,8 +2240,7 @@ msgstr ""
 msgid "Recently Popular"
 msgstr ""
 
-#: src/olympia/bandwagon/views.py:189
-#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:18
+#: src/olympia/bandwagon/views.py:189 src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:16
 msgid "Added"
 msgstr ""
 
@@ -2741,9 +2254,7 @@ msgstr ""
 
 #: src/olympia/bandwagon/views.py:316
 #, python-format
-msgid ""
-"Your new collection is shown below. You can <a href=\"%(url)s\">edit "
-"additional settings</a> if you'd like."
+msgid "Your new collection is shown below. You can <a href=\"%(url)s\">edit additional settings</a> if you'd like."
 msgstr ""
 
 #: src/olympia/bandwagon/views.py:322
@@ -2759,28 +2270,20 @@ msgstr ""
 msgid "Icon Deleted"
 msgstr ""
 
-#: src/olympia/bandwagon/templates/bandwagon/add.html:3
-#: src/olympia/bandwagon/templates/bandwagon/add.html:11
-#: src/olympia/bandwagon/templates/bandwagon/includes/collection_sidebar.html:26
+#: src/olympia/bandwagon/templates/bandwagon/add.html:3 src/olympia/bandwagon/templates/bandwagon/add.html:11 src/olympia/bandwagon/templates/bandwagon/includes/collection_sidebar.html:26
 msgid "Create a New Collection"
 msgstr ""
 
-#: src/olympia/bandwagon/templates/bandwagon/add.html:9
-#: src/olympia/devhub/templates/devhub/personas/submit.html:14
+#: src/olympia/bandwagon/templates/bandwagon/add.html:9 src/olympia/devhub/templates/devhub/personas/submit.html:14
 msgid "Create"
 msgstr ""
 
-#: src/olympia/bandwagon/templates/bandwagon/add.html:24
-#: src/olympia/bandwagon/templates/bandwagon/ajax_new.html:28
+#: src/olympia/bandwagon/templates/bandwagon/add.html:24 src/olympia/bandwagon/templates/bandwagon/ajax_new.html:28
 #, python-format
-msgid ""
-"As noted in our <a href=\"%(legal)s\">Legal Notices</a>, individual "
-"collection arrangements are governed by the Creative Commons Attribution "
-"Share-Alike License"
+msgid "As noted in our <a href=\"%(legal)s\">Legal Notices</a>, individual collection arrangements are governed by the Creative Commons Attribution Share-Alike License"
 msgstr ""
 
-#: src/olympia/bandwagon/templates/bandwagon/add.html:33
-#: src/olympia/bandwagon/templates/bandwagon/ajax_new.html:38
+#: src/olympia/bandwagon/templates/bandwagon/add.html:33 src/olympia/bandwagon/templates/bandwagon/ajax_new.html:38
 msgid "Create Collection"
 msgstr ""
 
@@ -2796,8 +2299,7 @@ msgstr ""
 msgid "Start a New Collection"
 msgstr ""
 
-#: src/olympia/bandwagon/templates/bandwagon/ajax_new.html:6
-#: src/olympia/bandwagon/templates/bandwagon/includes/addedit.html:7
+#: src/olympia/bandwagon/templates/bandwagon/ajax_new.html:6 src/olympia/bandwagon/templates/bandwagon/includes/addedit.html:7
 msgid "Name:"
 msgstr ""
 
@@ -2810,15 +2312,11 @@ msgstr ""
 msgid "To rate collections, you must have an add-ons account."
 msgstr ""
 
-#: src/olympia/bandwagon/templates/bandwagon/barometer.html:18
-#: src/olympia/templates/base.html:145
-#: src/olympia/templates/impala/base.html:198
+#: src/olympia/bandwagon/templates/bandwagon/barometer.html:18 src/olympia/templates/base.html:145 src/olympia/templates/impala/base.html:198
 msgid "Create an Add-ons Account"
 msgstr ""
 
-#: src/olympia/bandwagon/templates/bandwagon/barometer.html:21
-#: src/olympia/templates/base.html:148
-#: src/olympia/templates/impala/base.html:201
+#: src/olympia/bandwagon/templates/bandwagon/barometer.html:21 src/olympia/templates/base.html:148 src/olympia/templates/impala/base.html:201
 #, python-format
 msgid "or <a href=\"%(login)s\">log in to your current account</a>"
 msgstr ""
@@ -2831,8 +2329,7 @@ msgstr ""
 msgid "private"
 msgstr ""
 
-#: src/olympia/bandwagon/templates/bandwagon/collection_detail.html:45
-#: src/olympia/bandwagon/templates/bandwagon/mobile/listing_items.html:9
+#: src/olympia/bandwagon/templates/bandwagon/collection_detail.html:45 src/olympia/bandwagon/templates/bandwagon/mobile/listing_items.html:9
 #, python-format
 msgid "<span>%(num)s</span> follower"
 msgid_plural "<span>%(num)s</span> followers"
@@ -2869,8 +2366,7 @@ msgstr ""
 msgid "Edit Collection"
 msgstr ""
 
-#: src/olympia/bandwagon/templates/bandwagon/collection_detail.html:88
-#: src/olympia/bandwagon/templates/bandwagon/includes/delete.html:3
+#: src/olympia/bandwagon/templates/bandwagon/collection_detail.html:88 src/olympia/bandwagon/templates/bandwagon/includes/delete.html:3
 msgid "Delete Collection"
 msgstr ""
 
@@ -2892,11 +2388,8 @@ msgstr[1] ""
 msgstr[2] ""
 msgstr[3] ""
 
-#: src/olympia/bandwagon/templates/bandwagon/collection_detail.html:125
-#: src/olympia/compat/templates/compat/reporter_detail.html:29
-#: src/olympia/files/templates/files/viewer.html:29
-#: src/olympia/templates/amo_footer.html:17
-#: src/olympia/templates/includes/lang_switcher.html:10
+#: src/olympia/bandwagon/templates/bandwagon/collection_detail.html:125 src/olympia/compat/templates/compat/reporter_detail.html:29 src/olympia/files/templates/files/viewer.html:29
+#: src/olympia/templates/amo_footer.html:17 src/olympia/templates/includes/lang_switcher.html:10
 msgid "Go"
 msgstr ""
 
@@ -2922,18 +2415,14 @@ msgstr ""
 
 #: src/olympia/bandwagon/templates/bandwagon/collection_detail.html:179
 msgid ""
-"Add-ons that you mark as favorites using the <b>Add to Favorites</b> feature"
-" appear below. This collection is currently <b>public</b>, which means "
-"everyone can see it. If you would like to hide it from public view, click "
-"the button below to make it private."
+"Add-ons that you mark as favorites using the <b>Add to Favorites</b> feature appear below. This collection is currently <b>public</b>, which means everyone can see it. If you would like to hide it "
+"from public view, click the button below to make it private."
 msgstr ""
 
 #: src/olympia/bandwagon/templates/bandwagon/collection_detail.html:186
 msgid ""
-"Add-ons that you mark as favorites using the <b>Add to Favorites</b> feature"
-" appear below. This collection is currently <b>private</b>, which means only"
-" you can see it.  If you would like everyone to be able to see your "
-"favorites, click the button below to make it public."
+"Add-ons that you mark as favorites using the <b>Add to Favorites</b> feature appear below. This collection is currently <b>private</b>, which means only you can see it.  If you would like everyone "
+"to be able to see your favorites, click the button below to make it public."
 msgstr ""
 
 #: src/olympia/bandwagon/templates/bandwagon/collection_detail.html:196
@@ -2958,13 +2447,11 @@ msgstr[1] ""
 msgstr[2] ""
 msgstr[3] ""
 
-#. People "follow" collections to get notified of updates.
-#. Like
+#. People "follow" collections to get notified of updates.                    Like
 #. Twitter followers.
 #. People "follow" collections to get notified of updates.
 #. Like Twitter followers.
-#: src/olympia/bandwagon/templates/bandwagon/collection_listing_items.html:10
-#: src/olympia/bandwagon/templates/bandwagon/impala/collection_listing_items.html:18
+#: src/olympia/bandwagon/templates/bandwagon/collection_listing_items.html:10 src/olympia/bandwagon/templates/bandwagon/impala/collection_listing_items.html:18
 #, python-format
 msgid "%(num)s weekly follower"
 msgid_plural "%(num)s weekly followers"
@@ -2973,8 +2460,7 @@ msgstr[1] ""
 msgstr[2] ""
 msgstr[3] ""
 
-#. People "follow" collections to get notified of updates.
-#. Like
+#. People "follow" collections to get notified of updates.                    Like
 #. Twitter followers.
 #: src/olympia/bandwagon/templates/bandwagon/collection_listing_items.html:18
 #, python-format
@@ -2985,13 +2471,11 @@ msgstr[1] ""
 msgstr[2] ""
 msgstr[3] ""
 
-#. People "follow" collections to get notified of updates.
-#. Like
+#. People "follow" collections to get notified of updates.                    Like
 #. Twitter followers.
 #. People "follow" collections to get notified of updates.
 #. Like Twitter followers.
-#: src/olympia/bandwagon/templates/bandwagon/collection_listing_items.html:26
-#: src/olympia/bandwagon/templates/bandwagon/impala/collection_listing_items.html:26
+#: src/olympia/bandwagon/templates/bandwagon/collection_listing_items.html:26 src/olympia/bandwagon/templates/bandwagon/impala/collection_listing_items.html:26
 #, python-format
 msgid "%(num)s follower"
 msgid_plural "%(num)s followers"
@@ -3000,20 +2484,17 @@ msgstr[1] ""
 msgstr[2] ""
 msgstr[3] ""
 
-#: src/olympia/bandwagon/templates/bandwagon/collection_listing_items.html:56
-#: src/olympia/bandwagon/templates/bandwagon/impala/collection_listing_items.html:9
+#: src/olympia/bandwagon/templates/bandwagon/collection_listing_items.html:56 src/olympia/bandwagon/templates/bandwagon/impala/collection_listing_items.html:9
 #: src/olympia/devhub/templates/devhub/personas/edit.html:27
 msgid "by {0}"
 msgstr ""
 
-#: src/olympia/bandwagon/templates/bandwagon/collection_widgets.html:5
-#: src/olympia/bandwagon/templates/bandwagon/collection_widgets.html:7
+#: src/olympia/bandwagon/templates/bandwagon/collection_widgets.html:5 src/olympia/bandwagon/templates/bandwagon/collection_widgets.html:7
 #: src/olympia/bandwagon/templates/bandwagon/impala/collection_listing_items.html:53
 msgid "Stop Following"
 msgstr ""
 
-#: src/olympia/bandwagon/templates/bandwagon/collection_widgets.html:6
-#: src/olympia/bandwagon/templates/bandwagon/collection_widgets.html:7
+#: src/olympia/bandwagon/templates/bandwagon/collection_widgets.html:6 src/olympia/bandwagon/templates/bandwagon/collection_widgets.html:7
 #: src/olympia/bandwagon/templates/bandwagon/impala/collection_listing_items.html:53
 msgid "Follow this Collection"
 msgstr ""
@@ -3023,16 +2504,12 @@ msgid "Edit this Collection"
 msgstr ""
 
 #. %s is the name of the collection.
-#: src/olympia/bandwagon/templates/bandwagon/delete.html:4
-#: src/olympia/bandwagon/templates/bandwagon/delete.html:15
+#: src/olympia/bandwagon/templates/bandwagon/delete.html:4 src/olympia/bandwagon/templates/bandwagon/delete.html:15
 msgid "Delete {0}"
 msgstr ""
 
-#: src/olympia/bandwagon/templates/bandwagon/delete.html:13
-#: src/olympia/devhub/templates/devhub/addons/listing/item_actions.html:14
-#: src/olympia/devhub/templates/devhub/addons/listing/item_actions_theme.html:28
-#: src/olympia/devhub/templates/devhub/versions/list.html:131
-#: src/olympia/devhub/templates/devhub/versions/list.html:149
+#: src/olympia/bandwagon/templates/bandwagon/delete.html:13 src/olympia/devhub/templates/devhub/addons/listing/item_actions.html:14
+#: src/olympia/devhub/templates/devhub/addons/listing/item_actions_theme.html:28 src/olympia/devhub/templates/devhub/versions/list.html:131 src/olympia/devhub/templates/devhub/versions/list.html:149
 #: src/olympia/devhub/templates/devhub/versions/list.html:166
 msgid "Delete"
 msgstr ""
@@ -3041,35 +2518,24 @@ msgstr ""
 msgid "Are you sure?"
 msgstr ""
 
-#: src/olympia/bandwagon/templates/bandwagon/delete.html:21
-#: src/olympia/devhub/templates/devhub/personas/edit.html:131
-#: src/olympia/devhub/templates/devhub/personas/edit.html:152
-#: src/olympia/devhub/templates/devhub/personas/edit.html:173
-#: src/olympia/devhub/templates/devhub/personas/submit.html:77
-#: src/olympia/devhub/templates/devhub/personas/submit.html:98
+#: src/olympia/bandwagon/templates/bandwagon/delete.html:21 src/olympia/devhub/templates/devhub/personas/edit.html:131 src/olympia/devhub/templates/devhub/personas/edit.html:152
+#: src/olympia/devhub/templates/devhub/personas/edit.html:173 src/olympia/devhub/templates/devhub/personas/submit.html:77 src/olympia/devhub/templates/devhub/personas/submit.html:98
 #: src/olympia/devhub/templates/devhub/personas/submit.html:119
 msgid "Yes"
 msgstr ""
 
-#: src/olympia/bandwagon/templates/bandwagon/delete.html:22
-#: src/olympia/devhub/templates/devhub/personas/edit.html:140
-#: src/olympia/devhub/templates/devhub/personas/edit.html:161
-#: src/olympia/devhub/templates/devhub/personas/edit.html:191
-#: src/olympia/devhub/templates/devhub/personas/submit.html:86
-#: src/olympia/devhub/templates/devhub/personas/submit.html:107
+#: src/olympia/bandwagon/templates/bandwagon/delete.html:22 src/olympia/devhub/templates/devhub/personas/edit.html:140 src/olympia/devhub/templates/devhub/personas/edit.html:161
+#: src/olympia/devhub/templates/devhub/personas/edit.html:191 src/olympia/devhub/templates/devhub/personas/submit.html:86 src/olympia/devhub/templates/devhub/personas/submit.html:107
 #: src/olympia/devhub/templates/devhub/personas/submit.html:137
 msgid "No"
 msgstr ""
 
 #. {0} is the name of the collection.
-#: src/olympia/bandwagon/templates/bandwagon/edit.html:5
-#: src/olympia/bandwagon/templates/bandwagon/edit.html:21
+#: src/olympia/bandwagon/templates/bandwagon/edit.html:5 src/olympia/bandwagon/templates/bandwagon/edit.html:21
 msgid "Edit {0}"
 msgstr ""
 
-#: src/olympia/bandwagon/templates/bandwagon/edit.html:29
-#: src/olympia/devhub/templates/devhub/addons/edit/details.html:20
-#: src/olympia/editors/templates/editors/themes/themes.html:62
+#: src/olympia/bandwagon/templates/bandwagon/edit.html:29 src/olympia/devhub/templates/devhub/addons/edit/details.html:20 src/olympia/editors/templates/editors/themes/themes.html:62
 msgid "Description"
 msgstr ""
 
@@ -3077,31 +2543,17 @@ msgstr ""
 msgid "Contributors & More"
 msgstr ""
 
-#: src/olympia/bandwagon/templates/bandwagon/edit.html:54
-#: src/olympia/bandwagon/templates/bandwagon/edit.html:67
-#: src/olympia/bandwagon/templates/bandwagon/edit.html:82
-#: src/olympia/devhub/templates/devhub/addons/ajax_compat_update.html:35
-#: src/olympia/devhub/templates/devhub/addons/owner.html:59
-#: src/olympia/devhub/templates/devhub/addons/profile.html:42
-#: src/olympia/devhub/templates/devhub/addons/edit/admin.html:101
-#: src/olympia/devhub/templates/devhub/addons/edit/basic.html:152
-#: src/olympia/devhub/templates/devhub/addons/edit/details.html:85
-#: src/olympia/devhub/templates/devhub/addons/edit/support.html:67
-#: src/olympia/devhub/templates/devhub/addons/edit/technical.html:166
-#: src/olympia/devhub/templates/devhub/addons/forms_shared/media.html:149
-#: src/olympia/devhub/templates/devhub/payments/voluntary.html:64
-#: src/olympia/devhub/templates/devhub/personas/edit.html:35
-#: src/olympia/devhub/templates/devhub/personas/edit.html:304
-#: src/olympia/devhub/templates/devhub/versions/edit.html:139
-#: src/olympia/translations/templates/translations/trans-menu.html:48
+#: src/olympia/bandwagon/templates/bandwagon/edit.html:54 src/olympia/bandwagon/templates/bandwagon/edit.html:67 src/olympia/bandwagon/templates/bandwagon/edit.html:82
+#: src/olympia/devhub/templates/devhub/addons/ajax_compat_update.html:35 src/olympia/devhub/templates/devhub/addons/owner.html:59 src/olympia/devhub/templates/devhub/addons/profile.html:42
+#: src/olympia/devhub/templates/devhub/addons/edit/admin.html:101 src/olympia/devhub/templates/devhub/addons/edit/basic.html:152 src/olympia/devhub/templates/devhub/addons/edit/details.html:85
+#: src/olympia/devhub/templates/devhub/addons/edit/support.html:67 src/olympia/devhub/templates/devhub/addons/edit/technical.html:166
+#: src/olympia/devhub/templates/devhub/addons/forms_shared/media.html:149 src/olympia/devhub/templates/devhub/payments/voluntary.html:64 src/olympia/devhub/templates/devhub/personas/edit.html:35
+#: src/olympia/devhub/templates/devhub/personas/edit.html:304 src/olympia/devhub/templates/devhub/versions/edit.html:139 src/olympia/translations/templates/translations/trans-menu.html:48
 msgid "Save Changes"
 msgstr ""
 
-#: src/olympia/bandwagon/templates/bandwagon/edit_contributors.html:9
-#: src/olympia/bandwagon/templates/bandwagon/edit_contributors.html:12
-#: src/olympia/bandwagon/templates/bandwagon/edit_contributors.html:17
-#: src/olympia/bandwagon/templates/bandwagon/edit_contributors.html:58
-#: src/olympia/constants/base.py:134
+#: src/olympia/bandwagon/templates/bandwagon/edit_contributors.html:9 src/olympia/bandwagon/templates/bandwagon/edit_contributors.html:12
+#: src/olympia/bandwagon/templates/bandwagon/edit_contributors.html:17 src/olympia/bandwagon/templates/bandwagon/edit_contributors.html:58 src/olympia/constants/base.py:134
 msgid "Owner"
 msgstr ""
 
@@ -3113,10 +2565,8 @@ msgstr ""
 msgid "Remove this user as a contributor"
 msgstr ""
 
-#: src/olympia/bandwagon/templates/bandwagon/edit_contributors.html:18
-#: src/olympia/bandwagon/templates/bandwagon/edit_contributors.html:43
-#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:20
-#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:48
+#: src/olympia/bandwagon/templates/bandwagon/edit_contributors.html:18 src/olympia/bandwagon/templates/bandwagon/edit_contributors.html:43
+#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:18 src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:46
 #: src/olympia/devhub/templates/devhub/addons/ajax_compat_update.html:19
 msgid "Remove"
 msgstr ""
@@ -3127,19 +2577,15 @@ msgstr ""
 
 #: src/olympia/bandwagon/templates/bandwagon/edit_contributors.html:26
 msgid ""
-"You can add multiple contributors to this collection.  A contributor can add"
-" and remove add-ons from this collection, but cannot change its name or "
-"description.  To add a contributor, enter their email in the box below. "
-"Contributors must have a Mozilla Add-ons account."
+"You can add multiple contributors to this collection.  A contributor can add and remove add-ons from this collection, but cannot change its name or description.  To add a contributor, enter their "
+"email in the box below. Contributors must have a Mozilla Add-ons account."
 msgstr ""
 
 #: src/olympia/bandwagon/templates/bandwagon/edit_contributors.html:40
 msgid "User"
 msgstr ""
 
-#: src/olympia/bandwagon/templates/bandwagon/edit_contributors.html:41
-#: src/olympia/devhub/templates/devhub/addons/edit/support.html:20
-#: src/olympia/users/templates/users/delete.html:49
+#: src/olympia/bandwagon/templates/bandwagon/edit_contributors.html:41 src/olympia/devhub/templates/devhub/addons/edit/support.html:20 src/olympia/users/templates/users/delete.html:49
 msgid "Email"
 msgstr ""
 
@@ -3164,25 +2610,14 @@ msgid "Admin Settings"
 msgstr ""
 
 #: src/olympia/bandwagon/templates/bandwagon/edit_contributors.html:76
-msgid ""
-"<b>Warning:</b> By changing the owner of this collection, you will no longer"
-" be able to edit it. You will only be able to add and remove add-ons from "
-"it."
+msgid "<b>Warning:</b> By changing the owner of this collection, you will no longer be able to edit it. You will only be able to add and remove add-ons from it."
 msgstr ""
 
-#: src/olympia/bandwagon/templates/bandwagon/edit_contributors.html:83
-#: src/olympia/devhub/templates/devhub/addons/forms_shared/media.html:157
-#: src/olympia/devhub/templates/devhub/addons/submit/describe.html:69
-#: src/olympia/devhub/templates/devhub/addons/submit/license.html:60
-#: src/olympia/devhub/templates/devhub/addons/submit/upload.html:64
-#: src/olympia/devhub/templates/devhub/payments/tier.html:17
-#: src/olympia/editors/templates/editors/themes/themes.html:111
-#: src/olympia/editors/templates/editors/themes/themes.html:128
-#: src/olympia/editors/templates/editors/themes/themes.html:134
-#: src/olympia/editors/templates/editors/themes/themes.html:141
-#: src/olympia/users/templates/users/fxa_migration_prompt_content.html:10
-#: src/olympia/users/templates/users/login_form.html:42
-#: src/olympia/users/templates/users/mobile/login.html:57
+#: src/olympia/bandwagon/templates/bandwagon/edit_contributors.html:83 src/olympia/devhub/templates/devhub/addons/forms_shared/media.html:157
+#: src/olympia/devhub/templates/devhub/addons/submit/describe.html:69 src/olympia/devhub/templates/devhub/addons/submit/license.html:60 src/olympia/devhub/templates/devhub/addons/submit/upload.html:70
+#: src/olympia/devhub/templates/devhub/payments/tier.html:17 src/olympia/editors/templates/editors/themes/themes.html:111 src/olympia/editors/templates/editors/themes/themes.html:128
+#: src/olympia/editors/templates/editors/themes/themes.html:134 src/olympia/editors/templates/editors/themes/themes.html:141 src/olympia/users/templates/users/fxa_migration_prompt_content.html:10
+#: src/olympia/users/templates/users/login_form.html:42 src/olympia/users/templates/users/mobile/login.html:57
 msgid "Continue"
 msgstr ""
 
@@ -3221,15 +2656,10 @@ msgstr ""
 
 #: src/olympia/bandwagon/templates/bandwagon/impala/collection_listing.html:28
 #, python-format
-msgid ""
-"Collections are groups of related add-ons that anyone can create and share. "
-"Explore collections created by other users or <a href=\"%(url)s\">create "
-"your own</a>."
+msgid "Collections are groups of related add-ons that anyone can create and share. Explore collections created by other users or <a href=\"%(url)s\">create your own</a>."
 msgstr ""
 
-#: src/olympia/bandwagon/templates/bandwagon/impala/collection_listing.html:37
-#: src/olympia/browse/templates/browse/extensions.html:13
-#: src/olympia/browse/templates/browse/themes.html:14
+#: src/olympia/bandwagon/templates/bandwagon/impala/collection_listing.html:37 src/olympia/browse/templates/browse/extensions.html:13 src/olympia/browse/templates/browse/themes.html:14
 msgid "Subscribe"
 msgstr ""
 
@@ -3237,17 +2667,13 @@ msgstr ""
 msgid "Following"
 msgstr ""
 
-#: src/olympia/bandwagon/templates/bandwagon/impala/collection_sidebar.html:22
-#: src/olympia/bandwagon/templates/bandwagon/impala/collection_sidebar.html:28
+#: src/olympia/bandwagon/templates/bandwagon/impala/collection_sidebar.html:22 src/olympia/bandwagon/templates/bandwagon/impala/collection_sidebar.html:28
 #: src/olympia/bandwagon/templates/bandwagon/includes/collection_sidebar.html:32
 msgid "Create a Collection"
 msgstr ""
 
-#: src/olympia/bandwagon/templates/bandwagon/impala/collection_sidebar.html:23
-#: src/olympia/bandwagon/templates/bandwagon/includes/collection_sidebar.html:27
-msgid ""
-"Collections make it easy to keep track of favorite add-ons and share your "
-"perfectly customized browser with others."
+#: src/olympia/bandwagon/templates/bandwagon/impala/collection_sidebar.html:23 src/olympia/bandwagon/templates/bandwagon/includes/collection_sidebar.html:27
+msgid "Collections make it easy to keep track of favorite add-ons and share your perfectly customized browser with others."
 msgstr ""
 
 #: src/olympia/bandwagon/templates/bandwagon/includes/addedit.html:42
@@ -3271,37 +2697,31 @@ msgid "Add-ons in Your Collection"
 msgstr ""
 
 #: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:4
-msgid ""
-"To include an add-on in this collection, enter its name in the box below and"
-" hit enter.  You can also use the <strong>Add to Collection</strong> links "
-"throughout the site to include add-ons later."
+msgid "To include an add-on in this collection, enter its name in the box below and hit enter."
 msgstr ""
 
-#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:17
-#: src/olympia/constants/base.py:400
-#: src/olympia/devhub/templates/devhub/addons/activity.html:62
+#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:15 src/olympia/constants/base.py:400 src/olympia/devhub/templates/devhub/addons/activity.html:62
 #: src/olympia/editors/helpers.py:273 src/olympia/editors/helpers.py:360
 msgid "Add-on"
 msgstr ""
 
-#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:26
+#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:24
 msgid "Enter the name of the add-on to include"
 msgstr ""
 
-#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:28
+#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:26
 msgid "Add to Collection"
 msgstr ""
 
-#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:45
-#: src/olympia/editors/helpers.py:1012 src/olympia/editors/helpers.py:1032
+#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:43 src/olympia/editors/helpers.py:1016 src/olympia/editors/helpers.py:1036
 msgid "Pending"
 msgstr ""
 
-#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:47
+#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:45
 msgid "Add a comment"
 msgstr ""
 
-#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:48
+#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:46
 msgid "Remove this add-on from the collection"
 msgstr ""
 
@@ -3313,14 +2733,11 @@ msgstr ""
 msgid "Groups of related add-ons that anyone can create."
 msgstr ""
 
-#: src/olympia/blocklist/templates/blocklist/blocked_detail.html:3
-#: src/olympia/blocklist/templates/blocklist/blocked_list.html:3
-#: src/olympia/blocklist/templates/blocklist/blocked_list.html:10
+#: src/olympia/blocklist/templates/blocklist/blocked_detail.html:3 src/olympia/blocklist/templates/blocklist/blocked_list.html:3 src/olympia/blocklist/templates/blocklist/blocked_list.html:10
 msgid "Blocked Add-ons"
 msgstr ""
 
-#: src/olympia/blocklist/templates/blocklist/blocked_detail.html:8
-#: src/olympia/blocklist/templates/blocklist/blocked_list.html:6
+#: src/olympia/blocklist/templates/blocklist/blocked_detail.html:8 src/olympia/blocklist/templates/blocklist/blocked_list.html:6
 msgid "Blocklist"
 msgstr ""
 
@@ -3342,25 +2759,18 @@ msgid "What does this mean?"
 msgstr ""
 
 #: src/olympia/blocklist/templates/blocklist/blocked_detail.html:22
-msgid ""
-"Users are strongly encouraged to disable the problematic add-on or plugin, "
-"but may choose to continue using it if they accept the risks described."
+msgid "Users are strongly encouraged to disable the problematic add-on or plugin, but may choose to continue using it if they accept the risks described."
 msgstr ""
 
 #: src/olympia/blocklist/templates/blocklist/blocked_detail.html:27
-msgid ""
-"The problematic add-on or plugin will be automatically disabled and no "
-"longer usable."
+msgid "The problematic add-on or plugin will be automatically disabled and no longer usable."
 msgstr ""
 
 #: src/olympia/blocklist/templates/blocklist/blocked_detail.html:33
 #, python-format
 msgid ""
-"When Mozilla becomes aware of add-ons, plugins, or other third-party "
-"software that seriously compromises %(app)s security, stability, or "
-"performance and meets <a href=\"%(criteria)s\">certain criteria</a>, the "
-"software may be blocked from general use.  For more information, please read"
-" <a href=\"%(support)s\">this support article</a>."
+"When Mozilla becomes aware of add-ons, plugins, or other third-party software that seriously compromises %(app)s security, stability, or performance and meets <a href=\"%(criteria)s\">certain "
+"criteria</a>, the software may be blocked from general use.  For more information, please read <a href=\"%(support)s\">this support article</a>."
 msgstr ""
 
 #: src/olympia/blocklist/templates/blocklist/blocked_detail.html:44
@@ -3374,9 +2784,7 @@ msgid "Blocked on %(date)s."
 msgstr ""
 
 #: src/olympia/blocklist/templates/blocklist/blocked_list.html:11
-msgid ""
-"The following software is known to cause serious security, stability, or "
-"performance issues with {app}."
+msgid "The following software is known to cause serious security, stability, or performance issues with {app}."
 msgstr ""
 
 #. L10n: %s is a category name.
@@ -3399,8 +2807,7 @@ msgstr ""
 #. L10n: %s is an app name.
 #: src/olympia/browse/feeds.py:138
 #, python-format
-msgid ""
-"Here's a few of our favorite add-ons to help you get started customizing %s."
+msgid "Here's a few of our favorite add-ons to help you get started customizing %s."
 msgstr ""
 
 #. L10n: %s is a category name.
@@ -3417,43 +2824,28 @@ msgstr ""
 msgid "Search tools"
 msgstr ""
 
-#: src/olympia/browse/views.py:55 src/olympia/browse/views.py:65
-#: src/olympia/search/forms.py:85
+#: src/olympia/browse/views.py:55 src/olympia/browse/views.py:65 src/olympia/search/forms.py:85
 msgid "Most Users"
 msgstr ""
 
-#: src/olympia/browse/views.py:61 src/olympia/browse/views.py:72
-#: src/olympia/browse/views.py:279
-#: src/olympia/browse/templates/browse/personas/mobile/category_landing.html:63
-#: src/olympia/discovery/templates/discovery/pane.html:67
-#: src/olympia/search/forms.py:92
+#: src/olympia/browse/views.py:61 src/olympia/browse/views.py:72 src/olympia/browse/views.py:246 src/olympia/browse/templates/browse/personas/mobile/category_landing.html:63
+#: src/olympia/discovery/templates/discovery/pane.html:67 src/olympia/search/forms.py:92
 msgid "Up & Coming"
 msgstr ""
 
-#: src/olympia/browse/views.py:460 src/olympia/devhub/views.py:76
-#: src/olympia/devhub/views.py:83
-#: src/olympia/discovery/templates/discovery/addons/detail.html:66
+#: src/olympia/browse/views.py:427 src/olympia/devhub/views.py:74 src/olympia/devhub/views.py:81 src/olympia/discovery/templates/discovery/addons/detail.html:66
 msgid "Created"
 msgstr ""
 
 #. {0} is the category name. Ex: Sports
-#: src/olympia/browse/templates/browse/creatured.html:5
-#: src/olympia/browse/templates/browse/creatured.html:13
+#: src/olympia/browse/templates/browse/creatured.html:5 src/olympia/browse/templates/browse/creatured.html:13
 msgid "{0}: Featured Add-ons"
 msgstr ""
 
-#: src/olympia/browse/templates/browse/creatured.html:12
-#: src/olympia/browse/templates/browse/featured.html:4
-#: src/olympia/browse/templates/browse/featured.html:12
-#: src/olympia/browse/templates/browse/featured.html:13
-#: src/olympia/devhub/templates/devhub/docs/policies-recommended.html:3
-#: src/olympia/devhub/templates/devhub/docs/policies-recommended.html:7
-#: src/olympia/devhub/templates/devhub/docs/policies-recommended.html:9
-#: src/olympia/devhub/templates/devhub/docs/policies.html:21
-#: src/olympia/devhub/templates/devhub/docs/policies.html:90
-#: src/olympia/discovery/modules.py:341
-#: src/olympia/discovery/templates/discovery/pane.html:52
-#: src/olympia/templates/menu_links.html:7
+#: src/olympia/browse/templates/browse/creatured.html:12 src/olympia/browse/templates/browse/featured.html:4 src/olympia/browse/templates/browse/featured.html:12
+#: src/olympia/browse/templates/browse/featured.html:13 src/olympia/devhub/templates/devhub/docs/policies-recommended.html:3 src/olympia/devhub/templates/devhub/docs/policies-recommended.html:7
+#: src/olympia/devhub/templates/devhub/docs/policies-recommended.html:9 src/olympia/devhub/templates/devhub/docs/policies.html:21 src/olympia/devhub/templates/devhub/docs/policies.html:90
+#: src/olympia/discovery/modules.py:341 src/olympia/discovery/templates/discovery/pane.html:52 src/olympia/templates/menu_links.html:7
 msgid "Featured Add-ons"
 msgstr ""
 
@@ -3464,9 +2856,7 @@ msgstr ""
 
 #: src/olympia/browse/templates/browse/featured.html:15
 #, python-format
-msgid ""
-"Here's a few of our favorite add-ons to help you get started customizing "
-"%(app)s."
+msgid "Here's a few of our favorite add-ons to help you get started customizing %(app)s."
 msgstr ""
 
 #: src/olympia/browse/templates/browse/language_tools.html:9
@@ -3493,19 +2883,15 @@ msgstr ""
 msgid "List of language packs and dictionaries available in your locale."
 msgstr ""
 
-#: src/olympia/browse/templates/browse/language_tools.html:41
-#: src/olympia/browse/templates/browse/language_tools.html:63
+#: src/olympia/browse/templates/browse/language_tools.html:41 src/olympia/browse/templates/browse/language_tools.html:63
 msgid "Language"
 msgstr ""
 
-#: src/olympia/browse/templates/browse/language_tools.html:42
-#: src/olympia/browse/templates/browse/language_tools.html:64
-#: src/olympia/constants/base.py:162
+#: src/olympia/browse/templates/browse/language_tools.html:42 src/olympia/browse/templates/browse/language_tools.html:64 src/olympia/constants/base.py:162
 msgid "Dictionary"
 msgstr ""
 
-#: src/olympia/browse/templates/browse/language_tools.html:43
-#: src/olympia/browse/templates/browse/language_tools.html:65
+#: src/olympia/browse/templates/browse/language_tools.html:43 src/olympia/browse/templates/browse/language_tools.html:65
 msgid "Language Pack"
 msgstr ""
 
@@ -3523,8 +2909,7 @@ msgid "{0} :: Search Tools"
 msgstr ""
 
 #. {0} is an integer.
-#: src/olympia/browse/templates/browse/search_tools.html:39
-#: src/olympia/devhub/templates/devhub/addons/dashboard.html:17
+#: src/olympia/browse/templates/browse/search_tools.html:39 src/olympia/devhub/templates/devhub/addons/dashboard.html:17
 msgid "<b>{0}</b> add-on"
 msgid_plural "<b>{0}</b> add-ons"
 msgstr[0] ""
@@ -3554,27 +2939,18 @@ msgstr ""
 
 #. {0} is an app name, like Firefox.
 #: src/olympia/browse/templates/browse/search_tools.html:93
-msgid ""
-"Learn more about the <a "
-"href=\"http://support.mozilla.com/kb/Search+bar\">search bar</a> in {0}"
+msgid "Learn more about the <a href=\"http://support.mozilla.com/kb/Search+bar\">search bar</a> in {0}"
 msgstr ""
 
 #: src/olympia/browse/templates/browse/search_tools.html:94
-msgid ""
-"Browse through even more search providers at <a "
-"href=\"http://mycroft.mozdev.org/\">mycroft.mozdev.org</a>"
+msgid "Browse through even more search providers at <a href=\"http://mycroft.mozdev.org/\">mycroft.mozdev.org</a>"
 msgstr ""
 
 #: src/olympia/browse/templates/browse/search_tools.html:95
-msgid ""
-"<a "
-"href=\"https://developer.mozilla.org/en/Creating_OpenSearch_plugins_for_Firefox\">Make"
-" your own</a> search tool"
+msgid "<a href=\"https://developer.mozilla.org/en/Creating_OpenSearch_plugins_for_Firefox\">Make your own</a> search tool"
 msgstr ""
 
-#: src/olympia/browse/templates/browse/themes.html:6
-#: src/olympia/browse/templates/browse/themes.html:9
-#: src/olympia/constants/base.py:174
+#: src/olympia/browse/templates/browse/themes.html:6 src/olympia/browse/templates/browse/themes.html:9 src/olympia/constants/base.py:174
 msgid "Complete Themes"
 msgstr ""
 
@@ -3649,23 +3025,17 @@ msgstr[1] ""
 msgstr[2] ""
 msgstr[3] ""
 
-#: src/olympia/browse/templates/browse/mobile/extensions.html:13
-#: src/olympia/devhub/templates/devhub/devhub_search.html:24
-#: src/olympia/devhub/templates/devhub/addons/activity.html:47
-#: src/olympia/search/templates/search/no_results.html:4
-#: src/olympia/search/templates/search/mobile/results.html:36
+#: src/olympia/browse/templates/browse/mobile/extensions.html:13 src/olympia/devhub/templates/devhub/devhub_search.html:24 src/olympia/devhub/templates/devhub/addons/activity.html:47
+#: src/olympia/search/templates/search/no_results.html:4 src/olympia/search/templates/search/mobile/results.html:36
 msgid "No results found."
 msgstr ""
 
-#: src/olympia/browse/templates/browse/personas/base.html:6
-#: src/olympia/browse/templates/browse/personas/mobile/base.html:7
+#: src/olympia/browse/templates/browse/personas/base.html:6 src/olympia/browse/templates/browse/personas/mobile/base.html:7
 msgid "{0} Themes"
 msgstr ""
 
 #. {0} is a user's name.
-#: src/olympia/browse/templates/browse/personas/base.html:15
-#: src/olympia/browse/templates/browse/personas/base.html:40
-#: src/olympia/browse/templates/browse/personas/grid.html:8
+#: src/olympia/browse/templates/browse/personas/base.html:15 src/olympia/browse/templates/browse/personas/base.html:40 src/olympia/browse/templates/browse/personas/grid.html:8
 msgid "{0}'s Themes"
 msgstr ""
 
@@ -3685,27 +3055,21 @@ msgstr ""
 msgid "Learn more"
 msgstr ""
 
-#: src/olympia/browse/templates/browse/personas/category_landing.html:6
-#: src/olympia/browse/templates/browse/personas/mobile/category_landing.html:5
+#: src/olympia/browse/templates/browse/personas/category_landing.html:6 src/olympia/browse/templates/browse/personas/mobile/category_landing.html:5
 msgid "View All Recently Added"
 msgstr ""
 
-#: src/olympia/browse/templates/browse/personas/category_landing.html:7
-#: src/olympia/browse/templates/browse/personas/mobile/category_landing.html:6
+#: src/olympia/browse/templates/browse/personas/category_landing.html:7 src/olympia/browse/templates/browse/personas/mobile/category_landing.html:6
 msgid "View All Most Popular"
 msgstr ""
 
-#: src/olympia/browse/templates/browse/personas/category_landing.html:8
-#: src/olympia/browse/templates/browse/personas/mobile/category_landing.html:7
+#: src/olympia/browse/templates/browse/personas/category_landing.html:8 src/olympia/browse/templates/browse/personas/mobile/category_landing.html:7
 msgid "View All Top Rated"
 msgstr ""
 
 #: src/olympia/browse/templates/browse/personas/category_landing.html:40
 #, python-format
-msgid ""
-"Over 300,000 designs to personalize your browser! Move your mouse over a "
-"Background Theme to try it on. <a href=\"%(url)s\" class=\"more-info\">Start"
-" exploring</a>"
+msgid "Over 300,000 designs to personalize your browser! Move your mouse over a Background Theme to try it on. <a href=\"%(url)s\" class=\"more-info\">Start exploring</a>"
 msgstr ""
 
 #: src/olympia/browse/templates/browse/personas/category_landing.html:47
@@ -3716,10 +3080,7 @@ msgstr ""
 #. theme.
 #: src/olympia/browse/templates/browse/personas/category_landing.html:50
 #, python-format
-msgid ""
-"Complete Themes transform the look of your browser with styles for the "
-"window frame, address bar, buttons, tabs, and menus. <a href=\"%(url)s\" "
-"class=\"more-info\">Start exploring</a>"
+msgid "Complete Themes transform the look of your browser with styles for the window frame, address bar, buttons, tabs, and menus. <a href=\"%(url)s\" class=\"more-info\">Start exploring</a>"
 msgstr ""
 
 #: src/olympia/browse/templates/browse/personas/category_landing.html:76
@@ -3750,9 +3111,7 @@ msgstr ""
 msgid "All"
 msgstr ""
 
-#: src/olympia/compat/forms.py:22
-#: src/olympia/editors/templates/editors/base.html:69
-#: src/olympia/search/views.py:518
+#: src/olympia/compat/forms.py:22 src/olympia/editors/templates/editors/base.html:69 src/olympia/search/views.py:518
 msgid "All Add-ons"
 msgstr ""
 
@@ -3768,22 +3127,18 @@ msgstr ""
 msgid "Add-on Compatibility Reports"
 msgstr ""
 
-#: src/olympia/compat/templates/compat/reporter.html:11
-#: src/olympia/compat/templates/compat/reporter_detail.html:35
+#: src/olympia/compat/templates/compat/reporter.html:11 src/olympia/compat/templates/compat/reporter_detail.html:35
 #, python-format
 msgid ""
-"<p> Reports submitted to us through the <a href=\"%(url_)s\">Add-on "
-"Compatibility Reporter</a> are collected here for developers to view. These "
-"reports help us determine which add-ons will need help supporting an "
-"upcoming Firefox version. </p>"
+"<p> Reports submitted to us through the <a href=\"%(url_)s\">Add-on Compatibility Reporter</a> are collected here for developers to view. These reports help us determine which add-ons will need "
+"help supporting an upcoming Firefox version. </p>"
 msgstr ""
 
 #: src/olympia/compat/templates/compat/reporter.html:18
 msgid "Reports for your Add-ons"
 msgstr ""
 
-#: src/olympia/compat/templates/compat/reporter.html:30
-#: src/olympia/compat/templates/compat/reporter_detail.html:9
+#: src/olympia/compat/templates/compat/reporter.html:30 src/olympia/compat/templates/compat/reporter_detail.html:9
 msgid "Add-on Compatibility Center"
 msgstr ""
 
@@ -3791,9 +3146,7 @@ msgstr ""
 msgid "Enter the GUID of an add-on below to view any reports we've received."
 msgstr ""
 
-#: src/olympia/compat/templates/compat/reporter_detail.html:3
-#: src/olympia/compat/templates/compat/reporter_detail.html:10
-#: src/olympia/compat/templates/compat/reporter_detail.html:25
+#: src/olympia/compat/templates/compat/reporter_detail.html:3 src/olympia/compat/templates/compat/reporter_detail.html:10 src/olympia/compat/templates/compat/reporter_detail.html:25
 msgid "{addon} Compatibility Reports"
 msgstr ""
 
@@ -3813,8 +3166,7 @@ msgstr[1] ""
 msgstr[2] ""
 msgstr[3] ""
 
-#: src/olympia/compat/templates/compat/reporter_detail.html:21
-#: src/olympia/users/templates/users/profile.html:70
+#: src/olympia/compat/templates/compat/reporter_detail.html:21 src/olympia/users/templates/users/profile.html:70
 msgid "View all"
 msgstr ""
 
@@ -3826,10 +3178,8 @@ msgstr ""
 msgid "Report Type"
 msgstr ""
 
-#: src/olympia/compat/templates/compat/reporter_detail.html:47
-#: src/olympia/devhub/forms.py:776
-#: src/olympia/devhub/templates/devhub/addons/ajax_compat_update.html:17
-#: src/olympia/editors/forms.py:108 src/olympia/zadmin/forms.py:45
+#: src/olympia/compat/templates/compat/reporter_detail.html:47 src/olympia/devhub/forms.py:785 src/olympia/devhub/templates/devhub/addons/ajax_compat_update.html:17 src/olympia/editors/forms.py:108
+#: src/olympia/editors/forms.py:248 src/olympia/zadmin/forms.py:45
 msgid "Application"
 msgstr ""
 
@@ -3841,8 +3191,7 @@ msgstr ""
 msgid "Platform"
 msgstr ""
 
-#: src/olympia/compat/templates/compat/reporter_detail.html:50
-#: src/olympia/editors/templates/editors/themes/themes.html:40
+#: src/olympia/compat/templates/compat/reporter_detail.html:50 src/olympia/editors/templates/editors/themes/themes.html:40
 msgid "Submitted"
 msgstr ""
 
@@ -3870,8 +3219,7 @@ msgstr ""
 msgid "SeaMonkey"
 msgstr ""
 
-#: src/olympia/constants/applications.py:75
-#: src/olympia/pages/templates/pages/sunbird.html:4
+#: src/olympia/constants/applications.py:75 src/olympia/pages/templates/pages/sunbird.html:4
 msgid "Sunbird"
 msgstr ""
 
@@ -3919,8 +3267,7 @@ msgstr ""
 msgid "Preliminarily Reviewed and Awaiting Full Review"
 msgstr ""
 
-#: src/olympia/constants/base.py:33 src/olympia/editors/helpers.py:73
-#: src/olympia/editors/helpers.py:1000
+#: src/olympia/constants/base.py:33 src/olympia/editors/forms.py:258 src/olympia/editors/helpers.py:73 src/olympia/editors/helpers.py:1004
 #: src/olympia/editors/templates/editors/themes/history_table.html:34
 msgid "Deleted"
 msgstr ""
@@ -3953,13 +3300,11 @@ msgstr ""
 msgid "Viewer"
 msgstr ""
 
-#: src/olympia/constants/base.py:137
-#: src/olympia/templates/mobile/header.html:7
+#: src/olympia/constants/base.py:137 src/olympia/templates/mobile/header.html:7
 msgid "Support"
 msgstr ""
 
-#: src/olympia/constants/base.py:159 src/olympia/constants/base.py:172
-#: src/olympia/constants/platforms.py:10
+#: src/olympia/constants/base.py:159 src/olympia/constants/base.py:172 src/olympia/constants/platforms.py:10
 msgid "Any"
 msgstr ""
 
@@ -3987,11 +3332,8 @@ msgstr ""
 msgid "Plugin"
 msgstr ""
 
-#: src/olympia/constants/base.py:167
-#: src/olympia/editors/templates/editors/includes/search_results_themes.html:5
-#: src/olympia/editors/templates/editors/themes/deleted.html:18
-#: src/olympia/editors/templates/editors/themes/history_table.html:8
-#: src/olympia/editors/templates/editors/themes/logs.html:17
+#: src/olympia/constants/base.py:167 src/olympia/editors/templates/editors/includes/search_results_themes.html:5 src/olympia/editors/templates/editors/themes/deleted.html:18
+#: src/olympia/editors/templates/editors/themes/history_table.html:8 src/olympia/editors/templates/editors/themes/logs.html:17
 msgid "Theme"
 msgstr ""
 
@@ -4024,8 +3366,7 @@ msgid "Ask before users can download this add-on"
 msgstr ""
 
 #. Review points sources other than add-ons and themes.
-#: src/olympia/constants/base.py:388 src/olympia/devhub/forms.py:162
-#: src/olympia/editors/templates/editors/performance.html:75
+#: src/olympia/constants/base.py:388 src/olympia/devhub/forms.py:162 src/olympia/editors/templates/editors/performance.html:75
 msgid "Other"
 msgstr ""
 
@@ -4181,32 +3522,23 @@ msgstr ""
 msgid "Signed of a preliminary review"
 msgstr ""
 
-#: src/olympia/constants/editors.py:14
-#: src/olympia/editors/templates/editors/themes/queue.html:76
-#: src/olympia/editors/templates/editors/themes/themes.html:87
+#: src/olympia/constants/editors.py:14 src/olympia/editors/templates/editors/themes/queue.html:76 src/olympia/editors/templates/editors/themes/themes.html:87
 msgid "Request More Info"
 msgstr ""
 
-#: src/olympia/constants/editors.py:15
-#: src/olympia/editors/templates/editors/themes/queue.html:74
-#: src/olympia/editors/templates/editors/themes/themes.html:91
+#: src/olympia/constants/editors.py:15 src/olympia/editors/templates/editors/themes/queue.html:74 src/olympia/editors/templates/editors/themes/themes.html:91
 msgid "Flag"
 msgstr ""
 
-#: src/olympia/constants/editors.py:16
-#: src/olympia/editors/templates/editors/themes/queue.html:72
-#: src/olympia/editors/templates/editors/themes/themes.html:93
+#: src/olympia/constants/editors.py:16 src/olympia/editors/templates/editors/themes/queue.html:72 src/olympia/editors/templates/editors/themes/themes.html:93
 msgid "Duplicate"
 msgstr ""
 
-#: src/olympia/constants/editors.py:17 src/olympia/editors/helpers.py:571
-#: src/olympia/editors/templates/editors/themes/queue.html:71
-#: src/olympia/editors/templates/editors/themes/themes.html:94
+#: src/olympia/constants/editors.py:17 src/olympia/editors/helpers.py:575 src/olympia/editors/templates/editors/themes/queue.html:71 src/olympia/editors/templates/editors/themes/themes.html:94
 msgid "Reject"
 msgstr ""
 
-#: src/olympia/constants/editors.py:18
-#: src/olympia/editors/templates/editors/themes/queue.html:70
+#: src/olympia/constants/editors.py:18 src/olympia/editors/templates/editors/themes/queue.html:70
 msgid "Approve"
 msgstr ""
 
@@ -4339,9 +3671,7 @@ msgstr ""
 msgid "Message not eligible for annotation"
 msgstr ""
 
-#: src/olympia/devhub/forms.py:124
-#: src/olympia/devhub/templates/devhub/versions/edit.html:94
-#: src/olympia/users/templates/users/edit.html:150
+#: src/olympia/devhub/forms.py:124 src/olympia/devhub/templates/devhub/versions/edit.html:94 src/olympia/users/templates/users/edit.html:150
 msgid "Details"
 msgstr ""
 
@@ -4442,81 +3772,75 @@ msgid "Do not list my add-on on this site"
 msgstr ""
 
 #: src/olympia/devhub/forms.py:538
-msgid ""
-"Check this option if you intend to distribute your add-on on your own and "
-"only need it to be signed by Mozilla."
+msgid "Check this option if you intend to distribute your add-on on your own and only need it to be signed by Mozilla."
 msgstr ""
 
-#: src/olympia/devhub/forms.py:556
-#: src/olympia/devhub/templates/devhub/addons/submit/select-review.html:24
-#: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:42
+#: src/olympia/devhub/forms.py:544
+msgid "This add-on will be bundled with an application installer."
+msgstr ""
+
+#: src/olympia/devhub/forms.py:546
+msgid "Add-ons that are bundled with application installers will be code reviewed by Mozilla before they are signed and are held to a higher quality standard."
+msgstr ""
+
+#: src/olympia/devhub/forms.py:565 src/olympia/devhub/templates/devhub/addons/submit/select-review.html:24 src/olympia/devhub/templates/devhub/docs/policies-reviews.html:42
 msgid "Full Review"
 msgstr ""
 
-#: src/olympia/devhub/forms.py:557
-#: src/olympia/devhub/templates/devhub/addons/submit/select-review.html:47
-#: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:153
+#: src/olympia/devhub/forms.py:566 src/olympia/devhub/templates/devhub/addons/submit/select-review.html:47 src/olympia/devhub/templates/devhub/docs/policies-reviews.html:153
 msgid "Preliminary Review"
 msgstr ""
 
-#: src/olympia/devhub/forms.py:561
+#: src/olympia/devhub/forms.py:570
 msgid "Please choose a review nomination type"
 msgstr ""
 
-#: src/olympia/devhub/forms.py:565
-msgid ""
-"A file with a version ending with a|alpha|b|beta|pre|rc and an optional "
-"number is detected as beta."
+#: src/olympia/devhub/forms.py:574
+msgid "A file with a version ending with a|alpha|b|beta|pre|rc and an optional number is detected as beta."
 msgstr ""
 
-#: src/olympia/devhub/forms.py:583
+#: src/olympia/devhub/forms.py:592
 #, python-format
 msgid "Version %s already exists, or was uploaded before."
 msgstr ""
 
-#: src/olympia/devhub/forms.py:596
-msgid ""
-"Select a valid choice. That choice is not one of the available choices."
+#: src/olympia/devhub/forms.py:605
+msgid "Select a valid choice. That choice is not one of the available choices."
 msgstr ""
 
-#: src/olympia/devhub/forms.py:602
-msgid ""
-"A file with a version ending with a|alpha|b|beta and an optional number is "
-"detected as beta."
+#: src/olympia/devhub/forms.py:611
+msgid "A file with a version ending with a|alpha|b|beta and an optional number is detected as beta."
 msgstr ""
 
-#: src/olympia/devhub/forms.py:625
+#: src/olympia/devhub/forms.py:634
 msgid "You cannot upload any more files for this version."
 msgstr ""
 
-#: src/olympia/devhub/forms.py:631
+#: src/olympia/devhub/forms.py:640
 msgid "Version doesn't match"
 msgstr ""
 
-#: src/olympia/devhub/forms.py:660
-msgid ""
-"You cannot delete a file once the review process has started.  You must "
-"delete the whole version."
+#: src/olympia/devhub/forms.py:669
+msgid "You cannot delete a file once the review process has started.  You must delete the whole version."
 msgstr ""
 
-#: src/olympia/devhub/forms.py:680
+#: src/olympia/devhub/forms.py:689
 msgid "The platform All cannot be combined with specific platforms."
 msgstr ""
 
-#: src/olympia/devhub/forms.py:685
+#: src/olympia/devhub/forms.py:694
 msgid "A platform can only be chosen once."
 msgstr ""
 
-#: src/olympia/devhub/forms.py:698
+#: src/olympia/devhub/forms.py:707
 msgid "A review type must be selected."
 msgstr ""
 
-#: src/olympia/devhub/forms.py:780 src/olympia/editors/forms.py:114
-#: src/olympia/zadmin/forms.py:49 src/olympia/zadmin/forms.py:52
+#: src/olympia/devhub/forms.py:789 src/olympia/editors/forms.py:114 src/olympia/editors/forms.py:254 src/olympia/zadmin/forms.py:49 src/olympia/zadmin/forms.py:52
 msgid "Select an application first"
 msgstr ""
 
-#: src/olympia/devhub/forms.py:832
+#: src/olympia/devhub/forms.py:841
 msgid "There cannot be more than 3 required add-ons."
 msgstr ""
 
@@ -4550,183 +3874,169 @@ msgstr[1] ""
 msgstr[2] ""
 msgstr[3] ""
 
-#: src/olympia/devhub/models.py:375
-#: src/olympia/reviews/templates/reviews/add.html:58
+#: src/olympia/devhub/models.py:375 src/olympia/reviews/templates/reviews/add.html:58
 msgid "Review"
 msgstr ""
 
-#: src/olympia/devhub/tasks.py:590
+#: src/olympia/devhub/tasks.py:583
 #, python-format
 msgid "%s responded with %s (%s)."
 msgstr ""
 
-#: src/olympia/devhub/tasks.py:594
+#: src/olympia/devhub/tasks.py:587
 #, python-format
 msgid "Connection to \"%s\" timed out."
 msgstr ""
 
-#: src/olympia/devhub/tasks.py:596
+#: src/olympia/devhub/tasks.py:589
 #, python-format
 msgid "Could not contact host at \"%s\"."
 msgstr ""
 
 #: src/olympia/devhub/utils.py:105
 #, python-format
-msgid ""
-"Validation generated too many errors/warnings so %s messages were truncated."
-" After addressing the visible messages, you'll be able to see the others."
+msgid "Validation generated too many errors/warnings so %s messages were truncated. After addressing the visible messages, you'll be able to see the others."
 msgstr ""
 
-#: src/olympia/devhub/views.py:183
+#: src/olympia/devhub/views.py:181
 msgid "All My Add-ons"
 msgstr ""
 
-#: src/olympia/devhub/views.py:210
+#: src/olympia/devhub/views.py:208
 msgid "All Activity"
 msgstr ""
 
-#: src/olympia/devhub/views.py:211
+#: src/olympia/devhub/views.py:209
 msgid "Add-on Updates"
 msgstr ""
 
-#: src/olympia/devhub/views.py:212
+#: src/olympia/devhub/views.py:210
 msgid "Add-on Status"
 msgstr ""
 
-#: src/olympia/devhub/views.py:213
+#: src/olympia/devhub/views.py:211
 msgid "User Collections"
 msgstr ""
 
-#: src/olympia/devhub/views.py:214
-#: src/olympia/devhub/templates/devhub/docs/policies-maintenance.html:68
-#: src/olympia/pages/templates/pages/dev_faq.html:38
+#: src/olympia/devhub/views.py:212 src/olympia/devhub/templates/devhub/docs/policies-maintenance.html:68 src/olympia/pages/templates/pages/dev_faq.html:38
 #: src/olympia/pages/templates/pages/dev_faq.html:484
 msgid "User Reviews"
 msgstr ""
 
-#: src/olympia/devhub/views.py:327 src/olympia/devhub/views.py:331
-#: src/olympia/devhub/views.py:487 src/olympia/devhub/views.py:516
-#: src/olympia/devhub/views.py:567 src/olympia/devhub/views.py:1160
+#: src/olympia/devhub/views.py:325 src/olympia/devhub/views.py:329 src/olympia/devhub/views.py:484 src/olympia/devhub/views.py:513 src/olympia/devhub/views.py:564 src/olympia/devhub/views.py:1156
 msgid "Changes successfully saved."
 msgstr ""
 
-#: src/olympia/devhub/views.py:334 src/olympia/devhub/views.py:1634
+#: src/olympia/devhub/views.py:332 src/olympia/devhub/views.py:1637
 msgid "Please check the form for errors."
 msgstr ""
 
-#: src/olympia/devhub/views.py:346
+#: src/olympia/devhub/views.py:344
 msgid "Add-on cannot be deleted. Disable this add-on instead."
 msgstr ""
 
-#: src/olympia/devhub/views.py:356
+#: src/olympia/devhub/views.py:354
 msgid "Theme deleted."
 msgstr ""
 
-#: src/olympia/devhub/views.py:356
+#: src/olympia/devhub/views.py:354
 msgid "Add-on deleted."
 msgstr ""
 
-#: src/olympia/devhub/views.py:362
+#: src/olympia/devhub/views.py:360
 msgid "URL name was incorrect. Theme was not deleted."
 msgstr ""
 
-#: src/olympia/devhub/views.py:367
+#: src/olympia/devhub/views.py:365
 msgid "URL name was incorrect. Add-on was not deleted."
 msgstr ""
 
-#: src/olympia/devhub/views.py:452
+#: src/olympia/devhub/views.py:449
 msgid "An author has been added to your add-on"
 msgstr ""
 
-#: src/olympia/devhub/views.py:459
+#: src/olympia/devhub/views.py:456
 msgid "An author has a role changed on your add-on"
 msgstr ""
 
-#: src/olympia/devhub/views.py:479
+#: src/olympia/devhub/views.py:476
 msgid "An author has been removed from your add-on"
 msgstr ""
 
-#: src/olympia/devhub/views.py:522
+#: src/olympia/devhub/views.py:519
 msgid "There were errors in your submission."
 msgstr ""
 
-#: src/olympia/devhub/views.py:586
+#: src/olympia/devhub/views.py:583
 msgid "Validate Add-on"
 msgstr ""
 
-#: src/olympia/devhub/views.py:597
+#: src/olympia/devhub/views.py:594
 msgid "Check Add-on Compatibility"
 msgstr ""
 
-#: src/olympia/devhub/views.py:812 src/olympia/signing/views.py:95
+#: src/olympia/devhub/views.py:808 src/olympia/signing/views.py:95
 msgid "You cannot submit this type of add-on"
 msgstr ""
 
-#: src/olympia/devhub/views.py:1055 src/olympia/users/forms.py:471
+#: src/olympia/devhub/views.py:1051 src/olympia/users/forms.py:471
 msgid "Images must be either PNG or JPG."
 msgstr ""
 
-#: src/olympia/devhub/views.py:1059
+#: src/olympia/devhub/views.py:1055
 msgid "Icons cannot be animated."
 msgstr ""
 
-#: src/olympia/devhub/views.py:1061
+#: src/olympia/devhub/views.py:1057
 msgid "Images cannot be animated."
 msgstr ""
 
-#: src/olympia/devhub/views.py:1074
+#: src/olympia/devhub/views.py:1070
 #, python-format
 msgid "Images cannot be larger than %dKB."
 msgstr ""
 
 #. L10n: {0} is an image width (in pixels), {1} is a height.
-#: src/olympia/devhub/views.py:1084
+#: src/olympia/devhub/views.py:1080
 msgid "Image must be exactly {0} pixels wide and {1} pixels tall."
 msgstr ""
 
-#: src/olympia/devhub/views.py:1091
+#: src/olympia/devhub/views.py:1087
 msgid "There was an error uploading your preview."
 msgstr ""
 
-#: src/olympia/devhub/views.py:1199
+#: src/olympia/devhub/views.py:1195
 #, python-format
 msgid "Version %s disabled."
 msgstr ""
 
-#: src/olympia/devhub/views.py:1203
+#: src/olympia/devhub/views.py:1199
 #, python-format
 msgid "Version %s deleted."
 msgstr ""
 
-#: src/olympia/devhub/views.py:1213
-msgid ""
-"This upload has failed validation, and may lack complete validation results."
-" Please take due care when reviewing it."
+#: src/olympia/devhub/views.py:1209
+msgid "This upload has failed validation, and may lack complete validation results. Please take due care when reviewing it."
 msgstr ""
 
-#: src/olympia/devhub/views.py:1680
+#: src/olympia/devhub/views.py:1683
 msgid "Preliminary Review Requested."
 msgstr ""
 
-#: src/olympia/devhub/views.py:1681
+#: src/olympia/devhub/views.py:1684
 msgid "Full Review Requested."
 msgstr ""
 
-#: src/olympia/devhub/views.py:1782
-msgid ""
-"Your old credentials were revoked and are no longer valid. Be sure to update"
-" all API clients with the new credentials."
+#: src/olympia/devhub/views.py:1783
+msgid "Your old credentials were revoked and are no longer valid. Be sure to update all API clients with the new credentials."
 msgstr ""
 
-#: src/olympia/devhub/views.py:1800
+#: src/olympia/devhub/views.py:1801
 msgid "New API key created"
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/agreement.html:2
-msgid ""
-"Before starting, please read and accept our Firefox Add-on Distribution "
-"Agreement. It also links to our Privacy Notice which explains how we handle "
-"your information."
+msgid "Before starting, please read and accept our Firefox Add-on Distribution Agreement. It also links to our Privacy Notice which explains how we handle your information."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/agreement.html:13
@@ -4741,44 +4051,30 @@ msgstr ""
 msgid "or <a href=\"{0}\">Cancel</a>"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/base.html:23
-#: src/olympia/devhub/templates/devhub/base_impala.html:20
-#: src/olympia/discovery/templates/discovery/addons/base.html:17
+#: src/olympia/devhub/templates/devhub/base.html:23 src/olympia/devhub/templates/devhub/base_impala.html:20 src/olympia/discovery/templates/discovery/addons/base.html:17
 msgid "Back to Add-ons"
 msgstr ""
 
 #. {0} is a search term, such as Firebug.
 #. {0} is a search query.
-#: src/olympia/devhub/templates/devhub/devhub_search.html:4
-#: src/olympia/search/templates/search/results.html:9
-#: src/olympia/search/templates/search/mobile/results.html:6
+#: src/olympia/devhub/templates/devhub/devhub_search.html:4 src/olympia/search/templates/search/results.html:9 src/olympia/search/templates/search/mobile/results.html:6
 msgid "{0} :: Search"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/devhub_search.html:6
-#: src/olympia/devhub/templates/devhub/search.html:8
-#: src/olympia/editors/forms.py:430 src/olympia/editors/forms.py:432
-#: src/olympia/editors/templates/editors/queue.html:27
-#: src/olympia/editors/templates/editors/themes/queue_list.html:14
-#: src/olympia/search/templates/search/collections.html:17
-#: src/olympia/search/templates/search/personas.html:18
-#: src/olympia/search/templates/search/results.html:18
-#: src/olympia/search/templates/search/mobile/results.html:8
-#: src/olympia/templates/search.html:14
-#: src/olympia/templates/impala/search.html:18
+#: src/olympia/devhub/templates/devhub/devhub_search.html:6 src/olympia/devhub/templates/devhub/search.html:8 src/olympia/editors/forms.py:534 src/olympia/editors/forms.py:536
+#: src/olympia/editors/templates/editors/queue.html:27 src/olympia/editors/templates/editors/themes/queue_list.html:14 src/olympia/search/templates/search/collections.html:17
+#: src/olympia/search/templates/search/personas.html:18 src/olympia/search/templates/search/results.html:18 src/olympia/search/templates/search/mobile/results.html:8
+#: src/olympia/templates/search.html:14 src/olympia/templates/impala/search.html:18
 msgid "Search"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/devhub_search.html:11
-#: src/olympia/devhub/templates/devhub/devhub_search.html:15
-#: src/olympia/search/templates/search/collections.html:18
+#: src/olympia/devhub/templates/devhub/devhub_search.html:11 src/olympia/devhub/templates/devhub/devhub_search.html:15 src/olympia/search/templates/search/collections.html:18
 #: src/olympia/search/templates/search/personas.html:20
 msgid "Search Results"
 msgstr ""
 
 #. {0} is a search term, such as Firebug.
-#: src/olympia/devhub/templates/devhub/devhub_search.html:13
-#: src/olympia/search/templates/search/results.html:11
+#: src/olympia/devhub/templates/devhub/devhub_search.html:13 src/olympia/search/templates/search/results.html:11
 msgid "Search Results for \"{0}\""
 msgstr ""
 
@@ -4799,9 +4095,7 @@ msgid "AMO Reviewers"
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/index.html:29
-msgid ""
-"Get ahead! Become an AMO Reviewer today and get your add-ons reviewed "
-"faster."
+msgid "Get ahead! Become an AMO Reviewer today and get your add-ons reviewed faster."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/index.html:32
@@ -4814,33 +4108,25 @@ msgstr ""
 
 #: src/olympia/devhub/templates/devhub/index.html:41
 msgid ""
-"Add-ons let millions of Firefox users enhance and customize their browsing "
-"experience. If you're a Web developer and know <a "
-"href=\"https://developer.mozilla.org/docs/Web/HTML\">HTML</a>, <a "
-"href=\"https://developer.mozilla.org/docs/Web/JavaScript\">JavaScript</a>, "
-"and <a href=\"https://developer.mozilla.org/docs/Web/CSS\">CSS</a>, you "
-"already have all the necessary skills to make a great add-on."
+"Add-ons let millions of Firefox users enhance and customize their browsing experience. If you're a Web developer and know <a href=\"https://developer.mozilla.org/docs/Web/HTML\">HTML</a>, <a href="
+"\"https://developer.mozilla.org/docs/Web/JavaScript\">JavaScript</a>, and <a href=\"https://developer.mozilla.org/docs/Web/CSS\">CSS</a>, you already have all the necessary skills to make a great "
+"add-on."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/index.html:51
-msgid ""
-"Head over to the <a href=\"https://developer.mozilla.org/Add-ons\">Mozilla "
-"Developer Network</a> to learn everything you need to know to get started."
+msgid "Head over to the <a href=\"https://developer.mozilla.org/Add-ons\">Mozilla Developer Network</a> to learn everything you need to know to get started."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/index.html:58
 msgid "Start Making Add-ons"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/index.html:86
-#: src/olympia/devhub/templates/devhub/addons/listing/items.html:25
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:20
+#: src/olympia/devhub/templates/devhub/index.html:86 src/olympia/devhub/templates/devhub/addons/listing/items.html:25 src/olympia/devhub/templates/devhub/includes/addon_details.html:20
 #: src/olympia/devhub/templates/devhub/personas/edit.html:43
 msgid "Status:"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/index.html:90
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:87
+#: src/olympia/devhub/templates/devhub/index.html:90 src/olympia/devhub/templates/devhub/includes/addon_details.html:87
 msgid "Visibility:"
 msgstr ""
 
@@ -4848,21 +4134,16 @@ msgstr ""
 msgid "Latest Version:"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/index.html:109
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:131
-#: src/olympia/devhub/templates/devhub/personas/edit.html:49
+#: src/olympia/devhub/templates/devhub/index.html:109 src/olympia/devhub/templates/devhub/includes/addon_details.html:131 src/olympia/devhub/templates/devhub/personas/edit.html:49
 msgid "Queue Position:"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/index.html:110
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:132
-#: src/olympia/devhub/templates/devhub/personas/edit.html:50
+#: src/olympia/devhub/templates/devhub/index.html:110 src/olympia/devhub/templates/devhub/includes/addon_details.html:132 src/olympia/devhub/templates/devhub/personas/edit.html:50
 #, python-format
 msgid "%(position)s of %(total)s"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/index.html:120
-#: src/olympia/devhub/templates/devhub/includes/addons_edit_nav.html:19
+#: src/olympia/devhub/templates/devhub/index.html:120 src/olympia/devhub/templates/devhub/includes/addons_edit_nav.html:19
 msgid "Upload New Version"
 msgstr ""
 
@@ -4876,9 +4157,7 @@ msgstr ""
 
 #: src/olympia/devhub/templates/devhub/index.html:136
 #, python-format
-msgid ""
-"Upload an <a href=\"%(addon_url)s\">add-on</a> or <a "
-"href=\"%(theme_url)s\">theme</a> to get started!"
+msgid "Upload an <a href=\"%(addon_url)s\">add-on</a> or <a href=\"%(theme_url)s\">theme</a> to get started!"
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/nav.html:2
@@ -4906,17 +4185,10 @@ msgstr ""
 msgid "Lightweight Themes"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/nav.html:39
-#: src/olympia/devhub/templates/devhub/docs/policies-agreement.html:6
-#: src/olympia/devhub/templates/devhub/docs/policies-contact.html:6
-#: src/olympia/devhub/templates/devhub/docs/policies-maintenance.html:6
-#: src/olympia/devhub/templates/devhub/docs/policies-recommended.html:6
-#: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:6
-#: src/olympia/devhub/templates/devhub/docs/policies-submission.html:6
-#: src/olympia/devhub/templates/devhub/docs/policies.html:3
-#: src/olympia/devhub/templates/devhub/docs/policies.html:9
-#: src/olympia/devhub/templates/devhub/docs/policies.html:38
-#: src/olympia/devhub/templates/devhub/docs/policies.html:39
+#: src/olympia/devhub/templates/devhub/nav.html:39 src/olympia/devhub/templates/devhub/docs/policies-agreement.html:6 src/olympia/devhub/templates/devhub/docs/policies-contact.html:6
+#: src/olympia/devhub/templates/devhub/docs/policies-maintenance.html:6 src/olympia/devhub/templates/devhub/docs/policies-recommended.html:6
+#: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:6 src/olympia/devhub/templates/devhub/docs/policies-submission.html:6 src/olympia/devhub/templates/devhub/docs/policies.html:3
+#: src/olympia/devhub/templates/devhub/docs/policies.html:9 src/olympia/devhub/templates/devhub/docs/policies.html:38 src/olympia/devhub/templates/devhub/docs/policies.html:39
 msgid "Add-on Policies"
 msgstr ""
 
@@ -4957,19 +4229,14 @@ msgid "Use the field below to upload your add-on package."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/validate_addon.html:19
-msgid ""
-"After upload, a series of automated validation tests will run to check "
-"compatibility with the following application version:"
+msgid "After upload, a series of automated validation tests will run to check compatibility with the following application version:"
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/validate_addon.html:34
-msgid ""
-"After upload, a series of automated validation tests will be run on your "
-"file."
+msgid "After upload, a series of automated validation tests will be run on your file."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/validate_addon.html:42
-#: src/olympia/devhub/templates/devhub/addons/submit/upload.html:23
+#: src/olympia/devhub/templates/devhub/validate_addon.html:42 src/olympia/devhub/templates/devhub/addons/submit/upload.html:23
 msgid "Do you want your add-on to be distributed on this site?"
 msgstr ""
 
@@ -4990,14 +4257,11 @@ msgstr ""
 msgid "Tested for compatibility against:"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/addons/activity.html:4
-#: src/olympia/devhub/templates/devhub/addons/activity.html:20
+#: src/olympia/devhub/templates/devhub/addons/activity.html:4 src/olympia/devhub/templates/devhub/addons/activity.html:20
 msgid "Recent Activity for My Add-ons"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/addons/activity.html:14
-#: src/olympia/devhub/templates/devhub/addons/activity.html:19
-#: src/olympia/devhub/templates/devhub/addons/dashboard.html:33
+#: src/olympia/devhub/templates/devhub/addons/activity.html:14 src/olympia/devhub/templates/devhub/addons/activity.html:19 src/olympia/devhub/templates/devhub/addons/dashboard.html:33
 msgid "Recent Activity"
 msgstr ""
 
@@ -5019,37 +4283,30 @@ msgstr ""
 msgid "Activity"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/addons/activity.html:83
-#: src/olympia/devhub/templates/devhub/addons/dashboard.html:34
-#: src/olympia/devhub/templates/devhub/addons/dashboard.html:35
-#: src/olympia/devhub/templates/devhub/includes/blog_posts.html:4
-#: src/olympia/devhub/templates/devhub/includes/blog_posts.html:6
+#: src/olympia/devhub/templates/devhub/addons/activity.html:83 src/olympia/devhub/templates/devhub/addons/dashboard.html:34 src/olympia/devhub/templates/devhub/addons/dashboard.html:35
+#: src/olympia/devhub/templates/devhub/includes/blog_posts.html:4 src/olympia/devhub/templates/devhub/includes/blog_posts.html:6
 msgid "Subscribe to this feed"
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/ajax_compat_error.html:7
 #, python-format
 msgid ""
-"This add-on is incompatible with <b>%(app_name)s %(app_version)s</b>, the "
-"latest release of %(app_name)s. Please consider updating your add-on's "
-"compatibility info, or uploading a newer version of this add-on."
+"This add-on is incompatible with <b>%(app_name)s %(app_version)s</b>, the latest release of %(app_name)s. Please consider updating your add-on's compatibility info, or uploading a newer version of "
+"this add-on."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/ajax_compat_error.html:15
 #, python-format
 msgid ""
-"<a href=\"#\" class=\"button compat-update\" data-"
-"updateurl=\"%(update_url)s\">Update Compatibility</a> <a "
-"href=\"%(version_url)s\" class=\"button\">Upload New Version</a> or <a "
-"href=\"#\" class=\"close\">Ignore</a>"
+"<a href=\"#\" class=\"button compat-update\" data-updateurl=\"%(update_url)s\">Update Compatibility</a> <a href=\"%(version_url)s\" class=\"button\">Upload New Version</a> or <a href=\"#\" class="
+"\"close\">Ignore</a>"
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/ajax_compat_status.html:5
 msgid "View and update application compatibility ranges."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/addons/ajax_compat_status.html:6
-#: src/olympia/devhub/templates/devhub/versions/edit.html:44
+#: src/olympia/devhub/templates/devhub/addons/ajax_compat_status.html:6 src/olympia/devhub/templates/devhub/versions/edit.html:44
 msgid "Compatibility"
 msgstr ""
 
@@ -5057,37 +4314,25 @@ msgstr ""
 msgid "Update Compatibility"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/addons/ajax_compat_update.html:4
-#: src/olympia/devhub/templates/devhub/versions/edit.html:45
-msgid ""
-"Adjusting application information here will allow users to install your add-"
-"on even if the install manifest in the package indicates that the add-on is "
-"incompatible."
+#: src/olympia/devhub/templates/devhub/addons/ajax_compat_update.html:4 src/olympia/devhub/templates/devhub/versions/edit.html:45
+msgid "Adjusting application information here will allow users to install your add-on even if the install manifest in the package indicates that the add-on is incompatible."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/ajax_compat_update.html:18
 msgid "Supported Versions"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/addons/ajax_compat_update.html:31
-#: src/olympia/devhub/templates/devhub/versions/edit.html:63
+#: src/olympia/devhub/templates/devhub/addons/ajax_compat_update.html:31 src/olympia/devhub/templates/devhub/versions/edit.html:63
 msgid "Add Another Application&hellip;"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/addons/ajax_compat_update.html:38
-#: src/olympia/devhub/templates/devhub/addons/owner.html:86
-#: src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:45
-#: src/olympia/devhub/templates/devhub/versions/list.html:349
-#: src/olympia/devhub/templates/devhub/versions/list.html:351
-#: src/olympia/templates/impala/base.html:129
-#: src/olympia/templates/impala/base.html:140
-#: src/olympia/templates/impala/base.html:158
-#: src/olympia/templates/impala/base.html:168
+#: src/olympia/devhub/templates/devhub/addons/ajax_compat_update.html:38 src/olympia/devhub/templates/devhub/addons/owner.html:86 src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:45
+#: src/olympia/devhub/templates/devhub/versions/list.html:349 src/olympia/devhub/templates/devhub/versions/list.html:351 src/olympia/templates/impala/base.html:129
+#: src/olympia/templates/impala/base.html:140 src/olympia/templates/impala/base.html:158 src/olympia/templates/impala/base.html:168
 msgid "Close"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/addons/dashboard.html:43
-#: src/olympia/zadmin/templates/zadmin/index.html:22
+#: src/olympia/devhub/templates/devhub/addons/dashboard.html:43 src/olympia/zadmin/templates/zadmin/index.html:22
 #, python-format
 msgid "%(ago)s by %(user)s"
 msgstr ""
@@ -5105,30 +4350,21 @@ msgstr[1] ""
 msgstr[2] ""
 msgstr[3] ""
 
-#: src/olympia/devhub/templates/devhub/addons/edit.html:3
-#: src/olympia/devhub/templates/devhub/addons/listing/item_actions.html:25
-#: src/olympia/devhub/templates/devhub/addons/listing/item_actions_theme.html:7
-#: src/olympia/devhub/templates/devhub/includes/addons_edit_nav.html:2
-#: src/olympia/devhub/templates/devhub/personas/edit.html:6
-#: src/olympia/editors/templates/editors/themes/single.html:37
+#: src/olympia/devhub/templates/devhub/addons/edit.html:3 src/olympia/devhub/templates/devhub/addons/listing/item_actions.html:25
+#: src/olympia/devhub/templates/devhub/addons/listing/item_actions_theme.html:7 src/olympia/devhub/templates/devhub/includes/addons_edit_nav.html:2
+#: src/olympia/devhub/templates/devhub/personas/edit.html:6 src/olympia/editors/templates/editors/themes/single.html:37
 msgid "Edit Listing"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/addons/edit.html:13
-#: src/olympia/devhub/templates/devhub/includes/macros.html:18
-#: src/olympia/translations/templates/translations/all-locales.html:6
+#: src/olympia/devhub/templates/devhub/addons/edit.html:13 src/olympia/devhub/templates/devhub/includes/macros.html:18 src/olympia/translations/templates/translations/all-locales.html:6
 msgid "None"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/addons/owner.html:4
-#: src/olympia/devhub/templates/devhub/addons/listing/item_actions.html:52
-#: src/olympia/devhub/templates/devhub/includes/addons_edit_nav.html:3
+#: src/olympia/devhub/templates/devhub/addons/owner.html:4 src/olympia/devhub/templates/devhub/addons/listing/item_actions.html:52 src/olympia/devhub/templates/devhub/includes/addons_edit_nav.html:3
 msgid "Manage Authors & License"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/addons/owner.html:29
-#: src/olympia/editors/helpers.py:362
-#: src/olympia/editors/templates/editors/review.html:270
+#: src/olympia/devhub/templates/devhub/addons/owner.html:29 src/olympia/editors/helpers.py:362 src/olympia/editors/templates/editors/review.html:270
 msgid "Authors"
 msgstr ""
 
@@ -5138,25 +4374,18 @@ msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/owner.html:78
 msgid ""
-"<p>Add-ons can have any number of authors with 3 possible roles:</p> <ul> "
-"<li><b>Owner:</b> Can manage all aspects of the add-on's listing, including "
-"adding and removing other authors</li> <li><b>Developer:</b> Can manage all "
-"aspects of the add-on's listing, except for adding and removing other "
-"authors and managing payments</li> <li><b>Viewer:</b> Can view the add-on's "
-"settings and statistics, but cannot make any changes</li> </ul>"
+"<p>Add-ons can have any number of authors with 3 possible roles:</p> <ul> <li><b>Owner:</b> Can manage all aspects of the add-on's listing, including adding and removing other authors</li> "
+"<li><b>Developer:</b> Can manage all aspects of the add-on's listing, except for adding and removing other authors and managing payments</li> <li><b>Viewer:</b> Can view the add-on's settings and "
+"statistics, but cannot make any changes</li> </ul>"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/addons/profile.html:3
-#: src/olympia/devhub/templates/devhub/addons/listing/item_actions.html:53
-#: src/olympia/devhub/templates/devhub/includes/addons_edit_nav.html:4
+#: src/olympia/devhub/templates/devhub/addons/profile.html:3 src/olympia/devhub/templates/devhub/addons/listing/item_actions.html:53 src/olympia/devhub/templates/devhub/includes/addons_edit_nav.html:4
 msgid "Manage Developer Profile"
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/profile.html:16
 #, python-format
-msgid ""
-"Your <a href=\"%(url)s\">developer profile</a> is currently "
-"<strong>public</strong> and <strong>required</strong> for contributions."
+msgid "Your <a href=\"%(url)s\">developer profile</a> is currently <strong>public</strong> and <strong>required</strong> for contributions."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/profile.html:22
@@ -5165,9 +4394,7 @@ msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/profile.html:27
 #, python-format
-msgid ""
-"Your <a href=\"%(url)s\">developer profile</a> is currently "
-"<strong>public</strong>."
+msgid "Your <a href=\"%(url)s\">developer profile</a> is currently <strong>public</strong>."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/profile.html:33
@@ -5195,11 +4422,8 @@ msgstr ""
 msgid "Choose a short, unique URL slug for your add-on."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/addons/edit/basic.html:43
-#: src/olympia/devhub/templates/devhub/includes/addons_edit_nav.html:35
-#: src/olympia/devhub/templates/devhub/personas/edit.html:56
-#: src/olympia/editors/templates/editors/review.html:255
-#: src/olympia/editors/templates/editors/themes/single.html:33
+#: src/olympia/devhub/templates/devhub/addons/edit/basic.html:43 src/olympia/devhub/templates/devhub/includes/addons_edit_nav.html:35 src/olympia/devhub/templates/devhub/personas/edit.html:56
+#: src/olympia/editors/templates/editors/review.html:255 src/olympia/editors/templates/editors/themes/single.html:33
 msgid "View Listing"
 msgstr ""
 
@@ -5209,36 +4433,24 @@ msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/basic.html:52
 msgid ""
-"A short explanation of your add-on's basic functionality that is displayed "
-"in search and browse listings, as well as at the top of your add-on's "
-"details page. It is only relevant for listed add-ons."
+"A short explanation of your add-on's basic functionality that is displayed in search and browse listings, as well as at the top of your add-on's details page. It is only relevant for listed add-ons."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/basic.html:73
-msgid ""
-"Categories are the primary way users browse through add-ons. Choose any that"
-" fit your add-on's functionality for the most exposure. It is only relevant "
-"for listed add-ons."
+msgid "Categories are the primary way users browse through add-ons. Choose any that fit your add-on's functionality for the most exposure. It is only relevant for listed add-ons."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/basic.html:90
 #, python-format
 msgid ""
-"Categories cannot be changed while your add-on is featured for this "
-"application. Please email <a href=\"mailto:%(email)s\">%(email)s</a> if "
-"there is a reason you need to modify your categories."
+"Categories cannot be changed while your add-on is featured for this application. Please email <a href=\"mailto:%(email)s\">%(email)s</a> if there is a reason you need to modify your categories."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/basic.html:119
-msgid ""
-"Tags help users find your add-on and should be short descriptors such as "
-"tabs, toolbar, or twitter. You may have a maximum of {0} tags. It is only "
-"relevant for listed add-ons."
+msgid "Tags help users find your add-on and should be short descriptors such as tabs, toolbar, or twitter. You may have a maximum of {0} tags. It is only relevant for listed add-ons."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/addons/edit/basic.html:129
-#: src/olympia/devhub/templates/devhub/personas/edit.html:97
-#: src/olympia/devhub/templates/devhub/personas/submit.html:46
+#: src/olympia/devhub/templates/devhub/addons/edit/basic.html:129 src/olympia/devhub/templates/devhub/personas/edit.html:97 src/olympia/devhub/templates/devhub/personas/submit.html:46
 msgid "Comma-separated, minimum of {0} character."
 msgid_plural "Comma-separated, minimum of {0} characters."
 msgstr[0] ""
@@ -5246,9 +4458,7 @@ msgstr[1] ""
 msgstr[2] ""
 msgstr[3] ""
 
-#: src/olympia/devhub/templates/devhub/addons/edit/basic.html:132
-#: src/olympia/devhub/templates/devhub/personas/edit.html:100
-#: src/olympia/devhub/templates/devhub/personas/submit.html:49
+#: src/olympia/devhub/templates/devhub/addons/edit/basic.html:132 src/olympia/devhub/templates/devhub/personas/edit.html:100 src/olympia/devhub/templates/devhub/personas/submit.html:49
 msgid "Example: dark, cinema, noir. Limit 20."
 msgstr ""
 
@@ -5269,37 +4479,26 @@ msgid "Add-on Details for {0}"
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/details.html:22
-msgid ""
-"A longer explanation of features, functionality, and other relevant "
-"information. This field is only displayed on the add-on's details page. It "
-"is only relevant for listed add-ons."
+msgid "A longer explanation of features, functionality, and other relevant information. This field is only displayed on the add-on's details page. It is only relevant for listed add-ons."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/addons/edit/details.html:44
-#: src/olympia/translations/templates/translations/trans-menu.html:13
+#: src/olympia/devhub/templates/devhub/addons/edit/details.html:44 src/olympia/translations/templates/translations/trans-menu.html:13
 msgid "Default Locale"
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/details.html:45
-msgid ""
-"Information about your add-on is displayed in this locale unless you "
-"override it with a locale-specific translation. It is only relevant for "
-"listed add-ons."
+msgid "Information about your add-on is displayed in this locale unless you override it with a locale-specific translation. It is only relevant for listed add-ons."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/addons/edit/details.html:61
-#: src/olympia/users/forms.py:311
-#: src/olympia/users/templates/users/edit.html:122
-#: src/olympia/users/templates/users/register.html:57
+#: src/olympia/devhub/templates/devhub/addons/edit/details.html:61 src/olympia/users/forms.py:311 src/olympia/users/templates/users/edit.html:122 src/olympia/users/templates/users/register.html:57
 #: src/olympia/users/templates/users/vcard.html:22
 msgid "Homepage"
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/details.html:63
 msgid ""
-"If your add-on has another homepage, enter its address here. If your website"
-" is localized into other languages multiple translations of this field can "
-"be added. It is only relevant for listed add-ons."
+"If your add-on has another homepage, enter its address here. If your website is localized into other languages multiple translations of this field can be added. It is only relevant for listed add-"
+"ons."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/media.html:3
@@ -5317,17 +4516,14 @@ msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/support.html:22
 msgid ""
-"If you wish to display an e-mail address for support inquiries, enter it "
-"here. If you have different addresses for each language multiple "
-"translations of this field can be added. It is only relevant for listed add-"
-"ons."
+"If you wish to display an e-mail address for support inquiries, enter it here. If you have different addresses for each language multiple translations of this field can be added. It is only "
+"relevant for listed add-ons."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/support.html:45
 msgid ""
-"If your add-on has a support website or forum, enter its address here. If "
-"your website is localized into other languages, multiple translations of "
-"this field can be added. It is only relevant for listed add-ons."
+"If your add-on has a support website or forum, enter its address here. If your website is localized into other languages, multiple translations of this field can be added. It is only relevant for "
+"listed add-ons."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:6
@@ -5341,10 +4537,8 @@ msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:23
 msgid ""
-"Any information end users may want to know that isn't necessarily applicable"
-" to the add-on summary or description. Common uses include listing known "
-"major bugs, information on how to report bugs, anticipated release date of a"
-" new version, etc. It is only relevant for listed add-ons."
+"Any information end users may want to know that isn't necessarily applicable to the add-on summary or description. Common uses include listing known major bugs, information on how to report bugs, "
+"anticipated release date of a new version, etc. It is only relevant for listed add-ons."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:46
@@ -5356,9 +4550,7 @@ msgid "Add-on Flags"
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:69
-msgid ""
-"These flags are used to classify add-ons. It is only relevant for listed "
-"add-ons."
+msgid "These flags are used to classify add-ons. It is only relevant for listed add-ons."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:74
@@ -5374,9 +4566,7 @@ msgid "View Source?"
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:90
-msgid ""
-"Whether the source of your add-on can be displayed in our online viewer. It "
-"is only relevant for listed add-ons."
+msgid "Whether the source of your add-on can be displayed in our online viewer. It is only relevant for listed add-ons."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:94
@@ -5392,9 +4582,7 @@ msgid "Public Stats?"
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:102
-msgid ""
-"Whether the download and usage stats of your add-on can be displayed in our "
-"online viewer. It is only relevant for listed add-ons."
+msgid "Whether the download and usage stats of your add-on can be displayed in our online viewer. It is only relevant for listed add-ons."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:107
@@ -5410,15 +4598,11 @@ msgid "Upgrade SDK?"
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:116
-msgid ""
-"If selected, we will try to automatically upgrade your add-on when a new "
-"version of the SDK is released. It is only relevant for listed add-ons."
+msgid "If selected, we will try to automatically upgrade your add-on when a new version of the SDK is released. It is only relevant for listed add-ons."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:121
-msgid ""
-"This add-on will be automatically upgraded to new versions of the Add-on "
-"SDK."
+msgid "This add-on will be automatically upgraded to new versions of the Add-on SDK."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:123
@@ -5434,22 +4618,17 @@ msgid "UUID"
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:132
-msgid ""
-"The UUID of your add-on is specified in its install manifest and uniquely "
-"identifies it. You cannot change your UUID once it has been submitted."
+msgid "The UUID of your add-on is specified in its install manifest and uniquely identifies it. You cannot change your UUID once it has been submitted."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/addons/edit/technical.html:143
-#: src/olympia/devhub/templates/devhub/addons/edit/technical.html:144
+#: src/olympia/devhub/templates/devhub/addons/edit/technical.html:143 src/olympia/devhub/templates/devhub/addons/edit/technical.html:144
 msgid "Whiteboard"
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:146
 msgid ""
-"The whiteboard is the place to provide information relevant to your addon, "
-"whatever the version, to the editor. Use it to provide ways to test the "
-"addon, and any additional information that may help. This whiteboard is also"
-" editable by editors."
+"The whiteboard is the place to provide information relevant to your addon, whatever the version, to the editor. Use it to provide ways to test the addon, and any additional information that may "
+"help. This whiteboard is also editable by editors."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/technical_dependencies.html:9
@@ -5470,10 +4649,8 @@ msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/forms_shared/media.html:16
 msgid ""
-"Upload an icon for your add-on or choose from one of ours. The icon is "
-"displayed nearly everywhere your add-on is. Uploaded images must be one of "
-"the following image types: .png, .jpg. It is only relevant for listed add-"
-"ons."
+"Upload an icon for your add-on or choose from one of ours. The icon is displayed nearly everywhere your add-on is. Uploaded images must be one of the following image types: .png, .jpg. It is only "
+"relevant for listed add-ons."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/forms_shared/media.html:25
@@ -5526,60 +4703,49 @@ msgstr ""
 msgid "Tests"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/addons/includes/validation_compat_test_results.html:25
-#: src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:5
+#: src/olympia/devhub/templates/devhub/addons/includes/validation_compat_test_results.html:25 src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:5
 #: src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:53
 msgid "General Tests"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/addons/includes/validation_compat_test_results.html:32
-#: src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:9
+#: src/olympia/devhub/templates/devhub/addons/includes/validation_compat_test_results.html:32 src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:9
 #: src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:67
 msgid "Security Tests"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/addons/includes/validation_compat_test_results.html:39
-#: src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:13
+#: src/olympia/devhub/templates/devhub/addons/includes/validation_compat_test_results.html:39 src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:13
 #: src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:80
 msgid "Extension Tests"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/addons/includes/validation_compat_test_results.html:46
-#: src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:17
+#: src/olympia/devhub/templates/devhub/addons/includes/validation_compat_test_results.html:46 src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:17
 #: src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:93
 msgid "Localization Tests"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:21
-#: src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:106
+#: src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:21 src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:106
 msgid "Compatibility Tests"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:29
-#: src/olympia/files/templates/files/viewer.html:142
+#: src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:29 src/olympia/files/templates/files/viewer.html:142
 msgid "Hide messages not required for automated signing"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:35
-#: src/olympia/files/templates/files/viewer.html:150
+#: src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:35 src/olympia/files/templates/files/viewer.html:150
 msgid "Hide messages present in previous version and ignored"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:50
-#: src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:64
-#: src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:77
-#: src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:90
+#: src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:50 src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:64
+#: src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:77 src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:90
 #: src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:103
 msgid "Top"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:2
-#: src/olympia/devhub/templates/devhub/personas/edit.html:63
+#: src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:2 src/olympia/devhub/templates/devhub/personas/edit.html:63
 msgid "Delete Theme"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:2
-#: src/olympia/devhub/templates/devhub/versions/list.html:117
+#: src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:2 src/olympia/devhub/templates/devhub/versions/list.html:117
 msgid "Delete Add-on"
 msgstr ""
 
@@ -5588,9 +4754,7 @@ msgid "Deleting your theme will permanently remove it from the site."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:14
-msgid ""
-"Deleting your add-on will permanently remove it from the site and prevent "
-"its GUID from being submitted again by others."
+msgid "Deleting your add-on will permanently remove it from the site and prevent its GUID from being submitted again by others."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:24
@@ -5605,8 +4769,7 @@ msgstr ""
 msgid "Please tell us why you are deleting your add-on:"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/addons/listing/item_actions.html:1
-#: src/olympia/devhub/templates/devhub/addons/listing/item_actions_theme.html:1
+#: src/olympia/devhub/templates/devhub/addons/listing/item_actions.html:1 src/olympia/devhub/templates/devhub/addons/listing/item_actions_theme.html:1
 #: src/olympia/editors/templates/editors/review.html:253
 msgid "Actions"
 msgstr ""
@@ -5639,22 +4802,17 @@ msgstr ""
 msgid "Daily statistics on downloads and users."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/addons/listing/item_actions.html:45
-#: src/olympia/stats/templates/stats/stats.html:75
-#: src/olympia/stats/templates/stats/stats.html:79
-#: src/olympia/stats/templates/stats/stats.html:81
+#: src/olympia/devhub/templates/devhub/addons/listing/item_actions.html:45 src/olympia/stats/templates/stats/stats.html:31 src/olympia/stats/templates/stats/stats.html:35
+#: src/olympia/stats/templates/stats/stats.html:37
 msgid "Statistics"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/addons/listing/item_actions.html:54
-#: src/olympia/devhub/templates/devhub/includes/addons_edit_nav.html:5
-#: src/olympia/devhub/templates/devhub/payments/payments.html:3
-#: src/olympia/devhub/templates/devhub/payments/tier.html:4
+#: src/olympia/devhub/templates/devhub/addons/listing/item_actions.html:54 src/olympia/devhub/templates/devhub/includes/addons_edit_nav.html:5
+#: src/olympia/devhub/templates/devhub/payments/payments.html:3 src/olympia/devhub/templates/devhub/payments/tier.html:4
 msgid "Manage Payments"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/addons/listing/item_actions.html:55
-#: src/olympia/devhub/templates/devhub/includes/addons_edit_nav.html:6
+#: src/olympia/devhub/templates/devhub/addons/listing/item_actions.html:55 src/olympia/devhub/templates/devhub/includes/addons_edit_nav.html:6
 msgid "Manage Status & Versions"
 msgstr ""
 
@@ -5662,10 +4820,8 @@ msgstr ""
 msgid "View Add-on Listing"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/addons/listing/item_actions.html:64
-#: src/olympia/devhub/templates/devhub/addons/listing/item_actions_theme.html:12
-#: src/olympia/devhub/templates/devhub/includes/addons_edit_nav.html:37
-#: src/olympia/devhub/templates/devhub/personas/edit.html:58
+#: src/olympia/devhub/templates/devhub/addons/listing/item_actions.html:64 src/olympia/devhub/templates/devhub/addons/listing/item_actions_theme.html:12
+#: src/olympia/devhub/templates/devhub/includes/addons_edit_nav.html:37 src/olympia/devhub/templates/devhub/personas/edit.html:58
 msgid "View Recent Changes"
 msgstr ""
 
@@ -5690,9 +4846,7 @@ msgid "Delete this theme."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/listing/items.html:10
-msgid ""
-"This add-on will be deleted automatically after a few days if the submission"
-" process is not completed."
+msgid "This add-on will be deleted automatically after a few days if the submission process is not completed."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/listing/items.html:27
@@ -5733,9 +4887,7 @@ msgstr ""
 msgid "The detail page will be:"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/addons/submit/describe.html:24
-#: src/olympia/devhub/templates/devhub/personas/edit.html:89
-#: src/olympia/devhub/templates/devhub/personas/submit.html:38
+#: src/olympia/devhub/templates/devhub/addons/submit/describe.html:24 src/olympia/devhub/templates/devhub/personas/edit.html:89 src/olympia/devhub/templates/devhub/personas/submit.html:38
 msgid "Please use only letters, numbers, underscores, and dashes in your URL."
 msgstr ""
 
@@ -5755,14 +4907,11 @@ msgstr ""
 msgid "The description will appear on the detail page."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/addons/submit/done.html:4
-#: src/olympia/devhub/templates/devhub/personas/submit_done.html:4
+#: src/olympia/devhub/templates/devhub/addons/submit/done.html:4 src/olympia/devhub/templates/devhub/personas/submit_done.html:4
 msgid "Submission Complete"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/addons/submit/done.html:8
-#: src/olympia/devhub/templates/devhub/addons/submit/sidebar.html:13
-#: src/olympia/devhub/templates/devhub/personas/submit_done.html:8
+#: src/olympia/devhub/templates/devhub/addons/submit/done.html:8 src/olympia/devhub/templates/devhub/addons/submit/sidebar.html:13 src/olympia/devhub/templates/devhub/personas/submit_done.html:8
 msgid "You're done!"
 msgstr ""
 
@@ -5775,20 +4924,14 @@ msgid "Your add-on has been submitted to the Full Review queue."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/submit/done.html:18
-msgid ""
-"You'll receive an email once it has been reviewed by an editor. In the "
-"meantime, you and your friends can install it directly from its details "
-"page:"
+msgid "You'll receive an email once it has been reviewed by an editor. In the meantime, you and your friends can install it directly from its details page:"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/addons/submit/done.html:27
-#: src/olympia/devhub/templates/devhub/addons/submit/done.html:77
-#: src/olympia/devhub/templates/devhub/personas/submit_done.html:16
+#: src/olympia/devhub/templates/devhub/addons/submit/done.html:27 src/olympia/devhub/templates/devhub/addons/submit/done.html:77 src/olympia/devhub/templates/devhub/personas/submit_done.html:16
 msgid "Next steps:"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/addons/submit/done.html:32
-#: src/olympia/devhub/templates/devhub/addons/submit/done.html:82
+#: src/olympia/devhub/templates/devhub/addons/submit/done.html:32 src/olympia/devhub/templates/devhub/addons/submit/done.html:82
 msgid "<a href=\"{0}\">Upload</a> another platform-specific file to this version."
 msgstr ""
 
@@ -5797,19 +4940,14 @@ msgid "Provide more details by <a href=\"{0}\">editing its listing</a>."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/submit/done.html:35
-msgid ""
-"Tell your users why you created this in your <a href=\"{0}\">Developer "
-"Profile</a>."
+msgid "Tell your users why you created this in your <a href=\"{0}\">Developer Profile</a>."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/submit/done.html:36
-msgid ""
-"View and subscribe to your add-on's <a href=\"{0}\">activity feed</a> to "
-"stay updated on reviews, collections, and more."
+msgid "View and subscribe to your add-on's <a href=\"{0}\">activity feed</a> to stay updated on reviews, collections, and more."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/addons/submit/done.html:37
-#: src/olympia/devhub/templates/devhub/addons/submit/done.html:86
+#: src/olympia/devhub/templates/devhub/addons/submit/done.html:37 src/olympia/devhub/templates/devhub/addons/submit/done.html:86
 msgid "View approximate review queue <a href=\"{0}\">wait times</a>."
 msgstr ""
 
@@ -5822,13 +4960,11 @@ msgid "Become an AMO Reviewer today and get your add-ons reviewed faster."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/submit/done.html:54
-msgid ""
-"Your add-on has been signed and it's ready to use. You can download it here:"
+msgid "Your add-on has been signed and it's ready to use. You can download it here:"
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/submit/done.html:64
-msgid ""
-"Your add-on has been submitted to the Unlisted Preliminary Review queue."
+msgid "Your add-on has been submitted to the Unlisted Preliminary Review queue."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/submit/done.html:66
@@ -5836,8 +4972,7 @@ msgid "Your add-on has been submitted to the Unlisted Full Review queue."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/submit/done.html:70
-msgid ""
-"You'll receive an email once it has been reviewed by an editor and signed."
+msgid "You'll receive an email once it has been reviewed by an editor and signed."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/submit/done.html:74
@@ -5845,9 +4980,7 @@ msgid "Your add-on will not be publicly available on this website."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/submit/done.html:84
-msgid ""
-"You can upload new versions of your add-on in the <a href=\"{0}\">add-on's "
-"developer page</a>."
+msgid "You can upload new versions of your add-on in the <a href=\"{0}\">add-on's developer page</a>."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/submit/license.html:4
@@ -5859,10 +4992,7 @@ msgid "Step 5. Select a License"
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/submit/license.html:9
-msgid ""
-"We require all add-ons to indicate the terms under which their source code "
-"is licensed. Please select a license from the list below or enter a custom "
-"license."
+msgid "We require all add-ons to indicate the terms under which their source code is licensed. Please select a license from the list below or enter a custom license."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/submit/license.html:18
@@ -5879,9 +5009,8 @@ msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/submit/media.html:9
 msgid ""
-"Custom icons and screenshots draw attention and help users understand what "
-"it does. We strongly recommend uploading a custom icon, as in some areas of "
-"the website, only the icon and name will appear."
+"Custom icons and screenshots draw attention and help users understand what it does. We strongly recommend uploading a custom icon, as in some areas of the website, only the icon and name will "
+"appear."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/submit/select-review.html:5
@@ -5894,17 +5023,13 @@ msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/submit/select-review.html:10
 msgid ""
-"All add-ons hosted in our gallery must be reviewed by an editor before they "
-"appear in categories or search results. While waiting for review, your add-"
-"on can still be accessed through its direct URL. Please choose the review "
-"process below that best fits your add-on."
+"All add-ons hosted in our gallery must be reviewed by an editor before they appear in categories or search results. While waiting for review, your add-on can still be accessed through its direct "
+"URL. Please choose the review process below that best fits your add-on."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/submit/select-review.html:26
 #, python-format
-msgid ""
-"A complete review of your add-on's source and functionality. <a "
-"href=\"%(url)s\">Learn more&hellip;</a>"
+msgid "A complete review of your add-on's source and functionality. <a href=\"%(url)s\">Learn more&hellip;</a>"
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/submit/select-review.html:32
@@ -5933,9 +5058,7 @@ msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/submit/select-review.html:49
 #, python-format
-msgid ""
-"A faster review of your add-on's source for any major problems. <a "
-"href=\"%(url)s\">Learn more&hellip;</a>"
+msgid "A faster review of your add-on's source for any major problems. <a href=\"%(url)s\">Learn more&hellip;</a>"
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/submit/select-review.html:55
@@ -5982,10 +5105,8 @@ msgstr ""
 msgid "Select a review process"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/addons/submit/sidebar.html:18
-#: src/olympia/devhub/templates/devhub/docs/policies-submission.html:3
-#: src/olympia/devhub/templates/devhub/docs/policies-submission.html:7
-#: src/olympia/devhub/templates/devhub/docs/policies-submission.html:9
+#: src/olympia/devhub/templates/devhub/addons/submit/sidebar.html:18 src/olympia/devhub/templates/devhub/docs/policies-submission.html:3
+#: src/olympia/devhub/templates/devhub/docs/policies-submission.html:7 src/olympia/devhub/templates/devhub/docs/policies-submission.html:9
 msgid "Submission Process"
 msgstr ""
 
@@ -6006,24 +5127,18 @@ msgid "Step 2. Upload Your Add-on"
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/submit/upload.html:11
-msgid ""
-"Use the fields below to upload your add-on package and select any platform "
-"restrictions. After upload, a series of automated validation tests will be "
-"run on your file."
+msgid "Use the fields below to upload your add-on package and select any platform restrictions. After upload, a series of automated validation tests will be run on your file."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/addons/submit/upload.html:45
-#: src/olympia/devhub/templates/devhub/versions/add_file_modal.html:27
+#: src/olympia/devhub/templates/devhub/addons/submit/upload.html:51 src/olympia/devhub/templates/devhub/versions/add_file_modal.html:28
 msgid "Which platforms is this file compatible with?"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/addons/submit/upload.html:53
-#: src/olympia/devhub/templates/devhub/versions/add_file_modal.html:44
+#: src/olympia/devhub/templates/devhub/addons/submit/upload.html:59 src/olympia/devhub/templates/devhub/versions/add_file_modal.html:45
 msgid "Administrative overrides"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/api/agreement.html:3
-#: src/olympia/devhub/templates/devhub/api/agreement.html:11
+#: src/olympia/devhub/templates/devhub/api/agreement.html:3 src/olympia/devhub/templates/devhub/api/agreement.html:11
 msgid "Firefox Add-on Distribution Agreement"
 msgstr ""
 
@@ -6033,9 +5148,7 @@ msgstr ""
 
 #: src/olympia/devhub/templates/devhub/api/key.html:20
 #, python-format
-msgid ""
-"For detailed instructions, consult the <a href=\"%(docs_url)s\">API "
-"documentation</a>."
+msgid "For detailed instructions, consult the <a href=\"%(docs_url)s\">API documentation</a>."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/api/key.html:28
@@ -6049,10 +5162,8 @@ msgstr ""
 #: src/olympia/devhub/templates/devhub/api/key.html:37
 #, python-format
 msgid ""
-"To make API requests, send a <a href=\"%(jwt_url)s\">JSON Web Token "
-"(JWT)</a> as the authorization header. You'll need to generate a JWT for "
-"every request as explained in the <a href=\"%(docs_url)s\">API "
-"documentation</a>."
+"To make API requests, send a <a href=\"%(jwt_url)s\">JSON Web Token (JWT)</a> as the authorization header. You'll need to generate a JWT for every request as explained in the <a href=\"%(docs_url)s"
+"\">API documentation</a>."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/api/key.html:47
@@ -6061,9 +5172,7 @@ msgstr ""
 
 #: src/olympia/devhub/templates/devhub/api/key.html:53
 #, python-format
-msgid ""
-"This feature is under active development. If you find a problem please <a "
-"target=\"_blank\" href=\"%(bug_link)s\">report a bug</a>."
+msgid "This feature is under active development. If you find a problem please <a target=\"_blank\" href=\"%(bug_link)s\">report a bug</a>."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/api/key.html:61
@@ -6074,26 +5183,18 @@ msgstr ""
 msgid "Generate new credentials"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/docs/policies-agreement.html:3
-#: src/olympia/devhub/templates/devhub/docs/policies-agreement.html:7
-#: src/olympia/devhub/templates/devhub/docs/policies-agreement.html:9
-#: src/olympia/devhub/templates/devhub/docs/policies.html:24
-#: src/olympia/devhub/templates/devhub/docs/policies.html:103
+#: src/olympia/devhub/templates/devhub/docs/policies-agreement.html:3 src/olympia/devhub/templates/devhub/docs/policies-agreement.html:7
+#: src/olympia/devhub/templates/devhub/docs/policies-agreement.html:9 src/olympia/devhub/templates/devhub/docs/policies.html:24 src/olympia/devhub/templates/devhub/docs/policies.html:103
 msgid "Developer Agreement"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/docs/policies-contact.html:3
-#: src/olympia/devhub/templates/devhub/docs/policies-contact.html:7
-#: src/olympia/devhub/templates/devhub/docs/policies-contact.html:9
-#: src/olympia/devhub/templates/devhub/docs/policies.html:27
-#: src/olympia/devhub/templates/devhub/docs/policies.html:115
+#: src/olympia/devhub/templates/devhub/docs/policies-contact.html:3 src/olympia/devhub/templates/devhub/docs/policies-contact.html:7 src/olympia/devhub/templates/devhub/docs/policies-contact.html:9
+#: src/olympia/devhub/templates/devhub/docs/policies.html:27 src/olympia/devhub/templates/devhub/docs/policies.html:115
 msgid "Contacting Us"
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/docs/policies-contact.html:12
-msgid ""
-"Thanks for your interest in contacting the Mozilla Add-ons team. Please read"
-" this page carefully to ensure your request goes to the right place."
+msgid "Thanks for your interest in contacting the Mozilla Add-ons team. Please read this page carefully to ensure your request goes to the right place."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/docs/policies-contact.html:17
@@ -6102,10 +5203,8 @@ msgstr ""
 
 #: src/olympia/devhub/templates/devhub/docs/policies-contact.html:19
 msgid ""
-"If you have a support question about a particular add-on, such as \"how do I"
-" use this add-on?\" or \"why doesn't this work properly?\", please contact "
-"that add-on's author through the support channels listed on the add-on's "
-"listing page."
+"If you have a support question about a particular add-on, such as \"how do I use this add-on?\" or \"why doesn't this work properly?\", please contact that add-on's author through the support "
+"channels listed on the add-on's listing page."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/docs/policies-contact.html:24
@@ -6119,11 +5218,8 @@ msgstr ""
 #: src/olympia/devhub/templates/devhub/docs/policies-contact.html:26
 #, python-format
 msgid ""
-"If you have a question about an Editor's review of an add-on or want to "
-"report a policy violation, please email %(mail_editors)s. <strong>Almost all"
-" add-on reports fall under this category.</strong> Please be sure to include"
-" a link to the add-on in question and a detailed description of your "
-"question or comment."
+"If you have a question about an Editor's review of an add-on or want to report a policy violation, please email %(mail_editors)s. <strong>Almost all add-on reports fall under this category.</"
+"strong> Please be sure to include a link to the add-on in question and a detailed description of your question or comment."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/docs/policies-contact.html:31
@@ -6137,13 +5233,9 @@ msgstr ""
 #: src/olympia/devhub/templates/devhub/docs/policies-contact.html:36
 #, python-format
 msgid ""
-"If you have discovered a security vulnerability in an add-on, even if it is "
-"not hosted here, Mozilla is very interested in your discovery and will work "
-"with the add-on developer to correct the issue as soon as possible. Add-on "
-"security issues can be reported <a "
-"href=\"http://www.mozilla.org/projects/security/security-bugs-"
-"policy.html\">confidentially</a> in <a "
-"href=\"%(link_bugzilla)s\">Bugzilla</a> or by emailing %(mail_admins)s."
+"If you have discovered a security vulnerability in an add-on, even if it is not hosted here, Mozilla is very interested in your discovery and will work with the add-on developer to correct the "
+"issue as soon as possible. Add-on security issues can be reported <a href=\"http://www.mozilla.org/projects/security/security-bugs-policy.html\">confidentially</a> in <a href=\"%(link_bugzilla)s"
+"\">Bugzilla</a> or by emailing %(mail_admins)s."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/docs/policies-contact.html:42
@@ -6152,13 +5244,11 @@ msgstr ""
 
 #: src/olympia/devhub/templates/devhub/docs/policies-contact.html:44
 msgid ""
-"If you've found a problem with the site, we'd love to fix it. Please <a "
-"href=\"https://github.com/mozilla/addons/issues/new\">file a bug report</a> "
-"in GitHub, including the location of the problem and how you encountered it."
+"If you've found a problem with the site, we'd love to fix it. Please <a href=\"https://github.com/mozilla/addons/issues/new\">file a bug report</a> in GitHub, including the location of the problem "
+"and how you encountered it."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/docs/policies-maintenance.html:3
-#: src/olympia/devhub/templates/devhub/docs/policies-maintenance.html:7
+#: src/olympia/devhub/templates/devhub/docs/policies-maintenance.html:3 src/olympia/devhub/templates/devhub/docs/policies-maintenance.html:7
 #: src/olympia/devhub/templates/devhub/docs/policies-maintenance.html:8
 msgid "Maintaining Your Add-ons"
 msgstr ""
@@ -6169,20 +5259,13 @@ msgstr ""
 
 #: src/olympia/devhub/templates/devhub/docs/policies-maintenance.html:12
 msgid ""
-"Developers are encouraged to submit updates to their add-ons to fix bugs, "
-"add features, and otherwise improve their product. New versions of an add-on"
-" must have a <a "
-"href=\"https://developer.mozilla.org/en/Toolkit_version_format\">higher "
-"version number</a> and can be submitted through the Developer Tools "
-"provided. There is no limit to the number of versions that can be submitted,"
-" but please remember that versions must be reviewed by an editor."
+"Developers are encouraged to submit updates to their add-ons to fix bugs, add features, and otherwise improve their product. New versions of an add-on must have a <a href=\"https://developer."
+"mozilla.org/en/Toolkit_version_format\">higher version number</a> and can be submitted through the Developer Tools provided. There is no limit to the number of versions that can be submitted, but "
+"please remember that versions must be reviewed by an editor."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/docs/policies-maintenance.html:18
-msgid ""
-"New versions will be added to a pending review queue, and any additional "
-"versions submitted before the review is completed will move that version to "
-"the end of the queue."
+msgid "New versions will be added to a pending review queue, and any additional versions submitted before the review is completed will move that version to the end of the queue."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/docs/policies-maintenance.html:23
@@ -6195,31 +5278,22 @@ msgstr ""
 
 #: src/olympia/devhub/templates/devhub/docs/policies-maintenance.html:31
 msgid ""
-"To create a beta channel, upload a file with a unique version string that "
-"contains any of the following strings: <code>a,b,alpha,beta,pre,rc</code>, "
-"with an optional number at the end. This text must come at the end of the "
-"version string. If you understand regex format, here's what we look for in "
-"the version number: <code>\"(a|alpha|b|beta|pre|rc)\\d*$\"</code>."
+"To create a beta channel, upload a file with a unique version string that contains any of the following strings: <code>a,b,alpha,beta,pre,rc</code>, with an optional number at the end. This text "
+"must come at the end of the version string. If you understand regex format, here's what we look for in the version number: <code>\"(a|alpha|b|beta|pre|rc)\\d*$\"</code>."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/docs/policies-maintenance.html:37
 msgid ""
-"Once a file meeting this criteria is uploaded to AMO, it will automatically "
-"be marked as a beta version. Users of add-ons with these unique version "
-"numbers will automatically be served the newest beta updates."
+"Once a file meeting this criteria is uploaded to AMO, it will automatically be marked as a beta version. Users of add-ons with these unique version numbers will automatically be served the newest "
+"beta updates."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/docs/policies-maintenance.html:43
 msgid ""
-"While we call these \"Beta versions\", you can use this channel for "
-"nightlies, or alphas, or prerelease versions as you wish. Please note that "
-"there is only one channel for this purpose and all of your users on this "
-"channel will receive the latest add-ons submitted. For instance, if you "
-"upload <code>1.0beta1</code> to the release channel and then upload "
-"<code>1.1alpha1</code>, all users of <code>1.0beta1</code> will be offered "
-"an upgrade to <code>1.1alpha1</code>. Updates are pushed by submission date "
-"and not version number, so users will always get the most recent channel "
-"update regardless of any kind of alphabetical sorting."
+"While we call these \"Beta versions\", you can use this channel for nightlies, or alphas, or prerelease versions as you wish. Please note that there is only one channel for this purpose and all of "
+"your users on this channel will receive the latest add-ons submitted. For instance, if you upload <code>1.0beta1</code> to the release channel and then upload <code>1.1alpha1</code>, all users of "
+"<code>1.0beta1</code> will be offered an upgrade to <code>1.1alpha1</code>. Updates are pushed by submission date and not version number, so users will always get the most recent channel update "
+"regardless of any kind of alphabetical sorting."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/docs/policies-maintenance.html:48
@@ -6228,13 +5302,9 @@ msgstr ""
 
 #: src/olympia/devhub/templates/devhub/docs/policies-maintenance.html:50
 msgid ""
-"Certain situations may arise in which Mozilla requests that an add-on "
-"developer update their add-on within a given time period to address a major "
-"security issue or policy violation. We work with developers to reasonably "
-"accommodate their own schedules, but if the issue is of a serious enough "
-"nature, add-ons that cannot issue an update with the requested fix may be "
-"demoted from fully-reviewed status, disabled, or permanently removed from "
-"the site."
+"Certain situations may arise in which Mozilla requests that an add-on developer update their add-on within a given time period to address a major security issue or policy violation. We work with "
+"developers to reasonably accommodate their own schedules, but if the issue is of a serious enough nature, add-ons that cannot issue an update with the requested fix may be demoted from fully-"
+"reviewed status, disabled, or permanently removed from the site."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/docs/policies-maintenance.html:55
@@ -6243,43 +5313,32 @@ msgstr ""
 
 #: src/olympia/devhub/templates/devhub/docs/policies-maintenance.html:57
 msgid ""
-"Add-ons can have multiple users with permission to update and manage the "
-"listing. Existing authors of an add-on can transfer ownership and add "
-"additional developers to an add-on's listing through the Developer Tools "
-"provided. No interaction with Mozilla representatives is necessary for a "
-"transfer of ownership."
+"Add-ons can have multiple users with permission to update and manage the listing. Existing authors of an add-on can transfer ownership and add additional developers to an add-on's listing through "
+"the Developer Tools provided. No interaction with Mozilla representatives is necessary for a transfer of ownership."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/docs/policies-maintenance.html:63
 #, python-format
-msgid ""
-"Mozilla can assist with granting additional permissions of an add-on's "
-"listing if <a href=\"%(link_contact)s\">contacted</a> by the add-on's "
-"current owner."
+msgid "Mozilla can assist with granting additional permissions of an add-on's listing if <a href=\"%(link_contact)s\">contacted</a> by the add-on's current owner."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/docs/policies-maintenance.html:70
 msgid ""
-"Mozilla encourages its users to offer feedback on their experiences when "
-"using an add-on. This allows other users to determine if the add-on is "
-"stable and useful. It also provides valuable feedback to developers, "
-"allowing them to continuously improve their add-on to meet user needs."
+"Mozilla encourages its users to offer feedback on their experiences when using an add-on. This allows other users to determine if the add-on is stable and useful. It also provides valuable feedback "
+"to developers, allowing them to continuously improve their add-on to meet user needs."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/docs/policies-maintenance.html:76
 #, python-format
 msgid ""
-"Reviews must follow the <a href=\"%(link_guidelines)s\">review "
-"guidelines</a>. Reviews that do not meet these guidelines may be flagged for"
-" moderation, but negative reviews will not be removed unless they provide "
-"false information."
+"Reviews must follow the <a href=\"%(link_guidelines)s\">review guidelines</a>. Reviews that do not meet these guidelines may be flagged for moderation, but negative reviews will not be removed "
+"unless they provide false information."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/docs/policies-maintenance.html:82
 msgid ""
-"Many developers provide a support mechanism, such as a forum, discussion "
-"group, or email address. It is recommended that support questions be posted "
-"via those mediums instead of in an add-on's review section."
+"Many developers provide a support mechanism, such as a forum, discussion group, or email address. It is recommended that support questions be posted via those mediums instead of in an add-on's "
+"review section."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/docs/policies-maintenance.html:87
@@ -6288,31 +5347,21 @@ msgstr ""
 
 #: src/olympia/devhub/templates/devhub/docs/policies-maintenance.html:90
 msgid ""
-"Many add-ons allow their source code to be openly viewed. This does not mean"
-" that the source code is open source or available for use in another add-on."
-" The original author of an add-on retains copyright of their work unless "
-"otherwise noted in the add-on's license."
+"Many add-ons allow their source code to be openly viewed. This does not mean that the source code is open source or available for use in another add-on. The original author of an add-on retains "
+"copyright of their work unless otherwise noted in the add-on's license."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/docs/policies-maintenance.html:96
 msgid ""
-"In the event that we're notified of a copyright or license infringement, we "
-"will take steps to review the situation and determine if an actual "
-"infringement has occurred. If we determine that there is an infringement, we"
-" will remove the offending add-on and contact the author. New add-on "
-"submissions (including updates) containing infringing code will be denied "
-"approval for public status."
+"In the event that we're notified of a copyright or license infringement, we will take steps to review the situation and determine if an actual infringement has occurred. If we determine that there "
+"is an infringement, we will remove the offending add-on and contact the author. New add-on submissions (including updates) containing infringing code will be denied approval for public status."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/docs/policies-maintenance.html:102
-msgid ""
-"If you are unsure of the current copyright status of an add-on's source "
-"code, you must contact the original author and receive explicit permission "
-"before using the source code."
+msgid "If you are unsure of the current copyright status of an add-on's source code, you must contact the original author and receive explicit permission before using the source code."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/docs/policies-maintenance.html:107
-#: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:306
+#: src/olympia/devhub/templates/devhub/docs/policies-maintenance.html:107 src/olympia/devhub/templates/devhub/docs/policies-reviews.html:306
 #: src/olympia/devhub/templates/devhub/docs/policies-submission.html:97
 msgid "Last updated: January 13, 2011"
 msgstr ""
@@ -6320,25 +5369,18 @@ msgstr ""
 #: src/olympia/devhub/templates/devhub/docs/policies-recommended.html:13
 #, python-format
 msgid ""
-"Featured add-ons are top-quality extensions and themes highlighted on <a "
-"href=\"%(link_gallery)s\">AMO</a>, Firefox's Add-ons Manager, and across "
-"other Mozilla websites. These add-ons showcase the power of Firefox "
-"customization and are useful to a wide audience."
+"Featured add-ons are top-quality extensions and themes highlighted on <a href=\"%(link_gallery)s\">AMO</a>, Firefox's Add-ons Manager, and across other Mozilla websites. These add-ons showcase the "
+"power of Firefox customization and are useful to a wide audience."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/docs/policies-recommended.html:19
 msgid ""
-"Featured add-ons are chosen by the Featured Add-ons Advisory Board, a small "
-"group of add-on developers and fans from the Mozilla community who have "
-"volunteered to review and vote on nominations."
+"Featured add-ons are chosen by the Featured Add-ons Advisory Board, a small group of add-on developers and fans from the Mozilla community who have volunteered to review and vote on nominations."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/docs/policies-recommended.html:25
 #, python-format
-msgid ""
-"<a href=\"%(link_featured)s\">Featured extensions</a> are chosen every "
-"month, and <a href=\"%(link_themes)s\">featured complete themes</a> are "
-"chosen every quarter."
+msgid "<a href=\"%(link_featured)s\">Featured extensions</a> are chosen every month, and <a href=\"%(link_themes)s\">featured complete themes</a> are chosen every quarter."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/docs/policies-recommended.html:30
@@ -6346,14 +5388,11 @@ msgid "Criteria for Featured Add-ons"
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/docs/policies-recommended.html:33
-msgid ""
-"Before nominating an add-on to be featured, please ensure it meets the "
-"following criteria:"
+msgid "Before nominating an add-on to be featured, please ensure it meets the following criteria:"
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/docs/policies-recommended.html:39
-msgid ""
-"The add-on must have a complete and informative listing on AMO. This means:"
+msgid "The add-on must have a complete and informative listing on AMO. This means:"
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/docs/policies-recommended.html:41
@@ -6377,14 +5416,11 @@ msgid "updated screenshots of the add-on's functionality"
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/docs/policies-recommended.html:46
-msgid ""
-"must be fully approved by AMO editors (no preliminarily reviewed entries)"
+msgid "must be fully approved by AMO editors (no preliminarily reviewed entries)"
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/docs/policies-recommended.html:48
-msgid ""
-"The add-on must have excellent user reviews and any problems or support "
-"requests must be promptly addressed by the developer."
+msgid "The add-on must have excellent user reviews and any problems or support requests must be promptly addressed by the developer."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/docs/policies-recommended.html:49
@@ -6392,17 +5428,13 @@ msgid "The add-on must have a minimum of 2,000 users."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/docs/policies-recommended.html:50
-msgid ""
-"The add-on must be compatible with the latest release of Firefox and must be"
-" compatible with beta versions 4 weeks before their final release."
+msgid "The add-on must be compatible with the latest release of Firefox and must be compatible with beta versions 4 weeks before their final release."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/docs/policies-recommended.html:51
 msgid ""
-"<strong>Most importantly</strong>, the add-on must have wide consumer appeal"
-" to Firefox's users and be outstanding in nearly every way: user experience,"
-" performance, security, and usefulness or entertainment value. Featured "
-"complete themes must also be visually appealing."
+"<strong>Most importantly</strong>, the add-on must have wide consumer appeal to Firefox's users and be outstanding in nearly every way: user experience, performance, security, and usefulness or "
+"entertainment value. Featured complete themes must also be visually appealing."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/docs/policies-recommended.html:54
@@ -6415,9 +5447,7 @@ msgstr ""
 
 #: src/olympia/devhub/templates/devhub/docs/policies-recommended.html:57
 #, python-format
-msgid ""
-"If you wish to nominate an add-on to be featured and it meets the criteria "
-"above, send an email to %(mail_featured)s with:"
+msgid "If you wish to nominate an add-on to be featured and it meets the criteria above, send an email to %(mail_featured)s with:"
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/docs/policies-recommended.html:62
@@ -6425,22 +5455,17 @@ msgid "the add-on name, URL, and whether you are its developer"
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/docs/policies-recommended.html:63
-msgid ""
-"a short explanation of why the add-on has wide appeal and should be featured"
+msgid "a short explanation of why the add-on has wide appeal and should be featured"
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/docs/policies-recommended.html:64
-msgid ""
-"optionally, links to any external reviews or articles mentioning the add-on"
+msgid "optionally, links to any external reviews or articles mentioning the add-on"
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/docs/policies-recommended.html:68
 msgid ""
-"Add-on nominations are reviewed by the Advisory Board once a month (once "
-"every 3 months for complete theme nominations). Common reasons for rejection"
-" include lacking wide appeal to consumers, a suboptimal user experience, "
-"quality or security issues, incompatibility, and similarity to another "
-"featured add-on. Rejected add-ons cannot be re-nominated within 3 months."
+"Add-on nominations are reviewed by the Advisory Board once a month (once every 3 months for complete theme nominations). Common reasons for rejection include lacking wide appeal to consumers, a "
+"suboptimal user experience, quality or security issues, incompatibility, and similarity to another featured add-on. Rejected add-ons cannot be re-nominated within 3 months."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/docs/policies-recommended.html:73
@@ -6448,32 +5473,23 @@ msgid "Rotating Featured Add-ons"
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/docs/policies-recommended.html:76
-msgid ""
-"Mozilla and the Featured Add-ons Advisory Board regularly evaluate and "
-"rotate out featured add-ons. Some of the most common reasons for add-ons "
-"being removed from the featured list are:"
+msgid "Mozilla and the Featured Add-ons Advisory Board regularly evaluate and rotate out featured add-ons. Some of the most common reasons for add-ons being removed from the featured list are:"
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/docs/policies-recommended.html:83
 msgid ""
-"Lack of growth &mdash; Add-ons that are featured typically experience a "
-"substantial gain in both downloads and active users. If an add-on is not "
-"demonstrating growth in any substantial way, that's a good indicator the "
-"add-on may not be very useful to our users."
+"Lack of growth &mdash; Add-ons that are featured typically experience a substantial gain in both downloads and active users. If an add-on is not demonstrating growth in any substantial way, that's "
+"a good indicator the add-on may not be very useful to our users."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/docs/policies-recommended.html:88
-msgid ""
-"Negative reviews &mdash; Featured add-ons should have a great experience and"
-" very few bugs, so add-ons with many negative reviews may be reconsidered."
+msgid "Negative reviews &mdash; Featured add-ons should have a great experience and very few bugs, so add-ons with many negative reviews may be reconsidered."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/docs/policies-recommended.html:93
 msgid ""
-"Incompatibility with upcoming Firefox versions &mdash; Featured add-ons are "
-"expected to be compatible with stable and beta versions of Firefox. Add-ons "
-"not yet compatible with a Beta version of Firefox four weeks before its "
-"expected release will lose their featured status."
+"Incompatibility with upcoming Firefox versions &mdash; Featured add-ons are expected to be compatible with stable and beta versions of Firefox. Add-ons not yet compatible with a Beta version of "
+"Firefox four weeks before its expected release will lose their featured status."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/docs/policies-recommended.html:99
@@ -6481,121 +5497,87 @@ msgid "Joining the Featured Add-ons Advisory Board"
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/docs/policies-recommended.html:102
-msgid ""
-"Every six months a new Advisory Board is chosen based on applications from "
-"the add-ons community. Members must:"
+msgid "Every six months a new Advisory Board is chosen based on applications from the add-ons community. Members must:"
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/docs/policies-recommended.html:108
-msgid ""
-"be active members of the add-ons community, whether as a developer, "
-"evangelist, or fan"
+msgid "be active members of the add-ons community, whether as a developer, evangelist, or fan"
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/docs/policies-recommended.html:109
-msgid ""
-"commit to trying all the nominations submitted, giving their feedback, and "
-"casting their votes every month"
+msgid "commit to trying all the nominations submitted, giving their feedback, and casting their votes every month"
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/docs/policies-recommended.html:110
-msgid ""
-"abstain from voting on add-ons that they have any business or personal "
-"affiliations with, as well as direct competitors of any such add-ons"
+msgid "abstain from voting on add-ons that they have any business or personal affiliations with, as well as direct competitors of any such add-ons"
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/docs/policies-recommended.html:114
 msgid ""
-"Members of the Mozilla Add-ons team may veto any add-on's selection because "
-"of security, privacy, compatibility, or any other reason, but in general it "
-"is up to the Board to select add-ons to feature."
+"Members of the Mozilla Add-ons team may veto any add-on's selection because of security, privacy, compatibility, or any other reason, but in general it is up to the Board to select add-ons to "
+"feature."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/docs/policies-recommended.html:120
 msgid ""
-"This featured policy only applies to the addons.mozilla.org global list of "
-"featured add-ons. Add-ons featured in other locations are often pulled from "
-"this list, but Mozilla may feature any add-on in other locations without the"
-" Board's consent. Additionally, locale-specific features override the global"
-" defaults, so if a locale has opted to select its own features, some or all "
-"of the global features may not appear in that locale."
+"This featured policy only applies to the addons.mozilla.org global list of featured add-ons. Add-ons featured in other locations are often pulled from this list, but Mozilla may feature any add-on "
+"in other locations without the Board's consent. Additionally, locale-specific features override the global defaults, so if a locale has opted to select its own features, some or all of the global "
+"features may not appear in that locale."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/docs/policies-recommended.html:126
 #, python-format
-msgid ""
-"Follow the <a href=\"%(link_blog)s\">Add-ons Blog</a> or <a "
-"href=\"%(link_twitter)s\">@mozamo</a> on Twitter to learn when the next "
-"application period opens."
+msgid "Follow the <a href=\"%(link_blog)s\">Add-ons Blog</a> or <a href=\"%(link_twitter)s\">@mozamo</a> on Twitter to learn when the next application period opens."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/docs/policies-recommended.html:131
 msgid "Last updated: January 31, 2013"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:3
-#: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:7
-#: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:8
-#: src/olympia/devhub/templates/devhub/docs/policies.html:15
-#: src/olympia/devhub/templates/devhub/docs/policies.html:64
+#: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:3 src/olympia/devhub/templates/devhub/docs/policies-reviews.html:7 src/olympia/devhub/templates/devhub/docs/policies-reviews.html:8
+#: src/olympia/devhub/templates/devhub/docs/policies.html:15 src/olympia/devhub/templates/devhub/docs/policies.html:64
 msgid "Review Process"
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:12
 msgid ""
-"In order to ensure all add-ons hosted in our gallery are safe for users to "
-"install, Mozilla will begin requiring all hosted add-ons to undergo review. "
-"We offer two types of review and developers are free to choose the best fit "
-"for their add-on."
+"In order to ensure all add-ons hosted in our gallery are safe for users to install, Mozilla will begin requiring all hosted add-ons to undergo review. We offer two types of review and developers "
+"are free to choose the best fit for their add-on."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:19
 msgid ""
-"<strong><a href=\"#full\">Full Review</a></strong> &mdash; a thorough "
-"functional and code review of the add-on, appropriate for add-ons ready for "
-"distribution to the masses. All site features are available to these add-"
-"ons."
+"<strong><a href=\"#full\">Full Review</a></strong> &mdash; a thorough functional and code review of the add-on, appropriate for add-ons ready for distribution to the masses. All site features are "
+"available to these add-ons."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:24
 msgid ""
-"<strong><a href=\"#preliminary\">Preliminary Review</a></strong> &mdash; a "
-"faster review intended for experimental add-ons. Preliminary reviews do not "
-"check for functionality or full policy compliance, but the reviewed add-ons "
-"have install button cautions and some feature limitations."
+"<strong><a href=\"#preliminary\">Preliminary Review</a></strong> &mdash; a faster review intended for experimental add-ons. Preliminary reviews do not check for functionality or full policy "
+"compliance, but the reviewed add-ons have install button cautions and some feature limitations."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:31
 msgid ""
-"Detailed descriptions of each option are below. After selecting a review "
-"process at submission, the add-on will be placed in the queue. Add-ons are "
-"reviewed by the <a href=\"https://wiki.mozilla.org/AMO:Editors\">AMO "
-"Editors</a>, a group of talented developers that volunteer to help the "
-"Mozilla project by reviewing add-ons to ensure a stable and safe experience "
-"for users. Developers will receive an email with any updates throughout the "
-"review process."
+"Detailed descriptions of each option are below. After selecting a review process at submission, the add-on will be placed in the queue. Add-ons are reviewed by the <a href=\"https://wiki.mozilla."
+"org/AMO:Editors\">AMO Editors</a>, a group of talented developers that volunteer to help the Mozilla project by reviewing add-ons to ensure a stable and safe experience for users. Developers will "
+"receive an email with any updates throughout the review process."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:37
 msgid ""
-"While waiting for review, add-ons will not appear anywhere in the gallery "
-"publicly, but direct links to the add-on's details page will work. This "
-"allows the author to blog or share the link with friends, inviting them to "
-"try it out, even when not yet reviewed."
+"While waiting for review, add-ons will not appear anywhere in the gallery publicly, but direct links to the add-on's details page will work. This allows the author to blog or share the link with "
+"friends, inviting them to try it out, even when not yet reviewed."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:44
 msgid ""
-"Full reviews are appropriate for add-ons that are well-tested, stable, fast,"
-" and have wide appeal to our users. If you aren't confident that your add-on"
-" meets that criteria, please consider working out the kinks while in "
-"preliminary review and accumulating user feedback first."
+"Full reviews are appropriate for add-ons that are well-tested, stable, fast, and have wide appeal to our users. If you aren't confident that your add-on meets that criteria, please consider working "
+"out the kinks while in preliminary review and accumulating user feedback first."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:50
-msgid ""
-"We aim to perform full reviews in under 10 days, though most add-ons are "
-"reviewed in much less time."
+msgid "We aim to perform full reviews in under 10 days, though most add-ons are reviewed in much less time."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:55
@@ -6607,15 +5589,11 @@ msgid "When performing a full review, editors will:"
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:64
-msgid ""
-"install the add-on, making sure it functions as described and is free of "
-"major defects"
+msgid "install the add-on, making sure it functions as described and is free of major defects"
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:69
-msgid ""
-"perform a source code review, looking for performance and security best "
-"practices"
+msgid "perform a source code review, looking for performance and security best practices"
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:74
@@ -6623,28 +5601,21 @@ msgid "ensure the add-on's privacy policy is in line with its functionality"
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:79
-msgid ""
-"look for compliance with all of Mozilla's policies, detailed in these "
-"documents"
+msgid "look for compliance with all of Mozilla's policies, detailed in these documents"
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:86
-msgid ""
-"Some of the most common issues we see when performing these reviews are:"
+msgid "Some of the most common issues we see when performing these reviews are:"
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:93
 msgid ""
-"<strong>JavaScript namespace pollution</strong> &mdash; the most common "
-"violation. Be sure to <a "
-"href=\"https://developer.mozilla.org/en/XUL_School/JavaScript_Object_Management\">wrap"
-" your loose variables</a>"
+"<strong>JavaScript namespace pollution</strong> &mdash; the most common violation. Be sure to <a href=\"https://developer.mozilla.org/en/XUL_School/JavaScript_Object_Management\">wrap your loose "
+"variables</a>"
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:99
-msgid ""
-"proper preference naming - all preference names should begin with "
-"\"extensions.\", followed by the add-on name or some other unique identifier"
+msgid "proper preference naming - all preference names should begin with \"extensions.\", followed by the add-on name or some other unique identifier"
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:103
@@ -6690,67 +5661,49 @@ msgstr ""
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:117
 #, python-format
 msgid ""
-"For information on how to avoid these problems, please see our <a "
-"href=\"%(link_howto)s\">How-to Library</a>. Some of these practices, such as"
-" binary or obfuscated code, are allowed under certain conditions outlined "
-"below."
+"For information on how to avoid these problems, please see our <a href=\"%(link_howto)s\">How-to Library</a>. Some of these practices, such as binary or obfuscated code, are allowed under certain "
+"conditions outlined below."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:123
 #, python-format
 msgid ""
-"Many of the above restrictions are tested automatically by an extension "
-"scanner that will flag suspicious add-ons for editor review. You can read "
-"more about this scanner in the <a href=\"%(link_validation)s\">Validation "
-"Help</a> document."
+"Many of the above restrictions are tested automatically by an extension scanner that will flag suspicious add-ons for editor review. You can read more about this scanner in the <a href="
+"\"%(link_validation)s\">Validation Help</a> document."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:129
 msgid ""
-"If the add-on is site-specific, it is recommended that a test account is "
-"provided for use during the review process. Additionally, including detailed"
-" testing instructions will allow an editor to better understand how the add-"
-"on functions and expedite the testing process. This information can be "
-"placed in the Notes to Reviewer field when editing a version in the "
-"Developer Hub."
+"If the add-on is site-specific, it is recommended that a test account is provided for use during the review process. Additionally, including detailed testing instructions will allow an editor to "
+"better understand how the add-on functions and expedite the testing process. This information can be placed in the Notes to Reviewer field when editing a version in the Developer Hub."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:134
-#: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:168
+#: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:134 src/olympia/devhub/templates/devhub/docs/policies-reviews.html:168
 msgid "After the Review"
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:136
 msgid ""
-"Once an add-on is granted full review, it will immediately be available in "
-"the gallery, showing in browse and search results with a warning-free "
-"install button. All features, including voluntary contributions and beta "
-"channels will be available."
+"Once an add-on is granted full review, it will immediately be available in the gallery, showing in browse and search results with a warning-free install button. All features, including voluntary "
+"contributions and beta channels will be available."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:142
 msgid ""
-"Subsequent versions of the add-on will automatically be placed in the full "
-"review queue. Until the review is completed, the new version will only be "
-"displayed on the Version History page of the add-on. Once reviewed, the "
-"version will be updated across the site and deployed through the automatic "
-"update service."
+"Subsequent versions of the add-on will automatically be placed in the full review queue. Until the review is completed, the new version will only be displayed on the Version History page of the add-"
+"on. Once reviewed, the version will be updated across the site and deployed through the automatic update service."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:148
 msgid ""
-"If a version does not meet the criteria for full review, it can either be "
-"granted preliminary review or disabled if there is a security concern. The "
-"author will receive an email explaining the action taken and how to fix it. "
-"In most cases, the developer can simply fix the problem and re-submit for "
-"full review."
+"If a version does not meet the criteria for full review, it can either be granted preliminary review or disabled if there is a security concern. The author will receive an email explaining the "
+"action taken and how to fix it. In most cases, the developer can simply fix the problem and re-submit for full review."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:155
 msgid ""
-"Preliminary reviews are appropriate for experimental add-ons and provide a "
-"way to get user testing and feedback without going through the longer, more "
-"thorough review process. We aim to complete these reviews in under 3 days."
+"Preliminary reviews are appropriate for experimental add-ons and provide a way to get user testing and feedback without going through the longer, more thorough review process. We aim to complete "
+"these reviews in under 3 days."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:160
@@ -6759,36 +5712,25 @@ msgstr ""
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:162
 msgid ""
-"When performing a preliminary review, editors will review the source code "
-"for security issues and major policy violations, but will not install the "
-"add-on to test functionality in most cases. Preliminary review will be "
-"granted unless a security vulnerability or major policy violation is "
-"discovered."
+"When performing a preliminary review, editors will review the source code for security issues and major policy violations, but will not install the add-on to test functionality in most cases. "
+"Preliminary review will be granted unless a security vulnerability or major policy violation is discovered."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:171
 msgid ""
-"Once preliminary review is granted, the add-on will be immediately available"
-" in the gallery, showing in browse and search results but ranked lower than "
-"fully-reviewed add-ons. Install buttons will have caution stripes and a "
-"notice that the add-on is experimental and not fully reviewed by Mozilla, "
-"though no click-through is required. Additionally, these add-ons cannot use "
-"the voluntary contributions and beta channel features."
+"Once preliminary review is granted, the add-on will be immediately available in the gallery, showing in browse and search results but ranked lower than fully-reviewed add-ons. Install buttons will "
+"have caution stripes and a notice that the add-on is experimental and not fully reviewed by Mozilla, though no click-through is required. Additionally, these add-ons cannot use the voluntary "
+"contributions and beta channel features."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:177
-msgid ""
-"After being granted preliminary review, Mozilla may later revoke the review "
-"if other serious problems are reported to us by users."
+msgid "After being granted preliminary review, Mozilla may later revoke the review if other serious problems are reported to us by users."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:183
 msgid ""
-"Subsequent versions of the add-on will automatically be placed in the "
-"preliminary review queue. Until the review is completed, the new version "
-"will only be displayed on the Version History page of the add-on. Once "
-"reviewed, the version will be updated across the site and deployed through "
-"the automatic update service."
+"Subsequent versions of the add-on will automatically be placed in the preliminary review queue. Until the review is completed, the new version will only be displayed on the Version History page of "
+"the add-on. Once reviewed, the version will be updated across the site and deployed through the automatic update service."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:188
@@ -6804,41 +5746,29 @@ msgid "The following add-ons are not permitted in any form:"
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:194
-msgid ""
-"Add-ons that embed known <a "
-"href=\"http://en.wikipedia.org/wiki/Spyware\">spyware</a> or <a "
-"href=\"http://en.wikipedia.org/wiki/Malware\">malware</a>"
+msgid "Add-ons that embed known <a href=\"http://en.wikipedia.org/wiki/Spyware\">spyware</a> or <a href=\"http://en.wikipedia.org/wiki/Malware\">malware</a>"
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:199
 msgid ""
-"Illegal and criminal add-ons, such as <a "
-"href=\"http://en.wikipedia.org/wiki/Click_fraud\">click fraud</a> "
-"generators, <a href=\"http://en.wikipedia.org/wiki/Warez\">warez</a> "
-"download and directory assistants, child pornography finders, etc."
+"Illegal and criminal add-ons, such as <a href=\"http://en.wikipedia.org/wiki/Click_fraud\">click fraud</a> generators, <a href=\"http://en.wikipedia.org/wiki/Warez\">warez</a> download and "
+"directory assistants, child pornography finders, etc."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:204
-msgid ""
-"Add-ons whose main purpose is to facilitate access to pornographic material,"
-" or include references to this material in their descriptions"
+msgid "Add-ons whose main purpose is to facilitate access to pornographic material, or include references to this material in their descriptions"
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:210
-msgid ""
-"Add-ons that, upon installation, auto-install or launch installers of non-"
-"Firefox software"
+msgid "Add-ons that, upon installation, auto-install or launch installers of non-Firefox software"
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:215
-msgid ""
-"Add-ons that provide their own update mechanism for code or search engines"
+msgid "Add-ons that provide their own update mechanism for code or search engines"
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:220
-msgid ""
-"Add-ons that make changes to web content in ways that are non-obvious or "
-"difficult to trace by their users"
+msgid "Add-ons that make changes to web content in ways that are non-obvious or difficult to trace by their users"
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:225
@@ -6855,41 +5785,25 @@ msgstr ""
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:238
 msgid ""
-"Surprises can be appropriate in many situations, but they are not welcome "
-"when user security, privacy, and control are at stake. It is extremely "
-"important to be as transparent as possible when submitting an add-on for "
-"hosting on this site. A Mozilla user should be able to easily discern what "
-"the functionality of an add-on is and not be presented with unexpected "
-"experiences post-install."
+"Surprises can be appropriate in many situations, but they are not welcome when user security, privacy, and control are at stake. It is extremely important to be as transparent as possible when "
+"submitting an add-on for hosting on this site. A Mozilla user should be able to easily discern what the functionality of an add-on is and not be presented with unexpected experiences post-install."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:243
 msgid ""
-"<p> Whenever an add-on includes any unexpected* feature that </p> <ul> "
-"<li>compromises user privacy or security (like sending data to third "
-"parties),</li> <li>changes default settings like the homepage or search "
-"engine, or</li> <li>changes settings or features in other add-ons or "
-"deactivates them altogether</li> </ul> <p>the features must adhere to the "
-"following requirements:</p> <ul> <li>The add-on description must clearly "
-"state what changes the add-on makes.</li> <li>All changes must be opt-in, "
-"meaning the user must take non-default action to enact the change.</li> "
-"<li>The opt-in dialog must clearly state the name of the add-on requesting "
-"the change.</li> <li>Uninstalling the add-on restores the user's original "
-"settings if they were changed.</li> </ul> <p>*Unexpected features are those "
-"that are unrelated to the add-on's primary function.</p>"
+"<p> Whenever an add-on includes any unexpected* feature that </p> <ul> <li>compromises user privacy or security (like sending data to third parties),</li> <li>changes default settings like the "
+"homepage or search engine, or</li> <li>changes settings or features in other add-ons or deactivates them altogether</li> </ul> <p>the features must adhere to the following requirements:</p> <ul> "
+"<li>The add-on description must clearly state what changes the add-on makes.</li> <li>All changes must be opt-in, meaning the user must take non-default action to enact the change.</li> <li>The opt-"
+"in dialog must clearly state the name of the add-on requesting the change.</li> <li>Uninstalling the add-on restores the user's original settings if they were changed.</li> </ul> <p>*Unexpected "
+"features are those that are unrelated to the add-on's primary function.</p>"
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:268
-msgid ""
-"These features cannot be introduced into an update of a fully-reviewed add-"
-"on; the opt-in change process must be part of the initial review."
+msgid "These features cannot be introduced into an update of a fully-reviewed add-on; the opt-in change process must be part of the initial review."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:274
-msgid ""
-"These are minimum requirements and not a guarantee that the add-on will be "
-"approved. This section applies to all add-ons hosted on the site, including "
-"preliminarily reviewed add-ons."
+msgid "These are minimum requirements and not a guarantee that the add-on will be approved. This section applies to all add-ons hosted on the site, including preliminarily reviewed add-ons."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:279
@@ -6898,11 +5812,8 @@ msgstr ""
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:282
 msgid ""
-"Add-ons that store or otherwise handle browsing data must support <a "
-"href=\"https://developer.mozilla.org/En/Supporting_private_browsing_mode\">Private"
-" Browsing Mode</a>. During a Private Browsing session, no browsing data can "
-"be written to disk, and all of this data must be cleared when Firefox quits "
-"or the Private Browsing session ends."
+"Add-ons that store or otherwise handle browsing data must support <a href=\"https://developer.mozilla.org/En/Supporting_private_browsing_mode\">Private Browsing Mode</a>. During a Private Browsing "
+"session, no browsing data can be written to disk, and all of this data must be cleared when Firefox quits or the Private Browsing session ends."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:287
@@ -6911,27 +5822,19 @@ msgstr ""
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:289
 msgid ""
-"Add-ons may contain binary, obfuscated and minified source code, but Mozilla"
-" must be allowed to review a copy of the human-readable source code of each "
-"version of an add-on submitted for review. These add-ons are ineligible for "
-"preliminary review and must choose the full review process."
+"Add-ons may contain binary, obfuscated and minified source code, but Mozilla must be allowed to review a copy of the human-readable source code of each version of an add-on submitted for review. "
+"These add-ons are ineligible for preliminary review and must choose the full review process."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:295
 msgid ""
-"If an add-on contains binary or obfuscated source code, the author will "
-"receive a message when the add-on is reviewed indicating whom to contact at "
-"Mozilla to coordinate review of the source code. This code will be reviewed "
-"by an administrator and will not be shared or redistributed in any way. The "
-"code will only be used for the purpose of reviewing the add-on."
+"If an add-on contains binary or obfuscated source code, the author will receive a message when the add-on is reviewed indicating whom to contact at Mozilla to coordinate review of the source code. "
+"This code will be reviewed by an administrator and will not be shared or redistributed in any way. The code will only be used for the purpose of reviewing the add-on."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:301
 #, python-format
-msgid ""
-"If your add-on contains binary or obfuscated code that you don't own or "
-"can't get the source code for, you may <a href=\"%(link_contact)s\">contact "
-"us</a> for information on how to proceed."
+msgid "If your add-on contains binary or obfuscated code that you don't own or can't get the source code for, you may <a href=\"%(link_contact)s\">contact us</a> for information on how to proceed."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/docs/policies-submission.html:11
@@ -6940,138 +5843,86 @@ msgstr ""
 
 #: src/olympia/devhub/templates/devhub/docs/policies-submission.html:13
 msgid ""
-"Add-ons hosted on Mozilla Add-ons should be of high quality and give users "
-"an improved web experience. We look for the following things when deciding "
-"whether an add-on is appropriate to be public and unrestricted:"
+"Add-ons hosted on Mozilla Add-ons should be of high quality and give users an improved web experience. We look for the following things when deciding whether an add-on is appropriate to be public "
+"and unrestricted:"
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/docs/policies-submission.html:19
 msgid ""
-"<strong>Are you responsive?</strong> We expect that an author who is "
-"promoting their add-on to our applications' many users is responsive to "
-"problem reports, maintains their contact information, and updates their add-"
-"on promptly to keep current with Firefox releases and changes in our "
-"policies. This doesn't mean that you have to reply to every question that "
-"someone posts in the discussions, or that you even need to fix every bug, "
-"but we do expect that you will respond to issues in a manner that's "
-"appropriate to the severity of the issue in question."
+"<strong>Are you responsive?</strong> We expect that an author who is promoting their add-on to our applications' many users is responsive to problem reports, maintains their contact information, "
+"and updates their add-on promptly to keep current with Firefox releases and changes in our policies. This doesn't mean that you have to reply to every question that someone posts in the "
+"discussions, or that you even need to fix every bug, but we do expect that you will respond to issues in a manner that's appropriate to the severity of the issue in question."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/docs/policies-submission.html:25
 msgid ""
-"<strong>Is the add-on clearly and accurately described?</strong> It's of the"
-" utmost importance to us that users get what they expect when they try a new"
-" add-on. Your add-on name should be clear and concise, and you should "
-"refrain from using special characters or numbers to get higher search "
-"rankings or for decorative purposes. Your description should provide details"
-" about what the add-on does, how a user should take advantage of it, and "
-"what the user should expect when they install it. Links to external "
-"documents for detailed instructions are fine, but the description itself "
-"should cover the basics and leave users confident that they know what "
-"they'll get. Also, it is important that you maintain version notes "
-"appropriately as you improve and change your add-on. Users should be able to"
-" see what's new in an add-on they may have tried previously, and should be "
-"made aware of changes that might affect their current use of the add-on when"
-" they update."
+"<strong>Is the add-on clearly and accurately described?</strong> It's of the utmost importance to us that users get what they expect when they try a new add-on. Your add-on name should be clear and "
+"concise, and you should refrain from using special characters or numbers to get higher search rankings or for decorative purposes. Your description should provide details about what the add-on "
+"does, how a user should take advantage of it, and what the user should expect when they install it. Links to external documents for detailed instructions are fine, but the description itself should "
+"cover the basics and leave users confident that they know what they'll get. Also, it is important that you maintain version notes appropriately as you improve and change your add-on. Users should "
+"be able to see what's new in an add-on they may have tried previously, and should be made aware of changes that might affect their current use of the add-on when they update."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/docs/policies-submission.html:31
 msgid ""
-"<strong>Are all privacy and security concerns clearly spelled out?</strong> "
-"This is an aspect of a clear and accurate description, but such an important"
-" one that we feel it deserves specific mention. Many very useful and well-"
-"written add-ons manipulate some form of user data, or can present security "
-"hazards if misused; they are welcome on the site, but they must make it very"
-" clear to users what risks they might encounter, and what they can do to "
-"protect themselves."
+"<strong>Are all privacy and security concerns clearly spelled out?</strong> This is an aspect of a clear and accurate description, but such an important one that we feel it deserves specific "
+"mention. Many very useful and well-written add-ons manipulate some form of user data, or can present security hazards if misused; they are welcome on the site, but they must make it very clear to "
+"users what risks they might encounter, and what they can do to protect themselves."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/docs/policies-submission.html:37
 msgid ""
-"<strong>Has the add-on been well-tested, and is it free of obvious or "
-"serious defects?</strong> One important thing that we look for when "
-"considering an add-on is whether its user reviews indicate that it has "
-"received thorough testing, and that it doesn't have serious problems or "
-"negative impacts on the browser. If reviewers report problems such as major "
-"performance issues, crashes, frequent problems using the functions of the "
-"add-on, or spamming of messages to the error console, you should take those "
-"reports to heart, and re-submit your add-on after you've addressed them as "
-"best you can. We don't expect you to perfectly optimize or have zero bugs "
-"&mdash; Firefox itself undergoes constant improvement in these areas &mdash;"
-" but we do want you to take reasonable efforts to minimize downsides, and to"
-" clearly call out cases where users may be surprised by those that remain."
+"<strong>Has the add-on been well-tested, and is it free of obvious or serious defects?</strong> One important thing that we look for when considering an add-on is whether its user reviews indicate "
+"that it has received thorough testing, and that it doesn't have serious problems or negative impacts on the browser. If reviewers report problems such as major performance issues, crashes, frequent "
+"problems using the functions of the add-on, or spamming of messages to the error console, you should take those reports to heart, and re-submit your add-on after you've addressed them as best you "
+"can. We don't expect you to perfectly optimize or have zero bugs &mdash; Firefox itself undergoes constant improvement in these areas &mdash; but we do want you to take reasonable efforts to "
+"minimize downsides, and to clearly call out cases where users may be surprised by those that remain."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/docs/policies-submission.html:43
 msgid ""
-"<strong>Do the add-on and add-on author both treat the user "
-"respectfully?</strong> Your software should not intrude on the user "
-"unnecessarily, try to trick the user, or conceal any of its activities from "
-"the user. Users (or even non-users) are sometimes rude in their comments, "
-"and while we will do our best to filter out inaccurate reviews as they're "
-"reported to us, we do expect that authors will avoid retaliating with "
-"rudeness of their own."
+"<strong>Do the add-on and add-on author both treat the user respectfully?</strong> Your software should not intrude on the user unnecessarily, try to trick the user, or conceal any of its "
+"activities from the user. Users (or even non-users) are sometimes rude in their comments, and while we will do our best to filter out inaccurate reviews as they're reported to us, we do expect that "
+"authors will avoid retaliating with rudeness of their own."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/docs/policies-submission.html:49
 msgid ""
-"<strong>Is the add-on useful to an appropriately wide portion of Firefox's "
-"users?</strong> Your add-on doesn't need to be the next Greasemonkey or "
-"Firebug, but if it is only useful to people at your company or who are part "
-"of a small web community, we may feel that it's not yet appropriate to put "
-"it in front of all of our users."
+"<strong>Is the add-on useful to an appropriately wide portion of Firefox's users?</strong> Your add-on doesn't need to be the next Greasemonkey or Firebug, but if it is only useful to people at "
+"your company or who are part of a small web community, we may feel that it's not yet appropriate to put it in front of all of our users."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/docs/policies-submission.html:55
 msgid ""
-"We are constantly looking at ways to improve the organization of the site to"
-" better accommodate add-ons that are exemplary in other ways, but are aimed "
-"at only a small community of potential users. Correctly categorizing and "
-"maintaining the metadata of your add-on will help us figure out how we can "
-"surface more of those sorts of add-ons to people who are most likely to "
-"benefit from them."
+"We are constantly looking at ways to improve the organization of the site to better accommodate add-ons that are exemplary in other ways, but are aimed at only a small community of potential users. "
+"Correctly categorizing and maintaining the metadata of your add-on will help us figure out how we can surface more of those sorts of add-ons to people who are most likely to benefit from them."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/docs/policies-submission.html:61
 msgid ""
-"If your add-on just provides bookmarks or other simple access points to your"
-" site, it's probably not appropriate for the gallery. Like the rest of the "
-"Mozilla project, we love web applications and new web services, but Firefox "
-"add-ons should provide an improved browsing experience for the user and not "
-"just be a way to promote a new site or service through a Mozilla Add-ons "
-"listing."
+"If your add-on just provides bookmarks or other simple access points to your site, it's probably not appropriate for the gallery. Like the rest of the Mozilla project, we love web applications and "
+"new web services, but Firefox add-ons should provide an improved browsing experience for the user and not just be a way to promote a new site or service through a Mozilla Add-ons listing."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/docs/policies-submission.html:67
 msgid ""
-"<strong>Is the add-on free of unlicensed trademarks and copyrights?</strong>"
-" Though you may mean no harm to the holder of a trademark, or the owner of a"
-" copyrighted work, we can't host add-ons that infringe on trademarks or "
-"copyrights. If you don't have permission to use a trademarked name or image,"
-" please do not submit your add-on to us. If your add-on includes code that "
-"is copyrighted by someone else, and is not licensed to you to use in your "
-"add-on, please do not submit your add-on to us."
+"<strong>Is the add-on free of unlicensed trademarks and copyrights?</strong> Though you may mean no harm to the holder of a trademark, or the owner of a copyrighted work, we can't host add-ons that "
+"infringe on trademarks or copyrights. If you don't have permission to use a trademarked name or image, please do not submit your add-on to us. If your add-on includes code that is copyrighted by "
+"someone else, and is not licensed to you to use in your add-on, please do not submit your add-on to us."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/docs/policies-submission.html:73
 msgid ""
-"In terms of reuse of source code from other add-ons, if the author has not "
-"clearly stated that you are permitted to use his or her code in your own "
-"work &mdash; such as by placing it under an open source license &mdash; then"
-" you should assume that you do not have the right to do so. You can contact "
-"the author to seek such permission, but we can't provide you with any "
-"special rights to it just because it's listed on the site, or because the "
-"author isn't responding to your request."
+"In terms of reuse of source code from other add-ons, if the author has not clearly stated that you are permitted to use his or her code in your own work &mdash; such as by placing it under an open "
+"source license &mdash; then you should assume that you do not have the right to do so. You can contact the author to seek such permission, but we can't provide you with any special rights to it "
+"just because it's listed on the site, or because the author isn't responding to your request."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/docs/policies-submission.html:79
 msgid ""
-"This applies to the Mozilla Foundation's trademarks as well, including "
-"\"Mozilla\", \"Firefox\", and \"Thunderbird\". The Mozilla policy on "
-"trademark use is designed to protect against confusion, and prevent the "
-"trademarks from being overturned due to lack of protection; please respect "
-"the need for such protection, and help us preserve some of the most valuable"
-" assets of the Mozilla Foundation."
+"This applies to the Mozilla Foundation's trademarks as well, including \"Mozilla\", \"Firefox\", and \"Thunderbird\". The Mozilla policy on trademark use is designed to protect against confusion, "
+"and prevent the trademarks from being overturned due to lack of protection; please respect the need for such protection, and help us preserve some of the most valuable assets of the Mozilla "
+"Foundation."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/docs/policies-submission.html:84
@@ -7080,65 +5931,46 @@ msgstr ""
 
 #: src/olympia/devhub/templates/devhub/docs/policies-submission.html:86
 msgid ""
-"Selecting an appropriate license for your add-on is a very important step in"
-" the submission process. A license specifies the rights you grant on your "
-"source code and is important in protecting your intellectual property."
+"Selecting an appropriate license for your add-on is a very important step in the submission process. A license specifies the rights you grant on your source code and is important in protecting your "
+"intellectual property."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/docs/policies-submission.html:92
 msgid ""
-"During the add-on submission process, you will be presented with a list of "
-"popular licenses to choose from, as well as the ability to specify your own "
-"license. It is best to consult with a legal professional about which license"
-" option is best for you. Choosing the right license for your source code "
-"will help to prevent confusion and code conflicts in the future."
+"During the add-on submission process, you will be presented with a list of popular licenses to choose from, as well as the ability to specify your own license. It is best to consult with a legal "
+"professional about which license option is best for you. Choosing the right license for your source code will help to prevent confusion and code conflicts in the future."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/docs/policies.html:12
-#: src/olympia/devhub/templates/devhub/docs/policies.html:52
+#: src/olympia/devhub/templates/devhub/docs/policies.html:12 src/olympia/devhub/templates/devhub/docs/policies.html:52
 msgid "Add-on Submission"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/docs/policies.html:18
-#: src/olympia/devhub/templates/devhub/docs/policies.html:78
+#: src/olympia/devhub/templates/devhub/docs/policies.html:18 src/olympia/devhub/templates/devhub/docs/policies.html:78
 msgid "Maintaining Your Add-on"
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/docs/policies.html:43
-msgid ""
-"Mozilla is committed to ensuring a great add-ons experience for our users "
-"and developers. Please review the policies below before submitting your add-"
-"on."
+msgid "Mozilla is committed to ensuring a great add-ons experience for our users and developers. Please review the policies below before submitting your add-on."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/docs/policies.html:55
-msgid ""
-"Find out what is expected of add-ons we host and our policies on specific "
-"add-on practices."
+msgid "Find out what is expected of add-ons we host and our policies on specific add-on practices."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/docs/policies.html:67
-msgid ""
-"What happens after your add-on is submitted? Learn about how our Editors "
-"review submissions."
+msgid "What happens after your add-on is submitted? Learn about how our Editors review submissions."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/docs/policies.html:81
-msgid ""
-"Add-on updates, transferring ownership, user reviews, and what to expect "
-"once your add-on is approved."
+msgid "Add-on updates, transferring ownership, user reviews, and what to expect once your add-on is approved."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/docs/policies.html:93
-msgid ""
-"How up-and-coming add-ons become featured and what&#039;s involved in the "
-"process."
+msgid "How up-and-coming add-ons become featured and what&#039;s involved in the process."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/docs/policies.html:106
-msgid ""
-"Terms of Service for submitting your work to our site. Developers are "
-"required to accept this agreement before submission."
+msgid "Terms of Service for submitting your work to our site. Developers are required to accept this agreement before submission."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/docs/policies.html:118
@@ -7150,9 +5982,7 @@ msgid "You have disabled this add-on"
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/includes/addon_details.html:24
-msgid ""
-"Your add-on's listing is disabled and is not showing anywhere in our gallery"
-" or update service."
+msgid "Your add-on's listing is disabled and is not showing anywhere in our gallery or update service."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/includes/addon_details.html:27
@@ -7164,48 +5994,31 @@ msgid "You will receive an email when the review is complete."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/includes/addon_details.html:33
-msgid ""
-"You will receive an email when the review is complete. Until then, your add-"
-"on is not listed in our gallery but can be accessed directly from its "
-"details page."
+msgid "You will receive an email when the review is complete. Until then, your add-on is not listed in our gallery but can be accessed directly from its details page."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:37
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:45
-msgid ""
-"You will receive an email when the review is complete and your add-on is "
-"signed."
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:37 src/olympia/devhub/templates/devhub/includes/addon_details.html:45
+msgid "You will receive an email when the review is complete and your add-on is signed."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/includes/addon_details.html:41
-msgid ""
-"You will receive an email when the review is complete. Until then, your add-"
-"on is not listed in our gallery but can be accessed directly from its "
-"details page. "
+msgid "You will receive an email when the review is complete. Until then, your add-on is not listed in our gallery but can be accessed directly from its details page. "
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/includes/addon_details.html:49
-msgid ""
-"Your add-on is displayed in our gallery and users are receiving automatic "
-"updates."
+msgid "Your add-on is displayed in our gallery and users are receiving automatic updates."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/includes/addon_details.html:52
-msgid ""
-"Your add-on has been signed and can be bundled with an application "
-"installer."
+msgid "Your add-on has been signed and can be bundled with an application installer."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/includes/addon_details.html:56
-msgid ""
-"Your add-on was disabled by a site administrator and is no longer shown in "
-"our gallery. If you have any questions, please email amo-admins@mozilla.org."
+msgid "Your add-on was disabled by a site administrator and is no longer shown in our gallery. If you have any questions, please email amo-admins@mozilla.org."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/includes/addon_details.html:62
-msgid ""
-"Your add-on is displayed in our gallery as experimental and users are "
-"receiving automatic updates. Some features are unavailable to your add-on."
+msgid "Your add-on is displayed in our gallery as experimental and users are receiving automatic updates. Some features are unavailable to your add-on."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/includes/addon_details.html:66
@@ -7214,22 +6027,16 @@ msgstr ""
 
 #: src/olympia/devhub/templates/devhub/includes/addon_details.html:69
 msgid ""
-"You will receive an email when the full review is complete. Until then, your"
-" add-on is displayed in our gallery as experimental and users are receiving "
-"automatic updates. Some features are unavailable to your add-on."
+"You will receive an email when the full review is complete. Until then, your add-on is displayed in our gallery as experimental and users are receiving automatic updates. Some features are "
+"unavailable to your add-on."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/includes/addon_details.html:74
-msgid ""
-"You will receive an email when the full review is complete, making you able "
-"to bundle your add-on with an application installer."
+msgid "You will receive an email when the full review is complete, making you able to bundle your add-on with an application installer."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/includes/addon_details.html:79
-msgid ""
-"All add-ons hosted in our gallery must now be reviewed by an editor. If you "
-"wish to continue hosting your add-on, please click to select a review "
-"process."
+msgid "All add-ons hosted in our gallery must now be reviewed by an editor. If you wish to continue hosting your add-on, please click to select a review process."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/includes/addon_details.html:100
@@ -7237,10 +6044,7 @@ msgid "Current Version:"
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/includes/addon_details.html:102
-msgid ""
-"This is the version of your add-on that will be installed if someone clicks "
-"the Install button on addons.mozilla.org. It is only relevant for listed "
-"add-ons."
+msgid "This is the version of your add-on that will be installed if someone clicks the Install button on addons.mozilla.org. It is only relevant for listed add-ons."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/includes/addon_details.html:110
@@ -7248,8 +6052,7 @@ msgid "Created:"
 msgstr ""
 
 #. {0} is a date. dennis-ignore: E201
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:112
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:118
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:112 src/olympia/devhub/templates/devhub/includes/addon_details.html:118
 #, python-format
 msgid "%%b %%e, %%Y"
 msgstr ""
@@ -7259,12 +6062,10 @@ msgid "Next Version:"
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/includes/addon_details.html:125
-msgid ""
-"This is the newest uploaded version, however it isn’t live on the site yet."
+msgid "This is the newest uploaded version, however it isn’t live on the site yet."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:130
-#: src/olympia/devhub/templates/devhub/versions/list.html:30
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:130 src/olympia/devhub/templates/devhub/versions/list.html:30
 msgid "Queues are not reviewed strictly in order"
 msgstr ""
 
@@ -7282,10 +6083,8 @@ msgstr ""
 
 #: src/olympia/devhub/templates/devhub/includes/addons_create_profile.html:24
 msgid ""
-"Your developer profile will tell users about you, why you made this add-on, "
-"and what's next for the add-on. This profile is required for add-ons "
-"requesting contributions, but can be useful for any developer interested in "
-"connecting with users."
+"Your developer profile will tell users about you, why you made this add-on, and what's next for the add-on. This profile is required for add-ons requesting contributions, but can be useful for any "
+"developer interested in connecting with users."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/includes/addons_create_profile.html:32
@@ -7298,15 +6097,11 @@ msgid "<a href=\"%(url)s\"><strong>Update your user profile.</strong></a>"
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/includes/addons_create_profile.html:45
-msgid ""
-"Whether it was an idea while in line at the grocery store or the solution to"
-" one of life's great problems, share your story."
+msgid "Whether it was an idea while in line at the grocery store or the solution to one of life's great problems, share your story."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/includes/addons_create_profile.html:61
-msgid ""
-"Telling your users what's coming soon will give them something to look "
-"forward to."
+msgid "Telling your users what's coming soon will give them something to look forward to."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/includes/addons_edit_nav.html:23
@@ -7338,9 +6133,7 @@ msgid "View the blog &#9658;"
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/includes/license_form.html:6
-msgid ""
-"Please choose a license appropriate for the rights you grant on your source "
-"code. It is only relevant for listed add-ons."
+msgid "Please choose a license appropriate for the rights you grant on your source code. It is only relevant for listed add-ons."
 msgstr ""
 
 #. {0} is a list of HTML tags.
@@ -7356,8 +6149,7 @@ msgstr ""
 msgid "Remove this application"
 msgstr ""
 
-#. {0} is the maximum number of add-on categories allowed.                {1}
-#. is
+#. {0} is the maximum number of add-on categories allowed.                {1} is
 #. the application name.
 #: src/olympia/devhub/templates/devhub/includes/macros.html:70
 msgid "Select <b>up to {0}</b> {1} category for this add-on:"
@@ -7369,24 +6161,16 @@ msgstr[3] ""
 
 #: src/olympia/devhub/templates/devhub/includes/policy_form.html:4
 msgid ""
-"Users will be required to accept the following End-User License Agreement "
-"(EULA) prior to installing your add-on. The presence of a EULA significantly"
-" affects the number of downloads an add-on receives. Please note that a EULA"
-" is not the same as a code license, such as the GPL or MPL.It is only "
-"relevant for listed add-ons."
+"Users will be required to accept the following End-User License Agreement (EULA) prior to installing your add-on. The presence of a EULA significantly affects the number of downloads an add-on "
+"receives. Please note that a EULA is not the same as a code license, such as the GPL or MPL.It is only relevant for listed add-ons."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/includes/policy_form.html:24
-msgid ""
-"If your add-on transmits any data from the user's computer, a privacy policy"
-" is required that explains what data is sent and how it is used. It is only "
-"relevant for listed add-ons."
+msgid "If your add-on transmits any data from the user's computer, a privacy policy is required that explains what data is sent and how it is used. It is only relevant for listed add-ons."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/includes/source_form_field.html:2
-msgid ""
-"If your add-on contains binary or obfuscated code other than known "
-"libraries, upload its sources for review."
+msgid "If your add-on contains binary or obfuscated code other than known libraries, upload its sources for review."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/includes/source_form_field.html:3
@@ -7394,9 +6178,7 @@ msgid "Read more about the source code review policy."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/includes/version_file.html:20
-msgid ""
-"You cannot remove an individual file after the review process has begun. You"
-" must delete the entire version."
+msgid "You cannot remove an individual file after the review process has begun. You must delete the entire version."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/includes/version_file.html:36
@@ -7425,9 +6207,7 @@ msgid "Voluntary Contributions"
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/payments/payments.html:38
-msgid ""
-"Add-ons enrolled in our contributions program can request voluntary "
-"financial support from users."
+msgid "Add-ons enrolled in our contributions program can request voluntary financial support from users."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/payments/payments.html:40
@@ -7439,9 +6219,7 @@ msgid "Choose when and how users are asked to contribute"
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/payments/payments.html:42
-msgid ""
-"Receive contributions in your PayPal account or send them to an organization"
-" of your choice"
+msgid "Receive contributions in your PayPal account or send them to an organization of your choice"
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/payments/payments.html:46
@@ -7450,17 +6228,14 @@ msgstr ""
 
 #: src/olympia/devhub/templates/devhub/payments/payments.html:53
 #, python-format
-msgid ""
-"Contributions are only available for add-ons with a <a "
-"href=\"%(url)s\">completed developer profile</a>."
+msgid "Contributions are only available for add-ons with a <a href=\"%(url)s\">completed developer profile</a>."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/payments/payments.html:59
 msgid "Contributions are only available for fully reviewed add-ons."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/payments/payments.html:65
-#: src/olympia/devhub/templates/devhub/payments/voluntary.html:2
+#: src/olympia/devhub/templates/devhub/payments/payments.html:65 src/olympia/devhub/templates/devhub/payments/voluntary.html:2
 msgid "Set up Contributions"
 msgstr ""
 
@@ -7473,15 +6248,12 @@ msgstr ""
 msgid "or <a href=\"%(cancel)s\">Cancel</a>"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/payments/voluntary.html:2
-#: src/olympia/stats/templates/stats/addon_report_menu.html:39
+#: src/olympia/devhub/templates/devhub/payments/voluntary.html:2 src/olympia/stats/templates/stats/addon_report_menu.html:39
 msgid "Contributions"
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/payments/voluntary.html:3
-msgid ""
-"Fill in the fields below to begin asking for voluntary contributions from "
-"users."
+msgid "Fill in the fields below to begin asking for voluntary contributions from users."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/payments/voluntary.html:11
@@ -7525,16 +6297,13 @@ msgid "Send a thank-you note?"
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/payments/voluntary.html:47
-msgid ""
-"We'll automatically email users who contribute to your add-on with this "
-"message."
+msgid "We'll automatically email users who contribute to your add-on with this message."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/payments/voluntary.html:49
 msgid ""
-"We recommend thanking the user and telling them how much you appreciate "
-"their support. You might also want to tell them about what's next for your "
-"add-on and about any other add-ons you've made for them to try."
+"We recommend thanking the user and telling them how much you appreciate their support. You might also want to tell them about what's next for your add-on and about any other add-ons you've made for "
+"them to try."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/payments/voluntary.html:64
@@ -7549,128 +6318,90 @@ msgstr ""
 msgid "Transfer ownership"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/personas/edit.html:77
-#: src/olympia/devhub/templates/devhub/personas/submit.html:31
+#: src/olympia/devhub/templates/devhub/personas/edit.html:77 src/olympia/devhub/templates/devhub/personas/submit.html:31
 msgid "Theme Details"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/personas/edit.html:87
-#: src/olympia/devhub/templates/devhub/personas/submit.html:36
+#: src/olympia/devhub/templates/devhub/personas/edit.html:87 src/olympia/devhub/templates/devhub/personas/submit.html:36
 msgid "Supply a pretty URL for your detail page."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/personas/edit.html:92
-#: src/olympia/devhub/templates/devhub/personas/submit.html:41
+#: src/olympia/devhub/templates/devhub/personas/edit.html:92 src/olympia/devhub/templates/devhub/personas/submit.html:41
 msgid "Select the category that best describes your Theme."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/personas/edit.html:95
-#: src/olympia/devhub/templates/devhub/personas/submit.html:44
+#: src/olympia/devhub/templates/devhub/personas/edit.html:95 src/olympia/devhub/templates/devhub/personas/submit.html:44
 msgid "Add some tags to describe your Theme."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/personas/edit.html:106
-#: src/olympia/devhub/templates/devhub/personas/submit.html:54
-msgid ""
-"A short explanation of your theme's basic functionality that is displayed in"
-" search and browse listings, as well as at the top of your theme's details "
-"page."
+#: src/olympia/devhub/templates/devhub/personas/edit.html:106 src/olympia/devhub/templates/devhub/personas/submit.html:54
+msgid "A short explanation of your theme's basic functionality that is displayed in search and browse listings, as well as at the top of your theme's details page."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/personas/edit.html:122
-#: src/olympia/devhub/templates/devhub/personas/submit.html:68
+#: src/olympia/devhub/templates/devhub/personas/edit.html:122 src/olympia/devhub/templates/devhub/personas/submit.html:68
 msgid "Theme License"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/personas/edit.html:126
-#: src/olympia/devhub/templates/devhub/personas/submit.html:72
+#: src/olympia/devhub/templates/devhub/personas/edit.html:126 src/olympia/devhub/templates/devhub/personas/submit.html:72
 msgid "Can others share your Theme, as long as you're given credit?"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/personas/edit.html:132
-#: src/olympia/devhub/templates/devhub/personas/edit.html:153
-#: src/olympia/devhub/templates/devhub/personas/submit.html:78
+#: src/olympia/devhub/templates/devhub/personas/edit.html:132 src/olympia/devhub/templates/devhub/personas/edit.html:153 src/olympia/devhub/templates/devhub/personas/submit.html:78
 #: src/olympia/devhub/templates/devhub/personas/submit.html:99
-msgid ""
-"The licensor permits others to copy, distribute, display, and perform the "
-"work, including for commercial purposes."
+msgid "The licensor permits others to copy, distribute, display, and perform the work, including for commercial purposes."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/personas/edit.html:141
-#: src/olympia/devhub/templates/devhub/personas/edit.html:162
-#: src/olympia/devhub/templates/devhub/personas/submit.html:87
+#: src/olympia/devhub/templates/devhub/personas/edit.html:141 src/olympia/devhub/templates/devhub/personas/edit.html:162 src/olympia/devhub/templates/devhub/personas/submit.html:87
 #: src/olympia/devhub/templates/devhub/personas/submit.html:108
-msgid ""
-"The licensor permits others to copy, distribute, display, and perform the "
-"work for non-commercial purposes only."
+msgid "The licensor permits others to copy, distribute, display, and perform the work for non-commercial purposes only."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/personas/edit.html:147
-#: src/olympia/devhub/templates/devhub/personas/submit.html:93
+#: src/olympia/devhub/templates/devhub/personas/edit.html:147 src/olympia/devhub/templates/devhub/personas/submit.html:93
 msgid "Can others make commercial use of your Theme?"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/personas/edit.html:168
-#: src/olympia/devhub/templates/devhub/personas/submit.html:114
+#: src/olympia/devhub/templates/devhub/personas/edit.html:168 src/olympia/devhub/templates/devhub/personas/submit.html:114
 msgid "Can others create derivative works from your Theme?"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/personas/edit.html:174
-#: src/olympia/devhub/templates/devhub/personas/submit.html:120
-msgid ""
-"The licensor permits others to copy, distribute, display and perform the "
-"work, as well as make derivative works based on it."
+#: src/olympia/devhub/templates/devhub/personas/edit.html:174 src/olympia/devhub/templates/devhub/personas/submit.html:120
+msgid "The licensor permits others to copy, distribute, display and perform the work, as well as make derivative works based on it."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/personas/edit.html:182
-#: src/olympia/devhub/templates/devhub/personas/submit.html:128
+#: src/olympia/devhub/templates/devhub/personas/edit.html:182 src/olympia/devhub/templates/devhub/personas/submit.html:128
 msgid "Yes, as long as they share alike"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/personas/edit.html:183
-#: src/olympia/devhub/templates/devhub/personas/submit.html:129
-msgid ""
-"The licensor permits others to distribute derivativeworks only under the "
-"same license or one compatible with the one that governs the licensor's "
-"work."
+#: src/olympia/devhub/templates/devhub/personas/edit.html:183 src/olympia/devhub/templates/devhub/personas/submit.html:129
+msgid "The licensor permits others to distribute derivativeworks only under the same license or one compatible with the one that governs the licensor's work."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/personas/edit.html:192
-#: src/olympia/devhub/templates/devhub/personas/submit.html:138
-msgid ""
-"The licensor permits others to copy, distribute and transmit only unaltered "
-"copies of the work — not derivative works based on it."
+#: src/olympia/devhub/templates/devhub/personas/edit.html:192 src/olympia/devhub/templates/devhub/personas/submit.html:138
+msgid "The licensor permits others to copy, distribute and transmit only unaltered copies of the work — not derivative works based on it."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/personas/edit.html:199
-#: src/olympia/devhub/templates/devhub/personas/submit.html:145
+#: src/olympia/devhub/templates/devhub/personas/edit.html:199 src/olympia/devhub/templates/devhub/personas/submit.html:145
 msgid "Your Theme will be released under the following license:"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/personas/edit.html:202
-#: src/olympia/devhub/templates/devhub/personas/submit.html:148
+#: src/olympia/devhub/templates/devhub/personas/edit.html:202 src/olympia/devhub/templates/devhub/personas/submit.html:148
 msgid "Select a different license."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/personas/edit.html:207
-#: src/olympia/devhub/templates/devhub/personas/submit.html:153
+#: src/olympia/devhub/templates/devhub/personas/edit.html:207 src/olympia/devhub/templates/devhub/personas/submit.html:153
 msgid "Select a license for your Theme."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/personas/edit.html:217
-#: src/olympia/devhub/templates/devhub/personas/submit.html:163
+#: src/olympia/devhub/templates/devhub/personas/edit.html:217 src/olympia/devhub/templates/devhub/personas/submit.html:163
 msgid "Theme Design"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/personas/edit.html:221
-#: src/olympia/devhub/templates/devhub/personas/edit.html:224
+#: src/olympia/devhub/templates/devhub/personas/edit.html:221 src/olympia/devhub/templates/devhub/personas/edit.html:224
 msgid "Upload New Design"
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/personas/edit.html:226
-msgid ""
-"Upon upload and form submission, the AMO Team will review your updated "
-"design. Your current design will still be public in the meantime."
+msgid "Upon upload and form submission, the AMO Team will review your updated design. Your current design will still be public in the meantime."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/personas/edit.html:241
@@ -7697,43 +6428,35 @@ msgstr ""
 msgid "Footer"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/personas/edit.html:274
-#: src/olympia/devhub/templates/devhub/personas/submit.html:167
+#: src/olympia/devhub/templates/devhub/personas/edit.html:274 src/olympia/devhub/templates/devhub/personas/submit.html:167
 msgid "Select colors for your Theme."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/personas/edit.html:276
-#: src/olympia/devhub/templates/devhub/personas/submit.html:169
+#: src/olympia/devhub/templates/devhub/personas/edit.html:276 src/olympia/devhub/templates/devhub/personas/submit.html:169
 msgid "Foreground Text"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/personas/edit.html:277
-#: src/olympia/devhub/templates/devhub/personas/submit.html:170
+#: src/olympia/devhub/templates/devhub/personas/edit.html:277 src/olympia/devhub/templates/devhub/personas/submit.html:170
 msgid "This is the color of the tab text."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/personas/edit.html:279
-#: src/olympia/devhub/templates/devhub/personas/submit.html:172
+#: src/olympia/devhub/templates/devhub/personas/edit.html:279 src/olympia/devhub/templates/devhub/personas/submit.html:172
 msgid "Background"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/personas/edit.html:280
-#: src/olympia/devhub/templates/devhub/personas/submit.html:173
+#: src/olympia/devhub/templates/devhub/personas/edit.html:280 src/olympia/devhub/templates/devhub/personas/submit.html:173
 msgid "This is the color of the tabs."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/personas/edit.html:285
-#: src/olympia/devhub/templates/devhub/personas/submit.html:178
+#: src/olympia/devhub/templates/devhub/personas/edit.html:285 src/olympia/devhub/templates/devhub/personas/submit.html:178
 msgid "Preview"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/personas/edit.html:291
-#: src/olympia/devhub/templates/devhub/personas/submit.html:183
+#: src/olympia/devhub/templates/devhub/personas/edit.html:291 src/olympia/devhub/templates/devhub/personas/submit.html:183
 msgid "Your Theme's Name"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/personas/edit.html:294
-#: src/olympia/devhub/templates/devhub/personas/submit.html:186
+#: src/olympia/devhub/templates/devhub/personas/edit.html:294 src/olympia/devhub/templates/devhub/personas/submit.html:186
 #, python-format
 msgid "by <a href=\"%(profile_url)s\" target=\"_blank\">%(user)s</a>"
 msgstr ""
@@ -7744,10 +6467,7 @@ msgstr ""
 
 #: src/olympia/devhub/templates/devhub/personas/submit.html:18
 #, python-format
-msgid ""
-"Background themes let you easily personalize the look of your Firefox. "
-"Submit your own design below, or <a href=\"%(submit_url)s\">learn how to "
-"create one</a>!"
+msgid "Background themes let you easily personalize the look of your Firefox. Submit your own design below, or <a href=\"%(submit_url)s\">learn how to create one</a>!"
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/personas/submit.html:33
@@ -7757,9 +6477,7 @@ msgstr ""
 #: src/olympia/devhub/templates/devhub/personas/submit.html:198
 #, python-format
 msgid ""
-"I agree to the <a href=\"%(agreement_url)s\" target=\"_blank\">Firefox Add-"
-"on Distribution Agreement</a> and to my information being handled as "
-"described in the <a href=\"%(privacy_notice_url)s\" "
+"I agree to the <a href=\"%(agreement_url)s\" target=\"_blank\">Firefox Add-on Distribution Agreement</a> and to my information being handled as described in the <a href=\"%(privacy_notice_url)s\" "
 "target=\"_blank\">Websites, Communications and Cookies Privacy Notice</a>."
 msgstr ""
 
@@ -7768,23 +6486,17 @@ msgid "Submit Theme"
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/personas/submit_done.html:11
-msgid ""
-"Your theme has been submitted to the Review Queue. You'll receive an email "
-"once it has been reviewed, typically within 24 hours."
+msgid "Your theme has been submitted to the Review Queue. You'll receive an email once it has been reviewed, typically within 24 hours."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/personas/submit_done.html:19
 #, python-format
-msgid ""
-"Provide more details about your theme by <a href=\"%(edit_url)s\">editing "
-"its listing</a>."
+msgid "Provide more details about your theme by <a href=\"%(edit_url)s\">editing its listing</a>."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/personas/submit_done.html:25
 #, python-format
-msgid ""
-"View and subscribe to your theme's <a href=\"%(feed_url)s\">activity "
-"feed</a> to stay updated on reviews, collections, and more."
+msgid "View and subscribe to your theme's <a href=\"%(feed_url)s\">activity feed</a> to stay updated on reviews, collections, and more."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/personas/submit_done.html:32
@@ -7800,13 +6512,11 @@ msgstr ""
 msgid "3000 &times; 200 pixels"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/personas/includes/theme_design.html:9
-#: src/olympia/devhub/templates/devhub/personas/includes/theme_design.html:25
+#: src/olympia/devhub/templates/devhub/personas/includes/theme_design.html:9 src/olympia/devhub/templates/devhub/personas/includes/theme_design.html:25
 msgid "300 KB max"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/personas/includes/theme_design.html:10
-#: src/olympia/devhub/templates/devhub/personas/includes/theme_design.html:26
+#: src/olympia/devhub/templates/devhub/personas/includes/theme_design.html:10 src/olympia/devhub/templates/devhub/personas/includes/theme_design.html:26
 msgid "PNG or JPG"
 msgstr ""
 
@@ -7834,21 +6544,19 @@ msgstr ""
 msgid "Select a different footer image"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/add_file_modal.html:7
-msgid ""
-"Files added to reviewed versions must be reviewed before they will be "
-"available for download."
+#: src/olympia/devhub/templates/devhub/versions/add_file_modal.html:8
+msgid "Files added to reviewed versions must be reviewed before they will be available for download."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/add_file_modal.html:23
+#: src/olympia/devhub/templates/devhub/versions/add_file_modal.html:24
 msgid "Select the target platform for this file."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/add_file_modal.html:34
+#: src/olympia/devhub/templates/devhub/versions/add_file_modal.html:35
 msgid "Which review type would you like to nominate for?"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/add_file_modal.html:39
+#: src/olympia/devhub/templates/devhub/versions/add_file_modal.html:40
 msgid "Only publish this version to my beta channel."
 msgstr ""
 
@@ -7856,8 +6564,7 @@ msgstr ""
 msgid "Manage Version {0}"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/edit.html:12
-#: src/olympia/devhub/templates/devhub/versions/list.html:3
+#: src/olympia/devhub/templates/devhub/versions/edit.html:12 src/olympia/devhub/templates/devhub/versions/list.html:3
 msgid "Status & Versions"
 msgstr ""
 
@@ -7876,24 +6583,20 @@ msgstr ""
 
 #: src/olympia/devhub/templates/devhub/versions/edit.html:74
 msgid ""
-"Information about changes in this release, new features, known bugs, and "
-"other useful information specific to this release/version. This information "
-"is also shown in the Add-ons Manager when updating."
+"Information about changes in this release, new features, known bugs, and other useful information specific to this release/version. This information is also shown in the Add-ons Manager when "
+"updating."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/versions/edit.html:99
 msgid "Approval Status"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/edit.html:113
-#: src/olympia/editors/templates/editors/review.html:108
+#: src/olympia/devhub/templates/devhub/versions/edit.html:113 src/olympia/editors/templates/editors/review.html:108
 msgid "Notes for Reviewers"
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/versions/edit.html:114
-msgid ""
-"Optionally, enter any information that may be useful to the Editor reviewing"
-" this add-on, such as test account information."
+msgid "Optionally, enter any information that may be useful to the Editor reviewing this add-on, such as test account information."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/versions/edit.html:127
@@ -7901,13 +6604,10 @@ msgid "Source code"
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/versions/edit.html:128
-msgid ""
-"If your add-on contain binary or obfuscated code, make the source available "
-"here for reviewers."
+msgid "If your add-on contain binary or obfuscated code, make the source available here for reviewers."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/edit.html:145
-#: src/olympia/devhub/templates/devhub/versions/edit.html:149
+#: src/olympia/devhub/templates/devhub/versions/edit.html:145 src/olympia/devhub/templates/devhub/versions/edit.html:149
 msgid "Upload a new file"
 msgstr ""
 
@@ -7976,9 +6676,7 @@ msgstr ""
 msgid "Request Preliminary Review"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:80
-#: src/olympia/devhub/templates/devhub/versions/list.html:325
-#: src/olympia/devhub/templates/devhub/versions/list.html:348
+#: src/olympia/devhub/templates/devhub/versions/list.html:80 src/olympia/devhub/templates/devhub/versions/list.html:325 src/olympia/devhub/templates/devhub/versions/list.html:348
 msgid "Cancel Review Request"
 msgstr ""
 
@@ -7991,8 +6689,7 @@ msgid "Listed:"
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/versions/list.html:102
-msgid ""
-"Visible to everyone on {0} and included in search results and listing pages"
+msgid "Visible to everyone on {0} and included in search results and listing pages"
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/versions/list.html:108
@@ -8000,9 +6697,7 @@ msgid "Hidden:"
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/versions/list.html:108
-msgid ""
-"Hosted on {0}, but hidden to anyone but authors. Used to temporarily hide "
-"listings or discontinue them."
+msgid "Hosted on {0}, but hidden to anyone but authors. Used to temporarily hide listings or discontinue them."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/versions/list.html:114
@@ -8010,9 +6705,7 @@ msgid "Unlisted:"
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/versions/list.html:114
-msgid ""
-"Not distributed on {0}. Developers will upload new versions for signing and "
-"distribute the add-ons on their own."
+msgid "Not distributed on {0}. Developers will upload new versions for signing and distribute the add-ons on their own."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/versions/list.html:122
@@ -8023,17 +6716,12 @@ msgstr ""
 msgid "Currently on AMO"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:129
-#: src/olympia/devhub/templates/devhub/versions/list.html:147
-#: src/olympia/devhub/templates/devhub/versions/list.html:164
-#: src/olympia/editors/templates/editors/includes/search_results_themes.html:7
-#: src/olympia/editors/templates/editors/themes/queue_list.html:50
+#: src/olympia/devhub/templates/devhub/versions/list.html:129 src/olympia/devhub/templates/devhub/versions/list.html:147 src/olympia/devhub/templates/devhub/versions/list.html:164
+#: src/olympia/editors/templates/editors/includes/search_results_themes.html:7 src/olympia/editors/templates/editors/themes/queue_list.html:50
 msgid "Status"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:130
-#: src/olympia/devhub/templates/devhub/versions/list.html:148
-#: src/olympia/devhub/templates/devhub/versions/list.html:165
+#: src/olympia/devhub/templates/devhub/versions/list.html:130 src/olympia/devhub/templates/devhub/versions/list.html:148 src/olympia/devhub/templates/devhub/versions/list.html:165
 #: src/olympia/editors/templates/editors/includes/files_view.html:11
 msgid "Validation"
 msgstr ""
@@ -8055,10 +6743,7 @@ msgid "Full review may not be required"
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/versions/list.html:201
-msgid ""
-"Unlisted add-ons don't need Full Review unless they are distributed as part "
-"of an application installer. Read <a href=\"{link}\" target=\"_blank\">this "
-"documentation</a> for more information."
+msgid "Unlisted add-ons don't need Full Review unless they are distributed as part of an application installer. Read <a href=\"{link}\" target=\"_blank\">this documentation</a> for more information."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/versions/list.html:209
@@ -8071,9 +6756,7 @@ msgstr ""
 
 #: src/olympia/devhub/templates/devhub/versions/list.html:218
 msgid ""
-"You are about to delete the current version of your add-on. This may cause "
-"your add-on status to change, or your listing to lose public visibility, if "
-"this is the only public version of your add-on."
+"You are about to delete the current version of your add-on. This may cause your add-on status to change, or your listing to lose public visibility, if this is the only public version of your add-on."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/versions/list.html:219
@@ -8081,9 +6764,7 @@ msgid "Deleting this version will permanently delete:"
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/versions/list.html:225
-msgid ""
-"<strong>Important:</strong> Once a version has been deleted, you may not "
-"upload a new version with the same version number."
+msgid "<strong>Important:</strong> Once a version has been deleted, you may not upload a new version with the same version number."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/versions/list.html:230
@@ -8106,41 +6787,31 @@ msgstr ""
 msgid "Add Version"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:253
-#: src/olympia/devhub/templates/devhub/versions/list.html:279
+#: src/olympia/devhub/templates/devhub/versions/list.html:253 src/olympia/devhub/templates/devhub/versions/list.html:279
 msgid "Hide Add-on"
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/versions/list.html:256
-msgid ""
-"Hiding your add-on will prevent it from appearing anywhere in our gallery "
-"and will stop users from receiving automatic updates."
+msgid "Hiding your add-on will prevent it from appearing anywhere in our gallery and will stop users from receiving automatic updates."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/versions/list.html:263
-msgid ""
-"The files awaiting review will be disabled and you will need to upload new "
-"versions."
+msgid "The files awaiting review will be disabled and you will need to upload new versions."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/versions/list.html:270
 msgid "Are you sure you wish to hide your add-on?"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:291
-#: src/olympia/devhub/templates/devhub/versions/list.html:313
+#: src/olympia/devhub/templates/devhub/versions/list.html:291 src/olympia/devhub/templates/devhub/versions/list.html:313
 msgid "Unlist Add-on"
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/versions/list.html:294
 #, python-format
 msgid ""
-"Unlisting your add-on will make it (and each of its versions/files) "
-"invisible on this website. It won't show up in searches, won't have a public"
-" facing page, and won't be updated automatically for current users. It is "
-"recommended for unlisted add-ons to provide a custom <a "
-"href=\"%(update_url)s\" target=\"_blank\">updateURL</a> in their manifest "
-"file for automatic updates."
+"Unlisting your add-on will make it (and each of its versions/files) invisible on this website. It won't show up in searches, won't have a public facing page, and won't be updated automatically for "
+"current users. It is recommended for unlisted add-ons to provide a custom <a href=\"%(update_url)s\" target=\"_blank\">updateURL</a> in their manifest file for automatic updates."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/versions/list.html:303
@@ -8156,16 +6827,11 @@ msgid "Are you sure you wish to unlist your add-on?"
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/versions/list.html:328
-msgid ""
-"Canceling your review request will leave your add-on as preliminarily "
-"reviewed."
+msgid "Canceling your review request will leave your add-on as preliminarily reviewed."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/versions/list.html:333
-msgid ""
-"Canceling your review request will mark your add-on incomplete. If you do "
-"not complete your add-on after several days by re-requesting review, it will"
-" be deleted."
+msgid "Canceling your review request will mark your add-on incomplete. If you do not complete your add-on after several days by re-requesting review, it will be deleted."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/versions/list.html:341
@@ -8201,14 +6867,11 @@ msgid "Translate content on the web from and into over 40 languages."
 msgstr ""
 
 #: src/olympia/discovery/modules.py:171
-msgid ""
-"Easily connect to your social networks, and share or comment on the page "
-"you're visiting."
+msgid "Easily connect to your social networks, and share or comment on the page you're visiting."
 msgstr ""
 
 #: src/olympia/discovery/modules.py:173
-msgid ""
-"A quick view to compare prices when you shop online or search for flights."
+msgid "A quick view to compare prices when you shop online or search for flights."
 msgstr ""
 
 #: src/olympia/discovery/modules.py:183
@@ -8252,9 +6915,7 @@ msgid "Add-ons that help you on your travels!"
 msgstr ""
 
 #: src/olympia/discovery/modules.py:226
-msgid ""
-"Displays a country flag depicting the location of the current website's "
-"server and more."
+msgid "Displays a country flag depicting the location of the current website's server and more."
 msgstr ""
 
 #: src/olympia/discovery/modules.py:228
@@ -8262,9 +6923,7 @@ msgid "FoxClocks let you keep an eye on the time around the world."
 msgstr ""
 
 #: src/olympia/discovery/modules.py:230
-msgid ""
-"Automatically get the lowest price when you shop online or search for "
-"flights."
+msgid "Automatically get the lowest price when you shop online or search for flights."
 msgstr ""
 
 #: src/olympia/discovery/modules.py:240
@@ -8304,9 +6963,7 @@ msgid "Put a Theme on It!"
 msgstr ""
 
 #: src/olympia/discovery/modules.py:281
-msgid ""
-"Visit addons.mozilla.org from Firefox for Android and dress up your mobile "
-"browser to match your style, mood, or the season."
+msgid "Visit addons.mozilla.org from Firefox for Android and dress up your mobile browser to match your style, mood, or the season."
 msgstr ""
 
 #: src/olympia/discovery/modules.py:290
@@ -8334,9 +6991,7 @@ msgid "Protect your privacy online with the add-ons in this collection."
 msgstr ""
 
 #: src/olympia/discovery/modules.py:342
-msgid ""
-"Great add-ons for work, fun, privacy, productivity&hellip; just about "
-"anything!"
+msgid "Great add-ons for work, fun, privacy, productivity&hellip; just about anything!"
 msgstr ""
 
 #: src/olympia/discovery/modules.py:350
@@ -8357,18 +7012,14 @@ msgstr ""
 
 #: src/olympia/discovery/templates/discovery/pane.html:28
 #, python-format
-msgid ""
-"Add-ons are applications that let you personalize %(app)s with extra "
-"functionality or style. Try a time-saving sidebar, a weather notifier, or a "
-"themed look to make %(app)s your own."
+msgid "Add-ons are applications that let you personalize %(app)s with extra functionality or style. Try a time-saving sidebar, a weather notifier, or a themed look to make %(app)s your own."
 msgstr ""
 
 #: src/olympia/discovery/templates/discovery/pane.html:62
 msgid "Learn More About Add-ons"
 msgstr ""
 
-#: src/olympia/discovery/templates/discovery/pane.html:66
-#: src/olympia/discovery/templates/discovery/pane.html:73
+#: src/olympia/discovery/templates/discovery/pane.html:66 src/olympia/discovery/templates/discovery/pane.html:73
 msgid "See all"
 msgstr ""
 
@@ -8399,9 +7050,7 @@ msgstr ""
 
 #: src/olympia/discovery/templates/discovery/pane_account.html:17
 #, python-format
-msgid ""
-"Thanks for using %(app)s and supporting <a href=\"%(url)s\">Mozilla's "
-"mission</a>!"
+msgid "Thanks for using %(app)s and supporting <a href=\"%(url)s\">Mozilla's mission</a>!"
 msgstr ""
 
 #: src/olympia/discovery/templates/discovery/pane_account.html:23
@@ -8426,10 +7075,7 @@ msgstr ""
 
 #: src/olympia/discovery/templates/discovery/modules/go-mobile.html:8
 #, python-format
-msgid ""
-"Visit <a href=\"%(url)s\">firefox.com/m</a> to get Firefox on your phone and"
-" personalize your browser anytime, anywhere. Easily discover and install "
-"add-ons from the mobile Add-ons Manager."
+msgid "Visit <a href=\"%(url)s\">firefox.com/m</a> to get Firefox on your phone and personalize your browser anytime, anywhere. Easily discover and install add-ons from the mobile Add-ons Manager."
 msgstr ""
 
 #: src/olympia/discovery/templates/discovery/modules/go-mobile.html:13
@@ -8445,15 +7091,11 @@ msgid "Find great add-ons to help you with all your holiday shopping needs."
 msgstr ""
 
 #: src/olympia/discovery/templates/discovery/modules/holiday.html:13
-msgid ""
-"Install the Amazon Browser Apps and receive special Amazon features right at"
-" your fingertips."
+msgid "Install the Amazon Browser Apps and receive special Amazon features right at your fingertips."
 msgstr ""
 
 #: src/olympia/discovery/templates/discovery/modules/holiday.html:22
-msgid ""
-"Keep an eye on your eBay activity wherever you are on the web when you "
-"install the eBay Sidebar for Firefox."
+msgid "Keep an eye on your eBay activity wherever you are on the web when you install the eBay Sidebar for Firefox."
 msgstr ""
 
 #: src/olympia/discovery/templates/discovery/modules/holiday.html:31
@@ -8531,19 +7173,19 @@ msgstr ""
 msgid "Search by add-on name / author email"
 msgstr ""
 
-#: src/olympia/editors/forms.py:103
+#: src/olympia/editors/forms.py:103 src/olympia/editors/forms.py:244 src/olympia/editors/forms.py:257
 msgid "yes"
 msgstr ""
 
-#: src/olympia/editors/forms.py:104
+#: src/olympia/editors/forms.py:104 src/olympia/editors/forms.py:244 src/olympia/editors/forms.py:257
 msgid "no"
 msgstr ""
 
-#: src/olympia/editors/forms.py:105
+#: src/olympia/editors/forms.py:105 src/olympia/editors/forms.py:245
 msgid "Admin Flag"
 msgstr ""
 
-#: src/olympia/editors/forms.py:113
+#: src/olympia/editors/forms.py:113 src/olympia/editors/forms.py:253
 msgid "Max. Version"
 msgstr ""
 
@@ -8559,53 +7201,55 @@ msgstr ""
 msgid "Platforms"
 msgstr ""
 
+#: src/olympia/editors/forms.py:237
+msgid "Search by add-on name / author email / guid"
+msgstr ""
+
 #. L10n: 0 = platform, 1 = filename, 2 = status message
-#: src/olympia/editors/forms.py:238
+#: src/olympia/editors/forms.py:342
 #, python-format
 msgid "<strong>%s</strong> &middot; %s &middot; %s"
 msgstr ""
 
-#: src/olympia/editors/forms.py:252
+#: src/olympia/editors/forms.py:356
 msgid "Comments:"
 msgstr ""
 
-#: src/olympia/editors/forms.py:256
+#: src/olympia/editors/forms.py:360
 msgid "Operating systems:"
 msgstr ""
 
-#: src/olympia/editors/forms.py:258
+#: src/olympia/editors/forms.py:362
 msgid "Applications:"
 msgstr ""
 
-#: src/olympia/editors/forms.py:260
-msgid ""
-"Notify me the next time this add-on is updated. (Subsequent updates will not"
-" generate an email)"
+#: src/olympia/editors/forms.py:364
+msgid "Notify me the next time this add-on is updated. (Subsequent updates will not generate an email)"
 msgstr ""
 
-#: src/olympia/editors/forms.py:265
+#: src/olympia/editors/forms.py:369
 msgid "Clear Admin Review Flag"
 msgstr ""
 
-#: src/olympia/editors/forms.py:267
+#: src/olympia/editors/forms.py:371
 msgid "Clear more info requested flag"
 msgstr ""
 
-#: src/olympia/editors/forms.py:281
+#: src/olympia/editors/forms.py:385
 msgid "Choose a canned response..."
 msgstr ""
 
 #. L10n: Description of what can be searched for.
-#: src/olympia/editors/forms.py:319
+#: src/olympia/editors/forms.py:423
 msgid "theme name"
 msgstr ""
 
-#: src/olympia/editors/forms.py:345
+#: src/olympia/editors/forms.py:449
 msgid "Someone else is reviewing this theme."
 msgstr ""
 
 #. L10n: Description of what can be searched for.
-#: src/olympia/editors/forms.py:442
+#: src/olympia/editors/forms.py:546
 msgid "app, reviewer, or comment"
 msgstr ""
 
@@ -8625,31 +7269,23 @@ msgstr ""
 msgid "Queue"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:126
-#: src/olympia/editors/templates/editors/base.html:50
-#: src/olympia/editors/templates/editors/base.html:65
+#: src/olympia/editors/helpers.py:126 src/olympia/editors/templates/editors/base.html:50 src/olympia/editors/templates/editors/base.html:65
 msgid "Pending Updates"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:127
-#: src/olympia/editors/templates/editors/base.html:48
-#: src/olympia/editors/templates/editors/base.html:63
+#: src/olympia/editors/helpers.py:127 src/olympia/editors/templates/editors/base.html:48 src/olympia/editors/templates/editors/base.html:63
 msgid "Full Reviews"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:128
-#: src/olympia/editors/templates/editors/base.html:52
-#: src/olympia/editors/templates/editors/base.html:67
+#: src/olympia/editors/helpers.py:128 src/olympia/editors/templates/editors/base.html:52 src/olympia/editors/templates/editors/base.html:67
 msgid "Preliminary Reviews"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:129
-#: src/olympia/editors/templates/editors/base.html:54
+#: src/olympia/editors/helpers.py:129 src/olympia/editors/templates/editors/base.html:54
 msgid "Moderated Reviews"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:130
-#: src/olympia/editors/templates/editors/base.html:46
+#: src/olympia/editors/helpers.py:130 src/olympia/editors/templates/editors/base.html:46
 msgid "Fast Track"
 msgstr ""
 
@@ -8657,8 +7293,7 @@ msgstr ""
 msgid "Pending Themes"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:133
-#: src/olympia/editors/templates/editors/themes/queue.html:4
+#: src/olympia/editors/helpers.py:133 src/olympia/editors/templates/editors/themes/queue.html:4
 msgid "Flagged Themes"
 msgstr ""
 
@@ -8762,8 +7397,7 @@ msgstr ""
 msgid "Waiting Time"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:276
-#: src/olympia/editors/templates/editors/review.html:285
+#: src/olympia/editors/helpers.py:276 src/olympia/editors/templates/editors/review.html:285
 msgid "Flags"
 msgstr ""
 
@@ -8826,105 +7460,93 @@ msgstr ""
 msgid "Last Update"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:559
-msgid "Push to public"
+#: src/olympia/editors/helpers.py:387
+msgid "No Reviews"
 msgstr ""
 
 #: src/olympia/editors/helpers.py:561
+msgid "Push to public"
+msgstr ""
+
+#: src/olympia/editors/helpers.py:563
 msgid "Grant full review"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:574
+#: src/olympia/editors/helpers.py:578
 msgid "Request more information"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:577
+#: src/olympia/editors/helpers.py:581
 msgid "Request super-review"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:588
+#: src/olympia/editors/helpers.py:592
 msgid "Grant preliminary review"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:589
+#: src/olympia/editors/helpers.py:593
 msgid "This will mark the files as preliminarily reviewed."
 msgstr ""
 
-#: src/olympia/editors/helpers.py:591
-msgid ""
-"Use this form to request more information from the author. They will receive"
-" an email and be able to answer here. You will be notified by email when "
-"they reply."
-msgstr ""
-
 #: src/olympia/editors/helpers.py:595
-msgid ""
-"If you have concerns about this add-on's security, copyright issues, or "
-"other concerns that an administrator should look into, enter your comments "
-"in the area below. They will be sent to administrators, not the author."
+msgid "Use this form to request more information from the author. They will receive an email and be able to answer here. You will be notified by email when they reply."
 msgstr ""
 
-#: src/olympia/editors/helpers.py:601
+#: src/olympia/editors/helpers.py:599
+msgid ""
+"If you have concerns about this add-on's security, copyright issues, or other concerns that an administrator should look into, enter your comments in the area below. They will be sent to "
+"administrators, not the author."
+msgstr ""
+
+#: src/olympia/editors/helpers.py:605
 msgid "This will reject the add-on and remove it from the review queue."
 msgstr ""
 
-#: src/olympia/editors/helpers.py:603
+#: src/olympia/editors/helpers.py:607
 msgid "Make a comment on this version. The author won't be able to see this."
 msgstr ""
 
-#: src/olympia/editors/helpers.py:607
+#: src/olympia/editors/helpers.py:611
 msgid "This will reject the files and remove them from the review queue."
 msgstr ""
 
-#: src/olympia/editors/helpers.py:611
-msgid ""
-"This will mark the add-on as preliminarily reviewed. Future versions will "
-"undergo preliminary review."
+#: src/olympia/editors/helpers.py:615
+msgid "This will mark the add-on as preliminarily reviewed. Future versions will undergo preliminary review."
 msgstr ""
 
-#: src/olympia/editors/helpers.py:616
-msgid ""
-"This will mark the files as preliminarily reviewed. Future versions will "
-"undergo preliminary review."
+#: src/olympia/editors/helpers.py:620
+msgid "This will mark the files as preliminarily reviewed. Future versions will undergo preliminary review."
 msgstr ""
 
-#: src/olympia/editors/helpers.py:621
+#: src/olympia/editors/helpers.py:625
 msgid "Retain preliminary review"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:622
-msgid ""
-"This will retain the add-on as preliminarily reviewed. Future versions will "
-"undergo preliminary review."
+#: src/olympia/editors/helpers.py:626
+msgid "This will retain the add-on as preliminarily reviewed. Future versions will undergo preliminary review."
 msgstr ""
 
-#: src/olympia/editors/helpers.py:627
-msgid ""
-"This will approve a sandboxed version of a public add-on to appear on the "
-"public side."
+#: src/olympia/editors/helpers.py:631
+msgid "This will approve a sandboxed version of a public add-on to appear on the public side."
 msgstr ""
 
-#: src/olympia/editors/helpers.py:630
-msgid ""
-"This will reject a version of a public add-on and remove it from the queue."
+#: src/olympia/editors/helpers.py:634
+msgid "This will reject a version of a public add-on and remove it from the queue."
 msgstr ""
 
-#: src/olympia/editors/helpers.py:633
-msgid ""
-"This will mark the add-on and its most recent version and files as public. "
-"Future versions will go into the sandbox until they are reviewed by an "
-"editor."
+#: src/olympia/editors/helpers.py:637
+msgid "This will mark the add-on and its most recent version and files as public. Future versions will go into the sandbox until they are reviewed by an editor."
 msgstr ""
 
-#: src/olympia/editors/helpers.py:710
+#: src/olympia/editors/helpers.py:714
 msgid "add-on"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:1016 src/olympia/editors/helpers.py:1036
+#: src/olympia/editors/helpers.py:1020 src/olympia/editors/helpers.py:1040
 msgid "Flagged"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:1020 src/olympia/editors/helpers.py:1039
+#: src/olympia/editors/helpers.py:1024 src/olympia/editors/helpers.py:1043
 msgid "Updates"
 msgstr ""
 
@@ -8988,61 +7610,57 @@ msgstr ""
 msgid "Overdue (Over 10 days)"
 msgstr ""
 
-#: src/olympia/editors/views.py:538
+#: src/olympia/editors/views.py:539
 msgid "An unknown error occurred"
 msgstr ""
 
-#: src/olympia/editors/views.py:591
+#: src/olympia/editors/views.py:592
 msgid "Self-reviews are not allowed."
 msgstr ""
 
-#: src/olympia/editors/views.py:612
+#: src/olympia/editors/views.py:613
 msgid "Review successfully processed."
 msgstr ""
 
-#: src/olympia/editors/views.py:811
+#: src/olympia/editors/views.py:812
 msgid "was approved"
 msgstr ""
 
-#: src/olympia/editors/views.py:812
+#: src/olympia/editors/views.py:813
 msgid "given preliminary review"
 msgstr ""
 
-#: src/olympia/editors/views.py:813
+#: src/olympia/editors/views.py:814
 msgid "rejected"
 msgstr ""
 
-#: src/olympia/editors/views.py:814
+#: src/olympia/editors/views.py:815
 msgctxt "editors_review_history_nominated_adminreview"
 msgid "escalated"
 msgstr ""
 
-#: src/olympia/editors/views.py:816
+#: src/olympia/editors/views.py:817
 msgid "needs more information"
 msgstr ""
 
-#: src/olympia/editors/views.py:817
+#: src/olympia/editors/views.py:818
 msgid "needs super review"
 msgstr ""
 
-#: src/olympia/editors/views.py:818
+#: src/olympia/editors/views.py:819
 msgid "commented"
 msgstr ""
 
 #: src/olympia/editors/views_themes.py:326
 msgid "{0} theme review successfully processed (+{1} points, {2} total)."
-msgid_plural ""
-"{0} theme reviews successfully processed (+{1} points, {2} total)."
+msgid_plural "{0} theme reviews successfully processed (+{1} points, {2} total)."
 msgstr[0] ""
 msgstr[1] ""
 msgstr[2] ""
 msgstr[3] ""
 
 #: src/olympia/editors/views_themes.py:341
-msgid ""
-"Your theme locks have successfully been released. Other reviewers may now "
-"review those released themes. You may have to refresh the page to see the "
-"changes reflected in the table below."
+msgid "Your theme locks have successfully been released. Other reviewers may now review those released themes. You may have to refresh the page to see the changes reflected in the table below."
 msgstr ""
 
 #: src/olympia/editors/templates/editors/abuse_reports.html:4
@@ -9067,9 +7685,7 @@ msgstr ""
 msgid "Return to the Editor Tools homepage"
 msgstr ""
 
-#: src/olympia/editors/templates/editors/base.html:43
-#: src/olympia/editors/templates/editors/themes/base.html:14
-#: src/olympia/editors/templates/editors/themes/base.html:28
+#: src/olympia/editors/templates/editors/base.html:43 src/olympia/editors/templates/editors/themes/base.html:14 src/olympia/editors/templates/editors/themes/base.html:28
 #: src/olympia/editors/templates/editors/themes/queue.html:25
 msgid "Queues"
 msgstr ""
@@ -9078,71 +7694,51 @@ msgstr ""
 msgid "Unlisted Queues"
 msgstr ""
 
-#: src/olympia/editors/templates/editors/base.html:74
-#: src/olympia/editors/templates/editors/performance.html:6
+#: src/olympia/editors/templates/editors/base.html:74 src/olympia/editors/templates/editors/performance.html:6
 msgid "Performance"
 msgstr ""
 
-#: src/olympia/editors/templates/editors/base.html:77
-#: src/olympia/editors/templates/editors/themes/base.html:19
-#: src/olympia/editors/templates/editors/themes/base.html:38
+#: src/olympia/editors/templates/editors/base.html:77 src/olympia/editors/templates/editors/themes/base.html:19 src/olympia/editors/templates/editors/themes/base.html:38
 msgid "Logs"
 msgstr ""
 
-#: src/olympia/editors/templates/editors/base.html:80
-#: src/olympia/editors/templates/editors/reviewlog.html:4
-#: src/olympia/editors/templates/editors/reviewlog.html:27
+#: src/olympia/editors/templates/editors/base.html:80 src/olympia/editors/templates/editors/reviewlog.html:4 src/olympia/editors/templates/editors/reviewlog.html:27
 msgid "Add-on Review Log"
 msgstr ""
 
-#: src/olympia/editors/templates/editors/base.html:82
-#: src/olympia/editors/templates/editors/eventlog.html:4
-#: src/olympia/editors/templates/editors/eventlog.html:8
+#: src/olympia/editors/templates/editors/base.html:82 src/olympia/editors/templates/editors/eventlog.html:4 src/olympia/editors/templates/editors/eventlog.html:8
 #: src/olympia/editors/templates/editors/eventlog_detail.html:4
 msgid "Moderated Review Log"
 msgstr ""
 
-#: src/olympia/editors/templates/editors/base.html:84
-#: src/olympia/editors/templates/editors/beta_signed_log.html:4
-#: src/olympia/editors/templates/editors/beta_signed_log.html:8
+#: src/olympia/editors/templates/editors/base.html:84 src/olympia/editors/templates/editors/beta_signed_log.html:4 src/olympia/editors/templates/editors/beta_signed_log.html:8
 msgid "Signed Beta Files Log"
 msgstr ""
 
-#: src/olympia/editors/templates/editors/base.html:89
-#: src/olympia/editors/templates/editors/includes/daily-message.html:4
+#: src/olympia/editors/templates/editors/base.html:89 src/olympia/editors/templates/editors/includes/daily-message.html:4
 msgid "Announcement"
 msgstr ""
 
 #. "Filter" is a button label (verb)
-#: src/olympia/editors/templates/editors/beta_signed_log.html:17
-#: src/olympia/editors/templates/editors/eventlog.html:24
-#: src/olympia/editors/templates/editors/reviewlog.html:21
-#: src/olympia/editors/templates/editors/themes/macros.html:45
-#: src/olympia/editors/templates/editors/themes/includes/logs_filter_deleted.html:12
+#: src/olympia/editors/templates/editors/beta_signed_log.html:17 src/olympia/editors/templates/editors/eventlog.html:24 src/olympia/editors/templates/editors/reviewlog.html:21
+#: src/olympia/editors/templates/editors/themes/macros.html:45 src/olympia/editors/templates/editors/themes/includes/logs_filter_deleted.html:12
 msgid "Filter"
 msgstr ""
 
-#: src/olympia/editors/templates/editors/beta_signed_log.html:23
-#: src/olympia/editors/templates/editors/eventlog.html:30
-#: src/olympia/editors/templates/editors/reviewlog.html:34
+#: src/olympia/editors/templates/editors/beta_signed_log.html:23 src/olympia/editors/templates/editors/eventlog.html:30 src/olympia/editors/templates/editors/reviewlog.html:34
 #: src/olympia/editors/templates/editors/themes/logs.html:16
 msgid "Date"
 msgstr ""
 
-#: src/olympia/editors/templates/editors/beta_signed_log.html:24
-#: src/olympia/editors/templates/editors/eventlog.html:31
-#: src/olympia/editors/templates/editors/reviewlog.html:35
+#: src/olympia/editors/templates/editors/beta_signed_log.html:24 src/olympia/editors/templates/editors/eventlog.html:31 src/olympia/editors/templates/editors/reviewlog.html:35
 msgid "Event"
 msgstr ""
 
-#: src/olympia/editors/templates/editors/beta_signed_log.html:37
-#: src/olympia/editors/templates/editors/eventlog.html:44
-#: src/olympia/editors/templates/editors/home.html:180
+#: src/olympia/editors/templates/editors/beta_signed_log.html:37 src/olympia/editors/templates/editors/eventlog.html:44 src/olympia/editors/templates/editors/home.html:180
 msgid "More details."
 msgstr ""
 
-#: src/olympia/editors/templates/editors/beta_signed_log.html:46
-#: src/olympia/editors/templates/editors/eventlog.html:53
+#: src/olympia/editors/templates/editors/beta_signed_log.html:46 src/olympia/editors/templates/editors/eventlog.html:53
 msgid "No events found for this period."
 msgstr ""
 
@@ -9198,13 +7794,11 @@ msgstr[1] ""
 msgstr[2] ""
 msgstr[3] ""
 
-#: src/olympia/editors/templates/editors/home.html:36
-#: src/olympia/editors/templates/editors/home.html:86
+#: src/olympia/editors/templates/editors/home.html:36 src/olympia/editors/templates/editors/home.html:86
 msgid "Current waiting times:"
 msgstr ""
 
-#: src/olympia/editors/templates/editors/home.html:44
-#: src/olympia/editors/templates/editors/home.html:94
+#: src/olympia/editors/templates/editors/home.html:44 src/olympia/editors/templates/editors/home.html:94
 msgid "{0} add-on"
 msgid_plural "{0} add-ons"
 msgstr[0] ""
@@ -9212,8 +7806,7 @@ msgstr[1] ""
 msgstr[2] ""
 msgstr[3] ""
 
-#: src/olympia/editors/templates/editors/home.html:45
-#: src/olympia/editors/templates/editors/home.html:95
+#: src/olympia/editors/templates/editors/home.html:45 src/olympia/editors/templates/editors/home.html:95
 #, python-format
 msgid "{0}%%"
 msgstr ""
@@ -9242,14 +7835,11 @@ msgstr[1] ""
 msgstr[2] ""
 msgstr[3] ""
 
-#: src/olympia/editors/templates/editors/home.html:109
-#: src/olympia/editors/templates/editors/performance.html:37
-#: src/olympia/editors/templates/editors/themes/home.html:54
+#: src/olympia/editors/templates/editors/home.html:109 src/olympia/editors/templates/editors/performance.html:37 src/olympia/editors/templates/editors/themes/home.html:54
 msgid "Total Reviews"
 msgstr ""
 
-#: src/olympia/editors/templates/editors/home.html:110
-#: src/olympia/editors/templates/editors/themes/home.html:55
+#: src/olympia/editors/templates/editors/home.html:110 src/olympia/editors/templates/editors/themes/home.html:55
 msgid "Reviews This Month"
 msgstr ""
 
@@ -9257,8 +7847,7 @@ msgstr ""
 msgid "New Editors"
 msgstr ""
 
-#: src/olympia/editors/templates/editors/home.html:126
-#: src/olympia/editors/templates/editors/home.html:141
+#: src/olympia/editors/templates/editors/home.html:126 src/olympia/editors/templates/editors/home.html:141
 msgid "You're #{0} with {1} reviews"
 msgstr ""
 
@@ -9271,13 +7860,11 @@ msgstr[1] ""
 msgstr[2] ""
 msgstr[3] ""
 
-#: src/olympia/editors/templates/editors/leaderboard.html:3
-#: src/olympia/editors/templates/editors/includes/reviewers_score_bar.html:56
+#: src/olympia/editors/templates/editors/leaderboard.html:3 src/olympia/editors/templates/editors/includes/reviewers_score_bar.html:56
 msgid "Reviewer Leaderboard"
 msgstr ""
 
-#: src/olympia/editors/templates/editors/leaderboard.html:18
-#: src/olympia/editors/templates/editors/performance.html:65
+#: src/olympia/editors/templates/editors/leaderboard.html:18 src/olympia/editors/templates/editors/performance.html:65
 msgid "No review points awarded yet."
 msgstr ""
 
@@ -9297,8 +7884,7 @@ msgstr ""
 msgid "Update message of the day"
 msgstr ""
 
-#: src/olympia/editors/templates/editors/motd.html:15
-#: src/olympia/editors/templates/editors/review.html:224
+#: src/olympia/editors/templates/editors/motd.html:15 src/olympia/editors/templates/editors/review.html:224
 msgid "Save"
 msgstr ""
 
@@ -9366,49 +7952,45 @@ msgstr ""
 msgid "clear search"
 msgstr ""
 
-#: src/olympia/editors/templates/editors/queue.html:72
-#: src/olympia/editors/templates/editors/queue.html:122
+#: src/olympia/editors/templates/editors/queue.html:78 src/olympia/editors/templates/editors/queue.html:128
 msgid "Process Reviews"
 msgstr ""
 
-#: src/olympia/editors/templates/editors/queue.html:80
+#: src/olympia/editors/templates/editors/queue.html:86
 msgid "Moderation actions:"
 msgstr ""
 
-#: src/olympia/editors/templates/editors/queue.html:90
+#: src/olympia/editors/templates/editors/queue.html:96
 #, python-format
 msgid "by %(user)s on %(date)s %(stars)s (%(locale)s)"
 msgstr ""
 
-#: src/olympia/editors/templates/editors/queue.html:106
+#: src/olympia/editors/templates/editors/queue.html:112
 #, python-format
-msgid ""
-"<strong>%(reason)s</strong> <span class=\"light\">Flagged by %(user)s on "
-"%(date)s</span>"
+msgid "<strong>%(reason)s</strong> <span class=\"light\">Flagged by %(user)s on %(date)s</span>"
 msgstr ""
 
-#: src/olympia/editors/templates/editors/queue.html:119
+#: src/olympia/editors/templates/editors/queue.html:125
 msgid "All reviews have been moderated. Good work!"
 msgstr ""
 
-#: src/olympia/editors/templates/editors/queue.html:161
+#: src/olympia/editors/templates/editors/queue.html:167
 msgid "Version Notes / Notes for Reviewer"
 msgstr ""
 
-#: src/olympia/editors/templates/editors/queue.html:169
+#: src/olympia/editors/templates/editors/queue.html:175
 msgid "There are currently no add-ons of this type to review."
 msgstr ""
 
-#: src/olympia/editors/templates/editors/queue.html:181
-#: src/olympia/editors/templates/editors/themes/queue_list.html:85
+#: src/olympia/editors/templates/editors/queue.html:187 src/olympia/editors/templates/editors/themes/queue_list.html:85
 msgid "Helpful Links:"
 msgstr ""
 
-#: src/olympia/editors/templates/editors/queue.html:182
+#: src/olympia/editors/templates/editors/queue.html:188
 msgid "Add-on Policy"
 msgstr ""
 
-#: src/olympia/editors/templates/editors/queue.html:184
+#: src/olympia/editors/templates/editors/queue.html:190
 msgid "Editors' Guide"
 msgstr ""
 
@@ -9421,16 +8003,13 @@ msgstr ""
 msgid "Add-on user change history"
 msgstr ""
 
-#: src/olympia/editors/templates/editors/review.html:52
-#: src/olympia/editors/templates/editors/review.html:266
+#: src/olympia/editors/templates/editors/review.html:52 src/olympia/editors/templates/editors/review.html:266
 msgid "Add-on History"
 msgstr ""
 
 #: src/olympia/editors/templates/editors/review.html:64
 #, python-format
-msgid ""
-"Version %(version)s &middot; %(created)s <span class=\"light\">&middot; "
-"%(version_status)s</span>"
+msgid "Version %(version)s &middot; %(created)s <span class=\"light\">&middot; %(version_status)s</span>"
 msgstr ""
 
 #: src/olympia/editors/templates/editors/review.html:73
@@ -9454,17 +8033,14 @@ msgid "This version has not been reviewed."
 msgstr ""
 
 #: src/olympia/editors/templates/editors/review.html:154
-msgid ""
-"You can still submit this form, however only do so if you know it won't "
-"conflict."
+msgid "You can still submit this form, however only do so if you know it won't conflict."
 msgstr ""
 
 #: src/olympia/editors/templates/editors/review.html:161
 msgid "Insert canned response..."
 msgstr ""
 
-#: src/olympia/editors/templates/editors/review.html:167
-#: src/olympia/files/templates/files/viewer.html:54
+#: src/olympia/editors/templates/editors/review.html:167 src/olympia/files/templates/files/viewer.html:54
 msgid "Files:"
 msgstr ""
 
@@ -9473,23 +8049,18 @@ msgid "Tested on:"
 msgstr ""
 
 #: src/olympia/editors/templates/editors/review.html:220
-msgid ""
-"<strong>Warning!</strong> Another user was viewing this page before you."
+msgid "<strong>Warning!</strong> Another user was viewing this page before you."
 msgstr ""
 
 #: src/olympia/editors/templates/editors/review.html:237
-msgid ""
-"The whiteboard is the place to exchange information relevant to this addon "
-"(whatever the version), between the developer and the editor. This is "
-"visible and editable by both."
+msgid "The whiteboard is the place to exchange information relevant to this addon (whatever the version), between the developer and the editor. This is visible and editable by both."
 msgstr ""
 
 #: src/olympia/editors/templates/editors/review.html:241
 msgid "Update the whiteboard"
 msgstr ""
 
-#: src/olympia/editors/templates/editors/review.html:257
-#: src/olympia/editors/templates/editors/review.html:258
+#: src/olympia/editors/templates/editors/review.html:257 src/olympia/editors/templates/editors/review.html:258
 msgid "(admin)"
 msgstr ""
 
@@ -9517,18 +8088,15 @@ msgstr ""
 msgid "Add-on has been deleted."
 msgstr ""
 
-#: src/olympia/editors/templates/editors/reviewlog.html:59
-#: src/olympia/editors/templates/editors/themes/logs.html:36
+#: src/olympia/editors/templates/editors/reviewlog.html:59 src/olympia/editors/templates/editors/themes/logs.html:36
 msgid "Show Comments"
 msgstr ""
 
-#: src/olympia/editors/templates/editors/reviewlog.html:60
-#: src/olympia/editors/templates/editors/themes/logs.html:37
+#: src/olympia/editors/templates/editors/reviewlog.html:60 src/olympia/editors/templates/editors/themes/logs.html:37
 msgid "Hide Comments"
 msgstr ""
 
-#: src/olympia/editors/templates/editors/reviewlog.html:72
-#: src/olympia/editors/templates/editors/themes/logs.html:54
+#: src/olympia/editors/templates/editors/reviewlog.html:72 src/olympia/editors/templates/editors/themes/logs.html:54
 msgid "No reviews found for this period."
 msgstr ""
 
@@ -9586,11 +8154,8 @@ msgstr ""
 msgid "You have <span>{0}</span> points."
 msgstr ""
 
-#: src/olympia/editors/templates/editors/includes/search_results_themes.html:6
-#: src/olympia/editors/templates/editors/themes/history_table.html:7
-#: src/olympia/editors/templates/editors/themes/logs.html:19
-#: src/olympia/editors/templates/editors/themes/queue_list.html:49
-#: src/olympia/editors/templates/editors/themes/single.html:26
+#: src/olympia/editors/templates/editors/includes/search_results_themes.html:6 src/olympia/editors/templates/editors/themes/history_table.html:7
+#: src/olympia/editors/templates/editors/themes/logs.html:19 src/olympia/editors/templates/editors/themes/queue_list.html:49 src/olympia/editors/templates/editors/themes/single.html:26
 #: src/olympia/editors/templates/editors/themes/themes.html:45
 msgid "Reviewer"
 msgstr ""
@@ -9615,8 +8180,7 @@ msgstr ""
 msgid "Review Date"
 msgstr ""
 
-#: src/olympia/editors/templates/editors/themes/history_table.html:9
-#: src/olympia/editors/templates/editors/themes/logs.html:18
+#: src/olympia/editors/templates/editors/themes/history_table.html:9 src/olympia/editors/templates/editors/themes/logs.html:18
 msgid "Action"
 msgstr ""
 
@@ -9787,9 +8351,7 @@ msgid "Problems decoding {0}."
 msgstr ""
 
 #: src/olympia/files/helpers.py:186
-msgid ""
-"This file is not viewable online. Please download the file to view the "
-"contents."
+msgid "This file is not viewable online. Please download the file to view the contents."
 msgstr ""
 
 #: src/olympia/files/helpers.py:194
@@ -9847,9 +8409,7 @@ msgid "Version numbers should have fewer than 32 characters."
 msgstr ""
 
 #: src/olympia/files/utils.py:567
-msgid ""
-"Version numbers should only contain letters, numbers, and these punctuation "
-"characters: +*.-_."
+msgid "Version numbers should only contain letters, numbers, and these punctuation characters: +*.-_."
 msgstr ""
 
 #: src/olympia/files/utils.py:584
@@ -9870,9 +8430,7 @@ msgstr ""
 
 #: src/olympia/files/templates/files/file.html:4
 #, python-format
-msgid ""
-"Version: %(version)s &bull; Size: %(size)s &bull; MD5 hash: %(md5)s &bull; "
-"Mimetype: %(mimetype)s"
+msgid "Version: %(version)s &bull; Size: %(size)s &bull; MD5 hash: %(md5)s &bull; Mimetype: %(mimetype)s"
 msgstr ""
 
 #: src/olympia/files/templates/files/viewer.html:4
@@ -9911,48 +8469,39 @@ msgstr ""
 msgid "Tab stops:"
 msgstr ""
 
-#: src/olympia/files/templates/files/viewer.html:79
-#: src/olympia/files/templates/files/viewer.html:80
+#: src/olympia/files/templates/files/viewer.html:79 src/olympia/files/templates/files/viewer.html:80
 msgid "Up file"
 msgstr ""
 
-#: src/olympia/files/templates/files/viewer.html:84
-#: src/olympia/files/templates/files/viewer.html:85
+#: src/olympia/files/templates/files/viewer.html:84 src/olympia/files/templates/files/viewer.html:85
 msgid "Down file"
 msgstr ""
 
-#: src/olympia/files/templates/files/viewer.html:90
-#: src/olympia/files/templates/files/viewer.html:91
+#: src/olympia/files/templates/files/viewer.html:90 src/olympia/files/templates/files/viewer.html:91
 msgid "Previous diff"
 msgstr ""
 
-#: src/olympia/files/templates/files/viewer.html:93
-#: src/olympia/files/templates/files/viewer.html:94
+#: src/olympia/files/templates/files/viewer.html:93 src/olympia/files/templates/files/viewer.html:94
 msgid "Previous note"
 msgstr ""
 
-#: src/olympia/files/templates/files/viewer.html:100
-#: src/olympia/files/templates/files/viewer.html:101
+#: src/olympia/files/templates/files/viewer.html:100 src/olympia/files/templates/files/viewer.html:101
 msgid "Next diff"
 msgstr ""
 
-#: src/olympia/files/templates/files/viewer.html:103
-#: src/olympia/files/templates/files/viewer.html:104
+#: src/olympia/files/templates/files/viewer.html:103 src/olympia/files/templates/files/viewer.html:104
 msgid "Next note"
 msgstr ""
 
-#: src/olympia/files/templates/files/viewer.html:109
-#: src/olympia/files/templates/files/viewer.html:110
+#: src/olympia/files/templates/files/viewer.html:109 src/olympia/files/templates/files/viewer.html:110
 msgid "Expand all"
 msgstr ""
 
-#: src/olympia/files/templates/files/viewer.html:114
-#: src/olympia/files/templates/files/viewer.html:115
+#: src/olympia/files/templates/files/viewer.html:114 src/olympia/files/templates/files/viewer.html:115
 msgid "Hide or unhide tree"
 msgstr ""
 
-#: src/olympia/files/templates/files/viewer.html:119
-#: src/olympia/files/templates/files/viewer.html:120
+#: src/olympia/files/templates/files/viewer.html:119 src/olympia/files/templates/files/viewer.html:120
 msgid "Wrap or unwrap text"
 msgstr ""
 
@@ -10624,12 +9173,7 @@ msgstr ""
 msgid "Zimbabwe Dollar"
 msgstr ""
 
-#: src/olympia/lib/video/ffmpeg.py:112 src/olympia/lib/video/totem.py:81
-msgid "Videos must be in WebM."
-msgstr ""
-
-#: src/olympia/pages/templates/pages/about.lhtml:3
-#: src/olympia/pages/templates/pages/about.lhtml:10
+#: src/olympia/pages/templates/pages/about.lhtml:3 src/olympia/pages/templates/pages/about.lhtml:10
 msgid "About Mozilla Add-ons"
 msgstr ""
 
@@ -10639,11 +9183,8 @@ msgstr ""
 
 #: src/olympia/pages/templates/pages/about.lhtml:13
 msgid ""
-"addons.mozilla.org, commonly known as \"AMO\", is Mozilla's official site "
-"for add-ons to Mozilla software, such as Firefox, Thunderbird, and "
-"SeaMonkey. Add-ons let you add new features and change the way your browser "
-"or application works. Take a look around and explore the thousands of ways "
-"to customize the way you do things online."
+"addons.mozilla.org, commonly known as \"AMO\", is Mozilla's official site for add-ons to Mozilla software, such as Firefox, Thunderbird, and SeaMonkey. Add-ons let you add new features and change "
+"the way your browser or application works. Take a look around and explore the thousands of ways to customize the way you do things online."
 msgstr ""
 
 #: src/olympia/pages/templates/pages/about.lhtml:19
@@ -10652,11 +9193,8 @@ msgstr ""
 
 #: src/olympia/pages/templates/pages/about.lhtml:20
 msgid ""
-"The add-ons listed here have been created by thousands of developers from "
-"our community, ranging from individual hobbyists to large corporations. All "
-"publicly listed add-ons are reviewed by a team of editors before being "
-"released. Add-ons marked as Experimental have not been reviewed and should "
-"only be installed with caution."
+"The add-ons listed here have been created by thousands of developers from our community, ranging from individual hobbyists to large corporations. All publicly listed add-ons are reviewed by a team "
+"of editors before being released. Add-ons marked as Experimental have not been reviewed and should only be installed with caution."
 msgstr ""
 
 #: src/olympia/pages/templates/pages/about.lhtml:26
@@ -10664,30 +9202,22 @@ msgid "How do I keep up with what's happening at AMO?"
 msgstr ""
 
 #: src/olympia/pages/templates/pages/about.lhtml:27
-msgid ""
-"There are several ways to find out the latest news from the world of add-"
-"ons:"
+msgid "There are several ways to find out the latest news from the world of add-ons:"
 msgstr ""
 
 #: src/olympia/pages/templates/pages/about.lhtml:29
 #, python-format
-msgid ""
-"Our <a href=\"%(url)s\">Add-ons Blog</a> is regularly updated with "
-"information for both add-on enthusiasts and developers."
+msgid "Our <a href=\"%(url)s\">Add-ons Blog</a> is regularly updated with information for both add-on enthusiasts and developers."
 msgstr ""
 
 #: src/olympia/pages/templates/pages/about.lhtml:32
 #, python-format
-msgid ""
-"We often post news, tips, and tricks to our Twitter account, <a "
-"href=\"%(url)s\">mozamo</a>"
+msgid "We often post news, tips, and tricks to our Twitter account, <a href=\"%(url)s\">mozamo</a>"
 msgstr ""
 
 #: src/olympia/pages/templates/pages/about.lhtml:34
 #, python-format
-msgid ""
-"Our <a href=\"%(url)s\">forums</a> are a good place to interact with the "
-"add-ons community and discuss upcoming changes to AMO."
+msgid "Our <a href=\"%(url)s\">forums</a> are a good place to interact with the add-ons community and discuss upcoming changes to AMO."
 msgstr ""
 
 #: src/olympia/pages/templates/pages/about.lhtml:39
@@ -10695,37 +9225,27 @@ msgid "This sounds great! How can I get involved?"
 msgstr ""
 
 #: src/olympia/pages/templates/pages/about.lhtml:40
-msgid ""
-"There are plenty of ways to get involved. If you're on the technical side:"
+msgid "There are plenty of ways to get involved. If you're on the technical side:"
 msgstr ""
 
 #: src/olympia/pages/templates/pages/about.lhtml:42
 #, python-format
-msgid ""
-"<a href=\"%(url)s\">Make your own add-on</a>. We provide free hosting and "
-"update services and can help you reach a large audience of users."
+msgid "<a href=\"%(url)s\">Make your own add-on</a>. We provide free hosting and update services and can help you reach a large audience of users."
 msgstr ""
 
 #: src/olympia/pages/templates/pages/about.lhtml:45
 #, python-format
-msgid ""
-"If you have add-on development experience, <a href=\"%(url)s\"> become an "
-"editor</a>! Our editors are add-on fans with a technical background who "
-"review add-ons for code quality and stability."
+msgid "If you have add-on development experience, <a href=\"%(url)s\"> become an editor</a>! Our editors are add-on fans with a technical background who review add-ons for code quality and stability."
 msgstr ""
 
 #: src/olympia/pages/templates/pages/about.lhtml:49
 #, python-format
 msgid ""
-"Help improve this website. It's open source, and you can file bugs and "
-"submit patches. <a href=\"%(url)s\"> GitHub</a> contains all of our current "
-"bugs, legacy bugs can still be found in Bugzilla."
+"Help improve this website. It's open source, and you can file bugs and submit patches. <a href=\"%(url)s\"> GitHub</a> contains all of our current bugs, legacy bugs can still be found in Bugzilla."
 msgstr ""
 
 #: src/olympia/pages/templates/pages/about.lhtml:55
-msgid ""
-"If you're interested in add-ons but not quite as technical, there are still "
-"ways to help:"
+msgid "If you're interested in add-ons but not quite as technical, there are still ways to help:"
 msgstr ""
 
 #: src/olympia/pages/templates/pages/about.lhtml:58
@@ -10738,9 +9258,7 @@ msgid "Participate in our <a href=\"%(url)s\">forums</a>."
 msgstr ""
 
 #: src/olympia/pages/templates/pages/about.lhtml:61
-msgid ""
-"Review add-ons on the site. Add-on authors are more likely to improve their "
-"add-ons and write new ones when they know people appreciate their work."
+msgid "Review add-ons on the site. Add-on authors are more likely to improve their add-ons and write new ones when they know people appreciate their work."
 msgstr ""
 
 #: src/olympia/pages/templates/pages/about.lhtml:66
@@ -10750,16 +9268,13 @@ msgstr ""
 #: src/olympia/pages/templates/pages/about.lhtml:67
 #, python-format
 msgid ""
-"A good place to start is our <a href=\"%(faq_url)s\"><abbr "
-"title=\"Frequently Asked Questions\">FAQ</abbr></a>. If you don't find an "
-"answer there, you can <a href=\"%(forum_url)s\"> ask on our forums</a>."
+"A good place to start is our <a href=\"%(faq_url)s\"><abbr title=\"Frequently Asked Questions\">FAQ</abbr></a>. If you don't find an answer there, you can <a href=\"%(forum_url)s\"> ask on our "
+"forums</a>."
 msgstr ""
 
 #: src/olympia/pages/templates/pages/about.lhtml:72
 #, python-format
-msgid ""
-"If you really need to contact someone from the Mozilla team, please see our "
-"<a href=\"%(url)s\"> contact information</a> page."
+msgid "If you really need to contact someone from the Mozilla team, please see our <a href=\"%(url)s\"> contact information</a> page."
 msgstr ""
 
 #: src/olympia/pages/templates/pages/about.lhtml:76
@@ -10769,10 +9284,8 @@ msgstr ""
 #: src/olympia/pages/templates/pages/about.lhtml:77
 #, python-format
 msgid ""
-"Over the years, many people have contributed to this website, including both"
-" volunteers from the community and a dedicated AMO team. A list of "
-"significant contributors can be found on our <a href=\"%(url)s\"> Site "
-"Credits</a> page."
+"Over the years, many people have contributed to this website, including both volunteers from the community and a dedicated AMO team. A list of significant contributors can be found on our <a href="
+"\"%(url)s\"> Site Credits</a> page."
 msgstr ""
 
 #: src/olympia/pages/templates/pages/acr_firstrun.html:4
@@ -10784,9 +9297,7 @@ msgid "Add-on Compatibility Reporter has been installed"
 msgstr ""
 
 #: src/olympia/pages/templates/pages/acr_firstrun.html:28
-msgid ""
-"It’s easy to help us make sure add-ons are updated in time for the release "
-"of the next version of Firefox."
+msgid "It’s easy to help us make sure add-ons are updated in time for the release of the next version of Firefox."
 msgstr ""
 
 #: src/olympia/pages/templates/pages/acr_firstrun.html:35
@@ -10795,35 +9306,27 @@ msgstr ""
 
 #: src/olympia/pages/templates/pages/acr_firstrun.html:40
 msgid ""
-"As you start browsing and using your add-ons, take careful note of anything "
-"that seems different from when you last used the extension. This might be a "
-"display glitch, such as a menu item missing, or something more serious, like"
-" the add-on not working at all or showing errors."
+"As you start browsing and using your add-ons, take careful note of anything that seems different from when you last used the extension. This might be a display glitch, such as a menu item missing, "
+"or something more serious, like the add-on not working at all or showing errors."
 msgstr ""
 
 #: src/olympia/pages/templates/pages/acr_firstrun.html:49
 msgid ""
-"Once you know whether a particular add-on works properly or has problems, "
-"open the Add-ons Manager and click Compatibility next to the add-on to let "
-"Mozilla know what you found in your testing. Submitting a report will help "
-"us tell the add-on developer whether their add-on is working properly in "
-"this version or might need some fixes."
+"Once you know whether a particular add-on works properly or has problems, open the Add-ons Manager and click Compatibility next to the add-on to let Mozilla know what you found in your testing. "
+"Submitting a report will help us tell the add-on developer whether their add-on is working properly in this version or might need some fixes."
 msgstr ""
 
 #: src/olympia/pages/templates/pages/acr_firstrun.html:61
 #, python-format
 msgid ""
-"If you upgrade to a new version of Firefox or update your add-ons, your "
-"reports for the old versions will be hidden to allow you to test the new "
-"version. If you have any questions, please ask in <a href=\"%(url)s\">our "
-"forums</a>."
+"If you upgrade to a new version of Firefox or update your add-ons, your reports for the old versions will be hidden to allow you to test the new version. If you have any questions, please ask in <a "
+"href=\"%(url)s\">our forums</a>."
 msgstr ""
 
 #: src/olympia/pages/templates/pages/acr_firstrun.html:69
 msgid ""
-"Thousands of add-ons are made by our community every year, and your "
-"assistance with compatibility testing helps us make sure these add-ons stay "
-"useful as we strive to provide a great user experience."
+"Thousands of add-ons are made by our community every year, and your assistance with compatibility testing helps us make sure these add-ons stay useful as we strive to provide a great user "
+"experience."
 msgstr ""
 
 #: src/olympia/pages/templates/pages/acr_firstrun.html:75
@@ -10835,9 +9338,7 @@ msgid "Site Credits"
 msgstr ""
 
 #: src/olympia/pages/templates/pages/credits.html:12
-msgid ""
-"Mozilla would like to thank the following people for their contributions to "
-"the addons.mozilla.org project over the years:"
+msgid "Mozilla would like to thank the following people for their contributions to the addons.mozilla.org project over the years:"
 msgstr ""
 
 #: src/olympia/pages/templates/pages/credits.html:18
@@ -10871,73 +9372,57 @@ msgstr ""
 
 #: src/olympia/pages/templates/pages/credits.html:59
 msgid ""
-"Some icons used are from the <a "
-"href=\"http://www.famfamfam.com/lab/icons/silk/\">famfamfam Silk Icon "
-"Set</a>, licensed under a <a "
-"href=\"http://creativecommons.org/licenses/by/2.5/\">Creative Commons "
-"Attribution 2.5 License</a>."
+"Some icons used are from the <a href=\"http://www.famfamfam.com/lab/icons/silk/\">famfamfam Silk Icon Set</a>, licensed under a <a href=\"http://creativecommons.org/licenses/by/2.5/\">Creative "
+"Commons Attribution 2.5 License</a>."
 msgstr ""
 
 #: src/olympia/pages/templates/pages/credits.html:60
 msgid ""
-"Some icons used are from the <a href=\"http://www.fatcow.com/free-"
-"icons/\">FatCow Farm-Fresh Web Icons Set</a>, licensed under a <a "
-"href=\"http://creativecommons.org/licenses/by/3.0/us/\">Creative Commons "
-"Attribution 3.0 License</a>."
+"Some icons used are from the <a href=\"http://www.fatcow.com/free-icons/\">FatCow Farm-Fresh Web Icons Set</a>, licensed under a <a href=\"http://creativecommons.org/licenses/by/3.0/us/\">Creative "
+"Commons Attribution 3.0 License</a>."
 msgstr ""
 
 #: src/olympia/pages/templates/pages/credits.html:61
 msgid ""
-"Some pages use elements of <a "
-"href=\"http://shop.highsoft.com/highcharts.html\">Highcharts</a> (non-"
-"commercial), licensed under a <a href=\"http://creativecommons.org/licenses"
-"/by-nc/3.0/\">Creative Commons Attribution-NonCommercial 3.0 License</a>."
+"Some pages use elements of <a href=\"http://shop.highsoft.com/highcharts.html\">Highcharts</a> (non-commercial), licensed under a <a href=\"http://creativecommons.org/licenses/by-nc/3.0/\">Creative "
+"Commons Attribution-NonCommercial 3.0 License</a>."
 msgstr ""
 
 #: src/olympia/pages/templates/pages/credits.html:65
 #, python-format
-msgid ""
-"For information on contributing, please see our <a href=\"%(url)s\">wiki "
-"page</a>."
+msgid "For information on contributing, please see our <a href=\"%(url)s\">wiki page</a>."
 msgstr ""
 
 #: src/olympia/pages/templates/pages/dev_faq.html:4
 msgid "Developer FAQ"
 msgstr ""
 
-#: src/olympia/pages/templates/pages/dev_faq.html:31
-#: src/olympia/pages/templates/pages/review_guide.html:33
+#: src/olympia/pages/templates/pages/dev_faq.html:31 src/olympia/pages/templates/pages/review_guide.html:33
 msgid "Sections"
 msgstr ""
 
-#: src/olympia/pages/templates/pages/dev_faq.html:33
-#: src/olympia/pages/templates/pages/dev_faq.html:45
+#: src/olympia/pages/templates/pages/dev_faq.html:33 src/olympia/pages/templates/pages/dev_faq.html:45
 msgid "Developing an Add-on"
 msgstr ""
 
 #. Heading for a list of resources for developers
-#: src/olympia/pages/templates/pages/dev_faq.html:34
-#: src/olympia/pages/templates/pages/dev_faq.html:208
+#: src/olympia/pages/templates/pages/dev_faq.html:34 src/olympia/pages/templates/pages/dev_faq.html:208
 msgid "Support Resources"
 msgstr ""
 
-#: src/olympia/pages/templates/pages/dev_faq.html:35
-#: src/olympia/pages/templates/pages/dev_faq.html:261
+#: src/olympia/pages/templates/pages/dev_faq.html:35 src/olympia/pages/templates/pages/dev_faq.html:261
 msgid "Contributing your Add-on"
 msgstr ""
 
-#: src/olympia/pages/templates/pages/dev_faq.html:36
-#: src/olympia/pages/templates/pages/dev_faq.html:381
+#: src/olympia/pages/templates/pages/dev_faq.html:36 src/olympia/pages/templates/pages/dev_faq.html:381
 msgid "Add-on Review Process"
 msgstr ""
 
-#: src/olympia/pages/templates/pages/dev_faq.html:37
-#: src/olympia/pages/templates/pages/dev_faq.html:444
+#: src/olympia/pages/templates/pages/dev_faq.html:37 src/olympia/pages/templates/pages/dev_faq.html:444
 msgid "Managing Your Add-on"
 msgstr ""
 
-#: src/olympia/pages/templates/pages/dev_faq.html:39
-#: src/olympia/pages/templates/pages/dev_faq.html:528
+#: src/olympia/pages/templates/pages/dev_faq.html:39 src/olympia/pages/templates/pages/dev_faq.html:528
 msgid "References for Open Source Licenses"
 msgstr ""
 
@@ -10947,10 +9432,7 @@ msgstr ""
 
 #: src/olympia/pages/templates/pages/dev_faq.html:47
 #, python-format
-msgid ""
-"<h3>How do I build an Add-on?</h3> <p> Mozilla provides documentation on how"
-" to build an add-on via the <a href=\"%(url)s\">Mozilla Developer "
-"Network</a>. </p>"
+msgid "<h3>How do I build an Add-on?</h3> <p> Mozilla provides documentation on how to build an add-on via the <a href=\"%(url)s\">Mozilla Developer Network</a>. </p>"
 msgstr ""
 
 #: src/olympia/pages/templates/pages/dev_faq.html:55
@@ -10971,9 +9453,8 @@ msgstr ""
 
 #: src/olympia/pages/templates/pages/dev_faq.html:68
 msgid ""
-"You will need to have a version of the Mozilla software that you're building"
-" the add-on for and a code editor of your choice. Add-ons can be built for "
-"almost all Mozilla software but are primarily targeted for:"
+"You will need to have a version of the Mozilla software that you're building the add-on for and a code editor of your choice. Add-ons can be built for almost all Mozilla software but are primarily "
+"targeted for:"
 msgstr ""
 
 #: src/olympia/pages/templates/pages/dev_faq.html:82
@@ -10983,18 +9464,13 @@ msgstr ""
 #. This is a list of popular code editors.  Feel free to adjust as you like.
 #: src/olympia/pages/templates/pages/dev_faq.html:85
 msgid ""
-"<li><a href=\"http://komodoide.com/komodo-edit/\">Komodo Edit</a></li> "
-"<li><a href=\"http://macromates.com/\">TextMate</a></li> <li><a href=\"http"
-"://notepad-plus-plus.org/\">Notepad++</a></li> <li><a "
-"href=\"http://www.eclipse.org/\">Eclipse IDE</a></li>"
+"<li><a href=\"http://komodoide.com/komodo-edit/\">Komodo Edit</a></li> <li><a href=\"http://macromates.com/\">TextMate</a></li> <li><a href=\"http://notepad-plus-plus.org/\">Notepad++</a></li> "
+"<li><a href=\"http://www.eclipse.org/\">Eclipse IDE</a></li>"
 msgstr ""
 
 #: src/olympia/pages/templates/pages/dev_faq.html:94
 #, python-format
-msgid ""
-"You can also learn more about setting up your development environment via "
-"the MDN article <a href=\"%(url)s\">Setting up extension development "
-"environment</a>"
+msgid "You can also learn more about setting up your development environment via the MDN article <a href=\"%(url)s\">Setting up extension development environment</a>"
 msgstr ""
 
 #: src/olympia/pages/templates/pages/dev_faq.html:100
@@ -11002,9 +9478,7 @@ msgid "What is a \".xpi\" file?"
 msgstr ""
 
 #: src/olympia/pages/templates/pages/dev_faq.html:102
-msgid ""
-"Extensions are packaged and distributed in ZIP files or Bundles, with the "
-"XPI (pronounced \"zippy\") file extension."
+msgid "Extensions are packaged and distributed in ZIP files or Bundles, with the XPI (pronounced \"zippy\") file extension."
 msgstr ""
 
 #: src/olympia/pages/templates/pages/dev_faq.html:108
@@ -11013,10 +9487,8 @@ msgstr ""
 
 #: src/olympia/pages/templates/pages/dev_faq.html:110
 msgid ""
-"XUL (XML User Interface Language) is Mozilla's XML-based language that lets "
-"you build feature-rich cross platform applications. It provides user "
-"interface widgets like buttons, menus, toolbars, trees, etc that can be used"
-" to enhance add-ons by modifying parts of the browser UI."
+"XUL (XML User Interface Language) is Mozilla's XML-based language that lets you build feature-rich cross platform applications. It provides user interface widgets like buttons, menus, toolbars, "
+"trees, etc that can be used to enhance add-ons by modifying parts of the browser UI."
 msgstr ""
 
 #: src/olympia/pages/templates/pages/dev_faq.html:119
@@ -11026,13 +9498,9 @@ msgstr ""
 #: src/olympia/pages/templates/pages/dev_faq.html:121
 #, python-format
 msgid ""
-"This file, called an <a href=\"%(url)s\">Install Manifest</a>, is used by "
-"Add-on Manager-enabled XUL applications to determine information about an "
-"add-on as it is being installed. It contains metadata identifying the add-"
-"on, providing information about who created it, where more information can "
-"be found about it, which versions of what applications it is compatible "
-"with, how it should be updated, and so on. The format of the Install "
-"Manifest is RDF/XML."
+"This file, called an <a href=\"%(url)s\">Install Manifest</a>, is used by Add-on Manager-enabled XUL applications to determine information about an add-on as it is being installed. It contains "
+"metadata identifying the add-on, providing information about who created it, where more information can be found about it, which versions of what applications it is compatible with, how it should "
+"be updated, and so on. The format of the Install Manifest is RDF/XML."
 msgstr ""
 
 #: src/olympia/pages/templates/pages/dev_faq.html:132
@@ -11040,10 +9508,7 @@ msgid "What does \"maxVersion\" mean?"
 msgstr ""
 
 #: src/olympia/pages/templates/pages/dev_faq.html:134
-msgid ""
-"This determines the maximum version of Firefox you're saying this extension "
-"will work with. Set this to be no newer than the newest currently available "
-"version!"
+msgid "This determines the maximum version of Firefox you're saying this extension will work with. Set this to be no newer than the newest currently available version!"
 msgstr ""
 
 #: src/olympia/pages/templates/pages/dev_faq.html:141
@@ -11053,27 +9518,18 @@ msgstr ""
 #: src/olympia/pages/templates/pages/dev_faq.html:143
 #, python-format
 msgid ""
-"Yes. You can use Mozilla's <a href=\"%(url)s\">XPCOM component object "
-"model</a> to enhance your add-ons. XPCOM components be used and implemented "
-"in JavaScript, Java, and Python in addition to C++."
+"Yes. You can use Mozilla's <a href=\"%(url)s\">XPCOM component object model</a> to enhance your add-ons. XPCOM components be used and implemented in JavaScript, Java, and Python in addition to C++."
 msgstr ""
 
 #: src/olympia/pages/templates/pages/dev_faq.html:150
-msgid ""
-"Can I use a JavaScript library like jQuery, MooTools or Prototype to build "
-"my add-on?"
+msgid "Can I use a JavaScript library like jQuery, MooTools or Prototype to build my add-on?"
 msgstr ""
 
 #: src/olympia/pages/templates/pages/dev_faq.html:152
 msgid ""
-"Yes. It's possible, but some of the functionality provided by these "
-"libraries are available through XPCOM, XUL, and JavaScript. In addition, "
-"authors should take care if libraries modify primitive object prototypes "
-"(String.prototype, Date.prototype, etc.) and/or define global functions (eg."
-" the $ function). These are prone to cause conflict with other add-ons, in "
-"particular if different add-ons use different versions of libraries and so "
-"on. Developers need to be very, very careful with using them. Mozilla does "
-"not offer documentation on using them to build add-ons."
+"Yes. It's possible, but some of the functionality provided by these libraries are available through XPCOM, XUL, and JavaScript. In addition, authors should take care if libraries modify primitive "
+"object prototypes (String.prototype, Date.prototype, etc.) and/or define global functions (eg. the $ function). These are prone to cause conflict with other add-ons, in particular if different add-"
+"ons use different versions of libraries and so on. Developers need to be very, very careful with using them. Mozilla does not offer documentation on using them to build add-ons."
 msgstr ""
 
 #: src/olympia/pages/templates/pages/dev_faq.html:165
@@ -11086,20 +9542,14 @@ msgid "You can use the <a href=\"%(url)s\">Add-on Debugger</a>."
 msgstr ""
 
 #: src/olympia/pages/templates/pages/dev_faq.html:172
-msgid ""
-"How do I test for compatibility with the latest version of Mozilla software?"
+msgid "How do I test for compatibility with the latest version of Mozilla software?"
 msgstr ""
 
 #: src/olympia/pages/templates/pages/dev_faq.html:174
 msgid ""
-"To ensure compatibility with the latest Mozilla software, it's important to "
-"download updates as they become available and test your add-on to ensure "
-"that it is still functioning as expected. In many cases, the latest version "
-"of Mozilla software may be a beta release. Since these releases at times "
-"introduce architectural changes that may impact the functionality of your "
-"add-on, it's important to be actively involved in the beta process to ensure"
-" that your add-on users are not negatively impacted upon final release of "
-"Mozilla software."
+"To ensure compatibility with the latest Mozilla software, it's important to download updates as they become available and test your add-on to ensure that it is still functioning as expected. In "
+"many cases, the latest version of Mozilla software may be a beta release. Since these releases at times introduce architectural changes that may impact the functionality of your add-on, it's "
+"important to be actively involved in the beta process to ensure that your add-on users are not negatively impacted upon final release of Mozilla software."
 msgstr ""
 
 #: src/olympia/pages/templates/pages/dev_faq.html:185
@@ -11109,11 +9559,8 @@ msgstr ""
 #: src/olympia/pages/templates/pages/dev_faq.html:187
 #, python-format
 msgid ""
-"Poorly written extensions can have a severe impact on the browsing "
-"experience, including on the overall performance of Firefox itself. The "
-"following page contains many good <a href=\"%(url)s\">guides</a> that help "
-"you improve performance, whether you're developing core Mozilla code or an "
-"add-on."
+"Poorly written extensions can have a severe impact on the browsing experience, including on the overall performance of Firefox itself. The following page contains many good <a href=\"%(url)s"
+"\">guides</a> that help you improve performance, whether you're developing core Mozilla code or an add-on."
 msgstr ""
 
 #: src/olympia/pages/templates/pages/dev_faq.html:195
@@ -11123,10 +9570,8 @@ msgstr ""
 #: src/olympia/pages/templates/pages/dev_faq.html:197
 #, python-format
 msgid ""
-"Yes. Details on localizing your add-on can be found in the the <a "
-"href=\"%(l10n_url)s\">Mozilla Developer Network Localization page</a>. <a "
-"href=\"%(bz_url)s\">The BabelZilla project</a> is also a great resource for "
-"learning about localization and volunteering to help translate add-ons."
+"Yes. Details on localizing your add-on can be found in the the <a href=\"%(l10n_url)s\">Mozilla Developer Network Localization page</a>. <a href=\"%(bz_url)s\">The BabelZilla project</a> is also a "
+"great resource for learning about localization and volunteering to help translate add-ons."
 msgstr ""
 
 #: src/olympia/pages/templates/pages/dev_faq.html:210
@@ -11145,9 +9590,7 @@ msgstr ""
 
 #. #jetpack is the name of the IRC channel.  do not change.
 #: src/olympia/pages/templates/pages/dev_faq.html:220
-msgid ""
-"#jetpack (for discussions about the Add-ons SDK and cfx/jpm - formerly known"
-" as Jetpack)"
+msgid "#jetpack (for discussions about the Add-ons SDK and cfx/jpm - formerly known as Jetpack)"
 msgstr ""
 
 #. Label for a link to the extension developers mailing list
@@ -11188,11 +9631,8 @@ msgstr ""
 #: src/olympia/pages/templates/pages/dev_faq.html:248
 #, python-format
 msgid ""
-"Yes. You may find 3rd party developers via the <a href=\"%(forum_url)s"
-"\">Add-ons forum</a>, <a href=\"%(list_url)s\">mozilla.jobs list</a>, <a "
-"href=\"%(mz_url)s\">mozillaZine forums</a> or <a href=\"%(wiki_url)s\">the "
-"Mozilla Wiki</a>. Please note that Mozilla does not offer developer "
-"recommendations."
+"Yes. You may find 3rd party developers via the <a href=\"%(forum_url)s\">Add-ons forum</a>, <a href=\"%(list_url)s\">mozilla.jobs list</a>, <a href=\"%(mz_url)s\">mozillaZine forums</a> or <a href="
+"\"%(wiki_url)s\">the Mozilla Wiki</a>. Please note that Mozilla does not offer developer recommendations."
 msgstr ""
 
 #: src/olympia/pages/templates/pages/dev_faq.html:263
@@ -11202,13 +9642,9 @@ msgstr ""
 #: src/olympia/pages/templates/pages/dev_faq.html:265
 #, python-format
 msgid ""
-"Yes. Many developers choose to host their own add-ons. Choosing to host your"
-" add-on on <a href=\"%(amo_url)s\">Mozilla's add-on site</a>, though, allows"
-" for much greater exposure to your add-on due to the large volume of "
-"visitors to the site. <a href=\"%(md_url)s\">mozdev.org</a> offers free "
-"project hosting for Mozilla applications and extensions providing developers"
-" with tools to help manage source code, version control, bug tracking and "
-"documentation."
+"Yes. Many developers choose to host their own add-ons. Choosing to host your add-on on <a href=\"%(amo_url)s\">Mozilla's add-on site</a>, though, allows for much greater exposure to your add-on due "
+"to the large volume of visitors to the site. <a href=\"%(md_url)s\">mozdev.org</a> offers free project hosting for Mozilla applications and extensions providing developers with tools to help manage "
+"source code, version control, bug tracking and documentation."
 msgstr ""
 
 #: src/olympia/pages/templates/pages/dev_faq.html:277
@@ -11217,9 +9653,7 @@ msgstr ""
 
 #: src/olympia/pages/templates/pages/dev_faq.html:279
 #, python-format
-msgid ""
-"Yes. You can host your add-on on <a href=\"%(url)s\">Mozilla's add-on "
-"website</a>."
+msgid "Yes. You can host your add-on on <a href=\"%(url)s\">Mozilla's add-on website</a>."
 msgstr ""
 
 #: src/olympia/pages/templates/pages/dev_faq.html:284
@@ -11228,12 +9662,8 @@ msgstr ""
 
 #: src/olympia/pages/templates/pages/dev_faq.html:286
 msgid ""
-"Mozilla's AMO (<a "
-"href=\"https://addons.mozilla.org\">https://addons.mozilla.org</a>) is the "
-"incubator that helps developers build, distribute, and support fantastic "
-"consumer products powered by Mozilla. It provides you the tools and "
-"infrastructure necessary to manage, host and expose your add-on to a massive"
-" base of Mozilla users."
+"Mozilla's AMO (<a href=\"https://addons.mozilla.org\">https://addons.mozilla.org</a>) is the incubator that helps developers build, distribute, and support fantastic consumer products powered by "
+"Mozilla. It provides you the tools and infrastructure necessary to manage, host and expose your add-on to a massive base of Mozilla users."
 msgstr ""
 
 #: src/olympia/pages/templates/pages/dev_faq.html:295
@@ -11242,9 +9672,7 @@ msgstr ""
 
 #: src/olympia/pages/templates/pages/dev_faq.html:297
 #, python-format
-msgid ""
-"Yes. Our <a href=\"%(url)s\">Privacy Policy</a> describes how your "
-"information is managed by Mozilla."
+msgid "Yes. Our <a href=\"%(url)s\">Privacy Policy</a> describes how your information is managed by Mozilla."
 msgstr ""
 
 #: src/olympia/pages/templates/pages/dev_faq.html:302
@@ -11253,25 +9681,19 @@ msgstr ""
 
 #: src/olympia/pages/templates/pages/dev_faq.html:304
 msgid ""
-"The \"Developer Tools\" dashboard is the area that provides you the tools to"
-" successfully manage your add-ons. It provides the functionality necessary "
-"to submit your add-ons to AMO, manage add-on information, and review "
-"statistics."
+"The \"Developer Tools\" dashboard is the area that provides you the tools to successfully manage your add-ons. It provides the functionality necessary to submit your add-ons to AMO, manage add-on "
+"information, and review statistics."
 msgstr ""
 
 #: src/olympia/pages/templates/pages/dev_faq.html:312
-msgid ""
-"Does Mozilla have a policy in place as to what is an acceptable submission?"
+msgid "Does Mozilla have a policy in place as to what is an acceptable submission?"
 msgstr ""
 
 #: src/olympia/pages/templates/pages/dev_faq.html:314
 #, python-format
 msgid ""
-"Yes. Mozilla's <a href=\"%(p_url)s\">Add-on Policy</a> describes what is an "
-"acceptable submission. This policy is subject to change without notice. In "
-"addition, the AMO editorial team uses the <a href=\"%(g_url)s\">Editors "
-"Reviewing Guide</a> to ensure that your add-on meets specific guidelines for"
-" functionality and security."
+"Yes. Mozilla's <a href=\"%(p_url)s\">Add-on Policy</a> describes what is an acceptable submission. This policy is subject to change without notice. In addition, the AMO editorial team uses the <a "
+"href=\"%(g_url)s\">Editors Reviewing Guide</a> to ensure that your add-on meets specific guidelines for functionality and security."
 msgstr ""
 
 #: src/olympia/pages/templates/pages/dev_faq.html:324
@@ -11281,11 +9703,8 @@ msgstr ""
 #: src/olympia/pages/templates/pages/dev_faq.html:326
 #, python-format
 msgid ""
-"The Developer Tools dashboard will allow you to upload and submit add-ons to"
-" AMO. You must be a registered AMO users before you can submit an add-on. "
-"Before submitting your add-on be sure to you have read the AMO <a "
-"href=\"%(url)s\">Editors Reviewing Guide</a> to ensure that your add-on has "
-"met the guidelines used by editors to review add-ons."
+"The Developer Tools dashboard will allow you to upload and submit add-ons to AMO. You must be a registered AMO users before you can submit an add-on. Before submitting your add-on be sure to you "
+"have read the AMO <a href=\"%(url)s\">Editors Reviewing Guide</a> to ensure that your add-on has met the guidelines used by editors to review add-ons."
 msgstr ""
 
 #: src/olympia/pages/templates/pages/dev_faq.html:336
@@ -11293,9 +9712,7 @@ msgid "What operating system do I choose for my add-on?"
 msgstr ""
 
 #: src/olympia/pages/templates/pages/dev_faq.html:338
-msgid ""
-"You must choose the operating systems on which your add-on will successfully"
-" function."
+msgid "You must choose the operating systems on which your add-on will successfully function."
 msgstr ""
 
 #: src/olympia/pages/templates/pages/dev_faq.html:344
@@ -11304,11 +9721,8 @@ msgstr ""
 
 #: src/olympia/pages/templates/pages/dev_faq.html:346
 msgid ""
-"The choice of category is dependent on what type of audience you are "
-"targeting and the functionality of your add-on. If you're unsure of which "
-"category your add-on falls into, please choose \"Other\". The AMO team may "
-"re-categorize your add-on if it's determined that it's better suited in a "
-"different category."
+"The choice of category is dependent on what type of audience you are targeting and the functionality of your add-on. If you're unsure of which category your add-on falls into, please choose \"Other"
+"\". The AMO team may re-categorize your add-on if it's determined that it's better suited in a different category."
 msgstr ""
 
 #: src/olympia/pages/templates/pages/dev_faq.html:355
@@ -11316,9 +9730,7 @@ msgid "What does \"nominating\" my add-on mean?"
 msgstr ""
 
 #: src/olympia/pages/templates/pages/dev_faq.html:357
-msgid ""
-"Nominated add-ons are new add-ons that the author has nominated to become "
-"public via the Developer Tools."
+msgid "Nominated add-ons are new add-ons that the author has nominated to become public via the Developer Tools."
 msgstr ""
 
 #: src/olympia/pages/templates/pages/dev_faq.html:363
@@ -11326,10 +9738,7 @@ msgid "Can I specify a license agreement for using my add-on?"
 msgstr ""
 
 #: src/olympia/pages/templates/pages/dev_faq.html:365
-msgid ""
-"Yes. You can specify a license agreement when submitting your add-on. You "
-"can also add or update a license agreement via the Developer Tools dashboard"
-" after your add-on has been submitted."
+msgid "Yes. You can specify a license agreement when submitting your add-on. You can also add or update a license agreement via the Developer Tools dashboard after your add-on has been submitted."
 msgstr ""
 
 #: src/olympia/pages/templates/pages/dev_faq.html:372
@@ -11337,10 +9746,7 @@ msgid "Can I include a privacy policy for my add-on?"
 msgstr ""
 
 #: src/olympia/pages/templates/pages/dev_faq.html:374
-msgid ""
-"Yes. You can specify a privacy policy when submitting your add-on. You can "
-"also add or update a privacy policy via the Developer Tools dashboard after "
-"your add-on has been submitted."
+msgid "Yes. You can specify a privacy policy when submitting your add-on. You can also add or update a privacy policy via the Developer Tools dashboard after your add-on has been submitted."
 msgstr ""
 
 #: src/olympia/pages/templates/pages/dev_faq.html:383
@@ -11350,10 +9756,8 @@ msgstr ""
 #: src/olympia/pages/templates/pages/dev_faq.html:385
 #, python-format
 msgid ""
-"All add-ons submitted, whether new or updated, are reviewed to ensure that "
-"Mozilla users have a stable and safe experience. All add-ons submissions are"
-" reviewed using the guidelines outlined in the <a href=\"%(url)s\">Editors "
-"Reviewing Guide</a>."
+"All add-ons submitted, whether new or updated, are reviewed to ensure that Mozilla users have a stable and safe experience. All add-ons submissions are reviewed using the guidelines outlined in the "
+"<a href=\"%(url)s\">Editors Reviewing Guide</a>."
 msgstr ""
 
 #: src/olympia/pages/templates/pages/dev_faq.html:393
@@ -11363,12 +9767,9 @@ msgstr ""
 #: src/olympia/pages/templates/pages/dev_faq.html:395
 #, python-format
 msgid ""
-"Add-ons are reviewed by the AMO Editors, a group of talented developers that"
-" volunteer to help the Mozilla project by reviewing add-ons to ensure a "
-"stable and safe experience for Mozilla users. When communicating with "
-"editors, please be courteous, patient and respectful as they are working "
-"hard to ensure that your add-on is set up correctly and follows the "
-"guidelines outlined in the <a href=\"%(url)s\">Editors Reviewing Guide</a>."
+"Add-ons are reviewed by the AMO Editors, a group of talented developers that volunteer to help the Mozilla project by reviewing add-ons to ensure a stable and safe experience for Mozilla users. "
+"When communicating with editors, please be courteous, patient and respectful as they are working hard to ensure that your add-on is set up correctly and follows the guidelines outlined in the <a "
+"href=\"%(url)s\">Editors Reviewing Guide</a>."
 msgstr ""
 
 #: src/olympia/pages/templates/pages/dev_faq.html:406
@@ -11378,11 +9779,8 @@ msgstr ""
 #: src/olympia/pages/templates/pages/dev_faq.html:408
 #, python-format
 msgid ""
-"The Mozilla editorial team follows the <a href=\"%(url)s\">Editors Reviewing"
-" Guide</a> when testing an add-on for acceptance onto AMO. It is important "
-"that add-on developers review this guide to ensure that common problem areas"
-" are addressed prior to submitting their add-on for review. This will "
-"greatly assist in expediting the review process."
+"The Mozilla editorial team follows the <a href=\"%(url)s\">Editors Reviewing Guide</a> when testing an add-on for acceptance onto AMO. It is important that add-on developers review this guide to "
+"ensure that common problem areas are addressed prior to submitting their add-on for review. This will greatly assist in expediting the review process."
 msgstr ""
 
 #: src/olympia/pages/templates/pages/dev_faq.html:418
@@ -11390,9 +9788,7 @@ msgid "How long will it take for my add-on to be reviewed?"
 msgstr ""
 
 #: src/olympia/pages/templates/pages/dev_faq.html:420
-msgid ""
-"We cannot give a time estimate as to how long it will take before an add-on "
-"is reviewed. Many factors affect the time including the:"
+msgid "We cannot give a time estimate as to how long it will take before an add-on is reviewed. Many factors affect the time including the:"
 msgstr ""
 
 #. part of a list (<li>)
@@ -11413,11 +9809,8 @@ msgstr ""
 #: src/olympia/pages/templates/pages/dev_faq.html:434
 #, python-format
 msgid ""
-"This is why it's very important to read the <a href=\"%(g_url)s\">Editors "
-"Reviewing Guide</a> to ensure that your add-on is setup as expected. It's "
-"also a good idea to read the blog post, <a "
-"href=\"%(blog_url)s\">Successfully Getting your Add-on Reviewed</a> which "
-"provides excellent insight into ensuring a smooth review of your add-on."
+"This is why it's very important to read the <a href=\"%(g_url)s\">Editors Reviewing Guide</a> to ensure that your add-on is setup as expected. It's also a good idea to read the blog post, <a href="
+"\"%(blog_url)s\">Successfully Getting your Add-on Reviewed</a> which provides excellent insight into ensuring a smooth review of your add-on."
 msgstr ""
 
 #: src/olympia/pages/templates/pages/dev_faq.html:446
@@ -11425,10 +9818,7 @@ msgid "How can I see how many times my add-on has been downloaded?"
 msgstr ""
 
 #: src/olympia/pages/templates/pages/dev_faq.html:448
-msgid ""
-"The Statistics Dashboard found in the Developer Tools dashboard provides "
-"information that can help you determine your add-on downloads since you've "
-"submitted it to AMO."
+msgid "The Statistics Dashboard found in the Developer Tools dashboard provides information that can help you determine your add-on downloads since you've submitted it to AMO."
 msgstr ""
 
 #: src/olympia/pages/templates/pages/dev_faq.html:455
@@ -11437,9 +9827,7 @@ msgstr ""
 
 #: src/olympia/pages/templates/pages/dev_faq.html:457
 msgid ""
-"The Statistics Dashboard found in the Developer Tools dashboard provides "
-"information that can help you determine how many users have been actively "
-"using your add-on since you've submitted it to AMO."
+"The Statistics Dashboard found in the Developer Tools dashboard provides information that can help you determine how many users have been actively using your add-on since you've submitted it to AMO."
 msgstr ""
 
 #: src/olympia/pages/templates/pages/dev_faq.html:464
@@ -11447,10 +9835,7 @@ msgid "How do I submit an update for my add-on?"
 msgstr ""
 
 #: src/olympia/pages/templates/pages/dev_faq.html:466
-msgid ""
-"You can submit an update for your add-on via the Developer Tools dashboard "
-"by choosing the option \"Upload a new version\" and uploading a new .xpi "
-"file for your add-on."
+msgid "You can submit an update for your add-on via the Developer Tools dashboard by choosing the option \"Upload a new version\" and uploading a new .xpi file for your add-on."
 msgstr ""
 
 #: src/olympia/pages/templates/pages/dev_faq.html:473
@@ -11459,39 +9844,30 @@ msgstr ""
 
 #: src/olympia/pages/templates/pages/dev_faq.html:475
 msgid ""
-"That depends. If you are simply changing a description of your add-on or "
-"updating a \"maxVersion\" to ensure compatibility with a new Mozilla "
-"software update, then your add-on does not need to be reviewed again. If, "
-"however, you submit a new updated file, then your add-on update will need to"
-" be reviewed by an editor."
+"That depends. If you are simply changing a description of your add-on or updating a \"maxVersion\" to ensure compatibility with a new Mozilla software update, then your add-on does not need to be "
+"reviewed again. If, however, you submit a new updated file, then your add-on update will need to be reviewed by an editor."
 msgstr ""
 
 #: src/olympia/pages/templates/pages/dev_faq.html:486
-msgid ""
-"How do I reply to a user who has posted a negative review of my add-on?"
+msgid "How do I reply to a user who has posted a negative review of my add-on?"
 msgstr ""
 
 #: src/olympia/pages/templates/pages/dev_faq.html:488
-msgid ""
-"A developer may reply to any review posted to their add-on as long as they "
-"are logged into AMO. In addition, any user can flag a review as:"
+msgid "A developer may reply to any review posted to their add-on as long as they are logged into AMO. In addition, any user can flag a review as:"
 msgstr ""
 
 #. part of a list (<li>)
-#: src/olympia/pages/templates/pages/dev_faq.html:495
-#: src/olympia/reviews/models.py:159
+#: src/olympia/pages/templates/pages/dev_faq.html:495 src/olympia/reviews/models.py:159
 msgid "Spam or otherwise non-review content"
 msgstr ""
 
 #. part of a list (<li>)
-#: src/olympia/pages/templates/pages/dev_faq.html:497
-#: src/olympia/reviews/models.py:160
+#: src/olympia/pages/templates/pages/dev_faq.html:497 src/olympia/reviews/models.py:160
 msgid "Inappropriate language/dialog"
 msgstr ""
 
 #. part of a list (<li>)
-#: src/olympia/pages/templates/pages/dev_faq.html:499
-#: src/olympia/reviews/models.py:161
+#: src/olympia/pages/templates/pages/dev_faq.html:499 src/olympia/reviews/models.py:161
 msgid "Misplaced bug report or support request"
 msgstr ""
 
@@ -11501,10 +9877,7 @@ msgid "Other (provides a pop-up prompt for information)"
 msgstr ""
 
 #: src/olympia/pages/templates/pages/dev_faq.html:504
-msgid ""
-"Currently, AMO does not provide a mechanism to directly communicate with a "
-"reviewer but this feature is being investigated and considered for a future "
-"update."
+msgid "Currently, AMO does not provide a mechanism to directly communicate with a reviewer but this feature is being investigated and considered for a future update."
 msgstr ""
 
 #: src/olympia/pages/templates/pages/dev_faq.html:511
@@ -11512,9 +9885,7 @@ msgid "Can I request that a review be removed if the review is negative?"
 msgstr ""
 
 #: src/olympia/pages/templates/pages/dev_faq.html:513
-msgid ""
-"No. We do not remove negative reviews from add-ons unless they are found to "
-"be false."
+msgid "No. We do not remove negative reviews from add-ons unless they are found to be false."
 msgstr ""
 
 #: src/olympia/pages/templates/pages/dev_faq.html:519
@@ -11522,55 +9893,36 @@ msgid "Can I request that a review be removed if the review is inaccurate?"
 msgstr ""
 
 #: src/olympia/pages/templates/pages/dev_faq.html:521
-msgid ""
-"If an author contacts us and asks for a review containing false or "
-"inaccurate information to be removed, we will review the post and consider "
-"removing it."
+msgid "If an author contacts us and asks for a review containing false or inaccurate information to be removed, we will review the post and consider removing it."
 msgstr ""
 
 #: src/olympia/pages/templates/pages/dev_faq.html:530
 msgid ""
-"Do you need more information about the various open source licenses? Are you"
-" confused as to which license you should select? What rights does a specific"
-" license grant? While nothing replaces reading the full terms of a license, "
-"below are some sites that contain information about some of the key open "
-"source licenses that may help you sort out the differences between them. "
-"These sites are being provided solely for your convenience and as a "
-"reference for your personal use. These resources do not constitute legal "
-"advice nor should they be used in lieu of such advice. Mozilla neither "
-"guarantees nor is responsible for the content of these sites or your "
-"reliance on such content."
+"Do you need more information about the various open source licenses? Are you confused as to which license you should select? What rights does a specific license grant? While nothing replaces "
+"reading the full terms of a license, below are some sites that contain information about some of the key open source licenses that may help you sort out the differences between them. These sites "
+"are being provided solely for your convenience and as a reference for your personal use. These resources do not constitute legal advice nor should they be used in lieu of such advice. Mozilla "
+"neither guarantees nor is responsible for the content of these sites or your reliance on such content."
 msgstr ""
 
 #: src/olympia/pages/templates/pages/dev_faq.html:545
 msgid ""
-"In addition to the full text of the Mozilla Public License(\"MPL\"), this "
-"also provides an annotated version of the MPL and an <abbr "
-"title=\"Frequently Asked Questions\">FAQ</abbr> to help you if you want to "
-"use or distribute code licensed under it."
+"In addition to the full text of the Mozilla Public License(\"MPL\"), this also provides an annotated version of the MPL and an <abbr title=\"Frequently Asked Questions\">FAQ</abbr> to help you if "
+"you want to use or distribute code licensed under it."
 msgstr ""
 
 #: src/olympia/pages/templates/pages/dev_faq.html:559
-msgid ""
-"A table summarizing and comparing how some of the key open source licenses "
-"treat distributions, proprietary software linking, and redistribution of "
-"code with changes."
+msgid "A table summarizing and comparing how some of the key open source licenses treat distributions, proprietary software linking, and redistribution of code with changes."
 msgstr ""
 
 #: src/olympia/pages/templates/pages/dev_faq.html:572
 msgid ""
-"Free Software Foundation provides short summaries of the key open source "
-"licenses, including whether the license qualifies as a free software license"
-" or a copyleft license. Also includes a discussion of what constitutes a "
-"free software license or a copyleft license (e.g., a Copyleft license is a "
-"general method for making a program or other work free, and requiring all "
-"modified and extended versions of the program to be free as well.)"
+"Free Software Foundation provides short summaries of the key open source licenses, including whether the license qualifies as a free software license or a copyleft license. Also includes a "
+"discussion of what constitutes a free software license or a copyleft license (e.g., a Copyleft license is a general method for making a program or other work free, and requiring all modified and "
+"extended versions of the program to be free as well.)"
 msgstr ""
 
 #: src/olympia/pages/templates/pages/dev_faq.html:589
-msgid ""
-"Open Source Initiative provides the terms of some of the key open source "
-"licenses."
+msgid "Open Source Initiative provides the terms of some of the key open source licenses."
 msgstr ""
 
 #: src/olympia/pages/templates/pages/dev_faq.html:599
@@ -11578,14 +9930,10 @@ msgid "A comparison of known open source licenses on Wikipedia."
 msgstr ""
 
 #: src/olympia/pages/templates/pages/dev_faq.html:605
-msgid ""
-"A site to provide non-judgmental guidance on choosing a license for your "
-"open source project."
+msgid "A site to provide non-judgmental guidance on choosing a license for your open source project."
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:3
-#: src/olympia/pages/templates/pages/faq.html:9
-#: src/olympia/pages/templates/pages/faq.html:10
+#: src/olympia/pages/templates/pages/faq.html:3 src/olympia/pages/templates/pages/faq.html:9 src/olympia/pages/templates/pages/faq.html:10
 msgid "Frequently Asked Questions"
 msgstr ""
 
@@ -11600,12 +9948,8 @@ msgstr ""
 #: src/olympia/pages/templates/pages/faq.html:16
 #, python-format
 msgid ""
-"Add-ons are small pieces of software that add new features or functionality "
-"to your installation of %(app_name)s. Add-ons can augment %(app_name)s with "
-"new features, foreign language dictionaries, or change its visual "
-"appearance. Through add-ons, you can customize %(app_name)s to meet your "
-"needs and tastes. <a href=\"%(learnmore_url)s\">Learn more about "
-"customization</a>"
+"Add-ons are small pieces of software that add new features or functionality to your installation of %(app_name)s. Add-ons can augment %(app_name)s with new features, foreign language dictionaries, "
+"or change its visual appearance. Through add-ons, you can customize %(app_name)s to meet your needs and tastes. <a href=\"%(learnmore_url)s\">Learn more about customization</a>"
 msgstr ""
 
 #: src/olympia/pages/templates/pages/faq.html:26
@@ -11615,15 +9959,9 @@ msgstr ""
 #: src/olympia/pages/templates/pages/faq.html:27
 #, python-format
 msgid ""
-"Add-ons listed in this gallery only work with Mozilla-based applications, "
-"such as <a href=\"%(getfirefox_url)s\">Firefox</a>, <a "
-"href=\"%(getmobile_url)s\">Firefox Mobile</a>, <a "
-"href=\"%(getseamonkey_url)s\">SeaMonkey</a>, and <a "
-"href=\"%(getthunderbird_url)s\">Thunderbird</a>. However, not all add-ons "
-"work with each of those applications or every version of those applications."
-" Each add-on specifies which applications and versions it works with, such "
-"as Firefox 2.0 - 3.6.*. For Firefox add-ons, the install buttons will "
-"indicate whether the add-on is compatible or not."
+"Add-ons listed in this gallery only work with Mozilla-based applications, such as <a href=\"%(getfirefox_url)s\">Firefox</a>, <a href=\"%(getmobile_url)s\">Firefox Mobile</a>, <a href="
+"\"%(getseamonkey_url)s\">SeaMonkey</a>, and <a href=\"%(getthunderbird_url)s\">Thunderbird</a>. However, not all add-ons work with each of those applications or every version of those applications. "
+"Each add-on specifies which applications and versions it works with, such as Firefox 2.0 - 3.6.*. For Firefox add-ons, the install buttons will indicate whether the add-on is compatible or not."
 msgstr ""
 
 #: src/olympia/pages/templates/pages/faq.html:42
@@ -11632,57 +9970,39 @@ msgstr ""
 
 #: src/olympia/pages/templates/pages/faq.html:43
 #, python-format
-msgid ""
-"There are several kinds of add-ons that customize %(app_name)s in different "
-"ways:"
+msgid "There are several kinds of add-ons that customize %(app_name)s in different ways:"
 msgstr ""
 
 #: src/olympia/pages/templates/pages/faq.html:47
 #, python-format
 msgid ""
-"<strong><a href=\"%(browse_url)s\">Extensions</a></strong> add new features "
-"to %(app_name)s or modify existing functionality. There are extensions that "
-"allow you to block advertisements, download videos from websites, integrate "
-"more closely with social websites, and add features you see in other "
-"applications."
+"<strong><a href=\"%(browse_url)s\">Extensions</a></strong> add new features to %(app_name)s or modify existing functionality. There are extensions that allow you to block advertisements, download "
+"videos from websites, integrate more closely with social websites, and add features you see in other applications."
 msgstr ""
 
 #: src/olympia/pages/templates/pages/faq.html:55
 #, python-format
-msgid ""
-"<strong><a href=\"%(browse_url)s\">Complete Themes</a></strong> change the "
-"entire appearance of %(app_name)s, usually including icons, colors, dialogs,"
-" and other visual styles."
+msgid "<strong><a href=\"%(browse_url)s\">Complete Themes</a></strong> change the entire appearance of %(app_name)s, usually including icons, colors, dialogs, and other visual styles."
 msgstr ""
 
 #: src/olympia/pages/templates/pages/faq.html:61
 #, python-format
-msgid ""
-"<strong><a href=\"%(browse_url)s\">Themes</a></strong> are lightweight "
-"themes that use background images to customize your %(app_name)s toolbars."
+msgid "<strong><a href=\"%(browse_url)s\">Themes</a></strong> are lightweight themes that use background images to customize your %(app_name)s toolbars."
 msgstr ""
 
 #: src/olympia/pages/templates/pages/faq.html:66
 #, python-format
-msgid ""
-"<strong><a href=\"%(browse_url)s\">Search Providers</a> </strong> add "
-"additional choices to the search box dropdown. These providers allow you to "
-"quickly search any website."
+msgid "<strong><a href=\"%(browse_url)s\">Search Providers</a> </strong> add additional choices to the search box dropdown. These providers allow you to quickly search any website."
 msgstr ""
 
 #: src/olympia/pages/templates/pages/faq.html:72
 #, python-format
-msgid ""
-"<strong><a href=\"%(browse_url)s\">Dictionaries & Language "
-"Packs</a></strong> add support for additional languages to %(app_name)s."
+msgid "<strong><a href=\"%(browse_url)s\">Dictionaries & Language Packs</a></strong> add support for additional languages to %(app_name)s."
 msgstr ""
 
 #: src/olympia/pages/templates/pages/faq.html:77
 #, python-format
-msgid ""
-"<strong><a href=\"%(browse_url)s\">Plugins</a></strong> help %(app_name)s "
-"display or understand different types of media, such as Adobe Flash or Apple"
-" Quicktime."
+msgid "<strong><a href=\"%(browse_url)s\">Plugins</a></strong> help %(app_name)s display or understand different types of media, such as Adobe Flash or Apple Quicktime."
 msgstr ""
 
 #: src/olympia/pages/templates/pages/faq.html:85
@@ -11692,13 +10012,9 @@ msgstr ""
 #: src/olympia/pages/templates/pages/faq.html:86
 #, python-format
 msgid ""
-"In most cases, add-ons can be installed by simply clicking the install "
-"button provided. Add-ons can be managed, disabled, or uninstalled from the "
-"Add-ons Manager in %(app_name)s. For more detailed instructions, read <a "
-"href=\"%(extension_url)s\">this article on extensions</a> or <a "
-"href=\"%(theme_url)s\">this one for Themes and Complete Themes</a>. If you "
-"have difficulty installing add-ons, see <a "
-"href=\"%(troubleshooting_url)s\">Troubleshooting Extensions and Themes</a>."
+"In most cases, add-ons can be installed by simply clicking the install button provided. Add-ons can be managed, disabled, or uninstalled from the Add-ons Manager in %(app_name)s. For more detailed "
+"instructions, read <a href=\"%(extension_url)s\">this article on extensions</a> or <a href=\"%(theme_url)s\">this one for Themes and Complete Themes</a>. If you have difficulty installing add-ons, "
+"see <a href=\"%(troubleshooting_url)s\">Troubleshooting Extensions and Themes</a>."
 msgstr ""
 
 #: src/olympia/pages/templates/pages/faq.html:100
@@ -11708,11 +10024,8 @@ msgstr ""
 #: src/olympia/pages/templates/pages/faq.html:101
 #, python-format
 msgid ""
-"In Firefox, add-ons marked with \"No restart required\" can be installed "
-"without restarting. These add-ons have been created using the <a "
-"href=\"%(sdk_url)s\">Add-on SDK</a> or <a "
-"href=\"%(bootstrap_url)s\">bootstrapping</a>. Other add-ons will still "
-"require a restart before you can use them."
+"In Firefox, add-ons marked with \"No restart required\" can be installed without restarting. These add-ons have been created using the <a href=\"%(sdk_url)s\">Add-on SDK</a> or <a href="
+"\"%(bootstrap_url)s\">bootstrapping</a>. Other add-ons will still require a restart before you can use them."
 msgstr ""
 
 #: src/olympia/pages/templates/pages/faq.html:110
@@ -11722,13 +10035,9 @@ msgstr ""
 #: src/olympia/pages/templates/pages/faq.html:111
 #, python-format
 msgid ""
-"Add-ons, unlike plugins, are automatically checked for updates once every "
-"day. In Firefox, updates are automatically installed by default. Versions of"
-" Firefox prior to 4 (and other applications) will alert you that updates to "
-"your add-ons are available. <a href=\"%(plugin_url)s\">Plugins</a> are not "
-"currently automatically checked for updates, so be sure to regularly visit "
-"the <a href=\"%(plugincheck_url)s\">Plugin Check</a> page to stay up-to-"
-"date."
+"Add-ons, unlike plugins, are automatically checked for updates once every day. In Firefox, updates are automatically installed by default. Versions of Firefox prior to 4 (and other applications) "
+"will alert you that updates to your add-ons are available. <a href=\"%(plugin_url)s\">Plugins</a> are not currently automatically checked for updates, so be sure to regularly visit the <a href="
+"\"%(plugincheck_url)s\">Plugin Check</a> page to stay up-to-date."
 msgstr ""
 
 #: src/olympia/pages/templates/pages/faq.html:122
@@ -11738,12 +10047,9 @@ msgstr ""
 #: src/olympia/pages/templates/pages/faq.html:123
 #, python-format
 msgid ""
-"Unless clearly marked otherwise, add-ons available from this gallery have "
-"been checked and approved by Mozilla's team of editors and are safe to "
-"install. We recommend that you only install approved add-ons. If you wish to"
-" install unapproved add-ons or add-ons from third-party websites, use "
-"caution as these add-ons may harm your computer or violate your privacy. <a "
-"href=\"%(learnmore_url)s\">Learn more about our approval process</a>"
+"Unless clearly marked otherwise, add-ons available from this gallery have been checked and approved by Mozilla's team of editors and are safe to install. We recommend that you only install approved "
+"add-ons. If you wish to install unapproved add-ons or add-ons from third-party websites, use caution as these add-ons may harm your computer or violate your privacy. <a href=\"%(learnmore_url)s"
+"\">Learn more about our approval process</a>"
 msgstr ""
 
 #: src/olympia/pages/templates/pages/faq.html:133
@@ -11754,30 +10060,21 @@ msgstr ""
 #: src/olympia/pages/templates/pages/faq.html:135
 #, python-format
 msgid ""
-"Most add-ons do not cause a perceivable performance decrease in "
-"%(app_name)s, though installing an excessive number may have adverse "
-"effects. If you suspect an add-on is causing %(app_name)s to be slow, try "
-"disabling it."
+"Most add-ons do not cause a perceivable performance decrease in %(app_name)s, though installing an excessive number may have adverse effects. If you suspect an add-on is causing %(app_name)s to be "
+"slow, try disabling it."
 msgstr ""
 
 #: src/olympia/pages/templates/pages/faq.html:141
 #, python-format
-msgid ""
-"%(app_name)s told me an add-on isn't compatible. Is there a way I can still "
-"use it?"
+msgid "%(app_name)s told me an add-on isn't compatible. Is there a way I can still use it?"
 msgstr ""
 
 #: src/olympia/pages/templates/pages/faq.html:144
 #, python-format
 msgid ""
-"If an add-on isn't compatible with your version of %(app_name)s, it is "
-"usually either because your version of %(app_name)s is outdated or the add-"
-"on author has not yet updated the add-on to be compatible with a newer "
-"version you are using. Mozilla does not recommend trying to circumvent these"
-" compatibility checks, as they can lead to browser instability or in some "
-"cases loss of data. For users who are testing out alpha or beta versions of "
-"Firefox, we offer the <a href=\"%(acr_url)s\">Add-on Compatibility "
-"Reporter</a> to help add-on developers update their compatibility."
+"If an add-on isn't compatible with your version of %(app_name)s, it is usually either because your version of %(app_name)s is outdated or the add-on author has not yet updated the add-on to be "
+"compatible with a newer version you are using. Mozilla does not recommend trying to circumvent these compatibility checks, as they can lead to browser instability or in some cases loss of data. For "
+"users who are testing out alpha or beta versions of Firefox, we offer the <a href=\"%(acr_url)s\">Add-on Compatibility Reporter</a> to help add-on developers update their compatibility."
 msgstr ""
 
 #: src/olympia/pages/templates/pages/faq.html:156
@@ -11787,12 +10084,9 @@ msgstr ""
 #: src/olympia/pages/templates/pages/faq.html:157
 #, python-format
 msgid ""
-"Add-ons are usually created by third-party developers from around the world,"
-" so the best way to get help with an add-on is to look for support links on "
-"the add-on's homepage or contact the developer. If you are having issues "
-"with %(app_name)s that you suspect are related to add-ons you have "
-"installed, <a href=\"%(troubleshooting_url)s\">visit this support "
-"article</a> for troubleshooting tips."
+"Add-ons are usually created by third-party developers from around the world, so the best way to get help with an add-on is to look for support links on the add-on's homepage or contact the "
+"developer. If you are having issues with %(app_name)s that you suspect are related to add-ons you have installed, <a href=\"%(troubleshooting_url)s\">visit this support article</a> for "
+"troubleshooting tips."
 msgstr ""
 
 #: src/olympia/pages/templates/pages/faq.html:169
@@ -11805,12 +10099,8 @@ msgstr ""
 
 #: src/olympia/pages/templates/pages/faq.html:172
 msgid ""
-"There are often several add-ons that have similar features. To figure out "
-"which is right for you, read the entire description of the add-on and view "
-"its screenshots. If there are still several in the running, read through the"
-" add-on's ratings, user reviews, and statistics to see which is most liked "
-"by other users. Remember that you can also just try out both and see which "
-"you like better."
+"There are often several add-ons that have similar features. To figure out which is right for you, read the entire description of the add-on and view its screenshots. If there are still several in "
+"the running, read through the add-on's ratings, user reviews, and statistics to see which is most liked by other users. Remember that you can also just try out both and see which you like better."
 msgstr ""
 
 #: src/olympia/pages/templates/pages/faq.html:180
@@ -11820,26 +10110,19 @@ msgstr ""
 #: src/olympia/pages/templates/pages/faq.html:181
 #, python-format
 msgid ""
-"With thousands of add-ons available, there's something for everyone. But if "
-"you're looking for a particular add-on and can't find it, you might try "
-"searching on other sites or posting about it in our <a href=\"%(forum_url)s"
-"\">Add-ons </a>forum."
+"With thousands of add-ons available, there's something for everyone. But if you're looking for a particular add-on and can't find it, you might try searching on other sites or posting about it in "
+"our <a href=\"%(forum_url)s\">Add-ons </a>forum."
 msgstr ""
 
 #: src/olympia/pages/templates/pages/faq.html:187
-msgid ""
-"What does it mean if an add-on is \"experimental\" or \"preliminarily "
-"reviewed\"?"
+msgid "What does it mean if an add-on is \"experimental\" or \"preliminarily reviewed\"?"
 msgstr ""
 
 #: src/olympia/pages/templates/pages/faq.html:188
 #, python-format
 msgid ""
-"Experimental add-ons have been checked by our editors to make sure they "
-"don't have security problems, but they may still have bugs or not work "
-"properly. Use caution when installing experimental add-ons and uninstall the"
-" add-on immediately if you notice problems. <a href=\"%(url)s\">Learn more "
-"about our review process</a></dd>"
+"Experimental add-ons have been checked by our editors to make sure they don't have security problems, but they may still have bugs or not work properly. Use caution when installing experimental add-"
+"ons and uninstall the add-on immediately if you notice problems. <a href=\"%(url)s\">Learn more about our review process</a></dd>"
 msgstr ""
 
 #: src/olympia/pages/templates/pages/faq.html:196
@@ -11849,12 +10132,8 @@ msgstr ""
 #: src/olympia/pages/templates/pages/faq.html:197
 #, python-format
 msgid ""
-"While all add-ons publicly available in our gallery are reviewed by an "
-"editor, you may receive a direct link to an add-on that hasn't yet been "
-"reviewed. Use caution when installing these add-ons, as they could harm your"
-" computer or violate your privacy. We recommend that you only install "
-"reviewed add-ons. <a href=\"%(url)s\">Learn more about our review "
-"process</a></dd>"
+"While all add-ons publicly available in our gallery are reviewed by an editor, you may receive a direct link to an add-on that hasn't yet been reviewed. Use caution when installing these add-ons, "
+"as they could harm your computer or violate your privacy. We recommend that you only install reviewed add-ons. <a href=\"%(url)s\">Learn more about our review process</a></dd>"
 msgstr ""
 
 #: src/olympia/pages/templates/pages/faq.html:206
@@ -11862,8 +10141,7 @@ msgid "How much do add-ons cost to purchase?"
 msgstr ""
 
 #: src/olympia/pages/templates/pages/faq.html:207
-msgid ""
-"Add-ons hosted in our gallery are free unless clearly marked otherwise."
+msgid "Add-ons hosted in our gallery are free unless clearly marked otherwise."
 msgstr ""
 
 #: src/olympia/pages/templates/pages/faq.html:209
@@ -11872,10 +10150,8 @@ msgstr ""
 
 #: src/olympia/pages/templates/pages/faq.html:210
 msgid ""
-"Some add-on authors request users who enjoy an add-on to contribute to its "
-"development by making a monetary contribution. These contributions go "
-"directly to the developer unless a third party is indicated, such as the "
-"non-profit Mozilla Foundation."
+"Some add-on authors request users who enjoy an add-on to contribute to its development by making a monetary contribution. These contributions go directly to the developer unless a third party is "
+"indicated, such as the non-profit Mozilla Foundation."
 msgstr ""
 
 #: src/olympia/pages/templates/pages/faq.html:215
@@ -11884,19 +10160,14 @@ msgstr ""
 
 #: src/olympia/pages/templates/pages/faq.html:217
 msgid ""
-"Beta add-ons are unreviewed versions which represent the latest work of an "
-"add-on author. While different authors have different standards for beta "
-"code quality, you should assume that these add-ons are less stable than the "
-"general add-on releases."
+"Beta add-ons are unreviewed versions which represent the latest work of an add-on author. While different authors have different standards for beta code quality, you should assume that these add-"
+"ons are less stable than the general add-on releases."
 msgstr ""
 
 #: src/olympia/pages/templates/pages/faq.html:221
 msgid ""
-"Please note that when you install an add-on from the \"Beta Version\" "
-"section of an add-on's listing, you will continue to receive updates for "
-"that add-on as they become available. Like the initial version you "
-"installed, all beta releases are unreviewed by Mozilla and may harm your "
-"computer."
+"Please note that when you install an add-on from the \"Beta Version\" section of an add-on's listing, you will continue to receive updates for that add-on as they become available. Like the initial "
+"version you installed, all beta releases are unreviewed by Mozilla and may harm your computer."
 msgstr ""
 
 #: src/olympia/pages/templates/pages/faq.html:228
@@ -11904,10 +10175,7 @@ msgid "What does it mean when an add-on is flagged as slow?"
 msgstr ""
 
 #: src/olympia/pages/templates/pages/faq.html:229
-msgid ""
-"Most add-ons load code and resources at the same time Firefox is starting "
-"up. In most cases the impact in start-up time is minimal, but some add-ons "
-"can cause a noticeable slowdown."
+msgid "Most add-ons load code and resources at the same time Firefox is starting up. In most cases the impact in start-up time is minimal, but some add-ons can cause a noticeable slowdown."
 msgstr ""
 
 #: src/olympia/pages/templates/pages/faq.html:234
@@ -11916,10 +10184,8 @@ msgstr ""
 
 #: src/olympia/pages/templates/pages/faq.html:235
 msgid ""
-"To report a user review of an add-on, log in with your account and visit the"
-" add-on's reviews page. Find the review you wish to report, click \"Report "
-"this review\" and select a reason. Our editorial team will investigate the "
-"review and take appropriate action."
+"To report a user review of an add-on, log in with your account and visit the add-on's reviews page. Find the review you wish to report, click \"Report this review\" and select a reason. Our "
+"editorial team will investigate the review and take appropriate action."
 msgstr ""
 
 #: src/olympia/pages/templates/pages/faq.html:240
@@ -11938,19 +10204,14 @@ msgstr ""
 #: src/olympia/pages/templates/pages/faq.html:245
 #, python-format
 msgid ""
-"The source code used to create an add-on is an exclusive copyright of the "
-"add-on author, unless otherwise declared in a source code license. Many add-"
-"ons on this site have <a href=\"%(url)s\" lang=\"en\">open source "
-"licenses</a> that make the source code publicly available for copy and reuse"
-" under conditions determined by the author. Most authors choose widely known"
-" open source licenses like the GPL or BSD licenses instead of making up "
-"their own."
+"The source code used to create an add-on is an exclusive copyright of the add-on author, unless otherwise declared in a source code license. Many add-ons on this site have <a href=\"%(url)s\" lang="
+"\"en\">open source licenses</a> that make the source code publicly available for copy and reuse under conditions determined by the author. Most authors choose widely known open source licenses like "
+"the GPL or BSD licenses instead of making up their own."
 msgstr ""
 
 #: src/olympia/pages/templates/pages/faq.html:254
 #, python-format
-msgid ""
-"Firefox and other Mozilla software are <a href=\"%(url)s\">open source</a>."
+msgid "Firefox and other Mozilla software are <a href=\"%(url)s\">open source</a>."
 msgstr ""
 
 #: src/olympia/pages/templates/pages/faq.html:262
@@ -11970,15 +10231,10 @@ msgid "What is the My Favorites collection?"
 msgstr ""
 
 #: src/olympia/pages/templates/pages/faq.html:269
-msgid ""
-"Favorite add-ons are add-ons that you have bookmarked to easily get back to "
-"later. You can add an add-on to your favorites collection by clicking \"Add "
-"to favorites\" on its details page."
+msgid "Favorite add-ons are add-ons that you have bookmarked to easily get back to later. You can add an add-on to your favorites collection by clicking \"Add to favorites\" on its details page."
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:273
-#: src/olympia/templates/menu_links.html:13
-#: src/olympia/templates/impala/header_title.html:17
+#: src/olympia/pages/templates/pages/faq.html:273 src/olympia/templates/menu_links.html:13 src/olympia/templates/impala/header_title.html:17
 msgid "Mobile Add-ons"
 msgstr ""
 
@@ -11989,10 +10245,8 @@ msgstr ""
 #: src/olympia/pages/templates/pages/faq.html:277
 #, python-format
 msgid ""
-"Mobile add-ons work with <a href=\"%(mobile_url)s\">Firefox for Mobile</a> "
-"and add or modify functionality just like desktop add-ons. You can find add-"
-"ons that work with Firefox for Mobile in our <a "
-"href=\"%(gallery_url)s\">gallery</a>."
+"Mobile add-ons work with <a href=\"%(mobile_url)s\">Firefox for Mobile</a> and add or modify functionality just like desktop add-ons. You can find add-ons that work with Firefox for Mobile in our "
+"<a href=\"%(gallery_url)s\">gallery</a>."
 msgstr ""
 
 #: src/olympia/pages/templates/pages/faq.html:286
@@ -12001,10 +10255,7 @@ msgstr ""
 
 #: src/olympia/pages/templates/pages/faq.html:287
 #, python-format
-msgid ""
-"Please see our <a href=\"%(faq_url)s\">Developer FAQ</a> and <a "
-"href=\"%(hub_url)s\">Developer Hub</a> for answers to add-on developer-"
-"related questions."
+msgid "Please see our <a href=\"%(faq_url)s\">Developer FAQ</a> and <a href=\"%(hub_url)s\">Developer Hub</a> for answers to add-on developer-related questions."
 msgstr ""
 
 #: src/olympia/pages/templates/pages/faq.html:292
@@ -12013,27 +10264,21 @@ msgstr ""
 
 #: src/olympia/pages/templates/pages/faq.html:293
 #, python-format
-msgid ""
-"For general Firefox support, visit our <a href=\"%(sumo_url)s\">support "
-"website</a>. For general add-on and website questions, visit our <a "
-"href=\"%(forum_url)s\">forum</a>."
+msgid "For general Firefox support, visit our <a href=\"%(sumo_url)s\">support website</a>. For general add-on and website questions, visit our <a href=\"%(forum_url)s\">forum</a>."
 msgstr ""
 
-#: src/olympia/pages/templates/pages/review_guide.html:36
-#: src/olympia/pages/templates/pages/review_guide.html:51
+#: src/olympia/pages/templates/pages/review_guide.html:36 src/olympia/pages/templates/pages/review_guide.html:51
 msgid "Some tips for writing a great review"
 msgstr ""
 
-#: src/olympia/pages/templates/pages/review_guide.html:39
-#: src/olympia/pages/templates/pages/review_guide.html:131
+#: src/olympia/pages/templates/pages/review_guide.html:39 src/olympia/pages/templates/pages/review_guide.html:131
 msgid "Frequently Asked Questions about Reviews"
 msgstr ""
 
 #: src/olympia/pages/templates/pages/review_guide.html:46
 msgid ""
-"Add-on reviews are a way for you to share your opinions about the add-ons "
-"you’ve installed and used. Our review moderation team reserves the right to "
-"refuse or remove any review that does not comply with these guidelines."
+"Add-on reviews are a way for you to share your opinions about the add-ons you’ve installed and used. Our review moderation team reserves the right to refuse or remove any review that does not "
+"comply with these guidelines."
 msgstr ""
 
 #: src/olympia/pages/templates/pages/review_guide.html:53
@@ -12041,8 +10286,7 @@ msgid "Do:"
 msgstr ""
 
 #: src/olympia/pages/templates/pages/review_guide.html:56
-msgid ""
-"Write like you are telling a friend about your experience with the add-on."
+msgid "Write like you are telling a friend about your experience with the add-on."
 msgstr ""
 
 #: src/olympia/pages/templates/pages/review_guide.html:61
@@ -12074,8 +10318,7 @@ msgid "Will you continue to use this add-on?"
 msgstr ""
 
 #: src/olympia/pages/templates/pages/review_guide.html:73
-msgid ""
-"Take a moment to read your review before submitting it to minimize typos."
+msgid "Take a moment to read your review before submitting it to minimize typos."
 msgstr ""
 
 #: src/olympia/pages/templates/pages/review_guide.html:79
@@ -12088,9 +10331,8 @@ msgstr ""
 
 #: src/olympia/pages/templates/pages/review_guide.html:87
 msgid ""
-"Post technical issues, support requests, or feature suggestions. Use the "
-"available support options for each add-on, if available. You can find them "
-"in the side column next to the About this Add-on section."
+"Post technical issues, support requests, or feature suggestions. Use the available support options for each add-on, if available. You can find them in the side column next to the About this Add-on "
+"section."
 msgstr ""
 
 #: src/olympia/pages/templates/pages/review_guide.html:92
@@ -12098,38 +10340,29 @@ msgid "Write reviews for add-ons which you have not personally used."
 msgstr ""
 
 #: src/olympia/pages/templates/pages/review_guide.html:97
-msgid ""
-"Use profanity, sexual language or language that can be construed as hateful."
+msgid "Use profanity, sexual language or language that can be construed as hateful."
 msgstr ""
 
 #: src/olympia/pages/templates/pages/review_guide.html:103
-msgid ""
-"Include HTML, links, source code or code snippets. Reviews are meant to be "
-"text only."
+msgid "Include HTML, links, source code or code snippets. Reviews are meant to be text only."
 msgstr ""
 
 #: src/olympia/pages/templates/pages/review_guide.html:108
-msgid ""
-"Make false statements, disparage add-on authors or personally insult them."
+msgid "Make false statements, disparage add-on authors or personally insult them."
 msgstr ""
 
 #: src/olympia/pages/templates/pages/review_guide.html:114
-msgid ""
-"Include your own or anyone else’s email, phone number, or other personal "
-"details."
+msgid "Include your own or anyone else’s email, phone number, or other personal details."
 msgstr ""
 
 #: src/olympia/pages/templates/pages/review_guide.html:119
-msgid ""
-"Post reviews for an add-on you or your organization wrote or represent."
+msgid "Post reviews for an add-on you or your organization wrote or represent."
 msgstr ""
 
 #: src/olympia/pages/templates/pages/review_guide.html:125
 msgid ""
-"Criticize an add-on for something it’s intended to do. For example, leaving "
-"a negative review of an add-on for displaying ads or requiring data "
-"gathering, when that is the intended purpose of the add-on, or the add-on "
-"requires gathering data to function."
+"Criticize an add-on for something it’s intended to do. For example, leaving a negative review of an add-on for displaying ads or requiring data gathering, when that is the intended purpose of the "
+"add-on, or the add-on requires gathering data to function."
 msgstr ""
 
 #: src/olympia/pages/templates/pages/review_guide.html:133
@@ -12138,10 +10371,8 @@ msgstr ""
 
 #: src/olympia/pages/templates/pages/review_guide.html:135
 msgid ""
-"Please report or flag any questionable reviews by clicking the \"Report this"
-" review\" and it will be submitted to the site for moderation. Our "
-"moderation team will use the Review Guidelines to evaluate whether or not to"
-" delete the review or restore it back to the site."
+"Please report or flag any questionable reviews by clicking the \"Report this review\" and it will be submitted to the site for moderation. Our moderation team will use the Review Guidelines to "
+"evaluate whether or not to delete the review or restore it back to the site."
 msgstr ""
 
 #: src/olympia/pages/templates/pages/review_guide.html:140
@@ -12150,10 +10381,7 @@ msgstr ""
 
 #: src/olympia/pages/templates/pages/review_guide.html:142
 #, python-format
-msgid ""
-"Yes, add-on authors can provide a single response to a review. You can set "
-"up a discussion topic in our <a href=\"%(forum_url)s\">forum</a> to engage "
-"in additional discussion or follow-up."
+msgid "Yes, add-on authors can provide a single response to a review. You can set up a discussion topic in our <a href=\"%(forum_url)s\">forum</a> to engage in additional discussion or follow-up."
 msgstr ""
 
 #: src/olympia/pages/templates/pages/review_guide.html:149
@@ -12162,11 +10390,8 @@ msgstr ""
 
 #: src/olympia/pages/templates/pages/review_guide.html:151
 msgid ""
-"In general, no. But if the review did not meet the review guidelines "
-"outlined above, you can click \"Report this review\" and have it moderated. "
-"If a review included a complaint that is no longer valid due to a new "
-"release of your add-on, we may consider deleting the review. Submit your "
-"detailed request to amo-editors@mozilla.org."
+"In general, no. But if the review did not meet the review guidelines outlined above, you can click \"Report this review\" and have it moderated. If a review included a complaint that is no longer "
+"valid due to a new release of your add-on, we may consider deleting the review. Submit your detailed request to amo-editors@mozilla.org."
 msgstr ""
 
 #: src/olympia/pages/templates/pages/sunbird.html:26
@@ -12175,17 +10400,13 @@ msgstr ""
 
 #: src/olympia/pages/templates/pages/sunbird.html:29
 msgid ""
-"Development on the Sunbird project has halted and its final release was on "
-"March 30, 2010. We've been proud to host Sunbird add-ons on this site but as"
-" the project is no longer maintained we have disabled our support for the "
-"add-ons."
+"Development on the Sunbird project has halted and its final release was on March 30, 2010. We've been proud to host Sunbird add-ons on this site but as the project is no longer maintained we have "
+"disabled our support for the add-ons."
 msgstr ""
 
 #: src/olympia/pages/templates/pages/sunbird.html:38
 #, python-format
-msgid ""
-"We recommend upgrading to <a href=\"%(tb_url)s\">Thunderbird</a> and <a "
-"href=\"%(lightning_url)s\">Lightning</a>."
+msgid "We recommend upgrading to <a href=\"%(tb_url)s\">Thunderbird</a> and <a href=\"%(lightning_url)s\">Lightning</a>."
 msgstr ""
 
 #: src/olympia/pages/templates/pages/sunbird.html:45
@@ -12237,8 +10458,7 @@ msgstr ""
 msgid "Skip for now"
 msgstr ""
 
-#: src/olympia/reviews/forms.py:151
-#: src/olympia/reviews/templates/reviews/review.html:107
+#: src/olympia/reviews/forms.py:151 src/olympia/reviews/templates/reviews/review.html:107
 msgid "Delete review"
 msgstr ""
 
@@ -12257,27 +10477,18 @@ msgstr ""
 #: src/olympia/reviews/templates/reviews/add.html:26
 #, python-format
 msgid ""
-"<h2>Keep these tips in mind:</h2> <ul> <li> Write like you're telling a "
-"friend about your experience with the add-on. Give specifics and helpful "
-"details, such as what features you liked and/or disliked, how easy to use it"
-" is, and any disadvantages it has. Avoid generic language such as calling it"
-" \"Great\" or \"Bad\" unless you can give reasons why you believe this is "
-"so. </li> <li> Please do not post bug reports in reviews. We do not make "
-"your email address available to add-on developers and they may need to "
-"contact you to help resolve your issue. See the <a "
-"href=\"%(support)s\">support section</a> to find out where to get assistance"
-" for this add-on. </li> <li>Please keep reviews clean, avoid the use of "
-"improper language and do not post any personal information. </li> </ul> "
-"<p>Please read the <a href=\"%(guide)s\" target=\"_blank\">Review "
-"Guidelines</a> for more detail about user add-on reviews.</p>"
+"<h2>Keep these tips in mind:</h2> <ul> <li> Write like you're telling a friend about your experience with the add-on. Give specifics and helpful details, such as what features you liked and/or "
+"disliked, how easy to use it is, and any disadvantages it has. Avoid generic language such as calling it \"Great\" or \"Bad\" unless you can give reasons why you believe this is so. </li> <li> "
+"Please do not post bug reports in reviews. We do not make your email address available to add-on developers and they may need to contact you to help resolve your issue. See the <a href=\"%(support)s"
+"\">support section</a> to find out where to get assistance for this add-on. </li> <li>Please keep reviews clean, avoid the use of improper language and do not post any personal information. </li> </"
+"ul> <p>Please read the <a href=\"%(guide)s\" target=\"_blank\">Review Guidelines</a> for more detail about user add-on reviews.</p>"
 msgstr ""
 
 #: src/olympia/reviews/templates/reviews/reply.html:4
 msgid "Reply to review by {0}"
 msgstr ""
 
-#: src/olympia/reviews/templates/reviews/reply.html:15
-#: src/olympia/reviews/templates/reviews/reply.html:31
+#: src/olympia/reviews/templates/reviews/reply.html:15 src/olympia/reviews/templates/reviews/reply.html:31
 msgid "Reply"
 msgstr ""
 
@@ -12285,8 +10496,7 @@ msgstr ""
 msgid "Write a Reply"
 msgstr ""
 
-#: src/olympia/reviews/templates/reviews/reply.html:36
-#: src/olympia/reviews/templates/reviews/report_review.html:12
+#: src/olympia/reviews/templates/reviews/reply.html:36 src/olympia/reviews/templates/reviews/report_review.html:12
 msgid "Submit"
 msgstr ""
 
@@ -12306,19 +10516,14 @@ msgid "by %(user)s <b>(Developer)</b> on %(date)s"
 msgstr ""
 
 #. {0} is a version number (like 1.01)
-#: src/olympia/reviews/templates/reviews/review.html:50
-#: src/olympia/reviews/templates/reviews/mobile/review_list.html:41
+#: src/olympia/reviews/templates/reviews/review.html:50 src/olympia/reviews/templates/reviews/mobile/review_list.html:41
 msgid "This review is for a previous version of the add-on ({0})."
 msgstr ""
 
 #: src/olympia/reviews/templates/reviews/review.html:56
 #, python-format
-msgid ""
-"This user has a <a href=\"%(user_review_url)s\">previous review</a> of this "
-"add-on."
-msgid_plural ""
-"This user has <a href=\"%(user_review_url)s\">%(cnt)s previous reviews</a> "
-"of this add-on."
+msgid "This user has a <a href=\"%(user_review_url)s\">previous review</a> of this add-on."
+msgid_plural "This user has <a href=\"%(user_review_url)s\">%(cnt)s previous reviews</a> of this add-on."
 msgstr[0] ""
 msgstr[1] ""
 msgstr[2] ""
@@ -12326,9 +10531,7 @@ msgstr[3] ""
 
 #: src/olympia/reviews/templates/reviews/review.html:62
 #, python-format
-msgid ""
-"This user has <a href=\"%(user_review_url)s\">other reviews</a> of this add-"
-"on."
+msgid "This user has <a href=\"%(user_review_url)s\">other reviews</a> of this add-on."
 msgstr ""
 
 #: src/olympia/reviews/templates/reviews/review.html:72
@@ -12361,9 +10564,7 @@ msgid "{0} :: Reviews"
 msgstr ""
 
 #. {0} is an addon name.
-#: src/olympia/reviews/templates/reviews/review_list.html:24
-#: src/olympia/reviews/templates/reviews/mobile/add.html:4
-#: src/olympia/reviews/templates/reviews/mobile/review_list.html:4
+#: src/olympia/reviews/templates/reviews/review_list.html:24 src/olympia/reviews/templates/reviews/mobile/add.html:4 src/olympia/reviews/templates/reviews/mobile/review_list.html:4
 msgid "Reviews for {0}"
 msgstr ""
 
@@ -12403,8 +10604,7 @@ msgstr ""
 msgid "Write a New Review"
 msgstr ""
 
-#: src/olympia/reviews/templates/reviews/review_list.html:81
-#: src/olympia/reviews/templates/reviews/mobile/reviews_link.html:15
+#: src/olympia/reviews/templates/reviews/review_list.html:81 src/olympia/reviews/templates/reviews/mobile/reviews_link.html:15
 msgid "Be the first to write a review."
 msgstr ""
 
@@ -12425,8 +10625,7 @@ msgstr ""
 msgid "Rated %(rating)s out of 5 stars"
 msgstr ""
 
-#: src/olympia/reviews/templates/reviews/mobile/add_form.html:3
-#: src/olympia/reviews/templates/reviews/mobile/add_form.html:8
+#: src/olympia/reviews/templates/reviews/mobile/add_form.html:3 src/olympia/reviews/templates/reviews/mobile/add_form.html:8
 msgid "Add a Review"
 msgstr ""
 
@@ -12501,14 +10700,11 @@ msgid "Relevance"
 msgstr ""
 
 #: src/olympia/search/helpers.py:24
-msgid ""
-"Results <strong>{0}</strong>-<strong>{1}</strong> of <strong>{2}</strong>"
+msgid "Results <strong>{0}</strong>-<strong>{1}</strong> of <strong>{2}</strong>"
 msgstr ""
 
 #: src/olympia/search/helpers.py:44
-msgid ""
-"Showing {0} - {1} of {2} results for <strong>{3}</strong> tagged with "
-"<strong>{4}</strong>"
+msgid "Showing {0} - {1} of {2} results for <strong>{3}</strong> tagged with <strong>{4}</strong>"
 msgstr ""
 
 #: src/olympia/search/helpers.py:49
@@ -12524,9 +10720,7 @@ msgid "Showing {0} - {1} of {2} results"
 msgstr ""
 
 #. {0} is an application, like Firefox.
-#: src/olympia/search/views.py:264 src/olympia/templates/base.html:17
-#: src/olympia/templates/impala/base.html:17
-#: src/olympia/templates/mobile/base_addons.html:17
+#: src/olympia/search/views.py:264 src/olympia/templates/base.html:17 src/olympia/templates/impala/base.html:17 src/olympia/templates/mobile/base_addons.html:17
 msgid "{0} Add-ons"
 msgstr ""
 
@@ -12729,11 +10923,8 @@ msgstr ""
 msgid "Share this Collection"
 msgstr ""
 
-#: src/olympia/signing/views.py:33 src/olympia/templates/base.html:71
-#: src/olympia/templates/impala/base.html:112
-msgid ""
-"Some features are temporarily disabled while we perform website maintenance."
-" We'll be back to full capacity shortly."
+#: src/olympia/signing/views.py:33 src/olympia/templates/base.html:71 src/olympia/templates/impala/base.html:112
+msgid "Some features are temporarily disabled while we perform website maintenance. We'll be back to full capacity shortly."
 msgstr ""
 
 #: src/olympia/signing/views.py:56
@@ -12848,8 +11039,7 @@ msgstr ""
 msgid "To"
 msgstr ""
 
-#: src/olympia/stats/templates/stats/popup.html:27
-#: src/olympia/users/templates/users/pwreset_confirm.html:38
+#: src/olympia/stats/templates/stats/popup.html:27 src/olympia/users/templates/users/pwreset_confirm.html:38
 msgid "Update"
 msgstr ""
 
@@ -12870,95 +11060,89 @@ msgstr ""
 msgid "Statistics Dashboard :: Add-ons for {0}"
 msgstr ""
 
-#: src/olympia/stats/templates/stats/stats.html:30
-msgid "Controls:"
-msgstr ""
-
-#: src/olympia/stats/templates/stats/stats.html:33
-msgid "reset zoom"
-msgstr ""
-
-#: src/olympia/stats/templates/stats/stats.html:40
-msgid "Group by:"
-msgstr ""
-
-#: src/olympia/stats/templates/stats/stats.html:42
-msgid "day"
-msgstr ""
-
-#: src/olympia/stats/templates/stats/stats.html:45
-msgid "week"
-msgstr ""
-
-#: src/olympia/stats/templates/stats/stats.html:48
-msgid "month"
-msgstr ""
-
-#: src/olympia/stats/templates/stats/stats.html:54
-msgid "For last:"
-msgstr ""
-
-#: src/olympia/stats/templates/stats/stats.html:57
-msgid "7 days"
-msgstr ""
-
-#: src/olympia/stats/templates/stats/stats.html:60
-msgid "30 days"
-msgstr ""
-
-#: src/olympia/stats/templates/stats/stats.html:63
-msgid "90 days"
-msgstr ""
-
-#: src/olympia/stats/templates/stats/stats.html:66
-msgid "365 days"
-msgstr ""
-
-#: src/olympia/stats/templates/stats/stats.html:69
-msgid "Custom..."
-msgstr ""
-
 #. {0} is an add-on name
-#: src/olympia/stats/templates/stats/stats.html:88
-#: src/olympia/stats/templates/stats/stats.html:91
+#: src/olympia/stats/templates/stats/stats.html:44 src/olympia/stats/templates/stats/stats.html:47
 msgid "Statistics for {0}"
 msgstr ""
 
-#: src/olympia/stats/templates/stats/stats.html:94
+#: src/olympia/stats/templates/stats/stats.html:50
 msgid "Statistics Dashboard"
 msgstr ""
 
-#: src/olympia/stats/templates/stats/stats.html:104
-msgid ""
-"Statistics processing is currently disabled, so recent data is unavailable. "
-"The statistics are still being collected and this page will be updated soon "
-"with the missing data."
+#: src/olympia/stats/templates/stats/stats.html:57
+msgid "Controls:"
 msgstr ""
 
-#: src/olympia/stats/templates/stats/stats.html:110
+#: src/olympia/stats/templates/stats/stats.html:60
+msgid "reset zoom"
+msgstr ""
+
+#: src/olympia/stats/templates/stats/stats.html:67
+msgid "Group by:"
+msgstr ""
+
+#: src/olympia/stats/templates/stats/stats.html:69
+msgid "day"
+msgstr ""
+
+#: src/olympia/stats/templates/stats/stats.html:72
+msgid "week"
+msgstr ""
+
+#: src/olympia/stats/templates/stats/stats.html:75
+msgid "month"
+msgstr ""
+
+#: src/olympia/stats/templates/stats/stats.html:81
+msgid "For last:"
+msgstr ""
+
+#: src/olympia/stats/templates/stats/stats.html:84
+msgid "7 days"
+msgstr ""
+
+#: src/olympia/stats/templates/stats/stats.html:87
+msgid "30 days"
+msgstr ""
+
+#: src/olympia/stats/templates/stats/stats.html:90
+msgid "90 days"
+msgstr ""
+
+#: src/olympia/stats/templates/stats/stats.html:93
+msgid "365 days"
+msgstr ""
+
+#: src/olympia/stats/templates/stats/stats.html:96
+msgid "Custom..."
+msgstr ""
+
+#: src/olympia/stats/templates/stats/stats.html:106
+msgid "Statistics processing is currently disabled, so recent data is unavailable. The statistics are still being collected and this page will be updated soon with the missing data."
+msgstr ""
+
+#: src/olympia/stats/templates/stats/stats.html:112
 msgid "Loading the latest data&hellip;"
 msgstr ""
 
-#: src/olympia/stats/templates/stats/stats.html:142
-#: src/olympia/stats/templates/stats/reports/overview.html:25
-#: src/olympia/stats/templates/stats/reports/overview.html:37
+#: src/olympia/stats/templates/stats/stats.html:144 src/olympia/stats/templates/stats/reports/overview.html:25 src/olympia/stats/templates/stats/reports/overview.html:37
 #: src/olympia/stats/templates/stats/reports/overview.html:49
 msgid "No data available."
 msgstr ""
 
-#: src/olympia/stats/templates/stats/stats.html:177
+#: src/olympia/stats/templates/stats/stats.html:179
 msgid "This dashboard is currently <b>public</b>."
 msgstr ""
 
-#: src/olympia/stats/templates/stats/stats.html:179
+#: src/olympia/stats/templates/stats/stats.html:181
 msgid "Contribution stats are currently <b>private</b>."
 msgstr ""
 
-#: src/olympia/stats/templates/stats/stats.html:182
+#: src/olympia/stats/templates/stats/stats.html:184
 msgid "This dashboard is currently <b>private</b>."
 msgstr ""
 
-#: src/olympia/stats/templates/stats/stats.html:185
+#: src/olympia/stats/templates/stats/stats.html:187
 msgid "Change settings."
 msgstr ""
 
@@ -13000,9 +11184,8 @@ msgstr ""
 
 #: src/olympia/stats/templates/stats/reports/downloads.html:10
 msgid ""
-"<h2>How are downloads counted?</h2> <p> Download counts are updated every "
-"evening and only include original add-on downloads, not updates. Downloads "
-"can be broken down by the specific source referring the download. </p>"
+"<h2>How are downloads counted?</h2> <p> Download counts are updated every evening and only include original add-on downloads, not updates. Downloads can be broken down by the specific source "
+"referring the download. </p>"
 msgstr ""
 
 #: src/olympia/stats/templates/stats/reports/locales.html:3
@@ -13017,8 +11200,7 @@ msgstr ""
 msgid "<b>{0}</b> Downloads"
 msgstr ""
 
-#: src/olympia/stats/templates/stats/reports/overview.html:9
-#: src/olympia/stats/templates/stats/reports/overview.html:13
+#: src/olympia/stats/templates/stats/reports/overview.html:9 src/olympia/stats/templates/stats/reports/overview.html:13
 msgid "Loading..."
 msgstr ""
 
@@ -13069,19 +11251,11 @@ msgstr ""
 #: src/olympia/stats/templates/stats/reports/sources.html:10
 #, python-format
 msgid ""
-"<h2>Tracking external sources</h2> <p> If you link to your add-on's details "
-"page or directly to its file from an external site, such as your blog or "
-"website, you can append a parameter to be tracked as an additional download "
-"source on this page. For example, the following links would appear as "
-"sourced by your blog: <dl> <dt>Add-on Details Page</dt> "
-"<dd>https://addons.mozilla.org/addon/%(slug)s?src=<b>external-blog</b></dd> "
-"<dt>Direct File Link</dt> "
-"<dd>https://addons.mozilla.org/downloads/latest/%(id)s/addon-%(id)s-latest.xpi?src=<b"
-">external-blog</b></dd> </dl> <p> Only src parameters that begin with "
-"\"external-\" will be tracked, up to 61 additional characters. Any text "
-"after \"external-\" can be used to describe the source, such as \"external-"
-"blog\", \"external-sidebar\", \"external-campaign225\", etc. The following "
-"URL-safe characters are allowed: <code>a-z A-Z - . _ ~ %% +</code>"
+"<h2>Tracking external sources</h2> <p> If you link to your add-on's details page or directly to its file from an external site, such as your blog or website, you can append a parameter to be "
+"tracked as an additional download source on this page. For example, the following links would appear as sourced by your blog: <dl> <dt>Add-on Details Page</dt> <dd>https://addons.mozilla.org/addon/"
+"%(slug)s?src=<b>external-blog</b></dd> <dt>Direct File Link</dt> <dd>https://addons.mozilla.org/downloads/latest/%(id)s/addon-%(id)s-latest.xpi?src=<b>external-blog</b></dd> </dl> <p> Only src "
+"parameters that begin with \"external-\" will be tracked, up to 61 additional characters. Any text after \"external-\" can be used to describe the source, such as \"external-blog\", \"external-"
+"sidebar\", \"external-campaign225\", etc. The following URL-safe characters are allowed: <code>a-z A-Z - . _ ~ %% +</code>"
 msgstr ""
 
 #: src/olympia/stats/templates/stats/reports/statuses.html:3
@@ -13102,18 +11276,14 @@ msgstr ""
 
 #: src/olympia/stats/templates/stats/reports/usage.html:11
 msgid ""
-"<h2>What are daily users?</h2> <p> Themes installed from this site check for"
-" updates once per day. The total number of these update pings is known as "
-"Active Daily Users, or the total number of people using your theme by day. "
-"</p>"
+"<h2>What are daily users?</h2> <p> Themes installed from this site check for updates once per day. The total number of these update pings is known as Active Daily Users, or the total number of "
+"people using your theme by day. </p>"
 msgstr ""
 
 #: src/olympia/stats/templates/stats/reports/usage.html:20
 msgid ""
-"<h2>What are daily users?</h2> <p> Add-ons downloaded from this site check "
-"for updates once per day. The total number of these update pings is known as"
-" Active Daily Users. Daily users can be broken down by add-on version, "
-"operating system, add-on status, application, and locale. </p>"
+"<h2>What are daily users?</h2> <p> Add-ons downloaded from this site check for updates once per day. The total number of these update pings is known as Active Daily Users. Daily users can be broken "
+"down by add-on version, operating system, add-on status, application, and locale. </p>"
 msgstr ""
 
 #: src/olympia/stats/templates/stats/reports/users_created.html:3
@@ -13124,34 +11294,27 @@ msgstr ""
 msgid "Application versions by Date"
 msgstr ""
 
-#: src/olympia/templates/amo_footer.html:6
-#: src/olympia/templates/includes/lang_switcher.html:2
+#: src/olympia/templates/amo_footer.html:6 src/olympia/templates/includes/lang_switcher.html:2
 msgid "Other languages"
 msgstr ""
 
-#: src/olympia/templates/base.html:9 src/olympia/templates/impala/base.html:9
-#: src/olympia/templates/mobile/base_addons.html:9
+#: src/olympia/templates/base.html:9 src/olympia/templates/impala/base.html:9 src/olympia/templates/mobile/base_addons.html:9
 msgid "Mozilla Add-ons"
 msgstr ""
 
-#: src/olympia/templates/base.html:89
-#: src/olympia/templates/impala/base.html:78
+#: src/olympia/templates/base.html:89 src/olympia/templates/impala/base.html:78
 msgid "Find add-ons for other applications"
 msgstr ""
 
-#: src/olympia/templates/base.html:90
-#: src/olympia/templates/impala/base.html:78
+#: src/olympia/templates/base.html:90 src/olympia/templates/impala/base.html:78
 msgid "Other Applications"
 msgstr ""
 
-#: src/olympia/templates/base.html:141
-#: src/olympia/templates/impala/base.html:194
-msgid ""
-"To create your own collections, you must have a Mozilla Add-ons account."
+#: src/olympia/templates/base.html:141 src/olympia/templates/impala/base.html:194
+msgid "To create your own collections, you must have a Mozilla Add-ons account."
 msgstr ""
 
-#: src/olympia/templates/base.html:168
-#: src/olympia/templates/impala/base.html:215
+#: src/olympia/templates/base.html:168 src/olympia/templates/impala/base.html:215
 msgid "Footer logo"
 msgstr ""
 
@@ -13175,13 +11338,11 @@ msgstr ""
 msgid "get to know <b>add-ons</b>"
 msgstr ""
 
-#: src/olympia/templates/footer.html:4
-#: src/olympia/templates/menu_links.html:20
+#: src/olympia/templates/footer.html:4 src/olympia/templates/menu_links.html:20
 msgid "About"
 msgstr ""
 
-#: src/olympia/templates/footer.html:5
-#: src/olympia/templates/menu_links.html:32
+#: src/olympia/templates/footer.html:5 src/olympia/templates/menu_links.html:32
 msgid "Blog"
 msgstr ""
 
@@ -13257,9 +11418,7 @@ msgstr ""
 msgid "Contact Us"
 msgstr ""
 
-#: src/olympia/templates/user_login.html:22
-#: src/olympia/users/templates/users/edit.html:31
-#: src/olympia/users/templates/users/includes/navigation.html:12
+#: src/olympia/templates/user_login.html:22 src/olympia/users/templates/users/edit.html:31 src/olympia/users/templates/users/includes/navigation.html:12
 msgid "My Account"
 msgstr ""
 
@@ -13267,24 +11426,19 @@ msgstr ""
 msgid "Welcome, {0}"
 msgstr ""
 
-#: src/olympia/templates/user_login.html:41
-#: src/olympia/templates/impala/user_login.html:20
+#: src/olympia/templates/user_login.html:41 src/olympia/templates/impala/user_login.html:20
 #, python-format
 msgid "<a href=\"%(reg)s\">Register</a> or <a href=\"%(login)s\">Log in</a>"
 msgstr ""
 
 #: src/olympia/templates/impala/base.html:123
 #, python-format
-msgid ""
-"To try the thousands of add-ons available here, download <a "
-"href=\"%(url)s\">Mozilla Firefox</a>, a fast, free way to surf the Web!"
+msgid "To try the thousands of add-ons available here, download <a href=\"%(url)s\">Mozilla Firefox</a>, a fast, free way to surf the Web!"
 msgstr ""
 
 #: src/olympia/templates/impala/base.html:135
 #, python-format
-msgid ""
-"Add-ons is switching to Firefox Accounts for login. <a href=\"%(url)s\" "
-"class=\"fxa-login\">Sign in now to transfer your account.</a>"
+msgid "Add-ons is switching to Firefox Accounts for login. <a href=\"%(url)s\" class=\"fxa-login\">Sign in now to transfer your account.</a>"
 msgstr ""
 
 #. {0} is an application, such as Firefox.
@@ -13293,8 +11447,7 @@ msgid "Welcome to {0} Add-ons."
 msgstr ""
 
 #: src/olympia/templates/impala/base.html:148
-msgid ""
-"Choose from thousands of extra features and styles to make Firefox your own."
+msgid "Choose from thousands of extra features and styles to make Firefox your own."
 msgstr ""
 
 #: src/olympia/templates/impala/base.html:153
@@ -13314,8 +11467,7 @@ msgstr ""
 msgid "Android Add-ons"
 msgstr ""
 
-#: src/olympia/templates/includes/forms.html:2
-#: src/olympia/templates/includes/forms.html:6
+#: src/olympia/templates/includes/forms.html:2 src/olympia/templates/includes/forms.html:6
 msgid "required"
 msgstr ""
 
@@ -13360,15 +11512,11 @@ msgstr ""
 msgid "menu"
 msgstr ""
 
-#: src/olympia/templates/mobile/header_auth.html:7
-#: src/olympia/users/templates/users/register.html:41
-#: src/olympia/users/templates/users/register.html:89
+#: src/olympia/templates/mobile/header_auth.html:7 src/olympia/users/templates/users/register.html:41 src/olympia/users/templates/users/register.html:89
 msgid "Register"
 msgstr ""
 
-#: src/olympia/templates/mobile/header_auth.html:8
-#: src/olympia/users/templates/users/login_form.html:41
-#: src/olympia/users/templates/users/pwreset_complete.html:15
+#: src/olympia/templates/mobile/header_auth.html:8 src/olympia/users/templates/users/login_form.html:41 src/olympia/users/templates/users/pwreset_complete.html:15
 #: src/olympia/users/templates/users/mobile/login.html:56
 msgid "Log in"
 msgstr ""
@@ -13379,8 +11527,7 @@ msgstr ""
 msgid "Localize for: <a id=\"change-locale\" href=\"#\">%(dl)s</a>"
 msgstr ""
 
-#: src/olympia/translations/templates/translations/trans-menu.html:16
-#: src/olympia/translations/templates/translations/trans-menu.html:29
+#: src/olympia/translations/templates/translations/trans-menu.html:16 src/olympia/translations/templates/translations/trans-menu.html:29
 #, python-format
 msgid "%(title)s <em>&middot; %(lang)s</em>"
 msgstr ""
@@ -13395,9 +11542,7 @@ msgstr ""
 
 #. {0} is a language name, like 'French'
 #: src/olympia/translations/templates/translations/trans-menu.html:42
-msgid ""
-"You have unsaved changes in the <b>{0}</b> locale. Would you like to save "
-"your changes before switching locales?"
+msgid "You have unsaved changes in the <b>{0}</b> locale. Would you like to save your changes before switching locales?"
 msgstr ""
 
 #: src/olympia/translations/templates/translations/trans-menu.html:49
@@ -13406,9 +11551,7 @@ msgstr ""
 
 #. {0} is a language name, like 'French'
 #: src/olympia/translations/templates/translations/trans-menu.html:56
-msgid ""
-"Are you sure you want to remove all <b>{0}</b> translations? This cannot be "
-"undone."
+msgid "Are you sure you want to remove all <b>{0}</b> translations? This cannot be undone."
 msgstr ""
 
 #: src/olympia/translations/templates/translations/trans-menu.html:61
@@ -13430,20 +11573,14 @@ msgstr ""
 
 #: src/olympia/users/forms.py:90
 #, python-format
-msgid ""
-"As part of our new password policy, your password must be %s characters or "
-"more. Please update your password by <a href=\"%s\">issuing a password "
-"reset</a>."
+msgid "As part of our new password policy, your password must be %s characters or more. Please update your password by <a href=\"%s\">issuing a password reset</a>."
 msgstr ""
 
 #: src/olympia/users/forms.py:115
-msgid ""
-"You must recover your password through Firefox Accounts. Try logging in "
-"instead."
+msgid "You must recover your password through Firefox Accounts. Try logging in instead."
 msgstr ""
 
-#: src/olympia/users/forms.py:206
-#: src/olympia/users/templates/users/pwreset_confirm.html:24
+#: src/olympia/users/forms.py:206 src/olympia/users/templates/users/pwreset_confirm.html:24
 msgid "New password"
 msgstr ""
 
@@ -13456,9 +11593,7 @@ msgid "Usernames cannot contain only digits."
 msgstr ""
 
 #: src/olympia/users/forms.py:274
-msgid ""
-"Enter a valid username consisting of letters, numbers, underscores or "
-"hyphens."
+msgid "Enter a valid username consisting of letters, numbers, underscores or hyphens."
 msgstr ""
 
 #: src/olympia/users/forms.py:277
@@ -13469,33 +11604,24 @@ msgstr ""
 msgid "This username is already in use."
 msgstr ""
 
-#: src/olympia/users/forms.py:296
-#: src/olympia/users/templates/users/edit.html:107
+#: src/olympia/users/forms.py:296 src/olympia/users/templates/users/edit.html:107
 msgid "Display Name"
 msgstr ""
 
-#: src/olympia/users/forms.py:298
-#: src/olympia/users/templates/users/edit.html:112
-#: src/olympia/users/templates/users/vcard.html:10
+#: src/olympia/users/forms.py:298 src/olympia/users/templates/users/edit.html:112 src/olympia/users/templates/users/vcard.html:10
 msgid "Location"
 msgstr ""
 
-#: src/olympia/users/forms.py:300
-#: src/olympia/users/templates/users/edit.html:117
-#: src/olympia/users/templates/users/vcard.html:16
+#: src/olympia/users/forms.py:300 src/olympia/users/templates/users/edit.html:117 src/olympia/users/templates/users/vcard.html:16
 msgid "Occupation"
 msgstr ""
 
 #: src/olympia/users/forms.py:329
-msgid ""
-"This URL has an invalid format. Valid URLs look like "
-"http://example.com/my_page."
+msgid "This URL has an invalid format. Valid URLs look like http://example.com/my_page."
 msgstr ""
 
 #: src/olympia/users/forms.py:337
-msgid ""
-"Please use an email address from a different provider to complete your "
-"registration."
+msgid "Please use an email address from a different provider to complete your registration."
 msgstr ""
 
 #: src/olympia/users/forms.py:345
@@ -13506,13 +11632,11 @@ msgstr ""
 msgid "The passwords did not match."
 msgstr ""
 
-#: src/olympia/users/forms.py:377
-#: src/olympia/users/templates/users/edit.html:128
+#: src/olympia/users/forms.py:377 src/olympia/users/templates/users/edit.html:128
 msgid "Profile Photo"
 msgstr ""
 
-#: src/olympia/users/forms.py:385
-#: src/olympia/users/templates/users/edit.html:142
+#: src/olympia/users/forms.py:385 src/olympia/users/templates/users/edit.html:142
 msgid "Default locale"
 msgstr ""
 
@@ -13529,9 +11653,7 @@ msgid "Email cannot be changed."
 msgstr ""
 
 #: src/olympia/users/forms.py:541
-msgid ""
-"To anonymize, enter a reason for the change but do not change any other "
-"field."
+msgid "To anonymize, enter a reason for the change but do not change any other field."
 msgstr ""
 
 #: src/olympia/users/forms.py:587
@@ -13638,8 +11760,7 @@ msgid "Mozilla needs to contact me about my individual app"
 msgstr ""
 
 #: src/olympia/users/notifications.py:139
-msgid ""
-"Mozilla wants to contact me about relevant App Developer news and surveys"
+msgid "Mozilla wants to contact me about relevant App Developer news and surveys"
 msgstr ""
 
 #: src/olympia/users/notifications.py:150
@@ -13667,10 +11788,7 @@ msgid "Successfully verified!"
 msgstr ""
 
 #: src/olympia/users/views.py:132
-msgid ""
-"An email has been sent to your address to confirm your account. Before you "
-"can log in, you have to activate your account by clicking on the link "
-"provided in this email."
+msgid "An email has been sent to your address to confirm your account. Before you can log in, you have to activate your account by clicking on the link provided in this email."
 msgstr ""
 
 #: src/olympia/users/views.py:136 src/olympia/users/views.py:619
@@ -13695,9 +11813,8 @@ msgstr ""
 
 #: src/olympia/users/views.py:197
 msgid ""
-"An email has been sent to {0} to confirm your new email address. For the "
-"change to take effect, you need to click on the link provided in this email."
-" Until then, you can keep logging in with your current email address."
+"An email has been sent to {0} to confirm your new email address. For the change to take effect, you need to click on the link provided in this email. Until then, you can keep logging in with your "
+"current email address."
 msgstr ""
 
 #: src/olympia/users/views.py:210
@@ -13710,13 +11827,11 @@ msgid "Errors Found"
 msgstr ""
 
 #: src/olympia/users/views.py:225
-msgid ""
-"There were errors in the changes you made. Please correct them and resubmit."
+msgid "There were errors in the changes you made. Please correct them and resubmit."
 msgstr ""
 
 #: src/olympia/users/views.py:273
-msgid ""
-"We're sorry, but you are not eligible to request a t-shirt at this time."
+msgid "We're sorry, but you are not eligible to request a t-shirt at this time."
 msgstr ""
 
 #: src/olympia/users/views.py:329
@@ -13732,18 +11847,14 @@ msgid "Wrong email address or password!"
 msgstr ""
 
 #: src/olympia/users/views.py:434
-msgid ""
-"A link to activate your user account was sent by email to your address {0}. "
-"You have to click it before you can log in."
+msgid "A link to activate your user account was sent by email to your address {0}. You have to click it before you can log in."
 msgstr ""
 
 #: src/olympia/users/views.py:439
 #, python-format
 msgid ""
-"If you did not receive the confirmation email, make sure your email service "
-"did not mark it as \"junk mail\" or \"spam\". If you need to, you can have "
-"us <a href=\"%s\">resend the confirmation message</a> to your email address "
-"mentioned above."
+"If you did not receive the confirmation email, make sure your email service did not mark it as \"junk mail\" or \"spam\". If you need to, you can have us <a href=\"%s\">resend the confirmation "
+"message</a> to your email address mentioned above."
 msgstr ""
 
 #: src/olympia/users/views.py:444
@@ -13763,10 +11874,7 @@ msgid "Congratulations! Your user account was successfully created."
 msgstr ""
 
 #: src/olympia/users/views.py:615
-msgid ""
-"An email has been sent to your address {0} to confirm your account. Before "
-"you can log in, you have to activate your account by clicking on the link "
-"provided in this email."
+msgid "An email has been sent to your address {0} to confirm your account. Before you can log in, you have to activate your account by clicking on the link provided in this email."
 msgstr ""
 
 #: src/olympia/users/views.py:639
@@ -13785,24 +11893,19 @@ msgstr ""
 msgid "new"
 msgstr ""
 
-#: src/olympia/users/templates/users/delete.html:4
-#: src/olympia/users/templates/users/delete.html:10
+#: src/olympia/users/templates/users/delete.html:4 src/olympia/users/templates/users/delete.html:10
 msgid "Delete User Account"
 msgstr ""
 
 #: src/olympia/users/templates/users/delete.html:14
 #, python-format
 msgid ""
-"You cannot delete your account if you are listed as an <a href=\"%(link)s\">"
-" author of any add-ons</a>. To delete your account, please have another "
-"person in your development group delete you from the list of authors for "
-"your add-ons. Afterwards you will be able to delete your account here."
+"You cannot delete your account if you are listed as an <a href=\"%(link)s\"> author of any add-ons</a>. To delete your account, please have another person in your development group delete you from "
+"the list of authors for your add-ons. Afterwards you will be able to delete your account here."
 msgstr ""
 
 #: src/olympia/users/templates/users/delete.html:29
-msgid ""
-"By clicking \"delete\" your account is going to be <strong>permanently "
-"removed</strong>. That means:"
+msgid "By clicking \"delete\" your account is going to be <strong>permanently removed</strong>. That means:"
 msgstr ""
 
 #: src/olympia/users/templates/users/delete.html:35
@@ -13811,9 +11914,7 @@ msgid "You will not be able to log into %(site)s anymore."
 msgstr ""
 
 #: src/olympia/users/templates/users/delete.html:40
-msgid ""
-"Your reviews and ratings will not be deleted, but they will no longer be "
-"associated with you."
+msgid "Your reviews and ratings will not be deleted, but they will no longer be associated with you."
 msgstr ""
 
 #: src/olympia/users/templates/users/delete.html:46
@@ -13828,8 +11929,7 @@ msgstr ""
 msgid "Delete my user account now"
 msgstr ""
 
-#: src/olympia/users/templates/users/delete_photo.html:3
-#: src/olympia/users/templates/users/delete_photo.html:9
+#: src/olympia/users/templates/users/delete_photo.html:3 src/olympia/users/templates/users/delete_photo.html:9
 msgid "Delete User Photo"
 msgstr ""
 
@@ -13842,23 +11942,18 @@ msgid "Please set your display name"
 msgstr ""
 
 #: src/olympia/users/templates/users/edit.html:21
-msgid ""
-"Please set your display name or username to complete the registration "
-"process."
+msgid "Please set your display name or username to complete the registration process."
 msgstr ""
 
 #: src/olympia/users/templates/users/edit.html:33
 msgid "Manage basic account information, such as username and email address."
 msgstr ""
 
-#: src/olympia/users/templates/users/edit.html:39
-#: src/olympia/users/templates/users/register.html:47
+#: src/olympia/users/templates/users/edit.html:39 src/olympia/users/templates/users/register.html:47
 msgid "Username"
 msgstr ""
 
-#: src/olympia/users/templates/users/edit.html:45
-#: src/olympia/users/templates/users/pwreset_request.html:21
-#: src/olympia/users/templates/users/register.html:62
+#: src/olympia/users/templates/users/edit.html:45 src/olympia/users/templates/users/pwreset_request.html:21 src/olympia/users/templates/users/register.html:62
 msgid "Email Address"
 msgstr ""
 
@@ -13870,18 +11965,14 @@ msgstr ""
 msgid "Change Password"
 msgstr ""
 
-#: src/olympia/users/templates/users/edit.html:68
-#: src/olympia/users/templates/users/login_form.html:22
-#: src/olympia/users/templates/users/register.html:67
+#: src/olympia/users/templates/users/edit.html:68 src/olympia/users/templates/users/login_form.html:22 src/olympia/users/templates/users/register.html:67
 #: src/olympia/users/templates/users/mobile/login.html:37
 msgid "Password"
 msgstr ""
 
 #: src/olympia/users/templates/users/edit.html:70
 #, python-format
-msgid ""
-"Change your password. If you forgot your password, you can <a "
-"href=\"%(reset_url)s\">use the reset form</a>."
+msgid "Change your password. If you forgot your password, you can <a href=\"%(reset_url)s\">use the reset form</a>."
 msgstr ""
 
 #: src/olympia/users/templates/users/edit.html:76
@@ -13901,9 +11992,7 @@ msgid "Profile"
 msgstr ""
 
 #: src/olympia/users/templates/users/edit.html:100
-msgid ""
-"Give us a bit more information about yourself. All these fields are "
-"optional, but they'll help other users get to know you better."
+msgid "Give us a bit more information about yourself. All these fields are optional, but they'll help other users get to know you better."
 msgstr ""
 
 #: src/olympia/users/templates/users/edit.html:124
@@ -13919,15 +12008,11 @@ msgid "Delete current photo"
 msgstr ""
 
 #: src/olympia/users/templates/users/edit.html:144
-msgid ""
-"This is the default locale used to display information about you (like your "
-"description)."
+msgid "This is the default locale used to display information about you (like your description)."
 msgstr ""
 
 #: src/olympia/users/templates/users/edit.html:152
-msgid ""
-"Introduce yourself to the community, if you like! This text will appear "
-"publicly on your user info page."
+msgid "Introduce yourself to the community, if you like! This text will appear publicly on your user info page."
 msgstr ""
 
 #: src/olympia/users/templates/users/edit.html:161
@@ -13955,15 +12040,11 @@ msgid "Notifications"
 msgstr ""
 
 #: src/olympia/users/templates/users/edit.html:195
-msgid ""
-"From time to time, Mozilla may send you email about upcoming releases and "
-"add-on events. Please select the topics you are interested in."
+msgid "From time to time, Mozilla may send you email about upcoming releases and add-on events. Please select the topics you are interested in."
 msgstr ""
 
 #: src/olympia/users/templates/users/edit.html:205
-msgid ""
-"Mozilla reserves the right to contact you individually about specific "
-"concerns with your hosted add-ons."
+msgid "Mozilla reserves the right to contact you individually about specific concerns with your hosted add-ons."
 msgstr ""
 
 #: src/olympia/users/templates/users/edit.html:215
@@ -13986,60 +12067,48 @@ msgstr ""
 msgid "all"
 msgstr ""
 
-#: src/olympia/users/templates/users/fxa_migration.html:3
-#: src/olympia/users/templates/users/fxa_migration.html:11
-#: src/olympia/users/templates/users/mobile/fxa_migration.html:3
+#: src/olympia/users/templates/users/fxa_migration.html:3 src/olympia/users/templates/users/fxa_migration.html:11 src/olympia/users/templates/users/mobile/fxa_migration.html:3
 #: src/olympia/users/templates/users/mobile/fxa_migration.html:8
 msgid "Migrate to Firefox Accounts"
 msgstr ""
 
 #: src/olympia/users/templates/users/fxa_migration_prompt_content.html:3
-msgid ""
-"Mozilla Add-ons has transitioned to Firefox Accounts for login. Continue to "
-"complete the simple upgrade process."
+msgid "Mozilla Add-ons has transitioned to Firefox Accounts for login. Continue to complete the simple upgrade process."
 msgstr ""
 
 #: src/olympia/users/templates/users/fxa_migration_prompt_content.html:14
 msgid "Skip"
 msgstr ""
 
-#: src/olympia/users/templates/users/login.html:3
-#: src/olympia/users/templates/users/mobile/login.html:3
+#: src/olympia/users/templates/users/login.html:3 src/olympia/users/templates/users/mobile/login.html:3
 msgid "User Login"
 msgstr ""
 
-#: src/olympia/users/templates/users/login.html:13
-#: src/olympia/users/templates/users/mobile/login.html:21
+#: src/olympia/users/templates/users/login.html:13 src/olympia/users/templates/users/mobile/login.html:21
 msgid "Enter your email"
 msgstr ""
 
-#: src/olympia/users/templates/users/login.html:15
-#: src/olympia/users/templates/users/mobile/login.html:23
+#: src/olympia/users/templates/users/login.html:15 src/olympia/users/templates/users/mobile/login.html:23
 msgid "Log In"
 msgstr ""
 
-#: src/olympia/users/templates/users/login_form.html:17
-#: src/olympia/users/templates/users/mobile/login.html:32
+#: src/olympia/users/templates/users/login_form.html:17 src/olympia/users/templates/users/mobile/login.html:32
 msgid "Email address"
 msgstr ""
 
-#: src/olympia/users/templates/users/login_form.html:30
-#: src/olympia/users/templates/users/mobile/login.html:44
+#: src/olympia/users/templates/users/login_form.html:30 src/olympia/users/templates/users/mobile/login.html:44
 msgid "Remember me on this device"
 msgstr ""
 
-#: src/olympia/users/templates/users/login_help.html:3
-#: src/olympia/users/templates/users/mobile/login.html:63
+#: src/olympia/users/templates/users/login_help.html:3 src/olympia/users/templates/users/mobile/login.html:63
 msgid "Login Problems?"
 msgstr ""
 
-#: src/olympia/users/templates/users/login_help.html:5
-#: src/olympia/users/templates/users/mobile/login.html:65
+#: src/olympia/users/templates/users/login_help.html:5 src/olympia/users/templates/users/mobile/login.html:65
 msgid "I don't have an account."
 msgstr ""
 
-#: src/olympia/users/templates/users/login_help.html:6
-#: src/olympia/users/templates/users/mobile/login.html:66
+#: src/olympia/users/templates/users/login_help.html:6 src/olympia/users/templates/users/mobile/login.html:66
 msgid "I forgot my password."
 msgstr ""
 
@@ -14048,15 +12117,9 @@ msgstr ""
 msgid "You are now logged in as <strong>%(user_email)s</strong>!"
 msgstr ""
 
-#: src/olympia/users/templates/users/newpw_sent.html:3
-#: src/olympia/users/templates/users/newpw_sent.html:8
-#: src/olympia/users/templates/users/pwreset_complete.html:3
-#: src/olympia/users/templates/users/pwreset_confirm.html:4
-#: src/olympia/users/templates/users/pwreset_confirm.html:18
-#: src/olympia/users/templates/users/pwreset_request.html:4
-#: src/olympia/users/templates/users/pwreset_request.html:10
-#: src/olympia/users/templates/users/pwreset_sent.html:3
-#: src/olympia/users/templates/users/pwreset_sent.html:8
+#: src/olympia/users/templates/users/newpw_sent.html:3 src/olympia/users/templates/users/newpw_sent.html:8 src/olympia/users/templates/users/pwreset_complete.html:3
+#: src/olympia/users/templates/users/pwreset_confirm.html:4 src/olympia/users/templates/users/pwreset_confirm.html:18 src/olympia/users/templates/users/pwreset_request.html:4
+#: src/olympia/users/templates/users/pwreset_request.html:10 src/olympia/users/templates/users/pwreset_sent.html:3 src/olympia/users/templates/users/pwreset_sent.html:8
 msgid "Password Reset"
 msgstr ""
 
@@ -14072,8 +12135,7 @@ msgstr ""
 msgid "Manage user"
 msgstr ""
 
-#: src/olympia/users/templates/users/profile.html:18
-#: src/olympia/users/templates/users/report_abuse_full.html:9
+#: src/olympia/users/templates/users/profile.html:18 src/olympia/users/templates/users/report_abuse_full.html:9
 msgid "Report user"
 msgstr ""
 
@@ -14133,32 +12195,24 @@ msgstr ""
 msgid "Password successfully reset."
 msgstr ""
 
-#: src/olympia/users/templates/users/pwreset_confirm.html:13
-#: src/olympia/users/templates/users/pwreset_confirm.html:46
+#: src/olympia/users/templates/users/pwreset_confirm.html:13 src/olympia/users/templates/users/pwreset_confirm.html:46
 msgid "Password reset unsuccessful"
 msgstr ""
 
 #: src/olympia/users/templates/users/pwreset_confirm.html:14
-msgid ""
-"You have migrated to Firefox Accounts. You can no longer change your "
-"password here."
+msgid "You have migrated to Firefox Accounts. You can no longer change your password here."
 msgstr ""
 
-#: src/olympia/users/templates/users/pwreset_confirm.html:31
-#: src/olympia/users/templates/users/register.html:72
+#: src/olympia/users/templates/users/pwreset_confirm.html:31 src/olympia/users/templates/users/register.html:72
 msgid "Confirm password"
 msgstr ""
 
 #: src/olympia/users/templates/users/pwreset_confirm.html:47
-msgid ""
-"The password reset link was invalid, possibly because it has already been "
-"used. Please request a new password reset."
+msgid "The password reset link was invalid, possibly because it has already been used. Please request a new password reset."
 msgstr ""
 
 #: src/olympia/users/templates/users/pwreset_request.html:15
-msgid ""
-"Forgotten your password? Enter your e-mail address below, and we'll e-mail "
-"instructions for setting a new one."
+msgid "Forgotten your password? Enter your e-mail address below, and we'll e-mail instructions for setting a new one."
 msgstr ""
 
 #: src/olympia/users/templates/users/pwreset_request.html:25
@@ -14167,9 +12221,7 @@ msgstr ""
 
 #: src/olympia/users/templates/users/pwreset_sent.html:10
 msgid ""
-"An email has been sent to the requested account with further information. If"
-" you do not receive an email then please confirm you have entered the same "
-"email address used during account registration."
+"An email has been sent to the requested account with further information. If you do not receive an email then please confirm you have entered the same email address used during account registration."
 msgstr ""
 
 #: src/olympia/users/templates/users/register.html:4
@@ -14181,9 +12233,7 @@ msgid "Why register?"
 msgstr ""
 
 #: src/olympia/users/templates/users/register.html:14
-msgid ""
-"Registration on AMO is <strong>not required</strong> if you simply want to "
-"download and install public add-ons."
+msgid "Registration on AMO is <strong>not required</strong> if you simply want to download and install public add-ons."
 msgstr ""
 
 #: src/olympia/users/templates/users/register.html:16
@@ -14195,30 +12245,20 @@ msgid "You want to submit reviews for add-ons"
 msgstr ""
 
 #: src/olympia/users/templates/users/register.html:19
-msgid ""
-"You want to keep track of your favorite add-on collections or create one "
-"yourself"
+msgid "You want to keep track of your favorite add-on collections or create one yourself"
 msgstr ""
 
 #: src/olympia/users/templates/users/register.html:20
-msgid ""
-"You are an add-on developer and want to upload your add-on for hosting on "
-"AMO"
+msgid "You are an add-on developer and want to upload your add-on for hosting on AMO"
 msgstr ""
 
 #: src/olympia/users/templates/users/register.html:23
-msgid ""
-"Upon successful registration, you will be sent a confirmation email to the "
-"address you provided. Please follow the instructions there to confirm your "
-"account."
+msgid "Upon successful registration, you will be sent a confirmation email to the address you provided. Please follow the instructions there to confirm your account."
 msgstr ""
 
 #: src/olympia/users/templates/users/register.html:30
 #, python-format
-msgid ""
-"If you like, you can read our <a href=\"%(legal)s\" title=\"Legal "
-"Notices\">Legal Notices</a> and <a href=\"%(privacy)s\" title=\"Privacy "
-"Policy\">Privacy Policy</a>."
+msgid "If you like, you can read our <a href=\"%(legal)s\" title=\"Legal Notices\">Legal Notices</a> and <a href=\"%(privacy)s\" title=\"Privacy Policy\">Privacy Policy</a>."
 msgstr ""
 
 #: src/olympia/users/templates/users/register.html:52
@@ -14226,9 +12266,7 @@ msgid "Display name"
 msgstr ""
 
 #: src/olympia/users/templates/users/report_abuse.html:7
-msgid ""
-"Please describe why you are reporting this user, such as for spam or an "
-"inappropriate picture."
+msgid "Please describe why you are reporting this user, such as for spam or an inappropriate picture."
 msgstr ""
 
 #: src/olympia/users/templates/users/report_abuse_full.html:3
@@ -14243,32 +12281,24 @@ msgstr ""
 msgid "Special Edition Add-on Creator T-shirt"
 msgstr ""
 
-#: src/olympia/users/templates/users/t-shirt.html:14
-#: src/olympia/users/templates/users/t-shirt.html:120
+#: src/olympia/users/templates/users/t-shirt.html:14 src/olympia/users/templates/users/t-shirt.html:120
 msgid "Note:"
 msgstr ""
 
 #: src/olympia/users/templates/users/t-shirt.html:15
-msgid ""
-"You have already submitted a request for a t-shirt. You may re-submit this "
-"form to update your information, but you will only receive one shirt."
+msgid "You have already submitted a request for a t-shirt. You may re-submit this form to update your information, but you will only receive one shirt."
 msgstr ""
 
 #: src/olympia/users/templates/users/t-shirt.html:26
-msgid ""
-"Thank you for helping to make Firefox the most extensible browser available!"
+msgid "Thank you for helping to make Firefox the most extensible browser available!"
 msgstr ""
 
 #: src/olympia/users/templates/users/t-shirt.html:33
-msgid ""
-"As a thank you gift, we'd like to send you a special-edition, community-"
-"designed t-shirt. To receive your shirt, please fill out the form below."
+msgid "As a thank you gift, we'd like to send you a special-edition, community-designed t-shirt. To receive your shirt, please fill out the form below."
 msgstr ""
 
 #: src/olympia/users/templates/users/t-shirt.html:41
-msgid ""
-"Your contact information will only be used by Mozilla to ship this special "
-"edition t-shirt."
+msgid "Your contact information will only be used by Mozilla to ship this special edition t-shirt."
 msgstr ""
 
 #: src/olympia/users/templates/users/t-shirt.html:60
@@ -14325,16 +12355,12 @@ msgstr ""
 
 #: src/olympia/users/templates/users/t-shirt.html:137
 msgid ""
-"We're sorry, but in order to qualify for our special edition t-shirt, you "
-"must be an add-on developer with at least one listed add-on, one unlisted "
-"but signed add-on, or any number of background themes with a combined total "
-"of 10,000 average daily users."
+"We're sorry, but in order to qualify for our special edition t-shirt, you must be an add-on developer with at least one listed add-on, one unlisted but signed add-on, or any number of background "
+"themes with a combined total of 10,000 average daily users."
 msgstr ""
 
 #: src/olympia/users/templates/users/tougher_password.html:2
-msgid ""
-"For your account a password must contain at least 8 characters including "
-"letters and numbers."
+msgid "For your account a password must contain at least 8 characters including letters and numbers."
 msgstr ""
 
 #: src/olympia/users/templates/users/unsubscribe.html:2
@@ -14347,9 +12373,7 @@ msgstr ""
 
 #: src/olympia/users/templates/users/unsubscribe.html:10
 #, python-format
-msgid ""
-"The email address <strong>%(email)s</strong> will no longer get messages "
-"when:"
+msgid "The email address <strong>%(email)s</strong> will no longer get messages when:"
 msgstr ""
 
 #: src/olympia/users/templates/users/unsubscribe.html:20
@@ -14370,10 +12394,7 @@ msgstr ""
 
 #: src/olympia/users/templates/users/unsubscribe.html:30
 #, python-format
-msgid ""
-"Unfortunately, we weren't able to unsubscribe you. The link you clicked is "
-"invalid. However, you can unsubscribe still unsubscribe on your <a "
-"href=\"%(edit_url)s\">edit profile page</a>."
+msgid "Unfortunately, we weren't able to unsubscribe you. The link you clicked is invalid. However, you can unsubscribe still unsubscribe on your <a href=\"%(edit_url)s\">edit profile page</a>."
 msgstr ""
 
 #: src/olympia/users/templates/users/vcard.html:2
@@ -14480,17 +12501,13 @@ msgstr[1] ""
 msgstr[2] ""
 msgstr[3] ""
 
-#: src/olympia/versions/templates/versions/version_list.html:35
-#: src/olympia/versions/templates/versions/mobile/version_list.html:14
+#: src/olympia/versions/templates/versions/version_list.html:35 src/olympia/versions/templates/versions/mobile/version_list.html:14
 msgid "Be careful with old versions!"
 msgstr ""
 
-#: src/olympia/versions/templates/versions/version_list.html:36
-#: src/olympia/versions/templates/versions/mobile/version_list.html:15
+#: src/olympia/versions/templates/versions/version_list.html:36 src/olympia/versions/templates/versions/mobile/version_list.html:15
 #, python-format
-msgid ""
-"These versions are displayed for reference and testing purposes. You should "
-"always use the <a href=\"%(url)s\">latest version</a> of an add-on."
+msgid "These versions are displayed for reference and testing purposes. You should always use the <a href=\"%(url)s\">latest version</a> of an add-on."
 msgstr ""
 
 #: src/olympia/versions/templates/versions/mobile/version.html:4
@@ -14520,4 +12537,8 @@ msgstr ""
 
 #: src/olympia/zadmin/forms.py:105
 msgid "Log emails instead of sending"
+msgstr ""
+
+#: src/olympia/zadmin/forms.py:215
+msgid "Deleted versions can`t be changed."
 msgstr ""

--- a/locale/dsb/LC_MESSAGES/djangojs.po
+++ b/locale/dsb/LC_MESSAGES/djangojs.po
@@ -1,125 +1,92 @@
-# 
+#
 #, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT 1.0\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2016-04-11 14:21+0000\n"
+"POT-Creation-Date: 2016-04-18 15:40+0000\n"
 "PO-Revision-Date: 2016-04-16 19:54+0000\n"
 "Last-Translator: Michael Wolf <milupo@sorbzilla.de>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
 "Language: dsb\n"
 "MIME-Version: 1.0\n"
-"Content-Type: text/plain; charset=utf-8\n"
+"Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=4; plural=(n%100==1 ? 0 : n%100==2 ? 1 : n%100==3 || n%100==4 ? 2 : 3);\n"
 "Generated-By: Babel 2.2.0\n"
 "X-Generator: Pontoon\n"
 
-#: static/js/common-all.js:1426 static/js/impala-all.js:1511
-#: static/js/zamboni/discovery-all.js:12598 static/js/zamboni/init.js:28
-#: static/js/zamboni/mobile-all.js:14945
-msgid ""
-"This feature is temporarily disabled while we perform website maintenance. "
-"Please check back a little later."
-msgstr ""
-"Toś ta funkcija jo se nachylu znjemóžnjona, mjaztym až pśewjedujomy "
-"wótwardowańske źěła na websedle. Pšosym wopytajśo pitśku pózdźej hyšći raz."
+#: static/js/common-all.js:1426 static/js/impala-all.js:1511 static/js/zamboni/discovery-all.js:12598 static/js/zamboni/init.js:28 static/js/zamboni/mobile-all.js:14945
+msgid "This feature is temporarily disabled while we perform website maintenance. Please check back a little later."
+msgstr "Toś ta funkcija jo se nachylu znjemóžnjona, mjaztym až pśewjedujomy wótwardowańske źěła na websedle. Pšosym wopytajśo pitśku pózdźej hyšći raz."
 
 #. L10n: {0} is an app name like Firefox.
-#: static/js/common-all.js:1837 static/js/impala-all.js:1922
-#: static/js/zamboni/buttons.js:73 static/js/zamboni/discovery-all.js:13108
+#: static/js/common-all.js:1837 static/js/impala-all.js:1922 static/js/zamboni/buttons.js:73 static/js/zamboni/discovery-all.js:13108
 msgid "Accept and Install"
 msgstr "Akceptěrowaś a instalěrowaś"
 
-#: static/js/common-all.js:1837 static/js/impala-all.js:1922
-#: static/js/zamboni/buttons.js:73 static/js/zamboni/discovery-all.js:13108
+#: static/js/common-all.js:1837 static/js/impala-all.js:1922 static/js/zamboni/buttons.js:73 static/js/zamboni/discovery-all.js:13108
 msgid "Add to {0}"
 msgstr "K {0} pśidaś"
 
-#: static/js/common-all.js:1842 static/js/impala-all.js:1927
-#: static/js/zamboni/buttons.js:78 static/js/zamboni/discovery-all.js:13113
+#: static/js/common-all.js:1842 static/js/impala-all.js:1927 static/js/zamboni/buttons.js:78 static/js/zamboni/discovery-all.js:13113
 msgid "Download Now"
 msgstr "Něnto ześěgnuś"
 
-#: static/js/common-all.js:1883 static/js/impala-all.js:1968
-#: static/js/zamboni/buttons.js:119 static/js/zamboni/discovery-all.js:13154
+#: static/js/common-all.js:1883 static/js/impala-all.js:1968 static/js/zamboni/buttons.js:119 static/js/zamboni/discovery-all.js:13154
 msgid "Add-on has not been updated to support default-to-compatible."
-msgstr ""
-"Dodank njejo se ktualizěrował, aby standardnu kompatibelnosć pódpěrał."
+msgstr "Dodank njejo se ktualizěrował, aby standardnu kompatibelnosć pódpěrał."
 
-#: static/js/common-all.js:1888 static/js/impala-all.js:1973
-#: static/js/zamboni/buttons.js:124 static/js/zamboni/discovery-all.js:13159
+#: static/js/common-all.js:1888 static/js/impala-all.js:1973 static/js/zamboni/buttons.js:124 static/js/zamboni/discovery-all.js:13159
 msgid "You need to be using Firefox 10.0 or higher."
 msgstr "Musyśo Firefox 10.0 abo nowšy wužywaś."
 
-#: static/js/common-all.js:1900 static/js/impala-all.js:1985
-#: static/js/zamboni/buttons.js:136 static/js/zamboni/discovery-all.js:13171
-msgid ""
-"Mozilla has marked this version as incompatible with your Firefox version."
-msgstr ""
-"Mozilla jo toś tu wersiju ako z wašeju wersiju Firefox kompatibelnu "
-"markěrował."
+#: static/js/common-all.js:1900 static/js/impala-all.js:1985 static/js/zamboni/buttons.js:136 static/js/zamboni/discovery-all.js:13171
+msgid "Mozilla has marked this version as incompatible with your Firefox version."
+msgstr "Mozilla jo toś tu wersiju ako z wašeju wersiju Firefox kompatibelnu markěrował."
 
 #. L10n: {0} is an platform like Windows or Linux.
-#: static/js/common-all.js:1981 static/js/impala-all.js:2066
-#: static/js/zamboni/buttons.js:217 static/js/zamboni/discovery-all.js:13252
+#: static/js/common-all.js:1981 static/js/impala-all.js:2066 static/js/zamboni/buttons.js:217 static/js/zamboni/discovery-all.js:13252
 msgid "Install for {0} anyway"
 msgstr "Weto za {0} instalěrowaś"
 
-#: static/js/common-all.js:1981 static/js/impala-all.js:2066
-#: static/js/zamboni/buttons.js:217 static/js/zamboni/discovery-all.js:13252
+#: static/js/common-all.js:1981 static/js/impala-all.js:2066 static/js/zamboni/buttons.js:217 static/js/zamboni/discovery-all.js:13252
 msgid "Download for {0} anyway"
 msgstr "Weto za {0} ześěgnuś"
 
-#: static/js/common-all.js:2038 static/js/impala-all.js:2123
-#: static/js/zamboni/buttons.js:274 static/js/zamboni/discovery-all.js:13309
+#: static/js/common-all.js:2038 static/js/impala-all.js:2123 static/js/zamboni/buttons.js:274 static/js/zamboni/discovery-all.js:13309
 msgid "Not available for your platform"
 msgstr "Njejo za wašu platformu k dispoziciji"
 
 #. L10n: {0} is an app name, {1} is the app version.
-#: static/js/common-all.js:2049 static/js/common-all.js:2086
-#: static/js/impala-all.js:2134 static/js/impala-all.js:2171
-#: static/js/zamboni/buttons.js:285 static/js/zamboni/buttons.js:322
-#: static/js/zamboni/discovery-all.js:13320
-#: static/js/zamboni/discovery-all.js:13357
+#: static/js/common-all.js:2049 static/js/common-all.js:2086 static/js/impala-all.js:2134 static/js/impala-all.js:2171 static/js/zamboni/buttons.js:286 static/js/zamboni/buttons.js:324
+#: static/js/zamboni/discovery-all.js:13320 static/js/zamboni/discovery-all.js:13357
 msgid "Not available for {0} {1}"
 msgstr "Njejo za {0} {1} k dispoziciji"
 
-#: static/js/common-all.js:2112 static/js/impala-all.js:2197
-#: static/js/zamboni/buttons.js:348 static/js/zamboni/discovery-all.js:13383
+#: static/js/common-all.js:2112 static/js/impala-all.js:2197 static/js/zamboni/buttons.js:351 static/js/zamboni/discovery-all.js:13383
 msgid "Works with {app} {min} - {max}"
 msgstr "Funkcioněrujo z {app} {min} - {max}"
 
-#: static/js/common-all.js:2114 static/js/impala-all.js:2199
-#: static/js/zamboni/buttons.js:350 static/js/zamboni/discovery-all.js:13385
+#: static/js/common-all.js:2114 static/js/impala-all.js:2199 static/js/zamboni/buttons.js:353 static/js/zamboni/discovery-all.js:13385
 msgid "View other versions"
 msgstr "Druge wersije pokazaś"
 
-#: static/js/common-all.js:2162 static/js/impala-all.js:2247
-#: static/js/zamboni/buttons.js:398 static/js/zamboni/discovery-all.js:13433
+#: static/js/common-all.js:2162 static/js/impala-all.js:2247 static/js/zamboni/buttons.js:401 static/js/zamboni/discovery-all.js:13433
 msgid "Only with Firefox — Get Firefox Now!"
 msgstr "Jano z Firefox – Wobstarajśo se něnto Firefox!"
 
-#: static/js/common-all.js:2278 static/js/impala-all.js:2363
-#: static/js/zamboni/buttons.js:514 static/js/zamboni/discovery-all.js:13549
-#: static/js/zamboni/mobile-all.js:15177
+#: static/js/common-all.js:2278 static/js/impala-all.js:2363 static/js/zamboni/buttons.js:517 static/js/zamboni/discovery-all.js:13549 static/js/zamboni/mobile-all.js:15177
 #: static/js/zamboni/mobile/buttons.js:43
-msgid ""
-"Sorry, you need a Mozilla-based browser (such as Firefox) to install a "
-"search plugin."
-msgstr ""
-"Bóžko trjebaśo wobglědowak Mozilla (na pśikład Firefox), aby pytański tykac "
-"instalěrował."
+msgid "Sorry, you need a Mozilla-based browser (such as Firefox) to install a search plugin."
+msgstr "Bóžko trjebaśo wobglědowak Mozilla (na pśikład Firefox), aby pytański tykac instalěrował."
 
-#: static/js/common-all.js:9088 static/js/impala-all.js:9649
-#: static/js/zamboni/global.js:410
+#: static/js/common-all.js:9088 static/js/impala-all.js:9649 static/js/zamboni/global.js:410
 msgid "Loading..."
 msgstr "Zacitujo se..."
 
 #. L10n: {0} is the number of characters left.
-#: static/js/common-all.js:9152 static/js/impala-all.js:9713
-#: static/js/zamboni/global.js:474
+#: static/js/common-all.js:9152 static/js/impala-all.js:9713 static/js/zamboni/global.js:474
 msgid "<b>{0}</b> character left."
 msgid_plural "<b>{0}</b> characters left."
 msgstr[0] "<b>{0}</b> znamuško wušej."
@@ -127,9 +94,7 @@ msgstr[1] "<b>{0}</b> znamušce wušej."
 msgstr[2] "<b>{0}</b> znamuška wušej."
 msgstr[3] "<b>{0}</b> znamuškow wušej."
 
-#: static/js/common-all.js:9589 static/js/common-min.js:6
-#: static/js/impala-all.js:10052 static/js/impala-min.js:6
-#: static/js/common/ratingwidget.js:31 static/js/zamboni/mobile-all.js:16123
+#: static/js/common-all.js:9589 static/js/common-min.js:6 static/js/impala-all.js:10052 static/js/impala-min.js:6 static/js/common/ratingwidget.js:31 static/js/zamboni/mobile-all.js:16123
 #: static/js/zamboni/mobile-min.js:6
 msgid "{0} star"
 msgid_plural "{0} stars"
@@ -138,147 +103,101 @@ msgstr[1] "{0} gwězdce"
 msgstr[2] "{0} gwězdki"
 msgstr[3] "{0} gwězdkow"
 
-#: static/js/common-all.js:9676 static/js/common-min.js:6
-#: static/js/impala-all.js:10139 static/js/impala-min.js:6
-#: static/js/zamboni/l10n.js:45
+#: static/js/common-all.js:9676 static/js/common-min.js:6 static/js/impala-all.js:10139 static/js/impala-min.js:6 static/js/zamboni/l10n.js:45
 msgid "Remove this localization"
 msgstr "Toś ten pśełožk wótpóraś"
 
-#: static/js/common-all.js:10193 static/js/common-min.js:6
-#: static/js/impala-all.js:10674 static/js/impala-min.js:6
-#: static/js/zamboni/discovery-all.js:13678
+#: static/js/common-all.js:10193 static/js/common-min.js:6 static/js/impala-all.js:10674 static/js/impala-min.js:6 static/js/zamboni/discovery-all.js:13678
 msgid "close"
 msgstr "zacyniś"
 
-#: static/js/common-all.js:10860 static/js/common-min.js:6
-#: static/js/impala-all.js:11481 static/js/impala-min.js:6
-#: static/js/impala/reviews.js:23 static/js/zamboni/reviews.js:18
+#: static/js/common-all.js:10860 static/js/common-min.js:6 static/js/impala-all.js:11481 static/js/impala-min.js:6 static/js/impala/reviews.js:23 static/js/zamboni/reviews.js:18
 msgid "Flagged for review"
 msgstr "Za pśeglědowanje markěrowany"
 
-#: static/js/common-all.js:10876 static/js/common-min.js:6
-#: static/js/impala-all.js:11498 static/js/impala-min.js:6
-#: static/js/impala/reviews.js:40 static/js/zamboni/reviews.js:34
+#: static/js/common-all.js:10876 static/js/common-min.js:6 static/js/impala-all.js:11498 static/js/impala-min.js:6 static/js/impala/reviews.js:40 static/js/zamboni/reviews.js:34
 msgid "Your input is required"
 msgstr "Wašo zapódaśe jo trěbne"
 
-#: static/js/common-all.js:10945 static/js/common-min.js:6
-#: static/js/impala-all.js:11610 static/js/impala-min.js:7
-#: static/js/impala/reviews.js:152 static/js/zamboni/reviews.js:103
+#: static/js/common-all.js:10945 static/js/common-min.js:6 static/js/impala-all.js:11610 static/js/impala-min.js:7 static/js/impala/reviews.js:152 static/js/zamboni/reviews.js:103
 msgid "Marked for deletion"
 msgstr "Za wulašowanje markěrowany"
 
-#: static/js/common-all.js:11573 static/js/common-min.js:7
-#: static/js/impala-all.js:13809 static/js/impala-min.js:8
-#: static/js/zamboni/collections.js:229
+#: static/js/common-all.js:11573 static/js/common-min.js:7 static/js/impala-all.js:13809 static/js/impala-min.js:8 static/js/zamboni/collections.js:229
 msgid "Adding to Favorites&hellip;"
 msgstr "Pśidawa se faworitam&hellip;"
 
-#: static/js/common-all.js:11576 static/js/common-min.js:7
-#: static/js/impala-all.js:13812 static/js/impala-min.js:8
-#: static/js/zamboni/collections.js:232
+#: static/js/common-all.js:11576 static/js/common-min.js:7 static/js/impala-all.js:13812 static/js/impala-min.js:8 static/js/zamboni/collections.js:232
 msgid "Removing Favorite&hellip;"
 msgstr "Faworit se wótpórajo&hellip;"
 
-#: static/js/common-all.js:11579 static/js/common-min.js:7
-#: static/js/impala-all.js:13815 static/js/impala-min.js:8
-#: static/js/zamboni/collections.js:235
+#: static/js/common-all.js:11579 static/js/common-min.js:7 static/js/impala-all.js:13815 static/js/impala-min.js:8 static/js/zamboni/collections.js:235
 msgid "Add to Favorites"
 msgstr "Faworitam pśidaś"
 
-#: static/js/common-all.js:11582 static/js/common-min.js:7
-#: static/js/impala-all.js:13818 static/js/impala-min.js:8
-#: static/js/zamboni/collections.js:238
+#: static/js/common-all.js:11582 static/js/common-min.js:7 static/js/impala-all.js:13818 static/js/impala-min.js:8 static/js/zamboni/collections.js:238
 msgid "Remove from Favorites"
 msgstr "Z faworitow wótpóraś"
 
-#: static/js/common-all.js:11647 static/js/common-min.js:7
-#: static/js/impala-all.js:13883 static/js/impala-min.js:8
-#: static/js/zamboni/collections.js:303
+#: static/js/common-all.js:11647 static/js/common-min.js:7 static/js/impala-all.js:13883 static/js/impala-min.js:8 static/js/zamboni/collections.js:303
 msgid "Pending"
 msgstr "Felujucy"
 
-#: static/js/common-all.js:11648 static/js/common-min.js:7
-#: static/js/impala-all.js:13884 static/js/impala-min.js:8
-#: static/js/zamboni/collections.js:304
+#: static/js/common-all.js:11648 static/js/common-min.js:7 static/js/impala-all.js:13884 static/js/impala-min.js:8 static/js/zamboni/collections.js:304
 msgid "Add a comment"
 msgstr "Komentar pśidaś"
 
-#: static/js/common-all.js:11648 static/js/common-min.js:7
-#: static/js/impala-all.js:13884 static/js/impala-min.js:8
-#: static/js/zamboni/collections.js:304
+#: static/js/common-all.js:11648 static/js/common-min.js:7 static/js/impala-all.js:13884 static/js/impala-min.js:8 static/js/zamboni/collections.js:304
 msgid "Comment"
 msgstr "Komentar"
 
-#: static/js/common-all.js:11649 static/js/common-min.js:7
-#: static/js/impala-all.js:13885 static/js/impala-min.js:8
-#: static/js/zamboni/collections.js:305
+#: static/js/common-all.js:11649 static/js/common-min.js:7 static/js/impala-all.js:13885 static/js/impala-min.js:8 static/js/zamboni/collections.js:305
 msgid "Remove this add-on from the collection"
 msgstr "Toś ten dodank ze zběrki wótpóraś"
 
-#: static/js/common-all.js:11649 static/js/common-all.js:11678
-#: static/js/common-min.js:7 static/js/impala-all.js:13885
-#: static/js/impala-all.js:13914 static/js/impala-min.js:8
+#: static/js/common-all.js:11649 static/js/common-all.js:11678 static/js/common-min.js:7 static/js/impala-all.js:13885 static/js/impala-all.js:13914 static/js/impala-min.js:8
 #: static/js/zamboni/collections.js:305 static/js/zamboni/collections.js:334
 msgid "Remove"
 msgstr "Wótpóraś"
 
-#: static/js/common-all.js:11678 static/js/common-min.js:7
-#: static/js/impala-all.js:13914 static/js/impala-min.js:8
-#: static/js/zamboni/collections.js:334
+#: static/js/common-all.js:11678 static/js/common-min.js:7 static/js/impala-all.js:13914 static/js/impala-min.js:8 static/js/zamboni/collections.js:334
 msgid "Remove this user as a contributor"
 msgstr "Wužywarja ako sobustatkujucego wótpóraś"
 
-#: static/js/common-all.js:11690 static/js/common-min.js:7
-#: static/js/impala-all.js:13926 static/js/impala-min.js:8
-#: static/js/zamboni/collections.js:346
+#: static/js/common-all.js:11690 static/js/common-min.js:7 static/js/impala-all.js:13926 static/js/impala-min.js:8 static/js/zamboni/collections.js:346
 msgid "An email address is required."
 msgstr "E-mailowa adresa jo trěbna."
 
-#: static/js/common-all.js:11708 static/js/common-min.js:7
-#: static/js/impala-all.js:13944 static/js/impala-min.js:8
-#: static/js/zamboni/collections.js:364
+#: static/js/common-all.js:11708 static/js/common-min.js:7 static/js/impala-all.js:13944 static/js/impala-min.js:8 static/js/zamboni/collections.js:364
 msgid "You cannot add yourself as a contributor."
 msgstr "Njamóžośo sebje ako sobustatkujucego pśidaś."
 
-#: static/js/common-all.js:11710 static/js/common-min.js:7
-#: static/js/impala-all.js:13946 static/js/impala-min.js:8
-#: static/js/zamboni/collections.js:366
+#: static/js/common-all.js:11710 static/js/common-min.js:7 static/js/impala-all.js:13946 static/js/impala-min.js:8 static/js/zamboni/collections.js:366
 msgid "You have already added that user."
 msgstr "Sćo južo togo wužywarja pśidał."
 
-#: static/js/common-all.js:11917 static/js/common-min.js:7
-#: static/js/impala-all.js:14153 static/js/impala-min.js:8
-#: static/js/zamboni/collections.js:573
+#: static/js/common-all.js:11917 static/js/common-min.js:7 static/js/impala-all.js:14153 static/js/impala-min.js:8 static/js/zamboni/collections.js:573
 msgid "Add to favorites"
 msgstr "Faworitam pśidaś"
 
-#: static/js/common-all.js:11921 static/js/common-min.js:7
-#: static/js/impala-all.js:14157 static/js/impala-min.js:8
-#: static/js/zamboni/collections.js:577
+#: static/js/common-all.js:11921 static/js/common-min.js:7 static/js/impala-all.js:14157 static/js/impala-min.js:8 static/js/zamboni/collections.js:577
 msgid "Remove from favorites"
 msgstr "Z faworitow wótpóraś"
 
-#: static/js/common-all.js:11939 static/js/common-min.js:7
-#: static/js/impala-all.js:14175 static/js/impala-all.js:14233
-#: static/js/impala-min.js:8 static/js/impala/collections.js:10
+#: static/js/common-all.js:11939 static/js/common-min.js:7 static/js/impala-all.js:14175 static/js/impala-all.js:14233 static/js/impala-min.js:8 static/js/impala/collections.js:10
 #: static/js/zamboni/collections.js:595
 msgid "Follow this Collection"
 msgstr "Toś tej zběrce slědowaś"
 
-#: static/js/common-all.js:11948 static/js/common-min.js:7
-#: static/js/impala-all.js:14184 static/js/impala-min.js:8
-#: static/js/zamboni/collections.js:604
+#: static/js/common-all.js:11948 static/js/common-min.js:7 static/js/impala-all.js:14184 static/js/impala-min.js:8 static/js/zamboni/collections.js:604
 msgid "Stop following"
 msgstr "Wěcej njeslědowaś"
 
-#: static/js/common-all.js:12096 static/js/common-min.js:7
-#: static/js/zamboni/password-strength.js:20
+#: static/js/common-all.js:12096 static/js/common-min.js:7 static/js/zamboni/password-strength.js:20
 msgid "Password strength:"
 msgstr "Gronidłowa móc:"
 
-#: static/js/common-all.js:12102 static/js/common-min.js:7
-#: static/js/zamboni/password-strength.js:26
+#: static/js/common-all.js:12102 static/js/common-min.js:7 static/js/zamboni/password-strength.js:26
 msgid "At least {0} character left."
 msgid_plural "At least {0} characters left."
 msgstr[0] "Nanejmjenjej {0} znamuško wušej."
@@ -286,156 +205,121 @@ msgstr[1] "Nanejmjenjej {0} znamušce wušej."
 msgstr[2] "Nanejmjenjej {0} znamuška wušej."
 msgstr[3] "Nanejmjenjej {0} znamuškow wušej."
 
-#: static/js/common-all.js:12286 static/js/common-min.js:7
-#: static/js/impala-all.js:14632 static/js/impala-min.js:8
-#: static/js/impala/suggestions.js:39
+#: static/js/common-all.js:12286 static/js/common-min.js:7 static/js/impala-all.js:14632 static/js/impala-min.js:8 static/js/impala/suggestions.js:39
 msgid "Search themes for <b>{0}</b>"
 msgstr "Drastwy za <b>{0}</b> pytaś"
 
-#: static/js/common-all.js:12288 static/js/common-min.js:7
-#: static/js/impala-all.js:14634 static/js/impala-min.js:8
-#: static/js/impala/suggestions.js:41
+#: static/js/common-all.js:12288 static/js/common-min.js:7 static/js/impala-all.js:14634 static/js/impala-min.js:8 static/js/impala/suggestions.js:41
 msgid "Search apps for <b>{0}</b>"
 msgstr "Nałoženja za <b>{0}</b> pytaś"
 
-#: static/js/common-all.js:12290 static/js/common-min.js:7
-#: static/js/impala-all.js:14636 static/js/impala-min.js:8
-#: static/js/impala/suggestions.js:43
+#: static/js/common-all.js:12290 static/js/common-min.js:7 static/js/impala-all.js:14636 static/js/impala-min.js:8 static/js/impala/suggestions.js:43
 msgid "Search add-ons for <b>{0}</b>"
 msgstr "Dodanki za <b>{0}</b> pytaś"
 
-#: static/js/common-all.js:12521 static/js/common-min.js:7
-#: static/js/impala-all.js:14867 static/js/impala-min.js:8
-#: static/js/impala/site_suggestions.js:46
+#: static/js/common-all.js:12521 static/js/common-min.js:7 static/js/impala-all.js:14867 static/js/impala-min.js:8 static/js/impala/site_suggestions.js:46
 msgid "Category"
 msgstr "Kategorija"
 
 #. L10n: {0} is an app name.
-#: static/js/impala-all.js:11632 static/js/impala-min.js:7
-#: static/js/impala/listing.js:11 static/js/zamboni/themes.js:13
+#: static/js/impala-all.js:11632 static/js/impala-min.js:7 static/js/impala/listing.js:11 static/js/zamboni/themes.js:13
 msgid "This theme is incompatible with your version of {0}"
 msgstr "Toś ta drastwa njejo kompatibelna z wašeju wersiju {0}"
 
-#: static/js/impala-all.js:12146 static/js/impala-all.js:14331
-#: static/js/impala-min.js:7 static/js/impala-min.js:8
-#: static/js/common/upload-image.js:97 static/js/impala/users.js:51
+#: static/js/impala-all.js:12146 static/js/impala-all.js:14331 static/js/impala-min.js:7 static/js/impala-min.js:8 static/js/common/upload-image.js:97 static/js/impala/users.js:51
 #: static/js/zamboni/devhub-all.js:894 static/js/zamboni/devhub-min.js:1
 msgid "Images must be either PNG or JPG."
 msgstr "Wobraze muse pak PNG pak JPG byś."
 
-#: static/js/impala-all.js:12150 static/js/impala-min.js:7
-#: static/js/common/upload-image.js:101 static/js/zamboni/devhub-all.js:898
-#: static/js/zamboni/devhub-min.js:1
+#: static/js/impala-all.js:12150 static/js/impala-min.js:7 static/js/common/upload-image.js:101 static/js/zamboni/devhub-all.js:898 static/js/zamboni/devhub-min.js:1
 msgid "Videos must be in WebM."
 msgstr "Wideo muse we formaśe WebM byś."
 
-#: static/js/impala-all.js:12177 static/js/impala-min.js:7
-#: static/js/common/upload-addon.js:41 static/js/common/upload-image.js:128
-#: static/js/zamboni/devhub-all.js:272 static/js/zamboni/devhub-all.js:925
-#: static/js/zamboni/devhub-min.js:1
+#: static/js/impala-all.js:12177 static/js/impala-min.js:7 static/js/common/upload-addon.js:41 static/js/common/upload-image.js:128 static/js/zamboni/devhub-all.js:272
+#: static/js/zamboni/devhub-all.js:925 static/js/zamboni/devhub-min.js:1
 msgid "There was a problem contacting the server."
 msgstr "Pśi kontaktěrowanju serwera jo problem nastał."
 
-#: static/js/impala-all.js:13298 static/js/impala-min.js:7
-#: static/js/impala/persona_creation.js:60
+#: static/js/impala-all.js:13298 static/js/impala-min.js:7 static/js/impala/persona_creation.js:60
 msgid "All Rights Reserved"
 msgstr "Wšykne pšawa wuměnjone"
 
-#: static/js/impala-all.js:13302 static/js/impala-min.js:7
-#: static/js/impala/persona_creation.js:64
+#: static/js/impala-all.js:13302 static/js/impala-min.js:7 static/js/impala/persona_creation.js:64
 msgid "Creative Commons Attribution 3.0"
 msgstr "Creative Commons Attribution 3.0"
 
-#: static/js/impala-all.js:13307 static/js/impala-min.js:7
-#: static/js/impala/persona_creation.js:69
+#: static/js/impala-all.js:13307 static/js/impala-min.js:7 static/js/impala/persona_creation.js:69
 msgid "Creative Commons Attribution-NonCommercial 3.0"
 msgstr "Creative Commons Attribution-NonCommercial 3.0"
 
-#: static/js/impala-all.js:13312 static/js/impala-min.js:7
-#: static/js/impala/persona_creation.js:74
+#: static/js/impala-all.js:13312 static/js/impala-min.js:7 static/js/impala/persona_creation.js:74
 msgid "Creative Commons Attribution-NonCommercial-NoDerivs 3.0"
 msgstr "Creative Commons Attribution-NonCommercial-NoDerivs 3.0"
 
-#: static/js/impala-all.js:13317 static/js/impala-min.js:7
-#: static/js/impala/persona_creation.js:79
+#: static/js/impala-all.js:13317 static/js/impala-min.js:7 static/js/impala/persona_creation.js:79
 msgid "Creative Commons Attribution-NonCommercial-Share Alike 3.0"
 msgstr "Creative Commons Attribution-NonCommercial-Share Alike 3.0"
 
-#: static/js/impala-all.js:13322 static/js/impala-min.js:7
-#: static/js/impala/persona_creation.js:84
+#: static/js/impala-all.js:13322 static/js/impala-min.js:7 static/js/impala/persona_creation.js:84
 msgid "Creative Commons Attribution-NoDerivs 3.0"
 msgstr "Creative Commons Attribution-NoDerivs 3.0"
 
-#: static/js/impala-all.js:13327 static/js/impala-min.js:7
-#: static/js/impala/persona_creation.js:89
+#: static/js/impala-all.js:13327 static/js/impala-min.js:7 static/js/impala/persona_creation.js:89
 msgid "Creative Commons Attribution-ShareAlike 3.0"
 msgstr "Creative Commons Attribution-ShareAlike 3.0"
 
-#: static/js/impala-all.js:13530 static/js/impala-min.js:7
-#: static/js/impala/persona_creation.js:292
+#: static/js/impala-all.js:13530 static/js/impala-min.js:7 static/js/impala/persona_creation.js:292
 msgid "Your Theme's Name"
 msgstr "Mě wašeje drastwy"
 
-#: static/js/impala-all.js:14242 static/js/impala-min.js:8
-#: static/js/impala/collections.js:19
+#: static/js/impala-all.js:14242 static/js/impala-min.js:8 static/js/impala/collections.js:19
 msgid "Stop Following"
 msgstr "Wěcej njeslědowaś"
 
-#: static/js/impala-all.js:14243 static/js/impala-min.js:8
-#: static/js/impala/collections.js:20
+#: static/js/impala-all.js:14243 static/js/impala-min.js:8 static/js/impala/collections.js:20
 msgid "Following"
 msgstr "Slědowanje"
 
-#: static/js/impala-all.js:14313 static/js/impala-min.js:8
-#: static/js/impala/users.js:33
+#: static/js/impala-all.js:14313 static/js/impala-min.js:8 static/js/impala/users.js:33
 msgid "use original"
 msgstr "original wužywaś"
 
-#: static/js/impala-all.js:14523 static/js/impala-min.js:8
-#: static/js/impala/search.js:114
+#: static/js/impala-all.js:14523 static/js/impala-min.js:8 static/js/impala/search.js:114
 msgid "Updating results&hellip;"
 msgstr "Wuslědki so aktualizěruju&hellip;"
 
-#: static/js/common/upload-addon.js:69 static/js/zamboni/devhub-all.js:300
-#: static/js/zamboni/devhub-min.js:1
+#: static/js/common/upload-addon.js:69 static/js/zamboni/devhub-all.js:300 static/js/zamboni/devhub-min.js:1
 msgid "Select a file..."
 msgstr "Wubjeŕśo dataju..."
 
-#: static/js/common/upload-addon.js:70 static/js/zamboni/devhub-all.js:301
-#: static/js/zamboni/devhub-min.js:1
+#: static/js/common/upload-addon.js:70 static/js/zamboni/devhub-all.js:301 static/js/zamboni/devhub-min.js:1
 msgid "Your add-on should end with .xpi, .jar or .xml"
 msgstr "Waš dodank by dejał kóńcowku .xpi, .jar abo .xml měś"
 
 #. L10n: {0} is the percent of the file that has been uploaded.
-#: static/js/common/upload-addon.js:104 static/js/zamboni/devhub-all.js:335
-#: static/js/zamboni/devhub-min.js:1
+#: static/js/common/upload-addon.js:104 static/js/zamboni/devhub-all.js:335 static/js/zamboni/devhub-min.js:1
 #, python-format
 msgid "{0}% complete"
 msgstr "{0}% dokóńcone"
 
 #. L10n: "{bytes uploaded} of {total filesize}".
-#: static/js/common/upload-addon.js:107 static/js/zamboni/devhub-all.js:338
-#: static/js/zamboni/devhub-min.js:1
+#: static/js/common/upload-addon.js:107 static/js/zamboni/devhub-all.js:338 static/js/zamboni/devhub-min.js:1
 msgid "{0} of {1}"
 msgstr "{0} z {1}"
 
-#: static/js/common/upload-addon.js:140 static/js/zamboni/devhub-all.js:371
-#: static/js/zamboni/devhub-min.js:1
+#: static/js/common/upload-addon.js:140 static/js/zamboni/devhub-all.js:371 static/js/zamboni/devhub-min.js:1
 msgid "Cancel"
 msgstr "Pśetergnuś"
 
-#: static/js/common/upload-addon.js:162 static/js/zamboni/devhub-all.js:393
-#: static/js/zamboni/devhub-min.js:1
+#: static/js/common/upload-addon.js:162 static/js/zamboni/devhub-all.js:393 static/js/zamboni/devhub-min.js:1
 msgid "Uploading {0}"
 msgstr "{0} se nagrawa"
 
-#: static/js/common/upload-addon.js:189 static/js/zamboni/devhub-all.js:420
-#: static/js/zamboni/devhub-min.js:1
+#: static/js/common/upload-addon.js:189 static/js/zamboni/devhub-all.js:420 static/js/zamboni/devhub-min.js:1
 msgid "Error with {0}"
 msgstr "Zmólka z {0}"
 
-#: static/js/common/upload-addon.js:194 static/js/zamboni/devhub-all.js:425
-#: static/js/zamboni/devhub-min.js:1
+#: static/js/common/upload-addon.js:194 static/js/zamboni/devhub-all.js:425 static/js/zamboni/devhub-min.js:1
 msgid "Your add-on failed validation with {0} error."
 msgid_plural "Your add-on failed validation with {0} errors."
 msgstr[0] "Waš dodank jo pśi pśeglědowanju z {0} zmólku pśepadnuł."
@@ -443,8 +327,7 @@ msgstr[1] "Waš dodank jo pśi pśeglědowanju z {0} zmólkoma pśepadnuł."
 msgstr[2] "Waš dodank jo pśi pśeglědowanju z {0} zmólkami pśepadnuł."
 msgstr[3] "Waš dodank jo pśi pśeglědowanju z {0} zmólkami pśepadnuł."
 
-#: static/js/common/upload-addon.js:208 static/js/zamboni/devhub-all.js:439
-#: static/js/zamboni/devhub-min.js:1
+#: static/js/common/upload-addon.js:208 static/js/zamboni/devhub-all.js:439 static/js/zamboni/devhub-min.js:1
 msgid "&hellip;and {0} more"
 msgid_plural "&hellip;and {0} more"
 msgstr[0] "&hellip;a {0} dalšny"
@@ -452,923 +335,693 @@ msgstr[1] "&hellip;a {0} dalšnej"
 msgstr[2] "&hellip;a {0} dalšne"
 msgstr[3] "&hellip;a {0} dalšnych"
 
-#: static/js/common/upload-addon.js:222 static/js/common/upload-addon.js:478
-#: static/js/zamboni/devhub-all.js:453 static/js/zamboni/devhub-all.js:743
-#: static/js/zamboni/devhub-min.js:1
+#: static/js/common/upload-addon.js:222 static/js/common/upload-addon.js:497 static/js/zamboni/devhub-all.js:453 static/js/zamboni/devhub-all.js:743 static/js/zamboni/devhub-min.js:1
 msgid "See full validation report"
 msgstr "Dopołnu pśeglědowańsku rozpšawu cytaś"
 
-#: static/js/common/upload-addon.js:234 static/js/zamboni/devhub-all.js:465
-#: static/js/zamboni/devhub-min.js:1
+#: static/js/common/upload-addon.js:234 static/js/zamboni/devhub-all.js:465 static/js/zamboni/devhub-min.js:1
 msgid "Validating {0}"
 msgstr "{0} se pśeglědujo"
 
 #. L10n: first argument is an HTTP status code
-#: static/js/common/upload-addon.js:273 static/js/zamboni/devhub-all.js:504
-#: static/js/zamboni/devhub-min.js:1
+#: static/js/common/upload-addon.js:273 static/js/zamboni/devhub-all.js:504 static/js/zamboni/devhub-min.js:1
 msgid "Received an empty response from the server; status: {0}"
 msgstr "Prozne wótegrono jo se wót serwera dostało; status: {0}"
 
-#: static/js/common/upload-addon.js:352 static/js/zamboni/devhub-all.js:604
-#: static/js/zamboni/devhub-min.js:1
+#: static/js/common/upload-addon.js:370 static/js/zamboni/devhub-all.js:604 static/js/zamboni/devhub-min.js:1
 msgid "Unexpected server error while validating."
 msgstr "Njewótcakana serwerowa zmólka pśi pśeglědowanju."
 
-#: static/js/common/upload-addon.js:391 static/js/zamboni/devhub-all.js:643
-#: static/js/zamboni/devhub-min.js:1
+#: static/js/common/upload-addon.js:409 static/js/zamboni/devhub-all.js:643 static/js/zamboni/devhub-min.js:1
 msgid "Finished validating {0}"
 msgstr "Pśeglědowanje {0} dokóńcone"
 
-#: static/js/common/upload-addon.js:397 static/js/zamboni/devhub-all.js:649
-#: static/js/zamboni/devhub-min.js:1
+#: static/js/common/upload-addon.js:415 static/js/zamboni/devhub-all.js:649 static/js/zamboni/devhub-min.js:1
 msgid "Your add-on validation timed out, it will be manually reviewed."
-msgstr ""
-"Wašo pśeglědowanje dodanka jo cas pśekšocyło, buźo se togodla manuelnje "
-"pśewjasć."
+msgstr "Wašo pśeglědowanje dodanka jo cas pśekšocyło, buźo se togodla manuelnje pśewjasć."
 
-#: static/js/common/upload-addon.js:400 static/js/zamboni/devhub-all.js:652
-#: static/js/zamboni/devhub-min.js:1
+#: static/js/common/upload-addon.js:418 static/js/zamboni/devhub-all.js:652 static/js/zamboni/devhub-min.js:1
 msgid "Your add-on was validated with no errors and {0} warning."
 msgid_plural "Your add-on was validated with no errors and {0} warnings."
-msgstr[0] ""
-"Waš dodank jo pśeglědowanje bźeze zmólkow a z {0} warnowanim wobstał."
-msgstr[1] ""
-"Waš dodank jo pśeglědowanje bźeze zmólkow a z {0} warnowanjoma wobstał."
-msgstr[2] ""
-"Waš dodank jo pśeglědowanje bźeze zmólkow a z {0} warnowanjami wobstał."
-msgstr[3] ""
-"Waš dodank jo pśeglědowanje bźeze zmólkow a z {0} warnowanjami wobstał."
+msgstr[0] "Waš dodank jo pśeglědowanje bźeze zmólkow a z {0} warnowanim wobstał."
+msgstr[1] "Waš dodank jo pśeglědowanje bźeze zmólkow a z {0} warnowanjoma wobstał."
+msgstr[2] "Waš dodank jo pśeglědowanje bźeze zmólkow a z {0} warnowanjami wobstał."
+msgstr[3] "Waš dodank jo pśeglědowanje bźeze zmólkow a z {0} warnowanjami wobstał."
 
-#: static/js/common/upload-addon.js:405 static/js/zamboni/devhub-all.js:657
-#: static/js/zamboni/devhub-min.js:1
+#: static/js/common/upload-addon.js:423 static/js/zamboni/devhub-all.js:657 static/js/zamboni/devhub-min.js:1
 msgid "Your add-on was validated with no errors and {0} message."
 msgid_plural "Your add-on was validated with no errors and {0} messages."
-msgstr[0] ""
-"Waš dodank jo pśeglědowanje bźeze zmólkow a z {0} powězeńku wobstał."
-msgstr[1] ""
-"Waš dodank jo pśeglědowanje bźeze zmólkow a z {0} powězeńkoma wobstał."
-msgstr[2] ""
-"Waš dodank jo pśeglědowanje bźeze zmólkow a z {0} powězeńkami wobstał."
-msgstr[3] ""
-"Waš dodank jo pśeglědowanje bźeze zmólkow a z {0} powězeńkami wobstał."
+msgstr[0] "Waš dodank jo pśeglědowanje bźeze zmólkow a z {0} powězeńku wobstał."
+msgstr[1] "Waš dodank jo pśeglědowanje bźeze zmólkow a z {0} powězeńkoma wobstał."
+msgstr[2] "Waš dodank jo pśeglědowanje bźeze zmólkow a z {0} powězeńkami wobstał."
+msgstr[3] "Waš dodank jo pśeglědowanje bźeze zmólkow a z {0} powězeńkami wobstał."
 
-#: static/js/common/upload-addon.js:410 static/js/zamboni/devhub-all.js:662
-#: static/js/zamboni/devhub-min.js:1
+#: static/js/common/upload-addon.js:428 static/js/zamboni/devhub-all.js:662 static/js/zamboni/devhub-min.js:1
 msgid "Your add-on was validated with no errors or warnings."
 msgstr "Waš dodank jo pśeglědowanje bźeze zmólkow a bźez warnowanjow wobstał."
 
-#: static/js/common/upload-addon.js:424 static/js/zamboni/devhub-all.js:677
-#: static/js/zamboni/devhub-min.js:1
+#: static/js/common/upload-addon.js:443 static/js/zamboni/devhub-all.js:677 static/js/zamboni/devhub-min.js:1
 msgid "Your submission will be automatically signed."
 msgstr "Wašo zapódaśe buźo se awtomatiski signěrowaś."
 
-#: static/js/common/upload-addon.js:431 static/js/zamboni/devhub-all.js:696
-#: static/js/zamboni/devhub-min.js:1
+#: static/js/common/upload-addon.js:450 static/js/zamboni/devhub-all.js:696 static/js/zamboni/devhub-min.js:1
 msgid "Include detailed version notes (this can be done in the next step)."
-msgstr ""
-"Nadrobne wersijowe informacije zapśimjeś (to dajo se w pśiducem kšacu "
-"cyniś)."
+msgstr "Nadrobne wersijowe informacije zapśimjeś (to dajo se w pśiducem kšacu cyniś)."
 
-#: static/js/common/upload-addon.js:432 static/js/zamboni/devhub-all.js:697
-#: static/js/zamboni/devhub-min.js:1
-msgid ""
-"If your add-on requires an account to a website in order to be fully tested,"
-" include a test username and password in the Notes to Reviewer (this can be "
-"done in the next step)."
-msgstr ""
-"Jolic waš dodank pomina se konto z websedłom, aby se dopołnje testował, "
-"pódajśo w powěźeńkach na pśeglědowarja testowe wužywarske mě a grondło (to "
-"dajo se w pśiducem kšacu cyniś)."
+#: static/js/common/upload-addon.js:451 static/js/zamboni/devhub-all.js:697 static/js/zamboni/devhub-min.js:1
+msgid "If your add-on requires an account to a website in order to be fully tested, include a test username and password in the Notes to Reviewer (this can be done in the next step)."
+msgstr "Jolic waš dodank pomina se konto z websedłom, aby se dopołnje testował, pódajśo w powěźeńkach na pśeglědowarja testowe wužywarske mě a grondło (to dajo se w pśiducem kšacu cyniś)."
 
-#: static/js/common/upload-addon.js:433 static/js/zamboni/devhub-all.js:698
-#: static/js/zamboni/devhub-min.js:1
-msgid ""
-"If your add-on is intended for a limited audience you should choose "
-"Preliminary Review instead of Full Review."
-msgstr ""
-"Jolic waš dodank jo za wobgranicowany krejz wužywarjow myslony, wy by dejał "
-"„Nachylne pśeglědowanje“ město „Dopołne pśeglědowanje“ wubraś."
+#: static/js/common/upload-addon.js:452 static/js/zamboni/devhub-all.js:698 static/js/zamboni/devhub-min.js:1
+msgid "If your add-on is intended for a limited audience you should choose Preliminary Review instead of Full Review."
+msgstr "Jolic waš dodank jo za wobgranicowany krejz wužywarjow myslony, wy by dejał „Nachylne pśeglědowanje“ město „Dopołne pśeglědowanje“ wubraś."
 
-#: static/js/common/upload-addon.js:446 static/js/zamboni/devhub-all.js:711
-#: static/js/zamboni/devhub-min.js:1
+#: static/js/common/upload-addon.js:465 static/js/zamboni/devhub-all.js:711 static/js/zamboni/devhub-min.js:1
 msgid "Add-on submission checklist"
 msgstr "Kontrolna lisćina za zapdaśa dodankow"
 
-#: static/js/common/upload-addon.js:447 static/js/zamboni/devhub-all.js:712
-#: static/js/zamboni/devhub-min.js:1
-msgid ""
-"Please verify the following points before finalizing your submission. This "
-"will minimize delays or misunderstanding during the review process:"
-msgstr ""
-"Pšosym wobkšuśćo slědujuce dypki, nježli až swóje zapódaśe dokóńcyjośo. To "
-"miniměrujo wokomuźenja abo njedorozměśa za pséglědowański proces:"
+#: static/js/common/upload-addon.js:466 static/js/zamboni/devhub-all.js:712 static/js/zamboni/devhub-min.js:1
+msgid "Please verify the following points before finalizing your submission. This will minimize delays or misunderstanding during the review process:"
+msgstr "Pšosym wobkšuśćo slědujuce dypki, nježli až swóje zapódaśe dokóńcyjośo. To miniměrujo wokomuźenja abo njedorozměśa za pséglědowański proces:"
 
-#: static/js/common/upload-addon.js:449 static/js/zamboni/devhub-all.js:714
-#: static/js/zamboni/devhub-min.js:1
+#: static/js/common/upload-addon.js:468 static/js/zamboni/devhub-all.js:714 static/js/zamboni/devhub-min.js:1
 msgid ""
-"Compiled binaries, as well as minified or obfuscated scripts (excluding "
-"known libraries) need to have their sources submitted separately for review."
-" Make sure that you use the source code upload field to avoid having your "
-"submission rejected."
+"Compiled binaries, as well as minified or obfuscated scripts (excluding known libraries) need to have their sources submitted separately for review. Make sure that you use the source code upload "
+"field to avoid having your submission rejected."
 msgstr ""
-"Kompilěrowane binarne dataje ako teke skrótcone abo skazone skripty (mimo "
-"znatych bibliotekow) muse se separatnje za pśeglědowanje zapódaś. Wužywajśo "
-"na kuždy pad pólo za nagrawanje žrědłowego koda, až njeby se wašo zapódaśe "
-"wótpokazało."
+"Kompilěrowane binarne dataje ako teke skrótcone abo skazone skripty (mimo znatych bibliotekow) muse se separatnje za pśeglědowanje zapódaś. Wužywajśo na kuždy pad pólo za nagrawanje žrědłowego "
+"koda, až njeby se wašo zapódaśe wótpokazało."
 
-#: static/js/common/upload-addon.js:467 static/js/zamboni/devhub-all.js:732
-#: static/js/zamboni/devhub-min.js:1
+#: static/js/common/upload-addon.js:486 static/js/zamboni/devhub-all.js:732 static/js/zamboni/devhub-min.js:1
 msgid "The validation process found these issues that can lead to rejections:"
-msgstr ""
-"Pśeglědowański proces jo slědujuce problemy namakał, kótarež bymógli k "
-"wótpokazanjam wjasć:"
+msgstr "Pśeglědowański proces jo slědujuce problemy namakał, kótarež bymógli k wótpokazanjam wjasć:"
 
-#: static/js/common/upload-addon.js:484 static/js/zamboni/devhub-all.js:749
-#: static/js/zamboni/devhub-min.js:1
-msgid ""
-"If you are unfamiliar with the add-ons review process, you can read about it"
-" here."
-msgstr ""
-"Jolic njewuznaśo se z pśeglědowanskim procesom za dodanki, móžośo se how wó "
-"tom informěrowaś."
+#: static/js/common/upload-addon.js:503 static/js/zamboni/devhub-all.js:749 static/js/zamboni/devhub-min.js:1
+msgid "If you are unfamiliar with the add-ons review process, you can read about it here."
+msgstr "Jolic njewuznaśo se z pśeglědowanskim procesom za dodanki, móžośo se how wó tom informěrowaś."
 
-#: static/js/common/upload-addon.js:521 static/js/zamboni/devhub-all.js:786
-#: static/js/zamboni/devhub-min.js:1
+#: static/js/common/upload-addon.js:540 static/js/zamboni/devhub-all.js:786 static/js/zamboni/devhub-min.js:1
 msgid "Sorry, no supported platform has been found."
 msgstr "Bóžko njejo se pódpěrana platforma namakała."
 
-#: static/js/common/upload-base.js:57 static/js/zamboni/devhub-all.js:187
-#: static/js/zamboni/devhub-min.js:1
+#: static/js/common/upload-base.js:57 static/js/zamboni/devhub-all.js:187 static/js/zamboni/devhub-min.js:1
 msgid "The filetype you uploaded isn't recognized."
 msgstr "Datajowy typ, kótaryž sćo nagrał, se njespóznawa."
 
-#: static/js/common/upload-base.js:79 static/js/zamboni/devhub-all.js:209
-#: static/js/zamboni/devhub-min.js:1
+#: static/js/common/upload-base.js:79 static/js/zamboni/devhub-all.js:209 static/js/zamboni/devhub-min.js:1
 msgid "You cancelled the upload."
 msgstr "Sćo nagraśe pśetergnuł."
 
-#: static/js/impala/stats/chart.js:267 static/js/zamboni/stats-all.js:16898
-#: static/js/zamboni/stats-min.js:5
+#: static/js/impala/stats/chart.js:267 static/js/zamboni/stats-all.js:16898 static/js/zamboni/stats-min.js:5
 msgid "Week of {0}"
 msgstr "Tyźeń {0}"
 
-#: static/js/impala/stats/chart.js:269 static/js/zamboni/stats-all.js:16900
-#: static/js/zamboni/stats-min.js:5
+#: static/js/impala/stats/chart.js:269 static/js/zamboni/stats-all.js:16900 static/js/zamboni/stats-min.js:5
 msgid " downloads"
 msgstr " ześěgnjenjow"
 
-#: static/js/impala/stats/chart.js:270 static/js/zamboni/stats-all.js:16901
-#: static/js/zamboni/stats-min.js:5
+#: static/js/impala/stats/chart.js:270 static/js/zamboni/stats-all.js:16901 static/js/zamboni/stats-min.js:5
 msgid "{0} users"
 msgstr "{0} wužywarjow"
 
-#: static/js/impala/stats/chart.js:271 static/js/zamboni/stats-all.js:16902
-#: static/js/zamboni/stats-min.js:5
+#: static/js/impala/stats/chart.js:271 static/js/zamboni/stats-all.js:16902 static/js/zamboni/stats-min.js:5
 msgid "{0} add-ons"
 msgstr "{0} dodankow"
 
-#: static/js/impala/stats/chart.js:272 static/js/zamboni/stats-all.js:16903
-#: static/js/zamboni/stats-min.js:5
+#: static/js/impala/stats/chart.js:272 static/js/zamboni/stats-all.js:16903 static/js/zamboni/stats-min.js:5
 msgid "{0} collections"
 msgstr "{0} zběrkow"
 
-#: static/js/impala/stats/chart.js:273 static/js/zamboni/stats-all.js:16904
-#: static/js/zamboni/stats-min.js:5
+#: static/js/impala/stats/chart.js:273 static/js/zamboni/stats-all.js:16904 static/js/zamboni/stats-min.js:5
 msgid "{0} reviews"
 msgstr "{0} pógódnośénjow"
 
-#: static/js/impala/stats/chart.js:275 static/js/zamboni/stats-all.js:16906
-#: static/js/zamboni/stats-min.js:5
+#: static/js/impala/stats/chart.js:275 static/js/zamboni/stats-all.js:16906 static/js/zamboni/stats-min.js:5
 msgid "{0} sales"
 msgstr "{0} pśedankow"
 
-#: static/js/impala/stats/chart.js:276 static/js/zamboni/stats-all.js:16907
-#: static/js/zamboni/stats-min.js:5
+#: static/js/impala/stats/chart.js:276 static/js/zamboni/stats-all.js:16907 static/js/zamboni/stats-min.js:5
 msgid "{0} refunds"
 msgstr "{0} zarownanjow"
 
-#: static/js/impala/stats/chart.js:277 static/js/zamboni/stats-all.js:16908
-#: static/js/zamboni/stats-min.js:5
+#: static/js/impala/stats/chart.js:277 static/js/zamboni/stats-all.js:16908 static/js/zamboni/stats-min.js:5
 msgid "{0} installs"
 msgstr "{0} instalacijow"
 
-#: static/js/impala/stats/chart.js:369 static/js/impala/stats/csv_keys.js:3
-#: static/js/impala/stats/csv_keys.js:109 static/js/zamboni/stats-all.js:15284
-#: static/js/zamboni/stats-all.js:15390 static/js/zamboni/stats-all.js:17000
-#: static/js/zamboni/stats-min.js:4 static/js/zamboni/stats-min.js:5
+#: static/js/impala/stats/chart.js:369 static/js/impala/stats/csv_keys.js:3 static/js/impala/stats/csv_keys.js:109 static/js/zamboni/stats-all.js:15284 static/js/zamboni/stats-all.js:15390
+#: static/js/zamboni/stats-all.js:17000 static/js/zamboni/stats-min.js:4 static/js/zamboni/stats-min.js:5
 msgid "Downloads"
 msgstr "Ześěgnjenja"
 
-#: static/js/impala/stats/chart.js:379 static/js/impala/stats/csv_keys.js:6
-#: static/js/impala/stats/csv_keys.js:110 static/js/zamboni/stats-all.js:15287
-#: static/js/zamboni/stats-all.js:15391 static/js/zamboni/stats-all.js:17010
-#: static/js/zamboni/stats-min.js:4 static/js/zamboni/stats-min.js:5
+#: static/js/impala/stats/chart.js:379 static/js/impala/stats/csv_keys.js:6 static/js/impala/stats/csv_keys.js:110 static/js/zamboni/stats-all.js:15287 static/js/zamboni/stats-all.js:15391
+#: static/js/zamboni/stats-all.js:17010 static/js/zamboni/stats-min.js:4 static/js/zamboni/stats-min.js:5
 msgid "Daily Users"
 msgstr "Wšedne wužywarje"
 
-#: static/js/impala/stats/chart.js:410 static/js/zamboni/stats-all.js:17041
-#: static/js/zamboni/stats-min.js:5
+#: static/js/impala/stats/chart.js:410 static/js/zamboni/stats-all.js:17041 static/js/zamboni/stats-min.js:5
 msgid "Amount, in USD"
 msgstr "Suma, w USD"
 
-#: static/js/impala/stats/chart.js:421 static/js/impala/stats/csv_keys.js:104
-#: static/js/zamboni/stats-all.js:15385 static/js/zamboni/stats-all.js:17052
-#: static/js/zamboni/stats-min.js:5
+#: static/js/impala/stats/chart.js:421 static/js/impala/stats/csv_keys.js:104 static/js/zamboni/stats-all.js:15385 static/js/zamboni/stats-all.js:17052 static/js/zamboni/stats-min.js:5
 msgid "Number of Contributions"
 msgstr "Licba pśinoskow"
 
-#: static/js/impala/stats/chart.js:447 static/js/zamboni/stats-all.js:17078
-#: static/js/zamboni/stats-min.js:5
+#: static/js/impala/stats/chart.js:447 static/js/zamboni/stats-all.js:17078 static/js/zamboni/stats-min.js:5
 msgid "More Info..."
 msgstr "Dalšne informacije..."
 
 #. L10n: {0} is an ISO-formatted date.
-#: static/js/impala/stats/chart.js:451 static/js/zamboni/stats-all.js:17082
-#: static/js/zamboni/stats-min.js:5
+#: static/js/impala/stats/chart.js:451 static/js/zamboni/stats-all.js:17082 static/js/zamboni/stats-min.js:5
 msgid "Details for {0}"
 msgstr "Drobnostki za {0}"
 
-#: static/js/impala/stats/csv_keys.js:9 static/js/zamboni/stats-all.js:15290
-#: static/js/zamboni/stats-min.js:4
+#: static/js/impala/stats/csv_keys.js:9 static/js/zamboni/stats-all.js:15290 static/js/zamboni/stats-min.js:4
 msgid "Collections Created"
 msgstr "Napórane zběrki"
 
-#: static/js/impala/stats/csv_keys.js:12 static/js/zamboni/stats-all.js:15293
-#: static/js/zamboni/stats-min.js:4
+#: static/js/impala/stats/csv_keys.js:12 static/js/zamboni/stats-all.js:15293 static/js/zamboni/stats-min.js:4
 msgid "Add-ons in Use"
 msgstr "Wužywane dodanki"
 
-#: static/js/impala/stats/csv_keys.js:15 static/js/zamboni/stats-all.js:15296
-#: static/js/zamboni/stats-min.js:4
+#: static/js/impala/stats/csv_keys.js:15 static/js/zamboni/stats-all.js:15296 static/js/zamboni/stats-min.js:4
 msgid "Add-ons Created"
 msgstr "Napórane dodanki"
 
-#: static/js/impala/stats/csv_keys.js:18 static/js/zamboni/stats-all.js:15299
-#: static/js/zamboni/stats-min.js:4
+#: static/js/impala/stats/csv_keys.js:18 static/js/zamboni/stats-all.js:15299 static/js/zamboni/stats-min.js:4
 msgid "Add-ons Downloaded"
 msgstr "Ześěgnjone dodanki"
 
-#: static/js/impala/stats/csv_keys.js:21 static/js/zamboni/stats-all.js:15302
-#: static/js/zamboni/stats-min.js:4
+#: static/js/impala/stats/csv_keys.js:21 static/js/zamboni/stats-all.js:15302 static/js/zamboni/stats-min.js:4
 msgid "Add-ons Updated"
 msgstr "Zaktualizěrowane dodanki"
 
-#: static/js/impala/stats/csv_keys.js:24 static/js/zamboni/stats-all.js:15305
-#: static/js/zamboni/stats-min.js:4
+#: static/js/impala/stats/csv_keys.js:24 static/js/zamboni/stats-all.js:15305 static/js/zamboni/stats-min.js:4
 msgid "Reviews Written"
 msgstr "Napisane pógódnośenja"
 
-#: static/js/impala/stats/csv_keys.js:27 static/js/zamboni/stats-all.js:15308
-#: static/js/zamboni/stats-min.js:4
+#: static/js/impala/stats/csv_keys.js:27 static/js/zamboni/stats-all.js:15308 static/js/zamboni/stats-min.js:4
 msgid "User Signups"
 msgstr "Wužywarske registrěrowanja"
 
-#: static/js/impala/stats/csv_keys.js:30 static/js/zamboni/stats-all.js:15311
-#: static/js/zamboni/stats-min.js:4
+#: static/js/impala/stats/csv_keys.js:30 static/js/zamboni/stats-all.js:15311 static/js/zamboni/stats-min.js:4
 msgid "Subscribers"
 msgstr "Abonenty"
 
-#: static/js/impala/stats/csv_keys.js:33 static/js/zamboni/stats-all.js:15314
-#: static/js/zamboni/stats-min.js:4
+#: static/js/impala/stats/csv_keys.js:33 static/js/zamboni/stats-all.js:15314 static/js/zamboni/stats-min.js:4
 msgid "Ratings"
 msgstr "Pógódnośenja"
 
-#: static/js/impala/stats/csv_keys.js:36
-#: static/js/impala/stats/csv_keys.js:114 static/js/zamboni/stats-all.js:15317
-#: static/js/zamboni/stats-all.js:15395 static/js/zamboni/stats-min.js:4
+#: static/js/impala/stats/csv_keys.js:36 static/js/impala/stats/csv_keys.js:114 static/js/zamboni/stats-all.js:15317 static/js/zamboni/stats-all.js:15395 static/js/zamboni/stats-min.js:4
 #: static/js/zamboni/stats-min.js:5
 msgid "Sales"
 msgstr "Pśedanki"
 
-#: static/js/impala/stats/csv_keys.js:39
-#: static/js/impala/stats/csv_keys.js:113 static/js/zamboni/stats-all.js:15320
-#: static/js/zamboni/stats-all.js:15394 static/js/zamboni/stats-min.js:4
+#: static/js/impala/stats/csv_keys.js:39 static/js/impala/stats/csv_keys.js:113 static/js/zamboni/stats-all.js:15320 static/js/zamboni/stats-all.js:15394 static/js/zamboni/stats-min.js:4
 #: static/js/zamboni/stats-min.js:5
 msgid "Installs"
 msgstr "Instalacije"
 
-#: static/js/impala/stats/csv_keys.js:42 static/js/zamboni/stats-all.js:15323
-#: static/js/zamboni/stats-min.js:4
+#: static/js/impala/stats/csv_keys.js:42 static/js/zamboni/stats-all.js:15323 static/js/zamboni/stats-min.js:4
 msgid "Unknown"
 msgstr "Njeznate"
 
-#: static/js/impala/stats/csv_keys.js:43 static/js/zamboni/stats-all.js:15324
-#: static/js/zamboni/stats-min.js:4
+#: static/js/impala/stats/csv_keys.js:43 static/js/zamboni/stats-all.js:15324 static/js/zamboni/stats-min.js:4
 msgid "Add-ons Manager"
 msgstr "Zastojnik dodankow"
 
-#: static/js/impala/stats/csv_keys.js:44 static/js/zamboni/stats-all.js:15325
-#: static/js/zamboni/stats-min.js:4
+#: static/js/impala/stats/csv_keys.js:44 static/js/zamboni/stats-all.js:15325 static/js/zamboni/stats-min.js:4
 msgid "Add-ons Manager Promo"
 msgstr "Zastojnik dodankow „Promo“"
 
-#: static/js/impala/stats/csv_keys.js:45 static/js/zamboni/stats-all.js:15326
-#: static/js/zamboni/stats-min.js:4
+#: static/js/impala/stats/csv_keys.js:45 static/js/zamboni/stats-all.js:15326 static/js/zamboni/stats-min.js:4
 msgid "Add-ons Manager Featured"
 msgstr "W zastojniku dodankow pśedstajone"
 
-#: static/js/impala/stats/csv_keys.js:46 static/js/zamboni/stats-all.js:15327
-#: static/js/zamboni/stats-min.js:4
+#: static/js/impala/stats/csv_keys.js:46 static/js/zamboni/stats-all.js:15327 static/js/zamboni/stats-min.js:4
 msgid "Add-ons Manager Learn More"
 msgstr "Zastojnik dodankow „Dalšne informacije“"
 
-#: static/js/impala/stats/csv_keys.js:47 static/js/zamboni/stats-all.js:15328
-#: static/js/zamboni/stats-min.js:4
+#: static/js/impala/stats/csv_keys.js:47 static/js/zamboni/stats-all.js:15328 static/js/zamboni/stats-min.js:4
 msgid "Search Suggestions"
 msgstr "Pytańske naraźenja"
 
-#: static/js/impala/stats/csv_keys.js:48 static/js/zamboni/stats-all.js:15329
-#: static/js/zamboni/stats-min.js:4
+#: static/js/impala/stats/csv_keys.js:48 static/js/zamboni/stats-all.js:15329 static/js/zamboni/stats-min.js:4
 msgid "Search Results"
 msgstr "Pytańske wuslědki"
 
-#: static/js/impala/stats/csv_keys.js:49 static/js/impala/stats/csv_keys.js:50
-#: static/js/impala/stats/csv_keys.js:51 static/js/zamboni/stats-all.js:15330
-#: static/js/zamboni/stats-all.js:15331 static/js/zamboni/stats-all.js:15332
-#: static/js/zamboni/stats-min.js:4
+#: static/js/impala/stats/csv_keys.js:49 static/js/impala/stats/csv_keys.js:50 static/js/impala/stats/csv_keys.js:51 static/js/zamboni/stats-all.js:15330 static/js/zamboni/stats-all.js:15331
+#: static/js/zamboni/stats-all.js:15332 static/js/zamboni/stats-min.js:4
 msgid "Homepage Promo"
 msgstr "Startowy bok „Promo“"
 
-#: static/js/impala/stats/csv_keys.js:52 static/js/impala/stats/csv_keys.js:53
-#: static/js/zamboni/stats-all.js:15333 static/js/zamboni/stats-all.js:15334
-#: static/js/zamboni/stats-min.js:4
+#: static/js/impala/stats/csv_keys.js:52 static/js/impala/stats/csv_keys.js:53 static/js/zamboni/stats-all.js:15333 static/js/zamboni/stats-all.js:15334 static/js/zamboni/stats-min.js:4
 msgid "Homepage Featured"
 msgstr "Startowy bok „Pśedstajone“"
 
-#: static/js/impala/stats/csv_keys.js:54 static/js/impala/stats/csv_keys.js:55
-#: static/js/zamboni/stats-all.js:15335 static/js/zamboni/stats-all.js:15336
-#: static/js/zamboni/stats-min.js:4
+#: static/js/impala/stats/csv_keys.js:54 static/js/impala/stats/csv_keys.js:55 static/js/zamboni/stats-all.js:15335 static/js/zamboni/stats-all.js:15336 static/js/zamboni/stats-min.js:4
 msgid "Homepage Up and Coming"
 msgstr "Startowy bok „Rozmógujuce“"
 
-#: static/js/impala/stats/csv_keys.js:56 static/js/zamboni/stats-all.js:15337
-#: static/js/zamboni/stats-min.js:4
+#: static/js/impala/stats/csv_keys.js:56 static/js/zamboni/stats-all.js:15337 static/js/zamboni/stats-min.js:4
 msgid "Homepage Most Popular"
 msgstr "Startowy bok „Nejwěcej woblubowane“"
 
-#: static/js/impala/stats/csv_keys.js:57 static/js/impala/stats/csv_keys.js:59
-#: static/js/zamboni/stats-all.js:15338 static/js/zamboni/stats-all.js:15340
-#: static/js/zamboni/stats-min.js:4
+#: static/js/impala/stats/csv_keys.js:57 static/js/impala/stats/csv_keys.js:59 static/js/zamboni/stats-all.js:15338 static/js/zamboni/stats-all.js:15340 static/js/zamboni/stats-min.js:4
 msgid "Detail Page"
 msgstr "Bok drobnostkow"
 
-#: static/js/impala/stats/csv_keys.js:58 static/js/impala/stats/csv_keys.js:60
-#: static/js/zamboni/stats-all.js:15339 static/js/zamboni/stats-all.js:15341
-#: static/js/zamboni/stats-min.js:4
+#: static/js/impala/stats/csv_keys.js:58 static/js/impala/stats/csv_keys.js:60 static/js/zamboni/stats-all.js:15339 static/js/zamboni/stats-all.js:15341 static/js/zamboni/stats-min.js:4
 msgid "Detail Page (bottom)"
 msgstr "Bok drobnostkow (dołojce)"
 
-#: static/js/impala/stats/csv_keys.js:61 static/js/zamboni/stats-all.js:15342
-#: static/js/zamboni/stats-min.js:4
+#: static/js/impala/stats/csv_keys.js:61 static/js/zamboni/stats-all.js:15342 static/js/zamboni/stats-min.js:4
 msgid "Detail Page (Development Channel)"
 msgstr "Bok drobnostkow (wuwijarski kanal)"
 
-#: static/js/impala/stats/csv_keys.js:62 static/js/impala/stats/csv_keys.js:63
-#: static/js/impala/stats/csv_keys.js:64 static/js/zamboni/stats-all.js:15343
-#: static/js/zamboni/stats-all.js:15344 static/js/zamboni/stats-all.js:15345
-#: static/js/zamboni/stats-min.js:4
+#: static/js/impala/stats/csv_keys.js:62 static/js/impala/stats/csv_keys.js:63 static/js/impala/stats/csv_keys.js:64 static/js/zamboni/stats-all.js:15343 static/js/zamboni/stats-all.js:15344
+#: static/js/zamboni/stats-all.js:15345 static/js/zamboni/stats-min.js:4
 msgid "Often Used With"
 msgstr "Cesto wužywany z"
 
-#: static/js/impala/stats/csv_keys.js:65 static/js/impala/stats/csv_keys.js:66
-#: static/js/zamboni/stats-all.js:15346 static/js/zamboni/stats-all.js:15347
-#: static/js/zamboni/stats-min.js:4
+#: static/js/impala/stats/csv_keys.js:65 static/js/impala/stats/csv_keys.js:66 static/js/zamboni/stats-all.js:15346 static/js/zamboni/stats-all.js:15347 static/js/zamboni/stats-min.js:4
 msgid "Others By Author"
 msgstr "Druge pó awtorje"
 
-#: static/js/impala/stats/csv_keys.js:67 static/js/impala/stats/csv_keys.js:68
-#: static/js/zamboni/stats-all.js:15348 static/js/zamboni/stats-all.js:15349
-#: static/js/zamboni/stats-min.js:4
+#: static/js/impala/stats/csv_keys.js:67 static/js/impala/stats/csv_keys.js:68 static/js/zamboni/stats-all.js:15348 static/js/zamboni/stats-all.js:15349 static/js/zamboni/stats-min.js:4
 msgid "Dependencies"
 msgstr "Wótwisnosći"
 
-#: static/js/impala/stats/csv_keys.js:69 static/js/impala/stats/csv_keys.js:70
-#: static/js/zamboni/stats-all.js:15350 static/js/zamboni/stats-all.js:15351
-#: static/js/zamboni/stats-min.js:4
+#: static/js/impala/stats/csv_keys.js:69 static/js/impala/stats/csv_keys.js:70 static/js/zamboni/stats-all.js:15350 static/js/zamboni/stats-all.js:15351 static/js/zamboni/stats-min.js:4
 msgid "Upsell"
 msgstr "Pśidatne pśedanki"
 
-#: static/js/impala/stats/csv_keys.js:71 static/js/zamboni/stats-all.js:15352
-#: static/js/zamboni/stats-min.js:4
+#: static/js/impala/stats/csv_keys.js:71 static/js/zamboni/stats-all.js:15352 static/js/zamboni/stats-min.js:4
 msgid "Meet the Developer"
 msgstr "Póznajśo wuwijarja"
 
-#: static/js/impala/stats/csv_keys.js:72 static/js/zamboni/stats-all.js:15353
-#: static/js/zamboni/stats-min.js:4
+#: static/js/impala/stats/csv_keys.js:72 static/js/zamboni/stats-all.js:15353 static/js/zamboni/stats-min.js:4
 msgid "User Profile"
 msgstr "Wužywarski profil"
 
-#: static/js/impala/stats/csv_keys.js:73 static/js/zamboni/stats-all.js:15354
-#: static/js/zamboni/stats-min.js:4
+#: static/js/impala/stats/csv_keys.js:73 static/js/zamboni/stats-all.js:15354 static/js/zamboni/stats-min.js:4
 msgid "Version History"
 msgstr "Wersijowa historija"
 
-#: static/js/impala/stats/csv_keys.js:75 static/js/zamboni/stats-all.js:15356
-#: static/js/zamboni/stats-min.js:4
+#: static/js/impala/stats/csv_keys.js:75 static/js/zamboni/stats-all.js:15356 static/js/zamboni/stats-min.js:4
 msgid "Sharing"
 msgstr "Źěliś"
 
-#: static/js/impala/stats/csv_keys.js:76 static/js/zamboni/stats-all.js:15357
-#: static/js/zamboni/stats-min.js:4
+#: static/js/impala/stats/csv_keys.js:76 static/js/zamboni/stats-all.js:15357 static/js/zamboni/stats-min.js:4
 msgid "Category Pages"
 msgstr "Kategorijowe boki"
 
-#: static/js/impala/stats/csv_keys.js:77 static/js/zamboni/stats-all.js:15358
-#: static/js/zamboni/stats-min.js:4
+#: static/js/impala/stats/csv_keys.js:77 static/js/zamboni/stats-all.js:15358 static/js/zamboni/stats-min.js:4
 msgid "Collections"
 msgstr "Zběrki"
 
-#: static/js/impala/stats/csv_keys.js:78 static/js/impala/stats/csv_keys.js:79
-#: static/js/zamboni/stats-all.js:15359 static/js/zamboni/stats-all.js:15360
-#: static/js/zamboni/stats-min.js:4
+#: static/js/impala/stats/csv_keys.js:78 static/js/impala/stats/csv_keys.js:79 static/js/zamboni/stats-all.js:15359 static/js/zamboni/stats-all.js:15360 static/js/zamboni/stats-min.js:4
 msgid "Category Landing Featured Carousel"
 msgstr "Kategorijowy pśeglěd „Karusel pśedstajonych“"
 
-#: static/js/impala/stats/csv_keys.js:80 static/js/impala/stats/csv_keys.js:81
-#: static/js/zamboni/stats-all.js:15361 static/js/zamboni/stats-all.js:15362
-#: static/js/zamboni/stats-min.js:4
+#: static/js/impala/stats/csv_keys.js:80 static/js/impala/stats/csv_keys.js:81 static/js/zamboni/stats-all.js:15361 static/js/zamboni/stats-all.js:15362 static/js/zamboni/stats-min.js:4
 msgid "Category Landing Top Rated"
 msgstr "Kategorijowy pśeglěd „Nejwuše pógódnośenje“"
 
-#: static/js/impala/stats/csv_keys.js:82 static/js/impala/stats/csv_keys.js:83
-#: static/js/zamboni/stats-all.js:15363 static/js/zamboni/stats-all.js:15364
-#: static/js/zamboni/stats-min.js:5
+#: static/js/impala/stats/csv_keys.js:82 static/js/impala/stats/csv_keys.js:83 static/js/zamboni/stats-all.js:15363 static/js/zamboni/stats-all.js:15364 static/js/zamboni/stats-min.js:5
 msgid "Category Landing Most Popular"
 msgstr "Kategorjowy pśeglěd „Nejwěcej woblubowane“"
 
-#: static/js/impala/stats/csv_keys.js:84 static/js/impala/stats/csv_keys.js:85
-#: static/js/zamboni/stats-all.js:15365 static/js/zamboni/stats-all.js:15366
-#: static/js/zamboni/stats-min.js:5
+#: static/js/impala/stats/csv_keys.js:84 static/js/impala/stats/csv_keys.js:85 static/js/zamboni/stats-all.js:15365 static/js/zamboni/stats-all.js:15366 static/js/zamboni/stats-min.js:5
 msgid "Category Landing Recently Added"
 msgstr "Kategorijowy pśeglěd „Njedawno pśidane“"
 
-#: static/js/impala/stats/csv_keys.js:86 static/js/impala/stats/csv_keys.js:87
-#: static/js/zamboni/stats-all.js:15367 static/js/zamboni/stats-all.js:15368
-#: static/js/zamboni/stats-min.js:5
+#: static/js/impala/stats/csv_keys.js:86 static/js/impala/stats/csv_keys.js:87 static/js/zamboni/stats-all.js:15367 static/js/zamboni/stats-all.js:15368 static/js/zamboni/stats-min.js:5
 msgid "Browse Listing Featured Sort"
 msgstr "Lisćinu pśepytowaś „Sortěrowane pó pśedstajonych“"
 
-#: static/js/impala/stats/csv_keys.js:88 static/js/impala/stats/csv_keys.js:89
-#: static/js/zamboni/stats-all.js:15369 static/js/zamboni/stats-all.js:15370
-#: static/js/zamboni/stats-min.js:5
+#: static/js/impala/stats/csv_keys.js:88 static/js/impala/stats/csv_keys.js:89 static/js/zamboni/stats-all.js:15369 static/js/zamboni/stats-all.js:15370 static/js/zamboni/stats-min.js:5
 msgid "Browse Listing Users Sort"
 msgstr "Lisćinu pśepytowaś „Sortěrowane pó wužywarjach“"
 
-#: static/js/impala/stats/csv_keys.js:90 static/js/impala/stats/csv_keys.js:91
-#: static/js/zamboni/stats-all.js:15371 static/js/zamboni/stats-all.js:15372
-#: static/js/zamboni/stats-min.js:5
+#: static/js/impala/stats/csv_keys.js:90 static/js/impala/stats/csv_keys.js:91 static/js/zamboni/stats-all.js:15371 static/js/zamboni/stats-all.js:15372 static/js/zamboni/stats-min.js:5
 msgid "Browse Listing Rating Sort"
 msgstr "Lisćinu pśepytowaś „Sortěrowane pó pógódnośenju“"
 
-#: static/js/impala/stats/csv_keys.js:92 static/js/impala/stats/csv_keys.js:93
-#: static/js/zamboni/stats-all.js:15373 static/js/zamboni/stats-all.js:15374
-#: static/js/zamboni/stats-min.js:5
+#: static/js/impala/stats/csv_keys.js:92 static/js/impala/stats/csv_keys.js:93 static/js/zamboni/stats-all.js:15373 static/js/zamboni/stats-all.js:15374 static/js/zamboni/stats-min.js:5
 msgid "Browse Listing Created Sort"
 msgstr "Lisćinu pśepytowaś „Sortěrowane pó napóranju“"
 
-#: static/js/impala/stats/csv_keys.js:94 static/js/impala/stats/csv_keys.js:95
-#: static/js/zamboni/stats-all.js:15375 static/js/zamboni/stats-all.js:15376
-#: static/js/zamboni/stats-min.js:5
+#: static/js/impala/stats/csv_keys.js:94 static/js/impala/stats/csv_keys.js:95 static/js/zamboni/stats-all.js:15375 static/js/zamboni/stats-all.js:15376 static/js/zamboni/stats-min.js:5
 msgid "Browse Listing Name Sort"
 msgstr "Lisćinu pśepytowaś „Sortěrowane pó mjenju“"
 
-#: static/js/impala/stats/csv_keys.js:96 static/js/impala/stats/csv_keys.js:97
-#: static/js/zamboni/stats-all.js:15377 static/js/zamboni/stats-all.js:15378
-#: static/js/zamboni/stats-min.js:5
+#: static/js/impala/stats/csv_keys.js:96 static/js/impala/stats/csv_keys.js:97 static/js/zamboni/stats-all.js:15377 static/js/zamboni/stats-all.js:15378 static/js/zamboni/stats-min.js:5
 msgid "Browse Listing Popular Sort"
 msgstr "Lisćinu pśepytowaś „Sortěrowane pó woblubowanych“"
 
-#: static/js/impala/stats/csv_keys.js:98 static/js/impala/stats/csv_keys.js:99
-#: static/js/zamboni/stats-all.js:15379 static/js/zamboni/stats-all.js:15380
-#: static/js/zamboni/stats-min.js:5
+#: static/js/impala/stats/csv_keys.js:98 static/js/impala/stats/csv_keys.js:99 static/js/zamboni/stats-all.js:15379 static/js/zamboni/stats-all.js:15380 static/js/zamboni/stats-min.js:5
 msgid "Browse Listing Updated Sort"
 msgstr "Lisćinu pśepytowaś „Sortěrowane pó zaktualizěrowanych“"
 
-#: static/js/impala/stats/csv_keys.js:100
-#: static/js/impala/stats/csv_keys.js:101 static/js/zamboni/stats-all.js:15381
-#: static/js/zamboni/stats-all.js:15382 static/js/zamboni/stats-min.js:5
+#: static/js/impala/stats/csv_keys.js:100 static/js/impala/stats/csv_keys.js:101 static/js/zamboni/stats-all.js:15381 static/js/zamboni/stats-all.js:15382 static/js/zamboni/stats-min.js:5
 msgid "Browse Listing Up and Coming Sort"
 msgstr "Lisćinu pśepytowaś „Sortěrowane pó rozmógujucych“"
 
-#: static/js/impala/stats/csv_keys.js:105 static/js/zamboni/stats-all.js:15386
-#: static/js/zamboni/stats-min.js:5
+#: static/js/impala/stats/csv_keys.js:105 static/js/zamboni/stats-all.js:15386 static/js/zamboni/stats-min.js:5
 msgid "Total Amount Contributed"
 msgstr "Pósćona suma dogromady"
 
-#: static/js/impala/stats/csv_keys.js:106 static/js/zamboni/stats-all.js:15387
-#: static/js/zamboni/stats-min.js:5
+#: static/js/impala/stats/csv_keys.js:106 static/js/zamboni/stats-all.js:15387 static/js/zamboni/stats-min.js:5
 msgid "Average Contribution"
 msgstr "Pśerěznje pósćona suma"
 
-#: static/js/impala/stats/csv_keys.js:115 static/js/zamboni/stats-all.js:15396
-#: static/js/zamboni/stats-min.js:5
+#: static/js/impala/stats/csv_keys.js:115 static/js/zamboni/stats-all.js:15396 static/js/zamboni/stats-min.js:5
 msgid "Usage"
 msgstr "Wužywanje"
 
-#: static/js/impala/stats/csv_keys.js:118 static/js/zamboni/stats-all.js:15399
-#: static/js/zamboni/stats-min.js:5
+#: static/js/impala/stats/csv_keys.js:118 static/js/zamboni/stats-all.js:15399 static/js/zamboni/stats-min.js:5
 msgid "Firefox"
 msgstr "Firefox"
 
-#: static/js/impala/stats/csv_keys.js:119 static/js/zamboni/stats-all.js:15400
-#: static/js/zamboni/stats-min.js:5
+#: static/js/impala/stats/csv_keys.js:119 static/js/zamboni/stats-all.js:15400 static/js/zamboni/stats-min.js:5
 msgid "Mozilla"
 msgstr "Mozilla"
 
-#: static/js/impala/stats/csv_keys.js:120 static/js/zamboni/stats-all.js:15401
-#: static/js/zamboni/stats-min.js:5
+#: static/js/impala/stats/csv_keys.js:120 static/js/zamboni/stats-all.js:15401 static/js/zamboni/stats-min.js:5
 msgid "Thunderbird"
 msgstr "Thunderbird"
 
-#: static/js/impala/stats/csv_keys.js:121 static/js/zamboni/stats-all.js:15402
-#: static/js/zamboni/stats-min.js:5
+#: static/js/impala/stats/csv_keys.js:121 static/js/zamboni/stats-all.js:15402 static/js/zamboni/stats-min.js:5
 msgid "Sunbird"
 msgstr "Sunbird"
 
-#: static/js/impala/stats/csv_keys.js:122 static/js/zamboni/stats-all.js:15403
-#: static/js/zamboni/stats-min.js:5
+#: static/js/impala/stats/csv_keys.js:122 static/js/zamboni/stats-all.js:15403 static/js/zamboni/stats-min.js:5
 msgid "SeaMonkey"
 msgstr "SeaMonkey"
 
-#: static/js/impala/stats/csv_keys.js:123 static/js/zamboni/stats-all.js:15404
-#: static/js/zamboni/stats-min.js:5
+#: static/js/impala/stats/csv_keys.js:123 static/js/zamboni/stats-all.js:15404 static/js/zamboni/stats-min.js:5
 msgid "Fennec"
 msgstr "Fennec"
 
-#: static/js/impala/stats/csv_keys.js:124 static/js/zamboni/stats-all.js:15405
-#: static/js/zamboni/stats-min.js:5
+#: static/js/impala/stats/csv_keys.js:124 static/js/zamboni/stats-all.js:15405 static/js/zamboni/stats-min.js:5
 msgid "Android"
 msgstr "Android"
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:129 static/js/zamboni/stats-all.js:15410
-#: static/js/zamboni/stats-min.js:5
+#: static/js/impala/stats/csv_keys.js:129 static/js/zamboni/stats-all.js:15410 static/js/zamboni/stats-min.js:5
 msgid "Downloads and Daily Users, last {0} days"
 msgstr "Ześěgnjenja a wšedne wužywarje, zachadne {0} dnjow"
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:131 static/js/zamboni/stats-all.js:15412
-#: static/js/zamboni/stats-min.js:5
+#: static/js/impala/stats/csv_keys.js:131 static/js/zamboni/stats-all.js:15412 static/js/zamboni/stats-min.js:5
 msgid "Downloads and Daily Users from {0} to {1}"
 msgstr "Ześěgnjenja a wšedne wužywarje wót {0} až do {1}"
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:135 static/js/zamboni/stats-all.js:15416
-#: static/js/zamboni/stats-min.js:5
+#: static/js/impala/stats/csv_keys.js:135 static/js/zamboni/stats-all.js:15416 static/js/zamboni/stats-min.js:5
 msgid "Installs and Daily Users, last {0} days"
 msgstr "Instalacije a wšedne wužywarje, zachadne {0} dnjow"
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:137 static/js/zamboni/stats-all.js:15418
-#: static/js/zamboni/stats-min.js:5
+#: static/js/impala/stats/csv_keys.js:137 static/js/zamboni/stats-all.js:15418 static/js/zamboni/stats-min.js:5
 msgid "Installs and Daily Users from {0} to {1}"
 msgstr "Instalacije a wšedne wužywarje wót {0} až do {1}"
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:141 static/js/zamboni/stats-all.js:15422
-#: static/js/zamboni/stats-min.js:5
+#: static/js/impala/stats/csv_keys.js:141 static/js/zamboni/stats-all.js:15422 static/js/zamboni/stats-min.js:5
 msgid "Downloads, last {0} days"
 msgstr "Ześěgnjenja, zachadne {0} dnjow"
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:143 static/js/zamboni/stats-all.js:15424
-#: static/js/zamboni/stats-min.js:5
+#: static/js/impala/stats/csv_keys.js:143 static/js/zamboni/stats-all.js:15424 static/js/zamboni/stats-min.js:5
 msgid "Downloads from {0} to {1}"
 msgstr "Ześěgnjenja wót {0} až do {1}"
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:147 static/js/zamboni/stats-all.js:15428
-#: static/js/zamboni/stats-min.js:5
+#: static/js/impala/stats/csv_keys.js:147 static/js/zamboni/stats-all.js:15428 static/js/zamboni/stats-min.js:5
 msgid "Daily Users, last {0} days"
 msgstr "Wšedne wužywarje, zachadne {0} dnjow"
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:149 static/js/zamboni/stats-all.js:15430
-#: static/js/zamboni/stats-min.js:5
+#: static/js/impala/stats/csv_keys.js:149 static/js/zamboni/stats-all.js:15430 static/js/zamboni/stats-min.js:5
 msgid "Daily Users from {0} to {1}"
 msgstr "Wšedne wužywarje wót {0} až do {1}"
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:153 static/js/zamboni/stats-all.js:15434
-#: static/js/zamboni/stats-min.js:5
+#: static/js/impala/stats/csv_keys.js:153 static/js/zamboni/stats-all.js:15434 static/js/zamboni/stats-min.js:5
 msgid "Applications, last {0} days"
 msgstr "Nałoženja, zachadne {0} dnjow"
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:155 static/js/zamboni/stats-all.js:15436
-#: static/js/zamboni/stats-min.js:5
+#: static/js/impala/stats/csv_keys.js:155 static/js/zamboni/stats-all.js:15436 static/js/zamboni/stats-min.js:5
 msgid "Applications from {0} to {1}"
 msgstr "Nałoženja wót {0} až do {1}"
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:159 static/js/zamboni/stats-all.js:15440
-#: static/js/zamboni/stats-min.js:5
+#: static/js/impala/stats/csv_keys.js:159 static/js/zamboni/stats-all.js:15440 static/js/zamboni/stats-min.js:5
 msgid "Platforms, last {0} days"
 msgstr "Platformy, zachadne {0} dnjow"
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:161 static/js/zamboni/stats-all.js:15442
-#: static/js/zamboni/stats-min.js:5
+#: static/js/impala/stats/csv_keys.js:161 static/js/zamboni/stats-all.js:15442 static/js/zamboni/stats-min.js:5
 msgid "Platforms from {0} to {1}"
 msgstr "Platformy wót {0} až do {1}"
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:165 static/js/zamboni/stats-all.js:15446
-#: static/js/zamboni/stats-min.js:5
+#: static/js/impala/stats/csv_keys.js:165 static/js/zamboni/stats-all.js:15446 static/js/zamboni/stats-min.js:5
 msgid "Languages, last {0} days"
 msgstr "Rěcy, zachadne {0} dnjow"
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:167 static/js/zamboni/stats-all.js:15448
-#: static/js/zamboni/stats-min.js:5
+#: static/js/impala/stats/csv_keys.js:167 static/js/zamboni/stats-all.js:15448 static/js/zamboni/stats-min.js:5
 msgid "Languages from {0} to {1}"
 msgstr "Rěcy wót {0} až do {1}"
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:171 static/js/zamboni/stats-all.js:15452
-#: static/js/zamboni/stats-min.js:5
+#: static/js/impala/stats/csv_keys.js:171 static/js/zamboni/stats-all.js:15452 static/js/zamboni/stats-min.js:5
 msgid "Add-on Versions, last {0} days"
 msgstr "Dodankowe wersije, zachadne {0} dnjow"
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:173 static/js/zamboni/stats-all.js:15454
-#: static/js/zamboni/stats-min.js:5
+#: static/js/impala/stats/csv_keys.js:173 static/js/zamboni/stats-all.js:15454 static/js/zamboni/stats-min.js:5
 msgid "Add-on Versions from {0} to {1}"
 msgstr "Dodankowe wersije wót {0} až do {1}"
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:177 static/js/zamboni/stats-all.js:15458
-#: static/js/zamboni/stats-min.js:5
+#: static/js/impala/stats/csv_keys.js:177 static/js/zamboni/stats-all.js:15458 static/js/zamboni/stats-min.js:5
 msgid "Add-on Status, last {0} days"
 msgstr "Dodankowy status, zachadne {0} dnjow"
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:179 static/js/zamboni/stats-all.js:15460
-#: static/js/zamboni/stats-min.js:5
+#: static/js/impala/stats/csv_keys.js:179 static/js/zamboni/stats-all.js:15460 static/js/zamboni/stats-min.js:5
 msgid "Add-on Status from {0} to {1}"
 msgstr "Dodankowy status wót {0} až do {1}"
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:183 static/js/zamboni/stats-all.js:15464
-#: static/js/zamboni/stats-min.js:5
+#: static/js/impala/stats/csv_keys.js:183 static/js/zamboni/stats-all.js:15464 static/js/zamboni/stats-min.js:5
 msgid "Download Sources, last {0} days"
 msgstr "Ześěgnjeńske žrědła, zachadne {0} dnjow"
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:185 static/js/zamboni/stats-all.js:15466
-#: static/js/zamboni/stats-min.js:5
+#: static/js/impala/stats/csv_keys.js:185 static/js/zamboni/stats-all.js:15466 static/js/zamboni/stats-min.js:5
 msgid "Download Sources from {0} to {1}"
 msgstr "Ześěgnjeńske žrědła wót {0} až do {1}"
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:189 static/js/zamboni/stats-all.js:15470
-#: static/js/zamboni/stats-min.js:5
+#: static/js/impala/stats/csv_keys.js:189 static/js/zamboni/stats-all.js:15470 static/js/zamboni/stats-min.js:5
 msgid "Contributions, last {0} days"
 msgstr "Pśinoski, zachadne {0} dnjow"
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:191 static/js/zamboni/stats-all.js:15472
-#: static/js/zamboni/stats-min.js:5
+#: static/js/impala/stats/csv_keys.js:191 static/js/zamboni/stats-all.js:15472 static/js/zamboni/stats-min.js:5
 msgid "Contributions from {0} to {1}"
 msgstr "Pśinoski wót {0} až do {1}"
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:195 static/js/zamboni/stats-all.js:15476
-#: static/js/zamboni/stats-min.js:5
+#: static/js/impala/stats/csv_keys.js:195 static/js/zamboni/stats-all.js:15476 static/js/zamboni/stats-min.js:5
 msgid "Site Metrics, last {0} days"
 msgstr "Sedłowa statistika, zachadne {0} dnjow"
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:197 static/js/zamboni/stats-all.js:15478
-#: static/js/zamboni/stats-min.js:5
+#: static/js/impala/stats/csv_keys.js:197 static/js/zamboni/stats-all.js:15478 static/js/zamboni/stats-min.js:5
 msgid "Site Metrics from {0} to {1}"
 msgstr "Sedłowa statistika wót {0} až do {1}"
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:201 static/js/zamboni/stats-all.js:15482
-#: static/js/zamboni/stats-min.js:5
+#: static/js/impala/stats/csv_keys.js:201 static/js/zamboni/stats-all.js:15482 static/js/zamboni/stats-min.js:5
 msgid "Add-ons in Use, last {0} days"
 msgstr "Wužywane dodanki, zachadne {0} dnjow"
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:203 static/js/zamboni/stats-all.js:15484
-#: static/js/zamboni/stats-min.js:5
+#: static/js/impala/stats/csv_keys.js:203 static/js/zamboni/stats-all.js:15484 static/js/zamboni/stats-min.js:5
 msgid "Add-ons in Use from {0} to {1}"
 msgstr "Wužywane dodanki wót {0} až do {1}"
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:207 static/js/zamboni/stats-all.js:15488
-#: static/js/zamboni/stats-min.js:5
+#: static/js/impala/stats/csv_keys.js:207 static/js/zamboni/stats-all.js:15488 static/js/zamboni/stats-min.js:5
 msgid "Add-ons Downloaded, last {0} days"
 msgstr "Ześěgnjone dodanki, zachadne {0} dnjow"
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:209 static/js/zamboni/stats-all.js:15490
-#: static/js/zamboni/stats-min.js:5
+#: static/js/impala/stats/csv_keys.js:209 static/js/zamboni/stats-all.js:15490 static/js/zamboni/stats-min.js:5
 msgid "Add-ons Downloaded from {0} to {1}"
 msgstr "Ześěgnjone dodanki wót {0} až do {1}"
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:213 static/js/zamboni/stats-all.js:15494
-#: static/js/zamboni/stats-min.js:5
+#: static/js/impala/stats/csv_keys.js:213 static/js/zamboni/stats-all.js:15494 static/js/zamboni/stats-min.js:5
 msgid "Add-ons Created, last {0} days"
 msgstr "Napórane dodanki, zachadne {0} dnjow"
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:215 static/js/zamboni/stats-all.js:15496
-#: static/js/zamboni/stats-min.js:5
+#: static/js/impala/stats/csv_keys.js:215 static/js/zamboni/stats-all.js:15496 static/js/zamboni/stats-min.js:5
 msgid "Add-ons Created from {0} to {1}"
 msgstr "Napórane dodanki wót {0} až do {1}"
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:219 static/js/zamboni/stats-all.js:15500
-#: static/js/zamboni/stats-min.js:5
+#: static/js/impala/stats/csv_keys.js:219 static/js/zamboni/stats-all.js:15500 static/js/zamboni/stats-min.js:5
 msgid "Add-ons Updated, last {0} days"
 msgstr "Zaktualizěrowane dodanki, zachadne {0} dnjow"
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:221 static/js/zamboni/stats-all.js:15502
-#: static/js/zamboni/stats-min.js:5
+#: static/js/impala/stats/csv_keys.js:221 static/js/zamboni/stats-all.js:15502 static/js/zamboni/stats-min.js:5
 msgid "Add-ons Updated from {0} to {1}"
 msgstr "Zaktualizěrowane dodanki wót {0} až do {1}"
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:225 static/js/zamboni/stats-all.js:15506
-#: static/js/zamboni/stats-min.js:5
+#: static/js/impala/stats/csv_keys.js:225 static/js/zamboni/stats-all.js:15506 static/js/zamboni/stats-min.js:5
 msgid "Reviews Written, last {0} days"
 msgstr "Napisane pógódnośenja, zachadne {0} dnjow"
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:227 static/js/zamboni/stats-all.js:15508
-#: static/js/zamboni/stats-min.js:5
+#: static/js/impala/stats/csv_keys.js:227 static/js/zamboni/stats-all.js:15508 static/js/zamboni/stats-min.js:5
 msgid "Reviews Written from {0} to {1}"
 msgstr "Napisane pógódnośenja wót {0} až do {1}"
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:231 static/js/zamboni/stats-all.js:15512
-#: static/js/zamboni/stats-min.js:5
+#: static/js/impala/stats/csv_keys.js:231 static/js/zamboni/stats-all.js:15512 static/js/zamboni/stats-min.js:5
 msgid "User Signups, last {0} days"
 msgstr "Wužywarske registrěrowanja, zachadne {0} dnjow"
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:233 static/js/zamboni/stats-all.js:15514
-#: static/js/zamboni/stats-min.js:5
+#: static/js/impala/stats/csv_keys.js:233 static/js/zamboni/stats-all.js:15514 static/js/zamboni/stats-min.js:5
 msgid "User Signups from {0} to {1}"
 msgstr "Wužywarske registrěrowanja wót {0} až do {1}"
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:237 static/js/zamboni/stats-all.js:15518
-#: static/js/zamboni/stats-min.js:5
+#: static/js/impala/stats/csv_keys.js:237 static/js/zamboni/stats-all.js:15518 static/js/zamboni/stats-min.js:5
 msgid "Collections Created, last {0} days"
 msgstr "Napórane zběrki, zachadne {0} dnjow"
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:239 static/js/zamboni/stats-all.js:15520
-#: static/js/zamboni/stats-min.js:5
+#: static/js/impala/stats/csv_keys.js:239 static/js/zamboni/stats-all.js:15520 static/js/zamboni/stats-min.js:5
 msgid "Collections Created from {0} to {1}"
 msgstr "Napórane zběrki wót {0} až do {1}"
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:243 static/js/zamboni/stats-all.js:15524
-#: static/js/zamboni/stats-min.js:5
+#: static/js/impala/stats/csv_keys.js:243 static/js/zamboni/stats-all.js:15524 static/js/zamboni/stats-min.js:5
 msgid "Subscribers, last {0} days"
 msgstr "Abonenty, zachadne {0} dnjow"
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:245 static/js/zamboni/stats-all.js:15526
-#: static/js/zamboni/stats-min.js:5
+#: static/js/impala/stats/csv_keys.js:245 static/js/zamboni/stats-all.js:15526 static/js/zamboni/stats-min.js:5
 msgid "Subscribers from {0} to {1}"
 msgstr "Abonenty wót {0} až do {1}"
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:249 static/js/zamboni/stats-all.js:15530
-#: static/js/zamboni/stats-min.js:5
+#: static/js/impala/stats/csv_keys.js:249 static/js/zamboni/stats-all.js:15530 static/js/zamboni/stats-min.js:5
 msgid "Ratings, last {0} days"
 msgstr "Pógódnośenja, zachadne {0} dnjow"
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:251 static/js/zamboni/stats-all.js:15532
-#: static/js/zamboni/stats-min.js:5
+#: static/js/impala/stats/csv_keys.js:251 static/js/zamboni/stats-all.js:15532 static/js/zamboni/stats-min.js:5
 msgid "Ratings from {0} to {1}"
 msgstr "Pógódnośenja wót {0} až do {1}"
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:255 static/js/zamboni/stats-all.js:15536
-#: static/js/zamboni/stats-min.js:5
+#: static/js/impala/stats/csv_keys.js:255 static/js/zamboni/stats-all.js:15536 static/js/zamboni/stats-min.js:5
 msgid "Sales, last {0} days"
 msgstr "Pśedanki, zachadne {0} dnjow"
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:257 static/js/zamboni/stats-all.js:15538
-#: static/js/zamboni/stats-min.js:5
+#: static/js/impala/stats/csv_keys.js:257 static/js/zamboni/stats-all.js:15538 static/js/zamboni/stats-min.js:5
 msgid "Sales from {0} to {1}"
 msgstr "Pśedanki wót {0} až do {1}"
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:261 static/js/zamboni/stats-all.js:15542
-#: static/js/zamboni/stats-min.js:5
+#: static/js/impala/stats/csv_keys.js:261 static/js/zamboni/stats-all.js:15542 static/js/zamboni/stats-min.js:5
 msgid "Installs, last {0} days"
 msgstr "Instalacije, zachadne {0} dnjow"
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:263 static/js/zamboni/stats-all.js:15544
-#: static/js/zamboni/stats-min.js:5
+#: static/js/impala/stats/csv_keys.js:263 static/js/zamboni/stats-all.js:15544 static/js/zamboni/stats-min.js:5
 msgid "Installs from {0} to {1}"
 msgstr "Instalacije wót {0} až do {1}"
 
 #. L10n: {0} and {1} are integers.
-#: static/js/impala/stats/csv_keys.js:269 static/js/zamboni/stats-all.js:15550
-#: static/js/zamboni/stats-min.js:5
+#: static/js/impala/stats/csv_keys.js:269 static/js/zamboni/stats-all.js:15550 static/js/zamboni/stats-min.js:5
 msgid "<b>{0}</b> in last {1} days"
 msgstr "<b>{0}</b> w zachadnych {1} dnjach"
 
 #. L10n: {0} is an integer and {1} and {2} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:271
-#: static/js/impala/stats/csv_keys.js:277 static/js/zamboni/stats-all.js:15552
-#: static/js/zamboni/stats-all.js:15558 static/js/zamboni/stats-min.js:5
+#: static/js/impala/stats/csv_keys.js:271 static/js/impala/stats/csv_keys.js:277 static/js/zamboni/stats-all.js:15552 static/js/zamboni/stats-all.js:15558 static/js/zamboni/stats-min.js:5
 msgid "<b>{0}</b> from {1} to {2}"
 msgstr "<b>{0}</b> wót {1} až do {2}"
 
 #. L10n: {0} and {1} are integers.
-#: static/js/impala/stats/csv_keys.js:275 static/js/zamboni/stats-all.js:15556
-#: static/js/zamboni/stats-min.js:5
+#: static/js/impala/stats/csv_keys.js:275 static/js/zamboni/stats-all.js:15556 static/js/zamboni/stats-min.js:5
 msgid "<b>{0}</b> average in last {1} days"
 msgstr "Pśerěznje <b>{0}</b> w zachadnych {1} dnjach"
 
-#: static/js/impala/stats/overview.js:19 static/js/zamboni/stats-all.js:16469
-#: static/js/zamboni/stats-min.js:5
+#: static/js/impala/stats/overview.js:19 static/js/zamboni/stats-all.js:16469 static/js/zamboni/stats-min.js:5
 msgid "No data available."
 msgstr "Žedne daty k dispoziciji."
 
-#: static/js/impala/stats/table.js:74 static/js/zamboni/stats-all.js:17209
-#: static/js/zamboni/stats-min.js:5
+#: static/js/impala/stats/table.js:74 static/js/zamboni/stats-all.js:17209 static/js/zamboni/stats-min.js:5
 msgid "Date"
 msgstr "Datum"
 
-#: static/js/impala/stats/topchart.js:96 static/js/zamboni/stats-all.js:16600
-#: static/js/zamboni/stats-min.js:5
+#: static/js/impala/stats/topchart.js:96 static/js/zamboni/stats-all.js:16600 static/js/zamboni/stats-min.js:5
 msgid "Other"
 msgstr "Druge"
 
-#: static/js/zamboni/admin-all.js:180 static/js/zamboni/admin-min.js:1
-#: static/js/zamboni/admin_validation.js:24
-#: static/js/zamboni/devhub-all.js:2408 static/js/zamboni/devhub-min.js:2
-#: static/js/zamboni/devhub.js:1229 static/js/zamboni/editors-all.js:15576
-#: static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:295
+#: static/js/zamboni/admin-all.js:180 static/js/zamboni/admin-min.js:1 static/js/zamboni/admin_validation.js:24 static/js/zamboni/devhub-all.js:2408 static/js/zamboni/devhub-min.js:2
+#: static/js/zamboni/devhub.js:1229 static/js/zamboni/editors-all.js:15576 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:295
 msgid "Select an application first"
 msgstr "Wubjeŕśo nejpjerwjej nałoženje"
 
-#: static/js/zamboni/admin-all.js:207 static/js/zamboni/admin-min.js:1
-#: static/js/zamboni/admin_validation.js:51
+#: static/js/zamboni/admin-all.js:207 static/js/zamboni/admin-min.js:1 static/js/zamboni/admin_validation.js:51
 msgid "Set {0} add-on to a max version of {1} and email the author."
 msgid_plural "Set {0} add-ons to a max version of {1} and email the authors."
-msgstr[0] ""
-"{0} dodank na maksimalnu wersiju {1} stajiś a awtoroju mejlku pósłaś"
-msgstr[1] ""
-"{0} dodanka na maksimalnu wersiju {1} stajiś a awtoroju mejlku pósłaś"
-msgstr[2] ""
-"{0} dodanki na maksimalnu wersiju {1} stajiś a awtoroju mejlku pósłaś"
-msgstr[3] ""
-"{0} dodankow na maksimalnu wersiju {1} stajiś a awtoroju mejlku pósłaś"
+msgstr[0] "{0} dodank na maksimalnu wersiju {1} stajiś a awtoroju mejlku pósłaś"
+msgstr[1] "{0} dodanka na maksimalnu wersiju {1} stajiś a awtoroju mejlku pósłaś"
+msgstr[2] "{0} dodanki na maksimalnu wersiju {1} stajiś a awtoroju mejlku pósłaś"
+msgstr[3] "{0} dodankow na maksimalnu wersiju {1} stajiś a awtoroju mejlku pósłaś"
 
-#: static/js/zamboni/admin-all.js:210 static/js/zamboni/admin-min.js:1
-#: static/js/zamboni/admin_validation.js:54
+#: static/js/zamboni/admin-all.js:210 static/js/zamboni/admin-min.js:1 static/js/zamboni/admin_validation.js:54
 msgid "Email author of {2} add-on which failed validation."
 msgid_plural "Email authors of {2} add-ons which failed validation."
-msgstr[0] ""
-"Awtoroju {2} dodanka mejlku pósłaś, kótaregož pśeglědowanje njejo se raźiło."
-msgstr[1] ""
-"Awtoroju {2} dodankowu mejlku pósłaś, kótarejuž pśeglědowanje njejo se "
-"raźiło."
-msgstr[2] ""
-"Awtoroju {2} dodankow mejlku pósłaś, kótarychž pśeglědowanje njejo se "
-"raźiło."
-msgstr[3] ""
-"Awtoroju {2} dodankow mejlku pósłaś, kótarychž pśeglědowanje njejo se "
-"raźiło."
+msgstr[0] "Awtoroju {2} dodanka mejlku pósłaś, kótaregož pśeglědowanje njejo se raźiło."
+msgstr[1] "Awtoroju {2} dodankowu mejlku pósłaś, kótarejuž pśeglědowanje njejo se raźiło."
+msgstr[2] "Awtoroju {2} dodankow mejlku pósłaś, kótarychž pśeglědowanje njejo se raźiło."
+msgstr[3] "Awtoroju {2} dodankow mejlku pósłaś, kótarychž pśeglědowanje njejo se raźiło."
 
-#: static/js/zamboni/devhub-all.js:1289 static/js/zamboni/devhub-min.js:1
-#: static/js/zamboni/devhub.js:110
+#: static/js/zamboni/devhub-all.js:1289 static/js/zamboni/devhub-min.js:1 static/js/zamboni/devhub.js:110
 msgid "Your browser does not support the video tag"
 msgstr "Waš wobglědowak njepódpěra wobznamjenje video"
 
-#: static/js/zamboni/devhub-all.js:1550 static/js/zamboni/devhub-min.js:1
-#: static/js/zamboni/devhub.js:371
+#: static/js/zamboni/devhub-all.js:1550 static/js/zamboni/devhub-min.js:1 static/js/zamboni/devhub.js:371
 msgid "Changes Saved"
 msgstr "Změny su se składli"
 
-#: static/js/zamboni/devhub-all.js:1566 static/js/zamboni/devhub-min.js:1
-#: static/js/zamboni/devhub.js:387
+#: static/js/zamboni/devhub-all.js:1566 static/js/zamboni/devhub-min.js:1 static/js/zamboni/devhub.js:387
 msgid "Enter a new author's email address"
 msgstr "E-mailowu adresu nowego awtora zapódaś"
 
-#: static/js/zamboni/devhub-all.js:1715 static/js/zamboni/devhub-min.js:1
-#: static/js/zamboni/devhub.js:536
+#: static/js/zamboni/devhub-all.js:1715 static/js/zamboni/devhub-min.js:1 static/js/zamboni/devhub.js:536
 msgid "There was an error uploading your file."
 msgstr "Pśi nagrawanju wašeje dataje jo zmólka nastała."
 
-#: static/js/zamboni/devhub-all.js:1860 static/js/zamboni/devhub-min.js:1
-#: static/js/zamboni/devhub.js:681
+#: static/js/zamboni/devhub-all.js:1860 static/js/zamboni/devhub-min.js:1 static/js/zamboni/devhub.js:681
 msgid "{files} file"
 msgid_plural "{files} files"
 msgstr[0] "{files} dataja"
@@ -1376,8 +1029,7 @@ msgstr[1] "{files} dataji"
 msgstr[2] "{files} dataje"
 msgstr[3] "{files} datajow"
 
-#: static/js/zamboni/devhub-all.js:1863 static/js/zamboni/devhub-min.js:1
-#: static/js/zamboni/devhub.js:684
+#: static/js/zamboni/devhub-all.js:1863 static/js/zamboni/devhub-min.js:1 static/js/zamboni/devhub.js:684
 msgid "{reviews} user review"
 msgid_plural "{reviews} user reviews"
 msgstr[0] "{reviews} wužywarske pógódnośenje"
@@ -1385,89 +1037,70 @@ msgstr[1] "{reviews} wužywarskej pógódnośeni"
 msgstr[2] "{reviews} wužywarske pógódnośenja"
 msgstr[3] "{reviews} wužywarskich pógódnośenjow"
 
-#: static/js/zamboni/devhub-all.js:1975 static/js/zamboni/devhub-min.js:2
-#: static/js/zamboni/devhub.js:796
+#: static/js/zamboni/devhub-all.js:1975 static/js/zamboni/devhub-min.js:2 static/js/zamboni/devhub.js:796
 msgid "Learn more"
 msgstr "Dalšne informacije"
 
-#: static/js/zamboni/devhub-all.js:1979 static/js/zamboni/devhub-min.js:2
-#: static/js/zamboni/devhub.js:800
+#: static/js/zamboni/devhub-all.js:1979 static/js/zamboni/devhub-min.js:2 static/js/zamboni/devhub.js:800
 msgid "Example"
 msgstr "Pśikład"
 
-#: static/js/zamboni/devhub-all.js:2309 static/js/zamboni/devhub-min.js:2
-#: static/js/zamboni/devhub.js:1130
+#: static/js/zamboni/devhub-all.js:2309 static/js/zamboni/devhub-min.js:2 static/js/zamboni/devhub.js:1130
 msgid "Image changes being processed"
 msgstr "Wobrazowe změny se pśeźěłuju"
 
-#: static/js/zamboni/devhub-all.js:2459 static/js/zamboni/devhub-min.js:2
-#: static/js/zamboni/devhub.js:1280
+#: static/js/zamboni/devhub-all.js:2459 static/js/zamboni/devhub-min.js:2 static/js/zamboni/devhub.js:1280
 msgid "Must be a valid e-mail address."
 msgstr "To musy płaśiwa e-mailowa adresa byś."
 
-#: static/js/zamboni/devhub-all.js:2613 static/js/zamboni/devhub-min.js:2
-#: static/js/zamboni/validator.js:80
+#: static/js/zamboni/devhub-all.js:2613 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:80
 msgid "All tests passed successfully."
 msgstr "Wšykne testy wuspěšnje dokóńcone."
 
-#: static/js/zamboni/devhub-all.js:2616 static/js/zamboni/devhub-all.js:3011
-#: static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:83
-#: static/js/zamboni/validator.js:478
+#: static/js/zamboni/devhub-all.js:2616 static/js/zamboni/devhub-all.js:3011 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:83 static/js/zamboni/validator.js:478
 msgid "These tests were not run."
 msgstr "Toś te testy njejsu se pśewjadli."
 
-#: static/js/zamboni/devhub-all.js:2664 static/js/zamboni/devhub-all.js:2677
-#: static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:131
-#: static/js/zamboni/validator.js:144
+#: static/js/zamboni/devhub-all.js:2664 static/js/zamboni/devhub-all.js:2677 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:131 static/js/zamboni/validator.js:144
 msgid "Tests"
 msgstr "Testy"
 
-#: static/js/zamboni/devhub-all.js:2779 static/js/zamboni/devhub-all.js:3108
-#: static/js/zamboni/devhub-all.js:3127 static/js/zamboni/devhub-min.js:2
-#: static/js/zamboni/validator.js:246 static/js/zamboni/validator.js:575
-#: static/js/zamboni/validator.js:594
+#: static/js/zamboni/devhub-all.js:2779 static/js/zamboni/devhub-all.js:3108 static/js/zamboni/devhub-all.js:3127 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:246
+#: static/js/zamboni/validator.js:575 static/js/zamboni/validator.js:594
 msgid "Error"
 msgstr "Zmólka"
 
-#: static/js/zamboni/devhub-all.js:2780 static/js/zamboni/devhub-min.js:2
-#: static/js/zamboni/validator.js:247
+#: static/js/zamboni/devhub-all.js:2780 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:247
 msgid "Warning"
 msgstr "Warnowanje"
 
-#: static/js/zamboni/devhub-all.js:2794 static/js/zamboni/devhub-min.js:2
-#: static/js/zamboni/files-all.js:5657 static/js/zamboni/files-min.js:3
-#: static/js/zamboni/files.js:411 static/js/zamboni/validator.js:261
+#: static/js/zamboni/devhub-all.js:2794 static/js/zamboni/devhub-min.js:2 static/js/zamboni/files-all.js:5657 static/js/zamboni/files-min.js:3 static/js/zamboni/files.js:411
+#: static/js/zamboni/validator.js:261
 msgid "Ignore this message in future updates"
 msgstr "Toś tu powěźeńku w pśichodnych aktualizacijach ignorěrowaś"
 
-#: static/js/zamboni/devhub-all.js:2817 static/js/zamboni/devhub-min.js:2
-#: static/js/zamboni/files-all.js:5663 static/js/zamboni/files-min.js:3
-#: static/js/zamboni/files.js:417 static/js/zamboni/validator.js:284
+#: static/js/zamboni/devhub-all.js:2817 static/js/zamboni/devhub-min.js:2 static/js/zamboni/files-all.js:5663 static/js/zamboni/files-min.js:3 static/js/zamboni/files.js:417
+#: static/js/zamboni/validator.js:284
 msgid "Severity for automated signing:"
 msgstr "Nuznosć za awtomatiske signěrowanje:"
 
-#: static/js/zamboni/devhub-all.js:2832 static/js/zamboni/devhub-min.js:2
-#: static/js/zamboni/validator.js:299
+#: static/js/zamboni/devhub-all.js:2832 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:299
 msgid "Suggestions for passing automated signing:"
 msgstr "Naraźenja za wobstaśe awtomatiskego signěrowanja:"
 
-#: static/js/zamboni/devhub-all.js:2920 static/js/zamboni/devhub-min.js:2
-#: static/js/zamboni/validator.js:387
+#: static/js/zamboni/devhub-all.js:2920 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:387
 msgid "Compatibility Tests"
 msgstr "Testy kompatibelnosći"
 
-#: static/js/zamboni/devhub-all.js:2999 static/js/zamboni/devhub-min.js:2
-#: static/js/zamboni/validator.js:466
+#: static/js/zamboni/devhub-all.js:2999 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:466
 msgid "Add-on failed validation."
 msgstr "Dodank jo pśi pśeglědowanju pśepadnuł."
 
-#: static/js/zamboni/devhub-all.js:3001 static/js/zamboni/devhub-min.js:2
-#: static/js/zamboni/validator.js:468
+#: static/js/zamboni/devhub-all.js:3001 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:468
 msgid "Add-on passed validation."
 msgstr "Dodank jo pśeglědowanje wobstał."
 
-#: static/js/zamboni/devhub-all.js:3014 static/js/zamboni/devhub-min.js:2
-#: static/js/zamboni/validator.js:481
+#: static/js/zamboni/devhub-all.js:3014 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:481
 msgid "{0} error"
 msgid_plural "{0} errors"
 msgstr[0] "{0} zmólka"
@@ -1475,8 +1108,7 @@ msgstr[1] "{0} zmólce"
 msgstr[2] "{0} zmólki"
 msgstr[3] "{0} zmólkow"
 
-#: static/js/zamboni/devhub-all.js:3016 static/js/zamboni/devhub-min.js:2
-#: static/js/zamboni/validator.js:483
+#: static/js/zamboni/devhub-all.js:3016 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:483
 msgid "{0} warning"
 msgid_plural "{0} warnings"
 msgstr[0] "{0} warnowanje"
@@ -1484,8 +1116,7 @@ msgstr[1] "{0} warnowani"
 msgstr[2] "{0} warnowanja"
 msgstr[3] "{0} warnowanjow"
 
-#: static/js/zamboni/devhub-all.js:3018 static/js/zamboni/devhub-min.js:2
-#: static/js/zamboni/validator.js:485
+#: static/js/zamboni/devhub-all.js:3018 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:485
 msgid "{0} notice"
 msgid_plural "{0} notices"
 msgstr[0] "{0} powěsć"
@@ -1493,13 +1124,11 @@ msgstr[1] "{0} powěsći"
 msgstr[2] "{0} powěsći"
 msgstr[3] "{0} powěsćow"
 
-#: static/js/zamboni/devhub-all.js:3110 static/js/zamboni/devhub-min.js:2
-#: static/js/zamboni/validator.js:577
+#: static/js/zamboni/devhub-all.js:3110 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:577
 msgid "Validation task could not complete or completed with errors"
 msgstr "Pśeglědowanje njedajo se dokóńcyś abo jo se ze zmólkami dokóńcyło"
 
-#: static/js/zamboni/devhub-all.js:3128 static/js/zamboni/devhub-min.js:2
-#: static/js/zamboni/validator.js:595
+#: static/js/zamboni/devhub-all.js:3128 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:595
 msgid "Internal server error"
 msgstr "Nutśkowna serwerowa zmólka"
 
@@ -1507,168 +1136,134 @@ msgstr "Nutśkowna serwerowa zmólka"
 msgid "No results found."
 msgstr "Žedne wusědki namakane."
 
-#: static/js/zamboni/editors-all.js:15402 static/js/zamboni/editors-min.js:4
-#: static/js/zamboni/editors.js:121
+#: static/js/zamboni/editors-all.js:15402 static/js/zamboni/editors-min.js:4 static/js/zamboni/editors.js:121
 msgid "{name} was viewing this page first."
 msgstr "{name} jo se toś ten bok ako prědny woglědał."
 
-#: static/js/zamboni/editors-all.js:15452 static/js/zamboni/editors-min.js:5
-#: static/js/zamboni/editors.js:171
+#: static/js/zamboni/editors-all.js:15452 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:171
 msgid "Receipt checked by app."
 msgstr "Kwitowanka jo se pśez nałoženje pśeglědała."
 
-#: static/js/zamboni/editors-all.js:15454 static/js/zamboni/editors-min.js:5
-#: static/js/zamboni/editors.js:173
+#: static/js/zamboni/editors-all.js:15454 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:173
 msgid "Receipt was not checked by app."
 msgstr "Kwitowanka njejo se pśez nałoženje pśeglědała."
 
-#: static/js/zamboni/editors-all.js:15525 static/js/zamboni/editors-min.js:5
-#: static/js/zamboni/editors.js:244
+#: static/js/zamboni/editors-all.js:15525 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:244
 msgid "{name} was viewing this add-on first."
 msgstr "{name} jo se toś ten dodank ako prědny woglědał."
 
-#: static/js/zamboni/editors-all.js:15536 static/js/zamboni/editors-min.js:5
-#: static/js/zamboni/editors.js:255
+#: static/js/zamboni/editors-all.js:15536 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:255
 msgid "Loading&hellip;"
 msgstr "Zacytujo se&hellip;"
 
-#: static/js/zamboni/editors-all.js:15541 static/js/zamboni/editors-min.js:5
-#: static/js/zamboni/editors.js:260
+#: static/js/zamboni/editors-all.js:15541 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:260
 msgid "Version Notes"
 msgstr "Pśipiski k wersiji"
 
-#: static/js/zamboni/editors-all.js:15546 static/js/zamboni/editors-min.js:5
-#: static/js/zamboni/editors.js:265
+#: static/js/zamboni/editors-all.js:15546 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:265
 msgid "Notes for Reviewers"
 msgstr "Pokaze za pśeglědowarjow"
 
-#: static/js/zamboni/editors-all.js:15551 static/js/zamboni/editors-min.js:5
-#: static/js/zamboni/editors.js:270
+#: static/js/zamboni/editors-all.js:15551 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:270
 msgid "No version notes found"
 msgstr "Žedne wersijowe pokaze namakane"
 
-#: static/js/zamboni/editors-all.js:15611 static/js/zamboni/editors-min.js:5
-#: static/js/zamboni/editors.js:330
+#: static/js/zamboni/editors-all.js:15611 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:330
 msgid "Average Reviews"
 msgstr "Pśerězne pógódnośenja"
 
-#: static/js/zamboni/editors-all.js:15667 static/js/zamboni/editors-min.js:5
-#: static/js/zamboni/editors.js:386
+#: static/js/zamboni/editors-all.js:15667 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:386
 msgid "Number of Reviews"
 msgstr "Licba pógódnośenjow"
 
-#: static/js/zamboni/editors-all.js:15726 static/js/zamboni/editors-min.js:5
-#: static/js/zamboni/editors.js:445
+#: static/js/zamboni/editors-all.js:15726 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:445
 msgid "Error loading translation"
 msgstr "Zmólka pśi zacytowanju pśełožka"
 
-#: static/js/zamboni/editors-all.js:15975 static/js/zamboni/editors-min.js:5
-#: static/js/zamboni/themes_review_templates.js:31
+#: static/js/zamboni/editors-all.js:15975 static/js/zamboni/editors-min.js:5 static/js/zamboni/themes_review_templates.js:31
 msgid "Theme"
 msgstr "Drastwa"
 
-#: static/js/zamboni/editors-all.js:15977 static/js/zamboni/editors-min.js:5
-#: static/js/zamboni/themes_review_templates.js:33
+#: static/js/zamboni/editors-all.js:15977 static/js/zamboni/editors-min.js:5 static/js/zamboni/themes_review_templates.js:33
 msgid "Reviewer"
 msgstr "Pśepytowaŕ"
 
-#: static/js/zamboni/editors-all.js:15979 static/js/zamboni/editors-min.js:5
-#: static/js/zamboni/themes_review_templates.js:35
+#: static/js/zamboni/editors-all.js:15979 static/js/zamboni/editors-min.js:5 static/js/zamboni/themes_review_templates.js:35
 msgid "Status"
 msgstr "Status"
 
-#: static/js/zamboni/editors-all.js:16196 static/js/zamboni/editors-min.js:5
-#: static/js/zamboni/themes_review.js:176
+#: static/js/zamboni/editors-all.js:16196 static/js/zamboni/editors-min.js:5 static/js/zamboni/themes_review.js:176
 msgid "Requested Info"
 msgstr "Informacije pominane"
 
-#: static/js/zamboni/editors-all.js:16197 static/js/zamboni/editors-min.js:5
-#: static/js/zamboni/themes_review.js:177
+#: static/js/zamboni/editors-all.js:16197 static/js/zamboni/editors-min.js:5 static/js/zamboni/themes_review.js:177
 msgid "Flagged"
 msgstr "Wóznamjenjone"
 
-#: static/js/zamboni/editors-all.js:16198 static/js/zamboni/editors-min.js:5
-#: static/js/zamboni/themes_review.js:178
+#: static/js/zamboni/editors-all.js:16198 static/js/zamboni/editors-min.js:5 static/js/zamboni/themes_review.js:178
 msgid "Duplicate"
 msgstr "Duplikat"
 
-#: static/js/zamboni/editors-all.js:16199 static/js/zamboni/editors-min.js:5
-#: static/js/zamboni/themes_review.js:179
+#: static/js/zamboni/editors-all.js:16199 static/js/zamboni/editors-min.js:5 static/js/zamboni/themes_review.js:179
 msgid "Rejected"
 msgstr "Wótpokazane"
 
-#: static/js/zamboni/editors-all.js:16200 static/js/zamboni/editors-min.js:5
-#: static/js/zamboni/themes_review.js:180
+#: static/js/zamboni/editors-all.js:16200 static/js/zamboni/editors-min.js:5 static/js/zamboni/themes_review.js:180
 msgid "Approved"
 msgstr "Pśizwólone"
 
-#: static/js/zamboni/editors-all.js:16444 static/js/zamboni/editors-min.js:5
-#: static/js/zamboni/themes_review.js:424
+#: static/js/zamboni/editors-all.js:16444 static/js/zamboni/editors-min.js:5 static/js/zamboni/themes_review.js:424
 msgid "No results found"
 msgstr "Žedne wuslědki namakane"
 
-#: static/js/zamboni/mobile-all.js:15186
-#: static/js/zamboni/mobile/buttons.js:52
+#: static/js/zamboni/mobile-all.js:15186 static/js/zamboni/mobile/buttons.js:52
 msgid "Not Updated for {0} {1}"
 msgstr "Za {0} {1} njeaktualizěrowany"
 
-#: static/js/zamboni/mobile-all.js:15187
-#: static/js/zamboni/mobile/buttons.js:53
+#: static/js/zamboni/mobile-all.js:15187 static/js/zamboni/mobile/buttons.js:53
 msgid "Requires Newer Version of {0}"
 msgstr "Pomina se nowšu wersiju {0}"
 
-#: static/js/zamboni/mobile-all.js:15188
-#: static/js/zamboni/mobile/buttons.js:54
+#: static/js/zamboni/mobile-all.js:15188 static/js/zamboni/mobile/buttons.js:54
 msgid "Unreviewed"
 msgstr "Njepśeglědany"
 
-#: static/js/zamboni/mobile-all.js:15189
-#: static/js/zamboni/mobile/buttons.js:55
+#: static/js/zamboni/mobile-all.js:15189 static/js/zamboni/mobile/buttons.js:55
 msgid "Experimental <span>(Learn More)</span>"
 msgstr "Eksperimentelny <span>(Dalšne informacije)</span>"
 
-#: static/js/zamboni/mobile-all.js:15190 static/js/zamboni/mobile-all.js:15191
-#: static/js/zamboni/mobile/buttons.js:56
-#: static/js/zamboni/mobile/buttons.js:57
+#: static/js/zamboni/mobile-all.js:15190 static/js/zamboni/mobile-all.js:15191 static/js/zamboni/mobile/buttons.js:56 static/js/zamboni/mobile/buttons.js:57
 msgid "Not Available for {0}"
 msgstr "Njejo za {0} k dispoziciji"
 
-#: static/js/zamboni/mobile-all.js:15192
-#: static/js/zamboni/mobile/buttons.js:58
+#: static/js/zamboni/mobile-all.js:15192 static/js/zamboni/mobile/buttons.js:58
 msgid "Experimental"
 msgstr "Eksperimentelny"
 
-#: static/js/zamboni/mobile-all.js:15193
-#: static/js/zamboni/mobile/buttons.js:59
+#: static/js/zamboni/mobile-all.js:15193 static/js/zamboni/mobile/buttons.js:59
 msgid "Themes Require Newer Version of {0}"
 msgstr "Drastwy se nowšu wersiju {0} pominaju"
 
-#: static/js/zamboni/mobile-all.js:15194
-#: static/js/zamboni/mobile/buttons.js:60
+#: static/js/zamboni/mobile-all.js:15194 static/js/zamboni/mobile/buttons.js:60
 msgid "Themes Require {0}"
 msgstr "Drastwy se {0} pominaju"
 
-#: static/js/zamboni/mobile-all.js:15239
-#: static/js/zamboni/mobile/buttons.js:105
+#: static/js/zamboni/mobile-all.js:15239 static/js/zamboni/mobile/buttons.js:105
 msgid "Installing..."
 msgstr "Instalěrujo se..."
 
-#: static/js/zamboni/mobile-all.js:15259
-#: static/js/zamboni/mobile/buttons.js:125
+#: static/js/zamboni/mobile-all.js:15259 static/js/zamboni/mobile/buttons.js:125
 msgid "This add-on has been preliminarily reviewed by Mozilla."
 msgstr "Toś te dodank jo se nachylu wót Mozilla pśeglědał."
 
-#: static/js/zamboni/mobile-all.js:15384
-#: static/js/zamboni/mobile/buttons.js:250
+#: static/js/zamboni/mobile-all.js:15384 static/js/zamboni/mobile/buttons.js:250
 msgid "Keep it"
 msgstr "Wobchowaś"
 
-#: static/js/zamboni/mobile-all.js:16049 static/js/zamboni/mobile-min.js:6
-#: static/js/zamboni/mobile/general.js:344
+#: static/js/zamboni/mobile-all.js:16049 static/js/zamboni/mobile-min.js:6 static/js/zamboni/mobile/general.js:344
 msgid "You're trying it on!"
 msgstr "Wopytujośo jen!"
 
-#: static/js/zamboni/mobile-all.js:16061 static/js/zamboni/mobile-min.js:6
-#: static/js/zamboni/mobile/general.js:356
+#: static/js/zamboni/mobile-all.js:16061 static/js/zamboni/mobile-min.js:6 static/js/zamboni/mobile/general.js:356
 msgid "Added to Firefox"
 msgstr "K Firefox pśidany"

--- a/locale/el/LC_MESSAGES/django.po
+++ b/locale/el/LC_MESSAGES/django.po
@@ -3,69 +3,70 @@ msgid ""
 msgstr ""
 "Project-Id-Version: REMORA 0.1\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2016-02-24 21:23+0000\n"
+"POT-Creation-Date: 2016-04-18 15:47+0000\n"
 "PO-Revision-Date: 2015-12-01 12:33+0000\n"
 "Last-Translator: Alfredos-Panagiotis Damkalis <fredy@fredy.gr>\n"
 "Language-Team: el-GR <LL@li.org>\n"
+"Language: \n"
 "MIME-Version: 1.0\n"
-"Content-Type: text/plain; charset=utf-8\n"
+"Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Generated-By: Babel 2.2.0\n"
 
-#: src/olympia/accounts/views.py:52
+#: src/olympia/accounts/views.py:54
 msgid "Your log in attempt could not be parsed. Please try again."
 msgstr ""
 
-#: src/olympia/accounts/views.py:54
+#: src/olympia/accounts/views.py:56
 msgid "Your Firefox Account could not be found. Please try again."
 msgstr ""
 
-#: src/olympia/accounts/views.py:55
+#: src/olympia/accounts/views.py:57
 msgid "You could not be logged in. Please try again."
 msgstr ""
 
-#: src/olympia/accounts/views.py:57
+#: src/olympia/accounts/views.py:59
 msgid "Your account has already been migrated to Firefox Accounts."
 msgstr ""
 
-#: src/olympia/accounts/views.py:59
+#: src/olympia/accounts/views.py:61
 msgid "Your Firefox Account already exists on this site."
 msgstr ""
 
-#: src/olympia/accounts/views.py:108
+#: src/olympia/accounts/views.py:110
 msgid "Great job!"
 msgstr ""
 
-#: src/olympia/accounts/views.py:109
+#: src/olympia/accounts/views.py:111
 msgid "You can now log in to Add-ons with your Firefox Account."
 msgstr ""
 
-#: src/olympia/accounts/views.py:121
+#: src/olympia/accounts/views.py:123
 msgid "Need help?"
 msgstr ""
 
-#: src/olympia/addons/buttons.py:180
+#: src/olympia/addons/buttons.py:177
 msgid "Download Now"
 msgstr "Λήψη τώρα"
 
-#: src/olympia/addons/buttons.py:182
+#: src/olympia/addons/buttons.py:179
 msgid "Download"
 msgstr "Λήψη"
 
 #. L10n: please keep &nbsp; in the string so &rarr; does not wrap.
-#: src/olympia/addons/buttons.py:186
+#: src/olympia/addons/buttons.py:183
 msgid "Continue to Download&nbsp;&rarr;"
 msgstr "Συνέχεια λήψης&nbsp;&rarr;"
 
-#: src/olympia/addons/buttons.py:202 src/olympia/addons/helpers.py:35 src/olympia/addons/views.py:319 src/olympia/addons/templates/addons/impala/details.html:114
+#: src/olympia/addons/buttons.py:199 src/olympia/addons/helpers.py:35 src/olympia/addons/views.py:333 src/olympia/addons/templates/addons/impala/details.html:111
 #: src/olympia/addons/templates/addons/impala/listing/items.html:17 src/olympia/addons/templates/addons/mobile/home.html:40 src/olympia/amo/templates/amo/side_nav.html:6
-#: src/olympia/amo/templates/amo/side_nav.html:10 src/olympia/amo/templates/amo/site_nav.html:2 src/olympia/amo/templates/amo/site_nav.html:55 src/olympia/bandwagon/views.py:95
-#: src/olympia/browse/views.py:54 src/olympia/browse/views.py:68 src/olympia/browse/views.py:235 src/olympia/browse/templates/browse/impala/category_landing.html:22
+#: src/olympia/amo/templates/amo/side_nav.html:10 src/olympia/amo/templates/amo/site_nav.html:2 src/olympia/amo/templates/amo/site_nav.html:53 src/olympia/bandwagon/views.py:95
+#: src/olympia/browse/views.py:54 src/olympia/browse/views.py:68 src/olympia/browse/views.py:202 src/olympia/browse/templates/browse/impala/category_landing.html:22
 #: src/olympia/browse/templates/browse/personas/mobile/category_landing.html:26
 msgid "Featured"
 msgstr "Προβεβλημένα"
 
-#: src/olympia/addons/buttons.py:221
+#: src/olympia/addons/buttons.py:218
 msgid "Add to {0}"
 msgstr "Προσθήκη στον {0}"
 
@@ -113,39 +114,39 @@ msgid_plural "All tags must be at least {0} characters."
 msgstr[0] "Όλες οι ετικέτες θα πρέπει να έχουν τουλάχιστον {0} χαρακτήρα."
 msgstr[1] "Όλες οι ετικέτες θα πρέπει να έχουν τουλάχιστον {0} χαρακτήρες."
 
-#: src/olympia/addons/forms.py:234
+#: src/olympia/addons/forms.py:238
 msgid "Categories cannot be changed while your add-on is featured for this application."
 msgstr "Δε μπορείτε να αλλάξετε κατηγορίες καθώς το πρόσθετο σας προβάλλεται για αυτή την εφαρμογή."
 
 #. L10n: {0} is the number of categories.
-#: src/olympia/addons/forms.py:238
+#: src/olympia/addons/forms.py:242
 msgid "You can have only {0} category."
 msgid_plural "You can have only {0} categories."
 msgstr[0] "Μπορείτε να έχετε μόνο {0} κατηγορία."
 msgstr[1] "Μπορείτε να έχετε μόνο {0} κατηγορίες."
 
-#: src/olympia/addons/forms.py:246
+#: src/olympia/addons/forms.py:250
 msgid "The miscellaneous category cannot be combined with additional categories."
 msgstr "Αυτή η κατηγορία δεν μπορεί να συνδυαστεί με άλλες κατηγορίες."
 
-#: src/olympia/addons/forms.py:369
+#: src/olympia/addons/forms.py:374
 #, python-format
 msgid "Before changing your default locale you must have a name, summary, and description in that locale. You are missing %s."
 msgstr "Για να αλλάξετε την αρχική γλώσσα, θα πρέπει πρώτα να διαθέτετε το όνομα, την περιγραφή, και τη σύνοψη σ' αυτή τη γλώσσα. Σας λείπει %s."
 
-#: src/olympia/addons/forms.py:484 src/olympia/addons/forms.py:575
+#: src/olympia/addons/forms.py:455 src/olympia/addons/forms.py:546
 msgid "A license must be selected."
 msgstr "Πρέπει να επιλέξετε μια άδεια."
 
-#: src/olympia/addons/forms.py:556
+#: src/olympia/addons/forms.py:527
 msgid "Give Your Theme a Name."
 msgstr "Δώστε στο Θέμα σας ένα όνομα"
 
-#: src/olympia/addons/forms.py:562 src/olympia/devhub/templates/devhub/personas/submit.html:53
+#: src/olympia/addons/forms.py:533 src/olympia/devhub/templates/devhub/personas/submit.html:53
 msgid "Describe your Theme."
 msgstr "Περιγράψτε το θέμα σας."
 
-#: src/olympia/addons/forms.py:704
+#: src/olympia/addons/forms.py:675
 msgid "Enter a new author's email address"
 msgstr "Εισάγετε τη διεύθυνση email ενός νέου συντάκτη"
 
@@ -153,39 +154,39 @@ msgstr "Εισάγετε τη διεύθυνση email ενός νέου συν�
 msgid "Not Reviewed"
 msgstr "Χωρίς Αξιολόγηση"
 
-#: src/olympia/addons/models.py:301
+#: src/olympia/addons/models.py:298
 msgid "Users have the option of contributing more or less than this amount."
 msgstr "Οι χρήστες μπορούν να επιλέξουν αν θα κάνουν μεγαλύτερη ή μικρότερη δωρεά απ' αυτό το ποσό."
 
-#: src/olympia/addons/models.py:309
-msgid "Users will always be asked in the Add-ons Manager (Firefox 4 and above)"
-msgstr "Να γίνεται πάντα ερώτηση στη διαχείριση πρόσθετων (στον Firefox 4 και μεταγενέστερες εκδόσεις)"
+#: src/olympia/addons/models.py:306
+msgid "Users will always be asked in the Add-ons Manager (Firefox 4 and above). Only applies to desktop."
+msgstr ""
 
 # Column name in a table.
-#: src/olympia/addons/models.py:1804 src/olympia/addons/templates/addons/details_box.html:55 src/olympia/devhub/templates/devhub/index.html:92
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:102
+#: src/olympia/addons/models.py:1802 src/olympia/addons/templates/addons/details_box.html:55 src/olympia/devhub/templates/devhub/index.html:92
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:89
 msgid "Listed"
 msgstr "Δηλωμένοι"
 
-#: src/olympia/addons/views.py:320 src/olympia/browse/templates/browse/personas/mobile/category_landing.html:27
+#: src/olympia/addons/views.py:334 src/olympia/browse/templates/browse/personas/mobile/category_landing.html:27
 msgid "Popular"
 msgstr "Δημοφιλή"
 
-#: src/olympia/addons/views.py:321 src/olympia/browse/views.py:238 src/olympia/browse/views.py:280 src/olympia/browse/views.py:482
+#: src/olympia/addons/views.py:335 src/olympia/browse/views.py:205 src/olympia/browse/views.py:247 src/olympia/browse/views.py:449
 msgid "Recently Added"
 msgstr "Προστεθηκαν προσφατα"
 
-#: src/olympia/addons/views.py:322 src/olympia/bandwagon/views.py:99 src/olympia/browse/views.py:60 src/olympia/browse/views.py:71 src/olympia/search/forms.py:16 src/olympia/search/forms.py:91
+#: src/olympia/addons/views.py:336 src/olympia/bandwagon/views.py:99 src/olympia/browse/views.py:60 src/olympia/browse/views.py:71 src/olympia/search/forms.py:16 src/olympia/search/forms.py:91
 msgid "Recently Updated"
 msgstr "Πρόσφατα ενημερωμένα"
 
 # %1 is an add-on name.
 #. l10n: {0} is the addon name
-#: src/olympia/addons/views.py:520
+#: src/olympia/addons/views.py:534
 msgid "Contribution for {0}"
 msgstr "Δωρεά για το {0}"
 
-#: src/olympia/addons/views.py:613
+#: src/olympia/addons/views.py:627
 msgid "Abuse reported."
 msgstr "Αναφέρθηκε κατάχρηση."
 
@@ -254,9 +255,9 @@ msgstr "Συνεισφέρετε"
 #: src/olympia/devhub/templates/devhub/addons/ajax_compat_update.html:36 src/olympia/devhub/templates/devhub/addons/profile.html:44 src/olympia/devhub/templates/devhub/addons/edit/admin.html:101
 #: src/olympia/devhub/templates/devhub/addons/edit/basic.html:152 src/olympia/devhub/templates/devhub/addons/edit/details.html:85 src/olympia/devhub/templates/devhub/addons/edit/support.html:67
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:166 src/olympia/devhub/templates/devhub/addons/forms_shared/media.html:149
-#: src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:44 src/olympia/devhub/templates/devhub/versions/add_file_modal.html:78 src/olympia/devhub/templates/devhub/versions/edit.html:139
-#: src/olympia/devhub/templates/devhub/versions/list.html:242 src/olympia/devhub/templates/devhub/versions/list.html:276 src/olympia/devhub/templates/devhub/versions/list.html:317
-#: src/olympia/devhub/templates/devhub/versions/list.html:351 src/olympia/reviews/templates/reviews/edit_review.html:16 src/olympia/translations/templates/translations/trans-menu.html:50
+#: src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:43 src/olympia/devhub/templates/devhub/versions/add_file_modal.html:58 src/olympia/devhub/templates/devhub/versions/edit.html:139
+#: src/olympia/devhub/templates/devhub/versions/list.html:239 src/olympia/devhub/templates/devhub/versions/list.html:281 src/olympia/devhub/templates/devhub/versions/list.html:315
+#: src/olympia/devhub/templates/devhub/versions/list.html:349 src/olympia/reviews/templates/reviews/edit_review.html:16 src/olympia/translations/templates/translations/trans-menu.html:50
 #: src/olympia/translations/templates/translations/trans-menu.html:62
 msgid "or"
 msgstr "ή"
@@ -294,19 +295,20 @@ msgstr "Βοηθήστε στην υποστήριξη της συνεχούς �
 
 #: src/olympia/addons/templates/addons/contributions_lightbox.html:15
 #, python-format
-msgid "To show your support for <b>%(addon_name)s</b>, the developer asks that you make a donation to the <a href=\"%(charity_url)s\">%(charity_name)s</a> through <a href=\"%(paypal_url)s\">PayPal</a>."
+msgid ""
+"To show your support for <b>%(addon_name)s</b>, the developer asks that you make a donation to the <a href=\"%(charity_url)s\">%(charity_name)s</a> through <a href=\"%(paypal_url)s\">PayPal</a>."
 msgstr ""
-"Για να δείξετε την υποστήριξη σας στο/στα <b>%(addon_name)s</b>, ο προγραμματιστής ζητά να κάνετε μια δωρεά στο <a href=\"%(charity_url)s\">%(charity_name)s</a> <a "
-"href=\"%(paypal_url)s\">PayPal</a>."
+"Για να δείξετε την υποστήριξη σας στο/στα <b>%(addon_name)s</b>, ο προγραμματιστής ζητά να κάνετε μια δωρεά στο <a href=\"%(charity_url)s\">%(charity_name)s</a> <a href=\"%(paypal_url)s\">PayPal</"
+"a>."
 
 #: src/olympia/addons/templates/addons/contributions_lightbox.html:21
 #, python-format
 msgid ""
-"To show your support for <b>%(addon_name)s</b>, the developer asks that you make a small contribution to <a href=\"%(charity_url)s\">%(charity_name)s</a> through <a "
-"href=\"%(paypal_url)s\">PayPal</a>."
+"To show your support for <b>%(addon_name)s</b>, the developer asks that you make a small contribution to <a href=\"%(charity_url)s\">%(charity_name)s</a> through <a href=\"%(paypal_url)s\">PayPal</"
+"a>."
 msgstr ""
-"Για να δείξετε την υποστήριξη σας στο/στα <b>%(addon_name)s</b>, ο προγραμματιστής ζητά να κάνετε μια δωρεά στο <a href=\"%(charity_url)s\">%(charity_name)s</a> <a "
-"href=\"%(paypal_url)s\">PayPal</a>."
+"Για να δείξετε την υποστήριξη σας στο/στα <b>%(addon_name)s</b>, ο προγραμματιστής ζητά να κάνετε μια δωρεά στο <a href=\"%(charity_url)s\">%(charity_name)s</a> <a href=\"%(paypal_url)s\">PayPal</"
+"a>."
 
 #: src/olympia/addons/templates/addons/contributions_lightbox.html:30
 msgid "How much would you like to contribute?"
@@ -370,7 +372,7 @@ msgid "Add-on Information for {0}"
 msgstr "Πληροφορίες πρόσθετου για το {0}"
 
 #: src/olympia/addons/templates/addons/details_box.html:30 src/olympia/addons/templates/addons/persona_detail_table.html:3 src/olympia/addons/templates/addons/mobile/details.html:63
-#: src/olympia/addons/templates/addons/mobile/persona_detail_table.html:7 src/olympia/browse/views.py:459 src/olympia/devhub/views.py:75
+#: src/olympia/addons/templates/addons/mobile/persona_detail_table.html:7 src/olympia/browse/views.py:426 src/olympia/devhub/views.py:73
 msgid "Updated"
 msgstr "Ενημερωμένα"
 
@@ -389,11 +391,11 @@ msgstr "Δουλεύει με τον"
 msgid "Visibility"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/details_box.html:57 src/olympia/devhub/templates/devhub/index.html:94 src/olympia/devhub/templates/devhub/includes/addon_details.html:104
+#: src/olympia/addons/templates/addons/details_box.html:57 src/olympia/devhub/templates/devhub/index.html:94 src/olympia/devhub/templates/devhub/includes/addon_details.html:91
 msgid "Hidden"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/details_box.html:59 src/olympia/devhub/templates/devhub/index.html:96 src/olympia/devhub/templates/devhub/includes/addon_details.html:106
+#: src/olympia/addons/templates/addons/details_box.html:59 src/olympia/devhub/templates/devhub/index.html:96 src/olympia/devhub/templates/devhub/includes/addon_details.html:93
 msgid "Unlisted"
 msgstr ""
 
@@ -401,13 +403,13 @@ msgstr ""
 msgid "Required Add-ons"
 msgstr "Απαιτούμενα πρόσθετα"
 
-#: src/olympia/addons/templates/addons/details_box.html:81 src/olympia/addons/templates/addons/persona_detail_table.html:15 src/olympia/browse/views.py:462 src/olympia/devhub/views.py:78
-#: src/olympia/devhub/views.py:85 src/olympia/discovery/templates/discovery/addons/detail.html:57 src/olympia/reviews/forms.py:62 src/olympia/reviews/templates/reviews/add.html:57
+#: src/olympia/addons/templates/addons/details_box.html:81 src/olympia/addons/templates/addons/persona_detail_table.html:15 src/olympia/browse/views.py:429 src/olympia/devhub/views.py:76
+#: src/olympia/devhub/views.py:83 src/olympia/discovery/templates/discovery/addons/detail.html:57 src/olympia/reviews/forms.py:62 src/olympia/reviews/templates/reviews/add.html:57
 #: src/olympia/reviews/templates/reviews/mobile/review_list.html:18
 msgid "Rating"
 msgstr "Βαθμολογία"
 
-#: src/olympia/addons/templates/addons/details_box.html:85 src/olympia/browse/views.py:461 src/olympia/devhub/views.py:77 src/olympia/devhub/views.py:84
+#: src/olympia/addons/templates/addons/details_box.html:85 src/olympia/browse/views.py:428 src/olympia/devhub/views.py:75 src/olympia/devhub/views.py:82
 #: src/olympia/stats/templates/stats/addon_report_menu.html:8 src/olympia/stats/templates/stats/collection_report_menu.html:18
 msgid "Downloads"
 msgstr "Λήψεις"
@@ -427,7 +429,7 @@ msgstr "Αναφορές κατάχρησης"
 
 #. The Privacy Policy for this add-on.
 #: src/olympia/addons/templates/addons/details_box.html:121 src/olympia/addons/templates/addons/privacy.html:19 src/olympia/addons/templates/addons/privacy.html:23
-#: src/olympia/addons/templates/addons/impala/button.html:43 src/olympia/addons/templates/addons/impala/details.html:307 src/olympia/devhub/templates/devhub/includes/policy_form.html:20
+#: src/olympia/addons/templates/addons/impala/button.html:43 src/olympia/addons/templates/addons/impala/details.html:312 src/olympia/devhub/templates/devhub/includes/policy_form.html:23
 #: src/olympia/templates/mobile/base_addons.html:87
 msgid "Privacy Policy"
 msgstr "Πολιτική απορρήτου"
@@ -452,7 +454,7 @@ msgstr "Συλλογή εικόνων"
 msgid "Developer Comments"
 msgstr "Σχόλια δημιουργού"
 
-#: src/olympia/addons/templates/addons/details_box.html:199 src/olympia/addons/templates/addons/impala/details.html:259
+#: src/olympia/addons/templates/addons/details_box.html:199 src/olympia/addons/templates/addons/impala/details.html:264
 msgid "Development Channel"
 msgstr "Κανάλι ανάπτυξης"
 
@@ -476,13 +478,13 @@ msgstr ""
 "<strong>Προσοχή:</strong> Οι υπό ανάπτυξη εκδόσεις αυτού του πρόσθετου δεν έχουν αξιολογηθεί από το Mozilla. Αφού εγκαταστήσετε μια έκδοση υπό ανάπτυξη, θα λαμβάνετε ενημερώσεις από τον δημιουργό "
 "του. Για να σταματήσετε να λαμβάνετε νέες εκδόσεις υπό ανάπτυξη, εγκαταστήσετε ξανά τη σταθερή έκδοση του πρόσθετου από τον παραπάνω δεσμό."
 
-#: src/olympia/addons/templates/addons/details_box.html:220 src/olympia/addons/templates/addons/impala/details.html:278
+#: src/olympia/addons/templates/addons/details_box.html:220 src/olympia/addons/templates/addons/impala/details.html:283
 msgid "Version {0}:"
 msgstr "Έκδοση {0}:"
 
 #: src/olympia/addons/templates/addons/details_box.html:234
-msgid "Nothing to see here! The developer did not include any details."
-msgstr "Ο δημιουργός δεν έχει συμπεριλάβει λεπτομέριες. Δεν υπάρχει τίποτα για προβολή."
+msgid "Nothing to see here!  The developer did not include any details."
+msgstr ""
 
 #: src/olympia/addons/templates/addons/details_box.html:251 src/olympia/devhub/templates/devhub/versions/edit.html:73 src/olympia/editors/templates/editors/review.html:98
 msgid "Version Notes"
@@ -495,7 +497,7 @@ msgid "End-User License Agreement for {0}"
 msgstr "Αδειοδότηση τελικού χρήστη για το {0}"
 
 #: src/olympia/addons/templates/addons/eula.html:17 src/olympia/addons/templates/addons/eula.html:21 src/olympia/addons/templates/addons/impala/button.html:48
-#: src/olympia/addons/templates/addons/impala/details.html:316 src/olympia/devhub/templates/devhub/includes/policy_form.html:3 src/olympia/discovery/templates/discovery/addons/eula.html:11
+#: src/olympia/addons/templates/addons/impala/details.html:321 src/olympia/devhub/templates/devhub/includes/policy_form.html:3 src/olympia/discovery/templates/discovery/addons/eula.html:11
 msgid "End-User License Agreement"
 msgstr "Αδειοδότηση τελικού χρήστη (EULA)"
 
@@ -515,7 +517,7 @@ msgstr "Πίσω στο {0}..."
 msgid "Add-ons for {0}"
 msgstr "Πρόσθετα {0}"
 
-#: src/olympia/addons/templates/addons/home.html:10 src/olympia/addons/templates/addons/home.html:51 src/olympia/browse/templates/browse/impala/base_listing.html:11
+#: src/olympia/addons/templates/addons/home.html:10 src/olympia/addons/templates/addons/home.html:53 src/olympia/browse/templates/browse/impala/base_listing.html:11
 msgid "Featured Extensions"
 msgstr "Προβεβλημένες επεκτάσεις"
 
@@ -523,29 +525,29 @@ msgstr "Προβεβλημένες επεκτάσεις"
 msgid "Popular Extensions"
 msgstr "Δημοφιλείς επεκτάσεις"
 
-#: src/olympia/addons/templates/addons/home.html:42 src/olympia/amo/templates/amo/side_nav.html:3 src/olympia/amo/templates/amo/side_nav.html:11 src/olympia/amo/templates/amo/site_nav.html:3
-#: src/olympia/amo/templates/amo/site_nav.html:25 src/olympia/browse/views.py:236 src/olympia/browse/views.py:281 src/olympia/browse/views.py:481
+#: src/olympia/addons/templates/addons/home.html:44 src/olympia/amo/templates/amo/side_nav.html:3 src/olympia/amo/templates/amo/side_nav.html:11 src/olympia/amo/templates/amo/site_nav.html:3
+#: src/olympia/amo/templates/amo/site_nav.html:25 src/olympia/browse/views.py:203 src/olympia/browse/views.py:248 src/olympia/browse/views.py:448
 msgid "Most Popular"
 msgstr "Δημοφιλέστερα"
 
-#: src/olympia/addons/templates/addons/home.html:43
+#: src/olympia/addons/templates/addons/home.html:45
 msgid "All »"
 msgstr "Όλα »"
 
-#: src/olympia/addons/templates/addons/home.html:52 src/olympia/addons/templates/addons/home.html:61 src/olympia/addons/templates/addons/home.html:70 src/olympia/addons/templates/addons/home.html:78
+#: src/olympia/addons/templates/addons/home.html:54 src/olympia/addons/templates/addons/home.html:63 src/olympia/addons/templates/addons/home.html:72 src/olympia/addons/templates/addons/home.html:80
 #: src/olympia/browse/templates/browse/impala/category_landing.html:36
 msgid "See all »"
 msgstr "Δείτε τα όλα »"
 
-#: src/olympia/addons/templates/addons/home.html:60
+#: src/olympia/addons/templates/addons/home.html:62
 msgid "Up &amp; Coming Extensions"
 msgstr "Επερχόμενες επεκτάσεις"
 
-#: src/olympia/addons/templates/addons/home.html:69 src/olympia/browse/templates/browse/personas/category_landing.html:61 src/olympia/discovery/templates/discovery/pane.html:74
+#: src/olympia/addons/templates/addons/home.html:71 src/olympia/browse/templates/browse/personas/category_landing.html:61 src/olympia/discovery/templates/discovery/pane.html:74
 msgid "Featured Themes"
 msgstr "Προβεβλημένα θέματα"
 
-#: src/olympia/addons/templates/addons/home.html:77 src/olympia/bandwagon/templates/bandwagon/impala/collection_listing.html:5
+#: src/olympia/addons/templates/addons/home.html:79 src/olympia/bandwagon/templates/bandwagon/impala/collection_listing.html:5
 msgid "Featured Collections"
 msgstr "Προβεβλημένες συλλογές"
 
@@ -563,9 +565,9 @@ msgid "Updated {0}"
 msgstr "Ενημερώθηκε {0}"
 
 #. {0} is a date.
-#: src/olympia/addons/templates/addons/macros.html:10 src/olympia/addons/templates/addons/macros.html:69 src/olympia/addons/templates/addons/persona_preview.html:21
-#: src/olympia/addons/templates/addons/listing/items_mobile.html:44 src/olympia/addons/templates/addons/listing/macros.html:39 src/olympia/bandwagon/templates/bandwagon/collection_listing_items.html:37
-#: src/olympia/bandwagon/templates/bandwagon/impala/collection_listing_items.html:37
+#: src/olympia/addons/templates/addons/macros.html:10 src/olympia/addons/templates/addons/macros.html:69 src/olympia/addons/templates/addons/persona_preview.html:22
+#: src/olympia/addons/templates/addons/listing/items_mobile.html:44 src/olympia/addons/templates/addons/listing/macros.html:39
+#: src/olympia/bandwagon/templates/bandwagon/collection_listing_items.html:37 src/olympia/bandwagon/templates/bandwagon/impala/collection_listing_items.html:37
 msgid "Added {0}"
 msgstr "Προστέθηκε {0}"
 
@@ -584,15 +586,14 @@ msgstr[0] "%(num)s χρήστης"
 msgstr[1] "%(num)s χρήστες"
 
 #. {0} is the number of downloads.
-#: src/olympia/addons/templates/addons/macros.html:53 src/olympia/addons/templates/addons/impala/details.html:61
+#: src/olympia/addons/templates/addons/macros.html:53 src/olympia/addons/templates/addons/impala/details.html:59
 msgid "{0} weekly download"
 msgid_plural "{0} weekly downloads"
 msgstr[0] "{0} εβδομαδιαία λήψη"
 msgstr[1] "{0} εβδομαδιαίες λήψεις"
 
 #. {0} is the number of users.
-#: src/olympia/addons/templates/addons/macros.html:61 src/olympia/addons/templates/addons/impala/details.html:54 src/olympia/compat/templates/compat/index.html:71
-#: src/olympia/zadmin/templates/zadmin/compat.html:67
+#: src/olympia/addons/templates/addons/macros.html:61 src/olympia/addons/templates/addons/impala/details.html:52 src/olympia/zadmin/templates/zadmin/compat.html:67
 msgid "{0} user"
 msgid_plural "{0} users"
 msgstr[0] "{0} χρήστης"
@@ -610,7 +611,7 @@ msgstr "Ολοκληρώθηκε η πληρωμή"
 msgid "Return to the addon."
 msgstr "Επιστροφή στο πρόσθετο."
 
-#: src/olympia/addons/templates/addons/persona_detail.html:17 src/olympia/addons/templates/addons/impala/details.html:106 src/olympia/addons/templates/addons/mobile/details.html:23
+#: src/olympia/addons/templates/addons/persona_detail.html:17 src/olympia/addons/templates/addons/impala/details.html:103 src/olympia/addons/templates/addons/mobile/details.html:23
 #: src/olympia/addons/templates/addons/mobile/persona_detail.html:21 src/olympia/discovery/templates/discovery/addons/base.html:27 src/olympia/editors/templates/editors/review.html:31
 msgid "by"
 msgstr "από"
@@ -654,34 +655,35 @@ msgstr "Καθημερινοί χρήστες"
 msgid "License"
 msgstr "Άδεια"
 
-#: src/olympia/addons/templates/addons/persona_preview.html:12 src/olympia/constants/base.py:48
+#: src/olympia/addons/templates/addons/persona_preview.html:13 src/olympia/constants/base.py:48
 msgid "Awaiting Review"
 msgstr "Αναμένεται αξιολόγηση"
 
-#: src/olympia/addons/templates/addons/persona_preview.html:14 src/olympia/amo/log.py:180 src/olympia/constants/base.py:42 src/olympia/editors/helpers.py:62
+#: src/olympia/addons/templates/addons/persona_preview.html:15 src/olympia/amo/log.py:180 src/olympia/constants/base.py:42 src/olympia/editors/helpers.py:62
 msgid "Rejected"
 msgstr "Απορίφθηκε"
 
-#: src/olympia/addons/templates/addons/persona_preview.html:16 src/olympia/amo/log.py:159
+#: src/olympia/addons/templates/addons/persona_preview.html:17 src/olympia/amo/log.py:159
 msgid "Approved"
 msgstr "Εγκρίθηκε"
 
 #. {0} is the number of users.
-#: src/olympia/addons/templates/addons/persona_preview.html:26 src/olympia/addons/templates/addons/listing/items_mobile.html:36 src/olympia/addons/templates/addons/listing/macros.html:31
+#: src/olympia/addons/templates/addons/persona_preview.html:27 src/olympia/addons/templates/addons/listing/items_mobile.html:36 src/olympia/addons/templates/addons/listing/macros.html:31
 msgid "<strong>{0}</strong> user"
 msgid_plural "<strong>{0}</strong> users"
 msgstr[0] "<strong>{0}</strong> χρήστης"
 msgstr[1] "<strong>{0}</strong> χρήστες"
 
-#: src/olympia/addons/templates/addons/persona_preview.html:40
+#: src/olympia/addons/templates/addons/persona_preview.html:41
 msgid "Hover to Preview"
 msgstr "Περάστε από πάνω για προεπισκόπηση"
 
-#: src/olympia/addons/templates/addons/persona_preview.html:46 src/olympia/addons/templates/addons/persona_preview.html:48 src/olympia/reviews/templates/reviews/add.html:15
+#: src/olympia/addons/templates/addons/persona_preview.html:47 src/olympia/addons/templates/addons/persona_preview.html:49 src/olympia/addons/templates/addons/persona_preview.html:97
+#: src/olympia/reviews/templates/reviews/add.html:15
 msgid "Add"
 msgstr "Προσθήκη"
 
-#: src/olympia/addons/templates/addons/persona_preview.html:57 src/olympia/bandwagon/templates/bandwagon/ajax_new.html:16 src/olympia/bandwagon/templates/bandwagon/edit.html:19
+#: src/olympia/addons/templates/addons/persona_preview.html:58 src/olympia/bandwagon/templates/bandwagon/ajax_new.html:16 src/olympia/bandwagon/templates/bandwagon/edit.html:19
 #: src/olympia/bandwagon/templates/bandwagon/includes/addedit.html:19 src/olympia/devhub/templates/devhub/addons/edit/admin.html:13 src/olympia/devhub/templates/devhub/addons/edit/basic.html:10
 #: src/olympia/devhub/templates/devhub/addons/edit/details.html:8 src/olympia/devhub/templates/devhub/addons/edit/media.html:6 src/olympia/devhub/templates/devhub/addons/edit/support.html:8
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:9 src/olympia/devhub/templates/devhub/addons/submit/describe.html:29 src/olympia/editors/templates/editors/review.html:257
@@ -690,21 +692,21 @@ msgstr "Επεξεργασία"
 
 #. For datetime formatting, see the table on
 #. http://docs.python.org/library/datetime.html#strftime-and-strptime-behavior
-#: src/olympia/addons/templates/addons/persona_preview.html:66
+#: src/olympia/addons/templates/addons/persona_preview.html:67
 #, python-format
 msgid "%%Y-%%m-%%d"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/persona_preview.html:67
+#: src/olympia/addons/templates/addons/persona_preview.html:68
 msgid "by {0} on {1}"
 msgstr "από {0} την {1}"
 
-#: src/olympia/addons/templates/addons/persona_preview.html:75 src/olympia/reviews/helpers.py:17 src/olympia/reviews/templates/reviews/review_list.html:63
+#: src/olympia/addons/templates/addons/persona_preview.html:76 src/olympia/reviews/helpers.py:17 src/olympia/reviews/templates/reviews/review_list.html:63
 #: src/olympia/reviews/templates/reviews/reviews_link.html:21 src/olympia/reviews/templates/reviews/impala/reviews_link.html:16
 msgid "Not yet rated"
 msgstr "Δεν έχει βαθμολογηθεί ακόμα"
 
-#: src/olympia/addons/templates/addons/persona_preview.html:78
+#: src/olympia/addons/templates/addons/persona_preview.html:79
 msgid "<b>{0}</b> users"
 msgstr "<b>{0}</b> χρήστες"
 
@@ -717,16 +719,16 @@ msgid "Learn more about Firefox"
 msgstr "Μάθετε περισσότερα για τον Firefox"
 
 #: src/olympia/addons/templates/addons/popups.html:22
-msgid "or <b><a class=\"installer\" href=\"{url}\">download anyway</a></b>"
-msgstr "ή κάντε <b><a class=\"installer\" href=\"{url}\">λήψη οπωσδήποτε</a></b>"
+msgid "or <b><a class=\"button installer\" href=\"{url}\">download anyway</a></b>"
+msgstr ""
 
 #: src/olympia/addons/templates/addons/popups.html:26
 msgid ""
 "<strong>How to Install in Thunderbird</strong> <ol> <li>Download and save the file to your hard disk.</li> <li>In Mozilla Thunderbird, open Add-ons from the Tools menu.</li> <li>From the options "
 "button next to the add-on search field, select \"Install Add-on From File...\" and locate the downloaded add-on.</li> </ol>"
 msgstr ""
-"<strong>Πως θα εγκαταστήσετε το Thunderbird</strong> <ol> <li>Κατεβάστε και αποθηκεύστε το αρχείο στο σκληρό σας δίσκο.</li> <li>Στο Mozilla Thunderbird, ανοίξτε τα Πρόσθετα από το μενού "
-"Εργαλεία.</li> <li>Από το κουμπί επιλογές δίπλα στο πεδίο αναζήτησης προσθέτου, επιλέξτε \"Εγκατάσταση προσθέτου από αρχείο...\" και εντοπίστε το πρόσθετο που έχετε κατεβάσει.</li> </ol>"
+"<strong>Πως θα εγκαταστήσετε το Thunderbird</strong> <ol> <li>Κατεβάστε και αποθηκεύστε το αρχείο στο σκληρό σας δίσκο.</li> <li>Στο Mozilla Thunderbird, ανοίξτε τα Πρόσθετα από το μενού Εργαλεία.</"
+"li> <li>Από το κουμπί επιλογές δίπλα στο πεδίο αναζήτησης προσθέτου, επιλέξτε \"Εγκατάσταση προσθέτου από αρχείο...\" και εντοπίστε το πρόσθετο που έχετε κατεβάσει.</li> </ol>"
 
 #: src/olympia/addons/templates/addons/popups.html:41
 msgid "To install this Theme, <b>get Thunderbird</b>, a free and open source email client from Mozilla Messaging and install the Personas Plus add-on."
@@ -811,13 +813,14 @@ msgid "QR code for add-on"
 msgstr "Κώδικας QR για το πρόσθετο"
 
 #: src/olympia/addons/templates/addons/qr_code.html:6
-msgid "Want {0} on your mobile Firefox? Scan this QR code to install directly to your phone. (You'll need a QR reader. Search your phone's marketplace if don't have one.)"
+msgid ""
+"Want {0} on your mobile Firefox?  Scan this QR code to install directly\n"
+"  to your phone.  (You'll need a QR reader.  Search your phone's marketplace if\n"
+"  don't have one.)"
 msgstr ""
-"Θέλετε το {0} στον Firefox του κινητού σας; Σαρώστε τον κωδικό QR για να το εγκαταστήσετε άμεσα στο τηλέφωνο σας. (Θα χρειαστείτε ένα QR reader. Δείτε στις εφαρμογές του τηλεφώνου σας αν δεν έχετε "
-"ήδη ένα.)"
 
 #: src/olympia/addons/templates/addons/report_abuse.html:6 src/olympia/addons/templates/addons/report_abuse_full.html:10 src/olympia/addons/templates/addons/impala/details-more.html:23
-#: src/olympia/addons/templates/addons/impala/details.html:328
+#: src/olympia/addons/templates/addons/impala/details.html:333
 msgid "Report Abuse"
 msgstr "Αναφορά κατάχρησης"
 
@@ -838,9 +841,9 @@ msgstr "Αποστολή αναφοράς"
 #: src/olympia/devhub/templates/devhub/addons/ajax_compat_update.html:36 src/olympia/devhub/templates/devhub/addons/profile.html:44 src/olympia/devhub/templates/devhub/addons/edit/admin.html:104
 #: src/olympia/devhub/templates/devhub/addons/edit/basic.html:155 src/olympia/devhub/templates/devhub/addons/edit/details.html:88 src/olympia/devhub/templates/devhub/addons/edit/support.html:70
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:169 src/olympia/devhub/templates/devhub/addons/forms_shared/media.html:152
-#: src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:44 src/olympia/devhub/templates/devhub/personas/edit.html:222 src/olympia/devhub/templates/devhub/versions/add_file_modal.html:79
-#: src/olympia/devhub/templates/devhub/versions/edit.html:140 src/olympia/devhub/templates/devhub/versions/list.html:208 src/olympia/devhub/templates/devhub/versions/list.html:242
-#: src/olympia/devhub/templates/devhub/versions/list.html:276 src/olympia/devhub/templates/devhub/versions/list.html:317 src/olympia/reviews/templates/reviews/edit_review.html:16
+#: src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:43 src/olympia/devhub/templates/devhub/personas/edit.html:222 src/olympia/devhub/templates/devhub/versions/add_file_modal.html:59
+#: src/olympia/devhub/templates/devhub/versions/edit.html:140 src/olympia/devhub/templates/devhub/versions/list.html:208 src/olympia/devhub/templates/devhub/versions/list.html:239
+#: src/olympia/devhub/templates/devhub/versions/list.html:281 src/olympia/devhub/templates/devhub/versions/list.html:315 src/olympia/reviews/templates/reviews/edit_review.html:16
 #: src/olympia/translations/templates/translations/trans-menu.html:50 src/olympia/translations/templates/translations/trans-menu.html:62 src/olympia/zadmin/templates/zadmin/validation.html:105
 msgid "Cancel"
 msgstr "Ακύρωση"
@@ -887,7 +890,7 @@ msgstr "Δείτε το <a href=\"%(support)s\">τμήμα υποστήριξη�
 msgid "Review Guidelines"
 msgstr "Οδηγίες σύνταξης αξιολόγησης"
 
-#: src/olympia/addons/templates/addons/review_list_box.html:5 src/olympia/addons/templates/addons/impala/details-more.html:27 src/olympia/editors/helpers.py:921
+#: src/olympia/addons/templates/addons/review_list_box.html:5 src/olympia/addons/templates/addons/impala/details-more.html:27 src/olympia/editors/helpers.py:1001
 #: src/olympia/reviews/templates/reviews/add.html:14 src/olympia/reviews/templates/reviews/reply.html:14 src/olympia/reviews/templates/reviews/review_list.html:19
 #: src/olympia/reviews/templates/reviews/mobile/review_list.html:26
 msgid "Reviews"
@@ -978,31 +981,31 @@ msgid_plural "Other add-ons by these authors"
 msgstr[0] "Άλλα πρόσθετα από τον/την %(author)s"
 msgstr[1] "Άλλα πρόσθετα απ' αυτούς τους δημιουργούς"
 
-#: src/olympia/addons/templates/addons/impala/details.html:41
+#: src/olympia/addons/templates/addons/impala/details.html:39
 #, python-format
 msgid "<span itemprop=\"ratingCount\">%(num)s</span> user review"
 msgid_plural "<span itemprop=\"ratingCount\">%(num)s</span> user reviews"
 msgstr[0] "<span itemprop=\"ratingCount\">%(num)s</span> αξιολόγηση χρήστη"
 msgstr[1] "<span itemprop=\"ratingCount\">%(num)s</span> αξιολογήσεις χρηστών"
 
-#: src/olympia/addons/templates/addons/impala/details.html:69
+#: src/olympia/addons/templates/addons/impala/details.html:66
 msgid "View statistics"
 msgstr "Προβολή στατιστικών"
 
-#: src/olympia/addons/templates/addons/impala/details.html:84
+#: src/olympia/addons/templates/addons/impala/details.html:81
 msgid "Manage"
 msgstr "Διαχείριση"
 
 #. {0} is an add-on name.
-#: src/olympia/addons/templates/addons/impala/details.html:96
+#: src/olympia/addons/templates/addons/impala/details.html:93
 msgid "Icon of {0}"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/impala/details.html:103 src/olympia/addons/templates/addons/impala/listing/items.html:14
+#: src/olympia/addons/templates/addons/impala/details.html:100 src/olympia/addons/templates/addons/impala/listing/items.html:14
 msgid "No Restart"
 msgstr "Δεν απαιτείται επανεκκίνηση"
 
-#: src/olympia/addons/templates/addons/impala/details.html:127
+#: src/olympia/addons/templates/addons/impala/details.html:124
 #, fuzzy, python-format
 msgid "Meet the Developer: <a href=\"%(url)s\">%(name)s</a>"
 msgid_plural "<a href=\"%(url)s\">Meet the Developers</a>"
@@ -1010,72 +1013,72 @@ msgstr[0] "Γνωρίστε τον δημιουργό: <a href=\"%(url)s\">%(nam
 msgstr[1] "<a href=\"%(url)s\">Γνωρίστε τους δημιουργούς</a>"
 
 # {0} is an add-on name.
-#: src/olympia/addons/templates/addons/impala/details.html:137
+#: src/olympia/addons/templates/addons/impala/details.html:134
 msgid "Learn why {0} was created and find out what's next for this add-on."
 msgstr "Μάθετε γιατί δημιουργήθηκε το πρόσθετο {0} και ανακαλύψτε τι σχεδιάζεται για το μέλλον του."
 
 #. {0} is an index.
-#: src/olympia/addons/templates/addons/impala/details.html:156
+#: src/olympia/addons/templates/addons/impala/details.html:161
 msgid "Add-on screenshot #{0}"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/impala/details.html:182
+#: src/olympia/addons/templates/addons/impala/details.html:187
 msgid "Add-on home page"
 msgstr "Αρχική σελίδα πρόσθετου"
 
-#: src/olympia/addons/templates/addons/impala/details.html:185
+#: src/olympia/addons/templates/addons/impala/details.html:190
 msgid "Support site"
 msgstr "Ιστοσελίδα υποστήριξης"
 
-#: src/olympia/addons/templates/addons/impala/details.html:189
+#: src/olympia/addons/templates/addons/impala/details.html:194
 msgid "Support E-mail"
 msgstr "Ε-mail υποστήριξης"
 
-#: src/olympia/addons/templates/addons/impala/details.html:194 src/olympia/devhub/models.py:378 src/olympia/devhub/templates/devhub/versions/list.html:12
+#: src/olympia/addons/templates/addons/impala/details.html:199 src/olympia/devhub/models.py:378 src/olympia/devhub/templates/devhub/versions/list.html:12
 #: src/olympia/versions/templates/versions/version.html:6 src/olympia/versions/templates/versions/mobile/version.html:6
 msgid "Version {0}"
 msgstr "Έκδοση {0}"
 
-#: src/olympia/addons/templates/addons/impala/details.html:194
+#: src/olympia/addons/templates/addons/impala/details.html:199
 msgid "Info"
 msgstr "Πληροφορίες"
 
-#: src/olympia/addons/templates/addons/impala/details.html:195 src/olympia/devhub/templates/devhub/includes/addon_details.html:129
+#: src/olympia/addons/templates/addons/impala/details.html:200 src/olympia/devhub/templates/devhub/includes/addon_details.html:116
 msgid "Last Updated:"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/impala/details.html:200
+#: src/olympia/addons/templates/addons/impala/details.html:205
 #, python-format
 msgid "Released under <a target=\"_blank\" href=\"%(url)s\">%(name)s</a>"
 msgstr "Διατίθεται από <a target=\"_blank\" href=\"%(url)s\">%(name)s</a>"
 
-#: src/olympia/addons/templates/addons/impala/details.html:201 src/olympia/addons/templates/addons/impala/details.html:206 src/olympia/amo/helpers.py:398 src/olympia/devhub/forms.py:142
+#: src/olympia/addons/templates/addons/impala/details.html:206 src/olympia/addons/templates/addons/impala/details.html:211 src/olympia/amo/helpers.py:398 src/olympia/devhub/forms.py:142
 #: src/olympia/devhub/forms.py:173 src/olympia/versions/templates/versions/version.html:40 src/olympia/versions/templates/versions/version.html:45
 msgid "Custom License"
 msgstr "Προσαρμοσμένη άδεια"
 
-#: src/olympia/addons/templates/addons/impala/details.html:205
+#: src/olympia/addons/templates/addons/impala/details.html:210
 #, python-format
 msgid "Released under <a href=\"%(url)s\">%(name)s</a>"
 msgstr "Εκδίδεται σύμφωνα με την <a href=\"%(url)s\">%(name)s</a>"
 
-#: src/olympia/addons/templates/addons/impala/details.html:217
+#: src/olympia/addons/templates/addons/impala/details.html:222
 msgid "About this Add-on"
 msgstr "Σχετικά μ' αυτό το πρόσθετο"
 
-#: src/olympia/addons/templates/addons/impala/details.html:233
+#: src/olympia/addons/templates/addons/impala/details.html:238
 msgid "Developer’s Comments"
 msgstr "Σχόλια δημιουργού"
 
-#: src/olympia/addons/templates/addons/impala/details.html:243
+#: src/olympia/addons/templates/addons/impala/details.html:248
 msgid "Version Information"
 msgstr "Πληροφορίες έκδοσης"
 
-#: src/olympia/addons/templates/addons/impala/details.html:250
+#: src/olympia/addons/templates/addons/impala/details.html:255
 msgid "See complete version history"
 msgstr "Προβολή πλήρους ιστορικού έκδοσης"
 
-#: src/olympia/addons/templates/addons/impala/details.html:262
+#: src/olympia/addons/templates/addons/impala/details.html:267
 msgid ""
 "The Development Channel lets you test an experimental new version of this add-on before it's released to the general public. Once you install the development version, you will continue to get "
 "updates from this channel. To stop receiving development updates, reinstall the default version from the link above."
@@ -1083,17 +1086,17 @@ msgstr ""
 "Το Κανάλι Ανάπτυξης σας επιτρέπει να ελέγξετε μια δοκιμαστική νέα έκδοση αυτού του προσθέτου προτού αυτό διανεμηθεί στο ευρύ κοινό. Αφού εγκαταστήσετε την έκδοση ανάπτυξης, θα συνεχίσετε για να "
 "λάβετε ενημερώσεις από αυτό το κανάλι. Για να σταματήσετε να λαμβάνετε αναπτυξιακές ενημερώσεις, εγκαταστήστε ξανά την προεπιλεγμένη έκδοση από το σύνδεσμο παραπάνω."
 
-#: src/olympia/addons/templates/addons/impala/details.html:272
+#: src/olympia/addons/templates/addons/impala/details.html:277
 msgid "<strong>Caution:</strong> Development versions of this add-on have not been reviewed by Mozilla."
 msgstr ""
 
-#: src/olympia/addons/templates/addons/impala/details.html:287
+#: src/olympia/addons/templates/addons/impala/details.html:292
 msgid "See complete development channel history"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/impala/details.html:306 src/olympia/addons/templates/addons/impala/details.html:315 src/olympia/addons/templates/addons/impala/details.html:327
+#: src/olympia/addons/templates/addons/impala/details.html:311 src/olympia/addons/templates/addons/impala/details.html:320 src/olympia/addons/templates/addons/impala/details.html:332
 #: src/olympia/addons/templates/addons/impala/review_add_box.html:4 src/olympia/stats/templates/stats/popup.html:2 src/olympia/stats/templates/stats/popup.html:8
-#: src/olympia/stats/templates/stats/stats.html:202 src/olympia/users/templates/users/profile.html:119
+#: src/olympia/stats/templates/stats/stats.html:204 src/olympia/users/templates/users/profile.html:119
 msgid "close"
 msgstr "κλείσιμο"
 
@@ -1152,15 +1155,11 @@ msgstr "Άδεια πηγαίου κώδικα του πρόσθετου {addon}
 msgid "Source Code License"
 msgstr "Άδεια πηγαίου κώδικα"
 
-#: src/olympia/addons/templates/addons/impala/persona_grid.html:16 src/olympia/addons/templates/addons/impala/toplist.html:6
-msgid "{0} users"
-msgstr "{0} χρήστες"
-
 #: src/olympia/addons/templates/addons/impala/review_list_box.html:19 src/olympia/reviews/templates/reviews/review.html:40
 msgid "permalink"
 msgstr "μόνιμος σύνδεσμος"
 
-#: src/olympia/addons/templates/addons/impala/review_list_box.html:23 src/olympia/editors/templates/editors/queue.html:98 src/olympia/reviews/templates/reviews/review.html:44
+#: src/olympia/addons/templates/addons/impala/review_list_box.html:23 src/olympia/editors/templates/editors/queue.html:104 src/olympia/reviews/templates/reviews/review.html:44
 msgid "translate"
 msgstr ""
 
@@ -1179,6 +1178,10 @@ msgstr "Αυτό το πρόσθετο δεν έχει αξιολογηθεί α
 msgid "Be the first!"
 msgstr "Γίνε ο πρώτος!"
 
+#: src/olympia/addons/templates/addons/impala/toplist.html:6
+msgid "{0} users"
+msgstr "{0} χρήστες"
+
 #: src/olympia/addons/templates/addons/impala/listing/sorter.html:14 src/olympia/devhub/templates/devhub/addons/listing/item_actions.html:49
 msgid "More"
 msgstr "Περισσότερα"
@@ -1191,7 +1194,7 @@ msgstr "Προσθήκη σε συλλογή"
 msgid "My Add-ons"
 msgstr "Τα πρόσθετά μου"
 
-#: src/olympia/addons/templates/addons/includes/dashboard_tabs.html:6 src/olympia/amo/context_processors.py:51
+#: src/olympia/addons/templates/addons/includes/dashboard_tabs.html:6 src/olympia/amo/context_processors.py:50
 msgid "My Themes"
 msgstr "Τα θέματα μου"
 
@@ -1246,7 +1249,7 @@ msgstr "Χρήστες"
 msgid "Weekly Downloads"
 msgstr "Εβδομαδιαίες λήψεις"
 
-#: src/olympia/addons/templates/addons/mobile/details.html:99 src/olympia/compat/templates/compat/reporter_detail.html:46 src/olympia/devhub/forms.py:787
+#: src/olympia/addons/templates/addons/mobile/details.html:99 src/olympia/compat/templates/compat/reporter_detail.html:46 src/olympia/devhub/forms.py:788
 #: src/olympia/devhub/templates/devhub/versions/list.html:163
 msgid "Version"
 msgstr "Έκδοση"
@@ -1304,8 +1307,9 @@ msgstr "Επιστροφή στην αρχική σελίδα των πρόσθ�
 
 # Χωρίς τόνο λόγω του text-transform: uppercase
 #: src/olympia/addons/templates/addons/mobile/home.html:21 src/olympia/amo/helpers.py:237 src/olympia/bandwagon/templates/bandwagon/edit.html:34 src/olympia/discovery/templates/discovery/pane.html:92
-#: src/olympia/editors/templates/editors/base.html:21 src/olympia/editors/templates/editors/performance.html:72 src/olympia/templates/menu_links.html:4 src/olympia/templates/impala/header_title.html:13
-#: src/olympia/templates/impala/header_title.html:15 src/olympia/templates/impala/header_title.html:19 src/olympia/templates/impala/header_title.html:23 src/olympia/templates/mobile/base_addons.html:47
+#: src/olympia/editors/templates/editors/base.html:21 src/olympia/editors/templates/editors/performance.html:72 src/olympia/templates/menu_links.html:4
+#: src/olympia/templates/impala/header_title.html:13 src/olympia/templates/impala/header_title.html:15 src/olympia/templates/impala/header_title.html:19
+#: src/olympia/templates/impala/header_title.html:23 src/olympia/templates/mobile/base_addons.html:47
 msgid "Add-ons"
 msgstr "Προσθετα"
 
@@ -1328,11 +1332,12 @@ msgstr ""
 
 #. {0} is a category name. Ex: "Sports"
 #. {0} is a category name, such as Nature.
-#: src/olympia/addons/templates/addons/mobile/home.html:43 src/olympia/amo/templates/amo/site_nav.html:32 src/olympia/browse/feeds.py:107 src/olympia/browse/templates/browse/impala/base_listing.html:38
-#: src/olympia/browse/templates/browse/personas/base.html:6 src/olympia/browse/templates/browse/personas/base.html:42 src/olympia/browse/templates/browse/personas/category_landing.html:21
-#: src/olympia/browse/templates/browse/personas/category_landing.html:23 src/olympia/browse/templates/browse/personas/category_landing.html:38 src/olympia/browse/templates/browse/personas/grid.html:7
-#: src/olympia/browse/templates/browse/personas/grid.html:11 src/olympia/browse/templates/browse/personas/mobile/base.html:7 src/olympia/browse/templates/browse/personas/mobile/category_landing.html:19
-#: src/olympia/constants/base.py:180 src/olympia/devhub/templates/devhub/personas/submit.html:13 src/olympia/editors/helpers.py:105 src/olympia/editors/templates/editors/base.html:26
+#: src/olympia/addons/templates/addons/mobile/home.html:43 src/olympia/amo/templates/amo/site_nav.html:32 src/olympia/browse/feeds.py:107
+#: src/olympia/browse/templates/browse/impala/base_listing.html:38 src/olympia/browse/templates/browse/personas/base.html:6 src/olympia/browse/templates/browse/personas/base.html:42
+#: src/olympia/browse/templates/browse/personas/category_landing.html:21 src/olympia/browse/templates/browse/personas/category_landing.html:23
+#: src/olympia/browse/templates/browse/personas/category_landing.html:38 src/olympia/browse/templates/browse/personas/grid.html:7 src/olympia/browse/templates/browse/personas/grid.html:11
+#: src/olympia/browse/templates/browse/personas/mobile/base.html:7 src/olympia/browse/templates/browse/personas/mobile/category_landing.html:19 src/olympia/constants/base.py:180
+#: src/olympia/devhub/templates/devhub/personas/submit.html:13 src/olympia/editors/helpers.py:107 src/olympia/editors/templates/editors/base.html:26
 #: src/olympia/editors/templates/editors/performance.html:73 src/olympia/search/templates/search/personas.html:39 src/olympia/templates/menu_links.html:9
 msgid "Themes"
 msgstr "Θέματα"
@@ -1353,7 +1358,7 @@ msgstr "Περισσότερα πρόσθετα"
 msgid "Highest Rated"
 msgstr "Υψηλότερες βαθμολογίες"
 
-#: src/olympia/addons/templates/addons/mobile/home.html:74 src/olympia/amo/templates/amo/side_nav.html:5 src/olympia/amo/templates/amo/site_nav.html:27 src/olympia/amo/templates/amo/site_nav.html:57
+#: src/olympia/addons/templates/addons/mobile/home.html:74 src/olympia/amo/templates/amo/side_nav.html:5 src/olympia/amo/templates/amo/site_nav.html:27 src/olympia/amo/templates/amo/site_nav.html:55
 #: src/olympia/bandwagon/views.py:97 src/olympia/browse/views.py:57 src/olympia/browse/views.py:67 src/olympia/browse/templates/browse/personas/mobile/category_landing.html:65
 #: src/olympia/search/forms.py:15 src/olympia/search/forms.py:87
 msgid "Newest"
@@ -1367,88 +1372,90 @@ msgstr "Δοκιμάστε το!"
 msgid "Theme Info &raquo;"
 msgstr "Πληροφορίες θέματος &raquo;"
 
-#: src/olympia/amo/context_processors.py:39 src/olympia/devhub/templates/devhub/nav.html:43
+#: src/olympia/amo/context_processors.py:37 src/olympia/devhub/templates/devhub/nav.html:43
 msgid "Tools"
 msgstr "Εργαλεία"
 
-#: src/olympia/amo/context_processors.py:48 src/olympia/discovery/templates/discovery/pane_account.html:8 src/olympia/users/templates/users/includes/navigation.html:2
+#: src/olympia/amo/context_processors.py:47 src/olympia/discovery/templates/discovery/pane_account.html:8 src/olympia/users/templates/users/includes/navigation.html:2
 msgid "My Profile"
 msgstr "Το προφίλ μου"
 
-#: src/olympia/amo/context_processors.py:54 src/olympia/users/templates/users/edit.html:5 src/olympia/users/templates/users/includes/navigation.html:3
+#: src/olympia/amo/context_processors.py:53 src/olympia/users/templates/users/edit.html:5 src/olympia/users/templates/users/includes/navigation.html:3
 msgid "Account Settings"
 msgstr "Ρυθμίσεις λογαριασμού"
 
-#: src/olympia/amo/context_processors.py:57 src/olympia/discovery/templates/discovery/pane_account.html:11 src/olympia/users/templates/users/profile.html:83
+#: src/olympia/amo/context_processors.py:56 src/olympia/discovery/templates/discovery/pane_account.html:11 src/olympia/users/templates/users/profile.html:83
 #: src/olympia/users/templates/users/includes/navigation.html:4
 msgid "My Collections"
 msgstr "Οι συλλογές μου"
 
-#: src/olympia/amo/context_processors.py:62 src/olympia/discovery/templates/discovery/pane_account.html:10 src/olympia/users/templates/users/includes/navigation.html:7
+#: src/olympia/amo/context_processors.py:61 src/olympia/discovery/templates/discovery/pane_account.html:10 src/olympia/users/templates/users/includes/navigation.html:7
 msgid "My Favorites"
 msgstr "Οι αγαπημένες μου"
 
-#: src/olympia/amo/context_processors.py:67 src/olympia/discovery/templates/discovery/pane_account.html:13 src/olympia/templates/impala/user_login.html:14 src/olympia/templates/mobile/header_auth.html:5
+#: src/olympia/amo/context_processors.py:66 src/olympia/discovery/templates/discovery/pane_account.html:13 src/olympia/templates/impala/user_login.html:14
+#: src/olympia/templates/mobile/header_auth.html:5
 msgid "Log out"
 msgstr "Αποσύνδεση"
 
-#: src/olympia/amo/context_processors.py:72 src/olympia/devhub/templates/devhub/addons/dashboard.html:4
+#: src/olympia/amo/context_processors.py:71 src/olympia/devhub/templates/devhub/addons/dashboard.html:4
 msgid "Manage My Submissions"
 msgstr "Διαχείτιση των υποβολών μου"
 
-#: src/olympia/amo/context_processors.py:75 src/olympia/devhub/templates/devhub/nav.html:27 src/olympia/devhub/templates/devhub/addons/dashboard.html:25
+#: src/olympia/amo/context_processors.py:74 src/olympia/devhub/templates/devhub/nav.html:27 src/olympia/devhub/templates/devhub/addons/dashboard.html:25
 #: src/olympia/devhub/templates/devhub/addons/submit/base.html:4
 msgid "Submit a New Add-on"
 msgstr "Υποβολή νέου πρόσθετου"
 
-#: src/olympia/amo/context_processors.py:77 src/olympia/browse/templates/browse/personas/base.html:50 src/olympia/devhub/templates/devhub/index.html:24
+#: src/olympia/amo/context_processors.py:76 src/olympia/browse/templates/browse/personas/base.html:50 src/olympia/devhub/templates/devhub/index.html:24
 #: src/olympia/devhub/templates/devhub/addons/dashboard.html:29
 msgid "Submit a New Theme"
 msgstr "Υποβολή νέου θέματος"
 
-#: src/olympia/amo/context_processors.py:79 src/olympia/amo/templates/amo/site_nav.html:87 src/olympia/devhub/helpers.py:36 src/olympia/devhub/helpers.py:68 src/olympia/devhub/helpers.py:102
+#: src/olympia/amo/context_processors.py:78 src/olympia/amo/templates/amo/site_nav.html:85 src/olympia/devhub/helpers.py:36 src/olympia/devhub/helpers.py:68 src/olympia/devhub/helpers.py:102
 #: src/olympia/templates/footer.html:6 src/olympia/templates/menu_links.html:14
 msgid "Developer Hub"
 msgstr "Γωνιά προγραμματιστών"
 
-#: src/olympia/amo/context_processors.py:83 src/olympia/devhub/views.py:1792
+#: src/olympia/amo/context_processors.py:81 src/olympia/devhub/views.py:1796
 msgid "Manage API Keys"
 msgstr ""
 
-#: src/olympia/amo/context_processors.py:88 src/olympia/editors/helpers.py:82 src/olympia/editors/helpers.py:102 src/olympia/editors/templates/editors/base.html:10
+#: src/olympia/amo/context_processors.py:86 src/olympia/editors/helpers.py:84 src/olympia/editors/helpers.py:104 src/olympia/editors/templates/editors/base.html:10
 msgid "Editor Tools"
 msgstr "Εργαλεία συντακτών"
 
-#: src/olympia/amo/context_processors.py:92
+#: src/olympia/amo/context_processors.py:90
 msgid "Admin Tools"
 msgstr "Εργαλεία διαχειριστών"
 
-#: src/olympia/amo/fields.py:15
+#: src/olympia/amo/fields.py:20
 msgid "Incorrect, please try again."
 msgstr ""
 
-#: src/olympia/amo/fields.py:16
+#: src/olympia/amo/fields.py:21
 msgid "Error verifying input, please try again."
 msgstr ""
 
-#: src/olympia/amo/fields.py:32
+#: src/olympia/amo/fields.py:37
 msgid "This must be a valid hex color code, such as #000000."
 msgstr "Θα πρέπει να είναι μια έγκυρη δεκαεξαδική τιμή χρώματος, όπως η #000000."
 
-#: src/olympia/amo/fields.py:58
+#: src/olympia/amo/fields.py:63
 msgid "Enter at least one value."
 msgstr "Εισάγετε τουλάχιστον μία τιμή."
 
-#: src/olympia/amo/helpers.py:162 src/olympia/amo/templates/amo/site_nav.html:61 src/olympia/bandwagon/templates/bandwagon/add.html:9 src/olympia/bandwagon/templates/bandwagon/collection_detail.html:15
-#: src/olympia/bandwagon/templates/bandwagon/delete.html:9 src/olympia/bandwagon/templates/bandwagon/edit.html:15 src/olympia/bandwagon/templates/bandwagon/user_listing.html:18
-#: src/olympia/bandwagon/templates/bandwagon/user_listing.html:21 src/olympia/bandwagon/templates/bandwagon/impala/collection_listing.html:12
-#: src/olympia/bandwagon/templates/bandwagon/impala/collection_listing.html:20 src/olympia/bandwagon/templates/bandwagon/impala/collection_listing.html:24
-#: src/olympia/bandwagon/templates/bandwagon/impala/collection_sidebar.html:3 src/olympia/bandwagon/templates/bandwagon/includes/collection_sidebar.html:2
-#: src/olympia/bandwagon/templates/bandwagon/mobile/collection_listing.html:3 src/olympia/stats/templates/stats/stats.html:77 src/olympia/templates/menu_links.html:12
+#: src/olympia/amo/helpers.py:162 src/olympia/amo/templates/amo/site_nav.html:59 src/olympia/bandwagon/templates/bandwagon/add.html:9
+#: src/olympia/bandwagon/templates/bandwagon/collection_detail.html:15 src/olympia/bandwagon/templates/bandwagon/delete.html:9 src/olympia/bandwagon/templates/bandwagon/edit.html:15
+#: src/olympia/bandwagon/templates/bandwagon/user_listing.html:18 src/olympia/bandwagon/templates/bandwagon/user_listing.html:21
+#: src/olympia/bandwagon/templates/bandwagon/impala/collection_listing.html:12 src/olympia/bandwagon/templates/bandwagon/impala/collection_listing.html:20
+#: src/olympia/bandwagon/templates/bandwagon/impala/collection_listing.html:24 src/olympia/bandwagon/templates/bandwagon/impala/collection_sidebar.html:3
+#: src/olympia/bandwagon/templates/bandwagon/includes/collection_sidebar.html:2 src/olympia/bandwagon/templates/bandwagon/mobile/collection_listing.html:3
+#: src/olympia/stats/templates/stats/stats.html:33 src/olympia/templates/menu_links.html:12
 msgid "Collections"
 msgstr "Συλλογές"
 
-#: src/olympia/amo/helpers.py:171 src/olympia/amo/templates/amo/site_nav.html:85 src/olympia/browse/templates/browse/language_tools.html:3
+#: src/olympia/amo/helpers.py:171 src/olympia/amo/templates/amo/site_nav.html:83 src/olympia/browse/templates/browse/language_tools.html:3
 msgid "Dictionaries & Language Packs"
 msgstr "Λεξικά & πακέτα γλωσσών"
 
@@ -1600,8 +1607,8 @@ msgstr "Ζητήθηκε υπερ αξιολόγηση"
 msgid "Comment on {addon} {version}."
 msgstr "Σχόλιο για το πρόσθετο {addon} {version}."
 
-#: src/olympia/amo/log.py:236 src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:19 src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:47
-#: src/olympia/editors/helpers.py:511 src/olympia/editors/templates/editors/themes/history_table.html:11
+#: src/olympia/amo/log.py:236 src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:17 src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:45
+#: src/olympia/editors/helpers.py:584 src/olympia/editors/templates/editors/themes/history_table.html:11
 msgid "Comment"
 msgstr "Σχόλιο"
 
@@ -1754,8 +1761,8 @@ msgid "Reviewer escalation"
 msgstr "Κλιμάκωση επιθεωρητή"
 
 #: src/olympia/amo/log.py:442
-msgid "Video removed from {addon} because of a problem with the video."
-msgstr "Το βίντεο αφαιρέθηκε από το {addon} εξαιτίας κάποιου προβλήματος με το βίντεο."
+msgid "Video removed from {addon} because of a problem with the video. "
+msgstr ""
 
 #: src/olympia/amo/log.py:444
 msgid "Video removed"
@@ -1888,18 +1895,18 @@ msgstr "Δεν βρέθηκε"
 #, python-format
 msgid ""
 "<h1>We're sorry, but we can't find what you're looking for.</h1> <p> The page or file you requested wasn't found on our site. It's possible that you clicked a link that's out of date, or typed in "
-"the address incorrectly. </p> <ul> <li>If you typed in the address, please double check the spelling.</li> <li> If you followed a link from somewhere, please let us know at <a "
-"href=\"mailto:webmaster@mozilla.com\">webmaster@mozilla.com</a>. Tell us where you came from and what you were looking for, and we'll do our best to fix it. </li> </ul> <p>Or you can just jump over"
-" to some of the popular pages on our website.</p> <ul> <li>Are you interested in a <a href=\"%(rec)s\">list of featured add-ons</a>?</li> <li> Do you want to <a href=\"%(search)s\">search for add-"
-"ons</a>? You may go to the <a href=\"%(search)s\">search page</a> or just use the search field above. </li> <li> If you prefer to start over, just go to the <a href=\"%(home)s\">add-ons front "
-"page</a>. </li> </ul>"
+"the address incorrectly. </p> <ul> <li>If you typed in the address, please double check the spelling.</li> <li> If you followed a link from somewhere, please let us know at <a href=\"mailto:"
+"webmaster@mozilla.com\">webmaster@mozilla.com</a>. Tell us where you came from and what you were looking for, and we'll do our best to fix it. </li> </ul> <p>Or you can just jump over to some of "
+"the popular pages on our website.</p> <ul> <li>Are you interested in a <a href=\"%(rec)s\">list of featured add-ons</a>?</li> <li> Do you want to <a href=\"%(search)s\">search for add-ons</a>? You "
+"may go to the <a href=\"%(search)s\">search page</a> or just use the search field above. </li> <li> If you prefer to start over, just go to the <a href=\"%(home)s\">add-ons front page</a>. </li> </"
+"ul>"
 msgstr ""
 "<h1>Λυπούμαστε αλλά δεν μπορέσαμε να βρούμε αυτό που αναζητάτε.</h1> <p> Η σελίδα που ζητάτε δεν βρέθηκε στον ιστότοπο μας. Είναι πιθανό να κάνατε κλικ σ' ένα δεσμό που είναι παρωχημένος ή να "
 "πληκτρολογήσατε λάθος διεύθυνση. </p> <ul> <li> Αν πληκτρολογήσατε τη διεύθυνση, παρακαλούμε ελέγξτε την ορθογραφία της.</li> <li> Αν ακολουθήσατε κάποιο δεσμό, παρακαλούμε ενημερώστε μας στη "
 "διεύθυνση <a href=\"mailto:webmaster@mozilla.com\">webmaster@mozilla.com</a>. Πείτε μας από ποια σελίδα βρεθήκατε εδώ και τι αναζητούσατε και θα κάνουμε ό,τι μπορούμε για να διορθώσουμε το "
-"πρόβλημα. </li> </ul> <p>Επίσης, μπορείτε να μεταβείτε σε μια από τις δημοφιλείς σελίδες μας.</p> <ul> <li>Σας ενδιαφέρει μια <a href=\"%(rec)s\">λίστα προβεβλημένων πρόσθετων</a>;</li> <li> Θέλετε"
-" να κάνετε  <a href=\"%(search)s\">αναζήτηση για πρόσθετα</a>; Μπορείτε να πάτε στη <a href=\"%(search)s\">σελίδα αναζήτησης</a> ή απλά να χρησιμοποιήσετε το παραπάνω πεδίο αναζήτησης. </li> <li> "
-"Αν προτιμάτε να ξεκινήσετε απ' την αρχή, δεν έχετε παρά να πάτε στην <a href=\"%(home)s\">αρχική σελίδα των πρόσθετων</a>. </li> </ul>"
+"πρόβλημα. </li> </ul> <p>Επίσης, μπορείτε να μεταβείτε σε μια από τις δημοφιλείς σελίδες μας.</p> <ul> <li>Σας ενδιαφέρει μια <a href=\"%(rec)s\">λίστα προβεβλημένων πρόσθετων</a>;</li> <li> Θέλετε "
+"να κάνετε  <a href=\"%(search)s\">αναζήτηση για πρόσθετα</a>; Μπορείτε να πάτε στη <a href=\"%(search)s\">σελίδα αναζήτησης</a> ή απλά να χρησιμοποιήσετε το παραπάνω πεδίο αναζήτησης. </li> <li> Αν "
+"προτιμάτε να ξεκινήσετε απ' την αρχή, δεν έχετε παρά να πάτε στην <a href=\"%(home)s\">αρχική σελίδα των πρόσθετων</a>. </li> </ul>"
 
 #: src/olympia/amo/templates/amo/500.html:3
 msgid "Oops"
@@ -1907,10 +1914,8 @@ msgstr "Ωπ!"
 
 #: src/olympia/amo/templates/amo/500.html:6
 #, python-format
-msgid "<h1>Oops! We had an error.</h1> <p>We'll get to fixing that soon.</p> <p> You can try refreshing the page, or head back to the <a href=\"%(home)s\">Add-ons homepage</a>. </p>"
+msgid "<h1>Oops!  We had an error.</h1> <p>We'll get to fixing that soon.</p> <p> You can try refreshing the page, or head back to the <a href=\"%(home)s\">Add-ons homepage</a>. </p>"
 msgstr ""
-"<h1>Συγνώμη αλλά παρουσιάστηκε πρόβλημα.</h1> <p>Θα το διορθώσουμε το συντομότερο δυνατό.</p> <p> Μπορείτε να δοκιμάσετε να ανανεώσετε τη σελίδα ή να επιστρέψετε πίσω στην <a "
-"href=\"%(home)s\">αρχική σελίδα των πρόσθετων</a>. </p>"
 
 #: src/olympia/amo/templates/amo/license_link.html:10
 msgid "Some rights reserved"
@@ -1932,7 +1937,7 @@ msgstr "Προηγούμενο"
 #: src/olympia/amo/templates/amo/mobile/paginator.html:14 src/olympia/amo/templates/amo/mobile/paginator.html:16 src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:51
 #: src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:65 src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:78
 #: src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:91 src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:104
-#: src/olympia/discovery/templates/discovery/pane.html:45 src/olympia/discovery/templates/discovery/addons/detail.html:39 src/olympia/stats/templates/stats/stats.html:167
+#: src/olympia/discovery/templates/discovery/pane.html:45 src/olympia/discovery/templates/discovery/addons/detail.html:39 src/olympia/stats/templates/stats/stats.html:169
 msgid "Next"
 msgstr "Επόμενο"
 
@@ -1947,7 +1952,8 @@ msgstr "Εκτελούνται εργασίες συντήρησης"
 
 #: src/olympia/amo/templates/amo/read-only.html:9
 msgid "This feature is temporarily disabled while we perform website maintenance. Please use your browser's Back button and try again a little later."
-msgstr "Αυτό το χαρακτηριστικό απενεργοποιείται προσωρινά όταν εκτελούμε εργασίες συντήρησης. Παρακαλούμε χρησιμοποιήστε το κουμπί μετάβασης προς τα πίσω του περιηγητή σας και προσπαθήστε ξανά αργότερα."
+msgstr ""
+"Αυτό το χαρακτηριστικό απενεργοποιείται προσωρινά όταν εκτελούμε εργασίες συντήρησης. Παρακαλούμε χρησιμοποιήστε το κουμπί μετάβασης προς τα πίσω του περιηγητή σας και προσπαθήστε ξανά αργότερα."
 
 #: src/olympia/amo/templates/amo/read-only.html:14
 msgid "Some features on this page are temporarily disabled while we perform website maintenance. Please try again a little later."
@@ -1964,7 +1970,7 @@ msgid ""
 msgstr ""
 
 #: src/olympia/amo/templates/amo/side_nav.html:4 src/olympia/amo/templates/amo/side_nav.html:12 src/olympia/amo/templates/amo/site_nav.html:4 src/olympia/amo/templates/amo/site_nav.html:26
-#: src/olympia/browse/views.py:56 src/olympia/browse/views.py:66 src/olympia/browse/views.py:237 src/olympia/browse/views.py:282 src/olympia/search/forms.py:86
+#: src/olympia/browse/views.py:56 src/olympia/browse/views.py:66 src/olympia/browse/views.py:204 src/olympia/browse/views.py:249 src/olympia/search/forms.py:86
 msgid "Top Rated"
 msgstr "Υψηλότερη βαθμολογια"
 
@@ -1979,37 +1985,38 @@ msgstr "Ανακαλύψτε"
 msgid "Extensions"
 msgstr "Επεκτάσεις"
 
-#: src/olympia/amo/templates/amo/site_nav.html:45
+#: src/olympia/amo/templates/amo/site_nav.html:44
 msgid "Want more customization? Try <b>Complete Themes</b>"
 msgstr ""
 
-#: src/olympia/amo/templates/amo/site_nav.html:56 src/olympia/bandwagon/views.py:96
+#: src/olympia/amo/templates/amo/site_nav.html:54 src/olympia/bandwagon/views.py:96
 msgid "Most Followers"
 msgstr "Περισσότεροι ακόλουθοι"
 
-#: src/olympia/amo/templates/amo/site_nav.html:68 src/olympia/bandwagon/templates/bandwagon/impala/collection_sidebar.html:16 src/olympia/bandwagon/templates/bandwagon/includes/collection_sidebar.html:18
+#: src/olympia/amo/templates/amo/site_nav.html:66 src/olympia/bandwagon/templates/bandwagon/impala/collection_sidebar.html:16
+#: src/olympia/bandwagon/templates/bandwagon/includes/collection_sidebar.html:18
 msgid "Collections I've Made"
 msgstr "Συλλογές που έχω δημιουργήσει"
 
-#: src/olympia/amo/templates/amo/site_nav.html:70 src/olympia/bandwagon/templates/bandwagon/user_listing.html:4 src/olympia/bandwagon/templates/bandwagon/impala/collection_sidebar.html:13
+#: src/olympia/amo/templates/amo/site_nav.html:68 src/olympia/bandwagon/templates/bandwagon/user_listing.html:4 src/olympia/bandwagon/templates/bandwagon/impala/collection_sidebar.html:13
 #: src/olympia/bandwagon/templates/bandwagon/includes/collection_sidebar.html:15
 msgid "Collections I'm Following"
 msgstr "Συλλογές που παρακολουθώ"
 
-#: src/olympia/amo/templates/amo/site_nav.html:73 src/olympia/bandwagon/templates/bandwagon/impala/collection_sidebar.html:18 src/olympia/bandwagon/templates/bandwagon/includes/collection_sidebar.html:20
-#: src/olympia/users/models.py:512
+#: src/olympia/amo/templates/amo/site_nav.html:71 src/olympia/bandwagon/templates/bandwagon/impala/collection_sidebar.html:18
+#: src/olympia/bandwagon/templates/bandwagon/includes/collection_sidebar.html:20 src/olympia/users/models.py:521
 msgid "My Favorite Add-ons"
 msgstr "Τα αγαπημένα μου πρόσθετα"
 
-#: src/olympia/amo/templates/amo/site_nav.html:78
+#: src/olympia/amo/templates/amo/site_nav.html:76
 msgid "More&hellip;"
 msgstr "Περισσότερα&hellip;"
 
-#: src/olympia/amo/templates/amo/site_nav.html:82
+#: src/olympia/amo/templates/amo/site_nav.html:80
 msgid "Add-ons for Mobile"
 msgstr "Πρόσθετα για κινητά"
 
-#: src/olympia/amo/templates/amo/site_nav.html:86 src/olympia/browse/feeds.py:207 src/olympia/browse/templates/browse/search_tools.html:3 src/olympia/constants/base.py:176
+#: src/olympia/amo/templates/amo/site_nav.html:84 src/olympia/browse/feeds.py:207 src/olympia/browse/templates/browse/search_tools.html:3 src/olympia/constants/base.py:176
 #: src/olympia/templates/menu_links.html:10
 msgid "Search Tools"
 msgstr "Εργαλεία αναζήτησης"
@@ -2025,7 +2032,7 @@ msgid "Jump to first page"
 msgstr "Μετάβαση στην πρώτη σελίδα"
 
 #: src/olympia/amo/templates/amo/impala/paginator.html:22 src/olympia/amo/templates/amo/mobile/impala_paginator.html:12 src/olympia/discovery/templates/discovery/pane.html:44
-#: src/olympia/discovery/templates/discovery/addons/detail.html:38 src/olympia/stats/templates/stats/stats.html:164
+#: src/olympia/discovery/templates/discovery/addons/detail.html:38 src/olympia/stats/templates/stats/stats.html:166
 msgid "Previous"
 msgstr "Προηγούμενο"
 
@@ -2048,31 +2055,50 @@ msgid_plural "Page {n}"
 msgstr[0] "Σελίδα {n}"
 msgstr[1] "Σελίδα{n}"
 
-#: src/olympia/amo/templates/services/install.html:38
-#, python-format
-msgid "If you are not prompted to install %(addon_name)s in a moment, please <a href=\"%(addon_xpi)s\">click here</a>."
-msgstr "Αν δεν σας ζητηθεί η εγκατάσταση %(addon_name)s σε λίγο, παρακαλώ <a href=\"%(addon_xpi)s\">κάντε κλικ εδώ</a>."
-
-#: src/olympia/amo/tests/test_messages.py:57 src/olympia/amo/tests/test_messages.py:58 src/olympia/reviews/forms.py:25 src/olympia/reviews/forms.py:50 src/olympia/reviews/templates/reviews/add.html:56
+#: src/olympia/amo/tests/test_messages.py:56 src/olympia/amo/tests/test_messages.py:57 src/olympia/reviews/forms.py:25 src/olympia/reviews/forms.py:50 src/olympia/reviews/templates/reviews/add.html:56
 #: src/olympia/reviews/templates/reviews/reply.html:30
 msgid "Title"
 msgstr "Τίτλος"
 
-#: src/olympia/amo/tests/test_messages.py:57 src/olympia/amo/tests/test_messages.py:58
+#: src/olympia/amo/tests/test_messages.py:56 src/olympia/amo/tests/test_messages.py:57
 msgid "Body"
 msgstr "Σώμα"
 
-#: src/olympia/amo/tests/test_messages.py:59
+#: src/olympia/amo/tests/test_messages.py:58
 msgid "Another Title"
 msgstr "Άλλος τίτλος"
 
-#: src/olympia/amo/tests/test_messages.py:59
+#: src/olympia/amo/tests/test_messages.py:58
 msgid "Another Body"
 msgstr "Άλλο σώμα"
 
-#: src/olympia/api/views.py:255
-msgid "Not implemented yet."
-msgstr "Δεν έχει ενσωματωθεί ακόμη."
+#: src/olympia/api/authentication.py:76
+msgid "Signature has expired."
+msgstr ""
+
+#: src/olympia/api/authentication.py:79
+msgid "Error decoding signature."
+msgstr ""
+
+#: src/olympia/api/authentication.py:82
+msgid "Invalid JWT Token."
+msgstr ""
+
+#: src/olympia/api/authentication.py:130
+msgid "Invalid Authorization header. No credentials provided."
+msgstr ""
+
+#: src/olympia/api/authentication.py:133
+msgid "Invalid Authorization header. Credentials string should not contain spaces."
+msgstr ""
+
+#: src/olympia/api/fields.py:29
+msgid "The field must have a length of at least {num} characters."
+msgstr ""
+
+#: src/olympia/api/fields.py:31
+msgid "The language code {lang_code} is invalid."
+msgstr ""
 
 #: src/olympia/applications/views.py:39 src/olympia/applications/templates/applications/appversions.html:3
 msgid "Application Versions"
@@ -2090,7 +2116,7 @@ msgstr "Έγκυρες εκδόσεις εφαρμογής"
 msgid "Add-ons submitted to Mozilla Add-ons must have a manifest file with at least one of the below applications supported. Only the versions listed below are allowed for these applications."
 msgstr ""
 
-#: src/olympia/applications/templates/applications/appversions.html:25
+#: src/olympia/applications/templates/applications/appversions.html:25 src/olympia/editors/helpers.py:361
 msgid "GUID"
 msgstr "GUID"
 
@@ -2204,8 +2230,8 @@ msgstr "Αγαπημένη"
 msgid "Remove from favorites"
 msgstr "Αφαίρεση από τις αγαπημένες"
 
-#: src/olympia/bandwagon/views.py:98 src/olympia/bandwagon/views.py:191 src/olympia/browse/views.py:58 src/olympia/browse/views.py:69 src/olympia/browse/views.py:458 src/olympia/devhub/views.py:74
-#: src/olympia/devhub/views.py:82 src/olympia/devhub/templates/devhub/addons/edit/basic.html:20 src/olympia/editors/templates/editors/leaderboard.html:24
+#: src/olympia/bandwagon/views.py:98 src/olympia/bandwagon/views.py:191 src/olympia/browse/views.py:58 src/olympia/browse/views.py:69 src/olympia/browse/views.py:425 src/olympia/devhub/views.py:72
+#: src/olympia/devhub/views.py:80 src/olympia/devhub/templates/devhub/addons/edit/basic.html:20 src/olympia/editors/templates/editors/leaderboard.html:24
 #: src/olympia/editors/templates/editors/themes/queue_list.html:48 src/olympia/search/forms.py:17 src/olympia/search/forms.py:89 src/olympia/users/templates/users/vcard.html:5
 msgid "Name"
 msgstr "Όνομα"
@@ -2214,7 +2240,7 @@ msgstr "Όνομα"
 msgid "Recently Popular"
 msgstr "Πρόσφατα δημοφιλείς"
 
-#: src/olympia/bandwagon/views.py:189 src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:18
+#: src/olympia/bandwagon/views.py:189 src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:16
 msgid "Added"
 msgstr "Προστέθηκε"
 
@@ -2228,7 +2254,7 @@ msgstr "Η συλλογή δημιουργήθηκε!"
 
 #: src/olympia/bandwagon/views.py:316
 #, python-format
-msgid "Your new collection is shown below. You can <ahref=\"%(url)s\">edit additional settings</a> if you'dlike."
+msgid "Your new collection is shown below. You can <a href=\"%(url)s\">edit additional settings</a> if you'd like."
 msgstr ""
 
 #: src/olympia/bandwagon/views.py:322
@@ -2255,7 +2281,8 @@ msgstr "Δημιουργία"
 #: src/olympia/bandwagon/templates/bandwagon/add.html:24 src/olympia/bandwagon/templates/bandwagon/ajax_new.html:28
 #, python-format
 msgid "As noted in our <a href=\"%(legal)s\">Legal Notices</a>, individual collection arrangements are governed by the Creative Commons Attribution Share-Alike License"
-msgstr "Όπως αναφέρεται και στις <a href=\"%(legal)s\">νομικές σημειώσεις</a> μας, κάθε ξεχωριστή διάταξη συλλογής διέπεται από την άδεια χρήσης Creative Commons Αναφορά προέλευσης - Παρόμοια Διανομή."
+msgstr ""
+"Όπως αναφέρεται και στις <a href=\"%(legal)s\">νομικές σημειώσεις</a> μας, κάθε ξεχωριστή διάταξη συλλογής διέπεται από την άδεια χρήσης Creative Commons Αναφορά προέλευσης - Παρόμοια Διανομή."
 
 #: src/olympia/bandwagon/templates/bandwagon/add.html:33 src/olympia/bandwagon/templates/bandwagon/ajax_new.html:38
 msgid "Create Collection"
@@ -2356,8 +2383,8 @@ msgid_plural "%(num)s Add-ons in this Collection"
 msgstr[0] "%(num)s πρόσθετο στη συλλογή"
 msgstr[1] "%(num)s πρόσθετα στη συλλογή"
 
-#: src/olympia/bandwagon/templates/bandwagon/collection_detail.html:125 src/olympia/compat/templates/compat/index.html:25 src/olympia/compat/templates/compat/reporter_detail.html:29
-#: src/olympia/files/templates/files/viewer.html:29 src/olympia/templates/amo_footer.html:17 src/olympia/templates/includes/lang_switcher.html:10
+#: src/olympia/bandwagon/templates/bandwagon/collection_detail.html:125 src/olympia/compat/templates/compat/reporter_detail.html:29 src/olympia/files/templates/files/viewer.html:29
+#: src/olympia/templates/amo_footer.html:17 src/olympia/templates/includes/lang_switcher.html:10
 msgid "Go"
 msgstr "Μετάβαση"
 
@@ -2391,11 +2418,9 @@ msgstr ""
 
 #: src/olympia/bandwagon/templates/bandwagon/collection_detail.html:186
 msgid ""
-"Add-ons that you mark as favorites using the <b>Add to Favorites</b> feature appear below. This collection is currently <b>private</b>, which means only you can see it. If you would like everyone "
+"Add-ons that you mark as favorites using the <b>Add to Favorites</b> feature appear below. This collection is currently <b>private</b>, which means only you can see it.  If you would like everyone "
 "to be able to see your favorites, click the button below to make it public."
 msgstr ""
-"Παρακάτω εμφανίζονται τα πρόσθετα που σημειώνετε σαν αγαπημένα χρησιμοποιώντας τη λειτουργία <b>Προσθήκη στα αγαπημένα</b>. Αυτή η συλλογή είναι προς το παρόν <b>ιδιωτική</b>, πράγμα που σημαίνει "
-"ότι μόνο εσείς μπορείτε να τη δείτε. Αν θέλετε να μπορούν όλοι να δουν ποια είναι τα αγαπημένα σας πρόσθετα, κάντε κλικ στο παρακάτω κουμπί για να κάνετε τη συλλογή δημόσια."
 
 #: src/olympia/bandwagon/templates/bandwagon/collection_detail.html:196
 msgid "My favorite add-ons"
@@ -2529,7 +2554,7 @@ msgid "Remove this user as a contributor"
 msgstr "Αφαίρεση χρήστη από τη λίστα συντελεστών"
 
 #: src/olympia/bandwagon/templates/bandwagon/edit_contributors.html:18 src/olympia/bandwagon/templates/bandwagon/edit_contributors.html:43
-#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:20 src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:48
+#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:18 src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:46
 #: src/olympia/devhub/templates/devhub/addons/ajax_compat_update.html:19
 msgid "Remove"
 msgstr "Αφαίρεση"
@@ -2540,11 +2565,9 @@ msgstr "Συντελεστές συλλογής"
 
 #: src/olympia/bandwagon/templates/bandwagon/edit_contributors.html:26
 msgid ""
-"You can add multiple contributors to this collection. A contributor can add and remove add-ons from this collection, but cannot change its name or description. To add a contributor, enter their "
+"You can add multiple contributors to this collection.  A contributor can add and remove add-ons from this collection, but cannot change its name or description.  To add a contributor, enter their "
 "email in the box below. Contributors must have a Mozilla Add-ons account."
 msgstr ""
-"Μπορείτε να προσθέσετε πολλούς συντελεστές στη συλλογή. Ένας συντελεστής μπορεί να προσθέσει ή να αφαιρέσει πρόσθετα από τη συλλογή, αλλά δεν μπορεί να αλλάξει το όνομα ή την περιγραφή της. Για να "
-"προσθέσετε ένα συντελεστή, εισάγετε τη διεύθυνση ηλεκτρονικού ταχυδρομείου του στο παρακάτω πλαίσιο. Οι συντελεστές σας θα πρέπει να έχουν λογαριασμό στα πρόσθετα Mozilla."
 
 #: src/olympia/bandwagon/templates/bandwagon/edit_contributors.html:40
 msgid "User"
@@ -2580,7 +2603,7 @@ msgid "<b>Warning:</b> By changing the owner of this collection, you will no lon
 msgstr "<b>Προειδοποίηση:</b> Αν αλλάξετε τον ιδιοκτήτη της συλλογής, δεν θα μπορείτε πια να την επεξεργαστείτε πέρα από το να προσθέσετε ή να αφαιρέσετε πρόσθετα."
 
 #: src/olympia/bandwagon/templates/bandwagon/edit_contributors.html:83 src/olympia/devhub/templates/devhub/addons/forms_shared/media.html:157
-#: src/olympia/devhub/templates/devhub/addons/submit/describe.html:69 src/olympia/devhub/templates/devhub/addons/submit/license.html:60 src/olympia/devhub/templates/devhub/addons/submit/upload.html:78
+#: src/olympia/devhub/templates/devhub/addons/submit/describe.html:69 src/olympia/devhub/templates/devhub/addons/submit/license.html:60 src/olympia/devhub/templates/devhub/addons/submit/upload.html:70
 #: src/olympia/devhub/templates/devhub/payments/tier.html:17 src/olympia/editors/templates/editors/themes/themes.html:111 src/olympia/editors/templates/editors/themes/themes.html:128
 #: src/olympia/editors/templates/editors/themes/themes.html:134 src/olympia/editors/templates/editors/themes/themes.html:141 src/olympia/users/templates/users/fxa_migration_prompt_content.html:10
 #: src/olympia/users/templates/users/login_form.html:42 src/olympia/users/templates/users/mobile/login.html:57
@@ -2624,8 +2647,8 @@ msgstr "Πρόσφατα δημοφιλείς συλλογές"
 #, python-format
 msgid "Collections are groups of related add-ons that anyone can create and share. Explore collections created by other users or <a href=\"%(url)s\">create your own</a>."
 msgstr ""
-"Οι συλλογές είναι ομάδες σχετιζόμενων πρόσθετων που μπορεί να δημιουργήσει και να μοιράσει ο καθένας. Ανακαλύψτε τις συλλογές που έχουν φτιάξει άλλοι ή <a href=\"%(url)s\">δημιουργήστε τη δική "
-"σας</a>."
+"Οι συλλογές είναι ομάδες σχετιζόμενων πρόσθετων που μπορεί να δημιουργήσει και να μοιράσει ο καθένας. Ανακαλύψτε τις συλλογές που έχουν φτιάξει άλλοι ή <a href=\"%(url)s\">δημιουργήστε τη δική σας</"
+"a>."
 
 #: src/olympia/bandwagon/templates/bandwagon/impala/collection_listing.html:37 src/olympia/browse/templates/browse/extensions.html:13 src/olympia/browse/templates/browse/themes.html:14
 msgid "Subscribe"
@@ -2653,44 +2676,43 @@ msgid "Reset"
 msgstr "Επαναφορά"
 
 #: src/olympia/bandwagon/templates/bandwagon/includes/addedit.html:53
-msgid "PNG and JPG supported. Image will be resized to 32x32."
-msgstr "Υποστηρίζονται τύποι αρχείων PNG και JPG. Το μέγεθος της εικόνας θα μετατραπεί σε 32x32."
+msgid "PNG and JPG supported.  Image will be resized to 32x32."
+msgstr ""
 
 #: src/olympia/bandwagon/templates/bandwagon/includes/addedit_errors.html:3
-msgid "There are errors in this form. Please correct them below."
-msgstr "Υπάρχουν σφάλματα στη φόρμα. Παρακαλούμε διορθώστε τα παρακάτω."
+msgid "There are errors in this form.  Please correct them below."
+msgstr ""
 
 #: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:2
 msgid "Add-ons in Your Collection"
 msgstr "Πρόσθετα στη συλλογή σας"
 
 #: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:4
-msgid "To include an add-on in this collection, enter its name in the box below and hit enter. You can also use the <strong>Add to Collection</strong> links throughout the site to include add-ons later."
+msgid "To include an add-on in this collection, enter its name in the box below and hit enter."
 msgstr ""
-"Για να συμπεριλάβετε ένα πρόσθετο στη συλλογή, εισάγετε το όνομα του στο παρακάτω πλαίσιο και πατήστε το «enter». Μπορείτε επίσης να χρησιμοποιήσετε τους δεσμούς <strong>Προσθήκη σε "
-"συλλογή</strong> που θα δείτε στις σελίδες μας για να προσθέσετε πρόσθετα αργότερα."
 
-#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:17 src/olympia/constants/base.py:400 src/olympia/devhub/templates/devhub/addons/activity.html:62
+#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:15 src/olympia/constants/base.py:400 src/olympia/devhub/templates/devhub/addons/activity.html:62
+#: src/olympia/editors/helpers.py:273 src/olympia/editors/helpers.py:360
 msgid "Add-on"
 msgstr "Πρόσθετο"
 
-#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:26
+#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:24
 msgid "Enter the name of the add-on to include"
 msgstr "Εισαγωγή ονόματος πρόσθετου για να συμπεριληφθεί"
 
-#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:28
+#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:26
 msgid "Add to Collection"
 msgstr "Προσθήκη σε συλλογή"
 
-#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:45 src/olympia/editors/helpers.py:936 src/olympia/editors/helpers.py:956
+#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:43 src/olympia/editors/helpers.py:1016 src/olympia/editors/helpers.py:1036
 msgid "Pending"
 msgstr "Σε αναμονή"
 
-#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:47
+#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:45
 msgid "Add a comment"
 msgstr "Προσθήκη σχολίου"
 
-#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:48
+#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:46
 msgid "Remove this add-on from the collection"
 msgstr "Αφαίρεση του πρόσθετου από τη συλλογή"
 
@@ -2741,11 +2763,8 @@ msgstr "Το προβληματικό πρόσθετο ή η πρόσθετη λ
 #, python-format
 msgid ""
 "When Mozilla becomes aware of add-ons, plugins, or other third-party software that seriously compromises %(app)s security, stability, or performance and meets <a href=\"%(criteria)s\">certain "
-"criteria</a>, the software may be blocked from general use. For more information, please read <a href=\"%(support)s\">this support article</a>."
+"criteria</a>, the software may be blocked from general use.  For more information, please read <a href=\"%(support)s\">this support article</a>."
 msgstr ""
-"Όταν η κοινότητα Mozilla εντοπίσει κάποιο πρόσθετο, πρόσθετη λειτουργία ή οποιοδήποτε άλλο λογισμικό τρίτων κατασκευαστών, που θέτει σε κίνδυνο την ασφάλεια, τη σταθερότητα ή τις επιδόσεις του "
-"%(app)s και πληρεί <a href=\"%(criteria)s\">συγκεκριμένα κριτήρια</a>, μπορεί να απενεργοποιήσει τη χρήση του γενικά. Για περισσότερες πληροφορίες, σας παρακαλούμε να διαβάσετε <a "
-"href=\"%(support)s\">αυτό το άρθρο υποστήριξης</a>."
 
 #: src/olympia/blocklist/templates/blocklist/blocked_detail.html:44
 #, python-format
@@ -2802,12 +2821,12 @@ msgstr "Εργαλεία αναζήτησης"
 msgid "Most Users"
 msgstr "Περισσότεροι χρήστες"
 
-#: src/olympia/browse/views.py:61 src/olympia/browse/views.py:72 src/olympia/browse/views.py:279 src/olympia/browse/templates/browse/personas/mobile/category_landing.html:63
+#: src/olympia/browse/views.py:61 src/olympia/browse/views.py:72 src/olympia/browse/views.py:246 src/olympia/browse/templates/browse/personas/mobile/category_landing.html:63
 #: src/olympia/discovery/templates/discovery/pane.html:67 src/olympia/search/forms.py:92
 msgid "Up & Coming"
 msgstr "Επερχόμενα"
 
-#: src/olympia/browse/views.py:460 src/olympia/devhub/views.py:76 src/olympia/devhub/views.py:83 src/olympia/discovery/templates/discovery/addons/detail.html:66
+#: src/olympia/browse/views.py:427 src/olympia/devhub/views.py:74 src/olympia/devhub/views.py:81 src/olympia/discovery/templates/discovery/addons/detail.html:66
 msgid "Created"
 msgstr "Δημιουργήθηκε"
 
@@ -2995,8 +3014,8 @@ msgid_plural "See all %(cnt)s extensions in %(name)s &raquo;"
 msgstr[0] "Δείτε την επέκταση %(cnt)s σε %(name)s &raquo;"
 msgstr[1] "Δείτε όλες τις επεκτάσεις %(cnt)s σε %(name)s &raquo;"
 
-#: src/olympia/browse/templates/browse/mobile/extensions.html:13 src/olympia/compat/templates/compat/index.html:82 src/olympia/devhub/templates/devhub/devhub_search.html:24
-#: src/olympia/devhub/templates/devhub/addons/activity.html:47 src/olympia/search/templates/search/no_results.html:4 src/olympia/search/templates/search/mobile/results.html:36
+#: src/olympia/browse/templates/browse/mobile/extensions.html:13 src/olympia/devhub/templates/devhub/devhub_search.html:24 src/olympia/devhub/templates/devhub/addons/activity.html:47
+#: src/olympia/search/templates/search/no_results.html:4 src/olympia/search/templates/search/mobile/results.html:36
 msgid "No results found."
 msgstr "Δε βρέθηκαν αποτελέσματα."
 
@@ -3054,8 +3073,8 @@ msgstr "Θέλετε περισσότερη εξατομίκευση;"
 #, python-format
 msgid "Complete Themes transform the look of your browser with styles for the window frame, address bar, buttons, tabs, and menus. <a href=\"%(url)s\" class=\"more-info\">Start exploring</a>"
 msgstr ""
-"Τα πλήρη θέματα μεταμορφώνουν την όψη του περιηγητή σας με στυλ για τα παράθυρα, τη γραμμή διευθύνσεων, τα κουμπιά, τις καρτέλες, και τα μενού. <a href=\"%(url)s\" class=\"more-info\">Ξεκινήστε την"
-" εξερεύνηση</a>"
+"Τα πλήρη θέματα μεταμορφώνουν την όψη του περιηγητή σας με στυλ για τα παράθυρα, τη γραμμή διευθύνσεων, τα κουμπιά, τις καρτέλες, και τα μενού. <a href=\"%(url)s\" class=\"more-info\">Ξεκινήστε την "
+"εξερεύνηση</a>"
 
 #: src/olympia/browse/templates/browse/personas/category_landing.html:76
 msgid "Up & Coming Themes"
@@ -3085,7 +3104,7 @@ msgstr "&laquo; Όλα τα θέματα"
 msgid "All"
 msgstr "Όλα"
 
-#: src/olympia/compat/forms.py:22 src/olympia/search/views.py:525
+#: src/olympia/compat/forms.py:22 src/olympia/editors/templates/editors/base.html:69 src/olympia/search/views.py:518
 msgid "All Add-ons"
 msgstr "Όλα τα πρόσθετα"
 
@@ -3096,53 +3115,6 @@ msgstr "Εκτελέσιμο"
 #: src/olympia/compat/forms.py:24
 msgid "Non-binary"
 msgstr "Μη-εκτελέσιμο"
-
-#. Review points sources other than add-ons and themes.
-#: src/olympia/compat/views.py:87 src/olympia/constants/base.py:388 src/olympia/devhub/forms.py:162 src/olympia/editors/templates/editors/performance.html:75
-msgid "Other"
-msgstr "Άλλο"
-
-#: src/olympia/compat/templates/compat/index.html:4
-msgid "Add-on Compatibility Report for {app} {version}"
-msgstr "Αναφορά συμβατότητας για το {app} {version}"
-
-#: src/olympia/compat/templates/compat/index.html:11
-msgid "{app} {version} Compatibility"
-msgstr "Συμβατότητα {app} {version}"
-
-#: src/olympia/compat/templates/compat/index.html:17
-#, python-format
-msgid "Top 95%% compatible with previous version"
-msgstr ""
-
-#: src/olympia/compat/templates/compat/index.html:18
-#, python-format
-msgid "Top 95%% of all add-ons"
-msgstr ""
-
-#: src/olympia/compat/templates/compat/index.html:19
-msgid "All active add-ons"
-msgstr "Όλα τα ενεργά πρόσθετα"
-
-#: src/olympia/compat/templates/compat/index.html:23 src/olympia/constants/base.py:401
-msgid "App"
-msgstr "Εφαρμογή"
-
-#: src/olympia/compat/templates/compat/index.html:55
-msgid "Details for add-ons compatible with previous version:"
-msgstr "Λεπτομέρειες σχετικά με πρόσθετα συμβατά με προηγούμενες εκδόσεις:"
-
-#: src/olympia/compat/templates/compat/index.html:57
-msgid "Show all versions"
-msgstr "Προβολή όλων των εκδόσεων"
-
-#: src/olympia/compat/templates/compat/index.html:59
-msgid "Details for add-ons compatible with all versions:"
-msgstr "Λεπτομέρειες για πρόσθετα συμβατά με όλες τις εκδόσεις:"
-
-#: src/olympia/compat/templates/compat/index.html:61
-msgid "Show previous version only"
-msgstr "Προβολή μόνο της προηγούμενης έκδοσης"
 
 #: src/olympia/compat/templates/compat/reporter.html:3
 msgid "Add-on Compatibility Reports"
@@ -3197,8 +3169,8 @@ msgstr "Φιλτράρισμα βάσει εφαρμογής"
 msgid "Report Type"
 msgstr "Τύπος αναφοράς"
 
-#: src/olympia/compat/templates/compat/reporter_detail.html:47 src/olympia/devhub/forms.py:784 src/olympia/devhub/templates/devhub/addons/ajax_compat_update.html:17 src/olympia/editors/forms.py:108
-#: src/olympia/zadmin/forms.py:45
+#: src/olympia/compat/templates/compat/reporter_detail.html:47 src/olympia/devhub/forms.py:785 src/olympia/devhub/templates/devhub/addons/ajax_compat_update.html:17 src/olympia/editors/forms.py:108
+#: src/olympia/editors/forms.py:248 src/olympia/zadmin/forms.py:45
 msgid "Application"
 msgstr "Εφαρμογή"
 
@@ -3286,7 +3258,8 @@ msgstr "Αξιολογημένο προκαταρκτικά"
 msgid "Preliminarily Reviewed and Awaiting Full Review"
 msgstr "Αξιολογημένο προκαταρκτικά και σε αναμονή πλήρους αξιολόγησης"
 
-#: src/olympia/constants/base.py:33 src/olympia/editors/helpers.py:924 src/olympia/editors/templates/editors/themes/history_table.html:34
+#: src/olympia/constants/base.py:33 src/olympia/editors/forms.py:258 src/olympia/editors/helpers.py:73 src/olympia/editors/helpers.py:1004
+#: src/olympia/editors/templates/editors/themes/history_table.html:34
 msgid "Deleted"
 msgstr "Διαγράφηκε"
 
@@ -3386,6 +3359,11 @@ msgstr "Έκκληση μετά την εκκίνηση της λήψης του
 msgid "Ask before users can download this add-on"
 msgstr "Έκκληση πριν εκκινηθεί η λήψη του πρόσθετου"
 
+#. Review points sources other than add-ons and themes.
+#: src/olympia/constants/base.py:388 src/olympia/devhub/forms.py:162 src/olympia/editors/templates/editors/performance.html:75
+msgid "Other"
+msgstr "Άλλο"
+
 #: src/olympia/constants/base.py:389
 msgid "Exception"
 msgstr "Εξαίρεση"
@@ -3397,6 +3375,10 @@ msgstr "Έκδοση"
 #: src/olympia/constants/base.py:391
 msgid "Change"
 msgstr "Αλλαγή"
+
+#: src/olympia/constants/base.py:401
+msgid "App"
+msgstr "Εφαρμογή"
 
 #: src/olympia/constants/base.py:402
 msgid "Persona"
@@ -3546,7 +3528,7 @@ msgstr ""
 msgid "Duplicate"
 msgstr ""
 
-#: src/olympia/constants/editors.py:17 src/olympia/editors/helpers.py:502 src/olympia/editors/templates/editors/themes/queue.html:71 src/olympia/editors/templates/editors/themes/themes.html:94
+#: src/olympia/constants/editors.py:17 src/olympia/editors/helpers.py:575 src/olympia/editors/templates/editors/themes/queue.html:71 src/olympia/editors/templates/editors/themes/themes.html:94
 msgid "Reject"
 msgstr "Απόρριψη "
 
@@ -3646,7 +3628,7 @@ msgstr "Solaris"
 msgid "Android"
 msgstr "Android"
 
-#: src/olympia/core/apps.py:19
+#: src/olympia/core/apps.py:21
 msgid "Core"
 msgstr ""
 
@@ -3780,7 +3762,7 @@ msgid "Submit my add-on for manual review."
 msgstr ""
 
 #: src/olympia/devhub/forms.py:537
-msgid "Do not list my add-on on this site (beta)"
+msgid "Do not list my add-on on this site"
 msgstr ""
 
 #: src/olympia/devhub/forms.py:538
@@ -3813,46 +3795,46 @@ msgstr ""
 
 #: src/olympia/devhub/forms.py:592
 #, python-format
-msgid "Version %s already exists"
-msgstr "Υπάρχει ήδη η έκδοση %s"
+msgid "Version %s already exists, or was uploaded before."
+msgstr ""
 
-#: src/olympia/devhub/forms.py:604
+#: src/olympia/devhub/forms.py:605
 msgid "Select a valid choice. That choice is not one of the available choices."
 msgstr ""
 
-#: src/olympia/devhub/forms.py:610
+#: src/olympia/devhub/forms.py:611
 msgid "A file with a version ending with a|alpha|b|beta and an optional number is detected as beta."
 msgstr ""
 
-#: src/olympia/devhub/forms.py:633
+#: src/olympia/devhub/forms.py:634
 msgid "You cannot upload any more files for this version."
 msgstr "Δεν μπορείτε να αποστείλετε περισσότερα αρχεία γι' αυτή την έκδοση."
 
-#: src/olympia/devhub/forms.py:639
+#: src/olympia/devhub/forms.py:640
 msgid "Version doesn't match"
 msgstr "Δεν ταιριάζει η έκδοση"
 
-#: src/olympia/devhub/forms.py:668
-msgid "You cannot delete a file once the review process has started. You must delete the whole version."
-msgstr "Δεν μπορείτε να διαγράψετε ένα αρχείο μετά την έναρξη της διαδικασίας αξιολόγησης. Θα πρέπει να διαγράψετε ολόκληρη την έκδοση."
+#: src/olympia/devhub/forms.py:669
+msgid "You cannot delete a file once the review process has started.  You must delete the whole version."
+msgstr ""
 
-#: src/olympia/devhub/forms.py:688
+#: src/olympia/devhub/forms.py:689
 msgid "The platform All cannot be combined with specific platforms."
 msgstr "Η πλατφόρμα «Όλες» δεν μπορεί να συνδυαστεί με συγκεκριμένες πλατφόρμες."
 
-#: src/olympia/devhub/forms.py:693
+#: src/olympia/devhub/forms.py:694
 msgid "A platform can only be chosen once."
 msgstr "Μπορείτε να επιλέξετε πλατφόρμα μόνο μια φορά."
 
-#: src/olympia/devhub/forms.py:706
+#: src/olympia/devhub/forms.py:707
 msgid "A review type must be selected."
 msgstr "Πρέπει να επιλεχθεί μέθοδος αξιολόγησης."
 
-#: src/olympia/devhub/forms.py:788 src/olympia/editors/forms.py:114 src/olympia/zadmin/forms.py:49 src/olympia/zadmin/forms.py:52
+#: src/olympia/devhub/forms.py:789 src/olympia/editors/forms.py:114 src/olympia/editors/forms.py:254 src/olympia/zadmin/forms.py:49 src/olympia/zadmin/forms.py:52
 msgid "Select an application first"
 msgstr "Επιλέξτε πρώτα μια εφαρμογή"
 
-#: src/olympia/devhub/forms.py:840
+#: src/olympia/devhub/forms.py:841
 msgid "There cannot be more than 3 required add-ons."
 msgstr "Δεν μπορείτε να έχετε πάνω από 3 απαιτούμενα πρόσθετα."
 
@@ -3888,76 +3870,76 @@ msgstr[1] "{0} προειδοποιήσεις"
 msgid "Review"
 msgstr "Αξιολόγηση"
 
-#: src/olympia/devhub/tasks.py:551
+#: src/olympia/devhub/tasks.py:583
 #, python-format
 msgid "%s responded with %s (%s)."
 msgstr "%s αποκρίθηκε με %s (%s)."
 
-#: src/olympia/devhub/tasks.py:555
+#: src/olympia/devhub/tasks.py:587
 #, python-format
 msgid "Connection to \"%s\" timed out."
 msgstr "Λήξη χρόνου σύνδεσης με «%s»."
 
-#: src/olympia/devhub/tasks.py:557
+#: src/olympia/devhub/tasks.py:589
 #, python-format
 msgid "Could not contact host at \"%s\"."
 msgstr "Αδυναμία επικοινωνίας με «%s»."
 
-#: src/olympia/devhub/utils.py:104
+#: src/olympia/devhub/utils.py:105
 #, python-format
 msgid "Validation generated too many errors/warnings so %s messages were truncated. After addressing the visible messages, you'll be able to see the others."
 msgstr "Η επικύρωση παρήγαγε πάρα πολλά λάθη/προειδοποιήσεις έτσι %s μηνύματα περικόπηκαν. Αφού εντοπίσετε τα ορατά μηνύματα, θα μπορείτε να δείτε τα υπόλοιπα."
 
-#: src/olympia/devhub/views.py:183
+#: src/olympia/devhub/views.py:181
 msgid "All My Add-ons"
 msgstr "Όλα μου τα πρόσθετα"
 
-#: src/olympia/devhub/views.py:210
+#: src/olympia/devhub/views.py:208
 msgid "All Activity"
 msgstr "Όλες οι δραστηριότητες"
 
-#: src/olympia/devhub/views.py:211
+#: src/olympia/devhub/views.py:209
 msgid "Add-on Updates"
 msgstr "Ενημερώσεις πρόσθετου"
 
-#: src/olympia/devhub/views.py:212
+#: src/olympia/devhub/views.py:210
 msgid "Add-on Status"
 msgstr "Κατάσταση πρόσθετου"
 
-#: src/olympia/devhub/views.py:213
+#: src/olympia/devhub/views.py:211
 msgid "User Collections"
 msgstr "Συλλογές χρήστη"
 
-#: src/olympia/devhub/views.py:214 src/olympia/devhub/templates/devhub/docs/policies-maintenance.html:68 src/olympia/pages/templates/pages/dev_faq.html:38
+#: src/olympia/devhub/views.py:212 src/olympia/devhub/templates/devhub/docs/policies-maintenance.html:68 src/olympia/pages/templates/pages/dev_faq.html:38
 #: src/olympia/pages/templates/pages/dev_faq.html:484
 msgid "User Reviews"
 msgstr "Αξιολογήσεις χρηστών"
 
-#: src/olympia/devhub/views.py:327 src/olympia/devhub/views.py:331 src/olympia/devhub/views.py:484 src/olympia/devhub/views.py:513 src/olympia/devhub/views.py:564 src/olympia/devhub/views.py:1150
+#: src/olympia/devhub/views.py:325 src/olympia/devhub/views.py:329 src/olympia/devhub/views.py:484 src/olympia/devhub/views.py:513 src/olympia/devhub/views.py:564 src/olympia/devhub/views.py:1156
 msgid "Changes successfully saved."
 msgstr "Οι αλλαγές αποθηκεύτηκαν με επιτυχία. "
 
-#: src/olympia/devhub/views.py:334 src/olympia/devhub/views.py:1631
+#: src/olympia/devhub/views.py:332 src/olympia/devhub/views.py:1637
 msgid "Please check the form for errors."
 msgstr ""
 
-#: src/olympia/devhub/views.py:346
+#: src/olympia/devhub/views.py:344
 msgid "Add-on cannot be deleted. Disable this add-on instead."
 msgstr "Δεν είναι δυνατή η διαγραφή του προσθέτου. Απενεργοποιήστε το πρόσθετο αντ'αυτού."
 
-#: src/olympia/devhub/views.py:356
+#: src/olympia/devhub/views.py:354
 msgid "Theme deleted."
 msgstr "Το θέμα διαγράφηκε."
 
-#: src/olympia/devhub/views.py:356
+#: src/olympia/devhub/views.py:354
 msgid "Add-on deleted."
 msgstr "Διαγράφηκε το πρόσθετο."
 
-#: src/olympia/devhub/views.py:362
+#: src/olympia/devhub/views.py:360
 msgid "URL name was incorrect. Theme was not deleted."
 msgstr ""
 
-#: src/olympia/devhub/views.py:367
+#: src/olympia/devhub/views.py:365
 msgid "URL name was incorrect. Add-on was not deleted."
 msgstr ""
 
@@ -3985,7 +3967,7 @@ msgstr "Επικύρωση πρόσθετου"
 msgid "Check Add-on Compatibility"
 msgstr "Έλεγχος συμβατότητας πρόσθετου"
 
-#: src/olympia/devhub/views.py:808 src/olympia/signing/views.py:90
+#: src/olympia/devhub/views.py:808 src/olympia/signing/views.py:95
 msgid "You cannot submit this type of add-on"
 msgstr ""
 
@@ -4015,33 +3997,33 @@ msgstr "Η εικόνα θα πρέπει να έχει {0} pixels πλάτος 
 msgid "There was an error uploading your preview."
 msgstr "Παρουσιάστηκε σφάλμα κατά την αποστολή εικόνας προεπισκόπησης."
 
-#: src/olympia/devhub/views.py:1189
+#: src/olympia/devhub/views.py:1195
 #, python-format
 msgid "Version %s disabled."
 msgstr ""
 
-#: src/olympia/devhub/views.py:1193
+#: src/olympia/devhub/views.py:1199
 #, python-format
 msgid "Version %s deleted."
 msgstr "Διαγράφηκε η έκδοση %s."
 
-#: src/olympia/devhub/views.py:1203
+#: src/olympia/devhub/views.py:1209
 msgid "This upload has failed validation, and may lack complete validation results. Please take due care when reviewing it."
 msgstr "Αυτή η μεταφόρτωση απέτυχε να επικυρωθεί, και ενδέχεται να υπολείπεται αποτελεσμάτων επικύρωσης. Παρακαλώ επιθεωρήστε την με προσοχή."
 
-#: src/olympia/devhub/views.py:1677
+#: src/olympia/devhub/views.py:1683
 msgid "Preliminary Review Requested."
 msgstr "Αιτήθηκε πρωταρχική αξιολόγηση."
 
-#: src/olympia/devhub/views.py:1678
+#: src/olympia/devhub/views.py:1684
 msgid "Full Review Requested."
 msgstr "Αιτήθηκε πλήρης αξιολόγηση."
 
-#: src/olympia/devhub/views.py:1779
+#: src/olympia/devhub/views.py:1783
 msgid "Your old credentials were revoked and are no longer valid. Be sure to update all API clients with the new credentials."
 msgstr ""
 
-#: src/olympia/devhub/views.py:1797
+#: src/olympia/devhub/views.py:1801
 msgid "New API key created"
 msgstr ""
 
@@ -4071,10 +4053,10 @@ msgstr "Πίσω στα πρόσθετα"
 msgid "{0} :: Search"
 msgstr "{0} :: Αναζήτηση"
 
-#: src/olympia/devhub/templates/devhub/devhub_search.html:6 src/olympia/devhub/templates/devhub/search.html:8 src/olympia/editors/forms.py:435 src/olympia/editors/forms.py:437
+#: src/olympia/devhub/templates/devhub/devhub_search.html:6 src/olympia/devhub/templates/devhub/search.html:8 src/olympia/editors/forms.py:534 src/olympia/editors/forms.py:536
 #: src/olympia/editors/templates/editors/queue.html:27 src/olympia/editors/templates/editors/themes/queue_list.html:14 src/olympia/search/templates/search/collections.html:17
-#: src/olympia/search/templates/search/personas.html:18 src/olympia/search/templates/search/results.html:18 src/olympia/search/templates/search/mobile/results.html:8 src/olympia/templates/search.html:14
-#: src/olympia/templates/impala/search.html:18
+#: src/olympia/search/templates/search/personas.html:18 src/olympia/search/templates/search/results.html:18 src/olympia/search/templates/search/mobile/results.html:8
+#: src/olympia/templates/search.html:14 src/olympia/templates/impala/search.html:18
 msgid "Search"
 msgstr "Αναζήτηση"
 
@@ -4118,9 +4100,9 @@ msgstr ""
 
 #: src/olympia/devhub/templates/devhub/index.html:41
 msgid ""
-"Add-ons let millions of Firefox users enhance and customize their browsing experience. If you're a Web developer and know <a href=\"https://developer.mozilla.org/docs/Web/HTML\">HTML</a>, <a "
-"href=\"https://developer.mozilla.org/docs/Web/JavaScript\">JavaScript</a>, and <a href=\"https://developer.mozilla.org/docs/Web/CSS\">CSS</a>, you already have all the necessary skills to make a "
-"great add-on."
+"Add-ons let millions of Firefox users enhance and customize their browsing experience. If you're a Web developer and know <a href=\"https://developer.mozilla.org/docs/Web/HTML\">HTML</a>, <a href="
+"\"https://developer.mozilla.org/docs/Web/JavaScript\">JavaScript</a>, and <a href=\"https://developer.mozilla.org/docs/Web/CSS\">CSS</a>, you already have all the necessary skills to make a great "
+"add-on."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/index.html:51
@@ -4131,12 +4113,12 @@ msgstr ""
 msgid "Start Making Add-ons"
 msgstr "Ξεκινήστε να φτιάχνετε πρόσθετα"
 
-#: src/olympia/devhub/templates/devhub/index.html:86 src/olympia/devhub/templates/devhub/addons/listing/items.html:25 src/olympia/devhub/templates/devhub/includes/addon_details.html:15
+#: src/olympia/devhub/templates/devhub/index.html:86 src/olympia/devhub/templates/devhub/addons/listing/items.html:25 src/olympia/devhub/templates/devhub/includes/addon_details.html:20
 #: src/olympia/devhub/templates/devhub/personas/edit.html:43
 msgid "Status:"
 msgstr "Κατάσταση:"
 
-#: src/olympia/devhub/templates/devhub/index.html:90 src/olympia/devhub/templates/devhub/includes/addon_details.html:100
+#: src/olympia/devhub/templates/devhub/index.html:90 src/olympia/devhub/templates/devhub/includes/addon_details.html:87
 msgid "Visibility:"
 msgstr ""
 
@@ -4144,11 +4126,11 @@ msgstr ""
 msgid "Latest Version:"
 msgstr "Τελευταία έκδοση"
 
-#: src/olympia/devhub/templates/devhub/index.html:109 src/olympia/devhub/templates/devhub/includes/addon_details.html:145 src/olympia/devhub/templates/devhub/personas/edit.html:49
+#: src/olympia/devhub/templates/devhub/index.html:109 src/olympia/devhub/templates/devhub/includes/addon_details.html:131 src/olympia/devhub/templates/devhub/personas/edit.html:49
 msgid "Queue Position:"
 msgstr "Θέση ουράς:"
 
-#: src/olympia/devhub/templates/devhub/index.html:110 src/olympia/devhub/templates/devhub/includes/addon_details.html:146 src/olympia/devhub/templates/devhub/personas/edit.html:50
+#: src/olympia/devhub/templates/devhub/index.html:110 src/olympia/devhub/templates/devhub/includes/addon_details.html:132 src/olympia/devhub/templates/devhub/personas/edit.html:50
 #, python-format
 msgid "%(position)s of %(total)s"
 msgstr "%(position)s από %(total)s"
@@ -4251,16 +4233,6 @@ msgstr "Μετά τη μεταφόρτωση, μια σειρά από αυτό�
 msgid "Do you want your add-on to be distributed on this site?"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/validate_addon.html:49 src/olympia/devhub/templates/devhub/addons/submit/upload.html:30 src/olympia/devhub/templates/devhub/versions/add_file_modal.html:14
-#: src/olympia/devhub/templates/devhub/versions/add_file_modal.html:53 src/olympia/devhub/templates/devhub/versions/list.html:298
-msgid "Warning:"
-msgstr ""
-
-#: src/olympia/devhub/templates/devhub/validate_addon.html:50 src/olympia/devhub/templates/devhub/addons/submit/upload.html:31
-#, python-format
-msgid "Submission of unlisted add-ons for signing is currently in an open beta. Please <a href=\"%(url)s\" target=\"_blank\">report any bugs</a> that you encounter."
-msgstr ""
-
 #. first parameter is a filename like lorem-ipsum-1.0.2.xpi
 #: src/olympia/devhub/templates/devhub/validation.html:5
 msgid "Validation Results for {0}"
@@ -4315,14 +4287,14 @@ msgid ""
 "This add-on is incompatible with <b>%(app_name)s %(app_version)s</b>, the latest release of %(app_name)s. Please consider updating your add-on's compatibility info, or uploading a newer version of "
 "this add-on."
 msgstr ""
-"Αυτό το πρόσθετο δεν  είναι συμβατό με τον <b>%(app_name)s %(app_version)s</b>, που είναι η πιο πρόσφατη έκδοση του %(app_name)s. Παρακαλούμε αναβαθμίσετε τις πληροφορίες συμβατότητας του πρόσθετου"
-" σας ή αποστείλετε μια νέα έκδοση του."
+"Αυτό το πρόσθετο δεν  είναι συμβατό με τον <b>%(app_name)s %(app_version)s</b>, που είναι η πιο πρόσφατη έκδοση του %(app_name)s. Παρακαλούμε αναβαθμίσετε τις πληροφορίες συμβατότητας του πρόσθετου "
+"σας ή αποστείλετε μια νέα έκδοση του."
 
 #: src/olympia/devhub/templates/devhub/addons/ajax_compat_error.html:15
 #, python-format
 msgid ""
-"<a href=\"#\" class=\"button compat-update\" data-updateurl=\"%(update_url)s\">Update Compatibility</a> <a href=\"%(version_url)s\" class=\"button\">Upload New Version</a> or <a href=\"#\" "
-"class=\"close\">Ignore</a>"
+"<a href=\"#\" class=\"button compat-update\" data-updateurl=\"%(update_url)s\">Update Compatibility</a> <a href=\"%(version_url)s\" class=\"button\">Upload New Version</a> or <a href=\"#\" class="
+"\"close\">Ignore</a>"
 msgstr ""
 "<a href=\"#\" class=\"button compat-update\" data-updateurl=\"%(update_url)s\">Αναβάθμιση συμβατότητας</a> <a href=\"%(version_url)s\" class=\"button\">Αποστολή νέας έκδοσης</a> ή <a href=\"#\" "
 "class=\"close\">αγνόηση</a>"
@@ -4339,7 +4311,7 @@ msgstr "Συμβατότητα"
 msgid "Update Compatibility"
 msgstr "Ενημέρωση συμβατότητας"
 
-#: src/olympia/devhub/templates/devhub/addons/ajax_compat_update.html:4
+#: src/olympia/devhub/templates/devhub/addons/ajax_compat_update.html:4 src/olympia/devhub/templates/devhub/versions/edit.html:45
 msgid "Adjusting application information here will allow users to install your add-on even if the install manifest in the package indicates that the add-on is incompatible."
 msgstr ""
 "Η προσαρμογή των πληροφοριών για την εφαρμογή από εδώ, θα επιτρέψει στους χρήστες να εγκαταστήσουν το πρόσθετο σας ακόμη κι αν το αρχείο install manifest του πακέτου υποδεικνύει ότι δεν είναι "
@@ -4353,9 +4325,9 @@ msgstr "Υποστηριζόμενες εκδόσεις"
 msgid "Add Another Application&hellip;"
 msgstr "Προσθήκη κι άλλης εφαρμογής&hellip;"
 
-#: src/olympia/devhub/templates/devhub/addons/ajax_compat_update.html:38 src/olympia/devhub/templates/devhub/addons/owner.html:86 src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:46
-#: src/olympia/devhub/templates/devhub/versions/list.html:351 src/olympia/devhub/templates/devhub/versions/list.html:353 src/olympia/templates/impala/base.html:132
-#: src/olympia/templates/impala/base.html:143 src/olympia/templates/impala/base.html:161 src/olympia/templates/impala/base.html:171
+#: src/olympia/devhub/templates/devhub/addons/ajax_compat_update.html:38 src/olympia/devhub/templates/devhub/addons/owner.html:86 src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:45
+#: src/olympia/devhub/templates/devhub/versions/list.html:349 src/olympia/devhub/templates/devhub/versions/list.html:351 src/olympia/templates/impala/base.html:129
+#: src/olympia/templates/impala/base.html:140 src/olympia/templates/impala/base.html:158 src/olympia/templates/impala/base.html:168
 msgid "Close"
 msgstr "Κλείσιμο"
 
@@ -4389,7 +4361,7 @@ msgstr "Κανένα"
 msgid "Manage Authors & License"
 msgstr "Διαχείριση προγραμματιστών & άδειας χρήσης"
 
-#: src/olympia/devhub/templates/devhub/addons/owner.html:29 src/olympia/editors/templates/editors/review.html:270
+#: src/olympia/devhub/templates/devhub/addons/owner.html:29 src/olympia/editors/helpers.py:362 src/olympia/editors/templates/editors/review.html:270
 msgid "Authors"
 msgstr "Δημιουργοί"
 
@@ -4461,32 +4433,23 @@ msgstr "Σύνοψη"
 
 #: src/olympia/devhub/templates/devhub/addons/edit/basic.html:52
 msgid ""
-"A short explanation of your add-on's basic\n"
-"                          functionality that is displayed in search and browse\n"
-"                          listings, as well as at the top of your add-on's\n"
-"                          details page. It is only relevant for listed add-ons."
+"A short explanation of your add-on's basic functionality that is displayed in search and browse listings, as well as at the top of your add-on's details page. It is only relevant for listed add-ons."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/basic.html:73
-msgid ""
-"Categories are the primary way users browse through add-ons.\n"
-"                        Choose any that fit your add-on's functionality for the most\n"
-"                        exposure. It is only relevant for listed add-ons."
+msgid "Categories are the primary way users browse through add-ons. Choose any that fit your add-on's functionality for the most exposure. It is only relevant for listed add-ons."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/basic.html:90
 #, python-format
-msgid "Categories cannot be changed while your add-on is featured for this application. Please email <a href=\"mailto:%(email)s\">%(email)s</a> if there is a reason you need to modify your categories."
+msgid ""
+"Categories cannot be changed while your add-on is featured for this application. Please email <a href=\"mailto:%(email)s\">%(email)s</a> if there is a reason you need to modify your categories."
 msgstr ""
 "Οι κατηγορίες δε μπορούν να τροποποιηθούν καθώς το πρόσθετο σας προβάλλεται για αυτή την εφαρμογή. Παρακαλώ στείλτε email στο <a href=\"mailto:%(email)s\">%(email)s</a> αν υπάρχει λόγος για να "
 "τροποποιήσετε τις κατηγορίες σας."
 
 #: src/olympia/devhub/templates/devhub/addons/edit/basic.html:119
-msgid ""
-"Tags help users find your add-on and should be short\n"
-"                        descriptors such as tabs, toolbar, or twitter.  You\n"
-"                        may have a maximum of {0} tags. It is only relevant\n"
-"                        for listed add-ons."
+msgid "Tags help users find your add-on and should be short descriptors such as tabs, toolbar, or twitter. You may have a maximum of {0} tags. It is only relevant for listed add-ons."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/basic.html:129 src/olympia/devhub/templates/devhub/personas/edit.html:97 src/olympia/devhub/templates/devhub/personas/submit.html:46
@@ -4514,11 +4477,7 @@ msgid "Add-on Details for {0}"
 msgstr "Λεπτομέρειες πρόσθετου για το {0}"
 
 #: src/olympia/devhub/templates/devhub/addons/edit/details.html:22
-msgid ""
-"A longer explanation of features,\n"
-"                          functionality, and other relevant information. This\n"
-"                          field is only displayed on the add-on's details\n"
-"                          page. It is only relevant for listed add-ons."
+msgid "A longer explanation of features, functionality, and other relevant information. This field is only displayed on the add-on's details page. It is only relevant for listed add-ons."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/details.html:44 src/olympia/translations/templates/translations/trans-menu.html:13
@@ -4526,10 +4485,7 @@ msgid "Default Locale"
 msgstr "Αρχικές ρυθμίσεις γλώσσας"
 
 #: src/olympia/devhub/templates/devhub/addons/edit/details.html:45
-msgid ""
-"Information about your add-on is displayed in this locale\n"
-"                        unless you override it with a locale-specific translation.\n"
-"                        It is only relevant for listed add-ons."
+msgid "Information about your add-on is displayed in this locale unless you override it with a locale-specific translation. It is only relevant for listed add-ons."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/details.html:61 src/olympia/users/forms.py:311 src/olympia/users/templates/users/edit.html:122 src/olympia/users/templates/users/register.html:57
@@ -4539,10 +4495,8 @@ msgstr "Αρχική σελίδα"
 
 #: src/olympia/devhub/templates/devhub/addons/edit/details.html:63
 msgid ""
-"If your add-on has another homepage, enter its\n"
-"                          address here. If your website is localized into other\n"
-"                          languages multiple translations of this field can be\n"
-"                          added. It is only relevant for listed add-ons."
+"If your add-on has another homepage, enter its address here. If your website is localized into other languages multiple translations of this field can be added. It is only relevant for listed add-"
+"ons."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/media.html:3
@@ -4560,19 +4514,14 @@ msgstr "Πληροφορίες υποστήριξης για το {0}"
 
 #: src/olympia/devhub/templates/devhub/addons/edit/support.html:22
 msgid ""
-"If you wish to display an e-mail address for support\n"
-"                          inquiries, enter it here. If you have different\n"
-"                          addresses for each language multiple translations of\n"
-"                          this field can be added. It is only relevant for\n"
-"                          listed add-ons."
+"If you wish to display an e-mail address for support inquiries, enter it here. If you have different addresses for each language multiple translations of this field can be added. It is only "
+"relevant for listed add-ons."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/support.html:45
 msgid ""
-"If your add-on has a support website or forum, enter\n"
-"                          its address here. If your website is localized into\n"
-"                          other languages, multiple translations of this field can\n"
-"                          be added. It is only relevant for listed add-ons."
+"If your add-on has a support website or forum, enter its address here. If your website is localized into other languages, multiple translations of this field can be added. It is only relevant for "
+"listed add-ons."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:6
@@ -4586,11 +4535,8 @@ msgstr "Τεχνικές λεπτομέρειες για το {0}"
 
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:23
 msgid ""
-"Any information end users may want to know that isn't\n"
-"                          necessarily applicable to the add-on summary or description.\n"
-"                          Common uses include listing known major bugs, information on\n"
-"                          how to report bugs, anticipated release date of a new version,\n"
-"                          etc. It is only relevant for listed add-ons."
+"Any information end users may want to know that isn't necessarily applicable to the add-on summary or description. Common uses include listing known major bugs, information on how to report bugs, "
+"anticipated release date of a new version, etc. It is only relevant for listed add-ons."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:46
@@ -4602,9 +4548,7 @@ msgid "Add-on Flags"
 msgstr "Επισημάνσεις προσθέτου"
 
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:69
-msgid ""
-"These flags are used to classify add-ons. It is only\n"
-"                        relevant for listed add-ons."
+msgid "These flags are used to classify add-ons. It is only relevant for listed add-ons."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:74
@@ -4620,9 +4564,7 @@ msgid "View Source?"
 msgstr "Προβολή πηγαίου κώδικα;"
 
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:90
-msgid ""
-"Whether the source of your add-on can be displayed in our\n"
-"                        online viewer. It is only relevant for listed add-ons."
+msgid "Whether the source of your add-on can be displayed in our online viewer. It is only relevant for listed add-ons."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:94
@@ -4638,10 +4580,7 @@ msgid "Public Stats?"
 msgstr "Δημόσια στατιστικά;"
 
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:102
-msgid ""
-"Whether the download and usage stats of your add-on can\n"
-"                        be displayed in our online viewer.\n"
-"                        It is only relevant for listed add-ons."
+msgid "Whether the download and usage stats of your add-on can be displayed in our online viewer. It is only relevant for listed add-ons."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:107
@@ -4657,10 +4596,7 @@ msgid "Upgrade SDK?"
 msgstr "Να γίνει ενημέρωση του SDK;"
 
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:116
-msgid ""
-"If selected, we will try to automatically upgrade your\n"
-"                        add-on when a new version of the SDK is released.\n"
-"                        It is only relevant for listed add-ons."
+msgid "If selected, we will try to automatically upgrade your add-on when a new version of the SDK is released. It is only relevant for listed add-ons."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:121
@@ -4711,10 +4647,8 @@ msgstr "Εικονίδιο πρόσθετου"
 
 #: src/olympia/devhub/templates/devhub/addons/forms_shared/media.html:16
 msgid ""
-"Upload an icon for your add-on or choose from one of ours. The\n"
-"                      icon is displayed nearly everywhere your add-on is. Uploaded images\n"
-"                      must be one of the following image types: .png, .jpg.\n"
-"                      It is only relevant for listed add-ons."
+"Upload an icon for your add-on or choose from one of ours. The icon is displayed nearly everywhere your add-on is. Uploaded images must be one of the following image types: .png, .jpg. It is only "
+"relevant for listed add-ons."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/forms_shared/media.html:25
@@ -4822,16 +4756,14 @@ msgid "Deleting your add-on will permanently remove it from the site and prevent
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:24
-msgid ""
-"Enter the following text confirm your decision:\n"
-"           {slug}"
+msgid "Enter the following text confirm your decision: {slug}"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:34
+#: src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:33
 msgid "Please tell us why you are deleting your theme:"
 msgstr "Παρακαλώ πείτε μας γιατί διαγράφετε το θέμα σας:"
 
-#: src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:36
+#: src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:35
 msgid "Please tell us why you are deleting your add-on:"
 msgstr "Παρακαλώ πείτε μας γιατί διαγράφετε το πρόσθετό σας:"
 
@@ -4868,13 +4800,13 @@ msgstr "Νέα έκδοση"
 msgid "Daily statistics on downloads and users."
 msgstr "Ημερήσια στατιστικά λήψεων και χρηστών."
 
-#: src/olympia/devhub/templates/devhub/addons/listing/item_actions.html:45 src/olympia/stats/templates/stats/stats.html:75 src/olympia/stats/templates/stats/stats.html:79
-#: src/olympia/stats/templates/stats/stats.html:81
+#: src/olympia/devhub/templates/devhub/addons/listing/item_actions.html:45 src/olympia/stats/templates/stats/stats.html:31 src/olympia/stats/templates/stats/stats.html:35
+#: src/olympia/stats/templates/stats/stats.html:37
 msgid "Statistics"
 msgstr "Στατιστικά"
 
-#: src/olympia/devhub/templates/devhub/addons/listing/item_actions.html:54 src/olympia/devhub/templates/devhub/includes/addons_edit_nav.html:5 src/olympia/devhub/templates/devhub/payments/payments.html:3
-#: src/olympia/devhub/templates/devhub/payments/tier.html:4
+#: src/olympia/devhub/templates/devhub/addons/listing/item_actions.html:54 src/olympia/devhub/templates/devhub/includes/addons_edit_nav.html:5
+#: src/olympia/devhub/templates/devhub/payments/payments.html:3 src/olympia/devhub/templates/devhub/payments/tier.html:4
 msgid "Manage Payments"
 msgstr "Διαχείριση πληρωμών"
 
@@ -5198,14 +5130,14 @@ msgstr "Βημα 2. Αποστολή του πρόσθετου σας"
 #: src/olympia/devhub/templates/devhub/addons/submit/upload.html:11
 msgid "Use the fields below to upload your add-on package and select any platform restrictions. After upload, a series of automated validation tests will be run on your file."
 msgstr ""
-"Χρησιμοποιήστε τα παρακάτω πεδία για να αποστείλετε το πακέτο του πρόσθετου σας και να επιλέξετε τυχόν περιορισμούς λειτουργικού συστήματος. Μετά την αποστολή, θα διεξαχθεί στο αρχείο σας μια σειρά"
-" αυτοματοποιημένων δοκιμών και ελέγχων."
+"Χρησιμοποιήστε τα παρακάτω πεδία για να αποστείλετε το πακέτο του πρόσθετου σας και να επιλέξετε τυχόν περιορισμούς λειτουργικού συστήματος. Μετά την αποστολή, θα διεξαχθεί στο αρχείο σας μια σειρά "
+"αυτοματοποιημένων δοκιμών και ελέγχων."
 
-#: src/olympia/devhub/templates/devhub/addons/submit/upload.html:59 src/olympia/devhub/templates/devhub/versions/add_file_modal.html:39
+#: src/olympia/devhub/templates/devhub/addons/submit/upload.html:51 src/olympia/devhub/templates/devhub/versions/add_file_modal.html:28
 msgid "Which platforms is this file compatible with?"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/addons/submit/upload.html:67 src/olympia/devhub/templates/devhub/versions/add_file_modal.html:65
+#: src/olympia/devhub/templates/devhub/addons/submit/upload.html:59 src/olympia/devhub/templates/devhub/versions/add_file_modal.html:45
 msgid "Administrative overrides"
 msgstr "Διαχειριστική υπερίσχυση"
 
@@ -5233,8 +5165,8 @@ msgstr ""
 #: src/olympia/devhub/templates/devhub/api/key.html:37
 #, python-format
 msgid ""
-"To make API requests, send a <a href=\"%(jwt_url)s\">JSON Web Token (JWT)</a> as the authorization header. You'll need to generate a JWT for every request as explained in the <a "
-"href=\"%(docs_url)s\">API documentation</a>."
+"To make API requests, send a <a href=\"%(jwt_url)s\">JSON Web Token (JWT)</a> as the authorization header. You'll need to generate a JWT for every request as explained in the <a href=\"%(docs_url)s"
+"\">API documentation</a>."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/api/key.html:47
@@ -5254,8 +5186,8 @@ msgstr ""
 msgid "Generate new credentials"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/docs/policies-agreement.html:3 src/olympia/devhub/templates/devhub/docs/policies-agreement.html:7 src/olympia/devhub/templates/devhub/docs/policies-agreement.html:9
-#: src/olympia/devhub/templates/devhub/docs/policies.html:24 src/olympia/devhub/templates/devhub/docs/policies.html:103
+#: src/olympia/devhub/templates/devhub/docs/policies-agreement.html:3 src/olympia/devhub/templates/devhub/docs/policies-agreement.html:7
+#: src/olympia/devhub/templates/devhub/docs/policies-agreement.html:9 src/olympia/devhub/templates/devhub/docs/policies.html:24 src/olympia/devhub/templates/devhub/docs/policies.html:103
 msgid "Developer Agreement"
 msgstr "Συμφωνητικό δημιουργών "
 
@@ -5291,8 +5223,8 @@ msgstr "amo-editors at mozilla dot org"
 #: src/olympia/devhub/templates/devhub/docs/policies-contact.html:26
 #, python-format
 msgid ""
-"If you have a question about an Editor's review of an add-on or want to report a policy violation, please email %(mail_editors)s. <strong>Almost all add-on reports fall under this "
-"category.</strong> Please be sure to include a link to the add-on in question and a detailed description of your question or comment."
+"If you have a question about an Editor's review of an add-on or want to report a policy violation, please email %(mail_editors)s. <strong>Almost all add-on reports fall under this category.</"
+"strong> Please be sure to include a link to the add-on in question and a detailed description of your question or comment."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/docs/policies-contact.html:31
@@ -5307,8 +5239,8 @@ msgstr ""
 #, python-format
 msgid ""
 "If you have discovered a security vulnerability in an add-on, even if it is not hosted here, Mozilla is very interested in your discovery and will work with the add-on developer to correct the "
-"issue as soon as possible. Add-on security issues can be reported <a href=\"http://www.mozilla.org/projects/security/security-bugs-policy.html\">confidentially</a> in <a "
-"href=\"%(link_bugzilla)s\">Bugzilla</a> or by emailing %(mail_admins)s."
+"issue as soon as possible. Add-on security issues can be reported <a href=\"http://www.mozilla.org/projects/security/security-bugs-policy.html\">confidentially</a> in <a href=\"%(link_bugzilla)s"
+"\">Bugzilla</a> or by emailing %(mail_admins)s."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/docs/policies-contact.html:42
@@ -5317,8 +5249,8 @@ msgstr ""
 
 #: src/olympia/devhub/templates/devhub/docs/policies-contact.html:44
 msgid ""
-"If you've found a problem with the site, we'd love to fix it. Please <a href=\"https://github.com/mozilla/olympia/issues\">file a bug report</a> in GitHub, including the location of the problem and"
-" how you encountered it."
+"If you've found a problem with the site, we'd love to fix it. Please <a href=\"https://github.com/mozilla/addons/issues/new\">file a bug report</a> in GitHub, including the location of the problem "
+"and how you encountered it."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/docs/policies-maintenance.html:3 src/olympia/devhub/templates/devhub/docs/policies-maintenance.html:7
@@ -5332,9 +5264,9 @@ msgstr "Υποβολή Νέων Εκδόσεων του Προσθέτου σα�
 
 #: src/olympia/devhub/templates/devhub/docs/policies-maintenance.html:12
 msgid ""
-"Developers are encouraged to submit updates to their add-ons to fix bugs, add features, and otherwise improve their product. New versions of an add-on must have a <a "
-"href=\"https://developer.mozilla.org/en/Toolkit_version_format\">higher version number</a> and can be submitted through the Developer Tools provided. There is no limit to the number of versions "
-"that can be submitted, but please remember that versions must be reviewed by an editor."
+"Developers are encouraged to submit updates to their add-ons to fix bugs, add features, and otherwise improve their product. New versions of an add-on must have a <a href=\"https://developer."
+"mozilla.org/en/Toolkit_version_format\">higher version number</a> and can be submitted through the Developer Tools provided. There is no limit to the number of versions that can be submitted, but "
+"please remember that versions must be reviewed by an editor."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/docs/policies-maintenance.html:18
@@ -5397,8 +5329,8 @@ msgstr ""
 
 #: src/olympia/devhub/templates/devhub/docs/policies-maintenance.html:70
 msgid ""
-"Mozilla encourages its users to offer feedback on their experiences when using an add-on. This allows other users to determine if the add-on is stable and useful. It also provides valuable feedback"
-" to developers, allowing them to continuously improve their add-on to meet user needs."
+"Mozilla encourages its users to offer feedback on their experiences when using an add-on. This allows other users to determine if the add-on is stable and useful. It also provides valuable feedback "
+"to developers, allowing them to continuously improve their add-on to meet user needs."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/docs/policies-maintenance.html:76
@@ -5447,7 +5379,8 @@ msgid ""
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/docs/policies-recommended.html:19
-msgid "Featured add-ons are chosen by the Featured Add-ons Advisory Board, a small group of add-on developers and fans from the Mozilla community who have volunteered to review and vote on nominations."
+msgid ""
+"Featured add-ons are chosen by the Featured Add-ons Advisory Board, a small group of add-on developers and fans from the Mozilla community who have volunteered to review and vote on nominations."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/docs/policies-recommended.html:25
@@ -5633,9 +5566,9 @@ msgstr ""
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:31
 msgid ""
-"Detailed descriptions of each option are below. After selecting a review process at submission, the add-on will be placed in the queue. Add-ons are reviewed by the <a "
-"href=\"https://wiki.mozilla.org/AMO:Editors\">AMO Editors</a>, a group of talented developers that volunteer to help the Mozilla project by reviewing add-ons to ensure a stable and safe experience "
-"for users. Developers will receive an email with any updates throughout the review process."
+"Detailed descriptions of each option are below. After selecting a review process at submission, the add-on will be placed in the queue. Add-ons are reviewed by the <a href=\"https://wiki.mozilla."
+"org/AMO:Editors\">AMO Editors</a>, a group of talented developers that volunteer to help the Mozilla project by reviewing add-ons to ensure a stable and safe experience for users. Developers will "
+"receive an email with any updates throughout the review process."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:37
@@ -5646,8 +5579,8 @@ msgstr ""
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:44
 msgid ""
-"Full reviews are appropriate for add-ons that are well-tested, stable, fast, and have wide appeal to our users. If you aren't confident that your add-on meets that criteria, please consider working"
-" out the kinks while in preliminary review and accumulating user feedback first."
+"Full reviews are appropriate for add-ons that are well-tested, stable, fast, and have wide appeal to our users. If you aren't confident that your add-on meets that criteria, please consider working "
+"out the kinks while in preliminary review and accumulating user feedback first."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:50
@@ -5742,8 +5675,8 @@ msgstr ""
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:123
 #, python-format
 msgid ""
-"Many of the above restrictions are tested automatically by an extension scanner that will flag suspicious add-ons for editor review. You can read more about this scanner in the <a "
-"href=\"%(link_validation)s\">Validation Help</a> document."
+"Many of the above restrictions are tested automatically by an extension scanner that will flag suspicious add-ons for editor review. You can read more about this scanner in the <a href="
+"\"%(link_validation)s\">Validation Help</a> document."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:129
@@ -5764,8 +5697,8 @@ msgstr ""
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:142
 msgid ""
-"Subsequent versions of the add-on will automatically be placed in the full review queue. Until the review is completed, the new version will only be displayed on the Version History page of the "
-"add-on. Once reviewed, the version will be updated across the site and deployed through the automatic update service."
+"Subsequent versions of the add-on will automatically be placed in the full review queue. Until the review is completed, the new version will only be displayed on the Version History page of the add-"
+"on. Once reviewed, the version will be updated across the site and deployed through the automatic update service."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:148
@@ -5867,9 +5800,9 @@ msgstr ""
 msgid ""
 "<p> Whenever an add-on includes any unexpected* feature that </p> <ul> <li>compromises user privacy or security (like sending data to third parties),</li> <li>changes default settings like the "
 "homepage or search engine, or</li> <li>changes settings or features in other add-ons or deactivates them altogether</li> </ul> <p>the features must adhere to the following requirements:</p> <ul> "
-"<li>The add-on description must clearly state what changes the add-on makes.</li> <li>All changes must be opt-in, meaning the user must take non-default action to enact the change.</li> <li>The "
-"opt-in dialog must clearly state the name of the add-on requesting the change.</li> <li>Uninstalling the add-on restores the user's original settings if they were changed.</li> </ul> <p>*Unexpected"
-" features are those that are unrelated to the add-on's primary function.</p>"
+"<li>The add-on description must clearly state what changes the add-on makes.</li> <li>All changes must be opt-in, meaning the user must take non-default action to enact the change.</li> <li>The opt-"
+"in dialog must clearly state the name of the add-on requesting the change.</li> <li>Uninstalling the add-on restores the user's original settings if they were changed.</li> </ul> <p>*Unexpected "
+"features are those that are unrelated to the add-on's primary function.</p>"
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:268
@@ -5886,8 +5819,8 @@ msgstr "Λειτουργία ιδιωτικής περιήγησης"
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:282
 msgid ""
-"Add-ons that store or otherwise handle browsing data must support <a href=\"https://developer.mozilla.org/En/Supporting_private_browsing_mode\">Private Browsing Mode</a>.  During a Private Browsing"
-" session, no browsing data can be written to disk, and all of this data must be cleared when Firefox quits or the Private Browsing session ends."
+"Add-ons that store or otherwise handle browsing data must support <a href=\"https://developer.mozilla.org/En/Supporting_private_browsing_mode\">Private Browsing Mode</a>. During a Private Browsing "
+"session, no browsing data can be written to disk, and all of this data must be cleared when Firefox quits or the Private Browsing session ends."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:287
@@ -5930,10 +5863,10 @@ msgstr ""
 
 #: src/olympia/devhub/templates/devhub/docs/policies-submission.html:25
 msgid ""
-"<strong>Is the add-on clearly and accurately described?</strong> It's of the utmost importance to us that users get what they expect when they try a new add-on. Your add-on name should be clear and"
-" concise, and you should refrain from using special characters or numbers to get higher search rankings or for decorative purposes. Your description should provide details about what the add-on "
-"does, how a user should take advantage of it, and what the user should expect when they install it. Links to external documents for detailed instructions are fine, but the description itself should"
-" cover the basics and leave users confident that they know what they'll get. Also, it is important that you maintain version notes appropriately as you improve and change your add-on. Users should "
+"<strong>Is the add-on clearly and accurately described?</strong> It's of the utmost importance to us that users get what they expect when they try a new add-on. Your add-on name should be clear and "
+"concise, and you should refrain from using special characters or numbers to get higher search rankings or for decorative purposes. Your description should provide details about what the add-on "
+"does, how a user should take advantage of it, and what the user should expect when they install it. Links to external documents for detailed instructions are fine, but the description itself should "
+"cover the basics and leave users confident that they know what they'll get. Also, it is important that you maintain version notes appropriately as you improve and change your add-on. Users should "
 "be able to see what's new in an add-on they may have tried previously, and should be made aware of changes that might affect their current use of the add-on when they update."
 msgstr ""
 
@@ -5947,8 +5880,8 @@ msgstr ""
 #: src/olympia/devhub/templates/devhub/docs/policies-submission.html:37
 msgid ""
 "<strong>Has the add-on been well-tested, and is it free of obvious or serious defects?</strong> One important thing that we look for when considering an add-on is whether its user reviews indicate "
-"that it has received thorough testing, and that it doesn't have serious problems or negative impacts on the browser. If reviewers report problems such as major performance issues, crashes, frequent"
-" problems using the functions of the add-on, or spamming of messages to the error console, you should take those reports to heart, and re-submit your add-on after you've addressed them as best you "
+"that it has received thorough testing, and that it doesn't have serious problems or negative impacts on the browser. If reviewers report problems such as major performance issues, crashes, frequent "
+"problems using the functions of the add-on, or spamming of messages to the error console, you should take those reports to heart, and re-submit your add-on after you've addressed them as best you "
 "can. We don't expect you to perfectly optimize or have zero bugs &mdash; Firefox itself undergoes constant improvement in these areas &mdash; but we do want you to take reasonable efforts to "
 "minimize downsides, and to clearly call out cases where users may be surprised by those that remain."
 msgstr ""
@@ -5956,8 +5889,8 @@ msgstr ""
 #: src/olympia/devhub/templates/devhub/docs/policies-submission.html:43
 msgid ""
 "<strong>Do the add-on and add-on author both treat the user respectfully?</strong> Your software should not intrude on the user unnecessarily, try to trick the user, or conceal any of its "
-"activities from the user. Users (or even non-users) are sometimes rude in their comments, and while we will do our best to filter out inaccurate reviews as they're reported to us, we do expect that"
-" authors will avoid retaliating with rudeness of their own."
+"activities from the user. Users (or even non-users) are sometimes rude in their comments, and while we will do our best to filter out inaccurate reviews as they're reported to us, we do expect that "
+"authors will avoid retaliating with rudeness of their own."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/docs/policies-submission.html:49
@@ -5968,8 +5901,8 @@ msgstr ""
 
 #: src/olympia/devhub/templates/devhub/docs/policies-submission.html:55
 msgid ""
-"We are constantly looking at ways to improve the organization of the site to better accommodate add-ons that are exemplary in other ways, but are aimed at only a small community of potential users."
-" Correctly categorizing and maintaining the metadata of your add-on will help us figure out how we can surface more of those sorts of add-ons to people who are most likely to benefit from them."
+"We are constantly looking at ways to improve the organization of the site to better accommodate add-ons that are exemplary in other ways, but are aimed at only a small community of potential users. "
+"Correctly categorizing and maintaining the metadata of your add-on will help us figure out how we can surface more of those sorts of add-ons to people who are most likely to benefit from them."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/docs/policies-submission.html:61
@@ -5980,8 +5913,8 @@ msgstr ""
 
 #: src/olympia/devhub/templates/devhub/docs/policies-submission.html:67
 msgid ""
-"<strong>Is the add-on free of unlicensed trademarks and copyrights?</strong> Though you may mean no harm to the holder of a trademark, or the owner of a copyrighted work, we can't host add-ons that"
-" infringe on trademarks or copyrights. If you don't have permission to use a trademarked name or image, please do not submit your add-on to us. If your add-on includes code that is copyrighted by "
+"<strong>Is the add-on free of unlicensed trademarks and copyrights?</strong> Though you may mean no harm to the holder of a trademark, or the owner of a copyrighted work, we can't host add-ons that "
+"infringe on trademarks or copyrights. If you don't have permission to use a trademarked name or image, please do not submit your add-on to us. If your add-on includes code that is copyrighted by "
 "someone else, and is not licensed to you to use in your add-on, please do not submit your add-on to us."
 msgstr ""
 
@@ -6005,8 +5938,8 @@ msgstr "Αδειοδότηση"
 
 #: src/olympia/devhub/templates/devhub/docs/policies-submission.html:86
 msgid ""
-"Selecting an appropriate license for your add-on is a very important step in the submission process. A license specifies the rights you grant on your source code and is important in protecting your"
-" intellectual property."
+"Selecting an appropriate license for your add-on is a very important step in the submission process. A license specifies the rights you grant on your source code and is important in protecting your "
+"intellectual property."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/docs/policies-submission.html:92
@@ -6051,64 +5984,55 @@ msgstr ""
 msgid "How to get in touch with us regarding these policies or your add-on."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:6
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:10
 msgid "You have disabled this add-on"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:20
-msgid ""
-"Your add-on's listing is disabled and is not showing\n"
-"                             anywhere in our gallery or update service."
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:24
+msgid "Your add-on's listing is disabled and is not showing anywhere in our gallery or update service."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:25
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:27
 msgid "Please complete your add-on."
 msgstr "Παρακαλούμε ολοκληρώστε το πρόσθετο σας."
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:29
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:30
 msgid "You will receive an email when the review is complete."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:34
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:33
 msgid "You will receive an email when the review is complete. Until then, your add-on is not listed in our gallery but can be accessed directly from its details page."
 msgstr "Θα λάβετε ένα email όταν ολοκληρωθεί η αξιολόγηση. Μέχρι τότε, το πρόσθετο σας δεν θα εμφανίζεται γενικά στις σελίδες μας αλλά θα μπορείτε να το δείτε μόνο απευθείας στη σελίδα προβολής του."
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:38 src/olympia/devhub/templates/devhub/includes/addon_details.html:48
-msgid ""
-"You will receive an email when the review is\n"
-"                             complete and your add-on is signed."
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:37 src/olympia/devhub/templates/devhub/includes/addon_details.html:45
+msgid "You will receive an email when the review is complete and your add-on is signed."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:44
-msgid "You will receive an email when the review is complete. Until then, your add-on is not listed in our gallery but can be accessed directly from its details page."
-msgstr "Θα λάβετε ένα email όταν ολοκληρωθεί η αξιολόγηση. Μέχρι τότε, το πρόσθετο σας δεν θα εμφανίζεται γενικά στις σελίδες μας αλλά θα μπορείτε να το δείτε μόνο απευθείας στη σελίδα προβολής του."
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:41
+msgid "You will receive an email when the review is complete. Until then, your add-on is not listed in our gallery but can be accessed directly from its details page. "
+msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:54
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:49
 msgid "Your add-on is displayed in our gallery and users are receiving automatic updates."
 msgstr "Το πρόσθετο σας εμφανίζεται κανονικά στις σελίδες μας κι οι χρήστες θα λαμβάνουν αυτόματα ενημερώσεις."
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:57
-msgid ""
-"Your add-on has been signed and can be bundled with an\n"
-"                             application installer."
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:52
+msgid "Your add-on has been signed and can be bundled with an application installer."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:63
-msgid ""
-"Your add-on was disabled by a site administrator and is no\n"
-"                             longer shown in our gallery. If you have any questions,\n"
-"                             please email amo-admins@mozilla.org."
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:56
+msgid "Your add-on was disabled by a site administrator and is no longer shown in our gallery. If you have any questions, please email amo-admins@mozilla.org."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:70
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:62
 msgid "Your add-on is displayed in our gallery as experimental and users are receiving automatic updates. Some features are unavailable to your add-on."
 msgstr "Το πρόσθετο σας εμφανίζεται στις σελίδες μας σαν πειραματικό και οι χρήστες θα λαμβάνουν αυτόματα ενημερώσεις. Ορισμένα χαρακτηριστικά δεν είναι διαθέσιμα στο πρόσθετο σας."
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:74
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:66
 msgid "Your add-on has been signed."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:79
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:69
 msgid ""
 "You will receive an email when the full review is complete. Until then, your add-on is displayed in our gallery as experimental and users are receiving automatic updates. Some features are "
 "unavailable to your add-on."
@@ -6116,53 +6040,41 @@ msgstr ""
 "Θα λάβετε ένα email όταν ολοκληρωθεί η πλήρης αξιολόγηση. Μέχρι τότε, το πρόσθετο σας θα εμφανίζεται στις σελίδες μας σαν πειραματικό και οι χρήστες θα λαμβάνουν αυτόματα ενημερώσεις. Ορισμένα "
 "χαρακτηριστικά δεν είναι διαθέσιμα στο πρόσθετο σας."
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:84
-msgid ""
-"You will receive an email when the full review is\n"
-"                             complete, making you able to bundle your add-on with an\n"
-"                             application installer."
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:74
+msgid "You will receive an email when the full review is complete, making you able to bundle your add-on with an application installer."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:91
-msgid ""
-"All add-ons hosted in our gallery must now be reviewed by an\n"
-"                             editor. If you wish to continue hosting your add-on, please\n"
-"                             click to select a review process."
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:79
+msgid "All add-ons hosted in our gallery must now be reviewed by an editor. If you wish to continue hosting your add-on, please click to select a review process."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:113
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:100
 msgid "Current Version:"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:115
-msgid ""
-"This is the version of your add-on that will\n"
-"                                           be installed if someone clicks the Install\n"
-"                                           button on addons.mozilla.org. It is only\n"
-"                                           relevant for listed add-ons."
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:102
+msgid "This is the version of your add-on that will be installed if someone clicks the Install button on addons.mozilla.org. It is only relevant for listed add-ons."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:123
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:110
 msgid "Created:"
 msgstr ""
 
 #. {0} is a date. dennis-ignore: E201
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:125 src/olympia/devhub/templates/devhub/includes/addon_details.html:131
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:112 src/olympia/devhub/templates/devhub/includes/addon_details.html:118
 #, python-format
 msgid "%%b %%e, %%Y"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:136
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:123
 msgid "Next Version:"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:138
-msgid ""
-"This is the newest uploaded version, however\n"
-"                                           it isn’t live on the site yet."
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:125
+msgid "This is the newest uploaded version, however it isn’t live on the site yet."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:144 src/olympia/devhub/templates/devhub/versions/list.html:30
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:130 src/olympia/devhub/templates/devhub/versions/list.html:30
 msgid "Queues are not reviewed strictly in order"
 msgstr ""
 
@@ -6232,9 +6144,7 @@ msgid "View the blog &#9658;"
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/includes/license_form.html:6
-msgid ""
-"Please choose a license appropriate for the rights you grant on your source code.\n"
-"                  It is only relevant for listed add-ons."
+msgid "Please choose a license appropriate for the rights you grant on your source code. It is only relevant for listed add-ons."
 msgstr ""
 
 #. {0} is a list of HTML tags.
@@ -6261,14 +6171,11 @@ msgstr[1] "Επιλέξτε <b>μέχρι {0}</b> {1} κατηγορίες γι�
 #: src/olympia/devhub/templates/devhub/includes/policy_form.html:4
 msgid ""
 "Users will be required to accept the following End-User License Agreement (EULA) prior to installing your add-on. The presence of a EULA significantly affects the number of downloads an add-on "
-"receives. Please note that a EULA is not the same as a code license, such as the GPL or MPL.\n"
-"                It is only relevant for listed add-ons."
+"receives. Please note that a EULA is not the same as a code license, such as the GPL or MPL.It is only relevant for listed add-ons."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/policy_form.html:21
-msgid ""
-"If your add-on transmits any data from the user's computer, a privacy policy is required that explains what data is sent and how it is used.\n"
-"                It is only relevant for listed add-ons."
+#: src/olympia/devhub/templates/devhub/includes/policy_form.html:24
+msgid "If your add-on transmits any data from the user's computer, a privacy policy is required that explains what data is sent and how it is used. It is only relevant for listed add-ons."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/includes/source_form_field.html:2
@@ -6404,8 +6311,8 @@ msgstr "Θα στείλουμε αυτόματα μήνυμα ηλεκτρονι
 
 #: src/olympia/devhub/templates/devhub/payments/voluntary.html:49
 msgid ""
-"We recommend thanking the user and telling them how much you appreciate their support. You might also want to tell them about what's next for your add-on and about any other add-ons you've made for"
-" them to try."
+"We recommend thanking the user and telling them how much you appreciate their support. You might also want to tell them about what's next for your add-on and about any other add-ons you've made for "
+"them to try."
 msgstr ""
 "Συνιστούμε να ευχαριστήσετε τους χρήστες σας και να τους εκφράσετε την εκτίμηση σας για την υποστήριξη που σας παρέχουν. Μπορείτε επίσης να αναφέρετε τι σχεδιάζετε για το μέλλον του πρόσθετου σας "
 "και για τυχόν άλλα πρόσθετα που ίσως τους ενδιαφέρει να δοκιμάσουν."
@@ -6438,12 +6345,8 @@ msgstr ""
 msgid "Add some tags to describe your Theme."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/personas/edit.html:106
-msgid ""
-"A short explanation of your theme's\n"
-"                                basic functionality that is displayed in\n"
-"                                search and browse listings, as well as at\n"
-"                                the top of your theme's details page."
+#: src/olympia/devhub/templates/devhub/personas/edit.html:106 src/olympia/devhub/templates/devhub/personas/submit.html:54
+msgid "A short explanation of your theme's basic functionality that is displayed in search and browse listings, as well as at the top of your theme's details page."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/personas/edit.html:122 src/olympia/devhub/templates/devhub/personas/submit.html:68
@@ -6513,7 +6416,7 @@ msgid "Upon upload and form submission, the AMO Team will review your updated de
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/personas/edit.html:241
-msgid "Your previously resubmitted design,  which is under pending review."
+msgid "Your previously resubmitted design, which is under pending review."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/personas/edit.html:245
@@ -6580,14 +6483,6 @@ msgstr ""
 
 #: src/olympia/devhub/templates/devhub/personas/submit.html:33
 msgid "Give your Theme a name."
-msgstr ""
-
-#: src/olympia/devhub/templates/devhub/personas/submit.html:54
-msgid ""
-"A short explanation of your theme's\n"
-"                                      basic functionality that is displayed in\n"
-"                                      search and browse listings, as well as at\n"
-"                                      the top of your theme's details page."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/personas/submit.html:198
@@ -6664,30 +6559,16 @@ msgstr "Επιλογή διαφορετικής εικόνας υποσέλιδ�
 msgid "Files added to reviewed versions must be reviewed before they will be available for download."
 msgstr "Αρχεία που προστίθενται σε αξιολογημένες εκδόσεις θα πρέπει να αξιολογηθούν για να είναι διαθέσιμα για λήψη."
 
-#: src/olympia/devhub/templates/devhub/versions/add_file_modal.html:15
-#, python-format
-msgid ""
-"Submission of updates to unlisted add-ons for signing is currently in an open beta. Manual review may still be required for a large number of add-ons. Please <a href=\"%(url)s\" "
-"target=\"_blank\">report any bugs</a> that you encounter."
-msgstr ""
-
-#: src/olympia/devhub/templates/devhub/versions/add_file_modal.html:35
+#: src/olympia/devhub/templates/devhub/versions/add_file_modal.html:24
 msgid "Select the target platform for this file."
 msgstr "Επιλογή πλατφόρμας αυτού του αρχείου."
 
-#: src/olympia/devhub/templates/devhub/versions/add_file_modal.html:46
+#: src/olympia/devhub/templates/devhub/versions/add_file_modal.html:35
 msgid "Which review type would you like to nominate for?"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/add_file_modal.html:51
+#: src/olympia/devhub/templates/devhub/versions/add_file_modal.html:40
 msgid "Only publish this version to my beta channel."
-msgstr ""
-
-#: src/olympia/devhub/templates/devhub/versions/add_file_modal.html:54
-#, python-format
-msgid ""
-"The behavior of the beta channel has changed to accommodate <a href=\"%(addon_signing_url)s\" target=\"_blank\">mandatory add-on signing</a>. The new process is currently in an open beta, and may "
-"change significantly in the near future. Please <a href=\"%(issues_url)s\" target=\"_blank\">report any bugs</a> that you encounter."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/versions/edit.html:5
@@ -6711,12 +6592,6 @@ msgstr "Αρχεία"
 #: src/olympia/devhub/templates/devhub/versions/edit.html:38
 msgid "Upload Another File"
 msgstr "Αποστολή κι άλλου αρχείου"
-
-#: src/olympia/devhub/templates/devhub/versions/edit.html:45
-msgid "Adjusting application information here will allow users to install your add-on even if the install manifest in the package indicates that the add-on is incompatible."
-msgstr ""
-"Η προσαρμογή των πληροφοριών για την εφαρμογή από εδώ, θα επιτρέψει στους χρήστες να εγκαταστήσουν το πρόσθετο σας ακόμη κι αν το αρχείο install manifest του πακέτου υποδεικνύει ότι δεν είναι "
-"συμβατό."
 
 #: src/olympia/devhub/templates/devhub/versions/edit.html:74
 msgid ""
@@ -6813,7 +6688,7 @@ msgstr "Αίτηση πλήρους αξιολόγησης"
 msgid "Request Preliminary Review"
 msgstr "Αίτηση εισαγωγικής αξιολόγησης"
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:80 src/olympia/devhub/templates/devhub/versions/list.html:327 src/olympia/devhub/templates/devhub/versions/list.html:350
+#: src/olympia/devhub/templates/devhub/versions/list.html:80 src/olympia/devhub/templates/devhub/versions/list.html:325 src/olympia/devhub/templates/devhub/versions/list.html:348
 msgid "Cancel Review Request"
 msgstr "Ακύρωση αιτήματος αξιολόγησης"
 
@@ -6842,7 +6717,7 @@ msgid "Unlisted:"
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/versions/list.html:114
-msgid "Not distributed on {0}. Developers will upload new versions for signing and distribute the add-ons on their own. (beta)"
+msgid "Not distributed on {0}. Developers will upload new versions for signing and distribute the add-ons on their own."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/versions/list.html:122
@@ -6893,7 +6768,8 @@ msgid "Delete Version {version}"
 msgstr "Διαγραφή της έκδοσης {version}"
 
 #: src/olympia/devhub/templates/devhub/versions/list.html:218
-msgid "You are about to delete the current version of your add-on. This may cause your add-on status to change, or your listing to lose public visibility, if this is the only public version of your add-on."
+msgid ""
+"You are about to delete the current version of your add-on. This may cause your add-on status to change, or your listing to lose public visibility, if this is the only public version of your add-on."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/versions/list.html:219
@@ -6905,83 +6781,75 @@ msgid "<strong>Important:</strong> Once a version has been deleted, you may not 
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/versions/list.html:230
-msgid ""
-"Deleting a version which has already been reviewed\n"
-"               may also cause a significant delay in the review of\n"
-"               your next update."
-msgstr ""
-
-#: src/olympia/devhub/templates/devhub/versions/list.html:233
 msgid "Are you sure you wish to delete this version?"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:238
+#: src/olympia/devhub/templates/devhub/versions/list.html:235
 msgid "Delete Version"
 msgstr "Διαγραφή έκδοσης"
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:240
+#: src/olympia/devhub/templates/devhub/versions/list.html:237
 msgid "Disable Version"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:247
+#: src/olympia/devhub/templates/devhub/versions/list.html:244
 msgid "Add a new Version"
 msgstr "Προσθήκη νέας έκδοσης"
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:249
+#: src/olympia/devhub/templates/devhub/versions/list.html:246
 msgid "Add Version"
 msgstr "Προσθήκη έκδοσης"
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:256 src/olympia/devhub/templates/devhub/versions/list.html:274
+#: src/olympia/devhub/templates/devhub/versions/list.html:253 src/olympia/devhub/templates/devhub/versions/list.html:279
 msgid "Hide Add-on"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:259
+#: src/olympia/devhub/templates/devhub/versions/list.html:256
 msgid "Hiding your add-on will prevent it from appearing anywhere in our gallery and will stop users from receiving automatic updates."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:265
+#: src/olympia/devhub/templates/devhub/versions/list.html:263
+msgid "The files awaiting review will be disabled and you will need to upload new versions."
+msgstr ""
+
+#: src/olympia/devhub/templates/devhub/versions/list.html:270
 msgid "Are you sure you wish to hide your add-on?"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:286 src/olympia/devhub/templates/devhub/versions/list.html:315
+#: src/olympia/devhub/templates/devhub/versions/list.html:291 src/olympia/devhub/templates/devhub/versions/list.html:313
 msgid "Unlist Add-on"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:289
+#: src/olympia/devhub/templates/devhub/versions/list.html:294
 #, python-format
 msgid ""
 "Unlisting your add-on will make it (and each of its versions/files) invisible on this website. It won't show up in searches, won't have a public facing page, and won't be updated automatically for "
-"current users.  It is recommended for unlisted add-ons to provide a custom <a href=\"%(update_url)s\" target=\"_blank\">updateURL</a> in their manifest file for automatic updates."
+"current users. It is recommended for unlisted add-ons to provide a custom <a href=\"%(update_url)s\" target=\"_blank\">updateURL</a> in their manifest file for automatic updates."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:299
-#, python-format
-msgid "Switching add-ons to unlisted is currently in an open beta. Please <a href=\"%(url)s\" target=\"_blank\">report any bugs</a> that you encounter."
-msgstr ""
-
-#: src/olympia/devhub/templates/devhub/versions/list.html:305
+#: src/olympia/devhub/templates/devhub/versions/list.html:303
 msgid "Unlisting an add-on is irreversible!"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:305
+#: src/olympia/devhub/templates/devhub/versions/list.html:303
 msgid "An unlisted add-on cannot be switched to be listed."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:307
+#: src/olympia/devhub/templates/devhub/versions/list.html:305
 msgid "Are you sure you wish to unlist your add-on?"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:330
+#: src/olympia/devhub/templates/devhub/versions/list.html:328
 msgid "Canceling your review request will leave your add-on as preliminarily reviewed."
 msgstr "Η ακύρωση του αιτήματος για αξιολόγηση θα αφήσει το πρόσθετο σας σαν προκαταρκτικά αξιολογημένο."
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:335
+#: src/olympia/devhub/templates/devhub/versions/list.html:333
 msgid "Canceling your review request will mark your add-on incomplete. If you do not complete your add-on after several days by re-requesting review, it will be deleted."
 msgstr ""
 "Η ακύρωση του αιτήματος αξιολόγησης θα έχει ως αποτέλεσμα τη σημείωση του πρόσθετου σας ως ημιτελούς. Αν δεν ολοκληρώσετε το πρόσθετο σας μετά από μερικές ημέρες με νέα αίτηση αξιολόγησης, θα "
 "διαγραφεί."
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:343
+#: src/olympia/devhub/templates/devhub/versions/list.html:341
 msgid "Are you sure you wish to cancel your review request?"
 msgstr "Θέλετε σίγουρα να ακυρωθεί η αίτηση σας για αξιολόγηση;"
 
@@ -7161,8 +7029,8 @@ msgstr "Τί είναι τα πρόσθετα;"
 #, python-format
 msgid "Add-ons are applications that let you personalize %(app)s with extra functionality or style. Try a time-saving sidebar, a weather notifier, or a themed look to make %(app)s your own."
 msgstr ""
-"Τα πρόσθετα είναι μικρές εφαρμογές που σας επιτρέπουν να προσαρμόσετε τον %(app)s με νέες λειτουργίες ή στυλ.  Δοκιμάστε μια πλευρική στήλη, μια εφαρμογή για την προβολή μετεωρολογικών προγνώσεων ή"
-" ένα νέο θέμα εμφάνισης για να ξεκινήσετε να κάνετε τον %(app)s πραγματικά δικό σας."
+"Τα πρόσθετα είναι μικρές εφαρμογές που σας επιτρέπουν να προσαρμόσετε τον %(app)s με νέες λειτουργίες ή στυλ.  Δοκιμάστε μια πλευρική στήλη, μια εφαρμογή για την προβολή μετεωρολογικών προγνώσεων ή "
+"ένα νέο θέμα εμφάνισης για να ξεκινήσετε να κάνετε τον %(app)s πραγματικά δικό σας."
 
 #: src/olympia/discovery/templates/discovery/pane.html:62
 msgid "Learn More About Add-ons"
@@ -7324,19 +7192,19 @@ msgstr ""
 msgid "Search by add-on name / author email"
 msgstr "Αναζήτηση με βάση το όνομα του πρόσθετου/ email δημιουργού"
 
-#: src/olympia/editors/forms.py:103
+#: src/olympia/editors/forms.py:103 src/olympia/editors/forms.py:244 src/olympia/editors/forms.py:257
 msgid "yes"
 msgstr "ναι"
 
-#: src/olympia/editors/forms.py:104
+#: src/olympia/editors/forms.py:104 src/olympia/editors/forms.py:244 src/olympia/editors/forms.py:257
 msgid "no"
 msgstr "όχι"
 
-#: src/olympia/editors/forms.py:105
+#: src/olympia/editors/forms.py:105 src/olympia/editors/forms.py:245
 msgid "Admin Flag"
 msgstr "Σήμανση για διαχειριστές"
 
-#: src/olympia/editors/forms.py:113
+#: src/olympia/editors/forms.py:113 src/olympia/editors/forms.py:253
 msgid "Max. Version"
 msgstr "Μέγιστη έκδοση"
 
@@ -7348,55 +7216,59 @@ msgstr "Ημέρες από την υποβολή"
 msgid "Add-on Types"
 msgstr "Τύποι πρόσθετων"
 
-#: src/olympia/editors/forms.py:126 src/olympia/editors/helpers.py:267
+#: src/olympia/editors/forms.py:126 src/olympia/editors/helpers.py:279
 msgid "Platforms"
 msgstr "Πλατφόρμες"
 
+#: src/olympia/editors/forms.py:237
+msgid "Search by add-on name / author email / guid"
+msgstr ""
+
 #. L10n: 0 = platform, 1 = filename, 2 = status message
-#: src/olympia/editors/forms.py:238
+#: src/olympia/editors/forms.py:342
 #, python-format
 msgid "<strong>%s</strong> &middot; %s &middot; %s"
 msgstr "<strong>%s</strong> &middot; %s &middot; %s"
 
-#: src/olympia/editors/forms.py:252
+#: src/olympia/editors/forms.py:356
 msgid "Comments:"
 msgstr "Σχόλια:"
 
-#: src/olympia/editors/forms.py:256
+#: src/olympia/editors/forms.py:360
 msgid "Operating systems:"
 msgstr "Λειτουργικά συστήματα:"
 
-#: src/olympia/editors/forms.py:258
+#: src/olympia/editors/forms.py:362
 msgid "Applications:"
 msgstr "Εφαρμογές:"
 
-#: src/olympia/editors/forms.py:260
+#: src/olympia/editors/forms.py:364
 msgid "Notify me the next time this add-on is updated. (Subsequent updates will not generate an email)"
 msgstr "Να ειδοποιηθώ την επόμενη φορά που θα ενημερωθεί το πρόσθετο. (Θα αποσταλεί μήνυμα μόνο για την πρώτη ενημέρωση)"
 
-#: src/olympia/editors/forms.py:265
+#: src/olympia/editors/forms.py:369
 msgid "Clear Admin Review Flag"
 msgstr ""
 
-#: src/olympia/editors/forms.py:267
+#: src/olympia/editors/forms.py:371
 msgid "Clear more info requested flag"
 msgstr ""
 
-#: src/olympia/editors/forms.py:281
+#: src/olympia/editors/forms.py:385
 msgid "Choose a canned response..."
 msgstr "Επιλέξτε τυποποιημένη απάντηση..."
 
 #. L10n: Description of what can be searched for.
-#: src/olympia/editors/forms.py:324
+#: src/olympia/editors/forms.py:423
 msgid "theme name"
 msgstr "όνομα θέματος"
 
-#: src/olympia/editors/forms.py:350
+#: src/olympia/editors/forms.py:449
 msgid "Someone else is reviewing this theme."
 msgstr "Κάποιος άλλος αξιολογεί αυτό το θέμα"
 
 #. L10n: Description of what can be searched for.
-#: src/olympia/editors/forms.py:447
+#: src/olympia/editors/forms.py:546
 msgid "app, reviewer, or comment"
 msgstr "εφαρμογές, κριτικοί, ή σχόλια"
 
@@ -7412,250 +7284,268 @@ msgstr "Σε αναμονή εισαγωγικής αξιολόγησης"
 msgid "Rejected or Unreviewed"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:123 src/olympia/editors/helpers.py:136
+#: src/olympia/editors/helpers.py:125 src/olympia/editors/helpers.py:138
 msgid "Queue"
 msgstr "Ουρά αναμονής"
 
-#: src/olympia/editors/helpers.py:124 src/olympia/editors/templates/editors/base.html:50 src/olympia/editors/templates/editors/base.html:65
+#: src/olympia/editors/helpers.py:126 src/olympia/editors/templates/editors/base.html:50 src/olympia/editors/templates/editors/base.html:65
 msgid "Pending Updates"
 msgstr "Ενημερώσεις σε αναμονή"
 
-#: src/olympia/editors/helpers.py:125 src/olympia/editors/templates/editors/base.html:48 src/olympia/editors/templates/editors/base.html:63
+#: src/olympia/editors/helpers.py:127 src/olympia/editors/templates/editors/base.html:48 src/olympia/editors/templates/editors/base.html:63
 msgid "Full Reviews"
 msgstr "Πλήρεις αξιολογήσεις"
 
-#: src/olympia/editors/helpers.py:126 src/olympia/editors/templates/editors/base.html:52 src/olympia/editors/templates/editors/base.html:67
+#: src/olympia/editors/helpers.py:128 src/olympia/editors/templates/editors/base.html:52 src/olympia/editors/templates/editors/base.html:67
 msgid "Preliminary Reviews"
 msgstr "Εισαγωγικές αξιολογήσεις"
 
-#: src/olympia/editors/helpers.py:127 src/olympia/editors/templates/editors/base.html:54
+#: src/olympia/editors/helpers.py:129 src/olympia/editors/templates/editors/base.html:54
 msgid "Moderated Reviews"
 msgstr "Ελεγμένες αξιολογήσεις"
 
-#: src/olympia/editors/helpers.py:128 src/olympia/editors/templates/editors/base.html:46
+#: src/olympia/editors/helpers.py:130 src/olympia/editors/templates/editors/base.html:46
 msgid "Fast Track"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:130
+#: src/olympia/editors/helpers.py:132
 msgid "Pending Themes"
 msgstr "Θέματα σε αναμονή"
 
-#: src/olympia/editors/helpers.py:131 src/olympia/editors/templates/editors/themes/queue.html:4
+#: src/olympia/editors/helpers.py:133 src/olympia/editors/templates/editors/themes/queue.html:4
 msgid "Flagged Themes"
 msgstr "Θέματα με επισήμανση"
 
-#: src/olympia/editors/helpers.py:132
+#: src/olympia/editors/helpers.py:134
 msgid "Update Themes"
 msgstr "Ενημέρωση θεμάτων"
 
-#: src/olympia/editors/helpers.py:137
+#: src/olympia/editors/helpers.py:139
 msgid "Unlisted Pending Updates"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:138
+#: src/olympia/editors/helpers.py:140
 msgid "Unlisted Full Reviews"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:139
+#: src/olympia/editors/helpers.py:141
 msgid "Unlisted Preliminary Reviews"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:170
+#: src/olympia/editors/helpers.py:142
+msgid "Unlisted All Add-ons"
+msgstr ""
+
+#: src/olympia/editors/helpers.py:173
 msgid "Fast Track ({0})"
 msgid_plural "Fast Track ({0})"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/olympia/editors/helpers.py:175
+#: src/olympia/editors/helpers.py:178
 msgid "Full Review ({0})"
 msgid_plural "Full Reviews ({0})"
 msgstr[0] "Πλήρης αξιολόγηση ({0})"
 msgstr[1] "Πλήρης αξιολογήσεις ({0})"
 
-#: src/olympia/editors/helpers.py:180
+#: src/olympia/editors/helpers.py:183
 msgid "Pending Update ({0})"
 msgid_plural "Pending Updates ({0})"
 msgstr[0] "Ενημέρωση σε αναμονή ({0})"
 msgstr[1] "Ενημερώσεις σε αναμονή ({0})"
 
-#: src/olympia/editors/helpers.py:185
+#: src/olympia/editors/helpers.py:188
 msgid "Preliminary Review ({0})"
 msgid_plural "Preliminary Reviews ({0})"
 msgstr[0] "Εισαγωγική αξιολόγηση ({0})"
 msgstr[1] "Εισαγωγικές αξιολογήσεις ({0})"
 
-#: src/olympia/editors/helpers.py:190
+#: src/olympia/editors/helpers.py:193
 msgid "Moderated Review ({0})"
 msgid_plural "Moderated Reviews ({0})"
 msgstr[0] "Ελεγμένη αξιολόγηση ({0})"
 msgstr[1] "Ελεγμένες αξιολογήσεις ({0})"
 
-#: src/olympia/editors/helpers.py:196
+#: src/olympia/editors/helpers.py:199
 msgid "Unlisted Full Review ({0})"
 msgid_plural "Unlisted Full Reviews ({0})"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/olympia/editors/helpers.py:201
+#: src/olympia/editors/helpers.py:204
 msgid "Unlisted Pending Update ({0})"
 msgid_plural "Unlisted Pending Updates ({0})"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/olympia/editors/helpers.py:206
+#: src/olympia/editors/helpers.py:209
 msgid "Unlisted Preliminary Review ({0})"
 msgid_plural "Unlisted Preliminary Reviews ({0})"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/olympia/editors/helpers.py:261
-msgid "Addon"
-msgstr "Πρόσθετο"
+#: src/olympia/editors/helpers.py:214
+msgid "Unlisted All Add-ons ({0})"
+msgid_plural "Unlisted All Add-ons ({0})"
+msgstr[0] ""
+msgstr[1] ""
 
-#: src/olympia/editors/helpers.py:262
+#: src/olympia/editors/helpers.py:274
 msgid "Type"
 msgstr "Τύπος"
 
-#: src/olympia/editors/helpers.py:263
+#: src/olympia/editors/helpers.py:275
 msgid "Waiting Time"
 msgstr "Χρόνος αναμονής"
 
-#: src/olympia/editors/helpers.py:264 src/olympia/editors/templates/editors/review.html:285
+#: src/olympia/editors/helpers.py:276 src/olympia/editors/templates/editors/review.html:285
 msgid "Flags"
 msgstr "Σημάνσεις"
 
-#: src/olympia/editors/helpers.py:265
+#: src/olympia/editors/helpers.py:277
 msgid "Applications"
 msgstr "Εφαρμογές"
 
-#: src/olympia/editors/helpers.py:270
+#: src/olympia/editors/helpers.py:282
 msgid "Additional"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:285
+#: src/olympia/editors/helpers.py:302
 msgid "Site Specific"
 msgstr "Σχετικό με ιστότοπο"
 
-#: src/olympia/editors/helpers.py:287
+#: src/olympia/editors/helpers.py:304
 msgid "Requires External Software"
 msgstr "Απαιτεί πρόσθετο λογισμικό τρίτων"
 
-#: src/olympia/editors/helpers.py:289
+#: src/olympia/editors/helpers.py:306
 msgid "Binary Components"
 msgstr "Εκτελέσιμα στοιχεία"
 
-#: src/olympia/editors/helpers.py:313
+#: src/olympia/editors/helpers.py:339
 msgid "moments ago"
 msgstr "πριν λίγο"
 
 #. L10n: first argument is number of minutes
-#: src/olympia/editors/helpers.py:316
+#: src/olympia/editors/helpers.py:342
 msgid "{0} minute"
 msgid_plural "{0} minutes"
 msgstr[0] "{0} λεπτό"
 msgstr[1] "{0} λεπτά"
 
 #. L10n: first argument is number of hours
-#: src/olympia/editors/helpers.py:320
+#: src/olympia/editors/helpers.py:346
 msgid "{0} hour"
 msgid_plural "{0} hours"
 msgstr[0] "{0} ώρα"
 msgstr[1] "{0} ώρες"
 
 #. L10n: first argument is number of days
-#: src/olympia/editors/helpers.py:324
+#: src/olympia/editors/helpers.py:350
 msgid "{0} day"
 msgid_plural "{0} days"
 msgstr[0] "{0} ημέρα"
 msgstr[1] "{0} ημέρες"
 
-#: src/olympia/editors/helpers.py:488
+#: src/olympia/editors/helpers.py:364
+msgid "Last Review"
+msgstr ""
+
+#: src/olympia/editors/helpers.py:366
+msgid "Last Update"
+msgstr ""
+
+#: src/olympia/editors/helpers.py:387
+msgid "No Reviews"
+msgstr ""
+
+#: src/olympia/editors/helpers.py:561
 msgid "Push to public"
 msgstr "Προώθηση στο δημόσιο χώρο "
 
-#: src/olympia/editors/helpers.py:490
+#: src/olympia/editors/helpers.py:563
 msgid "Grant full review"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:505
+#: src/olympia/editors/helpers.py:578
 msgid "Request more information"
 msgstr "Αίτηση περισσότερων πληροφοριών "
 
-#: src/olympia/editors/helpers.py:508
+#: src/olympia/editors/helpers.py:581
 msgid "Request super-review"
 msgstr "Αίτηση για αξιολόγηση συντάκτη"
 
-#: src/olympia/editors/helpers.py:519
+#: src/olympia/editors/helpers.py:592
 msgid "Grant preliminary review"
 msgstr "Απόδοση εισαγωγικής αξιολόγησης"
 
-#: src/olympia/editors/helpers.py:520
+#: src/olympia/editors/helpers.py:593
 msgid "This will mark the files as preliminarily reviewed."
 msgstr ""
 
-#: src/olympia/editors/helpers.py:522
+#: src/olympia/editors/helpers.py:595
 msgid "Use this form to request more information from the author. They will receive an email and be able to answer here. You will be notified by email when they reply."
 msgstr ""
 "Χρησιμοποιείστε αυτή τη φόρμα για να ζητήσετε περισσότερες πληροφορίες από τον δημιουργό. Θα σταλεί ένα email για να ειδοποιηθούν και να απαντήσουν εδώ και θα ειδοποιηθείτε με τη σειρά σας όταν "
 "απαντήσουν."
 
-#: src/olympia/editors/helpers.py:526
+#: src/olympia/editors/helpers.py:599
 msgid ""
 "If you have concerns about this add-on's security, copyright issues, or other concerns that an administrator should look into, enter your comments in the area below. They will be sent to "
 "administrators, not the author."
 msgstr ""
-"Αν πιστεύετε ότι για ένα πρόσθετο υπάρχει κάποιο θέμα με την ασφάλεια, τα πνευματικά δικαιώματα ή κάτι άλλο  που θα πρέπει να δει ένας από τους διαχειριστές μας, εισάγετε τα σχόλια σας στο παρακάτω"
-" πεδίο.  Τα σχόλια σας θα αποσταλούν στους διαχειριστές μας και όχι στον δημιουργό του πρόσθετου."
+"Αν πιστεύετε ότι για ένα πρόσθετο υπάρχει κάποιο θέμα με την ασφάλεια, τα πνευματικά δικαιώματα ή κάτι άλλο  που θα πρέπει να δει ένας από τους διαχειριστές μας, εισάγετε τα σχόλια σας στο παρακάτω "
+"πεδίο.  Τα σχόλια σας θα αποσταλούν στους διαχειριστές μας και όχι στον δημιουργό του πρόσθετου."
 
-#: src/olympia/editors/helpers.py:532
+#: src/olympia/editors/helpers.py:605
 msgid "This will reject the add-on and remove it from the review queue."
 msgstr "Αυτή η ενέργεια θα απορρίψει το πρόσθετο και θα το αφαιρέσει από την ουρά αναμονής αξιολόγησης."
 
-#: src/olympia/editors/helpers.py:534
-msgid "Make a comment on this version.  The author won't be able to see this."
+#: src/olympia/editors/helpers.py:607
+msgid "Make a comment on this version. The author won't be able to see this."
 msgstr ""
 
-#: src/olympia/editors/helpers.py:538
+#: src/olympia/editors/helpers.py:611
 msgid "This will reject the files and remove them from the review queue."
 msgstr "Αυτή η ενέργεια θα απορρίψει τα αρχεία και θα τα αφαιρέσει από την ουρά αναμονής αξιολόγησης."
 
-#: src/olympia/editors/helpers.py:542
+#: src/olympia/editors/helpers.py:615
 msgid "This will mark the add-on as preliminarily reviewed. Future versions will undergo preliminary review."
 msgstr "Αυτή η ενέργεια θα σημειώσει το πρόσθετο ως εισαγωγικώς αξιολογημένο. Οι μελλοντικές του εκδόσεις θα περνάνε  από εισαγωγική  αξιολόγηση."
 
-#: src/olympia/editors/helpers.py:547
+#: src/olympia/editors/helpers.py:620
 msgid "This will mark the files as preliminarily reviewed. Future versions will undergo preliminary review."
 msgstr "Αυτή η ενέργεια θα σημειώσει τα αρχεία ως εισαγωγικώς αξιολογημένα. Οι μελλοντικές τους εκδόσεις θα περνάνε  από εισαγωγική  αξιολόγηση."
 
-#: src/olympia/editors/helpers.py:552
+#: src/olympia/editors/helpers.py:625
 msgid "Retain preliminary review"
 msgstr "Διατήρηση εισαγωγικής αξιολόγησης"
 
-#: src/olympia/editors/helpers.py:553
+#: src/olympia/editors/helpers.py:626
 msgid "This will retain the add-on as preliminarily reviewed. Future versions will undergo preliminary review."
 msgstr "Αυτή η ενέργεια θα διατηρήσει το καθεστώς του πρόσθετου σαν εισαγωγικώς αξιολογημένο. Οι μελλοντικές εκδόσεις του θα περνάνε επίσης από εισαγωγική αξιολόγηση."
 
-#: src/olympia/editors/helpers.py:558
+#: src/olympia/editors/helpers.py:631
 msgid "This will approve a sandboxed version of a public add-on to appear on the public side."
 msgstr "Αυτό θα επιτρέψει να δημοσιευτεί μια έκδοση πρόσθετου που είναι στο sandbox"
 
-#: src/olympia/editors/helpers.py:561
+#: src/olympia/editors/helpers.py:634
 msgid "This will reject a version of a public add-on and remove it from the queue."
 msgstr "Αυτή η ενέργεια θα απορρίψει μια έκδοση πρόσθετου που είναι δημόσιο και θα την αφαιρέσει από την ουρά αναμονής."
 
-#: src/olympia/editors/helpers.py:564
+#: src/olympia/editors/helpers.py:637
 msgid "This will mark the add-on and its most recent version and files as public. Future versions will go into the sandbox until they are reviewed by an editor."
 msgstr "Αυτή η ενέργεια θα σημάνει το πρόσθετο, την πιο πρόσφατη έκδοση του και τα αρχεία του σαν δημόσια. Οι μελλοντικές εκδόσεις θα παραμένουν στο sandbox μέχρι να αξιολογηθούν από συντάκτες."
 
-#: src/olympia/editors/helpers.py:637
+#: src/olympia/editors/helpers.py:714
 msgid "add-on"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:940 src/olympia/editors/helpers.py:960
+#: src/olympia/editors/helpers.py:1020 src/olympia/editors/helpers.py:1040
 msgid "Flagged"
 msgstr "Επισημάνθηκε"
 
-#: src/olympia/editors/helpers.py:944 src/olympia/editors/helpers.py:963
+#: src/olympia/editors/helpers.py:1024 src/olympia/editors/helpers.py:1043
 msgid "Updates"
 msgstr "Ενημερώσεις"
 
@@ -7707,56 +7597,56 @@ msgstr "Η υποβολή του Θέματος επισημάνθηκε για 
 msgid "A question about your Theme submission"
 msgstr "Μια ερώτηση για την υποβολή του Θέματος σας"
 
-#: src/olympia/editors/views.py:144
+#: src/olympia/editors/views.py:146
 msgid "New Add-ons (Under 5 days)"
 msgstr "Νέα πρόσθετα (λιγότερες από 5 ημέρες)"
 
-#: src/olympia/editors/views.py:145
+#: src/olympia/editors/views.py:147
 msgid "Passable (5 to 10 days)"
 msgstr ""
 
-#: src/olympia/editors/views.py:146
+#: src/olympia/editors/views.py:148
 msgid "Overdue (Over 10 days)"
 msgstr ""
 
-#: src/olympia/editors/views.py:532
+#: src/olympia/editors/views.py:539
 msgid "An unknown error occurred"
 msgstr ""
 
-#: src/olympia/editors/views.py:587
+#: src/olympia/editors/views.py:592
 msgid "Self-reviews are not allowed."
 msgstr "Δεν επιτρέπονται αξιολογήσεις για το δικό σας πρόσθετο"
 
-#: src/olympia/editors/views.py:609
+#: src/olympia/editors/views.py:613
 msgid "Review successfully processed."
 msgstr "Η αξιολόγηση επεξεργάστηκε με επιτυχία."
 
-#: src/olympia/editors/views.py:807
+#: src/olympia/editors/views.py:812
 msgid "was approved"
 msgstr "εγκρίθηκε"
 
-#: src/olympia/editors/views.py:808
+#: src/olympia/editors/views.py:813
 msgid "given preliminary review"
 msgstr "δόθηκε εισαγωγική αξιολόγηση"
 
-#: src/olympia/editors/views.py:809
+#: src/olympia/editors/views.py:814
 msgid "rejected"
 msgstr "απορρίφθηκε"
 
-#: src/olympia/editors/views.py:810
+#: src/olympia/editors/views.py:815
 msgctxt "editors_review_history_nominated_adminreview"
 msgid "escalated"
 msgstr "κλιμακώθηκε"
 
-#: src/olympia/editors/views.py:812
+#: src/olympia/editors/views.py:817
 msgid "needs more information"
 msgstr "χρειάζονται περισσότερες πληροφορίες"
 
-#: src/olympia/editors/views.py:813
+#: src/olympia/editors/views.py:818
 msgid "needs super review"
 msgstr "χρειάζεται αξιολόγηση συντάκτη"
 
-#: src/olympia/editors/views.py:814
+#: src/olympia/editors/views.py:819
 msgid "commented"
 msgstr ""
 
@@ -7801,28 +7691,28 @@ msgstr "Λίστες αναμονής"
 msgid "Unlisted Queues"
 msgstr ""
 
-#: src/olympia/editors/templates/editors/base.html:72 src/olympia/editors/templates/editors/performance.html:6
+#: src/olympia/editors/templates/editors/base.html:74 src/olympia/editors/templates/editors/performance.html:6
 msgid "Performance"
 msgstr "Επιδόσεις"
 
-#: src/olympia/editors/templates/editors/base.html:75 src/olympia/editors/templates/editors/themes/base.html:19 src/olympia/editors/templates/editors/themes/base.html:38
+#: src/olympia/editors/templates/editors/base.html:77 src/olympia/editors/templates/editors/themes/base.html:19 src/olympia/editors/templates/editors/themes/base.html:38
 msgid "Logs"
 msgstr "Καταγραφές"
 
-#: src/olympia/editors/templates/editors/base.html:78 src/olympia/editors/templates/editors/reviewlog.html:4 src/olympia/editors/templates/editors/reviewlog.html:27
+#: src/olympia/editors/templates/editors/base.html:80 src/olympia/editors/templates/editors/reviewlog.html:4 src/olympia/editors/templates/editors/reviewlog.html:27
 msgid "Add-on Review Log"
 msgstr ""
 
-#: src/olympia/editors/templates/editors/base.html:80 src/olympia/editors/templates/editors/eventlog.html:4 src/olympia/editors/templates/editors/eventlog.html:8
+#: src/olympia/editors/templates/editors/base.html:82 src/olympia/editors/templates/editors/eventlog.html:4 src/olympia/editors/templates/editors/eventlog.html:8
 #: src/olympia/editors/templates/editors/eventlog_detail.html:4
 msgid "Moderated Review Log"
 msgstr ""
 
-#: src/olympia/editors/templates/editors/base.html:82 src/olympia/editors/templates/editors/beta_signed_log.html:4 src/olympia/editors/templates/editors/beta_signed_log.html:8
+#: src/olympia/editors/templates/editors/base.html:84 src/olympia/editors/templates/editors/beta_signed_log.html:4 src/olympia/editors/templates/editors/beta_signed_log.html:8
 msgid "Signed Beta Files Log"
 msgstr ""
 
-#: src/olympia/editors/templates/editors/base.html:87 src/olympia/editors/templates/editors/includes/daily-message.html:4
+#: src/olympia/editors/templates/editors/base.html:89 src/olympia/editors/templates/editors/includes/daily-message.html:4
 msgid "Announcement"
 msgstr "Ανακοίνωση"
 
@@ -8043,45 +7933,45 @@ msgstr "Προχωρημένη αναζήτηση"
 msgid "clear search"
 msgstr "Εκκαθάριση αναζήτησης"
 
-#: src/olympia/editors/templates/editors/queue.html:72 src/olympia/editors/templates/editors/queue.html:122
+#: src/olympia/editors/templates/editors/queue.html:78 src/olympia/editors/templates/editors/queue.html:128
 msgid "Process Reviews"
 msgstr "Επεξεργασία αξιολογήσεων"
 
-#: src/olympia/editors/templates/editors/queue.html:80
+#: src/olympia/editors/templates/editors/queue.html:86
 msgid "Moderation actions:"
 msgstr "Διαχειριστικές ενέργειες:"
 
-#: src/olympia/editors/templates/editors/queue.html:90
+#: src/olympia/editors/templates/editors/queue.html:96
 #, python-format
 msgid "by %(user)s on %(date)s %(stars)s (%(locale)s)"
 msgstr "από τον/την  %(user)s στις %(date)s %(stars)s (%(locale)s)"
 
-#: src/olympia/editors/templates/editors/queue.html:106
+#: src/olympia/editors/templates/editors/queue.html:112
 #, python-format
 msgid "<strong>%(reason)s</strong> <span class=\"light\">Flagged by %(user)s on %(date)s</span>"
 msgstr ""
 
-#: src/olympia/editors/templates/editors/queue.html:119
+#: src/olympia/editors/templates/editors/queue.html:125
 msgid "All reviews have been moderated. Good work!"
 msgstr "Όλες οι αξιολογήσεις έχουν περάσει από έλεγχο. Συγχαρητήρια!"
 
-#: src/olympia/editors/templates/editors/queue.html:161
+#: src/olympia/editors/templates/editors/queue.html:167
 msgid "Version Notes / Notes for Reviewer"
 msgstr ""
 
-#: src/olympia/editors/templates/editors/queue.html:169
+#: src/olympia/editors/templates/editors/queue.html:175
 msgid "There are currently no add-ons of this type to review."
 msgstr "Προς το παρόν δεν υπάρχουν πρόσθετα αυτού του τύπου για αξιολόγηση."
 
-#: src/olympia/editors/templates/editors/queue.html:181 src/olympia/editors/templates/editors/themes/queue_list.html:85
+#: src/olympia/editors/templates/editors/queue.html:187 src/olympia/editors/templates/editors/themes/queue_list.html:85
 msgid "Helpful Links:"
 msgstr "Χρήσιμοι δεσμοί:"
 
-#: src/olympia/editors/templates/editors/queue.html:182
+#: src/olympia/editors/templates/editors/queue.html:188
 msgid "Add-on Policy"
 msgstr "Πολιτική πρόσθετου"
 
-#: src/olympia/editors/templates/editors/queue.html:184
+#: src/olympia/editors/templates/editors/queue.html:190
 msgid "Editors' Guide"
 msgstr "Οδηγός συντακτών"
 
@@ -8144,10 +8034,7 @@ msgid "<strong>Warning!</strong> Another user was viewing this page before you."
 msgstr ""
 
 #: src/olympia/editors/templates/editors/review.html:237
-msgid ""
-"The whiteboard is the place to exchange information relevant to\n"
-"               this addon (whatever the version), between the developer and the\n"
-"               editor. This is visible and editable by both."
+msgid "The whiteboard is the place to exchange information relevant to this addon (whatever the version), between the developer and the editor. This is visible and editable by both."
 msgstr ""
 
 #: src/olympia/editors/templates/editors/review.html:241
@@ -8248,8 +8135,9 @@ msgstr ""
 msgid "You have <span>{0}</span> points."
 msgstr ""
 
-#: src/olympia/editors/templates/editors/includes/search_results_themes.html:6 src/olympia/editors/templates/editors/themes/history_table.html:7 src/olympia/editors/templates/editors/themes/logs.html:19
-#: src/olympia/editors/templates/editors/themes/queue_list.html:49 src/olympia/editors/templates/editors/themes/single.html:26 src/olympia/editors/templates/editors/themes/themes.html:45
+#: src/olympia/editors/templates/editors/includes/search_results_themes.html:6 src/olympia/editors/templates/editors/themes/history_table.html:7
+#: src/olympia/editors/templates/editors/themes/logs.html:19 src/olympia/editors/templates/editors/themes/queue_list.html:49 src/olympia/editors/templates/editors/themes/single.html:26
+#: src/olympia/editors/templates/editors/themes/themes.html:45
 msgid "Reviewer"
 msgstr ""
 
@@ -8420,7 +8308,7 @@ msgstr "Κάντε μια ερώτηση στον καλλιτέχνη"
 msgid "Describe your reason for flagging"
 msgstr "Περιγράψτε την αιτία επισήμανσης"
 
-#: src/olympia/files/forms.py:88
+#: src/olympia/files/forms.py:90
 msgid "Cannot diff a version against itself"
 msgstr ""
 
@@ -8455,51 +8343,51 @@ msgstr ""
 msgid "There was an error accessing file %s."
 msgstr ""
 
-#: src/olympia/files/utils.py:343
+#: src/olympia/files/utils.py:340
 msgid "Could not parse uploaded file."
 msgstr ""
 
-#: src/olympia/files/utils.py:380
+#: src/olympia/files/utils.py:377
 msgid "Invalid file name in archive: {0}"
 msgstr ""
 
-#: src/olympia/files/utils.py:388
+#: src/olympia/files/utils.py:385
 msgid "File exceeding size limit in archive: {0}"
 msgstr ""
 
-#: src/olympia/files/utils.py:439
+#: src/olympia/files/utils.py:436
 msgid "Invalid archive."
 msgstr "Μη έγκυρο συμπιεσμένο αρχείο."
 
-#: src/olympia/files/utils.py:529 src/olympia/files/utils.py:532
+#: src/olympia/files/utils.py:526 src/olympia/files/utils.py:529
 msgid "Could not parse the manifest file."
 msgstr ""
 
-#: src/olympia/files/utils.py:551
+#: src/olympia/files/utils.py:548
 msgid "Could not find an add-on ID."
 msgstr ""
 
-#: src/olympia/files/utils.py:554
+#: src/olympia/files/utils.py:551
 msgid "Add-on ID must be 64 characters or less."
 msgstr ""
 
-#: src/olympia/files/utils.py:556
+#: src/olympia/files/utils.py:553
 msgid "Add-on ID doesn't match add-on."
 msgstr ""
 
-#: src/olympia/files/utils.py:564
+#: src/olympia/files/utils.py:561
 msgid "Duplicate add-on ID found."
 msgstr ""
 
-#: src/olympia/files/utils.py:567
+#: src/olympia/files/utils.py:564
 msgid "Version numbers should have fewer than 32 characters."
 msgstr "Οι αριθμοί εκδόσεων θα πρέπει να έχουν λιγότερους από 32 χαρακτήρες."
 
-#: src/olympia/files/utils.py:570
+#: src/olympia/files/utils.py:567
 msgid "Version numbers should only contain letters, numbers, and these punctuation characters: +*.-_."
 msgstr "Οι αριθμοί εκδόσεων μπορούν να περιλαμβάνουν μόνο αριθμούς, γράμματα και αυτά τα σύμβολα: +*.-_."
 
-#: src/olympia/files/utils.py:587
+#: src/olympia/files/utils.py:584
 msgid "<em:type> doesn't match add-on"
 msgstr "<em:type> δεν ταιριάζει με το πρόσθετο"
 
@@ -8599,6 +8487,10 @@ msgstr "Δεν υπάρχουν αρχεία μέσα στο αρχείο που
 #: src/olympia/files/templates/files/viewer.html:134
 msgid "Fetching file."
 msgstr "Φορτώνεται το αρχείο."
+
+#: src/olympia/legacy_api/views.py:255
+msgid "Not implemented yet."
+msgstr "Δεν έχει ενσωματωθεί ακόμη."
 
 #: src/olympia/lib/constants.py:6
 msgid "United Arab Emirates Dirham"
@@ -9256,10 +9148,6 @@ msgstr ""
 msgid "Zimbabwe Dollar"
 msgstr ""
 
-#: src/olympia/lib/video/ffmpeg.py:112 src/olympia/lib/video/totem.py:81
-msgid "Videos must be in WebM."
-msgstr ""
-
 #: src/olympia/pages/templates/pages/about.lhtml:3 src/olympia/pages/templates/pages/about.lhtml:10
 msgid "About Mozilla Add-ons"
 msgstr ""
@@ -9271,7 +9159,7 @@ msgstr ""
 #: src/olympia/pages/templates/pages/about.lhtml:13
 msgid ""
 "addons.mozilla.org, commonly known as \"AMO\", is Mozilla's official site for add-ons to Mozilla software, such as Firefox, Thunderbird, and SeaMonkey. Add-ons let you add new features and change "
-"the way your browser or application works.  Take a look around and explore the thousands of ways to customize the way you do things online."
+"the way your browser or application works. Take a look around and explore the thousands of ways to customize the way you do things online."
 msgstr ""
 
 #: src/olympia/pages/templates/pages/about.lhtml:19
@@ -9327,7 +9215,8 @@ msgstr ""
 
 #: src/olympia/pages/templates/pages/about.lhtml:49
 #, python-format
-msgid "Help improve this website. It's open source, and you can file bugs and submit patches. <a href=\"%(url)s\"> GitHub</a> contains all of our current bugs, legacy bugs can still be found in Bugzilla."
+msgid ""
+"Help improve this website. It's open source, and you can file bugs and submit patches. <a href=\"%(url)s\"> GitHub</a> contains all of our current bugs, legacy bugs can still be found in Bugzilla."
 msgstr ""
 
 #: src/olympia/pages/templates/pages/about.lhtml:55
@@ -9370,8 +9259,8 @@ msgstr ""
 #: src/olympia/pages/templates/pages/about.lhtml:77
 #, python-format
 msgid ""
-"Over the years, many people have contributed to this website, including both volunteers from the community and a dedicated AMO team. A list of significant contributors can be found on our <a "
-"href=\"%(url)s\"> Site Credits</a> page."
+"Over the years, many people have contributed to this website, including both volunteers from the community and a dedicated AMO team. A list of significant contributors can be found on our <a href="
+"\"%(url)s\"> Site Credits</a> page."
 msgstr ""
 
 #: src/olympia/pages/templates/pages/acr_firstrun.html:4
@@ -9405,8 +9294,8 @@ msgstr ""
 #: src/olympia/pages/templates/pages/acr_firstrun.html:61
 #, python-format
 msgid ""
-"If you upgrade to a new version of Firefox or update your add-ons, your reports for the old versions will be hidden to allow you to test the new version. If you have any questions, please ask in <a"
-" href=\"%(url)s\">our forums</a>."
+"If you upgrade to a new version of Firefox or update your add-ons, your reports for the old versions will be hidden to allow you to test the new version. If you have any questions, please ask in <a "
+"href=\"%(url)s\">our forums</a>."
 msgstr ""
 
 #: src/olympia/pages/templates/pages/acr_firstrun.html:69
@@ -9470,8 +9359,8 @@ msgstr ""
 
 #: src/olympia/pages/templates/pages/credits.html:61
 msgid ""
-"Some pages use elements of <a href=\"http://shop.highsoft.com/highcharts.html\">Highcharts</a> (non-commercial), licensed under a <a href=\"http://creativecommons.org/licenses/by-nc/3.0/\">Creative"
-" Commons Attribution-NonCommercial 3.0 License</a>."
+"Some pages use elements of <a href=\"http://shop.highsoft.com/highcharts.html\">Highcharts</a> (non-commercial), licensed under a <a href=\"http://creativecommons.org/licenses/by-nc/3.0/\">Creative "
+"Commons Attribution-NonCommercial 3.0 License</a>."
 msgstr ""
 
 #: src/olympia/pages/templates/pages/credits.html:65
@@ -9603,7 +9492,8 @@ msgstr ""
 
 #: src/olympia/pages/templates/pages/dev_faq.html:143
 #, python-format
-msgid "Yes. You can use Mozilla's <a href=\"%(url)s\">XPCOM component object model</a> to enhance your add-ons. XPCOM components be used and implemented in JavaScript, Java, and Python in addition to C++."
+msgid ""
+"Yes. You can use Mozilla's <a href=\"%(url)s\">XPCOM component object model</a> to enhance your add-ons. XPCOM components be used and implemented in JavaScript, Java, and Python in addition to C++."
 msgstr ""
 
 #: src/olympia/pages/templates/pages/dev_faq.html:150
@@ -9614,7 +9504,7 @@ msgstr ""
 msgid ""
 "Yes. It's possible, but some of the functionality provided by these libraries are available through XPCOM, XUL, and JavaScript. In addition, authors should take care if libraries modify primitive "
 "object prototypes (String.prototype, Date.prototype, etc.) and/or define global functions (eg. the $ function). These are prone to cause conflict with other add-ons, in particular if different add-"
-"ons use different versions of libraries and so on. Developers need to be very, very careful with using them.  Mozilla does not offer documentation on using them to build add-ons."
+"ons use different versions of libraries and so on. Developers need to be very, very careful with using them. Mozilla does not offer documentation on using them to build add-ons."
 msgstr ""
 
 #: src/olympia/pages/templates/pages/dev_faq.html:165
@@ -9644,8 +9534,8 @@ msgstr ""
 #: src/olympia/pages/templates/pages/dev_faq.html:187
 #, python-format
 msgid ""
-"Poorly written extensions can have a severe impact on the browsing experience, including on the overall performance of Firefox itself. The following page contains many good <a "
-"href=\"%(url)s\">guides</a> that help you improve performance, whether you're developing core Mozilla code or an add-on."
+"Poorly written extensions can have a severe impact on the browsing experience, including on the overall performance of Firefox itself. The following page contains many good <a href=\"%(url)s"
+"\">guides</a> that help you improve performance, whether you're developing core Mozilla code or an add-on."
 msgstr ""
 
 #: src/olympia/pages/templates/pages/dev_faq.html:195
@@ -9716,8 +9606,8 @@ msgstr ""
 #: src/olympia/pages/templates/pages/dev_faq.html:248
 #, python-format
 msgid ""
-"Yes. You may find 3rd party developers via the <a href=\"%(forum_url)s\">Add-ons forum</a>, <a href=\"%(list_url)s\">mozilla.jobs list</a>, <a href=\"%(mz_url)s\">mozillaZine forums</a> or <a "
-"href=\"%(wiki_url)s\">the Mozilla Wiki</a>. Please note that Mozilla does not offer developer recommendations."
+"Yes. You may find 3rd party developers via the <a href=\"%(forum_url)s\">Add-ons forum</a>, <a href=\"%(list_url)s\">mozilla.jobs list</a>, <a href=\"%(mz_url)s\">mozillaZine forums</a> or <a href="
+"\"%(wiki_url)s\">the Mozilla Wiki</a>. Please note that Mozilla does not offer developer recommendations."
 msgstr ""
 
 #: src/olympia/pages/templates/pages/dev_faq.html:263
@@ -9727,9 +9617,9 @@ msgstr ""
 #: src/olympia/pages/templates/pages/dev_faq.html:265
 #, python-format
 msgid ""
-"Yes. Many developers choose to host their own add-ons. Choosing to host your add-on on <a href=\"%(amo_url)s\">Mozilla's add-on site</a>, though, allows for much greater exposure to your add-on due"
-" to the large volume of visitors to the site.  <a href=\"%(md_url)s\">mozdev.org</a> offers free project hosting for Mozilla applications and extensions providing developers with tools to help "
-"manage source code, version control, bug tracking and documentation."
+"Yes. Many developers choose to host their own add-ons. Choosing to host your add-on on <a href=\"%(amo_url)s\">Mozilla's add-on site</a>, though, allows for much greater exposure to your add-on due "
+"to the large volume of visitors to the site. <a href=\"%(md_url)s\">mozdev.org</a> offers free project hosting for Mozilla applications and extensions providing developers with tools to help manage "
+"source code, version control, bug tracking and documentation."
 msgstr ""
 
 #: src/olympia/pages/templates/pages/dev_faq.html:277
@@ -9777,7 +9667,7 @@ msgstr ""
 #: src/olympia/pages/templates/pages/dev_faq.html:314
 #, python-format
 msgid ""
-"Yes. Mozilla's <a href=\"%(p_url)s\">Add-on Policy</a> describes what is an acceptable submission. This policy is subject to change without notice.  In addition, the AMO editorial team uses the <a "
+"Yes. Mozilla's <a href=\"%(p_url)s\">Add-on Policy</a> describes what is an acceptable submission. This policy is subject to change without notice. In addition, the AMO editorial team uses the <a "
 "href=\"%(g_url)s\">Editors Reviewing Guide</a> to ensure that your add-on meets specific guidelines for functionality and security."
 msgstr ""
 
@@ -9806,8 +9696,8 @@ msgstr ""
 
 #: src/olympia/pages/templates/pages/dev_faq.html:346
 msgid ""
-"The choice of category is dependent on what type of audience you are targeting and the functionality of your add-on. If you're unsure of which category your add-on falls into, please choose "
-"\"Other\". The AMO team may re-categorize your add-on if it's determined that it's better suited in a different category."
+"The choice of category is dependent on what type of audience you are targeting and the functionality of your add-on. If you're unsure of which category your add-on falls into, please choose \"Other"
+"\". The AMO team may re-categorize your add-on if it's determined that it's better suited in a different category."
 msgstr ""
 
 #: src/olympia/pages/templates/pages/dev_faq.html:355
@@ -9841,8 +9731,8 @@ msgstr ""
 #: src/olympia/pages/templates/pages/dev_faq.html:385
 #, python-format
 msgid ""
-"All add-ons submitted, whether new or updated, are reviewed to ensure that Mozilla users have a stable and safe experience. All add-ons submissions are reviewed using the guidelines outlined in the"
-" <a href=\"%(url)s\">Editors Reviewing Guide</a>."
+"All add-ons submitted, whether new or updated, are reviewed to ensure that Mozilla users have a stable and safe experience. All add-ons submissions are reviewed using the guidelines outlined in the "
+"<a href=\"%(url)s\">Editors Reviewing Guide</a>."
 msgstr ""
 
 #: src/olympia/pages/templates/pages/dev_faq.html:393
@@ -9894,8 +9784,8 @@ msgstr ""
 #: src/olympia/pages/templates/pages/dev_faq.html:434
 #, python-format
 msgid ""
-"This is why it's very important to read the <a href=\"%(g_url)s\">Editors Reviewing Guide</a> to ensure that your add-on is setup as expected.  It's also a good idea to read the blog post, <a "
-"href=\"%(blog_url)s\">Successfully Getting your Add-on Reviewed</a> which provides excellent insight into ensuring a smooth review of your add-on."
+"This is why it's very important to read the <a href=\"%(g_url)s\">Editors Reviewing Guide</a> to ensure that your add-on is setup as expected. It's also a good idea to read the blog post, <a href="
+"\"%(blog_url)s\">Successfully Getting your Add-on Reviewed</a> which provides excellent insight into ensuring a smooth review of your add-on."
 msgstr ""
 
 #: src/olympia/pages/templates/pages/dev_faq.html:446
@@ -9911,7 +9801,8 @@ msgid "How can I see how many active users are using my add-on?"
 msgstr ""
 
 #: src/olympia/pages/templates/pages/dev_faq.html:457
-msgid "The Statistics Dashboard found in the Developer Tools dashboard provides information that can help you determine how many users have been actively using your add-on since you've submitted it to AMO."
+msgid ""
+"The Statistics Dashboard found in the Developer Tools dashboard provides information that can help you determine how many users have been actively using your add-on since you've submitted it to AMO."
 msgstr ""
 
 #: src/olympia/pages/templates/pages/dev_faq.html:464
@@ -10000,7 +9891,7 @@ msgstr ""
 
 #: src/olympia/pages/templates/pages/dev_faq.html:572
 msgid ""
-"Free Software Foundation provides short summaries of the key open source licenses, including whether the license qualifies as a free software license or a copyleft license.  Also includes a "
+"Free Software Foundation provides short summaries of the key open source licenses, including whether the license qualifies as a free software license or a copyleft license. Also includes a "
 "discussion of what constitutes a free software license or a copyleft license (e.g., a Copyleft license is a general method for making a program or other work free, and requiring all modified and "
 "extended versions of the program to be free as well.)"
 msgstr ""
@@ -10046,15 +9937,14 @@ msgstr "Θα δουλεύουν τα πρόσθετα με τον περιηγη
 #: src/olympia/pages/templates/pages/faq.html:27
 #, python-format
 msgid ""
-"Add-ons listed in this gallery only work with Mozilla-based applications, such as <a href=\"%(getfirefox_url)s\">Firefox</a>, <a href=\"%(getmobile_url)s\">Firefox Mobile</a>, <a "
-"href=\"%(getseamonkey_url)s\">SeaMonkey</a>, and <a href=\"%(getthunderbird_url)s\">Thunderbird</a>. However, not all add-ons work with each of those applications or every version of those "
-"applications. Each add-on specifies which applications and versions it works with, such as Firefox 2.0 - 3.6.*. For Firefox add-ons, the install buttons will indicate whether the add-on is "
-"compatible or not."
+"Add-ons listed in this gallery only work with Mozilla-based applications, such as <a href=\"%(getfirefox_url)s\">Firefox</a>, <a href=\"%(getmobile_url)s\">Firefox Mobile</a>, <a href="
+"\"%(getseamonkey_url)s\">SeaMonkey</a>, and <a href=\"%(getthunderbird_url)s\">Thunderbird</a>. However, not all add-ons work with each of those applications or every version of those applications. "
+"Each add-on specifies which applications and versions it works with, such as Firefox 2.0 - 3.6.*. For Firefox add-ons, the install buttons will indicate whether the add-on is compatible or not."
 msgstr ""
-"Τα πρόσθετα που παρουσιάζονται εδώ, δουλεύουν μόνο με εφαρμογές βασισμένες σε κώδικα Mozilla, όπως ο <a href=\"%(getfirefox_url)s\">Firefox</a>,  ο <a href=\"%(getmobile_url)s\">Firefox για "
-"κινητά</a>, ο<a href=\"%(getseamonkey_url)s\">SeaMonkey</a> και ο <a href=\"%(getthunderbird_url)s\">Thunderbird</a>. Δεν δουλεύουν όμως απαραίτητα όλα τα πρόσθετα με όλες αυτές τις εφαρμογές, ή "
-"και με όλες τις εκδόσεις κάποιας εφαρμογής. Κάθε πρόσθετο καθορίζει τις εφαρμογές και τις εκδόσεις των εφαρμογών που συνεργάζεται, όπως πχ τον Firefox 2.0 - 3.6.*. Για τα πρόσθετα του Firefox, τα "
-"κουμπιά εγκατάστασης αναφέρουν αν το πρόσθετο είναι συμβατό ή όχι με την έκδοση που έχετε."
+"Τα πρόσθετα που παρουσιάζονται εδώ, δουλεύουν μόνο με εφαρμογές βασισμένες σε κώδικα Mozilla, όπως ο <a href=\"%(getfirefox_url)s\">Firefox</a>,  ο <a href=\"%(getmobile_url)s\">Firefox για κινητά</"
+"a>, ο<a href=\"%(getseamonkey_url)s\">SeaMonkey</a> και ο <a href=\"%(getthunderbird_url)s\">Thunderbird</a>. Δεν δουλεύουν όμως απαραίτητα όλα τα πρόσθετα με όλες αυτές τις εφαρμογές, ή και με "
+"όλες τις εκδόσεις κάποιας εφαρμογής. Κάθε πρόσθετο καθορίζει τις εφαρμογές και τις εκδόσεις των εφαρμογών που συνεργάζεται, όπως πχ τον Firefox 2.0 - 3.6.*. Για τα πρόσθετα του Firefox, τα κουμπιά "
+"εγκατάστασης αναφέρουν αν το πρόσθετο είναι συμβατό ή όχι με την έκδοση που έχετε."
 
 #: src/olympia/pages/templates/pages/faq.html:42
 msgid "What are the different types of add-ons?"
@@ -10122,8 +10012,8 @@ msgstr "Πως μπορώ να εγκαταστήσω πρόσθετα χωρί�
 #: src/olympia/pages/templates/pages/faq.html:101
 #, python-format
 msgid ""
-"In Firefox, add-ons marked with \"No restart required\" can be installed without restarting. These add-ons have been created using the <a href=\"%(sdk_url)s\">Add-on SDK</a> or <a "
-"href=\"%(bootstrap_url)s\">bootstrapping</a>. Other add-ons will still require a restart before you can use them."
+"In Firefox, add-ons marked with \"No restart required\" can be installed without restarting. These add-ons have been created using the <a href=\"%(sdk_url)s\">Add-on SDK</a> or <a href="
+"\"%(bootstrap_url)s\">bootstrapping</a>. Other add-ons will still require a restart before you can use them."
 msgstr ""
 
 #: src/olympia/pages/templates/pages/faq.html:110
@@ -10134,8 +10024,8 @@ msgstr "Πως μπορώ να διατηρώ ενημερωμένα τα πρό
 #, python-format
 msgid ""
 "Add-ons, unlike plugins, are automatically checked for updates once every day. In Firefox, updates are automatically installed by default. Versions of Firefox prior to 4 (and other applications) "
-"will alert you that updates to your add-ons are available. <a href=\"%(plugin_url)s\">Plugins</a> are not currently automatically checked for updates, so be sure to regularly visit the <a "
-"href=\"%(plugincheck_url)s\">Plugin Check</a> page to stay up-to-date."
+"will alert you that updates to your add-ons are available. <a href=\"%(plugin_url)s\">Plugins</a> are not currently automatically checked for updates, so be sure to regularly visit the <a href="
+"\"%(plugincheck_url)s\">Plugin Check</a> page to stay up-to-date."
 msgstr ""
 
 #: src/olympia/pages/templates/pages/faq.html:122
@@ -10145,9 +10035,9 @@ msgstr "Είναι ασφαλής η εγκατάσταση πρόσθετων;"
 #: src/olympia/pages/templates/pages/faq.html:123
 #, python-format
 msgid ""
-"Unless clearly marked otherwise, add-ons available from this gallery have been checked and approved by Mozilla's team of editors and are safe to install. We recommend that you only install approved"
-" add-ons. If you wish to install unapproved add-ons or add-ons from third-party websites, use caution as these add-ons may harm your computer or violate your privacy. <a "
-"href=\"%(learnmore_url)s\">Learn more about our approval process</a>"
+"Unless clearly marked otherwise, add-ons available from this gallery have been checked and approved by Mozilla's team of editors and are safe to install. We recommend that you only install approved "
+"add-ons. If you wish to install unapproved add-ons or add-ons from third-party websites, use caution as these add-ons may harm your computer or violate your privacy. <a href=\"%(learnmore_url)s"
+"\">Learn more about our approval process</a>"
 msgstr ""
 "Εκτός απ' όπου αναφέρεται διαφορετικά, τα πρόσθετα που διατίθενται από τις λίστες μας έχουν ελεγχθεί κι έχουν την έγκριση της συντακτικής ομάδας του Mozilla και η εγκατάσταση τους είναι ασφαλής. "
 "Συστήνουμε την εγκατάσταση μόνο εγκεκριμένων πρόσθετων. Αν θέλετε να εγκαταστήσετε μη εγκεκριμένα πρόσθετα ή πρόσθετα από ιστοσελίδες τρίτων, κάντε το με προσοχή αφού ίσως αυτά τα πρόσθετα "
@@ -10174,8 +10064,8 @@ msgstr "Ο %(app_name)s επισημαίνει ότι το πρόσθετο δε
 #, python-format
 msgid ""
 "If an add-on isn't compatible with your version of %(app_name)s, it is usually either because your version of %(app_name)s is outdated or the add-on author has not yet updated the add-on to be "
-"compatible with a newer version you are using. Mozilla does not recommend trying to circumvent these compatibility checks, as they can lead to browser instability or in some cases loss of data. For"
-" users who are testing out alpha or beta versions of Firefox, we offer the <a href=\"%(acr_url)s\">Add-on Compatibility Reporter</a> to help add-on developers update their compatibility."
+"compatible with a newer version you are using. Mozilla does not recommend trying to circumvent these compatibility checks, as they can lead to browser instability or in some cases loss of data. For "
+"users who are testing out alpha or beta versions of Firefox, we offer the <a href=\"%(acr_url)s\">Add-on Compatibility Reporter</a> to help add-on developers update their compatibility."
 msgstr ""
 "Αν ένα πρόσθετο δεν είναι συμβατό με την έκδοση του %(app_name)s που χρησιμοποιείτε, αυτό συνήθως συμβαίνει ότι είτε η έκδοση του %(app_name)s  που έχετε είναι παρωχημένη, είτε ο δημιουργός του "
 "πρόσθετου δεν έχει ενημερώσει ακόμα το πρόσθετο του για να είναι συμβατό με την νέα έκδοση που εσείς χρησιμοποιείτε. Ο οργανισμός Mozilla δεν συνιστά να παρακάμψετε τον έλεγχο συμβατότητας, καθώς "
@@ -10194,8 +10084,8 @@ msgid ""
 "troubleshooting tips."
 msgstr ""
 "Τα πρόσθετα φτιάχνονται στην πλειοψηφία τους από ανεξάρτητους δημιουργούς απ' όλο τον κόσμο, οπότε ο ευκολότερος τρόπος για να βρείτε βοήθεια σχετικά με ένα απ' αυτά είναι να ψάξετε για δεσμούς "
-"υποστήριξης στην αρχική τους σελίδα ή να επικοινωνήσετε με τον δημιουργό τους. Αν αντιμετωπίζετε προβλήματα με τον %(app_name)s και υποψιάζεστε ότι οφείλονται σε πρόσθετα που έχετε εγκαταστήσει, <a"
-" href=\"%(troubleshooting_url)s\">επισκεφθείτε αυτό το άρθρο υποστήριξης</a> για συμβουλές αντιμετώπισης προβλημάτων."
+"υποστήριξης στην αρχική τους σελίδα ή να επικοινωνήσετε με τον δημιουργό τους. Αν αντιμετωπίζετε προβλήματα με τον %(app_name)s και υποψιάζεστε ότι οφείλονται σε πρόσθετα που έχετε εγκαταστήσει, <a "
+"href=\"%(troubleshooting_url)s\">επισκεφθείτε αυτό το άρθρο υποστήριξης</a> για συμβουλές αντιμετώπισης προβλημάτων."
 
 #: src/olympia/pages/templates/pages/faq.html:169
 msgid "Add-on Gallery"
@@ -10205,7 +10095,7 @@ msgstr "Συλλογή πρόσθετων"
 msgid "How do I choose between add-ons that seem to do the same thing?"
 msgstr "Πως μπορώ να διαλέξω ανάμεσα σε δύο πρόσθετα που φαινομενικά έχουν την ίδια λειτουργία;"
 
-#: src/olympia/pages/templates/pages/faq.html:173
+#: src/olympia/pages/templates/pages/faq.html:172
 msgid ""
 "There are often several add-ons that have similar features. To figure out which is right for you, read the entire description of the add-on and view its screenshots. If there are still several in "
 "the running, read through the add-on's ratings, user reviews, and statistics to see which is most liked by other users. Remember that you can also just try out both and see which you like better."
@@ -10232,8 +10122,8 @@ msgstr "Τι σημαίνει ότι ένα πρόσθετο είναι «πει
 #: src/olympia/pages/templates/pages/faq.html:188
 #, python-format
 msgid ""
-"Experimental add-ons have been checked by our editors to make sure they don't have security problems, but they may still have bugs or not work properly. Use caution when installing experimental "
-"add-ons and uninstall the add-on immediately if you notice problems. <a href=\"%(url)s\">Learn more about our review process</a></dd>"
+"Experimental add-ons have been checked by our editors to make sure they don't have security problems, but they may still have bugs or not work properly. Use caution when installing experimental add-"
+"ons and uninstall the add-on immediately if you notice problems. <a href=\"%(url)s\">Learn more about our review process</a></dd>"
 msgstr ""
 "Τα πειραματικά πρόσθετα έχουν ελεγχθεί από τους συντάκτες μας για προβλήματα ασφαλείας, αλλά μπορεί να περιέχουν άλλα σφάλματα ή να μην είναι πλήρως λειτουργικά. Αν εγκαταστήσετε πειραματικά "
 "πρόσθετα, κάντε το με προσοχή και απεγκαταστήσετε τα άμεσα αν παρατηρήσετε προβλήματα. <a href=\"%(url)s\">Μάθετε περισσότερα για της διαδικασία αξιολόγησης</a></dd>"
@@ -10248,8 +10138,8 @@ msgid ""
 "While all add-ons publicly available in our gallery are reviewed by an editor, you may receive a direct link to an add-on that hasn't yet been reviewed. Use caution when installing these add-ons, "
 "as they could harm your computer or violate your privacy. We recommend that you only install reviewed add-ons. <a href=\"%(url)s\">Learn more about our review process</a></dd>"
 msgstr ""
-"Αν και όλα τα πρόσθετα της συλλογής μας που εμφανίζονται δημόσια έχουν αξιολογηθεί από τους συντάκτες μας, μπορεί να βρείτε μια σελίδα μέσω κάποιου εξωτερικού δεσμού με κάποιο πρόσθετο που δεν έχει"
-" αξιολογηθεί ακόμη. Αν εγκαταστήσετε τέτοιο πρόσθετο, κάντε με προσοχή, γιατί μπορεί να προκαλέσει προβλήματα στο μηχάνημα σας ή να παραβιάσει το ιδιωτικό σας απόρρητο. Συστήνουμε την εγκατάσταση "
+"Αν και όλα τα πρόσθετα της συλλογής μας που εμφανίζονται δημόσια έχουν αξιολογηθεί από τους συντάκτες μας, μπορεί να βρείτε μια σελίδα μέσω κάποιου εξωτερικού δεσμού με κάποιο πρόσθετο που δεν έχει "
+"αξιολογηθεί ακόμη. Αν εγκαταστήσετε τέτοιο πρόσθετο, κάντε με προσοχή, γιατί μπορεί να προκαλέσει προβλήματα στο μηχάνημα σας ή να παραβιάσει το ιδιωτικό σας απόρρητο. Συστήνουμε την εγκατάσταση "
 "μόνο αξιολογημένων πρόσθετων. <a href=\"%(url)s\">Μάθετε περισσότερα για τη διαδικασία αξιολόγησης</a></dd>"
 
 #: src/olympia/pages/templates/pages/faq.html:206
@@ -10260,11 +10150,11 @@ msgstr "Πόσο κοστίζει η αγορά των πρόσθετων;"
 msgid "Add-ons hosted in our gallery are free unless clearly marked otherwise."
 msgstr "Τα πρόσθετα που φιλοξενούνται στη συλλογή μας είναι δωρεάν εκτός από όσα δηλώνουν ρητά το αντίθετο. "
 
-#: src/olympia/pages/templates/pages/faq.html:210
+#: src/olympia/pages/templates/pages/faq.html:209
 msgid "What does it mean when an add-on asks for contributions?"
 msgstr "Τι σημαίνει ότι κάποιο πρόσθετο ζητάει συνεισφορά;"
 
-#: src/olympia/pages/templates/pages/faq.html:211
+#: src/olympia/pages/templates/pages/faq.html:210
 msgid ""
 "Some add-on authors request users who enjoy an add-on to contribute to its development by making a monetary contribution. These contributions go directly to the developer unless a third party is "
 "indicated, such as the non-profit Mozilla Foundation."
@@ -10272,11 +10162,11 @@ msgstr ""
 "Μερικοί δημιουργοί πρόσθετων, ζητούν από τους χρήστες που απολαμβάνουν τα πρόσθετα τους να ενισχύσουν την ανάπτυξη τους κάνοντας μια μικρή χρηματική δωρεά. Αυτές οι δωρεές κατατίθενται απευθείας "
 "στους δημιουργούς, εκτός κι αν έχει οριστεί κάποιο τρίτο μέρος σαν αποδέκτης, όπως πχ. το μη κερδοσκοπικό ίδρυμα Μozilla."
 
-#: src/olympia/pages/templates/pages/faq.html:216
+#: src/olympia/pages/templates/pages/faq.html:215
 msgid "What are beta add-ons?"
 msgstr "Τι είναι τα δοκιμαστικά πρόσθετα;"
 
-#: src/olympia/pages/templates/pages/faq.html:218
+#: src/olympia/pages/templates/pages/faq.html:217
 msgid ""
 "Beta add-ons are unreviewed versions which represent the latest work of an add-on author. While different authors have different standards for beta code quality, you should assume that these add-"
 "ons are less stable than the general add-on releases."
@@ -10284,30 +10174,27 @@ msgstr ""
 "Τα δοκιμαστικά (Beta) πρόσθετα, είναι εκδόσεις που δεν έχουν αξιολογηθεί και περιλαμβάνουν ό,τι πιο πρόσφατο έχει δημιουργήσει ο προγραμματιστής τους. Αν και κάθε δημιουργός έχει διαφορετικά "
 "πρότυπα για τον ορισμό μιας έκδοσης σαν δοκιμαστική, καλό θα είναι γενικότερα να θεωρείτε πως αυτά τα πρόσθετα είναι λιγότερο σταθερά από τις κανονικές εκδόσεις."
 
-#: src/olympia/pages/templates/pages/faq.html:222
+#: src/olympia/pages/templates/pages/faq.html:221
 msgid ""
-"Please note that when you install an add-on from the \"Beta Version\" section of an add-on's listing, you will continue to receive updates for that add-on as they become available. Like the initial"
-" version you installed, all beta releases are unreviewed by Mozilla and may harm your computer."
+"Please note that when you install an add-on from the \"Beta Version\" section of an add-on's listing, you will continue to receive updates for that add-on as they become available. Like the initial "
+"version you installed, all beta releases are unreviewed by Mozilla and may harm your computer."
 msgstr ""
 "Παρακαλούμε σημειώστε πως όταν εγκαταστήσετε ένα πρόσθετο από το «δοκιμαστικό» τμήμα της σελίδας προβολής του, θα λαμβάνετε και τις διαθέσιμες ενημερώσεις επίσης από το ίδιο τμήμα. Όπως και με την "
 "αρχική δοκιμαστική έκδοση που εγκαταστήσατε, όλες οι δοκιμαστικές εκδόσεις δεν αξιολογούνται από τους συντάκτες του Μozilla και μπορεί να προκαλέσουν προβλήματα στο σύστημα σας."
 
-#: src/olympia/pages/templates/pages/faq.html:229
+#: src/olympia/pages/templates/pages/faq.html:228
 msgid "What does it mean when an add-on is flagged as slow?"
 msgstr "Τι σημαίνει ότι ένα πρόσθετο έχει σημειωθεί σαν αργό;"
 
-#: src/olympia/pages/templates/pages/faq.html:231
-msgid ""
-"Most add-ons load code and resources at the same time Firefox\n"
-"        is starting up. In most cases the impact in start-up time is minimal,\n"
-"        but some add-ons can cause a noticeable slowdown."
+#: src/olympia/pages/templates/pages/faq.html:229
+msgid "Most add-ons load code and resources at the same time Firefox is starting up. In most cases the impact in start-up time is minimal, but some add-ons can cause a noticeable slowdown."
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:236
+#: src/olympia/pages/templates/pages/faq.html:234
 msgid "How do I report an inappropriate or spam user review?"
 msgstr "Πως μπορώ να αναφέρω μια απρεπή η κακόβουλη και άσχετη αξιολόγηση χρήστη;"
 
-#: src/olympia/pages/templates/pages/faq.html:237
+#: src/olympia/pages/templates/pages/faq.html:235
 msgid ""
 "To report a user review of an add-on, log in with your account and visit the add-on's reviews page. Find the review you wish to report, click \"Report this review\" and select a reason. Our "
 "editorial team will investigate the review and take appropriate action."
@@ -10315,66 +10202,66 @@ msgstr ""
 "Για να αναφέρετε μια αξιολόγηση χρήστη για ένα πρόσθετο, συνδεθείτε στο λογαριασμό σας και επισκεφθείτε τη σελίδα με τις αξιολογήσεις του πρόσθετου. Εντοπίστε την αξιολόγηση που θέλετε να "
 "αναφέρετε, κάντε κλικ στο «Αναφορά αξιολόγησης» και επιλέξτε μια αιτία.  Η συντακτική μας ομάδα θα διερευνήσει την αξιολόγηση και θα πάρει τα κατάλληλα μέτρα."
 
-#: src/olympia/pages/templates/pages/faq.html:242
+#: src/olympia/pages/templates/pages/faq.html:240
 msgid "How do I report a bug or contact the Mozilla Add-ons team?"
 msgstr "Πως μπορώ να αναφέρω ένα σφάλμα ή να επικοινωνήσω με την ομάδα των πρόσθετων του Mozilla;"
 
-#: src/olympia/pages/templates/pages/faq.html:243
+#: src/olympia/pages/templates/pages/faq.html:241
 #, python-format
 msgid "Please visit our <a href=\"%(contact_url)s\">Contact page</a>."
 msgstr "Παρακαλούμε επισκεφθείτε τη <a href=\"%(contact_url)s\">σελίδα επικοινωνίας μας</a>."
 
-#: src/olympia/pages/templates/pages/faq.html:246
+#: src/olympia/pages/templates/pages/faq.html:244
 msgid "What is a Source Code License?"
 msgstr "Τι είναι η άδεια πηγαίου κώδικα;"
 
-#: src/olympia/pages/templates/pages/faq.html:247
+#: src/olympia/pages/templates/pages/faq.html:245
 #, python-format
 msgid ""
-"The source code used to create an add-on is an exclusive copyright of the add-on author, unless otherwise declared in a source code license. Many add-ons on this site have <a href=\"%(url)s\" "
-"lang=\"en\">open source licenses</a> that make the source code publicly available for copy and reuse under conditions determined by the author. Most authors choose widely known open source licenses"
-" like the GPL or BSD licenses instead of making up their own."
+"The source code used to create an add-on is an exclusive copyright of the add-on author, unless otherwise declared in a source code license. Many add-ons on this site have <a href=\"%(url)s\" lang="
+"\"en\">open source licenses</a> that make the source code publicly available for copy and reuse under conditions determined by the author. Most authors choose widely known open source licenses like "
+"the GPL or BSD licenses instead of making up their own."
 msgstr ""
-"Ο πηγαίος κώδικας στον οποίο οφείλει την ύπαρξη του ένα πρόσθετο, είναι αποκλειστική πνευματική περιουσία του δημιουργού του, εκτός κι αν καθορίζεται αλλιώς στην άδεια χρήσης του πηγαίου κώδικα. Τα"
-" περισσότερα πρόσθετα στις σελίδες μας έχουν <a href=\"%(url)s\" lang=\"en\">άδειες χρήσης ανοιχτού κώδικα</a> οι οποίες καθιστούν τον πηγαίο κώδικα δημόσια διαθέσιμο για αντιγραφή και τροποποίηση "
+"Ο πηγαίος κώδικας στον οποίο οφείλει την ύπαρξη του ένα πρόσθετο, είναι αποκλειστική πνευματική περιουσία του δημιουργού του, εκτός κι αν καθορίζεται αλλιώς στην άδεια χρήσης του πηγαίου κώδικα. Τα "
+"περισσότερα πρόσθετα στις σελίδες μας έχουν <a href=\"%(url)s\" lang=\"en\">άδειες χρήσης ανοιχτού κώδικα</a> οι οποίες καθιστούν τον πηγαίο κώδικα δημόσια διαθέσιμο για αντιγραφή και τροποποίηση "
 "σύμφωνα με συνθήκες που καθορίζει ο δημιουργός του. Οι περισσότεροι δημιουργοί επιλέγουν  ευρύτατα γνωστές άδειες ανοιχτού κώδικα, όπως η GPL ή η BSD αντί να γράφουν δικές τους."
 
-#: src/olympia/pages/templates/pages/faq.html:256
+#: src/olympia/pages/templates/pages/faq.html:254
 #, python-format
 msgid "Firefox and other Mozilla software are <a href=\"%(url)s\">open source</a>."
 msgstr "Ο Firefox και οποιοδήποτε  άλλο λογισμικό του Mozilla, είναι <a href=\"%(url)s\">ανοικτού κώδικα</a>."
 
-#: src/olympia/pages/templates/pages/faq.html:264
+#: src/olympia/pages/templates/pages/faq.html:262
 msgid "Collections and Favorites"
 msgstr "Συλλογές κι αγαπημένα"
 
-#: src/olympia/pages/templates/pages/faq.html:267
+#: src/olympia/pages/templates/pages/faq.html:265
 msgid "What is a collection?"
 msgstr "Τι είναι οι συλλογές;"
 
-#: src/olympia/pages/templates/pages/faq.html:268
+#: src/olympia/pages/templates/pages/faq.html:266
 msgid "Collections are groups of related add-ons created by users to share."
 msgstr "Οι συλλογές είναι ομάδες σχετιζόμενων  πρόσθετων που δημιουργούν οι χρήστες για να τις μοιράζονται."
 
-#: src/olympia/pages/templates/pages/faq.html:270
+#: src/olympia/pages/templates/pages/faq.html:268
 msgid "What is the My Favorites collection?"
 msgstr "Τι είναι οι αγαπημένες συλλογές;"
 
-#: src/olympia/pages/templates/pages/faq.html:271
+#: src/olympia/pages/templates/pages/faq.html:269
 msgid "Favorite add-ons are add-ons that you have bookmarked to easily get back to later. You can add an add-on to your favorites collection by clicking \"Add to favorites\" on its details page."
 msgstr ""
 "Τα αγαπημένα πρόσθετα είναι πρόσθετα που έχετε σημειώσει με σελιδοδείκτη για να μπορείτε αργότερα να τα εντοπίζετε εύκολα. Μπορείτε να προσθέσετε ένα πρόσθετο στα αγαπημένα σας κάνοντας κλικ στο "
 "«προσθήκη στα αγαπημένα» που θα βρείτε στη σελίδα του."
 
-#: src/olympia/pages/templates/pages/faq.html:275 src/olympia/templates/menu_links.html:13 src/olympia/templates/impala/header_title.html:17
+#: src/olympia/pages/templates/pages/faq.html:273 src/olympia/templates/menu_links.html:13 src/olympia/templates/impala/header_title.html:17
 msgid "Mobile Add-ons"
 msgstr "Πρόσθετα κινητών"
 
-#: src/olympia/pages/templates/pages/faq.html:278
+#: src/olympia/pages/templates/pages/faq.html:276
 msgid "What are mobile add-ons?"
 msgstr "Τι είναι τα πρόσθετα για κινητό;"
 
-#: src/olympia/pages/templates/pages/faq.html:279
+#: src/olympia/pages/templates/pages/faq.html:277
 #, python-format
 msgid ""
 "Mobile add-ons work with <a href=\"%(mobile_url)s\">Firefox for Mobile</a> and add or modify functionality just like desktop add-ons. You can find add-ons that work with Firefox for Mobile in our "
@@ -10383,25 +10270,26 @@ msgstr ""
 "Τα πρόσθετα για κινητά, δουλεύουν στην έκδοση του <a href=\"%(mobile_url)s\">Firefox για κινητά</a> και προσθέτουν ή τροποποιούν χαρακτηριστικά όπως ακριβώς και τα πρόσθετα για τις υπόλοιπες "
 "πλατφόρμες. Μπορείτε να βρείτε πρόσθετα που δουλεύουν με τον Firefox για κινητά στη <a href=\"%(gallery_url)s\">λίστα</a> μας."
 
-#: src/olympia/pages/templates/pages/faq.html:288
+#: src/olympia/pages/templates/pages/faq.html:286
 msgid "Developer Topics"
 msgstr "Θεματολογία δημιουργών"
 
-#: src/olympia/pages/templates/pages/faq.html:289
+#: src/olympia/pages/templates/pages/faq.html:287
 #, python-format
 msgid "Please see our <a href=\"%(faq_url)s\">Developer FAQ</a> and <a href=\"%(hub_url)s\">Developer Hub</a> for answers to add-on developer-related questions."
-msgstr "Παρακαλούμε δείτε τις <a href=\"%(faq_url)s\">συχνές ερωτήσεις για δημιουργούς</a> και το <a href=\"%(hub_url)s\">ταμπλό δημιουργών</a> για απαντήσεις σε ερωτήσεις που αφορούν δημιουργούς πρόσθετων."
+msgstr ""
+"Παρακαλούμε δείτε τις <a href=\"%(faq_url)s\">συχνές ερωτήσεις για δημιουργούς</a> και το <a href=\"%(hub_url)s\">ταμπλό δημιουργών</a> για απαντήσεις σε ερωτήσεις που αφορούν δημιουργούς πρόσθετων."
 
-#: src/olympia/pages/templates/pages/faq.html:294
+#: src/olympia/pages/templates/pages/faq.html:292
 msgid "Still have questions?"
 msgstr "Έχετε κι άλλες ερωτήσεις;"
 
-#: src/olympia/pages/templates/pages/faq.html:295
+#: src/olympia/pages/templates/pages/faq.html:293
 #, python-format
 msgid "For general Firefox support, visit our <a href=\"%(sumo_url)s\">support website</a>. For general add-on and website questions, visit our <a href=\"%(forum_url)s\">forum</a>."
 msgstr ""
-"Για γενικότερη υποστήριξη του Firefox, επισκεφθείτε τις<a href=\"%(sumo_url)s\">σελίδες υποστήριξης</a>. Για γενικότερη υποστήριξη και ερωτήσεις σχετικά με τα πρόσθετα, επισκεφθείτε το <a "
-"href=\"%(forum_url)s\">φόρουμ</a> μας."
+"Για γενικότερη υποστήριξη του Firefox, επισκεφθείτε τις<a href=\"%(sumo_url)s\">σελίδες υποστήριξης</a>. Για γενικότερη υποστήριξη και ερωτήσεις σχετικά με τα πρόσθετα, επισκεφθείτε το <a href="
+"\"%(forum_url)s\">φόρουμ</a> μας."
 
 #: src/olympia/pages/templates/pages/review_guide.html:36 src/olympia/pages/templates/pages/review_guide.html:51
 msgid "Some tips for writing a great review"
@@ -10536,7 +10424,7 @@ msgstr ""
 
 #: src/olympia/pages/templates/pages/sunbird.html:29
 msgid ""
-"Development on the Sunbird project has halted and its final release was on March 30, 2010.  We've been proud to host Sunbird add-ons on this site but as the project is no longer maintained we have "
+"Development on the Sunbird project has halted and its final release was on March 30, 2010. We've been proud to host Sunbird add-ons on this site but as the project is no longer maintained we have "
 "disabled our support for the add-ons."
 msgstr ""
 
@@ -10614,10 +10502,10 @@ msgstr "Προσθήκη αξιολόγησης για το {0}"
 #, python-format
 msgid ""
 "<h2>Keep these tips in mind:</h2> <ul> <li> Write like you're telling a friend about your experience with the add-on. Give specifics and helpful details, such as what features you liked and/or "
-"disliked, how easy to use it is, and any disadvantages it has.  Avoid generic language such as calling it \"Great\" or \"Bad\" unless you can give reasons why you believe this is so. </li> <li> "
-"Please do not post bug reports in reviews. We do not make your email address available to add-on developers and they may need to contact you to help resolve your issue. See the <a "
-"href=\"%(support)s\">support section</a> to find out where to get assistance for this add-on. </li> <li>Please keep reviews clean, avoid the use of improper language and do not post any personal "
-"information. </li> </ul> <p>Please read the <a href=\"%(guide)s\" target=\"_blank\">Review Guidelines</a> for more detail about user add-on reviews.</p>"
+"disliked, how easy to use it is, and any disadvantages it has. Avoid generic language such as calling it \"Great\" or \"Bad\" unless you can give reasons why you believe this is so. </li> <li> "
+"Please do not post bug reports in reviews. We do not make your email address available to add-on developers and they may need to contact you to help resolve your issue. See the <a href=\"%(support)s"
+"\">support section</a> to find out where to get assistance for this add-on. </li> <li>Please keep reviews clean, avoid the use of improper language and do not post any personal information. </li> </"
+"ul> <p>Please read the <a href=\"%(guide)s\" target=\"_blank\">Review Guidelines</a> for more detail about user add-on reviews.</p>"
 msgstr ""
 
 #: src/olympia/reviews/templates/reviews/reply.html:4
@@ -10866,16 +10754,16 @@ msgstr "Πρόσθετα {0} "
 
 #. L10n: {0} is an application, such as Firefox. This means "any version of
 #. Firefox."
-#: src/olympia/search/views.py:554
+#: src/olympia/search/views.py:547
 msgid "Any {0}"
 msgstr ""
 
 #. L10n: "All Systems" means show everything regardless of platform.
-#: src/olympia/search/views.py:589
+#: src/olympia/search/views.py:582
 msgid "All Systems"
 msgstr ""
 
-#: src/olympia/search/views.py:600
+#: src/olympia/search/views.py:593
 msgid "All Tags"
 msgstr ""
 
@@ -11049,31 +10937,31 @@ msgstr "Διαμοιρασμός αυτού του πρόσθετου"
 msgid "Share this Collection"
 msgstr "Διαμοιρασμός συλλογής"
 
-#: src/olympia/signing/views.py:30 src/olympia/templates/base.html:75 src/olympia/templates/impala/base.html:115
+#: src/olympia/signing/views.py:33 src/olympia/templates/base.html:71 src/olympia/templates/impala/base.html:112
 msgid "Some features are temporarily disabled while we perform website maintenance. We'll be back to full capacity shortly."
 msgstr "Μερικές λειτουργίες έχουν προς το παρόν απενεργοποιηθεί λόγω εργασιών συντήρησης. Η πλήρης λειτουργικότητα θα επανέλθει σύντομα."
 
-#: src/olympia/signing/views.py:53
+#: src/olympia/signing/views.py:56
 msgid "Could not find add-on with id \"{}\"."
 msgstr ""
 
-#: src/olympia/signing/views.py:67
+#: src/olympia/signing/views.py:70
 msgid "You do not own this addon."
 msgstr ""
 
-#: src/olympia/signing/views.py:82
+#: src/olympia/signing/views.py:87
 msgid "Missing \"upload\" key in multipart file data."
 msgstr ""
 
-#: src/olympia/signing/views.py:96
+#: src/olympia/signing/views.py:101
 msgid "Version does not match the manifest file."
 msgstr ""
 
-#: src/olympia/signing/views.py:100
+#: src/olympia/signing/views.py:105
 msgid "Version already exists."
 msgstr ""
 
-#: src/olympia/signing/views.py:136
+#: src/olympia/signing/views.py:141
 msgid "No uploaded file for that addon and version."
 msgstr ""
 
@@ -11186,89 +11074,89 @@ msgstr ""
 msgid "Statistics Dashboard :: Add-ons for {0}"
 msgstr ""
 
-#: src/olympia/stats/templates/stats/stats.html:30
-msgid "Controls:"
-msgstr ""
-
-#: src/olympia/stats/templates/stats/stats.html:33
-msgid "reset zoom"
-msgstr ""
-
-#: src/olympia/stats/templates/stats/stats.html:40
-msgid "Group by:"
-msgstr ""
-
-#: src/olympia/stats/templates/stats/stats.html:42
-msgid "day"
-msgstr "ημέρα"
-
-#: src/olympia/stats/templates/stats/stats.html:45
-msgid "week"
-msgstr ""
-
-#: src/olympia/stats/templates/stats/stats.html:48
-msgid "month"
-msgstr "μήνα"
-
-#: src/olympia/stats/templates/stats/stats.html:54
-msgid "For last:"
-msgstr "Για τις τελευταίες:"
-
-#: src/olympia/stats/templates/stats/stats.html:57
-msgid "7 days"
-msgstr "7 ημέρες"
-
-#: src/olympia/stats/templates/stats/stats.html:60
-msgid "30 days"
-msgstr "30 ημέρες"
-
-#: src/olympia/stats/templates/stats/stats.html:63
-msgid "90 days"
-msgstr "90 ημέρες"
-
-#: src/olympia/stats/templates/stats/stats.html:66
-msgid "365 days"
-msgstr "365 ημέρες"
-
-#: src/olympia/stats/templates/stats/stats.html:69
-msgid "Custom..."
-msgstr ""
-
 #. {0} is an add-on name
-#: src/olympia/stats/templates/stats/stats.html:88 src/olympia/stats/templates/stats/stats.html:91
+#: src/olympia/stats/templates/stats/stats.html:44 src/olympia/stats/templates/stats/stats.html:47
 msgid "Statistics for {0}"
 msgstr "Στατιστικά για {0}"
 
-#: src/olympia/stats/templates/stats/stats.html:94
+#: src/olympia/stats/templates/stats/stats.html:50
 msgid "Statistics Dashboard"
 msgstr ""
 
-#: src/olympia/stats/templates/stats/stats.html:104
+#: src/olympia/stats/templates/stats/stats.html:57
+msgid "Controls:"
+msgstr ""
+
+#: src/olympia/stats/templates/stats/stats.html:60
+msgid "reset zoom"
+msgstr ""
+
+#: src/olympia/stats/templates/stats/stats.html:67
+msgid "Group by:"
+msgstr ""
+
+#: src/olympia/stats/templates/stats/stats.html:69
+msgid "day"
+msgstr "ημέρα"
+
+#: src/olympia/stats/templates/stats/stats.html:72
+msgid "week"
+msgstr ""
+
+#: src/olympia/stats/templates/stats/stats.html:75
+msgid "month"
+msgstr "μήνα"
+
+#: src/olympia/stats/templates/stats/stats.html:81
+msgid "For last:"
+msgstr "Για τις τελευταίες:"
+
+#: src/olympia/stats/templates/stats/stats.html:84
+msgid "7 days"
+msgstr "7 ημέρες"
+
+#: src/olympia/stats/templates/stats/stats.html:87
+msgid "30 days"
+msgstr "30 ημέρες"
+
+#: src/olympia/stats/templates/stats/stats.html:90
+msgid "90 days"
+msgstr "90 ημέρες"
+
+#: src/olympia/stats/templates/stats/stats.html:93
+msgid "365 days"
+msgstr "365 ημέρες"
+
+#: src/olympia/stats/templates/stats/stats.html:96
+msgid "Custom..."
+msgstr ""
+
+#: src/olympia/stats/templates/stats/stats.html:106
 msgid "Statistics processing is currently disabled, so recent data is unavailable. The statistics are still being collected and this page will be updated soon with the missing data."
 msgstr ""
 
-#: src/olympia/stats/templates/stats/stats.html:110
+#: src/olympia/stats/templates/stats/stats.html:112
 msgid "Loading the latest data&hellip;"
 msgstr "Φόρτωση των πιο πρόσφατων δεδομένων&hellip;"
 
-#: src/olympia/stats/templates/stats/stats.html:142 src/olympia/stats/templates/stats/reports/overview.html:25 src/olympia/stats/templates/stats/reports/overview.html:37
+#: src/olympia/stats/templates/stats/stats.html:144 src/olympia/stats/templates/stats/reports/overview.html:25 src/olympia/stats/templates/stats/reports/overview.html:37
 #: src/olympia/stats/templates/stats/reports/overview.html:49
 msgid "No data available."
 msgstr ""
 
-#: src/olympia/stats/templates/stats/stats.html:177
+#: src/olympia/stats/templates/stats/stats.html:179
 msgid "This dashboard is currently <b>public</b>."
 msgstr ""
 
-#: src/olympia/stats/templates/stats/stats.html:179
+#: src/olympia/stats/templates/stats/stats.html:181
 msgid "Contribution stats are currently <b>private</b>."
 msgstr ""
 
-#: src/olympia/stats/templates/stats/stats.html:182
+#: src/olympia/stats/templates/stats/stats.html:184
 msgid "This dashboard is currently <b>private</b>."
 msgstr ""
 
-#: src/olympia/stats/templates/stats/stats.html:185
+#: src/olympia/stats/templates/stats/stats.html:187
 msgid "Change settings."
 msgstr ""
 
@@ -11378,10 +11266,10 @@ msgstr ""
 #, python-format
 msgid ""
 "<h2>Tracking external sources</h2> <p> If you link to your add-on's details page or directly to its file from an external site, such as your blog or website, you can append a parameter to be "
-"tracked as an additional download source on this page. For example, the following links would appear as sourced by your blog: <dl> <dt>Add-on Details Page</dt> "
-"<dd>https://addons.mozilla.org/addon/%(slug)s?src=<b>external-blog</b></dd> <dt>Direct File Link</dt> <dd>https://addons.mozilla.org/downloads/latest/%(id)s/addon-%(id)s-latest.xpi?src=<b>external-"
-"blog</b></dd> </dl> <p> Only src parameters that begin with \"external-\" will be tracked, up to 61 additional characters. Any text after \"external-\" can be used to describe the source, such as "
-"\"external-blog\", \"external-sidebar\", \"external-campaign225\", etc. The following URL-safe characters are allowed: <code>a-z A-Z - . _ ~ %% +</code>"
+"tracked as an additional download source on this page. For example, the following links would appear as sourced by your blog: <dl> <dt>Add-on Details Page</dt> <dd>https://addons.mozilla.org/addon/"
+"%(slug)s?src=<b>external-blog</b></dd> <dt>Direct File Link</dt> <dd>https://addons.mozilla.org/downloads/latest/%(id)s/addon-%(id)s-latest.xpi?src=<b>external-blog</b></dd> </dl> <p> Only src "
+"parameters that begin with \"external-\" will be tracked, up to 61 additional characters. Any text after \"external-\" can be used to describe the source, such as \"external-blog\", \"external-"
+"sidebar\", \"external-campaign225\", etc. The following URL-safe characters are allowed: <code>a-z A-Z - . _ ~ %% +</code>"
 msgstr ""
 
 #: src/olympia/stats/templates/stats/reports/statuses.html:3
@@ -11408,8 +11296,8 @@ msgstr ""
 
 #: src/olympia/stats/templates/stats/reports/usage.html:20
 msgid ""
-"<h2>What are daily users?</h2> <p> Add-ons downloaded from this site check for updates once per day. The total number of these update pings is known as Active Daily Users. Daily users can be broken"
-" down by add-on version, operating system, add-on status, application, and locale. </p>"
+"<h2>What are daily users?</h2> <p> Add-ons downloaded from this site check for updates once per day. The total number of these update pings is known as Active Daily Users. Daily users can be broken "
+"down by add-on version, operating system, add-on status, application, and locale. </p>"
 msgstr ""
 
 #: src/olympia/stats/templates/stats/reports/users_created.html:3
@@ -11419,16 +11307,6 @@ msgstr ""
 #: src/olympia/stats/templates/stats/reports/versions.html:3
 msgid "Application versions by Date"
 msgstr "Έκδοση εφαρμογής κατά ημερομηνία"
-
-# {0} is a number
-#: src/olympia/tags/templates/tags/top_cloud.html:4
-msgid "Top {0} Tags"
-msgstr "Κορυφαίες {0} ετικέτες"
-
-#. {0} is the current application name
-#: src/olympia/tags/templates/tags/top_cloud.html:14
-msgid "{0} Top Tags"
-msgstr "Κορυφαίες ετικέτες για {0} "
 
 # the string is affected by text-transform:uppercase so there should not be
 # any accents
@@ -11440,11 +11318,11 @@ msgstr "Άλλες γλώσσες"
 msgid "Mozilla Add-ons"
 msgstr "Πρόσθετα Mozilla"
 
-#: src/olympia/templates/base.html:91 src/olympia/templates/impala/base.html:81
+#: src/olympia/templates/base.html:89 src/olympia/templates/impala/base.html:78
 msgid "Find add-ons for other applications"
 msgstr "Αναζήτηση πρόσθετων για άλλα προγράμματα"
 
-#: src/olympia/templates/base.html:92 src/olympia/templates/impala/base.html:81
+#: src/olympia/templates/base.html:90 src/olympia/templates/impala/base.html:78
 msgid "Other Applications"
 msgstr "Άλλα προγράμματα"
 
@@ -11469,7 +11347,7 @@ msgid "View Mobile Site"
 msgstr "Δείτε τον ιστότοπο για κινητά"
 
 #: src/olympia/templates/copyright.html:7
-msgid "Site Status "
+msgid "Site Status"
 msgstr ""
 
 # χωρίς τόνο στο «πρόσθετα» λόγω του text-transform:uppercase
@@ -11576,35 +11454,35 @@ msgstr "Καλώς ορίσατε, {0}"
 msgid "<a href=\"%(reg)s\">Register</a> or <a href=\"%(login)s\">Log in</a>"
 msgstr "<a href=\"%(reg)s\">Εγγραφείτε</a> ή <a href=\"%(login)s\">συνδεθείτε</a>"
 
-#: src/olympia/templates/impala/base.html:126
+#: src/olympia/templates/impala/base.html:123
 #, python-format
 msgid "To try the thousands of add-ons available here, download <a href=\"%(url)s\">Mozilla Firefox</a>, a fast, free way to surf the Web!"
 msgstr "Για να δοκιμάσετε τα χιλιάδες διαθέσιμα πρόσθετα που είναι διαθέσιμα εδω, κάντε λήψη του <a href=\"%(url)s\">Mozilla Firefox</a>, ενός γρήγορου, ελεύθερου τρόπου να πλοηγηθείτε στο Web!"
 
-#: src/olympia/templates/impala/base.html:138
+#: src/olympia/templates/impala/base.html:135
 #, python-format
 msgid "Add-ons is switching to Firefox Accounts for login. <a href=\"%(url)s\" class=\"fxa-login\">Sign in now to transfer your account.</a>"
 msgstr ""
 
 #. {0} is an application, such as Firefox.
-#: src/olympia/templates/impala/base.html:148
+#: src/olympia/templates/impala/base.html:145
 msgid "Welcome to {0} Add-ons."
 msgstr "Καλώς ορίσατε στα πρόσθετα {0}."
 
-#: src/olympia/templates/impala/base.html:151
+#: src/olympia/templates/impala/base.html:148
 msgid "Choose from thousands of extra features and styles to make Firefox your own."
 msgstr "Διαλέξτε μεταξύ χιλιάδων επιπλέον χαρακτηριστικών και στυλ για να κάνετε τον Firefox δικό σας."
 
-#: src/olympia/templates/impala/base.html:156
+#: src/olympia/templates/impala/base.html:153
 #, python-format
 msgid "Add extra features and styles to make %(app)s your own."
 msgstr "Προσθέστε επιπλέον χαρακτηριστικά και στυλ για κάνετε το %(app)s δικό σας."
 
-#: src/olympia/templates/impala/base.html:164
+#: src/olympia/templates/impala/base.html:161
 msgid "On the go?"
 msgstr "Στο δρόμο;"
 
-#: src/olympia/templates/impala/base.html:166
+#: src/olympia/templates/impala/base.html:163
 msgid "Check out our <a class=\"mobile-link\" href=\"#\">Mobile Add-ons site</a>."
 msgstr "Ελέγξτε τη σελίδα μας <a class=\"mobile-link\" href=\"#\">Mobile Πρόσθετα</a>."
 
@@ -11829,19 +11707,19 @@ msgstr "Δεν υπάρχει χρήστης με αυτή τη διεύθυνσ
 
 #. L10n: {id} will be something like "13ad6a", just a random number
 #. to differentiate this user from other anonymous users.
-#: src/olympia/users/models.py:353
+#: src/olympia/users/models.py:362
 msgid "Anonymous user {id}"
 msgstr ""
 
-#: src/olympia/users/models.py:410
+#: src/olympia/users/models.py:419
 msgid "Your account has been restricted"
 msgstr ""
 
-#: src/olympia/users/models.py:480
+#: src/olympia/users/models.py:489
 msgid "Please confirm your email address"
 msgstr "Παρακαλούμε επιβεβαιώστε τη διεύθυνση ηλ. ταχυδρομείου σας"
 
-#: src/olympia/users/models.py:506
+#: src/olympia/users/models.py:515
 msgid "My Mobile Add-ons"
 msgstr "Τα πρόσθετα μου για κινητό"
 
@@ -12121,7 +11999,7 @@ msgstr "Κωδικός"
 
 #: src/olympia/users/templates/users/edit.html:70
 #, python-format
-msgid "Change your password.  If you forgot your password, you can <a href=\"%(reset_url)s\">use the reset form</a>."
+msgid "Change your password. If you forgot your password, you can <a href=\"%(reset_url)s\">use the reset form</a>."
 msgstr ""
 
 #: src/olympia/users/templates/users/edit.html:76
@@ -12141,7 +12019,7 @@ msgid "Profile"
 msgstr ""
 
 #: src/olympia/users/templates/users/edit.html:100
-msgid "Give us a bit more information about yourself.  All these fields are optional, but they'll help other users get to know you better."
+msgid "Give us a bit more information about yourself. All these fields are optional, but they'll help other users get to know you better."
 msgstr ""
 
 #: src/olympia/users/templates/users/edit.html:124
@@ -12373,7 +12251,8 @@ msgid "Send password reset link"
 msgstr "Αποστολή δεσμού επαναφοράς κωδικού"
 
 #: src/olympia/users/templates/users/pwreset_sent.html:10
-msgid "An email has been sent to the requested account with further information. If you do not receive an email then please confirm you have entered the same email address used during account registration."
+msgid ""
+"An email has been sent to the requested account with further information. If you do not receive an email then please confirm you have entered the same email address used during account registration."
 msgstr ""
 "Έχει αποσταλεί ένα μήνυμα ηλεκτρονικού ταχυδρομείου με περισσότερες πληροφορίες στην επιλεγμένη διεύθυνση. Αν δεν παραλάβετε το μήνυμα, ελέγξτε και επιβεβαιώστε ότι δώσατε την ίδια διεύθυνση που "
 "είχατε δώσει όταν καταχωρήσατε τον λογαριασμό σας."
@@ -12548,7 +12427,7 @@ msgstr ""
 
 #: src/olympia/users/templates/users/unsubscribe.html:30
 #, python-format
-msgid "Unfortunately, we weren't able to unsubscribe you.  The link you clicked is invalid. However, you can unsubscribe still unsubscribe on your <a href=\"%(edit_url)s\">edit profile page</a>."
+msgid "Unfortunately, we weren't able to unsubscribe you. The link you clicked is invalid. However, you can unsubscribe still unsubscribe on your <a href=\"%(edit_url)s\">edit profile page</a>."
 msgstr ""
 
 #: src/olympia/users/templates/users/vcard.html:2
@@ -12602,15 +12481,15 @@ msgstr "Ιστορικό εκδόσεων %s"
 msgid "Version History with Changelogs"
 msgstr "Ιστορικό αλλαγών εκδόσεων "
 
-#: src/olympia/versions/models.py:314
+#: src/olympia/versions/models.py:313
 msgid "Add-on uses binary components."
 msgstr ""
 
-#: src/olympia/versions/models.py:317
+#: src/olympia/versions/models.py:316
 msgid "Add-on has opted into strict compatibility checking."
 msgstr ""
 
-#: src/olympia/versions/models.py:715
+#: src/olympia/versions/models.py:711
 msgid "{app} {min} and later"
 msgstr ""
 
@@ -12688,3 +12567,6 @@ msgstr ""
 msgid "Log emails instead of sending"
 msgstr ""
 
+#: src/olympia/zadmin/forms.py:215
+msgid "Deleted versions can`t be changed."
+msgstr ""

--- a/locale/el/LC_MESSAGES/djangojs.po
+++ b/locale/el/LC_MESSAGES/djangojs.po
@@ -1,138 +1,394 @@
-
 msgid ""
 msgstr ""
 "Project-Id-Version: AMO-JS 0.1\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2016-02-24 21:23+0000\n"
+"POT-Creation-Date: 2016-04-18 15:47+0000\n"
 "PO-Revision-Date: 2015-09-21 10:44+0000\n"
 "Last-Translator: Jorge <sitilop@hotmail.com>\n"
 "Language-Team: el <fiotakis@otenet.gr>, <alexandros@mioglou.me>\n"
+"Language: \n"
 "MIME-Version: 1.0\n"
-"Content-Type: text/plain; charset=utf-8\n"
+"Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Generated-By: Babel 2.2.0\n"
 
-#: static/js/common/ratingwidget.js:31
+#: static/js/common-all.js:1426 static/js/impala-all.js:1511 static/js/zamboni/discovery-all.js:12598 static/js/zamboni/init.js:28 static/js/zamboni/mobile-all.js:14945
+msgid "This feature is temporarily disabled while we perform website maintenance. Please check back a little later."
+msgstr "Αυτό το χαρακτηριστικό έχει απενεργοποιηθεί προς το παρόν λόγω εκτέλεσης εργασιών συντήρησης. Παρακαλούμε προσπαθήστε ξανά αργότερα."
+
+#. L10n: {0} is an app name like Firefox.
+#: static/js/common-all.js:1837 static/js/impala-all.js:1922 static/js/zamboni/buttons.js:73 static/js/zamboni/discovery-all.js:13108
+msgid "Accept and Install"
+msgstr "Αποδοχή και εγκατάσταση"
+
+#: static/js/common-all.js:1837 static/js/impala-all.js:1922 static/js/zamboni/buttons.js:73 static/js/zamboni/discovery-all.js:13108
+msgid "Add to {0}"
+msgstr "Προσθήκη στον {0}"
+
+#: static/js/common-all.js:1842 static/js/impala-all.js:1927 static/js/zamboni/buttons.js:78 static/js/zamboni/discovery-all.js:13113
+msgid "Download Now"
+msgstr "Λήψη τώρα"
+
+#: static/js/common-all.js:1883 static/js/impala-all.js:1968 static/js/zamboni/buttons.js:119 static/js/zamboni/discovery-all.js:13154
+msgid "Add-on has not been updated to support default-to-compatible."
+msgstr "Το πρόσθετο δεν έχει ενημερωθεί ώστε να υποστηρίζει την προεπιλογή σε συμβατό."
+
+#: static/js/common-all.js:1888 static/js/impala-all.js:1973 static/js/zamboni/buttons.js:124 static/js/zamboni/discovery-all.js:13159
+msgid "You need to be using Firefox 10.0 or higher."
+msgstr "Χρειάζεται να χρησιμοποιείτε την έκδοση 10.0 του Firefox ή υψηλότερη."
+
+#: static/js/common-all.js:1900 static/js/impala-all.js:1985 static/js/zamboni/buttons.js:136 static/js/zamboni/discovery-all.js:13171
+msgid "Mozilla has marked this version as incompatible with your Firefox version."
+msgstr "Ο Mozilla έχει σημειώσει αυτή την έκδοση ως μη συμβατή με την έκδοση του Firefox που έχετε."
+
+#. L10n: {0} is an platform like Windows or Linux.
+#: static/js/common-all.js:1981 static/js/impala-all.js:2066 static/js/zamboni/buttons.js:217 static/js/zamboni/discovery-all.js:13252
+msgid "Install for {0} anyway"
+msgstr "Εγκατάσταση σε {0} οπωσδήποτε"
+
+#: static/js/common-all.js:1981 static/js/impala-all.js:2066 static/js/zamboni/buttons.js:217 static/js/zamboni/discovery-all.js:13252
+msgid "Download for {0} anyway"
+msgstr "Λήψη για {0} οπωσδήποτε"
+
+#: static/js/common-all.js:2038 static/js/impala-all.js:2123 static/js/zamboni/buttons.js:274 static/js/zamboni/discovery-all.js:13309
+msgid "Not available for your platform"
+msgstr "Δεν διατίθεται για το λειτουργικό σας"
+
+#. L10n: {0} is an app name, {1} is the app version.
+#: static/js/common-all.js:2049 static/js/common-all.js:2086 static/js/impala-all.js:2134 static/js/impala-all.js:2171 static/js/zamboni/buttons.js:286 static/js/zamboni/buttons.js:324
+#: static/js/zamboni/discovery-all.js:13320 static/js/zamboni/discovery-all.js:13357
+msgid "Not available for {0} {1}"
+msgstr "Δεν διατίθεται για τον {0} {1}"
+
+#: static/js/common-all.js:2112 static/js/impala-all.js:2197 static/js/zamboni/buttons.js:351 static/js/zamboni/discovery-all.js:13383
+msgid "Works with {app} {min} - {max}"
+msgstr "Συμβατό με {app} {min} - {max}"
+
+#: static/js/common-all.js:2114 static/js/impala-all.js:2199 static/js/zamboni/buttons.js:353 static/js/zamboni/discovery-all.js:13385
+msgid "View other versions"
+msgstr "Προβολή άλλων εκδόσεων"
+
+#: static/js/common-all.js:2162 static/js/impala-all.js:2247 static/js/zamboni/buttons.js:401 static/js/zamboni/discovery-all.js:13433
+msgid "Only with Firefox — Get Firefox Now!"
+msgstr ""
+
+#: static/js/common-all.js:2278 static/js/impala-all.js:2363 static/js/zamboni/buttons.js:517 static/js/zamboni/discovery-all.js:13549 static/js/zamboni/mobile-all.js:15177
+#: static/js/zamboni/mobile/buttons.js:43
+msgid "Sorry, you need a Mozilla-based browser (such as Firefox) to install a search plugin."
+msgstr "Λυπούμαστε αλλά απαιτείται περιηγητής της οικογένειας Mozilla (όπως ο Firefox) για να εγκαταστήσετε πρόσθετα αναζήτησης."
+
+#: static/js/common-all.js:9088 static/js/impala-all.js:9649 static/js/zamboni/global.js:410
+msgid "Loading..."
+msgstr "Γίνεται φόρτωση..."
+
+#. L10n: {0} is the number of characters left.
+#: static/js/common-all.js:9152 static/js/impala-all.js:9713 static/js/zamboni/global.js:474
+msgid "<b>{0}</b> character left."
+msgid_plural "<b>{0}</b> characters left."
+msgstr[0] "<b>{0}</b> χαρακτήρας διαθέσιμος."
+msgstr[1] "<b>{0}</b> χαρακτήρες διαθέσιμοι."
+
+#: static/js/common-all.js:9589 static/js/common-min.js:6 static/js/impala-all.js:10052 static/js/impala-min.js:6 static/js/common/ratingwidget.js:31 static/js/zamboni/mobile-all.js:16123
+#: static/js/zamboni/mobile-min.js:6
 msgid "{0} star"
 msgid_plural "{0} stars"
 msgstr[0] "{0} αστέρι"
 msgstr[1] "{0} αστέρια"
 
-#: static/js/common/upload-addon.js:41 static/js/common/upload-image.js:128
+#: static/js/common-all.js:9676 static/js/common-min.js:6 static/js/impala-all.js:10139 static/js/impala-min.js:6 static/js/zamboni/l10n.js:45
+msgid "Remove this localization"
+msgstr "Αφαίρεση αυτής της μετάφρασης"
+
+#: static/js/common-all.js:10193 static/js/common-min.js:6 static/js/impala-all.js:10674 static/js/impala-min.js:6 static/js/zamboni/discovery-all.js:13678
+msgid "close"
+msgstr ""
+
+#: static/js/common-all.js:10860 static/js/common-min.js:6 static/js/impala-all.js:11481 static/js/impala-min.js:6 static/js/impala/reviews.js:23 static/js/zamboni/reviews.js:18
+msgid "Flagged for review"
+msgstr "Σημειώθηκε για αξιολόγηση"
+
+#: static/js/common-all.js:10876 static/js/common-min.js:6 static/js/impala-all.js:11498 static/js/impala-min.js:6 static/js/impala/reviews.js:40 static/js/zamboni/reviews.js:34
+msgid "Your input is required"
+msgstr "Απαιτείται η εισαγωγή"
+
+#: static/js/common-all.js:10945 static/js/common-min.js:6 static/js/impala-all.js:11610 static/js/impala-min.js:7 static/js/impala/reviews.js:152 static/js/zamboni/reviews.js:103
+msgid "Marked for deletion"
+msgstr "Σημειώθηκε για διαγραφή"
+
+#: static/js/common-all.js:11573 static/js/common-min.js:7 static/js/impala-all.js:13809 static/js/impala-min.js:8 static/js/zamboni/collections.js:229
+msgid "Adding to Favorites&hellip;"
+msgstr "Γίνεται προσθήκη στις αγαπημένες&hellip;"
+
+#: static/js/common-all.js:11576 static/js/common-min.js:7 static/js/impala-all.js:13812 static/js/impala-min.js:8 static/js/zamboni/collections.js:232
+msgid "Removing Favorite&hellip;"
+msgstr "Γίνεται αφαίρεση από τις αγαπημένες&hellip;"
+
+#: static/js/common-all.js:11579 static/js/common-min.js:7 static/js/impala-all.js:13815 static/js/impala-min.js:8 static/js/zamboni/collections.js:235
+msgid "Add to Favorites"
+msgstr "Προσθήκη στις αγαπημένες"
+
+#: static/js/common-all.js:11582 static/js/common-min.js:7 static/js/impala-all.js:13818 static/js/impala-min.js:8 static/js/zamboni/collections.js:238
+msgid "Remove from Favorites"
+msgstr "Αφαίρεση απ' τις αγαπημένες"
+
+#: static/js/common-all.js:11647 static/js/common-min.js:7 static/js/impala-all.js:13883 static/js/impala-min.js:8 static/js/zamboni/collections.js:303
+msgid "Pending"
+msgstr "Σε αναμονή"
+
+#: static/js/common-all.js:11648 static/js/common-min.js:7 static/js/impala-all.js:13884 static/js/impala-min.js:8 static/js/zamboni/collections.js:304
+msgid "Add a comment"
+msgstr "Προσθήκη σχολίου"
+
+#: static/js/common-all.js:11648 static/js/common-min.js:7 static/js/impala-all.js:13884 static/js/impala-min.js:8 static/js/zamboni/collections.js:304
+msgid "Comment"
+msgstr "Σχόλιο"
+
+#: static/js/common-all.js:11649 static/js/common-min.js:7 static/js/impala-all.js:13885 static/js/impala-min.js:8 static/js/zamboni/collections.js:305
+msgid "Remove this add-on from the collection"
+msgstr "Αφαίρεση αυτού του πρόσθετου από τη συλλογή"
+
+#: static/js/common-all.js:11649 static/js/common-all.js:11678 static/js/common-min.js:7 static/js/impala-all.js:13885 static/js/impala-all.js:13914 static/js/impala-min.js:8
+#: static/js/zamboni/collections.js:305 static/js/zamboni/collections.js:334
+msgid "Remove"
+msgstr "Αφαίρεση"
+
+#: static/js/common-all.js:11678 static/js/common-min.js:7 static/js/impala-all.js:13914 static/js/impala-min.js:8 static/js/zamboni/collections.js:334
+msgid "Remove this user as a contributor"
+msgstr "Αφαίρεση χρήστη από τους συντελεστές"
+
+#: static/js/common-all.js:11690 static/js/common-min.js:7 static/js/impala-all.js:13926 static/js/impala-min.js:8 static/js/zamboni/collections.js:346
+msgid "An email address is required."
+msgstr "Απαιτείται διεύθυνση email."
+
+#: static/js/common-all.js:11708 static/js/common-min.js:7 static/js/impala-all.js:13944 static/js/impala-min.js:8 static/js/zamboni/collections.js:364
+msgid "You cannot add yourself as a contributor."
+msgstr "Δε μπορείτε να προσθέσετε τον εαυτό σας στους συνεισφέροντες."
+
+#: static/js/common-all.js:11710 static/js/common-min.js:7 static/js/impala-all.js:13946 static/js/impala-min.js:8 static/js/zamboni/collections.js:366
+msgid "You have already added that user."
+msgstr "Έχετε ήδη προσθέσει αυτόν τον χρήστη."
+
+#: static/js/common-all.js:11917 static/js/common-min.js:7 static/js/impala-all.js:14153 static/js/impala-min.js:8 static/js/zamboni/collections.js:573
+msgid "Add to favorites"
+msgstr "Προσθήκη στα αγαπημένα"
+
+#: static/js/common-all.js:11921 static/js/common-min.js:7 static/js/impala-all.js:14157 static/js/impala-min.js:8 static/js/zamboni/collections.js:577
+msgid "Remove from favorites"
+msgstr "Αφαίρεση απ' τα αγαπημένα"
+
+#: static/js/common-all.js:11939 static/js/common-min.js:7 static/js/impala-all.js:14175 static/js/impala-all.js:14233 static/js/impala-min.js:8 static/js/impala/collections.js:10
+#: static/js/zamboni/collections.js:595
+msgid "Follow this Collection"
+msgstr "Παρακολούθηση της συλλογής"
+
+#: static/js/common-all.js:11948 static/js/common-min.js:7 static/js/impala-all.js:14184 static/js/impala-min.js:8 static/js/zamboni/collections.js:604
+msgid "Stop following"
+msgstr "Διακοπή παρακολούθησης"
+
+#: static/js/common-all.js:12096 static/js/common-min.js:7 static/js/zamboni/password-strength.js:20
+msgid "Password strength:"
+msgstr "Ισχύς κωδικού:"
+
+#: static/js/common-all.js:12102 static/js/common-min.js:7 static/js/zamboni/password-strength.js:26
+msgid "At least {0} character left."
+msgid_plural "At least {0} characters left."
+msgstr[0] "Τουλάχιστον {0} χαρακτήρας διαθέσιμος"
+msgstr[1] "Τουλάχιστον {0} χαρακτήρες διαθέσιμοι"
+
+#: static/js/common-all.js:12286 static/js/common-min.js:7 static/js/impala-all.js:14632 static/js/impala-min.js:8 static/js/impala/suggestions.js:39
+msgid "Search themes for <b>{0}</b>"
+msgstr "Αναζήτηση θέματος για <b>{0}</b>"
+
+#: static/js/common-all.js:12288 static/js/common-min.js:7 static/js/impala-all.js:14634 static/js/impala-min.js:8 static/js/impala/suggestions.js:41
+msgid "Search apps for <b>{0}</b>"
+msgstr "Αναζήτηση εφαρμογών για <b>{0}</b>"
+
+#: static/js/common-all.js:12290 static/js/common-min.js:7 static/js/impala-all.js:14636 static/js/impala-min.js:8 static/js/impala/suggestions.js:43
+msgid "Search add-ons for <b>{0}</b>"
+msgstr "Αναζήτηση προσθέτων για <b>{0}</b>"
+
+#: static/js/common-all.js:12521 static/js/common-min.js:7 static/js/impala-all.js:14867 static/js/impala-min.js:8 static/js/impala/site_suggestions.js:46
+msgid "Category"
+msgstr "Κατηγορία"
+
+#. L10n: {0} is an app name.
+#: static/js/impala-all.js:11632 static/js/impala-min.js:7 static/js/impala/listing.js:11 static/js/zamboni/themes.js:13
+msgid "This theme is incompatible with your version of {0}"
+msgstr "Δεν είναι συμβατό αυτό το θέμα με την έκδοση του {0} που έχετε"
+
+#: static/js/impala-all.js:12146 static/js/impala-all.js:14331 static/js/impala-min.js:7 static/js/impala-min.js:8 static/js/common/upload-image.js:97 static/js/impala/users.js:51
+#: static/js/zamboni/devhub-all.js:894 static/js/zamboni/devhub-min.js:1
+msgid "Images must be either PNG or JPG."
+msgstr "Οι εικόνες πρέπει να είναι είτε PNG είτε JPG"
+
+#: static/js/impala-all.js:12150 static/js/impala-min.js:7 static/js/common/upload-image.js:101 static/js/zamboni/devhub-all.js:898 static/js/zamboni/devhub-min.js:1
+msgid "Videos must be in WebM."
+msgstr "Τα βίντεο πρέπει να είναι τύπου WebM."
+
+#: static/js/impala-all.js:12177 static/js/impala-min.js:7 static/js/common/upload-addon.js:41 static/js/common/upload-image.js:128 static/js/zamboni/devhub-all.js:272
+#: static/js/zamboni/devhub-all.js:925 static/js/zamboni/devhub-min.js:1
 msgid "There was a problem contacting the server."
 msgstr "Παρουσιάστηκε πρόβλημα επικοινωνίας με το διακομιστή."
 
-#: static/js/common/upload-addon.js:69
+#: static/js/impala-all.js:13298 static/js/impala-min.js:7 static/js/impala/persona_creation.js:60
+msgid "All Rights Reserved"
+msgstr "All Rights Reserved"
+
+#: static/js/impala-all.js:13302 static/js/impala-min.js:7 static/js/impala/persona_creation.js:64
+msgid "Creative Commons Attribution 3.0"
+msgstr "Creative Commons Attribution 3.0"
+
+#: static/js/impala-all.js:13307 static/js/impala-min.js:7 static/js/impala/persona_creation.js:69
+msgid "Creative Commons Attribution-NonCommercial 3.0"
+msgstr "Creative Commons Attribution-NonCommercial 3.0"
+
+#: static/js/impala-all.js:13312 static/js/impala-min.js:7 static/js/impala/persona_creation.js:74
+msgid "Creative Commons Attribution-NonCommercial-NoDerivs 3.0"
+msgstr "Creative Commons Attribution-NonCommercial-NoDerivs 3.0"
+
+#: static/js/impala-all.js:13317 static/js/impala-min.js:7 static/js/impala/persona_creation.js:79
+msgid "Creative Commons Attribution-NonCommercial-Share Alike 3.0"
+msgstr "Creative Commons Attribution-NonCommercial-Share Alike 3.0"
+
+#: static/js/impala-all.js:13322 static/js/impala-min.js:7 static/js/impala/persona_creation.js:84
+msgid "Creative Commons Attribution-NoDerivs 3.0"
+msgstr "Creative Commons Attribution-NoDerivs 3.0"
+
+#: static/js/impala-all.js:13327 static/js/impala-min.js:7 static/js/impala/persona_creation.js:89
+msgid "Creative Commons Attribution-ShareAlike 3.0"
+msgstr "Creative Commons Attribution-ShareAlike 3.0"
+
+#: static/js/impala-all.js:13530 static/js/impala-min.js:7 static/js/impala/persona_creation.js:292
+msgid "Your Theme's Name"
+msgstr "Όνομα Θέματος"
+
+#: static/js/impala-all.js:14242 static/js/impala-min.js:8 static/js/impala/collections.js:19
+msgid "Stop Following"
+msgstr "Διακοπή παρακολούθησης"
+
+#: static/js/impala-all.js:14243 static/js/impala-min.js:8 static/js/impala/collections.js:20
+msgid "Following"
+msgstr "Παρακολούθηση"
+
+#: static/js/impala-all.js:14313 static/js/impala-min.js:8 static/js/impala/users.js:33
+msgid "use original"
+msgstr "χρησιμοποίηση αρχικού"
+
+#: static/js/impala-all.js:14523 static/js/impala-min.js:8 static/js/impala/search.js:114
+msgid "Updating results&hellip;"
+msgstr "Ανανέωση αποτελεσμάτων&hellip;"
+
+#: static/js/common/upload-addon.js:69 static/js/zamboni/devhub-all.js:300 static/js/zamboni/devhub-min.js:1
 msgid "Select a file..."
 msgstr "Επιλογή αρχείου..."
 
-#: static/js/common/upload-addon.js:70
+#: static/js/common/upload-addon.js:70 static/js/zamboni/devhub-all.js:301 static/js/zamboni/devhub-min.js:1
 msgid "Your add-on should end with .xpi, .jar or .xml"
 msgstr "Το πρόσθετο σας θα πρέπει να έχει κατάληξη .xpi, .jar ή .xml"
 
 #. L10n: {0} is the percent of the file that has been uploaded.
-#: static/js/common/upload-addon.js:104
+#: static/js/common/upload-addon.js:104 static/js/zamboni/devhub-all.js:335 static/js/zamboni/devhub-min.js:1
 #, fuzzy, python-format
 msgid "{0}% complete"
 msgstr "Ολοκληρώθηκε {0}%"
 
 #. L10n: "{bytes uploaded} of {total filesize}".
-#: static/js/common/upload-addon.js:107
+#: static/js/common/upload-addon.js:107 static/js/zamboni/devhub-all.js:338 static/js/zamboni/devhub-min.js:1
 msgid "{0} of {1}"
 msgstr "{0} από {1}"
 
-#: static/js/common/upload-addon.js:140
+#: static/js/common/upload-addon.js:140 static/js/zamboni/devhub-all.js:371 static/js/zamboni/devhub-min.js:1
 msgid "Cancel"
 msgstr "Ακύρωση"
 
-#: static/js/common/upload-addon.js:162
+#: static/js/common/upload-addon.js:162 static/js/zamboni/devhub-all.js:393 static/js/zamboni/devhub-min.js:1
 msgid "Uploading {0}"
 msgstr "Γίνεται αποστολή του {0}"
 
-#: static/js/common/upload-addon.js:189
+#: static/js/common/upload-addon.js:189 static/js/zamboni/devhub-all.js:420 static/js/zamboni/devhub-min.js:1
 msgid "Error with {0}"
 msgstr "Παρουσιάστηκε σφάλμα στο {0}"
 
-#: static/js/common/upload-addon.js:194
+#: static/js/common/upload-addon.js:194 static/js/zamboni/devhub-all.js:425 static/js/zamboni/devhub-min.js:1
 msgid "Your add-on failed validation with {0} error."
 msgid_plural "Your add-on failed validation with {0} errors."
 msgstr[0] "Το πρόσθετο σας απέτυχε να επικυρωθεί, επιστρέφοντας {0} σφάλμα."
 msgstr[1] "Το πρόσθετο σας απέτυχε να επικυρωθεί, επιστρέφοντας {0} σφάλματα."
 
-#: static/js/common/upload-addon.js:208
+#: static/js/common/upload-addon.js:208 static/js/zamboni/devhub-all.js:439 static/js/zamboni/devhub-min.js:1
 msgid "&hellip;and {0} more"
 msgid_plural "&hellip;and {0} more"
 msgstr[0] "&hellip;και {0} περισσότερο"
 msgstr[1] "&hellip;και {0} περισσότερα"
 
-#: static/js/common/upload-addon.js:222 static/js/common/upload-addon.js:512
+#: static/js/common/upload-addon.js:222 static/js/common/upload-addon.js:497 static/js/zamboni/devhub-all.js:453 static/js/zamboni/devhub-all.js:743 static/js/zamboni/devhub-min.js:1
 msgid "See full validation report"
 msgstr "Δείτε την αναλυτική αναφορά επικύρωσης"
 
-#: static/js/common/upload-addon.js:234
+#: static/js/common/upload-addon.js:234 static/js/zamboni/devhub-all.js:465 static/js/zamboni/devhub-min.js:1
 msgid "Validating {0}"
 msgstr "Γίνεται επικύρωση {0}"
 
 #. L10n: first argument is an HTTP status code
-#: static/js/common/upload-addon.js:273
+#: static/js/common/upload-addon.js:273 static/js/zamboni/devhub-all.js:504 static/js/zamboni/devhub-min.js:1
 msgid "Received an empty response from the server; status: {0}"
 msgstr "Η απάντηση του εξυπηρετητή ήταν κενή; κατάσταση: {0}"
 
-#: static/js/common/upload-addon.js:373
+#: static/js/common/upload-addon.js:370 static/js/zamboni/devhub-all.js:604 static/js/zamboni/devhub-min.js:1
 msgid "Unexpected server error while validating."
 msgstr "Απρόσμενο σφάλμα διακομιστή κατά την επικύρωση."
 
-#: static/js/common/upload-addon.js:412
+#: static/js/common/upload-addon.js:409 static/js/zamboni/devhub-all.js:643 static/js/zamboni/devhub-min.js:1
 msgid "Finished validating {0}"
 msgstr "Ολοκληρώθηκε η επικύρωση του {0}"
 
-#: static/js/common/upload-addon.js:418
+#: static/js/common/upload-addon.js:415 static/js/zamboni/devhub-all.js:649 static/js/zamboni/devhub-min.js:1
 msgid "Your add-on validation timed out, it will be manually reviewed."
 msgstr ""
 
-#: static/js/common/upload-addon.js:421
+#: static/js/common/upload-addon.js:418 static/js/zamboni/devhub-all.js:652 static/js/zamboni/devhub-min.js:1
 msgid "Your add-on was validated with no errors and {0} warning."
 msgid_plural "Your add-on was validated with no errors and {0} warnings."
 msgstr[0] ""
 msgstr[1] ""
 
-#: static/js/common/upload-addon.js:426
+#: static/js/common/upload-addon.js:423 static/js/zamboni/devhub-all.js:657 static/js/zamboni/devhub-min.js:1
 msgid "Your add-on was validated with no errors and {0} message."
 msgid_plural "Your add-on was validated with no errors and {0} messages."
 msgstr[0] ""
 msgstr[1] ""
 
-#: static/js/common/upload-addon.js:431
+#: static/js/common/upload-addon.js:428 static/js/zamboni/devhub-all.js:662 static/js/zamboni/devhub-min.js:1
 msgid "Your add-on was validated with no errors or warnings."
 msgstr ""
 
-#: static/js/common/upload-addon.js:446
+#: static/js/common/upload-addon.js:443 static/js/zamboni/devhub-all.js:677 static/js/zamboni/devhub-min.js:1
 msgid "Your submission will be automatically signed."
 msgstr ""
 
-#: static/js/common/upload-addon.js:465
+#: static/js/common/upload-addon.js:450 static/js/zamboni/devhub-all.js:696 static/js/zamboni/devhub-min.js:1
 msgid "Include detailed version notes (this can be done in the next step)."
 msgstr "Συμπεριλάβετε λεπτομερή σημειώματα της έκδοσης (αυτό μπορεί να γίνει στο επόμενο βήμα)."
 
-#: static/js/common/upload-addon.js:466
+#: static/js/common/upload-addon.js:451 static/js/zamboni/devhub-all.js:697 static/js/zamboni/devhub-min.js:1
 msgid "If your add-on requires an account to a website in order to be fully tested, include a test username and password in the Notes to Reviewer (this can be done in the next step)."
 msgstr ""
-"Εάν το πρόσθετό σας απαιτεί λογαριασμό σε ιστοσελίδα με σκοπό να δοκιμαστεί πλήρως, συμπεριλάβετε ένα όνομα χρήστη και κωδικό για δοκιμή στα Σημειώματα του Ελεγκτή (αυτό μπορεί να γίνει στο επόμενο"
-" βήμα). "
+"Εάν το πρόσθετό σας απαιτεί λογαριασμό σε ιστοσελίδα με σκοπό να δοκιμαστεί πλήρως, συμπεριλάβετε ένα όνομα χρήστη και κωδικό για δοκιμή στα Σημειώματα του Ελεγκτή (αυτό μπορεί να γίνει στο επόμενο "
+"βήμα). "
 
-#: static/js/common/upload-addon.js:467
+#: static/js/common/upload-addon.js:452 static/js/zamboni/devhub-all.js:698 static/js/zamboni/devhub-min.js:1
 msgid "If your add-on is intended for a limited audience you should choose Preliminary Review instead of Full Review."
 msgstr "Λίστα καταχωρήσεων προσθέτων"
 
-#: static/js/common/upload-addon.js:480
+#: static/js/common/upload-addon.js:465 static/js/zamboni/devhub-all.js:711 static/js/zamboni/devhub-min.js:1
 msgid "Add-on submission checklist"
 msgstr "Λίστα καταχωρήσεων προσθέτων"
 
-#: static/js/common/upload-addon.js:481
+#: static/js/common/upload-addon.js:466 static/js/zamboni/devhub-all.js:712 static/js/zamboni/devhub-min.js:1
 msgid "Please verify the following points before finalizing your submission. This will minimize delays or misunderstanding during the review process:"
 msgstr "Παρακαλώ επιβεβαιώστε τα παρακάτω σημεία πριν την ολοκλήρωση της υποβολής σας. Αυτό θα μειώσει καθυστερήσεις είτε ασάφειες κατά την διαδικασία της αξιολόγησης."
 
-#: static/js/common/upload-addon.js:483
+#: static/js/common/upload-addon.js:468 static/js/zamboni/devhub-all.js:714 static/js/zamboni/devhub-min.js:1
 msgid ""
 "Compiled binaries, as well as minified or obfuscated scripts (excluding known libraries) need to have their sources submitted separately for review. Make sure that you use the source code upload "
 "field to avoid having your submission rejected."
@@ -140,1080 +396,844 @@ msgstr ""
 "Μεταγλωττισμένα εκτελέσιμα , καθώς και ελαχιστοποιημένα ή ασαφή σενάρια (με εξαίρεση γνωστές βιβλιοθήκες) είναι αναγκαίο να έχουν υποβάλει τις πηγές τους ξεχωριστά για αξιολόγηση. Βεβαιωθείτε ότι "
 "χρησιμοποιείτε το πεδίο μεταφόρτωσης πηγαίου κώδικα για να αποφύγετε την απόρριψή της υποβολή σας."
 
-#: static/js/common/upload-addon.js:501
+#: static/js/common/upload-addon.js:486 static/js/zamboni/devhub-all.js:732 static/js/zamboni/devhub-min.js:1
 msgid "The validation process found these issues that can lead to rejections:"
 msgstr "Η διαδικασία επικύρωσης βρήκε προβλήματα που μπορούν να οδηγήσουν σε απόρριψη."
 
-#: static/js/common/upload-addon.js:518
+#: static/js/common/upload-addon.js:503 static/js/zamboni/devhub-all.js:749 static/js/zamboni/devhub-min.js:1
 msgid "If you are unfamiliar with the add-ons review process, you can read about it here."
 msgstr "Εάν δεν είστε εξοικειωμένος με την διαδικασία αξιολόγισης στα πρόσθετα, μπορείτε να διαβάσετε γι' αυτό εδώ."
 
-#: static/js/common/upload-addon.js:555
+#: static/js/common/upload-addon.js:540 static/js/zamboni/devhub-all.js:786 static/js/zamboni/devhub-min.js:1
 msgid "Sorry, no supported platform has been found."
 msgstr "Συγνώμη, δεν βρέθηκε υποστηριζόμενη πλατφόρμα."
 
-#: static/js/common/upload-base.js:57
+#: static/js/common/upload-base.js:57 static/js/zamboni/devhub-all.js:187 static/js/zamboni/devhub-min.js:1
 msgid "The filetype you uploaded isn't recognized."
 msgstr "Δεν αναγνωρίζεται η μορφή αρχείου που αποστείλατε."
 
-#: static/js/common/upload-base.js:79
+#: static/js/common/upload-base.js:79 static/js/zamboni/devhub-all.js:209 static/js/zamboni/devhub-min.js:1
 msgid "You cancelled the upload."
 msgstr "Ακυρώσατε την μεταφόρτωση."
 
-#: static/js/common/upload-image.js:97 static/js/impala/users.js:51
-msgid "Images must be either PNG or JPG."
-msgstr "Οι εικόνες πρέπει να είναι είτε PNG είτε JPG"
-
-#: static/js/common/upload-image.js:101
-msgid "Videos must be in WebM."
-msgstr "Τα βίντεο πρέπει να είναι τύπου WebM."
-
-#: static/js/impala/collections.js:10 static/js/zamboni/collections.js:595
-msgid "Follow this Collection"
-msgstr "Παρακολούθηση της συλλογής"
-
-#: static/js/impala/collections.js:19
-msgid "Stop Following"
-msgstr "Διακοπή παρακολούθησης"
-
-#: static/js/impala/collections.js:20
-msgid "Following"
-msgstr "Παρακολούθηση"
-
-#. L10n: {0} is an app name.
-#: static/js/impala/listing.js:11 static/js/zamboni/themes.js:13
-msgid "This theme is incompatible with your version of {0}"
-msgstr "Δεν είναι συμβατό αυτό το θέμα με την έκδοση του {0} που έχετε"
-
-#: static/js/impala/persona_creation.js:60
-msgid "All Rights Reserved"
-msgstr "All Rights Reserved"
-
-#: static/js/impala/persona_creation.js:64
-msgid "Creative Commons Attribution 3.0"
-msgstr "Creative Commons Attribution 3.0"
-
-#: static/js/impala/persona_creation.js:69
-msgid "Creative Commons Attribution-NonCommercial 3.0"
-msgstr "Creative Commons Attribution-NonCommercial 3.0"
-
-#: static/js/impala/persona_creation.js:74
-msgid "Creative Commons Attribution-NonCommercial-NoDerivs 3.0"
-msgstr "Creative Commons Attribution-NonCommercial-NoDerivs 3.0"
-
-#: static/js/impala/persona_creation.js:79
-msgid "Creative Commons Attribution-NonCommercial-Share Alike 3.0"
-msgstr "Creative Commons Attribution-NonCommercial-Share Alike 3.0"
-
-#: static/js/impala/persona_creation.js:84
-msgid "Creative Commons Attribution-NoDerivs 3.0"
-msgstr "Creative Commons Attribution-NoDerivs 3.0"
-
-#: static/js/impala/persona_creation.js:89
-msgid "Creative Commons Attribution-ShareAlike 3.0"
-msgstr "Creative Commons Attribution-ShareAlike 3.0"
-
-#: static/js/impala/persona_creation.js:292
-msgid "Your Theme's Name"
-msgstr "Όνομα Θέματος"
-
-#: static/js/impala/reviews.js:23 static/js/zamboni/reviews.js:18
-msgid "Flagged for review"
-msgstr "Σημειώθηκε για αξιολόγηση"
-
-#: static/js/impala/reviews.js:40 static/js/zamboni/reviews.js:34
-msgid "Your input is required"
-msgstr "Απαιτείται η εισαγωγή"
-
-#: static/js/impala/reviews.js:152 static/js/zamboni/reviews.js:103
-msgid "Marked for deletion"
-msgstr "Σημειώθηκε για διαγραφή"
-
-#: static/js/impala/search.js:114
-msgid "Updating results&hellip;"
-msgstr "Ανανέωση αποτελεσμάτων&hellip;"
-
-#: static/js/impala/site_suggestions.js:46
-msgid "Category"
-msgstr "Κατηγορία"
-
-#: static/js/impala/suggestions.js:39
-msgid "Search themes for <b>{0}</b>"
-msgstr "Αναζήτηση θέματος για <b>{0}</b>"
-
-#: static/js/impala/suggestions.js:41
-msgid "Search apps for <b>{0}</b>"
-msgstr "Αναζήτηση εφαρμογών για <b>{0}</b>"
-
-#: static/js/impala/suggestions.js:43
-msgid "Search add-ons for <b>{0}</b>"
-msgstr "Αναζήτηση προσθέτων για <b>{0}</b>"
-
-#: static/js/impala/users.js:33
-msgid "use original"
-msgstr "χρησιμοποίηση αρχικού"
-
-#: static/js/impala/stats/chart.js:267
+#: static/js/impala/stats/chart.js:267 static/js/zamboni/stats-all.js:16898 static/js/zamboni/stats-min.js:5
 msgid "Week of {0}"
 msgstr "Εβδομάδα {0}"
 
-#: static/js/impala/stats/chart.js:269
+#: static/js/impala/stats/chart.js:269 static/js/zamboni/stats-all.js:16900 static/js/zamboni/stats-min.js:5
 msgid " downloads"
 msgstr ""
 
-#: static/js/impala/stats/chart.js:270
+#: static/js/impala/stats/chart.js:270 static/js/zamboni/stats-all.js:16901 static/js/zamboni/stats-min.js:5
 msgid "{0} users"
 msgstr "{0} χρήστες"
 
-#: static/js/impala/stats/chart.js:271
+#: static/js/impala/stats/chart.js:271 static/js/zamboni/stats-all.js:16902 static/js/zamboni/stats-min.js:5
 msgid "{0} add-ons"
 msgstr "{0} πρόσθετα"
 
-#: static/js/impala/stats/chart.js:272
+#: static/js/impala/stats/chart.js:272 static/js/zamboni/stats-all.js:16903 static/js/zamboni/stats-min.js:5
 msgid "{0} collections"
 msgstr "{0} συλλογές"
 
-#: static/js/impala/stats/chart.js:273
+#: static/js/impala/stats/chart.js:273 static/js/zamboni/stats-all.js:16904 static/js/zamboni/stats-min.js:5
 msgid "{0} reviews"
 msgstr "{0} αξιολογήσεις"
 
-#: static/js/impala/stats/chart.js:275
+#: static/js/impala/stats/chart.js:275 static/js/zamboni/stats-all.js:16906 static/js/zamboni/stats-min.js:5
 msgid "{0} sales"
 msgstr "{0} πωλήσεις"
 
-#: static/js/impala/stats/chart.js:276
+#: static/js/impala/stats/chart.js:276 static/js/zamboni/stats-all.js:16907 static/js/zamboni/stats-min.js:5
 msgid "{0} refunds"
 msgstr "{0} επιστροφές"
 
-#: static/js/impala/stats/chart.js:277
+#: static/js/impala/stats/chart.js:277 static/js/zamboni/stats-all.js:16908 static/js/zamboni/stats-min.js:5
 msgid "{0} installs"
 msgstr "{0} εγκαταστάσεις"
 
-#: static/js/impala/stats/chart.js:369 static/js/impala/stats/csv_keys.js:3 static/js/impala/stats/csv_keys.js:109
+#: static/js/impala/stats/chart.js:369 static/js/impala/stats/csv_keys.js:3 static/js/impala/stats/csv_keys.js:109 static/js/zamboni/stats-all.js:15284 static/js/zamboni/stats-all.js:15390
+#: static/js/zamboni/stats-all.js:17000 static/js/zamboni/stats-min.js:4 static/js/zamboni/stats-min.js:5
 msgid "Downloads"
 msgstr "Λήψεις"
 
-#: static/js/impala/stats/chart.js:379 static/js/impala/stats/csv_keys.js:6 static/js/impala/stats/csv_keys.js:110
+#: static/js/impala/stats/chart.js:379 static/js/impala/stats/csv_keys.js:6 static/js/impala/stats/csv_keys.js:110 static/js/zamboni/stats-all.js:15287 static/js/zamboni/stats-all.js:15391
+#: static/js/zamboni/stats-all.js:17010 static/js/zamboni/stats-min.js:4 static/js/zamboni/stats-min.js:5
 msgid "Daily Users"
 msgstr "Καθημερινοί χρήστες"
 
-#: static/js/impala/stats/chart.js:410
+#: static/js/impala/stats/chart.js:410 static/js/zamboni/stats-all.js:17041 static/js/zamboni/stats-min.js:5
 msgid "Amount, in USD"
 msgstr "Σύνολο, σε USD"
 
-#: static/js/impala/stats/chart.js:421 static/js/impala/stats/csv_keys.js:104
+#: static/js/impala/stats/chart.js:421 static/js/impala/stats/csv_keys.js:104 static/js/zamboni/stats-all.js:15385 static/js/zamboni/stats-all.js:17052 static/js/zamboni/stats-min.js:5
 msgid "Number of Contributions"
 msgstr "Αριθμός συνεισφορών"
 
-#: static/js/impala/stats/chart.js:447
+#: static/js/impala/stats/chart.js:447 static/js/zamboni/stats-all.js:17078 static/js/zamboni/stats-min.js:5
 msgid "More Info..."
 msgstr "Περισσότερες πληροφορίες..."
 
 #. L10n: {0} is an ISO-formatted date.
-#: static/js/impala/stats/chart.js:451
+#: static/js/impala/stats/chart.js:451 static/js/zamboni/stats-all.js:17082 static/js/zamboni/stats-min.js:5
 msgid "Details for {0}"
 msgstr "Λεπτομέρειες του {0}"
 
-#: static/js/impala/stats/csv_keys.js:9
+#: static/js/impala/stats/csv_keys.js:9 static/js/zamboni/stats-all.js:15290 static/js/zamboni/stats-min.js:4
 msgid "Collections Created"
 msgstr "Συλλογές που δημιουργήθηκαν"
 
-#: static/js/impala/stats/csv_keys.js:12
+#: static/js/impala/stats/csv_keys.js:12 static/js/zamboni/stats-all.js:15293 static/js/zamboni/stats-min.js:4
 msgid "Add-ons in Use"
 msgstr "Πρόσθετα σε χρήση"
 
-#: static/js/impala/stats/csv_keys.js:15
+#: static/js/impala/stats/csv_keys.js:15 static/js/zamboni/stats-all.js:15296 static/js/zamboni/stats-min.js:4
 msgid "Add-ons Created"
 msgstr "Δημιουργηθέντα Πρόσθετα"
 
-#: static/js/impala/stats/csv_keys.js:18
+#: static/js/impala/stats/csv_keys.js:18 static/js/zamboni/stats-all.js:15299 static/js/zamboni/stats-min.js:4
 msgid "Add-ons Downloaded"
 msgstr "Ληφθέντα Πρόσθετα"
 
-#: static/js/impala/stats/csv_keys.js:21
+#: static/js/impala/stats/csv_keys.js:21 static/js/zamboni/stats-all.js:15302 static/js/zamboni/stats-min.js:4
 msgid "Add-ons Updated"
 msgstr "Ενημερωμένα πρόσθετα"
 
-#: static/js/impala/stats/csv_keys.js:24
+#: static/js/impala/stats/csv_keys.js:24 static/js/zamboni/stats-all.js:15305 static/js/zamboni/stats-min.js:4
 msgid "Reviews Written"
 msgstr "Συνταχθείσες αξιολογήσεις"
 
-#: static/js/impala/stats/csv_keys.js:27
+#: static/js/impala/stats/csv_keys.js:27 static/js/zamboni/stats-all.js:15308 static/js/zamboni/stats-min.js:4
 msgid "User Signups"
 msgstr "Εγγραφές χρήστη"
 
-#: static/js/impala/stats/csv_keys.js:30
+#: static/js/impala/stats/csv_keys.js:30 static/js/zamboni/stats-all.js:15311 static/js/zamboni/stats-min.js:4
 msgid "Subscribers"
 msgstr "Εγγεγραμμένοι"
 
-#: static/js/impala/stats/csv_keys.js:33
+#: static/js/impala/stats/csv_keys.js:33 static/js/zamboni/stats-all.js:15314 static/js/zamboni/stats-min.js:4
 msgid "Ratings"
 msgstr "Αξιολογήσεις"
 
-#: static/js/impala/stats/csv_keys.js:36 static/js/impala/stats/csv_keys.js:114
+#: static/js/impala/stats/csv_keys.js:36 static/js/impala/stats/csv_keys.js:114 static/js/zamboni/stats-all.js:15317 static/js/zamboni/stats-all.js:15395 static/js/zamboni/stats-min.js:4
+#: static/js/zamboni/stats-min.js:5
 msgid "Sales"
 msgstr "Πωλήσεις"
 
-#: static/js/impala/stats/csv_keys.js:39 static/js/impala/stats/csv_keys.js:113
+#: static/js/impala/stats/csv_keys.js:39 static/js/impala/stats/csv_keys.js:113 static/js/zamboni/stats-all.js:15320 static/js/zamboni/stats-all.js:15394 static/js/zamboni/stats-min.js:4
+#: static/js/zamboni/stats-min.js:5
 msgid "Installs"
 msgstr "Εγκαταστάσεις"
 
-#: static/js/impala/stats/csv_keys.js:42
+#: static/js/impala/stats/csv_keys.js:42 static/js/zamboni/stats-all.js:15323 static/js/zamboni/stats-min.js:4
 msgid "Unknown"
 msgstr "Άγνωστο"
 
-#: static/js/impala/stats/csv_keys.js:43
+#: static/js/impala/stats/csv_keys.js:43 static/js/zamboni/stats-all.js:15324 static/js/zamboni/stats-min.js:4
 msgid "Add-ons Manager"
 msgstr "Διαχειριστής προσθέτων"
 
-#: static/js/impala/stats/csv_keys.js:44
+#: static/js/impala/stats/csv_keys.js:44 static/js/zamboni/stats-all.js:15325 static/js/zamboni/stats-min.js:4
 msgid "Add-ons Manager Promo"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:45
+#: static/js/impala/stats/csv_keys.js:45 static/js/zamboni/stats-all.js:15326 static/js/zamboni/stats-min.js:4
 msgid "Add-ons Manager Featured"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:46
+#: static/js/impala/stats/csv_keys.js:46 static/js/zamboni/stats-all.js:15327 static/js/zamboni/stats-min.js:4
 msgid "Add-ons Manager Learn More"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:47
+#: static/js/impala/stats/csv_keys.js:47 static/js/zamboni/stats-all.js:15328 static/js/zamboni/stats-min.js:4
 msgid "Search Suggestions"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:48
+#: static/js/impala/stats/csv_keys.js:48 static/js/zamboni/stats-all.js:15329 static/js/zamboni/stats-min.js:4
 msgid "Search Results"
 msgstr "Αποτελέσματα αναζήτησης"
 
-#: static/js/impala/stats/csv_keys.js:49 static/js/impala/stats/csv_keys.js:50 static/js/impala/stats/csv_keys.js:51
+#: static/js/impala/stats/csv_keys.js:49 static/js/impala/stats/csv_keys.js:50 static/js/impala/stats/csv_keys.js:51 static/js/zamboni/stats-all.js:15330 static/js/zamboni/stats-all.js:15331
+#: static/js/zamboni/stats-all.js:15332 static/js/zamboni/stats-min.js:4
 msgid "Homepage Promo"
 msgstr "Promo Αρχικής Σελίδας"
 
-#: static/js/impala/stats/csv_keys.js:52 static/js/impala/stats/csv_keys.js:53
+#: static/js/impala/stats/csv_keys.js:52 static/js/impala/stats/csv_keys.js:53 static/js/zamboni/stats-all.js:15333 static/js/zamboni/stats-all.js:15334 static/js/zamboni/stats-min.js:4
 msgid "Homepage Featured"
 msgstr "Προβεβλημένη Αρχική Σελίδα"
 
-#: static/js/impala/stats/csv_keys.js:54 static/js/impala/stats/csv_keys.js:55
+#: static/js/impala/stats/csv_keys.js:54 static/js/impala/stats/csv_keys.js:55 static/js/zamboni/stats-all.js:15335 static/js/zamboni/stats-all.js:15336 static/js/zamboni/stats-min.js:4
 msgid "Homepage Up and Coming"
 msgstr "Προσεχής Αρχική Σελίδα"
 
-#: static/js/impala/stats/csv_keys.js:56
+#: static/js/impala/stats/csv_keys.js:56 static/js/zamboni/stats-all.js:15337 static/js/zamboni/stats-min.js:4
 msgid "Homepage Most Popular"
 msgstr "Δημοφιλέστερη Αρχική Σελίδα"
 
-#: static/js/impala/stats/csv_keys.js:57 static/js/impala/stats/csv_keys.js:59
+#: static/js/impala/stats/csv_keys.js:57 static/js/impala/stats/csv_keys.js:59 static/js/zamboni/stats-all.js:15338 static/js/zamboni/stats-all.js:15340 static/js/zamboni/stats-min.js:4
 msgid "Detail Page"
 msgstr "Σελίδα λεπτομερειών"
 
-#: static/js/impala/stats/csv_keys.js:58 static/js/impala/stats/csv_keys.js:60
+#: static/js/impala/stats/csv_keys.js:58 static/js/impala/stats/csv_keys.js:60 static/js/zamboni/stats-all.js:15339 static/js/zamboni/stats-all.js:15341 static/js/zamboni/stats-min.js:4
 msgid "Detail Page (bottom)"
 msgstr "Σελίδα λεπτομερειών (κάτω μέρος)"
 
-#: static/js/impala/stats/csv_keys.js:61
+#: static/js/impala/stats/csv_keys.js:61 static/js/zamboni/stats-all.js:15342 static/js/zamboni/stats-min.js:4
 msgid "Detail Page (Development Channel)"
 msgstr "Σελίδα λεπτομερειών (Κανάλι Ανάπτυξης)"
 
-#: static/js/impala/stats/csv_keys.js:62 static/js/impala/stats/csv_keys.js:63 static/js/impala/stats/csv_keys.js:64
+#: static/js/impala/stats/csv_keys.js:62 static/js/impala/stats/csv_keys.js:63 static/js/impala/stats/csv_keys.js:64 static/js/zamboni/stats-all.js:15343 static/js/zamboni/stats-all.js:15344
+#: static/js/zamboni/stats-all.js:15345 static/js/zamboni/stats-min.js:4
 msgid "Often Used With"
 msgstr "Χρησιμοποιείται συχνά μαζί με"
 
-#: static/js/impala/stats/csv_keys.js:65 static/js/impala/stats/csv_keys.js:66
+#: static/js/impala/stats/csv_keys.js:65 static/js/impala/stats/csv_keys.js:66 static/js/zamboni/stats-all.js:15346 static/js/zamboni/stats-all.js:15347 static/js/zamboni/stats-min.js:4
 msgid "Others By Author"
 msgstr "Άλλα από τον ίδιο"
 
-#: static/js/impala/stats/csv_keys.js:67 static/js/impala/stats/csv_keys.js:68
+#: static/js/impala/stats/csv_keys.js:67 static/js/impala/stats/csv_keys.js:68 static/js/zamboni/stats-all.js:15348 static/js/zamboni/stats-all.js:15349 static/js/zamboni/stats-min.js:4
 msgid "Dependencies"
 msgstr "Εξαρτήσεις"
 
-#: static/js/impala/stats/csv_keys.js:69 static/js/impala/stats/csv_keys.js:70
+#: static/js/impala/stats/csv_keys.js:69 static/js/impala/stats/csv_keys.js:70 static/js/zamboni/stats-all.js:15350 static/js/zamboni/stats-all.js:15351 static/js/zamboni/stats-min.js:4
 msgid "Upsell"
 msgstr "Upsell"
 
-#: static/js/impala/stats/csv_keys.js:71
+#: static/js/impala/stats/csv_keys.js:71 static/js/zamboni/stats-all.js:15352 static/js/zamboni/stats-min.js:4
 msgid "Meet the Developer"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:72
+#: static/js/impala/stats/csv_keys.js:72 static/js/zamboni/stats-all.js:15353 static/js/zamboni/stats-min.js:4
 msgid "User Profile"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:73
+#: static/js/impala/stats/csv_keys.js:73 static/js/zamboni/stats-all.js:15354 static/js/zamboni/stats-min.js:4
 msgid "Version History"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:75
+#: static/js/impala/stats/csv_keys.js:75 static/js/zamboni/stats-all.js:15356 static/js/zamboni/stats-min.js:4
 msgid "Sharing"
 msgstr "Διαμοιρασμός"
 
-#: static/js/impala/stats/csv_keys.js:76
+#: static/js/impala/stats/csv_keys.js:76 static/js/zamboni/stats-all.js:15357 static/js/zamboni/stats-min.js:4
 msgid "Category Pages"
 msgstr "Σελίδες κατηγορίας"
 
-#: static/js/impala/stats/csv_keys.js:77
+#: static/js/impala/stats/csv_keys.js:77 static/js/zamboni/stats-all.js:15358 static/js/zamboni/stats-min.js:4
 msgid "Collections"
 msgstr "Συλλογές"
 
-#: static/js/impala/stats/csv_keys.js:78 static/js/impala/stats/csv_keys.js:79
+#: static/js/impala/stats/csv_keys.js:78 static/js/impala/stats/csv_keys.js:79 static/js/zamboni/stats-all.js:15359 static/js/zamboni/stats-all.js:15360 static/js/zamboni/stats-min.js:4
 msgid "Category Landing Featured Carousel"
 msgstr "Κατηγορία Προβεβλημένο Καρουζέλ"
 
-#: static/js/impala/stats/csv_keys.js:80 static/js/impala/stats/csv_keys.js:81
+#: static/js/impala/stats/csv_keys.js:80 static/js/impala/stats/csv_keys.js:81 static/js/zamboni/stats-all.js:15361 static/js/zamboni/stats-all.js:15362 static/js/zamboni/stats-min.js:4
 msgid "Category Landing Top Rated"
 msgstr "Κατηγορία Υψηλότερη Βαθμολογία"
 
-#: static/js/impala/stats/csv_keys.js:82 static/js/impala/stats/csv_keys.js:83
+#: static/js/impala/stats/csv_keys.js:82 static/js/impala/stats/csv_keys.js:83 static/js/zamboni/stats-all.js:15363 static/js/zamboni/stats-all.js:15364 static/js/zamboni/stats-min.js:5
 msgid "Category Landing Most Popular"
 msgstr "Κατηγορία Δημοφιλέστερα"
 
-#: static/js/impala/stats/csv_keys.js:84 static/js/impala/stats/csv_keys.js:85
+#: static/js/impala/stats/csv_keys.js:84 static/js/impala/stats/csv_keys.js:85 static/js/zamboni/stats-all.js:15365 static/js/zamboni/stats-all.js:15366 static/js/zamboni/stats-min.js:5
 msgid "Category Landing Recently Added"
 msgstr "Κατηγορία Προστέθηκαν πρόσφατα"
 
-#: static/js/impala/stats/csv_keys.js:86 static/js/impala/stats/csv_keys.js:87
+#: static/js/impala/stats/csv_keys.js:86 static/js/impala/stats/csv_keys.js:87 static/js/zamboni/stats-all.js:15367 static/js/zamboni/stats-all.js:15368 static/js/zamboni/stats-min.js:5
 msgid "Browse Listing Featured Sort"
 msgstr "Αναζήτηση Λίστας Προβεβλημένων Ταξινόμηση"
 
-#: static/js/impala/stats/csv_keys.js:88 static/js/impala/stats/csv_keys.js:89
+#: static/js/impala/stats/csv_keys.js:88 static/js/impala/stats/csv_keys.js:89 static/js/zamboni/stats-all.js:15369 static/js/zamboni/stats-all.js:15370 static/js/zamboni/stats-min.js:5
 msgid "Browse Listing Users Sort"
 msgstr "Αναζήτηση Λίστας Χρηστών Ταξινόμηση"
 
-#: static/js/impala/stats/csv_keys.js:90 static/js/impala/stats/csv_keys.js:91
+#: static/js/impala/stats/csv_keys.js:90 static/js/impala/stats/csv_keys.js:91 static/js/zamboni/stats-all.js:15371 static/js/zamboni/stats-all.js:15372 static/js/zamboni/stats-min.js:5
 msgid "Browse Listing Rating Sort"
 msgstr "Αναζήτηση Λίστας Αξιολογήσεων Ταξινόμηση"
 
-#: static/js/impala/stats/csv_keys.js:92 static/js/impala/stats/csv_keys.js:93
+#: static/js/impala/stats/csv_keys.js:92 static/js/impala/stats/csv_keys.js:93 static/js/zamboni/stats-all.js:15373 static/js/zamboni/stats-all.js:15374 static/js/zamboni/stats-min.js:5
 msgid "Browse Listing Created Sort"
 msgstr "Αναζήτηση Λίστας Δημιουργηθέντων Ταξινόμηση"
 
-#: static/js/impala/stats/csv_keys.js:94 static/js/impala/stats/csv_keys.js:95
+#: static/js/impala/stats/csv_keys.js:94 static/js/impala/stats/csv_keys.js:95 static/js/zamboni/stats-all.js:15375 static/js/zamboni/stats-all.js:15376 static/js/zamboni/stats-min.js:5
 msgid "Browse Listing Name Sort"
 msgstr "Αναζήτηση Λίστας Ονομάτων Ταξινόμηση"
 
-#: static/js/impala/stats/csv_keys.js:96 static/js/impala/stats/csv_keys.js:97
+#: static/js/impala/stats/csv_keys.js:96 static/js/impala/stats/csv_keys.js:97 static/js/zamboni/stats-all.js:15377 static/js/zamboni/stats-all.js:15378 static/js/zamboni/stats-min.js:5
 msgid "Browse Listing Popular Sort"
 msgstr "Αναζήτηση Λίστας Δημοφιλών Ταξινόμηση"
 
-#: static/js/impala/stats/csv_keys.js:98 static/js/impala/stats/csv_keys.js:99
+#: static/js/impala/stats/csv_keys.js:98 static/js/impala/stats/csv_keys.js:99 static/js/zamboni/stats-all.js:15379 static/js/zamboni/stats-all.js:15380 static/js/zamboni/stats-min.js:5
 msgid "Browse Listing Updated Sort"
 msgstr "Αναζήτηση Λίστας Ανανεωμένων"
 
-#: static/js/impala/stats/csv_keys.js:100 static/js/impala/stats/csv_keys.js:101
+#: static/js/impala/stats/csv_keys.js:100 static/js/impala/stats/csv_keys.js:101 static/js/zamboni/stats-all.js:15381 static/js/zamboni/stats-all.js:15382 static/js/zamboni/stats-min.js:5
 msgid "Browse Listing Up and Coming Sort"
 msgstr "Αναζήτηση Λίστας Προσεχών"
 
-#: static/js/impala/stats/csv_keys.js:105
+#: static/js/impala/stats/csv_keys.js:105 static/js/zamboni/stats-all.js:15386 static/js/zamboni/stats-min.js:5
 msgid "Total Amount Contributed"
 msgstr "Σύνολο συνεισφορών"
 
-#: static/js/impala/stats/csv_keys.js:106
+#: static/js/impala/stats/csv_keys.js:106 static/js/zamboni/stats-all.js:15387 static/js/zamboni/stats-min.js:5
 msgid "Average Contribution"
 msgstr "Μέσος όρος συνεισφορών"
 
-#: static/js/impala/stats/csv_keys.js:115
+#: static/js/impala/stats/csv_keys.js:115 static/js/zamboni/stats-all.js:15396 static/js/zamboni/stats-min.js:5
 msgid "Usage"
 msgstr "Χρήση"
 
-#: static/js/impala/stats/csv_keys.js:118
+#: static/js/impala/stats/csv_keys.js:118 static/js/zamboni/stats-all.js:15399 static/js/zamboni/stats-min.js:5
 msgid "Firefox"
 msgstr "Firefox"
 
-#: static/js/impala/stats/csv_keys.js:119
+#: static/js/impala/stats/csv_keys.js:119 static/js/zamboni/stats-all.js:15400 static/js/zamboni/stats-min.js:5
 msgid "Mozilla"
 msgstr "Mozilla"
 
-#: static/js/impala/stats/csv_keys.js:120
+#: static/js/impala/stats/csv_keys.js:120 static/js/zamboni/stats-all.js:15401 static/js/zamboni/stats-min.js:5
 msgid "Thunderbird"
 msgstr "Thunderbird"
 
-#: static/js/impala/stats/csv_keys.js:121
+#: static/js/impala/stats/csv_keys.js:121 static/js/zamboni/stats-all.js:15402 static/js/zamboni/stats-min.js:5
 msgid "Sunbird"
 msgstr "Sunbird"
 
-#: static/js/impala/stats/csv_keys.js:122
+#: static/js/impala/stats/csv_keys.js:122 static/js/zamboni/stats-all.js:15403 static/js/zamboni/stats-min.js:5
 msgid "SeaMonkey"
 msgstr "SeaMonkey"
 
-#: static/js/impala/stats/csv_keys.js:123
+#: static/js/impala/stats/csv_keys.js:123 static/js/zamboni/stats-all.js:15404 static/js/zamboni/stats-min.js:5
 msgid "Fennec"
 msgstr "Fennec"
 
-#: static/js/impala/stats/csv_keys.js:124
+#: static/js/impala/stats/csv_keys.js:124 static/js/zamboni/stats-all.js:15405 static/js/zamboni/stats-min.js:5
 msgid "Android"
 msgstr "Android"
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:129
+#: static/js/impala/stats/csv_keys.js:129 static/js/zamboni/stats-all.js:15410 static/js/zamboni/stats-min.js:5
 msgid "Downloads and Daily Users, last {0} days"
 msgstr "Λήψεις και Καθημερινοί Χρήστες, τελευταίες {0} ημέρες"
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:131
+#: static/js/impala/stats/csv_keys.js:131 static/js/zamboni/stats-all.js:15412 static/js/zamboni/stats-min.js:5
 msgid "Downloads and Daily Users from {0} to {1}"
 msgstr "Λήψεις και Καθημερινοί Χρήστες από {0} ως {1}"
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:135
+#: static/js/impala/stats/csv_keys.js:135 static/js/zamboni/stats-all.js:15416 static/js/zamboni/stats-min.js:5
 msgid "Installs and Daily Users, last {0} days"
 msgstr "Λήψεις και Καθημερινοί Χρήστες, τελευταίες {0} ημέρες"
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:137
+#: static/js/impala/stats/csv_keys.js:137 static/js/zamboni/stats-all.js:15418 static/js/zamboni/stats-min.js:5
 msgid "Installs and Daily Users from {0} to {1}"
 msgstr "Εγκαταστάσεις και Καθημερινοί Χρήστες από {0} ως {1}"
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:141
+#: static/js/impala/stats/csv_keys.js:141 static/js/zamboni/stats-all.js:15422 static/js/zamboni/stats-min.js:5
 msgid "Downloads, last {0} days"
 msgstr "Λήψεις, τελευταίες {0} ημέρες"
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:143
+#: static/js/impala/stats/csv_keys.js:143 static/js/zamboni/stats-all.js:15424 static/js/zamboni/stats-min.js:5
 msgid "Downloads from {0} to {1}"
 msgstr "Λήψεις από {0} ως {1}"
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:147
+#: static/js/impala/stats/csv_keys.js:147 static/js/zamboni/stats-all.js:15428 static/js/zamboni/stats-min.js:5
 msgid "Daily Users, last {0} days"
 msgstr "Καθημερινοί Χρήστες, τελευταίες {0} ημέρες"
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:149
+#: static/js/impala/stats/csv_keys.js:149 static/js/zamboni/stats-all.js:15430 static/js/zamboni/stats-min.js:5
 msgid "Daily Users from {0} to {1}"
 msgstr "Καθημερινοί Χρήστες από {0} ως {1}"
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:153
+#: static/js/impala/stats/csv_keys.js:153 static/js/zamboni/stats-all.js:15434 static/js/zamboni/stats-min.js:5
 msgid "Applications, last {0} days"
 msgstr "Εφαρμογές, τελευταίες {0} ημέρες"
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:155
+#: static/js/impala/stats/csv_keys.js:155 static/js/zamboni/stats-all.js:15436 static/js/zamboni/stats-min.js:5
 msgid "Applications from {0} to {1}"
 msgstr "Εφαρμογές από {0} ως {1}"
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:159
+#: static/js/impala/stats/csv_keys.js:159 static/js/zamboni/stats-all.js:15440 static/js/zamboni/stats-min.js:5
 msgid "Platforms, last {0} days"
 msgstr "Πλατφόρμες, τελευταίες {0} ημέρες"
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:161
+#: static/js/impala/stats/csv_keys.js:161 static/js/zamboni/stats-all.js:15442 static/js/zamboni/stats-min.js:5
 msgid "Platforms from {0} to {1}"
 msgstr "Πλατφόρμες από {0} ως {1}"
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:165
+#: static/js/impala/stats/csv_keys.js:165 static/js/zamboni/stats-all.js:15446 static/js/zamboni/stats-min.js:5
 msgid "Languages, last {0} days"
 msgstr "Γλώσσες, τελευταίες {0} ημέρες"
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:167
+#: static/js/impala/stats/csv_keys.js:167 static/js/zamboni/stats-all.js:15448 static/js/zamboni/stats-min.js:5
 msgid "Languages from {0} to {1}"
 msgstr "Γλώσσες από {0} ως {1}"
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:171
+#: static/js/impala/stats/csv_keys.js:171 static/js/zamboni/stats-all.js:15452 static/js/zamboni/stats-min.js:5
 msgid "Add-on Versions, last {0} days"
 msgstr "Εκδόσεις προσθέτου, τελευταίες {0} ημέρες"
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:173
+#: static/js/impala/stats/csv_keys.js:173 static/js/zamboni/stats-all.js:15454 static/js/zamboni/stats-min.js:5
 msgid "Add-on Versions from {0} to {1}"
 msgstr "Εκδόσεις προσθέτου από {0} ως {1}"
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:177
+#: static/js/impala/stats/csv_keys.js:177 static/js/zamboni/stats-all.js:15458 static/js/zamboni/stats-min.js:5
 msgid "Add-on Status, last {0} days"
 msgstr "Κατάσταση προσθέτου, τελευταίες {0} ημέρες"
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:179
+#: static/js/impala/stats/csv_keys.js:179 static/js/zamboni/stats-all.js:15460 static/js/zamboni/stats-min.js:5
 msgid "Add-on Status from {0} to {1}"
 msgstr "Κατάσταση προσθέτου από {0} ως {1}"
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:183
+#: static/js/impala/stats/csv_keys.js:183 static/js/zamboni/stats-all.js:15464 static/js/zamboni/stats-min.js:5
 msgid "Download Sources, last {0} days"
 msgstr "Λήψη κώδικα, τελευταίες {0} ημέρες"
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:185
+#: static/js/impala/stats/csv_keys.js:185 static/js/zamboni/stats-all.js:15466 static/js/zamboni/stats-min.js:5
 msgid "Download Sources from {0} to {1}"
 msgstr "Λήψη κώδικα από {0} ως {1}"
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:189
+#: static/js/impala/stats/csv_keys.js:189 static/js/zamboni/stats-all.js:15470 static/js/zamboni/stats-min.js:5
 msgid "Contributions, last {0} days"
 msgstr "Συνεισφορές, τελευταίες {0} ημέρες"
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:191
+#: static/js/impala/stats/csv_keys.js:191 static/js/zamboni/stats-all.js:15472 static/js/zamboni/stats-min.js:5
 msgid "Contributions from {0} to {1}"
 msgstr "Συνεισφορές από {0} ως {1}"
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:195
+#: static/js/impala/stats/csv_keys.js:195 static/js/zamboni/stats-all.js:15476 static/js/zamboni/stats-min.js:5
 msgid "Site Metrics, last {0} days"
 msgstr "Μετρήσεις ιστοσελίδας, τελευταίες {0} ημέρες"
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:197
+#: static/js/impala/stats/csv_keys.js:197 static/js/zamboni/stats-all.js:15478 static/js/zamboni/stats-min.js:5
 msgid "Site Metrics from {0} to {1}"
 msgstr "Μετρήσεις ιστοσελίδας από {0} ως {1}"
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:201
+#: static/js/impala/stats/csv_keys.js:201 static/js/zamboni/stats-all.js:15482 static/js/zamboni/stats-min.js:5
 msgid "Add-ons in Use, last {0} days"
 msgstr "Πρόσθετα σε χρήση, τελευταίες {0} ημέρες"
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:203
+#: static/js/impala/stats/csv_keys.js:203 static/js/zamboni/stats-all.js:15484 static/js/zamboni/stats-min.js:5
 msgid "Add-ons in Use from {0} to {1}"
 msgstr "Πρόσθετα σε χρήση από {0} ως {1}"
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:207
+#: static/js/impala/stats/csv_keys.js:207 static/js/zamboni/stats-all.js:15488 static/js/zamboni/stats-min.js:5
 msgid "Add-ons Downloaded, last {0} days"
 msgstr "Ληφθέντα πρόσθετα, τελευταίες {0} ημέρες"
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:209
+#: static/js/impala/stats/csv_keys.js:209 static/js/zamboni/stats-all.js:15490 static/js/zamboni/stats-min.js:5
 msgid "Add-ons Downloaded from {0} to {1}"
 msgstr "Ληφθέντα πρόσθετα από {0} ως {1}"
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:213
+#: static/js/impala/stats/csv_keys.js:213 static/js/zamboni/stats-all.js:15494 static/js/zamboni/stats-min.js:5
 msgid "Add-ons Created, last {0} days"
 msgstr "Πρόσθετα που δημιουργήθηκαν, τελευταίες {0} ημέρες"
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:215
+#: static/js/impala/stats/csv_keys.js:215 static/js/zamboni/stats-all.js:15496 static/js/zamboni/stats-min.js:5
 msgid "Add-ons Created from {0} to {1}"
 msgstr "Πρόσθετα που δημιουργήθηκαν από {0} ως {1}"
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:219
+#: static/js/impala/stats/csv_keys.js:219 static/js/zamboni/stats-all.js:15500 static/js/zamboni/stats-min.js:5
 msgid "Add-ons Updated, last {0} days"
 msgstr "Πρόσθετα που ενημερώθηκαν, τελευταίες {0} ημέρες"
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:221
+#: static/js/impala/stats/csv_keys.js:221 static/js/zamboni/stats-all.js:15502 static/js/zamboni/stats-min.js:5
 msgid "Add-ons Updated from {0} to {1}"
 msgstr "Πρόσθετα που ενημερώθηκαν από {0} ως {1}"
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:225
+#: static/js/impala/stats/csv_keys.js:225 static/js/zamboni/stats-all.js:15506 static/js/zamboni/stats-min.js:5
 msgid "Reviews Written, last {0} days"
 msgstr "Συνταχθείσες αξιολογήσεις, τελευταίες {0} ημέρες"
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:227
+#: static/js/impala/stats/csv_keys.js:227 static/js/zamboni/stats-all.js:15508 static/js/zamboni/stats-min.js:5
 msgid "Reviews Written from {0} to {1}"
 msgstr "Συνταχθείσες αξιολογήσεις από {0} ως {1}"
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:231
+#: static/js/impala/stats/csv_keys.js:231 static/js/zamboni/stats-all.js:15512 static/js/zamboni/stats-min.js:5
 msgid "User Signups, last {0} days"
 msgstr "Εγγραφές χρήστη, τελευταίες {0} ημέρες"
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:233
+#: static/js/impala/stats/csv_keys.js:233 static/js/zamboni/stats-all.js:15514 static/js/zamboni/stats-min.js:5
 msgid "User Signups from {0} to {1}"
 msgstr "Εγγραφές χρήστη από {0} ως {1}"
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:237
+#: static/js/impala/stats/csv_keys.js:237 static/js/zamboni/stats-all.js:15518 static/js/zamboni/stats-min.js:5
 msgid "Collections Created, last {0} days"
 msgstr "Συλλογές που δημιουργήθηκαν, τελευταίες {0} ημέρες"
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:239
+#: static/js/impala/stats/csv_keys.js:239 static/js/zamboni/stats-all.js:15520 static/js/zamboni/stats-min.js:5
 msgid "Collections Created from {0} to {1}"
 msgstr "Συλλογές που δημιουργήθηκαν από {0} ως {1}"
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:243
+#: static/js/impala/stats/csv_keys.js:243 static/js/zamboni/stats-all.js:15524 static/js/zamboni/stats-min.js:5
 msgid "Subscribers, last {0} days"
 msgstr "Εγγεγραμμένοι, τελευταίες {0} ημέρες"
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:245
+#: static/js/impala/stats/csv_keys.js:245 static/js/zamboni/stats-all.js:15526 static/js/zamboni/stats-min.js:5
 msgid "Subscribers from {0} to {1}"
 msgstr "Εγγεγραμμένοι από {0} ως {1}"
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:249
+#: static/js/impala/stats/csv_keys.js:249 static/js/zamboni/stats-all.js:15530 static/js/zamboni/stats-min.js:5
 msgid "Ratings, last {0} days"
 msgstr "Αξιολογήσεις, τελευταίες {0} ημέρες"
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:251
+#: static/js/impala/stats/csv_keys.js:251 static/js/zamboni/stats-all.js:15532 static/js/zamboni/stats-min.js:5
 msgid "Ratings from {0} to {1}"
 msgstr "Αξιολογήσεις από {0} ως {1}"
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:255
+#: static/js/impala/stats/csv_keys.js:255 static/js/zamboni/stats-all.js:15536 static/js/zamboni/stats-min.js:5
 msgid "Sales, last {0} days"
 msgstr "Πωλήσεις, τελευταίες {0} ημέρες"
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:257
+#: static/js/impala/stats/csv_keys.js:257 static/js/zamboni/stats-all.js:15538 static/js/zamboni/stats-min.js:5
 msgid "Sales from {0} to {1}"
 msgstr "Πωλήσεις από {0} ως {1}"
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:261
+#: static/js/impala/stats/csv_keys.js:261 static/js/zamboni/stats-all.js:15542 static/js/zamboni/stats-min.js:5
 msgid "Installs, last {0} days"
 msgstr "Εγκαταστάσεις, τελευταίες {0} ημέρες"
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:263
+#: static/js/impala/stats/csv_keys.js:263 static/js/zamboni/stats-all.js:15544 static/js/zamboni/stats-min.js:5
 msgid "Installs from {0} to {1}"
 msgstr "Εγκαταστάσεις από {0} ως {1}"
 
 #. L10n: {0} and {1} are integers.
-#: static/js/impala/stats/csv_keys.js:269
+#: static/js/impala/stats/csv_keys.js:269 static/js/zamboni/stats-all.js:15550 static/js/zamboni/stats-min.js:5
 msgid "<b>{0}</b> in last {1} days"
 msgstr "<b>{0}</b> τις τελευταίες {1} ημέρες"
 
 #. L10n: {0} is an integer and {1} and {2} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:271 static/js/impala/stats/csv_keys.js:277
+#: static/js/impala/stats/csv_keys.js:271 static/js/impala/stats/csv_keys.js:277 static/js/zamboni/stats-all.js:15552 static/js/zamboni/stats-all.js:15558 static/js/zamboni/stats-min.js:5
 msgid "<b>{0}</b> from {1} to {2}"
 msgstr "<b>{0}</b> από {1} ως {2}"
 
 #. L10n: {0} and {1} are integers.
-#: static/js/impala/stats/csv_keys.js:275
+#: static/js/impala/stats/csv_keys.js:275 static/js/zamboni/stats-all.js:15556 static/js/zamboni/stats-min.js:5
 msgid "<b>{0}</b> average in last {1} days"
 msgstr "<b>{0}</b> κατά μέσο όρο τις τελευταίες {1} ημέρες"
 
-#: static/js/impala/stats/overview.js:19
+#: static/js/impala/stats/overview.js:19 static/js/zamboni/stats-all.js:16469 static/js/zamboni/stats-min.js:5
 msgid "No data available."
 msgstr "Δεν υπάρχουν δεδομένα."
 
-#: static/js/impala/stats/table.js:74
+#: static/js/impala/stats/table.js:74 static/js/zamboni/stats-all.js:17209 static/js/zamboni/stats-min.js:5
 msgid "Date"
 msgstr "Ημερομηνία"
 
-#: static/js/impala/stats/topchart.js:96
+#: static/js/impala/stats/topchart.js:96 static/js/zamboni/stats-all.js:16600 static/js/zamboni/stats-min.js:5
 msgid "Other"
 msgstr "Άλλο"
 
-#: static/js/zamboni/admin_validation.js:24 static/js/zamboni/devhub.js:1229 static/js/zamboni/editors.js:295
+#: static/js/zamboni/admin-all.js:180 static/js/zamboni/admin-min.js:1 static/js/zamboni/admin_validation.js:24 static/js/zamboni/devhub-all.js:2408 static/js/zamboni/devhub-min.js:2
+#: static/js/zamboni/devhub.js:1229 static/js/zamboni/editors-all.js:15576 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:295
 msgid "Select an application first"
 msgstr "Επιλέξτε πρώτα εφαρμογή"
 
-#: static/js/zamboni/admin_validation.js:51
+#: static/js/zamboni/admin-all.js:207 static/js/zamboni/admin-min.js:1 static/js/zamboni/admin_validation.js:51
 msgid "Set {0} add-on to a max version of {1} and email the author."
 msgid_plural "Set {0} add-ons to a max version of {1} and email the authors."
 msgstr[0] "Ορισμός του max version για το πρόσθετο {0} σε {1} και αποστολή μηνύματος στον δημιουργό."
 msgstr[1] "Ορισμός του max version για τα πρόσθετα {0} σε {1} και αποστολή μηνύματος στους δημιουργούς."
 
-#: static/js/zamboni/admin_validation.js:54
+#: static/js/zamboni/admin-all.js:210 static/js/zamboni/admin-min.js:1 static/js/zamboni/admin_validation.js:54
 msgid "Email author of {2} add-on which failed validation."
 msgid_plural "Email authors of {2} add-ons which failed validation."
 msgstr[0] "Στείλτε e-mail στον δημιουργό του {2} πρόσθετου το οποίου η επαλήθευση απέτυχε."
 msgstr[1] "Στείλτε e-mail στους δημιουργούς των {2} πρόσθετων των οποίων η επαλήθευση απέτυχε."
 
-#. L10n: {0} is an app name like Firefox.
-#: static/js/zamboni/buttons.js:66
-msgid "Accept and Install"
-msgstr "Αποδοχή και εγκατάσταση"
-
-#: static/js/zamboni/buttons.js:66
-msgid "Add to {0}"
-msgstr "Προσθήκη στον {0}"
-
-#: static/js/zamboni/buttons.js:71
-msgid "Download Now"
-msgstr "Λήψη τώρα"
-
-#: static/js/zamboni/buttons.js:112
-msgid "Add-on has not been updated to support default-to-compatible."
-msgstr "Το πρόσθετο δεν έχει ενημερωθεί ώστε να υποστηρίζει την προεπιλογή σε συμβατό."
-
-#: static/js/zamboni/buttons.js:117
-msgid "You need to be using Firefox 10.0 or higher."
-msgstr "Χρειάζεται να χρησιμοποιείτε την έκδοση 10.0 του Firefox ή υψηλότερη."
-
-#: static/js/zamboni/buttons.js:129
-msgid "Mozilla has marked this version as incompatible with your Firefox version."
-msgstr "Ο Mozilla έχει σημειώσει αυτή την έκδοση ως μη συμβατή με την έκδοση του Firefox που έχετε."
-
-#. L10n: {0} is an platform like Windows or Linux.
-#: static/js/zamboni/buttons.js:210
-msgid "Install for {0} anyway"
-msgstr "Εγκατάσταση σε {0} οπωσδήποτε"
-
-#: static/js/zamboni/buttons.js:210
-msgid "Download for {0} anyway"
-msgstr "Λήψη για {0} οπωσδήποτε"
-
-#: static/js/zamboni/buttons.js:267
-msgid "Not available for your platform"
-msgstr "Δεν διατίθεται για το λειτουργικό σας"
-
-#. L10n: {0} is an app name, {1} is the app version.
-#: static/js/zamboni/buttons.js:278 static/js/zamboni/buttons.js:315
-msgid "Not available for {0} {1}"
-msgstr "Δεν διατίθεται για τον {0} {1}"
-
-#: static/js/zamboni/buttons.js:341
-msgid "Works with {app} {min} - {max}"
-msgstr "Συμβατό με {app} {min} - {max}"
-
-#: static/js/zamboni/buttons.js:343
-msgid "View other versions"
-msgstr "Προβολή άλλων εκδόσεων"
-
-#: static/js/zamboni/buttons.js:391
-msgid "Only with Firefox — Get Firefox Now!"
-msgstr ""
-
-#: static/js/zamboni/buttons.js:507 static/js/zamboni/mobile/buttons.js:43
-msgid "Sorry, you need a Mozilla-based browser (such as Firefox) to install a search plugin."
-msgstr "Λυπούμαστε αλλά απαιτείται περιηγητής της οικογένειας Mozilla (όπως ο Firefox) για να εγκαταστήσετε πρόσθετα αναζήτησης."
-
-#: static/js/zamboni/collections.js:229
-msgid "Adding to Favorites&hellip;"
-msgstr "Γίνεται προσθήκη στις αγαπημένες&hellip;"
-
-#: static/js/zamboni/collections.js:232
-msgid "Removing Favorite&hellip;"
-msgstr "Γίνεται αφαίρεση από τις αγαπημένες&hellip;"
-
-#: static/js/zamboni/collections.js:235
-msgid "Add to Favorites"
-msgstr "Προσθήκη στις αγαπημένες"
-
-#: static/js/zamboni/collections.js:238
-msgid "Remove from Favorites"
-msgstr "Αφαίρεση απ' τις αγαπημένες"
-
-#: static/js/zamboni/collections.js:303
-msgid "Pending"
-msgstr "Σε αναμονή"
-
-#: static/js/zamboni/collections.js:304
-msgid "Add a comment"
-msgstr "Προσθήκη σχολίου"
-
-#: static/js/zamboni/collections.js:304
-msgid "Comment"
-msgstr "Σχόλιο"
-
-#: static/js/zamboni/collections.js:305
-msgid "Remove this add-on from the collection"
-msgstr "Αφαίρεση αυτού του πρόσθετου από τη συλλογή"
-
-#: static/js/zamboni/collections.js:305 static/js/zamboni/collections.js:334
-msgid "Remove"
-msgstr "Αφαίρεση"
-
-#: static/js/zamboni/collections.js:334
-msgid "Remove this user as a contributor"
-msgstr "Αφαίρεση χρήστη από τους συντελεστές"
-
-#: static/js/zamboni/collections.js:346
-msgid "An email address is required."
-msgstr "Απαιτείται διεύθυνση email."
-
-#: static/js/zamboni/collections.js:364
-msgid "You cannot add yourself as a contributor."
-msgstr "Δε μπορείτε να προσθέσετε τον εαυτό σας στους συνεισφέροντες."
-
-#: static/js/zamboni/collections.js:366
-msgid "You have already added that user."
-msgstr "Έχετε ήδη προσθέσει αυτόν τον χρήστη."
-
-#: static/js/zamboni/collections.js:573
-msgid "Add to favorites"
-msgstr "Προσθήκη στα αγαπημένα"
-
-#: static/js/zamboni/collections.js:577
-msgid "Remove from favorites"
-msgstr "Αφαίρεση απ' τα αγαπημένα"
-
-#: static/js/zamboni/collections.js:604
-msgid "Stop following"
-msgstr "Διακοπή παρακολούθησης"
-
-#: static/js/zamboni/devhub.js:110
+#: static/js/zamboni/devhub-all.js:1289 static/js/zamboni/devhub-min.js:1 static/js/zamboni/devhub.js:110
 msgid "Your browser does not support the video tag"
 msgstr "Ο περιηγητής σας δεν υποστηρίζει την οδηγία video."
 
-#: static/js/zamboni/devhub.js:371
+#: static/js/zamboni/devhub-all.js:1550 static/js/zamboni/devhub-min.js:1 static/js/zamboni/devhub.js:371
 msgid "Changes Saved"
 msgstr "Οι αλλαγές αποθηκεύτηκαν"
 
-#: static/js/zamboni/devhub.js:387
+#: static/js/zamboni/devhub-all.js:1566 static/js/zamboni/devhub-min.js:1 static/js/zamboni/devhub.js:387
 msgid "Enter a new author's email address"
 msgstr "Εισάγετε τη διεύθυνση νέου συντάκτη"
 
-#: static/js/zamboni/devhub.js:536
+#: static/js/zamboni/devhub-all.js:1715 static/js/zamboni/devhub-min.js:1 static/js/zamboni/devhub.js:536
 msgid "There was an error uploading your file."
 msgstr "Παρουσιάστηκε σφάλμα κατά τη μεταφόρτωση του αρχείου σας."
 
-#: static/js/zamboni/devhub.js:681
+#: static/js/zamboni/devhub-all.js:1860 static/js/zamboni/devhub-min.js:1 static/js/zamboni/devhub.js:681
 msgid "{files} file"
 msgid_plural "{files} files"
 msgstr[0] "{files} αρχείο"
 msgstr[1] "{files} αρχεία"
 
-#: static/js/zamboni/devhub.js:684
+#: static/js/zamboni/devhub-all.js:1863 static/js/zamboni/devhub-min.js:1 static/js/zamboni/devhub.js:684
 msgid "{reviews} user review"
 msgid_plural "{reviews} user reviews"
 msgstr[0] "{reviews} αξιολόγηση χρήστη"
 msgstr[1] "{reviews} αξιολογήσεις χρήστη"
 
-#: static/js/zamboni/devhub.js:796
+#: static/js/zamboni/devhub-all.js:1975 static/js/zamboni/devhub-min.js:2 static/js/zamboni/devhub.js:796
 msgid "Learn more"
 msgstr "Μάθετε περισσότερα"
 
-#: static/js/zamboni/devhub.js:800
+#: static/js/zamboni/devhub-all.js:1979 static/js/zamboni/devhub-min.js:2 static/js/zamboni/devhub.js:800
 msgid "Example"
 msgstr "Παράδειγμα"
 
-#: static/js/zamboni/devhub.js:1130
+#: static/js/zamboni/devhub-all.js:2309 static/js/zamboni/devhub-min.js:2 static/js/zamboni/devhub.js:1130
 msgid "Image changes being processed"
 msgstr "Επεξεργάζονται οι αλλαγές εικόνων"
 
-#: static/js/zamboni/devhub.js:1280
+#: static/js/zamboni/devhub-all.js:2459 static/js/zamboni/devhub-min.js:2 static/js/zamboni/devhub.js:1280
 msgid "Must be a valid e-mail address."
 msgstr "Η διεύθυνση email πρέπει να είναι έγκυρη."
 
-#: static/js/zamboni/devhub_search.js:8
-msgid "No results found."
-msgstr "Δεν βρέθηκαν αποτελέσματα."
-
-#: static/js/zamboni/editors.js:121
-msgid "{name} was viewing this page first."
-msgstr "Ο/Η {name} είχε φορτώσει τη σελίδα πριν από εσάς."
-
-#: static/js/zamboni/editors.js:171
-msgid "Receipt checked by app."
-msgstr "Η απόδειξη ελέγχθηκε από την εφαρμογή."
-
-#: static/js/zamboni/editors.js:173
-msgid "Receipt was not checked by app."
-msgstr "Η απόδειξη δεν ελέγχθηκε από την εφαρμογή."
-
-#: static/js/zamboni/editors.js:244
-msgid "{name} was viewing this add-on first."
-msgstr "Ο χρήστης {name} είδε αυτό το πρόσθετο πρώτος."
-
-#: static/js/zamboni/editors.js:255
-msgid "Loading&hellip;"
-msgstr "Γίνεται φόρτωση&hellip;"
-
-#: static/js/zamboni/editors.js:260
-msgid "Version Notes"
-msgstr "Σημειώσεις έκδοσης"
-
-#: static/js/zamboni/editors.js:265
-msgid "Notes for Reviewers"
-msgstr "Σημειώσεις για αξιολογητές"
-
-#: static/js/zamboni/editors.js:270
-msgid "No version notes found"
-msgstr "Δεν βρέθηκαν σημειώσεις έκδοσης"
-
-#: static/js/zamboni/editors.js:330
-msgid "Average Reviews"
-msgstr ""
-
-#: static/js/zamboni/editors.js:386
-msgid "Number of Reviews"
-msgstr ""
-
-#: static/js/zamboni/editors.js:445
-msgid "Error loading translation"
-msgstr "Σφάλμα στο φόρτωμα της μετάφρασης"
-
-#: static/js/zamboni/files.js:411 static/js/zamboni/validator.js:261
-msgid "Ignore this message in future updates"
-msgstr ""
-
-#: static/js/zamboni/files.js:417 static/js/zamboni/validator.js:284
-msgid "Severity for automated signing:"
-msgstr ""
-
-#: static/js/zamboni/global.js:410
-msgid "Loading..."
-msgstr "Γίνεται φόρτωση..."
-
-#. L10n: {0} is the number of characters left.
-#: static/js/zamboni/global.js:474
-msgid "<b>{0}</b> character left."
-msgid_plural "<b>{0}</b> characters left."
-msgstr[0] "<b>{0}</b> χαρακτήρας διαθέσιμος."
-msgstr[1] "<b>{0}</b> χαρακτήρες διαθέσιμοι."
-
-#: static/js/zamboni/init.js:28
-msgid "This feature is temporarily disabled while we perform website maintenance. Please check back a little later."
-msgstr "Αυτό το χαρακτηριστικό έχει απενεργοποιηθεί προς το παρόν λόγω εκτέλεσης εργασιών συντήρησης. Παρακαλούμε προσπαθήστε ξανά αργότερα."
-
-#: static/js/zamboni/l10n.js:45
-msgid "Remove this localization"
-msgstr "Αφαίρεση αυτής της μετάφρασης"
-
-#: static/js/zamboni/password-strength.js:20
-msgid "Password strength:"
-msgstr "Ισχύς κωδικού:"
-
-#: static/js/zamboni/password-strength.js:26
-msgid "At least {0} character left."
-msgid_plural "At least {0} characters left."
-msgstr[0] "Τουλάχιστον {0} χαρακτήρας διαθέσιμος"
-msgstr[1] "Τουλάχιστον {0} χαρακτήρες διαθέσιμοι"
-
-#: static/js/zamboni/themes_review.js:176
-msgid "Requested Info"
-msgstr "Ζητούμενες πληροφορίες"
-
-#: static/js/zamboni/themes_review.js:177
-msgid "Flagged"
-msgstr "Σημειωμένο"
-
-#: static/js/zamboni/themes_review.js:178
-msgid "Duplicate"
-msgstr "Αντίγραφο"
-
-#: static/js/zamboni/themes_review.js:179
-msgid "Rejected"
-msgstr "Απορριφθέν"
-
-#: static/js/zamboni/themes_review.js:180
-msgid "Approved"
-msgstr "Εγκεκριμένο"
-
-#: static/js/zamboni/themes_review.js:424
-msgid "No results found"
-msgstr ""
-
-#: static/js/zamboni/themes_review_templates.js:31
-msgid "Theme"
-msgstr ""
-
-#: static/js/zamboni/themes_review_templates.js:33
-msgid "Reviewer"
-msgstr ""
-
-#: static/js/zamboni/themes_review_templates.js:35
-msgid "Status"
-msgstr ""
-
-#: static/js/zamboni/validator.js:80
+#: static/js/zamboni/devhub-all.js:2613 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:80
 msgid "All tests passed successfully."
 msgstr "Όλοι οι έλεγχοι ολοκληρώθηκαν επιτυχώς."
 
-#: static/js/zamboni/validator.js:83 static/js/zamboni/validator.js:478
+#: static/js/zamboni/devhub-all.js:2616 static/js/zamboni/devhub-all.js:3011 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:83 static/js/zamboni/validator.js:478
 msgid "These tests were not run."
 msgstr "Δεν εκτελέστηκαν αυτοί οι έλεγχοι."
 
-#: static/js/zamboni/validator.js:131 static/js/zamboni/validator.js:144
+#: static/js/zamboni/devhub-all.js:2664 static/js/zamboni/devhub-all.js:2677 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:131 static/js/zamboni/validator.js:144
 msgid "Tests"
 msgstr "Έλεγχοι"
 
-#: static/js/zamboni/validator.js:246 static/js/zamboni/validator.js:575 static/js/zamboni/validator.js:594
+#: static/js/zamboni/devhub-all.js:2779 static/js/zamboni/devhub-all.js:3108 static/js/zamboni/devhub-all.js:3127 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:246
+#: static/js/zamboni/validator.js:575 static/js/zamboni/validator.js:594
 msgid "Error"
 msgstr "Σφάλμα"
 
-#: static/js/zamboni/validator.js:247
+#: static/js/zamboni/devhub-all.js:2780 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:247
 msgid "Warning"
 msgstr "Προειδοποίηση"
 
-#: static/js/zamboni/validator.js:299
+#: static/js/zamboni/devhub-all.js:2794 static/js/zamboni/devhub-min.js:2 static/js/zamboni/files-all.js:5657 static/js/zamboni/files-min.js:3 static/js/zamboni/files.js:411
+#: static/js/zamboni/validator.js:261
+msgid "Ignore this message in future updates"
+msgstr ""
+
+#: static/js/zamboni/devhub-all.js:2817 static/js/zamboni/devhub-min.js:2 static/js/zamboni/files-all.js:5663 static/js/zamboni/files-min.js:3 static/js/zamboni/files.js:417
+#: static/js/zamboni/validator.js:284
+msgid "Severity for automated signing:"
+msgstr ""
+
+#: static/js/zamboni/devhub-all.js:2832 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:299
 msgid "Suggestions for passing automated signing:"
 msgstr ""
 
-#: static/js/zamboni/validator.js:387
+#: static/js/zamboni/devhub-all.js:2920 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:387
 msgid "Compatibility Tests"
 msgstr "Τεστ συμβατότητας"
 
-#: static/js/zamboni/validator.js:466
+#: static/js/zamboni/devhub-all.js:2999 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:466
 msgid "Add-on failed validation."
 msgstr "Το πρόσθετο απέτυχε να επικυρωθεί."
 
-#: static/js/zamboni/validator.js:468
+#: static/js/zamboni/devhub-all.js:3001 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:468
 msgid "Add-on passed validation."
 msgstr "Το πρόσθετο επικυρώθηκε."
 
-#: static/js/zamboni/validator.js:481
+#: static/js/zamboni/devhub-all.js:3014 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:481
 msgid "{0} error"
 msgid_plural "{0} errors"
 msgstr[0] "{0} σφάλμα"
 msgstr[1] "{0} σφάλματα"
 
-#: static/js/zamboni/validator.js:483
+#: static/js/zamboni/devhub-all.js:3016 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:483
 msgid "{0} warning"
 msgid_plural "{0} warnings"
 msgstr[0] "{0} προειδοποίηση"
 msgstr[1] "{0} προειδοποιήσεις"
 
-#: static/js/zamboni/validator.js:485
+#: static/js/zamboni/devhub-all.js:3018 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:485
 msgid "{0} notice"
 msgid_plural "{0} notices"
 msgstr[0] "{0} σημείωμα"
 msgstr[1] "{0} σημειώματα"
 
-#: static/js/zamboni/validator.js:577
+#: static/js/zamboni/devhub-all.js:3110 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:577
 msgid "Validation task could not complete or completed with errors"
 msgstr "Δεν ολοκληρώθηκε η επικύρωση ή ολοκληρώθηκε με σφάλματα"
 
-#: static/js/zamboni/validator.js:595
+#: static/js/zamboni/devhub-all.js:3128 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:595
 msgid "Internal server error"
 msgstr "Εσωτερικό σφάλμα διακομιστή"
 
-#: static/js/zamboni/mobile/buttons.js:52
+#: static/js/zamboni/devhub_search.js:8
+msgid "No results found."
+msgstr "Δεν βρέθηκαν αποτελέσματα."
+
+#: static/js/zamboni/editors-all.js:15402 static/js/zamboni/editors-min.js:4 static/js/zamboni/editors.js:121
+msgid "{name} was viewing this page first."
+msgstr "Ο/Η {name} είχε φορτώσει τη σελίδα πριν από εσάς."
+
+#: static/js/zamboni/editors-all.js:15452 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:171
+msgid "Receipt checked by app."
+msgstr "Η απόδειξη ελέγχθηκε από την εφαρμογή."
+
+#: static/js/zamboni/editors-all.js:15454 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:173
+msgid "Receipt was not checked by app."
+msgstr "Η απόδειξη δεν ελέγχθηκε από την εφαρμογή."
+
+#: static/js/zamboni/editors-all.js:15525 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:244
+msgid "{name} was viewing this add-on first."
+msgstr "Ο χρήστης {name} είδε αυτό το πρόσθετο πρώτος."
+
+#: static/js/zamboni/editors-all.js:15536 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:255
+msgid "Loading&hellip;"
+msgstr "Γίνεται φόρτωση&hellip;"
+
+#: static/js/zamboni/editors-all.js:15541 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:260
+msgid "Version Notes"
+msgstr "Σημειώσεις έκδοσης"
+
+#: static/js/zamboni/editors-all.js:15546 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:265
+msgid "Notes for Reviewers"
+msgstr "Σημειώσεις για αξιολογητές"
+
+#: static/js/zamboni/editors-all.js:15551 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:270
+msgid "No version notes found"
+msgstr "Δεν βρέθηκαν σημειώσεις έκδοσης"
+
+#: static/js/zamboni/editors-all.js:15611 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:330
+msgid "Average Reviews"
+msgstr ""
+
+#: static/js/zamboni/editors-all.js:15667 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:386
+msgid "Number of Reviews"
+msgstr ""
+
+#: static/js/zamboni/editors-all.js:15726 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:445
+msgid "Error loading translation"
+msgstr "Σφάλμα στο φόρτωμα της μετάφρασης"
+
+#: static/js/zamboni/editors-all.js:15975 static/js/zamboni/editors-min.js:5 static/js/zamboni/themes_review_templates.js:31
+msgid "Theme"
+msgstr ""
+
+#: static/js/zamboni/editors-all.js:15977 static/js/zamboni/editors-min.js:5 static/js/zamboni/themes_review_templates.js:33
+msgid "Reviewer"
+msgstr ""
+
+#: static/js/zamboni/editors-all.js:15979 static/js/zamboni/editors-min.js:5 static/js/zamboni/themes_review_templates.js:35
+msgid "Status"
+msgstr ""
+
+#: static/js/zamboni/editors-all.js:16196 static/js/zamboni/editors-min.js:5 static/js/zamboni/themes_review.js:176
+msgid "Requested Info"
+msgstr "Ζητούμενες πληροφορίες"
+
+#: static/js/zamboni/editors-all.js:16197 static/js/zamboni/editors-min.js:5 static/js/zamboni/themes_review.js:177
+msgid "Flagged"
+msgstr "Σημειωμένο"
+
+#: static/js/zamboni/editors-all.js:16198 static/js/zamboni/editors-min.js:5 static/js/zamboni/themes_review.js:178
+msgid "Duplicate"
+msgstr "Αντίγραφο"
+
+#: static/js/zamboni/editors-all.js:16199 static/js/zamboni/editors-min.js:5 static/js/zamboni/themes_review.js:179
+msgid "Rejected"
+msgstr "Απορριφθέν"
+
+#: static/js/zamboni/editors-all.js:16200 static/js/zamboni/editors-min.js:5 static/js/zamboni/themes_review.js:180
+msgid "Approved"
+msgstr "Εγκεκριμένο"
+
+#: static/js/zamboni/editors-all.js:16444 static/js/zamboni/editors-min.js:5 static/js/zamboni/themes_review.js:424
+msgid "No results found"
+msgstr ""
+
+#: static/js/zamboni/mobile-all.js:15186 static/js/zamboni/mobile/buttons.js:52
 msgid "Not Updated for {0} {1}"
 msgstr "Δεν έχει ενημερωθεί για τον {0} {1}"
 
-#: static/js/zamboni/mobile/buttons.js:53
+#: static/js/zamboni/mobile-all.js:15187 static/js/zamboni/mobile/buttons.js:53
 msgid "Requires Newer Version of {0}"
 msgstr "Απαιτεί νεότερη έκδοση του {0}"
 
-#: static/js/zamboni/mobile/buttons.js:54
+#: static/js/zamboni/mobile-all.js:15188 static/js/zamboni/mobile/buttons.js:54
 msgid "Unreviewed"
 msgstr "Δεν έχει αξιολογηθεί"
 
-#: static/js/zamboni/mobile/buttons.js:55
+#: static/js/zamboni/mobile-all.js:15189 static/js/zamboni/mobile/buttons.js:55
 msgid "Experimental <span>(Learn More)</span>"
 msgstr "Πειραματικό <span>(Μάθετε περισσότερα)</span>"
 
-#: static/js/zamboni/mobile/buttons.js:56 static/js/zamboni/mobile/buttons.js:57
+#: static/js/zamboni/mobile-all.js:15190 static/js/zamboni/mobile-all.js:15191 static/js/zamboni/mobile/buttons.js:56 static/js/zamboni/mobile/buttons.js:57
 msgid "Not Available for {0}"
 msgstr "Δεν διατίθεται για τον {0}"
 
-#: static/js/zamboni/mobile/buttons.js:58
+#: static/js/zamboni/mobile-all.js:15192 static/js/zamboni/mobile/buttons.js:58
 msgid "Experimental"
 msgstr "Πειραματικό"
 
-#: static/js/zamboni/mobile/buttons.js:59
+#: static/js/zamboni/mobile-all.js:15193 static/js/zamboni/mobile/buttons.js:59
 msgid "Themes Require Newer Version of {0}"
 msgstr "Τα θέματα απαιτούν νεότερη έκδοση του {0}"
 
-#: static/js/zamboni/mobile/buttons.js:60
+#: static/js/zamboni/mobile-all.js:15194 static/js/zamboni/mobile/buttons.js:60
 msgid "Themes Require {0}"
 msgstr "Τα θέματα απαιτούν το {0}"
 
-#: static/js/zamboni/mobile/buttons.js:105
+#: static/js/zamboni/mobile-all.js:15239 static/js/zamboni/mobile/buttons.js:105
 msgid "Installing..."
 msgstr "Γίνεται εγκατάσταση..."
 
-#: static/js/zamboni/mobile/buttons.js:125
+#: static/js/zamboni/mobile-all.js:15259 static/js/zamboni/mobile/buttons.js:125
 msgid "This add-on has been preliminarily reviewed by Mozilla."
 msgstr "Αυτό το πρόσθετο έχει αξιολογηθεί μερικώς από την κοινότητα Mozilla"
 
-#: static/js/zamboni/mobile/buttons.js:250
+#: static/js/zamboni/mobile-all.js:15384 static/js/zamboni/mobile/buttons.js:250
 msgid "Keep it"
 msgstr "Διατήρηση"
 
-#: static/js/zamboni/mobile/general.js:344
+#: static/js/zamboni/mobile-all.js:16049 static/js/zamboni/mobile-min.js:6 static/js/zamboni/mobile/general.js:344
 msgid "You're trying it on!"
 msgstr "Το δοκιμάζετε!"
 
-#: static/js/zamboni/mobile/general.js:356
+#: static/js/zamboni/mobile-all.js:16061 static/js/zamboni/mobile-min.js:6 static/js/zamboni/mobile/general.js:356
 msgid "Added to Firefox"
 msgstr "Προστέθηκε στον Firefox"
-

--- a/locale/en_GB/LC_MESSAGES/django.po
+++ b/locale/en_GB/LC_MESSAGES/django.po
@@ -3,69 +3,70 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2016-02-24 21:23+0000\n"
+"POT-Creation-Date: 2016-04-18 15:47+0000\n"
 "PO-Revision-Date: 2016-03-05 03:07+0000\n"
 "Last-Translator: Ian Neal <iann_bugzilla@blueyonder.co.uk>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
+"Language: \n"
 "MIME-Version: 1.0\n"
-"Content-Type: text/plain; charset=utf-8\n"
+"Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Generated-By: Babel 2.2.0\n"
 
-#: src/olympia/accounts/views.py:52
+#: src/olympia/accounts/views.py:54
 msgid "Your log in attempt could not be parsed. Please try again."
 msgstr "Your log in attempt could not be parsed. Please try again."
 
-#: src/olympia/accounts/views.py:54
+#: src/olympia/accounts/views.py:56
 msgid "Your Firefox Account could not be found. Please try again."
 msgstr "Your Firefox Account could not be found. Please try again."
 
-#: src/olympia/accounts/views.py:55
+#: src/olympia/accounts/views.py:57
 msgid "You could not be logged in. Please try again."
 msgstr "You could not be logged in. Please try again."
 
-#: src/olympia/accounts/views.py:57
+#: src/olympia/accounts/views.py:59
 msgid "Your account has already been migrated to Firefox Accounts."
 msgstr "Your account has already been migrated to Firefox Accounts."
 
-#: src/olympia/accounts/views.py:59
+#: src/olympia/accounts/views.py:61
 msgid "Your Firefox Account already exists on this site."
 msgstr "Your Firefox Account already exists on this site."
 
-#: src/olympia/accounts/views.py:108
+#: src/olympia/accounts/views.py:110
 msgid "Great job!"
 msgstr "Great job!"
 
-#: src/olympia/accounts/views.py:109
+#: src/olympia/accounts/views.py:111
 msgid "You can now log in to Add-ons with your Firefox Account."
 msgstr "You can now log in to Add-ons with your Firefox Account."
 
-#: src/olympia/accounts/views.py:121
+#: src/olympia/accounts/views.py:123
 msgid "Need help?"
 msgstr "Need help?"
 
-#: src/olympia/addons/buttons.py:180
+#: src/olympia/addons/buttons.py:177
 msgid "Download Now"
 msgstr "Download Now"
 
-#: src/olympia/addons/buttons.py:182
+#: src/olympia/addons/buttons.py:179
 msgid "Download"
 msgstr "Download"
 
 #. L10n: please keep &nbsp; in the string so &rarr; does not wrap.
-#: src/olympia/addons/buttons.py:186
+#: src/olympia/addons/buttons.py:183
 msgid "Continue to Download&nbsp;&rarr;"
 msgstr "Continue to Download&nbsp;&rarr;"
 
-#: src/olympia/addons/buttons.py:202 src/olympia/addons/helpers.py:35 src/olympia/addons/views.py:319 src/olympia/addons/templates/addons/impala/details.html:114
+#: src/olympia/addons/buttons.py:199 src/olympia/addons/helpers.py:35 src/olympia/addons/views.py:333 src/olympia/addons/templates/addons/impala/details.html:111
 #: src/olympia/addons/templates/addons/impala/listing/items.html:17 src/olympia/addons/templates/addons/mobile/home.html:40 src/olympia/amo/templates/amo/side_nav.html:6
-#: src/olympia/amo/templates/amo/side_nav.html:10 src/olympia/amo/templates/amo/site_nav.html:2 src/olympia/amo/templates/amo/site_nav.html:55 src/olympia/bandwagon/views.py:95
-#: src/olympia/browse/views.py:54 src/olympia/browse/views.py:68 src/olympia/browse/views.py:235 src/olympia/browse/templates/browse/impala/category_landing.html:22
+#: src/olympia/amo/templates/amo/side_nav.html:10 src/olympia/amo/templates/amo/site_nav.html:2 src/olympia/amo/templates/amo/site_nav.html:53 src/olympia/bandwagon/views.py:95
+#: src/olympia/browse/views.py:54 src/olympia/browse/views.py:68 src/olympia/browse/views.py:202 src/olympia/browse/templates/browse/impala/category_landing.html:22
 #: src/olympia/browse/templates/browse/personas/mobile/category_landing.html:26
 msgid "Featured"
 msgstr "Featured"
 
-#: src/olympia/addons/buttons.py:221
+#: src/olympia/addons/buttons.py:218
 msgid "Add to {0}"
 msgstr "Add to {0}"
 
@@ -113,39 +114,39 @@ msgid_plural "All tags must be at least {0} characters."
 msgstr[0] "All tags must be at least {0} character."
 msgstr[1] "All tags must be at least {0} characters."
 
-#: src/olympia/addons/forms.py:234
+#: src/olympia/addons/forms.py:238
 msgid "Categories cannot be changed while your add-on is featured for this application."
 msgstr "Categories cannot be changed while your add-on is featured for this application."
 
 #. L10n: {0} is the number of categories.
-#: src/olympia/addons/forms.py:238
+#: src/olympia/addons/forms.py:242
 msgid "You can have only {0} category."
 msgid_plural "You can have only {0} categories."
 msgstr[0] "You can have only {0} category."
 msgstr[1] "You can have only {0} categories."
 
-#: src/olympia/addons/forms.py:246
+#: src/olympia/addons/forms.py:250
 msgid "The miscellaneous category cannot be combined with additional categories."
 msgstr "The miscellaneous category cannot be combined with additional categories."
 
-#: src/olympia/addons/forms.py:369
+#: src/olympia/addons/forms.py:374
 #, python-format
 msgid "Before changing your default locale you must have a name, summary, and description in that locale. You are missing %s."
 msgstr "Before changing your default locale you must have a name, summary, and description in that locale. You are missing %s."
 
-#: src/olympia/addons/forms.py:484 src/olympia/addons/forms.py:575
+#: src/olympia/addons/forms.py:455 src/olympia/addons/forms.py:546
 msgid "A license must be selected."
 msgstr "A licence must be selected."
 
-#: src/olympia/addons/forms.py:556
+#: src/olympia/addons/forms.py:527
 msgid "Give Your Theme a Name."
 msgstr "Give Your Theme a Name."
 
-#: src/olympia/addons/forms.py:562 src/olympia/devhub/templates/devhub/personas/submit.html:53
+#: src/olympia/addons/forms.py:533 src/olympia/devhub/templates/devhub/personas/submit.html:53
 msgid "Describe your Theme."
 msgstr "Describe your Theme."
 
-#: src/olympia/addons/forms.py:704
+#: src/olympia/addons/forms.py:675
 msgid "Enter a new author's email address"
 msgstr "Enter a new author's email address"
 
@@ -153,37 +154,37 @@ msgstr "Enter a new author's email address"
 msgid "Not Reviewed"
 msgstr "Not Reviewed"
 
-#: src/olympia/addons/models.py:301
+#: src/olympia/addons/models.py:298
 msgid "Users have the option of contributing more or less than this amount."
 msgstr "Users have the option of contributing more or less than this amount."
 
-#: src/olympia/addons/models.py:309
-msgid "Users will always be asked in the Add-ons Manager (Firefox 4 and above)"
-msgstr "Users will always be asked in the Add-ons Manager (Firefox 4 and above)"
+#: src/olympia/addons/models.py:306
+msgid "Users will always be asked in the Add-ons Manager (Firefox 4 and above). Only applies to desktop."
+msgstr ""
 
-#: src/olympia/addons/models.py:1804 src/olympia/addons/templates/addons/details_box.html:55 src/olympia/devhub/templates/devhub/index.html:92
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:102
+#: src/olympia/addons/models.py:1802 src/olympia/addons/templates/addons/details_box.html:55 src/olympia/devhub/templates/devhub/index.html:92
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:89
 msgid "Listed"
 msgstr "Listed"
 
-#: src/olympia/addons/views.py:320 src/olympia/browse/templates/browse/personas/mobile/category_landing.html:27
+#: src/olympia/addons/views.py:334 src/olympia/browse/templates/browse/personas/mobile/category_landing.html:27
 msgid "Popular"
 msgstr "Popular"
 
-#: src/olympia/addons/views.py:321 src/olympia/browse/views.py:238 src/olympia/browse/views.py:280 src/olympia/browse/views.py:482
+#: src/olympia/addons/views.py:335 src/olympia/browse/views.py:205 src/olympia/browse/views.py:247 src/olympia/browse/views.py:449
 msgid "Recently Added"
 msgstr "Recently Added"
 
-#: src/olympia/addons/views.py:322 src/olympia/bandwagon/views.py:99 src/olympia/browse/views.py:60 src/olympia/browse/views.py:71 src/olympia/search/forms.py:16 src/olympia/search/forms.py:91
+#: src/olympia/addons/views.py:336 src/olympia/bandwagon/views.py:99 src/olympia/browse/views.py:60 src/olympia/browse/views.py:71 src/olympia/search/forms.py:16 src/olympia/search/forms.py:91
 msgid "Recently Updated"
 msgstr "Recently Updated"
 
 #. l10n: {0} is the addon name
-#: src/olympia/addons/views.py:520
+#: src/olympia/addons/views.py:534
 msgid "Contribution for {0}"
 msgstr "Contribution for {0}"
 
-#: src/olympia/addons/views.py:613
+#: src/olympia/addons/views.py:627
 msgid "Abuse reported."
 msgstr "Abuse reported."
 
@@ -250,9 +251,9 @@ msgstr "Contribute"
 #: src/olympia/devhub/templates/devhub/addons/ajax_compat_update.html:36 src/olympia/devhub/templates/devhub/addons/profile.html:44 src/olympia/devhub/templates/devhub/addons/edit/admin.html:101
 #: src/olympia/devhub/templates/devhub/addons/edit/basic.html:152 src/olympia/devhub/templates/devhub/addons/edit/details.html:85 src/olympia/devhub/templates/devhub/addons/edit/support.html:67
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:166 src/olympia/devhub/templates/devhub/addons/forms_shared/media.html:149
-#: src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:44 src/olympia/devhub/templates/devhub/versions/add_file_modal.html:78 src/olympia/devhub/templates/devhub/versions/edit.html:139
-#: src/olympia/devhub/templates/devhub/versions/list.html:242 src/olympia/devhub/templates/devhub/versions/list.html:276 src/olympia/devhub/templates/devhub/versions/list.html:317
-#: src/olympia/devhub/templates/devhub/versions/list.html:351 src/olympia/reviews/templates/reviews/edit_review.html:16 src/olympia/translations/templates/translations/trans-menu.html:50
+#: src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:43 src/olympia/devhub/templates/devhub/versions/add_file_modal.html:58 src/olympia/devhub/templates/devhub/versions/edit.html:139
+#: src/olympia/devhub/templates/devhub/versions/list.html:239 src/olympia/devhub/templates/devhub/versions/list.html:281 src/olympia/devhub/templates/devhub/versions/list.html:315
+#: src/olympia/devhub/templates/devhub/versions/list.html:349 src/olympia/reviews/templates/reviews/edit_review.html:16 src/olympia/translations/templates/translations/trans-menu.html:50
 #: src/olympia/translations/templates/translations/trans-menu.html:62
 msgid "or"
 msgstr "or"
@@ -324,8 +325,7 @@ msgstr "Donation amount must be a number."
 msgid "A one-time suggested contribution of {0}"
 msgstr "A one-time suggested donation of {0}"
 
-#. {0} is a currency symbol (e.g., $),                    {1} is an amount
-#. input
+#. {0} is a currency symbol (e.g., $),                    {1} is an amount input
 #. field
 #: src/olympia/addons/templates/addons/contributions_lightbox.html:64
 msgid "A one-time contribution of {0} {1}"
@@ -366,7 +366,7 @@ msgid "Add-on Information for {0}"
 msgstr "Add-on Information for {0}"
 
 #: src/olympia/addons/templates/addons/details_box.html:30 src/olympia/addons/templates/addons/persona_detail_table.html:3 src/olympia/addons/templates/addons/mobile/details.html:63
-#: src/olympia/addons/templates/addons/mobile/persona_detail_table.html:7 src/olympia/browse/views.py:459 src/olympia/devhub/views.py:75
+#: src/olympia/addons/templates/addons/mobile/persona_detail_table.html:7 src/olympia/browse/views.py:426 src/olympia/devhub/views.py:73
 msgid "Updated"
 msgstr "Updated"
 
@@ -385,11 +385,11 @@ msgstr "Works with"
 msgid "Visibility"
 msgstr "Visibility"
 
-#: src/olympia/addons/templates/addons/details_box.html:57 src/olympia/devhub/templates/devhub/index.html:94 src/olympia/devhub/templates/devhub/includes/addon_details.html:104
+#: src/olympia/addons/templates/addons/details_box.html:57 src/olympia/devhub/templates/devhub/index.html:94 src/olympia/devhub/templates/devhub/includes/addon_details.html:91
 msgid "Hidden"
 msgstr "Hidden"
 
-#: src/olympia/addons/templates/addons/details_box.html:59 src/olympia/devhub/templates/devhub/index.html:96 src/olympia/devhub/templates/devhub/includes/addon_details.html:106
+#: src/olympia/addons/templates/addons/details_box.html:59 src/olympia/devhub/templates/devhub/index.html:96 src/olympia/devhub/templates/devhub/includes/addon_details.html:93
 msgid "Unlisted"
 msgstr "Unlisted"
 
@@ -397,13 +397,13 @@ msgstr "Unlisted"
 msgid "Required Add-ons"
 msgstr "Required Add-ons"
 
-#: src/olympia/addons/templates/addons/details_box.html:81 src/olympia/addons/templates/addons/persona_detail_table.html:15 src/olympia/browse/views.py:462 src/olympia/devhub/views.py:78
-#: src/olympia/devhub/views.py:85 src/olympia/discovery/templates/discovery/addons/detail.html:57 src/olympia/reviews/forms.py:62 src/olympia/reviews/templates/reviews/add.html:57
+#: src/olympia/addons/templates/addons/details_box.html:81 src/olympia/addons/templates/addons/persona_detail_table.html:15 src/olympia/browse/views.py:429 src/olympia/devhub/views.py:76
+#: src/olympia/devhub/views.py:83 src/olympia/discovery/templates/discovery/addons/detail.html:57 src/olympia/reviews/forms.py:62 src/olympia/reviews/templates/reviews/add.html:57
 #: src/olympia/reviews/templates/reviews/mobile/review_list.html:18
 msgid "Rating"
 msgstr "Rating"
 
-#: src/olympia/addons/templates/addons/details_box.html:85 src/olympia/browse/views.py:461 src/olympia/devhub/views.py:77 src/olympia/devhub/views.py:84
+#: src/olympia/addons/templates/addons/details_box.html:85 src/olympia/browse/views.py:428 src/olympia/devhub/views.py:75 src/olympia/devhub/views.py:82
 #: src/olympia/stats/templates/stats/addon_report_menu.html:8 src/olympia/stats/templates/stats/collection_report_menu.html:18
 msgid "Downloads"
 msgstr "Downloads"
@@ -423,7 +423,7 @@ msgstr "Abuse Reports"
 
 #. The Privacy Policy for this add-on.
 #: src/olympia/addons/templates/addons/details_box.html:121 src/olympia/addons/templates/addons/privacy.html:19 src/olympia/addons/templates/addons/privacy.html:23
-#: src/olympia/addons/templates/addons/impala/button.html:43 src/olympia/addons/templates/addons/impala/details.html:307 src/olympia/devhub/templates/devhub/includes/policy_form.html:20
+#: src/olympia/addons/templates/addons/impala/button.html:43 src/olympia/addons/templates/addons/impala/details.html:312 src/olympia/devhub/templates/devhub/includes/policy_form.html:23
 #: src/olympia/templates/mobile/base_addons.html:87
 msgid "Privacy Policy"
 msgstr "Privacy Policy"
@@ -448,7 +448,7 @@ msgstr "Image Gallery"
 msgid "Developer Comments"
 msgstr "Developer Comments"
 
-#: src/olympia/addons/templates/addons/details_box.html:199 src/olympia/addons/templates/addons/impala/details.html:259
+#: src/olympia/addons/templates/addons/details_box.html:199 src/olympia/addons/templates/addons/impala/details.html:264
 msgid "Development Channel"
 msgstr "Development Channel"
 
@@ -472,13 +472,13 @@ msgstr ""
 "<strong>Caution:</strong> Development versions of this add-on have not been reviewed by Mozilla. Once you install a development version you will continue to receive development updates from this "
 "developer. To stop receiving development updates, reinstall the default version from the link above."
 
-#: src/olympia/addons/templates/addons/details_box.html:220 src/olympia/addons/templates/addons/impala/details.html:278
+#: src/olympia/addons/templates/addons/details_box.html:220 src/olympia/addons/templates/addons/impala/details.html:283
 msgid "Version {0}:"
 msgstr "Version {0}:"
 
 #: src/olympia/addons/templates/addons/details_box.html:234
 msgid "Nothing to see here!  The developer did not include any details."
-msgstr "Nothing to see here!  The developer did not include any details."
+msgstr ""
 
 #: src/olympia/addons/templates/addons/details_box.html:251 src/olympia/devhub/templates/devhub/versions/edit.html:73 src/olympia/editors/templates/editors/review.html:98
 msgid "Version Notes"
@@ -491,7 +491,7 @@ msgid "End-User License Agreement for {0}"
 msgstr "End-User Licence Agreement for {0}"
 
 #: src/olympia/addons/templates/addons/eula.html:17 src/olympia/addons/templates/addons/eula.html:21 src/olympia/addons/templates/addons/impala/button.html:48
-#: src/olympia/addons/templates/addons/impala/details.html:316 src/olympia/devhub/templates/devhub/includes/policy_form.html:3 src/olympia/discovery/templates/discovery/addons/eula.html:11
+#: src/olympia/addons/templates/addons/impala/details.html:321 src/olympia/devhub/templates/devhub/includes/policy_form.html:3 src/olympia/discovery/templates/discovery/addons/eula.html:11
 msgid "End-User License Agreement"
 msgstr "End-User Licence Agreement"
 
@@ -508,7 +508,7 @@ msgstr "Back to {0}…"
 msgid "Add-ons for {0}"
 msgstr "Add-ons for {0}"
 
-#: src/olympia/addons/templates/addons/home.html:10 src/olympia/addons/templates/addons/home.html:51 src/olympia/browse/templates/browse/impala/base_listing.html:11
+#: src/olympia/addons/templates/addons/home.html:10 src/olympia/addons/templates/addons/home.html:53 src/olympia/browse/templates/browse/impala/base_listing.html:11
 msgid "Featured Extensions"
 msgstr "Featured Extensions"
 
@@ -516,29 +516,29 @@ msgstr "Featured Extensions"
 msgid "Popular Extensions"
 msgstr "Popular Extensions"
 
-#: src/olympia/addons/templates/addons/home.html:42 src/olympia/amo/templates/amo/side_nav.html:3 src/olympia/amo/templates/amo/side_nav.html:11 src/olympia/amo/templates/amo/site_nav.html:3
-#: src/olympia/amo/templates/amo/site_nav.html:25 src/olympia/browse/views.py:236 src/olympia/browse/views.py:281 src/olympia/browse/views.py:481
+#: src/olympia/addons/templates/addons/home.html:44 src/olympia/amo/templates/amo/side_nav.html:3 src/olympia/amo/templates/amo/side_nav.html:11 src/olympia/amo/templates/amo/site_nav.html:3
+#: src/olympia/amo/templates/amo/site_nav.html:25 src/olympia/browse/views.py:203 src/olympia/browse/views.py:248 src/olympia/browse/views.py:448
 msgid "Most Popular"
 msgstr "Most Popular"
 
-#: src/olympia/addons/templates/addons/home.html:43
+#: src/olympia/addons/templates/addons/home.html:45
 msgid "All »"
 msgstr "All »"
 
-#: src/olympia/addons/templates/addons/home.html:52 src/olympia/addons/templates/addons/home.html:61 src/olympia/addons/templates/addons/home.html:70 src/olympia/addons/templates/addons/home.html:78
+#: src/olympia/addons/templates/addons/home.html:54 src/olympia/addons/templates/addons/home.html:63 src/olympia/addons/templates/addons/home.html:72 src/olympia/addons/templates/addons/home.html:80
 #: src/olympia/browse/templates/browse/impala/category_landing.html:36
 msgid "See all »"
 msgstr "See all »"
 
-#: src/olympia/addons/templates/addons/home.html:60
+#: src/olympia/addons/templates/addons/home.html:62
 msgid "Up &amp; Coming Extensions"
 msgstr "Up &amp; Coming Extensions"
 
-#: src/olympia/addons/templates/addons/home.html:69 src/olympia/browse/templates/browse/personas/category_landing.html:61 src/olympia/discovery/templates/discovery/pane.html:74
+#: src/olympia/addons/templates/addons/home.html:71 src/olympia/browse/templates/browse/personas/category_landing.html:61 src/olympia/discovery/templates/discovery/pane.html:74
 msgid "Featured Themes"
 msgstr "Featured Themes"
 
-#: src/olympia/addons/templates/addons/home.html:77 src/olympia/bandwagon/templates/bandwagon/impala/collection_listing.html:5
+#: src/olympia/addons/templates/addons/home.html:79 src/olympia/bandwagon/templates/bandwagon/impala/collection_listing.html:5
 msgid "Featured Collections"
 msgstr "Featured Collections"
 
@@ -556,7 +556,7 @@ msgid "Updated {0}"
 msgstr "Updated {0}"
 
 #. {0} is a date.
-#: src/olympia/addons/templates/addons/macros.html:10 src/olympia/addons/templates/addons/macros.html:69 src/olympia/addons/templates/addons/persona_preview.html:21
+#: src/olympia/addons/templates/addons/macros.html:10 src/olympia/addons/templates/addons/macros.html:69 src/olympia/addons/templates/addons/persona_preview.html:22
 #: src/olympia/addons/templates/addons/listing/items_mobile.html:44 src/olympia/addons/templates/addons/listing/macros.html:39
 #: src/olympia/bandwagon/templates/bandwagon/collection_listing_items.html:37 src/olympia/bandwagon/templates/bandwagon/impala/collection_listing_items.html:37
 msgid "Added {0}"
@@ -577,15 +577,14 @@ msgstr[0] "%(num)s user"
 msgstr[1] "%(num)s users"
 
 #. {0} is the number of downloads.
-#: src/olympia/addons/templates/addons/macros.html:53 src/olympia/addons/templates/addons/impala/details.html:61
+#: src/olympia/addons/templates/addons/macros.html:53 src/olympia/addons/templates/addons/impala/details.html:59
 msgid "{0} weekly download"
 msgid_plural "{0} weekly downloads"
 msgstr[0] "{0} weekly download"
 msgstr[1] "{0} weekly downloads"
 
 #. {0} is the number of users.
-#: src/olympia/addons/templates/addons/macros.html:61 src/olympia/addons/templates/addons/impala/details.html:54 src/olympia/compat/templates/compat/index.html:71
-#: src/olympia/zadmin/templates/zadmin/compat.html:67
+#: src/olympia/addons/templates/addons/macros.html:61 src/olympia/addons/templates/addons/impala/details.html:52 src/olympia/zadmin/templates/zadmin/compat.html:67
 msgid "{0} user"
 msgid_plural "{0} users"
 msgstr[0] "{0} user"
@@ -603,7 +602,7 @@ msgstr "Payment completed"
 msgid "Return to the addon."
 msgstr "Return to the addon."
 
-#: src/olympia/addons/templates/addons/persona_detail.html:17 src/olympia/addons/templates/addons/impala/details.html:106 src/olympia/addons/templates/addons/mobile/details.html:23
+#: src/olympia/addons/templates/addons/persona_detail.html:17 src/olympia/addons/templates/addons/impala/details.html:103 src/olympia/addons/templates/addons/mobile/details.html:23
 #: src/olympia/addons/templates/addons/mobile/persona_detail.html:21 src/olympia/discovery/templates/discovery/addons/base.html:27 src/olympia/editors/templates/editors/review.html:31
 msgid "by"
 msgstr "by"
@@ -647,34 +646,35 @@ msgstr "Daily Users"
 msgid "License"
 msgstr "Licence"
 
-#: src/olympia/addons/templates/addons/persona_preview.html:12 src/olympia/constants/base.py:48
+#: src/olympia/addons/templates/addons/persona_preview.html:13 src/olympia/constants/base.py:48
 msgid "Awaiting Review"
 msgstr "Awaiting Review"
 
-#: src/olympia/addons/templates/addons/persona_preview.html:14 src/olympia/amo/log.py:180 src/olympia/constants/base.py:42 src/olympia/editors/helpers.py:62
+#: src/olympia/addons/templates/addons/persona_preview.html:15 src/olympia/amo/log.py:180 src/olympia/constants/base.py:42 src/olympia/editors/helpers.py:62
 msgid "Rejected"
 msgstr "Rejected"
 
-#: src/olympia/addons/templates/addons/persona_preview.html:16 src/olympia/amo/log.py:159
+#: src/olympia/addons/templates/addons/persona_preview.html:17 src/olympia/amo/log.py:159
 msgid "Approved"
 msgstr "Approved"
 
 #. {0} is the number of users.
-#: src/olympia/addons/templates/addons/persona_preview.html:26 src/olympia/addons/templates/addons/listing/items_mobile.html:36 src/olympia/addons/templates/addons/listing/macros.html:31
+#: src/olympia/addons/templates/addons/persona_preview.html:27 src/olympia/addons/templates/addons/listing/items_mobile.html:36 src/olympia/addons/templates/addons/listing/macros.html:31
 msgid "<strong>{0}</strong> user"
 msgid_plural "<strong>{0}</strong> users"
 msgstr[0] "<strong>{0}</strong> user"
 msgstr[1] "<strong>{0}</strong> users"
 
-#: src/olympia/addons/templates/addons/persona_preview.html:40
+#: src/olympia/addons/templates/addons/persona_preview.html:41
 msgid "Hover to Preview"
 msgstr "Hover to Preview"
 
-#: src/olympia/addons/templates/addons/persona_preview.html:46 src/olympia/addons/templates/addons/persona_preview.html:48 src/olympia/reviews/templates/reviews/add.html:15
+#: src/olympia/addons/templates/addons/persona_preview.html:47 src/olympia/addons/templates/addons/persona_preview.html:49 src/olympia/addons/templates/addons/persona_preview.html:97
+#: src/olympia/reviews/templates/reviews/add.html:15
 msgid "Add"
 msgstr "Add"
 
-#: src/olympia/addons/templates/addons/persona_preview.html:57 src/olympia/bandwagon/templates/bandwagon/ajax_new.html:16 src/olympia/bandwagon/templates/bandwagon/edit.html:19
+#: src/olympia/addons/templates/addons/persona_preview.html:58 src/olympia/bandwagon/templates/bandwagon/ajax_new.html:16 src/olympia/bandwagon/templates/bandwagon/edit.html:19
 #: src/olympia/bandwagon/templates/bandwagon/includes/addedit.html:19 src/olympia/devhub/templates/devhub/addons/edit/admin.html:13 src/olympia/devhub/templates/devhub/addons/edit/basic.html:10
 #: src/olympia/devhub/templates/devhub/addons/edit/details.html:8 src/olympia/devhub/templates/devhub/addons/edit/media.html:6 src/olympia/devhub/templates/devhub/addons/edit/support.html:8
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:9 src/olympia/devhub/templates/devhub/addons/submit/describe.html:29 src/olympia/editors/templates/editors/review.html:257
@@ -683,21 +683,21 @@ msgstr "Edit"
 
 #. For datetime formatting, see the table on
 #. http://docs.python.org/library/datetime.html#strftime-and-strptime-behavior
-#: src/olympia/addons/templates/addons/persona_preview.html:66
+#: src/olympia/addons/templates/addons/persona_preview.html:67
 #, python-format
 msgid "%%Y-%%m-%%d"
 msgstr "%%Y-%%m-%%d"
 
-#: src/olympia/addons/templates/addons/persona_preview.html:67
+#: src/olympia/addons/templates/addons/persona_preview.html:68
 msgid "by {0} on {1}"
 msgstr "by {0} on {1}"
 
-#: src/olympia/addons/templates/addons/persona_preview.html:75 src/olympia/reviews/helpers.py:17 src/olympia/reviews/templates/reviews/review_list.html:63
+#: src/olympia/addons/templates/addons/persona_preview.html:76 src/olympia/reviews/helpers.py:17 src/olympia/reviews/templates/reviews/review_list.html:63
 #: src/olympia/reviews/templates/reviews/reviews_link.html:21 src/olympia/reviews/templates/reviews/impala/reviews_link.html:16
 msgid "Not yet rated"
 msgstr "Not yet rated"
 
-#: src/olympia/addons/templates/addons/persona_preview.html:78
+#: src/olympia/addons/templates/addons/persona_preview.html:79
 msgid "<b>{0}</b> users"
 msgstr "<b>{0}</b> users"
 
@@ -710,8 +710,8 @@ msgid "Learn more about Firefox"
 msgstr "Learn more about Firefox"
 
 #: src/olympia/addons/templates/addons/popups.html:22
-msgid "or <b><a class=\"installer\" href=\"{url}\">download anyway</a></b>"
-msgstr "or <b><a class=\"installer\" href=\"{url}\">download anyway</a></b>"
+msgid "or <b><a class=\"button installer\" href=\"{url}\">download anyway</a></b>"
+msgstr ""
 
 #: src/olympia/addons/templates/addons/popups.html:26
 msgid ""
@@ -775,8 +775,6 @@ msgid ""
 "<strong>Caution:</strong> This add-on has not been reviewed by Mozilla and can't be installed on release versions of Firefox 43 and above.  Be careful when installing third-party software that "
 "might harm your computer."
 msgstr ""
-"<strong>Caution:</strong> This add-on has not been reviewed by Mozilla and can't be installed on release versions of Firefox 43 and above.  Be careful when installing third-party software that "
-"might harm your computer."
 
 #: src/olympia/addons/templates/addons/popups.html:120
 msgid "<strong>Please note:</strong> This add-on is not compatible with your operating system."
@@ -811,12 +809,9 @@ msgid ""
 "  to your phone.  (You'll need a QR reader.  Search your phone's marketplace if\n"
 "  don't have one.)"
 msgstr ""
-"Want {0} on your mobile Firefox?  Scan this QR code to install directly\n"
-"  to your phone.  (You'll need a QR reader.  Search your phone's marketplace if\n"
-"  don't have one.)"
 
 #: src/olympia/addons/templates/addons/report_abuse.html:6 src/olympia/addons/templates/addons/report_abuse_full.html:10 src/olympia/addons/templates/addons/impala/details-more.html:23
-#: src/olympia/addons/templates/addons/impala/details.html:328
+#: src/olympia/addons/templates/addons/impala/details.html:333
 msgid "Report Abuse"
 msgstr "Report Abuse"
 
@@ -837,9 +832,9 @@ msgstr "Send Report"
 #: src/olympia/devhub/templates/devhub/addons/ajax_compat_update.html:36 src/olympia/devhub/templates/devhub/addons/profile.html:44 src/olympia/devhub/templates/devhub/addons/edit/admin.html:104
 #: src/olympia/devhub/templates/devhub/addons/edit/basic.html:155 src/olympia/devhub/templates/devhub/addons/edit/details.html:88 src/olympia/devhub/templates/devhub/addons/edit/support.html:70
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:169 src/olympia/devhub/templates/devhub/addons/forms_shared/media.html:152
-#: src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:44 src/olympia/devhub/templates/devhub/personas/edit.html:222 src/olympia/devhub/templates/devhub/versions/add_file_modal.html:79
-#: src/olympia/devhub/templates/devhub/versions/edit.html:140 src/olympia/devhub/templates/devhub/versions/list.html:208 src/olympia/devhub/templates/devhub/versions/list.html:242
-#: src/olympia/devhub/templates/devhub/versions/list.html:276 src/olympia/devhub/templates/devhub/versions/list.html:317 src/olympia/reviews/templates/reviews/edit_review.html:16
+#: src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:43 src/olympia/devhub/templates/devhub/personas/edit.html:222 src/olympia/devhub/templates/devhub/versions/add_file_modal.html:59
+#: src/olympia/devhub/templates/devhub/versions/edit.html:140 src/olympia/devhub/templates/devhub/versions/list.html:208 src/olympia/devhub/templates/devhub/versions/list.html:239
+#: src/olympia/devhub/templates/devhub/versions/list.html:281 src/olympia/devhub/templates/devhub/versions/list.html:315 src/olympia/reviews/templates/reviews/edit_review.html:16
 #: src/olympia/translations/templates/translations/trans-menu.html:50 src/olympia/translations/templates/translations/trans-menu.html:62 src/olympia/zadmin/templates/zadmin/validation.html:105
 msgid "Cancel"
 msgstr "Cancel"
@@ -884,7 +879,7 @@ msgstr "See the <a href=\"%(support)s\">support section</a> to find out where to
 msgid "Review Guidelines"
 msgstr "Review Guidelines"
 
-#: src/olympia/addons/templates/addons/review_list_box.html:5 src/olympia/addons/templates/addons/impala/details-more.html:27 src/olympia/editors/helpers.py:921
+#: src/olympia/addons/templates/addons/review_list_box.html:5 src/olympia/addons/templates/addons/impala/details-more.html:27 src/olympia/editors/helpers.py:1001
 #: src/olympia/reviews/templates/reviews/add.html:14 src/olympia/reviews/templates/reviews/reply.html:14 src/olympia/reviews/templates/reviews/review_list.html:19
 #: src/olympia/reviews/templates/reviews/mobile/review_list.html:26
 msgid "Reviews"
@@ -975,103 +970,103 @@ msgid_plural "Other add-ons by these authors"
 msgstr[0] "Other add-ons by %(author)s"
 msgstr[1] "Other add-ons by these authors"
 
-#: src/olympia/addons/templates/addons/impala/details.html:41
+#: src/olympia/addons/templates/addons/impala/details.html:39
 #, python-format
 msgid "<span itemprop=\"ratingCount\">%(num)s</span> user review"
 msgid_plural "<span itemprop=\"ratingCount\">%(num)s</span> user reviews"
 msgstr[0] "<span itemprop=\"ratingCount\">%(num)s</span> user review"
 msgstr[1] "<span itemprop=\"ratingCount\">%(num)s</span> user reviews"
 
-#: src/olympia/addons/templates/addons/impala/details.html:69
+#: src/olympia/addons/templates/addons/impala/details.html:66
 msgid "View statistics"
 msgstr "View statistics"
 
-#: src/olympia/addons/templates/addons/impala/details.html:84
+#: src/olympia/addons/templates/addons/impala/details.html:81
 msgid "Manage"
 msgstr "Manage"
 
 #. {0} is an add-on name.
-#: src/olympia/addons/templates/addons/impala/details.html:96
+#: src/olympia/addons/templates/addons/impala/details.html:93
 msgid "Icon of {0}"
 msgstr "Icon of {0}"
 
-#: src/olympia/addons/templates/addons/impala/details.html:103 src/olympia/addons/templates/addons/impala/listing/items.html:14
+#: src/olympia/addons/templates/addons/impala/details.html:100 src/olympia/addons/templates/addons/impala/listing/items.html:14
 msgid "No Restart"
 msgstr "No Restart"
 
-#: src/olympia/addons/templates/addons/impala/details.html:127
+#: src/olympia/addons/templates/addons/impala/details.html:124
 #, python-format
 msgid "Meet the Developer: <a href=\"%(url)s\">%(name)s</a>"
 msgid_plural "<a href=\"%(url)s\">Meet the Developers</a>"
 msgstr[0] "Meet the Developer: <a href=\"%(url)s\">%(name)s</a>"
 msgstr[1] "<a href=\"%(url)s\">Meet the Developers</a>"
 
-#: src/olympia/addons/templates/addons/impala/details.html:137
+#: src/olympia/addons/templates/addons/impala/details.html:134
 msgid "Learn why {0} was created and find out what's next for this add-on."
 msgstr "Learn why {0} was created and find out what's next for this add-on."
 
 #. {0} is an index.
-#: src/olympia/addons/templates/addons/impala/details.html:156
+#: src/olympia/addons/templates/addons/impala/details.html:161
 msgid "Add-on screenshot #{0}"
 msgstr "Add-on screenshot #{0}"
 
-#: src/olympia/addons/templates/addons/impala/details.html:182
+#: src/olympia/addons/templates/addons/impala/details.html:187
 msgid "Add-on home page"
 msgstr "Add-on home page"
 
-#: src/olympia/addons/templates/addons/impala/details.html:185
+#: src/olympia/addons/templates/addons/impala/details.html:190
 msgid "Support site"
 msgstr "Support site"
 
-#: src/olympia/addons/templates/addons/impala/details.html:189
+#: src/olympia/addons/templates/addons/impala/details.html:194
 msgid "Support E-mail"
 msgstr "Support E-mail"
 
-#: src/olympia/addons/templates/addons/impala/details.html:194 src/olympia/devhub/models.py:378 src/olympia/devhub/templates/devhub/versions/list.html:12
+#: src/olympia/addons/templates/addons/impala/details.html:199 src/olympia/devhub/models.py:378 src/olympia/devhub/templates/devhub/versions/list.html:12
 #: src/olympia/versions/templates/versions/version.html:6 src/olympia/versions/templates/versions/mobile/version.html:6
 msgid "Version {0}"
 msgstr "Version {0}"
 
-#: src/olympia/addons/templates/addons/impala/details.html:194
+#: src/olympia/addons/templates/addons/impala/details.html:199
 msgid "Info"
 msgstr "Info"
 
-#: src/olympia/addons/templates/addons/impala/details.html:195 src/olympia/devhub/templates/devhub/includes/addon_details.html:129
+#: src/olympia/addons/templates/addons/impala/details.html:200 src/olympia/devhub/templates/devhub/includes/addon_details.html:116
 msgid "Last Updated:"
 msgstr "Last Updated:"
 
-#: src/olympia/addons/templates/addons/impala/details.html:200
+#: src/olympia/addons/templates/addons/impala/details.html:205
 #, python-format
 msgid "Released under <a target=\"_blank\" href=\"%(url)s\">%(name)s</a>"
 msgstr "Released under <a target=\"_blank\" href=\"%(url)s\">%(name)s</a>"
 
-#: src/olympia/addons/templates/addons/impala/details.html:201 src/olympia/addons/templates/addons/impala/details.html:206 src/olympia/amo/helpers.py:398 src/olympia/devhub/forms.py:142
+#: src/olympia/addons/templates/addons/impala/details.html:206 src/olympia/addons/templates/addons/impala/details.html:211 src/olympia/amo/helpers.py:398 src/olympia/devhub/forms.py:142
 #: src/olympia/devhub/forms.py:173 src/olympia/versions/templates/versions/version.html:40 src/olympia/versions/templates/versions/version.html:45
 msgid "Custom License"
 msgstr "Custom Licence"
 
-#: src/olympia/addons/templates/addons/impala/details.html:205
+#: src/olympia/addons/templates/addons/impala/details.html:210
 #, python-format
 msgid "Released under <a href=\"%(url)s\">%(name)s</a>"
 msgstr "Released under <a href=\"%(url)s\">%(name)s</a>"
 
-#: src/olympia/addons/templates/addons/impala/details.html:217
+#: src/olympia/addons/templates/addons/impala/details.html:222
 msgid "About this Add-on"
 msgstr "About this Add-on"
 
-#: src/olympia/addons/templates/addons/impala/details.html:233
+#: src/olympia/addons/templates/addons/impala/details.html:238
 msgid "Developer’s Comments"
 msgstr "Developer’s Comments"
 
-#: src/olympia/addons/templates/addons/impala/details.html:243
+#: src/olympia/addons/templates/addons/impala/details.html:248
 msgid "Version Information"
 msgstr "Version Information"
 
-#: src/olympia/addons/templates/addons/impala/details.html:250
+#: src/olympia/addons/templates/addons/impala/details.html:255
 msgid "See complete version history"
 msgstr "See complete version history"
 
-#: src/olympia/addons/templates/addons/impala/details.html:262
+#: src/olympia/addons/templates/addons/impala/details.html:267
 msgid ""
 "The Development Channel lets you test an experimental new version of this add-on before it's released to the general public. Once you install the development version, you will continue to get "
 "updates from this channel. To stop receiving development updates, reinstall the default version from the link above."
@@ -1079,17 +1074,17 @@ msgstr ""
 "The Development Channel lets you test an experimental new version of this add-on before it's released to the general public. Once you install the development version, you will continue to get "
 "updates from this channel. To stop receiving development updates, reinstall the default version from the link above."
 
-#: src/olympia/addons/templates/addons/impala/details.html:272
+#: src/olympia/addons/templates/addons/impala/details.html:277
 msgid "<strong>Caution:</strong> Development versions of this add-on have not been reviewed by Mozilla."
 msgstr "<strong>Caution:</strong> Development versions of this add-on have not been reviewed by Mozilla."
 
-#: src/olympia/addons/templates/addons/impala/details.html:287
+#: src/olympia/addons/templates/addons/impala/details.html:292
 msgid "See complete development channel history"
 msgstr "See complete development channel history"
 
-#: src/olympia/addons/templates/addons/impala/details.html:306 src/olympia/addons/templates/addons/impala/details.html:315 src/olympia/addons/templates/addons/impala/details.html:327
+#: src/olympia/addons/templates/addons/impala/details.html:311 src/olympia/addons/templates/addons/impala/details.html:320 src/olympia/addons/templates/addons/impala/details.html:332
 #: src/olympia/addons/templates/addons/impala/review_add_box.html:4 src/olympia/stats/templates/stats/popup.html:2 src/olympia/stats/templates/stats/popup.html:8
-#: src/olympia/stats/templates/stats/stats.html:202 src/olympia/users/templates/users/profile.html:119
+#: src/olympia/stats/templates/stats/stats.html:204 src/olympia/users/templates/users/profile.html:119
 msgid "close"
 msgstr "close"
 
@@ -1145,15 +1140,11 @@ msgstr "Source Code Licence for {addon}"
 msgid "Source Code License"
 msgstr "Source Code Licence"
 
-#: src/olympia/addons/templates/addons/impala/persona_grid.html:16 src/olympia/addons/templates/addons/impala/toplist.html:6
-msgid "{0} users"
-msgstr "{0} users"
-
 #: src/olympia/addons/templates/addons/impala/review_list_box.html:19 src/olympia/reviews/templates/reviews/review.html:40
 msgid "permalink"
 msgstr "permalink"
 
-#: src/olympia/addons/templates/addons/impala/review_list_box.html:23 src/olympia/editors/templates/editors/queue.html:98 src/olympia/reviews/templates/reviews/review.html:44
+#: src/olympia/addons/templates/addons/impala/review_list_box.html:23 src/olympia/editors/templates/editors/queue.html:104 src/olympia/reviews/templates/reviews/review.html:44
 msgid "translate"
 msgstr "translate"
 
@@ -1172,6 +1163,10 @@ msgstr "This add-on has not yet been reviewed."
 msgid "Be the first!"
 msgstr "Be the first!"
 
+#: src/olympia/addons/templates/addons/impala/toplist.html:6
+msgid "{0} users"
+msgstr "{0} users"
+
 #: src/olympia/addons/templates/addons/impala/listing/sorter.html:14 src/olympia/devhub/templates/devhub/addons/listing/item_actions.html:49
 msgid "More"
 msgstr "More"
@@ -1184,7 +1179,7 @@ msgstr "Add to collection"
 msgid "My Add-ons"
 msgstr "My Add-ons"
 
-#: src/olympia/addons/templates/addons/includes/dashboard_tabs.html:6 src/olympia/amo/context_processors.py:51
+#: src/olympia/addons/templates/addons/includes/dashboard_tabs.html:6 src/olympia/amo/context_processors.py:50
 msgid "My Themes"
 msgstr "My Themes"
 
@@ -1239,7 +1234,7 @@ msgstr "Users"
 msgid "Weekly Downloads"
 msgstr "Weekly Downloads"
 
-#: src/olympia/addons/templates/addons/mobile/details.html:99 src/olympia/compat/templates/compat/reporter_detail.html:46 src/olympia/devhub/forms.py:787
+#: src/olympia/addons/templates/addons/mobile/details.html:99 src/olympia/compat/templates/compat/reporter_detail.html:46 src/olympia/devhub/forms.py:788
 #: src/olympia/devhub/templates/devhub/versions/list.html:163
 msgid "Version"
 msgstr "Version"
@@ -1325,7 +1320,7 @@ msgstr ""
 #: src/olympia/browse/templates/browse/personas/category_landing.html:21 src/olympia/browse/templates/browse/personas/category_landing.html:23
 #: src/olympia/browse/templates/browse/personas/category_landing.html:38 src/olympia/browse/templates/browse/personas/grid.html:7 src/olympia/browse/templates/browse/personas/grid.html:11
 #: src/olympia/browse/templates/browse/personas/mobile/base.html:7 src/olympia/browse/templates/browse/personas/mobile/category_landing.html:19 src/olympia/constants/base.py:180
-#: src/olympia/devhub/templates/devhub/personas/submit.html:13 src/olympia/editors/helpers.py:105 src/olympia/editors/templates/editors/base.html:26
+#: src/olympia/devhub/templates/devhub/personas/submit.html:13 src/olympia/editors/helpers.py:107 src/olympia/editors/templates/editors/base.html:26
 #: src/olympia/editors/templates/editors/performance.html:73 src/olympia/search/templates/search/personas.html:39 src/olympia/templates/menu_links.html:9
 msgid "Themes"
 msgstr "Themes"
@@ -1346,7 +1341,7 @@ msgstr "More Add-ons"
 msgid "Highest Rated"
 msgstr "Highest Rated"
 
-#: src/olympia/addons/templates/addons/mobile/home.html:74 src/olympia/amo/templates/amo/side_nav.html:5 src/olympia/amo/templates/amo/site_nav.html:27 src/olympia/amo/templates/amo/site_nav.html:57
+#: src/olympia/addons/templates/addons/mobile/home.html:74 src/olympia/amo/templates/amo/side_nav.html:5 src/olympia/amo/templates/amo/site_nav.html:27 src/olympia/amo/templates/amo/site_nav.html:55
 #: src/olympia/bandwagon/views.py:97 src/olympia/browse/views.py:57 src/olympia/browse/views.py:67 src/olympia/browse/templates/browse/personas/mobile/category_landing.html:65
 #: src/olympia/search/forms.py:15 src/olympia/search/forms.py:87
 msgid "Newest"
@@ -1360,90 +1355,90 @@ msgstr "Try it on!"
 msgid "Theme Info &raquo;"
 msgstr "Theme Info &raquo;"
 
-#: src/olympia/amo/context_processors.py:39 src/olympia/devhub/templates/devhub/nav.html:43
+#: src/olympia/amo/context_processors.py:37 src/olympia/devhub/templates/devhub/nav.html:43
 msgid "Tools"
 msgstr "Tools"
 
-#: src/olympia/amo/context_processors.py:48 src/olympia/discovery/templates/discovery/pane_account.html:8 src/olympia/users/templates/users/includes/navigation.html:2
+#: src/olympia/amo/context_processors.py:47 src/olympia/discovery/templates/discovery/pane_account.html:8 src/olympia/users/templates/users/includes/navigation.html:2
 msgid "My Profile"
 msgstr "My Profile"
 
-#: src/olympia/amo/context_processors.py:54 src/olympia/users/templates/users/edit.html:5 src/olympia/users/templates/users/includes/navigation.html:3
+#: src/olympia/amo/context_processors.py:53 src/olympia/users/templates/users/edit.html:5 src/olympia/users/templates/users/includes/navigation.html:3
 msgid "Account Settings"
 msgstr "Account Settings"
 
-#: src/olympia/amo/context_processors.py:57 src/olympia/discovery/templates/discovery/pane_account.html:11 src/olympia/users/templates/users/profile.html:83
+#: src/olympia/amo/context_processors.py:56 src/olympia/discovery/templates/discovery/pane_account.html:11 src/olympia/users/templates/users/profile.html:83
 #: src/olympia/users/templates/users/includes/navigation.html:4
 msgid "My Collections"
 msgstr "My Collections"
 
-#: src/olympia/amo/context_processors.py:62 src/olympia/discovery/templates/discovery/pane_account.html:10 src/olympia/users/templates/users/includes/navigation.html:7
+#: src/olympia/amo/context_processors.py:61 src/olympia/discovery/templates/discovery/pane_account.html:10 src/olympia/users/templates/users/includes/navigation.html:7
 msgid "My Favorites"
 msgstr "My Favourites"
 
-#: src/olympia/amo/context_processors.py:67 src/olympia/discovery/templates/discovery/pane_account.html:13 src/olympia/templates/impala/user_login.html:14
+#: src/olympia/amo/context_processors.py:66 src/olympia/discovery/templates/discovery/pane_account.html:13 src/olympia/templates/impala/user_login.html:14
 #: src/olympia/templates/mobile/header_auth.html:5
 msgid "Log out"
 msgstr "Log out"
 
-#: src/olympia/amo/context_processors.py:72 src/olympia/devhub/templates/devhub/addons/dashboard.html:4
+#: src/olympia/amo/context_processors.py:71 src/olympia/devhub/templates/devhub/addons/dashboard.html:4
 msgid "Manage My Submissions"
 msgstr "Manage My Submissions"
 
-#: src/olympia/amo/context_processors.py:75 src/olympia/devhub/templates/devhub/nav.html:27 src/olympia/devhub/templates/devhub/addons/dashboard.html:25
+#: src/olympia/amo/context_processors.py:74 src/olympia/devhub/templates/devhub/nav.html:27 src/olympia/devhub/templates/devhub/addons/dashboard.html:25
 #: src/olympia/devhub/templates/devhub/addons/submit/base.html:4
 msgid "Submit a New Add-on"
 msgstr "Submit a New Add-on"
 
-#: src/olympia/amo/context_processors.py:77 src/olympia/browse/templates/browse/personas/base.html:50 src/olympia/devhub/templates/devhub/index.html:24
+#: src/olympia/amo/context_processors.py:76 src/olympia/browse/templates/browse/personas/base.html:50 src/olympia/devhub/templates/devhub/index.html:24
 #: src/olympia/devhub/templates/devhub/addons/dashboard.html:29
 msgid "Submit a New Theme"
 msgstr "Submit a New Theme"
 
-#: src/olympia/amo/context_processors.py:79 src/olympia/amo/templates/amo/site_nav.html:87 src/olympia/devhub/helpers.py:36 src/olympia/devhub/helpers.py:68 src/olympia/devhub/helpers.py:102
+#: src/olympia/amo/context_processors.py:78 src/olympia/amo/templates/amo/site_nav.html:85 src/olympia/devhub/helpers.py:36 src/olympia/devhub/helpers.py:68 src/olympia/devhub/helpers.py:102
 #: src/olympia/templates/footer.html:6 src/olympia/templates/menu_links.html:14
 msgid "Developer Hub"
 msgstr "Developer Hub"
 
-#: src/olympia/amo/context_processors.py:83 src/olympia/devhub/views.py:1792
+#: src/olympia/amo/context_processors.py:81 src/olympia/devhub/views.py:1796
 msgid "Manage API Keys"
 msgstr "Manage API Keys"
 
-#: src/olympia/amo/context_processors.py:88 src/olympia/editors/helpers.py:82 src/olympia/editors/helpers.py:102 src/olympia/editors/templates/editors/base.html:10
+#: src/olympia/amo/context_processors.py:86 src/olympia/editors/helpers.py:84 src/olympia/editors/helpers.py:104 src/olympia/editors/templates/editors/base.html:10
 msgid "Editor Tools"
 msgstr "Editor Tools"
 
-#: src/olympia/amo/context_processors.py:92
+#: src/olympia/amo/context_processors.py:90
 msgid "Admin Tools"
 msgstr "Admin Tools"
 
-#: src/olympia/amo/fields.py:15
+#: src/olympia/amo/fields.py:20
 msgid "Incorrect, please try again."
 msgstr "Incorrect, please try again."
 
-#: src/olympia/amo/fields.py:16
+#: src/olympia/amo/fields.py:21
 msgid "Error verifying input, please try again."
 msgstr "Error verifying input, please try again."
 
-#: src/olympia/amo/fields.py:32
+#: src/olympia/amo/fields.py:37
 msgid "This must be a valid hex color code, such as #000000."
 msgstr "This must be a valid hex colour code, such as #000000."
 
-#: src/olympia/amo/fields.py:58
+#: src/olympia/amo/fields.py:63
 msgid "Enter at least one value."
 msgstr "Enter at least one value."
 
-#: src/olympia/amo/helpers.py:162 src/olympia/amo/templates/amo/site_nav.html:61 src/olympia/bandwagon/templates/bandwagon/add.html:9
+#: src/olympia/amo/helpers.py:162 src/olympia/amo/templates/amo/site_nav.html:59 src/olympia/bandwagon/templates/bandwagon/add.html:9
 #: src/olympia/bandwagon/templates/bandwagon/collection_detail.html:15 src/olympia/bandwagon/templates/bandwagon/delete.html:9 src/olympia/bandwagon/templates/bandwagon/edit.html:15
 #: src/olympia/bandwagon/templates/bandwagon/user_listing.html:18 src/olympia/bandwagon/templates/bandwagon/user_listing.html:21
 #: src/olympia/bandwagon/templates/bandwagon/impala/collection_listing.html:12 src/olympia/bandwagon/templates/bandwagon/impala/collection_listing.html:20
 #: src/olympia/bandwagon/templates/bandwagon/impala/collection_listing.html:24 src/olympia/bandwagon/templates/bandwagon/impala/collection_sidebar.html:3
 #: src/olympia/bandwagon/templates/bandwagon/includes/collection_sidebar.html:2 src/olympia/bandwagon/templates/bandwagon/mobile/collection_listing.html:3
-#: src/olympia/stats/templates/stats/stats.html:77 src/olympia/templates/menu_links.html:12
+#: src/olympia/stats/templates/stats/stats.html:33 src/olympia/templates/menu_links.html:12
 msgid "Collections"
 msgstr "Collections"
 
-#: src/olympia/amo/helpers.py:171 src/olympia/amo/templates/amo/site_nav.html:85 src/olympia/browse/templates/browse/language_tools.html:3
+#: src/olympia/amo/helpers.py:171 src/olympia/amo/templates/amo/site_nav.html:83 src/olympia/browse/templates/browse/language_tools.html:3
 msgid "Dictionaries & Language Packs"
 msgstr "Dictionaries & Language Packs"
 
@@ -1595,8 +1590,8 @@ msgstr "Super review requested"
 msgid "Comment on {addon} {version}."
 msgstr "Comment on {addon} {version}."
 
-#: src/olympia/amo/log.py:236 src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:19 src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:47
-#: src/olympia/editors/helpers.py:511 src/olympia/editors/templates/editors/themes/history_table.html:11
+#: src/olympia/amo/log.py:236 src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:17 src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:45
+#: src/olympia/editors/helpers.py:584 src/olympia/editors/templates/editors/themes/history_table.html:11
 msgid "Comment"
 msgstr "Comment"
 
@@ -1750,7 +1745,7 @@ msgstr "Reviewer escalation"
 
 #: src/olympia/amo/log.py:442
 msgid "Video removed from {addon} because of a problem with the video. "
-msgstr "Video removed from {addon} because of a problem with the video. "
+msgstr ""
 
 #: src/olympia/amo/log.py:444
 msgid "Video removed"
@@ -1903,7 +1898,7 @@ msgstr "Oops"
 #: src/olympia/amo/templates/amo/500.html:6
 #, python-format
 msgid "<h1>Oops!  We had an error.</h1> <p>We'll get to fixing that soon.</p> <p> You can try refreshing the page, or head back to the <a href=\"%(home)s\">Add-ons homepage</a>. </p>"
-msgstr "<h1>Oops!  We had an error.</h1> <p>We'll get to fixing that soon.</p> <p> You can try refreshing the page, or head back to the <a href=\"%(home)s\">Add-ons homepage</a>. </p>"
+msgstr ""
 
 #: src/olympia/amo/templates/amo/license_link.html:10
 msgid "Some rights reserved"
@@ -1925,7 +1920,7 @@ msgstr "Prev"
 #: src/olympia/amo/templates/amo/mobile/paginator.html:14 src/olympia/amo/templates/amo/mobile/paginator.html:16 src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:51
 #: src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:65 src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:78
 #: src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:91 src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:104
-#: src/olympia/discovery/templates/discovery/pane.html:45 src/olympia/discovery/templates/discovery/addons/detail.html:39 src/olympia/stats/templates/stats/stats.html:167
+#: src/olympia/discovery/templates/discovery/pane.html:45 src/olympia/discovery/templates/discovery/addons/detail.html:39 src/olympia/stats/templates/stats/stats.html:169
 msgid "Next"
 msgstr "Next"
 
@@ -1959,7 +1954,7 @@ msgstr ""
 "different words</a> or <a href=\"#\" id=\"recaptcha_audio\">try a different type of challenge</a> instead. </p>"
 
 #: src/olympia/amo/templates/amo/side_nav.html:4 src/olympia/amo/templates/amo/side_nav.html:12 src/olympia/amo/templates/amo/site_nav.html:4 src/olympia/amo/templates/amo/site_nav.html:26
-#: src/olympia/browse/views.py:56 src/olympia/browse/views.py:66 src/olympia/browse/views.py:237 src/olympia/browse/views.py:282 src/olympia/search/forms.py:86
+#: src/olympia/browse/views.py:56 src/olympia/browse/views.py:66 src/olympia/browse/views.py:204 src/olympia/browse/views.py:249 src/olympia/search/forms.py:86
 msgid "Top Rated"
 msgstr "Top Rated"
 
@@ -1973,38 +1968,38 @@ msgstr "Explore"
 msgid "Extensions"
 msgstr "Extensions"
 
-#: src/olympia/amo/templates/amo/site_nav.html:45
+#: src/olympia/amo/templates/amo/site_nav.html:44
 msgid "Want more customization? Try <b>Complete Themes</b>"
 msgstr "Want more customisation? Try <b>Complete Themes</b>"
 
-#: src/olympia/amo/templates/amo/site_nav.html:56 src/olympia/bandwagon/views.py:96
+#: src/olympia/amo/templates/amo/site_nav.html:54 src/olympia/bandwagon/views.py:96
 msgid "Most Followers"
 msgstr "Most Followers"
 
-#: src/olympia/amo/templates/amo/site_nav.html:68 src/olympia/bandwagon/templates/bandwagon/impala/collection_sidebar.html:16
+#: src/olympia/amo/templates/amo/site_nav.html:66 src/olympia/bandwagon/templates/bandwagon/impala/collection_sidebar.html:16
 #: src/olympia/bandwagon/templates/bandwagon/includes/collection_sidebar.html:18
 msgid "Collections I've Made"
 msgstr "Collections I've Made"
 
-#: src/olympia/amo/templates/amo/site_nav.html:70 src/olympia/bandwagon/templates/bandwagon/user_listing.html:4 src/olympia/bandwagon/templates/bandwagon/impala/collection_sidebar.html:13
+#: src/olympia/amo/templates/amo/site_nav.html:68 src/olympia/bandwagon/templates/bandwagon/user_listing.html:4 src/olympia/bandwagon/templates/bandwagon/impala/collection_sidebar.html:13
 #: src/olympia/bandwagon/templates/bandwagon/includes/collection_sidebar.html:15
 msgid "Collections I'm Following"
 msgstr "Collections I'm Following"
 
-#: src/olympia/amo/templates/amo/site_nav.html:73 src/olympia/bandwagon/templates/bandwagon/impala/collection_sidebar.html:18
-#: src/olympia/bandwagon/templates/bandwagon/includes/collection_sidebar.html:20 src/olympia/users/models.py:512
+#: src/olympia/amo/templates/amo/site_nav.html:71 src/olympia/bandwagon/templates/bandwagon/impala/collection_sidebar.html:18
+#: src/olympia/bandwagon/templates/bandwagon/includes/collection_sidebar.html:20 src/olympia/users/models.py:521
 msgid "My Favorite Add-ons"
 msgstr "My Favourite Add-ons"
 
-#: src/olympia/amo/templates/amo/site_nav.html:78
+#: src/olympia/amo/templates/amo/site_nav.html:76
 msgid "More&hellip;"
 msgstr "More&hellip;"
 
-#: src/olympia/amo/templates/amo/site_nav.html:82
+#: src/olympia/amo/templates/amo/site_nav.html:80
 msgid "Add-ons for Mobile"
 msgstr "Add-ons for Mobile"
 
-#: src/olympia/amo/templates/amo/site_nav.html:86 src/olympia/browse/feeds.py:207 src/olympia/browse/templates/browse/search_tools.html:3 src/olympia/constants/base.py:176
+#: src/olympia/amo/templates/amo/site_nav.html:84 src/olympia/browse/feeds.py:207 src/olympia/browse/templates/browse/search_tools.html:3 src/olympia/constants/base.py:176
 #: src/olympia/templates/menu_links.html:10
 msgid "Search Tools"
 msgstr "Search Tools"
@@ -2020,7 +2015,7 @@ msgid "Jump to first page"
 msgstr "Jump to first page"
 
 #: src/olympia/amo/templates/amo/impala/paginator.html:22 src/olympia/amo/templates/amo/mobile/impala_paginator.html:12 src/olympia/discovery/templates/discovery/pane.html:44
-#: src/olympia/discovery/templates/discovery/addons/detail.html:38 src/olympia/stats/templates/stats/stats.html:164
+#: src/olympia/discovery/templates/discovery/addons/detail.html:38 src/olympia/stats/templates/stats/stats.html:166
 msgid "Previous"
 msgstr "Previous"
 
@@ -2030,7 +2025,7 @@ msgstr "Jump to last page"
 
 #. First and second arguments are the result range (e.g., 1-20);
 #. third argument is the number of total results (e.g., 1,000).
-#. third
+#. First and second arguments are the result range (e.g., 1-20);              third
 #. argument is the number of total results (e.g., 1,000).
 #: src/olympia/amo/templates/amo/impala/paginator.html:36 src/olympia/amo/templates/amo/mobile/impala_paginator.html:38
 #, python-format
@@ -2043,31 +2038,50 @@ msgid_plural "Page {n}"
 msgstr[0] "Page {n}"
 msgstr[1] "Page {n}"
 
-#: src/olympia/amo/templates/services/install.html:38
-#, python-format
-msgid "If you are not prompted to install %(addon_name)s in a moment, please <a href=\"%(addon_xpi)s\">click here</a>."
-msgstr "If you are not prompted to install %(addon_name)s in a moment, please <a href=\"%(addon_xpi)s\">click here</a>."
-
-#: src/olympia/amo/tests/test_messages.py:57 src/olympia/amo/tests/test_messages.py:58 src/olympia/reviews/forms.py:25 src/olympia/reviews/forms.py:50 src/olympia/reviews/templates/reviews/add.html:56
+#: src/olympia/amo/tests/test_messages.py:56 src/olympia/amo/tests/test_messages.py:57 src/olympia/reviews/forms.py:25 src/olympia/reviews/forms.py:50 src/olympia/reviews/templates/reviews/add.html:56
 #: src/olympia/reviews/templates/reviews/reply.html:30
 msgid "Title"
 msgstr "Title"
 
-#: src/olympia/amo/tests/test_messages.py:57 src/olympia/amo/tests/test_messages.py:58
+#: src/olympia/amo/tests/test_messages.py:56 src/olympia/amo/tests/test_messages.py:57
 msgid "Body"
 msgstr "Body"
 
-#: src/olympia/amo/tests/test_messages.py:59
+#: src/olympia/amo/tests/test_messages.py:58
 msgid "Another Title"
 msgstr "Another Title"
 
-#: src/olympia/amo/tests/test_messages.py:59
+#: src/olympia/amo/tests/test_messages.py:58
 msgid "Another Body"
 msgstr "Another Body"
 
-#: src/olympia/api/views.py:255
-msgid "Not implemented yet."
-msgstr "Not implemented yet."
+#: src/olympia/api/authentication.py:76
+msgid "Signature has expired."
+msgstr ""
+
+#: src/olympia/api/authentication.py:79
+msgid "Error decoding signature."
+msgstr ""
+
+#: src/olympia/api/authentication.py:82
+msgid "Invalid JWT Token."
+msgstr ""
+
+#: src/olympia/api/authentication.py:130
+msgid "Invalid Authorization header. No credentials provided."
+msgstr ""
+
+#: src/olympia/api/authentication.py:133
+msgid "Invalid Authorization header. Credentials string should not contain spaces."
+msgstr ""
+
+#: src/olympia/api/fields.py:29
+msgid "The field must have a length of at least {num} characters."
+msgstr ""
+
+#: src/olympia/api/fields.py:31
+msgid "The language code {lang_code} is invalid."
+msgstr ""
 
 #: src/olympia/applications/views.py:39 src/olympia/applications/templates/applications/appversions.html:3
 msgid "Application Versions"
@@ -2085,7 +2099,7 @@ msgstr "Valid Application Versions"
 msgid "Add-ons submitted to Mozilla Add-ons must have a manifest file with at least one of the below applications supported. Only the versions listed below are allowed for these applications."
 msgstr "Add-ons submitted to Mozilla Add-ons must have a manifest file with at least one of the below applications supported. Only the versions listed below are allowed for these applications."
 
-#: src/olympia/applications/templates/applications/appversions.html:25
+#: src/olympia/applications/templates/applications/appversions.html:25 src/olympia/editors/helpers.py:361
 msgid "GUID"
 msgstr "GUID"
 
@@ -2199,8 +2213,8 @@ msgstr "Favourite"
 msgid "Remove from favorites"
 msgstr "Remove from favourites"
 
-#: src/olympia/bandwagon/views.py:98 src/olympia/bandwagon/views.py:191 src/olympia/browse/views.py:58 src/olympia/browse/views.py:69 src/olympia/browse/views.py:458 src/olympia/devhub/views.py:74
-#: src/olympia/devhub/views.py:82 src/olympia/devhub/templates/devhub/addons/edit/basic.html:20 src/olympia/editors/templates/editors/leaderboard.html:24
+#: src/olympia/bandwagon/views.py:98 src/olympia/bandwagon/views.py:191 src/olympia/browse/views.py:58 src/olympia/browse/views.py:69 src/olympia/browse/views.py:425 src/olympia/devhub/views.py:72
+#: src/olympia/devhub/views.py:80 src/olympia/devhub/templates/devhub/addons/edit/basic.html:20 src/olympia/editors/templates/editors/leaderboard.html:24
 #: src/olympia/editors/templates/editors/themes/queue_list.html:48 src/olympia/search/forms.py:17 src/olympia/search/forms.py:89 src/olympia/users/templates/users/vcard.html:5
 msgid "Name"
 msgstr "Name"
@@ -2209,7 +2223,7 @@ msgstr "Name"
 msgid "Recently Popular"
 msgstr "Recently Popular"
 
-#: src/olympia/bandwagon/views.py:189 src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:18
+#: src/olympia/bandwagon/views.py:189 src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:16
 msgid "Added"
 msgstr "Added"
 
@@ -2223,8 +2237,8 @@ msgstr "Collection created!"
 
 #: src/olympia/bandwagon/views.py:316
 #, python-format
-msgid "Your new collection is shown below. You can <ahref=\"%(url)s\">edit additional settings</a> if you'dlike."
-msgstr "Your new collection is shown below. You can <ahref=\"%(url)s\">edit additional settings</a> if you'dlike."
+msgid "Your new collection is shown below. You can <a href=\"%(url)s\">edit additional settings</a> if you'd like."
+msgstr ""
 
 #: src/olympia/bandwagon/views.py:322
 msgid "Collection updated!"
@@ -2351,8 +2365,8 @@ msgid_plural "%(num)s Add-ons in this Collection"
 msgstr[0] "%(num)s Add-on in this Collection"
 msgstr[1] "%(num)s Add-ons in this Collection"
 
-#: src/olympia/bandwagon/templates/bandwagon/collection_detail.html:125 src/olympia/compat/templates/compat/index.html:25 src/olympia/compat/templates/compat/reporter_detail.html:29
-#: src/olympia/files/templates/files/viewer.html:29 src/olympia/templates/amo_footer.html:17 src/olympia/templates/includes/lang_switcher.html:10
+#: src/olympia/bandwagon/templates/bandwagon/collection_detail.html:125 src/olympia/compat/templates/compat/reporter_detail.html:29 src/olympia/files/templates/files/viewer.html:29
+#: src/olympia/templates/amo_footer.html:17 src/olympia/templates/includes/lang_switcher.html:10
 msgid "Go"
 msgstr "Go"
 
@@ -2389,8 +2403,6 @@ msgid ""
 "Add-ons that you mark as favorites using the <b>Add to Favorites</b> feature appear below. This collection is currently <b>private</b>, which means only you can see it.  If you would like everyone "
 "to be able to see your favorites, click the button below to make it public."
 msgstr ""
-"Add-ons that you mark as favourites using the <b>Add to Favourites</b> feature appear below. This collection is currently <b>private</b>, which means only you can see it.  If you would like "
-"everyone to be able to see your favourites, click the button below to make it public."
 
 #: src/olympia/bandwagon/templates/bandwagon/collection_detail.html:196
 msgid "My favorite add-ons"
@@ -2410,9 +2422,9 @@ msgid_plural "<span>%(followers)s</span> followers"
 msgstr[0] "<span>%(followers)s</span> follower"
 msgstr[1] "<span>%(followers)s</span> followers"
 
-#. People "follow" collections to get notified of updates.
-#. Like
+#. People "follow" collections to get notified of updates.                    Like
 #. Twitter followers.
+#. People "follow" collections to get notified of updates.
 #. Like Twitter followers.
 #: src/olympia/bandwagon/templates/bandwagon/collection_listing_items.html:10 src/olympia/bandwagon/templates/bandwagon/impala/collection_listing_items.html:18
 #, python-format
@@ -2421,8 +2433,7 @@ msgid_plural "%(num)s weekly followers"
 msgstr[0] "%(num)s weekly follower"
 msgstr[1] "%(num)s weekly followers"
 
-#. People "follow" collections to get notified of updates.
-#. Like
+#. People "follow" collections to get notified of updates.                    Like
 #. Twitter followers.
 #: src/olympia/bandwagon/templates/bandwagon/collection_listing_items.html:18
 #, python-format
@@ -2431,9 +2442,9 @@ msgid_plural "%(num)s monthly followers"
 msgstr[0] "%(num)s monthly follower"
 msgstr[1] "%(num)s monthly followers"
 
-#. People "follow" collections to get notified of updates.
-#. Like
+#. People "follow" collections to get notified of updates.                    Like
 #. Twitter followers.
+#. People "follow" collections to get notified of updates.
 #. Like Twitter followers.
 #: src/olympia/bandwagon/templates/bandwagon/collection_listing_items.html:26 src/olympia/bandwagon/templates/bandwagon/impala/collection_listing_items.html:26
 #, python-format
@@ -2524,7 +2535,7 @@ msgid "Remove this user as a contributor"
 msgstr "Remove this user as a contributor"
 
 #: src/olympia/bandwagon/templates/bandwagon/edit_contributors.html:18 src/olympia/bandwagon/templates/bandwagon/edit_contributors.html:43
-#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:20 src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:48
+#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:18 src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:46
 #: src/olympia/devhub/templates/devhub/addons/ajax_compat_update.html:19
 msgid "Remove"
 msgstr "Remove"
@@ -2538,8 +2549,6 @@ msgid ""
 "You can add multiple contributors to this collection.  A contributor can add and remove add-ons from this collection, but cannot change its name or description.  To add a contributor, enter their "
 "email in the box below. Contributors must have a Mozilla Add-ons account."
 msgstr ""
-"You can add multiple contributors to this collection.  A contributor can add and remove add-ons from this collection, but cannot change its name or description.  To add a contributor, enter their "
-"email in the box below. Contributors must have a Mozilla Add-ons account."
 
 #: src/olympia/bandwagon/templates/bandwagon/edit_contributors.html:40
 msgid "User"
@@ -2574,7 +2583,7 @@ msgid "<b>Warning:</b> By changing the owner of this collection, you will no lon
 msgstr "<b>Warning:</b> By changing the owner of this collection, you will no longer be able to edit it. You will only be able to add and remove add-ons from it."
 
 #: src/olympia/bandwagon/templates/bandwagon/edit_contributors.html:83 src/olympia/devhub/templates/devhub/addons/forms_shared/media.html:157
-#: src/olympia/devhub/templates/devhub/addons/submit/describe.html:69 src/olympia/devhub/templates/devhub/addons/submit/license.html:60 src/olympia/devhub/templates/devhub/addons/submit/upload.html:78
+#: src/olympia/devhub/templates/devhub/addons/submit/describe.html:69 src/olympia/devhub/templates/devhub/addons/submit/license.html:60 src/olympia/devhub/templates/devhub/addons/submit/upload.html:70
 #: src/olympia/devhub/templates/devhub/payments/tier.html:17 src/olympia/editors/templates/editors/themes/themes.html:111 src/olympia/editors/templates/editors/themes/themes.html:128
 #: src/olympia/editors/templates/editors/themes/themes.html:134 src/olympia/editors/templates/editors/themes/themes.html:141 src/olympia/users/templates/users/fxa_migration_prompt_content.html:10
 #: src/olympia/users/templates/users/login_form.html:42 src/olympia/users/templates/users/mobile/login.html:57
@@ -2646,43 +2655,42 @@ msgstr "Reset"
 
 #: src/olympia/bandwagon/templates/bandwagon/includes/addedit.html:53
 msgid "PNG and JPG supported.  Image will be resized to 32x32."
-msgstr "PNG and JPG supported.  Image will be resized to 32x32."
+msgstr ""
 
 #: src/olympia/bandwagon/templates/bandwagon/includes/addedit_errors.html:3
 msgid "There are errors in this form.  Please correct them below."
-msgstr "There are errors in this form.  Please correct them below."
+msgstr ""
 
 #: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:2
 msgid "Add-ons in Your Collection"
 msgstr "Add-ons in Your Collection"
 
 #: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:4
-msgid ""
-"To include an add-on in this collection, enter its name in the box below and hit enter.  You can also use the <strong>Add to Collection</strong> links throughout the site to include add-ons later."
+msgid "To include an add-on in this collection, enter its name in the box below and hit enter."
 msgstr ""
-"To include an add-on in this collection, enter its name in the box below and hit enter.  You can also use the <strong>Add to Collection</strong> links throughout the site to include add-ons later."
 
-#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:17 src/olympia/constants/base.py:400 src/olympia/devhub/templates/devhub/addons/activity.html:62
+#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:15 src/olympia/constants/base.py:400 src/olympia/devhub/templates/devhub/addons/activity.html:62
+#: src/olympia/editors/helpers.py:273 src/olympia/editors/helpers.py:360
 msgid "Add-on"
 msgstr "Add-on"
 
-#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:26
+#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:24
 msgid "Enter the name of the add-on to include"
 msgstr "Enter the name of the add-on to include"
 
-#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:28
+#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:26
 msgid "Add to Collection"
 msgstr "Add to Collection"
 
-#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:45 src/olympia/editors/helpers.py:936 src/olympia/editors/helpers.py:956
+#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:43 src/olympia/editors/helpers.py:1016 src/olympia/editors/helpers.py:1036
 msgid "Pending"
 msgstr "Pending"
 
-#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:47
+#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:45
 msgid "Add a comment"
 msgstr "Add a comment"
 
-#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:48
+#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:46
 msgid "Remove this add-on from the collection"
 msgstr "Remove this add-on from the collection"
 
@@ -2733,8 +2741,6 @@ msgid ""
 "When Mozilla becomes aware of add-ons, plugins, or other third-party software that seriously compromises %(app)s security, stability, or performance and meets <a href=\"%(criteria)s\">certain "
 "criteria</a>, the software may be blocked from general use.  For more information, please read <a href=\"%(support)s\">this support article</a>."
 msgstr ""
-"When Mozilla becomes aware of add-ons, plugins, or other third-party software that seriously compromises %(app)s security, stability, or performance and meets <a href=\"%(criteria)s\">certain "
-"criteria</a>, the software may be blocked from general use.  For more information, please read <a href=\"%(support)s\">this support article</a>."
 
 #: src/olympia/blocklist/templates/blocklist/blocked_detail.html:44
 #, python-format
@@ -2791,12 +2797,12 @@ msgstr "Search tools"
 msgid "Most Users"
 msgstr "Most Users"
 
-#: src/olympia/browse/views.py:61 src/olympia/browse/views.py:72 src/olympia/browse/views.py:279 src/olympia/browse/templates/browse/personas/mobile/category_landing.html:63
+#: src/olympia/browse/views.py:61 src/olympia/browse/views.py:72 src/olympia/browse/views.py:246 src/olympia/browse/templates/browse/personas/mobile/category_landing.html:63
 #: src/olympia/discovery/templates/discovery/pane.html:67 src/olympia/search/forms.py:92
 msgid "Up & Coming"
 msgstr "Up & Coming"
 
-#: src/olympia/browse/views.py:460 src/olympia/devhub/views.py:76 src/olympia/devhub/views.py:83 src/olympia/discovery/templates/discovery/addons/detail.html:66
+#: src/olympia/browse/views.py:427 src/olympia/devhub/views.py:74 src/olympia/devhub/views.py:81 src/olympia/discovery/templates/discovery/addons/detail.html:66
 msgid "Created"
 msgstr "Created"
 
@@ -2984,8 +2990,8 @@ msgid_plural "See all %(cnt)s extensions in %(name)s &raquo;"
 msgstr[0] "See the %(cnt)s extension in %(name)s &raquo;"
 msgstr[1] "See all %(cnt)s extensions in %(name)s &raquo;"
 
-#: src/olympia/browse/templates/browse/mobile/extensions.html:13 src/olympia/compat/templates/compat/index.html:82 src/olympia/devhub/templates/devhub/devhub_search.html:24
-#: src/olympia/devhub/templates/devhub/addons/activity.html:47 src/olympia/search/templates/search/no_results.html:4 src/olympia/search/templates/search/mobile/results.html:36
+#: src/olympia/browse/templates/browse/mobile/extensions.html:13 src/olympia/devhub/templates/devhub/devhub_search.html:24 src/olympia/devhub/templates/devhub/addons/activity.html:47
+#: src/olympia/search/templates/search/no_results.html:4 src/olympia/search/templates/search/mobile/results.html:36
 msgid "No results found."
 msgstr "No results found."
 
@@ -3070,7 +3076,7 @@ msgstr "&laquo; All Themes"
 msgid "All"
 msgstr "All"
 
-#: src/olympia/compat/forms.py:22 src/olympia/search/views.py:525
+#: src/olympia/compat/forms.py:22 src/olympia/editors/templates/editors/base.html:69 src/olympia/search/views.py:518
 msgid "All Add-ons"
 msgstr "All Add-ons"
 
@@ -3081,53 +3087,6 @@ msgstr "Binary"
 #: src/olympia/compat/forms.py:24
 msgid "Non-binary"
 msgstr "Non-binary"
-
-#. Review points sources other than add-ons and themes.
-#: src/olympia/compat/views.py:87 src/olympia/constants/base.py:388 src/olympia/devhub/forms.py:162 src/olympia/editors/templates/editors/performance.html:75
-msgid "Other"
-msgstr "Other"
-
-#: src/olympia/compat/templates/compat/index.html:4
-msgid "Add-on Compatibility Report for {app} {version}"
-msgstr "Add-on Compatibility Report for {app} {version}"
-
-#: src/olympia/compat/templates/compat/index.html:11
-msgid "{app} {version} Compatibility"
-msgstr "{app} {version} Compatibility"
-
-#: src/olympia/compat/templates/compat/index.html:17
-#, python-format
-msgid "Top 95%% compatible with previous version"
-msgstr "Top 95%% compatible with previous version"
-
-#: src/olympia/compat/templates/compat/index.html:18
-#, python-format
-msgid "Top 95%% of all add-ons"
-msgstr "Top 95%% of all add-ons"
-
-#: src/olympia/compat/templates/compat/index.html:19
-msgid "All active add-ons"
-msgstr "All active add-ons"
-
-#: src/olympia/compat/templates/compat/index.html:23 src/olympia/constants/base.py:401
-msgid "App"
-msgstr "App"
-
-#: src/olympia/compat/templates/compat/index.html:55
-msgid "Details for add-ons compatible with previous version:"
-msgstr "Details for add-ons compatible with previous version:"
-
-#: src/olympia/compat/templates/compat/index.html:57
-msgid "Show all versions"
-msgstr "Show all versions"
-
-#: src/olympia/compat/templates/compat/index.html:59
-msgid "Details for add-ons compatible with all versions:"
-msgstr "Details for add-ons compatible with all versions:"
-
-#: src/olympia/compat/templates/compat/index.html:61
-msgid "Show previous version only"
-msgstr "Show previous version only"
 
 #: src/olympia/compat/templates/compat/reporter.html:3
 msgid "Add-on Compatibility Reports"
@@ -3182,8 +3141,8 @@ msgstr "Filter by Application"
 msgid "Report Type"
 msgstr "Report Type"
 
-#: src/olympia/compat/templates/compat/reporter_detail.html:47 src/olympia/devhub/forms.py:784 src/olympia/devhub/templates/devhub/addons/ajax_compat_update.html:17 src/olympia/editors/forms.py:108
-#: src/olympia/zadmin/forms.py:45
+#: src/olympia/compat/templates/compat/reporter_detail.html:47 src/olympia/devhub/forms.py:785 src/olympia/devhub/templates/devhub/addons/ajax_compat_update.html:17 src/olympia/editors/forms.py:108
+#: src/olympia/editors/forms.py:248 src/olympia/zadmin/forms.py:45
 msgid "Application"
 msgstr "Application"
 
@@ -3271,7 +3230,8 @@ msgstr "Preliminarily Reviewed"
 msgid "Preliminarily Reviewed and Awaiting Full Review"
 msgstr "Preliminarily Reviewed and Awaiting Full Review"
 
-#: src/olympia/constants/base.py:33 src/olympia/editors/helpers.py:924 src/olympia/editors/templates/editors/themes/history_table.html:34
+#: src/olympia/constants/base.py:33 src/olympia/editors/forms.py:258 src/olympia/editors/helpers.py:73 src/olympia/editors/helpers.py:1004
+#: src/olympia/editors/templates/editors/themes/history_table.html:34
 msgid "Deleted"
 msgstr "Deleted"
 
@@ -3368,6 +3328,11 @@ msgstr "Ask after users start downloading this add-on"
 msgid "Ask before users can download this add-on"
 msgstr "Ask before users can download this add-on"
 
+#. Review points sources other than add-ons and themes.
+#: src/olympia/constants/base.py:388 src/olympia/devhub/forms.py:162 src/olympia/editors/templates/editors/performance.html:75
+msgid "Other"
+msgstr "Other"
+
 #: src/olympia/constants/base.py:389
 msgid "Exception"
 msgstr "Exception"
@@ -3379,6 +3344,10 @@ msgstr "Release"
 #: src/olympia/constants/base.py:391
 msgid "Change"
 msgstr "Change"
+
+#: src/olympia/constants/base.py:401
+msgid "App"
+msgstr "App"
 
 #: src/olympia/constants/base.py:402
 msgid "Persona"
@@ -3528,7 +3497,7 @@ msgstr "Flag"
 msgid "Duplicate"
 msgstr "Duplicate"
 
-#: src/olympia/constants/editors.py:17 src/olympia/editors/helpers.py:502 src/olympia/editors/templates/editors/themes/queue.html:71 src/olympia/editors/templates/editors/themes/themes.html:94
+#: src/olympia/constants/editors.py:17 src/olympia/editors/helpers.py:575 src/olympia/editors/templates/editors/themes/queue.html:71 src/olympia/editors/templates/editors/themes/themes.html:94
 msgid "Reject"
 msgstr "Reject"
 
@@ -3628,7 +3597,7 @@ msgstr "Solaris"
 msgid "Android"
 msgstr "Android"
 
-#: src/olympia/core/apps.py:19
+#: src/olympia/core/apps.py:21
 msgid "Core"
 msgstr "Core"
 
@@ -3762,8 +3731,8 @@ msgid "Submit my add-on for manual review."
 msgstr "Submit my add-on for manual review."
 
 #: src/olympia/devhub/forms.py:537
-msgid "Do not list my add-on on this site (beta)"
-msgstr "Do not list my add-on on this site (beta)"
+msgid "Do not list my add-on on this site"
+msgstr ""
 
 #: src/olympia/devhub/forms.py:538
 msgid "Check this option if you intend to distribute your add-on on your own and only need it to be signed by Mozilla."
@@ -3795,46 +3764,46 @@ msgstr "A file with a version ending with a|alpha|b|beta|pre|rc and an optional 
 
 #: src/olympia/devhub/forms.py:592
 #, python-format
-msgid "Version %s already exists"
-msgstr "Version %s already exists"
+msgid "Version %s already exists, or was uploaded before."
+msgstr ""
 
-#: src/olympia/devhub/forms.py:604
+#: src/olympia/devhub/forms.py:605
 msgid "Select a valid choice. That choice is not one of the available choices."
 msgstr "Select a valid choice. That choice is not one of the available choices."
 
-#: src/olympia/devhub/forms.py:610
+#: src/olympia/devhub/forms.py:611
 msgid "A file with a version ending with a|alpha|b|beta and an optional number is detected as beta."
 msgstr "A file with a version ending with a|alpha|b|beta and an optional number is detected as beta."
 
-#: src/olympia/devhub/forms.py:633
+#: src/olympia/devhub/forms.py:634
 msgid "You cannot upload any more files for this version."
 msgstr "You cannot upload any more files for this version."
 
-#: src/olympia/devhub/forms.py:639
+#: src/olympia/devhub/forms.py:640
 msgid "Version doesn't match"
 msgstr "Version doesn't match"
 
-#: src/olympia/devhub/forms.py:668
+#: src/olympia/devhub/forms.py:669
 msgid "You cannot delete a file once the review process has started.  You must delete the whole version."
-msgstr "You cannot delete a file once the review process has started.  You must delete the whole version."
+msgstr ""
 
-#: src/olympia/devhub/forms.py:688
+#: src/olympia/devhub/forms.py:689
 msgid "The platform All cannot be combined with specific platforms."
 msgstr "The platform All cannot be combined with specific platforms."
 
-#: src/olympia/devhub/forms.py:693
+#: src/olympia/devhub/forms.py:694
 msgid "A platform can only be chosen once."
 msgstr "A platform can only be chosen once."
 
-#: src/olympia/devhub/forms.py:706
+#: src/olympia/devhub/forms.py:707
 msgid "A review type must be selected."
 msgstr "A review type must be selected."
 
-#: src/olympia/devhub/forms.py:788 src/olympia/editors/forms.py:114 src/olympia/zadmin/forms.py:49 src/olympia/zadmin/forms.py:52
+#: src/olympia/devhub/forms.py:789 src/olympia/editors/forms.py:114 src/olympia/editors/forms.py:254 src/olympia/zadmin/forms.py:49 src/olympia/zadmin/forms.py:52
 msgid "Select an application first"
 msgstr "Select an application first"
 
-#: src/olympia/devhub/forms.py:840
+#: src/olympia/devhub/forms.py:841
 msgid "There cannot be more than 3 required add-ons."
 msgstr "There cannot be more than 3 required add-ons."
 
@@ -3868,76 +3837,76 @@ msgstr[1] "{0} warnings"
 msgid "Review"
 msgstr "Review"
 
-#: src/olympia/devhub/tasks.py:551
+#: src/olympia/devhub/tasks.py:583
 #, python-format
 msgid "%s responded with %s (%s)."
 msgstr "%s responded with %s (%s)."
 
-#: src/olympia/devhub/tasks.py:555
+#: src/olympia/devhub/tasks.py:587
 #, python-format
 msgid "Connection to \"%s\" timed out."
 msgstr "Connection to \"%s\" timed out."
 
-#: src/olympia/devhub/tasks.py:557
+#: src/olympia/devhub/tasks.py:589
 #, python-format
 msgid "Could not contact host at \"%s\"."
 msgstr "Could not contact host at \"%s\"."
 
-#: src/olympia/devhub/utils.py:104
+#: src/olympia/devhub/utils.py:105
 #, python-format
 msgid "Validation generated too many errors/warnings so %s messages were truncated. After addressing the visible messages, you'll be able to see the others."
 msgstr "Validation generated too many errors/warnings so %s messages were truncated. After addressing the visible messages, you'll be able to see the others."
 
-#: src/olympia/devhub/views.py:183
+#: src/olympia/devhub/views.py:181
 msgid "All My Add-ons"
 msgstr "All My Add-ons"
 
-#: src/olympia/devhub/views.py:210
+#: src/olympia/devhub/views.py:208
 msgid "All Activity"
 msgstr "All Activity"
 
-#: src/olympia/devhub/views.py:211
+#: src/olympia/devhub/views.py:209
 msgid "Add-on Updates"
 msgstr "Add-on Updates"
 
-#: src/olympia/devhub/views.py:212
+#: src/olympia/devhub/views.py:210
 msgid "Add-on Status"
 msgstr "Add-on Status"
 
-#: src/olympia/devhub/views.py:213
+#: src/olympia/devhub/views.py:211
 msgid "User Collections"
 msgstr "User Collections"
 
-#: src/olympia/devhub/views.py:214 src/olympia/devhub/templates/devhub/docs/policies-maintenance.html:68 src/olympia/pages/templates/pages/dev_faq.html:38
+#: src/olympia/devhub/views.py:212 src/olympia/devhub/templates/devhub/docs/policies-maintenance.html:68 src/olympia/pages/templates/pages/dev_faq.html:38
 #: src/olympia/pages/templates/pages/dev_faq.html:484
 msgid "User Reviews"
 msgstr "User Reviews"
 
-#: src/olympia/devhub/views.py:327 src/olympia/devhub/views.py:331 src/olympia/devhub/views.py:484 src/olympia/devhub/views.py:513 src/olympia/devhub/views.py:564 src/olympia/devhub/views.py:1150
+#: src/olympia/devhub/views.py:325 src/olympia/devhub/views.py:329 src/olympia/devhub/views.py:484 src/olympia/devhub/views.py:513 src/olympia/devhub/views.py:564 src/olympia/devhub/views.py:1156
 msgid "Changes successfully saved."
 msgstr "Changes successfully saved."
 
-#: src/olympia/devhub/views.py:334 src/olympia/devhub/views.py:1631
+#: src/olympia/devhub/views.py:332 src/olympia/devhub/views.py:1637
 msgid "Please check the form for errors."
 msgstr "Please check the form for errors."
 
-#: src/olympia/devhub/views.py:346
+#: src/olympia/devhub/views.py:344
 msgid "Add-on cannot be deleted. Disable this add-on instead."
 msgstr "Add-on cannot be deleted. Disable this add-on instead."
 
-#: src/olympia/devhub/views.py:356
+#: src/olympia/devhub/views.py:354
 msgid "Theme deleted."
 msgstr "Theme deleted."
 
-#: src/olympia/devhub/views.py:356
+#: src/olympia/devhub/views.py:354
 msgid "Add-on deleted."
 msgstr "Add-on deleted."
 
-#: src/olympia/devhub/views.py:362
+#: src/olympia/devhub/views.py:360
 msgid "URL name was incorrect. Theme was not deleted."
 msgstr "URL name was incorrect. Theme was not deleted."
 
-#: src/olympia/devhub/views.py:367
+#: src/olympia/devhub/views.py:365
 msgid "URL name was incorrect. Add-on was not deleted."
 msgstr "URL name was incorrect. Add-on was not deleted."
 
@@ -3965,7 +3934,7 @@ msgstr "Validate Add-on"
 msgid "Check Add-on Compatibility"
 msgstr "Check Add-on Compatibility"
 
-#: src/olympia/devhub/views.py:808 src/olympia/signing/views.py:90
+#: src/olympia/devhub/views.py:808 src/olympia/signing/views.py:95
 msgid "You cannot submit this type of add-on"
 msgstr "You cannot submit this type of add-on"
 
@@ -3995,33 +3964,33 @@ msgstr "Image must be exactly {0} pixels wide and {1} pixels tall."
 msgid "There was an error uploading your preview."
 msgstr "There was an error uploading your preview."
 
-#: src/olympia/devhub/views.py:1189
+#: src/olympia/devhub/views.py:1195
 #, python-format
 msgid "Version %s disabled."
 msgstr "Version %s disabled."
 
-#: src/olympia/devhub/views.py:1193
+#: src/olympia/devhub/views.py:1199
 #, python-format
 msgid "Version %s deleted."
 msgstr "Version %s deleted."
 
-#: src/olympia/devhub/views.py:1203
+#: src/olympia/devhub/views.py:1209
 msgid "This upload has failed validation, and may lack complete validation results. Please take due care when reviewing it."
 msgstr "This upload has failed validation, and may lack complete validation results. Please take due care when reviewing it."
 
-#: src/olympia/devhub/views.py:1677
+#: src/olympia/devhub/views.py:1683
 msgid "Preliminary Review Requested."
 msgstr "Preliminary Review Requested."
 
-#: src/olympia/devhub/views.py:1678
+#: src/olympia/devhub/views.py:1684
 msgid "Full Review Requested."
 msgstr "Full Review Requested."
 
-#: src/olympia/devhub/views.py:1779
+#: src/olympia/devhub/views.py:1783
 msgid "Your old credentials were revoked and are no longer valid. Be sure to update all API clients with the new credentials."
 msgstr "Your old credentials were revoked and are no longer valid. Be sure to update all API clients with the new credentials."
 
-#: src/olympia/devhub/views.py:1797
+#: src/olympia/devhub/views.py:1801
 msgid "New API key created"
 msgstr "New API key created"
 
@@ -4051,7 +4020,7 @@ msgstr "Back to Add-ons"
 msgid "{0} :: Search"
 msgstr "{0} :: Search"
 
-#: src/olympia/devhub/templates/devhub/devhub_search.html:6 src/olympia/devhub/templates/devhub/search.html:8 src/olympia/editors/forms.py:435 src/olympia/editors/forms.py:437
+#: src/olympia/devhub/templates/devhub/devhub_search.html:6 src/olympia/devhub/templates/devhub/search.html:8 src/olympia/editors/forms.py:534 src/olympia/editors/forms.py:536
 #: src/olympia/editors/templates/editors/queue.html:27 src/olympia/editors/templates/editors/themes/queue_list.html:14 src/olympia/search/templates/search/collections.html:17
 #: src/olympia/search/templates/search/personas.html:18 src/olympia/search/templates/search/results.html:18 src/olympia/search/templates/search/mobile/results.html:8
 #: src/olympia/templates/search.html:14 src/olympia/templates/impala/search.html:18
@@ -4114,12 +4083,12 @@ msgstr "Head over to the <a href=\"https://developer.mozilla.org/Add-ons\">Mozil
 msgid "Start Making Add-ons"
 msgstr "Start Making Add-ons"
 
-#: src/olympia/devhub/templates/devhub/index.html:86 src/olympia/devhub/templates/devhub/addons/listing/items.html:25 src/olympia/devhub/templates/devhub/includes/addon_details.html:15
+#: src/olympia/devhub/templates/devhub/index.html:86 src/olympia/devhub/templates/devhub/addons/listing/items.html:25 src/olympia/devhub/templates/devhub/includes/addon_details.html:20
 #: src/olympia/devhub/templates/devhub/personas/edit.html:43
 msgid "Status:"
 msgstr "Status:"
 
-#: src/olympia/devhub/templates/devhub/index.html:90 src/olympia/devhub/templates/devhub/includes/addon_details.html:100
+#: src/olympia/devhub/templates/devhub/index.html:90 src/olympia/devhub/templates/devhub/includes/addon_details.html:87
 msgid "Visibility:"
 msgstr "Visibility:"
 
@@ -4127,11 +4096,11 @@ msgstr "Visibility:"
 msgid "Latest Version:"
 msgstr "Latest Version:"
 
-#: src/olympia/devhub/templates/devhub/index.html:109 src/olympia/devhub/templates/devhub/includes/addon_details.html:145 src/olympia/devhub/templates/devhub/personas/edit.html:49
+#: src/olympia/devhub/templates/devhub/index.html:109 src/olympia/devhub/templates/devhub/includes/addon_details.html:131 src/olympia/devhub/templates/devhub/personas/edit.html:49
 msgid "Queue Position:"
 msgstr "Queue Position:"
 
-#: src/olympia/devhub/templates/devhub/index.html:110 src/olympia/devhub/templates/devhub/includes/addon_details.html:146 src/olympia/devhub/templates/devhub/personas/edit.html:50
+#: src/olympia/devhub/templates/devhub/index.html:110 src/olympia/devhub/templates/devhub/includes/addon_details.html:132 src/olympia/devhub/templates/devhub/personas/edit.html:50
 #, python-format
 msgid "%(position)s of %(total)s"
 msgstr "%(position)s of %(total)s"
@@ -4233,16 +4202,6 @@ msgstr "After upload, a series of automated validation tests will be run on your
 msgid "Do you want your add-on to be distributed on this site?"
 msgstr "Do you want your add-on to be distributed on this site?"
 
-#: src/olympia/devhub/templates/devhub/validate_addon.html:49 src/olympia/devhub/templates/devhub/addons/submit/upload.html:30 src/olympia/devhub/templates/devhub/versions/add_file_modal.html:14
-#: src/olympia/devhub/templates/devhub/versions/add_file_modal.html:53 src/olympia/devhub/templates/devhub/versions/list.html:298
-msgid "Warning:"
-msgstr "Warning:"
-
-#: src/olympia/devhub/templates/devhub/validate_addon.html:50 src/olympia/devhub/templates/devhub/addons/submit/upload.html:31
-#, python-format
-msgid "Submission of unlisted add-ons for signing is currently in an open beta. Please <a href=\"%(url)s\" target=\"_blank\">report any bugs</a> that you encounter."
-msgstr "Submission of unlisted add-ons for signing is currently in an open beta. Please <a href=\"%(url)s\" target=\"_blank\">report any bugs</a> that you encounter."
-
 #. first parameter is a filename like lorem-ipsum-1.0.2.xpi
 #: src/olympia/devhub/templates/devhub/validation.html:5
 msgid "Validation Results for {0}"
@@ -4321,7 +4280,7 @@ msgstr "Compatibility"
 msgid "Update Compatibility"
 msgstr "Update Compatibility"
 
-#: src/olympia/devhub/templates/devhub/addons/ajax_compat_update.html:4
+#: src/olympia/devhub/templates/devhub/addons/ajax_compat_update.html:4 src/olympia/devhub/templates/devhub/versions/edit.html:45
 msgid "Adjusting application information here will allow users to install your add-on even if the install manifest in the package indicates that the add-on is incompatible."
 msgstr "Adjusting application information here will allow users to install your add-on even if the install manifest in the package indicates that the add-on is incompatible."
 
@@ -4333,9 +4292,9 @@ msgstr "Supported Versions"
 msgid "Add Another Application&hellip;"
 msgstr "Add Another Application&hellip;"
 
-#: src/olympia/devhub/templates/devhub/addons/ajax_compat_update.html:38 src/olympia/devhub/templates/devhub/addons/owner.html:86 src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:46
-#: src/olympia/devhub/templates/devhub/versions/list.html:351 src/olympia/devhub/templates/devhub/versions/list.html:353 src/olympia/templates/impala/base.html:132
-#: src/olympia/templates/impala/base.html:143 src/olympia/templates/impala/base.html:161 src/olympia/templates/impala/base.html:171
+#: src/olympia/devhub/templates/devhub/addons/ajax_compat_update.html:38 src/olympia/devhub/templates/devhub/addons/owner.html:86 src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:45
+#: src/olympia/devhub/templates/devhub/versions/list.html:349 src/olympia/devhub/templates/devhub/versions/list.html:351 src/olympia/templates/impala/base.html:129
+#: src/olympia/templates/impala/base.html:140 src/olympia/templates/impala/base.html:158 src/olympia/templates/impala/base.html:168
 msgid "Close"
 msgstr "Close"
 
@@ -4369,7 +4328,7 @@ msgstr "None"
 msgid "Manage Authors & License"
 msgstr "Manage Authors & Licence"
 
-#: src/olympia/devhub/templates/devhub/addons/owner.html:29 src/olympia/editors/templates/editors/review.html:270
+#: src/olympia/devhub/templates/devhub/addons/owner.html:29 src/olympia/editors/helpers.py:362 src/olympia/editors/templates/editors/review.html:270
 msgid "Authors"
 msgstr "Authors"
 
@@ -4441,10 +4400,7 @@ msgstr "Summary"
 
 #: src/olympia/devhub/templates/devhub/addons/edit/basic.html:52
 msgid ""
-"A short explanation of your add-on's basic\n"
-"                          functionality that is displayed in search and browse\n"
-"                          listings, as well as at the top of your add-on's\n"
-"                          details page. It is only relevant for listed add-ons."
+"A short explanation of your add-on's basic functionality that is displayed in search and browse listings, as well as at the top of your add-on's details page. It is only relevant for listed add-ons."
 msgstr ""
 "A short explanation of your add-on's basic\n"
 "                          functionality that is displayed in search and browse\n"
@@ -4452,10 +4408,7 @@ msgstr ""
 "                          details page. It is only relevant for listed add-ons."
 
 #: src/olympia/devhub/templates/devhub/addons/edit/basic.html:73
-msgid ""
-"Categories are the primary way users browse through add-ons.\n"
-"                        Choose any that fit your add-on's functionality for the most\n"
-"                        exposure. It is only relevant for listed add-ons."
+msgid "Categories are the primary way users browse through add-ons. Choose any that fit your add-on's functionality for the most exposure. It is only relevant for listed add-ons."
 msgstr ""
 "Categories are the primary way users browse through add-ons.\n"
 "                        Choose any that fit your add-on's functionality for the most\n"
@@ -4469,11 +4422,7 @@ msgstr ""
 "Categories cannot be changed while your add-on is featured for this application. Please email <a href=\"mailto:%(email)s\">%(email)s</a> if there is a reason you need to modify your categories."
 
 #: src/olympia/devhub/templates/devhub/addons/edit/basic.html:119
-msgid ""
-"Tags help users find your add-on and should be short\n"
-"                        descriptors such as tabs, toolbar, or twitter.  You\n"
-"                        may have a maximum of {0} tags. It is only relevant\n"
-"                        for listed add-ons."
+msgid "Tags help users find your add-on and should be short descriptors such as tabs, toolbar, or twitter. You may have a maximum of {0} tags. It is only relevant for listed add-ons."
 msgstr ""
 "Tags help users find your add-on and should be short\n"
 "                        descriptors such as tabs, toolbar, or twitter.  You\n"
@@ -4505,11 +4454,7 @@ msgid "Add-on Details for {0}"
 msgstr "Add-on Details for {0}"
 
 #: src/olympia/devhub/templates/devhub/addons/edit/details.html:22
-msgid ""
-"A longer explanation of features,\n"
-"                          functionality, and other relevant information. This\n"
-"                          field is only displayed on the add-on's details\n"
-"                          page. It is only relevant for listed add-ons."
+msgid "A longer explanation of features, functionality, and other relevant information. This field is only displayed on the add-on's details page. It is only relevant for listed add-ons."
 msgstr ""
 "A longer explanation of features,\n"
 "                          functionality, and other relevant information. This\n"
@@ -4521,10 +4466,7 @@ msgid "Default Locale"
 msgstr "Default Locale"
 
 #: src/olympia/devhub/templates/devhub/addons/edit/details.html:45
-msgid ""
-"Information about your add-on is displayed in this locale\n"
-"                        unless you override it with a locale-specific translation.\n"
-"                        It is only relevant for listed add-ons."
+msgid "Information about your add-on is displayed in this locale unless you override it with a locale-specific translation. It is only relevant for listed add-ons."
 msgstr ""
 "Information about your add-on is displayed in this locale\n"
 "                        unless you override it with a locale-specific translation.\n"
@@ -4537,10 +4479,8 @@ msgstr "Homepage"
 
 #: src/olympia/devhub/templates/devhub/addons/edit/details.html:63
 msgid ""
-"If your add-on has another homepage, enter its\n"
-"                          address here. If your website is localized into other\n"
-"                          languages multiple translations of this field can be\n"
-"                          added. It is only relevant for listed add-ons."
+"If your add-on has another homepage, enter its address here. If your website is localized into other languages multiple translations of this field can be added. It is only relevant for listed add-"
+"ons."
 msgstr ""
 "If your add-on has another homepage, enter its\n"
 "                          address here. If your web site is localised into other\n"
@@ -4562,11 +4502,8 @@ msgstr "Support Information for {0}"
 
 #: src/olympia/devhub/templates/devhub/addons/edit/support.html:22
 msgid ""
-"If you wish to display an e-mail address for support\n"
-"                          inquiries, enter it here. If you have different\n"
-"                          addresses for each language multiple translations of\n"
-"                          this field can be added. It is only relevant for\n"
-"                          listed add-ons."
+"If you wish to display an e-mail address for support inquiries, enter it here. If you have different addresses for each language multiple translations of this field can be added. It is only "
+"relevant for listed add-ons."
 msgstr ""
 "If you wish to display an e-mail address for support\n"
 "                          inquiries, enter it here. If you have different\n"
@@ -4576,10 +4513,8 @@ msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/support.html:45
 msgid ""
-"If your add-on has a support website or forum, enter\n"
-"                          its address here. If your website is localized into\n"
-"                          other languages, multiple translations of this field can\n"
-"                          be added. It is only relevant for listed add-ons."
+"If your add-on has a support website or forum, enter its address here. If your website is localized into other languages, multiple translations of this field can be added. It is only relevant for "
+"listed add-ons."
 msgstr ""
 "If your add-on has a support web site or forum, enter\n"
 "                          its address here. If your web site is localised into\n"
@@ -4597,11 +4532,8 @@ msgstr "Technical Details for {0}"
 
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:23
 msgid ""
-"Any information end users may want to know that isn't\n"
-"                          necessarily applicable to the add-on summary or description.\n"
-"                          Common uses include listing known major bugs, information on\n"
-"                          how to report bugs, anticipated release date of a new version,\n"
-"                          etc. It is only relevant for listed add-ons."
+"Any information end users may want to know that isn't necessarily applicable to the add-on summary or description. Common uses include listing known major bugs, information on how to report bugs, "
+"anticipated release date of a new version, etc. It is only relevant for listed add-ons."
 msgstr ""
 "Any information end users may want to know that isn't\n"
 "                          necessarily applicable to the add-on summary or description.\n"
@@ -4618,9 +4550,7 @@ msgid "Add-on Flags"
 msgstr "Add-on Flags"
 
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:69
-msgid ""
-"These flags are used to classify add-ons. It is only\n"
-"                        relevant for listed add-ons."
+msgid "These flags are used to classify add-ons. It is only relevant for listed add-ons."
 msgstr ""
 "These flags are used to classify add-ons. It is only\n"
 "                        relevant for listed add-ons."
@@ -4638,9 +4568,7 @@ msgid "View Source?"
 msgstr "View Source?"
 
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:90
-msgid ""
-"Whether the source of your add-on can be displayed in our\n"
-"                        online viewer. It is only relevant for listed add-ons."
+msgid "Whether the source of your add-on can be displayed in our online viewer. It is only relevant for listed add-ons."
 msgstr ""
 "Whether the source of your add-on can be displayed in our\n"
 "                        online viewer. It is only relevant for listed add-ons."
@@ -4658,10 +4586,7 @@ msgid "Public Stats?"
 msgstr "Public Stats?"
 
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:102
-msgid ""
-"Whether the download and usage stats of your add-on can\n"
-"                        be displayed in our online viewer.\n"
-"                        It is only relevant for listed add-ons."
+msgid "Whether the download and usage stats of your add-on can be displayed in our online viewer. It is only relevant for listed add-ons."
 msgstr ""
 "Whether the download and usage stats of your add-on can\n"
 "                        be displayed in our online viewer.\n"
@@ -4680,10 +4605,7 @@ msgid "Upgrade SDK?"
 msgstr "Upgrade SDK?"
 
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:116
-msgid ""
-"If selected, we will try to automatically upgrade your\n"
-"                        add-on when a new version of the SDK is released.\n"
-"                        It is only relevant for listed add-ons."
+msgid "If selected, we will try to automatically upgrade your add-on when a new version of the SDK is released. It is only relevant for listed add-ons."
 msgstr ""
 "If selected, we will try to automatically upgrade your\n"
 "                        add-on when a new version of the SDK is released.\n"
@@ -4739,10 +4661,8 @@ msgstr "Add-on icon"
 
 #: src/olympia/devhub/templates/devhub/addons/forms_shared/media.html:16
 msgid ""
-"Upload an icon for your add-on or choose from one of ours. The\n"
-"                      icon is displayed nearly everywhere your add-on is. Uploaded images\n"
-"                      must be one of the following image types: .png, .jpg.\n"
-"                      It is only relevant for listed add-ons."
+"Upload an icon for your add-on or choose from one of ours. The icon is displayed nearly everywhere your add-on is. Uploaded images must be one of the following image types: .png, .jpg. It is only "
+"relevant for listed add-ons."
 msgstr ""
 "Upload an icon for your add-on or choose from one of ours. The\n"
 "                      icon is displayed nearly everywhere your add-on is. Uploaded images\n"
@@ -4759,9 +4679,7 @@ msgid "32x32px"
 msgstr "32x32px"
 
 #: src/olympia/devhub/templates/devhub/addons/forms_shared/media.html:39
-msgid ""
-"Used in listings of add-ons, like search results\n"
-"                            and featured add-ons."
+msgid "Used in listings of add-ons, like search results and featured add-ons."
 msgstr ""
 "Used in listings of add-ons, like search results\n"
 "                            and featured add-ons."
@@ -4858,18 +4776,16 @@ msgid "Deleting your add-on will permanently remove it from the site and prevent
 msgstr "Deleting your add-on will permanently remove it from the site and prevent its GUID from being submitted again by others."
 
 #: src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:24
-msgid ""
-"Enter the following text confirm your decision:\n"
-"           {slug}"
+msgid "Enter the following text confirm your decision: {slug}"
 msgstr ""
 "Enter the following text confirm your decision:\n"
 "           {slug}"
 
-#: src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:34
+#: src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:33
 msgid "Please tell us why you are deleting your theme:"
 msgstr "Please tell us why you are deleting your theme:"
 
-#: src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:36
+#: src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:35
 msgid "Please tell us why you are deleting your add-on:"
 msgstr "Please tell us why you are deleting your add-on:"
 
@@ -4906,8 +4822,8 @@ msgstr "New Version"
 msgid "Daily statistics on downloads and users."
 msgstr "Daily statistics on downloads and users."
 
-#: src/olympia/devhub/templates/devhub/addons/listing/item_actions.html:45 src/olympia/stats/templates/stats/stats.html:75 src/olympia/stats/templates/stats/stats.html:79
-#: src/olympia/stats/templates/stats/stats.html:81
+#: src/olympia/devhub/templates/devhub/addons/listing/item_actions.html:45 src/olympia/stats/templates/stats/stats.html:31 src/olympia/stats/templates/stats/stats.html:35
+#: src/olympia/stats/templates/stats/stats.html:37
 msgid "Statistics"
 msgstr "Statistics"
 
@@ -5026,10 +4942,7 @@ msgid "Your add-on has been submitted to the Full Review queue."
 msgstr "Your add-on has been submitted to the Full Review queue."
 
 #: src/olympia/devhub/templates/devhub/addons/submit/done.html:18
-msgid ""
-"You'll receive an email once it has been reviewed by an editor. In\n"
-"          the meantime, you and your friends can install it directly from its\n"
-"          details page:"
+msgid "You'll receive an email once it has been reviewed by an editor. In the meantime, you and your friends can install it directly from its details page:"
 msgstr ""
 "You'll receive an email once it has been reviewed by an editor. In\n"
 "          the meantime, you and your friends can install it directly from its\n"
@@ -5242,11 +5155,11 @@ msgstr "Step 2. Upload Your Add-on"
 msgid "Use the fields below to upload your add-on package and select any platform restrictions. After upload, a series of automated validation tests will be run on your file."
 msgstr "Use the fields below to upload your add-on package and select any platform restrictions. After upload, a series of automated validation tests will be run on your file."
 
-#: src/olympia/devhub/templates/devhub/addons/submit/upload.html:59 src/olympia/devhub/templates/devhub/versions/add_file_modal.html:39
+#: src/olympia/devhub/templates/devhub/addons/submit/upload.html:51 src/olympia/devhub/templates/devhub/versions/add_file_modal.html:28
 msgid "Which platforms is this file compatible with?"
 msgstr "Which platforms is this file compatible with?"
 
-#: src/olympia/devhub/templates/devhub/addons/submit/upload.html:67 src/olympia/devhub/templates/devhub/versions/add_file_modal.html:65
+#: src/olympia/devhub/templates/devhub/addons/submit/upload.html:59 src/olympia/devhub/templates/devhub/versions/add_file_modal.html:45
 msgid "Administrative overrides"
 msgstr "Administrative overrides"
 
@@ -5365,11 +5278,9 @@ msgstr "Web Site Functionality & Development"
 
 #: src/olympia/devhub/templates/devhub/docs/policies-contact.html:44
 msgid ""
-"If you've found a problem with the site, we'd love to fix it. Please <a href=\"https://github.com/mozilla/olympia/issues\">file a bug report</a> in GitHub, including the location of the problem and "
-"how you encountered it."
+"If you've found a problem with the site, we'd love to fix it. Please <a href=\"https://github.com/mozilla/addons/issues/new\">file a bug report</a> in GitHub, including the location of the problem "
+"and how you encountered it."
 msgstr ""
-"If you've found a problem with the site, we'd love to fix it. Please <a href=\"https://github.com/mozilla/olympia/issues\">file a bug report</a> in GitHub, including the location of the problem and "
-"how you encountered it."
 
 #: src/olympia/devhub/templates/devhub/docs/policies-maintenance.html:3 src/olympia/devhub/templates/devhub/docs/policies-maintenance.html:7
 #: src/olympia/devhub/templates/devhub/docs/policies-maintenance.html:8
@@ -6022,7 +5933,7 @@ msgstr "Private Browsing Mode"
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:282
 msgid ""
-"Add-ons that store or otherwise handle browsing data must support <a href=\"https://developer.mozilla.org/En/Supporting_private_browsing_mode\">Private Browsing Mode</a>.  During a Private Browsing "
+"Add-ons that store or otherwise handle browsing data must support <a href=\"https://developer.mozilla.org/En/Supporting_private_browsing_mode\">Private Browsing Mode</a>. During a Private Browsing "
 "session, no browsing data can be written to disk, and all of this data must be cleared when Firefox quits or the Private Browsing session ends."
 msgstr ""
 "Add-ons that store or otherwise handle browsing data must support <a href=\"https://developer.mozilla.org/En/Supporting_private_browsing_mode\">Private Browsing Mode</a>.  During a Private Browsing "
@@ -6233,165 +6144,128 @@ msgstr "Terms of Service for submitting your work to our site. Developers are re
 msgid "How to get in touch with us regarding these policies or your add-on."
 msgstr "How to get in touch with us regarding these policies or your add-on."
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:6
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:10
 msgid "You have disabled this add-on"
 msgstr "You have disabled this add-on"
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:20
-msgid ""
-"Your add-on's listing is disabled and is not showing\n"
-"                             anywhere in our gallery or update service."
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:24
+msgid "Your add-on's listing is disabled and is not showing anywhere in our gallery or update service."
 msgstr ""
 "Your add-on's listing is disabled and is not showing\n"
 "                             anywhere in our gallery or update service."
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:25
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:27
 msgid "Please complete your add-on."
 msgstr "Please complete your add-on."
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:29
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:30
 msgid "You will receive an email when the review is complete."
 msgstr "You will receive an email when the review is complete."
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:34
-msgid ""
-"You will receive an email when the review is complete. Until\n"
-"                             then, your add-on is not listed in our gallery but can be\n"
-"                             accessed directly from its details page."
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:33
+msgid "You will receive an email when the review is complete. Until then, your add-on is not listed in our gallery but can be accessed directly from its details page."
 msgstr ""
 "You will receive an email when the review is complete. Until\n"
 "                             then, your add-on is not listed in our gallery but can be\n"
 "                             accessed directly from its details page."
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:38 src/olympia/devhub/templates/devhub/includes/addon_details.html:48
-msgid ""
-"You will receive an email when the review is\n"
-"                             complete and your add-on is signed."
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:37 src/olympia/devhub/templates/devhub/includes/addon_details.html:45
+msgid "You will receive an email when the review is complete and your add-on is signed."
 msgstr ""
 "You will receive an email when the review is\n"
 "                             complete and your add-on is signed."
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:44
-msgid ""
-"You will receive an email when the review is complete. Until\n"
-"                             then, your add-on is not listed in our gallery but can be\n"
-"                             accessed directly from its details page. "
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:41
+msgid "You will receive an email when the review is complete. Until then, your add-on is not listed in our gallery but can be accessed directly from its details page. "
 msgstr ""
-"You will receive an email when the review is complete. Until\n"
-"                             then, your add-on is not listed in our gallery but can be\n"
-"                             accessed directly from its details page. "
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:54
-msgid ""
-"Your add-on is displayed in our gallery and users are\n"
-"                             receiving automatic updates."
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:49
+msgid "Your add-on is displayed in our gallery and users are receiving automatic updates."
 msgstr ""
 "Your add-on is displayed in our gallery and users are\n"
 "                             receiving automatic updates."
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:57
-msgid ""
-"Your add-on has been signed and can be bundled with an\n"
-"                             application installer."
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:52
+msgid "Your add-on has been signed and can be bundled with an application installer."
 msgstr ""
 "Your add-on has been signed and can be bundled with an\n"
 "                             application installer."
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:63
-msgid ""
-"Your add-on was disabled by a site administrator and is no\n"
-"                             longer shown in our gallery. If you have any questions,\n"
-"                             please email amo-admins@mozilla.org."
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:56
+msgid "Your add-on was disabled by a site administrator and is no longer shown in our gallery. If you have any questions, please email amo-admins@mozilla.org."
 msgstr ""
 "Your add-on was disabled by a site administrator and is no\n"
 "                             longer shown in our gallery. If you have any questions,\n"
 "                             please email amo-admins@mozilla.org."
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:70
-msgid ""
-"Your add-on is displayed in our gallery as experimental\n"
-"                             and users are receiving automatic updates. Some features\n"
-"                             are unavailable to your add-on."
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:62
+msgid "Your add-on is displayed in our gallery as experimental and users are receiving automatic updates. Some features are unavailable to your add-on."
 msgstr ""
 "Your add-on is displayed in our gallery as experimental\n"
 "                             and users are receiving automatic updates. Some features\n"
 "                             are unavailable to your add-on."
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:74
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:66
 msgid "Your add-on has been signed."
 msgstr "Your add-on has been signed."
 
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:69
+msgid ""
+"You will receive an email when the full review is complete. Until then, your add-on is displayed in our gallery as experimental and users are receiving automatic updates. Some features are "
+"unavailable to your add-on."
+msgstr ""
+"You will receive an email when the full review is complete.\n"
+"                             Until then, your add-on is displayed in our gallery as\n"
+"                             experimental and users are receiving automatic updates.\n"
+"                             Some features are unavailable to your add-on."
+
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:74
+msgid "You will receive an email when the full review is complete, making you able to bundle your add-on with an application installer."
+msgstr ""
+"You will receive an email when the full review is\n"
+"                             complete, making you able to bundle your add-on with an\n"
+"                             application installer."
+
 #: src/olympia/devhub/templates/devhub/includes/addon_details.html:79
-msgid ""
-"You will receive an email when the full review is complete.\n"
-"                             Until then, your add-on is displayed in our gallery as\n"
-"                             experimental and users are receiving automatic updates.\n"
-"                             Some features are unavailable to your add-on."
-msgstr ""
-"You will receive an email when the full review is complete.\n"
-"                             Until then, your add-on is displayed in our gallery as\n"
-"                             experimental and users are receiving automatic updates.\n"
-"                             Some features are unavailable to your add-on."
-
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:84
-msgid ""
-"You will receive an email when the full review is\n"
-"                             complete, making you able to bundle your add-on with an\n"
-"                             application installer."
-msgstr ""
-"You will receive an email when the full review is\n"
-"                             complete, making you able to bundle your add-on with an\n"
-"                             application installer."
-
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:91
-msgid ""
-"All add-ons hosted in our gallery must now be reviewed by an\n"
-"                             editor. If you wish to continue hosting your add-on, please\n"
-"                             click to select a review process."
+msgid "All add-ons hosted in our gallery must now be reviewed by an editor. If you wish to continue hosting your add-on, please click to select a review process."
 msgstr ""
 "All add-ons hosted in our gallery must now be reviewed by an\n"
 "                             editor. If you wish to continue hosting your add-on, please\n"
 "                             click to select a review process."
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:113
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:100
 msgid "Current Version:"
 msgstr "Current Version:"
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:115
-msgid ""
-"This is the version of your add-on that will\n"
-"                                           be installed if someone clicks the Install\n"
-"                                           button on addons.mozilla.org. It is only\n"
-"                                           relevant for listed add-ons."
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:102
+msgid "This is the version of your add-on that will be installed if someone clicks the Install button on addons.mozilla.org. It is only relevant for listed add-ons."
 msgstr ""
 "This is the version of your add-on that will\n"
 "                                           be installed if someone clicks the Install\n"
 "                                           button on addons.mozilla.org. It is only\n"
 "                                           relevant for listed add-ons."
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:123
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:110
 msgid "Created:"
 msgstr "Created:"
 
 #. {0} is a date. dennis-ignore: E201
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:125 src/olympia/devhub/templates/devhub/includes/addon_details.html:131
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:112 src/olympia/devhub/templates/devhub/includes/addon_details.html:118
 #, python-format
 msgid "%%b %%e, %%Y"
 msgstr "%%e %%b %%Y"
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:136
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:123
 msgid "Next Version:"
 msgstr "Next Version:"
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:138
-msgid ""
-"This is the newest uploaded version, however\n"
-"                                           it isn’t live on the site yet."
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:125
+msgid "This is the newest uploaded version, however it isn’t live on the site yet."
 msgstr ""
 "This is the newest uploaded version, however\n"
 "                                           it isn’t live on the site yet."
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:144 src/olympia/devhub/templates/devhub/versions/list.html:30
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:130 src/olympia/devhub/templates/devhub/versions/list.html:30
 msgid "Queues are not reviewed strictly in order"
 msgstr "Queues are not reviewed strictly in order"
 
@@ -6461,9 +6335,7 @@ msgid "View the blog &#9658;"
 msgstr "View the blog &#9658;"
 
 #: src/olympia/devhub/templates/devhub/includes/license_form.html:6
-msgid ""
-"Please choose a license appropriate for the rights you grant on your source code.\n"
-"                  It is only relevant for listed add-ons."
+msgid "Please choose a license appropriate for the rights you grant on your source code. It is only relevant for listed add-ons."
 msgstr ""
 "Please choose a licence appropriate for the rights you grant on your source code.\n"
 "                  It is only relevant for listed add-ons."
@@ -6481,8 +6353,7 @@ msgstr "Some HTML supported."
 msgid "Remove this application"
 msgstr "Remove this application"
 
-#. {0} is the maximum number of add-on categories allowed.                {1}
-#. is
+#. {0} is the maximum number of add-on categories allowed.                {1} is
 #. the application name.
 #: src/olympia/devhub/templates/devhub/includes/macros.html:70
 msgid "Select <b>up to {0}</b> {1} category for this add-on:"
@@ -6493,17 +6364,11 @@ msgstr[1] "Select <b>up to {0}</b> {1} categories for this add-on:"
 #: src/olympia/devhub/templates/devhub/includes/policy_form.html:4
 msgid ""
 "Users will be required to accept the following End-User License Agreement (EULA) prior to installing your add-on. The presence of a EULA significantly affects the number of downloads an add-on "
-"receives. Please note that a EULA is not the same as a code license, such as the GPL or MPL.\n"
-"                It is only relevant for listed add-ons."
+"receives. Please note that a EULA is not the same as a code license, such as the GPL or MPL.It is only relevant for listed add-ons."
 msgstr ""
-"Users will be required to accept the following End-User Licence Agreement (EULA) prior to installing your add-on. The presence of a EULA significantly affects the number of downloads an add-on "
-"receives. Please note that a EULA is not the same as a code licence, such as the GPL or MPL.\n"
-"                It is only relevant for listed add-ons."
 
-#: src/olympia/devhub/templates/devhub/includes/policy_form.html:21
-msgid ""
-"If your add-on transmits any data from the user's computer, a privacy policy is required that explains what data is sent and how it is used.\n"
-"                It is only relevant for listed add-ons."
+#: src/olympia/devhub/templates/devhub/includes/policy_form.html:24
+msgid "If your add-on transmits any data from the user's computer, a privacy policy is required that explains what data is sent and how it is used. It is only relevant for listed add-ons."
 msgstr ""
 "If your add-on transmits any data from the user's computer, a privacy policy is required that explains what data is sent and how it is used.\n"
 "                It is only relevant for listed add-ons."
@@ -6675,12 +6540,8 @@ msgstr "Select the category that best describes your Theme."
 msgid "Add some tags to describe your Theme."
 msgstr "Add some tags to describe your Theme."
 
-#: src/olympia/devhub/templates/devhub/personas/edit.html:106
-msgid ""
-"A short explanation of your theme's\n"
-"                                basic functionality that is displayed in\n"
-"                                search and browse listings, as well as at\n"
-"                                the top of your theme's details page."
+#: src/olympia/devhub/templates/devhub/personas/edit.html:106 src/olympia/devhub/templates/devhub/personas/submit.html:54
+msgid "A short explanation of your theme's basic functionality that is displayed in search and browse listings, as well as at the top of your theme's details page."
 msgstr ""
 "A short explanation of your theme's\n"
 "                                basic functionality that is displayed in\n"
@@ -6754,7 +6615,7 @@ msgid "Upon upload and form submission, the AMO Team will review your updated de
 msgstr "Upon upload and form submission, the AMO Team will review your updated design. Your current design will still be public in the meantime."
 
 #: src/olympia/devhub/templates/devhub/personas/edit.html:241
-msgid "Your previously resubmitted design,  which is under pending review."
+msgid "Your previously resubmitted design, which is under pending review."
 msgstr "Your previously resubmitted design,  which is under pending review."
 
 #: src/olympia/devhub/templates/devhub/personas/edit.html:245
@@ -6822,18 +6683,6 @@ msgstr "Background themes let you easily personalise the look of your Firefox. S
 #: src/olympia/devhub/templates/devhub/personas/submit.html:33
 msgid "Give your Theme a name."
 msgstr "Give your Theme a name."
-
-#: src/olympia/devhub/templates/devhub/personas/submit.html:54
-msgid ""
-"A short explanation of your theme's\n"
-"                                      basic functionality that is displayed in\n"
-"                                      search and browse listings, as well as at\n"
-"                                      the top of your theme's details page."
-msgstr ""
-"A short explanation of your theme's\n"
-"                                      basic functionality that is displayed in\n"
-"                                      search and browse listings, as well as at\n"
-"                                      the top of your theme's details page."
 
 #: src/olympia/devhub/templates/devhub/personas/submit.html:198
 #, python-format
@@ -6911,35 +6760,17 @@ msgstr "Select a different footer image"
 msgid "Files added to reviewed versions must be reviewed before they will be available for download."
 msgstr "Files added to reviewed versions must be reviewed before they will be available for download."
 
-#: src/olympia/devhub/templates/devhub/versions/add_file_modal.html:15
-#, python-format
-msgid ""
-"Submission of updates to unlisted add-ons for signing is currently in an open beta. Manual review may still be required for a large number of add-ons. Please <a href=\"%(url)s\" target=\"_blank"
-"\">report any bugs</a> that you encounter."
-msgstr ""
-"Submission of updates to unlisted add-ons for signing is currently in an open beta. Manual review may still be required for a large number of add-ons. Please <a href=\"%(url)s\" target=\"_blank"
-"\">report any bugs</a> that you encounter."
-
-#: src/olympia/devhub/templates/devhub/versions/add_file_modal.html:35
+#: src/olympia/devhub/templates/devhub/versions/add_file_modal.html:24
 msgid "Select the target platform for this file."
 msgstr "Select the target platform for this file."
 
-#: src/olympia/devhub/templates/devhub/versions/add_file_modal.html:46
+#: src/olympia/devhub/templates/devhub/versions/add_file_modal.html:35
 msgid "Which review type would you like to nominate for?"
 msgstr "Which review type would you like to nominate for?"
 
-#: src/olympia/devhub/templates/devhub/versions/add_file_modal.html:51
+#: src/olympia/devhub/templates/devhub/versions/add_file_modal.html:40
 msgid "Only publish this version to my beta channel."
 msgstr "Only publish this version to my beta channel."
-
-#: src/olympia/devhub/templates/devhub/versions/add_file_modal.html:54
-#, python-format
-msgid ""
-"The behavior of the beta channel has changed to accommodate <a href=\"%(addon_signing_url)s\" target=\"_blank\">mandatory add-on signing</a>. The new process is currently in an open beta, and may "
-"change significantly in the near future. Please <a href=\"%(issues_url)s\" target=\"_blank\">report any bugs</a> that you encounter."
-msgstr ""
-"The behaviour of the beta channel has changed to accommodate <a href=\"%(addon_signing_url)s\" target=\"_blank\">mandatory add-on signing</a>. The new process is currently in an open beta, and may "
-"change significantly in the near future. Please <a href=\"%(issues_url)s\" target=\"_blank\">report any bugs</a> that you encounter."
 
 #: src/olympia/devhub/templates/devhub/versions/edit.html:5
 msgid "Manage Version {0}"
@@ -6962,22 +6793,10 @@ msgstr "Files"
 msgid "Upload Another File"
 msgstr "Upload Another File"
 
-#: src/olympia/devhub/templates/devhub/versions/edit.html:45
-msgid ""
-"Adjusting application information here will allow users to install your\n"
-"                          add-on even if the install manifest in the package indicates that the\n"
-"                          add-on is incompatible."
-msgstr ""
-"Adjusting application information here will allow users to install your\n"
-"                          add-on even if the install manifest in the package indicates that the\n"
-"                          add-on is incompatible."
-
 #: src/olympia/devhub/templates/devhub/versions/edit.html:74
 msgid ""
-"Information about changes in this release, new features,\n"
-"                              known bugs, and other useful information specific to this\n"
-"                              release/version. This information is also shown in the\n"
-"                              Add-ons Manager when updating."
+"Information about changes in this release, new features, known bugs, and other useful information specific to this release/version. This information is also shown in the Add-ons Manager when "
+"updating."
 msgstr ""
 "Information about changes in this release, new features,\n"
 "                              known bugs, and other useful information specific to this\n"
@@ -6993,10 +6812,7 @@ msgid "Notes for Reviewers"
 msgstr "Notes for Reviewers"
 
 #: src/olympia/devhub/templates/devhub/versions/edit.html:114
-msgid ""
-"Optionally, enter any information that may be useful\n"
-"                              to the Editor reviewing this add-on, such as test\n"
-"                              account information."
+msgid "Optionally, enter any information that may be useful to the Editor reviewing this add-on, such as test account information."
 msgstr ""
 "Optionally, enter any information that may be useful\n"
 "                              to the Editor reviewing this add-on, such as test\n"
@@ -7077,7 +6893,7 @@ msgstr "Request Full Review"
 msgid "Request Preliminary Review"
 msgstr "Request Preliminary Review"
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:80 src/olympia/devhub/templates/devhub/versions/list.html:327 src/olympia/devhub/templates/devhub/versions/list.html:350
+#: src/olympia/devhub/templates/devhub/versions/list.html:80 src/olympia/devhub/templates/devhub/versions/list.html:325 src/olympia/devhub/templates/devhub/versions/list.html:348
 msgid "Cancel Review Request"
 msgstr "Cancel Review Request"
 
@@ -7106,8 +6922,8 @@ msgid "Unlisted:"
 msgstr "Unlisted:"
 
 #: src/olympia/devhub/templates/devhub/versions/list.html:114
-msgid "Not distributed on {0}. Developers will upload new versions for signing and distribute the add-ons on their own. (beta)"
-msgstr "Not distributed on {0}. Developers will upload new versions for signing and distribute the add-ons on their own. (beta)"
+msgid "Not distributed on {0}. Developers will upload new versions for signing and distribute the add-ons on their own."
+msgstr ""
 
 #: src/olympia/devhub/templates/devhub/versions/list.html:122
 msgid "Current versions"
@@ -7170,86 +6986,75 @@ msgid "<strong>Important:</strong> Once a version has been deleted, you may not 
 msgstr "<strong>Important:</strong> Once a version has been deleted, you may not upload a new version with the same version number."
 
 #: src/olympia/devhub/templates/devhub/versions/list.html:230
-msgid ""
-"Deleting a version which has already been reviewed\n"
-"               may also cause a significant delay in the review of\n"
-"               your next update."
-msgstr ""
-"Deleting a version which has already been reviewed\n"
-"               may also cause a significant delay in the review of\n"
-"               your next update."
-
-#: src/olympia/devhub/templates/devhub/versions/list.html:233
 msgid "Are you sure you wish to delete this version?"
 msgstr "Are you sure you wish to delete this version?"
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:238
+#: src/olympia/devhub/templates/devhub/versions/list.html:235
 msgid "Delete Version"
 msgstr "Delete Version"
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:240
+#: src/olympia/devhub/templates/devhub/versions/list.html:237
 msgid "Disable Version"
 msgstr "Disable Version"
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:247
+#: src/olympia/devhub/templates/devhub/versions/list.html:244
 msgid "Add a new Version"
 msgstr "Add a new Version"
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:249
+#: src/olympia/devhub/templates/devhub/versions/list.html:246
 msgid "Add Version"
 msgstr "Add Version"
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:256 src/olympia/devhub/templates/devhub/versions/list.html:274
+#: src/olympia/devhub/templates/devhub/versions/list.html:253 src/olympia/devhub/templates/devhub/versions/list.html:279
 msgid "Hide Add-on"
 msgstr "Hide Add-on"
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:259
+#: src/olympia/devhub/templates/devhub/versions/list.html:256
 msgid "Hiding your add-on will prevent it from appearing anywhere in our gallery and will stop users from receiving automatic updates."
 msgstr "Hiding your add-on will prevent it from appearing anywhere in our gallery and will stop users from receiving automatic updates."
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:265
+#: src/olympia/devhub/templates/devhub/versions/list.html:263
+msgid "The files awaiting review will be disabled and you will need to upload new versions."
+msgstr ""
+
+#: src/olympia/devhub/templates/devhub/versions/list.html:270
 msgid "Are you sure you wish to hide your add-on?"
 msgstr "Are you sure you wish to hide your add-on?"
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:286 src/olympia/devhub/templates/devhub/versions/list.html:315
+#: src/olympia/devhub/templates/devhub/versions/list.html:291 src/olympia/devhub/templates/devhub/versions/list.html:313
 msgid "Unlist Add-on"
 msgstr "Unlist Add-on"
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:289
+#: src/olympia/devhub/templates/devhub/versions/list.html:294
 #, python-format
 msgid ""
 "Unlisting your add-on will make it (and each of its versions/files) invisible on this website. It won't show up in searches, won't have a public facing page, and won't be updated automatically for "
-"current users.  It is recommended for unlisted add-ons to provide a custom <a href=\"%(update_url)s\" target=\"_blank\">updateURL</a> in their manifest file for automatic updates."
+"current users. It is recommended for unlisted add-ons to provide a custom <a href=\"%(update_url)s\" target=\"_blank\">updateURL</a> in their manifest file for automatic updates."
 msgstr ""
 "Unlisting your add-on will make it (and each of its versions/files) invisible on this web site. It won't show up in searches, won't have a public facing page, and won't be updated automatically for "
 "current users.  It is recommended for unlisted add-ons to provide a custom <a href=\"%(update_url)s\" target=\"_blank\">updateURL</a> in their manifest file for automatic updates."
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:299
-#, python-format
-msgid "Switching add-ons to unlisted is currently in an open beta. Please <a href=\"%(url)s\" target=\"_blank\">report any bugs</a> that you encounter."
-msgstr "Switching add-ons to unlisted is currently in an open beta. Please <a href=\"%(url)s\" target=\"_blank\">report any bugs</a> that you encounter."
-
-#: src/olympia/devhub/templates/devhub/versions/list.html:305
+#: src/olympia/devhub/templates/devhub/versions/list.html:303
 msgid "Unlisting an add-on is irreversible!"
 msgstr "Unlisting an add-on is irreversible!"
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:305
+#: src/olympia/devhub/templates/devhub/versions/list.html:303
 msgid "An unlisted add-on cannot be switched to be listed."
 msgstr "An unlisted add-on cannot be switched to be listed."
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:307
+#: src/olympia/devhub/templates/devhub/versions/list.html:305
 msgid "Are you sure you wish to unlist your add-on?"
 msgstr "Are you sure you wish to unlist your add-on?"
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:330
+#: src/olympia/devhub/templates/devhub/versions/list.html:328
 msgid "Canceling your review request will leave your add-on as preliminarily reviewed."
 msgstr "Cancelling your review request will leave your add-on as preliminarily reviewed."
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:335
+#: src/olympia/devhub/templates/devhub/versions/list.html:333
 msgid "Canceling your review request will mark your add-on incomplete. If you do not complete your add-on after several days by re-requesting review, it will be deleted."
 msgstr "Cancelling your review request will mark your add-on incomplete. If you do not complete your add-on after several days by re-requesting review, it will be deleted."
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:343
+#: src/olympia/devhub/templates/devhub/versions/list.html:341
 msgid "Are you sure you wish to cancel your review request?"
 msgstr "Are you sure you wish to cancel your review request?"
 
@@ -7588,19 +7393,19 @@ msgstr "add-on, editor or comment"
 msgid "Search by add-on name / author email"
 msgstr "Search by add-on name / author email"
 
-#: src/olympia/editors/forms.py:103
+#: src/olympia/editors/forms.py:103 src/olympia/editors/forms.py:244 src/olympia/editors/forms.py:257
 msgid "yes"
 msgstr "yes"
 
-#: src/olympia/editors/forms.py:104
+#: src/olympia/editors/forms.py:104 src/olympia/editors/forms.py:244 src/olympia/editors/forms.py:257
 msgid "no"
 msgstr "no"
 
-#: src/olympia/editors/forms.py:105
+#: src/olympia/editors/forms.py:105 src/olympia/editors/forms.py:245
 msgid "Admin Flag"
 msgstr "Admin Flag"
 
-#: src/olympia/editors/forms.py:113
+#: src/olympia/editors/forms.py:113 src/olympia/editors/forms.py:253
 msgid "Max. Version"
 msgstr "Max. Version"
 
@@ -7612,55 +7417,59 @@ msgstr "Days Since Submission"
 msgid "Add-on Types"
 msgstr "Add-on Types"
 
-#: src/olympia/editors/forms.py:126 src/olympia/editors/helpers.py:267
+#: src/olympia/editors/forms.py:126 src/olympia/editors/helpers.py:279
 msgid "Platforms"
 msgstr "Platforms"
 
+#: src/olympia/editors/forms.py:237
+msgid "Search by add-on name / author email / guid"
+msgstr ""
+
 #. L10n: 0 = platform, 1 = filename, 2 = status message
-#: src/olympia/editors/forms.py:238
+#: src/olympia/editors/forms.py:342
 #, python-format
 msgid "<strong>%s</strong> &middot; %s &middot; %s"
 msgstr "<strong>%s</strong> &middot; %s &middot; %s"
 
-#: src/olympia/editors/forms.py:252
+#: src/olympia/editors/forms.py:356
 msgid "Comments:"
 msgstr "Comments:"
 
-#: src/olympia/editors/forms.py:256
+#: src/olympia/editors/forms.py:360
 msgid "Operating systems:"
 msgstr "Operating systems:"
 
-#: src/olympia/editors/forms.py:258
+#: src/olympia/editors/forms.py:362
 msgid "Applications:"
 msgstr "Applications:"
 
-#: src/olympia/editors/forms.py:260
+#: src/olympia/editors/forms.py:364
 msgid "Notify me the next time this add-on is updated. (Subsequent updates will not generate an email)"
 msgstr "Notify me the next time this add-on is updated. (Subsequent updates will not generate an email)"
 
-#: src/olympia/editors/forms.py:265
+#: src/olympia/editors/forms.py:369
 msgid "Clear Admin Review Flag"
 msgstr "Clear Admin Review Flag"
 
-#: src/olympia/editors/forms.py:267
+#: src/olympia/editors/forms.py:371
 msgid "Clear more info requested flag"
 msgstr "Clear more info requested flag"
 
-#: src/olympia/editors/forms.py:281
+#: src/olympia/editors/forms.py:385
 msgid "Choose a canned response..."
 msgstr "Choose a canned response..."
 
 #. L10n: Description of what can be searched for.
-#: src/olympia/editors/forms.py:324
+#: src/olympia/editors/forms.py:423
 msgid "theme name"
 msgstr "theme name"
 
-#: src/olympia/editors/forms.py:350
+#: src/olympia/editors/forms.py:449
 msgid "Someone else is reviewing this theme."
 msgstr "Someone else is reviewing this theme."
 
 #. L10n: Description of what can be searched for.
-#: src/olympia/editors/forms.py:447
+#: src/olympia/editors/forms.py:546
 msgid "app, reviewer, or comment"
 msgstr "app, reviewer, or comment"
 
@@ -7676,192 +7485,210 @@ msgstr "Pending Preliminary Review"
 msgid "Rejected or Unreviewed"
 msgstr "Rejected or Unreviewed"
 
-#: src/olympia/editors/helpers.py:123 src/olympia/editors/helpers.py:136
+#: src/olympia/editors/helpers.py:125 src/olympia/editors/helpers.py:138
 msgid "Queue"
 msgstr "Queue"
 
-#: src/olympia/editors/helpers.py:124 src/olympia/editors/templates/editors/base.html:50 src/olympia/editors/templates/editors/base.html:65
+#: src/olympia/editors/helpers.py:126 src/olympia/editors/templates/editors/base.html:50 src/olympia/editors/templates/editors/base.html:65
 msgid "Pending Updates"
 msgstr "Pending Updates"
 
-#: src/olympia/editors/helpers.py:125 src/olympia/editors/templates/editors/base.html:48 src/olympia/editors/templates/editors/base.html:63
+#: src/olympia/editors/helpers.py:127 src/olympia/editors/templates/editors/base.html:48 src/olympia/editors/templates/editors/base.html:63
 msgid "Full Reviews"
 msgstr "Full Reviews"
 
-#: src/olympia/editors/helpers.py:126 src/olympia/editors/templates/editors/base.html:52 src/olympia/editors/templates/editors/base.html:67
+#: src/olympia/editors/helpers.py:128 src/olympia/editors/templates/editors/base.html:52 src/olympia/editors/templates/editors/base.html:67
 msgid "Preliminary Reviews"
 msgstr "Preliminary Reviews"
 
-#: src/olympia/editors/helpers.py:127 src/olympia/editors/templates/editors/base.html:54
+#: src/olympia/editors/helpers.py:129 src/olympia/editors/templates/editors/base.html:54
 msgid "Moderated Reviews"
 msgstr "Moderated Reviews"
 
-#: src/olympia/editors/helpers.py:128 src/olympia/editors/templates/editors/base.html:46
+#: src/olympia/editors/helpers.py:130 src/olympia/editors/templates/editors/base.html:46
 msgid "Fast Track"
 msgstr "Fast Track"
 
-#: src/olympia/editors/helpers.py:130
+#: src/olympia/editors/helpers.py:132
 msgid "Pending Themes"
 msgstr "Pending Themes"
 
-#: src/olympia/editors/helpers.py:131 src/olympia/editors/templates/editors/themes/queue.html:4
+#: src/olympia/editors/helpers.py:133 src/olympia/editors/templates/editors/themes/queue.html:4
 msgid "Flagged Themes"
 msgstr "Flagged Themes"
 
-#: src/olympia/editors/helpers.py:132
+#: src/olympia/editors/helpers.py:134
 msgid "Update Themes"
 msgstr "Update Themes"
 
-#: src/olympia/editors/helpers.py:137
+#: src/olympia/editors/helpers.py:139
 msgid "Unlisted Pending Updates"
 msgstr "Unlisted Pending Updates"
 
-#: src/olympia/editors/helpers.py:138
+#: src/olympia/editors/helpers.py:140
 msgid "Unlisted Full Reviews"
 msgstr "Unlisted Full Reviews"
 
-#: src/olympia/editors/helpers.py:139
+#: src/olympia/editors/helpers.py:141
 msgid "Unlisted Preliminary Reviews"
 msgstr "Unlisted Preliminary Reviews"
 
-#: src/olympia/editors/helpers.py:170
+#: src/olympia/editors/helpers.py:142
+msgid "Unlisted All Add-ons"
+msgstr ""
+
+#: src/olympia/editors/helpers.py:173
 msgid "Fast Track ({0})"
 msgid_plural "Fast Track ({0})"
 msgstr[0] "Fast Track ({0})"
 msgstr[1] "Fast Track ({0})"
 
-#: src/olympia/editors/helpers.py:175
+#: src/olympia/editors/helpers.py:178
 msgid "Full Review ({0})"
 msgid_plural "Full Reviews ({0})"
 msgstr[0] "Full Review ({0})"
 msgstr[1] "Full Reviews ({0})"
 
-#: src/olympia/editors/helpers.py:180
+#: src/olympia/editors/helpers.py:183
 msgid "Pending Update ({0})"
 msgid_plural "Pending Updates ({0})"
 msgstr[0] "Pending Update ({0})"
 msgstr[1] "Pending Updates ({0})"
 
-#: src/olympia/editors/helpers.py:185
+#: src/olympia/editors/helpers.py:188
 msgid "Preliminary Review ({0})"
 msgid_plural "Preliminary Reviews ({0})"
 msgstr[0] "Preliminary Review ({0})"
 msgstr[1] "Preliminary Reviews ({0})"
 
-#: src/olympia/editors/helpers.py:190
+#: src/olympia/editors/helpers.py:193
 msgid "Moderated Review ({0})"
 msgid_plural "Moderated Reviews ({0})"
 msgstr[0] "Moderated Review ({0})"
 msgstr[1] "Moderated Reviews ({0})"
 
-#: src/olympia/editors/helpers.py:196
+#: src/olympia/editors/helpers.py:199
 msgid "Unlisted Full Review ({0})"
 msgid_plural "Unlisted Full Reviews ({0})"
 msgstr[0] "Unlisted Full Review ({0})"
 msgstr[1] "Unlisted Full Reviews ({0})"
 
-#: src/olympia/editors/helpers.py:201
+#: src/olympia/editors/helpers.py:204
 msgid "Unlisted Pending Update ({0})"
 msgid_plural "Unlisted Pending Updates ({0})"
 msgstr[0] "Unlisted Pending Update ({0})"
 msgstr[1] "Unlisted Pending Updates ({0})"
 
-#: src/olympia/editors/helpers.py:206
+#: src/olympia/editors/helpers.py:209
 msgid "Unlisted Preliminary Review ({0})"
 msgid_plural "Unlisted Preliminary Reviews ({0})"
 msgstr[0] "Unlisted Preliminary Review ({0})"
 msgstr[1] "Unlisted Preliminary Reviews ({0})"
 
-#: src/olympia/editors/helpers.py:261
-msgid "Addon"
-msgstr "Add-on"
+#: src/olympia/editors/helpers.py:214
+msgid "Unlisted All Add-ons ({0})"
+msgid_plural "Unlisted All Add-ons ({0})"
+msgstr[0] ""
+msgstr[1] ""
 
-#: src/olympia/editors/helpers.py:262
+#: src/olympia/editors/helpers.py:274
 msgid "Type"
 msgstr "Type"
 
-#: src/olympia/editors/helpers.py:263
+#: src/olympia/editors/helpers.py:275
 msgid "Waiting Time"
 msgstr "Waiting Time"
 
-#: src/olympia/editors/helpers.py:264 src/olympia/editors/templates/editors/review.html:285
+#: src/olympia/editors/helpers.py:276 src/olympia/editors/templates/editors/review.html:285
 msgid "Flags"
 msgstr "Flags"
 
-#: src/olympia/editors/helpers.py:265
+#: src/olympia/editors/helpers.py:277
 msgid "Applications"
 msgstr "Applications"
 
-#: src/olympia/editors/helpers.py:270
+#: src/olympia/editors/helpers.py:282
 msgid "Additional"
 msgstr "Additional"
 
-#: src/olympia/editors/helpers.py:285
+#: src/olympia/editors/helpers.py:302
 msgid "Site Specific"
 msgstr "Site Specific"
 
-#: src/olympia/editors/helpers.py:287
+#: src/olympia/editors/helpers.py:304
 msgid "Requires External Software"
 msgstr "Requires External Software"
 
-#: src/olympia/editors/helpers.py:289
+#: src/olympia/editors/helpers.py:306
 msgid "Binary Components"
 msgstr "Binary Components"
 
-#: src/olympia/editors/helpers.py:313
+#: src/olympia/editors/helpers.py:339
 msgid "moments ago"
 msgstr "moments ago"
 
 #. L10n: first argument is number of minutes
-#: src/olympia/editors/helpers.py:316
+#: src/olympia/editors/helpers.py:342
 msgid "{0} minute"
 msgid_plural "{0} minutes"
 msgstr[0] "{0} minute"
 msgstr[1] "{0} minutes"
 
 #. L10n: first argument is number of hours
-#: src/olympia/editors/helpers.py:320
+#: src/olympia/editors/helpers.py:346
 msgid "{0} hour"
 msgid_plural "{0} hours"
 msgstr[0] "{0} hour"
 msgstr[1] "{0} hours"
 
 #. L10n: first argument is number of days
-#: src/olympia/editors/helpers.py:324
+#: src/olympia/editors/helpers.py:350
 msgid "{0} day"
 msgid_plural "{0} days"
 msgstr[0] "{0} day"
 msgstr[1] "{0} days"
 
-#: src/olympia/editors/helpers.py:488
+#: src/olympia/editors/helpers.py:364
+msgid "Last Review"
+msgstr ""
+
+#: src/olympia/editors/helpers.py:366
+msgid "Last Update"
+msgstr ""
+
+#: src/olympia/editors/helpers.py:387
+msgid "No Reviews"
+msgstr ""
+
+#: src/olympia/editors/helpers.py:561
 msgid "Push to public"
 msgstr "Push to public"
 
-#: src/olympia/editors/helpers.py:490
+#: src/olympia/editors/helpers.py:563
 msgid "Grant full review"
 msgstr "Grant full review"
 
-#: src/olympia/editors/helpers.py:505
+#: src/olympia/editors/helpers.py:578
 msgid "Request more information"
 msgstr "Request more information"
 
-#: src/olympia/editors/helpers.py:508
+#: src/olympia/editors/helpers.py:581
 msgid "Request super-review"
 msgstr "Request super-review"
 
-#: src/olympia/editors/helpers.py:519
+#: src/olympia/editors/helpers.py:592
 msgid "Grant preliminary review"
 msgstr "Grant preliminary review"
 
-#: src/olympia/editors/helpers.py:520
+#: src/olympia/editors/helpers.py:593
 msgid "This will mark the files as preliminarily reviewed."
 msgstr "This will mark the files as preliminarily reviewed."
 
-#: src/olympia/editors/helpers.py:522
+#: src/olympia/editors/helpers.py:595
 msgid "Use this form to request more information from the author. They will receive an email and be able to answer here. You will be notified by email when they reply."
 msgstr "Use this form to request more information from the author. They will receive an email and be able to answer here. You will be notified by email when they reply."
 
-#: src/olympia/editors/helpers.py:526
+#: src/olympia/editors/helpers.py:599
 msgid ""
 "If you have concerns about this add-on's security, copyright issues, or other concerns that an administrator should look into, enter your comments in the area below. They will be sent to "
 "administrators, not the author."
@@ -7869,55 +7696,55 @@ msgstr ""
 "If you have concerns about this add-on's security, copyright issues, or other concerns that an administrator should look into, enter your comments in the area below. They will be sent to "
 "administrators, not the author."
 
-#: src/olympia/editors/helpers.py:532
+#: src/olympia/editors/helpers.py:605
 msgid "This will reject the add-on and remove it from the review queue."
 msgstr "This will reject the add-on and remove it from the review queue."
 
-#: src/olympia/editors/helpers.py:534
-msgid "Make a comment on this version.  The author won't be able to see this."
+#: src/olympia/editors/helpers.py:607
+msgid "Make a comment on this version. The author won't be able to see this."
 msgstr "Make a comment on this version.  The author won't be able to see this."
 
-#: src/olympia/editors/helpers.py:538
+#: src/olympia/editors/helpers.py:611
 msgid "This will reject the files and remove them from the review queue."
 msgstr "This will reject the files and remove them from the review queue."
 
-#: src/olympia/editors/helpers.py:542
+#: src/olympia/editors/helpers.py:615
 msgid "This will mark the add-on as preliminarily reviewed. Future versions will undergo preliminary review."
 msgstr "This will mark the add-on as preliminarily reviewed. Future versions will undergo preliminary review."
 
-#: src/olympia/editors/helpers.py:547
+#: src/olympia/editors/helpers.py:620
 msgid "This will mark the files as preliminarily reviewed. Future versions will undergo preliminary review."
 msgstr "This will mark the files as preliminarily reviewed. Future versions will undergo preliminary review."
 
-#: src/olympia/editors/helpers.py:552
+#: src/olympia/editors/helpers.py:625
 msgid "Retain preliminary review"
 msgstr "Retain preliminary review"
 
-#: src/olympia/editors/helpers.py:553
+#: src/olympia/editors/helpers.py:626
 msgid "This will retain the add-on as preliminarily reviewed. Future versions will undergo preliminary review."
 msgstr "This will retain the add-on as preliminarily reviewed. Future versions will undergo preliminary review."
 
-#: src/olympia/editors/helpers.py:558
+#: src/olympia/editors/helpers.py:631
 msgid "This will approve a sandboxed version of a public add-on to appear on the public side."
 msgstr "This will approve a sandboxed version of a public add-on to appear on the public side."
 
-#: src/olympia/editors/helpers.py:561
+#: src/olympia/editors/helpers.py:634
 msgid "This will reject a version of a public add-on and remove it from the queue."
 msgstr "This will reject a version of a public add-on and remove it from the queue."
 
-#: src/olympia/editors/helpers.py:564
+#: src/olympia/editors/helpers.py:637
 msgid "This will mark the add-on and its most recent version and files as public. Future versions will go into the sandbox until they are reviewed by an editor."
 msgstr "This will mark the add-on and its most recent version and files as public. Future versions will go into the sandbox until they are reviewed by an editor."
 
-#: src/olympia/editors/helpers.py:637
+#: src/olympia/editors/helpers.py:714
 msgid "add-on"
 msgstr "add-on"
 
-#: src/olympia/editors/helpers.py:940 src/olympia/editors/helpers.py:960
+#: src/olympia/editors/helpers.py:1020 src/olympia/editors/helpers.py:1040
 msgid "Flagged"
 msgstr "Flagged"
 
-#: src/olympia/editors/helpers.py:944 src/olympia/editors/helpers.py:963
+#: src/olympia/editors/helpers.py:1024 src/olympia/editors/helpers.py:1043
 msgid "Updates"
 msgstr "Updates"
 
@@ -7969,56 +7796,56 @@ msgstr "Theme submission flagged for review"
 msgid "A question about your Theme submission"
 msgstr "A question about your Theme submission"
 
-#: src/olympia/editors/views.py:144
+#: src/olympia/editors/views.py:146
 msgid "New Add-ons (Under 5 days)"
 msgstr "New Add-ons (Under 5 days)"
 
-#: src/olympia/editors/views.py:145
+#: src/olympia/editors/views.py:147
 msgid "Passable (5 to 10 days)"
 msgstr "Passable (5 to 10 days)"
 
-#: src/olympia/editors/views.py:146
+#: src/olympia/editors/views.py:148
 msgid "Overdue (Over 10 days)"
 msgstr "Overdue (Over 10 days)"
 
-#: src/olympia/editors/views.py:532
+#: src/olympia/editors/views.py:539
 msgid "An unknown error occurred"
 msgstr "An unknown error occurred"
 
-#: src/olympia/editors/views.py:587
+#: src/olympia/editors/views.py:592
 msgid "Self-reviews are not allowed."
 msgstr "Self-reviews are not allowed."
 
-#: src/olympia/editors/views.py:609
+#: src/olympia/editors/views.py:613
 msgid "Review successfully processed."
 msgstr "Review successfully processed."
 
-#: src/olympia/editors/views.py:807
+#: src/olympia/editors/views.py:812
 msgid "was approved"
 msgstr "was approved"
 
-#: src/olympia/editors/views.py:808
+#: src/olympia/editors/views.py:813
 msgid "given preliminary review"
 msgstr "given preliminary review"
 
-#: src/olympia/editors/views.py:809
+#: src/olympia/editors/views.py:814
 msgid "rejected"
 msgstr "rejected"
 
-#: src/olympia/editors/views.py:810
+#: src/olympia/editors/views.py:815
 msgctxt "editors_review_history_nominated_adminreview"
 msgid "escalated"
 msgstr "escalated"
 
-#: src/olympia/editors/views.py:812
+#: src/olympia/editors/views.py:817
 msgid "needs more information"
 msgstr "needs more information"
 
-#: src/olympia/editors/views.py:813
+#: src/olympia/editors/views.py:818
 msgid "needs super review"
 msgstr "needs super review"
 
-#: src/olympia/editors/views.py:814
+#: src/olympia/editors/views.py:819
 msgid "commented"
 msgstr "commented"
 
@@ -8063,28 +7890,28 @@ msgstr "Queues"
 msgid "Unlisted Queues"
 msgstr "Unlisted Queues"
 
-#: src/olympia/editors/templates/editors/base.html:72 src/olympia/editors/templates/editors/performance.html:6
+#: src/olympia/editors/templates/editors/base.html:74 src/olympia/editors/templates/editors/performance.html:6
 msgid "Performance"
 msgstr "Performance"
 
-#: src/olympia/editors/templates/editors/base.html:75 src/olympia/editors/templates/editors/themes/base.html:19 src/olympia/editors/templates/editors/themes/base.html:38
+#: src/olympia/editors/templates/editors/base.html:77 src/olympia/editors/templates/editors/themes/base.html:19 src/olympia/editors/templates/editors/themes/base.html:38
 msgid "Logs"
 msgstr "Logs"
 
-#: src/olympia/editors/templates/editors/base.html:78 src/olympia/editors/templates/editors/reviewlog.html:4 src/olympia/editors/templates/editors/reviewlog.html:27
+#: src/olympia/editors/templates/editors/base.html:80 src/olympia/editors/templates/editors/reviewlog.html:4 src/olympia/editors/templates/editors/reviewlog.html:27
 msgid "Add-on Review Log"
 msgstr "Add-on Review Log"
 
-#: src/olympia/editors/templates/editors/base.html:80 src/olympia/editors/templates/editors/eventlog.html:4 src/olympia/editors/templates/editors/eventlog.html:8
+#: src/olympia/editors/templates/editors/base.html:82 src/olympia/editors/templates/editors/eventlog.html:4 src/olympia/editors/templates/editors/eventlog.html:8
 #: src/olympia/editors/templates/editors/eventlog_detail.html:4
 msgid "Moderated Review Log"
 msgstr "Moderated Review Log"
 
-#: src/olympia/editors/templates/editors/base.html:82 src/olympia/editors/templates/editors/beta_signed_log.html:4 src/olympia/editors/templates/editors/beta_signed_log.html:8
+#: src/olympia/editors/templates/editors/base.html:84 src/olympia/editors/templates/editors/beta_signed_log.html:4 src/olympia/editors/templates/editors/beta_signed_log.html:8
 msgid "Signed Beta Files Log"
 msgstr "Signed Beta Files Log"
 
-#: src/olympia/editors/templates/editors/base.html:87 src/olympia/editors/templates/editors/includes/daily-message.html:4
+#: src/olympia/editors/templates/editors/base.html:89 src/olympia/editors/templates/editors/includes/daily-message.html:4
 msgid "Announcement"
 msgstr "Announcement"
 
@@ -8305,45 +8132,45 @@ msgstr "Advanced Search"
 msgid "clear search"
 msgstr "clear search"
 
-#: src/olympia/editors/templates/editors/queue.html:72 src/olympia/editors/templates/editors/queue.html:122
+#: src/olympia/editors/templates/editors/queue.html:78 src/olympia/editors/templates/editors/queue.html:128
 msgid "Process Reviews"
 msgstr "Process Reviews"
 
-#: src/olympia/editors/templates/editors/queue.html:80
+#: src/olympia/editors/templates/editors/queue.html:86
 msgid "Moderation actions:"
 msgstr "Moderation actions:"
 
-#: src/olympia/editors/templates/editors/queue.html:90
+#: src/olympia/editors/templates/editors/queue.html:96
 #, python-format
 msgid "by %(user)s on %(date)s %(stars)s (%(locale)s)"
 msgstr "by %(user)s on %(date)s %(stars)s (%(locale)s)"
 
-#: src/olympia/editors/templates/editors/queue.html:106
+#: src/olympia/editors/templates/editors/queue.html:112
 #, python-format
 msgid "<strong>%(reason)s</strong> <span class=\"light\">Flagged by %(user)s on %(date)s</span>"
 msgstr "<strong>%(reason)s</strong> <span class=\"light\">Flagged by %(user)s on %(date)s</span>"
 
-#: src/olympia/editors/templates/editors/queue.html:119
-msgid "All reviews have been moderated.  Good work!"
+#: src/olympia/editors/templates/editors/queue.html:125
+msgid "All reviews have been moderated. Good work!"
 msgstr "All reviews have been moderated.  Good work!"
 
-#: src/olympia/editors/templates/editors/queue.html:161
+#: src/olympia/editors/templates/editors/queue.html:167
 msgid "Version Notes / Notes for Reviewer"
 msgstr "Version Notes / Notes for Reviewer"
 
-#: src/olympia/editors/templates/editors/queue.html:169
+#: src/olympia/editors/templates/editors/queue.html:175
 msgid "There are currently no add-ons of this type to review."
 msgstr "There are currently no add-ons of this type to review."
 
-#: src/olympia/editors/templates/editors/queue.html:181 src/olympia/editors/templates/editors/themes/queue_list.html:85
+#: src/olympia/editors/templates/editors/queue.html:187 src/olympia/editors/templates/editors/themes/queue_list.html:85
 msgid "Helpful Links:"
 msgstr "Helpful Links:"
 
-#: src/olympia/editors/templates/editors/queue.html:182
+#: src/olympia/editors/templates/editors/queue.html:188
 msgid "Add-on Policy"
 msgstr "Add-on Policy"
 
-#: src/olympia/editors/templates/editors/queue.html:184
+#: src/olympia/editors/templates/editors/queue.html:190
 msgid "Editors' Guide"
 msgstr "Editors' Guide"
 
@@ -8406,10 +8233,7 @@ msgid "<strong>Warning!</strong> Another user was viewing this page before you."
 msgstr "<strong>Warning!</strong> Another user was viewing this page before you."
 
 #: src/olympia/editors/templates/editors/review.html:237
-msgid ""
-"The whiteboard is the place to exchange information relevant to\n"
-"               this addon (whatever the version), between the developer and the\n"
-"               editor. This is visible and editable by both."
+msgid "The whiteboard is the place to exchange information relevant to this addon (whatever the version), between the developer and the editor. This is visible and editable by both."
 msgstr ""
 "The whiteboard is the place to exchange information relevant to\n"
 "               this addon (whatever the version), between the developer and the\n"
@@ -8686,7 +8510,7 @@ msgstr "Ask a question to the artist"
 msgid "Describe your reason for flagging"
 msgstr "Describe your reason for flagging"
 
-#: src/olympia/files/forms.py:88
+#: src/olympia/files/forms.py:90
 msgid "Cannot diff a version against itself"
 msgstr "Cannot diff a version against itself"
 
@@ -8721,51 +8545,51 @@ msgstr "There was an error accessing file %s. %s."
 msgid "There was an error accessing file %s."
 msgstr "There was an error accessing file %s."
 
-#: src/olympia/files/utils.py:343
+#: src/olympia/files/utils.py:340
 msgid "Could not parse uploaded file."
 msgstr "Could not parse uploaded file."
 
-#: src/olympia/files/utils.py:380
+#: src/olympia/files/utils.py:377
 msgid "Invalid file name in archive: {0}"
 msgstr "Invalid file name in archive: {0}"
 
-#: src/olympia/files/utils.py:388
+#: src/olympia/files/utils.py:385
 msgid "File exceeding size limit in archive: {0}"
 msgstr "File exceeding size limit in archive: {0}"
 
-#: src/olympia/files/utils.py:439
+#: src/olympia/files/utils.py:436
 msgid "Invalid archive."
 msgstr "Invalid archive."
 
-#: src/olympia/files/utils.py:529 src/olympia/files/utils.py:532
+#: src/olympia/files/utils.py:526 src/olympia/files/utils.py:529
 msgid "Could not parse the manifest file."
 msgstr "Could not parse the manifest file."
 
-#: src/olympia/files/utils.py:551
+#: src/olympia/files/utils.py:548
 msgid "Could not find an add-on ID."
 msgstr "Could not find an add-on ID."
 
-#: src/olympia/files/utils.py:554
+#: src/olympia/files/utils.py:551
 msgid "Add-on ID must be 64 characters or less."
 msgstr "Add-on ID must be 64 characters or less."
 
-#: src/olympia/files/utils.py:556
+#: src/olympia/files/utils.py:553
 msgid "Add-on ID doesn't match add-on."
 msgstr "Add-on ID doesn't match add-on."
 
-#: src/olympia/files/utils.py:564
+#: src/olympia/files/utils.py:561
 msgid "Duplicate add-on ID found."
 msgstr "Duplicate add-on ID found."
 
-#: src/olympia/files/utils.py:567
+#: src/olympia/files/utils.py:564
 msgid "Version numbers should have fewer than 32 characters."
 msgstr "Version numbers should have fewer than 32 characters."
 
-#: src/olympia/files/utils.py:570
+#: src/olympia/files/utils.py:567
 msgid "Version numbers should only contain letters, numbers, and these punctuation characters: +*.-_."
 msgstr "Version numbers should only contain letters, numbers, and these punctuation characters: +*.-_."
 
-#: src/olympia/files/utils.py:587
+#: src/olympia/files/utils.py:584
 msgid "<em:type> doesn't match add-on"
 msgstr "<em:type> doesn't match add-on"
 
@@ -8865,6 +8689,10 @@ msgstr "No files in the uploaded file."
 #: src/olympia/files/templates/files/viewer.html:134
 msgid "Fetching file."
 msgstr "Fetching file."
+
+#: src/olympia/legacy_api/views.py:255
+msgid "Not implemented yet."
+msgstr "Not implemented yet."
 
 #: src/olympia/lib/constants.py:6
 msgid "United Arab Emirates Dirham"
@@ -9522,10 +9350,6 @@ msgstr "Zambia Kwacha"
 msgid "Zimbabwe Dollar"
 msgstr "Zimbabwe Dollar"
 
-#: src/olympia/lib/video/ffmpeg.py:112 src/olympia/lib/video/totem.py:81
-msgid "Videos must be in WebM."
-msgstr "Videos must be in WebM."
-
 #: src/olympia/pages/templates/pages/about.lhtml:3 src/olympia/pages/templates/pages/about.lhtml:10
 msgid "About Mozilla Add-ons"
 msgstr "About Mozilla Add-ons"
@@ -9537,7 +9361,7 @@ msgstr "What is this web site?"
 #: src/olympia/pages/templates/pages/about.lhtml:13
 msgid ""
 "addons.mozilla.org, commonly known as \"AMO\", is Mozilla's official site for add-ons to Mozilla software, such as Firefox, Thunderbird, and SeaMonkey. Add-ons let you add new features and change "
-"the way your browser or application works.  Take a look around and explore the thousands of ways to customize the way you do things online."
+"the way your browser or application works. Take a look around and explore the thousands of ways to customize the way you do things online."
 msgstr ""
 "addons.mozilla.org, commonly known as \"AMO\", is Mozilla's official site for add-ons to Mozilla software, such as Firefox, Thunderbird, and SeaMonkey. Add-ons let you add new features and change "
 "the way your browser or application works.  Take a look around and explore the thousands of ways to customise the way you do things online."
@@ -9916,7 +9740,7 @@ msgstr "Can I use a JavaScript library like jQuery, MooTools or Prototype to bui
 msgid ""
 "Yes. It's possible, but some of the functionality provided by these libraries are available through XPCOM, XUL, and JavaScript. In addition, authors should take care if libraries modify primitive "
 "object prototypes (String.prototype, Date.prototype, etc.) and/or define global functions (eg. the $ function). These are prone to cause conflict with other add-ons, in particular if different add-"
-"ons use different versions of libraries and so on. Developers need to be very, very careful with using them.  Mozilla does not offer documentation on using them to build add-ons."
+"ons use different versions of libraries and so on. Developers need to be very, very careful with using them. Mozilla does not offer documentation on using them to build add-ons."
 msgstr ""
 "Yes. It's possible, but some of the functionality provided by these libraries are available through XPCOM, XUL, and JavaScript. In addition, authors should take care if libraries modify primitive "
 "object prototypes (String.prototype, Date.prototype, etc.) and/or define global functions (eg. the $ function). These are prone to cause conflict with other add-ons, in particular if different add-"
@@ -10042,8 +9866,8 @@ msgstr "Can I host my own add-on?"
 #, python-format
 msgid ""
 "Yes. Many developers choose to host their own add-ons. Choosing to host your add-on on <a href=\"%(amo_url)s\">Mozilla's add-on site</a>, though, allows for much greater exposure to your add-on due "
-"to the large volume of visitors to the site.  <a href=\"%(md_url)s\">mozdev.org</a> offers free project hosting for Mozilla applications and extensions providing developers with tools to help "
-"manage source code, version control, bug tracking and documentation."
+"to the large volume of visitors to the site. <a href=\"%(md_url)s\">mozdev.org</a> offers free project hosting for Mozilla applications and extensions providing developers with tools to help manage "
+"source code, version control, bug tracking and documentation."
 msgstr ""
 "Yes. Many developers choose to host their own add-ons. Choosing to host your add-on on <a href=\"%(amo_url)s\">Mozilla's add-on site</a>, though, allows for much greater exposure to your add-on due "
 "to the large volume of visitors to the site.  <a href=\"%(md_url)s\">mozdev.org</a> offers free project hosting for Mozilla applications and extensions providing developers with tools to help "
@@ -10098,7 +9922,7 @@ msgstr "Does Mozilla have a policy in place as to what is an acceptable submissi
 #: src/olympia/pages/templates/pages/dev_faq.html:314
 #, python-format
 msgid ""
-"Yes. Mozilla's <a href=\"%(p_url)s\">Add-on Policy</a> describes what is an acceptable submission. This policy is subject to change without notice.  In addition, the AMO editorial team uses the <a "
+"Yes. Mozilla's <a href=\"%(p_url)s\">Add-on Policy</a> describes what is an acceptable submission. This policy is subject to change without notice. In addition, the AMO editorial team uses the <a "
 "href=\"%(g_url)s\">Editors Reviewing Guide</a> to ensure that your add-on meets specific guidelines for functionality and security."
 msgstr ""
 "Yes. Mozilla's <a href=\"%(p_url)s\">Add-on Policy</a> describes what is an acceptable submission. This policy is subject to change without notice.  In addition, the AMO editorial team uses the <a "
@@ -10228,7 +10052,7 @@ msgstr "number of problem areas discovered"
 #: src/olympia/pages/templates/pages/dev_faq.html:434
 #, python-format
 msgid ""
-"This is why it's very important to read the <a href=\"%(g_url)s\">Editors Reviewing Guide</a> to ensure that your add-on is setup as expected.  It's also a good idea to read the blog post, <a href="
+"This is why it's very important to read the <a href=\"%(g_url)s\">Editors Reviewing Guide</a> to ensure that your add-on is setup as expected. It's also a good idea to read the blog post, <a href="
 "\"%(blog_url)s\">Successfully Getting your Add-on Reviewed</a> which provides excellent insight into ensuring a smooth review of your add-on."
 msgstr ""
 "This is why it's very important to read the <a href=\"%(g_url)s\">Editors Reviewing Guide</a> to ensure that your add-on is setup as expected.  It's also a good idea to read the blog post, <a href="
@@ -10346,7 +10170,7 @@ msgstr "A table summarising and comparing how some of the key open source licenc
 
 #: src/olympia/pages/templates/pages/dev_faq.html:572
 msgid ""
-"Free Software Foundation provides short summaries of the key open source licenses, including whether the license qualifies as a free software license or a copyleft license.  Also includes a "
+"Free Software Foundation provides short summaries of the key open source licenses, including whether the license qualifies as a free software license or a copyleft license. Also includes a "
 "discussion of what constitutes a free software license or a copyleft license (e.g., a Copyleft license is a general method for making a program or other work free, and requiring all modified and "
 "extended versions of the program to be free as well.)"
 msgstr ""
@@ -10553,21 +10377,15 @@ msgid "Add-on Gallery"
 msgstr "Add-on Gallery"
 
 #: src/olympia/pages/templates/pages/faq.html:171
-msgid ""
-"How do I choose between add-ons that seem to do the same\n"
-"    thing?"
+msgid "How do I choose between add-ons that seem to do the same thing?"
 msgstr ""
 "How do I choose between add-ons that seem to do the same\n"
 "    thing?"
 
-#: src/olympia/pages/templates/pages/faq.html:173
+#: src/olympia/pages/templates/pages/faq.html:172
 msgid ""
-"There are often several add-ons that have similar features. To\n"
-"    figure out which is right for you, read the entire description of the\n"
-"    add-on and view its screenshots. If there are still several in the running,\n"
-"    read through the add-on's ratings, user reviews, and statistics to see\n"
-"    which is most liked by other users. Remember that you can also just try\n"
-"    out both and see which you like better."
+"There are often several add-ons that have similar features. To figure out which is right for you, read the entire description of the add-on and view its screenshots. If there are still several in "
+"the running, read through the add-on's ratings, user reviews, and statistics to see which is most liked by other users. Remember that you can also just try out both and see which you like better."
 msgstr ""
 "There are often several add-ons that have similar features. To\n"
 "    figure out which is right for you, read the entire description of the\n"
@@ -10620,101 +10438,88 @@ msgid "How much do add-ons cost to purchase?"
 msgstr "How much do add-ons cost to purchase?"
 
 #: src/olympia/pages/templates/pages/faq.html:207
-msgid ""
-"Add-ons hosted in our gallery are free unless clearly marked\n"
-"    otherwise."
+msgid "Add-ons hosted in our gallery are free unless clearly marked otherwise."
 msgstr ""
 "Add-ons hosted in our gallery are free unless clearly marked\n"
 "    otherwise."
 
-#: src/olympia/pages/templates/pages/faq.html:210
+#: src/olympia/pages/templates/pages/faq.html:209
 msgid "What does it mean when an add-on asks for contributions?"
 msgstr "What does it mean when an add-on asks for donations?"
 
-#: src/olympia/pages/templates/pages/faq.html:211
+#: src/olympia/pages/templates/pages/faq.html:210
 msgid ""
-"Some add-on authors request users who enjoy an add-on to\n"
-"        contribute to its development by making a monetary contribution. These\n"
-"        contributions go directly to the developer unless a third party is\n"
-"        indicated, such as the non-profit Mozilla Foundation."
+"Some add-on authors request users who enjoy an add-on to contribute to its development by making a monetary contribution. These contributions go directly to the developer unless a third party is "
+"indicated, such as the non-profit Mozilla Foundation."
 msgstr ""
 "Some add-on authors request users who enjoy an add-on to\n"
 "        contribute to its development by making a monetary contribution. These\n"
 "        contributions go directly to the developer unless a third party is\n"
 "        indicated, such as the non-profit Mozilla Foundation."
 
-#: src/olympia/pages/templates/pages/faq.html:216
+#: src/olympia/pages/templates/pages/faq.html:215
 msgid "What are beta add-ons?"
 msgstr "What are beta add-ons?"
 
-#: src/olympia/pages/templates/pages/faq.html:218
+#: src/olympia/pages/templates/pages/faq.html:217
 msgid ""
-"Beta add-ons are unreviewed versions which represent the\n"
-"        latest work of an add-on author. While different authors have different\n"
-"        standards for beta code quality, you should assume that these add-ons\n"
-"        are less stable than the general add-on releases."
+"Beta add-ons are unreviewed versions which represent the latest work of an add-on author. While different authors have different standards for beta code quality, you should assume that these add-"
+"ons are less stable than the general add-on releases."
 msgstr ""
 "Beta add-ons are unreviewed versions which represent the\n"
 "        latest work of an add-on author. While different authors have different\n"
 "        standards for beta code quality, you should assume that these add-ons\n"
 "        are less stable than the general add-on releases."
 
-#: src/olympia/pages/templates/pages/faq.html:222
+#: src/olympia/pages/templates/pages/faq.html:221
 msgid ""
 "Please note that when you install an add-on from the \"Beta Version\" section of an add-on's listing, you will continue to receive updates for that add-on as they become available. Like the initial "
 "version you installed, all beta releases are unreviewed by Mozilla and may harm your computer."
 msgstr ""
 "Please note that when you install an add-on from the \"Beta Version\" section of an add-on's listing, you will continue to receive updates for that add-on as they become available. Like the initial "
 "version you installed, all beta releases are unreviewed by Mozilla and may harm your computer."
+
+#: src/olympia/pages/templates/pages/faq.html:228
+msgid "What does it mean when an add-on is flagged as slow?"
+msgstr ""
+"What does it mean when an add-on is flagged as\n"
+"    slow?"
 
 #: src/olympia/pages/templates/pages/faq.html:229
-msgid ""
-"What does it mean when an add-on is flagged as\n"
-"    slow?"
-msgstr ""
-"What does it mean when an add-on is flagged as\n"
-"    slow?"
-
-#: src/olympia/pages/templates/pages/faq.html:231
-msgid ""
-"Most add-ons load code and resources at the same time Firefox\n"
-"        is starting up. In most cases the impact in start-up time is minimal,\n"
-"        but some add-ons can cause a noticeable slowdown."
+msgid "Most add-ons load code and resources at the same time Firefox is starting up. In most cases the impact in start-up time is minimal, but some add-ons can cause a noticeable slowdown."
 msgstr ""
 "Most add-ons load code and resources at the same time Firefox\n"
 "        is starting up. In most cases the impact in start-up time is minimal,\n"
 "        but some add-ons can cause a noticeable slowdown."
 
-#: src/olympia/pages/templates/pages/faq.html:236
+#: src/olympia/pages/templates/pages/faq.html:234
 msgid "How do I report an inappropriate or spam user review?"
 msgstr "How do I report an inappropriate or spam user review?"
 
-#: src/olympia/pages/templates/pages/faq.html:237
+#: src/olympia/pages/templates/pages/faq.html:235
 msgid ""
-"To report a user review of an add-on, log in with your account\n"
-"    and visit the add-on's reviews page. Find the review you wish to report,\n"
-"    click \"Report this review\" and select a reason. Our editorial team will\n"
-"    investigate the review and take appropriate action."
+"To report a user review of an add-on, log in with your account and visit the add-on's reviews page. Find the review you wish to report, click \"Report this review\" and select a reason. Our "
+"editorial team will investigate the review and take appropriate action."
 msgstr ""
 "To report a user review of an add-on, log in with your account\n"
 "    and visit the add-on's reviews page. Find the review you wish to report,\n"
 "    click \"Report this review\" and select a reason. Our editorial team will\n"
 "    investigate the review and take appropriate action."
 
-#: src/olympia/pages/templates/pages/faq.html:242
+#: src/olympia/pages/templates/pages/faq.html:240
 msgid "How do I report a bug or contact the Mozilla Add-ons team?"
 msgstr "How do I report a bug or contact the Mozilla Add-ons team?"
 
-#: src/olympia/pages/templates/pages/faq.html:243
+#: src/olympia/pages/templates/pages/faq.html:241
 #, python-format
 msgid "Please visit our <a href=\"%(contact_url)s\">Contact page</a>."
 msgstr "Please visit our <a href=\"%(contact_url)s\">Contact page</a>."
 
-#: src/olympia/pages/templates/pages/faq.html:246
+#: src/olympia/pages/templates/pages/faq.html:244
 msgid "What is a Source Code License?"
 msgstr "What is a Source Code Licence?"
 
-#: src/olympia/pages/templates/pages/faq.html:247
+#: src/olympia/pages/templates/pages/faq.html:245
 #, python-format
 msgid ""
 "The source code used to create an add-on is an exclusive copyright of the add-on author, unless otherwise declared in a source code license. Many add-ons on this site have <a href=\"%(url)s\" lang="
@@ -10725,40 +10530,40 @@ msgstr ""
 "\"en\">open source licences</a> that make the source code publicly available for copy and reuse under conditions determined by the author. Most authors choose widely known open source licences like "
 "the GPL or BSD licences instead of making up their own."
 
-#: src/olympia/pages/templates/pages/faq.html:256
+#: src/olympia/pages/templates/pages/faq.html:254
 #, python-format
 msgid "Firefox and other Mozilla software are <a href=\"%(url)s\">open source</a>."
 msgstr "Firefox and other Mozilla software are <a href=\"%(url)s\">open source</a>."
 
-#: src/olympia/pages/templates/pages/faq.html:264
+#: src/olympia/pages/templates/pages/faq.html:262
 msgid "Collections and Favorites"
 msgstr "Collections and Favourites"
 
-#: src/olympia/pages/templates/pages/faq.html:267
+#: src/olympia/pages/templates/pages/faq.html:265
 msgid "What is a collection?"
 msgstr "What is a collection?"
 
-#: src/olympia/pages/templates/pages/faq.html:268
+#: src/olympia/pages/templates/pages/faq.html:266
 msgid "Collections are groups of related add-ons created by users to share."
 msgstr "Collections are groups of related add-ons created by users to share."
 
-#: src/olympia/pages/templates/pages/faq.html:270
+#: src/olympia/pages/templates/pages/faq.html:268
 msgid "What is the My Favorites collection?"
 msgstr "What is the My Favourites collection?"
 
-#: src/olympia/pages/templates/pages/faq.html:271
+#: src/olympia/pages/templates/pages/faq.html:269
 msgid "Favorite add-ons are add-ons that you have bookmarked to easily get back to later. You can add an add-on to your favorites collection by clicking \"Add to favorites\" on its details page."
 msgstr "Favourite add-ons are add-ons that you have bookmarked to easily get back to later. You can add an add-on to your favourites collection by clicking \"Add to favourites\" on its details page."
 
-#: src/olympia/pages/templates/pages/faq.html:275 src/olympia/templates/menu_links.html:13 src/olympia/templates/impala/header_title.html:17
+#: src/olympia/pages/templates/pages/faq.html:273 src/olympia/templates/menu_links.html:13 src/olympia/templates/impala/header_title.html:17
 msgid "Mobile Add-ons"
 msgstr "Mobile Add-ons"
 
-#: src/olympia/pages/templates/pages/faq.html:278
+#: src/olympia/pages/templates/pages/faq.html:276
 msgid "What are mobile add-ons?"
 msgstr "What are mobile add-ons?"
 
-#: src/olympia/pages/templates/pages/faq.html:279
+#: src/olympia/pages/templates/pages/faq.html:277
 #, python-format
 msgid ""
 "Mobile add-ons work with <a href=\"%(mobile_url)s\">Firefox for Mobile</a> and add or modify functionality just like desktop add-ons. You can find add-ons that work with Firefox for Mobile in our "
@@ -10767,20 +10572,20 @@ msgstr ""
 "Mobile add-ons work with <a href=\"%(mobile_url)s\">Firefox for Mobile</a> and add or modify functionality just like desktop add-ons. You can find add-ons that work with Firefox for Mobile in our "
 "<a href=\"%(gallery_url)s\">gallery</a>."
 
-#: src/olympia/pages/templates/pages/faq.html:288
+#: src/olympia/pages/templates/pages/faq.html:286
 msgid "Developer Topics"
 msgstr "Developer Topics"
 
-#: src/olympia/pages/templates/pages/faq.html:289
+#: src/olympia/pages/templates/pages/faq.html:287
 #, python-format
 msgid "Please see our <a href=\"%(faq_url)s\">Developer FAQ</a> and <a href=\"%(hub_url)s\">Developer Hub</a> for answers to add-on developer-related questions."
 msgstr "Please see our <a href=\"%(faq_url)s\">Developer FAQ</a> and <a href=\"%(hub_url)s\">Developer Hub</a> for answers to add-on developer-related questions."
 
-#: src/olympia/pages/templates/pages/faq.html:294
+#: src/olympia/pages/templates/pages/faq.html:292
 msgid "Still have questions?"
 msgstr "Still have questions?"
 
-#: src/olympia/pages/templates/pages/faq.html:295
+#: src/olympia/pages/templates/pages/faq.html:293
 #, python-format
 msgid "For general Firefox support, visit our <a href=\"%(sumo_url)s\">support website</a>. For general add-on and website questions, visit our <a href=\"%(forum_url)s\">forum</a>."
 msgstr "For general Firefox support, visit our <a href=\"%(sumo_url)s\">support website</a>. For general add-on and web site questions, visit our <a href=\"%(forum_url)s\">forum</a>."
@@ -10928,7 +10733,7 @@ msgstr "Sunbird has retired"
 
 #: src/olympia/pages/templates/pages/sunbird.html:29
 msgid ""
-"Development on the Sunbird project has halted and its final release was on March 30, 2010.  We've been proud to host Sunbird add-ons on this site but as the project is no longer maintained we have "
+"Development on the Sunbird project has halted and its final release was on March 30, 2010. We've been proud to host Sunbird add-ons on this site but as the project is no longer maintained we have "
 "disabled our support for the add-ons."
 msgstr ""
 "Development on the Sunbird project has halted and its final release was on March 30, 2010.  We've been proud to host Sunbird add-ons on this site but as the project is no longer maintained we have "
@@ -11008,7 +10813,7 @@ msgstr "Add a review for {0}"
 #, python-format
 msgid ""
 "<h2>Keep these tips in mind:</h2> <ul> <li> Write like you're telling a friend about your experience with the add-on. Give specifics and helpful details, such as what features you liked and/or "
-"disliked, how easy to use it is, and any disadvantages it has.  Avoid generic language such as calling it \"Great\" or \"Bad\" unless you can give reasons why you believe this is so. </li> <li> "
+"disliked, how easy to use it is, and any disadvantages it has. Avoid generic language such as calling it \"Great\" or \"Bad\" unless you can give reasons why you believe this is so. </li> <li> "
 "Please do not post bug reports in reviews. We do not make your email address available to add-on developers and they may need to contact you to help resolve your issue. See the <a href=\"%(support)s"
 "\">support section</a> to find out where to get assistance for this add-on. </li> <li>Please keep reviews clean, avoid the use of improper language and do not post any personal information. </li> </"
 "ul> <p>Please read the <a href=\"%(guide)s\" target=\"_blank\">Review Guidelines</a> for more detail about user add-on reviews.</p>"
@@ -11249,16 +11054,16 @@ msgstr "{0} Add-ons"
 
 #. L10n: {0} is an application, such as Firefox. This means "any version of
 #. Firefox."
-#: src/olympia/search/views.py:554
+#: src/olympia/search/views.py:547
 msgid "Any {0}"
 msgstr "Any {0}"
 
 #. L10n: "All Systems" means show everything regardless of platform.
-#: src/olympia/search/views.py:589
+#: src/olympia/search/views.py:582
 msgid "All Systems"
 msgstr "All Systems"
 
-#: src/olympia/search/views.py:600
+#: src/olympia/search/views.py:593
 msgid "All Tags"
 msgstr "All Tags"
 
@@ -11432,31 +11237,31 @@ msgstr "Share this Add-on"
 msgid "Share this Collection"
 msgstr "Share this Collection"
 
-#: src/olympia/signing/views.py:30 src/olympia/templates/base.html:75 src/olympia/templates/impala/base.html:115
+#: src/olympia/signing/views.py:33 src/olympia/templates/base.html:71 src/olympia/templates/impala/base.html:112
 msgid "Some features are temporarily disabled while we perform website maintenance. We'll be back to full capacity shortly."
 msgstr "Some features are temporarily disabled while we perform web site maintenance. We'll be back to full capacity shortly."
 
-#: src/olympia/signing/views.py:53
+#: src/olympia/signing/views.py:56
 msgid "Could not find add-on with id \"{}\"."
 msgstr "Could not find add-on with id \"{}\"."
 
-#: src/olympia/signing/views.py:67
+#: src/olympia/signing/views.py:70
 msgid "You do not own this addon."
 msgstr "You do not own this add-on."
 
-#: src/olympia/signing/views.py:82
+#: src/olympia/signing/views.py:87
 msgid "Missing \"upload\" key in multipart file data."
 msgstr "Missing \"upload\" key in multi-part file data."
 
-#: src/olympia/signing/views.py:96
+#: src/olympia/signing/views.py:101
 msgid "Version does not match the manifest file."
 msgstr "Version does not match the manifest file."
 
-#: src/olympia/signing/views.py:100
+#: src/olympia/signing/views.py:105
 msgid "Version already exists."
 msgstr "Version already exists."
 
-#: src/olympia/signing/views.py:136
+#: src/olympia/signing/views.py:141
 msgid "No uploaded file for that addon and version."
 msgstr "No uploaded file for that add-on and version."
 
@@ -11569,89 +11374,89 @@ msgstr "{0} :: Statistics Dashboard"
 msgid "Statistics Dashboard :: Add-ons for {0}"
 msgstr "Statistics Dashboard :: Add-ons for {0}"
 
-#: src/olympia/stats/templates/stats/stats.html:30
-msgid "Controls:"
-msgstr "Controls:"
-
-#: src/olympia/stats/templates/stats/stats.html:33
-msgid "reset zoom"
-msgstr "reset zoom"
-
-#: src/olympia/stats/templates/stats/stats.html:40
-msgid "Group by:"
-msgstr "Group by:"
-
-#: src/olympia/stats/templates/stats/stats.html:42
-msgid "day"
-msgstr "day"
-
-#: src/olympia/stats/templates/stats/stats.html:45
-msgid "week"
-msgstr "week"
-
-#: src/olympia/stats/templates/stats/stats.html:48
-msgid "month"
-msgstr "month"
-
-#: src/olympia/stats/templates/stats/stats.html:54
-msgid "For last:"
-msgstr "For last:"
-
-#: src/olympia/stats/templates/stats/stats.html:57
-msgid "7 days"
-msgstr "7 days"
-
-#: src/olympia/stats/templates/stats/stats.html:60
-msgid "30 days"
-msgstr "30 days"
-
-#: src/olympia/stats/templates/stats/stats.html:63
-msgid "90 days"
-msgstr "90 days"
-
-#: src/olympia/stats/templates/stats/stats.html:66
-msgid "365 days"
-msgstr "365 days"
-
-#: src/olympia/stats/templates/stats/stats.html:69
-msgid "Custom..."
-msgstr "Custom..."
-
 #. {0} is an add-on name
-#: src/olympia/stats/templates/stats/stats.html:88 src/olympia/stats/templates/stats/stats.html:91
+#: src/olympia/stats/templates/stats/stats.html:44 src/olympia/stats/templates/stats/stats.html:47
 msgid "Statistics for {0}"
 msgstr "Statistics for {0}"
 
-#: src/olympia/stats/templates/stats/stats.html:94
+#: src/olympia/stats/templates/stats/stats.html:50
 msgid "Statistics Dashboard"
 msgstr "Statistics Dashboard"
 
-#: src/olympia/stats/templates/stats/stats.html:104
+#: src/olympia/stats/templates/stats/stats.html:57
+msgid "Controls:"
+msgstr "Controls:"
+
+#: src/olympia/stats/templates/stats/stats.html:60
+msgid "reset zoom"
+msgstr "reset zoom"
+
+#: src/olympia/stats/templates/stats/stats.html:67
+msgid "Group by:"
+msgstr "Group by:"
+
+#: src/olympia/stats/templates/stats/stats.html:69
+msgid "day"
+msgstr "day"
+
+#: src/olympia/stats/templates/stats/stats.html:72
+msgid "week"
+msgstr "week"
+
+#: src/olympia/stats/templates/stats/stats.html:75
+msgid "month"
+msgstr "month"
+
+#: src/olympia/stats/templates/stats/stats.html:81
+msgid "For last:"
+msgstr "For last:"
+
+#: src/olympia/stats/templates/stats/stats.html:84
+msgid "7 days"
+msgstr "7 days"
+
+#: src/olympia/stats/templates/stats/stats.html:87
+msgid "30 days"
+msgstr "30 days"
+
+#: src/olympia/stats/templates/stats/stats.html:90
+msgid "90 days"
+msgstr "90 days"
+
+#: src/olympia/stats/templates/stats/stats.html:93
+msgid "365 days"
+msgstr "365 days"
+
+#: src/olympia/stats/templates/stats/stats.html:96
+msgid "Custom..."
+msgstr "Custom..."
+
+#: src/olympia/stats/templates/stats/stats.html:106
 msgid "Statistics processing is currently disabled, so recent data is unavailable. The statistics are still being collected and this page will be updated soon with the missing data."
 msgstr "Statistics processing is currently disabled, so recent data is unavailable. The statistics are still being collected and this page will be updated soon with the missing data."
 
-#: src/olympia/stats/templates/stats/stats.html:110
+#: src/olympia/stats/templates/stats/stats.html:112
 msgid "Loading the latest data&hellip;"
 msgstr "Loading the latest data&hellip;"
 
-#: src/olympia/stats/templates/stats/stats.html:142 src/olympia/stats/templates/stats/reports/overview.html:25 src/olympia/stats/templates/stats/reports/overview.html:37
+#: src/olympia/stats/templates/stats/stats.html:144 src/olympia/stats/templates/stats/reports/overview.html:25 src/olympia/stats/templates/stats/reports/overview.html:37
 #: src/olympia/stats/templates/stats/reports/overview.html:49
 msgid "No data available."
 msgstr "No data available."
 
-#: src/olympia/stats/templates/stats/stats.html:177
+#: src/olympia/stats/templates/stats/stats.html:179
 msgid "This dashboard is currently <b>public</b>."
 msgstr "This dashboard is currently <b>public</b>."
 
-#: src/olympia/stats/templates/stats/stats.html:179
+#: src/olympia/stats/templates/stats/stats.html:181
 msgid "Contribution stats are currently <b>private</b>."
 msgstr "Contribution stats are currently <b>private</b>."
 
-#: src/olympia/stats/templates/stats/stats.html:182
+#: src/olympia/stats/templates/stats/stats.html:184
 msgid "This dashboard is currently <b>private</b>."
 msgstr "This dashboard is currently <b>private</b>."
 
-#: src/olympia/stats/templates/stats/stats.html:185
+#: src/olympia/stats/templates/stats/stats.html:187
 msgid "Change settings."
 msgstr "Change settings."
 
@@ -11814,15 +11619,6 @@ msgstr "User Signups by Date"
 msgid "Application versions by Date"
 msgstr "Application versions by Date"
 
-#: src/olympia/tags/templates/tags/top_cloud.html:4
-msgid "Top {0} Tags"
-msgstr "Top {0} Tags"
-
-#. {0} is the current application name
-#: src/olympia/tags/templates/tags/top_cloud.html:14
-msgid "{0} Top Tags"
-msgstr "{0} Top Tags"
-
 #: src/olympia/templates/amo_footer.html:6 src/olympia/templates/includes/lang_switcher.html:2
 msgid "Other languages"
 msgstr "Other languages"
@@ -11831,11 +11627,11 @@ msgstr "Other languages"
 msgid "Mozilla Add-ons"
 msgstr "Mozilla Add-ons"
 
-#: src/olympia/templates/base.html:91 src/olympia/templates/impala/base.html:81
+#: src/olympia/templates/base.html:89 src/olympia/templates/impala/base.html:78
 msgid "Find add-ons for other applications"
 msgstr "Find add-ons for other applications"
 
-#: src/olympia/templates/base.html:92 src/olympia/templates/impala/base.html:81
+#: src/olympia/templates/base.html:90 src/olympia/templates/impala/base.html:78
 msgid "Other Applications"
 msgstr "Other Applications"
 
@@ -11860,7 +11656,7 @@ msgid "View Mobile Site"
 msgstr "View Mobile Site"
 
 #: src/olympia/templates/copyright.html:7
-msgid "Site Status "
+msgid "Site Status"
 msgstr "Site Status "
 
 #: src/olympia/templates/footer.html:3
@@ -11960,35 +11756,35 @@ msgstr "Welcome, {0}"
 msgid "<a href=\"%(reg)s\">Register</a> or <a href=\"%(login)s\">Log in</a>"
 msgstr "<a href=\"%(reg)s\">Register</a> or <a href=\"%(login)s\">Log in</a>"
 
-#: src/olympia/templates/impala/base.html:126
+#: src/olympia/templates/impala/base.html:123
 #, python-format
 msgid "To try the thousands of add-ons available here, download <a href=\"%(url)s\">Mozilla Firefox</a>, a fast, free way to surf the Web!"
 msgstr "To try the thousands of add-ons available here, download <a href=\"%(url)s\">Mozilla Firefox</a>, a fast, free way to surf the Web!"
 
-#: src/olympia/templates/impala/base.html:138
+#: src/olympia/templates/impala/base.html:135
 #, python-format
 msgid "Add-ons is switching to Firefox Accounts for login. <a href=\"%(url)s\" class=\"fxa-login\">Sign in now to transfer your account.</a>"
 msgstr "Add-ons is switching to Firefox Accounts for login. <a href=\"%(url)s\" class=\"fxa-login\">Sign in now to transfer your account.</a>"
 
 #. {0} is an application, such as Firefox.
-#: src/olympia/templates/impala/base.html:148
+#: src/olympia/templates/impala/base.html:145
 msgid "Welcome to {0} Add-ons."
 msgstr "Welcome to {0} Add-ons."
 
-#: src/olympia/templates/impala/base.html:151
+#: src/olympia/templates/impala/base.html:148
 msgid "Choose from thousands of extra features and styles to make Firefox your own."
 msgstr "Choose from thousands of extra features and styles to make Firefox your own."
 
-#: src/olympia/templates/impala/base.html:156
+#: src/olympia/templates/impala/base.html:153
 #, python-format
 msgid "Add extra features and styles to make %(app)s your own."
 msgstr "Add extra features and styles to make %(app)s your own."
 
-#: src/olympia/templates/impala/base.html:164
+#: src/olympia/templates/impala/base.html:161
 msgid "On the go?"
 msgstr "On the go?"
 
-#: src/olympia/templates/impala/base.html:166
+#: src/olympia/templates/impala/base.html:163
 msgid "Check out our <a class=\"mobile-link\" href=\"#\">Mobile Add-ons site</a>."
 msgstr "Check out our <a class=\"mobile-link\" href=\"#\">Mobile Add-ons site</a>."
 
@@ -12212,19 +12008,19 @@ msgstr "No user with that email."
 
 #. L10n: {id} will be something like "13ad6a", just a random number
 #. to differentiate this user from other anonymous users.
-#: src/olympia/users/models.py:353
+#: src/olympia/users/models.py:362
 msgid "Anonymous user {id}"
 msgstr "Anonymous user {id}"
 
-#: src/olympia/users/models.py:410
+#: src/olympia/users/models.py:419
 msgid "Your account has been restricted"
 msgstr "Your account has been restricted"
 
-#: src/olympia/users/models.py:480
+#: src/olympia/users/models.py:489
 msgid "Please confirm your email address"
 msgstr "Please confirm your email address"
 
-#: src/olympia/users/models.py:506
+#: src/olympia/users/models.py:515
 msgid "My Mobile Add-ons"
 msgstr "My Mobile Add-ons"
 
@@ -12507,7 +12303,7 @@ msgstr "Password"
 
 #: src/olympia/users/templates/users/edit.html:70
 #, python-format
-msgid "Change your password.  If you forgot your password, you can <a href=\"%(reset_url)s\">use the reset form</a>."
+msgid "Change your password. If you forgot your password, you can <a href=\"%(reset_url)s\">use the reset form</a>."
 msgstr "Change your password.  If you forgot your password, you can <a href=\"%(reset_url)s\">use the reset form</a>."
 
 #: src/olympia/users/templates/users/edit.html:76
@@ -12527,7 +12323,7 @@ msgid "Profile"
 msgstr "Profile"
 
 #: src/olympia/users/templates/users/edit.html:100
-msgid "Give us a bit more information about yourself.  All these fields are optional, but they'll help other users get to know you better."
+msgid "Give us a bit more information about yourself. All these fields are optional, but they'll help other users get to know you better."
 msgstr "Give us a bit more information about yourself.  All these fields are optional, but they'll help other users get to know you better."
 
 #: src/olympia/users/templates/users/edit.html:124
@@ -12743,7 +12539,7 @@ msgid "Confirm password"
 msgstr "Confirm password"
 
 #: src/olympia/users/templates/users/pwreset_confirm.html:47
-msgid "The password reset link was invalid, possibly because it has already been used.  Please request a new password reset."
+msgid "The password reset link was invalid, possibly because it has already been used. Please request a new password reset."
 msgstr "The password reset link was invalid, possibly because it has already been used.  Please request a new password reset."
 
 #: src/olympia/users/templates/users/pwreset_request.html:15
@@ -12932,7 +12728,7 @@ msgstr "We could not unsubscribe you"
 
 #: src/olympia/users/templates/users/unsubscribe.html:30
 #, python-format
-msgid "Unfortunately, we weren't able to unsubscribe you.  The link you clicked is invalid. However, you can unsubscribe still unsubscribe on your <a href=\"%(edit_url)s\">edit profile page</a>."
+msgid "Unfortunately, we weren't able to unsubscribe you. The link you clicked is invalid. However, you can unsubscribe still unsubscribe on your <a href=\"%(edit_url)s\">edit profile page</a>."
 msgstr ""
 "Unfortunately, we weren't able to unsubscribe you.  The link you clicked is invalid. However, you can unsubscribe still by clicking unsubscribe on your <a href=\"%(edit_url)s\">edit profile page</"
 "a>."
@@ -12988,15 +12784,15 @@ msgstr "%s Version History"
 msgid "Version History with Changelogs"
 msgstr "Version History with Changelogs"
 
-#: src/olympia/versions/models.py:314
+#: src/olympia/versions/models.py:313
 msgid "Add-on uses binary components."
 msgstr "Add-on uses binary components."
 
-#: src/olympia/versions/models.py:317
+#: src/olympia/versions/models.py:316
 msgid "Add-on has opted into strict compatibility checking."
 msgstr "Add-on has opted into strict compatibility checking."
 
-#: src/olympia/versions/models.py:715
+#: src/olympia/versions/models.py:711
 msgid "{app} {min} and later"
 msgstr "{app} {min} and later"
 
@@ -13072,3 +12868,7 @@ msgstr "Email when finished"
 #: src/olympia/zadmin/forms.py:105
 msgid "Log emails instead of sending"
 msgstr "Log emails instead of sending"
+
+#: src/olympia/zadmin/forms.py:215
+msgid "Deleted versions can`t be changed."
+msgstr ""

--- a/locale/en_GB/LC_MESSAGES/djangojs.po
+++ b/locale/en_GB/LC_MESSAGES/djangojs.po
@@ -3,134 +3,391 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2016-02-24 21:23+0000\n"
+"POT-Creation-Date: 2016-04-18 15:47+0000\n"
 "PO-Revision-Date: 2016-01-25 00:00+0000\n"
 "Last-Translator: Ian Neal <iann_bugzilla@blueyonder.co.uk>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
+"Language: \n"
 "MIME-Version: 1.0\n"
-"Content-Type: text/plain; charset=utf-8\n"
+"Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Generated-By: Babel 2.2.0\n"
 
-#: static/js/common/ratingwidget.js:31
+#: static/js/common-all.js:1426 static/js/impala-all.js:1511 static/js/zamboni/discovery-all.js:12598 static/js/zamboni/init.js:28 static/js/zamboni/mobile-all.js:14945
+msgid "This feature is temporarily disabled while we perform website maintenance. Please check back a little later."
+msgstr "This feature is temporarily disabled while we perform web site maintenance. Please check back a little later."
+
+#. L10n: {0} is an app name like Firefox.
+#: static/js/common-all.js:1837 static/js/impala-all.js:1922 static/js/zamboni/buttons.js:73 static/js/zamboni/discovery-all.js:13108
+msgid "Accept and Install"
+msgstr "Accept and Install"
+
+#: static/js/common-all.js:1837 static/js/impala-all.js:1922 static/js/zamboni/buttons.js:73 static/js/zamboni/discovery-all.js:13108
+msgid "Add to {0}"
+msgstr "Add to {0}"
+
+#: static/js/common-all.js:1842 static/js/impala-all.js:1927 static/js/zamboni/buttons.js:78 static/js/zamboni/discovery-all.js:13113
+msgid "Download Now"
+msgstr "Download Now"
+
+#: static/js/common-all.js:1883 static/js/impala-all.js:1968 static/js/zamboni/buttons.js:119 static/js/zamboni/discovery-all.js:13154
+msgid "Add-on has not been updated to support default-to-compatible."
+msgstr "Add-on has not been updated to support default-to-compatible."
+
+#: static/js/common-all.js:1888 static/js/impala-all.js:1973 static/js/zamboni/buttons.js:124 static/js/zamboni/discovery-all.js:13159
+msgid "You need to be using Firefox 10.0 or higher."
+msgstr "You need to be using Firefox 10.0 or higher."
+
+#: static/js/common-all.js:1900 static/js/impala-all.js:1985 static/js/zamboni/buttons.js:136 static/js/zamboni/discovery-all.js:13171
+msgid "Mozilla has marked this version as incompatible with your Firefox version."
+msgstr "Mozilla has marked this version as incompatible with your Firefox version."
+
+#. L10n: {0} is an platform like Windows or Linux.
+#: static/js/common-all.js:1981 static/js/impala-all.js:2066 static/js/zamboni/buttons.js:217 static/js/zamboni/discovery-all.js:13252
+msgid "Install for {0} anyway"
+msgstr "Install for {0} anyway"
+
+#: static/js/common-all.js:1981 static/js/impala-all.js:2066 static/js/zamboni/buttons.js:217 static/js/zamboni/discovery-all.js:13252
+msgid "Download for {0} anyway"
+msgstr "Download for {0} anyway"
+
+#: static/js/common-all.js:2038 static/js/impala-all.js:2123 static/js/zamboni/buttons.js:274 static/js/zamboni/discovery-all.js:13309
+msgid "Not available for your platform"
+msgstr "Not available for your platform"
+
+#. L10n: {0} is an app name, {1} is the app version.
+#: static/js/common-all.js:2049 static/js/common-all.js:2086 static/js/impala-all.js:2134 static/js/impala-all.js:2171 static/js/zamboni/buttons.js:286 static/js/zamboni/buttons.js:324
+#: static/js/zamboni/discovery-all.js:13320 static/js/zamboni/discovery-all.js:13357
+msgid "Not available for {0} {1}"
+msgstr "Not available for {0} {1}"
+
+#: static/js/common-all.js:2112 static/js/impala-all.js:2197 static/js/zamboni/buttons.js:351 static/js/zamboni/discovery-all.js:13383
+msgid "Works with {app} {min} - {max}"
+msgstr "Works with {app} {min} - {max}"
+
+#: static/js/common-all.js:2114 static/js/impala-all.js:2199 static/js/zamboni/buttons.js:353 static/js/zamboni/discovery-all.js:13385
+msgid "View other versions"
+msgstr "View other versions"
+
+#: static/js/common-all.js:2162 static/js/impala-all.js:2247 static/js/zamboni/buttons.js:401 static/js/zamboni/discovery-all.js:13433
+msgid "Only with Firefox — Get Firefox Now!"
+msgstr "Only with Firefox — Get Firefox Now!"
+
+#: static/js/common-all.js:2278 static/js/impala-all.js:2363 static/js/zamboni/buttons.js:517 static/js/zamboni/discovery-all.js:13549 static/js/zamboni/mobile-all.js:15177
+#: static/js/zamboni/mobile/buttons.js:43
+msgid "Sorry, you need a Mozilla-based browser (such as Firefox) to install a search plugin."
+msgstr "Sorry, you need a Mozilla-based browser (such as Firefox) to install a search plugin."
+
+#: static/js/common-all.js:9088 static/js/impala-all.js:9649 static/js/zamboni/global.js:410
+msgid "Loading..."
+msgstr "Loading..."
+
+#. L10n: {0} is the number of characters left.
+#: static/js/common-all.js:9152 static/js/impala-all.js:9713 static/js/zamboni/global.js:474
+msgid "<b>{0}</b> character left."
+msgid_plural "<b>{0}</b> characters left."
+msgstr[0] "<b>{0}</b> character left."
+msgstr[1] "<b>{0}</b> characters left."
+
+#: static/js/common-all.js:9589 static/js/common-min.js:6 static/js/impala-all.js:10052 static/js/impala-min.js:6 static/js/common/ratingwidget.js:31 static/js/zamboni/mobile-all.js:16123
+#: static/js/zamboni/mobile-min.js:6
 msgid "{0} star"
 msgid_plural "{0} stars"
 msgstr[0] "{0} star"
 msgstr[1] "{0} stars"
 
-#: static/js/common/upload-addon.js:41 static/js/common/upload-image.js:128
+#: static/js/common-all.js:9676 static/js/common-min.js:6 static/js/impala-all.js:10139 static/js/impala-min.js:6 static/js/zamboni/l10n.js:45
+msgid "Remove this localization"
+msgstr "Remove this localisation"
+
+#: static/js/common-all.js:10193 static/js/common-min.js:6 static/js/impala-all.js:10674 static/js/impala-min.js:6 static/js/zamboni/discovery-all.js:13678
+msgid "close"
+msgstr ""
+
+#: static/js/common-all.js:10860 static/js/common-min.js:6 static/js/impala-all.js:11481 static/js/impala-min.js:6 static/js/impala/reviews.js:23 static/js/zamboni/reviews.js:18
+msgid "Flagged for review"
+msgstr "Flagged for review"
+
+#: static/js/common-all.js:10876 static/js/common-min.js:6 static/js/impala-all.js:11498 static/js/impala-min.js:6 static/js/impala/reviews.js:40 static/js/zamboni/reviews.js:34
+msgid "Your input is required"
+msgstr "Your input is required"
+
+#: static/js/common-all.js:10945 static/js/common-min.js:6 static/js/impala-all.js:11610 static/js/impala-min.js:7 static/js/impala/reviews.js:152 static/js/zamboni/reviews.js:103
+msgid "Marked for deletion"
+msgstr "Marked for deletion"
+
+#: static/js/common-all.js:11573 static/js/common-min.js:7 static/js/impala-all.js:13809 static/js/impala-min.js:8 static/js/zamboni/collections.js:229
+msgid "Adding to Favorites&hellip;"
+msgstr "Adding to Favourites&hellip;"
+
+#: static/js/common-all.js:11576 static/js/common-min.js:7 static/js/impala-all.js:13812 static/js/impala-min.js:8 static/js/zamboni/collections.js:232
+msgid "Removing Favorite&hellip;"
+msgstr "Removing Favourite&hellip;"
+
+#: static/js/common-all.js:11579 static/js/common-min.js:7 static/js/impala-all.js:13815 static/js/impala-min.js:8 static/js/zamboni/collections.js:235
+msgid "Add to Favorites"
+msgstr "Add to Favourites"
+
+#: static/js/common-all.js:11582 static/js/common-min.js:7 static/js/impala-all.js:13818 static/js/impala-min.js:8 static/js/zamboni/collections.js:238
+msgid "Remove from Favorites"
+msgstr "Remove from Favourites"
+
+#: static/js/common-all.js:11647 static/js/common-min.js:7 static/js/impala-all.js:13883 static/js/impala-min.js:8 static/js/zamboni/collections.js:303
+msgid "Pending"
+msgstr "Pending"
+
+#: static/js/common-all.js:11648 static/js/common-min.js:7 static/js/impala-all.js:13884 static/js/impala-min.js:8 static/js/zamboni/collections.js:304
+msgid "Add a comment"
+msgstr "Add a comment"
+
+#: static/js/common-all.js:11648 static/js/common-min.js:7 static/js/impala-all.js:13884 static/js/impala-min.js:8 static/js/zamboni/collections.js:304
+msgid "Comment"
+msgstr "Comment"
+
+#: static/js/common-all.js:11649 static/js/common-min.js:7 static/js/impala-all.js:13885 static/js/impala-min.js:8 static/js/zamboni/collections.js:305
+msgid "Remove this add-on from the collection"
+msgstr "Remove this add-on from the collection"
+
+#: static/js/common-all.js:11649 static/js/common-all.js:11678 static/js/common-min.js:7 static/js/impala-all.js:13885 static/js/impala-all.js:13914 static/js/impala-min.js:8
+#: static/js/zamboni/collections.js:305 static/js/zamboni/collections.js:334
+msgid "Remove"
+msgstr "Remove"
+
+#: static/js/common-all.js:11678 static/js/common-min.js:7 static/js/impala-all.js:13914 static/js/impala-min.js:8 static/js/zamboni/collections.js:334
+msgid "Remove this user as a contributor"
+msgstr "Remove this user as a contributor"
+
+#: static/js/common-all.js:11690 static/js/common-min.js:7 static/js/impala-all.js:13926 static/js/impala-min.js:8 static/js/zamboni/collections.js:346
+msgid "An email address is required."
+msgstr "An email address is required."
+
+#: static/js/common-all.js:11708 static/js/common-min.js:7 static/js/impala-all.js:13944 static/js/impala-min.js:8 static/js/zamboni/collections.js:364
+msgid "You cannot add yourself as a contributor."
+msgstr "You cannot add yourself as a contributor."
+
+#: static/js/common-all.js:11710 static/js/common-min.js:7 static/js/impala-all.js:13946 static/js/impala-min.js:8 static/js/zamboni/collections.js:366
+msgid "You have already added that user."
+msgstr "You have already added that user."
+
+#: static/js/common-all.js:11917 static/js/common-min.js:7 static/js/impala-all.js:14153 static/js/impala-min.js:8 static/js/zamboni/collections.js:573
+msgid "Add to favorites"
+msgstr "Add to favourites"
+
+#: static/js/common-all.js:11921 static/js/common-min.js:7 static/js/impala-all.js:14157 static/js/impala-min.js:8 static/js/zamboni/collections.js:577
+msgid "Remove from favorites"
+msgstr "Remove from favourites"
+
+#: static/js/common-all.js:11939 static/js/common-min.js:7 static/js/impala-all.js:14175 static/js/impala-all.js:14233 static/js/impala-min.js:8 static/js/impala/collections.js:10
+#: static/js/zamboni/collections.js:595
+msgid "Follow this Collection"
+msgstr "Follow this Collection"
+
+#: static/js/common-all.js:11948 static/js/common-min.js:7 static/js/impala-all.js:14184 static/js/impala-min.js:8 static/js/zamboni/collections.js:604
+msgid "Stop following"
+msgstr "Stop following"
+
+#: static/js/common-all.js:12096 static/js/common-min.js:7 static/js/zamboni/password-strength.js:20
+msgid "Password strength:"
+msgstr "Password strength:"
+
+#: static/js/common-all.js:12102 static/js/common-min.js:7 static/js/zamboni/password-strength.js:26
+msgid "At least {0} character left."
+msgid_plural "At least {0} characters left."
+msgstr[0] "At least {0} character left."
+msgstr[1] "At least {0} characters left."
+
+#: static/js/common-all.js:12286 static/js/common-min.js:7 static/js/impala-all.js:14632 static/js/impala-min.js:8 static/js/impala/suggestions.js:39
+msgid "Search themes for <b>{0}</b>"
+msgstr "Search themes for <b>{0}</b>"
+
+#: static/js/common-all.js:12288 static/js/common-min.js:7 static/js/impala-all.js:14634 static/js/impala-min.js:8 static/js/impala/suggestions.js:41
+msgid "Search apps for <b>{0}</b>"
+msgstr "Search apps for <b>{0}</b>"
+
+#: static/js/common-all.js:12290 static/js/common-min.js:7 static/js/impala-all.js:14636 static/js/impala-min.js:8 static/js/impala/suggestions.js:43
+msgid "Search add-ons for <b>{0}</b>"
+msgstr "Search add-ons for <b>{0}</b>"
+
+#: static/js/common-all.js:12521 static/js/common-min.js:7 static/js/impala-all.js:14867 static/js/impala-min.js:8 static/js/impala/site_suggestions.js:46
+msgid "Category"
+msgstr "Category"
+
+#. L10n: {0} is an app name.
+#: static/js/impala-all.js:11632 static/js/impala-min.js:7 static/js/impala/listing.js:11 static/js/zamboni/themes.js:13
+msgid "This theme is incompatible with your version of {0}"
+msgstr "This theme is incompatible with your version of {0}"
+
+#: static/js/impala-all.js:12146 static/js/impala-all.js:14331 static/js/impala-min.js:7 static/js/impala-min.js:8 static/js/common/upload-image.js:97 static/js/impala/users.js:51
+#: static/js/zamboni/devhub-all.js:894 static/js/zamboni/devhub-min.js:1
+msgid "Images must be either PNG or JPG."
+msgstr "Images must be either PNG or JPG."
+
+#: static/js/impala-all.js:12150 static/js/impala-min.js:7 static/js/common/upload-image.js:101 static/js/zamboni/devhub-all.js:898 static/js/zamboni/devhub-min.js:1
+msgid "Videos must be in WebM."
+msgstr "Videos must be in WebM."
+
+#: static/js/impala-all.js:12177 static/js/impala-min.js:7 static/js/common/upload-addon.js:41 static/js/common/upload-image.js:128 static/js/zamboni/devhub-all.js:272
+#: static/js/zamboni/devhub-all.js:925 static/js/zamboni/devhub-min.js:1
 msgid "There was a problem contacting the server."
 msgstr "There was a problem contacting the server."
 
-#: static/js/common/upload-addon.js:69
+#: static/js/impala-all.js:13298 static/js/impala-min.js:7 static/js/impala/persona_creation.js:60
+msgid "All Rights Reserved"
+msgstr "All Rights Reserved"
+
+#: static/js/impala-all.js:13302 static/js/impala-min.js:7 static/js/impala/persona_creation.js:64
+msgid "Creative Commons Attribution 3.0"
+msgstr "Creative Commons Attribution 3.0"
+
+#: static/js/impala-all.js:13307 static/js/impala-min.js:7 static/js/impala/persona_creation.js:69
+msgid "Creative Commons Attribution-NonCommercial 3.0"
+msgstr "Creative Commons Attribution-NonCommercial 3.0"
+
+#: static/js/impala-all.js:13312 static/js/impala-min.js:7 static/js/impala/persona_creation.js:74
+msgid "Creative Commons Attribution-NonCommercial-NoDerivs 3.0"
+msgstr "Creative Commons Attribution-NonCommercial-NoDerivs 3.0"
+
+#: static/js/impala-all.js:13317 static/js/impala-min.js:7 static/js/impala/persona_creation.js:79
+msgid "Creative Commons Attribution-NonCommercial-Share Alike 3.0"
+msgstr "Creative Commons Attribution-NonCommercial-Share Alike 3.0"
+
+#: static/js/impala-all.js:13322 static/js/impala-min.js:7 static/js/impala/persona_creation.js:84
+msgid "Creative Commons Attribution-NoDerivs 3.0"
+msgstr "Creative Commons Attribution-NoDerivs 3.0"
+
+#: static/js/impala-all.js:13327 static/js/impala-min.js:7 static/js/impala/persona_creation.js:89
+msgid "Creative Commons Attribution-ShareAlike 3.0"
+msgstr "Creative Commons Attribution-ShareAlike 3.0"
+
+#: static/js/impala-all.js:13530 static/js/impala-min.js:7 static/js/impala/persona_creation.js:292
+msgid "Your Theme's Name"
+msgstr "Your Theme's Name"
+
+#: static/js/impala-all.js:14242 static/js/impala-min.js:8 static/js/impala/collections.js:19
+msgid "Stop Following"
+msgstr "Stop Following"
+
+#: static/js/impala-all.js:14243 static/js/impala-min.js:8 static/js/impala/collections.js:20
+msgid "Following"
+msgstr "Following"
+
+#: static/js/impala-all.js:14313 static/js/impala-min.js:8 static/js/impala/users.js:33
+msgid "use original"
+msgstr "use original"
+
+#: static/js/impala-all.js:14523 static/js/impala-min.js:8 static/js/impala/search.js:114
+msgid "Updating results&hellip;"
+msgstr "Updating results&hellip;"
+
+#: static/js/common/upload-addon.js:69 static/js/zamboni/devhub-all.js:300 static/js/zamboni/devhub-min.js:1
 msgid "Select a file..."
 msgstr "Select a file..."
 
-#: static/js/common/upload-addon.js:70
+#: static/js/common/upload-addon.js:70 static/js/zamboni/devhub-all.js:301 static/js/zamboni/devhub-min.js:1
 msgid "Your add-on should end with .xpi, .jar or .xml"
 msgstr "Your add-on should end with .xpi, .jar or .xml"
 
 #. L10n: {0} is the percent of the file that has been uploaded.
-#: static/js/common/upload-addon.js:104
+#: static/js/common/upload-addon.js:104 static/js/zamboni/devhub-all.js:335 static/js/zamboni/devhub-min.js:1
 #, python-format
 msgid "{0}% complete"
 msgstr "{0}% complete"
 
 #. L10n: "{bytes uploaded} of {total filesize}".
-#: static/js/common/upload-addon.js:107
+#: static/js/common/upload-addon.js:107 static/js/zamboni/devhub-all.js:338 static/js/zamboni/devhub-min.js:1
 msgid "{0} of {1}"
 msgstr "{0} of {1}"
 
-#: static/js/common/upload-addon.js:140
+#: static/js/common/upload-addon.js:140 static/js/zamboni/devhub-all.js:371 static/js/zamboni/devhub-min.js:1
 msgid "Cancel"
 msgstr "Cancel"
 
-#: static/js/common/upload-addon.js:162
+#: static/js/common/upload-addon.js:162 static/js/zamboni/devhub-all.js:393 static/js/zamboni/devhub-min.js:1
 msgid "Uploading {0}"
 msgstr "Uploading {0}"
 
-#: static/js/common/upload-addon.js:189
+#: static/js/common/upload-addon.js:189 static/js/zamboni/devhub-all.js:420 static/js/zamboni/devhub-min.js:1
 msgid "Error with {0}"
 msgstr "Error with {0}"
 
-#: static/js/common/upload-addon.js:194
+#: static/js/common/upload-addon.js:194 static/js/zamboni/devhub-all.js:425 static/js/zamboni/devhub-min.js:1
 msgid "Your add-on failed validation with {0} error."
 msgid_plural "Your add-on failed validation with {0} errors."
 msgstr[0] "Your add-on failed validation with {0} error."
 msgstr[1] "Your add-on failed validation with {0} errors."
 
-#: static/js/common/upload-addon.js:208
+#: static/js/common/upload-addon.js:208 static/js/zamboni/devhub-all.js:439 static/js/zamboni/devhub-min.js:1
 msgid "&hellip;and {0} more"
 msgid_plural "&hellip;and {0} more"
 msgstr[0] "&hellip;and {0} more"
 msgstr[1] "&hellip;and {0} more"
 
-#: static/js/common/upload-addon.js:222 static/js/common/upload-addon.js:512
+#: static/js/common/upload-addon.js:222 static/js/common/upload-addon.js:497 static/js/zamboni/devhub-all.js:453 static/js/zamboni/devhub-all.js:743 static/js/zamboni/devhub-min.js:1
 msgid "See full validation report"
 msgstr "See full validation report"
 
-#: static/js/common/upload-addon.js:234
+#: static/js/common/upload-addon.js:234 static/js/zamboni/devhub-all.js:465 static/js/zamboni/devhub-min.js:1
 msgid "Validating {0}"
 msgstr "Validating {0}"
 
 #. L10n: first argument is an HTTP status code
-#: static/js/common/upload-addon.js:273
+#: static/js/common/upload-addon.js:273 static/js/zamboni/devhub-all.js:504 static/js/zamboni/devhub-min.js:1
 msgid "Received an empty response from the server; status: {0}"
 msgstr "Received an empty response from the server; status: {0}"
 
-#: static/js/common/upload-addon.js:373
+#: static/js/common/upload-addon.js:370 static/js/zamboni/devhub-all.js:604 static/js/zamboni/devhub-min.js:1
 msgid "Unexpected server error while validating."
 msgstr "Unexpected server error while validating."
 
-#: static/js/common/upload-addon.js:412
+#: static/js/common/upload-addon.js:409 static/js/zamboni/devhub-all.js:643 static/js/zamboni/devhub-min.js:1
 msgid "Finished validating {0}"
 msgstr "Finished validating {0}"
 
-#: static/js/common/upload-addon.js:418
+#: static/js/common/upload-addon.js:415 static/js/zamboni/devhub-all.js:649 static/js/zamboni/devhub-min.js:1
 msgid "Your add-on validation timed out, it will be manually reviewed."
 msgstr "Your add-on validation timed out, it will be manually reviewed."
 
-#: static/js/common/upload-addon.js:421
+#: static/js/common/upload-addon.js:418 static/js/zamboni/devhub-all.js:652 static/js/zamboni/devhub-min.js:1
 msgid "Your add-on was validated with no errors and {0} warning."
 msgid_plural "Your add-on was validated with no errors and {0} warnings."
 msgstr[0] "Your add-on was validated with no errors and {0} warning."
 msgstr[1] "Your add-on was validated with no errors and {0} warnings."
 
-#: static/js/common/upload-addon.js:426
+#: static/js/common/upload-addon.js:423 static/js/zamboni/devhub-all.js:657 static/js/zamboni/devhub-min.js:1
 msgid "Your add-on was validated with no errors and {0} message."
 msgid_plural "Your add-on was validated with no errors and {0} messages."
 msgstr[0] "Your add-on was validated with no errors and {0} message."
 msgstr[1] "Your add-on was validated with no errors and {0} messages."
 
-#: static/js/common/upload-addon.js:431
+#: static/js/common/upload-addon.js:428 static/js/zamboni/devhub-all.js:662 static/js/zamboni/devhub-min.js:1
 msgid "Your add-on was validated with no errors or warnings."
 msgstr "Your add-on was validated with no errors or warnings."
 
-#: static/js/common/upload-addon.js:446
+#: static/js/common/upload-addon.js:443 static/js/zamboni/devhub-all.js:677 static/js/zamboni/devhub-min.js:1
 msgid "Your submission will be automatically signed."
 msgstr "Your submission will be automatically signed."
 
-#: static/js/common/upload-addon.js:465
+#: static/js/common/upload-addon.js:450 static/js/zamboni/devhub-all.js:696 static/js/zamboni/devhub-min.js:1
 msgid "Include detailed version notes (this can be done in the next step)."
 msgstr "Include detailed version notes (this can be done in the next step)."
 
-#: static/js/common/upload-addon.js:466
+#: static/js/common/upload-addon.js:451 static/js/zamboni/devhub-all.js:697 static/js/zamboni/devhub-min.js:1
 msgid "If your add-on requires an account to a website in order to be fully tested, include a test username and password in the Notes to Reviewer (this can be done in the next step)."
 msgstr "If your add-on requires an account to a website in order to be fully tested, include a test username and password in the Notes to Reviewer (this can be done in the next step)."
 
-#: static/js/common/upload-addon.js:467
+#: static/js/common/upload-addon.js:452 static/js/zamboni/devhub-all.js:698 static/js/zamboni/devhub-min.js:1
 msgid "If your add-on is intended for a limited audience you should choose Preliminary Review instead of Full Review."
 msgstr "If your add-on is intended for a limited audience you should choose Preliminary Review instead of Full Review."
 
-#: static/js/common/upload-addon.js:480
+#: static/js/common/upload-addon.js:465 static/js/zamboni/devhub-all.js:711 static/js/zamboni/devhub-min.js:1
 msgid "Add-on submission checklist"
 msgstr "Add-on submission checklist"
 
-#: static/js/common/upload-addon.js:481
+#: static/js/common/upload-addon.js:466 static/js/zamboni/devhub-all.js:712 static/js/zamboni/devhub-min.js:1
 msgid "Please verify the following points before finalizing your submission. This will minimize delays or misunderstanding during the review process:"
 msgstr "Please verify the following points before finalising your submission. This will minimise delays or misunderstanding during the review process:"
 
-#: static/js/common/upload-addon.js:483
+#: static/js/common/upload-addon.js:468 static/js/zamboni/devhub-all.js:714 static/js/zamboni/devhub-min.js:1
 msgid ""
 "Compiled binaries, as well as minified or obfuscated scripts (excluding known libraries) need to have their sources submitted separately for review. Make sure that you use the source code upload "
 "field to avoid having your submission rejected."
@@ -138,1080 +395,844 @@ msgstr ""
 "Compiled binaries, as well as minified or obfuscated scripts (excluding known libraries) need to have their sources submitted separately for review. Make sure that you use the source code upload "
 "field to avoid having your submission rejected."
 
-#: static/js/common/upload-addon.js:501
+#: static/js/common/upload-addon.js:486 static/js/zamboni/devhub-all.js:732 static/js/zamboni/devhub-min.js:1
 msgid "The validation process found these issues that can lead to rejections:"
 msgstr "The validation process found these issues that can lead to rejections:"
 
-#: static/js/common/upload-addon.js:518
+#: static/js/common/upload-addon.js:503 static/js/zamboni/devhub-all.js:749 static/js/zamboni/devhub-min.js:1
 msgid "If you are unfamiliar with the add-ons review process, you can read about it here."
 msgstr "If you are unfamiliar with the add-ons review process, you can read about it here."
 
-#: static/js/common/upload-addon.js:555
+#: static/js/common/upload-addon.js:540 static/js/zamboni/devhub-all.js:786 static/js/zamboni/devhub-min.js:1
 msgid "Sorry, no supported platform has been found."
 msgstr "Sorry, no supported platform has been found."
 
-#: static/js/common/upload-base.js:57
+#: static/js/common/upload-base.js:57 static/js/zamboni/devhub-all.js:187 static/js/zamboni/devhub-min.js:1
 msgid "The filetype you uploaded isn't recognized."
 msgstr "The filetype you uploaded isn't recognised."
 
-#: static/js/common/upload-base.js:79
+#: static/js/common/upload-base.js:79 static/js/zamboni/devhub-all.js:209 static/js/zamboni/devhub-min.js:1
 msgid "You cancelled the upload."
 msgstr "You cancelled the upload."
 
-#: static/js/common/upload-image.js:97 static/js/impala/users.js:51
-msgid "Images must be either PNG or JPG."
-msgstr "Images must be either PNG or JPG."
-
-#: static/js/common/upload-image.js:101
-msgid "Videos must be in WebM."
-msgstr "Videos must be in WebM."
-
-#: static/js/impala/collections.js:10 static/js/zamboni/collections.js:595
-msgid "Follow this Collection"
-msgstr "Follow this Collection"
-
-#: static/js/impala/collections.js:19
-msgid "Stop Following"
-msgstr "Stop Following"
-
-#: static/js/impala/collections.js:20
-msgid "Following"
-msgstr "Following"
-
-#. L10n: {0} is an app name.
-#: static/js/impala/listing.js:11 static/js/zamboni/themes.js:13
-msgid "This theme is incompatible with your version of {0}"
-msgstr "This theme is incompatible with your version of {0}"
-
-#: static/js/impala/persona_creation.js:60
-msgid "All Rights Reserved"
-msgstr "All Rights Reserved"
-
-#: static/js/impala/persona_creation.js:64
-msgid "Creative Commons Attribution 3.0"
-msgstr "Creative Commons Attribution 3.0"
-
-#: static/js/impala/persona_creation.js:69
-msgid "Creative Commons Attribution-NonCommercial 3.0"
-msgstr "Creative Commons Attribution-NonCommercial 3.0"
-
-#: static/js/impala/persona_creation.js:74
-msgid "Creative Commons Attribution-NonCommercial-NoDerivs 3.0"
-msgstr "Creative Commons Attribution-NonCommercial-NoDerivs 3.0"
-
-#: static/js/impala/persona_creation.js:79
-msgid "Creative Commons Attribution-NonCommercial-Share Alike 3.0"
-msgstr "Creative Commons Attribution-NonCommercial-Share Alike 3.0"
-
-#: static/js/impala/persona_creation.js:84
-msgid "Creative Commons Attribution-NoDerivs 3.0"
-msgstr "Creative Commons Attribution-NoDerivs 3.0"
-
-#: static/js/impala/persona_creation.js:89
-msgid "Creative Commons Attribution-ShareAlike 3.0"
-msgstr "Creative Commons Attribution-ShareAlike 3.0"
-
-#: static/js/impala/persona_creation.js:292
-msgid "Your Theme's Name"
-msgstr "Your Theme's Name"
-
-#: static/js/impala/reviews.js:23 static/js/zamboni/reviews.js:18
-msgid "Flagged for review"
-msgstr "Flagged for review"
-
-#: static/js/impala/reviews.js:40 static/js/zamboni/reviews.js:34
-msgid "Your input is required"
-msgstr "Your input is required"
-
-#: static/js/impala/reviews.js:152 static/js/zamboni/reviews.js:103
-msgid "Marked for deletion"
-msgstr "Marked for deletion"
-
-#: static/js/impala/search.js:114
-msgid "Updating results&hellip;"
-msgstr "Updating results&hellip;"
-
-#: static/js/impala/site_suggestions.js:46
-msgid "Category"
-msgstr "Category"
-
-#: static/js/impala/suggestions.js:39
-msgid "Search themes for <b>{0}</b>"
-msgstr "Search themes for <b>{0}</b>"
-
-#: static/js/impala/suggestions.js:41
-msgid "Search apps for <b>{0}</b>"
-msgstr "Search apps for <b>{0}</b>"
-
-#: static/js/impala/suggestions.js:43
-msgid "Search add-ons for <b>{0}</b>"
-msgstr "Search add-ons for <b>{0}</b>"
-
-#: static/js/impala/users.js:33
-msgid "use original"
-msgstr "use original"
-
-#: static/js/impala/stats/chart.js:267
+#: static/js/impala/stats/chart.js:267 static/js/zamboni/stats-all.js:16898 static/js/zamboni/stats-min.js:5
 msgid "Week of {0}"
 msgstr "Week of {0}"
 
-#: static/js/impala/stats/chart.js:269
+#: static/js/impala/stats/chart.js:269 static/js/zamboni/stats-all.js:16900 static/js/zamboni/stats-min.js:5
 msgid " downloads"
-msgstr " downloads"
+msgstr ""
 
-#: static/js/impala/stats/chart.js:270
+#: static/js/impala/stats/chart.js:270 static/js/zamboni/stats-all.js:16901 static/js/zamboni/stats-min.js:5
 msgid "{0} users"
 msgstr "{0} users"
 
-#: static/js/impala/stats/chart.js:271
+#: static/js/impala/stats/chart.js:271 static/js/zamboni/stats-all.js:16902 static/js/zamboni/stats-min.js:5
 msgid "{0} add-ons"
 msgstr "{0} add-ons"
 
-#: static/js/impala/stats/chart.js:272
+#: static/js/impala/stats/chart.js:272 static/js/zamboni/stats-all.js:16903 static/js/zamboni/stats-min.js:5
 msgid "{0} collections"
 msgstr "{0} collections"
 
-#: static/js/impala/stats/chart.js:273
+#: static/js/impala/stats/chart.js:273 static/js/zamboni/stats-all.js:16904 static/js/zamboni/stats-min.js:5
 msgid "{0} reviews"
 msgstr "{0} reviews"
 
-#: static/js/impala/stats/chart.js:275
+#: static/js/impala/stats/chart.js:275 static/js/zamboni/stats-all.js:16906 static/js/zamboni/stats-min.js:5
 msgid "{0} sales"
 msgstr "{0} sales"
 
-#: static/js/impala/stats/chart.js:276
+#: static/js/impala/stats/chart.js:276 static/js/zamboni/stats-all.js:16907 static/js/zamboni/stats-min.js:5
 msgid "{0} refunds"
 msgstr "{0} refunds"
 
-#: static/js/impala/stats/chart.js:277
+#: static/js/impala/stats/chart.js:277 static/js/zamboni/stats-all.js:16908 static/js/zamboni/stats-min.js:5
 msgid "{0} installs"
 msgstr "{0} installs"
 
-#: static/js/impala/stats/chart.js:369 static/js/impala/stats/csv_keys.js:3 static/js/impala/stats/csv_keys.js:109
+#: static/js/impala/stats/chart.js:369 static/js/impala/stats/csv_keys.js:3 static/js/impala/stats/csv_keys.js:109 static/js/zamboni/stats-all.js:15284 static/js/zamboni/stats-all.js:15390
+#: static/js/zamboni/stats-all.js:17000 static/js/zamboni/stats-min.js:4 static/js/zamboni/stats-min.js:5
 msgid "Downloads"
 msgstr "Downloads"
 
-#: static/js/impala/stats/chart.js:379 static/js/impala/stats/csv_keys.js:6 static/js/impala/stats/csv_keys.js:110
+#: static/js/impala/stats/chart.js:379 static/js/impala/stats/csv_keys.js:6 static/js/impala/stats/csv_keys.js:110 static/js/zamboni/stats-all.js:15287 static/js/zamboni/stats-all.js:15391
+#: static/js/zamboni/stats-all.js:17010 static/js/zamboni/stats-min.js:4 static/js/zamboni/stats-min.js:5
 msgid "Daily Users"
 msgstr "Daily Users"
 
-#: static/js/impala/stats/chart.js:410
+#: static/js/impala/stats/chart.js:410 static/js/zamboni/stats-all.js:17041 static/js/zamboni/stats-min.js:5
 msgid "Amount, in USD"
 msgstr "Amount, in USD"
 
-#: static/js/impala/stats/chart.js:421 static/js/impala/stats/csv_keys.js:104
+#: static/js/impala/stats/chart.js:421 static/js/impala/stats/csv_keys.js:104 static/js/zamboni/stats-all.js:15385 static/js/zamboni/stats-all.js:17052 static/js/zamboni/stats-min.js:5
 msgid "Number of Contributions"
 msgstr "Number of Contributions"
 
-#: static/js/impala/stats/chart.js:447
+#: static/js/impala/stats/chart.js:447 static/js/zamboni/stats-all.js:17078 static/js/zamboni/stats-min.js:5
 msgid "More Info..."
 msgstr "More Info..."
 
 #. L10n: {0} is an ISO-formatted date.
-#: static/js/impala/stats/chart.js:451
+#: static/js/impala/stats/chart.js:451 static/js/zamboni/stats-all.js:17082 static/js/zamboni/stats-min.js:5
 msgid "Details for {0}"
 msgstr "Details for {0}"
 
-#: static/js/impala/stats/csv_keys.js:9
+#: static/js/impala/stats/csv_keys.js:9 static/js/zamboni/stats-all.js:15290 static/js/zamboni/stats-min.js:4
 msgid "Collections Created"
 msgstr "Collections Created"
 
-#: static/js/impala/stats/csv_keys.js:12
+#: static/js/impala/stats/csv_keys.js:12 static/js/zamboni/stats-all.js:15293 static/js/zamboni/stats-min.js:4
 msgid "Add-ons in Use"
 msgstr "Add-ons in Use"
 
-#: static/js/impala/stats/csv_keys.js:15
+#: static/js/impala/stats/csv_keys.js:15 static/js/zamboni/stats-all.js:15296 static/js/zamboni/stats-min.js:4
 msgid "Add-ons Created"
 msgstr "Add-ons Created"
 
-#: static/js/impala/stats/csv_keys.js:18
+#: static/js/impala/stats/csv_keys.js:18 static/js/zamboni/stats-all.js:15299 static/js/zamboni/stats-min.js:4
 msgid "Add-ons Downloaded"
 msgstr "Add-ons Downloaded"
 
-#: static/js/impala/stats/csv_keys.js:21
+#: static/js/impala/stats/csv_keys.js:21 static/js/zamboni/stats-all.js:15302 static/js/zamboni/stats-min.js:4
 msgid "Add-ons Updated"
 msgstr "Add-ons Updated"
 
-#: static/js/impala/stats/csv_keys.js:24
+#: static/js/impala/stats/csv_keys.js:24 static/js/zamboni/stats-all.js:15305 static/js/zamboni/stats-min.js:4
 msgid "Reviews Written"
 msgstr "Reviews Written"
 
-#: static/js/impala/stats/csv_keys.js:27
+#: static/js/impala/stats/csv_keys.js:27 static/js/zamboni/stats-all.js:15308 static/js/zamboni/stats-min.js:4
 msgid "User Signups"
 msgstr "User Signups"
 
-#: static/js/impala/stats/csv_keys.js:30
+#: static/js/impala/stats/csv_keys.js:30 static/js/zamboni/stats-all.js:15311 static/js/zamboni/stats-min.js:4
 msgid "Subscribers"
 msgstr "Subscribers"
 
-#: static/js/impala/stats/csv_keys.js:33
+#: static/js/impala/stats/csv_keys.js:33 static/js/zamboni/stats-all.js:15314 static/js/zamboni/stats-min.js:4
 msgid "Ratings"
 msgstr "Ratings"
 
-#: static/js/impala/stats/csv_keys.js:36 static/js/impala/stats/csv_keys.js:114
+#: static/js/impala/stats/csv_keys.js:36 static/js/impala/stats/csv_keys.js:114 static/js/zamboni/stats-all.js:15317 static/js/zamboni/stats-all.js:15395 static/js/zamboni/stats-min.js:4
+#: static/js/zamboni/stats-min.js:5
 msgid "Sales"
 msgstr "Sales"
 
-#: static/js/impala/stats/csv_keys.js:39 static/js/impala/stats/csv_keys.js:113
+#: static/js/impala/stats/csv_keys.js:39 static/js/impala/stats/csv_keys.js:113 static/js/zamboni/stats-all.js:15320 static/js/zamboni/stats-all.js:15394 static/js/zamboni/stats-min.js:4
+#: static/js/zamboni/stats-min.js:5
 msgid "Installs"
 msgstr "Installs"
 
-#: static/js/impala/stats/csv_keys.js:42
+#: static/js/impala/stats/csv_keys.js:42 static/js/zamboni/stats-all.js:15323 static/js/zamboni/stats-min.js:4
 msgid "Unknown"
 msgstr "Unknown"
 
-#: static/js/impala/stats/csv_keys.js:43
+#: static/js/impala/stats/csv_keys.js:43 static/js/zamboni/stats-all.js:15324 static/js/zamboni/stats-min.js:4
 msgid "Add-ons Manager"
 msgstr "Add-ons Manager"
 
-#: static/js/impala/stats/csv_keys.js:44
+#: static/js/impala/stats/csv_keys.js:44 static/js/zamboni/stats-all.js:15325 static/js/zamboni/stats-min.js:4
 msgid "Add-ons Manager Promo"
 msgstr "Add-ons Manager Promo"
 
-#: static/js/impala/stats/csv_keys.js:45
+#: static/js/impala/stats/csv_keys.js:45 static/js/zamboni/stats-all.js:15326 static/js/zamboni/stats-min.js:4
 msgid "Add-ons Manager Featured"
 msgstr "Add-ons Manager Featured"
 
-#: static/js/impala/stats/csv_keys.js:46
+#: static/js/impala/stats/csv_keys.js:46 static/js/zamboni/stats-all.js:15327 static/js/zamboni/stats-min.js:4
 msgid "Add-ons Manager Learn More"
 msgstr "Add-ons Manager Learn More"
 
-#: static/js/impala/stats/csv_keys.js:47
+#: static/js/impala/stats/csv_keys.js:47 static/js/zamboni/stats-all.js:15328 static/js/zamboni/stats-min.js:4
 msgid "Search Suggestions"
 msgstr "Search Suggestions"
 
-#: static/js/impala/stats/csv_keys.js:48
+#: static/js/impala/stats/csv_keys.js:48 static/js/zamboni/stats-all.js:15329 static/js/zamboni/stats-min.js:4
 msgid "Search Results"
 msgstr "Search Results"
 
-#: static/js/impala/stats/csv_keys.js:49 static/js/impala/stats/csv_keys.js:50 static/js/impala/stats/csv_keys.js:51
+#: static/js/impala/stats/csv_keys.js:49 static/js/impala/stats/csv_keys.js:50 static/js/impala/stats/csv_keys.js:51 static/js/zamboni/stats-all.js:15330 static/js/zamboni/stats-all.js:15331
+#: static/js/zamboni/stats-all.js:15332 static/js/zamboni/stats-min.js:4
 msgid "Homepage Promo"
 msgstr "Homepage Promo"
 
-#: static/js/impala/stats/csv_keys.js:52 static/js/impala/stats/csv_keys.js:53
+#: static/js/impala/stats/csv_keys.js:52 static/js/impala/stats/csv_keys.js:53 static/js/zamboni/stats-all.js:15333 static/js/zamboni/stats-all.js:15334 static/js/zamboni/stats-min.js:4
 msgid "Homepage Featured"
 msgstr "Homepage Featured"
 
-#: static/js/impala/stats/csv_keys.js:54 static/js/impala/stats/csv_keys.js:55
+#: static/js/impala/stats/csv_keys.js:54 static/js/impala/stats/csv_keys.js:55 static/js/zamboni/stats-all.js:15335 static/js/zamboni/stats-all.js:15336 static/js/zamboni/stats-min.js:4
 msgid "Homepage Up and Coming"
 msgstr "Homepage Up and Coming"
 
-#: static/js/impala/stats/csv_keys.js:56
+#: static/js/impala/stats/csv_keys.js:56 static/js/zamboni/stats-all.js:15337 static/js/zamboni/stats-min.js:4
 msgid "Homepage Most Popular"
 msgstr "Homepage Most Popular"
 
-#: static/js/impala/stats/csv_keys.js:57 static/js/impala/stats/csv_keys.js:59
+#: static/js/impala/stats/csv_keys.js:57 static/js/impala/stats/csv_keys.js:59 static/js/zamboni/stats-all.js:15338 static/js/zamboni/stats-all.js:15340 static/js/zamboni/stats-min.js:4
 msgid "Detail Page"
 msgstr "Detail Page"
 
-#: static/js/impala/stats/csv_keys.js:58 static/js/impala/stats/csv_keys.js:60
+#: static/js/impala/stats/csv_keys.js:58 static/js/impala/stats/csv_keys.js:60 static/js/zamboni/stats-all.js:15339 static/js/zamboni/stats-all.js:15341 static/js/zamboni/stats-min.js:4
 msgid "Detail Page (bottom)"
 msgstr "Detail Page (bottom)"
 
-#: static/js/impala/stats/csv_keys.js:61
+#: static/js/impala/stats/csv_keys.js:61 static/js/zamboni/stats-all.js:15342 static/js/zamboni/stats-min.js:4
 msgid "Detail Page (Development Channel)"
 msgstr "Detail Page (Development Channel)"
 
-#: static/js/impala/stats/csv_keys.js:62 static/js/impala/stats/csv_keys.js:63 static/js/impala/stats/csv_keys.js:64
+#: static/js/impala/stats/csv_keys.js:62 static/js/impala/stats/csv_keys.js:63 static/js/impala/stats/csv_keys.js:64 static/js/zamboni/stats-all.js:15343 static/js/zamboni/stats-all.js:15344
+#: static/js/zamboni/stats-all.js:15345 static/js/zamboni/stats-min.js:4
 msgid "Often Used With"
 msgstr "Often Used With"
 
-#: static/js/impala/stats/csv_keys.js:65 static/js/impala/stats/csv_keys.js:66
+#: static/js/impala/stats/csv_keys.js:65 static/js/impala/stats/csv_keys.js:66 static/js/zamboni/stats-all.js:15346 static/js/zamboni/stats-all.js:15347 static/js/zamboni/stats-min.js:4
 msgid "Others By Author"
 msgstr "Others By Author"
 
-#: static/js/impala/stats/csv_keys.js:67 static/js/impala/stats/csv_keys.js:68
+#: static/js/impala/stats/csv_keys.js:67 static/js/impala/stats/csv_keys.js:68 static/js/zamboni/stats-all.js:15348 static/js/zamboni/stats-all.js:15349 static/js/zamboni/stats-min.js:4
 msgid "Dependencies"
 msgstr "Dependencies"
 
-#: static/js/impala/stats/csv_keys.js:69 static/js/impala/stats/csv_keys.js:70
+#: static/js/impala/stats/csv_keys.js:69 static/js/impala/stats/csv_keys.js:70 static/js/zamboni/stats-all.js:15350 static/js/zamboni/stats-all.js:15351 static/js/zamboni/stats-min.js:4
 msgid "Upsell"
 msgstr "Upsell"
 
-#: static/js/impala/stats/csv_keys.js:71
+#: static/js/impala/stats/csv_keys.js:71 static/js/zamboni/stats-all.js:15352 static/js/zamboni/stats-min.js:4
 msgid "Meet the Developer"
 msgstr "Meet the Developer"
 
-#: static/js/impala/stats/csv_keys.js:72
+#: static/js/impala/stats/csv_keys.js:72 static/js/zamboni/stats-all.js:15353 static/js/zamboni/stats-min.js:4
 msgid "User Profile"
 msgstr "User Profile"
 
-#: static/js/impala/stats/csv_keys.js:73
+#: static/js/impala/stats/csv_keys.js:73 static/js/zamboni/stats-all.js:15354 static/js/zamboni/stats-min.js:4
 msgid "Version History"
 msgstr "Version History"
 
-#: static/js/impala/stats/csv_keys.js:75
+#: static/js/impala/stats/csv_keys.js:75 static/js/zamboni/stats-all.js:15356 static/js/zamboni/stats-min.js:4
 msgid "Sharing"
 msgstr "Sharing"
 
-#: static/js/impala/stats/csv_keys.js:76
+#: static/js/impala/stats/csv_keys.js:76 static/js/zamboni/stats-all.js:15357 static/js/zamboni/stats-min.js:4
 msgid "Category Pages"
 msgstr "Category Pages"
 
-#: static/js/impala/stats/csv_keys.js:77
+#: static/js/impala/stats/csv_keys.js:77 static/js/zamboni/stats-all.js:15358 static/js/zamboni/stats-min.js:4
 msgid "Collections"
 msgstr "Collections"
 
-#: static/js/impala/stats/csv_keys.js:78 static/js/impala/stats/csv_keys.js:79
+#: static/js/impala/stats/csv_keys.js:78 static/js/impala/stats/csv_keys.js:79 static/js/zamboni/stats-all.js:15359 static/js/zamboni/stats-all.js:15360 static/js/zamboni/stats-min.js:4
 msgid "Category Landing Featured Carousel"
 msgstr "Category Landing Featured Carousel"
 
-#: static/js/impala/stats/csv_keys.js:80 static/js/impala/stats/csv_keys.js:81
+#: static/js/impala/stats/csv_keys.js:80 static/js/impala/stats/csv_keys.js:81 static/js/zamboni/stats-all.js:15361 static/js/zamboni/stats-all.js:15362 static/js/zamboni/stats-min.js:4
 msgid "Category Landing Top Rated"
 msgstr "Category Landing Top Rated"
 
-#: static/js/impala/stats/csv_keys.js:82 static/js/impala/stats/csv_keys.js:83
+#: static/js/impala/stats/csv_keys.js:82 static/js/impala/stats/csv_keys.js:83 static/js/zamboni/stats-all.js:15363 static/js/zamboni/stats-all.js:15364 static/js/zamboni/stats-min.js:5
 msgid "Category Landing Most Popular"
 msgstr "Category Landing Most Popular"
 
-#: static/js/impala/stats/csv_keys.js:84 static/js/impala/stats/csv_keys.js:85
+#: static/js/impala/stats/csv_keys.js:84 static/js/impala/stats/csv_keys.js:85 static/js/zamboni/stats-all.js:15365 static/js/zamboni/stats-all.js:15366 static/js/zamboni/stats-min.js:5
 msgid "Category Landing Recently Added"
 msgstr "Category Landing Recently Added"
 
-#: static/js/impala/stats/csv_keys.js:86 static/js/impala/stats/csv_keys.js:87
+#: static/js/impala/stats/csv_keys.js:86 static/js/impala/stats/csv_keys.js:87 static/js/zamboni/stats-all.js:15367 static/js/zamboni/stats-all.js:15368 static/js/zamboni/stats-min.js:5
 msgid "Browse Listing Featured Sort"
 msgstr "Browse Listing Featured Sort"
 
-#: static/js/impala/stats/csv_keys.js:88 static/js/impala/stats/csv_keys.js:89
+#: static/js/impala/stats/csv_keys.js:88 static/js/impala/stats/csv_keys.js:89 static/js/zamboni/stats-all.js:15369 static/js/zamboni/stats-all.js:15370 static/js/zamboni/stats-min.js:5
 msgid "Browse Listing Users Sort"
 msgstr "Browse Listing Users Sort"
 
-#: static/js/impala/stats/csv_keys.js:90 static/js/impala/stats/csv_keys.js:91
+#: static/js/impala/stats/csv_keys.js:90 static/js/impala/stats/csv_keys.js:91 static/js/zamboni/stats-all.js:15371 static/js/zamboni/stats-all.js:15372 static/js/zamboni/stats-min.js:5
 msgid "Browse Listing Rating Sort"
 msgstr "Browse Listing Rating Sort"
 
-#: static/js/impala/stats/csv_keys.js:92 static/js/impala/stats/csv_keys.js:93
+#: static/js/impala/stats/csv_keys.js:92 static/js/impala/stats/csv_keys.js:93 static/js/zamboni/stats-all.js:15373 static/js/zamboni/stats-all.js:15374 static/js/zamboni/stats-min.js:5
 msgid "Browse Listing Created Sort"
 msgstr "Browse Listing Created Sort"
 
-#: static/js/impala/stats/csv_keys.js:94 static/js/impala/stats/csv_keys.js:95
+#: static/js/impala/stats/csv_keys.js:94 static/js/impala/stats/csv_keys.js:95 static/js/zamboni/stats-all.js:15375 static/js/zamboni/stats-all.js:15376 static/js/zamboni/stats-min.js:5
 msgid "Browse Listing Name Sort"
 msgstr "Browse Listing Name Sort"
 
-#: static/js/impala/stats/csv_keys.js:96 static/js/impala/stats/csv_keys.js:97
+#: static/js/impala/stats/csv_keys.js:96 static/js/impala/stats/csv_keys.js:97 static/js/zamboni/stats-all.js:15377 static/js/zamboni/stats-all.js:15378 static/js/zamboni/stats-min.js:5
 msgid "Browse Listing Popular Sort"
 msgstr "Browse Listing Popular Sort"
 
-#: static/js/impala/stats/csv_keys.js:98 static/js/impala/stats/csv_keys.js:99
+#: static/js/impala/stats/csv_keys.js:98 static/js/impala/stats/csv_keys.js:99 static/js/zamboni/stats-all.js:15379 static/js/zamboni/stats-all.js:15380 static/js/zamboni/stats-min.js:5
 msgid "Browse Listing Updated Sort"
 msgstr "Browse Listing Updated Sort"
 
-#: static/js/impala/stats/csv_keys.js:100 static/js/impala/stats/csv_keys.js:101
+#: static/js/impala/stats/csv_keys.js:100 static/js/impala/stats/csv_keys.js:101 static/js/zamboni/stats-all.js:15381 static/js/zamboni/stats-all.js:15382 static/js/zamboni/stats-min.js:5
 msgid "Browse Listing Up and Coming Sort"
 msgstr "Browse Listing Up and Coming Sort"
 
-#: static/js/impala/stats/csv_keys.js:105
+#: static/js/impala/stats/csv_keys.js:105 static/js/zamboni/stats-all.js:15386 static/js/zamboni/stats-min.js:5
 msgid "Total Amount Contributed"
 msgstr "Total Amount Contributed"
 
-#: static/js/impala/stats/csv_keys.js:106
+#: static/js/impala/stats/csv_keys.js:106 static/js/zamboni/stats-all.js:15387 static/js/zamboni/stats-min.js:5
 msgid "Average Contribution"
 msgstr "Average Contribution"
 
-#: static/js/impala/stats/csv_keys.js:115
+#: static/js/impala/stats/csv_keys.js:115 static/js/zamboni/stats-all.js:15396 static/js/zamboni/stats-min.js:5
 msgid "Usage"
 msgstr "Usage"
 
-#: static/js/impala/stats/csv_keys.js:118
+#: static/js/impala/stats/csv_keys.js:118 static/js/zamboni/stats-all.js:15399 static/js/zamboni/stats-min.js:5
 msgid "Firefox"
 msgstr "Firefox"
 
-#: static/js/impala/stats/csv_keys.js:119
+#: static/js/impala/stats/csv_keys.js:119 static/js/zamboni/stats-all.js:15400 static/js/zamboni/stats-min.js:5
 msgid "Mozilla"
 msgstr "Mozilla"
 
-#: static/js/impala/stats/csv_keys.js:120
+#: static/js/impala/stats/csv_keys.js:120 static/js/zamboni/stats-all.js:15401 static/js/zamboni/stats-min.js:5
 msgid "Thunderbird"
 msgstr "Thunderbird"
 
-#: static/js/impala/stats/csv_keys.js:121
+#: static/js/impala/stats/csv_keys.js:121 static/js/zamboni/stats-all.js:15402 static/js/zamboni/stats-min.js:5
 msgid "Sunbird"
 msgstr "Sunbird"
 
-#: static/js/impala/stats/csv_keys.js:122
+#: static/js/impala/stats/csv_keys.js:122 static/js/zamboni/stats-all.js:15403 static/js/zamboni/stats-min.js:5
 msgid "SeaMonkey"
 msgstr "SeaMonkey"
 
-#: static/js/impala/stats/csv_keys.js:123
+#: static/js/impala/stats/csv_keys.js:123 static/js/zamboni/stats-all.js:15404 static/js/zamboni/stats-min.js:5
 msgid "Fennec"
 msgstr "Fennec"
 
-#: static/js/impala/stats/csv_keys.js:124
+#: static/js/impala/stats/csv_keys.js:124 static/js/zamboni/stats-all.js:15405 static/js/zamboni/stats-min.js:5
 msgid "Android"
 msgstr "Android"
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:129
+#: static/js/impala/stats/csv_keys.js:129 static/js/zamboni/stats-all.js:15410 static/js/zamboni/stats-min.js:5
 msgid "Downloads and Daily Users, last {0} days"
 msgstr "Downloads and Daily Users, last {0} days"
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:131
+#: static/js/impala/stats/csv_keys.js:131 static/js/zamboni/stats-all.js:15412 static/js/zamboni/stats-min.js:5
 msgid "Downloads and Daily Users from {0} to {1}"
 msgstr "Downloads and Daily Users from {0} to {1}"
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:135
+#: static/js/impala/stats/csv_keys.js:135 static/js/zamboni/stats-all.js:15416 static/js/zamboni/stats-min.js:5
 msgid "Installs and Daily Users, last {0} days"
 msgstr "Installs and Daily Users, last {0} days"
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:137
+#: static/js/impala/stats/csv_keys.js:137 static/js/zamboni/stats-all.js:15418 static/js/zamboni/stats-min.js:5
 msgid "Installs and Daily Users from {0} to {1}"
 msgstr "Installs and Daily Users from {0} to {1}"
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:141
+#: static/js/impala/stats/csv_keys.js:141 static/js/zamboni/stats-all.js:15422 static/js/zamboni/stats-min.js:5
 msgid "Downloads, last {0} days"
 msgstr "Downloads, last {0} days"
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:143
+#: static/js/impala/stats/csv_keys.js:143 static/js/zamboni/stats-all.js:15424 static/js/zamboni/stats-min.js:5
 msgid "Downloads from {0} to {1}"
 msgstr "Downloads from {0} to {1}"
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:147
+#: static/js/impala/stats/csv_keys.js:147 static/js/zamboni/stats-all.js:15428 static/js/zamboni/stats-min.js:5
 msgid "Daily Users, last {0} days"
 msgstr "Daily Users, last {0} days"
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:149
+#: static/js/impala/stats/csv_keys.js:149 static/js/zamboni/stats-all.js:15430 static/js/zamboni/stats-min.js:5
 msgid "Daily Users from {0} to {1}"
 msgstr "Daily Users from {0} to {1}"
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:153
+#: static/js/impala/stats/csv_keys.js:153 static/js/zamboni/stats-all.js:15434 static/js/zamboni/stats-min.js:5
 msgid "Applications, last {0} days"
 msgstr "Applications, last {0} days"
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:155
+#: static/js/impala/stats/csv_keys.js:155 static/js/zamboni/stats-all.js:15436 static/js/zamboni/stats-min.js:5
 msgid "Applications from {0} to {1}"
 msgstr "Applications from {0} to {1}"
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:159
+#: static/js/impala/stats/csv_keys.js:159 static/js/zamboni/stats-all.js:15440 static/js/zamboni/stats-min.js:5
 msgid "Platforms, last {0} days"
 msgstr "Platforms, last {0} days"
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:161
+#: static/js/impala/stats/csv_keys.js:161 static/js/zamboni/stats-all.js:15442 static/js/zamboni/stats-min.js:5
 msgid "Platforms from {0} to {1}"
 msgstr "Platforms from {0} to {1}"
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:165
+#: static/js/impala/stats/csv_keys.js:165 static/js/zamboni/stats-all.js:15446 static/js/zamboni/stats-min.js:5
 msgid "Languages, last {0} days"
 msgstr "Languages, last {0} days"
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:167
+#: static/js/impala/stats/csv_keys.js:167 static/js/zamboni/stats-all.js:15448 static/js/zamboni/stats-min.js:5
 msgid "Languages from {0} to {1}"
 msgstr "Languages from {0} to {1}"
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:171
+#: static/js/impala/stats/csv_keys.js:171 static/js/zamboni/stats-all.js:15452 static/js/zamboni/stats-min.js:5
 msgid "Add-on Versions, last {0} days"
 msgstr "Add-on Versions, last {0} days"
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:173
+#: static/js/impala/stats/csv_keys.js:173 static/js/zamboni/stats-all.js:15454 static/js/zamboni/stats-min.js:5
 msgid "Add-on Versions from {0} to {1}"
 msgstr "Add-on Versions from {0} to {1}"
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:177
+#: static/js/impala/stats/csv_keys.js:177 static/js/zamboni/stats-all.js:15458 static/js/zamboni/stats-min.js:5
 msgid "Add-on Status, last {0} days"
 msgstr "Add-on Status, last {0} days"
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:179
+#: static/js/impala/stats/csv_keys.js:179 static/js/zamboni/stats-all.js:15460 static/js/zamboni/stats-min.js:5
 msgid "Add-on Status from {0} to {1}"
 msgstr "Add-on Status from {0} to {1}"
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:183
+#: static/js/impala/stats/csv_keys.js:183 static/js/zamboni/stats-all.js:15464 static/js/zamboni/stats-min.js:5
 msgid "Download Sources, last {0} days"
 msgstr "Download Sources, last {0} days"
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:185
+#: static/js/impala/stats/csv_keys.js:185 static/js/zamboni/stats-all.js:15466 static/js/zamboni/stats-min.js:5
 msgid "Download Sources from {0} to {1}"
 msgstr "Download Sources from {0} to {1}"
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:189
+#: static/js/impala/stats/csv_keys.js:189 static/js/zamboni/stats-all.js:15470 static/js/zamboni/stats-min.js:5
 msgid "Contributions, last {0} days"
 msgstr "Contributions, last {0} days"
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:191
+#: static/js/impala/stats/csv_keys.js:191 static/js/zamboni/stats-all.js:15472 static/js/zamboni/stats-min.js:5
 msgid "Contributions from {0} to {1}"
 msgstr "Contributions from {0} to {1}"
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:195
+#: static/js/impala/stats/csv_keys.js:195 static/js/zamboni/stats-all.js:15476 static/js/zamboni/stats-min.js:5
 msgid "Site Metrics, last {0} days"
 msgstr "Site Metrics, last {0} days"
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:197
+#: static/js/impala/stats/csv_keys.js:197 static/js/zamboni/stats-all.js:15478 static/js/zamboni/stats-min.js:5
 msgid "Site Metrics from {0} to {1}"
 msgstr "Site Metrics from {0} to {1}"
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:201
+#: static/js/impala/stats/csv_keys.js:201 static/js/zamboni/stats-all.js:15482 static/js/zamboni/stats-min.js:5
 msgid "Add-ons in Use, last {0} days"
 msgstr "Add-ons in Use, last {0} days"
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:203
+#: static/js/impala/stats/csv_keys.js:203 static/js/zamboni/stats-all.js:15484 static/js/zamboni/stats-min.js:5
 msgid "Add-ons in Use from {0} to {1}"
 msgstr "Add-ons in Use from {0} to {1}"
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:207
+#: static/js/impala/stats/csv_keys.js:207 static/js/zamboni/stats-all.js:15488 static/js/zamboni/stats-min.js:5
 msgid "Add-ons Downloaded, last {0} days"
 msgstr "Add-ons Downloaded, last {0} days"
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:209
+#: static/js/impala/stats/csv_keys.js:209 static/js/zamboni/stats-all.js:15490 static/js/zamboni/stats-min.js:5
 msgid "Add-ons Downloaded from {0} to {1}"
 msgstr "Add-ons Downloaded from {0} to {1}"
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:213
+#: static/js/impala/stats/csv_keys.js:213 static/js/zamboni/stats-all.js:15494 static/js/zamboni/stats-min.js:5
 msgid "Add-ons Created, last {0} days"
 msgstr "Add-ons Created, last {0} days"
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:215
+#: static/js/impala/stats/csv_keys.js:215 static/js/zamboni/stats-all.js:15496 static/js/zamboni/stats-min.js:5
 msgid "Add-ons Created from {0} to {1}"
 msgstr "Add-ons Created from {0} to {1}"
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:219
+#: static/js/impala/stats/csv_keys.js:219 static/js/zamboni/stats-all.js:15500 static/js/zamboni/stats-min.js:5
 msgid "Add-ons Updated, last {0} days"
 msgstr "Add-ons Updated, last {0} days"
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:221
+#: static/js/impala/stats/csv_keys.js:221 static/js/zamboni/stats-all.js:15502 static/js/zamboni/stats-min.js:5
 msgid "Add-ons Updated from {0} to {1}"
 msgstr "Add-ons Updated from {0} to {1}"
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:225
+#: static/js/impala/stats/csv_keys.js:225 static/js/zamboni/stats-all.js:15506 static/js/zamboni/stats-min.js:5
 msgid "Reviews Written, last {0} days"
 msgstr "Reviews Written, last {0} days"
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:227
+#: static/js/impala/stats/csv_keys.js:227 static/js/zamboni/stats-all.js:15508 static/js/zamboni/stats-min.js:5
 msgid "Reviews Written from {0} to {1}"
 msgstr "Reviews Written from {0} to {1}"
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:231
+#: static/js/impala/stats/csv_keys.js:231 static/js/zamboni/stats-all.js:15512 static/js/zamboni/stats-min.js:5
 msgid "User Signups, last {0} days"
 msgstr "User Signups, last {0} days"
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:233
+#: static/js/impala/stats/csv_keys.js:233 static/js/zamboni/stats-all.js:15514 static/js/zamboni/stats-min.js:5
 msgid "User Signups from {0} to {1}"
 msgstr "User Signups from {0} to {1}"
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:237
+#: static/js/impala/stats/csv_keys.js:237 static/js/zamboni/stats-all.js:15518 static/js/zamboni/stats-min.js:5
 msgid "Collections Created, last {0} days"
 msgstr "Collections Created, last {0} days"
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:239
+#: static/js/impala/stats/csv_keys.js:239 static/js/zamboni/stats-all.js:15520 static/js/zamboni/stats-min.js:5
 msgid "Collections Created from {0} to {1}"
 msgstr "Collections Created from {0} to {1}"
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:243
+#: static/js/impala/stats/csv_keys.js:243 static/js/zamboni/stats-all.js:15524 static/js/zamboni/stats-min.js:5
 msgid "Subscribers, last {0} days"
 msgstr "Subscribers, last {0} days"
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:245
+#: static/js/impala/stats/csv_keys.js:245 static/js/zamboni/stats-all.js:15526 static/js/zamboni/stats-min.js:5
 msgid "Subscribers from {0} to {1}"
 msgstr "Subscribers from {0} to {1}"
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:249
+#: static/js/impala/stats/csv_keys.js:249 static/js/zamboni/stats-all.js:15530 static/js/zamboni/stats-min.js:5
 msgid "Ratings, last {0} days"
 msgstr "Ratings, last {0} days"
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:251
+#: static/js/impala/stats/csv_keys.js:251 static/js/zamboni/stats-all.js:15532 static/js/zamboni/stats-min.js:5
 msgid "Ratings from {0} to {1}"
 msgstr "Ratings from {0} to {1}"
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:255
+#: static/js/impala/stats/csv_keys.js:255 static/js/zamboni/stats-all.js:15536 static/js/zamboni/stats-min.js:5
 msgid "Sales, last {0} days"
 msgstr "Sales, last {0} days"
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:257
+#: static/js/impala/stats/csv_keys.js:257 static/js/zamboni/stats-all.js:15538 static/js/zamboni/stats-min.js:5
 msgid "Sales from {0} to {1}"
 msgstr "Sales from {0} to {1}"
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:261
+#: static/js/impala/stats/csv_keys.js:261 static/js/zamboni/stats-all.js:15542 static/js/zamboni/stats-min.js:5
 msgid "Installs, last {0} days"
 msgstr "Installs, last {0} days"
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:263
+#: static/js/impala/stats/csv_keys.js:263 static/js/zamboni/stats-all.js:15544 static/js/zamboni/stats-min.js:5
 msgid "Installs from {0} to {1}"
 msgstr "Installs from {0} to {1}"
 
 #. L10n: {0} and {1} are integers.
-#: static/js/impala/stats/csv_keys.js:269
+#: static/js/impala/stats/csv_keys.js:269 static/js/zamboni/stats-all.js:15550 static/js/zamboni/stats-min.js:5
 msgid "<b>{0}</b> in last {1} days"
 msgstr "<b>{0}</b> in last {1} days"
 
 #. L10n: {0} is an integer and {1} and {2} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:271 static/js/impala/stats/csv_keys.js:277
+#: static/js/impala/stats/csv_keys.js:271 static/js/impala/stats/csv_keys.js:277 static/js/zamboni/stats-all.js:15552 static/js/zamboni/stats-all.js:15558 static/js/zamboni/stats-min.js:5
 msgid "<b>{0}</b> from {1} to {2}"
 msgstr "<b>{0}</b> from {1} to {2}"
 
 #. L10n: {0} and {1} are integers.
-#: static/js/impala/stats/csv_keys.js:275
+#: static/js/impala/stats/csv_keys.js:275 static/js/zamboni/stats-all.js:15556 static/js/zamboni/stats-min.js:5
 msgid "<b>{0}</b> average in last {1} days"
 msgstr "<b>{0}</b> average in last {1} days"
 
-#: static/js/impala/stats/overview.js:19
+#: static/js/impala/stats/overview.js:19 static/js/zamboni/stats-all.js:16469 static/js/zamboni/stats-min.js:5
 msgid "No data available."
 msgstr "No data available."
 
-#: static/js/impala/stats/table.js:74
+#: static/js/impala/stats/table.js:74 static/js/zamboni/stats-all.js:17209 static/js/zamboni/stats-min.js:5
 msgid "Date"
 msgstr "Date"
 
-#: static/js/impala/stats/topchart.js:96
+#: static/js/impala/stats/topchart.js:96 static/js/zamboni/stats-all.js:16600 static/js/zamboni/stats-min.js:5
 msgid "Other"
 msgstr "Other"
 
-#: static/js/zamboni/admin_validation.js:24 static/js/zamboni/devhub.js:1229 static/js/zamboni/editors.js:295
+#: static/js/zamboni/admin-all.js:180 static/js/zamboni/admin-min.js:1 static/js/zamboni/admin_validation.js:24 static/js/zamboni/devhub-all.js:2408 static/js/zamboni/devhub-min.js:2
+#: static/js/zamboni/devhub.js:1229 static/js/zamboni/editors-all.js:15576 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:295
 msgid "Select an application first"
 msgstr "Select an application first"
 
-#: static/js/zamboni/admin_validation.js:51
+#: static/js/zamboni/admin-all.js:207 static/js/zamboni/admin-min.js:1 static/js/zamboni/admin_validation.js:51
 msgid "Set {0} add-on to a max version of {1} and email the author."
 msgid_plural "Set {0} add-ons to a max version of {1} and email the authors."
 msgstr[0] "Set {0} add-on to a max version of {1} and email the author."
 msgstr[1] "Set {0} add-ons to a max version of {1} and email the authors."
 
-#: static/js/zamboni/admin_validation.js:54
+#: static/js/zamboni/admin-all.js:210 static/js/zamboni/admin-min.js:1 static/js/zamboni/admin_validation.js:54
 msgid "Email author of {2} add-on which failed validation."
 msgid_plural "Email authors of {2} add-ons which failed validation."
 msgstr[0] "Email author of {2} add-on which failed validation."
 msgstr[1] "Email authors of {2} add-ons which failed validation."
 
-#. L10n: {0} is an app name like Firefox.
-#: static/js/zamboni/buttons.js:66
-msgid "Accept and Install"
-msgstr "Accept and Install"
-
-#: static/js/zamboni/buttons.js:66
-msgid "Add to {0}"
-msgstr "Add to {0}"
-
-#: static/js/zamboni/buttons.js:71
-msgid "Download Now"
-msgstr "Download Now"
-
-#: static/js/zamboni/buttons.js:112
-msgid "Add-on has not been updated to support default-to-compatible."
-msgstr "Add-on has not been updated to support default-to-compatible."
-
-#: static/js/zamboni/buttons.js:117
-msgid "You need to be using Firefox 10.0 or higher."
-msgstr "You need to be using Firefox 10.0 or higher."
-
-#: static/js/zamboni/buttons.js:129
-msgid "Mozilla has marked this version as incompatible with your Firefox version."
-msgstr "Mozilla has marked this version as incompatible with your Firefox version."
-
-#. L10n: {0} is an platform like Windows or Linux.
-#: static/js/zamboni/buttons.js:210
-msgid "Install for {0} anyway"
-msgstr "Install for {0} anyway"
-
-#: static/js/zamboni/buttons.js:210
-msgid "Download for {0} anyway"
-msgstr "Download for {0} anyway"
-
-#: static/js/zamboni/buttons.js:267
-msgid "Not available for your platform"
-msgstr "Not available for your platform"
-
-#. L10n: {0} is an app name, {1} is the app version.
-#: static/js/zamboni/buttons.js:278 static/js/zamboni/buttons.js:315
-msgid "Not available for {0} {1}"
-msgstr "Not available for {0} {1}"
-
-#: static/js/zamboni/buttons.js:341
-msgid "Works with {app} {min} - {max}"
-msgstr "Works with {app} {min} - {max}"
-
-#: static/js/zamboni/buttons.js:343
-msgid "View other versions"
-msgstr "View other versions"
-
-#: static/js/zamboni/buttons.js:391
-msgid "Only with Firefox — Get Firefox Now!"
-msgstr "Only with Firefox — Get Firefox Now!"
-
-#: static/js/zamboni/buttons.js:507 static/js/zamboni/mobile/buttons.js:43
-msgid "Sorry, you need a Mozilla-based browser (such as Firefox) to install a search plugin."
-msgstr "Sorry, you need a Mozilla-based browser (such as Firefox) to install a search plugin."
-
-#: static/js/zamboni/collections.js:229
-msgid "Adding to Favorites&hellip;"
-msgstr "Adding to Favourites&hellip;"
-
-#: static/js/zamboni/collections.js:232
-msgid "Removing Favorite&hellip;"
-msgstr "Removing Favourite&hellip;"
-
-#: static/js/zamboni/collections.js:235
-msgid "Add to Favorites"
-msgstr "Add to Favourites"
-
-#: static/js/zamboni/collections.js:238
-msgid "Remove from Favorites"
-msgstr "Remove from Favourites"
-
-#: static/js/zamboni/collections.js:303
-msgid "Pending"
-msgstr "Pending"
-
-#: static/js/zamboni/collections.js:304
-msgid "Add a comment"
-msgstr "Add a comment"
-
-#: static/js/zamboni/collections.js:304
-msgid "Comment"
-msgstr "Comment"
-
-#: static/js/zamboni/collections.js:305
-msgid "Remove this add-on from the collection"
-msgstr "Remove this add-on from the collection"
-
-#: static/js/zamboni/collections.js:305 static/js/zamboni/collections.js:334
-msgid "Remove"
-msgstr "Remove"
-
-#: static/js/zamboni/collections.js:334
-msgid "Remove this user as a contributor"
-msgstr "Remove this user as a contributor"
-
-#: static/js/zamboni/collections.js:346
-msgid "An email address is required."
-msgstr "An email address is required."
-
-#: static/js/zamboni/collections.js:364
-msgid "You cannot add yourself as a contributor."
-msgstr "You cannot add yourself as a contributor."
-
-#: static/js/zamboni/collections.js:366
-msgid "You have already added that user."
-msgstr "You have already added that user."
-
-#: static/js/zamboni/collections.js:573
-msgid "Add to favorites"
-msgstr "Add to favourites"
-
-#: static/js/zamboni/collections.js:577
-msgid "Remove from favorites"
-msgstr "Remove from favourites"
-
-#: static/js/zamboni/collections.js:604
-msgid "Stop following"
-msgstr "Stop following"
-
-#: static/js/zamboni/devhub.js:110
+#: static/js/zamboni/devhub-all.js:1289 static/js/zamboni/devhub-min.js:1 static/js/zamboni/devhub.js:110
 msgid "Your browser does not support the video tag"
 msgstr "Your browser does not support the video tag"
 
-#: static/js/zamboni/devhub.js:371
+#: static/js/zamboni/devhub-all.js:1550 static/js/zamboni/devhub-min.js:1 static/js/zamboni/devhub.js:371
 msgid "Changes Saved"
 msgstr "Changes Saved"
 
-#: static/js/zamboni/devhub.js:387
+#: static/js/zamboni/devhub-all.js:1566 static/js/zamboni/devhub-min.js:1 static/js/zamboni/devhub.js:387
 msgid "Enter a new author's email address"
 msgstr "Enter a new author's email address"
 
-#: static/js/zamboni/devhub.js:536
+#: static/js/zamboni/devhub-all.js:1715 static/js/zamboni/devhub-min.js:1 static/js/zamboni/devhub.js:536
 msgid "There was an error uploading your file."
 msgstr "There was an error uploading your file."
 
-#: static/js/zamboni/devhub.js:681
+#: static/js/zamboni/devhub-all.js:1860 static/js/zamboni/devhub-min.js:1 static/js/zamboni/devhub.js:681
 msgid "{files} file"
 msgid_plural "{files} files"
 msgstr[0] "{files} file"
 msgstr[1] "{files} files"
 
-#: static/js/zamboni/devhub.js:684
+#: static/js/zamboni/devhub-all.js:1863 static/js/zamboni/devhub-min.js:1 static/js/zamboni/devhub.js:684
 msgid "{reviews} user review"
 msgid_plural "{reviews} user reviews"
 msgstr[0] "{reviews} user review"
 msgstr[1] "{reviews} user reviews"
 
-#: static/js/zamboni/devhub.js:796
+#: static/js/zamboni/devhub-all.js:1975 static/js/zamboni/devhub-min.js:2 static/js/zamboni/devhub.js:796
 msgid "Learn more"
 msgstr "Learn more"
 
-#: static/js/zamboni/devhub.js:800
+#: static/js/zamboni/devhub-all.js:1979 static/js/zamboni/devhub-min.js:2 static/js/zamboni/devhub.js:800
 msgid "Example"
 msgstr "Example"
 
-#: static/js/zamboni/devhub.js:1130
+#: static/js/zamboni/devhub-all.js:2309 static/js/zamboni/devhub-min.js:2 static/js/zamboni/devhub.js:1130
 msgid "Image changes being processed"
 msgstr "Image changes being processed"
 
-#: static/js/zamboni/devhub.js:1280
+#: static/js/zamboni/devhub-all.js:2459 static/js/zamboni/devhub-min.js:2 static/js/zamboni/devhub.js:1280
 msgid "Must be a valid e-mail address."
 msgstr "Must be a valid email address."
 
-#: static/js/zamboni/devhub_search.js:8
-msgid "No results found."
-msgstr "No results found."
-
-#: static/js/zamboni/editors.js:121
-msgid "{name} was viewing this page first."
-msgstr "{name} was viewing this page first."
-
-#: static/js/zamboni/editors.js:171
-msgid "Receipt checked by app."
-msgstr "Receipt checked by app."
-
-#: static/js/zamboni/editors.js:173
-msgid "Receipt was not checked by app."
-msgstr "Receipt was not checked by app."
-
-#: static/js/zamboni/editors.js:244
-msgid "{name} was viewing this add-on first."
-msgstr "{name} was viewing this add-on first."
-
-#: static/js/zamboni/editors.js:255
-msgid "Loading&hellip;"
-msgstr "Loading&hellip;"
-
-#: static/js/zamboni/editors.js:260
-msgid "Version Notes"
-msgstr "Version Notes"
-
-#: static/js/zamboni/editors.js:265
-msgid "Notes for Reviewers"
-msgstr "Notes for Reviewers"
-
-#: static/js/zamboni/editors.js:270
-msgid "No version notes found"
-msgstr "No version notes found"
-
-#: static/js/zamboni/editors.js:330
-msgid "Average Reviews"
-msgstr "Average Reviews"
-
-#: static/js/zamboni/editors.js:386
-msgid "Number of Reviews"
-msgstr "Number of Reviews"
-
-#: static/js/zamboni/editors.js:445
-msgid "Error loading translation"
-msgstr "Error loading translation"
-
-#: static/js/zamboni/files.js:411 static/js/zamboni/validator.js:261
-msgid "Ignore this message in future updates"
-msgstr "Ignore this message in future updates"
-
-#: static/js/zamboni/files.js:417 static/js/zamboni/validator.js:284
-msgid "Severity for automated signing:"
-msgstr "Severity for automated signing:"
-
-#: static/js/zamboni/global.js:410
-msgid "Loading..."
-msgstr "Loading..."
-
-#. L10n: {0} is the number of characters left.
-#: static/js/zamboni/global.js:474
-msgid "<b>{0}</b> character left."
-msgid_plural "<b>{0}</b> characters left."
-msgstr[0] "<b>{0}</b> character left."
-msgstr[1] "<b>{0}</b> characters left."
-
-#: static/js/zamboni/init.js:28
-msgid "This feature is temporarily disabled while we perform website maintenance. Please check back a little later."
-msgstr "This feature is temporarily disabled while we perform web site maintenance. Please check back a little later."
-
-#: static/js/zamboni/l10n.js:45
-msgid "Remove this localization"
-msgstr "Remove this localisation"
-
-#: static/js/zamboni/password-strength.js:20
-msgid "Password strength:"
-msgstr "Password strength:"
-
-#: static/js/zamboni/password-strength.js:26
-msgid "At least {0} character left."
-msgid_plural "At least {0} characters left."
-msgstr[0] "At least {0} character left."
-msgstr[1] "At least {0} characters left."
-
-#: static/js/zamboni/themes_review.js:176
-msgid "Requested Info"
-msgstr "Requested Info"
-
-#: static/js/zamboni/themes_review.js:177
-msgid "Flagged"
-msgstr "Flagged"
-
-#: static/js/zamboni/themes_review.js:178
-msgid "Duplicate"
-msgstr "Duplicate"
-
-#: static/js/zamboni/themes_review.js:179
-msgid "Rejected"
-msgstr "Rejected"
-
-#: static/js/zamboni/themes_review.js:180
-msgid "Approved"
-msgstr "Approved"
-
-#: static/js/zamboni/themes_review.js:424
-msgid "No results found"
-msgstr "No results found"
-
-#: static/js/zamboni/themes_review_templates.js:31
-msgid "Theme"
-msgstr "Theme"
-
-#: static/js/zamboni/themes_review_templates.js:33
-msgid "Reviewer"
-msgstr "Reviewer"
-
-#: static/js/zamboni/themes_review_templates.js:35
-msgid "Status"
-msgstr "Status"
-
-#: static/js/zamboni/validator.js:80
+#: static/js/zamboni/devhub-all.js:2613 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:80
 msgid "All tests passed successfully."
 msgstr "All tests passed successfully."
 
-#: static/js/zamboni/validator.js:83 static/js/zamboni/validator.js:478
+#: static/js/zamboni/devhub-all.js:2616 static/js/zamboni/devhub-all.js:3011 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:83 static/js/zamboni/validator.js:478
 msgid "These tests were not run."
 msgstr "These tests were not run."
 
-#: static/js/zamboni/validator.js:131 static/js/zamboni/validator.js:144
+#: static/js/zamboni/devhub-all.js:2664 static/js/zamboni/devhub-all.js:2677 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:131 static/js/zamboni/validator.js:144
 msgid "Tests"
 msgstr "Tests"
 
-#: static/js/zamboni/validator.js:246 static/js/zamboni/validator.js:575 static/js/zamboni/validator.js:594
+#: static/js/zamboni/devhub-all.js:2779 static/js/zamboni/devhub-all.js:3108 static/js/zamboni/devhub-all.js:3127 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:246
+#: static/js/zamboni/validator.js:575 static/js/zamboni/validator.js:594
 msgid "Error"
 msgstr "Error"
 
-#: static/js/zamboni/validator.js:247
+#: static/js/zamboni/devhub-all.js:2780 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:247
 msgid "Warning"
 msgstr "Warning"
 
-#: static/js/zamboni/validator.js:299
+#: static/js/zamboni/devhub-all.js:2794 static/js/zamboni/devhub-min.js:2 static/js/zamboni/files-all.js:5657 static/js/zamboni/files-min.js:3 static/js/zamboni/files.js:411
+#: static/js/zamboni/validator.js:261
+msgid "Ignore this message in future updates"
+msgstr "Ignore this message in future updates"
+
+#: static/js/zamboni/devhub-all.js:2817 static/js/zamboni/devhub-min.js:2 static/js/zamboni/files-all.js:5663 static/js/zamboni/files-min.js:3 static/js/zamboni/files.js:417
+#: static/js/zamboni/validator.js:284
+msgid "Severity for automated signing:"
+msgstr "Severity for automated signing:"
+
+#: static/js/zamboni/devhub-all.js:2832 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:299
 msgid "Suggestions for passing automated signing:"
 msgstr "Suggestions for passing automated signing:"
 
-#: static/js/zamboni/validator.js:387
+#: static/js/zamboni/devhub-all.js:2920 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:387
 msgid "Compatibility Tests"
 msgstr "Compatibility Tests"
 
-#: static/js/zamboni/validator.js:466
+#: static/js/zamboni/devhub-all.js:2999 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:466
 msgid "Add-on failed validation."
 msgstr "Add-on failed validation."
 
-#: static/js/zamboni/validator.js:468
+#: static/js/zamboni/devhub-all.js:3001 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:468
 msgid "Add-on passed validation."
 msgstr "Add-on passed validation."
 
-#: static/js/zamboni/validator.js:481
+#: static/js/zamboni/devhub-all.js:3014 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:481
 msgid "{0} error"
 msgid_plural "{0} errors"
 msgstr[0] "{0} error"
 msgstr[1] "{0} errors"
 
-#: static/js/zamboni/validator.js:483
+#: static/js/zamboni/devhub-all.js:3016 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:483
 msgid "{0} warning"
 msgid_plural "{0} warnings"
 msgstr[0] "{0} warning"
 msgstr[1] "{0} warnings"
 
-#: static/js/zamboni/validator.js:485
+#: static/js/zamboni/devhub-all.js:3018 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:485
 msgid "{0} notice"
 msgid_plural "{0} notices"
 msgstr[0] "{0} notice"
 msgstr[1] "{0} notices"
 
-#: static/js/zamboni/validator.js:577
+#: static/js/zamboni/devhub-all.js:3110 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:577
 msgid "Validation task could not complete or completed with errors"
 msgstr "Validation task could not complete or completed with errors"
 
-#: static/js/zamboni/validator.js:595
+#: static/js/zamboni/devhub-all.js:3128 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:595
 msgid "Internal server error"
 msgstr "Internal server error"
 
-#: static/js/zamboni/mobile/buttons.js:52
+#: static/js/zamboni/devhub_search.js:8
+msgid "No results found."
+msgstr "No results found."
+
+#: static/js/zamboni/editors-all.js:15402 static/js/zamboni/editors-min.js:4 static/js/zamboni/editors.js:121
+msgid "{name} was viewing this page first."
+msgstr "{name} was viewing this page first."
+
+#: static/js/zamboni/editors-all.js:15452 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:171
+msgid "Receipt checked by app."
+msgstr "Receipt checked by app."
+
+#: static/js/zamboni/editors-all.js:15454 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:173
+msgid "Receipt was not checked by app."
+msgstr "Receipt was not checked by app."
+
+#: static/js/zamboni/editors-all.js:15525 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:244
+msgid "{name} was viewing this add-on first."
+msgstr "{name} was viewing this add-on first."
+
+#: static/js/zamboni/editors-all.js:15536 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:255
+msgid "Loading&hellip;"
+msgstr "Loading&hellip;"
+
+#: static/js/zamboni/editors-all.js:15541 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:260
+msgid "Version Notes"
+msgstr "Version Notes"
+
+#: static/js/zamboni/editors-all.js:15546 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:265
+msgid "Notes for Reviewers"
+msgstr "Notes for Reviewers"
+
+#: static/js/zamboni/editors-all.js:15551 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:270
+msgid "No version notes found"
+msgstr "No version notes found"
+
+#: static/js/zamboni/editors-all.js:15611 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:330
+msgid "Average Reviews"
+msgstr "Average Reviews"
+
+#: static/js/zamboni/editors-all.js:15667 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:386
+msgid "Number of Reviews"
+msgstr "Number of Reviews"
+
+#: static/js/zamboni/editors-all.js:15726 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:445
+msgid "Error loading translation"
+msgstr "Error loading translation"
+
+#: static/js/zamboni/editors-all.js:15975 static/js/zamboni/editors-min.js:5 static/js/zamboni/themes_review_templates.js:31
+msgid "Theme"
+msgstr "Theme"
+
+#: static/js/zamboni/editors-all.js:15977 static/js/zamboni/editors-min.js:5 static/js/zamboni/themes_review_templates.js:33
+msgid "Reviewer"
+msgstr "Reviewer"
+
+#: static/js/zamboni/editors-all.js:15979 static/js/zamboni/editors-min.js:5 static/js/zamboni/themes_review_templates.js:35
+msgid "Status"
+msgstr "Status"
+
+#: static/js/zamboni/editors-all.js:16196 static/js/zamboni/editors-min.js:5 static/js/zamboni/themes_review.js:176
+msgid "Requested Info"
+msgstr "Requested Info"
+
+#: static/js/zamboni/editors-all.js:16197 static/js/zamboni/editors-min.js:5 static/js/zamboni/themes_review.js:177
+msgid "Flagged"
+msgstr "Flagged"
+
+#: static/js/zamboni/editors-all.js:16198 static/js/zamboni/editors-min.js:5 static/js/zamboni/themes_review.js:178
+msgid "Duplicate"
+msgstr "Duplicate"
+
+#: static/js/zamboni/editors-all.js:16199 static/js/zamboni/editors-min.js:5 static/js/zamboni/themes_review.js:179
+msgid "Rejected"
+msgstr "Rejected"
+
+#: static/js/zamboni/editors-all.js:16200 static/js/zamboni/editors-min.js:5 static/js/zamboni/themes_review.js:180
+msgid "Approved"
+msgstr "Approved"
+
+#: static/js/zamboni/editors-all.js:16444 static/js/zamboni/editors-min.js:5 static/js/zamboni/themes_review.js:424
+msgid "No results found"
+msgstr "No results found"
+
+#: static/js/zamboni/mobile-all.js:15186 static/js/zamboni/mobile/buttons.js:52
 msgid "Not Updated for {0} {1}"
 msgstr "Not Updated for {0} {1}"
 
-#: static/js/zamboni/mobile/buttons.js:53
+#: static/js/zamboni/mobile-all.js:15187 static/js/zamboni/mobile/buttons.js:53
 msgid "Requires Newer Version of {0}"
 msgstr "Requires Newer Version of {0}"
 
-#: static/js/zamboni/mobile/buttons.js:54
+#: static/js/zamboni/mobile-all.js:15188 static/js/zamboni/mobile/buttons.js:54
 msgid "Unreviewed"
 msgstr "Unreviewed"
 
-#: static/js/zamboni/mobile/buttons.js:55
+#: static/js/zamboni/mobile-all.js:15189 static/js/zamboni/mobile/buttons.js:55
 msgid "Experimental <span>(Learn More)</span>"
 msgstr "Experimental <span>(Learn More)</span>"
 
-#: static/js/zamboni/mobile/buttons.js:56 static/js/zamboni/mobile/buttons.js:57
+#: static/js/zamboni/mobile-all.js:15190 static/js/zamboni/mobile-all.js:15191 static/js/zamboni/mobile/buttons.js:56 static/js/zamboni/mobile/buttons.js:57
 msgid "Not Available for {0}"
 msgstr "Not Available for {0}"
 
-#: static/js/zamboni/mobile/buttons.js:58
+#: static/js/zamboni/mobile-all.js:15192 static/js/zamboni/mobile/buttons.js:58
 msgid "Experimental"
 msgstr "Experimental"
 
-#: static/js/zamboni/mobile/buttons.js:59
+#: static/js/zamboni/mobile-all.js:15193 static/js/zamboni/mobile/buttons.js:59
 msgid "Themes Require Newer Version of {0}"
 msgstr "Themes Require Newer Version of {0}"
 
-#: static/js/zamboni/mobile/buttons.js:60
+#: static/js/zamboni/mobile-all.js:15194 static/js/zamboni/mobile/buttons.js:60
 msgid "Themes Require {0}"
 msgstr "Themes Require {0}"
 
-#: static/js/zamboni/mobile/buttons.js:105
+#: static/js/zamboni/mobile-all.js:15239 static/js/zamboni/mobile/buttons.js:105
 msgid "Installing..."
 msgstr "Installing..."
 
-#: static/js/zamboni/mobile/buttons.js:125
+#: static/js/zamboni/mobile-all.js:15259 static/js/zamboni/mobile/buttons.js:125
 msgid "This add-on has been preliminarily reviewed by Mozilla."
 msgstr "This add-on has been preliminarily reviewed by Mozilla."
 
-#: static/js/zamboni/mobile/buttons.js:250
+#: static/js/zamboni/mobile-all.js:15384 static/js/zamboni/mobile/buttons.js:250
 msgid "Keep it"
 msgstr "Keep it"
 
-#: static/js/zamboni/mobile/general.js:344
+#: static/js/zamboni/mobile-all.js:16049 static/js/zamboni/mobile-min.js:6 static/js/zamboni/mobile/general.js:344
 msgid "You're trying it on!"
 msgstr "You're trying it on!"
 
-#: static/js/zamboni/mobile/general.js:356
+#: static/js/zamboni/mobile-all.js:16061 static/js/zamboni/mobile-min.js:6 static/js/zamboni/mobile/general.js:356
 msgid "Added to Firefox"
 msgstr "Added to Firefox"
-

--- a/locale/en_US/LC_MESSAGES/django.po
+++ b/locale/en_US/LC_MESSAGES/django.po
@@ -7,69 +7,70 @@ msgid ""
 msgstr ""
 "Project-Id-Version:  addons\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2016-02-24 21:23+0000\n"
+"POT-Creation-Date: 2016-04-18 15:47+0000\n"
 "PO-Revision-Date: 2009-02-26 15:08-0800\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
+"Language: \n"
 "MIME-Version: 1.0\n"
-"Content-Type: text/plain; charset=utf-8\n"
+"Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Generated-By: Babel 2.2.0\n"
 
-#: src/olympia/accounts/views.py:52
+#: src/olympia/accounts/views.py:54
 msgid "Your log in attempt could not be parsed. Please try again."
 msgstr "Your log in attempt could not be parsed. Please try again."
 
-#: src/olympia/accounts/views.py:54
+#: src/olympia/accounts/views.py:56
 msgid "Your Firefox Account could not be found. Please try again."
 msgstr "Your Firefox Account could not be found. Please try again."
 
-#: src/olympia/accounts/views.py:55
+#: src/olympia/accounts/views.py:57
 msgid "You could not be logged in. Please try again."
 msgstr "You could not be logged in. Please try again."
 
-#: src/olympia/accounts/views.py:57
+#: src/olympia/accounts/views.py:59
 msgid "Your account has already been migrated to Firefox Accounts."
 msgstr "Your account has already been migrated to Firefox Accounts."
 
-#: src/olympia/accounts/views.py:59
+#: src/olympia/accounts/views.py:61
 msgid "Your Firefox Account already exists on this site."
 msgstr "Your Firefox Account already exists on this site."
 
-#: src/olympia/accounts/views.py:108
+#: src/olympia/accounts/views.py:110
 msgid "Great job!"
 msgstr "Great job!"
 
-#: src/olympia/accounts/views.py:109
+#: src/olympia/accounts/views.py:111
 msgid "You can now log in to Add-ons with your Firefox Account."
 msgstr "You can now log in to Add-ons with your Firefox Account."
 
-#: src/olympia/accounts/views.py:121
+#: src/olympia/accounts/views.py:123
 msgid "Need help?"
 msgstr "Need help?"
 
-#: src/olympia/addons/buttons.py:180
+#: src/olympia/addons/buttons.py:177
 msgid "Download Now"
 msgstr "Download Now"
 
-#: src/olympia/addons/buttons.py:182
+#: src/olympia/addons/buttons.py:179
 msgid "Download"
 msgstr "Download"
 
 #. L10n: please keep &nbsp; in the string so &rarr; does not wrap.
-#: src/olympia/addons/buttons.py:186
+#: src/olympia/addons/buttons.py:183
 msgid "Continue to Download&nbsp;&rarr;"
 msgstr "Continue to Download&nbsp;&rarr;"
 
-#: src/olympia/addons/buttons.py:202 src/olympia/addons/helpers.py:35 src/olympia/addons/views.py:319 src/olympia/addons/templates/addons/impala/details.html:114
+#: src/olympia/addons/buttons.py:199 src/olympia/addons/helpers.py:35 src/olympia/addons/views.py:333 src/olympia/addons/templates/addons/impala/details.html:111
 #: src/olympia/addons/templates/addons/impala/listing/items.html:17 src/olympia/addons/templates/addons/mobile/home.html:40 src/olympia/amo/templates/amo/side_nav.html:6
-#: src/olympia/amo/templates/amo/side_nav.html:10 src/olympia/amo/templates/amo/site_nav.html:2 src/olympia/amo/templates/amo/site_nav.html:55 src/olympia/bandwagon/views.py:95
-#: src/olympia/browse/views.py:54 src/olympia/browse/views.py:68 src/olympia/browse/views.py:235 src/olympia/browse/templates/browse/impala/category_landing.html:22
+#: src/olympia/amo/templates/amo/side_nav.html:10 src/olympia/amo/templates/amo/site_nav.html:2 src/olympia/amo/templates/amo/site_nav.html:53 src/olympia/bandwagon/views.py:95
+#: src/olympia/browse/views.py:54 src/olympia/browse/views.py:68 src/olympia/browse/views.py:202 src/olympia/browse/templates/browse/impala/category_landing.html:22
 #: src/olympia/browse/templates/browse/personas/mobile/category_landing.html:26
 msgid "Featured"
 msgstr "Featured"
 
-#: src/olympia/addons/buttons.py:221
+#: src/olympia/addons/buttons.py:218
 msgid "Add to {0}"
 msgstr "Add to {0}"
 
@@ -117,39 +118,39 @@ msgid_plural "All tags must be at least {0} characters."
 msgstr[0] "All tags must be at least {0} character."
 msgstr[1] "All tags must be at least {0} characters."
 
-#: src/olympia/addons/forms.py:234
+#: src/olympia/addons/forms.py:238
 msgid "Categories cannot be changed while your add-on is featured for this application."
 msgstr "Categories cannot be changed while your add-on is featured for this application."
 
 #. L10n: {0} is the number of categories.
-#: src/olympia/addons/forms.py:238
+#: src/olympia/addons/forms.py:242
 msgid "You can have only {0} category."
 msgid_plural "You can have only {0} categories."
 msgstr[0] "You can have only {0} category."
 msgstr[1] "You can have only {0} categories."
 
-#: src/olympia/addons/forms.py:246
+#: src/olympia/addons/forms.py:250
 msgid "The miscellaneous category cannot be combined with additional categories."
 msgstr "The miscellaneous category cannot be combined with additional categories."
 
-#: src/olympia/addons/forms.py:369
+#: src/olympia/addons/forms.py:374
 #, python-format
 msgid "Before changing your default locale you must have a name, summary, and description in that locale. You are missing %s."
 msgstr "Before changing your default locale you must have a name, summary, and description in that locale. You are missing %s."
 
-#: src/olympia/addons/forms.py:484 src/olympia/addons/forms.py:575
+#: src/olympia/addons/forms.py:455 src/olympia/addons/forms.py:546
 msgid "A license must be selected."
 msgstr "A license must be selected."
 
-#: src/olympia/addons/forms.py:556
+#: src/olympia/addons/forms.py:527
 msgid "Give Your Theme a Name."
 msgstr "Give Your Theme a Name."
 
-#: src/olympia/addons/forms.py:562 src/olympia/devhub/templates/devhub/personas/submit.html:53
+#: src/olympia/addons/forms.py:533 src/olympia/devhub/templates/devhub/personas/submit.html:53
 msgid "Describe your Theme."
 msgstr "Describe your Theme."
 
-#: src/olympia/addons/forms.py:704
+#: src/olympia/addons/forms.py:675
 msgid "Enter a new author's email address"
 msgstr "Enter a new author's email address"
 
@@ -157,39 +158,39 @@ msgstr "Enter a new author's email address"
 msgid "Not Reviewed"
 msgstr "Not Reviewed"
 
-#: src/olympia/addons/models.py:301
+#: src/olympia/addons/models.py:298
 msgid "Users have the option of contributing more or less than this amount."
 msgstr "Users have the option of contributing more or less than this amount."
 
-#: src/olympia/addons/models.py:309
-msgid "Users will always be asked in the Add-ons Manager (Firefox 4 and above)"
-msgstr "Users will always be asked in the Add-ons Manager (Firefox 4 and above)"
+#: src/olympia/addons/models.py:306
+msgid "Users will always be asked in the Add-ons Manager (Firefox 4 and above). Only applies to desktop."
+msgstr "Users will always be asked in the Add-ons Manager (Firefox 4 and above). Only applies to desktop."
 
 # Column name in a table.
-#: src/olympia/addons/models.py:1804 src/olympia/addons/templates/addons/details_box.html:55 src/olympia/devhub/templates/devhub/index.html:92
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:102
+#: src/olympia/addons/models.py:1802 src/olympia/addons/templates/addons/details_box.html:55 src/olympia/devhub/templates/devhub/index.html:92
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:89
 msgid "Listed"
 msgstr "Listed"
 
-#: src/olympia/addons/views.py:320 src/olympia/browse/templates/browse/personas/mobile/category_landing.html:27
+#: src/olympia/addons/views.py:334 src/olympia/browse/templates/browse/personas/mobile/category_landing.html:27
 msgid "Popular"
 msgstr "Popular"
 
-#: src/olympia/addons/views.py:321 src/olympia/browse/views.py:238 src/olympia/browse/views.py:280 src/olympia/browse/views.py:482
+#: src/olympia/addons/views.py:335 src/olympia/browse/views.py:205 src/olympia/browse/views.py:247 src/olympia/browse/views.py:449
 msgid "Recently Added"
 msgstr "Recently Added"
 
-#: src/olympia/addons/views.py:322 src/olympia/bandwagon/views.py:99 src/olympia/browse/views.py:60 src/olympia/browse/views.py:71 src/olympia/search/forms.py:16 src/olympia/search/forms.py:91
+#: src/olympia/addons/views.py:336 src/olympia/bandwagon/views.py:99 src/olympia/browse/views.py:60 src/olympia/browse/views.py:71 src/olympia/search/forms.py:16 src/olympia/search/forms.py:91
 msgid "Recently Updated"
 msgstr "Recently Updated"
 
 # %1 is an add-on name.
 #. l10n: {0} is the addon name
-#: src/olympia/addons/views.py:520
+#: src/olympia/addons/views.py:534
 msgid "Contribution for {0}"
 msgstr "Contribution for {0}"
 
-#: src/olympia/addons/views.py:613
+#: src/olympia/addons/views.py:627
 msgid "Abuse reported."
 msgstr "Abuse reported."
 
@@ -258,9 +259,9 @@ msgstr "Contribute"
 #: src/olympia/devhub/templates/devhub/addons/ajax_compat_update.html:36 src/olympia/devhub/templates/devhub/addons/profile.html:44 src/olympia/devhub/templates/devhub/addons/edit/admin.html:101
 #: src/olympia/devhub/templates/devhub/addons/edit/basic.html:152 src/olympia/devhub/templates/devhub/addons/edit/details.html:85 src/olympia/devhub/templates/devhub/addons/edit/support.html:67
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:166 src/olympia/devhub/templates/devhub/addons/forms_shared/media.html:149
-#: src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:44 src/olympia/devhub/templates/devhub/versions/add_file_modal.html:78 src/olympia/devhub/templates/devhub/versions/edit.html:139
-#: src/olympia/devhub/templates/devhub/versions/list.html:242 src/olympia/devhub/templates/devhub/versions/list.html:276 src/olympia/devhub/templates/devhub/versions/list.html:317
-#: src/olympia/devhub/templates/devhub/versions/list.html:351 src/olympia/reviews/templates/reviews/edit_review.html:16 src/olympia/translations/templates/translations/trans-menu.html:50
+#: src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:43 src/olympia/devhub/templates/devhub/versions/add_file_modal.html:58 src/olympia/devhub/templates/devhub/versions/edit.html:139
+#: src/olympia/devhub/templates/devhub/versions/list.html:239 src/olympia/devhub/templates/devhub/versions/list.html:281 src/olympia/devhub/templates/devhub/versions/list.html:315
+#: src/olympia/devhub/templates/devhub/versions/list.html:349 src/olympia/reviews/templates/reviews/edit_review.html:16 src/olympia/translations/templates/translations/trans-menu.html:50
 #: src/olympia/translations/templates/translations/trans-menu.html:62
 msgid "or"
 msgstr "or"
@@ -374,7 +375,7 @@ msgid "Add-on Information for {0}"
 msgstr "Add-on Information for {0}"
 
 #: src/olympia/addons/templates/addons/details_box.html:30 src/olympia/addons/templates/addons/persona_detail_table.html:3 src/olympia/addons/templates/addons/mobile/details.html:63
-#: src/olympia/addons/templates/addons/mobile/persona_detail_table.html:7 src/olympia/browse/views.py:459 src/olympia/devhub/views.py:75
+#: src/olympia/addons/templates/addons/mobile/persona_detail_table.html:7 src/olympia/browse/views.py:426 src/olympia/devhub/views.py:73
 msgid "Updated"
 msgstr "Updated"
 
@@ -393,11 +394,11 @@ msgstr "Works with"
 msgid "Visibility"
 msgstr "Visibility"
 
-#: src/olympia/addons/templates/addons/details_box.html:57 src/olympia/devhub/templates/devhub/index.html:94 src/olympia/devhub/templates/devhub/includes/addon_details.html:104
+#: src/olympia/addons/templates/addons/details_box.html:57 src/olympia/devhub/templates/devhub/index.html:94 src/olympia/devhub/templates/devhub/includes/addon_details.html:91
 msgid "Hidden"
 msgstr "Hidden"
 
-#: src/olympia/addons/templates/addons/details_box.html:59 src/olympia/devhub/templates/devhub/index.html:96 src/olympia/devhub/templates/devhub/includes/addon_details.html:106
+#: src/olympia/addons/templates/addons/details_box.html:59 src/olympia/devhub/templates/devhub/index.html:96 src/olympia/devhub/templates/devhub/includes/addon_details.html:93
 msgid "Unlisted"
 msgstr "Unlisted"
 
@@ -405,13 +406,13 @@ msgstr "Unlisted"
 msgid "Required Add-ons"
 msgstr "Required Add-ons"
 
-#: src/olympia/addons/templates/addons/details_box.html:81 src/olympia/addons/templates/addons/persona_detail_table.html:15 src/olympia/browse/views.py:462 src/olympia/devhub/views.py:78
-#: src/olympia/devhub/views.py:85 src/olympia/discovery/templates/discovery/addons/detail.html:57 src/olympia/reviews/forms.py:62 src/olympia/reviews/templates/reviews/add.html:57
+#: src/olympia/addons/templates/addons/details_box.html:81 src/olympia/addons/templates/addons/persona_detail_table.html:15 src/olympia/browse/views.py:429 src/olympia/devhub/views.py:76
+#: src/olympia/devhub/views.py:83 src/olympia/discovery/templates/discovery/addons/detail.html:57 src/olympia/reviews/forms.py:62 src/olympia/reviews/templates/reviews/add.html:57
 #: src/olympia/reviews/templates/reviews/mobile/review_list.html:18
 msgid "Rating"
 msgstr "Rating"
 
-#: src/olympia/addons/templates/addons/details_box.html:85 src/olympia/browse/views.py:461 src/olympia/devhub/views.py:77 src/olympia/devhub/views.py:84
+#: src/olympia/addons/templates/addons/details_box.html:85 src/olympia/browse/views.py:428 src/olympia/devhub/views.py:75 src/olympia/devhub/views.py:82
 #: src/olympia/stats/templates/stats/addon_report_menu.html:8 src/olympia/stats/templates/stats/collection_report_menu.html:18
 msgid "Downloads"
 msgstr "Downloads"
@@ -431,7 +432,7 @@ msgstr "Abuse Reports"
 
 #. The Privacy Policy for this add-on.
 #: src/olympia/addons/templates/addons/details_box.html:121 src/olympia/addons/templates/addons/privacy.html:19 src/olympia/addons/templates/addons/privacy.html:23
-#: src/olympia/addons/templates/addons/impala/button.html:43 src/olympia/addons/templates/addons/impala/details.html:307 src/olympia/devhub/templates/devhub/includes/policy_form.html:20
+#: src/olympia/addons/templates/addons/impala/button.html:43 src/olympia/addons/templates/addons/impala/details.html:312 src/olympia/devhub/templates/devhub/includes/policy_form.html:23
 #: src/olympia/templates/mobile/base_addons.html:87
 msgid "Privacy Policy"
 msgstr "Privacy Policy"
@@ -456,7 +457,7 @@ msgstr "Image Gallery"
 msgid "Developer Comments"
 msgstr "Developer Comments"
 
-#: src/olympia/addons/templates/addons/details_box.html:199 src/olympia/addons/templates/addons/impala/details.html:259
+#: src/olympia/addons/templates/addons/details_box.html:199 src/olympia/addons/templates/addons/impala/details.html:264
 msgid "Development Channel"
 msgstr "Development Channel"
 
@@ -480,7 +481,7 @@ msgstr ""
 "<strong>Caution:</strong> Development versions of this add-on have not been reviewed by Mozilla. Once you install a development version you will continue to receive development updates from this "
 "developer. To stop receiving development updates, reinstall the default version from the link above."
 
-#: src/olympia/addons/templates/addons/details_box.html:220 src/olympia/addons/templates/addons/impala/details.html:278
+#: src/olympia/addons/templates/addons/details_box.html:220 src/olympia/addons/templates/addons/impala/details.html:283
 msgid "Version {0}:"
 msgstr "Version {0}:"
 
@@ -499,7 +500,7 @@ msgid "End-User License Agreement for {0}"
 msgstr "End-User License Agreement for {0}"
 
 #: src/olympia/addons/templates/addons/eula.html:17 src/olympia/addons/templates/addons/eula.html:21 src/olympia/addons/templates/addons/impala/button.html:48
-#: src/olympia/addons/templates/addons/impala/details.html:316 src/olympia/devhub/templates/devhub/includes/policy_form.html:3 src/olympia/discovery/templates/discovery/addons/eula.html:11
+#: src/olympia/addons/templates/addons/impala/details.html:321 src/olympia/devhub/templates/devhub/includes/policy_form.html:3 src/olympia/discovery/templates/discovery/addons/eula.html:11
 msgid "End-User License Agreement"
 msgstr "End-User License Agreement"
 
@@ -518,7 +519,7 @@ msgstr "Back to {0}…"
 msgid "Add-ons for {0}"
 msgstr "Add-ons for {0}"
 
-#: src/olympia/addons/templates/addons/home.html:10 src/olympia/addons/templates/addons/home.html:51 src/olympia/browse/templates/browse/impala/base_listing.html:11
+#: src/olympia/addons/templates/addons/home.html:10 src/olympia/addons/templates/addons/home.html:53 src/olympia/browse/templates/browse/impala/base_listing.html:11
 msgid "Featured Extensions"
 msgstr "Featured Extensions"
 
@@ -526,29 +527,29 @@ msgstr "Featured Extensions"
 msgid "Popular Extensions"
 msgstr "Popular Extensions"
 
-#: src/olympia/addons/templates/addons/home.html:42 src/olympia/amo/templates/amo/side_nav.html:3 src/olympia/amo/templates/amo/side_nav.html:11 src/olympia/amo/templates/amo/site_nav.html:3
-#: src/olympia/amo/templates/amo/site_nav.html:25 src/olympia/browse/views.py:236 src/olympia/browse/views.py:281 src/olympia/browse/views.py:481
+#: src/olympia/addons/templates/addons/home.html:44 src/olympia/amo/templates/amo/side_nav.html:3 src/olympia/amo/templates/amo/side_nav.html:11 src/olympia/amo/templates/amo/site_nav.html:3
+#: src/olympia/amo/templates/amo/site_nav.html:25 src/olympia/browse/views.py:203 src/olympia/browse/views.py:248 src/olympia/browse/views.py:448
 msgid "Most Popular"
 msgstr "Most Popular"
 
-#: src/olympia/addons/templates/addons/home.html:43
+#: src/olympia/addons/templates/addons/home.html:45
 msgid "All »"
 msgstr "All »"
 
-#: src/olympia/addons/templates/addons/home.html:52 src/olympia/addons/templates/addons/home.html:61 src/olympia/addons/templates/addons/home.html:70 src/olympia/addons/templates/addons/home.html:78
+#: src/olympia/addons/templates/addons/home.html:54 src/olympia/addons/templates/addons/home.html:63 src/olympia/addons/templates/addons/home.html:72 src/olympia/addons/templates/addons/home.html:80
 #: src/olympia/browse/templates/browse/impala/category_landing.html:36
 msgid "See all »"
 msgstr "See all »"
 
-#: src/olympia/addons/templates/addons/home.html:60
+#: src/olympia/addons/templates/addons/home.html:62
 msgid "Up &amp; Coming Extensions"
 msgstr "Up &amp; Coming Extensions"
 
-#: src/olympia/addons/templates/addons/home.html:69 src/olympia/browse/templates/browse/personas/category_landing.html:61 src/olympia/discovery/templates/discovery/pane.html:74
+#: src/olympia/addons/templates/addons/home.html:71 src/olympia/browse/templates/browse/personas/category_landing.html:61 src/olympia/discovery/templates/discovery/pane.html:74
 msgid "Featured Themes"
 msgstr "Featured Themes"
 
-#: src/olympia/addons/templates/addons/home.html:77 src/olympia/bandwagon/templates/bandwagon/impala/collection_listing.html:5
+#: src/olympia/addons/templates/addons/home.html:79 src/olympia/bandwagon/templates/bandwagon/impala/collection_listing.html:5
 msgid "Featured Collections"
 msgstr "Featured Collections"
 
@@ -566,7 +567,7 @@ msgid "Updated {0}"
 msgstr "Updated {0}"
 
 #. {0} is a date.
-#: src/olympia/addons/templates/addons/macros.html:10 src/olympia/addons/templates/addons/macros.html:69 src/olympia/addons/templates/addons/persona_preview.html:21
+#: src/olympia/addons/templates/addons/macros.html:10 src/olympia/addons/templates/addons/macros.html:69 src/olympia/addons/templates/addons/persona_preview.html:22
 #: src/olympia/addons/templates/addons/listing/items_mobile.html:44 src/olympia/addons/templates/addons/listing/macros.html:39
 #: src/olympia/bandwagon/templates/bandwagon/collection_listing_items.html:37 src/olympia/bandwagon/templates/bandwagon/impala/collection_listing_items.html:37
 msgid "Added {0}"
@@ -587,15 +588,14 @@ msgstr[0] "%(num)s user"
 msgstr[1] "%(num)s users"
 
 #. {0} is the number of downloads.
-#: src/olympia/addons/templates/addons/macros.html:53 src/olympia/addons/templates/addons/impala/details.html:61
+#: src/olympia/addons/templates/addons/macros.html:53 src/olympia/addons/templates/addons/impala/details.html:59
 msgid "{0} weekly download"
 msgid_plural "{0} weekly downloads"
 msgstr[0] "{0} weekly download"
 msgstr[1] "{0} weekly downloads"
 
 #. {0} is the number of users.
-#: src/olympia/addons/templates/addons/macros.html:61 src/olympia/addons/templates/addons/impala/details.html:54 src/olympia/compat/templates/compat/index.html:71
-#: src/olympia/zadmin/templates/zadmin/compat.html:67
+#: src/olympia/addons/templates/addons/macros.html:61 src/olympia/addons/templates/addons/impala/details.html:52 src/olympia/zadmin/templates/zadmin/compat.html:67
 msgid "{0} user"
 msgid_plural "{0} users"
 msgstr[0] "{0} user"
@@ -613,7 +613,7 @@ msgstr "Payment completed"
 msgid "Return to the addon."
 msgstr "Return to the addon."
 
-#: src/olympia/addons/templates/addons/persona_detail.html:17 src/olympia/addons/templates/addons/impala/details.html:106 src/olympia/addons/templates/addons/mobile/details.html:23
+#: src/olympia/addons/templates/addons/persona_detail.html:17 src/olympia/addons/templates/addons/impala/details.html:103 src/olympia/addons/templates/addons/mobile/details.html:23
 #: src/olympia/addons/templates/addons/mobile/persona_detail.html:21 src/olympia/discovery/templates/discovery/addons/base.html:27 src/olympia/editors/templates/editors/review.html:31
 msgid "by"
 msgstr "by"
@@ -657,34 +657,35 @@ msgstr "Daily Users"
 msgid "License"
 msgstr "License"
 
-#: src/olympia/addons/templates/addons/persona_preview.html:12 src/olympia/constants/base.py:48
+#: src/olympia/addons/templates/addons/persona_preview.html:13 src/olympia/constants/base.py:48
 msgid "Awaiting Review"
 msgstr "Awaiting Review"
 
-#: src/olympia/addons/templates/addons/persona_preview.html:14 src/olympia/amo/log.py:180 src/olympia/constants/base.py:42 src/olympia/editors/helpers.py:62
+#: src/olympia/addons/templates/addons/persona_preview.html:15 src/olympia/amo/log.py:180 src/olympia/constants/base.py:42 src/olympia/editors/helpers.py:62
 msgid "Rejected"
 msgstr "Rejected"
 
-#: src/olympia/addons/templates/addons/persona_preview.html:16 src/olympia/amo/log.py:159
+#: src/olympia/addons/templates/addons/persona_preview.html:17 src/olympia/amo/log.py:159
 msgid "Approved"
 msgstr "Approved"
 
 #. {0} is the number of users.
-#: src/olympia/addons/templates/addons/persona_preview.html:26 src/olympia/addons/templates/addons/listing/items_mobile.html:36 src/olympia/addons/templates/addons/listing/macros.html:31
+#: src/olympia/addons/templates/addons/persona_preview.html:27 src/olympia/addons/templates/addons/listing/items_mobile.html:36 src/olympia/addons/templates/addons/listing/macros.html:31
 msgid "<strong>{0}</strong> user"
 msgid_plural "<strong>{0}</strong> users"
 msgstr[0] "<strong>{0}</strong> user"
 msgstr[1] "<strong>{0}</strong> users"
 
-#: src/olympia/addons/templates/addons/persona_preview.html:40
+#: src/olympia/addons/templates/addons/persona_preview.html:41
 msgid "Hover to Preview"
 msgstr "Hover to Preview"
 
-#: src/olympia/addons/templates/addons/persona_preview.html:46 src/olympia/addons/templates/addons/persona_preview.html:48 src/olympia/reviews/templates/reviews/add.html:15
+#: src/olympia/addons/templates/addons/persona_preview.html:47 src/olympia/addons/templates/addons/persona_preview.html:49 src/olympia/addons/templates/addons/persona_preview.html:97
+#: src/olympia/reviews/templates/reviews/add.html:15
 msgid "Add"
 msgstr "Add"
 
-#: src/olympia/addons/templates/addons/persona_preview.html:57 src/olympia/bandwagon/templates/bandwagon/ajax_new.html:16 src/olympia/bandwagon/templates/bandwagon/edit.html:19
+#: src/olympia/addons/templates/addons/persona_preview.html:58 src/olympia/bandwagon/templates/bandwagon/ajax_new.html:16 src/olympia/bandwagon/templates/bandwagon/edit.html:19
 #: src/olympia/bandwagon/templates/bandwagon/includes/addedit.html:19 src/olympia/devhub/templates/devhub/addons/edit/admin.html:13 src/olympia/devhub/templates/devhub/addons/edit/basic.html:10
 #: src/olympia/devhub/templates/devhub/addons/edit/details.html:8 src/olympia/devhub/templates/devhub/addons/edit/media.html:6 src/olympia/devhub/templates/devhub/addons/edit/support.html:8
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:9 src/olympia/devhub/templates/devhub/addons/submit/describe.html:29 src/olympia/editors/templates/editors/review.html:257
@@ -693,21 +694,21 @@ msgstr "Edit"
 
 #. For datetime formatting, see the table on
 #. http://docs.python.org/library/datetime.html#strftime-and-strptime-behavior
-#: src/olympia/addons/templates/addons/persona_preview.html:66
+#: src/olympia/addons/templates/addons/persona_preview.html:67
 #, python-format
 msgid "%%Y-%%m-%%d"
 msgstr "%%Y-%%m-%%d"
 
-#: src/olympia/addons/templates/addons/persona_preview.html:67
+#: src/olympia/addons/templates/addons/persona_preview.html:68
 msgid "by {0} on {1}"
 msgstr "by {0} on {1}"
 
-#: src/olympia/addons/templates/addons/persona_preview.html:75 src/olympia/reviews/helpers.py:17 src/olympia/reviews/templates/reviews/review_list.html:63
+#: src/olympia/addons/templates/addons/persona_preview.html:76 src/olympia/reviews/helpers.py:17 src/olympia/reviews/templates/reviews/review_list.html:63
 #: src/olympia/reviews/templates/reviews/reviews_link.html:21 src/olympia/reviews/templates/reviews/impala/reviews_link.html:16
 msgid "Not yet rated"
 msgstr "Not yet rated"
 
-#: src/olympia/addons/templates/addons/persona_preview.html:78
+#: src/olympia/addons/templates/addons/persona_preview.html:79
 msgid "<b>{0}</b> users"
 msgstr "<b>{0}</b> users"
 
@@ -720,8 +721,8 @@ msgid "Learn more about Firefox"
 msgstr "Learn more about Firefox"
 
 #: src/olympia/addons/templates/addons/popups.html:22
-msgid "or <b><a class=\"installer\" href=\"{url}\">download anyway</a></b>"
-msgstr "or <b><a class=\"installer\" href=\"{url}\">download anyway</a></b>"
+msgid "or <b><a class=\"button installer\" href=\"{url}\">download anyway</a></b>"
+msgstr "or <b><a class=\"button installer\" href=\"{url}\">download anyway</a></b>"
 
 #: src/olympia/addons/templates/addons/popups.html:26
 msgid ""
@@ -826,7 +827,7 @@ msgstr ""
 "  don't have one.)"
 
 #: src/olympia/addons/templates/addons/report_abuse.html:6 src/olympia/addons/templates/addons/report_abuse_full.html:10 src/olympia/addons/templates/addons/impala/details-more.html:23
-#: src/olympia/addons/templates/addons/impala/details.html:328
+#: src/olympia/addons/templates/addons/impala/details.html:333
 msgid "Report Abuse"
 msgstr "Report Abuse"
 
@@ -847,9 +848,9 @@ msgstr "Send Report"
 #: src/olympia/devhub/templates/devhub/addons/ajax_compat_update.html:36 src/olympia/devhub/templates/devhub/addons/profile.html:44 src/olympia/devhub/templates/devhub/addons/edit/admin.html:104
 #: src/olympia/devhub/templates/devhub/addons/edit/basic.html:155 src/olympia/devhub/templates/devhub/addons/edit/details.html:88 src/olympia/devhub/templates/devhub/addons/edit/support.html:70
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:169 src/olympia/devhub/templates/devhub/addons/forms_shared/media.html:152
-#: src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:44 src/olympia/devhub/templates/devhub/personas/edit.html:222 src/olympia/devhub/templates/devhub/versions/add_file_modal.html:79
-#: src/olympia/devhub/templates/devhub/versions/edit.html:140 src/olympia/devhub/templates/devhub/versions/list.html:208 src/olympia/devhub/templates/devhub/versions/list.html:242
-#: src/olympia/devhub/templates/devhub/versions/list.html:276 src/olympia/devhub/templates/devhub/versions/list.html:317 src/olympia/reviews/templates/reviews/edit_review.html:16
+#: src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:43 src/olympia/devhub/templates/devhub/personas/edit.html:222 src/olympia/devhub/templates/devhub/versions/add_file_modal.html:59
+#: src/olympia/devhub/templates/devhub/versions/edit.html:140 src/olympia/devhub/templates/devhub/versions/list.html:208 src/olympia/devhub/templates/devhub/versions/list.html:239
+#: src/olympia/devhub/templates/devhub/versions/list.html:281 src/olympia/devhub/templates/devhub/versions/list.html:315 src/olympia/reviews/templates/reviews/edit_review.html:16
 #: src/olympia/translations/templates/translations/trans-menu.html:50 src/olympia/translations/templates/translations/trans-menu.html:62 src/olympia/zadmin/templates/zadmin/validation.html:105
 msgid "Cancel"
 msgstr "Cancel"
@@ -894,7 +895,7 @@ msgstr "See the <a href=\"%(support)s\">support section</a> to find out where to
 msgid "Review Guidelines"
 msgstr "Review Guidelines"
 
-#: src/olympia/addons/templates/addons/review_list_box.html:5 src/olympia/addons/templates/addons/impala/details-more.html:27 src/olympia/editors/helpers.py:921
+#: src/olympia/addons/templates/addons/review_list_box.html:5 src/olympia/addons/templates/addons/impala/details-more.html:27 src/olympia/editors/helpers.py:1001
 #: src/olympia/reviews/templates/reviews/add.html:14 src/olympia/reviews/templates/reviews/reply.html:14 src/olympia/reviews/templates/reviews/review_list.html:19
 #: src/olympia/reviews/templates/reviews/mobile/review_list.html:26
 msgid "Reviews"
@@ -985,31 +986,31 @@ msgid_plural "Other add-ons by these authors"
 msgstr[0] "Other add-ons by %(author)s"
 msgstr[1] "Other add-ons by these authors"
 
-#: src/olympia/addons/templates/addons/impala/details.html:41
+#: src/olympia/addons/templates/addons/impala/details.html:39
 #, python-format
 msgid "<span itemprop=\"ratingCount\">%(num)s</span> user review"
 msgid_plural "<span itemprop=\"ratingCount\">%(num)s</span> user reviews"
 msgstr[0] "<span itemprop=\"ratingCount\">%(num)s</span> user review"
 msgstr[1] "<span itemprop=\"ratingCount\">%(num)s</span> user reviews"
 
-#: src/olympia/addons/templates/addons/impala/details.html:69
+#: src/olympia/addons/templates/addons/impala/details.html:66
 msgid "View statistics"
 msgstr "View statistics"
 
-#: src/olympia/addons/templates/addons/impala/details.html:84
+#: src/olympia/addons/templates/addons/impala/details.html:81
 msgid "Manage"
 msgstr "Manage"
 
 #. {0} is an add-on name.
-#: src/olympia/addons/templates/addons/impala/details.html:96
+#: src/olympia/addons/templates/addons/impala/details.html:93
 msgid "Icon of {0}"
 msgstr "Icon of {0}"
 
-#: src/olympia/addons/templates/addons/impala/details.html:103 src/olympia/addons/templates/addons/impala/listing/items.html:14
+#: src/olympia/addons/templates/addons/impala/details.html:100 src/olympia/addons/templates/addons/impala/listing/items.html:14
 msgid "No Restart"
 msgstr "No Restart"
 
-#: src/olympia/addons/templates/addons/impala/details.html:127
+#: src/olympia/addons/templates/addons/impala/details.html:124
 #, fuzzy, python-format
 msgid "Meet the Developer: <a href=\"%(url)s\">%(name)s</a>"
 msgid_plural "<a href=\"%(url)s\">Meet the Developers</a>"
@@ -1017,72 +1018,72 @@ msgstr[0] "Meet the Developer: <a href=\"%(url)s\">%(name)s</a>"
 msgstr[1] "<a href=\"%(url)s\">Meet the Developers</a>"
 
 # {0} is an add-on name.
-#: src/olympia/addons/templates/addons/impala/details.html:137
+#: src/olympia/addons/templates/addons/impala/details.html:134
 msgid "Learn why {0} was created and find out what's next for this add-on."
 msgstr "Learn why {0} was created and find out what's next for this add-on."
 
 #. {0} is an index.
-#: src/olympia/addons/templates/addons/impala/details.html:156
+#: src/olympia/addons/templates/addons/impala/details.html:161
 msgid "Add-on screenshot #{0}"
 msgstr "Add-on screenshot #{0}"
 
-#: src/olympia/addons/templates/addons/impala/details.html:182
+#: src/olympia/addons/templates/addons/impala/details.html:187
 msgid "Add-on home page"
 msgstr "Add-on home page"
 
-#: src/olympia/addons/templates/addons/impala/details.html:185
+#: src/olympia/addons/templates/addons/impala/details.html:190
 msgid "Support site"
 msgstr "Support site"
 
-#: src/olympia/addons/templates/addons/impala/details.html:189
+#: src/olympia/addons/templates/addons/impala/details.html:194
 msgid "Support E-mail"
 msgstr "Support E-mail"
 
-#: src/olympia/addons/templates/addons/impala/details.html:194 src/olympia/devhub/models.py:378 src/olympia/devhub/templates/devhub/versions/list.html:12
+#: src/olympia/addons/templates/addons/impala/details.html:199 src/olympia/devhub/models.py:378 src/olympia/devhub/templates/devhub/versions/list.html:12
 #: src/olympia/versions/templates/versions/version.html:6 src/olympia/versions/templates/versions/mobile/version.html:6
 msgid "Version {0}"
 msgstr "Version {0}"
 
-#: src/olympia/addons/templates/addons/impala/details.html:194
+#: src/olympia/addons/templates/addons/impala/details.html:199
 msgid "Info"
 msgstr "Info"
 
-#: src/olympia/addons/templates/addons/impala/details.html:195 src/olympia/devhub/templates/devhub/includes/addon_details.html:129
+#: src/olympia/addons/templates/addons/impala/details.html:200 src/olympia/devhub/templates/devhub/includes/addon_details.html:116
 msgid "Last Updated:"
 msgstr "Last Updated:"
 
-#: src/olympia/addons/templates/addons/impala/details.html:200
+#: src/olympia/addons/templates/addons/impala/details.html:205
 #, python-format
 msgid "Released under <a target=\"_blank\" href=\"%(url)s\">%(name)s</a>"
 msgstr "Released under <a target=\"_blank\" href=\"%(url)s\">%(name)s</a>"
 
-#: src/olympia/addons/templates/addons/impala/details.html:201 src/olympia/addons/templates/addons/impala/details.html:206 src/olympia/amo/helpers.py:398 src/olympia/devhub/forms.py:142
+#: src/olympia/addons/templates/addons/impala/details.html:206 src/olympia/addons/templates/addons/impala/details.html:211 src/olympia/amo/helpers.py:398 src/olympia/devhub/forms.py:142
 #: src/olympia/devhub/forms.py:173 src/olympia/versions/templates/versions/version.html:40 src/olympia/versions/templates/versions/version.html:45
 msgid "Custom License"
 msgstr "Custom License"
 
-#: src/olympia/addons/templates/addons/impala/details.html:205
+#: src/olympia/addons/templates/addons/impala/details.html:210
 #, python-format
 msgid "Released under <a href=\"%(url)s\">%(name)s</a>"
 msgstr "Released under <a href=\"%(url)s\">%(name)s</a>"
 
-#: src/olympia/addons/templates/addons/impala/details.html:217
+#: src/olympia/addons/templates/addons/impala/details.html:222
 msgid "About this Add-on"
 msgstr "About this Add-on"
 
-#: src/olympia/addons/templates/addons/impala/details.html:233
+#: src/olympia/addons/templates/addons/impala/details.html:238
 msgid "Developer’s Comments"
 msgstr "Developer’s Comments"
 
-#: src/olympia/addons/templates/addons/impala/details.html:243
+#: src/olympia/addons/templates/addons/impala/details.html:248
 msgid "Version Information"
 msgstr "Version Information"
 
-#: src/olympia/addons/templates/addons/impala/details.html:250
+#: src/olympia/addons/templates/addons/impala/details.html:255
 msgid "See complete version history"
 msgstr "See complete version history"
 
-#: src/olympia/addons/templates/addons/impala/details.html:262
+#: src/olympia/addons/templates/addons/impala/details.html:267
 msgid ""
 "The Development Channel lets you test an experimental new version of this add-on before it's released to the general public. Once you install the development version, you will continue to get "
 "updates from this channel. To stop receiving development updates, reinstall the default version from the link above."
@@ -1090,17 +1091,17 @@ msgstr ""
 "The Development Channel lets you test an experimental new version of this add-on before it's released to the general public. Once you install the development version, you will continue to get "
 "updates from this channel. To stop receiving development updates, reinstall the default version from the link above."
 
-#: src/olympia/addons/templates/addons/impala/details.html:272
+#: src/olympia/addons/templates/addons/impala/details.html:277
 msgid "<strong>Caution:</strong> Development versions of this add-on have not been reviewed by Mozilla."
 msgstr "<strong>Caution:</strong> Development versions of this add-on have not been reviewed by Mozilla."
 
-#: src/olympia/addons/templates/addons/impala/details.html:287
+#: src/olympia/addons/templates/addons/impala/details.html:292
 msgid "See complete development channel history"
 msgstr "See complete development channel history"
 
-#: src/olympia/addons/templates/addons/impala/details.html:306 src/olympia/addons/templates/addons/impala/details.html:315 src/olympia/addons/templates/addons/impala/details.html:327
+#: src/olympia/addons/templates/addons/impala/details.html:311 src/olympia/addons/templates/addons/impala/details.html:320 src/olympia/addons/templates/addons/impala/details.html:332
 #: src/olympia/addons/templates/addons/impala/review_add_box.html:4 src/olympia/stats/templates/stats/popup.html:2 src/olympia/stats/templates/stats/popup.html:8
-#: src/olympia/stats/templates/stats/stats.html:202 src/olympia/users/templates/users/profile.html:119
+#: src/olympia/stats/templates/stats/stats.html:204 src/olympia/users/templates/users/profile.html:119
 msgid "close"
 msgstr "close"
 
@@ -1159,15 +1160,11 @@ msgstr "Source Code License for {addon}"
 msgid "Source Code License"
 msgstr "Source Code License"
 
-#: src/olympia/addons/templates/addons/impala/persona_grid.html:16 src/olympia/addons/templates/addons/impala/toplist.html:6
-msgid "{0} users"
-msgstr "{0} users"
-
 #: src/olympia/addons/templates/addons/impala/review_list_box.html:19 src/olympia/reviews/templates/reviews/review.html:40
 msgid "permalink"
 msgstr "permalink"
 
-#: src/olympia/addons/templates/addons/impala/review_list_box.html:23 src/olympia/editors/templates/editors/queue.html:98 src/olympia/reviews/templates/reviews/review.html:44
+#: src/olympia/addons/templates/addons/impala/review_list_box.html:23 src/olympia/editors/templates/editors/queue.html:104 src/olympia/reviews/templates/reviews/review.html:44
 msgid "translate"
 msgstr "translate"
 
@@ -1186,6 +1183,10 @@ msgstr "This add-on has not yet been reviewed."
 msgid "Be the first!"
 msgstr "Be the first!"
 
+#: src/olympia/addons/templates/addons/impala/toplist.html:6
+msgid "{0} users"
+msgstr "{0} users"
+
 #: src/olympia/addons/templates/addons/impala/listing/sorter.html:14 src/olympia/devhub/templates/devhub/addons/listing/item_actions.html:49
 msgid "More"
 msgstr "More"
@@ -1198,7 +1199,7 @@ msgstr "Add to collection"
 msgid "My Add-ons"
 msgstr "My Add-ons"
 
-#: src/olympia/addons/templates/addons/includes/dashboard_tabs.html:6 src/olympia/amo/context_processors.py:51
+#: src/olympia/addons/templates/addons/includes/dashboard_tabs.html:6 src/olympia/amo/context_processors.py:50
 msgid "My Themes"
 msgstr "My Themes"
 
@@ -1253,7 +1254,7 @@ msgstr "Users"
 msgid "Weekly Downloads"
 msgstr "Weekly Downloads"
 
-#: src/olympia/addons/templates/addons/mobile/details.html:99 src/olympia/compat/templates/compat/reporter_detail.html:46 src/olympia/devhub/forms.py:787
+#: src/olympia/addons/templates/addons/mobile/details.html:99 src/olympia/compat/templates/compat/reporter_detail.html:46 src/olympia/devhub/forms.py:788
 #: src/olympia/devhub/templates/devhub/versions/list.html:163
 msgid "Version"
 msgstr "Version"
@@ -1340,7 +1341,7 @@ msgstr ""
 #: src/olympia/browse/templates/browse/personas/category_landing.html:21 src/olympia/browse/templates/browse/personas/category_landing.html:23
 #: src/olympia/browse/templates/browse/personas/category_landing.html:38 src/olympia/browse/templates/browse/personas/grid.html:7 src/olympia/browse/templates/browse/personas/grid.html:11
 #: src/olympia/browse/templates/browse/personas/mobile/base.html:7 src/olympia/browse/templates/browse/personas/mobile/category_landing.html:19 src/olympia/constants/base.py:180
-#: src/olympia/devhub/templates/devhub/personas/submit.html:13 src/olympia/editors/helpers.py:105 src/olympia/editors/templates/editors/base.html:26
+#: src/olympia/devhub/templates/devhub/personas/submit.html:13 src/olympia/editors/helpers.py:107 src/olympia/editors/templates/editors/base.html:26
 #: src/olympia/editors/templates/editors/performance.html:73 src/olympia/search/templates/search/personas.html:39 src/olympia/templates/menu_links.html:9
 msgid "Themes"
 msgstr "Themes"
@@ -1361,7 +1362,7 @@ msgstr "More Add-ons"
 msgid "Highest Rated"
 msgstr "Highest Rated"
 
-#: src/olympia/addons/templates/addons/mobile/home.html:74 src/olympia/amo/templates/amo/side_nav.html:5 src/olympia/amo/templates/amo/site_nav.html:27 src/olympia/amo/templates/amo/site_nav.html:57
+#: src/olympia/addons/templates/addons/mobile/home.html:74 src/olympia/amo/templates/amo/side_nav.html:5 src/olympia/amo/templates/amo/site_nav.html:27 src/olympia/amo/templates/amo/site_nav.html:55
 #: src/olympia/bandwagon/views.py:97 src/olympia/browse/views.py:57 src/olympia/browse/views.py:67 src/olympia/browse/templates/browse/personas/mobile/category_landing.html:65
 #: src/olympia/search/forms.py:15 src/olympia/search/forms.py:87
 msgid "Newest"
@@ -1375,90 +1376,90 @@ msgstr "Try it on!"
 msgid "Theme Info &raquo;"
 msgstr "Theme Info &raquo;"
 
-#: src/olympia/amo/context_processors.py:39 src/olympia/devhub/templates/devhub/nav.html:43
+#: src/olympia/amo/context_processors.py:37 src/olympia/devhub/templates/devhub/nav.html:43
 msgid "Tools"
 msgstr "Tools"
 
-#: src/olympia/amo/context_processors.py:48 src/olympia/discovery/templates/discovery/pane_account.html:8 src/olympia/users/templates/users/includes/navigation.html:2
+#: src/olympia/amo/context_processors.py:47 src/olympia/discovery/templates/discovery/pane_account.html:8 src/olympia/users/templates/users/includes/navigation.html:2
 msgid "My Profile"
 msgstr "My Profile"
 
-#: src/olympia/amo/context_processors.py:54 src/olympia/users/templates/users/edit.html:5 src/olympia/users/templates/users/includes/navigation.html:3
+#: src/olympia/amo/context_processors.py:53 src/olympia/users/templates/users/edit.html:5 src/olympia/users/templates/users/includes/navigation.html:3
 msgid "Account Settings"
 msgstr "Account Settings"
 
-#: src/olympia/amo/context_processors.py:57 src/olympia/discovery/templates/discovery/pane_account.html:11 src/olympia/users/templates/users/profile.html:83
+#: src/olympia/amo/context_processors.py:56 src/olympia/discovery/templates/discovery/pane_account.html:11 src/olympia/users/templates/users/profile.html:83
 #: src/olympia/users/templates/users/includes/navigation.html:4
 msgid "My Collections"
 msgstr "My Collections"
 
-#: src/olympia/amo/context_processors.py:62 src/olympia/discovery/templates/discovery/pane_account.html:10 src/olympia/users/templates/users/includes/navigation.html:7
+#: src/olympia/amo/context_processors.py:61 src/olympia/discovery/templates/discovery/pane_account.html:10 src/olympia/users/templates/users/includes/navigation.html:7
 msgid "My Favorites"
 msgstr "My Favorites"
 
-#: src/olympia/amo/context_processors.py:67 src/olympia/discovery/templates/discovery/pane_account.html:13 src/olympia/templates/impala/user_login.html:14
+#: src/olympia/amo/context_processors.py:66 src/olympia/discovery/templates/discovery/pane_account.html:13 src/olympia/templates/impala/user_login.html:14
 #: src/olympia/templates/mobile/header_auth.html:5
 msgid "Log out"
 msgstr "Log out"
 
-#: src/olympia/amo/context_processors.py:72 src/olympia/devhub/templates/devhub/addons/dashboard.html:4
+#: src/olympia/amo/context_processors.py:71 src/olympia/devhub/templates/devhub/addons/dashboard.html:4
 msgid "Manage My Submissions"
 msgstr "Manage My Submissions"
 
-#: src/olympia/amo/context_processors.py:75 src/olympia/devhub/templates/devhub/nav.html:27 src/olympia/devhub/templates/devhub/addons/dashboard.html:25
+#: src/olympia/amo/context_processors.py:74 src/olympia/devhub/templates/devhub/nav.html:27 src/olympia/devhub/templates/devhub/addons/dashboard.html:25
 #: src/olympia/devhub/templates/devhub/addons/submit/base.html:4
 msgid "Submit a New Add-on"
 msgstr "Submit a New Add-on"
 
-#: src/olympia/amo/context_processors.py:77 src/olympia/browse/templates/browse/personas/base.html:50 src/olympia/devhub/templates/devhub/index.html:24
+#: src/olympia/amo/context_processors.py:76 src/olympia/browse/templates/browse/personas/base.html:50 src/olympia/devhub/templates/devhub/index.html:24
 #: src/olympia/devhub/templates/devhub/addons/dashboard.html:29
 msgid "Submit a New Theme"
 msgstr "Submit a New Theme"
 
-#: src/olympia/amo/context_processors.py:79 src/olympia/amo/templates/amo/site_nav.html:87 src/olympia/devhub/helpers.py:36 src/olympia/devhub/helpers.py:68 src/olympia/devhub/helpers.py:102
+#: src/olympia/amo/context_processors.py:78 src/olympia/amo/templates/amo/site_nav.html:85 src/olympia/devhub/helpers.py:36 src/olympia/devhub/helpers.py:68 src/olympia/devhub/helpers.py:102
 #: src/olympia/templates/footer.html:6 src/olympia/templates/menu_links.html:14
 msgid "Developer Hub"
 msgstr "Developer Hub"
 
-#: src/olympia/amo/context_processors.py:83 src/olympia/devhub/views.py:1792
+#: src/olympia/amo/context_processors.py:81 src/olympia/devhub/views.py:1796
 msgid "Manage API Keys"
 msgstr "Manage API Keys"
 
-#: src/olympia/amo/context_processors.py:88 src/olympia/editors/helpers.py:82 src/olympia/editors/helpers.py:102 src/olympia/editors/templates/editors/base.html:10
+#: src/olympia/amo/context_processors.py:86 src/olympia/editors/helpers.py:84 src/olympia/editors/helpers.py:104 src/olympia/editors/templates/editors/base.html:10
 msgid "Editor Tools"
 msgstr "Editor Tools"
 
-#: src/olympia/amo/context_processors.py:92
+#: src/olympia/amo/context_processors.py:90
 msgid "Admin Tools"
 msgstr "Admin Tools"
 
-#: src/olympia/amo/fields.py:15
+#: src/olympia/amo/fields.py:20
 msgid "Incorrect, please try again."
 msgstr "Incorrect, please try again."
 
-#: src/olympia/amo/fields.py:16
+#: src/olympia/amo/fields.py:21
 msgid "Error verifying input, please try again."
 msgstr "Error verifying input, please try again."
 
-#: src/olympia/amo/fields.py:32
+#: src/olympia/amo/fields.py:37
 msgid "This must be a valid hex color code, such as #000000."
 msgstr "This must be a valid hex color code, such as #000000."
 
-#: src/olympia/amo/fields.py:58
+#: src/olympia/amo/fields.py:63
 msgid "Enter at least one value."
 msgstr "Enter at least one value."
 
-#: src/olympia/amo/helpers.py:162 src/olympia/amo/templates/amo/site_nav.html:61 src/olympia/bandwagon/templates/bandwagon/add.html:9
+#: src/olympia/amo/helpers.py:162 src/olympia/amo/templates/amo/site_nav.html:59 src/olympia/bandwagon/templates/bandwagon/add.html:9
 #: src/olympia/bandwagon/templates/bandwagon/collection_detail.html:15 src/olympia/bandwagon/templates/bandwagon/delete.html:9 src/olympia/bandwagon/templates/bandwagon/edit.html:15
 #: src/olympia/bandwagon/templates/bandwagon/user_listing.html:18 src/olympia/bandwagon/templates/bandwagon/user_listing.html:21
 #: src/olympia/bandwagon/templates/bandwagon/impala/collection_listing.html:12 src/olympia/bandwagon/templates/bandwagon/impala/collection_listing.html:20
 #: src/olympia/bandwagon/templates/bandwagon/impala/collection_listing.html:24 src/olympia/bandwagon/templates/bandwagon/impala/collection_sidebar.html:3
 #: src/olympia/bandwagon/templates/bandwagon/includes/collection_sidebar.html:2 src/olympia/bandwagon/templates/bandwagon/mobile/collection_listing.html:3
-#: src/olympia/stats/templates/stats/stats.html:77 src/olympia/templates/menu_links.html:12
+#: src/olympia/stats/templates/stats/stats.html:33 src/olympia/templates/menu_links.html:12
 msgid "Collections"
 msgstr "Collections"
 
-#: src/olympia/amo/helpers.py:171 src/olympia/amo/templates/amo/site_nav.html:85 src/olympia/browse/templates/browse/language_tools.html:3
+#: src/olympia/amo/helpers.py:171 src/olympia/amo/templates/amo/site_nav.html:83 src/olympia/browse/templates/browse/language_tools.html:3
 msgid "Dictionaries & Language Packs"
 msgstr "Dictionaries & Language Packs"
 
@@ -1610,8 +1611,8 @@ msgstr "Super review requested"
 msgid "Comment on {addon} {version}."
 msgstr "Comment on {addon} {version}."
 
-#: src/olympia/amo/log.py:236 src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:19 src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:47
-#: src/olympia/editors/helpers.py:511 src/olympia/editors/templates/editors/themes/history_table.html:11
+#: src/olympia/amo/log.py:236 src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:17 src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:45
+#: src/olympia/editors/helpers.py:584 src/olympia/editors/templates/editors/themes/history_table.html:11
 msgid "Comment"
 msgstr "Comment"
 
@@ -1940,7 +1941,7 @@ msgstr "Prev"
 #: src/olympia/amo/templates/amo/mobile/paginator.html:14 src/olympia/amo/templates/amo/mobile/paginator.html:16 src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:51
 #: src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:65 src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:78
 #: src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:91 src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:104
-#: src/olympia/discovery/templates/discovery/pane.html:45 src/olympia/discovery/templates/discovery/addons/detail.html:39 src/olympia/stats/templates/stats/stats.html:167
+#: src/olympia/discovery/templates/discovery/pane.html:45 src/olympia/discovery/templates/discovery/addons/detail.html:39 src/olympia/stats/templates/stats/stats.html:169
 msgid "Next"
 msgstr "Next"
 
@@ -1974,7 +1975,7 @@ msgstr ""
 "different words</a> or <a href=\"#\" id=\"recaptcha_audio\">try a different type of challenge</a> instead. </p>"
 
 #: src/olympia/amo/templates/amo/side_nav.html:4 src/olympia/amo/templates/amo/side_nav.html:12 src/olympia/amo/templates/amo/site_nav.html:4 src/olympia/amo/templates/amo/site_nav.html:26
-#: src/olympia/browse/views.py:56 src/olympia/browse/views.py:66 src/olympia/browse/views.py:237 src/olympia/browse/views.py:282 src/olympia/search/forms.py:86
+#: src/olympia/browse/views.py:56 src/olympia/browse/views.py:66 src/olympia/browse/views.py:204 src/olympia/browse/views.py:249 src/olympia/search/forms.py:86
 msgid "Top Rated"
 msgstr "Top Rated"
 
@@ -1989,38 +1990,38 @@ msgstr "Explore"
 msgid "Extensions"
 msgstr "Extensions"
 
-#: src/olympia/amo/templates/amo/site_nav.html:45
+#: src/olympia/amo/templates/amo/site_nav.html:44
 msgid "Want more customization? Try <b>Complete Themes</b>"
 msgstr "Want more customization? Try <b>Complete Themes</b>"
 
-#: src/olympia/amo/templates/amo/site_nav.html:56 src/olympia/bandwagon/views.py:96
+#: src/olympia/amo/templates/amo/site_nav.html:54 src/olympia/bandwagon/views.py:96
 msgid "Most Followers"
 msgstr "Most Followers"
 
-#: src/olympia/amo/templates/amo/site_nav.html:68 src/olympia/bandwagon/templates/bandwagon/impala/collection_sidebar.html:16
+#: src/olympia/amo/templates/amo/site_nav.html:66 src/olympia/bandwagon/templates/bandwagon/impala/collection_sidebar.html:16
 #: src/olympia/bandwagon/templates/bandwagon/includes/collection_sidebar.html:18
 msgid "Collections I've Made"
 msgstr "Collections I've Made"
 
-#: src/olympia/amo/templates/amo/site_nav.html:70 src/olympia/bandwagon/templates/bandwagon/user_listing.html:4 src/olympia/bandwagon/templates/bandwagon/impala/collection_sidebar.html:13
+#: src/olympia/amo/templates/amo/site_nav.html:68 src/olympia/bandwagon/templates/bandwagon/user_listing.html:4 src/olympia/bandwagon/templates/bandwagon/impala/collection_sidebar.html:13
 #: src/olympia/bandwagon/templates/bandwagon/includes/collection_sidebar.html:15
 msgid "Collections I'm Following"
 msgstr "Collections I'm Following"
 
-#: src/olympia/amo/templates/amo/site_nav.html:73 src/olympia/bandwagon/templates/bandwagon/impala/collection_sidebar.html:18
-#: src/olympia/bandwagon/templates/bandwagon/includes/collection_sidebar.html:20 src/olympia/users/models.py:512
+#: src/olympia/amo/templates/amo/site_nav.html:71 src/olympia/bandwagon/templates/bandwagon/impala/collection_sidebar.html:18
+#: src/olympia/bandwagon/templates/bandwagon/includes/collection_sidebar.html:20 src/olympia/users/models.py:521
 msgid "My Favorite Add-ons"
 msgstr "My Favorite Add-ons"
 
-#: src/olympia/amo/templates/amo/site_nav.html:78
+#: src/olympia/amo/templates/amo/site_nav.html:76
 msgid "More&hellip;"
 msgstr "More&hellip;"
 
-#: src/olympia/amo/templates/amo/site_nav.html:82
+#: src/olympia/amo/templates/amo/site_nav.html:80
 msgid "Add-ons for Mobile"
 msgstr "Add-ons for Mobile"
 
-#: src/olympia/amo/templates/amo/site_nav.html:86 src/olympia/browse/feeds.py:207 src/olympia/browse/templates/browse/search_tools.html:3 src/olympia/constants/base.py:176
+#: src/olympia/amo/templates/amo/site_nav.html:84 src/olympia/browse/feeds.py:207 src/olympia/browse/templates/browse/search_tools.html:3 src/olympia/constants/base.py:176
 #: src/olympia/templates/menu_links.html:10
 msgid "Search Tools"
 msgstr "Search Tools"
@@ -2036,7 +2037,7 @@ msgid "Jump to first page"
 msgstr "Jump to first page"
 
 #: src/olympia/amo/templates/amo/impala/paginator.html:22 src/olympia/amo/templates/amo/mobile/impala_paginator.html:12 src/olympia/discovery/templates/discovery/pane.html:44
-#: src/olympia/discovery/templates/discovery/addons/detail.html:38 src/olympia/stats/templates/stats/stats.html:164
+#: src/olympia/discovery/templates/discovery/addons/detail.html:38 src/olympia/stats/templates/stats/stats.html:166
 msgid "Previous"
 msgstr "Previous"
 
@@ -2059,31 +2060,50 @@ msgid_plural "Page {n}"
 msgstr[0] "Page {n}"
 msgstr[1] "Page {n}"
 
-#: src/olympia/amo/templates/services/install.html:38
-#, python-format
-msgid "If you are not prompted to install %(addon_name)s in a moment, please <a href=\"%(addon_xpi)s\">click here</a>."
-msgstr "If you are not prompted to install %(addon_name)s in a moment, please <a href=\"%(addon_xpi)s\">click here</a>."
-
-#: src/olympia/amo/tests/test_messages.py:57 src/olympia/amo/tests/test_messages.py:58 src/olympia/reviews/forms.py:25 src/olympia/reviews/forms.py:50 src/olympia/reviews/templates/reviews/add.html:56
+#: src/olympia/amo/tests/test_messages.py:56 src/olympia/amo/tests/test_messages.py:57 src/olympia/reviews/forms.py:25 src/olympia/reviews/forms.py:50 src/olympia/reviews/templates/reviews/add.html:56
 #: src/olympia/reviews/templates/reviews/reply.html:30
 msgid "Title"
 msgstr "Title"
 
-#: src/olympia/amo/tests/test_messages.py:57 src/olympia/amo/tests/test_messages.py:58
+#: src/olympia/amo/tests/test_messages.py:56 src/olympia/amo/tests/test_messages.py:57
 msgid "Body"
 msgstr "Body"
 
-#: src/olympia/amo/tests/test_messages.py:59
+#: src/olympia/amo/tests/test_messages.py:58
 msgid "Another Title"
 msgstr "Another Title"
 
-#: src/olympia/amo/tests/test_messages.py:59
+#: src/olympia/amo/tests/test_messages.py:58
 msgid "Another Body"
 msgstr "Another Body"
 
-#: src/olympia/api/views.py:255
-msgid "Not implemented yet."
-msgstr "Not implemented yet."
+#: src/olympia/api/authentication.py:76
+msgid "Signature has expired."
+msgstr "Signature has expired."
+
+#: src/olympia/api/authentication.py:79
+msgid "Error decoding signature."
+msgstr "Error decoding signature."
+
+#: src/olympia/api/authentication.py:82
+msgid "Invalid JWT Token."
+msgstr "Invalid JWT Token."
+
+#: src/olympia/api/authentication.py:130
+msgid "Invalid Authorization header. No credentials provided."
+msgstr "Invalid Authorization header. No credentials provided."
+
+#: src/olympia/api/authentication.py:133
+msgid "Invalid Authorization header. Credentials string should not contain spaces."
+msgstr "Invalid Authorization header. Credentials string should not contain spaces."
+
+#: src/olympia/api/fields.py:29
+msgid "The field must have a length of at least {num} characters."
+msgstr "The field must have a length of at least {num} characters."
+
+#: src/olympia/api/fields.py:31
+msgid "The language code {lang_code} is invalid."
+msgstr "The language code {lang_code} is invalid."
 
 #: src/olympia/applications/views.py:39 src/olympia/applications/templates/applications/appversions.html:3
 msgid "Application Versions"
@@ -2101,7 +2121,7 @@ msgstr "Valid Application Versions"
 msgid "Add-ons submitted to Mozilla Add-ons must have a manifest file with at least one of the below applications supported. Only the versions listed below are allowed for these applications."
 msgstr "Add-ons submitted to Mozilla Add-ons must have a manifest file with at least one of the below applications supported. Only the versions listed below are allowed for these applications."
 
-#: src/olympia/applications/templates/applications/appversions.html:25
+#: src/olympia/applications/templates/applications/appversions.html:25 src/olympia/editors/helpers.py:361
 msgid "GUID"
 msgstr "GUID"
 
@@ -2215,8 +2235,8 @@ msgstr "Favorite"
 msgid "Remove from favorites"
 msgstr "Remove from favorites"
 
-#: src/olympia/bandwagon/views.py:98 src/olympia/bandwagon/views.py:191 src/olympia/browse/views.py:58 src/olympia/browse/views.py:69 src/olympia/browse/views.py:458 src/olympia/devhub/views.py:74
-#: src/olympia/devhub/views.py:82 src/olympia/devhub/templates/devhub/addons/edit/basic.html:20 src/olympia/editors/templates/editors/leaderboard.html:24
+#: src/olympia/bandwagon/views.py:98 src/olympia/bandwagon/views.py:191 src/olympia/browse/views.py:58 src/olympia/browse/views.py:69 src/olympia/browse/views.py:425 src/olympia/devhub/views.py:72
+#: src/olympia/devhub/views.py:80 src/olympia/devhub/templates/devhub/addons/edit/basic.html:20 src/olympia/editors/templates/editors/leaderboard.html:24
 #: src/olympia/editors/templates/editors/themes/queue_list.html:48 src/olympia/search/forms.py:17 src/olympia/search/forms.py:89 src/olympia/users/templates/users/vcard.html:5
 msgid "Name"
 msgstr "Name"
@@ -2225,7 +2245,7 @@ msgstr "Name"
 msgid "Recently Popular"
 msgstr "Recently Popular"
 
-#: src/olympia/bandwagon/views.py:189 src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:18
+#: src/olympia/bandwagon/views.py:189 src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:16
 msgid "Added"
 msgstr "Added"
 
@@ -2239,8 +2259,8 @@ msgstr "Collection created!"
 
 #: src/olympia/bandwagon/views.py:316
 #, python-format
-msgid "Your new collection is shown below. You can <ahref=\"%(url)s\">edit additional settings</a> if you'dlike."
-msgstr "Your new collection is shown below. You can <ahref=\"%(url)s\">edit additional settings</a> if you'dlike."
+msgid "Your new collection is shown below. You can <a href=\"%(url)s\">edit additional settings</a> if you'd like."
+msgstr "Your new collection is shown below. You can <a href=\"%(url)s\">edit additional settings</a> if you'd like."
 
 #: src/olympia/bandwagon/views.py:322
 msgid "Collection updated!"
@@ -2367,8 +2387,8 @@ msgid_plural "%(num)s Add-ons in this Collection"
 msgstr[0] "%(num)s Add-on in this Collection"
 msgstr[1] "%(num)s Add-ons in this Collection"
 
-#: src/olympia/bandwagon/templates/bandwagon/collection_detail.html:125 src/olympia/compat/templates/compat/index.html:25 src/olympia/compat/templates/compat/reporter_detail.html:29
-#: src/olympia/files/templates/files/viewer.html:29 src/olympia/templates/amo_footer.html:17 src/olympia/templates/includes/lang_switcher.html:10
+#: src/olympia/bandwagon/templates/bandwagon/collection_detail.html:125 src/olympia/compat/templates/compat/reporter_detail.html:29 src/olympia/files/templates/files/viewer.html:29
+#: src/olympia/templates/amo_footer.html:17 src/olympia/templates/includes/lang_switcher.html:10
 msgid "Go"
 msgstr "Go"
 
@@ -2540,7 +2560,7 @@ msgid "Remove this user as a contributor"
 msgstr "Remove this user as a contributor"
 
 #: src/olympia/bandwagon/templates/bandwagon/edit_contributors.html:18 src/olympia/bandwagon/templates/bandwagon/edit_contributors.html:43
-#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:20 src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:48
+#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:18 src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:46
 #: src/olympia/devhub/templates/devhub/addons/ajax_compat_update.html:19
 msgid "Remove"
 msgstr "Remove"
@@ -2591,7 +2611,7 @@ msgid "<b>Warning:</b> By changing the owner of this collection, you will no lon
 msgstr "<b>Warning:</b> By changing the owner of this collection, you will no longer be able to edit it. You will only be able to add and remove add-ons from it."
 
 #: src/olympia/bandwagon/templates/bandwagon/edit_contributors.html:83 src/olympia/devhub/templates/devhub/addons/forms_shared/media.html:157
-#: src/olympia/devhub/templates/devhub/addons/submit/describe.html:69 src/olympia/devhub/templates/devhub/addons/submit/license.html:60 src/olympia/devhub/templates/devhub/addons/submit/upload.html:78
+#: src/olympia/devhub/templates/devhub/addons/submit/describe.html:69 src/olympia/devhub/templates/devhub/addons/submit/license.html:60 src/olympia/devhub/templates/devhub/addons/submit/upload.html:70
 #: src/olympia/devhub/templates/devhub/payments/tier.html:17 src/olympia/editors/templates/editors/themes/themes.html:111 src/olympia/editors/templates/editors/themes/themes.html:128
 #: src/olympia/editors/templates/editors/themes/themes.html:134 src/olympia/editors/templates/editors/themes/themes.html:141 src/olympia/users/templates/users/fxa_migration_prompt_content.html:10
 #: src/olympia/users/templates/users/login_form.html:42 src/olympia/users/templates/users/mobile/login.html:57
@@ -2674,32 +2694,31 @@ msgid "Add-ons in Your Collection"
 msgstr "Add-ons in Your Collection"
 
 #: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:4
-msgid ""
-"To include an add-on in this collection, enter its name in the box below and hit enter.  You can also use the <strong>Add to Collection</strong> links throughout the site to include add-ons later."
-msgstr ""
-"To include an add-on in this collection, enter its name in the box below and hit enter.  You can also use the <strong>Add to Collection</strong> links throughout the site to include add-ons later."
+msgid "To include an add-on in this collection, enter its name in the box below and hit enter."
+msgstr "To include an add-on in this collection, enter its name in the box below and hit enter."
 
-#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:17 src/olympia/constants/base.py:400 src/olympia/devhub/templates/devhub/addons/activity.html:62
+#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:15 src/olympia/constants/base.py:400 src/olympia/devhub/templates/devhub/addons/activity.html:62
+#: src/olympia/editors/helpers.py:273 src/olympia/editors/helpers.py:360
 msgid "Add-on"
 msgstr "Add-on"
 
-#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:26
+#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:24
 msgid "Enter the name of the add-on to include"
 msgstr "Enter the name of the add-on to include"
 
-#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:28
+#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:26
 msgid "Add to Collection"
 msgstr "Add to Collection"
 
-#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:45 src/olympia/editors/helpers.py:936 src/olympia/editors/helpers.py:956
+#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:43 src/olympia/editors/helpers.py:1016 src/olympia/editors/helpers.py:1036
 msgid "Pending"
 msgstr "Pending"
 
-#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:47
+#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:45
 msgid "Add a comment"
 msgstr "Add a comment"
 
-#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:48
+#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:46
 msgid "Remove this add-on from the collection"
 msgstr "Remove this add-on from the collection"
 
@@ -2808,12 +2827,12 @@ msgstr "Search tools"
 msgid "Most Users"
 msgstr "Most Users"
 
-#: src/olympia/browse/views.py:61 src/olympia/browse/views.py:72 src/olympia/browse/views.py:279 src/olympia/browse/templates/browse/personas/mobile/category_landing.html:63
+#: src/olympia/browse/views.py:61 src/olympia/browse/views.py:72 src/olympia/browse/views.py:246 src/olympia/browse/templates/browse/personas/mobile/category_landing.html:63
 #: src/olympia/discovery/templates/discovery/pane.html:67 src/olympia/search/forms.py:92
 msgid "Up & Coming"
 msgstr "Up & Coming"
 
-#: src/olympia/browse/views.py:460 src/olympia/devhub/views.py:76 src/olympia/devhub/views.py:83 src/olympia/discovery/templates/discovery/addons/detail.html:66
+#: src/olympia/browse/views.py:427 src/olympia/devhub/views.py:74 src/olympia/devhub/views.py:81 src/olympia/discovery/templates/discovery/addons/detail.html:66
 msgid "Created"
 msgstr "Created"
 
@@ -3001,8 +3020,8 @@ msgid_plural "See all %(cnt)s extensions in %(name)s &raquo;"
 msgstr[0] "See the %(cnt)s extension in %(name)s &raquo;"
 msgstr[1] "See all %(cnt)s extensions in %(name)s &raquo;"
 
-#: src/olympia/browse/templates/browse/mobile/extensions.html:13 src/olympia/compat/templates/compat/index.html:82 src/olympia/devhub/templates/devhub/devhub_search.html:24
-#: src/olympia/devhub/templates/devhub/addons/activity.html:47 src/olympia/search/templates/search/no_results.html:4 src/olympia/search/templates/search/mobile/results.html:36
+#: src/olympia/browse/templates/browse/mobile/extensions.html:13 src/olympia/devhub/templates/devhub/devhub_search.html:24 src/olympia/devhub/templates/devhub/addons/activity.html:47
+#: src/olympia/search/templates/search/no_results.html:4 src/olympia/search/templates/search/mobile/results.html:36
 msgid "No results found."
 msgstr "No results found."
 
@@ -3087,7 +3106,7 @@ msgstr "&laquo; All Themes"
 msgid "All"
 msgstr "All"
 
-#: src/olympia/compat/forms.py:22 src/olympia/search/views.py:525
+#: src/olympia/compat/forms.py:22 src/olympia/editors/templates/editors/base.html:69 src/olympia/search/views.py:518
 msgid "All Add-ons"
 msgstr "All Add-ons"
 
@@ -3098,53 +3117,6 @@ msgstr "Binary"
 #: src/olympia/compat/forms.py:24
 msgid "Non-binary"
 msgstr "Non-binary"
-
-#. Review points sources other than add-ons and themes.
-#: src/olympia/compat/views.py:87 src/olympia/constants/base.py:388 src/olympia/devhub/forms.py:162 src/olympia/editors/templates/editors/performance.html:75
-msgid "Other"
-msgstr "Other"
-
-#: src/olympia/compat/templates/compat/index.html:4
-msgid "Add-on Compatibility Report for {app} {version}"
-msgstr "Add-on Compatibility Report for {app} {version}"
-
-#: src/olympia/compat/templates/compat/index.html:11
-msgid "{app} {version} Compatibility"
-msgstr "{app} {version} Compatibility"
-
-#: src/olympia/compat/templates/compat/index.html:17
-#, python-format
-msgid "Top 95%% compatible with previous version"
-msgstr "Top 95%% compatible with previous version"
-
-#: src/olympia/compat/templates/compat/index.html:18
-#, python-format
-msgid "Top 95%% of all add-ons"
-msgstr "Top 95%% of all add-ons"
-
-#: src/olympia/compat/templates/compat/index.html:19
-msgid "All active add-ons"
-msgstr "All active add-ons"
-
-#: src/olympia/compat/templates/compat/index.html:23 src/olympia/constants/base.py:401
-msgid "App"
-msgstr "App"
-
-#: src/olympia/compat/templates/compat/index.html:55
-msgid "Details for add-ons compatible with previous version:"
-msgstr "Details for add-ons compatible with previous version:"
-
-#: src/olympia/compat/templates/compat/index.html:57
-msgid "Show all versions"
-msgstr "Show all versions"
-
-#: src/olympia/compat/templates/compat/index.html:59
-msgid "Details for add-ons compatible with all versions:"
-msgstr "Details for add-ons compatible with all versions:"
-
-#: src/olympia/compat/templates/compat/index.html:61
-msgid "Show previous version only"
-msgstr "Show previous version only"
 
 #: src/olympia/compat/templates/compat/reporter.html:3
 msgid "Add-on Compatibility Reports"
@@ -3199,8 +3171,8 @@ msgstr "Filter by Application"
 msgid "Report Type"
 msgstr "Report Type"
 
-#: src/olympia/compat/templates/compat/reporter_detail.html:47 src/olympia/devhub/forms.py:784 src/olympia/devhub/templates/devhub/addons/ajax_compat_update.html:17 src/olympia/editors/forms.py:108
-#: src/olympia/zadmin/forms.py:45
+#: src/olympia/compat/templates/compat/reporter_detail.html:47 src/olympia/devhub/forms.py:785 src/olympia/devhub/templates/devhub/addons/ajax_compat_update.html:17 src/olympia/editors/forms.py:108
+#: src/olympia/editors/forms.py:248 src/olympia/zadmin/forms.py:45
 msgid "Application"
 msgstr "Application"
 
@@ -3288,7 +3260,8 @@ msgstr "Preliminarily Reviewed"
 msgid "Preliminarily Reviewed and Awaiting Full Review"
 msgstr "Preliminarily Reviewed and Awaiting Full Review"
 
-#: src/olympia/constants/base.py:33 src/olympia/editors/helpers.py:924 src/olympia/editors/templates/editors/themes/history_table.html:34
+#: src/olympia/constants/base.py:33 src/olympia/editors/forms.py:258 src/olympia/editors/helpers.py:73 src/olympia/editors/helpers.py:1004
+#: src/olympia/editors/templates/editors/themes/history_table.html:34
 msgid "Deleted"
 msgstr "Deleted"
 
@@ -3388,6 +3361,11 @@ msgstr "Ask after users start downloading this add-on"
 msgid "Ask before users can download this add-on"
 msgstr "Ask before users can download this add-on"
 
+#. Review points sources other than add-ons and themes.
+#: src/olympia/constants/base.py:388 src/olympia/devhub/forms.py:162 src/olympia/editors/templates/editors/performance.html:75
+msgid "Other"
+msgstr "Other"
+
 #: src/olympia/constants/base.py:389
 msgid "Exception"
 msgstr "Exception"
@@ -3399,6 +3377,10 @@ msgstr "Release"
 #: src/olympia/constants/base.py:391
 msgid "Change"
 msgstr "Change"
+
+#: src/olympia/constants/base.py:401
+msgid "App"
+msgstr "App"
 
 #: src/olympia/constants/base.py:402
 msgid "Persona"
@@ -3548,7 +3530,7 @@ msgstr "Flag"
 msgid "Duplicate"
 msgstr "Duplicate"
 
-#: src/olympia/constants/editors.py:17 src/olympia/editors/helpers.py:502 src/olympia/editors/templates/editors/themes/queue.html:71 src/olympia/editors/templates/editors/themes/themes.html:94
+#: src/olympia/constants/editors.py:17 src/olympia/editors/helpers.py:575 src/olympia/editors/templates/editors/themes/queue.html:71 src/olympia/editors/templates/editors/themes/themes.html:94
 msgid "Reject"
 msgstr "Reject"
 
@@ -3648,7 +3630,7 @@ msgstr "Solaris"
 msgid "Android"
 msgstr "Android"
 
-#: src/olympia/core/apps.py:19
+#: src/olympia/core/apps.py:21
 msgid "Core"
 msgstr "Core"
 
@@ -3782,8 +3764,8 @@ msgid "Submit my add-on for manual review."
 msgstr "Submit my add-on for manual review."
 
 #: src/olympia/devhub/forms.py:537
-msgid "Do not list my add-on on this site (beta)"
-msgstr "Do not list my add-on on this site (beta)"
+msgid "Do not list my add-on on this site"
+msgstr "Do not list my add-on on this site"
 
 #: src/olympia/devhub/forms.py:538
 msgid "Check this option if you intend to distribute your add-on on your own and only need it to be signed by Mozilla."
@@ -3815,46 +3797,46 @@ msgstr "A file with a version ending with a|alpha|b|beta|pre|rc and an optional 
 
 #: src/olympia/devhub/forms.py:592
 #, python-format
-msgid "Version %s already exists"
-msgstr "Version %s already exists"
+msgid "Version %s already exists, or was uploaded before."
+msgstr "Version %s already exists, or was uploaded before."
 
-#: src/olympia/devhub/forms.py:604
+#: src/olympia/devhub/forms.py:605
 msgid "Select a valid choice. That choice is not one of the available choices."
 msgstr "Select a valid choice. That choice is not one of the available choices."
 
-#: src/olympia/devhub/forms.py:610
+#: src/olympia/devhub/forms.py:611
 msgid "A file with a version ending with a|alpha|b|beta and an optional number is detected as beta."
 msgstr "A file with a version ending with a|alpha|b|beta and an optional number is detected as beta."
 
-#: src/olympia/devhub/forms.py:633
+#: src/olympia/devhub/forms.py:634
 msgid "You cannot upload any more files for this version."
 msgstr "You cannot upload any more files for this version."
 
-#: src/olympia/devhub/forms.py:639
+#: src/olympia/devhub/forms.py:640
 msgid "Version doesn't match"
 msgstr "Version doesn't match"
 
-#: src/olympia/devhub/forms.py:668
+#: src/olympia/devhub/forms.py:669
 msgid "You cannot delete a file once the review process has started.  You must delete the whole version."
 msgstr "You cannot delete a file once the review process has started.  You must delete the whole version."
 
-#: src/olympia/devhub/forms.py:688
+#: src/olympia/devhub/forms.py:689
 msgid "The platform All cannot be combined with specific platforms."
 msgstr "The platform All cannot be combined with specific platforms."
 
-#: src/olympia/devhub/forms.py:693
+#: src/olympia/devhub/forms.py:694
 msgid "A platform can only be chosen once."
 msgstr "A platform can only be chosen once."
 
-#: src/olympia/devhub/forms.py:706
+#: src/olympia/devhub/forms.py:707
 msgid "A review type must be selected."
 msgstr "A review type must be selected."
 
-#: src/olympia/devhub/forms.py:788 src/olympia/editors/forms.py:114 src/olympia/zadmin/forms.py:49 src/olympia/zadmin/forms.py:52
+#: src/olympia/devhub/forms.py:789 src/olympia/editors/forms.py:114 src/olympia/editors/forms.py:254 src/olympia/zadmin/forms.py:49 src/olympia/zadmin/forms.py:52
 msgid "Select an application first"
 msgstr "Select an application first"
 
-#: src/olympia/devhub/forms.py:840
+#: src/olympia/devhub/forms.py:841
 msgid "There cannot be more than 3 required add-ons."
 msgstr "There cannot be more than 3 required add-ons."
 
@@ -3890,76 +3872,76 @@ msgstr[1] "{0} warnings"
 msgid "Review"
 msgstr "Review"
 
-#: src/olympia/devhub/tasks.py:551
+#: src/olympia/devhub/tasks.py:583
 #, python-format
 msgid "%s responded with %s (%s)."
 msgstr "%s responded with %s (%s)."
 
-#: src/olympia/devhub/tasks.py:555
+#: src/olympia/devhub/tasks.py:587
 #, python-format
 msgid "Connection to \"%s\" timed out."
 msgstr "Connection to \"%s\" timed out."
 
-#: src/olympia/devhub/tasks.py:557
+#: src/olympia/devhub/tasks.py:589
 #, python-format
 msgid "Could not contact host at \"%s\"."
 msgstr "Could not contact host at \"%s\"."
 
-#: src/olympia/devhub/utils.py:104
+#: src/olympia/devhub/utils.py:105
 #, python-format
 msgid "Validation generated too many errors/warnings so %s messages were truncated. After addressing the visible messages, you'll be able to see the others."
 msgstr "Validation generated too many errors/warnings so %s messages were truncated. After addressing the visible messages, you'll be able to see the others."
 
-#: src/olympia/devhub/views.py:183
+#: src/olympia/devhub/views.py:181
 msgid "All My Add-ons"
 msgstr "All My Add-ons"
 
-#: src/olympia/devhub/views.py:210
+#: src/olympia/devhub/views.py:208
 msgid "All Activity"
 msgstr "All Activity"
 
-#: src/olympia/devhub/views.py:211
+#: src/olympia/devhub/views.py:209
 msgid "Add-on Updates"
 msgstr "Add-on Updates"
 
-#: src/olympia/devhub/views.py:212
+#: src/olympia/devhub/views.py:210
 msgid "Add-on Status"
 msgstr "Add-on Status"
 
-#: src/olympia/devhub/views.py:213
+#: src/olympia/devhub/views.py:211
 msgid "User Collections"
 msgstr "User Collections"
 
-#: src/olympia/devhub/views.py:214 src/olympia/devhub/templates/devhub/docs/policies-maintenance.html:68 src/olympia/pages/templates/pages/dev_faq.html:38
+#: src/olympia/devhub/views.py:212 src/olympia/devhub/templates/devhub/docs/policies-maintenance.html:68 src/olympia/pages/templates/pages/dev_faq.html:38
 #: src/olympia/pages/templates/pages/dev_faq.html:484
 msgid "User Reviews"
 msgstr "User Reviews"
 
-#: src/olympia/devhub/views.py:327 src/olympia/devhub/views.py:331 src/olympia/devhub/views.py:484 src/olympia/devhub/views.py:513 src/olympia/devhub/views.py:564 src/olympia/devhub/views.py:1150
+#: src/olympia/devhub/views.py:325 src/olympia/devhub/views.py:329 src/olympia/devhub/views.py:484 src/olympia/devhub/views.py:513 src/olympia/devhub/views.py:564 src/olympia/devhub/views.py:1156
 msgid "Changes successfully saved."
 msgstr "Changes successfully saved."
 
-#: src/olympia/devhub/views.py:334 src/olympia/devhub/views.py:1631
+#: src/olympia/devhub/views.py:332 src/olympia/devhub/views.py:1637
 msgid "Please check the form for errors."
 msgstr "Please check the form for errors."
 
-#: src/olympia/devhub/views.py:346
+#: src/olympia/devhub/views.py:344
 msgid "Add-on cannot be deleted. Disable this add-on instead."
 msgstr "Add-on cannot be deleted. Disable this add-on instead."
 
-#: src/olympia/devhub/views.py:356
+#: src/olympia/devhub/views.py:354
 msgid "Theme deleted."
 msgstr "Theme deleted."
 
-#: src/olympia/devhub/views.py:356
+#: src/olympia/devhub/views.py:354
 msgid "Add-on deleted."
 msgstr "Add-on deleted."
 
-#: src/olympia/devhub/views.py:362
+#: src/olympia/devhub/views.py:360
 msgid "URL name was incorrect. Theme was not deleted."
 msgstr "URL name was incorrect. Theme was not deleted."
 
-#: src/olympia/devhub/views.py:367
+#: src/olympia/devhub/views.py:365
 msgid "URL name was incorrect. Add-on was not deleted."
 msgstr "URL name was incorrect. Add-on was not deleted."
 
@@ -3987,7 +3969,7 @@ msgstr "Validate Add-on"
 msgid "Check Add-on Compatibility"
 msgstr "Check Add-on Compatibility"
 
-#: src/olympia/devhub/views.py:808 src/olympia/signing/views.py:90
+#: src/olympia/devhub/views.py:808 src/olympia/signing/views.py:95
 msgid "You cannot submit this type of add-on"
 msgstr "You cannot submit this type of add-on"
 
@@ -4017,33 +3999,33 @@ msgstr "Image must be exactly {0} pixels wide and {1} pixels tall."
 msgid "There was an error uploading your preview."
 msgstr "There was an error uploading your preview."
 
-#: src/olympia/devhub/views.py:1189
+#: src/olympia/devhub/views.py:1195
 #, python-format
 msgid "Version %s disabled."
 msgstr "Version %s disabled."
 
-#: src/olympia/devhub/views.py:1193
+#: src/olympia/devhub/views.py:1199
 #, python-format
 msgid "Version %s deleted."
 msgstr "Version %s deleted."
 
-#: src/olympia/devhub/views.py:1203
+#: src/olympia/devhub/views.py:1209
 msgid "This upload has failed validation, and may lack complete validation results. Please take due care when reviewing it."
 msgstr "This upload has failed validation, and may lack complete validation results. Please take due care when reviewing it."
 
-#: src/olympia/devhub/views.py:1677
+#: src/olympia/devhub/views.py:1683
 msgid "Preliminary Review Requested."
 msgstr "Preliminary Review Requested."
 
-#: src/olympia/devhub/views.py:1678
+#: src/olympia/devhub/views.py:1684
 msgid "Full Review Requested."
 msgstr "Full Review Requested."
 
-#: src/olympia/devhub/views.py:1779
+#: src/olympia/devhub/views.py:1783
 msgid "Your old credentials were revoked and are no longer valid. Be sure to update all API clients with the new credentials."
 msgstr "Your old credentials were revoked and are no longer valid. Be sure to update all API clients with the new credentials."
 
-#: src/olympia/devhub/views.py:1797
+#: src/olympia/devhub/views.py:1801
 msgid "New API key created"
 msgstr "New API key created"
 
@@ -4073,7 +4055,7 @@ msgstr "Back to Add-ons"
 msgid "{0} :: Search"
 msgstr "{0} :: Search"
 
-#: src/olympia/devhub/templates/devhub/devhub_search.html:6 src/olympia/devhub/templates/devhub/search.html:8 src/olympia/editors/forms.py:435 src/olympia/editors/forms.py:437
+#: src/olympia/devhub/templates/devhub/devhub_search.html:6 src/olympia/devhub/templates/devhub/search.html:8 src/olympia/editors/forms.py:534 src/olympia/editors/forms.py:536
 #: src/olympia/editors/templates/editors/queue.html:27 src/olympia/editors/templates/editors/themes/queue_list.html:14 src/olympia/search/templates/search/collections.html:17
 #: src/olympia/search/templates/search/personas.html:18 src/olympia/search/templates/search/results.html:18 src/olympia/search/templates/search/mobile/results.html:8
 #: src/olympia/templates/search.html:14 src/olympia/templates/impala/search.html:18
@@ -4136,12 +4118,12 @@ msgstr "Head over to the <a href=\"https://developer.mozilla.org/Add-ons\">Mozil
 msgid "Start Making Add-ons"
 msgstr "Start Making Add-ons"
 
-#: src/olympia/devhub/templates/devhub/index.html:86 src/olympia/devhub/templates/devhub/addons/listing/items.html:25 src/olympia/devhub/templates/devhub/includes/addon_details.html:15
+#: src/olympia/devhub/templates/devhub/index.html:86 src/olympia/devhub/templates/devhub/addons/listing/items.html:25 src/olympia/devhub/templates/devhub/includes/addon_details.html:20
 #: src/olympia/devhub/templates/devhub/personas/edit.html:43
 msgid "Status:"
 msgstr "Status:"
 
-#: src/olympia/devhub/templates/devhub/index.html:90 src/olympia/devhub/templates/devhub/includes/addon_details.html:100
+#: src/olympia/devhub/templates/devhub/index.html:90 src/olympia/devhub/templates/devhub/includes/addon_details.html:87
 msgid "Visibility:"
 msgstr "Visibility:"
 
@@ -4149,11 +4131,11 @@ msgstr "Visibility:"
 msgid "Latest Version:"
 msgstr "Latest Version:"
 
-#: src/olympia/devhub/templates/devhub/index.html:109 src/olympia/devhub/templates/devhub/includes/addon_details.html:145 src/olympia/devhub/templates/devhub/personas/edit.html:49
+#: src/olympia/devhub/templates/devhub/index.html:109 src/olympia/devhub/templates/devhub/includes/addon_details.html:131 src/olympia/devhub/templates/devhub/personas/edit.html:49
 msgid "Queue Position:"
 msgstr "Queue Position:"
 
-#: src/olympia/devhub/templates/devhub/index.html:110 src/olympia/devhub/templates/devhub/includes/addon_details.html:146 src/olympia/devhub/templates/devhub/personas/edit.html:50
+#: src/olympia/devhub/templates/devhub/index.html:110 src/olympia/devhub/templates/devhub/includes/addon_details.html:132 src/olympia/devhub/templates/devhub/personas/edit.html:50
 #, python-format
 msgid "%(position)s of %(total)s"
 msgstr "%(position)s of %(total)s"
@@ -4255,16 +4237,6 @@ msgstr "After upload, a series of automated validation tests will be run on your
 msgid "Do you want your add-on to be distributed on this site?"
 msgstr "Do you want your add-on to be distributed on this site?"
 
-#: src/olympia/devhub/templates/devhub/validate_addon.html:49 src/olympia/devhub/templates/devhub/addons/submit/upload.html:30 src/olympia/devhub/templates/devhub/versions/add_file_modal.html:14
-#: src/olympia/devhub/templates/devhub/versions/add_file_modal.html:53 src/olympia/devhub/templates/devhub/versions/list.html:298
-msgid "Warning:"
-msgstr "Warning:"
-
-#: src/olympia/devhub/templates/devhub/validate_addon.html:50 src/olympia/devhub/templates/devhub/addons/submit/upload.html:31
-#, python-format
-msgid "Submission of unlisted add-ons for signing is currently in an open beta. Please <a href=\"%(url)s\" target=\"_blank\">report any bugs</a> that you encounter."
-msgstr "Submission of unlisted add-ons for signing is currently in an open beta. Please <a href=\"%(url)s\" target=\"_blank\">report any bugs</a> that you encounter."
-
 #. first parameter is a filename like lorem-ipsum-1.0.2.xpi
 #: src/olympia/devhub/templates/devhub/validation.html:5
 msgid "Validation Results for {0}"
@@ -4343,7 +4315,7 @@ msgstr "Compatibility"
 msgid "Update Compatibility"
 msgstr "Update Compatibility"
 
-#: src/olympia/devhub/templates/devhub/addons/ajax_compat_update.html:4
+#: src/olympia/devhub/templates/devhub/addons/ajax_compat_update.html:4 src/olympia/devhub/templates/devhub/versions/edit.html:45
 msgid "Adjusting application information here will allow users to install your add-on even if the install manifest in the package indicates that the add-on is incompatible."
 msgstr "Adjusting application information here will allow users to install your add-on even if the install manifest in the package indicates that the add-on is incompatible."
 
@@ -4355,9 +4327,9 @@ msgstr "Supported Versions"
 msgid "Add Another Application&hellip;"
 msgstr "Add Another Application&hellip;"
 
-#: src/olympia/devhub/templates/devhub/addons/ajax_compat_update.html:38 src/olympia/devhub/templates/devhub/addons/owner.html:86 src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:46
-#: src/olympia/devhub/templates/devhub/versions/list.html:351 src/olympia/devhub/templates/devhub/versions/list.html:353 src/olympia/templates/impala/base.html:132
-#: src/olympia/templates/impala/base.html:143 src/olympia/templates/impala/base.html:161 src/olympia/templates/impala/base.html:171
+#: src/olympia/devhub/templates/devhub/addons/ajax_compat_update.html:38 src/olympia/devhub/templates/devhub/addons/owner.html:86 src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:45
+#: src/olympia/devhub/templates/devhub/versions/list.html:349 src/olympia/devhub/templates/devhub/versions/list.html:351 src/olympia/templates/impala/base.html:129
+#: src/olympia/templates/impala/base.html:140 src/olympia/templates/impala/base.html:158 src/olympia/templates/impala/base.html:168
 msgid "Close"
 msgstr "Close"
 
@@ -4391,7 +4363,7 @@ msgstr "None"
 msgid "Manage Authors & License"
 msgstr "Manage Authors & License"
 
-#: src/olympia/devhub/templates/devhub/addons/owner.html:29 src/olympia/editors/templates/editors/review.html:270
+#: src/olympia/devhub/templates/devhub/addons/owner.html:29 src/olympia/editors/helpers.py:362 src/olympia/editors/templates/editors/review.html:270
 msgid "Authors"
 msgstr "Authors"
 
@@ -4463,10 +4435,7 @@ msgstr "Summary"
 
 #: src/olympia/devhub/templates/devhub/addons/edit/basic.html:52
 msgid ""
-"A short explanation of your add-on's basic\n"
-"                          functionality that is displayed in search and browse\n"
-"                          listings, as well as at the top of your add-on's\n"
-"                          details page. It is only relevant for listed add-ons."
+"A short explanation of your add-on's basic functionality that is displayed in search and browse listings, as well as at the top of your add-on's details page. It is only relevant for listed add-ons."
 msgstr ""
 "A short explanation of your add-on's basic\n"
 "                          functionality that is displayed in search and browse\n"
@@ -4474,10 +4443,7 @@ msgstr ""
 "                          details page. It is only relevant for listed add-ons."
 
 #: src/olympia/devhub/templates/devhub/addons/edit/basic.html:73
-msgid ""
-"Categories are the primary way users browse through add-ons.\n"
-"                        Choose any that fit your add-on's functionality for the most\n"
-"                        exposure. It is only relevant for listed add-ons."
+msgid "Categories are the primary way users browse through add-ons. Choose any that fit your add-on's functionality for the most exposure. It is only relevant for listed add-ons."
 msgstr ""
 "Categories are the primary way users browse through add-ons.\n"
 "                        Choose any that fit your add-on's functionality for the most\n"
@@ -4491,11 +4457,7 @@ msgstr ""
 "Categories cannot be changed while your add-on is featured for this application. Please email <a href=\"mailto:%(email)s\">%(email)s</a> if there is a reason you need to modify your categories."
 
 #: src/olympia/devhub/templates/devhub/addons/edit/basic.html:119
-msgid ""
-"Tags help users find your add-on and should be short\n"
-"                        descriptors such as tabs, toolbar, or twitter.  You\n"
-"                        may have a maximum of {0} tags. It is only relevant\n"
-"                        for listed add-ons."
+msgid "Tags help users find your add-on and should be short descriptors such as tabs, toolbar, or twitter. You may have a maximum of {0} tags. It is only relevant for listed add-ons."
 msgstr ""
 "Tags help users find your add-on and should be short\n"
 "                        descriptors such as tabs, toolbar, or twitter.  You\n"
@@ -4527,11 +4489,7 @@ msgid "Add-on Details for {0}"
 msgstr "Add-on Details for {0}"
 
 #: src/olympia/devhub/templates/devhub/addons/edit/details.html:22
-msgid ""
-"A longer explanation of features,\n"
-"                          functionality, and other relevant information. This\n"
-"                          field is only displayed on the add-on's details\n"
-"                          page. It is only relevant for listed add-ons."
+msgid "A longer explanation of features, functionality, and other relevant information. This field is only displayed on the add-on's details page. It is only relevant for listed add-ons."
 msgstr ""
 "A longer explanation of features,\n"
 "                          functionality, and other relevant information. This\n"
@@ -4543,10 +4501,7 @@ msgid "Default Locale"
 msgstr "Default Locale"
 
 #: src/olympia/devhub/templates/devhub/addons/edit/details.html:45
-msgid ""
-"Information about your add-on is displayed in this locale\n"
-"                        unless you override it with a locale-specific translation.\n"
-"                        It is only relevant for listed add-ons."
+msgid "Information about your add-on is displayed in this locale unless you override it with a locale-specific translation. It is only relevant for listed add-ons."
 msgstr ""
 "Information about your add-on is displayed in this locale\n"
 "                        unless you override it with a locale-specific translation.\n"
@@ -4559,10 +4514,8 @@ msgstr "Homepage"
 
 #: src/olympia/devhub/templates/devhub/addons/edit/details.html:63
 msgid ""
-"If your add-on has another homepage, enter its\n"
-"                          address here. If your website is localized into other\n"
-"                          languages multiple translations of this field can be\n"
-"                          added. It is only relevant for listed add-ons."
+"If your add-on has another homepage, enter its address here. If your website is localized into other languages multiple translations of this field can be added. It is only relevant for listed add-"
+"ons."
 msgstr ""
 "If your add-on has another homepage, enter its\n"
 "                          address here. If your website is localized into other\n"
@@ -4584,11 +4537,8 @@ msgstr "Support Information for {0}"
 
 #: src/olympia/devhub/templates/devhub/addons/edit/support.html:22
 msgid ""
-"If you wish to display an e-mail address for support\n"
-"                          inquiries, enter it here. If you have different\n"
-"                          addresses for each language multiple translations of\n"
-"                          this field can be added. It is only relevant for\n"
-"                          listed add-ons."
+"If you wish to display an e-mail address for support inquiries, enter it here. If you have different addresses for each language multiple translations of this field can be added. It is only "
+"relevant for listed add-ons."
 msgstr ""
 "If you wish to display an e-mail address for support\n"
 "                          inquiries, enter it here. If you have different\n"
@@ -4598,10 +4548,8 @@ msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/support.html:45
 msgid ""
-"If your add-on has a support website or forum, enter\n"
-"                          its address here. If your website is localized into\n"
-"                          other languages, multiple translations of this field can\n"
-"                          be added. It is only relevant for listed add-ons."
+"If your add-on has a support website or forum, enter its address here. If your website is localized into other languages, multiple translations of this field can be added. It is only relevant for "
+"listed add-ons."
 msgstr ""
 "If your add-on has a support website or forum, enter\n"
 "                          its address here. If your website is localized into\n"
@@ -4619,11 +4567,8 @@ msgstr "Technical Details for {0}"
 
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:23
 msgid ""
-"Any information end users may want to know that isn't\n"
-"                          necessarily applicable to the add-on summary or description.\n"
-"                          Common uses include listing known major bugs, information on\n"
-"                          how to report bugs, anticipated release date of a new version,\n"
-"                          etc. It is only relevant for listed add-ons."
+"Any information end users may want to know that isn't necessarily applicable to the add-on summary or description. Common uses include listing known major bugs, information on how to report bugs, "
+"anticipated release date of a new version, etc. It is only relevant for listed add-ons."
 msgstr ""
 "Any information end users may want to know that isn't\n"
 "                          necessarily applicable to the add-on summary or description.\n"
@@ -4640,9 +4585,7 @@ msgid "Add-on Flags"
 msgstr "Add-on Flags"
 
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:69
-msgid ""
-"These flags are used to classify add-ons. It is only\n"
-"                        relevant for listed add-ons."
+msgid "These flags are used to classify add-ons. It is only relevant for listed add-ons."
 msgstr ""
 "These flags are used to classify add-ons. It is only\n"
 "                        relevant for listed add-ons."
@@ -4660,9 +4603,7 @@ msgid "View Source?"
 msgstr "View Source?"
 
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:90
-msgid ""
-"Whether the source of your add-on can be displayed in our\n"
-"                        online viewer. It is only relevant for listed add-ons."
+msgid "Whether the source of your add-on can be displayed in our online viewer. It is only relevant for listed add-ons."
 msgstr ""
 "Whether the source of your add-on can be displayed in our\n"
 "                        online viewer. It is only relevant for listed add-ons."
@@ -4680,10 +4621,7 @@ msgid "Public Stats?"
 msgstr "Public Stats?"
 
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:102
-msgid ""
-"Whether the download and usage stats of your add-on can\n"
-"                        be displayed in our online viewer.\n"
-"                        It is only relevant for listed add-ons."
+msgid "Whether the download and usage stats of your add-on can be displayed in our online viewer. It is only relevant for listed add-ons."
 msgstr ""
 "Whether the download and usage stats of your add-on can\n"
 "                        be displayed in our online viewer.\n"
@@ -4702,10 +4640,7 @@ msgid "Upgrade SDK?"
 msgstr "Upgrade SDK?"
 
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:116
-msgid ""
-"If selected, we will try to automatically upgrade your\n"
-"                        add-on when a new version of the SDK is released.\n"
-"                        It is only relevant for listed add-ons."
+msgid "If selected, we will try to automatically upgrade your add-on when a new version of the SDK is released. It is only relevant for listed add-ons."
 msgstr ""
 "If selected, we will try to automatically upgrade your\n"
 "                        add-on when a new version of the SDK is released.\n"
@@ -4761,10 +4696,8 @@ msgstr "Add-on icon"
 
 #: src/olympia/devhub/templates/devhub/addons/forms_shared/media.html:16
 msgid ""
-"Upload an icon for your add-on or choose from one of ours. The\n"
-"                      icon is displayed nearly everywhere your add-on is. Uploaded images\n"
-"                      must be one of the following image types: .png, .jpg.\n"
-"                      It is only relevant for listed add-ons."
+"Upload an icon for your add-on or choose from one of ours. The icon is displayed nearly everywhere your add-on is. Uploaded images must be one of the following image types: .png, .jpg. It is only "
+"relevant for listed add-ons."
 msgstr ""
 "Upload an icon for your add-on or choose from one of ours. The\n"
 "                      icon is displayed nearly everywhere your add-on is. Uploaded images\n"
@@ -4781,9 +4714,7 @@ msgid "32x32px"
 msgstr "32x32px"
 
 #: src/olympia/devhub/templates/devhub/addons/forms_shared/media.html:39
-msgid ""
-"Used in listings of add-ons, like search results\n"
-"                            and featured add-ons."
+msgid "Used in listings of add-ons, like search results and featured add-ons."
 msgstr ""
 "Used in listings of add-ons, like search results\n"
 "                            and featured add-ons."
@@ -4880,18 +4811,16 @@ msgid "Deleting your add-on will permanently remove it from the site and prevent
 msgstr "Deleting your add-on will permanently remove it from the site and prevent its GUID from being submitted again by others."
 
 #: src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:24
-msgid ""
-"Enter the following text confirm your decision:\n"
-"           {slug}"
+msgid "Enter the following text confirm your decision: {slug}"
 msgstr ""
 "Enter the following text confirm your decision:\n"
 "           {slug}"
 
-#: src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:34
+#: src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:33
 msgid "Please tell us why you are deleting your theme:"
 msgstr "Please tell us why you are deleting your theme:"
 
-#: src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:36
+#: src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:35
 msgid "Please tell us why you are deleting your add-on:"
 msgstr "Please tell us why you are deleting your add-on:"
 
@@ -4928,8 +4857,8 @@ msgstr "New Version"
 msgid "Daily statistics on downloads and users."
 msgstr "Daily statistics on downloads and users."
 
-#: src/olympia/devhub/templates/devhub/addons/listing/item_actions.html:45 src/olympia/stats/templates/stats/stats.html:75 src/olympia/stats/templates/stats/stats.html:79
-#: src/olympia/stats/templates/stats/stats.html:81
+#: src/olympia/devhub/templates/devhub/addons/listing/item_actions.html:45 src/olympia/stats/templates/stats/stats.html:31 src/olympia/stats/templates/stats/stats.html:35
+#: src/olympia/stats/templates/stats/stats.html:37
 msgid "Statistics"
 msgstr "Statistics"
 
@@ -5048,10 +4977,7 @@ msgid "Your add-on has been submitted to the Full Review queue."
 msgstr "Your add-on has been submitted to the Full Review queue."
 
 #: src/olympia/devhub/templates/devhub/addons/submit/done.html:18
-msgid ""
-"You'll receive an email once it has been reviewed by an editor. In\n"
-"          the meantime, you and your friends can install it directly from its\n"
-"          details page:"
+msgid "You'll receive an email once it has been reviewed by an editor. In the meantime, you and your friends can install it directly from its details page:"
 msgstr ""
 "You'll receive an email once it has been reviewed by an editor. In\n"
 "          the meantime, you and your friends can install it directly from its\n"
@@ -5264,11 +5190,11 @@ msgstr "Step 2. Upload Your Add-on"
 msgid "Use the fields below to upload your add-on package and select any platform restrictions. After upload, a series of automated validation tests will be run on your file."
 msgstr "Use the fields below to upload your add-on package and select any platform restrictions. After upload, a series of automated validation tests will be run on your file."
 
-#: src/olympia/devhub/templates/devhub/addons/submit/upload.html:59 src/olympia/devhub/templates/devhub/versions/add_file_modal.html:39
+#: src/olympia/devhub/templates/devhub/addons/submit/upload.html:51 src/olympia/devhub/templates/devhub/versions/add_file_modal.html:28
 msgid "Which platforms is this file compatible with?"
 msgstr "Which platforms is this file compatible with?"
 
-#: src/olympia/devhub/templates/devhub/addons/submit/upload.html:67 src/olympia/devhub/templates/devhub/versions/add_file_modal.html:65
+#: src/olympia/devhub/templates/devhub/addons/submit/upload.html:59 src/olympia/devhub/templates/devhub/versions/add_file_modal.html:45
 msgid "Administrative overrides"
 msgstr "Administrative overrides"
 
@@ -5387,11 +5313,11 @@ msgstr "Website Functionality & Development"
 
 #: src/olympia/devhub/templates/devhub/docs/policies-contact.html:44
 msgid ""
-"If you've found a problem with the site, we'd love to fix it. Please <a href=\"https://github.com/mozilla/olympia/issues\">file a bug report</a> in GitHub, including the location of the problem and "
-"how you encountered it."
+"If you've found a problem with the site, we'd love to fix it. Please <a href=\"https://github.com/mozilla/addons/issues/new\">file a bug report</a> in GitHub, including the location of the problem "
+"and how you encountered it."
 msgstr ""
-"If you've found a problem with the site, we'd love to fix it. Please <a href=\"https://github.com/mozilla/olympia/issues\">file a bug report</a> in GitHub, including the location of the problem and "
-"how you encountered it."
+"If you've found a problem with the site, we'd love to fix it. Please <a href=\"https://github.com/mozilla/addons/issues/new\">file a bug report</a> in GitHub, including the location of the problem "
+"and how you encountered it."
 
 #: src/olympia/devhub/templates/devhub/docs/policies-maintenance.html:3 src/olympia/devhub/templates/devhub/docs/policies-maintenance.html:7
 #: src/olympia/devhub/templates/devhub/docs/policies-maintenance.html:8
@@ -6044,7 +5970,7 @@ msgstr "Private Browsing Mode"
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:282
 msgid ""
-"Add-ons that store or otherwise handle browsing data must support <a href=\"https://developer.mozilla.org/En/Supporting_private_browsing_mode\">Private Browsing Mode</a>.  During a Private Browsing "
+"Add-ons that store or otherwise handle browsing data must support <a href=\"https://developer.mozilla.org/En/Supporting_private_browsing_mode\">Private Browsing Mode</a>. During a Private Browsing "
 "session, no browsing data can be written to disk, and all of this data must be cleared when Firefox quits or the Private Browsing session ends."
 msgstr ""
 "Add-ons that store or otherwise handle browsing data must support <a href=\"https://developer.mozilla.org/En/Supporting_private_browsing_mode\">Private Browsing Mode</a>.  During a Private Browsing "
@@ -6255,165 +6181,128 @@ msgstr "Terms of Service for submitting your work to our site. Developers are re
 msgid "How to get in touch with us regarding these policies or your add-on."
 msgstr "How to get in touch with us regarding these policies or your add-on."
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:6
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:10
 msgid "You have disabled this add-on"
 msgstr "You have disabled this add-on"
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:20
-msgid ""
-"Your add-on's listing is disabled and is not showing\n"
-"                             anywhere in our gallery or update service."
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:24
+msgid "Your add-on's listing is disabled and is not showing anywhere in our gallery or update service."
 msgstr ""
 "Your add-on's listing is disabled and is not showing\n"
 "                             anywhere in our gallery or update service."
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:25
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:27
 msgid "Please complete your add-on."
 msgstr "Please complete your add-on."
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:29
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:30
 msgid "You will receive an email when the review is complete."
 msgstr "You will receive an email when the review is complete."
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:34
-msgid ""
-"You will receive an email when the review is complete. Until\n"
-"                             then, your add-on is not listed in our gallery but can be\n"
-"                             accessed directly from its details page."
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:33
+msgid "You will receive an email when the review is complete. Until then, your add-on is not listed in our gallery but can be accessed directly from its details page."
 msgstr ""
 "You will receive an email when the review is complete. Until\n"
 "                             then, your add-on is not listed in our gallery but can be\n"
 "                             accessed directly from its details page."
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:38 src/olympia/devhub/templates/devhub/includes/addon_details.html:48
-msgid ""
-"You will receive an email when the review is\n"
-"                             complete and your add-on is signed."
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:37 src/olympia/devhub/templates/devhub/includes/addon_details.html:45
+msgid "You will receive an email when the review is complete and your add-on is signed."
 msgstr ""
 "You will receive an email when the review is\n"
 "                             complete and your add-on is signed."
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:44
-msgid ""
-"You will receive an email when the review is complete. Until\n"
-"                             then, your add-on is not listed in our gallery but can be\n"
-"                             accessed directly from its details page. "
-msgstr ""
-"You will receive an email when the review is complete. Until\n"
-"                             then, your add-on is not listed in our gallery but can be\n"
-"                             accessed directly from its details page. "
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:41
+msgid "You will receive an email when the review is complete. Until then, your add-on is not listed in our gallery but can be accessed directly from its details page. "
+msgstr "You will receive an email when the review is complete. Until then, your add-on is not listed in our gallery but can be accessed directly from its details page. "
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:54
-msgid ""
-"Your add-on is displayed in our gallery and users are\n"
-"                             receiving automatic updates."
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:49
+msgid "Your add-on is displayed in our gallery and users are receiving automatic updates."
 msgstr ""
 "Your add-on is displayed in our gallery and users are\n"
 "                             receiving automatic updates."
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:57
-msgid ""
-"Your add-on has been signed and can be bundled with an\n"
-"                             application installer."
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:52
+msgid "Your add-on has been signed and can be bundled with an application installer."
 msgstr ""
 "Your add-on has been signed and can be bundled with an\n"
 "                             application installer."
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:63
-msgid ""
-"Your add-on was disabled by a site administrator and is no\n"
-"                             longer shown in our gallery. If you have any questions,\n"
-"                             please email amo-admins@mozilla.org."
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:56
+msgid "Your add-on was disabled by a site administrator and is no longer shown in our gallery. If you have any questions, please email amo-admins@mozilla.org."
 msgstr ""
 "Your add-on was disabled by a site administrator and is no\n"
 "                             longer shown in our gallery. If you have any questions,\n"
 "                             please email amo-admins@mozilla.org."
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:70
-msgid ""
-"Your add-on is displayed in our gallery as experimental\n"
-"                             and users are receiving automatic updates. Some features\n"
-"                             are unavailable to your add-on."
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:62
+msgid "Your add-on is displayed in our gallery as experimental and users are receiving automatic updates. Some features are unavailable to your add-on."
 msgstr ""
 "Your add-on is displayed in our gallery as experimental\n"
 "                             and users are receiving automatic updates. Some features\n"
 "                             are unavailable to your add-on."
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:74
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:66
 msgid "Your add-on has been signed."
 msgstr "Your add-on has been signed."
 
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:69
+msgid ""
+"You will receive an email when the full review is complete. Until then, your add-on is displayed in our gallery as experimental and users are receiving automatic updates. Some features are "
+"unavailable to your add-on."
+msgstr ""
+"You will receive an email when the full review is complete.\n"
+"                             Until then, your add-on is displayed in our gallery as\n"
+"                             experimental and users are receiving automatic updates.\n"
+"                             Some features are unavailable to your add-on."
+
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:74
+msgid "You will receive an email when the full review is complete, making you able to bundle your add-on with an application installer."
+msgstr ""
+"You will receive an email when the full review is\n"
+"                             complete, making you able to bundle your add-on with an\n"
+"                             application installer."
+
 #: src/olympia/devhub/templates/devhub/includes/addon_details.html:79
-msgid ""
-"You will receive an email when the full review is complete.\n"
-"                             Until then, your add-on is displayed in our gallery as\n"
-"                             experimental and users are receiving automatic updates.\n"
-"                             Some features are unavailable to your add-on."
-msgstr ""
-"You will receive an email when the full review is complete.\n"
-"                             Until then, your add-on is displayed in our gallery as\n"
-"                             experimental and users are receiving automatic updates.\n"
-"                             Some features are unavailable to your add-on."
-
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:84
-msgid ""
-"You will receive an email when the full review is\n"
-"                             complete, making you able to bundle your add-on with an\n"
-"                             application installer."
-msgstr ""
-"You will receive an email when the full review is\n"
-"                             complete, making you able to bundle your add-on with an\n"
-"                             application installer."
-
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:91
-msgid ""
-"All add-ons hosted in our gallery must now be reviewed by an\n"
-"                             editor. If you wish to continue hosting your add-on, please\n"
-"                             click to select a review process."
+msgid "All add-ons hosted in our gallery must now be reviewed by an editor. If you wish to continue hosting your add-on, please click to select a review process."
 msgstr ""
 "All add-ons hosted in our gallery must now be reviewed by an\n"
 "                             editor. If you wish to continue hosting your add-on, please\n"
 "                             click to select a review process."
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:113
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:100
 msgid "Current Version:"
 msgstr "Current Version:"
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:115
-msgid ""
-"This is the version of your add-on that will\n"
-"                                           be installed if someone clicks the Install\n"
-"                                           button on addons.mozilla.org. It is only\n"
-"                                           relevant for listed add-ons."
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:102
+msgid "This is the version of your add-on that will be installed if someone clicks the Install button on addons.mozilla.org. It is only relevant for listed add-ons."
 msgstr ""
 "This is the version of your add-on that will\n"
 "                                           be installed if someone clicks the Install\n"
 "                                           button on addons.mozilla.org. It is only\n"
 "                                           relevant for listed add-ons."
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:123
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:110
 msgid "Created:"
 msgstr "Created:"
 
 #. {0} is a date. dennis-ignore: E201
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:125 src/olympia/devhub/templates/devhub/includes/addon_details.html:131
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:112 src/olympia/devhub/templates/devhub/includes/addon_details.html:118
 #, python-format
 msgid "%%b %%e, %%Y"
 msgstr "%%b %%e, %%Y"
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:136
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:123
 msgid "Next Version:"
 msgstr "Next Version:"
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:138
-msgid ""
-"This is the newest uploaded version, however\n"
-"                                           it isn’t live on the site yet."
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:125
+msgid "This is the newest uploaded version, however it isn’t live on the site yet."
 msgstr ""
 "This is the newest uploaded version, however\n"
 "                                           it isn’t live on the site yet."
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:144 src/olympia/devhub/templates/devhub/versions/list.html:30
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:130 src/olympia/devhub/templates/devhub/versions/list.html:30
 msgid "Queues are not reviewed strictly in order"
 msgstr "Queues are not reviewed strictly in order"
 
@@ -6483,9 +6372,7 @@ msgid "View the blog &#9658;"
 msgstr "View the blog &#9658;"
 
 #: src/olympia/devhub/templates/devhub/includes/license_form.html:6
-msgid ""
-"Please choose a license appropriate for the rights you grant on your source code.\n"
-"                  It is only relevant for listed add-ons."
+msgid "Please choose a license appropriate for the rights you grant on your source code. It is only relevant for listed add-ons."
 msgstr ""
 "Please choose a license appropriate for the rights you grant on your source code.\n"
 "                  It is only relevant for listed add-ons."
@@ -6514,17 +6401,13 @@ msgstr[1] "Select <b>up to {0}</b> {1} categories for this add-on:"
 #: src/olympia/devhub/templates/devhub/includes/policy_form.html:4
 msgid ""
 "Users will be required to accept the following End-User License Agreement (EULA) prior to installing your add-on. The presence of a EULA significantly affects the number of downloads an add-on "
-"receives. Please note that a EULA is not the same as a code license, such as the GPL or MPL.\n"
-"                It is only relevant for listed add-ons."
+"receives. Please note that a EULA is not the same as a code license, such as the GPL or MPL.It is only relevant for listed add-ons."
 msgstr ""
 "Users will be required to accept the following End-User License Agreement (EULA) prior to installing your add-on. The presence of a EULA significantly affects the number of downloads an add-on "
-"receives. Please note that a EULA is not the same as a code license, such as the GPL or MPL.\n"
-"                It is only relevant for listed add-ons."
+"receives. Please note that a EULA is not the same as a code license, such as the GPL or MPL.It is only relevant for listed add-ons."
 
-#: src/olympia/devhub/templates/devhub/includes/policy_form.html:21
-msgid ""
-"If your add-on transmits any data from the user's computer, a privacy policy is required that explains what data is sent and how it is used.\n"
-"                It is only relevant for listed add-ons."
+#: src/olympia/devhub/templates/devhub/includes/policy_form.html:24
+msgid "If your add-on transmits any data from the user's computer, a privacy policy is required that explains what data is sent and how it is used. It is only relevant for listed add-ons."
 msgstr ""
 "If your add-on transmits any data from the user's computer, a privacy policy is required that explains what data is sent and how it is used.\n"
 "                It is only relevant for listed add-ons."
@@ -6696,12 +6579,8 @@ msgstr "Select the category that best describes your Theme."
 msgid "Add some tags to describe your Theme."
 msgstr "Add some tags to describe your Theme."
 
-#: src/olympia/devhub/templates/devhub/personas/edit.html:106
-msgid ""
-"A short explanation of your theme's\n"
-"                                basic functionality that is displayed in\n"
-"                                search and browse listings, as well as at\n"
-"                                the top of your theme's details page."
+#: src/olympia/devhub/templates/devhub/personas/edit.html:106 src/olympia/devhub/templates/devhub/personas/submit.html:54
+msgid "A short explanation of your theme's basic functionality that is displayed in search and browse listings, as well as at the top of your theme's details page."
 msgstr ""
 "A short explanation of your theme's\n"
 "                                basic functionality that is displayed in\n"
@@ -6775,7 +6654,7 @@ msgid "Upon upload and form submission, the AMO Team will review your updated de
 msgstr "Upon upload and form submission, the AMO Team will review your updated design. Your current design will still be public in the meantime."
 
 #: src/olympia/devhub/templates/devhub/personas/edit.html:241
-msgid "Your previously resubmitted design,  which is under pending review."
+msgid "Your previously resubmitted design, which is under pending review."
 msgstr "Your previously resubmitted design,  which is under pending review."
 
 #: src/olympia/devhub/templates/devhub/personas/edit.html:245
@@ -6843,18 +6722,6 @@ msgstr "Background themes let you easily personalize the look of your Firefox. S
 #: src/olympia/devhub/templates/devhub/personas/submit.html:33
 msgid "Give your Theme a name."
 msgstr "Give your Theme a name."
-
-#: src/olympia/devhub/templates/devhub/personas/submit.html:54
-msgid ""
-"A short explanation of your theme's\n"
-"                                      basic functionality that is displayed in\n"
-"                                      search and browse listings, as well as at\n"
-"                                      the top of your theme's details page."
-msgstr ""
-"A short explanation of your theme's\n"
-"                                      basic functionality that is displayed in\n"
-"                                      search and browse listings, as well as at\n"
-"                                      the top of your theme's details page."
 
 #: src/olympia/devhub/templates/devhub/personas/submit.html:198
 #, python-format
@@ -6932,35 +6799,17 @@ msgstr "Select a different footer image"
 msgid "Files added to reviewed versions must be reviewed before they will be available for download."
 msgstr "Files added to reviewed versions must be reviewed before they will be available for download."
 
-#: src/olympia/devhub/templates/devhub/versions/add_file_modal.html:15
-#, python-format
-msgid ""
-"Submission of updates to unlisted add-ons for signing is currently in an open beta. Manual review may still be required for a large number of add-ons. Please <a href=\"%(url)s\" target=\"_blank"
-"\">report any bugs</a> that you encounter."
-msgstr ""
-"Submission of updates to unlisted add-ons for signing is currently in an open beta. Manual review may still be required for a large number of add-ons. Please <a href=\"%(url)s\" target=\"_blank"
-"\">report any bugs</a> that you encounter."
-
-#: src/olympia/devhub/templates/devhub/versions/add_file_modal.html:35
+#: src/olympia/devhub/templates/devhub/versions/add_file_modal.html:24
 msgid "Select the target platform for this file."
 msgstr "Select the target platform for this file."
 
-#: src/olympia/devhub/templates/devhub/versions/add_file_modal.html:46
+#: src/olympia/devhub/templates/devhub/versions/add_file_modal.html:35
 msgid "Which review type would you like to nominate for?"
 msgstr "Which review type would you like to nominate for?"
 
-#: src/olympia/devhub/templates/devhub/versions/add_file_modal.html:51
+#: src/olympia/devhub/templates/devhub/versions/add_file_modal.html:40
 msgid "Only publish this version to my beta channel."
 msgstr "Only publish this version to my beta channel."
-
-#: src/olympia/devhub/templates/devhub/versions/add_file_modal.html:54
-#, python-format
-msgid ""
-"The behavior of the beta channel has changed to accommodate <a href=\"%(addon_signing_url)s\" target=\"_blank\">mandatory add-on signing</a>. The new process is currently in an open beta, and may "
-"change significantly in the near future. Please <a href=\"%(issues_url)s\" target=\"_blank\">report any bugs</a> that you encounter."
-msgstr ""
-"The behavior of the beta channel has changed to accommodate <a href=\"%(addon_signing_url)s\" target=\"_blank\">mandatory add-on signing</a>. The new process is currently in an open beta, and may "
-"change significantly in the near future. Please <a href=\"%(issues_url)s\" target=\"_blank\">report any bugs</a> that you encounter."
 
 #: src/olympia/devhub/templates/devhub/versions/edit.html:5
 msgid "Manage Version {0}"
@@ -6984,22 +6833,10 @@ msgstr "Files"
 msgid "Upload Another File"
 msgstr "Upload Another File"
 
-#: src/olympia/devhub/templates/devhub/versions/edit.html:45
-msgid ""
-"Adjusting application information here will allow users to install your\n"
-"                          add-on even if the install manifest in the package indicates that the\n"
-"                          add-on is incompatible."
-msgstr ""
-"Adjusting application information here will allow users to install your\n"
-"                          add-on even if the install manifest in the package indicates that the\n"
-"                          add-on is incompatible."
-
 #: src/olympia/devhub/templates/devhub/versions/edit.html:74
 msgid ""
-"Information about changes in this release, new features,\n"
-"                              known bugs, and other useful information specific to this\n"
-"                              release/version. This information is also shown in the\n"
-"                              Add-ons Manager when updating."
+"Information about changes in this release, new features, known bugs, and other useful information specific to this release/version. This information is also shown in the Add-ons Manager when "
+"updating."
 msgstr ""
 "Information about changes in this release, new features,\n"
 "                              known bugs, and other useful information specific to this\n"
@@ -7015,10 +6852,7 @@ msgid "Notes for Reviewers"
 msgstr "Notes for Reviewers"
 
 #: src/olympia/devhub/templates/devhub/versions/edit.html:114
-msgid ""
-"Optionally, enter any information that may be useful\n"
-"                              to the Editor reviewing this add-on, such as test\n"
-"                              account information."
+msgid "Optionally, enter any information that may be useful to the Editor reviewing this add-on, such as test account information."
 msgstr ""
 "Optionally, enter any information that may be useful\n"
 "                              to the Editor reviewing this add-on, such as test\n"
@@ -7099,7 +6933,7 @@ msgstr "Request Full Review"
 msgid "Request Preliminary Review"
 msgstr "Request Preliminary Review"
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:80 src/olympia/devhub/templates/devhub/versions/list.html:327 src/olympia/devhub/templates/devhub/versions/list.html:350
+#: src/olympia/devhub/templates/devhub/versions/list.html:80 src/olympia/devhub/templates/devhub/versions/list.html:325 src/olympia/devhub/templates/devhub/versions/list.html:348
 msgid "Cancel Review Request"
 msgstr "Cancel Review Request"
 
@@ -7128,8 +6962,8 @@ msgid "Unlisted:"
 msgstr "Unlisted:"
 
 #: src/olympia/devhub/templates/devhub/versions/list.html:114
-msgid "Not distributed on {0}. Developers will upload new versions for signing and distribute the add-ons on their own. (beta)"
-msgstr "Not distributed on {0}. Developers will upload new versions for signing and distribute the add-ons on their own. (beta)"
+msgid "Not distributed on {0}. Developers will upload new versions for signing and distribute the add-ons on their own."
+msgstr "Not distributed on {0}. Developers will upload new versions for signing and distribute the add-ons on their own."
 
 #: src/olympia/devhub/templates/devhub/versions/list.html:122
 msgid "Current versions"
@@ -7193,86 +7027,75 @@ msgid "<strong>Important:</strong> Once a version has been deleted, you may not 
 msgstr "<strong>Important:</strong> Once a version has been deleted, you may not upload a new version with the same version number."
 
 #: src/olympia/devhub/templates/devhub/versions/list.html:230
-msgid ""
-"Deleting a version which has already been reviewed\n"
-"               may also cause a significant delay in the review of\n"
-"               your next update."
-msgstr ""
-"Deleting a version which has already been reviewed\n"
-"               may also cause a significant delay in the review of\n"
-"               your next update."
-
-#: src/olympia/devhub/templates/devhub/versions/list.html:233
 msgid "Are you sure you wish to delete this version?"
 msgstr "Are you sure you wish to delete this version?"
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:238
+#: src/olympia/devhub/templates/devhub/versions/list.html:235
 msgid "Delete Version"
 msgstr "Delete Version"
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:240
+#: src/olympia/devhub/templates/devhub/versions/list.html:237
 msgid "Disable Version"
 msgstr "Disable Version"
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:247
+#: src/olympia/devhub/templates/devhub/versions/list.html:244
 msgid "Add a new Version"
 msgstr "Add a new Version"
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:249
+#: src/olympia/devhub/templates/devhub/versions/list.html:246
 msgid "Add Version"
 msgstr "Add Version"
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:256 src/olympia/devhub/templates/devhub/versions/list.html:274
+#: src/olympia/devhub/templates/devhub/versions/list.html:253 src/olympia/devhub/templates/devhub/versions/list.html:279
 msgid "Hide Add-on"
 msgstr "Hide Add-on"
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:259
+#: src/olympia/devhub/templates/devhub/versions/list.html:256
 msgid "Hiding your add-on will prevent it from appearing anywhere in our gallery and will stop users from receiving automatic updates."
 msgstr "Hiding your add-on will prevent it from appearing anywhere in our gallery and will stop users from receiving automatic updates."
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:265
+#: src/olympia/devhub/templates/devhub/versions/list.html:263
+msgid "The files awaiting review will be disabled and you will need to upload new versions."
+msgstr "The files awaiting review will be disabled and you will need to upload new versions."
+
+#: src/olympia/devhub/templates/devhub/versions/list.html:270
 msgid "Are you sure you wish to hide your add-on?"
 msgstr "Are you sure you wish to hide your add-on?"
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:286 src/olympia/devhub/templates/devhub/versions/list.html:315
+#: src/olympia/devhub/templates/devhub/versions/list.html:291 src/olympia/devhub/templates/devhub/versions/list.html:313
 msgid "Unlist Add-on"
 msgstr "Unlist Add-on"
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:289
+#: src/olympia/devhub/templates/devhub/versions/list.html:294
 #, python-format
 msgid ""
 "Unlisting your add-on will make it (and each of its versions/files) invisible on this website. It won't show up in searches, won't have a public facing page, and won't be updated automatically for "
-"current users.  It is recommended for unlisted add-ons to provide a custom <a href=\"%(update_url)s\" target=\"_blank\">updateURL</a> in their manifest file for automatic updates."
+"current users. It is recommended for unlisted add-ons to provide a custom <a href=\"%(update_url)s\" target=\"_blank\">updateURL</a> in their manifest file for automatic updates."
 msgstr ""
 "Unlisting your add-on will make it (and each of its versions/files) invisible on this website. It won't show up in searches, won't have a public facing page, and won't be updated automatically for "
 "current users.  It is recommended for unlisted add-ons to provide a custom <a href=\"%(update_url)s\" target=\"_blank\">updateURL</a> in their manifest file for automatic updates."
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:299
-#, python-format
-msgid "Switching add-ons to unlisted is currently in an open beta. Please <a href=\"%(url)s\" target=\"_blank\">report any bugs</a> that you encounter."
-msgstr "Switching add-ons to unlisted is currently in an open beta. Please <a href=\"%(url)s\" target=\"_blank\">report any bugs</a> that you encounter."
-
-#: src/olympia/devhub/templates/devhub/versions/list.html:305
+#: src/olympia/devhub/templates/devhub/versions/list.html:303
 msgid "Unlisting an add-on is irreversible!"
 msgstr "Unlisting an add-on is irreversible!"
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:305
+#: src/olympia/devhub/templates/devhub/versions/list.html:303
 msgid "An unlisted add-on cannot be switched to be listed."
 msgstr "An unlisted add-on cannot be switched to be listed."
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:307
+#: src/olympia/devhub/templates/devhub/versions/list.html:305
 msgid "Are you sure you wish to unlist your add-on?"
 msgstr "Are you sure you wish to unlist your add-on?"
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:330
+#: src/olympia/devhub/templates/devhub/versions/list.html:328
 msgid "Canceling your review request will leave your add-on as preliminarily reviewed."
 msgstr "Canceling your review request will leave your add-on as preliminarily reviewed."
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:335
+#: src/olympia/devhub/templates/devhub/versions/list.html:333
 msgid "Canceling your review request will mark your add-on incomplete. If you do not complete your add-on after several days by re-requesting review, it will be deleted."
 msgstr "Canceling your review request will mark your add-on incomplete. If you do not complete your add-on after several days by re-requesting review, it will be deleted."
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:343
+#: src/olympia/devhub/templates/devhub/versions/list.html:341
 msgid "Are you sure you wish to cancel your review request?"
 msgstr "Are you sure you wish to cancel your review request?"
 
@@ -7611,19 +7434,19 @@ msgstr "add-on, editor or comment"
 msgid "Search by add-on name / author email"
 msgstr "Search by add-on name / author email"
 
-#: src/olympia/editors/forms.py:103
+#: src/olympia/editors/forms.py:103 src/olympia/editors/forms.py:244 src/olympia/editors/forms.py:257
 msgid "yes"
 msgstr "yes"
 
-#: src/olympia/editors/forms.py:104
+#: src/olympia/editors/forms.py:104 src/olympia/editors/forms.py:244 src/olympia/editors/forms.py:257
 msgid "no"
 msgstr "no"
 
-#: src/olympia/editors/forms.py:105
+#: src/olympia/editors/forms.py:105 src/olympia/editors/forms.py:245
 msgid "Admin Flag"
 msgstr "Admin Flag"
 
-#: src/olympia/editors/forms.py:113
+#: src/olympia/editors/forms.py:113 src/olympia/editors/forms.py:253
 msgid "Max. Version"
 msgstr "Max. Version"
 
@@ -7635,55 +7458,59 @@ msgstr "Days Since Submission"
 msgid "Add-on Types"
 msgstr "Add-on Types"
 
-#: src/olympia/editors/forms.py:126 src/olympia/editors/helpers.py:267
+#: src/olympia/editors/forms.py:126 src/olympia/editors/helpers.py:279
 msgid "Platforms"
 msgstr "Platforms"
 
+#: src/olympia/editors/forms.py:237
+msgid "Search by add-on name / author email / guid"
+msgstr "Search by add-on name / author email / guid"
+
 #. L10n: 0 = platform, 1 = filename, 2 = status message
-#: src/olympia/editors/forms.py:238
+#: src/olympia/editors/forms.py:342
 #, python-format
 msgid "<strong>%s</strong> &middot; %s &middot; %s"
 msgstr "<strong>%s</strong> &middot; %s &middot; %s"
 
-#: src/olympia/editors/forms.py:252
+#: src/olympia/editors/forms.py:356
 msgid "Comments:"
 msgstr "Comments:"
 
-#: src/olympia/editors/forms.py:256
+#: src/olympia/editors/forms.py:360
 msgid "Operating systems:"
 msgstr "Operating systems:"
 
-#: src/olympia/editors/forms.py:258
+#: src/olympia/editors/forms.py:362
 msgid "Applications:"
 msgstr "Applications:"
 
-#: src/olympia/editors/forms.py:260
+#: src/olympia/editors/forms.py:364
 msgid "Notify me the next time this add-on is updated. (Subsequent updates will not generate an email)"
 msgstr "Notify me the next time this add-on is updated. (Subsequent updates will not generate an email)"
 
-#: src/olympia/editors/forms.py:265
+#: src/olympia/editors/forms.py:369
 msgid "Clear Admin Review Flag"
 msgstr "Clear Admin Review Flag"
 
-#: src/olympia/editors/forms.py:267
+#: src/olympia/editors/forms.py:371
 msgid "Clear more info requested flag"
 msgstr "Clear more info requested flag"
 
-#: src/olympia/editors/forms.py:281
+#: src/olympia/editors/forms.py:385
 msgid "Choose a canned response..."
 msgstr "Choose a canned response..."
 
 #. L10n: Description of what can be searched for.
-#: src/olympia/editors/forms.py:324
+#: src/olympia/editors/forms.py:423
 msgid "theme name"
 msgstr "theme name"
 
-#: src/olympia/editors/forms.py:350
+#: src/olympia/editors/forms.py:449
 msgid "Someone else is reviewing this theme."
 msgstr "Someone else is reviewing this theme."
 
 #. L10n: Description of what can be searched for.
-#: src/olympia/editors/forms.py:447
+#: src/olympia/editors/forms.py:546
 msgid "app, reviewer, or comment"
 msgstr "app, reviewer, or comment"
 
@@ -7699,192 +7526,210 @@ msgstr "Pending Preliminary Review"
 msgid "Rejected or Unreviewed"
 msgstr "Rejected or Unreviewed"
 
-#: src/olympia/editors/helpers.py:123 src/olympia/editors/helpers.py:136
+#: src/olympia/editors/helpers.py:125 src/olympia/editors/helpers.py:138
 msgid "Queue"
 msgstr "Queue"
 
-#: src/olympia/editors/helpers.py:124 src/olympia/editors/templates/editors/base.html:50 src/olympia/editors/templates/editors/base.html:65
+#: src/olympia/editors/helpers.py:126 src/olympia/editors/templates/editors/base.html:50 src/olympia/editors/templates/editors/base.html:65
 msgid "Pending Updates"
 msgstr "Pending Updates"
 
-#: src/olympia/editors/helpers.py:125 src/olympia/editors/templates/editors/base.html:48 src/olympia/editors/templates/editors/base.html:63
+#: src/olympia/editors/helpers.py:127 src/olympia/editors/templates/editors/base.html:48 src/olympia/editors/templates/editors/base.html:63
 msgid "Full Reviews"
 msgstr "Full Reviews"
 
-#: src/olympia/editors/helpers.py:126 src/olympia/editors/templates/editors/base.html:52 src/olympia/editors/templates/editors/base.html:67
+#: src/olympia/editors/helpers.py:128 src/olympia/editors/templates/editors/base.html:52 src/olympia/editors/templates/editors/base.html:67
 msgid "Preliminary Reviews"
 msgstr "Preliminary Reviews"
 
-#: src/olympia/editors/helpers.py:127 src/olympia/editors/templates/editors/base.html:54
+#: src/olympia/editors/helpers.py:129 src/olympia/editors/templates/editors/base.html:54
 msgid "Moderated Reviews"
 msgstr "Moderated Reviews"
 
-#: src/olympia/editors/helpers.py:128 src/olympia/editors/templates/editors/base.html:46
+#: src/olympia/editors/helpers.py:130 src/olympia/editors/templates/editors/base.html:46
 msgid "Fast Track"
 msgstr "Fast Track"
 
-#: src/olympia/editors/helpers.py:130
+#: src/olympia/editors/helpers.py:132
 msgid "Pending Themes"
 msgstr "Pending Themes"
 
-#: src/olympia/editors/helpers.py:131 src/olympia/editors/templates/editors/themes/queue.html:4
+#: src/olympia/editors/helpers.py:133 src/olympia/editors/templates/editors/themes/queue.html:4
 msgid "Flagged Themes"
 msgstr "Flagged Themes"
 
-#: src/olympia/editors/helpers.py:132
+#: src/olympia/editors/helpers.py:134
 msgid "Update Themes"
 msgstr "Update Themes"
 
-#: src/olympia/editors/helpers.py:137
+#: src/olympia/editors/helpers.py:139
 msgid "Unlisted Pending Updates"
 msgstr "Unlisted Pending Updates"
 
-#: src/olympia/editors/helpers.py:138
+#: src/olympia/editors/helpers.py:140
 msgid "Unlisted Full Reviews"
 msgstr "Unlisted Full Reviews"
 
-#: src/olympia/editors/helpers.py:139
+#: src/olympia/editors/helpers.py:141
 msgid "Unlisted Preliminary Reviews"
 msgstr "Unlisted Preliminary Reviews"
 
-#: src/olympia/editors/helpers.py:170
+#: src/olympia/editors/helpers.py:142
+msgid "Unlisted All Add-ons"
+msgstr "Unlisted All Add-ons"
+
+#: src/olympia/editors/helpers.py:173
 msgid "Fast Track ({0})"
 msgid_plural "Fast Track ({0})"
 msgstr[0] "Fast Track ({0})"
 msgstr[1] "Fast Track ({0})"
 
-#: src/olympia/editors/helpers.py:175
+#: src/olympia/editors/helpers.py:178
 msgid "Full Review ({0})"
 msgid_plural "Full Reviews ({0})"
 msgstr[0] "Full Review ({0})"
 msgstr[1] "Full Reviews ({0})"
 
-#: src/olympia/editors/helpers.py:180
+#: src/olympia/editors/helpers.py:183
 msgid "Pending Update ({0})"
 msgid_plural "Pending Updates ({0})"
 msgstr[0] "Pending Update ({0})"
 msgstr[1] "Pending Updates ({0})"
 
-#: src/olympia/editors/helpers.py:185
+#: src/olympia/editors/helpers.py:188
 msgid "Preliminary Review ({0})"
 msgid_plural "Preliminary Reviews ({0})"
 msgstr[0] "Preliminary Review ({0})"
 msgstr[1] "Preliminary Reviews ({0})"
 
-#: src/olympia/editors/helpers.py:190
+#: src/olympia/editors/helpers.py:193
 msgid "Moderated Review ({0})"
 msgid_plural "Moderated Reviews ({0})"
 msgstr[0] "Moderated Review ({0})"
 msgstr[1] "Moderated Reviews ({0})"
 
-#: src/olympia/editors/helpers.py:196
+#: src/olympia/editors/helpers.py:199
 msgid "Unlisted Full Review ({0})"
 msgid_plural "Unlisted Full Reviews ({0})"
 msgstr[0] "Unlisted Full Review ({0})"
 msgstr[1] "Unlisted Full Reviews ({0})"
 
-#: src/olympia/editors/helpers.py:201
+#: src/olympia/editors/helpers.py:204
 msgid "Unlisted Pending Update ({0})"
 msgid_plural "Unlisted Pending Updates ({0})"
 msgstr[0] "Unlisted Pending Update ({0})"
 msgstr[1] "Unlisted Pending Updates ({0})"
 
-#: src/olympia/editors/helpers.py:206
+#: src/olympia/editors/helpers.py:209
 msgid "Unlisted Preliminary Review ({0})"
 msgid_plural "Unlisted Preliminary Reviews ({0})"
 msgstr[0] "Unlisted Preliminary Review ({0})"
 msgstr[1] "Unlisted Preliminary Reviews ({0})"
 
-#: src/olympia/editors/helpers.py:261
-msgid "Addon"
-msgstr "Addon"
+#: src/olympia/editors/helpers.py:214
+msgid "Unlisted All Add-ons ({0})"
+msgid_plural "Unlisted All Add-ons ({0})"
+msgstr[0] "Unlisted All Add-ons ({0})"
+msgstr[1] "Unlisted All Add-ons ({0})"
 
-#: src/olympia/editors/helpers.py:262
+#: src/olympia/editors/helpers.py:274
 msgid "Type"
 msgstr "Type"
 
-#: src/olympia/editors/helpers.py:263
+#: src/olympia/editors/helpers.py:275
 msgid "Waiting Time"
 msgstr "Waiting Time"
 
-#: src/olympia/editors/helpers.py:264 src/olympia/editors/templates/editors/review.html:285
+#: src/olympia/editors/helpers.py:276 src/olympia/editors/templates/editors/review.html:285
 msgid "Flags"
 msgstr "Flags"
 
-#: src/olympia/editors/helpers.py:265
+#: src/olympia/editors/helpers.py:277
 msgid "Applications"
 msgstr "Applications"
 
-#: src/olympia/editors/helpers.py:270
+#: src/olympia/editors/helpers.py:282
 msgid "Additional"
 msgstr "Additional"
 
-#: src/olympia/editors/helpers.py:285
+#: src/olympia/editors/helpers.py:302
 msgid "Site Specific"
 msgstr "Site Specific"
 
-#: src/olympia/editors/helpers.py:287
+#: src/olympia/editors/helpers.py:304
 msgid "Requires External Software"
 msgstr "Requires External Software"
 
-#: src/olympia/editors/helpers.py:289
+#: src/olympia/editors/helpers.py:306
 msgid "Binary Components"
 msgstr "Binary Components"
 
-#: src/olympia/editors/helpers.py:313
+#: src/olympia/editors/helpers.py:339
 msgid "moments ago"
 msgstr "moments ago"
 
 #. L10n: first argument is number of minutes
-#: src/olympia/editors/helpers.py:316
+#: src/olympia/editors/helpers.py:342
 msgid "{0} minute"
 msgid_plural "{0} minutes"
 msgstr[0] "{0} minute"
 msgstr[1] "{0} minutes"
 
 #. L10n: first argument is number of hours
-#: src/olympia/editors/helpers.py:320
+#: src/olympia/editors/helpers.py:346
 msgid "{0} hour"
 msgid_plural "{0} hours"
 msgstr[0] "{0} hour"
 msgstr[1] "{0} hours"
 
 #. L10n: first argument is number of days
-#: src/olympia/editors/helpers.py:324
+#: src/olympia/editors/helpers.py:350
 msgid "{0} day"
 msgid_plural "{0} days"
 msgstr[0] "{0} day"
 msgstr[1] "{0} days"
 
-#: src/olympia/editors/helpers.py:488
+#: src/olympia/editors/helpers.py:364
+msgid "Last Review"
+msgstr "Last Review"
+
+#: src/olympia/editors/helpers.py:366
+msgid "Last Update"
+msgstr "Last Update"
+
+#: src/olympia/editors/helpers.py:387
+msgid "No Reviews"
+msgstr "No Reviews"
+
+#: src/olympia/editors/helpers.py:561
 msgid "Push to public"
 msgstr "Push to public"
 
-#: src/olympia/editors/helpers.py:490
+#: src/olympia/editors/helpers.py:563
 msgid "Grant full review"
 msgstr "Grant full review"
 
-#: src/olympia/editors/helpers.py:505
+#: src/olympia/editors/helpers.py:578
 msgid "Request more information"
 msgstr "Request more information"
 
-#: src/olympia/editors/helpers.py:508
+#: src/olympia/editors/helpers.py:581
 msgid "Request super-review"
 msgstr "Request super-review"
 
-#: src/olympia/editors/helpers.py:519
+#: src/olympia/editors/helpers.py:592
 msgid "Grant preliminary review"
 msgstr "Grant preliminary review"
 
-#: src/olympia/editors/helpers.py:520
+#: src/olympia/editors/helpers.py:593
 msgid "This will mark the files as preliminarily reviewed."
 msgstr "This will mark the files as preliminarily reviewed."
 
-#: src/olympia/editors/helpers.py:522
+#: src/olympia/editors/helpers.py:595
 msgid "Use this form to request more information from the author. They will receive an email and be able to answer here. You will be notified by email when they reply."
 msgstr "Use this form to request more information from the author. They will receive an email and be able to answer here. You will be notified by email when they reply."
 
-#: src/olympia/editors/helpers.py:526
+#: src/olympia/editors/helpers.py:599
 msgid ""
 "If you have concerns about this add-on's security, copyright issues, or other concerns that an administrator should look into, enter your comments in the area below. They will be sent to "
 "administrators, not the author."
@@ -7892,55 +7737,55 @@ msgstr ""
 "If you have concerns about this add-on's security, copyright issues, or other concerns that an administrator should look into, enter your comments in the area below. They will be sent to "
 "administrators, not the author."
 
-#: src/olympia/editors/helpers.py:532
+#: src/olympia/editors/helpers.py:605
 msgid "This will reject the add-on and remove it from the review queue."
 msgstr "This will reject the add-on and remove it from the review queue."
 
-#: src/olympia/editors/helpers.py:534
-msgid "Make a comment on this version.  The author won't be able to see this."
+#: src/olympia/editors/helpers.py:607
+msgid "Make a comment on this version. The author won't be able to see this."
 msgstr "Make a comment on this version.  The author won't be able to see this."
 
-#: src/olympia/editors/helpers.py:538
+#: src/olympia/editors/helpers.py:611
 msgid "This will reject the files and remove them from the review queue."
 msgstr "This will reject the files and remove them from the review queue."
 
-#: src/olympia/editors/helpers.py:542
+#: src/olympia/editors/helpers.py:615
 msgid "This will mark the add-on as preliminarily reviewed. Future versions will undergo preliminary review."
 msgstr "This will mark the add-on as preliminarily reviewed. Future versions will undergo preliminary review."
 
-#: src/olympia/editors/helpers.py:547
+#: src/olympia/editors/helpers.py:620
 msgid "This will mark the files as preliminarily reviewed. Future versions will undergo preliminary review."
 msgstr "This will mark the files as preliminarily reviewed. Future versions will undergo preliminary review."
 
-#: src/olympia/editors/helpers.py:552
+#: src/olympia/editors/helpers.py:625
 msgid "Retain preliminary review"
 msgstr "Retain preliminary review"
 
-#: src/olympia/editors/helpers.py:553
+#: src/olympia/editors/helpers.py:626
 msgid "This will retain the add-on as preliminarily reviewed. Future versions will undergo preliminary review."
 msgstr "This will retain the add-on as preliminarily reviewed. Future versions will undergo preliminary review."
 
-#: src/olympia/editors/helpers.py:558
+#: src/olympia/editors/helpers.py:631
 msgid "This will approve a sandboxed version of a public add-on to appear on the public side."
 msgstr "This will approve a sandboxed version of a public add-on to appear on the public side."
 
-#: src/olympia/editors/helpers.py:561
+#: src/olympia/editors/helpers.py:634
 msgid "This will reject a version of a public add-on and remove it from the queue."
 msgstr "This will reject a version of a public add-on and remove it from the queue."
 
-#: src/olympia/editors/helpers.py:564
+#: src/olympia/editors/helpers.py:637
 msgid "This will mark the add-on and its most recent version and files as public. Future versions will go into the sandbox until they are reviewed by an editor."
 msgstr "This will mark the add-on and its most recent version and files as public. Future versions will go into the sandbox until they are reviewed by an editor."
 
-#: src/olympia/editors/helpers.py:637
+#: src/olympia/editors/helpers.py:714
 msgid "add-on"
 msgstr "add-on"
 
-#: src/olympia/editors/helpers.py:940 src/olympia/editors/helpers.py:960
+#: src/olympia/editors/helpers.py:1020 src/olympia/editors/helpers.py:1040
 msgid "Flagged"
 msgstr "Flagged"
 
-#: src/olympia/editors/helpers.py:944 src/olympia/editors/helpers.py:963
+#: src/olympia/editors/helpers.py:1024 src/olympia/editors/helpers.py:1043
 msgid "Updates"
 msgstr "Updates"
 
@@ -7992,56 +7837,56 @@ msgstr "Theme submission flagged for review"
 msgid "A question about your Theme submission"
 msgstr "A question about your Theme submission"
 
-#: src/olympia/editors/views.py:144
+#: src/olympia/editors/views.py:146
 msgid "New Add-ons (Under 5 days)"
 msgstr "New Add-ons (Under 5 days)"
 
-#: src/olympia/editors/views.py:145
+#: src/olympia/editors/views.py:147
 msgid "Passable (5 to 10 days)"
 msgstr "Passable (5 to 10 days)"
 
-#: src/olympia/editors/views.py:146
+#: src/olympia/editors/views.py:148
 msgid "Overdue (Over 10 days)"
 msgstr "Overdue (Over 10 days)"
 
-#: src/olympia/editors/views.py:532
+#: src/olympia/editors/views.py:539
 msgid "An unknown error occurred"
 msgstr "An unknown error occurred"
 
-#: src/olympia/editors/views.py:587
+#: src/olympia/editors/views.py:592
 msgid "Self-reviews are not allowed."
 msgstr "Self-reviews are not allowed."
 
-#: src/olympia/editors/views.py:609
+#: src/olympia/editors/views.py:613
 msgid "Review successfully processed."
 msgstr "Review successfully processed."
 
-#: src/olympia/editors/views.py:807
+#: src/olympia/editors/views.py:812
 msgid "was approved"
 msgstr "was approved"
 
-#: src/olympia/editors/views.py:808
+#: src/olympia/editors/views.py:813
 msgid "given preliminary review"
 msgstr "given preliminary review"
 
-#: src/olympia/editors/views.py:809
+#: src/olympia/editors/views.py:814
 msgid "rejected"
 msgstr "rejected"
 
-#: src/olympia/editors/views.py:810
+#: src/olympia/editors/views.py:815
 msgctxt "editors_review_history_nominated_adminreview"
 msgid "escalated"
 msgstr "escalated"
 
-#: src/olympia/editors/views.py:812
+#: src/olympia/editors/views.py:817
 msgid "needs more information"
 msgstr "needs more information"
 
-#: src/olympia/editors/views.py:813
+#: src/olympia/editors/views.py:818
 msgid "needs super review"
 msgstr "needs super review"
 
-#: src/olympia/editors/views.py:814
+#: src/olympia/editors/views.py:819
 msgid "commented"
 msgstr "commented"
 
@@ -8086,28 +7931,28 @@ msgstr "Queues"
 msgid "Unlisted Queues"
 msgstr "Unlisted Queues"
 
-#: src/olympia/editors/templates/editors/base.html:72 src/olympia/editors/templates/editors/performance.html:6
+#: src/olympia/editors/templates/editors/base.html:74 src/olympia/editors/templates/editors/performance.html:6
 msgid "Performance"
 msgstr "Performance"
 
-#: src/olympia/editors/templates/editors/base.html:75 src/olympia/editors/templates/editors/themes/base.html:19 src/olympia/editors/templates/editors/themes/base.html:38
+#: src/olympia/editors/templates/editors/base.html:77 src/olympia/editors/templates/editors/themes/base.html:19 src/olympia/editors/templates/editors/themes/base.html:38
 msgid "Logs"
 msgstr "Logs"
 
-#: src/olympia/editors/templates/editors/base.html:78 src/olympia/editors/templates/editors/reviewlog.html:4 src/olympia/editors/templates/editors/reviewlog.html:27
+#: src/olympia/editors/templates/editors/base.html:80 src/olympia/editors/templates/editors/reviewlog.html:4 src/olympia/editors/templates/editors/reviewlog.html:27
 msgid "Add-on Review Log"
 msgstr "Add-on Review Log"
 
-#: src/olympia/editors/templates/editors/base.html:80 src/olympia/editors/templates/editors/eventlog.html:4 src/olympia/editors/templates/editors/eventlog.html:8
+#: src/olympia/editors/templates/editors/base.html:82 src/olympia/editors/templates/editors/eventlog.html:4 src/olympia/editors/templates/editors/eventlog.html:8
 #: src/olympia/editors/templates/editors/eventlog_detail.html:4
 msgid "Moderated Review Log"
 msgstr "Moderated Review Log"
 
-#: src/olympia/editors/templates/editors/base.html:82 src/olympia/editors/templates/editors/beta_signed_log.html:4 src/olympia/editors/templates/editors/beta_signed_log.html:8
+#: src/olympia/editors/templates/editors/base.html:84 src/olympia/editors/templates/editors/beta_signed_log.html:4 src/olympia/editors/templates/editors/beta_signed_log.html:8
 msgid "Signed Beta Files Log"
 msgstr "Signed Beta Files Log"
 
-#: src/olympia/editors/templates/editors/base.html:87 src/olympia/editors/templates/editors/includes/daily-message.html:4
+#: src/olympia/editors/templates/editors/base.html:89 src/olympia/editors/templates/editors/includes/daily-message.html:4
 msgid "Announcement"
 msgstr "Announcement"
 
@@ -8328,45 +8173,45 @@ msgstr "Advanced Search"
 msgid "clear search"
 msgstr "clear search"
 
-#: src/olympia/editors/templates/editors/queue.html:72 src/olympia/editors/templates/editors/queue.html:122
+#: src/olympia/editors/templates/editors/queue.html:78 src/olympia/editors/templates/editors/queue.html:128
 msgid "Process Reviews"
 msgstr "Process Reviews"
 
-#: src/olympia/editors/templates/editors/queue.html:80
+#: src/olympia/editors/templates/editors/queue.html:86
 msgid "Moderation actions:"
 msgstr "Moderation actions:"
 
-#: src/olympia/editors/templates/editors/queue.html:90
+#: src/olympia/editors/templates/editors/queue.html:96
 #, python-format
 msgid "by %(user)s on %(date)s %(stars)s (%(locale)s)"
 msgstr "by %(user)s on %(date)s %(stars)s (%(locale)s)"
 
-#: src/olympia/editors/templates/editors/queue.html:106
+#: src/olympia/editors/templates/editors/queue.html:112
 #, python-format
 msgid "<strong>%(reason)s</strong> <span class=\"light\">Flagged by %(user)s on %(date)s</span>"
 msgstr "<strong>%(reason)s</strong> <span class=\"light\">Flagged by %(user)s on %(date)s</span>"
 
-#: src/olympia/editors/templates/editors/queue.html:119
-msgid "All reviews have been moderated.  Good work!"
+#: src/olympia/editors/templates/editors/queue.html:125
+msgid "All reviews have been moderated. Good work!"
 msgstr "All reviews have been moderated.  Good work!"
 
-#: src/olympia/editors/templates/editors/queue.html:161
+#: src/olympia/editors/templates/editors/queue.html:167
 msgid "Version Notes / Notes for Reviewer"
 msgstr "Version Notes / Notes for Reviewer"
 
-#: src/olympia/editors/templates/editors/queue.html:169
+#: src/olympia/editors/templates/editors/queue.html:175
 msgid "There are currently no add-ons of this type to review."
 msgstr "There are currently no add-ons of this type to review."
 
-#: src/olympia/editors/templates/editors/queue.html:181 src/olympia/editors/templates/editors/themes/queue_list.html:85
+#: src/olympia/editors/templates/editors/queue.html:187 src/olympia/editors/templates/editors/themes/queue_list.html:85
 msgid "Helpful Links:"
 msgstr "Helpful Links:"
 
-#: src/olympia/editors/templates/editors/queue.html:182
+#: src/olympia/editors/templates/editors/queue.html:188
 msgid "Add-on Policy"
 msgstr "Add-on Policy"
 
-#: src/olympia/editors/templates/editors/queue.html:184
+#: src/olympia/editors/templates/editors/queue.html:190
 msgid "Editors' Guide"
 msgstr "Editors' Guide"
 
@@ -8429,10 +8274,7 @@ msgid "<strong>Warning!</strong> Another user was viewing this page before you."
 msgstr "<strong>Warning!</strong> Another user was viewing this page before you."
 
 #: src/olympia/editors/templates/editors/review.html:237
-msgid ""
-"The whiteboard is the place to exchange information relevant to\n"
-"               this addon (whatever the version), between the developer and the\n"
-"               editor. This is visible and editable by both."
+msgid "The whiteboard is the place to exchange information relevant to this addon (whatever the version), between the developer and the editor. This is visible and editable by both."
 msgstr ""
 "The whiteboard is the place to exchange information relevant to\n"
 "               this addon (whatever the version), between the developer and the\n"
@@ -8709,7 +8551,7 @@ msgstr "Ask a question to the artist"
 msgid "Describe your reason for flagging"
 msgstr "Describe your reason for flagging"
 
-#: src/olympia/files/forms.py:88
+#: src/olympia/files/forms.py:90
 msgid "Cannot diff a version against itself"
 msgstr "Cannot diff a version against itself"
 
@@ -8744,51 +8586,51 @@ msgstr "There was an error accessing file %s. %s."
 msgid "There was an error accessing file %s."
 msgstr "There was an error accessing file %s."
 
-#: src/olympia/files/utils.py:343
+#: src/olympia/files/utils.py:340
 msgid "Could not parse uploaded file."
 msgstr "Could not parse uploaded file."
 
-#: src/olympia/files/utils.py:380
+#: src/olympia/files/utils.py:377
 msgid "Invalid file name in archive: {0}"
 msgstr "Invalid file name in archive: {0}"
 
-#: src/olympia/files/utils.py:388
+#: src/olympia/files/utils.py:385
 msgid "File exceeding size limit in archive: {0}"
 msgstr "File exceeding size limit in archive: {0}"
 
-#: src/olympia/files/utils.py:439
+#: src/olympia/files/utils.py:436
 msgid "Invalid archive."
 msgstr "Invalid archive."
 
-#: src/olympia/files/utils.py:529 src/olympia/files/utils.py:532
+#: src/olympia/files/utils.py:526 src/olympia/files/utils.py:529
 msgid "Could not parse the manifest file."
 msgstr "Could not parse the manifest file."
 
-#: src/olympia/files/utils.py:551
+#: src/olympia/files/utils.py:548
 msgid "Could not find an add-on ID."
 msgstr "Could not find an add-on ID."
 
-#: src/olympia/files/utils.py:554
+#: src/olympia/files/utils.py:551
 msgid "Add-on ID must be 64 characters or less."
 msgstr "Add-on ID must be 64 characters or less."
 
-#: src/olympia/files/utils.py:556
+#: src/olympia/files/utils.py:553
 msgid "Add-on ID doesn't match add-on."
 msgstr "Add-on ID doesn't match add-on."
 
-#: src/olympia/files/utils.py:564
+#: src/olympia/files/utils.py:561
 msgid "Duplicate add-on ID found."
 msgstr "Duplicate add-on ID found."
 
-#: src/olympia/files/utils.py:567
+#: src/olympia/files/utils.py:564
 msgid "Version numbers should have fewer than 32 characters."
 msgstr "Version numbers should have fewer than 32 characters."
 
-#: src/olympia/files/utils.py:570
+#: src/olympia/files/utils.py:567
 msgid "Version numbers should only contain letters, numbers, and these punctuation characters: +*.-_."
 msgstr "Version numbers should only contain letters, numbers, and these punctuation characters: +*.-_."
 
-#: src/olympia/files/utils.py:587
+#: src/olympia/files/utils.py:584
 msgid "<em:type> doesn't match add-on"
 msgstr "<em:type> doesn't match add-on"
 
@@ -8888,6 +8730,10 @@ msgstr "No files in the uploaded file."
 #: src/olympia/files/templates/files/viewer.html:134
 msgid "Fetching file."
 msgstr "Fetching file."
+
+#: src/olympia/legacy_api/views.py:255
+msgid "Not implemented yet."
+msgstr "Not implemented yet."
 
 #: src/olympia/lib/constants.py:6
 msgid "United Arab Emirates Dirham"
@@ -9545,10 +9391,6 @@ msgstr "Zambia Kwacha"
 msgid "Zimbabwe Dollar"
 msgstr "Zimbabwe Dollar"
 
-#: src/olympia/lib/video/ffmpeg.py:112 src/olympia/lib/video/totem.py:81
-msgid "Videos must be in WebM."
-msgstr "Videos must be in WebM."
-
 #: src/olympia/pages/templates/pages/about.lhtml:3 src/olympia/pages/templates/pages/about.lhtml:10
 msgid "About Mozilla Add-ons"
 msgstr "About Mozilla Add-ons"
@@ -9560,7 +9402,7 @@ msgstr "What is this website?"
 #: src/olympia/pages/templates/pages/about.lhtml:13
 msgid ""
 "addons.mozilla.org, commonly known as \"AMO\", is Mozilla's official site for add-ons to Mozilla software, such as Firefox, Thunderbird, and SeaMonkey. Add-ons let you add new features and change "
-"the way your browser or application works.  Take a look around and explore the thousands of ways to customize the way you do things online."
+"the way your browser or application works. Take a look around and explore the thousands of ways to customize the way you do things online."
 msgstr ""
 "addons.mozilla.org, commonly known as \"AMO\", is Mozilla's official site for add-ons to Mozilla software, such as Firefox, Thunderbird, and SeaMonkey. Add-ons let you add new features and change "
 "the way your browser or application works.  Take a look around and explore the thousands of ways to customize the way you do things online."
@@ -9939,7 +9781,7 @@ msgstr "Can I use a JavaScript library like jQuery, MooTools or Prototype to bui
 msgid ""
 "Yes. It's possible, but some of the functionality provided by these libraries are available through XPCOM, XUL, and JavaScript. In addition, authors should take care if libraries modify primitive "
 "object prototypes (String.prototype, Date.prototype, etc.) and/or define global functions (eg. the $ function). These are prone to cause conflict with other add-ons, in particular if different add-"
-"ons use different versions of libraries and so on. Developers need to be very, very careful with using them.  Mozilla does not offer documentation on using them to build add-ons."
+"ons use different versions of libraries and so on. Developers need to be very, very careful with using them. Mozilla does not offer documentation on using them to build add-ons."
 msgstr ""
 "Yes. It's possible, but some of the functionality provided by these libraries are available through XPCOM, XUL, and JavaScript. In addition, authors should take care if libraries modify primitive "
 "object prototypes (String.prototype, Date.prototype, etc.) and/or define global functions (eg. the $ function). These are prone to cause conflict with other add-ons, in particular if different add-"
@@ -10065,8 +9907,8 @@ msgstr "Can I host my own add-on?"
 #, python-format
 msgid ""
 "Yes. Many developers choose to host their own add-ons. Choosing to host your add-on on <a href=\"%(amo_url)s\">Mozilla's add-on site</a>, though, allows for much greater exposure to your add-on due "
-"to the large volume of visitors to the site.  <a href=\"%(md_url)s\">mozdev.org</a> offers free project hosting for Mozilla applications and extensions providing developers with tools to help "
-"manage source code, version control, bug tracking and documentation."
+"to the large volume of visitors to the site. <a href=\"%(md_url)s\">mozdev.org</a> offers free project hosting for Mozilla applications and extensions providing developers with tools to help manage "
+"source code, version control, bug tracking and documentation."
 msgstr ""
 "Yes. Many developers choose to host their own add-ons. Choosing to host your add-on on <a href=\"%(amo_url)s\">Mozilla's add-on site</a>, though, allows for much greater exposure to your add-on due "
 "to the large volume of visitors to the site.  <a href=\"%(md_url)s\">mozdev.org</a> offers free project hosting for Mozilla applications and extensions providing developers with tools to help "
@@ -10121,7 +9963,7 @@ msgstr "Does Mozilla have a policy in place as to what is an acceptable submissi
 #: src/olympia/pages/templates/pages/dev_faq.html:314
 #, python-format
 msgid ""
-"Yes. Mozilla's <a href=\"%(p_url)s\">Add-on Policy</a> describes what is an acceptable submission. This policy is subject to change without notice.  In addition, the AMO editorial team uses the <a "
+"Yes. Mozilla's <a href=\"%(p_url)s\">Add-on Policy</a> describes what is an acceptable submission. This policy is subject to change without notice. In addition, the AMO editorial team uses the <a "
 "href=\"%(g_url)s\">Editors Reviewing Guide</a> to ensure that your add-on meets specific guidelines for functionality and security."
 msgstr ""
 "Yes. Mozilla's <a href=\"%(p_url)s\">Add-on Policy</a> describes what is an acceptable submission. This policy is subject to change without notice.  In addition, the AMO editorial team uses the <a "
@@ -10251,7 +10093,7 @@ msgstr "number of problem areas discovered"
 #: src/olympia/pages/templates/pages/dev_faq.html:434
 #, python-format
 msgid ""
-"This is why it's very important to read the <a href=\"%(g_url)s\">Editors Reviewing Guide</a> to ensure that your add-on is setup as expected.  It's also a good idea to read the blog post, <a href="
+"This is why it's very important to read the <a href=\"%(g_url)s\">Editors Reviewing Guide</a> to ensure that your add-on is setup as expected. It's also a good idea to read the blog post, <a href="
 "\"%(blog_url)s\">Successfully Getting your Add-on Reviewed</a> which provides excellent insight into ensuring a smooth review of your add-on."
 msgstr ""
 "This is why it's very important to read the <a href=\"%(g_url)s\">Editors Reviewing Guide</a> to ensure that your add-on is setup as expected.  It's also a good idea to read the blog post, <a href="
@@ -10369,7 +10211,7 @@ msgstr "A table summarizing and comparing how some of the key open source licens
 
 #: src/olympia/pages/templates/pages/dev_faq.html:572
 msgid ""
-"Free Software Foundation provides short summaries of the key open source licenses, including whether the license qualifies as a free software license or a copyleft license.  Also includes a "
+"Free Software Foundation provides short summaries of the key open source licenses, including whether the license qualifies as a free software license or a copyleft license. Also includes a "
 "discussion of what constitutes a free software license or a copyleft license (e.g., a Copyleft license is a general method for making a program or other work free, and requiring all modified and "
 "extended versions of the program to be free as well.)"
 msgstr ""
@@ -10576,21 +10418,15 @@ msgid "Add-on Gallery"
 msgstr "Add-on Gallery"
 
 #: src/olympia/pages/templates/pages/faq.html:171
-msgid ""
-"How do I choose between add-ons that seem to do the same\n"
-"    thing?"
+msgid "How do I choose between add-ons that seem to do the same thing?"
 msgstr ""
 "How do I choose between add-ons that seem to do the same\n"
 "    thing?"
 
-#: src/olympia/pages/templates/pages/faq.html:173
+#: src/olympia/pages/templates/pages/faq.html:172
 msgid ""
-"There are often several add-ons that have similar features. To\n"
-"    figure out which is right for you, read the entire description of the\n"
-"    add-on and view its screenshots. If there are still several in the running,\n"
-"    read through the add-on's ratings, user reviews, and statistics to see\n"
-"    which is most liked by other users. Remember that you can also just try\n"
-"    out both and see which you like better."
+"There are often several add-ons that have similar features. To figure out which is right for you, read the entire description of the add-on and view its screenshots. If there are still several in "
+"the running, read through the add-on's ratings, user reviews, and statistics to see which is most liked by other users. Remember that you can also just try out both and see which you like better."
 msgstr ""
 "There are often several add-ons that have similar features. To\n"
 "    figure out which is right for you, read the entire description of the\n"
@@ -10643,101 +10479,88 @@ msgid "How much do add-ons cost to purchase?"
 msgstr "How much do add-ons cost to purchase?"
 
 #: src/olympia/pages/templates/pages/faq.html:207
-msgid ""
-"Add-ons hosted in our gallery are free unless clearly marked\n"
-"    otherwise."
+msgid "Add-ons hosted in our gallery are free unless clearly marked otherwise."
 msgstr ""
 "Add-ons hosted in our gallery are free unless clearly marked\n"
 "    otherwise."
 
-#: src/olympia/pages/templates/pages/faq.html:210
+#: src/olympia/pages/templates/pages/faq.html:209
 msgid "What does it mean when an add-on asks for contributions?"
 msgstr "What does it mean when an add-on asks for contributions?"
 
-#: src/olympia/pages/templates/pages/faq.html:211
+#: src/olympia/pages/templates/pages/faq.html:210
 msgid ""
-"Some add-on authors request users who enjoy an add-on to\n"
-"        contribute to its development by making a monetary contribution. These\n"
-"        contributions go directly to the developer unless a third party is\n"
-"        indicated, such as the non-profit Mozilla Foundation."
+"Some add-on authors request users who enjoy an add-on to contribute to its development by making a monetary contribution. These contributions go directly to the developer unless a third party is "
+"indicated, such as the non-profit Mozilla Foundation."
 msgstr ""
 "Some add-on authors request users who enjoy an add-on to\n"
 "        contribute to its development by making a monetary contribution. These\n"
 "        contributions go directly to the developer unless a third party is\n"
 "        indicated, such as the non-profit Mozilla Foundation."
 
-#: src/olympia/pages/templates/pages/faq.html:216
+#: src/olympia/pages/templates/pages/faq.html:215
 msgid "What are beta add-ons?"
 msgstr "What are beta add-ons?"
 
-#: src/olympia/pages/templates/pages/faq.html:218
+#: src/olympia/pages/templates/pages/faq.html:217
 msgid ""
-"Beta add-ons are unreviewed versions which represent the\n"
-"        latest work of an add-on author. While different authors have different\n"
-"        standards for beta code quality, you should assume that these add-ons\n"
-"        are less stable than the general add-on releases."
+"Beta add-ons are unreviewed versions which represent the latest work of an add-on author. While different authors have different standards for beta code quality, you should assume that these add-"
+"ons are less stable than the general add-on releases."
 msgstr ""
 "Beta add-ons are unreviewed versions which represent the\n"
 "        latest work of an add-on author. While different authors have different\n"
 "        standards for beta code quality, you should assume that these add-ons\n"
 "        are less stable than the general add-on releases."
 
-#: src/olympia/pages/templates/pages/faq.html:222
+#: src/olympia/pages/templates/pages/faq.html:221
 msgid ""
 "Please note that when you install an add-on from the \"Beta Version\" section of an add-on's listing, you will continue to receive updates for that add-on as they become available. Like the initial "
 "version you installed, all beta releases are unreviewed by Mozilla and may harm your computer."
 msgstr ""
 "Please note that when you install an add-on from the \"Beta Version\" section of an add-on's listing, you will continue to receive updates for that add-on as they become available. Like the initial "
 "version you installed, all beta releases are unreviewed by Mozilla and may harm your computer."
+
+#: src/olympia/pages/templates/pages/faq.html:228
+msgid "What does it mean when an add-on is flagged as slow?"
+msgstr ""
+"What does it mean when an add-on is flagged as\n"
+"    slow?"
 
 #: src/olympia/pages/templates/pages/faq.html:229
-msgid ""
-"What does it mean when an add-on is flagged as\n"
-"    slow?"
-msgstr ""
-"What does it mean when an add-on is flagged as\n"
-"    slow?"
-
-#: src/olympia/pages/templates/pages/faq.html:231
-msgid ""
-"Most add-ons load code and resources at the same time Firefox\n"
-"        is starting up. In most cases the impact in start-up time is minimal,\n"
-"        but some add-ons can cause a noticeable slowdown."
+msgid "Most add-ons load code and resources at the same time Firefox is starting up. In most cases the impact in start-up time is minimal, but some add-ons can cause a noticeable slowdown."
 msgstr ""
 "Most add-ons load code and resources at the same time Firefox\n"
 "        is starting up. In most cases the impact in start-up time is minimal,\n"
 "        but some add-ons can cause a noticeable slowdown."
 
-#: src/olympia/pages/templates/pages/faq.html:236
+#: src/olympia/pages/templates/pages/faq.html:234
 msgid "How do I report an inappropriate or spam user review?"
 msgstr "How do I report an inappropriate or spam user review?"
 
-#: src/olympia/pages/templates/pages/faq.html:237
+#: src/olympia/pages/templates/pages/faq.html:235
 msgid ""
-"To report a user review of an add-on, log in with your account\n"
-"    and visit the add-on's reviews page. Find the review you wish to report,\n"
-"    click \"Report this review\" and select a reason. Our editorial team will\n"
-"    investigate the review and take appropriate action."
+"To report a user review of an add-on, log in with your account and visit the add-on's reviews page. Find the review you wish to report, click \"Report this review\" and select a reason. Our "
+"editorial team will investigate the review and take appropriate action."
 msgstr ""
 "To report a user review of an add-on, log in with your account\n"
 "    and visit the add-on's reviews page. Find the review you wish to report,\n"
 "    click \"Report this review\" and select a reason. Our editorial team will\n"
 "    investigate the review and take appropriate action."
 
-#: src/olympia/pages/templates/pages/faq.html:242
+#: src/olympia/pages/templates/pages/faq.html:240
 msgid "How do I report a bug or contact the Mozilla Add-ons team?"
 msgstr "How do I report a bug or contact the Mozilla Add-ons team?"
 
-#: src/olympia/pages/templates/pages/faq.html:243
+#: src/olympia/pages/templates/pages/faq.html:241
 #, python-format
 msgid "Please visit our <a href=\"%(contact_url)s\">Contact page</a>."
 msgstr "Please visit our <a href=\"%(contact_url)s\">Contact page</a>."
 
-#: src/olympia/pages/templates/pages/faq.html:246
+#: src/olympia/pages/templates/pages/faq.html:244
 msgid "What is a Source Code License?"
 msgstr "What is a Source Code License?"
 
-#: src/olympia/pages/templates/pages/faq.html:247
+#: src/olympia/pages/templates/pages/faq.html:245
 #, python-format
 msgid ""
 "The source code used to create an add-on is an exclusive copyright of the add-on author, unless otherwise declared in a source code license. Many add-ons on this site have <a href=\"%(url)s\" lang="
@@ -10748,40 +10571,40 @@ msgstr ""
 "\"en\">open source licenses</a> that make the source code publicly available for copy and reuse under conditions determined by the author. Most authors choose widely known open source licenses like "
 "the GPL or BSD licenses instead of making up their own."
 
-#: src/olympia/pages/templates/pages/faq.html:256
+#: src/olympia/pages/templates/pages/faq.html:254
 #, python-format
 msgid "Firefox and other Mozilla software are <a href=\"%(url)s\">open source</a>."
 msgstr "Firefox and other Mozilla software are <a href=\"%(url)s\">open source</a>."
 
-#: src/olympia/pages/templates/pages/faq.html:264
+#: src/olympia/pages/templates/pages/faq.html:262
 msgid "Collections and Favorites"
 msgstr "Collections and Favorites"
 
-#: src/olympia/pages/templates/pages/faq.html:267
+#: src/olympia/pages/templates/pages/faq.html:265
 msgid "What is a collection?"
 msgstr "What is a collection?"
 
-#: src/olympia/pages/templates/pages/faq.html:268
+#: src/olympia/pages/templates/pages/faq.html:266
 msgid "Collections are groups of related add-ons created by users to share."
 msgstr "Collections are groups of related add-ons created by users to share."
 
-#: src/olympia/pages/templates/pages/faq.html:270
+#: src/olympia/pages/templates/pages/faq.html:268
 msgid "What is the My Favorites collection?"
 msgstr "What is the My Favorites collection?"
 
-#: src/olympia/pages/templates/pages/faq.html:271
+#: src/olympia/pages/templates/pages/faq.html:269
 msgid "Favorite add-ons are add-ons that you have bookmarked to easily get back to later. You can add an add-on to your favorites collection by clicking \"Add to favorites\" on its details page."
 msgstr "Favorite add-ons are add-ons that you have bookmarked to easily get back to later. You can add an add-on to your favorites collection by clicking \"Add to favorites\" on its details page."
 
-#: src/olympia/pages/templates/pages/faq.html:275 src/olympia/templates/menu_links.html:13 src/olympia/templates/impala/header_title.html:17
+#: src/olympia/pages/templates/pages/faq.html:273 src/olympia/templates/menu_links.html:13 src/olympia/templates/impala/header_title.html:17
 msgid "Mobile Add-ons"
 msgstr "Mobile Add-ons"
 
-#: src/olympia/pages/templates/pages/faq.html:278
+#: src/olympia/pages/templates/pages/faq.html:276
 msgid "What are mobile add-ons?"
 msgstr "What are mobile add-ons?"
 
-#: src/olympia/pages/templates/pages/faq.html:279
+#: src/olympia/pages/templates/pages/faq.html:277
 #, python-format
 msgid ""
 "Mobile add-ons work with <a href=\"%(mobile_url)s\">Firefox for Mobile</a> and add or modify functionality just like desktop add-ons. You can find add-ons that work with Firefox for Mobile in our "
@@ -10790,20 +10613,20 @@ msgstr ""
 "Mobile add-ons work with <a href=\"%(mobile_url)s\">Firefox for Mobile</a> and add or modify functionality just like desktop add-ons. You can find add-ons that work with Firefox for Mobile in our "
 "<a href=\"%(gallery_url)s\">gallery</a>."
 
-#: src/olympia/pages/templates/pages/faq.html:288
+#: src/olympia/pages/templates/pages/faq.html:286
 msgid "Developer Topics"
 msgstr "Developer Topics"
 
-#: src/olympia/pages/templates/pages/faq.html:289
+#: src/olympia/pages/templates/pages/faq.html:287
 #, python-format
 msgid "Please see our <a href=\"%(faq_url)s\">Developer FAQ</a> and <a href=\"%(hub_url)s\">Developer Hub</a> for answers to add-on developer-related questions."
 msgstr "Please see our <a href=\"%(faq_url)s\">Developer FAQ</a> and <a href=\"%(hub_url)s\">Developer Hub</a> for answers to add-on developer-related questions."
 
-#: src/olympia/pages/templates/pages/faq.html:294
+#: src/olympia/pages/templates/pages/faq.html:292
 msgid "Still have questions?"
 msgstr "Still have questions?"
 
-#: src/olympia/pages/templates/pages/faq.html:295
+#: src/olympia/pages/templates/pages/faq.html:293
 #, python-format
 msgid "For general Firefox support, visit our <a href=\"%(sumo_url)s\">support website</a>. For general add-on and website questions, visit our <a href=\"%(forum_url)s\">forum</a>."
 msgstr "For general Firefox support, visit our <a href=\"%(sumo_url)s\">support website</a>. For general add-on and website questions, visit our <a href=\"%(forum_url)s\">forum</a>."
@@ -10951,7 +10774,7 @@ msgstr "Sunbird has retired"
 
 #: src/olympia/pages/templates/pages/sunbird.html:29
 msgid ""
-"Development on the Sunbird project has halted and its final release was on March 30, 2010.  We've been proud to host Sunbird add-ons on this site but as the project is no longer maintained we have "
+"Development on the Sunbird project has halted and its final release was on March 30, 2010. We've been proud to host Sunbird add-ons on this site but as the project is no longer maintained we have "
 "disabled our support for the add-ons."
 msgstr ""
 "Development on the Sunbird project has halted and its final release was on March 30, 2010.  We've been proud to host Sunbird add-ons on this site but as the project is no longer maintained we have "
@@ -11031,7 +10854,7 @@ msgstr "Add a review for {0}"
 #, python-format
 msgid ""
 "<h2>Keep these tips in mind:</h2> <ul> <li> Write like you're telling a friend about your experience with the add-on. Give specifics and helpful details, such as what features you liked and/or "
-"disliked, how easy to use it is, and any disadvantages it has.  Avoid generic language such as calling it \"Great\" or \"Bad\" unless you can give reasons why you believe this is so. </li> <li> "
+"disliked, how easy to use it is, and any disadvantages it has. Avoid generic language such as calling it \"Great\" or \"Bad\" unless you can give reasons why you believe this is so. </li> <li> "
 "Please do not post bug reports in reviews. We do not make your email address available to add-on developers and they may need to contact you to help resolve your issue. See the <a href=\"%(support)s"
 "\">support section</a> to find out where to get assistance for this add-on. </li> <li>Please keep reviews clean, avoid the use of improper language and do not post any personal information. </li> </"
 "ul> <p>Please read the <a href=\"%(guide)s\" target=\"_blank\">Review Guidelines</a> for more detail about user add-on reviews.</p>"
@@ -11288,16 +11111,16 @@ msgstr "{0} Add-ons"
 
 #. L10n: {0} is an application, such as Firefox. This means "any version of
 #. Firefox."
-#: src/olympia/search/views.py:554
+#: src/olympia/search/views.py:547
 msgid "Any {0}"
 msgstr "Any {0}"
 
 #. L10n: "All Systems" means show everything regardless of platform.
-#: src/olympia/search/views.py:589
+#: src/olympia/search/views.py:582
 msgid "All Systems"
 msgstr "All Systems"
 
-#: src/olympia/search/views.py:600
+#: src/olympia/search/views.py:593
 msgid "All Tags"
 msgstr "All Tags"
 
@@ -11471,31 +11294,31 @@ msgstr "Share this Add-on"
 msgid "Share this Collection"
 msgstr "Share this Collection"
 
-#: src/olympia/signing/views.py:30 src/olympia/templates/base.html:75 src/olympia/templates/impala/base.html:115
+#: src/olympia/signing/views.py:33 src/olympia/templates/base.html:71 src/olympia/templates/impala/base.html:112
 msgid "Some features are temporarily disabled while we perform website maintenance. We'll be back to full capacity shortly."
 msgstr "Some features are temporarily disabled while we perform website maintenance. We'll be back to full capacity shortly."
 
-#: src/olympia/signing/views.py:53
+#: src/olympia/signing/views.py:56
 msgid "Could not find add-on with id \"{}\"."
 msgstr "Could not find add-on with id \"{}\"."
 
-#: src/olympia/signing/views.py:67
+#: src/olympia/signing/views.py:70
 msgid "You do not own this addon."
 msgstr "You do not own this addon."
 
-#: src/olympia/signing/views.py:82
+#: src/olympia/signing/views.py:87
 msgid "Missing \"upload\" key in multipart file data."
 msgstr "Missing \"upload\" key in multipart file data."
 
-#: src/olympia/signing/views.py:96
+#: src/olympia/signing/views.py:101
 msgid "Version does not match the manifest file."
 msgstr "Version does not match the manifest file."
 
-#: src/olympia/signing/views.py:100
+#: src/olympia/signing/views.py:105
 msgid "Version already exists."
 msgstr "Version already exists."
 
-#: src/olympia/signing/views.py:136
+#: src/olympia/signing/views.py:141
 msgid "No uploaded file for that addon and version."
 msgstr "No uploaded file for that addon and version."
 
@@ -11608,90 +11431,90 @@ msgstr "{0} :: Statistics Dashboard"
 msgid "Statistics Dashboard :: Add-ons for {0}"
 msgstr "Statistics Dashboard :: Add-ons for {0}"
 
-#: src/olympia/stats/templates/stats/stats.html:30
-msgid "Controls:"
-msgstr "Controls:"
-
-#: src/olympia/stats/templates/stats/stats.html:33
-msgid "reset zoom"
-msgstr "reset zoom"
-
-#: src/olympia/stats/templates/stats/stats.html:40
-msgid "Group by:"
-msgstr "Group by:"
-
-#: src/olympia/stats/templates/stats/stats.html:42
-msgid "day"
-msgstr "day"
-
-#: src/olympia/stats/templates/stats/stats.html:45
-msgid "week"
-msgstr "week"
-
-#: src/olympia/stats/templates/stats/stats.html:48
-msgid "month"
-msgstr "month"
-
-#: src/olympia/stats/templates/stats/stats.html:54
-msgid "For last:"
-msgstr "For last:"
-
-#: src/olympia/stats/templates/stats/stats.html:57
-msgid "7 days"
-msgstr "7 days"
-
-#: src/olympia/stats/templates/stats/stats.html:60
-msgid "30 days"
-msgstr "30 days"
-
-#: src/olympia/stats/templates/stats/stats.html:63
-msgid "90 days"
-msgstr "90 days"
-
-#: src/olympia/stats/templates/stats/stats.html:66
-msgid "365 days"
-msgstr "365 days"
-
-#: src/olympia/stats/templates/stats/stats.html:69
-msgid "Custom..."
-msgstr "Custom..."
-
 # %1 is the name of a collection
 #. {0} is an add-on name
-#: src/olympia/stats/templates/stats/stats.html:88 src/olympia/stats/templates/stats/stats.html:91
+#: src/olympia/stats/templates/stats/stats.html:44 src/olympia/stats/templates/stats/stats.html:47
 msgid "Statistics for {0}"
 msgstr "Statistics for {0}"
 
-#: src/olympia/stats/templates/stats/stats.html:94
+#: src/olympia/stats/templates/stats/stats.html:50
 msgid "Statistics Dashboard"
 msgstr "Statistics Dashboard"
 
-#: src/olympia/stats/templates/stats/stats.html:104
+#: src/olympia/stats/templates/stats/stats.html:57
+msgid "Controls:"
+msgstr "Controls:"
+
+#: src/olympia/stats/templates/stats/stats.html:60
+msgid "reset zoom"
+msgstr "reset zoom"
+
+#: src/olympia/stats/templates/stats/stats.html:67
+msgid "Group by:"
+msgstr "Group by:"
+
+#: src/olympia/stats/templates/stats/stats.html:69
+msgid "day"
+msgstr "day"
+
+#: src/olympia/stats/templates/stats/stats.html:72
+msgid "week"
+msgstr "week"
+
+#: src/olympia/stats/templates/stats/stats.html:75
+msgid "month"
+msgstr "month"
+
+#: src/olympia/stats/templates/stats/stats.html:81
+msgid "For last:"
+msgstr "For last:"
+
+#: src/olympia/stats/templates/stats/stats.html:84
+msgid "7 days"
+msgstr "7 days"
+
+#: src/olympia/stats/templates/stats/stats.html:87
+msgid "30 days"
+msgstr "30 days"
+
+#: src/olympia/stats/templates/stats/stats.html:90
+msgid "90 days"
+msgstr "90 days"
+
+#: src/olympia/stats/templates/stats/stats.html:93
+msgid "365 days"
+msgstr "365 days"
+
+#: src/olympia/stats/templates/stats/stats.html:96
+msgid "Custom..."
+msgstr "Custom..."
+
+#: src/olympia/stats/templates/stats/stats.html:106
 msgid "Statistics processing is currently disabled, so recent data is unavailable. The statistics are still being collected and this page will be updated soon with the missing data."
 msgstr "Statistics processing is currently disabled, so recent data is unavailable. The statistics are still being collected and this page will be updated soon with the missing data."
 
-#: src/olympia/stats/templates/stats/stats.html:110
+#: src/olympia/stats/templates/stats/stats.html:112
 msgid "Loading the latest data&hellip;"
 msgstr "Loading the latest data&hellip;"
 
-#: src/olympia/stats/templates/stats/stats.html:142 src/olympia/stats/templates/stats/reports/overview.html:25 src/olympia/stats/templates/stats/reports/overview.html:37
+#: src/olympia/stats/templates/stats/stats.html:144 src/olympia/stats/templates/stats/reports/overview.html:25 src/olympia/stats/templates/stats/reports/overview.html:37
 #: src/olympia/stats/templates/stats/reports/overview.html:49
 msgid "No data available."
 msgstr "No data available."
 
-#: src/olympia/stats/templates/stats/stats.html:177
+#: src/olympia/stats/templates/stats/stats.html:179
 msgid "This dashboard is currently <b>public</b>."
 msgstr "This dashboard is currently <b>public</b>."
 
-#: src/olympia/stats/templates/stats/stats.html:179
+#: src/olympia/stats/templates/stats/stats.html:181
 msgid "Contribution stats are currently <b>private</b>."
 msgstr "Contribution stats are currently <b>private</b>."
 
-#: src/olympia/stats/templates/stats/stats.html:182
+#: src/olympia/stats/templates/stats/stats.html:184
 msgid "This dashboard is currently <b>private</b>."
 msgstr "This dashboard is currently <b>private</b>."
 
-#: src/olympia/stats/templates/stats/stats.html:185
+#: src/olympia/stats/templates/stats/stats.html:187
 msgid "Change settings."
 msgstr "Change settings."
 
@@ -11854,16 +11677,6 @@ msgstr "User Signups by Date"
 msgid "Application versions by Date"
 msgstr "Application versions by Date"
 
-# {0} is a number
-#: src/olympia/tags/templates/tags/top_cloud.html:4
-msgid "Top {0} Tags"
-msgstr "Top {0} Tags"
-
-#. {0} is the current application name
-#: src/olympia/tags/templates/tags/top_cloud.html:14
-msgid "{0} Top Tags"
-msgstr "{0} Top Tags"
-
 #: src/olympia/templates/amo_footer.html:6 src/olympia/templates/includes/lang_switcher.html:2
 msgid "Other languages"
 msgstr "Other languages"
@@ -11872,11 +11685,11 @@ msgstr "Other languages"
 msgid "Mozilla Add-ons"
 msgstr "Mozilla Add-ons"
 
-#: src/olympia/templates/base.html:91 src/olympia/templates/impala/base.html:81
+#: src/olympia/templates/base.html:89 src/olympia/templates/impala/base.html:78
 msgid "Find add-ons for other applications"
 msgstr "Find add-ons for other applications"
 
-#: src/olympia/templates/base.html:92 src/olympia/templates/impala/base.html:81
+#: src/olympia/templates/base.html:90 src/olympia/templates/impala/base.html:78
 msgid "Other Applications"
 msgstr "Other Applications"
 
@@ -11901,7 +11714,7 @@ msgid "View Mobile Site"
 msgstr "View Mobile Site"
 
 #: src/olympia/templates/copyright.html:7
-msgid "Site Status "
+msgid "Site Status"
 msgstr "Site Status "
 
 #: src/olympia/templates/footer.html:3
@@ -12003,35 +11816,35 @@ msgstr "Welcome, {0}"
 msgid "<a href=\"%(reg)s\">Register</a> or <a href=\"%(login)s\">Log in</a>"
 msgstr "<a href=\"%(reg)s\">Register</a> or <a href=\"%(login)s\">Log in</a>"
 
-#: src/olympia/templates/impala/base.html:126
+#: src/olympia/templates/impala/base.html:123
 #, python-format
 msgid "To try the thousands of add-ons available here, download <a href=\"%(url)s\">Mozilla Firefox</a>, a fast, free way to surf the Web!"
 msgstr "To try the thousands of add-ons available here, download <a href=\"%(url)s\">Mozilla Firefox</a>, a fast, free way to surf the Web!"
 
-#: src/olympia/templates/impala/base.html:138
+#: src/olympia/templates/impala/base.html:135
 #, python-format
 msgid "Add-ons is switching to Firefox Accounts for login. <a href=\"%(url)s\" class=\"fxa-login\">Sign in now to transfer your account.</a>"
 msgstr "Add-ons is switching to Firefox Accounts for login. <a href=\"%(url)s\" class=\"fxa-login\">Sign in now to transfer your account.</a>"
 
 #. {0} is an application, such as Firefox.
-#: src/olympia/templates/impala/base.html:148
+#: src/olympia/templates/impala/base.html:145
 msgid "Welcome to {0} Add-ons."
 msgstr "Welcome to {0} Add-ons."
 
-#: src/olympia/templates/impala/base.html:151
+#: src/olympia/templates/impala/base.html:148
 msgid "Choose from thousands of extra features and styles to make Firefox your own."
 msgstr "Choose from thousands of extra features and styles to make Firefox your own."
 
-#: src/olympia/templates/impala/base.html:156
+#: src/olympia/templates/impala/base.html:153
 #, python-format
 msgid "Add extra features and styles to make %(app)s your own."
 msgstr "Add extra features and styles to make %(app)s your own."
 
-#: src/olympia/templates/impala/base.html:164
+#: src/olympia/templates/impala/base.html:161
 msgid "On the go?"
 msgstr "On the go?"
 
-#: src/olympia/templates/impala/base.html:166
+#: src/olympia/templates/impala/base.html:163
 msgid "Check out our <a class=\"mobile-link\" href=\"#\">Mobile Add-ons site</a>."
 msgstr "Check out our <a class=\"mobile-link\" href=\"#\">Mobile Add-ons site</a>."
 
@@ -12255,19 +12068,19 @@ msgstr "No user with that email."
 
 #. L10n: {id} will be something like "13ad6a", just a random number
 #. to differentiate this user from other anonymous users.
-#: src/olympia/users/models.py:353
+#: src/olympia/users/models.py:362
 msgid "Anonymous user {id}"
 msgstr "Anonymous user {id}"
 
-#: src/olympia/users/models.py:410
+#: src/olympia/users/models.py:419
 msgid "Your account has been restricted"
 msgstr "Your account has been restricted"
 
-#: src/olympia/users/models.py:480
+#: src/olympia/users/models.py:489
 msgid "Please confirm your email address"
 msgstr "Please confirm your email address"
 
-#: src/olympia/users/models.py:506
+#: src/olympia/users/models.py:515
 msgid "My Mobile Add-ons"
 msgstr "My Mobile Add-ons"
 
@@ -12551,7 +12364,7 @@ msgstr "Password"
 
 #: src/olympia/users/templates/users/edit.html:70
 #, python-format
-msgid "Change your password.  If you forgot your password, you can <a href=\"%(reset_url)s\">use the reset form</a>."
+msgid "Change your password. If you forgot your password, you can <a href=\"%(reset_url)s\">use the reset form</a>."
 msgstr "Change your password.  If you forgot your password, you can <a href=\"%(reset_url)s\">use the reset form</a>."
 
 #: src/olympia/users/templates/users/edit.html:76
@@ -12571,7 +12384,7 @@ msgid "Profile"
 msgstr "Profile"
 
 #: src/olympia/users/templates/users/edit.html:100
-msgid "Give us a bit more information about yourself.  All these fields are optional, but they'll help other users get to know you better."
+msgid "Give us a bit more information about yourself. All these fields are optional, but they'll help other users get to know you better."
 msgstr "Give us a bit more information about yourself.  All these fields are optional, but they'll help other users get to know you better."
 
 #: src/olympia/users/templates/users/edit.html:124
@@ -12791,7 +12604,7 @@ msgid "Confirm password"
 msgstr "Confirm password"
 
 #: src/olympia/users/templates/users/pwreset_confirm.html:47
-msgid "The password reset link was invalid, possibly because it has already been used.  Please request a new password reset."
+msgid "The password reset link was invalid, possibly because it has already been used. Please request a new password reset."
 msgstr "The password reset link was invalid, possibly because it has already been used.  Please request a new password reset."
 
 #: src/olympia/users/templates/users/pwreset_request.html:15
@@ -12980,7 +12793,7 @@ msgstr "We could not unsubscribe you"
 
 #: src/olympia/users/templates/users/unsubscribe.html:30
 #, python-format
-msgid "Unfortunately, we weren't able to unsubscribe you.  The link you clicked is invalid. However, you can unsubscribe still unsubscribe on your <a href=\"%(edit_url)s\">edit profile page</a>."
+msgid "Unfortunately, we weren't able to unsubscribe you. The link you clicked is invalid. However, you can unsubscribe still unsubscribe on your <a href=\"%(edit_url)s\">edit profile page</a>."
 msgstr "Unfortunately, we weren't able to unsubscribe you.  The link you clicked is invalid. However, you can unsubscribe still unsubscribe on your <a href=\"%(edit_url)s\">edit profile page</a>."
 
 #: src/olympia/users/templates/users/vcard.html:2
@@ -13034,15 +12847,15 @@ msgstr "%s Version History"
 msgid "Version History with Changelogs"
 msgstr "Version History with Changelogs"
 
-#: src/olympia/versions/models.py:314
+#: src/olympia/versions/models.py:313
 msgid "Add-on uses binary components."
 msgstr "Add-on uses binary components."
 
-#: src/olympia/versions/models.py:317
+#: src/olympia/versions/models.py:316
 msgid "Add-on has opted into strict compatibility checking."
 msgstr "Add-on has opted into strict compatibility checking."
 
-#: src/olympia/versions/models.py:715
+#: src/olympia/versions/models.py:711
 msgid "{app} {min} and later"
 msgstr "{app} {min} and later"
 
@@ -13119,3 +12932,7 @@ msgstr "Email when finished"
 #: src/olympia/zadmin/forms.py:105
 msgid "Log emails instead of sending"
 msgstr "Log emails instead of sending"
+
+#: src/olympia/zadmin/forms.py:215
+msgid "Deleted versions can`t be changed."
+msgstr "Deleted versions can`t be changed."

--- a/locale/en_US/LC_MESSAGES/djangojs.po
+++ b/locale/en_US/LC_MESSAGES/djangojs.po
@@ -1,136 +1,392 @@
-
 msgid ""
 msgstr ""
 "Project-Id-Version: AMO-JS 0.1\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2016-02-24 21:23+0000\n"
+"POT-Creation-Date: 2016-04-18 15:47+0000\n"
 "PO-Revision-Date: 2009-02-26 15:08-0800\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
+"Language: \n"
 "MIME-Version: 1.0\n"
-"Content-Type: text/plain; charset=utf-8\n"
+"Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Generated-By: Babel 2.2.0\n"
 
-#: static/js/common/ratingwidget.js:31
+#: static/js/common-all.js:1426 static/js/impala-all.js:1511 static/js/zamboni/discovery-all.js:12598 static/js/zamboni/init.js:28 static/js/zamboni/mobile-all.js:14945
+msgid "This feature is temporarily disabled while we perform website maintenance. Please check back a little later."
+msgstr "This feature is temporarily disabled while we perform website maintenance. Please check back a little later."
+
+#. L10n: {0} is an app name like Firefox.
+#: static/js/common-all.js:1837 static/js/impala-all.js:1922 static/js/zamboni/buttons.js:73 static/js/zamboni/discovery-all.js:13108
+msgid "Accept and Install"
+msgstr "Accept and Install"
+
+#: static/js/common-all.js:1837 static/js/impala-all.js:1922 static/js/zamboni/buttons.js:73 static/js/zamboni/discovery-all.js:13108
+msgid "Add to {0}"
+msgstr "Add to {0}"
+
+#: static/js/common-all.js:1842 static/js/impala-all.js:1927 static/js/zamboni/buttons.js:78 static/js/zamboni/discovery-all.js:13113
+msgid "Download Now"
+msgstr "Download Now"
+
+#: static/js/common-all.js:1883 static/js/impala-all.js:1968 static/js/zamboni/buttons.js:119 static/js/zamboni/discovery-all.js:13154
+msgid "Add-on has not been updated to support default-to-compatible."
+msgstr "Add-on has not been updated to support default-to-compatible."
+
+#: static/js/common-all.js:1888 static/js/impala-all.js:1973 static/js/zamboni/buttons.js:124 static/js/zamboni/discovery-all.js:13159
+msgid "You need to be using Firefox 10.0 or higher."
+msgstr "You need to be using Firefox 10.0 or higher."
+
+#: static/js/common-all.js:1900 static/js/impala-all.js:1985 static/js/zamboni/buttons.js:136 static/js/zamboni/discovery-all.js:13171
+msgid "Mozilla has marked this version as incompatible with your Firefox version."
+msgstr "Mozilla has marked this version as incompatible with your Firefox version."
+
+#. L10n: {0} is an platform like Windows or Linux.
+#: static/js/common-all.js:1981 static/js/impala-all.js:2066 static/js/zamboni/buttons.js:217 static/js/zamboni/discovery-all.js:13252
+msgid "Install for {0} anyway"
+msgstr "Install for {0} anyway"
+
+#: static/js/common-all.js:1981 static/js/impala-all.js:2066 static/js/zamboni/buttons.js:217 static/js/zamboni/discovery-all.js:13252
+msgid "Download for {0} anyway"
+msgstr "Download for {0} anyway"
+
+#: static/js/common-all.js:2038 static/js/impala-all.js:2123 static/js/zamboni/buttons.js:274 static/js/zamboni/discovery-all.js:13309
+msgid "Not available for your platform"
+msgstr "Not available for your platform"
+
+#. L10n: {0} is an app name, {1} is the app version.
+#: static/js/common-all.js:2049 static/js/common-all.js:2086 static/js/impala-all.js:2134 static/js/impala-all.js:2171 static/js/zamboni/buttons.js:286 static/js/zamboni/buttons.js:324
+#: static/js/zamboni/discovery-all.js:13320 static/js/zamboni/discovery-all.js:13357
+msgid "Not available for {0} {1}"
+msgstr "Not available for {0} {1}"
+
+#: static/js/common-all.js:2112 static/js/impala-all.js:2197 static/js/zamboni/buttons.js:351 static/js/zamboni/discovery-all.js:13383
+msgid "Works with {app} {min} - {max}"
+msgstr "Works with {app} {min} - {max}"
+
+#: static/js/common-all.js:2114 static/js/impala-all.js:2199 static/js/zamboni/buttons.js:353 static/js/zamboni/discovery-all.js:13385
+msgid "View other versions"
+msgstr "View other versions"
+
+#: static/js/common-all.js:2162 static/js/impala-all.js:2247 static/js/zamboni/buttons.js:401 static/js/zamboni/discovery-all.js:13433
+msgid "Only with Firefox — Get Firefox Now!"
+msgstr "Only with Firefox — Get Firefox Now!"
+
+#: static/js/common-all.js:2278 static/js/impala-all.js:2363 static/js/zamboni/buttons.js:517 static/js/zamboni/discovery-all.js:13549 static/js/zamboni/mobile-all.js:15177
+#: static/js/zamboni/mobile/buttons.js:43
+msgid "Sorry, you need a Mozilla-based browser (such as Firefox) to install a search plugin."
+msgstr "Sorry, you need a Mozilla-based browser (such as Firefox) to install a search plugin."
+
+#: static/js/common-all.js:9088 static/js/impala-all.js:9649 static/js/zamboni/global.js:410
+msgid "Loading..."
+msgstr "Loading..."
+
+#. L10n: {0} is the number of characters left.
+#: static/js/common-all.js:9152 static/js/impala-all.js:9713 static/js/zamboni/global.js:474
+msgid "<b>{0}</b> character left."
+msgid_plural "<b>{0}</b> characters left."
+msgstr[0] "<b>{0}</b> character left."
+msgstr[1] "<b>{0}</b> characters left."
+
+#: static/js/common-all.js:9589 static/js/common-min.js:6 static/js/impala-all.js:10052 static/js/impala-min.js:6 static/js/common/ratingwidget.js:31 static/js/zamboni/mobile-all.js:16123
+#: static/js/zamboni/mobile-min.js:6
 msgid "{0} star"
 msgid_plural "{0} stars"
 msgstr[0] "{0} star"
 msgstr[1] "{0} stars"
 
-#: static/js/common/upload-addon.js:41 static/js/common/upload-image.js:128
+#: static/js/common-all.js:9676 static/js/common-min.js:6 static/js/impala-all.js:10139 static/js/impala-min.js:6 static/js/zamboni/l10n.js:45
+msgid "Remove this localization"
+msgstr "Remove this localization"
+
+#: static/js/common-all.js:10193 static/js/common-min.js:6 static/js/impala-all.js:10674 static/js/impala-min.js:6 static/js/zamboni/discovery-all.js:13678
+msgid "close"
+msgstr "close"
+
+#: static/js/common-all.js:10860 static/js/common-min.js:6 static/js/impala-all.js:11481 static/js/impala-min.js:6 static/js/impala/reviews.js:23 static/js/zamboni/reviews.js:18
+msgid "Flagged for review"
+msgstr "Flagged for review"
+
+#: static/js/common-all.js:10876 static/js/common-min.js:6 static/js/impala-all.js:11498 static/js/impala-min.js:6 static/js/impala/reviews.js:40 static/js/zamboni/reviews.js:34
+msgid "Your input is required"
+msgstr "Your input is required"
+
+#: static/js/common-all.js:10945 static/js/common-min.js:6 static/js/impala-all.js:11610 static/js/impala-min.js:7 static/js/impala/reviews.js:152 static/js/zamboni/reviews.js:103
+msgid "Marked for deletion"
+msgstr "Marked for deletion"
+
+#: static/js/common-all.js:11573 static/js/common-min.js:7 static/js/impala-all.js:13809 static/js/impala-min.js:8 static/js/zamboni/collections.js:229
+msgid "Adding to Favorites&hellip;"
+msgstr "Adding to Favorites&hellip;"
+
+#: static/js/common-all.js:11576 static/js/common-min.js:7 static/js/impala-all.js:13812 static/js/impala-min.js:8 static/js/zamboni/collections.js:232
+msgid "Removing Favorite&hellip;"
+msgstr "Removing Favorite&hellip;"
+
+#: static/js/common-all.js:11579 static/js/common-min.js:7 static/js/impala-all.js:13815 static/js/impala-min.js:8 static/js/zamboni/collections.js:235
+msgid "Add to Favorites"
+msgstr "Add to Favorites"
+
+#: static/js/common-all.js:11582 static/js/common-min.js:7 static/js/impala-all.js:13818 static/js/impala-min.js:8 static/js/zamboni/collections.js:238
+msgid "Remove from Favorites"
+msgstr "Remove from Favorites"
+
+#: static/js/common-all.js:11647 static/js/common-min.js:7 static/js/impala-all.js:13883 static/js/impala-min.js:8 static/js/zamboni/collections.js:303
+msgid "Pending"
+msgstr "Pending"
+
+#: static/js/common-all.js:11648 static/js/common-min.js:7 static/js/impala-all.js:13884 static/js/impala-min.js:8 static/js/zamboni/collections.js:304
+msgid "Add a comment"
+msgstr "Add a comment"
+
+#: static/js/common-all.js:11648 static/js/common-min.js:7 static/js/impala-all.js:13884 static/js/impala-min.js:8 static/js/zamboni/collections.js:304
+msgid "Comment"
+msgstr "Comment"
+
+#: static/js/common-all.js:11649 static/js/common-min.js:7 static/js/impala-all.js:13885 static/js/impala-min.js:8 static/js/zamboni/collections.js:305
+msgid "Remove this add-on from the collection"
+msgstr "Remove this add-on from the collection"
+
+#: static/js/common-all.js:11649 static/js/common-all.js:11678 static/js/common-min.js:7 static/js/impala-all.js:13885 static/js/impala-all.js:13914 static/js/impala-min.js:8
+#: static/js/zamboni/collections.js:305 static/js/zamboni/collections.js:334
+msgid "Remove"
+msgstr "Remove"
+
+#: static/js/common-all.js:11678 static/js/common-min.js:7 static/js/impala-all.js:13914 static/js/impala-min.js:8 static/js/zamboni/collections.js:334
+msgid "Remove this user as a contributor"
+msgstr "Remove this user as a contributor"
+
+#: static/js/common-all.js:11690 static/js/common-min.js:7 static/js/impala-all.js:13926 static/js/impala-min.js:8 static/js/zamboni/collections.js:346
+msgid "An email address is required."
+msgstr "An email address is required."
+
+#: static/js/common-all.js:11708 static/js/common-min.js:7 static/js/impala-all.js:13944 static/js/impala-min.js:8 static/js/zamboni/collections.js:364
+msgid "You cannot add yourself as a contributor."
+msgstr "You cannot add yourself as a contributor."
+
+#: static/js/common-all.js:11710 static/js/common-min.js:7 static/js/impala-all.js:13946 static/js/impala-min.js:8 static/js/zamboni/collections.js:366
+msgid "You have already added that user."
+msgstr "You have already added that user."
+
+#: static/js/common-all.js:11917 static/js/common-min.js:7 static/js/impala-all.js:14153 static/js/impala-min.js:8 static/js/zamboni/collections.js:573
+msgid "Add to favorites"
+msgstr "Add to favorites"
+
+#: static/js/common-all.js:11921 static/js/common-min.js:7 static/js/impala-all.js:14157 static/js/impala-min.js:8 static/js/zamboni/collections.js:577
+msgid "Remove from favorites"
+msgstr "Remove from favorites"
+
+#: static/js/common-all.js:11939 static/js/common-min.js:7 static/js/impala-all.js:14175 static/js/impala-all.js:14233 static/js/impala-min.js:8 static/js/impala/collections.js:10
+#: static/js/zamboni/collections.js:595
+msgid "Follow this Collection"
+msgstr "Follow this Collection"
+
+#: static/js/common-all.js:11948 static/js/common-min.js:7 static/js/impala-all.js:14184 static/js/impala-min.js:8 static/js/zamboni/collections.js:604
+msgid "Stop following"
+msgstr "Stop following"
+
+#: static/js/common-all.js:12096 static/js/common-min.js:7 static/js/zamboni/password-strength.js:20
+msgid "Password strength:"
+msgstr "Password strength:"
+
+#: static/js/common-all.js:12102 static/js/common-min.js:7 static/js/zamboni/password-strength.js:26
+msgid "At least {0} character left."
+msgid_plural "At least {0} characters left."
+msgstr[0] "At least {0} character left."
+msgstr[1] "At least {0} characters left."
+
+#: static/js/common-all.js:12286 static/js/common-min.js:7 static/js/impala-all.js:14632 static/js/impala-min.js:8 static/js/impala/suggestions.js:39
+msgid "Search themes for <b>{0}</b>"
+msgstr "Search themes for <b>{0}</b>"
+
+#: static/js/common-all.js:12288 static/js/common-min.js:7 static/js/impala-all.js:14634 static/js/impala-min.js:8 static/js/impala/suggestions.js:41
+msgid "Search apps for <b>{0}</b>"
+msgstr "Search apps for <b>{0}</b>"
+
+#: static/js/common-all.js:12290 static/js/common-min.js:7 static/js/impala-all.js:14636 static/js/impala-min.js:8 static/js/impala/suggestions.js:43
+msgid "Search add-ons for <b>{0}</b>"
+msgstr "Search add-ons for <b>{0}</b>"
+
+#: static/js/common-all.js:12521 static/js/common-min.js:7 static/js/impala-all.js:14867 static/js/impala-min.js:8 static/js/impala/site_suggestions.js:46
+msgid "Category"
+msgstr "Category"
+
+#. L10n: {0} is an app name.
+#: static/js/impala-all.js:11632 static/js/impala-min.js:7 static/js/impala/listing.js:11 static/js/zamboni/themes.js:13
+msgid "This theme is incompatible with your version of {0}"
+msgstr "This theme is incompatible with your version of {0}"
+
+#: static/js/impala-all.js:12146 static/js/impala-all.js:14331 static/js/impala-min.js:7 static/js/impala-min.js:8 static/js/common/upload-image.js:97 static/js/impala/users.js:51
+#: static/js/zamboni/devhub-all.js:894 static/js/zamboni/devhub-min.js:1
+msgid "Images must be either PNG or JPG."
+msgstr "Images must be either PNG or JPG."
+
+#: static/js/impala-all.js:12150 static/js/impala-min.js:7 static/js/common/upload-image.js:101 static/js/zamboni/devhub-all.js:898 static/js/zamboni/devhub-min.js:1
+msgid "Videos must be in WebM."
+msgstr "Videos must be in WebM."
+
+#: static/js/impala-all.js:12177 static/js/impala-min.js:7 static/js/common/upload-addon.js:41 static/js/common/upload-image.js:128 static/js/zamboni/devhub-all.js:272
+#: static/js/zamboni/devhub-all.js:925 static/js/zamboni/devhub-min.js:1
 msgid "There was a problem contacting the server."
 msgstr "There was a problem contacting the server."
 
-#: static/js/common/upload-addon.js:69
+#: static/js/impala-all.js:13298 static/js/impala-min.js:7 static/js/impala/persona_creation.js:60
+msgid "All Rights Reserved"
+msgstr "All Rights Reserved"
+
+#: static/js/impala-all.js:13302 static/js/impala-min.js:7 static/js/impala/persona_creation.js:64
+msgid "Creative Commons Attribution 3.0"
+msgstr "Creative Commons Attribution 3.0"
+
+#: static/js/impala-all.js:13307 static/js/impala-min.js:7 static/js/impala/persona_creation.js:69
+msgid "Creative Commons Attribution-NonCommercial 3.0"
+msgstr "Creative Commons Attribution-NonCommercial 3.0"
+
+#: static/js/impala-all.js:13312 static/js/impala-min.js:7 static/js/impala/persona_creation.js:74
+msgid "Creative Commons Attribution-NonCommercial-NoDerivs 3.0"
+msgstr "Creative Commons Attribution-NonCommercial-NoDerivs 3.0"
+
+#: static/js/impala-all.js:13317 static/js/impala-min.js:7 static/js/impala/persona_creation.js:79
+msgid "Creative Commons Attribution-NonCommercial-Share Alike 3.0"
+msgstr "Creative Commons Attribution-NonCommercial-Share Alike 3.0"
+
+#: static/js/impala-all.js:13322 static/js/impala-min.js:7 static/js/impala/persona_creation.js:84
+msgid "Creative Commons Attribution-NoDerivs 3.0"
+msgstr "Creative Commons Attribution-NoDerivs 3.0"
+
+#: static/js/impala-all.js:13327 static/js/impala-min.js:7 static/js/impala/persona_creation.js:89
+msgid "Creative Commons Attribution-ShareAlike 3.0"
+msgstr "Creative Commons Attribution-ShareAlike 3.0"
+
+#: static/js/impala-all.js:13530 static/js/impala-min.js:7 static/js/impala/persona_creation.js:292
+msgid "Your Theme's Name"
+msgstr "Your Theme's Name"
+
+#: static/js/impala-all.js:14242 static/js/impala-min.js:8 static/js/impala/collections.js:19
+msgid "Stop Following"
+msgstr "Stop Following"
+
+#: static/js/impala-all.js:14243 static/js/impala-min.js:8 static/js/impala/collections.js:20
+msgid "Following"
+msgstr "Following"
+
+#: static/js/impala-all.js:14313 static/js/impala-min.js:8 static/js/impala/users.js:33
+msgid "use original"
+msgstr "use original"
+
+#: static/js/impala-all.js:14523 static/js/impala-min.js:8 static/js/impala/search.js:114
+msgid "Updating results&hellip;"
+msgstr "Updating results&hellip;"
+
+#: static/js/common/upload-addon.js:69 static/js/zamboni/devhub-all.js:300 static/js/zamboni/devhub-min.js:1
 msgid "Select a file..."
 msgstr "Select a file..."
 
-#: static/js/common/upload-addon.js:70
+#: static/js/common/upload-addon.js:70 static/js/zamboni/devhub-all.js:301 static/js/zamboni/devhub-min.js:1
 msgid "Your add-on should end with .xpi, .jar or .xml"
 msgstr "Your add-on should end with .xpi, .jar or .xml"
 
 #. L10n: {0} is the percent of the file that has been uploaded.
-#: static/js/common/upload-addon.js:104
+#: static/js/common/upload-addon.js:104 static/js/zamboni/devhub-all.js:335 static/js/zamboni/devhub-min.js:1
 #, python-format
 msgid "{0}% complete"
 msgstr "{0}% complete"
 
 #. L10n: "{bytes uploaded} of {total filesize}".
-#: static/js/common/upload-addon.js:107
+#: static/js/common/upload-addon.js:107 static/js/zamboni/devhub-all.js:338 static/js/zamboni/devhub-min.js:1
 msgid "{0} of {1}"
 msgstr "{0} of {1}"
 
-#: static/js/common/upload-addon.js:140
+#: static/js/common/upload-addon.js:140 static/js/zamboni/devhub-all.js:371 static/js/zamboni/devhub-min.js:1
 msgid "Cancel"
 msgstr "Cancel"
 
-#: static/js/common/upload-addon.js:162
+#: static/js/common/upload-addon.js:162 static/js/zamboni/devhub-all.js:393 static/js/zamboni/devhub-min.js:1
 msgid "Uploading {0}"
 msgstr "Uploading {0}"
 
-#: static/js/common/upload-addon.js:189
+#: static/js/common/upload-addon.js:189 static/js/zamboni/devhub-all.js:420 static/js/zamboni/devhub-min.js:1
 msgid "Error with {0}"
 msgstr "Error with {0}"
 
-#: static/js/common/upload-addon.js:194
+#: static/js/common/upload-addon.js:194 static/js/zamboni/devhub-all.js:425 static/js/zamboni/devhub-min.js:1
 msgid "Your add-on failed validation with {0} error."
 msgid_plural "Your add-on failed validation with {0} errors."
 msgstr[0] "Your add-on failed validation with {0} error."
 msgstr[1] "Your add-on failed validation with {0} errors."
 
-#: static/js/common/upload-addon.js:208
+#: static/js/common/upload-addon.js:208 static/js/zamboni/devhub-all.js:439 static/js/zamboni/devhub-min.js:1
 msgid "&hellip;and {0} more"
 msgid_plural "&hellip;and {0} more"
 msgstr[0] "&hellip;and {0} more"
 msgstr[1] "&hellip;and {0} more"
 
-#: static/js/common/upload-addon.js:222 static/js/common/upload-addon.js:512
+#: static/js/common/upload-addon.js:222 static/js/common/upload-addon.js:497 static/js/zamboni/devhub-all.js:453 static/js/zamboni/devhub-all.js:743 static/js/zamboni/devhub-min.js:1
 msgid "See full validation report"
 msgstr "See full validation report"
 
-#: static/js/common/upload-addon.js:234
+#: static/js/common/upload-addon.js:234 static/js/zamboni/devhub-all.js:465 static/js/zamboni/devhub-min.js:1
 msgid "Validating {0}"
 msgstr "Validating {0}"
 
 #. L10n: first argument is an HTTP status code
-#: static/js/common/upload-addon.js:273
+#: static/js/common/upload-addon.js:273 static/js/zamboni/devhub-all.js:504 static/js/zamboni/devhub-min.js:1
 msgid "Received an empty response from the server; status: {0}"
 msgstr "Received an empty response from the server; status: {0}"
 
-#: static/js/common/upload-addon.js:373
+#: static/js/common/upload-addon.js:370 static/js/zamboni/devhub-all.js:604 static/js/zamboni/devhub-min.js:1
 msgid "Unexpected server error while validating."
 msgstr "Unexpected server error while validating."
 
-#: static/js/common/upload-addon.js:412
+#: static/js/common/upload-addon.js:409 static/js/zamboni/devhub-all.js:643 static/js/zamboni/devhub-min.js:1
 msgid "Finished validating {0}"
 msgstr "Finished validating {0}"
 
-#: static/js/common/upload-addon.js:418
+#: static/js/common/upload-addon.js:415 static/js/zamboni/devhub-all.js:649 static/js/zamboni/devhub-min.js:1
 msgid "Your add-on validation timed out, it will be manually reviewed."
 msgstr "Your add-on validation timed out, it will be manually reviewed."
 
-#: static/js/common/upload-addon.js:421
+#: static/js/common/upload-addon.js:418 static/js/zamboni/devhub-all.js:652 static/js/zamboni/devhub-min.js:1
 msgid "Your add-on was validated with no errors and {0} warning."
 msgid_plural "Your add-on was validated with no errors and {0} warnings."
 msgstr[0] "Your add-on was validated with no errors and {0} warning."
 msgstr[1] "Your add-on was validated with no errors and {0} warnings."
 
-#: static/js/common/upload-addon.js:426
+#: static/js/common/upload-addon.js:423 static/js/zamboni/devhub-all.js:657 static/js/zamboni/devhub-min.js:1
 msgid "Your add-on was validated with no errors and {0} message."
 msgid_plural "Your add-on was validated with no errors and {0} messages."
 msgstr[0] "Your add-on was validated with no errors and {0} message."
 msgstr[1] "Your add-on was validated with no errors and {0} messages."
 
-#: static/js/common/upload-addon.js:431
+#: static/js/common/upload-addon.js:428 static/js/zamboni/devhub-all.js:662 static/js/zamboni/devhub-min.js:1
 msgid "Your add-on was validated with no errors or warnings."
 msgstr "Your add-on was validated with no errors or warnings."
 
-#: static/js/common/upload-addon.js:446
+#: static/js/common/upload-addon.js:443 static/js/zamboni/devhub-all.js:677 static/js/zamboni/devhub-min.js:1
 msgid "Your submission will be automatically signed."
 msgstr "Your submission will be automatically signed."
 
-#: static/js/common/upload-addon.js:465
+#: static/js/common/upload-addon.js:450 static/js/zamboni/devhub-all.js:696 static/js/zamboni/devhub-min.js:1
 msgid "Include detailed version notes (this can be done in the next step)."
 msgstr "Include detailed version notes (this can be done in the next step)."
 
-#: static/js/common/upload-addon.js:466
+#: static/js/common/upload-addon.js:451 static/js/zamboni/devhub-all.js:697 static/js/zamboni/devhub-min.js:1
 msgid "If your add-on requires an account to a website in order to be fully tested, include a test username and password in the Notes to Reviewer (this can be done in the next step)."
 msgstr "If your add-on requires an account to a website in order to be fully tested, include a test username and password in the Notes to Reviewer (this can be done in the next step)."
 
-#: static/js/common/upload-addon.js:467
+#: static/js/common/upload-addon.js:452 static/js/zamboni/devhub-all.js:698 static/js/zamboni/devhub-min.js:1
 msgid "If your add-on is intended for a limited audience you should choose Preliminary Review instead of Full Review."
 msgstr "If your add-on is intended for a limited audience you should choose Preliminary Review instead of Full Review."
 
-#: static/js/common/upload-addon.js:480
+#: static/js/common/upload-addon.js:465 static/js/zamboni/devhub-all.js:711 static/js/zamboni/devhub-min.js:1
 msgid "Add-on submission checklist"
 msgstr "Add-on submission checklist"
 
-#: static/js/common/upload-addon.js:481
+#: static/js/common/upload-addon.js:466 static/js/zamboni/devhub-all.js:712 static/js/zamboni/devhub-min.js:1
 msgid "Please verify the following points before finalizing your submission. This will minimize delays or misunderstanding during the review process:"
 msgstr "Please verify the following points before finalizing your submission. This will minimize delays or misunderstanding during the review process:"
 
-#: static/js/common/upload-addon.js:483
+#: static/js/common/upload-addon.js:468 static/js/zamboni/devhub-all.js:714 static/js/zamboni/devhub-min.js:1
 msgid ""
 "Compiled binaries, as well as minified or obfuscated scripts (excluding known libraries) need to have their sources submitted separately for review. Make sure that you use the source code upload "
 "field to avoid having your submission rejected."
@@ -138,1081 +394,845 @@ msgstr ""
 "Compiled binaries, as well as minified or obfuscated scripts (excluding known libraries) need to have their sources submitted separately for review. Make sure that you use the source code upload "
 "field to avoid having your submission rejected."
 
-#: static/js/common/upload-addon.js:501
+#: static/js/common/upload-addon.js:486 static/js/zamboni/devhub-all.js:732 static/js/zamboni/devhub-min.js:1
 msgid "The validation process found these issues that can lead to rejections:"
 msgstr "The validation process found these issues that can lead to rejections:"
 
-#: static/js/common/upload-addon.js:518
+#: static/js/common/upload-addon.js:503 static/js/zamboni/devhub-all.js:749 static/js/zamboni/devhub-min.js:1
 msgid "If you are unfamiliar with the add-ons review process, you can read about it here."
 msgstr "If you are unfamiliar with the add-ons review process, you can read about it here."
 
-#: static/js/common/upload-addon.js:555
+#: static/js/common/upload-addon.js:540 static/js/zamboni/devhub-all.js:786 static/js/zamboni/devhub-min.js:1
 msgid "Sorry, no supported platform has been found."
 msgstr "Sorry, no supported platform has been found."
 
-#: static/js/common/upload-base.js:57
+#: static/js/common/upload-base.js:57 static/js/zamboni/devhub-all.js:187 static/js/zamboni/devhub-min.js:1
 msgid "The filetype you uploaded isn't recognized."
 msgstr "The filetype you uploaded isn't recognized."
 
-#: static/js/common/upload-base.js:79
+#: static/js/common/upload-base.js:79 static/js/zamboni/devhub-all.js:209 static/js/zamboni/devhub-min.js:1
 msgid "You cancelled the upload."
 msgstr "You cancelled the upload."
 
-#: static/js/common/upload-image.js:97 static/js/impala/users.js:51
-msgid "Images must be either PNG or JPG."
-msgstr "Images must be either PNG or JPG."
-
-#: static/js/common/upload-image.js:101
-msgid "Videos must be in WebM."
-msgstr "Videos must be in WebM."
-
-#: static/js/impala/collections.js:10 static/js/zamboni/collections.js:595
-msgid "Follow this Collection"
-msgstr "Follow this Collection"
-
-#: static/js/impala/collections.js:19
-msgid "Stop Following"
-msgstr "Stop Following"
-
-#: static/js/impala/collections.js:20
-msgid "Following"
-msgstr "Following"
-
-#. L10n: {0} is an app name.
-#: static/js/impala/listing.js:11 static/js/zamboni/themes.js:13
-msgid "This theme is incompatible with your version of {0}"
-msgstr "This theme is incompatible with your version of {0}"
-
-#: static/js/impala/persona_creation.js:60
-msgid "All Rights Reserved"
-msgstr "All Rights Reserved"
-
-#: static/js/impala/persona_creation.js:64
-msgid "Creative Commons Attribution 3.0"
-msgstr "Creative Commons Attribution 3.0"
-
-#: static/js/impala/persona_creation.js:69
-msgid "Creative Commons Attribution-NonCommercial 3.0"
-msgstr "Creative Commons Attribution-NonCommercial 3.0"
-
-#: static/js/impala/persona_creation.js:74
-msgid "Creative Commons Attribution-NonCommercial-NoDerivs 3.0"
-msgstr "Creative Commons Attribution-NonCommercial-NoDerivs 3.0"
-
-#: static/js/impala/persona_creation.js:79
-msgid "Creative Commons Attribution-NonCommercial-Share Alike 3.0"
-msgstr "Creative Commons Attribution-NonCommercial-Share Alike 3.0"
-
-#: static/js/impala/persona_creation.js:84
-msgid "Creative Commons Attribution-NoDerivs 3.0"
-msgstr "Creative Commons Attribution-NoDerivs 3.0"
-
-#: static/js/impala/persona_creation.js:89
-msgid "Creative Commons Attribution-ShareAlike 3.0"
-msgstr "Creative Commons Attribution-ShareAlike 3.0"
-
-#: static/js/impala/persona_creation.js:292
-msgid "Your Theme's Name"
-msgstr "Your Theme's Name"
-
-#: static/js/impala/reviews.js:23 static/js/zamboni/reviews.js:18
-msgid "Flagged for review"
-msgstr "Flagged for review"
-
-#: static/js/impala/reviews.js:40 static/js/zamboni/reviews.js:34
-msgid "Your input is required"
-msgstr "Your input is required"
-
-#: static/js/impala/reviews.js:152 static/js/zamboni/reviews.js:103
-msgid "Marked for deletion"
-msgstr "Marked for deletion"
-
-#: static/js/impala/search.js:114
-msgid "Updating results&hellip;"
-msgstr "Updating results&hellip;"
-
-#: static/js/impala/site_suggestions.js:46
-msgid "Category"
-msgstr "Category"
-
-#: static/js/impala/suggestions.js:39
-msgid "Search themes for <b>{0}</b>"
-msgstr "Search themes for <b>{0}</b>"
-
-#: static/js/impala/suggestions.js:41
-msgid "Search apps for <b>{0}</b>"
-msgstr "Search apps for <b>{0}</b>"
-
-#: static/js/impala/suggestions.js:43
-msgid "Search add-ons for <b>{0}</b>"
-msgstr "Search add-ons for <b>{0}</b>"
-
-#: static/js/impala/users.js:33
-msgid "use original"
-msgstr "use original"
-
-#: static/js/impala/stats/chart.js:267
+#: static/js/impala/stats/chart.js:267 static/js/zamboni/stats-all.js:16898 static/js/zamboni/stats-min.js:5
 msgid "Week of {0}"
 msgstr "Week of {0}"
 
-#: static/js/impala/stats/chart.js:269
+#: static/js/impala/stats/chart.js:269 static/js/zamboni/stats-all.js:16900 static/js/zamboni/stats-min.js:5
 msgid " downloads"
 msgstr " downloads"
 
-#: static/js/impala/stats/chart.js:270
+#: static/js/impala/stats/chart.js:270 static/js/zamboni/stats-all.js:16901 static/js/zamboni/stats-min.js:5
 msgid "{0} users"
 msgstr "{0} users"
 
-#: static/js/impala/stats/chart.js:271
+#: static/js/impala/stats/chart.js:271 static/js/zamboni/stats-all.js:16902 static/js/zamboni/stats-min.js:5
 msgid "{0} add-ons"
 msgstr "{0} add-ons"
 
-#: static/js/impala/stats/chart.js:272
+#: static/js/impala/stats/chart.js:272 static/js/zamboni/stats-all.js:16903 static/js/zamboni/stats-min.js:5
 msgid "{0} collections"
 msgstr "{0} collections"
 
-#: static/js/impala/stats/chart.js:273
+#: static/js/impala/stats/chart.js:273 static/js/zamboni/stats-all.js:16904 static/js/zamboni/stats-min.js:5
 msgid "{0} reviews"
 msgstr "{0} reviews"
 
-#: static/js/impala/stats/chart.js:275
+#: static/js/impala/stats/chart.js:275 static/js/zamboni/stats-all.js:16906 static/js/zamboni/stats-min.js:5
 msgid "{0} sales"
 msgstr "{0} sales"
 
-#: static/js/impala/stats/chart.js:276
+#: static/js/impala/stats/chart.js:276 static/js/zamboni/stats-all.js:16907 static/js/zamboni/stats-min.js:5
 msgid "{0} refunds"
 msgstr "{0} refunds"
 
-#: static/js/impala/stats/chart.js:277
+#: static/js/impala/stats/chart.js:277 static/js/zamboni/stats-all.js:16908 static/js/zamboni/stats-min.js:5
 msgid "{0} installs"
 msgstr "{0} installs"
 
-#: static/js/impala/stats/chart.js:369 static/js/impala/stats/csv_keys.js:3 static/js/impala/stats/csv_keys.js:109
+#: static/js/impala/stats/chart.js:369 static/js/impala/stats/csv_keys.js:3 static/js/impala/stats/csv_keys.js:109 static/js/zamboni/stats-all.js:15284 static/js/zamboni/stats-all.js:15390
+#: static/js/zamboni/stats-all.js:17000 static/js/zamboni/stats-min.js:4 static/js/zamboni/stats-min.js:5
 msgid "Downloads"
 msgstr "Downloads"
 
-#: static/js/impala/stats/chart.js:379 static/js/impala/stats/csv_keys.js:6 static/js/impala/stats/csv_keys.js:110
+#: static/js/impala/stats/chart.js:379 static/js/impala/stats/csv_keys.js:6 static/js/impala/stats/csv_keys.js:110 static/js/zamboni/stats-all.js:15287 static/js/zamboni/stats-all.js:15391
+#: static/js/zamboni/stats-all.js:17010 static/js/zamboni/stats-min.js:4 static/js/zamboni/stats-min.js:5
 msgid "Daily Users"
 msgstr "Daily Users"
 
-#: static/js/impala/stats/chart.js:410
+#: static/js/impala/stats/chart.js:410 static/js/zamboni/stats-all.js:17041 static/js/zamboni/stats-min.js:5
 msgid "Amount, in USD"
 msgstr "Amount, in USD"
 
-#: static/js/impala/stats/chart.js:421 static/js/impala/stats/csv_keys.js:104
+#: static/js/impala/stats/chart.js:421 static/js/impala/stats/csv_keys.js:104 static/js/zamboni/stats-all.js:15385 static/js/zamboni/stats-all.js:17052 static/js/zamboni/stats-min.js:5
 msgid "Number of Contributions"
 msgstr "Number of Contributions"
 
-#: static/js/impala/stats/chart.js:447
+#: static/js/impala/stats/chart.js:447 static/js/zamboni/stats-all.js:17078 static/js/zamboni/stats-min.js:5
 msgid "More Info..."
 msgstr "More Info..."
 
 #. L10n: {0} is an ISO-formatted date.
-#: static/js/impala/stats/chart.js:451
+#: static/js/impala/stats/chart.js:451 static/js/zamboni/stats-all.js:17082 static/js/zamboni/stats-min.js:5
 msgid "Details for {0}"
 msgstr "Details for {0}"
 
-#: static/js/impala/stats/csv_keys.js:9
+#: static/js/impala/stats/csv_keys.js:9 static/js/zamboni/stats-all.js:15290 static/js/zamboni/stats-min.js:4
 msgid "Collections Created"
 msgstr "Collections Created"
 
-#: static/js/impala/stats/csv_keys.js:12
+#: static/js/impala/stats/csv_keys.js:12 static/js/zamboni/stats-all.js:15293 static/js/zamboni/stats-min.js:4
 msgid "Add-ons in Use"
 msgstr "Add-ons in Use"
 
-#: static/js/impala/stats/csv_keys.js:15
+#: static/js/impala/stats/csv_keys.js:15 static/js/zamboni/stats-all.js:15296 static/js/zamboni/stats-min.js:4
 msgid "Add-ons Created"
 msgstr "Add-ons Created"
 
-#: static/js/impala/stats/csv_keys.js:18
+#: static/js/impala/stats/csv_keys.js:18 static/js/zamboni/stats-all.js:15299 static/js/zamboni/stats-min.js:4
 msgid "Add-ons Downloaded"
 msgstr "Add-ons Downloaded"
 
-#: static/js/impala/stats/csv_keys.js:21
+#: static/js/impala/stats/csv_keys.js:21 static/js/zamboni/stats-all.js:15302 static/js/zamboni/stats-min.js:4
 msgid "Add-ons Updated"
 msgstr "Add-ons Updated"
 
-#: static/js/impala/stats/csv_keys.js:24
+#: static/js/impala/stats/csv_keys.js:24 static/js/zamboni/stats-all.js:15305 static/js/zamboni/stats-min.js:4
 msgid "Reviews Written"
 msgstr "Reviews Written"
 
-#: static/js/impala/stats/csv_keys.js:27
+#: static/js/impala/stats/csv_keys.js:27 static/js/zamboni/stats-all.js:15308 static/js/zamboni/stats-min.js:4
 msgid "User Signups"
 msgstr "User Signups"
 
-#: static/js/impala/stats/csv_keys.js:30
+#: static/js/impala/stats/csv_keys.js:30 static/js/zamboni/stats-all.js:15311 static/js/zamboni/stats-min.js:4
 msgid "Subscribers"
 msgstr "Subscribers"
 
-#: static/js/impala/stats/csv_keys.js:33
+#: static/js/impala/stats/csv_keys.js:33 static/js/zamboni/stats-all.js:15314 static/js/zamboni/stats-min.js:4
 msgid "Ratings"
 msgstr "Ratings"
 
-#: static/js/impala/stats/csv_keys.js:36 static/js/impala/stats/csv_keys.js:114
+#: static/js/impala/stats/csv_keys.js:36 static/js/impala/stats/csv_keys.js:114 static/js/zamboni/stats-all.js:15317 static/js/zamboni/stats-all.js:15395 static/js/zamboni/stats-min.js:4
+#: static/js/zamboni/stats-min.js:5
 msgid "Sales"
 msgstr "Sales"
 
-#: static/js/impala/stats/csv_keys.js:39 static/js/impala/stats/csv_keys.js:113
+#: static/js/impala/stats/csv_keys.js:39 static/js/impala/stats/csv_keys.js:113 static/js/zamboni/stats-all.js:15320 static/js/zamboni/stats-all.js:15394 static/js/zamboni/stats-min.js:4
+#: static/js/zamboni/stats-min.js:5
 msgid "Installs"
 msgstr "Installs"
 
-#: static/js/impala/stats/csv_keys.js:42
+#: static/js/impala/stats/csv_keys.js:42 static/js/zamboni/stats-all.js:15323 static/js/zamboni/stats-min.js:4
 msgid "Unknown"
 msgstr "Unknown"
 
-#: static/js/impala/stats/csv_keys.js:43
+#: static/js/impala/stats/csv_keys.js:43 static/js/zamboni/stats-all.js:15324 static/js/zamboni/stats-min.js:4
 msgid "Add-ons Manager"
 msgstr "Add-ons Manager"
 
-#: static/js/impala/stats/csv_keys.js:44
+#: static/js/impala/stats/csv_keys.js:44 static/js/zamboni/stats-all.js:15325 static/js/zamboni/stats-min.js:4
 msgid "Add-ons Manager Promo"
 msgstr "Add-ons Manager Promo"
 
-#: static/js/impala/stats/csv_keys.js:45
+#: static/js/impala/stats/csv_keys.js:45 static/js/zamboni/stats-all.js:15326 static/js/zamboni/stats-min.js:4
 msgid "Add-ons Manager Featured"
 msgstr "Add-ons Manager Featured"
 
-#: static/js/impala/stats/csv_keys.js:46
+#: static/js/impala/stats/csv_keys.js:46 static/js/zamboni/stats-all.js:15327 static/js/zamboni/stats-min.js:4
 msgid "Add-ons Manager Learn More"
 msgstr "Add-ons Manager Learn More"
 
-#: static/js/impala/stats/csv_keys.js:47
+#: static/js/impala/stats/csv_keys.js:47 static/js/zamboni/stats-all.js:15328 static/js/zamboni/stats-min.js:4
 msgid "Search Suggestions"
 msgstr "Search Suggestions"
 
-#: static/js/impala/stats/csv_keys.js:48
+#: static/js/impala/stats/csv_keys.js:48 static/js/zamboni/stats-all.js:15329 static/js/zamboni/stats-min.js:4
 msgid "Search Results"
 msgstr "Search Results"
 
-#: static/js/impala/stats/csv_keys.js:49 static/js/impala/stats/csv_keys.js:50 static/js/impala/stats/csv_keys.js:51
+#: static/js/impala/stats/csv_keys.js:49 static/js/impala/stats/csv_keys.js:50 static/js/impala/stats/csv_keys.js:51 static/js/zamboni/stats-all.js:15330 static/js/zamboni/stats-all.js:15331
+#: static/js/zamboni/stats-all.js:15332 static/js/zamboni/stats-min.js:4
 msgid "Homepage Promo"
 msgstr "Homepage Promo"
 
-#: static/js/impala/stats/csv_keys.js:52 static/js/impala/stats/csv_keys.js:53
+#: static/js/impala/stats/csv_keys.js:52 static/js/impala/stats/csv_keys.js:53 static/js/zamboni/stats-all.js:15333 static/js/zamboni/stats-all.js:15334 static/js/zamboni/stats-min.js:4
 msgid "Homepage Featured"
 msgstr "Homepage Featured"
 
-#: static/js/impala/stats/csv_keys.js:54 static/js/impala/stats/csv_keys.js:55
+#: static/js/impala/stats/csv_keys.js:54 static/js/impala/stats/csv_keys.js:55 static/js/zamboni/stats-all.js:15335 static/js/zamboni/stats-all.js:15336 static/js/zamboni/stats-min.js:4
 msgid "Homepage Up and Coming"
 msgstr "Homepage Up and Coming"
 
-#: static/js/impala/stats/csv_keys.js:56
+#: static/js/impala/stats/csv_keys.js:56 static/js/zamboni/stats-all.js:15337 static/js/zamboni/stats-min.js:4
 msgid "Homepage Most Popular"
 msgstr "Homepage Most Popular"
 
-#: static/js/impala/stats/csv_keys.js:57 static/js/impala/stats/csv_keys.js:59
+#: static/js/impala/stats/csv_keys.js:57 static/js/impala/stats/csv_keys.js:59 static/js/zamboni/stats-all.js:15338 static/js/zamboni/stats-all.js:15340 static/js/zamboni/stats-min.js:4
 msgid "Detail Page"
 msgstr "Detail Page"
 
-#: static/js/impala/stats/csv_keys.js:58 static/js/impala/stats/csv_keys.js:60
+#: static/js/impala/stats/csv_keys.js:58 static/js/impala/stats/csv_keys.js:60 static/js/zamboni/stats-all.js:15339 static/js/zamboni/stats-all.js:15341 static/js/zamboni/stats-min.js:4
 msgid "Detail Page (bottom)"
 msgstr "Detail Page (bottom)"
 
-#: static/js/impala/stats/csv_keys.js:61
+#: static/js/impala/stats/csv_keys.js:61 static/js/zamboni/stats-all.js:15342 static/js/zamboni/stats-min.js:4
 msgid "Detail Page (Development Channel)"
 msgstr "Detail Page (Development Channel)"
 
-#: static/js/impala/stats/csv_keys.js:62 static/js/impala/stats/csv_keys.js:63 static/js/impala/stats/csv_keys.js:64
+#: static/js/impala/stats/csv_keys.js:62 static/js/impala/stats/csv_keys.js:63 static/js/impala/stats/csv_keys.js:64 static/js/zamboni/stats-all.js:15343 static/js/zamboni/stats-all.js:15344
+#: static/js/zamboni/stats-all.js:15345 static/js/zamboni/stats-min.js:4
 msgid "Often Used With"
 msgstr "Often Used With"
 
-#: static/js/impala/stats/csv_keys.js:65 static/js/impala/stats/csv_keys.js:66
+#: static/js/impala/stats/csv_keys.js:65 static/js/impala/stats/csv_keys.js:66 static/js/zamboni/stats-all.js:15346 static/js/zamboni/stats-all.js:15347 static/js/zamboni/stats-min.js:4
 msgid "Others By Author"
 msgstr "Others By Author"
 
-#: static/js/impala/stats/csv_keys.js:67 static/js/impala/stats/csv_keys.js:68
+#: static/js/impala/stats/csv_keys.js:67 static/js/impala/stats/csv_keys.js:68 static/js/zamboni/stats-all.js:15348 static/js/zamboni/stats-all.js:15349 static/js/zamboni/stats-min.js:4
 msgid "Dependencies"
 msgstr "Dependencies"
 
-#: static/js/impala/stats/csv_keys.js:69 static/js/impala/stats/csv_keys.js:70
+#: static/js/impala/stats/csv_keys.js:69 static/js/impala/stats/csv_keys.js:70 static/js/zamboni/stats-all.js:15350 static/js/zamboni/stats-all.js:15351 static/js/zamboni/stats-min.js:4
 msgid "Upsell"
 msgstr "Upsell"
 
-#: static/js/impala/stats/csv_keys.js:71
+#: static/js/impala/stats/csv_keys.js:71 static/js/zamboni/stats-all.js:15352 static/js/zamboni/stats-min.js:4
 msgid "Meet the Developer"
 msgstr "Meet the Developer"
 
-#: static/js/impala/stats/csv_keys.js:72
+#: static/js/impala/stats/csv_keys.js:72 static/js/zamboni/stats-all.js:15353 static/js/zamboni/stats-min.js:4
 msgid "User Profile"
 msgstr "User Profile"
 
-#: static/js/impala/stats/csv_keys.js:73
+#: static/js/impala/stats/csv_keys.js:73 static/js/zamboni/stats-all.js:15354 static/js/zamboni/stats-min.js:4
 msgid "Version History"
 msgstr "Version History"
 
-#: static/js/impala/stats/csv_keys.js:75
+#: static/js/impala/stats/csv_keys.js:75 static/js/zamboni/stats-all.js:15356 static/js/zamboni/stats-min.js:4
 msgid "Sharing"
 msgstr "Sharing"
 
-#: static/js/impala/stats/csv_keys.js:76
+#: static/js/impala/stats/csv_keys.js:76 static/js/zamboni/stats-all.js:15357 static/js/zamboni/stats-min.js:4
 msgid "Category Pages"
 msgstr "Category Pages"
 
-#: static/js/impala/stats/csv_keys.js:77
+#: static/js/impala/stats/csv_keys.js:77 static/js/zamboni/stats-all.js:15358 static/js/zamboni/stats-min.js:4
 msgid "Collections"
 msgstr "Collections"
 
-#: static/js/impala/stats/csv_keys.js:78 static/js/impala/stats/csv_keys.js:79
+#: static/js/impala/stats/csv_keys.js:78 static/js/impala/stats/csv_keys.js:79 static/js/zamboni/stats-all.js:15359 static/js/zamboni/stats-all.js:15360 static/js/zamboni/stats-min.js:4
 msgid "Category Landing Featured Carousel"
 msgstr "Category Landing Featured Carousel"
 
-#: static/js/impala/stats/csv_keys.js:80 static/js/impala/stats/csv_keys.js:81
+#: static/js/impala/stats/csv_keys.js:80 static/js/impala/stats/csv_keys.js:81 static/js/zamboni/stats-all.js:15361 static/js/zamboni/stats-all.js:15362 static/js/zamboni/stats-min.js:4
 msgid "Category Landing Top Rated"
 msgstr "Category Landing Top Rated"
 
-#: static/js/impala/stats/csv_keys.js:82 static/js/impala/stats/csv_keys.js:83
+#: static/js/impala/stats/csv_keys.js:82 static/js/impala/stats/csv_keys.js:83 static/js/zamboni/stats-all.js:15363 static/js/zamboni/stats-all.js:15364 static/js/zamboni/stats-min.js:5
 msgid "Category Landing Most Popular"
 msgstr "Category Landing Most Popular"
 
-#: static/js/impala/stats/csv_keys.js:84 static/js/impala/stats/csv_keys.js:85
+#: static/js/impala/stats/csv_keys.js:84 static/js/impala/stats/csv_keys.js:85 static/js/zamboni/stats-all.js:15365 static/js/zamboni/stats-all.js:15366 static/js/zamboni/stats-min.js:5
 msgid "Category Landing Recently Added"
 msgstr "Category Landing Recently Added"
 
-#: static/js/impala/stats/csv_keys.js:86 static/js/impala/stats/csv_keys.js:87
+#: static/js/impala/stats/csv_keys.js:86 static/js/impala/stats/csv_keys.js:87 static/js/zamboni/stats-all.js:15367 static/js/zamboni/stats-all.js:15368 static/js/zamboni/stats-min.js:5
 msgid "Browse Listing Featured Sort"
 msgstr "Browse Listing Featured Sort"
 
-#: static/js/impala/stats/csv_keys.js:88 static/js/impala/stats/csv_keys.js:89
+#: static/js/impala/stats/csv_keys.js:88 static/js/impala/stats/csv_keys.js:89 static/js/zamboni/stats-all.js:15369 static/js/zamboni/stats-all.js:15370 static/js/zamboni/stats-min.js:5
 msgid "Browse Listing Users Sort"
 msgstr "Browse Listing Users Sort"
 
-#: static/js/impala/stats/csv_keys.js:90 static/js/impala/stats/csv_keys.js:91
+#: static/js/impala/stats/csv_keys.js:90 static/js/impala/stats/csv_keys.js:91 static/js/zamboni/stats-all.js:15371 static/js/zamboni/stats-all.js:15372 static/js/zamboni/stats-min.js:5
 msgid "Browse Listing Rating Sort"
 msgstr "Browse Listing Rating Sort"
 
-#: static/js/impala/stats/csv_keys.js:92 static/js/impala/stats/csv_keys.js:93
+#: static/js/impala/stats/csv_keys.js:92 static/js/impala/stats/csv_keys.js:93 static/js/zamboni/stats-all.js:15373 static/js/zamboni/stats-all.js:15374 static/js/zamboni/stats-min.js:5
 msgid "Browse Listing Created Sort"
 msgstr "Browse Listing Created Sort"
 
-#: static/js/impala/stats/csv_keys.js:94 static/js/impala/stats/csv_keys.js:95
+#: static/js/impala/stats/csv_keys.js:94 static/js/impala/stats/csv_keys.js:95 static/js/zamboni/stats-all.js:15375 static/js/zamboni/stats-all.js:15376 static/js/zamboni/stats-min.js:5
 msgid "Browse Listing Name Sort"
 msgstr "Browse Listing Name Sort"
 
-#: static/js/impala/stats/csv_keys.js:96 static/js/impala/stats/csv_keys.js:97
+#: static/js/impala/stats/csv_keys.js:96 static/js/impala/stats/csv_keys.js:97 static/js/zamboni/stats-all.js:15377 static/js/zamboni/stats-all.js:15378 static/js/zamboni/stats-min.js:5
 msgid "Browse Listing Popular Sort"
 msgstr "Browse Listing Popular Sort"
 
-#: static/js/impala/stats/csv_keys.js:98 static/js/impala/stats/csv_keys.js:99
+#: static/js/impala/stats/csv_keys.js:98 static/js/impala/stats/csv_keys.js:99 static/js/zamboni/stats-all.js:15379 static/js/zamboni/stats-all.js:15380 static/js/zamboni/stats-min.js:5
 msgid "Browse Listing Updated Sort"
 msgstr "Browse Listing Updated Sort"
 
-#: static/js/impala/stats/csv_keys.js:100 static/js/impala/stats/csv_keys.js:101
+#: static/js/impala/stats/csv_keys.js:100 static/js/impala/stats/csv_keys.js:101 static/js/zamboni/stats-all.js:15381 static/js/zamboni/stats-all.js:15382 static/js/zamboni/stats-min.js:5
 msgid "Browse Listing Up and Coming Sort"
 msgstr "Browse Listing Up and Coming Sort"
 
-#: static/js/impala/stats/csv_keys.js:105
+#: static/js/impala/stats/csv_keys.js:105 static/js/zamboni/stats-all.js:15386 static/js/zamboni/stats-min.js:5
 msgid "Total Amount Contributed"
 msgstr "Total Amount Contributed"
 
-#: static/js/impala/stats/csv_keys.js:106
+#: static/js/impala/stats/csv_keys.js:106 static/js/zamboni/stats-all.js:15387 static/js/zamboni/stats-min.js:5
 msgid "Average Contribution"
 msgstr "Average Contribution"
 
-#: static/js/impala/stats/csv_keys.js:115
+#: static/js/impala/stats/csv_keys.js:115 static/js/zamboni/stats-all.js:15396 static/js/zamboni/stats-min.js:5
 msgid "Usage"
 msgstr "Usage"
 
-#: static/js/impala/stats/csv_keys.js:118
+#: static/js/impala/stats/csv_keys.js:118 static/js/zamboni/stats-all.js:15399 static/js/zamboni/stats-min.js:5
 msgid "Firefox"
 msgstr "Firefox"
 
-#: static/js/impala/stats/csv_keys.js:119
+#: static/js/impala/stats/csv_keys.js:119 static/js/zamboni/stats-all.js:15400 static/js/zamboni/stats-min.js:5
 msgid "Mozilla"
 msgstr "Mozilla"
 
-#: static/js/impala/stats/csv_keys.js:120
+#: static/js/impala/stats/csv_keys.js:120 static/js/zamboni/stats-all.js:15401 static/js/zamboni/stats-min.js:5
 msgid "Thunderbird"
 msgstr "Thunderbird"
 
-#: static/js/impala/stats/csv_keys.js:121
+#: static/js/impala/stats/csv_keys.js:121 static/js/zamboni/stats-all.js:15402 static/js/zamboni/stats-min.js:5
 msgid "Sunbird"
 msgstr "Sunbird"
 
-#: static/js/impala/stats/csv_keys.js:122
+#: static/js/impala/stats/csv_keys.js:122 static/js/zamboni/stats-all.js:15403 static/js/zamboni/stats-min.js:5
 msgid "SeaMonkey"
 msgstr "SeaMonkey"
 
-#: static/js/impala/stats/csv_keys.js:123
+#: static/js/impala/stats/csv_keys.js:123 static/js/zamboni/stats-all.js:15404 static/js/zamboni/stats-min.js:5
 msgid "Fennec"
 msgstr "Fennec"
 
-#: static/js/impala/stats/csv_keys.js:124
+#: static/js/impala/stats/csv_keys.js:124 static/js/zamboni/stats-all.js:15405 static/js/zamboni/stats-min.js:5
 msgid "Android"
 msgstr "Android"
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:129
+#: static/js/impala/stats/csv_keys.js:129 static/js/zamboni/stats-all.js:15410 static/js/zamboni/stats-min.js:5
 msgid "Downloads and Daily Users, last {0} days"
 msgstr "Downloads and Daily Users, last {0} days"
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:131
+#: static/js/impala/stats/csv_keys.js:131 static/js/zamboni/stats-all.js:15412 static/js/zamboni/stats-min.js:5
 msgid "Downloads and Daily Users from {0} to {1}"
 msgstr "Downloads and Daily Users from {0} to {1}"
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:135
+#: static/js/impala/stats/csv_keys.js:135 static/js/zamboni/stats-all.js:15416 static/js/zamboni/stats-min.js:5
 msgid "Installs and Daily Users, last {0} days"
 msgstr "Installs and Daily Users, last {0} days"
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:137
+#: static/js/impala/stats/csv_keys.js:137 static/js/zamboni/stats-all.js:15418 static/js/zamboni/stats-min.js:5
 msgid "Installs and Daily Users from {0} to {1}"
 msgstr "Installs and Daily Users from {0} to {1}"
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:141
+#: static/js/impala/stats/csv_keys.js:141 static/js/zamboni/stats-all.js:15422 static/js/zamboni/stats-min.js:5
 msgid "Downloads, last {0} days"
 msgstr "Downloads, last {0} days"
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:143
+#: static/js/impala/stats/csv_keys.js:143 static/js/zamboni/stats-all.js:15424 static/js/zamboni/stats-min.js:5
 msgid "Downloads from {0} to {1}"
 msgstr "Downloads from {0} to {1}"
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:147
+#: static/js/impala/stats/csv_keys.js:147 static/js/zamboni/stats-all.js:15428 static/js/zamboni/stats-min.js:5
 msgid "Daily Users, last {0} days"
 msgstr "Daily Users, last {0} days"
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:149
+#: static/js/impala/stats/csv_keys.js:149 static/js/zamboni/stats-all.js:15430 static/js/zamboni/stats-min.js:5
 msgid "Daily Users from {0} to {1}"
 msgstr "Daily Users from {0} to {1}"
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:153
+#: static/js/impala/stats/csv_keys.js:153 static/js/zamboni/stats-all.js:15434 static/js/zamboni/stats-min.js:5
 msgid "Applications, last {0} days"
 msgstr "Applications, last {0} days"
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:155
+#: static/js/impala/stats/csv_keys.js:155 static/js/zamboni/stats-all.js:15436 static/js/zamboni/stats-min.js:5
 msgid "Applications from {0} to {1}"
 msgstr "Applications from {0} to {1}"
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:159
+#: static/js/impala/stats/csv_keys.js:159 static/js/zamboni/stats-all.js:15440 static/js/zamboni/stats-min.js:5
 msgid "Platforms, last {0} days"
 msgstr "Platforms, last {0} days"
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:161
+#: static/js/impala/stats/csv_keys.js:161 static/js/zamboni/stats-all.js:15442 static/js/zamboni/stats-min.js:5
 msgid "Platforms from {0} to {1}"
 msgstr "Platforms from {0} to {1}"
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:165
+#: static/js/impala/stats/csv_keys.js:165 static/js/zamboni/stats-all.js:15446 static/js/zamboni/stats-min.js:5
 msgid "Languages, last {0} days"
 msgstr "Languages, last {0} days"
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:167
+#: static/js/impala/stats/csv_keys.js:167 static/js/zamboni/stats-all.js:15448 static/js/zamboni/stats-min.js:5
 msgid "Languages from {0} to {1}"
 msgstr "Languages from {0} to {1}"
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:171
+#: static/js/impala/stats/csv_keys.js:171 static/js/zamboni/stats-all.js:15452 static/js/zamboni/stats-min.js:5
 msgid "Add-on Versions, last {0} days"
 msgstr "Add-on Versions, last {0} days"
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:173
+#: static/js/impala/stats/csv_keys.js:173 static/js/zamboni/stats-all.js:15454 static/js/zamboni/stats-min.js:5
 msgid "Add-on Versions from {0} to {1}"
 msgstr "Add-on Versions from {0} to {1}"
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:177
+#: static/js/impala/stats/csv_keys.js:177 static/js/zamboni/stats-all.js:15458 static/js/zamboni/stats-min.js:5
 msgid "Add-on Status, last {0} days"
 msgstr "Add-on Status, last {0} days"
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:179
+#: static/js/impala/stats/csv_keys.js:179 static/js/zamboni/stats-all.js:15460 static/js/zamboni/stats-min.js:5
 msgid "Add-on Status from {0} to {1}"
 msgstr "Add-on Status from {0} to {1}"
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:183
+#: static/js/impala/stats/csv_keys.js:183 static/js/zamboni/stats-all.js:15464 static/js/zamboni/stats-min.js:5
 msgid "Download Sources, last {0} days"
 msgstr "Download Sources, last {0} days"
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:185
+#: static/js/impala/stats/csv_keys.js:185 static/js/zamboni/stats-all.js:15466 static/js/zamboni/stats-min.js:5
 msgid "Download Sources from {0} to {1}"
 msgstr "Download Sources from {0} to {1}"
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:189
+#: static/js/impala/stats/csv_keys.js:189 static/js/zamboni/stats-all.js:15470 static/js/zamboni/stats-min.js:5
 msgid "Contributions, last {0} days"
 msgstr "Contributions, last {0} days"
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:191
+#: static/js/impala/stats/csv_keys.js:191 static/js/zamboni/stats-all.js:15472 static/js/zamboni/stats-min.js:5
 msgid "Contributions from {0} to {1}"
 msgstr "Contributions from {0} to {1}"
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:195
+#: static/js/impala/stats/csv_keys.js:195 static/js/zamboni/stats-all.js:15476 static/js/zamboni/stats-min.js:5
 msgid "Site Metrics, last {0} days"
 msgstr "Site Metrics, last {0} days"
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:197
+#: static/js/impala/stats/csv_keys.js:197 static/js/zamboni/stats-all.js:15478 static/js/zamboni/stats-min.js:5
 msgid "Site Metrics from {0} to {1}"
 msgstr "Site Metrics from {0} to {1}"
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:201
+#: static/js/impala/stats/csv_keys.js:201 static/js/zamboni/stats-all.js:15482 static/js/zamboni/stats-min.js:5
 msgid "Add-ons in Use, last {0} days"
 msgstr "Add-ons in Use, last {0} days"
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:203
+#: static/js/impala/stats/csv_keys.js:203 static/js/zamboni/stats-all.js:15484 static/js/zamboni/stats-min.js:5
 msgid "Add-ons in Use from {0} to {1}"
 msgstr "Add-ons in Use from {0} to {1}"
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:207
+#: static/js/impala/stats/csv_keys.js:207 static/js/zamboni/stats-all.js:15488 static/js/zamboni/stats-min.js:5
 msgid "Add-ons Downloaded, last {0} days"
 msgstr "Add-ons Downloaded, last {0} days"
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:209
+#: static/js/impala/stats/csv_keys.js:209 static/js/zamboni/stats-all.js:15490 static/js/zamboni/stats-min.js:5
 msgid "Add-ons Downloaded from {0} to {1}"
 msgstr "Add-ons Downloaded from {0} to {1}"
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:213
+#: static/js/impala/stats/csv_keys.js:213 static/js/zamboni/stats-all.js:15494 static/js/zamboni/stats-min.js:5
 msgid "Add-ons Created, last {0} days"
 msgstr "Add-ons Created, last {0} days"
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:215
+#: static/js/impala/stats/csv_keys.js:215 static/js/zamboni/stats-all.js:15496 static/js/zamboni/stats-min.js:5
 msgid "Add-ons Created from {0} to {1}"
 msgstr "Add-ons Created from {0} to {1}"
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:219
+#: static/js/impala/stats/csv_keys.js:219 static/js/zamboni/stats-all.js:15500 static/js/zamboni/stats-min.js:5
 msgid "Add-ons Updated, last {0} days"
 msgstr "Add-ons Updated, last {0} days"
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:221
+#: static/js/impala/stats/csv_keys.js:221 static/js/zamboni/stats-all.js:15502 static/js/zamboni/stats-min.js:5
 msgid "Add-ons Updated from {0} to {1}"
 msgstr "Add-ons Updated from {0} to {1}"
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:225
+#: static/js/impala/stats/csv_keys.js:225 static/js/zamboni/stats-all.js:15506 static/js/zamboni/stats-min.js:5
 msgid "Reviews Written, last {0} days"
 msgstr "Reviews Written, last {0} days"
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:227
+#: static/js/impala/stats/csv_keys.js:227 static/js/zamboni/stats-all.js:15508 static/js/zamboni/stats-min.js:5
 msgid "Reviews Written from {0} to {1}"
 msgstr "Reviews Written from {0} to {1}"
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:231
+#: static/js/impala/stats/csv_keys.js:231 static/js/zamboni/stats-all.js:15512 static/js/zamboni/stats-min.js:5
 msgid "User Signups, last {0} days"
 msgstr "User Signups, last {0} days"
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:233
+#: static/js/impala/stats/csv_keys.js:233 static/js/zamboni/stats-all.js:15514 static/js/zamboni/stats-min.js:5
 msgid "User Signups from {0} to {1}"
 msgstr "User Signups from {0} to {1}"
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:237
+#: static/js/impala/stats/csv_keys.js:237 static/js/zamboni/stats-all.js:15518 static/js/zamboni/stats-min.js:5
 msgid "Collections Created, last {0} days"
 msgstr "Collections Created, last {0} days"
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:239
+#: static/js/impala/stats/csv_keys.js:239 static/js/zamboni/stats-all.js:15520 static/js/zamboni/stats-min.js:5
 msgid "Collections Created from {0} to {1}"
 msgstr "Collections Created from {0} to {1}"
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:243
+#: static/js/impala/stats/csv_keys.js:243 static/js/zamboni/stats-all.js:15524 static/js/zamboni/stats-min.js:5
 msgid "Subscribers, last {0} days"
 msgstr "Subscribers, last {0} days"
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:245
+#: static/js/impala/stats/csv_keys.js:245 static/js/zamboni/stats-all.js:15526 static/js/zamboni/stats-min.js:5
 msgid "Subscribers from {0} to {1}"
 msgstr "Subscribers from {0} to {1}"
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:249
+#: static/js/impala/stats/csv_keys.js:249 static/js/zamboni/stats-all.js:15530 static/js/zamboni/stats-min.js:5
 msgid "Ratings, last {0} days"
 msgstr "Ratings, last {0} days"
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:251
+#: static/js/impala/stats/csv_keys.js:251 static/js/zamboni/stats-all.js:15532 static/js/zamboni/stats-min.js:5
 msgid "Ratings from {0} to {1}"
 msgstr "Ratings from {0} to {1}"
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:255
+#: static/js/impala/stats/csv_keys.js:255 static/js/zamboni/stats-all.js:15536 static/js/zamboni/stats-min.js:5
 msgid "Sales, last {0} days"
 msgstr "Sales, last {0} days"
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:257
+#: static/js/impala/stats/csv_keys.js:257 static/js/zamboni/stats-all.js:15538 static/js/zamboni/stats-min.js:5
 msgid "Sales from {0} to {1}"
 msgstr "Sales from {0} to {1}"
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:261
+#: static/js/impala/stats/csv_keys.js:261 static/js/zamboni/stats-all.js:15542 static/js/zamboni/stats-min.js:5
 msgid "Installs, last {0} days"
 msgstr "Installs, last {0} days"
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:263
+#: static/js/impala/stats/csv_keys.js:263 static/js/zamboni/stats-all.js:15544 static/js/zamboni/stats-min.js:5
 msgid "Installs from {0} to {1}"
 msgstr "Installs from {0} to {1}"
 
 #. L10n: {0} and {1} are integers.
-#: static/js/impala/stats/csv_keys.js:269
+#: static/js/impala/stats/csv_keys.js:269 static/js/zamboni/stats-all.js:15550 static/js/zamboni/stats-min.js:5
 msgid "<b>{0}</b> in last {1} days"
 msgstr "<b>{0}</b> in last {1} days"
 
 #. L10n: {0} is an integer and {1} and {2} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:271 static/js/impala/stats/csv_keys.js:277
+#: static/js/impala/stats/csv_keys.js:271 static/js/impala/stats/csv_keys.js:277 static/js/zamboni/stats-all.js:15552 static/js/zamboni/stats-all.js:15558 static/js/zamboni/stats-min.js:5
 msgid "<b>{0}</b> from {1} to {2}"
 msgstr "<b>{0}</b> from {1} to {2}"
 
 #. L10n: {0} and {1} are integers.
-#: static/js/impala/stats/csv_keys.js:275
+#: static/js/impala/stats/csv_keys.js:275 static/js/zamboni/stats-all.js:15556 static/js/zamboni/stats-min.js:5
 msgid "<b>{0}</b> average in last {1} days"
 msgstr "<b>{0}</b> average in last {1} days"
 
-#: static/js/impala/stats/overview.js:19
+#: static/js/impala/stats/overview.js:19 static/js/zamboni/stats-all.js:16469 static/js/zamboni/stats-min.js:5
 msgid "No data available."
 msgstr "No data available."
 
-#: static/js/impala/stats/table.js:74
+#: static/js/impala/stats/table.js:74 static/js/zamboni/stats-all.js:17209 static/js/zamboni/stats-min.js:5
 msgid "Date"
 msgstr "Date"
 
-#: static/js/impala/stats/topchart.js:96
+#: static/js/impala/stats/topchart.js:96 static/js/zamboni/stats-all.js:16600 static/js/zamboni/stats-min.js:5
 msgid "Other"
 msgstr "Other"
 
-#: static/js/zamboni/admin_validation.js:24 static/js/zamboni/devhub.js:1229 static/js/zamboni/editors.js:295
+#: static/js/zamboni/admin-all.js:180 static/js/zamboni/admin-min.js:1 static/js/zamboni/admin_validation.js:24 static/js/zamboni/devhub-all.js:2408 static/js/zamboni/devhub-min.js:2
+#: static/js/zamboni/devhub.js:1229 static/js/zamboni/editors-all.js:15576 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:295
 msgid "Select an application first"
 msgstr "Select an application first"
 
-#: static/js/zamboni/admin_validation.js:51
+#: static/js/zamboni/admin-all.js:207 static/js/zamboni/admin-min.js:1 static/js/zamboni/admin_validation.js:51
 #, fuzzy
 msgid "Set {0} add-on to a max version of {1} and email the author."
 msgid_plural "Set {0} add-ons to a max version of {1} and email the authors."
 msgstr[0] "Set {0} add-on to a max version of {1} and email the author."
 msgstr[1] "Set {0} add-ons to a max version of {1} and email the authors"
 
-#: static/js/zamboni/admin_validation.js:54
+#: static/js/zamboni/admin-all.js:210 static/js/zamboni/admin-min.js:1 static/js/zamboni/admin_validation.js:54
 msgid "Email author of {2} add-on which failed validation."
 msgid_plural "Email authors of {2} add-ons which failed validation."
 msgstr[0] "Email author of {2} add-on which failed validation."
 msgstr[1] "Email authors of {2} add-ons which failed validation."
 
-#. L10n: {0} is an app name like Firefox.
-#: static/js/zamboni/buttons.js:66
-msgid "Accept and Install"
-msgstr "Accept and Install"
-
-#: static/js/zamboni/buttons.js:66
-msgid "Add to {0}"
-msgstr "Add to {0}"
-
-#: static/js/zamboni/buttons.js:71
-msgid "Download Now"
-msgstr "Download Now"
-
-#: static/js/zamboni/buttons.js:112
-msgid "Add-on has not been updated to support default-to-compatible."
-msgstr "Add-on has not been updated to support default-to-compatible."
-
-#: static/js/zamboni/buttons.js:117
-msgid "You need to be using Firefox 10.0 or higher."
-msgstr "You need to be using Firefox 10.0 or higher."
-
-#: static/js/zamboni/buttons.js:129
-msgid "Mozilla has marked this version as incompatible with your Firefox version."
-msgstr "Mozilla has marked this version as incompatible with your Firefox version."
-
-#. L10n: {0} is an platform like Windows or Linux.
-#: static/js/zamboni/buttons.js:210
-msgid "Install for {0} anyway"
-msgstr "Install for {0} anyway"
-
-#: static/js/zamboni/buttons.js:210
-msgid "Download for {0} anyway"
-msgstr "Download for {0} anyway"
-
-#: static/js/zamboni/buttons.js:267
-msgid "Not available for your platform"
-msgstr "Not available for your platform"
-
-#. L10n: {0} is an app name, {1} is the app version.
-#: static/js/zamboni/buttons.js:278 static/js/zamboni/buttons.js:315
-msgid "Not available for {0} {1}"
-msgstr "Not available for {0} {1}"
-
-#: static/js/zamboni/buttons.js:341
-msgid "Works with {app} {min} - {max}"
-msgstr "Works with {app} {min} - {max}"
-
-#: static/js/zamboni/buttons.js:343
-msgid "View other versions"
-msgstr "View other versions"
-
-#: static/js/zamboni/buttons.js:391
-msgid "Only with Firefox — Get Firefox Now!"
-msgstr "Only with Firefox — Get Firefox Now!"
-
-#: static/js/zamboni/buttons.js:507 static/js/zamboni/mobile/buttons.js:43
-msgid "Sorry, you need a Mozilla-based browser (such as Firefox) to install a search plugin."
-msgstr "Sorry, you need a Mozilla-based browser (such as Firefox) to install a search plugin."
-
-#: static/js/zamboni/collections.js:229
-msgid "Adding to Favorites&hellip;"
-msgstr "Adding to Favorites&hellip;"
-
-#: static/js/zamboni/collections.js:232
-msgid "Removing Favorite&hellip;"
-msgstr "Removing Favorite&hellip;"
-
-#: static/js/zamboni/collections.js:235
-msgid "Add to Favorites"
-msgstr "Add to Favorites"
-
-#: static/js/zamboni/collections.js:238
-msgid "Remove from Favorites"
-msgstr "Remove from Favorites"
-
-#: static/js/zamboni/collections.js:303
-msgid "Pending"
-msgstr "Pending"
-
-#: static/js/zamboni/collections.js:304
-msgid "Add a comment"
-msgstr "Add a comment"
-
-#: static/js/zamboni/collections.js:304
-msgid "Comment"
-msgstr "Comment"
-
-#: static/js/zamboni/collections.js:305
-msgid "Remove this add-on from the collection"
-msgstr "Remove this add-on from the collection"
-
-#: static/js/zamboni/collections.js:305 static/js/zamboni/collections.js:334
-msgid "Remove"
-msgstr "Remove"
-
-#: static/js/zamboni/collections.js:334
-msgid "Remove this user as a contributor"
-msgstr "Remove this user as a contributor"
-
-#: static/js/zamboni/collections.js:346
-msgid "An email address is required."
-msgstr "An email address is required."
-
-#: static/js/zamboni/collections.js:364
-msgid "You cannot add yourself as a contributor."
-msgstr "You cannot add yourself as a contributor."
-
-#: static/js/zamboni/collections.js:366
-msgid "You have already added that user."
-msgstr "You have already added that user."
-
-#: static/js/zamboni/collections.js:573
-msgid "Add to favorites"
-msgstr "Add to favorites"
-
-#: static/js/zamboni/collections.js:577
-msgid "Remove from favorites"
-msgstr "Remove from favorites"
-
-#: static/js/zamboni/collections.js:604
-msgid "Stop following"
-msgstr "Stop following"
-
-#: static/js/zamboni/devhub.js:110
+#: static/js/zamboni/devhub-all.js:1289 static/js/zamboni/devhub-min.js:1 static/js/zamboni/devhub.js:110
 msgid "Your browser does not support the video tag"
 msgstr "Your browser does not support the video tag"
 
-#: static/js/zamboni/devhub.js:371
+#: static/js/zamboni/devhub-all.js:1550 static/js/zamboni/devhub-min.js:1 static/js/zamboni/devhub.js:371
 msgid "Changes Saved"
 msgstr "Changes Saved"
 
-#: static/js/zamboni/devhub.js:387
+#: static/js/zamboni/devhub-all.js:1566 static/js/zamboni/devhub-min.js:1 static/js/zamboni/devhub.js:387
 msgid "Enter a new author's email address"
 msgstr "Enter a new author's email address"
 
-#: static/js/zamboni/devhub.js:536
+#: static/js/zamboni/devhub-all.js:1715 static/js/zamboni/devhub-min.js:1 static/js/zamboni/devhub.js:536
 msgid "There was an error uploading your file."
 msgstr "There was an error uploading your file."
 
-#: static/js/zamboni/devhub.js:681
+#: static/js/zamboni/devhub-all.js:1860 static/js/zamboni/devhub-min.js:1 static/js/zamboni/devhub.js:681
 msgid "{files} file"
 msgid_plural "{files} files"
 msgstr[0] "{files} file"
 msgstr[1] "{files} files"
 
-#: static/js/zamboni/devhub.js:684
+#: static/js/zamboni/devhub-all.js:1863 static/js/zamboni/devhub-min.js:1 static/js/zamboni/devhub.js:684
 msgid "{reviews} user review"
 msgid_plural "{reviews} user reviews"
 msgstr[0] "{reviews} user review"
 msgstr[1] "{reviews} user reviews"
 
-#: static/js/zamboni/devhub.js:796
+#: static/js/zamboni/devhub-all.js:1975 static/js/zamboni/devhub-min.js:2 static/js/zamboni/devhub.js:796
 msgid "Learn more"
 msgstr "Learn more"
 
-#: static/js/zamboni/devhub.js:800
+#: static/js/zamboni/devhub-all.js:1979 static/js/zamboni/devhub-min.js:2 static/js/zamboni/devhub.js:800
 msgid "Example"
 msgstr "Example"
 
-#: static/js/zamboni/devhub.js:1130
+#: static/js/zamboni/devhub-all.js:2309 static/js/zamboni/devhub-min.js:2 static/js/zamboni/devhub.js:1130
 msgid "Image changes being processed"
 msgstr "Image changes being processed"
 
-#: static/js/zamboni/devhub.js:1280
+#: static/js/zamboni/devhub-all.js:2459 static/js/zamboni/devhub-min.js:2 static/js/zamboni/devhub.js:1280
 msgid "Must be a valid e-mail address."
 msgstr "Must be a valid e-mail address."
 
-#: static/js/zamboni/devhub_search.js:8
-msgid "No results found."
-msgstr "No results found."
-
-#: static/js/zamboni/editors.js:121
-msgid "{name} was viewing this page first."
-msgstr "{name} was viewing this page first."
-
-#: static/js/zamboni/editors.js:171
-msgid "Receipt checked by app."
-msgstr "Receipt checked by app."
-
-#: static/js/zamboni/editors.js:173
-msgid "Receipt was not checked by app."
-msgstr "Receipt was not checked by app."
-
-#: static/js/zamboni/editors.js:244
-msgid "{name} was viewing this add-on first."
-msgstr "{name} was viewing this add-on first."
-
-#: static/js/zamboni/editors.js:255
-msgid "Loading&hellip;"
-msgstr "Loading&hellip;"
-
-#: static/js/zamboni/editors.js:260
-msgid "Version Notes"
-msgstr "Version Notes"
-
-#: static/js/zamboni/editors.js:265
-msgid "Notes for Reviewers"
-msgstr "Notes for Reviewers"
-
-#: static/js/zamboni/editors.js:270
-msgid "No version notes found"
-msgstr "No version notes found"
-
-#: static/js/zamboni/editors.js:330
-msgid "Average Reviews"
-msgstr "Average Reviews"
-
-#: static/js/zamboni/editors.js:386
-msgid "Number of Reviews"
-msgstr "Number of Reviews"
-
-#: static/js/zamboni/editors.js:445
-msgid "Error loading translation"
-msgstr "Error loading translation"
-
-#: static/js/zamboni/files.js:411 static/js/zamboni/validator.js:261
-msgid "Ignore this message in future updates"
-msgstr "Ignore this message in future updates"
-
-#: static/js/zamboni/files.js:417 static/js/zamboni/validator.js:284
-msgid "Severity for automated signing:"
-msgstr "Severity for automated signing:"
-
-#: static/js/zamboni/global.js:410
-msgid "Loading..."
-msgstr "Loading..."
-
-#. L10n: {0} is the number of characters left.
-#: static/js/zamboni/global.js:474
-msgid "<b>{0}</b> character left."
-msgid_plural "<b>{0}</b> characters left."
-msgstr[0] "<b>{0}</b> character left."
-msgstr[1] "<b>{0}</b> characters left."
-
-#: static/js/zamboni/init.js:28
-msgid "This feature is temporarily disabled while we perform website maintenance. Please check back a little later."
-msgstr "This feature is temporarily disabled while we perform website maintenance. Please check back a little later."
-
-#: static/js/zamboni/l10n.js:45
-msgid "Remove this localization"
-msgstr "Remove this localization"
-
-#: static/js/zamboni/password-strength.js:20
-msgid "Password strength:"
-msgstr "Password strength:"
-
-#: static/js/zamboni/password-strength.js:26
-msgid "At least {0} character left."
-msgid_plural "At least {0} characters left."
-msgstr[0] "At least {0} character left."
-msgstr[1] "At least {0} characters left."
-
-#: static/js/zamboni/themes_review.js:176
-msgid "Requested Info"
-msgstr "Requested Info"
-
-#: static/js/zamboni/themes_review.js:177
-msgid "Flagged"
-msgstr "Flagged"
-
-#: static/js/zamboni/themes_review.js:178
-msgid "Duplicate"
-msgstr "Duplicate"
-
-#: static/js/zamboni/themes_review.js:179
-msgid "Rejected"
-msgstr "Rejected"
-
-#: static/js/zamboni/themes_review.js:180
-msgid "Approved"
-msgstr "Approved"
-
-#: static/js/zamboni/themes_review.js:424
-msgid "No results found"
-msgstr "No results found"
-
-#: static/js/zamboni/themes_review_templates.js:31
-msgid "Theme"
-msgstr "Theme"
-
-#: static/js/zamboni/themes_review_templates.js:33
-msgid "Reviewer"
-msgstr "Reviewer"
-
-#: static/js/zamboni/themes_review_templates.js:35
-msgid "Status"
-msgstr "Status"
-
-#: static/js/zamboni/validator.js:80
+#: static/js/zamboni/devhub-all.js:2613 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:80
 msgid "All tests passed successfully."
 msgstr "All tests passed successfully."
 
-#: static/js/zamboni/validator.js:83 static/js/zamboni/validator.js:478
+#: static/js/zamboni/devhub-all.js:2616 static/js/zamboni/devhub-all.js:3011 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:83 static/js/zamboni/validator.js:478
 msgid "These tests were not run."
 msgstr "These tests were not run."
 
-#: static/js/zamboni/validator.js:131 static/js/zamboni/validator.js:144
+#: static/js/zamboni/devhub-all.js:2664 static/js/zamboni/devhub-all.js:2677 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:131 static/js/zamboni/validator.js:144
 msgid "Tests"
 msgstr "Tests"
 
-#: static/js/zamboni/validator.js:246 static/js/zamboni/validator.js:575 static/js/zamboni/validator.js:594
+#: static/js/zamboni/devhub-all.js:2779 static/js/zamboni/devhub-all.js:3108 static/js/zamboni/devhub-all.js:3127 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:246
+#: static/js/zamboni/validator.js:575 static/js/zamboni/validator.js:594
 msgid "Error"
 msgstr "Error"
 
-#: static/js/zamboni/validator.js:247
+#: static/js/zamboni/devhub-all.js:2780 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:247
 msgid "Warning"
 msgstr "Warning"
 
-#: static/js/zamboni/validator.js:299
+#: static/js/zamboni/devhub-all.js:2794 static/js/zamboni/devhub-min.js:2 static/js/zamboni/files-all.js:5657 static/js/zamboni/files-min.js:3 static/js/zamboni/files.js:411
+#: static/js/zamboni/validator.js:261
+msgid "Ignore this message in future updates"
+msgstr "Ignore this message in future updates"
+
+#: static/js/zamboni/devhub-all.js:2817 static/js/zamboni/devhub-min.js:2 static/js/zamboni/files-all.js:5663 static/js/zamboni/files-min.js:3 static/js/zamboni/files.js:417
+#: static/js/zamboni/validator.js:284
+msgid "Severity for automated signing:"
+msgstr "Severity for automated signing:"
+
+#: static/js/zamboni/devhub-all.js:2832 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:299
 msgid "Suggestions for passing automated signing:"
 msgstr "Suggestions for passing automated signing:"
 
-#: static/js/zamboni/validator.js:387
+#: static/js/zamboni/devhub-all.js:2920 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:387
 msgid "Compatibility Tests"
 msgstr "Compatibility Tests"
 
-#: static/js/zamboni/validator.js:466
+#: static/js/zamboni/devhub-all.js:2999 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:466
 msgid "Add-on failed validation."
 msgstr "Add-on failed validation."
 
-#: static/js/zamboni/validator.js:468
+#: static/js/zamboni/devhub-all.js:3001 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:468
 msgid "Add-on passed validation."
 msgstr "Add-on passed validation."
 
-#: static/js/zamboni/validator.js:481
+#: static/js/zamboni/devhub-all.js:3014 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:481
 msgid "{0} error"
 msgid_plural "{0} errors"
 msgstr[0] "{0} error"
 msgstr[1] "{0} errors"
 
-#: static/js/zamboni/validator.js:483
+#: static/js/zamboni/devhub-all.js:3016 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:483
 msgid "{0} warning"
 msgid_plural "{0} warnings"
 msgstr[0] "{0} warning"
 msgstr[1] "{0} warnings"
 
-#: static/js/zamboni/validator.js:485
+#: static/js/zamboni/devhub-all.js:3018 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:485
 msgid "{0} notice"
 msgid_plural "{0} notices"
 msgstr[0] "{0} notice"
 msgstr[1] "{0} notices"
 
-#: static/js/zamboni/validator.js:577
+#: static/js/zamboni/devhub-all.js:3110 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:577
 msgid "Validation task could not complete or completed with errors"
 msgstr "Validation task could not complete or completed with errors"
 
-#: static/js/zamboni/validator.js:595
+#: static/js/zamboni/devhub-all.js:3128 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:595
 msgid "Internal server error"
 msgstr "Internal server error"
 
-#: static/js/zamboni/mobile/buttons.js:52
+#: static/js/zamboni/devhub_search.js:8
+msgid "No results found."
+msgstr "No results found."
+
+#: static/js/zamboni/editors-all.js:15402 static/js/zamboni/editors-min.js:4 static/js/zamboni/editors.js:121
+msgid "{name} was viewing this page first."
+msgstr "{name} was viewing this page first."
+
+#: static/js/zamboni/editors-all.js:15452 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:171
+msgid "Receipt checked by app."
+msgstr "Receipt checked by app."
+
+#: static/js/zamboni/editors-all.js:15454 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:173
+msgid "Receipt was not checked by app."
+msgstr "Receipt was not checked by app."
+
+#: static/js/zamboni/editors-all.js:15525 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:244
+msgid "{name} was viewing this add-on first."
+msgstr "{name} was viewing this add-on first."
+
+#: static/js/zamboni/editors-all.js:15536 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:255
+msgid "Loading&hellip;"
+msgstr "Loading&hellip;"
+
+#: static/js/zamboni/editors-all.js:15541 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:260
+msgid "Version Notes"
+msgstr "Version Notes"
+
+#: static/js/zamboni/editors-all.js:15546 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:265
+msgid "Notes for Reviewers"
+msgstr "Notes for Reviewers"
+
+#: static/js/zamboni/editors-all.js:15551 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:270
+msgid "No version notes found"
+msgstr "No version notes found"
+
+#: static/js/zamboni/editors-all.js:15611 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:330
+msgid "Average Reviews"
+msgstr "Average Reviews"
+
+#: static/js/zamboni/editors-all.js:15667 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:386
+msgid "Number of Reviews"
+msgstr "Number of Reviews"
+
+#: static/js/zamboni/editors-all.js:15726 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:445
+msgid "Error loading translation"
+msgstr "Error loading translation"
+
+#: static/js/zamboni/editors-all.js:15975 static/js/zamboni/editors-min.js:5 static/js/zamboni/themes_review_templates.js:31
+msgid "Theme"
+msgstr "Theme"
+
+#: static/js/zamboni/editors-all.js:15977 static/js/zamboni/editors-min.js:5 static/js/zamboni/themes_review_templates.js:33
+msgid "Reviewer"
+msgstr "Reviewer"
+
+#: static/js/zamboni/editors-all.js:15979 static/js/zamboni/editors-min.js:5 static/js/zamboni/themes_review_templates.js:35
+msgid "Status"
+msgstr "Status"
+
+#: static/js/zamboni/editors-all.js:16196 static/js/zamboni/editors-min.js:5 static/js/zamboni/themes_review.js:176
+msgid "Requested Info"
+msgstr "Requested Info"
+
+#: static/js/zamboni/editors-all.js:16197 static/js/zamboni/editors-min.js:5 static/js/zamboni/themes_review.js:177
+msgid "Flagged"
+msgstr "Flagged"
+
+#: static/js/zamboni/editors-all.js:16198 static/js/zamboni/editors-min.js:5 static/js/zamboni/themes_review.js:178
+msgid "Duplicate"
+msgstr "Duplicate"
+
+#: static/js/zamboni/editors-all.js:16199 static/js/zamboni/editors-min.js:5 static/js/zamboni/themes_review.js:179
+msgid "Rejected"
+msgstr "Rejected"
+
+#: static/js/zamboni/editors-all.js:16200 static/js/zamboni/editors-min.js:5 static/js/zamboni/themes_review.js:180
+msgid "Approved"
+msgstr "Approved"
+
+#: static/js/zamboni/editors-all.js:16444 static/js/zamboni/editors-min.js:5 static/js/zamboni/themes_review.js:424
+msgid "No results found"
+msgstr "No results found"
+
+#: static/js/zamboni/mobile-all.js:15186 static/js/zamboni/mobile/buttons.js:52
 msgid "Not Updated for {0} {1}"
 msgstr "Not Updated for {0} {1}"
 
-#: static/js/zamboni/mobile/buttons.js:53
+#: static/js/zamboni/mobile-all.js:15187 static/js/zamboni/mobile/buttons.js:53
 msgid "Requires Newer Version of {0}"
 msgstr "Requires Newer Version of {0}"
 
-#: static/js/zamboni/mobile/buttons.js:54
+#: static/js/zamboni/mobile-all.js:15188 static/js/zamboni/mobile/buttons.js:54
 msgid "Unreviewed"
 msgstr "Unreviewed"
 
-#: static/js/zamboni/mobile/buttons.js:55
+#: static/js/zamboni/mobile-all.js:15189 static/js/zamboni/mobile/buttons.js:55
 msgid "Experimental <span>(Learn More)</span>"
 msgstr "Experimental <span>(Learn More)</span>"
 
-#: static/js/zamboni/mobile/buttons.js:56 static/js/zamboni/mobile/buttons.js:57
+#: static/js/zamboni/mobile-all.js:15190 static/js/zamboni/mobile-all.js:15191 static/js/zamboni/mobile/buttons.js:56 static/js/zamboni/mobile/buttons.js:57
 msgid "Not Available for {0}"
 msgstr "Not Available for {0}"
 
-#: static/js/zamboni/mobile/buttons.js:58
+#: static/js/zamboni/mobile-all.js:15192 static/js/zamboni/mobile/buttons.js:58
 msgid "Experimental"
 msgstr "Experimental"
 
-#: static/js/zamboni/mobile/buttons.js:59
+#: static/js/zamboni/mobile-all.js:15193 static/js/zamboni/mobile/buttons.js:59
 msgid "Themes Require Newer Version of {0}"
 msgstr "Themes Require Newer Version of {0}"
 
-#: static/js/zamboni/mobile/buttons.js:60
+#: static/js/zamboni/mobile-all.js:15194 static/js/zamboni/mobile/buttons.js:60
 msgid "Themes Require {0}"
 msgstr "Themes Require {0}"
 
-#: static/js/zamboni/mobile/buttons.js:105
+#: static/js/zamboni/mobile-all.js:15239 static/js/zamboni/mobile/buttons.js:105
 msgid "Installing..."
 msgstr "Installing..."
 
-#: static/js/zamboni/mobile/buttons.js:125
+#: static/js/zamboni/mobile-all.js:15259 static/js/zamboni/mobile/buttons.js:125
 msgid "This add-on has been preliminarily reviewed by Mozilla."
 msgstr "This add-on has been preliminarily reviewed by Mozilla."
 
-#: static/js/zamboni/mobile/buttons.js:250
+#: static/js/zamboni/mobile-all.js:15384 static/js/zamboni/mobile/buttons.js:250
 msgid "Keep it"
 msgstr "Keep it"
 
-#: static/js/zamboni/mobile/general.js:344
+#: static/js/zamboni/mobile-all.js:16049 static/js/zamboni/mobile-min.js:6 static/js/zamboni/mobile/general.js:344
 msgid "You're trying it on!"
 msgstr "You're trying it on!"
 
-#: static/js/zamboni/mobile/general.js:356
+#: static/js/zamboni/mobile-all.js:16061 static/js/zamboni/mobile-min.js:6 static/js/zamboni/mobile/general.js:356
 msgid "Added to Firefox"
 msgstr "Added to Firefox"
-

--- a/locale/eo/LC_MESSAGES/django.po
+++ b/locale/eo/LC_MESSAGES/django.po
@@ -3,69 +3,70 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2016-02-24 21:23+0000\n"
+"POT-Creation-Date: 2016-04-18 15:47+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
+"Language: \n"
 "MIME-Version: 1.0\n"
-"Content-Type: text/plain; charset=utf-8\n"
+"Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Generated-By: Babel 2.2.0\n"
 
-#: src/olympia/accounts/views.py:52
+#: src/olympia/accounts/views.py:54
 msgid "Your log in attempt could not be parsed. Please try again."
 msgstr ""
 
-#: src/olympia/accounts/views.py:54
+#: src/olympia/accounts/views.py:56
 msgid "Your Firefox Account could not be found. Please try again."
 msgstr ""
 
-#: src/olympia/accounts/views.py:55
+#: src/olympia/accounts/views.py:57
 msgid "You could not be logged in. Please try again."
 msgstr ""
 
-#: src/olympia/accounts/views.py:57
+#: src/olympia/accounts/views.py:59
 msgid "Your account has already been migrated to Firefox Accounts."
 msgstr ""
 
-#: src/olympia/accounts/views.py:59
+#: src/olympia/accounts/views.py:61
 msgid "Your Firefox Account already exists on this site."
 msgstr ""
 
-#: src/olympia/accounts/views.py:108
+#: src/olympia/accounts/views.py:110
 msgid "Great job!"
 msgstr ""
 
-#: src/olympia/accounts/views.py:109
+#: src/olympia/accounts/views.py:111
 msgid "You can now log in to Add-ons with your Firefox Account."
 msgstr ""
 
-#: src/olympia/accounts/views.py:121
+#: src/olympia/accounts/views.py:123
 msgid "Need help?"
 msgstr ""
 
-#: src/olympia/addons/buttons.py:180
+#: src/olympia/addons/buttons.py:177
 msgid "Download Now"
 msgstr ""
 
-#: src/olympia/addons/buttons.py:182
+#: src/olympia/addons/buttons.py:179
 msgid "Download"
 msgstr ""
 
 #. L10n: please keep &nbsp; in the string so &rarr; does not wrap.
-#: src/olympia/addons/buttons.py:186
+#: src/olympia/addons/buttons.py:183
 msgid "Continue to Download&nbsp;&rarr;"
 msgstr ""
 
-#: src/olympia/addons/buttons.py:202 src/olympia/addons/helpers.py:35 src/olympia/addons/views.py:319 src/olympia/addons/templates/addons/impala/details.html:114
+#: src/olympia/addons/buttons.py:199 src/olympia/addons/helpers.py:35 src/olympia/addons/views.py:333 src/olympia/addons/templates/addons/impala/details.html:111
 #: src/olympia/addons/templates/addons/impala/listing/items.html:17 src/olympia/addons/templates/addons/mobile/home.html:40 src/olympia/amo/templates/amo/side_nav.html:6
-#: src/olympia/amo/templates/amo/side_nav.html:10 src/olympia/amo/templates/amo/site_nav.html:2 src/olympia/amo/templates/amo/site_nav.html:55 src/olympia/bandwagon/views.py:95
-#: src/olympia/browse/views.py:54 src/olympia/browse/views.py:68 src/olympia/browse/views.py:235 src/olympia/browse/templates/browse/impala/category_landing.html:22
+#: src/olympia/amo/templates/amo/side_nav.html:10 src/olympia/amo/templates/amo/site_nav.html:2 src/olympia/amo/templates/amo/site_nav.html:53 src/olympia/bandwagon/views.py:95
+#: src/olympia/browse/views.py:54 src/olympia/browse/views.py:68 src/olympia/browse/views.py:202 src/olympia/browse/templates/browse/impala/category_landing.html:22
 #: src/olympia/browse/templates/browse/personas/mobile/category_landing.html:26
 msgid "Featured"
 msgstr ""
 
-#: src/olympia/addons/buttons.py:221
+#: src/olympia/addons/buttons.py:218
 msgid "Add to {0}"
 msgstr ""
 
@@ -113,39 +114,39 @@ msgid_plural "All tags must be at least {0} characters."
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/olympia/addons/forms.py:234
+#: src/olympia/addons/forms.py:238
 msgid "Categories cannot be changed while your add-on is featured for this application."
 msgstr ""
 
 #. L10n: {0} is the number of categories.
-#: src/olympia/addons/forms.py:238
+#: src/olympia/addons/forms.py:242
 msgid "You can have only {0} category."
 msgid_plural "You can have only {0} categories."
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/olympia/addons/forms.py:246
+#: src/olympia/addons/forms.py:250
 msgid "The miscellaneous category cannot be combined with additional categories."
 msgstr ""
 
-#: src/olympia/addons/forms.py:369
+#: src/olympia/addons/forms.py:374
 #, python-format
 msgid "Before changing your default locale you must have a name, summary, and description in that locale. You are missing %s."
 msgstr ""
 
-#: src/olympia/addons/forms.py:484 src/olympia/addons/forms.py:575
+#: src/olympia/addons/forms.py:455 src/olympia/addons/forms.py:546
 msgid "A license must be selected."
 msgstr ""
 
-#: src/olympia/addons/forms.py:556
+#: src/olympia/addons/forms.py:527
 msgid "Give Your Theme a Name."
 msgstr ""
 
-#: src/olympia/addons/forms.py:562 src/olympia/devhub/templates/devhub/personas/submit.html:53
+#: src/olympia/addons/forms.py:533 src/olympia/devhub/templates/devhub/personas/submit.html:53
 msgid "Describe your Theme."
 msgstr ""
 
-#: src/olympia/addons/forms.py:704
+#: src/olympia/addons/forms.py:675
 msgid "Enter a new author's email address"
 msgstr ""
 
@@ -153,37 +154,37 @@ msgstr ""
 msgid "Not Reviewed"
 msgstr ""
 
-#: src/olympia/addons/models.py:301
+#: src/olympia/addons/models.py:298
 msgid "Users have the option of contributing more or less than this amount."
 msgstr ""
 
-#: src/olympia/addons/models.py:309
-msgid "Users will always be asked in the Add-ons Manager (Firefox 4 and above)"
+#: src/olympia/addons/models.py:306
+msgid "Users will always be asked in the Add-ons Manager (Firefox 4 and above). Only applies to desktop."
 msgstr ""
 
-#: src/olympia/addons/models.py:1804 src/olympia/addons/templates/addons/details_box.html:55 src/olympia/devhub/templates/devhub/index.html:92
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:102
+#: src/olympia/addons/models.py:1802 src/olympia/addons/templates/addons/details_box.html:55 src/olympia/devhub/templates/devhub/index.html:92
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:89
 msgid "Listed"
 msgstr ""
 
-#: src/olympia/addons/views.py:320 src/olympia/browse/templates/browse/personas/mobile/category_landing.html:27
+#: src/olympia/addons/views.py:334 src/olympia/browse/templates/browse/personas/mobile/category_landing.html:27
 msgid "Popular"
 msgstr ""
 
-#: src/olympia/addons/views.py:321 src/olympia/browse/views.py:238 src/olympia/browse/views.py:280 src/olympia/browse/views.py:482
+#: src/olympia/addons/views.py:335 src/olympia/browse/views.py:205 src/olympia/browse/views.py:247 src/olympia/browse/views.py:449
 msgid "Recently Added"
 msgstr ""
 
-#: src/olympia/addons/views.py:322 src/olympia/bandwagon/views.py:99 src/olympia/browse/views.py:60 src/olympia/browse/views.py:71 src/olympia/search/forms.py:16 src/olympia/search/forms.py:91
+#: src/olympia/addons/views.py:336 src/olympia/bandwagon/views.py:99 src/olympia/browse/views.py:60 src/olympia/browse/views.py:71 src/olympia/search/forms.py:16 src/olympia/search/forms.py:91
 msgid "Recently Updated"
 msgstr ""
 
 #. l10n: {0} is the addon name
-#: src/olympia/addons/views.py:520
+#: src/olympia/addons/views.py:534
 msgid "Contribution for {0}"
 msgstr ""
 
-#: src/olympia/addons/views.py:613
+#: src/olympia/addons/views.py:627
 msgid "Abuse reported."
 msgstr ""
 
@@ -250,9 +251,9 @@ msgstr ""
 #: src/olympia/devhub/templates/devhub/addons/ajax_compat_update.html:36 src/olympia/devhub/templates/devhub/addons/profile.html:44 src/olympia/devhub/templates/devhub/addons/edit/admin.html:101
 #: src/olympia/devhub/templates/devhub/addons/edit/basic.html:152 src/olympia/devhub/templates/devhub/addons/edit/details.html:85 src/olympia/devhub/templates/devhub/addons/edit/support.html:67
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:166 src/olympia/devhub/templates/devhub/addons/forms_shared/media.html:149
-#: src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:44 src/olympia/devhub/templates/devhub/versions/add_file_modal.html:78 src/olympia/devhub/templates/devhub/versions/edit.html:139
-#: src/olympia/devhub/templates/devhub/versions/list.html:242 src/olympia/devhub/templates/devhub/versions/list.html:276 src/olympia/devhub/templates/devhub/versions/list.html:317
-#: src/olympia/devhub/templates/devhub/versions/list.html:351 src/olympia/reviews/templates/reviews/edit_review.html:16 src/olympia/translations/templates/translations/trans-menu.html:50
+#: src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:43 src/olympia/devhub/templates/devhub/versions/add_file_modal.html:58 src/olympia/devhub/templates/devhub/versions/edit.html:139
+#: src/olympia/devhub/templates/devhub/versions/list.html:239 src/olympia/devhub/templates/devhub/versions/list.html:281 src/olympia/devhub/templates/devhub/versions/list.html:315
+#: src/olympia/devhub/templates/devhub/versions/list.html:349 src/olympia/reviews/templates/reviews/edit_review.html:16 src/olympia/translations/templates/translations/trans-menu.html:50
 #: src/olympia/translations/templates/translations/trans-menu.html:62
 msgid "or"
 msgstr ""
@@ -363,7 +364,7 @@ msgid "Add-on Information for {0}"
 msgstr ""
 
 #: src/olympia/addons/templates/addons/details_box.html:30 src/olympia/addons/templates/addons/persona_detail_table.html:3 src/olympia/addons/templates/addons/mobile/details.html:63
-#: src/olympia/addons/templates/addons/mobile/persona_detail_table.html:7 src/olympia/browse/views.py:459 src/olympia/devhub/views.py:75
+#: src/olympia/addons/templates/addons/mobile/persona_detail_table.html:7 src/olympia/browse/views.py:426 src/olympia/devhub/views.py:73
 msgid "Updated"
 msgstr ""
 
@@ -382,11 +383,11 @@ msgstr ""
 msgid "Visibility"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/details_box.html:57 src/olympia/devhub/templates/devhub/index.html:94 src/olympia/devhub/templates/devhub/includes/addon_details.html:104
+#: src/olympia/addons/templates/addons/details_box.html:57 src/olympia/devhub/templates/devhub/index.html:94 src/olympia/devhub/templates/devhub/includes/addon_details.html:91
 msgid "Hidden"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/details_box.html:59 src/olympia/devhub/templates/devhub/index.html:96 src/olympia/devhub/templates/devhub/includes/addon_details.html:106
+#: src/olympia/addons/templates/addons/details_box.html:59 src/olympia/devhub/templates/devhub/index.html:96 src/olympia/devhub/templates/devhub/includes/addon_details.html:93
 msgid "Unlisted"
 msgstr ""
 
@@ -394,13 +395,13 @@ msgstr ""
 msgid "Required Add-ons"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/details_box.html:81 src/olympia/addons/templates/addons/persona_detail_table.html:15 src/olympia/browse/views.py:462 src/olympia/devhub/views.py:78
-#: src/olympia/devhub/views.py:85 src/olympia/discovery/templates/discovery/addons/detail.html:57 src/olympia/reviews/forms.py:62 src/olympia/reviews/templates/reviews/add.html:57
+#: src/olympia/addons/templates/addons/details_box.html:81 src/olympia/addons/templates/addons/persona_detail_table.html:15 src/olympia/browse/views.py:429 src/olympia/devhub/views.py:76
+#: src/olympia/devhub/views.py:83 src/olympia/discovery/templates/discovery/addons/detail.html:57 src/olympia/reviews/forms.py:62 src/olympia/reviews/templates/reviews/add.html:57
 #: src/olympia/reviews/templates/reviews/mobile/review_list.html:18
 msgid "Rating"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/details_box.html:85 src/olympia/browse/views.py:461 src/olympia/devhub/views.py:77 src/olympia/devhub/views.py:84
+#: src/olympia/addons/templates/addons/details_box.html:85 src/olympia/browse/views.py:428 src/olympia/devhub/views.py:75 src/olympia/devhub/views.py:82
 #: src/olympia/stats/templates/stats/addon_report_menu.html:8 src/olympia/stats/templates/stats/collection_report_menu.html:18
 msgid "Downloads"
 msgstr ""
@@ -420,7 +421,7 @@ msgstr ""
 
 #. The Privacy Policy for this add-on.
 #: src/olympia/addons/templates/addons/details_box.html:121 src/olympia/addons/templates/addons/privacy.html:19 src/olympia/addons/templates/addons/privacy.html:23
-#: src/olympia/addons/templates/addons/impala/button.html:43 src/olympia/addons/templates/addons/impala/details.html:307 src/olympia/devhub/templates/devhub/includes/policy_form.html:20
+#: src/olympia/addons/templates/addons/impala/button.html:43 src/olympia/addons/templates/addons/impala/details.html:312 src/olympia/devhub/templates/devhub/includes/policy_form.html:23
 #: src/olympia/templates/mobile/base_addons.html:87
 msgid "Privacy Policy"
 msgstr ""
@@ -445,7 +446,7 @@ msgstr ""
 msgid "Developer Comments"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/details_box.html:199 src/olympia/addons/templates/addons/impala/details.html:259
+#: src/olympia/addons/templates/addons/details_box.html:199 src/olympia/addons/templates/addons/impala/details.html:264
 msgid "Development Channel"
 msgstr ""
 
@@ -465,7 +466,7 @@ msgid ""
 "developer. To stop receiving development updates, reinstall the default version from the link above."
 msgstr ""
 
-#: src/olympia/addons/templates/addons/details_box.html:220 src/olympia/addons/templates/addons/impala/details.html:278
+#: src/olympia/addons/templates/addons/details_box.html:220 src/olympia/addons/templates/addons/impala/details.html:283
 msgid "Version {0}:"
 msgstr ""
 
@@ -484,7 +485,7 @@ msgid "End-User License Agreement for {0}"
 msgstr ""
 
 #: src/olympia/addons/templates/addons/eula.html:17 src/olympia/addons/templates/addons/eula.html:21 src/olympia/addons/templates/addons/impala/button.html:48
-#: src/olympia/addons/templates/addons/impala/details.html:316 src/olympia/devhub/templates/devhub/includes/policy_form.html:3 src/olympia/discovery/templates/discovery/addons/eula.html:11
+#: src/olympia/addons/templates/addons/impala/details.html:321 src/olympia/devhub/templates/devhub/includes/policy_form.html:3 src/olympia/discovery/templates/discovery/addons/eula.html:11
 msgid "End-User License Agreement"
 msgstr ""
 
@@ -501,7 +502,7 @@ msgstr ""
 msgid "Add-ons for {0}"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/home.html:10 src/olympia/addons/templates/addons/home.html:51 src/olympia/browse/templates/browse/impala/base_listing.html:11
+#: src/olympia/addons/templates/addons/home.html:10 src/olympia/addons/templates/addons/home.html:53 src/olympia/browse/templates/browse/impala/base_listing.html:11
 msgid "Featured Extensions"
 msgstr ""
 
@@ -509,29 +510,29 @@ msgstr ""
 msgid "Popular Extensions"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/home.html:42 src/olympia/amo/templates/amo/side_nav.html:3 src/olympia/amo/templates/amo/side_nav.html:11 src/olympia/amo/templates/amo/site_nav.html:3
-#: src/olympia/amo/templates/amo/site_nav.html:25 src/olympia/browse/views.py:236 src/olympia/browse/views.py:281 src/olympia/browse/views.py:481
+#: src/olympia/addons/templates/addons/home.html:44 src/olympia/amo/templates/amo/side_nav.html:3 src/olympia/amo/templates/amo/side_nav.html:11 src/olympia/amo/templates/amo/site_nav.html:3
+#: src/olympia/amo/templates/amo/site_nav.html:25 src/olympia/browse/views.py:203 src/olympia/browse/views.py:248 src/olympia/browse/views.py:448
 msgid "Most Popular"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/home.html:43
+#: src/olympia/addons/templates/addons/home.html:45
 msgid "All »"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/home.html:52 src/olympia/addons/templates/addons/home.html:61 src/olympia/addons/templates/addons/home.html:70 src/olympia/addons/templates/addons/home.html:78
+#: src/olympia/addons/templates/addons/home.html:54 src/olympia/addons/templates/addons/home.html:63 src/olympia/addons/templates/addons/home.html:72 src/olympia/addons/templates/addons/home.html:80
 #: src/olympia/browse/templates/browse/impala/category_landing.html:36
 msgid "See all »"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/home.html:60
+#: src/olympia/addons/templates/addons/home.html:62
 msgid "Up &amp; Coming Extensions"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/home.html:69 src/olympia/browse/templates/browse/personas/category_landing.html:61 src/olympia/discovery/templates/discovery/pane.html:74
+#: src/olympia/addons/templates/addons/home.html:71 src/olympia/browse/templates/browse/personas/category_landing.html:61 src/olympia/discovery/templates/discovery/pane.html:74
 msgid "Featured Themes"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/home.html:77 src/olympia/bandwagon/templates/bandwagon/impala/collection_listing.html:5
+#: src/olympia/addons/templates/addons/home.html:79 src/olympia/bandwagon/templates/bandwagon/impala/collection_listing.html:5
 msgid "Featured Collections"
 msgstr ""
 
@@ -549,7 +550,7 @@ msgid "Updated {0}"
 msgstr ""
 
 #. {0} is a date.
-#: src/olympia/addons/templates/addons/macros.html:10 src/olympia/addons/templates/addons/macros.html:69 src/olympia/addons/templates/addons/persona_preview.html:21
+#: src/olympia/addons/templates/addons/macros.html:10 src/olympia/addons/templates/addons/macros.html:69 src/olympia/addons/templates/addons/persona_preview.html:22
 #: src/olympia/addons/templates/addons/listing/items_mobile.html:44 src/olympia/addons/templates/addons/listing/macros.html:39
 #: src/olympia/bandwagon/templates/bandwagon/collection_listing_items.html:37 src/olympia/bandwagon/templates/bandwagon/impala/collection_listing_items.html:37
 msgid "Added {0}"
@@ -570,15 +571,14 @@ msgstr[0] ""
 msgstr[1] ""
 
 #. {0} is the number of downloads.
-#: src/olympia/addons/templates/addons/macros.html:53 src/olympia/addons/templates/addons/impala/details.html:61
+#: src/olympia/addons/templates/addons/macros.html:53 src/olympia/addons/templates/addons/impala/details.html:59
 msgid "{0} weekly download"
 msgid_plural "{0} weekly downloads"
 msgstr[0] ""
 msgstr[1] ""
 
 #. {0} is the number of users.
-#: src/olympia/addons/templates/addons/macros.html:61 src/olympia/addons/templates/addons/impala/details.html:54 src/olympia/compat/templates/compat/index.html:71
-#: src/olympia/zadmin/templates/zadmin/compat.html:67
+#: src/olympia/addons/templates/addons/macros.html:61 src/olympia/addons/templates/addons/impala/details.html:52 src/olympia/zadmin/templates/zadmin/compat.html:67
 msgid "{0} user"
 msgid_plural "{0} users"
 msgstr[0] ""
@@ -596,7 +596,7 @@ msgstr ""
 msgid "Return to the addon."
 msgstr ""
 
-#: src/olympia/addons/templates/addons/persona_detail.html:17 src/olympia/addons/templates/addons/impala/details.html:106 src/olympia/addons/templates/addons/mobile/details.html:23
+#: src/olympia/addons/templates/addons/persona_detail.html:17 src/olympia/addons/templates/addons/impala/details.html:103 src/olympia/addons/templates/addons/mobile/details.html:23
 #: src/olympia/addons/templates/addons/mobile/persona_detail.html:21 src/olympia/discovery/templates/discovery/addons/base.html:27 src/olympia/editors/templates/editors/review.html:31
 msgid "by"
 msgstr ""
@@ -640,34 +640,35 @@ msgstr ""
 msgid "License"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/persona_preview.html:12 src/olympia/constants/base.py:48
+#: src/olympia/addons/templates/addons/persona_preview.html:13 src/olympia/constants/base.py:48
 msgid "Awaiting Review"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/persona_preview.html:14 src/olympia/amo/log.py:180 src/olympia/constants/base.py:42 src/olympia/editors/helpers.py:62
+#: src/olympia/addons/templates/addons/persona_preview.html:15 src/olympia/amo/log.py:180 src/olympia/constants/base.py:42 src/olympia/editors/helpers.py:62
 msgid "Rejected"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/persona_preview.html:16 src/olympia/amo/log.py:159
+#: src/olympia/addons/templates/addons/persona_preview.html:17 src/olympia/amo/log.py:159
 msgid "Approved"
 msgstr ""
 
 #. {0} is the number of users.
-#: src/olympia/addons/templates/addons/persona_preview.html:26 src/olympia/addons/templates/addons/listing/items_mobile.html:36 src/olympia/addons/templates/addons/listing/macros.html:31
+#: src/olympia/addons/templates/addons/persona_preview.html:27 src/olympia/addons/templates/addons/listing/items_mobile.html:36 src/olympia/addons/templates/addons/listing/macros.html:31
 msgid "<strong>{0}</strong> user"
 msgid_plural "<strong>{0}</strong> users"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/olympia/addons/templates/addons/persona_preview.html:40
+#: src/olympia/addons/templates/addons/persona_preview.html:41
 msgid "Hover to Preview"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/persona_preview.html:46 src/olympia/addons/templates/addons/persona_preview.html:48 src/olympia/reviews/templates/reviews/add.html:15
+#: src/olympia/addons/templates/addons/persona_preview.html:47 src/olympia/addons/templates/addons/persona_preview.html:49 src/olympia/addons/templates/addons/persona_preview.html:97
+#: src/olympia/reviews/templates/reviews/add.html:15
 msgid "Add"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/persona_preview.html:57 src/olympia/bandwagon/templates/bandwagon/ajax_new.html:16 src/olympia/bandwagon/templates/bandwagon/edit.html:19
+#: src/olympia/addons/templates/addons/persona_preview.html:58 src/olympia/bandwagon/templates/bandwagon/ajax_new.html:16 src/olympia/bandwagon/templates/bandwagon/edit.html:19
 #: src/olympia/bandwagon/templates/bandwagon/includes/addedit.html:19 src/olympia/devhub/templates/devhub/addons/edit/admin.html:13 src/olympia/devhub/templates/devhub/addons/edit/basic.html:10
 #: src/olympia/devhub/templates/devhub/addons/edit/details.html:8 src/olympia/devhub/templates/devhub/addons/edit/media.html:6 src/olympia/devhub/templates/devhub/addons/edit/support.html:8
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:9 src/olympia/devhub/templates/devhub/addons/submit/describe.html:29 src/olympia/editors/templates/editors/review.html:257
@@ -676,21 +677,21 @@ msgstr ""
 
 #. For datetime formatting, see the table on
 #. http://docs.python.org/library/datetime.html#strftime-and-strptime-behavior
-#: src/olympia/addons/templates/addons/persona_preview.html:66
+#: src/olympia/addons/templates/addons/persona_preview.html:67
 #, python-format
 msgid "%%Y-%%m-%%d"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/persona_preview.html:67
+#: src/olympia/addons/templates/addons/persona_preview.html:68
 msgid "by {0} on {1}"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/persona_preview.html:75 src/olympia/reviews/helpers.py:17 src/olympia/reviews/templates/reviews/review_list.html:63
+#: src/olympia/addons/templates/addons/persona_preview.html:76 src/olympia/reviews/helpers.py:17 src/olympia/reviews/templates/reviews/review_list.html:63
 #: src/olympia/reviews/templates/reviews/reviews_link.html:21 src/olympia/reviews/templates/reviews/impala/reviews_link.html:16
 msgid "Not yet rated"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/persona_preview.html:78
+#: src/olympia/addons/templates/addons/persona_preview.html:79
 msgid "<b>{0}</b> users"
 msgstr ""
 
@@ -703,7 +704,7 @@ msgid "Learn more about Firefox"
 msgstr ""
 
 #: src/olympia/addons/templates/addons/popups.html:22
-msgid "or <b><a class=\"installer\" href=\"{url}\">download anyway</a></b>"
+msgid "or <b><a class=\"button installer\" href=\"{url}\">download anyway</a></b>"
 msgstr ""
 
 #: src/olympia/addons/templates/addons/popups.html:26
@@ -802,7 +803,7 @@ msgid ""
 msgstr ""
 
 #: src/olympia/addons/templates/addons/report_abuse.html:6 src/olympia/addons/templates/addons/report_abuse_full.html:10 src/olympia/addons/templates/addons/impala/details-more.html:23
-#: src/olympia/addons/templates/addons/impala/details.html:328
+#: src/olympia/addons/templates/addons/impala/details.html:333
 msgid "Report Abuse"
 msgstr ""
 
@@ -821,9 +822,9 @@ msgstr ""
 #: src/olympia/devhub/templates/devhub/addons/ajax_compat_update.html:36 src/olympia/devhub/templates/devhub/addons/profile.html:44 src/olympia/devhub/templates/devhub/addons/edit/admin.html:104
 #: src/olympia/devhub/templates/devhub/addons/edit/basic.html:155 src/olympia/devhub/templates/devhub/addons/edit/details.html:88 src/olympia/devhub/templates/devhub/addons/edit/support.html:70
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:169 src/olympia/devhub/templates/devhub/addons/forms_shared/media.html:152
-#: src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:44 src/olympia/devhub/templates/devhub/personas/edit.html:222 src/olympia/devhub/templates/devhub/versions/add_file_modal.html:79
-#: src/olympia/devhub/templates/devhub/versions/edit.html:140 src/olympia/devhub/templates/devhub/versions/list.html:208 src/olympia/devhub/templates/devhub/versions/list.html:242
-#: src/olympia/devhub/templates/devhub/versions/list.html:276 src/olympia/devhub/templates/devhub/versions/list.html:317 src/olympia/reviews/templates/reviews/edit_review.html:16
+#: src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:43 src/olympia/devhub/templates/devhub/personas/edit.html:222 src/olympia/devhub/templates/devhub/versions/add_file_modal.html:59
+#: src/olympia/devhub/templates/devhub/versions/edit.html:140 src/olympia/devhub/templates/devhub/versions/list.html:208 src/olympia/devhub/templates/devhub/versions/list.html:239
+#: src/olympia/devhub/templates/devhub/versions/list.html:281 src/olympia/devhub/templates/devhub/versions/list.html:315 src/olympia/reviews/templates/reviews/edit_review.html:16
 #: src/olympia/translations/templates/translations/trans-menu.html:50 src/olympia/translations/templates/translations/trans-menu.html:62 src/olympia/zadmin/templates/zadmin/validation.html:105
 msgid "Cancel"
 msgstr ""
@@ -868,7 +869,7 @@ msgstr ""
 msgid "Review Guidelines"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/review_list_box.html:5 src/olympia/addons/templates/addons/impala/details-more.html:27 src/olympia/editors/helpers.py:921
+#: src/olympia/addons/templates/addons/review_list_box.html:5 src/olympia/addons/templates/addons/impala/details-more.html:27 src/olympia/editors/helpers.py:1001
 #: src/olympia/reviews/templates/reviews/add.html:14 src/olympia/reviews/templates/reviews/reply.html:14 src/olympia/reviews/templates/reviews/review_list.html:19
 #: src/olympia/reviews/templates/reviews/mobile/review_list.html:26
 msgid "Reviews"
@@ -959,119 +960,119 @@ msgid_plural "Other add-ons by these authors"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/olympia/addons/templates/addons/impala/details.html:41
+#: src/olympia/addons/templates/addons/impala/details.html:39
 #, python-format
 msgid "<span itemprop=\"ratingCount\">%(num)s</span> user review"
 msgid_plural "<span itemprop=\"ratingCount\">%(num)s</span> user reviews"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/olympia/addons/templates/addons/impala/details.html:69
+#: src/olympia/addons/templates/addons/impala/details.html:66
 msgid "View statistics"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/impala/details.html:84
+#: src/olympia/addons/templates/addons/impala/details.html:81
 msgid "Manage"
 msgstr ""
 
 #. {0} is an add-on name.
-#: src/olympia/addons/templates/addons/impala/details.html:96
+#: src/olympia/addons/templates/addons/impala/details.html:93
 msgid "Icon of {0}"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/impala/details.html:103 src/olympia/addons/templates/addons/impala/listing/items.html:14
+#: src/olympia/addons/templates/addons/impala/details.html:100 src/olympia/addons/templates/addons/impala/listing/items.html:14
 msgid "No Restart"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/impala/details.html:127
+#: src/olympia/addons/templates/addons/impala/details.html:124
 #, python-format
 msgid "Meet the Developer: <a href=\"%(url)s\">%(name)s</a>"
 msgid_plural "<a href=\"%(url)s\">Meet the Developers</a>"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/olympia/addons/templates/addons/impala/details.html:137
+#: src/olympia/addons/templates/addons/impala/details.html:134
 msgid "Learn why {0} was created and find out what's next for this add-on."
 msgstr ""
 
 #. {0} is an index.
-#: src/olympia/addons/templates/addons/impala/details.html:156
+#: src/olympia/addons/templates/addons/impala/details.html:161
 msgid "Add-on screenshot #{0}"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/impala/details.html:182
+#: src/olympia/addons/templates/addons/impala/details.html:187
 msgid "Add-on home page"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/impala/details.html:185
+#: src/olympia/addons/templates/addons/impala/details.html:190
 msgid "Support site"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/impala/details.html:189
+#: src/olympia/addons/templates/addons/impala/details.html:194
 msgid "Support E-mail"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/impala/details.html:194 src/olympia/devhub/models.py:378 src/olympia/devhub/templates/devhub/versions/list.html:12
+#: src/olympia/addons/templates/addons/impala/details.html:199 src/olympia/devhub/models.py:378 src/olympia/devhub/templates/devhub/versions/list.html:12
 #: src/olympia/versions/templates/versions/version.html:6 src/olympia/versions/templates/versions/mobile/version.html:6
 msgid "Version {0}"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/impala/details.html:194
+#: src/olympia/addons/templates/addons/impala/details.html:199
 msgid "Info"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/impala/details.html:195 src/olympia/devhub/templates/devhub/includes/addon_details.html:129
+#: src/olympia/addons/templates/addons/impala/details.html:200 src/olympia/devhub/templates/devhub/includes/addon_details.html:116
 msgid "Last Updated:"
-msgstr ""
-
-#: src/olympia/addons/templates/addons/impala/details.html:200
-#, python-format
-msgid "Released under <a target=\"_blank\" href=\"%(url)s\">%(name)s</a>"
-msgstr ""
-
-#: src/olympia/addons/templates/addons/impala/details.html:201 src/olympia/addons/templates/addons/impala/details.html:206 src/olympia/amo/helpers.py:398 src/olympia/devhub/forms.py:142
-#: src/olympia/devhub/forms.py:173 src/olympia/versions/templates/versions/version.html:40 src/olympia/versions/templates/versions/version.html:45
-msgid "Custom License"
 msgstr ""
 
 #: src/olympia/addons/templates/addons/impala/details.html:205
 #, python-format
+msgid "Released under <a target=\"_blank\" href=\"%(url)s\">%(name)s</a>"
+msgstr ""
+
+#: src/olympia/addons/templates/addons/impala/details.html:206 src/olympia/addons/templates/addons/impala/details.html:211 src/olympia/amo/helpers.py:398 src/olympia/devhub/forms.py:142
+#: src/olympia/devhub/forms.py:173 src/olympia/versions/templates/versions/version.html:40 src/olympia/versions/templates/versions/version.html:45
+msgid "Custom License"
+msgstr ""
+
+#: src/olympia/addons/templates/addons/impala/details.html:210
+#, python-format
 msgid "Released under <a href=\"%(url)s\">%(name)s</a>"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/impala/details.html:217
+#: src/olympia/addons/templates/addons/impala/details.html:222
 msgid "About this Add-on"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/impala/details.html:233
+#: src/olympia/addons/templates/addons/impala/details.html:238
 msgid "Developer’s Comments"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/impala/details.html:243
+#: src/olympia/addons/templates/addons/impala/details.html:248
 msgid "Version Information"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/impala/details.html:250
+#: src/olympia/addons/templates/addons/impala/details.html:255
 msgid "See complete version history"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/impala/details.html:262
+#: src/olympia/addons/templates/addons/impala/details.html:267
 msgid ""
 "The Development Channel lets you test an experimental new version of this add-on before it's released to the general public. Once you install the development version, you will continue to get "
 "updates from this channel. To stop receiving development updates, reinstall the default version from the link above."
 msgstr ""
 
-#: src/olympia/addons/templates/addons/impala/details.html:272
+#: src/olympia/addons/templates/addons/impala/details.html:277
 msgid "<strong>Caution:</strong> Development versions of this add-on have not been reviewed by Mozilla."
 msgstr ""
 
-#: src/olympia/addons/templates/addons/impala/details.html:287
+#: src/olympia/addons/templates/addons/impala/details.html:292
 msgid "See complete development channel history"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/impala/details.html:306 src/olympia/addons/templates/addons/impala/details.html:315 src/olympia/addons/templates/addons/impala/details.html:327
+#: src/olympia/addons/templates/addons/impala/details.html:311 src/olympia/addons/templates/addons/impala/details.html:320 src/olympia/addons/templates/addons/impala/details.html:332
 #: src/olympia/addons/templates/addons/impala/review_add_box.html:4 src/olympia/stats/templates/stats/popup.html:2 src/olympia/stats/templates/stats/popup.html:8
-#: src/olympia/stats/templates/stats/stats.html:202 src/olympia/users/templates/users/profile.html:119
+#: src/olympia/stats/templates/stats/stats.html:204 src/olympia/users/templates/users/profile.html:119
 msgid "close"
 msgstr ""
 
@@ -1127,15 +1128,11 @@ msgstr ""
 msgid "Source Code License"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/impala/persona_grid.html:16 src/olympia/addons/templates/addons/impala/toplist.html:6
-msgid "{0} users"
-msgstr ""
-
 #: src/olympia/addons/templates/addons/impala/review_list_box.html:19 src/olympia/reviews/templates/reviews/review.html:40
 msgid "permalink"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/impala/review_list_box.html:23 src/olympia/editors/templates/editors/queue.html:98 src/olympia/reviews/templates/reviews/review.html:44
+#: src/olympia/addons/templates/addons/impala/review_list_box.html:23 src/olympia/editors/templates/editors/queue.html:104 src/olympia/reviews/templates/reviews/review.html:44
 msgid "translate"
 msgstr ""
 
@@ -1154,6 +1151,10 @@ msgstr ""
 msgid "Be the first!"
 msgstr ""
 
+#: src/olympia/addons/templates/addons/impala/toplist.html:6
+msgid "{0} users"
+msgstr ""
+
 #: src/olympia/addons/templates/addons/impala/listing/sorter.html:14 src/olympia/devhub/templates/devhub/addons/listing/item_actions.html:49
 msgid "More"
 msgstr ""
@@ -1166,7 +1167,7 @@ msgstr ""
 msgid "My Add-ons"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/includes/dashboard_tabs.html:6 src/olympia/amo/context_processors.py:51
+#: src/olympia/addons/templates/addons/includes/dashboard_tabs.html:6 src/olympia/amo/context_processors.py:50
 msgid "My Themes"
 msgstr ""
 
@@ -1221,7 +1222,7 @@ msgstr ""
 msgid "Weekly Downloads"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/mobile/details.html:99 src/olympia/compat/templates/compat/reporter_detail.html:46 src/olympia/devhub/forms.py:787
+#: src/olympia/addons/templates/addons/mobile/details.html:99 src/olympia/compat/templates/compat/reporter_detail.html:46 src/olympia/devhub/forms.py:788
 #: src/olympia/devhub/templates/devhub/versions/list.html:163
 msgid "Version"
 msgstr ""
@@ -1305,7 +1306,7 @@ msgstr ""
 #: src/olympia/browse/templates/browse/personas/category_landing.html:21 src/olympia/browse/templates/browse/personas/category_landing.html:23
 #: src/olympia/browse/templates/browse/personas/category_landing.html:38 src/olympia/browse/templates/browse/personas/grid.html:7 src/olympia/browse/templates/browse/personas/grid.html:11
 #: src/olympia/browse/templates/browse/personas/mobile/base.html:7 src/olympia/browse/templates/browse/personas/mobile/category_landing.html:19 src/olympia/constants/base.py:180
-#: src/olympia/devhub/templates/devhub/personas/submit.html:13 src/olympia/editors/helpers.py:105 src/olympia/editors/templates/editors/base.html:26
+#: src/olympia/devhub/templates/devhub/personas/submit.html:13 src/olympia/editors/helpers.py:107 src/olympia/editors/templates/editors/base.html:26
 #: src/olympia/editors/templates/editors/performance.html:73 src/olympia/search/templates/search/personas.html:39 src/olympia/templates/menu_links.html:9
 msgid "Themes"
 msgstr ""
@@ -1326,7 +1327,7 @@ msgstr ""
 msgid "Highest Rated"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/mobile/home.html:74 src/olympia/amo/templates/amo/side_nav.html:5 src/olympia/amo/templates/amo/site_nav.html:27 src/olympia/amo/templates/amo/site_nav.html:57
+#: src/olympia/addons/templates/addons/mobile/home.html:74 src/olympia/amo/templates/amo/side_nav.html:5 src/olympia/amo/templates/amo/site_nav.html:27 src/olympia/amo/templates/amo/site_nav.html:55
 #: src/olympia/bandwagon/views.py:97 src/olympia/browse/views.py:57 src/olympia/browse/views.py:67 src/olympia/browse/templates/browse/personas/mobile/category_landing.html:65
 #: src/olympia/search/forms.py:15 src/olympia/search/forms.py:87
 msgid "Newest"
@@ -1340,90 +1341,90 @@ msgstr ""
 msgid "Theme Info &raquo;"
 msgstr ""
 
-#: src/olympia/amo/context_processors.py:39 src/olympia/devhub/templates/devhub/nav.html:43
+#: src/olympia/amo/context_processors.py:37 src/olympia/devhub/templates/devhub/nav.html:43
 msgid "Tools"
 msgstr ""
 
-#: src/olympia/amo/context_processors.py:48 src/olympia/discovery/templates/discovery/pane_account.html:8 src/olympia/users/templates/users/includes/navigation.html:2
+#: src/olympia/amo/context_processors.py:47 src/olympia/discovery/templates/discovery/pane_account.html:8 src/olympia/users/templates/users/includes/navigation.html:2
 msgid "My Profile"
 msgstr ""
 
-#: src/olympia/amo/context_processors.py:54 src/olympia/users/templates/users/edit.html:5 src/olympia/users/templates/users/includes/navigation.html:3
+#: src/olympia/amo/context_processors.py:53 src/olympia/users/templates/users/edit.html:5 src/olympia/users/templates/users/includes/navigation.html:3
 msgid "Account Settings"
 msgstr ""
 
-#: src/olympia/amo/context_processors.py:57 src/olympia/discovery/templates/discovery/pane_account.html:11 src/olympia/users/templates/users/profile.html:83
+#: src/olympia/amo/context_processors.py:56 src/olympia/discovery/templates/discovery/pane_account.html:11 src/olympia/users/templates/users/profile.html:83
 #: src/olympia/users/templates/users/includes/navigation.html:4
 msgid "My Collections"
 msgstr ""
 
-#: src/olympia/amo/context_processors.py:62 src/olympia/discovery/templates/discovery/pane_account.html:10 src/olympia/users/templates/users/includes/navigation.html:7
+#: src/olympia/amo/context_processors.py:61 src/olympia/discovery/templates/discovery/pane_account.html:10 src/olympia/users/templates/users/includes/navigation.html:7
 msgid "My Favorites"
 msgstr ""
 
-#: src/olympia/amo/context_processors.py:67 src/olympia/discovery/templates/discovery/pane_account.html:13 src/olympia/templates/impala/user_login.html:14
+#: src/olympia/amo/context_processors.py:66 src/olympia/discovery/templates/discovery/pane_account.html:13 src/olympia/templates/impala/user_login.html:14
 #: src/olympia/templates/mobile/header_auth.html:5
 msgid "Log out"
 msgstr ""
 
-#: src/olympia/amo/context_processors.py:72 src/olympia/devhub/templates/devhub/addons/dashboard.html:4
+#: src/olympia/amo/context_processors.py:71 src/olympia/devhub/templates/devhub/addons/dashboard.html:4
 msgid "Manage My Submissions"
 msgstr ""
 
-#: src/olympia/amo/context_processors.py:75 src/olympia/devhub/templates/devhub/nav.html:27 src/olympia/devhub/templates/devhub/addons/dashboard.html:25
+#: src/olympia/amo/context_processors.py:74 src/olympia/devhub/templates/devhub/nav.html:27 src/olympia/devhub/templates/devhub/addons/dashboard.html:25
 #: src/olympia/devhub/templates/devhub/addons/submit/base.html:4
 msgid "Submit a New Add-on"
 msgstr ""
 
-#: src/olympia/amo/context_processors.py:77 src/olympia/browse/templates/browse/personas/base.html:50 src/olympia/devhub/templates/devhub/index.html:24
+#: src/olympia/amo/context_processors.py:76 src/olympia/browse/templates/browse/personas/base.html:50 src/olympia/devhub/templates/devhub/index.html:24
 #: src/olympia/devhub/templates/devhub/addons/dashboard.html:29
 msgid "Submit a New Theme"
 msgstr ""
 
-#: src/olympia/amo/context_processors.py:79 src/olympia/amo/templates/amo/site_nav.html:87 src/olympia/devhub/helpers.py:36 src/olympia/devhub/helpers.py:68 src/olympia/devhub/helpers.py:102
+#: src/olympia/amo/context_processors.py:78 src/olympia/amo/templates/amo/site_nav.html:85 src/olympia/devhub/helpers.py:36 src/olympia/devhub/helpers.py:68 src/olympia/devhub/helpers.py:102
 #: src/olympia/templates/footer.html:6 src/olympia/templates/menu_links.html:14
 msgid "Developer Hub"
 msgstr ""
 
-#: src/olympia/amo/context_processors.py:83 src/olympia/devhub/views.py:1792
+#: src/olympia/amo/context_processors.py:81 src/olympia/devhub/views.py:1796
 msgid "Manage API Keys"
 msgstr ""
 
-#: src/olympia/amo/context_processors.py:88 src/olympia/editors/helpers.py:82 src/olympia/editors/helpers.py:102 src/olympia/editors/templates/editors/base.html:10
+#: src/olympia/amo/context_processors.py:86 src/olympia/editors/helpers.py:84 src/olympia/editors/helpers.py:104 src/olympia/editors/templates/editors/base.html:10
 msgid "Editor Tools"
 msgstr ""
 
-#: src/olympia/amo/context_processors.py:92
+#: src/olympia/amo/context_processors.py:90
 msgid "Admin Tools"
 msgstr ""
 
-#: src/olympia/amo/fields.py:15
+#: src/olympia/amo/fields.py:20
 msgid "Incorrect, please try again."
 msgstr ""
 
-#: src/olympia/amo/fields.py:16
+#: src/olympia/amo/fields.py:21
 msgid "Error verifying input, please try again."
 msgstr ""
 
-#: src/olympia/amo/fields.py:32
+#: src/olympia/amo/fields.py:37
 msgid "This must be a valid hex color code, such as #000000."
 msgstr ""
 
-#: src/olympia/amo/fields.py:58
+#: src/olympia/amo/fields.py:63
 msgid "Enter at least one value."
 msgstr ""
 
-#: src/olympia/amo/helpers.py:162 src/olympia/amo/templates/amo/site_nav.html:61 src/olympia/bandwagon/templates/bandwagon/add.html:9
+#: src/olympia/amo/helpers.py:162 src/olympia/amo/templates/amo/site_nav.html:59 src/olympia/bandwagon/templates/bandwagon/add.html:9
 #: src/olympia/bandwagon/templates/bandwagon/collection_detail.html:15 src/olympia/bandwagon/templates/bandwagon/delete.html:9 src/olympia/bandwagon/templates/bandwagon/edit.html:15
 #: src/olympia/bandwagon/templates/bandwagon/user_listing.html:18 src/olympia/bandwagon/templates/bandwagon/user_listing.html:21
 #: src/olympia/bandwagon/templates/bandwagon/impala/collection_listing.html:12 src/olympia/bandwagon/templates/bandwagon/impala/collection_listing.html:20
 #: src/olympia/bandwagon/templates/bandwagon/impala/collection_listing.html:24 src/olympia/bandwagon/templates/bandwagon/impala/collection_sidebar.html:3
 #: src/olympia/bandwagon/templates/bandwagon/includes/collection_sidebar.html:2 src/olympia/bandwagon/templates/bandwagon/mobile/collection_listing.html:3
-#: src/olympia/stats/templates/stats/stats.html:77 src/olympia/templates/menu_links.html:12
+#: src/olympia/stats/templates/stats/stats.html:33 src/olympia/templates/menu_links.html:12
 msgid "Collections"
 msgstr ""
 
-#: src/olympia/amo/helpers.py:171 src/olympia/amo/templates/amo/site_nav.html:85 src/olympia/browse/templates/browse/language_tools.html:3
+#: src/olympia/amo/helpers.py:171 src/olympia/amo/templates/amo/site_nav.html:83 src/olympia/browse/templates/browse/language_tools.html:3
 msgid "Dictionaries & Language Packs"
 msgstr ""
 
@@ -1575,8 +1576,8 @@ msgstr ""
 msgid "Comment on {addon} {version}."
 msgstr ""
 
-#: src/olympia/amo/log.py:236 src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:19 src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:47
-#: src/olympia/editors/helpers.py:511 src/olympia/editors/templates/editors/themes/history_table.html:11
+#: src/olympia/amo/log.py:236 src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:17 src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:45
+#: src/olympia/editors/helpers.py:584 src/olympia/editors/templates/editors/themes/history_table.html:11
 msgid "Comment"
 msgstr ""
 
@@ -1899,7 +1900,7 @@ msgstr ""
 #: src/olympia/amo/templates/amo/mobile/paginator.html:14 src/olympia/amo/templates/amo/mobile/paginator.html:16 src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:51
 #: src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:65 src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:78
 #: src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:91 src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:104
-#: src/olympia/discovery/templates/discovery/pane.html:45 src/olympia/discovery/templates/discovery/addons/detail.html:39 src/olympia/stats/templates/stats/stats.html:167
+#: src/olympia/discovery/templates/discovery/pane.html:45 src/olympia/discovery/templates/discovery/addons/detail.html:39 src/olympia/stats/templates/stats/stats.html:169
 msgid "Next"
 msgstr ""
 
@@ -1931,7 +1932,7 @@ msgid ""
 msgstr ""
 
 #: src/olympia/amo/templates/amo/side_nav.html:4 src/olympia/amo/templates/amo/side_nav.html:12 src/olympia/amo/templates/amo/site_nav.html:4 src/olympia/amo/templates/amo/site_nav.html:26
-#: src/olympia/browse/views.py:56 src/olympia/browse/views.py:66 src/olympia/browse/views.py:237 src/olympia/browse/views.py:282 src/olympia/search/forms.py:86
+#: src/olympia/browse/views.py:56 src/olympia/browse/views.py:66 src/olympia/browse/views.py:204 src/olympia/browse/views.py:249 src/olympia/search/forms.py:86
 msgid "Top Rated"
 msgstr ""
 
@@ -1945,38 +1946,38 @@ msgstr ""
 msgid "Extensions"
 msgstr ""
 
-#: src/olympia/amo/templates/amo/site_nav.html:45
+#: src/olympia/amo/templates/amo/site_nav.html:44
 msgid "Want more customization? Try <b>Complete Themes</b>"
 msgstr ""
 
-#: src/olympia/amo/templates/amo/site_nav.html:56 src/olympia/bandwagon/views.py:96
+#: src/olympia/amo/templates/amo/site_nav.html:54 src/olympia/bandwagon/views.py:96
 msgid "Most Followers"
 msgstr ""
 
-#: src/olympia/amo/templates/amo/site_nav.html:68 src/olympia/bandwagon/templates/bandwagon/impala/collection_sidebar.html:16
+#: src/olympia/amo/templates/amo/site_nav.html:66 src/olympia/bandwagon/templates/bandwagon/impala/collection_sidebar.html:16
 #: src/olympia/bandwagon/templates/bandwagon/includes/collection_sidebar.html:18
 msgid "Collections I've Made"
 msgstr ""
 
-#: src/olympia/amo/templates/amo/site_nav.html:70 src/olympia/bandwagon/templates/bandwagon/user_listing.html:4 src/olympia/bandwagon/templates/bandwagon/impala/collection_sidebar.html:13
+#: src/olympia/amo/templates/amo/site_nav.html:68 src/olympia/bandwagon/templates/bandwagon/user_listing.html:4 src/olympia/bandwagon/templates/bandwagon/impala/collection_sidebar.html:13
 #: src/olympia/bandwagon/templates/bandwagon/includes/collection_sidebar.html:15
 msgid "Collections I'm Following"
 msgstr ""
 
-#: src/olympia/amo/templates/amo/site_nav.html:73 src/olympia/bandwagon/templates/bandwagon/impala/collection_sidebar.html:18
-#: src/olympia/bandwagon/templates/bandwagon/includes/collection_sidebar.html:20 src/olympia/users/models.py:512
+#: src/olympia/amo/templates/amo/site_nav.html:71 src/olympia/bandwagon/templates/bandwagon/impala/collection_sidebar.html:18
+#: src/olympia/bandwagon/templates/bandwagon/includes/collection_sidebar.html:20 src/olympia/users/models.py:521
 msgid "My Favorite Add-ons"
 msgstr ""
 
-#: src/olympia/amo/templates/amo/site_nav.html:78
+#: src/olympia/amo/templates/amo/site_nav.html:76
 msgid "More&hellip;"
 msgstr ""
 
-#: src/olympia/amo/templates/amo/site_nav.html:82
+#: src/olympia/amo/templates/amo/site_nav.html:80
 msgid "Add-ons for Mobile"
 msgstr ""
 
-#: src/olympia/amo/templates/amo/site_nav.html:86 src/olympia/browse/feeds.py:207 src/olympia/browse/templates/browse/search_tools.html:3 src/olympia/constants/base.py:176
+#: src/olympia/amo/templates/amo/site_nav.html:84 src/olympia/browse/feeds.py:207 src/olympia/browse/templates/browse/search_tools.html:3 src/olympia/constants/base.py:176
 #: src/olympia/templates/menu_links.html:10
 msgid "Search Tools"
 msgstr ""
@@ -1992,7 +1993,7 @@ msgid "Jump to first page"
 msgstr ""
 
 #: src/olympia/amo/templates/amo/impala/paginator.html:22 src/olympia/amo/templates/amo/mobile/impala_paginator.html:12 src/olympia/discovery/templates/discovery/pane.html:44
-#: src/olympia/discovery/templates/discovery/addons/detail.html:38 src/olympia/stats/templates/stats/stats.html:164
+#: src/olympia/discovery/templates/discovery/addons/detail.html:38 src/olympia/stats/templates/stats/stats.html:166
 msgid "Previous"
 msgstr ""
 
@@ -2015,30 +2016,49 @@ msgid_plural "Page {n}"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/olympia/amo/templates/services/install.html:38
-#, python-format
-msgid "If you are not prompted to install %(addon_name)s in a moment, please <a href=\"%(addon_xpi)s\">click here</a>."
-msgstr ""
-
-#: src/olympia/amo/tests/test_messages.py:57 src/olympia/amo/tests/test_messages.py:58 src/olympia/reviews/forms.py:25 src/olympia/reviews/forms.py:50 src/olympia/reviews/templates/reviews/add.html:56
+#: src/olympia/amo/tests/test_messages.py:56 src/olympia/amo/tests/test_messages.py:57 src/olympia/reviews/forms.py:25 src/olympia/reviews/forms.py:50 src/olympia/reviews/templates/reviews/add.html:56
 #: src/olympia/reviews/templates/reviews/reply.html:30
 msgid "Title"
 msgstr ""
 
-#: src/olympia/amo/tests/test_messages.py:57 src/olympia/amo/tests/test_messages.py:58
+#: src/olympia/amo/tests/test_messages.py:56 src/olympia/amo/tests/test_messages.py:57
 msgid "Body"
 msgstr ""
 
-#: src/olympia/amo/tests/test_messages.py:59
+#: src/olympia/amo/tests/test_messages.py:58
 msgid "Another Title"
 msgstr ""
 
-#: src/olympia/amo/tests/test_messages.py:59
+#: src/olympia/amo/tests/test_messages.py:58
 msgid "Another Body"
 msgstr ""
 
-#: src/olympia/api/views.py:255
-msgid "Not implemented yet."
+#: src/olympia/api/authentication.py:76
+msgid "Signature has expired."
+msgstr ""
+
+#: src/olympia/api/authentication.py:79
+msgid "Error decoding signature."
+msgstr ""
+
+#: src/olympia/api/authentication.py:82
+msgid "Invalid JWT Token."
+msgstr ""
+
+#: src/olympia/api/authentication.py:130
+msgid "Invalid Authorization header. No credentials provided."
+msgstr ""
+
+#: src/olympia/api/authentication.py:133
+msgid "Invalid Authorization header. Credentials string should not contain spaces."
+msgstr ""
+
+#: src/olympia/api/fields.py:29
+msgid "The field must have a length of at least {num} characters."
+msgstr ""
+
+#: src/olympia/api/fields.py:31
+msgid "The language code {lang_code} is invalid."
 msgstr ""
 
 #: src/olympia/applications/views.py:39 src/olympia/applications/templates/applications/appversions.html:3
@@ -2057,7 +2077,7 @@ msgstr ""
 msgid "Add-ons submitted to Mozilla Add-ons must have a manifest file with at least one of the below applications supported. Only the versions listed below are allowed for these applications."
 msgstr ""
 
-#: src/olympia/applications/templates/applications/appversions.html:25
+#: src/olympia/applications/templates/applications/appversions.html:25 src/olympia/editors/helpers.py:361
 msgid "GUID"
 msgstr ""
 
@@ -2171,8 +2191,8 @@ msgstr ""
 msgid "Remove from favorites"
 msgstr ""
 
-#: src/olympia/bandwagon/views.py:98 src/olympia/bandwagon/views.py:191 src/olympia/browse/views.py:58 src/olympia/browse/views.py:69 src/olympia/browse/views.py:458 src/olympia/devhub/views.py:74
-#: src/olympia/devhub/views.py:82 src/olympia/devhub/templates/devhub/addons/edit/basic.html:20 src/olympia/editors/templates/editors/leaderboard.html:24
+#: src/olympia/bandwagon/views.py:98 src/olympia/bandwagon/views.py:191 src/olympia/browse/views.py:58 src/olympia/browse/views.py:69 src/olympia/browse/views.py:425 src/olympia/devhub/views.py:72
+#: src/olympia/devhub/views.py:80 src/olympia/devhub/templates/devhub/addons/edit/basic.html:20 src/olympia/editors/templates/editors/leaderboard.html:24
 #: src/olympia/editors/templates/editors/themes/queue_list.html:48 src/olympia/search/forms.py:17 src/olympia/search/forms.py:89 src/olympia/users/templates/users/vcard.html:5
 msgid "Name"
 msgstr ""
@@ -2181,7 +2201,7 @@ msgstr ""
 msgid "Recently Popular"
 msgstr ""
 
-#: src/olympia/bandwagon/views.py:189 src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:18
+#: src/olympia/bandwagon/views.py:189 src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:16
 msgid "Added"
 msgstr ""
 
@@ -2195,7 +2215,7 @@ msgstr ""
 
 #: src/olympia/bandwagon/views.py:316
 #, python-format
-msgid "Your new collection is shown below. You can <ahref=\"%(url)s\">edit additional settings</a> if you'dlike."
+msgid "Your new collection is shown below. You can <a href=\"%(url)s\">edit additional settings</a> if you'd like."
 msgstr ""
 
 #: src/olympia/bandwagon/views.py:322
@@ -2323,8 +2343,8 @@ msgid_plural "%(num)s Add-ons in this Collection"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/olympia/bandwagon/templates/bandwagon/collection_detail.html:125 src/olympia/compat/templates/compat/index.html:25 src/olympia/compat/templates/compat/reporter_detail.html:29
-#: src/olympia/files/templates/files/viewer.html:29 src/olympia/templates/amo_footer.html:17 src/olympia/templates/includes/lang_switcher.html:10
+#: src/olympia/bandwagon/templates/bandwagon/collection_detail.html:125 src/olympia/compat/templates/compat/reporter_detail.html:29 src/olympia/files/templates/files/viewer.html:29
+#: src/olympia/templates/amo_footer.html:17 src/olympia/templates/includes/lang_switcher.html:10
 msgid "Go"
 msgstr ""
 
@@ -2491,7 +2511,7 @@ msgid "Remove this user as a contributor"
 msgstr ""
 
 #: src/olympia/bandwagon/templates/bandwagon/edit_contributors.html:18 src/olympia/bandwagon/templates/bandwagon/edit_contributors.html:43
-#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:20 src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:48
+#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:18 src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:46
 #: src/olympia/devhub/templates/devhub/addons/ajax_compat_update.html:19
 msgid "Remove"
 msgstr ""
@@ -2539,7 +2559,7 @@ msgid "<b>Warning:</b> By changing the owner of this collection, you will no lon
 msgstr ""
 
 #: src/olympia/bandwagon/templates/bandwagon/edit_contributors.html:83 src/olympia/devhub/templates/devhub/addons/forms_shared/media.html:157
-#: src/olympia/devhub/templates/devhub/addons/submit/describe.html:69 src/olympia/devhub/templates/devhub/addons/submit/license.html:60 src/olympia/devhub/templates/devhub/addons/submit/upload.html:78
+#: src/olympia/devhub/templates/devhub/addons/submit/describe.html:69 src/olympia/devhub/templates/devhub/addons/submit/license.html:60 src/olympia/devhub/templates/devhub/addons/submit/upload.html:70
 #: src/olympia/devhub/templates/devhub/payments/tier.html:17 src/olympia/editors/templates/editors/themes/themes.html:111 src/olympia/editors/templates/editors/themes/themes.html:128
 #: src/olympia/editors/templates/editors/themes/themes.html:134 src/olympia/editors/templates/editors/themes/themes.html:141 src/olympia/users/templates/users/fxa_migration_prompt_content.html:10
 #: src/olympia/users/templates/users/login_form.html:42 src/olympia/users/templates/users/mobile/login.html:57
@@ -2622,31 +2642,31 @@ msgid "Add-ons in Your Collection"
 msgstr ""
 
 #: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:4
-msgid ""
-"To include an add-on in this collection, enter its name in the box below and hit enter.  You can also use the <strong>Add to Collection</strong> links throughout the site to include add-ons later."
+msgid "To include an add-on in this collection, enter its name in the box below and hit enter."
 msgstr ""
 
-#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:17 src/olympia/constants/base.py:400 src/olympia/devhub/templates/devhub/addons/activity.html:62
+#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:15 src/olympia/constants/base.py:400 src/olympia/devhub/templates/devhub/addons/activity.html:62
+#: src/olympia/editors/helpers.py:273 src/olympia/editors/helpers.py:360
 msgid "Add-on"
 msgstr ""
 
-#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:26
+#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:24
 msgid "Enter the name of the add-on to include"
 msgstr ""
 
-#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:28
+#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:26
 msgid "Add to Collection"
 msgstr ""
 
-#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:45 src/olympia/editors/helpers.py:936 src/olympia/editors/helpers.py:956
+#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:43 src/olympia/editors/helpers.py:1016 src/olympia/editors/helpers.py:1036
 msgid "Pending"
 msgstr ""
 
-#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:47
+#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:45
 msgid "Add a comment"
 msgstr ""
 
-#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:48
+#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:46
 msgid "Remove this add-on from the collection"
 msgstr ""
 
@@ -2753,12 +2773,12 @@ msgstr ""
 msgid "Most Users"
 msgstr ""
 
-#: src/olympia/browse/views.py:61 src/olympia/browse/views.py:72 src/olympia/browse/views.py:279 src/olympia/browse/templates/browse/personas/mobile/category_landing.html:63
+#: src/olympia/browse/views.py:61 src/olympia/browse/views.py:72 src/olympia/browse/views.py:246 src/olympia/browse/templates/browse/personas/mobile/category_landing.html:63
 #: src/olympia/discovery/templates/discovery/pane.html:67 src/olympia/search/forms.py:92
 msgid "Up & Coming"
 msgstr ""
 
-#: src/olympia/browse/views.py:460 src/olympia/devhub/views.py:76 src/olympia/devhub/views.py:83 src/olympia/discovery/templates/discovery/addons/detail.html:66
+#: src/olympia/browse/views.py:427 src/olympia/devhub/views.py:74 src/olympia/devhub/views.py:81 src/olympia/discovery/templates/discovery/addons/detail.html:66
 msgid "Created"
 msgstr ""
 
@@ -2946,8 +2966,8 @@ msgid_plural "See all %(cnt)s extensions in %(name)s &raquo;"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/olympia/browse/templates/browse/mobile/extensions.html:13 src/olympia/compat/templates/compat/index.html:82 src/olympia/devhub/templates/devhub/devhub_search.html:24
-#: src/olympia/devhub/templates/devhub/addons/activity.html:47 src/olympia/search/templates/search/no_results.html:4 src/olympia/search/templates/search/mobile/results.html:36
+#: src/olympia/browse/templates/browse/mobile/extensions.html:13 src/olympia/devhub/templates/devhub/devhub_search.html:24 src/olympia/devhub/templates/devhub/addons/activity.html:47
+#: src/olympia/search/templates/search/no_results.html:4 src/olympia/search/templates/search/mobile/results.html:36
 msgid "No results found."
 msgstr ""
 
@@ -3032,7 +3052,7 @@ msgstr ""
 msgid "All"
 msgstr ""
 
-#: src/olympia/compat/forms.py:22 src/olympia/search/views.py:525
+#: src/olympia/compat/forms.py:22 src/olympia/editors/templates/editors/base.html:69 src/olympia/search/views.py:518
 msgid "All Add-ons"
 msgstr ""
 
@@ -3042,53 +3062,6 @@ msgstr ""
 
 #: src/olympia/compat/forms.py:24
 msgid "Non-binary"
-msgstr ""
-
-#. Review points sources other than add-ons and themes.
-#: src/olympia/compat/views.py:87 src/olympia/constants/base.py:388 src/olympia/devhub/forms.py:162 src/olympia/editors/templates/editors/performance.html:75
-msgid "Other"
-msgstr ""
-
-#: src/olympia/compat/templates/compat/index.html:4
-msgid "Add-on Compatibility Report for {app} {version}"
-msgstr ""
-
-#: src/olympia/compat/templates/compat/index.html:11
-msgid "{app} {version} Compatibility"
-msgstr ""
-
-#: src/olympia/compat/templates/compat/index.html:17
-#, python-format
-msgid "Top 95%% compatible with previous version"
-msgstr ""
-
-#: src/olympia/compat/templates/compat/index.html:18
-#, python-format
-msgid "Top 95%% of all add-ons"
-msgstr ""
-
-#: src/olympia/compat/templates/compat/index.html:19
-msgid "All active add-ons"
-msgstr ""
-
-#: src/olympia/compat/templates/compat/index.html:23 src/olympia/constants/base.py:401
-msgid "App"
-msgstr ""
-
-#: src/olympia/compat/templates/compat/index.html:55
-msgid "Details for add-ons compatible with previous version:"
-msgstr ""
-
-#: src/olympia/compat/templates/compat/index.html:57
-msgid "Show all versions"
-msgstr ""
-
-#: src/olympia/compat/templates/compat/index.html:59
-msgid "Details for add-ons compatible with all versions:"
-msgstr ""
-
-#: src/olympia/compat/templates/compat/index.html:61
-msgid "Show previous version only"
 msgstr ""
 
 #: src/olympia/compat/templates/compat/reporter.html:3
@@ -3142,8 +3115,8 @@ msgstr ""
 msgid "Report Type"
 msgstr ""
 
-#: src/olympia/compat/templates/compat/reporter_detail.html:47 src/olympia/devhub/forms.py:784 src/olympia/devhub/templates/devhub/addons/ajax_compat_update.html:17 src/olympia/editors/forms.py:108
-#: src/olympia/zadmin/forms.py:45
+#: src/olympia/compat/templates/compat/reporter_detail.html:47 src/olympia/devhub/forms.py:785 src/olympia/devhub/templates/devhub/addons/ajax_compat_update.html:17 src/olympia/editors/forms.py:108
+#: src/olympia/editors/forms.py:248 src/olympia/zadmin/forms.py:45
 msgid "Application"
 msgstr ""
 
@@ -3231,7 +3204,8 @@ msgstr ""
 msgid "Preliminarily Reviewed and Awaiting Full Review"
 msgstr ""
 
-#: src/olympia/constants/base.py:33 src/olympia/editors/helpers.py:924 src/olympia/editors/templates/editors/themes/history_table.html:34
+#: src/olympia/constants/base.py:33 src/olympia/editors/forms.py:258 src/olympia/editors/helpers.py:73 src/olympia/editors/helpers.py:1004
+#: src/olympia/editors/templates/editors/themes/history_table.html:34
 msgid "Deleted"
 msgstr ""
 
@@ -3328,6 +3302,11 @@ msgstr ""
 msgid "Ask before users can download this add-on"
 msgstr ""
 
+#. Review points sources other than add-ons and themes.
+#: src/olympia/constants/base.py:388 src/olympia/devhub/forms.py:162 src/olympia/editors/templates/editors/performance.html:75
+msgid "Other"
+msgstr ""
+
 #: src/olympia/constants/base.py:389
 msgid "Exception"
 msgstr ""
@@ -3338,6 +3317,10 @@ msgstr ""
 
 #: src/olympia/constants/base.py:391
 msgid "Change"
+msgstr ""
+
+#: src/olympia/constants/base.py:401
+msgid "App"
 msgstr ""
 
 #: src/olympia/constants/base.py:402
@@ -3488,7 +3471,7 @@ msgstr ""
 msgid "Duplicate"
 msgstr ""
 
-#: src/olympia/constants/editors.py:17 src/olympia/editors/helpers.py:502 src/olympia/editors/templates/editors/themes/queue.html:71 src/olympia/editors/templates/editors/themes/themes.html:94
+#: src/olympia/constants/editors.py:17 src/olympia/editors/helpers.py:575 src/olympia/editors/templates/editors/themes/queue.html:71 src/olympia/editors/templates/editors/themes/themes.html:94
 msgid "Reject"
 msgstr ""
 
@@ -3588,7 +3571,7 @@ msgstr ""
 msgid "Android"
 msgstr ""
 
-#: src/olympia/core/apps.py:19
+#: src/olympia/core/apps.py:21
 msgid "Core"
 msgstr ""
 
@@ -3722,7 +3705,7 @@ msgid "Submit my add-on for manual review."
 msgstr ""
 
 #: src/olympia/devhub/forms.py:537
-msgid "Do not list my add-on on this site (beta)"
+msgid "Do not list my add-on on this site"
 msgstr ""
 
 #: src/olympia/devhub/forms.py:538
@@ -3755,46 +3738,46 @@ msgstr ""
 
 #: src/olympia/devhub/forms.py:592
 #, python-format
-msgid "Version %s already exists"
+msgid "Version %s already exists, or was uploaded before."
 msgstr ""
 
-#: src/olympia/devhub/forms.py:604
+#: src/olympia/devhub/forms.py:605
 msgid "Select a valid choice. That choice is not one of the available choices."
 msgstr ""
 
-#: src/olympia/devhub/forms.py:610
+#: src/olympia/devhub/forms.py:611
 msgid "A file with a version ending with a|alpha|b|beta and an optional number is detected as beta."
 msgstr ""
 
-#: src/olympia/devhub/forms.py:633
+#: src/olympia/devhub/forms.py:634
 msgid "You cannot upload any more files for this version."
 msgstr ""
 
-#: src/olympia/devhub/forms.py:639
+#: src/olympia/devhub/forms.py:640
 msgid "Version doesn't match"
 msgstr ""
 
-#: src/olympia/devhub/forms.py:668
+#: src/olympia/devhub/forms.py:669
 msgid "You cannot delete a file once the review process has started.  You must delete the whole version."
 msgstr ""
 
-#: src/olympia/devhub/forms.py:688
+#: src/olympia/devhub/forms.py:689
 msgid "The platform All cannot be combined with specific platforms."
 msgstr ""
 
-#: src/olympia/devhub/forms.py:693
+#: src/olympia/devhub/forms.py:694
 msgid "A platform can only be chosen once."
 msgstr ""
 
-#: src/olympia/devhub/forms.py:706
+#: src/olympia/devhub/forms.py:707
 msgid "A review type must be selected."
 msgstr ""
 
-#: src/olympia/devhub/forms.py:788 src/olympia/editors/forms.py:114 src/olympia/zadmin/forms.py:49 src/olympia/zadmin/forms.py:52
+#: src/olympia/devhub/forms.py:789 src/olympia/editors/forms.py:114 src/olympia/editors/forms.py:254 src/olympia/zadmin/forms.py:49 src/olympia/zadmin/forms.py:52
 msgid "Select an application first"
 msgstr ""
 
-#: src/olympia/devhub/forms.py:840
+#: src/olympia/devhub/forms.py:841
 msgid "There cannot be more than 3 required add-ons."
 msgstr ""
 
@@ -3828,76 +3811,76 @@ msgstr[1] ""
 msgid "Review"
 msgstr ""
 
-#: src/olympia/devhub/tasks.py:551
+#: src/olympia/devhub/tasks.py:583
 #, python-format
 msgid "%s responded with %s (%s)."
 msgstr ""
 
-#: src/olympia/devhub/tasks.py:555
+#: src/olympia/devhub/tasks.py:587
 #, python-format
 msgid "Connection to \"%s\" timed out."
 msgstr ""
 
-#: src/olympia/devhub/tasks.py:557
+#: src/olympia/devhub/tasks.py:589
 #, python-format
 msgid "Could not contact host at \"%s\"."
 msgstr ""
 
-#: src/olympia/devhub/utils.py:104
+#: src/olympia/devhub/utils.py:105
 #, python-format
 msgid "Validation generated too many errors/warnings so %s messages were truncated. After addressing the visible messages, you'll be able to see the others."
 msgstr ""
 
-#: src/olympia/devhub/views.py:183
+#: src/olympia/devhub/views.py:181
 msgid "All My Add-ons"
 msgstr ""
 
-#: src/olympia/devhub/views.py:210
+#: src/olympia/devhub/views.py:208
 msgid "All Activity"
 msgstr ""
 
-#: src/olympia/devhub/views.py:211
+#: src/olympia/devhub/views.py:209
 msgid "Add-on Updates"
 msgstr ""
 
-#: src/olympia/devhub/views.py:212
+#: src/olympia/devhub/views.py:210
 msgid "Add-on Status"
 msgstr ""
 
-#: src/olympia/devhub/views.py:213
+#: src/olympia/devhub/views.py:211
 msgid "User Collections"
 msgstr ""
 
-#: src/olympia/devhub/views.py:214 src/olympia/devhub/templates/devhub/docs/policies-maintenance.html:68 src/olympia/pages/templates/pages/dev_faq.html:38
+#: src/olympia/devhub/views.py:212 src/olympia/devhub/templates/devhub/docs/policies-maintenance.html:68 src/olympia/pages/templates/pages/dev_faq.html:38
 #: src/olympia/pages/templates/pages/dev_faq.html:484
 msgid "User Reviews"
 msgstr ""
 
-#: src/olympia/devhub/views.py:327 src/olympia/devhub/views.py:331 src/olympia/devhub/views.py:484 src/olympia/devhub/views.py:513 src/olympia/devhub/views.py:564 src/olympia/devhub/views.py:1150
+#: src/olympia/devhub/views.py:325 src/olympia/devhub/views.py:329 src/olympia/devhub/views.py:484 src/olympia/devhub/views.py:513 src/olympia/devhub/views.py:564 src/olympia/devhub/views.py:1156
 msgid "Changes successfully saved."
 msgstr ""
 
-#: src/olympia/devhub/views.py:334 src/olympia/devhub/views.py:1631
+#: src/olympia/devhub/views.py:332 src/olympia/devhub/views.py:1637
 msgid "Please check the form for errors."
 msgstr ""
 
-#: src/olympia/devhub/views.py:346
+#: src/olympia/devhub/views.py:344
 msgid "Add-on cannot be deleted. Disable this add-on instead."
 msgstr ""
 
-#: src/olympia/devhub/views.py:356
+#: src/olympia/devhub/views.py:354
 msgid "Theme deleted."
 msgstr ""
 
-#: src/olympia/devhub/views.py:356
+#: src/olympia/devhub/views.py:354
 msgid "Add-on deleted."
 msgstr ""
 
-#: src/olympia/devhub/views.py:362
+#: src/olympia/devhub/views.py:360
 msgid "URL name was incorrect. Theme was not deleted."
 msgstr ""
 
-#: src/olympia/devhub/views.py:367
+#: src/olympia/devhub/views.py:365
 msgid "URL name was incorrect. Add-on was not deleted."
 msgstr ""
 
@@ -3925,7 +3908,7 @@ msgstr ""
 msgid "Check Add-on Compatibility"
 msgstr ""
 
-#: src/olympia/devhub/views.py:808 src/olympia/signing/views.py:90
+#: src/olympia/devhub/views.py:808 src/olympia/signing/views.py:95
 msgid "You cannot submit this type of add-on"
 msgstr ""
 
@@ -3955,33 +3938,33 @@ msgstr ""
 msgid "There was an error uploading your preview."
 msgstr ""
 
-#: src/olympia/devhub/views.py:1189
+#: src/olympia/devhub/views.py:1195
 #, python-format
 msgid "Version %s disabled."
 msgstr ""
 
-#: src/olympia/devhub/views.py:1193
+#: src/olympia/devhub/views.py:1199
 #, python-format
 msgid "Version %s deleted."
 msgstr ""
 
-#: src/olympia/devhub/views.py:1203
+#: src/olympia/devhub/views.py:1209
 msgid "This upload has failed validation, and may lack complete validation results. Please take due care when reviewing it."
 msgstr ""
 
-#: src/olympia/devhub/views.py:1677
+#: src/olympia/devhub/views.py:1683
 msgid "Preliminary Review Requested."
 msgstr ""
 
-#: src/olympia/devhub/views.py:1678
+#: src/olympia/devhub/views.py:1684
 msgid "Full Review Requested."
 msgstr ""
 
-#: src/olympia/devhub/views.py:1779
+#: src/olympia/devhub/views.py:1783
 msgid "Your old credentials were revoked and are no longer valid. Be sure to update all API clients with the new credentials."
 msgstr ""
 
-#: src/olympia/devhub/views.py:1797
+#: src/olympia/devhub/views.py:1801
 msgid "New API key created"
 msgstr ""
 
@@ -4011,7 +3994,7 @@ msgstr ""
 msgid "{0} :: Search"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/devhub_search.html:6 src/olympia/devhub/templates/devhub/search.html:8 src/olympia/editors/forms.py:435 src/olympia/editors/forms.py:437
+#: src/olympia/devhub/templates/devhub/devhub_search.html:6 src/olympia/devhub/templates/devhub/search.html:8 src/olympia/editors/forms.py:534 src/olympia/editors/forms.py:536
 #: src/olympia/editors/templates/editors/queue.html:27 src/olympia/editors/templates/editors/themes/queue_list.html:14 src/olympia/search/templates/search/collections.html:17
 #: src/olympia/search/templates/search/personas.html:18 src/olympia/search/templates/search/results.html:18 src/olympia/search/templates/search/mobile/results.html:8
 #: src/olympia/templates/search.html:14 src/olympia/templates/impala/search.html:18
@@ -4071,12 +4054,12 @@ msgstr ""
 msgid "Start Making Add-ons"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/index.html:86 src/olympia/devhub/templates/devhub/addons/listing/items.html:25 src/olympia/devhub/templates/devhub/includes/addon_details.html:15
+#: src/olympia/devhub/templates/devhub/index.html:86 src/olympia/devhub/templates/devhub/addons/listing/items.html:25 src/olympia/devhub/templates/devhub/includes/addon_details.html:20
 #: src/olympia/devhub/templates/devhub/personas/edit.html:43
 msgid "Status:"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/index.html:90 src/olympia/devhub/templates/devhub/includes/addon_details.html:100
+#: src/olympia/devhub/templates/devhub/index.html:90 src/olympia/devhub/templates/devhub/includes/addon_details.html:87
 msgid "Visibility:"
 msgstr ""
 
@@ -4084,11 +4067,11 @@ msgstr ""
 msgid "Latest Version:"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/index.html:109 src/olympia/devhub/templates/devhub/includes/addon_details.html:145 src/olympia/devhub/templates/devhub/personas/edit.html:49
+#: src/olympia/devhub/templates/devhub/index.html:109 src/olympia/devhub/templates/devhub/includes/addon_details.html:131 src/olympia/devhub/templates/devhub/personas/edit.html:49
 msgid "Queue Position:"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/index.html:110 src/olympia/devhub/templates/devhub/includes/addon_details.html:146 src/olympia/devhub/templates/devhub/personas/edit.html:50
+#: src/olympia/devhub/templates/devhub/index.html:110 src/olympia/devhub/templates/devhub/includes/addon_details.html:132 src/olympia/devhub/templates/devhub/personas/edit.html:50
 #, python-format
 msgid "%(position)s of %(total)s"
 msgstr ""
@@ -4190,16 +4173,6 @@ msgstr ""
 msgid "Do you want your add-on to be distributed on this site?"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/validate_addon.html:49 src/olympia/devhub/templates/devhub/addons/submit/upload.html:30 src/olympia/devhub/templates/devhub/versions/add_file_modal.html:14
-#: src/olympia/devhub/templates/devhub/versions/add_file_modal.html:53 src/olympia/devhub/templates/devhub/versions/list.html:298
-msgid "Warning:"
-msgstr ""
-
-#: src/olympia/devhub/templates/devhub/validate_addon.html:50 src/olympia/devhub/templates/devhub/addons/submit/upload.html:31
-#, python-format
-msgid "Submission of unlisted add-ons for signing is currently in an open beta. Please <a href=\"%(url)s\" target=\"_blank\">report any bugs</a> that you encounter."
-msgstr ""
-
 #. first parameter is a filename like lorem-ipsum-1.0.2.xpi
 #: src/olympia/devhub/templates/devhub/validation.html:5
 msgid "Validation Results for {0}"
@@ -4274,7 +4247,7 @@ msgstr ""
 msgid "Update Compatibility"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/addons/ajax_compat_update.html:4
+#: src/olympia/devhub/templates/devhub/addons/ajax_compat_update.html:4 src/olympia/devhub/templates/devhub/versions/edit.html:45
 msgid "Adjusting application information here will allow users to install your add-on even if the install manifest in the package indicates that the add-on is incompatible."
 msgstr ""
 
@@ -4286,9 +4259,9 @@ msgstr ""
 msgid "Add Another Application&hellip;"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/addons/ajax_compat_update.html:38 src/olympia/devhub/templates/devhub/addons/owner.html:86 src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:46
-#: src/olympia/devhub/templates/devhub/versions/list.html:351 src/olympia/devhub/templates/devhub/versions/list.html:353 src/olympia/templates/impala/base.html:132
-#: src/olympia/templates/impala/base.html:143 src/olympia/templates/impala/base.html:161 src/olympia/templates/impala/base.html:171
+#: src/olympia/devhub/templates/devhub/addons/ajax_compat_update.html:38 src/olympia/devhub/templates/devhub/addons/owner.html:86 src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:45
+#: src/olympia/devhub/templates/devhub/versions/list.html:349 src/olympia/devhub/templates/devhub/versions/list.html:351 src/olympia/templates/impala/base.html:129
+#: src/olympia/templates/impala/base.html:140 src/olympia/templates/impala/base.html:158 src/olympia/templates/impala/base.html:168
 msgid "Close"
 msgstr ""
 
@@ -4322,7 +4295,7 @@ msgstr ""
 msgid "Manage Authors & License"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/addons/owner.html:29 src/olympia/editors/templates/editors/review.html:270
+#: src/olympia/devhub/templates/devhub/addons/owner.html:29 src/olympia/editors/helpers.py:362 src/olympia/editors/templates/editors/review.html:270
 msgid "Authors"
 msgstr ""
 
@@ -4391,17 +4364,11 @@ msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/basic.html:52
 msgid ""
-"A short explanation of your add-on's basic\n"
-"                          functionality that is displayed in search and browse\n"
-"                          listings, as well as at the top of your add-on's\n"
-"                          details page. It is only relevant for listed add-ons."
+"A short explanation of your add-on's basic functionality that is displayed in search and browse listings, as well as at the top of your add-on's details page. It is only relevant for listed add-ons."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/basic.html:73
-msgid ""
-"Categories are the primary way users browse through add-ons.\n"
-"                        Choose any that fit your add-on's functionality for the most\n"
-"                        exposure. It is only relevant for listed add-ons."
+msgid "Categories are the primary way users browse through add-ons. Choose any that fit your add-on's functionality for the most exposure. It is only relevant for listed add-ons."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/basic.html:90
@@ -4411,11 +4378,7 @@ msgid ""
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/basic.html:119
-msgid ""
-"Tags help users find your add-on and should be short\n"
-"                        descriptors such as tabs, toolbar, or twitter.  You\n"
-"                        may have a maximum of {0} tags. It is only relevant\n"
-"                        for listed add-ons."
+msgid "Tags help users find your add-on and should be short descriptors such as tabs, toolbar, or twitter. You may have a maximum of {0} tags. It is only relevant for listed add-ons."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/basic.html:129 src/olympia/devhub/templates/devhub/personas/edit.html:97 src/olympia/devhub/templates/devhub/personas/submit.html:46
@@ -4443,11 +4406,7 @@ msgid "Add-on Details for {0}"
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/details.html:22
-msgid ""
-"A longer explanation of features,\n"
-"                          functionality, and other relevant information. This\n"
-"                          field is only displayed on the add-on's details\n"
-"                          page. It is only relevant for listed add-ons."
+msgid "A longer explanation of features, functionality, and other relevant information. This field is only displayed on the add-on's details page. It is only relevant for listed add-ons."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/details.html:44 src/olympia/translations/templates/translations/trans-menu.html:13
@@ -4455,10 +4414,7 @@ msgid "Default Locale"
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/details.html:45
-msgid ""
-"Information about your add-on is displayed in this locale\n"
-"                        unless you override it with a locale-specific translation.\n"
-"                        It is only relevant for listed add-ons."
+msgid "Information about your add-on is displayed in this locale unless you override it with a locale-specific translation. It is only relevant for listed add-ons."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/details.html:61 src/olympia/users/forms.py:311 src/olympia/users/templates/users/edit.html:122 src/olympia/users/templates/users/register.html:57
@@ -4468,10 +4424,8 @@ msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/details.html:63
 msgid ""
-"If your add-on has another homepage, enter its\n"
-"                          address here. If your website is localized into other\n"
-"                          languages multiple translations of this field can be\n"
-"                          added. It is only relevant for listed add-ons."
+"If your add-on has another homepage, enter its address here. If your website is localized into other languages multiple translations of this field can be added. It is only relevant for listed add-"
+"ons."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/media.html:3
@@ -4489,19 +4443,14 @@ msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/support.html:22
 msgid ""
-"If you wish to display an e-mail address for support\n"
-"                          inquiries, enter it here. If you have different\n"
-"                          addresses for each language multiple translations of\n"
-"                          this field can be added. It is only relevant for\n"
-"                          listed add-ons."
+"If you wish to display an e-mail address for support inquiries, enter it here. If you have different addresses for each language multiple translations of this field can be added. It is only "
+"relevant for listed add-ons."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/support.html:45
 msgid ""
-"If your add-on has a support website or forum, enter\n"
-"                          its address here. If your website is localized into\n"
-"                          other languages, multiple translations of this field can\n"
-"                          be added. It is only relevant for listed add-ons."
+"If your add-on has a support website or forum, enter its address here. If your website is localized into other languages, multiple translations of this field can be added. It is only relevant for "
+"listed add-ons."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:6
@@ -4515,11 +4464,8 @@ msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:23
 msgid ""
-"Any information end users may want to know that isn't\n"
-"                          necessarily applicable to the add-on summary or description.\n"
-"                          Common uses include listing known major bugs, information on\n"
-"                          how to report bugs, anticipated release date of a new version,\n"
-"                          etc. It is only relevant for listed add-ons."
+"Any information end users may want to know that isn't necessarily applicable to the add-on summary or description. Common uses include listing known major bugs, information on how to report bugs, "
+"anticipated release date of a new version, etc. It is only relevant for listed add-ons."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:46
@@ -4531,9 +4477,7 @@ msgid "Add-on Flags"
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:69
-msgid ""
-"These flags are used to classify add-ons. It is only\n"
-"                        relevant for listed add-ons."
+msgid "These flags are used to classify add-ons. It is only relevant for listed add-ons."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:74
@@ -4549,9 +4493,7 @@ msgid "View Source?"
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:90
-msgid ""
-"Whether the source of your add-on can be displayed in our\n"
-"                        online viewer. It is only relevant for listed add-ons."
+msgid "Whether the source of your add-on can be displayed in our online viewer. It is only relevant for listed add-ons."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:94
@@ -4567,10 +4509,7 @@ msgid "Public Stats?"
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:102
-msgid ""
-"Whether the download and usage stats of your add-on can\n"
-"                        be displayed in our online viewer.\n"
-"                        It is only relevant for listed add-ons."
+msgid "Whether the download and usage stats of your add-on can be displayed in our online viewer. It is only relevant for listed add-ons."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:107
@@ -4586,10 +4525,7 @@ msgid "Upgrade SDK?"
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:116
-msgid ""
-"If selected, we will try to automatically upgrade your\n"
-"                        add-on when a new version of the SDK is released.\n"
-"                        It is only relevant for listed add-ons."
+msgid "If selected, we will try to automatically upgrade your add-on when a new version of the SDK is released. It is only relevant for listed add-ons."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:121
@@ -4640,10 +4576,8 @@ msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/forms_shared/media.html:16
 msgid ""
-"Upload an icon for your add-on or choose from one of ours. The\n"
-"                      icon is displayed nearly everywhere your add-on is. Uploaded images\n"
-"                      must be one of the following image types: .png, .jpg.\n"
-"                      It is only relevant for listed add-ons."
+"Upload an icon for your add-on or choose from one of ours. The icon is displayed nearly everywhere your add-on is. Uploaded images must be one of the following image types: .png, .jpg. It is only "
+"relevant for listed add-ons."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/forms_shared/media.html:25
@@ -4656,9 +4590,7 @@ msgid "32x32px"
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/forms_shared/media.html:39
-msgid ""
-"Used in listings of add-ons, like search results\n"
-"                            and featured add-ons."
+msgid "Used in listings of add-ons, like search results and featured add-ons."
 msgstr ""
 
 #. The size of the icon
@@ -4753,16 +4685,14 @@ msgid "Deleting your add-on will permanently remove it from the site and prevent
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:24
-msgid ""
-"Enter the following text confirm your decision:\n"
-"           {slug}"
+msgid "Enter the following text confirm your decision: {slug}"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:34
+#: src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:33
 msgid "Please tell us why you are deleting your theme:"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:36
+#: src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:35
 msgid "Please tell us why you are deleting your add-on:"
 msgstr ""
 
@@ -4799,8 +4729,8 @@ msgstr ""
 msgid "Daily statistics on downloads and users."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/addons/listing/item_actions.html:45 src/olympia/stats/templates/stats/stats.html:75 src/olympia/stats/templates/stats/stats.html:79
-#: src/olympia/stats/templates/stats/stats.html:81
+#: src/olympia/devhub/templates/devhub/addons/listing/item_actions.html:45 src/olympia/stats/templates/stats/stats.html:31 src/olympia/stats/templates/stats/stats.html:35
+#: src/olympia/stats/templates/stats/stats.html:37
 msgid "Statistics"
 msgstr ""
 
@@ -4919,10 +4849,7 @@ msgid "Your add-on has been submitted to the Full Review queue."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/submit/done.html:18
-msgid ""
-"You'll receive an email once it has been reviewed by an editor. In\n"
-"          the meantime, you and your friends can install it directly from its\n"
-"          details page:"
+msgid "You'll receive an email once it has been reviewed by an editor. In the meantime, you and your friends can install it directly from its details page:"
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/submit/done.html:27 src/olympia/devhub/templates/devhub/addons/submit/done.html:77 src/olympia/devhub/templates/devhub/personas/submit_done.html:16
@@ -5128,11 +5055,11 @@ msgstr ""
 msgid "Use the fields below to upload your add-on package and select any platform restrictions. After upload, a series of automated validation tests will be run on your file."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/addons/submit/upload.html:59 src/olympia/devhub/templates/devhub/versions/add_file_modal.html:39
+#: src/olympia/devhub/templates/devhub/addons/submit/upload.html:51 src/olympia/devhub/templates/devhub/versions/add_file_modal.html:28
 msgid "Which platforms is this file compatible with?"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/addons/submit/upload.html:67 src/olympia/devhub/templates/devhub/versions/add_file_modal.html:65
+#: src/olympia/devhub/templates/devhub/addons/submit/upload.html:59 src/olympia/devhub/templates/devhub/versions/add_file_modal.html:45
 msgid "Administrative overrides"
 msgstr ""
 
@@ -5242,8 +5169,8 @@ msgstr ""
 
 #: src/olympia/devhub/templates/devhub/docs/policies-contact.html:44
 msgid ""
-"If you've found a problem with the site, we'd love to fix it. Please <a href=\"https://github.com/mozilla/olympia/issues\">file a bug report</a> in GitHub, including the location of the problem and "
-"how you encountered it."
+"If you've found a problem with the site, we'd love to fix it. Please <a href=\"https://github.com/mozilla/addons/issues/new\">file a bug report</a> in GitHub, including the location of the problem "
+"and how you encountered it."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/docs/policies-maintenance.html:3 src/olympia/devhub/templates/devhub/docs/policies-maintenance.html:7
@@ -5810,7 +5737,7 @@ msgstr ""
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:282
 msgid ""
-"Add-ons that store or otherwise handle browsing data must support <a href=\"https://developer.mozilla.org/En/Supporting_private_browsing_mode\">Private Browsing Mode</a>.  During a Private Browsing "
+"Add-ons that store or otherwise handle browsing data must support <a href=\"https://developer.mozilla.org/En/Supporting_private_browsing_mode\">Private Browsing Mode</a>. During a Private Browsing "
 "session, no browsing data can be written to disk, and all of this data must be cleared when Firefox quits or the Private Browsing session ends."
 msgstr ""
 
@@ -5975,129 +5902,95 @@ msgstr ""
 msgid "How to get in touch with us regarding these policies or your add-on."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:6
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:10
 msgid "You have disabled this add-on"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:20
-msgid ""
-"Your add-on's listing is disabled and is not showing\n"
-"                             anywhere in our gallery or update service."
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:24
+msgid "Your add-on's listing is disabled and is not showing anywhere in our gallery or update service."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:25
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:27
 msgid "Please complete your add-on."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:29
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:30
 msgid "You will receive an email when the review is complete."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:34
-msgid ""
-"You will receive an email when the review is complete. Until\n"
-"                             then, your add-on is not listed in our gallery but can be\n"
-"                             accessed directly from its details page."
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:33
+msgid "You will receive an email when the review is complete. Until then, your add-on is not listed in our gallery but can be accessed directly from its details page."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:38 src/olympia/devhub/templates/devhub/includes/addon_details.html:48
-msgid ""
-"You will receive an email when the review is\n"
-"                             complete and your add-on is signed."
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:37 src/olympia/devhub/templates/devhub/includes/addon_details.html:45
+msgid "You will receive an email when the review is complete and your add-on is signed."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:44
-msgid ""
-"You will receive an email when the review is complete. Until\n"
-"                             then, your add-on is not listed in our gallery but can be\n"
-"                             accessed directly from its details page. "
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:41
+msgid "You will receive an email when the review is complete. Until then, your add-on is not listed in our gallery but can be accessed directly from its details page. "
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:54
-msgid ""
-"Your add-on is displayed in our gallery and users are\n"
-"                             receiving automatic updates."
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:49
+msgid "Your add-on is displayed in our gallery and users are receiving automatic updates."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:57
-msgid ""
-"Your add-on has been signed and can be bundled with an\n"
-"                             application installer."
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:52
+msgid "Your add-on has been signed and can be bundled with an application installer."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:63
-msgid ""
-"Your add-on was disabled by a site administrator and is no\n"
-"                             longer shown in our gallery. If you have any questions,\n"
-"                             please email amo-admins@mozilla.org."
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:56
+msgid "Your add-on was disabled by a site administrator and is no longer shown in our gallery. If you have any questions, please email amo-admins@mozilla.org."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:70
-msgid ""
-"Your add-on is displayed in our gallery as experimental\n"
-"                             and users are receiving automatic updates. Some features\n"
-"                             are unavailable to your add-on."
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:62
+msgid "Your add-on is displayed in our gallery as experimental and users are receiving automatic updates. Some features are unavailable to your add-on."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:74
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:66
 msgid "Your add-on has been signed."
 msgstr ""
 
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:69
+msgid ""
+"You will receive an email when the full review is complete. Until then, your add-on is displayed in our gallery as experimental and users are receiving automatic updates. Some features are "
+"unavailable to your add-on."
+msgstr ""
+
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:74
+msgid "You will receive an email when the full review is complete, making you able to bundle your add-on with an application installer."
+msgstr ""
+
 #: src/olympia/devhub/templates/devhub/includes/addon_details.html:79
-msgid ""
-"You will receive an email when the full review is complete.\n"
-"                             Until then, your add-on is displayed in our gallery as\n"
-"                             experimental and users are receiving automatic updates.\n"
-"                             Some features are unavailable to your add-on."
+msgid "All add-ons hosted in our gallery must now be reviewed by an editor. If you wish to continue hosting your add-on, please click to select a review process."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:84
-msgid ""
-"You will receive an email when the full review is\n"
-"                             complete, making you able to bundle your add-on with an\n"
-"                             application installer."
-msgstr ""
-
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:91
-msgid ""
-"All add-ons hosted in our gallery must now be reviewed by an\n"
-"                             editor. If you wish to continue hosting your add-on, please\n"
-"                             click to select a review process."
-msgstr ""
-
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:113
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:100
 msgid "Current Version:"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:115
-msgid ""
-"This is the version of your add-on that will\n"
-"                                           be installed if someone clicks the Install\n"
-"                                           button on addons.mozilla.org. It is only\n"
-"                                           relevant for listed add-ons."
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:102
+msgid "This is the version of your add-on that will be installed if someone clicks the Install button on addons.mozilla.org. It is only relevant for listed add-ons."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:123
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:110
 msgid "Created:"
 msgstr ""
 
 #. {0} is a date. dennis-ignore: E201
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:125 src/olympia/devhub/templates/devhub/includes/addon_details.html:131
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:112 src/olympia/devhub/templates/devhub/includes/addon_details.html:118
 #, python-format
 msgid "%%b %%e, %%Y"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:136
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:123
 msgid "Next Version:"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:138
-msgid ""
-"This is the newest uploaded version, however\n"
-"                                           it isn’t live on the site yet."
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:125
+msgid "This is the newest uploaded version, however it isn’t live on the site yet."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:144 src/olympia/devhub/templates/devhub/versions/list.html:30
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:130 src/olympia/devhub/templates/devhub/versions/list.html:30
 msgid "Queues are not reviewed strictly in order"
 msgstr ""
 
@@ -6165,9 +6058,7 @@ msgid "View the blog &#9658;"
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/includes/license_form.html:6
-msgid ""
-"Please choose a license appropriate for the rights you grant on your source code.\n"
-"                  It is only relevant for listed add-ons."
+msgid "Please choose a license appropriate for the rights you grant on your source code. It is only relevant for listed add-ons."
 msgstr ""
 
 #. {0} is a list of HTML tags.
@@ -6194,14 +6085,11 @@ msgstr[1] ""
 #: src/olympia/devhub/templates/devhub/includes/policy_form.html:4
 msgid ""
 "Users will be required to accept the following End-User License Agreement (EULA) prior to installing your add-on. The presence of a EULA significantly affects the number of downloads an add-on "
-"receives. Please note that a EULA is not the same as a code license, such as the GPL or MPL.\n"
-"                It is only relevant for listed add-ons."
+"receives. Please note that a EULA is not the same as a code license, such as the GPL or MPL.It is only relevant for listed add-ons."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/policy_form.html:21
-msgid ""
-"If your add-on transmits any data from the user's computer, a privacy policy is required that explains what data is sent and how it is used.\n"
-"                It is only relevant for listed add-ons."
+#: src/olympia/devhub/templates/devhub/includes/policy_form.html:24
+msgid "If your add-on transmits any data from the user's computer, a privacy policy is required that explains what data is sent and how it is used. It is only relevant for listed add-ons."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/includes/source_form_field.html:2
@@ -6369,12 +6257,8 @@ msgstr ""
 msgid "Add some tags to describe your Theme."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/personas/edit.html:106
-msgid ""
-"A short explanation of your theme's\n"
-"                                basic functionality that is displayed in\n"
-"                                search and browse listings, as well as at\n"
-"                                the top of your theme's details page."
+#: src/olympia/devhub/templates/devhub/personas/edit.html:106 src/olympia/devhub/templates/devhub/personas/submit.html:54
+msgid "A short explanation of your theme's basic functionality that is displayed in search and browse listings, as well as at the top of your theme's details page."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/personas/edit.html:122 src/olympia/devhub/templates/devhub/personas/submit.html:68
@@ -6444,7 +6328,7 @@ msgid "Upon upload and form submission, the AMO Team will review your updated de
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/personas/edit.html:241
-msgid "Your previously resubmitted design,  which is under pending review."
+msgid "Your previously resubmitted design, which is under pending review."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/personas/edit.html:245
@@ -6511,14 +6395,6 @@ msgstr ""
 
 #: src/olympia/devhub/templates/devhub/personas/submit.html:33
 msgid "Give your Theme a name."
-msgstr ""
-
-#: src/olympia/devhub/templates/devhub/personas/submit.html:54
-msgid ""
-"A short explanation of your theme's\n"
-"                                      basic functionality that is displayed in\n"
-"                                      search and browse listings, as well as at\n"
-"                                      the top of your theme's details page."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/personas/submit.html:198
@@ -6595,30 +6471,16 @@ msgstr ""
 msgid "Files added to reviewed versions must be reviewed before they will be available for download."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/add_file_modal.html:15
-#, python-format
-msgid ""
-"Submission of updates to unlisted add-ons for signing is currently in an open beta. Manual review may still be required for a large number of add-ons. Please <a href=\"%(url)s\" target=\"_blank"
-"\">report any bugs</a> that you encounter."
-msgstr ""
-
-#: src/olympia/devhub/templates/devhub/versions/add_file_modal.html:35
+#: src/olympia/devhub/templates/devhub/versions/add_file_modal.html:24
 msgid "Select the target platform for this file."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/add_file_modal.html:46
+#: src/olympia/devhub/templates/devhub/versions/add_file_modal.html:35
 msgid "Which review type would you like to nominate for?"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/add_file_modal.html:51
+#: src/olympia/devhub/templates/devhub/versions/add_file_modal.html:40
 msgid "Only publish this version to my beta channel."
-msgstr ""
-
-#: src/olympia/devhub/templates/devhub/versions/add_file_modal.html:54
-#, python-format
-msgid ""
-"The behavior of the beta channel has changed to accommodate <a href=\"%(addon_signing_url)s\" target=\"_blank\">mandatory add-on signing</a>. The new process is currently in an open beta, and may "
-"change significantly in the near future. Please <a href=\"%(issues_url)s\" target=\"_blank\">report any bugs</a> that you encounter."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/versions/edit.html:5
@@ -6642,19 +6504,10 @@ msgstr ""
 msgid "Upload Another File"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/edit.html:45
-msgid ""
-"Adjusting application information here will allow users to install your\n"
-"                          add-on even if the install manifest in the package indicates that the\n"
-"                          add-on is incompatible."
-msgstr ""
-
 #: src/olympia/devhub/templates/devhub/versions/edit.html:74
 msgid ""
-"Information about changes in this release, new features,\n"
-"                              known bugs, and other useful information specific to this\n"
-"                              release/version. This information is also shown in the\n"
-"                              Add-ons Manager when updating."
+"Information about changes in this release, new features, known bugs, and other useful information specific to this release/version. This information is also shown in the Add-ons Manager when "
+"updating."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/versions/edit.html:99
@@ -6666,10 +6519,7 @@ msgid "Notes for Reviewers"
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/versions/edit.html:114
-msgid ""
-"Optionally, enter any information that may be useful\n"
-"                              to the Editor reviewing this add-on, such as test\n"
-"                              account information."
+msgid "Optionally, enter any information that may be useful to the Editor reviewing this add-on, such as test account information."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/versions/edit.html:127
@@ -6747,7 +6597,7 @@ msgstr ""
 msgid "Request Preliminary Review"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:80 src/olympia/devhub/templates/devhub/versions/list.html:327 src/olympia/devhub/templates/devhub/versions/list.html:350
+#: src/olympia/devhub/templates/devhub/versions/list.html:80 src/olympia/devhub/templates/devhub/versions/list.html:325 src/olympia/devhub/templates/devhub/versions/list.html:348
 msgid "Cancel Review Request"
 msgstr ""
 
@@ -6776,7 +6626,7 @@ msgid "Unlisted:"
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/versions/list.html:114
-msgid "Not distributed on {0}. Developers will upload new versions for signing and distribute the add-ons on their own. (beta)"
+msgid "Not distributed on {0}. Developers will upload new versions for signing and distribute the add-ons on their own."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/versions/list.html:122
@@ -6839,81 +6689,73 @@ msgid "<strong>Important:</strong> Once a version has been deleted, you may not 
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/versions/list.html:230
-msgid ""
-"Deleting a version which has already been reviewed\n"
-"               may also cause a significant delay in the review of\n"
-"               your next update."
-msgstr ""
-
-#: src/olympia/devhub/templates/devhub/versions/list.html:233
 msgid "Are you sure you wish to delete this version?"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:238
+#: src/olympia/devhub/templates/devhub/versions/list.html:235
 msgid "Delete Version"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:240
+#: src/olympia/devhub/templates/devhub/versions/list.html:237
 msgid "Disable Version"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:247
+#: src/olympia/devhub/templates/devhub/versions/list.html:244
 msgid "Add a new Version"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:249
+#: src/olympia/devhub/templates/devhub/versions/list.html:246
 msgid "Add Version"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:256 src/olympia/devhub/templates/devhub/versions/list.html:274
+#: src/olympia/devhub/templates/devhub/versions/list.html:253 src/olympia/devhub/templates/devhub/versions/list.html:279
 msgid "Hide Add-on"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:259
+#: src/olympia/devhub/templates/devhub/versions/list.html:256
 msgid "Hiding your add-on will prevent it from appearing anywhere in our gallery and will stop users from receiving automatic updates."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:265
+#: src/olympia/devhub/templates/devhub/versions/list.html:263
+msgid "The files awaiting review will be disabled and you will need to upload new versions."
+msgstr ""
+
+#: src/olympia/devhub/templates/devhub/versions/list.html:270
 msgid "Are you sure you wish to hide your add-on?"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:286 src/olympia/devhub/templates/devhub/versions/list.html:315
+#: src/olympia/devhub/templates/devhub/versions/list.html:291 src/olympia/devhub/templates/devhub/versions/list.html:313
 msgid "Unlist Add-on"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:289
+#: src/olympia/devhub/templates/devhub/versions/list.html:294
 #, python-format
 msgid ""
 "Unlisting your add-on will make it (and each of its versions/files) invisible on this website. It won't show up in searches, won't have a public facing page, and won't be updated automatically for "
-"current users.  It is recommended for unlisted add-ons to provide a custom <a href=\"%(update_url)s\" target=\"_blank\">updateURL</a> in their manifest file for automatic updates."
+"current users. It is recommended for unlisted add-ons to provide a custom <a href=\"%(update_url)s\" target=\"_blank\">updateURL</a> in their manifest file for automatic updates."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:299
-#, python-format
-msgid "Switching add-ons to unlisted is currently in an open beta. Please <a href=\"%(url)s\" target=\"_blank\">report any bugs</a> that you encounter."
-msgstr ""
-
-#: src/olympia/devhub/templates/devhub/versions/list.html:305
+#: src/olympia/devhub/templates/devhub/versions/list.html:303
 msgid "Unlisting an add-on is irreversible!"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:305
+#: src/olympia/devhub/templates/devhub/versions/list.html:303
 msgid "An unlisted add-on cannot be switched to be listed."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:307
+#: src/olympia/devhub/templates/devhub/versions/list.html:305
 msgid "Are you sure you wish to unlist your add-on?"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:330
+#: src/olympia/devhub/templates/devhub/versions/list.html:328
 msgid "Canceling your review request will leave your add-on as preliminarily reviewed."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:335
+#: src/olympia/devhub/templates/devhub/versions/list.html:333
 msgid "Canceling your review request will mark your add-on incomplete. If you do not complete your add-on after several days by re-requesting review, it will be deleted."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:343
+#: src/olympia/devhub/templates/devhub/versions/list.html:341
 msgid "Are you sure you wish to cancel your review request?"
 msgstr ""
 
@@ -7252,19 +7094,19 @@ msgstr ""
 msgid "Search by add-on name / author email"
 msgstr ""
 
-#: src/olympia/editors/forms.py:103
+#: src/olympia/editors/forms.py:103 src/olympia/editors/forms.py:244 src/olympia/editors/forms.py:257
 msgid "yes"
 msgstr ""
 
-#: src/olympia/editors/forms.py:104
+#: src/olympia/editors/forms.py:104 src/olympia/editors/forms.py:244 src/olympia/editors/forms.py:257
 msgid "no"
 msgstr ""
 
-#: src/olympia/editors/forms.py:105
+#: src/olympia/editors/forms.py:105 src/olympia/editors/forms.py:245
 msgid "Admin Flag"
 msgstr ""
 
-#: src/olympia/editors/forms.py:113
+#: src/olympia/editors/forms.py:113 src/olympia/editors/forms.py:253
 msgid "Max. Version"
 msgstr ""
 
@@ -7276,55 +7118,59 @@ msgstr ""
 msgid "Add-on Types"
 msgstr ""
 
-#: src/olympia/editors/forms.py:126 src/olympia/editors/helpers.py:267
+#: src/olympia/editors/forms.py:126 src/olympia/editors/helpers.py:279
 msgid "Platforms"
 msgstr ""
 
+#: src/olympia/editors/forms.py:237
+msgid "Search by add-on name / author email / guid"
+msgstr ""
+
 #. L10n: 0 = platform, 1 = filename, 2 = status message
-#: src/olympia/editors/forms.py:238
+#: src/olympia/editors/forms.py:342
 #, python-format
 msgid "<strong>%s</strong> &middot; %s &middot; %s"
 msgstr ""
 
-#: src/olympia/editors/forms.py:252
+#: src/olympia/editors/forms.py:356
 msgid "Comments:"
 msgstr ""
 
-#: src/olympia/editors/forms.py:256
+#: src/olympia/editors/forms.py:360
 msgid "Operating systems:"
 msgstr ""
 
-#: src/olympia/editors/forms.py:258
+#: src/olympia/editors/forms.py:362
 msgid "Applications:"
 msgstr ""
 
-#: src/olympia/editors/forms.py:260
+#: src/olympia/editors/forms.py:364
 msgid "Notify me the next time this add-on is updated. (Subsequent updates will not generate an email)"
 msgstr ""
 
-#: src/olympia/editors/forms.py:265
+#: src/olympia/editors/forms.py:369
 msgid "Clear Admin Review Flag"
 msgstr ""
 
-#: src/olympia/editors/forms.py:267
+#: src/olympia/editors/forms.py:371
 msgid "Clear more info requested flag"
 msgstr ""
 
-#: src/olympia/editors/forms.py:281
+#: src/olympia/editors/forms.py:385
 msgid "Choose a canned response..."
 msgstr ""
 
 #. L10n: Description of what can be searched for.
-#: src/olympia/editors/forms.py:324
+#: src/olympia/editors/forms.py:423
 msgid "theme name"
 msgstr ""
 
-#: src/olympia/editors/forms.py:350
+#: src/olympia/editors/forms.py:449
 msgid "Someone else is reviewing this theme."
 msgstr ""
 
 #. L10n: Description of what can be searched for.
-#: src/olympia/editors/forms.py:447
+#: src/olympia/editors/forms.py:546
 msgid "app, reviewer, or comment"
 msgstr ""
 
@@ -7340,246 +7186,264 @@ msgstr ""
 msgid "Rejected or Unreviewed"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:123 src/olympia/editors/helpers.py:136
+#: src/olympia/editors/helpers.py:125 src/olympia/editors/helpers.py:138
 msgid "Queue"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:124 src/olympia/editors/templates/editors/base.html:50 src/olympia/editors/templates/editors/base.html:65
+#: src/olympia/editors/helpers.py:126 src/olympia/editors/templates/editors/base.html:50 src/olympia/editors/templates/editors/base.html:65
 msgid "Pending Updates"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:125 src/olympia/editors/templates/editors/base.html:48 src/olympia/editors/templates/editors/base.html:63
+#: src/olympia/editors/helpers.py:127 src/olympia/editors/templates/editors/base.html:48 src/olympia/editors/templates/editors/base.html:63
 msgid "Full Reviews"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:126 src/olympia/editors/templates/editors/base.html:52 src/olympia/editors/templates/editors/base.html:67
+#: src/olympia/editors/helpers.py:128 src/olympia/editors/templates/editors/base.html:52 src/olympia/editors/templates/editors/base.html:67
 msgid "Preliminary Reviews"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:127 src/olympia/editors/templates/editors/base.html:54
+#: src/olympia/editors/helpers.py:129 src/olympia/editors/templates/editors/base.html:54
 msgid "Moderated Reviews"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:128 src/olympia/editors/templates/editors/base.html:46
+#: src/olympia/editors/helpers.py:130 src/olympia/editors/templates/editors/base.html:46
 msgid "Fast Track"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:130
+#: src/olympia/editors/helpers.py:132
 msgid "Pending Themes"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:131 src/olympia/editors/templates/editors/themes/queue.html:4
+#: src/olympia/editors/helpers.py:133 src/olympia/editors/templates/editors/themes/queue.html:4
 msgid "Flagged Themes"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:132
+#: src/olympia/editors/helpers.py:134
 msgid "Update Themes"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:137
+#: src/olympia/editors/helpers.py:139
 msgid "Unlisted Pending Updates"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:138
+#: src/olympia/editors/helpers.py:140
 msgid "Unlisted Full Reviews"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:139
+#: src/olympia/editors/helpers.py:141
 msgid "Unlisted Preliminary Reviews"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:170
+#: src/olympia/editors/helpers.py:142
+msgid "Unlisted All Add-ons"
+msgstr ""
+
+#: src/olympia/editors/helpers.py:173
 msgid "Fast Track ({0})"
 msgid_plural "Fast Track ({0})"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/olympia/editors/helpers.py:175
+#: src/olympia/editors/helpers.py:178
 msgid "Full Review ({0})"
 msgid_plural "Full Reviews ({0})"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/olympia/editors/helpers.py:180
+#: src/olympia/editors/helpers.py:183
 msgid "Pending Update ({0})"
 msgid_plural "Pending Updates ({0})"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/olympia/editors/helpers.py:185
+#: src/olympia/editors/helpers.py:188
 msgid "Preliminary Review ({0})"
 msgid_plural "Preliminary Reviews ({0})"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/olympia/editors/helpers.py:190
+#: src/olympia/editors/helpers.py:193
 msgid "Moderated Review ({0})"
 msgid_plural "Moderated Reviews ({0})"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/olympia/editors/helpers.py:196
+#: src/olympia/editors/helpers.py:199
 msgid "Unlisted Full Review ({0})"
 msgid_plural "Unlisted Full Reviews ({0})"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/olympia/editors/helpers.py:201
+#: src/olympia/editors/helpers.py:204
 msgid "Unlisted Pending Update ({0})"
 msgid_plural "Unlisted Pending Updates ({0})"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/olympia/editors/helpers.py:206
+#: src/olympia/editors/helpers.py:209
 msgid "Unlisted Preliminary Review ({0})"
 msgid_plural "Unlisted Preliminary Reviews ({0})"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/olympia/editors/helpers.py:261
-msgid "Addon"
-msgstr ""
+#: src/olympia/editors/helpers.py:214
+msgid "Unlisted All Add-ons ({0})"
+msgid_plural "Unlisted All Add-ons ({0})"
+msgstr[0] ""
+msgstr[1] ""
 
-#: src/olympia/editors/helpers.py:262
+#: src/olympia/editors/helpers.py:274
 msgid "Type"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:263
+#: src/olympia/editors/helpers.py:275
 msgid "Waiting Time"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:264 src/olympia/editors/templates/editors/review.html:285
+#: src/olympia/editors/helpers.py:276 src/olympia/editors/templates/editors/review.html:285
 msgid "Flags"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:265
+#: src/olympia/editors/helpers.py:277
 msgid "Applications"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:270
+#: src/olympia/editors/helpers.py:282
 msgid "Additional"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:285
+#: src/olympia/editors/helpers.py:302
 msgid "Site Specific"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:287
+#: src/olympia/editors/helpers.py:304
 msgid "Requires External Software"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:289
+#: src/olympia/editors/helpers.py:306
 msgid "Binary Components"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:313
+#: src/olympia/editors/helpers.py:339
 msgid "moments ago"
 msgstr ""
 
 #. L10n: first argument is number of minutes
-#: src/olympia/editors/helpers.py:316
+#: src/olympia/editors/helpers.py:342
 msgid "{0} minute"
 msgid_plural "{0} minutes"
 msgstr[0] ""
 msgstr[1] ""
 
 #. L10n: first argument is number of hours
-#: src/olympia/editors/helpers.py:320
+#: src/olympia/editors/helpers.py:346
 msgid "{0} hour"
 msgid_plural "{0} hours"
 msgstr[0] ""
 msgstr[1] ""
 
 #. L10n: first argument is number of days
-#: src/olympia/editors/helpers.py:324
+#: src/olympia/editors/helpers.py:350
 msgid "{0} day"
 msgid_plural "{0} days"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/olympia/editors/helpers.py:488
+#: src/olympia/editors/helpers.py:364
+msgid "Last Review"
+msgstr ""
+
+#: src/olympia/editors/helpers.py:366
+msgid "Last Update"
+msgstr ""
+
+#: src/olympia/editors/helpers.py:387
+msgid "No Reviews"
+msgstr ""
+
+#: src/olympia/editors/helpers.py:561
 msgid "Push to public"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:490
+#: src/olympia/editors/helpers.py:563
 msgid "Grant full review"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:505
+#: src/olympia/editors/helpers.py:578
 msgid "Request more information"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:508
+#: src/olympia/editors/helpers.py:581
 msgid "Request super-review"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:519
+#: src/olympia/editors/helpers.py:592
 msgid "Grant preliminary review"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:520
+#: src/olympia/editors/helpers.py:593
 msgid "This will mark the files as preliminarily reviewed."
 msgstr ""
 
-#: src/olympia/editors/helpers.py:522
+#: src/olympia/editors/helpers.py:595
 msgid "Use this form to request more information from the author. They will receive an email and be able to answer here. You will be notified by email when they reply."
 msgstr ""
 
-#: src/olympia/editors/helpers.py:526
+#: src/olympia/editors/helpers.py:599
 msgid ""
 "If you have concerns about this add-on's security, copyright issues, or other concerns that an administrator should look into, enter your comments in the area below. They will be sent to "
 "administrators, not the author."
 msgstr ""
 
-#: src/olympia/editors/helpers.py:532
+#: src/olympia/editors/helpers.py:605
 msgid "This will reject the add-on and remove it from the review queue."
 msgstr ""
 
-#: src/olympia/editors/helpers.py:534
-msgid "Make a comment on this version.  The author won't be able to see this."
+#: src/olympia/editors/helpers.py:607
+msgid "Make a comment on this version. The author won't be able to see this."
 msgstr ""
 
-#: src/olympia/editors/helpers.py:538
+#: src/olympia/editors/helpers.py:611
 msgid "This will reject the files and remove them from the review queue."
 msgstr ""
 
-#: src/olympia/editors/helpers.py:542
+#: src/olympia/editors/helpers.py:615
 msgid "This will mark the add-on as preliminarily reviewed. Future versions will undergo preliminary review."
 msgstr ""
 
-#: src/olympia/editors/helpers.py:547
+#: src/olympia/editors/helpers.py:620
 msgid "This will mark the files as preliminarily reviewed. Future versions will undergo preliminary review."
 msgstr ""
 
-#: src/olympia/editors/helpers.py:552
+#: src/olympia/editors/helpers.py:625
 msgid "Retain preliminary review"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:553
+#: src/olympia/editors/helpers.py:626
 msgid "This will retain the add-on as preliminarily reviewed. Future versions will undergo preliminary review."
 msgstr ""
 
-#: src/olympia/editors/helpers.py:558
+#: src/olympia/editors/helpers.py:631
 msgid "This will approve a sandboxed version of a public add-on to appear on the public side."
 msgstr ""
 
-#: src/olympia/editors/helpers.py:561
+#: src/olympia/editors/helpers.py:634
 msgid "This will reject a version of a public add-on and remove it from the queue."
 msgstr ""
 
-#: src/olympia/editors/helpers.py:564
+#: src/olympia/editors/helpers.py:637
 msgid "This will mark the add-on and its most recent version and files as public. Future versions will go into the sandbox until they are reviewed by an editor."
 msgstr ""
 
-#: src/olympia/editors/helpers.py:637
+#: src/olympia/editors/helpers.py:714
 msgid "add-on"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:940 src/olympia/editors/helpers.py:960
+#: src/olympia/editors/helpers.py:1020 src/olympia/editors/helpers.py:1040
 msgid "Flagged"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:944 src/olympia/editors/helpers.py:963
+#: src/olympia/editors/helpers.py:1024 src/olympia/editors/helpers.py:1043
 msgid "Updates"
 msgstr ""
 
@@ -7631,56 +7495,56 @@ msgstr ""
 msgid "A question about your Theme submission"
 msgstr ""
 
-#: src/olympia/editors/views.py:144
+#: src/olympia/editors/views.py:146
 msgid "New Add-ons (Under 5 days)"
 msgstr ""
 
-#: src/olympia/editors/views.py:145
+#: src/olympia/editors/views.py:147
 msgid "Passable (5 to 10 days)"
 msgstr ""
 
-#: src/olympia/editors/views.py:146
+#: src/olympia/editors/views.py:148
 msgid "Overdue (Over 10 days)"
 msgstr ""
 
-#: src/olympia/editors/views.py:532
+#: src/olympia/editors/views.py:539
 msgid "An unknown error occurred"
 msgstr ""
 
-#: src/olympia/editors/views.py:587
+#: src/olympia/editors/views.py:592
 msgid "Self-reviews are not allowed."
 msgstr ""
 
-#: src/olympia/editors/views.py:609
+#: src/olympia/editors/views.py:613
 msgid "Review successfully processed."
 msgstr ""
 
-#: src/olympia/editors/views.py:807
+#: src/olympia/editors/views.py:812
 msgid "was approved"
 msgstr ""
 
-#: src/olympia/editors/views.py:808
+#: src/olympia/editors/views.py:813
 msgid "given preliminary review"
 msgstr ""
 
-#: src/olympia/editors/views.py:809
+#: src/olympia/editors/views.py:814
 msgid "rejected"
 msgstr ""
 
-#: src/olympia/editors/views.py:810
+#: src/olympia/editors/views.py:815
 msgctxt "editors_review_history_nominated_adminreview"
 msgid "escalated"
 msgstr ""
 
-#: src/olympia/editors/views.py:812
+#: src/olympia/editors/views.py:817
 msgid "needs more information"
 msgstr ""
 
-#: src/olympia/editors/views.py:813
+#: src/olympia/editors/views.py:818
 msgid "needs super review"
 msgstr ""
 
-#: src/olympia/editors/views.py:814
+#: src/olympia/editors/views.py:819
 msgid "commented"
 msgstr ""
 
@@ -7725,28 +7589,28 @@ msgstr ""
 msgid "Unlisted Queues"
 msgstr ""
 
-#: src/olympia/editors/templates/editors/base.html:72 src/olympia/editors/templates/editors/performance.html:6
+#: src/olympia/editors/templates/editors/base.html:74 src/olympia/editors/templates/editors/performance.html:6
 msgid "Performance"
 msgstr ""
 
-#: src/olympia/editors/templates/editors/base.html:75 src/olympia/editors/templates/editors/themes/base.html:19 src/olympia/editors/templates/editors/themes/base.html:38
+#: src/olympia/editors/templates/editors/base.html:77 src/olympia/editors/templates/editors/themes/base.html:19 src/olympia/editors/templates/editors/themes/base.html:38
 msgid "Logs"
 msgstr ""
 
-#: src/olympia/editors/templates/editors/base.html:78 src/olympia/editors/templates/editors/reviewlog.html:4 src/olympia/editors/templates/editors/reviewlog.html:27
+#: src/olympia/editors/templates/editors/base.html:80 src/olympia/editors/templates/editors/reviewlog.html:4 src/olympia/editors/templates/editors/reviewlog.html:27
 msgid "Add-on Review Log"
 msgstr ""
 
-#: src/olympia/editors/templates/editors/base.html:80 src/olympia/editors/templates/editors/eventlog.html:4 src/olympia/editors/templates/editors/eventlog.html:8
+#: src/olympia/editors/templates/editors/base.html:82 src/olympia/editors/templates/editors/eventlog.html:4 src/olympia/editors/templates/editors/eventlog.html:8
 #: src/olympia/editors/templates/editors/eventlog_detail.html:4
 msgid "Moderated Review Log"
 msgstr ""
 
-#: src/olympia/editors/templates/editors/base.html:82 src/olympia/editors/templates/editors/beta_signed_log.html:4 src/olympia/editors/templates/editors/beta_signed_log.html:8
+#: src/olympia/editors/templates/editors/base.html:84 src/olympia/editors/templates/editors/beta_signed_log.html:4 src/olympia/editors/templates/editors/beta_signed_log.html:8
 msgid "Signed Beta Files Log"
 msgstr ""
 
-#: src/olympia/editors/templates/editors/base.html:87 src/olympia/editors/templates/editors/includes/daily-message.html:4
+#: src/olympia/editors/templates/editors/base.html:89 src/olympia/editors/templates/editors/includes/daily-message.html:4
 msgid "Announcement"
 msgstr ""
 
@@ -7967,45 +7831,45 @@ msgstr ""
 msgid "clear search"
 msgstr ""
 
-#: src/olympia/editors/templates/editors/queue.html:72 src/olympia/editors/templates/editors/queue.html:122
+#: src/olympia/editors/templates/editors/queue.html:78 src/olympia/editors/templates/editors/queue.html:128
 msgid "Process Reviews"
 msgstr ""
 
-#: src/olympia/editors/templates/editors/queue.html:80
+#: src/olympia/editors/templates/editors/queue.html:86
 msgid "Moderation actions:"
 msgstr ""
 
-#: src/olympia/editors/templates/editors/queue.html:90
+#: src/olympia/editors/templates/editors/queue.html:96
 #, python-format
 msgid "by %(user)s on %(date)s %(stars)s (%(locale)s)"
 msgstr ""
 
-#: src/olympia/editors/templates/editors/queue.html:106
+#: src/olympia/editors/templates/editors/queue.html:112
 #, python-format
 msgid "<strong>%(reason)s</strong> <span class=\"light\">Flagged by %(user)s on %(date)s</span>"
 msgstr ""
 
-#: src/olympia/editors/templates/editors/queue.html:119
-msgid "All reviews have been moderated.  Good work!"
+#: src/olympia/editors/templates/editors/queue.html:125
+msgid "All reviews have been moderated. Good work!"
 msgstr ""
 
-#: src/olympia/editors/templates/editors/queue.html:161
+#: src/olympia/editors/templates/editors/queue.html:167
 msgid "Version Notes / Notes for Reviewer"
 msgstr ""
 
-#: src/olympia/editors/templates/editors/queue.html:169
+#: src/olympia/editors/templates/editors/queue.html:175
 msgid "There are currently no add-ons of this type to review."
 msgstr ""
 
-#: src/olympia/editors/templates/editors/queue.html:181 src/olympia/editors/templates/editors/themes/queue_list.html:85
+#: src/olympia/editors/templates/editors/queue.html:187 src/olympia/editors/templates/editors/themes/queue_list.html:85
 msgid "Helpful Links:"
 msgstr ""
 
-#: src/olympia/editors/templates/editors/queue.html:182
+#: src/olympia/editors/templates/editors/queue.html:188
 msgid "Add-on Policy"
 msgstr ""
 
-#: src/olympia/editors/templates/editors/queue.html:184
+#: src/olympia/editors/templates/editors/queue.html:190
 msgid "Editors' Guide"
 msgstr ""
 
@@ -8068,10 +7932,7 @@ msgid "<strong>Warning!</strong> Another user was viewing this page before you."
 msgstr ""
 
 #: src/olympia/editors/templates/editors/review.html:237
-msgid ""
-"The whiteboard is the place to exchange information relevant to\n"
-"               this addon (whatever the version), between the developer and the\n"
-"               editor. This is visible and editable by both."
+msgid "The whiteboard is the place to exchange information relevant to this addon (whatever the version), between the developer and the editor. This is visible and editable by both."
 msgstr ""
 
 #: src/olympia/editors/templates/editors/review.html:241
@@ -8345,7 +8206,7 @@ msgstr ""
 msgid "Describe your reason for flagging"
 msgstr ""
 
-#: src/olympia/files/forms.py:88
+#: src/olympia/files/forms.py:90
 msgid "Cannot diff a version against itself"
 msgstr ""
 
@@ -8380,51 +8241,51 @@ msgstr ""
 msgid "There was an error accessing file %s."
 msgstr ""
 
-#: src/olympia/files/utils.py:343
+#: src/olympia/files/utils.py:340
 msgid "Could not parse uploaded file."
 msgstr ""
 
-#: src/olympia/files/utils.py:380
+#: src/olympia/files/utils.py:377
 msgid "Invalid file name in archive: {0}"
 msgstr ""
 
-#: src/olympia/files/utils.py:388
+#: src/olympia/files/utils.py:385
 msgid "File exceeding size limit in archive: {0}"
 msgstr ""
 
-#: src/olympia/files/utils.py:439
+#: src/olympia/files/utils.py:436
 msgid "Invalid archive."
 msgstr ""
 
-#: src/olympia/files/utils.py:529 src/olympia/files/utils.py:532
+#: src/olympia/files/utils.py:526 src/olympia/files/utils.py:529
 msgid "Could not parse the manifest file."
 msgstr ""
 
-#: src/olympia/files/utils.py:551
+#: src/olympia/files/utils.py:548
 msgid "Could not find an add-on ID."
 msgstr ""
 
-#: src/olympia/files/utils.py:554
+#: src/olympia/files/utils.py:551
 msgid "Add-on ID must be 64 characters or less."
 msgstr ""
 
-#: src/olympia/files/utils.py:556
+#: src/olympia/files/utils.py:553
 msgid "Add-on ID doesn't match add-on."
 msgstr ""
 
-#: src/olympia/files/utils.py:564
+#: src/olympia/files/utils.py:561
 msgid "Duplicate add-on ID found."
 msgstr ""
 
-#: src/olympia/files/utils.py:567
+#: src/olympia/files/utils.py:564
 msgid "Version numbers should have fewer than 32 characters."
 msgstr ""
 
-#: src/olympia/files/utils.py:570
+#: src/olympia/files/utils.py:567
 msgid "Version numbers should only contain letters, numbers, and these punctuation characters: +*.-_."
 msgstr ""
 
-#: src/olympia/files/utils.py:587
+#: src/olympia/files/utils.py:584
 msgid "<em:type> doesn't match add-on"
 msgstr ""
 
@@ -8523,6 +8384,10 @@ msgstr ""
 
 #: src/olympia/files/templates/files/viewer.html:134
 msgid "Fetching file."
+msgstr ""
+
+#: src/olympia/legacy_api/views.py:255
+msgid "Not implemented yet."
 msgstr ""
 
 #: src/olympia/lib/constants.py:6
@@ -9181,10 +9046,6 @@ msgstr ""
 msgid "Zimbabwe Dollar"
 msgstr ""
 
-#: src/olympia/lib/video/ffmpeg.py:112 src/olympia/lib/video/totem.py:81
-msgid "Videos must be in WebM."
-msgstr ""
-
 #: src/olympia/pages/templates/pages/about.lhtml:3 src/olympia/pages/templates/pages/about.lhtml:10
 msgid "About Mozilla Add-ons"
 msgstr ""
@@ -9196,7 +9057,7 @@ msgstr ""
 #: src/olympia/pages/templates/pages/about.lhtml:13
 msgid ""
 "addons.mozilla.org, commonly known as \"AMO\", is Mozilla's official site for add-ons to Mozilla software, such as Firefox, Thunderbird, and SeaMonkey. Add-ons let you add new features and change "
-"the way your browser or application works.  Take a look around and explore the thousands of ways to customize the way you do things online."
+"the way your browser or application works. Take a look around and explore the thousands of ways to customize the way you do things online."
 msgstr ""
 
 #: src/olympia/pages/templates/pages/about.lhtml:19
@@ -9541,7 +9402,7 @@ msgstr ""
 msgid ""
 "Yes. It's possible, but some of the functionality provided by these libraries are available through XPCOM, XUL, and JavaScript. In addition, authors should take care if libraries modify primitive "
 "object prototypes (String.prototype, Date.prototype, etc.) and/or define global functions (eg. the $ function). These are prone to cause conflict with other add-ons, in particular if different add-"
-"ons use different versions of libraries and so on. Developers need to be very, very careful with using them.  Mozilla does not offer documentation on using them to build add-ons."
+"ons use different versions of libraries and so on. Developers need to be very, very careful with using them. Mozilla does not offer documentation on using them to build add-ons."
 msgstr ""
 
 #: src/olympia/pages/templates/pages/dev_faq.html:165
@@ -9655,8 +9516,8 @@ msgstr ""
 #, python-format
 msgid ""
 "Yes. Many developers choose to host their own add-ons. Choosing to host your add-on on <a href=\"%(amo_url)s\">Mozilla's add-on site</a>, though, allows for much greater exposure to your add-on due "
-"to the large volume of visitors to the site.  <a href=\"%(md_url)s\">mozdev.org</a> offers free project hosting for Mozilla applications and extensions providing developers with tools to help "
-"manage source code, version control, bug tracking and documentation."
+"to the large volume of visitors to the site. <a href=\"%(md_url)s\">mozdev.org</a> offers free project hosting for Mozilla applications and extensions providing developers with tools to help manage "
+"source code, version control, bug tracking and documentation."
 msgstr ""
 
 #: src/olympia/pages/templates/pages/dev_faq.html:277
@@ -9704,7 +9565,7 @@ msgstr ""
 #: src/olympia/pages/templates/pages/dev_faq.html:314
 #, python-format
 msgid ""
-"Yes. Mozilla's <a href=\"%(p_url)s\">Add-on Policy</a> describes what is an acceptable submission. This policy is subject to change without notice.  In addition, the AMO editorial team uses the <a "
+"Yes. Mozilla's <a href=\"%(p_url)s\">Add-on Policy</a> describes what is an acceptable submission. This policy is subject to change without notice. In addition, the AMO editorial team uses the <a "
 "href=\"%(g_url)s\">Editors Reviewing Guide</a> to ensure that your add-on meets specific guidelines for functionality and security."
 msgstr ""
 
@@ -9821,7 +9682,7 @@ msgstr ""
 #: src/olympia/pages/templates/pages/dev_faq.html:434
 #, python-format
 msgid ""
-"This is why it's very important to read the <a href=\"%(g_url)s\">Editors Reviewing Guide</a> to ensure that your add-on is setup as expected.  It's also a good idea to read the blog post, <a href="
+"This is why it's very important to read the <a href=\"%(g_url)s\">Editors Reviewing Guide</a> to ensure that your add-on is setup as expected. It's also a good idea to read the blog post, <a href="
 "\"%(blog_url)s\">Successfully Getting your Add-on Reviewed</a> which provides excellent insight into ensuring a smooth review of your add-on."
 msgstr ""
 
@@ -9928,7 +9789,7 @@ msgstr ""
 
 #: src/olympia/pages/templates/pages/dev_faq.html:572
 msgid ""
-"Free Software Foundation provides short summaries of the key open source licenses, including whether the license qualifies as a free software license or a copyleft license.  Also includes a "
+"Free Software Foundation provides short summaries of the key open source licenses, including whether the license qualifies as a free software license or a copyleft license. Also includes a "
 "discussion of what constitutes a free software license or a copyleft license (e.g., a Copyleft license is a general method for making a program or other work free, and requiring all modified and "
 "extended versions of the program to be free as well.)"
 msgstr ""
@@ -10106,19 +9967,13 @@ msgid "Add-on Gallery"
 msgstr ""
 
 #: src/olympia/pages/templates/pages/faq.html:171
-msgid ""
-"How do I choose between add-ons that seem to do the same\n"
-"    thing?"
+msgid "How do I choose between add-ons that seem to do the same thing?"
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:173
+#: src/olympia/pages/templates/pages/faq.html:172
 msgid ""
-"There are often several add-ons that have similar features. To\n"
-"    figure out which is right for you, read the entire description of the\n"
-"    add-on and view its screenshots. If there are still several in the running,\n"
-"    read through the add-on's ratings, user reviews, and statistics to see\n"
-"    which is most liked by other users. Remember that you can also just try\n"
-"    out both and see which you like better."
+"There are often several add-ons that have similar features. To figure out which is right for you, read the entire description of the add-on and view its screenshots. If there are still several in "
+"the running, read through the add-on's ratings, user reviews, and statistics to see which is most liked by other users. Remember that you can also just try out both and see which you like better."
 msgstr ""
 
 #: src/olympia/pages/templates/pages/faq.html:180
@@ -10159,80 +10014,67 @@ msgid "How much do add-ons cost to purchase?"
 msgstr ""
 
 #: src/olympia/pages/templates/pages/faq.html:207
-msgid ""
-"Add-ons hosted in our gallery are free unless clearly marked\n"
-"    otherwise."
+msgid "Add-ons hosted in our gallery are free unless clearly marked otherwise."
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:210
+#: src/olympia/pages/templates/pages/faq.html:209
 msgid "What does it mean when an add-on asks for contributions?"
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:211
+#: src/olympia/pages/templates/pages/faq.html:210
 msgid ""
-"Some add-on authors request users who enjoy an add-on to\n"
-"        contribute to its development by making a monetary contribution. These\n"
-"        contributions go directly to the developer unless a third party is\n"
-"        indicated, such as the non-profit Mozilla Foundation."
+"Some add-on authors request users who enjoy an add-on to contribute to its development by making a monetary contribution. These contributions go directly to the developer unless a third party is "
+"indicated, such as the non-profit Mozilla Foundation."
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:216
+#: src/olympia/pages/templates/pages/faq.html:215
 msgid "What are beta add-ons?"
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:218
+#: src/olympia/pages/templates/pages/faq.html:217
 msgid ""
-"Beta add-ons are unreviewed versions which represent the\n"
-"        latest work of an add-on author. While different authors have different\n"
-"        standards for beta code quality, you should assume that these add-ons\n"
-"        are less stable than the general add-on releases."
+"Beta add-ons are unreviewed versions which represent the latest work of an add-on author. While different authors have different standards for beta code quality, you should assume that these add-"
+"ons are less stable than the general add-on releases."
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:222
+#: src/olympia/pages/templates/pages/faq.html:221
 msgid ""
 "Please note that when you install an add-on from the \"Beta Version\" section of an add-on's listing, you will continue to receive updates for that add-on as they become available. Like the initial "
 "version you installed, all beta releases are unreviewed by Mozilla and may harm your computer."
 msgstr ""
 
+#: src/olympia/pages/templates/pages/faq.html:228
+msgid "What does it mean when an add-on is flagged as slow?"
+msgstr ""
+
 #: src/olympia/pages/templates/pages/faq.html:229
-msgid ""
-"What does it mean when an add-on is flagged as\n"
-"    slow?"
+msgid "Most add-ons load code and resources at the same time Firefox is starting up. In most cases the impact in start-up time is minimal, but some add-ons can cause a noticeable slowdown."
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:231
-msgid ""
-"Most add-ons load code and resources at the same time Firefox\n"
-"        is starting up. In most cases the impact in start-up time is minimal,\n"
-"        but some add-ons can cause a noticeable slowdown."
-msgstr ""
-
-#: src/olympia/pages/templates/pages/faq.html:236
+#: src/olympia/pages/templates/pages/faq.html:234
 msgid "How do I report an inappropriate or spam user review?"
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:237
+#: src/olympia/pages/templates/pages/faq.html:235
 msgid ""
-"To report a user review of an add-on, log in with your account\n"
-"    and visit the add-on's reviews page. Find the review you wish to report,\n"
-"    click \"Report this review\" and select a reason. Our editorial team will\n"
-"    investigate the review and take appropriate action."
+"To report a user review of an add-on, log in with your account and visit the add-on's reviews page. Find the review you wish to report, click \"Report this review\" and select a reason. Our "
+"editorial team will investigate the review and take appropriate action."
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:242
+#: src/olympia/pages/templates/pages/faq.html:240
 msgid "How do I report a bug or contact the Mozilla Add-ons team?"
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:243
+#: src/olympia/pages/templates/pages/faq.html:241
 #, python-format
 msgid "Please visit our <a href=\"%(contact_url)s\">Contact page</a>."
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:246
+#: src/olympia/pages/templates/pages/faq.html:244
 msgid "What is a Source Code License?"
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:247
+#: src/olympia/pages/templates/pages/faq.html:245
 #, python-format
 msgid ""
 "The source code used to create an add-on is an exclusive copyright of the add-on author, unless otherwise declared in a source code license. Many add-ons on this site have <a href=\"%(url)s\" lang="
@@ -10240,60 +10082,60 @@ msgid ""
 "the GPL or BSD licenses instead of making up their own."
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:256
+#: src/olympia/pages/templates/pages/faq.html:254
 #, python-format
 msgid "Firefox and other Mozilla software are <a href=\"%(url)s\">open source</a>."
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:264
+#: src/olympia/pages/templates/pages/faq.html:262
 msgid "Collections and Favorites"
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:267
+#: src/olympia/pages/templates/pages/faq.html:265
 msgid "What is a collection?"
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:268
+#: src/olympia/pages/templates/pages/faq.html:266
 msgid "Collections are groups of related add-ons created by users to share."
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:270
+#: src/olympia/pages/templates/pages/faq.html:268
 msgid "What is the My Favorites collection?"
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:271
+#: src/olympia/pages/templates/pages/faq.html:269
 msgid "Favorite add-ons are add-ons that you have bookmarked to easily get back to later. You can add an add-on to your favorites collection by clicking \"Add to favorites\" on its details page."
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:275 src/olympia/templates/menu_links.html:13 src/olympia/templates/impala/header_title.html:17
+#: src/olympia/pages/templates/pages/faq.html:273 src/olympia/templates/menu_links.html:13 src/olympia/templates/impala/header_title.html:17
 msgid "Mobile Add-ons"
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:278
+#: src/olympia/pages/templates/pages/faq.html:276
 msgid "What are mobile add-ons?"
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:279
+#: src/olympia/pages/templates/pages/faq.html:277
 #, python-format
 msgid ""
 "Mobile add-ons work with <a href=\"%(mobile_url)s\">Firefox for Mobile</a> and add or modify functionality just like desktop add-ons. You can find add-ons that work with Firefox for Mobile in our "
 "<a href=\"%(gallery_url)s\">gallery</a>."
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:288
+#: src/olympia/pages/templates/pages/faq.html:286
 msgid "Developer Topics"
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:289
+#: src/olympia/pages/templates/pages/faq.html:287
 #, python-format
 msgid "Please see our <a href=\"%(faq_url)s\">Developer FAQ</a> and <a href=\"%(hub_url)s\">Developer Hub</a> for answers to add-on developer-related questions."
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:294
+#: src/olympia/pages/templates/pages/faq.html:292
 msgid "Still have questions?"
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:295
+#: src/olympia/pages/templates/pages/faq.html:293
 #, python-format
 msgid "For general Firefox support, visit our <a href=\"%(sumo_url)s\">support website</a>. For general add-on and website questions, visit our <a href=\"%(forum_url)s\">forum</a>."
 msgstr ""
@@ -10431,7 +10273,7 @@ msgstr ""
 
 #: src/olympia/pages/templates/pages/sunbird.html:29
 msgid ""
-"Development on the Sunbird project has halted and its final release was on March 30, 2010.  We've been proud to host Sunbird add-ons on this site but as the project is no longer maintained we have "
+"Development on the Sunbird project has halted and its final release was on March 30, 2010. We've been proud to host Sunbird add-ons on this site but as the project is no longer maintained we have "
 "disabled our support for the add-ons."
 msgstr ""
 
@@ -10509,7 +10351,7 @@ msgstr ""
 #, python-format
 msgid ""
 "<h2>Keep these tips in mind:</h2> <ul> <li> Write like you're telling a friend about your experience with the add-on. Give specifics and helpful details, such as what features you liked and/or "
-"disliked, how easy to use it is, and any disadvantages it has.  Avoid generic language such as calling it \"Great\" or \"Bad\" unless you can give reasons why you believe this is so. </li> <li> "
+"disliked, how easy to use it is, and any disadvantages it has. Avoid generic language such as calling it \"Great\" or \"Bad\" unless you can give reasons why you believe this is so. </li> <li> "
 "Please do not post bug reports in reviews. We do not make your email address available to add-on developers and they may need to contact you to help resolve your issue. See the <a href=\"%(support)s"
 "\">support section</a> to find out where to get assistance for this add-on. </li> <li>Please keep reviews clean, avoid the use of improper language and do not post any personal information. </li> </"
 "ul> <p>Please read the <a href=\"%(guide)s\" target=\"_blank\">Review Guidelines</a> for more detail about user add-on reviews.</p>"
@@ -10745,16 +10587,16 @@ msgstr ""
 
 #. L10n: {0} is an application, such as Firefox. This means "any version of
 #. Firefox."
-#: src/olympia/search/views.py:554
+#: src/olympia/search/views.py:547
 msgid "Any {0}"
 msgstr ""
 
 #. L10n: "All Systems" means show everything regardless of platform.
-#: src/olympia/search/views.py:589
+#: src/olympia/search/views.py:582
 msgid "All Systems"
 msgstr ""
 
-#: src/olympia/search/views.py:600
+#: src/olympia/search/views.py:593
 msgid "All Tags"
 msgstr ""
 
@@ -10928,31 +10770,31 @@ msgstr ""
 msgid "Share this Collection"
 msgstr ""
 
-#: src/olympia/signing/views.py:30 src/olympia/templates/base.html:75 src/olympia/templates/impala/base.html:115
+#: src/olympia/signing/views.py:33 src/olympia/templates/base.html:71 src/olympia/templates/impala/base.html:112
 msgid "Some features are temporarily disabled while we perform website maintenance. We'll be back to full capacity shortly."
 msgstr ""
 
-#: src/olympia/signing/views.py:53
+#: src/olympia/signing/views.py:56
 msgid "Could not find add-on with id \"{}\"."
 msgstr ""
 
-#: src/olympia/signing/views.py:67
+#: src/olympia/signing/views.py:70
 msgid "You do not own this addon."
 msgstr ""
 
-#: src/olympia/signing/views.py:82
+#: src/olympia/signing/views.py:87
 msgid "Missing \"upload\" key in multipart file data."
 msgstr ""
 
-#: src/olympia/signing/views.py:96
+#: src/olympia/signing/views.py:101
 msgid "Version does not match the manifest file."
 msgstr ""
 
-#: src/olympia/signing/views.py:100
+#: src/olympia/signing/views.py:105
 msgid "Version already exists."
 msgstr ""
 
-#: src/olympia/signing/views.py:136
+#: src/olympia/signing/views.py:141
 msgid "No uploaded file for that addon and version."
 msgstr ""
 
@@ -11065,89 +10907,89 @@ msgstr ""
 msgid "Statistics Dashboard :: Add-ons for {0}"
 msgstr ""
 
-#: src/olympia/stats/templates/stats/stats.html:30
-msgid "Controls:"
-msgstr ""
-
-#: src/olympia/stats/templates/stats/stats.html:33
-msgid "reset zoom"
-msgstr ""
-
-#: src/olympia/stats/templates/stats/stats.html:40
-msgid "Group by:"
-msgstr ""
-
-#: src/olympia/stats/templates/stats/stats.html:42
-msgid "day"
-msgstr ""
-
-#: src/olympia/stats/templates/stats/stats.html:45
-msgid "week"
-msgstr ""
-
-#: src/olympia/stats/templates/stats/stats.html:48
-msgid "month"
-msgstr ""
-
-#: src/olympia/stats/templates/stats/stats.html:54
-msgid "For last:"
-msgstr ""
-
-#: src/olympia/stats/templates/stats/stats.html:57
-msgid "7 days"
-msgstr ""
-
-#: src/olympia/stats/templates/stats/stats.html:60
-msgid "30 days"
-msgstr ""
-
-#: src/olympia/stats/templates/stats/stats.html:63
-msgid "90 days"
-msgstr ""
-
-#: src/olympia/stats/templates/stats/stats.html:66
-msgid "365 days"
-msgstr ""
-
-#: src/olympia/stats/templates/stats/stats.html:69
-msgid "Custom..."
-msgstr ""
-
 #. {0} is an add-on name
-#: src/olympia/stats/templates/stats/stats.html:88 src/olympia/stats/templates/stats/stats.html:91
+#: src/olympia/stats/templates/stats/stats.html:44 src/olympia/stats/templates/stats/stats.html:47
 msgid "Statistics for {0}"
 msgstr ""
 
-#: src/olympia/stats/templates/stats/stats.html:94
+#: src/olympia/stats/templates/stats/stats.html:50
 msgid "Statistics Dashboard"
 msgstr ""
 
-#: src/olympia/stats/templates/stats/stats.html:104
+#: src/olympia/stats/templates/stats/stats.html:57
+msgid "Controls:"
+msgstr ""
+
+#: src/olympia/stats/templates/stats/stats.html:60
+msgid "reset zoom"
+msgstr ""
+
+#: src/olympia/stats/templates/stats/stats.html:67
+msgid "Group by:"
+msgstr ""
+
+#: src/olympia/stats/templates/stats/stats.html:69
+msgid "day"
+msgstr ""
+
+#: src/olympia/stats/templates/stats/stats.html:72
+msgid "week"
+msgstr ""
+
+#: src/olympia/stats/templates/stats/stats.html:75
+msgid "month"
+msgstr ""
+
+#: src/olympia/stats/templates/stats/stats.html:81
+msgid "For last:"
+msgstr ""
+
+#: src/olympia/stats/templates/stats/stats.html:84
+msgid "7 days"
+msgstr ""
+
+#: src/olympia/stats/templates/stats/stats.html:87
+msgid "30 days"
+msgstr ""
+
+#: src/olympia/stats/templates/stats/stats.html:90
+msgid "90 days"
+msgstr ""
+
+#: src/olympia/stats/templates/stats/stats.html:93
+msgid "365 days"
+msgstr ""
+
+#: src/olympia/stats/templates/stats/stats.html:96
+msgid "Custom..."
+msgstr ""
+
+#: src/olympia/stats/templates/stats/stats.html:106
 msgid "Statistics processing is currently disabled, so recent data is unavailable. The statistics are still being collected and this page will be updated soon with the missing data."
 msgstr ""
 
-#: src/olympia/stats/templates/stats/stats.html:110
+#: src/olympia/stats/templates/stats/stats.html:112
 msgid "Loading the latest data&hellip;"
 msgstr ""
 
-#: src/olympia/stats/templates/stats/stats.html:142 src/olympia/stats/templates/stats/reports/overview.html:25 src/olympia/stats/templates/stats/reports/overview.html:37
+#: src/olympia/stats/templates/stats/stats.html:144 src/olympia/stats/templates/stats/reports/overview.html:25 src/olympia/stats/templates/stats/reports/overview.html:37
 #: src/olympia/stats/templates/stats/reports/overview.html:49
 msgid "No data available."
 msgstr ""
 
-#: src/olympia/stats/templates/stats/stats.html:177
+#: src/olympia/stats/templates/stats/stats.html:179
 msgid "This dashboard is currently <b>public</b>."
 msgstr ""
 
-#: src/olympia/stats/templates/stats/stats.html:179
+#: src/olympia/stats/templates/stats/stats.html:181
 msgid "Contribution stats are currently <b>private</b>."
 msgstr ""
 
-#: src/olympia/stats/templates/stats/stats.html:182
+#: src/olympia/stats/templates/stats/stats.html:184
 msgid "This dashboard is currently <b>private</b>."
 msgstr ""
 
-#: src/olympia/stats/templates/stats/stats.html:185
+#: src/olympia/stats/templates/stats/stats.html:187
 msgid "Change settings."
 msgstr ""
 
@@ -11299,15 +11141,6 @@ msgstr ""
 msgid "Application versions by Date"
 msgstr ""
 
-#: src/olympia/tags/templates/tags/top_cloud.html:4
-msgid "Top {0} Tags"
-msgstr ""
-
-#. {0} is the current application name
-#: src/olympia/tags/templates/tags/top_cloud.html:14
-msgid "{0} Top Tags"
-msgstr ""
-
 #: src/olympia/templates/amo_footer.html:6 src/olympia/templates/includes/lang_switcher.html:2
 msgid "Other languages"
 msgstr ""
@@ -11316,11 +11149,11 @@ msgstr ""
 msgid "Mozilla Add-ons"
 msgstr ""
 
-#: src/olympia/templates/base.html:91 src/olympia/templates/impala/base.html:81
+#: src/olympia/templates/base.html:89 src/olympia/templates/impala/base.html:78
 msgid "Find add-ons for other applications"
 msgstr ""
 
-#: src/olympia/templates/base.html:92 src/olympia/templates/impala/base.html:81
+#: src/olympia/templates/base.html:90 src/olympia/templates/impala/base.html:78
 msgid "Other Applications"
 msgstr ""
 
@@ -11345,7 +11178,7 @@ msgid "View Mobile Site"
 msgstr ""
 
 #: src/olympia/templates/copyright.html:7
-msgid "Site Status "
+msgid "Site Status"
 msgstr ""
 
 #: src/olympia/templates/footer.html:3
@@ -11445,35 +11278,35 @@ msgstr ""
 msgid "<a href=\"%(reg)s\">Register</a> or <a href=\"%(login)s\">Log in</a>"
 msgstr ""
 
-#: src/olympia/templates/impala/base.html:126
+#: src/olympia/templates/impala/base.html:123
 #, python-format
 msgid "To try the thousands of add-ons available here, download <a href=\"%(url)s\">Mozilla Firefox</a>, a fast, free way to surf the Web!"
 msgstr ""
 
-#: src/olympia/templates/impala/base.html:138
+#: src/olympia/templates/impala/base.html:135
 #, python-format
 msgid "Add-ons is switching to Firefox Accounts for login. <a href=\"%(url)s\" class=\"fxa-login\">Sign in now to transfer your account.</a>"
 msgstr ""
 
 #. {0} is an application, such as Firefox.
-#: src/olympia/templates/impala/base.html:148
+#: src/olympia/templates/impala/base.html:145
 msgid "Welcome to {0} Add-ons."
 msgstr ""
 
-#: src/olympia/templates/impala/base.html:151
+#: src/olympia/templates/impala/base.html:148
 msgid "Choose from thousands of extra features and styles to make Firefox your own."
 msgstr ""
 
-#: src/olympia/templates/impala/base.html:156
+#: src/olympia/templates/impala/base.html:153
 #, python-format
 msgid "Add extra features and styles to make %(app)s your own."
 msgstr ""
 
-#: src/olympia/templates/impala/base.html:164
+#: src/olympia/templates/impala/base.html:161
 msgid "On the go?"
 msgstr ""
 
-#: src/olympia/templates/impala/base.html:166
+#: src/olympia/templates/impala/base.html:163
 msgid "Check out our <a class=\"mobile-link\" href=\"#\">Mobile Add-ons site</a>."
 msgstr ""
 
@@ -11697,19 +11530,19 @@ msgstr ""
 
 #. L10n: {id} will be something like "13ad6a", just a random number
 #. to differentiate this user from other anonymous users.
-#: src/olympia/users/models.py:353
+#: src/olympia/users/models.py:362
 msgid "Anonymous user {id}"
 msgstr ""
 
-#: src/olympia/users/models.py:410
+#: src/olympia/users/models.py:419
 msgid "Your account has been restricted"
 msgstr ""
 
-#: src/olympia/users/models.py:480
+#: src/olympia/users/models.py:489
 msgid "Please confirm your email address"
 msgstr ""
 
-#: src/olympia/users/models.py:506
+#: src/olympia/users/models.py:515
 msgid "My Mobile Add-ons"
 msgstr ""
 
@@ -11986,7 +11819,7 @@ msgstr ""
 
 #: src/olympia/users/templates/users/edit.html:70
 #, python-format
-msgid "Change your password.  If you forgot your password, you can <a href=\"%(reset_url)s\">use the reset form</a>."
+msgid "Change your password. If you forgot your password, you can <a href=\"%(reset_url)s\">use the reset form</a>."
 msgstr ""
 
 #: src/olympia/users/templates/users/edit.html:76
@@ -12006,7 +11839,7 @@ msgid "Profile"
 msgstr ""
 
 #: src/olympia/users/templates/users/edit.html:100
-msgid "Give us a bit more information about yourself.  All these fields are optional, but they'll help other users get to know you better."
+msgid "Give us a bit more information about yourself. All these fields are optional, but they'll help other users get to know you better."
 msgstr ""
 
 #: src/olympia/users/templates/users/edit.html:124
@@ -12222,7 +12055,7 @@ msgid "Confirm password"
 msgstr ""
 
 #: src/olympia/users/templates/users/pwreset_confirm.html:47
-msgid "The password reset link was invalid, possibly because it has already been used.  Please request a new password reset."
+msgid "The password reset link was invalid, possibly because it has already been used. Please request a new password reset."
 msgstr ""
 
 #: src/olympia/users/templates/users/pwreset_request.html:15
@@ -12408,7 +12241,7 @@ msgstr ""
 
 #: src/olympia/users/templates/users/unsubscribe.html:30
 #, python-format
-msgid "Unfortunately, we weren't able to unsubscribe you.  The link you clicked is invalid. However, you can unsubscribe still unsubscribe on your <a href=\"%(edit_url)s\">edit profile page</a>."
+msgid "Unfortunately, we weren't able to unsubscribe you. The link you clicked is invalid. However, you can unsubscribe still unsubscribe on your <a href=\"%(edit_url)s\">edit profile page</a>."
 msgstr ""
 
 #: src/olympia/users/templates/users/vcard.html:2
@@ -12462,15 +12295,15 @@ msgstr ""
 msgid "Version History with Changelogs"
 msgstr ""
 
-#: src/olympia/versions/models.py:314
+#: src/olympia/versions/models.py:313
 msgid "Add-on uses binary components."
 msgstr ""
 
-#: src/olympia/versions/models.py:317
+#: src/olympia/versions/models.py:316
 msgid "Add-on has opted into strict compatibility checking."
 msgstr ""
 
-#: src/olympia/versions/models.py:715
+#: src/olympia/versions/models.py:711
 msgid "{app} {min} and later"
 msgstr ""
 
@@ -12545,4 +12378,8 @@ msgstr ""
 
 #: src/olympia/zadmin/forms.py:105
 msgid "Log emails instead of sending"
+msgstr ""
+
+#: src/olympia/zadmin/forms.py:215
+msgid "Deleted versions can`t be changed."
 msgstr ""

--- a/locale/eo/LC_MESSAGES/djangojs.po
+++ b/locale/eo/LC_MESSAGES/djangojs.po
@@ -1,1216 +1,1236 @@
-
 #, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2016-02-24 21:23+0000\n"
+"POT-Creation-Date: 2016-04-18 15:47+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
+"Language: \n"
 "MIME-Version: 1.0\n"
-"Content-Type: text/plain; charset=utf-8\n"
+"Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Generated-By: Babel 2.2.0\n"
 
-#: static/js/common/ratingwidget.js:31
+#: static/js/common-all.js:1426 static/js/impala-all.js:1511 static/js/zamboni/discovery-all.js:12598 static/js/zamboni/init.js:28 static/js/zamboni/mobile-all.js:14945
+msgid "This feature is temporarily disabled while we perform website maintenance. Please check back a little later."
+msgstr ""
+
+#. L10n: {0} is an app name like Firefox.
+#: static/js/common-all.js:1837 static/js/impala-all.js:1922 static/js/zamboni/buttons.js:73 static/js/zamboni/discovery-all.js:13108
+msgid "Accept and Install"
+msgstr ""
+
+#: static/js/common-all.js:1837 static/js/impala-all.js:1922 static/js/zamboni/buttons.js:73 static/js/zamboni/discovery-all.js:13108
+msgid "Add to {0}"
+msgstr ""
+
+#: static/js/common-all.js:1842 static/js/impala-all.js:1927 static/js/zamboni/buttons.js:78 static/js/zamboni/discovery-all.js:13113
+msgid "Download Now"
+msgstr ""
+
+#: static/js/common-all.js:1883 static/js/impala-all.js:1968 static/js/zamboni/buttons.js:119 static/js/zamboni/discovery-all.js:13154
+msgid "Add-on has not been updated to support default-to-compatible."
+msgstr ""
+
+#: static/js/common-all.js:1888 static/js/impala-all.js:1973 static/js/zamboni/buttons.js:124 static/js/zamboni/discovery-all.js:13159
+msgid "You need to be using Firefox 10.0 or higher."
+msgstr ""
+
+#: static/js/common-all.js:1900 static/js/impala-all.js:1985 static/js/zamboni/buttons.js:136 static/js/zamboni/discovery-all.js:13171
+msgid "Mozilla has marked this version as incompatible with your Firefox version."
+msgstr ""
+
+#. L10n: {0} is an platform like Windows or Linux.
+#: static/js/common-all.js:1981 static/js/impala-all.js:2066 static/js/zamboni/buttons.js:217 static/js/zamboni/discovery-all.js:13252
+msgid "Install for {0} anyway"
+msgstr ""
+
+#: static/js/common-all.js:1981 static/js/impala-all.js:2066 static/js/zamboni/buttons.js:217 static/js/zamboni/discovery-all.js:13252
+msgid "Download for {0} anyway"
+msgstr ""
+
+#: static/js/common-all.js:2038 static/js/impala-all.js:2123 static/js/zamboni/buttons.js:274 static/js/zamboni/discovery-all.js:13309
+msgid "Not available for your platform"
+msgstr ""
+
+#. L10n: {0} is an app name, {1} is the app version.
+#: static/js/common-all.js:2049 static/js/common-all.js:2086 static/js/impala-all.js:2134 static/js/impala-all.js:2171 static/js/zamboni/buttons.js:286 static/js/zamboni/buttons.js:324
+#: static/js/zamboni/discovery-all.js:13320 static/js/zamboni/discovery-all.js:13357
+msgid "Not available for {0} {1}"
+msgstr ""
+
+#: static/js/common-all.js:2112 static/js/impala-all.js:2197 static/js/zamboni/buttons.js:351 static/js/zamboni/discovery-all.js:13383
+msgid "Works with {app} {min} - {max}"
+msgstr ""
+
+#: static/js/common-all.js:2114 static/js/impala-all.js:2199 static/js/zamboni/buttons.js:353 static/js/zamboni/discovery-all.js:13385
+msgid "View other versions"
+msgstr ""
+
+#: static/js/common-all.js:2162 static/js/impala-all.js:2247 static/js/zamboni/buttons.js:401 static/js/zamboni/discovery-all.js:13433
+msgid "Only with Firefox — Get Firefox Now!"
+msgstr ""
+
+#: static/js/common-all.js:2278 static/js/impala-all.js:2363 static/js/zamboni/buttons.js:517 static/js/zamboni/discovery-all.js:13549 static/js/zamboni/mobile-all.js:15177
+#: static/js/zamboni/mobile/buttons.js:43
+msgid "Sorry, you need a Mozilla-based browser (such as Firefox) to install a search plugin."
+msgstr ""
+
+#: static/js/common-all.js:9088 static/js/impala-all.js:9649 static/js/zamboni/global.js:410
+msgid "Loading..."
+msgstr ""
+
+#. L10n: {0} is the number of characters left.
+#: static/js/common-all.js:9152 static/js/impala-all.js:9713 static/js/zamboni/global.js:474
+msgid "<b>{0}</b> character left."
+msgid_plural "<b>{0}</b> characters left."
+msgstr[0] ""
+msgstr[1] ""
+
+#: static/js/common-all.js:9589 static/js/common-min.js:6 static/js/impala-all.js:10052 static/js/impala-min.js:6 static/js/common/ratingwidget.js:31 static/js/zamboni/mobile-all.js:16123
+#: static/js/zamboni/mobile-min.js:6
 msgid "{0} star"
 msgid_plural "{0} stars"
 msgstr[0] ""
 msgstr[1] ""
 
-#: static/js/common/upload-addon.js:41 static/js/common/upload-image.js:128
+#: static/js/common-all.js:9676 static/js/common-min.js:6 static/js/impala-all.js:10139 static/js/impala-min.js:6 static/js/zamboni/l10n.js:45
+msgid "Remove this localization"
+msgstr ""
+
+#: static/js/common-all.js:10193 static/js/common-min.js:6 static/js/impala-all.js:10674 static/js/impala-min.js:6 static/js/zamboni/discovery-all.js:13678
+msgid "close"
+msgstr ""
+
+#: static/js/common-all.js:10860 static/js/common-min.js:6 static/js/impala-all.js:11481 static/js/impala-min.js:6 static/js/impala/reviews.js:23 static/js/zamboni/reviews.js:18
+msgid "Flagged for review"
+msgstr ""
+
+#: static/js/common-all.js:10876 static/js/common-min.js:6 static/js/impala-all.js:11498 static/js/impala-min.js:6 static/js/impala/reviews.js:40 static/js/zamboni/reviews.js:34
+msgid "Your input is required"
+msgstr ""
+
+#: static/js/common-all.js:10945 static/js/common-min.js:6 static/js/impala-all.js:11610 static/js/impala-min.js:7 static/js/impala/reviews.js:152 static/js/zamboni/reviews.js:103
+msgid "Marked for deletion"
+msgstr ""
+
+#: static/js/common-all.js:11573 static/js/common-min.js:7 static/js/impala-all.js:13809 static/js/impala-min.js:8 static/js/zamboni/collections.js:229
+msgid "Adding to Favorites&hellip;"
+msgstr ""
+
+#: static/js/common-all.js:11576 static/js/common-min.js:7 static/js/impala-all.js:13812 static/js/impala-min.js:8 static/js/zamboni/collections.js:232
+msgid "Removing Favorite&hellip;"
+msgstr ""
+
+#: static/js/common-all.js:11579 static/js/common-min.js:7 static/js/impala-all.js:13815 static/js/impala-min.js:8 static/js/zamboni/collections.js:235
+msgid "Add to Favorites"
+msgstr ""
+
+#: static/js/common-all.js:11582 static/js/common-min.js:7 static/js/impala-all.js:13818 static/js/impala-min.js:8 static/js/zamboni/collections.js:238
+msgid "Remove from Favorites"
+msgstr ""
+
+#: static/js/common-all.js:11647 static/js/common-min.js:7 static/js/impala-all.js:13883 static/js/impala-min.js:8 static/js/zamboni/collections.js:303
+msgid "Pending"
+msgstr ""
+
+#: static/js/common-all.js:11648 static/js/common-min.js:7 static/js/impala-all.js:13884 static/js/impala-min.js:8 static/js/zamboni/collections.js:304
+msgid "Add a comment"
+msgstr ""
+
+#: static/js/common-all.js:11648 static/js/common-min.js:7 static/js/impala-all.js:13884 static/js/impala-min.js:8 static/js/zamboni/collections.js:304
+msgid "Comment"
+msgstr ""
+
+#: static/js/common-all.js:11649 static/js/common-min.js:7 static/js/impala-all.js:13885 static/js/impala-min.js:8 static/js/zamboni/collections.js:305
+msgid "Remove this add-on from the collection"
+msgstr ""
+
+#: static/js/common-all.js:11649 static/js/common-all.js:11678 static/js/common-min.js:7 static/js/impala-all.js:13885 static/js/impala-all.js:13914 static/js/impala-min.js:8
+#: static/js/zamboni/collections.js:305 static/js/zamboni/collections.js:334
+msgid "Remove"
+msgstr ""
+
+#: static/js/common-all.js:11678 static/js/common-min.js:7 static/js/impala-all.js:13914 static/js/impala-min.js:8 static/js/zamboni/collections.js:334
+msgid "Remove this user as a contributor"
+msgstr ""
+
+#: static/js/common-all.js:11690 static/js/common-min.js:7 static/js/impala-all.js:13926 static/js/impala-min.js:8 static/js/zamboni/collections.js:346
+msgid "An email address is required."
+msgstr ""
+
+#: static/js/common-all.js:11708 static/js/common-min.js:7 static/js/impala-all.js:13944 static/js/impala-min.js:8 static/js/zamboni/collections.js:364
+msgid "You cannot add yourself as a contributor."
+msgstr ""
+
+#: static/js/common-all.js:11710 static/js/common-min.js:7 static/js/impala-all.js:13946 static/js/impala-min.js:8 static/js/zamboni/collections.js:366
+msgid "You have already added that user."
+msgstr ""
+
+#: static/js/common-all.js:11917 static/js/common-min.js:7 static/js/impala-all.js:14153 static/js/impala-min.js:8 static/js/zamboni/collections.js:573
+msgid "Add to favorites"
+msgstr ""
+
+#: static/js/common-all.js:11921 static/js/common-min.js:7 static/js/impala-all.js:14157 static/js/impala-min.js:8 static/js/zamboni/collections.js:577
+msgid "Remove from favorites"
+msgstr ""
+
+#: static/js/common-all.js:11939 static/js/common-min.js:7 static/js/impala-all.js:14175 static/js/impala-all.js:14233 static/js/impala-min.js:8 static/js/impala/collections.js:10
+#: static/js/zamboni/collections.js:595
+msgid "Follow this Collection"
+msgstr ""
+
+#: static/js/common-all.js:11948 static/js/common-min.js:7 static/js/impala-all.js:14184 static/js/impala-min.js:8 static/js/zamboni/collections.js:604
+msgid "Stop following"
+msgstr ""
+
+#: static/js/common-all.js:12096 static/js/common-min.js:7 static/js/zamboni/password-strength.js:20
+msgid "Password strength:"
+msgstr ""
+
+#: static/js/common-all.js:12102 static/js/common-min.js:7 static/js/zamboni/password-strength.js:26
+msgid "At least {0} character left."
+msgid_plural "At least {0} characters left."
+msgstr[0] ""
+msgstr[1] ""
+
+#: static/js/common-all.js:12286 static/js/common-min.js:7 static/js/impala-all.js:14632 static/js/impala-min.js:8 static/js/impala/suggestions.js:39
+msgid "Search themes for <b>{0}</b>"
+msgstr ""
+
+#: static/js/common-all.js:12288 static/js/common-min.js:7 static/js/impala-all.js:14634 static/js/impala-min.js:8 static/js/impala/suggestions.js:41
+msgid "Search apps for <b>{0}</b>"
+msgstr ""
+
+#: static/js/common-all.js:12290 static/js/common-min.js:7 static/js/impala-all.js:14636 static/js/impala-min.js:8 static/js/impala/suggestions.js:43
+msgid "Search add-ons for <b>{0}</b>"
+msgstr ""
+
+#: static/js/common-all.js:12521 static/js/common-min.js:7 static/js/impala-all.js:14867 static/js/impala-min.js:8 static/js/impala/site_suggestions.js:46
+msgid "Category"
+msgstr ""
+
+#. L10n: {0} is an app name.
+#: static/js/impala-all.js:11632 static/js/impala-min.js:7 static/js/impala/listing.js:11 static/js/zamboni/themes.js:13
+msgid "This theme is incompatible with your version of {0}"
+msgstr ""
+
+#: static/js/impala-all.js:12146 static/js/impala-all.js:14331 static/js/impala-min.js:7 static/js/impala-min.js:8 static/js/common/upload-image.js:97 static/js/impala/users.js:51
+#: static/js/zamboni/devhub-all.js:894 static/js/zamboni/devhub-min.js:1
+msgid "Images must be either PNG or JPG."
+msgstr ""
+
+#: static/js/impala-all.js:12150 static/js/impala-min.js:7 static/js/common/upload-image.js:101 static/js/zamboni/devhub-all.js:898 static/js/zamboni/devhub-min.js:1
+msgid "Videos must be in WebM."
+msgstr ""
+
+#: static/js/impala-all.js:12177 static/js/impala-min.js:7 static/js/common/upload-addon.js:41 static/js/common/upload-image.js:128 static/js/zamboni/devhub-all.js:272
+#: static/js/zamboni/devhub-all.js:925 static/js/zamboni/devhub-min.js:1
 msgid "There was a problem contacting the server."
 msgstr ""
 
-#: static/js/common/upload-addon.js:69
+#: static/js/impala-all.js:13298 static/js/impala-min.js:7 static/js/impala/persona_creation.js:60
+msgid "All Rights Reserved"
+msgstr ""
+
+#: static/js/impala-all.js:13302 static/js/impala-min.js:7 static/js/impala/persona_creation.js:64
+msgid "Creative Commons Attribution 3.0"
+msgstr ""
+
+#: static/js/impala-all.js:13307 static/js/impala-min.js:7 static/js/impala/persona_creation.js:69
+msgid "Creative Commons Attribution-NonCommercial 3.0"
+msgstr ""
+
+#: static/js/impala-all.js:13312 static/js/impala-min.js:7 static/js/impala/persona_creation.js:74
+msgid "Creative Commons Attribution-NonCommercial-NoDerivs 3.0"
+msgstr ""
+
+#: static/js/impala-all.js:13317 static/js/impala-min.js:7 static/js/impala/persona_creation.js:79
+msgid "Creative Commons Attribution-NonCommercial-Share Alike 3.0"
+msgstr ""
+
+#: static/js/impala-all.js:13322 static/js/impala-min.js:7 static/js/impala/persona_creation.js:84
+msgid "Creative Commons Attribution-NoDerivs 3.0"
+msgstr ""
+
+#: static/js/impala-all.js:13327 static/js/impala-min.js:7 static/js/impala/persona_creation.js:89
+msgid "Creative Commons Attribution-ShareAlike 3.0"
+msgstr ""
+
+#: static/js/impala-all.js:13530 static/js/impala-min.js:7 static/js/impala/persona_creation.js:292
+msgid "Your Theme's Name"
+msgstr ""
+
+#: static/js/impala-all.js:14242 static/js/impala-min.js:8 static/js/impala/collections.js:19
+msgid "Stop Following"
+msgstr ""
+
+#: static/js/impala-all.js:14243 static/js/impala-min.js:8 static/js/impala/collections.js:20
+msgid "Following"
+msgstr ""
+
+#: static/js/impala-all.js:14313 static/js/impala-min.js:8 static/js/impala/users.js:33
+msgid "use original"
+msgstr ""
+
+#: static/js/impala-all.js:14523 static/js/impala-min.js:8 static/js/impala/search.js:114
+msgid "Updating results&hellip;"
+msgstr ""
+
+#: static/js/common/upload-addon.js:69 static/js/zamboni/devhub-all.js:300 static/js/zamboni/devhub-min.js:1
 msgid "Select a file..."
 msgstr ""
 
-#: static/js/common/upload-addon.js:70
+#: static/js/common/upload-addon.js:70 static/js/zamboni/devhub-all.js:301 static/js/zamboni/devhub-min.js:1
 msgid "Your add-on should end with .xpi, .jar or .xml"
 msgstr ""
 
 #. L10n: {0} is the percent of the file that has been uploaded.
-#: static/js/common/upload-addon.js:104
+#: static/js/common/upload-addon.js:104 static/js/zamboni/devhub-all.js:335 static/js/zamboni/devhub-min.js:1
 #, python-format
 msgid "{0}% complete"
 msgstr ""
 
 #. L10n: "{bytes uploaded} of {total filesize}".
-#: static/js/common/upload-addon.js:107
+#: static/js/common/upload-addon.js:107 static/js/zamboni/devhub-all.js:338 static/js/zamboni/devhub-min.js:1
 msgid "{0} of {1}"
 msgstr ""
 
-#: static/js/common/upload-addon.js:140
+#: static/js/common/upload-addon.js:140 static/js/zamboni/devhub-all.js:371 static/js/zamboni/devhub-min.js:1
 msgid "Cancel"
 msgstr ""
 
-#: static/js/common/upload-addon.js:162
+#: static/js/common/upload-addon.js:162 static/js/zamboni/devhub-all.js:393 static/js/zamboni/devhub-min.js:1
 msgid "Uploading {0}"
 msgstr ""
 
-#: static/js/common/upload-addon.js:189
+#: static/js/common/upload-addon.js:189 static/js/zamboni/devhub-all.js:420 static/js/zamboni/devhub-min.js:1
 msgid "Error with {0}"
 msgstr ""
 
-#: static/js/common/upload-addon.js:194
+#: static/js/common/upload-addon.js:194 static/js/zamboni/devhub-all.js:425 static/js/zamboni/devhub-min.js:1
 msgid "Your add-on failed validation with {0} error."
 msgid_plural "Your add-on failed validation with {0} errors."
 msgstr[0] ""
 msgstr[1] ""
 
-#: static/js/common/upload-addon.js:208
+#: static/js/common/upload-addon.js:208 static/js/zamboni/devhub-all.js:439 static/js/zamboni/devhub-min.js:1
 msgid "&hellip;and {0} more"
 msgid_plural "&hellip;and {0} more"
 msgstr[0] ""
 msgstr[1] ""
 
-#: static/js/common/upload-addon.js:222 static/js/common/upload-addon.js:512
+#: static/js/common/upload-addon.js:222 static/js/common/upload-addon.js:497 static/js/zamboni/devhub-all.js:453 static/js/zamboni/devhub-all.js:743 static/js/zamboni/devhub-min.js:1
 msgid "See full validation report"
 msgstr ""
 
-#: static/js/common/upload-addon.js:234
+#: static/js/common/upload-addon.js:234 static/js/zamboni/devhub-all.js:465 static/js/zamboni/devhub-min.js:1
 msgid "Validating {0}"
 msgstr ""
 
 #. L10n: first argument is an HTTP status code
-#: static/js/common/upload-addon.js:273
+#: static/js/common/upload-addon.js:273 static/js/zamboni/devhub-all.js:504 static/js/zamboni/devhub-min.js:1
 msgid "Received an empty response from the server; status: {0}"
 msgstr ""
 
-#: static/js/common/upload-addon.js:373
+#: static/js/common/upload-addon.js:370 static/js/zamboni/devhub-all.js:604 static/js/zamboni/devhub-min.js:1
 msgid "Unexpected server error while validating."
 msgstr ""
 
-#: static/js/common/upload-addon.js:412
+#: static/js/common/upload-addon.js:409 static/js/zamboni/devhub-all.js:643 static/js/zamboni/devhub-min.js:1
 msgid "Finished validating {0}"
 msgstr ""
 
-#: static/js/common/upload-addon.js:418
+#: static/js/common/upload-addon.js:415 static/js/zamboni/devhub-all.js:649 static/js/zamboni/devhub-min.js:1
 msgid "Your add-on validation timed out, it will be manually reviewed."
 msgstr ""
 
-#: static/js/common/upload-addon.js:421
+#: static/js/common/upload-addon.js:418 static/js/zamboni/devhub-all.js:652 static/js/zamboni/devhub-min.js:1
 msgid "Your add-on was validated with no errors and {0} warning."
 msgid_plural "Your add-on was validated with no errors and {0} warnings."
 msgstr[0] ""
 msgstr[1] ""
 
-#: static/js/common/upload-addon.js:426
+#: static/js/common/upload-addon.js:423 static/js/zamboni/devhub-all.js:657 static/js/zamboni/devhub-min.js:1
 msgid "Your add-on was validated with no errors and {0} message."
 msgid_plural "Your add-on was validated with no errors and {0} messages."
 msgstr[0] ""
 msgstr[1] ""
 
-#: static/js/common/upload-addon.js:431
+#: static/js/common/upload-addon.js:428 static/js/zamboni/devhub-all.js:662 static/js/zamboni/devhub-min.js:1
 msgid "Your add-on was validated with no errors or warnings."
 msgstr ""
 
-#: static/js/common/upload-addon.js:446
+#: static/js/common/upload-addon.js:443 static/js/zamboni/devhub-all.js:677 static/js/zamboni/devhub-min.js:1
 msgid "Your submission will be automatically signed."
 msgstr ""
 
-#: static/js/common/upload-addon.js:465
+#: static/js/common/upload-addon.js:450 static/js/zamboni/devhub-all.js:696 static/js/zamboni/devhub-min.js:1
 msgid "Include detailed version notes (this can be done in the next step)."
 msgstr ""
 
-#: static/js/common/upload-addon.js:466
+#: static/js/common/upload-addon.js:451 static/js/zamboni/devhub-all.js:697 static/js/zamboni/devhub-min.js:1
 msgid "If your add-on requires an account to a website in order to be fully tested, include a test username and password in the Notes to Reviewer (this can be done in the next step)."
 msgstr ""
 
-#: static/js/common/upload-addon.js:467
+#: static/js/common/upload-addon.js:452 static/js/zamboni/devhub-all.js:698 static/js/zamboni/devhub-min.js:1
 msgid "If your add-on is intended for a limited audience you should choose Preliminary Review instead of Full Review."
 msgstr ""
 
-#: static/js/common/upload-addon.js:480
+#: static/js/common/upload-addon.js:465 static/js/zamboni/devhub-all.js:711 static/js/zamboni/devhub-min.js:1
 msgid "Add-on submission checklist"
 msgstr ""
 
-#: static/js/common/upload-addon.js:481
+#: static/js/common/upload-addon.js:466 static/js/zamboni/devhub-all.js:712 static/js/zamboni/devhub-min.js:1
 msgid "Please verify the following points before finalizing your submission. This will minimize delays or misunderstanding during the review process:"
 msgstr ""
 
-#: static/js/common/upload-addon.js:483
+#: static/js/common/upload-addon.js:468 static/js/zamboni/devhub-all.js:714 static/js/zamboni/devhub-min.js:1
 msgid ""
 "Compiled binaries, as well as minified or obfuscated scripts (excluding known libraries) need to have their sources submitted separately for review. Make sure that you use the source code upload "
 "field to avoid having your submission rejected."
 msgstr ""
 
-#: static/js/common/upload-addon.js:501
+#: static/js/common/upload-addon.js:486 static/js/zamboni/devhub-all.js:732 static/js/zamboni/devhub-min.js:1
 msgid "The validation process found these issues that can lead to rejections:"
 msgstr ""
 
-#: static/js/common/upload-addon.js:518
+#: static/js/common/upload-addon.js:503 static/js/zamboni/devhub-all.js:749 static/js/zamboni/devhub-min.js:1
 msgid "If you are unfamiliar with the add-ons review process, you can read about it here."
 msgstr ""
 
-#: static/js/common/upload-addon.js:555
+#: static/js/common/upload-addon.js:540 static/js/zamboni/devhub-all.js:786 static/js/zamboni/devhub-min.js:1
 msgid "Sorry, no supported platform has been found."
 msgstr ""
 
-#: static/js/common/upload-base.js:57
+#: static/js/common/upload-base.js:57 static/js/zamboni/devhub-all.js:187 static/js/zamboni/devhub-min.js:1
 msgid "The filetype you uploaded isn't recognized."
 msgstr ""
 
-#: static/js/common/upload-base.js:79
+#: static/js/common/upload-base.js:79 static/js/zamboni/devhub-all.js:209 static/js/zamboni/devhub-min.js:1
 msgid "You cancelled the upload."
 msgstr ""
 
-#: static/js/common/upload-image.js:97 static/js/impala/users.js:51
-msgid "Images must be either PNG or JPG."
-msgstr ""
-
-#: static/js/common/upload-image.js:101
-msgid "Videos must be in WebM."
-msgstr ""
-
-#: static/js/impala/collections.js:10 static/js/zamboni/collections.js:595
-msgid "Follow this Collection"
-msgstr ""
-
-#: static/js/impala/collections.js:19
-msgid "Stop Following"
-msgstr ""
-
-#: static/js/impala/collections.js:20
-msgid "Following"
-msgstr ""
-
-#. L10n: {0} is an app name.
-#: static/js/impala/listing.js:11 static/js/zamboni/themes.js:13
-msgid "This theme is incompatible with your version of {0}"
-msgstr ""
-
-#: static/js/impala/persona_creation.js:60
-msgid "All Rights Reserved"
-msgstr ""
-
-#: static/js/impala/persona_creation.js:64
-msgid "Creative Commons Attribution 3.0"
-msgstr ""
-
-#: static/js/impala/persona_creation.js:69
-msgid "Creative Commons Attribution-NonCommercial 3.0"
-msgstr ""
-
-#: static/js/impala/persona_creation.js:74
-msgid "Creative Commons Attribution-NonCommercial-NoDerivs 3.0"
-msgstr ""
-
-#: static/js/impala/persona_creation.js:79
-msgid "Creative Commons Attribution-NonCommercial-Share Alike 3.0"
-msgstr ""
-
-#: static/js/impala/persona_creation.js:84
-msgid "Creative Commons Attribution-NoDerivs 3.0"
-msgstr ""
-
-#: static/js/impala/persona_creation.js:89
-msgid "Creative Commons Attribution-ShareAlike 3.0"
-msgstr ""
-
-#: static/js/impala/persona_creation.js:292
-msgid "Your Theme's Name"
-msgstr ""
-
-#: static/js/impala/reviews.js:23 static/js/zamboni/reviews.js:18
-msgid "Flagged for review"
-msgstr ""
-
-#: static/js/impala/reviews.js:40 static/js/zamboni/reviews.js:34
-msgid "Your input is required"
-msgstr ""
-
-#: static/js/impala/reviews.js:152 static/js/zamboni/reviews.js:103
-msgid "Marked for deletion"
-msgstr ""
-
-#: static/js/impala/search.js:114
-msgid "Updating results&hellip;"
-msgstr ""
-
-#: static/js/impala/site_suggestions.js:46
-msgid "Category"
-msgstr ""
-
-#: static/js/impala/suggestions.js:39
-msgid "Search themes for <b>{0}</b>"
-msgstr ""
-
-#: static/js/impala/suggestions.js:41
-msgid "Search apps for <b>{0}</b>"
-msgstr ""
-
-#: static/js/impala/suggestions.js:43
-msgid "Search add-ons for <b>{0}</b>"
-msgstr ""
-
-#: static/js/impala/users.js:33
-msgid "use original"
-msgstr ""
-
-#: static/js/impala/stats/chart.js:267
+#: static/js/impala/stats/chart.js:267 static/js/zamboni/stats-all.js:16898 static/js/zamboni/stats-min.js:5
 msgid "Week of {0}"
 msgstr ""
 
-#: static/js/impala/stats/chart.js:269
+#: static/js/impala/stats/chart.js:269 static/js/zamboni/stats-all.js:16900 static/js/zamboni/stats-min.js:5
 msgid " downloads"
 msgstr ""
 
-#: static/js/impala/stats/chart.js:270
+#: static/js/impala/stats/chart.js:270 static/js/zamboni/stats-all.js:16901 static/js/zamboni/stats-min.js:5
 msgid "{0} users"
 msgstr ""
 
-#: static/js/impala/stats/chart.js:271
+#: static/js/impala/stats/chart.js:271 static/js/zamboni/stats-all.js:16902 static/js/zamboni/stats-min.js:5
 msgid "{0} add-ons"
 msgstr ""
 
-#: static/js/impala/stats/chart.js:272
+#: static/js/impala/stats/chart.js:272 static/js/zamboni/stats-all.js:16903 static/js/zamboni/stats-min.js:5
 msgid "{0} collections"
 msgstr ""
 
-#: static/js/impala/stats/chart.js:273
+#: static/js/impala/stats/chart.js:273 static/js/zamboni/stats-all.js:16904 static/js/zamboni/stats-min.js:5
 msgid "{0} reviews"
 msgstr ""
 
-#: static/js/impala/stats/chart.js:275
+#: static/js/impala/stats/chart.js:275 static/js/zamboni/stats-all.js:16906 static/js/zamboni/stats-min.js:5
 msgid "{0} sales"
 msgstr ""
 
-#: static/js/impala/stats/chart.js:276
+#: static/js/impala/stats/chart.js:276 static/js/zamboni/stats-all.js:16907 static/js/zamboni/stats-min.js:5
 msgid "{0} refunds"
 msgstr ""
 
-#: static/js/impala/stats/chart.js:277
+#: static/js/impala/stats/chart.js:277 static/js/zamboni/stats-all.js:16908 static/js/zamboni/stats-min.js:5
 msgid "{0} installs"
 msgstr ""
 
-#: static/js/impala/stats/chart.js:369 static/js/impala/stats/csv_keys.js:3 static/js/impala/stats/csv_keys.js:109
+#: static/js/impala/stats/chart.js:369 static/js/impala/stats/csv_keys.js:3 static/js/impala/stats/csv_keys.js:109 static/js/zamboni/stats-all.js:15284 static/js/zamboni/stats-all.js:15390
+#: static/js/zamboni/stats-all.js:17000 static/js/zamboni/stats-min.js:4 static/js/zamboni/stats-min.js:5
 msgid "Downloads"
 msgstr ""
 
-#: static/js/impala/stats/chart.js:379 static/js/impala/stats/csv_keys.js:6 static/js/impala/stats/csv_keys.js:110
+#: static/js/impala/stats/chart.js:379 static/js/impala/stats/csv_keys.js:6 static/js/impala/stats/csv_keys.js:110 static/js/zamboni/stats-all.js:15287 static/js/zamboni/stats-all.js:15391
+#: static/js/zamboni/stats-all.js:17010 static/js/zamboni/stats-min.js:4 static/js/zamboni/stats-min.js:5
 msgid "Daily Users"
 msgstr ""
 
-#: static/js/impala/stats/chart.js:410
+#: static/js/impala/stats/chart.js:410 static/js/zamboni/stats-all.js:17041 static/js/zamboni/stats-min.js:5
 msgid "Amount, in USD"
 msgstr ""
 
-#: static/js/impala/stats/chart.js:421 static/js/impala/stats/csv_keys.js:104
+#: static/js/impala/stats/chart.js:421 static/js/impala/stats/csv_keys.js:104 static/js/zamboni/stats-all.js:15385 static/js/zamboni/stats-all.js:17052 static/js/zamboni/stats-min.js:5
 msgid "Number of Contributions"
 msgstr ""
 
-#: static/js/impala/stats/chart.js:447
+#: static/js/impala/stats/chart.js:447 static/js/zamboni/stats-all.js:17078 static/js/zamboni/stats-min.js:5
 msgid "More Info..."
 msgstr ""
 
 #. L10n: {0} is an ISO-formatted date.
-#: static/js/impala/stats/chart.js:451
+#: static/js/impala/stats/chart.js:451 static/js/zamboni/stats-all.js:17082 static/js/zamboni/stats-min.js:5
 msgid "Details for {0}"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:9
+#: static/js/impala/stats/csv_keys.js:9 static/js/zamboni/stats-all.js:15290 static/js/zamboni/stats-min.js:4
 msgid "Collections Created"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:12
+#: static/js/impala/stats/csv_keys.js:12 static/js/zamboni/stats-all.js:15293 static/js/zamboni/stats-min.js:4
 msgid "Add-ons in Use"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:15
+#: static/js/impala/stats/csv_keys.js:15 static/js/zamboni/stats-all.js:15296 static/js/zamboni/stats-min.js:4
 msgid "Add-ons Created"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:18
+#: static/js/impala/stats/csv_keys.js:18 static/js/zamboni/stats-all.js:15299 static/js/zamboni/stats-min.js:4
 msgid "Add-ons Downloaded"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:21
+#: static/js/impala/stats/csv_keys.js:21 static/js/zamboni/stats-all.js:15302 static/js/zamboni/stats-min.js:4
 msgid "Add-ons Updated"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:24
+#: static/js/impala/stats/csv_keys.js:24 static/js/zamboni/stats-all.js:15305 static/js/zamboni/stats-min.js:4
 msgid "Reviews Written"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:27
+#: static/js/impala/stats/csv_keys.js:27 static/js/zamboni/stats-all.js:15308 static/js/zamboni/stats-min.js:4
 msgid "User Signups"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:30
+#: static/js/impala/stats/csv_keys.js:30 static/js/zamboni/stats-all.js:15311 static/js/zamboni/stats-min.js:4
 msgid "Subscribers"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:33
+#: static/js/impala/stats/csv_keys.js:33 static/js/zamboni/stats-all.js:15314 static/js/zamboni/stats-min.js:4
 msgid "Ratings"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:36 static/js/impala/stats/csv_keys.js:114
+#: static/js/impala/stats/csv_keys.js:36 static/js/impala/stats/csv_keys.js:114 static/js/zamboni/stats-all.js:15317 static/js/zamboni/stats-all.js:15395 static/js/zamboni/stats-min.js:4
+#: static/js/zamboni/stats-min.js:5
 msgid "Sales"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:39 static/js/impala/stats/csv_keys.js:113
+#: static/js/impala/stats/csv_keys.js:39 static/js/impala/stats/csv_keys.js:113 static/js/zamboni/stats-all.js:15320 static/js/zamboni/stats-all.js:15394 static/js/zamboni/stats-min.js:4
+#: static/js/zamboni/stats-min.js:5
 msgid "Installs"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:42
+#: static/js/impala/stats/csv_keys.js:42 static/js/zamboni/stats-all.js:15323 static/js/zamboni/stats-min.js:4
 msgid "Unknown"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:43
+#: static/js/impala/stats/csv_keys.js:43 static/js/zamboni/stats-all.js:15324 static/js/zamboni/stats-min.js:4
 msgid "Add-ons Manager"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:44
+#: static/js/impala/stats/csv_keys.js:44 static/js/zamboni/stats-all.js:15325 static/js/zamboni/stats-min.js:4
 msgid "Add-ons Manager Promo"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:45
+#: static/js/impala/stats/csv_keys.js:45 static/js/zamboni/stats-all.js:15326 static/js/zamboni/stats-min.js:4
 msgid "Add-ons Manager Featured"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:46
+#: static/js/impala/stats/csv_keys.js:46 static/js/zamboni/stats-all.js:15327 static/js/zamboni/stats-min.js:4
 msgid "Add-ons Manager Learn More"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:47
+#: static/js/impala/stats/csv_keys.js:47 static/js/zamboni/stats-all.js:15328 static/js/zamboni/stats-min.js:4
 msgid "Search Suggestions"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:48
+#: static/js/impala/stats/csv_keys.js:48 static/js/zamboni/stats-all.js:15329 static/js/zamboni/stats-min.js:4
 msgid "Search Results"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:49 static/js/impala/stats/csv_keys.js:50 static/js/impala/stats/csv_keys.js:51
+#: static/js/impala/stats/csv_keys.js:49 static/js/impala/stats/csv_keys.js:50 static/js/impala/stats/csv_keys.js:51 static/js/zamboni/stats-all.js:15330 static/js/zamboni/stats-all.js:15331
+#: static/js/zamboni/stats-all.js:15332 static/js/zamboni/stats-min.js:4
 msgid "Homepage Promo"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:52 static/js/impala/stats/csv_keys.js:53
+#: static/js/impala/stats/csv_keys.js:52 static/js/impala/stats/csv_keys.js:53 static/js/zamboni/stats-all.js:15333 static/js/zamboni/stats-all.js:15334 static/js/zamboni/stats-min.js:4
 msgid "Homepage Featured"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:54 static/js/impala/stats/csv_keys.js:55
+#: static/js/impala/stats/csv_keys.js:54 static/js/impala/stats/csv_keys.js:55 static/js/zamboni/stats-all.js:15335 static/js/zamboni/stats-all.js:15336 static/js/zamboni/stats-min.js:4
 msgid "Homepage Up and Coming"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:56
+#: static/js/impala/stats/csv_keys.js:56 static/js/zamboni/stats-all.js:15337 static/js/zamboni/stats-min.js:4
 msgid "Homepage Most Popular"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:57 static/js/impala/stats/csv_keys.js:59
+#: static/js/impala/stats/csv_keys.js:57 static/js/impala/stats/csv_keys.js:59 static/js/zamboni/stats-all.js:15338 static/js/zamboni/stats-all.js:15340 static/js/zamboni/stats-min.js:4
 msgid "Detail Page"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:58 static/js/impala/stats/csv_keys.js:60
+#: static/js/impala/stats/csv_keys.js:58 static/js/impala/stats/csv_keys.js:60 static/js/zamboni/stats-all.js:15339 static/js/zamboni/stats-all.js:15341 static/js/zamboni/stats-min.js:4
 msgid "Detail Page (bottom)"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:61
+#: static/js/impala/stats/csv_keys.js:61 static/js/zamboni/stats-all.js:15342 static/js/zamboni/stats-min.js:4
 msgid "Detail Page (Development Channel)"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:62 static/js/impala/stats/csv_keys.js:63 static/js/impala/stats/csv_keys.js:64
+#: static/js/impala/stats/csv_keys.js:62 static/js/impala/stats/csv_keys.js:63 static/js/impala/stats/csv_keys.js:64 static/js/zamboni/stats-all.js:15343 static/js/zamboni/stats-all.js:15344
+#: static/js/zamboni/stats-all.js:15345 static/js/zamboni/stats-min.js:4
 msgid "Often Used With"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:65 static/js/impala/stats/csv_keys.js:66
+#: static/js/impala/stats/csv_keys.js:65 static/js/impala/stats/csv_keys.js:66 static/js/zamboni/stats-all.js:15346 static/js/zamboni/stats-all.js:15347 static/js/zamboni/stats-min.js:4
 msgid "Others By Author"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:67 static/js/impala/stats/csv_keys.js:68
+#: static/js/impala/stats/csv_keys.js:67 static/js/impala/stats/csv_keys.js:68 static/js/zamboni/stats-all.js:15348 static/js/zamboni/stats-all.js:15349 static/js/zamboni/stats-min.js:4
 msgid "Dependencies"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:69 static/js/impala/stats/csv_keys.js:70
+#: static/js/impala/stats/csv_keys.js:69 static/js/impala/stats/csv_keys.js:70 static/js/zamboni/stats-all.js:15350 static/js/zamboni/stats-all.js:15351 static/js/zamboni/stats-min.js:4
 msgid "Upsell"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:71
+#: static/js/impala/stats/csv_keys.js:71 static/js/zamboni/stats-all.js:15352 static/js/zamboni/stats-min.js:4
 msgid "Meet the Developer"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:72
+#: static/js/impala/stats/csv_keys.js:72 static/js/zamboni/stats-all.js:15353 static/js/zamboni/stats-min.js:4
 msgid "User Profile"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:73
+#: static/js/impala/stats/csv_keys.js:73 static/js/zamboni/stats-all.js:15354 static/js/zamboni/stats-min.js:4
 msgid "Version History"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:75
+#: static/js/impala/stats/csv_keys.js:75 static/js/zamboni/stats-all.js:15356 static/js/zamboni/stats-min.js:4
 msgid "Sharing"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:76
+#: static/js/impala/stats/csv_keys.js:76 static/js/zamboni/stats-all.js:15357 static/js/zamboni/stats-min.js:4
 msgid "Category Pages"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:77
+#: static/js/impala/stats/csv_keys.js:77 static/js/zamboni/stats-all.js:15358 static/js/zamboni/stats-min.js:4
 msgid "Collections"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:78 static/js/impala/stats/csv_keys.js:79
+#: static/js/impala/stats/csv_keys.js:78 static/js/impala/stats/csv_keys.js:79 static/js/zamboni/stats-all.js:15359 static/js/zamboni/stats-all.js:15360 static/js/zamboni/stats-min.js:4
 msgid "Category Landing Featured Carousel"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:80 static/js/impala/stats/csv_keys.js:81
+#: static/js/impala/stats/csv_keys.js:80 static/js/impala/stats/csv_keys.js:81 static/js/zamboni/stats-all.js:15361 static/js/zamboni/stats-all.js:15362 static/js/zamboni/stats-min.js:4
 msgid "Category Landing Top Rated"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:82 static/js/impala/stats/csv_keys.js:83
+#: static/js/impala/stats/csv_keys.js:82 static/js/impala/stats/csv_keys.js:83 static/js/zamboni/stats-all.js:15363 static/js/zamboni/stats-all.js:15364 static/js/zamboni/stats-min.js:5
 msgid "Category Landing Most Popular"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:84 static/js/impala/stats/csv_keys.js:85
+#: static/js/impala/stats/csv_keys.js:84 static/js/impala/stats/csv_keys.js:85 static/js/zamboni/stats-all.js:15365 static/js/zamboni/stats-all.js:15366 static/js/zamboni/stats-min.js:5
 msgid "Category Landing Recently Added"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:86 static/js/impala/stats/csv_keys.js:87
+#: static/js/impala/stats/csv_keys.js:86 static/js/impala/stats/csv_keys.js:87 static/js/zamboni/stats-all.js:15367 static/js/zamboni/stats-all.js:15368 static/js/zamboni/stats-min.js:5
 msgid "Browse Listing Featured Sort"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:88 static/js/impala/stats/csv_keys.js:89
+#: static/js/impala/stats/csv_keys.js:88 static/js/impala/stats/csv_keys.js:89 static/js/zamboni/stats-all.js:15369 static/js/zamboni/stats-all.js:15370 static/js/zamboni/stats-min.js:5
 msgid "Browse Listing Users Sort"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:90 static/js/impala/stats/csv_keys.js:91
+#: static/js/impala/stats/csv_keys.js:90 static/js/impala/stats/csv_keys.js:91 static/js/zamboni/stats-all.js:15371 static/js/zamboni/stats-all.js:15372 static/js/zamboni/stats-min.js:5
 msgid "Browse Listing Rating Sort"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:92 static/js/impala/stats/csv_keys.js:93
+#: static/js/impala/stats/csv_keys.js:92 static/js/impala/stats/csv_keys.js:93 static/js/zamboni/stats-all.js:15373 static/js/zamboni/stats-all.js:15374 static/js/zamboni/stats-min.js:5
 msgid "Browse Listing Created Sort"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:94 static/js/impala/stats/csv_keys.js:95
+#: static/js/impala/stats/csv_keys.js:94 static/js/impala/stats/csv_keys.js:95 static/js/zamboni/stats-all.js:15375 static/js/zamboni/stats-all.js:15376 static/js/zamboni/stats-min.js:5
 msgid "Browse Listing Name Sort"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:96 static/js/impala/stats/csv_keys.js:97
+#: static/js/impala/stats/csv_keys.js:96 static/js/impala/stats/csv_keys.js:97 static/js/zamboni/stats-all.js:15377 static/js/zamboni/stats-all.js:15378 static/js/zamboni/stats-min.js:5
 msgid "Browse Listing Popular Sort"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:98 static/js/impala/stats/csv_keys.js:99
+#: static/js/impala/stats/csv_keys.js:98 static/js/impala/stats/csv_keys.js:99 static/js/zamboni/stats-all.js:15379 static/js/zamboni/stats-all.js:15380 static/js/zamboni/stats-min.js:5
 msgid "Browse Listing Updated Sort"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:100 static/js/impala/stats/csv_keys.js:101
+#: static/js/impala/stats/csv_keys.js:100 static/js/impala/stats/csv_keys.js:101 static/js/zamboni/stats-all.js:15381 static/js/zamboni/stats-all.js:15382 static/js/zamboni/stats-min.js:5
 msgid "Browse Listing Up and Coming Sort"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:105
+#: static/js/impala/stats/csv_keys.js:105 static/js/zamboni/stats-all.js:15386 static/js/zamboni/stats-min.js:5
 msgid "Total Amount Contributed"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:106
+#: static/js/impala/stats/csv_keys.js:106 static/js/zamboni/stats-all.js:15387 static/js/zamboni/stats-min.js:5
 msgid "Average Contribution"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:115
+#: static/js/impala/stats/csv_keys.js:115 static/js/zamboni/stats-all.js:15396 static/js/zamboni/stats-min.js:5
 msgid "Usage"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:118
+#: static/js/impala/stats/csv_keys.js:118 static/js/zamboni/stats-all.js:15399 static/js/zamboni/stats-min.js:5
 msgid "Firefox"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:119
+#: static/js/impala/stats/csv_keys.js:119 static/js/zamboni/stats-all.js:15400 static/js/zamboni/stats-min.js:5
 msgid "Mozilla"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:120
+#: static/js/impala/stats/csv_keys.js:120 static/js/zamboni/stats-all.js:15401 static/js/zamboni/stats-min.js:5
 msgid "Thunderbird"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:121
+#: static/js/impala/stats/csv_keys.js:121 static/js/zamboni/stats-all.js:15402 static/js/zamboni/stats-min.js:5
 msgid "Sunbird"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:122
+#: static/js/impala/stats/csv_keys.js:122 static/js/zamboni/stats-all.js:15403 static/js/zamboni/stats-min.js:5
 msgid "SeaMonkey"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:123
+#: static/js/impala/stats/csv_keys.js:123 static/js/zamboni/stats-all.js:15404 static/js/zamboni/stats-min.js:5
 msgid "Fennec"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:124
+#: static/js/impala/stats/csv_keys.js:124 static/js/zamboni/stats-all.js:15405 static/js/zamboni/stats-min.js:5
 msgid "Android"
 msgstr ""
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:129
+#: static/js/impala/stats/csv_keys.js:129 static/js/zamboni/stats-all.js:15410 static/js/zamboni/stats-min.js:5
 msgid "Downloads and Daily Users, last {0} days"
 msgstr ""
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:131
+#: static/js/impala/stats/csv_keys.js:131 static/js/zamboni/stats-all.js:15412 static/js/zamboni/stats-min.js:5
 msgid "Downloads and Daily Users from {0} to {1}"
 msgstr ""
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:135
+#: static/js/impala/stats/csv_keys.js:135 static/js/zamboni/stats-all.js:15416 static/js/zamboni/stats-min.js:5
 msgid "Installs and Daily Users, last {0} days"
 msgstr ""
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:137
+#: static/js/impala/stats/csv_keys.js:137 static/js/zamboni/stats-all.js:15418 static/js/zamboni/stats-min.js:5
 msgid "Installs and Daily Users from {0} to {1}"
 msgstr ""
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:141
+#: static/js/impala/stats/csv_keys.js:141 static/js/zamboni/stats-all.js:15422 static/js/zamboni/stats-min.js:5
 msgid "Downloads, last {0} days"
 msgstr ""
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:143
+#: static/js/impala/stats/csv_keys.js:143 static/js/zamboni/stats-all.js:15424 static/js/zamboni/stats-min.js:5
 msgid "Downloads from {0} to {1}"
 msgstr ""
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:147
+#: static/js/impala/stats/csv_keys.js:147 static/js/zamboni/stats-all.js:15428 static/js/zamboni/stats-min.js:5
 msgid "Daily Users, last {0} days"
 msgstr ""
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:149
+#: static/js/impala/stats/csv_keys.js:149 static/js/zamboni/stats-all.js:15430 static/js/zamboni/stats-min.js:5
 msgid "Daily Users from {0} to {1}"
 msgstr ""
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:153
+#: static/js/impala/stats/csv_keys.js:153 static/js/zamboni/stats-all.js:15434 static/js/zamboni/stats-min.js:5
 msgid "Applications, last {0} days"
 msgstr ""
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:155
+#: static/js/impala/stats/csv_keys.js:155 static/js/zamboni/stats-all.js:15436 static/js/zamboni/stats-min.js:5
 msgid "Applications from {0} to {1}"
 msgstr ""
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:159
+#: static/js/impala/stats/csv_keys.js:159 static/js/zamboni/stats-all.js:15440 static/js/zamboni/stats-min.js:5
 msgid "Platforms, last {0} days"
 msgstr ""
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:161
+#: static/js/impala/stats/csv_keys.js:161 static/js/zamboni/stats-all.js:15442 static/js/zamboni/stats-min.js:5
 msgid "Platforms from {0} to {1}"
 msgstr ""
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:165
+#: static/js/impala/stats/csv_keys.js:165 static/js/zamboni/stats-all.js:15446 static/js/zamboni/stats-min.js:5
 msgid "Languages, last {0} days"
 msgstr ""
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:167
+#: static/js/impala/stats/csv_keys.js:167 static/js/zamboni/stats-all.js:15448 static/js/zamboni/stats-min.js:5
 msgid "Languages from {0} to {1}"
 msgstr ""
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:171
+#: static/js/impala/stats/csv_keys.js:171 static/js/zamboni/stats-all.js:15452 static/js/zamboni/stats-min.js:5
 msgid "Add-on Versions, last {0} days"
 msgstr ""
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:173
+#: static/js/impala/stats/csv_keys.js:173 static/js/zamboni/stats-all.js:15454 static/js/zamboni/stats-min.js:5
 msgid "Add-on Versions from {0} to {1}"
 msgstr ""
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:177
+#: static/js/impala/stats/csv_keys.js:177 static/js/zamboni/stats-all.js:15458 static/js/zamboni/stats-min.js:5
 msgid "Add-on Status, last {0} days"
 msgstr ""
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:179
+#: static/js/impala/stats/csv_keys.js:179 static/js/zamboni/stats-all.js:15460 static/js/zamboni/stats-min.js:5
 msgid "Add-on Status from {0} to {1}"
 msgstr ""
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:183
+#: static/js/impala/stats/csv_keys.js:183 static/js/zamboni/stats-all.js:15464 static/js/zamboni/stats-min.js:5
 msgid "Download Sources, last {0} days"
 msgstr ""
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:185
+#: static/js/impala/stats/csv_keys.js:185 static/js/zamboni/stats-all.js:15466 static/js/zamboni/stats-min.js:5
 msgid "Download Sources from {0} to {1}"
 msgstr ""
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:189
+#: static/js/impala/stats/csv_keys.js:189 static/js/zamboni/stats-all.js:15470 static/js/zamboni/stats-min.js:5
 msgid "Contributions, last {0} days"
 msgstr ""
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:191
+#: static/js/impala/stats/csv_keys.js:191 static/js/zamboni/stats-all.js:15472 static/js/zamboni/stats-min.js:5
 msgid "Contributions from {0} to {1}"
 msgstr ""
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:195
+#: static/js/impala/stats/csv_keys.js:195 static/js/zamboni/stats-all.js:15476 static/js/zamboni/stats-min.js:5
 msgid "Site Metrics, last {0} days"
 msgstr ""
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:197
+#: static/js/impala/stats/csv_keys.js:197 static/js/zamboni/stats-all.js:15478 static/js/zamboni/stats-min.js:5
 msgid "Site Metrics from {0} to {1}"
 msgstr ""
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:201
+#: static/js/impala/stats/csv_keys.js:201 static/js/zamboni/stats-all.js:15482 static/js/zamboni/stats-min.js:5
 msgid "Add-ons in Use, last {0} days"
 msgstr ""
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:203
+#: static/js/impala/stats/csv_keys.js:203 static/js/zamboni/stats-all.js:15484 static/js/zamboni/stats-min.js:5
 msgid "Add-ons in Use from {0} to {1}"
 msgstr ""
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:207
+#: static/js/impala/stats/csv_keys.js:207 static/js/zamboni/stats-all.js:15488 static/js/zamboni/stats-min.js:5
 msgid "Add-ons Downloaded, last {0} days"
 msgstr ""
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:209
+#: static/js/impala/stats/csv_keys.js:209 static/js/zamboni/stats-all.js:15490 static/js/zamboni/stats-min.js:5
 msgid "Add-ons Downloaded from {0} to {1}"
 msgstr ""
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:213
+#: static/js/impala/stats/csv_keys.js:213 static/js/zamboni/stats-all.js:15494 static/js/zamboni/stats-min.js:5
 msgid "Add-ons Created, last {0} days"
 msgstr ""
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:215
+#: static/js/impala/stats/csv_keys.js:215 static/js/zamboni/stats-all.js:15496 static/js/zamboni/stats-min.js:5
 msgid "Add-ons Created from {0} to {1}"
 msgstr ""
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:219
+#: static/js/impala/stats/csv_keys.js:219 static/js/zamboni/stats-all.js:15500 static/js/zamboni/stats-min.js:5
 msgid "Add-ons Updated, last {0} days"
 msgstr ""
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:221
+#: static/js/impala/stats/csv_keys.js:221 static/js/zamboni/stats-all.js:15502 static/js/zamboni/stats-min.js:5
 msgid "Add-ons Updated from {0} to {1}"
 msgstr ""
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:225
+#: static/js/impala/stats/csv_keys.js:225 static/js/zamboni/stats-all.js:15506 static/js/zamboni/stats-min.js:5
 msgid "Reviews Written, last {0} days"
 msgstr ""
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:227
+#: static/js/impala/stats/csv_keys.js:227 static/js/zamboni/stats-all.js:15508 static/js/zamboni/stats-min.js:5
 msgid "Reviews Written from {0} to {1}"
 msgstr ""
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:231
+#: static/js/impala/stats/csv_keys.js:231 static/js/zamboni/stats-all.js:15512 static/js/zamboni/stats-min.js:5
 msgid "User Signups, last {0} days"
 msgstr ""
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:233
+#: static/js/impala/stats/csv_keys.js:233 static/js/zamboni/stats-all.js:15514 static/js/zamboni/stats-min.js:5
 msgid "User Signups from {0} to {1}"
 msgstr ""
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:237
+#: static/js/impala/stats/csv_keys.js:237 static/js/zamboni/stats-all.js:15518 static/js/zamboni/stats-min.js:5
 msgid "Collections Created, last {0} days"
 msgstr ""
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:239
+#: static/js/impala/stats/csv_keys.js:239 static/js/zamboni/stats-all.js:15520 static/js/zamboni/stats-min.js:5
 msgid "Collections Created from {0} to {1}"
 msgstr ""
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:243
+#: static/js/impala/stats/csv_keys.js:243 static/js/zamboni/stats-all.js:15524 static/js/zamboni/stats-min.js:5
 msgid "Subscribers, last {0} days"
 msgstr ""
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:245
+#: static/js/impala/stats/csv_keys.js:245 static/js/zamboni/stats-all.js:15526 static/js/zamboni/stats-min.js:5
 msgid "Subscribers from {0} to {1}"
 msgstr ""
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:249
+#: static/js/impala/stats/csv_keys.js:249 static/js/zamboni/stats-all.js:15530 static/js/zamboni/stats-min.js:5
 msgid "Ratings, last {0} days"
 msgstr ""
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:251
+#: static/js/impala/stats/csv_keys.js:251 static/js/zamboni/stats-all.js:15532 static/js/zamboni/stats-min.js:5
 msgid "Ratings from {0} to {1}"
 msgstr ""
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:255
+#: static/js/impala/stats/csv_keys.js:255 static/js/zamboni/stats-all.js:15536 static/js/zamboni/stats-min.js:5
 msgid "Sales, last {0} days"
 msgstr ""
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:257
+#: static/js/impala/stats/csv_keys.js:257 static/js/zamboni/stats-all.js:15538 static/js/zamboni/stats-min.js:5
 msgid "Sales from {0} to {1}"
 msgstr ""
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:261
+#: static/js/impala/stats/csv_keys.js:261 static/js/zamboni/stats-all.js:15542 static/js/zamboni/stats-min.js:5
 msgid "Installs, last {0} days"
 msgstr ""
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:263
+#: static/js/impala/stats/csv_keys.js:263 static/js/zamboni/stats-all.js:15544 static/js/zamboni/stats-min.js:5
 msgid "Installs from {0} to {1}"
 msgstr ""
 
 #. L10n: {0} and {1} are integers.
-#: static/js/impala/stats/csv_keys.js:269
+#: static/js/impala/stats/csv_keys.js:269 static/js/zamboni/stats-all.js:15550 static/js/zamboni/stats-min.js:5
 msgid "<b>{0}</b> in last {1} days"
 msgstr ""
 
 #. L10n: {0} is an integer and {1} and {2} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:271 static/js/impala/stats/csv_keys.js:277
+#: static/js/impala/stats/csv_keys.js:271 static/js/impala/stats/csv_keys.js:277 static/js/zamboni/stats-all.js:15552 static/js/zamboni/stats-all.js:15558 static/js/zamboni/stats-min.js:5
 msgid "<b>{0}</b> from {1} to {2}"
 msgstr ""
 
 #. L10n: {0} and {1} are integers.
-#: static/js/impala/stats/csv_keys.js:275
+#: static/js/impala/stats/csv_keys.js:275 static/js/zamboni/stats-all.js:15556 static/js/zamboni/stats-min.js:5
 msgid "<b>{0}</b> average in last {1} days"
 msgstr ""
 
-#: static/js/impala/stats/overview.js:19
+#: static/js/impala/stats/overview.js:19 static/js/zamboni/stats-all.js:16469 static/js/zamboni/stats-min.js:5
 msgid "No data available."
 msgstr ""
 
-#: static/js/impala/stats/table.js:74
+#: static/js/impala/stats/table.js:74 static/js/zamboni/stats-all.js:17209 static/js/zamboni/stats-min.js:5
 msgid "Date"
 msgstr ""
 
-#: static/js/impala/stats/topchart.js:96
+#: static/js/impala/stats/topchart.js:96 static/js/zamboni/stats-all.js:16600 static/js/zamboni/stats-min.js:5
 msgid "Other"
 msgstr ""
 
-#: static/js/zamboni/admin_validation.js:24 static/js/zamboni/devhub.js:1229 static/js/zamboni/editors.js:295
+#: static/js/zamboni/admin-all.js:180 static/js/zamboni/admin-min.js:1 static/js/zamboni/admin_validation.js:24 static/js/zamboni/devhub-all.js:2408 static/js/zamboni/devhub-min.js:2
+#: static/js/zamboni/devhub.js:1229 static/js/zamboni/editors-all.js:15576 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:295
 msgid "Select an application first"
 msgstr ""
 
-#: static/js/zamboni/admin_validation.js:51
+#: static/js/zamboni/admin-all.js:207 static/js/zamboni/admin-min.js:1 static/js/zamboni/admin_validation.js:51
 msgid "Set {0} add-on to a max version of {1} and email the author."
 msgid_plural "Set {0} add-ons to a max version of {1} and email the authors."
 msgstr[0] ""
 msgstr[1] ""
 
-#: static/js/zamboni/admin_validation.js:54
+#: static/js/zamboni/admin-all.js:210 static/js/zamboni/admin-min.js:1 static/js/zamboni/admin_validation.js:54
 msgid "Email author of {2} add-on which failed validation."
 msgid_plural "Email authors of {2} add-ons which failed validation."
 msgstr[0] ""
 msgstr[1] ""
 
-#. L10n: {0} is an app name like Firefox.
-#: static/js/zamboni/buttons.js:66
-msgid "Accept and Install"
-msgstr ""
-
-#: static/js/zamboni/buttons.js:66
-msgid "Add to {0}"
-msgstr ""
-
-#: static/js/zamboni/buttons.js:71
-msgid "Download Now"
-msgstr ""
-
-#: static/js/zamboni/buttons.js:112
-msgid "Add-on has not been updated to support default-to-compatible."
-msgstr ""
-
-#: static/js/zamboni/buttons.js:117
-msgid "You need to be using Firefox 10.0 or higher."
-msgstr ""
-
-#: static/js/zamboni/buttons.js:129
-msgid "Mozilla has marked this version as incompatible with your Firefox version."
-msgstr ""
-
-#. L10n: {0} is an platform like Windows or Linux.
-#: static/js/zamboni/buttons.js:210
-msgid "Install for {0} anyway"
-msgstr ""
-
-#: static/js/zamboni/buttons.js:210
-msgid "Download for {0} anyway"
-msgstr ""
-
-#: static/js/zamboni/buttons.js:267
-msgid "Not available for your platform"
-msgstr ""
-
-#. L10n: {0} is an app name, {1} is the app version.
-#: static/js/zamboni/buttons.js:278 static/js/zamboni/buttons.js:315
-msgid "Not available for {0} {1}"
-msgstr ""
-
-#: static/js/zamboni/buttons.js:341
-msgid "Works with {app} {min} - {max}"
-msgstr ""
-
-#: static/js/zamboni/buttons.js:343
-msgid "View other versions"
-msgstr ""
-
-#: static/js/zamboni/buttons.js:391
-msgid "Only with Firefox — Get Firefox Now!"
-msgstr ""
-
-#: static/js/zamboni/buttons.js:507 static/js/zamboni/mobile/buttons.js:43
-msgid "Sorry, you need a Mozilla-based browser (such as Firefox) to install a search plugin."
-msgstr ""
-
-#: static/js/zamboni/collections.js:229
-msgid "Adding to Favorites&hellip;"
-msgstr ""
-
-#: static/js/zamboni/collections.js:232
-msgid "Removing Favorite&hellip;"
-msgstr ""
-
-#: static/js/zamboni/collections.js:235
-msgid "Add to Favorites"
-msgstr ""
-
-#: static/js/zamboni/collections.js:238
-msgid "Remove from Favorites"
-msgstr ""
-
-#: static/js/zamboni/collections.js:303
-msgid "Pending"
-msgstr ""
-
-#: static/js/zamboni/collections.js:304
-msgid "Add a comment"
-msgstr ""
-
-#: static/js/zamboni/collections.js:304
-msgid "Comment"
-msgstr ""
-
-#: static/js/zamboni/collections.js:305
-msgid "Remove this add-on from the collection"
-msgstr ""
-
-#: static/js/zamboni/collections.js:305 static/js/zamboni/collections.js:334
-msgid "Remove"
-msgstr ""
-
-#: static/js/zamboni/collections.js:334
-msgid "Remove this user as a contributor"
-msgstr ""
-
-#: static/js/zamboni/collections.js:346
-msgid "An email address is required."
-msgstr ""
-
-#: static/js/zamboni/collections.js:364
-msgid "You cannot add yourself as a contributor."
-msgstr ""
-
-#: static/js/zamboni/collections.js:366
-msgid "You have already added that user."
-msgstr ""
-
-#: static/js/zamboni/collections.js:573
-msgid "Add to favorites"
-msgstr ""
-
-#: static/js/zamboni/collections.js:577
-msgid "Remove from favorites"
-msgstr ""
-
-#: static/js/zamboni/collections.js:604
-msgid "Stop following"
-msgstr ""
-
-#: static/js/zamboni/devhub.js:110
+#: static/js/zamboni/devhub-all.js:1289 static/js/zamboni/devhub-min.js:1 static/js/zamboni/devhub.js:110
 msgid "Your browser does not support the video tag"
 msgstr ""
 
-#: static/js/zamboni/devhub.js:371
+#: static/js/zamboni/devhub-all.js:1550 static/js/zamboni/devhub-min.js:1 static/js/zamboni/devhub.js:371
 msgid "Changes Saved"
 msgstr ""
 
-#: static/js/zamboni/devhub.js:387
+#: static/js/zamboni/devhub-all.js:1566 static/js/zamboni/devhub-min.js:1 static/js/zamboni/devhub.js:387
 msgid "Enter a new author's email address"
 msgstr ""
 
-#: static/js/zamboni/devhub.js:536
+#: static/js/zamboni/devhub-all.js:1715 static/js/zamboni/devhub-min.js:1 static/js/zamboni/devhub.js:536
 msgid "There was an error uploading your file."
 msgstr ""
 
-#: static/js/zamboni/devhub.js:681
+#: static/js/zamboni/devhub-all.js:1860 static/js/zamboni/devhub-min.js:1 static/js/zamboni/devhub.js:681
 msgid "{files} file"
 msgid_plural "{files} files"
 msgstr[0] ""
 msgstr[1] ""
 
-#: static/js/zamboni/devhub.js:684
+#: static/js/zamboni/devhub-all.js:1863 static/js/zamboni/devhub-min.js:1 static/js/zamboni/devhub.js:684
 msgid "{reviews} user review"
 msgid_plural "{reviews} user reviews"
 msgstr[0] ""
 msgstr[1] ""
 
-#: static/js/zamboni/devhub.js:796
+#: static/js/zamboni/devhub-all.js:1975 static/js/zamboni/devhub-min.js:2 static/js/zamboni/devhub.js:796
 msgid "Learn more"
 msgstr ""
 
-#: static/js/zamboni/devhub.js:800
+#: static/js/zamboni/devhub-all.js:1979 static/js/zamboni/devhub-min.js:2 static/js/zamboni/devhub.js:800
 msgid "Example"
 msgstr ""
 
-#: static/js/zamboni/devhub.js:1130
+#: static/js/zamboni/devhub-all.js:2309 static/js/zamboni/devhub-min.js:2 static/js/zamboni/devhub.js:1130
 msgid "Image changes being processed"
 msgstr ""
 
-#: static/js/zamboni/devhub.js:1280
+#: static/js/zamboni/devhub-all.js:2459 static/js/zamboni/devhub-min.js:2 static/js/zamboni/devhub.js:1280
 msgid "Must be a valid e-mail address."
+msgstr ""
+
+#: static/js/zamboni/devhub-all.js:2613 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:80
+msgid "All tests passed successfully."
+msgstr ""
+
+#: static/js/zamboni/devhub-all.js:2616 static/js/zamboni/devhub-all.js:3011 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:83 static/js/zamboni/validator.js:478
+msgid "These tests were not run."
+msgstr ""
+
+#: static/js/zamboni/devhub-all.js:2664 static/js/zamboni/devhub-all.js:2677 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:131 static/js/zamboni/validator.js:144
+msgid "Tests"
+msgstr ""
+
+#: static/js/zamboni/devhub-all.js:2779 static/js/zamboni/devhub-all.js:3108 static/js/zamboni/devhub-all.js:3127 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:246
+#: static/js/zamboni/validator.js:575 static/js/zamboni/validator.js:594
+msgid "Error"
+msgstr ""
+
+#: static/js/zamboni/devhub-all.js:2780 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:247
+msgid "Warning"
+msgstr ""
+
+#: static/js/zamboni/devhub-all.js:2794 static/js/zamboni/devhub-min.js:2 static/js/zamboni/files-all.js:5657 static/js/zamboni/files-min.js:3 static/js/zamboni/files.js:411
+#: static/js/zamboni/validator.js:261
+msgid "Ignore this message in future updates"
+msgstr ""
+
+#: static/js/zamboni/devhub-all.js:2817 static/js/zamboni/devhub-min.js:2 static/js/zamboni/files-all.js:5663 static/js/zamboni/files-min.js:3 static/js/zamboni/files.js:417
+#: static/js/zamboni/validator.js:284
+msgid "Severity for automated signing:"
+msgstr ""
+
+#: static/js/zamboni/devhub-all.js:2832 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:299
+msgid "Suggestions for passing automated signing:"
+msgstr ""
+
+#: static/js/zamboni/devhub-all.js:2920 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:387
+msgid "Compatibility Tests"
+msgstr ""
+
+#: static/js/zamboni/devhub-all.js:2999 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:466
+msgid "Add-on failed validation."
+msgstr ""
+
+#: static/js/zamboni/devhub-all.js:3001 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:468
+msgid "Add-on passed validation."
+msgstr ""
+
+#: static/js/zamboni/devhub-all.js:3014 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:481
+msgid "{0} error"
+msgid_plural "{0} errors"
+msgstr[0] ""
+msgstr[1] ""
+
+#: static/js/zamboni/devhub-all.js:3016 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:483
+msgid "{0} warning"
+msgid_plural "{0} warnings"
+msgstr[0] ""
+msgstr[1] ""
+
+#: static/js/zamboni/devhub-all.js:3018 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:485
+msgid "{0} notice"
+msgid_plural "{0} notices"
+msgstr[0] ""
+msgstr[1] ""
+
+#: static/js/zamboni/devhub-all.js:3110 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:577
+msgid "Validation task could not complete or completed with errors"
+msgstr ""
+
+#: static/js/zamboni/devhub-all.js:3128 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:595
+msgid "Internal server error"
 msgstr ""
 
 #: static/js/zamboni/devhub_search.js:8
 msgid "No results found."
 msgstr ""
 
-#: static/js/zamboni/editors.js:121
+#: static/js/zamboni/editors-all.js:15402 static/js/zamboni/editors-min.js:4 static/js/zamboni/editors.js:121
 msgid "{name} was viewing this page first."
 msgstr ""
 
-#: static/js/zamboni/editors.js:171
+#: static/js/zamboni/editors-all.js:15452 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:171
 msgid "Receipt checked by app."
 msgstr ""
 
-#: static/js/zamboni/editors.js:173
+#: static/js/zamboni/editors-all.js:15454 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:173
 msgid "Receipt was not checked by app."
 msgstr ""
 
-#: static/js/zamboni/editors.js:244
+#: static/js/zamboni/editors-all.js:15525 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:244
 msgid "{name} was viewing this add-on first."
 msgstr ""
 
-#: static/js/zamboni/editors.js:255
+#: static/js/zamboni/editors-all.js:15536 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:255
 msgid "Loading&hellip;"
 msgstr ""
 
-#: static/js/zamboni/editors.js:260
+#: static/js/zamboni/editors-all.js:15541 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:260
 msgid "Version Notes"
 msgstr ""
 
-#: static/js/zamboni/editors.js:265
+#: static/js/zamboni/editors-all.js:15546 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:265
 msgid "Notes for Reviewers"
 msgstr ""
 
-#: static/js/zamboni/editors.js:270
+#: static/js/zamboni/editors-all.js:15551 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:270
 msgid "No version notes found"
 msgstr ""
 
-#: static/js/zamboni/editors.js:330
+#: static/js/zamboni/editors-all.js:15611 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:330
 msgid "Average Reviews"
 msgstr ""
 
-#: static/js/zamboni/editors.js:386
+#: static/js/zamboni/editors-all.js:15667 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:386
 msgid "Number of Reviews"
 msgstr ""
 
-#: static/js/zamboni/editors.js:445
+#: static/js/zamboni/editors-all.js:15726 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:445
 msgid "Error loading translation"
 msgstr ""
 
-#: static/js/zamboni/files.js:411 static/js/zamboni/validator.js:261
-msgid "Ignore this message in future updates"
-msgstr ""
-
-#: static/js/zamboni/files.js:417 static/js/zamboni/validator.js:284
-msgid "Severity for automated signing:"
-msgstr ""
-
-#: static/js/zamboni/global.js:410
-msgid "Loading..."
-msgstr ""
-
-#. L10n: {0} is the number of characters left.
-#: static/js/zamboni/global.js:474
-msgid "<b>{0}</b> character left."
-msgid_plural "<b>{0}</b> characters left."
-msgstr[0] ""
-msgstr[1] ""
-
-#: static/js/zamboni/init.js:28
-msgid "This feature is temporarily disabled while we perform website maintenance. Please check back a little later."
-msgstr ""
-
-#: static/js/zamboni/l10n.js:45
-msgid "Remove this localization"
-msgstr ""
-
-#: static/js/zamboni/password-strength.js:20
-msgid "Password strength:"
-msgstr ""
-
-#: static/js/zamboni/password-strength.js:26
-msgid "At least {0} character left."
-msgid_plural "At least {0} characters left."
-msgstr[0] ""
-msgstr[1] ""
-
-#: static/js/zamboni/themes_review.js:176
-msgid "Requested Info"
-msgstr ""
-
-#: static/js/zamboni/themes_review.js:177
-msgid "Flagged"
-msgstr ""
-
-#: static/js/zamboni/themes_review.js:178
-msgid "Duplicate"
-msgstr ""
-
-#: static/js/zamboni/themes_review.js:179
-msgid "Rejected"
-msgstr ""
-
-#: static/js/zamboni/themes_review.js:180
-msgid "Approved"
-msgstr ""
-
-#: static/js/zamboni/themes_review.js:424
-msgid "No results found"
-msgstr ""
-
-#: static/js/zamboni/themes_review_templates.js:31
+#: static/js/zamboni/editors-all.js:15975 static/js/zamboni/editors-min.js:5 static/js/zamboni/themes_review_templates.js:31
 msgid "Theme"
 msgstr ""
 
-#: static/js/zamboni/themes_review_templates.js:33
+#: static/js/zamboni/editors-all.js:15977 static/js/zamboni/editors-min.js:5 static/js/zamboni/themes_review_templates.js:33
 msgid "Reviewer"
 msgstr ""
 
-#: static/js/zamboni/themes_review_templates.js:35
+#: static/js/zamboni/editors-all.js:15979 static/js/zamboni/editors-min.js:5 static/js/zamboni/themes_review_templates.js:35
 msgid "Status"
 msgstr ""
 
-#: static/js/zamboni/validator.js:80
-msgid "All tests passed successfully."
+#: static/js/zamboni/editors-all.js:16196 static/js/zamboni/editors-min.js:5 static/js/zamboni/themes_review.js:176
+msgid "Requested Info"
 msgstr ""
 
-#: static/js/zamboni/validator.js:83 static/js/zamboni/validator.js:478
-msgid "These tests were not run."
+#: static/js/zamboni/editors-all.js:16197 static/js/zamboni/editors-min.js:5 static/js/zamboni/themes_review.js:177
+msgid "Flagged"
 msgstr ""
 
-#: static/js/zamboni/validator.js:131 static/js/zamboni/validator.js:144
-msgid "Tests"
+#: static/js/zamboni/editors-all.js:16198 static/js/zamboni/editors-min.js:5 static/js/zamboni/themes_review.js:178
+msgid "Duplicate"
 msgstr ""
 
-#: static/js/zamboni/validator.js:246 static/js/zamboni/validator.js:575 static/js/zamboni/validator.js:594
-msgid "Error"
+#: static/js/zamboni/editors-all.js:16199 static/js/zamboni/editors-min.js:5 static/js/zamboni/themes_review.js:179
+msgid "Rejected"
 msgstr ""
 
-#: static/js/zamboni/validator.js:247
-msgid "Warning"
+#: static/js/zamboni/editors-all.js:16200 static/js/zamboni/editors-min.js:5 static/js/zamboni/themes_review.js:180
+msgid "Approved"
 msgstr ""
 
-#: static/js/zamboni/validator.js:299
-msgid "Suggestions for passing automated signing:"
+#: static/js/zamboni/editors-all.js:16444 static/js/zamboni/editors-min.js:5 static/js/zamboni/themes_review.js:424
+msgid "No results found"
 msgstr ""
 
-#: static/js/zamboni/validator.js:387
-msgid "Compatibility Tests"
-msgstr ""
-
-#: static/js/zamboni/validator.js:466
-msgid "Add-on failed validation."
-msgstr ""
-
-#: static/js/zamboni/validator.js:468
-msgid "Add-on passed validation."
-msgstr ""
-
-#: static/js/zamboni/validator.js:481
-msgid "{0} error"
-msgid_plural "{0} errors"
-msgstr[0] ""
-msgstr[1] ""
-
-#: static/js/zamboni/validator.js:483
-msgid "{0} warning"
-msgid_plural "{0} warnings"
-msgstr[0] ""
-msgstr[1] ""
-
-#: static/js/zamboni/validator.js:485
-msgid "{0} notice"
-msgid_plural "{0} notices"
-msgstr[0] ""
-msgstr[1] ""
-
-#: static/js/zamboni/validator.js:577
-msgid "Validation task could not complete or completed with errors"
-msgstr ""
-
-#: static/js/zamboni/validator.js:595
-msgid "Internal server error"
-msgstr ""
-
-#: static/js/zamboni/mobile/buttons.js:52
+#: static/js/zamboni/mobile-all.js:15186 static/js/zamboni/mobile/buttons.js:52
 msgid "Not Updated for {0} {1}"
 msgstr ""
 
-#: static/js/zamboni/mobile/buttons.js:53
+#: static/js/zamboni/mobile-all.js:15187 static/js/zamboni/mobile/buttons.js:53
 msgid "Requires Newer Version of {0}"
 msgstr ""
 
-#: static/js/zamboni/mobile/buttons.js:54
+#: static/js/zamboni/mobile-all.js:15188 static/js/zamboni/mobile/buttons.js:54
 msgid "Unreviewed"
 msgstr ""
 
-#: static/js/zamboni/mobile/buttons.js:55
+#: static/js/zamboni/mobile-all.js:15189 static/js/zamboni/mobile/buttons.js:55
 msgid "Experimental <span>(Learn More)</span>"
 msgstr ""
 
-#: static/js/zamboni/mobile/buttons.js:56 static/js/zamboni/mobile/buttons.js:57
+#: static/js/zamboni/mobile-all.js:15190 static/js/zamboni/mobile-all.js:15191 static/js/zamboni/mobile/buttons.js:56 static/js/zamboni/mobile/buttons.js:57
 msgid "Not Available for {0}"
 msgstr ""
 
-#: static/js/zamboni/mobile/buttons.js:58
+#: static/js/zamboni/mobile-all.js:15192 static/js/zamboni/mobile/buttons.js:58
 msgid "Experimental"
 msgstr ""
 
-#: static/js/zamboni/mobile/buttons.js:59
+#: static/js/zamboni/mobile-all.js:15193 static/js/zamboni/mobile/buttons.js:59
 msgid "Themes Require Newer Version of {0}"
 msgstr ""
 
-#: static/js/zamboni/mobile/buttons.js:60
+#: static/js/zamboni/mobile-all.js:15194 static/js/zamboni/mobile/buttons.js:60
 msgid "Themes Require {0}"
 msgstr ""
 
-#: static/js/zamboni/mobile/buttons.js:105
+#: static/js/zamboni/mobile-all.js:15239 static/js/zamboni/mobile/buttons.js:105
 msgid "Installing..."
 msgstr ""
 
-#: static/js/zamboni/mobile/buttons.js:125
+#: static/js/zamboni/mobile-all.js:15259 static/js/zamboni/mobile/buttons.js:125
 msgid "This add-on has been preliminarily reviewed by Mozilla."
 msgstr ""
 
-#: static/js/zamboni/mobile/buttons.js:250
+#: static/js/zamboni/mobile-all.js:15384 static/js/zamboni/mobile/buttons.js:250
 msgid "Keep it"
 msgstr ""
 
-#: static/js/zamboni/mobile/general.js:344
+#: static/js/zamboni/mobile-all.js:16049 static/js/zamboni/mobile-min.js:6 static/js/zamboni/mobile/general.js:344
 msgid "You're trying it on!"
 msgstr ""
 
-#: static/js/zamboni/mobile/general.js:356
+#: static/js/zamboni/mobile-all.js:16061 static/js/zamboni/mobile-min.js:6 static/js/zamboni/mobile/general.js:356
 msgid "Added to Firefox"
 msgstr ""
-

--- a/locale/es/LC_MESSAGES/django.po
+++ b/locale/es/LC_MESSAGES/django.po
@@ -10,71 +10,72 @@ msgid ""
 msgstr ""
 "Project-Id-Version:  messages\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2016-02-24 21:23+0000\n"
+"POT-Creation-Date: 2016-04-18 15:47+0000\n"
 "PO-Revision-Date: 2016-02-29 12:10+0000\n"
 "Last-Translator: avelper <avelper@mozilla-hispano.org>\n"
 "Language-Team: Español (España) <nave@elistas.net>\n"
+"Language: \n"
 "MIME-Version: 1.0\n"
-"Content-Type: text/plain; charset=utf-8\n"
+"Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Generated-By: Babel 2.2.0\n"
 
-#: src/olympia/accounts/views.py:52
+#: src/olympia/accounts/views.py:54
 msgid "Your log in attempt could not be parsed. Please try again."
 msgstr "No pudimos analizar tu intento de conectar. Inténtalo de nuevo."
 
-#: src/olympia/accounts/views.py:54
+#: src/olympia/accounts/views.py:56
 msgid "Your Firefox Account could not be found. Please try again."
 msgstr "No pudimos encontrar tu cuenta de Firefox. Inténtalo de nuevo."
 
-#: src/olympia/accounts/views.py:55
+#: src/olympia/accounts/views.py:57
 msgid "You could not be logged in. Please try again."
 msgstr "No pudiste conectar. Inténtalo de nuevo."
 
-#: src/olympia/accounts/views.py:57
+#: src/olympia/accounts/views.py:59
 msgid "Your account has already been migrated to Firefox Accounts."
 msgstr "Tu cuenta ya ha sido migrada a Firefox Accounts."
 
-#: src/olympia/accounts/views.py:59
+#: src/olympia/accounts/views.py:61
 msgid "Your Firefox Account already exists on this site."
 msgstr "Tu cuenta de Firefox ya existe en este sitio."
 
-#: src/olympia/accounts/views.py:108
+#: src/olympia/accounts/views.py:110
 msgid "Great job!"
 msgstr "¡Buen trabajo!"
 
-#: src/olympia/accounts/views.py:109
+#: src/olympia/accounts/views.py:111
 msgid "You can now log in to Add-ons with your Firefox Account."
 msgstr "Ya puedes conectarte a Complementos con tu cuenta de Firefox."
 
-#: src/olympia/accounts/views.py:121
+#: src/olympia/accounts/views.py:123
 msgid "Need help?"
 msgstr "¿Necesitas ayuda?"
 
-#: src/olympia/addons/buttons.py:180
+#: src/olympia/addons/buttons.py:177
 msgid "Download Now"
 msgstr "Descargar ahora"
 
-#: src/olympia/addons/buttons.py:182
+#: src/olympia/addons/buttons.py:179
 msgid "Download"
 msgstr "Descargar"
 
 #. L10n: please keep &nbsp; in the string so &rarr; does not wrap.
-#: src/olympia/addons/buttons.py:186
+#: src/olympia/addons/buttons.py:183
 msgid "Continue to Download&nbsp;&rarr;"
 msgstr "Continuar con la descarga&nbsp;&rarr;"
 
-#: src/olympia/addons/buttons.py:202 src/olympia/addons/helpers.py:35 src/olympia/addons/views.py:319 src/olympia/addons/templates/addons/impala/details.html:114
+#: src/olympia/addons/buttons.py:199 src/olympia/addons/helpers.py:35 src/olympia/addons/views.py:333 src/olympia/addons/templates/addons/impala/details.html:111
 #: src/olympia/addons/templates/addons/impala/listing/items.html:17 src/olympia/addons/templates/addons/mobile/home.html:40 src/olympia/amo/templates/amo/side_nav.html:6
-#: src/olympia/amo/templates/amo/side_nav.html:10 src/olympia/amo/templates/amo/site_nav.html:2 src/olympia/amo/templates/amo/site_nav.html:55 src/olympia/bandwagon/views.py:95
-#: src/olympia/browse/views.py:54 src/olympia/browse/views.py:68 src/olympia/browse/views.py:235 src/olympia/browse/templates/browse/impala/category_landing.html:22
+#: src/olympia/amo/templates/amo/side_nav.html:10 src/olympia/amo/templates/amo/site_nav.html:2 src/olympia/amo/templates/amo/site_nav.html:53 src/olympia/bandwagon/views.py:95
+#: src/olympia/browse/views.py:54 src/olympia/browse/views.py:68 src/olympia/browse/views.py:202 src/olympia/browse/templates/browse/impala/category_landing.html:22
 #: src/olympia/browse/templates/browse/personas/mobile/category_landing.html:26
 msgid "Featured"
 msgstr "Destacados"
 
 # Link text to the AMO blog.
 # Link text to the Frequently Asked Questions page.
-#: src/olympia/addons/buttons.py:221
+#: src/olympia/addons/buttons.py:218
 msgid "Add to {0}"
 msgstr "Agregar a {0}"
 
@@ -122,39 +123,39 @@ msgid_plural "All tags must be at least {0} characters."
 msgstr[0] "Todas las etiquetas deben tener al menos {0} carácter."
 msgstr[1] "Todas las etiquetas deben tener al menos {0} caracteres."
 
-#: src/olympia/addons/forms.py:234
+#: src/olympia/addons/forms.py:238
 msgid "Categories cannot be changed while your add-on is featured for this application."
 msgstr "Las categorías no pueden cambiarse mientras tu complemento figura destacado para esta aplicación."
 
 #. L10n: {0} is the number of categories.
-#: src/olympia/addons/forms.py:238
+#: src/olympia/addons/forms.py:242
 msgid "You can have only {0} category."
 msgid_plural "You can have only {0} categories."
 msgstr[0] "Solo puedes tener {0} categoría."
 msgstr[1] "Solo puedes tener {0} categorías."
 
-#: src/olympia/addons/forms.py:246
+#: src/olympia/addons/forms.py:250
 msgid "The miscellaneous category cannot be combined with additional categories."
 msgstr "La categoría miscelánea no puede combinarse con categorías adicionales."
 
-#: src/olympia/addons/forms.py:369
+#: src/olympia/addons/forms.py:374
 #, python-format
 msgid "Before changing your default locale you must have a name, summary, and description in that locale. You are missing %s."
 msgstr "Antes de cambiar tu idioma predeterminado, debes tener un nombre, un resumen y una descripción en dicho idioma. Te falta %s."
 
-#: src/olympia/addons/forms.py:484 src/olympia/addons/forms.py:575
+#: src/olympia/addons/forms.py:455 src/olympia/addons/forms.py:546
 msgid "A license must be selected."
 msgstr "Debe seleccionarse una licencia."
 
-#: src/olympia/addons/forms.py:556
+#: src/olympia/addons/forms.py:527
 msgid "Give Your Theme a Name."
 msgstr "Pon un nombre a tu tema."
 
-#: src/olympia/addons/forms.py:562 src/olympia/devhub/templates/devhub/personas/submit.html:53
+#: src/olympia/addons/forms.py:533 src/olympia/devhub/templates/devhub/personas/submit.html:53
 msgid "Describe your Theme."
 msgstr "Describe tu tema."
 
-#: src/olympia/addons/forms.py:704
+#: src/olympia/addons/forms.py:675
 msgid "Enter a new author's email address"
 msgstr "Escribe la dirección de correo de un nuevo autor"
 
@@ -162,40 +163,40 @@ msgstr "Escribe la dirección de correo de un nuevo autor"
 msgid "Not Reviewed"
 msgstr "Sin valoraciones"
 
-#: src/olympia/addons/models.py:301
+#: src/olympia/addons/models.py:298
 msgid "Users have the option of contributing more or less than this amount."
 msgstr "Los usuarios tienen la opción de colaborar más o menos que esta cantidad."
 
-#: src/olympia/addons/models.py:309
-msgid "Users will always be asked in the Add-ons Manager (Firefox 4 and above)"
-msgstr "Se preguntará siempre a los usuarios en el administrador de complementos (Firefox 4 y posteriores)"
+#: src/olympia/addons/models.py:306
+msgid "Users will always be asked in the Add-ons Manager (Firefox 4 and above). Only applies to desktop."
+msgstr ""
 
 # Column name in a table.
-#: src/olympia/addons/models.py:1804 src/olympia/addons/templates/addons/details_box.html:55 src/olympia/devhub/templates/devhub/index.html:92
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:102
+#: src/olympia/addons/models.py:1802 src/olympia/addons/templates/addons/details_box.html:55 src/olympia/devhub/templates/devhub/index.html:92
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:89
 msgid "Listed"
 msgstr "Listado"
 
-#: src/olympia/addons/views.py:320 src/olympia/browse/templates/browse/personas/mobile/category_landing.html:27
+#: src/olympia/addons/views.py:334 src/olympia/browse/templates/browse/personas/mobile/category_landing.html:27
 msgid "Popular"
 msgstr "Popular"
 
-#: src/olympia/addons/views.py:321 src/olympia/browse/views.py:238 src/olympia/browse/views.py:280 src/olympia/browse/views.py:482
+#: src/olympia/addons/views.py:335 src/olympia/browse/views.py:205 src/olympia/browse/views.py:247 src/olympia/browse/views.py:449
 msgid "Recently Added"
 msgstr "Agregados recientemente"
 
 # Acortado para que salga completo el texto en la web
-#: src/olympia/addons/views.py:322 src/olympia/bandwagon/views.py:99 src/olympia/browse/views.py:60 src/olympia/browse/views.py:71 src/olympia/search/forms.py:16 src/olympia/search/forms.py:91
+#: src/olympia/addons/views.py:336 src/olympia/bandwagon/views.py:99 src/olympia/browse/views.py:60 src/olympia/browse/views.py:71 src/olympia/search/forms.py:16 src/olympia/search/forms.py:91
 msgid "Recently Updated"
 msgstr "Actualizados recientemente"
 
 # %1 is an add-on name.
 #. l10n: {0} is the addon name
-#: src/olympia/addons/views.py:520
+#: src/olympia/addons/views.py:534
 msgid "Contribution for {0}"
 msgstr "Colaboración para {0}"
 
-#: src/olympia/addons/views.py:613
+#: src/olympia/addons/views.py:627
 msgid "Abuse reported."
 msgstr "Informe de uso indebido enviado."
 
@@ -264,9 +265,9 @@ msgstr "Colabora"
 #: src/olympia/devhub/templates/devhub/addons/ajax_compat_update.html:36 src/olympia/devhub/templates/devhub/addons/profile.html:44 src/olympia/devhub/templates/devhub/addons/edit/admin.html:101
 #: src/olympia/devhub/templates/devhub/addons/edit/basic.html:152 src/olympia/devhub/templates/devhub/addons/edit/details.html:85 src/olympia/devhub/templates/devhub/addons/edit/support.html:67
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:166 src/olympia/devhub/templates/devhub/addons/forms_shared/media.html:149
-#: src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:44 src/olympia/devhub/templates/devhub/versions/add_file_modal.html:78 src/olympia/devhub/templates/devhub/versions/edit.html:139
-#: src/olympia/devhub/templates/devhub/versions/list.html:242 src/olympia/devhub/templates/devhub/versions/list.html:276 src/olympia/devhub/templates/devhub/versions/list.html:317
-#: src/olympia/devhub/templates/devhub/versions/list.html:351 src/olympia/reviews/templates/reviews/edit_review.html:16 src/olympia/translations/templates/translations/trans-menu.html:50
+#: src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:43 src/olympia/devhub/templates/devhub/versions/add_file_modal.html:58 src/olympia/devhub/templates/devhub/versions/edit.html:139
+#: src/olympia/devhub/templates/devhub/versions/list.html:239 src/olympia/devhub/templates/devhub/versions/list.html:281 src/olympia/devhub/templates/devhub/versions/list.html:315
+#: src/olympia/devhub/templates/devhub/versions/list.html:349 src/olympia/reviews/templates/reviews/edit_review.html:16 src/olympia/translations/templates/translations/trans-menu.html:50
 #: src/olympia/translations/templates/translations/trans-menu.html:62
 msgid "or"
 msgstr "o"
@@ -339,8 +340,7 @@ msgstr "La cantidad de colaboración debe ser un número."
 msgid "A one-time suggested contribution of {0}"
 msgstr "Una colaboración única sugerida de {0}"
 
-#. {0} is a currency symbol (e.g., $),                    {1} is an amount
-#. input
+#. {0} is a currency symbol (e.g., $),                    {1} is an amount input
 #. field
 #: src/olympia/addons/templates/addons/contributions_lightbox.html:64
 msgid "A one-time contribution of {0} {1}"
@@ -381,7 +381,7 @@ msgid "Add-on Information for {0}"
 msgstr "Información del complemento para {0}"
 
 #: src/olympia/addons/templates/addons/details_box.html:30 src/olympia/addons/templates/addons/persona_detail_table.html:3 src/olympia/addons/templates/addons/mobile/details.html:63
-#: src/olympia/addons/templates/addons/mobile/persona_detail_table.html:7 src/olympia/browse/views.py:459 src/olympia/devhub/views.py:75
+#: src/olympia/addons/templates/addons/mobile/persona_detail_table.html:7 src/olympia/browse/views.py:426 src/olympia/devhub/views.py:73
 msgid "Updated"
 msgstr "Actualizados"
 
@@ -400,11 +400,11 @@ msgstr "Funciona con"
 msgid "Visibility"
 msgstr "Visibilidad"
 
-#: src/olympia/addons/templates/addons/details_box.html:57 src/olympia/devhub/templates/devhub/index.html:94 src/olympia/devhub/templates/devhub/includes/addon_details.html:104
+#: src/olympia/addons/templates/addons/details_box.html:57 src/olympia/devhub/templates/devhub/index.html:94 src/olympia/devhub/templates/devhub/includes/addon_details.html:91
 msgid "Hidden"
 msgstr "Oculto"
 
-#: src/olympia/addons/templates/addons/details_box.html:59 src/olympia/devhub/templates/devhub/index.html:96 src/olympia/devhub/templates/devhub/includes/addon_details.html:106
+#: src/olympia/addons/templates/addons/details_box.html:59 src/olympia/devhub/templates/devhub/index.html:96 src/olympia/devhub/templates/devhub/includes/addon_details.html:93
 msgid "Unlisted"
 msgstr "No listado"
 
@@ -412,13 +412,13 @@ msgstr "No listado"
 msgid "Required Add-ons"
 msgstr "Complementos necesarios"
 
-#: src/olympia/addons/templates/addons/details_box.html:81 src/olympia/addons/templates/addons/persona_detail_table.html:15 src/olympia/browse/views.py:462 src/olympia/devhub/views.py:78
-#: src/olympia/devhub/views.py:85 src/olympia/discovery/templates/discovery/addons/detail.html:57 src/olympia/reviews/forms.py:62 src/olympia/reviews/templates/reviews/add.html:57
+#: src/olympia/addons/templates/addons/details_box.html:81 src/olympia/addons/templates/addons/persona_detail_table.html:15 src/olympia/browse/views.py:429 src/olympia/devhub/views.py:76
+#: src/olympia/devhub/views.py:83 src/olympia/discovery/templates/discovery/addons/detail.html:57 src/olympia/reviews/forms.py:62 src/olympia/reviews/templates/reviews/add.html:57
 #: src/olympia/reviews/templates/reviews/mobile/review_list.html:18
 msgid "Rating"
 msgstr "Calificación"
 
-#: src/olympia/addons/templates/addons/details_box.html:85 src/olympia/browse/views.py:461 src/olympia/devhub/views.py:77 src/olympia/devhub/views.py:84
+#: src/olympia/addons/templates/addons/details_box.html:85 src/olympia/browse/views.py:428 src/olympia/devhub/views.py:75 src/olympia/devhub/views.py:82
 #: src/olympia/stats/templates/stats/addon_report_menu.html:8 src/olympia/stats/templates/stats/collection_report_menu.html:18
 msgid "Downloads"
 msgstr "Descargas"
@@ -438,7 +438,7 @@ msgstr "Informes de uso indebido"
 
 #. The Privacy Policy for this add-on.
 #: src/olympia/addons/templates/addons/details_box.html:121 src/olympia/addons/templates/addons/privacy.html:19 src/olympia/addons/templates/addons/privacy.html:23
-#: src/olympia/addons/templates/addons/impala/button.html:43 src/olympia/addons/templates/addons/impala/details.html:307 src/olympia/devhub/templates/devhub/includes/policy_form.html:20
+#: src/olympia/addons/templates/addons/impala/button.html:43 src/olympia/addons/templates/addons/impala/details.html:312 src/olympia/devhub/templates/devhub/includes/policy_form.html:23
 #: src/olympia/templates/mobile/base_addons.html:87
 msgid "Privacy Policy"
 msgstr "Política de privacidad"
@@ -463,7 +463,7 @@ msgstr "Galería de imágenes"
 msgid "Developer Comments"
 msgstr "Comentarios del desarrollador"
 
-#: src/olympia/addons/templates/addons/details_box.html:199 src/olympia/addons/templates/addons/impala/details.html:259
+#: src/olympia/addons/templates/addons/details_box.html:199 src/olympia/addons/templates/addons/impala/details.html:264
 msgid "Development Channel"
 msgstr "Canal de desarrollo"
 
@@ -487,13 +487,13 @@ msgstr ""
 "<strong>Atención:</strong> las versiones de pruebas de este complemento no han sido revisadas por Mozilla. Una vez instales la versión de desarrollo, continuarás recibiendo actualizaciones de "
 "desarrollo. Para dejar de recibirlas, reinstala la versión por defecto desde el siguiente enlace."
 
-#: src/olympia/addons/templates/addons/details_box.html:220 src/olympia/addons/templates/addons/impala/details.html:278
+#: src/olympia/addons/templates/addons/details_box.html:220 src/olympia/addons/templates/addons/impala/details.html:283
 msgid "Version {0}:"
 msgstr "Versión {0}:"
 
 #: src/olympia/addons/templates/addons/details_box.html:234
 msgid "Nothing to see here!  The developer did not include any details."
-msgstr "¡Nada que mostrar aquí!  El desarrollador no incluyó ningún detalle."
+msgstr ""
 
 #: src/olympia/addons/templates/addons/details_box.html:251 src/olympia/devhub/templates/devhub/versions/edit.html:73 src/olympia/editors/templates/editors/review.html:98
 msgid "Version Notes"
@@ -506,7 +506,7 @@ msgid "End-User License Agreement for {0}"
 msgstr "Acuerdo de licencia final de usuario por {0}"
 
 #: src/olympia/addons/templates/addons/eula.html:17 src/olympia/addons/templates/addons/eula.html:21 src/olympia/addons/templates/addons/impala/button.html:48
-#: src/olympia/addons/templates/addons/impala/details.html:316 src/olympia/devhub/templates/devhub/includes/policy_form.html:3 src/olympia/discovery/templates/discovery/addons/eula.html:11
+#: src/olympia/addons/templates/addons/impala/details.html:321 src/olympia/devhub/templates/devhub/includes/policy_form.html:3 src/olympia/discovery/templates/discovery/addons/eula.html:11
 msgid "End-User License Agreement"
 msgstr "Acuerdo de licencia final de usuario"
 
@@ -526,7 +526,7 @@ msgstr "Volver a {0}…"
 msgid "Add-ons for {0}"
 msgstr "Complementos para {0}"
 
-#: src/olympia/addons/templates/addons/home.html:10 src/olympia/addons/templates/addons/home.html:51 src/olympia/browse/templates/browse/impala/base_listing.html:11
+#: src/olympia/addons/templates/addons/home.html:10 src/olympia/addons/templates/addons/home.html:53 src/olympia/browse/templates/browse/impala/base_listing.html:11
 msgid "Featured Extensions"
 msgstr "Extensiones destacadas"
 
@@ -534,29 +534,29 @@ msgstr "Extensiones destacadas"
 msgid "Popular Extensions"
 msgstr "Extensiones populares"
 
-#: src/olympia/addons/templates/addons/home.html:42 src/olympia/amo/templates/amo/side_nav.html:3 src/olympia/amo/templates/amo/side_nav.html:11 src/olympia/amo/templates/amo/site_nav.html:3
-#: src/olympia/amo/templates/amo/site_nav.html:25 src/olympia/browse/views.py:236 src/olympia/browse/views.py:281 src/olympia/browse/views.py:481
+#: src/olympia/addons/templates/addons/home.html:44 src/olympia/amo/templates/amo/side_nav.html:3 src/olympia/amo/templates/amo/side_nav.html:11 src/olympia/amo/templates/amo/site_nav.html:3
+#: src/olympia/amo/templates/amo/site_nav.html:25 src/olympia/browse/views.py:203 src/olympia/browse/views.py:248 src/olympia/browse/views.py:448
 msgid "Most Popular"
 msgstr "Más populares"
 
-#: src/olympia/addons/templates/addons/home.html:43
+#: src/olympia/addons/templates/addons/home.html:45
 msgid "All »"
 msgstr "Todos »"
 
-#: src/olympia/addons/templates/addons/home.html:52 src/olympia/addons/templates/addons/home.html:61 src/olympia/addons/templates/addons/home.html:70 src/olympia/addons/templates/addons/home.html:78
+#: src/olympia/addons/templates/addons/home.html:54 src/olympia/addons/templates/addons/home.html:63 src/olympia/addons/templates/addons/home.html:72 src/olympia/addons/templates/addons/home.html:80
 #: src/olympia/browse/templates/browse/impala/category_landing.html:36
 msgid "See all »"
 msgstr "Ver todos »"
 
-#: src/olympia/addons/templates/addons/home.html:60
+#: src/olympia/addons/templates/addons/home.html:62
 msgid "Up &amp; Coming Extensions"
 msgstr "Extensiones disponibles próximamente"
 
-#: src/olympia/addons/templates/addons/home.html:69 src/olympia/browse/templates/browse/personas/category_landing.html:61 src/olympia/discovery/templates/discovery/pane.html:74
+#: src/olympia/addons/templates/addons/home.html:71 src/olympia/browse/templates/browse/personas/category_landing.html:61 src/olympia/discovery/templates/discovery/pane.html:74
 msgid "Featured Themes"
 msgstr "Temas destacados"
 
-#: src/olympia/addons/templates/addons/home.html:77 src/olympia/bandwagon/templates/bandwagon/impala/collection_listing.html:5
+#: src/olympia/addons/templates/addons/home.html:79 src/olympia/bandwagon/templates/bandwagon/impala/collection_listing.html:5
 msgid "Featured Collections"
 msgstr "Colecciones destacadas"
 
@@ -574,7 +574,7 @@ msgid "Updated {0}"
 msgstr "Actualizadas {0}"
 
 #. {0} is a date.
-#: src/olympia/addons/templates/addons/macros.html:10 src/olympia/addons/templates/addons/macros.html:69 src/olympia/addons/templates/addons/persona_preview.html:21
+#: src/olympia/addons/templates/addons/macros.html:10 src/olympia/addons/templates/addons/macros.html:69 src/olympia/addons/templates/addons/persona_preview.html:22
 #: src/olympia/addons/templates/addons/listing/items_mobile.html:44 src/olympia/addons/templates/addons/listing/macros.html:39
 #: src/olympia/bandwagon/templates/bandwagon/collection_listing_items.html:37 src/olympia/bandwagon/templates/bandwagon/impala/collection_listing_items.html:37
 msgid "Added {0}"
@@ -595,15 +595,14 @@ msgstr[0] "%(num)s usuario"
 msgstr[1] "%(num)s usuarios"
 
 #. {0} is the number of downloads.
-#: src/olympia/addons/templates/addons/macros.html:53 src/olympia/addons/templates/addons/impala/details.html:61
+#: src/olympia/addons/templates/addons/macros.html:53 src/olympia/addons/templates/addons/impala/details.html:59
 msgid "{0} weekly download"
 msgid_plural "{0} weekly downloads"
 msgstr[0] "{0} descarga semanal"
 msgstr[1] "{0} descargas semanales"
 
 #. {0} is the number of users.
-#: src/olympia/addons/templates/addons/macros.html:61 src/olympia/addons/templates/addons/impala/details.html:54 src/olympia/compat/templates/compat/index.html:71
-#: src/olympia/zadmin/templates/zadmin/compat.html:67
+#: src/olympia/addons/templates/addons/macros.html:61 src/olympia/addons/templates/addons/impala/details.html:52 src/olympia/zadmin/templates/zadmin/compat.html:67
 msgid "{0} user"
 msgid_plural "{0} users"
 msgstr[0] "{0} usuario"
@@ -621,7 +620,7 @@ msgstr "Pago completado"
 msgid "Return to the addon."
 msgstr "Volver al complemento."
 
-#: src/olympia/addons/templates/addons/persona_detail.html:17 src/olympia/addons/templates/addons/impala/details.html:106 src/olympia/addons/templates/addons/mobile/details.html:23
+#: src/olympia/addons/templates/addons/persona_detail.html:17 src/olympia/addons/templates/addons/impala/details.html:103 src/olympia/addons/templates/addons/mobile/details.html:23
 #: src/olympia/addons/templates/addons/mobile/persona_detail.html:21 src/olympia/discovery/templates/discovery/addons/base.html:27 src/olympia/editors/templates/editors/review.html:31
 msgid "by"
 msgstr "por"
@@ -665,34 +664,35 @@ msgstr "Usuarios diarios"
 msgid "License"
 msgstr "Licencia"
 
-#: src/olympia/addons/templates/addons/persona_preview.html:12 src/olympia/constants/base.py:48
+#: src/olympia/addons/templates/addons/persona_preview.html:13 src/olympia/constants/base.py:48
 msgid "Awaiting Review"
 msgstr "Esperando revisión"
 
-#: src/olympia/addons/templates/addons/persona_preview.html:14 src/olympia/amo/log.py:180 src/olympia/constants/base.py:42 src/olympia/editors/helpers.py:62
+#: src/olympia/addons/templates/addons/persona_preview.html:15 src/olympia/amo/log.py:180 src/olympia/constants/base.py:42 src/olympia/editors/helpers.py:62
 msgid "Rejected"
 msgstr "Rechazado"
 
-#: src/olympia/addons/templates/addons/persona_preview.html:16 src/olympia/amo/log.py:159
+#: src/olympia/addons/templates/addons/persona_preview.html:17 src/olympia/amo/log.py:159
 msgid "Approved"
 msgstr "Aprobado"
 
 #. {0} is the number of users.
-#: src/olympia/addons/templates/addons/persona_preview.html:26 src/olympia/addons/templates/addons/listing/items_mobile.html:36 src/olympia/addons/templates/addons/listing/macros.html:31
+#: src/olympia/addons/templates/addons/persona_preview.html:27 src/olympia/addons/templates/addons/listing/items_mobile.html:36 src/olympia/addons/templates/addons/listing/macros.html:31
 msgid "<strong>{0}</strong> user"
 msgid_plural "<strong>{0}</strong> users"
 msgstr[0] "<strong>{0}</strong> usuario"
 msgstr[1] "<strong>{0}</strong> usuarios"
 
-#: src/olympia/addons/templates/addons/persona_preview.html:40
+#: src/olympia/addons/templates/addons/persona_preview.html:41
 msgid "Hover to Preview"
 msgstr "Pasa el puntero por encima para ver una vista preliminar"
 
-#: src/olympia/addons/templates/addons/persona_preview.html:46 src/olympia/addons/templates/addons/persona_preview.html:48 src/olympia/reviews/templates/reviews/add.html:15
+#: src/olympia/addons/templates/addons/persona_preview.html:47 src/olympia/addons/templates/addons/persona_preview.html:49 src/olympia/addons/templates/addons/persona_preview.html:97
+#: src/olympia/reviews/templates/reviews/add.html:15
 msgid "Add"
 msgstr "Agregar"
 
-#: src/olympia/addons/templates/addons/persona_preview.html:57 src/olympia/bandwagon/templates/bandwagon/ajax_new.html:16 src/olympia/bandwagon/templates/bandwagon/edit.html:19
+#: src/olympia/addons/templates/addons/persona_preview.html:58 src/olympia/bandwagon/templates/bandwagon/ajax_new.html:16 src/olympia/bandwagon/templates/bandwagon/edit.html:19
 #: src/olympia/bandwagon/templates/bandwagon/includes/addedit.html:19 src/olympia/devhub/templates/devhub/addons/edit/admin.html:13 src/olympia/devhub/templates/devhub/addons/edit/basic.html:10
 #: src/olympia/devhub/templates/devhub/addons/edit/details.html:8 src/olympia/devhub/templates/devhub/addons/edit/media.html:6 src/olympia/devhub/templates/devhub/addons/edit/support.html:8
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:9 src/olympia/devhub/templates/devhub/addons/submit/describe.html:29 src/olympia/editors/templates/editors/review.html:257
@@ -701,21 +701,21 @@ msgstr "Editar"
 
 #. For datetime formatting, see the table on
 #. http://docs.python.org/library/datetime.html#strftime-and-strptime-behavior
-#: src/olympia/addons/templates/addons/persona_preview.html:66
+#: src/olympia/addons/templates/addons/persona_preview.html:67
 #, python-format
 msgid "%%Y-%%m-%%d"
 msgstr "%%A-%%m-%%d"
 
-#: src/olympia/addons/templates/addons/persona_preview.html:67
+#: src/olympia/addons/templates/addons/persona_preview.html:68
 msgid "by {0} on {1}"
 msgstr "por {0} el {1}"
 
-#: src/olympia/addons/templates/addons/persona_preview.html:75 src/olympia/reviews/helpers.py:17 src/olympia/reviews/templates/reviews/review_list.html:63
+#: src/olympia/addons/templates/addons/persona_preview.html:76 src/olympia/reviews/helpers.py:17 src/olympia/reviews/templates/reviews/review_list.html:63
 #: src/olympia/reviews/templates/reviews/reviews_link.html:21 src/olympia/reviews/templates/reviews/impala/reviews_link.html:16
 msgid "Not yet rated"
 msgstr "Sin puntuar aún"
 
-#: src/olympia/addons/templates/addons/persona_preview.html:78
+#: src/olympia/addons/templates/addons/persona_preview.html:79
 msgid "<b>{0}</b> users"
 msgstr "<b>{0}</b> usuarios"
 
@@ -728,8 +728,8 @@ msgid "Learn more about Firefox"
 msgstr "Más información acerca de Firefox"
 
 #: src/olympia/addons/templates/addons/popups.html:22
-msgid "or <b><a class=\"installer\" href=\"{url}\">download anyway</a></b>"
-msgstr "o <b><a class=\"installer\" href=\"{url}\">descargar de todas formas</a></b>"
+msgid "or <b><a class=\"button installer\" href=\"{url}\">download anyway</a></b>"
+msgstr ""
 
 #: src/olympia/addons/templates/addons/popups.html:26
 msgid ""
@@ -793,8 +793,6 @@ msgid ""
 "<strong>Caution:</strong> This add-on has not been reviewed by Mozilla and can't be installed on release versions of Firefox 43 and above.  Be careful when installing third-party software that "
 "might harm your computer."
 msgstr ""
-"<strong>Atención:</strong> Mozilla no ha revisado este complemento y no se puede instalar en la versión 43 de Firefox o posteriores. Ten cuidado cuando instales software de terceros, puede dañar tu "
-"equipo."
 
 #: src/olympia/addons/templates/addons/popups.html:120
 msgid "<strong>Please note:</strong> This add-on is not compatible with your operating system."
@@ -829,12 +827,9 @@ msgid ""
 "  to your phone.  (You'll need a QR reader.  Search your phone's marketplace if\n"
 "  don't have one.)"
 msgstr ""
-"¿Quieres {0} en tu móvil Firefox?  Escanea este código QR para instalarlo directamente\n"
-"  en tu teléfono.  (Necesitarás un lector QR.  Busca en la tienda de tu teléfono si\n"
-"  no tienes ninguno.)"
 
 #: src/olympia/addons/templates/addons/report_abuse.html:6 src/olympia/addons/templates/addons/report_abuse_full.html:10 src/olympia/addons/templates/addons/impala/details-more.html:23
-#: src/olympia/addons/templates/addons/impala/details.html:328
+#: src/olympia/addons/templates/addons/impala/details.html:333
 msgid "Report Abuse"
 msgstr "Informar de uso indebido"
 
@@ -855,9 +850,9 @@ msgstr "Enviar informe"
 #: src/olympia/devhub/templates/devhub/addons/ajax_compat_update.html:36 src/olympia/devhub/templates/devhub/addons/profile.html:44 src/olympia/devhub/templates/devhub/addons/edit/admin.html:104
 #: src/olympia/devhub/templates/devhub/addons/edit/basic.html:155 src/olympia/devhub/templates/devhub/addons/edit/details.html:88 src/olympia/devhub/templates/devhub/addons/edit/support.html:70
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:169 src/olympia/devhub/templates/devhub/addons/forms_shared/media.html:152
-#: src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:44 src/olympia/devhub/templates/devhub/personas/edit.html:222 src/olympia/devhub/templates/devhub/versions/add_file_modal.html:79
-#: src/olympia/devhub/templates/devhub/versions/edit.html:140 src/olympia/devhub/templates/devhub/versions/list.html:208 src/olympia/devhub/templates/devhub/versions/list.html:242
-#: src/olympia/devhub/templates/devhub/versions/list.html:276 src/olympia/devhub/templates/devhub/versions/list.html:317 src/olympia/reviews/templates/reviews/edit_review.html:16
+#: src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:43 src/olympia/devhub/templates/devhub/personas/edit.html:222 src/olympia/devhub/templates/devhub/versions/add_file_modal.html:59
+#: src/olympia/devhub/templates/devhub/versions/edit.html:140 src/olympia/devhub/templates/devhub/versions/list.html:208 src/olympia/devhub/templates/devhub/versions/list.html:239
+#: src/olympia/devhub/templates/devhub/versions/list.html:281 src/olympia/devhub/templates/devhub/versions/list.html:315 src/olympia/reviews/templates/reviews/edit_review.html:16
 #: src/olympia/translations/templates/translations/trans-menu.html:50 src/olympia/translations/templates/translations/trans-menu.html:62 src/olympia/zadmin/templates/zadmin/validation.html:105
 msgid "Cancel"
 msgstr "Cancelar"
@@ -904,7 +899,7 @@ msgstr "Ver la <a href=\"%(support)s\">sección de asistencia</a> para averiguar
 msgid "Review Guidelines"
 msgstr "Pautas sobre valoraciones"
 
-#: src/olympia/addons/templates/addons/review_list_box.html:5 src/olympia/addons/templates/addons/impala/details-more.html:27 src/olympia/editors/helpers.py:921
+#: src/olympia/addons/templates/addons/review_list_box.html:5 src/olympia/addons/templates/addons/impala/details-more.html:27 src/olympia/editors/helpers.py:1001
 #: src/olympia/reviews/templates/reviews/add.html:14 src/olympia/reviews/templates/reviews/reply.html:14 src/olympia/reviews/templates/reviews/review_list.html:19
 #: src/olympia/reviews/templates/reviews/mobile/review_list.html:26
 msgid "Reviews"
@@ -995,31 +990,31 @@ msgid_plural "Other add-ons by these authors"
 msgstr[0] "Otros complementos de %(author)s"
 msgstr[1] "Otros complementos de estos autores"
 
-#: src/olympia/addons/templates/addons/impala/details.html:41
+#: src/olympia/addons/templates/addons/impala/details.html:39
 #, python-format
 msgid "<span itemprop=\"ratingCount\">%(num)s</span> user review"
 msgid_plural "<span itemprop=\"ratingCount\">%(num)s</span> user reviews"
 msgstr[0] "<span itemprop=\"ratingCount\">%(num)s</span> valoración de los usuarios"
 msgstr[1] "<span itemprop=\"ratingCount\">%(num)s</span> valoraciones de los usuarios"
 
-#: src/olympia/addons/templates/addons/impala/details.html:69
+#: src/olympia/addons/templates/addons/impala/details.html:66
 msgid "View statistics"
 msgstr "Ver estadísticas"
 
-#: src/olympia/addons/templates/addons/impala/details.html:84
+#: src/olympia/addons/templates/addons/impala/details.html:81
 msgid "Manage"
 msgstr "Gestionar"
 
 #. {0} is an add-on name.
-#: src/olympia/addons/templates/addons/impala/details.html:96
+#: src/olympia/addons/templates/addons/impala/details.html:93
 msgid "Icon of {0}"
 msgstr "Icono de {0}"
 
-#: src/olympia/addons/templates/addons/impala/details.html:103 src/olympia/addons/templates/addons/impala/listing/items.html:14
+#: src/olympia/addons/templates/addons/impala/details.html:100 src/olympia/addons/templates/addons/impala/listing/items.html:14
 msgid "No Restart"
 msgstr "Sin reiniciar"
 
-#: src/olympia/addons/templates/addons/impala/details.html:127
+#: src/olympia/addons/templates/addons/impala/details.html:124
 #, python-format
 msgid "Meet the Developer: <a href=\"%(url)s\">%(name)s</a>"
 msgid_plural "<a href=\"%(url)s\">Meet the Developers</a>"
@@ -1027,72 +1022,72 @@ msgstr[0] "Conoce al desarrollador: <a href=\"%(url)s\">%(name)s</a>"
 msgstr[1] "<a href=\"%(url)s\">Conoce a los desarrolladores</a>"
 
 # {0} is an add-on name.
-#: src/olympia/addons/templates/addons/impala/details.html:137
+#: src/olympia/addons/templates/addons/impala/details.html:134
 msgid "Learn why {0} was created and find out what's next for this add-on."
 msgstr "Descubre por qué se creó {0} y cuál es el futuro de este complemento."
 
 #. {0} is an index.
-#: src/olympia/addons/templates/addons/impala/details.html:156
+#: src/olympia/addons/templates/addons/impala/details.html:161
 msgid "Add-on screenshot #{0}"
 msgstr "Captura de pantalla nº {0} del complemento"
 
-#: src/olympia/addons/templates/addons/impala/details.html:182
+#: src/olympia/addons/templates/addons/impala/details.html:187
 msgid "Add-on home page"
 msgstr "Página principal del complemento"
 
-#: src/olympia/addons/templates/addons/impala/details.html:185
+#: src/olympia/addons/templates/addons/impala/details.html:190
 msgid "Support site"
 msgstr "Sitio de asistencia"
 
-#: src/olympia/addons/templates/addons/impala/details.html:189
+#: src/olympia/addons/templates/addons/impala/details.html:194
 msgid "Support E-mail"
 msgstr "Correo de soporte"
 
-#: src/olympia/addons/templates/addons/impala/details.html:194 src/olympia/devhub/models.py:378 src/olympia/devhub/templates/devhub/versions/list.html:12
+#: src/olympia/addons/templates/addons/impala/details.html:199 src/olympia/devhub/models.py:378 src/olympia/devhub/templates/devhub/versions/list.html:12
 #: src/olympia/versions/templates/versions/version.html:6 src/olympia/versions/templates/versions/mobile/version.html:6
 msgid "Version {0}"
 msgstr "Versión {0}"
 
-#: src/olympia/addons/templates/addons/impala/details.html:194
+#: src/olympia/addons/templates/addons/impala/details.html:199
 msgid "Info"
 msgstr "Información"
 
-#: src/olympia/addons/templates/addons/impala/details.html:195 src/olympia/devhub/templates/devhub/includes/addon_details.html:129
+#: src/olympia/addons/templates/addons/impala/details.html:200 src/olympia/devhub/templates/devhub/includes/addon_details.html:116
 msgid "Last Updated:"
 msgstr "Última actualización:"
 
-#: src/olympia/addons/templates/addons/impala/details.html:200
+#: src/olympia/addons/templates/addons/impala/details.html:205
 #, python-format
 msgid "Released under <a target=\"_blank\" href=\"%(url)s\">%(name)s</a>"
 msgstr "Publicado bajo <a target=\"_blank\" href=\"%(url)s\">%(name)s</a>"
 
-#: src/olympia/addons/templates/addons/impala/details.html:201 src/olympia/addons/templates/addons/impala/details.html:206 src/olympia/amo/helpers.py:398 src/olympia/devhub/forms.py:142
+#: src/olympia/addons/templates/addons/impala/details.html:206 src/olympia/addons/templates/addons/impala/details.html:211 src/olympia/amo/helpers.py:398 src/olympia/devhub/forms.py:142
 #: src/olympia/devhub/forms.py:173 src/olympia/versions/templates/versions/version.html:40 src/olympia/versions/templates/versions/version.html:45
 msgid "Custom License"
 msgstr "Licencia personalizada"
 
-#: src/olympia/addons/templates/addons/impala/details.html:205
+#: src/olympia/addons/templates/addons/impala/details.html:210
 #, python-format
 msgid "Released under <a href=\"%(url)s\">%(name)s</a>"
 msgstr "Publicado bajo <a href=\"%(url)s\">%(name)s</a>"
 
-#: src/olympia/addons/templates/addons/impala/details.html:217
+#: src/olympia/addons/templates/addons/impala/details.html:222
 msgid "About this Add-on"
 msgstr "Acerca de este complemento"
 
-#: src/olympia/addons/templates/addons/impala/details.html:233
+#: src/olympia/addons/templates/addons/impala/details.html:238
 msgid "Developer’s Comments"
 msgstr "Comentarios de los desarrolladores"
 
-#: src/olympia/addons/templates/addons/impala/details.html:243
+#: src/olympia/addons/templates/addons/impala/details.html:248
 msgid "Version Information"
 msgstr "Información de la versión"
 
-#: src/olympia/addons/templates/addons/impala/details.html:250
+#: src/olympia/addons/templates/addons/impala/details.html:255
 msgid "See complete version history"
 msgstr "Ver el historial completo de versiones"
 
-#: src/olympia/addons/templates/addons/impala/details.html:262
+#: src/olympia/addons/templates/addons/impala/details.html:267
 msgid ""
 "The Development Channel lets you test an experimental new version of this add-on before it's released to the general public. Once you install the development version, you will continue to get "
 "updates from this channel. To stop receiving development updates, reinstall the default version from the link above."
@@ -1100,17 +1095,17 @@ msgstr ""
 "El canal de desarrollo te permite probar una nueva versión experimental de este complemento antes de su lanzamiento al público en general. Una vez que instales la versión de desarrollo, seguirás "
 "recibiendo actualizaciones de este canal. Para dejar de recibir actualizaciones de desarrollo, reinstala la versión predeterminada desde el enlace anterior."
 
-#: src/olympia/addons/templates/addons/impala/details.html:272
+#: src/olympia/addons/templates/addons/impala/details.html:277
 msgid "<strong>Caution:</strong> Development versions of this add-on have not been reviewed by Mozilla."
 msgstr "<strong>Precaución:</strong> las versiones de desarrollo de este complemento no han sido revisadas por Mozilla."
 
-#: src/olympia/addons/templates/addons/impala/details.html:287
+#: src/olympia/addons/templates/addons/impala/details.html:292
 msgid "See complete development channel history"
 msgstr "Ver el historial completo del canal de desarrollo"
 
-#: src/olympia/addons/templates/addons/impala/details.html:306 src/olympia/addons/templates/addons/impala/details.html:315 src/olympia/addons/templates/addons/impala/details.html:327
+#: src/olympia/addons/templates/addons/impala/details.html:311 src/olympia/addons/templates/addons/impala/details.html:320 src/olympia/addons/templates/addons/impala/details.html:332
 #: src/olympia/addons/templates/addons/impala/review_add_box.html:4 src/olympia/stats/templates/stats/popup.html:2 src/olympia/stats/templates/stats/popup.html:8
-#: src/olympia/stats/templates/stats/stats.html:202 src/olympia/users/templates/users/profile.html:119
+#: src/olympia/stats/templates/stats/stats.html:204 src/olympia/users/templates/users/profile.html:119
 msgid "close"
 msgstr "cerrar"
 
@@ -1169,15 +1164,11 @@ msgstr "Licencia de código abierto para {addon}"
 msgid "Source Code License"
 msgstr "Licencia del código fuente"
 
-#: src/olympia/addons/templates/addons/impala/persona_grid.html:16 src/olympia/addons/templates/addons/impala/toplist.html:6
-msgid "{0} users"
-msgstr "{0} usuarios"
-
 #: src/olympia/addons/templates/addons/impala/review_list_box.html:19 src/olympia/reviews/templates/reviews/review.html:40
 msgid "permalink"
 msgstr "enlace permanente"
 
-#: src/olympia/addons/templates/addons/impala/review_list_box.html:23 src/olympia/editors/templates/editors/queue.html:98 src/olympia/reviews/templates/reviews/review.html:44
+#: src/olympia/addons/templates/addons/impala/review_list_box.html:23 src/olympia/editors/templates/editors/queue.html:104 src/olympia/reviews/templates/reviews/review.html:44
 msgid "translate"
 msgstr "traducir"
 
@@ -1196,6 +1187,10 @@ msgstr "Este complemento no ha sido valorado aún."
 msgid "Be the first!"
 msgstr "¡Sé el primero!"
 
+#: src/olympia/addons/templates/addons/impala/toplist.html:6
+msgid "{0} users"
+msgstr "{0} usuarios"
+
 #: src/olympia/addons/templates/addons/impala/listing/sorter.html:14 src/olympia/devhub/templates/devhub/addons/listing/item_actions.html:49
 msgid "More"
 msgstr "Más"
@@ -1208,7 +1203,7 @@ msgstr "Agregar a una colección"
 msgid "My Add-ons"
 msgstr "Mis complementos"
 
-#: src/olympia/addons/templates/addons/includes/dashboard_tabs.html:6 src/olympia/amo/context_processors.py:51
+#: src/olympia/addons/templates/addons/includes/dashboard_tabs.html:6 src/olympia/amo/context_processors.py:50
 msgid "My Themes"
 msgstr "Mis temas"
 
@@ -1263,7 +1258,7 @@ msgstr "Usuarios"
 msgid "Weekly Downloads"
 msgstr "Descargas semanales"
 
-#: src/olympia/addons/templates/addons/mobile/details.html:99 src/olympia/compat/templates/compat/reporter_detail.html:46 src/olympia/devhub/forms.py:787
+#: src/olympia/addons/templates/addons/mobile/details.html:99 src/olympia/compat/templates/compat/reporter_detail.html:46 src/olympia/devhub/forms.py:788
 #: src/olympia/devhub/templates/devhub/versions/list.html:163
 msgid "Version"
 msgstr "Versión"
@@ -1350,7 +1345,7 @@ msgstr ""
 #: src/olympia/browse/templates/browse/personas/category_landing.html:21 src/olympia/browse/templates/browse/personas/category_landing.html:23
 #: src/olympia/browse/templates/browse/personas/category_landing.html:38 src/olympia/browse/templates/browse/personas/grid.html:7 src/olympia/browse/templates/browse/personas/grid.html:11
 #: src/olympia/browse/templates/browse/personas/mobile/base.html:7 src/olympia/browse/templates/browse/personas/mobile/category_landing.html:19 src/olympia/constants/base.py:180
-#: src/olympia/devhub/templates/devhub/personas/submit.html:13 src/olympia/editors/helpers.py:105 src/olympia/editors/templates/editors/base.html:26
+#: src/olympia/devhub/templates/devhub/personas/submit.html:13 src/olympia/editors/helpers.py:107 src/olympia/editors/templates/editors/base.html:26
 #: src/olympia/editors/templates/editors/performance.html:73 src/olympia/search/templates/search/personas.html:39 src/olympia/templates/menu_links.html:9
 msgid "Themes"
 msgstr "Temas"
@@ -1373,7 +1368,7 @@ msgstr "Más complementos"
 msgid "Highest Rated"
 msgstr "Mejor puntuados"
 
-#: src/olympia/addons/templates/addons/mobile/home.html:74 src/olympia/amo/templates/amo/side_nav.html:5 src/olympia/amo/templates/amo/site_nav.html:27 src/olympia/amo/templates/amo/site_nav.html:57
+#: src/olympia/addons/templates/addons/mobile/home.html:74 src/olympia/amo/templates/amo/side_nav.html:5 src/olympia/amo/templates/amo/site_nav.html:27 src/olympia/amo/templates/amo/site_nav.html:55
 #: src/olympia/bandwagon/views.py:97 src/olympia/browse/views.py:57 src/olympia/browse/views.py:67 src/olympia/browse/templates/browse/personas/mobile/category_landing.html:65
 #: src/olympia/search/forms.py:15 src/olympia/search/forms.py:87
 msgid "Newest"
@@ -1387,90 +1382,90 @@ msgstr "¡Pruébalo!"
 msgid "Theme Info &raquo;"
 msgstr "Info sobre el tema &raquo;"
 
-#: src/olympia/amo/context_processors.py:39 src/olympia/devhub/templates/devhub/nav.html:43
+#: src/olympia/amo/context_processors.py:37 src/olympia/devhub/templates/devhub/nav.html:43
 msgid "Tools"
 msgstr "Herramientas"
 
-#: src/olympia/amo/context_processors.py:48 src/olympia/discovery/templates/discovery/pane_account.html:8 src/olympia/users/templates/users/includes/navigation.html:2
+#: src/olympia/amo/context_processors.py:47 src/olympia/discovery/templates/discovery/pane_account.html:8 src/olympia/users/templates/users/includes/navigation.html:2
 msgid "My Profile"
 msgstr "Mi perfil"
 
-#: src/olympia/amo/context_processors.py:54 src/olympia/users/templates/users/edit.html:5 src/olympia/users/templates/users/includes/navigation.html:3
+#: src/olympia/amo/context_processors.py:53 src/olympia/users/templates/users/edit.html:5 src/olympia/users/templates/users/includes/navigation.html:3
 msgid "Account Settings"
 msgstr "Preferencias de la cuenta"
 
-#: src/olympia/amo/context_processors.py:57 src/olympia/discovery/templates/discovery/pane_account.html:11 src/olympia/users/templates/users/profile.html:83
+#: src/olympia/amo/context_processors.py:56 src/olympia/discovery/templates/discovery/pane_account.html:11 src/olympia/users/templates/users/profile.html:83
 #: src/olympia/users/templates/users/includes/navigation.html:4
 msgid "My Collections"
 msgstr "Mis colecciones"
 
-#: src/olympia/amo/context_processors.py:62 src/olympia/discovery/templates/discovery/pane_account.html:10 src/olympia/users/templates/users/includes/navigation.html:7
+#: src/olympia/amo/context_processors.py:61 src/olympia/discovery/templates/discovery/pane_account.html:10 src/olympia/users/templates/users/includes/navigation.html:7
 msgid "My Favorites"
 msgstr "Mis favoritos"
 
-#: src/olympia/amo/context_processors.py:67 src/olympia/discovery/templates/discovery/pane_account.html:13 src/olympia/templates/impala/user_login.html:14
+#: src/olympia/amo/context_processors.py:66 src/olympia/discovery/templates/discovery/pane_account.html:13 src/olympia/templates/impala/user_login.html:14
 #: src/olympia/templates/mobile/header_auth.html:5
 msgid "Log out"
 msgstr "Salir"
 
-#: src/olympia/amo/context_processors.py:72 src/olympia/devhub/templates/devhub/addons/dashboard.html:4
+#: src/olympia/amo/context_processors.py:71 src/olympia/devhub/templates/devhub/addons/dashboard.html:4
 msgid "Manage My Submissions"
 msgstr "Administrar mis envíos"
 
-#: src/olympia/amo/context_processors.py:75 src/olympia/devhub/templates/devhub/nav.html:27 src/olympia/devhub/templates/devhub/addons/dashboard.html:25
+#: src/olympia/amo/context_processors.py:74 src/olympia/devhub/templates/devhub/nav.html:27 src/olympia/devhub/templates/devhub/addons/dashboard.html:25
 #: src/olympia/devhub/templates/devhub/addons/submit/base.html:4
 msgid "Submit a New Add-on"
 msgstr "Envía un nuevo complemento"
 
-#: src/olympia/amo/context_processors.py:77 src/olympia/browse/templates/browse/personas/base.html:50 src/olympia/devhub/templates/devhub/index.html:24
+#: src/olympia/amo/context_processors.py:76 src/olympia/browse/templates/browse/personas/base.html:50 src/olympia/devhub/templates/devhub/index.html:24
 #: src/olympia/devhub/templates/devhub/addons/dashboard.html:29
 msgid "Submit a New Theme"
 msgstr "Enviar un nuevo tema"
 
-#: src/olympia/amo/context_processors.py:79 src/olympia/amo/templates/amo/site_nav.html:87 src/olympia/devhub/helpers.py:36 src/olympia/devhub/helpers.py:68 src/olympia/devhub/helpers.py:102
+#: src/olympia/amo/context_processors.py:78 src/olympia/amo/templates/amo/site_nav.html:85 src/olympia/devhub/helpers.py:36 src/olympia/devhub/helpers.py:68 src/olympia/devhub/helpers.py:102
 #: src/olympia/templates/footer.html:6 src/olympia/templates/menu_links.html:14
 msgid "Developer Hub"
 msgstr "Centro de Desarrolladores"
 
-#: src/olympia/amo/context_processors.py:83 src/olympia/devhub/views.py:1792
+#: src/olympia/amo/context_processors.py:81 src/olympia/devhub/views.py:1796
 msgid "Manage API Keys"
 msgstr "Administrar llaves API"
 
-#: src/olympia/amo/context_processors.py:88 src/olympia/editors/helpers.py:82 src/olympia/editors/helpers.py:102 src/olympia/editors/templates/editors/base.html:10
+#: src/olympia/amo/context_processors.py:86 src/olympia/editors/helpers.py:84 src/olympia/editors/helpers.py:104 src/olympia/editors/templates/editors/base.html:10
 msgid "Editor Tools"
 msgstr "Herramientas del editor"
 
-#: src/olympia/amo/context_processors.py:92
+#: src/olympia/amo/context_processors.py:90
 msgid "Admin Tools"
 msgstr "Herramientas de administrador"
 
-#: src/olympia/amo/fields.py:15
+#: src/olympia/amo/fields.py:20
 msgid "Incorrect, please try again."
 msgstr "Incorrecto, inténtelo de nuevo."
 
-#: src/olympia/amo/fields.py:16
+#: src/olympia/amo/fields.py:21
 msgid "Error verifying input, please try again."
 msgstr "Error al comprobar los datos, inténtelo de nuevo."
 
-#: src/olympia/amo/fields.py:32
+#: src/olympia/amo/fields.py:37
 msgid "This must be a valid hex color code, such as #000000."
 msgstr "Esto debe ser un código de color hexadecimal válido, tal como #000000."
 
-#: src/olympia/amo/fields.py:58
+#: src/olympia/amo/fields.py:63
 msgid "Enter at least one value."
 msgstr "Escribe al menos un valor."
 
-#: src/olympia/amo/helpers.py:162 src/olympia/amo/templates/amo/site_nav.html:61 src/olympia/bandwagon/templates/bandwagon/add.html:9
+#: src/olympia/amo/helpers.py:162 src/olympia/amo/templates/amo/site_nav.html:59 src/olympia/bandwagon/templates/bandwagon/add.html:9
 #: src/olympia/bandwagon/templates/bandwagon/collection_detail.html:15 src/olympia/bandwagon/templates/bandwagon/delete.html:9 src/olympia/bandwagon/templates/bandwagon/edit.html:15
 #: src/olympia/bandwagon/templates/bandwagon/user_listing.html:18 src/olympia/bandwagon/templates/bandwagon/user_listing.html:21
 #: src/olympia/bandwagon/templates/bandwagon/impala/collection_listing.html:12 src/olympia/bandwagon/templates/bandwagon/impala/collection_listing.html:20
 #: src/olympia/bandwagon/templates/bandwagon/impala/collection_listing.html:24 src/olympia/bandwagon/templates/bandwagon/impala/collection_sidebar.html:3
 #: src/olympia/bandwagon/templates/bandwagon/includes/collection_sidebar.html:2 src/olympia/bandwagon/templates/bandwagon/mobile/collection_listing.html:3
-#: src/olympia/stats/templates/stats/stats.html:77 src/olympia/templates/menu_links.html:12
+#: src/olympia/stats/templates/stats/stats.html:33 src/olympia/templates/menu_links.html:12
 msgid "Collections"
 msgstr "Colecciones"
 
-#: src/olympia/amo/helpers.py:171 src/olympia/amo/templates/amo/site_nav.html:85 src/olympia/browse/templates/browse/language_tools.html:3
+#: src/olympia/amo/helpers.py:171 src/olympia/amo/templates/amo/site_nav.html:83 src/olympia/browse/templates/browse/language_tools.html:3
 msgid "Dictionaries & Language Packs"
 msgstr "Diccionarios y paquetes de idioma"
 
@@ -1622,8 +1617,8 @@ msgstr "Solicitada superrevisión"
 msgid "Comment on {addon} {version}."
 msgstr "Comentario en {addon} {version}."
 
-#: src/olympia/amo/log.py:236 src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:19 src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:47
-#: src/olympia/editors/helpers.py:511 src/olympia/editors/templates/editors/themes/history_table.html:11
+#: src/olympia/amo/log.py:236 src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:17 src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:45
+#: src/olympia/editors/helpers.py:584 src/olympia/editors/templates/editors/themes/history_table.html:11
 msgid "Comment"
 msgstr "Comentario"
 
@@ -1777,7 +1772,7 @@ msgstr "Remisión de incidencias del revisor"
 
 #: src/olympia/amo/log.py:442
 msgid "Video removed from {addon} because of a problem with the video. "
-msgstr "El video de {addon} tenía un problema y se ha eliminado."
+msgstr ""
 
 #: src/olympia/amo/log.py:444
 msgid "Video removed"
@@ -1930,7 +1925,7 @@ msgstr "Vaya"
 #: src/olympia/amo/templates/amo/500.html:6
 #, python-format
 msgid "<h1>Oops!  We had an error.</h1> <p>We'll get to fixing that soon.</p> <p> You can try refreshing the page, or head back to the <a href=\"%(home)s\">Add-ons homepage</a>. </p>"
-msgstr "<h1>¡Ups!  Hubo un error.</h1> <p>Lo solucionaremos lo antes posible.</p> <p> Prueba a actualizar la página o volver a la <a href=\"%(home)s\">página de inicio de Complementos</a>. </p>"
+msgstr ""
 
 #: src/olympia/amo/templates/amo/license_link.html:10
 msgid "Some rights reserved"
@@ -1952,7 +1947,7 @@ msgstr "Anterior"
 #: src/olympia/amo/templates/amo/mobile/paginator.html:14 src/olympia/amo/templates/amo/mobile/paginator.html:16 src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:51
 #: src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:65 src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:78
 #: src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:91 src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:104
-#: src/olympia/discovery/templates/discovery/pane.html:45 src/olympia/discovery/templates/discovery/addons/detail.html:39 src/olympia/stats/templates/stats/stats.html:167
+#: src/olympia/discovery/templates/discovery/pane.html:45 src/olympia/discovery/templates/discovery/addons/detail.html:39 src/olympia/stats/templates/stats/stats.html:169
 msgid "Next"
 msgstr "Siguiente"
 
@@ -1986,7 +1981,7 @@ msgstr ""
 "\"recaptcha_different\">probar con otras palabras</a> o <a href=\"#\" id=\"recaptcha_audio\">probar otro tipo de reto</a>. </p>"
 
 #: src/olympia/amo/templates/amo/side_nav.html:4 src/olympia/amo/templates/amo/side_nav.html:12 src/olympia/amo/templates/amo/site_nav.html:4 src/olympia/amo/templates/amo/site_nav.html:26
-#: src/olympia/browse/views.py:56 src/olympia/browse/views.py:66 src/olympia/browse/views.py:237 src/olympia/browse/views.py:282 src/olympia/search/forms.py:86
+#: src/olympia/browse/views.py:56 src/olympia/browse/views.py:66 src/olympia/browse/views.py:204 src/olympia/browse/views.py:249 src/olympia/search/forms.py:86
 msgid "Top Rated"
 msgstr "Mejor puntuados"
 
@@ -2001,38 +1996,38 @@ msgstr "Explorar"
 msgid "Extensions"
 msgstr "Extensiones"
 
-#: src/olympia/amo/templates/amo/site_nav.html:45
+#: src/olympia/amo/templates/amo/site_nav.html:44
 msgid "Want more customization? Try <b>Complete Themes</b>"
 msgstr "¿Quieres personalizarlo más? Prueba <b>todos los temas</b>"
 
-#: src/olympia/amo/templates/amo/site_nav.html:56 src/olympia/bandwagon/views.py:96
+#: src/olympia/amo/templates/amo/site_nav.html:54 src/olympia/bandwagon/views.py:96
 msgid "Most Followers"
 msgstr "Con más seguidores"
 
-#: src/olympia/amo/templates/amo/site_nav.html:68 src/olympia/bandwagon/templates/bandwagon/impala/collection_sidebar.html:16
+#: src/olympia/amo/templates/amo/site_nav.html:66 src/olympia/bandwagon/templates/bandwagon/impala/collection_sidebar.html:16
 #: src/olympia/bandwagon/templates/bandwagon/includes/collection_sidebar.html:18
 msgid "Collections I've Made"
 msgstr "Colecciones mías"
 
-#: src/olympia/amo/templates/amo/site_nav.html:70 src/olympia/bandwagon/templates/bandwagon/user_listing.html:4 src/olympia/bandwagon/templates/bandwagon/impala/collection_sidebar.html:13
+#: src/olympia/amo/templates/amo/site_nav.html:68 src/olympia/bandwagon/templates/bandwagon/user_listing.html:4 src/olympia/bandwagon/templates/bandwagon/impala/collection_sidebar.html:13
 #: src/olympia/bandwagon/templates/bandwagon/includes/collection_sidebar.html:15
 msgid "Collections I'm Following"
 msgstr "Colecciones que sigo"
 
-#: src/olympia/amo/templates/amo/site_nav.html:73 src/olympia/bandwagon/templates/bandwagon/impala/collection_sidebar.html:18
-#: src/olympia/bandwagon/templates/bandwagon/includes/collection_sidebar.html:20 src/olympia/users/models.py:512
+#: src/olympia/amo/templates/amo/site_nav.html:71 src/olympia/bandwagon/templates/bandwagon/impala/collection_sidebar.html:18
+#: src/olympia/bandwagon/templates/bandwagon/includes/collection_sidebar.html:20 src/olympia/users/models.py:521
 msgid "My Favorite Add-ons"
 msgstr "Mis complementos favoritos"
 
-#: src/olympia/amo/templates/amo/site_nav.html:78
+#: src/olympia/amo/templates/amo/site_nav.html:76
 msgid "More&hellip;"
 msgstr "Más&hellip;"
 
-#: src/olympia/amo/templates/amo/site_nav.html:82
+#: src/olympia/amo/templates/amo/site_nav.html:80
 msgid "Add-ons for Mobile"
 msgstr "Complementos para Mobile"
 
-#: src/olympia/amo/templates/amo/site_nav.html:86 src/olympia/browse/feeds.py:207 src/olympia/browse/templates/browse/search_tools.html:3 src/olympia/constants/base.py:176
+#: src/olympia/amo/templates/amo/site_nav.html:84 src/olympia/browse/feeds.py:207 src/olympia/browse/templates/browse/search_tools.html:3 src/olympia/constants/base.py:176
 #: src/olympia/templates/menu_links.html:10
 msgid "Search Tools"
 msgstr "Herramientas de búsqueda"
@@ -2048,7 +2043,7 @@ msgid "Jump to first page"
 msgstr "Saltar a la primera página"
 
 #: src/olympia/amo/templates/amo/impala/paginator.html:22 src/olympia/amo/templates/amo/mobile/impala_paginator.html:12 src/olympia/discovery/templates/discovery/pane.html:44
-#: src/olympia/discovery/templates/discovery/addons/detail.html:38 src/olympia/stats/templates/stats/stats.html:164
+#: src/olympia/discovery/templates/discovery/addons/detail.html:38 src/olympia/stats/templates/stats/stats.html:166
 msgid "Previous"
 msgstr "Anterior"
 
@@ -2058,7 +2053,7 @@ msgstr "Saltar a la última página"
 
 #. First and second arguments are the result range (e.g., 1-20);
 #. third argument is the number of total results (e.g., 1,000).
-#. third
+#. First and second arguments are the result range (e.g., 1-20);              third
 #. argument is the number of total results (e.g., 1,000).
 #: src/olympia/amo/templates/amo/impala/paginator.html:36 src/olympia/amo/templates/amo/mobile/impala_paginator.html:38
 #, python-format
@@ -2071,31 +2066,50 @@ msgid_plural "Page {n}"
 msgstr[0] "Página {n}"
 msgstr[1] "Página {n}"
 
-#: src/olympia/amo/templates/services/install.html:38
-#, python-format
-msgid "If you are not prompted to install %(addon_name)s in a moment, please <a href=\"%(addon_xpi)s\">click here</a>."
-msgstr "Si en un momento no se muestra un aviso para instalar %(addon_name)s, <a href=\"%(addon_xpi)s\">haz clic aquí</a>."
-
-#: src/olympia/amo/tests/test_messages.py:57 src/olympia/amo/tests/test_messages.py:58 src/olympia/reviews/forms.py:25 src/olympia/reviews/forms.py:50 src/olympia/reviews/templates/reviews/add.html:56
+#: src/olympia/amo/tests/test_messages.py:56 src/olympia/amo/tests/test_messages.py:57 src/olympia/reviews/forms.py:25 src/olympia/reviews/forms.py:50 src/olympia/reviews/templates/reviews/add.html:56
 #: src/olympia/reviews/templates/reviews/reply.html:30
 msgid "Title"
 msgstr "Título"
 
-#: src/olympia/amo/tests/test_messages.py:57 src/olympia/amo/tests/test_messages.py:58
+#: src/olympia/amo/tests/test_messages.py:56 src/olympia/amo/tests/test_messages.py:57
 msgid "Body"
 msgstr "Cuerpo"
 
-#: src/olympia/amo/tests/test_messages.py:59
+#: src/olympia/amo/tests/test_messages.py:58
 msgid "Another Title"
 msgstr "Otro título"
 
-#: src/olympia/amo/tests/test_messages.py:59
+#: src/olympia/amo/tests/test_messages.py:58
 msgid "Another Body"
 msgstr "Otro cuerpo"
 
-#: src/olympia/api/views.py:255
-msgid "Not implemented yet."
-msgstr "Sin implementar aún."
+#: src/olympia/api/authentication.py:76
+msgid "Signature has expired."
+msgstr ""
+
+#: src/olympia/api/authentication.py:79
+msgid "Error decoding signature."
+msgstr ""
+
+#: src/olympia/api/authentication.py:82
+msgid "Invalid JWT Token."
+msgstr ""
+
+#: src/olympia/api/authentication.py:130
+msgid "Invalid Authorization header. No credentials provided."
+msgstr ""
+
+#: src/olympia/api/authentication.py:133
+msgid "Invalid Authorization header. Credentials string should not contain spaces."
+msgstr ""
+
+#: src/olympia/api/fields.py:29
+msgid "The field must have a length of at least {num} characters."
+msgstr ""
+
+#: src/olympia/api/fields.py:31
+msgid "The language code {lang_code} is invalid."
+msgstr ""
 
 #: src/olympia/applications/views.py:39 src/olympia/applications/templates/applications/appversions.html:3
 msgid "Application Versions"
@@ -2115,7 +2129,7 @@ msgstr ""
 "Los complementos enviados a Mozilla Add-ons deben tener un archivo de manifiesto con al menos una de las siguientes aplicaciones compatibles. Sólo se admiten las versiones listadas a continuación "
 "para estas aplicaciones."
 
-#: src/olympia/applications/templates/applications/appversions.html:25
+#: src/olympia/applications/templates/applications/appversions.html:25 src/olympia/editors/helpers.py:361
 msgid "GUID"
 msgstr "GUID"
 
@@ -2231,8 +2245,8 @@ msgstr "Favorito"
 msgid "Remove from favorites"
 msgstr "Eliminar de favoritos"
 
-#: src/olympia/bandwagon/views.py:98 src/olympia/bandwagon/views.py:191 src/olympia/browse/views.py:58 src/olympia/browse/views.py:69 src/olympia/browse/views.py:458 src/olympia/devhub/views.py:74
-#: src/olympia/devhub/views.py:82 src/olympia/devhub/templates/devhub/addons/edit/basic.html:20 src/olympia/editors/templates/editors/leaderboard.html:24
+#: src/olympia/bandwagon/views.py:98 src/olympia/bandwagon/views.py:191 src/olympia/browse/views.py:58 src/olympia/browse/views.py:69 src/olympia/browse/views.py:425 src/olympia/devhub/views.py:72
+#: src/olympia/devhub/views.py:80 src/olympia/devhub/templates/devhub/addons/edit/basic.html:20 src/olympia/editors/templates/editors/leaderboard.html:24
 #: src/olympia/editors/templates/editors/themes/queue_list.html:48 src/olympia/search/forms.py:17 src/olympia/search/forms.py:89 src/olympia/users/templates/users/vcard.html:5
 msgid "Name"
 msgstr "Nombre"
@@ -2241,7 +2255,7 @@ msgstr "Nombre"
 msgid "Recently Popular"
 msgstr "Populares recientemente"
 
-#: src/olympia/bandwagon/views.py:189 src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:18
+#: src/olympia/bandwagon/views.py:189 src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:16
 msgid "Added"
 msgstr "Añadido"
 
@@ -2255,8 +2269,8 @@ msgstr "¡Se ha creado la colección!"
 
 #: src/olympia/bandwagon/views.py:316
 #, python-format
-msgid "Your new collection is shown below. You can <ahref=\"%(url)s\">edit additional settings</a> if you'dlike."
-msgstr "Tu nueva colección aparece más abajo. Si quieres, puedes <ahref=\"%(url)s\">editar ajustes adicionales</a>."
+msgid "Your new collection is shown below. You can <a href=\"%(url)s\">edit additional settings</a> if you'd like."
+msgstr ""
 
 #: src/olympia/bandwagon/views.py:322
 msgid "Collection updated!"
@@ -2383,8 +2397,8 @@ msgid_plural "%(num)s Add-ons in this Collection"
 msgstr[0] "%(num)s complemento en esta colección"
 msgstr[1] "%(num)s complementos en esta colección"
 
-#: src/olympia/bandwagon/templates/bandwagon/collection_detail.html:125 src/olympia/compat/templates/compat/index.html:25 src/olympia/compat/templates/compat/reporter_detail.html:29
-#: src/olympia/files/templates/files/viewer.html:29 src/olympia/templates/amo_footer.html:17 src/olympia/templates/includes/lang_switcher.html:10
+#: src/olympia/bandwagon/templates/bandwagon/collection_detail.html:125 src/olympia/compat/templates/compat/reporter_detail.html:29 src/olympia/files/templates/files/viewer.html:29
+#: src/olympia/templates/amo_footer.html:17 src/olympia/templates/includes/lang_switcher.html:10
 msgid "Go"
 msgstr "Ir"
 
@@ -2421,8 +2435,6 @@ msgid ""
 "Add-ons that you mark as favorites using the <b>Add to Favorites</b> feature appear below. This collection is currently <b>private</b>, which means only you can see it.  If you would like everyone "
 "to be able to see your favorites, click the button below to make it public."
 msgstr ""
-"Los complementos que marcas como favoritos con la opción <b>Agregar a favoritos</b> aparecen más abajo. Esta colección es <b>privada</b>, por lo que solo tú puedes verla.  Si quieres que todo el "
-"mundo vea tus favoritos, haz clic en el botón de abajo para hacerlos públicos."
 
 #: src/olympia/bandwagon/templates/bandwagon/collection_detail.html:196
 msgid "My favorite add-ons"
@@ -2442,9 +2454,9 @@ msgid_plural "<span>%(followers)s</span> followers"
 msgstr[0] "<span>%(followers)s</span> seguidor"
 msgstr[1] "<span>%(followers)s</span> seguidores"
 
-#. People "follow" collections to get notified of updates.
-#. Like
+#. People "follow" collections to get notified of updates.                    Like
 #. Twitter followers.
+#. People "follow" collections to get notified of updates.
 #. Like Twitter followers.
 #: src/olympia/bandwagon/templates/bandwagon/collection_listing_items.html:10 src/olympia/bandwagon/templates/bandwagon/impala/collection_listing_items.html:18
 #, python-format
@@ -2453,8 +2465,7 @@ msgid_plural "%(num)s weekly followers"
 msgstr[0] "%(num)s seguidor semanal"
 msgstr[1] "%(num)s seguidores semanales"
 
-#. People "follow" collections to get notified of updates.
-#. Like
+#. People "follow" collections to get notified of updates.                    Like
 #. Twitter followers.
 #: src/olympia/bandwagon/templates/bandwagon/collection_listing_items.html:18
 #, python-format
@@ -2463,9 +2474,9 @@ msgid_plural "%(num)s monthly followers"
 msgstr[0] "%(num)s seguidor al mes"
 msgstr[1] "%(num)s seguidores al mes"
 
-#. People "follow" collections to get notified of updates.
-#. Like
+#. People "follow" collections to get notified of updates.                    Like
 #. Twitter followers.
+#. People "follow" collections to get notified of updates.
 #. Like Twitter followers.
 #: src/olympia/bandwagon/templates/bandwagon/collection_listing_items.html:26 src/olympia/bandwagon/templates/bandwagon/impala/collection_listing_items.html:26
 #, python-format
@@ -2557,7 +2568,7 @@ msgid "Remove this user as a contributor"
 msgstr "Eliminar a este usuario como colaborador"
 
 #: src/olympia/bandwagon/templates/bandwagon/edit_contributors.html:18 src/olympia/bandwagon/templates/bandwagon/edit_contributors.html:43
-#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:20 src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:48
+#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:18 src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:46
 #: src/olympia/devhub/templates/devhub/addons/ajax_compat_update.html:19
 msgid "Remove"
 msgstr "Borrar"
@@ -2571,8 +2582,6 @@ msgid ""
 "You can add multiple contributors to this collection.  A contributor can add and remove add-ons from this collection, but cannot change its name or description.  To add a contributor, enter their "
 "email in the box below. Contributors must have a Mozilla Add-ons account."
 msgstr ""
-"Puedes agregar varios colaboradores a esta colección. Un colaborador puede agregar o eliminar complementos, pero no cambiar su nombre o descripción. Para agregar un colaborador, introduce su correo "
-"en el campo de abajo. Los colaboradores deben tener una cuenta de Mozilla Complementos."
 
 #: src/olympia/bandwagon/templates/bandwagon/edit_contributors.html:40
 msgid "User"
@@ -2608,7 +2617,7 @@ msgid "<b>Warning:</b> By changing the owner of this collection, you will no lon
 msgstr "<b>Advertencia:</b> al cambiar el propietario de esta colección, ya no podrás editarlo. Sólo podrás agregar y quitar complementos del mismo."
 
 #: src/olympia/bandwagon/templates/bandwagon/edit_contributors.html:83 src/olympia/devhub/templates/devhub/addons/forms_shared/media.html:157
-#: src/olympia/devhub/templates/devhub/addons/submit/describe.html:69 src/olympia/devhub/templates/devhub/addons/submit/license.html:60 src/olympia/devhub/templates/devhub/addons/submit/upload.html:78
+#: src/olympia/devhub/templates/devhub/addons/submit/describe.html:69 src/olympia/devhub/templates/devhub/addons/submit/license.html:60 src/olympia/devhub/templates/devhub/addons/submit/upload.html:70
 #: src/olympia/devhub/templates/devhub/payments/tier.html:17 src/olympia/editors/templates/editors/themes/themes.html:111 src/olympia/editors/templates/editors/themes/themes.html:128
 #: src/olympia/editors/templates/editors/themes/themes.html:134 src/olympia/editors/templates/editors/themes/themes.html:141 src/olympia/users/templates/users/fxa_migration_prompt_content.html:10
 #: src/olympia/users/templates/users/login_form.html:42 src/olympia/users/templates/users/mobile/login.html:57
@@ -2681,44 +2690,42 @@ msgstr "Restablecer"
 
 #: src/olympia/bandwagon/templates/bandwagon/includes/addedit.html:53
 msgid "PNG and JPG supported.  Image will be resized to 32x32."
-msgstr "Se admiten archivos PNG y JPG.  La imagen se adaptará al tamaño 32x32."
+msgstr ""
 
 #: src/olympia/bandwagon/templates/bandwagon/includes/addedit_errors.html:3
 msgid "There are errors in this form.  Please correct them below."
-msgstr "Hay errores en el formulario.  Corrígelos más abajo."
+msgstr ""
 
 #: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:2
 msgid "Add-ons in Your Collection"
 msgstr "Complementos en tu colección"
 
 #: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:4
-msgid ""
-"To include an add-on in this collection, enter its name in the box below and hit enter.  You can also use the <strong>Add to Collection</strong> links throughout the site to include add-ons later."
+msgid "To include an add-on in this collection, enter its name in the box below and hit enter."
 msgstr ""
-"Para incluir un complemento en esta colección, introduce el nombre y presiona enter. También puedes utilizar los enlaces <strong>Agregar a la Colección</strong> repartidos por la página para "
-"agregarlos más tarde."
 
-#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:17 src/olympia/constants/base.py:400 src/olympia/devhub/templates/devhub/addons/activity.html:62
+#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:15 src/olympia/constants/base.py:400 src/olympia/devhub/templates/devhub/addons/activity.html:62
+#: src/olympia/editors/helpers.py:273 src/olympia/editors/helpers.py:360
 msgid "Add-on"
 msgstr "Complemento"
 
-#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:26
+#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:24
 msgid "Enter the name of the add-on to include"
 msgstr "Introduce el nombre del complemento que vas a incluir"
 
-#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:28
+#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:26
 msgid "Add to Collection"
 msgstr "Agregar a colección"
 
-#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:45 src/olympia/editors/helpers.py:936 src/olympia/editors/helpers.py:956
+#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:43 src/olympia/editors/helpers.py:1016 src/olympia/editors/helpers.py:1036
 msgid "Pending"
 msgstr "Pendiente"
 
-#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:47
+#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:45
 msgid "Add a comment"
 msgstr "Agregar un comentario"
 
-#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:48
+#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:46
 msgid "Remove this add-on from the collection"
 msgstr "Eliminar este complemento de la colección"
 
@@ -2769,8 +2776,6 @@ msgid ""
 "When Mozilla becomes aware of add-ons, plugins, or other third-party software that seriously compromises %(app)s security, stability, or performance and meets <a href=\"%(criteria)s\">certain "
 "criteria</a>, the software may be blocked from general use.  For more information, please read <a href=\"%(support)s\">this support article</a>."
 msgstr ""
-"Cuando Mozilla detecta complementos, plugins o software de terceros que comprometen seriamente la %(app)s seguridad, estabilidad o rendimiento y cumplen <a href=\"%(criteria)s\">ciertos requisitos</"
-"a>, puede que se bloquee su uso.  Para más información, lee <a href=\"%(support)s\">este artículo de ayuda</a>."
 
 #: src/olympia/blocklist/templates/blocklist/blocked_detail.html:44
 #, python-format
@@ -2827,12 +2832,12 @@ msgstr "Buscar herramientas"
 msgid "Most Users"
 msgstr "Con más usuarios"
 
-#: src/olympia/browse/views.py:61 src/olympia/browse/views.py:72 src/olympia/browse/views.py:279 src/olympia/browse/templates/browse/personas/mobile/category_landing.html:63
+#: src/olympia/browse/views.py:61 src/olympia/browse/views.py:72 src/olympia/browse/views.py:246 src/olympia/browse/templates/browse/personas/mobile/category_landing.html:63
 #: src/olympia/discovery/templates/discovery/pane.html:67 src/olympia/search/forms.py:92
 msgid "Up & Coming"
 msgstr "Disponibles próximamente"
 
-#: src/olympia/browse/views.py:460 src/olympia/devhub/views.py:76 src/olympia/devhub/views.py:83 src/olympia/discovery/templates/discovery/addons/detail.html:66
+#: src/olympia/browse/views.py:427 src/olympia/devhub/views.py:74 src/olympia/devhub/views.py:81 src/olympia/discovery/templates/discovery/addons/detail.html:66
 msgid "Created"
 msgstr "Creadas"
 
@@ -3020,8 +3025,8 @@ msgid_plural "See all %(cnt)s extensions in %(name)s &raquo;"
 msgstr[0] "Ver la %(cnt)s extensión en %(name)s &raquo;"
 msgstr[1] "Ver las %(cnt)s extensiones en %(name)s &raquo;"
 
-#: src/olympia/browse/templates/browse/mobile/extensions.html:13 src/olympia/compat/templates/compat/index.html:82 src/olympia/devhub/templates/devhub/devhub_search.html:24
-#: src/olympia/devhub/templates/devhub/addons/activity.html:47 src/olympia/search/templates/search/no_results.html:4 src/olympia/search/templates/search/mobile/results.html:36
+#: src/olympia/browse/templates/browse/mobile/extensions.html:13 src/olympia/devhub/templates/devhub/devhub_search.html:24 src/olympia/devhub/templates/devhub/addons/activity.html:47
+#: src/olympia/search/templates/search/no_results.html:4 src/olympia/search/templates/search/mobile/results.html:36
 msgid "No results found."
 msgstr "No se ha encontrado ningún resultado."
 
@@ -3108,7 +3113,7 @@ msgstr "&laquo; Todos los temas"
 msgid "All"
 msgstr "Todos"
 
-#: src/olympia/compat/forms.py:22 src/olympia/search/views.py:525
+#: src/olympia/compat/forms.py:22 src/olympia/editors/templates/editors/base.html:69 src/olympia/search/views.py:518
 msgid "All Add-ons"
 msgstr "Todos los complementos"
 
@@ -3119,53 +3124,6 @@ msgstr "Binario"
 #: src/olympia/compat/forms.py:24
 msgid "Non-binary"
 msgstr "No binario"
-
-#. Review points sources other than add-ons and themes.
-#: src/olympia/compat/views.py:87 src/olympia/constants/base.py:388 src/olympia/devhub/forms.py:162 src/olympia/editors/templates/editors/performance.html:75
-msgid "Other"
-msgstr "Otro"
-
-#: src/olympia/compat/templates/compat/index.html:4
-msgid "Add-on Compatibility Report for {app} {version}"
-msgstr "Informe sobre compatibilidad del complemento con {app} {version}"
-
-#: src/olympia/compat/templates/compat/index.html:11
-msgid "{app} {version} Compatibility"
-msgstr "Compatibilidad con {app} {version}"
-
-#: src/olympia/compat/templates/compat/index.html:17
-#, python-format
-msgid "Top 95%% compatible with previous version"
-msgstr "Top 95%% compatible con la versión anterior"
-
-#: src/olympia/compat/templates/compat/index.html:18
-#, python-format
-msgid "Top 95%% of all add-ons"
-msgstr "Top 95%% de todos los complementos"
-
-#: src/olympia/compat/templates/compat/index.html:19
-msgid "All active add-ons"
-msgstr "Todos los complementos activos"
-
-#: src/olympia/compat/templates/compat/index.html:23 src/olympia/constants/base.py:401
-msgid "App"
-msgstr "App"
-
-#: src/olympia/compat/templates/compat/index.html:55
-msgid "Details for add-ons compatible with previous version:"
-msgstr "Detalles sobre los complementos compatibles con la versión anterior:"
-
-#: src/olympia/compat/templates/compat/index.html:57
-msgid "Show all versions"
-msgstr "Mostrar todas las versiones"
-
-#: src/olympia/compat/templates/compat/index.html:59
-msgid "Details for add-ons compatible with all versions:"
-msgstr "Detalles de complementos compatibles con todas las versiones:"
-
-#: src/olympia/compat/templates/compat/index.html:61
-msgid "Show previous version only"
-msgstr "Mostrar sólo la versión anterior"
 
 #: src/olympia/compat/templates/compat/reporter.html:3
 msgid "Add-on Compatibility Reports"
@@ -3220,8 +3178,8 @@ msgstr "Filtrar por aplicación"
 msgid "Report Type"
 msgstr "Tipo de informe"
 
-#: src/olympia/compat/templates/compat/reporter_detail.html:47 src/olympia/devhub/forms.py:784 src/olympia/devhub/templates/devhub/addons/ajax_compat_update.html:17 src/olympia/editors/forms.py:108
-#: src/olympia/zadmin/forms.py:45
+#: src/olympia/compat/templates/compat/reporter_detail.html:47 src/olympia/devhub/forms.py:785 src/olympia/devhub/templates/devhub/addons/ajax_compat_update.html:17 src/olympia/editors/forms.py:108
+#: src/olympia/editors/forms.py:248 src/olympia/zadmin/forms.py:45
 msgid "Application"
 msgstr "Aplicación"
 
@@ -3309,7 +3267,8 @@ msgstr "Revisado preliminarmente"
 msgid "Preliminarily Reviewed and Awaiting Full Review"
 msgstr "Revisado preliminarmente y esperando revisión completa"
 
-#: src/olympia/constants/base.py:33 src/olympia/editors/helpers.py:924 src/olympia/editors/templates/editors/themes/history_table.html:34
+#: src/olympia/constants/base.py:33 src/olympia/editors/forms.py:258 src/olympia/editors/helpers.py:73 src/olympia/editors/helpers.py:1004
+#: src/olympia/editors/templates/editors/themes/history_table.html:34
 msgid "Deleted"
 msgstr "Eliminado"
 
@@ -3409,6 +3368,11 @@ msgstr "Preguntar cuando los usuarios hayan comenzado a descargar este complemen
 msgid "Ask before users can download this add-on"
 msgstr "Preguntar antes de que los usuarios puedan descargar este complemento"
 
+#. Review points sources other than add-ons and themes.
+#: src/olympia/constants/base.py:388 src/olympia/devhub/forms.py:162 src/olympia/editors/templates/editors/performance.html:75
+msgid "Other"
+msgstr "Otro"
+
 #: src/olympia/constants/base.py:389
 msgid "Exception"
 msgstr "Excepción"
@@ -3420,6 +3384,10 @@ msgstr "Lanzamiento"
 #: src/olympia/constants/base.py:391
 msgid "Change"
 msgstr "Cambio"
+
+#: src/olympia/constants/base.py:401
+msgid "App"
+msgstr "App"
 
 #: src/olympia/constants/base.py:402
 msgid "Persona"
@@ -3569,7 +3537,7 @@ msgstr "Marca"
 msgid "Duplicate"
 msgstr "Duplicar"
 
-#: src/olympia/constants/editors.py:17 src/olympia/editors/helpers.py:502 src/olympia/editors/templates/editors/themes/queue.html:71 src/olympia/editors/templates/editors/themes/themes.html:94
+#: src/olympia/constants/editors.py:17 src/olympia/editors/helpers.py:575 src/olympia/editors/templates/editors/themes/queue.html:71 src/olympia/editors/templates/editors/themes/themes.html:94
 msgid "Reject"
 msgstr "Rechazar"
 
@@ -3669,7 +3637,7 @@ msgstr "Solaris"
 msgid "Android"
 msgstr "Android"
 
-#: src/olympia/core/apps.py:19
+#: src/olympia/core/apps.py:21
 msgid "Core"
 msgstr "Core"
 
@@ -3803,8 +3771,8 @@ msgid "Submit my add-on for manual review."
 msgstr "Enviar mi complemento para revisión manual."
 
 #: src/olympia/devhub/forms.py:537
-msgid "Do not list my add-on on this site (beta)"
-msgstr "No listar mi complemento en esta página (beta)"
+msgid "Do not list my add-on on this site"
+msgstr ""
 
 #: src/olympia/devhub/forms.py:538
 msgid "Check this option if you intend to distribute your add-on on your own and only need it to be signed by Mozilla."
@@ -3836,46 +3804,46 @@ msgstr "Los archivos con una versión que termine con a|alpha|b|beta|pre|rc y un
 
 #: src/olympia/devhub/forms.py:592
 #, python-format
-msgid "Version %s already exists"
-msgstr "La versión %s ya existe"
+msgid "Version %s already exists, or was uploaded before."
+msgstr ""
 
-#: src/olympia/devhub/forms.py:604
+#: src/olympia/devhub/forms.py:605
 msgid "Select a valid choice. That choice is not one of the available choices."
 msgstr "Selecciona una opción válida. Esta opción no está entre las disponibles."
 
-#: src/olympia/devhub/forms.py:610
+#: src/olympia/devhub/forms.py:611
 msgid "A file with a version ending with a|alpha|b|beta and an optional number is detected as beta."
 msgstr "Un archivo con una versión terminando con a|alfa|b|beta y un número opcional es detectado como beta."
 
-#: src/olympia/devhub/forms.py:633
+#: src/olympia/devhub/forms.py:634
 msgid "You cannot upload any more files for this version."
 msgstr "No puedes subir más archivos para esta versión."
 
-#: src/olympia/devhub/forms.py:639
+#: src/olympia/devhub/forms.py:640
 msgid "Version doesn't match"
 msgstr "La versión no coincide"
 
-#: src/olympia/devhub/forms.py:668
+#: src/olympia/devhub/forms.py:669
 msgid "You cannot delete a file once the review process has started.  You must delete the whole version."
-msgstr "No puedes eliminar un archivo cuando se ha iniciado el proceso de revisión.  Debes eliminar la versión completa."
+msgstr ""
 
-#: src/olympia/devhub/forms.py:688
+#: src/olympia/devhub/forms.py:689
 msgid "The platform All cannot be combined with specific platforms."
 msgstr "La plataforma Todas no puede combinarse con plataformas específicas."
 
-#: src/olympia/devhub/forms.py:693
+#: src/olympia/devhub/forms.py:694
 msgid "A platform can only be chosen once."
 msgstr "Una plataforma sólo puede ser elegida una vez."
 
-#: src/olympia/devhub/forms.py:706
+#: src/olympia/devhub/forms.py:707
 msgid "A review type must be selected."
 msgstr "Debe seleccionarse un tipo de revisión."
 
-#: src/olympia/devhub/forms.py:788 src/olympia/editors/forms.py:114 src/olympia/zadmin/forms.py:49 src/olympia/zadmin/forms.py:52
+#: src/olympia/devhub/forms.py:789 src/olympia/editors/forms.py:114 src/olympia/editors/forms.py:254 src/olympia/zadmin/forms.py:49 src/olympia/zadmin/forms.py:52
 msgid "Select an application first"
 msgstr "Primero selecciona una aplicación"
 
-#: src/olympia/devhub/forms.py:840
+#: src/olympia/devhub/forms.py:841
 msgid "There cannot be more than 3 required add-ons."
 msgstr "No puede haber más de tres complementos obligatorios."
 
@@ -3909,76 +3877,76 @@ msgstr[1] "{0} avisos"
 msgid "Review"
 msgstr "Revisión"
 
-#: src/olympia/devhub/tasks.py:551
+#: src/olympia/devhub/tasks.py:583
 #, python-format
 msgid "%s responded with %s (%s)."
 msgstr "%s ha respondido con %s (%s)."
 
-#: src/olympia/devhub/tasks.py:555
+#: src/olympia/devhub/tasks.py:587
 #, python-format
 msgid "Connection to \"%s\" timed out."
 msgstr "La conexión a \"%s\" ha caducado."
 
-#: src/olympia/devhub/tasks.py:557
+#: src/olympia/devhub/tasks.py:589
 #, python-format
 msgid "Could not contact host at \"%s\"."
 msgstr "No se ha podido contactar con el servidor en \"%s\"."
 
-#: src/olympia/devhub/utils.py:104
+#: src/olympia/devhub/utils.py:105
 #, python-format
 msgid "Validation generated too many errors/warnings so %s messages were truncated. After addressing the visible messages, you'll be able to see the others."
 msgstr "La validación ha generado demasiados errores/advertencias de modo que %s mensajes han sido ocultados. Una vez tratados los mensajes visibles, podrás ver el resto."
 
-#: src/olympia/devhub/views.py:183
+#: src/olympia/devhub/views.py:181
 msgid "All My Add-ons"
 msgstr "Todos mis complementos"
 
-#: src/olympia/devhub/views.py:210
+#: src/olympia/devhub/views.py:208
 msgid "All Activity"
 msgstr "Toda la actividad"
 
-#: src/olympia/devhub/views.py:211
+#: src/olympia/devhub/views.py:209
 msgid "Add-on Updates"
 msgstr "Actualizaciones del complemento"
 
-#: src/olympia/devhub/views.py:212
+#: src/olympia/devhub/views.py:210
 msgid "Add-on Status"
 msgstr "Estado del complemento"
 
-#: src/olympia/devhub/views.py:213
+#: src/olympia/devhub/views.py:211
 msgid "User Collections"
 msgstr "Colecciones de los usuarios"
 
-#: src/olympia/devhub/views.py:214 src/olympia/devhub/templates/devhub/docs/policies-maintenance.html:68 src/olympia/pages/templates/pages/dev_faq.html:38
+#: src/olympia/devhub/views.py:212 src/olympia/devhub/templates/devhub/docs/policies-maintenance.html:68 src/olympia/pages/templates/pages/dev_faq.html:38
 #: src/olympia/pages/templates/pages/dev_faq.html:484
 msgid "User Reviews"
 msgstr "Valoraciones de los usuarios"
 
-#: src/olympia/devhub/views.py:327 src/olympia/devhub/views.py:331 src/olympia/devhub/views.py:484 src/olympia/devhub/views.py:513 src/olympia/devhub/views.py:564 src/olympia/devhub/views.py:1150
+#: src/olympia/devhub/views.py:325 src/olympia/devhub/views.py:329 src/olympia/devhub/views.py:484 src/olympia/devhub/views.py:513 src/olympia/devhub/views.py:564 src/olympia/devhub/views.py:1156
 msgid "Changes successfully saved."
 msgstr "Los cambios se han guardado correctamente."
 
-#: src/olympia/devhub/views.py:334 src/olympia/devhub/views.py:1631
+#: src/olympia/devhub/views.py:332 src/olympia/devhub/views.py:1637
 msgid "Please check the form for errors."
 msgstr "Por favor, comprueba el formulario en busca de errores."
 
-#: src/olympia/devhub/views.py:346
+#: src/olympia/devhub/views.py:344
 msgid "Add-on cannot be deleted. Disable this add-on instead."
 msgstr "El complemento no puede desinstalarse. En su lugar, desactiva este complemento."
 
-#: src/olympia/devhub/views.py:356
+#: src/olympia/devhub/views.py:354
 msgid "Theme deleted."
 msgstr "Tema borrado."
 
-#: src/olympia/devhub/views.py:356
+#: src/olympia/devhub/views.py:354
 msgid "Add-on deleted."
 msgstr "Complemento borrado."
 
-#: src/olympia/devhub/views.py:362
+#: src/olympia/devhub/views.py:360
 msgid "URL name was incorrect. Theme was not deleted."
 msgstr "El nombre de la URL es incorrecto. No se eliminó el tema."
 
-#: src/olympia/devhub/views.py:367
+#: src/olympia/devhub/views.py:365
 msgid "URL name was incorrect. Add-on was not deleted."
 msgstr "El nombre de la URL es incorrecto. No se eliminó el complemento."
 
@@ -4006,7 +3974,7 @@ msgstr "Validar el complemento"
 msgid "Check Add-on Compatibility"
 msgstr "Comprobar la compatibilidad del complemento"
 
-#: src/olympia/devhub/views.py:808 src/olympia/signing/views.py:90
+#: src/olympia/devhub/views.py:808 src/olympia/signing/views.py:95
 msgid "You cannot submit this type of add-on"
 msgstr "No puedes enviar este tipo de complemento"
 
@@ -4036,33 +4004,33 @@ msgstr "La imagen debe ser exactamente de {0} píxeles de ancho y {1} píxeles d
 msgid "There was an error uploading your preview."
 msgstr "Ha sucedido un error al subir la vista previa."
 
-#: src/olympia/devhub/views.py:1189
+#: src/olympia/devhub/views.py:1195
 #, python-format
 msgid "Version %s disabled."
 msgstr "Versión %s desactivada."
 
-#: src/olympia/devhub/views.py:1193
+#: src/olympia/devhub/views.py:1199
 #, python-format
 msgid "Version %s deleted."
 msgstr "Versión %s borrada."
 
-#: src/olympia/devhub/views.py:1203
+#: src/olympia/devhub/views.py:1209
 msgid "This upload has failed validation, and may lack complete validation results. Please take due care when reviewing it."
 msgstr "Esta subida ha fallado la validación y puede carecer de resultados de validación completos. Revísala con atención."
 
-#: src/olympia/devhub/views.py:1677
+#: src/olympia/devhub/views.py:1683
 msgid "Preliminary Review Requested."
 msgstr "Revisión preliminar solicitada."
 
-#: src/olympia/devhub/views.py:1678
+#: src/olympia/devhub/views.py:1684
 msgid "Full Review Requested."
 msgstr "Revisión completa solicitada."
 
-#: src/olympia/devhub/views.py:1779
+#: src/olympia/devhub/views.py:1783
 msgid "Your old credentials were revoked and are no longer valid. Be sure to update all API clients with the new credentials."
 msgstr "Tus antiguas credenciales fueron revocadas y ya no son válidas. Asegúrate de actualizar todos los clientes API con las nuevas credenciales."
 
-#: src/olympia/devhub/views.py:1797
+#: src/olympia/devhub/views.py:1801
 msgid "New API key created"
 msgstr "Nueva clave API creada"
 
@@ -4094,7 +4062,7 @@ msgstr "Volver a complementos"
 msgid "{0} :: Search"
 msgstr "{0} :: Búsqueda"
 
-#: src/olympia/devhub/templates/devhub/devhub_search.html:6 src/olympia/devhub/templates/devhub/search.html:8 src/olympia/editors/forms.py:435 src/olympia/editors/forms.py:437
+#: src/olympia/devhub/templates/devhub/devhub_search.html:6 src/olympia/devhub/templates/devhub/search.html:8 src/olympia/editors/forms.py:534 src/olympia/editors/forms.py:536
 #: src/olympia/editors/templates/editors/queue.html:27 src/olympia/editors/templates/editors/themes/queue_list.html:14 src/olympia/search/templates/search/collections.html:17
 #: src/olympia/search/templates/search/personas.html:18 src/olympia/search/templates/search/results.html:18 src/olympia/search/templates/search/mobile/results.html:8
 #: src/olympia/templates/search.html:14 src/olympia/templates/impala/search.html:18
@@ -4156,12 +4124,12 @@ msgstr "Dirígete a <a href=\"https://developer.mozilla.org/Add-ons\">Mozilla De
 msgid "Start Making Add-ons"
 msgstr "Empieza a crear complementos"
 
-#: src/olympia/devhub/templates/devhub/index.html:86 src/olympia/devhub/templates/devhub/addons/listing/items.html:25 src/olympia/devhub/templates/devhub/includes/addon_details.html:15
+#: src/olympia/devhub/templates/devhub/index.html:86 src/olympia/devhub/templates/devhub/addons/listing/items.html:25 src/olympia/devhub/templates/devhub/includes/addon_details.html:20
 #: src/olympia/devhub/templates/devhub/personas/edit.html:43
 msgid "Status:"
 msgstr "Estado:"
 
-#: src/olympia/devhub/templates/devhub/index.html:90 src/olympia/devhub/templates/devhub/includes/addon_details.html:100
+#: src/olympia/devhub/templates/devhub/index.html:90 src/olympia/devhub/templates/devhub/includes/addon_details.html:87
 msgid "Visibility:"
 msgstr "Visibilidad:"
 
@@ -4169,11 +4137,11 @@ msgstr "Visibilidad:"
 msgid "Latest Version:"
 msgstr "Última versión:"
 
-#: src/olympia/devhub/templates/devhub/index.html:109 src/olympia/devhub/templates/devhub/includes/addon_details.html:145 src/olympia/devhub/templates/devhub/personas/edit.html:49
+#: src/olympia/devhub/templates/devhub/index.html:109 src/olympia/devhub/templates/devhub/includes/addon_details.html:131 src/olympia/devhub/templates/devhub/personas/edit.html:49
 msgid "Queue Position:"
 msgstr "Posición en cola:"
 
-#: src/olympia/devhub/templates/devhub/index.html:110 src/olympia/devhub/templates/devhub/includes/addon_details.html:146 src/olympia/devhub/templates/devhub/personas/edit.html:50
+#: src/olympia/devhub/templates/devhub/index.html:110 src/olympia/devhub/templates/devhub/includes/addon_details.html:132 src/olympia/devhub/templates/devhub/personas/edit.html:50
 #, python-format
 msgid "%(position)s of %(total)s"
 msgstr "%(position)s de %(total)s"
@@ -4275,16 +4243,6 @@ msgstr "Tras la subida, se ejecutarán una serie de pruebas de validación autom
 msgid "Do you want your add-on to be distributed on this site?"
 msgstr "¿Quieres que se distribuya tu complemento en esta página?"
 
-#: src/olympia/devhub/templates/devhub/validate_addon.html:49 src/olympia/devhub/templates/devhub/addons/submit/upload.html:30 src/olympia/devhub/templates/devhub/versions/add_file_modal.html:14
-#: src/olympia/devhub/templates/devhub/versions/add_file_modal.html:53 src/olympia/devhub/templates/devhub/versions/list.html:298
-msgid "Warning:"
-msgstr "Advertencia:"
-
-#: src/olympia/devhub/templates/devhub/validate_addon.html:50 src/olympia/devhub/templates/devhub/addons/submit/upload.html:31
-#, python-format
-msgid "Submission of unlisted add-ons for signing is currently in an open beta. Please <a href=\"%(url)s\" target=\"_blank\">report any bugs</a> that you encounter."
-msgstr "El envío de complementos que no aparecen en la lista para su firma está en versión beta. Por favor, <a href=\"%(url)s\" target=\"_blank\">envía todos los bugs</a> que encuentres."
-
 #. first parameter is a filename like lorem-ipsum-1.0.2.xpi
 #: src/olympia/devhub/templates/devhub/validation.html:5
 msgid "Validation Results for {0}"
@@ -4363,7 +4321,7 @@ msgstr "Compatibilidad"
 msgid "Update Compatibility"
 msgstr "Actualizar compatiblidad"
 
-#: src/olympia/devhub/templates/devhub/addons/ajax_compat_update.html:4
+#: src/olympia/devhub/templates/devhub/addons/ajax_compat_update.html:4 src/olympia/devhub/templates/devhub/versions/edit.html:45
 msgid "Adjusting application information here will allow users to install your add-on even if the install manifest in the package indicates that the add-on is incompatible."
 msgstr "Al ajustar la información de la aplicación, permitirás a los usuarios instalar tu complemento incluso si el archivo manifest del paquete indica que no es compatible."
 
@@ -4375,9 +4333,9 @@ msgstr "Versiones compatibles"
 msgid "Add Another Application&hellip;"
 msgstr "Agregar otra aplicación&hellip;"
 
-#: src/olympia/devhub/templates/devhub/addons/ajax_compat_update.html:38 src/olympia/devhub/templates/devhub/addons/owner.html:86 src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:46
-#: src/olympia/devhub/templates/devhub/versions/list.html:351 src/olympia/devhub/templates/devhub/versions/list.html:353 src/olympia/templates/impala/base.html:132
-#: src/olympia/templates/impala/base.html:143 src/olympia/templates/impala/base.html:161 src/olympia/templates/impala/base.html:171
+#: src/olympia/devhub/templates/devhub/addons/ajax_compat_update.html:38 src/olympia/devhub/templates/devhub/addons/owner.html:86 src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:45
+#: src/olympia/devhub/templates/devhub/versions/list.html:349 src/olympia/devhub/templates/devhub/versions/list.html:351 src/olympia/templates/impala/base.html:129
+#: src/olympia/templates/impala/base.html:140 src/olympia/templates/impala/base.html:158 src/olympia/templates/impala/base.html:168
 msgid "Close"
 msgstr "Cerrar"
 
@@ -4411,7 +4369,7 @@ msgstr "Ninguno"
 msgid "Manage Authors & License"
 msgstr "Administrar autores y licencia"
 
-#: src/olympia/devhub/templates/devhub/addons/owner.html:29 src/olympia/editors/templates/editors/review.html:270
+#: src/olympia/devhub/templates/devhub/addons/owner.html:29 src/olympia/editors/helpers.py:362 src/olympia/editors/templates/editors/review.html:270
 msgid "Authors"
 msgstr "Autores"
 
@@ -4483,10 +4441,7 @@ msgstr "Descripción"
 
 #: src/olympia/devhub/templates/devhub/addons/edit/basic.html:52
 msgid ""
-"A short explanation of your add-on's basic\n"
-"                          functionality that is displayed in search and browse\n"
-"                          listings, as well as at the top of your add-on's\n"
-"                          details page. It is only relevant for listed add-ons."
+"A short explanation of your add-on's basic functionality that is displayed in search and browse listings, as well as at the top of your add-on's details page. It is only relevant for listed add-ons."
 msgstr ""
 "Una breve explicación de las\n"
 "                          funcionalidades básicas aparece en las búsquedas, listas de                          \n"
@@ -4494,10 +4449,7 @@ msgstr ""
 "                          detalles del complemento. Solo es útil para complementos listados."
 
 #: src/olympia/devhub/templates/devhub/addons/edit/basic.html:73
-msgid ""
-"Categories are the primary way users browse through add-ons.\n"
-"                        Choose any that fit your add-on's functionality for the most\n"
-"                        exposure. It is only relevant for listed add-ons."
+msgid "Categories are the primary way users browse through add-ons. Choose any that fit your add-on's functionality for the most exposure. It is only relevant for listed add-ons."
 msgstr ""
 "Las categorías son la forma principal de buscar complementos.\n"
 "                        Elige la que mejor se adapte a la funcionalidad de tu\n"
@@ -4512,11 +4464,7 @@ msgstr ""
 "modificar tus categorías."
 
 #: src/olympia/devhub/templates/devhub/addons/edit/basic.html:119
-msgid ""
-"Tags help users find your add-on and should be short\n"
-"                        descriptors such as tabs, toolbar, or twitter.  You\n"
-"                        may have a maximum of {0} tags. It is only relevant\n"
-"                        for listed add-ons."
+msgid "Tags help users find your add-on and should be short descriptors such as tabs, toolbar, or twitter. You may have a maximum of {0} tags. It is only relevant for listed add-ons."
 msgstr ""
 "Las etiquetas ayudan a los usuarios a encontrar complementos y deberían ser\n"
 "                        breves descripciones como pestañas, barras de herramientas o Twitter.\n"
@@ -4548,11 +4496,7 @@ msgid "Add-on Details for {0}"
 msgstr "Detalles del complento {0}"
 
 #: src/olympia/devhub/templates/devhub/addons/edit/details.html:22
-msgid ""
-"A longer explanation of features,\n"
-"                          functionality, and other relevant information. This\n"
-"                          field is only displayed on the add-on's details\n"
-"                          page. It is only relevant for listed add-ons."
+msgid "A longer explanation of features, functionality, and other relevant information. This field is only displayed on the add-on's details page. It is only relevant for listed add-ons."
 msgstr ""
 "Una explicación amplia de características,\n"
 "                          funcionalidad y más información. Este campo\n"
@@ -4564,10 +4508,7 @@ msgid "Default Locale"
 msgstr "Idioma por defecto"
 
 #: src/olympia/devhub/templates/devhub/addons/edit/details.html:45
-msgid ""
-"Information about your add-on is displayed in this locale\n"
-"                        unless you override it with a locale-specific translation.\n"
-"                        It is only relevant for listed add-ons."
+msgid "Information about your add-on is displayed in this locale unless you override it with a locale-specific translation. It is only relevant for listed add-ons."
 msgstr ""
 "La información de tu complemento se muestra en este idioma\n"
 "                        a menos que antepongas una traducción específica.\n"
@@ -4580,10 +4521,8 @@ msgstr "Inicio"
 
 #: src/olympia/devhub/templates/devhub/addons/edit/details.html:63
 msgid ""
-"If your add-on has another homepage, enter its\n"
-"                          address here. If your website is localized into other\n"
-"                          languages multiple translations of this field can be\n"
-"                          added. It is only relevant for listed add-ons."
+"If your add-on has another homepage, enter its address here. If your website is localized into other languages multiple translations of this field can be added. It is only relevant for listed add-"
+"ons."
 msgstr ""
 "Si tu complemento tiene otra página de inicio, escribe la\n"
 "                          dirección aquí. Si la página está localizada en\n"
@@ -4605,11 +4544,8 @@ msgstr "Información de ayuda para {0}"
 
 #: src/olympia/devhub/templates/devhub/addons/edit/support.html:22
 msgid ""
-"If you wish to display an e-mail address for support\n"
-"                          inquiries, enter it here. If you have different\n"
-"                          addresses for each language multiple translations of\n"
-"                          this field can be added. It is only relevant for\n"
-"                          listed add-ons."
+"If you wish to display an e-mail address for support inquiries, enter it here. If you have different addresses for each language multiple translations of this field can be added. It is only "
+"relevant for listed add-ons."
 msgstr ""
 "Si quieres mostrar el correo para resolver\n"
 "                          preguntas, introdúcelo aquí. Si tienes distintos correos\n"
@@ -4619,10 +4555,8 @@ msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/support.html:45
 msgid ""
-"If your add-on has a support website or forum, enter\n"
-"                          its address here. If your website is localized into\n"
-"                          other languages, multiple translations of this field can\n"
-"                          be added. It is only relevant for listed add-ons."
+"If your add-on has a support website or forum, enter its address here. If your website is localized into other languages, multiple translations of this field can be added. It is only relevant for "
+"listed add-ons."
 msgstr ""
 "Si tu complemento tiene foro o página de ayuda, introduce\n"
 "                          la dirección aquí. Si la página está localizada en\n"
@@ -4640,11 +4574,8 @@ msgstr "Detalles técnicos de {0}"
 
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:23
 msgid ""
-"Any information end users may want to know that isn't\n"
-"                          necessarily applicable to the add-on summary or description.\n"
-"                          Common uses include listing known major bugs, information on\n"
-"                          how to report bugs, anticipated release date of a new version,\n"
-"                          etc. It is only relevant for listed add-ons."
+"Any information end users may want to know that isn't necessarily applicable to the add-on summary or description. Common uses include listing known major bugs, information on how to report bugs, "
+"anticipated release date of a new version, etc. It is only relevant for listed add-ons."
 msgstr ""
 "Cualquier información que quieran conocer los usuarios y que no esté en\n"
 "                          el sumario o la descripción del complemento.\n"
@@ -4661,9 +4592,7 @@ msgid "Add-on Flags"
 msgstr "Indicadores del complemento"
 
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:69
-msgid ""
-"These flags are used to classify add-ons. It is only\n"
-"                        relevant for listed add-ons."
+msgid "These flags are used to classify add-ons. It is only relevant for listed add-ons."
 msgstr ""
 "Estas marcas se utilizan para clasificar los complementos. Solo\n"
 "                        es útil para complementos listados."
@@ -4681,9 +4610,7 @@ msgid "View Source?"
 msgstr "¿Ver el código fuente?"
 
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:90
-msgid ""
-"Whether the source of your add-on can be displayed in our\n"
-"                        online viewer. It is only relevant for listed add-ons."
+msgid "Whether the source of your add-on can be displayed in our online viewer. It is only relevant for listed add-ons."
 msgstr ""
 "Si podemos mostrar la fuente de tu complemento en nuestro visor\n"
 "                        online. Solo es válido para complementos listados."
@@ -4701,10 +4628,7 @@ msgid "Public Stats?"
 msgstr "¿Estadísticas públicas?"
 
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:102
-msgid ""
-"Whether the download and usage stats of your add-on can\n"
-"                        be displayed in our online viewer.\n"
-"                        It is only relevant for listed add-ons."
+msgid "Whether the download and usage stats of your add-on can be displayed in our online viewer. It is only relevant for listed add-ons."
 msgstr ""
 "Si podemos mostrar la descarga y el estado de uso de tu\n"
 "                        complemento en nuestro visor online.\n"
@@ -4723,10 +4647,7 @@ msgid "Upgrade SDK?"
 msgstr "¿Actualizar el SDK?"
 
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:116
-msgid ""
-"If selected, we will try to automatically upgrade your\n"
-"                        add-on when a new version of the SDK is released.\n"
-"                        It is only relevant for listed add-ons."
+msgid "If selected, we will try to automatically upgrade your add-on when a new version of the SDK is released. It is only relevant for listed add-ons."
 msgstr ""
 "Si aceptas, intentaremos actualizar automáticamente tu\n"
 "                        complemento cuando haya una nueva versión de SDK.\n"
@@ -4782,10 +4703,8 @@ msgstr "Icono del complemento"
 
 #: src/olympia/devhub/templates/devhub/addons/forms_shared/media.html:16
 msgid ""
-"Upload an icon for your add-on or choose from one of ours. The\n"
-"                      icon is displayed nearly everywhere your add-on is. Uploaded images\n"
-"                      must be one of the following image types: .png, .jpg.\n"
-"                      It is only relevant for listed add-ons."
+"Upload an icon for your add-on or choose from one of ours. The icon is displayed nearly everywhere your add-on is. Uploaded images must be one of the following image types: .png, .jpg. It is only "
+"relevant for listed add-ons."
 msgstr ""
 "Sube un icono para tu complemento o elige uno de los nuestros. El icono\n"
 "                      aparecerá donde aparezca tu complemento. Las imágenes que subas\n"
@@ -4802,9 +4721,7 @@ msgid "32x32px"
 msgstr "32x32px"
 
 #: src/olympia/devhub/templates/devhub/addons/forms_shared/media.html:39
-msgid ""
-"Used in listings of add-ons, like search results\n"
-"                            and featured add-ons."
+msgid "Used in listings of add-ons, like search results and featured add-ons."
 msgstr ""
 "Se utiliza en los listados de complementos, como resultados de\n"
 "                            búsqueda y complementos patrocinados."
@@ -4901,18 +4818,16 @@ msgid "Deleting your add-on will permanently remove it from the site and prevent
 msgstr "Si eliminas el complemento de forma permanente, desparecerá del sitio e impedirá que cualquiera pueda volver a enviar el GUID."
 
 #: src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:24
-msgid ""
-"Enter the following text confirm your decision:\n"
-"           {slug}"
+msgid "Enter the following text confirm your decision: {slug}"
 msgstr ""
 "Confirma tu decisión escribiendo el siguiente texto:\n"
 "           {slug}"
 
-#: src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:34
+#: src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:33
 msgid "Please tell us why you are deleting your theme:"
 msgstr "Explica brevemente la razón por la que eliminas tu tema:"
 
-#: src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:36
+#: src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:35
 msgid "Please tell us why you are deleting your add-on:"
 msgstr "Explica brevemente la razón por la que eliminas tu complemento:"
 
@@ -4949,8 +4864,8 @@ msgstr "Nueva versión"
 msgid "Daily statistics on downloads and users."
 msgstr "Estadísticas diarias de descargas y usuarios."
 
-#: src/olympia/devhub/templates/devhub/addons/listing/item_actions.html:45 src/olympia/stats/templates/stats/stats.html:75 src/olympia/stats/templates/stats/stats.html:79
-#: src/olympia/stats/templates/stats/stats.html:81
+#: src/olympia/devhub/templates/devhub/addons/listing/item_actions.html:45 src/olympia/stats/templates/stats/stats.html:31 src/olympia/stats/templates/stats/stats.html:35
+#: src/olympia/stats/templates/stats/stats.html:37
 msgid "Statistics"
 msgstr "Estadísticas"
 
@@ -5069,10 +4984,7 @@ msgid "Your add-on has been submitted to the Full Review queue."
 msgstr "Tu complemento ha sido enviado a la cola de revisión completa."
 
 #: src/olympia/devhub/templates/devhub/addons/submit/done.html:18
-msgid ""
-"You'll receive an email once it has been reviewed by an editor. In\n"
-"          the meantime, you and your friends can install it directly from its\n"
-"          details page:"
+msgid "You'll receive an email once it has been reviewed by an editor. In the meantime, you and your friends can install it directly from its details page:"
 msgstr ""
 "Recibirás un correo cuando un editor lo haya revisado.\n"
 "          Mientras, tanto tú como tus amigos lo podéis instalar\n"
@@ -5286,11 +5198,11 @@ msgid "Use the fields below to upload your add-on package and select any platfor
 msgstr ""
 "Use los siguientes campos para enviar tu paquete y seleccionar cualquier restricción en la plataforma. Tras enviarlo, una serie de pruebas de validación automática se ejecutarán sobre tu fichero."
 
-#: src/olympia/devhub/templates/devhub/addons/submit/upload.html:59 src/olympia/devhub/templates/devhub/versions/add_file_modal.html:39
+#: src/olympia/devhub/templates/devhub/addons/submit/upload.html:51 src/olympia/devhub/templates/devhub/versions/add_file_modal.html:28
 msgid "Which platforms is this file compatible with?"
 msgstr "¿Con qué plataformas es compatible este archivo?"
 
-#: src/olympia/devhub/templates/devhub/addons/submit/upload.html:67 src/olympia/devhub/templates/devhub/versions/add_file_modal.html:65
+#: src/olympia/devhub/templates/devhub/addons/submit/upload.html:59 src/olympia/devhub/templates/devhub/versions/add_file_modal.html:45
 msgid "Administrative overrides"
 msgstr "Anulaciones administrativas"
 
@@ -5409,11 +5321,9 @@ msgstr "Funcionalidad y desarrollo del sitio web"
 
 #: src/olympia/devhub/templates/devhub/docs/policies-contact.html:44
 msgid ""
-"If you've found a problem with the site, we'd love to fix it. Please <a href=\"https://github.com/mozilla/olympia/issues\">file a bug report</a> in GitHub, including the location of the problem and "
-"how you encountered it."
+"If you've found a problem with the site, we'd love to fix it. Please <a href=\"https://github.com/mozilla/addons/issues/new\">file a bug report</a> in GitHub, including the location of the problem "
+"and how you encountered it."
 msgstr ""
-"Si tienes algún problema con la página, queremos solucionarlo. Así que, por favor, <a href=\"https://github.com/mozilla/olympia/issues\">envía un informe de bug</a> en GitHub, incluyendo la "
-"ubicación del problema y cómo diste con él."
 
 #: src/olympia/devhub/templates/devhub/docs/policies-maintenance.html:3 src/olympia/devhub/templates/devhub/docs/policies-maintenance.html:7
 #: src/olympia/devhub/templates/devhub/docs/policies-maintenance.html:8
@@ -6084,7 +5994,7 @@ msgstr "Modo Navegación privada"
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:282
 msgid ""
-"Add-ons that store or otherwise handle browsing data must support <a href=\"https://developer.mozilla.org/En/Supporting_private_browsing_mode\">Private Browsing Mode</a>.  During a Private Browsing "
+"Add-ons that store or otherwise handle browsing data must support <a href=\"https://developer.mozilla.org/En/Supporting_private_browsing_mode\">Private Browsing Mode</a>. During a Private Browsing "
 "session, no browsing data can be written to disk, and all of this data must be cleared when Firefox quits or the Private Browsing session ends."
 msgstr ""
 "Los complementos que almacenan o administran datos de navegación deben admitir el <a href=\"https://developer.mozilla.org/En/Supporting_private_browsing_mode\">modo de navegación privada</a>.  "
@@ -6304,165 +6214,128 @@ msgstr "Términos del servicio respecto al envío de tu obra a nuestro sitio. Lo
 msgid "How to get in touch with us regarding these policies or your add-on."
 msgstr "Cómo ponerte en contacto con nosotros en relación a estas políticas o tu complemento."
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:6
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:10
 msgid "You have disabled this add-on"
 msgstr "Has deshabilitado este complemento"
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:20
-msgid ""
-"Your add-on's listing is disabled and is not showing\n"
-"                             anywhere in our gallery or update service."
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:24
+msgid "Your add-on's listing is disabled and is not showing anywhere in our gallery or update service."
 msgstr ""
 "Se ha desactivado el listado de tu complemento y ya no se muestra\n"
 "                              en ningún sitio de nuestra galería o nuestro servicio de actualización."
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:25
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:27
 msgid "Please complete your add-on."
 msgstr "Por favor, completa tu complemento."
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:29
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:30
 msgid "You will receive an email when the review is complete."
 msgstr "Recibirás un correo electrónico cuando se complete la revisión."
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:34
-msgid ""
-"You will receive an email when the review is complete. Until\n"
-"                             then, your add-on is not listed in our gallery but can be\n"
-"                             accessed directly from its details page."
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:33
+msgid "You will receive an email when the review is complete. Until then, your add-on is not listed in our gallery but can be accessed directly from its details page."
 msgstr ""
 "Recibirás un correo cuando se finalice la revisión. Hasta entonces,\n"
 "                             tu complemento no aparecerá en la galería pero se podrá\n"
 "                             acceder a él desde la página de detalles."
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:38 src/olympia/devhub/templates/devhub/includes/addon_details.html:48
-msgid ""
-"You will receive an email when the review is\n"
-"                             complete and your add-on is signed."
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:37 src/olympia/devhub/templates/devhub/includes/addon_details.html:45
+msgid "You will receive an email when the review is complete and your add-on is signed."
 msgstr ""
 "Recibirás un correo cuando se finalice la revisión y\n"
 "                             tu complemento esté firmado."
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:44
-msgid ""
-"You will receive an email when the review is complete. Until\n"
-"                             then, your add-on is not listed in our gallery but can be\n"
-"                             accessed directly from its details page. "
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:41
+msgid "You will receive an email when the review is complete. Until then, your add-on is not listed in our gallery but can be accessed directly from its details page. "
 msgstr ""
-"Recibirás un correo cuando se finalice la revisión. Hasta entonces,\n"
-"                             tu complemento no aparecerá en la galería pero se podrá\n"
-"                             acceder a él desde la página de detalles."
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:54
-msgid ""
-"Your add-on is displayed in our gallery and users are\n"
-"                             receiving automatic updates."
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:49
+msgid "Your add-on is displayed in our gallery and users are receiving automatic updates."
 msgstr ""
 "Tu complemento aparece en nuestra galería y los usuarios\n"
 "                             reciben actualizaciones automáticas."
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:57
-msgid ""
-"Your add-on has been signed and can be bundled with an\n"
-"                             application installer."
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:52
+msgid "Your add-on has been signed and can be bundled with an application installer."
 msgstr ""
 "Tu complemento se ha firmado y se puede empaquetar \n"
 "                             con un instalador de aplicaciones."
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:63
-msgid ""
-"Your add-on was disabled by a site administrator and is no\n"
-"                             longer shown in our gallery. If you have any questions,\n"
-"                             please email amo-admins@mozilla.org."
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:56
+msgid "Your add-on was disabled by a site administrator and is no longer shown in our gallery. If you have any questions, please email amo-admins@mozilla.org."
 msgstr ""
 "Un administrador ha desactivado tu complemento y ya no aparece\n"
 "                             en nuestra galería. Si tienes alguna duda, por favor\n"
 "                             escribe a amo-admins@mozilla.org."
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:70
-msgid ""
-"Your add-on is displayed in our gallery as experimental\n"
-"                             and users are receiving automatic updates. Some features\n"
-"                             are unavailable to your add-on."
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:62
+msgid "Your add-on is displayed in our gallery as experimental and users are receiving automatic updates. Some features are unavailable to your add-on."
 msgstr ""
 "Tu complemento aparece en la galería como experimental y\n"
 "                             los usuarios reciben actualizaciones automáticas. Algunas funciones\n"
 "                             aún no están disponibles."
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:74
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:66
 msgid "Your add-on has been signed."
 msgstr "Tu complemento ha sido firmado."
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:79
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:69
 msgid ""
-"You will receive an email when the full review is complete.\n"
-"                             Until then, your add-on is displayed in our gallery as\n"
-"                             experimental and users are receiving automatic updates.\n"
-"                             Some features are unavailable to your add-on."
+"You will receive an email when the full review is complete. Until then, your add-on is displayed in our gallery as experimental and users are receiving automatic updates. Some features are "
+"unavailable to your add-on."
 msgstr ""
 "Recibirás un correo cuando se finalice la revisión completa.\n"
 "                             Hasta entonces, se mostrará en la galería como\n"
 "                             experimental y los usuarios reciben actualizaciones automáticas.\n"
 "                             Algunas funciones aún no están disponibles."
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:84
-msgid ""
-"You will receive an email when the full review is\n"
-"                             complete, making you able to bundle your add-on with an\n"
-"                             application installer."
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:74
+msgid "You will receive an email when the full review is complete, making you able to bundle your add-on with an application installer."
 msgstr ""
 "Recibirás un correo electrónico cuando se termine \n"
 "                             una revisión completa, permitiéndote empaquetar tu complemento\n"
 "                              con un instalador de aplicaciones."
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:91
-msgid ""
-"All add-ons hosted in our gallery must now be reviewed by an\n"
-"                             editor. If you wish to continue hosting your add-on, please\n"
-"                             click to select a review process."
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:79
+msgid "All add-ons hosted in our gallery must now be reviewed by an editor. If you wish to continue hosting your add-on, please click to select a review process."
 msgstr ""
 "Ahora, un editor tiene que revisar todos los complementos alojados en la\n"
 "                             galería. Si quieres seguir alojándolo, haz clic para\n"
 "                             seleccionar el proceso de revisión."
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:113
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:100
 msgid "Current Version:"
 msgstr "Versión actual:"
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:115
-msgid ""
-"This is the version of your add-on that will\n"
-"                                           be installed if someone clicks the Install\n"
-"                                           button on addons.mozilla.org. It is only\n"
-"                                           relevant for listed add-ons."
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:102
+msgid "This is the version of your add-on that will be installed if someone clicks the Install button on addons.mozilla.org. It is only relevant for listed add-ons."
 msgstr ""
 "Esta es la versión de tu complemento que\n"
 "                                           se instalará si alguien hace clic en el botón\n"
 "                                           Instalar en addons.mozilla.org. Solo es útil\n"
 "                                           para complementos listados."
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:123
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:110
 msgid "Created:"
 msgstr "Creado:"
 
 #. {0} is a date. dennis-ignore: E201
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:125 src/olympia/devhub/templates/devhub/includes/addon_details.html:131
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:112 src/olympia/devhub/templates/devhub/includes/addon_details.html:118
 #, python-format
 msgid "%%b %%e, %%Y"
 msgstr "%%b %%e, %%Y"
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:136
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:123
 msgid "Next Version:"
 msgstr "Próxima versión:"
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:138
-msgid ""
-"This is the newest uploaded version, however\n"
-"                                           it isn’t live on the site yet."
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:125
+msgid "This is the newest uploaded version, however it isn’t live on the site yet."
 msgstr ""
 "Esta es la última versión, pero\n"
 "                                           aún no está disponible en la página."
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:144 src/olympia/devhub/templates/devhub/versions/list.html:30
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:130 src/olympia/devhub/templates/devhub/versions/list.html:30
 msgid "Queues are not reviewed strictly in order"
 msgstr "Las colas no son revisadas en orden estricto"
 
@@ -6532,9 +6405,7 @@ msgid "View the blog &#9658;"
 msgstr "Ver el blog &#9658;"
 
 #: src/olympia/devhub/templates/devhub/includes/license_form.html:6
-msgid ""
-"Please choose a license appropriate for the rights you grant on your source code.\n"
-"                  It is only relevant for listed add-ons."
+msgid "Please choose a license appropriate for the rights you grant on your source code. It is only relevant for listed add-ons."
 msgstr ""
 "Por favor, elige una licencia apropiada para los derechos que garantizas en el código fuente.\n"
 "                  Solo es útil para complementos listados."
@@ -6552,8 +6423,7 @@ msgstr "Algunas etiquetas HTML admitidas."
 msgid "Remove this application"
 msgstr "Borrar esta aplicación"
 
-#. {0} is the maximum number of add-on categories allowed.                {1}
-#. is
+#. {0} is the maximum number of add-on categories allowed.                {1} is
 #. the application name.
 #: src/olympia/devhub/templates/devhub/includes/macros.html:70
 msgid "Select <b>up to {0}</b> {1} category for this add-on:"
@@ -6564,17 +6434,11 @@ msgstr[1] "Selecciona <b>hasta {0}</b> categorías de {1} para este complemento:
 #: src/olympia/devhub/templates/devhub/includes/policy_form.html:4
 msgid ""
 "Users will be required to accept the following End-User License Agreement (EULA) prior to installing your add-on. The presence of a EULA significantly affects the number of downloads an add-on "
-"receives. Please note that a EULA is not the same as a code license, such as the GPL or MPL.\n"
-"                It is only relevant for listed add-ons."
+"receives. Please note that a EULA is not the same as a code license, such as the GPL or MPL.It is only relevant for listed add-ons."
 msgstr ""
-"Se pedirá a los usuarios que acepten el Contrato de Licencia para el Usuario Final (CLUF) antes de instalar el complemento. La presencia de un CLUF afecta significativamente al número de descargas "
-"de un complemento. Ten en cuenta que un CLUF no es lo mismo que una licencia de código, como GPL o LPM.\n"
-"                Solo es útil para complementos listados."
 
-#: src/olympia/devhub/templates/devhub/includes/policy_form.html:21
-msgid ""
-"If your add-on transmits any data from the user's computer, a privacy policy is required that explains what data is sent and how it is used.\n"
-"                It is only relevant for listed add-ons."
+#: src/olympia/devhub/templates/devhub/includes/policy_form.html:24
+msgid "If your add-on transmits any data from the user's computer, a privacy policy is required that explains what data is sent and how it is used. It is only relevant for listed add-ons."
 msgstr ""
 "Si tu complemento transmite datos desde el equipo del usuario, se requiere una política de privacidad que explique qué datos se envían y cómo se utilizan.\n"
 "                Solo es útil para complementos listados."
@@ -6748,12 +6612,8 @@ msgstr "Selecciona la categoría que describa mejor tu tema."
 msgid "Add some tags to describe your Theme."
 msgstr "Agrega algunas etiquetas para describir tu tema."
 
-#: src/olympia/devhub/templates/devhub/personas/edit.html:106
-msgid ""
-"A short explanation of your theme's\n"
-"                                basic functionality that is displayed in\n"
-"                                search and browse listings, as well as at\n"
-"                                the top of your theme's details page."
+#: src/olympia/devhub/templates/devhub/personas/edit.html:106 src/olympia/devhub/templates/devhub/personas/submit.html:54
+msgid "A short explanation of your theme's basic functionality that is displayed in search and browse listings, as well as at the top of your theme's details page."
 msgstr ""
 "Una breve explicación de la funcionalidad\n"
 "                                básica del tema que se muestra en las listas\n"
@@ -6835,7 +6695,7 @@ msgid "Upon upload and form submission, the AMO Team will review your updated de
 msgstr "Tras subir el archivo y enviar el formulario, el equipo de AMO revisará tu diseño actualizado. Tu diseño actual seguirá siendo público mientras tanto."
 
 #: src/olympia/devhub/templates/devhub/personas/edit.html:241
-msgid "Your previously resubmitted design,  which is under pending review."
+msgid "Your previously resubmitted design, which is under pending review."
 msgstr "El diseño que enviaste anteriormente,  que está pendiente de revisión."
 
 #: src/olympia/devhub/templates/devhub/personas/edit.html:245
@@ -6903,18 +6763,6 @@ msgstr "Los temas de fondo te permiten personalizar fácilmente el aspecto de tu
 #: src/olympia/devhub/templates/devhub/personas/submit.html:33
 msgid "Give your Theme a name."
 msgstr "Dar un nombre a tu tema nuevo."
-
-#: src/olympia/devhub/templates/devhub/personas/submit.html:54
-msgid ""
-"A short explanation of your theme's\n"
-"                                      basic functionality that is displayed in\n"
-"                                      search and browse listings, as well as at\n"
-"                                      the top of your theme's details page."
-msgstr ""
-"Una breve explicación de la funcionalidad\n"
-"                                básica del tema que se muestra en las listas\n"
-"                                de búsqueda y navegación, además de en la parte\n"
-"                                superior de la página de detalles del tema."
 
 #: src/olympia/devhub/templates/devhub/personas/submit.html:198
 #, python-format
@@ -6998,35 +6846,17 @@ msgstr "Selecciona una imagen de pie diferente"
 msgid "Files added to reviewed versions must be reviewed before they will be available for download."
 msgstr "Los ficheros añadidos a versiones con revisión deben ser revisados antes de poder descargarse."
 
-#: src/olympia/devhub/templates/devhub/versions/add_file_modal.html:15
-#, python-format
-msgid ""
-"Submission of updates to unlisted add-ons for signing is currently in an open beta. Manual review may still be required for a large number of add-ons. Please <a href=\"%(url)s\" target=\"_blank"
-"\">report any bugs</a> that you encounter."
-msgstr ""
-"El envío de actualizaciones para complementos que necesitan firma y no están en la lista está en versión beta. Quizás necesites revisar el manual para muchos de los complementos. Por favor, <a href="
-"\"%(url)s\" target=\"_blank\">infórmanos de cualquier bug</a> que encuentres."
-
-#: src/olympia/devhub/templates/devhub/versions/add_file_modal.html:35
+#: src/olympia/devhub/templates/devhub/versions/add_file_modal.html:24
 msgid "Select the target platform for this file."
 msgstr "Selecciona la plataforma para la cual está dirigida este archivo."
 
-#: src/olympia/devhub/templates/devhub/versions/add_file_modal.html:46
+#: src/olympia/devhub/templates/devhub/versions/add_file_modal.html:35
 msgid "Which review type would you like to nominate for?"
 msgstr "¿Para qué tipo de revisión te gustaría postularte?"
 
-#: src/olympia/devhub/templates/devhub/versions/add_file_modal.html:51
+#: src/olympia/devhub/templates/devhub/versions/add_file_modal.html:40
 msgid "Only publish this version to my beta channel."
 msgstr "Solo publicar esta versión a mi canal beta."
-
-#: src/olympia/devhub/templates/devhub/versions/add_file_modal.html:54
-#, python-format
-msgid ""
-"The behavior of the beta channel has changed to accommodate <a href=\"%(addon_signing_url)s\" target=\"_blank\">mandatory add-on signing</a>. The new process is currently in an open beta, and may "
-"change significantly in the near future. Please <a href=\"%(issues_url)s\" target=\"_blank\">report any bugs</a> that you encounter."
-msgstr ""
-"El comportamiento del canal beta ha cambiado para acoger <a href=\"%(addon_signing_url)s\" target=\"_blank\">la firma obligatoria de complementos</a>. El nuevo proceso se encuentra todavía en "
-"versión beta y puede sufrir grandes cambios en un futuro. Te pedimos que <a href=\"%(issues_url)s\" target=\"_blank\">nos informes de cualquier bug</a> que encuentres."
 
 #: src/olympia/devhub/templates/devhub/versions/edit.html:5
 msgid "Manage Version {0}"
@@ -7050,22 +6880,10 @@ msgstr "Archivos"
 msgid "Upload Another File"
 msgstr "Subir otro archivo"
 
-#: src/olympia/devhub/templates/devhub/versions/edit.html:45
-msgid ""
-"Adjusting application information here will allow users to install your\n"
-"                          add-on even if the install manifest in the package indicates that the\n"
-"                          add-on is incompatible."
-msgstr ""
-"Modificar aquí la información de la aplicación permitirá a los usuarios instalar\n"
-"                          tu complemento aunque el manifiesto del paquete indique que\n"
-"                          el complemento es incompatible."
-
 #: src/olympia/devhub/templates/devhub/versions/edit.html:74
 msgid ""
-"Information about changes in this release, new features,\n"
-"                              known bugs, and other useful information specific to this\n"
-"                              release/version. This information is also shown in the\n"
-"                              Add-ons Manager when updating."
+"Information about changes in this release, new features, known bugs, and other useful information specific to this release/version. This information is also shown in the Add-ons Manager when "
+"updating."
 msgstr ""
 "Información sobre los cambios en esta versión, nuevas funciones,\n"
 "                              errores conocidos e información útil y específica\n"
@@ -7081,10 +6899,7 @@ msgid "Notes for Reviewers"
 msgstr "Notas para Revisores"
 
 #: src/olympia/devhub/templates/devhub/versions/edit.html:114
-msgid ""
-"Optionally, enter any information that may be useful\n"
-"                              to the Editor reviewing this add-on, such as test\n"
-"                              account information."
+msgid "Optionally, enter any information that may be useful to the Editor reviewing this add-on, such as test account information."
 msgstr ""
 "También puedes introducir información que pueda ser útil\n"
 "                              para el editor que revise el complemento, como\n"
@@ -7165,7 +6980,7 @@ msgstr "Solicitar revisión completa"
 msgid "Request Preliminary Review"
 msgstr "Solicitar revisión preliminar"
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:80 src/olympia/devhub/templates/devhub/versions/list.html:327 src/olympia/devhub/templates/devhub/versions/list.html:350
+#: src/olympia/devhub/templates/devhub/versions/list.html:80 src/olympia/devhub/templates/devhub/versions/list.html:325 src/olympia/devhub/templates/devhub/versions/list.html:348
 msgid "Cancel Review Request"
 msgstr "Cancelar la petición de valoración"
 
@@ -7194,8 +7009,8 @@ msgid "Unlisted:"
 msgstr "No listados:"
 
 #: src/olympia/devhub/templates/devhub/versions/list.html:114
-msgid "Not distributed on {0}. Developers will upload new versions for signing and distribute the add-ons on their own. (beta)"
-msgstr "No distribuido en {0}. Los desarrolladores subirán nuevas versiones para su firma y distribuirán los complementos por su cuenta. (beta)"
+msgid "Not distributed on {0}. Developers will upload new versions for signing and distribute the add-ons on their own."
+msgstr ""
 
 #: src/olympia/devhub/templates/devhub/versions/list.html:122
 msgid "Current versions"
@@ -7262,87 +7077,76 @@ msgid "<strong>Important:</strong> Once a version has been deleted, you may not 
 msgstr "<strong>Importante:</strong> Una vez que se ha eliminado una versión, no podrás subir una nueva versión con el mismo número de versión."
 
 #: src/olympia/devhub/templates/devhub/versions/list.html:230
-msgid ""
-"Deleting a version which has already been reviewed\n"
-"               may also cause a significant delay in the review of\n"
-"               your next update."
-msgstr ""
-"Eliminar una versión revisada también puede provocar\n"
-"               un retraso importante en la revisión de tu\n"
-"               próxima actualización."
-
-#: src/olympia/devhub/templates/devhub/versions/list.html:233
 msgid "Are you sure you wish to delete this version?"
 msgstr "¿Seguro que deseas eliminar esta versión?"
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:238
+#: src/olympia/devhub/templates/devhub/versions/list.html:235
 msgid "Delete Version"
 msgstr "Borrar versión"
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:240
+#: src/olympia/devhub/templates/devhub/versions/list.html:237
 msgid "Disable Version"
 msgstr "Desactivar la versión"
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:247
+#: src/olympia/devhub/templates/devhub/versions/list.html:244
 msgid "Add a new Version"
 msgstr "Agregar nueva versión"
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:249
+#: src/olympia/devhub/templates/devhub/versions/list.html:246
 msgid "Add Version"
 msgstr "Agregar versión"
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:256 src/olympia/devhub/templates/devhub/versions/list.html:274
+#: src/olympia/devhub/templates/devhub/versions/list.html:253 src/olympia/devhub/templates/devhub/versions/list.html:279
 msgid "Hide Add-on"
 msgstr "Ocultar complemento"
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:259
+#: src/olympia/devhub/templates/devhub/versions/list.html:256
 msgid "Hiding your add-on will prevent it from appearing anywhere in our gallery and will stop users from receiving automatic updates."
 msgstr "Ocultar tu complemento prevendrá que aparezca en cualquier lugar de nuestra galería y no permitirá a los usuarios recibir actualizaciones automáticas."
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:265
+#: src/olympia/devhub/templates/devhub/versions/list.html:263
+msgid "The files awaiting review will be disabled and you will need to upload new versions."
+msgstr ""
+
+#: src/olympia/devhub/templates/devhub/versions/list.html:270
 msgid "Are you sure you wish to hide your add-on?"
 msgstr "¿Estás seguro de que deseas ocultar tu complemento?"
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:286 src/olympia/devhub/templates/devhub/versions/list.html:315
+#: src/olympia/devhub/templates/devhub/versions/list.html:291 src/olympia/devhub/templates/devhub/versions/list.html:313
 msgid "Unlist Add-on"
 msgstr "Eliminar complemento de las listas."
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:289
+#: src/olympia/devhub/templates/devhub/versions/list.html:294
 #, python-format
 msgid ""
 "Unlisting your add-on will make it (and each of its versions/files) invisible on this website. It won't show up in searches, won't have a public facing page, and won't be updated automatically for "
-"current users.  It is recommended for unlisted add-ons to provide a custom <a href=\"%(update_url)s\" target=\"_blank\">updateURL</a> in their manifest file for automatic updates."
+"current users. It is recommended for unlisted add-ons to provide a custom <a href=\"%(update_url)s\" target=\"_blank\">updateURL</a> in their manifest file for automatic updates."
 msgstr ""
 "Si eliminas tu complemento de la lista, se volverá invisible en la página (y todos sus archivos y versiones). No aparecerá en las búsquedas, no tendrá una página pública de presentación ni se "
 "actualizará automáticamente.  Se recomienda que los complementos no listados proporcionen una <a href=\"%(update_url)s\" target=\"_blank\">updateURL</a> en su manifiesto para actualizaciones "
 "automáticas."
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:299
-#, python-format
-msgid "Switching add-ons to unlisted is currently in an open beta. Please <a href=\"%(url)s\" target=\"_blank\">report any bugs</a> that you encounter."
-msgstr "El cambio de complementos a no listados está en beta. Por favor, <a href=\"%(url)s\" target=\"_blank\">informa de cualquier bug</a> que encuentres."
-
-#: src/olympia/devhub/templates/devhub/versions/list.html:305
+#: src/olympia/devhub/templates/devhub/versions/list.html:303
 msgid "Unlisting an add-on is irreversible!"
 msgstr "¡Si quitas un complemento del listado, no hay vuelta atrás!"
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:305
+#: src/olympia/devhub/templates/devhub/versions/list.html:303
 msgid "An unlisted add-on cannot be switched to be listed."
 msgstr "Un complemento oculto no se puede cambiar para ser listado."
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:307
+#: src/olympia/devhub/templates/devhub/versions/list.html:305
 msgid "Are you sure you wish to unlist your add-on?"
 msgstr "¿Estás seguro de que quieres eliminar tu complemento de las listas?"
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:330
+#: src/olympia/devhub/templates/devhub/versions/list.html:328
 msgid "Canceling your review request will leave your add-on as preliminarily reviewed."
 msgstr "Cancelar tu solicitud de revisión dejará tu complemento como revisado preliminarmente."
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:335
+#: src/olympia/devhub/templates/devhub/versions/list.html:333
 msgid "Canceling your review request will mark your add-on incomplete. If you do not complete your add-on after several days by re-requesting review, it will be deleted."
 msgstr "Cancelar tu solicitud de revisión marcará tu complemento incompleto. Si no completas tu complemento a los pocos días volviendo a solicitar su revisión, será borrado."
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:343
+#: src/olympia/devhub/templates/devhub/versions/list.html:341
 msgid "Are you sure you wish to cancel your review request?"
 msgstr "¿Estás seguro de que quieres cancelar tu petición de valoración?"
 
@@ -7685,19 +7489,19 @@ msgstr "complemento, editor o comentario"
 msgid "Search by add-on name / author email"
 msgstr "Buscar por nombre del complemento / correo electrónico del autor"
 
-#: src/olympia/editors/forms.py:103
+#: src/olympia/editors/forms.py:103 src/olympia/editors/forms.py:244 src/olympia/editors/forms.py:257
 msgid "yes"
 msgstr "sí"
 
-#: src/olympia/editors/forms.py:104
+#: src/olympia/editors/forms.py:104 src/olympia/editors/forms.py:244 src/olympia/editors/forms.py:257
 msgid "no"
 msgstr "no"
 
-#: src/olympia/editors/forms.py:105
+#: src/olympia/editors/forms.py:105 src/olympia/editors/forms.py:245
 msgid "Admin Flag"
 msgstr "Indicador de administrador"
 
-#: src/olympia/editors/forms.py:113
+#: src/olympia/editors/forms.py:113 src/olympia/editors/forms.py:253
 msgid "Max. Version"
 msgstr "Versión máxima"
 
@@ -7709,55 +7513,59 @@ msgstr "Días desde el envío"
 msgid "Add-on Types"
 msgstr "Tipos de complemento"
 
-#: src/olympia/editors/forms.py:126 src/olympia/editors/helpers.py:267
+#: src/olympia/editors/forms.py:126 src/olympia/editors/helpers.py:279
 msgid "Platforms"
 msgstr "Plataformas"
 
+#: src/olympia/editors/forms.py:237
+msgid "Search by add-on name / author email / guid"
+msgstr ""
+
 #. L10n: 0 = platform, 1 = filename, 2 = status message
-#: src/olympia/editors/forms.py:238
+#: src/olympia/editors/forms.py:342
 #, python-format
 msgid "<strong>%s</strong> &middot; %s &middot; %s"
 msgstr "<strong>%s</strong> &middot; %s &middot; %s"
 
-#: src/olympia/editors/forms.py:252
+#: src/olympia/editors/forms.py:356
 msgid "Comments:"
 msgstr "Comentarios:"
 
-#: src/olympia/editors/forms.py:256
+#: src/olympia/editors/forms.py:360
 msgid "Operating systems:"
 msgstr "Sistemas operativos:"
 
-#: src/olympia/editors/forms.py:258
+#: src/olympia/editors/forms.py:362
 msgid "Applications:"
 msgstr "Aplicaciones:"
 
-#: src/olympia/editors/forms.py:260
+#: src/olympia/editors/forms.py:364
 msgid "Notify me the next time this add-on is updated. (Subsequent updates will not generate an email)"
 msgstr "Notificarme la próxima vez que se actualice este complemento (las siguientes actualizaciones no generarán un correo electrónico)."
 
-#: src/olympia/editors/forms.py:265
+#: src/olympia/editors/forms.py:369
 msgid "Clear Admin Review Flag"
 msgstr "Eliminar la marca de valoración del administrador"
 
-#: src/olympia/editors/forms.py:267
+#: src/olympia/editors/forms.py:371
 msgid "Clear more info requested flag"
 msgstr "Borrar la señal de solicitud de más información"
 
-#: src/olympia/editors/forms.py:281
+#: src/olympia/editors/forms.py:385
 msgid "Choose a canned response..."
 msgstr "Selecciona una respuesta predefinida..."
 
 #. L10n: Description of what can be searched for.
-#: src/olympia/editors/forms.py:324
+#: src/olympia/editors/forms.py:423
 msgid "theme name"
 msgstr "nombre del tema"
 
-#: src/olympia/editors/forms.py:350
+#: src/olympia/editors/forms.py:449
 msgid "Someone else is reviewing this theme."
 msgstr "Alguien más está revisando este tema."
 
 #. L10n: Description of what can be searched for.
-#: src/olympia/editors/forms.py:447
+#: src/olympia/editors/forms.py:546
 msgid "app, reviewer, or comment"
 msgstr "aplicación, revisor o comentario"
 
@@ -7773,192 +7581,210 @@ msgstr "Pendiente de revisión preliminar"
 msgid "Rejected or Unreviewed"
 msgstr "Rechazados o sin revisar"
 
-#: src/olympia/editors/helpers.py:123 src/olympia/editors/helpers.py:136
+#: src/olympia/editors/helpers.py:125 src/olympia/editors/helpers.py:138
 msgid "Queue"
 msgstr "Cola"
 
-#: src/olympia/editors/helpers.py:124 src/olympia/editors/templates/editors/base.html:50 src/olympia/editors/templates/editors/base.html:65
+#: src/olympia/editors/helpers.py:126 src/olympia/editors/templates/editors/base.html:50 src/olympia/editors/templates/editors/base.html:65
 msgid "Pending Updates"
 msgstr "Actualizaciones pendientes"
 
-#: src/olympia/editors/helpers.py:125 src/olympia/editors/templates/editors/base.html:48 src/olympia/editors/templates/editors/base.html:63
+#: src/olympia/editors/helpers.py:127 src/olympia/editors/templates/editors/base.html:48 src/olympia/editors/templates/editors/base.html:63
 msgid "Full Reviews"
 msgstr "Revisiones completas"
 
-#: src/olympia/editors/helpers.py:126 src/olympia/editors/templates/editors/base.html:52 src/olympia/editors/templates/editors/base.html:67
+#: src/olympia/editors/helpers.py:128 src/olympia/editors/templates/editors/base.html:52 src/olympia/editors/templates/editors/base.html:67
 msgid "Preliminary Reviews"
 msgstr "Revisiones preliminares"
 
-#: src/olympia/editors/helpers.py:127 src/olympia/editors/templates/editors/base.html:54
+#: src/olympia/editors/helpers.py:129 src/olympia/editors/templates/editors/base.html:54
 msgid "Moderated Reviews"
 msgstr "Revisiones moderadas"
 
-#: src/olympia/editors/helpers.py:128 src/olympia/editors/templates/editors/base.html:46
+#: src/olympia/editors/helpers.py:130 src/olympia/editors/templates/editors/base.html:46
 msgid "Fast Track"
 msgstr "Pista rápida"
 
-#: src/olympia/editors/helpers.py:130
+#: src/olympia/editors/helpers.py:132
 msgid "Pending Themes"
 msgstr "Temas pendientes"
 
-#: src/olympia/editors/helpers.py:131 src/olympia/editors/templates/editors/themes/queue.html:4
+#: src/olympia/editors/helpers.py:133 src/olympia/editors/templates/editors/themes/queue.html:4
 msgid "Flagged Themes"
 msgstr "Temas marcados"
 
-#: src/olympia/editors/helpers.py:132
+#: src/olympia/editors/helpers.py:134
 msgid "Update Themes"
 msgstr "Actualizar temas"
 
-#: src/olympia/editors/helpers.py:137
+#: src/olympia/editors/helpers.py:139
 msgid "Unlisted Pending Updates"
 msgstr "Actualizaciones pendientes no listadas"
 
-#: src/olympia/editors/helpers.py:138
+#: src/olympia/editors/helpers.py:140
 msgid "Unlisted Full Reviews"
 msgstr "Revisiones completas no listadas"
 
-#: src/olympia/editors/helpers.py:139
+#: src/olympia/editors/helpers.py:141
 msgid "Unlisted Preliminary Reviews"
 msgstr "Revisiones preliminares no listadas"
 
-#: src/olympia/editors/helpers.py:170
+#: src/olympia/editors/helpers.py:142
+msgid "Unlisted All Add-ons"
+msgstr ""
+
+#: src/olympia/editors/helpers.py:173
 msgid "Fast Track ({0})"
 msgid_plural "Fast Track ({0})"
 msgstr[0] "Pista rápida ({0})"
 msgstr[1] "Pista rápida ({0})"
 
-#: src/olympia/editors/helpers.py:175
+#: src/olympia/editors/helpers.py:178
 msgid "Full Review ({0})"
 msgid_plural "Full Reviews ({0})"
 msgstr[0] "Revisión completa ({0})"
 msgstr[1] "Revisiones completas ({0})"
 
-#: src/olympia/editors/helpers.py:180
+#: src/olympia/editors/helpers.py:183
 msgid "Pending Update ({0})"
 msgid_plural "Pending Updates ({0})"
 msgstr[0] "Actualización pendiente ({0})"
 msgstr[1] "Actualizaciones pendientes ({0})"
 
-#: src/olympia/editors/helpers.py:185
+#: src/olympia/editors/helpers.py:188
 msgid "Preliminary Review ({0})"
 msgid_plural "Preliminary Reviews ({0})"
 msgstr[0] "Revisión preliminar ({0})"
 msgstr[1] "Revisiones preliminares ({0})"
 
-#: src/olympia/editors/helpers.py:190
+#: src/olympia/editors/helpers.py:193
 msgid "Moderated Review ({0})"
 msgid_plural "Moderated Reviews ({0})"
 msgstr[0] "Revisión moderada ({0})"
 msgstr[1] "Revisiones moderadas ({0})"
 
-#: src/olympia/editors/helpers.py:196
+#: src/olympia/editors/helpers.py:199
 msgid "Unlisted Full Review ({0})"
 msgid_plural "Unlisted Full Reviews ({0})"
 msgstr[0] "Revisión completa no listada ({0})"
 msgstr[1] "Revisiones completas no listadas ({0})"
 
-#: src/olympia/editors/helpers.py:201
+#: src/olympia/editors/helpers.py:204
 msgid "Unlisted Pending Update ({0})"
 msgid_plural "Unlisted Pending Updates ({0})"
 msgstr[0] "Revisión pendiente no listada ({0})"
 msgstr[1] "Revisiones pendientes no listadas ({0})"
 
-#: src/olympia/editors/helpers.py:206
+#: src/olympia/editors/helpers.py:209
 msgid "Unlisted Preliminary Review ({0})"
 msgid_plural "Unlisted Preliminary Reviews ({0})"
 msgstr[0] "Revisión preliminar no listadas ({0})"
 msgstr[1] "Revisiones preliminares no listadas ({0})"
 
-#: src/olympia/editors/helpers.py:261
-msgid "Addon"
-msgstr "Complemento"
+#: src/olympia/editors/helpers.py:214
+msgid "Unlisted All Add-ons ({0})"
+msgid_plural "Unlisted All Add-ons ({0})"
+msgstr[0] ""
+msgstr[1] ""
 
-#: src/olympia/editors/helpers.py:262
+#: src/olympia/editors/helpers.py:274
 msgid "Type"
 msgstr "Tipo"
 
-#: src/olympia/editors/helpers.py:263
+#: src/olympia/editors/helpers.py:275
 msgid "Waiting Time"
 msgstr "Tiempo en espera"
 
-#: src/olympia/editors/helpers.py:264 src/olympia/editors/templates/editors/review.html:285
+#: src/olympia/editors/helpers.py:276 src/olympia/editors/templates/editors/review.html:285
 msgid "Flags"
 msgstr "Marcas"
 
-#: src/olympia/editors/helpers.py:265
+#: src/olympia/editors/helpers.py:277
 msgid "Applications"
 msgstr "Aplicaciones"
 
-#: src/olympia/editors/helpers.py:270
+#: src/olympia/editors/helpers.py:282
 msgid "Additional"
 msgstr "Adicional"
 
-#: src/olympia/editors/helpers.py:285
+#: src/olympia/editors/helpers.py:302
 msgid "Site Specific"
 msgstr "Específico del sitio"
 
-#: src/olympia/editors/helpers.py:287
+#: src/olympia/editors/helpers.py:304
 msgid "Requires External Software"
 msgstr "Requiere software externo"
 
-#: src/olympia/editors/helpers.py:289
+#: src/olympia/editors/helpers.py:306
 msgid "Binary Components"
 msgstr "Componentes binarios"
 
-#: src/olympia/editors/helpers.py:313
+#: src/olympia/editors/helpers.py:339
 msgid "moments ago"
 msgstr "hace unos instantes"
 
 #. L10n: first argument is number of minutes
-#: src/olympia/editors/helpers.py:316
+#: src/olympia/editors/helpers.py:342
 msgid "{0} minute"
 msgid_plural "{0} minutes"
 msgstr[0] "{0} minuto"
 msgstr[1] "{0} minutos"
 
 #. L10n: first argument is number of hours
-#: src/olympia/editors/helpers.py:320
+#: src/olympia/editors/helpers.py:346
 msgid "{0} hour"
 msgid_plural "{0} hours"
 msgstr[0] "{0} hora"
 msgstr[1] "{0} horas"
 
 #. L10n: first argument is number of days
-#: src/olympia/editors/helpers.py:324
+#: src/olympia/editors/helpers.py:350
 msgid "{0} day"
 msgid_plural "{0} days"
 msgstr[0] "{0} día"
 msgstr[1] "{0} días"
 
-#: src/olympia/editors/helpers.py:488
+#: src/olympia/editors/helpers.py:364
+msgid "Last Review"
+msgstr ""
+
+#: src/olympia/editors/helpers.py:366
+msgid "Last Update"
+msgstr ""
+
+#: src/olympia/editors/helpers.py:387
+msgid "No Reviews"
+msgstr ""
+
+#: src/olympia/editors/helpers.py:561
 msgid "Push to public"
 msgstr "Pasar a público"
 
-#: src/olympia/editors/helpers.py:490
+#: src/olympia/editors/helpers.py:563
 msgid "Grant full review"
 msgstr "Otorgar revisión completa"
 
-#: src/olympia/editors/helpers.py:505
+#: src/olympia/editors/helpers.py:578
 msgid "Request more information"
 msgstr "Solicitar más información"
 
-#: src/olympia/editors/helpers.py:508
+#: src/olympia/editors/helpers.py:581
 msgid "Request super-review"
 msgstr "Solicitar una super-revisión"
 
-#: src/olympia/editors/helpers.py:519
+#: src/olympia/editors/helpers.py:592
 msgid "Grant preliminary review"
 msgstr "Garantizar la revisión preliminar"
 
-#: src/olympia/editors/helpers.py:520
+#: src/olympia/editors/helpers.py:593
 msgid "This will mark the files as preliminarily reviewed."
 msgstr "Esto marcará los archivos con revisados de forma preliminar."
 
-#: src/olympia/editors/helpers.py:522
+#: src/olympia/editors/helpers.py:595
 msgid "Use this form to request more information from the author. They will receive an email and be able to answer here. You will be notified by email when they reply."
 msgstr "Utiliza este formulario para solicitar más información del autor. Ellos recibirán un correo electrónico y podrán responder aquí. Se te notificará su respuesta por correo electrónico."
 
-#: src/olympia/editors/helpers.py:526
+#: src/olympia/editors/helpers.py:599
 msgid ""
 "If you have concerns about this add-on's security, copyright issues, or other concerns that an administrator should look into, enter your comments in the area below. They will be sent to "
 "administrators, not the author."
@@ -7966,57 +7792,57 @@ msgstr ""
 "Si tienes dudas acerca de la seguridad o de los derechos de autor de este complemento, o si tienes otras dudas que un administrador deba tener en cuenta, escribe tus comentarios en el campo que se "
 "encuentra a continuación. Serán enviados al administrador, no al autor."
 
-#: src/olympia/editors/helpers.py:532
+#: src/olympia/editors/helpers.py:605
 msgid "This will reject the add-on and remove it from the review queue."
 msgstr "Estor rechazará el complemento y lo eliminará de la cola de revisiones."
 
-#: src/olympia/editors/helpers.py:534
-msgid "Make a comment on this version.  The author won't be able to see this."
+#: src/olympia/editors/helpers.py:607
+msgid "Make a comment on this version. The author won't be able to see this."
 msgstr "Haz un comentario de esta versión.  El autor no podrá verlo."
 
-#: src/olympia/editors/helpers.py:538
+#: src/olympia/editors/helpers.py:611
 msgid "This will reject the files and remove them from the review queue."
 msgstr "Esto rechazará los archivos y los eliminará de la cola de revisiones."
 
-#: src/olympia/editors/helpers.py:542
+#: src/olympia/editors/helpers.py:615
 msgid "This will mark the add-on as preliminarily reviewed. Future versions will undergo preliminary review."
 msgstr "Esto marcará el complemento como revisado en forma preliminar. Las futuras versiones pasarán por la revisión preliminar."
 
-#: src/olympia/editors/helpers.py:547
+#: src/olympia/editors/helpers.py:620
 msgid "This will mark the files as preliminarily reviewed. Future versions will undergo preliminary review."
 msgstr "Esto marcará los archivos como revisados en forma preliminar. Las futuras versiones pasarán por la revisión preliminar."
 
-#: src/olympia/editors/helpers.py:552
+#: src/olympia/editors/helpers.py:625
 msgid "Retain preliminary review"
 msgstr "Retener la revisión preliminar"
 
-#: src/olympia/editors/helpers.py:553
+#: src/olympia/editors/helpers.py:626
 msgid "This will retain the add-on as preliminarily reviewed. Future versions will undergo preliminary review."
 msgstr "Esto retendrá la revisión preliminar del complemento. Las futuras versiones pasarán la revisión preliminar."
 
-#: src/olympia/editors/helpers.py:558
+#: src/olympia/editors/helpers.py:631
 msgid "This will approve a sandboxed version of a public add-on to appear on the public side."
 msgstr "Esto aprobará una versión en el área de pruebas de un complemento público para que aparezca en la parte pública."
 
-#: src/olympia/editors/helpers.py:561
+#: src/olympia/editors/helpers.py:634
 msgid "This will reject a version of a public add-on and remove it from the queue."
 msgstr "Esto rechazará una versión de un complemento público y lo eliminará de la cola."
 
-#: src/olympia/editors/helpers.py:564
+#: src/olympia/editors/helpers.py:637
 msgid "This will mark the add-on and its most recent version and files as public. Future versions will go into the sandbox until they are reviewed by an editor."
 msgstr "Esto marcará el complemento y su versión y archivos más recientes como públicos. Las versiones futuras irán al área de pruebas hasta que sean revisadas por un editor."
 
-#: src/olympia/editors/helpers.py:637
+#: src/olympia/editors/helpers.py:714
 msgid "add-on"
 msgstr "complemento"
 
-#: src/olympia/editors/helpers.py:940 src/olympia/editors/helpers.py:960
+#: src/olympia/editors/helpers.py:1020 src/olympia/editors/helpers.py:1040
 msgid "Flagged"
 msgstr "Marcado"
 
 # 85%
 # 100%
-#: src/olympia/editors/helpers.py:944 src/olympia/editors/helpers.py:963
+#: src/olympia/editors/helpers.py:1024 src/olympia/editors/helpers.py:1043
 msgid "Updates"
 msgstr "Actualizaciones"
 
@@ -8068,56 +7894,56 @@ msgstr "Envío del tema marcado para revisión"
 msgid "A question about your Theme submission"
 msgstr "Una pregunta acerca del envío de tu tema"
 
-#: src/olympia/editors/views.py:144
+#: src/olympia/editors/views.py:146
 msgid "New Add-ons (Under 5 days)"
 msgstr "Nuevos complementos (de los últimos 5 días)"
 
-#: src/olympia/editors/views.py:145
+#: src/olympia/editors/views.py:147
 msgid "Passable (5 to 10 days)"
 msgstr "Recientes (5 a 10 días)"
 
-#: src/olympia/editors/views.py:146
+#: src/olympia/editors/views.py:148
 msgid "Overdue (Over 10 days)"
 msgstr "Atrasado (Más de 10 días)"
 
-#: src/olympia/editors/views.py:532
+#: src/olympia/editors/views.py:539
 msgid "An unknown error occurred"
 msgstr "Ha sucedido un error desconocido"
 
-#: src/olympia/editors/views.py:587
+#: src/olympia/editors/views.py:592
 msgid "Self-reviews are not allowed."
 msgstr "Las autorevisiones no están permitidas."
 
-#: src/olympia/editors/views.py:609
+#: src/olympia/editors/views.py:613
 msgid "Review successfully processed."
 msgstr "Revisión procesada con éxito."
 
-#: src/olympia/editors/views.py:807
+#: src/olympia/editors/views.py:812
 msgid "was approved"
 msgstr "ha sido aprobado"
 
-#: src/olympia/editors/views.py:808
+#: src/olympia/editors/views.py:813
 msgid "given preliminary review"
 msgstr "revisado en forma preliminar"
 
-#: src/olympia/editors/views.py:809
+#: src/olympia/editors/views.py:814
 msgid "rejected"
 msgstr "rechazado"
 
-#: src/olympia/editors/views.py:810
+#: src/olympia/editors/views.py:815
 msgctxt "editors_review_history_nominated_adminreview"
 msgid "escalated"
 msgstr "remitido por incidencias"
 
-#: src/olympia/editors/views.py:812
+#: src/olympia/editors/views.py:817
 msgid "needs more information"
 msgstr "necesita más información"
 
-#: src/olympia/editors/views.py:813
+#: src/olympia/editors/views.py:818
 msgid "needs super review"
 msgstr "necesita una super revisión"
 
-#: src/olympia/editors/views.py:814
+#: src/olympia/editors/views.py:819
 msgid "commented"
 msgstr "comentado"
 
@@ -8164,30 +7990,30 @@ msgstr "Colas"
 msgid "Unlisted Queues"
 msgstr "Colas no listadas"
 
-#: src/olympia/editors/templates/editors/base.html:72 src/olympia/editors/templates/editors/performance.html:6
+#: src/olympia/editors/templates/editors/base.html:74 src/olympia/editors/templates/editors/performance.html:6
 msgid "Performance"
 msgstr "Rendimiento"
 
-#: src/olympia/editors/templates/editors/base.html:75 src/olympia/editors/templates/editors/themes/base.html:19 src/olympia/editors/templates/editors/themes/base.html:38
+#: src/olympia/editors/templates/editors/base.html:77 src/olympia/editors/templates/editors/themes/base.html:19 src/olympia/editors/templates/editors/themes/base.html:38
 msgid "Logs"
 msgstr "Registros"
 
-#: src/olympia/editors/templates/editors/base.html:78 src/olympia/editors/templates/editors/reviewlog.html:4 src/olympia/editors/templates/editors/reviewlog.html:27
+#: src/olympia/editors/templates/editors/base.html:80 src/olympia/editors/templates/editors/reviewlog.html:4 src/olympia/editors/templates/editors/reviewlog.html:27
 msgid "Add-on Review Log"
 msgstr "Registro de revisiones del complemento"
 
 # 80%
 # 100%
-#: src/olympia/editors/templates/editors/base.html:80 src/olympia/editors/templates/editors/eventlog.html:4 src/olympia/editors/templates/editors/eventlog.html:8
+#: src/olympia/editors/templates/editors/base.html:82 src/olympia/editors/templates/editors/eventlog.html:4 src/olympia/editors/templates/editors/eventlog.html:8
 #: src/olympia/editors/templates/editors/eventlog_detail.html:4
 msgid "Moderated Review Log"
 msgstr "Registro de revisiones moderadas"
 
-#: src/olympia/editors/templates/editors/base.html:82 src/olympia/editors/templates/editors/beta_signed_log.html:4 src/olympia/editors/templates/editors/beta_signed_log.html:8
+#: src/olympia/editors/templates/editors/base.html:84 src/olympia/editors/templates/editors/beta_signed_log.html:4 src/olympia/editors/templates/editors/beta_signed_log.html:8
 msgid "Signed Beta Files Log"
 msgstr "Registro de archivos beta firmados"
 
-#: src/olympia/editors/templates/editors/base.html:87 src/olympia/editors/templates/editors/includes/daily-message.html:4
+#: src/olympia/editors/templates/editors/base.html:89 src/olympia/editors/templates/editors/includes/daily-message.html:4
 msgid "Announcement"
 msgstr "Anuncio"
 
@@ -8410,45 +8236,45 @@ msgstr "Búsqueda avanzada"
 msgid "clear search"
 msgstr "borrar búsqueda"
 
-#: src/olympia/editors/templates/editors/queue.html:72 src/olympia/editors/templates/editors/queue.html:122
+#: src/olympia/editors/templates/editors/queue.html:78 src/olympia/editors/templates/editors/queue.html:128
 msgid "Process Reviews"
 msgstr "Procesar revisiones"
 
-#: src/olympia/editors/templates/editors/queue.html:80
+#: src/olympia/editors/templates/editors/queue.html:86
 msgid "Moderation actions:"
 msgstr "Acciones de moderación:"
 
-#: src/olympia/editors/templates/editors/queue.html:90
+#: src/olympia/editors/templates/editors/queue.html:96
 #, python-format
 msgid "by %(user)s on %(date)s %(stars)s (%(locale)s)"
 msgstr "por %(user)s el %(date)s %(stars)s (%(locale)s)"
 
-#: src/olympia/editors/templates/editors/queue.html:106
+#: src/olympia/editors/templates/editors/queue.html:112
 #, python-format
 msgid "<strong>%(reason)s</strong> <span class=\"light\">Flagged by %(user)s on %(date)s</span>"
 msgstr "<strong>%(reason)s</strong> <span class=\"light\">marcada por %(user)s el %(date)s</span>"
 
-#: src/olympia/editors/templates/editors/queue.html:119
-msgid "All reviews have been moderated.  Good work!"
+#: src/olympia/editors/templates/editors/queue.html:125
+msgid "All reviews have been moderated. Good work!"
 msgstr "Todas las revisiones completadas.  ¡Buen trabajo!"
 
-#: src/olympia/editors/templates/editors/queue.html:161
+#: src/olympia/editors/templates/editors/queue.html:167
 msgid "Version Notes / Notes for Reviewer"
 msgstr "Notas de la versión / Notas para el revisor"
 
-#: src/olympia/editors/templates/editors/queue.html:169
+#: src/olympia/editors/templates/editors/queue.html:175
 msgid "There are currently no add-ons of this type to review."
 msgstr "No hay ningún complemento de este tipo para revisar."
 
-#: src/olympia/editors/templates/editors/queue.html:181 src/olympia/editors/templates/editors/themes/queue_list.html:85
+#: src/olympia/editors/templates/editors/queue.html:187 src/olympia/editors/templates/editors/themes/queue_list.html:85
 msgid "Helpful Links:"
 msgstr "Enlaces útiles:"
 
-#: src/olympia/editors/templates/editors/queue.html:182
+#: src/olympia/editors/templates/editors/queue.html:188
 msgid "Add-on Policy"
 msgstr "Política sobre complementos"
 
-#: src/olympia/editors/templates/editors/queue.html:184
+#: src/olympia/editors/templates/editors/queue.html:190
 msgid "Editors' Guide"
 msgstr "Guía de editores"
 
@@ -8511,10 +8337,7 @@ msgid "<strong>Warning!</strong> Another user was viewing this page before you."
 msgstr "<strong>¡Atención!</strong> Otro usuario estuvo mirando esta página antes que tú."
 
 #: src/olympia/editors/templates/editors/review.html:237
-msgid ""
-"The whiteboard is the place to exchange information relevant to\n"
-"               this addon (whatever the version), between the developer and the\n"
-"               editor. This is visible and editable by both."
+msgid "The whiteboard is the place to exchange information relevant to this addon (whatever the version), between the developer and the editor. This is visible and editable by both."
 msgstr ""
 "La pizarra es el lugar donde intercambiar información sobre el\n"
 "               complemento entre el desarrollador y el editor (cualquier\n"
@@ -8791,7 +8614,7 @@ msgstr "Hazle una pregunta al artista"
 msgid "Describe your reason for flagging"
 msgstr "Describe un motivo para marcarla"
 
-#: src/olympia/files/forms.py:88
+#: src/olympia/files/forms.py:90
 msgid "Cannot diff a version against itself"
 msgstr "No se puede comparar una versión consigo misma"
 
@@ -8826,51 +8649,51 @@ msgstr "Hubo un error al acceder al archivo %s. %s."
 msgid "There was an error accessing file %s."
 msgstr "Hubo un error al acceder al archivo %s."
 
-#: src/olympia/files/utils.py:343
+#: src/olympia/files/utils.py:340
 msgid "Could not parse uploaded file."
 msgstr "No se ha podido interpretar el archivo subido."
 
-#: src/olympia/files/utils.py:380
+#: src/olympia/files/utils.py:377
 msgid "Invalid file name in archive: {0}"
 msgstr "Nombre de archivo no válido en archivo: {0}"
 
-#: src/olympia/files/utils.py:388
+#: src/olympia/files/utils.py:385
 msgid "File exceeding size limit in archive: {0}"
 msgstr "Archivo excede límite de tamaño en archivo: {0}"
 
-#: src/olympia/files/utils.py:439
+#: src/olympia/files/utils.py:436
 msgid "Invalid archive."
 msgstr "Archivo no válido."
 
-#: src/olympia/files/utils.py:529 src/olympia/files/utils.py:532
+#: src/olympia/files/utils.py:526 src/olympia/files/utils.py:529
 msgid "Could not parse the manifest file."
 msgstr "No se pudo analizar el archivo de manifiesto."
 
-#: src/olympia/files/utils.py:551
+#: src/olympia/files/utils.py:548
 msgid "Could not find an add-on ID."
 msgstr "No se pudo encontrar una identificación para el complemento."
 
-#: src/olympia/files/utils.py:554
+#: src/olympia/files/utils.py:551
 msgid "Add-on ID must be 64 characters or less."
 msgstr "La identificación del complemento debe ser de 64 caracteres o menos."
 
-#: src/olympia/files/utils.py:556
+#: src/olympia/files/utils.py:553
 msgid "Add-on ID doesn't match add-on."
 msgstr "La identificación del complemento no concuerda con el complemento."
 
-#: src/olympia/files/utils.py:564
+#: src/olympia/files/utils.py:561
 msgid "Duplicate add-on ID found."
 msgstr "Se encontró una identificación de complemento duplicada."
 
-#: src/olympia/files/utils.py:567
+#: src/olympia/files/utils.py:564
 msgid "Version numbers should have fewer than 32 characters."
 msgstr "Los números de las versiones deben tener menos de 32 caracteres."
 
-#: src/olympia/files/utils.py:570
+#: src/olympia/files/utils.py:567
 msgid "Version numbers should only contain letters, numbers, and these punctuation characters: +*.-_."
 msgstr "Los números de las versiones deben contener únicamente letras, números y los siguientes caracteres: +*.-_."
 
-#: src/olympia/files/utils.py:587
+#: src/olympia/files/utils.py:584
 msgid "<em:type> doesn't match add-on"
 msgstr "<em:type> no concuerda con un complemento"
 
@@ -8972,6 +8795,10 @@ msgstr "No hay archivos en el archivo subido."
 #: src/olympia/files/templates/files/viewer.html:134
 msgid "Fetching file."
 msgstr "Extrayendo archivo."
+
+#: src/olympia/legacy_api/views.py:255
+msgid "Not implemented yet."
+msgstr "Sin implementar aún."
 
 #: src/olympia/lib/constants.py:6
 msgid "United Arab Emirates Dirham"
@@ -9629,10 +9456,6 @@ msgstr "Kwacha zambiano"
 msgid "Zimbabwe Dollar"
 msgstr "Dólar zimbabuense"
 
-#: src/olympia/lib/video/ffmpeg.py:112 src/olympia/lib/video/totem.py:81
-msgid "Videos must be in WebM."
-msgstr "Los vídeos deben estar en WebM."
-
 #: src/olympia/pages/templates/pages/about.lhtml:3 src/olympia/pages/templates/pages/about.lhtml:10
 msgid "About Mozilla Add-ons"
 msgstr "Acerca de Mozilla Add-ons"
@@ -9644,7 +9467,7 @@ msgstr "¿Qué es este sitio web?"
 #: src/olympia/pages/templates/pages/about.lhtml:13
 msgid ""
 "addons.mozilla.org, commonly known as \"AMO\", is Mozilla's official site for add-ons to Mozilla software, such as Firefox, Thunderbird, and SeaMonkey. Add-ons let you add new features and change "
-"the way your browser or application works.  Take a look around and explore the thousands of ways to customize the way you do things online."
+"the way your browser or application works. Take a look around and explore the thousands of ways to customize the way you do things online."
 msgstr ""
 "addons.mozilla.org, conocida como \"AMO\", es la página oficial de Mozilla para los complementos de su software, como Firefox, Thunderbird y SeaMonkey. Los complementos te permiten agregar nuevas "
 "funciones y cambian el funcionamiento de tu navegador o aplicación. Échale un vistazo y explora las miles de formas de personalizar tu comportamiento en línea."
@@ -10030,7 +9853,7 @@ msgstr "¿Puedo usar una biblioteca de JavaScript como jQuery, MooTools o Protot
 msgid ""
 "Yes. It's possible, but some of the functionality provided by these libraries are available through XPCOM, XUL, and JavaScript. In addition, authors should take care if libraries modify primitive "
 "object prototypes (String.prototype, Date.prototype, etc.) and/or define global functions (eg. the $ function). These are prone to cause conflict with other add-ons, in particular if different add-"
-"ons use different versions of libraries and so on. Developers need to be very, very careful with using them.  Mozilla does not offer documentation on using them to build add-ons."
+"ons use different versions of libraries and so on. Developers need to be very, very careful with using them. Mozilla does not offer documentation on using them to build add-ons."
 msgstr ""
 "Sí. Es posible, pero parte de la funcionalidad que proporcionan estas librerías están disponibles a través de XPCOM, XUL y JavaScript. Además, los autores deberían considerar si las librerías "
 "modifican los prototipos de los objetos primitivos (String.prototype, Date.prototype, etc.) y/o si definen funciones globales (la función $), que tienden a provocar conflictos con otros "
@@ -10160,8 +9983,8 @@ msgstr "¿Puedo alojar mi propio complemento?"
 #, python-format
 msgid ""
 "Yes. Many developers choose to host their own add-ons. Choosing to host your add-on on <a href=\"%(amo_url)s\">Mozilla's add-on site</a>, though, allows for much greater exposure to your add-on due "
-"to the large volume of visitors to the site.  <a href=\"%(md_url)s\">mozdev.org</a> offers free project hosting for Mozilla applications and extensions providing developers with tools to help "
-"manage source code, version control, bug tracking and documentation."
+"to the large volume of visitors to the site. <a href=\"%(md_url)s\">mozdev.org</a> offers free project hosting for Mozilla applications and extensions providing developers with tools to help manage "
+"source code, version control, bug tracking and documentation."
 msgstr ""
 "Sí. Muchos desarrolladores alojan sus propios complementos. Sin embargo, si lo alojas en la <a href=\"%(amo_url)s\">página de complementos de Mozilla</a>, tendrá mucha más visibilidad por el amplio "
 "número de visitantes de la página.  <a href=\"%(md_url)s\">mozdev.org</a> ofrece alojamiento gratis para las aplicaciones y extensiones de Mozilla, proporcionando a los desarrolladores herramientas "
@@ -10216,7 +10039,7 @@ msgstr "¿Dispone Mozilla de una política en relación a lo que se considera un
 #: src/olympia/pages/templates/pages/dev_faq.html:314
 #, python-format
 msgid ""
-"Yes. Mozilla's <a href=\"%(p_url)s\">Add-on Policy</a> describes what is an acceptable submission. This policy is subject to change without notice.  In addition, the AMO editorial team uses the <a "
+"Yes. Mozilla's <a href=\"%(p_url)s\">Add-on Policy</a> describes what is an acceptable submission. This policy is subject to change without notice. In addition, the AMO editorial team uses the <a "
 "href=\"%(g_url)s\">Editors Reviewing Guide</a> to ensure that your add-on meets specific guidelines for functionality and security."
 msgstr ""
 "Sí. La <a href=\"%(p_url)s\">Política de complementos</a> de Mozilla especifíca qué envíos son aceptables. Esta política está sujeta a cambios sin previo aviso. Además, el equipo editorial de AMO "
@@ -10350,7 +10173,7 @@ msgstr "número de aspectos problemáticos descubiertos"
 #: src/olympia/pages/templates/pages/dev_faq.html:434
 #, python-format
 msgid ""
-"This is why it's very important to read the <a href=\"%(g_url)s\">Editors Reviewing Guide</a> to ensure that your add-on is setup as expected.  It's also a good idea to read the blog post, <a href="
+"This is why it's very important to read the <a href=\"%(g_url)s\">Editors Reviewing Guide</a> to ensure that your add-on is setup as expected. It's also a good idea to read the blog post, <a href="
 "\"%(blog_url)s\">Successfully Getting your Add-on Reviewed</a> which provides excellent insight into ensuring a smooth review of your add-on."
 msgstr ""
 "Por eso es muy importante leer la <a href=\"%(g_url)s\">Guía de revisión para editores</a>, para confirmar que tu complemento es lo que esperabas. También recomendamos leer el post <a href="
@@ -10475,7 +10298,7 @@ msgstr ""
 
 #: src/olympia/pages/templates/pages/dev_faq.html:572
 msgid ""
-"Free Software Foundation provides short summaries of the key open source licenses, including whether the license qualifies as a free software license or a copyleft license.  Also includes a "
+"Free Software Foundation provides short summaries of the key open source licenses, including whether the license qualifies as a free software license or a copyleft license. Also includes a "
 "discussion of what constitutes a free software license or a copyleft license (e.g., a Copyleft license is a general method for making a program or other work free, and requiring all modified and "
 "extended versions of the program to be free as well.)"
 msgstr ""
@@ -10689,21 +10512,15 @@ msgid "Add-on Gallery"
 msgstr "Galería de complementos"
 
 #: src/olympia/pages/templates/pages/faq.html:171
-msgid ""
-"How do I choose between add-ons that seem to do the same\n"
-"    thing?"
+msgid "How do I choose between add-ons that seem to do the same thing?"
 msgstr ""
 "¿Cómo puedo elegir entre complementos que parece que hacen\n"
 "    lo mismo?"
 
-#: src/olympia/pages/templates/pages/faq.html:173
+#: src/olympia/pages/templates/pages/faq.html:172
 msgid ""
-"There are often several add-ons that have similar features. To\n"
-"    figure out which is right for you, read the entire description of the\n"
-"    add-on and view its screenshots. If there are still several in the running,\n"
-"    read through the add-on's ratings, user reviews, and statistics to see\n"
-"    which is most liked by other users. Remember that you can also just try\n"
-"    out both and see which you like better."
+"There are often several add-ons that have similar features. To figure out which is right for you, read the entire description of the add-on and view its screenshots. If there are still several in "
+"the running, read through the add-on's ratings, user reviews, and statistics to see which is most liked by other users. Remember that you can also just try out both and see which you like better."
 msgstr ""
 "A veces, hay varios complementos con funciones similares. Para\n"
 "    saber cuál es mejor, lee la descripción completa del complemento\n"
@@ -10757,46 +10574,40 @@ msgid "How much do add-ons cost to purchase?"
 msgstr "¿Cuánto cuesta comprar un complemento?"
 
 #: src/olympia/pages/templates/pages/faq.html:207
-msgid ""
-"Add-ons hosted in our gallery are free unless clearly marked\n"
-"    otherwise."
+msgid "Add-ons hosted in our gallery are free unless clearly marked otherwise."
 msgstr ""
 "Los complementos alojados en nuestra galería son gratis, excepto aquellos\n"
 "    que lo especifiquen."
 
-#: src/olympia/pages/templates/pages/faq.html:210
+#: src/olympia/pages/templates/pages/faq.html:209
 msgid "What does it mean when an add-on asks for contributions?"
 msgstr "¿Qué significa que un complemento solicita contribuciones?"
 
-#: src/olympia/pages/templates/pages/faq.html:211
+#: src/olympia/pages/templates/pages/faq.html:210
 msgid ""
-"Some add-on authors request users who enjoy an add-on to\n"
-"        contribute to its development by making a monetary contribution. These\n"
-"        contributions go directly to the developer unless a third party is\n"
-"        indicated, such as the non-profit Mozilla Foundation."
+"Some add-on authors request users who enjoy an add-on to contribute to its development by making a monetary contribution. These contributions go directly to the developer unless a third party is "
+"indicated, such as the non-profit Mozilla Foundation."
 msgstr ""
 "Algunos autores piden a los usuarios que les gustó su complemento que         \n"
 "        colaboren con el desarrollo haciendo donaciones. Estas donaciones van\n"
 "        directamente al desarrollador, excepto si aparece nombrado\n"
 "        un tercero, como la fundación sin ánimo de lucro Mozilla."
 
-#: src/olympia/pages/templates/pages/faq.html:216
+#: src/olympia/pages/templates/pages/faq.html:215
 msgid "What are beta add-ons?"
 msgstr "¿Qué son los complementos en fase beta?"
 
-#: src/olympia/pages/templates/pages/faq.html:218
+#: src/olympia/pages/templates/pages/faq.html:217
 msgid ""
-"Beta add-ons are unreviewed versions which represent the\n"
-"        latest work of an add-on author. While different authors have different\n"
-"        standards for beta code quality, you should assume that these add-ons\n"
-"        are less stable than the general add-on releases."
+"Beta add-ons are unreviewed versions which represent the latest work of an add-on author. While different authors have different standards for beta code quality, you should assume that these add-"
+"ons are less stable than the general add-on releases."
 msgstr ""
 "Los complementos beta son versiones no revisadas de los últimos\n"
 "        avances del autor. Aunque los autores tienen distintos estándares \n"
 "        para medir la calidad del código beta, deberías asumir que es una \n"
 "        versión menos estable que las generales."
 
-#: src/olympia/pages/templates/pages/faq.html:222
+#: src/olympia/pages/templates/pages/faq.html:221
 msgid ""
 "Please note that when you install an add-on from the \"Beta Version\" section of an add-on's listing, you will continue to receive updates for that add-on as they become available. Like the initial "
 "version you installed, all beta releases are unreviewed by Mozilla and may harm your computer."
@@ -10804,54 +10615,47 @@ msgstr ""
 "Por favor, ten en cuenta que cuando instalas un complemento de la sección \"Versiones beta\", seguirás recibiendo actualizaciones cuando estén disponibles. Como la versión inicial que instalaste, "
 "ninguna de las versiones beta son revisadas por Mozilla y pueden dañar tu equipo."
 
-#: src/olympia/pages/templates/pages/faq.html:229
-msgid ""
-"What does it mean when an add-on is flagged as\n"
-"    slow?"
+#: src/olympia/pages/templates/pages/faq.html:228
+msgid "What does it mean when an add-on is flagged as slow?"
 msgstr ""
 "¿Qué significa cuando un complemento está marcado como\n"
 "    lento?"
 
-#: src/olympia/pages/templates/pages/faq.html:231
-msgid ""
-"Most add-ons load code and resources at the same time Firefox\n"
-"        is starting up. In most cases the impact in start-up time is minimal,\n"
-"        but some add-ons can cause a noticeable slowdown."
+#: src/olympia/pages/templates/pages/faq.html:229
+msgid "Most add-ons load code and resources at the same time Firefox is starting up. In most cases the impact in start-up time is minimal, but some add-ons can cause a noticeable slowdown."
 msgstr ""
 "La mayoría de complementos cargan código y recursos durante el inicio\n"
 "        de Firefox. El impacto al inicio suele ser mínimo, pero algunos\n"
 "        complementos pueden provocar cierta ralentización."
 
-#: src/olympia/pages/templates/pages/faq.html:236
+#: src/olympia/pages/templates/pages/faq.html:234
 msgid "How do I report an inappropriate or spam user review?"
 msgstr "¿Cómo informar de una reseña inapropiada o spam?"
 
-#: src/olympia/pages/templates/pages/faq.html:237
+#: src/olympia/pages/templates/pages/faq.html:235
 msgid ""
-"To report a user review of an add-on, log in with your account\n"
-"    and visit the add-on's reviews page. Find the review you wish to report,\n"
-"    click \"Report this review\" and select a reason. Our editorial team will\n"
-"    investigate the review and take appropriate action."
+"To report a user review of an add-on, log in with your account and visit the add-on's reviews page. Find the review you wish to report, click \"Report this review\" and select a reason. Our "
+"editorial team will investigate the review and take appropriate action."
 msgstr ""
 "Para informar sobre el comentario de un complemento, inicia sesión\n"
 "    y ve a la página de revisiones del complemento. Busca el comentario,\n"
 "    haz clic en \"Denunciar este comentario\" y selecciona una razón. Nuestro equipo\n"
 "    editorial lo investigará y aplicará las acciones adecuadas."
 
-#: src/olympia/pages/templates/pages/faq.html:242
+#: src/olympia/pages/templates/pages/faq.html:240
 msgid "How do I report a bug or contact the Mozilla Add-ons team?"
 msgstr "¿Cómo informar de un bug o contactar con el equipo de Mozilla Add-ons?"
 
-#: src/olympia/pages/templates/pages/faq.html:243
+#: src/olympia/pages/templates/pages/faq.html:241
 #, python-format
 msgid "Please visit our <a href=\"%(contact_url)s\">Contact page</a>."
 msgstr "Por favor visita nuestra <a href=\"%(contact_url)s\">página de contacto</a>."
 
-#: src/olympia/pages/templates/pages/faq.html:246
+#: src/olympia/pages/templates/pages/faq.html:244
 msgid "What is a Source Code License?"
 msgstr "¿Qué es una licencia de código abierto?"
 
-#: src/olympia/pages/templates/pages/faq.html:247
+#: src/olympia/pages/templates/pages/faq.html:245
 #, python-format
 msgid ""
 "The source code used to create an add-on is an exclusive copyright of the add-on author, unless otherwise declared in a source code license. Many add-ons on this site have <a href=\"%(url)s\" lang="
@@ -10862,42 +10666,42 @@ msgstr ""
 "sitio tienen <a href=\"%(url)s\" lang=\"en\">licencias de código abierto</a> que hacen su código públicamente disponible para copiar y reutilizar bajo condiciones determinadas por el autor. Muchos "
 "autores eligen licencias conocidas como GPL o BSD en lugar de hacer las suyas."
 
-#: src/olympia/pages/templates/pages/faq.html:256
+#: src/olympia/pages/templates/pages/faq.html:254
 #, python-format
 msgid "Firefox and other Mozilla software are <a href=\"%(url)s\">open source</a>."
 msgstr "Firefox y otros productos Mozilla son de <a href=\"%(url)s\">código abierto</a>."
 
-#: src/olympia/pages/templates/pages/faq.html:264
+#: src/olympia/pages/templates/pages/faq.html:262
 msgid "Collections and Favorites"
 msgstr "Colecciones y favoritos"
 
-#: src/olympia/pages/templates/pages/faq.html:267
+#: src/olympia/pages/templates/pages/faq.html:265
 msgid "What is a collection?"
 msgstr "¿Qué es una colección?"
 
-#: src/olympia/pages/templates/pages/faq.html:268
+#: src/olympia/pages/templates/pages/faq.html:266
 msgid "Collections are groups of related add-ons created by users to share."
 msgstr "Las colecciones son grupos de complementos relacionados entre sí, creados por usuarios para compartirlos."
 
-#: src/olympia/pages/templates/pages/faq.html:270
+#: src/olympia/pages/templates/pages/faq.html:268
 msgid "What is the My Favorites collection?"
 msgstr "¿Qué es la colección Mis favoritos?"
 
-#: src/olympia/pages/templates/pages/faq.html:271
+#: src/olympia/pages/templates/pages/faq.html:269
 msgid "Favorite add-ons are add-ons that you have bookmarked to easily get back to later. You can add an add-on to your favorites collection by clicking \"Add to favorites\" on its details page."
 msgstr ""
 "Los complementos favoritos son complementos que has etiquetado para poder encontrarlos fácilmente posteriormente. Puedes añadir un complemento a tu colección de favoritos haciendo clic en \"Agregar "
 "a favoritos\" en su página de detalles."
 
-#: src/olympia/pages/templates/pages/faq.html:275 src/olympia/templates/menu_links.html:13 src/olympia/templates/impala/header_title.html:17
+#: src/olympia/pages/templates/pages/faq.html:273 src/olympia/templates/menu_links.html:13 src/olympia/templates/impala/header_title.html:17
 msgid "Mobile Add-ons"
 msgstr "Complementos para Mobile"
 
-#: src/olympia/pages/templates/pages/faq.html:278
+#: src/olympia/pages/templates/pages/faq.html:276
 msgid "What are mobile add-ons?"
 msgstr "¿Qué son los complementos para móviles?"
 
-#: src/olympia/pages/templates/pages/faq.html:279
+#: src/olympia/pages/templates/pages/faq.html:277
 #, python-format
 msgid ""
 "Mobile add-ons work with <a href=\"%(mobile_url)s\">Firefox for Mobile</a> and add or modify functionality just like desktop add-ons. You can find add-ons that work with Firefox for Mobile in our "
@@ -10906,22 +10710,22 @@ msgstr ""
 "Los complementos para móviles funcionan con <a href=\"%(mobile_url)s\">Firefox para dispositivos móviles</a> y agregan o modifican funcionalidades de la misma forma que los complementos de "
 "escritorio. Puedes encontrar complementos que funcionan con Firefox para dispositivos móviles en nuestra <a href=\"%(gallery_url)s\">galería</a>."
 
-#: src/olympia/pages/templates/pages/faq.html:288
+#: src/olympia/pages/templates/pages/faq.html:286
 msgid "Developer Topics"
 msgstr "Temas para desarrolladores"
 
-#: src/olympia/pages/templates/pages/faq.html:289
+#: src/olympia/pages/templates/pages/faq.html:287
 #, python-format
 msgid "Please see our <a href=\"%(faq_url)s\">Developer FAQ</a> and <a href=\"%(hub_url)s\">Developer Hub</a> for answers to add-on developer-related questions."
 msgstr ""
 "Consulta nuestras <a href=\"%(faq_url)s\">FAQ para desarrolladores</a> y el <a href=\"%(hub_url)s\">Centro de Desarrolladores</a> para encontrar respuestas relacionadas con la programación de "
 "complementos."
 
-#: src/olympia/pages/templates/pages/faq.html:294
+#: src/olympia/pages/templates/pages/faq.html:292
 msgid "Still have questions?"
 msgstr "¿Aún tienes preguntas?"
 
-#: src/olympia/pages/templates/pages/faq.html:295
+#: src/olympia/pages/templates/pages/faq.html:293
 #, python-format
 msgid "For general Firefox support, visit our <a href=\"%(sumo_url)s\">support website</a>. For general add-on and website questions, visit our <a href=\"%(forum_url)s\">forum</a>."
 msgstr ""
@@ -11073,7 +10877,7 @@ msgstr "Sunbird se ha retirado"
 
 #: src/olympia/pages/templates/pages/sunbird.html:29
 msgid ""
-"Development on the Sunbird project has halted and its final release was on March 30, 2010.  We've been proud to host Sunbird add-ons on this site but as the project is no longer maintained we have "
+"Development on the Sunbird project has halted and its final release was on March 30, 2010. We've been proud to host Sunbird add-ons on this site but as the project is no longer maintained we have "
 "disabled our support for the add-ons."
 msgstr ""
 "El desarrollo del proyecto Sunbird se detuvo y el último lanzamiento fue el 30 de Marzo 2010.  Nos enorgullece haber alojado los complementos de Sunbird en la página, para como el proyecto ya no se "
@@ -11153,7 +10957,7 @@ msgstr "Agregar una valoración para {0}"
 #, python-format
 msgid ""
 "<h2>Keep these tips in mind:</h2> <ul> <li> Write like you're telling a friend about your experience with the add-on. Give specifics and helpful details, such as what features you liked and/or "
-"disliked, how easy to use it is, and any disadvantages it has.  Avoid generic language such as calling it \"Great\" or \"Bad\" unless you can give reasons why you believe this is so. </li> <li> "
+"disliked, how easy to use it is, and any disadvantages it has. Avoid generic language such as calling it \"Great\" or \"Bad\" unless you can give reasons why you believe this is so. </li> <li> "
 "Please do not post bug reports in reviews. We do not make your email address available to add-on developers and they may need to contact you to help resolve your issue. See the <a href=\"%(support)s"
 "\">support section</a> to find out where to get assistance for this add-on. </li> <li>Please keep reviews clean, avoid the use of improper language and do not post any personal information. </li> </"
 "ul> <p>Please read the <a href=\"%(guide)s\" target=\"_blank\">Review Guidelines</a> for more detail about user add-on reviews.</p>"
@@ -11410,16 +11214,16 @@ msgstr "{0} complementos"
 
 #. L10n: {0} is an application, such as Firefox. This means "any version of
 #. Firefox."
-#: src/olympia/search/views.py:554
+#: src/olympia/search/views.py:547
 msgid "Any {0}"
 msgstr "Cualquier {0}"
 
 #. L10n: "All Systems" means show everything regardless of platform.
-#: src/olympia/search/views.py:589
+#: src/olympia/search/views.py:582
 msgid "All Systems"
 msgstr "Todos los sistemas"
 
-#: src/olympia/search/views.py:600
+#: src/olympia/search/views.py:593
 msgid "All Tags"
 msgstr "Todas las etiquetas"
 
@@ -11593,31 +11397,31 @@ msgstr "Compartir este complemento"
 msgid "Share this Collection"
 msgstr "Compartir esta colección"
 
-#: src/olympia/signing/views.py:30 src/olympia/templates/base.html:75 src/olympia/templates/impala/base.html:115
+#: src/olympia/signing/views.py:33 src/olympia/templates/base.html:71 src/olympia/templates/impala/base.html:112
 msgid "Some features are temporarily disabled while we perform website maintenance. We'll be back to full capacity shortly."
 msgstr "Algunas características están temporalmente deshabilitadas mientras realizamos tareas de mantenimiento en la web. Volveremos a tener plena capacidad muy pronto."
 
-#: src/olympia/signing/views.py:53
+#: src/olympia/signing/views.py:56
 msgid "Could not find add-on with id \"{}\"."
 msgstr "No se pudo encontrar ningún complemento con el ID \"{}\"."
 
-#: src/olympia/signing/views.py:67
+#: src/olympia/signing/views.py:70
 msgid "You do not own this addon."
 msgstr "Este complemento no te pertenece."
 
-#: src/olympia/signing/views.py:82
+#: src/olympia/signing/views.py:87
 msgid "Missing \"upload\" key in multipart file data."
 msgstr "Falta la clave \"upload\" en los datos del fichero multipart."
 
-#: src/olympia/signing/views.py:96
+#: src/olympia/signing/views.py:101
 msgid "Version does not match the manifest file."
 msgstr "La versión no coincide con el archivo manifest."
 
-#: src/olympia/signing/views.py:100
+#: src/olympia/signing/views.py:105
 msgid "Version already exists."
 msgstr "Esta versión ya existe."
 
-#: src/olympia/signing/views.py:136
+#: src/olympia/signing/views.py:141
 msgid "No uploaded file for that addon and version."
 msgstr "Ningún archivo subido para ese complemento o esa versión."
 
@@ -11730,91 +11534,91 @@ msgstr "{0} :: Panel de estadísticas"
 msgid "Statistics Dashboard :: Add-ons for {0}"
 msgstr "Panel de estadísticas :: Complementos para {0}"
 
-#: src/olympia/stats/templates/stats/stats.html:30
-msgid "Controls:"
-msgstr "Controles:"
-
-#: src/olympia/stats/templates/stats/stats.html:33
-msgid "reset zoom"
-msgstr "restablecer zoom"
-
-#: src/olympia/stats/templates/stats/stats.html:40
-msgid "Group by:"
-msgstr "Agrupar por:"
-
-#: src/olympia/stats/templates/stats/stats.html:42
-msgid "day"
-msgstr "día"
-
-#: src/olympia/stats/templates/stats/stats.html:45
-msgid "week"
-msgstr "semana"
-
-#: src/olympia/stats/templates/stats/stats.html:48
-msgid "month"
-msgstr "mes"
-
-#: src/olympia/stats/templates/stats/stats.html:54
-msgid "For last:"
-msgstr "Por último:"
-
-#: src/olympia/stats/templates/stats/stats.html:57
-msgid "7 days"
-msgstr "7 días"
-
-#: src/olympia/stats/templates/stats/stats.html:60
-msgid "30 days"
-msgstr "30 días"
-
-#: src/olympia/stats/templates/stats/stats.html:63
-msgid "90 days"
-msgstr "90 días"
-
-#: src/olympia/stats/templates/stats/stats.html:66
-msgid "365 days"
-msgstr "365 días"
-
-#: src/olympia/stats/templates/stats/stats.html:69
-msgid "Custom..."
-msgstr "Personalizar..."
-
 #. {0} is an add-on name
-#: src/olympia/stats/templates/stats/stats.html:88 src/olympia/stats/templates/stats/stats.html:91
+#: src/olympia/stats/templates/stats/stats.html:44 src/olympia/stats/templates/stats/stats.html:47
 msgid "Statistics for {0}"
 msgstr "Estadísticas para {0}"
 
-#: src/olympia/stats/templates/stats/stats.html:94
+#: src/olympia/stats/templates/stats/stats.html:50
 msgid "Statistics Dashboard"
 msgstr "Panel de estadísticas"
 
-#: src/olympia/stats/templates/stats/stats.html:104
+#: src/olympia/stats/templates/stats/stats.html:57
+msgid "Controls:"
+msgstr "Controles:"
+
+#: src/olympia/stats/templates/stats/stats.html:60
+msgid "reset zoom"
+msgstr "restablecer zoom"
+
+#: src/olympia/stats/templates/stats/stats.html:67
+msgid "Group by:"
+msgstr "Agrupar por:"
+
+#: src/olympia/stats/templates/stats/stats.html:69
+msgid "day"
+msgstr "día"
+
+#: src/olympia/stats/templates/stats/stats.html:72
+msgid "week"
+msgstr "semana"
+
+#: src/olympia/stats/templates/stats/stats.html:75
+msgid "month"
+msgstr "mes"
+
+#: src/olympia/stats/templates/stats/stats.html:81
+msgid "For last:"
+msgstr "Por último:"
+
+#: src/olympia/stats/templates/stats/stats.html:84
+msgid "7 days"
+msgstr "7 días"
+
+#: src/olympia/stats/templates/stats/stats.html:87
+msgid "30 days"
+msgstr "30 días"
+
+#: src/olympia/stats/templates/stats/stats.html:90
+msgid "90 days"
+msgstr "90 días"
+
+#: src/olympia/stats/templates/stats/stats.html:93
+msgid "365 days"
+msgstr "365 días"
+
+#: src/olympia/stats/templates/stats/stats.html:96
+msgid "Custom..."
+msgstr "Personalizar..."
+
+#: src/olympia/stats/templates/stats/stats.html:106
 msgid "Statistics processing is currently disabled, so recent data is unavailable. The statistics are still being collected and this page will be updated soon with the missing data."
 msgstr ""
 "El proceso de estadísticas está desactivado temporalmente, por lo que los datos más recientes no están disponibles. Seguimos recopilando estadísticas y la página se actualizará pronto con los datos "
 "que faltan."
 
-#: src/olympia/stats/templates/stats/stats.html:110
+#: src/olympia/stats/templates/stats/stats.html:112
 msgid "Loading the latest data&hellip;"
 msgstr "Cargando los datos más recientes&hellip;"
 
-#: src/olympia/stats/templates/stats/stats.html:142 src/olympia/stats/templates/stats/reports/overview.html:25 src/olympia/stats/templates/stats/reports/overview.html:37
+#: src/olympia/stats/templates/stats/stats.html:144 src/olympia/stats/templates/stats/reports/overview.html:25 src/olympia/stats/templates/stats/reports/overview.html:37
 #: src/olympia/stats/templates/stats/reports/overview.html:49
 msgid "No data available."
 msgstr "No hay datos disponibles."
 
-#: src/olympia/stats/templates/stats/stats.html:177
+#: src/olympia/stats/templates/stats/stats.html:179
 msgid "This dashboard is currently <b>public</b>."
 msgstr "Este panel de control es actualmente <b>público</b>."
 
-#: src/olympia/stats/templates/stats/stats.html:179
+#: src/olympia/stats/templates/stats/stats.html:181
 msgid "Contribution stats are currently <b>private</b>."
 msgstr "Las estadísticas de contribuciones son actualmente <b>privadas</b>."
 
-#: src/olympia/stats/templates/stats/stats.html:182
+#: src/olympia/stats/templates/stats/stats.html:184
 msgid "This dashboard is currently <b>private</b>."
 msgstr "Este panel de control es actualmente <b>privado</b>."
 
-#: src/olympia/stats/templates/stats/stats.html:185
+#: src/olympia/stats/templates/stats/stats.html:187
 msgid "Change settings."
 msgstr "Cambiar configuración."
 
@@ -11978,15 +11782,6 @@ msgstr "Registros de usuarios por fecha"
 msgid "Application versions by Date"
 msgstr "Versiones de la aplicación por fecha"
 
-#: src/olympia/tags/templates/tags/top_cloud.html:4
-msgid "Top {0} Tags"
-msgstr "{0} etiquetas más populares"
-
-#. {0} is the current application name
-#: src/olympia/tags/templates/tags/top_cloud.html:14
-msgid "{0} Top Tags"
-msgstr "Etiquetas más populares de {0}"
-
 #: src/olympia/templates/amo_footer.html:6 src/olympia/templates/includes/lang_switcher.html:2
 msgid "Other languages"
 msgstr "Otros idiomas"
@@ -11995,11 +11790,11 @@ msgstr "Otros idiomas"
 msgid "Mozilla Add-ons"
 msgstr "Complementos de Mozilla"
 
-#: src/olympia/templates/base.html:91 src/olympia/templates/impala/base.html:81
+#: src/olympia/templates/base.html:89 src/olympia/templates/impala/base.html:78
 msgid "Find add-ons for other applications"
 msgstr "Encuentra complementos para otras aplicaciones"
 
-#: src/olympia/templates/base.html:92 src/olympia/templates/impala/base.html:81
+#: src/olympia/templates/base.html:90 src/olympia/templates/impala/base.html:78
 msgid "Other Applications"
 msgstr "Otras aplicaciones"
 
@@ -12024,7 +11819,7 @@ msgid "View Mobile Site"
 msgstr "Ver sitio para dispositivos móviles"
 
 #: src/olympia/templates/copyright.html:7
-msgid "Site Status "
+msgid "Site Status"
 msgstr "Estado del sitio"
 
 #: src/olympia/templates/footer.html:3
@@ -12126,35 +11921,35 @@ msgstr "Bienvenido/a, {0}"
 msgid "<a href=\"%(reg)s\">Register</a> or <a href=\"%(login)s\">Log in</a>"
 msgstr "<a href=\"%(reg)s\">Registrarse</a> o <a href=\"%(login)s\">Conectarse</a>"
 
-#: src/olympia/templates/impala/base.html:126
+#: src/olympia/templates/impala/base.html:123
 #, python-format
 msgid "To try the thousands of add-ons available here, download <a href=\"%(url)s\">Mozilla Firefox</a>, a fast, free way to surf the Web!"
 msgstr "Para probar los miles de complementos que están disponibles aquí, descarga <a href=\"%(url)s\">Mozilla Firefox</a>, ¡una forma rápida y gratuita de navegar en la Web!"
 
-#: src/olympia/templates/impala/base.html:138
+#: src/olympia/templates/impala/base.html:135
 #, python-format
 msgid "Add-ons is switching to Firefox Accounts for login. <a href=\"%(url)s\" class=\"fxa-login\">Sign in now to transfer your account.</a>"
 msgstr "Inicia sesión en tu cuenta de Firefox para acceder a tus complementos. <a href=\"%(url)s\" class=\"fxa-login\">Inicia sesión ahora.</a>"
 
 #. {0} is an application, such as Firefox.
-#: src/olympia/templates/impala/base.html:148
+#: src/olympia/templates/impala/base.html:145
 msgid "Welcome to {0} Add-ons."
 msgstr "Bienvenido a Complementos {0}."
 
-#: src/olympia/templates/impala/base.html:151
+#: src/olympia/templates/impala/base.html:148
 msgid "Choose from thousands of extra features and styles to make Firefox your own."
 msgstr "Elige de entre miles de funciones y estilos extra para hacer de Firefox tu propio navegador."
 
-#: src/olympia/templates/impala/base.html:156
+#: src/olympia/templates/impala/base.html:153
 #, python-format
 msgid "Add extra features and styles to make %(app)s your own."
 msgstr "Añade funciones y estilos extra para hacer tu propio %(app)s."
 
-#: src/olympia/templates/impala/base.html:164
+#: src/olympia/templates/impala/base.html:161
 msgid "On the go?"
 msgstr "¿Eres una persona dinámica?"
 
-#: src/olympia/templates/impala/base.html:166
+#: src/olympia/templates/impala/base.html:163
 msgid "Check out our <a class=\"mobile-link\" href=\"#\">Mobile Add-ons site</a>."
 msgstr "Revisa nuestro <a class=\"mobile-link\" href=\"#\">sitio sobre complementos para dispositivos móviles</a>."
 
@@ -12380,19 +12175,19 @@ msgstr "No se ha encontrado un usuario con ese correo electrónico."
 
 #. L10n: {id} will be something like "13ad6a", just a random number
 #. to differentiate this user from other anonymous users.
-#: src/olympia/users/models.py:353
+#: src/olympia/users/models.py:362
 msgid "Anonymous user {id}"
 msgstr "Usuario anónimo {id}"
 
-#: src/olympia/users/models.py:410
+#: src/olympia/users/models.py:419
 msgid "Your account has been restricted"
 msgstr "Tu cuenta ha sido restringida"
 
-#: src/olympia/users/models.py:480
+#: src/olympia/users/models.py:489
 msgid "Please confirm your email address"
 msgstr "Por favor, confirma tu dirección de correo"
 
-#: src/olympia/users/models.py:506
+#: src/olympia/users/models.py:515
 msgid "My Mobile Add-ons"
 msgstr "Mis complementos para móviles"
 
@@ -12676,7 +12471,7 @@ msgstr "Contraseña"
 
 #: src/olympia/users/templates/users/edit.html:70
 #, python-format
-msgid "Change your password.  If you forgot your password, you can <a href=\"%(reset_url)s\">use the reset form</a>."
+msgid "Change your password. If you forgot your password, you can <a href=\"%(reset_url)s\">use the reset form</a>."
 msgstr "Cambia la contraseña.  Si la has olvidado, puedes <a href=\"%(reset_url)s\">usar el formulario para restablecerla</a>."
 
 #: src/olympia/users/templates/users/edit.html:76
@@ -12696,7 +12491,7 @@ msgid "Profile"
 msgstr "Perfil"
 
 #: src/olympia/users/templates/users/edit.html:100
-msgid "Give us a bit more information about yourself.  All these fields are optional, but they'll help other users get to know you better."
+msgid "Give us a bit more information about yourself. All these fields are optional, but they'll help other users get to know you better."
 msgstr "Cuéntanos un poco más sobre ti.  Todos los campos son opcionales, pero ayudarán a otros usuarios a conocerte mejor."
 
 #: src/olympia/users/templates/users/edit.html:124
@@ -12916,7 +12711,7 @@ msgid "Confirm password"
 msgstr "Confirmar contraseña"
 
 #: src/olympia/users/templates/users/pwreset_confirm.html:47
-msgid "The password reset link was invalid, possibly because it has already been used.  Please request a new password reset."
+msgid "The password reset link was invalid, possibly because it has already been used. Please request a new password reset."
 msgstr "El enlace para restablecer la contraseña es inválido, quizás porque ya se ha usado.  Solicita uno nuevo, por favor."
 
 #: src/olympia/users/templates/users/pwreset_request.html:15
@@ -13104,7 +12899,7 @@ msgstr "No hemos podido cancelar tu suscripción"
 
 #: src/olympia/users/templates/users/unsubscribe.html:30
 #, python-format
-msgid "Unfortunately, we weren't able to unsubscribe you.  The link you clicked is invalid. However, you can unsubscribe still unsubscribe on your <a href=\"%(edit_url)s\">edit profile page</a>."
+msgid "Unfortunately, we weren't able to unsubscribe you. The link you clicked is invalid. However, you can unsubscribe still unsubscribe on your <a href=\"%(edit_url)s\">edit profile page</a>."
 msgstr "Lo sentimos, no se ha cancelado la suspcripción.  El enlace que seleccionaste es inválido. Pero puedes cancelar la suscripción en tu <a href=\"%(edit_url)s\">página de edición de perfil</a>."
 
 #: src/olympia/users/templates/users/vcard.html:2
@@ -13158,15 +12953,15 @@ msgstr "Historial de versiones de %s"
 msgid "Version History with Changelogs"
 msgstr "Historial de la versión con las listas de cambios"
 
-#: src/olympia/versions/models.py:314
+#: src/olympia/versions/models.py:313
 msgid "Add-on uses binary components."
 msgstr "El complemento usa componentes binarios."
 
-#: src/olympia/versions/models.py:317
+#: src/olympia/versions/models.py:316
 msgid "Add-on has opted into strict compatibility checking."
 msgstr "El complemento ha optado por la comprobación estricta de compatibilidad."
 
-#: src/olympia/versions/models.py:715
+#: src/olympia/versions/models.py:711
 msgid "{app} {min} and later"
 msgstr "{app} {min} y posterior"
 
@@ -13243,3 +13038,7 @@ msgstr "Envíame un correo cuando finalice"
 #: src/olympia/zadmin/forms.py:105
 msgid "Log emails instead of sending"
 msgstr "Mantener un registro de los correos en lugar de enviarlos"
+
+#: src/olympia/zadmin/forms.py:215
+msgid "Deleted versions can`t be changed."
+msgstr ""

--- a/locale/es/LC_MESSAGES/djangojs.po
+++ b/locale/es/LC_MESSAGES/djangojs.po
@@ -3,134 +3,392 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2016-02-24 21:23+0000\n"
+"POT-Creation-Date: 2016-04-18 15:47+0000\n"
 "PO-Revision-Date: 2016-01-21 13:36+0000\n"
 "Last-Translator: avelper <avelper@mozilla-hispano.org>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
+"Language: \n"
 "MIME-Version: 1.0\n"
-"Content-Type: text/plain; charset=utf-8\n"
+"Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Generated-By: Babel 2.2.0\n"
 
-#: static/js/common/ratingwidget.js:31
+#: static/js/common-all.js:1426 static/js/impala-all.js:1511 static/js/zamboni/discovery-all.js:12598 static/js/zamboni/init.js:28 static/js/zamboni/mobile-all.js:14945
+msgid "This feature is temporarily disabled while we perform website maintenance. Please check back a little later."
+msgstr "Esta característica está desactivada temporalmente mientras realizamos el mantenimiento de la página web. Inténtalo de nuevo pasados unos minutos."
+
+#. L10n: {0} is an app name like Firefox.
+#: static/js/common-all.js:1837 static/js/impala-all.js:1922 static/js/zamboni/buttons.js:73 static/js/zamboni/discovery-all.js:13108
+msgid "Accept and Install"
+msgstr "Aceptar e instalar"
+
+#: static/js/common-all.js:1837 static/js/impala-all.js:1922 static/js/zamboni/buttons.js:73 static/js/zamboni/discovery-all.js:13108
+msgid "Add to {0}"
+msgstr "Agregar a {0}"
+
+#: static/js/common-all.js:1842 static/js/impala-all.js:1927 static/js/zamboni/buttons.js:78 static/js/zamboni/discovery-all.js:13113
+msgid "Download Now"
+msgstr "Descargar ahora"
+
+#: static/js/common-all.js:1883 static/js/impala-all.js:1968 static/js/zamboni/buttons.js:119 static/js/zamboni/discovery-all.js:13154
+msgid "Add-on has not been updated to support default-to-compatible."
+msgstr "El complemento no se ha actualizado para que permita la opción de ser compatible de forma predeterminada."
+
+#: static/js/common-all.js:1888 static/js/impala-all.js:1973 static/js/zamboni/buttons.js:124 static/js/zamboni/discovery-all.js:13159
+msgid "You need to be using Firefox 10.0 or higher."
+msgstr "Tienes que usar Firefox 10.0 o una versión superior."
+
+#: static/js/common-all.js:1900 static/js/impala-all.js:1985 static/js/zamboni/buttons.js:136 static/js/zamboni/discovery-all.js:13171
+msgid "Mozilla has marked this version as incompatible with your Firefox version."
+msgstr "Mozilla ha marcado que esta versión es incompatible con tu versión de Firefox."
+
+#. L10n: {0} is an platform like Windows or Linux.
+#: static/js/common-all.js:1981 static/js/impala-all.js:2066 static/js/zamboni/buttons.js:217 static/js/zamboni/discovery-all.js:13252
+msgid "Install for {0} anyway"
+msgstr "Instalar en {0} de todas formas"
+
+#: static/js/common-all.js:1981 static/js/impala-all.js:2066 static/js/zamboni/buttons.js:217 static/js/zamboni/discovery-all.js:13252
+msgid "Download for {0} anyway"
+msgstr "Descargar para {0} de todas formas"
+
+#: static/js/common-all.js:2038 static/js/impala-all.js:2123 static/js/zamboni/buttons.js:274 static/js/zamboni/discovery-all.js:13309
+msgid "Not available for your platform"
+msgstr "No está disponible para tu plataforma"
+
+#. L10n: {0} is an app name, {1} is the app version.
+#: static/js/common-all.js:2049 static/js/common-all.js:2086 static/js/impala-all.js:2134 static/js/impala-all.js:2171 static/js/zamboni/buttons.js:286 static/js/zamboni/buttons.js:324
+#: static/js/zamboni/discovery-all.js:13320 static/js/zamboni/discovery-all.js:13357
+msgid "Not available for {0} {1}"
+msgstr "No está disponible para {0} {1}"
+
+#: static/js/common-all.js:2112 static/js/impala-all.js:2197 static/js/zamboni/buttons.js:351 static/js/zamboni/discovery-all.js:13383
+msgid "Works with {app} {min} - {max}"
+msgstr "Funciona con {app} {min} - {max}"
+
+#: static/js/common-all.js:2114 static/js/impala-all.js:2199 static/js/zamboni/buttons.js:353 static/js/zamboni/discovery-all.js:13385
+msgid "View other versions"
+msgstr "Ver otras versiones"
+
+#: static/js/common-all.js:2162 static/js/impala-all.js:2247 static/js/zamboni/buttons.js:401 static/js/zamboni/discovery-all.js:13433
+msgid "Only with Firefox — Get Firefox Now!"
+msgstr "Solo con Firefox - ¡Descárgalo ahora!"
+
+#: static/js/common-all.js:2278 static/js/impala-all.js:2363 static/js/zamboni/buttons.js:517 static/js/zamboni/discovery-all.js:13549 static/js/zamboni/mobile-all.js:15177
+#: static/js/zamboni/mobile/buttons.js:43
+msgid "Sorry, you need a Mozilla-based browser (such as Firefox) to install a search plugin."
+msgstr "Lo sentimos, necesitas un navegador basado en Mozilla (como Firefox) para instalar un plugin de búsqueda."
+
+#: static/js/common-all.js:9088 static/js/impala-all.js:9649 static/js/zamboni/global.js:410
+msgid "Loading..."
+msgstr "Cargando..."
+
+#. L10n: {0} is the number of characters left.
+#: static/js/common-all.js:9152 static/js/impala-all.js:9713 static/js/zamboni/global.js:474
+msgid "<b>{0}</b> character left."
+msgid_plural "<b>{0}</b> characters left."
+msgstr[0] "<b>{0}</b> carácter restante."
+msgstr[1] "<b>{0}</b> caracteres restantes."
+
+#: static/js/common-all.js:9589 static/js/common-min.js:6 static/js/impala-all.js:10052 static/js/impala-min.js:6 static/js/common/ratingwidget.js:31 static/js/zamboni/mobile-all.js:16123
+#: static/js/zamboni/mobile-min.js:6
 msgid "{0} star"
 msgid_plural "{0} stars"
 msgstr[0] "{0} estrella"
 msgstr[1] "{0} estrellas"
 
-#: static/js/common/upload-addon.js:41 static/js/common/upload-image.js:128
+#: static/js/common-all.js:9676 static/js/common-min.js:6 static/js/impala-all.js:10139 static/js/impala-min.js:6 static/js/zamboni/l10n.js:45
+msgid "Remove this localization"
+msgstr "Eliminar esta localización"
+
+#: static/js/common-all.js:10193 static/js/common-min.js:6 static/js/impala-all.js:10674 static/js/impala-min.js:6 static/js/zamboni/discovery-all.js:13678
+msgid "close"
+msgstr ""
+
+#: static/js/common-all.js:10860 static/js/common-min.js:6 static/js/impala-all.js:11481 static/js/impala-min.js:6 static/js/impala/reviews.js:23 static/js/zamboni/reviews.js:18
+msgid "Flagged for review"
+msgstr "Marcado para revisión"
+
+#: static/js/common-all.js:10876 static/js/common-min.js:6 static/js/impala-all.js:11498 static/js/impala-min.js:6 static/js/impala/reviews.js:40 static/js/zamboni/reviews.js:34
+msgid "Your input is required"
+msgstr "Tu contribución es necesaria"
+
+#: static/js/common-all.js:10945 static/js/common-min.js:6 static/js/impala-all.js:11610 static/js/impala-min.js:7 static/js/impala/reviews.js:152 static/js/zamboni/reviews.js:103
+msgid "Marked for deletion"
+msgstr "Marcado para su eliminación"
+
+#: static/js/common-all.js:11573 static/js/common-min.js:7 static/js/impala-all.js:13809 static/js/impala-min.js:8 static/js/zamboni/collections.js:229
+msgid "Adding to Favorites&hellip;"
+msgstr "Agregando a Favoritos&hellip;"
+
+#: static/js/common-all.js:11576 static/js/common-min.js:7 static/js/impala-all.js:13812 static/js/impala-min.js:8 static/js/zamboni/collections.js:232
+msgid "Removing Favorite&hellip;"
+msgstr "Eliminando favorito&hellip;"
+
+#: static/js/common-all.js:11579 static/js/common-min.js:7 static/js/impala-all.js:13815 static/js/impala-min.js:8 static/js/zamboni/collections.js:235
+msgid "Add to Favorites"
+msgstr "Agregar a Favoritos"
+
+#: static/js/common-all.js:11582 static/js/common-min.js:7 static/js/impala-all.js:13818 static/js/impala-min.js:8 static/js/zamboni/collections.js:238
+msgid "Remove from Favorites"
+msgstr "Eliminar de Favoritos"
+
+#: static/js/common-all.js:11647 static/js/common-min.js:7 static/js/impala-all.js:13883 static/js/impala-min.js:8 static/js/zamboni/collections.js:303
+msgid "Pending"
+msgstr "Pendiente"
+
+#: static/js/common-all.js:11648 static/js/common-min.js:7 static/js/impala-all.js:13884 static/js/impala-min.js:8 static/js/zamboni/collections.js:304
+msgid "Add a comment"
+msgstr "Agregar un comentario"
+
+#: static/js/common-all.js:11648 static/js/common-min.js:7 static/js/impala-all.js:13884 static/js/impala-min.js:8 static/js/zamboni/collections.js:304
+msgid "Comment"
+msgstr "Comentar"
+
+#: static/js/common-all.js:11649 static/js/common-min.js:7 static/js/impala-all.js:13885 static/js/impala-min.js:8 static/js/zamboni/collections.js:305
+msgid "Remove this add-on from the collection"
+msgstr "Eliminar este complemento de la colección"
+
+#: static/js/common-all.js:11649 static/js/common-all.js:11678 static/js/common-min.js:7 static/js/impala-all.js:13885 static/js/impala-all.js:13914 static/js/impala-min.js:8
+#: static/js/zamboni/collections.js:305 static/js/zamboni/collections.js:334
+msgid "Remove"
+msgstr "Eliminar"
+
+#: static/js/common-all.js:11678 static/js/common-min.js:7 static/js/impala-all.js:13914 static/js/impala-min.js:8 static/js/zamboni/collections.js:334
+msgid "Remove this user as a contributor"
+msgstr "Eliminar a este usuario como colaborador"
+
+#: static/js/common-all.js:11690 static/js/common-min.js:7 static/js/impala-all.js:13926 static/js/impala-min.js:8 static/js/zamboni/collections.js:346
+msgid "An email address is required."
+msgstr "Es obligatoria una dirección de correo electrónico."
+
+#: static/js/common-all.js:11708 static/js/common-min.js:7 static/js/impala-all.js:13944 static/js/impala-min.js:8 static/js/zamboni/collections.js:364
+msgid "You cannot add yourself as a contributor."
+msgstr "No puedes agregarte como colaborador."
+
+#: static/js/common-all.js:11710 static/js/common-min.js:7 static/js/impala-all.js:13946 static/js/impala-min.js:8 static/js/zamboni/collections.js:366
+msgid "You have already added that user."
+msgstr "Ya has agregado a ese usuario."
+
+#: static/js/common-all.js:11917 static/js/common-min.js:7 static/js/impala-all.js:14153 static/js/impala-min.js:8 static/js/zamboni/collections.js:573
+msgid "Add to favorites"
+msgstr "Agregar a favoritos"
+
+#: static/js/common-all.js:11921 static/js/common-min.js:7 static/js/impala-all.js:14157 static/js/impala-min.js:8 static/js/zamboni/collections.js:577
+msgid "Remove from favorites"
+msgstr "Eliminar de favoritos"
+
+#: static/js/common-all.js:11939 static/js/common-min.js:7 static/js/impala-all.js:14175 static/js/impala-all.js:14233 static/js/impala-min.js:8 static/js/impala/collections.js:10
+#: static/js/zamboni/collections.js:595
+msgid "Follow this Collection"
+msgstr "Seguir esta colección"
+
+#: static/js/common-all.js:11948 static/js/common-min.js:7 static/js/impala-all.js:14184 static/js/impala-min.js:8 static/js/zamboni/collections.js:604
+msgid "Stop following"
+msgstr "Dejar de seguir"
+
+#: static/js/common-all.js:12096 static/js/common-min.js:7 static/js/zamboni/password-strength.js:20
+msgid "Password strength:"
+msgstr "Fortaleza de la contraseña:"
+
+#: static/js/common-all.js:12102 static/js/common-min.js:7 static/js/zamboni/password-strength.js:26
+msgid "At least {0} character left."
+msgid_plural "At least {0} characters left."
+msgstr[0] "Queda al menos {0} carácter."
+msgstr[1] "Quedan al menos {0} caracteres."
+
+#: static/js/common-all.js:12286 static/js/common-min.js:7 static/js/impala-all.js:14632 static/js/impala-min.js:8 static/js/impala/suggestions.js:39
+msgid "Search themes for <b>{0}</b>"
+msgstr "Buscar temas para <b>{0}</b>"
+
+#: static/js/common-all.js:12288 static/js/common-min.js:7 static/js/impala-all.js:14634 static/js/impala-min.js:8 static/js/impala/suggestions.js:41
+msgid "Search apps for <b>{0}</b>"
+msgstr "Buscar aplicaciones para <b>{0}</b>"
+
+#: static/js/common-all.js:12290 static/js/common-min.js:7 static/js/impala-all.js:14636 static/js/impala-min.js:8 static/js/impala/suggestions.js:43
+msgid "Search add-ons for <b>{0}</b>"
+msgstr "Buscar complementos para <b>{0}</b>"
+
+#: static/js/common-all.js:12521 static/js/common-min.js:7 static/js/impala-all.js:14867 static/js/impala-min.js:8 static/js/impala/site_suggestions.js:46
+msgid "Category"
+msgstr "Categoría"
+
+#. L10n: {0} is an app name.
+#: static/js/impala-all.js:11632 static/js/impala-min.js:7 static/js/impala/listing.js:11 static/js/zamboni/themes.js:13
+msgid "This theme is incompatible with your version of {0}"
+msgstr "Este tema es incompatible con tu versión de {0}"
+
+#: static/js/impala-all.js:12146 static/js/impala-all.js:14331 static/js/impala-min.js:7 static/js/impala-min.js:8 static/js/common/upload-image.js:97 static/js/impala/users.js:51
+#: static/js/zamboni/devhub-all.js:894 static/js/zamboni/devhub-min.js:1
+msgid "Images must be either PNG or JPG."
+msgstr "Las imágenes deben tener un formato PNG o JPG."
+
+#: static/js/impala-all.js:12150 static/js/impala-min.js:7 static/js/common/upload-image.js:101 static/js/zamboni/devhub-all.js:898 static/js/zamboni/devhub-min.js:1
+msgid "Videos must be in WebM."
+msgstr "Los videos deben estar en el formato WebM."
+
+#: static/js/impala-all.js:12177 static/js/impala-min.js:7 static/js/common/upload-addon.js:41 static/js/common/upload-image.js:128 static/js/zamboni/devhub-all.js:272
+#: static/js/zamboni/devhub-all.js:925 static/js/zamboni/devhub-min.js:1
 msgid "There was a problem contacting the server."
 msgstr "Ha habido un problema al contactar con el servidor."
 
-#: static/js/common/upload-addon.js:69
+#: static/js/impala-all.js:13298 static/js/impala-min.js:7 static/js/impala/persona_creation.js:60
+msgid "All Rights Reserved"
+msgstr "Todos los derechos reservados"
+
+#: static/js/impala-all.js:13302 static/js/impala-min.js:7 static/js/impala/persona_creation.js:64
+msgid "Creative Commons Attribution 3.0"
+msgstr "Creative Commons Reconocimiento 3.0"
+
+#: static/js/impala-all.js:13307 static/js/impala-min.js:7 static/js/impala/persona_creation.js:69
+msgid "Creative Commons Attribution-NonCommercial 3.0"
+msgstr "Creative Commons Reconocimiento-No Comercial 3.0"
+
+#: static/js/impala-all.js:13312 static/js/impala-min.js:7 static/js/impala/persona_creation.js:74
+msgid "Creative Commons Attribution-NonCommercial-NoDerivs 3.0"
+msgstr "Creative Commons Reconocimiento-No Comercial-No Derivadas 3.0"
+
+#: static/js/impala-all.js:13317 static/js/impala-min.js:7 static/js/impala/persona_creation.js:79
+msgid "Creative Commons Attribution-NonCommercial-Share Alike 3.0"
+msgstr "Creative Commons Reconocimiento-Compartir Igual 3.0"
+
+#: static/js/impala-all.js:13322 static/js/impala-min.js:7 static/js/impala/persona_creation.js:84
+msgid "Creative Commons Attribution-NoDerivs 3.0"
+msgstr "Creative Commons Reconocimiento-No Derivadas 3.0"
+
+#: static/js/impala-all.js:13327 static/js/impala-min.js:7 static/js/impala/persona_creation.js:89
+msgid "Creative Commons Attribution-ShareAlike 3.0"
+msgstr "Creative Commons Reconocimiento-Compartir Igual 3.0"
+
+#: static/js/impala-all.js:13530 static/js/impala-min.js:7 static/js/impala/persona_creation.js:292
+msgid "Your Theme's Name"
+msgstr "El nombre de tu tema"
+
+#: static/js/impala-all.js:14242 static/js/impala-min.js:8 static/js/impala/collections.js:19
+msgid "Stop Following"
+msgstr "Dejar de seguir"
+
+#: static/js/impala-all.js:14243 static/js/impala-min.js:8 static/js/impala/collections.js:20
+msgid "Following"
+msgstr "Siguiendo"
+
+#: static/js/impala-all.js:14313 static/js/impala-min.js:8 static/js/impala/users.js:33
+msgid "use original"
+msgstr "usar originales"
+
+#: static/js/impala-all.js:14523 static/js/impala-min.js:8 static/js/impala/search.js:114
+msgid "Updating results&hellip;"
+msgstr "Actualizando resultados&hellip;"
+
+#: static/js/common/upload-addon.js:69 static/js/zamboni/devhub-all.js:300 static/js/zamboni/devhub-min.js:1
 msgid "Select a file..."
 msgstr "Selecciona un archivo..."
 
-#: static/js/common/upload-addon.js:70
+#: static/js/common/upload-addon.js:70 static/js/zamboni/devhub-all.js:301 static/js/zamboni/devhub-min.js:1
 msgid "Your add-on should end with .xpi, .jar or .xml"
 msgstr "Tu complemento debe terminar en .xpi, .jar o .xml"
 
 #. L10n: {0} is the percent of the file that has been uploaded.
-#: static/js/common/upload-addon.js:104
+#: static/js/common/upload-addon.js:104 static/js/zamboni/devhub-all.js:335 static/js/zamboni/devhub-min.js:1
 #, python-format
 msgid "{0}% complete"
 msgstr "{0}% completado"
 
 #. L10n: "{bytes uploaded} of {total filesize}".
-#: static/js/common/upload-addon.js:107
+#: static/js/common/upload-addon.js:107 static/js/zamboni/devhub-all.js:338 static/js/zamboni/devhub-min.js:1
 msgid "{0} of {1}"
 msgstr "{0} de {1}"
 
-#: static/js/common/upload-addon.js:140
+#: static/js/common/upload-addon.js:140 static/js/zamboni/devhub-all.js:371 static/js/zamboni/devhub-min.js:1
 msgid "Cancel"
 msgstr "Cancelar"
 
-#: static/js/common/upload-addon.js:162
+#: static/js/common/upload-addon.js:162 static/js/zamboni/devhub-all.js:393 static/js/zamboni/devhub-min.js:1
 msgid "Uploading {0}"
 msgstr "Subiendo {0}"
 
-#: static/js/common/upload-addon.js:189
+#: static/js/common/upload-addon.js:189 static/js/zamboni/devhub-all.js:420 static/js/zamboni/devhub-min.js:1
 msgid "Error with {0}"
 msgstr "Error con {0}"
 
-#: static/js/common/upload-addon.js:194
+#: static/js/common/upload-addon.js:194 static/js/zamboni/devhub-all.js:425 static/js/zamboni/devhub-min.js:1
 msgid "Your add-on failed validation with {0} error."
 msgid_plural "Your add-on failed validation with {0} errors."
 msgstr[0] "Tu complemento ha fallado la validación con {0} error."
 msgstr[1] "Tu complemento ha fallado la validación con {0} errores."
 
-#: static/js/common/upload-addon.js:208
+#: static/js/common/upload-addon.js:208 static/js/zamboni/devhub-all.js:439 static/js/zamboni/devhub-min.js:1
 msgid "&hellip;and {0} more"
 msgid_plural "&hellip;and {0} more"
 msgstr[0] "&hellip;y {0} más"
 msgstr[1] "&hellip;y {0} más"
 
-#: static/js/common/upload-addon.js:222 static/js/common/upload-addon.js:512
+#: static/js/common/upload-addon.js:222 static/js/common/upload-addon.js:497 static/js/zamboni/devhub-all.js:453 static/js/zamboni/devhub-all.js:743 static/js/zamboni/devhub-min.js:1
 msgid "See full validation report"
 msgstr "Ver el informe completo de la validación"
 
-#: static/js/common/upload-addon.js:234
+#: static/js/common/upload-addon.js:234 static/js/zamboni/devhub-all.js:465 static/js/zamboni/devhub-min.js:1
 msgid "Validating {0}"
 msgstr "Validando {0}"
 
 #. L10n: first argument is an HTTP status code
-#: static/js/common/upload-addon.js:273
+#: static/js/common/upload-addon.js:273 static/js/zamboni/devhub-all.js:504 static/js/zamboni/devhub-min.js:1
 msgid "Received an empty response from the server; status: {0}"
 msgstr "Se ha recibido una respuesta vacía del servidor; estado: {0}"
 
-#: static/js/common/upload-addon.js:373
+#: static/js/common/upload-addon.js:370 static/js/zamboni/devhub-all.js:604 static/js/zamboni/devhub-min.js:1
 msgid "Unexpected server error while validating."
 msgstr "Error inesperado del servidor durante la validación."
 
-#: static/js/common/upload-addon.js:412
+#: static/js/common/upload-addon.js:409 static/js/zamboni/devhub-all.js:643 static/js/zamboni/devhub-min.js:1
 msgid "Finished validating {0}"
 msgstr "Se ha terminado de validar {0}"
 
-#: static/js/common/upload-addon.js:418
+#: static/js/common/upload-addon.js:415 static/js/zamboni/devhub-all.js:649 static/js/zamboni/devhub-min.js:1
 msgid "Your add-on validation timed out, it will be manually reviewed."
 msgstr "El tiempo de validación de tu complemento se ha agotado, será revisado manualmente."
 
-#: static/js/common/upload-addon.js:421
+#: static/js/common/upload-addon.js:418 static/js/zamboni/devhub-all.js:652 static/js/zamboni/devhub-min.js:1
 msgid "Your add-on was validated with no errors and {0} warning."
 msgid_plural "Your add-on was validated with no errors and {0} warnings."
 msgstr[0] "Tu complemento fue validado sin errores y {0} advertencia."
 msgstr[1] "Tu complemento fue validado sin errores y {0} advertencias."
 
-#: static/js/common/upload-addon.js:426
+#: static/js/common/upload-addon.js:423 static/js/zamboni/devhub-all.js:657 static/js/zamboni/devhub-min.js:1
 msgid "Your add-on was validated with no errors and {0} message."
 msgid_plural "Your add-on was validated with no errors and {0} messages."
 msgstr[0] "Tu complemento fue validado sin errores y {0} mensaje."
 msgstr[1] "Tu complemento fue validado sin errores y {0} mensajes."
 
-#: static/js/common/upload-addon.js:431
+#: static/js/common/upload-addon.js:428 static/js/zamboni/devhub-all.js:662 static/js/zamboni/devhub-min.js:1
 msgid "Your add-on was validated with no errors or warnings."
 msgstr "Tu complemento fue validado sin errores ni advertencias."
 
-#: static/js/common/upload-addon.js:446
+#: static/js/common/upload-addon.js:443 static/js/zamboni/devhub-all.js:677 static/js/zamboni/devhub-min.js:1
 msgid "Your submission will be automatically signed."
 msgstr "Tu envío se firmará automáticamente."
 
-#: static/js/common/upload-addon.js:465
+#: static/js/common/upload-addon.js:450 static/js/zamboni/devhub-all.js:696 static/js/zamboni/devhub-min.js:1
 msgid "Include detailed version notes (this can be done in the next step)."
 msgstr "Incluye notas detalladas de la versión (esto puede hacerse en el siguiente paso)."
 
-#: static/js/common/upload-addon.js:466
+#: static/js/common/upload-addon.js:451 static/js/zamboni/devhub-all.js:697 static/js/zamboni/devhub-min.js:1
 msgid "If your add-on requires an account to a website in order to be fully tested, include a test username and password in the Notes to Reviewer (this can be done in the next step)."
-msgstr "Si tu complemento requiere una cuenta en un sitio web para probarlo con profundidad, incluye un usuario y contraseña de prueba en las Notas para el revisor (esto puede hacerse en el siguiente paso)."
+msgstr ""
+"Si tu complemento requiere una cuenta en un sitio web para probarlo con profundidad, incluye un usuario y contraseña de prueba en las Notas para el revisor (esto puede hacerse en el siguiente paso)."
 
-#: static/js/common/upload-addon.js:467
+#: static/js/common/upload-addon.js:452 static/js/zamboni/devhub-all.js:698 static/js/zamboni/devhub-min.js:1
 msgid "If your add-on is intended for a limited audience you should choose Preliminary Review instead of Full Review."
 msgstr "Si tu complemento está dirigido a un público limitado deberías seleccionar Revisión preliminar en lugar de Revisión completa."
 
-#: static/js/common/upload-addon.js:480
+#: static/js/common/upload-addon.js:465 static/js/zamboni/devhub-all.js:711 static/js/zamboni/devhub-min.js:1
 msgid "Add-on submission checklist"
 msgstr "Lista de verificación de envío de complementos"
 
-#: static/js/common/upload-addon.js:481
+#: static/js/common/upload-addon.js:466 static/js/zamboni/devhub-all.js:712 static/js/zamboni/devhub-min.js:1
 msgid "Please verify the following points before finalizing your submission. This will minimize delays or misunderstanding during the review process:"
 msgstr "Por favor, verifica los siguientes puntos antes de finalizar tu envío. Esto minimizará retrasos o malentendidos durante el proceso de revisión:"
 
-#: static/js/common/upload-addon.js:483
+#: static/js/common/upload-addon.js:468 static/js/zamboni/devhub-all.js:714 static/js/zamboni/devhub-min.js:1
 msgid ""
 "Compiled binaries, as well as minified or obfuscated scripts (excluding known libraries) need to have their sources submitted separately for review. Make sure that you use the source code upload "
 "field to avoid having your submission rejected."
@@ -138,1080 +396,844 @@ msgstr ""
 "Los binarios compilados, así como los scripts minificados u ofuscados (excluyendo bibliotecas conocidas) deben ser enviados por separado para su revisión. Asegúrate de que utilizas el campo de "
 "subir código fuente para evitar que tu envío sea rechazado."
 
-#: static/js/common/upload-addon.js:501
+#: static/js/common/upload-addon.js:486 static/js/zamboni/devhub-all.js:732 static/js/zamboni/devhub-min.js:1
 msgid "The validation process found these issues that can lead to rejections:"
 msgstr "El proceso de validación encontró estos problemas que pueden llevar a rechazos:"
 
-#: static/js/common/upload-addon.js:518
+#: static/js/common/upload-addon.js:503 static/js/zamboni/devhub-all.js:749 static/js/zamboni/devhub-min.js:1
 msgid "If you are unfamiliar with the add-ons review process, you can read about it here."
 msgstr "Si no estás familiarizado con el proceso de revisión de complementos, puedes informarte aquí."
 
-#: static/js/common/upload-addon.js:555
+#: static/js/common/upload-addon.js:540 static/js/zamboni/devhub-all.js:786 static/js/zamboni/devhub-min.js:1
 msgid "Sorry, no supported platform has been found."
 msgstr "Lo sentimos, no se ha encontrado ninguna plataforma compatible."
 
-#: static/js/common/upload-base.js:57
+#: static/js/common/upload-base.js:57 static/js/zamboni/devhub-all.js:187 static/js/zamboni/devhub-min.js:1
 msgid "The filetype you uploaded isn't recognized."
 msgstr "No se reconoce el tipo de archivo que has subido."
 
-#: static/js/common/upload-base.js:79
+#: static/js/common/upload-base.js:79 static/js/zamboni/devhub-all.js:209 static/js/zamboni/devhub-min.js:1
 msgid "You cancelled the upload."
 msgstr "Has cancelado la subida."
 
-#: static/js/common/upload-image.js:97 static/js/impala/users.js:51
-msgid "Images must be either PNG or JPG."
-msgstr "Las imágenes deben tener un formato PNG o JPG."
-
-#: static/js/common/upload-image.js:101
-msgid "Videos must be in WebM."
-msgstr "Los videos deben estar en el formato WebM."
-
-#: static/js/impala/collections.js:10 static/js/zamboni/collections.js:595
-msgid "Follow this Collection"
-msgstr "Seguir esta colección"
-
-#: static/js/impala/collections.js:19
-msgid "Stop Following"
-msgstr "Dejar de seguir"
-
-#: static/js/impala/collections.js:20
-msgid "Following"
-msgstr "Siguiendo"
-
-#. L10n: {0} is an app name.
-#: static/js/impala/listing.js:11 static/js/zamboni/themes.js:13
-msgid "This theme is incompatible with your version of {0}"
-msgstr "Este tema es incompatible con tu versión de {0}"
-
-#: static/js/impala/persona_creation.js:60
-msgid "All Rights Reserved"
-msgstr "Todos los derechos reservados"
-
-#: static/js/impala/persona_creation.js:64
-msgid "Creative Commons Attribution 3.0"
-msgstr "Creative Commons Reconocimiento 3.0"
-
-#: static/js/impala/persona_creation.js:69
-msgid "Creative Commons Attribution-NonCommercial 3.0"
-msgstr "Creative Commons Reconocimiento-No Comercial 3.0"
-
-#: static/js/impala/persona_creation.js:74
-msgid "Creative Commons Attribution-NonCommercial-NoDerivs 3.0"
-msgstr "Creative Commons Reconocimiento-No Comercial-No Derivadas 3.0"
-
-#: static/js/impala/persona_creation.js:79
-msgid "Creative Commons Attribution-NonCommercial-Share Alike 3.0"
-msgstr "Creative Commons Reconocimiento-Compartir Igual 3.0"
-
-#: static/js/impala/persona_creation.js:84
-msgid "Creative Commons Attribution-NoDerivs 3.0"
-msgstr "Creative Commons Reconocimiento-No Derivadas 3.0"
-
-#: static/js/impala/persona_creation.js:89
-msgid "Creative Commons Attribution-ShareAlike 3.0"
-msgstr "Creative Commons Reconocimiento-Compartir Igual 3.0"
-
-#: static/js/impala/persona_creation.js:292
-msgid "Your Theme's Name"
-msgstr "El nombre de tu tema"
-
-#: static/js/impala/reviews.js:23 static/js/zamboni/reviews.js:18
-msgid "Flagged for review"
-msgstr "Marcado para revisión"
-
-#: static/js/impala/reviews.js:40 static/js/zamboni/reviews.js:34
-msgid "Your input is required"
-msgstr "Tu contribución es necesaria"
-
-#: static/js/impala/reviews.js:152 static/js/zamboni/reviews.js:103
-msgid "Marked for deletion"
-msgstr "Marcado para su eliminación"
-
-#: static/js/impala/search.js:114
-msgid "Updating results&hellip;"
-msgstr "Actualizando resultados&hellip;"
-
-#: static/js/impala/site_suggestions.js:46
-msgid "Category"
-msgstr "Categoría"
-
-#: static/js/impala/suggestions.js:39
-msgid "Search themes for <b>{0}</b>"
-msgstr "Buscar temas para <b>{0}</b>"
-
-#: static/js/impala/suggestions.js:41
-msgid "Search apps for <b>{0}</b>"
-msgstr "Buscar aplicaciones para <b>{0}</b>"
-
-#: static/js/impala/suggestions.js:43
-msgid "Search add-ons for <b>{0}</b>"
-msgstr "Buscar complementos para <b>{0}</b>"
-
-#: static/js/impala/users.js:33
-msgid "use original"
-msgstr "usar originales"
-
-#: static/js/impala/stats/chart.js:267
+#: static/js/impala/stats/chart.js:267 static/js/zamboni/stats-all.js:16898 static/js/zamboni/stats-min.js:5
 msgid "Week of {0}"
 msgstr "Semana de {0}"
 
-#: static/js/impala/stats/chart.js:269
+#: static/js/impala/stats/chart.js:269 static/js/zamboni/stats-all.js:16900 static/js/zamboni/stats-min.js:5
 msgid " downloads"
-msgstr " descargas"
+msgstr ""
 
-#: static/js/impala/stats/chart.js:270
+#: static/js/impala/stats/chart.js:270 static/js/zamboni/stats-all.js:16901 static/js/zamboni/stats-min.js:5
 msgid "{0} users"
 msgstr "{0} usuarios"
 
-#: static/js/impala/stats/chart.js:271
+#: static/js/impala/stats/chart.js:271 static/js/zamboni/stats-all.js:16902 static/js/zamboni/stats-min.js:5
 msgid "{0} add-ons"
 msgstr "{0} complementos"
 
-#: static/js/impala/stats/chart.js:272
+#: static/js/impala/stats/chart.js:272 static/js/zamboni/stats-all.js:16903 static/js/zamboni/stats-min.js:5
 msgid "{0} collections"
 msgstr "{0} colecciones"
 
-#: static/js/impala/stats/chart.js:273
+#: static/js/impala/stats/chart.js:273 static/js/zamboni/stats-all.js:16904 static/js/zamboni/stats-min.js:5
 msgid "{0} reviews"
 msgstr "{0} valoraciones"
 
-#: static/js/impala/stats/chart.js:275
+#: static/js/impala/stats/chart.js:275 static/js/zamboni/stats-all.js:16906 static/js/zamboni/stats-min.js:5
 msgid "{0} sales"
 msgstr "{0} ventas"
 
-#: static/js/impala/stats/chart.js:276
+#: static/js/impala/stats/chart.js:276 static/js/zamboni/stats-all.js:16907 static/js/zamboni/stats-min.js:5
 msgid "{0} refunds"
 msgstr "{0} reembolsos"
 
-#: static/js/impala/stats/chart.js:277
+#: static/js/impala/stats/chart.js:277 static/js/zamboni/stats-all.js:16908 static/js/zamboni/stats-min.js:5
 msgid "{0} installs"
 msgstr "{0} instalaciones"
 
-#: static/js/impala/stats/chart.js:369 static/js/impala/stats/csv_keys.js:3 static/js/impala/stats/csv_keys.js:109
+#: static/js/impala/stats/chart.js:369 static/js/impala/stats/csv_keys.js:3 static/js/impala/stats/csv_keys.js:109 static/js/zamboni/stats-all.js:15284 static/js/zamboni/stats-all.js:15390
+#: static/js/zamboni/stats-all.js:17000 static/js/zamboni/stats-min.js:4 static/js/zamboni/stats-min.js:5
 msgid "Downloads"
 msgstr "Descargas"
 
-#: static/js/impala/stats/chart.js:379 static/js/impala/stats/csv_keys.js:6 static/js/impala/stats/csv_keys.js:110
+#: static/js/impala/stats/chart.js:379 static/js/impala/stats/csv_keys.js:6 static/js/impala/stats/csv_keys.js:110 static/js/zamboni/stats-all.js:15287 static/js/zamboni/stats-all.js:15391
+#: static/js/zamboni/stats-all.js:17010 static/js/zamboni/stats-min.js:4 static/js/zamboni/stats-min.js:5
 msgid "Daily Users"
 msgstr "Usuarios diarios"
 
-#: static/js/impala/stats/chart.js:410
+#: static/js/impala/stats/chart.js:410 static/js/zamboni/stats-all.js:17041 static/js/zamboni/stats-min.js:5
 msgid "Amount, in USD"
 msgstr "Cantidad, en USD"
 
-#: static/js/impala/stats/chart.js:421 static/js/impala/stats/csv_keys.js:104
+#: static/js/impala/stats/chart.js:421 static/js/impala/stats/csv_keys.js:104 static/js/zamboni/stats-all.js:15385 static/js/zamboni/stats-all.js:17052 static/js/zamboni/stats-min.js:5
 msgid "Number of Contributions"
 msgstr "Número de colaboraciones"
 
-#: static/js/impala/stats/chart.js:447
+#: static/js/impala/stats/chart.js:447 static/js/zamboni/stats-all.js:17078 static/js/zamboni/stats-min.js:5
 msgid "More Info..."
 msgstr "Más información..."
 
 #. L10n: {0} is an ISO-formatted date.
-#: static/js/impala/stats/chart.js:451
+#: static/js/impala/stats/chart.js:451 static/js/zamboni/stats-all.js:17082 static/js/zamboni/stats-min.js:5
 msgid "Details for {0}"
 msgstr "Detalles para {0}"
 
-#: static/js/impala/stats/csv_keys.js:9
+#: static/js/impala/stats/csv_keys.js:9 static/js/zamboni/stats-all.js:15290 static/js/zamboni/stats-min.js:4
 msgid "Collections Created"
 msgstr "Colecciones creadas"
 
-#: static/js/impala/stats/csv_keys.js:12
+#: static/js/impala/stats/csv_keys.js:12 static/js/zamboni/stats-all.js:15293 static/js/zamboni/stats-min.js:4
 msgid "Add-ons in Use"
 msgstr "Complementos en uso"
 
-#: static/js/impala/stats/csv_keys.js:15
+#: static/js/impala/stats/csv_keys.js:15 static/js/zamboni/stats-all.js:15296 static/js/zamboni/stats-min.js:4
 msgid "Add-ons Created"
 msgstr "Complementos creados"
 
-#: static/js/impala/stats/csv_keys.js:18
+#: static/js/impala/stats/csv_keys.js:18 static/js/zamboni/stats-all.js:15299 static/js/zamboni/stats-min.js:4
 msgid "Add-ons Downloaded"
 msgstr "Complementos descargados"
 
-#: static/js/impala/stats/csv_keys.js:21
+#: static/js/impala/stats/csv_keys.js:21 static/js/zamboni/stats-all.js:15302 static/js/zamboni/stats-min.js:4
 msgid "Add-ons Updated"
 msgstr "Complementos actualizados"
 
-#: static/js/impala/stats/csv_keys.js:24
+#: static/js/impala/stats/csv_keys.js:24 static/js/zamboni/stats-all.js:15305 static/js/zamboni/stats-min.js:4
 msgid "Reviews Written"
 msgstr "Valoraciones escritas"
 
-#: static/js/impala/stats/csv_keys.js:27
+#: static/js/impala/stats/csv_keys.js:27 static/js/zamboni/stats-all.js:15308 static/js/zamboni/stats-min.js:4
 msgid "User Signups"
 msgstr "Registros de usuarios"
 
-#: static/js/impala/stats/csv_keys.js:30
+#: static/js/impala/stats/csv_keys.js:30 static/js/zamboni/stats-all.js:15311 static/js/zamboni/stats-min.js:4
 msgid "Subscribers"
 msgstr "Suscriptores"
 
-#: static/js/impala/stats/csv_keys.js:33
+#: static/js/impala/stats/csv_keys.js:33 static/js/zamboni/stats-all.js:15314 static/js/zamboni/stats-min.js:4
 msgid "Ratings"
 msgstr "Calificaciones"
 
-#: static/js/impala/stats/csv_keys.js:36 static/js/impala/stats/csv_keys.js:114
+#: static/js/impala/stats/csv_keys.js:36 static/js/impala/stats/csv_keys.js:114 static/js/zamboni/stats-all.js:15317 static/js/zamboni/stats-all.js:15395 static/js/zamboni/stats-min.js:4
+#: static/js/zamboni/stats-min.js:5
 msgid "Sales"
 msgstr "Ventas"
 
-#: static/js/impala/stats/csv_keys.js:39 static/js/impala/stats/csv_keys.js:113
+#: static/js/impala/stats/csv_keys.js:39 static/js/impala/stats/csv_keys.js:113 static/js/zamboni/stats-all.js:15320 static/js/zamboni/stats-all.js:15394 static/js/zamboni/stats-min.js:4
+#: static/js/zamboni/stats-min.js:5
 msgid "Installs"
 msgstr "Instalaciones"
 
-#: static/js/impala/stats/csv_keys.js:42
+#: static/js/impala/stats/csv_keys.js:42 static/js/zamboni/stats-all.js:15323 static/js/zamboni/stats-min.js:4
 msgid "Unknown"
 msgstr "Desconocidas"
 
-#: static/js/impala/stats/csv_keys.js:43
+#: static/js/impala/stats/csv_keys.js:43 static/js/zamboni/stats-all.js:15324 static/js/zamboni/stats-min.js:4
 msgid "Add-ons Manager"
 msgstr "Administrador de complementos"
 
-#: static/js/impala/stats/csv_keys.js:44
+#: static/js/impala/stats/csv_keys.js:44 static/js/zamboni/stats-all.js:15325 static/js/zamboni/stats-min.js:4
 msgid "Add-ons Manager Promo"
 msgstr "Contenido promocional del administrador de complementos"
 
-#: static/js/impala/stats/csv_keys.js:45
+#: static/js/impala/stats/csv_keys.js:45 static/js/zamboni/stats-all.js:15326 static/js/zamboni/stats-min.js:4
 msgid "Add-ons Manager Featured"
 msgstr "Destacados del administrador de complementos"
 
-#: static/js/impala/stats/csv_keys.js:46
+#: static/js/impala/stats/csv_keys.js:46 static/js/zamboni/stats-all.js:15327 static/js/zamboni/stats-min.js:4
 msgid "Add-ons Manager Learn More"
 msgstr "Aprender más del administrador de complementos"
 
-#: static/js/impala/stats/csv_keys.js:47
+#: static/js/impala/stats/csv_keys.js:47 static/js/zamboni/stats-all.js:15328 static/js/zamboni/stats-min.js:4
 msgid "Search Suggestions"
 msgstr "Sugerencias de búsqueda"
 
-#: static/js/impala/stats/csv_keys.js:48
+#: static/js/impala/stats/csv_keys.js:48 static/js/zamboni/stats-all.js:15329 static/js/zamboni/stats-min.js:4
 msgid "Search Results"
 msgstr "Resultados de la búsqueda"
 
-#: static/js/impala/stats/csv_keys.js:49 static/js/impala/stats/csv_keys.js:50 static/js/impala/stats/csv_keys.js:51
+#: static/js/impala/stats/csv_keys.js:49 static/js/impala/stats/csv_keys.js:50 static/js/impala/stats/csv_keys.js:51 static/js/zamboni/stats-all.js:15330 static/js/zamboni/stats-all.js:15331
+#: static/js/zamboni/stats-all.js:15332 static/js/zamboni/stats-min.js:4
 msgid "Homepage Promo"
 msgstr "Promocionadas en la página de inicio"
 
-#: static/js/impala/stats/csv_keys.js:52 static/js/impala/stats/csv_keys.js:53
+#: static/js/impala/stats/csv_keys.js:52 static/js/impala/stats/csv_keys.js:53 static/js/zamboni/stats-all.js:15333 static/js/zamboni/stats-all.js:15334 static/js/zamboni/stats-min.js:4
 msgid "Homepage Featured"
 msgstr "Destacadas en la página de inicio"
 
-#: static/js/impala/stats/csv_keys.js:54 static/js/impala/stats/csv_keys.js:55
+#: static/js/impala/stats/csv_keys.js:54 static/js/impala/stats/csv_keys.js:55 static/js/zamboni/stats-all.js:15335 static/js/zamboni/stats-all.js:15336 static/js/zamboni/stats-min.js:4
 msgid "Homepage Up and Coming"
 msgstr "Próximamente disponibles en la página de inicio"
 
-#: static/js/impala/stats/csv_keys.js:56
+#: static/js/impala/stats/csv_keys.js:56 static/js/zamboni/stats-all.js:15337 static/js/zamboni/stats-min.js:4
 msgid "Homepage Most Popular"
 msgstr "Más populares en la página de inicio"
 
-#: static/js/impala/stats/csv_keys.js:57 static/js/impala/stats/csv_keys.js:59
+#: static/js/impala/stats/csv_keys.js:57 static/js/impala/stats/csv_keys.js:59 static/js/zamboni/stats-all.js:15338 static/js/zamboni/stats-all.js:15340 static/js/zamboni/stats-min.js:4
 msgid "Detail Page"
 msgstr "Página de detalles"
 
-#: static/js/impala/stats/csv_keys.js:58 static/js/impala/stats/csv_keys.js:60
+#: static/js/impala/stats/csv_keys.js:58 static/js/impala/stats/csv_keys.js:60 static/js/zamboni/stats-all.js:15339 static/js/zamboni/stats-all.js:15341 static/js/zamboni/stats-min.js:4
 msgid "Detail Page (bottom)"
 msgstr "Página de detalles (abajo)"
 
-#: static/js/impala/stats/csv_keys.js:61
+#: static/js/impala/stats/csv_keys.js:61 static/js/zamboni/stats-all.js:15342 static/js/zamboni/stats-min.js:4
 msgid "Detail Page (Development Channel)"
 msgstr "Página de detalles (Canal de desarrollo)"
 
-#: static/js/impala/stats/csv_keys.js:62 static/js/impala/stats/csv_keys.js:63 static/js/impala/stats/csv_keys.js:64
+#: static/js/impala/stats/csv_keys.js:62 static/js/impala/stats/csv_keys.js:63 static/js/impala/stats/csv_keys.js:64 static/js/zamboni/stats-all.js:15343 static/js/zamboni/stats-all.js:15344
+#: static/js/zamboni/stats-all.js:15345 static/js/zamboni/stats-min.js:4
 msgid "Often Used With"
 msgstr "Se suele usar con"
 
-#: static/js/impala/stats/csv_keys.js:65 static/js/impala/stats/csv_keys.js:66
+#: static/js/impala/stats/csv_keys.js:65 static/js/impala/stats/csv_keys.js:66 static/js/zamboni/stats-all.js:15346 static/js/zamboni/stats-all.js:15347 static/js/zamboni/stats-min.js:4
 msgid "Others By Author"
 msgstr "Otros por autor"
 
-#: static/js/impala/stats/csv_keys.js:67 static/js/impala/stats/csv_keys.js:68
+#: static/js/impala/stats/csv_keys.js:67 static/js/impala/stats/csv_keys.js:68 static/js/zamboni/stats-all.js:15348 static/js/zamboni/stats-all.js:15349 static/js/zamboni/stats-min.js:4
 msgid "Dependencies"
 msgstr "Dependencias"
 
-#: static/js/impala/stats/csv_keys.js:69 static/js/impala/stats/csv_keys.js:70
+#: static/js/impala/stats/csv_keys.js:69 static/js/impala/stats/csv_keys.js:70 static/js/zamboni/stats-all.js:15350 static/js/zamboni/stats-all.js:15351 static/js/zamboni/stats-min.js:4
 msgid "Upsell"
 msgstr "Promoción"
 
-#: static/js/impala/stats/csv_keys.js:71
+#: static/js/impala/stats/csv_keys.js:71 static/js/zamboni/stats-all.js:15352 static/js/zamboni/stats-min.js:4
 msgid "Meet the Developer"
 msgstr "Conoce al desarrollador"
 
-#: static/js/impala/stats/csv_keys.js:72
+#: static/js/impala/stats/csv_keys.js:72 static/js/zamboni/stats-all.js:15353 static/js/zamboni/stats-min.js:4
 msgid "User Profile"
 msgstr "Perfil de usuario"
 
-#: static/js/impala/stats/csv_keys.js:73
+#: static/js/impala/stats/csv_keys.js:73 static/js/zamboni/stats-all.js:15354 static/js/zamboni/stats-min.js:4
 msgid "Version History"
 msgstr "Historial de versiones"
 
-#: static/js/impala/stats/csv_keys.js:75
+#: static/js/impala/stats/csv_keys.js:75 static/js/zamboni/stats-all.js:15356 static/js/zamboni/stats-min.js:4
 msgid "Sharing"
 msgstr "Compartir"
 
-#: static/js/impala/stats/csv_keys.js:76
+#: static/js/impala/stats/csv_keys.js:76 static/js/zamboni/stats-all.js:15357 static/js/zamboni/stats-min.js:4
 msgid "Category Pages"
 msgstr "Páginas de categorías"
 
-#: static/js/impala/stats/csv_keys.js:77
+#: static/js/impala/stats/csv_keys.js:77 static/js/zamboni/stats-all.js:15358 static/js/zamboni/stats-min.js:4
 msgid "Collections"
 msgstr "Colecciones"
 
-#: static/js/impala/stats/csv_keys.js:78 static/js/impala/stats/csv_keys.js:79
+#: static/js/impala/stats/csv_keys.js:78 static/js/impala/stats/csv_keys.js:79 static/js/zamboni/stats-all.js:15359 static/js/zamboni/stats-all.js:15360 static/js/zamboni/stats-min.js:4
 msgid "Category Landing Featured Carousel"
 msgstr "Página de aterrizaje según la categoría Carrusel de destacados"
 
-#: static/js/impala/stats/csv_keys.js:80 static/js/impala/stats/csv_keys.js:81
+#: static/js/impala/stats/csv_keys.js:80 static/js/impala/stats/csv_keys.js:81 static/js/zamboni/stats-all.js:15361 static/js/zamboni/stats-all.js:15362 static/js/zamboni/stats-min.js:4
 msgid "Category Landing Top Rated"
 msgstr "Páginas de inicio según la categoría Mejor puntuadas"
 
-#: static/js/impala/stats/csv_keys.js:82 static/js/impala/stats/csv_keys.js:83
+#: static/js/impala/stats/csv_keys.js:82 static/js/impala/stats/csv_keys.js:83 static/js/zamboni/stats-all.js:15363 static/js/zamboni/stats-all.js:15364 static/js/zamboni/stats-min.js:5
 msgid "Category Landing Most Popular"
 msgstr "Páginas de inicio según la categoría Más populares"
 
-#: static/js/impala/stats/csv_keys.js:84 static/js/impala/stats/csv_keys.js:85
+#: static/js/impala/stats/csv_keys.js:84 static/js/impala/stats/csv_keys.js:85 static/js/zamboni/stats-all.js:15365 static/js/zamboni/stats-all.js:15366 static/js/zamboni/stats-min.js:5
 msgid "Category Landing Recently Added"
 msgstr "Páginas de inicio según la categoría Agregadas recientemente"
 
-#: static/js/impala/stats/csv_keys.js:86 static/js/impala/stats/csv_keys.js:87
+#: static/js/impala/stats/csv_keys.js:86 static/js/impala/stats/csv_keys.js:87 static/js/zamboni/stats-all.js:15367 static/js/zamboni/stats-all.js:15368 static/js/zamboni/stats-min.js:5
 msgid "Browse Listing Featured Sort"
 msgstr "Explorar la lista ordenada por destacados"
 
-#: static/js/impala/stats/csv_keys.js:88 static/js/impala/stats/csv_keys.js:89
+#: static/js/impala/stats/csv_keys.js:88 static/js/impala/stats/csv_keys.js:89 static/js/zamboni/stats-all.js:15369 static/js/zamboni/stats-all.js:15370 static/js/zamboni/stats-min.js:5
 msgid "Browse Listing Users Sort"
 msgstr "Explorar la lista ordenada por usuarios"
 
-#: static/js/impala/stats/csv_keys.js:90 static/js/impala/stats/csv_keys.js:91
+#: static/js/impala/stats/csv_keys.js:90 static/js/impala/stats/csv_keys.js:91 static/js/zamboni/stats-all.js:15371 static/js/zamboni/stats-all.js:15372 static/js/zamboni/stats-min.js:5
 msgid "Browse Listing Rating Sort"
 msgstr "Explorar la lista ordenada por calificaciones"
 
-#: static/js/impala/stats/csv_keys.js:92 static/js/impala/stats/csv_keys.js:93
+#: static/js/impala/stats/csv_keys.js:92 static/js/impala/stats/csv_keys.js:93 static/js/zamboni/stats-all.js:15373 static/js/zamboni/stats-all.js:15374 static/js/zamboni/stats-min.js:5
 msgid "Browse Listing Created Sort"
 msgstr "Explorar la lista ordenada por fecha de creación"
 
-#: static/js/impala/stats/csv_keys.js:94 static/js/impala/stats/csv_keys.js:95
+#: static/js/impala/stats/csv_keys.js:94 static/js/impala/stats/csv_keys.js:95 static/js/zamboni/stats-all.js:15375 static/js/zamboni/stats-all.js:15376 static/js/zamboni/stats-min.js:5
 msgid "Browse Listing Name Sort"
 msgstr "Explorar la lista ordenada por nombres"
 
-#: static/js/impala/stats/csv_keys.js:96 static/js/impala/stats/csv_keys.js:97
+#: static/js/impala/stats/csv_keys.js:96 static/js/impala/stats/csv_keys.js:97 static/js/zamboni/stats-all.js:15377 static/js/zamboni/stats-all.js:15378 static/js/zamboni/stats-min.js:5
 msgid "Browse Listing Popular Sort"
 msgstr "Explorar la lista ordenada por popularidad"
 
-#: static/js/impala/stats/csv_keys.js:98 static/js/impala/stats/csv_keys.js:99
+#: static/js/impala/stats/csv_keys.js:98 static/js/impala/stats/csv_keys.js:99 static/js/zamboni/stats-all.js:15379 static/js/zamboni/stats-all.js:15380 static/js/zamboni/stats-min.js:5
 msgid "Browse Listing Updated Sort"
 msgstr "Explorar la lista ordenada por actualizaciones"
 
-#: static/js/impala/stats/csv_keys.js:100 static/js/impala/stats/csv_keys.js:101
+#: static/js/impala/stats/csv_keys.js:100 static/js/impala/stats/csv_keys.js:101 static/js/zamboni/stats-all.js:15381 static/js/zamboni/stats-all.js:15382 static/js/zamboni/stats-min.js:5
 msgid "Browse Listing Up and Coming Sort"
 msgstr "Explorar la lista ordenada por disponibles próximamente"
 
-#: static/js/impala/stats/csv_keys.js:105
+#: static/js/impala/stats/csv_keys.js:105 static/js/zamboni/stats-all.js:15386 static/js/zamboni/stats-min.js:5
 msgid "Total Amount Contributed"
 msgstr "Cantidad total de la contribución"
 
-#: static/js/impala/stats/csv_keys.js:106
+#: static/js/impala/stats/csv_keys.js:106 static/js/zamboni/stats-all.js:15387 static/js/zamboni/stats-min.js:5
 msgid "Average Contribution"
 msgstr "Contribución media"
 
-#: static/js/impala/stats/csv_keys.js:115
+#: static/js/impala/stats/csv_keys.js:115 static/js/zamboni/stats-all.js:15396 static/js/zamboni/stats-min.js:5
 msgid "Usage"
 msgstr "Uso"
 
-#: static/js/impala/stats/csv_keys.js:118
+#: static/js/impala/stats/csv_keys.js:118 static/js/zamboni/stats-all.js:15399 static/js/zamboni/stats-min.js:5
 msgid "Firefox"
 msgstr "Firefox"
 
-#: static/js/impala/stats/csv_keys.js:119
+#: static/js/impala/stats/csv_keys.js:119 static/js/zamboni/stats-all.js:15400 static/js/zamboni/stats-min.js:5
 msgid "Mozilla"
 msgstr "Mozilla"
 
-#: static/js/impala/stats/csv_keys.js:120
+#: static/js/impala/stats/csv_keys.js:120 static/js/zamboni/stats-all.js:15401 static/js/zamboni/stats-min.js:5
 msgid "Thunderbird"
 msgstr "Thunderbird"
 
-#: static/js/impala/stats/csv_keys.js:121
+#: static/js/impala/stats/csv_keys.js:121 static/js/zamboni/stats-all.js:15402 static/js/zamboni/stats-min.js:5
 msgid "Sunbird"
 msgstr "Sunbird"
 
-#: static/js/impala/stats/csv_keys.js:122
+#: static/js/impala/stats/csv_keys.js:122 static/js/zamboni/stats-all.js:15403 static/js/zamboni/stats-min.js:5
 msgid "SeaMonkey"
 msgstr "SeaMonkey"
 
-#: static/js/impala/stats/csv_keys.js:123
+#: static/js/impala/stats/csv_keys.js:123 static/js/zamboni/stats-all.js:15404 static/js/zamboni/stats-min.js:5
 msgid "Fennec"
 msgstr "Fennec"
 
-#: static/js/impala/stats/csv_keys.js:124
+#: static/js/impala/stats/csv_keys.js:124 static/js/zamboni/stats-all.js:15405 static/js/zamboni/stats-min.js:5
 msgid "Android"
 msgstr "Android"
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:129
+#: static/js/impala/stats/csv_keys.js:129 static/js/zamboni/stats-all.js:15410 static/js/zamboni/stats-min.js:5
 msgid "Downloads and Daily Users, last {0} days"
 msgstr "Descargas y usuarios diarios en los últimos {0} días"
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:131
+#: static/js/impala/stats/csv_keys.js:131 static/js/zamboni/stats-all.js:15412 static/js/zamboni/stats-min.js:5
 msgid "Downloads and Daily Users from {0} to {1}"
 msgstr "Descargas y usuarios diarios desde {0} al {1}"
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:135
+#: static/js/impala/stats/csv_keys.js:135 static/js/zamboni/stats-all.js:15416 static/js/zamboni/stats-min.js:5
 msgid "Installs and Daily Users, last {0} days"
 msgstr "Instalaciones y usuarios diarios en los últimos {0} días"
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:137
+#: static/js/impala/stats/csv_keys.js:137 static/js/zamboni/stats-all.js:15418 static/js/zamboni/stats-min.js:5
 msgid "Installs and Daily Users from {0} to {1}"
 msgstr "Instalaciones y usuarios diarios desde {0} al {1}"
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:141
+#: static/js/impala/stats/csv_keys.js:141 static/js/zamboni/stats-all.js:15422 static/js/zamboni/stats-min.js:5
 msgid "Downloads, last {0} days"
 msgstr "Descargas en los últimos {0} días"
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:143
+#: static/js/impala/stats/csv_keys.js:143 static/js/zamboni/stats-all.js:15424 static/js/zamboni/stats-min.js:5
 msgid "Downloads from {0} to {1}"
 msgstr "Descargas desde {0} al {1}"
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:147
+#: static/js/impala/stats/csv_keys.js:147 static/js/zamboni/stats-all.js:15428 static/js/zamboni/stats-min.js:5
 msgid "Daily Users, last {0} days"
 msgstr "Usuarios diarios en los últimos {0} días"
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:149
+#: static/js/impala/stats/csv_keys.js:149 static/js/zamboni/stats-all.js:15430 static/js/zamboni/stats-min.js:5
 msgid "Daily Users from {0} to {1}"
 msgstr "Usuarios diarios desde {0} al {1}"
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:153
+#: static/js/impala/stats/csv_keys.js:153 static/js/zamboni/stats-all.js:15434 static/js/zamboni/stats-min.js:5
 msgid "Applications, last {0} days"
 msgstr "Aplicaciones en los últimos {0} días"
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:155
+#: static/js/impala/stats/csv_keys.js:155 static/js/zamboni/stats-all.js:15436 static/js/zamboni/stats-min.js:5
 msgid "Applications from {0} to {1}"
 msgstr "Aplicaciones desde {0} al {1}"
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:159
+#: static/js/impala/stats/csv_keys.js:159 static/js/zamboni/stats-all.js:15440 static/js/zamboni/stats-min.js:5
 msgid "Platforms, last {0} days"
 msgstr "Plataformas en los últimos {0} días"
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:161
+#: static/js/impala/stats/csv_keys.js:161 static/js/zamboni/stats-all.js:15442 static/js/zamboni/stats-min.js:5
 msgid "Platforms from {0} to {1}"
 msgstr "Plataformas desde {0} al {1}"
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:165
+#: static/js/impala/stats/csv_keys.js:165 static/js/zamboni/stats-all.js:15446 static/js/zamboni/stats-min.js:5
 msgid "Languages, last {0} days"
 msgstr "Idiomas en los últimos {0} días"
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:167
+#: static/js/impala/stats/csv_keys.js:167 static/js/zamboni/stats-all.js:15448 static/js/zamboni/stats-min.js:5
 msgid "Languages from {0} to {1}"
 msgstr "Idiomas desde {0} al {1}"
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:171
+#: static/js/impala/stats/csv_keys.js:171 static/js/zamboni/stats-all.js:15452 static/js/zamboni/stats-min.js:5
 msgid "Add-on Versions, last {0} days"
 msgstr "Versiones de complementos en los últimos {0} días"
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:173
+#: static/js/impala/stats/csv_keys.js:173 static/js/zamboni/stats-all.js:15454 static/js/zamboni/stats-min.js:5
 msgid "Add-on Versions from {0} to {1}"
 msgstr "Versiones de complementos desde {0} al {1}"
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:177
+#: static/js/impala/stats/csv_keys.js:177 static/js/zamboni/stats-all.js:15458 static/js/zamboni/stats-min.js:5
 msgid "Add-on Status, last {0} days"
 msgstr "Estados de complementos en los últimos {0} días"
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:179
+#: static/js/impala/stats/csv_keys.js:179 static/js/zamboni/stats-all.js:15460 static/js/zamboni/stats-min.js:5
 msgid "Add-on Status from {0} to {1}"
 msgstr "Estados de complementos desde {0} al {1}"
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:183
+#: static/js/impala/stats/csv_keys.js:183 static/js/zamboni/stats-all.js:15464 static/js/zamboni/stats-min.js:5
 msgid "Download Sources, last {0} days"
 msgstr "Descarga de fuentes en los últimos {0} días"
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:185
+#: static/js/impala/stats/csv_keys.js:185 static/js/zamboni/stats-all.js:15466 static/js/zamboni/stats-min.js:5
 msgid "Download Sources from {0} to {1}"
 msgstr "Descarga de fuentes desde {0} al {1}"
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:189
+#: static/js/impala/stats/csv_keys.js:189 static/js/zamboni/stats-all.js:15470 static/js/zamboni/stats-min.js:5
 msgid "Contributions, last {0} days"
 msgstr "Colaboraciones en los últimos {0} días"
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:191
+#: static/js/impala/stats/csv_keys.js:191 static/js/zamboni/stats-all.js:15472 static/js/zamboni/stats-min.js:5
 msgid "Contributions from {0} to {1}"
 msgstr "Colaboraciones desde {0} al {1}"
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:195
+#: static/js/impala/stats/csv_keys.js:195 static/js/zamboni/stats-all.js:15476 static/js/zamboni/stats-min.js:5
 msgid "Site Metrics, last {0} days"
 msgstr "Métricas del sitio en los últimos {0} días"
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:197
+#: static/js/impala/stats/csv_keys.js:197 static/js/zamboni/stats-all.js:15478 static/js/zamboni/stats-min.js:5
 msgid "Site Metrics from {0} to {1}"
 msgstr "Métricas del sitio desde {0} al {1}"
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:201
+#: static/js/impala/stats/csv_keys.js:201 static/js/zamboni/stats-all.js:15482 static/js/zamboni/stats-min.js:5
 msgid "Add-ons in Use, last {0} days"
 msgstr "Complementos en uso en los últimos {0} días"
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:203
+#: static/js/impala/stats/csv_keys.js:203 static/js/zamboni/stats-all.js:15484 static/js/zamboni/stats-min.js:5
 msgid "Add-ons in Use from {0} to {1}"
 msgstr "Complementos en uso desde {0} al {1}"
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:207
+#: static/js/impala/stats/csv_keys.js:207 static/js/zamboni/stats-all.js:15488 static/js/zamboni/stats-min.js:5
 msgid "Add-ons Downloaded, last {0} days"
 msgstr "Complementos descargados en los últimos {0} días"
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:209
+#: static/js/impala/stats/csv_keys.js:209 static/js/zamboni/stats-all.js:15490 static/js/zamboni/stats-min.js:5
 msgid "Add-ons Downloaded from {0} to {1}"
 msgstr "Complementos descargados desde {0} al {1}"
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:213
+#: static/js/impala/stats/csv_keys.js:213 static/js/zamboni/stats-all.js:15494 static/js/zamboni/stats-min.js:5
 msgid "Add-ons Created, last {0} days"
 msgstr "Complementos creados en los últimos {0} días"
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:215
+#: static/js/impala/stats/csv_keys.js:215 static/js/zamboni/stats-all.js:15496 static/js/zamboni/stats-min.js:5
 msgid "Add-ons Created from {0} to {1}"
 msgstr "Complementos creados desde {0} al {1}"
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:219
+#: static/js/impala/stats/csv_keys.js:219 static/js/zamboni/stats-all.js:15500 static/js/zamboni/stats-min.js:5
 msgid "Add-ons Updated, last {0} days"
 msgstr "Complementos actualizados en los últimos {0} días"
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:221
+#: static/js/impala/stats/csv_keys.js:221 static/js/zamboni/stats-all.js:15502 static/js/zamboni/stats-min.js:5
 msgid "Add-ons Updated from {0} to {1}"
 msgstr "Complementos actualizados desde {0} al {1}"
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:225
+#: static/js/impala/stats/csv_keys.js:225 static/js/zamboni/stats-all.js:15506 static/js/zamboni/stats-min.js:5
 msgid "Reviews Written, last {0} days"
 msgstr "Valoraciones escritas en los últimos {0} días"
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:227
+#: static/js/impala/stats/csv_keys.js:227 static/js/zamboni/stats-all.js:15508 static/js/zamboni/stats-min.js:5
 msgid "Reviews Written from {0} to {1}"
 msgstr "Valoraciones escritas desde {0} al {1}"
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:231
+#: static/js/impala/stats/csv_keys.js:231 static/js/zamboni/stats-all.js:15512 static/js/zamboni/stats-min.js:5
 msgid "User Signups, last {0} days"
 msgstr "Registros de usuarios en los últimos {0} días"
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:233
+#: static/js/impala/stats/csv_keys.js:233 static/js/zamboni/stats-all.js:15514 static/js/zamboni/stats-min.js:5
 msgid "User Signups from {0} to {1}"
 msgstr "Registros de usuarios desde {0} al {1}"
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:237
+#: static/js/impala/stats/csv_keys.js:237 static/js/zamboni/stats-all.js:15518 static/js/zamboni/stats-min.js:5
 msgid "Collections Created, last {0} days"
 msgstr "Colecciones creadas en los últimos {0} días"
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:239
+#: static/js/impala/stats/csv_keys.js:239 static/js/zamboni/stats-all.js:15520 static/js/zamboni/stats-min.js:5
 msgid "Collections Created from {0} to {1}"
 msgstr "Colecciones creadas desde {0} al {1}"
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:243
+#: static/js/impala/stats/csv_keys.js:243 static/js/zamboni/stats-all.js:15524 static/js/zamboni/stats-min.js:5
 msgid "Subscribers, last {0} days"
 msgstr "Suscriptores en los últimos {0} días"
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:245
+#: static/js/impala/stats/csv_keys.js:245 static/js/zamboni/stats-all.js:15526 static/js/zamboni/stats-min.js:5
 msgid "Subscribers from {0} to {1}"
 msgstr "Suscriptores desde {0} al {1}"
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:249
+#: static/js/impala/stats/csv_keys.js:249 static/js/zamboni/stats-all.js:15530 static/js/zamboni/stats-min.js:5
 msgid "Ratings, last {0} days"
 msgstr "Calificaciones en los últimos {0} días"
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:251
+#: static/js/impala/stats/csv_keys.js:251 static/js/zamboni/stats-all.js:15532 static/js/zamboni/stats-min.js:5
 msgid "Ratings from {0} to {1}"
 msgstr "Calificaciones desde {0} al {1}"
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:255
+#: static/js/impala/stats/csv_keys.js:255 static/js/zamboni/stats-all.js:15536 static/js/zamboni/stats-min.js:5
 msgid "Sales, last {0} days"
 msgstr "Ventas en los últimos {0} días"
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:257
+#: static/js/impala/stats/csv_keys.js:257 static/js/zamboni/stats-all.js:15538 static/js/zamboni/stats-min.js:5
 msgid "Sales from {0} to {1}"
 msgstr "Ventas desde {0} al {1}"
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:261
+#: static/js/impala/stats/csv_keys.js:261 static/js/zamboni/stats-all.js:15542 static/js/zamboni/stats-min.js:5
 msgid "Installs, last {0} days"
 msgstr "Instalaciones en los últimos {0} días"
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:263
+#: static/js/impala/stats/csv_keys.js:263 static/js/zamboni/stats-all.js:15544 static/js/zamboni/stats-min.js:5
 msgid "Installs from {0} to {1}"
 msgstr "Instalaciones desde {0} al {1}"
 
 #. L10n: {0} and {1} are integers.
-#: static/js/impala/stats/csv_keys.js:269
+#: static/js/impala/stats/csv_keys.js:269 static/js/zamboni/stats-all.js:15550 static/js/zamboni/stats-min.js:5
 msgid "<b>{0}</b> in last {1} days"
 msgstr "<b>{0}</b> en los últimos {1} días"
 
 #. L10n: {0} is an integer and {1} and {2} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:271 static/js/impala/stats/csv_keys.js:277
+#: static/js/impala/stats/csv_keys.js:271 static/js/impala/stats/csv_keys.js:277 static/js/zamboni/stats-all.js:15552 static/js/zamboni/stats-all.js:15558 static/js/zamboni/stats-min.js:5
 msgid "<b>{0}</b> from {1} to {2}"
 msgstr "<b>{0}</b> desde {1} al {2}"
 
 #. L10n: {0} and {1} are integers.
-#: static/js/impala/stats/csv_keys.js:275
+#: static/js/impala/stats/csv_keys.js:275 static/js/zamboni/stats-all.js:15556 static/js/zamboni/stats-min.js:5
 msgid "<b>{0}</b> average in last {1} days"
 msgstr "<b>{0}</b> promedio en los últimos {1} días"
 
-#: static/js/impala/stats/overview.js:19
+#: static/js/impala/stats/overview.js:19 static/js/zamboni/stats-all.js:16469 static/js/zamboni/stats-min.js:5
 msgid "No data available."
 msgstr "No existen datos disponibles."
 
-#: static/js/impala/stats/table.js:74
+#: static/js/impala/stats/table.js:74 static/js/zamboni/stats-all.js:17209 static/js/zamboni/stats-min.js:5
 msgid "Date"
 msgstr "Fecha"
 
-#: static/js/impala/stats/topchart.js:96
+#: static/js/impala/stats/topchart.js:96 static/js/zamboni/stats-all.js:16600 static/js/zamboni/stats-min.js:5
 msgid "Other"
 msgstr "Otros"
 
-#: static/js/zamboni/admin_validation.js:24 static/js/zamboni/devhub.js:1229 static/js/zamboni/editors.js:295
+#: static/js/zamboni/admin-all.js:180 static/js/zamboni/admin-min.js:1 static/js/zamboni/admin_validation.js:24 static/js/zamboni/devhub-all.js:2408 static/js/zamboni/devhub-min.js:2
+#: static/js/zamboni/devhub.js:1229 static/js/zamboni/editors-all.js:15576 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:295
 msgid "Select an application first"
 msgstr "Selecciona primero una aplicación"
 
-#: static/js/zamboni/admin_validation.js:51
+#: static/js/zamboni/admin-all.js:207 static/js/zamboni/admin-min.js:1 static/js/zamboni/admin_validation.js:51
 msgid "Set {0} add-on to a max version of {1} and email the author."
 msgid_plural "Set {0} add-ons to a max version of {1} and email the authors."
 msgstr[0] "Configura {0} complemento a una versión máxima de {1} envíale un correo electrónico al autor."
 msgstr[1] "Configura {0} complementos a una versión máxima de {1} envíale un correo electrónico a los autores."
 
-#: static/js/zamboni/admin_validation.js:54
+#: static/js/zamboni/admin-all.js:210 static/js/zamboni/admin-min.js:1 static/js/zamboni/admin_validation.js:54
 msgid "Email author of {2} add-on which failed validation."
 msgid_plural "Email authors of {2} add-ons which failed validation."
 msgstr[0] "Enviar mensaje al autor de {2} complemento que falló la validación."
 msgstr[1] "Enviar mensaje a los autores de {2} complementos que fallaron la validación."
 
-#. L10n: {0} is an app name like Firefox.
-#: static/js/zamboni/buttons.js:66
-msgid "Accept and Install"
-msgstr "Aceptar e instalar"
-
-#: static/js/zamboni/buttons.js:66
-msgid "Add to {0}"
-msgstr "Agregar a {0}"
-
-#: static/js/zamboni/buttons.js:71
-msgid "Download Now"
-msgstr "Descargar ahora"
-
-#: static/js/zamboni/buttons.js:112
-msgid "Add-on has not been updated to support default-to-compatible."
-msgstr "El complemento no se ha actualizado para que permita la opción de ser compatible de forma predeterminada."
-
-#: static/js/zamboni/buttons.js:117
-msgid "You need to be using Firefox 10.0 or higher."
-msgstr "Tienes que usar Firefox 10.0 o una versión superior."
-
-#: static/js/zamboni/buttons.js:129
-msgid "Mozilla has marked this version as incompatible with your Firefox version."
-msgstr "Mozilla ha marcado que esta versión es incompatible con tu versión de Firefox."
-
-#. L10n: {0} is an platform like Windows or Linux.
-#: static/js/zamboni/buttons.js:210
-msgid "Install for {0} anyway"
-msgstr "Instalar en {0} de todas formas"
-
-#: static/js/zamboni/buttons.js:210
-msgid "Download for {0} anyway"
-msgstr "Descargar para {0} de todas formas"
-
-#: static/js/zamboni/buttons.js:267
-msgid "Not available for your platform"
-msgstr "No está disponible para tu plataforma"
-
-#. L10n: {0} is an app name, {1} is the app version.
-#: static/js/zamboni/buttons.js:278 static/js/zamboni/buttons.js:315
-msgid "Not available for {0} {1}"
-msgstr "No está disponible para {0} {1}"
-
-#: static/js/zamboni/buttons.js:341
-msgid "Works with {app} {min} - {max}"
-msgstr "Funciona con {app} {min} - {max}"
-
-#: static/js/zamboni/buttons.js:343
-msgid "View other versions"
-msgstr "Ver otras versiones"
-
-#: static/js/zamboni/buttons.js:391
-msgid "Only with Firefox — Get Firefox Now!"
-msgstr "Solo con Firefox - ¡Descárgalo ahora!"
-
-#: static/js/zamboni/buttons.js:507 static/js/zamboni/mobile/buttons.js:43
-msgid "Sorry, you need a Mozilla-based browser (such as Firefox) to install a search plugin."
-msgstr "Lo sentimos, necesitas un navegador basado en Mozilla (como Firefox) para instalar un plugin de búsqueda."
-
-#: static/js/zamboni/collections.js:229
-msgid "Adding to Favorites&hellip;"
-msgstr "Agregando a Favoritos&hellip;"
-
-#: static/js/zamboni/collections.js:232
-msgid "Removing Favorite&hellip;"
-msgstr "Eliminando favorito&hellip;"
-
-#: static/js/zamboni/collections.js:235
-msgid "Add to Favorites"
-msgstr "Agregar a Favoritos"
-
-#: static/js/zamboni/collections.js:238
-msgid "Remove from Favorites"
-msgstr "Eliminar de Favoritos"
-
-#: static/js/zamboni/collections.js:303
-msgid "Pending"
-msgstr "Pendiente"
-
-#: static/js/zamboni/collections.js:304
-msgid "Add a comment"
-msgstr "Agregar un comentario"
-
-#: static/js/zamboni/collections.js:304
-msgid "Comment"
-msgstr "Comentar"
-
-#: static/js/zamboni/collections.js:305
-msgid "Remove this add-on from the collection"
-msgstr "Eliminar este complemento de la colección"
-
-#: static/js/zamboni/collections.js:305 static/js/zamboni/collections.js:334
-msgid "Remove"
-msgstr "Eliminar"
-
-#: static/js/zamboni/collections.js:334
-msgid "Remove this user as a contributor"
-msgstr "Eliminar a este usuario como colaborador"
-
-#: static/js/zamboni/collections.js:346
-msgid "An email address is required."
-msgstr "Es obligatoria una dirección de correo electrónico."
-
-#: static/js/zamboni/collections.js:364
-msgid "You cannot add yourself as a contributor."
-msgstr "No puedes agregarte como colaborador."
-
-#: static/js/zamboni/collections.js:366
-msgid "You have already added that user."
-msgstr "Ya has agregado a ese usuario."
-
-#: static/js/zamboni/collections.js:573
-msgid "Add to favorites"
-msgstr "Agregar a favoritos"
-
-#: static/js/zamboni/collections.js:577
-msgid "Remove from favorites"
-msgstr "Eliminar de favoritos"
-
-#: static/js/zamboni/collections.js:604
-msgid "Stop following"
-msgstr "Dejar de seguir"
-
-#: static/js/zamboni/devhub.js:110
+#: static/js/zamboni/devhub-all.js:1289 static/js/zamboni/devhub-min.js:1 static/js/zamboni/devhub.js:110
 msgid "Your browser does not support the video tag"
 msgstr "Tu navegador no admite la etiqueta de video"
 
-#: static/js/zamboni/devhub.js:371
+#: static/js/zamboni/devhub-all.js:1550 static/js/zamboni/devhub-min.js:1 static/js/zamboni/devhub.js:371
 msgid "Changes Saved"
 msgstr "Se han guardado los cambios"
 
-#: static/js/zamboni/devhub.js:387
+#: static/js/zamboni/devhub-all.js:1566 static/js/zamboni/devhub-min.js:1 static/js/zamboni/devhub.js:387
 msgid "Enter a new author's email address"
 msgstr "Escribe una nueva dirección de correo del autor"
 
-#: static/js/zamboni/devhub.js:536
+#: static/js/zamboni/devhub-all.js:1715 static/js/zamboni/devhub-min.js:1 static/js/zamboni/devhub.js:536
 msgid "There was an error uploading your file."
 msgstr "Ha habido un error al subir tu archivo."
 
-#: static/js/zamboni/devhub.js:681
+#: static/js/zamboni/devhub-all.js:1860 static/js/zamboni/devhub-min.js:1 static/js/zamboni/devhub.js:681
 msgid "{files} file"
 msgid_plural "{files} files"
 msgstr[0] "{files} archivo"
 msgstr[1] "{files} archivos"
 
-#: static/js/zamboni/devhub.js:684
+#: static/js/zamboni/devhub-all.js:1863 static/js/zamboni/devhub-min.js:1 static/js/zamboni/devhub.js:684
 msgid "{reviews} user review"
 msgid_plural "{reviews} user reviews"
 msgstr[0] "{reviews} valoración de usuario"
 msgstr[1] "{reviews} valoraciones de los usuarios"
 
-#: static/js/zamboni/devhub.js:796
+#: static/js/zamboni/devhub-all.js:1975 static/js/zamboni/devhub-min.js:2 static/js/zamboni/devhub.js:796
 msgid "Learn more"
 msgstr "Más información"
 
-#: static/js/zamboni/devhub.js:800
+#: static/js/zamboni/devhub-all.js:1979 static/js/zamboni/devhub-min.js:2 static/js/zamboni/devhub.js:800
 msgid "Example"
 msgstr "Ejemplo"
 
-#: static/js/zamboni/devhub.js:1130
+#: static/js/zamboni/devhub-all.js:2309 static/js/zamboni/devhub-min.js:2 static/js/zamboni/devhub.js:1130
 msgid "Image changes being processed"
 msgstr "Se están procesando los cambios en la imagen"
 
-#: static/js/zamboni/devhub.js:1280
+#: static/js/zamboni/devhub-all.js:2459 static/js/zamboni/devhub-min.js:2 static/js/zamboni/devhub.js:1280
 msgid "Must be a valid e-mail address."
 msgstr "Debe ser una dirección de correo válida."
 
-#: static/js/zamboni/devhub_search.js:8
-msgid "No results found."
-msgstr "No se ha encontrado ningún resultado."
-
-#: static/js/zamboni/editors.js:121
-msgid "{name} was viewing this page first."
-msgstr "{name} estuvo viendo esta página antes."
-
-#: static/js/zamboni/editors.js:171
-msgid "Receipt checked by app."
-msgstr "El recibo fue comprobado por la aplicación."
-
-#: static/js/zamboni/editors.js:173
-msgid "Receipt was not checked by app."
-msgstr "El recibo no fue comprobado por la aplicación."
-
-#: static/js/zamboni/editors.js:244
-msgid "{name} was viewing this add-on first."
-msgstr "{name} fue el primero en ver este complemento."
-
-#: static/js/zamboni/editors.js:255
-msgid "Loading&hellip;"
-msgstr "Cargando &hellip;"
-
-#: static/js/zamboni/editors.js:260
-msgid "Version Notes"
-msgstr "Notas de la versión"
-
-#: static/js/zamboni/editors.js:265
-msgid "Notes for Reviewers"
-msgstr "Notas para los revisores"
-
-#: static/js/zamboni/editors.js:270
-msgid "No version notes found"
-msgstr "No se han encontrado las notas de la versión"
-
-#: static/js/zamboni/editors.js:330
-msgid "Average Reviews"
-msgstr "Revisiones medias"
-
-#: static/js/zamboni/editors.js:386
-msgid "Number of Reviews"
-msgstr "Número de revisiones"
-
-#: static/js/zamboni/editors.js:445
-msgid "Error loading translation"
-msgstr "Error al cargar traducción"
-
-#: static/js/zamboni/files.js:411 static/js/zamboni/validator.js:261
-msgid "Ignore this message in future updates"
-msgstr "No haga caso de este mensaje en futuras actualizaciones"
-
-#: static/js/zamboni/files.js:417 static/js/zamboni/validator.js:284
-msgid "Severity for automated signing:"
-msgstr "Severidad de la firma automatizada"
-
-#: static/js/zamboni/global.js:410
-msgid "Loading..."
-msgstr "Cargando..."
-
-#. L10n: {0} is the number of characters left.
-#: static/js/zamboni/global.js:474
-msgid "<b>{0}</b> character left."
-msgid_plural "<b>{0}</b> characters left."
-msgstr[0] "<b>{0}</b> carácter restante."
-msgstr[1] "<b>{0}</b> caracteres restantes."
-
-#: static/js/zamboni/init.js:28
-msgid "This feature is temporarily disabled while we perform website maintenance. Please check back a little later."
-msgstr "Esta característica está desactivada temporalmente mientras realizamos el mantenimiento de la página web. Inténtalo de nuevo pasados unos minutos."
-
-#: static/js/zamboni/l10n.js:45
-msgid "Remove this localization"
-msgstr "Eliminar esta localización"
-
-#: static/js/zamboni/password-strength.js:20
-msgid "Password strength:"
-msgstr "Fortaleza de la contraseña:"
-
-#: static/js/zamboni/password-strength.js:26
-msgid "At least {0} character left."
-msgid_plural "At least {0} characters left."
-msgstr[0] "Queda al menos {0} carácter."
-msgstr[1] "Quedan al menos {0} caracteres."
-
-#: static/js/zamboni/themes_review.js:176
-msgid "Requested Info"
-msgstr "Información solicitada"
-
-#: static/js/zamboni/themes_review.js:177
-msgid "Flagged"
-msgstr "Marcadas"
-
-#: static/js/zamboni/themes_review.js:178
-msgid "Duplicate"
-msgstr "Duplicadas"
-
-#: static/js/zamboni/themes_review.js:179
-msgid "Rejected"
-msgstr "Rechazadas"
-
-#: static/js/zamboni/themes_review.js:180
-msgid "Approved"
-msgstr "Aprobadas"
-
-#: static/js/zamboni/themes_review.js:424
-msgid "No results found"
-msgstr "No hay resultados"
-
-#: static/js/zamboni/themes_review_templates.js:31
-msgid "Theme"
-msgstr "Tema"
-
-#: static/js/zamboni/themes_review_templates.js:33
-msgid "Reviewer"
-msgstr "Revisor"
-
-#: static/js/zamboni/themes_review_templates.js:35
-msgid "Status"
-msgstr "Estado"
-
-#: static/js/zamboni/validator.js:80
+#: static/js/zamboni/devhub-all.js:2613 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:80
 msgid "All tests passed successfully."
 msgstr "Todas las pruebas se han pasado con éxito."
 
-#: static/js/zamboni/validator.js:83 static/js/zamboni/validator.js:478
+#: static/js/zamboni/devhub-all.js:2616 static/js/zamboni/devhub-all.js:3011 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:83 static/js/zamboni/validator.js:478
 msgid "These tests were not run."
 msgstr "Estas pruebas no se han ejecutado."
 
-#: static/js/zamboni/validator.js:131 static/js/zamboni/validator.js:144
+#: static/js/zamboni/devhub-all.js:2664 static/js/zamboni/devhub-all.js:2677 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:131 static/js/zamboni/validator.js:144
 msgid "Tests"
 msgstr "Pruebas"
 
-#: static/js/zamboni/validator.js:246 static/js/zamboni/validator.js:575 static/js/zamboni/validator.js:594
+#: static/js/zamboni/devhub-all.js:2779 static/js/zamboni/devhub-all.js:3108 static/js/zamboni/devhub-all.js:3127 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:246
+#: static/js/zamboni/validator.js:575 static/js/zamboni/validator.js:594
 msgid "Error"
 msgstr "Error"
 
-#: static/js/zamboni/validator.js:247
+#: static/js/zamboni/devhub-all.js:2780 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:247
 msgid "Warning"
 msgstr "Advertencia"
 
-#: static/js/zamboni/validator.js:299
+#: static/js/zamboni/devhub-all.js:2794 static/js/zamboni/devhub-min.js:2 static/js/zamboni/files-all.js:5657 static/js/zamboni/files-min.js:3 static/js/zamboni/files.js:411
+#: static/js/zamboni/validator.js:261
+msgid "Ignore this message in future updates"
+msgstr "No haga caso de este mensaje en futuras actualizaciones"
+
+#: static/js/zamboni/devhub-all.js:2817 static/js/zamboni/devhub-min.js:2 static/js/zamboni/files-all.js:5663 static/js/zamboni/files-min.js:3 static/js/zamboni/files.js:417
+#: static/js/zamboni/validator.js:284
+msgid "Severity for automated signing:"
+msgstr "Severidad de la firma automatizada"
+
+#: static/js/zamboni/devhub-all.js:2832 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:299
 msgid "Suggestions for passing automated signing:"
 msgstr "Sugerencias para pasar la firma automatizada:"
 
-#: static/js/zamboni/validator.js:387
+#: static/js/zamboni/devhub-all.js:2920 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:387
 msgid "Compatibility Tests"
 msgstr "Pruebas de compatibilidad"
 
-#: static/js/zamboni/validator.js:466
+#: static/js/zamboni/devhub-all.js:2999 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:466
 msgid "Add-on failed validation."
 msgstr "El complemento ha fallado la validación."
 
-#: static/js/zamboni/validator.js:468
+#: static/js/zamboni/devhub-all.js:3001 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:468
 msgid "Add-on passed validation."
 msgstr "El complemento ha pasado la validación."
 
-#: static/js/zamboni/validator.js:481
+#: static/js/zamboni/devhub-all.js:3014 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:481
 msgid "{0} error"
 msgid_plural "{0} errors"
 msgstr[0] "{0} error"
 msgstr[1] "{0} errores"
 
-#: static/js/zamboni/validator.js:483
+#: static/js/zamboni/devhub-all.js:3016 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:483
 msgid "{0} warning"
 msgid_plural "{0} warnings"
 msgstr[0] "{0} aviso"
 msgstr[1] "{0} avisos"
 
-#: static/js/zamboni/validator.js:485
+#: static/js/zamboni/devhub-all.js:3018 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:485
 msgid "{0} notice"
 msgid_plural "{0} notices"
 msgstr[0] "{0} mensaje"
 msgstr[1] "{0} mensajes"
 
-#: static/js/zamboni/validator.js:577
+#: static/js/zamboni/devhub-all.js:3110 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:577
 msgid "Validation task could not complete or completed with errors"
 msgstr "La tarea de validación no ha podido completarse o se ha completado con errores"
 
-#: static/js/zamboni/validator.js:595
+#: static/js/zamboni/devhub-all.js:3128 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:595
 msgid "Internal server error"
 msgstr "Error interno del servidor"
 
-#: static/js/zamboni/mobile/buttons.js:52
+#: static/js/zamboni/devhub_search.js:8
+msgid "No results found."
+msgstr "No se ha encontrado ningún resultado."
+
+#: static/js/zamboni/editors-all.js:15402 static/js/zamboni/editors-min.js:4 static/js/zamboni/editors.js:121
+msgid "{name} was viewing this page first."
+msgstr "{name} estuvo viendo esta página antes."
+
+#: static/js/zamboni/editors-all.js:15452 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:171
+msgid "Receipt checked by app."
+msgstr "El recibo fue comprobado por la aplicación."
+
+#: static/js/zamboni/editors-all.js:15454 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:173
+msgid "Receipt was not checked by app."
+msgstr "El recibo no fue comprobado por la aplicación."
+
+#: static/js/zamboni/editors-all.js:15525 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:244
+msgid "{name} was viewing this add-on first."
+msgstr "{name} fue el primero en ver este complemento."
+
+#: static/js/zamboni/editors-all.js:15536 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:255
+msgid "Loading&hellip;"
+msgstr "Cargando &hellip;"
+
+#: static/js/zamboni/editors-all.js:15541 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:260
+msgid "Version Notes"
+msgstr "Notas de la versión"
+
+#: static/js/zamboni/editors-all.js:15546 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:265
+msgid "Notes for Reviewers"
+msgstr "Notas para los revisores"
+
+#: static/js/zamboni/editors-all.js:15551 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:270
+msgid "No version notes found"
+msgstr "No se han encontrado las notas de la versión"
+
+#: static/js/zamboni/editors-all.js:15611 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:330
+msgid "Average Reviews"
+msgstr "Revisiones medias"
+
+#: static/js/zamboni/editors-all.js:15667 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:386
+msgid "Number of Reviews"
+msgstr "Número de revisiones"
+
+#: static/js/zamboni/editors-all.js:15726 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:445
+msgid "Error loading translation"
+msgstr "Error al cargar traducción"
+
+#: static/js/zamboni/editors-all.js:15975 static/js/zamboni/editors-min.js:5 static/js/zamboni/themes_review_templates.js:31
+msgid "Theme"
+msgstr "Tema"
+
+#: static/js/zamboni/editors-all.js:15977 static/js/zamboni/editors-min.js:5 static/js/zamboni/themes_review_templates.js:33
+msgid "Reviewer"
+msgstr "Revisor"
+
+#: static/js/zamboni/editors-all.js:15979 static/js/zamboni/editors-min.js:5 static/js/zamboni/themes_review_templates.js:35
+msgid "Status"
+msgstr "Estado"
+
+#: static/js/zamboni/editors-all.js:16196 static/js/zamboni/editors-min.js:5 static/js/zamboni/themes_review.js:176
+msgid "Requested Info"
+msgstr "Información solicitada"
+
+#: static/js/zamboni/editors-all.js:16197 static/js/zamboni/editors-min.js:5 static/js/zamboni/themes_review.js:177
+msgid "Flagged"
+msgstr "Marcadas"
+
+#: static/js/zamboni/editors-all.js:16198 static/js/zamboni/editors-min.js:5 static/js/zamboni/themes_review.js:178
+msgid "Duplicate"
+msgstr "Duplicadas"
+
+#: static/js/zamboni/editors-all.js:16199 static/js/zamboni/editors-min.js:5 static/js/zamboni/themes_review.js:179
+msgid "Rejected"
+msgstr "Rechazadas"
+
+#: static/js/zamboni/editors-all.js:16200 static/js/zamboni/editors-min.js:5 static/js/zamboni/themes_review.js:180
+msgid "Approved"
+msgstr "Aprobadas"
+
+#: static/js/zamboni/editors-all.js:16444 static/js/zamboni/editors-min.js:5 static/js/zamboni/themes_review.js:424
+msgid "No results found"
+msgstr "No hay resultados"
+
+#: static/js/zamboni/mobile-all.js:15186 static/js/zamboni/mobile/buttons.js:52
 msgid "Not Updated for {0} {1}"
 msgstr "No actualizado para {0} {1}"
 
-#: static/js/zamboni/mobile/buttons.js:53
+#: static/js/zamboni/mobile-all.js:15187 static/js/zamboni/mobile/buttons.js:53
 msgid "Requires Newer Version of {0}"
 msgstr "Requiere una nueva versión de {0}"
 
-#: static/js/zamboni/mobile/buttons.js:54
+#: static/js/zamboni/mobile-all.js:15188 static/js/zamboni/mobile/buttons.js:54
 msgid "Unreviewed"
 msgstr "Sin revisar"
 
-#: static/js/zamboni/mobile/buttons.js:55
+#: static/js/zamboni/mobile-all.js:15189 static/js/zamboni/mobile/buttons.js:55
 msgid "Experimental <span>(Learn More)</span>"
 msgstr "Experimental <span>(más información)</span>"
 
-#: static/js/zamboni/mobile/buttons.js:56 static/js/zamboni/mobile/buttons.js:57
+#: static/js/zamboni/mobile-all.js:15190 static/js/zamboni/mobile-all.js:15191 static/js/zamboni/mobile/buttons.js:56 static/js/zamboni/mobile/buttons.js:57
 msgid "Not Available for {0}"
 msgstr "No está disponible para {0}"
 
-#: static/js/zamboni/mobile/buttons.js:58
+#: static/js/zamboni/mobile-all.js:15192 static/js/zamboni/mobile/buttons.js:58
 msgid "Experimental"
 msgstr "Experimental"
 
-#: static/js/zamboni/mobile/buttons.js:59
+#: static/js/zamboni/mobile-all.js:15193 static/js/zamboni/mobile/buttons.js:59
 msgid "Themes Require Newer Version of {0}"
 msgstr "Los temas requieren una versión reciente de {0}"
 
-#: static/js/zamboni/mobile/buttons.js:60
+#: static/js/zamboni/mobile-all.js:15194 static/js/zamboni/mobile/buttons.js:60
 msgid "Themes Require {0}"
 msgstr "Los temas requieren {0}"
 
-#: static/js/zamboni/mobile/buttons.js:105
+#: static/js/zamboni/mobile-all.js:15239 static/js/zamboni/mobile/buttons.js:105
 msgid "Installing..."
 msgstr "Instalando..."
 
-#: static/js/zamboni/mobile/buttons.js:125
+#: static/js/zamboni/mobile-all.js:15259 static/js/zamboni/mobile/buttons.js:125
 msgid "This add-on has been preliminarily reviewed by Mozilla."
 msgstr "Este complemento ha sido revisado preliminarmente por Mozilla."
 
-#: static/js/zamboni/mobile/buttons.js:250
+#: static/js/zamboni/mobile-all.js:15384 static/js/zamboni/mobile/buttons.js:250
 msgid "Keep it"
 msgstr "Conservarlo"
 
-#: static/js/zamboni/mobile/general.js:344
+#: static/js/zamboni/mobile-all.js:16049 static/js/zamboni/mobile-min.js:6 static/js/zamboni/mobile/general.js:344
 msgid "You're trying it on!"
 msgstr "¡Lo estás probando!"
 
-#: static/js/zamboni/mobile/general.js:356
+#: static/js/zamboni/mobile-all.js:16061 static/js/zamboni/mobile-min.js:6 static/js/zamboni/mobile/general.js:356
 msgid "Added to Firefox"
 msgstr "Agregado a Firefox"
-

--- a/locale/et/LC_MESSAGES/django.po
+++ b/locale/et/LC_MESSAGES/django.po
@@ -3,69 +3,70 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2016-02-24 21:23+0000\n"
+"POT-Creation-Date: 2016-04-18 15:47+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
+"Language: \n"
 "MIME-Version: 1.0\n"
-"Content-Type: text/plain; charset=utf-8\n"
+"Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Generated-By: Babel 2.2.0\n"
 
-#: src/olympia/accounts/views.py:52
+#: src/olympia/accounts/views.py:54
 msgid "Your log in attempt could not be parsed. Please try again."
 msgstr ""
 
-#: src/olympia/accounts/views.py:54
+#: src/olympia/accounts/views.py:56
 msgid "Your Firefox Account could not be found. Please try again."
 msgstr ""
 
-#: src/olympia/accounts/views.py:55
+#: src/olympia/accounts/views.py:57
 msgid "You could not be logged in. Please try again."
 msgstr ""
 
-#: src/olympia/accounts/views.py:57
+#: src/olympia/accounts/views.py:59
 msgid "Your account has already been migrated to Firefox Accounts."
 msgstr ""
 
-#: src/olympia/accounts/views.py:59
+#: src/olympia/accounts/views.py:61
 msgid "Your Firefox Account already exists on this site."
 msgstr ""
 
-#: src/olympia/accounts/views.py:108
+#: src/olympia/accounts/views.py:110
 msgid "Great job!"
 msgstr ""
 
-#: src/olympia/accounts/views.py:109
+#: src/olympia/accounts/views.py:111
 msgid "You can now log in to Add-ons with your Firefox Account."
 msgstr ""
 
-#: src/olympia/accounts/views.py:121
+#: src/olympia/accounts/views.py:123
 msgid "Need help?"
 msgstr ""
 
-#: src/olympia/addons/buttons.py:180
+#: src/olympia/addons/buttons.py:177
 msgid "Download Now"
 msgstr ""
 
-#: src/olympia/addons/buttons.py:182
+#: src/olympia/addons/buttons.py:179
 msgid "Download"
 msgstr ""
 
 #. L10n: please keep &nbsp; in the string so &rarr; does not wrap.
-#: src/olympia/addons/buttons.py:186
+#: src/olympia/addons/buttons.py:183
 msgid "Continue to Download&nbsp;&rarr;"
 msgstr ""
 
-#: src/olympia/addons/buttons.py:202 src/olympia/addons/helpers.py:35 src/olympia/addons/views.py:319 src/olympia/addons/templates/addons/impala/details.html:114
+#: src/olympia/addons/buttons.py:199 src/olympia/addons/helpers.py:35 src/olympia/addons/views.py:333 src/olympia/addons/templates/addons/impala/details.html:111
 #: src/olympia/addons/templates/addons/impala/listing/items.html:17 src/olympia/addons/templates/addons/mobile/home.html:40 src/olympia/amo/templates/amo/side_nav.html:6
-#: src/olympia/amo/templates/amo/side_nav.html:10 src/olympia/amo/templates/amo/site_nav.html:2 src/olympia/amo/templates/amo/site_nav.html:55 src/olympia/bandwagon/views.py:95
-#: src/olympia/browse/views.py:54 src/olympia/browse/views.py:68 src/olympia/browse/views.py:235 src/olympia/browse/templates/browse/impala/category_landing.html:22
+#: src/olympia/amo/templates/amo/side_nav.html:10 src/olympia/amo/templates/amo/site_nav.html:2 src/olympia/amo/templates/amo/site_nav.html:53 src/olympia/bandwagon/views.py:95
+#: src/olympia/browse/views.py:54 src/olympia/browse/views.py:68 src/olympia/browse/views.py:202 src/olympia/browse/templates/browse/impala/category_landing.html:22
 #: src/olympia/browse/templates/browse/personas/mobile/category_landing.html:26
 msgid "Featured"
 msgstr ""
 
-#: src/olympia/addons/buttons.py:221
+#: src/olympia/addons/buttons.py:218
 msgid "Add to {0}"
 msgstr ""
 
@@ -113,39 +114,39 @@ msgid_plural "All tags must be at least {0} characters."
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/olympia/addons/forms.py:234
+#: src/olympia/addons/forms.py:238
 msgid "Categories cannot be changed while your add-on is featured for this application."
 msgstr ""
 
 #. L10n: {0} is the number of categories.
-#: src/olympia/addons/forms.py:238
+#: src/olympia/addons/forms.py:242
 msgid "You can have only {0} category."
 msgid_plural "You can have only {0} categories."
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/olympia/addons/forms.py:246
+#: src/olympia/addons/forms.py:250
 msgid "The miscellaneous category cannot be combined with additional categories."
 msgstr ""
 
-#: src/olympia/addons/forms.py:369
+#: src/olympia/addons/forms.py:374
 #, python-format
 msgid "Before changing your default locale you must have a name, summary, and description in that locale. You are missing %s."
 msgstr ""
 
-#: src/olympia/addons/forms.py:484 src/olympia/addons/forms.py:575
+#: src/olympia/addons/forms.py:455 src/olympia/addons/forms.py:546
 msgid "A license must be selected."
 msgstr ""
 
-#: src/olympia/addons/forms.py:556
+#: src/olympia/addons/forms.py:527
 msgid "Give Your Theme a Name."
 msgstr ""
 
-#: src/olympia/addons/forms.py:562 src/olympia/devhub/templates/devhub/personas/submit.html:53
+#: src/olympia/addons/forms.py:533 src/olympia/devhub/templates/devhub/personas/submit.html:53
 msgid "Describe your Theme."
 msgstr ""
 
-#: src/olympia/addons/forms.py:704
+#: src/olympia/addons/forms.py:675
 msgid "Enter a new author's email address"
 msgstr ""
 
@@ -153,37 +154,37 @@ msgstr ""
 msgid "Not Reviewed"
 msgstr ""
 
-#: src/olympia/addons/models.py:301
+#: src/olympia/addons/models.py:298
 msgid "Users have the option of contributing more or less than this amount."
 msgstr ""
 
-#: src/olympia/addons/models.py:309
-msgid "Users will always be asked in the Add-ons Manager (Firefox 4 and above)"
+#: src/olympia/addons/models.py:306
+msgid "Users will always be asked in the Add-ons Manager (Firefox 4 and above). Only applies to desktop."
 msgstr ""
 
-#: src/olympia/addons/models.py:1804 src/olympia/addons/templates/addons/details_box.html:55 src/olympia/devhub/templates/devhub/index.html:92
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:102
+#: src/olympia/addons/models.py:1802 src/olympia/addons/templates/addons/details_box.html:55 src/olympia/devhub/templates/devhub/index.html:92
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:89
 msgid "Listed"
 msgstr ""
 
-#: src/olympia/addons/views.py:320 src/olympia/browse/templates/browse/personas/mobile/category_landing.html:27
+#: src/olympia/addons/views.py:334 src/olympia/browse/templates/browse/personas/mobile/category_landing.html:27
 msgid "Popular"
 msgstr ""
 
-#: src/olympia/addons/views.py:321 src/olympia/browse/views.py:238 src/olympia/browse/views.py:280 src/olympia/browse/views.py:482
+#: src/olympia/addons/views.py:335 src/olympia/browse/views.py:205 src/olympia/browse/views.py:247 src/olympia/browse/views.py:449
 msgid "Recently Added"
 msgstr ""
 
-#: src/olympia/addons/views.py:322 src/olympia/bandwagon/views.py:99 src/olympia/browse/views.py:60 src/olympia/browse/views.py:71 src/olympia/search/forms.py:16 src/olympia/search/forms.py:91
+#: src/olympia/addons/views.py:336 src/olympia/bandwagon/views.py:99 src/olympia/browse/views.py:60 src/olympia/browse/views.py:71 src/olympia/search/forms.py:16 src/olympia/search/forms.py:91
 msgid "Recently Updated"
 msgstr ""
 
 #. l10n: {0} is the addon name
-#: src/olympia/addons/views.py:520
+#: src/olympia/addons/views.py:534
 msgid "Contribution for {0}"
 msgstr ""
 
-#: src/olympia/addons/views.py:613
+#: src/olympia/addons/views.py:627
 msgid "Abuse reported."
 msgstr ""
 
@@ -250,9 +251,9 @@ msgstr ""
 #: src/olympia/devhub/templates/devhub/addons/ajax_compat_update.html:36 src/olympia/devhub/templates/devhub/addons/profile.html:44 src/olympia/devhub/templates/devhub/addons/edit/admin.html:101
 #: src/olympia/devhub/templates/devhub/addons/edit/basic.html:152 src/olympia/devhub/templates/devhub/addons/edit/details.html:85 src/olympia/devhub/templates/devhub/addons/edit/support.html:67
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:166 src/olympia/devhub/templates/devhub/addons/forms_shared/media.html:149
-#: src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:44 src/olympia/devhub/templates/devhub/versions/add_file_modal.html:78 src/olympia/devhub/templates/devhub/versions/edit.html:139
-#: src/olympia/devhub/templates/devhub/versions/list.html:242 src/olympia/devhub/templates/devhub/versions/list.html:276 src/olympia/devhub/templates/devhub/versions/list.html:317
-#: src/olympia/devhub/templates/devhub/versions/list.html:351 src/olympia/reviews/templates/reviews/edit_review.html:16 src/olympia/translations/templates/translations/trans-menu.html:50
+#: src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:43 src/olympia/devhub/templates/devhub/versions/add_file_modal.html:58 src/olympia/devhub/templates/devhub/versions/edit.html:139
+#: src/olympia/devhub/templates/devhub/versions/list.html:239 src/olympia/devhub/templates/devhub/versions/list.html:281 src/olympia/devhub/templates/devhub/versions/list.html:315
+#: src/olympia/devhub/templates/devhub/versions/list.html:349 src/olympia/reviews/templates/reviews/edit_review.html:16 src/olympia/translations/templates/translations/trans-menu.html:50
 #: src/olympia/translations/templates/translations/trans-menu.html:62
 msgid "or"
 msgstr ""
@@ -363,7 +364,7 @@ msgid "Add-on Information for {0}"
 msgstr ""
 
 #: src/olympia/addons/templates/addons/details_box.html:30 src/olympia/addons/templates/addons/persona_detail_table.html:3 src/olympia/addons/templates/addons/mobile/details.html:63
-#: src/olympia/addons/templates/addons/mobile/persona_detail_table.html:7 src/olympia/browse/views.py:459 src/olympia/devhub/views.py:75
+#: src/olympia/addons/templates/addons/mobile/persona_detail_table.html:7 src/olympia/browse/views.py:426 src/olympia/devhub/views.py:73
 msgid "Updated"
 msgstr ""
 
@@ -382,11 +383,11 @@ msgstr ""
 msgid "Visibility"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/details_box.html:57 src/olympia/devhub/templates/devhub/index.html:94 src/olympia/devhub/templates/devhub/includes/addon_details.html:104
+#: src/olympia/addons/templates/addons/details_box.html:57 src/olympia/devhub/templates/devhub/index.html:94 src/olympia/devhub/templates/devhub/includes/addon_details.html:91
 msgid "Hidden"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/details_box.html:59 src/olympia/devhub/templates/devhub/index.html:96 src/olympia/devhub/templates/devhub/includes/addon_details.html:106
+#: src/olympia/addons/templates/addons/details_box.html:59 src/olympia/devhub/templates/devhub/index.html:96 src/olympia/devhub/templates/devhub/includes/addon_details.html:93
 msgid "Unlisted"
 msgstr ""
 
@@ -394,13 +395,13 @@ msgstr ""
 msgid "Required Add-ons"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/details_box.html:81 src/olympia/addons/templates/addons/persona_detail_table.html:15 src/olympia/browse/views.py:462 src/olympia/devhub/views.py:78
-#: src/olympia/devhub/views.py:85 src/olympia/discovery/templates/discovery/addons/detail.html:57 src/olympia/reviews/forms.py:62 src/olympia/reviews/templates/reviews/add.html:57
+#: src/olympia/addons/templates/addons/details_box.html:81 src/olympia/addons/templates/addons/persona_detail_table.html:15 src/olympia/browse/views.py:429 src/olympia/devhub/views.py:76
+#: src/olympia/devhub/views.py:83 src/olympia/discovery/templates/discovery/addons/detail.html:57 src/olympia/reviews/forms.py:62 src/olympia/reviews/templates/reviews/add.html:57
 #: src/olympia/reviews/templates/reviews/mobile/review_list.html:18
 msgid "Rating"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/details_box.html:85 src/olympia/browse/views.py:461 src/olympia/devhub/views.py:77 src/olympia/devhub/views.py:84
+#: src/olympia/addons/templates/addons/details_box.html:85 src/olympia/browse/views.py:428 src/olympia/devhub/views.py:75 src/olympia/devhub/views.py:82
 #: src/olympia/stats/templates/stats/addon_report_menu.html:8 src/olympia/stats/templates/stats/collection_report_menu.html:18
 msgid "Downloads"
 msgstr ""
@@ -420,7 +421,7 @@ msgstr ""
 
 #. The Privacy Policy for this add-on.
 #: src/olympia/addons/templates/addons/details_box.html:121 src/olympia/addons/templates/addons/privacy.html:19 src/olympia/addons/templates/addons/privacy.html:23
-#: src/olympia/addons/templates/addons/impala/button.html:43 src/olympia/addons/templates/addons/impala/details.html:307 src/olympia/devhub/templates/devhub/includes/policy_form.html:20
+#: src/olympia/addons/templates/addons/impala/button.html:43 src/olympia/addons/templates/addons/impala/details.html:312 src/olympia/devhub/templates/devhub/includes/policy_form.html:23
 #: src/olympia/templates/mobile/base_addons.html:87
 msgid "Privacy Policy"
 msgstr ""
@@ -445,7 +446,7 @@ msgstr ""
 msgid "Developer Comments"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/details_box.html:199 src/olympia/addons/templates/addons/impala/details.html:259
+#: src/olympia/addons/templates/addons/details_box.html:199 src/olympia/addons/templates/addons/impala/details.html:264
 msgid "Development Channel"
 msgstr ""
 
@@ -465,7 +466,7 @@ msgid ""
 "developer. To stop receiving development updates, reinstall the default version from the link above."
 msgstr ""
 
-#: src/olympia/addons/templates/addons/details_box.html:220 src/olympia/addons/templates/addons/impala/details.html:278
+#: src/olympia/addons/templates/addons/details_box.html:220 src/olympia/addons/templates/addons/impala/details.html:283
 msgid "Version {0}:"
 msgstr ""
 
@@ -484,7 +485,7 @@ msgid "End-User License Agreement for {0}"
 msgstr ""
 
 #: src/olympia/addons/templates/addons/eula.html:17 src/olympia/addons/templates/addons/eula.html:21 src/olympia/addons/templates/addons/impala/button.html:48
-#: src/olympia/addons/templates/addons/impala/details.html:316 src/olympia/devhub/templates/devhub/includes/policy_form.html:3 src/olympia/discovery/templates/discovery/addons/eula.html:11
+#: src/olympia/addons/templates/addons/impala/details.html:321 src/olympia/devhub/templates/devhub/includes/policy_form.html:3 src/olympia/discovery/templates/discovery/addons/eula.html:11
 msgid "End-User License Agreement"
 msgstr ""
 
@@ -501,7 +502,7 @@ msgstr ""
 msgid "Add-ons for {0}"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/home.html:10 src/olympia/addons/templates/addons/home.html:51 src/olympia/browse/templates/browse/impala/base_listing.html:11
+#: src/olympia/addons/templates/addons/home.html:10 src/olympia/addons/templates/addons/home.html:53 src/olympia/browse/templates/browse/impala/base_listing.html:11
 msgid "Featured Extensions"
 msgstr ""
 
@@ -509,29 +510,29 @@ msgstr ""
 msgid "Popular Extensions"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/home.html:42 src/olympia/amo/templates/amo/side_nav.html:3 src/olympia/amo/templates/amo/side_nav.html:11 src/olympia/amo/templates/amo/site_nav.html:3
-#: src/olympia/amo/templates/amo/site_nav.html:25 src/olympia/browse/views.py:236 src/olympia/browse/views.py:281 src/olympia/browse/views.py:481
+#: src/olympia/addons/templates/addons/home.html:44 src/olympia/amo/templates/amo/side_nav.html:3 src/olympia/amo/templates/amo/side_nav.html:11 src/olympia/amo/templates/amo/site_nav.html:3
+#: src/olympia/amo/templates/amo/site_nav.html:25 src/olympia/browse/views.py:203 src/olympia/browse/views.py:248 src/olympia/browse/views.py:448
 msgid "Most Popular"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/home.html:43
+#: src/olympia/addons/templates/addons/home.html:45
 msgid "All »"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/home.html:52 src/olympia/addons/templates/addons/home.html:61 src/olympia/addons/templates/addons/home.html:70 src/olympia/addons/templates/addons/home.html:78
+#: src/olympia/addons/templates/addons/home.html:54 src/olympia/addons/templates/addons/home.html:63 src/olympia/addons/templates/addons/home.html:72 src/olympia/addons/templates/addons/home.html:80
 #: src/olympia/browse/templates/browse/impala/category_landing.html:36
 msgid "See all »"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/home.html:60
+#: src/olympia/addons/templates/addons/home.html:62
 msgid "Up &amp; Coming Extensions"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/home.html:69 src/olympia/browse/templates/browse/personas/category_landing.html:61 src/olympia/discovery/templates/discovery/pane.html:74
+#: src/olympia/addons/templates/addons/home.html:71 src/olympia/browse/templates/browse/personas/category_landing.html:61 src/olympia/discovery/templates/discovery/pane.html:74
 msgid "Featured Themes"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/home.html:77 src/olympia/bandwagon/templates/bandwagon/impala/collection_listing.html:5
+#: src/olympia/addons/templates/addons/home.html:79 src/olympia/bandwagon/templates/bandwagon/impala/collection_listing.html:5
 msgid "Featured Collections"
 msgstr ""
 
@@ -549,7 +550,7 @@ msgid "Updated {0}"
 msgstr ""
 
 #. {0} is a date.
-#: src/olympia/addons/templates/addons/macros.html:10 src/olympia/addons/templates/addons/macros.html:69 src/olympia/addons/templates/addons/persona_preview.html:21
+#: src/olympia/addons/templates/addons/macros.html:10 src/olympia/addons/templates/addons/macros.html:69 src/olympia/addons/templates/addons/persona_preview.html:22
 #: src/olympia/addons/templates/addons/listing/items_mobile.html:44 src/olympia/addons/templates/addons/listing/macros.html:39
 #: src/olympia/bandwagon/templates/bandwagon/collection_listing_items.html:37 src/olympia/bandwagon/templates/bandwagon/impala/collection_listing_items.html:37
 msgid "Added {0}"
@@ -570,15 +571,14 @@ msgstr[0] ""
 msgstr[1] ""
 
 #. {0} is the number of downloads.
-#: src/olympia/addons/templates/addons/macros.html:53 src/olympia/addons/templates/addons/impala/details.html:61
+#: src/olympia/addons/templates/addons/macros.html:53 src/olympia/addons/templates/addons/impala/details.html:59
 msgid "{0} weekly download"
 msgid_plural "{0} weekly downloads"
 msgstr[0] ""
 msgstr[1] ""
 
 #. {0} is the number of users.
-#: src/olympia/addons/templates/addons/macros.html:61 src/olympia/addons/templates/addons/impala/details.html:54 src/olympia/compat/templates/compat/index.html:71
-#: src/olympia/zadmin/templates/zadmin/compat.html:67
+#: src/olympia/addons/templates/addons/macros.html:61 src/olympia/addons/templates/addons/impala/details.html:52 src/olympia/zadmin/templates/zadmin/compat.html:67
 msgid "{0} user"
 msgid_plural "{0} users"
 msgstr[0] ""
@@ -596,7 +596,7 @@ msgstr ""
 msgid "Return to the addon."
 msgstr ""
 
-#: src/olympia/addons/templates/addons/persona_detail.html:17 src/olympia/addons/templates/addons/impala/details.html:106 src/olympia/addons/templates/addons/mobile/details.html:23
+#: src/olympia/addons/templates/addons/persona_detail.html:17 src/olympia/addons/templates/addons/impala/details.html:103 src/olympia/addons/templates/addons/mobile/details.html:23
 #: src/olympia/addons/templates/addons/mobile/persona_detail.html:21 src/olympia/discovery/templates/discovery/addons/base.html:27 src/olympia/editors/templates/editors/review.html:31
 msgid "by"
 msgstr ""
@@ -640,34 +640,35 @@ msgstr ""
 msgid "License"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/persona_preview.html:12 src/olympia/constants/base.py:48
+#: src/olympia/addons/templates/addons/persona_preview.html:13 src/olympia/constants/base.py:48
 msgid "Awaiting Review"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/persona_preview.html:14 src/olympia/amo/log.py:180 src/olympia/constants/base.py:42 src/olympia/editors/helpers.py:62
+#: src/olympia/addons/templates/addons/persona_preview.html:15 src/olympia/amo/log.py:180 src/olympia/constants/base.py:42 src/olympia/editors/helpers.py:62
 msgid "Rejected"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/persona_preview.html:16 src/olympia/amo/log.py:159
+#: src/olympia/addons/templates/addons/persona_preview.html:17 src/olympia/amo/log.py:159
 msgid "Approved"
 msgstr ""
 
 #. {0} is the number of users.
-#: src/olympia/addons/templates/addons/persona_preview.html:26 src/olympia/addons/templates/addons/listing/items_mobile.html:36 src/olympia/addons/templates/addons/listing/macros.html:31
+#: src/olympia/addons/templates/addons/persona_preview.html:27 src/olympia/addons/templates/addons/listing/items_mobile.html:36 src/olympia/addons/templates/addons/listing/macros.html:31
 msgid "<strong>{0}</strong> user"
 msgid_plural "<strong>{0}</strong> users"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/olympia/addons/templates/addons/persona_preview.html:40
+#: src/olympia/addons/templates/addons/persona_preview.html:41
 msgid "Hover to Preview"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/persona_preview.html:46 src/olympia/addons/templates/addons/persona_preview.html:48 src/olympia/reviews/templates/reviews/add.html:15
+#: src/olympia/addons/templates/addons/persona_preview.html:47 src/olympia/addons/templates/addons/persona_preview.html:49 src/olympia/addons/templates/addons/persona_preview.html:97
+#: src/olympia/reviews/templates/reviews/add.html:15
 msgid "Add"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/persona_preview.html:57 src/olympia/bandwagon/templates/bandwagon/ajax_new.html:16 src/olympia/bandwagon/templates/bandwagon/edit.html:19
+#: src/olympia/addons/templates/addons/persona_preview.html:58 src/olympia/bandwagon/templates/bandwagon/ajax_new.html:16 src/olympia/bandwagon/templates/bandwagon/edit.html:19
 #: src/olympia/bandwagon/templates/bandwagon/includes/addedit.html:19 src/olympia/devhub/templates/devhub/addons/edit/admin.html:13 src/olympia/devhub/templates/devhub/addons/edit/basic.html:10
 #: src/olympia/devhub/templates/devhub/addons/edit/details.html:8 src/olympia/devhub/templates/devhub/addons/edit/media.html:6 src/olympia/devhub/templates/devhub/addons/edit/support.html:8
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:9 src/olympia/devhub/templates/devhub/addons/submit/describe.html:29 src/olympia/editors/templates/editors/review.html:257
@@ -676,21 +677,21 @@ msgstr ""
 
 #. For datetime formatting, see the table on
 #. http://docs.python.org/library/datetime.html#strftime-and-strptime-behavior
-#: src/olympia/addons/templates/addons/persona_preview.html:66
+#: src/olympia/addons/templates/addons/persona_preview.html:67
 #, python-format
 msgid "%%Y-%%m-%%d"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/persona_preview.html:67
+#: src/olympia/addons/templates/addons/persona_preview.html:68
 msgid "by {0} on {1}"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/persona_preview.html:75 src/olympia/reviews/helpers.py:17 src/olympia/reviews/templates/reviews/review_list.html:63
+#: src/olympia/addons/templates/addons/persona_preview.html:76 src/olympia/reviews/helpers.py:17 src/olympia/reviews/templates/reviews/review_list.html:63
 #: src/olympia/reviews/templates/reviews/reviews_link.html:21 src/olympia/reviews/templates/reviews/impala/reviews_link.html:16
 msgid "Not yet rated"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/persona_preview.html:78
+#: src/olympia/addons/templates/addons/persona_preview.html:79
 msgid "<b>{0}</b> users"
 msgstr ""
 
@@ -703,7 +704,7 @@ msgid "Learn more about Firefox"
 msgstr ""
 
 #: src/olympia/addons/templates/addons/popups.html:22
-msgid "or <b><a class=\"installer\" href=\"{url}\">download anyway</a></b>"
+msgid "or <b><a class=\"button installer\" href=\"{url}\">download anyway</a></b>"
 msgstr ""
 
 #: src/olympia/addons/templates/addons/popups.html:26
@@ -802,7 +803,7 @@ msgid ""
 msgstr ""
 
 #: src/olympia/addons/templates/addons/report_abuse.html:6 src/olympia/addons/templates/addons/report_abuse_full.html:10 src/olympia/addons/templates/addons/impala/details-more.html:23
-#: src/olympia/addons/templates/addons/impala/details.html:328
+#: src/olympia/addons/templates/addons/impala/details.html:333
 msgid "Report Abuse"
 msgstr ""
 
@@ -821,9 +822,9 @@ msgstr ""
 #: src/olympia/devhub/templates/devhub/addons/ajax_compat_update.html:36 src/olympia/devhub/templates/devhub/addons/profile.html:44 src/olympia/devhub/templates/devhub/addons/edit/admin.html:104
 #: src/olympia/devhub/templates/devhub/addons/edit/basic.html:155 src/olympia/devhub/templates/devhub/addons/edit/details.html:88 src/olympia/devhub/templates/devhub/addons/edit/support.html:70
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:169 src/olympia/devhub/templates/devhub/addons/forms_shared/media.html:152
-#: src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:44 src/olympia/devhub/templates/devhub/personas/edit.html:222 src/olympia/devhub/templates/devhub/versions/add_file_modal.html:79
-#: src/olympia/devhub/templates/devhub/versions/edit.html:140 src/olympia/devhub/templates/devhub/versions/list.html:208 src/olympia/devhub/templates/devhub/versions/list.html:242
-#: src/olympia/devhub/templates/devhub/versions/list.html:276 src/olympia/devhub/templates/devhub/versions/list.html:317 src/olympia/reviews/templates/reviews/edit_review.html:16
+#: src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:43 src/olympia/devhub/templates/devhub/personas/edit.html:222 src/olympia/devhub/templates/devhub/versions/add_file_modal.html:59
+#: src/olympia/devhub/templates/devhub/versions/edit.html:140 src/olympia/devhub/templates/devhub/versions/list.html:208 src/olympia/devhub/templates/devhub/versions/list.html:239
+#: src/olympia/devhub/templates/devhub/versions/list.html:281 src/olympia/devhub/templates/devhub/versions/list.html:315 src/olympia/reviews/templates/reviews/edit_review.html:16
 #: src/olympia/translations/templates/translations/trans-menu.html:50 src/olympia/translations/templates/translations/trans-menu.html:62 src/olympia/zadmin/templates/zadmin/validation.html:105
 msgid "Cancel"
 msgstr ""
@@ -868,7 +869,7 @@ msgstr ""
 msgid "Review Guidelines"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/review_list_box.html:5 src/olympia/addons/templates/addons/impala/details-more.html:27 src/olympia/editors/helpers.py:921
+#: src/olympia/addons/templates/addons/review_list_box.html:5 src/olympia/addons/templates/addons/impala/details-more.html:27 src/olympia/editors/helpers.py:1001
 #: src/olympia/reviews/templates/reviews/add.html:14 src/olympia/reviews/templates/reviews/reply.html:14 src/olympia/reviews/templates/reviews/review_list.html:19
 #: src/olympia/reviews/templates/reviews/mobile/review_list.html:26
 msgid "Reviews"
@@ -959,119 +960,119 @@ msgid_plural "Other add-ons by these authors"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/olympia/addons/templates/addons/impala/details.html:41
+#: src/olympia/addons/templates/addons/impala/details.html:39
 #, python-format
 msgid "<span itemprop=\"ratingCount\">%(num)s</span> user review"
 msgid_plural "<span itemprop=\"ratingCount\">%(num)s</span> user reviews"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/olympia/addons/templates/addons/impala/details.html:69
+#: src/olympia/addons/templates/addons/impala/details.html:66
 msgid "View statistics"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/impala/details.html:84
+#: src/olympia/addons/templates/addons/impala/details.html:81
 msgid "Manage"
 msgstr ""
 
 #. {0} is an add-on name.
-#: src/olympia/addons/templates/addons/impala/details.html:96
+#: src/olympia/addons/templates/addons/impala/details.html:93
 msgid "Icon of {0}"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/impala/details.html:103 src/olympia/addons/templates/addons/impala/listing/items.html:14
+#: src/olympia/addons/templates/addons/impala/details.html:100 src/olympia/addons/templates/addons/impala/listing/items.html:14
 msgid "No Restart"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/impala/details.html:127
+#: src/olympia/addons/templates/addons/impala/details.html:124
 #, python-format
 msgid "Meet the Developer: <a href=\"%(url)s\">%(name)s</a>"
 msgid_plural "<a href=\"%(url)s\">Meet the Developers</a>"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/olympia/addons/templates/addons/impala/details.html:137
+#: src/olympia/addons/templates/addons/impala/details.html:134
 msgid "Learn why {0} was created and find out what's next for this add-on."
 msgstr ""
 
 #. {0} is an index.
-#: src/olympia/addons/templates/addons/impala/details.html:156
+#: src/olympia/addons/templates/addons/impala/details.html:161
 msgid "Add-on screenshot #{0}"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/impala/details.html:182
+#: src/olympia/addons/templates/addons/impala/details.html:187
 msgid "Add-on home page"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/impala/details.html:185
+#: src/olympia/addons/templates/addons/impala/details.html:190
 msgid "Support site"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/impala/details.html:189
+#: src/olympia/addons/templates/addons/impala/details.html:194
 msgid "Support E-mail"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/impala/details.html:194 src/olympia/devhub/models.py:378 src/olympia/devhub/templates/devhub/versions/list.html:12
+#: src/olympia/addons/templates/addons/impala/details.html:199 src/olympia/devhub/models.py:378 src/olympia/devhub/templates/devhub/versions/list.html:12
 #: src/olympia/versions/templates/versions/version.html:6 src/olympia/versions/templates/versions/mobile/version.html:6
 msgid "Version {0}"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/impala/details.html:194
+#: src/olympia/addons/templates/addons/impala/details.html:199
 msgid "Info"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/impala/details.html:195 src/olympia/devhub/templates/devhub/includes/addon_details.html:129
+#: src/olympia/addons/templates/addons/impala/details.html:200 src/olympia/devhub/templates/devhub/includes/addon_details.html:116
 msgid "Last Updated:"
-msgstr ""
-
-#: src/olympia/addons/templates/addons/impala/details.html:200
-#, python-format
-msgid "Released under <a target=\"_blank\" href=\"%(url)s\">%(name)s</a>"
-msgstr ""
-
-#: src/olympia/addons/templates/addons/impala/details.html:201 src/olympia/addons/templates/addons/impala/details.html:206 src/olympia/amo/helpers.py:398 src/olympia/devhub/forms.py:142
-#: src/olympia/devhub/forms.py:173 src/olympia/versions/templates/versions/version.html:40 src/olympia/versions/templates/versions/version.html:45
-msgid "Custom License"
 msgstr ""
 
 #: src/olympia/addons/templates/addons/impala/details.html:205
 #, python-format
+msgid "Released under <a target=\"_blank\" href=\"%(url)s\">%(name)s</a>"
+msgstr ""
+
+#: src/olympia/addons/templates/addons/impala/details.html:206 src/olympia/addons/templates/addons/impala/details.html:211 src/olympia/amo/helpers.py:398 src/olympia/devhub/forms.py:142
+#: src/olympia/devhub/forms.py:173 src/olympia/versions/templates/versions/version.html:40 src/olympia/versions/templates/versions/version.html:45
+msgid "Custom License"
+msgstr ""
+
+#: src/olympia/addons/templates/addons/impala/details.html:210
+#, python-format
 msgid "Released under <a href=\"%(url)s\">%(name)s</a>"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/impala/details.html:217
+#: src/olympia/addons/templates/addons/impala/details.html:222
 msgid "About this Add-on"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/impala/details.html:233
+#: src/olympia/addons/templates/addons/impala/details.html:238
 msgid "Developer’s Comments"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/impala/details.html:243
+#: src/olympia/addons/templates/addons/impala/details.html:248
 msgid "Version Information"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/impala/details.html:250
+#: src/olympia/addons/templates/addons/impala/details.html:255
 msgid "See complete version history"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/impala/details.html:262
+#: src/olympia/addons/templates/addons/impala/details.html:267
 msgid ""
 "The Development Channel lets you test an experimental new version of this add-on before it's released to the general public. Once you install the development version, you will continue to get "
 "updates from this channel. To stop receiving development updates, reinstall the default version from the link above."
 msgstr ""
 
-#: src/olympia/addons/templates/addons/impala/details.html:272
+#: src/olympia/addons/templates/addons/impala/details.html:277
 msgid "<strong>Caution:</strong> Development versions of this add-on have not been reviewed by Mozilla."
 msgstr ""
 
-#: src/olympia/addons/templates/addons/impala/details.html:287
+#: src/olympia/addons/templates/addons/impala/details.html:292
 msgid "See complete development channel history"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/impala/details.html:306 src/olympia/addons/templates/addons/impala/details.html:315 src/olympia/addons/templates/addons/impala/details.html:327
+#: src/olympia/addons/templates/addons/impala/details.html:311 src/olympia/addons/templates/addons/impala/details.html:320 src/olympia/addons/templates/addons/impala/details.html:332
 #: src/olympia/addons/templates/addons/impala/review_add_box.html:4 src/olympia/stats/templates/stats/popup.html:2 src/olympia/stats/templates/stats/popup.html:8
-#: src/olympia/stats/templates/stats/stats.html:202 src/olympia/users/templates/users/profile.html:119
+#: src/olympia/stats/templates/stats/stats.html:204 src/olympia/users/templates/users/profile.html:119
 msgid "close"
 msgstr ""
 
@@ -1127,15 +1128,11 @@ msgstr ""
 msgid "Source Code License"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/impala/persona_grid.html:16 src/olympia/addons/templates/addons/impala/toplist.html:6
-msgid "{0} users"
-msgstr ""
-
 #: src/olympia/addons/templates/addons/impala/review_list_box.html:19 src/olympia/reviews/templates/reviews/review.html:40
 msgid "permalink"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/impala/review_list_box.html:23 src/olympia/editors/templates/editors/queue.html:98 src/olympia/reviews/templates/reviews/review.html:44
+#: src/olympia/addons/templates/addons/impala/review_list_box.html:23 src/olympia/editors/templates/editors/queue.html:104 src/olympia/reviews/templates/reviews/review.html:44
 msgid "translate"
 msgstr ""
 
@@ -1154,6 +1151,10 @@ msgstr ""
 msgid "Be the first!"
 msgstr ""
 
+#: src/olympia/addons/templates/addons/impala/toplist.html:6
+msgid "{0} users"
+msgstr ""
+
 #: src/olympia/addons/templates/addons/impala/listing/sorter.html:14 src/olympia/devhub/templates/devhub/addons/listing/item_actions.html:49
 msgid "More"
 msgstr ""
@@ -1166,7 +1167,7 @@ msgstr ""
 msgid "My Add-ons"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/includes/dashboard_tabs.html:6 src/olympia/amo/context_processors.py:51
+#: src/olympia/addons/templates/addons/includes/dashboard_tabs.html:6 src/olympia/amo/context_processors.py:50
 msgid "My Themes"
 msgstr ""
 
@@ -1221,7 +1222,7 @@ msgstr ""
 msgid "Weekly Downloads"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/mobile/details.html:99 src/olympia/compat/templates/compat/reporter_detail.html:46 src/olympia/devhub/forms.py:787
+#: src/olympia/addons/templates/addons/mobile/details.html:99 src/olympia/compat/templates/compat/reporter_detail.html:46 src/olympia/devhub/forms.py:788
 #: src/olympia/devhub/templates/devhub/versions/list.html:163
 msgid "Version"
 msgstr ""
@@ -1305,7 +1306,7 @@ msgstr ""
 #: src/olympia/browse/templates/browse/personas/category_landing.html:21 src/olympia/browse/templates/browse/personas/category_landing.html:23
 #: src/olympia/browse/templates/browse/personas/category_landing.html:38 src/olympia/browse/templates/browse/personas/grid.html:7 src/olympia/browse/templates/browse/personas/grid.html:11
 #: src/olympia/browse/templates/browse/personas/mobile/base.html:7 src/olympia/browse/templates/browse/personas/mobile/category_landing.html:19 src/olympia/constants/base.py:180
-#: src/olympia/devhub/templates/devhub/personas/submit.html:13 src/olympia/editors/helpers.py:105 src/olympia/editors/templates/editors/base.html:26
+#: src/olympia/devhub/templates/devhub/personas/submit.html:13 src/olympia/editors/helpers.py:107 src/olympia/editors/templates/editors/base.html:26
 #: src/olympia/editors/templates/editors/performance.html:73 src/olympia/search/templates/search/personas.html:39 src/olympia/templates/menu_links.html:9
 msgid "Themes"
 msgstr ""
@@ -1326,7 +1327,7 @@ msgstr ""
 msgid "Highest Rated"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/mobile/home.html:74 src/olympia/amo/templates/amo/side_nav.html:5 src/olympia/amo/templates/amo/site_nav.html:27 src/olympia/amo/templates/amo/site_nav.html:57
+#: src/olympia/addons/templates/addons/mobile/home.html:74 src/olympia/amo/templates/amo/side_nav.html:5 src/olympia/amo/templates/amo/site_nav.html:27 src/olympia/amo/templates/amo/site_nav.html:55
 #: src/olympia/bandwagon/views.py:97 src/olympia/browse/views.py:57 src/olympia/browse/views.py:67 src/olympia/browse/templates/browse/personas/mobile/category_landing.html:65
 #: src/olympia/search/forms.py:15 src/olympia/search/forms.py:87
 msgid "Newest"
@@ -1340,90 +1341,90 @@ msgstr ""
 msgid "Theme Info &raquo;"
 msgstr ""
 
-#: src/olympia/amo/context_processors.py:39 src/olympia/devhub/templates/devhub/nav.html:43
+#: src/olympia/amo/context_processors.py:37 src/olympia/devhub/templates/devhub/nav.html:43
 msgid "Tools"
 msgstr ""
 
-#: src/olympia/amo/context_processors.py:48 src/olympia/discovery/templates/discovery/pane_account.html:8 src/olympia/users/templates/users/includes/navigation.html:2
+#: src/olympia/amo/context_processors.py:47 src/olympia/discovery/templates/discovery/pane_account.html:8 src/olympia/users/templates/users/includes/navigation.html:2
 msgid "My Profile"
 msgstr ""
 
-#: src/olympia/amo/context_processors.py:54 src/olympia/users/templates/users/edit.html:5 src/olympia/users/templates/users/includes/navigation.html:3
+#: src/olympia/amo/context_processors.py:53 src/olympia/users/templates/users/edit.html:5 src/olympia/users/templates/users/includes/navigation.html:3
 msgid "Account Settings"
 msgstr ""
 
-#: src/olympia/amo/context_processors.py:57 src/olympia/discovery/templates/discovery/pane_account.html:11 src/olympia/users/templates/users/profile.html:83
+#: src/olympia/amo/context_processors.py:56 src/olympia/discovery/templates/discovery/pane_account.html:11 src/olympia/users/templates/users/profile.html:83
 #: src/olympia/users/templates/users/includes/navigation.html:4
 msgid "My Collections"
 msgstr ""
 
-#: src/olympia/amo/context_processors.py:62 src/olympia/discovery/templates/discovery/pane_account.html:10 src/olympia/users/templates/users/includes/navigation.html:7
+#: src/olympia/amo/context_processors.py:61 src/olympia/discovery/templates/discovery/pane_account.html:10 src/olympia/users/templates/users/includes/navigation.html:7
 msgid "My Favorites"
 msgstr ""
 
-#: src/olympia/amo/context_processors.py:67 src/olympia/discovery/templates/discovery/pane_account.html:13 src/olympia/templates/impala/user_login.html:14
+#: src/olympia/amo/context_processors.py:66 src/olympia/discovery/templates/discovery/pane_account.html:13 src/olympia/templates/impala/user_login.html:14
 #: src/olympia/templates/mobile/header_auth.html:5
 msgid "Log out"
 msgstr ""
 
-#: src/olympia/amo/context_processors.py:72 src/olympia/devhub/templates/devhub/addons/dashboard.html:4
+#: src/olympia/amo/context_processors.py:71 src/olympia/devhub/templates/devhub/addons/dashboard.html:4
 msgid "Manage My Submissions"
 msgstr ""
 
-#: src/olympia/amo/context_processors.py:75 src/olympia/devhub/templates/devhub/nav.html:27 src/olympia/devhub/templates/devhub/addons/dashboard.html:25
+#: src/olympia/amo/context_processors.py:74 src/olympia/devhub/templates/devhub/nav.html:27 src/olympia/devhub/templates/devhub/addons/dashboard.html:25
 #: src/olympia/devhub/templates/devhub/addons/submit/base.html:4
 msgid "Submit a New Add-on"
 msgstr ""
 
-#: src/olympia/amo/context_processors.py:77 src/olympia/browse/templates/browse/personas/base.html:50 src/olympia/devhub/templates/devhub/index.html:24
+#: src/olympia/amo/context_processors.py:76 src/olympia/browse/templates/browse/personas/base.html:50 src/olympia/devhub/templates/devhub/index.html:24
 #: src/olympia/devhub/templates/devhub/addons/dashboard.html:29
 msgid "Submit a New Theme"
 msgstr ""
 
-#: src/olympia/amo/context_processors.py:79 src/olympia/amo/templates/amo/site_nav.html:87 src/olympia/devhub/helpers.py:36 src/olympia/devhub/helpers.py:68 src/olympia/devhub/helpers.py:102
+#: src/olympia/amo/context_processors.py:78 src/olympia/amo/templates/amo/site_nav.html:85 src/olympia/devhub/helpers.py:36 src/olympia/devhub/helpers.py:68 src/olympia/devhub/helpers.py:102
 #: src/olympia/templates/footer.html:6 src/olympia/templates/menu_links.html:14
 msgid "Developer Hub"
 msgstr ""
 
-#: src/olympia/amo/context_processors.py:83 src/olympia/devhub/views.py:1792
+#: src/olympia/amo/context_processors.py:81 src/olympia/devhub/views.py:1796
 msgid "Manage API Keys"
 msgstr ""
 
-#: src/olympia/amo/context_processors.py:88 src/olympia/editors/helpers.py:82 src/olympia/editors/helpers.py:102 src/olympia/editors/templates/editors/base.html:10
+#: src/olympia/amo/context_processors.py:86 src/olympia/editors/helpers.py:84 src/olympia/editors/helpers.py:104 src/olympia/editors/templates/editors/base.html:10
 msgid "Editor Tools"
 msgstr ""
 
-#: src/olympia/amo/context_processors.py:92
+#: src/olympia/amo/context_processors.py:90
 msgid "Admin Tools"
 msgstr ""
 
-#: src/olympia/amo/fields.py:15
+#: src/olympia/amo/fields.py:20
 msgid "Incorrect, please try again."
 msgstr ""
 
-#: src/olympia/amo/fields.py:16
+#: src/olympia/amo/fields.py:21
 msgid "Error verifying input, please try again."
 msgstr ""
 
-#: src/olympia/amo/fields.py:32
+#: src/olympia/amo/fields.py:37
 msgid "This must be a valid hex color code, such as #000000."
 msgstr ""
 
-#: src/olympia/amo/fields.py:58
+#: src/olympia/amo/fields.py:63
 msgid "Enter at least one value."
 msgstr ""
 
-#: src/olympia/amo/helpers.py:162 src/olympia/amo/templates/amo/site_nav.html:61 src/olympia/bandwagon/templates/bandwagon/add.html:9
+#: src/olympia/amo/helpers.py:162 src/olympia/amo/templates/amo/site_nav.html:59 src/olympia/bandwagon/templates/bandwagon/add.html:9
 #: src/olympia/bandwagon/templates/bandwagon/collection_detail.html:15 src/olympia/bandwagon/templates/bandwagon/delete.html:9 src/olympia/bandwagon/templates/bandwagon/edit.html:15
 #: src/olympia/bandwagon/templates/bandwagon/user_listing.html:18 src/olympia/bandwagon/templates/bandwagon/user_listing.html:21
 #: src/olympia/bandwagon/templates/bandwagon/impala/collection_listing.html:12 src/olympia/bandwagon/templates/bandwagon/impala/collection_listing.html:20
 #: src/olympia/bandwagon/templates/bandwagon/impala/collection_listing.html:24 src/olympia/bandwagon/templates/bandwagon/impala/collection_sidebar.html:3
 #: src/olympia/bandwagon/templates/bandwagon/includes/collection_sidebar.html:2 src/olympia/bandwagon/templates/bandwagon/mobile/collection_listing.html:3
-#: src/olympia/stats/templates/stats/stats.html:77 src/olympia/templates/menu_links.html:12
+#: src/olympia/stats/templates/stats/stats.html:33 src/olympia/templates/menu_links.html:12
 msgid "Collections"
 msgstr ""
 
-#: src/olympia/amo/helpers.py:171 src/olympia/amo/templates/amo/site_nav.html:85 src/olympia/browse/templates/browse/language_tools.html:3
+#: src/olympia/amo/helpers.py:171 src/olympia/amo/templates/amo/site_nav.html:83 src/olympia/browse/templates/browse/language_tools.html:3
 msgid "Dictionaries & Language Packs"
 msgstr ""
 
@@ -1575,8 +1576,8 @@ msgstr ""
 msgid "Comment on {addon} {version}."
 msgstr ""
 
-#: src/olympia/amo/log.py:236 src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:19 src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:47
-#: src/olympia/editors/helpers.py:511 src/olympia/editors/templates/editors/themes/history_table.html:11
+#: src/olympia/amo/log.py:236 src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:17 src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:45
+#: src/olympia/editors/helpers.py:584 src/olympia/editors/templates/editors/themes/history_table.html:11
 msgid "Comment"
 msgstr ""
 
@@ -1899,7 +1900,7 @@ msgstr ""
 #: src/olympia/amo/templates/amo/mobile/paginator.html:14 src/olympia/amo/templates/amo/mobile/paginator.html:16 src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:51
 #: src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:65 src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:78
 #: src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:91 src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:104
-#: src/olympia/discovery/templates/discovery/pane.html:45 src/olympia/discovery/templates/discovery/addons/detail.html:39 src/olympia/stats/templates/stats/stats.html:167
+#: src/olympia/discovery/templates/discovery/pane.html:45 src/olympia/discovery/templates/discovery/addons/detail.html:39 src/olympia/stats/templates/stats/stats.html:169
 msgid "Next"
 msgstr ""
 
@@ -1931,7 +1932,7 @@ msgid ""
 msgstr ""
 
 #: src/olympia/amo/templates/amo/side_nav.html:4 src/olympia/amo/templates/amo/side_nav.html:12 src/olympia/amo/templates/amo/site_nav.html:4 src/olympia/amo/templates/amo/site_nav.html:26
-#: src/olympia/browse/views.py:56 src/olympia/browse/views.py:66 src/olympia/browse/views.py:237 src/olympia/browse/views.py:282 src/olympia/search/forms.py:86
+#: src/olympia/browse/views.py:56 src/olympia/browse/views.py:66 src/olympia/browse/views.py:204 src/olympia/browse/views.py:249 src/olympia/search/forms.py:86
 msgid "Top Rated"
 msgstr ""
 
@@ -1945,38 +1946,38 @@ msgstr ""
 msgid "Extensions"
 msgstr ""
 
-#: src/olympia/amo/templates/amo/site_nav.html:45
+#: src/olympia/amo/templates/amo/site_nav.html:44
 msgid "Want more customization? Try <b>Complete Themes</b>"
 msgstr ""
 
-#: src/olympia/amo/templates/amo/site_nav.html:56 src/olympia/bandwagon/views.py:96
+#: src/olympia/amo/templates/amo/site_nav.html:54 src/olympia/bandwagon/views.py:96
 msgid "Most Followers"
 msgstr ""
 
-#: src/olympia/amo/templates/amo/site_nav.html:68 src/olympia/bandwagon/templates/bandwagon/impala/collection_sidebar.html:16
+#: src/olympia/amo/templates/amo/site_nav.html:66 src/olympia/bandwagon/templates/bandwagon/impala/collection_sidebar.html:16
 #: src/olympia/bandwagon/templates/bandwagon/includes/collection_sidebar.html:18
 msgid "Collections I've Made"
 msgstr ""
 
-#: src/olympia/amo/templates/amo/site_nav.html:70 src/olympia/bandwagon/templates/bandwagon/user_listing.html:4 src/olympia/bandwagon/templates/bandwagon/impala/collection_sidebar.html:13
+#: src/olympia/amo/templates/amo/site_nav.html:68 src/olympia/bandwagon/templates/bandwagon/user_listing.html:4 src/olympia/bandwagon/templates/bandwagon/impala/collection_sidebar.html:13
 #: src/olympia/bandwagon/templates/bandwagon/includes/collection_sidebar.html:15
 msgid "Collections I'm Following"
 msgstr ""
 
-#: src/olympia/amo/templates/amo/site_nav.html:73 src/olympia/bandwagon/templates/bandwagon/impala/collection_sidebar.html:18
-#: src/olympia/bandwagon/templates/bandwagon/includes/collection_sidebar.html:20 src/olympia/users/models.py:512
+#: src/olympia/amo/templates/amo/site_nav.html:71 src/olympia/bandwagon/templates/bandwagon/impala/collection_sidebar.html:18
+#: src/olympia/bandwagon/templates/bandwagon/includes/collection_sidebar.html:20 src/olympia/users/models.py:521
 msgid "My Favorite Add-ons"
 msgstr ""
 
-#: src/olympia/amo/templates/amo/site_nav.html:78
+#: src/olympia/amo/templates/amo/site_nav.html:76
 msgid "More&hellip;"
 msgstr ""
 
-#: src/olympia/amo/templates/amo/site_nav.html:82
+#: src/olympia/amo/templates/amo/site_nav.html:80
 msgid "Add-ons for Mobile"
 msgstr ""
 
-#: src/olympia/amo/templates/amo/site_nav.html:86 src/olympia/browse/feeds.py:207 src/olympia/browse/templates/browse/search_tools.html:3 src/olympia/constants/base.py:176
+#: src/olympia/amo/templates/amo/site_nav.html:84 src/olympia/browse/feeds.py:207 src/olympia/browse/templates/browse/search_tools.html:3 src/olympia/constants/base.py:176
 #: src/olympia/templates/menu_links.html:10
 msgid "Search Tools"
 msgstr ""
@@ -1992,7 +1993,7 @@ msgid "Jump to first page"
 msgstr ""
 
 #: src/olympia/amo/templates/amo/impala/paginator.html:22 src/olympia/amo/templates/amo/mobile/impala_paginator.html:12 src/olympia/discovery/templates/discovery/pane.html:44
-#: src/olympia/discovery/templates/discovery/addons/detail.html:38 src/olympia/stats/templates/stats/stats.html:164
+#: src/olympia/discovery/templates/discovery/addons/detail.html:38 src/olympia/stats/templates/stats/stats.html:166
 msgid "Previous"
 msgstr ""
 
@@ -2015,30 +2016,49 @@ msgid_plural "Page {n}"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/olympia/amo/templates/services/install.html:38
-#, python-format
-msgid "If you are not prompted to install %(addon_name)s in a moment, please <a href=\"%(addon_xpi)s\">click here</a>."
-msgstr ""
-
-#: src/olympia/amo/tests/test_messages.py:57 src/olympia/amo/tests/test_messages.py:58 src/olympia/reviews/forms.py:25 src/olympia/reviews/forms.py:50 src/olympia/reviews/templates/reviews/add.html:56
+#: src/olympia/amo/tests/test_messages.py:56 src/olympia/amo/tests/test_messages.py:57 src/olympia/reviews/forms.py:25 src/olympia/reviews/forms.py:50 src/olympia/reviews/templates/reviews/add.html:56
 #: src/olympia/reviews/templates/reviews/reply.html:30
 msgid "Title"
 msgstr ""
 
-#: src/olympia/amo/tests/test_messages.py:57 src/olympia/amo/tests/test_messages.py:58
+#: src/olympia/amo/tests/test_messages.py:56 src/olympia/amo/tests/test_messages.py:57
 msgid "Body"
 msgstr ""
 
-#: src/olympia/amo/tests/test_messages.py:59
+#: src/olympia/amo/tests/test_messages.py:58
 msgid "Another Title"
 msgstr ""
 
-#: src/olympia/amo/tests/test_messages.py:59
+#: src/olympia/amo/tests/test_messages.py:58
 msgid "Another Body"
 msgstr ""
 
-#: src/olympia/api/views.py:255
-msgid "Not implemented yet."
+#: src/olympia/api/authentication.py:76
+msgid "Signature has expired."
+msgstr ""
+
+#: src/olympia/api/authentication.py:79
+msgid "Error decoding signature."
+msgstr ""
+
+#: src/olympia/api/authentication.py:82
+msgid "Invalid JWT Token."
+msgstr ""
+
+#: src/olympia/api/authentication.py:130
+msgid "Invalid Authorization header. No credentials provided."
+msgstr ""
+
+#: src/olympia/api/authentication.py:133
+msgid "Invalid Authorization header. Credentials string should not contain spaces."
+msgstr ""
+
+#: src/olympia/api/fields.py:29
+msgid "The field must have a length of at least {num} characters."
+msgstr ""
+
+#: src/olympia/api/fields.py:31
+msgid "The language code {lang_code} is invalid."
 msgstr ""
 
 #: src/olympia/applications/views.py:39 src/olympia/applications/templates/applications/appversions.html:3
@@ -2057,7 +2077,7 @@ msgstr ""
 msgid "Add-ons submitted to Mozilla Add-ons must have a manifest file with at least one of the below applications supported. Only the versions listed below are allowed for these applications."
 msgstr ""
 
-#: src/olympia/applications/templates/applications/appversions.html:25
+#: src/olympia/applications/templates/applications/appversions.html:25 src/olympia/editors/helpers.py:361
 msgid "GUID"
 msgstr ""
 
@@ -2171,8 +2191,8 @@ msgstr ""
 msgid "Remove from favorites"
 msgstr ""
 
-#: src/olympia/bandwagon/views.py:98 src/olympia/bandwagon/views.py:191 src/olympia/browse/views.py:58 src/olympia/browse/views.py:69 src/olympia/browse/views.py:458 src/olympia/devhub/views.py:74
-#: src/olympia/devhub/views.py:82 src/olympia/devhub/templates/devhub/addons/edit/basic.html:20 src/olympia/editors/templates/editors/leaderboard.html:24
+#: src/olympia/bandwagon/views.py:98 src/olympia/bandwagon/views.py:191 src/olympia/browse/views.py:58 src/olympia/browse/views.py:69 src/olympia/browse/views.py:425 src/olympia/devhub/views.py:72
+#: src/olympia/devhub/views.py:80 src/olympia/devhub/templates/devhub/addons/edit/basic.html:20 src/olympia/editors/templates/editors/leaderboard.html:24
 #: src/olympia/editors/templates/editors/themes/queue_list.html:48 src/olympia/search/forms.py:17 src/olympia/search/forms.py:89 src/olympia/users/templates/users/vcard.html:5
 msgid "Name"
 msgstr ""
@@ -2181,7 +2201,7 @@ msgstr ""
 msgid "Recently Popular"
 msgstr ""
 
-#: src/olympia/bandwagon/views.py:189 src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:18
+#: src/olympia/bandwagon/views.py:189 src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:16
 msgid "Added"
 msgstr ""
 
@@ -2195,7 +2215,7 @@ msgstr ""
 
 #: src/olympia/bandwagon/views.py:316
 #, python-format
-msgid "Your new collection is shown below. You can <ahref=\"%(url)s\">edit additional settings</a> if you'dlike."
+msgid "Your new collection is shown below. You can <a href=\"%(url)s\">edit additional settings</a> if you'd like."
 msgstr ""
 
 #: src/olympia/bandwagon/views.py:322
@@ -2323,8 +2343,8 @@ msgid_plural "%(num)s Add-ons in this Collection"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/olympia/bandwagon/templates/bandwagon/collection_detail.html:125 src/olympia/compat/templates/compat/index.html:25 src/olympia/compat/templates/compat/reporter_detail.html:29
-#: src/olympia/files/templates/files/viewer.html:29 src/olympia/templates/amo_footer.html:17 src/olympia/templates/includes/lang_switcher.html:10
+#: src/olympia/bandwagon/templates/bandwagon/collection_detail.html:125 src/olympia/compat/templates/compat/reporter_detail.html:29 src/olympia/files/templates/files/viewer.html:29
+#: src/olympia/templates/amo_footer.html:17 src/olympia/templates/includes/lang_switcher.html:10
 msgid "Go"
 msgstr ""
 
@@ -2491,7 +2511,7 @@ msgid "Remove this user as a contributor"
 msgstr ""
 
 #: src/olympia/bandwagon/templates/bandwagon/edit_contributors.html:18 src/olympia/bandwagon/templates/bandwagon/edit_contributors.html:43
-#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:20 src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:48
+#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:18 src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:46
 #: src/olympia/devhub/templates/devhub/addons/ajax_compat_update.html:19
 msgid "Remove"
 msgstr ""
@@ -2539,7 +2559,7 @@ msgid "<b>Warning:</b> By changing the owner of this collection, you will no lon
 msgstr ""
 
 #: src/olympia/bandwagon/templates/bandwagon/edit_contributors.html:83 src/olympia/devhub/templates/devhub/addons/forms_shared/media.html:157
-#: src/olympia/devhub/templates/devhub/addons/submit/describe.html:69 src/olympia/devhub/templates/devhub/addons/submit/license.html:60 src/olympia/devhub/templates/devhub/addons/submit/upload.html:78
+#: src/olympia/devhub/templates/devhub/addons/submit/describe.html:69 src/olympia/devhub/templates/devhub/addons/submit/license.html:60 src/olympia/devhub/templates/devhub/addons/submit/upload.html:70
 #: src/olympia/devhub/templates/devhub/payments/tier.html:17 src/olympia/editors/templates/editors/themes/themes.html:111 src/olympia/editors/templates/editors/themes/themes.html:128
 #: src/olympia/editors/templates/editors/themes/themes.html:134 src/olympia/editors/templates/editors/themes/themes.html:141 src/olympia/users/templates/users/fxa_migration_prompt_content.html:10
 #: src/olympia/users/templates/users/login_form.html:42 src/olympia/users/templates/users/mobile/login.html:57
@@ -2622,31 +2642,31 @@ msgid "Add-ons in Your Collection"
 msgstr ""
 
 #: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:4
-msgid ""
-"To include an add-on in this collection, enter its name in the box below and hit enter.  You can also use the <strong>Add to Collection</strong> links throughout the site to include add-ons later."
+msgid "To include an add-on in this collection, enter its name in the box below and hit enter."
 msgstr ""
 
-#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:17 src/olympia/constants/base.py:400 src/olympia/devhub/templates/devhub/addons/activity.html:62
+#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:15 src/olympia/constants/base.py:400 src/olympia/devhub/templates/devhub/addons/activity.html:62
+#: src/olympia/editors/helpers.py:273 src/olympia/editors/helpers.py:360
 msgid "Add-on"
 msgstr ""
 
-#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:26
+#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:24
 msgid "Enter the name of the add-on to include"
 msgstr ""
 
-#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:28
+#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:26
 msgid "Add to Collection"
 msgstr ""
 
-#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:45 src/olympia/editors/helpers.py:936 src/olympia/editors/helpers.py:956
+#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:43 src/olympia/editors/helpers.py:1016 src/olympia/editors/helpers.py:1036
 msgid "Pending"
 msgstr ""
 
-#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:47
+#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:45
 msgid "Add a comment"
 msgstr ""
 
-#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:48
+#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:46
 msgid "Remove this add-on from the collection"
 msgstr ""
 
@@ -2753,12 +2773,12 @@ msgstr ""
 msgid "Most Users"
 msgstr ""
 
-#: src/olympia/browse/views.py:61 src/olympia/browse/views.py:72 src/olympia/browse/views.py:279 src/olympia/browse/templates/browse/personas/mobile/category_landing.html:63
+#: src/olympia/browse/views.py:61 src/olympia/browse/views.py:72 src/olympia/browse/views.py:246 src/olympia/browse/templates/browse/personas/mobile/category_landing.html:63
 #: src/olympia/discovery/templates/discovery/pane.html:67 src/olympia/search/forms.py:92
 msgid "Up & Coming"
 msgstr ""
 
-#: src/olympia/browse/views.py:460 src/olympia/devhub/views.py:76 src/olympia/devhub/views.py:83 src/olympia/discovery/templates/discovery/addons/detail.html:66
+#: src/olympia/browse/views.py:427 src/olympia/devhub/views.py:74 src/olympia/devhub/views.py:81 src/olympia/discovery/templates/discovery/addons/detail.html:66
 msgid "Created"
 msgstr ""
 
@@ -2946,8 +2966,8 @@ msgid_plural "See all %(cnt)s extensions in %(name)s &raquo;"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/olympia/browse/templates/browse/mobile/extensions.html:13 src/olympia/compat/templates/compat/index.html:82 src/olympia/devhub/templates/devhub/devhub_search.html:24
-#: src/olympia/devhub/templates/devhub/addons/activity.html:47 src/olympia/search/templates/search/no_results.html:4 src/olympia/search/templates/search/mobile/results.html:36
+#: src/olympia/browse/templates/browse/mobile/extensions.html:13 src/olympia/devhub/templates/devhub/devhub_search.html:24 src/olympia/devhub/templates/devhub/addons/activity.html:47
+#: src/olympia/search/templates/search/no_results.html:4 src/olympia/search/templates/search/mobile/results.html:36
 msgid "No results found."
 msgstr ""
 
@@ -3032,7 +3052,7 @@ msgstr ""
 msgid "All"
 msgstr ""
 
-#: src/olympia/compat/forms.py:22 src/olympia/search/views.py:525
+#: src/olympia/compat/forms.py:22 src/olympia/editors/templates/editors/base.html:69 src/olympia/search/views.py:518
 msgid "All Add-ons"
 msgstr ""
 
@@ -3042,53 +3062,6 @@ msgstr ""
 
 #: src/olympia/compat/forms.py:24
 msgid "Non-binary"
-msgstr ""
-
-#. Review points sources other than add-ons and themes.
-#: src/olympia/compat/views.py:87 src/olympia/constants/base.py:388 src/olympia/devhub/forms.py:162 src/olympia/editors/templates/editors/performance.html:75
-msgid "Other"
-msgstr ""
-
-#: src/olympia/compat/templates/compat/index.html:4
-msgid "Add-on Compatibility Report for {app} {version}"
-msgstr ""
-
-#: src/olympia/compat/templates/compat/index.html:11
-msgid "{app} {version} Compatibility"
-msgstr ""
-
-#: src/olympia/compat/templates/compat/index.html:17
-#, python-format
-msgid "Top 95%% compatible with previous version"
-msgstr ""
-
-#: src/olympia/compat/templates/compat/index.html:18
-#, python-format
-msgid "Top 95%% of all add-ons"
-msgstr ""
-
-#: src/olympia/compat/templates/compat/index.html:19
-msgid "All active add-ons"
-msgstr ""
-
-#: src/olympia/compat/templates/compat/index.html:23 src/olympia/constants/base.py:401
-msgid "App"
-msgstr ""
-
-#: src/olympia/compat/templates/compat/index.html:55
-msgid "Details for add-ons compatible with previous version:"
-msgstr ""
-
-#: src/olympia/compat/templates/compat/index.html:57
-msgid "Show all versions"
-msgstr ""
-
-#: src/olympia/compat/templates/compat/index.html:59
-msgid "Details for add-ons compatible with all versions:"
-msgstr ""
-
-#: src/olympia/compat/templates/compat/index.html:61
-msgid "Show previous version only"
 msgstr ""
 
 #: src/olympia/compat/templates/compat/reporter.html:3
@@ -3142,8 +3115,8 @@ msgstr ""
 msgid "Report Type"
 msgstr ""
 
-#: src/olympia/compat/templates/compat/reporter_detail.html:47 src/olympia/devhub/forms.py:784 src/olympia/devhub/templates/devhub/addons/ajax_compat_update.html:17 src/olympia/editors/forms.py:108
-#: src/olympia/zadmin/forms.py:45
+#: src/olympia/compat/templates/compat/reporter_detail.html:47 src/olympia/devhub/forms.py:785 src/olympia/devhub/templates/devhub/addons/ajax_compat_update.html:17 src/olympia/editors/forms.py:108
+#: src/olympia/editors/forms.py:248 src/olympia/zadmin/forms.py:45
 msgid "Application"
 msgstr ""
 
@@ -3231,7 +3204,8 @@ msgstr ""
 msgid "Preliminarily Reviewed and Awaiting Full Review"
 msgstr ""
 
-#: src/olympia/constants/base.py:33 src/olympia/editors/helpers.py:924 src/olympia/editors/templates/editors/themes/history_table.html:34
+#: src/olympia/constants/base.py:33 src/olympia/editors/forms.py:258 src/olympia/editors/helpers.py:73 src/olympia/editors/helpers.py:1004
+#: src/olympia/editors/templates/editors/themes/history_table.html:34
 msgid "Deleted"
 msgstr ""
 
@@ -3328,6 +3302,11 @@ msgstr ""
 msgid "Ask before users can download this add-on"
 msgstr ""
 
+#. Review points sources other than add-ons and themes.
+#: src/olympia/constants/base.py:388 src/olympia/devhub/forms.py:162 src/olympia/editors/templates/editors/performance.html:75
+msgid "Other"
+msgstr ""
+
 #: src/olympia/constants/base.py:389
 msgid "Exception"
 msgstr ""
@@ -3338,6 +3317,10 @@ msgstr ""
 
 #: src/olympia/constants/base.py:391
 msgid "Change"
+msgstr ""
+
+#: src/olympia/constants/base.py:401
+msgid "App"
 msgstr ""
 
 #: src/olympia/constants/base.py:402
@@ -3488,7 +3471,7 @@ msgstr ""
 msgid "Duplicate"
 msgstr ""
 
-#: src/olympia/constants/editors.py:17 src/olympia/editors/helpers.py:502 src/olympia/editors/templates/editors/themes/queue.html:71 src/olympia/editors/templates/editors/themes/themes.html:94
+#: src/olympia/constants/editors.py:17 src/olympia/editors/helpers.py:575 src/olympia/editors/templates/editors/themes/queue.html:71 src/olympia/editors/templates/editors/themes/themes.html:94
 msgid "Reject"
 msgstr ""
 
@@ -3588,7 +3571,7 @@ msgstr ""
 msgid "Android"
 msgstr ""
 
-#: src/olympia/core/apps.py:19
+#: src/olympia/core/apps.py:21
 msgid "Core"
 msgstr ""
 
@@ -3722,7 +3705,7 @@ msgid "Submit my add-on for manual review."
 msgstr ""
 
 #: src/olympia/devhub/forms.py:537
-msgid "Do not list my add-on on this site (beta)"
+msgid "Do not list my add-on on this site"
 msgstr ""
 
 #: src/olympia/devhub/forms.py:538
@@ -3755,46 +3738,46 @@ msgstr ""
 
 #: src/olympia/devhub/forms.py:592
 #, python-format
-msgid "Version %s already exists"
+msgid "Version %s already exists, or was uploaded before."
 msgstr ""
 
-#: src/olympia/devhub/forms.py:604
+#: src/olympia/devhub/forms.py:605
 msgid "Select a valid choice. That choice is not one of the available choices."
 msgstr ""
 
-#: src/olympia/devhub/forms.py:610
+#: src/olympia/devhub/forms.py:611
 msgid "A file with a version ending with a|alpha|b|beta and an optional number is detected as beta."
 msgstr ""
 
-#: src/olympia/devhub/forms.py:633
+#: src/olympia/devhub/forms.py:634
 msgid "You cannot upload any more files for this version."
 msgstr ""
 
-#: src/olympia/devhub/forms.py:639
+#: src/olympia/devhub/forms.py:640
 msgid "Version doesn't match"
 msgstr ""
 
-#: src/olympia/devhub/forms.py:668
+#: src/olympia/devhub/forms.py:669
 msgid "You cannot delete a file once the review process has started.  You must delete the whole version."
 msgstr ""
 
-#: src/olympia/devhub/forms.py:688
+#: src/olympia/devhub/forms.py:689
 msgid "The platform All cannot be combined with specific platforms."
 msgstr ""
 
-#: src/olympia/devhub/forms.py:693
+#: src/olympia/devhub/forms.py:694
 msgid "A platform can only be chosen once."
 msgstr ""
 
-#: src/olympia/devhub/forms.py:706
+#: src/olympia/devhub/forms.py:707
 msgid "A review type must be selected."
 msgstr ""
 
-#: src/olympia/devhub/forms.py:788 src/olympia/editors/forms.py:114 src/olympia/zadmin/forms.py:49 src/olympia/zadmin/forms.py:52
+#: src/olympia/devhub/forms.py:789 src/olympia/editors/forms.py:114 src/olympia/editors/forms.py:254 src/olympia/zadmin/forms.py:49 src/olympia/zadmin/forms.py:52
 msgid "Select an application first"
 msgstr ""
 
-#: src/olympia/devhub/forms.py:840
+#: src/olympia/devhub/forms.py:841
 msgid "There cannot be more than 3 required add-ons."
 msgstr ""
 
@@ -3828,76 +3811,76 @@ msgstr[1] ""
 msgid "Review"
 msgstr ""
 
-#: src/olympia/devhub/tasks.py:551
+#: src/olympia/devhub/tasks.py:583
 #, python-format
 msgid "%s responded with %s (%s)."
 msgstr ""
 
-#: src/olympia/devhub/tasks.py:555
+#: src/olympia/devhub/tasks.py:587
 #, python-format
 msgid "Connection to \"%s\" timed out."
 msgstr ""
 
-#: src/olympia/devhub/tasks.py:557
+#: src/olympia/devhub/tasks.py:589
 #, python-format
 msgid "Could not contact host at \"%s\"."
 msgstr ""
 
-#: src/olympia/devhub/utils.py:104
+#: src/olympia/devhub/utils.py:105
 #, python-format
 msgid "Validation generated too many errors/warnings so %s messages were truncated. After addressing the visible messages, you'll be able to see the others."
 msgstr ""
 
-#: src/olympia/devhub/views.py:183
+#: src/olympia/devhub/views.py:181
 msgid "All My Add-ons"
 msgstr ""
 
-#: src/olympia/devhub/views.py:210
+#: src/olympia/devhub/views.py:208
 msgid "All Activity"
 msgstr ""
 
-#: src/olympia/devhub/views.py:211
+#: src/olympia/devhub/views.py:209
 msgid "Add-on Updates"
 msgstr ""
 
-#: src/olympia/devhub/views.py:212
+#: src/olympia/devhub/views.py:210
 msgid "Add-on Status"
 msgstr ""
 
-#: src/olympia/devhub/views.py:213
+#: src/olympia/devhub/views.py:211
 msgid "User Collections"
 msgstr ""
 
-#: src/olympia/devhub/views.py:214 src/olympia/devhub/templates/devhub/docs/policies-maintenance.html:68 src/olympia/pages/templates/pages/dev_faq.html:38
+#: src/olympia/devhub/views.py:212 src/olympia/devhub/templates/devhub/docs/policies-maintenance.html:68 src/olympia/pages/templates/pages/dev_faq.html:38
 #: src/olympia/pages/templates/pages/dev_faq.html:484
 msgid "User Reviews"
 msgstr ""
 
-#: src/olympia/devhub/views.py:327 src/olympia/devhub/views.py:331 src/olympia/devhub/views.py:484 src/olympia/devhub/views.py:513 src/olympia/devhub/views.py:564 src/olympia/devhub/views.py:1150
+#: src/olympia/devhub/views.py:325 src/olympia/devhub/views.py:329 src/olympia/devhub/views.py:484 src/olympia/devhub/views.py:513 src/olympia/devhub/views.py:564 src/olympia/devhub/views.py:1156
 msgid "Changes successfully saved."
 msgstr ""
 
-#: src/olympia/devhub/views.py:334 src/olympia/devhub/views.py:1631
+#: src/olympia/devhub/views.py:332 src/olympia/devhub/views.py:1637
 msgid "Please check the form for errors."
 msgstr ""
 
-#: src/olympia/devhub/views.py:346
+#: src/olympia/devhub/views.py:344
 msgid "Add-on cannot be deleted. Disable this add-on instead."
 msgstr ""
 
-#: src/olympia/devhub/views.py:356
+#: src/olympia/devhub/views.py:354
 msgid "Theme deleted."
 msgstr ""
 
-#: src/olympia/devhub/views.py:356
+#: src/olympia/devhub/views.py:354
 msgid "Add-on deleted."
 msgstr ""
 
-#: src/olympia/devhub/views.py:362
+#: src/olympia/devhub/views.py:360
 msgid "URL name was incorrect. Theme was not deleted."
 msgstr ""
 
-#: src/olympia/devhub/views.py:367
+#: src/olympia/devhub/views.py:365
 msgid "URL name was incorrect. Add-on was not deleted."
 msgstr ""
 
@@ -3925,7 +3908,7 @@ msgstr ""
 msgid "Check Add-on Compatibility"
 msgstr ""
 
-#: src/olympia/devhub/views.py:808 src/olympia/signing/views.py:90
+#: src/olympia/devhub/views.py:808 src/olympia/signing/views.py:95
 msgid "You cannot submit this type of add-on"
 msgstr ""
 
@@ -3955,33 +3938,33 @@ msgstr ""
 msgid "There was an error uploading your preview."
 msgstr ""
 
-#: src/olympia/devhub/views.py:1189
+#: src/olympia/devhub/views.py:1195
 #, python-format
 msgid "Version %s disabled."
 msgstr ""
 
-#: src/olympia/devhub/views.py:1193
+#: src/olympia/devhub/views.py:1199
 #, python-format
 msgid "Version %s deleted."
 msgstr ""
 
-#: src/olympia/devhub/views.py:1203
+#: src/olympia/devhub/views.py:1209
 msgid "This upload has failed validation, and may lack complete validation results. Please take due care when reviewing it."
 msgstr ""
 
-#: src/olympia/devhub/views.py:1677
+#: src/olympia/devhub/views.py:1683
 msgid "Preliminary Review Requested."
 msgstr ""
 
-#: src/olympia/devhub/views.py:1678
+#: src/olympia/devhub/views.py:1684
 msgid "Full Review Requested."
 msgstr ""
 
-#: src/olympia/devhub/views.py:1779
+#: src/olympia/devhub/views.py:1783
 msgid "Your old credentials were revoked and are no longer valid. Be sure to update all API clients with the new credentials."
 msgstr ""
 
-#: src/olympia/devhub/views.py:1797
+#: src/olympia/devhub/views.py:1801
 msgid "New API key created"
 msgstr ""
 
@@ -4011,7 +3994,7 @@ msgstr ""
 msgid "{0} :: Search"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/devhub_search.html:6 src/olympia/devhub/templates/devhub/search.html:8 src/olympia/editors/forms.py:435 src/olympia/editors/forms.py:437
+#: src/olympia/devhub/templates/devhub/devhub_search.html:6 src/olympia/devhub/templates/devhub/search.html:8 src/olympia/editors/forms.py:534 src/olympia/editors/forms.py:536
 #: src/olympia/editors/templates/editors/queue.html:27 src/olympia/editors/templates/editors/themes/queue_list.html:14 src/olympia/search/templates/search/collections.html:17
 #: src/olympia/search/templates/search/personas.html:18 src/olympia/search/templates/search/results.html:18 src/olympia/search/templates/search/mobile/results.html:8
 #: src/olympia/templates/search.html:14 src/olympia/templates/impala/search.html:18
@@ -4071,12 +4054,12 @@ msgstr ""
 msgid "Start Making Add-ons"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/index.html:86 src/olympia/devhub/templates/devhub/addons/listing/items.html:25 src/olympia/devhub/templates/devhub/includes/addon_details.html:15
+#: src/olympia/devhub/templates/devhub/index.html:86 src/olympia/devhub/templates/devhub/addons/listing/items.html:25 src/olympia/devhub/templates/devhub/includes/addon_details.html:20
 #: src/olympia/devhub/templates/devhub/personas/edit.html:43
 msgid "Status:"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/index.html:90 src/olympia/devhub/templates/devhub/includes/addon_details.html:100
+#: src/olympia/devhub/templates/devhub/index.html:90 src/olympia/devhub/templates/devhub/includes/addon_details.html:87
 msgid "Visibility:"
 msgstr ""
 
@@ -4084,11 +4067,11 @@ msgstr ""
 msgid "Latest Version:"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/index.html:109 src/olympia/devhub/templates/devhub/includes/addon_details.html:145 src/olympia/devhub/templates/devhub/personas/edit.html:49
+#: src/olympia/devhub/templates/devhub/index.html:109 src/olympia/devhub/templates/devhub/includes/addon_details.html:131 src/olympia/devhub/templates/devhub/personas/edit.html:49
 msgid "Queue Position:"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/index.html:110 src/olympia/devhub/templates/devhub/includes/addon_details.html:146 src/olympia/devhub/templates/devhub/personas/edit.html:50
+#: src/olympia/devhub/templates/devhub/index.html:110 src/olympia/devhub/templates/devhub/includes/addon_details.html:132 src/olympia/devhub/templates/devhub/personas/edit.html:50
 #, python-format
 msgid "%(position)s of %(total)s"
 msgstr ""
@@ -4190,16 +4173,6 @@ msgstr ""
 msgid "Do you want your add-on to be distributed on this site?"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/validate_addon.html:49 src/olympia/devhub/templates/devhub/addons/submit/upload.html:30 src/olympia/devhub/templates/devhub/versions/add_file_modal.html:14
-#: src/olympia/devhub/templates/devhub/versions/add_file_modal.html:53 src/olympia/devhub/templates/devhub/versions/list.html:298
-msgid "Warning:"
-msgstr ""
-
-#: src/olympia/devhub/templates/devhub/validate_addon.html:50 src/olympia/devhub/templates/devhub/addons/submit/upload.html:31
-#, python-format
-msgid "Submission of unlisted add-ons for signing is currently in an open beta. Please <a href=\"%(url)s\" target=\"_blank\">report any bugs</a> that you encounter."
-msgstr ""
-
 #. first parameter is a filename like lorem-ipsum-1.0.2.xpi
 #: src/olympia/devhub/templates/devhub/validation.html:5
 msgid "Validation Results for {0}"
@@ -4274,7 +4247,7 @@ msgstr ""
 msgid "Update Compatibility"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/addons/ajax_compat_update.html:4
+#: src/olympia/devhub/templates/devhub/addons/ajax_compat_update.html:4 src/olympia/devhub/templates/devhub/versions/edit.html:45
 msgid "Adjusting application information here will allow users to install your add-on even if the install manifest in the package indicates that the add-on is incompatible."
 msgstr ""
 
@@ -4286,9 +4259,9 @@ msgstr ""
 msgid "Add Another Application&hellip;"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/addons/ajax_compat_update.html:38 src/olympia/devhub/templates/devhub/addons/owner.html:86 src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:46
-#: src/olympia/devhub/templates/devhub/versions/list.html:351 src/olympia/devhub/templates/devhub/versions/list.html:353 src/olympia/templates/impala/base.html:132
-#: src/olympia/templates/impala/base.html:143 src/olympia/templates/impala/base.html:161 src/olympia/templates/impala/base.html:171
+#: src/olympia/devhub/templates/devhub/addons/ajax_compat_update.html:38 src/olympia/devhub/templates/devhub/addons/owner.html:86 src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:45
+#: src/olympia/devhub/templates/devhub/versions/list.html:349 src/olympia/devhub/templates/devhub/versions/list.html:351 src/olympia/templates/impala/base.html:129
+#: src/olympia/templates/impala/base.html:140 src/olympia/templates/impala/base.html:158 src/olympia/templates/impala/base.html:168
 msgid "Close"
 msgstr ""
 
@@ -4322,7 +4295,7 @@ msgstr ""
 msgid "Manage Authors & License"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/addons/owner.html:29 src/olympia/editors/templates/editors/review.html:270
+#: src/olympia/devhub/templates/devhub/addons/owner.html:29 src/olympia/editors/helpers.py:362 src/olympia/editors/templates/editors/review.html:270
 msgid "Authors"
 msgstr ""
 
@@ -4391,17 +4364,11 @@ msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/basic.html:52
 msgid ""
-"A short explanation of your add-on's basic\n"
-"                          functionality that is displayed in search and browse\n"
-"                          listings, as well as at the top of your add-on's\n"
-"                          details page. It is only relevant for listed add-ons."
+"A short explanation of your add-on's basic functionality that is displayed in search and browse listings, as well as at the top of your add-on's details page. It is only relevant for listed add-ons."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/basic.html:73
-msgid ""
-"Categories are the primary way users browse through add-ons.\n"
-"                        Choose any that fit your add-on's functionality for the most\n"
-"                        exposure. It is only relevant for listed add-ons."
+msgid "Categories are the primary way users browse through add-ons. Choose any that fit your add-on's functionality for the most exposure. It is only relevant for listed add-ons."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/basic.html:90
@@ -4411,11 +4378,7 @@ msgid ""
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/basic.html:119
-msgid ""
-"Tags help users find your add-on and should be short\n"
-"                        descriptors such as tabs, toolbar, or twitter.  You\n"
-"                        may have a maximum of {0} tags. It is only relevant\n"
-"                        for listed add-ons."
+msgid "Tags help users find your add-on and should be short descriptors such as tabs, toolbar, or twitter. You may have a maximum of {0} tags. It is only relevant for listed add-ons."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/basic.html:129 src/olympia/devhub/templates/devhub/personas/edit.html:97 src/olympia/devhub/templates/devhub/personas/submit.html:46
@@ -4443,11 +4406,7 @@ msgid "Add-on Details for {0}"
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/details.html:22
-msgid ""
-"A longer explanation of features,\n"
-"                          functionality, and other relevant information. This\n"
-"                          field is only displayed on the add-on's details\n"
-"                          page. It is only relevant for listed add-ons."
+msgid "A longer explanation of features, functionality, and other relevant information. This field is only displayed on the add-on's details page. It is only relevant for listed add-ons."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/details.html:44 src/olympia/translations/templates/translations/trans-menu.html:13
@@ -4455,10 +4414,7 @@ msgid "Default Locale"
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/details.html:45
-msgid ""
-"Information about your add-on is displayed in this locale\n"
-"                        unless you override it with a locale-specific translation.\n"
-"                        It is only relevant for listed add-ons."
+msgid "Information about your add-on is displayed in this locale unless you override it with a locale-specific translation. It is only relevant for listed add-ons."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/details.html:61 src/olympia/users/forms.py:311 src/olympia/users/templates/users/edit.html:122 src/olympia/users/templates/users/register.html:57
@@ -4468,10 +4424,8 @@ msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/details.html:63
 msgid ""
-"If your add-on has another homepage, enter its\n"
-"                          address here. If your website is localized into other\n"
-"                          languages multiple translations of this field can be\n"
-"                          added. It is only relevant for listed add-ons."
+"If your add-on has another homepage, enter its address here. If your website is localized into other languages multiple translations of this field can be added. It is only relevant for listed add-"
+"ons."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/media.html:3
@@ -4489,19 +4443,14 @@ msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/support.html:22
 msgid ""
-"If you wish to display an e-mail address for support\n"
-"                          inquiries, enter it here. If you have different\n"
-"                          addresses for each language multiple translations of\n"
-"                          this field can be added. It is only relevant for\n"
-"                          listed add-ons."
+"If you wish to display an e-mail address for support inquiries, enter it here. If you have different addresses for each language multiple translations of this field can be added. It is only "
+"relevant for listed add-ons."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/support.html:45
 msgid ""
-"If your add-on has a support website or forum, enter\n"
-"                          its address here. If your website is localized into\n"
-"                          other languages, multiple translations of this field can\n"
-"                          be added. It is only relevant for listed add-ons."
+"If your add-on has a support website or forum, enter its address here. If your website is localized into other languages, multiple translations of this field can be added. It is only relevant for "
+"listed add-ons."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:6
@@ -4515,11 +4464,8 @@ msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:23
 msgid ""
-"Any information end users may want to know that isn't\n"
-"                          necessarily applicable to the add-on summary or description.\n"
-"                          Common uses include listing known major bugs, information on\n"
-"                          how to report bugs, anticipated release date of a new version,\n"
-"                          etc. It is only relevant for listed add-ons."
+"Any information end users may want to know that isn't necessarily applicable to the add-on summary or description. Common uses include listing known major bugs, information on how to report bugs, "
+"anticipated release date of a new version, etc. It is only relevant for listed add-ons."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:46
@@ -4531,9 +4477,7 @@ msgid "Add-on Flags"
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:69
-msgid ""
-"These flags are used to classify add-ons. It is only\n"
-"                        relevant for listed add-ons."
+msgid "These flags are used to classify add-ons. It is only relevant for listed add-ons."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:74
@@ -4549,9 +4493,7 @@ msgid "View Source?"
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:90
-msgid ""
-"Whether the source of your add-on can be displayed in our\n"
-"                        online viewer. It is only relevant for listed add-ons."
+msgid "Whether the source of your add-on can be displayed in our online viewer. It is only relevant for listed add-ons."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:94
@@ -4567,10 +4509,7 @@ msgid "Public Stats?"
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:102
-msgid ""
-"Whether the download and usage stats of your add-on can\n"
-"                        be displayed in our online viewer.\n"
-"                        It is only relevant for listed add-ons."
+msgid "Whether the download and usage stats of your add-on can be displayed in our online viewer. It is only relevant for listed add-ons."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:107
@@ -4586,10 +4525,7 @@ msgid "Upgrade SDK?"
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:116
-msgid ""
-"If selected, we will try to automatically upgrade your\n"
-"                        add-on when a new version of the SDK is released.\n"
-"                        It is only relevant for listed add-ons."
+msgid "If selected, we will try to automatically upgrade your add-on when a new version of the SDK is released. It is only relevant for listed add-ons."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:121
@@ -4640,10 +4576,8 @@ msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/forms_shared/media.html:16
 msgid ""
-"Upload an icon for your add-on or choose from one of ours. The\n"
-"                      icon is displayed nearly everywhere your add-on is. Uploaded images\n"
-"                      must be one of the following image types: .png, .jpg.\n"
-"                      It is only relevant for listed add-ons."
+"Upload an icon for your add-on or choose from one of ours. The icon is displayed nearly everywhere your add-on is. Uploaded images must be one of the following image types: .png, .jpg. It is only "
+"relevant for listed add-ons."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/forms_shared/media.html:25
@@ -4656,9 +4590,7 @@ msgid "32x32px"
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/forms_shared/media.html:39
-msgid ""
-"Used in listings of add-ons, like search results\n"
-"                            and featured add-ons."
+msgid "Used in listings of add-ons, like search results and featured add-ons."
 msgstr ""
 
 #. The size of the icon
@@ -4753,16 +4685,14 @@ msgid "Deleting your add-on will permanently remove it from the site and prevent
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:24
-msgid ""
-"Enter the following text confirm your decision:\n"
-"           {slug}"
+msgid "Enter the following text confirm your decision: {slug}"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:34
+#: src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:33
 msgid "Please tell us why you are deleting your theme:"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:36
+#: src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:35
 msgid "Please tell us why you are deleting your add-on:"
 msgstr ""
 
@@ -4799,8 +4729,8 @@ msgstr ""
 msgid "Daily statistics on downloads and users."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/addons/listing/item_actions.html:45 src/olympia/stats/templates/stats/stats.html:75 src/olympia/stats/templates/stats/stats.html:79
-#: src/olympia/stats/templates/stats/stats.html:81
+#: src/olympia/devhub/templates/devhub/addons/listing/item_actions.html:45 src/olympia/stats/templates/stats/stats.html:31 src/olympia/stats/templates/stats/stats.html:35
+#: src/olympia/stats/templates/stats/stats.html:37
 msgid "Statistics"
 msgstr ""
 
@@ -4919,10 +4849,7 @@ msgid "Your add-on has been submitted to the Full Review queue."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/submit/done.html:18
-msgid ""
-"You'll receive an email once it has been reviewed by an editor. In\n"
-"          the meantime, you and your friends can install it directly from its\n"
-"          details page:"
+msgid "You'll receive an email once it has been reviewed by an editor. In the meantime, you and your friends can install it directly from its details page:"
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/submit/done.html:27 src/olympia/devhub/templates/devhub/addons/submit/done.html:77 src/olympia/devhub/templates/devhub/personas/submit_done.html:16
@@ -5128,11 +5055,11 @@ msgstr ""
 msgid "Use the fields below to upload your add-on package and select any platform restrictions. After upload, a series of automated validation tests will be run on your file."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/addons/submit/upload.html:59 src/olympia/devhub/templates/devhub/versions/add_file_modal.html:39
+#: src/olympia/devhub/templates/devhub/addons/submit/upload.html:51 src/olympia/devhub/templates/devhub/versions/add_file_modal.html:28
 msgid "Which platforms is this file compatible with?"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/addons/submit/upload.html:67 src/olympia/devhub/templates/devhub/versions/add_file_modal.html:65
+#: src/olympia/devhub/templates/devhub/addons/submit/upload.html:59 src/olympia/devhub/templates/devhub/versions/add_file_modal.html:45
 msgid "Administrative overrides"
 msgstr ""
 
@@ -5242,8 +5169,8 @@ msgstr ""
 
 #: src/olympia/devhub/templates/devhub/docs/policies-contact.html:44
 msgid ""
-"If you've found a problem with the site, we'd love to fix it. Please <a href=\"https://github.com/mozilla/olympia/issues\">file a bug report</a> in GitHub, including the location of the problem and "
-"how you encountered it."
+"If you've found a problem with the site, we'd love to fix it. Please <a href=\"https://github.com/mozilla/addons/issues/new\">file a bug report</a> in GitHub, including the location of the problem "
+"and how you encountered it."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/docs/policies-maintenance.html:3 src/olympia/devhub/templates/devhub/docs/policies-maintenance.html:7
@@ -5810,7 +5737,7 @@ msgstr ""
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:282
 msgid ""
-"Add-ons that store or otherwise handle browsing data must support <a href=\"https://developer.mozilla.org/En/Supporting_private_browsing_mode\">Private Browsing Mode</a>.  During a Private Browsing "
+"Add-ons that store or otherwise handle browsing data must support <a href=\"https://developer.mozilla.org/En/Supporting_private_browsing_mode\">Private Browsing Mode</a>. During a Private Browsing "
 "session, no browsing data can be written to disk, and all of this data must be cleared when Firefox quits or the Private Browsing session ends."
 msgstr ""
 
@@ -5975,129 +5902,95 @@ msgstr ""
 msgid "How to get in touch with us regarding these policies or your add-on."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:6
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:10
 msgid "You have disabled this add-on"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:20
-msgid ""
-"Your add-on's listing is disabled and is not showing\n"
-"                             anywhere in our gallery or update service."
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:24
+msgid "Your add-on's listing is disabled and is not showing anywhere in our gallery or update service."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:25
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:27
 msgid "Please complete your add-on."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:29
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:30
 msgid "You will receive an email when the review is complete."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:34
-msgid ""
-"You will receive an email when the review is complete. Until\n"
-"                             then, your add-on is not listed in our gallery but can be\n"
-"                             accessed directly from its details page."
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:33
+msgid "You will receive an email when the review is complete. Until then, your add-on is not listed in our gallery but can be accessed directly from its details page."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:38 src/olympia/devhub/templates/devhub/includes/addon_details.html:48
-msgid ""
-"You will receive an email when the review is\n"
-"                             complete and your add-on is signed."
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:37 src/olympia/devhub/templates/devhub/includes/addon_details.html:45
+msgid "You will receive an email when the review is complete and your add-on is signed."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:44
-msgid ""
-"You will receive an email when the review is complete. Until\n"
-"                             then, your add-on is not listed in our gallery but can be\n"
-"                             accessed directly from its details page. "
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:41
+msgid "You will receive an email when the review is complete. Until then, your add-on is not listed in our gallery but can be accessed directly from its details page. "
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:54
-msgid ""
-"Your add-on is displayed in our gallery and users are\n"
-"                             receiving automatic updates."
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:49
+msgid "Your add-on is displayed in our gallery and users are receiving automatic updates."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:57
-msgid ""
-"Your add-on has been signed and can be bundled with an\n"
-"                             application installer."
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:52
+msgid "Your add-on has been signed and can be bundled with an application installer."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:63
-msgid ""
-"Your add-on was disabled by a site administrator and is no\n"
-"                             longer shown in our gallery. If you have any questions,\n"
-"                             please email amo-admins@mozilla.org."
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:56
+msgid "Your add-on was disabled by a site administrator and is no longer shown in our gallery. If you have any questions, please email amo-admins@mozilla.org."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:70
-msgid ""
-"Your add-on is displayed in our gallery as experimental\n"
-"                             and users are receiving automatic updates. Some features\n"
-"                             are unavailable to your add-on."
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:62
+msgid "Your add-on is displayed in our gallery as experimental and users are receiving automatic updates. Some features are unavailable to your add-on."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:74
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:66
 msgid "Your add-on has been signed."
 msgstr ""
 
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:69
+msgid ""
+"You will receive an email when the full review is complete. Until then, your add-on is displayed in our gallery as experimental and users are receiving automatic updates. Some features are "
+"unavailable to your add-on."
+msgstr ""
+
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:74
+msgid "You will receive an email when the full review is complete, making you able to bundle your add-on with an application installer."
+msgstr ""
+
 #: src/olympia/devhub/templates/devhub/includes/addon_details.html:79
-msgid ""
-"You will receive an email when the full review is complete.\n"
-"                             Until then, your add-on is displayed in our gallery as\n"
-"                             experimental and users are receiving automatic updates.\n"
-"                             Some features are unavailable to your add-on."
+msgid "All add-ons hosted in our gallery must now be reviewed by an editor. If you wish to continue hosting your add-on, please click to select a review process."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:84
-msgid ""
-"You will receive an email when the full review is\n"
-"                             complete, making you able to bundle your add-on with an\n"
-"                             application installer."
-msgstr ""
-
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:91
-msgid ""
-"All add-ons hosted in our gallery must now be reviewed by an\n"
-"                             editor. If you wish to continue hosting your add-on, please\n"
-"                             click to select a review process."
-msgstr ""
-
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:113
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:100
 msgid "Current Version:"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:115
-msgid ""
-"This is the version of your add-on that will\n"
-"                                           be installed if someone clicks the Install\n"
-"                                           button on addons.mozilla.org. It is only\n"
-"                                           relevant for listed add-ons."
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:102
+msgid "This is the version of your add-on that will be installed if someone clicks the Install button on addons.mozilla.org. It is only relevant for listed add-ons."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:123
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:110
 msgid "Created:"
 msgstr ""
 
 #. {0} is a date. dennis-ignore: E201
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:125 src/olympia/devhub/templates/devhub/includes/addon_details.html:131
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:112 src/olympia/devhub/templates/devhub/includes/addon_details.html:118
 #, python-format
 msgid "%%b %%e, %%Y"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:136
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:123
 msgid "Next Version:"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:138
-msgid ""
-"This is the newest uploaded version, however\n"
-"                                           it isn’t live on the site yet."
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:125
+msgid "This is the newest uploaded version, however it isn’t live on the site yet."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:144 src/olympia/devhub/templates/devhub/versions/list.html:30
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:130 src/olympia/devhub/templates/devhub/versions/list.html:30
 msgid "Queues are not reviewed strictly in order"
 msgstr ""
 
@@ -6165,9 +6058,7 @@ msgid "View the blog &#9658;"
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/includes/license_form.html:6
-msgid ""
-"Please choose a license appropriate for the rights you grant on your source code.\n"
-"                  It is only relevant for listed add-ons."
+msgid "Please choose a license appropriate for the rights you grant on your source code. It is only relevant for listed add-ons."
 msgstr ""
 
 #. {0} is a list of HTML tags.
@@ -6194,14 +6085,11 @@ msgstr[1] ""
 #: src/olympia/devhub/templates/devhub/includes/policy_form.html:4
 msgid ""
 "Users will be required to accept the following End-User License Agreement (EULA) prior to installing your add-on. The presence of a EULA significantly affects the number of downloads an add-on "
-"receives. Please note that a EULA is not the same as a code license, such as the GPL or MPL.\n"
-"                It is only relevant for listed add-ons."
+"receives. Please note that a EULA is not the same as a code license, such as the GPL or MPL.It is only relevant for listed add-ons."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/policy_form.html:21
-msgid ""
-"If your add-on transmits any data from the user's computer, a privacy policy is required that explains what data is sent and how it is used.\n"
-"                It is only relevant for listed add-ons."
+#: src/olympia/devhub/templates/devhub/includes/policy_form.html:24
+msgid "If your add-on transmits any data from the user's computer, a privacy policy is required that explains what data is sent and how it is used. It is only relevant for listed add-ons."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/includes/source_form_field.html:2
@@ -6369,12 +6257,8 @@ msgstr ""
 msgid "Add some tags to describe your Theme."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/personas/edit.html:106
-msgid ""
-"A short explanation of your theme's\n"
-"                                basic functionality that is displayed in\n"
-"                                search and browse listings, as well as at\n"
-"                                the top of your theme's details page."
+#: src/olympia/devhub/templates/devhub/personas/edit.html:106 src/olympia/devhub/templates/devhub/personas/submit.html:54
+msgid "A short explanation of your theme's basic functionality that is displayed in search and browse listings, as well as at the top of your theme's details page."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/personas/edit.html:122 src/olympia/devhub/templates/devhub/personas/submit.html:68
@@ -6444,7 +6328,7 @@ msgid "Upon upload and form submission, the AMO Team will review your updated de
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/personas/edit.html:241
-msgid "Your previously resubmitted design,  which is under pending review."
+msgid "Your previously resubmitted design, which is under pending review."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/personas/edit.html:245
@@ -6511,14 +6395,6 @@ msgstr ""
 
 #: src/olympia/devhub/templates/devhub/personas/submit.html:33
 msgid "Give your Theme a name."
-msgstr ""
-
-#: src/olympia/devhub/templates/devhub/personas/submit.html:54
-msgid ""
-"A short explanation of your theme's\n"
-"                                      basic functionality that is displayed in\n"
-"                                      search and browse listings, as well as at\n"
-"                                      the top of your theme's details page."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/personas/submit.html:198
@@ -6595,30 +6471,16 @@ msgstr ""
 msgid "Files added to reviewed versions must be reviewed before they will be available for download."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/add_file_modal.html:15
-#, python-format
-msgid ""
-"Submission of updates to unlisted add-ons for signing is currently in an open beta. Manual review may still be required for a large number of add-ons. Please <a href=\"%(url)s\" target=\"_blank"
-"\">report any bugs</a> that you encounter."
-msgstr ""
-
-#: src/olympia/devhub/templates/devhub/versions/add_file_modal.html:35
+#: src/olympia/devhub/templates/devhub/versions/add_file_modal.html:24
 msgid "Select the target platform for this file."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/add_file_modal.html:46
+#: src/olympia/devhub/templates/devhub/versions/add_file_modal.html:35
 msgid "Which review type would you like to nominate for?"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/add_file_modal.html:51
+#: src/olympia/devhub/templates/devhub/versions/add_file_modal.html:40
 msgid "Only publish this version to my beta channel."
-msgstr ""
-
-#: src/olympia/devhub/templates/devhub/versions/add_file_modal.html:54
-#, python-format
-msgid ""
-"The behavior of the beta channel has changed to accommodate <a href=\"%(addon_signing_url)s\" target=\"_blank\">mandatory add-on signing</a>. The new process is currently in an open beta, and may "
-"change significantly in the near future. Please <a href=\"%(issues_url)s\" target=\"_blank\">report any bugs</a> that you encounter."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/versions/edit.html:5
@@ -6642,19 +6504,10 @@ msgstr ""
 msgid "Upload Another File"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/edit.html:45
-msgid ""
-"Adjusting application information here will allow users to install your\n"
-"                          add-on even if the install manifest in the package indicates that the\n"
-"                          add-on is incompatible."
-msgstr ""
-
 #: src/olympia/devhub/templates/devhub/versions/edit.html:74
 msgid ""
-"Information about changes in this release, new features,\n"
-"                              known bugs, and other useful information specific to this\n"
-"                              release/version. This information is also shown in the\n"
-"                              Add-ons Manager when updating."
+"Information about changes in this release, new features, known bugs, and other useful information specific to this release/version. This information is also shown in the Add-ons Manager when "
+"updating."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/versions/edit.html:99
@@ -6666,10 +6519,7 @@ msgid "Notes for Reviewers"
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/versions/edit.html:114
-msgid ""
-"Optionally, enter any information that may be useful\n"
-"                              to the Editor reviewing this add-on, such as test\n"
-"                              account information."
+msgid "Optionally, enter any information that may be useful to the Editor reviewing this add-on, such as test account information."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/versions/edit.html:127
@@ -6747,7 +6597,7 @@ msgstr ""
 msgid "Request Preliminary Review"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:80 src/olympia/devhub/templates/devhub/versions/list.html:327 src/olympia/devhub/templates/devhub/versions/list.html:350
+#: src/olympia/devhub/templates/devhub/versions/list.html:80 src/olympia/devhub/templates/devhub/versions/list.html:325 src/olympia/devhub/templates/devhub/versions/list.html:348
 msgid "Cancel Review Request"
 msgstr ""
 
@@ -6776,7 +6626,7 @@ msgid "Unlisted:"
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/versions/list.html:114
-msgid "Not distributed on {0}. Developers will upload new versions for signing and distribute the add-ons on their own. (beta)"
+msgid "Not distributed on {0}. Developers will upload new versions for signing and distribute the add-ons on their own."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/versions/list.html:122
@@ -6839,81 +6689,73 @@ msgid "<strong>Important:</strong> Once a version has been deleted, you may not 
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/versions/list.html:230
-msgid ""
-"Deleting a version which has already been reviewed\n"
-"               may also cause a significant delay in the review of\n"
-"               your next update."
-msgstr ""
-
-#: src/olympia/devhub/templates/devhub/versions/list.html:233
 msgid "Are you sure you wish to delete this version?"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:238
+#: src/olympia/devhub/templates/devhub/versions/list.html:235
 msgid "Delete Version"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:240
+#: src/olympia/devhub/templates/devhub/versions/list.html:237
 msgid "Disable Version"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:247
+#: src/olympia/devhub/templates/devhub/versions/list.html:244
 msgid "Add a new Version"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:249
+#: src/olympia/devhub/templates/devhub/versions/list.html:246
 msgid "Add Version"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:256 src/olympia/devhub/templates/devhub/versions/list.html:274
+#: src/olympia/devhub/templates/devhub/versions/list.html:253 src/olympia/devhub/templates/devhub/versions/list.html:279
 msgid "Hide Add-on"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:259
+#: src/olympia/devhub/templates/devhub/versions/list.html:256
 msgid "Hiding your add-on will prevent it from appearing anywhere in our gallery and will stop users from receiving automatic updates."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:265
+#: src/olympia/devhub/templates/devhub/versions/list.html:263
+msgid "The files awaiting review will be disabled and you will need to upload new versions."
+msgstr ""
+
+#: src/olympia/devhub/templates/devhub/versions/list.html:270
 msgid "Are you sure you wish to hide your add-on?"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:286 src/olympia/devhub/templates/devhub/versions/list.html:315
+#: src/olympia/devhub/templates/devhub/versions/list.html:291 src/olympia/devhub/templates/devhub/versions/list.html:313
 msgid "Unlist Add-on"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:289
+#: src/olympia/devhub/templates/devhub/versions/list.html:294
 #, python-format
 msgid ""
 "Unlisting your add-on will make it (and each of its versions/files) invisible on this website. It won't show up in searches, won't have a public facing page, and won't be updated automatically for "
-"current users.  It is recommended for unlisted add-ons to provide a custom <a href=\"%(update_url)s\" target=\"_blank\">updateURL</a> in their manifest file for automatic updates."
+"current users. It is recommended for unlisted add-ons to provide a custom <a href=\"%(update_url)s\" target=\"_blank\">updateURL</a> in their manifest file for automatic updates."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:299
-#, python-format
-msgid "Switching add-ons to unlisted is currently in an open beta. Please <a href=\"%(url)s\" target=\"_blank\">report any bugs</a> that you encounter."
-msgstr ""
-
-#: src/olympia/devhub/templates/devhub/versions/list.html:305
+#: src/olympia/devhub/templates/devhub/versions/list.html:303
 msgid "Unlisting an add-on is irreversible!"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:305
+#: src/olympia/devhub/templates/devhub/versions/list.html:303
 msgid "An unlisted add-on cannot be switched to be listed."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:307
+#: src/olympia/devhub/templates/devhub/versions/list.html:305
 msgid "Are you sure you wish to unlist your add-on?"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:330
+#: src/olympia/devhub/templates/devhub/versions/list.html:328
 msgid "Canceling your review request will leave your add-on as preliminarily reviewed."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:335
+#: src/olympia/devhub/templates/devhub/versions/list.html:333
 msgid "Canceling your review request will mark your add-on incomplete. If you do not complete your add-on after several days by re-requesting review, it will be deleted."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:343
+#: src/olympia/devhub/templates/devhub/versions/list.html:341
 msgid "Are you sure you wish to cancel your review request?"
 msgstr ""
 
@@ -7252,19 +7094,19 @@ msgstr ""
 msgid "Search by add-on name / author email"
 msgstr ""
 
-#: src/olympia/editors/forms.py:103
+#: src/olympia/editors/forms.py:103 src/olympia/editors/forms.py:244 src/olympia/editors/forms.py:257
 msgid "yes"
 msgstr ""
 
-#: src/olympia/editors/forms.py:104
+#: src/olympia/editors/forms.py:104 src/olympia/editors/forms.py:244 src/olympia/editors/forms.py:257
 msgid "no"
 msgstr ""
 
-#: src/olympia/editors/forms.py:105
+#: src/olympia/editors/forms.py:105 src/olympia/editors/forms.py:245
 msgid "Admin Flag"
 msgstr ""
 
-#: src/olympia/editors/forms.py:113
+#: src/olympia/editors/forms.py:113 src/olympia/editors/forms.py:253
 msgid "Max. Version"
 msgstr ""
 
@@ -7276,55 +7118,59 @@ msgstr ""
 msgid "Add-on Types"
 msgstr ""
 
-#: src/olympia/editors/forms.py:126 src/olympia/editors/helpers.py:267
+#: src/olympia/editors/forms.py:126 src/olympia/editors/helpers.py:279
 msgid "Platforms"
 msgstr ""
 
+#: src/olympia/editors/forms.py:237
+msgid "Search by add-on name / author email / guid"
+msgstr ""
+
 #. L10n: 0 = platform, 1 = filename, 2 = status message
-#: src/olympia/editors/forms.py:238
+#: src/olympia/editors/forms.py:342
 #, python-format
 msgid "<strong>%s</strong> &middot; %s &middot; %s"
 msgstr ""
 
-#: src/olympia/editors/forms.py:252
+#: src/olympia/editors/forms.py:356
 msgid "Comments:"
 msgstr ""
 
-#: src/olympia/editors/forms.py:256
+#: src/olympia/editors/forms.py:360
 msgid "Operating systems:"
 msgstr ""
 
-#: src/olympia/editors/forms.py:258
+#: src/olympia/editors/forms.py:362
 msgid "Applications:"
 msgstr ""
 
-#: src/olympia/editors/forms.py:260
+#: src/olympia/editors/forms.py:364
 msgid "Notify me the next time this add-on is updated. (Subsequent updates will not generate an email)"
 msgstr ""
 
-#: src/olympia/editors/forms.py:265
+#: src/olympia/editors/forms.py:369
 msgid "Clear Admin Review Flag"
 msgstr ""
 
-#: src/olympia/editors/forms.py:267
+#: src/olympia/editors/forms.py:371
 msgid "Clear more info requested flag"
 msgstr ""
 
-#: src/olympia/editors/forms.py:281
+#: src/olympia/editors/forms.py:385
 msgid "Choose a canned response..."
 msgstr ""
 
 #. L10n: Description of what can be searched for.
-#: src/olympia/editors/forms.py:324
+#: src/olympia/editors/forms.py:423
 msgid "theme name"
 msgstr ""
 
-#: src/olympia/editors/forms.py:350
+#: src/olympia/editors/forms.py:449
 msgid "Someone else is reviewing this theme."
 msgstr ""
 
 #. L10n: Description of what can be searched for.
-#: src/olympia/editors/forms.py:447
+#: src/olympia/editors/forms.py:546
 msgid "app, reviewer, or comment"
 msgstr ""
 
@@ -7340,246 +7186,264 @@ msgstr ""
 msgid "Rejected or Unreviewed"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:123 src/olympia/editors/helpers.py:136
+#: src/olympia/editors/helpers.py:125 src/olympia/editors/helpers.py:138
 msgid "Queue"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:124 src/olympia/editors/templates/editors/base.html:50 src/olympia/editors/templates/editors/base.html:65
+#: src/olympia/editors/helpers.py:126 src/olympia/editors/templates/editors/base.html:50 src/olympia/editors/templates/editors/base.html:65
 msgid "Pending Updates"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:125 src/olympia/editors/templates/editors/base.html:48 src/olympia/editors/templates/editors/base.html:63
+#: src/olympia/editors/helpers.py:127 src/olympia/editors/templates/editors/base.html:48 src/olympia/editors/templates/editors/base.html:63
 msgid "Full Reviews"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:126 src/olympia/editors/templates/editors/base.html:52 src/olympia/editors/templates/editors/base.html:67
+#: src/olympia/editors/helpers.py:128 src/olympia/editors/templates/editors/base.html:52 src/olympia/editors/templates/editors/base.html:67
 msgid "Preliminary Reviews"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:127 src/olympia/editors/templates/editors/base.html:54
+#: src/olympia/editors/helpers.py:129 src/olympia/editors/templates/editors/base.html:54
 msgid "Moderated Reviews"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:128 src/olympia/editors/templates/editors/base.html:46
+#: src/olympia/editors/helpers.py:130 src/olympia/editors/templates/editors/base.html:46
 msgid "Fast Track"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:130
+#: src/olympia/editors/helpers.py:132
 msgid "Pending Themes"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:131 src/olympia/editors/templates/editors/themes/queue.html:4
+#: src/olympia/editors/helpers.py:133 src/olympia/editors/templates/editors/themes/queue.html:4
 msgid "Flagged Themes"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:132
+#: src/olympia/editors/helpers.py:134
 msgid "Update Themes"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:137
+#: src/olympia/editors/helpers.py:139
 msgid "Unlisted Pending Updates"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:138
+#: src/olympia/editors/helpers.py:140
 msgid "Unlisted Full Reviews"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:139
+#: src/olympia/editors/helpers.py:141
 msgid "Unlisted Preliminary Reviews"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:170
+#: src/olympia/editors/helpers.py:142
+msgid "Unlisted All Add-ons"
+msgstr ""
+
+#: src/olympia/editors/helpers.py:173
 msgid "Fast Track ({0})"
 msgid_plural "Fast Track ({0})"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/olympia/editors/helpers.py:175
+#: src/olympia/editors/helpers.py:178
 msgid "Full Review ({0})"
 msgid_plural "Full Reviews ({0})"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/olympia/editors/helpers.py:180
+#: src/olympia/editors/helpers.py:183
 msgid "Pending Update ({0})"
 msgid_plural "Pending Updates ({0})"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/olympia/editors/helpers.py:185
+#: src/olympia/editors/helpers.py:188
 msgid "Preliminary Review ({0})"
 msgid_plural "Preliminary Reviews ({0})"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/olympia/editors/helpers.py:190
+#: src/olympia/editors/helpers.py:193
 msgid "Moderated Review ({0})"
 msgid_plural "Moderated Reviews ({0})"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/olympia/editors/helpers.py:196
+#: src/olympia/editors/helpers.py:199
 msgid "Unlisted Full Review ({0})"
 msgid_plural "Unlisted Full Reviews ({0})"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/olympia/editors/helpers.py:201
+#: src/olympia/editors/helpers.py:204
 msgid "Unlisted Pending Update ({0})"
 msgid_plural "Unlisted Pending Updates ({0})"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/olympia/editors/helpers.py:206
+#: src/olympia/editors/helpers.py:209
 msgid "Unlisted Preliminary Review ({0})"
 msgid_plural "Unlisted Preliminary Reviews ({0})"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/olympia/editors/helpers.py:261
-msgid "Addon"
-msgstr ""
+#: src/olympia/editors/helpers.py:214
+msgid "Unlisted All Add-ons ({0})"
+msgid_plural "Unlisted All Add-ons ({0})"
+msgstr[0] ""
+msgstr[1] ""
 
-#: src/olympia/editors/helpers.py:262
+#: src/olympia/editors/helpers.py:274
 msgid "Type"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:263
+#: src/olympia/editors/helpers.py:275
 msgid "Waiting Time"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:264 src/olympia/editors/templates/editors/review.html:285
+#: src/olympia/editors/helpers.py:276 src/olympia/editors/templates/editors/review.html:285
 msgid "Flags"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:265
+#: src/olympia/editors/helpers.py:277
 msgid "Applications"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:270
+#: src/olympia/editors/helpers.py:282
 msgid "Additional"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:285
+#: src/olympia/editors/helpers.py:302
 msgid "Site Specific"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:287
+#: src/olympia/editors/helpers.py:304
 msgid "Requires External Software"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:289
+#: src/olympia/editors/helpers.py:306
 msgid "Binary Components"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:313
+#: src/olympia/editors/helpers.py:339
 msgid "moments ago"
 msgstr ""
 
 #. L10n: first argument is number of minutes
-#: src/olympia/editors/helpers.py:316
+#: src/olympia/editors/helpers.py:342
 msgid "{0} minute"
 msgid_plural "{0} minutes"
 msgstr[0] ""
 msgstr[1] ""
 
 #. L10n: first argument is number of hours
-#: src/olympia/editors/helpers.py:320
+#: src/olympia/editors/helpers.py:346
 msgid "{0} hour"
 msgid_plural "{0} hours"
 msgstr[0] ""
 msgstr[1] ""
 
 #. L10n: first argument is number of days
-#: src/olympia/editors/helpers.py:324
+#: src/olympia/editors/helpers.py:350
 msgid "{0} day"
 msgid_plural "{0} days"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/olympia/editors/helpers.py:488
+#: src/olympia/editors/helpers.py:364
+msgid "Last Review"
+msgstr ""
+
+#: src/olympia/editors/helpers.py:366
+msgid "Last Update"
+msgstr ""
+
+#: src/olympia/editors/helpers.py:387
+msgid "No Reviews"
+msgstr ""
+
+#: src/olympia/editors/helpers.py:561
 msgid "Push to public"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:490
+#: src/olympia/editors/helpers.py:563
 msgid "Grant full review"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:505
+#: src/olympia/editors/helpers.py:578
 msgid "Request more information"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:508
+#: src/olympia/editors/helpers.py:581
 msgid "Request super-review"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:519
+#: src/olympia/editors/helpers.py:592
 msgid "Grant preliminary review"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:520
+#: src/olympia/editors/helpers.py:593
 msgid "This will mark the files as preliminarily reviewed."
 msgstr ""
 
-#: src/olympia/editors/helpers.py:522
+#: src/olympia/editors/helpers.py:595
 msgid "Use this form to request more information from the author. They will receive an email and be able to answer here. You will be notified by email when they reply."
 msgstr ""
 
-#: src/olympia/editors/helpers.py:526
+#: src/olympia/editors/helpers.py:599
 msgid ""
 "If you have concerns about this add-on's security, copyright issues, or other concerns that an administrator should look into, enter your comments in the area below. They will be sent to "
 "administrators, not the author."
 msgstr ""
 
-#: src/olympia/editors/helpers.py:532
+#: src/olympia/editors/helpers.py:605
 msgid "This will reject the add-on and remove it from the review queue."
 msgstr ""
 
-#: src/olympia/editors/helpers.py:534
-msgid "Make a comment on this version.  The author won't be able to see this."
+#: src/olympia/editors/helpers.py:607
+msgid "Make a comment on this version. The author won't be able to see this."
 msgstr ""
 
-#: src/olympia/editors/helpers.py:538
+#: src/olympia/editors/helpers.py:611
 msgid "This will reject the files and remove them from the review queue."
 msgstr ""
 
-#: src/olympia/editors/helpers.py:542
+#: src/olympia/editors/helpers.py:615
 msgid "This will mark the add-on as preliminarily reviewed. Future versions will undergo preliminary review."
 msgstr ""
 
-#: src/olympia/editors/helpers.py:547
+#: src/olympia/editors/helpers.py:620
 msgid "This will mark the files as preliminarily reviewed. Future versions will undergo preliminary review."
 msgstr ""
 
-#: src/olympia/editors/helpers.py:552
+#: src/olympia/editors/helpers.py:625
 msgid "Retain preliminary review"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:553
+#: src/olympia/editors/helpers.py:626
 msgid "This will retain the add-on as preliminarily reviewed. Future versions will undergo preliminary review."
 msgstr ""
 
-#: src/olympia/editors/helpers.py:558
+#: src/olympia/editors/helpers.py:631
 msgid "This will approve a sandboxed version of a public add-on to appear on the public side."
 msgstr ""
 
-#: src/olympia/editors/helpers.py:561
+#: src/olympia/editors/helpers.py:634
 msgid "This will reject a version of a public add-on and remove it from the queue."
 msgstr ""
 
-#: src/olympia/editors/helpers.py:564
+#: src/olympia/editors/helpers.py:637
 msgid "This will mark the add-on and its most recent version and files as public. Future versions will go into the sandbox until they are reviewed by an editor."
 msgstr ""
 
-#: src/olympia/editors/helpers.py:637
+#: src/olympia/editors/helpers.py:714
 msgid "add-on"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:940 src/olympia/editors/helpers.py:960
+#: src/olympia/editors/helpers.py:1020 src/olympia/editors/helpers.py:1040
 msgid "Flagged"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:944 src/olympia/editors/helpers.py:963
+#: src/olympia/editors/helpers.py:1024 src/olympia/editors/helpers.py:1043
 msgid "Updates"
 msgstr ""
 
@@ -7631,56 +7495,56 @@ msgstr ""
 msgid "A question about your Theme submission"
 msgstr ""
 
-#: src/olympia/editors/views.py:144
+#: src/olympia/editors/views.py:146
 msgid "New Add-ons (Under 5 days)"
 msgstr ""
 
-#: src/olympia/editors/views.py:145
+#: src/olympia/editors/views.py:147
 msgid "Passable (5 to 10 days)"
 msgstr ""
 
-#: src/olympia/editors/views.py:146
+#: src/olympia/editors/views.py:148
 msgid "Overdue (Over 10 days)"
 msgstr ""
 
-#: src/olympia/editors/views.py:532
+#: src/olympia/editors/views.py:539
 msgid "An unknown error occurred"
 msgstr ""
 
-#: src/olympia/editors/views.py:587
+#: src/olympia/editors/views.py:592
 msgid "Self-reviews are not allowed."
 msgstr ""
 
-#: src/olympia/editors/views.py:609
+#: src/olympia/editors/views.py:613
 msgid "Review successfully processed."
 msgstr ""
 
-#: src/olympia/editors/views.py:807
+#: src/olympia/editors/views.py:812
 msgid "was approved"
 msgstr ""
 
-#: src/olympia/editors/views.py:808
+#: src/olympia/editors/views.py:813
 msgid "given preliminary review"
 msgstr ""
 
-#: src/olympia/editors/views.py:809
+#: src/olympia/editors/views.py:814
 msgid "rejected"
 msgstr ""
 
-#: src/olympia/editors/views.py:810
+#: src/olympia/editors/views.py:815
 msgctxt "editors_review_history_nominated_adminreview"
 msgid "escalated"
 msgstr ""
 
-#: src/olympia/editors/views.py:812
+#: src/olympia/editors/views.py:817
 msgid "needs more information"
 msgstr ""
 
-#: src/olympia/editors/views.py:813
+#: src/olympia/editors/views.py:818
 msgid "needs super review"
 msgstr ""
 
-#: src/olympia/editors/views.py:814
+#: src/olympia/editors/views.py:819
 msgid "commented"
 msgstr ""
 
@@ -7725,28 +7589,28 @@ msgstr ""
 msgid "Unlisted Queues"
 msgstr ""
 
-#: src/olympia/editors/templates/editors/base.html:72 src/olympia/editors/templates/editors/performance.html:6
+#: src/olympia/editors/templates/editors/base.html:74 src/olympia/editors/templates/editors/performance.html:6
 msgid "Performance"
 msgstr ""
 
-#: src/olympia/editors/templates/editors/base.html:75 src/olympia/editors/templates/editors/themes/base.html:19 src/olympia/editors/templates/editors/themes/base.html:38
+#: src/olympia/editors/templates/editors/base.html:77 src/olympia/editors/templates/editors/themes/base.html:19 src/olympia/editors/templates/editors/themes/base.html:38
 msgid "Logs"
 msgstr ""
 
-#: src/olympia/editors/templates/editors/base.html:78 src/olympia/editors/templates/editors/reviewlog.html:4 src/olympia/editors/templates/editors/reviewlog.html:27
+#: src/olympia/editors/templates/editors/base.html:80 src/olympia/editors/templates/editors/reviewlog.html:4 src/olympia/editors/templates/editors/reviewlog.html:27
 msgid "Add-on Review Log"
 msgstr ""
 
-#: src/olympia/editors/templates/editors/base.html:80 src/olympia/editors/templates/editors/eventlog.html:4 src/olympia/editors/templates/editors/eventlog.html:8
+#: src/olympia/editors/templates/editors/base.html:82 src/olympia/editors/templates/editors/eventlog.html:4 src/olympia/editors/templates/editors/eventlog.html:8
 #: src/olympia/editors/templates/editors/eventlog_detail.html:4
 msgid "Moderated Review Log"
 msgstr ""
 
-#: src/olympia/editors/templates/editors/base.html:82 src/olympia/editors/templates/editors/beta_signed_log.html:4 src/olympia/editors/templates/editors/beta_signed_log.html:8
+#: src/olympia/editors/templates/editors/base.html:84 src/olympia/editors/templates/editors/beta_signed_log.html:4 src/olympia/editors/templates/editors/beta_signed_log.html:8
 msgid "Signed Beta Files Log"
 msgstr ""
 
-#: src/olympia/editors/templates/editors/base.html:87 src/olympia/editors/templates/editors/includes/daily-message.html:4
+#: src/olympia/editors/templates/editors/base.html:89 src/olympia/editors/templates/editors/includes/daily-message.html:4
 msgid "Announcement"
 msgstr ""
 
@@ -7967,45 +7831,45 @@ msgstr ""
 msgid "clear search"
 msgstr ""
 
-#: src/olympia/editors/templates/editors/queue.html:72 src/olympia/editors/templates/editors/queue.html:122
+#: src/olympia/editors/templates/editors/queue.html:78 src/olympia/editors/templates/editors/queue.html:128
 msgid "Process Reviews"
 msgstr ""
 
-#: src/olympia/editors/templates/editors/queue.html:80
+#: src/olympia/editors/templates/editors/queue.html:86
 msgid "Moderation actions:"
 msgstr ""
 
-#: src/olympia/editors/templates/editors/queue.html:90
+#: src/olympia/editors/templates/editors/queue.html:96
 #, python-format
 msgid "by %(user)s on %(date)s %(stars)s (%(locale)s)"
 msgstr ""
 
-#: src/olympia/editors/templates/editors/queue.html:106
+#: src/olympia/editors/templates/editors/queue.html:112
 #, python-format
 msgid "<strong>%(reason)s</strong> <span class=\"light\">Flagged by %(user)s on %(date)s</span>"
 msgstr ""
 
-#: src/olympia/editors/templates/editors/queue.html:119
-msgid "All reviews have been moderated.  Good work!"
+#: src/olympia/editors/templates/editors/queue.html:125
+msgid "All reviews have been moderated. Good work!"
 msgstr ""
 
-#: src/olympia/editors/templates/editors/queue.html:161
+#: src/olympia/editors/templates/editors/queue.html:167
 msgid "Version Notes / Notes for Reviewer"
 msgstr ""
 
-#: src/olympia/editors/templates/editors/queue.html:169
+#: src/olympia/editors/templates/editors/queue.html:175
 msgid "There are currently no add-ons of this type to review."
 msgstr ""
 
-#: src/olympia/editors/templates/editors/queue.html:181 src/olympia/editors/templates/editors/themes/queue_list.html:85
+#: src/olympia/editors/templates/editors/queue.html:187 src/olympia/editors/templates/editors/themes/queue_list.html:85
 msgid "Helpful Links:"
 msgstr ""
 
-#: src/olympia/editors/templates/editors/queue.html:182
+#: src/olympia/editors/templates/editors/queue.html:188
 msgid "Add-on Policy"
 msgstr ""
 
-#: src/olympia/editors/templates/editors/queue.html:184
+#: src/olympia/editors/templates/editors/queue.html:190
 msgid "Editors' Guide"
 msgstr ""
 
@@ -8068,10 +7932,7 @@ msgid "<strong>Warning!</strong> Another user was viewing this page before you."
 msgstr ""
 
 #: src/olympia/editors/templates/editors/review.html:237
-msgid ""
-"The whiteboard is the place to exchange information relevant to\n"
-"               this addon (whatever the version), between the developer and the\n"
-"               editor. This is visible and editable by both."
+msgid "The whiteboard is the place to exchange information relevant to this addon (whatever the version), between the developer and the editor. This is visible and editable by both."
 msgstr ""
 
 #: src/olympia/editors/templates/editors/review.html:241
@@ -8345,7 +8206,7 @@ msgstr ""
 msgid "Describe your reason for flagging"
 msgstr ""
 
-#: src/olympia/files/forms.py:88
+#: src/olympia/files/forms.py:90
 msgid "Cannot diff a version against itself"
 msgstr ""
 
@@ -8380,51 +8241,51 @@ msgstr ""
 msgid "There was an error accessing file %s."
 msgstr ""
 
-#: src/olympia/files/utils.py:343
+#: src/olympia/files/utils.py:340
 msgid "Could not parse uploaded file."
 msgstr ""
 
-#: src/olympia/files/utils.py:380
+#: src/olympia/files/utils.py:377
 msgid "Invalid file name in archive: {0}"
 msgstr ""
 
-#: src/olympia/files/utils.py:388
+#: src/olympia/files/utils.py:385
 msgid "File exceeding size limit in archive: {0}"
 msgstr ""
 
-#: src/olympia/files/utils.py:439
+#: src/olympia/files/utils.py:436
 msgid "Invalid archive."
 msgstr ""
 
-#: src/olympia/files/utils.py:529 src/olympia/files/utils.py:532
+#: src/olympia/files/utils.py:526 src/olympia/files/utils.py:529
 msgid "Could not parse the manifest file."
 msgstr ""
 
-#: src/olympia/files/utils.py:551
+#: src/olympia/files/utils.py:548
 msgid "Could not find an add-on ID."
 msgstr ""
 
-#: src/olympia/files/utils.py:554
+#: src/olympia/files/utils.py:551
 msgid "Add-on ID must be 64 characters or less."
 msgstr ""
 
-#: src/olympia/files/utils.py:556
+#: src/olympia/files/utils.py:553
 msgid "Add-on ID doesn't match add-on."
 msgstr ""
 
-#: src/olympia/files/utils.py:564
+#: src/olympia/files/utils.py:561
 msgid "Duplicate add-on ID found."
 msgstr ""
 
-#: src/olympia/files/utils.py:567
+#: src/olympia/files/utils.py:564
 msgid "Version numbers should have fewer than 32 characters."
 msgstr ""
 
-#: src/olympia/files/utils.py:570
+#: src/olympia/files/utils.py:567
 msgid "Version numbers should only contain letters, numbers, and these punctuation characters: +*.-_."
 msgstr ""
 
-#: src/olympia/files/utils.py:587
+#: src/olympia/files/utils.py:584
 msgid "<em:type> doesn't match add-on"
 msgstr ""
 
@@ -8523,6 +8384,10 @@ msgstr ""
 
 #: src/olympia/files/templates/files/viewer.html:134
 msgid "Fetching file."
+msgstr ""
+
+#: src/olympia/legacy_api/views.py:255
+msgid "Not implemented yet."
 msgstr ""
 
 #: src/olympia/lib/constants.py:6
@@ -9181,10 +9046,6 @@ msgstr ""
 msgid "Zimbabwe Dollar"
 msgstr ""
 
-#: src/olympia/lib/video/ffmpeg.py:112 src/olympia/lib/video/totem.py:81
-msgid "Videos must be in WebM."
-msgstr ""
-
 #: src/olympia/pages/templates/pages/about.lhtml:3 src/olympia/pages/templates/pages/about.lhtml:10
 msgid "About Mozilla Add-ons"
 msgstr ""
@@ -9196,7 +9057,7 @@ msgstr ""
 #: src/olympia/pages/templates/pages/about.lhtml:13
 msgid ""
 "addons.mozilla.org, commonly known as \"AMO\", is Mozilla's official site for add-ons to Mozilla software, such as Firefox, Thunderbird, and SeaMonkey. Add-ons let you add new features and change "
-"the way your browser or application works.  Take a look around and explore the thousands of ways to customize the way you do things online."
+"the way your browser or application works. Take a look around and explore the thousands of ways to customize the way you do things online."
 msgstr ""
 
 #: src/olympia/pages/templates/pages/about.lhtml:19
@@ -9541,7 +9402,7 @@ msgstr ""
 msgid ""
 "Yes. It's possible, but some of the functionality provided by these libraries are available through XPCOM, XUL, and JavaScript. In addition, authors should take care if libraries modify primitive "
 "object prototypes (String.prototype, Date.prototype, etc.) and/or define global functions (eg. the $ function). These are prone to cause conflict with other add-ons, in particular if different add-"
-"ons use different versions of libraries and so on. Developers need to be very, very careful with using them.  Mozilla does not offer documentation on using them to build add-ons."
+"ons use different versions of libraries and so on. Developers need to be very, very careful with using them. Mozilla does not offer documentation on using them to build add-ons."
 msgstr ""
 
 #: src/olympia/pages/templates/pages/dev_faq.html:165
@@ -9655,8 +9516,8 @@ msgstr ""
 #, python-format
 msgid ""
 "Yes. Many developers choose to host their own add-ons. Choosing to host your add-on on <a href=\"%(amo_url)s\">Mozilla's add-on site</a>, though, allows for much greater exposure to your add-on due "
-"to the large volume of visitors to the site.  <a href=\"%(md_url)s\">mozdev.org</a> offers free project hosting for Mozilla applications and extensions providing developers with tools to help "
-"manage source code, version control, bug tracking and documentation."
+"to the large volume of visitors to the site. <a href=\"%(md_url)s\">mozdev.org</a> offers free project hosting for Mozilla applications and extensions providing developers with tools to help manage "
+"source code, version control, bug tracking and documentation."
 msgstr ""
 
 #: src/olympia/pages/templates/pages/dev_faq.html:277
@@ -9704,7 +9565,7 @@ msgstr ""
 #: src/olympia/pages/templates/pages/dev_faq.html:314
 #, python-format
 msgid ""
-"Yes. Mozilla's <a href=\"%(p_url)s\">Add-on Policy</a> describes what is an acceptable submission. This policy is subject to change without notice.  In addition, the AMO editorial team uses the <a "
+"Yes. Mozilla's <a href=\"%(p_url)s\">Add-on Policy</a> describes what is an acceptable submission. This policy is subject to change without notice. In addition, the AMO editorial team uses the <a "
 "href=\"%(g_url)s\">Editors Reviewing Guide</a> to ensure that your add-on meets specific guidelines for functionality and security."
 msgstr ""
 
@@ -9821,7 +9682,7 @@ msgstr ""
 #: src/olympia/pages/templates/pages/dev_faq.html:434
 #, python-format
 msgid ""
-"This is why it's very important to read the <a href=\"%(g_url)s\">Editors Reviewing Guide</a> to ensure that your add-on is setup as expected.  It's also a good idea to read the blog post, <a href="
+"This is why it's very important to read the <a href=\"%(g_url)s\">Editors Reviewing Guide</a> to ensure that your add-on is setup as expected. It's also a good idea to read the blog post, <a href="
 "\"%(blog_url)s\">Successfully Getting your Add-on Reviewed</a> which provides excellent insight into ensuring a smooth review of your add-on."
 msgstr ""
 
@@ -9928,7 +9789,7 @@ msgstr ""
 
 #: src/olympia/pages/templates/pages/dev_faq.html:572
 msgid ""
-"Free Software Foundation provides short summaries of the key open source licenses, including whether the license qualifies as a free software license or a copyleft license.  Also includes a "
+"Free Software Foundation provides short summaries of the key open source licenses, including whether the license qualifies as a free software license or a copyleft license. Also includes a "
 "discussion of what constitutes a free software license or a copyleft license (e.g., a Copyleft license is a general method for making a program or other work free, and requiring all modified and "
 "extended versions of the program to be free as well.)"
 msgstr ""
@@ -10106,19 +9967,13 @@ msgid "Add-on Gallery"
 msgstr ""
 
 #: src/olympia/pages/templates/pages/faq.html:171
-msgid ""
-"How do I choose between add-ons that seem to do the same\n"
-"    thing?"
+msgid "How do I choose between add-ons that seem to do the same thing?"
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:173
+#: src/olympia/pages/templates/pages/faq.html:172
 msgid ""
-"There are often several add-ons that have similar features. To\n"
-"    figure out which is right for you, read the entire description of the\n"
-"    add-on and view its screenshots. If there are still several in the running,\n"
-"    read through the add-on's ratings, user reviews, and statistics to see\n"
-"    which is most liked by other users. Remember that you can also just try\n"
-"    out both and see which you like better."
+"There are often several add-ons that have similar features. To figure out which is right for you, read the entire description of the add-on and view its screenshots. If there are still several in "
+"the running, read through the add-on's ratings, user reviews, and statistics to see which is most liked by other users. Remember that you can also just try out both and see which you like better."
 msgstr ""
 
 #: src/olympia/pages/templates/pages/faq.html:180
@@ -10159,80 +10014,67 @@ msgid "How much do add-ons cost to purchase?"
 msgstr ""
 
 #: src/olympia/pages/templates/pages/faq.html:207
-msgid ""
-"Add-ons hosted in our gallery are free unless clearly marked\n"
-"    otherwise."
+msgid "Add-ons hosted in our gallery are free unless clearly marked otherwise."
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:210
+#: src/olympia/pages/templates/pages/faq.html:209
 msgid "What does it mean when an add-on asks for contributions?"
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:211
+#: src/olympia/pages/templates/pages/faq.html:210
 msgid ""
-"Some add-on authors request users who enjoy an add-on to\n"
-"        contribute to its development by making a monetary contribution. These\n"
-"        contributions go directly to the developer unless a third party is\n"
-"        indicated, such as the non-profit Mozilla Foundation."
+"Some add-on authors request users who enjoy an add-on to contribute to its development by making a monetary contribution. These contributions go directly to the developer unless a third party is "
+"indicated, such as the non-profit Mozilla Foundation."
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:216
+#: src/olympia/pages/templates/pages/faq.html:215
 msgid "What are beta add-ons?"
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:218
+#: src/olympia/pages/templates/pages/faq.html:217
 msgid ""
-"Beta add-ons are unreviewed versions which represent the\n"
-"        latest work of an add-on author. While different authors have different\n"
-"        standards for beta code quality, you should assume that these add-ons\n"
-"        are less stable than the general add-on releases."
+"Beta add-ons are unreviewed versions which represent the latest work of an add-on author. While different authors have different standards for beta code quality, you should assume that these add-"
+"ons are less stable than the general add-on releases."
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:222
+#: src/olympia/pages/templates/pages/faq.html:221
 msgid ""
 "Please note that when you install an add-on from the \"Beta Version\" section of an add-on's listing, you will continue to receive updates for that add-on as they become available. Like the initial "
 "version you installed, all beta releases are unreviewed by Mozilla and may harm your computer."
 msgstr ""
 
+#: src/olympia/pages/templates/pages/faq.html:228
+msgid "What does it mean when an add-on is flagged as slow?"
+msgstr ""
+
 #: src/olympia/pages/templates/pages/faq.html:229
-msgid ""
-"What does it mean when an add-on is flagged as\n"
-"    slow?"
+msgid "Most add-ons load code and resources at the same time Firefox is starting up. In most cases the impact in start-up time is minimal, but some add-ons can cause a noticeable slowdown."
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:231
-msgid ""
-"Most add-ons load code and resources at the same time Firefox\n"
-"        is starting up. In most cases the impact in start-up time is minimal,\n"
-"        but some add-ons can cause a noticeable slowdown."
-msgstr ""
-
-#: src/olympia/pages/templates/pages/faq.html:236
+#: src/olympia/pages/templates/pages/faq.html:234
 msgid "How do I report an inappropriate or spam user review?"
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:237
+#: src/olympia/pages/templates/pages/faq.html:235
 msgid ""
-"To report a user review of an add-on, log in with your account\n"
-"    and visit the add-on's reviews page. Find the review you wish to report,\n"
-"    click \"Report this review\" and select a reason. Our editorial team will\n"
-"    investigate the review and take appropriate action."
+"To report a user review of an add-on, log in with your account and visit the add-on's reviews page. Find the review you wish to report, click \"Report this review\" and select a reason. Our "
+"editorial team will investigate the review and take appropriate action."
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:242
+#: src/olympia/pages/templates/pages/faq.html:240
 msgid "How do I report a bug or contact the Mozilla Add-ons team?"
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:243
+#: src/olympia/pages/templates/pages/faq.html:241
 #, python-format
 msgid "Please visit our <a href=\"%(contact_url)s\">Contact page</a>."
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:246
+#: src/olympia/pages/templates/pages/faq.html:244
 msgid "What is a Source Code License?"
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:247
+#: src/olympia/pages/templates/pages/faq.html:245
 #, python-format
 msgid ""
 "The source code used to create an add-on is an exclusive copyright of the add-on author, unless otherwise declared in a source code license. Many add-ons on this site have <a href=\"%(url)s\" lang="
@@ -10240,60 +10082,60 @@ msgid ""
 "the GPL or BSD licenses instead of making up their own."
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:256
+#: src/olympia/pages/templates/pages/faq.html:254
 #, python-format
 msgid "Firefox and other Mozilla software are <a href=\"%(url)s\">open source</a>."
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:264
+#: src/olympia/pages/templates/pages/faq.html:262
 msgid "Collections and Favorites"
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:267
+#: src/olympia/pages/templates/pages/faq.html:265
 msgid "What is a collection?"
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:268
+#: src/olympia/pages/templates/pages/faq.html:266
 msgid "Collections are groups of related add-ons created by users to share."
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:270
+#: src/olympia/pages/templates/pages/faq.html:268
 msgid "What is the My Favorites collection?"
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:271
+#: src/olympia/pages/templates/pages/faq.html:269
 msgid "Favorite add-ons are add-ons that you have bookmarked to easily get back to later. You can add an add-on to your favorites collection by clicking \"Add to favorites\" on its details page."
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:275 src/olympia/templates/menu_links.html:13 src/olympia/templates/impala/header_title.html:17
+#: src/olympia/pages/templates/pages/faq.html:273 src/olympia/templates/menu_links.html:13 src/olympia/templates/impala/header_title.html:17
 msgid "Mobile Add-ons"
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:278
+#: src/olympia/pages/templates/pages/faq.html:276
 msgid "What are mobile add-ons?"
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:279
+#: src/olympia/pages/templates/pages/faq.html:277
 #, python-format
 msgid ""
 "Mobile add-ons work with <a href=\"%(mobile_url)s\">Firefox for Mobile</a> and add or modify functionality just like desktop add-ons. You can find add-ons that work with Firefox for Mobile in our "
 "<a href=\"%(gallery_url)s\">gallery</a>."
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:288
+#: src/olympia/pages/templates/pages/faq.html:286
 msgid "Developer Topics"
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:289
+#: src/olympia/pages/templates/pages/faq.html:287
 #, python-format
 msgid "Please see our <a href=\"%(faq_url)s\">Developer FAQ</a> and <a href=\"%(hub_url)s\">Developer Hub</a> for answers to add-on developer-related questions."
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:294
+#: src/olympia/pages/templates/pages/faq.html:292
 msgid "Still have questions?"
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:295
+#: src/olympia/pages/templates/pages/faq.html:293
 #, python-format
 msgid "For general Firefox support, visit our <a href=\"%(sumo_url)s\">support website</a>. For general add-on and website questions, visit our <a href=\"%(forum_url)s\">forum</a>."
 msgstr ""
@@ -10431,7 +10273,7 @@ msgstr ""
 
 #: src/olympia/pages/templates/pages/sunbird.html:29
 msgid ""
-"Development on the Sunbird project has halted and its final release was on March 30, 2010.  We've been proud to host Sunbird add-ons on this site but as the project is no longer maintained we have "
+"Development on the Sunbird project has halted and its final release was on March 30, 2010. We've been proud to host Sunbird add-ons on this site but as the project is no longer maintained we have "
 "disabled our support for the add-ons."
 msgstr ""
 
@@ -10509,7 +10351,7 @@ msgstr ""
 #, python-format
 msgid ""
 "<h2>Keep these tips in mind:</h2> <ul> <li> Write like you're telling a friend about your experience with the add-on. Give specifics and helpful details, such as what features you liked and/or "
-"disliked, how easy to use it is, and any disadvantages it has.  Avoid generic language such as calling it \"Great\" or \"Bad\" unless you can give reasons why you believe this is so. </li> <li> "
+"disliked, how easy to use it is, and any disadvantages it has. Avoid generic language such as calling it \"Great\" or \"Bad\" unless you can give reasons why you believe this is so. </li> <li> "
 "Please do not post bug reports in reviews. We do not make your email address available to add-on developers and they may need to contact you to help resolve your issue. See the <a href=\"%(support)s"
 "\">support section</a> to find out where to get assistance for this add-on. </li> <li>Please keep reviews clean, avoid the use of improper language and do not post any personal information. </li> </"
 "ul> <p>Please read the <a href=\"%(guide)s\" target=\"_blank\">Review Guidelines</a> for more detail about user add-on reviews.</p>"
@@ -10745,16 +10587,16 @@ msgstr ""
 
 #. L10n: {0} is an application, such as Firefox. This means "any version of
 #. Firefox."
-#: src/olympia/search/views.py:554
+#: src/olympia/search/views.py:547
 msgid "Any {0}"
 msgstr ""
 
 #. L10n: "All Systems" means show everything regardless of platform.
-#: src/olympia/search/views.py:589
+#: src/olympia/search/views.py:582
 msgid "All Systems"
 msgstr ""
 
-#: src/olympia/search/views.py:600
+#: src/olympia/search/views.py:593
 msgid "All Tags"
 msgstr ""
 
@@ -10928,31 +10770,31 @@ msgstr ""
 msgid "Share this Collection"
 msgstr ""
 
-#: src/olympia/signing/views.py:30 src/olympia/templates/base.html:75 src/olympia/templates/impala/base.html:115
+#: src/olympia/signing/views.py:33 src/olympia/templates/base.html:71 src/olympia/templates/impala/base.html:112
 msgid "Some features are temporarily disabled while we perform website maintenance. We'll be back to full capacity shortly."
 msgstr ""
 
-#: src/olympia/signing/views.py:53
+#: src/olympia/signing/views.py:56
 msgid "Could not find add-on with id \"{}\"."
 msgstr ""
 
-#: src/olympia/signing/views.py:67
+#: src/olympia/signing/views.py:70
 msgid "You do not own this addon."
 msgstr ""
 
-#: src/olympia/signing/views.py:82
+#: src/olympia/signing/views.py:87
 msgid "Missing \"upload\" key in multipart file data."
 msgstr ""
 
-#: src/olympia/signing/views.py:96
+#: src/olympia/signing/views.py:101
 msgid "Version does not match the manifest file."
 msgstr ""
 
-#: src/olympia/signing/views.py:100
+#: src/olympia/signing/views.py:105
 msgid "Version already exists."
 msgstr ""
 
-#: src/olympia/signing/views.py:136
+#: src/olympia/signing/views.py:141
 msgid "No uploaded file for that addon and version."
 msgstr ""
 
@@ -11065,89 +10907,89 @@ msgstr ""
 msgid "Statistics Dashboard :: Add-ons for {0}"
 msgstr ""
 
-#: src/olympia/stats/templates/stats/stats.html:30
-msgid "Controls:"
-msgstr ""
-
-#: src/olympia/stats/templates/stats/stats.html:33
-msgid "reset zoom"
-msgstr ""
-
-#: src/olympia/stats/templates/stats/stats.html:40
-msgid "Group by:"
-msgstr ""
-
-#: src/olympia/stats/templates/stats/stats.html:42
-msgid "day"
-msgstr ""
-
-#: src/olympia/stats/templates/stats/stats.html:45
-msgid "week"
-msgstr ""
-
-#: src/olympia/stats/templates/stats/stats.html:48
-msgid "month"
-msgstr ""
-
-#: src/olympia/stats/templates/stats/stats.html:54
-msgid "For last:"
-msgstr ""
-
-#: src/olympia/stats/templates/stats/stats.html:57
-msgid "7 days"
-msgstr ""
-
-#: src/olympia/stats/templates/stats/stats.html:60
-msgid "30 days"
-msgstr ""
-
-#: src/olympia/stats/templates/stats/stats.html:63
-msgid "90 days"
-msgstr ""
-
-#: src/olympia/stats/templates/stats/stats.html:66
-msgid "365 days"
-msgstr ""
-
-#: src/olympia/stats/templates/stats/stats.html:69
-msgid "Custom..."
-msgstr ""
-
 #. {0} is an add-on name
-#: src/olympia/stats/templates/stats/stats.html:88 src/olympia/stats/templates/stats/stats.html:91
+#: src/olympia/stats/templates/stats/stats.html:44 src/olympia/stats/templates/stats/stats.html:47
 msgid "Statistics for {0}"
 msgstr ""
 
-#: src/olympia/stats/templates/stats/stats.html:94
+#: src/olympia/stats/templates/stats/stats.html:50
 msgid "Statistics Dashboard"
 msgstr ""
 
-#: src/olympia/stats/templates/stats/stats.html:104
+#: src/olympia/stats/templates/stats/stats.html:57
+msgid "Controls:"
+msgstr ""
+
+#: src/olympia/stats/templates/stats/stats.html:60
+msgid "reset zoom"
+msgstr ""
+
+#: src/olympia/stats/templates/stats/stats.html:67
+msgid "Group by:"
+msgstr ""
+
+#: src/olympia/stats/templates/stats/stats.html:69
+msgid "day"
+msgstr ""
+
+#: src/olympia/stats/templates/stats/stats.html:72
+msgid "week"
+msgstr ""
+
+#: src/olympia/stats/templates/stats/stats.html:75
+msgid "month"
+msgstr ""
+
+#: src/olympia/stats/templates/stats/stats.html:81
+msgid "For last:"
+msgstr ""
+
+#: src/olympia/stats/templates/stats/stats.html:84
+msgid "7 days"
+msgstr ""
+
+#: src/olympia/stats/templates/stats/stats.html:87
+msgid "30 days"
+msgstr ""
+
+#: src/olympia/stats/templates/stats/stats.html:90
+msgid "90 days"
+msgstr ""
+
+#: src/olympia/stats/templates/stats/stats.html:93
+msgid "365 days"
+msgstr ""
+
+#: src/olympia/stats/templates/stats/stats.html:96
+msgid "Custom..."
+msgstr ""
+
+#: src/olympia/stats/templates/stats/stats.html:106
 msgid "Statistics processing is currently disabled, so recent data is unavailable. The statistics are still being collected and this page will be updated soon with the missing data."
 msgstr ""
 
-#: src/olympia/stats/templates/stats/stats.html:110
+#: src/olympia/stats/templates/stats/stats.html:112
 msgid "Loading the latest data&hellip;"
 msgstr ""
 
-#: src/olympia/stats/templates/stats/stats.html:142 src/olympia/stats/templates/stats/reports/overview.html:25 src/olympia/stats/templates/stats/reports/overview.html:37
+#: src/olympia/stats/templates/stats/stats.html:144 src/olympia/stats/templates/stats/reports/overview.html:25 src/olympia/stats/templates/stats/reports/overview.html:37
 #: src/olympia/stats/templates/stats/reports/overview.html:49
 msgid "No data available."
 msgstr ""
 
-#: src/olympia/stats/templates/stats/stats.html:177
+#: src/olympia/stats/templates/stats/stats.html:179
 msgid "This dashboard is currently <b>public</b>."
 msgstr ""
 
-#: src/olympia/stats/templates/stats/stats.html:179
+#: src/olympia/stats/templates/stats/stats.html:181
 msgid "Contribution stats are currently <b>private</b>."
 msgstr ""
 
-#: src/olympia/stats/templates/stats/stats.html:182
+#: src/olympia/stats/templates/stats/stats.html:184
 msgid "This dashboard is currently <b>private</b>."
 msgstr ""
 
-#: src/olympia/stats/templates/stats/stats.html:185
+#: src/olympia/stats/templates/stats/stats.html:187
 msgid "Change settings."
 msgstr ""
 
@@ -11299,15 +11141,6 @@ msgstr ""
 msgid "Application versions by Date"
 msgstr ""
 
-#: src/olympia/tags/templates/tags/top_cloud.html:4
-msgid "Top {0} Tags"
-msgstr ""
-
-#. {0} is the current application name
-#: src/olympia/tags/templates/tags/top_cloud.html:14
-msgid "{0} Top Tags"
-msgstr ""
-
 #: src/olympia/templates/amo_footer.html:6 src/olympia/templates/includes/lang_switcher.html:2
 msgid "Other languages"
 msgstr ""
@@ -11316,11 +11149,11 @@ msgstr ""
 msgid "Mozilla Add-ons"
 msgstr ""
 
-#: src/olympia/templates/base.html:91 src/olympia/templates/impala/base.html:81
+#: src/olympia/templates/base.html:89 src/olympia/templates/impala/base.html:78
 msgid "Find add-ons for other applications"
 msgstr ""
 
-#: src/olympia/templates/base.html:92 src/olympia/templates/impala/base.html:81
+#: src/olympia/templates/base.html:90 src/olympia/templates/impala/base.html:78
 msgid "Other Applications"
 msgstr ""
 
@@ -11345,7 +11178,7 @@ msgid "View Mobile Site"
 msgstr ""
 
 #: src/olympia/templates/copyright.html:7
-msgid "Site Status "
+msgid "Site Status"
 msgstr ""
 
 #: src/olympia/templates/footer.html:3
@@ -11445,35 +11278,35 @@ msgstr ""
 msgid "<a href=\"%(reg)s\">Register</a> or <a href=\"%(login)s\">Log in</a>"
 msgstr ""
 
-#: src/olympia/templates/impala/base.html:126
+#: src/olympia/templates/impala/base.html:123
 #, python-format
 msgid "To try the thousands of add-ons available here, download <a href=\"%(url)s\">Mozilla Firefox</a>, a fast, free way to surf the Web!"
 msgstr ""
 
-#: src/olympia/templates/impala/base.html:138
+#: src/olympia/templates/impala/base.html:135
 #, python-format
 msgid "Add-ons is switching to Firefox Accounts for login. <a href=\"%(url)s\" class=\"fxa-login\">Sign in now to transfer your account.</a>"
 msgstr ""
 
 #. {0} is an application, such as Firefox.
-#: src/olympia/templates/impala/base.html:148
+#: src/olympia/templates/impala/base.html:145
 msgid "Welcome to {0} Add-ons."
 msgstr ""
 
-#: src/olympia/templates/impala/base.html:151
+#: src/olympia/templates/impala/base.html:148
 msgid "Choose from thousands of extra features and styles to make Firefox your own."
 msgstr ""
 
-#: src/olympia/templates/impala/base.html:156
+#: src/olympia/templates/impala/base.html:153
 #, python-format
 msgid "Add extra features and styles to make %(app)s your own."
 msgstr ""
 
-#: src/olympia/templates/impala/base.html:164
+#: src/olympia/templates/impala/base.html:161
 msgid "On the go?"
 msgstr ""
 
-#: src/olympia/templates/impala/base.html:166
+#: src/olympia/templates/impala/base.html:163
 msgid "Check out our <a class=\"mobile-link\" href=\"#\">Mobile Add-ons site</a>."
 msgstr ""
 
@@ -11697,19 +11530,19 @@ msgstr ""
 
 #. L10n: {id} will be something like "13ad6a", just a random number
 #. to differentiate this user from other anonymous users.
-#: src/olympia/users/models.py:353
+#: src/olympia/users/models.py:362
 msgid "Anonymous user {id}"
 msgstr ""
 
-#: src/olympia/users/models.py:410
+#: src/olympia/users/models.py:419
 msgid "Your account has been restricted"
 msgstr ""
 
-#: src/olympia/users/models.py:480
+#: src/olympia/users/models.py:489
 msgid "Please confirm your email address"
 msgstr ""
 
-#: src/olympia/users/models.py:506
+#: src/olympia/users/models.py:515
 msgid "My Mobile Add-ons"
 msgstr ""
 
@@ -11986,7 +11819,7 @@ msgstr ""
 
 #: src/olympia/users/templates/users/edit.html:70
 #, python-format
-msgid "Change your password.  If you forgot your password, you can <a href=\"%(reset_url)s\">use the reset form</a>."
+msgid "Change your password. If you forgot your password, you can <a href=\"%(reset_url)s\">use the reset form</a>."
 msgstr ""
 
 #: src/olympia/users/templates/users/edit.html:76
@@ -12006,7 +11839,7 @@ msgid "Profile"
 msgstr ""
 
 #: src/olympia/users/templates/users/edit.html:100
-msgid "Give us a bit more information about yourself.  All these fields are optional, but they'll help other users get to know you better."
+msgid "Give us a bit more information about yourself. All these fields are optional, but they'll help other users get to know you better."
 msgstr ""
 
 #: src/olympia/users/templates/users/edit.html:124
@@ -12222,7 +12055,7 @@ msgid "Confirm password"
 msgstr ""
 
 #: src/olympia/users/templates/users/pwreset_confirm.html:47
-msgid "The password reset link was invalid, possibly because it has already been used.  Please request a new password reset."
+msgid "The password reset link was invalid, possibly because it has already been used. Please request a new password reset."
 msgstr ""
 
 #: src/olympia/users/templates/users/pwreset_request.html:15
@@ -12408,7 +12241,7 @@ msgstr ""
 
 #: src/olympia/users/templates/users/unsubscribe.html:30
 #, python-format
-msgid "Unfortunately, we weren't able to unsubscribe you.  The link you clicked is invalid. However, you can unsubscribe still unsubscribe on your <a href=\"%(edit_url)s\">edit profile page</a>."
+msgid "Unfortunately, we weren't able to unsubscribe you. The link you clicked is invalid. However, you can unsubscribe still unsubscribe on your <a href=\"%(edit_url)s\">edit profile page</a>."
 msgstr ""
 
 #: src/olympia/users/templates/users/vcard.html:2
@@ -12462,15 +12295,15 @@ msgstr ""
 msgid "Version History with Changelogs"
 msgstr ""
 
-#: src/olympia/versions/models.py:314
+#: src/olympia/versions/models.py:313
 msgid "Add-on uses binary components."
 msgstr ""
 
-#: src/olympia/versions/models.py:317
+#: src/olympia/versions/models.py:316
 msgid "Add-on has opted into strict compatibility checking."
 msgstr ""
 
-#: src/olympia/versions/models.py:715
+#: src/olympia/versions/models.py:711
 msgid "{app} {min} and later"
 msgstr ""
 
@@ -12545,4 +12378,8 @@ msgstr ""
 
 #: src/olympia/zadmin/forms.py:105
 msgid "Log emails instead of sending"
+msgstr ""
+
+#: src/olympia/zadmin/forms.py:215
+msgid "Deleted versions can`t be changed."
 msgstr ""

--- a/locale/et/LC_MESSAGES/djangojs.po
+++ b/locale/et/LC_MESSAGES/djangojs.po
@@ -1,1216 +1,1236 @@
-
 #, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2016-02-24 21:23+0000\n"
+"POT-Creation-Date: 2016-04-18 15:47+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
+"Language: \n"
 "MIME-Version: 1.0\n"
-"Content-Type: text/plain; charset=utf-8\n"
+"Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Generated-By: Babel 2.2.0\n"
 
-#: static/js/common/ratingwidget.js:31
+#: static/js/common-all.js:1426 static/js/impala-all.js:1511 static/js/zamboni/discovery-all.js:12598 static/js/zamboni/init.js:28 static/js/zamboni/mobile-all.js:14945
+msgid "This feature is temporarily disabled while we perform website maintenance. Please check back a little later."
+msgstr ""
+
+#. L10n: {0} is an app name like Firefox.
+#: static/js/common-all.js:1837 static/js/impala-all.js:1922 static/js/zamboni/buttons.js:73 static/js/zamboni/discovery-all.js:13108
+msgid "Accept and Install"
+msgstr ""
+
+#: static/js/common-all.js:1837 static/js/impala-all.js:1922 static/js/zamboni/buttons.js:73 static/js/zamboni/discovery-all.js:13108
+msgid "Add to {0}"
+msgstr ""
+
+#: static/js/common-all.js:1842 static/js/impala-all.js:1927 static/js/zamboni/buttons.js:78 static/js/zamboni/discovery-all.js:13113
+msgid "Download Now"
+msgstr ""
+
+#: static/js/common-all.js:1883 static/js/impala-all.js:1968 static/js/zamboni/buttons.js:119 static/js/zamboni/discovery-all.js:13154
+msgid "Add-on has not been updated to support default-to-compatible."
+msgstr ""
+
+#: static/js/common-all.js:1888 static/js/impala-all.js:1973 static/js/zamboni/buttons.js:124 static/js/zamboni/discovery-all.js:13159
+msgid "You need to be using Firefox 10.0 or higher."
+msgstr ""
+
+#: static/js/common-all.js:1900 static/js/impala-all.js:1985 static/js/zamboni/buttons.js:136 static/js/zamboni/discovery-all.js:13171
+msgid "Mozilla has marked this version as incompatible with your Firefox version."
+msgstr ""
+
+#. L10n: {0} is an platform like Windows or Linux.
+#: static/js/common-all.js:1981 static/js/impala-all.js:2066 static/js/zamboni/buttons.js:217 static/js/zamboni/discovery-all.js:13252
+msgid "Install for {0} anyway"
+msgstr ""
+
+#: static/js/common-all.js:1981 static/js/impala-all.js:2066 static/js/zamboni/buttons.js:217 static/js/zamboni/discovery-all.js:13252
+msgid "Download for {0} anyway"
+msgstr ""
+
+#: static/js/common-all.js:2038 static/js/impala-all.js:2123 static/js/zamboni/buttons.js:274 static/js/zamboni/discovery-all.js:13309
+msgid "Not available for your platform"
+msgstr ""
+
+#. L10n: {0} is an app name, {1} is the app version.
+#: static/js/common-all.js:2049 static/js/common-all.js:2086 static/js/impala-all.js:2134 static/js/impala-all.js:2171 static/js/zamboni/buttons.js:286 static/js/zamboni/buttons.js:324
+#: static/js/zamboni/discovery-all.js:13320 static/js/zamboni/discovery-all.js:13357
+msgid "Not available for {0} {1}"
+msgstr ""
+
+#: static/js/common-all.js:2112 static/js/impala-all.js:2197 static/js/zamboni/buttons.js:351 static/js/zamboni/discovery-all.js:13383
+msgid "Works with {app} {min} - {max}"
+msgstr ""
+
+#: static/js/common-all.js:2114 static/js/impala-all.js:2199 static/js/zamboni/buttons.js:353 static/js/zamboni/discovery-all.js:13385
+msgid "View other versions"
+msgstr ""
+
+#: static/js/common-all.js:2162 static/js/impala-all.js:2247 static/js/zamboni/buttons.js:401 static/js/zamboni/discovery-all.js:13433
+msgid "Only with Firefox — Get Firefox Now!"
+msgstr ""
+
+#: static/js/common-all.js:2278 static/js/impala-all.js:2363 static/js/zamboni/buttons.js:517 static/js/zamboni/discovery-all.js:13549 static/js/zamboni/mobile-all.js:15177
+#: static/js/zamboni/mobile/buttons.js:43
+msgid "Sorry, you need a Mozilla-based browser (such as Firefox) to install a search plugin."
+msgstr ""
+
+#: static/js/common-all.js:9088 static/js/impala-all.js:9649 static/js/zamboni/global.js:410
+msgid "Loading..."
+msgstr ""
+
+#. L10n: {0} is the number of characters left.
+#: static/js/common-all.js:9152 static/js/impala-all.js:9713 static/js/zamboni/global.js:474
+msgid "<b>{0}</b> character left."
+msgid_plural "<b>{0}</b> characters left."
+msgstr[0] ""
+msgstr[1] ""
+
+#: static/js/common-all.js:9589 static/js/common-min.js:6 static/js/impala-all.js:10052 static/js/impala-min.js:6 static/js/common/ratingwidget.js:31 static/js/zamboni/mobile-all.js:16123
+#: static/js/zamboni/mobile-min.js:6
 msgid "{0} star"
 msgid_plural "{0} stars"
 msgstr[0] ""
 msgstr[1] ""
 
-#: static/js/common/upload-addon.js:41 static/js/common/upload-image.js:128
+#: static/js/common-all.js:9676 static/js/common-min.js:6 static/js/impala-all.js:10139 static/js/impala-min.js:6 static/js/zamboni/l10n.js:45
+msgid "Remove this localization"
+msgstr ""
+
+#: static/js/common-all.js:10193 static/js/common-min.js:6 static/js/impala-all.js:10674 static/js/impala-min.js:6 static/js/zamboni/discovery-all.js:13678
+msgid "close"
+msgstr ""
+
+#: static/js/common-all.js:10860 static/js/common-min.js:6 static/js/impala-all.js:11481 static/js/impala-min.js:6 static/js/impala/reviews.js:23 static/js/zamboni/reviews.js:18
+msgid "Flagged for review"
+msgstr ""
+
+#: static/js/common-all.js:10876 static/js/common-min.js:6 static/js/impala-all.js:11498 static/js/impala-min.js:6 static/js/impala/reviews.js:40 static/js/zamboni/reviews.js:34
+msgid "Your input is required"
+msgstr ""
+
+#: static/js/common-all.js:10945 static/js/common-min.js:6 static/js/impala-all.js:11610 static/js/impala-min.js:7 static/js/impala/reviews.js:152 static/js/zamboni/reviews.js:103
+msgid "Marked for deletion"
+msgstr ""
+
+#: static/js/common-all.js:11573 static/js/common-min.js:7 static/js/impala-all.js:13809 static/js/impala-min.js:8 static/js/zamboni/collections.js:229
+msgid "Adding to Favorites&hellip;"
+msgstr ""
+
+#: static/js/common-all.js:11576 static/js/common-min.js:7 static/js/impala-all.js:13812 static/js/impala-min.js:8 static/js/zamboni/collections.js:232
+msgid "Removing Favorite&hellip;"
+msgstr ""
+
+#: static/js/common-all.js:11579 static/js/common-min.js:7 static/js/impala-all.js:13815 static/js/impala-min.js:8 static/js/zamboni/collections.js:235
+msgid "Add to Favorites"
+msgstr ""
+
+#: static/js/common-all.js:11582 static/js/common-min.js:7 static/js/impala-all.js:13818 static/js/impala-min.js:8 static/js/zamboni/collections.js:238
+msgid "Remove from Favorites"
+msgstr ""
+
+#: static/js/common-all.js:11647 static/js/common-min.js:7 static/js/impala-all.js:13883 static/js/impala-min.js:8 static/js/zamboni/collections.js:303
+msgid "Pending"
+msgstr ""
+
+#: static/js/common-all.js:11648 static/js/common-min.js:7 static/js/impala-all.js:13884 static/js/impala-min.js:8 static/js/zamboni/collections.js:304
+msgid "Add a comment"
+msgstr ""
+
+#: static/js/common-all.js:11648 static/js/common-min.js:7 static/js/impala-all.js:13884 static/js/impala-min.js:8 static/js/zamboni/collections.js:304
+msgid "Comment"
+msgstr ""
+
+#: static/js/common-all.js:11649 static/js/common-min.js:7 static/js/impala-all.js:13885 static/js/impala-min.js:8 static/js/zamboni/collections.js:305
+msgid "Remove this add-on from the collection"
+msgstr ""
+
+#: static/js/common-all.js:11649 static/js/common-all.js:11678 static/js/common-min.js:7 static/js/impala-all.js:13885 static/js/impala-all.js:13914 static/js/impala-min.js:8
+#: static/js/zamboni/collections.js:305 static/js/zamboni/collections.js:334
+msgid "Remove"
+msgstr ""
+
+#: static/js/common-all.js:11678 static/js/common-min.js:7 static/js/impala-all.js:13914 static/js/impala-min.js:8 static/js/zamboni/collections.js:334
+msgid "Remove this user as a contributor"
+msgstr ""
+
+#: static/js/common-all.js:11690 static/js/common-min.js:7 static/js/impala-all.js:13926 static/js/impala-min.js:8 static/js/zamboni/collections.js:346
+msgid "An email address is required."
+msgstr ""
+
+#: static/js/common-all.js:11708 static/js/common-min.js:7 static/js/impala-all.js:13944 static/js/impala-min.js:8 static/js/zamboni/collections.js:364
+msgid "You cannot add yourself as a contributor."
+msgstr ""
+
+#: static/js/common-all.js:11710 static/js/common-min.js:7 static/js/impala-all.js:13946 static/js/impala-min.js:8 static/js/zamboni/collections.js:366
+msgid "You have already added that user."
+msgstr ""
+
+#: static/js/common-all.js:11917 static/js/common-min.js:7 static/js/impala-all.js:14153 static/js/impala-min.js:8 static/js/zamboni/collections.js:573
+msgid "Add to favorites"
+msgstr ""
+
+#: static/js/common-all.js:11921 static/js/common-min.js:7 static/js/impala-all.js:14157 static/js/impala-min.js:8 static/js/zamboni/collections.js:577
+msgid "Remove from favorites"
+msgstr ""
+
+#: static/js/common-all.js:11939 static/js/common-min.js:7 static/js/impala-all.js:14175 static/js/impala-all.js:14233 static/js/impala-min.js:8 static/js/impala/collections.js:10
+#: static/js/zamboni/collections.js:595
+msgid "Follow this Collection"
+msgstr ""
+
+#: static/js/common-all.js:11948 static/js/common-min.js:7 static/js/impala-all.js:14184 static/js/impala-min.js:8 static/js/zamboni/collections.js:604
+msgid "Stop following"
+msgstr ""
+
+#: static/js/common-all.js:12096 static/js/common-min.js:7 static/js/zamboni/password-strength.js:20
+msgid "Password strength:"
+msgstr ""
+
+#: static/js/common-all.js:12102 static/js/common-min.js:7 static/js/zamboni/password-strength.js:26
+msgid "At least {0} character left."
+msgid_plural "At least {0} characters left."
+msgstr[0] ""
+msgstr[1] ""
+
+#: static/js/common-all.js:12286 static/js/common-min.js:7 static/js/impala-all.js:14632 static/js/impala-min.js:8 static/js/impala/suggestions.js:39
+msgid "Search themes for <b>{0}</b>"
+msgstr ""
+
+#: static/js/common-all.js:12288 static/js/common-min.js:7 static/js/impala-all.js:14634 static/js/impala-min.js:8 static/js/impala/suggestions.js:41
+msgid "Search apps for <b>{0}</b>"
+msgstr ""
+
+#: static/js/common-all.js:12290 static/js/common-min.js:7 static/js/impala-all.js:14636 static/js/impala-min.js:8 static/js/impala/suggestions.js:43
+msgid "Search add-ons for <b>{0}</b>"
+msgstr ""
+
+#: static/js/common-all.js:12521 static/js/common-min.js:7 static/js/impala-all.js:14867 static/js/impala-min.js:8 static/js/impala/site_suggestions.js:46
+msgid "Category"
+msgstr ""
+
+#. L10n: {0} is an app name.
+#: static/js/impala-all.js:11632 static/js/impala-min.js:7 static/js/impala/listing.js:11 static/js/zamboni/themes.js:13
+msgid "This theme is incompatible with your version of {0}"
+msgstr ""
+
+#: static/js/impala-all.js:12146 static/js/impala-all.js:14331 static/js/impala-min.js:7 static/js/impala-min.js:8 static/js/common/upload-image.js:97 static/js/impala/users.js:51
+#: static/js/zamboni/devhub-all.js:894 static/js/zamboni/devhub-min.js:1
+msgid "Images must be either PNG or JPG."
+msgstr ""
+
+#: static/js/impala-all.js:12150 static/js/impala-min.js:7 static/js/common/upload-image.js:101 static/js/zamboni/devhub-all.js:898 static/js/zamboni/devhub-min.js:1
+msgid "Videos must be in WebM."
+msgstr ""
+
+#: static/js/impala-all.js:12177 static/js/impala-min.js:7 static/js/common/upload-addon.js:41 static/js/common/upload-image.js:128 static/js/zamboni/devhub-all.js:272
+#: static/js/zamboni/devhub-all.js:925 static/js/zamboni/devhub-min.js:1
 msgid "There was a problem contacting the server."
 msgstr ""
 
-#: static/js/common/upload-addon.js:69
+#: static/js/impala-all.js:13298 static/js/impala-min.js:7 static/js/impala/persona_creation.js:60
+msgid "All Rights Reserved"
+msgstr ""
+
+#: static/js/impala-all.js:13302 static/js/impala-min.js:7 static/js/impala/persona_creation.js:64
+msgid "Creative Commons Attribution 3.0"
+msgstr ""
+
+#: static/js/impala-all.js:13307 static/js/impala-min.js:7 static/js/impala/persona_creation.js:69
+msgid "Creative Commons Attribution-NonCommercial 3.0"
+msgstr ""
+
+#: static/js/impala-all.js:13312 static/js/impala-min.js:7 static/js/impala/persona_creation.js:74
+msgid "Creative Commons Attribution-NonCommercial-NoDerivs 3.0"
+msgstr ""
+
+#: static/js/impala-all.js:13317 static/js/impala-min.js:7 static/js/impala/persona_creation.js:79
+msgid "Creative Commons Attribution-NonCommercial-Share Alike 3.0"
+msgstr ""
+
+#: static/js/impala-all.js:13322 static/js/impala-min.js:7 static/js/impala/persona_creation.js:84
+msgid "Creative Commons Attribution-NoDerivs 3.0"
+msgstr ""
+
+#: static/js/impala-all.js:13327 static/js/impala-min.js:7 static/js/impala/persona_creation.js:89
+msgid "Creative Commons Attribution-ShareAlike 3.0"
+msgstr ""
+
+#: static/js/impala-all.js:13530 static/js/impala-min.js:7 static/js/impala/persona_creation.js:292
+msgid "Your Theme's Name"
+msgstr ""
+
+#: static/js/impala-all.js:14242 static/js/impala-min.js:8 static/js/impala/collections.js:19
+msgid "Stop Following"
+msgstr ""
+
+#: static/js/impala-all.js:14243 static/js/impala-min.js:8 static/js/impala/collections.js:20
+msgid "Following"
+msgstr ""
+
+#: static/js/impala-all.js:14313 static/js/impala-min.js:8 static/js/impala/users.js:33
+msgid "use original"
+msgstr ""
+
+#: static/js/impala-all.js:14523 static/js/impala-min.js:8 static/js/impala/search.js:114
+msgid "Updating results&hellip;"
+msgstr ""
+
+#: static/js/common/upload-addon.js:69 static/js/zamboni/devhub-all.js:300 static/js/zamboni/devhub-min.js:1
 msgid "Select a file..."
 msgstr ""
 
-#: static/js/common/upload-addon.js:70
+#: static/js/common/upload-addon.js:70 static/js/zamboni/devhub-all.js:301 static/js/zamboni/devhub-min.js:1
 msgid "Your add-on should end with .xpi, .jar or .xml"
 msgstr ""
 
 #. L10n: {0} is the percent of the file that has been uploaded.
-#: static/js/common/upload-addon.js:104
+#: static/js/common/upload-addon.js:104 static/js/zamboni/devhub-all.js:335 static/js/zamboni/devhub-min.js:1
 #, python-format
 msgid "{0}% complete"
 msgstr ""
 
 #. L10n: "{bytes uploaded} of {total filesize}".
-#: static/js/common/upload-addon.js:107
+#: static/js/common/upload-addon.js:107 static/js/zamboni/devhub-all.js:338 static/js/zamboni/devhub-min.js:1
 msgid "{0} of {1}"
 msgstr ""
 
-#: static/js/common/upload-addon.js:140
+#: static/js/common/upload-addon.js:140 static/js/zamboni/devhub-all.js:371 static/js/zamboni/devhub-min.js:1
 msgid "Cancel"
 msgstr ""
 
-#: static/js/common/upload-addon.js:162
+#: static/js/common/upload-addon.js:162 static/js/zamboni/devhub-all.js:393 static/js/zamboni/devhub-min.js:1
 msgid "Uploading {0}"
 msgstr ""
 
-#: static/js/common/upload-addon.js:189
+#: static/js/common/upload-addon.js:189 static/js/zamboni/devhub-all.js:420 static/js/zamboni/devhub-min.js:1
 msgid "Error with {0}"
 msgstr ""
 
-#: static/js/common/upload-addon.js:194
+#: static/js/common/upload-addon.js:194 static/js/zamboni/devhub-all.js:425 static/js/zamboni/devhub-min.js:1
 msgid "Your add-on failed validation with {0} error."
 msgid_plural "Your add-on failed validation with {0} errors."
 msgstr[0] ""
 msgstr[1] ""
 
-#: static/js/common/upload-addon.js:208
+#: static/js/common/upload-addon.js:208 static/js/zamboni/devhub-all.js:439 static/js/zamboni/devhub-min.js:1
 msgid "&hellip;and {0} more"
 msgid_plural "&hellip;and {0} more"
 msgstr[0] ""
 msgstr[1] ""
 
-#: static/js/common/upload-addon.js:222 static/js/common/upload-addon.js:512
+#: static/js/common/upload-addon.js:222 static/js/common/upload-addon.js:497 static/js/zamboni/devhub-all.js:453 static/js/zamboni/devhub-all.js:743 static/js/zamboni/devhub-min.js:1
 msgid "See full validation report"
 msgstr ""
 
-#: static/js/common/upload-addon.js:234
+#: static/js/common/upload-addon.js:234 static/js/zamboni/devhub-all.js:465 static/js/zamboni/devhub-min.js:1
 msgid "Validating {0}"
 msgstr ""
 
 #. L10n: first argument is an HTTP status code
-#: static/js/common/upload-addon.js:273
+#: static/js/common/upload-addon.js:273 static/js/zamboni/devhub-all.js:504 static/js/zamboni/devhub-min.js:1
 msgid "Received an empty response from the server; status: {0}"
 msgstr ""
 
-#: static/js/common/upload-addon.js:373
+#: static/js/common/upload-addon.js:370 static/js/zamboni/devhub-all.js:604 static/js/zamboni/devhub-min.js:1
 msgid "Unexpected server error while validating."
 msgstr ""
 
-#: static/js/common/upload-addon.js:412
+#: static/js/common/upload-addon.js:409 static/js/zamboni/devhub-all.js:643 static/js/zamboni/devhub-min.js:1
 msgid "Finished validating {0}"
 msgstr ""
 
-#: static/js/common/upload-addon.js:418
+#: static/js/common/upload-addon.js:415 static/js/zamboni/devhub-all.js:649 static/js/zamboni/devhub-min.js:1
 msgid "Your add-on validation timed out, it will be manually reviewed."
 msgstr ""
 
-#: static/js/common/upload-addon.js:421
+#: static/js/common/upload-addon.js:418 static/js/zamboni/devhub-all.js:652 static/js/zamboni/devhub-min.js:1
 msgid "Your add-on was validated with no errors and {0} warning."
 msgid_plural "Your add-on was validated with no errors and {0} warnings."
 msgstr[0] ""
 msgstr[1] ""
 
-#: static/js/common/upload-addon.js:426
+#: static/js/common/upload-addon.js:423 static/js/zamboni/devhub-all.js:657 static/js/zamboni/devhub-min.js:1
 msgid "Your add-on was validated with no errors and {0} message."
 msgid_plural "Your add-on was validated with no errors and {0} messages."
 msgstr[0] ""
 msgstr[1] ""
 
-#: static/js/common/upload-addon.js:431
+#: static/js/common/upload-addon.js:428 static/js/zamboni/devhub-all.js:662 static/js/zamboni/devhub-min.js:1
 msgid "Your add-on was validated with no errors or warnings."
 msgstr ""
 
-#: static/js/common/upload-addon.js:446
+#: static/js/common/upload-addon.js:443 static/js/zamboni/devhub-all.js:677 static/js/zamboni/devhub-min.js:1
 msgid "Your submission will be automatically signed."
 msgstr ""
 
-#: static/js/common/upload-addon.js:465
+#: static/js/common/upload-addon.js:450 static/js/zamboni/devhub-all.js:696 static/js/zamboni/devhub-min.js:1
 msgid "Include detailed version notes (this can be done in the next step)."
 msgstr ""
 
-#: static/js/common/upload-addon.js:466
+#: static/js/common/upload-addon.js:451 static/js/zamboni/devhub-all.js:697 static/js/zamboni/devhub-min.js:1
 msgid "If your add-on requires an account to a website in order to be fully tested, include a test username and password in the Notes to Reviewer (this can be done in the next step)."
 msgstr ""
 
-#: static/js/common/upload-addon.js:467
+#: static/js/common/upload-addon.js:452 static/js/zamboni/devhub-all.js:698 static/js/zamboni/devhub-min.js:1
 msgid "If your add-on is intended for a limited audience you should choose Preliminary Review instead of Full Review."
 msgstr ""
 
-#: static/js/common/upload-addon.js:480
+#: static/js/common/upload-addon.js:465 static/js/zamboni/devhub-all.js:711 static/js/zamboni/devhub-min.js:1
 msgid "Add-on submission checklist"
 msgstr ""
 
-#: static/js/common/upload-addon.js:481
+#: static/js/common/upload-addon.js:466 static/js/zamboni/devhub-all.js:712 static/js/zamboni/devhub-min.js:1
 msgid "Please verify the following points before finalizing your submission. This will minimize delays or misunderstanding during the review process:"
 msgstr ""
 
-#: static/js/common/upload-addon.js:483
+#: static/js/common/upload-addon.js:468 static/js/zamboni/devhub-all.js:714 static/js/zamboni/devhub-min.js:1
 msgid ""
 "Compiled binaries, as well as minified or obfuscated scripts (excluding known libraries) need to have their sources submitted separately for review. Make sure that you use the source code upload "
 "field to avoid having your submission rejected."
 msgstr ""
 
-#: static/js/common/upload-addon.js:501
+#: static/js/common/upload-addon.js:486 static/js/zamboni/devhub-all.js:732 static/js/zamboni/devhub-min.js:1
 msgid "The validation process found these issues that can lead to rejections:"
 msgstr ""
 
-#: static/js/common/upload-addon.js:518
+#: static/js/common/upload-addon.js:503 static/js/zamboni/devhub-all.js:749 static/js/zamboni/devhub-min.js:1
 msgid "If you are unfamiliar with the add-ons review process, you can read about it here."
 msgstr ""
 
-#: static/js/common/upload-addon.js:555
+#: static/js/common/upload-addon.js:540 static/js/zamboni/devhub-all.js:786 static/js/zamboni/devhub-min.js:1
 msgid "Sorry, no supported platform has been found."
 msgstr ""
 
-#: static/js/common/upload-base.js:57
+#: static/js/common/upload-base.js:57 static/js/zamboni/devhub-all.js:187 static/js/zamboni/devhub-min.js:1
 msgid "The filetype you uploaded isn't recognized."
 msgstr ""
 
-#: static/js/common/upload-base.js:79
+#: static/js/common/upload-base.js:79 static/js/zamboni/devhub-all.js:209 static/js/zamboni/devhub-min.js:1
 msgid "You cancelled the upload."
 msgstr ""
 
-#: static/js/common/upload-image.js:97 static/js/impala/users.js:51
-msgid "Images must be either PNG or JPG."
-msgstr ""
-
-#: static/js/common/upload-image.js:101
-msgid "Videos must be in WebM."
-msgstr ""
-
-#: static/js/impala/collections.js:10 static/js/zamboni/collections.js:595
-msgid "Follow this Collection"
-msgstr ""
-
-#: static/js/impala/collections.js:19
-msgid "Stop Following"
-msgstr ""
-
-#: static/js/impala/collections.js:20
-msgid "Following"
-msgstr ""
-
-#. L10n: {0} is an app name.
-#: static/js/impala/listing.js:11 static/js/zamboni/themes.js:13
-msgid "This theme is incompatible with your version of {0}"
-msgstr ""
-
-#: static/js/impala/persona_creation.js:60
-msgid "All Rights Reserved"
-msgstr ""
-
-#: static/js/impala/persona_creation.js:64
-msgid "Creative Commons Attribution 3.0"
-msgstr ""
-
-#: static/js/impala/persona_creation.js:69
-msgid "Creative Commons Attribution-NonCommercial 3.0"
-msgstr ""
-
-#: static/js/impala/persona_creation.js:74
-msgid "Creative Commons Attribution-NonCommercial-NoDerivs 3.0"
-msgstr ""
-
-#: static/js/impala/persona_creation.js:79
-msgid "Creative Commons Attribution-NonCommercial-Share Alike 3.0"
-msgstr ""
-
-#: static/js/impala/persona_creation.js:84
-msgid "Creative Commons Attribution-NoDerivs 3.0"
-msgstr ""
-
-#: static/js/impala/persona_creation.js:89
-msgid "Creative Commons Attribution-ShareAlike 3.0"
-msgstr ""
-
-#: static/js/impala/persona_creation.js:292
-msgid "Your Theme's Name"
-msgstr ""
-
-#: static/js/impala/reviews.js:23 static/js/zamboni/reviews.js:18
-msgid "Flagged for review"
-msgstr ""
-
-#: static/js/impala/reviews.js:40 static/js/zamboni/reviews.js:34
-msgid "Your input is required"
-msgstr ""
-
-#: static/js/impala/reviews.js:152 static/js/zamboni/reviews.js:103
-msgid "Marked for deletion"
-msgstr ""
-
-#: static/js/impala/search.js:114
-msgid "Updating results&hellip;"
-msgstr ""
-
-#: static/js/impala/site_suggestions.js:46
-msgid "Category"
-msgstr ""
-
-#: static/js/impala/suggestions.js:39
-msgid "Search themes for <b>{0}</b>"
-msgstr ""
-
-#: static/js/impala/suggestions.js:41
-msgid "Search apps for <b>{0}</b>"
-msgstr ""
-
-#: static/js/impala/suggestions.js:43
-msgid "Search add-ons for <b>{0}</b>"
-msgstr ""
-
-#: static/js/impala/users.js:33
-msgid "use original"
-msgstr ""
-
-#: static/js/impala/stats/chart.js:267
+#: static/js/impala/stats/chart.js:267 static/js/zamboni/stats-all.js:16898 static/js/zamboni/stats-min.js:5
 msgid "Week of {0}"
 msgstr ""
 
-#: static/js/impala/stats/chart.js:269
+#: static/js/impala/stats/chart.js:269 static/js/zamboni/stats-all.js:16900 static/js/zamboni/stats-min.js:5
 msgid " downloads"
 msgstr ""
 
-#: static/js/impala/stats/chart.js:270
+#: static/js/impala/stats/chart.js:270 static/js/zamboni/stats-all.js:16901 static/js/zamboni/stats-min.js:5
 msgid "{0} users"
 msgstr ""
 
-#: static/js/impala/stats/chart.js:271
+#: static/js/impala/stats/chart.js:271 static/js/zamboni/stats-all.js:16902 static/js/zamboni/stats-min.js:5
 msgid "{0} add-ons"
 msgstr ""
 
-#: static/js/impala/stats/chart.js:272
+#: static/js/impala/stats/chart.js:272 static/js/zamboni/stats-all.js:16903 static/js/zamboni/stats-min.js:5
 msgid "{0} collections"
 msgstr ""
 
-#: static/js/impala/stats/chart.js:273
+#: static/js/impala/stats/chart.js:273 static/js/zamboni/stats-all.js:16904 static/js/zamboni/stats-min.js:5
 msgid "{0} reviews"
 msgstr ""
 
-#: static/js/impala/stats/chart.js:275
+#: static/js/impala/stats/chart.js:275 static/js/zamboni/stats-all.js:16906 static/js/zamboni/stats-min.js:5
 msgid "{0} sales"
 msgstr ""
 
-#: static/js/impala/stats/chart.js:276
+#: static/js/impala/stats/chart.js:276 static/js/zamboni/stats-all.js:16907 static/js/zamboni/stats-min.js:5
 msgid "{0} refunds"
 msgstr ""
 
-#: static/js/impala/stats/chart.js:277
+#: static/js/impala/stats/chart.js:277 static/js/zamboni/stats-all.js:16908 static/js/zamboni/stats-min.js:5
 msgid "{0} installs"
 msgstr ""
 
-#: static/js/impala/stats/chart.js:369 static/js/impala/stats/csv_keys.js:3 static/js/impala/stats/csv_keys.js:109
+#: static/js/impala/stats/chart.js:369 static/js/impala/stats/csv_keys.js:3 static/js/impala/stats/csv_keys.js:109 static/js/zamboni/stats-all.js:15284 static/js/zamboni/stats-all.js:15390
+#: static/js/zamboni/stats-all.js:17000 static/js/zamboni/stats-min.js:4 static/js/zamboni/stats-min.js:5
 msgid "Downloads"
 msgstr ""
 
-#: static/js/impala/stats/chart.js:379 static/js/impala/stats/csv_keys.js:6 static/js/impala/stats/csv_keys.js:110
+#: static/js/impala/stats/chart.js:379 static/js/impala/stats/csv_keys.js:6 static/js/impala/stats/csv_keys.js:110 static/js/zamboni/stats-all.js:15287 static/js/zamboni/stats-all.js:15391
+#: static/js/zamboni/stats-all.js:17010 static/js/zamboni/stats-min.js:4 static/js/zamboni/stats-min.js:5
 msgid "Daily Users"
 msgstr ""
 
-#: static/js/impala/stats/chart.js:410
+#: static/js/impala/stats/chart.js:410 static/js/zamboni/stats-all.js:17041 static/js/zamboni/stats-min.js:5
 msgid "Amount, in USD"
 msgstr ""
 
-#: static/js/impala/stats/chart.js:421 static/js/impala/stats/csv_keys.js:104
+#: static/js/impala/stats/chart.js:421 static/js/impala/stats/csv_keys.js:104 static/js/zamboni/stats-all.js:15385 static/js/zamboni/stats-all.js:17052 static/js/zamboni/stats-min.js:5
 msgid "Number of Contributions"
 msgstr ""
 
-#: static/js/impala/stats/chart.js:447
+#: static/js/impala/stats/chart.js:447 static/js/zamboni/stats-all.js:17078 static/js/zamboni/stats-min.js:5
 msgid "More Info..."
 msgstr ""
 
 #. L10n: {0} is an ISO-formatted date.
-#: static/js/impala/stats/chart.js:451
+#: static/js/impala/stats/chart.js:451 static/js/zamboni/stats-all.js:17082 static/js/zamboni/stats-min.js:5
 msgid "Details for {0}"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:9
+#: static/js/impala/stats/csv_keys.js:9 static/js/zamboni/stats-all.js:15290 static/js/zamboni/stats-min.js:4
 msgid "Collections Created"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:12
+#: static/js/impala/stats/csv_keys.js:12 static/js/zamboni/stats-all.js:15293 static/js/zamboni/stats-min.js:4
 msgid "Add-ons in Use"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:15
+#: static/js/impala/stats/csv_keys.js:15 static/js/zamboni/stats-all.js:15296 static/js/zamboni/stats-min.js:4
 msgid "Add-ons Created"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:18
+#: static/js/impala/stats/csv_keys.js:18 static/js/zamboni/stats-all.js:15299 static/js/zamboni/stats-min.js:4
 msgid "Add-ons Downloaded"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:21
+#: static/js/impala/stats/csv_keys.js:21 static/js/zamboni/stats-all.js:15302 static/js/zamboni/stats-min.js:4
 msgid "Add-ons Updated"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:24
+#: static/js/impala/stats/csv_keys.js:24 static/js/zamboni/stats-all.js:15305 static/js/zamboni/stats-min.js:4
 msgid "Reviews Written"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:27
+#: static/js/impala/stats/csv_keys.js:27 static/js/zamboni/stats-all.js:15308 static/js/zamboni/stats-min.js:4
 msgid "User Signups"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:30
+#: static/js/impala/stats/csv_keys.js:30 static/js/zamboni/stats-all.js:15311 static/js/zamboni/stats-min.js:4
 msgid "Subscribers"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:33
+#: static/js/impala/stats/csv_keys.js:33 static/js/zamboni/stats-all.js:15314 static/js/zamboni/stats-min.js:4
 msgid "Ratings"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:36 static/js/impala/stats/csv_keys.js:114
+#: static/js/impala/stats/csv_keys.js:36 static/js/impala/stats/csv_keys.js:114 static/js/zamboni/stats-all.js:15317 static/js/zamboni/stats-all.js:15395 static/js/zamboni/stats-min.js:4
+#: static/js/zamboni/stats-min.js:5
 msgid "Sales"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:39 static/js/impala/stats/csv_keys.js:113
+#: static/js/impala/stats/csv_keys.js:39 static/js/impala/stats/csv_keys.js:113 static/js/zamboni/stats-all.js:15320 static/js/zamboni/stats-all.js:15394 static/js/zamboni/stats-min.js:4
+#: static/js/zamboni/stats-min.js:5
 msgid "Installs"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:42
+#: static/js/impala/stats/csv_keys.js:42 static/js/zamboni/stats-all.js:15323 static/js/zamboni/stats-min.js:4
 msgid "Unknown"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:43
+#: static/js/impala/stats/csv_keys.js:43 static/js/zamboni/stats-all.js:15324 static/js/zamboni/stats-min.js:4
 msgid "Add-ons Manager"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:44
+#: static/js/impala/stats/csv_keys.js:44 static/js/zamboni/stats-all.js:15325 static/js/zamboni/stats-min.js:4
 msgid "Add-ons Manager Promo"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:45
+#: static/js/impala/stats/csv_keys.js:45 static/js/zamboni/stats-all.js:15326 static/js/zamboni/stats-min.js:4
 msgid "Add-ons Manager Featured"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:46
+#: static/js/impala/stats/csv_keys.js:46 static/js/zamboni/stats-all.js:15327 static/js/zamboni/stats-min.js:4
 msgid "Add-ons Manager Learn More"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:47
+#: static/js/impala/stats/csv_keys.js:47 static/js/zamboni/stats-all.js:15328 static/js/zamboni/stats-min.js:4
 msgid "Search Suggestions"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:48
+#: static/js/impala/stats/csv_keys.js:48 static/js/zamboni/stats-all.js:15329 static/js/zamboni/stats-min.js:4
 msgid "Search Results"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:49 static/js/impala/stats/csv_keys.js:50 static/js/impala/stats/csv_keys.js:51
+#: static/js/impala/stats/csv_keys.js:49 static/js/impala/stats/csv_keys.js:50 static/js/impala/stats/csv_keys.js:51 static/js/zamboni/stats-all.js:15330 static/js/zamboni/stats-all.js:15331
+#: static/js/zamboni/stats-all.js:15332 static/js/zamboni/stats-min.js:4
 msgid "Homepage Promo"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:52 static/js/impala/stats/csv_keys.js:53
+#: static/js/impala/stats/csv_keys.js:52 static/js/impala/stats/csv_keys.js:53 static/js/zamboni/stats-all.js:15333 static/js/zamboni/stats-all.js:15334 static/js/zamboni/stats-min.js:4
 msgid "Homepage Featured"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:54 static/js/impala/stats/csv_keys.js:55
+#: static/js/impala/stats/csv_keys.js:54 static/js/impala/stats/csv_keys.js:55 static/js/zamboni/stats-all.js:15335 static/js/zamboni/stats-all.js:15336 static/js/zamboni/stats-min.js:4
 msgid "Homepage Up and Coming"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:56
+#: static/js/impala/stats/csv_keys.js:56 static/js/zamboni/stats-all.js:15337 static/js/zamboni/stats-min.js:4
 msgid "Homepage Most Popular"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:57 static/js/impala/stats/csv_keys.js:59
+#: static/js/impala/stats/csv_keys.js:57 static/js/impala/stats/csv_keys.js:59 static/js/zamboni/stats-all.js:15338 static/js/zamboni/stats-all.js:15340 static/js/zamboni/stats-min.js:4
 msgid "Detail Page"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:58 static/js/impala/stats/csv_keys.js:60
+#: static/js/impala/stats/csv_keys.js:58 static/js/impala/stats/csv_keys.js:60 static/js/zamboni/stats-all.js:15339 static/js/zamboni/stats-all.js:15341 static/js/zamboni/stats-min.js:4
 msgid "Detail Page (bottom)"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:61
+#: static/js/impala/stats/csv_keys.js:61 static/js/zamboni/stats-all.js:15342 static/js/zamboni/stats-min.js:4
 msgid "Detail Page (Development Channel)"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:62 static/js/impala/stats/csv_keys.js:63 static/js/impala/stats/csv_keys.js:64
+#: static/js/impala/stats/csv_keys.js:62 static/js/impala/stats/csv_keys.js:63 static/js/impala/stats/csv_keys.js:64 static/js/zamboni/stats-all.js:15343 static/js/zamboni/stats-all.js:15344
+#: static/js/zamboni/stats-all.js:15345 static/js/zamboni/stats-min.js:4
 msgid "Often Used With"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:65 static/js/impala/stats/csv_keys.js:66
+#: static/js/impala/stats/csv_keys.js:65 static/js/impala/stats/csv_keys.js:66 static/js/zamboni/stats-all.js:15346 static/js/zamboni/stats-all.js:15347 static/js/zamboni/stats-min.js:4
 msgid "Others By Author"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:67 static/js/impala/stats/csv_keys.js:68
+#: static/js/impala/stats/csv_keys.js:67 static/js/impala/stats/csv_keys.js:68 static/js/zamboni/stats-all.js:15348 static/js/zamboni/stats-all.js:15349 static/js/zamboni/stats-min.js:4
 msgid "Dependencies"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:69 static/js/impala/stats/csv_keys.js:70
+#: static/js/impala/stats/csv_keys.js:69 static/js/impala/stats/csv_keys.js:70 static/js/zamboni/stats-all.js:15350 static/js/zamboni/stats-all.js:15351 static/js/zamboni/stats-min.js:4
 msgid "Upsell"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:71
+#: static/js/impala/stats/csv_keys.js:71 static/js/zamboni/stats-all.js:15352 static/js/zamboni/stats-min.js:4
 msgid "Meet the Developer"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:72
+#: static/js/impala/stats/csv_keys.js:72 static/js/zamboni/stats-all.js:15353 static/js/zamboni/stats-min.js:4
 msgid "User Profile"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:73
+#: static/js/impala/stats/csv_keys.js:73 static/js/zamboni/stats-all.js:15354 static/js/zamboni/stats-min.js:4
 msgid "Version History"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:75
+#: static/js/impala/stats/csv_keys.js:75 static/js/zamboni/stats-all.js:15356 static/js/zamboni/stats-min.js:4
 msgid "Sharing"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:76
+#: static/js/impala/stats/csv_keys.js:76 static/js/zamboni/stats-all.js:15357 static/js/zamboni/stats-min.js:4
 msgid "Category Pages"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:77
+#: static/js/impala/stats/csv_keys.js:77 static/js/zamboni/stats-all.js:15358 static/js/zamboni/stats-min.js:4
 msgid "Collections"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:78 static/js/impala/stats/csv_keys.js:79
+#: static/js/impala/stats/csv_keys.js:78 static/js/impala/stats/csv_keys.js:79 static/js/zamboni/stats-all.js:15359 static/js/zamboni/stats-all.js:15360 static/js/zamboni/stats-min.js:4
 msgid "Category Landing Featured Carousel"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:80 static/js/impala/stats/csv_keys.js:81
+#: static/js/impala/stats/csv_keys.js:80 static/js/impala/stats/csv_keys.js:81 static/js/zamboni/stats-all.js:15361 static/js/zamboni/stats-all.js:15362 static/js/zamboni/stats-min.js:4
 msgid "Category Landing Top Rated"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:82 static/js/impala/stats/csv_keys.js:83
+#: static/js/impala/stats/csv_keys.js:82 static/js/impala/stats/csv_keys.js:83 static/js/zamboni/stats-all.js:15363 static/js/zamboni/stats-all.js:15364 static/js/zamboni/stats-min.js:5
 msgid "Category Landing Most Popular"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:84 static/js/impala/stats/csv_keys.js:85
+#: static/js/impala/stats/csv_keys.js:84 static/js/impala/stats/csv_keys.js:85 static/js/zamboni/stats-all.js:15365 static/js/zamboni/stats-all.js:15366 static/js/zamboni/stats-min.js:5
 msgid "Category Landing Recently Added"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:86 static/js/impala/stats/csv_keys.js:87
+#: static/js/impala/stats/csv_keys.js:86 static/js/impala/stats/csv_keys.js:87 static/js/zamboni/stats-all.js:15367 static/js/zamboni/stats-all.js:15368 static/js/zamboni/stats-min.js:5
 msgid "Browse Listing Featured Sort"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:88 static/js/impala/stats/csv_keys.js:89
+#: static/js/impala/stats/csv_keys.js:88 static/js/impala/stats/csv_keys.js:89 static/js/zamboni/stats-all.js:15369 static/js/zamboni/stats-all.js:15370 static/js/zamboni/stats-min.js:5
 msgid "Browse Listing Users Sort"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:90 static/js/impala/stats/csv_keys.js:91
+#: static/js/impala/stats/csv_keys.js:90 static/js/impala/stats/csv_keys.js:91 static/js/zamboni/stats-all.js:15371 static/js/zamboni/stats-all.js:15372 static/js/zamboni/stats-min.js:5
 msgid "Browse Listing Rating Sort"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:92 static/js/impala/stats/csv_keys.js:93
+#: static/js/impala/stats/csv_keys.js:92 static/js/impala/stats/csv_keys.js:93 static/js/zamboni/stats-all.js:15373 static/js/zamboni/stats-all.js:15374 static/js/zamboni/stats-min.js:5
 msgid "Browse Listing Created Sort"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:94 static/js/impala/stats/csv_keys.js:95
+#: static/js/impala/stats/csv_keys.js:94 static/js/impala/stats/csv_keys.js:95 static/js/zamboni/stats-all.js:15375 static/js/zamboni/stats-all.js:15376 static/js/zamboni/stats-min.js:5
 msgid "Browse Listing Name Sort"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:96 static/js/impala/stats/csv_keys.js:97
+#: static/js/impala/stats/csv_keys.js:96 static/js/impala/stats/csv_keys.js:97 static/js/zamboni/stats-all.js:15377 static/js/zamboni/stats-all.js:15378 static/js/zamboni/stats-min.js:5
 msgid "Browse Listing Popular Sort"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:98 static/js/impala/stats/csv_keys.js:99
+#: static/js/impala/stats/csv_keys.js:98 static/js/impala/stats/csv_keys.js:99 static/js/zamboni/stats-all.js:15379 static/js/zamboni/stats-all.js:15380 static/js/zamboni/stats-min.js:5
 msgid "Browse Listing Updated Sort"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:100 static/js/impala/stats/csv_keys.js:101
+#: static/js/impala/stats/csv_keys.js:100 static/js/impala/stats/csv_keys.js:101 static/js/zamboni/stats-all.js:15381 static/js/zamboni/stats-all.js:15382 static/js/zamboni/stats-min.js:5
 msgid "Browse Listing Up and Coming Sort"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:105
+#: static/js/impala/stats/csv_keys.js:105 static/js/zamboni/stats-all.js:15386 static/js/zamboni/stats-min.js:5
 msgid "Total Amount Contributed"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:106
+#: static/js/impala/stats/csv_keys.js:106 static/js/zamboni/stats-all.js:15387 static/js/zamboni/stats-min.js:5
 msgid "Average Contribution"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:115
+#: static/js/impala/stats/csv_keys.js:115 static/js/zamboni/stats-all.js:15396 static/js/zamboni/stats-min.js:5
 msgid "Usage"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:118
+#: static/js/impala/stats/csv_keys.js:118 static/js/zamboni/stats-all.js:15399 static/js/zamboni/stats-min.js:5
 msgid "Firefox"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:119
+#: static/js/impala/stats/csv_keys.js:119 static/js/zamboni/stats-all.js:15400 static/js/zamboni/stats-min.js:5
 msgid "Mozilla"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:120
+#: static/js/impala/stats/csv_keys.js:120 static/js/zamboni/stats-all.js:15401 static/js/zamboni/stats-min.js:5
 msgid "Thunderbird"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:121
+#: static/js/impala/stats/csv_keys.js:121 static/js/zamboni/stats-all.js:15402 static/js/zamboni/stats-min.js:5
 msgid "Sunbird"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:122
+#: static/js/impala/stats/csv_keys.js:122 static/js/zamboni/stats-all.js:15403 static/js/zamboni/stats-min.js:5
 msgid "SeaMonkey"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:123
+#: static/js/impala/stats/csv_keys.js:123 static/js/zamboni/stats-all.js:15404 static/js/zamboni/stats-min.js:5
 msgid "Fennec"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:124
+#: static/js/impala/stats/csv_keys.js:124 static/js/zamboni/stats-all.js:15405 static/js/zamboni/stats-min.js:5
 msgid "Android"
 msgstr ""
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:129
+#: static/js/impala/stats/csv_keys.js:129 static/js/zamboni/stats-all.js:15410 static/js/zamboni/stats-min.js:5
 msgid "Downloads and Daily Users, last {0} days"
 msgstr ""
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:131
+#: static/js/impala/stats/csv_keys.js:131 static/js/zamboni/stats-all.js:15412 static/js/zamboni/stats-min.js:5
 msgid "Downloads and Daily Users from {0} to {1}"
 msgstr ""
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:135
+#: static/js/impala/stats/csv_keys.js:135 static/js/zamboni/stats-all.js:15416 static/js/zamboni/stats-min.js:5
 msgid "Installs and Daily Users, last {0} days"
 msgstr ""
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:137
+#: static/js/impala/stats/csv_keys.js:137 static/js/zamboni/stats-all.js:15418 static/js/zamboni/stats-min.js:5
 msgid "Installs and Daily Users from {0} to {1}"
 msgstr ""
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:141
+#: static/js/impala/stats/csv_keys.js:141 static/js/zamboni/stats-all.js:15422 static/js/zamboni/stats-min.js:5
 msgid "Downloads, last {0} days"
 msgstr ""
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:143
+#: static/js/impala/stats/csv_keys.js:143 static/js/zamboni/stats-all.js:15424 static/js/zamboni/stats-min.js:5
 msgid "Downloads from {0} to {1}"
 msgstr ""
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:147
+#: static/js/impala/stats/csv_keys.js:147 static/js/zamboni/stats-all.js:15428 static/js/zamboni/stats-min.js:5
 msgid "Daily Users, last {0} days"
 msgstr ""
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:149
+#: static/js/impala/stats/csv_keys.js:149 static/js/zamboni/stats-all.js:15430 static/js/zamboni/stats-min.js:5
 msgid "Daily Users from {0} to {1}"
 msgstr ""
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:153
+#: static/js/impala/stats/csv_keys.js:153 static/js/zamboni/stats-all.js:15434 static/js/zamboni/stats-min.js:5
 msgid "Applications, last {0} days"
 msgstr ""
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:155
+#: static/js/impala/stats/csv_keys.js:155 static/js/zamboni/stats-all.js:15436 static/js/zamboni/stats-min.js:5
 msgid "Applications from {0} to {1}"
 msgstr ""
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:159
+#: static/js/impala/stats/csv_keys.js:159 static/js/zamboni/stats-all.js:15440 static/js/zamboni/stats-min.js:5
 msgid "Platforms, last {0} days"
 msgstr ""
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:161
+#: static/js/impala/stats/csv_keys.js:161 static/js/zamboni/stats-all.js:15442 static/js/zamboni/stats-min.js:5
 msgid "Platforms from {0} to {1}"
 msgstr ""
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:165
+#: static/js/impala/stats/csv_keys.js:165 static/js/zamboni/stats-all.js:15446 static/js/zamboni/stats-min.js:5
 msgid "Languages, last {0} days"
 msgstr ""
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:167
+#: static/js/impala/stats/csv_keys.js:167 static/js/zamboni/stats-all.js:15448 static/js/zamboni/stats-min.js:5
 msgid "Languages from {0} to {1}"
 msgstr ""
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:171
+#: static/js/impala/stats/csv_keys.js:171 static/js/zamboni/stats-all.js:15452 static/js/zamboni/stats-min.js:5
 msgid "Add-on Versions, last {0} days"
 msgstr ""
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:173
+#: static/js/impala/stats/csv_keys.js:173 static/js/zamboni/stats-all.js:15454 static/js/zamboni/stats-min.js:5
 msgid "Add-on Versions from {0} to {1}"
 msgstr ""
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:177
+#: static/js/impala/stats/csv_keys.js:177 static/js/zamboni/stats-all.js:15458 static/js/zamboni/stats-min.js:5
 msgid "Add-on Status, last {0} days"
 msgstr ""
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:179
+#: static/js/impala/stats/csv_keys.js:179 static/js/zamboni/stats-all.js:15460 static/js/zamboni/stats-min.js:5
 msgid "Add-on Status from {0} to {1}"
 msgstr ""
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:183
+#: static/js/impala/stats/csv_keys.js:183 static/js/zamboni/stats-all.js:15464 static/js/zamboni/stats-min.js:5
 msgid "Download Sources, last {0} days"
 msgstr ""
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:185
+#: static/js/impala/stats/csv_keys.js:185 static/js/zamboni/stats-all.js:15466 static/js/zamboni/stats-min.js:5
 msgid "Download Sources from {0} to {1}"
 msgstr ""
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:189
+#: static/js/impala/stats/csv_keys.js:189 static/js/zamboni/stats-all.js:15470 static/js/zamboni/stats-min.js:5
 msgid "Contributions, last {0} days"
 msgstr ""
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:191
+#: static/js/impala/stats/csv_keys.js:191 static/js/zamboni/stats-all.js:15472 static/js/zamboni/stats-min.js:5
 msgid "Contributions from {0} to {1}"
 msgstr ""
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:195
+#: static/js/impala/stats/csv_keys.js:195 static/js/zamboni/stats-all.js:15476 static/js/zamboni/stats-min.js:5
 msgid "Site Metrics, last {0} days"
 msgstr ""
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:197
+#: static/js/impala/stats/csv_keys.js:197 static/js/zamboni/stats-all.js:15478 static/js/zamboni/stats-min.js:5
 msgid "Site Metrics from {0} to {1}"
 msgstr ""
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:201
+#: static/js/impala/stats/csv_keys.js:201 static/js/zamboni/stats-all.js:15482 static/js/zamboni/stats-min.js:5
 msgid "Add-ons in Use, last {0} days"
 msgstr ""
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:203
+#: static/js/impala/stats/csv_keys.js:203 static/js/zamboni/stats-all.js:15484 static/js/zamboni/stats-min.js:5
 msgid "Add-ons in Use from {0} to {1}"
 msgstr ""
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:207
+#: static/js/impala/stats/csv_keys.js:207 static/js/zamboni/stats-all.js:15488 static/js/zamboni/stats-min.js:5
 msgid "Add-ons Downloaded, last {0} days"
 msgstr ""
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:209
+#: static/js/impala/stats/csv_keys.js:209 static/js/zamboni/stats-all.js:15490 static/js/zamboni/stats-min.js:5
 msgid "Add-ons Downloaded from {0} to {1}"
 msgstr ""
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:213
+#: static/js/impala/stats/csv_keys.js:213 static/js/zamboni/stats-all.js:15494 static/js/zamboni/stats-min.js:5
 msgid "Add-ons Created, last {0} days"
 msgstr ""
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:215
+#: static/js/impala/stats/csv_keys.js:215 static/js/zamboni/stats-all.js:15496 static/js/zamboni/stats-min.js:5
 msgid "Add-ons Created from {0} to {1}"
 msgstr ""
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:219
+#: static/js/impala/stats/csv_keys.js:219 static/js/zamboni/stats-all.js:15500 static/js/zamboni/stats-min.js:5
 msgid "Add-ons Updated, last {0} days"
 msgstr ""
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:221
+#: static/js/impala/stats/csv_keys.js:221 static/js/zamboni/stats-all.js:15502 static/js/zamboni/stats-min.js:5
 msgid "Add-ons Updated from {0} to {1}"
 msgstr ""
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:225
+#: static/js/impala/stats/csv_keys.js:225 static/js/zamboni/stats-all.js:15506 static/js/zamboni/stats-min.js:5
 msgid "Reviews Written, last {0} days"
 msgstr ""
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:227
+#: static/js/impala/stats/csv_keys.js:227 static/js/zamboni/stats-all.js:15508 static/js/zamboni/stats-min.js:5
 msgid "Reviews Written from {0} to {1}"
 msgstr ""
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:231
+#: static/js/impala/stats/csv_keys.js:231 static/js/zamboni/stats-all.js:15512 static/js/zamboni/stats-min.js:5
 msgid "User Signups, last {0} days"
 msgstr ""
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:233
+#: static/js/impala/stats/csv_keys.js:233 static/js/zamboni/stats-all.js:15514 static/js/zamboni/stats-min.js:5
 msgid "User Signups from {0} to {1}"
 msgstr ""
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:237
+#: static/js/impala/stats/csv_keys.js:237 static/js/zamboni/stats-all.js:15518 static/js/zamboni/stats-min.js:5
 msgid "Collections Created, last {0} days"
 msgstr ""
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:239
+#: static/js/impala/stats/csv_keys.js:239 static/js/zamboni/stats-all.js:15520 static/js/zamboni/stats-min.js:5
 msgid "Collections Created from {0} to {1}"
 msgstr ""
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:243
+#: static/js/impala/stats/csv_keys.js:243 static/js/zamboni/stats-all.js:15524 static/js/zamboni/stats-min.js:5
 msgid "Subscribers, last {0} days"
 msgstr ""
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:245
+#: static/js/impala/stats/csv_keys.js:245 static/js/zamboni/stats-all.js:15526 static/js/zamboni/stats-min.js:5
 msgid "Subscribers from {0} to {1}"
 msgstr ""
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:249
+#: static/js/impala/stats/csv_keys.js:249 static/js/zamboni/stats-all.js:15530 static/js/zamboni/stats-min.js:5
 msgid "Ratings, last {0} days"
 msgstr ""
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:251
+#: static/js/impala/stats/csv_keys.js:251 static/js/zamboni/stats-all.js:15532 static/js/zamboni/stats-min.js:5
 msgid "Ratings from {0} to {1}"
 msgstr ""
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:255
+#: static/js/impala/stats/csv_keys.js:255 static/js/zamboni/stats-all.js:15536 static/js/zamboni/stats-min.js:5
 msgid "Sales, last {0} days"
 msgstr ""
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:257
+#: static/js/impala/stats/csv_keys.js:257 static/js/zamboni/stats-all.js:15538 static/js/zamboni/stats-min.js:5
 msgid "Sales from {0} to {1}"
 msgstr ""
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:261
+#: static/js/impala/stats/csv_keys.js:261 static/js/zamboni/stats-all.js:15542 static/js/zamboni/stats-min.js:5
 msgid "Installs, last {0} days"
 msgstr ""
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:263
+#: static/js/impala/stats/csv_keys.js:263 static/js/zamboni/stats-all.js:15544 static/js/zamboni/stats-min.js:5
 msgid "Installs from {0} to {1}"
 msgstr ""
 
 #. L10n: {0} and {1} are integers.
-#: static/js/impala/stats/csv_keys.js:269
+#: static/js/impala/stats/csv_keys.js:269 static/js/zamboni/stats-all.js:15550 static/js/zamboni/stats-min.js:5
 msgid "<b>{0}</b> in last {1} days"
 msgstr ""
 
 #. L10n: {0} is an integer and {1} and {2} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:271 static/js/impala/stats/csv_keys.js:277
+#: static/js/impala/stats/csv_keys.js:271 static/js/impala/stats/csv_keys.js:277 static/js/zamboni/stats-all.js:15552 static/js/zamboni/stats-all.js:15558 static/js/zamboni/stats-min.js:5
 msgid "<b>{0}</b> from {1} to {2}"
 msgstr ""
 
 #. L10n: {0} and {1} are integers.
-#: static/js/impala/stats/csv_keys.js:275
+#: static/js/impala/stats/csv_keys.js:275 static/js/zamboni/stats-all.js:15556 static/js/zamboni/stats-min.js:5
 msgid "<b>{0}</b> average in last {1} days"
 msgstr ""
 
-#: static/js/impala/stats/overview.js:19
+#: static/js/impala/stats/overview.js:19 static/js/zamboni/stats-all.js:16469 static/js/zamboni/stats-min.js:5
 msgid "No data available."
 msgstr ""
 
-#: static/js/impala/stats/table.js:74
+#: static/js/impala/stats/table.js:74 static/js/zamboni/stats-all.js:17209 static/js/zamboni/stats-min.js:5
 msgid "Date"
 msgstr ""
 
-#: static/js/impala/stats/topchart.js:96
+#: static/js/impala/stats/topchart.js:96 static/js/zamboni/stats-all.js:16600 static/js/zamboni/stats-min.js:5
 msgid "Other"
 msgstr ""
 
-#: static/js/zamboni/admin_validation.js:24 static/js/zamboni/devhub.js:1229 static/js/zamboni/editors.js:295
+#: static/js/zamboni/admin-all.js:180 static/js/zamboni/admin-min.js:1 static/js/zamboni/admin_validation.js:24 static/js/zamboni/devhub-all.js:2408 static/js/zamboni/devhub-min.js:2
+#: static/js/zamboni/devhub.js:1229 static/js/zamboni/editors-all.js:15576 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:295
 msgid "Select an application first"
 msgstr ""
 
-#: static/js/zamboni/admin_validation.js:51
+#: static/js/zamboni/admin-all.js:207 static/js/zamboni/admin-min.js:1 static/js/zamboni/admin_validation.js:51
 msgid "Set {0} add-on to a max version of {1} and email the author."
 msgid_plural "Set {0} add-ons to a max version of {1} and email the authors."
 msgstr[0] ""
 msgstr[1] ""
 
-#: static/js/zamboni/admin_validation.js:54
+#: static/js/zamboni/admin-all.js:210 static/js/zamboni/admin-min.js:1 static/js/zamboni/admin_validation.js:54
 msgid "Email author of {2} add-on which failed validation."
 msgid_plural "Email authors of {2} add-ons which failed validation."
 msgstr[0] ""
 msgstr[1] ""
 
-#. L10n: {0} is an app name like Firefox.
-#: static/js/zamboni/buttons.js:66
-msgid "Accept and Install"
-msgstr ""
-
-#: static/js/zamboni/buttons.js:66
-msgid "Add to {0}"
-msgstr ""
-
-#: static/js/zamboni/buttons.js:71
-msgid "Download Now"
-msgstr ""
-
-#: static/js/zamboni/buttons.js:112
-msgid "Add-on has not been updated to support default-to-compatible."
-msgstr ""
-
-#: static/js/zamboni/buttons.js:117
-msgid "You need to be using Firefox 10.0 or higher."
-msgstr ""
-
-#: static/js/zamboni/buttons.js:129
-msgid "Mozilla has marked this version as incompatible with your Firefox version."
-msgstr ""
-
-#. L10n: {0} is an platform like Windows or Linux.
-#: static/js/zamboni/buttons.js:210
-msgid "Install for {0} anyway"
-msgstr ""
-
-#: static/js/zamboni/buttons.js:210
-msgid "Download for {0} anyway"
-msgstr ""
-
-#: static/js/zamboni/buttons.js:267
-msgid "Not available for your platform"
-msgstr ""
-
-#. L10n: {0} is an app name, {1} is the app version.
-#: static/js/zamboni/buttons.js:278 static/js/zamboni/buttons.js:315
-msgid "Not available for {0} {1}"
-msgstr ""
-
-#: static/js/zamboni/buttons.js:341
-msgid "Works with {app} {min} - {max}"
-msgstr ""
-
-#: static/js/zamboni/buttons.js:343
-msgid "View other versions"
-msgstr ""
-
-#: static/js/zamboni/buttons.js:391
-msgid "Only with Firefox — Get Firefox Now!"
-msgstr ""
-
-#: static/js/zamboni/buttons.js:507 static/js/zamboni/mobile/buttons.js:43
-msgid "Sorry, you need a Mozilla-based browser (such as Firefox) to install a search plugin."
-msgstr ""
-
-#: static/js/zamboni/collections.js:229
-msgid "Adding to Favorites&hellip;"
-msgstr ""
-
-#: static/js/zamboni/collections.js:232
-msgid "Removing Favorite&hellip;"
-msgstr ""
-
-#: static/js/zamboni/collections.js:235
-msgid "Add to Favorites"
-msgstr ""
-
-#: static/js/zamboni/collections.js:238
-msgid "Remove from Favorites"
-msgstr ""
-
-#: static/js/zamboni/collections.js:303
-msgid "Pending"
-msgstr ""
-
-#: static/js/zamboni/collections.js:304
-msgid "Add a comment"
-msgstr ""
-
-#: static/js/zamboni/collections.js:304
-msgid "Comment"
-msgstr ""
-
-#: static/js/zamboni/collections.js:305
-msgid "Remove this add-on from the collection"
-msgstr ""
-
-#: static/js/zamboni/collections.js:305 static/js/zamboni/collections.js:334
-msgid "Remove"
-msgstr ""
-
-#: static/js/zamboni/collections.js:334
-msgid "Remove this user as a contributor"
-msgstr ""
-
-#: static/js/zamboni/collections.js:346
-msgid "An email address is required."
-msgstr ""
-
-#: static/js/zamboni/collections.js:364
-msgid "You cannot add yourself as a contributor."
-msgstr ""
-
-#: static/js/zamboni/collections.js:366
-msgid "You have already added that user."
-msgstr ""
-
-#: static/js/zamboni/collections.js:573
-msgid "Add to favorites"
-msgstr ""
-
-#: static/js/zamboni/collections.js:577
-msgid "Remove from favorites"
-msgstr ""
-
-#: static/js/zamboni/collections.js:604
-msgid "Stop following"
-msgstr ""
-
-#: static/js/zamboni/devhub.js:110
+#: static/js/zamboni/devhub-all.js:1289 static/js/zamboni/devhub-min.js:1 static/js/zamboni/devhub.js:110
 msgid "Your browser does not support the video tag"
 msgstr ""
 
-#: static/js/zamboni/devhub.js:371
+#: static/js/zamboni/devhub-all.js:1550 static/js/zamboni/devhub-min.js:1 static/js/zamboni/devhub.js:371
 msgid "Changes Saved"
 msgstr ""
 
-#: static/js/zamboni/devhub.js:387
+#: static/js/zamboni/devhub-all.js:1566 static/js/zamboni/devhub-min.js:1 static/js/zamboni/devhub.js:387
 msgid "Enter a new author's email address"
 msgstr ""
 
-#: static/js/zamboni/devhub.js:536
+#: static/js/zamboni/devhub-all.js:1715 static/js/zamboni/devhub-min.js:1 static/js/zamboni/devhub.js:536
 msgid "There was an error uploading your file."
 msgstr ""
 
-#: static/js/zamboni/devhub.js:681
+#: static/js/zamboni/devhub-all.js:1860 static/js/zamboni/devhub-min.js:1 static/js/zamboni/devhub.js:681
 msgid "{files} file"
 msgid_plural "{files} files"
 msgstr[0] ""
 msgstr[1] ""
 
-#: static/js/zamboni/devhub.js:684
+#: static/js/zamboni/devhub-all.js:1863 static/js/zamboni/devhub-min.js:1 static/js/zamboni/devhub.js:684
 msgid "{reviews} user review"
 msgid_plural "{reviews} user reviews"
 msgstr[0] ""
 msgstr[1] ""
 
-#: static/js/zamboni/devhub.js:796
+#: static/js/zamboni/devhub-all.js:1975 static/js/zamboni/devhub-min.js:2 static/js/zamboni/devhub.js:796
 msgid "Learn more"
 msgstr ""
 
-#: static/js/zamboni/devhub.js:800
+#: static/js/zamboni/devhub-all.js:1979 static/js/zamboni/devhub-min.js:2 static/js/zamboni/devhub.js:800
 msgid "Example"
 msgstr ""
 
-#: static/js/zamboni/devhub.js:1130
+#: static/js/zamboni/devhub-all.js:2309 static/js/zamboni/devhub-min.js:2 static/js/zamboni/devhub.js:1130
 msgid "Image changes being processed"
 msgstr ""
 
-#: static/js/zamboni/devhub.js:1280
+#: static/js/zamboni/devhub-all.js:2459 static/js/zamboni/devhub-min.js:2 static/js/zamboni/devhub.js:1280
 msgid "Must be a valid e-mail address."
+msgstr ""
+
+#: static/js/zamboni/devhub-all.js:2613 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:80
+msgid "All tests passed successfully."
+msgstr ""
+
+#: static/js/zamboni/devhub-all.js:2616 static/js/zamboni/devhub-all.js:3011 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:83 static/js/zamboni/validator.js:478
+msgid "These tests were not run."
+msgstr ""
+
+#: static/js/zamboni/devhub-all.js:2664 static/js/zamboni/devhub-all.js:2677 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:131 static/js/zamboni/validator.js:144
+msgid "Tests"
+msgstr ""
+
+#: static/js/zamboni/devhub-all.js:2779 static/js/zamboni/devhub-all.js:3108 static/js/zamboni/devhub-all.js:3127 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:246
+#: static/js/zamboni/validator.js:575 static/js/zamboni/validator.js:594
+msgid "Error"
+msgstr ""
+
+#: static/js/zamboni/devhub-all.js:2780 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:247
+msgid "Warning"
+msgstr ""
+
+#: static/js/zamboni/devhub-all.js:2794 static/js/zamboni/devhub-min.js:2 static/js/zamboni/files-all.js:5657 static/js/zamboni/files-min.js:3 static/js/zamboni/files.js:411
+#: static/js/zamboni/validator.js:261
+msgid "Ignore this message in future updates"
+msgstr ""
+
+#: static/js/zamboni/devhub-all.js:2817 static/js/zamboni/devhub-min.js:2 static/js/zamboni/files-all.js:5663 static/js/zamboni/files-min.js:3 static/js/zamboni/files.js:417
+#: static/js/zamboni/validator.js:284
+msgid "Severity for automated signing:"
+msgstr ""
+
+#: static/js/zamboni/devhub-all.js:2832 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:299
+msgid "Suggestions for passing automated signing:"
+msgstr ""
+
+#: static/js/zamboni/devhub-all.js:2920 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:387
+msgid "Compatibility Tests"
+msgstr ""
+
+#: static/js/zamboni/devhub-all.js:2999 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:466
+msgid "Add-on failed validation."
+msgstr ""
+
+#: static/js/zamboni/devhub-all.js:3001 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:468
+msgid "Add-on passed validation."
+msgstr ""
+
+#: static/js/zamboni/devhub-all.js:3014 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:481
+msgid "{0} error"
+msgid_plural "{0} errors"
+msgstr[0] ""
+msgstr[1] ""
+
+#: static/js/zamboni/devhub-all.js:3016 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:483
+msgid "{0} warning"
+msgid_plural "{0} warnings"
+msgstr[0] ""
+msgstr[1] ""
+
+#: static/js/zamboni/devhub-all.js:3018 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:485
+msgid "{0} notice"
+msgid_plural "{0} notices"
+msgstr[0] ""
+msgstr[1] ""
+
+#: static/js/zamboni/devhub-all.js:3110 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:577
+msgid "Validation task could not complete or completed with errors"
+msgstr ""
+
+#: static/js/zamboni/devhub-all.js:3128 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:595
+msgid "Internal server error"
 msgstr ""
 
 #: static/js/zamboni/devhub_search.js:8
 msgid "No results found."
 msgstr ""
 
-#: static/js/zamboni/editors.js:121
+#: static/js/zamboni/editors-all.js:15402 static/js/zamboni/editors-min.js:4 static/js/zamboni/editors.js:121
 msgid "{name} was viewing this page first."
 msgstr ""
 
-#: static/js/zamboni/editors.js:171
+#: static/js/zamboni/editors-all.js:15452 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:171
 msgid "Receipt checked by app."
 msgstr ""
 
-#: static/js/zamboni/editors.js:173
+#: static/js/zamboni/editors-all.js:15454 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:173
 msgid "Receipt was not checked by app."
 msgstr ""
 
-#: static/js/zamboni/editors.js:244
+#: static/js/zamboni/editors-all.js:15525 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:244
 msgid "{name} was viewing this add-on first."
 msgstr ""
 
-#: static/js/zamboni/editors.js:255
+#: static/js/zamboni/editors-all.js:15536 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:255
 msgid "Loading&hellip;"
 msgstr ""
 
-#: static/js/zamboni/editors.js:260
+#: static/js/zamboni/editors-all.js:15541 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:260
 msgid "Version Notes"
 msgstr ""
 
-#: static/js/zamboni/editors.js:265
+#: static/js/zamboni/editors-all.js:15546 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:265
 msgid "Notes for Reviewers"
 msgstr ""
 
-#: static/js/zamboni/editors.js:270
+#: static/js/zamboni/editors-all.js:15551 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:270
 msgid "No version notes found"
 msgstr ""
 
-#: static/js/zamboni/editors.js:330
+#: static/js/zamboni/editors-all.js:15611 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:330
 msgid "Average Reviews"
 msgstr ""
 
-#: static/js/zamboni/editors.js:386
+#: static/js/zamboni/editors-all.js:15667 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:386
 msgid "Number of Reviews"
 msgstr ""
 
-#: static/js/zamboni/editors.js:445
+#: static/js/zamboni/editors-all.js:15726 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:445
 msgid "Error loading translation"
 msgstr ""
 
-#: static/js/zamboni/files.js:411 static/js/zamboni/validator.js:261
-msgid "Ignore this message in future updates"
-msgstr ""
-
-#: static/js/zamboni/files.js:417 static/js/zamboni/validator.js:284
-msgid "Severity for automated signing:"
-msgstr ""
-
-#: static/js/zamboni/global.js:410
-msgid "Loading..."
-msgstr ""
-
-#. L10n: {0} is the number of characters left.
-#: static/js/zamboni/global.js:474
-msgid "<b>{0}</b> character left."
-msgid_plural "<b>{0}</b> characters left."
-msgstr[0] ""
-msgstr[1] ""
-
-#: static/js/zamboni/init.js:28
-msgid "This feature is temporarily disabled while we perform website maintenance. Please check back a little later."
-msgstr ""
-
-#: static/js/zamboni/l10n.js:45
-msgid "Remove this localization"
-msgstr ""
-
-#: static/js/zamboni/password-strength.js:20
-msgid "Password strength:"
-msgstr ""
-
-#: static/js/zamboni/password-strength.js:26
-msgid "At least {0} character left."
-msgid_plural "At least {0} characters left."
-msgstr[0] ""
-msgstr[1] ""
-
-#: static/js/zamboni/themes_review.js:176
-msgid "Requested Info"
-msgstr ""
-
-#: static/js/zamboni/themes_review.js:177
-msgid "Flagged"
-msgstr ""
-
-#: static/js/zamboni/themes_review.js:178
-msgid "Duplicate"
-msgstr ""
-
-#: static/js/zamboni/themes_review.js:179
-msgid "Rejected"
-msgstr ""
-
-#: static/js/zamboni/themes_review.js:180
-msgid "Approved"
-msgstr ""
-
-#: static/js/zamboni/themes_review.js:424
-msgid "No results found"
-msgstr ""
-
-#: static/js/zamboni/themes_review_templates.js:31
+#: static/js/zamboni/editors-all.js:15975 static/js/zamboni/editors-min.js:5 static/js/zamboni/themes_review_templates.js:31
 msgid "Theme"
 msgstr ""
 
-#: static/js/zamboni/themes_review_templates.js:33
+#: static/js/zamboni/editors-all.js:15977 static/js/zamboni/editors-min.js:5 static/js/zamboni/themes_review_templates.js:33
 msgid "Reviewer"
 msgstr ""
 
-#: static/js/zamboni/themes_review_templates.js:35
+#: static/js/zamboni/editors-all.js:15979 static/js/zamboni/editors-min.js:5 static/js/zamboni/themes_review_templates.js:35
 msgid "Status"
 msgstr ""
 
-#: static/js/zamboni/validator.js:80
-msgid "All tests passed successfully."
+#: static/js/zamboni/editors-all.js:16196 static/js/zamboni/editors-min.js:5 static/js/zamboni/themes_review.js:176
+msgid "Requested Info"
 msgstr ""
 
-#: static/js/zamboni/validator.js:83 static/js/zamboni/validator.js:478
-msgid "These tests were not run."
+#: static/js/zamboni/editors-all.js:16197 static/js/zamboni/editors-min.js:5 static/js/zamboni/themes_review.js:177
+msgid "Flagged"
 msgstr ""
 
-#: static/js/zamboni/validator.js:131 static/js/zamboni/validator.js:144
-msgid "Tests"
+#: static/js/zamboni/editors-all.js:16198 static/js/zamboni/editors-min.js:5 static/js/zamboni/themes_review.js:178
+msgid "Duplicate"
 msgstr ""
 
-#: static/js/zamboni/validator.js:246 static/js/zamboni/validator.js:575 static/js/zamboni/validator.js:594
-msgid "Error"
+#: static/js/zamboni/editors-all.js:16199 static/js/zamboni/editors-min.js:5 static/js/zamboni/themes_review.js:179
+msgid "Rejected"
 msgstr ""
 
-#: static/js/zamboni/validator.js:247
-msgid "Warning"
+#: static/js/zamboni/editors-all.js:16200 static/js/zamboni/editors-min.js:5 static/js/zamboni/themes_review.js:180
+msgid "Approved"
 msgstr ""
 
-#: static/js/zamboni/validator.js:299
-msgid "Suggestions for passing automated signing:"
+#: static/js/zamboni/editors-all.js:16444 static/js/zamboni/editors-min.js:5 static/js/zamboni/themes_review.js:424
+msgid "No results found"
 msgstr ""
 
-#: static/js/zamboni/validator.js:387
-msgid "Compatibility Tests"
-msgstr ""
-
-#: static/js/zamboni/validator.js:466
-msgid "Add-on failed validation."
-msgstr ""
-
-#: static/js/zamboni/validator.js:468
-msgid "Add-on passed validation."
-msgstr ""
-
-#: static/js/zamboni/validator.js:481
-msgid "{0} error"
-msgid_plural "{0} errors"
-msgstr[0] ""
-msgstr[1] ""
-
-#: static/js/zamboni/validator.js:483
-msgid "{0} warning"
-msgid_plural "{0} warnings"
-msgstr[0] ""
-msgstr[1] ""
-
-#: static/js/zamboni/validator.js:485
-msgid "{0} notice"
-msgid_plural "{0} notices"
-msgstr[0] ""
-msgstr[1] ""
-
-#: static/js/zamboni/validator.js:577
-msgid "Validation task could not complete or completed with errors"
-msgstr ""
-
-#: static/js/zamboni/validator.js:595
-msgid "Internal server error"
-msgstr ""
-
-#: static/js/zamboni/mobile/buttons.js:52
+#: static/js/zamboni/mobile-all.js:15186 static/js/zamboni/mobile/buttons.js:52
 msgid "Not Updated for {0} {1}"
 msgstr ""
 
-#: static/js/zamboni/mobile/buttons.js:53
+#: static/js/zamboni/mobile-all.js:15187 static/js/zamboni/mobile/buttons.js:53
 msgid "Requires Newer Version of {0}"
 msgstr ""
 
-#: static/js/zamboni/mobile/buttons.js:54
+#: static/js/zamboni/mobile-all.js:15188 static/js/zamboni/mobile/buttons.js:54
 msgid "Unreviewed"
 msgstr ""
 
-#: static/js/zamboni/mobile/buttons.js:55
+#: static/js/zamboni/mobile-all.js:15189 static/js/zamboni/mobile/buttons.js:55
 msgid "Experimental <span>(Learn More)</span>"
 msgstr ""
 
-#: static/js/zamboni/mobile/buttons.js:56 static/js/zamboni/mobile/buttons.js:57
+#: static/js/zamboni/mobile-all.js:15190 static/js/zamboni/mobile-all.js:15191 static/js/zamboni/mobile/buttons.js:56 static/js/zamboni/mobile/buttons.js:57
 msgid "Not Available for {0}"
 msgstr ""
 
-#: static/js/zamboni/mobile/buttons.js:58
+#: static/js/zamboni/mobile-all.js:15192 static/js/zamboni/mobile/buttons.js:58
 msgid "Experimental"
 msgstr ""
 
-#: static/js/zamboni/mobile/buttons.js:59
+#: static/js/zamboni/mobile-all.js:15193 static/js/zamboni/mobile/buttons.js:59
 msgid "Themes Require Newer Version of {0}"
 msgstr ""
 
-#: static/js/zamboni/mobile/buttons.js:60
+#: static/js/zamboni/mobile-all.js:15194 static/js/zamboni/mobile/buttons.js:60
 msgid "Themes Require {0}"
 msgstr ""
 
-#: static/js/zamboni/mobile/buttons.js:105
+#: static/js/zamboni/mobile-all.js:15239 static/js/zamboni/mobile/buttons.js:105
 msgid "Installing..."
 msgstr ""
 
-#: static/js/zamboni/mobile/buttons.js:125
+#: static/js/zamboni/mobile-all.js:15259 static/js/zamboni/mobile/buttons.js:125
 msgid "This add-on has been preliminarily reviewed by Mozilla."
 msgstr ""
 
-#: static/js/zamboni/mobile/buttons.js:250
+#: static/js/zamboni/mobile-all.js:15384 static/js/zamboni/mobile/buttons.js:250
 msgid "Keep it"
 msgstr ""
 
-#: static/js/zamboni/mobile/general.js:344
+#: static/js/zamboni/mobile-all.js:16049 static/js/zamboni/mobile-min.js:6 static/js/zamboni/mobile/general.js:344
 msgid "You're trying it on!"
 msgstr ""
 
-#: static/js/zamboni/mobile/general.js:356
+#: static/js/zamboni/mobile-all.js:16061 static/js/zamboni/mobile-min.js:6 static/js/zamboni/mobile/general.js:356
 msgid "Added to Firefox"
 msgstr ""
-

--- a/locale/eu/LC_MESSAGES/django.po
+++ b/locale/eu/LC_MESSAGES/django.po
@@ -8,69 +8,70 @@ msgid ""
 msgstr ""
 "Project-Id-Version:  messages.pootle\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2016-02-24 21:23+0000\n"
+"POT-Creation-Date: 2016-04-18 15:47+0000\n"
 "PO-Revision-Date: 2013-11-07 07:24+0000\n"
 "Last-Translator: Julen <julenx@gmail.com>\n"
 "Language-Team: librezale@librezale.org\n"
+"Language: \n"
 "MIME-Version: 1.0\n"
-"Content-Type: text/plain; charset=utf-8\n"
+"Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Generated-By: Babel 2.2.0\n"
 
-#: src/olympia/accounts/views.py:52
+#: src/olympia/accounts/views.py:54
 msgid "Your log in attempt could not be parsed. Please try again."
 msgstr ""
 
-#: src/olympia/accounts/views.py:54
+#: src/olympia/accounts/views.py:56
 msgid "Your Firefox Account could not be found. Please try again."
 msgstr ""
 
-#: src/olympia/accounts/views.py:55
+#: src/olympia/accounts/views.py:57
 msgid "You could not be logged in. Please try again."
 msgstr ""
 
-#: src/olympia/accounts/views.py:57
+#: src/olympia/accounts/views.py:59
 msgid "Your account has already been migrated to Firefox Accounts."
 msgstr ""
 
-#: src/olympia/accounts/views.py:59
+#: src/olympia/accounts/views.py:61
 msgid "Your Firefox Account already exists on this site."
 msgstr ""
 
-#: src/olympia/accounts/views.py:108
+#: src/olympia/accounts/views.py:110
 msgid "Great job!"
 msgstr ""
 
-#: src/olympia/accounts/views.py:109
+#: src/olympia/accounts/views.py:111
 msgid "You can now log in to Add-ons with your Firefox Account."
 msgstr ""
 
-#: src/olympia/accounts/views.py:121
+#: src/olympia/accounts/views.py:123
 msgid "Need help?"
 msgstr ""
 
-#: src/olympia/addons/buttons.py:180
+#: src/olympia/addons/buttons.py:177
 msgid "Download Now"
 msgstr "Deskargatu orain"
 
-#: src/olympia/addons/buttons.py:182
+#: src/olympia/addons/buttons.py:179
 msgid "Download"
 msgstr "Deskargatu"
 
 #. L10n: please keep &nbsp; in the string so &rarr; does not wrap.
-#: src/olympia/addons/buttons.py:186
+#: src/olympia/addons/buttons.py:183
 msgid "Continue to Download&nbsp;&rarr;"
 msgstr "Jarraitu deskargara&nbsp;&rarr;"
 
-#: src/olympia/addons/buttons.py:202 src/olympia/addons/helpers.py:35 src/olympia/addons/views.py:319 src/olympia/addons/templates/addons/impala/details.html:114
+#: src/olympia/addons/buttons.py:199 src/olympia/addons/helpers.py:35 src/olympia/addons/views.py:333 src/olympia/addons/templates/addons/impala/details.html:111
 #: src/olympia/addons/templates/addons/impala/listing/items.html:17 src/olympia/addons/templates/addons/mobile/home.html:40 src/olympia/amo/templates/amo/side_nav.html:6
-#: src/olympia/amo/templates/amo/side_nav.html:10 src/olympia/amo/templates/amo/site_nav.html:2 src/olympia/amo/templates/amo/site_nav.html:55 src/olympia/bandwagon/views.py:95
-#: src/olympia/browse/views.py:54 src/olympia/browse/views.py:68 src/olympia/browse/views.py:235 src/olympia/browse/templates/browse/impala/category_landing.html:22
+#: src/olympia/amo/templates/amo/side_nav.html:10 src/olympia/amo/templates/amo/site_nav.html:2 src/olympia/amo/templates/amo/site_nav.html:53 src/olympia/bandwagon/views.py:95
+#: src/olympia/browse/views.py:54 src/olympia/browse/views.py:68 src/olympia/browse/views.py:202 src/olympia/browse/templates/browse/impala/category_landing.html:22
 #: src/olympia/browse/templates/browse/personas/mobile/category_landing.html:26
 msgid "Featured"
 msgstr "Nabarmenduak"
 
-#: src/olympia/addons/buttons.py:221
+#: src/olympia/addons/buttons.py:218
 msgid "Add to {0}"
 msgstr "Gehitu {0}(e)ra"
 
@@ -118,39 +119,39 @@ msgid_plural "All tags must be at least {0} characters."
 msgstr[0] "Etiketa guztiek gutxienez karaktere bat izan behar dute."
 msgstr[1] "Etiketa guztiek gutxienez {0} karaktere izan behar dituzte."
 
-#: src/olympia/addons/forms.py:234
+#: src/olympia/addons/forms.py:238
 msgid "Categories cannot be changed while your add-on is featured for this application."
 msgstr ""
 
 #. L10n: {0} is the number of categories.
-#: src/olympia/addons/forms.py:238
+#: src/olympia/addons/forms.py:242
 msgid "You can have only {0} category."
 msgid_plural "You can have only {0} categories."
 msgstr[0] "Kategoria bakarra izan dezakezu soilik."
 msgstr[1] "{0} kategoria izan ditzakezu soilik."
 
-#: src/olympia/addons/forms.py:246
+#: src/olympia/addons/forms.py:250
 msgid "The miscellaneous category cannot be combined with additional categories."
 msgstr ""
 
-#: src/olympia/addons/forms.py:369
+#: src/olympia/addons/forms.py:374
 #, python-format
 msgid "Before changing your default locale you must have a name, summary, and description in that locale. You are missing %s."
 msgstr ""
 
-#: src/olympia/addons/forms.py:484 src/olympia/addons/forms.py:575
+#: src/olympia/addons/forms.py:455 src/olympia/addons/forms.py:546
 msgid "A license must be selected."
 msgstr ""
 
-#: src/olympia/addons/forms.py:556
+#: src/olympia/addons/forms.py:527
 msgid "Give Your Theme a Name."
 msgstr ""
 
-#: src/olympia/addons/forms.py:562 src/olympia/devhub/templates/devhub/personas/submit.html:53
+#: src/olympia/addons/forms.py:533 src/olympia/devhub/templates/devhub/personas/submit.html:53
 msgid "Describe your Theme."
 msgstr ""
 
-#: src/olympia/addons/forms.py:704
+#: src/olympia/addons/forms.py:675
 msgid "Enter a new author's email address"
 msgstr ""
 
@@ -158,39 +159,39 @@ msgstr ""
 msgid "Not Reviewed"
 msgstr "Berrikusi gabea"
 
-#: src/olympia/addons/models.py:301
+#: src/olympia/addons/models.py:298
 msgid "Users have the option of contributing more or less than this amount."
 msgstr ""
 
-#: src/olympia/addons/models.py:309
-msgid "Users will always be asked in the Add-ons Manager (Firefox 4 and above)"
-msgstr "Erabiltzaileei beti galdetuko zaie gehigarrien kudeatzailean (Firefox 4 eta berriagoak)"
+#: src/olympia/addons/models.py:306
+msgid "Users will always be asked in the Add-ons Manager (Firefox 4 and above). Only applies to desktop."
+msgstr ""
 
 # Column name in a table.
-#: src/olympia/addons/models.py:1804 src/olympia/addons/templates/addons/details_box.html:55 src/olympia/devhub/templates/devhub/index.html:92
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:102
+#: src/olympia/addons/models.py:1802 src/olympia/addons/templates/addons/details_box.html:55 src/olympia/devhub/templates/devhub/index.html:92
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:89
 msgid "Listed"
 msgstr "Zerrendatuta"
 
-#: src/olympia/addons/views.py:320 src/olympia/browse/templates/browse/personas/mobile/category_landing.html:27
+#: src/olympia/addons/views.py:334 src/olympia/browse/templates/browse/personas/mobile/category_landing.html:27
 msgid "Popular"
 msgstr "Arrakastatsuak"
 
-#: src/olympia/addons/views.py:321 src/olympia/browse/views.py:238 src/olympia/browse/views.py:280 src/olympia/browse/views.py:482
+#: src/olympia/addons/views.py:335 src/olympia/browse/views.py:205 src/olympia/browse/views.py:247 src/olympia/browse/views.py:449
 msgid "Recently Added"
 msgstr "Gehitutako azkenak"
 
-#: src/olympia/addons/views.py:322 src/olympia/bandwagon/views.py:99 src/olympia/browse/views.py:60 src/olympia/browse/views.py:71 src/olympia/search/forms.py:16 src/olympia/search/forms.py:91
+#: src/olympia/addons/views.py:336 src/olympia/bandwagon/views.py:99 src/olympia/browse/views.py:60 src/olympia/browse/views.py:71 src/olympia/search/forms.py:16 src/olympia/search/forms.py:91
 msgid "Recently Updated"
 msgstr "Eguneraketak"
 
 # %1 is an add-on name.
 #. l10n: {0} is the addon name
-#: src/olympia/addons/views.py:520
+#: src/olympia/addons/views.py:534
 msgid "Contribution for {0}"
 msgstr "Ekarpena {0} gehigarriarentzat"
 
-#: src/olympia/addons/views.py:613
+#: src/olympia/addons/views.py:627
 msgid "Abuse reported."
 msgstr ""
 
@@ -259,9 +260,9 @@ msgstr "Egin ekarpena"
 #: src/olympia/devhub/templates/devhub/addons/ajax_compat_update.html:36 src/olympia/devhub/templates/devhub/addons/profile.html:44 src/olympia/devhub/templates/devhub/addons/edit/admin.html:101
 #: src/olympia/devhub/templates/devhub/addons/edit/basic.html:152 src/olympia/devhub/templates/devhub/addons/edit/details.html:85 src/olympia/devhub/templates/devhub/addons/edit/support.html:67
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:166 src/olympia/devhub/templates/devhub/addons/forms_shared/media.html:149
-#: src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:44 src/olympia/devhub/templates/devhub/versions/add_file_modal.html:78 src/olympia/devhub/templates/devhub/versions/edit.html:139
-#: src/olympia/devhub/templates/devhub/versions/list.html:242 src/olympia/devhub/templates/devhub/versions/list.html:276 src/olympia/devhub/templates/devhub/versions/list.html:317
-#: src/olympia/devhub/templates/devhub/versions/list.html:351 src/olympia/reviews/templates/reviews/edit_review.html:16 src/olympia/translations/templates/translations/trans-menu.html:50
+#: src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:43 src/olympia/devhub/templates/devhub/versions/add_file_modal.html:58 src/olympia/devhub/templates/devhub/versions/edit.html:139
+#: src/olympia/devhub/templates/devhub/versions/list.html:239 src/olympia/devhub/templates/devhub/versions/list.html:281 src/olympia/devhub/templates/devhub/versions/list.html:315
+#: src/olympia/devhub/templates/devhub/versions/list.html:349 src/olympia/reviews/templates/reviews/edit_review.html:16 src/olympia/translations/templates/translations/trans-menu.html:50
 #: src/olympia/translations/templates/translations/trans-menu.html:62
 msgid "or"
 msgstr "edo"
@@ -372,7 +373,7 @@ msgid "Add-on Information for {0}"
 msgstr ""
 
 #: src/olympia/addons/templates/addons/details_box.html:30 src/olympia/addons/templates/addons/persona_detail_table.html:3 src/olympia/addons/templates/addons/mobile/details.html:63
-#: src/olympia/addons/templates/addons/mobile/persona_detail_table.html:7 src/olympia/browse/views.py:459 src/olympia/devhub/views.py:75
+#: src/olympia/addons/templates/addons/mobile/persona_detail_table.html:7 src/olympia/browse/views.py:426 src/olympia/devhub/views.py:73
 msgid "Updated"
 msgstr "Eguneratua"
 
@@ -391,11 +392,11 @@ msgstr "Honekin dabil"
 msgid "Visibility"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/details_box.html:57 src/olympia/devhub/templates/devhub/index.html:94 src/olympia/devhub/templates/devhub/includes/addon_details.html:104
+#: src/olympia/addons/templates/addons/details_box.html:57 src/olympia/devhub/templates/devhub/index.html:94 src/olympia/devhub/templates/devhub/includes/addon_details.html:91
 msgid "Hidden"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/details_box.html:59 src/olympia/devhub/templates/devhub/index.html:96 src/olympia/devhub/templates/devhub/includes/addon_details.html:106
+#: src/olympia/addons/templates/addons/details_box.html:59 src/olympia/devhub/templates/devhub/index.html:96 src/olympia/devhub/templates/devhub/includes/addon_details.html:93
 msgid "Unlisted"
 msgstr ""
 
@@ -403,13 +404,13 @@ msgstr ""
 msgid "Required Add-ons"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/details_box.html:81 src/olympia/addons/templates/addons/persona_detail_table.html:15 src/olympia/browse/views.py:462 src/olympia/devhub/views.py:78
-#: src/olympia/devhub/views.py:85 src/olympia/discovery/templates/discovery/addons/detail.html:57 src/olympia/reviews/forms.py:62 src/olympia/reviews/templates/reviews/add.html:57
+#: src/olympia/addons/templates/addons/details_box.html:81 src/olympia/addons/templates/addons/persona_detail_table.html:15 src/olympia/browse/views.py:429 src/olympia/devhub/views.py:76
+#: src/olympia/devhub/views.py:83 src/olympia/discovery/templates/discovery/addons/detail.html:57 src/olympia/reviews/forms.py:62 src/olympia/reviews/templates/reviews/add.html:57
 #: src/olympia/reviews/templates/reviews/mobile/review_list.html:18
 msgid "Rating"
 msgstr "Balorazioa"
 
-#: src/olympia/addons/templates/addons/details_box.html:85 src/olympia/browse/views.py:461 src/olympia/devhub/views.py:77 src/olympia/devhub/views.py:84
+#: src/olympia/addons/templates/addons/details_box.html:85 src/olympia/browse/views.py:428 src/olympia/devhub/views.py:75 src/olympia/devhub/views.py:82
 #: src/olympia/stats/templates/stats/addon_report_menu.html:8 src/olympia/stats/templates/stats/collection_report_menu.html:18
 msgid "Downloads"
 msgstr "Deskargak"
@@ -429,7 +430,7 @@ msgstr ""
 
 #. The Privacy Policy for this add-on.
 #: src/olympia/addons/templates/addons/details_box.html:121 src/olympia/addons/templates/addons/privacy.html:19 src/olympia/addons/templates/addons/privacy.html:23
-#: src/olympia/addons/templates/addons/impala/button.html:43 src/olympia/addons/templates/addons/impala/details.html:307 src/olympia/devhub/templates/devhub/includes/policy_form.html:20
+#: src/olympia/addons/templates/addons/impala/button.html:43 src/olympia/addons/templates/addons/impala/details.html:312 src/olympia/devhub/templates/devhub/includes/policy_form.html:23
 #: src/olympia/templates/mobile/base_addons.html:87
 msgid "Privacy Policy"
 msgstr "Pribatutasun-politika"
@@ -454,7 +455,7 @@ msgstr "Irudi-galeria"
 msgid "Developer Comments"
 msgstr "Garatzailearen iruzkinak"
 
-#: src/olympia/addons/templates/addons/details_box.html:199 src/olympia/addons/templates/addons/impala/details.html:259
+#: src/olympia/addons/templates/addons/details_box.html:199 src/olympia/addons/templates/addons/impala/details.html:264
 msgid "Development Channel"
 msgstr "Garapen-kanala"
 
@@ -474,7 +475,7 @@ msgid ""
 "developer. To stop receiving development updates, reinstall the default version from the link above."
 msgstr ""
 
-#: src/olympia/addons/templates/addons/details_box.html:220 src/olympia/addons/templates/addons/impala/details.html:278
+#: src/olympia/addons/templates/addons/details_box.html:220 src/olympia/addons/templates/addons/impala/details.html:283
 msgid "Version {0}:"
 msgstr "{0} bertsioa:"
 
@@ -493,7 +494,7 @@ msgid "End-User License Agreement for {0}"
 msgstr "{0} gehigarriaren Azken Erabiltzailearen Lizentzia-kontratua"
 
 #: src/olympia/addons/templates/addons/eula.html:17 src/olympia/addons/templates/addons/eula.html:21 src/olympia/addons/templates/addons/impala/button.html:48
-#: src/olympia/addons/templates/addons/impala/details.html:316 src/olympia/devhub/templates/devhub/includes/policy_form.html:3 src/olympia/discovery/templates/discovery/addons/eula.html:11
+#: src/olympia/addons/templates/addons/impala/details.html:321 src/olympia/devhub/templates/devhub/includes/policy_form.html:3 src/olympia/discovery/templates/discovery/addons/eula.html:11
 msgid "End-User License Agreement"
 msgstr "Azken Erabiltzailearen Lizentzia-kontratua"
 
@@ -512,7 +513,7 @@ msgstr "Atzera {0}(e)ra…"
 msgid "Add-ons for {0}"
 msgstr "{0}(e)rako gehigarriak"
 
-#: src/olympia/addons/templates/addons/home.html:10 src/olympia/addons/templates/addons/home.html:51 src/olympia/browse/templates/browse/impala/base_listing.html:11
+#: src/olympia/addons/templates/addons/home.html:10 src/olympia/addons/templates/addons/home.html:53 src/olympia/browse/templates/browse/impala/base_listing.html:11
 msgid "Featured Extensions"
 msgstr "Nabarmendutako gehigarriak"
 
@@ -520,29 +521,29 @@ msgstr "Nabarmendutako gehigarriak"
 msgid "Popular Extensions"
 msgstr "Gehigarri ezagunak"
 
-#: src/olympia/addons/templates/addons/home.html:42 src/olympia/amo/templates/amo/side_nav.html:3 src/olympia/amo/templates/amo/side_nav.html:11 src/olympia/amo/templates/amo/site_nav.html:3
-#: src/olympia/amo/templates/amo/site_nav.html:25 src/olympia/browse/views.py:236 src/olympia/browse/views.py:281 src/olympia/browse/views.py:481
+#: src/olympia/addons/templates/addons/home.html:44 src/olympia/amo/templates/amo/side_nav.html:3 src/olympia/amo/templates/amo/side_nav.html:11 src/olympia/amo/templates/amo/site_nav.html:3
+#: src/olympia/amo/templates/amo/site_nav.html:25 src/olympia/browse/views.py:203 src/olympia/browse/views.py:248 src/olympia/browse/views.py:448
 msgid "Most Popular"
 msgstr "Ezagunenak"
 
-#: src/olympia/addons/templates/addons/home.html:43
+#: src/olympia/addons/templates/addons/home.html:45
 msgid "All »"
 msgstr "Guztiak »"
 
-#: src/olympia/addons/templates/addons/home.html:52 src/olympia/addons/templates/addons/home.html:61 src/olympia/addons/templates/addons/home.html:70 src/olympia/addons/templates/addons/home.html:78
+#: src/olympia/addons/templates/addons/home.html:54 src/olympia/addons/templates/addons/home.html:63 src/olympia/addons/templates/addons/home.html:72 src/olympia/addons/templates/addons/home.html:80
 #: src/olympia/browse/templates/browse/impala/category_landing.html:36
 msgid "See all »"
 msgstr "Ikusi guztiak »"
 
-#: src/olympia/addons/templates/addons/home.html:60
+#: src/olympia/addons/templates/addons/home.html:62
 msgid "Up &amp; Coming Extensions"
 msgstr "Datozen gehigarriak"
 
-#: src/olympia/addons/templates/addons/home.html:69 src/olympia/browse/templates/browse/personas/category_landing.html:61 src/olympia/discovery/templates/discovery/pane.html:74
+#: src/olympia/addons/templates/addons/home.html:71 src/olympia/browse/templates/browse/personas/category_landing.html:61 src/olympia/discovery/templates/discovery/pane.html:74
 msgid "Featured Themes"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/home.html:77 src/olympia/bandwagon/templates/bandwagon/impala/collection_listing.html:5
+#: src/olympia/addons/templates/addons/home.html:79 src/olympia/bandwagon/templates/bandwagon/impala/collection_listing.html:5
 msgid "Featured Collections"
 msgstr "Nabarmendutako bildumak"
 
@@ -560,7 +561,7 @@ msgid "Updated {0}"
 msgstr "Eguneraketa: {0}"
 
 #. {0} is a date.
-#: src/olympia/addons/templates/addons/macros.html:10 src/olympia/addons/templates/addons/macros.html:69 src/olympia/addons/templates/addons/persona_preview.html:21
+#: src/olympia/addons/templates/addons/macros.html:10 src/olympia/addons/templates/addons/macros.html:69 src/olympia/addons/templates/addons/persona_preview.html:22
 #: src/olympia/addons/templates/addons/listing/items_mobile.html:44 src/olympia/addons/templates/addons/listing/macros.html:39
 #: src/olympia/bandwagon/templates/bandwagon/collection_listing_items.html:37 src/olympia/bandwagon/templates/bandwagon/impala/collection_listing_items.html:37
 msgid "Added {0}"
@@ -581,15 +582,14 @@ msgstr[0] "Erabiltzaile bat"
 msgstr[1] "%(num)s erabiltzaile"
 
 #. {0} is the number of downloads.
-#: src/olympia/addons/templates/addons/macros.html:53 src/olympia/addons/templates/addons/impala/details.html:61
+#: src/olympia/addons/templates/addons/macros.html:53 src/olympia/addons/templates/addons/impala/details.html:59
 msgid "{0} weekly download"
 msgid_plural "{0} weekly downloads"
 msgstr[0] "Deskarga bat asteko"
 msgstr[1] "{0} deskarga asteko"
 
 #. {0} is the number of users.
-#: src/olympia/addons/templates/addons/macros.html:61 src/olympia/addons/templates/addons/impala/details.html:54 src/olympia/compat/templates/compat/index.html:71
-#: src/olympia/zadmin/templates/zadmin/compat.html:67
+#: src/olympia/addons/templates/addons/macros.html:61 src/olympia/addons/templates/addons/impala/details.html:52 src/olympia/zadmin/templates/zadmin/compat.html:67
 msgid "{0} user"
 msgid_plural "{0} users"
 msgstr[0] "Erabiltzaile bat"
@@ -607,7 +607,7 @@ msgstr "Ordainketa burututa"
 msgid "Return to the addon."
 msgstr "Itzuli gehigarrira."
 
-#: src/olympia/addons/templates/addons/persona_detail.html:17 src/olympia/addons/templates/addons/impala/details.html:106 src/olympia/addons/templates/addons/mobile/details.html:23
+#: src/olympia/addons/templates/addons/persona_detail.html:17 src/olympia/addons/templates/addons/impala/details.html:103 src/olympia/addons/templates/addons/mobile/details.html:23
 #: src/olympia/addons/templates/addons/mobile/persona_detail.html:21 src/olympia/discovery/templates/discovery/addons/base.html:27 src/olympia/editors/templates/editors/review.html:31
 msgid "by"
 msgstr "egilea:"
@@ -651,20 +651,20 @@ msgstr "Eguneko erabiltzaileak"
 msgid "License"
 msgstr "Lizentzia"
 
-#: src/olympia/addons/templates/addons/persona_preview.html:12 src/olympia/constants/base.py:48
+#: src/olympia/addons/templates/addons/persona_preview.html:13 src/olympia/constants/base.py:48
 msgid "Awaiting Review"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/persona_preview.html:14 src/olympia/amo/log.py:180 src/olympia/constants/base.py:42 src/olympia/editors/helpers.py:62
+#: src/olympia/addons/templates/addons/persona_preview.html:15 src/olympia/amo/log.py:180 src/olympia/constants/base.py:42 src/olympia/editors/helpers.py:62
 msgid "Rejected"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/persona_preview.html:16 src/olympia/amo/log.py:159
+#: src/olympia/addons/templates/addons/persona_preview.html:17 src/olympia/amo/log.py:159
 msgid "Approved"
 msgstr ""
 
 #. {0} is the number of users.
-#: src/olympia/addons/templates/addons/persona_preview.html:26 src/olympia/addons/templates/addons/listing/items_mobile.html:36 src/olympia/addons/templates/addons/listing/macros.html:31
+#: src/olympia/addons/templates/addons/persona_preview.html:27 src/olympia/addons/templates/addons/listing/items_mobile.html:36 src/olympia/addons/templates/addons/listing/macros.html:31
 msgid "<strong>{0}</strong> user"
 msgid_plural "<strong>{0}</strong> users"
 msgstr[0] ""
@@ -673,15 +673,16 @@ msgstr[1] ""
 # This appears on a page that views the source of an add-on.  This link will return
 # the user to the add-on's review page (it only appears if the add-on is being
 # reviewed)
-#: src/olympia/addons/templates/addons/persona_preview.html:40
+#: src/olympia/addons/templates/addons/persona_preview.html:41
 msgid "Hover to Preview"
 msgstr "Pasa sagua gainetik berrikuspenerako"
 
-#: src/olympia/addons/templates/addons/persona_preview.html:46 src/olympia/addons/templates/addons/persona_preview.html:48 src/olympia/reviews/templates/reviews/add.html:15
+#: src/olympia/addons/templates/addons/persona_preview.html:47 src/olympia/addons/templates/addons/persona_preview.html:49 src/olympia/addons/templates/addons/persona_preview.html:97
+#: src/olympia/reviews/templates/reviews/add.html:15
 msgid "Add"
 msgstr "Gehitu"
 
-#: src/olympia/addons/templates/addons/persona_preview.html:57 src/olympia/bandwagon/templates/bandwagon/ajax_new.html:16 src/olympia/bandwagon/templates/bandwagon/edit.html:19
+#: src/olympia/addons/templates/addons/persona_preview.html:58 src/olympia/bandwagon/templates/bandwagon/ajax_new.html:16 src/olympia/bandwagon/templates/bandwagon/edit.html:19
 #: src/olympia/bandwagon/templates/bandwagon/includes/addedit.html:19 src/olympia/devhub/templates/devhub/addons/edit/admin.html:13 src/olympia/devhub/templates/devhub/addons/edit/basic.html:10
 #: src/olympia/devhub/templates/devhub/addons/edit/details.html:8 src/olympia/devhub/templates/devhub/addons/edit/media.html:6 src/olympia/devhub/templates/devhub/addons/edit/support.html:8
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:9 src/olympia/devhub/templates/devhub/addons/submit/describe.html:29 src/olympia/editors/templates/editors/review.html:257
@@ -690,21 +691,21 @@ msgstr "Editatu"
 
 #. For datetime formatting, see the table on
 #. http://docs.python.org/library/datetime.html#strftime-and-strptime-behavior
-#: src/olympia/addons/templates/addons/persona_preview.html:66
+#: src/olympia/addons/templates/addons/persona_preview.html:67
 #, python-format
 msgid "%%Y-%%m-%%d"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/persona_preview.html:67
+#: src/olympia/addons/templates/addons/persona_preview.html:68
 msgid "by {0} on {1}"
 msgstr "{0}(e)k {1}(e)an"
 
-#: src/olympia/addons/templates/addons/persona_preview.html:75 src/olympia/reviews/helpers.py:17 src/olympia/reviews/templates/reviews/review_list.html:63
+#: src/olympia/addons/templates/addons/persona_preview.html:76 src/olympia/reviews/helpers.py:17 src/olympia/reviews/templates/reviews/review_list.html:63
 #: src/olympia/reviews/templates/reviews/reviews_link.html:21 src/olympia/reviews/templates/reviews/impala/reviews_link.html:16
 msgid "Not yet rated"
 msgstr "Puntuatu gabe oraindik"
 
-#: src/olympia/addons/templates/addons/persona_preview.html:78
+#: src/olympia/addons/templates/addons/persona_preview.html:79
 msgid "<b>{0}</b> users"
 msgstr "<b>{0}</b> erabiltzaile"
 
@@ -717,8 +718,8 @@ msgid "Learn more about Firefox"
 msgstr "Firefoxi buruzko argibide gehiago"
 
 #: src/olympia/addons/templates/addons/popups.html:22
-msgid "or <b><a class=\"installer\" href=\"{url}\">download anyway</a></b>"
-msgstr "edo <b><a class=\"installer\" href=\"{url}\">deskargatu halere</a></b>"
+msgid "or <b><a class=\"button installer\" href=\"{url}\">download anyway</a></b>"
+msgstr ""
 
 #: src/olympia/addons/templates/addons/popups.html:26
 msgid ""
@@ -816,7 +817,7 @@ msgid ""
 msgstr ""
 
 #: src/olympia/addons/templates/addons/report_abuse.html:6 src/olympia/addons/templates/addons/report_abuse_full.html:10 src/olympia/addons/templates/addons/impala/details-more.html:23
-#: src/olympia/addons/templates/addons/impala/details.html:328
+#: src/olympia/addons/templates/addons/impala/details.html:333
 msgid "Report Abuse"
 msgstr ""
 
@@ -835,9 +836,9 @@ msgstr "Bidali txostena"
 #: src/olympia/devhub/templates/devhub/addons/ajax_compat_update.html:36 src/olympia/devhub/templates/devhub/addons/profile.html:44 src/olympia/devhub/templates/devhub/addons/edit/admin.html:104
 #: src/olympia/devhub/templates/devhub/addons/edit/basic.html:155 src/olympia/devhub/templates/devhub/addons/edit/details.html:88 src/olympia/devhub/templates/devhub/addons/edit/support.html:70
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:169 src/olympia/devhub/templates/devhub/addons/forms_shared/media.html:152
-#: src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:44 src/olympia/devhub/templates/devhub/personas/edit.html:222 src/olympia/devhub/templates/devhub/versions/add_file_modal.html:79
-#: src/olympia/devhub/templates/devhub/versions/edit.html:140 src/olympia/devhub/templates/devhub/versions/list.html:208 src/olympia/devhub/templates/devhub/versions/list.html:242
-#: src/olympia/devhub/templates/devhub/versions/list.html:276 src/olympia/devhub/templates/devhub/versions/list.html:317 src/olympia/reviews/templates/reviews/edit_review.html:16
+#: src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:43 src/olympia/devhub/templates/devhub/personas/edit.html:222 src/olympia/devhub/templates/devhub/versions/add_file_modal.html:59
+#: src/olympia/devhub/templates/devhub/versions/edit.html:140 src/olympia/devhub/templates/devhub/versions/list.html:208 src/olympia/devhub/templates/devhub/versions/list.html:239
+#: src/olympia/devhub/templates/devhub/versions/list.html:281 src/olympia/devhub/templates/devhub/versions/list.html:315 src/olympia/reviews/templates/reviews/edit_review.html:16
 #: src/olympia/translations/templates/translations/trans-menu.html:50 src/olympia/translations/templates/translations/trans-menu.html:62 src/olympia/zadmin/templates/zadmin/validation.html:105
 msgid "Cancel"
 msgstr "Utzi"
@@ -884,7 +885,7 @@ msgstr "Ikusi <a href=\"%(support)s\">laguntzaren atala</a> gehigarri honentzako
 msgid "Review Guidelines"
 msgstr "Berrikusteko gidalerroak"
 
-#: src/olympia/addons/templates/addons/review_list_box.html:5 src/olympia/addons/templates/addons/impala/details-more.html:27 src/olympia/editors/helpers.py:921
+#: src/olympia/addons/templates/addons/review_list_box.html:5 src/olympia/addons/templates/addons/impala/details-more.html:27 src/olympia/editors/helpers.py:1001
 #: src/olympia/reviews/templates/reviews/add.html:14 src/olympia/reviews/templates/reviews/reply.html:14 src/olympia/reviews/templates/reviews/review_list.html:19
 #: src/olympia/reviews/templates/reviews/mobile/review_list.html:26
 msgid "Reviews"
@@ -975,31 +976,31 @@ msgid_plural "Other add-ons by these authors"
 msgstr[0] "%(author)s egilearen gehigarri gehiago"
 msgstr[1] "Egile hauen gehigarri gehiago"
 
-#: src/olympia/addons/templates/addons/impala/details.html:41
+#: src/olympia/addons/templates/addons/impala/details.html:39
 #, python-format
 msgid "<span itemprop=\"ratingCount\">%(num)s</span> user review"
 msgid_plural "<span itemprop=\"ratingCount\">%(num)s</span> user reviews"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/olympia/addons/templates/addons/impala/details.html:69
+#: src/olympia/addons/templates/addons/impala/details.html:66
 msgid "View statistics"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/impala/details.html:84
+#: src/olympia/addons/templates/addons/impala/details.html:81
 msgid "Manage"
 msgstr "Kudeatu"
 
 #. {0} is an add-on name.
-#: src/olympia/addons/templates/addons/impala/details.html:96
+#: src/olympia/addons/templates/addons/impala/details.html:93
 msgid "Icon of {0}"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/impala/details.html:103 src/olympia/addons/templates/addons/impala/listing/items.html:14
+#: src/olympia/addons/templates/addons/impala/details.html:100 src/olympia/addons/templates/addons/impala/listing/items.html:14
 msgid "No Restart"
 msgstr "Berrabiarazterik gabe"
 
-#: src/olympia/addons/templates/addons/impala/details.html:127
+#: src/olympia/addons/templates/addons/impala/details.html:124
 #, fuzzy, python-format
 msgid "Meet the Developer: <a href=\"%(url)s\">%(name)s</a>"
 msgid_plural "<a href=\"%(url)s\">Meet the Developers</a>"
@@ -1007,88 +1008,88 @@ msgstr[0] "Ezagutu garatzailea: <a href=\"%(url)s\">%(name)s</a>"
 msgstr[1] "<a href=\"%(url)s\">Ezagutu garatzaileak</a>"
 
 # {0} is an add-on name.
-#: src/olympia/addons/templates/addons/impala/details.html:137
+#: src/olympia/addons/templates/addons/impala/details.html:134
 msgid "Learn why {0} was created and find out what's next for this add-on."
 msgstr "Ikusi zergatik sortu zen {0} eta begiratu zer ekarriko duen etorkizunean."
 
 #. {0} is an index.
-#: src/olympia/addons/templates/addons/impala/details.html:156
+#: src/olympia/addons/templates/addons/impala/details.html:161
 msgid "Add-on screenshot #{0}"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/impala/details.html:182
+#: src/olympia/addons/templates/addons/impala/details.html:187
 msgid "Add-on home page"
 msgstr "Gehigarriaren webgunea"
 
-#: src/olympia/addons/templates/addons/impala/details.html:185
+#: src/olympia/addons/templates/addons/impala/details.html:190
 msgid "Support site"
 msgstr "Laguntzarako gunea"
 
-#: src/olympia/addons/templates/addons/impala/details.html:189
+#: src/olympia/addons/templates/addons/impala/details.html:194
 msgid "Support E-mail"
 msgstr "Laguntzarako helbide elektronikoa"
 
-#: src/olympia/addons/templates/addons/impala/details.html:194 src/olympia/devhub/models.py:378 src/olympia/devhub/templates/devhub/versions/list.html:12
+#: src/olympia/addons/templates/addons/impala/details.html:199 src/olympia/devhub/models.py:378 src/olympia/devhub/templates/devhub/versions/list.html:12
 #: src/olympia/versions/templates/versions/version.html:6 src/olympia/versions/templates/versions/mobile/version.html:6
 msgid "Version {0}"
 msgstr "{0} bertsioa"
 
-#: src/olympia/addons/templates/addons/impala/details.html:194
+#: src/olympia/addons/templates/addons/impala/details.html:199
 msgid "Info"
 msgstr "Informazioa"
 
-#: src/olympia/addons/templates/addons/impala/details.html:195 src/olympia/devhub/templates/devhub/includes/addon_details.html:129
+#: src/olympia/addons/templates/addons/impala/details.html:200 src/olympia/devhub/templates/devhub/includes/addon_details.html:116
 msgid "Last Updated:"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/impala/details.html:200
+#: src/olympia/addons/templates/addons/impala/details.html:205
 #, python-format
 msgid "Released under <a target=\"_blank\" href=\"%(url)s\">%(name)s</a>"
 msgstr "<a target=\"_blank\" href=\"%(url)s\">%(name)s</a> lizentziarekin argitaratua"
 
-#: src/olympia/addons/templates/addons/impala/details.html:201 src/olympia/addons/templates/addons/impala/details.html:206 src/olympia/amo/helpers.py:398 src/olympia/devhub/forms.py:142
+#: src/olympia/addons/templates/addons/impala/details.html:206 src/olympia/addons/templates/addons/impala/details.html:211 src/olympia/amo/helpers.py:398 src/olympia/devhub/forms.py:142
 #: src/olympia/devhub/forms.py:173 src/olympia/versions/templates/versions/version.html:40 src/olympia/versions/templates/versions/version.html:45
 msgid "Custom License"
 msgstr "Lizentzia pertsonalizatua"
 
-#: src/olympia/addons/templates/addons/impala/details.html:205
+#: src/olympia/addons/templates/addons/impala/details.html:210
 #, python-format
 msgid "Released under <a href=\"%(url)s\">%(name)s</a>"
 msgstr "<a href=\"%(url)s\">%(name)s</a> lizentziarekin argitaratua"
 
-#: src/olympia/addons/templates/addons/impala/details.html:217
+#: src/olympia/addons/templates/addons/impala/details.html:222
 msgid "About this Add-on"
 msgstr "Gehigarri honi buruz"
 
-#: src/olympia/addons/templates/addons/impala/details.html:233
+#: src/olympia/addons/templates/addons/impala/details.html:238
 msgid "Developer’s Comments"
 msgstr "Garatzaileen iruzkinak"
 
-#: src/olympia/addons/templates/addons/impala/details.html:243
+#: src/olympia/addons/templates/addons/impala/details.html:248
 msgid "Version Information"
 msgstr "Bertsioaren informazioa"
 
-#: src/olympia/addons/templates/addons/impala/details.html:250
+#: src/olympia/addons/templates/addons/impala/details.html:255
 msgid "See complete version history"
 msgstr "Ikusi bertsioen historia osoa"
 
-#: src/olympia/addons/templates/addons/impala/details.html:262
+#: src/olympia/addons/templates/addons/impala/details.html:267
 msgid ""
 "The Development Channel lets you test an experimental new version of this add-on before it's released to the general public. Once you install the development version, you will continue to get "
 "updates from this channel. To stop receiving development updates, reinstall the default version from the link above."
 msgstr ""
 
-#: src/olympia/addons/templates/addons/impala/details.html:272
+#: src/olympia/addons/templates/addons/impala/details.html:277
 msgid "<strong>Caution:</strong> Development versions of this add-on have not been reviewed by Mozilla."
 msgstr ""
 
-#: src/olympia/addons/templates/addons/impala/details.html:287
+#: src/olympia/addons/templates/addons/impala/details.html:292
 msgid "See complete development channel history"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/impala/details.html:306 src/olympia/addons/templates/addons/impala/details.html:315 src/olympia/addons/templates/addons/impala/details.html:327
+#: src/olympia/addons/templates/addons/impala/details.html:311 src/olympia/addons/templates/addons/impala/details.html:320 src/olympia/addons/templates/addons/impala/details.html:332
 #: src/olympia/addons/templates/addons/impala/review_add_box.html:4 src/olympia/stats/templates/stats/popup.html:2 src/olympia/stats/templates/stats/popup.html:8
-#: src/olympia/stats/templates/stats/stats.html:202 src/olympia/users/templates/users/profile.html:119
+#: src/olympia/stats/templates/stats/stats.html:204 src/olympia/users/templates/users/profile.html:119
 msgid "close"
 msgstr "itxi"
 
@@ -1147,15 +1148,11 @@ msgstr "{addon} gehigarriaren iturburu-kodearen lizentzia"
 msgid "Source Code License"
 msgstr "Iturburu-kodearen lizentzia"
 
-#: src/olympia/addons/templates/addons/impala/persona_grid.html:16 src/olympia/addons/templates/addons/impala/toplist.html:6
-msgid "{0} users"
-msgstr "{0} erabiltzaile"
-
 #: src/olympia/addons/templates/addons/impala/review_list_box.html:19 src/olympia/reviews/templates/reviews/review.html:40
 msgid "permalink"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/impala/review_list_box.html:23 src/olympia/editors/templates/editors/queue.html:98 src/olympia/reviews/templates/reviews/review.html:44
+#: src/olympia/addons/templates/addons/impala/review_list_box.html:23 src/olympia/editors/templates/editors/queue.html:104 src/olympia/reviews/templates/reviews/review.html:44
 msgid "translate"
 msgstr ""
 
@@ -1174,6 +1171,10 @@ msgstr "Gehigarri hau ez da berrikusi oraindik."
 msgid "Be the first!"
 msgstr "Izan lehena!"
 
+#: src/olympia/addons/templates/addons/impala/toplist.html:6
+msgid "{0} users"
+msgstr "{0} erabiltzaile"
+
 #: src/olympia/addons/templates/addons/impala/listing/sorter.html:14 src/olympia/devhub/templates/devhub/addons/listing/item_actions.html:49
 msgid "More"
 msgstr "Gehiago"
@@ -1186,7 +1187,7 @@ msgstr "Gehitu bildumara"
 msgid "My Add-ons"
 msgstr "Nire gehigarriak"
 
-#: src/olympia/addons/templates/addons/includes/dashboard_tabs.html:6 src/olympia/amo/context_processors.py:51
+#: src/olympia/addons/templates/addons/includes/dashboard_tabs.html:6 src/olympia/amo/context_processors.py:50
 msgid "My Themes"
 msgstr ""
 
@@ -1241,7 +1242,7 @@ msgstr ""
 msgid "Weekly Downloads"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/mobile/details.html:99 src/olympia/compat/templates/compat/reporter_detail.html:46 src/olympia/devhub/forms.py:787
+#: src/olympia/addons/templates/addons/mobile/details.html:99 src/olympia/compat/templates/compat/reporter_detail.html:46 src/olympia/devhub/forms.py:788
 #: src/olympia/devhub/templates/devhub/versions/list.html:163
 msgid "Version"
 msgstr "Bertsioa"
@@ -1326,7 +1327,7 @@ msgstr ""
 #: src/olympia/browse/templates/browse/personas/category_landing.html:21 src/olympia/browse/templates/browse/personas/category_landing.html:23
 #: src/olympia/browse/templates/browse/personas/category_landing.html:38 src/olympia/browse/templates/browse/personas/grid.html:7 src/olympia/browse/templates/browse/personas/grid.html:11
 #: src/olympia/browse/templates/browse/personas/mobile/base.html:7 src/olympia/browse/templates/browse/personas/mobile/category_landing.html:19 src/olympia/constants/base.py:180
-#: src/olympia/devhub/templates/devhub/personas/submit.html:13 src/olympia/editors/helpers.py:105 src/olympia/editors/templates/editors/base.html:26
+#: src/olympia/devhub/templates/devhub/personas/submit.html:13 src/olympia/editors/helpers.py:107 src/olympia/editors/templates/editors/base.html:26
 #: src/olympia/editors/templates/editors/performance.html:73 src/olympia/search/templates/search/personas.html:39 src/olympia/templates/menu_links.html:9
 msgid "Themes"
 msgstr "Gaiak"
@@ -1347,7 +1348,7 @@ msgstr "Gehigarri gehiago"
 msgid "Highest Rated"
 msgstr "Puntuazio onenak"
 
-#: src/olympia/addons/templates/addons/mobile/home.html:74 src/olympia/amo/templates/amo/side_nav.html:5 src/olympia/amo/templates/amo/site_nav.html:27 src/olympia/amo/templates/amo/site_nav.html:57
+#: src/olympia/addons/templates/addons/mobile/home.html:74 src/olympia/amo/templates/amo/side_nav.html:5 src/olympia/amo/templates/amo/site_nav.html:27 src/olympia/amo/templates/amo/site_nav.html:55
 #: src/olympia/bandwagon/views.py:97 src/olympia/browse/views.py:57 src/olympia/browse/views.py:67 src/olympia/browse/templates/browse/personas/mobile/category_landing.html:65
 #: src/olympia/search/forms.py:15 src/olympia/search/forms.py:87
 msgid "Newest"
@@ -1361,90 +1362,90 @@ msgstr ""
 msgid "Theme Info &raquo;"
 msgstr ""
 
-#: src/olympia/amo/context_processors.py:39 src/olympia/devhub/templates/devhub/nav.html:43
+#: src/olympia/amo/context_processors.py:37 src/olympia/devhub/templates/devhub/nav.html:43
 msgid "Tools"
 msgstr "Tresnak"
 
-#: src/olympia/amo/context_processors.py:48 src/olympia/discovery/templates/discovery/pane_account.html:8 src/olympia/users/templates/users/includes/navigation.html:2
+#: src/olympia/amo/context_processors.py:47 src/olympia/discovery/templates/discovery/pane_account.html:8 src/olympia/users/templates/users/includes/navigation.html:2
 msgid "My Profile"
 msgstr "Nire profila"
 
-#: src/olympia/amo/context_processors.py:54 src/olympia/users/templates/users/edit.html:5 src/olympia/users/templates/users/includes/navigation.html:3
+#: src/olympia/amo/context_processors.py:53 src/olympia/users/templates/users/edit.html:5 src/olympia/users/templates/users/includes/navigation.html:3
 msgid "Account Settings"
 msgstr "Kontu-ezarpenak"
 
-#: src/olympia/amo/context_processors.py:57 src/olympia/discovery/templates/discovery/pane_account.html:11 src/olympia/users/templates/users/profile.html:83
+#: src/olympia/amo/context_processors.py:56 src/olympia/discovery/templates/discovery/pane_account.html:11 src/olympia/users/templates/users/profile.html:83
 #: src/olympia/users/templates/users/includes/navigation.html:4
 msgid "My Collections"
 msgstr "Nire bildumak"
 
-#: src/olympia/amo/context_processors.py:62 src/olympia/discovery/templates/discovery/pane_account.html:10 src/olympia/users/templates/users/includes/navigation.html:7
+#: src/olympia/amo/context_processors.py:61 src/olympia/discovery/templates/discovery/pane_account.html:10 src/olympia/users/templates/users/includes/navigation.html:7
 msgid "My Favorites"
 msgstr "Nire gogokoak"
 
-#: src/olympia/amo/context_processors.py:67 src/olympia/discovery/templates/discovery/pane_account.html:13 src/olympia/templates/impala/user_login.html:14
+#: src/olympia/amo/context_processors.py:66 src/olympia/discovery/templates/discovery/pane_account.html:13 src/olympia/templates/impala/user_login.html:14
 #: src/olympia/templates/mobile/header_auth.html:5
 msgid "Log out"
 msgstr "Amaitu saioa"
 
-#: src/olympia/amo/context_processors.py:72 src/olympia/devhub/templates/devhub/addons/dashboard.html:4
+#: src/olympia/amo/context_processors.py:71 src/olympia/devhub/templates/devhub/addons/dashboard.html:4
 msgid "Manage My Submissions"
 msgstr ""
 
-#: src/olympia/amo/context_processors.py:75 src/olympia/devhub/templates/devhub/nav.html:27 src/olympia/devhub/templates/devhub/addons/dashboard.html:25
+#: src/olympia/amo/context_processors.py:74 src/olympia/devhub/templates/devhub/nav.html:27 src/olympia/devhub/templates/devhub/addons/dashboard.html:25
 #: src/olympia/devhub/templates/devhub/addons/submit/base.html:4
 msgid "Submit a New Add-on"
 msgstr "Bidali gehigarri berria"
 
-#: src/olympia/amo/context_processors.py:77 src/olympia/browse/templates/browse/personas/base.html:50 src/olympia/devhub/templates/devhub/index.html:24
+#: src/olympia/amo/context_processors.py:76 src/olympia/browse/templates/browse/personas/base.html:50 src/olympia/devhub/templates/devhub/index.html:24
 #: src/olympia/devhub/templates/devhub/addons/dashboard.html:29
 msgid "Submit a New Theme"
 msgstr ""
 
-#: src/olympia/amo/context_processors.py:79 src/olympia/amo/templates/amo/site_nav.html:87 src/olympia/devhub/helpers.py:36 src/olympia/devhub/helpers.py:68 src/olympia/devhub/helpers.py:102
+#: src/olympia/amo/context_processors.py:78 src/olympia/amo/templates/amo/site_nav.html:85 src/olympia/devhub/helpers.py:36 src/olympia/devhub/helpers.py:68 src/olympia/devhub/helpers.py:102
 #: src/olympia/templates/footer.html:6 src/olympia/templates/menu_links.html:14
 msgid "Developer Hub"
 msgstr "Garatzaile-zentroa"
 
-#: src/olympia/amo/context_processors.py:83 src/olympia/devhub/views.py:1792
+#: src/olympia/amo/context_processors.py:81 src/olympia/devhub/views.py:1796
 msgid "Manage API Keys"
 msgstr ""
 
-#: src/olympia/amo/context_processors.py:88 src/olympia/editors/helpers.py:82 src/olympia/editors/helpers.py:102 src/olympia/editors/templates/editors/base.html:10
+#: src/olympia/amo/context_processors.py:86 src/olympia/editors/helpers.py:84 src/olympia/editors/helpers.py:104 src/olympia/editors/templates/editors/base.html:10
 msgid "Editor Tools"
 msgstr "Editore-tresnak"
 
-#: src/olympia/amo/context_processors.py:92
+#: src/olympia/amo/context_processors.py:90
 msgid "Admin Tools"
 msgstr "Kudeaketa-tresnak"
 
-#: src/olympia/amo/fields.py:15
+#: src/olympia/amo/fields.py:20
 msgid "Incorrect, please try again."
 msgstr ""
 
-#: src/olympia/amo/fields.py:16
+#: src/olympia/amo/fields.py:21
 msgid "Error verifying input, please try again."
 msgstr ""
 
-#: src/olympia/amo/fields.py:32
+#: src/olympia/amo/fields.py:37
 msgid "This must be a valid hex color code, such as #000000."
 msgstr ""
 
-#: src/olympia/amo/fields.py:58
+#: src/olympia/amo/fields.py:63
 msgid "Enter at least one value."
 msgstr ""
 
-#: src/olympia/amo/helpers.py:162 src/olympia/amo/templates/amo/site_nav.html:61 src/olympia/bandwagon/templates/bandwagon/add.html:9
+#: src/olympia/amo/helpers.py:162 src/olympia/amo/templates/amo/site_nav.html:59 src/olympia/bandwagon/templates/bandwagon/add.html:9
 #: src/olympia/bandwagon/templates/bandwagon/collection_detail.html:15 src/olympia/bandwagon/templates/bandwagon/delete.html:9 src/olympia/bandwagon/templates/bandwagon/edit.html:15
 #: src/olympia/bandwagon/templates/bandwagon/user_listing.html:18 src/olympia/bandwagon/templates/bandwagon/user_listing.html:21
 #: src/olympia/bandwagon/templates/bandwagon/impala/collection_listing.html:12 src/olympia/bandwagon/templates/bandwagon/impala/collection_listing.html:20
 #: src/olympia/bandwagon/templates/bandwagon/impala/collection_listing.html:24 src/olympia/bandwagon/templates/bandwagon/impala/collection_sidebar.html:3
 #: src/olympia/bandwagon/templates/bandwagon/includes/collection_sidebar.html:2 src/olympia/bandwagon/templates/bandwagon/mobile/collection_listing.html:3
-#: src/olympia/stats/templates/stats/stats.html:77 src/olympia/templates/menu_links.html:12
+#: src/olympia/stats/templates/stats/stats.html:33 src/olympia/templates/menu_links.html:12
 msgid "Collections"
 msgstr "Bildumak"
 
-#: src/olympia/amo/helpers.py:171 src/olympia/amo/templates/amo/site_nav.html:85 src/olympia/browse/templates/browse/language_tools.html:3
+#: src/olympia/amo/helpers.py:171 src/olympia/amo/templates/amo/site_nav.html:83 src/olympia/browse/templates/browse/language_tools.html:3
 msgid "Dictionaries & Language Packs"
 msgstr "Hiztegiak eta hizkuntza-paketeak"
 
@@ -1596,8 +1597,8 @@ msgstr ""
 msgid "Comment on {addon} {version}."
 msgstr ""
 
-#: src/olympia/amo/log.py:236 src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:19 src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:47
-#: src/olympia/editors/helpers.py:511 src/olympia/editors/templates/editors/themes/history_table.html:11
+#: src/olympia/amo/log.py:236 src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:17 src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:45
+#: src/olympia/editors/helpers.py:584 src/olympia/editors/templates/editors/themes/history_table.html:11
 msgid "Comment"
 msgstr "Iruzkina"
 
@@ -1899,8 +1900,8 @@ msgstr "Ene"
 
 #: src/olympia/amo/templates/amo/500.html:6
 #, python-format
-msgid "<h1>Oops! We had an error.</h1> <p>We'll get to fixing that soon.</p> <p> You can try refreshing the page, or head back to the <a href=\"%(home)s\">Add-ons homepage</a>. </p>"
-msgstr "<h1>Ene! Errorea izan dugu.</h1> <p>Laster saiatuko gara konpontzen.</p> <p>Orria freskatzen saia zaitezke, edo <a href=\"%(home)s\">gehigarrien hasiera-orrira</a> joaten. </p>"
+msgid "<h1>Oops!  We had an error.</h1> <p>We'll get to fixing that soon.</p> <p> You can try refreshing the page, or head back to the <a href=\"%(home)s\">Add-ons homepage</a>. </p>"
+msgstr ""
 
 #: src/olympia/amo/templates/amo/license_link.html:10
 msgid "Some rights reserved"
@@ -1922,7 +1923,7 @@ msgstr "Aur."
 #: src/olympia/amo/templates/amo/mobile/paginator.html:14 src/olympia/amo/templates/amo/mobile/paginator.html:16 src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:51
 #: src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:65 src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:78
 #: src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:91 src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:104
-#: src/olympia/discovery/templates/discovery/pane.html:45 src/olympia/discovery/templates/discovery/addons/detail.html:39 src/olympia/stats/templates/stats/stats.html:167
+#: src/olympia/discovery/templates/discovery/pane.html:45 src/olympia/discovery/templates/discovery/addons/detail.html:39 src/olympia/stats/templates/stats/stats.html:169
 msgid "Next"
 msgstr "Hurrengoa"
 
@@ -1954,7 +1955,7 @@ msgid ""
 msgstr ""
 
 #: src/olympia/amo/templates/amo/side_nav.html:4 src/olympia/amo/templates/amo/side_nav.html:12 src/olympia/amo/templates/amo/site_nav.html:4 src/olympia/amo/templates/amo/site_nav.html:26
-#: src/olympia/browse/views.py:56 src/olympia/browse/views.py:66 src/olympia/browse/views.py:237 src/olympia/browse/views.py:282 src/olympia/search/forms.py:86
+#: src/olympia/browse/views.py:56 src/olympia/browse/views.py:66 src/olympia/browse/views.py:204 src/olympia/browse/views.py:249 src/olympia/search/forms.py:86
 msgid "Top Rated"
 msgstr "Ondoen puntuatutakoak"
 
@@ -1969,38 +1970,38 @@ msgstr "Arakatu"
 msgid "Extensions"
 msgstr "Hedapenak"
 
-#: src/olympia/amo/templates/amo/site_nav.html:45
+#: src/olympia/amo/templates/amo/site_nav.html:44
 msgid "Want more customization? Try <b>Complete Themes</b>"
 msgstr ""
 
-#: src/olympia/amo/templates/amo/site_nav.html:56 src/olympia/bandwagon/views.py:96
+#: src/olympia/amo/templates/amo/site_nav.html:54 src/olympia/bandwagon/views.py:96
 msgid "Most Followers"
 msgstr "Jarraitzaile gehienekoak"
 
-#: src/olympia/amo/templates/amo/site_nav.html:68 src/olympia/bandwagon/templates/bandwagon/impala/collection_sidebar.html:16
+#: src/olympia/amo/templates/amo/site_nav.html:66 src/olympia/bandwagon/templates/bandwagon/impala/collection_sidebar.html:16
 #: src/olympia/bandwagon/templates/bandwagon/includes/collection_sidebar.html:18
 msgid "Collections I've Made"
 msgstr "Egin ditudan bildumak"
 
-#: src/olympia/amo/templates/amo/site_nav.html:70 src/olympia/bandwagon/templates/bandwagon/user_listing.html:4 src/olympia/bandwagon/templates/bandwagon/impala/collection_sidebar.html:13
+#: src/olympia/amo/templates/amo/site_nav.html:68 src/olympia/bandwagon/templates/bandwagon/user_listing.html:4 src/olympia/bandwagon/templates/bandwagon/impala/collection_sidebar.html:13
 #: src/olympia/bandwagon/templates/bandwagon/includes/collection_sidebar.html:15
 msgid "Collections I'm Following"
 msgstr "Jarraitzen ditudan bildumak"
 
-#: src/olympia/amo/templates/amo/site_nav.html:73 src/olympia/bandwagon/templates/bandwagon/impala/collection_sidebar.html:18
-#: src/olympia/bandwagon/templates/bandwagon/includes/collection_sidebar.html:20 src/olympia/users/models.py:512
+#: src/olympia/amo/templates/amo/site_nav.html:71 src/olympia/bandwagon/templates/bandwagon/impala/collection_sidebar.html:18
+#: src/olympia/bandwagon/templates/bandwagon/includes/collection_sidebar.html:20 src/olympia/users/models.py:521
 msgid "My Favorite Add-ons"
 msgstr "Nire gehigarri gogokoenak"
 
-#: src/olympia/amo/templates/amo/site_nav.html:78
+#: src/olympia/amo/templates/amo/site_nav.html:76
 msgid "More&hellip;"
 msgstr "Gehiago&hellip;"
 
-#: src/olympia/amo/templates/amo/site_nav.html:82
+#: src/olympia/amo/templates/amo/site_nav.html:80
 msgid "Add-ons for Mobile"
 msgstr ""
 
-#: src/olympia/amo/templates/amo/site_nav.html:86 src/olympia/browse/feeds.py:207 src/olympia/browse/templates/browse/search_tools.html:3 src/olympia/constants/base.py:176
+#: src/olympia/amo/templates/amo/site_nav.html:84 src/olympia/browse/feeds.py:207 src/olympia/browse/templates/browse/search_tools.html:3 src/olympia/constants/base.py:176
 #: src/olympia/templates/menu_links.html:10
 msgid "Search Tools"
 msgstr "Bilaketa-tresnak"
@@ -2016,7 +2017,7 @@ msgid "Jump to first page"
 msgstr "Joan lehen orrira"
 
 #: src/olympia/amo/templates/amo/impala/paginator.html:22 src/olympia/amo/templates/amo/mobile/impala_paginator.html:12 src/olympia/discovery/templates/discovery/pane.html:44
-#: src/olympia/discovery/templates/discovery/addons/detail.html:38 src/olympia/stats/templates/stats/stats.html:164
+#: src/olympia/discovery/templates/discovery/addons/detail.html:38 src/olympia/stats/templates/stats/stats.html:166
 msgid "Previous"
 msgstr "Aurrekoa"
 
@@ -2039,31 +2040,50 @@ msgid_plural "Page {n}"
 msgstr[0] "{n}.orria"
 msgstr[1] "{n}.orria"
 
-#: src/olympia/amo/templates/services/install.html:38
-#, python-format
-msgid "If you are not prompted to install %(addon_name)s in a moment, please <a href=\"%(addon_xpi)s\">click here</a>."
-msgstr ""
-
-#: src/olympia/amo/tests/test_messages.py:57 src/olympia/amo/tests/test_messages.py:58 src/olympia/reviews/forms.py:25 src/olympia/reviews/forms.py:50 src/olympia/reviews/templates/reviews/add.html:56
+#: src/olympia/amo/tests/test_messages.py:56 src/olympia/amo/tests/test_messages.py:57 src/olympia/reviews/forms.py:25 src/olympia/reviews/forms.py:50 src/olympia/reviews/templates/reviews/add.html:56
 #: src/olympia/reviews/templates/reviews/reply.html:30
 msgid "Title"
 msgstr ""
 
-#: src/olympia/amo/tests/test_messages.py:57 src/olympia/amo/tests/test_messages.py:58
+#: src/olympia/amo/tests/test_messages.py:56 src/olympia/amo/tests/test_messages.py:57
 msgid "Body"
 msgstr ""
 
-#: src/olympia/amo/tests/test_messages.py:59
+#: src/olympia/amo/tests/test_messages.py:58
 msgid "Another Title"
 msgstr ""
 
-#: src/olympia/amo/tests/test_messages.py:59
+#: src/olympia/amo/tests/test_messages.py:58
 msgid "Another Body"
 msgstr ""
 
-#: src/olympia/api/views.py:255
-msgid "Not implemented yet."
-msgstr "Oraindik inplementatu gabe."
+#: src/olympia/api/authentication.py:76
+msgid "Signature has expired."
+msgstr ""
+
+#: src/olympia/api/authentication.py:79
+msgid "Error decoding signature."
+msgstr ""
+
+#: src/olympia/api/authentication.py:82
+msgid "Invalid JWT Token."
+msgstr ""
+
+#: src/olympia/api/authentication.py:130
+msgid "Invalid Authorization header. No credentials provided."
+msgstr ""
+
+#: src/olympia/api/authentication.py:133
+msgid "Invalid Authorization header. Credentials string should not contain spaces."
+msgstr ""
+
+#: src/olympia/api/fields.py:29
+msgid "The field must have a length of at least {num} characters."
+msgstr ""
+
+#: src/olympia/api/fields.py:31
+msgid "The language code {lang_code} is invalid."
+msgstr ""
 
 #: src/olympia/applications/views.py:39 src/olympia/applications/templates/applications/appversions.html:3
 msgid "Application Versions"
@@ -2081,7 +2101,7 @@ msgstr "Baliozko aplikazio-bertsioak"
 msgid "Add-ons submitted to Mozilla Add-ons must have a manifest file with at least one of the below applications supported. Only the versions listed below are allowed for these applications."
 msgstr ""
 
-#: src/olympia/applications/templates/applications/appversions.html:25
+#: src/olympia/applications/templates/applications/appversions.html:25 src/olympia/editors/helpers.py:361
 msgid "GUID"
 msgstr "GUID"
 
@@ -2195,8 +2215,8 @@ msgstr "Gogokoa"
 msgid "Remove from favorites"
 msgstr "Kendu gogokoetatik"
 
-#: src/olympia/bandwagon/views.py:98 src/olympia/bandwagon/views.py:191 src/olympia/browse/views.py:58 src/olympia/browse/views.py:69 src/olympia/browse/views.py:458 src/olympia/devhub/views.py:74
-#: src/olympia/devhub/views.py:82 src/olympia/devhub/templates/devhub/addons/edit/basic.html:20 src/olympia/editors/templates/editors/leaderboard.html:24
+#: src/olympia/bandwagon/views.py:98 src/olympia/bandwagon/views.py:191 src/olympia/browse/views.py:58 src/olympia/browse/views.py:69 src/olympia/browse/views.py:425 src/olympia/devhub/views.py:72
+#: src/olympia/devhub/views.py:80 src/olympia/devhub/templates/devhub/addons/edit/basic.html:20 src/olympia/editors/templates/editors/leaderboard.html:24
 #: src/olympia/editors/templates/editors/themes/queue_list.html:48 src/olympia/search/forms.py:17 src/olympia/search/forms.py:89 src/olympia/users/templates/users/vcard.html:5
 msgid "Name"
 msgstr "Izena"
@@ -2205,7 +2225,7 @@ msgstr "Izena"
 msgid "Recently Popular"
 msgstr ""
 
-#: src/olympia/bandwagon/views.py:189 src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:18
+#: src/olympia/bandwagon/views.py:189 src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:16
 msgid "Added"
 msgstr ""
 
@@ -2219,7 +2239,7 @@ msgstr "Bilduma sortuta!"
 
 #: src/olympia/bandwagon/views.py:316
 #, python-format
-msgid "Your new collection is shown below. You can <ahref=\"%(url)s\">edit additional settings</a> if you'dlike."
+msgid "Your new collection is shown below. You can <a href=\"%(url)s\">edit additional settings</a> if you'd like."
 msgstr ""
 
 #: src/olympia/bandwagon/views.py:322
@@ -2347,8 +2367,8 @@ msgid_plural "%(num)s Add-ons in this Collection"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/olympia/bandwagon/templates/bandwagon/collection_detail.html:125 src/olympia/compat/templates/compat/index.html:25 src/olympia/compat/templates/compat/reporter_detail.html:29
-#: src/olympia/files/templates/files/viewer.html:29 src/olympia/templates/amo_footer.html:17 src/olympia/templates/includes/lang_switcher.html:10
+#: src/olympia/bandwagon/templates/bandwagon/collection_detail.html:125 src/olympia/compat/templates/compat/reporter_detail.html:29 src/olympia/files/templates/files/viewer.html:29
+#: src/olympia/templates/amo_footer.html:17 src/olympia/templates/includes/lang_switcher.html:10
 msgid "Go"
 msgstr "Joan"
 
@@ -2516,7 +2536,7 @@ msgid "Remove this user as a contributor"
 msgstr ""
 
 #: src/olympia/bandwagon/templates/bandwagon/edit_contributors.html:18 src/olympia/bandwagon/templates/bandwagon/edit_contributors.html:43
-#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:20 src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:48
+#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:18 src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:46
 #: src/olympia/devhub/templates/devhub/addons/ajax_compat_update.html:19
 msgid "Remove"
 msgstr ""
@@ -2565,7 +2585,7 @@ msgid "<b>Warning:</b> By changing the owner of this collection, you will no lon
 msgstr ""
 
 #: src/olympia/bandwagon/templates/bandwagon/edit_contributors.html:83 src/olympia/devhub/templates/devhub/addons/forms_shared/media.html:157
-#: src/olympia/devhub/templates/devhub/addons/submit/describe.html:69 src/olympia/devhub/templates/devhub/addons/submit/license.html:60 src/olympia/devhub/templates/devhub/addons/submit/upload.html:78
+#: src/olympia/devhub/templates/devhub/addons/submit/describe.html:69 src/olympia/devhub/templates/devhub/addons/submit/license.html:60 src/olympia/devhub/templates/devhub/addons/submit/upload.html:70
 #: src/olympia/devhub/templates/devhub/payments/tier.html:17 src/olympia/editors/templates/editors/themes/themes.html:111 src/olympia/editors/templates/editors/themes/themes.html:128
 #: src/olympia/editors/templates/editors/themes/themes.html:134 src/olympia/editors/templates/editors/themes/themes.html:141 src/olympia/users/templates/users/fxa_migration_prompt_content.html:10
 #: src/olympia/users/templates/users/login_form.html:42 src/olympia/users/templates/users/mobile/login.html:57
@@ -2637,43 +2657,43 @@ msgid "Reset"
 msgstr "Berrezarri"
 
 #: src/olympia/bandwagon/templates/bandwagon/includes/addedit.html:53
-msgid "PNG and JPG supported. Image will be resized to 32x32."
-msgstr "PNG eta JPG onartzen dira. Irudia 32x32ra aldatuko da tamainaz."
+msgid "PNG and JPG supported.  Image will be resized to 32x32."
+msgstr ""
 
 #: src/olympia/bandwagon/templates/bandwagon/includes/addedit_errors.html:3
-msgid "There are errors in this form. Please correct them below."
-msgstr "Erroreak daude inprimaki honetan. Zuzendu itzazu azpian."
+msgid "There are errors in this form.  Please correct them below."
+msgstr ""
 
 #: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:2
 msgid "Add-ons in Your Collection"
 msgstr ""
 
 #: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:4
-msgid ""
-"To include an add-on in this collection, enter its name in the box below and hit enter.  You can also use the <strong>Add to Collection</strong> links throughout the site to include add-ons later."
+msgid "To include an add-on in this collection, enter its name in the box below and hit enter."
 msgstr ""
 
-#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:17 src/olympia/constants/base.py:400 src/olympia/devhub/templates/devhub/addons/activity.html:62
+#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:15 src/olympia/constants/base.py:400 src/olympia/devhub/templates/devhub/addons/activity.html:62
+#: src/olympia/editors/helpers.py:273 src/olympia/editors/helpers.py:360
 msgid "Add-on"
 msgstr "Gehigarria"
 
-#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:26
+#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:24
 msgid "Enter the name of the add-on to include"
 msgstr ""
 
-#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:28
+#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:26
 msgid "Add to Collection"
 msgstr "Gehitu bilduman"
 
-#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:45 src/olympia/editors/helpers.py:936 src/olympia/editors/helpers.py:956
+#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:43 src/olympia/editors/helpers.py:1016 src/olympia/editors/helpers.py:1036
 msgid "Pending"
 msgstr "Zain"
 
-#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:47
+#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:45
 msgid "Add a comment"
 msgstr "Gehitu iruzkina"
 
-#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:48
+#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:46
 msgid "Remove this add-on from the collection"
 msgstr "Kendu gehigarri hau bildumatik"
 
@@ -2780,12 +2800,12 @@ msgstr "Bilaketa-tresnak"
 msgid "Most Users"
 msgstr "Erabiltzaile gehien dituztenak"
 
-#: src/olympia/browse/views.py:61 src/olympia/browse/views.py:72 src/olympia/browse/views.py:279 src/olympia/browse/templates/browse/personas/mobile/category_landing.html:63
+#: src/olympia/browse/views.py:61 src/olympia/browse/views.py:72 src/olympia/browse/views.py:246 src/olympia/browse/templates/browse/personas/mobile/category_landing.html:63
 #: src/olympia/discovery/templates/discovery/pane.html:67 src/olympia/search/forms.py:92
 msgid "Up & Coming"
 msgstr "Berrienak eta datozenak"
 
-#: src/olympia/browse/views.py:460 src/olympia/devhub/views.py:76 src/olympia/devhub/views.py:83 src/olympia/discovery/templates/discovery/addons/detail.html:66
+#: src/olympia/browse/views.py:427 src/olympia/devhub/views.py:74 src/olympia/devhub/views.py:81 src/olympia/discovery/templates/discovery/addons/detail.html:66
 msgid "Created"
 msgstr "Sortuta"
 
@@ -2973,8 +2993,8 @@ msgid_plural "See all %(cnt)s extensions in %(name)s &raquo;"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/olympia/browse/templates/browse/mobile/extensions.html:13 src/olympia/compat/templates/compat/index.html:82 src/olympia/devhub/templates/devhub/devhub_search.html:24
-#: src/olympia/devhub/templates/devhub/addons/activity.html:47 src/olympia/search/templates/search/no_results.html:4 src/olympia/search/templates/search/mobile/results.html:36
+#: src/olympia/browse/templates/browse/mobile/extensions.html:13 src/olympia/devhub/templates/devhub/devhub_search.html:24 src/olympia/devhub/templates/devhub/addons/activity.html:47
+#: src/olympia/search/templates/search/no_results.html:4 src/olympia/search/templates/search/mobile/results.html:36
 msgid "No results found."
 msgstr "Ez da emaitzarik aurkitu."
 
@@ -3059,7 +3079,7 @@ msgstr ""
 msgid "All"
 msgstr "Denak"
 
-#: src/olympia/compat/forms.py:22 src/olympia/search/views.py:525
+#: src/olympia/compat/forms.py:22 src/olympia/editors/templates/editors/base.html:69 src/olympia/search/views.py:518
 msgid "All Add-ons"
 msgstr ""
 
@@ -3069,53 +3089,6 @@ msgstr ""
 
 #: src/olympia/compat/forms.py:24
 msgid "Non-binary"
-msgstr ""
-
-#. Review points sources other than add-ons and themes.
-#: src/olympia/compat/views.py:87 src/olympia/constants/base.py:388 src/olympia/devhub/forms.py:162 src/olympia/editors/templates/editors/performance.html:75
-msgid "Other"
-msgstr "Bestelakoa"
-
-#: src/olympia/compat/templates/compat/index.html:4
-msgid "Add-on Compatibility Report for {app} {version}"
-msgstr ""
-
-#: src/olympia/compat/templates/compat/index.html:11
-msgid "{app} {version} Compatibility"
-msgstr ""
-
-#: src/olympia/compat/templates/compat/index.html:17
-#, python-format
-msgid "Top 95%% compatible with previous version"
-msgstr ""
-
-#: src/olympia/compat/templates/compat/index.html:18
-#, python-format
-msgid "Top 95%% of all add-ons"
-msgstr ""
-
-#: src/olympia/compat/templates/compat/index.html:19
-msgid "All active add-ons"
-msgstr ""
-
-#: src/olympia/compat/templates/compat/index.html:23 src/olympia/constants/base.py:401
-msgid "App"
-msgstr ""
-
-#: src/olympia/compat/templates/compat/index.html:55
-msgid "Details for add-ons compatible with previous version:"
-msgstr ""
-
-#: src/olympia/compat/templates/compat/index.html:57
-msgid "Show all versions"
-msgstr ""
-
-#: src/olympia/compat/templates/compat/index.html:59
-msgid "Details for add-ons compatible with all versions:"
-msgstr ""
-
-#: src/olympia/compat/templates/compat/index.html:61
-msgid "Show previous version only"
 msgstr ""
 
 #: src/olympia/compat/templates/compat/reporter.html:3
@@ -3169,8 +3142,8 @@ msgstr ""
 msgid "Report Type"
 msgstr ""
 
-#: src/olympia/compat/templates/compat/reporter_detail.html:47 src/olympia/devhub/forms.py:784 src/olympia/devhub/templates/devhub/addons/ajax_compat_update.html:17 src/olympia/editors/forms.py:108
-#: src/olympia/zadmin/forms.py:45
+#: src/olympia/compat/templates/compat/reporter_detail.html:47 src/olympia/devhub/forms.py:785 src/olympia/devhub/templates/devhub/addons/ajax_compat_update.html:17 src/olympia/editors/forms.py:108
+#: src/olympia/editors/forms.py:248 src/olympia/zadmin/forms.py:45
 msgid "Application"
 msgstr "Aplikazioa"
 
@@ -3265,7 +3238,8 @@ msgstr "Prozesatu berrikuspenak"
 msgid "Preliminarily Reviewed and Awaiting Full Review"
 msgstr "Behin-behinean berrikusia eta erabateko berrikuspenaren zain"
 
-#: src/olympia/constants/base.py:33 src/olympia/editors/helpers.py:924 src/olympia/editors/templates/editors/themes/history_table.html:34
+#: src/olympia/constants/base.py:33 src/olympia/editors/forms.py:258 src/olympia/editors/helpers.py:73 src/olympia/editors/helpers.py:1004
+#: src/olympia/editors/templates/editors/themes/history_table.html:34
 msgid "Deleted"
 msgstr ""
 
@@ -3365,6 +3339,11 @@ msgstr "Galdetu erabiltzaileek gehigarriaren deskarga hasi ondoren"
 msgid "Ask before users can download this add-on"
 msgstr "Galdetu erabiltzaileek gehigarria deskargatu ahal izan baino lehen"
 
+#. Review points sources other than add-ons and themes.
+#: src/olympia/constants/base.py:388 src/olympia/devhub/forms.py:162 src/olympia/editors/templates/editors/performance.html:75
+msgid "Other"
+msgstr "Bestelakoa"
+
 #: src/olympia/constants/base.py:389
 msgid "Exception"
 msgstr ""
@@ -3375,6 +3354,10 @@ msgstr ""
 
 #: src/olympia/constants/base.py:391
 msgid "Change"
+msgstr ""
+
+#: src/olympia/constants/base.py:401
+msgid "App"
 msgstr ""
 
 #: src/olympia/constants/base.py:402
@@ -3525,7 +3508,7 @@ msgstr ""
 msgid "Duplicate"
 msgstr ""
 
-#: src/olympia/constants/editors.py:17 src/olympia/editors/helpers.py:502 src/olympia/editors/templates/editors/themes/queue.html:71 src/olympia/editors/templates/editors/themes/themes.html:94
+#: src/olympia/constants/editors.py:17 src/olympia/editors/helpers.py:575 src/olympia/editors/templates/editors/themes/queue.html:71 src/olympia/editors/templates/editors/themes/themes.html:94
 msgid "Reject"
 msgstr "Baztertu"
 
@@ -3625,7 +3608,7 @@ msgstr "Solaris"
 msgid "Android"
 msgstr "Android"
 
-#: src/olympia/core/apps.py:19
+#: src/olympia/core/apps.py:21
 msgid "Core"
 msgstr ""
 
@@ -3761,7 +3744,7 @@ msgid "Submit my add-on for manual review."
 msgstr ""
 
 #: src/olympia/devhub/forms.py:537
-msgid "Do not list my add-on on this site (beta)"
+msgid "Do not list my add-on on this site"
 msgstr ""
 
 #: src/olympia/devhub/forms.py:538
@@ -3795,46 +3778,46 @@ msgstr ""
 
 #: src/olympia/devhub/forms.py:592
 #, python-format
-msgid "Version %s already exists"
+msgid "Version %s already exists, or was uploaded before."
 msgstr ""
 
-#: src/olympia/devhub/forms.py:604
+#: src/olympia/devhub/forms.py:605
 msgid "Select a valid choice. That choice is not one of the available choices."
 msgstr ""
 
-#: src/olympia/devhub/forms.py:610
+#: src/olympia/devhub/forms.py:611
 msgid "A file with a version ending with a|alpha|b|beta and an optional number is detected as beta."
 msgstr ""
 
-#: src/olympia/devhub/forms.py:633
+#: src/olympia/devhub/forms.py:634
 msgid "You cannot upload any more files for this version."
 msgstr ""
 
-#: src/olympia/devhub/forms.py:639
+#: src/olympia/devhub/forms.py:640
 msgid "Version doesn't match"
 msgstr ""
 
-#: src/olympia/devhub/forms.py:668
+#: src/olympia/devhub/forms.py:669
 msgid "You cannot delete a file once the review process has started.  You must delete the whole version."
 msgstr ""
 
-#: src/olympia/devhub/forms.py:688
+#: src/olympia/devhub/forms.py:689
 msgid "The platform All cannot be combined with specific platforms."
 msgstr ""
 
-#: src/olympia/devhub/forms.py:693
+#: src/olympia/devhub/forms.py:694
 msgid "A platform can only be chosen once."
 msgstr ""
 
-#: src/olympia/devhub/forms.py:706
+#: src/olympia/devhub/forms.py:707
 msgid "A review type must be selected."
 msgstr ""
 
-#: src/olympia/devhub/forms.py:788 src/olympia/editors/forms.py:114 src/olympia/zadmin/forms.py:49 src/olympia/zadmin/forms.py:52
+#: src/olympia/devhub/forms.py:789 src/olympia/editors/forms.py:114 src/olympia/editors/forms.py:254 src/olympia/zadmin/forms.py:49 src/olympia/zadmin/forms.py:52
 msgid "Select an application first"
 msgstr "Hautatu aplikazioa lehenik"
 
-#: src/olympia/devhub/forms.py:840
+#: src/olympia/devhub/forms.py:841
 msgid "There cannot be more than 3 required add-ons."
 msgstr ""
 
@@ -3870,76 +3853,76 @@ msgstr[1] "{0} abisu"
 msgid "Review"
 msgstr "Berrikusi"
 
-#: src/olympia/devhub/tasks.py:551
+#: src/olympia/devhub/tasks.py:583
 #, python-format
 msgid "%s responded with %s (%s)."
 msgstr ""
 
-#: src/olympia/devhub/tasks.py:555
+#: src/olympia/devhub/tasks.py:587
 #, python-format
 msgid "Connection to \"%s\" timed out."
 msgstr ""
 
-#: src/olympia/devhub/tasks.py:557
+#: src/olympia/devhub/tasks.py:589
 #, python-format
 msgid "Could not contact host at \"%s\"."
 msgstr ""
 
-#: src/olympia/devhub/utils.py:104
+#: src/olympia/devhub/utils.py:105
 #, python-format
 msgid "Validation generated too many errors/warnings so %s messages were truncated. After addressing the visible messages, you'll be able to see the others."
 msgstr ""
 
-#: src/olympia/devhub/views.py:183
+#: src/olympia/devhub/views.py:181
 msgid "All My Add-ons"
 msgstr ""
 
-#: src/olympia/devhub/views.py:210
+#: src/olympia/devhub/views.py:208
 msgid "All Activity"
 msgstr ""
 
-#: src/olympia/devhub/views.py:211
+#: src/olympia/devhub/views.py:209
 msgid "Add-on Updates"
 msgstr "Gehigarrien eguneraketak"
 
-#: src/olympia/devhub/views.py:212
+#: src/olympia/devhub/views.py:210
 msgid "Add-on Status"
 msgstr ""
 
-#: src/olympia/devhub/views.py:213
+#: src/olympia/devhub/views.py:211
 msgid "User Collections"
 msgstr "Erabiltzailearen bildumak"
 
-#: src/olympia/devhub/views.py:214 src/olympia/devhub/templates/devhub/docs/policies-maintenance.html:68 src/olympia/pages/templates/pages/dev_faq.html:38
+#: src/olympia/devhub/views.py:212 src/olympia/devhub/templates/devhub/docs/policies-maintenance.html:68 src/olympia/pages/templates/pages/dev_faq.html:38
 #: src/olympia/pages/templates/pages/dev_faq.html:484
 msgid "User Reviews"
 msgstr ""
 
-#: src/olympia/devhub/views.py:327 src/olympia/devhub/views.py:331 src/olympia/devhub/views.py:484 src/olympia/devhub/views.py:513 src/olympia/devhub/views.py:564 src/olympia/devhub/views.py:1150
+#: src/olympia/devhub/views.py:325 src/olympia/devhub/views.py:329 src/olympia/devhub/views.py:484 src/olympia/devhub/views.py:513 src/olympia/devhub/views.py:564 src/olympia/devhub/views.py:1156
 msgid "Changes successfully saved."
 msgstr ""
 
-#: src/olympia/devhub/views.py:334 src/olympia/devhub/views.py:1631
+#: src/olympia/devhub/views.py:332 src/olympia/devhub/views.py:1637
 msgid "Please check the form for errors."
 msgstr ""
 
-#: src/olympia/devhub/views.py:346
+#: src/olympia/devhub/views.py:344
 msgid "Add-on cannot be deleted. Disable this add-on instead."
 msgstr ""
 
-#: src/olympia/devhub/views.py:356
+#: src/olympia/devhub/views.py:354
 msgid "Theme deleted."
 msgstr ""
 
-#: src/olympia/devhub/views.py:356
+#: src/olympia/devhub/views.py:354
 msgid "Add-on deleted."
 msgstr ""
 
-#: src/olympia/devhub/views.py:362
+#: src/olympia/devhub/views.py:360
 msgid "URL name was incorrect. Theme was not deleted."
 msgstr ""
 
-#: src/olympia/devhub/views.py:367
+#: src/olympia/devhub/views.py:365
 msgid "URL name was incorrect. Add-on was not deleted."
 msgstr ""
 
@@ -3967,7 +3950,7 @@ msgstr "Balidatu gehigarria"
 msgid "Check Add-on Compatibility"
 msgstr ""
 
-#: src/olympia/devhub/views.py:808 src/olympia/signing/views.py:90
+#: src/olympia/devhub/views.py:808 src/olympia/signing/views.py:95
 msgid "You cannot submit this type of add-on"
 msgstr ""
 
@@ -3997,33 +3980,33 @@ msgstr ""
 msgid "There was an error uploading your preview."
 msgstr "Errorea gertatu da aurrebista igotzean."
 
-#: src/olympia/devhub/views.py:1189
+#: src/olympia/devhub/views.py:1195
 #, python-format
 msgid "Version %s disabled."
 msgstr ""
 
-#: src/olympia/devhub/views.py:1193
+#: src/olympia/devhub/views.py:1199
 #, python-format
 msgid "Version %s deleted."
 msgstr ""
 
-#: src/olympia/devhub/views.py:1203
+#: src/olympia/devhub/views.py:1209
 msgid "This upload has failed validation, and may lack complete validation results. Please take due care when reviewing it."
 msgstr ""
 
-#: src/olympia/devhub/views.py:1677
+#: src/olympia/devhub/views.py:1683
 msgid "Preliminary Review Requested."
 msgstr ""
 
-#: src/olympia/devhub/views.py:1678
+#: src/olympia/devhub/views.py:1684
 msgid "Full Review Requested."
 msgstr ""
 
-#: src/olympia/devhub/views.py:1779
+#: src/olympia/devhub/views.py:1783
 msgid "Your old credentials were revoked and are no longer valid. Be sure to update all API clients with the new credentials."
 msgstr ""
 
-#: src/olympia/devhub/views.py:1797
+#: src/olympia/devhub/views.py:1801
 msgid "New API key created"
 msgstr ""
 
@@ -4055,7 +4038,7 @@ msgstr "Atzera gehigarrietara"
 msgid "{0} :: Search"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/devhub_search.html:6 src/olympia/devhub/templates/devhub/search.html:8 src/olympia/editors/forms.py:435 src/olympia/editors/forms.py:437
+#: src/olympia/devhub/templates/devhub/devhub_search.html:6 src/olympia/devhub/templates/devhub/search.html:8 src/olympia/editors/forms.py:534 src/olympia/editors/forms.py:536
 #: src/olympia/editors/templates/editors/queue.html:27 src/olympia/editors/templates/editors/themes/queue_list.html:14 src/olympia/search/templates/search/collections.html:17
 #: src/olympia/search/templates/search/personas.html:18 src/olympia/search/templates/search/results.html:18 src/olympia/search/templates/search/mobile/results.html:8
 #: src/olympia/templates/search.html:14 src/olympia/templates/impala/search.html:18
@@ -4115,12 +4098,12 @@ msgstr ""
 msgid "Start Making Add-ons"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/index.html:86 src/olympia/devhub/templates/devhub/addons/listing/items.html:25 src/olympia/devhub/templates/devhub/includes/addon_details.html:15
+#: src/olympia/devhub/templates/devhub/index.html:86 src/olympia/devhub/templates/devhub/addons/listing/items.html:25 src/olympia/devhub/templates/devhub/includes/addon_details.html:20
 #: src/olympia/devhub/templates/devhub/personas/edit.html:43
 msgid "Status:"
 msgstr "Egoera:"
 
-#: src/olympia/devhub/templates/devhub/index.html:90 src/olympia/devhub/templates/devhub/includes/addon_details.html:100
+#: src/olympia/devhub/templates/devhub/index.html:90 src/olympia/devhub/templates/devhub/includes/addon_details.html:87
 msgid "Visibility:"
 msgstr ""
 
@@ -4128,11 +4111,11 @@ msgstr ""
 msgid "Latest Version:"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/index.html:109 src/olympia/devhub/templates/devhub/includes/addon_details.html:145 src/olympia/devhub/templates/devhub/personas/edit.html:49
+#: src/olympia/devhub/templates/devhub/index.html:109 src/olympia/devhub/templates/devhub/includes/addon_details.html:131 src/olympia/devhub/templates/devhub/personas/edit.html:49
 msgid "Queue Position:"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/index.html:110 src/olympia/devhub/templates/devhub/includes/addon_details.html:146 src/olympia/devhub/templates/devhub/personas/edit.html:50
+#: src/olympia/devhub/templates/devhub/index.html:110 src/olympia/devhub/templates/devhub/includes/addon_details.html:132 src/olympia/devhub/templates/devhub/personas/edit.html:50
 #, python-format
 msgid "%(position)s of %(total)s"
 msgstr ""
@@ -4234,16 +4217,6 @@ msgstr ""
 msgid "Do you want your add-on to be distributed on this site?"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/validate_addon.html:49 src/olympia/devhub/templates/devhub/addons/submit/upload.html:30 src/olympia/devhub/templates/devhub/versions/add_file_modal.html:14
-#: src/olympia/devhub/templates/devhub/versions/add_file_modal.html:53 src/olympia/devhub/templates/devhub/versions/list.html:298
-msgid "Warning:"
-msgstr ""
-
-#: src/olympia/devhub/templates/devhub/validate_addon.html:50 src/olympia/devhub/templates/devhub/addons/submit/upload.html:31
-#, python-format
-msgid "Submission of unlisted add-ons for signing is currently in an open beta. Please <a href=\"%(url)s\" target=\"_blank\">report any bugs</a> that you encounter."
-msgstr ""
-
 #. first parameter is a filename like lorem-ipsum-1.0.2.xpi
 #: src/olympia/devhub/templates/devhub/validation.html:5
 msgid "Validation Results for {0}"
@@ -4318,7 +4291,7 @@ msgstr ""
 msgid "Update Compatibility"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/addons/ajax_compat_update.html:4
+#: src/olympia/devhub/templates/devhub/addons/ajax_compat_update.html:4 src/olympia/devhub/templates/devhub/versions/edit.html:45
 msgid "Adjusting application information here will allow users to install your add-on even if the install manifest in the package indicates that the add-on is incompatible."
 msgstr ""
 
@@ -4330,9 +4303,9 @@ msgstr "Onartutako bertsioak"
 msgid "Add Another Application&hellip;"
 msgstr "Gehitu beste aplikazio bat&hellip;"
 
-#: src/olympia/devhub/templates/devhub/addons/ajax_compat_update.html:38 src/olympia/devhub/templates/devhub/addons/owner.html:86 src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:46
-#: src/olympia/devhub/templates/devhub/versions/list.html:351 src/olympia/devhub/templates/devhub/versions/list.html:353 src/olympia/templates/impala/base.html:132
-#: src/olympia/templates/impala/base.html:143 src/olympia/templates/impala/base.html:161 src/olympia/templates/impala/base.html:171
+#: src/olympia/devhub/templates/devhub/addons/ajax_compat_update.html:38 src/olympia/devhub/templates/devhub/addons/owner.html:86 src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:45
+#: src/olympia/devhub/templates/devhub/versions/list.html:349 src/olympia/devhub/templates/devhub/versions/list.html:351 src/olympia/templates/impala/base.html:129
+#: src/olympia/templates/impala/base.html:140 src/olympia/templates/impala/base.html:158 src/olympia/templates/impala/base.html:168
 msgid "Close"
 msgstr "Itxi"
 
@@ -4366,7 +4339,7 @@ msgstr "Bat ere ez"
 msgid "Manage Authors & License"
 msgstr "Kudeatu egileak eta lizentzia"
 
-#: src/olympia/devhub/templates/devhub/addons/owner.html:29 src/olympia/editors/templates/editors/review.html:270
+#: src/olympia/devhub/templates/devhub/addons/owner.html:29 src/olympia/editors/helpers.py:362 src/olympia/editors/templates/editors/review.html:270
 msgid "Authors"
 msgstr "Egileak"
 
@@ -4436,17 +4409,11 @@ msgstr "Laburpena"
 
 #: src/olympia/devhub/templates/devhub/addons/edit/basic.html:52
 msgid ""
-"A short explanation of your add-on's basic\n"
-"                          functionality that is displayed in search and browse\n"
-"                          listings, as well as at the top of your add-on's\n"
-"                          details page. It is only relevant for listed add-ons."
+"A short explanation of your add-on's basic functionality that is displayed in search and browse listings, as well as at the top of your add-on's details page. It is only relevant for listed add-ons."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/basic.html:73
-msgid ""
-"Categories are the primary way users browse through add-ons.\n"
-"                        Choose any that fit your add-on's functionality for the most\n"
-"                        exposure. It is only relevant for listed add-ons."
+msgid "Categories are the primary way users browse through add-ons. Choose any that fit your add-on's functionality for the most exposure. It is only relevant for listed add-ons."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/basic.html:90
@@ -4456,11 +4423,7 @@ msgid ""
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/basic.html:119
-msgid ""
-"Tags help users find your add-on and should be short\n"
-"                        descriptors such as tabs, toolbar, or twitter.  You\n"
-"                        may have a maximum of {0} tags. It is only relevant\n"
-"                        for listed add-ons."
+msgid "Tags help users find your add-on and should be short descriptors such as tabs, toolbar, or twitter. You may have a maximum of {0} tags. It is only relevant for listed add-ons."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/basic.html:129 src/olympia/devhub/templates/devhub/personas/edit.html:97 src/olympia/devhub/templates/devhub/personas/submit.html:46
@@ -4488,11 +4451,7 @@ msgid "Add-on Details for {0}"
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/details.html:22
-msgid ""
-"A longer explanation of features,\n"
-"                          functionality, and other relevant information. This\n"
-"                          field is only displayed on the add-on's details\n"
-"                          page. It is only relevant for listed add-ons."
+msgid "A longer explanation of features, functionality, and other relevant information. This field is only displayed on the add-on's details page. It is only relevant for listed add-ons."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/details.html:44 src/olympia/translations/templates/translations/trans-menu.html:13
@@ -4500,10 +4459,7 @@ msgid "Default Locale"
 msgstr "Hizkuntza lehenetsia"
 
 #: src/olympia/devhub/templates/devhub/addons/edit/details.html:45
-msgid ""
-"Information about your add-on is displayed in this locale\n"
-"                        unless you override it with a locale-specific translation.\n"
-"                        It is only relevant for listed add-ons."
+msgid "Information about your add-on is displayed in this locale unless you override it with a locale-specific translation. It is only relevant for listed add-ons."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/details.html:61 src/olympia/users/forms.py:311 src/olympia/users/templates/users/edit.html:122 src/olympia/users/templates/users/register.html:57
@@ -4513,10 +4469,8 @@ msgstr "Hasiera-orria"
 
 #: src/olympia/devhub/templates/devhub/addons/edit/details.html:63
 msgid ""
-"If your add-on has another homepage, enter its\n"
-"                          address here. If your website is localized into other\n"
-"                          languages multiple translations of this field can be\n"
-"                          added. It is only relevant for listed add-ons."
+"If your add-on has another homepage, enter its address here. If your website is localized into other languages multiple translations of this field can be added. It is only relevant for listed add-"
+"ons."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/media.html:3
@@ -4534,19 +4488,14 @@ msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/support.html:22
 msgid ""
-"If you wish to display an e-mail address for support\n"
-"                          inquiries, enter it here. If you have different\n"
-"                          addresses for each language multiple translations of\n"
-"                          this field can be added. It is only relevant for\n"
-"                          listed add-ons."
+"If you wish to display an e-mail address for support inquiries, enter it here. If you have different addresses for each language multiple translations of this field can be added. It is only "
+"relevant for listed add-ons."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/support.html:45
 msgid ""
-"If your add-on has a support website or forum, enter\n"
-"                          its address here. If your website is localized into\n"
-"                          other languages, multiple translations of this field can\n"
-"                          be added. It is only relevant for listed add-ons."
+"If your add-on has a support website or forum, enter its address here. If your website is localized into other languages, multiple translations of this field can be added. It is only relevant for "
+"listed add-ons."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:6
@@ -4560,11 +4509,8 @@ msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:23
 msgid ""
-"Any information end users may want to know that isn't\n"
-"                          necessarily applicable to the add-on summary or description.\n"
-"                          Common uses include listing known major bugs, information on\n"
-"                          how to report bugs, anticipated release date of a new version,\n"
-"                          etc. It is only relevant for listed add-ons."
+"Any information end users may want to know that isn't necessarily applicable to the add-on summary or description. Common uses include listing known major bugs, information on how to report bugs, "
+"anticipated release date of a new version, etc. It is only relevant for listed add-ons."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:46
@@ -4576,9 +4522,7 @@ msgid "Add-on Flags"
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:69
-msgid ""
-"These flags are used to classify add-ons. It is only\n"
-"                        relevant for listed add-ons."
+msgid "These flags are used to classify add-ons. It is only relevant for listed add-ons."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:74
@@ -4594,9 +4538,7 @@ msgid "View Source?"
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:90
-msgid ""
-"Whether the source of your add-on can be displayed in our\n"
-"                        online viewer. It is only relevant for listed add-ons."
+msgid "Whether the source of your add-on can be displayed in our online viewer. It is only relevant for listed add-ons."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:94
@@ -4612,10 +4554,7 @@ msgid "Public Stats?"
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:102
-msgid ""
-"Whether the download and usage stats of your add-on can\n"
-"                        be displayed in our online viewer.\n"
-"                        It is only relevant for listed add-ons."
+msgid "Whether the download and usage stats of your add-on can be displayed in our online viewer. It is only relevant for listed add-ons."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:107
@@ -4631,10 +4570,7 @@ msgid "Upgrade SDK?"
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:116
-msgid ""
-"If selected, we will try to automatically upgrade your\n"
-"                        add-on when a new version of the SDK is released.\n"
-"                        It is only relevant for listed add-ons."
+msgid "If selected, we will try to automatically upgrade your add-on when a new version of the SDK is released. It is only relevant for listed add-ons."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:121
@@ -4685,10 +4621,8 @@ msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/forms_shared/media.html:16
 msgid ""
-"Upload an icon for your add-on or choose from one of ours. The\n"
-"                      icon is displayed nearly everywhere your add-on is. Uploaded images\n"
-"                      must be one of the following image types: .png, .jpg.\n"
-"                      It is only relevant for listed add-ons."
+"Upload an icon for your add-on or choose from one of ours. The icon is displayed nearly everywhere your add-on is. Uploaded images must be one of the following image types: .png, .jpg. It is only "
+"relevant for listed add-ons."
 msgstr ""
 
 # %s is the application name (Firefox, Thunderbird).
@@ -4702,9 +4636,7 @@ msgid "32x32px"
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/forms_shared/media.html:39
-msgid ""
-"Used in listings of add-ons, like search results\n"
-"                            and featured add-ons."
+msgid "Used in listings of add-ons, like search results and featured add-ons."
 msgstr ""
 
 #. The size of the icon
@@ -4799,16 +4731,14 @@ msgid "Deleting your add-on will permanently remove it from the site and prevent
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:24
-msgid ""
-"Enter the following text confirm your decision:\n"
-"           {slug}"
+msgid "Enter the following text confirm your decision: {slug}"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:34
+#: src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:33
 msgid "Please tell us why you are deleting your theme:"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:36
+#: src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:35
 msgid "Please tell us why you are deleting your add-on:"
 msgstr ""
 
@@ -4845,8 +4775,8 @@ msgstr "Bertsio berria"
 msgid "Daily statistics on downloads and users."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/addons/listing/item_actions.html:45 src/olympia/stats/templates/stats/stats.html:75 src/olympia/stats/templates/stats/stats.html:79
-#: src/olympia/stats/templates/stats/stats.html:81
+#: src/olympia/devhub/templates/devhub/addons/listing/item_actions.html:45 src/olympia/stats/templates/stats/stats.html:31 src/olympia/stats/templates/stats/stats.html:35
+#: src/olympia/stats/templates/stats/stats.html:37
 msgid "Statistics"
 msgstr "Estatistikak"
 
@@ -4965,10 +4895,7 @@ msgid "Your add-on has been submitted to the Full Review queue."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/submit/done.html:18
-msgid ""
-"You'll receive an email once it has been reviewed by an editor. In\n"
-"          the meantime, you and your friends can install it directly from its\n"
-"          details page:"
+msgid "You'll receive an email once it has been reviewed by an editor. In the meantime, you and your friends can install it directly from its details page:"
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/submit/done.html:27 src/olympia/devhub/templates/devhub/addons/submit/done.html:77 src/olympia/devhub/templates/devhub/personas/submit_done.html:16
@@ -5178,11 +5105,11 @@ msgstr ""
 msgid "Use the fields below to upload your add-on package and select any platform restrictions. After upload, a series of automated validation tests will be run on your file."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/addons/submit/upload.html:59 src/olympia/devhub/templates/devhub/versions/add_file_modal.html:39
+#: src/olympia/devhub/templates/devhub/addons/submit/upload.html:51 src/olympia/devhub/templates/devhub/versions/add_file_modal.html:28
 msgid "Which platforms is this file compatible with?"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/addons/submit/upload.html:67 src/olympia/devhub/templates/devhub/versions/add_file_modal.html:65
+#: src/olympia/devhub/templates/devhub/addons/submit/upload.html:59 src/olympia/devhub/templates/devhub/versions/add_file_modal.html:45
 msgid "Administrative overrides"
 msgstr ""
 
@@ -5292,8 +5219,8 @@ msgstr ""
 
 #: src/olympia/devhub/templates/devhub/docs/policies-contact.html:44
 msgid ""
-"If you've found a problem with the site, we'd love to fix it. Please <a href=\"https://github.com/mozilla/olympia/issues\">file a bug report</a> in GitHub, including the location of the problem and "
-"how you encountered it."
+"If you've found a problem with the site, we'd love to fix it. Please <a href=\"https://github.com/mozilla/addons/issues/new\">file a bug report</a> in GitHub, including the location of the problem "
+"and how you encountered it."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/docs/policies-maintenance.html:3 src/olympia/devhub/templates/devhub/docs/policies-maintenance.html:7
@@ -5860,7 +5787,7 @@ msgstr ""
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:282
 msgid ""
-"Add-ons that store or otherwise handle browsing data must support <a href=\"https://developer.mozilla.org/En/Supporting_private_browsing_mode\">Private Browsing Mode</a>.  During a Private Browsing "
+"Add-ons that store or otherwise handle browsing data must support <a href=\"https://developer.mozilla.org/En/Supporting_private_browsing_mode\">Private Browsing Mode</a>. During a Private Browsing "
 "session, no browsing data can be written to disk, and all of this data must be cleared when Firefox quits or the Private Browsing session ends."
 msgstr ""
 
@@ -6025,129 +5952,95 @@ msgstr ""
 msgid "How to get in touch with us regarding these policies or your add-on."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:6
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:10
 msgid "You have disabled this add-on"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:20
-msgid ""
-"Your add-on's listing is disabled and is not showing\n"
-"                             anywhere in our gallery or update service."
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:24
+msgid "Your add-on's listing is disabled and is not showing anywhere in our gallery or update service."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:25
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:27
 msgid "Please complete your add-on."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:29
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:30
 msgid "You will receive an email when the review is complete."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:34
-msgid ""
-"You will receive an email when the review is complete. Until\n"
-"                             then, your add-on is not listed in our gallery but can be\n"
-"                             accessed directly from its details page."
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:33
+msgid "You will receive an email when the review is complete. Until then, your add-on is not listed in our gallery but can be accessed directly from its details page."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:38 src/olympia/devhub/templates/devhub/includes/addon_details.html:48
-msgid ""
-"You will receive an email when the review is\n"
-"                             complete and your add-on is signed."
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:37 src/olympia/devhub/templates/devhub/includes/addon_details.html:45
+msgid "You will receive an email when the review is complete and your add-on is signed."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:44
-msgid ""
-"You will receive an email when the review is complete. Until\n"
-"                             then, your add-on is not listed in our gallery but can be\n"
-"                             accessed directly from its details page. "
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:41
+msgid "You will receive an email when the review is complete. Until then, your add-on is not listed in our gallery but can be accessed directly from its details page. "
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:54
-msgid ""
-"Your add-on is displayed in our gallery and users are\n"
-"                             receiving automatic updates."
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:49
+msgid "Your add-on is displayed in our gallery and users are receiving automatic updates."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:57
-msgid ""
-"Your add-on has been signed and can be bundled with an\n"
-"                             application installer."
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:52
+msgid "Your add-on has been signed and can be bundled with an application installer."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:63
-msgid ""
-"Your add-on was disabled by a site administrator and is no\n"
-"                             longer shown in our gallery. If you have any questions,\n"
-"                             please email amo-admins@mozilla.org."
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:56
+msgid "Your add-on was disabled by a site administrator and is no longer shown in our gallery. If you have any questions, please email amo-admins@mozilla.org."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:70
-msgid ""
-"Your add-on is displayed in our gallery as experimental\n"
-"                             and users are receiving automatic updates. Some features\n"
-"                             are unavailable to your add-on."
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:62
+msgid "Your add-on is displayed in our gallery as experimental and users are receiving automatic updates. Some features are unavailable to your add-on."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:74
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:66
 msgid "Your add-on has been signed."
 msgstr ""
 
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:69
+msgid ""
+"You will receive an email when the full review is complete. Until then, your add-on is displayed in our gallery as experimental and users are receiving automatic updates. Some features are "
+"unavailable to your add-on."
+msgstr ""
+
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:74
+msgid "You will receive an email when the full review is complete, making you able to bundle your add-on with an application installer."
+msgstr ""
+
 #: src/olympia/devhub/templates/devhub/includes/addon_details.html:79
-msgid ""
-"You will receive an email when the full review is complete.\n"
-"                             Until then, your add-on is displayed in our gallery as\n"
-"                             experimental and users are receiving automatic updates.\n"
-"                             Some features are unavailable to your add-on."
+msgid "All add-ons hosted in our gallery must now be reviewed by an editor. If you wish to continue hosting your add-on, please click to select a review process."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:84
-msgid ""
-"You will receive an email when the full review is\n"
-"                             complete, making you able to bundle your add-on with an\n"
-"                             application installer."
-msgstr ""
-
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:91
-msgid ""
-"All add-ons hosted in our gallery must now be reviewed by an\n"
-"                             editor. If you wish to continue hosting your add-on, please\n"
-"                             click to select a review process."
-msgstr ""
-
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:113
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:100
 msgid "Current Version:"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:115
-msgid ""
-"This is the version of your add-on that will\n"
-"                                           be installed if someone clicks the Install\n"
-"                                           button on addons.mozilla.org. It is only\n"
-"                                           relevant for listed add-ons."
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:102
+msgid "This is the version of your add-on that will be installed if someone clicks the Install button on addons.mozilla.org. It is only relevant for listed add-ons."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:123
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:110
 msgid "Created:"
 msgstr ""
 
 #. {0} is a date. dennis-ignore: E201
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:125 src/olympia/devhub/templates/devhub/includes/addon_details.html:131
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:112 src/olympia/devhub/templates/devhub/includes/addon_details.html:118
 #, python-format
 msgid "%%b %%e, %%Y"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:136
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:123
 msgid "Next Version:"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:138
-msgid ""
-"This is the newest uploaded version, however\n"
-"                                           it isn’t live on the site yet."
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:125
+msgid "This is the newest uploaded version, however it isn’t live on the site yet."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:144 src/olympia/devhub/templates/devhub/versions/list.html:30
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:130 src/olympia/devhub/templates/devhub/versions/list.html:30
 msgid "Queues are not reviewed strictly in order"
 msgstr ""
 
@@ -6215,9 +6108,7 @@ msgid "View the blog &#9658;"
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/includes/license_form.html:6
-msgid ""
-"Please choose a license appropriate for the rights you grant on your source code.\n"
-"                  It is only relevant for listed add-ons."
+msgid "Please choose a license appropriate for the rights you grant on your source code. It is only relevant for listed add-ons."
 msgstr ""
 
 #. {0} is a list of HTML tags.
@@ -6246,14 +6137,11 @@ msgstr[1] "Hautatu gehienez ere %s(r)en hiru kategoria zure gehigarriarentzat"
 #: src/olympia/devhub/templates/devhub/includes/policy_form.html:4
 msgid ""
 "Users will be required to accept the following End-User License Agreement (EULA) prior to installing your add-on. The presence of a EULA significantly affects the number of downloads an add-on "
-"receives. Please note that a EULA is not the same as a code license, such as the GPL or MPL.\n"
-"                It is only relevant for listed add-ons."
+"receives. Please note that a EULA is not the same as a code license, such as the GPL or MPL.It is only relevant for listed add-ons."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/policy_form.html:21
-msgid ""
-"If your add-on transmits any data from the user's computer, a privacy policy is required that explains what data is sent and how it is used.\n"
-"                It is only relevant for listed add-ons."
+#: src/olympia/devhub/templates/devhub/includes/policy_form.html:24
+msgid "If your add-on transmits any data from the user's computer, a privacy policy is required that explains what data is sent and how it is used. It is only relevant for listed add-ons."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/includes/source_form_field.html:2
@@ -6421,12 +6309,8 @@ msgstr ""
 msgid "Add some tags to describe your Theme."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/personas/edit.html:106
-msgid ""
-"A short explanation of your theme's\n"
-"                                basic functionality that is displayed in\n"
-"                                search and browse listings, as well as at\n"
-"                                the top of your theme's details page."
+#: src/olympia/devhub/templates/devhub/personas/edit.html:106 src/olympia/devhub/templates/devhub/personas/submit.html:54
+msgid "A short explanation of your theme's basic functionality that is displayed in search and browse listings, as well as at the top of your theme's details page."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/personas/edit.html:122 src/olympia/devhub/templates/devhub/personas/submit.html:68
@@ -6496,7 +6380,7 @@ msgid "Upon upload and form submission, the AMO Team will review your updated de
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/personas/edit.html:241
-msgid "Your previously resubmitted design,  which is under pending review."
+msgid "Your previously resubmitted design, which is under pending review."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/personas/edit.html:245
@@ -6563,14 +6447,6 @@ msgstr ""
 
 #: src/olympia/devhub/templates/devhub/personas/submit.html:33
 msgid "Give your Theme a name."
-msgstr ""
-
-#: src/olympia/devhub/templates/devhub/personas/submit.html:54
-msgid ""
-"A short explanation of your theme's\n"
-"                                      basic functionality that is displayed in\n"
-"                                      search and browse listings, as well as at\n"
-"                                      the top of your theme's details page."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/personas/submit.html:198
@@ -6647,30 +6523,16 @@ msgstr ""
 msgid "Files added to reviewed versions must be reviewed before they will be available for download."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/add_file_modal.html:15
-#, python-format
-msgid ""
-"Submission of updates to unlisted add-ons for signing is currently in an open beta. Manual review may still be required for a large number of add-ons. Please <a href=\"%(url)s\" target=\"_blank"
-"\">report any bugs</a> that you encounter."
-msgstr ""
-
-#: src/olympia/devhub/templates/devhub/versions/add_file_modal.html:35
+#: src/olympia/devhub/templates/devhub/versions/add_file_modal.html:24
 msgid "Select the target platform for this file."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/add_file_modal.html:46
+#: src/olympia/devhub/templates/devhub/versions/add_file_modal.html:35
 msgid "Which review type would you like to nominate for?"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/add_file_modal.html:51
+#: src/olympia/devhub/templates/devhub/versions/add_file_modal.html:40
 msgid "Only publish this version to my beta channel."
-msgstr ""
-
-#: src/olympia/devhub/templates/devhub/versions/add_file_modal.html:54
-#, python-format
-msgid ""
-"The behavior of the beta channel has changed to accommodate <a href=\"%(addon_signing_url)s\" target=\"_blank\">mandatory add-on signing</a>. The new process is currently in an open beta, and may "
-"change significantly in the near future. Please <a href=\"%(issues_url)s\" target=\"_blank\">report any bugs</a> that you encounter."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/versions/edit.html:5
@@ -6695,13 +6557,6 @@ msgstr ""
 msgid "Upload Another File"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/edit.html:45
-msgid ""
-"Adjusting application information here will allow users to install your\n"
-"                          add-on even if the install manifest in the package indicates that the\n"
-"                          add-on is incompatible."
-msgstr ""
-
 #: src/olympia/devhub/templates/devhub/versions/edit.html:74
 msgid ""
 "Information about changes in this release, new features, known bugs, and other useful information specific to this release/version. This information is also shown in the Add-ons Manager when "
@@ -6719,10 +6574,7 @@ msgid "Notes for Reviewers"
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/versions/edit.html:114
-msgid ""
-"Optionally, enter any information that may be useful\n"
-"                              to the Editor reviewing this add-on, such as test\n"
-"                              account information."
+msgid "Optionally, enter any information that may be useful to the Editor reviewing this add-on, such as test account information."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/versions/edit.html:127
@@ -6805,7 +6657,7 @@ msgstr ""
 msgid "Request Preliminary Review"
 msgstr "Ordezkatu aurrebista"
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:80 src/olympia/devhub/templates/devhub/versions/list.html:327 src/olympia/devhub/templates/devhub/versions/list.html:350
+#: src/olympia/devhub/templates/devhub/versions/list.html:80 src/olympia/devhub/templates/devhub/versions/list.html:325 src/olympia/devhub/templates/devhub/versions/list.html:348
 msgid "Cancel Review Request"
 msgstr ""
 
@@ -6834,7 +6686,7 @@ msgid "Unlisted:"
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/versions/list.html:114
-msgid "Not distributed on {0}. Developers will upload new versions for signing and distribute the add-ons on their own. (beta)"
+msgid "Not distributed on {0}. Developers will upload new versions for signing and distribute the add-ons on their own."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/versions/list.html:122
@@ -6899,81 +6751,73 @@ msgid "<strong>Important:</strong> Once a version has been deleted, you may not 
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/versions/list.html:230
-msgid ""
-"Deleting a version which has already been reviewed\n"
-"               may also cause a significant delay in the review of\n"
-"               your next update."
-msgstr ""
-
-#: src/olympia/devhub/templates/devhub/versions/list.html:233
 msgid "Are you sure you wish to delete this version?"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:238
+#: src/olympia/devhub/templates/devhub/versions/list.html:235
 msgid "Delete Version"
 msgstr "Ezabatu bertsioa"
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:240
+#: src/olympia/devhub/templates/devhub/versions/list.html:237
 msgid "Disable Version"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:247
+#: src/olympia/devhub/templates/devhub/versions/list.html:244
 msgid "Add a new Version"
 msgstr "Gehitu bertsio berria"
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:249
+#: src/olympia/devhub/templates/devhub/versions/list.html:246
 msgid "Add Version"
 msgstr "Gehitu bertsioa"
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:256 src/olympia/devhub/templates/devhub/versions/list.html:274
+#: src/olympia/devhub/templates/devhub/versions/list.html:253 src/olympia/devhub/templates/devhub/versions/list.html:279
 msgid "Hide Add-on"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:259
+#: src/olympia/devhub/templates/devhub/versions/list.html:256
 msgid "Hiding your add-on will prevent it from appearing anywhere in our gallery and will stop users from receiving automatic updates."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:265
+#: src/olympia/devhub/templates/devhub/versions/list.html:263
+msgid "The files awaiting review will be disabled and you will need to upload new versions."
+msgstr ""
+
+#: src/olympia/devhub/templates/devhub/versions/list.html:270
 msgid "Are you sure you wish to hide your add-on?"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:286 src/olympia/devhub/templates/devhub/versions/list.html:315
+#: src/olympia/devhub/templates/devhub/versions/list.html:291 src/olympia/devhub/templates/devhub/versions/list.html:313
 msgid "Unlist Add-on"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:289
+#: src/olympia/devhub/templates/devhub/versions/list.html:294
 #, python-format
 msgid ""
 "Unlisting your add-on will make it (and each of its versions/files) invisible on this website. It won't show up in searches, won't have a public facing page, and won't be updated automatically for "
-"current users.  It is recommended for unlisted add-ons to provide a custom <a href=\"%(update_url)s\" target=\"_blank\">updateURL</a> in their manifest file for automatic updates."
+"current users. It is recommended for unlisted add-ons to provide a custom <a href=\"%(update_url)s\" target=\"_blank\">updateURL</a> in their manifest file for automatic updates."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:299
-#, python-format
-msgid "Switching add-ons to unlisted is currently in an open beta. Please <a href=\"%(url)s\" target=\"_blank\">report any bugs</a> that you encounter."
-msgstr ""
-
-#: src/olympia/devhub/templates/devhub/versions/list.html:305
+#: src/olympia/devhub/templates/devhub/versions/list.html:303
 msgid "Unlisting an add-on is irreversible!"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:305
+#: src/olympia/devhub/templates/devhub/versions/list.html:303
 msgid "An unlisted add-on cannot be switched to be listed."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:307
+#: src/olympia/devhub/templates/devhub/versions/list.html:305
 msgid "Are you sure you wish to unlist your add-on?"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:330
+#: src/olympia/devhub/templates/devhub/versions/list.html:328
 msgid "Canceling your review request will leave your add-on as preliminarily reviewed."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:335
+#: src/olympia/devhub/templates/devhub/versions/list.html:333
 msgid "Canceling your review request will mark your add-on incomplete. If you do not complete your add-on after several days by re-requesting review, it will be deleted."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:343
+#: src/olympia/devhub/templates/devhub/versions/list.html:341
 msgid "Are you sure you wish to cancel your review request?"
 msgstr ""
 
@@ -7318,19 +7162,19 @@ msgstr ""
 msgid "Search by add-on name / author email"
 msgstr ""
 
-#: src/olympia/editors/forms.py:103
+#: src/olympia/editors/forms.py:103 src/olympia/editors/forms.py:244 src/olympia/editors/forms.py:257
 msgid "yes"
 msgstr "bai"
 
-#: src/olympia/editors/forms.py:104
+#: src/olympia/editors/forms.py:104 src/olympia/editors/forms.py:244 src/olympia/editors/forms.py:257
 msgid "no"
 msgstr "ez"
 
-#: src/olympia/editors/forms.py:105
+#: src/olympia/editors/forms.py:105 src/olympia/editors/forms.py:245
 msgid "Admin Flag"
 msgstr ""
 
-#: src/olympia/editors/forms.py:113
+#: src/olympia/editors/forms.py:113 src/olympia/editors/forms.py:253
 msgid "Max. Version"
 msgstr ""
 
@@ -7342,55 +7186,59 @@ msgstr ""
 msgid "Add-on Types"
 msgstr "Gehigarri motak"
 
-#: src/olympia/editors/forms.py:126 src/olympia/editors/helpers.py:267
+#: src/olympia/editors/forms.py:126 src/olympia/editors/helpers.py:279
 msgid "Platforms"
 msgstr "Plataforma"
 
+#: src/olympia/editors/forms.py:237
+msgid "Search by add-on name / author email / guid"
+msgstr ""
+
 #. L10n: 0 = platform, 1 = filename, 2 = status message
-#: src/olympia/editors/forms.py:238
+#: src/olympia/editors/forms.py:342
 #, python-format
 msgid "<strong>%s</strong> &middot; %s &middot; %s"
 msgstr ""
 
-#: src/olympia/editors/forms.py:252
+#: src/olympia/editors/forms.py:356
 msgid "Comments:"
 msgstr "Iruzkinak:"
 
-#: src/olympia/editors/forms.py:256
+#: src/olympia/editors/forms.py:360
 msgid "Operating systems:"
 msgstr "Sistema eragileak:"
 
-#: src/olympia/editors/forms.py:258
+#: src/olympia/editors/forms.py:362
 msgid "Applications:"
 msgstr "Aplikazioak:"
 
-#: src/olympia/editors/forms.py:260
+#: src/olympia/editors/forms.py:364
 msgid "Notify me the next time this add-on is updated. (Subsequent updates will not generate an email)"
 msgstr ""
 
-#: src/olympia/editors/forms.py:265
+#: src/olympia/editors/forms.py:369
 msgid "Clear Admin Review Flag"
 msgstr ""
 
-#: src/olympia/editors/forms.py:267
+#: src/olympia/editors/forms.py:371
 msgid "Clear more info requested flag"
 msgstr ""
 
-#: src/olympia/editors/forms.py:281
+#: src/olympia/editors/forms.py:385
 msgid "Choose a canned response..."
 msgstr ""
 
 #. L10n: Description of what can be searched for.
-#: src/olympia/editors/forms.py:324
+#: src/olympia/editors/forms.py:423
 msgid "theme name"
 msgstr ""
 
-#: src/olympia/editors/forms.py:350
+#: src/olympia/editors/forms.py:449
 msgid "Someone else is reviewing this theme."
 msgstr ""
 
 #. L10n: Description of what can be searched for.
-#: src/olympia/editors/forms.py:447
+#: src/olympia/editors/forms.py:546
 msgid "app, reviewer, or comment"
 msgstr ""
 
@@ -7412,255 +7260,273 @@ msgstr "Ordezkatu aurrebista"
 msgid "Rejected or Unreviewed"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:123 src/olympia/editors/helpers.py:136
+#: src/olympia/editors/helpers.py:125 src/olympia/editors/helpers.py:138
 msgid "Queue"
 msgstr ""
 
 # %1 is the update count
-#: src/olympia/editors/helpers.py:124 src/olympia/editors/templates/editors/base.html:50 src/olympia/editors/templates/editors/base.html:65
+#: src/olympia/editors/helpers.py:126 src/olympia/editors/templates/editors/base.html:50 src/olympia/editors/templates/editors/base.html:65
 msgid "Pending Updates"
 msgstr "Eguneraketak zain"
 
-#: src/olympia/editors/helpers.py:125 src/olympia/editors/templates/editors/base.html:48 src/olympia/editors/templates/editors/base.html:63
+#: src/olympia/editors/helpers.py:127 src/olympia/editors/templates/editors/base.html:48 src/olympia/editors/templates/editors/base.html:63
 #, fuzzy
 msgid "Full Reviews"
 msgstr "Berrikuspenak"
 
-#: src/olympia/editors/helpers.py:126 src/olympia/editors/templates/editors/base.html:52 src/olympia/editors/templates/editors/base.html:67
+#: src/olympia/editors/helpers.py:128 src/olympia/editors/templates/editors/base.html:52 src/olympia/editors/templates/editors/base.html:67
 #, fuzzy
 msgid "Preliminary Reviews"
 msgstr "Prozesatu berrikuspenak"
 
 # %1 is the review count
-#: src/olympia/editors/helpers.py:127 src/olympia/editors/templates/editors/base.html:54
+#: src/olympia/editors/helpers.py:129 src/olympia/editors/templates/editors/base.html:54
 msgid "Moderated Reviews"
 msgstr "Moderatutako berrikuspenak"
 
-#: src/olympia/editors/helpers.py:128 src/olympia/editors/templates/editors/base.html:46
+#: src/olympia/editors/helpers.py:130 src/olympia/editors/templates/editors/base.html:46
 msgid "Fast Track"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:130
+#: src/olympia/editors/helpers.py:132
 msgid "Pending Themes"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:131 src/olympia/editors/templates/editors/themes/queue.html:4
+#: src/olympia/editors/helpers.py:133 src/olympia/editors/templates/editors/themes/queue.html:4
 msgid "Flagged Themes"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:132
+#: src/olympia/editors/helpers.py:134
 msgid "Update Themes"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:137
+#: src/olympia/editors/helpers.py:139
 msgid "Unlisted Pending Updates"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:138
+#: src/olympia/editors/helpers.py:140
 msgid "Unlisted Full Reviews"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:139
+#: src/olympia/editors/helpers.py:141
 msgid "Unlisted Preliminary Reviews"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:170
+#: src/olympia/editors/helpers.py:142
+msgid "Unlisted All Add-ons"
+msgstr ""
+
+#: src/olympia/editors/helpers.py:173
 msgid "Fast Track ({0})"
 msgid_plural "Fast Track ({0})"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/olympia/editors/helpers.py:175
+#: src/olympia/editors/helpers.py:178
 msgid "Full Review ({0})"
 msgid_plural "Full Reviews ({0})"
 msgstr[0] ""
 msgstr[1] ""
 
 # %1 is the update count
-#: src/olympia/editors/helpers.py:180
+#: src/olympia/editors/helpers.py:183
 msgid "Pending Update ({0})"
 msgid_plural "Pending Updates ({0})"
 msgstr[0] "Eguneraketak zain ({0})"
 msgstr[1] "Eguneraketak zain ({0})"
 
-#: src/olympia/editors/helpers.py:185
+#: src/olympia/editors/helpers.py:188
 msgid "Preliminary Review ({0})"
 msgid_plural "Preliminary Reviews ({0})"
 msgstr[0] ""
 msgstr[1] ""
 
 # %1 is the review count
-#: src/olympia/editors/helpers.py:190
+#: src/olympia/editors/helpers.py:193
 msgid "Moderated Review ({0})"
 msgid_plural "Moderated Reviews ({0})"
 msgstr[0] "Moderatutako berrikuspena ({0})"
 msgstr[1] "Moderatutako berrikuspenak ({0})"
 
-#: src/olympia/editors/helpers.py:196
+#: src/olympia/editors/helpers.py:199
 msgid "Unlisted Full Review ({0})"
 msgid_plural "Unlisted Full Reviews ({0})"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/olympia/editors/helpers.py:201
+#: src/olympia/editors/helpers.py:204
 msgid "Unlisted Pending Update ({0})"
 msgid_plural "Unlisted Pending Updates ({0})"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/olympia/editors/helpers.py:206
+#: src/olympia/editors/helpers.py:209
 msgid "Unlisted Preliminary Review ({0})"
 msgid_plural "Unlisted Preliminary Reviews ({0})"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/olympia/editors/helpers.py:261
-msgid "Addon"
-msgstr "Gehigarria"
+#: src/olympia/editors/helpers.py:214
+msgid "Unlisted All Add-ons ({0})"
+msgid_plural "Unlisted All Add-ons ({0})"
+msgstr[0] ""
+msgstr[1] ""
 
-#: src/olympia/editors/helpers.py:262
+#: src/olympia/editors/helpers.py:274
 msgid "Type"
 msgstr "Mota"
 
-#: src/olympia/editors/helpers.py:263
+#: src/olympia/editors/helpers.py:275
 msgid "Waiting Time"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:264 src/olympia/editors/templates/editors/review.html:285
+#: src/olympia/editors/helpers.py:276 src/olympia/editors/templates/editors/review.html:285
 msgid "Flags"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:265
+#: src/olympia/editors/helpers.py:277
 msgid "Applications"
 msgstr "Aplikazioak"
 
-#: src/olympia/editors/helpers.py:270
+#: src/olympia/editors/helpers.py:282
 msgid "Additional"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:285
+#: src/olympia/editors/helpers.py:302
 msgid "Site Specific"
 msgstr "Gune konkreturako"
 
-#: src/olympia/editors/helpers.py:287
+#: src/olympia/editors/helpers.py:304
 msgid "Requires External Software"
 msgstr "Kanpoko softwarea behar du"
 
-#: src/olympia/editors/helpers.py:289
+#: src/olympia/editors/helpers.py:306
 msgid "Binary Components"
 msgstr "Osagai bitarrak"
 
-#: src/olympia/editors/helpers.py:313
+#: src/olympia/editors/helpers.py:339
 #, fuzzy
 msgid "moments ago"
 msgstr "Duela hilabete"
 
 #. L10n: first argument is number of minutes
-#: src/olympia/editors/helpers.py:316
+#: src/olympia/editors/helpers.py:342
 msgid "{0} minute"
 msgid_plural "{0} minutes"
 msgstr[0] "minutu bat"
 msgstr[1] "{0} minutu"
 
 #. L10n: first argument is number of hours
-#: src/olympia/editors/helpers.py:320
+#: src/olympia/editors/helpers.py:346
 msgid "{0} hour"
 msgid_plural "{0} hours"
 msgstr[0] "ordu bat"
 msgstr[1] "{0} ordu"
 
 #. L10n: first argument is number of days
-#: src/olympia/editors/helpers.py:324
+#: src/olympia/editors/helpers.py:350
 msgid "{0} day"
 msgid_plural "{0} days"
 msgstr[0] "egun bat"
 msgstr[1] "{0} egun"
 
-#: src/olympia/editors/helpers.py:488
+#: src/olympia/editors/helpers.py:364
+msgid "Last Review"
+msgstr ""
+
+#: src/olympia/editors/helpers.py:366
+msgid "Last Update"
+msgstr ""
+
+#: src/olympia/editors/helpers.py:387
+msgid "No Reviews"
+msgstr ""
+
+#: src/olympia/editors/helpers.py:561
 msgid "Push to public"
 msgstr "Eskatu publiko izatea"
 
-#: src/olympia/editors/helpers.py:490
+#: src/olympia/editors/helpers.py:563
 msgid "Grant full review"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:505
+#: src/olympia/editors/helpers.py:578
 msgid "Request more information"
 msgstr "Eskatu informazio gehiago"
 
-#: src/olympia/editors/helpers.py:508
+#: src/olympia/editors/helpers.py:581
 msgid "Request super-review"
 msgstr "Eskatu super-berrikusp"
 
-#: src/olympia/editors/helpers.py:519
+#: src/olympia/editors/helpers.py:592
 #, fuzzy
 msgid "Grant preliminary review"
 msgstr "Ordezkatu aurrebista"
 
-#: src/olympia/editors/helpers.py:520
+#: src/olympia/editors/helpers.py:593
 msgid "This will mark the files as preliminarily reviewed."
 msgstr ""
 
-#: src/olympia/editors/helpers.py:522
+#: src/olympia/editors/helpers.py:595
 msgid "Use this form to request more information from the author. They will receive an email and be able to answer here. You will be notified by email when they reply."
 msgstr ""
 
-#: src/olympia/editors/helpers.py:526
+#: src/olympia/editors/helpers.py:599
 msgid ""
 "If you have concerns about this add-on's security, copyright issues, or other concerns that an administrator should look into, enter your comments in the area below. They will be sent to "
 "administrators, not the author."
 msgstr ""
 
-#: src/olympia/editors/helpers.py:532
+#: src/olympia/editors/helpers.py:605
 msgid "This will reject the add-on and remove it from the review queue."
 msgstr ""
 
-#: src/olympia/editors/helpers.py:534
-msgid "Make a comment on this version.  The author won't be able to see this."
+#: src/olympia/editors/helpers.py:607
+msgid "Make a comment on this version. The author won't be able to see this."
 msgstr ""
 
-#: src/olympia/editors/helpers.py:538
+#: src/olympia/editors/helpers.py:611
 msgid "This will reject the files and remove them from the review queue."
 msgstr ""
 
-#: src/olympia/editors/helpers.py:542
+#: src/olympia/editors/helpers.py:615
 msgid "This will mark the add-on as preliminarily reviewed. Future versions will undergo preliminary review."
 msgstr ""
 
-#: src/olympia/editors/helpers.py:547
+#: src/olympia/editors/helpers.py:620
 msgid "This will mark the files as preliminarily reviewed. Future versions will undergo preliminary review."
 msgstr ""
 
-#: src/olympia/editors/helpers.py:552
+#: src/olympia/editors/helpers.py:625
 #, fuzzy
 msgid "Retain preliminary review"
 msgstr "Ordezkatu aurrebista"
 
-#: src/olympia/editors/helpers.py:553
+#: src/olympia/editors/helpers.py:626
 msgid "This will retain the add-on as preliminarily reviewed. Future versions will undergo preliminary review."
 msgstr ""
 
-#: src/olympia/editors/helpers.py:558
+#: src/olympia/editors/helpers.py:631
 msgid "This will approve a sandboxed version of a public add-on to appear on the public side."
 msgstr ""
 
-#: src/olympia/editors/helpers.py:561
+#: src/olympia/editors/helpers.py:634
 msgid "This will reject a version of a public add-on and remove it from the queue."
 msgstr ""
 
-#: src/olympia/editors/helpers.py:564
+#: src/olympia/editors/helpers.py:637
 msgid "This will mark the add-on and its most recent version and files as public. Future versions will go into the sandbox until they are reviewed by an editor."
 msgstr ""
 
-#: src/olympia/editors/helpers.py:637
+#: src/olympia/editors/helpers.py:714
 msgid "add-on"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:940 src/olympia/editors/helpers.py:960
+#: src/olympia/editors/helpers.py:1020 src/olympia/editors/helpers.py:1040
 msgid "Flagged"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:944 src/olympia/editors/helpers.py:963
+#: src/olympia/editors/helpers.py:1024 src/olympia/editors/helpers.py:1043
 msgid "Updates"
 msgstr ""
 
@@ -7713,62 +7579,62 @@ msgstr ""
 msgid "A question about your Theme submission"
 msgstr ""
 
-#: src/olympia/editors/views.py:144
+#: src/olympia/editors/views.py:146
 msgid "New Add-ons (Under 5 days)"
 msgstr ""
 
-#: src/olympia/editors/views.py:145
+#: src/olympia/editors/views.py:147
 msgid "Passable (5 to 10 days)"
 msgstr ""
 
-#: src/olympia/editors/views.py:146
+#: src/olympia/editors/views.py:148
 msgid "Overdue (Over 10 days)"
 msgstr ""
 
-#: src/olympia/editors/views.py:532
+#: src/olympia/editors/views.py:539
 msgid "An unknown error occurred"
 msgstr ""
 
-#: src/olympia/editors/views.py:587
+#: src/olympia/editors/views.py:592
 msgid "Self-reviews are not allowed."
 msgstr "Norbere berrikuspenak ez dira onartzen."
 
-#: src/olympia/editors/views.py:609
+#: src/olympia/editors/views.py:613
 msgid "Review successfully processed."
 msgstr "Berrikuspena arrakastaz prozesatu da."
 
-#: src/olympia/editors/views.py:807
+#: src/olympia/editors/views.py:812
 msgid "was approved"
 msgstr ""
 
 # 80%
 # 100%
-#: src/olympia/editors/views.py:808
+#: src/olympia/editors/views.py:813
 #, fuzzy
 msgid "given preliminary review"
 msgstr "Ordezkatu aurrebista"
 
-#: src/olympia/editors/views.py:809
+#: src/olympia/editors/views.py:814
 msgid "rejected"
 msgstr ""
 
-#: src/olympia/editors/views.py:810
+#: src/olympia/editors/views.py:815
 msgctxt "editors_review_history_nominated_adminreview"
 msgid "escalated"
 msgstr ""
 
 # 79%
 # 100%
-#: src/olympia/editors/views.py:812
+#: src/olympia/editors/views.py:817
 #, fuzzy
 msgid "needs more information"
 msgstr "Eskatu informazio gehiago"
 
-#: src/olympia/editors/views.py:813
+#: src/olympia/editors/views.py:818
 msgid "needs super review"
 msgstr ""
 
-#: src/olympia/editors/views.py:814
+#: src/olympia/editors/views.py:819
 msgid "commented"
 msgstr ""
 
@@ -7815,33 +7681,33 @@ msgstr ""
 msgid "Unlisted Queues"
 msgstr ""
 
-#: src/olympia/editors/templates/editors/base.html:72 src/olympia/editors/templates/editors/performance.html:6
+#: src/olympia/editors/templates/editors/base.html:74 src/olympia/editors/templates/editors/performance.html:6
 msgid "Performance"
 msgstr "Errendimendua"
 
-#: src/olympia/editors/templates/editors/base.html:75 src/olympia/editors/templates/editors/themes/base.html:19 src/olympia/editors/templates/editors/themes/base.html:38
+#: src/olympia/editors/templates/editors/base.html:77 src/olympia/editors/templates/editors/themes/base.html:19 src/olympia/editors/templates/editors/themes/base.html:38
 #, fuzzy
 msgid "Logs"
 msgstr "Hasi saioa"
 
-#: src/olympia/editors/templates/editors/base.html:78 src/olympia/editors/templates/editors/reviewlog.html:4 src/olympia/editors/templates/editors/reviewlog.html:27
+#: src/olympia/editors/templates/editors/base.html:80 src/olympia/editors/templates/editors/reviewlog.html:4 src/olympia/editors/templates/editors/reviewlog.html:27
 msgid "Add-on Review Log"
 msgstr ""
 
 # %1 is the review count
 # 80%
 # 100%
-#: src/olympia/editors/templates/editors/base.html:80 src/olympia/editors/templates/editors/eventlog.html:4 src/olympia/editors/templates/editors/eventlog.html:8
+#: src/olympia/editors/templates/editors/base.html:82 src/olympia/editors/templates/editors/eventlog.html:4 src/olympia/editors/templates/editors/eventlog.html:8
 #: src/olympia/editors/templates/editors/eventlog_detail.html:4
 #, fuzzy
 msgid "Moderated Review Log"
 msgstr "Moderatutako berrikuspenak (%s)"
 
-#: src/olympia/editors/templates/editors/base.html:82 src/olympia/editors/templates/editors/beta_signed_log.html:4 src/olympia/editors/templates/editors/beta_signed_log.html:8
+#: src/olympia/editors/templates/editors/base.html:84 src/olympia/editors/templates/editors/beta_signed_log.html:4 src/olympia/editors/templates/editors/beta_signed_log.html:8
 msgid "Signed Beta Files Log"
 msgstr ""
 
-#: src/olympia/editors/templates/editors/base.html:87 src/olympia/editors/templates/editors/includes/daily-message.html:4
+#: src/olympia/editors/templates/editors/base.html:89 src/olympia/editors/templates/editors/includes/daily-message.html:4
 msgid "Announcement"
 msgstr ""
 
@@ -8076,47 +7942,47 @@ msgstr "Bilaketa aurreratua"
 msgid "clear search"
 msgstr ""
 
-#: src/olympia/editors/templates/editors/queue.html:72 src/olympia/editors/templates/editors/queue.html:122
+#: src/olympia/editors/templates/editors/queue.html:78 src/olympia/editors/templates/editors/queue.html:128
 msgid "Process Reviews"
 msgstr "Prozesatu berrikuspenak"
 
-#: src/olympia/editors/templates/editors/queue.html:80
+#: src/olympia/editors/templates/editors/queue.html:86
 #, fuzzy
 msgid "Moderation actions:"
 msgstr "Bildumaren puntuazioak"
 
-#: src/olympia/editors/templates/editors/queue.html:90
+#: src/olympia/editors/templates/editors/queue.html:96
 #, python-format
 msgid "by %(user)s on %(date)s %(stars)s (%(locale)s)"
 msgstr ""
 
-#: src/olympia/editors/templates/editors/queue.html:106
+#: src/olympia/editors/templates/editors/queue.html:112
 #, python-format
 msgid "<strong>%(reason)s</strong> <span class=\"light\">Flagged by %(user)s on %(date)s</span>"
 msgstr ""
 
-#: src/olympia/editors/templates/editors/queue.html:119
-msgid "All reviews have been moderated.  Good work!"
+#: src/olympia/editors/templates/editors/queue.html:125
+msgid "All reviews have been moderated. Good work!"
 msgstr ""
 
-#: src/olympia/editors/templates/editors/queue.html:161
+#: src/olympia/editors/templates/editors/queue.html:167
 msgid "Version Notes / Notes for Reviewer"
 msgstr ""
 
 # %1 is the queue mode
-#: src/olympia/editors/templates/editors/queue.html:169
+#: src/olympia/editors/templates/editors/queue.html:175
 msgid "There are currently no add-ons of this type to review."
 msgstr "Ez dago mota horretako gehigarririk berrikusteko."
 
-#: src/olympia/editors/templates/editors/queue.html:181 src/olympia/editors/templates/editors/themes/queue_list.html:85
+#: src/olympia/editors/templates/editors/queue.html:187 src/olympia/editors/templates/editors/themes/queue_list.html:85
 msgid "Helpful Links:"
 msgstr "Lotura lagungarriak:"
 
-#: src/olympia/editors/templates/editors/queue.html:182
+#: src/olympia/editors/templates/editors/queue.html:188
 msgid "Add-on Policy"
 msgstr "Gehigarriaren politika"
 
-#: src/olympia/editors/templates/editors/queue.html:184
+#: src/olympia/editors/templates/editors/queue.html:190
 msgid "Editors' Guide"
 msgstr "Editorearen gida"
 
@@ -8180,10 +8046,7 @@ msgid "<strong>Warning!</strong> Another user was viewing this page before you."
 msgstr ""
 
 #: src/olympia/editors/templates/editors/review.html:237
-msgid ""
-"The whiteboard is the place to exchange information relevant to\n"
-"               this addon (whatever the version), between the developer and the\n"
-"               editor. This is visible and editable by both."
+msgid "The whiteboard is the place to exchange information relevant to this addon (whatever the version), between the developer and the editor. This is visible and editable by both."
 msgstr ""
 
 #: src/olympia/editors/templates/editors/review.html:241
@@ -8457,7 +8320,7 @@ msgstr ""
 msgid "Describe your reason for flagging"
 msgstr ""
 
-#: src/olympia/files/forms.py:88
+#: src/olympia/files/forms.py:90
 msgid "Cannot diff a version against itself"
 msgstr ""
 
@@ -8492,51 +8355,51 @@ msgstr ""
 msgid "There was an error accessing file %s."
 msgstr ""
 
-#: src/olympia/files/utils.py:343
+#: src/olympia/files/utils.py:340
 msgid "Could not parse uploaded file."
 msgstr ""
 
-#: src/olympia/files/utils.py:380
+#: src/olympia/files/utils.py:377
 msgid "Invalid file name in archive: {0}"
 msgstr ""
 
-#: src/olympia/files/utils.py:388
+#: src/olympia/files/utils.py:385
 msgid "File exceeding size limit in archive: {0}"
 msgstr ""
 
-#: src/olympia/files/utils.py:439
+#: src/olympia/files/utils.py:436
 msgid "Invalid archive."
 msgstr "Artxibo baliogabea."
 
-#: src/olympia/files/utils.py:529 src/olympia/files/utils.py:532
+#: src/olympia/files/utils.py:526 src/olympia/files/utils.py:529
 msgid "Could not parse the manifest file."
 msgstr ""
 
-#: src/olympia/files/utils.py:551
+#: src/olympia/files/utils.py:548
 msgid "Could not find an add-on ID."
 msgstr ""
 
-#: src/olympia/files/utils.py:554
+#: src/olympia/files/utils.py:551
 msgid "Add-on ID must be 64 characters or less."
 msgstr ""
 
-#: src/olympia/files/utils.py:556
+#: src/olympia/files/utils.py:553
 msgid "Add-on ID doesn't match add-on."
 msgstr ""
 
-#: src/olympia/files/utils.py:564
+#: src/olympia/files/utils.py:561
 msgid "Duplicate add-on ID found."
 msgstr ""
 
-#: src/olympia/files/utils.py:567
+#: src/olympia/files/utils.py:564
 msgid "Version numbers should have fewer than 32 characters."
 msgstr ""
 
-#: src/olympia/files/utils.py:570
+#: src/olympia/files/utils.py:567
 msgid "Version numbers should only contain letters, numbers, and these punctuation characters: +*.-_."
 msgstr ""
 
-#: src/olympia/files/utils.py:587
+#: src/olympia/files/utils.py:584
 msgid "<em:type> doesn't match add-on"
 msgstr "<em:type> ez dator gehigarriarekin bat"
 
@@ -8642,6 +8505,10 @@ msgstr ""
 #: src/olympia/files/templates/files/viewer.html:134
 msgid "Fetching file."
 msgstr ""
+
+#: src/olympia/legacy_api/views.py:255
+msgid "Not implemented yet."
+msgstr "Oraindik inplementatu gabe."
 
 #: src/olympia/lib/constants.py:6
 msgid "United Arab Emirates Dirham"
@@ -9299,10 +9166,6 @@ msgstr ""
 msgid "Zimbabwe Dollar"
 msgstr ""
 
-#: src/olympia/lib/video/ffmpeg.py:112 src/olympia/lib/video/totem.py:81
-msgid "Videos must be in WebM."
-msgstr ""
-
 #: src/olympia/pages/templates/pages/about.lhtml:3 src/olympia/pages/templates/pages/about.lhtml:10
 msgid "About Mozilla Add-ons"
 msgstr ""
@@ -9314,7 +9177,7 @@ msgstr ""
 #: src/olympia/pages/templates/pages/about.lhtml:13
 msgid ""
 "addons.mozilla.org, commonly known as \"AMO\", is Mozilla's official site for add-ons to Mozilla software, such as Firefox, Thunderbird, and SeaMonkey. Add-ons let you add new features and change "
-"the way your browser or application works.  Take a look around and explore the thousands of ways to customize the way you do things online."
+"the way your browser or application works. Take a look around and explore the thousands of ways to customize the way you do things online."
 msgstr ""
 
 #: src/olympia/pages/templates/pages/about.lhtml:19
@@ -9659,7 +9522,7 @@ msgstr ""
 msgid ""
 "Yes. It's possible, but some of the functionality provided by these libraries are available through XPCOM, XUL, and JavaScript. In addition, authors should take care if libraries modify primitive "
 "object prototypes (String.prototype, Date.prototype, etc.) and/or define global functions (eg. the $ function). These are prone to cause conflict with other add-ons, in particular if different add-"
-"ons use different versions of libraries and so on. Developers need to be very, very careful with using them.  Mozilla does not offer documentation on using them to build add-ons."
+"ons use different versions of libraries and so on. Developers need to be very, very careful with using them. Mozilla does not offer documentation on using them to build add-ons."
 msgstr ""
 
 #: src/olympia/pages/templates/pages/dev_faq.html:165
@@ -9773,8 +9636,8 @@ msgstr ""
 #, python-format
 msgid ""
 "Yes. Many developers choose to host their own add-ons. Choosing to host your add-on on <a href=\"%(amo_url)s\">Mozilla's add-on site</a>, though, allows for much greater exposure to your add-on due "
-"to the large volume of visitors to the site.  <a href=\"%(md_url)s\">mozdev.org</a> offers free project hosting for Mozilla applications and extensions providing developers with tools to help "
-"manage source code, version control, bug tracking and documentation."
+"to the large volume of visitors to the site. <a href=\"%(md_url)s\">mozdev.org</a> offers free project hosting for Mozilla applications and extensions providing developers with tools to help manage "
+"source code, version control, bug tracking and documentation."
 msgstr ""
 
 #: src/olympia/pages/templates/pages/dev_faq.html:277
@@ -9822,7 +9685,7 @@ msgstr ""
 #: src/olympia/pages/templates/pages/dev_faq.html:314
 #, python-format
 msgid ""
-"Yes. Mozilla's <a href=\"%(p_url)s\">Add-on Policy</a> describes what is an acceptable submission. This policy is subject to change without notice.  In addition, the AMO editorial team uses the <a "
+"Yes. Mozilla's <a href=\"%(p_url)s\">Add-on Policy</a> describes what is an acceptable submission. This policy is subject to change without notice. In addition, the AMO editorial team uses the <a "
 "href=\"%(g_url)s\">Editors Reviewing Guide</a> to ensure that your add-on meets specific guidelines for functionality and security."
 msgstr ""
 
@@ -9939,7 +9802,7 @@ msgstr ""
 #: src/olympia/pages/templates/pages/dev_faq.html:434
 #, python-format
 msgid ""
-"This is why it's very important to read the <a href=\"%(g_url)s\">Editors Reviewing Guide</a> to ensure that your add-on is setup as expected.  It's also a good idea to read the blog post, <a href="
+"This is why it's very important to read the <a href=\"%(g_url)s\">Editors Reviewing Guide</a> to ensure that your add-on is setup as expected. It's also a good idea to read the blog post, <a href="
 "\"%(blog_url)s\">Successfully Getting your Add-on Reviewed</a> which provides excellent insight into ensuring a smooth review of your add-on."
 msgstr ""
 
@@ -10049,7 +9912,7 @@ msgstr ""
 
 #: src/olympia/pages/templates/pages/dev_faq.html:572
 msgid ""
-"Free Software Foundation provides short summaries of the key open source licenses, including whether the license qualifies as a free software license or a copyleft license.  Also includes a "
+"Free Software Foundation provides short summaries of the key open source licenses, including whether the license qualifies as a free software license or a copyleft license. Also includes a "
 "discussion of what constitutes a free software license or a copyleft license (e.g., a Copyleft license is a general method for making a program or other work free, and requiring all modified and "
 "extended versions of the program to be free as well.)"
 msgstr ""
@@ -10227,19 +10090,13 @@ msgid "Add-on Gallery"
 msgstr ""
 
 #: src/olympia/pages/templates/pages/faq.html:171
-msgid ""
-"How do I choose between add-ons that seem to do the same\n"
-"    thing?"
+msgid "How do I choose between add-ons that seem to do the same thing?"
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:173
+#: src/olympia/pages/templates/pages/faq.html:172
 msgid ""
-"There are often several add-ons that have similar features. To\n"
-"    figure out which is right for you, read the entire description of the\n"
-"    add-on and view its screenshots. If there are still several in the running,\n"
-"    read through the add-on's ratings, user reviews, and statistics to see\n"
-"    which is most liked by other users. Remember that you can also just try\n"
-"    out both and see which you like better."
+"There are often several add-ons that have similar features. To figure out which is right for you, read the entire description of the add-on and view its screenshots. If there are still several in "
+"the running, read through the add-on's ratings, user reviews, and statistics to see which is most liked by other users. Remember that you can also just try out both and see which you like better."
 msgstr ""
 
 #: src/olympia/pages/templates/pages/faq.html:180
@@ -10280,80 +10137,67 @@ msgid "How much do add-ons cost to purchase?"
 msgstr ""
 
 #: src/olympia/pages/templates/pages/faq.html:207
-msgid ""
-"Add-ons hosted in our gallery are free unless clearly marked\n"
-"    otherwise."
+msgid "Add-ons hosted in our gallery are free unless clearly marked otherwise."
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:210
+#: src/olympia/pages/templates/pages/faq.html:209
 msgid "What does it mean when an add-on asks for contributions?"
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:211
+#: src/olympia/pages/templates/pages/faq.html:210
 msgid ""
-"Some add-on authors request users who enjoy an add-on to\n"
-"        contribute to its development by making a monetary contribution. These\n"
-"        contributions go directly to the developer unless a third party is\n"
-"        indicated, such as the non-profit Mozilla Foundation."
+"Some add-on authors request users who enjoy an add-on to contribute to its development by making a monetary contribution. These contributions go directly to the developer unless a third party is "
+"indicated, such as the non-profit Mozilla Foundation."
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:216
+#: src/olympia/pages/templates/pages/faq.html:215
 msgid "What are beta add-ons?"
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:218
+#: src/olympia/pages/templates/pages/faq.html:217
 msgid ""
-"Beta add-ons are unreviewed versions which represent the\n"
-"        latest work of an add-on author. While different authors have different\n"
-"        standards for beta code quality, you should assume that these add-ons\n"
-"        are less stable than the general add-on releases."
+"Beta add-ons are unreviewed versions which represent the latest work of an add-on author. While different authors have different standards for beta code quality, you should assume that these add-"
+"ons are less stable than the general add-on releases."
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:222
+#: src/olympia/pages/templates/pages/faq.html:221
 msgid ""
 "Please note that when you install an add-on from the \"Beta Version\" section of an add-on's listing, you will continue to receive updates for that add-on as they become available. Like the initial "
 "version you installed, all beta releases are unreviewed by Mozilla and may harm your computer."
 msgstr ""
 
+#: src/olympia/pages/templates/pages/faq.html:228
+msgid "What does it mean when an add-on is flagged as slow?"
+msgstr ""
+
 #: src/olympia/pages/templates/pages/faq.html:229
-msgid ""
-"What does it mean when an add-on is flagged as\n"
-"    slow?"
+msgid "Most add-ons load code and resources at the same time Firefox is starting up. In most cases the impact in start-up time is minimal, but some add-ons can cause a noticeable slowdown."
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:231
-msgid ""
-"Most add-ons load code and resources at the same time Firefox\n"
-"        is starting up. In most cases the impact in start-up time is minimal,\n"
-"        but some add-ons can cause a noticeable slowdown."
-msgstr ""
-
-#: src/olympia/pages/templates/pages/faq.html:236
+#: src/olympia/pages/templates/pages/faq.html:234
 msgid "How do I report an inappropriate or spam user review?"
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:237
+#: src/olympia/pages/templates/pages/faq.html:235
 msgid ""
-"To report a user review of an add-on, log in with your account\n"
-"    and visit the add-on's reviews page. Find the review you wish to report,\n"
-"    click \"Report this review\" and select a reason. Our editorial team will\n"
-"    investigate the review and take appropriate action."
+"To report a user review of an add-on, log in with your account and visit the add-on's reviews page. Find the review you wish to report, click \"Report this review\" and select a reason. Our "
+"editorial team will investigate the review and take appropriate action."
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:242
+#: src/olympia/pages/templates/pages/faq.html:240
 msgid "How do I report a bug or contact the Mozilla Add-ons team?"
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:243
+#: src/olympia/pages/templates/pages/faq.html:241
 #, python-format
 msgid "Please visit our <a href=\"%(contact_url)s\">Contact page</a>."
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:246
+#: src/olympia/pages/templates/pages/faq.html:244
 msgid "What is a Source Code License?"
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:247
+#: src/olympia/pages/templates/pages/faq.html:245
 #, python-format
 msgid ""
 "The source code used to create an add-on is an exclusive copyright of the add-on author, unless otherwise declared in a source code license. Many add-ons on this site have <a href=\"%(url)s\" lang="
@@ -10361,60 +10205,60 @@ msgid ""
 "the GPL or BSD licenses instead of making up their own."
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:256
+#: src/olympia/pages/templates/pages/faq.html:254
 #, python-format
 msgid "Firefox and other Mozilla software are <a href=\"%(url)s\">open source</a>."
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:264
+#: src/olympia/pages/templates/pages/faq.html:262
 msgid "Collections and Favorites"
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:267
+#: src/olympia/pages/templates/pages/faq.html:265
 msgid "What is a collection?"
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:268
+#: src/olympia/pages/templates/pages/faq.html:266
 msgid "Collections are groups of related add-ons created by users to share."
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:270
+#: src/olympia/pages/templates/pages/faq.html:268
 msgid "What is the My Favorites collection?"
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:271
+#: src/olympia/pages/templates/pages/faq.html:269
 msgid "Favorite add-ons are add-ons that you have bookmarked to easily get back to later. You can add an add-on to your favorites collection by clicking \"Add to favorites\" on its details page."
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:275 src/olympia/templates/menu_links.html:13 src/olympia/templates/impala/header_title.html:17
+#: src/olympia/pages/templates/pages/faq.html:273 src/olympia/templates/menu_links.html:13 src/olympia/templates/impala/header_title.html:17
 msgid "Mobile Add-ons"
 msgstr "Mugikorrerako gehigarriak"
 
-#: src/olympia/pages/templates/pages/faq.html:278
+#: src/olympia/pages/templates/pages/faq.html:276
 msgid "What are mobile add-ons?"
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:279
+#: src/olympia/pages/templates/pages/faq.html:277
 #, python-format
 msgid ""
 "Mobile add-ons work with <a href=\"%(mobile_url)s\">Firefox for Mobile</a> and add or modify functionality just like desktop add-ons. You can find add-ons that work with Firefox for Mobile in our "
 "<a href=\"%(gallery_url)s\">gallery</a>."
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:288
+#: src/olympia/pages/templates/pages/faq.html:286
 msgid "Developer Topics"
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:289
+#: src/olympia/pages/templates/pages/faq.html:287
 #, python-format
 msgid "Please see our <a href=\"%(faq_url)s\">Developer FAQ</a> and <a href=\"%(hub_url)s\">Developer Hub</a> for answers to add-on developer-related questions."
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:294
+#: src/olympia/pages/templates/pages/faq.html:292
 msgid "Still have questions?"
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:295
+#: src/olympia/pages/templates/pages/faq.html:293
 #, python-format
 msgid "For general Firefox support, visit our <a href=\"%(sumo_url)s\">support website</a>. For general add-on and website questions, visit our <a href=\"%(forum_url)s\">forum</a>."
 msgstr ""
@@ -10552,7 +10396,7 @@ msgstr ""
 
 #: src/olympia/pages/templates/pages/sunbird.html:29
 msgid ""
-"Development on the Sunbird project has halted and its final release was on March 30, 2010.  We've been proud to host Sunbird add-ons on this site but as the project is no longer maintained we have "
+"Development on the Sunbird project has halted and its final release was on March 30, 2010. We've been proud to host Sunbird add-ons on this site but as the project is no longer maintained we have "
 "disabled our support for the add-ons."
 msgstr ""
 
@@ -10632,7 +10476,7 @@ msgstr "Gehitu berrikuspena {0} gehigarriarentzat"
 #, python-format
 msgid ""
 "<h2>Keep these tips in mind:</h2> <ul> <li> Write like you're telling a friend about your experience with the add-on. Give specifics and helpful details, such as what features you liked and/or "
-"disliked, how easy to use it is, and any disadvantages it has.  Avoid generic language such as calling it \"Great\" or \"Bad\" unless you can give reasons why you believe this is so. </li> <li> "
+"disliked, how easy to use it is, and any disadvantages it has. Avoid generic language such as calling it \"Great\" or \"Bad\" unless you can give reasons why you believe this is so. </li> <li> "
 "Please do not post bug reports in reviews. We do not make your email address available to add-on developers and they may need to contact you to help resolve your issue. See the <a href=\"%(support)s"
 "\">support section</a> to find out where to get assistance for this add-on. </li> <li>Please keep reviews clean, avoid the use of improper language and do not post any personal information. </li> </"
 "ul> <p>Please read the <a href=\"%(guide)s\" target=\"_blank\">Review Guidelines</a> for more detail about user add-on reviews.</p>"
@@ -10885,16 +10729,16 @@ msgstr "{0}(e)rako gehigarriak"
 
 #. L10n: {0} is an application, such as Firefox. This means "any version of
 #. Firefox."
-#: src/olympia/search/views.py:554
+#: src/olympia/search/views.py:547
 msgid "Any {0}"
 msgstr ""
 
 #. L10n: "All Systems" means show everything regardless of platform.
-#: src/olympia/search/views.py:589
+#: src/olympia/search/views.py:582
 msgid "All Systems"
 msgstr ""
 
-#: src/olympia/search/views.py:600
+#: src/olympia/search/views.py:593
 msgid "All Tags"
 msgstr "Etiketa guztiak"
 
@@ -11069,31 +10913,31 @@ msgstr "Partekatu gehigarri hau"
 msgid "Share this Collection"
 msgstr "Partekatu bilduma hau"
 
-#: src/olympia/signing/views.py:30 src/olympia/templates/base.html:75 src/olympia/templates/impala/base.html:115
+#: src/olympia/signing/views.py:33 src/olympia/templates/base.html:71 src/olympia/templates/impala/base.html:112
 msgid "Some features are temporarily disabled while we perform website maintenance. We'll be back to full capacity shortly."
 msgstr ""
 
-#: src/olympia/signing/views.py:53
+#: src/olympia/signing/views.py:56
 msgid "Could not find add-on with id \"{}\"."
 msgstr ""
 
-#: src/olympia/signing/views.py:67
+#: src/olympia/signing/views.py:70
 msgid "You do not own this addon."
 msgstr ""
 
-#: src/olympia/signing/views.py:82
+#: src/olympia/signing/views.py:87
 msgid "Missing \"upload\" key in multipart file data."
 msgstr ""
 
-#: src/olympia/signing/views.py:96
+#: src/olympia/signing/views.py:101
 msgid "Version does not match the manifest file."
 msgstr ""
 
-#: src/olympia/signing/views.py:100
+#: src/olympia/signing/views.py:105
 msgid "Version already exists."
 msgstr ""
 
-#: src/olympia/signing/views.py:136
+#: src/olympia/signing/views.py:141
 msgid "No uploaded file for that addon and version."
 msgstr ""
 
@@ -11207,89 +11051,89 @@ msgstr ""
 msgid "Statistics Dashboard :: Add-ons for {0}"
 msgstr ""
 
-#: src/olympia/stats/templates/stats/stats.html:30
-msgid "Controls:"
-msgstr ""
-
-#: src/olympia/stats/templates/stats/stats.html:33
-msgid "reset zoom"
-msgstr ""
-
-#: src/olympia/stats/templates/stats/stats.html:40
-msgid "Group by:"
-msgstr ""
-
-#: src/olympia/stats/templates/stats/stats.html:42
-msgid "day"
-msgstr ""
-
-#: src/olympia/stats/templates/stats/stats.html:45
-msgid "week"
-msgstr ""
-
-#: src/olympia/stats/templates/stats/stats.html:48
-msgid "month"
-msgstr ""
-
-#: src/olympia/stats/templates/stats/stats.html:54
-msgid "For last:"
-msgstr ""
-
-#: src/olympia/stats/templates/stats/stats.html:57
-msgid "7 days"
-msgstr ""
-
-#: src/olympia/stats/templates/stats/stats.html:60
-msgid "30 days"
-msgstr ""
-
-#: src/olympia/stats/templates/stats/stats.html:63
-msgid "90 days"
-msgstr ""
-
-#: src/olympia/stats/templates/stats/stats.html:66
-msgid "365 days"
-msgstr ""
-
-#: src/olympia/stats/templates/stats/stats.html:69
-msgid "Custom..."
-msgstr ""
-
 #. {0} is an add-on name
-#: src/olympia/stats/templates/stats/stats.html:88 src/olympia/stats/templates/stats/stats.html:91
+#: src/olympia/stats/templates/stats/stats.html:44 src/olympia/stats/templates/stats/stats.html:47
 msgid "Statistics for {0}"
 msgstr "Honen estatistikak: {0}"
 
-#: src/olympia/stats/templates/stats/stats.html:94
+#: src/olympia/stats/templates/stats/stats.html:50
 msgid "Statistics Dashboard"
 msgstr ""
 
-#: src/olympia/stats/templates/stats/stats.html:104
+#: src/olympia/stats/templates/stats/stats.html:57
+msgid "Controls:"
+msgstr ""
+
+#: src/olympia/stats/templates/stats/stats.html:60
+msgid "reset zoom"
+msgstr ""
+
+#: src/olympia/stats/templates/stats/stats.html:67
+msgid "Group by:"
+msgstr ""
+
+#: src/olympia/stats/templates/stats/stats.html:69
+msgid "day"
+msgstr ""
+
+#: src/olympia/stats/templates/stats/stats.html:72
+msgid "week"
+msgstr ""
+
+#: src/olympia/stats/templates/stats/stats.html:75
+msgid "month"
+msgstr ""
+
+#: src/olympia/stats/templates/stats/stats.html:81
+msgid "For last:"
+msgstr ""
+
+#: src/olympia/stats/templates/stats/stats.html:84
+msgid "7 days"
+msgstr ""
+
+#: src/olympia/stats/templates/stats/stats.html:87
+msgid "30 days"
+msgstr ""
+
+#: src/olympia/stats/templates/stats/stats.html:90
+msgid "90 days"
+msgstr ""
+
+#: src/olympia/stats/templates/stats/stats.html:93
+msgid "365 days"
+msgstr ""
+
+#: src/olympia/stats/templates/stats/stats.html:96
+msgid "Custom..."
+msgstr ""
+
+#: src/olympia/stats/templates/stats/stats.html:106
 msgid "Statistics processing is currently disabled, so recent data is unavailable. The statistics are still being collected and this page will be updated soon with the missing data."
 msgstr ""
 
-#: src/olympia/stats/templates/stats/stats.html:110
+#: src/olympia/stats/templates/stats/stats.html:112
 msgid "Loading the latest data&hellip;"
 msgstr ""
 
-#: src/olympia/stats/templates/stats/stats.html:142 src/olympia/stats/templates/stats/reports/overview.html:25 src/olympia/stats/templates/stats/reports/overview.html:37
+#: src/olympia/stats/templates/stats/stats.html:144 src/olympia/stats/templates/stats/reports/overview.html:25 src/olympia/stats/templates/stats/reports/overview.html:37
 #: src/olympia/stats/templates/stats/reports/overview.html:49
 msgid "No data available."
 msgstr ""
 
-#: src/olympia/stats/templates/stats/stats.html:177
+#: src/olympia/stats/templates/stats/stats.html:179
 msgid "This dashboard is currently <b>public</b>."
 msgstr ""
 
-#: src/olympia/stats/templates/stats/stats.html:179
+#: src/olympia/stats/templates/stats/stats.html:181
 msgid "Contribution stats are currently <b>private</b>."
 msgstr ""
 
-#: src/olympia/stats/templates/stats/stats.html:182
+#: src/olympia/stats/templates/stats/stats.html:184
 msgid "This dashboard is currently <b>private</b>."
 msgstr ""
 
-#: src/olympia/stats/templates/stats/stats.html:185
+#: src/olympia/stats/templates/stats/stats.html:187
 msgid "Change settings."
 msgstr ""
 
@@ -11441,16 +11285,6 @@ msgstr ""
 msgid "Application versions by Date"
 msgstr ""
 
-# {0} is a number
-#: src/olympia/tags/templates/tags/top_cloud.html:4
-msgid "Top {0} Tags"
-msgstr "{0} etiketa erabilienak"
-
-#. {0} is the current application name
-#: src/olympia/tags/templates/tags/top_cloud.html:14
-msgid "{0} Top Tags"
-msgstr ""
-
 #: src/olympia/templates/amo_footer.html:6 src/olympia/templates/includes/lang_switcher.html:2
 msgid "Other languages"
 msgstr "Beste hizkuntzak"
@@ -11459,11 +11293,11 @@ msgstr "Beste hizkuntzak"
 msgid "Mozilla Add-ons"
 msgstr "Mozilla gehigarriak"
 
-#: src/olympia/templates/base.html:91 src/olympia/templates/impala/base.html:81
+#: src/olympia/templates/base.html:89 src/olympia/templates/impala/base.html:78
 msgid "Find add-ons for other applications"
 msgstr "Bilatu beste aplikazioetarako gehigarriak"
 
-#: src/olympia/templates/base.html:92 src/olympia/templates/impala/base.html:81
+#: src/olympia/templates/base.html:90 src/olympia/templates/impala/base.html:78
 msgid "Other Applications"
 msgstr "Beste aplikazioak"
 
@@ -11488,7 +11322,7 @@ msgid "View Mobile Site"
 msgstr "Ikusi mugikorretarako gunea"
 
 #: src/olympia/templates/copyright.html:7
-msgid "Site Status "
+msgid "Site Status"
 msgstr ""
 
 #: src/olympia/templates/footer.html:3
@@ -11590,35 +11424,35 @@ msgstr "Ongi etorri, {0}"
 msgid "<a href=\"%(reg)s\">Register</a> or <a href=\"%(login)s\">Log in</a>"
 msgstr "<a href=\"%(reg)s\">Eman izena</a> edo <a href=\"%(login)s\">hasi saioa</a>"
 
-#: src/olympia/templates/impala/base.html:126
+#: src/olympia/templates/impala/base.html:123
 #, python-format
 msgid "To try the thousands of add-ons available here, download <a href=\"%(url)s\">Mozilla Firefox</a>, a fast, free way to surf the Web!"
 msgstr ""
 
-#: src/olympia/templates/impala/base.html:138
+#: src/olympia/templates/impala/base.html:135
 #, python-format
 msgid "Add-ons is switching to Firefox Accounts for login. <a href=\"%(url)s\" class=\"fxa-login\">Sign in now to transfer your account.</a>"
 msgstr ""
 
 #. {0} is an application, such as Firefox.
-#: src/olympia/templates/impala/base.html:148
+#: src/olympia/templates/impala/base.html:145
 msgid "Welcome to {0} Add-ons."
 msgstr ""
 
-#: src/olympia/templates/impala/base.html:151
+#: src/olympia/templates/impala/base.html:148
 msgid "Choose from thousands of extra features and styles to make Firefox your own."
 msgstr ""
 
-#: src/olympia/templates/impala/base.html:156
+#: src/olympia/templates/impala/base.html:153
 #, python-format
 msgid "Add extra features and styles to make %(app)s your own."
 msgstr ""
 
-#: src/olympia/templates/impala/base.html:164
+#: src/olympia/templates/impala/base.html:161
 msgid "On the go?"
 msgstr ""
 
-#: src/olympia/templates/impala/base.html:166
+#: src/olympia/templates/impala/base.html:163
 msgid "Check out our <a class=\"mobile-link\" href=\"#\">Mobile Add-ons site</a>."
 msgstr ""
 
@@ -11843,19 +11677,19 @@ msgstr "Erabiltzailerik ez helbide elektroniko horrekin."
 
 #. L10n: {id} will be something like "13ad6a", just a random number
 #. to differentiate this user from other anonymous users.
-#: src/olympia/users/models.py:353
+#: src/olympia/users/models.py:362
 msgid "Anonymous user {id}"
 msgstr ""
 
-#: src/olympia/users/models.py:410
+#: src/olympia/users/models.py:419
 msgid "Your account has been restricted"
 msgstr ""
 
-#: src/olympia/users/models.py:480
+#: src/olympia/users/models.py:489
 msgid "Please confirm your email address"
 msgstr "Berretsi zure helbide elektronikoa"
 
-#: src/olympia/users/models.py:506
+#: src/olympia/users/models.py:515
 msgid "My Mobile Add-ons"
 msgstr "Mugikorrerako nire gehigarriak"
 
@@ -12133,7 +11967,7 @@ msgstr "Pasahitza"
 
 #: src/olympia/users/templates/users/edit.html:70
 #, python-format
-msgid "Change your password.  If you forgot your password, you can <a href=\"%(reset_url)s\">use the reset form</a>."
+msgid "Change your password. If you forgot your password, you can <a href=\"%(reset_url)s\">use the reset form</a>."
 msgstr ""
 
 #: src/olympia/users/templates/users/edit.html:76
@@ -12153,7 +11987,7 @@ msgid "Profile"
 msgstr ""
 
 #: src/olympia/users/templates/users/edit.html:100
-msgid "Give us a bit more information about yourself.  All these fields are optional, but they'll help other users get to know you better."
+msgid "Give us a bit more information about yourself. All these fields are optional, but they'll help other users get to know you better."
 msgstr ""
 
 #: src/olympia/users/templates/users/edit.html:124
@@ -12559,7 +12393,7 @@ msgstr ""
 
 #: src/olympia/users/templates/users/unsubscribe.html:30
 #, python-format
-msgid "Unfortunately, we weren't able to unsubscribe you.  The link you clicked is invalid. However, you can unsubscribe still unsubscribe on your <a href=\"%(edit_url)s\">edit profile page</a>."
+msgid "Unfortunately, we weren't able to unsubscribe you. The link you clicked is invalid. However, you can unsubscribe still unsubscribe on your <a href=\"%(edit_url)s\">edit profile page</a>."
 msgstr ""
 
 #: src/olympia/users/templates/users/vcard.html:2
@@ -12614,15 +12448,15 @@ msgstr "%s bertsioaren historia"
 msgid "Version History with Changelogs"
 msgstr "Bertsioaren historia aldaketen egunkariarekin"
 
-#: src/olympia/versions/models.py:314
+#: src/olympia/versions/models.py:313
 msgid "Add-on uses binary components."
 msgstr ""
 
-#: src/olympia/versions/models.py:317
+#: src/olympia/versions/models.py:316
 msgid "Add-on has opted into strict compatibility checking."
 msgstr ""
 
-#: src/olympia/versions/models.py:715
+#: src/olympia/versions/models.py:711
 msgid "{app} {min} and later"
 msgstr ""
 
@@ -12699,4 +12533,8 @@ msgstr ""
 
 #: src/olympia/zadmin/forms.py:105
 msgid "Log emails instead of sending"
+msgstr ""
+
+#: src/olympia/zadmin/forms.py:215
+msgid "Deleted versions can`t be changed."
 msgstr ""

--- a/locale/eu/LC_MESSAGES/djangojs.po
+++ b/locale/eu/LC_MESSAGES/djangojs.po
@@ -3,1251 +3,1236 @@ msgid ""
 msgstr ""
 "Project-Id-Version: AMO-JS 0.1\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2016-02-24 21:23+0000\n"
+"POT-Creation-Date: 2016-04-18 15:47+0000\n"
 "PO-Revision-Date: 2016-04-01 10:09+0000\n"
 "Last-Translator: galleteroion1 <galleteroion1@gmail.com>\n"
 "Language-Team: librezale@librezale.org\n"
-"Language: eu\n"
+"Language: \n"
 "MIME-Version: 1.0\n"
-"Content-Type: text/plain; charset=utf-8\n"
+"Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 "Generated-By: Babel 2.2.0\n"
-"X-Generator: Pontoon\n"
 
-#: static/js/common/ratingwidget.js:31
-msgid "{0} star"
-msgid_plural "{0} stars"
-msgstr[0] ""
-msgstr[1] ""
-
-#: static/js/common/upload-addon.js:41 static/js/common/upload-image.js:128
-msgid "There was a problem contacting the server."
-msgstr "Errorea gertatu da zerbitzariarekin konektatzean."
-
-#: static/js/common/upload-addon.js:69
-msgid "Select a file..."
-msgstr "Hautatu fitxategia..."
-
-#: static/js/common/upload-addon.js:70
-msgid "Your add-on should end with .xpi, .jar or .xml"
-msgstr "Zure gehigarriak .xpi, .jar edo .xml luzapenarekin amaitu behar du"
-
-#. L10n: {0} is the percent of the file that has been uploaded.
-#: static/js/common/upload-addon.js:104
-#, fuzzy, python-format
-msgid "{0}% complete"
-msgstr "%{0} osatuta"
-
-#. L10n: "{bytes uploaded} of {total filesize}".
-#: static/js/common/upload-addon.js:107
-msgid "{0} of {1}"
-msgstr "{1}/{0}"
-
-#: static/js/common/upload-addon.js:140
-msgid "Cancel"
-msgstr "Utzi"
-
-#: static/js/common/upload-addon.js:162
-msgid "Uploading {0}"
-msgstr "{0} igotzen"
-
-#: static/js/common/upload-addon.js:189
-msgid "Error with {0}"
-msgstr "Errorea {0}(r)ekin"
-
-#: static/js/common/upload-addon.js:194
-msgid "Your add-on failed validation with {0} error."
-msgid_plural "Your add-on failed validation with {0} errors."
-msgstr[0] "Zure gehigarriak balidazioa huts egin du errore batekin."
-msgstr[1] "Zure gehigarriak balidazioa huts egin du {0} errorerekin."
-
-#: static/js/common/upload-addon.js:208
-msgid "&hellip;and {0} more"
-msgid_plural "&hellip;and {0} more"
-msgstr[0] "&hellip;eta bat gehiago"
-msgstr[1] "&hellip;eta {0} gehiago"
-
-#: static/js/common/upload-addon.js:222 static/js/common/upload-addon.js:512
-msgid "See full validation report"
-msgstr "Ikusi balidazioaren txosten osoa"
-
-#: static/js/common/upload-addon.js:234
-msgid "Validating {0}"
-msgstr "{0} balidatzen"
-
-#. L10n: first argument is an HTTP status code
-#: static/js/common/upload-addon.js:273
-msgid "Received an empty response from the server; status: {0}"
-msgstr "Erantzun huts jaso da zerbitzaritik; egoera: {0}"
-
-#: static/js/common/upload-addon.js:373
-msgid "Unexpected server error while validating."
-msgstr "Espero gabeko zerbitzari-errorea balidatzean."
-
-#: static/js/common/upload-addon.js:412
-msgid "Finished validating {0}"
-msgstr "{0}(r)en balidazioa amaitu da"
-
-#: static/js/common/upload-addon.js:418
-msgid "Your add-on validation timed out, it will be manually reviewed."
-msgstr ""
-
-#: static/js/common/upload-addon.js:421
-msgid "Your add-on was validated with no errors and {0} warning."
-msgid_plural "Your add-on was validated with no errors and {0} warnings."
-msgstr[0] ""
-msgstr[1] ""
-
-#: static/js/common/upload-addon.js:426
-msgid "Your add-on was validated with no errors and {0} message."
-msgid_plural "Your add-on was validated with no errors and {0} messages."
-msgstr[0] ""
-msgstr[1] ""
-
-#: static/js/common/upload-addon.js:431
-msgid "Your add-on was validated with no errors or warnings."
-msgstr ""
-
-#: static/js/common/upload-addon.js:446
-msgid "Your submission will be automatically signed."
-msgstr ""
-
-#: static/js/common/upload-addon.js:465
-msgid "Include detailed version notes (this can be done in the next step)."
-msgstr ""
-
-#: static/js/common/upload-addon.js:466
-msgid ""
-"If your add-on requires an account to a website in order to be fully tested,"
-" include a test username and password in the Notes to Reviewer (this can be "
-"done in the next step)."
-msgstr ""
-
-#: static/js/common/upload-addon.js:467
-msgid ""
-"If your add-on is intended for a limited audience you should choose "
-"Preliminary Review instead of Full Review."
-msgstr ""
-
-#: static/js/common/upload-addon.js:480
-msgid "Add-on submission checklist"
-msgstr ""
-
-#: static/js/common/upload-addon.js:481
-msgid ""
-"Please verify the following points before finalizing your submission. This "
-"will minimize delays or misunderstanding during the review process:"
-msgstr ""
-
-#: static/js/common/upload-addon.js:483
-msgid ""
-"Compiled binaries, as well as minified or obfuscated scripts (excluding "
-"known libraries) need to have their sources submitted separately for review."
-" Make sure that you use the source code upload field to avoid having your "
-"submission rejected."
-msgstr ""
-
-#: static/js/common/upload-addon.js:501
-msgid "The validation process found these issues that can lead to rejections:"
-msgstr ""
-
-#: static/js/common/upload-addon.js:518
-msgid ""
-"If you are unfamiliar with the add-ons review process, you can read about it"
-" here."
-msgstr ""
-
-#: static/js/common/upload-addon.js:555
-msgid "Sorry, no supported platform has been found."
-msgstr "Sentitzen dugu, ez da onarturiko plataformarik aurkitu."
-
-#: static/js/common/upload-base.js:57
-msgid "The filetype you uploaded isn't recognized."
-msgstr "Igo duzun fitxategi mota ez da ezagutzen."
-
-#: static/js/common/upload-base.js:79
-msgid "You cancelled the upload."
-msgstr "Igotzea bertan behera utzi duzu."
-
-#: static/js/common/upload-image.js:97 static/js/impala/users.js:51
-msgid "Images must be either PNG or JPG."
-msgstr ""
-
-#: static/js/common/upload-image.js:101
-msgid "Videos must be in WebM."
-msgstr "Bideoek WebM formatua izan behar dute."
-
-#: static/js/impala/collections.js:10 static/js/zamboni/collections.js:595
-msgid "Follow this Collection"
-msgstr "Jarraitu bilduma hau"
-
-#: static/js/impala/collections.js:19
-msgid "Stop Following"
-msgstr "Utzi jarraitzeari"
-
-#: static/js/impala/collections.js:20
-msgid "Following"
-msgstr "Jarraitzen"
-
-#. L10n: {0} is an app name.
-#: static/js/impala/listing.js:11 static/js/zamboni/themes.js:13
-msgid "This theme is incompatible with your version of {0}"
-msgstr "Gai hau bateraezina da {0}(r)en zure bertsioarekin"
-
-#: static/js/impala/persona_creation.js:60
-msgid "All Rights Reserved"
-msgstr "Eskubide guztiak erreserbatuta"
-
-#: static/js/impala/persona_creation.js:64
-msgid "Creative Commons Attribution 3.0"
-msgstr ""
-
-#: static/js/impala/persona_creation.js:69
-msgid "Creative Commons Attribution-NonCommercial 3.0"
-msgstr ""
-
-#: static/js/impala/persona_creation.js:74
-msgid "Creative Commons Attribution-NonCommercial-NoDerivs 3.0"
-msgstr ""
-
-#: static/js/impala/persona_creation.js:79
-msgid "Creative Commons Attribution-NonCommercial-Share Alike 3.0"
-msgstr ""
-
-#: static/js/impala/persona_creation.js:84
-msgid "Creative Commons Attribution-NoDerivs 3.0"
-msgstr ""
-
-#: static/js/impala/persona_creation.js:89
-msgid "Creative Commons Attribution-ShareAlike 3.0"
-msgstr ""
-
-#: static/js/impala/persona_creation.js:292
-msgid "Your Theme's Name"
-msgstr "Zure gaiaren izena"
-
-#: static/js/impala/reviews.js:23 static/js/zamboni/reviews.js:18
-msgid "Flagged for review"
-msgstr "Berrikusteko markatuta"
-
-#: static/js/impala/reviews.js:40 static/js/zamboni/reviews.js:34
-msgid "Your input is required"
-msgstr "Zure sarrera beharrezkoa da"
-
-#: static/js/impala/reviews.js:152 static/js/zamboni/reviews.js:103
-msgid "Marked for deletion"
-msgstr "Ezabatzeko markatuta"
-
-#: static/js/impala/search.js:114
-msgid "Updating results&hellip;"
-msgstr "Emaitzak eguneratzen&hellip;"
-
-#: static/js/impala/site_suggestions.js:46
-msgid "Category"
-msgstr "Kategoria"
-
-#: static/js/impala/suggestions.js:39
-msgid "Search themes for <b>{0}</b>"
-msgstr ""
-
-#: static/js/impala/suggestions.js:41
-msgid "Search apps for <b>{0}</b>"
-msgstr ""
-
-#: static/js/impala/suggestions.js:43
-msgid "Search add-ons for <b>{0}</b>"
-msgstr ""
-
-#: static/js/impala/users.js:33
-msgid "use original"
-msgstr ""
-
-#: static/js/impala/stats/chart.js:267
-msgid "Week of {0}"
-msgstr ""
-
-#: static/js/impala/stats/chart.js:269
-msgid " downloads"
-msgstr ""
-
-#: static/js/impala/stats/chart.js:270
-msgid "{0} users"
-msgstr ""
-
-#: static/js/impala/stats/chart.js:271
-msgid "{0} add-ons"
-msgstr ""
-
-#: static/js/impala/stats/chart.js:272
-msgid "{0} collections"
-msgstr ""
-
-#: static/js/impala/stats/chart.js:273
-msgid "{0} reviews"
-msgstr ""
-
-#: static/js/impala/stats/chart.js:275
-msgid "{0} sales"
-msgstr ""
-
-#: static/js/impala/stats/chart.js:276
-msgid "{0} refunds"
-msgstr ""
-
-#: static/js/impala/stats/chart.js:277
-msgid "{0} installs"
-msgstr ""
-
-#: static/js/impala/stats/chart.js:369 static/js/impala/stats/csv_keys.js:3
-#: static/js/impala/stats/csv_keys.js:109
-msgid "Downloads"
-msgstr ""
-
-#: static/js/impala/stats/chart.js:379 static/js/impala/stats/csv_keys.js:6
-#: static/js/impala/stats/csv_keys.js:110
-msgid "Daily Users"
-msgstr ""
-
-#: static/js/impala/stats/chart.js:410
-msgid "Amount, in USD"
-msgstr ""
-
-#: static/js/impala/stats/chart.js:421 static/js/impala/stats/csv_keys.js:104
-msgid "Number of Contributions"
-msgstr ""
-
-#: static/js/impala/stats/chart.js:447
-msgid "More Info..."
-msgstr "Informazio gehiago..."
-
-#. L10n: {0} is an ISO-formatted date.
-#: static/js/impala/stats/chart.js:451
-msgid "Details for {0}"
-msgstr ""
-
-#: static/js/impala/stats/csv_keys.js:9
-msgid "Collections Created"
-msgstr ""
-
-#: static/js/impala/stats/csv_keys.js:12
-msgid "Add-ons in Use"
-msgstr ""
-
-#: static/js/impala/stats/csv_keys.js:15
-msgid "Add-ons Created"
-msgstr ""
-
-#: static/js/impala/stats/csv_keys.js:18
-msgid "Add-ons Downloaded"
-msgstr ""
-
-#: static/js/impala/stats/csv_keys.js:21
-msgid "Add-ons Updated"
-msgstr ""
-
-#: static/js/impala/stats/csv_keys.js:24
-msgid "Reviews Written"
-msgstr ""
-
-#: static/js/impala/stats/csv_keys.js:27
-msgid "User Signups"
-msgstr ""
-
-#: static/js/impala/stats/csv_keys.js:30
-msgid "Subscribers"
-msgstr ""
-
-#: static/js/impala/stats/csv_keys.js:33
-msgid "Ratings"
-msgstr ""
-
-#: static/js/impala/stats/csv_keys.js:36
-#: static/js/impala/stats/csv_keys.js:114
-msgid "Sales"
-msgstr ""
-
-#: static/js/impala/stats/csv_keys.js:39
-#: static/js/impala/stats/csv_keys.js:113
-msgid "Installs"
-msgstr ""
-
-#: static/js/impala/stats/csv_keys.js:42
-msgid "Unknown"
-msgstr ""
-
-#: static/js/impala/stats/csv_keys.js:43
-msgid "Add-ons Manager"
-msgstr ""
-
-#: static/js/impala/stats/csv_keys.js:44
-msgid "Add-ons Manager Promo"
-msgstr ""
-
-#: static/js/impala/stats/csv_keys.js:45
-msgid "Add-ons Manager Featured"
-msgstr ""
-
-#: static/js/impala/stats/csv_keys.js:46
-msgid "Add-ons Manager Learn More"
-msgstr ""
-
-#: static/js/impala/stats/csv_keys.js:47
-msgid "Search Suggestions"
-msgstr ""
-
-#: static/js/impala/stats/csv_keys.js:48
-msgid "Search Results"
-msgstr ""
-
-#: static/js/impala/stats/csv_keys.js:49 static/js/impala/stats/csv_keys.js:50
-#: static/js/impala/stats/csv_keys.js:51
-msgid "Homepage Promo"
-msgstr ""
-
-#: static/js/impala/stats/csv_keys.js:52 static/js/impala/stats/csv_keys.js:53
-msgid "Homepage Featured"
-msgstr ""
-
-#: static/js/impala/stats/csv_keys.js:54 static/js/impala/stats/csv_keys.js:55
-msgid "Homepage Up and Coming"
-msgstr ""
-
-#: static/js/impala/stats/csv_keys.js:56
-msgid "Homepage Most Popular"
-msgstr ""
-
-#: static/js/impala/stats/csv_keys.js:57 static/js/impala/stats/csv_keys.js:59
-msgid "Detail Page"
-msgstr ""
-
-#: static/js/impala/stats/csv_keys.js:58 static/js/impala/stats/csv_keys.js:60
-msgid "Detail Page (bottom)"
-msgstr ""
-
-#: static/js/impala/stats/csv_keys.js:61
-msgid "Detail Page (Development Channel)"
-msgstr ""
-
-#: static/js/impala/stats/csv_keys.js:62 static/js/impala/stats/csv_keys.js:63
-#: static/js/impala/stats/csv_keys.js:64
-msgid "Often Used With"
-msgstr ""
-
-#: static/js/impala/stats/csv_keys.js:65 static/js/impala/stats/csv_keys.js:66
-msgid "Others By Author"
-msgstr ""
-
-#: static/js/impala/stats/csv_keys.js:67 static/js/impala/stats/csv_keys.js:68
-msgid "Dependencies"
-msgstr ""
-
-#: static/js/impala/stats/csv_keys.js:69 static/js/impala/stats/csv_keys.js:70
-msgid "Upsell"
-msgstr ""
-
-#: static/js/impala/stats/csv_keys.js:71
-msgid "Meet the Developer"
-msgstr ""
-
-#: static/js/impala/stats/csv_keys.js:72
-msgid "User Profile"
-msgstr ""
-
-#: static/js/impala/stats/csv_keys.js:73
-msgid "Version History"
-msgstr ""
-
-#: static/js/impala/stats/csv_keys.js:75
-msgid "Sharing"
-msgstr ""
-
-#: static/js/impala/stats/csv_keys.js:76
-msgid "Category Pages"
-msgstr ""
-
-#: static/js/impala/stats/csv_keys.js:77
-msgid "Collections"
-msgstr ""
-
-#: static/js/impala/stats/csv_keys.js:78 static/js/impala/stats/csv_keys.js:79
-msgid "Category Landing Featured Carousel"
-msgstr ""
-
-#: static/js/impala/stats/csv_keys.js:80 static/js/impala/stats/csv_keys.js:81
-msgid "Category Landing Top Rated"
-msgstr ""
-
-#: static/js/impala/stats/csv_keys.js:82 static/js/impala/stats/csv_keys.js:83
-msgid "Category Landing Most Popular"
-msgstr ""
-
-#: static/js/impala/stats/csv_keys.js:84 static/js/impala/stats/csv_keys.js:85
-msgid "Category Landing Recently Added"
-msgstr ""
-
-#: static/js/impala/stats/csv_keys.js:86 static/js/impala/stats/csv_keys.js:87
-msgid "Browse Listing Featured Sort"
-msgstr ""
-
-#: static/js/impala/stats/csv_keys.js:88 static/js/impala/stats/csv_keys.js:89
-msgid "Browse Listing Users Sort"
-msgstr ""
-
-#: static/js/impala/stats/csv_keys.js:90 static/js/impala/stats/csv_keys.js:91
-msgid "Browse Listing Rating Sort"
-msgstr ""
-
-#: static/js/impala/stats/csv_keys.js:92 static/js/impala/stats/csv_keys.js:93
-msgid "Browse Listing Created Sort"
-msgstr ""
-
-#: static/js/impala/stats/csv_keys.js:94 static/js/impala/stats/csv_keys.js:95
-msgid "Browse Listing Name Sort"
-msgstr ""
-
-#: static/js/impala/stats/csv_keys.js:96 static/js/impala/stats/csv_keys.js:97
-msgid "Browse Listing Popular Sort"
-msgstr ""
-
-#: static/js/impala/stats/csv_keys.js:98 static/js/impala/stats/csv_keys.js:99
-msgid "Browse Listing Updated Sort"
-msgstr ""
-
-#: static/js/impala/stats/csv_keys.js:100
-#: static/js/impala/stats/csv_keys.js:101
-msgid "Browse Listing Up and Coming Sort"
-msgstr ""
-
-#: static/js/impala/stats/csv_keys.js:105
-msgid "Total Amount Contributed"
-msgstr ""
-
-#: static/js/impala/stats/csv_keys.js:106
-msgid "Average Contribution"
-msgstr ""
-
-#: static/js/impala/stats/csv_keys.js:115
-msgid "Usage"
-msgstr ""
-
-#: static/js/impala/stats/csv_keys.js:118
-msgid "Firefox"
-msgstr ""
-
-#: static/js/impala/stats/csv_keys.js:119
-msgid "Mozilla"
-msgstr ""
-
-#: static/js/impala/stats/csv_keys.js:120
-msgid "Thunderbird"
-msgstr ""
-
-#: static/js/impala/stats/csv_keys.js:121
-msgid "Sunbird"
-msgstr ""
-
-#: static/js/impala/stats/csv_keys.js:122
-msgid "SeaMonkey"
-msgstr ""
-
-#: static/js/impala/stats/csv_keys.js:123
-msgid "Fennec"
-msgstr ""
-
-#: static/js/impala/stats/csv_keys.js:124
-msgid "Android"
-msgstr ""
-
-#. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:129
-msgid "Downloads and Daily Users, last {0} days"
-msgstr ""
-
-#. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:131
-msgid "Downloads and Daily Users from {0} to {1}"
-msgstr ""
-
-#. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:135
-msgid "Installs and Daily Users, last {0} days"
-msgstr ""
-
-#. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:137
-msgid "Installs and Daily Users from {0} to {1}"
-msgstr ""
-
-#. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:141
-msgid "Downloads, last {0} days"
-msgstr ""
-
-#. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:143
-msgid "Downloads from {0} to {1}"
-msgstr ""
-
-#. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:147
-msgid "Daily Users, last {0} days"
-msgstr ""
-
-#. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:149
-msgid "Daily Users from {0} to {1}"
-msgstr ""
-
-#. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:153
-msgid "Applications, last {0} days"
-msgstr ""
-
-#. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:155
-msgid "Applications from {0} to {1}"
-msgstr ""
-
-#. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:159
-msgid "Platforms, last {0} days"
-msgstr ""
-
-#. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:161
-msgid "Platforms from {0} to {1}"
-msgstr ""
-
-#. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:165
-msgid "Languages, last {0} days"
-msgstr ""
-
-#. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:167
-msgid "Languages from {0} to {1}"
-msgstr ""
-
-#. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:171
-msgid "Add-on Versions, last {0} days"
-msgstr ""
-
-#. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:173
-msgid "Add-on Versions from {0} to {1}"
-msgstr ""
-
-#. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:177
-msgid "Add-on Status, last {0} days"
-msgstr ""
-
-#. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:179
-msgid "Add-on Status from {0} to {1}"
-msgstr ""
-
-#. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:183
-msgid "Download Sources, last {0} days"
-msgstr ""
-
-#. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:185
-msgid "Download Sources from {0} to {1}"
-msgstr ""
-
-#. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:189
-msgid "Contributions, last {0} days"
-msgstr ""
-
-#. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:191
-msgid "Contributions from {0} to {1}"
-msgstr ""
-
-#. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:195
-msgid "Site Metrics, last {0} days"
-msgstr ""
-
-#. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:197
-msgid "Site Metrics from {0} to {1}"
-msgstr ""
-
-#. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:201
-msgid "Add-ons in Use, last {0} days"
-msgstr ""
-
-#. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:203
-msgid "Add-ons in Use from {0} to {1}"
-msgstr ""
-
-#. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:207
-msgid "Add-ons Downloaded, last {0} days"
-msgstr ""
-
-#. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:209
-msgid "Add-ons Downloaded from {0} to {1}"
-msgstr ""
-
-#. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:213
-msgid "Add-ons Created, last {0} days"
-msgstr ""
-
-#. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:215
-msgid "Add-ons Created from {0} to {1}"
-msgstr ""
-
-#. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:219
-msgid "Add-ons Updated, last {0} days"
-msgstr ""
-
-#. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:221
-msgid "Add-ons Updated from {0} to {1}"
-msgstr ""
-
-#. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:225
-msgid "Reviews Written, last {0} days"
-msgstr ""
-
-#. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:227
-msgid "Reviews Written from {0} to {1}"
-msgstr ""
-
-#. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:231
-msgid "User Signups, last {0} days"
-msgstr ""
-
-#. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:233
-msgid "User Signups from {0} to {1}"
-msgstr ""
-
-#. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:237
-msgid "Collections Created, last {0} days"
-msgstr ""
-
-#. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:239
-msgid "Collections Created from {0} to {1}"
-msgstr ""
-
-#. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:243
-msgid "Subscribers, last {0} days"
-msgstr ""
-
-#. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:245
-msgid "Subscribers from {0} to {1}"
-msgstr ""
-
-#. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:249
-msgid "Ratings, last {0} days"
-msgstr ""
-
-#. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:251
-msgid "Ratings from {0} to {1}"
-msgstr ""
-
-#. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:255
-msgid "Sales, last {0} days"
-msgstr ""
-
-#. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:257
-msgid "Sales from {0} to {1}"
-msgstr ""
-
-#. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:261
-msgid "Installs, last {0} days"
-msgstr ""
-
-#. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:263
-msgid "Installs from {0} to {1}"
-msgstr ""
-
-#. L10n: {0} and {1} are integers.
-#: static/js/impala/stats/csv_keys.js:269
-msgid "<b>{0}</b> in last {1} days"
-msgstr ""
-
-#. L10n: {0} is an integer and {1} and {2} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:271
-#: static/js/impala/stats/csv_keys.js:277
-msgid "<b>{0}</b> from {1} to {2}"
-msgstr ""
-
-#. L10n: {0} and {1} are integers.
-#: static/js/impala/stats/csv_keys.js:275
-msgid "<b>{0}</b> average in last {1} days"
-msgstr ""
-
-#: static/js/impala/stats/overview.js:19
-msgid "No data available."
-msgstr ""
-
-#: static/js/impala/stats/table.js:74
-msgid "Date"
-msgstr ""
-
-#: static/js/impala/stats/topchart.js:96
-msgid "Other"
-msgstr "Bestelakoa"
-
-#: static/js/zamboni/admin_validation.js:24 static/js/zamboni/devhub.js:1229
-#: static/js/zamboni/editors.js:295
-msgid "Select an application first"
-msgstr "Hautatu aplikazioa lehenik"
-
-#: static/js/zamboni/admin_validation.js:51
-#, fuzzy
-msgid "Set {0} add-on to a max version of {1} and email the author."
-msgid_plural "Set {0} add-ons to a max version of {1} and email the authors."
-msgstr[0] ""
-"Ezarri {0} gehigarriari {1} bertsio maximoa eta bidali mezu elektronikoa "
-"egileari."
-msgstr[1] ""
-"Ezarri {0} gehigarriei {1} bertsio maximoa eta bidali mezu elektronikoa "
-"egileei."
-
-#: static/js/zamboni/admin_validation.js:54
-msgid "Email author of {2} add-on which failed validation."
-msgid_plural "Email authors of {2} add-ons which failed validation."
-msgstr[0] ""
-msgstr[1] ""
+#: static/js/common-all.js:1426 static/js/impala-all.js:1511 static/js/zamboni/discovery-all.js:12598 static/js/zamboni/init.js:28 static/js/zamboni/mobile-all.js:14945
+msgid "This feature is temporarily disabled while we perform website maintenance. Please check back a little later."
+msgstr "Funtzionaltasun hau behin-behinean desgaituta dago webgunearen mantentze-lanak burutu artean. Saiatu berriro beranduago."
 
 #. L10n: {0} is an app name like Firefox.
-#: static/js/zamboni/buttons.js:66
+#: static/js/common-all.js:1837 static/js/impala-all.js:1922 static/js/zamboni/buttons.js:73 static/js/zamboni/discovery-all.js:13108
 msgid "Accept and Install"
 msgstr "Onartu eta instalatu"
 
-#: static/js/zamboni/buttons.js:66
+#: static/js/common-all.js:1837 static/js/impala-all.js:1922 static/js/zamboni/buttons.js:73 static/js/zamboni/discovery-all.js:13108
 msgid "Add to {0}"
 msgstr "Gehitu {0}(e)ra"
 
-#: static/js/zamboni/buttons.js:71
+#: static/js/common-all.js:1842 static/js/impala-all.js:1927 static/js/zamboni/buttons.js:78 static/js/zamboni/discovery-all.js:13113
 msgid "Download Now"
 msgstr "Deskargatu orain"
 
-#: static/js/zamboni/buttons.js:112
+#: static/js/common-all.js:1883 static/js/impala-all.js:1968 static/js/zamboni/buttons.js:119 static/js/zamboni/discovery-all.js:13154
 msgid "Add-on has not been updated to support default-to-compatible."
 msgstr ""
 
-#: static/js/zamboni/buttons.js:117
+#: static/js/common-all.js:1888 static/js/impala-all.js:1973 static/js/zamboni/buttons.js:124 static/js/zamboni/discovery-all.js:13159
 msgid "You need to be using Firefox 10.0 or higher."
 msgstr ""
 
-#: static/js/zamboni/buttons.js:129
-msgid ""
-"Mozilla has marked this version as incompatible with your Firefox version."
+#: static/js/common-all.js:1900 static/js/impala-all.js:1985 static/js/zamboni/buttons.js:136 static/js/zamboni/discovery-all.js:13171
+msgid "Mozilla has marked this version as incompatible with your Firefox version."
 msgstr ""
 
 #. L10n: {0} is an platform like Windows or Linux.
-#: static/js/zamboni/buttons.js:210
+#: static/js/common-all.js:1981 static/js/impala-all.js:2066 static/js/zamboni/buttons.js:217 static/js/zamboni/discovery-all.js:13252
 msgid "Install for {0} anyway"
 msgstr "Instalatu {0}(e)rako halare"
 
-#: static/js/zamboni/buttons.js:210
+#: static/js/common-all.js:1981 static/js/impala-all.js:2066 static/js/zamboni/buttons.js:217 static/js/zamboni/discovery-all.js:13252
 msgid "Download for {0} anyway"
 msgstr "Deskargatu {0}(e)rako halere"
 
-#: static/js/zamboni/buttons.js:267
+#: static/js/common-all.js:2038 static/js/impala-all.js:2123 static/js/zamboni/buttons.js:274 static/js/zamboni/discovery-all.js:13309
 msgid "Not available for your platform"
 msgstr "Ez dago eskuragarri zure plataformarako"
 
 #. L10n: {0} is an app name, {1} is the app version.
-#: static/js/zamboni/buttons.js:278 static/js/zamboni/buttons.js:315
+#: static/js/common-all.js:2049 static/js/common-all.js:2086 static/js/impala-all.js:2134 static/js/impala-all.js:2171 static/js/zamboni/buttons.js:286 static/js/zamboni/buttons.js:324
+#: static/js/zamboni/discovery-all.js:13320 static/js/zamboni/discovery-all.js:13357
 msgid "Not available for {0} {1}"
 msgstr "Ez dago eskuragarri {0} {1} bertsiorako"
 
-#: static/js/zamboni/buttons.js:341
+#: static/js/common-all.js:2112 static/js/impala-all.js:2197 static/js/zamboni/buttons.js:351 static/js/zamboni/discovery-all.js:13383
 msgid "Works with {app} {min} - {max}"
 msgstr ""
 
-#: static/js/zamboni/buttons.js:343
+#: static/js/common-all.js:2114 static/js/impala-all.js:2199 static/js/zamboni/buttons.js:353 static/js/zamboni/discovery-all.js:13385
 msgid "View other versions"
 msgstr ""
 
-#: static/js/zamboni/buttons.js:391
+#: static/js/common-all.js:2162 static/js/impala-all.js:2247 static/js/zamboni/buttons.js:401 static/js/zamboni/discovery-all.js:13433
 msgid "Only with Firefox — Get Firefox Now!"
 msgstr ""
 
-#: static/js/zamboni/buttons.js:507 static/js/zamboni/mobile/buttons.js:43
-msgid ""
-"Sorry, you need a Mozilla-based browser (such as Firefox) to install a "
-"search plugin."
-msgstr ""
-"Mozillan oinarritutako nabigatzailea behar duzu (Firefox, adibidez) "
-"bilaketa-motorra instalatzeko."
+#: static/js/common-all.js:2278 static/js/impala-all.js:2363 static/js/zamboni/buttons.js:517 static/js/zamboni/discovery-all.js:13549 static/js/zamboni/mobile-all.js:15177
+#: static/js/zamboni/mobile/buttons.js:43
+msgid "Sorry, you need a Mozilla-based browser (such as Firefox) to install a search plugin."
+msgstr "Mozillan oinarritutako nabigatzailea behar duzu (Firefox, adibidez) bilaketa-motorra instalatzeko."
 
-#: static/js/zamboni/collections.js:229
-msgid "Adding to Favorites&hellip;"
-msgstr "Gogokoetara gehitzen&hellip;"
-
-#: static/js/zamboni/collections.js:232
-msgid "Removing Favorite&hellip;"
-msgstr "Gogokoa kentzen&hellip;"
-
-#: static/js/zamboni/collections.js:235
-msgid "Add to Favorites"
-msgstr "Gehitu gogokoetara"
-
-#: static/js/zamboni/collections.js:238
-msgid "Remove from Favorites"
-msgstr "Kendu gogokoetatik"
-
-#: static/js/zamboni/collections.js:303
-msgid "Pending"
-msgstr "Zain"
-
-#: static/js/zamboni/collections.js:304
-msgid "Add a comment"
-msgstr "Gehitu iruzkina"
-
-#: static/js/zamboni/collections.js:304
-msgid "Comment"
-msgstr "Iruzkina"
-
-#: static/js/zamboni/collections.js:305
-msgid "Remove this add-on from the collection"
-msgstr "Kendu gehigarri hau bildumatik"
-
-#: static/js/zamboni/collections.js:305 static/js/zamboni/collections.js:334
-msgid "Remove"
-msgstr "Kendu"
-
-#: static/js/zamboni/collections.js:334
-msgid "Remove this user as a contributor"
-msgstr "Kendu erabiltzaile hau ekarpen-egile gisa"
-
-#: static/js/zamboni/collections.js:346
-msgid "An email address is required."
-msgstr ""
-
-#: static/js/zamboni/collections.js:364
-msgid "You cannot add yourself as a contributor."
-msgstr ""
-
-#: static/js/zamboni/collections.js:366
-msgid "You have already added that user."
-msgstr ""
-
-#: static/js/zamboni/collections.js:573
-msgid "Add to favorites"
-msgstr "Gehitu gogokoetara"
-
-#: static/js/zamboni/collections.js:577
-msgid "Remove from favorites"
-msgstr "Kendu gogokoetatik"
-
-#: static/js/zamboni/collections.js:604
-msgid "Stop following"
-msgstr "Utzi jarraitzeari"
-
-#: static/js/zamboni/devhub.js:110
-msgid "Your browser does not support the video tag"
-msgstr "Zure nabigatzaileak ez du 'video' etiketa onartzen"
-
-#: static/js/zamboni/devhub.js:371
-msgid "Changes Saved"
-msgstr "Aldaketak gordeta"
-
-#: static/js/zamboni/devhub.js:387
-msgid "Enter a new author's email address"
-msgstr "Idatzi egile berriaren helbide elektronikoa"
-
-#: static/js/zamboni/devhub.js:536
-msgid "There was an error uploading your file."
-msgstr "Errorea gertatu da fitxategia igotzean."
-
-#: static/js/zamboni/devhub.js:681
-msgid "{files} file"
-msgid_plural "{files} files"
-msgstr[0] "Fitxategi bat"
-msgstr[1] "{files} fitxategi"
-
-#: static/js/zamboni/devhub.js:684
-msgid "{reviews} user review"
-msgid_plural "{reviews} user reviews"
-msgstr[0] ""
-msgstr[1] ""
-
-#: static/js/zamboni/devhub.js:796
-msgid "Learn more"
-msgstr "Argibide gehiago"
-
-#: static/js/zamboni/devhub.js:800
-msgid "Example"
-msgstr "Adibidea"
-
-#: static/js/zamboni/devhub.js:1130
-msgid "Image changes being processed"
-msgstr "Irudi-aldaketak prozesatzen ari dira"
-
-#: static/js/zamboni/devhub.js:1280
-msgid "Must be a valid e-mail address."
-msgstr ""
-
-#: static/js/zamboni/devhub_search.js:8
-msgid "No results found."
-msgstr ""
-
-#: static/js/zamboni/editors.js:121
-msgid "{name} was viewing this page first."
-msgstr "{name} ari zen orri hau ikusten aurrena."
-
-#: static/js/zamboni/editors.js:171
-msgid "Receipt checked by app."
-msgstr ""
-
-#: static/js/zamboni/editors.js:173
-msgid "Receipt was not checked by app."
-msgstr ""
-
-#: static/js/zamboni/editors.js:244
-msgid "{name} was viewing this add-on first."
-msgstr ""
-
-#: static/js/zamboni/editors.js:255
-msgid "Loading&hellip;"
-msgstr "Kargatzen&hellip;"
-
-#: static/js/zamboni/editors.js:260
-msgid "Version Notes"
-msgstr ""
-
-#: static/js/zamboni/editors.js:265
-msgid "Notes for Reviewers"
-msgstr ""
-
-#: static/js/zamboni/editors.js:270
-msgid "No version notes found"
-msgstr "Ez da bertsio-oharrik aurkitu"
-
-#: static/js/zamboni/editors.js:330
-msgid "Average Reviews"
-msgstr ""
-
-#: static/js/zamboni/editors.js:386
-msgid "Number of Reviews"
-msgstr ""
-
-#: static/js/zamboni/editors.js:445
-msgid "Error loading translation"
-msgstr ""
-
-#: static/js/zamboni/files.js:411 static/js/zamboni/validator.js:261
-msgid "Ignore this message in future updates"
-msgstr ""
-
-#: static/js/zamboni/files.js:417 static/js/zamboni/validator.js:284
-msgid "Severity for automated signing:"
-msgstr ""
-
-#: static/js/zamboni/global.js:410
+#: static/js/common-all.js:9088 static/js/impala-all.js:9649 static/js/zamboni/global.js:410
 msgid "Loading..."
 msgstr "Kargatzen..."
 
 #. L10n: {0} is the number of characters left.
-#: static/js/zamboni/global.js:474
+#: static/js/common-all.js:9152 static/js/impala-all.js:9713 static/js/zamboni/global.js:474
 msgid "<b>{0}</b> character left."
 msgid_plural "<b>{0}</b> characters left."
 msgstr[0] "Karaktere <b>bat</b> faltan."
 msgstr[1] "<b>{0}</b> karaktere faltan."
 
-#: static/js/zamboni/init.js:28
-msgid ""
-"This feature is temporarily disabled while we perform website maintenance. "
-"Please check back a little later."
-msgstr ""
-"Funtzionaltasun hau behin-behinean desgaituta dago webgunearen mantentze-"
-"lanak burutu artean. Saiatu berriro beranduago."
+#: static/js/common-all.js:9589 static/js/common-min.js:6 static/js/impala-all.js:10052 static/js/impala-min.js:6 static/js/common/ratingwidget.js:31 static/js/zamboni/mobile-all.js:16123
+#: static/js/zamboni/mobile-min.js:6
+msgid "{0} star"
+msgid_plural "{0} stars"
+msgstr[0] ""
+msgstr[1] ""
 
-#: static/js/zamboni/l10n.js:45
+#: static/js/common-all.js:9676 static/js/common-min.js:6 static/js/impala-all.js:10139 static/js/impala-min.js:6 static/js/zamboni/l10n.js:45
 msgid "Remove this localization"
 msgstr "Kendu itzulpen hau"
 
-#: static/js/zamboni/password-strength.js:20
+#: static/js/common-all.js:10193 static/js/common-min.js:6 static/js/impala-all.js:10674 static/js/impala-min.js:6 static/js/zamboni/discovery-all.js:13678
+msgid "close"
+msgstr ""
+
+#: static/js/common-all.js:10860 static/js/common-min.js:6 static/js/impala-all.js:11481 static/js/impala-min.js:6 static/js/impala/reviews.js:23 static/js/zamboni/reviews.js:18
+msgid "Flagged for review"
+msgstr "Berrikusteko markatuta"
+
+#: static/js/common-all.js:10876 static/js/common-min.js:6 static/js/impala-all.js:11498 static/js/impala-min.js:6 static/js/impala/reviews.js:40 static/js/zamboni/reviews.js:34
+msgid "Your input is required"
+msgstr "Zure sarrera beharrezkoa da"
+
+#: static/js/common-all.js:10945 static/js/common-min.js:6 static/js/impala-all.js:11610 static/js/impala-min.js:7 static/js/impala/reviews.js:152 static/js/zamboni/reviews.js:103
+msgid "Marked for deletion"
+msgstr "Ezabatzeko markatuta"
+
+#: static/js/common-all.js:11573 static/js/common-min.js:7 static/js/impala-all.js:13809 static/js/impala-min.js:8 static/js/zamboni/collections.js:229
+msgid "Adding to Favorites&hellip;"
+msgstr "Gogokoetara gehitzen&hellip;"
+
+#: static/js/common-all.js:11576 static/js/common-min.js:7 static/js/impala-all.js:13812 static/js/impala-min.js:8 static/js/zamboni/collections.js:232
+msgid "Removing Favorite&hellip;"
+msgstr "Gogokoa kentzen&hellip;"
+
+#: static/js/common-all.js:11579 static/js/common-min.js:7 static/js/impala-all.js:13815 static/js/impala-min.js:8 static/js/zamboni/collections.js:235
+msgid "Add to Favorites"
+msgstr "Gehitu gogokoetara"
+
+#: static/js/common-all.js:11582 static/js/common-min.js:7 static/js/impala-all.js:13818 static/js/impala-min.js:8 static/js/zamboni/collections.js:238
+msgid "Remove from Favorites"
+msgstr "Kendu gogokoetatik"
+
+#: static/js/common-all.js:11647 static/js/common-min.js:7 static/js/impala-all.js:13883 static/js/impala-min.js:8 static/js/zamboni/collections.js:303
+msgid "Pending"
+msgstr "Zain"
+
+#: static/js/common-all.js:11648 static/js/common-min.js:7 static/js/impala-all.js:13884 static/js/impala-min.js:8 static/js/zamboni/collections.js:304
+msgid "Add a comment"
+msgstr "Gehitu iruzkina"
+
+#: static/js/common-all.js:11648 static/js/common-min.js:7 static/js/impala-all.js:13884 static/js/impala-min.js:8 static/js/zamboni/collections.js:304
+msgid "Comment"
+msgstr "Iruzkina"
+
+#: static/js/common-all.js:11649 static/js/common-min.js:7 static/js/impala-all.js:13885 static/js/impala-min.js:8 static/js/zamboni/collections.js:305
+msgid "Remove this add-on from the collection"
+msgstr "Kendu gehigarri hau bildumatik"
+
+#: static/js/common-all.js:11649 static/js/common-all.js:11678 static/js/common-min.js:7 static/js/impala-all.js:13885 static/js/impala-all.js:13914 static/js/impala-min.js:8
+#: static/js/zamboni/collections.js:305 static/js/zamboni/collections.js:334
+msgid "Remove"
+msgstr "Kendu"
+
+#: static/js/common-all.js:11678 static/js/common-min.js:7 static/js/impala-all.js:13914 static/js/impala-min.js:8 static/js/zamboni/collections.js:334
+msgid "Remove this user as a contributor"
+msgstr "Kendu erabiltzaile hau ekarpen-egile gisa"
+
+#: static/js/common-all.js:11690 static/js/common-min.js:7 static/js/impala-all.js:13926 static/js/impala-min.js:8 static/js/zamboni/collections.js:346
+msgid "An email address is required."
+msgstr ""
+
+#: static/js/common-all.js:11708 static/js/common-min.js:7 static/js/impala-all.js:13944 static/js/impala-min.js:8 static/js/zamboni/collections.js:364
+msgid "You cannot add yourself as a contributor."
+msgstr ""
+
+#: static/js/common-all.js:11710 static/js/common-min.js:7 static/js/impala-all.js:13946 static/js/impala-min.js:8 static/js/zamboni/collections.js:366
+msgid "You have already added that user."
+msgstr ""
+
+#: static/js/common-all.js:11917 static/js/common-min.js:7 static/js/impala-all.js:14153 static/js/impala-min.js:8 static/js/zamboni/collections.js:573
+msgid "Add to favorites"
+msgstr "Gehitu gogokoetara"
+
+#: static/js/common-all.js:11921 static/js/common-min.js:7 static/js/impala-all.js:14157 static/js/impala-min.js:8 static/js/zamboni/collections.js:577
+msgid "Remove from favorites"
+msgstr "Kendu gogokoetatik"
+
+#: static/js/common-all.js:11939 static/js/common-min.js:7 static/js/impala-all.js:14175 static/js/impala-all.js:14233 static/js/impala-min.js:8 static/js/impala/collections.js:10
+#: static/js/zamboni/collections.js:595
+msgid "Follow this Collection"
+msgstr "Jarraitu bilduma hau"
+
+#: static/js/common-all.js:11948 static/js/common-min.js:7 static/js/impala-all.js:14184 static/js/impala-min.js:8 static/js/zamboni/collections.js:604
+msgid "Stop following"
+msgstr "Utzi jarraitzeari"
+
+#: static/js/common-all.js:12096 static/js/common-min.js:7 static/js/zamboni/password-strength.js:20
 msgid "Password strength:"
 msgstr "Pasahitzaren sendotasuna:"
 
-#: static/js/zamboni/password-strength.js:26
+#: static/js/common-all.js:12102 static/js/common-min.js:7 static/js/zamboni/password-strength.js:26
 msgid "At least {0} character left."
 msgid_plural "At least {0} characters left."
 msgstr[0] "Gutxienez karaktere bat geratzen da."
 msgstr[1] "Gutxienez {0} karaktere geratzen dira."
 
-#: static/js/zamboni/themes_review.js:176
-msgid "Requested Info"
+#: static/js/common-all.js:12286 static/js/common-min.js:7 static/js/impala-all.js:14632 static/js/impala-min.js:8 static/js/impala/suggestions.js:39
+msgid "Search themes for <b>{0}</b>"
 msgstr ""
 
-#: static/js/zamboni/themes_review.js:177
-msgid "Flagged"
+#: static/js/common-all.js:12288 static/js/common-min.js:7 static/js/impala-all.js:14634 static/js/impala-min.js:8 static/js/impala/suggestions.js:41
+msgid "Search apps for <b>{0}</b>"
 msgstr ""
 
-#: static/js/zamboni/themes_review.js:178
-msgid "Duplicate"
+#: static/js/common-all.js:12290 static/js/common-min.js:7 static/js/impala-all.js:14636 static/js/impala-min.js:8 static/js/impala/suggestions.js:43
+msgid "Search add-ons for <b>{0}</b>"
 msgstr ""
 
-#: static/js/zamboni/themes_review.js:179
-msgid "Rejected"
+#: static/js/common-all.js:12521 static/js/common-min.js:7 static/js/impala-all.js:14867 static/js/impala-min.js:8 static/js/impala/site_suggestions.js:46
+msgid "Category"
+msgstr "Kategoria"
+
+#. L10n: {0} is an app name.
+#: static/js/impala-all.js:11632 static/js/impala-min.js:7 static/js/impala/listing.js:11 static/js/zamboni/themes.js:13
+msgid "This theme is incompatible with your version of {0}"
+msgstr "Gai hau bateraezina da {0}(r)en zure bertsioarekin"
+
+#: static/js/impala-all.js:12146 static/js/impala-all.js:14331 static/js/impala-min.js:7 static/js/impala-min.js:8 static/js/common/upload-image.js:97 static/js/impala/users.js:51
+#: static/js/zamboni/devhub-all.js:894 static/js/zamboni/devhub-min.js:1
+msgid "Images must be either PNG or JPG."
 msgstr ""
 
-#: static/js/zamboni/themes_review.js:180
-msgid "Approved"
+#: static/js/impala-all.js:12150 static/js/impala-min.js:7 static/js/common/upload-image.js:101 static/js/zamboni/devhub-all.js:898 static/js/zamboni/devhub-min.js:1
+msgid "Videos must be in WebM."
+msgstr "Bideoek WebM formatua izan behar dute."
+
+#: static/js/impala-all.js:12177 static/js/impala-min.js:7 static/js/common/upload-addon.js:41 static/js/common/upload-image.js:128 static/js/zamboni/devhub-all.js:272
+#: static/js/zamboni/devhub-all.js:925 static/js/zamboni/devhub-min.js:1
+msgid "There was a problem contacting the server."
+msgstr "Errorea gertatu da zerbitzariarekin konektatzean."
+
+#: static/js/impala-all.js:13298 static/js/impala-min.js:7 static/js/impala/persona_creation.js:60
+msgid "All Rights Reserved"
+msgstr "Eskubide guztiak erreserbatuta"
+
+#: static/js/impala-all.js:13302 static/js/impala-min.js:7 static/js/impala/persona_creation.js:64
+msgid "Creative Commons Attribution 3.0"
 msgstr ""
 
-#: static/js/zamboni/themes_review.js:424
-msgid "No results found"
+#: static/js/impala-all.js:13307 static/js/impala-min.js:7 static/js/impala/persona_creation.js:69
+msgid "Creative Commons Attribution-NonCommercial 3.0"
 msgstr ""
 
-#: static/js/zamboni/themes_review_templates.js:31
-msgid "Theme"
+#: static/js/impala-all.js:13312 static/js/impala-min.js:7 static/js/impala/persona_creation.js:74
+msgid "Creative Commons Attribution-NonCommercial-NoDerivs 3.0"
 msgstr ""
 
-#: static/js/zamboni/themes_review_templates.js:33
-msgid "Reviewer"
+#: static/js/impala-all.js:13317 static/js/impala-min.js:7 static/js/impala/persona_creation.js:79
+msgid "Creative Commons Attribution-NonCommercial-Share Alike 3.0"
 msgstr ""
 
-#: static/js/zamboni/themes_review_templates.js:35
-msgid "Status"
+#: static/js/impala-all.js:13322 static/js/impala-min.js:7 static/js/impala/persona_creation.js:84
+msgid "Creative Commons Attribution-NoDerivs 3.0"
 msgstr ""
 
-#: static/js/zamboni/validator.js:80
+#: static/js/impala-all.js:13327 static/js/impala-min.js:7 static/js/impala/persona_creation.js:89
+msgid "Creative Commons Attribution-ShareAlike 3.0"
+msgstr ""
+
+#: static/js/impala-all.js:13530 static/js/impala-min.js:7 static/js/impala/persona_creation.js:292
+msgid "Your Theme's Name"
+msgstr "Zure gaiaren izena"
+
+#: static/js/impala-all.js:14242 static/js/impala-min.js:8 static/js/impala/collections.js:19
+msgid "Stop Following"
+msgstr "Utzi jarraitzeari"
+
+#: static/js/impala-all.js:14243 static/js/impala-min.js:8 static/js/impala/collections.js:20
+msgid "Following"
+msgstr "Jarraitzen"
+
+#: static/js/impala-all.js:14313 static/js/impala-min.js:8 static/js/impala/users.js:33
+msgid "use original"
+msgstr ""
+
+#: static/js/impala-all.js:14523 static/js/impala-min.js:8 static/js/impala/search.js:114
+msgid "Updating results&hellip;"
+msgstr "Emaitzak eguneratzen&hellip;"
+
+#: static/js/common/upload-addon.js:69 static/js/zamboni/devhub-all.js:300 static/js/zamboni/devhub-min.js:1
+msgid "Select a file..."
+msgstr "Hautatu fitxategia..."
+
+#: static/js/common/upload-addon.js:70 static/js/zamboni/devhub-all.js:301 static/js/zamboni/devhub-min.js:1
+msgid "Your add-on should end with .xpi, .jar or .xml"
+msgstr "Zure gehigarriak .xpi, .jar edo .xml luzapenarekin amaitu behar du"
+
+#. L10n: {0} is the percent of the file that has been uploaded.
+#: static/js/common/upload-addon.js:104 static/js/zamboni/devhub-all.js:335 static/js/zamboni/devhub-min.js:1
+#, fuzzy, python-format
+msgid "{0}% complete"
+msgstr "%{0} osatuta"
+
+#. L10n: "{bytes uploaded} of {total filesize}".
+#: static/js/common/upload-addon.js:107 static/js/zamboni/devhub-all.js:338 static/js/zamboni/devhub-min.js:1
+msgid "{0} of {1}"
+msgstr "{1}/{0}"
+
+#: static/js/common/upload-addon.js:140 static/js/zamboni/devhub-all.js:371 static/js/zamboni/devhub-min.js:1
+msgid "Cancel"
+msgstr "Utzi"
+
+#: static/js/common/upload-addon.js:162 static/js/zamboni/devhub-all.js:393 static/js/zamboni/devhub-min.js:1
+msgid "Uploading {0}"
+msgstr "{0} igotzen"
+
+#: static/js/common/upload-addon.js:189 static/js/zamboni/devhub-all.js:420 static/js/zamboni/devhub-min.js:1
+msgid "Error with {0}"
+msgstr "Errorea {0}(r)ekin"
+
+#: static/js/common/upload-addon.js:194 static/js/zamboni/devhub-all.js:425 static/js/zamboni/devhub-min.js:1
+msgid "Your add-on failed validation with {0} error."
+msgid_plural "Your add-on failed validation with {0} errors."
+msgstr[0] "Zure gehigarriak balidazioa huts egin du errore batekin."
+msgstr[1] "Zure gehigarriak balidazioa huts egin du {0} errorerekin."
+
+#: static/js/common/upload-addon.js:208 static/js/zamboni/devhub-all.js:439 static/js/zamboni/devhub-min.js:1
+msgid "&hellip;and {0} more"
+msgid_plural "&hellip;and {0} more"
+msgstr[0] "&hellip;eta bat gehiago"
+msgstr[1] "&hellip;eta {0} gehiago"
+
+#: static/js/common/upload-addon.js:222 static/js/common/upload-addon.js:497 static/js/zamboni/devhub-all.js:453 static/js/zamboni/devhub-all.js:743 static/js/zamboni/devhub-min.js:1
+msgid "See full validation report"
+msgstr "Ikusi balidazioaren txosten osoa"
+
+#: static/js/common/upload-addon.js:234 static/js/zamboni/devhub-all.js:465 static/js/zamboni/devhub-min.js:1
+msgid "Validating {0}"
+msgstr "{0} balidatzen"
+
+#. L10n: first argument is an HTTP status code
+#: static/js/common/upload-addon.js:273 static/js/zamboni/devhub-all.js:504 static/js/zamboni/devhub-min.js:1
+msgid "Received an empty response from the server; status: {0}"
+msgstr "Erantzun huts jaso da zerbitzaritik; egoera: {0}"
+
+#: static/js/common/upload-addon.js:370 static/js/zamboni/devhub-all.js:604 static/js/zamboni/devhub-min.js:1
+msgid "Unexpected server error while validating."
+msgstr "Espero gabeko zerbitzari-errorea balidatzean."
+
+#: static/js/common/upload-addon.js:409 static/js/zamboni/devhub-all.js:643 static/js/zamboni/devhub-min.js:1
+msgid "Finished validating {0}"
+msgstr "{0}(r)en balidazioa amaitu da"
+
+#: static/js/common/upload-addon.js:415 static/js/zamboni/devhub-all.js:649 static/js/zamboni/devhub-min.js:1
+msgid "Your add-on validation timed out, it will be manually reviewed."
+msgstr ""
+
+#: static/js/common/upload-addon.js:418 static/js/zamboni/devhub-all.js:652 static/js/zamboni/devhub-min.js:1
+msgid "Your add-on was validated with no errors and {0} warning."
+msgid_plural "Your add-on was validated with no errors and {0} warnings."
+msgstr[0] ""
+msgstr[1] ""
+
+#: static/js/common/upload-addon.js:423 static/js/zamboni/devhub-all.js:657 static/js/zamboni/devhub-min.js:1
+msgid "Your add-on was validated with no errors and {0} message."
+msgid_plural "Your add-on was validated with no errors and {0} messages."
+msgstr[0] ""
+msgstr[1] ""
+
+#: static/js/common/upload-addon.js:428 static/js/zamboni/devhub-all.js:662 static/js/zamboni/devhub-min.js:1
+msgid "Your add-on was validated with no errors or warnings."
+msgstr ""
+
+#: static/js/common/upload-addon.js:443 static/js/zamboni/devhub-all.js:677 static/js/zamboni/devhub-min.js:1
+msgid "Your submission will be automatically signed."
+msgstr ""
+
+#: static/js/common/upload-addon.js:450 static/js/zamboni/devhub-all.js:696 static/js/zamboni/devhub-min.js:1
+msgid "Include detailed version notes (this can be done in the next step)."
+msgstr ""
+
+#: static/js/common/upload-addon.js:451 static/js/zamboni/devhub-all.js:697 static/js/zamboni/devhub-min.js:1
+msgid "If your add-on requires an account to a website in order to be fully tested, include a test username and password in the Notes to Reviewer (this can be done in the next step)."
+msgstr ""
+
+#: static/js/common/upload-addon.js:452 static/js/zamboni/devhub-all.js:698 static/js/zamboni/devhub-min.js:1
+msgid "If your add-on is intended for a limited audience you should choose Preliminary Review instead of Full Review."
+msgstr ""
+
+#: static/js/common/upload-addon.js:465 static/js/zamboni/devhub-all.js:711 static/js/zamboni/devhub-min.js:1
+msgid "Add-on submission checklist"
+msgstr ""
+
+#: static/js/common/upload-addon.js:466 static/js/zamboni/devhub-all.js:712 static/js/zamboni/devhub-min.js:1
+msgid "Please verify the following points before finalizing your submission. This will minimize delays or misunderstanding during the review process:"
+msgstr ""
+
+#: static/js/common/upload-addon.js:468 static/js/zamboni/devhub-all.js:714 static/js/zamboni/devhub-min.js:1
+msgid ""
+"Compiled binaries, as well as minified or obfuscated scripts (excluding known libraries) need to have their sources submitted separately for review. Make sure that you use the source code upload "
+"field to avoid having your submission rejected."
+msgstr ""
+
+#: static/js/common/upload-addon.js:486 static/js/zamboni/devhub-all.js:732 static/js/zamboni/devhub-min.js:1
+msgid "The validation process found these issues that can lead to rejections:"
+msgstr ""
+
+#: static/js/common/upload-addon.js:503 static/js/zamboni/devhub-all.js:749 static/js/zamboni/devhub-min.js:1
+msgid "If you are unfamiliar with the add-ons review process, you can read about it here."
+msgstr ""
+
+#: static/js/common/upload-addon.js:540 static/js/zamboni/devhub-all.js:786 static/js/zamboni/devhub-min.js:1
+msgid "Sorry, no supported platform has been found."
+msgstr "Sentitzen dugu, ez da onarturiko plataformarik aurkitu."
+
+#: static/js/common/upload-base.js:57 static/js/zamboni/devhub-all.js:187 static/js/zamboni/devhub-min.js:1
+msgid "The filetype you uploaded isn't recognized."
+msgstr "Igo duzun fitxategi mota ez da ezagutzen."
+
+#: static/js/common/upload-base.js:79 static/js/zamboni/devhub-all.js:209 static/js/zamboni/devhub-min.js:1
+msgid "You cancelled the upload."
+msgstr "Igotzea bertan behera utzi duzu."
+
+#: static/js/impala/stats/chart.js:267 static/js/zamboni/stats-all.js:16898 static/js/zamboni/stats-min.js:5
+msgid "Week of {0}"
+msgstr ""
+
+#: static/js/impala/stats/chart.js:269 static/js/zamboni/stats-all.js:16900 static/js/zamboni/stats-min.js:5
+msgid " downloads"
+msgstr ""
+
+#: static/js/impala/stats/chart.js:270 static/js/zamboni/stats-all.js:16901 static/js/zamboni/stats-min.js:5
+msgid "{0} users"
+msgstr ""
+
+#: static/js/impala/stats/chart.js:271 static/js/zamboni/stats-all.js:16902 static/js/zamboni/stats-min.js:5
+msgid "{0} add-ons"
+msgstr ""
+
+#: static/js/impala/stats/chart.js:272 static/js/zamboni/stats-all.js:16903 static/js/zamboni/stats-min.js:5
+msgid "{0} collections"
+msgstr ""
+
+#: static/js/impala/stats/chart.js:273 static/js/zamboni/stats-all.js:16904 static/js/zamboni/stats-min.js:5
+msgid "{0} reviews"
+msgstr ""
+
+#: static/js/impala/stats/chart.js:275 static/js/zamboni/stats-all.js:16906 static/js/zamboni/stats-min.js:5
+msgid "{0} sales"
+msgstr ""
+
+#: static/js/impala/stats/chart.js:276 static/js/zamboni/stats-all.js:16907 static/js/zamboni/stats-min.js:5
+msgid "{0} refunds"
+msgstr ""
+
+#: static/js/impala/stats/chart.js:277 static/js/zamboni/stats-all.js:16908 static/js/zamboni/stats-min.js:5
+msgid "{0} installs"
+msgstr ""
+
+#: static/js/impala/stats/chart.js:369 static/js/impala/stats/csv_keys.js:3 static/js/impala/stats/csv_keys.js:109 static/js/zamboni/stats-all.js:15284 static/js/zamboni/stats-all.js:15390
+#: static/js/zamboni/stats-all.js:17000 static/js/zamboni/stats-min.js:4 static/js/zamboni/stats-min.js:5
+msgid "Downloads"
+msgstr ""
+
+#: static/js/impala/stats/chart.js:379 static/js/impala/stats/csv_keys.js:6 static/js/impala/stats/csv_keys.js:110 static/js/zamboni/stats-all.js:15287 static/js/zamboni/stats-all.js:15391
+#: static/js/zamboni/stats-all.js:17010 static/js/zamboni/stats-min.js:4 static/js/zamboni/stats-min.js:5
+msgid "Daily Users"
+msgstr ""
+
+#: static/js/impala/stats/chart.js:410 static/js/zamboni/stats-all.js:17041 static/js/zamboni/stats-min.js:5
+msgid "Amount, in USD"
+msgstr ""
+
+#: static/js/impala/stats/chart.js:421 static/js/impala/stats/csv_keys.js:104 static/js/zamboni/stats-all.js:15385 static/js/zamboni/stats-all.js:17052 static/js/zamboni/stats-min.js:5
+msgid "Number of Contributions"
+msgstr ""
+
+#: static/js/impala/stats/chart.js:447 static/js/zamboni/stats-all.js:17078 static/js/zamboni/stats-min.js:5
+msgid "More Info..."
+msgstr "Informazio gehiago..."
+
+#. L10n: {0} is an ISO-formatted date.
+#: static/js/impala/stats/chart.js:451 static/js/zamboni/stats-all.js:17082 static/js/zamboni/stats-min.js:5
+msgid "Details for {0}"
+msgstr ""
+
+#: static/js/impala/stats/csv_keys.js:9 static/js/zamboni/stats-all.js:15290 static/js/zamboni/stats-min.js:4
+msgid "Collections Created"
+msgstr ""
+
+#: static/js/impala/stats/csv_keys.js:12 static/js/zamboni/stats-all.js:15293 static/js/zamboni/stats-min.js:4
+msgid "Add-ons in Use"
+msgstr ""
+
+#: static/js/impala/stats/csv_keys.js:15 static/js/zamboni/stats-all.js:15296 static/js/zamboni/stats-min.js:4
+msgid "Add-ons Created"
+msgstr ""
+
+#: static/js/impala/stats/csv_keys.js:18 static/js/zamboni/stats-all.js:15299 static/js/zamboni/stats-min.js:4
+msgid "Add-ons Downloaded"
+msgstr ""
+
+#: static/js/impala/stats/csv_keys.js:21 static/js/zamboni/stats-all.js:15302 static/js/zamboni/stats-min.js:4
+msgid "Add-ons Updated"
+msgstr ""
+
+#: static/js/impala/stats/csv_keys.js:24 static/js/zamboni/stats-all.js:15305 static/js/zamboni/stats-min.js:4
+msgid "Reviews Written"
+msgstr ""
+
+#: static/js/impala/stats/csv_keys.js:27 static/js/zamboni/stats-all.js:15308 static/js/zamboni/stats-min.js:4
+msgid "User Signups"
+msgstr ""
+
+#: static/js/impala/stats/csv_keys.js:30 static/js/zamboni/stats-all.js:15311 static/js/zamboni/stats-min.js:4
+msgid "Subscribers"
+msgstr ""
+
+#: static/js/impala/stats/csv_keys.js:33 static/js/zamboni/stats-all.js:15314 static/js/zamboni/stats-min.js:4
+msgid "Ratings"
+msgstr ""
+
+#: static/js/impala/stats/csv_keys.js:36 static/js/impala/stats/csv_keys.js:114 static/js/zamboni/stats-all.js:15317 static/js/zamboni/stats-all.js:15395 static/js/zamboni/stats-min.js:4
+#: static/js/zamboni/stats-min.js:5
+msgid "Sales"
+msgstr ""
+
+#: static/js/impala/stats/csv_keys.js:39 static/js/impala/stats/csv_keys.js:113 static/js/zamboni/stats-all.js:15320 static/js/zamboni/stats-all.js:15394 static/js/zamboni/stats-min.js:4
+#: static/js/zamboni/stats-min.js:5
+msgid "Installs"
+msgstr ""
+
+#: static/js/impala/stats/csv_keys.js:42 static/js/zamboni/stats-all.js:15323 static/js/zamboni/stats-min.js:4
+msgid "Unknown"
+msgstr ""
+
+#: static/js/impala/stats/csv_keys.js:43 static/js/zamboni/stats-all.js:15324 static/js/zamboni/stats-min.js:4
+msgid "Add-ons Manager"
+msgstr ""
+
+#: static/js/impala/stats/csv_keys.js:44 static/js/zamboni/stats-all.js:15325 static/js/zamboni/stats-min.js:4
+msgid "Add-ons Manager Promo"
+msgstr ""
+
+#: static/js/impala/stats/csv_keys.js:45 static/js/zamboni/stats-all.js:15326 static/js/zamboni/stats-min.js:4
+msgid "Add-ons Manager Featured"
+msgstr ""
+
+#: static/js/impala/stats/csv_keys.js:46 static/js/zamboni/stats-all.js:15327 static/js/zamboni/stats-min.js:4
+msgid "Add-ons Manager Learn More"
+msgstr ""
+
+#: static/js/impala/stats/csv_keys.js:47 static/js/zamboni/stats-all.js:15328 static/js/zamboni/stats-min.js:4
+msgid "Search Suggestions"
+msgstr ""
+
+#: static/js/impala/stats/csv_keys.js:48 static/js/zamboni/stats-all.js:15329 static/js/zamboni/stats-min.js:4
+msgid "Search Results"
+msgstr ""
+
+#: static/js/impala/stats/csv_keys.js:49 static/js/impala/stats/csv_keys.js:50 static/js/impala/stats/csv_keys.js:51 static/js/zamboni/stats-all.js:15330 static/js/zamboni/stats-all.js:15331
+#: static/js/zamboni/stats-all.js:15332 static/js/zamboni/stats-min.js:4
+msgid "Homepage Promo"
+msgstr ""
+
+#: static/js/impala/stats/csv_keys.js:52 static/js/impala/stats/csv_keys.js:53 static/js/zamboni/stats-all.js:15333 static/js/zamboni/stats-all.js:15334 static/js/zamboni/stats-min.js:4
+msgid "Homepage Featured"
+msgstr ""
+
+#: static/js/impala/stats/csv_keys.js:54 static/js/impala/stats/csv_keys.js:55 static/js/zamboni/stats-all.js:15335 static/js/zamboni/stats-all.js:15336 static/js/zamboni/stats-min.js:4
+msgid "Homepage Up and Coming"
+msgstr ""
+
+#: static/js/impala/stats/csv_keys.js:56 static/js/zamboni/stats-all.js:15337 static/js/zamboni/stats-min.js:4
+msgid "Homepage Most Popular"
+msgstr ""
+
+#: static/js/impala/stats/csv_keys.js:57 static/js/impala/stats/csv_keys.js:59 static/js/zamboni/stats-all.js:15338 static/js/zamboni/stats-all.js:15340 static/js/zamboni/stats-min.js:4
+msgid "Detail Page"
+msgstr ""
+
+#: static/js/impala/stats/csv_keys.js:58 static/js/impala/stats/csv_keys.js:60 static/js/zamboni/stats-all.js:15339 static/js/zamboni/stats-all.js:15341 static/js/zamboni/stats-min.js:4
+msgid "Detail Page (bottom)"
+msgstr ""
+
+#: static/js/impala/stats/csv_keys.js:61 static/js/zamboni/stats-all.js:15342 static/js/zamboni/stats-min.js:4
+msgid "Detail Page (Development Channel)"
+msgstr ""
+
+#: static/js/impala/stats/csv_keys.js:62 static/js/impala/stats/csv_keys.js:63 static/js/impala/stats/csv_keys.js:64 static/js/zamboni/stats-all.js:15343 static/js/zamboni/stats-all.js:15344
+#: static/js/zamboni/stats-all.js:15345 static/js/zamboni/stats-min.js:4
+msgid "Often Used With"
+msgstr ""
+
+#: static/js/impala/stats/csv_keys.js:65 static/js/impala/stats/csv_keys.js:66 static/js/zamboni/stats-all.js:15346 static/js/zamboni/stats-all.js:15347 static/js/zamboni/stats-min.js:4
+msgid "Others By Author"
+msgstr ""
+
+#: static/js/impala/stats/csv_keys.js:67 static/js/impala/stats/csv_keys.js:68 static/js/zamboni/stats-all.js:15348 static/js/zamboni/stats-all.js:15349 static/js/zamboni/stats-min.js:4
+msgid "Dependencies"
+msgstr ""
+
+#: static/js/impala/stats/csv_keys.js:69 static/js/impala/stats/csv_keys.js:70 static/js/zamboni/stats-all.js:15350 static/js/zamboni/stats-all.js:15351 static/js/zamboni/stats-min.js:4
+msgid "Upsell"
+msgstr ""
+
+#: static/js/impala/stats/csv_keys.js:71 static/js/zamboni/stats-all.js:15352 static/js/zamboni/stats-min.js:4
+msgid "Meet the Developer"
+msgstr ""
+
+#: static/js/impala/stats/csv_keys.js:72 static/js/zamboni/stats-all.js:15353 static/js/zamboni/stats-min.js:4
+msgid "User Profile"
+msgstr ""
+
+#: static/js/impala/stats/csv_keys.js:73 static/js/zamboni/stats-all.js:15354 static/js/zamboni/stats-min.js:4
+msgid "Version History"
+msgstr ""
+
+#: static/js/impala/stats/csv_keys.js:75 static/js/zamboni/stats-all.js:15356 static/js/zamboni/stats-min.js:4
+msgid "Sharing"
+msgstr ""
+
+#: static/js/impala/stats/csv_keys.js:76 static/js/zamboni/stats-all.js:15357 static/js/zamboni/stats-min.js:4
+msgid "Category Pages"
+msgstr ""
+
+#: static/js/impala/stats/csv_keys.js:77 static/js/zamboni/stats-all.js:15358 static/js/zamboni/stats-min.js:4
+msgid "Collections"
+msgstr ""
+
+#: static/js/impala/stats/csv_keys.js:78 static/js/impala/stats/csv_keys.js:79 static/js/zamboni/stats-all.js:15359 static/js/zamboni/stats-all.js:15360 static/js/zamboni/stats-min.js:4
+msgid "Category Landing Featured Carousel"
+msgstr ""
+
+#: static/js/impala/stats/csv_keys.js:80 static/js/impala/stats/csv_keys.js:81 static/js/zamboni/stats-all.js:15361 static/js/zamboni/stats-all.js:15362 static/js/zamboni/stats-min.js:4
+msgid "Category Landing Top Rated"
+msgstr ""
+
+#: static/js/impala/stats/csv_keys.js:82 static/js/impala/stats/csv_keys.js:83 static/js/zamboni/stats-all.js:15363 static/js/zamboni/stats-all.js:15364 static/js/zamboni/stats-min.js:5
+msgid "Category Landing Most Popular"
+msgstr ""
+
+#: static/js/impala/stats/csv_keys.js:84 static/js/impala/stats/csv_keys.js:85 static/js/zamboni/stats-all.js:15365 static/js/zamboni/stats-all.js:15366 static/js/zamboni/stats-min.js:5
+msgid "Category Landing Recently Added"
+msgstr ""
+
+#: static/js/impala/stats/csv_keys.js:86 static/js/impala/stats/csv_keys.js:87 static/js/zamboni/stats-all.js:15367 static/js/zamboni/stats-all.js:15368 static/js/zamboni/stats-min.js:5
+msgid "Browse Listing Featured Sort"
+msgstr ""
+
+#: static/js/impala/stats/csv_keys.js:88 static/js/impala/stats/csv_keys.js:89 static/js/zamboni/stats-all.js:15369 static/js/zamboni/stats-all.js:15370 static/js/zamboni/stats-min.js:5
+msgid "Browse Listing Users Sort"
+msgstr ""
+
+#: static/js/impala/stats/csv_keys.js:90 static/js/impala/stats/csv_keys.js:91 static/js/zamboni/stats-all.js:15371 static/js/zamboni/stats-all.js:15372 static/js/zamboni/stats-min.js:5
+msgid "Browse Listing Rating Sort"
+msgstr ""
+
+#: static/js/impala/stats/csv_keys.js:92 static/js/impala/stats/csv_keys.js:93 static/js/zamboni/stats-all.js:15373 static/js/zamboni/stats-all.js:15374 static/js/zamboni/stats-min.js:5
+msgid "Browse Listing Created Sort"
+msgstr ""
+
+#: static/js/impala/stats/csv_keys.js:94 static/js/impala/stats/csv_keys.js:95 static/js/zamboni/stats-all.js:15375 static/js/zamboni/stats-all.js:15376 static/js/zamboni/stats-min.js:5
+msgid "Browse Listing Name Sort"
+msgstr ""
+
+#: static/js/impala/stats/csv_keys.js:96 static/js/impala/stats/csv_keys.js:97 static/js/zamboni/stats-all.js:15377 static/js/zamboni/stats-all.js:15378 static/js/zamboni/stats-min.js:5
+msgid "Browse Listing Popular Sort"
+msgstr ""
+
+#: static/js/impala/stats/csv_keys.js:98 static/js/impala/stats/csv_keys.js:99 static/js/zamboni/stats-all.js:15379 static/js/zamboni/stats-all.js:15380 static/js/zamboni/stats-min.js:5
+msgid "Browse Listing Updated Sort"
+msgstr ""
+
+#: static/js/impala/stats/csv_keys.js:100 static/js/impala/stats/csv_keys.js:101 static/js/zamboni/stats-all.js:15381 static/js/zamboni/stats-all.js:15382 static/js/zamboni/stats-min.js:5
+msgid "Browse Listing Up and Coming Sort"
+msgstr ""
+
+#: static/js/impala/stats/csv_keys.js:105 static/js/zamboni/stats-all.js:15386 static/js/zamboni/stats-min.js:5
+msgid "Total Amount Contributed"
+msgstr ""
+
+#: static/js/impala/stats/csv_keys.js:106 static/js/zamboni/stats-all.js:15387 static/js/zamboni/stats-min.js:5
+msgid "Average Contribution"
+msgstr ""
+
+#: static/js/impala/stats/csv_keys.js:115 static/js/zamboni/stats-all.js:15396 static/js/zamboni/stats-min.js:5
+msgid "Usage"
+msgstr ""
+
+#: static/js/impala/stats/csv_keys.js:118 static/js/zamboni/stats-all.js:15399 static/js/zamboni/stats-min.js:5
+msgid "Firefox"
+msgstr ""
+
+#: static/js/impala/stats/csv_keys.js:119 static/js/zamboni/stats-all.js:15400 static/js/zamboni/stats-min.js:5
+msgid "Mozilla"
+msgstr ""
+
+#: static/js/impala/stats/csv_keys.js:120 static/js/zamboni/stats-all.js:15401 static/js/zamboni/stats-min.js:5
+msgid "Thunderbird"
+msgstr ""
+
+#: static/js/impala/stats/csv_keys.js:121 static/js/zamboni/stats-all.js:15402 static/js/zamboni/stats-min.js:5
+msgid "Sunbird"
+msgstr ""
+
+#: static/js/impala/stats/csv_keys.js:122 static/js/zamboni/stats-all.js:15403 static/js/zamboni/stats-min.js:5
+msgid "SeaMonkey"
+msgstr ""
+
+#: static/js/impala/stats/csv_keys.js:123 static/js/zamboni/stats-all.js:15404 static/js/zamboni/stats-min.js:5
+msgid "Fennec"
+msgstr ""
+
+#: static/js/impala/stats/csv_keys.js:124 static/js/zamboni/stats-all.js:15405 static/js/zamboni/stats-min.js:5
+msgid "Android"
+msgstr ""
+
+#. L10n: {0} is an integer.
+#: static/js/impala/stats/csv_keys.js:129 static/js/zamboni/stats-all.js:15410 static/js/zamboni/stats-min.js:5
+msgid "Downloads and Daily Users, last {0} days"
+msgstr ""
+
+#. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
+#: static/js/impala/stats/csv_keys.js:131 static/js/zamboni/stats-all.js:15412 static/js/zamboni/stats-min.js:5
+msgid "Downloads and Daily Users from {0} to {1}"
+msgstr ""
+
+#. L10n: {0} is an integer.
+#: static/js/impala/stats/csv_keys.js:135 static/js/zamboni/stats-all.js:15416 static/js/zamboni/stats-min.js:5
+msgid "Installs and Daily Users, last {0} days"
+msgstr ""
+
+#. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
+#: static/js/impala/stats/csv_keys.js:137 static/js/zamboni/stats-all.js:15418 static/js/zamboni/stats-min.js:5
+msgid "Installs and Daily Users from {0} to {1}"
+msgstr ""
+
+#. L10n: {0} is an integer.
+#: static/js/impala/stats/csv_keys.js:141 static/js/zamboni/stats-all.js:15422 static/js/zamboni/stats-min.js:5
+msgid "Downloads, last {0} days"
+msgstr ""
+
+#. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
+#: static/js/impala/stats/csv_keys.js:143 static/js/zamboni/stats-all.js:15424 static/js/zamboni/stats-min.js:5
+msgid "Downloads from {0} to {1}"
+msgstr ""
+
+#. L10n: {0} is an integer.
+#: static/js/impala/stats/csv_keys.js:147 static/js/zamboni/stats-all.js:15428 static/js/zamboni/stats-min.js:5
+msgid "Daily Users, last {0} days"
+msgstr ""
+
+#. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
+#: static/js/impala/stats/csv_keys.js:149 static/js/zamboni/stats-all.js:15430 static/js/zamboni/stats-min.js:5
+msgid "Daily Users from {0} to {1}"
+msgstr ""
+
+#. L10n: {0} is an integer.
+#: static/js/impala/stats/csv_keys.js:153 static/js/zamboni/stats-all.js:15434 static/js/zamboni/stats-min.js:5
+msgid "Applications, last {0} days"
+msgstr ""
+
+#. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
+#: static/js/impala/stats/csv_keys.js:155 static/js/zamboni/stats-all.js:15436 static/js/zamboni/stats-min.js:5
+msgid "Applications from {0} to {1}"
+msgstr ""
+
+#. L10n: {0} is an integer.
+#: static/js/impala/stats/csv_keys.js:159 static/js/zamboni/stats-all.js:15440 static/js/zamboni/stats-min.js:5
+msgid "Platforms, last {0} days"
+msgstr ""
+
+#. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
+#: static/js/impala/stats/csv_keys.js:161 static/js/zamboni/stats-all.js:15442 static/js/zamboni/stats-min.js:5
+msgid "Platforms from {0} to {1}"
+msgstr ""
+
+#. L10n: {0} is an integer.
+#: static/js/impala/stats/csv_keys.js:165 static/js/zamboni/stats-all.js:15446 static/js/zamboni/stats-min.js:5
+msgid "Languages, last {0} days"
+msgstr ""
+
+#. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
+#: static/js/impala/stats/csv_keys.js:167 static/js/zamboni/stats-all.js:15448 static/js/zamboni/stats-min.js:5
+msgid "Languages from {0} to {1}"
+msgstr ""
+
+#. L10n: {0} is an integer.
+#: static/js/impala/stats/csv_keys.js:171 static/js/zamboni/stats-all.js:15452 static/js/zamboni/stats-min.js:5
+msgid "Add-on Versions, last {0} days"
+msgstr ""
+
+#. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
+#: static/js/impala/stats/csv_keys.js:173 static/js/zamboni/stats-all.js:15454 static/js/zamboni/stats-min.js:5
+msgid "Add-on Versions from {0} to {1}"
+msgstr ""
+
+#. L10n: {0} is an integer.
+#: static/js/impala/stats/csv_keys.js:177 static/js/zamboni/stats-all.js:15458 static/js/zamboni/stats-min.js:5
+msgid "Add-on Status, last {0} days"
+msgstr ""
+
+#. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
+#: static/js/impala/stats/csv_keys.js:179 static/js/zamboni/stats-all.js:15460 static/js/zamboni/stats-min.js:5
+msgid "Add-on Status from {0} to {1}"
+msgstr ""
+
+#. L10n: {0} is an integer.
+#: static/js/impala/stats/csv_keys.js:183 static/js/zamboni/stats-all.js:15464 static/js/zamboni/stats-min.js:5
+msgid "Download Sources, last {0} days"
+msgstr ""
+
+#. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
+#: static/js/impala/stats/csv_keys.js:185 static/js/zamboni/stats-all.js:15466 static/js/zamboni/stats-min.js:5
+msgid "Download Sources from {0} to {1}"
+msgstr ""
+
+#. L10n: {0} is an integer.
+#: static/js/impala/stats/csv_keys.js:189 static/js/zamboni/stats-all.js:15470 static/js/zamboni/stats-min.js:5
+msgid "Contributions, last {0} days"
+msgstr ""
+
+#. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
+#: static/js/impala/stats/csv_keys.js:191 static/js/zamboni/stats-all.js:15472 static/js/zamboni/stats-min.js:5
+msgid "Contributions from {0} to {1}"
+msgstr ""
+
+#. L10n: {0} is an integer.
+#: static/js/impala/stats/csv_keys.js:195 static/js/zamboni/stats-all.js:15476 static/js/zamboni/stats-min.js:5
+msgid "Site Metrics, last {0} days"
+msgstr ""
+
+#. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
+#: static/js/impala/stats/csv_keys.js:197 static/js/zamboni/stats-all.js:15478 static/js/zamboni/stats-min.js:5
+msgid "Site Metrics from {0} to {1}"
+msgstr ""
+
+#. L10n: {0} is an integer.
+#: static/js/impala/stats/csv_keys.js:201 static/js/zamboni/stats-all.js:15482 static/js/zamboni/stats-min.js:5
+msgid "Add-ons in Use, last {0} days"
+msgstr ""
+
+#. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
+#: static/js/impala/stats/csv_keys.js:203 static/js/zamboni/stats-all.js:15484 static/js/zamboni/stats-min.js:5
+msgid "Add-ons in Use from {0} to {1}"
+msgstr ""
+
+#. L10n: {0} is an integer.
+#: static/js/impala/stats/csv_keys.js:207 static/js/zamboni/stats-all.js:15488 static/js/zamboni/stats-min.js:5
+msgid "Add-ons Downloaded, last {0} days"
+msgstr ""
+
+#. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
+#: static/js/impala/stats/csv_keys.js:209 static/js/zamboni/stats-all.js:15490 static/js/zamboni/stats-min.js:5
+msgid "Add-ons Downloaded from {0} to {1}"
+msgstr ""
+
+#. L10n: {0} is an integer.
+#: static/js/impala/stats/csv_keys.js:213 static/js/zamboni/stats-all.js:15494 static/js/zamboni/stats-min.js:5
+msgid "Add-ons Created, last {0} days"
+msgstr ""
+
+#. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
+#: static/js/impala/stats/csv_keys.js:215 static/js/zamboni/stats-all.js:15496 static/js/zamboni/stats-min.js:5
+msgid "Add-ons Created from {0} to {1}"
+msgstr ""
+
+#. L10n: {0} is an integer.
+#: static/js/impala/stats/csv_keys.js:219 static/js/zamboni/stats-all.js:15500 static/js/zamboni/stats-min.js:5
+msgid "Add-ons Updated, last {0} days"
+msgstr ""
+
+#. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
+#: static/js/impala/stats/csv_keys.js:221 static/js/zamboni/stats-all.js:15502 static/js/zamboni/stats-min.js:5
+msgid "Add-ons Updated from {0} to {1}"
+msgstr ""
+
+#. L10n: {0} is an integer.
+#: static/js/impala/stats/csv_keys.js:225 static/js/zamboni/stats-all.js:15506 static/js/zamboni/stats-min.js:5
+msgid "Reviews Written, last {0} days"
+msgstr ""
+
+#. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
+#: static/js/impala/stats/csv_keys.js:227 static/js/zamboni/stats-all.js:15508 static/js/zamboni/stats-min.js:5
+msgid "Reviews Written from {0} to {1}"
+msgstr ""
+
+#. L10n: {0} is an integer.
+#: static/js/impala/stats/csv_keys.js:231 static/js/zamboni/stats-all.js:15512 static/js/zamboni/stats-min.js:5
+msgid "User Signups, last {0} days"
+msgstr ""
+
+#. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
+#: static/js/impala/stats/csv_keys.js:233 static/js/zamboni/stats-all.js:15514 static/js/zamboni/stats-min.js:5
+msgid "User Signups from {0} to {1}"
+msgstr ""
+
+#. L10n: {0} is an integer.
+#: static/js/impala/stats/csv_keys.js:237 static/js/zamboni/stats-all.js:15518 static/js/zamboni/stats-min.js:5
+msgid "Collections Created, last {0} days"
+msgstr ""
+
+#. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
+#: static/js/impala/stats/csv_keys.js:239 static/js/zamboni/stats-all.js:15520 static/js/zamboni/stats-min.js:5
+msgid "Collections Created from {0} to {1}"
+msgstr ""
+
+#. L10n: {0} is an integer.
+#: static/js/impala/stats/csv_keys.js:243 static/js/zamboni/stats-all.js:15524 static/js/zamboni/stats-min.js:5
+msgid "Subscribers, last {0} days"
+msgstr ""
+
+#. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
+#: static/js/impala/stats/csv_keys.js:245 static/js/zamboni/stats-all.js:15526 static/js/zamboni/stats-min.js:5
+msgid "Subscribers from {0} to {1}"
+msgstr ""
+
+#. L10n: {0} is an integer.
+#: static/js/impala/stats/csv_keys.js:249 static/js/zamboni/stats-all.js:15530 static/js/zamboni/stats-min.js:5
+msgid "Ratings, last {0} days"
+msgstr ""
+
+#. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
+#: static/js/impala/stats/csv_keys.js:251 static/js/zamboni/stats-all.js:15532 static/js/zamboni/stats-min.js:5
+msgid "Ratings from {0} to {1}"
+msgstr ""
+
+#. L10n: {0} is an integer.
+#: static/js/impala/stats/csv_keys.js:255 static/js/zamboni/stats-all.js:15536 static/js/zamboni/stats-min.js:5
+msgid "Sales, last {0} days"
+msgstr ""
+
+#. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
+#: static/js/impala/stats/csv_keys.js:257 static/js/zamboni/stats-all.js:15538 static/js/zamboni/stats-min.js:5
+msgid "Sales from {0} to {1}"
+msgstr ""
+
+#. L10n: {0} is an integer.
+#: static/js/impala/stats/csv_keys.js:261 static/js/zamboni/stats-all.js:15542 static/js/zamboni/stats-min.js:5
+msgid "Installs, last {0} days"
+msgstr ""
+
+#. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
+#: static/js/impala/stats/csv_keys.js:263 static/js/zamboni/stats-all.js:15544 static/js/zamboni/stats-min.js:5
+msgid "Installs from {0} to {1}"
+msgstr ""
+
+#. L10n: {0} and {1} are integers.
+#: static/js/impala/stats/csv_keys.js:269 static/js/zamboni/stats-all.js:15550 static/js/zamboni/stats-min.js:5
+msgid "<b>{0}</b> in last {1} days"
+msgstr ""
+
+#. L10n: {0} is an integer and {1} and {2} are dates in YYYY-MM-DD format.
+#: static/js/impala/stats/csv_keys.js:271 static/js/impala/stats/csv_keys.js:277 static/js/zamboni/stats-all.js:15552 static/js/zamboni/stats-all.js:15558 static/js/zamboni/stats-min.js:5
+msgid "<b>{0}</b> from {1} to {2}"
+msgstr ""
+
+#. L10n: {0} and {1} are integers.
+#: static/js/impala/stats/csv_keys.js:275 static/js/zamboni/stats-all.js:15556 static/js/zamboni/stats-min.js:5
+msgid "<b>{0}</b> average in last {1} days"
+msgstr ""
+
+#: static/js/impala/stats/overview.js:19 static/js/zamboni/stats-all.js:16469 static/js/zamboni/stats-min.js:5
+msgid "No data available."
+msgstr ""
+
+#: static/js/impala/stats/table.js:74 static/js/zamboni/stats-all.js:17209 static/js/zamboni/stats-min.js:5
+msgid "Date"
+msgstr ""
+
+#: static/js/impala/stats/topchart.js:96 static/js/zamboni/stats-all.js:16600 static/js/zamboni/stats-min.js:5
+msgid "Other"
+msgstr "Bestelakoa"
+
+#: static/js/zamboni/admin-all.js:180 static/js/zamboni/admin-min.js:1 static/js/zamboni/admin_validation.js:24 static/js/zamboni/devhub-all.js:2408 static/js/zamboni/devhub-min.js:2
+#: static/js/zamboni/devhub.js:1229 static/js/zamboni/editors-all.js:15576 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:295
+msgid "Select an application first"
+msgstr "Hautatu aplikazioa lehenik"
+
+#: static/js/zamboni/admin-all.js:207 static/js/zamboni/admin-min.js:1 static/js/zamboni/admin_validation.js:51
+#, fuzzy
+msgid "Set {0} add-on to a max version of {1} and email the author."
+msgid_plural "Set {0} add-ons to a max version of {1} and email the authors."
+msgstr[0] "Ezarri {0} gehigarriari {1} bertsio maximoa eta bidali mezu elektronikoa egileari."
+msgstr[1] "Ezarri {0} gehigarriei {1} bertsio maximoa eta bidali mezu elektronikoa egileei."
+
+#: static/js/zamboni/admin-all.js:210 static/js/zamboni/admin-min.js:1 static/js/zamboni/admin_validation.js:54
+msgid "Email author of {2} add-on which failed validation."
+msgid_plural "Email authors of {2} add-ons which failed validation."
+msgstr[0] ""
+msgstr[1] ""
+
+#: static/js/zamboni/devhub-all.js:1289 static/js/zamboni/devhub-min.js:1 static/js/zamboni/devhub.js:110
+msgid "Your browser does not support the video tag"
+msgstr "Zure nabigatzaileak ez du 'video' etiketa onartzen"
+
+#: static/js/zamboni/devhub-all.js:1550 static/js/zamboni/devhub-min.js:1 static/js/zamboni/devhub.js:371
+msgid "Changes Saved"
+msgstr "Aldaketak gordeta"
+
+#: static/js/zamboni/devhub-all.js:1566 static/js/zamboni/devhub-min.js:1 static/js/zamboni/devhub.js:387
+msgid "Enter a new author's email address"
+msgstr "Idatzi egile berriaren helbide elektronikoa"
+
+#: static/js/zamboni/devhub-all.js:1715 static/js/zamboni/devhub-min.js:1 static/js/zamboni/devhub.js:536
+msgid "There was an error uploading your file."
+msgstr "Errorea gertatu da fitxategia igotzean."
+
+#: static/js/zamboni/devhub-all.js:1860 static/js/zamboni/devhub-min.js:1 static/js/zamboni/devhub.js:681
+msgid "{files} file"
+msgid_plural "{files} files"
+msgstr[0] "Fitxategi bat"
+msgstr[1] "{files} fitxategi"
+
+#: static/js/zamboni/devhub-all.js:1863 static/js/zamboni/devhub-min.js:1 static/js/zamboni/devhub.js:684
+msgid "{reviews} user review"
+msgid_plural "{reviews} user reviews"
+msgstr[0] ""
+msgstr[1] ""
+
+#: static/js/zamboni/devhub-all.js:1975 static/js/zamboni/devhub-min.js:2 static/js/zamboni/devhub.js:796
+msgid "Learn more"
+msgstr "Argibide gehiago"
+
+#: static/js/zamboni/devhub-all.js:1979 static/js/zamboni/devhub-min.js:2 static/js/zamboni/devhub.js:800
+msgid "Example"
+msgstr "Adibidea"
+
+#: static/js/zamboni/devhub-all.js:2309 static/js/zamboni/devhub-min.js:2 static/js/zamboni/devhub.js:1130
+msgid "Image changes being processed"
+msgstr "Irudi-aldaketak prozesatzen ari dira"
+
+#: static/js/zamboni/devhub-all.js:2459 static/js/zamboni/devhub-min.js:2 static/js/zamboni/devhub.js:1280
+msgid "Must be a valid e-mail address."
+msgstr ""
+
+#: static/js/zamboni/devhub-all.js:2613 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:80
 msgid "All tests passed successfully."
 msgstr "Proba guztiak ondo pasa dira."
 
-#: static/js/zamboni/validator.js:83 static/js/zamboni/validator.js:478
+#: static/js/zamboni/devhub-all.js:2616 static/js/zamboni/devhub-all.js:3011 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:83 static/js/zamboni/validator.js:478
 msgid "These tests were not run."
 msgstr "Probak ez dira exekutatu."
 
-#: static/js/zamboni/validator.js:131 static/js/zamboni/validator.js:144
+#: static/js/zamboni/devhub-all.js:2664 static/js/zamboni/devhub-all.js:2677 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:131 static/js/zamboni/validator.js:144
 msgid "Tests"
 msgstr "Probak"
 
-#: static/js/zamboni/validator.js:246 static/js/zamboni/validator.js:575
-#: static/js/zamboni/validator.js:594
+#: static/js/zamboni/devhub-all.js:2779 static/js/zamboni/devhub-all.js:3108 static/js/zamboni/devhub-all.js:3127 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:246
+#: static/js/zamboni/validator.js:575 static/js/zamboni/validator.js:594
 msgid "Error"
 msgstr "Errorea"
 
-#: static/js/zamboni/validator.js:247
+#: static/js/zamboni/devhub-all.js:2780 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:247
 msgid "Warning"
 msgstr "Abisua"
 
-#: static/js/zamboni/validator.js:299
+#: static/js/zamboni/devhub-all.js:2794 static/js/zamboni/devhub-min.js:2 static/js/zamboni/files-all.js:5657 static/js/zamboni/files-min.js:3 static/js/zamboni/files.js:411
+#: static/js/zamboni/validator.js:261
+msgid "Ignore this message in future updates"
+msgstr ""
+
+#: static/js/zamboni/devhub-all.js:2817 static/js/zamboni/devhub-min.js:2 static/js/zamboni/files-all.js:5663 static/js/zamboni/files-min.js:3 static/js/zamboni/files.js:417
+#: static/js/zamboni/validator.js:284
+msgid "Severity for automated signing:"
+msgstr ""
+
+#: static/js/zamboni/devhub-all.js:2832 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:299
 msgid "Suggestions for passing automated signing:"
 msgstr ""
 
-#: static/js/zamboni/validator.js:387
+#: static/js/zamboni/devhub-all.js:2920 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:387
 msgid "Compatibility Tests"
 msgstr "Bateragarritasun-probak"
 
-#: static/js/zamboni/validator.js:466
+#: static/js/zamboni/devhub-all.js:2999 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:466
 msgid "Add-on failed validation."
 msgstr "Gehigarriaren balidazioak huts egin du."
 
-#: static/js/zamboni/validator.js:468
+#: static/js/zamboni/devhub-all.js:3001 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:468
 msgid "Add-on passed validation."
 msgstr "Gehigarriak balidazioa pasa du."
 
-#: static/js/zamboni/validator.js:481
+#: static/js/zamboni/devhub-all.js:3014 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:481
 msgid "{0} error"
 msgid_plural "{0} errors"
 msgstr[0] "Errore bat"
 msgstr[1] "{0} errore"
 
-#: static/js/zamboni/validator.js:483
+#: static/js/zamboni/devhub-all.js:3016 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:483
 msgid "{0} warning"
 msgid_plural "{0} warnings"
 msgstr[0] "Abisu bat"
 msgstr[1] "{0} abisu"
 
-#: static/js/zamboni/validator.js:485
+#: static/js/zamboni/devhub-all.js:3018 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:485
 msgid "{0} notice"
 msgid_plural "{0} notices"
 msgstr[0] ""
 msgstr[1] ""
 
-#: static/js/zamboni/validator.js:577
+#: static/js/zamboni/devhub-all.js:3110 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:577
 msgid "Validation task could not complete or completed with errors"
 msgstr "Ezin izan da balidazio-ataza burutu edo erroreekin burutu da"
 
-#: static/js/zamboni/validator.js:595
+#: static/js/zamboni/devhub-all.js:3128 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:595
 msgid "Internal server error"
 msgstr "Zerbitzariaren barne-errorea"
 
-#: static/js/zamboni/mobile/buttons.js:52
+#: static/js/zamboni/devhub_search.js:8
+msgid "No results found."
+msgstr ""
+
+#: static/js/zamboni/editors-all.js:15402 static/js/zamboni/editors-min.js:4 static/js/zamboni/editors.js:121
+msgid "{name} was viewing this page first."
+msgstr "{name} ari zen orri hau ikusten aurrena."
+
+#: static/js/zamboni/editors-all.js:15452 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:171
+msgid "Receipt checked by app."
+msgstr ""
+
+#: static/js/zamboni/editors-all.js:15454 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:173
+msgid "Receipt was not checked by app."
+msgstr ""
+
+#: static/js/zamboni/editors-all.js:15525 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:244
+msgid "{name} was viewing this add-on first."
+msgstr ""
+
+#: static/js/zamboni/editors-all.js:15536 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:255
+msgid "Loading&hellip;"
+msgstr "Kargatzen&hellip;"
+
+#: static/js/zamboni/editors-all.js:15541 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:260
+msgid "Version Notes"
+msgstr ""
+
+#: static/js/zamboni/editors-all.js:15546 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:265
+msgid "Notes for Reviewers"
+msgstr ""
+
+#: static/js/zamboni/editors-all.js:15551 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:270
+msgid "No version notes found"
+msgstr "Ez da bertsio-oharrik aurkitu"
+
+#: static/js/zamboni/editors-all.js:15611 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:330
+msgid "Average Reviews"
+msgstr ""
+
+#: static/js/zamboni/editors-all.js:15667 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:386
+msgid "Number of Reviews"
+msgstr ""
+
+#: static/js/zamboni/editors-all.js:15726 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:445
+msgid "Error loading translation"
+msgstr ""
+
+#: static/js/zamboni/editors-all.js:15975 static/js/zamboni/editors-min.js:5 static/js/zamboni/themes_review_templates.js:31
+msgid "Theme"
+msgstr ""
+
+#: static/js/zamboni/editors-all.js:15977 static/js/zamboni/editors-min.js:5 static/js/zamboni/themes_review_templates.js:33
+msgid "Reviewer"
+msgstr ""
+
+#: static/js/zamboni/editors-all.js:15979 static/js/zamboni/editors-min.js:5 static/js/zamboni/themes_review_templates.js:35
+msgid "Status"
+msgstr ""
+
+#: static/js/zamboni/editors-all.js:16196 static/js/zamboni/editors-min.js:5 static/js/zamboni/themes_review.js:176
+msgid "Requested Info"
+msgstr ""
+
+#: static/js/zamboni/editors-all.js:16197 static/js/zamboni/editors-min.js:5 static/js/zamboni/themes_review.js:177
+msgid "Flagged"
+msgstr ""
+
+#: static/js/zamboni/editors-all.js:16198 static/js/zamboni/editors-min.js:5 static/js/zamboni/themes_review.js:178
+msgid "Duplicate"
+msgstr ""
+
+#: static/js/zamboni/editors-all.js:16199 static/js/zamboni/editors-min.js:5 static/js/zamboni/themes_review.js:179
+msgid "Rejected"
+msgstr ""
+
+#: static/js/zamboni/editors-all.js:16200 static/js/zamboni/editors-min.js:5 static/js/zamboni/themes_review.js:180
+msgid "Approved"
+msgstr ""
+
+#: static/js/zamboni/editors-all.js:16444 static/js/zamboni/editors-min.js:5 static/js/zamboni/themes_review.js:424
+msgid "No results found"
+msgstr ""
+
+#: static/js/zamboni/mobile-all.js:15186 static/js/zamboni/mobile/buttons.js:52
 msgid "Not Updated for {0} {1}"
 msgstr "Eguneratu gabe {0} {1}(e)rako"
 
-#: static/js/zamboni/mobile/buttons.js:53
+#: static/js/zamboni/mobile-all.js:15187 static/js/zamboni/mobile/buttons.js:53
 msgid "Requires Newer Version of {0}"
 msgstr "{0}(r)en bertsio berriagoa eskatzen du"
 
-#: static/js/zamboni/mobile/buttons.js:54
+#: static/js/zamboni/mobile-all.js:15188 static/js/zamboni/mobile/buttons.js:54
 msgid "Unreviewed"
 msgstr "Berrikusi gabea"
 
-#: static/js/zamboni/mobile/buttons.js:55
+#: static/js/zamboni/mobile-all.js:15189 static/js/zamboni/mobile/buttons.js:55
 msgid "Experimental <span>(Learn More)</span>"
 msgstr "Esperimentala <span>(argibide gehiago)</span>"
 
-#: static/js/zamboni/mobile/buttons.js:56
-#: static/js/zamboni/mobile/buttons.js:57
+#: static/js/zamboni/mobile-all.js:15190 static/js/zamboni/mobile-all.js:15191 static/js/zamboni/mobile/buttons.js:56 static/js/zamboni/mobile/buttons.js:57
 msgid "Not Available for {0}"
 msgstr "Ez dago eskuragarri {0}(e)rako"
 
-#: static/js/zamboni/mobile/buttons.js:58
+#: static/js/zamboni/mobile-all.js:15192 static/js/zamboni/mobile/buttons.js:58
 msgid "Experimental"
 msgstr "Esperimentala"
 
-#: static/js/zamboni/mobile/buttons.js:59
+#: static/js/zamboni/mobile-all.js:15193 static/js/zamboni/mobile/buttons.js:59
 msgid "Themes Require Newer Version of {0}"
 msgstr ""
 
-#: static/js/zamboni/mobile/buttons.js:60
+#: static/js/zamboni/mobile-all.js:15194 static/js/zamboni/mobile/buttons.js:60
 msgid "Themes Require {0}"
 msgstr ""
 
-#: static/js/zamboni/mobile/buttons.js:105
+#: static/js/zamboni/mobile-all.js:15239 static/js/zamboni/mobile/buttons.js:105
 msgid "Installing..."
 msgstr ""
 
-#: static/js/zamboni/mobile/buttons.js:125
+#: static/js/zamboni/mobile-all.js:15259 static/js/zamboni/mobile/buttons.js:125
 msgid "This add-on has been preliminarily reviewed by Mozilla."
 msgstr "Gehigarri hau aurretik Mozilla berrikusi du."
 
-#: static/js/zamboni/mobile/buttons.js:250
+#: static/js/zamboni/mobile-all.js:15384 static/js/zamboni/mobile/buttons.js:250
 msgid "Keep it"
 msgstr "Mantendu"
 
-#: static/js/zamboni/mobile/general.js:344
+#: static/js/zamboni/mobile-all.js:16049 static/js/zamboni/mobile-min.js:6 static/js/zamboni/mobile/general.js:344
 msgid "You're trying it on!"
 msgstr "Saiatzen ari zara!"
 
-#: static/js/zamboni/mobile/general.js:356
+#: static/js/zamboni/mobile-all.js:16061 static/js/zamboni/mobile-min.js:6 static/js/zamboni/mobile/general.js:356
 msgid "Added to Firefox"
 msgstr "Firefoxera gehituta"

--- a/locale/fa/LC_MESSAGES/django.po
+++ b/locale/fa/LC_MESSAGES/django.po
@@ -3,69 +3,70 @@ msgid ""
 msgstr ""
 "Project-Id-Version:  addons.mozilla.org\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2016-02-24 21:23+0000\n"
+"POT-Creation-Date: 2016-04-18 15:47+0000\n"
 "PO-Revision-Date: 2014-11-04 11:24+0000\n"
 "Last-Translator: Amir <amir_farsi@ymail.com>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
+"Language: \n"
 "MIME-Version: 1.0\n"
-"Content-Type: text/plain; charset=utf-8\n"
+"Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Generated-By: Babel 2.2.0\n"
 
-#: src/olympia/accounts/views.py:52
+#: src/olympia/accounts/views.py:54
 msgid "Your log in attempt could not be parsed. Please try again."
 msgstr ""
 
-#: src/olympia/accounts/views.py:54
+#: src/olympia/accounts/views.py:56
 msgid "Your Firefox Account could not be found. Please try again."
 msgstr ""
 
-#: src/olympia/accounts/views.py:55
+#: src/olympia/accounts/views.py:57
 msgid "You could not be logged in. Please try again."
 msgstr ""
 
-#: src/olympia/accounts/views.py:57
+#: src/olympia/accounts/views.py:59
 msgid "Your account has already been migrated to Firefox Accounts."
 msgstr ""
 
-#: src/olympia/accounts/views.py:59
+#: src/olympia/accounts/views.py:61
 msgid "Your Firefox Account already exists on this site."
 msgstr ""
 
-#: src/olympia/accounts/views.py:108
+#: src/olympia/accounts/views.py:110
 msgid "Great job!"
 msgstr ""
 
-#: src/olympia/accounts/views.py:109
+#: src/olympia/accounts/views.py:111
 msgid "You can now log in to Add-ons with your Firefox Account."
 msgstr ""
 
-#: src/olympia/accounts/views.py:121
+#: src/olympia/accounts/views.py:123
 msgid "Need help?"
 msgstr ""
 
-#: src/olympia/addons/buttons.py:180
+#: src/olympia/addons/buttons.py:177
 msgid "Download Now"
 msgstr "هم‌اکنون بارگیری کن"
 
-#: src/olympia/addons/buttons.py:182
+#: src/olympia/addons/buttons.py:179
 msgid "Download"
 msgstr "بارگیری‌"
 
 #. L10n: please keep &nbsp; in the string so &rarr; does not wrap.
-#: src/olympia/addons/buttons.py:186
+#: src/olympia/addons/buttons.py:183
 msgid "Continue to Download&nbsp;&rarr;"
 msgstr "برو به دانلود&nbsp;&rarr;"
 
-#: src/olympia/addons/buttons.py:202 src/olympia/addons/helpers.py:35 src/olympia/addons/views.py:319 src/olympia/addons/templates/addons/impala/details.html:114
+#: src/olympia/addons/buttons.py:199 src/olympia/addons/helpers.py:35 src/olympia/addons/views.py:333 src/olympia/addons/templates/addons/impala/details.html:111
 #: src/olympia/addons/templates/addons/impala/listing/items.html:17 src/olympia/addons/templates/addons/mobile/home.html:40 src/olympia/amo/templates/amo/side_nav.html:6
-#: src/olympia/amo/templates/amo/side_nav.html:10 src/olympia/amo/templates/amo/site_nav.html:2 src/olympia/amo/templates/amo/site_nav.html:55 src/olympia/bandwagon/views.py:95
-#: src/olympia/browse/views.py:54 src/olympia/browse/views.py:68 src/olympia/browse/views.py:235 src/olympia/browse/templates/browse/impala/category_landing.html:22
+#: src/olympia/amo/templates/amo/side_nav.html:10 src/olympia/amo/templates/amo/site_nav.html:2 src/olympia/amo/templates/amo/site_nav.html:53 src/olympia/bandwagon/views.py:95
+#: src/olympia/browse/views.py:54 src/olympia/browse/views.py:68 src/olympia/browse/views.py:202 src/olympia/browse/templates/browse/impala/category_landing.html:22
 #: src/olympia/browse/templates/browse/personas/mobile/category_landing.html:26
 msgid "Featured"
 msgstr "ویژه"
 
-#: src/olympia/addons/buttons.py:221
+#: src/olympia/addons/buttons.py:218
 msgid "Add to {0}"
 msgstr "افزودن به {0}"
 
@@ -88,17 +89,20 @@ msgstr ""
 msgid "Invalid tag: {0}"
 msgid_plural "Invalid tags: {0}"
 msgstr[0] ""
+msgstr[1] ""
 
 #. L10n: {0} is a single tag or a comma-separated list of tags.
 #: src/olympia/addons/forms.py:103
 msgid "\"{0}\" is a reserved tag and cannot be used."
 msgid_plural "\"{0}\" are reserved tags and cannot be used."
 msgstr[0] ""
+msgstr[1] ""
 
 #: src/olympia/addons/forms.py:111
 msgid "You have {0} too many tags."
 msgid_plural "You have {0} too many tags."
 msgstr[0] ""
+msgstr[1] ""
 
 #: src/olympia/addons/forms.py:117
 #, python-format
@@ -109,39 +113,41 @@ msgstr "بعد از حذف کاراکترهای ممنوع، برچسب ها ه�
 msgid "All tags must be at least {0} character."
 msgid_plural "All tags must be at least {0} characters."
 msgstr[0] ""
+msgstr[1] ""
 
-#: src/olympia/addons/forms.py:234
+#: src/olympia/addons/forms.py:238
 msgid "Categories cannot be changed while your add-on is featured for this application."
 msgstr ""
 
 #. L10n: {0} is the number of categories.
-#: src/olympia/addons/forms.py:238
+#: src/olympia/addons/forms.py:242
 msgid "You can have only {0} category."
 msgid_plural "You can have only {0} categories."
 msgstr[0] ""
+msgstr[1] ""
 
-#: src/olympia/addons/forms.py:246
+#: src/olympia/addons/forms.py:250
 msgid "The miscellaneous category cannot be combined with additional categories."
 msgstr ""
 
-#: src/olympia/addons/forms.py:369
+#: src/olympia/addons/forms.py:374
 #, python-format
 msgid "Before changing your default locale you must have a name, summary, and description in that locale. You are missing %s."
 msgstr ""
 
-#: src/olympia/addons/forms.py:484 src/olympia/addons/forms.py:575
+#: src/olympia/addons/forms.py:455 src/olympia/addons/forms.py:546
 msgid "A license must be selected."
 msgstr "باید حتما یک مجوز انتخاب کنید."
 
-#: src/olympia/addons/forms.py:556
+#: src/olympia/addons/forms.py:527
 msgid "Give Your Theme a Name."
 msgstr ""
 
-#: src/olympia/addons/forms.py:562 src/olympia/devhub/templates/devhub/personas/submit.html:53
+#: src/olympia/addons/forms.py:533 src/olympia/devhub/templates/devhub/personas/submit.html:53
 msgid "Describe your Theme."
 msgstr ""
 
-#: src/olympia/addons/forms.py:704
+#: src/olympia/addons/forms.py:675
 msgid "Enter a new author's email address"
 msgstr ""
 
@@ -149,39 +155,39 @@ msgstr ""
 msgid "Not Reviewed"
 msgstr "بازبینی نشده"
 
-#: src/olympia/addons/models.py:301
+#: src/olympia/addons/models.py:298
 msgid "Users have the option of contributing more or less than this amount."
 msgstr ""
 
-#: src/olympia/addons/models.py:309
-msgid "Users will always be asked in the Add-ons Manager (Firefox 4 and above)"
+#: src/olympia/addons/models.py:306
+msgid "Users will always be asked in the Add-ons Manager (Firefox 4 and above). Only applies to desktop."
 msgstr ""
 
 # Column name in a table.
-#: src/olympia/addons/models.py:1804 src/olympia/addons/templates/addons/details_box.html:55 src/olympia/devhub/templates/devhub/index.html:92
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:102
+#: src/olympia/addons/models.py:1802 src/olympia/addons/templates/addons/details_box.html:55 src/olympia/devhub/templates/devhub/index.html:92
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:89
 msgid "Listed"
 msgstr "فهرست شده"
 
-#: src/olympia/addons/views.py:320 src/olympia/browse/templates/browse/personas/mobile/category_landing.html:27
+#: src/olympia/addons/views.py:334 src/olympia/browse/templates/browse/personas/mobile/category_landing.html:27
 msgid "Popular"
 msgstr ""
 
-#: src/olympia/addons/views.py:321 src/olympia/browse/views.py:238 src/olympia/browse/views.py:280 src/olympia/browse/views.py:482
+#: src/olympia/addons/views.py:335 src/olympia/browse/views.py:205 src/olympia/browse/views.py:247 src/olympia/browse/views.py:449
 msgid "Recently Added"
 msgstr "به تازگی افزوده شده"
 
-#: src/olympia/addons/views.py:322 src/olympia/bandwagon/views.py:99 src/olympia/browse/views.py:60 src/olympia/browse/views.py:71 src/olympia/search/forms.py:16 src/olympia/search/forms.py:91
+#: src/olympia/addons/views.py:336 src/olympia/bandwagon/views.py:99 src/olympia/browse/views.py:60 src/olympia/browse/views.py:71 src/olympia/search/forms.py:16 src/olympia/search/forms.py:91
 msgid "Recently Updated"
 msgstr "به تازگی به روز رسانی شده"
 
 # %1 is an add-on name.
 #. l10n: {0} is the addon name
-#: src/olympia/addons/views.py:520
+#: src/olympia/addons/views.py:534
 msgid "Contribution for {0}"
 msgstr "مشارکت در {0}"
 
-#: src/olympia/addons/views.py:613
+#: src/olympia/addons/views.py:627
 msgid "Abuse reported."
 msgstr "سوء استفاده گزارش شد."
 
@@ -251,9 +257,9 @@ msgstr "مشارکت"
 #: src/olympia/devhub/templates/devhub/addons/ajax_compat_update.html:36 src/olympia/devhub/templates/devhub/addons/profile.html:44 src/olympia/devhub/templates/devhub/addons/edit/admin.html:101
 #: src/olympia/devhub/templates/devhub/addons/edit/basic.html:152 src/olympia/devhub/templates/devhub/addons/edit/details.html:85 src/olympia/devhub/templates/devhub/addons/edit/support.html:67
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:166 src/olympia/devhub/templates/devhub/addons/forms_shared/media.html:149
-#: src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:44 src/olympia/devhub/templates/devhub/versions/add_file_modal.html:78 src/olympia/devhub/templates/devhub/versions/edit.html:139
-#: src/olympia/devhub/templates/devhub/versions/list.html:242 src/olympia/devhub/templates/devhub/versions/list.html:276 src/olympia/devhub/templates/devhub/versions/list.html:317
-#: src/olympia/devhub/templates/devhub/versions/list.html:351 src/olympia/reviews/templates/reviews/edit_review.html:16 src/olympia/translations/templates/translations/trans-menu.html:50
+#: src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:43 src/olympia/devhub/templates/devhub/versions/add_file_modal.html:58 src/olympia/devhub/templates/devhub/versions/edit.html:139
+#: src/olympia/devhub/templates/devhub/versions/list.html:239 src/olympia/devhub/templates/devhub/versions/list.html:281 src/olympia/devhub/templates/devhub/versions/list.html:315
+#: src/olympia/devhub/templates/devhub/versions/list.html:349 src/olympia/reviews/templates/reviews/edit_review.html:16 src/olympia/translations/templates/translations/trans-menu.html:50
 #: src/olympia/translations/templates/translations/trans-menu.html:62
 msgid "or"
 msgstr "یا"
@@ -365,7 +371,7 @@ msgid "Add-on Information for {0}"
 msgstr ""
 
 #: src/olympia/addons/templates/addons/details_box.html:30 src/olympia/addons/templates/addons/persona_detail_table.html:3 src/olympia/addons/templates/addons/mobile/details.html:63
-#: src/olympia/addons/templates/addons/mobile/persona_detail_table.html:7 src/olympia/browse/views.py:459 src/olympia/devhub/views.py:75
+#: src/olympia/addons/templates/addons/mobile/persona_detail_table.html:7 src/olympia/browse/views.py:426 src/olympia/devhub/views.py:73
 msgid "Updated"
 msgstr "به‌هنگام شده"
 
@@ -384,11 +390,11 @@ msgstr "با این برنامه‌ها کار می‌کند"
 msgid "Visibility"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/details_box.html:57 src/olympia/devhub/templates/devhub/index.html:94 src/olympia/devhub/templates/devhub/includes/addon_details.html:104
+#: src/olympia/addons/templates/addons/details_box.html:57 src/olympia/devhub/templates/devhub/index.html:94 src/olympia/devhub/templates/devhub/includes/addon_details.html:91
 msgid "Hidden"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/details_box.html:59 src/olympia/devhub/templates/devhub/index.html:96 src/olympia/devhub/templates/devhub/includes/addon_details.html:106
+#: src/olympia/addons/templates/addons/details_box.html:59 src/olympia/devhub/templates/devhub/index.html:96 src/olympia/devhub/templates/devhub/includes/addon_details.html:93
 msgid "Unlisted"
 msgstr ""
 
@@ -397,14 +403,14 @@ msgid "Required Add-ons"
 msgstr ""
 
 # 100%
-#: src/olympia/addons/templates/addons/details_box.html:81 src/olympia/addons/templates/addons/persona_detail_table.html:15 src/olympia/browse/views.py:462 src/olympia/devhub/views.py:78
-#: src/olympia/devhub/views.py:85 src/olympia/discovery/templates/discovery/addons/detail.html:57 src/olympia/reviews/forms.py:62 src/olympia/reviews/templates/reviews/add.html:57
+#: src/olympia/addons/templates/addons/details_box.html:81 src/olympia/addons/templates/addons/persona_detail_table.html:15 src/olympia/browse/views.py:429 src/olympia/devhub/views.py:76
+#: src/olympia/devhub/views.py:83 src/olympia/discovery/templates/discovery/addons/detail.html:57 src/olympia/reviews/forms.py:62 src/olympia/reviews/templates/reviews/add.html:57
 #: src/olympia/reviews/templates/reviews/mobile/review_list.html:18
 msgid "Rating"
 msgstr "رتبه"
 
 # 100%
-#: src/olympia/addons/templates/addons/details_box.html:85 src/olympia/browse/views.py:461 src/olympia/devhub/views.py:77 src/olympia/devhub/views.py:84
+#: src/olympia/addons/templates/addons/details_box.html:85 src/olympia/browse/views.py:428 src/olympia/devhub/views.py:75 src/olympia/devhub/views.py:82
 #: src/olympia/stats/templates/stats/addon_report_menu.html:8 src/olympia/stats/templates/stats/collection_report_menu.html:18
 msgid "Downloads"
 msgstr "بارگیری‌ها"
@@ -424,7 +430,7 @@ msgstr "گزارش‌های سوء استفاده"
 
 #. The Privacy Policy for this add-on.
 #: src/olympia/addons/templates/addons/details_box.html:121 src/olympia/addons/templates/addons/privacy.html:19 src/olympia/addons/templates/addons/privacy.html:23
-#: src/olympia/addons/templates/addons/impala/button.html:43 src/olympia/addons/templates/addons/impala/details.html:307 src/olympia/devhub/templates/devhub/includes/policy_form.html:20
+#: src/olympia/addons/templates/addons/impala/button.html:43 src/olympia/addons/templates/addons/impala/details.html:312 src/olympia/devhub/templates/devhub/includes/policy_form.html:23
 #: src/olympia/templates/mobile/base_addons.html:87
 msgid "Privacy Policy"
 msgstr ""
@@ -450,7 +456,7 @@ msgstr "گالری تصاویر"
 msgid "Developer Comments"
 msgstr "توضیحات توسعه دهنده"
 
-#: src/olympia/addons/templates/addons/details_box.html:199 src/olympia/addons/templates/addons/impala/details.html:259
+#: src/olympia/addons/templates/addons/details_box.html:199 src/olympia/addons/templates/addons/impala/details.html:264
 msgid "Development Channel"
 msgstr ""
 
@@ -470,7 +476,7 @@ msgid ""
 "developer. To stop receiving development updates, reinstall the default version from the link above."
 msgstr ""
 
-#: src/olympia/addons/templates/addons/details_box.html:220 src/olympia/addons/templates/addons/impala/details.html:278
+#: src/olympia/addons/templates/addons/details_box.html:220 src/olympia/addons/templates/addons/impala/details.html:283
 msgid "Version {0}:"
 msgstr ""
 
@@ -490,7 +496,7 @@ msgid "End-User License Agreement for {0}"
 msgstr "توافق‌نامهٔ مجوز کاربر نهایی"
 
 #: src/olympia/addons/templates/addons/eula.html:17 src/olympia/addons/templates/addons/eula.html:21 src/olympia/addons/templates/addons/impala/button.html:48
-#: src/olympia/addons/templates/addons/impala/details.html:316 src/olympia/devhub/templates/devhub/includes/policy_form.html:3 src/olympia/discovery/templates/discovery/addons/eula.html:11
+#: src/olympia/addons/templates/addons/impala/details.html:321 src/olympia/devhub/templates/devhub/includes/policy_form.html:3 src/olympia/discovery/templates/discovery/addons/eula.html:11
 msgid "End-User License Agreement"
 msgstr "توافق‌نامهٔ مجوز کاربر نهایی"
 
@@ -510,7 +516,7 @@ msgstr ""
 msgid "Add-ons for {0}"
 msgstr "افزودنی‌های {0}"
 
-#: src/olympia/addons/templates/addons/home.html:10 src/olympia/addons/templates/addons/home.html:51 src/olympia/browse/templates/browse/impala/base_listing.html:11
+#: src/olympia/addons/templates/addons/home.html:10 src/olympia/addons/templates/addons/home.html:53 src/olympia/browse/templates/browse/impala/base_listing.html:11
 msgid "Featured Extensions"
 msgstr "ضمیمه‌های ویژه"
 
@@ -519,29 +525,29 @@ msgstr "ضمیمه‌های ویژه"
 msgid "Popular Extensions"
 msgstr "محبوب‌ترین ضمیمه‌ها"
 
-#: src/olympia/addons/templates/addons/home.html:42 src/olympia/amo/templates/amo/side_nav.html:3 src/olympia/amo/templates/amo/side_nav.html:11 src/olympia/amo/templates/amo/site_nav.html:3
-#: src/olympia/amo/templates/amo/site_nav.html:25 src/olympia/browse/views.py:236 src/olympia/browse/views.py:281 src/olympia/browse/views.py:481
+#: src/olympia/addons/templates/addons/home.html:44 src/olympia/amo/templates/amo/side_nav.html:3 src/olympia/amo/templates/amo/side_nav.html:11 src/olympia/amo/templates/amo/site_nav.html:3
+#: src/olympia/amo/templates/amo/site_nav.html:25 src/olympia/browse/views.py:203 src/olympia/browse/views.py:248 src/olympia/browse/views.py:448
 msgid "Most Popular"
 msgstr "محبوب‌ترین"
 
-#: src/olympia/addons/templates/addons/home.html:43
+#: src/olympia/addons/templates/addons/home.html:45
 msgid "All »"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/home.html:52 src/olympia/addons/templates/addons/home.html:61 src/olympia/addons/templates/addons/home.html:70 src/olympia/addons/templates/addons/home.html:78
+#: src/olympia/addons/templates/addons/home.html:54 src/olympia/addons/templates/addons/home.html:63 src/olympia/addons/templates/addons/home.html:72 src/olympia/addons/templates/addons/home.html:80
 #: src/olympia/browse/templates/browse/impala/category_landing.html:36
 msgid "See all »"
 msgstr "مشاهده همه »"
 
-#: src/olympia/addons/templates/addons/home.html:60
+#: src/olympia/addons/templates/addons/home.html:62
 msgid "Up &amp; Coming Extensions"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/home.html:69 src/olympia/browse/templates/browse/personas/category_landing.html:61 src/olympia/discovery/templates/discovery/pane.html:74
+#: src/olympia/addons/templates/addons/home.html:71 src/olympia/browse/templates/browse/personas/category_landing.html:61 src/olympia/discovery/templates/discovery/pane.html:74
 msgid "Featured Themes"
 msgstr "مضامین ویژه"
 
-#: src/olympia/addons/templates/addons/home.html:77 src/olympia/bandwagon/templates/bandwagon/impala/collection_listing.html:5
+#: src/olympia/addons/templates/addons/home.html:79 src/olympia/bandwagon/templates/bandwagon/impala/collection_listing.html:5
 msgid "Featured Collections"
 msgstr "مجموعه‌های ویژه"
 
@@ -559,7 +565,7 @@ msgid "Updated {0}"
 msgstr ""
 
 #. {0} is a date.
-#: src/olympia/addons/templates/addons/macros.html:10 src/olympia/addons/templates/addons/macros.html:69 src/olympia/addons/templates/addons/persona_preview.html:21
+#: src/olympia/addons/templates/addons/macros.html:10 src/olympia/addons/templates/addons/macros.html:69 src/olympia/addons/templates/addons/persona_preview.html:22
 #: src/olympia/addons/templates/addons/listing/items_mobile.html:44 src/olympia/addons/templates/addons/listing/macros.html:39
 #: src/olympia/bandwagon/templates/bandwagon/collection_listing_items.html:37 src/olympia/bandwagon/templates/bandwagon/impala/collection_listing_items.html:37
 msgid "Added {0}"
@@ -570,25 +576,28 @@ msgstr ""
 msgid "%(num)s weekly download"
 msgid_plural "%(num)s weekly downloads"
 msgstr[0] "%(num)s بارگیری هفگی"
+msgstr[1] ""
 
 #: src/olympia/addons/templates/addons/macros.html:28
 #, python-format
 msgid "%(num)s user"
 msgid_plural "%(num)s users"
 msgstr[0] ""
+msgstr[1] ""
 
 #. {0} is the number of downloads.
-#: src/olympia/addons/templates/addons/macros.html:53 src/olympia/addons/templates/addons/impala/details.html:61
+#: src/olympia/addons/templates/addons/macros.html:53 src/olympia/addons/templates/addons/impala/details.html:59
 msgid "{0} weekly download"
 msgid_plural "{0} weekly downloads"
 msgstr[0] "{0} بارگیری هفتگی"
+msgstr[1] ""
 
 #. {0} is the number of users.
-#: src/olympia/addons/templates/addons/macros.html:61 src/olympia/addons/templates/addons/impala/details.html:54 src/olympia/compat/templates/compat/index.html:71
-#: src/olympia/zadmin/templates/zadmin/compat.html:67
+#: src/olympia/addons/templates/addons/macros.html:61 src/olympia/addons/templates/addons/impala/details.html:52 src/olympia/zadmin/templates/zadmin/compat.html:67
 msgid "{0} user"
 msgid_plural "{0} users"
 msgstr[0] ""
+msgstr[1] ""
 
 #: src/olympia/addons/templates/addons/paypal_result.html:12
 msgid "Payment cancelled"
@@ -602,7 +611,7 @@ msgstr ""
 msgid "Return to the addon."
 msgstr ""
 
-#: src/olympia/addons/templates/addons/persona_detail.html:17 src/olympia/addons/templates/addons/impala/details.html:106 src/olympia/addons/templates/addons/mobile/details.html:23
+#: src/olympia/addons/templates/addons/persona_detail.html:17 src/olympia/addons/templates/addons/impala/details.html:103 src/olympia/addons/templates/addons/mobile/details.html:23
 #: src/olympia/addons/templates/addons/mobile/persona_detail.html:21 src/olympia/discovery/templates/discovery/addons/base.html:27 src/olympia/editors/templates/editors/review.html:31
 msgid "by"
 msgstr "توسط"
@@ -646,33 +655,35 @@ msgstr ""
 msgid "License"
 msgstr "مجوز"
 
-#: src/olympia/addons/templates/addons/persona_preview.html:12 src/olympia/constants/base.py:48
+#: src/olympia/addons/templates/addons/persona_preview.html:13 src/olympia/constants/base.py:48
 msgid "Awaiting Review"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/persona_preview.html:14 src/olympia/amo/log.py:180 src/olympia/constants/base.py:42 src/olympia/editors/helpers.py:62
+#: src/olympia/addons/templates/addons/persona_preview.html:15 src/olympia/amo/log.py:180 src/olympia/constants/base.py:42 src/olympia/editors/helpers.py:62
 msgid "Rejected"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/persona_preview.html:16 src/olympia/amo/log.py:159
+#: src/olympia/addons/templates/addons/persona_preview.html:17 src/olympia/amo/log.py:159
 msgid "Approved"
 msgstr ""
 
 #. {0} is the number of users.
-#: src/olympia/addons/templates/addons/persona_preview.html:26 src/olympia/addons/templates/addons/listing/items_mobile.html:36 src/olympia/addons/templates/addons/listing/macros.html:31
+#: src/olympia/addons/templates/addons/persona_preview.html:27 src/olympia/addons/templates/addons/listing/items_mobile.html:36 src/olympia/addons/templates/addons/listing/macros.html:31
 msgid "<strong>{0}</strong> user"
 msgid_plural "<strong>{0}</strong> users"
 msgstr[0] ""
+msgstr[1] ""
 
-#: src/olympia/addons/templates/addons/persona_preview.html:40
+#: src/olympia/addons/templates/addons/persona_preview.html:41
 msgid "Hover to Preview"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/persona_preview.html:46 src/olympia/addons/templates/addons/persona_preview.html:48 src/olympia/reviews/templates/reviews/add.html:15
+#: src/olympia/addons/templates/addons/persona_preview.html:47 src/olympia/addons/templates/addons/persona_preview.html:49 src/olympia/addons/templates/addons/persona_preview.html:97
+#: src/olympia/reviews/templates/reviews/add.html:15
 msgid "Add"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/persona_preview.html:57 src/olympia/bandwagon/templates/bandwagon/ajax_new.html:16 src/olympia/bandwagon/templates/bandwagon/edit.html:19
+#: src/olympia/addons/templates/addons/persona_preview.html:58 src/olympia/bandwagon/templates/bandwagon/ajax_new.html:16 src/olympia/bandwagon/templates/bandwagon/edit.html:19
 #: src/olympia/bandwagon/templates/bandwagon/includes/addedit.html:19 src/olympia/devhub/templates/devhub/addons/edit/admin.html:13 src/olympia/devhub/templates/devhub/addons/edit/basic.html:10
 #: src/olympia/devhub/templates/devhub/addons/edit/details.html:8 src/olympia/devhub/templates/devhub/addons/edit/media.html:6 src/olympia/devhub/templates/devhub/addons/edit/support.html:8
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:9 src/olympia/devhub/templates/devhub/addons/submit/describe.html:29 src/olympia/editors/templates/editors/review.html:257
@@ -681,21 +692,21 @@ msgstr ""
 
 #. For datetime formatting, see the table on
 #. http://docs.python.org/library/datetime.html#strftime-and-strptime-behavior
-#: src/olympia/addons/templates/addons/persona_preview.html:66
+#: src/olympia/addons/templates/addons/persona_preview.html:67
 #, python-format
 msgid "%%Y-%%m-%%d"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/persona_preview.html:67
+#: src/olympia/addons/templates/addons/persona_preview.html:68
 msgid "by {0} on {1}"
 msgstr "توسط {0} در تاریخ {1}"
 
-#: src/olympia/addons/templates/addons/persona_preview.html:75 src/olympia/reviews/helpers.py:17 src/olympia/reviews/templates/reviews/review_list.html:63
+#: src/olympia/addons/templates/addons/persona_preview.html:76 src/olympia/reviews/helpers.py:17 src/olympia/reviews/templates/reviews/review_list.html:63
 #: src/olympia/reviews/templates/reviews/reviews_link.html:21 src/olympia/reviews/templates/reviews/impala/reviews_link.html:16
 msgid "Not yet rated"
 msgstr "هنوز رتبه‌دهی نشده است"
 
-#: src/olympia/addons/templates/addons/persona_preview.html:78
+#: src/olympia/addons/templates/addons/persona_preview.html:79
 msgid "<b>{0}</b> users"
 msgstr ""
 
@@ -708,8 +719,8 @@ msgid "Learn more about Firefox"
 msgstr "درباره‌ی فایرفاکس بیشتر بدانید"
 
 #: src/olympia/addons/templates/addons/popups.html:22
-msgid "or <b><a class=\"installer\" href=\"{url}\">download anyway</a></b>"
-msgstr "یا <b><a class=\"installer\" href=\"{url}\">در هر صورت بارگیری کن</a></b>"
+msgid "or <b><a class=\"button installer\" href=\"{url}\">download anyway</a></b>"
+msgstr ""
 
 #: src/olympia/addons/templates/addons/popups.html:26
 msgid ""
@@ -807,7 +818,7 @@ msgid ""
 msgstr ""
 
 #: src/olympia/addons/templates/addons/report_abuse.html:6 src/olympia/addons/templates/addons/report_abuse_full.html:10 src/olympia/addons/templates/addons/impala/details-more.html:23
-#: src/olympia/addons/templates/addons/impala/details.html:328
+#: src/olympia/addons/templates/addons/impala/details.html:333
 msgid "Report Abuse"
 msgstr "گزارش سوء استفاده"
 
@@ -826,9 +837,9 @@ msgstr ""
 #: src/olympia/devhub/templates/devhub/addons/ajax_compat_update.html:36 src/olympia/devhub/templates/devhub/addons/profile.html:44 src/olympia/devhub/templates/devhub/addons/edit/admin.html:104
 #: src/olympia/devhub/templates/devhub/addons/edit/basic.html:155 src/olympia/devhub/templates/devhub/addons/edit/details.html:88 src/olympia/devhub/templates/devhub/addons/edit/support.html:70
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:169 src/olympia/devhub/templates/devhub/addons/forms_shared/media.html:152
-#: src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:44 src/olympia/devhub/templates/devhub/personas/edit.html:222 src/olympia/devhub/templates/devhub/versions/add_file_modal.html:79
-#: src/olympia/devhub/templates/devhub/versions/edit.html:140 src/olympia/devhub/templates/devhub/versions/list.html:208 src/olympia/devhub/templates/devhub/versions/list.html:242
-#: src/olympia/devhub/templates/devhub/versions/list.html:276 src/olympia/devhub/templates/devhub/versions/list.html:317 src/olympia/reviews/templates/reviews/edit_review.html:16
+#: src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:43 src/olympia/devhub/templates/devhub/personas/edit.html:222 src/olympia/devhub/templates/devhub/versions/add_file_modal.html:59
+#: src/olympia/devhub/templates/devhub/versions/edit.html:140 src/olympia/devhub/templates/devhub/versions/list.html:208 src/olympia/devhub/templates/devhub/versions/list.html:239
+#: src/olympia/devhub/templates/devhub/versions/list.html:281 src/olympia/devhub/templates/devhub/versions/list.html:315 src/olympia/reviews/templates/reviews/edit_review.html:16
 #: src/olympia/translations/templates/translations/trans-menu.html:50 src/olympia/translations/templates/translations/trans-menu.html:62 src/olympia/zadmin/templates/zadmin/validation.html:105
 msgid "Cancel"
 msgstr ""
@@ -875,7 +886,7 @@ msgstr ""
 msgid "Review Guidelines"
 msgstr "رهنمون‌های بررسی"
 
-#: src/olympia/addons/templates/addons/review_list_box.html:5 src/olympia/addons/templates/addons/impala/details-more.html:27 src/olympia/editors/helpers.py:921
+#: src/olympia/addons/templates/addons/review_list_box.html:5 src/olympia/addons/templates/addons/impala/details-more.html:27 src/olympia/editors/helpers.py:1001
 #: src/olympia/reviews/templates/reviews/add.html:14 src/olympia/reviews/templates/reviews/reply.html:14 src/olympia/reviews/templates/reviews/review_list.html:19
 #: src/olympia/reviews/templates/reviews/mobile/review_list.html:26
 msgid "Reviews"
@@ -895,6 +906,7 @@ msgstr ""
 msgid "See all reviews of this add-on"
 msgid_plural "See all %(cnt)s reviews of this add-on"
 msgstr[0] ""
+msgstr[1] ""
 
 # 100%
 #: src/olympia/addons/templates/addons/tags_box.html:3 src/olympia/devhub/templates/devhub/addons/edit/basic.html:118
@@ -964,121 +976,124 @@ msgstr "بخشی از این مجموعه‌ها"
 msgid "Other add-ons by %(author)s"
 msgid_plural "Other add-ons by these authors"
 msgstr[0] "سایر افزودنی‌ها توسط %(author)s"
+msgstr[1] ""
 
-#: src/olympia/addons/templates/addons/impala/details.html:41
+#: src/olympia/addons/templates/addons/impala/details.html:39
 #, python-format
 msgid "<span itemprop=\"ratingCount\">%(num)s</span> user review"
 msgid_plural "<span itemprop=\"ratingCount\">%(num)s</span> user reviews"
 msgstr[0] ""
+msgstr[1] ""
 
-#: src/olympia/addons/templates/addons/impala/details.html:69
+#: src/olympia/addons/templates/addons/impala/details.html:66
 #, fuzzy
 msgid "View statistics"
 msgstr "آمار مشاهده"
 
-#: src/olympia/addons/templates/addons/impala/details.html:84
+#: src/olympia/addons/templates/addons/impala/details.html:81
 msgid "Manage"
 msgstr ""
 
 #. {0} is an add-on name.
-#: src/olympia/addons/templates/addons/impala/details.html:96
+#: src/olympia/addons/templates/addons/impala/details.html:93
 msgid "Icon of {0}"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/impala/details.html:103 src/olympia/addons/templates/addons/impala/listing/items.html:14
+#: src/olympia/addons/templates/addons/impala/details.html:100 src/olympia/addons/templates/addons/impala/listing/items.html:14
 msgid "No Restart"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/impala/details.html:127
+#: src/olympia/addons/templates/addons/impala/details.html:124
 #, python-format
 msgid "Meet the Developer: <a href=\"%(url)s\">%(name)s</a>"
 msgid_plural "<a href=\"%(url)s\">Meet the Developers</a>"
 msgstr[0] ""
+msgstr[1] ""
 
 # {0} is an add-on name.
-#: src/olympia/addons/templates/addons/impala/details.html:137
+#: src/olympia/addons/templates/addons/impala/details.html:134
 msgid "Learn why {0} was created and find out what's next for this add-on."
 msgstr "بدانید که {0} به چه منظوری ایجاد گردید و در آینده چه تغییراتی خواهد کرد."
 
 #. {0} is an index.
-#: src/olympia/addons/templates/addons/impala/details.html:156
+#: src/olympia/addons/templates/addons/impala/details.html:161
 msgid "Add-on screenshot #{0}"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/impala/details.html:182
+#: src/olympia/addons/templates/addons/impala/details.html:187
 msgid "Add-on home page"
 msgstr "صفحه خانگی افزودنی"
 
-#: src/olympia/addons/templates/addons/impala/details.html:185
+#: src/olympia/addons/templates/addons/impala/details.html:190
 msgid "Support site"
 msgstr "تارنمای پشتیبانی"
 
-#: src/olympia/addons/templates/addons/impala/details.html:189
+#: src/olympia/addons/templates/addons/impala/details.html:194
 msgid "Support E-mail"
 msgstr "رایانامه پشتیبانی"
 
-#: src/olympia/addons/templates/addons/impala/details.html:194 src/olympia/devhub/models.py:378 src/olympia/devhub/templates/devhub/versions/list.html:12
+#: src/olympia/addons/templates/addons/impala/details.html:199 src/olympia/devhub/models.py:378 src/olympia/devhub/templates/devhub/versions/list.html:12
 #: src/olympia/versions/templates/versions/version.html:6 src/olympia/versions/templates/versions/mobile/version.html:6
 msgid "Version {0}"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/impala/details.html:194
+#: src/olympia/addons/templates/addons/impala/details.html:199
 msgid "Info"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/impala/details.html:195 src/olympia/devhub/templates/devhub/includes/addon_details.html:129
+#: src/olympia/addons/templates/addons/impala/details.html:200 src/olympia/devhub/templates/devhub/includes/addon_details.html:116
 #, fuzzy
 msgid "Last Updated:"
 msgstr "آخرین به‌هنگام‌سازی"
 
-#: src/olympia/addons/templates/addons/impala/details.html:200
+#: src/olympia/addons/templates/addons/impala/details.html:205
 #, python-format
 msgid "Released under <a target=\"_blank\" href=\"%(url)s\">%(name)s</a>"
 msgstr "منتشر شده تحت <a target=\"_blank\" href=\"%(url)s\">%(name)s</a>"
 
-#: src/olympia/addons/templates/addons/impala/details.html:201 src/olympia/addons/templates/addons/impala/details.html:206 src/olympia/amo/helpers.py:398 src/olympia/devhub/forms.py:142
+#: src/olympia/addons/templates/addons/impala/details.html:206 src/olympia/addons/templates/addons/impala/details.html:211 src/olympia/amo/helpers.py:398 src/olympia/devhub/forms.py:142
 #: src/olympia/devhub/forms.py:173 src/olympia/versions/templates/versions/version.html:40 src/olympia/versions/templates/versions/version.html:45
 msgid "Custom License"
 msgstr "مجوز خاص"
 
-#: src/olympia/addons/templates/addons/impala/details.html:205
+#: src/olympia/addons/templates/addons/impala/details.html:210
 #, python-format
 msgid "Released under <a href=\"%(url)s\">%(name)s</a>"
 msgstr "منتشر شده تحت <a href=\"%(url)s\">%(name)s</a>"
 
-#: src/olympia/addons/templates/addons/impala/details.html:217
+#: src/olympia/addons/templates/addons/impala/details.html:222
 msgid "About this Add-on"
 msgstr "درباره‌ی این افزودنی"
 
-#: src/olympia/addons/templates/addons/impala/details.html:233
+#: src/olympia/addons/templates/addons/impala/details.html:238
 msgid "Developer’s Comments"
 msgstr "توضیحات توسعه دهنده"
 
-#: src/olympia/addons/templates/addons/impala/details.html:243
+#: src/olympia/addons/templates/addons/impala/details.html:248
 msgid "Version Information"
 msgstr "اطّلاعات نسخه"
 
-#: src/olympia/addons/templates/addons/impala/details.html:250
+#: src/olympia/addons/templates/addons/impala/details.html:255
 msgid "See complete version history"
 msgstr "مشاهده‌ی تاریخچه‌ی کامل نسخه‌ها"
 
-#: src/olympia/addons/templates/addons/impala/details.html:262
+#: src/olympia/addons/templates/addons/impala/details.html:267
 msgid ""
 "The Development Channel lets you test an experimental new version of this add-on before it's released to the general public. Once you install the development version, you will continue to get "
 "updates from this channel. To stop receiving development updates, reinstall the default version from the link above."
 msgstr ""
 
-#: src/olympia/addons/templates/addons/impala/details.html:272
+#: src/olympia/addons/templates/addons/impala/details.html:277
 msgid "<strong>Caution:</strong> Development versions of this add-on have not been reviewed by Mozilla."
 msgstr ""
 
-#: src/olympia/addons/templates/addons/impala/details.html:287
+#: src/olympia/addons/templates/addons/impala/details.html:292
 msgid "See complete development channel history"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/impala/details.html:306 src/olympia/addons/templates/addons/impala/details.html:315 src/olympia/addons/templates/addons/impala/details.html:327
+#: src/olympia/addons/templates/addons/impala/details.html:311 src/olympia/addons/templates/addons/impala/details.html:320 src/olympia/addons/templates/addons/impala/details.html:332
 #: src/olympia/addons/templates/addons/impala/review_add_box.html:4 src/olympia/stats/templates/stats/popup.html:2 src/olympia/stats/templates/stats/popup.html:8
-#: src/olympia/stats/templates/stats/stats.html:202 src/olympia/users/templates/users/profile.html:119
+#: src/olympia/stats/templates/stats/stats.html:204 src/olympia/users/templates/users/profile.html:119
 msgid "close"
 msgstr ""
 
@@ -1110,6 +1125,7 @@ msgstr "گام بعدی برای {0}"
 msgid "About the Developer"
 msgid_plural "About the Developers"
 msgstr[0] "درباره‌ی توسعه دهنده"
+msgstr[1] ""
 
 #: src/olympia/addons/templates/addons/impala/developers.html:96 src/olympia/users/templates/users/edit.html:130 src/olympia/users/templates/users/profile.html:26
 msgid "No Photo"
@@ -1135,15 +1151,11 @@ msgstr "مجوّز کد منبع برای {addon}"
 msgid "Source Code License"
 msgstr "مجوز کد منبع"
 
-#: src/olympia/addons/templates/addons/impala/persona_grid.html:16 src/olympia/addons/templates/addons/impala/toplist.html:6
-msgid "{0} users"
-msgstr ""
-
 #: src/olympia/addons/templates/addons/impala/review_list_box.html:19 src/olympia/reviews/templates/reviews/review.html:40
 msgid "permalink"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/impala/review_list_box.html:23 src/olympia/editors/templates/editors/queue.html:98 src/olympia/reviews/templates/reviews/review.html:44
+#: src/olympia/addons/templates/addons/impala/review_list_box.html:23 src/olympia/editors/templates/editors/queue.html:104 src/olympia/reviews/templates/reviews/review.html:44
 msgid "translate"
 msgstr ""
 
@@ -1152,6 +1164,7 @@ msgstr ""
 msgid "See all user reviews"
 msgid_plural "See all %(cnt)s user reviews"
 msgstr[0] ""
+msgstr[1] ""
 
 #: src/olympia/addons/templates/addons/impala/review_list_box.html:47 src/olympia/reviews/templates/reviews/review_list.html:84
 msgid "This add-on has not yet been reviewed."
@@ -1159,6 +1172,10 @@ msgstr ""
 
 #: src/olympia/addons/templates/addons/impala/review_list_box.html:50
 msgid "Be the first!"
+msgstr ""
+
+#: src/olympia/addons/templates/addons/impala/toplist.html:6
+msgid "{0} users"
 msgstr ""
 
 #: src/olympia/addons/templates/addons/impala/listing/sorter.html:14 src/olympia/devhub/templates/devhub/addons/listing/item_actions.html:49
@@ -1173,7 +1190,7 @@ msgstr "افزودن به مجموعه"
 msgid "My Add-ons"
 msgstr "افزودنی‌های من"
 
-#: src/olympia/addons/templates/addons/includes/dashboard_tabs.html:6 src/olympia/amo/context_processors.py:51
+#: src/olympia/addons/templates/addons/includes/dashboard_tabs.html:6 src/olympia/amo/context_processors.py:50
 msgid "My Themes"
 msgstr "مضمون‌های من"
 
@@ -1215,6 +1232,7 @@ msgstr "هنوز رتبه‌دهی نشده است"
 msgid "<strong>{0}</strong> weekly download"
 msgid_plural "<strong>{0}</strong> weekly downloads"
 msgstr[0] ""
+msgstr[1] ""
 
 #: src/olympia/addons/templates/addons/mobile/details.html:32
 msgid "Read More"
@@ -1228,7 +1246,7 @@ msgstr ""
 msgid "Weekly Downloads"
 msgstr "بارگیری‌های هفتگی"
 
-#: src/olympia/addons/templates/addons/mobile/details.html:99 src/olympia/compat/templates/compat/reporter_detail.html:46 src/olympia/devhub/forms.py:787
+#: src/olympia/addons/templates/addons/mobile/details.html:99 src/olympia/compat/templates/compat/reporter_detail.html:46 src/olympia/devhub/forms.py:788
 #: src/olympia/devhub/templates/devhub/versions/list.html:163
 msgid "Version"
 msgstr "نسخه"
@@ -1313,7 +1331,7 @@ msgstr ""
 #: src/olympia/browse/templates/browse/personas/category_landing.html:21 src/olympia/browse/templates/browse/personas/category_landing.html:23
 #: src/olympia/browse/templates/browse/personas/category_landing.html:38 src/olympia/browse/templates/browse/personas/grid.html:7 src/olympia/browse/templates/browse/personas/grid.html:11
 #: src/olympia/browse/templates/browse/personas/mobile/base.html:7 src/olympia/browse/templates/browse/personas/mobile/category_landing.html:19 src/olympia/constants/base.py:180
-#: src/olympia/devhub/templates/devhub/personas/submit.html:13 src/olympia/editors/helpers.py:105 src/olympia/editors/templates/editors/base.html:26
+#: src/olympia/devhub/templates/devhub/personas/submit.html:13 src/olympia/editors/helpers.py:107 src/olympia/editors/templates/editors/base.html:26
 #: src/olympia/editors/templates/editors/performance.html:73 src/olympia/search/templates/search/personas.html:39 src/olympia/templates/menu_links.html:9
 msgid "Themes"
 msgstr "مضامین"
@@ -1335,7 +1353,7 @@ msgid "Highest Rated"
 msgstr ""
 
 # 100%
-#: src/olympia/addons/templates/addons/mobile/home.html:74 src/olympia/amo/templates/amo/side_nav.html:5 src/olympia/amo/templates/amo/site_nav.html:27 src/olympia/amo/templates/amo/site_nav.html:57
+#: src/olympia/addons/templates/addons/mobile/home.html:74 src/olympia/amo/templates/amo/side_nav.html:5 src/olympia/amo/templates/amo/site_nav.html:27 src/olympia/amo/templates/amo/site_nav.html:55
 #: src/olympia/bandwagon/views.py:97 src/olympia/browse/views.py:57 src/olympia/browse/views.py:67 src/olympia/browse/templates/browse/personas/mobile/category_landing.html:65
 #: src/olympia/search/forms.py:15 src/olympia/search/forms.py:87
 msgid "Newest"
@@ -1349,90 +1367,90 @@ msgstr ""
 msgid "Theme Info &raquo;"
 msgstr ""
 
-#: src/olympia/amo/context_processors.py:39 src/olympia/devhub/templates/devhub/nav.html:43
+#: src/olympia/amo/context_processors.py:37 src/olympia/devhub/templates/devhub/nav.html:43
 msgid "Tools"
 msgstr "ابزارها"
 
-#: src/olympia/amo/context_processors.py:48 src/olympia/discovery/templates/discovery/pane_account.html:8 src/olympia/users/templates/users/includes/navigation.html:2
+#: src/olympia/amo/context_processors.py:47 src/olympia/discovery/templates/discovery/pane_account.html:8 src/olympia/users/templates/users/includes/navigation.html:2
 msgid "My Profile"
 msgstr ""
 
-#: src/olympia/amo/context_processors.py:54 src/olympia/users/templates/users/edit.html:5 src/olympia/users/templates/users/includes/navigation.html:3
+#: src/olympia/amo/context_processors.py:53 src/olympia/users/templates/users/edit.html:5 src/olympia/users/templates/users/includes/navigation.html:3
 msgid "Account Settings"
 msgstr ""
 
-#: src/olympia/amo/context_processors.py:57 src/olympia/discovery/templates/discovery/pane_account.html:11 src/olympia/users/templates/users/profile.html:83
+#: src/olympia/amo/context_processors.py:56 src/olympia/discovery/templates/discovery/pane_account.html:11 src/olympia/users/templates/users/profile.html:83
 #: src/olympia/users/templates/users/includes/navigation.html:4
 msgid "My Collections"
 msgstr "مجوعه‌های من"
 
-#: src/olympia/amo/context_processors.py:62 src/olympia/discovery/templates/discovery/pane_account.html:10 src/olympia/users/templates/users/includes/navigation.html:7
+#: src/olympia/amo/context_processors.py:61 src/olympia/discovery/templates/discovery/pane_account.html:10 src/olympia/users/templates/users/includes/navigation.html:7
 msgid "My Favorites"
 msgstr "افزودنی‌های محبوب من"
 
-#: src/olympia/amo/context_processors.py:67 src/olympia/discovery/templates/discovery/pane_account.html:13 src/olympia/templates/impala/user_login.html:14
+#: src/olympia/amo/context_processors.py:66 src/olympia/discovery/templates/discovery/pane_account.html:13 src/olympia/templates/impala/user_login.html:14
 #: src/olympia/templates/mobile/header_auth.html:5
 msgid "Log out"
 msgstr "خروج"
 
-#: src/olympia/amo/context_processors.py:72 src/olympia/devhub/templates/devhub/addons/dashboard.html:4
+#: src/olympia/amo/context_processors.py:71 src/olympia/devhub/templates/devhub/addons/dashboard.html:4
 msgid "Manage My Submissions"
 msgstr ""
 
-#: src/olympia/amo/context_processors.py:75 src/olympia/devhub/templates/devhub/nav.html:27 src/olympia/devhub/templates/devhub/addons/dashboard.html:25
+#: src/olympia/amo/context_processors.py:74 src/olympia/devhub/templates/devhub/nav.html:27 src/olympia/devhub/templates/devhub/addons/dashboard.html:25
 #: src/olympia/devhub/templates/devhub/addons/submit/base.html:4
 msgid "Submit a New Add-on"
 msgstr ""
 
-#: src/olympia/amo/context_processors.py:77 src/olympia/browse/templates/browse/personas/base.html:50 src/olympia/devhub/templates/devhub/index.html:24
+#: src/olympia/amo/context_processors.py:76 src/olympia/browse/templates/browse/personas/base.html:50 src/olympia/devhub/templates/devhub/index.html:24
 #: src/olympia/devhub/templates/devhub/addons/dashboard.html:29
 msgid "Submit a New Theme"
 msgstr ""
 
-#: src/olympia/amo/context_processors.py:79 src/olympia/amo/templates/amo/site_nav.html:87 src/olympia/devhub/helpers.py:36 src/olympia/devhub/helpers.py:68 src/olympia/devhub/helpers.py:102
+#: src/olympia/amo/context_processors.py:78 src/olympia/amo/templates/amo/site_nav.html:85 src/olympia/devhub/helpers.py:36 src/olympia/devhub/helpers.py:68 src/olympia/devhub/helpers.py:102
 #: src/olympia/templates/footer.html:6 src/olympia/templates/menu_links.html:14
 msgid "Developer Hub"
 msgstr "قطب توسعه دهنده"
 
-#: src/olympia/amo/context_processors.py:83 src/olympia/devhub/views.py:1792
+#: src/olympia/amo/context_processors.py:81 src/olympia/devhub/views.py:1796
 msgid "Manage API Keys"
 msgstr ""
 
-#: src/olympia/amo/context_processors.py:88 src/olympia/editors/helpers.py:82 src/olympia/editors/helpers.py:102 src/olympia/editors/templates/editors/base.html:10
+#: src/olympia/amo/context_processors.py:86 src/olympia/editors/helpers.py:84 src/olympia/editors/helpers.py:104 src/olympia/editors/templates/editors/base.html:10
 msgid "Editor Tools"
 msgstr ""
 
-#: src/olympia/amo/context_processors.py:92
+#: src/olympia/amo/context_processors.py:90
 msgid "Admin Tools"
 msgstr ""
 
-#: src/olympia/amo/fields.py:15
+#: src/olympia/amo/fields.py:20
 msgid "Incorrect, please try again."
 msgstr ""
 
-#: src/olympia/amo/fields.py:16
+#: src/olympia/amo/fields.py:21
 msgid "Error verifying input, please try again."
 msgstr ""
 
-#: src/olympia/amo/fields.py:32
+#: src/olympia/amo/fields.py:37
 msgid "This must be a valid hex color code, such as #000000."
 msgstr ""
 
-#: src/olympia/amo/fields.py:58
+#: src/olympia/amo/fields.py:63
 msgid "Enter at least one value."
 msgstr ""
 
-#: src/olympia/amo/helpers.py:162 src/olympia/amo/templates/amo/site_nav.html:61 src/olympia/bandwagon/templates/bandwagon/add.html:9
+#: src/olympia/amo/helpers.py:162 src/olympia/amo/templates/amo/site_nav.html:59 src/olympia/bandwagon/templates/bandwagon/add.html:9
 #: src/olympia/bandwagon/templates/bandwagon/collection_detail.html:15 src/olympia/bandwagon/templates/bandwagon/delete.html:9 src/olympia/bandwagon/templates/bandwagon/edit.html:15
 #: src/olympia/bandwagon/templates/bandwagon/user_listing.html:18 src/olympia/bandwagon/templates/bandwagon/user_listing.html:21
 #: src/olympia/bandwagon/templates/bandwagon/impala/collection_listing.html:12 src/olympia/bandwagon/templates/bandwagon/impala/collection_listing.html:20
 #: src/olympia/bandwagon/templates/bandwagon/impala/collection_listing.html:24 src/olympia/bandwagon/templates/bandwagon/impala/collection_sidebar.html:3
 #: src/olympia/bandwagon/templates/bandwagon/includes/collection_sidebar.html:2 src/olympia/bandwagon/templates/bandwagon/mobile/collection_listing.html:3
-#: src/olympia/stats/templates/stats/stats.html:77 src/olympia/templates/menu_links.html:12
+#: src/olympia/stats/templates/stats/stats.html:33 src/olympia/templates/menu_links.html:12
 msgid "Collections"
 msgstr "مجموعه‌ها"
 
-#: src/olympia/amo/helpers.py:171 src/olympia/amo/templates/amo/site_nav.html:85 src/olympia/browse/templates/browse/language_tools.html:3
+#: src/olympia/amo/helpers.py:171 src/olympia/amo/templates/amo/site_nav.html:83 src/olympia/browse/templates/browse/language_tools.html:3
 msgid "Dictionaries & Language Packs"
 msgstr "واژه‌نامه‌ها و بسته‌های زبان"
 
@@ -1588,8 +1606,8 @@ msgstr ""
 msgid "Comment on {addon} {version}."
 msgstr ""
 
-#: src/olympia/amo/log.py:236 src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:19 src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:47
-#: src/olympia/editors/helpers.py:511 src/olympia/editors/templates/editors/themes/history_table.html:11
+#: src/olympia/amo/log.py:236 src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:17 src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:45
+#: src/olympia/editors/helpers.py:584 src/olympia/editors/templates/editors/themes/history_table.html:11
 msgid "Comment"
 msgstr ""
 
@@ -1914,7 +1932,7 @@ msgstr "قبلی"
 #: src/olympia/amo/templates/amo/mobile/paginator.html:14 src/olympia/amo/templates/amo/mobile/paginator.html:16 src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:51
 #: src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:65 src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:78
 #: src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:91 src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:104
-#: src/olympia/discovery/templates/discovery/pane.html:45 src/olympia/discovery/templates/discovery/addons/detail.html:39 src/olympia/stats/templates/stats/stats.html:167
+#: src/olympia/discovery/templates/discovery/pane.html:45 src/olympia/discovery/templates/discovery/addons/detail.html:39 src/olympia/stats/templates/stats/stats.html:169
 msgid "Next"
 msgstr "بعدی"
 
@@ -1946,7 +1964,7 @@ msgid ""
 msgstr ""
 
 #: src/olympia/amo/templates/amo/side_nav.html:4 src/olympia/amo/templates/amo/side_nav.html:12 src/olympia/amo/templates/amo/site_nav.html:4 src/olympia/amo/templates/amo/site_nav.html:26
-#: src/olympia/browse/views.py:56 src/olympia/browse/views.py:66 src/olympia/browse/views.py:237 src/olympia/browse/views.py:282 src/olympia/search/forms.py:86
+#: src/olympia/browse/views.py:56 src/olympia/browse/views.py:66 src/olympia/browse/views.py:204 src/olympia/browse/views.py:249 src/olympia/search/forms.py:86
 msgid "Top Rated"
 msgstr "بالاترین رتبه"
 
@@ -1961,38 +1979,38 @@ msgstr "مرور"
 msgid "Extensions"
 msgstr "ضمیمه‌ها"
 
-#: src/olympia/amo/templates/amo/site_nav.html:45
+#: src/olympia/amo/templates/amo/site_nav.html:44
 msgid "Want more customization? Try <b>Complete Themes</b>"
 msgstr ""
 
-#: src/olympia/amo/templates/amo/site_nav.html:56 src/olympia/bandwagon/views.py:96
+#: src/olympia/amo/templates/amo/site_nav.html:54 src/olympia/bandwagon/views.py:96
 msgid "Most Followers"
 msgstr "بیشترین دنبال کنندگان"
 
-#: src/olympia/amo/templates/amo/site_nav.html:68 src/olympia/bandwagon/templates/bandwagon/impala/collection_sidebar.html:16
+#: src/olympia/amo/templates/amo/site_nav.html:66 src/olympia/bandwagon/templates/bandwagon/impala/collection_sidebar.html:16
 #: src/olympia/bandwagon/templates/bandwagon/includes/collection_sidebar.html:18
 msgid "Collections I've Made"
 msgstr "مجموعه‌هایی که من ساخته‌ام"
 
-#: src/olympia/amo/templates/amo/site_nav.html:70 src/olympia/bandwagon/templates/bandwagon/user_listing.html:4 src/olympia/bandwagon/templates/bandwagon/impala/collection_sidebar.html:13
+#: src/olympia/amo/templates/amo/site_nav.html:68 src/olympia/bandwagon/templates/bandwagon/user_listing.html:4 src/olympia/bandwagon/templates/bandwagon/impala/collection_sidebar.html:13
 #: src/olympia/bandwagon/templates/bandwagon/includes/collection_sidebar.html:15
 msgid "Collections I'm Following"
 msgstr "مجموعه‌هایی که من دنبال می‌کنم"
 
-#: src/olympia/amo/templates/amo/site_nav.html:73 src/olympia/bandwagon/templates/bandwagon/impala/collection_sidebar.html:18
-#: src/olympia/bandwagon/templates/bandwagon/includes/collection_sidebar.html:20 src/olympia/users/models.py:512
+#: src/olympia/amo/templates/amo/site_nav.html:71 src/olympia/bandwagon/templates/bandwagon/impala/collection_sidebar.html:18
+#: src/olympia/bandwagon/templates/bandwagon/includes/collection_sidebar.html:20 src/olympia/users/models.py:521
 msgid "My Favorite Add-ons"
 msgstr "افزودنی‌های مورد علاقه من"
 
-#: src/olympia/amo/templates/amo/site_nav.html:78
+#: src/olympia/amo/templates/amo/site_nav.html:76
 msgid "More&hellip;"
 msgstr ""
 
-#: src/olympia/amo/templates/amo/site_nav.html:82
+#: src/olympia/amo/templates/amo/site_nav.html:80
 msgid "Add-ons for Mobile"
 msgstr "افزودنی‌های برای تلفن همراه"
 
-#: src/olympia/amo/templates/amo/site_nav.html:86 src/olympia/browse/feeds.py:207 src/olympia/browse/templates/browse/search_tools.html:3 src/olympia/constants/base.py:176
+#: src/olympia/amo/templates/amo/site_nav.html:84 src/olympia/browse/feeds.py:207 src/olympia/browse/templates/browse/search_tools.html:3 src/olympia/constants/base.py:176
 #: src/olympia/templates/menu_links.html:10
 msgid "Search Tools"
 msgstr "ابزارهای جستجو"
@@ -2008,7 +2026,7 @@ msgid "Jump to first page"
 msgstr ""
 
 #: src/olympia/amo/templates/amo/impala/paginator.html:22 src/olympia/amo/templates/amo/mobile/impala_paginator.html:12 src/olympia/discovery/templates/discovery/pane.html:44
-#: src/olympia/discovery/templates/discovery/addons/detail.html:38 src/olympia/stats/templates/stats/stats.html:164
+#: src/olympia/discovery/templates/discovery/addons/detail.html:38 src/olympia/stats/templates/stats/stats.html:166
 msgid "Previous"
 msgstr ""
 
@@ -2029,31 +2047,51 @@ msgstr ""
 msgid "Page {n}"
 msgid_plural "Page {n}"
 msgstr[0] ""
+msgstr[1] ""
 
-#: src/olympia/amo/templates/services/install.html:38
-#, python-format
-msgid "If you are not prompted to install %(addon_name)s in a moment, please <a href=\"%(addon_xpi)s\">click here</a>."
-msgstr ""
-
-#: src/olympia/amo/tests/test_messages.py:57 src/olympia/amo/tests/test_messages.py:58 src/olympia/reviews/forms.py:25 src/olympia/reviews/forms.py:50 src/olympia/reviews/templates/reviews/add.html:56
+#: src/olympia/amo/tests/test_messages.py:56 src/olympia/amo/tests/test_messages.py:57 src/olympia/reviews/forms.py:25 src/olympia/reviews/forms.py:50 src/olympia/reviews/templates/reviews/add.html:56
 #: src/olympia/reviews/templates/reviews/reply.html:30
 msgid "Title"
 msgstr ""
 
-#: src/olympia/amo/tests/test_messages.py:57 src/olympia/amo/tests/test_messages.py:58
+#: src/olympia/amo/tests/test_messages.py:56 src/olympia/amo/tests/test_messages.py:57
 msgid "Body"
 msgstr ""
 
-#: src/olympia/amo/tests/test_messages.py:59
+#: src/olympia/amo/tests/test_messages.py:58
 msgid "Another Title"
 msgstr ""
 
-#: src/olympia/amo/tests/test_messages.py:59
+#: src/olympia/amo/tests/test_messages.py:58
 msgid "Another Body"
 msgstr ""
 
-#: src/olympia/api/views.py:255
-msgid "Not implemented yet."
+#: src/olympia/api/authentication.py:76
+msgid "Signature has expired."
+msgstr ""
+
+#: src/olympia/api/authentication.py:79
+msgid "Error decoding signature."
+msgstr ""
+
+#: src/olympia/api/authentication.py:82
+msgid "Invalid JWT Token."
+msgstr ""
+
+#: src/olympia/api/authentication.py:130
+msgid "Invalid Authorization header. No credentials provided."
+msgstr ""
+
+#: src/olympia/api/authentication.py:133
+msgid "Invalid Authorization header. Credentials string should not contain spaces."
+msgstr ""
+
+#: src/olympia/api/fields.py:29
+msgid "The field must have a length of at least {num} characters."
+msgstr ""
+
+#: src/olympia/api/fields.py:31
+msgid "The language code {lang_code} is invalid."
 msgstr ""
 
 #: src/olympia/applications/views.py:39 src/olympia/applications/templates/applications/appversions.html:3
@@ -2072,7 +2110,7 @@ msgstr "نسخه‌های معتبر برنامه"
 msgid "Add-ons submitted to Mozilla Add-ons must have a manifest file with at least one of the below applications supported. Only the versions listed below are allowed for these applications."
 msgstr ""
 
-#: src/olympia/applications/templates/applications/appversions.html:25
+#: src/olympia/applications/templates/applications/appversions.html:25 src/olympia/editors/helpers.py:361
 msgid "GUID"
 msgstr "GUID"
 
@@ -2188,8 +2226,8 @@ msgstr ""
 msgid "Remove from favorites"
 msgstr "حذف از افزودنی‌های محبوب"
 
-#: src/olympia/bandwagon/views.py:98 src/olympia/bandwagon/views.py:191 src/olympia/browse/views.py:58 src/olympia/browse/views.py:69 src/olympia/browse/views.py:458 src/olympia/devhub/views.py:74
-#: src/olympia/devhub/views.py:82 src/olympia/devhub/templates/devhub/addons/edit/basic.html:20 src/olympia/editors/templates/editors/leaderboard.html:24
+#: src/olympia/bandwagon/views.py:98 src/olympia/bandwagon/views.py:191 src/olympia/browse/views.py:58 src/olympia/browse/views.py:69 src/olympia/browse/views.py:425 src/olympia/devhub/views.py:72
+#: src/olympia/devhub/views.py:80 src/olympia/devhub/templates/devhub/addons/edit/basic.html:20 src/olympia/editors/templates/editors/leaderboard.html:24
 #: src/olympia/editors/templates/editors/themes/queue_list.html:48 src/olympia/search/forms.py:17 src/olympia/search/forms.py:89 src/olympia/users/templates/users/vcard.html:5
 msgid "Name"
 msgstr ""
@@ -2198,7 +2236,7 @@ msgstr ""
 msgid "Recently Popular"
 msgstr ""
 
-#: src/olympia/bandwagon/views.py:189 src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:18
+#: src/olympia/bandwagon/views.py:189 src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:16
 msgid "Added"
 msgstr ""
 
@@ -2213,7 +2251,7 @@ msgstr ""
 
 #: src/olympia/bandwagon/views.py:316
 #, python-format
-msgid "Your new collection is shown below. You can <ahref=\"%(url)s\">edit additional settings</a> if you'dlike."
+msgid "Your new collection is shown below. You can <a href=\"%(url)s\">edit additional settings</a> if you'd like."
 msgstr ""
 
 #: src/olympia/bandwagon/views.py:322
@@ -2295,6 +2333,7 @@ msgstr ""
 msgid "<span>%(num)s</span> follower"
 msgid_plural "<span>%(num)s</span> followers"
 msgstr[0] ""
+msgstr[1] ""
 
 #: src/olympia/bandwagon/templates/bandwagon/collection_detail.html:54
 msgid "About this Collection"
@@ -2335,16 +2374,18 @@ msgstr "ایجاد مجموعه"
 msgid "%(num)s Theme in this Collection"
 msgid_plural "%(num)s Themes in this Collection"
 msgstr[0] "%(num)s مضمون در این مجموعه"
+msgstr[1] ""
 
 #: src/olympia/bandwagon/templates/bandwagon/collection_detail.html:111
 #, python-format
 msgid "%(num)s Add-on in this Collection"
 msgid_plural "%(num)s Add-ons in this Collection"
 msgstr[0] ""
+msgstr[1] ""
 
 # 100%
-#: src/olympia/bandwagon/templates/bandwagon/collection_detail.html:125 src/olympia/compat/templates/compat/index.html:25 src/olympia/compat/templates/compat/reporter_detail.html:29
-#: src/olympia/files/templates/files/viewer.html:29 src/olympia/templates/amo_footer.html:17 src/olympia/templates/includes/lang_switcher.html:10
+#: src/olympia/bandwagon/templates/bandwagon/collection_detail.html:125 src/olympia/compat/templates/compat/reporter_detail.html:29 src/olympia/files/templates/files/viewer.html:29
+#: src/olympia/templates/amo_footer.html:17 src/olympia/templates/includes/lang_switcher.html:10
 msgid "Go"
 msgstr "برو"
 
@@ -2390,12 +2431,14 @@ msgstr "افزودنی‌های مورد علاقه من"
 msgid "<span>%(addons)s</span> add-on"
 msgid_plural "<span>%(addons)s</span> add-ons"
 msgstr[0] ""
+msgstr[1] ""
 
 #: src/olympia/bandwagon/templates/bandwagon/collection_grid.html:32
 #, python-format
 msgid "<span>%(followers)s</span> follower"
 msgid_plural "<span>%(followers)s</span> followers"
 msgstr[0] ""
+msgstr[1] ""
 
 #. People "follow" collections to get notified of updates.                    Like
 #. Twitter followers.
@@ -2406,6 +2449,7 @@ msgstr[0] ""
 msgid "%(num)s weekly follower"
 msgid_plural "%(num)s weekly followers"
 msgstr[0] ""
+msgstr[1] ""
 
 #. People "follow" collections to get notified of updates.                    Like
 #. Twitter followers.
@@ -2414,6 +2458,7 @@ msgstr[0] ""
 msgid "%(num)s monthly follower"
 msgid_plural "%(num)s monthly followers"
 msgstr[0] ""
+msgstr[1] ""
 
 #. People "follow" collections to get notified of updates.                    Like
 #. Twitter followers.
@@ -2424,6 +2469,7 @@ msgstr[0] ""
 msgid "%(num)s follower"
 msgid_plural "%(num)s followers"
 msgstr[0] ""
+msgstr[1] ""
 
 #: src/olympia/bandwagon/templates/bandwagon/collection_listing_items.html:56 src/olympia/bandwagon/templates/bandwagon/impala/collection_listing_items.html:9
 #: src/olympia/devhub/templates/devhub/personas/edit.html:27
@@ -2509,7 +2555,7 @@ msgid "Remove this user as a contributor"
 msgstr ""
 
 #: src/olympia/bandwagon/templates/bandwagon/edit_contributors.html:18 src/olympia/bandwagon/templates/bandwagon/edit_contributors.html:43
-#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:20 src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:48
+#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:18 src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:46
 #: src/olympia/devhub/templates/devhub/addons/ajax_compat_update.html:19
 msgid "Remove"
 msgstr ""
@@ -2558,7 +2604,7 @@ msgid "<b>Warning:</b> By changing the owner of this collection, you will no lon
 msgstr ""
 
 #: src/olympia/bandwagon/templates/bandwagon/edit_contributors.html:83 src/olympia/devhub/templates/devhub/addons/forms_shared/media.html:157
-#: src/olympia/devhub/templates/devhub/addons/submit/describe.html:69 src/olympia/devhub/templates/devhub/addons/submit/license.html:60 src/olympia/devhub/templates/devhub/addons/submit/upload.html:78
+#: src/olympia/devhub/templates/devhub/addons/submit/describe.html:69 src/olympia/devhub/templates/devhub/addons/submit/license.html:60 src/olympia/devhub/templates/devhub/addons/submit/upload.html:70
 #: src/olympia/devhub/templates/devhub/payments/tier.html:17 src/olympia/editors/templates/editors/themes/themes.html:111 src/olympia/editors/templates/editors/themes/themes.html:128
 #: src/olympia/editors/templates/editors/themes/themes.html:134 src/olympia/editors/templates/editors/themes/themes.html:141 src/olympia/users/templates/users/fxa_migration_prompt_content.html:10
 #: src/olympia/users/templates/users/login_form.html:42 src/olympia/users/templates/users/mobile/login.html:57
@@ -2643,31 +2689,31 @@ msgid "Add-ons in Your Collection"
 msgstr ""
 
 #: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:4
-msgid ""
-"To include an add-on in this collection, enter its name in the box below and hit enter.  You can also use the <strong>Add to Collection</strong> links throughout the site to include add-ons later."
+msgid "To include an add-on in this collection, enter its name in the box below and hit enter."
 msgstr ""
 
-#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:17 src/olympia/constants/base.py:400 src/olympia/devhub/templates/devhub/addons/activity.html:62
+#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:15 src/olympia/constants/base.py:400 src/olympia/devhub/templates/devhub/addons/activity.html:62
+#: src/olympia/editors/helpers.py:273 src/olympia/editors/helpers.py:360
 msgid "Add-on"
 msgstr ""
 
-#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:26
+#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:24
 msgid "Enter the name of the add-on to include"
 msgstr ""
 
-#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:28
+#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:26
 msgid "Add to Collection"
 msgstr "افزودن به مجموعه"
 
-#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:45 src/olympia/editors/helpers.py:936 src/olympia/editors/helpers.py:956
+#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:43 src/olympia/editors/helpers.py:1016 src/olympia/editors/helpers.py:1036
 msgid "Pending"
 msgstr ""
 
-#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:47
+#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:45
 msgid "Add a comment"
 msgstr ""
 
-#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:48
+#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:46
 msgid "Remove this add-on from the collection"
 msgstr ""
 
@@ -2774,12 +2820,12 @@ msgstr "ابزارهای جستجو"
 msgid "Most Users"
 msgstr "بیشتر کاربران"
 
-#: src/olympia/browse/views.py:61 src/olympia/browse/views.py:72 src/olympia/browse/views.py:279 src/olympia/browse/templates/browse/personas/mobile/category_landing.html:63
+#: src/olympia/browse/views.py:61 src/olympia/browse/views.py:72 src/olympia/browse/views.py:246 src/olympia/browse/templates/browse/personas/mobile/category_landing.html:63
 #: src/olympia/discovery/templates/discovery/pane.html:67 src/olympia/search/forms.py:92
 msgid "Up & Coming"
 msgstr ""
 
-#: src/olympia/browse/views.py:460 src/olympia/devhub/views.py:76 src/olympia/devhub/views.py:83 src/olympia/discovery/templates/discovery/addons/detail.html:66
+#: src/olympia/browse/views.py:427 src/olympia/devhub/views.py:74 src/olympia/devhub/views.py:81 src/olympia/discovery/templates/discovery/addons/detail.html:66
 msgid "Created"
 msgstr "ایجاد شده در تاریخ"
 
@@ -2861,6 +2907,7 @@ msgstr ""
 msgid "<b>{0}</b> add-on"
 msgid_plural "<b>{0}</b> add-ons"
 msgstr[0] ""
+msgstr[1] ""
 
 #: src/olympia/browse/templates/browse/search_tools.html:61
 msgid "Search Extensions"
@@ -2966,9 +3013,10 @@ msgstr ""
 msgid "See the %(cnt)s extension in %(name)s &raquo;"
 msgid_plural "See all %(cnt)s extensions in %(name)s &raquo;"
 msgstr[0] ""
+msgstr[1] ""
 
-#: src/olympia/browse/templates/browse/mobile/extensions.html:13 src/olympia/compat/templates/compat/index.html:82 src/olympia/devhub/templates/devhub/devhub_search.html:24
-#: src/olympia/devhub/templates/devhub/addons/activity.html:47 src/olympia/search/templates/search/no_results.html:4 src/olympia/search/templates/search/mobile/results.html:36
+#: src/olympia/browse/templates/browse/mobile/extensions.html:13 src/olympia/devhub/templates/devhub/devhub_search.html:24 src/olympia/devhub/templates/devhub/addons/activity.html:47
+#: src/olympia/search/templates/search/no_results.html:4 src/olympia/search/templates/search/mobile/results.html:36
 msgid "No results found."
 msgstr "هیچ نتیجه‌ای پیدا نشد."
 
@@ -3053,7 +3101,7 @@ msgstr ""
 msgid "All"
 msgstr ""
 
-#: src/olympia/compat/forms.py:22 src/olympia/search/views.py:525
+#: src/olympia/compat/forms.py:22 src/olympia/editors/templates/editors/base.html:69 src/olympia/search/views.py:518
 msgid "All Add-ons"
 msgstr ""
 
@@ -3063,53 +3111,6 @@ msgstr ""
 
 #: src/olympia/compat/forms.py:24
 msgid "Non-binary"
-msgstr ""
-
-#. Review points sources other than add-ons and themes.
-#: src/olympia/compat/views.py:87 src/olympia/constants/base.py:388 src/olympia/devhub/forms.py:162 src/olympia/editors/templates/editors/performance.html:75
-msgid "Other"
-msgstr "دیگر"
-
-#: src/olympia/compat/templates/compat/index.html:4
-msgid "Add-on Compatibility Report for {app} {version}"
-msgstr ""
-
-#: src/olympia/compat/templates/compat/index.html:11
-msgid "{app} {version} Compatibility"
-msgstr ""
-
-#: src/olympia/compat/templates/compat/index.html:17
-#, python-format
-msgid "Top 95%% compatible with previous version"
-msgstr ""
-
-#: src/olympia/compat/templates/compat/index.html:18
-#, python-format
-msgid "Top 95%% of all add-ons"
-msgstr ""
-
-#: src/olympia/compat/templates/compat/index.html:19
-msgid "All active add-ons"
-msgstr ""
-
-#: src/olympia/compat/templates/compat/index.html:23 src/olympia/constants/base.py:401
-msgid "App"
-msgstr ""
-
-#: src/olympia/compat/templates/compat/index.html:55
-msgid "Details for add-ons compatible with previous version:"
-msgstr ""
-
-#: src/olympia/compat/templates/compat/index.html:57
-msgid "Show all versions"
-msgstr ""
-
-#: src/olympia/compat/templates/compat/index.html:59
-msgid "Details for add-ons compatible with all versions:"
-msgstr ""
-
-#: src/olympia/compat/templates/compat/index.html:61
-msgid "Show previous version only"
 msgstr ""
 
 #: src/olympia/compat/templates/compat/reporter.html:3
@@ -3143,11 +3144,13 @@ msgstr ""
 msgid "{0} success report"
 msgid_plural "{0} success reports"
 msgstr[0] ""
+msgstr[1] ""
 
 #: src/olympia/compat/templates/compat/reporter_detail.html:17
 msgid "{0} problem report"
 msgid_plural "{0} problem reports"
 msgstr[0] ""
+msgstr[1] ""
 
 #: src/olympia/compat/templates/compat/reporter_detail.html:21 src/olympia/users/templates/users/profile.html:70
 msgid "View all"
@@ -3161,8 +3164,8 @@ msgstr ""
 msgid "Report Type"
 msgstr ""
 
-#: src/olympia/compat/templates/compat/reporter_detail.html:47 src/olympia/devhub/forms.py:784 src/olympia/devhub/templates/devhub/addons/ajax_compat_update.html:17 src/olympia/editors/forms.py:108
-#: src/olympia/zadmin/forms.py:45
+#: src/olympia/compat/templates/compat/reporter_detail.html:47 src/olympia/devhub/forms.py:785 src/olympia/devhub/templates/devhub/addons/ajax_compat_update.html:17 src/olympia/editors/forms.py:108
+#: src/olympia/editors/forms.py:248 src/olympia/zadmin/forms.py:45
 msgid "Application"
 msgstr ""
 
@@ -3252,7 +3255,8 @@ msgstr ""
 msgid "Preliminarily Reviewed and Awaiting Full Review"
 msgstr ""
 
-#: src/olympia/constants/base.py:33 src/olympia/editors/helpers.py:924 src/olympia/editors/templates/editors/themes/history_table.html:34
+#: src/olympia/constants/base.py:33 src/olympia/editors/forms.py:258 src/olympia/editors/helpers.py:73 src/olympia/editors/helpers.py:1004
+#: src/olympia/editors/templates/editors/themes/history_table.html:34
 #, fuzzy
 msgid "Deleted"
 msgstr "حذف"
@@ -3354,6 +3358,11 @@ msgstr ""
 msgid "Ask before users can download this add-on"
 msgstr ""
 
+#. Review points sources other than add-ons and themes.
+#: src/olympia/constants/base.py:388 src/olympia/devhub/forms.py:162 src/olympia/editors/templates/editors/performance.html:75
+msgid "Other"
+msgstr "دیگر"
+
 #: src/olympia/constants/base.py:389
 msgid "Exception"
 msgstr ""
@@ -3364,6 +3373,10 @@ msgstr ""
 
 #: src/olympia/constants/base.py:391
 msgid "Change"
+msgstr ""
+
+#: src/olympia/constants/base.py:401
+msgid "App"
 msgstr ""
 
 #: src/olympia/constants/base.py:402
@@ -3514,7 +3527,7 @@ msgstr ""
 msgid "Duplicate"
 msgstr ""
 
-#: src/olympia/constants/editors.py:17 src/olympia/editors/helpers.py:502 src/olympia/editors/templates/editors/themes/queue.html:71 src/olympia/editors/templates/editors/themes/themes.html:94
+#: src/olympia/constants/editors.py:17 src/olympia/editors/helpers.py:575 src/olympia/editors/templates/editors/themes/queue.html:71 src/olympia/editors/templates/editors/themes/themes.html:94
 msgid "Reject"
 msgstr ""
 
@@ -3614,7 +3627,7 @@ msgstr ""
 msgid "Android"
 msgstr ""
 
-#: src/olympia/core/apps.py:19
+#: src/olympia/core/apps.py:21
 msgid "Core"
 msgstr ""
 
@@ -3748,7 +3761,7 @@ msgid "Submit my add-on for manual review."
 msgstr ""
 
 #: src/olympia/devhub/forms.py:537
-msgid "Do not list my add-on on this site (beta)"
+msgid "Do not list my add-on on this site"
 msgstr ""
 
 #: src/olympia/devhub/forms.py:538
@@ -3781,46 +3794,46 @@ msgstr ""
 
 #: src/olympia/devhub/forms.py:592
 #, python-format
-msgid "Version %s already exists"
+msgid "Version %s already exists, or was uploaded before."
 msgstr ""
 
-#: src/olympia/devhub/forms.py:604
+#: src/olympia/devhub/forms.py:605
 msgid "Select a valid choice. That choice is not one of the available choices."
 msgstr ""
 
-#: src/olympia/devhub/forms.py:610
+#: src/olympia/devhub/forms.py:611
 msgid "A file with a version ending with a|alpha|b|beta and an optional number is detected as beta."
 msgstr ""
 
-#: src/olympia/devhub/forms.py:633
+#: src/olympia/devhub/forms.py:634
 msgid "You cannot upload any more files for this version."
 msgstr ""
 
-#: src/olympia/devhub/forms.py:639
+#: src/olympia/devhub/forms.py:640
 msgid "Version doesn't match"
 msgstr ""
 
-#: src/olympia/devhub/forms.py:668
+#: src/olympia/devhub/forms.py:669
 msgid "You cannot delete a file once the review process has started.  You must delete the whole version."
 msgstr ""
 
-#: src/olympia/devhub/forms.py:688
+#: src/olympia/devhub/forms.py:689
 msgid "The platform All cannot be combined with specific platforms."
 msgstr ""
 
-#: src/olympia/devhub/forms.py:693
+#: src/olympia/devhub/forms.py:694
 msgid "A platform can only be chosen once."
 msgstr ""
 
-#: src/olympia/devhub/forms.py:706
+#: src/olympia/devhub/forms.py:707
 msgid "A review type must be selected."
 msgstr ""
 
-#: src/olympia/devhub/forms.py:788 src/olympia/editors/forms.py:114 src/olympia/zadmin/forms.py:49 src/olympia/zadmin/forms.py:52
+#: src/olympia/devhub/forms.py:789 src/olympia/editors/forms.py:114 src/olympia/editors/forms.py:254 src/olympia/zadmin/forms.py:49 src/olympia/zadmin/forms.py:52
 msgid "Select an application first"
 msgstr ""
 
-#: src/olympia/devhub/forms.py:840
+#: src/olympia/devhub/forms.py:841
 msgid "There cannot be more than 3 required add-ons."
 msgstr ""
 
@@ -3843,6 +3856,7 @@ msgstr "انجمن‌های توسعه دهنده"
 msgid "{0} error"
 msgid_plural "{0} errors"
 msgstr[0] "{0} خطا"
+msgstr[1] ""
 
 # {0} is a number
 #. L10n: first parameter is the number of warnings
@@ -3850,82 +3864,83 @@ msgstr[0] "{0} خطا"
 msgid "{0} warning"
 msgid_plural "{0} warnings"
 msgstr[0] "{0} هشدار"
+msgstr[1] ""
 
 #: src/olympia/devhub/models.py:375 src/olympia/reviews/templates/reviews/add.html:58
 msgid "Review"
 msgstr "بررسی"
 
-#: src/olympia/devhub/tasks.py:551
+#: src/olympia/devhub/tasks.py:583
 #, python-format
 msgid "%s responded with %s (%s)."
 msgstr ""
 
-#: src/olympia/devhub/tasks.py:555
+#: src/olympia/devhub/tasks.py:587
 #, python-format
 msgid "Connection to \"%s\" timed out."
 msgstr ""
 
-#: src/olympia/devhub/tasks.py:557
+#: src/olympia/devhub/tasks.py:589
 #, python-format
 msgid "Could not contact host at \"%s\"."
 msgstr ""
 
-#: src/olympia/devhub/utils.py:104
+#: src/olympia/devhub/utils.py:105
 #, python-format
 msgid "Validation generated too many errors/warnings so %s messages were truncated. After addressing the visible messages, you'll be able to see the others."
 msgstr ""
 
-#: src/olympia/devhub/views.py:183
+#: src/olympia/devhub/views.py:181
 msgid "All My Add-ons"
 msgstr ""
 
-#: src/olympia/devhub/views.py:210
+#: src/olympia/devhub/views.py:208
 msgid "All Activity"
 msgstr ""
 
-#: src/olympia/devhub/views.py:211
+#: src/olympia/devhub/views.py:209
 msgid "Add-on Updates"
 msgstr ""
 
-#: src/olympia/devhub/views.py:212
+#: src/olympia/devhub/views.py:210
 msgid "Add-on Status"
 msgstr ""
 
-#: src/olympia/devhub/views.py:213
+#: src/olympia/devhub/views.py:211
 #, fuzzy
 msgid "User Collections"
 msgstr "مجوعه‌های من"
 
-#: src/olympia/devhub/views.py:214 src/olympia/devhub/templates/devhub/docs/policies-maintenance.html:68 src/olympia/pages/templates/pages/dev_faq.html:38
+#: src/olympia/devhub/views.py:212 src/olympia/devhub/templates/devhub/docs/policies-maintenance.html:68 src/olympia/pages/templates/pages/dev_faq.html:38
 #: src/olympia/pages/templates/pages/dev_faq.html:484
 msgid "User Reviews"
 msgstr ""
 
-#: src/olympia/devhub/views.py:327 src/olympia/devhub/views.py:331 src/olympia/devhub/views.py:484 src/olympia/devhub/views.py:513 src/olympia/devhub/views.py:564 src/olympia/devhub/views.py:1150
+#: src/olympia/devhub/views.py:325 src/olympia/devhub/views.py:329 src/olympia/devhub/views.py:484 src/olympia/devhub/views.py:513 src/olympia/devhub/views.py:564 src/olympia/devhub/views.py:1156
 msgid "Changes successfully saved."
 msgstr ""
 
-#: src/olympia/devhub/views.py:334 src/olympia/devhub/views.py:1631
+#: src/olympia/devhub/views.py:332 src/olympia/devhub/views.py:1637
 msgid "Please check the form for errors."
 msgstr ""
 
-#: src/olympia/devhub/views.py:346
+#: src/olympia/devhub/views.py:344
 msgid "Add-on cannot be deleted. Disable this add-on instead."
 msgstr ""
 
-#: src/olympia/devhub/views.py:356
+#: src/olympia/devhub/views.py:354
 msgid "Theme deleted."
 msgstr ""
 
-#: src/olympia/devhub/views.py:356
+#: src/olympia/devhub/views.py:354
 msgid "Add-on deleted."
 msgstr ""
 
-#: src/olympia/devhub/views.py:362
+#: src/olympia/devhub/views.py:360
 msgid "URL name was incorrect. Theme was not deleted."
 msgstr ""
 
-#: src/olympia/devhub/views.py:367
+#: src/olympia/devhub/views.py:365
 msgid "URL name was incorrect. Add-on was not deleted."
 msgstr ""
 
@@ -3953,7 +3968,7 @@ msgstr ""
 msgid "Check Add-on Compatibility"
 msgstr ""
 
-#: src/olympia/devhub/views.py:808 src/olympia/signing/views.py:90
+#: src/olympia/devhub/views.py:808 src/olympia/signing/views.py:95
 msgid "You cannot submit this type of add-on"
 msgstr ""
 
@@ -3983,33 +3998,33 @@ msgstr ""
 msgid "There was an error uploading your preview."
 msgstr ""
 
-#: src/olympia/devhub/views.py:1189
+#: src/olympia/devhub/views.py:1195
 #, python-format
 msgid "Version %s disabled."
 msgstr ""
 
-#: src/olympia/devhub/views.py:1193
+#: src/olympia/devhub/views.py:1199
 #, python-format
 msgid "Version %s deleted."
 msgstr ""
 
-#: src/olympia/devhub/views.py:1203
+#: src/olympia/devhub/views.py:1209
 msgid "This upload has failed validation, and may lack complete validation results. Please take due care when reviewing it."
 msgstr ""
 
-#: src/olympia/devhub/views.py:1677
+#: src/olympia/devhub/views.py:1683
 msgid "Preliminary Review Requested."
 msgstr ""
 
-#: src/olympia/devhub/views.py:1678
+#: src/olympia/devhub/views.py:1684
 msgid "Full Review Requested."
 msgstr ""
 
-#: src/olympia/devhub/views.py:1779
+#: src/olympia/devhub/views.py:1783
 msgid "Your old credentials were revoked and are no longer valid. Be sure to update all API clients with the new credentials."
 msgstr ""
 
-#: src/olympia/devhub/views.py:1797
+#: src/olympia/devhub/views.py:1801
 msgid "New API key created"
 msgstr ""
 
@@ -4039,7 +4054,7 @@ msgstr ""
 msgid "{0} :: Search"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/devhub_search.html:6 src/olympia/devhub/templates/devhub/search.html:8 src/olympia/editors/forms.py:435 src/olympia/editors/forms.py:437
+#: src/olympia/devhub/templates/devhub/devhub_search.html:6 src/olympia/devhub/templates/devhub/search.html:8 src/olympia/editors/forms.py:534 src/olympia/editors/forms.py:536
 #: src/olympia/editors/templates/editors/queue.html:27 src/olympia/editors/templates/editors/themes/queue_list.html:14 src/olympia/search/templates/search/collections.html:17
 #: src/olympia/search/templates/search/personas.html:18 src/olympia/search/templates/search/results.html:18 src/olympia/search/templates/search/mobile/results.html:8
 #: src/olympia/templates/search.html:14 src/olympia/templates/impala/search.html:18
@@ -4099,12 +4114,12 @@ msgstr ""
 msgid "Start Making Add-ons"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/index.html:86 src/olympia/devhub/templates/devhub/addons/listing/items.html:25 src/olympia/devhub/templates/devhub/includes/addon_details.html:15
+#: src/olympia/devhub/templates/devhub/index.html:86 src/olympia/devhub/templates/devhub/addons/listing/items.html:25 src/olympia/devhub/templates/devhub/includes/addon_details.html:20
 #: src/olympia/devhub/templates/devhub/personas/edit.html:43
 msgid "Status:"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/index.html:90 src/olympia/devhub/templates/devhub/includes/addon_details.html:100
+#: src/olympia/devhub/templates/devhub/index.html:90 src/olympia/devhub/templates/devhub/includes/addon_details.html:87
 msgid "Visibility:"
 msgstr ""
 
@@ -4112,11 +4127,11 @@ msgstr ""
 msgid "Latest Version:"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/index.html:109 src/olympia/devhub/templates/devhub/includes/addon_details.html:145 src/olympia/devhub/templates/devhub/personas/edit.html:49
+#: src/olympia/devhub/templates/devhub/index.html:109 src/olympia/devhub/templates/devhub/includes/addon_details.html:131 src/olympia/devhub/templates/devhub/personas/edit.html:49
 msgid "Queue Position:"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/index.html:110 src/olympia/devhub/templates/devhub/includes/addon_details.html:146 src/olympia/devhub/templates/devhub/personas/edit.html:50
+#: src/olympia/devhub/templates/devhub/index.html:110 src/olympia/devhub/templates/devhub/includes/addon_details.html:132 src/olympia/devhub/templates/devhub/personas/edit.html:50
 #, python-format
 msgid "%(position)s of %(total)s"
 msgstr ""
@@ -4218,16 +4233,6 @@ msgstr ""
 msgid "Do you want your add-on to be distributed on this site?"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/validate_addon.html:49 src/olympia/devhub/templates/devhub/addons/submit/upload.html:30 src/olympia/devhub/templates/devhub/versions/add_file_modal.html:14
-#: src/olympia/devhub/templates/devhub/versions/add_file_modal.html:53 src/olympia/devhub/templates/devhub/versions/list.html:298
-msgid "Warning:"
-msgstr ""
-
-#: src/olympia/devhub/templates/devhub/validate_addon.html:50 src/olympia/devhub/templates/devhub/addons/submit/upload.html:31
-#, python-format
-msgid "Submission of unlisted add-ons for signing is currently in an open beta. Please <a href=\"%(url)s\" target=\"_blank\">report any bugs</a> that you encounter."
-msgstr ""
-
 #. first parameter is a filename like lorem-ipsum-1.0.2.xpi
 #: src/olympia/devhub/templates/devhub/validation.html:5
 msgid "Validation Results for {0}"
@@ -4302,7 +4307,7 @@ msgstr ""
 msgid "Update Compatibility"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/addons/ajax_compat_update.html:4
+#: src/olympia/devhub/templates/devhub/addons/ajax_compat_update.html:4 src/olympia/devhub/templates/devhub/versions/edit.html:45
 msgid "Adjusting application information here will allow users to install your add-on even if the install manifest in the package indicates that the add-on is incompatible."
 msgstr ""
 
@@ -4314,9 +4319,9 @@ msgstr ""
 msgid "Add Another Application&hellip;"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/addons/ajax_compat_update.html:38 src/olympia/devhub/templates/devhub/addons/owner.html:86 src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:46
-#: src/olympia/devhub/templates/devhub/versions/list.html:351 src/olympia/devhub/templates/devhub/versions/list.html:353 src/olympia/templates/impala/base.html:132
-#: src/olympia/templates/impala/base.html:143 src/olympia/templates/impala/base.html:161 src/olympia/templates/impala/base.html:171
+#: src/olympia/devhub/templates/devhub/addons/ajax_compat_update.html:38 src/olympia/devhub/templates/devhub/addons/owner.html:86 src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:45
+#: src/olympia/devhub/templates/devhub/versions/list.html:349 src/olympia/devhub/templates/devhub/versions/list.html:351 src/olympia/templates/impala/base.html:129
+#: src/olympia/templates/impala/base.html:140 src/olympia/templates/impala/base.html:158 src/olympia/templates/impala/base.html:168
 msgid "Close"
 msgstr ""
 
@@ -4334,6 +4339,7 @@ msgstr ""
 msgid "<b>{0}</b> theme"
 msgid_plural "<b>{0}</b> themes"
 msgstr[0] ""
+msgstr[1] ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit.html:3 src/olympia/devhub/templates/devhub/addons/listing/item_actions.html:25
 #: src/olympia/devhub/templates/devhub/addons/listing/item_actions_theme.html:7 src/olympia/devhub/templates/devhub/includes/addons_edit_nav.html:2
@@ -4350,7 +4356,7 @@ msgstr "هیچ"
 msgid "Manage Authors & License"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/addons/owner.html:29 src/olympia/editors/templates/editors/review.html:270
+#: src/olympia/devhub/templates/devhub/addons/owner.html:29 src/olympia/editors/helpers.py:362 src/olympia/editors/templates/editors/review.html:270
 msgid "Authors"
 msgstr "مؤلفان"
 
@@ -4419,17 +4425,11 @@ msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/basic.html:52
 msgid ""
-"A short explanation of your add-on's basic\n"
-"                          functionality that is displayed in search and browse\n"
-"                          listings, as well as at the top of your add-on's\n"
-"                          details page. It is only relevant for listed add-ons."
+"A short explanation of your add-on's basic functionality that is displayed in search and browse listings, as well as at the top of your add-on's details page. It is only relevant for listed add-ons."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/basic.html:73
-msgid ""
-"Categories are the primary way users browse through add-ons.\n"
-"                        Choose any that fit your add-on's functionality for the most\n"
-"                        exposure. It is only relevant for listed add-ons."
+msgid "Categories are the primary way users browse through add-ons. Choose any that fit your add-on's functionality for the most exposure. It is only relevant for listed add-ons."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/basic.html:90
@@ -4439,17 +4439,14 @@ msgid ""
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/basic.html:119
-msgid ""
-"Tags help users find your add-on and should be short\n"
-"                        descriptors such as tabs, toolbar, or twitter.  You\n"
-"                        may have a maximum of {0} tags. It is only relevant\n"
-"                        for listed add-ons."
+msgid "Tags help users find your add-on and should be short descriptors such as tabs, toolbar, or twitter. You may have a maximum of {0} tags. It is only relevant for listed add-ons."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/basic.html:129 src/olympia/devhub/templates/devhub/personas/edit.html:97 src/olympia/devhub/templates/devhub/personas/submit.html:46
 msgid "Comma-separated, minimum of {0} character."
 msgid_plural "Comma-separated, minimum of {0} characters."
 msgstr[0] ""
+msgstr[1] ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/basic.html:132 src/olympia/devhub/templates/devhub/personas/edit.html:100 src/olympia/devhub/templates/devhub/personas/submit.html:49
 msgid "Example: dark, cinema, noir. Limit 20."
@@ -4459,6 +4456,7 @@ msgstr ""
 msgid "Reserved tag:"
 msgid_plural "Reserved tags:"
 msgstr[0] ""
+msgstr[1] ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/details.html:5
 msgid "Add-on Details"
@@ -4469,11 +4467,7 @@ msgid "Add-on Details for {0}"
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/details.html:22
-msgid ""
-"A longer explanation of features,\n"
-"                          functionality, and other relevant information. This\n"
-"                          field is only displayed on the add-on's details\n"
-"                          page. It is only relevant for listed add-ons."
+msgid "A longer explanation of features, functionality, and other relevant information. This field is only displayed on the add-on's details page. It is only relevant for listed add-ons."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/details.html:44 src/olympia/translations/templates/translations/trans-menu.html:13
@@ -4481,10 +4475,7 @@ msgid "Default Locale"
 msgstr "زبان پیش‌فرض"
 
 #: src/olympia/devhub/templates/devhub/addons/edit/details.html:45
-msgid ""
-"Information about your add-on is displayed in this locale\n"
-"                        unless you override it with a locale-specific translation.\n"
-"                        It is only relevant for listed add-ons."
+msgid "Information about your add-on is displayed in this locale unless you override it with a locale-specific translation. It is only relevant for listed add-ons."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/details.html:61 src/olympia/users/forms.py:311 src/olympia/users/templates/users/edit.html:122 src/olympia/users/templates/users/register.html:57
@@ -4494,10 +4485,8 @@ msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/details.html:63
 msgid ""
-"If your add-on has another homepage, enter its\n"
-"                          address here. If your website is localized into other\n"
-"                          languages multiple translations of this field can be\n"
-"                          added. It is only relevant for listed add-ons."
+"If your add-on has another homepage, enter its address here. If your website is localized into other languages multiple translations of this field can be added. It is only relevant for listed add-"
+"ons."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/media.html:3
@@ -4515,19 +4504,14 @@ msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/support.html:22
 msgid ""
-"If you wish to display an e-mail address for support\n"
-"                          inquiries, enter it here. If you have different\n"
-"                          addresses for each language multiple translations of\n"
-"                          this field can be added. It is only relevant for\n"
-"                          listed add-ons."
+"If you wish to display an e-mail address for support inquiries, enter it here. If you have different addresses for each language multiple translations of this field can be added. It is only "
+"relevant for listed add-ons."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/support.html:45
 msgid ""
-"If your add-on has a support website or forum, enter\n"
-"                          its address here. If your website is localized into\n"
-"                          other languages, multiple translations of this field can\n"
-"                          be added. It is only relevant for listed add-ons."
+"If your add-on has a support website or forum, enter its address here. If your website is localized into other languages, multiple translations of this field can be added. It is only relevant for "
+"listed add-ons."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:6
@@ -4541,11 +4525,8 @@ msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:23
 msgid ""
-"Any information end users may want to know that isn't\n"
-"                          necessarily applicable to the add-on summary or description.\n"
-"                          Common uses include listing known major bugs, information on\n"
-"                          how to report bugs, anticipated release date of a new version,\n"
-"                          etc. It is only relevant for listed add-ons."
+"Any information end users may want to know that isn't necessarily applicable to the add-on summary or description. Common uses include listing known major bugs, information on how to report bugs, "
+"anticipated release date of a new version, etc. It is only relevant for listed add-ons."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:46
@@ -4557,9 +4538,7 @@ msgid "Add-on Flags"
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:69
-msgid ""
-"These flags are used to classify add-ons. It is only\n"
-"                        relevant for listed add-ons."
+msgid "These flags are used to classify add-ons. It is only relevant for listed add-ons."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:74
@@ -4575,9 +4554,7 @@ msgid "View Source?"
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:90
-msgid ""
-"Whether the source of your add-on can be displayed in our\n"
-"                        online viewer. It is only relevant for listed add-ons."
+msgid "Whether the source of your add-on can be displayed in our online viewer. It is only relevant for listed add-ons."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:94
@@ -4593,10 +4570,7 @@ msgid "Public Stats?"
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:102
-msgid ""
-"Whether the download and usage stats of your add-on can\n"
-"                        be displayed in our online viewer.\n"
-"                        It is only relevant for listed add-ons."
+msgid "Whether the download and usage stats of your add-on can be displayed in our online viewer. It is only relevant for listed add-ons."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:107
@@ -4612,10 +4586,7 @@ msgid "Upgrade SDK?"
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:116
-msgid ""
-"If selected, we will try to automatically upgrade your\n"
-"                        add-on when a new version of the SDK is released.\n"
-"                        It is only relevant for listed add-ons."
+msgid "If selected, we will try to automatically upgrade your add-on when a new version of the SDK is released. It is only relevant for listed add-ons."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:121
@@ -4667,10 +4638,8 @@ msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/forms_shared/media.html:16
 msgid ""
-"Upload an icon for your add-on or choose from one of ours. The\n"
-"                      icon is displayed nearly everywhere your add-on is. Uploaded images\n"
-"                      must be one of the following image types: .png, .jpg.\n"
-"                      It is only relevant for listed add-ons."
+"Upload an icon for your add-on or choose from one of ours. The icon is displayed nearly everywhere your add-on is. Uploaded images must be one of the following image types: .png, .jpg. It is only "
+"relevant for listed add-ons."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/forms_shared/media.html:25
@@ -4683,9 +4652,7 @@ msgid "32x32px"
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/forms_shared/media.html:39
-msgid ""
-"Used in listings of add-ons, like search results\n"
-"                            and featured add-ons."
+msgid "Used in listings of add-ons, like search results and featured add-ons."
 msgstr ""
 
 #. The size of the icon
@@ -4780,16 +4747,14 @@ msgid "Deleting your add-on will permanently remove it from the site and prevent
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:24
-msgid ""
-"Enter the following text confirm your decision:\n"
-"           {slug}"
+msgid "Enter the following text confirm your decision: {slug}"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:34
+#: src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:33
 msgid "Please tell us why you are deleting your theme:"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:36
+#: src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:35
 msgid "Please tell us why you are deleting your add-on:"
 msgstr ""
 
@@ -4826,8 +4791,8 @@ msgstr "نسخهٔ جدید"
 msgid "Daily statistics on downloads and users."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/addons/listing/item_actions.html:45 src/olympia/stats/templates/stats/stats.html:75 src/olympia/stats/templates/stats/stats.html:79
-#: src/olympia/stats/templates/stats/stats.html:81
+#: src/olympia/devhub/templates/devhub/addons/listing/item_actions.html:45 src/olympia/stats/templates/stats/stats.html:31 src/olympia/stats/templates/stats/stats.html:35
+#: src/olympia/stats/templates/stats/stats.html:37
 msgid "Statistics"
 msgstr "آمار"
 
@@ -4887,6 +4852,7 @@ msgstr ""
 msgid "<strong>{0}</strong> active user"
 msgid_plural "<strong>{0}</strong> active users"
 msgstr[0] ""
+msgstr[1] ""
 
 #: src/olympia/devhub/templates/devhub/addons/submit/base.html:11
 msgid "Submit Add-on"
@@ -4945,10 +4911,7 @@ msgid "Your add-on has been submitted to the Full Review queue."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/submit/done.html:18
-msgid ""
-"You'll receive an email once it has been reviewed by an editor. In\n"
-"          the meantime, you and your friends can install it directly from its\n"
-"          details page:"
+msgid "You'll receive an email once it has been reviewed by an editor. In the meantime, you and your friends can install it directly from its details page:"
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/submit/done.html:27 src/olympia/devhub/templates/devhub/addons/submit/done.html:77 src/olympia/devhub/templates/devhub/personas/submit_done.html:16
@@ -5154,11 +5117,11 @@ msgstr ""
 msgid "Use the fields below to upload your add-on package and select any platform restrictions. After upload, a series of automated validation tests will be run on your file."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/addons/submit/upload.html:59 src/olympia/devhub/templates/devhub/versions/add_file_modal.html:39
+#: src/olympia/devhub/templates/devhub/addons/submit/upload.html:51 src/olympia/devhub/templates/devhub/versions/add_file_modal.html:28
 msgid "Which platforms is this file compatible with?"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/addons/submit/upload.html:67 src/olympia/devhub/templates/devhub/versions/add_file_modal.html:65
+#: src/olympia/devhub/templates/devhub/addons/submit/upload.html:59 src/olympia/devhub/templates/devhub/versions/add_file_modal.html:45
 msgid "Administrative overrides"
 msgstr ""
 
@@ -5268,8 +5231,8 @@ msgstr ""
 
 #: src/olympia/devhub/templates/devhub/docs/policies-contact.html:44
 msgid ""
-"If you've found a problem with the site, we'd love to fix it. Please <a href=\"https://github.com/mozilla/olympia/issues\">file a bug report</a> in GitHub, including the location of the problem and "
-"how you encountered it."
+"If you've found a problem with the site, we'd love to fix it. Please <a href=\"https://github.com/mozilla/addons/issues/new\">file a bug report</a> in GitHub, including the location of the problem "
+"and how you encountered it."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/docs/policies-maintenance.html:3 src/olympia/devhub/templates/devhub/docs/policies-maintenance.html:7
@@ -5836,7 +5799,7 @@ msgstr ""
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:282
 msgid ""
-"Add-ons that store or otherwise handle browsing data must support <a href=\"https://developer.mozilla.org/En/Supporting_private_browsing_mode\">Private Browsing Mode</a>.  During a Private Browsing "
+"Add-ons that store or otherwise handle browsing data must support <a href=\"https://developer.mozilla.org/En/Supporting_private_browsing_mode\">Private Browsing Mode</a>. During a Private Browsing "
 "session, no browsing data can be written to disk, and all of this data must be cleared when Firefox quits or the Private Browsing session ends."
 msgstr ""
 
@@ -6001,131 +5964,97 @@ msgstr ""
 msgid "How to get in touch with us regarding these policies or your add-on."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:6
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:10
 msgid "You have disabled this add-on"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:20
-msgid ""
-"Your add-on's listing is disabled and is not showing\n"
-"                             anywhere in our gallery or update service."
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:24
+msgid "Your add-on's listing is disabled and is not showing anywhere in our gallery or update service."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:25
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:27
 msgid "Please complete your add-on."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:29
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:30
 msgid "You will receive an email when the review is complete."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:34
-msgid ""
-"You will receive an email when the review is complete. Until\n"
-"                             then, your add-on is not listed in our gallery but can be\n"
-"                             accessed directly from its details page."
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:33
+msgid "You will receive an email when the review is complete. Until then, your add-on is not listed in our gallery but can be accessed directly from its details page."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:38 src/olympia/devhub/templates/devhub/includes/addon_details.html:48
-msgid ""
-"You will receive an email when the review is\n"
-"                             complete and your add-on is signed."
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:37 src/olympia/devhub/templates/devhub/includes/addon_details.html:45
+msgid "You will receive an email when the review is complete and your add-on is signed."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:44
-msgid ""
-"You will receive an email when the review is complete. Until\n"
-"                             then, your add-on is not listed in our gallery but can be\n"
-"                             accessed directly from its details page. "
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:41
+msgid "You will receive an email when the review is complete. Until then, your add-on is not listed in our gallery but can be accessed directly from its details page. "
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:54
-msgid ""
-"Your add-on is displayed in our gallery and users are\n"
-"                             receiving automatic updates."
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:49
+msgid "Your add-on is displayed in our gallery and users are receiving automatic updates."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:57
-msgid ""
-"Your add-on has been signed and can be bundled with an\n"
-"                             application installer."
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:52
+msgid "Your add-on has been signed and can be bundled with an application installer."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:63
-msgid ""
-"Your add-on was disabled by a site administrator and is no\n"
-"                             longer shown in our gallery. If you have any questions,\n"
-"                             please email amo-admins@mozilla.org."
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:56
+msgid "Your add-on was disabled by a site administrator and is no longer shown in our gallery. If you have any questions, please email amo-admins@mozilla.org."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:70
-msgid ""
-"Your add-on is displayed in our gallery as experimental\n"
-"                             and users are receiving automatic updates. Some features\n"
-"                             are unavailable to your add-on."
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:62
+msgid "Your add-on is displayed in our gallery as experimental and users are receiving automatic updates. Some features are unavailable to your add-on."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:74
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:66
 msgid "Your add-on has been signed."
 msgstr ""
 
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:69
+msgid ""
+"You will receive an email when the full review is complete. Until then, your add-on is displayed in our gallery as experimental and users are receiving automatic updates. Some features are "
+"unavailable to your add-on."
+msgstr ""
+
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:74
+msgid "You will receive an email when the full review is complete, making you able to bundle your add-on with an application installer."
+msgstr ""
+
 #: src/olympia/devhub/templates/devhub/includes/addon_details.html:79
-msgid ""
-"You will receive an email when the full review is complete.\n"
-"                             Until then, your add-on is displayed in our gallery as\n"
-"                             experimental and users are receiving automatic updates.\n"
-"                             Some features are unavailable to your add-on."
+msgid "All add-ons hosted in our gallery must now be reviewed by an editor. If you wish to continue hosting your add-on, please click to select a review process."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:84
-msgid ""
-"You will receive an email when the full review is\n"
-"                             complete, making you able to bundle your add-on with an\n"
-"                             application installer."
-msgstr ""
-
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:91
-msgid ""
-"All add-ons hosted in our gallery must now be reviewed by an\n"
-"                             editor. If you wish to continue hosting your add-on, please\n"
-"                             click to select a review process."
-msgstr ""
-
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:113
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:100
 msgid "Current Version:"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:115
-msgid ""
-"This is the version of your add-on that will\n"
-"                                           be installed if someone clicks the Install\n"
-"                                           button on addons.mozilla.org. It is only\n"
-"                                           relevant for listed add-ons."
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:102
+msgid "This is the version of your add-on that will be installed if someone clicks the Install button on addons.mozilla.org. It is only relevant for listed add-ons."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:123
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:110
 #, fuzzy
 msgid "Created:"
 msgstr "ایجاد شده در تاریخ"
 
 #. {0} is a date. dennis-ignore: E201
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:125 src/olympia/devhub/templates/devhub/includes/addon_details.html:131
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:112 src/olympia/devhub/templates/devhub/includes/addon_details.html:118
 #, python-format
 msgid "%%b %%e, %%Y"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:136
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:123
 #, fuzzy
 msgid "Next Version:"
 msgstr "نسخهٔ جدید"
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:138
-msgid ""
-"This is the newest uploaded version, however\n"
-"                                           it isn’t live on the site yet."
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:125
+msgid "This is the newest uploaded version, however it isn’t live on the site yet."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:144 src/olympia/devhub/templates/devhub/versions/list.html:30
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:130 src/olympia/devhub/templates/devhub/versions/list.html:30
 msgid "Queues are not reviewed strictly in order"
 msgstr ""
 
@@ -6194,9 +6123,7 @@ msgid "View the blog &#9658;"
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/includes/license_form.html:6
-msgid ""
-"Please choose a license appropriate for the rights you grant on your source code.\n"
-"                  It is only relevant for listed add-ons."
+msgid "Please choose a license appropriate for the rights you grant on your source code. It is only relevant for listed add-ons."
 msgstr ""
 
 #. {0} is a list of HTML tags.
@@ -6218,18 +6145,16 @@ msgstr ""
 msgid "Select <b>up to {0}</b> {1} category for this add-on:"
 msgid_plural "Select <b>up to {0}</b> {1} categories for this add-on:"
 msgstr[0] ""
+msgstr[1] ""
 
 #: src/olympia/devhub/templates/devhub/includes/policy_form.html:4
 msgid ""
 "Users will be required to accept the following End-User License Agreement (EULA) prior to installing your add-on. The presence of a EULA significantly affects the number of downloads an add-on "
-"receives. Please note that a EULA is not the same as a code license, such as the GPL or MPL.\n"
-"                It is only relevant for listed add-ons."
+"receives. Please note that a EULA is not the same as a code license, such as the GPL or MPL.It is only relevant for listed add-ons."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/policy_form.html:21
-msgid ""
-"If your add-on transmits any data from the user's computer, a privacy policy is required that explains what data is sent and how it is used.\n"
-"                It is only relevant for listed add-ons."
+#: src/olympia/devhub/templates/devhub/includes/policy_form.html:24
+msgid "If your add-on transmits any data from the user's computer, a privacy policy is required that explains what data is sent and how it is used. It is only relevant for listed add-ons."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/includes/source_form_field.html:2
@@ -6397,12 +6322,8 @@ msgstr ""
 msgid "Add some tags to describe your Theme."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/personas/edit.html:106
-msgid ""
-"A short explanation of your theme's\n"
-"                                basic functionality that is displayed in\n"
-"                                search and browse listings, as well as at\n"
-"                                the top of your theme's details page."
+#: src/olympia/devhub/templates/devhub/personas/edit.html:106 src/olympia/devhub/templates/devhub/personas/submit.html:54
+msgid "A short explanation of your theme's basic functionality that is displayed in search and browse listings, as well as at the top of your theme's details page."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/personas/edit.html:122 src/olympia/devhub/templates/devhub/personas/submit.html:68
@@ -6472,7 +6393,7 @@ msgid "Upon upload and form submission, the AMO Team will review your updated de
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/personas/edit.html:241
-msgid "Your previously resubmitted design,  which is under pending review."
+msgid "Your previously resubmitted design, which is under pending review."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/personas/edit.html:245
@@ -6539,14 +6460,6 @@ msgstr ""
 
 #: src/olympia/devhub/templates/devhub/personas/submit.html:33
 msgid "Give your Theme a name."
-msgstr ""
-
-#: src/olympia/devhub/templates/devhub/personas/submit.html:54
-msgid ""
-"A short explanation of your theme's\n"
-"                                      basic functionality that is displayed in\n"
-"                                      search and browse listings, as well as at\n"
-"                                      the top of your theme's details page."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/personas/submit.html:198
@@ -6623,30 +6536,16 @@ msgstr ""
 msgid "Files added to reviewed versions must be reviewed before they will be available for download."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/add_file_modal.html:15
-#, python-format
-msgid ""
-"Submission of updates to unlisted add-ons for signing is currently in an open beta. Manual review may still be required for a large number of add-ons. Please <a href=\"%(url)s\" target=\"_blank"
-"\">report any bugs</a> that you encounter."
-msgstr ""
-
-#: src/olympia/devhub/templates/devhub/versions/add_file_modal.html:35
+#: src/olympia/devhub/templates/devhub/versions/add_file_modal.html:24
 msgid "Select the target platform for this file."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/add_file_modal.html:46
+#: src/olympia/devhub/templates/devhub/versions/add_file_modal.html:35
 msgid "Which review type would you like to nominate for?"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/add_file_modal.html:51
+#: src/olympia/devhub/templates/devhub/versions/add_file_modal.html:40
 msgid "Only publish this version to my beta channel."
-msgstr ""
-
-#: src/olympia/devhub/templates/devhub/versions/add_file_modal.html:54
-#, python-format
-msgid ""
-"The behavior of the beta channel has changed to accommodate <a href=\"%(addon_signing_url)s\" target=\"_blank\">mandatory add-on signing</a>. The new process is currently in an open beta, and may "
-"change significantly in the near future. Please <a href=\"%(issues_url)s\" target=\"_blank\">report any bugs</a> that you encounter."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/versions/edit.html:5
@@ -6671,19 +6570,10 @@ msgstr ""
 msgid "Upload Another File"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/edit.html:45
-msgid ""
-"Adjusting application information here will allow users to install your\n"
-"                          add-on even if the install manifest in the package indicates that the\n"
-"                          add-on is incompatible."
-msgstr ""
-
 #: src/olympia/devhub/templates/devhub/versions/edit.html:74
 msgid ""
-"Information about changes in this release, new features,\n"
-"                              known bugs, and other useful information specific to this\n"
-"                              release/version. This information is also shown in the\n"
-"                              Add-ons Manager when updating."
+"Information about changes in this release, new features, known bugs, and other useful information specific to this release/version. This information is also shown in the Add-ons Manager when "
+"updating."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/versions/edit.html:99
@@ -6695,10 +6585,7 @@ msgid "Notes for Reviewers"
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/versions/edit.html:114
-msgid ""
-"Optionally, enter any information that may be useful\n"
-"                              to the Editor reviewing this add-on, such as test\n"
-"                              account information."
+msgid "Optionally, enter any information that may be useful to the Editor reviewing this add-on, such as test account information."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/versions/edit.html:127
@@ -6749,6 +6636,7 @@ msgstr ""
 msgid "{0} file"
 msgid_plural "{0} files"
 msgstr[0] ""
+msgstr[1] ""
 
 #: src/olympia/devhub/templates/devhub/versions/list.html:25
 msgid "0 files"
@@ -6775,7 +6663,7 @@ msgstr ""
 msgid "Request Preliminary Review"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:80 src/olympia/devhub/templates/devhub/versions/list.html:327 src/olympia/devhub/templates/devhub/versions/list.html:350
+#: src/olympia/devhub/templates/devhub/versions/list.html:80 src/olympia/devhub/templates/devhub/versions/list.html:325 src/olympia/devhub/templates/devhub/versions/list.html:348
 msgid "Cancel Review Request"
 msgstr ""
 
@@ -6804,7 +6692,7 @@ msgid "Unlisted:"
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/versions/list.html:114
-msgid "Not distributed on {0}. Developers will upload new versions for signing and distribute the add-ons on their own. (beta)"
+msgid "Not distributed on {0}. Developers will upload new versions for signing and distribute the add-ons on their own."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/versions/list.html:122
@@ -6867,81 +6755,73 @@ msgid "<strong>Important:</strong> Once a version has been deleted, you may not 
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/versions/list.html:230
-msgid ""
-"Deleting a version which has already been reviewed\n"
-"               may also cause a significant delay in the review of\n"
-"               your next update."
-msgstr ""
-
-#: src/olympia/devhub/templates/devhub/versions/list.html:233
 msgid "Are you sure you wish to delete this version?"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:238
+#: src/olympia/devhub/templates/devhub/versions/list.html:235
 msgid "Delete Version"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:240
+#: src/olympia/devhub/templates/devhub/versions/list.html:237
 msgid "Disable Version"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:247
+#: src/olympia/devhub/templates/devhub/versions/list.html:244
 msgid "Add a new Version"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:249
+#: src/olympia/devhub/templates/devhub/versions/list.html:246
 msgid "Add Version"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:256 src/olympia/devhub/templates/devhub/versions/list.html:274
+#: src/olympia/devhub/templates/devhub/versions/list.html:253 src/olympia/devhub/templates/devhub/versions/list.html:279
 msgid "Hide Add-on"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:259
+#: src/olympia/devhub/templates/devhub/versions/list.html:256
 msgid "Hiding your add-on will prevent it from appearing anywhere in our gallery and will stop users from receiving automatic updates."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:265
+#: src/olympia/devhub/templates/devhub/versions/list.html:263
+msgid "The files awaiting review will be disabled and you will need to upload new versions."
+msgstr ""
+
+#: src/olympia/devhub/templates/devhub/versions/list.html:270
 msgid "Are you sure you wish to hide your add-on?"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:286 src/olympia/devhub/templates/devhub/versions/list.html:315
+#: src/olympia/devhub/templates/devhub/versions/list.html:291 src/olympia/devhub/templates/devhub/versions/list.html:313
 msgid "Unlist Add-on"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:289
+#: src/olympia/devhub/templates/devhub/versions/list.html:294
 #, python-format
 msgid ""
 "Unlisting your add-on will make it (and each of its versions/files) invisible on this website. It won't show up in searches, won't have a public facing page, and won't be updated automatically for "
-"current users.  It is recommended for unlisted add-ons to provide a custom <a href=\"%(update_url)s\" target=\"_blank\">updateURL</a> in their manifest file for automatic updates."
+"current users. It is recommended for unlisted add-ons to provide a custom <a href=\"%(update_url)s\" target=\"_blank\">updateURL</a> in their manifest file for automatic updates."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:299
-#, python-format
-msgid "Switching add-ons to unlisted is currently in an open beta. Please <a href=\"%(url)s\" target=\"_blank\">report any bugs</a> that you encounter."
-msgstr ""
-
-#: src/olympia/devhub/templates/devhub/versions/list.html:305
+#: src/olympia/devhub/templates/devhub/versions/list.html:303
 msgid "Unlisting an add-on is irreversible!"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:305
+#: src/olympia/devhub/templates/devhub/versions/list.html:303
 msgid "An unlisted add-on cannot be switched to be listed."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:307
+#: src/olympia/devhub/templates/devhub/versions/list.html:305
 msgid "Are you sure you wish to unlist your add-on?"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:330
+#: src/olympia/devhub/templates/devhub/versions/list.html:328
 msgid "Canceling your review request will leave your add-on as preliminarily reviewed."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:335
+#: src/olympia/devhub/templates/devhub/versions/list.html:333
 msgid "Canceling your review request will mark your add-on incomplete. If you do not complete your add-on after several days by re-requesting review, it will be deleted."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:343
+#: src/olympia/devhub/templates/devhub/versions/list.html:341
 msgid "Are you sure you wish to cancel your review request?"
 msgstr ""
 
@@ -7283,19 +7163,19 @@ msgstr ""
 msgid "Search by add-on name / author email"
 msgstr ""
 
-#: src/olympia/editors/forms.py:103
+#: src/olympia/editors/forms.py:103 src/olympia/editors/forms.py:244 src/olympia/editors/forms.py:257
 msgid "yes"
 msgstr "بله"
 
-#: src/olympia/editors/forms.py:104
+#: src/olympia/editors/forms.py:104 src/olympia/editors/forms.py:244 src/olympia/editors/forms.py:257
 msgid "no"
 msgstr "خیر"
 
-#: src/olympia/editors/forms.py:105
+#: src/olympia/editors/forms.py:105 src/olympia/editors/forms.py:245
 msgid "Admin Flag"
 msgstr ""
 
-#: src/olympia/editors/forms.py:113
+#: src/olympia/editors/forms.py:113 src/olympia/editors/forms.py:253
 msgid "Max. Version"
 msgstr ""
 
@@ -7307,55 +7187,59 @@ msgstr ""
 msgid "Add-on Types"
 msgstr ""
 
-#: src/olympia/editors/forms.py:126 src/olympia/editors/helpers.py:267
+#: src/olympia/editors/forms.py:126 src/olympia/editors/helpers.py:279
 msgid "Platforms"
 msgstr "سکوهای نرم‌افزاری"
 
+#: src/olympia/editors/forms.py:237
+msgid "Search by add-on name / author email / guid"
+msgstr ""
+
 #. L10n: 0 = platform, 1 = filename, 2 = status message
-#: src/olympia/editors/forms.py:238
+#: src/olympia/editors/forms.py:342
 #, python-format
 msgid "<strong>%s</strong> &middot; %s &middot; %s"
 msgstr ""
 
-#: src/olympia/editors/forms.py:252
+#: src/olympia/editors/forms.py:356
 msgid "Comments:"
 msgstr ""
 
-#: src/olympia/editors/forms.py:256
+#: src/olympia/editors/forms.py:360
 msgid "Operating systems:"
 msgstr ""
 
-#: src/olympia/editors/forms.py:258
+#: src/olympia/editors/forms.py:362
 msgid "Applications:"
 msgstr ""
 
-#: src/olympia/editors/forms.py:260
+#: src/olympia/editors/forms.py:364
 msgid "Notify me the next time this add-on is updated. (Subsequent updates will not generate an email)"
 msgstr ""
 
-#: src/olympia/editors/forms.py:265
+#: src/olympia/editors/forms.py:369
 msgid "Clear Admin Review Flag"
 msgstr ""
 
-#: src/olympia/editors/forms.py:267
+#: src/olympia/editors/forms.py:371
 msgid "Clear more info requested flag"
 msgstr ""
 
-#: src/olympia/editors/forms.py:281
+#: src/olympia/editors/forms.py:385
 msgid "Choose a canned response..."
 msgstr ""
 
 #. L10n: Description of what can be searched for.
-#: src/olympia/editors/forms.py:324
+#: src/olympia/editors/forms.py:423
 msgid "theme name"
 msgstr ""
 
-#: src/olympia/editors/forms.py:350
+#: src/olympia/editors/forms.py:449
 msgid "Someone else is reviewing this theme."
 msgstr ""
 
 #. L10n: Description of what can be searched for.
-#: src/olympia/editors/forms.py:447
+#: src/olympia/editors/forms.py:546
 msgid "app, reviewer, or comment"
 msgstr ""
 
@@ -7371,235 +7255,264 @@ msgstr ""
 msgid "Rejected or Unreviewed"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:123 src/olympia/editors/helpers.py:136
+#: src/olympia/editors/helpers.py:125 src/olympia/editors/helpers.py:138
 msgid "Queue"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:124 src/olympia/editors/templates/editors/base.html:50 src/olympia/editors/templates/editors/base.html:65
+#: src/olympia/editors/helpers.py:126 src/olympia/editors/templates/editors/base.html:50 src/olympia/editors/templates/editors/base.html:65
 msgid "Pending Updates"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:125 src/olympia/editors/templates/editors/base.html:48 src/olympia/editors/templates/editors/base.html:63
+#: src/olympia/editors/helpers.py:127 src/olympia/editors/templates/editors/base.html:48 src/olympia/editors/templates/editors/base.html:63
 msgid "Full Reviews"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:126 src/olympia/editors/templates/editors/base.html:52 src/olympia/editors/templates/editors/base.html:67
+#: src/olympia/editors/helpers.py:128 src/olympia/editors/templates/editors/base.html:52 src/olympia/editors/templates/editors/base.html:67
 msgid "Preliminary Reviews"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:127 src/olympia/editors/templates/editors/base.html:54
+#: src/olympia/editors/helpers.py:129 src/olympia/editors/templates/editors/base.html:54
 msgid "Moderated Reviews"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:128 src/olympia/editors/templates/editors/base.html:46
+#: src/olympia/editors/helpers.py:130 src/olympia/editors/templates/editors/base.html:46
 msgid "Fast Track"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:130
+#: src/olympia/editors/helpers.py:132
 msgid "Pending Themes"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:131 src/olympia/editors/templates/editors/themes/queue.html:4
+#: src/olympia/editors/helpers.py:133 src/olympia/editors/templates/editors/themes/queue.html:4
 msgid "Flagged Themes"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:132
+#: src/olympia/editors/helpers.py:134
 msgid "Update Themes"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:137
+#: src/olympia/editors/helpers.py:139
 msgid "Unlisted Pending Updates"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:138
+#: src/olympia/editors/helpers.py:140
 msgid "Unlisted Full Reviews"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:139
+#: src/olympia/editors/helpers.py:141
 msgid "Unlisted Preliminary Reviews"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:170
+#: src/olympia/editors/helpers.py:142
+msgid "Unlisted All Add-ons"
+msgstr ""
+
+#: src/olympia/editors/helpers.py:173
 msgid "Fast Track ({0})"
 msgid_plural "Fast Track ({0})"
 msgstr[0] ""
+msgstr[1] ""
 
-#: src/olympia/editors/helpers.py:175
+#: src/olympia/editors/helpers.py:178
 msgid "Full Review ({0})"
 msgid_plural "Full Reviews ({0})"
 msgstr[0] ""
+msgstr[1] ""
 
-#: src/olympia/editors/helpers.py:180
+#: src/olympia/editors/helpers.py:183
 msgid "Pending Update ({0})"
 msgid_plural "Pending Updates ({0})"
 msgstr[0] ""
+msgstr[1] ""
 
-#: src/olympia/editors/helpers.py:185
+#: src/olympia/editors/helpers.py:188
 msgid "Preliminary Review ({0})"
 msgid_plural "Preliminary Reviews ({0})"
 msgstr[0] ""
+msgstr[1] ""
 
-#: src/olympia/editors/helpers.py:190
+#: src/olympia/editors/helpers.py:193
 msgid "Moderated Review ({0})"
 msgid_plural "Moderated Reviews ({0})"
 msgstr[0] ""
+msgstr[1] ""
 
-#: src/olympia/editors/helpers.py:196
+#: src/olympia/editors/helpers.py:199
 msgid "Unlisted Full Review ({0})"
 msgid_plural "Unlisted Full Reviews ({0})"
 msgstr[0] ""
+msgstr[1] ""
 
-#: src/olympia/editors/helpers.py:201
+#: src/olympia/editors/helpers.py:204
 msgid "Unlisted Pending Update ({0})"
 msgid_plural "Unlisted Pending Updates ({0})"
 msgstr[0] ""
+msgstr[1] ""
 
-#: src/olympia/editors/helpers.py:206
+#: src/olympia/editors/helpers.py:209
 msgid "Unlisted Preliminary Review ({0})"
 msgid_plural "Unlisted Preliminary Reviews ({0})"
 msgstr[0] ""
+msgstr[1] ""
 
-#: src/olympia/editors/helpers.py:261
-msgid "Addon"
-msgstr ""
+#: src/olympia/editors/helpers.py:214
+msgid "Unlisted All Add-ons ({0})"
+msgid_plural "Unlisted All Add-ons ({0})"
+msgstr[0] ""
+msgstr[1] ""
 
-#: src/olympia/editors/helpers.py:262
+#: src/olympia/editors/helpers.py:274
 msgid "Type"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:263
+#: src/olympia/editors/helpers.py:275
 msgid "Waiting Time"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:264 src/olympia/editors/templates/editors/review.html:285
+#: src/olympia/editors/helpers.py:276 src/olympia/editors/templates/editors/review.html:285
 msgid "Flags"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:265
+#: src/olympia/editors/helpers.py:277
 msgid "Applications"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:270
+#: src/olympia/editors/helpers.py:282
 msgid "Additional"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:285
+#: src/olympia/editors/helpers.py:302
 msgid "Site Specific"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:287
+#: src/olympia/editors/helpers.py:304
 msgid "Requires External Software"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:289
+#: src/olympia/editors/helpers.py:306
 msgid "Binary Components"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:313
+#: src/olympia/editors/helpers.py:339
 msgid "moments ago"
 msgstr ""
 
 #. L10n: first argument is number of minutes
-#: src/olympia/editors/helpers.py:316
+#: src/olympia/editors/helpers.py:342
 msgid "{0} minute"
 msgid_plural "{0} minutes"
 msgstr[0] ""
+msgstr[1] ""
 
 #. L10n: first argument is number of hours
-#: src/olympia/editors/helpers.py:320
+#: src/olympia/editors/helpers.py:346
 msgid "{0} hour"
 msgid_plural "{0} hours"
 msgstr[0] ""
+msgstr[1] ""
 
 #. L10n: first argument is number of days
-#: src/olympia/editors/helpers.py:324
+#: src/olympia/editors/helpers.py:350
 msgid "{0} day"
 msgid_plural "{0} days"
 msgstr[0] ""
+msgstr[1] ""
 
-#: src/olympia/editors/helpers.py:488
+#: src/olympia/editors/helpers.py:364
+msgid "Last Review"
+msgstr ""
+
+#: src/olympia/editors/helpers.py:366
+msgid "Last Update"
+msgstr ""
+
+#: src/olympia/editors/helpers.py:387
+msgid "No Reviews"
+msgstr ""
+
+#: src/olympia/editors/helpers.py:561
 msgid "Push to public"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:490
+#: src/olympia/editors/helpers.py:563
 msgid "Grant full review"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:505
+#: src/olympia/editors/helpers.py:578
 msgid "Request more information"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:508
+#: src/olympia/editors/helpers.py:581
 msgid "Request super-review"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:519
+#: src/olympia/editors/helpers.py:592
 msgid "Grant preliminary review"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:520
+#: src/olympia/editors/helpers.py:593
 msgid "This will mark the files as preliminarily reviewed."
 msgstr ""
 
-#: src/olympia/editors/helpers.py:522
+#: src/olympia/editors/helpers.py:595
 msgid "Use this form to request more information from the author. They will receive an email and be able to answer here. You will be notified by email when they reply."
 msgstr ""
 
-#: src/olympia/editors/helpers.py:526
+#: src/olympia/editors/helpers.py:599
 msgid ""
 "If you have concerns about this add-on's security, copyright issues, or other concerns that an administrator should look into, enter your comments in the area below. They will be sent to "
 "administrators, not the author."
 msgstr ""
 
-#: src/olympia/editors/helpers.py:532
+#: src/olympia/editors/helpers.py:605
 msgid "This will reject the add-on and remove it from the review queue."
 msgstr ""
 
-#: src/olympia/editors/helpers.py:534
-msgid "Make a comment on this version.  The author won't be able to see this."
+#: src/olympia/editors/helpers.py:607
+msgid "Make a comment on this version. The author won't be able to see this."
 msgstr ""
 
-#: src/olympia/editors/helpers.py:538
+#: src/olympia/editors/helpers.py:611
 msgid "This will reject the files and remove them from the review queue."
 msgstr ""
 
-#: src/olympia/editors/helpers.py:542
+#: src/olympia/editors/helpers.py:615
 msgid "This will mark the add-on as preliminarily reviewed. Future versions will undergo preliminary review."
 msgstr ""
 
-#: src/olympia/editors/helpers.py:547
+#: src/olympia/editors/helpers.py:620
 msgid "This will mark the files as preliminarily reviewed. Future versions will undergo preliminary review."
 msgstr ""
 
-#: src/olympia/editors/helpers.py:552
+#: src/olympia/editors/helpers.py:625
 msgid "Retain preliminary review"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:553
+#: src/olympia/editors/helpers.py:626
 msgid "This will retain the add-on as preliminarily reviewed. Future versions will undergo preliminary review."
 msgstr ""
 
-#: src/olympia/editors/helpers.py:558
+#: src/olympia/editors/helpers.py:631
 msgid "This will approve a sandboxed version of a public add-on to appear on the public side."
 msgstr ""
 
-#: src/olympia/editors/helpers.py:561
+#: src/olympia/editors/helpers.py:634
 msgid "This will reject a version of a public add-on and remove it from the queue."
 msgstr ""
 
-#: src/olympia/editors/helpers.py:564
+#: src/olympia/editors/helpers.py:637
 msgid "This will mark the add-on and its most recent version and files as public. Future versions will go into the sandbox until they are reviewed by an editor."
 msgstr ""
 
-#: src/olympia/editors/helpers.py:637
+#: src/olympia/editors/helpers.py:714
 msgid "add-on"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:940 src/olympia/editors/helpers.py:960
+#: src/olympia/editors/helpers.py:1020 src/olympia/editors/helpers.py:1040
 msgid "Flagged"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:944 src/olympia/editors/helpers.py:963
+#: src/olympia/editors/helpers.py:1024 src/olympia/editors/helpers.py:1043
 #, fuzzy
 msgid "Updates"
 msgstr "به‌هنگام شده"
@@ -7652,56 +7565,56 @@ msgstr ""
 msgid "A question about your Theme submission"
 msgstr ""
 
-#: src/olympia/editors/views.py:144
+#: src/olympia/editors/views.py:146
 msgid "New Add-ons (Under 5 days)"
 msgstr ""
 
-#: src/olympia/editors/views.py:145
+#: src/olympia/editors/views.py:147
 msgid "Passable (5 to 10 days)"
 msgstr ""
 
-#: src/olympia/editors/views.py:146
+#: src/olympia/editors/views.py:148
 msgid "Overdue (Over 10 days)"
 msgstr ""
 
-#: src/olympia/editors/views.py:532
+#: src/olympia/editors/views.py:539
 msgid "An unknown error occurred"
 msgstr ""
 
-#: src/olympia/editors/views.py:587
+#: src/olympia/editors/views.py:592
 msgid "Self-reviews are not allowed."
 msgstr ""
 
-#: src/olympia/editors/views.py:609
+#: src/olympia/editors/views.py:613
 msgid "Review successfully processed."
 msgstr ""
 
-#: src/olympia/editors/views.py:807
+#: src/olympia/editors/views.py:812
 msgid "was approved"
 msgstr ""
 
-#: src/olympia/editors/views.py:808
+#: src/olympia/editors/views.py:813
 msgid "given preliminary review"
 msgstr ""
 
-#: src/olympia/editors/views.py:809
+#: src/olympia/editors/views.py:814
 msgid "rejected"
 msgstr ""
 
-#: src/olympia/editors/views.py:810
+#: src/olympia/editors/views.py:815
 msgctxt "editors_review_history_nominated_adminreview"
 msgid "escalated"
 msgstr ""
 
-#: src/olympia/editors/views.py:812
+#: src/olympia/editors/views.py:817
 msgid "needs more information"
 msgstr ""
 
-#: src/olympia/editors/views.py:813
+#: src/olympia/editors/views.py:818
 msgid "needs super review"
 msgstr ""
 
-#: src/olympia/editors/views.py:814
+#: src/olympia/editors/views.py:819
 msgid "commented"
 msgstr ""
 
@@ -7709,6 +7622,7 @@ msgstr ""
 msgid "{0} theme review successfully processed (+{1} points, {2} total)."
 msgid_plural "{0} theme reviews successfully processed (+{1} points, {2} total)."
 msgstr[0] ""
+msgstr[1] ""
 
 #: src/olympia/editors/views_themes.py:341
 msgid "Your theme locks have successfully been released. Other reviewers may now review those released themes. You may have to refresh the page to see the changes reflected in the table below."
@@ -7745,28 +7659,28 @@ msgstr ""
 msgid "Unlisted Queues"
 msgstr ""
 
-#: src/olympia/editors/templates/editors/base.html:72 src/olympia/editors/templates/editors/performance.html:6
+#: src/olympia/editors/templates/editors/base.html:74 src/olympia/editors/templates/editors/performance.html:6
 msgid "Performance"
 msgstr ""
 
-#: src/olympia/editors/templates/editors/base.html:75 src/olympia/editors/templates/editors/themes/base.html:19 src/olympia/editors/templates/editors/themes/base.html:38
+#: src/olympia/editors/templates/editors/base.html:77 src/olympia/editors/templates/editors/themes/base.html:19 src/olympia/editors/templates/editors/themes/base.html:38
 msgid "Logs"
 msgstr ""
 
-#: src/olympia/editors/templates/editors/base.html:78 src/olympia/editors/templates/editors/reviewlog.html:4 src/olympia/editors/templates/editors/reviewlog.html:27
+#: src/olympia/editors/templates/editors/base.html:80 src/olympia/editors/templates/editors/reviewlog.html:4 src/olympia/editors/templates/editors/reviewlog.html:27
 msgid "Add-on Review Log"
 msgstr ""
 
-#: src/olympia/editors/templates/editors/base.html:80 src/olympia/editors/templates/editors/eventlog.html:4 src/olympia/editors/templates/editors/eventlog.html:8
+#: src/olympia/editors/templates/editors/base.html:82 src/olympia/editors/templates/editors/eventlog.html:4 src/olympia/editors/templates/editors/eventlog.html:8
 #: src/olympia/editors/templates/editors/eventlog_detail.html:4
 msgid "Moderated Review Log"
 msgstr ""
 
-#: src/olympia/editors/templates/editors/base.html:82 src/olympia/editors/templates/editors/beta_signed_log.html:4 src/olympia/editors/templates/editors/beta_signed_log.html:8
+#: src/olympia/editors/templates/editors/base.html:84 src/olympia/editors/templates/editors/beta_signed_log.html:4 src/olympia/editors/templates/editors/beta_signed_log.html:8
 msgid "Signed Beta Files Log"
 msgstr ""
 
-#: src/olympia/editors/templates/editors/base.html:87 src/olympia/editors/templates/editors/includes/daily-message.html:4
+#: src/olympia/editors/templates/editors/base.html:89 src/olympia/editors/templates/editors/includes/daily-message.html:4
 msgid "Announcement"
 msgstr ""
 
@@ -7825,16 +7739,19 @@ msgstr ""
 msgid "Full Review ({num})"
 msgid_plural "Full Reviews ({num})"
 msgstr[0] ""
+msgstr[1] ""
 
 #: src/olympia/editors/templates/editors/home.html:18
 msgid "Pending Update ({num})"
 msgid_plural "Pending Updates ({num})"
 msgstr[0] ""
+msgstr[1] ""
 
 #: src/olympia/editors/templates/editors/home.html:25
 msgid "Preliminary Review ({num})"
 msgid_plural "Preliminary Reviews ({num})"
 msgstr[0] ""
+msgstr[1] ""
 
 #: src/olympia/editors/templates/editors/home.html:36 src/olympia/editors/templates/editors/home.html:86
 msgid "Current waiting times:"
@@ -7844,6 +7761,7 @@ msgstr ""
 msgid "{0} add-on"
 msgid_plural "{0} add-ons"
 msgstr[0] ""
+msgstr[1] ""
 
 #: src/olympia/editors/templates/editors/home.html:45 src/olympia/editors/templates/editors/home.html:95
 #, python-format
@@ -7854,16 +7772,19 @@ msgstr ""
 msgid "Unlisted Full Review ({num})"
 msgid_plural "Unlisted Full Reviews ({num})"
 msgstr[0] ""
+msgstr[1] ""
 
 #: src/olympia/editors/templates/editors/home.html:68
 msgid "Unlisted Pending Update ({num})"
 msgid_plural "Unlisted Pending Updates ({num})"
 msgstr[0] ""
+msgstr[1] ""
 
 #: src/olympia/editors/templates/editors/home.html:75
 msgid "Unlisted Preliminary Review ({num})"
 msgid_plural "Unlisted Preliminary Reviews ({num})"
 msgstr[0] ""
+msgstr[1] ""
 
 #: src/olympia/editors/templates/editors/home.html:109 src/olympia/editors/templates/editors/performance.html:37 src/olympia/editors/templates/editors/themes/home.html:54
 msgid "Total Reviews"
@@ -7886,6 +7807,7 @@ msgstr ""
 msgid "Moderated Review ({num})"
 msgid_plural "Moderated Reviews ({num})"
 msgstr[0] ""
+msgstr[1] ""
 
 #: src/olympia/editors/templates/editors/leaderboard.html:3 src/olympia/editors/templates/editors/includes/reviewers_score_bar.html:56
 msgid "Reviewer Leaderboard"
@@ -7979,45 +7901,45 @@ msgstr ""
 msgid "clear search"
 msgstr ""
 
-#: src/olympia/editors/templates/editors/queue.html:72 src/olympia/editors/templates/editors/queue.html:122
+#: src/olympia/editors/templates/editors/queue.html:78 src/olympia/editors/templates/editors/queue.html:128
 msgid "Process Reviews"
 msgstr ""
 
-#: src/olympia/editors/templates/editors/queue.html:80
+#: src/olympia/editors/templates/editors/queue.html:86
 msgid "Moderation actions:"
 msgstr ""
 
-#: src/olympia/editors/templates/editors/queue.html:90
+#: src/olympia/editors/templates/editors/queue.html:96
 #, python-format
 msgid "by %(user)s on %(date)s %(stars)s (%(locale)s)"
 msgstr ""
 
-#: src/olympia/editors/templates/editors/queue.html:106
+#: src/olympia/editors/templates/editors/queue.html:112
 #, python-format
 msgid "<strong>%(reason)s</strong> <span class=\"light\">Flagged by %(user)s on %(date)s</span>"
 msgstr ""
 
-#: src/olympia/editors/templates/editors/queue.html:119
-msgid "All reviews have been moderated.  Good work!"
+#: src/olympia/editors/templates/editors/queue.html:125
+msgid "All reviews have been moderated. Good work!"
 msgstr ""
 
-#: src/olympia/editors/templates/editors/queue.html:161
+#: src/olympia/editors/templates/editors/queue.html:167
 msgid "Version Notes / Notes for Reviewer"
 msgstr ""
 
-#: src/olympia/editors/templates/editors/queue.html:169
+#: src/olympia/editors/templates/editors/queue.html:175
 msgid "There are currently no add-ons of this type to review."
 msgstr ""
 
-#: src/olympia/editors/templates/editors/queue.html:181 src/olympia/editors/templates/editors/themes/queue_list.html:85
+#: src/olympia/editors/templates/editors/queue.html:187 src/olympia/editors/templates/editors/themes/queue_list.html:85
 msgid "Helpful Links:"
 msgstr ""
 
-#: src/olympia/editors/templates/editors/queue.html:182
+#: src/olympia/editors/templates/editors/queue.html:188
 msgid "Add-on Policy"
 msgstr ""
 
-#: src/olympia/editors/templates/editors/queue.html:184
+#: src/olympia/editors/templates/editors/queue.html:190
 msgid "Editors' Guide"
 msgstr ""
 
@@ -8081,10 +8003,7 @@ msgid "<strong>Warning!</strong> Another user was viewing this page before you."
 msgstr ""
 
 #: src/olympia/editors/templates/editors/review.html:237
-msgid ""
-"The whiteboard is the place to exchange information relevant to\n"
-"               this addon (whatever the version), between the developer and the\n"
-"               editor. This is visible and editable by both."
+msgid "The whiteboard is the place to exchange information relevant to this addon (whatever the version), between the developer and the editor. This is visible and editable by both."
 msgstr ""
 
 #: src/olympia/editors/templates/editors/review.html:241
@@ -8228,16 +8147,19 @@ msgstr ""
 msgid "{num} Pending Theme Review"
 msgid_plural "{num} Pending Theme Reviews"
 msgstr[0] ""
+msgstr[1] ""
 
 #: src/olympia/editors/templates/editors/themes/home.html:27
 msgid "{num} Flagged Review"
 msgid_plural "{num} Flagged Reviews"
 msgstr[0] ""
+msgstr[1] ""
 
 #: src/olympia/editors/templates/editors/themes/home.html:34
 msgid "{num} Update"
 msgid_plural "{num} Updates"
 msgstr[0] ""
+msgstr[1] ""
 
 #: src/olympia/editors/templates/editors/themes/logs.html:4
 msgid "Theme Review Log"
@@ -8356,7 +8278,7 @@ msgstr "پرسیدن یک پرسش از هنرمند"
 msgid "Describe your reason for flagging"
 msgstr ""
 
-#: src/olympia/files/forms.py:88
+#: src/olympia/files/forms.py:90
 msgid "Cannot diff a version against itself"
 msgstr ""
 
@@ -8391,51 +8313,51 @@ msgstr ""
 msgid "There was an error accessing file %s."
 msgstr ""
 
-#: src/olympia/files/utils.py:343
+#: src/olympia/files/utils.py:340
 msgid "Could not parse uploaded file."
 msgstr ""
 
-#: src/olympia/files/utils.py:380
+#: src/olympia/files/utils.py:377
 msgid "Invalid file name in archive: {0}"
 msgstr ""
 
-#: src/olympia/files/utils.py:388
+#: src/olympia/files/utils.py:385
 msgid "File exceeding size limit in archive: {0}"
 msgstr ""
 
-#: src/olympia/files/utils.py:439
+#: src/olympia/files/utils.py:436
 msgid "Invalid archive."
 msgstr ""
 
-#: src/olympia/files/utils.py:529 src/olympia/files/utils.py:532
+#: src/olympia/files/utils.py:526 src/olympia/files/utils.py:529
 msgid "Could not parse the manifest file."
 msgstr ""
 
-#: src/olympia/files/utils.py:551
+#: src/olympia/files/utils.py:548
 msgid "Could not find an add-on ID."
 msgstr ""
 
-#: src/olympia/files/utils.py:554
+#: src/olympia/files/utils.py:551
 msgid "Add-on ID must be 64 characters or less."
 msgstr ""
 
-#: src/olympia/files/utils.py:556
+#: src/olympia/files/utils.py:553
 msgid "Add-on ID doesn't match add-on."
 msgstr ""
 
-#: src/olympia/files/utils.py:564
+#: src/olympia/files/utils.py:561
 msgid "Duplicate add-on ID found."
 msgstr ""
 
-#: src/olympia/files/utils.py:567
+#: src/olympia/files/utils.py:564
 msgid "Version numbers should have fewer than 32 characters."
 msgstr ""
 
-#: src/olympia/files/utils.py:570
+#: src/olympia/files/utils.py:567
 msgid "Version numbers should only contain letters, numbers, and these punctuation characters: +*.-_."
 msgstr ""
 
-#: src/olympia/files/utils.py:587
+#: src/olympia/files/utils.py:584
 msgid "<em:type> doesn't match add-on"
 msgstr ""
 
@@ -8535,6 +8457,10 @@ msgstr ""
 
 #: src/olympia/files/templates/files/viewer.html:134
 msgid "Fetching file."
+msgstr ""
+
+#: src/olympia/legacy_api/views.py:255
+msgid "Not implemented yet."
 msgstr ""
 
 #: src/olympia/lib/constants.py:6
@@ -9193,10 +9119,6 @@ msgstr ""
 msgid "Zimbabwe Dollar"
 msgstr ""
 
-#: src/olympia/lib/video/ffmpeg.py:112 src/olympia/lib/video/totem.py:81
-msgid "Videos must be in WebM."
-msgstr ""
-
 #: src/olympia/pages/templates/pages/about.lhtml:3 src/olympia/pages/templates/pages/about.lhtml:10
 msgid "About Mozilla Add-ons"
 msgstr ""
@@ -9208,7 +9130,7 @@ msgstr ""
 #: src/olympia/pages/templates/pages/about.lhtml:13
 msgid ""
 "addons.mozilla.org, commonly known as \"AMO\", is Mozilla's official site for add-ons to Mozilla software, such as Firefox, Thunderbird, and SeaMonkey. Add-ons let you add new features and change "
-"the way your browser or application works.  Take a look around and explore the thousands of ways to customize the way you do things online."
+"the way your browser or application works. Take a look around and explore the thousands of ways to customize the way you do things online."
 msgstr ""
 
 #: src/olympia/pages/templates/pages/about.lhtml:19
@@ -9555,7 +9477,7 @@ msgstr ""
 msgid ""
 "Yes. It's possible, but some of the functionality provided by these libraries are available through XPCOM, XUL, and JavaScript. In addition, authors should take care if libraries modify primitive "
 "object prototypes (String.prototype, Date.prototype, etc.) and/or define global functions (eg. the $ function). These are prone to cause conflict with other add-ons, in particular if different add-"
-"ons use different versions of libraries and so on. Developers need to be very, very careful with using them.  Mozilla does not offer documentation on using them to build add-ons."
+"ons use different versions of libraries and so on. Developers need to be very, very careful with using them. Mozilla does not offer documentation on using them to build add-ons."
 msgstr ""
 
 #: src/olympia/pages/templates/pages/dev_faq.html:165
@@ -9669,8 +9591,8 @@ msgstr ""
 #, python-format
 msgid ""
 "Yes. Many developers choose to host their own add-ons. Choosing to host your add-on on <a href=\"%(amo_url)s\">Mozilla's add-on site</a>, though, allows for much greater exposure to your add-on due "
-"to the large volume of visitors to the site.  <a href=\"%(md_url)s\">mozdev.org</a> offers free project hosting for Mozilla applications and extensions providing developers with tools to help "
-"manage source code, version control, bug tracking and documentation."
+"to the large volume of visitors to the site. <a href=\"%(md_url)s\">mozdev.org</a> offers free project hosting for Mozilla applications and extensions providing developers with tools to help manage "
+"source code, version control, bug tracking and documentation."
 msgstr ""
 
 #: src/olympia/pages/templates/pages/dev_faq.html:277
@@ -9718,7 +9640,7 @@ msgstr ""
 #: src/olympia/pages/templates/pages/dev_faq.html:314
 #, python-format
 msgid ""
-"Yes. Mozilla's <a href=\"%(p_url)s\">Add-on Policy</a> describes what is an acceptable submission. This policy is subject to change without notice.  In addition, the AMO editorial team uses the <a "
+"Yes. Mozilla's <a href=\"%(p_url)s\">Add-on Policy</a> describes what is an acceptable submission. This policy is subject to change without notice. In addition, the AMO editorial team uses the <a "
 "href=\"%(g_url)s\">Editors Reviewing Guide</a> to ensure that your add-on meets specific guidelines for functionality and security."
 msgstr ""
 
@@ -9835,7 +9757,7 @@ msgstr ""
 #: src/olympia/pages/templates/pages/dev_faq.html:434
 #, python-format
 msgid ""
-"This is why it's very important to read the <a href=\"%(g_url)s\">Editors Reviewing Guide</a> to ensure that your add-on is setup as expected.  It's also a good idea to read the blog post, <a href="
+"This is why it's very important to read the <a href=\"%(g_url)s\">Editors Reviewing Guide</a> to ensure that your add-on is setup as expected. It's also a good idea to read the blog post, <a href="
 "\"%(blog_url)s\">Successfully Getting your Add-on Reviewed</a> which provides excellent insight into ensuring a smooth review of your add-on."
 msgstr ""
 
@@ -9942,7 +9864,7 @@ msgstr ""
 
 #: src/olympia/pages/templates/pages/dev_faq.html:572
 msgid ""
-"Free Software Foundation provides short summaries of the key open source licenses, including whether the license qualifies as a free software license or a copyleft license.  Also includes a "
+"Free Software Foundation provides short summaries of the key open source licenses, including whether the license qualifies as a free software license or a copyleft license. Also includes a "
 "discussion of what constitutes a free software license or a copyleft license (e.g., a Copyleft license is a general method for making a program or other work free, and requiring all modified and "
 "extended versions of the program to be free as well.)"
 msgstr ""
@@ -10120,19 +10042,13 @@ msgid "Add-on Gallery"
 msgstr ""
 
 #: src/olympia/pages/templates/pages/faq.html:171
-msgid ""
-"How do I choose between add-ons that seem to do the same\n"
-"    thing?"
+msgid "How do I choose between add-ons that seem to do the same thing?"
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:173
+#: src/olympia/pages/templates/pages/faq.html:172
 msgid ""
-"There are often several add-ons that have similar features. To\n"
-"    figure out which is right for you, read the entire description of the\n"
-"    add-on and view its screenshots. If there are still several in the running,\n"
-"    read through the add-on's ratings, user reviews, and statistics to see\n"
-"    which is most liked by other users. Remember that you can also just try\n"
-"    out both and see which you like better."
+"There are often several add-ons that have similar features. To figure out which is right for you, read the entire description of the add-on and view its screenshots. If there are still several in "
+"the running, read through the add-on's ratings, user reviews, and statistics to see which is most liked by other users. Remember that you can also just try out both and see which you like better."
 msgstr ""
 
 #: src/olympia/pages/templates/pages/faq.html:180
@@ -10173,80 +10089,67 @@ msgid "How much do add-ons cost to purchase?"
 msgstr ""
 
 #: src/olympia/pages/templates/pages/faq.html:207
-msgid ""
-"Add-ons hosted in our gallery are free unless clearly marked\n"
-"    otherwise."
+msgid "Add-ons hosted in our gallery are free unless clearly marked otherwise."
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:210
+#: src/olympia/pages/templates/pages/faq.html:209
 msgid "What does it mean when an add-on asks for contributions?"
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:211
+#: src/olympia/pages/templates/pages/faq.html:210
 msgid ""
-"Some add-on authors request users who enjoy an add-on to\n"
-"        contribute to its development by making a monetary contribution. These\n"
-"        contributions go directly to the developer unless a third party is\n"
-"        indicated, such as the non-profit Mozilla Foundation."
+"Some add-on authors request users who enjoy an add-on to contribute to its development by making a monetary contribution. These contributions go directly to the developer unless a third party is "
+"indicated, such as the non-profit Mozilla Foundation."
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:216
+#: src/olympia/pages/templates/pages/faq.html:215
 msgid "What are beta add-ons?"
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:218
+#: src/olympia/pages/templates/pages/faq.html:217
 msgid ""
-"Beta add-ons are unreviewed versions which represent the\n"
-"        latest work of an add-on author. While different authors have different\n"
-"        standards for beta code quality, you should assume that these add-ons\n"
-"        are less stable than the general add-on releases."
+"Beta add-ons are unreviewed versions which represent the latest work of an add-on author. While different authors have different standards for beta code quality, you should assume that these add-"
+"ons are less stable than the general add-on releases."
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:222
+#: src/olympia/pages/templates/pages/faq.html:221
 msgid ""
 "Please note that when you install an add-on from the \"Beta Version\" section of an add-on's listing, you will continue to receive updates for that add-on as they become available. Like the initial "
 "version you installed, all beta releases are unreviewed by Mozilla and may harm your computer."
 msgstr ""
 
+#: src/olympia/pages/templates/pages/faq.html:228
+msgid "What does it mean when an add-on is flagged as slow?"
+msgstr ""
+
 #: src/olympia/pages/templates/pages/faq.html:229
-msgid ""
-"What does it mean when an add-on is flagged as\n"
-"    slow?"
+msgid "Most add-ons load code and resources at the same time Firefox is starting up. In most cases the impact in start-up time is minimal, but some add-ons can cause a noticeable slowdown."
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:231
-msgid ""
-"Most add-ons load code and resources at the same time Firefox\n"
-"        is starting up. In most cases the impact in start-up time is minimal,\n"
-"        but some add-ons can cause a noticeable slowdown."
-msgstr ""
-
-#: src/olympia/pages/templates/pages/faq.html:236
+#: src/olympia/pages/templates/pages/faq.html:234
 msgid "How do I report an inappropriate or spam user review?"
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:237
+#: src/olympia/pages/templates/pages/faq.html:235
 msgid ""
-"To report a user review of an add-on, log in with your account\n"
-"    and visit the add-on's reviews page. Find the review you wish to report,\n"
-"    click \"Report this review\" and select a reason. Our editorial team will\n"
-"    investigate the review and take appropriate action."
+"To report a user review of an add-on, log in with your account and visit the add-on's reviews page. Find the review you wish to report, click \"Report this review\" and select a reason. Our "
+"editorial team will investigate the review and take appropriate action."
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:242
+#: src/olympia/pages/templates/pages/faq.html:240
 msgid "How do I report a bug or contact the Mozilla Add-ons team?"
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:243
+#: src/olympia/pages/templates/pages/faq.html:241
 #, python-format
 msgid "Please visit our <a href=\"%(contact_url)s\">Contact page</a>."
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:246
+#: src/olympia/pages/templates/pages/faq.html:244
 msgid "What is a Source Code License?"
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:247
+#: src/olympia/pages/templates/pages/faq.html:245
 #, python-format
 msgid ""
 "The source code used to create an add-on is an exclusive copyright of the add-on author, unless otherwise declared in a source code license. Many add-ons on this site have <a href=\"%(url)s\" lang="
@@ -10254,62 +10157,62 @@ msgid ""
 "the GPL or BSD licenses instead of making up their own."
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:256
+#: src/olympia/pages/templates/pages/faq.html:254
 #, python-format
 msgid "Firefox and other Mozilla software are <a href=\"%(url)s\">open source</a>."
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:264
+#: src/olympia/pages/templates/pages/faq.html:262
 msgid "Collections and Favorites"
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:267
+#: src/olympia/pages/templates/pages/faq.html:265
 msgid "What is a collection?"
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:268
+#: src/olympia/pages/templates/pages/faq.html:266
 msgid "Collections are groups of related add-ons created by users to share."
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:270
+#: src/olympia/pages/templates/pages/faq.html:268
 msgid "What is the My Favorites collection?"
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:271
+#: src/olympia/pages/templates/pages/faq.html:269
 msgid "Favorite add-ons are add-ons that you have bookmarked to easily get back to later. You can add an add-on to your favorites collection by clicking \"Add to favorites\" on its details page."
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:275 src/olympia/templates/menu_links.html:13 src/olympia/templates/impala/header_title.html:17
+#: src/olympia/pages/templates/pages/faq.html:273 src/olympia/templates/menu_links.html:13 src/olympia/templates/impala/header_title.html:17
 #, fuzzy
 msgid "Mobile Add-ons"
 msgstr "افزودنی‌های بیشتر"
 
-#: src/olympia/pages/templates/pages/faq.html:278
+#: src/olympia/pages/templates/pages/faq.html:276
 msgid "What are mobile add-ons?"
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:279
+#: src/olympia/pages/templates/pages/faq.html:277
 #, python-format
 msgid ""
 "Mobile add-ons work with <a href=\"%(mobile_url)s\">Firefox for Mobile</a> and add or modify functionality just like desktop add-ons. You can find add-ons that work with Firefox for Mobile in our "
 "<a href=\"%(gallery_url)s\">gallery</a>."
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:288
+#: src/olympia/pages/templates/pages/faq.html:286
 #, fuzzy
 msgid "Developer Topics"
 msgstr "انجمن‌های توسعه دهنده"
 
-#: src/olympia/pages/templates/pages/faq.html:289
+#: src/olympia/pages/templates/pages/faq.html:287
 #, python-format
 msgid "Please see our <a href=\"%(faq_url)s\">Developer FAQ</a> and <a href=\"%(hub_url)s\">Developer Hub</a> for answers to add-on developer-related questions."
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:294
+#: src/olympia/pages/templates/pages/faq.html:292
 msgid "Still have questions?"
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:295
+#: src/olympia/pages/templates/pages/faq.html:293
 #, python-format
 msgid "For general Firefox support, visit our <a href=\"%(sumo_url)s\">support website</a>. For general add-on and website questions, visit our <a href=\"%(forum_url)s\">forum</a>."
 msgstr ""
@@ -10447,7 +10350,7 @@ msgstr ""
 
 #: src/olympia/pages/templates/pages/sunbird.html:29
 msgid ""
-"Development on the Sunbird project has halted and its final release was on March 30, 2010.  We've been proud to host Sunbird add-ons on this site but as the project is no longer maintained we have "
+"Development on the Sunbird project has halted and its final release was on March 30, 2010. We've been proud to host Sunbird add-ons on this site but as the project is no longer maintained we have "
 "disabled our support for the add-ons."
 msgstr ""
 
@@ -10525,7 +10428,7 @@ msgstr ""
 #, python-format
 msgid ""
 "<h2>Keep these tips in mind:</h2> <ul> <li> Write like you're telling a friend about your experience with the add-on. Give specifics and helpful details, such as what features you liked and/or "
-"disliked, how easy to use it is, and any disadvantages it has.  Avoid generic language such as calling it \"Great\" or \"Bad\" unless you can give reasons why you believe this is so. </li> <li> "
+"disliked, how easy to use it is, and any disadvantages it has. Avoid generic language such as calling it \"Great\" or \"Bad\" unless you can give reasons why you believe this is so. </li> <li> "
 "Please do not post bug reports in reviews. We do not make your email address available to add-on developers and they may need to contact you to help resolve your issue. See the <a href=\"%(support)s"
 "\">support section</a> to find out where to get assistance for this add-on. </li> <li>Please keep reviews clean, avoid the use of improper language and do not post any personal information. </li> </"
 "ul> <p>Please read the <a href=\"%(guide)s\" target=\"_blank\">Review Guidelines</a> for more detail about user add-on reviews.</p>"
@@ -10572,6 +10475,7 @@ msgstr ""
 msgid "This user has a <a href=\"%(user_review_url)s\">previous review</a> of this add-on."
 msgid_plural "This user has <a href=\"%(user_review_url)s\">%(cnt)s previous reviews</a> of this add-on."
 msgstr[0] ""
+msgstr[1] ""
 
 #: src/olympia/reviews/templates/reviews/review.html:62
 #, python-format
@@ -10617,6 +10521,7 @@ msgstr ""
 msgid "<b>{0}</b> review for this add-on"
 msgid_plural "<b>{0}</b> reviews for this add-on"
 msgstr[0] ""
+msgstr[1] ""
 
 #. {0} is a developer's name.
 #: src/olympia/reviews/templates/reviews/review_list.html:33
@@ -10628,6 +10533,7 @@ msgstr ""
 msgid "Review for %(addon)s by %(user)s"
 msgid_plural "Reviews for %(addon)s by %(user)s"
 msgstr[0] ""
+msgstr[1] ""
 
 #: src/olympia/reviews/templates/reviews/review_list.html:42
 #, fuzzy
@@ -10651,6 +10557,7 @@ msgstr ""
 msgid "{num} review"
 msgid_plural "{num} reviews"
 msgstr[0] ""
+msgstr[1] ""
 
 #: src/olympia/reviews/templates/reviews/impala/reviews_rating.html:1
 msgid "Rated {0} out of 5 stars"
@@ -10677,6 +10584,7 @@ msgstr ""
 msgid "Average from {0} Rating"
 msgid_plural "Average from {0} Ratings"
 msgstr[0] ""
+msgstr[1] ""
 
 #: src/olympia/reviews/templates/reviews/mobile/review_list.html:34
 #, python-format
@@ -10692,6 +10600,7 @@ msgstr ""
 msgid "See All Reviews"
 msgid_plural "See All %(cnt)s Reviews"
 msgstr[0] ""
+msgstr[1] ""
 
 #: src/olympia/search/forms.py:11
 msgid "Most popular this week"
@@ -10772,16 +10681,16 @@ msgstr ""
 
 #. L10n: {0} is an application, such as Firefox. This means "any version of
 #. Firefox."
-#: src/olympia/search/views.py:554
+#: src/olympia/search/views.py:547
 msgid "Any {0}"
 msgstr ""
 
 #. L10n: "All Systems" means show everything regardless of platform.
-#: src/olympia/search/views.py:589
+#: src/olympia/search/views.py:582
 msgid "All Systems"
 msgstr ""
 
-#: src/olympia/search/views.py:600
+#: src/olympia/search/views.py:593
 msgid "All Tags"
 msgstr ""
 
@@ -10825,6 +10734,7 @@ msgstr ""
 msgid "<b>{0}</b> matching result"
 msgid_plural "<b>{0}</b> matching results"
 msgstr[0] ""
+msgstr[1] ""
 
 #: src/olympia/search/templates/search/results.html:67
 msgid "Filter Results"
@@ -10847,6 +10757,7 @@ msgstr ""
 msgid "{0} post"
 msgid_plural "{0} posts"
 msgstr[0] ""
+msgstr[1] ""
 
 #: src/olympia/sharing/__init__.py:20
 msgid "Post to Facebook"
@@ -10856,6 +10767,7 @@ msgstr "ارسال به Facebook"
 msgid "{0} Like"
 msgid_plural "{0} Likes"
 msgstr[0] ""
+msgstr[1] ""
 
 #: src/olympia/sharing/__init__.py:30
 msgid "Tweet on Twitter"
@@ -10865,6 +10777,7 @@ msgstr ""
 msgid "{0} tweet"
 msgid_plural "{0} tweets"
 msgstr[0] ""
+msgstr[1] ""
 
 #: src/olympia/sharing/__init__.py:40
 msgid "Share on g+"
@@ -10898,6 +10811,7 @@ msgstr ""
 msgid "{0} post on localservice1"
 msgid_plural "{0} posts on localservice1"
 msgstr[0] ""
+msgstr[1] ""
 
 #. L10n: Only change if you have reason! wiki.mozilla.org/AMO:Localizers
 #: src/olympia/sharing/__init__.py:76
@@ -10919,6 +10833,7 @@ msgstr ""
 msgid "{0} post on localservice2"
 msgid_plural "{0} posts on localservice2"
 msgstr[0] ""
+msgstr[1] ""
 
 #. L10n: Only change if you have reason! wiki.mozilla.org/AMO:Localizers
 #: src/olympia/sharing/__init__.py:91
@@ -10940,6 +10855,7 @@ msgstr ""
 msgid "{0} post on localservice3"
 msgid_plural "{0} posts on localservice3"
 msgstr[0] ""
+msgstr[1] ""
 
 #: src/olympia/sharing/templates/sharing/sharing_widget.html:2
 msgid "Share this Add-on"
@@ -10949,31 +10865,31 @@ msgstr "به اشتراک گذاشتن این افزودنی"
 msgid "Share this Collection"
 msgstr ""
 
-#: src/olympia/signing/views.py:30 src/olympia/templates/base.html:75 src/olympia/templates/impala/base.html:115
+#: src/olympia/signing/views.py:33 src/olympia/templates/base.html:71 src/olympia/templates/impala/base.html:112
 msgid "Some features are temporarily disabled while we perform website maintenance. We'll be back to full capacity shortly."
 msgstr ""
 
-#: src/olympia/signing/views.py:53
+#: src/olympia/signing/views.py:56
 msgid "Could not find add-on with id \"{}\"."
 msgstr ""
 
-#: src/olympia/signing/views.py:67
+#: src/olympia/signing/views.py:70
 msgid "You do not own this addon."
 msgstr ""
 
-#: src/olympia/signing/views.py:82
+#: src/olympia/signing/views.py:87
 msgid "Missing \"upload\" key in multipart file data."
 msgstr ""
 
-#: src/olympia/signing/views.py:96
+#: src/olympia/signing/views.py:101
 msgid "Version does not match the manifest file."
 msgstr ""
 
-#: src/olympia/signing/views.py:100
+#: src/olympia/signing/views.py:105
 msgid "Version already exists."
 msgstr ""
 
-#: src/olympia/signing/views.py:136
+#: src/olympia/signing/views.py:141
 msgid "No uploaded file for that addon and version."
 msgstr ""
 
@@ -11090,89 +11006,89 @@ msgstr ""
 msgid "Statistics Dashboard :: Add-ons for {0}"
 msgstr ""
 
-#: src/olympia/stats/templates/stats/stats.html:30
-msgid "Controls:"
-msgstr ""
-
-#: src/olympia/stats/templates/stats/stats.html:33
-msgid "reset zoom"
-msgstr ""
-
-#: src/olympia/stats/templates/stats/stats.html:40
-msgid "Group by:"
-msgstr ""
-
-#: src/olympia/stats/templates/stats/stats.html:42
-msgid "day"
-msgstr "روز"
-
-#: src/olympia/stats/templates/stats/stats.html:45
-msgid "week"
-msgstr "هفته"
-
-#: src/olympia/stats/templates/stats/stats.html:48
-msgid "month"
-msgstr "ماه"
-
-#: src/olympia/stats/templates/stats/stats.html:54
-msgid "For last:"
-msgstr ""
-
-#: src/olympia/stats/templates/stats/stats.html:57
-msgid "7 days"
-msgstr ""
-
-#: src/olympia/stats/templates/stats/stats.html:60
-msgid "30 days"
-msgstr ""
-
-#: src/olympia/stats/templates/stats/stats.html:63
-msgid "90 days"
-msgstr ""
-
-#: src/olympia/stats/templates/stats/stats.html:66
-msgid "365 days"
-msgstr ""
-
-#: src/olympia/stats/templates/stats/stats.html:69
-msgid "Custom..."
-msgstr ""
-
 #. {0} is an add-on name
-#: src/olympia/stats/templates/stats/stats.html:88 src/olympia/stats/templates/stats/stats.html:91
+#: src/olympia/stats/templates/stats/stats.html:44 src/olympia/stats/templates/stats/stats.html:47
 msgid "Statistics for {0}"
 msgstr "آمار {0}"
 
-#: src/olympia/stats/templates/stats/stats.html:94
+#: src/olympia/stats/templates/stats/stats.html:50
 msgid "Statistics Dashboard"
 msgstr ""
 
-#: src/olympia/stats/templates/stats/stats.html:104
+#: src/olympia/stats/templates/stats/stats.html:57
+msgid "Controls:"
+msgstr ""
+
+#: src/olympia/stats/templates/stats/stats.html:60
+msgid "reset zoom"
+msgstr ""
+
+#: src/olympia/stats/templates/stats/stats.html:67
+msgid "Group by:"
+msgstr ""
+
+#: src/olympia/stats/templates/stats/stats.html:69
+msgid "day"
+msgstr "روز"
+
+#: src/olympia/stats/templates/stats/stats.html:72
+msgid "week"
+msgstr "هفته"
+
+#: src/olympia/stats/templates/stats/stats.html:75
+msgid "month"
+msgstr "ماه"
+
+#: src/olympia/stats/templates/stats/stats.html:81
+msgid "For last:"
+msgstr ""
+
+#: src/olympia/stats/templates/stats/stats.html:84
+msgid "7 days"
+msgstr ""
+
+#: src/olympia/stats/templates/stats/stats.html:87
+msgid "30 days"
+msgstr ""
+
+#: src/olympia/stats/templates/stats/stats.html:90
+msgid "90 days"
+msgstr ""
+
+#: src/olympia/stats/templates/stats/stats.html:93
+msgid "365 days"
+msgstr ""
+
+#: src/olympia/stats/templates/stats/stats.html:96
+msgid "Custom..."
+msgstr ""
+
+#: src/olympia/stats/templates/stats/stats.html:106
 msgid "Statistics processing is currently disabled, so recent data is unavailable. The statistics are still being collected and this page will be updated soon with the missing data."
 msgstr ""
 
-#: src/olympia/stats/templates/stats/stats.html:110
+#: src/olympia/stats/templates/stats/stats.html:112
 msgid "Loading the latest data&hellip;"
 msgstr ""
 
-#: src/olympia/stats/templates/stats/stats.html:142 src/olympia/stats/templates/stats/reports/overview.html:25 src/olympia/stats/templates/stats/reports/overview.html:37
+#: src/olympia/stats/templates/stats/stats.html:144 src/olympia/stats/templates/stats/reports/overview.html:25 src/olympia/stats/templates/stats/reports/overview.html:37
 #: src/olympia/stats/templates/stats/reports/overview.html:49
 msgid "No data available."
 msgstr ""
 
-#: src/olympia/stats/templates/stats/stats.html:177
+#: src/olympia/stats/templates/stats/stats.html:179
 msgid "This dashboard is currently <b>public</b>."
 msgstr ""
 
-#: src/olympia/stats/templates/stats/stats.html:179
+#: src/olympia/stats/templates/stats/stats.html:181
 msgid "Contribution stats are currently <b>private</b>."
 msgstr ""
 
-#: src/olympia/stats/templates/stats/stats.html:182
+#: src/olympia/stats/templates/stats/stats.html:184
 msgid "This dashboard is currently <b>private</b>."
 msgstr ""
 
-#: src/olympia/stats/templates/stats/stats.html:185
+#: src/olympia/stats/templates/stats/stats.html:187
 msgid "Change settings."
 msgstr ""
 
@@ -11324,16 +11240,6 @@ msgstr ""
 msgid "Application versions by Date"
 msgstr ""
 
-# {0} is a number
-#: src/olympia/tags/templates/tags/top_cloud.html:4
-msgid "Top {0} Tags"
-msgstr "{0} برچسب برتر"
-
-#. {0} is the current application name
-#: src/olympia/tags/templates/tags/top_cloud.html:14
-msgid "{0} Top Tags"
-msgstr ""
-
 #: src/olympia/templates/amo_footer.html:6 src/olympia/templates/includes/lang_switcher.html:2
 msgid "Other languages"
 msgstr ""
@@ -11343,11 +11249,11 @@ msgstr ""
 msgid "Mozilla Add-ons"
 msgstr "افزودنی‌های بیشتر"
 
-#: src/olympia/templates/base.html:91 src/olympia/templates/impala/base.html:81
+#: src/olympia/templates/base.html:89 src/olympia/templates/impala/base.html:78
 msgid "Find add-ons for other applications"
 msgstr "پیدا کردن افزودنی‌های برنامه‌های دیگر"
 
-#: src/olympia/templates/base.html:92 src/olympia/templates/impala/base.html:81
+#: src/olympia/templates/base.html:90 src/olympia/templates/impala/base.html:78
 msgid "Other Applications"
 msgstr "برنامه‌های دیگر"
 
@@ -11372,7 +11278,7 @@ msgid "View Mobile Site"
 msgstr ""
 
 #: src/olympia/templates/copyright.html:7
-msgid "Site Status "
+msgid "Site Status"
 msgstr ""
 
 #: src/olympia/templates/footer.html:3
@@ -11474,35 +11380,35 @@ msgstr ""
 msgid "<a href=\"%(reg)s\">Register</a> or <a href=\"%(login)s\">Log in</a>"
 msgstr "<a href=\"%(reg)s\">ثبت نام</a>یا <a href=\"%(login)s\">ورود</a>"
 
-#: src/olympia/templates/impala/base.html:126
+#: src/olympia/templates/impala/base.html:123
 #, python-format
 msgid "To try the thousands of add-ons available here, download <a href=\"%(url)s\">Mozilla Firefox</a>, a fast, free way to surf the Web!"
 msgstr "برای امتحان کردن صدها افزودنی موجود در اینجا، <a href=\"%(url)s\">موزیلا فایرفاکس</a>، یک راه سریع، رایگان برای مرور وب را بارگیری کنید!"
 
-#: src/olympia/templates/impala/base.html:138
+#: src/olympia/templates/impala/base.html:135
 #, python-format
 msgid "Add-ons is switching to Firefox Accounts for login. <a href=\"%(url)s\" class=\"fxa-login\">Sign in now to transfer your account.</a>"
 msgstr ""
 
 #. {0} is an application, such as Firefox.
-#: src/olympia/templates/impala/base.html:148
+#: src/olympia/templates/impala/base.html:145
 msgid "Welcome to {0} Add-ons."
 msgstr ""
 
-#: src/olympia/templates/impala/base.html:151
+#: src/olympia/templates/impala/base.html:148
 msgid "Choose from thousands of extra features and styles to make Firefox your own."
 msgstr ""
 
-#: src/olympia/templates/impala/base.html:156
+#: src/olympia/templates/impala/base.html:153
 #, python-format
 msgid "Add extra features and styles to make %(app)s your own."
 msgstr ""
 
-#: src/olympia/templates/impala/base.html:164
+#: src/olympia/templates/impala/base.html:161
 msgid "On the go?"
 msgstr ""
 
-#: src/olympia/templates/impala/base.html:166
+#: src/olympia/templates/impala/base.html:163
 msgid "Check out our <a class=\"mobile-link\" href=\"#\">Mobile Add-ons site</a>."
 msgstr ""
 
@@ -11727,19 +11633,19 @@ msgstr ""
 
 #. L10n: {id} will be something like "13ad6a", just a random number
 #. to differentiate this user from other anonymous users.
-#: src/olympia/users/models.py:353
+#: src/olympia/users/models.py:362
 msgid "Anonymous user {id}"
 msgstr ""
 
-#: src/olympia/users/models.py:410
+#: src/olympia/users/models.py:419
 msgid "Your account has been restricted"
 msgstr ""
 
-#: src/olympia/users/models.py:480
+#: src/olympia/users/models.py:489
 msgid "Please confirm your email address"
 msgstr ""
 
-#: src/olympia/users/models.py:506
+#: src/olympia/users/models.py:515
 #, fuzzy
 msgid "My Mobile Add-ons"
 msgstr "افزودنی‌های بیشتر"
@@ -12019,7 +11925,7 @@ msgstr "گذرواژه"
 
 #: src/olympia/users/templates/users/edit.html:70
 #, python-format
-msgid "Change your password.  If you forgot your password, you can <a href=\"%(reset_url)s\">use the reset form</a>."
+msgid "Change your password. If you forgot your password, you can <a href=\"%(reset_url)s\">use the reset form</a>."
 msgstr ""
 
 #: src/olympia/users/templates/users/edit.html:76
@@ -12040,7 +11946,7 @@ msgid "Profile"
 msgstr ""
 
 #: src/olympia/users/templates/users/edit.html:100
-msgid "Give us a bit more information about yourself.  All these fields are optional, but they'll help other users get to know you better."
+msgid "Give us a bit more information about yourself. All these fields are optional, but they'll help other users get to know you better."
 msgstr ""
 
 #: src/olympia/users/templates/users/edit.html:124
@@ -12258,7 +12164,7 @@ msgid "Confirm password"
 msgstr "تأیید گذرواژه"
 
 #: src/olympia/users/templates/users/pwreset_confirm.html:47
-msgid "The password reset link was invalid, possibly because it has already been used.  Please request a new password reset."
+msgid "The password reset link was invalid, possibly because it has already been used. Please request a new password reset."
 msgstr ""
 
 #: src/olympia/users/templates/users/pwreset_request.html:15
@@ -12445,7 +12351,7 @@ msgstr ""
 
 #: src/olympia/users/templates/users/unsubscribe.html:30
 #, python-format
-msgid "Unfortunately, we weren't able to unsubscribe you.  The link you clicked is invalid. However, you can unsubscribe still unsubscribe on your <a href=\"%(edit_url)s\">edit profile page</a>."
+msgid "Unfortunately, we weren't able to unsubscribe you. The link you clicked is invalid. However, you can unsubscribe still unsubscribe on your <a href=\"%(edit_url)s\">edit profile page</a>."
 msgstr ""
 
 #: src/olympia/users/templates/users/vcard.html:2
@@ -12477,12 +12383,14 @@ msgstr ""
 msgid "%(num)s theme"
 msgid_plural "%(num)s themes"
 msgstr[0] ""
+msgstr[1] ""
 
 #: src/olympia/users/templates/users/vcard.html:62
 #, python-format
 msgid "%(num)s add-on"
 msgid_plural "%(num)s add-ons"
 msgstr[0] ""
+msgstr[1] ""
 
 #: src/olympia/users/templates/users/vcard.html:75
 msgid "Average rating of developer's add-ons"
@@ -12498,15 +12406,15 @@ msgstr "تاریخچه نسخه های %s"
 msgid "Version History with Changelogs"
 msgstr "تاریخچهٔ نسخه‌ها به همراه فهرست تغییرات"
 
-#: src/olympia/versions/models.py:314
+#: src/olympia/versions/models.py:313
 msgid "Add-on uses binary components."
 msgstr ""
 
-#: src/olympia/versions/models.py:317
+#: src/olympia/versions/models.py:316
 msgid "Add-on has opted into strict compatibility checking."
 msgstr ""
 
-#: src/olympia/versions/models.py:715
+#: src/olympia/versions/models.py:711
 msgid "{app} {min} and later"
 msgstr ""
 
@@ -12544,6 +12452,7 @@ msgstr "تاریخچهٔ نسخه‌های {0}"
 msgid "<b>{0}</b> version"
 msgid_plural "<b>{0}</b> versions"
 msgstr[0] ""
+msgstr[1] ""
 
 #: src/olympia/versions/templates/versions/version_list.html:35 src/olympia/versions/templates/versions/mobile/version_list.html:14
 msgid "Be careful with old versions!"
@@ -12582,4 +12491,8 @@ msgstr ""
 
 #: src/olympia/zadmin/forms.py:105
 msgid "Log emails instead of sending"
+msgstr ""
+
+#: src/olympia/zadmin/forms.py:215
+msgid "Deleted versions can`t be changed."
 msgstr ""

--- a/locale/fa/LC_MESSAGES/djangojs.po
+++ b/locale/fa/LC_MESSAGES/djangojs.po
@@ -3,1199 +3,1234 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2016-02-24 21:23+0000\n"
+"POT-Creation-Date: 2016-04-18 15:47+0000\n"
 "PO-Revision-Date: 2013-12-04 18:56+0000\n"
 "Last-Translator: Amir <amir_farsi@ymail.com>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
+"Language: \n"
 "MIME-Version: 1.0\n"
-"Content-Type: text/plain; charset=utf-8\n"
+"Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Generated-By: Babel 2.2.0\n"
 
-#: static/js/common/ratingwidget.js:31
+#: static/js/common-all.js:1426 static/js/impala-all.js:1511 static/js/zamboni/discovery-all.js:12598 static/js/zamboni/init.js:28 static/js/zamboni/mobile-all.js:14945
+msgid "This feature is temporarily disabled while we perform website maintenance. Please check back a little later."
+msgstr ""
+
+#. L10n: {0} is an app name like Firefox.
+#: static/js/common-all.js:1837 static/js/impala-all.js:1922 static/js/zamboni/buttons.js:73 static/js/zamboni/discovery-all.js:13108
+msgid "Accept and Install"
+msgstr "قبول و نصب"
+
+#: static/js/common-all.js:1837 static/js/impala-all.js:1922 static/js/zamboni/buttons.js:73 static/js/zamboni/discovery-all.js:13108
+msgid "Add to {0}"
+msgstr "افزودن به {0}"
+
+#: static/js/common-all.js:1842 static/js/impala-all.js:1927 static/js/zamboni/buttons.js:78 static/js/zamboni/discovery-all.js:13113
+msgid "Download Now"
+msgstr "هم‌اکنون بارگیری کن"
+
+#: static/js/common-all.js:1883 static/js/impala-all.js:1968 static/js/zamboni/buttons.js:119 static/js/zamboni/discovery-all.js:13154
+msgid "Add-on has not been updated to support default-to-compatible."
+msgstr ""
+
+#: static/js/common-all.js:1888 static/js/impala-all.js:1973 static/js/zamboni/buttons.js:124 static/js/zamboni/discovery-all.js:13159
+msgid "You need to be using Firefox 10.0 or higher."
+msgstr ""
+
+#: static/js/common-all.js:1900 static/js/impala-all.js:1985 static/js/zamboni/buttons.js:136 static/js/zamboni/discovery-all.js:13171
+msgid "Mozilla has marked this version as incompatible with your Firefox version."
+msgstr ""
+
+#. L10n: {0} is an platform like Windows or Linux.
+#: static/js/common-all.js:1981 static/js/impala-all.js:2066 static/js/zamboni/buttons.js:217 static/js/zamboni/discovery-all.js:13252
+msgid "Install for {0} anyway"
+msgstr ""
+
+#: static/js/common-all.js:1981 static/js/impala-all.js:2066 static/js/zamboni/buttons.js:217 static/js/zamboni/discovery-all.js:13252
+msgid "Download for {0} anyway"
+msgstr ""
+
+#: static/js/common-all.js:2038 static/js/impala-all.js:2123 static/js/zamboni/buttons.js:274 static/js/zamboni/discovery-all.js:13309
+msgid "Not available for your platform"
+msgstr "برای سیستم عامل شما موجود نیست"
+
+#. L10n: {0} is an app name, {1} is the app version.
+#: static/js/common-all.js:2049 static/js/common-all.js:2086 static/js/impala-all.js:2134 static/js/impala-all.js:2171 static/js/zamboni/buttons.js:286 static/js/zamboni/buttons.js:324
+#: static/js/zamboni/discovery-all.js:13320 static/js/zamboni/discovery-all.js:13357
+msgid "Not available for {0} {1}"
+msgstr "برای {0} {1} موجود نیست"
+
+#: static/js/common-all.js:2112 static/js/impala-all.js:2197 static/js/zamboni/buttons.js:351 static/js/zamboni/discovery-all.js:13383
+msgid "Works with {app} {min} - {max}"
+msgstr "با {app} {min} - {max} کار می‌کند"
+
+#: static/js/common-all.js:2114 static/js/impala-all.js:2199 static/js/zamboni/buttons.js:353 static/js/zamboni/discovery-all.js:13385
+msgid "View other versions"
+msgstr "نمایش سایر نسخه‌ها"
+
+#: static/js/common-all.js:2162 static/js/impala-all.js:2247 static/js/zamboni/buttons.js:401 static/js/zamboni/discovery-all.js:13433
+msgid "Only with Firefox — Get Firefox Now!"
+msgstr ""
+
+#: static/js/common-all.js:2278 static/js/impala-all.js:2363 static/js/zamboni/buttons.js:517 static/js/zamboni/discovery-all.js:13549 static/js/zamboni/mobile-all.js:15177
+#: static/js/zamboni/mobile/buttons.js:43
+msgid "Sorry, you need a Mozilla-based browser (such as Firefox) to install a search plugin."
+msgstr ""
+
+#: static/js/common-all.js:9088 static/js/impala-all.js:9649 static/js/zamboni/global.js:410
+msgid "Loading..."
+msgstr ""
+
+#. L10n: {0} is the number of characters left.
+#: static/js/common-all.js:9152 static/js/impala-all.js:9713 static/js/zamboni/global.js:474
+msgid "<b>{0}</b> character left."
+msgid_plural "<b>{0}</b> characters left."
+msgstr[0] ""
+msgstr[1] ""
+
+#: static/js/common-all.js:9589 static/js/common-min.js:6 static/js/impala-all.js:10052 static/js/impala-min.js:6 static/js/common/ratingwidget.js:31 static/js/zamboni/mobile-all.js:16123
+#: static/js/zamboni/mobile-min.js:6
 msgid "{0} star"
 msgid_plural "{0} stars"
 msgstr[0] "{0} ستاره"
+msgstr[1] ""
 
-#: static/js/common/upload-addon.js:41 static/js/common/upload-image.js:128
+#: static/js/common-all.js:9676 static/js/common-min.js:6 static/js/impala-all.js:10139 static/js/impala-min.js:6 static/js/zamboni/l10n.js:45
+msgid "Remove this localization"
+msgstr ""
+
+#: static/js/common-all.js:10193 static/js/common-min.js:6 static/js/impala-all.js:10674 static/js/impala-min.js:6 static/js/zamboni/discovery-all.js:13678
+msgid "close"
+msgstr ""
+
+#: static/js/common-all.js:10860 static/js/common-min.js:6 static/js/impala-all.js:11481 static/js/impala-min.js:6 static/js/impala/reviews.js:23 static/js/zamboni/reviews.js:18
+msgid "Flagged for review"
+msgstr "برای بازبینی پرچم گذاری شد"
+
+#: static/js/common-all.js:10876 static/js/common-min.js:6 static/js/impala-all.js:11498 static/js/impala-min.js:6 static/js/impala/reviews.js:40 static/js/zamboni/reviews.js:34
+msgid "Your input is required"
+msgstr "ورودی شما لازم است"
+
+#: static/js/common-all.js:10945 static/js/common-min.js:6 static/js/impala-all.js:11610 static/js/impala-min.js:7 static/js/impala/reviews.js:152 static/js/zamboni/reviews.js:103
+msgid "Marked for deletion"
+msgstr "علامت گذاری شده برای حذف"
+
+#: static/js/common-all.js:11573 static/js/common-min.js:7 static/js/impala-all.js:13809 static/js/impala-min.js:8 static/js/zamboni/collections.js:229
+msgid "Adding to Favorites&hellip;"
+msgstr ""
+
+#: static/js/common-all.js:11576 static/js/common-min.js:7 static/js/impala-all.js:13812 static/js/impala-min.js:8 static/js/zamboni/collections.js:232
+msgid "Removing Favorite&hellip;"
+msgstr ""
+
+#: static/js/common-all.js:11579 static/js/common-min.js:7 static/js/impala-all.js:13815 static/js/impala-min.js:8 static/js/zamboni/collections.js:235
+msgid "Add to Favorites"
+msgstr ""
+
+#: static/js/common-all.js:11582 static/js/common-min.js:7 static/js/impala-all.js:13818 static/js/impala-min.js:8 static/js/zamboni/collections.js:238
+msgid "Remove from Favorites"
+msgstr ""
+
+#: static/js/common-all.js:11647 static/js/common-min.js:7 static/js/impala-all.js:13883 static/js/impala-min.js:8 static/js/zamboni/collections.js:303
+msgid "Pending"
+msgstr ""
+
+#: static/js/common-all.js:11648 static/js/common-min.js:7 static/js/impala-all.js:13884 static/js/impala-min.js:8 static/js/zamboni/collections.js:304
+msgid "Add a comment"
+msgstr ""
+
+#: static/js/common-all.js:11648 static/js/common-min.js:7 static/js/impala-all.js:13884 static/js/impala-min.js:8 static/js/zamboni/collections.js:304
+msgid "Comment"
+msgstr "توضیح"
+
+#: static/js/common-all.js:11649 static/js/common-min.js:7 static/js/impala-all.js:13885 static/js/impala-min.js:8 static/js/zamboni/collections.js:305
+msgid "Remove this add-on from the collection"
+msgstr "این افزودنی را از مجموعه حذف کن"
+
+#: static/js/common-all.js:11649 static/js/common-all.js:11678 static/js/common-min.js:7 static/js/impala-all.js:13885 static/js/impala-all.js:13914 static/js/impala-min.js:8
+#: static/js/zamboni/collections.js:305 static/js/zamboni/collections.js:334
+msgid "Remove"
+msgstr "حذف"
+
+#: static/js/common-all.js:11678 static/js/common-min.js:7 static/js/impala-all.js:13914 static/js/impala-min.js:8 static/js/zamboni/collections.js:334
+msgid "Remove this user as a contributor"
+msgstr ""
+
+#: static/js/common-all.js:11690 static/js/common-min.js:7 static/js/impala-all.js:13926 static/js/impala-min.js:8 static/js/zamboni/collections.js:346
+msgid "An email address is required."
+msgstr ""
+
+#: static/js/common-all.js:11708 static/js/common-min.js:7 static/js/impala-all.js:13944 static/js/impala-min.js:8 static/js/zamboni/collections.js:364
+msgid "You cannot add yourself as a contributor."
+msgstr ""
+
+#: static/js/common-all.js:11710 static/js/common-min.js:7 static/js/impala-all.js:13946 static/js/impala-min.js:8 static/js/zamboni/collections.js:366
+msgid "You have already added that user."
+msgstr ""
+
+#: static/js/common-all.js:11917 static/js/common-min.js:7 static/js/impala-all.js:14153 static/js/impala-min.js:8 static/js/zamboni/collections.js:573
+msgid "Add to favorites"
+msgstr ""
+
+#: static/js/common-all.js:11921 static/js/common-min.js:7 static/js/impala-all.js:14157 static/js/impala-min.js:8 static/js/zamboni/collections.js:577
+msgid "Remove from favorites"
+msgstr ""
+
+#: static/js/common-all.js:11939 static/js/common-min.js:7 static/js/impala-all.js:14175 static/js/impala-all.js:14233 static/js/impala-min.js:8 static/js/impala/collections.js:10
+#: static/js/zamboni/collections.js:595
+msgid "Follow this Collection"
+msgstr "این مجموعه را دنبال کن"
+
+#: static/js/common-all.js:11948 static/js/common-min.js:7 static/js/impala-all.js:14184 static/js/impala-min.js:8 static/js/zamboni/collections.js:604
+msgid "Stop following"
+msgstr ""
+
+#: static/js/common-all.js:12096 static/js/common-min.js:7 static/js/zamboni/password-strength.js:20
+msgid "Password strength:"
+msgstr ""
+
+#: static/js/common-all.js:12102 static/js/common-min.js:7 static/js/zamboni/password-strength.js:26
+msgid "At least {0} character left."
+msgid_plural "At least {0} characters left."
+msgstr[0] ""
+msgstr[1] ""
+
+#: static/js/common-all.js:12286 static/js/common-min.js:7 static/js/impala-all.js:14632 static/js/impala-min.js:8 static/js/impala/suggestions.js:39
+msgid "Search themes for <b>{0}</b>"
+msgstr ""
+
+#: static/js/common-all.js:12288 static/js/common-min.js:7 static/js/impala-all.js:14634 static/js/impala-min.js:8 static/js/impala/suggestions.js:41
+msgid "Search apps for <b>{0}</b>"
+msgstr ""
+
+#: static/js/common-all.js:12290 static/js/common-min.js:7 static/js/impala-all.js:14636 static/js/impala-min.js:8 static/js/impala/suggestions.js:43
+msgid "Search add-ons for <b>{0}</b>"
+msgstr ""
+
+#: static/js/common-all.js:12521 static/js/common-min.js:7 static/js/impala-all.js:14867 static/js/impala-min.js:8 static/js/impala/site_suggestions.js:46
+msgid "Category"
+msgstr ""
+
+#. L10n: {0} is an app name.
+#: static/js/impala-all.js:11632 static/js/impala-min.js:7 static/js/impala/listing.js:11 static/js/zamboni/themes.js:13
+msgid "This theme is incompatible with your version of {0}"
+msgstr ""
+
+#: static/js/impala-all.js:12146 static/js/impala-all.js:14331 static/js/impala-min.js:7 static/js/impala-min.js:8 static/js/common/upload-image.js:97 static/js/impala/users.js:51
+#: static/js/zamboni/devhub-all.js:894 static/js/zamboni/devhub-min.js:1
+msgid "Images must be either PNG or JPG."
+msgstr ""
+
+#: static/js/impala-all.js:12150 static/js/impala-min.js:7 static/js/common/upload-image.js:101 static/js/zamboni/devhub-all.js:898 static/js/zamboni/devhub-min.js:1
+msgid "Videos must be in WebM."
+msgstr ""
+
+#: static/js/impala-all.js:12177 static/js/impala-min.js:7 static/js/common/upload-addon.js:41 static/js/common/upload-image.js:128 static/js/zamboni/devhub-all.js:272
+#: static/js/zamboni/devhub-all.js:925 static/js/zamboni/devhub-min.js:1
 msgid "There was a problem contacting the server."
 msgstr "اشکالی در تماس با سرویس دهنده به وجود آمده است."
 
-#: static/js/common/upload-addon.js:69
+#: static/js/impala-all.js:13298 static/js/impala-min.js:7 static/js/impala/persona_creation.js:60
+msgid "All Rights Reserved"
+msgstr ""
+
+#: static/js/impala-all.js:13302 static/js/impala-min.js:7 static/js/impala/persona_creation.js:64
+msgid "Creative Commons Attribution 3.0"
+msgstr ""
+
+#: static/js/impala-all.js:13307 static/js/impala-min.js:7 static/js/impala/persona_creation.js:69
+msgid "Creative Commons Attribution-NonCommercial 3.0"
+msgstr ""
+
+#: static/js/impala-all.js:13312 static/js/impala-min.js:7 static/js/impala/persona_creation.js:74
+msgid "Creative Commons Attribution-NonCommercial-NoDerivs 3.0"
+msgstr ""
+
+#: static/js/impala-all.js:13317 static/js/impala-min.js:7 static/js/impala/persona_creation.js:79
+msgid "Creative Commons Attribution-NonCommercial-Share Alike 3.0"
+msgstr ""
+
+#: static/js/impala-all.js:13322 static/js/impala-min.js:7 static/js/impala/persona_creation.js:84
+msgid "Creative Commons Attribution-NoDerivs 3.0"
+msgstr ""
+
+#: static/js/impala-all.js:13327 static/js/impala-min.js:7 static/js/impala/persona_creation.js:89
+msgid "Creative Commons Attribution-ShareAlike 3.0"
+msgstr ""
+
+#: static/js/impala-all.js:13530 static/js/impala-min.js:7 static/js/impala/persona_creation.js:292
+msgid "Your Theme's Name"
+msgstr ""
+
+#: static/js/impala-all.js:14242 static/js/impala-min.js:8 static/js/impala/collections.js:19
+msgid "Stop Following"
+msgstr ""
+
+#: static/js/impala-all.js:14243 static/js/impala-min.js:8 static/js/impala/collections.js:20
+msgid "Following"
+msgstr ""
+
+#: static/js/impala-all.js:14313 static/js/impala-min.js:8 static/js/impala/users.js:33
+msgid "use original"
+msgstr ""
+
+#: static/js/impala-all.js:14523 static/js/impala-min.js:8 static/js/impala/search.js:114
+msgid "Updating results&hellip;"
+msgstr ""
+
+#: static/js/common/upload-addon.js:69 static/js/zamboni/devhub-all.js:300 static/js/zamboni/devhub-min.js:1
 msgid "Select a file..."
 msgstr "یک فایل را انتخاب کنید..."
 
-#: static/js/common/upload-addon.js:70
+#: static/js/common/upload-addon.js:70 static/js/zamboni/devhub-all.js:301 static/js/zamboni/devhub-min.js:1
 msgid "Your add-on should end with .xpi, .jar or .xml"
 msgstr "افزودنی‌های شما باید با .xpi، .jar، یا .xml پایان یابند"
 
 #. L10n: {0} is the percent of the file that has been uploaded.
-#: static/js/common/upload-addon.js:104
+#: static/js/common/upload-addon.js:104 static/js/zamboni/devhub-all.js:335 static/js/zamboni/devhub-min.js:1
 #, fuzzy, python-format
 msgid "{0}% complete"
 msgstr "‏{0}% تکمیل شده است"
 
 #. L10n: "{bytes uploaded} of {total filesize}".
-#: static/js/common/upload-addon.js:107
+#: static/js/common/upload-addon.js:107 static/js/zamboni/devhub-all.js:338 static/js/zamboni/devhub-min.js:1
 msgid "{0} of {1}"
 msgstr "{0} از {1}"
 
-#: static/js/common/upload-addon.js:140
+#: static/js/common/upload-addon.js:140 static/js/zamboni/devhub-all.js:371 static/js/zamboni/devhub-min.js:1
 msgid "Cancel"
 msgstr "انصراف"
 
-#: static/js/common/upload-addon.js:162
+#: static/js/common/upload-addon.js:162 static/js/zamboni/devhub-all.js:393 static/js/zamboni/devhub-min.js:1
 msgid "Uploading {0}"
 msgstr "در حال آپلود {0}"
 
-#: static/js/common/upload-addon.js:189
+#: static/js/common/upload-addon.js:189 static/js/zamboni/devhub-all.js:420 static/js/zamboni/devhub-min.js:1
 msgid "Error with {0}"
 msgstr "خطا با {0}"
 
-#: static/js/common/upload-addon.js:194
+#: static/js/common/upload-addon.js:194 static/js/zamboni/devhub-all.js:425 static/js/zamboni/devhub-min.js:1
 msgid "Your add-on failed validation with {0} error."
 msgid_plural "Your add-on failed validation with {0} errors."
 msgstr[0] ""
+msgstr[1] ""
 
-#: static/js/common/upload-addon.js:208
+#: static/js/common/upload-addon.js:208 static/js/zamboni/devhub-all.js:439 static/js/zamboni/devhub-min.js:1
 msgid "&hellip;and {0} more"
 msgid_plural "&hellip;and {0} more"
 msgstr[0] ""
+msgstr[1] ""
 
-#: static/js/common/upload-addon.js:222 static/js/common/upload-addon.js:512
+#: static/js/common/upload-addon.js:222 static/js/common/upload-addon.js:497 static/js/zamboni/devhub-all.js:453 static/js/zamboni/devhub-all.js:743 static/js/zamboni/devhub-min.js:1
 msgid "See full validation report"
 msgstr ""
 
-#: static/js/common/upload-addon.js:234
+#: static/js/common/upload-addon.js:234 static/js/zamboni/devhub-all.js:465 static/js/zamboni/devhub-min.js:1
 msgid "Validating {0}"
 msgstr "در حال اعتبار سنجی {0}"
 
 #. L10n: first argument is an HTTP status code
-#: static/js/common/upload-addon.js:273
+#: static/js/common/upload-addon.js:273 static/js/zamboni/devhub-all.js:504 static/js/zamboni/devhub-min.js:1
 msgid "Received an empty response from the server; status: {0}"
 msgstr "یک پاسخ خالی از سرور دریافت شد، وضعیت: {0}"
 
-#: static/js/common/upload-addon.js:373
+#: static/js/common/upload-addon.js:370 static/js/zamboni/devhub-all.js:604 static/js/zamboni/devhub-min.js:1
 msgid "Unexpected server error while validating."
 msgstr "خطای غیر منتظره در هنگام اعتبار سنجی."
 
-#: static/js/common/upload-addon.js:412
+#: static/js/common/upload-addon.js:409 static/js/zamboni/devhub-all.js:643 static/js/zamboni/devhub-min.js:1
 msgid "Finished validating {0}"
 msgstr "اعتبار سنجی {0} پایان یافت"
 
-#: static/js/common/upload-addon.js:418
+#: static/js/common/upload-addon.js:415 static/js/zamboni/devhub-all.js:649 static/js/zamboni/devhub-min.js:1
 msgid "Your add-on validation timed out, it will be manually reviewed."
 msgstr ""
 
-#: static/js/common/upload-addon.js:421
+#: static/js/common/upload-addon.js:418 static/js/zamboni/devhub-all.js:652 static/js/zamboni/devhub-min.js:1
 msgid "Your add-on was validated with no errors and {0} warning."
 msgid_plural "Your add-on was validated with no errors and {0} warnings."
 msgstr[0] ""
+msgstr[1] ""
 
-#: static/js/common/upload-addon.js:426
+#: static/js/common/upload-addon.js:423 static/js/zamboni/devhub-all.js:657 static/js/zamboni/devhub-min.js:1
 msgid "Your add-on was validated with no errors and {0} message."
 msgid_plural "Your add-on was validated with no errors and {0} messages."
 msgstr[0] ""
+msgstr[1] ""
 
-#: static/js/common/upload-addon.js:431
+#: static/js/common/upload-addon.js:428 static/js/zamboni/devhub-all.js:662 static/js/zamboni/devhub-min.js:1
 msgid "Your add-on was validated with no errors or warnings."
 msgstr ""
 
-#: static/js/common/upload-addon.js:446
+#: static/js/common/upload-addon.js:443 static/js/zamboni/devhub-all.js:677 static/js/zamboni/devhub-min.js:1
 msgid "Your submission will be automatically signed."
 msgstr ""
 
-#: static/js/common/upload-addon.js:465
+#: static/js/common/upload-addon.js:450 static/js/zamboni/devhub-all.js:696 static/js/zamboni/devhub-min.js:1
 msgid "Include detailed version notes (this can be done in the next step)."
 msgstr ""
 
-#: static/js/common/upload-addon.js:466
+#: static/js/common/upload-addon.js:451 static/js/zamboni/devhub-all.js:697 static/js/zamboni/devhub-min.js:1
 msgid "If your add-on requires an account to a website in order to be fully tested, include a test username and password in the Notes to Reviewer (this can be done in the next step)."
 msgstr ""
 
-#: static/js/common/upload-addon.js:467
+#: static/js/common/upload-addon.js:452 static/js/zamboni/devhub-all.js:698 static/js/zamboni/devhub-min.js:1
 msgid "If your add-on is intended for a limited audience you should choose Preliminary Review instead of Full Review."
 msgstr ""
 
-#: static/js/common/upload-addon.js:480
+#: static/js/common/upload-addon.js:465 static/js/zamboni/devhub-all.js:711 static/js/zamboni/devhub-min.js:1
 msgid "Add-on submission checklist"
 msgstr ""
 
-#: static/js/common/upload-addon.js:481
+#: static/js/common/upload-addon.js:466 static/js/zamboni/devhub-all.js:712 static/js/zamboni/devhub-min.js:1
 msgid "Please verify the following points before finalizing your submission. This will minimize delays or misunderstanding during the review process:"
 msgstr ""
 
-#: static/js/common/upload-addon.js:483
+#: static/js/common/upload-addon.js:468 static/js/zamboni/devhub-all.js:714 static/js/zamboni/devhub-min.js:1
 msgid ""
 "Compiled binaries, as well as minified or obfuscated scripts (excluding known libraries) need to have their sources submitted separately for review. Make sure that you use the source code upload "
 "field to avoid having your submission rejected."
 msgstr ""
 
-#: static/js/common/upload-addon.js:501
+#: static/js/common/upload-addon.js:486 static/js/zamboni/devhub-all.js:732 static/js/zamboni/devhub-min.js:1
 msgid "The validation process found these issues that can lead to rejections:"
 msgstr ""
 
-#: static/js/common/upload-addon.js:518
+#: static/js/common/upload-addon.js:503 static/js/zamboni/devhub-all.js:749 static/js/zamboni/devhub-min.js:1
 msgid "If you are unfamiliar with the add-ons review process, you can read about it here."
 msgstr ""
 
-#: static/js/common/upload-addon.js:555
+#: static/js/common/upload-addon.js:540 static/js/zamboni/devhub-all.js:786 static/js/zamboni/devhub-min.js:1
 msgid "Sorry, no supported platform has been found."
 msgstr ""
 
-#: static/js/common/upload-base.js:57
+#: static/js/common/upload-base.js:57 static/js/zamboni/devhub-all.js:187 static/js/zamboni/devhub-min.js:1
 msgid "The filetype you uploaded isn't recognized."
 msgstr ""
 
-#: static/js/common/upload-base.js:79
+#: static/js/common/upload-base.js:79 static/js/zamboni/devhub-all.js:209 static/js/zamboni/devhub-min.js:1
 msgid "You cancelled the upload."
 msgstr ""
 
-#: static/js/common/upload-image.js:97 static/js/impala/users.js:51
-msgid "Images must be either PNG or JPG."
-msgstr ""
-
-#: static/js/common/upload-image.js:101
-msgid "Videos must be in WebM."
-msgstr ""
-
-#: static/js/impala/collections.js:10 static/js/zamboni/collections.js:595
-msgid "Follow this Collection"
-msgstr "این مجموعه را دنبال کن"
-
-#: static/js/impala/collections.js:19
-msgid "Stop Following"
-msgstr ""
-
-#: static/js/impala/collections.js:20
-msgid "Following"
-msgstr ""
-
-#. L10n: {0} is an app name.
-#: static/js/impala/listing.js:11 static/js/zamboni/themes.js:13
-msgid "This theme is incompatible with your version of {0}"
-msgstr ""
-
-#: static/js/impala/persona_creation.js:60
-msgid "All Rights Reserved"
-msgstr ""
-
-#: static/js/impala/persona_creation.js:64
-msgid "Creative Commons Attribution 3.0"
-msgstr ""
-
-#: static/js/impala/persona_creation.js:69
-msgid "Creative Commons Attribution-NonCommercial 3.0"
-msgstr ""
-
-#: static/js/impala/persona_creation.js:74
-msgid "Creative Commons Attribution-NonCommercial-NoDerivs 3.0"
-msgstr ""
-
-#: static/js/impala/persona_creation.js:79
-msgid "Creative Commons Attribution-NonCommercial-Share Alike 3.0"
-msgstr ""
-
-#: static/js/impala/persona_creation.js:84
-msgid "Creative Commons Attribution-NoDerivs 3.0"
-msgstr ""
-
-#: static/js/impala/persona_creation.js:89
-msgid "Creative Commons Attribution-ShareAlike 3.0"
-msgstr ""
-
-#: static/js/impala/persona_creation.js:292
-msgid "Your Theme's Name"
-msgstr ""
-
-#: static/js/impala/reviews.js:23 static/js/zamboni/reviews.js:18
-msgid "Flagged for review"
-msgstr "برای بازبینی پرچم گذاری شد"
-
-#: static/js/impala/reviews.js:40 static/js/zamboni/reviews.js:34
-msgid "Your input is required"
-msgstr "ورودی شما لازم است"
-
-#: static/js/impala/reviews.js:152 static/js/zamboni/reviews.js:103
-msgid "Marked for deletion"
-msgstr "علامت گذاری شده برای حذف"
-
-#: static/js/impala/search.js:114
-msgid "Updating results&hellip;"
-msgstr ""
-
-#: static/js/impala/site_suggestions.js:46
-msgid "Category"
-msgstr ""
-
-#: static/js/impala/suggestions.js:39
-msgid "Search themes for <b>{0}</b>"
-msgstr ""
-
-#: static/js/impala/suggestions.js:41
-msgid "Search apps for <b>{0}</b>"
-msgstr ""
-
-#: static/js/impala/suggestions.js:43
-msgid "Search add-ons for <b>{0}</b>"
-msgstr ""
-
-#: static/js/impala/users.js:33
-msgid "use original"
-msgstr ""
-
-#: static/js/impala/stats/chart.js:267
+#: static/js/impala/stats/chart.js:267 static/js/zamboni/stats-all.js:16898 static/js/zamboni/stats-min.js:5
 msgid "Week of {0}"
 msgstr ""
 
-#: static/js/impala/stats/chart.js:269
+#: static/js/impala/stats/chart.js:269 static/js/zamboni/stats-all.js:16900 static/js/zamboni/stats-min.js:5
 msgid " downloads"
 msgstr ""
 
-#: static/js/impala/stats/chart.js:270
+#: static/js/impala/stats/chart.js:270 static/js/zamboni/stats-all.js:16901 static/js/zamboni/stats-min.js:5
 msgid "{0} users"
 msgstr ""
 
-#: static/js/impala/stats/chart.js:271
+#: static/js/impala/stats/chart.js:271 static/js/zamboni/stats-all.js:16902 static/js/zamboni/stats-min.js:5
 msgid "{0} add-ons"
 msgstr ""
 
-#: static/js/impala/stats/chart.js:272
+#: static/js/impala/stats/chart.js:272 static/js/zamboni/stats-all.js:16903 static/js/zamboni/stats-min.js:5
 msgid "{0} collections"
 msgstr "{0} مجموعه"
 
-#: static/js/impala/stats/chart.js:273
+#: static/js/impala/stats/chart.js:273 static/js/zamboni/stats-all.js:16904 static/js/zamboni/stats-min.js:5
 msgid "{0} reviews"
 msgstr ""
 
-#: static/js/impala/stats/chart.js:275
+#: static/js/impala/stats/chart.js:275 static/js/zamboni/stats-all.js:16906 static/js/zamboni/stats-min.js:5
 msgid "{0} sales"
 msgstr ""
 
-#: static/js/impala/stats/chart.js:276
+#: static/js/impala/stats/chart.js:276 static/js/zamboni/stats-all.js:16907 static/js/zamboni/stats-min.js:5
 msgid "{0} refunds"
 msgstr ""
 
-#: static/js/impala/stats/chart.js:277
+#: static/js/impala/stats/chart.js:277 static/js/zamboni/stats-all.js:16908 static/js/zamboni/stats-min.js:5
 msgid "{0} installs"
 msgstr ""
 
-#: static/js/impala/stats/chart.js:369 static/js/impala/stats/csv_keys.js:3 static/js/impala/stats/csv_keys.js:109
+#: static/js/impala/stats/chart.js:369 static/js/impala/stats/csv_keys.js:3 static/js/impala/stats/csv_keys.js:109 static/js/zamboni/stats-all.js:15284 static/js/zamboni/stats-all.js:15390
+#: static/js/zamboni/stats-all.js:17000 static/js/zamboni/stats-min.js:4 static/js/zamboni/stats-min.js:5
 msgid "Downloads"
 msgstr ""
 
-#: static/js/impala/stats/chart.js:379 static/js/impala/stats/csv_keys.js:6 static/js/impala/stats/csv_keys.js:110
+#: static/js/impala/stats/chart.js:379 static/js/impala/stats/csv_keys.js:6 static/js/impala/stats/csv_keys.js:110 static/js/zamboni/stats-all.js:15287 static/js/zamboni/stats-all.js:15391
+#: static/js/zamboni/stats-all.js:17010 static/js/zamboni/stats-min.js:4 static/js/zamboni/stats-min.js:5
 msgid "Daily Users"
 msgstr ""
 
-#: static/js/impala/stats/chart.js:410
+#: static/js/impala/stats/chart.js:410 static/js/zamboni/stats-all.js:17041 static/js/zamboni/stats-min.js:5
 msgid "Amount, in USD"
 msgstr ""
 
-#: static/js/impala/stats/chart.js:421 static/js/impala/stats/csv_keys.js:104
+#: static/js/impala/stats/chart.js:421 static/js/impala/stats/csv_keys.js:104 static/js/zamboni/stats-all.js:15385 static/js/zamboni/stats-all.js:17052 static/js/zamboni/stats-min.js:5
 msgid "Number of Contributions"
 msgstr ""
 
-#: static/js/impala/stats/chart.js:447
+#: static/js/impala/stats/chart.js:447 static/js/zamboni/stats-all.js:17078 static/js/zamboni/stats-min.js:5
 msgid "More Info..."
 msgstr "اطّلاعات بیشتر..."
 
 #. L10n: {0} is an ISO-formatted date.
-#: static/js/impala/stats/chart.js:451
+#: static/js/impala/stats/chart.js:451 static/js/zamboni/stats-all.js:17082 static/js/zamboni/stats-min.js:5
 msgid "Details for {0}"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:9
+#: static/js/impala/stats/csv_keys.js:9 static/js/zamboni/stats-all.js:15290 static/js/zamboni/stats-min.js:4
 msgid "Collections Created"
 msgstr "مجوعه‌ها ایجاد شدند"
 
-#: static/js/impala/stats/csv_keys.js:12
+#: static/js/impala/stats/csv_keys.js:12 static/js/zamboni/stats-all.js:15293 static/js/zamboni/stats-min.js:4
 msgid "Add-ons in Use"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:15
+#: static/js/impala/stats/csv_keys.js:15 static/js/zamboni/stats-all.js:15296 static/js/zamboni/stats-min.js:4
 msgid "Add-ons Created"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:18
+#: static/js/impala/stats/csv_keys.js:18 static/js/zamboni/stats-all.js:15299 static/js/zamboni/stats-min.js:4
 msgid "Add-ons Downloaded"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:21
+#: static/js/impala/stats/csv_keys.js:21 static/js/zamboni/stats-all.js:15302 static/js/zamboni/stats-min.js:4
 msgid "Add-ons Updated"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:24
+#: static/js/impala/stats/csv_keys.js:24 static/js/zamboni/stats-all.js:15305 static/js/zamboni/stats-min.js:4
 msgid "Reviews Written"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:27
+#: static/js/impala/stats/csv_keys.js:27 static/js/zamboni/stats-all.js:15308 static/js/zamboni/stats-min.js:4
 msgid "User Signups"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:30
+#: static/js/impala/stats/csv_keys.js:30 static/js/zamboni/stats-all.js:15311 static/js/zamboni/stats-min.js:4
 msgid "Subscribers"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:33
+#: static/js/impala/stats/csv_keys.js:33 static/js/zamboni/stats-all.js:15314 static/js/zamboni/stats-min.js:4
 msgid "Ratings"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:36 static/js/impala/stats/csv_keys.js:114
+#: static/js/impala/stats/csv_keys.js:36 static/js/impala/stats/csv_keys.js:114 static/js/zamboni/stats-all.js:15317 static/js/zamboni/stats-all.js:15395 static/js/zamboni/stats-min.js:4
+#: static/js/zamboni/stats-min.js:5
 msgid "Sales"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:39 static/js/impala/stats/csv_keys.js:113
+#: static/js/impala/stats/csv_keys.js:39 static/js/impala/stats/csv_keys.js:113 static/js/zamboni/stats-all.js:15320 static/js/zamboni/stats-all.js:15394 static/js/zamboni/stats-min.js:4
+#: static/js/zamboni/stats-min.js:5
 msgid "Installs"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:42
+#: static/js/impala/stats/csv_keys.js:42 static/js/zamboni/stats-all.js:15323 static/js/zamboni/stats-min.js:4
 msgid "Unknown"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:43
+#: static/js/impala/stats/csv_keys.js:43 static/js/zamboni/stats-all.js:15324 static/js/zamboni/stats-min.js:4
 msgid "Add-ons Manager"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:44
+#: static/js/impala/stats/csv_keys.js:44 static/js/zamboni/stats-all.js:15325 static/js/zamboni/stats-min.js:4
 msgid "Add-ons Manager Promo"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:45
+#: static/js/impala/stats/csv_keys.js:45 static/js/zamboni/stats-all.js:15326 static/js/zamboni/stats-min.js:4
 msgid "Add-ons Manager Featured"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:46
+#: static/js/impala/stats/csv_keys.js:46 static/js/zamboni/stats-all.js:15327 static/js/zamboni/stats-min.js:4
 msgid "Add-ons Manager Learn More"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:47
+#: static/js/impala/stats/csv_keys.js:47 static/js/zamboni/stats-all.js:15328 static/js/zamboni/stats-min.js:4
 msgid "Search Suggestions"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:48
+#: static/js/impala/stats/csv_keys.js:48 static/js/zamboni/stats-all.js:15329 static/js/zamboni/stats-min.js:4
 msgid "Search Results"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:49 static/js/impala/stats/csv_keys.js:50 static/js/impala/stats/csv_keys.js:51
+#: static/js/impala/stats/csv_keys.js:49 static/js/impala/stats/csv_keys.js:50 static/js/impala/stats/csv_keys.js:51 static/js/zamboni/stats-all.js:15330 static/js/zamboni/stats-all.js:15331
+#: static/js/zamboni/stats-all.js:15332 static/js/zamboni/stats-min.js:4
 msgid "Homepage Promo"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:52 static/js/impala/stats/csv_keys.js:53
+#: static/js/impala/stats/csv_keys.js:52 static/js/impala/stats/csv_keys.js:53 static/js/zamboni/stats-all.js:15333 static/js/zamboni/stats-all.js:15334 static/js/zamboni/stats-min.js:4
 msgid "Homepage Featured"
 msgstr "صفحه خانگی ویژه"
 
-#: static/js/impala/stats/csv_keys.js:54 static/js/impala/stats/csv_keys.js:55
+#: static/js/impala/stats/csv_keys.js:54 static/js/impala/stats/csv_keys.js:55 static/js/zamboni/stats-all.js:15335 static/js/zamboni/stats-all.js:15336 static/js/zamboni/stats-min.js:4
 msgid "Homepage Up and Coming"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:56
+#: static/js/impala/stats/csv_keys.js:56 static/js/zamboni/stats-all.js:15337 static/js/zamboni/stats-min.js:4
 msgid "Homepage Most Popular"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:57 static/js/impala/stats/csv_keys.js:59
+#: static/js/impala/stats/csv_keys.js:57 static/js/impala/stats/csv_keys.js:59 static/js/zamboni/stats-all.js:15338 static/js/zamboni/stats-all.js:15340 static/js/zamboni/stats-min.js:4
 msgid "Detail Page"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:58 static/js/impala/stats/csv_keys.js:60
+#: static/js/impala/stats/csv_keys.js:58 static/js/impala/stats/csv_keys.js:60 static/js/zamboni/stats-all.js:15339 static/js/zamboni/stats-all.js:15341 static/js/zamboni/stats-min.js:4
 msgid "Detail Page (bottom)"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:61
+#: static/js/impala/stats/csv_keys.js:61 static/js/zamboni/stats-all.js:15342 static/js/zamboni/stats-min.js:4
 msgid "Detail Page (Development Channel)"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:62 static/js/impala/stats/csv_keys.js:63 static/js/impala/stats/csv_keys.js:64
+#: static/js/impala/stats/csv_keys.js:62 static/js/impala/stats/csv_keys.js:63 static/js/impala/stats/csv_keys.js:64 static/js/zamboni/stats-all.js:15343 static/js/zamboni/stats-all.js:15344
+#: static/js/zamboni/stats-all.js:15345 static/js/zamboni/stats-min.js:4
 msgid "Often Used With"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:65 static/js/impala/stats/csv_keys.js:66
+#: static/js/impala/stats/csv_keys.js:65 static/js/impala/stats/csv_keys.js:66 static/js/zamboni/stats-all.js:15346 static/js/zamboni/stats-all.js:15347 static/js/zamboni/stats-min.js:4
 msgid "Others By Author"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:67 static/js/impala/stats/csv_keys.js:68
+#: static/js/impala/stats/csv_keys.js:67 static/js/impala/stats/csv_keys.js:68 static/js/zamboni/stats-all.js:15348 static/js/zamboni/stats-all.js:15349 static/js/zamboni/stats-min.js:4
 msgid "Dependencies"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:69 static/js/impala/stats/csv_keys.js:70
+#: static/js/impala/stats/csv_keys.js:69 static/js/impala/stats/csv_keys.js:70 static/js/zamboni/stats-all.js:15350 static/js/zamboni/stats-all.js:15351 static/js/zamboni/stats-min.js:4
 msgid "Upsell"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:71
+#: static/js/impala/stats/csv_keys.js:71 static/js/zamboni/stats-all.js:15352 static/js/zamboni/stats-min.js:4
 msgid "Meet the Developer"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:72
+#: static/js/impala/stats/csv_keys.js:72 static/js/zamboni/stats-all.js:15353 static/js/zamboni/stats-min.js:4
 msgid "User Profile"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:73
+#: static/js/impala/stats/csv_keys.js:73 static/js/zamboni/stats-all.js:15354 static/js/zamboni/stats-min.js:4
 msgid "Version History"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:75
+#: static/js/impala/stats/csv_keys.js:75 static/js/zamboni/stats-all.js:15356 static/js/zamboni/stats-min.js:4
 msgid "Sharing"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:76
+#: static/js/impala/stats/csv_keys.js:76 static/js/zamboni/stats-all.js:15357 static/js/zamboni/stats-min.js:4
 msgid "Category Pages"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:77
+#: static/js/impala/stats/csv_keys.js:77 static/js/zamboni/stats-all.js:15358 static/js/zamboni/stats-min.js:4
 msgid "Collections"
 msgstr "مجوعه‌ها"
 
-#: static/js/impala/stats/csv_keys.js:78 static/js/impala/stats/csv_keys.js:79
+#: static/js/impala/stats/csv_keys.js:78 static/js/impala/stats/csv_keys.js:79 static/js/zamboni/stats-all.js:15359 static/js/zamboni/stats-all.js:15360 static/js/zamboni/stats-min.js:4
 msgid "Category Landing Featured Carousel"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:80 static/js/impala/stats/csv_keys.js:81
+#: static/js/impala/stats/csv_keys.js:80 static/js/impala/stats/csv_keys.js:81 static/js/zamboni/stats-all.js:15361 static/js/zamboni/stats-all.js:15362 static/js/zamboni/stats-min.js:4
 msgid "Category Landing Top Rated"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:82 static/js/impala/stats/csv_keys.js:83
+#: static/js/impala/stats/csv_keys.js:82 static/js/impala/stats/csv_keys.js:83 static/js/zamboni/stats-all.js:15363 static/js/zamboni/stats-all.js:15364 static/js/zamboni/stats-min.js:5
 msgid "Category Landing Most Popular"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:84 static/js/impala/stats/csv_keys.js:85
+#: static/js/impala/stats/csv_keys.js:84 static/js/impala/stats/csv_keys.js:85 static/js/zamboni/stats-all.js:15365 static/js/zamboni/stats-all.js:15366 static/js/zamboni/stats-min.js:5
 msgid "Category Landing Recently Added"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:86 static/js/impala/stats/csv_keys.js:87
+#: static/js/impala/stats/csv_keys.js:86 static/js/impala/stats/csv_keys.js:87 static/js/zamboni/stats-all.js:15367 static/js/zamboni/stats-all.js:15368 static/js/zamboni/stats-min.js:5
 msgid "Browse Listing Featured Sort"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:88 static/js/impala/stats/csv_keys.js:89
+#: static/js/impala/stats/csv_keys.js:88 static/js/impala/stats/csv_keys.js:89 static/js/zamboni/stats-all.js:15369 static/js/zamboni/stats-all.js:15370 static/js/zamboni/stats-min.js:5
 msgid "Browse Listing Users Sort"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:90 static/js/impala/stats/csv_keys.js:91
+#: static/js/impala/stats/csv_keys.js:90 static/js/impala/stats/csv_keys.js:91 static/js/zamboni/stats-all.js:15371 static/js/zamboni/stats-all.js:15372 static/js/zamboni/stats-min.js:5
 msgid "Browse Listing Rating Sort"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:92 static/js/impala/stats/csv_keys.js:93
+#: static/js/impala/stats/csv_keys.js:92 static/js/impala/stats/csv_keys.js:93 static/js/zamboni/stats-all.js:15373 static/js/zamboni/stats-all.js:15374 static/js/zamboni/stats-min.js:5
 msgid "Browse Listing Created Sort"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:94 static/js/impala/stats/csv_keys.js:95
+#: static/js/impala/stats/csv_keys.js:94 static/js/impala/stats/csv_keys.js:95 static/js/zamboni/stats-all.js:15375 static/js/zamboni/stats-all.js:15376 static/js/zamboni/stats-min.js:5
 msgid "Browse Listing Name Sort"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:96 static/js/impala/stats/csv_keys.js:97
+#: static/js/impala/stats/csv_keys.js:96 static/js/impala/stats/csv_keys.js:97 static/js/zamboni/stats-all.js:15377 static/js/zamboni/stats-all.js:15378 static/js/zamboni/stats-min.js:5
 msgid "Browse Listing Popular Sort"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:98 static/js/impala/stats/csv_keys.js:99
+#: static/js/impala/stats/csv_keys.js:98 static/js/impala/stats/csv_keys.js:99 static/js/zamboni/stats-all.js:15379 static/js/zamboni/stats-all.js:15380 static/js/zamboni/stats-min.js:5
 msgid "Browse Listing Updated Sort"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:100 static/js/impala/stats/csv_keys.js:101
+#: static/js/impala/stats/csv_keys.js:100 static/js/impala/stats/csv_keys.js:101 static/js/zamboni/stats-all.js:15381 static/js/zamboni/stats-all.js:15382 static/js/zamboni/stats-min.js:5
 msgid "Browse Listing Up and Coming Sort"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:105
+#: static/js/impala/stats/csv_keys.js:105 static/js/zamboni/stats-all.js:15386 static/js/zamboni/stats-min.js:5
 msgid "Total Amount Contributed"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:106
+#: static/js/impala/stats/csv_keys.js:106 static/js/zamboni/stats-all.js:15387 static/js/zamboni/stats-min.js:5
 msgid "Average Contribution"
 msgstr "میانگین مشارکت"
 
-#: static/js/impala/stats/csv_keys.js:115
+#: static/js/impala/stats/csv_keys.js:115 static/js/zamboni/stats-all.js:15396 static/js/zamboni/stats-min.js:5
 msgid "Usage"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:118
+#: static/js/impala/stats/csv_keys.js:118 static/js/zamboni/stats-all.js:15399 static/js/zamboni/stats-min.js:5
 msgid "Firefox"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:119
+#: static/js/impala/stats/csv_keys.js:119 static/js/zamboni/stats-all.js:15400 static/js/zamboni/stats-min.js:5
 msgid "Mozilla"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:120
+#: static/js/impala/stats/csv_keys.js:120 static/js/zamboni/stats-all.js:15401 static/js/zamboni/stats-min.js:5
 msgid "Thunderbird"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:121
+#: static/js/impala/stats/csv_keys.js:121 static/js/zamboni/stats-all.js:15402 static/js/zamboni/stats-min.js:5
 msgid "Sunbird"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:122
+#: static/js/impala/stats/csv_keys.js:122 static/js/zamboni/stats-all.js:15403 static/js/zamboni/stats-min.js:5
 msgid "SeaMonkey"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:123
+#: static/js/impala/stats/csv_keys.js:123 static/js/zamboni/stats-all.js:15404 static/js/zamboni/stats-min.js:5
 msgid "Fennec"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:124
+#: static/js/impala/stats/csv_keys.js:124 static/js/zamboni/stats-all.js:15405 static/js/zamboni/stats-min.js:5
 msgid "Android"
 msgstr ""
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:129
+#: static/js/impala/stats/csv_keys.js:129 static/js/zamboni/stats-all.js:15410 static/js/zamboni/stats-min.js:5
 msgid "Downloads and Daily Users, last {0} days"
 msgstr ""
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:131
+#: static/js/impala/stats/csv_keys.js:131 static/js/zamboni/stats-all.js:15412 static/js/zamboni/stats-min.js:5
 msgid "Downloads and Daily Users from {0} to {1}"
 msgstr ""
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:135
+#: static/js/impala/stats/csv_keys.js:135 static/js/zamboni/stats-all.js:15416 static/js/zamboni/stats-min.js:5
 msgid "Installs and Daily Users, last {0} days"
 msgstr ""
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:137
+#: static/js/impala/stats/csv_keys.js:137 static/js/zamboni/stats-all.js:15418 static/js/zamboni/stats-min.js:5
 msgid "Installs and Daily Users from {0} to {1}"
 msgstr ""
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:141
+#: static/js/impala/stats/csv_keys.js:141 static/js/zamboni/stats-all.js:15422 static/js/zamboni/stats-min.js:5
 msgid "Downloads, last {0} days"
 msgstr ""
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:143
+#: static/js/impala/stats/csv_keys.js:143 static/js/zamboni/stats-all.js:15424 static/js/zamboni/stats-min.js:5
 msgid "Downloads from {0} to {1}"
 msgstr ""
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:147
+#: static/js/impala/stats/csv_keys.js:147 static/js/zamboni/stats-all.js:15428 static/js/zamboni/stats-min.js:5
 msgid "Daily Users, last {0} days"
 msgstr ""
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:149
+#: static/js/impala/stats/csv_keys.js:149 static/js/zamboni/stats-all.js:15430 static/js/zamboni/stats-min.js:5
 msgid "Daily Users from {0} to {1}"
 msgstr ""
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:153
+#: static/js/impala/stats/csv_keys.js:153 static/js/zamboni/stats-all.js:15434 static/js/zamboni/stats-min.js:5
 msgid "Applications, last {0} days"
 msgstr ""
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:155
+#: static/js/impala/stats/csv_keys.js:155 static/js/zamboni/stats-all.js:15436 static/js/zamboni/stats-min.js:5
 msgid "Applications from {0} to {1}"
 msgstr ""
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:159
+#: static/js/impala/stats/csv_keys.js:159 static/js/zamboni/stats-all.js:15440 static/js/zamboni/stats-min.js:5
 msgid "Platforms, last {0} days"
 msgstr ""
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:161
+#: static/js/impala/stats/csv_keys.js:161 static/js/zamboni/stats-all.js:15442 static/js/zamboni/stats-min.js:5
 msgid "Platforms from {0} to {1}"
 msgstr ""
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:165
+#: static/js/impala/stats/csv_keys.js:165 static/js/zamboni/stats-all.js:15446 static/js/zamboni/stats-min.js:5
 msgid "Languages, last {0} days"
 msgstr ""
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:167
+#: static/js/impala/stats/csv_keys.js:167 static/js/zamboni/stats-all.js:15448 static/js/zamboni/stats-min.js:5
 msgid "Languages from {0} to {1}"
 msgstr ""
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:171
+#: static/js/impala/stats/csv_keys.js:171 static/js/zamboni/stats-all.js:15452 static/js/zamboni/stats-min.js:5
 msgid "Add-on Versions, last {0} days"
 msgstr ""
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:173
+#: static/js/impala/stats/csv_keys.js:173 static/js/zamboni/stats-all.js:15454 static/js/zamboni/stats-min.js:5
 msgid "Add-on Versions from {0} to {1}"
 msgstr ""
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:177
+#: static/js/impala/stats/csv_keys.js:177 static/js/zamboni/stats-all.js:15458 static/js/zamboni/stats-min.js:5
 msgid "Add-on Status, last {0} days"
 msgstr ""
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:179
+#: static/js/impala/stats/csv_keys.js:179 static/js/zamboni/stats-all.js:15460 static/js/zamboni/stats-min.js:5
 msgid "Add-on Status from {0} to {1}"
 msgstr ""
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:183
+#: static/js/impala/stats/csv_keys.js:183 static/js/zamboni/stats-all.js:15464 static/js/zamboni/stats-min.js:5
 msgid "Download Sources, last {0} days"
 msgstr ""
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:185
+#: static/js/impala/stats/csv_keys.js:185 static/js/zamboni/stats-all.js:15466 static/js/zamboni/stats-min.js:5
 msgid "Download Sources from {0} to {1}"
 msgstr ""
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:189
+#: static/js/impala/stats/csv_keys.js:189 static/js/zamboni/stats-all.js:15470 static/js/zamboni/stats-min.js:5
 msgid "Contributions, last {0} days"
 msgstr ""
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:191
+#: static/js/impala/stats/csv_keys.js:191 static/js/zamboni/stats-all.js:15472 static/js/zamboni/stats-min.js:5
 msgid "Contributions from {0} to {1}"
 msgstr ""
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:195
+#: static/js/impala/stats/csv_keys.js:195 static/js/zamboni/stats-all.js:15476 static/js/zamboni/stats-min.js:5
 msgid "Site Metrics, last {0} days"
 msgstr ""
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:197
+#: static/js/impala/stats/csv_keys.js:197 static/js/zamboni/stats-all.js:15478 static/js/zamboni/stats-min.js:5
 msgid "Site Metrics from {0} to {1}"
 msgstr ""
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:201
+#: static/js/impala/stats/csv_keys.js:201 static/js/zamboni/stats-all.js:15482 static/js/zamboni/stats-min.js:5
 msgid "Add-ons in Use, last {0} days"
 msgstr ""
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:203
+#: static/js/impala/stats/csv_keys.js:203 static/js/zamboni/stats-all.js:15484 static/js/zamboni/stats-min.js:5
 msgid "Add-ons in Use from {0} to {1}"
 msgstr ""
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:207
+#: static/js/impala/stats/csv_keys.js:207 static/js/zamboni/stats-all.js:15488 static/js/zamboni/stats-min.js:5
 msgid "Add-ons Downloaded, last {0} days"
 msgstr ""
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:209
+#: static/js/impala/stats/csv_keys.js:209 static/js/zamboni/stats-all.js:15490 static/js/zamboni/stats-min.js:5
 msgid "Add-ons Downloaded from {0} to {1}"
 msgstr ""
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:213
+#: static/js/impala/stats/csv_keys.js:213 static/js/zamboni/stats-all.js:15494 static/js/zamboni/stats-min.js:5
 msgid "Add-ons Created, last {0} days"
 msgstr ""
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:215
+#: static/js/impala/stats/csv_keys.js:215 static/js/zamboni/stats-all.js:15496 static/js/zamboni/stats-min.js:5
 msgid "Add-ons Created from {0} to {1}"
 msgstr ""
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:219
+#: static/js/impala/stats/csv_keys.js:219 static/js/zamboni/stats-all.js:15500 static/js/zamboni/stats-min.js:5
 msgid "Add-ons Updated, last {0} days"
 msgstr ""
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:221
+#: static/js/impala/stats/csv_keys.js:221 static/js/zamboni/stats-all.js:15502 static/js/zamboni/stats-min.js:5
 msgid "Add-ons Updated from {0} to {1}"
 msgstr ""
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:225
+#: static/js/impala/stats/csv_keys.js:225 static/js/zamboni/stats-all.js:15506 static/js/zamboni/stats-min.js:5
 msgid "Reviews Written, last {0} days"
 msgstr ""
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:227
+#: static/js/impala/stats/csv_keys.js:227 static/js/zamboni/stats-all.js:15508 static/js/zamboni/stats-min.js:5
 msgid "Reviews Written from {0} to {1}"
 msgstr ""
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:231
+#: static/js/impala/stats/csv_keys.js:231 static/js/zamboni/stats-all.js:15512 static/js/zamboni/stats-min.js:5
 msgid "User Signups, last {0} days"
 msgstr ""
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:233
+#: static/js/impala/stats/csv_keys.js:233 static/js/zamboni/stats-all.js:15514 static/js/zamboni/stats-min.js:5
 msgid "User Signups from {0} to {1}"
 msgstr ""
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:237
+#: static/js/impala/stats/csv_keys.js:237 static/js/zamboni/stats-all.js:15518 static/js/zamboni/stats-min.js:5
 msgid "Collections Created, last {0} days"
 msgstr ""
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:239
+#: static/js/impala/stats/csv_keys.js:239 static/js/zamboni/stats-all.js:15520 static/js/zamboni/stats-min.js:5
 msgid "Collections Created from {0} to {1}"
 msgstr ""
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:243
+#: static/js/impala/stats/csv_keys.js:243 static/js/zamboni/stats-all.js:15524 static/js/zamboni/stats-min.js:5
 msgid "Subscribers, last {0} days"
 msgstr ""
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:245
+#: static/js/impala/stats/csv_keys.js:245 static/js/zamboni/stats-all.js:15526 static/js/zamboni/stats-min.js:5
 msgid "Subscribers from {0} to {1}"
 msgstr ""
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:249
+#: static/js/impala/stats/csv_keys.js:249 static/js/zamboni/stats-all.js:15530 static/js/zamboni/stats-min.js:5
 msgid "Ratings, last {0} days"
 msgstr ""
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:251
+#: static/js/impala/stats/csv_keys.js:251 static/js/zamboni/stats-all.js:15532 static/js/zamboni/stats-min.js:5
 msgid "Ratings from {0} to {1}"
 msgstr ""
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:255
+#: static/js/impala/stats/csv_keys.js:255 static/js/zamboni/stats-all.js:15536 static/js/zamboni/stats-min.js:5
 msgid "Sales, last {0} days"
 msgstr ""
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:257
+#: static/js/impala/stats/csv_keys.js:257 static/js/zamboni/stats-all.js:15538 static/js/zamboni/stats-min.js:5
 msgid "Sales from {0} to {1}"
 msgstr ""
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:261
+#: static/js/impala/stats/csv_keys.js:261 static/js/zamboni/stats-all.js:15542 static/js/zamboni/stats-min.js:5
 msgid "Installs, last {0} days"
 msgstr ""
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:263
+#: static/js/impala/stats/csv_keys.js:263 static/js/zamboni/stats-all.js:15544 static/js/zamboni/stats-min.js:5
 msgid "Installs from {0} to {1}"
 msgstr ""
 
 #. L10n: {0} and {1} are integers.
-#: static/js/impala/stats/csv_keys.js:269
+#: static/js/impala/stats/csv_keys.js:269 static/js/zamboni/stats-all.js:15550 static/js/zamboni/stats-min.js:5
 msgid "<b>{0}</b> in last {1} days"
 msgstr ""
 
 #. L10n: {0} is an integer and {1} and {2} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:271 static/js/impala/stats/csv_keys.js:277
+#: static/js/impala/stats/csv_keys.js:271 static/js/impala/stats/csv_keys.js:277 static/js/zamboni/stats-all.js:15552 static/js/zamboni/stats-all.js:15558 static/js/zamboni/stats-min.js:5
 msgid "<b>{0}</b> from {1} to {2}"
 msgstr ""
 
 #. L10n: {0} and {1} are integers.
-#: static/js/impala/stats/csv_keys.js:275
+#: static/js/impala/stats/csv_keys.js:275 static/js/zamboni/stats-all.js:15556 static/js/zamboni/stats-min.js:5
 msgid "<b>{0}</b> average in last {1} days"
 msgstr ""
 
-#: static/js/impala/stats/overview.js:19
+#: static/js/impala/stats/overview.js:19 static/js/zamboni/stats-all.js:16469 static/js/zamboni/stats-min.js:5
 msgid "No data available."
 msgstr ""
 
-#: static/js/impala/stats/table.js:74
+#: static/js/impala/stats/table.js:74 static/js/zamboni/stats-all.js:17209 static/js/zamboni/stats-min.js:5
 msgid "Date"
 msgstr ""
 
-#: static/js/impala/stats/topchart.js:96
+#: static/js/impala/stats/topchart.js:96 static/js/zamboni/stats-all.js:16600 static/js/zamboni/stats-min.js:5
 msgid "Other"
 msgstr ""
 
-#: static/js/zamboni/admin_validation.js:24 static/js/zamboni/devhub.js:1229 static/js/zamboni/editors.js:295
+#: static/js/zamboni/admin-all.js:180 static/js/zamboni/admin-min.js:1 static/js/zamboni/admin_validation.js:24 static/js/zamboni/devhub-all.js:2408 static/js/zamboni/devhub-min.js:2
+#: static/js/zamboni/devhub.js:1229 static/js/zamboni/editors-all.js:15576 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:295
 msgid "Select an application first"
 msgstr ""
 
-#: static/js/zamboni/admin_validation.js:51
+#: static/js/zamboni/admin-all.js:207 static/js/zamboni/admin-min.js:1 static/js/zamboni/admin_validation.js:51
 msgid "Set {0} add-on to a max version of {1} and email the author."
 msgid_plural "Set {0} add-ons to a max version of {1} and email the authors."
 msgstr[0] ""
+msgstr[1] ""
 
-#: static/js/zamboni/admin_validation.js:54
+#: static/js/zamboni/admin-all.js:210 static/js/zamboni/admin-min.js:1 static/js/zamboni/admin_validation.js:54
 msgid "Email author of {2} add-on which failed validation."
 msgid_plural "Email authors of {2} add-ons which failed validation."
 msgstr[0] ""
+msgstr[1] ""
 
-#. L10n: {0} is an app name like Firefox.
-#: static/js/zamboni/buttons.js:66
-msgid "Accept and Install"
-msgstr "قبول و نصب"
-
-#: static/js/zamboni/buttons.js:66
-msgid "Add to {0}"
-msgstr "افزودن به {0}"
-
-#: static/js/zamboni/buttons.js:71
-msgid "Download Now"
-msgstr "هم‌اکنون بارگیری کن"
-
-#: static/js/zamboni/buttons.js:112
-msgid "Add-on has not been updated to support default-to-compatible."
-msgstr ""
-
-#: static/js/zamboni/buttons.js:117
-msgid "You need to be using Firefox 10.0 or higher."
-msgstr ""
-
-#: static/js/zamboni/buttons.js:129
-msgid "Mozilla has marked this version as incompatible with your Firefox version."
-msgstr ""
-
-#. L10n: {0} is an platform like Windows or Linux.
-#: static/js/zamboni/buttons.js:210
-msgid "Install for {0} anyway"
-msgstr ""
-
-#: static/js/zamboni/buttons.js:210
-msgid "Download for {0} anyway"
-msgstr ""
-
-#: static/js/zamboni/buttons.js:267
-msgid "Not available for your platform"
-msgstr "برای سیستم عامل شما موجود نیست"
-
-#. L10n: {0} is an app name, {1} is the app version.
-#: static/js/zamboni/buttons.js:278 static/js/zamboni/buttons.js:315
-msgid "Not available for {0} {1}"
-msgstr "برای {0} {1} موجود نیست"
-
-#: static/js/zamboni/buttons.js:341
-msgid "Works with {app} {min} - {max}"
-msgstr "با {app} {min} - {max} کار می‌کند"
-
-#: static/js/zamboni/buttons.js:343
-msgid "View other versions"
-msgstr "نمایش سایر نسخه‌ها"
-
-#: static/js/zamboni/buttons.js:391
-msgid "Only with Firefox — Get Firefox Now!"
-msgstr ""
-
-#: static/js/zamboni/buttons.js:507 static/js/zamboni/mobile/buttons.js:43
-msgid "Sorry, you need a Mozilla-based browser (such as Firefox) to install a search plugin."
-msgstr ""
-
-#: static/js/zamboni/collections.js:229
-msgid "Adding to Favorites&hellip;"
-msgstr ""
-
-#: static/js/zamboni/collections.js:232
-msgid "Removing Favorite&hellip;"
-msgstr ""
-
-#: static/js/zamboni/collections.js:235
-msgid "Add to Favorites"
-msgstr ""
-
-#: static/js/zamboni/collections.js:238
-msgid "Remove from Favorites"
-msgstr ""
-
-#: static/js/zamboni/collections.js:303
-msgid "Pending"
-msgstr ""
-
-#: static/js/zamboni/collections.js:304
-msgid "Add a comment"
-msgstr ""
-
-#: static/js/zamboni/collections.js:304
-msgid "Comment"
-msgstr "توضیح"
-
-#: static/js/zamboni/collections.js:305
-msgid "Remove this add-on from the collection"
-msgstr "این افزودنی را از مجموعه حذف کن"
-
-#: static/js/zamboni/collections.js:305 static/js/zamboni/collections.js:334
-msgid "Remove"
-msgstr "حذف"
-
-#: static/js/zamboni/collections.js:334
-msgid "Remove this user as a contributor"
-msgstr ""
-
-#: static/js/zamboni/collections.js:346
-msgid "An email address is required."
-msgstr ""
-
-#: static/js/zamboni/collections.js:364
-msgid "You cannot add yourself as a contributor."
-msgstr ""
-
-#: static/js/zamboni/collections.js:366
-msgid "You have already added that user."
-msgstr ""
-
-#: static/js/zamboni/collections.js:573
-msgid "Add to favorites"
-msgstr ""
-
-#: static/js/zamboni/collections.js:577
-msgid "Remove from favorites"
-msgstr ""
-
-#: static/js/zamboni/collections.js:604
-msgid "Stop following"
-msgstr ""
-
-#: static/js/zamboni/devhub.js:110
+#: static/js/zamboni/devhub-all.js:1289 static/js/zamboni/devhub-min.js:1 static/js/zamboni/devhub.js:110
 msgid "Your browser does not support the video tag"
 msgstr ""
 
-#: static/js/zamboni/devhub.js:371
+#: static/js/zamboni/devhub-all.js:1550 static/js/zamboni/devhub-min.js:1 static/js/zamboni/devhub.js:371
 msgid "Changes Saved"
 msgstr "تغییرات ذخیره شد"
 
-#: static/js/zamboni/devhub.js:387
+#: static/js/zamboni/devhub-all.js:1566 static/js/zamboni/devhub-min.js:1 static/js/zamboni/devhub.js:387
 msgid "Enter a new author's email address"
 msgstr "ایمیل یک نویسنده جدید را وارد کنید"
 
-#: static/js/zamboni/devhub.js:536
+#: static/js/zamboni/devhub-all.js:1715 static/js/zamboni/devhub-min.js:1 static/js/zamboni/devhub.js:536
 msgid "There was an error uploading your file."
 msgstr "هنگام آپلود فایل شما خطایی رخ داد."
 
-#: static/js/zamboni/devhub.js:681
+#: static/js/zamboni/devhub-all.js:1860 static/js/zamboni/devhub-min.js:1 static/js/zamboni/devhub.js:681
 msgid "{files} file"
 msgid_plural "{files} files"
 msgstr[0] "{files} فایل"
+msgstr[1] ""
 
-#: static/js/zamboni/devhub.js:684
+#: static/js/zamboni/devhub-all.js:1863 static/js/zamboni/devhub-min.js:1 static/js/zamboni/devhub.js:684
 msgid "{reviews} user review"
 msgid_plural "{reviews} user reviews"
 msgstr[0] ""
+msgstr[1] ""
 
-#: static/js/zamboni/devhub.js:796
+#: static/js/zamboni/devhub-all.js:1975 static/js/zamboni/devhub-min.js:2 static/js/zamboni/devhub.js:796
 msgid "Learn more"
 msgstr "بیشتر بدانید"
 
-#: static/js/zamboni/devhub.js:800
+#: static/js/zamboni/devhub-all.js:1979 static/js/zamboni/devhub-min.js:2 static/js/zamboni/devhub.js:800
 msgid "Example"
 msgstr ""
 
-#: static/js/zamboni/devhub.js:1130
+#: static/js/zamboni/devhub-all.js:2309 static/js/zamboni/devhub-min.js:2 static/js/zamboni/devhub.js:1130
 msgid "Image changes being processed"
 msgstr ""
 
-#: static/js/zamboni/devhub.js:1280
+#: static/js/zamboni/devhub-all.js:2459 static/js/zamboni/devhub-min.js:2 static/js/zamboni/devhub.js:1280
 msgid "Must be a valid e-mail address."
+msgstr ""
+
+#: static/js/zamboni/devhub-all.js:2613 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:80
+msgid "All tests passed successfully."
+msgstr ""
+
+#: static/js/zamboni/devhub-all.js:2616 static/js/zamboni/devhub-all.js:3011 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:83 static/js/zamboni/validator.js:478
+msgid "These tests were not run."
+msgstr ""
+
+#: static/js/zamboni/devhub-all.js:2664 static/js/zamboni/devhub-all.js:2677 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:131 static/js/zamboni/validator.js:144
+msgid "Tests"
+msgstr ""
+
+#: static/js/zamboni/devhub-all.js:2779 static/js/zamboni/devhub-all.js:3108 static/js/zamboni/devhub-all.js:3127 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:246
+#: static/js/zamboni/validator.js:575 static/js/zamboni/validator.js:594
+msgid "Error"
+msgstr ""
+
+#: static/js/zamboni/devhub-all.js:2780 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:247
+msgid "Warning"
+msgstr ""
+
+#: static/js/zamboni/devhub-all.js:2794 static/js/zamboni/devhub-min.js:2 static/js/zamboni/files-all.js:5657 static/js/zamboni/files-min.js:3 static/js/zamboni/files.js:411
+#: static/js/zamboni/validator.js:261
+msgid "Ignore this message in future updates"
+msgstr ""
+
+#: static/js/zamboni/devhub-all.js:2817 static/js/zamboni/devhub-min.js:2 static/js/zamboni/files-all.js:5663 static/js/zamboni/files-min.js:3 static/js/zamboni/files.js:417
+#: static/js/zamboni/validator.js:284
+msgid "Severity for automated signing:"
+msgstr ""
+
+#: static/js/zamboni/devhub-all.js:2832 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:299
+msgid "Suggestions for passing automated signing:"
+msgstr ""
+
+#: static/js/zamboni/devhub-all.js:2920 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:387
+msgid "Compatibility Tests"
+msgstr ""
+
+#: static/js/zamboni/devhub-all.js:2999 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:466
+msgid "Add-on failed validation."
+msgstr ""
+
+#: static/js/zamboni/devhub-all.js:3001 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:468
+msgid "Add-on passed validation."
+msgstr ""
+
+#: static/js/zamboni/devhub-all.js:3014 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:481
+msgid "{0} error"
+msgid_plural "{0} errors"
+msgstr[0] ""
+msgstr[1] ""
+
+#: static/js/zamboni/devhub-all.js:3016 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:483
+msgid "{0} warning"
+msgid_plural "{0} warnings"
+msgstr[0] ""
+msgstr[1] ""
+
+#: static/js/zamboni/devhub-all.js:3018 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:485
+msgid "{0} notice"
+msgid_plural "{0} notices"
+msgstr[0] ""
+msgstr[1] ""
+
+#: static/js/zamboni/devhub-all.js:3110 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:577
+msgid "Validation task could not complete or completed with errors"
+msgstr ""
+
+#: static/js/zamboni/devhub-all.js:3128 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:595
+msgid "Internal server error"
 msgstr ""
 
 #: static/js/zamboni/devhub_search.js:8
 msgid "No results found."
 msgstr ""
 
-#: static/js/zamboni/editors.js:121
+#: static/js/zamboni/editors-all.js:15402 static/js/zamboni/editors-min.js:4 static/js/zamboni/editors.js:121
 msgid "{name} was viewing this page first."
 msgstr ""
 
-#: static/js/zamboni/editors.js:171
+#: static/js/zamboni/editors-all.js:15452 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:171
 msgid "Receipt checked by app."
 msgstr ""
 
-#: static/js/zamboni/editors.js:173
+#: static/js/zamboni/editors-all.js:15454 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:173
 msgid "Receipt was not checked by app."
 msgstr ""
 
-#: static/js/zamboni/editors.js:244
+#: static/js/zamboni/editors-all.js:15525 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:244
 msgid "{name} was viewing this add-on first."
 msgstr ""
 
-#: static/js/zamboni/editors.js:255
+#: static/js/zamboni/editors-all.js:15536 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:255
 msgid "Loading&hellip;"
 msgstr ""
 
-#: static/js/zamboni/editors.js:260
+#: static/js/zamboni/editors-all.js:15541 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:260
 msgid "Version Notes"
 msgstr ""
 
-#: static/js/zamboni/editors.js:265
+#: static/js/zamboni/editors-all.js:15546 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:265
 msgid "Notes for Reviewers"
 msgstr ""
 
-#: static/js/zamboni/editors.js:270
+#: static/js/zamboni/editors-all.js:15551 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:270
 msgid "No version notes found"
 msgstr ""
 
-#: static/js/zamboni/editors.js:330
+#: static/js/zamboni/editors-all.js:15611 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:330
 msgid "Average Reviews"
 msgstr ""
 
-#: static/js/zamboni/editors.js:386
+#: static/js/zamboni/editors-all.js:15667 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:386
 msgid "Number of Reviews"
 msgstr ""
 
-#: static/js/zamboni/editors.js:445
+#: static/js/zamboni/editors-all.js:15726 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:445
 msgid "Error loading translation"
 msgstr ""
 
-#: static/js/zamboni/files.js:411 static/js/zamboni/validator.js:261
-msgid "Ignore this message in future updates"
-msgstr ""
-
-#: static/js/zamboni/files.js:417 static/js/zamboni/validator.js:284
-msgid "Severity for automated signing:"
-msgstr ""
-
-#: static/js/zamboni/global.js:410
-msgid "Loading..."
-msgstr ""
-
-#. L10n: {0} is the number of characters left.
-#: static/js/zamboni/global.js:474
-msgid "<b>{0}</b> character left."
-msgid_plural "<b>{0}</b> characters left."
-msgstr[0] ""
-
-#: static/js/zamboni/init.js:28
-msgid "This feature is temporarily disabled while we perform website maintenance. Please check back a little later."
-msgstr ""
-
-#: static/js/zamboni/l10n.js:45
-msgid "Remove this localization"
-msgstr ""
-
-#: static/js/zamboni/password-strength.js:20
-msgid "Password strength:"
-msgstr ""
-
-#: static/js/zamboni/password-strength.js:26
-msgid "At least {0} character left."
-msgid_plural "At least {0} characters left."
-msgstr[0] ""
-
-#: static/js/zamboni/themes_review.js:176
-msgid "Requested Info"
-msgstr ""
-
-#: static/js/zamboni/themes_review.js:177
-msgid "Flagged"
-msgstr ""
-
-#: static/js/zamboni/themes_review.js:178
-msgid "Duplicate"
-msgstr ""
-
-#: static/js/zamboni/themes_review.js:179
-msgid "Rejected"
-msgstr ""
-
-#: static/js/zamboni/themes_review.js:180
-msgid "Approved"
-msgstr ""
-
-#: static/js/zamboni/themes_review.js:424
-msgid "No results found"
-msgstr ""
-
-#: static/js/zamboni/themes_review_templates.js:31
+#: static/js/zamboni/editors-all.js:15975 static/js/zamboni/editors-min.js:5 static/js/zamboni/themes_review_templates.js:31
 msgid "Theme"
 msgstr ""
 
-#: static/js/zamboni/themes_review_templates.js:33
+#: static/js/zamboni/editors-all.js:15977 static/js/zamboni/editors-min.js:5 static/js/zamboni/themes_review_templates.js:33
 msgid "Reviewer"
 msgstr ""
 
-#: static/js/zamboni/themes_review_templates.js:35
+#: static/js/zamboni/editors-all.js:15979 static/js/zamboni/editors-min.js:5 static/js/zamboni/themes_review_templates.js:35
 msgid "Status"
 msgstr ""
 
-#: static/js/zamboni/validator.js:80
-msgid "All tests passed successfully."
+#: static/js/zamboni/editors-all.js:16196 static/js/zamboni/editors-min.js:5 static/js/zamboni/themes_review.js:176
+msgid "Requested Info"
 msgstr ""
 
-#: static/js/zamboni/validator.js:83 static/js/zamboni/validator.js:478
-msgid "These tests were not run."
+#: static/js/zamboni/editors-all.js:16197 static/js/zamboni/editors-min.js:5 static/js/zamboni/themes_review.js:177
+msgid "Flagged"
 msgstr ""
 
-#: static/js/zamboni/validator.js:131 static/js/zamboni/validator.js:144
-msgid "Tests"
+#: static/js/zamboni/editors-all.js:16198 static/js/zamboni/editors-min.js:5 static/js/zamboni/themes_review.js:178
+msgid "Duplicate"
 msgstr ""
 
-#: static/js/zamboni/validator.js:246 static/js/zamboni/validator.js:575 static/js/zamboni/validator.js:594
-msgid "Error"
+#: static/js/zamboni/editors-all.js:16199 static/js/zamboni/editors-min.js:5 static/js/zamboni/themes_review.js:179
+msgid "Rejected"
 msgstr ""
 
-#: static/js/zamboni/validator.js:247
-msgid "Warning"
+#: static/js/zamboni/editors-all.js:16200 static/js/zamboni/editors-min.js:5 static/js/zamboni/themes_review.js:180
+msgid "Approved"
 msgstr ""
 
-#: static/js/zamboni/validator.js:299
-msgid "Suggestions for passing automated signing:"
+#: static/js/zamboni/editors-all.js:16444 static/js/zamboni/editors-min.js:5 static/js/zamboni/themes_review.js:424
+msgid "No results found"
 msgstr ""
 
-#: static/js/zamboni/validator.js:387
-msgid "Compatibility Tests"
-msgstr ""
-
-#: static/js/zamboni/validator.js:466
-msgid "Add-on failed validation."
-msgstr ""
-
-#: static/js/zamboni/validator.js:468
-msgid "Add-on passed validation."
-msgstr ""
-
-#: static/js/zamboni/validator.js:481
-msgid "{0} error"
-msgid_plural "{0} errors"
-msgstr[0] ""
-
-#: static/js/zamboni/validator.js:483
-msgid "{0} warning"
-msgid_plural "{0} warnings"
-msgstr[0] ""
-
-#: static/js/zamboni/validator.js:485
-msgid "{0} notice"
-msgid_plural "{0} notices"
-msgstr[0] ""
-
-#: static/js/zamboni/validator.js:577
-msgid "Validation task could not complete or completed with errors"
-msgstr ""
-
-#: static/js/zamboni/validator.js:595
-msgid "Internal server error"
-msgstr ""
-
-#: static/js/zamboni/mobile/buttons.js:52
+#: static/js/zamboni/mobile-all.js:15186 static/js/zamboni/mobile/buttons.js:52
 msgid "Not Updated for {0} {1}"
 msgstr ""
 
-#: static/js/zamboni/mobile/buttons.js:53
+#: static/js/zamboni/mobile-all.js:15187 static/js/zamboni/mobile/buttons.js:53
 msgid "Requires Newer Version of {0}"
 msgstr ""
 
-#: static/js/zamboni/mobile/buttons.js:54
+#: static/js/zamboni/mobile-all.js:15188 static/js/zamboni/mobile/buttons.js:54
 msgid "Unreviewed"
 msgstr ""
 
-#: static/js/zamboni/mobile/buttons.js:55
+#: static/js/zamboni/mobile-all.js:15189 static/js/zamboni/mobile/buttons.js:55
 msgid "Experimental <span>(Learn More)</span>"
 msgstr ""
 
-#: static/js/zamboni/mobile/buttons.js:56 static/js/zamboni/mobile/buttons.js:57
+#: static/js/zamboni/mobile-all.js:15190 static/js/zamboni/mobile-all.js:15191 static/js/zamboni/mobile/buttons.js:56 static/js/zamboni/mobile/buttons.js:57
 msgid "Not Available for {0}"
 msgstr ""
 
-#: static/js/zamboni/mobile/buttons.js:58
+#: static/js/zamboni/mobile-all.js:15192 static/js/zamboni/mobile/buttons.js:58
 msgid "Experimental"
 msgstr ""
 
-#: static/js/zamboni/mobile/buttons.js:59
+#: static/js/zamboni/mobile-all.js:15193 static/js/zamboni/mobile/buttons.js:59
 msgid "Themes Require Newer Version of {0}"
 msgstr ""
 
-#: static/js/zamboni/mobile/buttons.js:60
+#: static/js/zamboni/mobile-all.js:15194 static/js/zamboni/mobile/buttons.js:60
 msgid "Themes Require {0}"
 msgstr ""
 
-#: static/js/zamboni/mobile/buttons.js:105
+#: static/js/zamboni/mobile-all.js:15239 static/js/zamboni/mobile/buttons.js:105
 msgid "Installing..."
 msgstr ""
 
-#: static/js/zamboni/mobile/buttons.js:125
+#: static/js/zamboni/mobile-all.js:15259 static/js/zamboni/mobile/buttons.js:125
 msgid "This add-on has been preliminarily reviewed by Mozilla."
 msgstr ""
 
-#: static/js/zamboni/mobile/buttons.js:250
+#: static/js/zamboni/mobile-all.js:15384 static/js/zamboni/mobile/buttons.js:250
 msgid "Keep it"
 msgstr ""
 
-#: static/js/zamboni/mobile/general.js:344
+#: static/js/zamboni/mobile-all.js:16049 static/js/zamboni/mobile-min.js:6 static/js/zamboni/mobile/general.js:344
 msgid "You're trying it on!"
 msgstr ""
 
-#: static/js/zamboni/mobile/general.js:356
+#: static/js/zamboni/mobile-all.js:16061 static/js/zamboni/mobile-min.js:6 static/js/zamboni/mobile/general.js:356
 msgid "Added to Firefox"
 msgstr ""
-

--- a/locale/ff/LC_MESSAGES/django.po
+++ b/locale/ff/LC_MESSAGES/django.po
@@ -3,69 +3,70 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2016-02-24 21:23+0000\n"
+"POT-Creation-Date: 2016-04-18 15:47+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
+"Language: \n"
 "MIME-Version: 1.0\n"
-"Content-Type: text/plain; charset=utf-8\n"
+"Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Generated-By: Babel 2.2.0\n"
 
-#: src/olympia/accounts/views.py:52
+#: src/olympia/accounts/views.py:54
 msgid "Your log in attempt could not be parsed. Please try again."
 msgstr ""
 
-#: src/olympia/accounts/views.py:54
+#: src/olympia/accounts/views.py:56
 msgid "Your Firefox Account could not be found. Please try again."
 msgstr ""
 
-#: src/olympia/accounts/views.py:55
+#: src/olympia/accounts/views.py:57
 msgid "You could not be logged in. Please try again."
 msgstr ""
 
-#: src/olympia/accounts/views.py:57
+#: src/olympia/accounts/views.py:59
 msgid "Your account has already been migrated to Firefox Accounts."
 msgstr ""
 
-#: src/olympia/accounts/views.py:59
+#: src/olympia/accounts/views.py:61
 msgid "Your Firefox Account already exists on this site."
 msgstr ""
 
-#: src/olympia/accounts/views.py:108
+#: src/olympia/accounts/views.py:110
 msgid "Great job!"
 msgstr ""
 
-#: src/olympia/accounts/views.py:109
+#: src/olympia/accounts/views.py:111
 msgid "You can now log in to Add-ons with your Firefox Account."
 msgstr ""
 
-#: src/olympia/accounts/views.py:121
+#: src/olympia/accounts/views.py:123
 msgid "Need help?"
 msgstr ""
 
-#: src/olympia/addons/buttons.py:180
+#: src/olympia/addons/buttons.py:177
 msgid "Download Now"
 msgstr ""
 
-#: src/olympia/addons/buttons.py:182
+#: src/olympia/addons/buttons.py:179
 msgid "Download"
 msgstr ""
 
 #. L10n: please keep &nbsp; in the string so &rarr; does not wrap.
-#: src/olympia/addons/buttons.py:186
+#: src/olympia/addons/buttons.py:183
 msgid "Continue to Download&nbsp;&rarr;"
 msgstr ""
 
-#: src/olympia/addons/buttons.py:202 src/olympia/addons/helpers.py:35 src/olympia/addons/views.py:319 src/olympia/addons/templates/addons/impala/details.html:114
+#: src/olympia/addons/buttons.py:199 src/olympia/addons/helpers.py:35 src/olympia/addons/views.py:333 src/olympia/addons/templates/addons/impala/details.html:111
 #: src/olympia/addons/templates/addons/impala/listing/items.html:17 src/olympia/addons/templates/addons/mobile/home.html:40 src/olympia/amo/templates/amo/side_nav.html:6
-#: src/olympia/amo/templates/amo/side_nav.html:10 src/olympia/amo/templates/amo/site_nav.html:2 src/olympia/amo/templates/amo/site_nav.html:55 src/olympia/bandwagon/views.py:95
-#: src/olympia/browse/views.py:54 src/olympia/browse/views.py:68 src/olympia/browse/views.py:235 src/olympia/browse/templates/browse/impala/category_landing.html:22
+#: src/olympia/amo/templates/amo/side_nav.html:10 src/olympia/amo/templates/amo/site_nav.html:2 src/olympia/amo/templates/amo/site_nav.html:53 src/olympia/bandwagon/views.py:95
+#: src/olympia/browse/views.py:54 src/olympia/browse/views.py:68 src/olympia/browse/views.py:202 src/olympia/browse/templates/browse/impala/category_landing.html:22
 #: src/olympia/browse/templates/browse/personas/mobile/category_landing.html:26
 msgid "Featured"
 msgstr ""
 
-#: src/olympia/addons/buttons.py:221
+#: src/olympia/addons/buttons.py:218
 msgid "Add to {0}"
 msgstr ""
 
@@ -113,39 +114,39 @@ msgid_plural "All tags must be at least {0} characters."
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/olympia/addons/forms.py:234
+#: src/olympia/addons/forms.py:238
 msgid "Categories cannot be changed while your add-on is featured for this application."
 msgstr ""
 
 #. L10n: {0} is the number of categories.
-#: src/olympia/addons/forms.py:238
+#: src/olympia/addons/forms.py:242
 msgid "You can have only {0} category."
 msgid_plural "You can have only {0} categories."
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/olympia/addons/forms.py:246
+#: src/olympia/addons/forms.py:250
 msgid "The miscellaneous category cannot be combined with additional categories."
 msgstr ""
 
-#: src/olympia/addons/forms.py:369
+#: src/olympia/addons/forms.py:374
 #, python-format
 msgid "Before changing your default locale you must have a name, summary, and description in that locale. You are missing %s."
 msgstr ""
 
-#: src/olympia/addons/forms.py:484 src/olympia/addons/forms.py:575
+#: src/olympia/addons/forms.py:455 src/olympia/addons/forms.py:546
 msgid "A license must be selected."
 msgstr ""
 
-#: src/olympia/addons/forms.py:556
+#: src/olympia/addons/forms.py:527
 msgid "Give Your Theme a Name."
 msgstr ""
 
-#: src/olympia/addons/forms.py:562 src/olympia/devhub/templates/devhub/personas/submit.html:53
+#: src/olympia/addons/forms.py:533 src/olympia/devhub/templates/devhub/personas/submit.html:53
 msgid "Describe your Theme."
 msgstr ""
 
-#: src/olympia/addons/forms.py:704
+#: src/olympia/addons/forms.py:675
 msgid "Enter a new author's email address"
 msgstr ""
 
@@ -153,37 +154,37 @@ msgstr ""
 msgid "Not Reviewed"
 msgstr ""
 
-#: src/olympia/addons/models.py:301
+#: src/olympia/addons/models.py:298
 msgid "Users have the option of contributing more or less than this amount."
 msgstr ""
 
-#: src/olympia/addons/models.py:309
-msgid "Users will always be asked in the Add-ons Manager (Firefox 4 and above)"
+#: src/olympia/addons/models.py:306
+msgid "Users will always be asked in the Add-ons Manager (Firefox 4 and above). Only applies to desktop."
 msgstr ""
 
-#: src/olympia/addons/models.py:1804 src/olympia/addons/templates/addons/details_box.html:55 src/olympia/devhub/templates/devhub/index.html:92
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:102
+#: src/olympia/addons/models.py:1802 src/olympia/addons/templates/addons/details_box.html:55 src/olympia/devhub/templates/devhub/index.html:92
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:89
 msgid "Listed"
 msgstr ""
 
-#: src/olympia/addons/views.py:320 src/olympia/browse/templates/browse/personas/mobile/category_landing.html:27
+#: src/olympia/addons/views.py:334 src/olympia/browse/templates/browse/personas/mobile/category_landing.html:27
 msgid "Popular"
 msgstr ""
 
-#: src/olympia/addons/views.py:321 src/olympia/browse/views.py:238 src/olympia/browse/views.py:280 src/olympia/browse/views.py:482
+#: src/olympia/addons/views.py:335 src/olympia/browse/views.py:205 src/olympia/browse/views.py:247 src/olympia/browse/views.py:449
 msgid "Recently Added"
 msgstr ""
 
-#: src/olympia/addons/views.py:322 src/olympia/bandwagon/views.py:99 src/olympia/browse/views.py:60 src/olympia/browse/views.py:71 src/olympia/search/forms.py:16 src/olympia/search/forms.py:91
+#: src/olympia/addons/views.py:336 src/olympia/bandwagon/views.py:99 src/olympia/browse/views.py:60 src/olympia/browse/views.py:71 src/olympia/search/forms.py:16 src/olympia/search/forms.py:91
 msgid "Recently Updated"
 msgstr ""
 
 #. l10n: {0} is the addon name
-#: src/olympia/addons/views.py:520
+#: src/olympia/addons/views.py:534
 msgid "Contribution for {0}"
 msgstr ""
 
-#: src/olympia/addons/views.py:613
+#: src/olympia/addons/views.py:627
 msgid "Abuse reported."
 msgstr ""
 
@@ -250,9 +251,9 @@ msgstr ""
 #: src/olympia/devhub/templates/devhub/addons/ajax_compat_update.html:36 src/olympia/devhub/templates/devhub/addons/profile.html:44 src/olympia/devhub/templates/devhub/addons/edit/admin.html:101
 #: src/olympia/devhub/templates/devhub/addons/edit/basic.html:152 src/olympia/devhub/templates/devhub/addons/edit/details.html:85 src/olympia/devhub/templates/devhub/addons/edit/support.html:67
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:166 src/olympia/devhub/templates/devhub/addons/forms_shared/media.html:149
-#: src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:44 src/olympia/devhub/templates/devhub/versions/add_file_modal.html:78 src/olympia/devhub/templates/devhub/versions/edit.html:139
-#: src/olympia/devhub/templates/devhub/versions/list.html:242 src/olympia/devhub/templates/devhub/versions/list.html:276 src/olympia/devhub/templates/devhub/versions/list.html:317
-#: src/olympia/devhub/templates/devhub/versions/list.html:351 src/olympia/reviews/templates/reviews/edit_review.html:16 src/olympia/translations/templates/translations/trans-menu.html:50
+#: src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:43 src/olympia/devhub/templates/devhub/versions/add_file_modal.html:58 src/olympia/devhub/templates/devhub/versions/edit.html:139
+#: src/olympia/devhub/templates/devhub/versions/list.html:239 src/olympia/devhub/templates/devhub/versions/list.html:281 src/olympia/devhub/templates/devhub/versions/list.html:315
+#: src/olympia/devhub/templates/devhub/versions/list.html:349 src/olympia/reviews/templates/reviews/edit_review.html:16 src/olympia/translations/templates/translations/trans-menu.html:50
 #: src/olympia/translations/templates/translations/trans-menu.html:62
 msgid "or"
 msgstr ""
@@ -363,7 +364,7 @@ msgid "Add-on Information for {0}"
 msgstr ""
 
 #: src/olympia/addons/templates/addons/details_box.html:30 src/olympia/addons/templates/addons/persona_detail_table.html:3 src/olympia/addons/templates/addons/mobile/details.html:63
-#: src/olympia/addons/templates/addons/mobile/persona_detail_table.html:7 src/olympia/browse/views.py:459 src/olympia/devhub/views.py:75
+#: src/olympia/addons/templates/addons/mobile/persona_detail_table.html:7 src/olympia/browse/views.py:426 src/olympia/devhub/views.py:73
 msgid "Updated"
 msgstr ""
 
@@ -382,11 +383,11 @@ msgstr ""
 msgid "Visibility"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/details_box.html:57 src/olympia/devhub/templates/devhub/index.html:94 src/olympia/devhub/templates/devhub/includes/addon_details.html:104
+#: src/olympia/addons/templates/addons/details_box.html:57 src/olympia/devhub/templates/devhub/index.html:94 src/olympia/devhub/templates/devhub/includes/addon_details.html:91
 msgid "Hidden"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/details_box.html:59 src/olympia/devhub/templates/devhub/index.html:96 src/olympia/devhub/templates/devhub/includes/addon_details.html:106
+#: src/olympia/addons/templates/addons/details_box.html:59 src/olympia/devhub/templates/devhub/index.html:96 src/olympia/devhub/templates/devhub/includes/addon_details.html:93
 msgid "Unlisted"
 msgstr ""
 
@@ -394,13 +395,13 @@ msgstr ""
 msgid "Required Add-ons"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/details_box.html:81 src/olympia/addons/templates/addons/persona_detail_table.html:15 src/olympia/browse/views.py:462 src/olympia/devhub/views.py:78
-#: src/olympia/devhub/views.py:85 src/olympia/discovery/templates/discovery/addons/detail.html:57 src/olympia/reviews/forms.py:62 src/olympia/reviews/templates/reviews/add.html:57
+#: src/olympia/addons/templates/addons/details_box.html:81 src/olympia/addons/templates/addons/persona_detail_table.html:15 src/olympia/browse/views.py:429 src/olympia/devhub/views.py:76
+#: src/olympia/devhub/views.py:83 src/olympia/discovery/templates/discovery/addons/detail.html:57 src/olympia/reviews/forms.py:62 src/olympia/reviews/templates/reviews/add.html:57
 #: src/olympia/reviews/templates/reviews/mobile/review_list.html:18
 msgid "Rating"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/details_box.html:85 src/olympia/browse/views.py:461 src/olympia/devhub/views.py:77 src/olympia/devhub/views.py:84
+#: src/olympia/addons/templates/addons/details_box.html:85 src/olympia/browse/views.py:428 src/olympia/devhub/views.py:75 src/olympia/devhub/views.py:82
 #: src/olympia/stats/templates/stats/addon_report_menu.html:8 src/olympia/stats/templates/stats/collection_report_menu.html:18
 msgid "Downloads"
 msgstr ""
@@ -420,7 +421,7 @@ msgstr ""
 
 #. The Privacy Policy for this add-on.
 #: src/olympia/addons/templates/addons/details_box.html:121 src/olympia/addons/templates/addons/privacy.html:19 src/olympia/addons/templates/addons/privacy.html:23
-#: src/olympia/addons/templates/addons/impala/button.html:43 src/olympia/addons/templates/addons/impala/details.html:307 src/olympia/devhub/templates/devhub/includes/policy_form.html:20
+#: src/olympia/addons/templates/addons/impala/button.html:43 src/olympia/addons/templates/addons/impala/details.html:312 src/olympia/devhub/templates/devhub/includes/policy_form.html:23
 #: src/olympia/templates/mobile/base_addons.html:87
 msgid "Privacy Policy"
 msgstr ""
@@ -445,7 +446,7 @@ msgstr ""
 msgid "Developer Comments"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/details_box.html:199 src/olympia/addons/templates/addons/impala/details.html:259
+#: src/olympia/addons/templates/addons/details_box.html:199 src/olympia/addons/templates/addons/impala/details.html:264
 msgid "Development Channel"
 msgstr ""
 
@@ -465,7 +466,7 @@ msgid ""
 "developer. To stop receiving development updates, reinstall the default version from the link above."
 msgstr ""
 
-#: src/olympia/addons/templates/addons/details_box.html:220 src/olympia/addons/templates/addons/impala/details.html:278
+#: src/olympia/addons/templates/addons/details_box.html:220 src/olympia/addons/templates/addons/impala/details.html:283
 msgid "Version {0}:"
 msgstr ""
 
@@ -484,7 +485,7 @@ msgid "End-User License Agreement for {0}"
 msgstr ""
 
 #: src/olympia/addons/templates/addons/eula.html:17 src/olympia/addons/templates/addons/eula.html:21 src/olympia/addons/templates/addons/impala/button.html:48
-#: src/olympia/addons/templates/addons/impala/details.html:316 src/olympia/devhub/templates/devhub/includes/policy_form.html:3 src/olympia/discovery/templates/discovery/addons/eula.html:11
+#: src/olympia/addons/templates/addons/impala/details.html:321 src/olympia/devhub/templates/devhub/includes/policy_form.html:3 src/olympia/discovery/templates/discovery/addons/eula.html:11
 msgid "End-User License Agreement"
 msgstr ""
 
@@ -501,7 +502,7 @@ msgstr ""
 msgid "Add-ons for {0}"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/home.html:10 src/olympia/addons/templates/addons/home.html:51 src/olympia/browse/templates/browse/impala/base_listing.html:11
+#: src/olympia/addons/templates/addons/home.html:10 src/olympia/addons/templates/addons/home.html:53 src/olympia/browse/templates/browse/impala/base_listing.html:11
 msgid "Featured Extensions"
 msgstr ""
 
@@ -509,29 +510,29 @@ msgstr ""
 msgid "Popular Extensions"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/home.html:42 src/olympia/amo/templates/amo/side_nav.html:3 src/olympia/amo/templates/amo/side_nav.html:11 src/olympia/amo/templates/amo/site_nav.html:3
-#: src/olympia/amo/templates/amo/site_nav.html:25 src/olympia/browse/views.py:236 src/olympia/browse/views.py:281 src/olympia/browse/views.py:481
+#: src/olympia/addons/templates/addons/home.html:44 src/olympia/amo/templates/amo/side_nav.html:3 src/olympia/amo/templates/amo/side_nav.html:11 src/olympia/amo/templates/amo/site_nav.html:3
+#: src/olympia/amo/templates/amo/site_nav.html:25 src/olympia/browse/views.py:203 src/olympia/browse/views.py:248 src/olympia/browse/views.py:448
 msgid "Most Popular"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/home.html:43
+#: src/olympia/addons/templates/addons/home.html:45
 msgid "All »"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/home.html:52 src/olympia/addons/templates/addons/home.html:61 src/olympia/addons/templates/addons/home.html:70 src/olympia/addons/templates/addons/home.html:78
+#: src/olympia/addons/templates/addons/home.html:54 src/olympia/addons/templates/addons/home.html:63 src/olympia/addons/templates/addons/home.html:72 src/olympia/addons/templates/addons/home.html:80
 #: src/olympia/browse/templates/browse/impala/category_landing.html:36
 msgid "See all »"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/home.html:60
+#: src/olympia/addons/templates/addons/home.html:62
 msgid "Up &amp; Coming Extensions"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/home.html:69 src/olympia/browse/templates/browse/personas/category_landing.html:61 src/olympia/discovery/templates/discovery/pane.html:74
+#: src/olympia/addons/templates/addons/home.html:71 src/olympia/browse/templates/browse/personas/category_landing.html:61 src/olympia/discovery/templates/discovery/pane.html:74
 msgid "Featured Themes"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/home.html:77 src/olympia/bandwagon/templates/bandwagon/impala/collection_listing.html:5
+#: src/olympia/addons/templates/addons/home.html:79 src/olympia/bandwagon/templates/bandwagon/impala/collection_listing.html:5
 msgid "Featured Collections"
 msgstr ""
 
@@ -549,7 +550,7 @@ msgid "Updated {0}"
 msgstr ""
 
 #. {0} is a date.
-#: src/olympia/addons/templates/addons/macros.html:10 src/olympia/addons/templates/addons/macros.html:69 src/olympia/addons/templates/addons/persona_preview.html:21
+#: src/olympia/addons/templates/addons/macros.html:10 src/olympia/addons/templates/addons/macros.html:69 src/olympia/addons/templates/addons/persona_preview.html:22
 #: src/olympia/addons/templates/addons/listing/items_mobile.html:44 src/olympia/addons/templates/addons/listing/macros.html:39
 #: src/olympia/bandwagon/templates/bandwagon/collection_listing_items.html:37 src/olympia/bandwagon/templates/bandwagon/impala/collection_listing_items.html:37
 msgid "Added {0}"
@@ -570,15 +571,14 @@ msgstr[0] ""
 msgstr[1] ""
 
 #. {0} is the number of downloads.
-#: src/olympia/addons/templates/addons/macros.html:53 src/olympia/addons/templates/addons/impala/details.html:61
+#: src/olympia/addons/templates/addons/macros.html:53 src/olympia/addons/templates/addons/impala/details.html:59
 msgid "{0} weekly download"
 msgid_plural "{0} weekly downloads"
 msgstr[0] ""
 msgstr[1] ""
 
 #. {0} is the number of users.
-#: src/olympia/addons/templates/addons/macros.html:61 src/olympia/addons/templates/addons/impala/details.html:54 src/olympia/compat/templates/compat/index.html:71
-#: src/olympia/zadmin/templates/zadmin/compat.html:67
+#: src/olympia/addons/templates/addons/macros.html:61 src/olympia/addons/templates/addons/impala/details.html:52 src/olympia/zadmin/templates/zadmin/compat.html:67
 msgid "{0} user"
 msgid_plural "{0} users"
 msgstr[0] ""
@@ -596,7 +596,7 @@ msgstr ""
 msgid "Return to the addon."
 msgstr ""
 
-#: src/olympia/addons/templates/addons/persona_detail.html:17 src/olympia/addons/templates/addons/impala/details.html:106 src/olympia/addons/templates/addons/mobile/details.html:23
+#: src/olympia/addons/templates/addons/persona_detail.html:17 src/olympia/addons/templates/addons/impala/details.html:103 src/olympia/addons/templates/addons/mobile/details.html:23
 #: src/olympia/addons/templates/addons/mobile/persona_detail.html:21 src/olympia/discovery/templates/discovery/addons/base.html:27 src/olympia/editors/templates/editors/review.html:31
 msgid "by"
 msgstr ""
@@ -640,34 +640,35 @@ msgstr ""
 msgid "License"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/persona_preview.html:12 src/olympia/constants/base.py:48
+#: src/olympia/addons/templates/addons/persona_preview.html:13 src/olympia/constants/base.py:48
 msgid "Awaiting Review"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/persona_preview.html:14 src/olympia/amo/log.py:180 src/olympia/constants/base.py:42 src/olympia/editors/helpers.py:62
+#: src/olympia/addons/templates/addons/persona_preview.html:15 src/olympia/amo/log.py:180 src/olympia/constants/base.py:42 src/olympia/editors/helpers.py:62
 msgid "Rejected"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/persona_preview.html:16 src/olympia/amo/log.py:159
+#: src/olympia/addons/templates/addons/persona_preview.html:17 src/olympia/amo/log.py:159
 msgid "Approved"
 msgstr ""
 
 #. {0} is the number of users.
-#: src/olympia/addons/templates/addons/persona_preview.html:26 src/olympia/addons/templates/addons/listing/items_mobile.html:36 src/olympia/addons/templates/addons/listing/macros.html:31
+#: src/olympia/addons/templates/addons/persona_preview.html:27 src/olympia/addons/templates/addons/listing/items_mobile.html:36 src/olympia/addons/templates/addons/listing/macros.html:31
 msgid "<strong>{0}</strong> user"
 msgid_plural "<strong>{0}</strong> users"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/olympia/addons/templates/addons/persona_preview.html:40
+#: src/olympia/addons/templates/addons/persona_preview.html:41
 msgid "Hover to Preview"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/persona_preview.html:46 src/olympia/addons/templates/addons/persona_preview.html:48 src/olympia/reviews/templates/reviews/add.html:15
+#: src/olympia/addons/templates/addons/persona_preview.html:47 src/olympia/addons/templates/addons/persona_preview.html:49 src/olympia/addons/templates/addons/persona_preview.html:97
+#: src/olympia/reviews/templates/reviews/add.html:15
 msgid "Add"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/persona_preview.html:57 src/olympia/bandwagon/templates/bandwagon/ajax_new.html:16 src/olympia/bandwagon/templates/bandwagon/edit.html:19
+#: src/olympia/addons/templates/addons/persona_preview.html:58 src/olympia/bandwagon/templates/bandwagon/ajax_new.html:16 src/olympia/bandwagon/templates/bandwagon/edit.html:19
 #: src/olympia/bandwagon/templates/bandwagon/includes/addedit.html:19 src/olympia/devhub/templates/devhub/addons/edit/admin.html:13 src/olympia/devhub/templates/devhub/addons/edit/basic.html:10
 #: src/olympia/devhub/templates/devhub/addons/edit/details.html:8 src/olympia/devhub/templates/devhub/addons/edit/media.html:6 src/olympia/devhub/templates/devhub/addons/edit/support.html:8
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:9 src/olympia/devhub/templates/devhub/addons/submit/describe.html:29 src/olympia/editors/templates/editors/review.html:257
@@ -676,21 +677,21 @@ msgstr ""
 
 #. For datetime formatting, see the table on
 #. http://docs.python.org/library/datetime.html#strftime-and-strptime-behavior
-#: src/olympia/addons/templates/addons/persona_preview.html:66
+#: src/olympia/addons/templates/addons/persona_preview.html:67
 #, python-format
 msgid "%%Y-%%m-%%d"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/persona_preview.html:67
+#: src/olympia/addons/templates/addons/persona_preview.html:68
 msgid "by {0} on {1}"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/persona_preview.html:75 src/olympia/reviews/helpers.py:17 src/olympia/reviews/templates/reviews/review_list.html:63
+#: src/olympia/addons/templates/addons/persona_preview.html:76 src/olympia/reviews/helpers.py:17 src/olympia/reviews/templates/reviews/review_list.html:63
 #: src/olympia/reviews/templates/reviews/reviews_link.html:21 src/olympia/reviews/templates/reviews/impala/reviews_link.html:16
 msgid "Not yet rated"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/persona_preview.html:78
+#: src/olympia/addons/templates/addons/persona_preview.html:79
 msgid "<b>{0}</b> users"
 msgstr ""
 
@@ -703,7 +704,7 @@ msgid "Learn more about Firefox"
 msgstr ""
 
 #: src/olympia/addons/templates/addons/popups.html:22
-msgid "or <b><a class=\"installer\" href=\"{url}\">download anyway</a></b>"
+msgid "or <b><a class=\"button installer\" href=\"{url}\">download anyway</a></b>"
 msgstr ""
 
 #: src/olympia/addons/templates/addons/popups.html:26
@@ -802,7 +803,7 @@ msgid ""
 msgstr ""
 
 #: src/olympia/addons/templates/addons/report_abuse.html:6 src/olympia/addons/templates/addons/report_abuse_full.html:10 src/olympia/addons/templates/addons/impala/details-more.html:23
-#: src/olympia/addons/templates/addons/impala/details.html:328
+#: src/olympia/addons/templates/addons/impala/details.html:333
 msgid "Report Abuse"
 msgstr ""
 
@@ -821,9 +822,9 @@ msgstr ""
 #: src/olympia/devhub/templates/devhub/addons/ajax_compat_update.html:36 src/olympia/devhub/templates/devhub/addons/profile.html:44 src/olympia/devhub/templates/devhub/addons/edit/admin.html:104
 #: src/olympia/devhub/templates/devhub/addons/edit/basic.html:155 src/olympia/devhub/templates/devhub/addons/edit/details.html:88 src/olympia/devhub/templates/devhub/addons/edit/support.html:70
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:169 src/olympia/devhub/templates/devhub/addons/forms_shared/media.html:152
-#: src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:44 src/olympia/devhub/templates/devhub/personas/edit.html:222 src/olympia/devhub/templates/devhub/versions/add_file_modal.html:79
-#: src/olympia/devhub/templates/devhub/versions/edit.html:140 src/olympia/devhub/templates/devhub/versions/list.html:208 src/olympia/devhub/templates/devhub/versions/list.html:242
-#: src/olympia/devhub/templates/devhub/versions/list.html:276 src/olympia/devhub/templates/devhub/versions/list.html:317 src/olympia/reviews/templates/reviews/edit_review.html:16
+#: src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:43 src/olympia/devhub/templates/devhub/personas/edit.html:222 src/olympia/devhub/templates/devhub/versions/add_file_modal.html:59
+#: src/olympia/devhub/templates/devhub/versions/edit.html:140 src/olympia/devhub/templates/devhub/versions/list.html:208 src/olympia/devhub/templates/devhub/versions/list.html:239
+#: src/olympia/devhub/templates/devhub/versions/list.html:281 src/olympia/devhub/templates/devhub/versions/list.html:315 src/olympia/reviews/templates/reviews/edit_review.html:16
 #: src/olympia/translations/templates/translations/trans-menu.html:50 src/olympia/translations/templates/translations/trans-menu.html:62 src/olympia/zadmin/templates/zadmin/validation.html:105
 msgid "Cancel"
 msgstr ""
@@ -868,7 +869,7 @@ msgstr ""
 msgid "Review Guidelines"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/review_list_box.html:5 src/olympia/addons/templates/addons/impala/details-more.html:27 src/olympia/editors/helpers.py:921
+#: src/olympia/addons/templates/addons/review_list_box.html:5 src/olympia/addons/templates/addons/impala/details-more.html:27 src/olympia/editors/helpers.py:1001
 #: src/olympia/reviews/templates/reviews/add.html:14 src/olympia/reviews/templates/reviews/reply.html:14 src/olympia/reviews/templates/reviews/review_list.html:19
 #: src/olympia/reviews/templates/reviews/mobile/review_list.html:26
 msgid "Reviews"
@@ -959,119 +960,119 @@ msgid_plural "Other add-ons by these authors"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/olympia/addons/templates/addons/impala/details.html:41
+#: src/olympia/addons/templates/addons/impala/details.html:39
 #, python-format
 msgid "<span itemprop=\"ratingCount\">%(num)s</span> user review"
 msgid_plural "<span itemprop=\"ratingCount\">%(num)s</span> user reviews"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/olympia/addons/templates/addons/impala/details.html:69
+#: src/olympia/addons/templates/addons/impala/details.html:66
 msgid "View statistics"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/impala/details.html:84
+#: src/olympia/addons/templates/addons/impala/details.html:81
 msgid "Manage"
 msgstr ""
 
 #. {0} is an add-on name.
-#: src/olympia/addons/templates/addons/impala/details.html:96
+#: src/olympia/addons/templates/addons/impala/details.html:93
 msgid "Icon of {0}"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/impala/details.html:103 src/olympia/addons/templates/addons/impala/listing/items.html:14
+#: src/olympia/addons/templates/addons/impala/details.html:100 src/olympia/addons/templates/addons/impala/listing/items.html:14
 msgid "No Restart"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/impala/details.html:127
+#: src/olympia/addons/templates/addons/impala/details.html:124
 #, python-format
 msgid "Meet the Developer: <a href=\"%(url)s\">%(name)s</a>"
 msgid_plural "<a href=\"%(url)s\">Meet the Developers</a>"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/olympia/addons/templates/addons/impala/details.html:137
+#: src/olympia/addons/templates/addons/impala/details.html:134
 msgid "Learn why {0} was created and find out what's next for this add-on."
 msgstr ""
 
 #. {0} is an index.
-#: src/olympia/addons/templates/addons/impala/details.html:156
+#: src/olympia/addons/templates/addons/impala/details.html:161
 msgid "Add-on screenshot #{0}"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/impala/details.html:182
+#: src/olympia/addons/templates/addons/impala/details.html:187
 msgid "Add-on home page"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/impala/details.html:185
+#: src/olympia/addons/templates/addons/impala/details.html:190
 msgid "Support site"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/impala/details.html:189
+#: src/olympia/addons/templates/addons/impala/details.html:194
 msgid "Support E-mail"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/impala/details.html:194 src/olympia/devhub/models.py:378 src/olympia/devhub/templates/devhub/versions/list.html:12
+#: src/olympia/addons/templates/addons/impala/details.html:199 src/olympia/devhub/models.py:378 src/olympia/devhub/templates/devhub/versions/list.html:12
 #: src/olympia/versions/templates/versions/version.html:6 src/olympia/versions/templates/versions/mobile/version.html:6
 msgid "Version {0}"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/impala/details.html:194
+#: src/olympia/addons/templates/addons/impala/details.html:199
 msgid "Info"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/impala/details.html:195 src/olympia/devhub/templates/devhub/includes/addon_details.html:129
+#: src/olympia/addons/templates/addons/impala/details.html:200 src/olympia/devhub/templates/devhub/includes/addon_details.html:116
 msgid "Last Updated:"
-msgstr ""
-
-#: src/olympia/addons/templates/addons/impala/details.html:200
-#, python-format
-msgid "Released under <a target=\"_blank\" href=\"%(url)s\">%(name)s</a>"
-msgstr ""
-
-#: src/olympia/addons/templates/addons/impala/details.html:201 src/olympia/addons/templates/addons/impala/details.html:206 src/olympia/amo/helpers.py:398 src/olympia/devhub/forms.py:142
-#: src/olympia/devhub/forms.py:173 src/olympia/versions/templates/versions/version.html:40 src/olympia/versions/templates/versions/version.html:45
-msgid "Custom License"
 msgstr ""
 
 #: src/olympia/addons/templates/addons/impala/details.html:205
 #, python-format
+msgid "Released under <a target=\"_blank\" href=\"%(url)s\">%(name)s</a>"
+msgstr ""
+
+#: src/olympia/addons/templates/addons/impala/details.html:206 src/olympia/addons/templates/addons/impala/details.html:211 src/olympia/amo/helpers.py:398 src/olympia/devhub/forms.py:142
+#: src/olympia/devhub/forms.py:173 src/olympia/versions/templates/versions/version.html:40 src/olympia/versions/templates/versions/version.html:45
+msgid "Custom License"
+msgstr ""
+
+#: src/olympia/addons/templates/addons/impala/details.html:210
+#, python-format
 msgid "Released under <a href=\"%(url)s\">%(name)s</a>"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/impala/details.html:217
+#: src/olympia/addons/templates/addons/impala/details.html:222
 msgid "About this Add-on"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/impala/details.html:233
+#: src/olympia/addons/templates/addons/impala/details.html:238
 msgid "Developer’s Comments"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/impala/details.html:243
+#: src/olympia/addons/templates/addons/impala/details.html:248
 msgid "Version Information"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/impala/details.html:250
+#: src/olympia/addons/templates/addons/impala/details.html:255
 msgid "See complete version history"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/impala/details.html:262
+#: src/olympia/addons/templates/addons/impala/details.html:267
 msgid ""
 "The Development Channel lets you test an experimental new version of this add-on before it's released to the general public. Once you install the development version, you will continue to get "
 "updates from this channel. To stop receiving development updates, reinstall the default version from the link above."
 msgstr ""
 
-#: src/olympia/addons/templates/addons/impala/details.html:272
+#: src/olympia/addons/templates/addons/impala/details.html:277
 msgid "<strong>Caution:</strong> Development versions of this add-on have not been reviewed by Mozilla."
 msgstr ""
 
-#: src/olympia/addons/templates/addons/impala/details.html:287
+#: src/olympia/addons/templates/addons/impala/details.html:292
 msgid "See complete development channel history"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/impala/details.html:306 src/olympia/addons/templates/addons/impala/details.html:315 src/olympia/addons/templates/addons/impala/details.html:327
+#: src/olympia/addons/templates/addons/impala/details.html:311 src/olympia/addons/templates/addons/impala/details.html:320 src/olympia/addons/templates/addons/impala/details.html:332
 #: src/olympia/addons/templates/addons/impala/review_add_box.html:4 src/olympia/stats/templates/stats/popup.html:2 src/olympia/stats/templates/stats/popup.html:8
-#: src/olympia/stats/templates/stats/stats.html:202 src/olympia/users/templates/users/profile.html:119
+#: src/olympia/stats/templates/stats/stats.html:204 src/olympia/users/templates/users/profile.html:119
 msgid "close"
 msgstr ""
 
@@ -1127,15 +1128,11 @@ msgstr ""
 msgid "Source Code License"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/impala/persona_grid.html:16 src/olympia/addons/templates/addons/impala/toplist.html:6
-msgid "{0} users"
-msgstr ""
-
 #: src/olympia/addons/templates/addons/impala/review_list_box.html:19 src/olympia/reviews/templates/reviews/review.html:40
 msgid "permalink"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/impala/review_list_box.html:23 src/olympia/editors/templates/editors/queue.html:98 src/olympia/reviews/templates/reviews/review.html:44
+#: src/olympia/addons/templates/addons/impala/review_list_box.html:23 src/olympia/editors/templates/editors/queue.html:104 src/olympia/reviews/templates/reviews/review.html:44
 msgid "translate"
 msgstr ""
 
@@ -1154,6 +1151,10 @@ msgstr ""
 msgid "Be the first!"
 msgstr ""
 
+#: src/olympia/addons/templates/addons/impala/toplist.html:6
+msgid "{0} users"
+msgstr ""
+
 #: src/olympia/addons/templates/addons/impala/listing/sorter.html:14 src/olympia/devhub/templates/devhub/addons/listing/item_actions.html:49
 msgid "More"
 msgstr ""
@@ -1166,7 +1167,7 @@ msgstr ""
 msgid "My Add-ons"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/includes/dashboard_tabs.html:6 src/olympia/amo/context_processors.py:51
+#: src/olympia/addons/templates/addons/includes/dashboard_tabs.html:6 src/olympia/amo/context_processors.py:50
 msgid "My Themes"
 msgstr ""
 
@@ -1221,7 +1222,7 @@ msgstr ""
 msgid "Weekly Downloads"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/mobile/details.html:99 src/olympia/compat/templates/compat/reporter_detail.html:46 src/olympia/devhub/forms.py:787
+#: src/olympia/addons/templates/addons/mobile/details.html:99 src/olympia/compat/templates/compat/reporter_detail.html:46 src/olympia/devhub/forms.py:788
 #: src/olympia/devhub/templates/devhub/versions/list.html:163
 msgid "Version"
 msgstr ""
@@ -1305,7 +1306,7 @@ msgstr ""
 #: src/olympia/browse/templates/browse/personas/category_landing.html:21 src/olympia/browse/templates/browse/personas/category_landing.html:23
 #: src/olympia/browse/templates/browse/personas/category_landing.html:38 src/olympia/browse/templates/browse/personas/grid.html:7 src/olympia/browse/templates/browse/personas/grid.html:11
 #: src/olympia/browse/templates/browse/personas/mobile/base.html:7 src/olympia/browse/templates/browse/personas/mobile/category_landing.html:19 src/olympia/constants/base.py:180
-#: src/olympia/devhub/templates/devhub/personas/submit.html:13 src/olympia/editors/helpers.py:105 src/olympia/editors/templates/editors/base.html:26
+#: src/olympia/devhub/templates/devhub/personas/submit.html:13 src/olympia/editors/helpers.py:107 src/olympia/editors/templates/editors/base.html:26
 #: src/olympia/editors/templates/editors/performance.html:73 src/olympia/search/templates/search/personas.html:39 src/olympia/templates/menu_links.html:9
 msgid "Themes"
 msgstr ""
@@ -1326,7 +1327,7 @@ msgstr ""
 msgid "Highest Rated"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/mobile/home.html:74 src/olympia/amo/templates/amo/side_nav.html:5 src/olympia/amo/templates/amo/site_nav.html:27 src/olympia/amo/templates/amo/site_nav.html:57
+#: src/olympia/addons/templates/addons/mobile/home.html:74 src/olympia/amo/templates/amo/side_nav.html:5 src/olympia/amo/templates/amo/site_nav.html:27 src/olympia/amo/templates/amo/site_nav.html:55
 #: src/olympia/bandwagon/views.py:97 src/olympia/browse/views.py:57 src/olympia/browse/views.py:67 src/olympia/browse/templates/browse/personas/mobile/category_landing.html:65
 #: src/olympia/search/forms.py:15 src/olympia/search/forms.py:87
 msgid "Newest"
@@ -1340,90 +1341,90 @@ msgstr ""
 msgid "Theme Info &raquo;"
 msgstr ""
 
-#: src/olympia/amo/context_processors.py:39 src/olympia/devhub/templates/devhub/nav.html:43
+#: src/olympia/amo/context_processors.py:37 src/olympia/devhub/templates/devhub/nav.html:43
 msgid "Tools"
 msgstr ""
 
-#: src/olympia/amo/context_processors.py:48 src/olympia/discovery/templates/discovery/pane_account.html:8 src/olympia/users/templates/users/includes/navigation.html:2
+#: src/olympia/amo/context_processors.py:47 src/olympia/discovery/templates/discovery/pane_account.html:8 src/olympia/users/templates/users/includes/navigation.html:2
 msgid "My Profile"
 msgstr ""
 
-#: src/olympia/amo/context_processors.py:54 src/olympia/users/templates/users/edit.html:5 src/olympia/users/templates/users/includes/navigation.html:3
+#: src/olympia/amo/context_processors.py:53 src/olympia/users/templates/users/edit.html:5 src/olympia/users/templates/users/includes/navigation.html:3
 msgid "Account Settings"
 msgstr ""
 
-#: src/olympia/amo/context_processors.py:57 src/olympia/discovery/templates/discovery/pane_account.html:11 src/olympia/users/templates/users/profile.html:83
+#: src/olympia/amo/context_processors.py:56 src/olympia/discovery/templates/discovery/pane_account.html:11 src/olympia/users/templates/users/profile.html:83
 #: src/olympia/users/templates/users/includes/navigation.html:4
 msgid "My Collections"
 msgstr ""
 
-#: src/olympia/amo/context_processors.py:62 src/olympia/discovery/templates/discovery/pane_account.html:10 src/olympia/users/templates/users/includes/navigation.html:7
+#: src/olympia/amo/context_processors.py:61 src/olympia/discovery/templates/discovery/pane_account.html:10 src/olympia/users/templates/users/includes/navigation.html:7
 msgid "My Favorites"
 msgstr ""
 
-#: src/olympia/amo/context_processors.py:67 src/olympia/discovery/templates/discovery/pane_account.html:13 src/olympia/templates/impala/user_login.html:14
+#: src/olympia/amo/context_processors.py:66 src/olympia/discovery/templates/discovery/pane_account.html:13 src/olympia/templates/impala/user_login.html:14
 #: src/olympia/templates/mobile/header_auth.html:5
 msgid "Log out"
 msgstr ""
 
-#: src/olympia/amo/context_processors.py:72 src/olympia/devhub/templates/devhub/addons/dashboard.html:4
+#: src/olympia/amo/context_processors.py:71 src/olympia/devhub/templates/devhub/addons/dashboard.html:4
 msgid "Manage My Submissions"
 msgstr ""
 
-#: src/olympia/amo/context_processors.py:75 src/olympia/devhub/templates/devhub/nav.html:27 src/olympia/devhub/templates/devhub/addons/dashboard.html:25
+#: src/olympia/amo/context_processors.py:74 src/olympia/devhub/templates/devhub/nav.html:27 src/olympia/devhub/templates/devhub/addons/dashboard.html:25
 #: src/olympia/devhub/templates/devhub/addons/submit/base.html:4
 msgid "Submit a New Add-on"
 msgstr ""
 
-#: src/olympia/amo/context_processors.py:77 src/olympia/browse/templates/browse/personas/base.html:50 src/olympia/devhub/templates/devhub/index.html:24
+#: src/olympia/amo/context_processors.py:76 src/olympia/browse/templates/browse/personas/base.html:50 src/olympia/devhub/templates/devhub/index.html:24
 #: src/olympia/devhub/templates/devhub/addons/dashboard.html:29
 msgid "Submit a New Theme"
 msgstr ""
 
-#: src/olympia/amo/context_processors.py:79 src/olympia/amo/templates/amo/site_nav.html:87 src/olympia/devhub/helpers.py:36 src/olympia/devhub/helpers.py:68 src/olympia/devhub/helpers.py:102
+#: src/olympia/amo/context_processors.py:78 src/olympia/amo/templates/amo/site_nav.html:85 src/olympia/devhub/helpers.py:36 src/olympia/devhub/helpers.py:68 src/olympia/devhub/helpers.py:102
 #: src/olympia/templates/footer.html:6 src/olympia/templates/menu_links.html:14
 msgid "Developer Hub"
 msgstr ""
 
-#: src/olympia/amo/context_processors.py:83 src/olympia/devhub/views.py:1792
+#: src/olympia/amo/context_processors.py:81 src/olympia/devhub/views.py:1796
 msgid "Manage API Keys"
 msgstr ""
 
-#: src/olympia/amo/context_processors.py:88 src/olympia/editors/helpers.py:82 src/olympia/editors/helpers.py:102 src/olympia/editors/templates/editors/base.html:10
+#: src/olympia/amo/context_processors.py:86 src/olympia/editors/helpers.py:84 src/olympia/editors/helpers.py:104 src/olympia/editors/templates/editors/base.html:10
 msgid "Editor Tools"
 msgstr ""
 
-#: src/olympia/amo/context_processors.py:92
+#: src/olympia/amo/context_processors.py:90
 msgid "Admin Tools"
 msgstr ""
 
-#: src/olympia/amo/fields.py:15
+#: src/olympia/amo/fields.py:20
 msgid "Incorrect, please try again."
 msgstr ""
 
-#: src/olympia/amo/fields.py:16
+#: src/olympia/amo/fields.py:21
 msgid "Error verifying input, please try again."
 msgstr ""
 
-#: src/olympia/amo/fields.py:32
+#: src/olympia/amo/fields.py:37
 msgid "This must be a valid hex color code, such as #000000."
 msgstr ""
 
-#: src/olympia/amo/fields.py:58
+#: src/olympia/amo/fields.py:63
 msgid "Enter at least one value."
 msgstr ""
 
-#: src/olympia/amo/helpers.py:162 src/olympia/amo/templates/amo/site_nav.html:61 src/olympia/bandwagon/templates/bandwagon/add.html:9
+#: src/olympia/amo/helpers.py:162 src/olympia/amo/templates/amo/site_nav.html:59 src/olympia/bandwagon/templates/bandwagon/add.html:9
 #: src/olympia/bandwagon/templates/bandwagon/collection_detail.html:15 src/olympia/bandwagon/templates/bandwagon/delete.html:9 src/olympia/bandwagon/templates/bandwagon/edit.html:15
 #: src/olympia/bandwagon/templates/bandwagon/user_listing.html:18 src/olympia/bandwagon/templates/bandwagon/user_listing.html:21
 #: src/olympia/bandwagon/templates/bandwagon/impala/collection_listing.html:12 src/olympia/bandwagon/templates/bandwagon/impala/collection_listing.html:20
 #: src/olympia/bandwagon/templates/bandwagon/impala/collection_listing.html:24 src/olympia/bandwagon/templates/bandwagon/impala/collection_sidebar.html:3
 #: src/olympia/bandwagon/templates/bandwagon/includes/collection_sidebar.html:2 src/olympia/bandwagon/templates/bandwagon/mobile/collection_listing.html:3
-#: src/olympia/stats/templates/stats/stats.html:77 src/olympia/templates/menu_links.html:12
+#: src/olympia/stats/templates/stats/stats.html:33 src/olympia/templates/menu_links.html:12
 msgid "Collections"
 msgstr ""
 
-#: src/olympia/amo/helpers.py:171 src/olympia/amo/templates/amo/site_nav.html:85 src/olympia/browse/templates/browse/language_tools.html:3
+#: src/olympia/amo/helpers.py:171 src/olympia/amo/templates/amo/site_nav.html:83 src/olympia/browse/templates/browse/language_tools.html:3
 msgid "Dictionaries & Language Packs"
 msgstr ""
 
@@ -1575,8 +1576,8 @@ msgstr ""
 msgid "Comment on {addon} {version}."
 msgstr ""
 
-#: src/olympia/amo/log.py:236 src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:19 src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:47
-#: src/olympia/editors/helpers.py:511 src/olympia/editors/templates/editors/themes/history_table.html:11
+#: src/olympia/amo/log.py:236 src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:17 src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:45
+#: src/olympia/editors/helpers.py:584 src/olympia/editors/templates/editors/themes/history_table.html:11
 msgid "Comment"
 msgstr ""
 
@@ -1899,7 +1900,7 @@ msgstr ""
 #: src/olympia/amo/templates/amo/mobile/paginator.html:14 src/olympia/amo/templates/amo/mobile/paginator.html:16 src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:51
 #: src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:65 src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:78
 #: src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:91 src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:104
-#: src/olympia/discovery/templates/discovery/pane.html:45 src/olympia/discovery/templates/discovery/addons/detail.html:39 src/olympia/stats/templates/stats/stats.html:167
+#: src/olympia/discovery/templates/discovery/pane.html:45 src/olympia/discovery/templates/discovery/addons/detail.html:39 src/olympia/stats/templates/stats/stats.html:169
 msgid "Next"
 msgstr ""
 
@@ -1931,7 +1932,7 @@ msgid ""
 msgstr ""
 
 #: src/olympia/amo/templates/amo/side_nav.html:4 src/olympia/amo/templates/amo/side_nav.html:12 src/olympia/amo/templates/amo/site_nav.html:4 src/olympia/amo/templates/amo/site_nav.html:26
-#: src/olympia/browse/views.py:56 src/olympia/browse/views.py:66 src/olympia/browse/views.py:237 src/olympia/browse/views.py:282 src/olympia/search/forms.py:86
+#: src/olympia/browse/views.py:56 src/olympia/browse/views.py:66 src/olympia/browse/views.py:204 src/olympia/browse/views.py:249 src/olympia/search/forms.py:86
 msgid "Top Rated"
 msgstr ""
 
@@ -1945,38 +1946,38 @@ msgstr ""
 msgid "Extensions"
 msgstr ""
 
-#: src/olympia/amo/templates/amo/site_nav.html:45
+#: src/olympia/amo/templates/amo/site_nav.html:44
 msgid "Want more customization? Try <b>Complete Themes</b>"
 msgstr ""
 
-#: src/olympia/amo/templates/amo/site_nav.html:56 src/olympia/bandwagon/views.py:96
+#: src/olympia/amo/templates/amo/site_nav.html:54 src/olympia/bandwagon/views.py:96
 msgid "Most Followers"
 msgstr ""
 
-#: src/olympia/amo/templates/amo/site_nav.html:68 src/olympia/bandwagon/templates/bandwagon/impala/collection_sidebar.html:16
+#: src/olympia/amo/templates/amo/site_nav.html:66 src/olympia/bandwagon/templates/bandwagon/impala/collection_sidebar.html:16
 #: src/olympia/bandwagon/templates/bandwagon/includes/collection_sidebar.html:18
 msgid "Collections I've Made"
 msgstr ""
 
-#: src/olympia/amo/templates/amo/site_nav.html:70 src/olympia/bandwagon/templates/bandwagon/user_listing.html:4 src/olympia/bandwagon/templates/bandwagon/impala/collection_sidebar.html:13
+#: src/olympia/amo/templates/amo/site_nav.html:68 src/olympia/bandwagon/templates/bandwagon/user_listing.html:4 src/olympia/bandwagon/templates/bandwagon/impala/collection_sidebar.html:13
 #: src/olympia/bandwagon/templates/bandwagon/includes/collection_sidebar.html:15
 msgid "Collections I'm Following"
 msgstr ""
 
-#: src/olympia/amo/templates/amo/site_nav.html:73 src/olympia/bandwagon/templates/bandwagon/impala/collection_sidebar.html:18
-#: src/olympia/bandwagon/templates/bandwagon/includes/collection_sidebar.html:20 src/olympia/users/models.py:512
+#: src/olympia/amo/templates/amo/site_nav.html:71 src/olympia/bandwagon/templates/bandwagon/impala/collection_sidebar.html:18
+#: src/olympia/bandwagon/templates/bandwagon/includes/collection_sidebar.html:20 src/olympia/users/models.py:521
 msgid "My Favorite Add-ons"
 msgstr ""
 
-#: src/olympia/amo/templates/amo/site_nav.html:78
+#: src/olympia/amo/templates/amo/site_nav.html:76
 msgid "More&hellip;"
 msgstr ""
 
-#: src/olympia/amo/templates/amo/site_nav.html:82
+#: src/olympia/amo/templates/amo/site_nav.html:80
 msgid "Add-ons for Mobile"
 msgstr ""
 
-#: src/olympia/amo/templates/amo/site_nav.html:86 src/olympia/browse/feeds.py:207 src/olympia/browse/templates/browse/search_tools.html:3 src/olympia/constants/base.py:176
+#: src/olympia/amo/templates/amo/site_nav.html:84 src/olympia/browse/feeds.py:207 src/olympia/browse/templates/browse/search_tools.html:3 src/olympia/constants/base.py:176
 #: src/olympia/templates/menu_links.html:10
 msgid "Search Tools"
 msgstr ""
@@ -1992,7 +1993,7 @@ msgid "Jump to first page"
 msgstr ""
 
 #: src/olympia/amo/templates/amo/impala/paginator.html:22 src/olympia/amo/templates/amo/mobile/impala_paginator.html:12 src/olympia/discovery/templates/discovery/pane.html:44
-#: src/olympia/discovery/templates/discovery/addons/detail.html:38 src/olympia/stats/templates/stats/stats.html:164
+#: src/olympia/discovery/templates/discovery/addons/detail.html:38 src/olympia/stats/templates/stats/stats.html:166
 msgid "Previous"
 msgstr ""
 
@@ -2015,30 +2016,49 @@ msgid_plural "Page {n}"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/olympia/amo/templates/services/install.html:38
-#, python-format
-msgid "If you are not prompted to install %(addon_name)s in a moment, please <a href=\"%(addon_xpi)s\">click here</a>."
-msgstr ""
-
-#: src/olympia/amo/tests/test_messages.py:57 src/olympia/amo/tests/test_messages.py:58 src/olympia/reviews/forms.py:25 src/olympia/reviews/forms.py:50 src/olympia/reviews/templates/reviews/add.html:56
+#: src/olympia/amo/tests/test_messages.py:56 src/olympia/amo/tests/test_messages.py:57 src/olympia/reviews/forms.py:25 src/olympia/reviews/forms.py:50 src/olympia/reviews/templates/reviews/add.html:56
 #: src/olympia/reviews/templates/reviews/reply.html:30
 msgid "Title"
 msgstr ""
 
-#: src/olympia/amo/tests/test_messages.py:57 src/olympia/amo/tests/test_messages.py:58
+#: src/olympia/amo/tests/test_messages.py:56 src/olympia/amo/tests/test_messages.py:57
 msgid "Body"
 msgstr ""
 
-#: src/olympia/amo/tests/test_messages.py:59
+#: src/olympia/amo/tests/test_messages.py:58
 msgid "Another Title"
 msgstr ""
 
-#: src/olympia/amo/tests/test_messages.py:59
+#: src/olympia/amo/tests/test_messages.py:58
 msgid "Another Body"
 msgstr ""
 
-#: src/olympia/api/views.py:255
-msgid "Not implemented yet."
+#: src/olympia/api/authentication.py:76
+msgid "Signature has expired."
+msgstr ""
+
+#: src/olympia/api/authentication.py:79
+msgid "Error decoding signature."
+msgstr ""
+
+#: src/olympia/api/authentication.py:82
+msgid "Invalid JWT Token."
+msgstr ""
+
+#: src/olympia/api/authentication.py:130
+msgid "Invalid Authorization header. No credentials provided."
+msgstr ""
+
+#: src/olympia/api/authentication.py:133
+msgid "Invalid Authorization header. Credentials string should not contain spaces."
+msgstr ""
+
+#: src/olympia/api/fields.py:29
+msgid "The field must have a length of at least {num} characters."
+msgstr ""
+
+#: src/olympia/api/fields.py:31
+msgid "The language code {lang_code} is invalid."
 msgstr ""
 
 #: src/olympia/applications/views.py:39 src/olympia/applications/templates/applications/appversions.html:3
@@ -2057,7 +2077,7 @@ msgstr ""
 msgid "Add-ons submitted to Mozilla Add-ons must have a manifest file with at least one of the below applications supported. Only the versions listed below are allowed for these applications."
 msgstr ""
 
-#: src/olympia/applications/templates/applications/appversions.html:25
+#: src/olympia/applications/templates/applications/appversions.html:25 src/olympia/editors/helpers.py:361
 msgid "GUID"
 msgstr ""
 
@@ -2171,8 +2191,8 @@ msgstr ""
 msgid "Remove from favorites"
 msgstr ""
 
-#: src/olympia/bandwagon/views.py:98 src/olympia/bandwagon/views.py:191 src/olympia/browse/views.py:58 src/olympia/browse/views.py:69 src/olympia/browse/views.py:458 src/olympia/devhub/views.py:74
-#: src/olympia/devhub/views.py:82 src/olympia/devhub/templates/devhub/addons/edit/basic.html:20 src/olympia/editors/templates/editors/leaderboard.html:24
+#: src/olympia/bandwagon/views.py:98 src/olympia/bandwagon/views.py:191 src/olympia/browse/views.py:58 src/olympia/browse/views.py:69 src/olympia/browse/views.py:425 src/olympia/devhub/views.py:72
+#: src/olympia/devhub/views.py:80 src/olympia/devhub/templates/devhub/addons/edit/basic.html:20 src/olympia/editors/templates/editors/leaderboard.html:24
 #: src/olympia/editors/templates/editors/themes/queue_list.html:48 src/olympia/search/forms.py:17 src/olympia/search/forms.py:89 src/olympia/users/templates/users/vcard.html:5
 msgid "Name"
 msgstr ""
@@ -2181,7 +2201,7 @@ msgstr ""
 msgid "Recently Popular"
 msgstr ""
 
-#: src/olympia/bandwagon/views.py:189 src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:18
+#: src/olympia/bandwagon/views.py:189 src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:16
 msgid "Added"
 msgstr ""
 
@@ -2195,7 +2215,7 @@ msgstr ""
 
 #: src/olympia/bandwagon/views.py:316
 #, python-format
-msgid "Your new collection is shown below. You can <ahref=\"%(url)s\">edit additional settings</a> if you'dlike."
+msgid "Your new collection is shown below. You can <a href=\"%(url)s\">edit additional settings</a> if you'd like."
 msgstr ""
 
 #: src/olympia/bandwagon/views.py:322
@@ -2323,8 +2343,8 @@ msgid_plural "%(num)s Add-ons in this Collection"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/olympia/bandwagon/templates/bandwagon/collection_detail.html:125 src/olympia/compat/templates/compat/index.html:25 src/olympia/compat/templates/compat/reporter_detail.html:29
-#: src/olympia/files/templates/files/viewer.html:29 src/olympia/templates/amo_footer.html:17 src/olympia/templates/includes/lang_switcher.html:10
+#: src/olympia/bandwagon/templates/bandwagon/collection_detail.html:125 src/olympia/compat/templates/compat/reporter_detail.html:29 src/olympia/files/templates/files/viewer.html:29
+#: src/olympia/templates/amo_footer.html:17 src/olympia/templates/includes/lang_switcher.html:10
 msgid "Go"
 msgstr ""
 
@@ -2491,7 +2511,7 @@ msgid "Remove this user as a contributor"
 msgstr ""
 
 #: src/olympia/bandwagon/templates/bandwagon/edit_contributors.html:18 src/olympia/bandwagon/templates/bandwagon/edit_contributors.html:43
-#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:20 src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:48
+#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:18 src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:46
 #: src/olympia/devhub/templates/devhub/addons/ajax_compat_update.html:19
 msgid "Remove"
 msgstr ""
@@ -2539,7 +2559,7 @@ msgid "<b>Warning:</b> By changing the owner of this collection, you will no lon
 msgstr ""
 
 #: src/olympia/bandwagon/templates/bandwagon/edit_contributors.html:83 src/olympia/devhub/templates/devhub/addons/forms_shared/media.html:157
-#: src/olympia/devhub/templates/devhub/addons/submit/describe.html:69 src/olympia/devhub/templates/devhub/addons/submit/license.html:60 src/olympia/devhub/templates/devhub/addons/submit/upload.html:78
+#: src/olympia/devhub/templates/devhub/addons/submit/describe.html:69 src/olympia/devhub/templates/devhub/addons/submit/license.html:60 src/olympia/devhub/templates/devhub/addons/submit/upload.html:70
 #: src/olympia/devhub/templates/devhub/payments/tier.html:17 src/olympia/editors/templates/editors/themes/themes.html:111 src/olympia/editors/templates/editors/themes/themes.html:128
 #: src/olympia/editors/templates/editors/themes/themes.html:134 src/olympia/editors/templates/editors/themes/themes.html:141 src/olympia/users/templates/users/fxa_migration_prompt_content.html:10
 #: src/olympia/users/templates/users/login_form.html:42 src/olympia/users/templates/users/mobile/login.html:57
@@ -2622,31 +2642,31 @@ msgid "Add-ons in Your Collection"
 msgstr ""
 
 #: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:4
-msgid ""
-"To include an add-on in this collection, enter its name in the box below and hit enter.  You can also use the <strong>Add to Collection</strong> links throughout the site to include add-ons later."
+msgid "To include an add-on in this collection, enter its name in the box below and hit enter."
 msgstr ""
 
-#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:17 src/olympia/constants/base.py:400 src/olympia/devhub/templates/devhub/addons/activity.html:62
+#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:15 src/olympia/constants/base.py:400 src/olympia/devhub/templates/devhub/addons/activity.html:62
+#: src/olympia/editors/helpers.py:273 src/olympia/editors/helpers.py:360
 msgid "Add-on"
 msgstr ""
 
-#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:26
+#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:24
 msgid "Enter the name of the add-on to include"
 msgstr ""
 
-#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:28
+#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:26
 msgid "Add to Collection"
 msgstr ""
 
-#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:45 src/olympia/editors/helpers.py:936 src/olympia/editors/helpers.py:956
+#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:43 src/olympia/editors/helpers.py:1016 src/olympia/editors/helpers.py:1036
 msgid "Pending"
 msgstr ""
 
-#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:47
+#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:45
 msgid "Add a comment"
 msgstr ""
 
-#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:48
+#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:46
 msgid "Remove this add-on from the collection"
 msgstr ""
 
@@ -2753,12 +2773,12 @@ msgstr ""
 msgid "Most Users"
 msgstr ""
 
-#: src/olympia/browse/views.py:61 src/olympia/browse/views.py:72 src/olympia/browse/views.py:279 src/olympia/browse/templates/browse/personas/mobile/category_landing.html:63
+#: src/olympia/browse/views.py:61 src/olympia/browse/views.py:72 src/olympia/browse/views.py:246 src/olympia/browse/templates/browse/personas/mobile/category_landing.html:63
 #: src/olympia/discovery/templates/discovery/pane.html:67 src/olympia/search/forms.py:92
 msgid "Up & Coming"
 msgstr ""
 
-#: src/olympia/browse/views.py:460 src/olympia/devhub/views.py:76 src/olympia/devhub/views.py:83 src/olympia/discovery/templates/discovery/addons/detail.html:66
+#: src/olympia/browse/views.py:427 src/olympia/devhub/views.py:74 src/olympia/devhub/views.py:81 src/olympia/discovery/templates/discovery/addons/detail.html:66
 msgid "Created"
 msgstr ""
 
@@ -2946,8 +2966,8 @@ msgid_plural "See all %(cnt)s extensions in %(name)s &raquo;"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/olympia/browse/templates/browse/mobile/extensions.html:13 src/olympia/compat/templates/compat/index.html:82 src/olympia/devhub/templates/devhub/devhub_search.html:24
-#: src/olympia/devhub/templates/devhub/addons/activity.html:47 src/olympia/search/templates/search/no_results.html:4 src/olympia/search/templates/search/mobile/results.html:36
+#: src/olympia/browse/templates/browse/mobile/extensions.html:13 src/olympia/devhub/templates/devhub/devhub_search.html:24 src/olympia/devhub/templates/devhub/addons/activity.html:47
+#: src/olympia/search/templates/search/no_results.html:4 src/olympia/search/templates/search/mobile/results.html:36
 msgid "No results found."
 msgstr ""
 
@@ -3032,7 +3052,7 @@ msgstr ""
 msgid "All"
 msgstr ""
 
-#: src/olympia/compat/forms.py:22 src/olympia/search/views.py:525
+#: src/olympia/compat/forms.py:22 src/olympia/editors/templates/editors/base.html:69 src/olympia/search/views.py:518
 msgid "All Add-ons"
 msgstr ""
 
@@ -3042,53 +3062,6 @@ msgstr ""
 
 #: src/olympia/compat/forms.py:24
 msgid "Non-binary"
-msgstr ""
-
-#. Review points sources other than add-ons and themes.
-#: src/olympia/compat/views.py:87 src/olympia/constants/base.py:388 src/olympia/devhub/forms.py:162 src/olympia/editors/templates/editors/performance.html:75
-msgid "Other"
-msgstr ""
-
-#: src/olympia/compat/templates/compat/index.html:4
-msgid "Add-on Compatibility Report for {app} {version}"
-msgstr ""
-
-#: src/olympia/compat/templates/compat/index.html:11
-msgid "{app} {version} Compatibility"
-msgstr ""
-
-#: src/olympia/compat/templates/compat/index.html:17
-#, python-format
-msgid "Top 95%% compatible with previous version"
-msgstr ""
-
-#: src/olympia/compat/templates/compat/index.html:18
-#, python-format
-msgid "Top 95%% of all add-ons"
-msgstr ""
-
-#: src/olympia/compat/templates/compat/index.html:19
-msgid "All active add-ons"
-msgstr ""
-
-#: src/olympia/compat/templates/compat/index.html:23 src/olympia/constants/base.py:401
-msgid "App"
-msgstr ""
-
-#: src/olympia/compat/templates/compat/index.html:55
-msgid "Details for add-ons compatible with previous version:"
-msgstr ""
-
-#: src/olympia/compat/templates/compat/index.html:57
-msgid "Show all versions"
-msgstr ""
-
-#: src/olympia/compat/templates/compat/index.html:59
-msgid "Details for add-ons compatible with all versions:"
-msgstr ""
-
-#: src/olympia/compat/templates/compat/index.html:61
-msgid "Show previous version only"
 msgstr ""
 
 #: src/olympia/compat/templates/compat/reporter.html:3
@@ -3142,8 +3115,8 @@ msgstr ""
 msgid "Report Type"
 msgstr ""
 
-#: src/olympia/compat/templates/compat/reporter_detail.html:47 src/olympia/devhub/forms.py:784 src/olympia/devhub/templates/devhub/addons/ajax_compat_update.html:17 src/olympia/editors/forms.py:108
-#: src/olympia/zadmin/forms.py:45
+#: src/olympia/compat/templates/compat/reporter_detail.html:47 src/olympia/devhub/forms.py:785 src/olympia/devhub/templates/devhub/addons/ajax_compat_update.html:17 src/olympia/editors/forms.py:108
+#: src/olympia/editors/forms.py:248 src/olympia/zadmin/forms.py:45
 msgid "Application"
 msgstr ""
 
@@ -3231,7 +3204,8 @@ msgstr ""
 msgid "Preliminarily Reviewed and Awaiting Full Review"
 msgstr ""
 
-#: src/olympia/constants/base.py:33 src/olympia/editors/helpers.py:924 src/olympia/editors/templates/editors/themes/history_table.html:34
+#: src/olympia/constants/base.py:33 src/olympia/editors/forms.py:258 src/olympia/editors/helpers.py:73 src/olympia/editors/helpers.py:1004
+#: src/olympia/editors/templates/editors/themes/history_table.html:34
 msgid "Deleted"
 msgstr ""
 
@@ -3328,6 +3302,11 @@ msgstr ""
 msgid "Ask before users can download this add-on"
 msgstr ""
 
+#. Review points sources other than add-ons and themes.
+#: src/olympia/constants/base.py:388 src/olympia/devhub/forms.py:162 src/olympia/editors/templates/editors/performance.html:75
+msgid "Other"
+msgstr ""
+
 #: src/olympia/constants/base.py:389
 msgid "Exception"
 msgstr ""
@@ -3338,6 +3317,10 @@ msgstr ""
 
 #: src/olympia/constants/base.py:391
 msgid "Change"
+msgstr ""
+
+#: src/olympia/constants/base.py:401
+msgid "App"
 msgstr ""
 
 #: src/olympia/constants/base.py:402
@@ -3488,7 +3471,7 @@ msgstr ""
 msgid "Duplicate"
 msgstr ""
 
-#: src/olympia/constants/editors.py:17 src/olympia/editors/helpers.py:502 src/olympia/editors/templates/editors/themes/queue.html:71 src/olympia/editors/templates/editors/themes/themes.html:94
+#: src/olympia/constants/editors.py:17 src/olympia/editors/helpers.py:575 src/olympia/editors/templates/editors/themes/queue.html:71 src/olympia/editors/templates/editors/themes/themes.html:94
 msgid "Reject"
 msgstr ""
 
@@ -3588,7 +3571,7 @@ msgstr ""
 msgid "Android"
 msgstr ""
 
-#: src/olympia/core/apps.py:19
+#: src/olympia/core/apps.py:21
 msgid "Core"
 msgstr ""
 
@@ -3722,7 +3705,7 @@ msgid "Submit my add-on for manual review."
 msgstr ""
 
 #: src/olympia/devhub/forms.py:537
-msgid "Do not list my add-on on this site (beta)"
+msgid "Do not list my add-on on this site"
 msgstr ""
 
 #: src/olympia/devhub/forms.py:538
@@ -3755,46 +3738,46 @@ msgstr ""
 
 #: src/olympia/devhub/forms.py:592
 #, python-format
-msgid "Version %s already exists"
+msgid "Version %s already exists, or was uploaded before."
 msgstr ""
 
-#: src/olympia/devhub/forms.py:604
+#: src/olympia/devhub/forms.py:605
 msgid "Select a valid choice. That choice is not one of the available choices."
 msgstr ""
 
-#: src/olympia/devhub/forms.py:610
+#: src/olympia/devhub/forms.py:611
 msgid "A file with a version ending with a|alpha|b|beta and an optional number is detected as beta."
 msgstr ""
 
-#: src/olympia/devhub/forms.py:633
+#: src/olympia/devhub/forms.py:634
 msgid "You cannot upload any more files for this version."
 msgstr ""
 
-#: src/olympia/devhub/forms.py:639
+#: src/olympia/devhub/forms.py:640
 msgid "Version doesn't match"
 msgstr ""
 
-#: src/olympia/devhub/forms.py:668
+#: src/olympia/devhub/forms.py:669
 msgid "You cannot delete a file once the review process has started.  You must delete the whole version."
 msgstr ""
 
-#: src/olympia/devhub/forms.py:688
+#: src/olympia/devhub/forms.py:689
 msgid "The platform All cannot be combined with specific platforms."
 msgstr ""
 
-#: src/olympia/devhub/forms.py:693
+#: src/olympia/devhub/forms.py:694
 msgid "A platform can only be chosen once."
 msgstr ""
 
-#: src/olympia/devhub/forms.py:706
+#: src/olympia/devhub/forms.py:707
 msgid "A review type must be selected."
 msgstr ""
 
-#: src/olympia/devhub/forms.py:788 src/olympia/editors/forms.py:114 src/olympia/zadmin/forms.py:49 src/olympia/zadmin/forms.py:52
+#: src/olympia/devhub/forms.py:789 src/olympia/editors/forms.py:114 src/olympia/editors/forms.py:254 src/olympia/zadmin/forms.py:49 src/olympia/zadmin/forms.py:52
 msgid "Select an application first"
 msgstr ""
 
-#: src/olympia/devhub/forms.py:840
+#: src/olympia/devhub/forms.py:841
 msgid "There cannot be more than 3 required add-ons."
 msgstr ""
 
@@ -3828,76 +3811,76 @@ msgstr[1] ""
 msgid "Review"
 msgstr ""
 
-#: src/olympia/devhub/tasks.py:551
+#: src/olympia/devhub/tasks.py:583
 #, python-format
 msgid "%s responded with %s (%s)."
 msgstr ""
 
-#: src/olympia/devhub/tasks.py:555
+#: src/olympia/devhub/tasks.py:587
 #, python-format
 msgid "Connection to \"%s\" timed out."
 msgstr ""
 
-#: src/olympia/devhub/tasks.py:557
+#: src/olympia/devhub/tasks.py:589
 #, python-format
 msgid "Could not contact host at \"%s\"."
 msgstr ""
 
-#: src/olympia/devhub/utils.py:104
+#: src/olympia/devhub/utils.py:105
 #, python-format
 msgid "Validation generated too many errors/warnings so %s messages were truncated. After addressing the visible messages, you'll be able to see the others."
 msgstr ""
 
-#: src/olympia/devhub/views.py:183
+#: src/olympia/devhub/views.py:181
 msgid "All My Add-ons"
 msgstr ""
 
-#: src/olympia/devhub/views.py:210
+#: src/olympia/devhub/views.py:208
 msgid "All Activity"
 msgstr ""
 
-#: src/olympia/devhub/views.py:211
+#: src/olympia/devhub/views.py:209
 msgid "Add-on Updates"
 msgstr ""
 
-#: src/olympia/devhub/views.py:212
+#: src/olympia/devhub/views.py:210
 msgid "Add-on Status"
 msgstr ""
 
-#: src/olympia/devhub/views.py:213
+#: src/olympia/devhub/views.py:211
 msgid "User Collections"
 msgstr ""
 
-#: src/olympia/devhub/views.py:214 src/olympia/devhub/templates/devhub/docs/policies-maintenance.html:68 src/olympia/pages/templates/pages/dev_faq.html:38
+#: src/olympia/devhub/views.py:212 src/olympia/devhub/templates/devhub/docs/policies-maintenance.html:68 src/olympia/pages/templates/pages/dev_faq.html:38
 #: src/olympia/pages/templates/pages/dev_faq.html:484
 msgid "User Reviews"
 msgstr ""
 
-#: src/olympia/devhub/views.py:327 src/olympia/devhub/views.py:331 src/olympia/devhub/views.py:484 src/olympia/devhub/views.py:513 src/olympia/devhub/views.py:564 src/olympia/devhub/views.py:1150
+#: src/olympia/devhub/views.py:325 src/olympia/devhub/views.py:329 src/olympia/devhub/views.py:484 src/olympia/devhub/views.py:513 src/olympia/devhub/views.py:564 src/olympia/devhub/views.py:1156
 msgid "Changes successfully saved."
 msgstr ""
 
-#: src/olympia/devhub/views.py:334 src/olympia/devhub/views.py:1631
+#: src/olympia/devhub/views.py:332 src/olympia/devhub/views.py:1637
 msgid "Please check the form for errors."
 msgstr ""
 
-#: src/olympia/devhub/views.py:346
+#: src/olympia/devhub/views.py:344
 msgid "Add-on cannot be deleted. Disable this add-on instead."
 msgstr ""
 
-#: src/olympia/devhub/views.py:356
+#: src/olympia/devhub/views.py:354
 msgid "Theme deleted."
 msgstr ""
 
-#: src/olympia/devhub/views.py:356
+#: src/olympia/devhub/views.py:354
 msgid "Add-on deleted."
 msgstr ""
 
-#: src/olympia/devhub/views.py:362
+#: src/olympia/devhub/views.py:360
 msgid "URL name was incorrect. Theme was not deleted."
 msgstr ""
 
-#: src/olympia/devhub/views.py:367
+#: src/olympia/devhub/views.py:365
 msgid "URL name was incorrect. Add-on was not deleted."
 msgstr ""
 
@@ -3925,7 +3908,7 @@ msgstr ""
 msgid "Check Add-on Compatibility"
 msgstr ""
 
-#: src/olympia/devhub/views.py:808 src/olympia/signing/views.py:90
+#: src/olympia/devhub/views.py:808 src/olympia/signing/views.py:95
 msgid "You cannot submit this type of add-on"
 msgstr ""
 
@@ -3955,33 +3938,33 @@ msgstr ""
 msgid "There was an error uploading your preview."
 msgstr ""
 
-#: src/olympia/devhub/views.py:1189
+#: src/olympia/devhub/views.py:1195
 #, python-format
 msgid "Version %s disabled."
 msgstr ""
 
-#: src/olympia/devhub/views.py:1193
+#: src/olympia/devhub/views.py:1199
 #, python-format
 msgid "Version %s deleted."
 msgstr ""
 
-#: src/olympia/devhub/views.py:1203
+#: src/olympia/devhub/views.py:1209
 msgid "This upload has failed validation, and may lack complete validation results. Please take due care when reviewing it."
 msgstr ""
 
-#: src/olympia/devhub/views.py:1677
+#: src/olympia/devhub/views.py:1683
 msgid "Preliminary Review Requested."
 msgstr ""
 
-#: src/olympia/devhub/views.py:1678
+#: src/olympia/devhub/views.py:1684
 msgid "Full Review Requested."
 msgstr ""
 
-#: src/olympia/devhub/views.py:1779
+#: src/olympia/devhub/views.py:1783
 msgid "Your old credentials were revoked and are no longer valid. Be sure to update all API clients with the new credentials."
 msgstr ""
 
-#: src/olympia/devhub/views.py:1797
+#: src/olympia/devhub/views.py:1801
 msgid "New API key created"
 msgstr ""
 
@@ -4011,7 +3994,7 @@ msgstr ""
 msgid "{0} :: Search"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/devhub_search.html:6 src/olympia/devhub/templates/devhub/search.html:8 src/olympia/editors/forms.py:435 src/olympia/editors/forms.py:437
+#: src/olympia/devhub/templates/devhub/devhub_search.html:6 src/olympia/devhub/templates/devhub/search.html:8 src/olympia/editors/forms.py:534 src/olympia/editors/forms.py:536
 #: src/olympia/editors/templates/editors/queue.html:27 src/olympia/editors/templates/editors/themes/queue_list.html:14 src/olympia/search/templates/search/collections.html:17
 #: src/olympia/search/templates/search/personas.html:18 src/olympia/search/templates/search/results.html:18 src/olympia/search/templates/search/mobile/results.html:8
 #: src/olympia/templates/search.html:14 src/olympia/templates/impala/search.html:18
@@ -4071,12 +4054,12 @@ msgstr ""
 msgid "Start Making Add-ons"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/index.html:86 src/olympia/devhub/templates/devhub/addons/listing/items.html:25 src/olympia/devhub/templates/devhub/includes/addon_details.html:15
+#: src/olympia/devhub/templates/devhub/index.html:86 src/olympia/devhub/templates/devhub/addons/listing/items.html:25 src/olympia/devhub/templates/devhub/includes/addon_details.html:20
 #: src/olympia/devhub/templates/devhub/personas/edit.html:43
 msgid "Status:"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/index.html:90 src/olympia/devhub/templates/devhub/includes/addon_details.html:100
+#: src/olympia/devhub/templates/devhub/index.html:90 src/olympia/devhub/templates/devhub/includes/addon_details.html:87
 msgid "Visibility:"
 msgstr ""
 
@@ -4084,11 +4067,11 @@ msgstr ""
 msgid "Latest Version:"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/index.html:109 src/olympia/devhub/templates/devhub/includes/addon_details.html:145 src/olympia/devhub/templates/devhub/personas/edit.html:49
+#: src/olympia/devhub/templates/devhub/index.html:109 src/olympia/devhub/templates/devhub/includes/addon_details.html:131 src/olympia/devhub/templates/devhub/personas/edit.html:49
 msgid "Queue Position:"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/index.html:110 src/olympia/devhub/templates/devhub/includes/addon_details.html:146 src/olympia/devhub/templates/devhub/personas/edit.html:50
+#: src/olympia/devhub/templates/devhub/index.html:110 src/olympia/devhub/templates/devhub/includes/addon_details.html:132 src/olympia/devhub/templates/devhub/personas/edit.html:50
 #, python-format
 msgid "%(position)s of %(total)s"
 msgstr ""
@@ -4190,16 +4173,6 @@ msgstr ""
 msgid "Do you want your add-on to be distributed on this site?"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/validate_addon.html:49 src/olympia/devhub/templates/devhub/addons/submit/upload.html:30 src/olympia/devhub/templates/devhub/versions/add_file_modal.html:14
-#: src/olympia/devhub/templates/devhub/versions/add_file_modal.html:53 src/olympia/devhub/templates/devhub/versions/list.html:298
-msgid "Warning:"
-msgstr ""
-
-#: src/olympia/devhub/templates/devhub/validate_addon.html:50 src/olympia/devhub/templates/devhub/addons/submit/upload.html:31
-#, python-format
-msgid "Submission of unlisted add-ons for signing is currently in an open beta. Please <a href=\"%(url)s\" target=\"_blank\">report any bugs</a> that you encounter."
-msgstr ""
-
 #. first parameter is a filename like lorem-ipsum-1.0.2.xpi
 #: src/olympia/devhub/templates/devhub/validation.html:5
 msgid "Validation Results for {0}"
@@ -4274,7 +4247,7 @@ msgstr ""
 msgid "Update Compatibility"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/addons/ajax_compat_update.html:4
+#: src/olympia/devhub/templates/devhub/addons/ajax_compat_update.html:4 src/olympia/devhub/templates/devhub/versions/edit.html:45
 msgid "Adjusting application information here will allow users to install your add-on even if the install manifest in the package indicates that the add-on is incompatible."
 msgstr ""
 
@@ -4286,9 +4259,9 @@ msgstr ""
 msgid "Add Another Application&hellip;"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/addons/ajax_compat_update.html:38 src/olympia/devhub/templates/devhub/addons/owner.html:86 src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:46
-#: src/olympia/devhub/templates/devhub/versions/list.html:351 src/olympia/devhub/templates/devhub/versions/list.html:353 src/olympia/templates/impala/base.html:132
-#: src/olympia/templates/impala/base.html:143 src/olympia/templates/impala/base.html:161 src/olympia/templates/impala/base.html:171
+#: src/olympia/devhub/templates/devhub/addons/ajax_compat_update.html:38 src/olympia/devhub/templates/devhub/addons/owner.html:86 src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:45
+#: src/olympia/devhub/templates/devhub/versions/list.html:349 src/olympia/devhub/templates/devhub/versions/list.html:351 src/olympia/templates/impala/base.html:129
+#: src/olympia/templates/impala/base.html:140 src/olympia/templates/impala/base.html:158 src/olympia/templates/impala/base.html:168
 msgid "Close"
 msgstr ""
 
@@ -4322,7 +4295,7 @@ msgstr ""
 msgid "Manage Authors & License"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/addons/owner.html:29 src/olympia/editors/templates/editors/review.html:270
+#: src/olympia/devhub/templates/devhub/addons/owner.html:29 src/olympia/editors/helpers.py:362 src/olympia/editors/templates/editors/review.html:270
 msgid "Authors"
 msgstr ""
 
@@ -4391,17 +4364,11 @@ msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/basic.html:52
 msgid ""
-"A short explanation of your add-on's basic\n"
-"                          functionality that is displayed in search and browse\n"
-"                          listings, as well as at the top of your add-on's\n"
-"                          details page. It is only relevant for listed add-ons."
+"A short explanation of your add-on's basic functionality that is displayed in search and browse listings, as well as at the top of your add-on's details page. It is only relevant for listed add-ons."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/basic.html:73
-msgid ""
-"Categories are the primary way users browse through add-ons.\n"
-"                        Choose any that fit your add-on's functionality for the most\n"
-"                        exposure. It is only relevant for listed add-ons."
+msgid "Categories are the primary way users browse through add-ons. Choose any that fit your add-on's functionality for the most exposure. It is only relevant for listed add-ons."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/basic.html:90
@@ -4411,11 +4378,7 @@ msgid ""
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/basic.html:119
-msgid ""
-"Tags help users find your add-on and should be short\n"
-"                        descriptors such as tabs, toolbar, or twitter.  You\n"
-"                        may have a maximum of {0} tags. It is only relevant\n"
-"                        for listed add-ons."
+msgid "Tags help users find your add-on and should be short descriptors such as tabs, toolbar, or twitter. You may have a maximum of {0} tags. It is only relevant for listed add-ons."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/basic.html:129 src/olympia/devhub/templates/devhub/personas/edit.html:97 src/olympia/devhub/templates/devhub/personas/submit.html:46
@@ -4443,11 +4406,7 @@ msgid "Add-on Details for {0}"
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/details.html:22
-msgid ""
-"A longer explanation of features,\n"
-"                          functionality, and other relevant information. This\n"
-"                          field is only displayed on the add-on's details\n"
-"                          page. It is only relevant for listed add-ons."
+msgid "A longer explanation of features, functionality, and other relevant information. This field is only displayed on the add-on's details page. It is only relevant for listed add-ons."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/details.html:44 src/olympia/translations/templates/translations/trans-menu.html:13
@@ -4455,10 +4414,7 @@ msgid "Default Locale"
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/details.html:45
-msgid ""
-"Information about your add-on is displayed in this locale\n"
-"                        unless you override it with a locale-specific translation.\n"
-"                        It is only relevant for listed add-ons."
+msgid "Information about your add-on is displayed in this locale unless you override it with a locale-specific translation. It is only relevant for listed add-ons."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/details.html:61 src/olympia/users/forms.py:311 src/olympia/users/templates/users/edit.html:122 src/olympia/users/templates/users/register.html:57
@@ -4468,10 +4424,8 @@ msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/details.html:63
 msgid ""
-"If your add-on has another homepage, enter its\n"
-"                          address here. If your website is localized into other\n"
-"                          languages multiple translations of this field can be\n"
-"                          added. It is only relevant for listed add-ons."
+"If your add-on has another homepage, enter its address here. If your website is localized into other languages multiple translations of this field can be added. It is only relevant for listed add-"
+"ons."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/media.html:3
@@ -4489,19 +4443,14 @@ msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/support.html:22
 msgid ""
-"If you wish to display an e-mail address for support\n"
-"                          inquiries, enter it here. If you have different\n"
-"                          addresses for each language multiple translations of\n"
-"                          this field can be added. It is only relevant for\n"
-"                          listed add-ons."
+"If you wish to display an e-mail address for support inquiries, enter it here. If you have different addresses for each language multiple translations of this field can be added. It is only "
+"relevant for listed add-ons."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/support.html:45
 msgid ""
-"If your add-on has a support website or forum, enter\n"
-"                          its address here. If your website is localized into\n"
-"                          other languages, multiple translations of this field can\n"
-"                          be added. It is only relevant for listed add-ons."
+"If your add-on has a support website or forum, enter its address here. If your website is localized into other languages, multiple translations of this field can be added. It is only relevant for "
+"listed add-ons."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:6
@@ -4515,11 +4464,8 @@ msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:23
 msgid ""
-"Any information end users may want to know that isn't\n"
-"                          necessarily applicable to the add-on summary or description.\n"
-"                          Common uses include listing known major bugs, information on\n"
-"                          how to report bugs, anticipated release date of a new version,\n"
-"                          etc. It is only relevant for listed add-ons."
+"Any information end users may want to know that isn't necessarily applicable to the add-on summary or description. Common uses include listing known major bugs, information on how to report bugs, "
+"anticipated release date of a new version, etc. It is only relevant for listed add-ons."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:46
@@ -4531,9 +4477,7 @@ msgid "Add-on Flags"
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:69
-msgid ""
-"These flags are used to classify add-ons. It is only\n"
-"                        relevant for listed add-ons."
+msgid "These flags are used to classify add-ons. It is only relevant for listed add-ons."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:74
@@ -4549,9 +4493,7 @@ msgid "View Source?"
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:90
-msgid ""
-"Whether the source of your add-on can be displayed in our\n"
-"                        online viewer. It is only relevant for listed add-ons."
+msgid "Whether the source of your add-on can be displayed in our online viewer. It is only relevant for listed add-ons."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:94
@@ -4567,10 +4509,7 @@ msgid "Public Stats?"
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:102
-msgid ""
-"Whether the download and usage stats of your add-on can\n"
-"                        be displayed in our online viewer.\n"
-"                        It is only relevant for listed add-ons."
+msgid "Whether the download and usage stats of your add-on can be displayed in our online viewer. It is only relevant for listed add-ons."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:107
@@ -4586,10 +4525,7 @@ msgid "Upgrade SDK?"
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:116
-msgid ""
-"If selected, we will try to automatically upgrade your\n"
-"                        add-on when a new version of the SDK is released.\n"
-"                        It is only relevant for listed add-ons."
+msgid "If selected, we will try to automatically upgrade your add-on when a new version of the SDK is released. It is only relevant for listed add-ons."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:121
@@ -4640,10 +4576,8 @@ msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/forms_shared/media.html:16
 msgid ""
-"Upload an icon for your add-on or choose from one of ours. The\n"
-"                      icon is displayed nearly everywhere your add-on is. Uploaded images\n"
-"                      must be one of the following image types: .png, .jpg.\n"
-"                      It is only relevant for listed add-ons."
+"Upload an icon for your add-on or choose from one of ours. The icon is displayed nearly everywhere your add-on is. Uploaded images must be one of the following image types: .png, .jpg. It is only "
+"relevant for listed add-ons."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/forms_shared/media.html:25
@@ -4656,9 +4590,7 @@ msgid "32x32px"
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/forms_shared/media.html:39
-msgid ""
-"Used in listings of add-ons, like search results\n"
-"                            and featured add-ons."
+msgid "Used in listings of add-ons, like search results and featured add-ons."
 msgstr ""
 
 #. The size of the icon
@@ -4753,16 +4685,14 @@ msgid "Deleting your add-on will permanently remove it from the site and prevent
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:24
-msgid ""
-"Enter the following text confirm your decision:\n"
-"           {slug}"
+msgid "Enter the following text confirm your decision: {slug}"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:34
+#: src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:33
 msgid "Please tell us why you are deleting your theme:"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:36
+#: src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:35
 msgid "Please tell us why you are deleting your add-on:"
 msgstr ""
 
@@ -4799,8 +4729,8 @@ msgstr ""
 msgid "Daily statistics on downloads and users."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/addons/listing/item_actions.html:45 src/olympia/stats/templates/stats/stats.html:75 src/olympia/stats/templates/stats/stats.html:79
-#: src/olympia/stats/templates/stats/stats.html:81
+#: src/olympia/devhub/templates/devhub/addons/listing/item_actions.html:45 src/olympia/stats/templates/stats/stats.html:31 src/olympia/stats/templates/stats/stats.html:35
+#: src/olympia/stats/templates/stats/stats.html:37
 msgid "Statistics"
 msgstr ""
 
@@ -4919,10 +4849,7 @@ msgid "Your add-on has been submitted to the Full Review queue."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/submit/done.html:18
-msgid ""
-"You'll receive an email once it has been reviewed by an editor. In\n"
-"          the meantime, you and your friends can install it directly from its\n"
-"          details page:"
+msgid "You'll receive an email once it has been reviewed by an editor. In the meantime, you and your friends can install it directly from its details page:"
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/submit/done.html:27 src/olympia/devhub/templates/devhub/addons/submit/done.html:77 src/olympia/devhub/templates/devhub/personas/submit_done.html:16
@@ -5128,11 +5055,11 @@ msgstr ""
 msgid "Use the fields below to upload your add-on package and select any platform restrictions. After upload, a series of automated validation tests will be run on your file."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/addons/submit/upload.html:59 src/olympia/devhub/templates/devhub/versions/add_file_modal.html:39
+#: src/olympia/devhub/templates/devhub/addons/submit/upload.html:51 src/olympia/devhub/templates/devhub/versions/add_file_modal.html:28
 msgid "Which platforms is this file compatible with?"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/addons/submit/upload.html:67 src/olympia/devhub/templates/devhub/versions/add_file_modal.html:65
+#: src/olympia/devhub/templates/devhub/addons/submit/upload.html:59 src/olympia/devhub/templates/devhub/versions/add_file_modal.html:45
 msgid "Administrative overrides"
 msgstr ""
 
@@ -5242,8 +5169,8 @@ msgstr ""
 
 #: src/olympia/devhub/templates/devhub/docs/policies-contact.html:44
 msgid ""
-"If you've found a problem with the site, we'd love to fix it. Please <a href=\"https://github.com/mozilla/olympia/issues\">file a bug report</a> in GitHub, including the location of the problem and "
-"how you encountered it."
+"If you've found a problem with the site, we'd love to fix it. Please <a href=\"https://github.com/mozilla/addons/issues/new\">file a bug report</a> in GitHub, including the location of the problem "
+"and how you encountered it."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/docs/policies-maintenance.html:3 src/olympia/devhub/templates/devhub/docs/policies-maintenance.html:7
@@ -5810,7 +5737,7 @@ msgstr ""
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:282
 msgid ""
-"Add-ons that store or otherwise handle browsing data must support <a href=\"https://developer.mozilla.org/En/Supporting_private_browsing_mode\">Private Browsing Mode</a>.  During a Private Browsing "
+"Add-ons that store or otherwise handle browsing data must support <a href=\"https://developer.mozilla.org/En/Supporting_private_browsing_mode\">Private Browsing Mode</a>. During a Private Browsing "
 "session, no browsing data can be written to disk, and all of this data must be cleared when Firefox quits or the Private Browsing session ends."
 msgstr ""
 
@@ -5975,129 +5902,95 @@ msgstr ""
 msgid "How to get in touch with us regarding these policies or your add-on."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:6
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:10
 msgid "You have disabled this add-on"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:20
-msgid ""
-"Your add-on's listing is disabled and is not showing\n"
-"                             anywhere in our gallery or update service."
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:24
+msgid "Your add-on's listing is disabled and is not showing anywhere in our gallery or update service."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:25
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:27
 msgid "Please complete your add-on."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:29
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:30
 msgid "You will receive an email when the review is complete."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:34
-msgid ""
-"You will receive an email when the review is complete. Until\n"
-"                             then, your add-on is not listed in our gallery but can be\n"
-"                             accessed directly from its details page."
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:33
+msgid "You will receive an email when the review is complete. Until then, your add-on is not listed in our gallery but can be accessed directly from its details page."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:38 src/olympia/devhub/templates/devhub/includes/addon_details.html:48
-msgid ""
-"You will receive an email when the review is\n"
-"                             complete and your add-on is signed."
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:37 src/olympia/devhub/templates/devhub/includes/addon_details.html:45
+msgid "You will receive an email when the review is complete and your add-on is signed."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:44
-msgid ""
-"You will receive an email when the review is complete. Until\n"
-"                             then, your add-on is not listed in our gallery but can be\n"
-"                             accessed directly from its details page. "
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:41
+msgid "You will receive an email when the review is complete. Until then, your add-on is not listed in our gallery but can be accessed directly from its details page. "
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:54
-msgid ""
-"Your add-on is displayed in our gallery and users are\n"
-"                             receiving automatic updates."
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:49
+msgid "Your add-on is displayed in our gallery and users are receiving automatic updates."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:57
-msgid ""
-"Your add-on has been signed and can be bundled with an\n"
-"                             application installer."
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:52
+msgid "Your add-on has been signed and can be bundled with an application installer."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:63
-msgid ""
-"Your add-on was disabled by a site administrator and is no\n"
-"                             longer shown in our gallery. If you have any questions,\n"
-"                             please email amo-admins@mozilla.org."
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:56
+msgid "Your add-on was disabled by a site administrator and is no longer shown in our gallery. If you have any questions, please email amo-admins@mozilla.org."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:70
-msgid ""
-"Your add-on is displayed in our gallery as experimental\n"
-"                             and users are receiving automatic updates. Some features\n"
-"                             are unavailable to your add-on."
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:62
+msgid "Your add-on is displayed in our gallery as experimental and users are receiving automatic updates. Some features are unavailable to your add-on."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:74
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:66
 msgid "Your add-on has been signed."
 msgstr ""
 
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:69
+msgid ""
+"You will receive an email when the full review is complete. Until then, your add-on is displayed in our gallery as experimental and users are receiving automatic updates. Some features are "
+"unavailable to your add-on."
+msgstr ""
+
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:74
+msgid "You will receive an email when the full review is complete, making you able to bundle your add-on with an application installer."
+msgstr ""
+
 #: src/olympia/devhub/templates/devhub/includes/addon_details.html:79
-msgid ""
-"You will receive an email when the full review is complete.\n"
-"                             Until then, your add-on is displayed in our gallery as\n"
-"                             experimental and users are receiving automatic updates.\n"
-"                             Some features are unavailable to your add-on."
+msgid "All add-ons hosted in our gallery must now be reviewed by an editor. If you wish to continue hosting your add-on, please click to select a review process."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:84
-msgid ""
-"You will receive an email when the full review is\n"
-"                             complete, making you able to bundle your add-on with an\n"
-"                             application installer."
-msgstr ""
-
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:91
-msgid ""
-"All add-ons hosted in our gallery must now be reviewed by an\n"
-"                             editor. If you wish to continue hosting your add-on, please\n"
-"                             click to select a review process."
-msgstr ""
-
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:113
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:100
 msgid "Current Version:"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:115
-msgid ""
-"This is the version of your add-on that will\n"
-"                                           be installed if someone clicks the Install\n"
-"                                           button on addons.mozilla.org. It is only\n"
-"                                           relevant for listed add-ons."
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:102
+msgid "This is the version of your add-on that will be installed if someone clicks the Install button on addons.mozilla.org. It is only relevant for listed add-ons."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:123
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:110
 msgid "Created:"
 msgstr ""
 
 #. {0} is a date. dennis-ignore: E201
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:125 src/olympia/devhub/templates/devhub/includes/addon_details.html:131
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:112 src/olympia/devhub/templates/devhub/includes/addon_details.html:118
 #, python-format
 msgid "%%b %%e, %%Y"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:136
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:123
 msgid "Next Version:"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:138
-msgid ""
-"This is the newest uploaded version, however\n"
-"                                           it isn’t live on the site yet."
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:125
+msgid "This is the newest uploaded version, however it isn’t live on the site yet."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:144 src/olympia/devhub/templates/devhub/versions/list.html:30
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:130 src/olympia/devhub/templates/devhub/versions/list.html:30
 msgid "Queues are not reviewed strictly in order"
 msgstr ""
 
@@ -6165,9 +6058,7 @@ msgid "View the blog &#9658;"
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/includes/license_form.html:6
-msgid ""
-"Please choose a license appropriate for the rights you grant on your source code.\n"
-"                  It is only relevant for listed add-ons."
+msgid "Please choose a license appropriate for the rights you grant on your source code. It is only relevant for listed add-ons."
 msgstr ""
 
 #. {0} is a list of HTML tags.
@@ -6194,14 +6085,11 @@ msgstr[1] ""
 #: src/olympia/devhub/templates/devhub/includes/policy_form.html:4
 msgid ""
 "Users will be required to accept the following End-User License Agreement (EULA) prior to installing your add-on. The presence of a EULA significantly affects the number of downloads an add-on "
-"receives. Please note that a EULA is not the same as a code license, such as the GPL or MPL.\n"
-"                It is only relevant for listed add-ons."
+"receives. Please note that a EULA is not the same as a code license, such as the GPL or MPL.It is only relevant for listed add-ons."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/policy_form.html:21
-msgid ""
-"If your add-on transmits any data from the user's computer, a privacy policy is required that explains what data is sent and how it is used.\n"
-"                It is only relevant for listed add-ons."
+#: src/olympia/devhub/templates/devhub/includes/policy_form.html:24
+msgid "If your add-on transmits any data from the user's computer, a privacy policy is required that explains what data is sent and how it is used. It is only relevant for listed add-ons."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/includes/source_form_field.html:2
@@ -6369,12 +6257,8 @@ msgstr ""
 msgid "Add some tags to describe your Theme."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/personas/edit.html:106
-msgid ""
-"A short explanation of your theme's\n"
-"                                basic functionality that is displayed in\n"
-"                                search and browse listings, as well as at\n"
-"                                the top of your theme's details page."
+#: src/olympia/devhub/templates/devhub/personas/edit.html:106 src/olympia/devhub/templates/devhub/personas/submit.html:54
+msgid "A short explanation of your theme's basic functionality that is displayed in search and browse listings, as well as at the top of your theme's details page."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/personas/edit.html:122 src/olympia/devhub/templates/devhub/personas/submit.html:68
@@ -6444,7 +6328,7 @@ msgid "Upon upload and form submission, the AMO Team will review your updated de
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/personas/edit.html:241
-msgid "Your previously resubmitted design,  which is under pending review."
+msgid "Your previously resubmitted design, which is under pending review."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/personas/edit.html:245
@@ -6511,14 +6395,6 @@ msgstr ""
 
 #: src/olympia/devhub/templates/devhub/personas/submit.html:33
 msgid "Give your Theme a name."
-msgstr ""
-
-#: src/olympia/devhub/templates/devhub/personas/submit.html:54
-msgid ""
-"A short explanation of your theme's\n"
-"                                      basic functionality that is displayed in\n"
-"                                      search and browse listings, as well as at\n"
-"                                      the top of your theme's details page."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/personas/submit.html:198
@@ -6595,30 +6471,16 @@ msgstr ""
 msgid "Files added to reviewed versions must be reviewed before they will be available for download."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/add_file_modal.html:15
-#, python-format
-msgid ""
-"Submission of updates to unlisted add-ons for signing is currently in an open beta. Manual review may still be required for a large number of add-ons. Please <a href=\"%(url)s\" target=\"_blank"
-"\">report any bugs</a> that you encounter."
-msgstr ""
-
-#: src/olympia/devhub/templates/devhub/versions/add_file_modal.html:35
+#: src/olympia/devhub/templates/devhub/versions/add_file_modal.html:24
 msgid "Select the target platform for this file."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/add_file_modal.html:46
+#: src/olympia/devhub/templates/devhub/versions/add_file_modal.html:35
 msgid "Which review type would you like to nominate for?"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/add_file_modal.html:51
+#: src/olympia/devhub/templates/devhub/versions/add_file_modal.html:40
 msgid "Only publish this version to my beta channel."
-msgstr ""
-
-#: src/olympia/devhub/templates/devhub/versions/add_file_modal.html:54
-#, python-format
-msgid ""
-"The behavior of the beta channel has changed to accommodate <a href=\"%(addon_signing_url)s\" target=\"_blank\">mandatory add-on signing</a>. The new process is currently in an open beta, and may "
-"change significantly in the near future. Please <a href=\"%(issues_url)s\" target=\"_blank\">report any bugs</a> that you encounter."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/versions/edit.html:5
@@ -6642,19 +6504,10 @@ msgstr ""
 msgid "Upload Another File"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/edit.html:45
-msgid ""
-"Adjusting application information here will allow users to install your\n"
-"                          add-on even if the install manifest in the package indicates that the\n"
-"                          add-on is incompatible."
-msgstr ""
-
 #: src/olympia/devhub/templates/devhub/versions/edit.html:74
 msgid ""
-"Information about changes in this release, new features,\n"
-"                              known bugs, and other useful information specific to this\n"
-"                              release/version. This information is also shown in the\n"
-"                              Add-ons Manager when updating."
+"Information about changes in this release, new features, known bugs, and other useful information specific to this release/version. This information is also shown in the Add-ons Manager when "
+"updating."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/versions/edit.html:99
@@ -6666,10 +6519,7 @@ msgid "Notes for Reviewers"
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/versions/edit.html:114
-msgid ""
-"Optionally, enter any information that may be useful\n"
-"                              to the Editor reviewing this add-on, such as test\n"
-"                              account information."
+msgid "Optionally, enter any information that may be useful to the Editor reviewing this add-on, such as test account information."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/versions/edit.html:127
@@ -6747,7 +6597,7 @@ msgstr ""
 msgid "Request Preliminary Review"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:80 src/olympia/devhub/templates/devhub/versions/list.html:327 src/olympia/devhub/templates/devhub/versions/list.html:350
+#: src/olympia/devhub/templates/devhub/versions/list.html:80 src/olympia/devhub/templates/devhub/versions/list.html:325 src/olympia/devhub/templates/devhub/versions/list.html:348
 msgid "Cancel Review Request"
 msgstr ""
 
@@ -6776,7 +6626,7 @@ msgid "Unlisted:"
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/versions/list.html:114
-msgid "Not distributed on {0}. Developers will upload new versions for signing and distribute the add-ons on their own. (beta)"
+msgid "Not distributed on {0}. Developers will upload new versions for signing and distribute the add-ons on their own."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/versions/list.html:122
@@ -6839,81 +6689,73 @@ msgid "<strong>Important:</strong> Once a version has been deleted, you may not 
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/versions/list.html:230
-msgid ""
-"Deleting a version which has already been reviewed\n"
-"               may also cause a significant delay in the review of\n"
-"               your next update."
-msgstr ""
-
-#: src/olympia/devhub/templates/devhub/versions/list.html:233
 msgid "Are you sure you wish to delete this version?"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:238
+#: src/olympia/devhub/templates/devhub/versions/list.html:235
 msgid "Delete Version"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:240
+#: src/olympia/devhub/templates/devhub/versions/list.html:237
 msgid "Disable Version"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:247
+#: src/olympia/devhub/templates/devhub/versions/list.html:244
 msgid "Add a new Version"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:249
+#: src/olympia/devhub/templates/devhub/versions/list.html:246
 msgid "Add Version"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:256 src/olympia/devhub/templates/devhub/versions/list.html:274
+#: src/olympia/devhub/templates/devhub/versions/list.html:253 src/olympia/devhub/templates/devhub/versions/list.html:279
 msgid "Hide Add-on"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:259
+#: src/olympia/devhub/templates/devhub/versions/list.html:256
 msgid "Hiding your add-on will prevent it from appearing anywhere in our gallery and will stop users from receiving automatic updates."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:265
+#: src/olympia/devhub/templates/devhub/versions/list.html:263
+msgid "The files awaiting review will be disabled and you will need to upload new versions."
+msgstr ""
+
+#: src/olympia/devhub/templates/devhub/versions/list.html:270
 msgid "Are you sure you wish to hide your add-on?"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:286 src/olympia/devhub/templates/devhub/versions/list.html:315
+#: src/olympia/devhub/templates/devhub/versions/list.html:291 src/olympia/devhub/templates/devhub/versions/list.html:313
 msgid "Unlist Add-on"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:289
+#: src/olympia/devhub/templates/devhub/versions/list.html:294
 #, python-format
 msgid ""
 "Unlisting your add-on will make it (and each of its versions/files) invisible on this website. It won't show up in searches, won't have a public facing page, and won't be updated automatically for "
-"current users.  It is recommended for unlisted add-ons to provide a custom <a href=\"%(update_url)s\" target=\"_blank\">updateURL</a> in their manifest file for automatic updates."
+"current users. It is recommended for unlisted add-ons to provide a custom <a href=\"%(update_url)s\" target=\"_blank\">updateURL</a> in their manifest file for automatic updates."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:299
-#, python-format
-msgid "Switching add-ons to unlisted is currently in an open beta. Please <a href=\"%(url)s\" target=\"_blank\">report any bugs</a> that you encounter."
-msgstr ""
-
-#: src/olympia/devhub/templates/devhub/versions/list.html:305
+#: src/olympia/devhub/templates/devhub/versions/list.html:303
 msgid "Unlisting an add-on is irreversible!"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:305
+#: src/olympia/devhub/templates/devhub/versions/list.html:303
 msgid "An unlisted add-on cannot be switched to be listed."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:307
+#: src/olympia/devhub/templates/devhub/versions/list.html:305
 msgid "Are you sure you wish to unlist your add-on?"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:330
+#: src/olympia/devhub/templates/devhub/versions/list.html:328
 msgid "Canceling your review request will leave your add-on as preliminarily reviewed."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:335
+#: src/olympia/devhub/templates/devhub/versions/list.html:333
 msgid "Canceling your review request will mark your add-on incomplete. If you do not complete your add-on after several days by re-requesting review, it will be deleted."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:343
+#: src/olympia/devhub/templates/devhub/versions/list.html:341
 msgid "Are you sure you wish to cancel your review request?"
 msgstr ""
 
@@ -7252,19 +7094,19 @@ msgstr ""
 msgid "Search by add-on name / author email"
 msgstr ""
 
-#: src/olympia/editors/forms.py:103
+#: src/olympia/editors/forms.py:103 src/olympia/editors/forms.py:244 src/olympia/editors/forms.py:257
 msgid "yes"
 msgstr ""
 
-#: src/olympia/editors/forms.py:104
+#: src/olympia/editors/forms.py:104 src/olympia/editors/forms.py:244 src/olympia/editors/forms.py:257
 msgid "no"
 msgstr ""
 
-#: src/olympia/editors/forms.py:105
+#: src/olympia/editors/forms.py:105 src/olympia/editors/forms.py:245
 msgid "Admin Flag"
 msgstr ""
 
-#: src/olympia/editors/forms.py:113
+#: src/olympia/editors/forms.py:113 src/olympia/editors/forms.py:253
 msgid "Max. Version"
 msgstr ""
 
@@ -7276,55 +7118,59 @@ msgstr ""
 msgid "Add-on Types"
 msgstr ""
 
-#: src/olympia/editors/forms.py:126 src/olympia/editors/helpers.py:267
+#: src/olympia/editors/forms.py:126 src/olympia/editors/helpers.py:279
 msgid "Platforms"
 msgstr ""
 
+#: src/olympia/editors/forms.py:237
+msgid "Search by add-on name / author email / guid"
+msgstr ""
+
 #. L10n: 0 = platform, 1 = filename, 2 = status message
-#: src/olympia/editors/forms.py:238
+#: src/olympia/editors/forms.py:342
 #, python-format
 msgid "<strong>%s</strong> &middot; %s &middot; %s"
 msgstr ""
 
-#: src/olympia/editors/forms.py:252
+#: src/olympia/editors/forms.py:356
 msgid "Comments:"
 msgstr ""
 
-#: src/olympia/editors/forms.py:256
+#: src/olympia/editors/forms.py:360
 msgid "Operating systems:"
 msgstr ""
 
-#: src/olympia/editors/forms.py:258
+#: src/olympia/editors/forms.py:362
 msgid "Applications:"
 msgstr ""
 
-#: src/olympia/editors/forms.py:260
+#: src/olympia/editors/forms.py:364
 msgid "Notify me the next time this add-on is updated. (Subsequent updates will not generate an email)"
 msgstr ""
 
-#: src/olympia/editors/forms.py:265
+#: src/olympia/editors/forms.py:369
 msgid "Clear Admin Review Flag"
 msgstr ""
 
-#: src/olympia/editors/forms.py:267
+#: src/olympia/editors/forms.py:371
 msgid "Clear more info requested flag"
 msgstr ""
 
-#: src/olympia/editors/forms.py:281
+#: src/olympia/editors/forms.py:385
 msgid "Choose a canned response..."
 msgstr ""
 
 #. L10n: Description of what can be searched for.
-#: src/olympia/editors/forms.py:324
+#: src/olympia/editors/forms.py:423
 msgid "theme name"
 msgstr ""
 
-#: src/olympia/editors/forms.py:350
+#: src/olympia/editors/forms.py:449
 msgid "Someone else is reviewing this theme."
 msgstr ""
 
 #. L10n: Description of what can be searched for.
-#: src/olympia/editors/forms.py:447
+#: src/olympia/editors/forms.py:546
 msgid "app, reviewer, or comment"
 msgstr ""
 
@@ -7340,246 +7186,264 @@ msgstr ""
 msgid "Rejected or Unreviewed"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:123 src/olympia/editors/helpers.py:136
+#: src/olympia/editors/helpers.py:125 src/olympia/editors/helpers.py:138
 msgid "Queue"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:124 src/olympia/editors/templates/editors/base.html:50 src/olympia/editors/templates/editors/base.html:65
+#: src/olympia/editors/helpers.py:126 src/olympia/editors/templates/editors/base.html:50 src/olympia/editors/templates/editors/base.html:65
 msgid "Pending Updates"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:125 src/olympia/editors/templates/editors/base.html:48 src/olympia/editors/templates/editors/base.html:63
+#: src/olympia/editors/helpers.py:127 src/olympia/editors/templates/editors/base.html:48 src/olympia/editors/templates/editors/base.html:63
 msgid "Full Reviews"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:126 src/olympia/editors/templates/editors/base.html:52 src/olympia/editors/templates/editors/base.html:67
+#: src/olympia/editors/helpers.py:128 src/olympia/editors/templates/editors/base.html:52 src/olympia/editors/templates/editors/base.html:67
 msgid "Preliminary Reviews"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:127 src/olympia/editors/templates/editors/base.html:54
+#: src/olympia/editors/helpers.py:129 src/olympia/editors/templates/editors/base.html:54
 msgid "Moderated Reviews"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:128 src/olympia/editors/templates/editors/base.html:46
+#: src/olympia/editors/helpers.py:130 src/olympia/editors/templates/editors/base.html:46
 msgid "Fast Track"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:130
+#: src/olympia/editors/helpers.py:132
 msgid "Pending Themes"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:131 src/olympia/editors/templates/editors/themes/queue.html:4
+#: src/olympia/editors/helpers.py:133 src/olympia/editors/templates/editors/themes/queue.html:4
 msgid "Flagged Themes"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:132
+#: src/olympia/editors/helpers.py:134
 msgid "Update Themes"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:137
+#: src/olympia/editors/helpers.py:139
 msgid "Unlisted Pending Updates"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:138
+#: src/olympia/editors/helpers.py:140
 msgid "Unlisted Full Reviews"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:139
+#: src/olympia/editors/helpers.py:141
 msgid "Unlisted Preliminary Reviews"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:170
+#: src/olympia/editors/helpers.py:142
+msgid "Unlisted All Add-ons"
+msgstr ""
+
+#: src/olympia/editors/helpers.py:173
 msgid "Fast Track ({0})"
 msgid_plural "Fast Track ({0})"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/olympia/editors/helpers.py:175
+#: src/olympia/editors/helpers.py:178
 msgid "Full Review ({0})"
 msgid_plural "Full Reviews ({0})"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/olympia/editors/helpers.py:180
+#: src/olympia/editors/helpers.py:183
 msgid "Pending Update ({0})"
 msgid_plural "Pending Updates ({0})"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/olympia/editors/helpers.py:185
+#: src/olympia/editors/helpers.py:188
 msgid "Preliminary Review ({0})"
 msgid_plural "Preliminary Reviews ({0})"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/olympia/editors/helpers.py:190
+#: src/olympia/editors/helpers.py:193
 msgid "Moderated Review ({0})"
 msgid_plural "Moderated Reviews ({0})"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/olympia/editors/helpers.py:196
+#: src/olympia/editors/helpers.py:199
 msgid "Unlisted Full Review ({0})"
 msgid_plural "Unlisted Full Reviews ({0})"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/olympia/editors/helpers.py:201
+#: src/olympia/editors/helpers.py:204
 msgid "Unlisted Pending Update ({0})"
 msgid_plural "Unlisted Pending Updates ({0})"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/olympia/editors/helpers.py:206
+#: src/olympia/editors/helpers.py:209
 msgid "Unlisted Preliminary Review ({0})"
 msgid_plural "Unlisted Preliminary Reviews ({0})"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/olympia/editors/helpers.py:261
-msgid "Addon"
-msgstr ""
+#: src/olympia/editors/helpers.py:214
+msgid "Unlisted All Add-ons ({0})"
+msgid_plural "Unlisted All Add-ons ({0})"
+msgstr[0] ""
+msgstr[1] ""
 
-#: src/olympia/editors/helpers.py:262
+#: src/olympia/editors/helpers.py:274
 msgid "Type"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:263
+#: src/olympia/editors/helpers.py:275
 msgid "Waiting Time"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:264 src/olympia/editors/templates/editors/review.html:285
+#: src/olympia/editors/helpers.py:276 src/olympia/editors/templates/editors/review.html:285
 msgid "Flags"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:265
+#: src/olympia/editors/helpers.py:277
 msgid "Applications"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:270
+#: src/olympia/editors/helpers.py:282
 msgid "Additional"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:285
+#: src/olympia/editors/helpers.py:302
 msgid "Site Specific"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:287
+#: src/olympia/editors/helpers.py:304
 msgid "Requires External Software"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:289
+#: src/olympia/editors/helpers.py:306
 msgid "Binary Components"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:313
+#: src/olympia/editors/helpers.py:339
 msgid "moments ago"
 msgstr ""
 
 #. L10n: first argument is number of minutes
-#: src/olympia/editors/helpers.py:316
+#: src/olympia/editors/helpers.py:342
 msgid "{0} minute"
 msgid_plural "{0} minutes"
 msgstr[0] ""
 msgstr[1] ""
 
 #. L10n: first argument is number of hours
-#: src/olympia/editors/helpers.py:320
+#: src/olympia/editors/helpers.py:346
 msgid "{0} hour"
 msgid_plural "{0} hours"
 msgstr[0] ""
 msgstr[1] ""
 
 #. L10n: first argument is number of days
-#: src/olympia/editors/helpers.py:324
+#: src/olympia/editors/helpers.py:350
 msgid "{0} day"
 msgid_plural "{0} days"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/olympia/editors/helpers.py:488
+#: src/olympia/editors/helpers.py:364
+msgid "Last Review"
+msgstr ""
+
+#: src/olympia/editors/helpers.py:366
+msgid "Last Update"
+msgstr ""
+
+#: src/olympia/editors/helpers.py:387
+msgid "No Reviews"
+msgstr ""
+
+#: src/olympia/editors/helpers.py:561
 msgid "Push to public"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:490
+#: src/olympia/editors/helpers.py:563
 msgid "Grant full review"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:505
+#: src/olympia/editors/helpers.py:578
 msgid "Request more information"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:508
+#: src/olympia/editors/helpers.py:581
 msgid "Request super-review"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:519
+#: src/olympia/editors/helpers.py:592
 msgid "Grant preliminary review"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:520
+#: src/olympia/editors/helpers.py:593
 msgid "This will mark the files as preliminarily reviewed."
 msgstr ""
 
-#: src/olympia/editors/helpers.py:522
+#: src/olympia/editors/helpers.py:595
 msgid "Use this form to request more information from the author. They will receive an email and be able to answer here. You will be notified by email when they reply."
 msgstr ""
 
-#: src/olympia/editors/helpers.py:526
+#: src/olympia/editors/helpers.py:599
 msgid ""
 "If you have concerns about this add-on's security, copyright issues, or other concerns that an administrator should look into, enter your comments in the area below. They will be sent to "
 "administrators, not the author."
 msgstr ""
 
-#: src/olympia/editors/helpers.py:532
+#: src/olympia/editors/helpers.py:605
 msgid "This will reject the add-on and remove it from the review queue."
 msgstr ""
 
-#: src/olympia/editors/helpers.py:534
-msgid "Make a comment on this version.  The author won't be able to see this."
+#: src/olympia/editors/helpers.py:607
+msgid "Make a comment on this version. The author won't be able to see this."
 msgstr ""
 
-#: src/olympia/editors/helpers.py:538
+#: src/olympia/editors/helpers.py:611
 msgid "This will reject the files and remove them from the review queue."
 msgstr ""
 
-#: src/olympia/editors/helpers.py:542
+#: src/olympia/editors/helpers.py:615
 msgid "This will mark the add-on as preliminarily reviewed. Future versions will undergo preliminary review."
 msgstr ""
 
-#: src/olympia/editors/helpers.py:547
+#: src/olympia/editors/helpers.py:620
 msgid "This will mark the files as preliminarily reviewed. Future versions will undergo preliminary review."
 msgstr ""
 
-#: src/olympia/editors/helpers.py:552
+#: src/olympia/editors/helpers.py:625
 msgid "Retain preliminary review"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:553
+#: src/olympia/editors/helpers.py:626
 msgid "This will retain the add-on as preliminarily reviewed. Future versions will undergo preliminary review."
 msgstr ""
 
-#: src/olympia/editors/helpers.py:558
+#: src/olympia/editors/helpers.py:631
 msgid "This will approve a sandboxed version of a public add-on to appear on the public side."
 msgstr ""
 
-#: src/olympia/editors/helpers.py:561
+#: src/olympia/editors/helpers.py:634
 msgid "This will reject a version of a public add-on and remove it from the queue."
 msgstr ""
 
-#: src/olympia/editors/helpers.py:564
+#: src/olympia/editors/helpers.py:637
 msgid "This will mark the add-on and its most recent version and files as public. Future versions will go into the sandbox until they are reviewed by an editor."
 msgstr ""
 
-#: src/olympia/editors/helpers.py:637
+#: src/olympia/editors/helpers.py:714
 msgid "add-on"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:940 src/olympia/editors/helpers.py:960
+#: src/olympia/editors/helpers.py:1020 src/olympia/editors/helpers.py:1040
 msgid "Flagged"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:944 src/olympia/editors/helpers.py:963
+#: src/olympia/editors/helpers.py:1024 src/olympia/editors/helpers.py:1043
 msgid "Updates"
 msgstr ""
 
@@ -7631,56 +7495,56 @@ msgstr ""
 msgid "A question about your Theme submission"
 msgstr ""
 
-#: src/olympia/editors/views.py:144
+#: src/olympia/editors/views.py:146
 msgid "New Add-ons (Under 5 days)"
 msgstr ""
 
-#: src/olympia/editors/views.py:145
+#: src/olympia/editors/views.py:147
 msgid "Passable (5 to 10 days)"
 msgstr ""
 
-#: src/olympia/editors/views.py:146
+#: src/olympia/editors/views.py:148
 msgid "Overdue (Over 10 days)"
 msgstr ""
 
-#: src/olympia/editors/views.py:532
+#: src/olympia/editors/views.py:539
 msgid "An unknown error occurred"
 msgstr ""
 
-#: src/olympia/editors/views.py:587
+#: src/olympia/editors/views.py:592
 msgid "Self-reviews are not allowed."
 msgstr ""
 
-#: src/olympia/editors/views.py:609
+#: src/olympia/editors/views.py:613
 msgid "Review successfully processed."
 msgstr ""
 
-#: src/olympia/editors/views.py:807
+#: src/olympia/editors/views.py:812
 msgid "was approved"
 msgstr ""
 
-#: src/olympia/editors/views.py:808
+#: src/olympia/editors/views.py:813
 msgid "given preliminary review"
 msgstr ""
 
-#: src/olympia/editors/views.py:809
+#: src/olympia/editors/views.py:814
 msgid "rejected"
 msgstr ""
 
-#: src/olympia/editors/views.py:810
+#: src/olympia/editors/views.py:815
 msgctxt "editors_review_history_nominated_adminreview"
 msgid "escalated"
 msgstr ""
 
-#: src/olympia/editors/views.py:812
+#: src/olympia/editors/views.py:817
 msgid "needs more information"
 msgstr ""
 
-#: src/olympia/editors/views.py:813
+#: src/olympia/editors/views.py:818
 msgid "needs super review"
 msgstr ""
 
-#: src/olympia/editors/views.py:814
+#: src/olympia/editors/views.py:819
 msgid "commented"
 msgstr ""
 
@@ -7725,28 +7589,28 @@ msgstr ""
 msgid "Unlisted Queues"
 msgstr ""
 
-#: src/olympia/editors/templates/editors/base.html:72 src/olympia/editors/templates/editors/performance.html:6
+#: src/olympia/editors/templates/editors/base.html:74 src/olympia/editors/templates/editors/performance.html:6
 msgid "Performance"
 msgstr ""
 
-#: src/olympia/editors/templates/editors/base.html:75 src/olympia/editors/templates/editors/themes/base.html:19 src/olympia/editors/templates/editors/themes/base.html:38
+#: src/olympia/editors/templates/editors/base.html:77 src/olympia/editors/templates/editors/themes/base.html:19 src/olympia/editors/templates/editors/themes/base.html:38
 msgid "Logs"
 msgstr ""
 
-#: src/olympia/editors/templates/editors/base.html:78 src/olympia/editors/templates/editors/reviewlog.html:4 src/olympia/editors/templates/editors/reviewlog.html:27
+#: src/olympia/editors/templates/editors/base.html:80 src/olympia/editors/templates/editors/reviewlog.html:4 src/olympia/editors/templates/editors/reviewlog.html:27
 msgid "Add-on Review Log"
 msgstr ""
 
-#: src/olympia/editors/templates/editors/base.html:80 src/olympia/editors/templates/editors/eventlog.html:4 src/olympia/editors/templates/editors/eventlog.html:8
+#: src/olympia/editors/templates/editors/base.html:82 src/olympia/editors/templates/editors/eventlog.html:4 src/olympia/editors/templates/editors/eventlog.html:8
 #: src/olympia/editors/templates/editors/eventlog_detail.html:4
 msgid "Moderated Review Log"
 msgstr ""
 
-#: src/olympia/editors/templates/editors/base.html:82 src/olympia/editors/templates/editors/beta_signed_log.html:4 src/olympia/editors/templates/editors/beta_signed_log.html:8
+#: src/olympia/editors/templates/editors/base.html:84 src/olympia/editors/templates/editors/beta_signed_log.html:4 src/olympia/editors/templates/editors/beta_signed_log.html:8
 msgid "Signed Beta Files Log"
 msgstr ""
 
-#: src/olympia/editors/templates/editors/base.html:87 src/olympia/editors/templates/editors/includes/daily-message.html:4
+#: src/olympia/editors/templates/editors/base.html:89 src/olympia/editors/templates/editors/includes/daily-message.html:4
 msgid "Announcement"
 msgstr ""
 
@@ -7967,45 +7831,45 @@ msgstr ""
 msgid "clear search"
 msgstr ""
 
-#: src/olympia/editors/templates/editors/queue.html:72 src/olympia/editors/templates/editors/queue.html:122
+#: src/olympia/editors/templates/editors/queue.html:78 src/olympia/editors/templates/editors/queue.html:128
 msgid "Process Reviews"
 msgstr ""
 
-#: src/olympia/editors/templates/editors/queue.html:80
+#: src/olympia/editors/templates/editors/queue.html:86
 msgid "Moderation actions:"
 msgstr ""
 
-#: src/olympia/editors/templates/editors/queue.html:90
+#: src/olympia/editors/templates/editors/queue.html:96
 #, python-format
 msgid "by %(user)s on %(date)s %(stars)s (%(locale)s)"
 msgstr ""
 
-#: src/olympia/editors/templates/editors/queue.html:106
+#: src/olympia/editors/templates/editors/queue.html:112
 #, python-format
 msgid "<strong>%(reason)s</strong> <span class=\"light\">Flagged by %(user)s on %(date)s</span>"
 msgstr ""
 
-#: src/olympia/editors/templates/editors/queue.html:119
-msgid "All reviews have been moderated.  Good work!"
+#: src/olympia/editors/templates/editors/queue.html:125
+msgid "All reviews have been moderated. Good work!"
 msgstr ""
 
-#: src/olympia/editors/templates/editors/queue.html:161
+#: src/olympia/editors/templates/editors/queue.html:167
 msgid "Version Notes / Notes for Reviewer"
 msgstr ""
 
-#: src/olympia/editors/templates/editors/queue.html:169
+#: src/olympia/editors/templates/editors/queue.html:175
 msgid "There are currently no add-ons of this type to review."
 msgstr ""
 
-#: src/olympia/editors/templates/editors/queue.html:181 src/olympia/editors/templates/editors/themes/queue_list.html:85
+#: src/olympia/editors/templates/editors/queue.html:187 src/olympia/editors/templates/editors/themes/queue_list.html:85
 msgid "Helpful Links:"
 msgstr ""
 
-#: src/olympia/editors/templates/editors/queue.html:182
+#: src/olympia/editors/templates/editors/queue.html:188
 msgid "Add-on Policy"
 msgstr ""
 
-#: src/olympia/editors/templates/editors/queue.html:184
+#: src/olympia/editors/templates/editors/queue.html:190
 msgid "Editors' Guide"
 msgstr ""
 
@@ -8068,10 +7932,7 @@ msgid "<strong>Warning!</strong> Another user was viewing this page before you."
 msgstr ""
 
 #: src/olympia/editors/templates/editors/review.html:237
-msgid ""
-"The whiteboard is the place to exchange information relevant to\n"
-"               this addon (whatever the version), between the developer and the\n"
-"               editor. This is visible and editable by both."
+msgid "The whiteboard is the place to exchange information relevant to this addon (whatever the version), between the developer and the editor. This is visible and editable by both."
 msgstr ""
 
 #: src/olympia/editors/templates/editors/review.html:241
@@ -8345,7 +8206,7 @@ msgstr ""
 msgid "Describe your reason for flagging"
 msgstr ""
 
-#: src/olympia/files/forms.py:88
+#: src/olympia/files/forms.py:90
 msgid "Cannot diff a version against itself"
 msgstr ""
 
@@ -8380,51 +8241,51 @@ msgstr ""
 msgid "There was an error accessing file %s."
 msgstr ""
 
-#: src/olympia/files/utils.py:343
+#: src/olympia/files/utils.py:340
 msgid "Could not parse uploaded file."
 msgstr ""
 
-#: src/olympia/files/utils.py:380
+#: src/olympia/files/utils.py:377
 msgid "Invalid file name in archive: {0}"
 msgstr ""
 
-#: src/olympia/files/utils.py:388
+#: src/olympia/files/utils.py:385
 msgid "File exceeding size limit in archive: {0}"
 msgstr ""
 
-#: src/olympia/files/utils.py:439
+#: src/olympia/files/utils.py:436
 msgid "Invalid archive."
 msgstr ""
 
-#: src/olympia/files/utils.py:529 src/olympia/files/utils.py:532
+#: src/olympia/files/utils.py:526 src/olympia/files/utils.py:529
 msgid "Could not parse the manifest file."
 msgstr ""
 
-#: src/olympia/files/utils.py:551
+#: src/olympia/files/utils.py:548
 msgid "Could not find an add-on ID."
 msgstr ""
 
-#: src/olympia/files/utils.py:554
+#: src/olympia/files/utils.py:551
 msgid "Add-on ID must be 64 characters or less."
 msgstr ""
 
-#: src/olympia/files/utils.py:556
+#: src/olympia/files/utils.py:553
 msgid "Add-on ID doesn't match add-on."
 msgstr ""
 
-#: src/olympia/files/utils.py:564
+#: src/olympia/files/utils.py:561
 msgid "Duplicate add-on ID found."
 msgstr ""
 
-#: src/olympia/files/utils.py:567
+#: src/olympia/files/utils.py:564
 msgid "Version numbers should have fewer than 32 characters."
 msgstr ""
 
-#: src/olympia/files/utils.py:570
+#: src/olympia/files/utils.py:567
 msgid "Version numbers should only contain letters, numbers, and these punctuation characters: +*.-_."
 msgstr ""
 
-#: src/olympia/files/utils.py:587
+#: src/olympia/files/utils.py:584
 msgid "<em:type> doesn't match add-on"
 msgstr ""
 
@@ -8523,6 +8384,10 @@ msgstr ""
 
 #: src/olympia/files/templates/files/viewer.html:134
 msgid "Fetching file."
+msgstr ""
+
+#: src/olympia/legacy_api/views.py:255
+msgid "Not implemented yet."
 msgstr ""
 
 #: src/olympia/lib/constants.py:6
@@ -9181,10 +9046,6 @@ msgstr ""
 msgid "Zimbabwe Dollar"
 msgstr ""
 
-#: src/olympia/lib/video/ffmpeg.py:112 src/olympia/lib/video/totem.py:81
-msgid "Videos must be in WebM."
-msgstr ""
-
 #: src/olympia/pages/templates/pages/about.lhtml:3 src/olympia/pages/templates/pages/about.lhtml:10
 msgid "About Mozilla Add-ons"
 msgstr ""
@@ -9196,7 +9057,7 @@ msgstr ""
 #: src/olympia/pages/templates/pages/about.lhtml:13
 msgid ""
 "addons.mozilla.org, commonly known as \"AMO\", is Mozilla's official site for add-ons to Mozilla software, such as Firefox, Thunderbird, and SeaMonkey. Add-ons let you add new features and change "
-"the way your browser or application works.  Take a look around and explore the thousands of ways to customize the way you do things online."
+"the way your browser or application works. Take a look around and explore the thousands of ways to customize the way you do things online."
 msgstr ""
 
 #: src/olympia/pages/templates/pages/about.lhtml:19
@@ -9541,7 +9402,7 @@ msgstr ""
 msgid ""
 "Yes. It's possible, but some of the functionality provided by these libraries are available through XPCOM, XUL, and JavaScript. In addition, authors should take care if libraries modify primitive "
 "object prototypes (String.prototype, Date.prototype, etc.) and/or define global functions (eg. the $ function). These are prone to cause conflict with other add-ons, in particular if different add-"
-"ons use different versions of libraries and so on. Developers need to be very, very careful with using them.  Mozilla does not offer documentation on using them to build add-ons."
+"ons use different versions of libraries and so on. Developers need to be very, very careful with using them. Mozilla does not offer documentation on using them to build add-ons."
 msgstr ""
 
 #: src/olympia/pages/templates/pages/dev_faq.html:165
@@ -9655,8 +9516,8 @@ msgstr ""
 #, python-format
 msgid ""
 "Yes. Many developers choose to host their own add-ons. Choosing to host your add-on on <a href=\"%(amo_url)s\">Mozilla's add-on site</a>, though, allows for much greater exposure to your add-on due "
-"to the large volume of visitors to the site.  <a href=\"%(md_url)s\">mozdev.org</a> offers free project hosting for Mozilla applications and extensions providing developers with tools to help "
-"manage source code, version control, bug tracking and documentation."
+"to the large volume of visitors to the site. <a href=\"%(md_url)s\">mozdev.org</a> offers free project hosting for Mozilla applications and extensions providing developers with tools to help manage "
+"source code, version control, bug tracking and documentation."
 msgstr ""
 
 #: src/olympia/pages/templates/pages/dev_faq.html:277
@@ -9704,7 +9565,7 @@ msgstr ""
 #: src/olympia/pages/templates/pages/dev_faq.html:314
 #, python-format
 msgid ""
-"Yes. Mozilla's <a href=\"%(p_url)s\">Add-on Policy</a> describes what is an acceptable submission. This policy is subject to change without notice.  In addition, the AMO editorial team uses the <a "
+"Yes. Mozilla's <a href=\"%(p_url)s\">Add-on Policy</a> describes what is an acceptable submission. This policy is subject to change without notice. In addition, the AMO editorial team uses the <a "
 "href=\"%(g_url)s\">Editors Reviewing Guide</a> to ensure that your add-on meets specific guidelines for functionality and security."
 msgstr ""
 
@@ -9821,7 +9682,7 @@ msgstr ""
 #: src/olympia/pages/templates/pages/dev_faq.html:434
 #, python-format
 msgid ""
-"This is why it's very important to read the <a href=\"%(g_url)s\">Editors Reviewing Guide</a> to ensure that your add-on is setup as expected.  It's also a good idea to read the blog post, <a href="
+"This is why it's very important to read the <a href=\"%(g_url)s\">Editors Reviewing Guide</a> to ensure that your add-on is setup as expected. It's also a good idea to read the blog post, <a href="
 "\"%(blog_url)s\">Successfully Getting your Add-on Reviewed</a> which provides excellent insight into ensuring a smooth review of your add-on."
 msgstr ""
 
@@ -9928,7 +9789,7 @@ msgstr ""
 
 #: src/olympia/pages/templates/pages/dev_faq.html:572
 msgid ""
-"Free Software Foundation provides short summaries of the key open source licenses, including whether the license qualifies as a free software license or a copyleft license.  Also includes a "
+"Free Software Foundation provides short summaries of the key open source licenses, including whether the license qualifies as a free software license or a copyleft license. Also includes a "
 "discussion of what constitutes a free software license or a copyleft license (e.g., a Copyleft license is a general method for making a program or other work free, and requiring all modified and "
 "extended versions of the program to be free as well.)"
 msgstr ""
@@ -10106,19 +9967,13 @@ msgid "Add-on Gallery"
 msgstr ""
 
 #: src/olympia/pages/templates/pages/faq.html:171
-msgid ""
-"How do I choose between add-ons that seem to do the same\n"
-"    thing?"
+msgid "How do I choose between add-ons that seem to do the same thing?"
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:173
+#: src/olympia/pages/templates/pages/faq.html:172
 msgid ""
-"There are often several add-ons that have similar features. To\n"
-"    figure out which is right for you, read the entire description of the\n"
-"    add-on and view its screenshots. If there are still several in the running,\n"
-"    read through the add-on's ratings, user reviews, and statistics to see\n"
-"    which is most liked by other users. Remember that you can also just try\n"
-"    out both and see which you like better."
+"There are often several add-ons that have similar features. To figure out which is right for you, read the entire description of the add-on and view its screenshots. If there are still several in "
+"the running, read through the add-on's ratings, user reviews, and statistics to see which is most liked by other users. Remember that you can also just try out both and see which you like better."
 msgstr ""
 
 #: src/olympia/pages/templates/pages/faq.html:180
@@ -10159,80 +10014,67 @@ msgid "How much do add-ons cost to purchase?"
 msgstr ""
 
 #: src/olympia/pages/templates/pages/faq.html:207
-msgid ""
-"Add-ons hosted in our gallery are free unless clearly marked\n"
-"    otherwise."
+msgid "Add-ons hosted in our gallery are free unless clearly marked otherwise."
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:210
+#: src/olympia/pages/templates/pages/faq.html:209
 msgid "What does it mean when an add-on asks for contributions?"
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:211
+#: src/olympia/pages/templates/pages/faq.html:210
 msgid ""
-"Some add-on authors request users who enjoy an add-on to\n"
-"        contribute to its development by making a monetary contribution. These\n"
-"        contributions go directly to the developer unless a third party is\n"
-"        indicated, such as the non-profit Mozilla Foundation."
+"Some add-on authors request users who enjoy an add-on to contribute to its development by making a monetary contribution. These contributions go directly to the developer unless a third party is "
+"indicated, such as the non-profit Mozilla Foundation."
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:216
+#: src/olympia/pages/templates/pages/faq.html:215
 msgid "What are beta add-ons?"
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:218
+#: src/olympia/pages/templates/pages/faq.html:217
 msgid ""
-"Beta add-ons are unreviewed versions which represent the\n"
-"        latest work of an add-on author. While different authors have different\n"
-"        standards for beta code quality, you should assume that these add-ons\n"
-"        are less stable than the general add-on releases."
+"Beta add-ons are unreviewed versions which represent the latest work of an add-on author. While different authors have different standards for beta code quality, you should assume that these add-"
+"ons are less stable than the general add-on releases."
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:222
+#: src/olympia/pages/templates/pages/faq.html:221
 msgid ""
 "Please note that when you install an add-on from the \"Beta Version\" section of an add-on's listing, you will continue to receive updates for that add-on as they become available. Like the initial "
 "version you installed, all beta releases are unreviewed by Mozilla and may harm your computer."
 msgstr ""
 
+#: src/olympia/pages/templates/pages/faq.html:228
+msgid "What does it mean when an add-on is flagged as slow?"
+msgstr ""
+
 #: src/olympia/pages/templates/pages/faq.html:229
-msgid ""
-"What does it mean when an add-on is flagged as\n"
-"    slow?"
+msgid "Most add-ons load code and resources at the same time Firefox is starting up. In most cases the impact in start-up time is minimal, but some add-ons can cause a noticeable slowdown."
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:231
-msgid ""
-"Most add-ons load code and resources at the same time Firefox\n"
-"        is starting up. In most cases the impact in start-up time is minimal,\n"
-"        but some add-ons can cause a noticeable slowdown."
-msgstr ""
-
-#: src/olympia/pages/templates/pages/faq.html:236
+#: src/olympia/pages/templates/pages/faq.html:234
 msgid "How do I report an inappropriate or spam user review?"
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:237
+#: src/olympia/pages/templates/pages/faq.html:235
 msgid ""
-"To report a user review of an add-on, log in with your account\n"
-"    and visit the add-on's reviews page. Find the review you wish to report,\n"
-"    click \"Report this review\" and select a reason. Our editorial team will\n"
-"    investigate the review and take appropriate action."
+"To report a user review of an add-on, log in with your account and visit the add-on's reviews page. Find the review you wish to report, click \"Report this review\" and select a reason. Our "
+"editorial team will investigate the review and take appropriate action."
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:242
+#: src/olympia/pages/templates/pages/faq.html:240
 msgid "How do I report a bug or contact the Mozilla Add-ons team?"
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:243
+#: src/olympia/pages/templates/pages/faq.html:241
 #, python-format
 msgid "Please visit our <a href=\"%(contact_url)s\">Contact page</a>."
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:246
+#: src/olympia/pages/templates/pages/faq.html:244
 msgid "What is a Source Code License?"
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:247
+#: src/olympia/pages/templates/pages/faq.html:245
 #, python-format
 msgid ""
 "The source code used to create an add-on is an exclusive copyright of the add-on author, unless otherwise declared in a source code license. Many add-ons on this site have <a href=\"%(url)s\" lang="
@@ -10240,60 +10082,60 @@ msgid ""
 "the GPL or BSD licenses instead of making up their own."
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:256
+#: src/olympia/pages/templates/pages/faq.html:254
 #, python-format
 msgid "Firefox and other Mozilla software are <a href=\"%(url)s\">open source</a>."
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:264
+#: src/olympia/pages/templates/pages/faq.html:262
 msgid "Collections and Favorites"
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:267
+#: src/olympia/pages/templates/pages/faq.html:265
 msgid "What is a collection?"
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:268
+#: src/olympia/pages/templates/pages/faq.html:266
 msgid "Collections are groups of related add-ons created by users to share."
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:270
+#: src/olympia/pages/templates/pages/faq.html:268
 msgid "What is the My Favorites collection?"
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:271
+#: src/olympia/pages/templates/pages/faq.html:269
 msgid "Favorite add-ons are add-ons that you have bookmarked to easily get back to later. You can add an add-on to your favorites collection by clicking \"Add to favorites\" on its details page."
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:275 src/olympia/templates/menu_links.html:13 src/olympia/templates/impala/header_title.html:17
+#: src/olympia/pages/templates/pages/faq.html:273 src/olympia/templates/menu_links.html:13 src/olympia/templates/impala/header_title.html:17
 msgid "Mobile Add-ons"
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:278
+#: src/olympia/pages/templates/pages/faq.html:276
 msgid "What are mobile add-ons?"
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:279
+#: src/olympia/pages/templates/pages/faq.html:277
 #, python-format
 msgid ""
 "Mobile add-ons work with <a href=\"%(mobile_url)s\">Firefox for Mobile</a> and add or modify functionality just like desktop add-ons. You can find add-ons that work with Firefox for Mobile in our "
 "<a href=\"%(gallery_url)s\">gallery</a>."
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:288
+#: src/olympia/pages/templates/pages/faq.html:286
 msgid "Developer Topics"
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:289
+#: src/olympia/pages/templates/pages/faq.html:287
 #, python-format
 msgid "Please see our <a href=\"%(faq_url)s\">Developer FAQ</a> and <a href=\"%(hub_url)s\">Developer Hub</a> for answers to add-on developer-related questions."
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:294
+#: src/olympia/pages/templates/pages/faq.html:292
 msgid "Still have questions?"
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:295
+#: src/olympia/pages/templates/pages/faq.html:293
 #, python-format
 msgid "For general Firefox support, visit our <a href=\"%(sumo_url)s\">support website</a>. For general add-on and website questions, visit our <a href=\"%(forum_url)s\">forum</a>."
 msgstr ""
@@ -10431,7 +10273,7 @@ msgstr ""
 
 #: src/olympia/pages/templates/pages/sunbird.html:29
 msgid ""
-"Development on the Sunbird project has halted and its final release was on March 30, 2010.  We've been proud to host Sunbird add-ons on this site but as the project is no longer maintained we have "
+"Development on the Sunbird project has halted and its final release was on March 30, 2010. We've been proud to host Sunbird add-ons on this site but as the project is no longer maintained we have "
 "disabled our support for the add-ons."
 msgstr ""
 
@@ -10509,7 +10351,7 @@ msgstr ""
 #, python-format
 msgid ""
 "<h2>Keep these tips in mind:</h2> <ul> <li> Write like you're telling a friend about your experience with the add-on. Give specifics and helpful details, such as what features you liked and/or "
-"disliked, how easy to use it is, and any disadvantages it has.  Avoid generic language such as calling it \"Great\" or \"Bad\" unless you can give reasons why you believe this is so. </li> <li> "
+"disliked, how easy to use it is, and any disadvantages it has. Avoid generic language such as calling it \"Great\" or \"Bad\" unless you can give reasons why you believe this is so. </li> <li> "
 "Please do not post bug reports in reviews. We do not make your email address available to add-on developers and they may need to contact you to help resolve your issue. See the <a href=\"%(support)s"
 "\">support section</a> to find out where to get assistance for this add-on. </li> <li>Please keep reviews clean, avoid the use of improper language and do not post any personal information. </li> </"
 "ul> <p>Please read the <a href=\"%(guide)s\" target=\"_blank\">Review Guidelines</a> for more detail about user add-on reviews.</p>"
@@ -10745,16 +10587,16 @@ msgstr ""
 
 #. L10n: {0} is an application, such as Firefox. This means "any version of
 #. Firefox."
-#: src/olympia/search/views.py:554
+#: src/olympia/search/views.py:547
 msgid "Any {0}"
 msgstr ""
 
 #. L10n: "All Systems" means show everything regardless of platform.
-#: src/olympia/search/views.py:589
+#: src/olympia/search/views.py:582
 msgid "All Systems"
 msgstr ""
 
-#: src/olympia/search/views.py:600
+#: src/olympia/search/views.py:593
 msgid "All Tags"
 msgstr ""
 
@@ -10928,31 +10770,31 @@ msgstr ""
 msgid "Share this Collection"
 msgstr ""
 
-#: src/olympia/signing/views.py:30 src/olympia/templates/base.html:75 src/olympia/templates/impala/base.html:115
+#: src/olympia/signing/views.py:33 src/olympia/templates/base.html:71 src/olympia/templates/impala/base.html:112
 msgid "Some features are temporarily disabled while we perform website maintenance. We'll be back to full capacity shortly."
 msgstr ""
 
-#: src/olympia/signing/views.py:53
+#: src/olympia/signing/views.py:56
 msgid "Could not find add-on with id \"{}\"."
 msgstr ""
 
-#: src/olympia/signing/views.py:67
+#: src/olympia/signing/views.py:70
 msgid "You do not own this addon."
 msgstr ""
 
-#: src/olympia/signing/views.py:82
+#: src/olympia/signing/views.py:87
 msgid "Missing \"upload\" key in multipart file data."
 msgstr ""
 
-#: src/olympia/signing/views.py:96
+#: src/olympia/signing/views.py:101
 msgid "Version does not match the manifest file."
 msgstr ""
 
-#: src/olympia/signing/views.py:100
+#: src/olympia/signing/views.py:105
 msgid "Version already exists."
 msgstr ""
 
-#: src/olympia/signing/views.py:136
+#: src/olympia/signing/views.py:141
 msgid "No uploaded file for that addon and version."
 msgstr ""
 
@@ -11065,89 +10907,89 @@ msgstr ""
 msgid "Statistics Dashboard :: Add-ons for {0}"
 msgstr ""
 
-#: src/olympia/stats/templates/stats/stats.html:30
-msgid "Controls:"
-msgstr ""
-
-#: src/olympia/stats/templates/stats/stats.html:33
-msgid "reset zoom"
-msgstr ""
-
-#: src/olympia/stats/templates/stats/stats.html:40
-msgid "Group by:"
-msgstr ""
-
-#: src/olympia/stats/templates/stats/stats.html:42
-msgid "day"
-msgstr ""
-
-#: src/olympia/stats/templates/stats/stats.html:45
-msgid "week"
-msgstr ""
-
-#: src/olympia/stats/templates/stats/stats.html:48
-msgid "month"
-msgstr ""
-
-#: src/olympia/stats/templates/stats/stats.html:54
-msgid "For last:"
-msgstr ""
-
-#: src/olympia/stats/templates/stats/stats.html:57
-msgid "7 days"
-msgstr ""
-
-#: src/olympia/stats/templates/stats/stats.html:60
-msgid "30 days"
-msgstr ""
-
-#: src/olympia/stats/templates/stats/stats.html:63
-msgid "90 days"
-msgstr ""
-
-#: src/olympia/stats/templates/stats/stats.html:66
-msgid "365 days"
-msgstr ""
-
-#: src/olympia/stats/templates/stats/stats.html:69
-msgid "Custom..."
-msgstr ""
-
 #. {0} is an add-on name
-#: src/olympia/stats/templates/stats/stats.html:88 src/olympia/stats/templates/stats/stats.html:91
+#: src/olympia/stats/templates/stats/stats.html:44 src/olympia/stats/templates/stats/stats.html:47
 msgid "Statistics for {0}"
 msgstr ""
 
-#: src/olympia/stats/templates/stats/stats.html:94
+#: src/olympia/stats/templates/stats/stats.html:50
 msgid "Statistics Dashboard"
 msgstr ""
 
-#: src/olympia/stats/templates/stats/stats.html:104
+#: src/olympia/stats/templates/stats/stats.html:57
+msgid "Controls:"
+msgstr ""
+
+#: src/olympia/stats/templates/stats/stats.html:60
+msgid "reset zoom"
+msgstr ""
+
+#: src/olympia/stats/templates/stats/stats.html:67
+msgid "Group by:"
+msgstr ""
+
+#: src/olympia/stats/templates/stats/stats.html:69
+msgid "day"
+msgstr ""
+
+#: src/olympia/stats/templates/stats/stats.html:72
+msgid "week"
+msgstr ""
+
+#: src/olympia/stats/templates/stats/stats.html:75
+msgid "month"
+msgstr ""
+
+#: src/olympia/stats/templates/stats/stats.html:81
+msgid "For last:"
+msgstr ""
+
+#: src/olympia/stats/templates/stats/stats.html:84
+msgid "7 days"
+msgstr ""
+
+#: src/olympia/stats/templates/stats/stats.html:87
+msgid "30 days"
+msgstr ""
+
+#: src/olympia/stats/templates/stats/stats.html:90
+msgid "90 days"
+msgstr ""
+
+#: src/olympia/stats/templates/stats/stats.html:93
+msgid "365 days"
+msgstr ""
+
+#: src/olympia/stats/templates/stats/stats.html:96
+msgid "Custom..."
+msgstr ""
+
+#: src/olympia/stats/templates/stats/stats.html:106
 msgid "Statistics processing is currently disabled, so recent data is unavailable. The statistics are still being collected and this page will be updated soon with the missing data."
 msgstr ""
 
-#: src/olympia/stats/templates/stats/stats.html:110
+#: src/olympia/stats/templates/stats/stats.html:112
 msgid "Loading the latest data&hellip;"
 msgstr ""
 
-#: src/olympia/stats/templates/stats/stats.html:142 src/olympia/stats/templates/stats/reports/overview.html:25 src/olympia/stats/templates/stats/reports/overview.html:37
+#: src/olympia/stats/templates/stats/stats.html:144 src/olympia/stats/templates/stats/reports/overview.html:25 src/olympia/stats/templates/stats/reports/overview.html:37
 #: src/olympia/stats/templates/stats/reports/overview.html:49
 msgid "No data available."
 msgstr ""
 
-#: src/olympia/stats/templates/stats/stats.html:177
+#: src/olympia/stats/templates/stats/stats.html:179
 msgid "This dashboard is currently <b>public</b>."
 msgstr ""
 
-#: src/olympia/stats/templates/stats/stats.html:179
+#: src/olympia/stats/templates/stats/stats.html:181
 msgid "Contribution stats are currently <b>private</b>."
 msgstr ""
 
-#: src/olympia/stats/templates/stats/stats.html:182
+#: src/olympia/stats/templates/stats/stats.html:184
 msgid "This dashboard is currently <b>private</b>."
 msgstr ""
 
-#: src/olympia/stats/templates/stats/stats.html:185
+#: src/olympia/stats/templates/stats/stats.html:187
 msgid "Change settings."
 msgstr ""
 
@@ -11299,15 +11141,6 @@ msgstr ""
 msgid "Application versions by Date"
 msgstr ""
 
-#: src/olympia/tags/templates/tags/top_cloud.html:4
-msgid "Top {0} Tags"
-msgstr ""
-
-#. {0} is the current application name
-#: src/olympia/tags/templates/tags/top_cloud.html:14
-msgid "{0} Top Tags"
-msgstr ""
-
 #: src/olympia/templates/amo_footer.html:6 src/olympia/templates/includes/lang_switcher.html:2
 msgid "Other languages"
 msgstr ""
@@ -11316,11 +11149,11 @@ msgstr ""
 msgid "Mozilla Add-ons"
 msgstr ""
 
-#: src/olympia/templates/base.html:91 src/olympia/templates/impala/base.html:81
+#: src/olympia/templates/base.html:89 src/olympia/templates/impala/base.html:78
 msgid "Find add-ons for other applications"
 msgstr ""
 
-#: src/olympia/templates/base.html:92 src/olympia/templates/impala/base.html:81
+#: src/olympia/templates/base.html:90 src/olympia/templates/impala/base.html:78
 msgid "Other Applications"
 msgstr ""
 
@@ -11345,7 +11178,7 @@ msgid "View Mobile Site"
 msgstr ""
 
 #: src/olympia/templates/copyright.html:7
-msgid "Site Status "
+msgid "Site Status"
 msgstr ""
 
 #: src/olympia/templates/footer.html:3
@@ -11445,35 +11278,35 @@ msgstr ""
 msgid "<a href=\"%(reg)s\">Register</a> or <a href=\"%(login)s\">Log in</a>"
 msgstr ""
 
-#: src/olympia/templates/impala/base.html:126
+#: src/olympia/templates/impala/base.html:123
 #, python-format
 msgid "To try the thousands of add-ons available here, download <a href=\"%(url)s\">Mozilla Firefox</a>, a fast, free way to surf the Web!"
 msgstr ""
 
-#: src/olympia/templates/impala/base.html:138
+#: src/olympia/templates/impala/base.html:135
 #, python-format
 msgid "Add-ons is switching to Firefox Accounts for login. <a href=\"%(url)s\" class=\"fxa-login\">Sign in now to transfer your account.</a>"
 msgstr ""
 
 #. {0} is an application, such as Firefox.
-#: src/olympia/templates/impala/base.html:148
+#: src/olympia/templates/impala/base.html:145
 msgid "Welcome to {0} Add-ons."
 msgstr ""
 
-#: src/olympia/templates/impala/base.html:151
+#: src/olympia/templates/impala/base.html:148
 msgid "Choose from thousands of extra features and styles to make Firefox your own."
 msgstr ""
 
-#: src/olympia/templates/impala/base.html:156
+#: src/olympia/templates/impala/base.html:153
 #, python-format
 msgid "Add extra features and styles to make %(app)s your own."
 msgstr ""
 
-#: src/olympia/templates/impala/base.html:164
+#: src/olympia/templates/impala/base.html:161
 msgid "On the go?"
 msgstr ""
 
-#: src/olympia/templates/impala/base.html:166
+#: src/olympia/templates/impala/base.html:163
 msgid "Check out our <a class=\"mobile-link\" href=\"#\">Mobile Add-ons site</a>."
 msgstr ""
 
@@ -11697,19 +11530,19 @@ msgstr ""
 
 #. L10n: {id} will be something like "13ad6a", just a random number
 #. to differentiate this user from other anonymous users.
-#: src/olympia/users/models.py:353
+#: src/olympia/users/models.py:362
 msgid "Anonymous user {id}"
 msgstr ""
 
-#: src/olympia/users/models.py:410
+#: src/olympia/users/models.py:419
 msgid "Your account has been restricted"
 msgstr ""
 
-#: src/olympia/users/models.py:480
+#: src/olympia/users/models.py:489
 msgid "Please confirm your email address"
 msgstr ""
 
-#: src/olympia/users/models.py:506
+#: src/olympia/users/models.py:515
 msgid "My Mobile Add-ons"
 msgstr ""
 
@@ -11986,7 +11819,7 @@ msgstr ""
 
 #: src/olympia/users/templates/users/edit.html:70
 #, python-format
-msgid "Change your password.  If you forgot your password, you can <a href=\"%(reset_url)s\">use the reset form</a>."
+msgid "Change your password. If you forgot your password, you can <a href=\"%(reset_url)s\">use the reset form</a>."
 msgstr ""
 
 #: src/olympia/users/templates/users/edit.html:76
@@ -12006,7 +11839,7 @@ msgid "Profile"
 msgstr ""
 
 #: src/olympia/users/templates/users/edit.html:100
-msgid "Give us a bit more information about yourself.  All these fields are optional, but they'll help other users get to know you better."
+msgid "Give us a bit more information about yourself. All these fields are optional, but they'll help other users get to know you better."
 msgstr ""
 
 #: src/olympia/users/templates/users/edit.html:124
@@ -12222,7 +12055,7 @@ msgid "Confirm password"
 msgstr ""
 
 #: src/olympia/users/templates/users/pwreset_confirm.html:47
-msgid "The password reset link was invalid, possibly because it has already been used.  Please request a new password reset."
+msgid "The password reset link was invalid, possibly because it has already been used. Please request a new password reset."
 msgstr ""
 
 #: src/olympia/users/templates/users/pwreset_request.html:15
@@ -12408,7 +12241,7 @@ msgstr ""
 
 #: src/olympia/users/templates/users/unsubscribe.html:30
 #, python-format
-msgid "Unfortunately, we weren't able to unsubscribe you.  The link you clicked is invalid. However, you can unsubscribe still unsubscribe on your <a href=\"%(edit_url)s\">edit profile page</a>."
+msgid "Unfortunately, we weren't able to unsubscribe you. The link you clicked is invalid. However, you can unsubscribe still unsubscribe on your <a href=\"%(edit_url)s\">edit profile page</a>."
 msgstr ""
 
 #: src/olympia/users/templates/users/vcard.html:2
@@ -12462,15 +12295,15 @@ msgstr ""
 msgid "Version History with Changelogs"
 msgstr ""
 
-#: src/olympia/versions/models.py:314
+#: src/olympia/versions/models.py:313
 msgid "Add-on uses binary components."
 msgstr ""
 
-#: src/olympia/versions/models.py:317
+#: src/olympia/versions/models.py:316
 msgid "Add-on has opted into strict compatibility checking."
 msgstr ""
 
-#: src/olympia/versions/models.py:715
+#: src/olympia/versions/models.py:711
 msgid "{app} {min} and later"
 msgstr ""
 
@@ -12545,4 +12378,8 @@ msgstr ""
 
 #: src/olympia/zadmin/forms.py:105
 msgid "Log emails instead of sending"
+msgstr ""
+
+#: src/olympia/zadmin/forms.py:215
+msgid "Deleted versions can`t be changed."
 msgstr ""

--- a/locale/ff/LC_MESSAGES/djangojs.po
+++ b/locale/ff/LC_MESSAGES/djangojs.po
@@ -1,1216 +1,1236 @@
-
 #, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2016-02-24 21:23+0000\n"
+"POT-Creation-Date: 2016-04-18 15:47+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
+"Language: \n"
 "MIME-Version: 1.0\n"
-"Content-Type: text/plain; charset=utf-8\n"
+"Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Generated-By: Babel 2.2.0\n"
 
-#: static/js/common/ratingwidget.js:31
+#: static/js/common-all.js:1426 static/js/impala-all.js:1511 static/js/zamboni/discovery-all.js:12598 static/js/zamboni/init.js:28 static/js/zamboni/mobile-all.js:14945
+msgid "This feature is temporarily disabled while we perform website maintenance. Please check back a little later."
+msgstr ""
+
+#. L10n: {0} is an app name like Firefox.
+#: static/js/common-all.js:1837 static/js/impala-all.js:1922 static/js/zamboni/buttons.js:73 static/js/zamboni/discovery-all.js:13108
+msgid "Accept and Install"
+msgstr ""
+
+#: static/js/common-all.js:1837 static/js/impala-all.js:1922 static/js/zamboni/buttons.js:73 static/js/zamboni/discovery-all.js:13108
+msgid "Add to {0}"
+msgstr ""
+
+#: static/js/common-all.js:1842 static/js/impala-all.js:1927 static/js/zamboni/buttons.js:78 static/js/zamboni/discovery-all.js:13113
+msgid "Download Now"
+msgstr ""
+
+#: static/js/common-all.js:1883 static/js/impala-all.js:1968 static/js/zamboni/buttons.js:119 static/js/zamboni/discovery-all.js:13154
+msgid "Add-on has not been updated to support default-to-compatible."
+msgstr ""
+
+#: static/js/common-all.js:1888 static/js/impala-all.js:1973 static/js/zamboni/buttons.js:124 static/js/zamboni/discovery-all.js:13159
+msgid "You need to be using Firefox 10.0 or higher."
+msgstr ""
+
+#: static/js/common-all.js:1900 static/js/impala-all.js:1985 static/js/zamboni/buttons.js:136 static/js/zamboni/discovery-all.js:13171
+msgid "Mozilla has marked this version as incompatible with your Firefox version."
+msgstr ""
+
+#. L10n: {0} is an platform like Windows or Linux.
+#: static/js/common-all.js:1981 static/js/impala-all.js:2066 static/js/zamboni/buttons.js:217 static/js/zamboni/discovery-all.js:13252
+msgid "Install for {0} anyway"
+msgstr ""
+
+#: static/js/common-all.js:1981 static/js/impala-all.js:2066 static/js/zamboni/buttons.js:217 static/js/zamboni/discovery-all.js:13252
+msgid "Download for {0} anyway"
+msgstr ""
+
+#: static/js/common-all.js:2038 static/js/impala-all.js:2123 static/js/zamboni/buttons.js:274 static/js/zamboni/discovery-all.js:13309
+msgid "Not available for your platform"
+msgstr ""
+
+#. L10n: {0} is an app name, {1} is the app version.
+#: static/js/common-all.js:2049 static/js/common-all.js:2086 static/js/impala-all.js:2134 static/js/impala-all.js:2171 static/js/zamboni/buttons.js:286 static/js/zamboni/buttons.js:324
+#: static/js/zamboni/discovery-all.js:13320 static/js/zamboni/discovery-all.js:13357
+msgid "Not available for {0} {1}"
+msgstr ""
+
+#: static/js/common-all.js:2112 static/js/impala-all.js:2197 static/js/zamboni/buttons.js:351 static/js/zamboni/discovery-all.js:13383
+msgid "Works with {app} {min} - {max}"
+msgstr ""
+
+#: static/js/common-all.js:2114 static/js/impala-all.js:2199 static/js/zamboni/buttons.js:353 static/js/zamboni/discovery-all.js:13385
+msgid "View other versions"
+msgstr ""
+
+#: static/js/common-all.js:2162 static/js/impala-all.js:2247 static/js/zamboni/buttons.js:401 static/js/zamboni/discovery-all.js:13433
+msgid "Only with Firefox — Get Firefox Now!"
+msgstr ""
+
+#: static/js/common-all.js:2278 static/js/impala-all.js:2363 static/js/zamboni/buttons.js:517 static/js/zamboni/discovery-all.js:13549 static/js/zamboni/mobile-all.js:15177
+#: static/js/zamboni/mobile/buttons.js:43
+msgid "Sorry, you need a Mozilla-based browser (such as Firefox) to install a search plugin."
+msgstr ""
+
+#: static/js/common-all.js:9088 static/js/impala-all.js:9649 static/js/zamboni/global.js:410
+msgid "Loading..."
+msgstr ""
+
+#. L10n: {0} is the number of characters left.
+#: static/js/common-all.js:9152 static/js/impala-all.js:9713 static/js/zamboni/global.js:474
+msgid "<b>{0}</b> character left."
+msgid_plural "<b>{0}</b> characters left."
+msgstr[0] ""
+msgstr[1] ""
+
+#: static/js/common-all.js:9589 static/js/common-min.js:6 static/js/impala-all.js:10052 static/js/impala-min.js:6 static/js/common/ratingwidget.js:31 static/js/zamboni/mobile-all.js:16123
+#: static/js/zamboni/mobile-min.js:6
 msgid "{0} star"
 msgid_plural "{0} stars"
 msgstr[0] ""
 msgstr[1] ""
 
-#: static/js/common/upload-addon.js:41 static/js/common/upload-image.js:128
+#: static/js/common-all.js:9676 static/js/common-min.js:6 static/js/impala-all.js:10139 static/js/impala-min.js:6 static/js/zamboni/l10n.js:45
+msgid "Remove this localization"
+msgstr ""
+
+#: static/js/common-all.js:10193 static/js/common-min.js:6 static/js/impala-all.js:10674 static/js/impala-min.js:6 static/js/zamboni/discovery-all.js:13678
+msgid "close"
+msgstr ""
+
+#: static/js/common-all.js:10860 static/js/common-min.js:6 static/js/impala-all.js:11481 static/js/impala-min.js:6 static/js/impala/reviews.js:23 static/js/zamboni/reviews.js:18
+msgid "Flagged for review"
+msgstr ""
+
+#: static/js/common-all.js:10876 static/js/common-min.js:6 static/js/impala-all.js:11498 static/js/impala-min.js:6 static/js/impala/reviews.js:40 static/js/zamboni/reviews.js:34
+msgid "Your input is required"
+msgstr ""
+
+#: static/js/common-all.js:10945 static/js/common-min.js:6 static/js/impala-all.js:11610 static/js/impala-min.js:7 static/js/impala/reviews.js:152 static/js/zamboni/reviews.js:103
+msgid "Marked for deletion"
+msgstr ""
+
+#: static/js/common-all.js:11573 static/js/common-min.js:7 static/js/impala-all.js:13809 static/js/impala-min.js:8 static/js/zamboni/collections.js:229
+msgid "Adding to Favorites&hellip;"
+msgstr ""
+
+#: static/js/common-all.js:11576 static/js/common-min.js:7 static/js/impala-all.js:13812 static/js/impala-min.js:8 static/js/zamboni/collections.js:232
+msgid "Removing Favorite&hellip;"
+msgstr ""
+
+#: static/js/common-all.js:11579 static/js/common-min.js:7 static/js/impala-all.js:13815 static/js/impala-min.js:8 static/js/zamboni/collections.js:235
+msgid "Add to Favorites"
+msgstr ""
+
+#: static/js/common-all.js:11582 static/js/common-min.js:7 static/js/impala-all.js:13818 static/js/impala-min.js:8 static/js/zamboni/collections.js:238
+msgid "Remove from Favorites"
+msgstr ""
+
+#: static/js/common-all.js:11647 static/js/common-min.js:7 static/js/impala-all.js:13883 static/js/impala-min.js:8 static/js/zamboni/collections.js:303
+msgid "Pending"
+msgstr ""
+
+#: static/js/common-all.js:11648 static/js/common-min.js:7 static/js/impala-all.js:13884 static/js/impala-min.js:8 static/js/zamboni/collections.js:304
+msgid "Add a comment"
+msgstr ""
+
+#: static/js/common-all.js:11648 static/js/common-min.js:7 static/js/impala-all.js:13884 static/js/impala-min.js:8 static/js/zamboni/collections.js:304
+msgid "Comment"
+msgstr ""
+
+#: static/js/common-all.js:11649 static/js/common-min.js:7 static/js/impala-all.js:13885 static/js/impala-min.js:8 static/js/zamboni/collections.js:305
+msgid "Remove this add-on from the collection"
+msgstr ""
+
+#: static/js/common-all.js:11649 static/js/common-all.js:11678 static/js/common-min.js:7 static/js/impala-all.js:13885 static/js/impala-all.js:13914 static/js/impala-min.js:8
+#: static/js/zamboni/collections.js:305 static/js/zamboni/collections.js:334
+msgid "Remove"
+msgstr ""
+
+#: static/js/common-all.js:11678 static/js/common-min.js:7 static/js/impala-all.js:13914 static/js/impala-min.js:8 static/js/zamboni/collections.js:334
+msgid "Remove this user as a contributor"
+msgstr ""
+
+#: static/js/common-all.js:11690 static/js/common-min.js:7 static/js/impala-all.js:13926 static/js/impala-min.js:8 static/js/zamboni/collections.js:346
+msgid "An email address is required."
+msgstr ""
+
+#: static/js/common-all.js:11708 static/js/common-min.js:7 static/js/impala-all.js:13944 static/js/impala-min.js:8 static/js/zamboni/collections.js:364
+msgid "You cannot add yourself as a contributor."
+msgstr ""
+
+#: static/js/common-all.js:11710 static/js/common-min.js:7 static/js/impala-all.js:13946 static/js/impala-min.js:8 static/js/zamboni/collections.js:366
+msgid "You have already added that user."
+msgstr ""
+
+#: static/js/common-all.js:11917 static/js/common-min.js:7 static/js/impala-all.js:14153 static/js/impala-min.js:8 static/js/zamboni/collections.js:573
+msgid "Add to favorites"
+msgstr ""
+
+#: static/js/common-all.js:11921 static/js/common-min.js:7 static/js/impala-all.js:14157 static/js/impala-min.js:8 static/js/zamboni/collections.js:577
+msgid "Remove from favorites"
+msgstr ""
+
+#: static/js/common-all.js:11939 static/js/common-min.js:7 static/js/impala-all.js:14175 static/js/impala-all.js:14233 static/js/impala-min.js:8 static/js/impala/collections.js:10
+#: static/js/zamboni/collections.js:595
+msgid "Follow this Collection"
+msgstr ""
+
+#: static/js/common-all.js:11948 static/js/common-min.js:7 static/js/impala-all.js:14184 static/js/impala-min.js:8 static/js/zamboni/collections.js:604
+msgid "Stop following"
+msgstr ""
+
+#: static/js/common-all.js:12096 static/js/common-min.js:7 static/js/zamboni/password-strength.js:20
+msgid "Password strength:"
+msgstr ""
+
+#: static/js/common-all.js:12102 static/js/common-min.js:7 static/js/zamboni/password-strength.js:26
+msgid "At least {0} character left."
+msgid_plural "At least {0} characters left."
+msgstr[0] ""
+msgstr[1] ""
+
+#: static/js/common-all.js:12286 static/js/common-min.js:7 static/js/impala-all.js:14632 static/js/impala-min.js:8 static/js/impala/suggestions.js:39
+msgid "Search themes for <b>{0}</b>"
+msgstr ""
+
+#: static/js/common-all.js:12288 static/js/common-min.js:7 static/js/impala-all.js:14634 static/js/impala-min.js:8 static/js/impala/suggestions.js:41
+msgid "Search apps for <b>{0}</b>"
+msgstr ""
+
+#: static/js/common-all.js:12290 static/js/common-min.js:7 static/js/impala-all.js:14636 static/js/impala-min.js:8 static/js/impala/suggestions.js:43
+msgid "Search add-ons for <b>{0}</b>"
+msgstr ""
+
+#: static/js/common-all.js:12521 static/js/common-min.js:7 static/js/impala-all.js:14867 static/js/impala-min.js:8 static/js/impala/site_suggestions.js:46
+msgid "Category"
+msgstr ""
+
+#. L10n: {0} is an app name.
+#: static/js/impala-all.js:11632 static/js/impala-min.js:7 static/js/impala/listing.js:11 static/js/zamboni/themes.js:13
+msgid "This theme is incompatible with your version of {0}"
+msgstr ""
+
+#: static/js/impala-all.js:12146 static/js/impala-all.js:14331 static/js/impala-min.js:7 static/js/impala-min.js:8 static/js/common/upload-image.js:97 static/js/impala/users.js:51
+#: static/js/zamboni/devhub-all.js:894 static/js/zamboni/devhub-min.js:1
+msgid "Images must be either PNG or JPG."
+msgstr ""
+
+#: static/js/impala-all.js:12150 static/js/impala-min.js:7 static/js/common/upload-image.js:101 static/js/zamboni/devhub-all.js:898 static/js/zamboni/devhub-min.js:1
+msgid "Videos must be in WebM."
+msgstr ""
+
+#: static/js/impala-all.js:12177 static/js/impala-min.js:7 static/js/common/upload-addon.js:41 static/js/common/upload-image.js:128 static/js/zamboni/devhub-all.js:272
+#: static/js/zamboni/devhub-all.js:925 static/js/zamboni/devhub-min.js:1
 msgid "There was a problem contacting the server."
 msgstr ""
 
-#: static/js/common/upload-addon.js:69
+#: static/js/impala-all.js:13298 static/js/impala-min.js:7 static/js/impala/persona_creation.js:60
+msgid "All Rights Reserved"
+msgstr ""
+
+#: static/js/impala-all.js:13302 static/js/impala-min.js:7 static/js/impala/persona_creation.js:64
+msgid "Creative Commons Attribution 3.0"
+msgstr ""
+
+#: static/js/impala-all.js:13307 static/js/impala-min.js:7 static/js/impala/persona_creation.js:69
+msgid "Creative Commons Attribution-NonCommercial 3.0"
+msgstr ""
+
+#: static/js/impala-all.js:13312 static/js/impala-min.js:7 static/js/impala/persona_creation.js:74
+msgid "Creative Commons Attribution-NonCommercial-NoDerivs 3.0"
+msgstr ""
+
+#: static/js/impala-all.js:13317 static/js/impala-min.js:7 static/js/impala/persona_creation.js:79
+msgid "Creative Commons Attribution-NonCommercial-Share Alike 3.0"
+msgstr ""
+
+#: static/js/impala-all.js:13322 static/js/impala-min.js:7 static/js/impala/persona_creation.js:84
+msgid "Creative Commons Attribution-NoDerivs 3.0"
+msgstr ""
+
+#: static/js/impala-all.js:13327 static/js/impala-min.js:7 static/js/impala/persona_creation.js:89
+msgid "Creative Commons Attribution-ShareAlike 3.0"
+msgstr ""
+
+#: static/js/impala-all.js:13530 static/js/impala-min.js:7 static/js/impala/persona_creation.js:292
+msgid "Your Theme's Name"
+msgstr ""
+
+#: static/js/impala-all.js:14242 static/js/impala-min.js:8 static/js/impala/collections.js:19
+msgid "Stop Following"
+msgstr ""
+
+#: static/js/impala-all.js:14243 static/js/impala-min.js:8 static/js/impala/collections.js:20
+msgid "Following"
+msgstr ""
+
+#: static/js/impala-all.js:14313 static/js/impala-min.js:8 static/js/impala/users.js:33
+msgid "use original"
+msgstr ""
+
+#: static/js/impala-all.js:14523 static/js/impala-min.js:8 static/js/impala/search.js:114
+msgid "Updating results&hellip;"
+msgstr ""
+
+#: static/js/common/upload-addon.js:69 static/js/zamboni/devhub-all.js:300 static/js/zamboni/devhub-min.js:1
 msgid "Select a file..."
 msgstr ""
 
-#: static/js/common/upload-addon.js:70
+#: static/js/common/upload-addon.js:70 static/js/zamboni/devhub-all.js:301 static/js/zamboni/devhub-min.js:1
 msgid "Your add-on should end with .xpi, .jar or .xml"
 msgstr ""
 
 #. L10n: {0} is the percent of the file that has been uploaded.
-#: static/js/common/upload-addon.js:104
+#: static/js/common/upload-addon.js:104 static/js/zamboni/devhub-all.js:335 static/js/zamboni/devhub-min.js:1
 #, python-format
 msgid "{0}% complete"
 msgstr ""
 
 #. L10n: "{bytes uploaded} of {total filesize}".
-#: static/js/common/upload-addon.js:107
+#: static/js/common/upload-addon.js:107 static/js/zamboni/devhub-all.js:338 static/js/zamboni/devhub-min.js:1
 msgid "{0} of {1}"
 msgstr ""
 
-#: static/js/common/upload-addon.js:140
+#: static/js/common/upload-addon.js:140 static/js/zamboni/devhub-all.js:371 static/js/zamboni/devhub-min.js:1
 msgid "Cancel"
 msgstr ""
 
-#: static/js/common/upload-addon.js:162
+#: static/js/common/upload-addon.js:162 static/js/zamboni/devhub-all.js:393 static/js/zamboni/devhub-min.js:1
 msgid "Uploading {0}"
 msgstr ""
 
-#: static/js/common/upload-addon.js:189
+#: static/js/common/upload-addon.js:189 static/js/zamboni/devhub-all.js:420 static/js/zamboni/devhub-min.js:1
 msgid "Error with {0}"
 msgstr ""
 
-#: static/js/common/upload-addon.js:194
+#: static/js/common/upload-addon.js:194 static/js/zamboni/devhub-all.js:425 static/js/zamboni/devhub-min.js:1
 msgid "Your add-on failed validation with {0} error."
 msgid_plural "Your add-on failed validation with {0} errors."
 msgstr[0] ""
 msgstr[1] ""
 
-#: static/js/common/upload-addon.js:208
+#: static/js/common/upload-addon.js:208 static/js/zamboni/devhub-all.js:439 static/js/zamboni/devhub-min.js:1
 msgid "&hellip;and {0} more"
 msgid_plural "&hellip;and {0} more"
 msgstr[0] ""
 msgstr[1] ""
 
-#: static/js/common/upload-addon.js:222 static/js/common/upload-addon.js:512
+#: static/js/common/upload-addon.js:222 static/js/common/upload-addon.js:497 static/js/zamboni/devhub-all.js:453 static/js/zamboni/devhub-all.js:743 static/js/zamboni/devhub-min.js:1
 msgid "See full validation report"
 msgstr ""
 
-#: static/js/common/upload-addon.js:234
+#: static/js/common/upload-addon.js:234 static/js/zamboni/devhub-all.js:465 static/js/zamboni/devhub-min.js:1
 msgid "Validating {0}"
 msgstr ""
 
 #. L10n: first argument is an HTTP status code
-#: static/js/common/upload-addon.js:273
+#: static/js/common/upload-addon.js:273 static/js/zamboni/devhub-all.js:504 static/js/zamboni/devhub-min.js:1
 msgid "Received an empty response from the server; status: {0}"
 msgstr ""
 
-#: static/js/common/upload-addon.js:373
+#: static/js/common/upload-addon.js:370 static/js/zamboni/devhub-all.js:604 static/js/zamboni/devhub-min.js:1
 msgid "Unexpected server error while validating."
 msgstr ""
 
-#: static/js/common/upload-addon.js:412
+#: static/js/common/upload-addon.js:409 static/js/zamboni/devhub-all.js:643 static/js/zamboni/devhub-min.js:1
 msgid "Finished validating {0}"
 msgstr ""
 
-#: static/js/common/upload-addon.js:418
+#: static/js/common/upload-addon.js:415 static/js/zamboni/devhub-all.js:649 static/js/zamboni/devhub-min.js:1
 msgid "Your add-on validation timed out, it will be manually reviewed."
 msgstr ""
 
-#: static/js/common/upload-addon.js:421
+#: static/js/common/upload-addon.js:418 static/js/zamboni/devhub-all.js:652 static/js/zamboni/devhub-min.js:1
 msgid "Your add-on was validated with no errors and {0} warning."
 msgid_plural "Your add-on was validated with no errors and {0} warnings."
 msgstr[0] ""
 msgstr[1] ""
 
-#: static/js/common/upload-addon.js:426
+#: static/js/common/upload-addon.js:423 static/js/zamboni/devhub-all.js:657 static/js/zamboni/devhub-min.js:1
 msgid "Your add-on was validated with no errors and {0} message."
 msgid_plural "Your add-on was validated with no errors and {0} messages."
 msgstr[0] ""
 msgstr[1] ""
 
-#: static/js/common/upload-addon.js:431
+#: static/js/common/upload-addon.js:428 static/js/zamboni/devhub-all.js:662 static/js/zamboni/devhub-min.js:1
 msgid "Your add-on was validated with no errors or warnings."
 msgstr ""
 
-#: static/js/common/upload-addon.js:446
+#: static/js/common/upload-addon.js:443 static/js/zamboni/devhub-all.js:677 static/js/zamboni/devhub-min.js:1
 msgid "Your submission will be automatically signed."
 msgstr ""
 
-#: static/js/common/upload-addon.js:465
+#: static/js/common/upload-addon.js:450 static/js/zamboni/devhub-all.js:696 static/js/zamboni/devhub-min.js:1
 msgid "Include detailed version notes (this can be done in the next step)."
 msgstr ""
 
-#: static/js/common/upload-addon.js:466
+#: static/js/common/upload-addon.js:451 static/js/zamboni/devhub-all.js:697 static/js/zamboni/devhub-min.js:1
 msgid "If your add-on requires an account to a website in order to be fully tested, include a test username and password in the Notes to Reviewer (this can be done in the next step)."
 msgstr ""
 
-#: static/js/common/upload-addon.js:467
+#: static/js/common/upload-addon.js:452 static/js/zamboni/devhub-all.js:698 static/js/zamboni/devhub-min.js:1
 msgid "If your add-on is intended for a limited audience you should choose Preliminary Review instead of Full Review."
 msgstr ""
 
-#: static/js/common/upload-addon.js:480
+#: static/js/common/upload-addon.js:465 static/js/zamboni/devhub-all.js:711 static/js/zamboni/devhub-min.js:1
 msgid "Add-on submission checklist"
 msgstr ""
 
-#: static/js/common/upload-addon.js:481
+#: static/js/common/upload-addon.js:466 static/js/zamboni/devhub-all.js:712 static/js/zamboni/devhub-min.js:1
 msgid "Please verify the following points before finalizing your submission. This will minimize delays or misunderstanding during the review process:"
 msgstr ""
 
-#: static/js/common/upload-addon.js:483
+#: static/js/common/upload-addon.js:468 static/js/zamboni/devhub-all.js:714 static/js/zamboni/devhub-min.js:1
 msgid ""
 "Compiled binaries, as well as minified or obfuscated scripts (excluding known libraries) need to have their sources submitted separately for review. Make sure that you use the source code upload "
 "field to avoid having your submission rejected."
 msgstr ""
 
-#: static/js/common/upload-addon.js:501
+#: static/js/common/upload-addon.js:486 static/js/zamboni/devhub-all.js:732 static/js/zamboni/devhub-min.js:1
 msgid "The validation process found these issues that can lead to rejections:"
 msgstr ""
 
-#: static/js/common/upload-addon.js:518
+#: static/js/common/upload-addon.js:503 static/js/zamboni/devhub-all.js:749 static/js/zamboni/devhub-min.js:1
 msgid "If you are unfamiliar with the add-ons review process, you can read about it here."
 msgstr ""
 
-#: static/js/common/upload-addon.js:555
+#: static/js/common/upload-addon.js:540 static/js/zamboni/devhub-all.js:786 static/js/zamboni/devhub-min.js:1
 msgid "Sorry, no supported platform has been found."
 msgstr ""
 
-#: static/js/common/upload-base.js:57
+#: static/js/common/upload-base.js:57 static/js/zamboni/devhub-all.js:187 static/js/zamboni/devhub-min.js:1
 msgid "The filetype you uploaded isn't recognized."
 msgstr ""
 
-#: static/js/common/upload-base.js:79
+#: static/js/common/upload-base.js:79 static/js/zamboni/devhub-all.js:209 static/js/zamboni/devhub-min.js:1
 msgid "You cancelled the upload."
 msgstr ""
 
-#: static/js/common/upload-image.js:97 static/js/impala/users.js:51
-msgid "Images must be either PNG or JPG."
-msgstr ""
-
-#: static/js/common/upload-image.js:101
-msgid "Videos must be in WebM."
-msgstr ""
-
-#: static/js/impala/collections.js:10 static/js/zamboni/collections.js:595
-msgid "Follow this Collection"
-msgstr ""
-
-#: static/js/impala/collections.js:19
-msgid "Stop Following"
-msgstr ""
-
-#: static/js/impala/collections.js:20
-msgid "Following"
-msgstr ""
-
-#. L10n: {0} is an app name.
-#: static/js/impala/listing.js:11 static/js/zamboni/themes.js:13
-msgid "This theme is incompatible with your version of {0}"
-msgstr ""
-
-#: static/js/impala/persona_creation.js:60
-msgid "All Rights Reserved"
-msgstr ""
-
-#: static/js/impala/persona_creation.js:64
-msgid "Creative Commons Attribution 3.0"
-msgstr ""
-
-#: static/js/impala/persona_creation.js:69
-msgid "Creative Commons Attribution-NonCommercial 3.0"
-msgstr ""
-
-#: static/js/impala/persona_creation.js:74
-msgid "Creative Commons Attribution-NonCommercial-NoDerivs 3.0"
-msgstr ""
-
-#: static/js/impala/persona_creation.js:79
-msgid "Creative Commons Attribution-NonCommercial-Share Alike 3.0"
-msgstr ""
-
-#: static/js/impala/persona_creation.js:84
-msgid "Creative Commons Attribution-NoDerivs 3.0"
-msgstr ""
-
-#: static/js/impala/persona_creation.js:89
-msgid "Creative Commons Attribution-ShareAlike 3.0"
-msgstr ""
-
-#: static/js/impala/persona_creation.js:292
-msgid "Your Theme's Name"
-msgstr ""
-
-#: static/js/impala/reviews.js:23 static/js/zamboni/reviews.js:18
-msgid "Flagged for review"
-msgstr ""
-
-#: static/js/impala/reviews.js:40 static/js/zamboni/reviews.js:34
-msgid "Your input is required"
-msgstr ""
-
-#: static/js/impala/reviews.js:152 static/js/zamboni/reviews.js:103
-msgid "Marked for deletion"
-msgstr ""
-
-#: static/js/impala/search.js:114
-msgid "Updating results&hellip;"
-msgstr ""
-
-#: static/js/impala/site_suggestions.js:46
-msgid "Category"
-msgstr ""
-
-#: static/js/impala/suggestions.js:39
-msgid "Search themes for <b>{0}</b>"
-msgstr ""
-
-#: static/js/impala/suggestions.js:41
-msgid "Search apps for <b>{0}</b>"
-msgstr ""
-
-#: static/js/impala/suggestions.js:43
-msgid "Search add-ons for <b>{0}</b>"
-msgstr ""
-
-#: static/js/impala/users.js:33
-msgid "use original"
-msgstr ""
-
-#: static/js/impala/stats/chart.js:267
+#: static/js/impala/stats/chart.js:267 static/js/zamboni/stats-all.js:16898 static/js/zamboni/stats-min.js:5
 msgid "Week of {0}"
 msgstr ""
 
-#: static/js/impala/stats/chart.js:269
+#: static/js/impala/stats/chart.js:269 static/js/zamboni/stats-all.js:16900 static/js/zamboni/stats-min.js:5
 msgid " downloads"
 msgstr ""
 
-#: static/js/impala/stats/chart.js:270
+#: static/js/impala/stats/chart.js:270 static/js/zamboni/stats-all.js:16901 static/js/zamboni/stats-min.js:5
 msgid "{0} users"
 msgstr ""
 
-#: static/js/impala/stats/chart.js:271
+#: static/js/impala/stats/chart.js:271 static/js/zamboni/stats-all.js:16902 static/js/zamboni/stats-min.js:5
 msgid "{0} add-ons"
 msgstr ""
 
-#: static/js/impala/stats/chart.js:272
+#: static/js/impala/stats/chart.js:272 static/js/zamboni/stats-all.js:16903 static/js/zamboni/stats-min.js:5
 msgid "{0} collections"
 msgstr ""
 
-#: static/js/impala/stats/chart.js:273
+#: static/js/impala/stats/chart.js:273 static/js/zamboni/stats-all.js:16904 static/js/zamboni/stats-min.js:5
 msgid "{0} reviews"
 msgstr ""
 
-#: static/js/impala/stats/chart.js:275
+#: static/js/impala/stats/chart.js:275 static/js/zamboni/stats-all.js:16906 static/js/zamboni/stats-min.js:5
 msgid "{0} sales"
 msgstr ""
 
-#: static/js/impala/stats/chart.js:276
+#: static/js/impala/stats/chart.js:276 static/js/zamboni/stats-all.js:16907 static/js/zamboni/stats-min.js:5
 msgid "{0} refunds"
 msgstr ""
 
-#: static/js/impala/stats/chart.js:277
+#: static/js/impala/stats/chart.js:277 static/js/zamboni/stats-all.js:16908 static/js/zamboni/stats-min.js:5
 msgid "{0} installs"
 msgstr ""
 
-#: static/js/impala/stats/chart.js:369 static/js/impala/stats/csv_keys.js:3 static/js/impala/stats/csv_keys.js:109
+#: static/js/impala/stats/chart.js:369 static/js/impala/stats/csv_keys.js:3 static/js/impala/stats/csv_keys.js:109 static/js/zamboni/stats-all.js:15284 static/js/zamboni/stats-all.js:15390
+#: static/js/zamboni/stats-all.js:17000 static/js/zamboni/stats-min.js:4 static/js/zamboni/stats-min.js:5
 msgid "Downloads"
 msgstr ""
 
-#: static/js/impala/stats/chart.js:379 static/js/impala/stats/csv_keys.js:6 static/js/impala/stats/csv_keys.js:110
+#: static/js/impala/stats/chart.js:379 static/js/impala/stats/csv_keys.js:6 static/js/impala/stats/csv_keys.js:110 static/js/zamboni/stats-all.js:15287 static/js/zamboni/stats-all.js:15391
+#: static/js/zamboni/stats-all.js:17010 static/js/zamboni/stats-min.js:4 static/js/zamboni/stats-min.js:5
 msgid "Daily Users"
 msgstr ""
 
-#: static/js/impala/stats/chart.js:410
+#: static/js/impala/stats/chart.js:410 static/js/zamboni/stats-all.js:17041 static/js/zamboni/stats-min.js:5
 msgid "Amount, in USD"
 msgstr ""
 
-#: static/js/impala/stats/chart.js:421 static/js/impala/stats/csv_keys.js:104
+#: static/js/impala/stats/chart.js:421 static/js/impala/stats/csv_keys.js:104 static/js/zamboni/stats-all.js:15385 static/js/zamboni/stats-all.js:17052 static/js/zamboni/stats-min.js:5
 msgid "Number of Contributions"
 msgstr ""
 
-#: static/js/impala/stats/chart.js:447
+#: static/js/impala/stats/chart.js:447 static/js/zamboni/stats-all.js:17078 static/js/zamboni/stats-min.js:5
 msgid "More Info..."
 msgstr ""
 
 #. L10n: {0} is an ISO-formatted date.
-#: static/js/impala/stats/chart.js:451
+#: static/js/impala/stats/chart.js:451 static/js/zamboni/stats-all.js:17082 static/js/zamboni/stats-min.js:5
 msgid "Details for {0}"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:9
+#: static/js/impala/stats/csv_keys.js:9 static/js/zamboni/stats-all.js:15290 static/js/zamboni/stats-min.js:4
 msgid "Collections Created"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:12
+#: static/js/impala/stats/csv_keys.js:12 static/js/zamboni/stats-all.js:15293 static/js/zamboni/stats-min.js:4
 msgid "Add-ons in Use"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:15
+#: static/js/impala/stats/csv_keys.js:15 static/js/zamboni/stats-all.js:15296 static/js/zamboni/stats-min.js:4
 msgid "Add-ons Created"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:18
+#: static/js/impala/stats/csv_keys.js:18 static/js/zamboni/stats-all.js:15299 static/js/zamboni/stats-min.js:4
 msgid "Add-ons Downloaded"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:21
+#: static/js/impala/stats/csv_keys.js:21 static/js/zamboni/stats-all.js:15302 static/js/zamboni/stats-min.js:4
 msgid "Add-ons Updated"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:24
+#: static/js/impala/stats/csv_keys.js:24 static/js/zamboni/stats-all.js:15305 static/js/zamboni/stats-min.js:4
 msgid "Reviews Written"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:27
+#: static/js/impala/stats/csv_keys.js:27 static/js/zamboni/stats-all.js:15308 static/js/zamboni/stats-min.js:4
 msgid "User Signups"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:30
+#: static/js/impala/stats/csv_keys.js:30 static/js/zamboni/stats-all.js:15311 static/js/zamboni/stats-min.js:4
 msgid "Subscribers"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:33
+#: static/js/impala/stats/csv_keys.js:33 static/js/zamboni/stats-all.js:15314 static/js/zamboni/stats-min.js:4
 msgid "Ratings"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:36 static/js/impala/stats/csv_keys.js:114
+#: static/js/impala/stats/csv_keys.js:36 static/js/impala/stats/csv_keys.js:114 static/js/zamboni/stats-all.js:15317 static/js/zamboni/stats-all.js:15395 static/js/zamboni/stats-min.js:4
+#: static/js/zamboni/stats-min.js:5
 msgid "Sales"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:39 static/js/impala/stats/csv_keys.js:113
+#: static/js/impala/stats/csv_keys.js:39 static/js/impala/stats/csv_keys.js:113 static/js/zamboni/stats-all.js:15320 static/js/zamboni/stats-all.js:15394 static/js/zamboni/stats-min.js:4
+#: static/js/zamboni/stats-min.js:5
 msgid "Installs"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:42
+#: static/js/impala/stats/csv_keys.js:42 static/js/zamboni/stats-all.js:15323 static/js/zamboni/stats-min.js:4
 msgid "Unknown"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:43
+#: static/js/impala/stats/csv_keys.js:43 static/js/zamboni/stats-all.js:15324 static/js/zamboni/stats-min.js:4
 msgid "Add-ons Manager"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:44
+#: static/js/impala/stats/csv_keys.js:44 static/js/zamboni/stats-all.js:15325 static/js/zamboni/stats-min.js:4
 msgid "Add-ons Manager Promo"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:45
+#: static/js/impala/stats/csv_keys.js:45 static/js/zamboni/stats-all.js:15326 static/js/zamboni/stats-min.js:4
 msgid "Add-ons Manager Featured"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:46
+#: static/js/impala/stats/csv_keys.js:46 static/js/zamboni/stats-all.js:15327 static/js/zamboni/stats-min.js:4
 msgid "Add-ons Manager Learn More"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:47
+#: static/js/impala/stats/csv_keys.js:47 static/js/zamboni/stats-all.js:15328 static/js/zamboni/stats-min.js:4
 msgid "Search Suggestions"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:48
+#: static/js/impala/stats/csv_keys.js:48 static/js/zamboni/stats-all.js:15329 static/js/zamboni/stats-min.js:4
 msgid "Search Results"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:49 static/js/impala/stats/csv_keys.js:50 static/js/impala/stats/csv_keys.js:51
+#: static/js/impala/stats/csv_keys.js:49 static/js/impala/stats/csv_keys.js:50 static/js/impala/stats/csv_keys.js:51 static/js/zamboni/stats-all.js:15330 static/js/zamboni/stats-all.js:15331
+#: static/js/zamboni/stats-all.js:15332 static/js/zamboni/stats-min.js:4
 msgid "Homepage Promo"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:52 static/js/impala/stats/csv_keys.js:53
+#: static/js/impala/stats/csv_keys.js:52 static/js/impala/stats/csv_keys.js:53 static/js/zamboni/stats-all.js:15333 static/js/zamboni/stats-all.js:15334 static/js/zamboni/stats-min.js:4
 msgid "Homepage Featured"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:54 static/js/impala/stats/csv_keys.js:55
+#: static/js/impala/stats/csv_keys.js:54 static/js/impala/stats/csv_keys.js:55 static/js/zamboni/stats-all.js:15335 static/js/zamboni/stats-all.js:15336 static/js/zamboni/stats-min.js:4
 msgid "Homepage Up and Coming"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:56
+#: static/js/impala/stats/csv_keys.js:56 static/js/zamboni/stats-all.js:15337 static/js/zamboni/stats-min.js:4
 msgid "Homepage Most Popular"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:57 static/js/impala/stats/csv_keys.js:59
+#: static/js/impala/stats/csv_keys.js:57 static/js/impala/stats/csv_keys.js:59 static/js/zamboni/stats-all.js:15338 static/js/zamboni/stats-all.js:15340 static/js/zamboni/stats-min.js:4
 msgid "Detail Page"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:58 static/js/impala/stats/csv_keys.js:60
+#: static/js/impala/stats/csv_keys.js:58 static/js/impala/stats/csv_keys.js:60 static/js/zamboni/stats-all.js:15339 static/js/zamboni/stats-all.js:15341 static/js/zamboni/stats-min.js:4
 msgid "Detail Page (bottom)"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:61
+#: static/js/impala/stats/csv_keys.js:61 static/js/zamboni/stats-all.js:15342 static/js/zamboni/stats-min.js:4
 msgid "Detail Page (Development Channel)"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:62 static/js/impala/stats/csv_keys.js:63 static/js/impala/stats/csv_keys.js:64
+#: static/js/impala/stats/csv_keys.js:62 static/js/impala/stats/csv_keys.js:63 static/js/impala/stats/csv_keys.js:64 static/js/zamboni/stats-all.js:15343 static/js/zamboni/stats-all.js:15344
+#: static/js/zamboni/stats-all.js:15345 static/js/zamboni/stats-min.js:4
 msgid "Often Used With"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:65 static/js/impala/stats/csv_keys.js:66
+#: static/js/impala/stats/csv_keys.js:65 static/js/impala/stats/csv_keys.js:66 static/js/zamboni/stats-all.js:15346 static/js/zamboni/stats-all.js:15347 static/js/zamboni/stats-min.js:4
 msgid "Others By Author"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:67 static/js/impala/stats/csv_keys.js:68
+#: static/js/impala/stats/csv_keys.js:67 static/js/impala/stats/csv_keys.js:68 static/js/zamboni/stats-all.js:15348 static/js/zamboni/stats-all.js:15349 static/js/zamboni/stats-min.js:4
 msgid "Dependencies"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:69 static/js/impala/stats/csv_keys.js:70
+#: static/js/impala/stats/csv_keys.js:69 static/js/impala/stats/csv_keys.js:70 static/js/zamboni/stats-all.js:15350 static/js/zamboni/stats-all.js:15351 static/js/zamboni/stats-min.js:4
 msgid "Upsell"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:71
+#: static/js/impala/stats/csv_keys.js:71 static/js/zamboni/stats-all.js:15352 static/js/zamboni/stats-min.js:4
 msgid "Meet the Developer"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:72
+#: static/js/impala/stats/csv_keys.js:72 static/js/zamboni/stats-all.js:15353 static/js/zamboni/stats-min.js:4
 msgid "User Profile"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:73
+#: static/js/impala/stats/csv_keys.js:73 static/js/zamboni/stats-all.js:15354 static/js/zamboni/stats-min.js:4
 msgid "Version History"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:75
+#: static/js/impala/stats/csv_keys.js:75 static/js/zamboni/stats-all.js:15356 static/js/zamboni/stats-min.js:4
 msgid "Sharing"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:76
+#: static/js/impala/stats/csv_keys.js:76 static/js/zamboni/stats-all.js:15357 static/js/zamboni/stats-min.js:4
 msgid "Category Pages"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:77
+#: static/js/impala/stats/csv_keys.js:77 static/js/zamboni/stats-all.js:15358 static/js/zamboni/stats-min.js:4
 msgid "Collections"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:78 static/js/impala/stats/csv_keys.js:79
+#: static/js/impala/stats/csv_keys.js:78 static/js/impala/stats/csv_keys.js:79 static/js/zamboni/stats-all.js:15359 static/js/zamboni/stats-all.js:15360 static/js/zamboni/stats-min.js:4
 msgid "Category Landing Featured Carousel"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:80 static/js/impala/stats/csv_keys.js:81
+#: static/js/impala/stats/csv_keys.js:80 static/js/impala/stats/csv_keys.js:81 static/js/zamboni/stats-all.js:15361 static/js/zamboni/stats-all.js:15362 static/js/zamboni/stats-min.js:4
 msgid "Category Landing Top Rated"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:82 static/js/impala/stats/csv_keys.js:83
+#: static/js/impala/stats/csv_keys.js:82 static/js/impala/stats/csv_keys.js:83 static/js/zamboni/stats-all.js:15363 static/js/zamboni/stats-all.js:15364 static/js/zamboni/stats-min.js:5
 msgid "Category Landing Most Popular"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:84 static/js/impala/stats/csv_keys.js:85
+#: static/js/impala/stats/csv_keys.js:84 static/js/impala/stats/csv_keys.js:85 static/js/zamboni/stats-all.js:15365 static/js/zamboni/stats-all.js:15366 static/js/zamboni/stats-min.js:5
 msgid "Category Landing Recently Added"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:86 static/js/impala/stats/csv_keys.js:87
+#: static/js/impala/stats/csv_keys.js:86 static/js/impala/stats/csv_keys.js:87 static/js/zamboni/stats-all.js:15367 static/js/zamboni/stats-all.js:15368 static/js/zamboni/stats-min.js:5
 msgid "Browse Listing Featured Sort"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:88 static/js/impala/stats/csv_keys.js:89
+#: static/js/impala/stats/csv_keys.js:88 static/js/impala/stats/csv_keys.js:89 static/js/zamboni/stats-all.js:15369 static/js/zamboni/stats-all.js:15370 static/js/zamboni/stats-min.js:5
 msgid "Browse Listing Users Sort"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:90 static/js/impala/stats/csv_keys.js:91
+#: static/js/impala/stats/csv_keys.js:90 static/js/impala/stats/csv_keys.js:91 static/js/zamboni/stats-all.js:15371 static/js/zamboni/stats-all.js:15372 static/js/zamboni/stats-min.js:5
 msgid "Browse Listing Rating Sort"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:92 static/js/impala/stats/csv_keys.js:93
+#: static/js/impala/stats/csv_keys.js:92 static/js/impala/stats/csv_keys.js:93 static/js/zamboni/stats-all.js:15373 static/js/zamboni/stats-all.js:15374 static/js/zamboni/stats-min.js:5
 msgid "Browse Listing Created Sort"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:94 static/js/impala/stats/csv_keys.js:95
+#: static/js/impala/stats/csv_keys.js:94 static/js/impala/stats/csv_keys.js:95 static/js/zamboni/stats-all.js:15375 static/js/zamboni/stats-all.js:15376 static/js/zamboni/stats-min.js:5
 msgid "Browse Listing Name Sort"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:96 static/js/impala/stats/csv_keys.js:97
+#: static/js/impala/stats/csv_keys.js:96 static/js/impala/stats/csv_keys.js:97 static/js/zamboni/stats-all.js:15377 static/js/zamboni/stats-all.js:15378 static/js/zamboni/stats-min.js:5
 msgid "Browse Listing Popular Sort"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:98 static/js/impala/stats/csv_keys.js:99
+#: static/js/impala/stats/csv_keys.js:98 static/js/impala/stats/csv_keys.js:99 static/js/zamboni/stats-all.js:15379 static/js/zamboni/stats-all.js:15380 static/js/zamboni/stats-min.js:5
 msgid "Browse Listing Updated Sort"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:100 static/js/impala/stats/csv_keys.js:101
+#: static/js/impala/stats/csv_keys.js:100 static/js/impala/stats/csv_keys.js:101 static/js/zamboni/stats-all.js:15381 static/js/zamboni/stats-all.js:15382 static/js/zamboni/stats-min.js:5
 msgid "Browse Listing Up and Coming Sort"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:105
+#: static/js/impala/stats/csv_keys.js:105 static/js/zamboni/stats-all.js:15386 static/js/zamboni/stats-min.js:5
 msgid "Total Amount Contributed"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:106
+#: static/js/impala/stats/csv_keys.js:106 static/js/zamboni/stats-all.js:15387 static/js/zamboni/stats-min.js:5
 msgid "Average Contribution"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:115
+#: static/js/impala/stats/csv_keys.js:115 static/js/zamboni/stats-all.js:15396 static/js/zamboni/stats-min.js:5
 msgid "Usage"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:118
+#: static/js/impala/stats/csv_keys.js:118 static/js/zamboni/stats-all.js:15399 static/js/zamboni/stats-min.js:5
 msgid "Firefox"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:119
+#: static/js/impala/stats/csv_keys.js:119 static/js/zamboni/stats-all.js:15400 static/js/zamboni/stats-min.js:5
 msgid "Mozilla"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:120
+#: static/js/impala/stats/csv_keys.js:120 static/js/zamboni/stats-all.js:15401 static/js/zamboni/stats-min.js:5
 msgid "Thunderbird"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:121
+#: static/js/impala/stats/csv_keys.js:121 static/js/zamboni/stats-all.js:15402 static/js/zamboni/stats-min.js:5
 msgid "Sunbird"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:122
+#: static/js/impala/stats/csv_keys.js:122 static/js/zamboni/stats-all.js:15403 static/js/zamboni/stats-min.js:5
 msgid "SeaMonkey"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:123
+#: static/js/impala/stats/csv_keys.js:123 static/js/zamboni/stats-all.js:15404 static/js/zamboni/stats-min.js:5
 msgid "Fennec"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:124
+#: static/js/impala/stats/csv_keys.js:124 static/js/zamboni/stats-all.js:15405 static/js/zamboni/stats-min.js:5
 msgid "Android"
 msgstr ""
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:129
+#: static/js/impala/stats/csv_keys.js:129 static/js/zamboni/stats-all.js:15410 static/js/zamboni/stats-min.js:5
 msgid "Downloads and Daily Users, last {0} days"
 msgstr ""
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:131
+#: static/js/impala/stats/csv_keys.js:131 static/js/zamboni/stats-all.js:15412 static/js/zamboni/stats-min.js:5
 msgid "Downloads and Daily Users from {0} to {1}"
 msgstr ""
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:135
+#: static/js/impala/stats/csv_keys.js:135 static/js/zamboni/stats-all.js:15416 static/js/zamboni/stats-min.js:5
 msgid "Installs and Daily Users, last {0} days"
 msgstr ""
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:137
+#: static/js/impala/stats/csv_keys.js:137 static/js/zamboni/stats-all.js:15418 static/js/zamboni/stats-min.js:5
 msgid "Installs and Daily Users from {0} to {1}"
 msgstr ""
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:141
+#: static/js/impala/stats/csv_keys.js:141 static/js/zamboni/stats-all.js:15422 static/js/zamboni/stats-min.js:5
 msgid "Downloads, last {0} days"
 msgstr ""
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:143
+#: static/js/impala/stats/csv_keys.js:143 static/js/zamboni/stats-all.js:15424 static/js/zamboni/stats-min.js:5
 msgid "Downloads from {0} to {1}"
 msgstr ""
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:147
+#: static/js/impala/stats/csv_keys.js:147 static/js/zamboni/stats-all.js:15428 static/js/zamboni/stats-min.js:5
 msgid "Daily Users, last {0} days"
 msgstr ""
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:149
+#: static/js/impala/stats/csv_keys.js:149 static/js/zamboni/stats-all.js:15430 static/js/zamboni/stats-min.js:5
 msgid "Daily Users from {0} to {1}"
 msgstr ""
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:153
+#: static/js/impala/stats/csv_keys.js:153 static/js/zamboni/stats-all.js:15434 static/js/zamboni/stats-min.js:5
 msgid "Applications, last {0} days"
 msgstr ""
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:155
+#: static/js/impala/stats/csv_keys.js:155 static/js/zamboni/stats-all.js:15436 static/js/zamboni/stats-min.js:5
 msgid "Applications from {0} to {1}"
 msgstr ""
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:159
+#: static/js/impala/stats/csv_keys.js:159 static/js/zamboni/stats-all.js:15440 static/js/zamboni/stats-min.js:5
 msgid "Platforms, last {0} days"
 msgstr ""
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:161
+#: static/js/impala/stats/csv_keys.js:161 static/js/zamboni/stats-all.js:15442 static/js/zamboni/stats-min.js:5
 msgid "Platforms from {0} to {1}"
 msgstr ""
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:165
+#: static/js/impala/stats/csv_keys.js:165 static/js/zamboni/stats-all.js:15446 static/js/zamboni/stats-min.js:5
 msgid "Languages, last {0} days"
 msgstr ""
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:167
+#: static/js/impala/stats/csv_keys.js:167 static/js/zamboni/stats-all.js:15448 static/js/zamboni/stats-min.js:5
 msgid "Languages from {0} to {1}"
 msgstr ""
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:171
+#: static/js/impala/stats/csv_keys.js:171 static/js/zamboni/stats-all.js:15452 static/js/zamboni/stats-min.js:5
 msgid "Add-on Versions, last {0} days"
 msgstr ""
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:173
+#: static/js/impala/stats/csv_keys.js:173 static/js/zamboni/stats-all.js:15454 static/js/zamboni/stats-min.js:5
 msgid "Add-on Versions from {0} to {1}"
 msgstr ""
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:177
+#: static/js/impala/stats/csv_keys.js:177 static/js/zamboni/stats-all.js:15458 static/js/zamboni/stats-min.js:5
 msgid "Add-on Status, last {0} days"
 msgstr ""
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:179
+#: static/js/impala/stats/csv_keys.js:179 static/js/zamboni/stats-all.js:15460 static/js/zamboni/stats-min.js:5
 msgid "Add-on Status from {0} to {1}"
 msgstr ""
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:183
+#: static/js/impala/stats/csv_keys.js:183 static/js/zamboni/stats-all.js:15464 static/js/zamboni/stats-min.js:5
 msgid "Download Sources, last {0} days"
 msgstr ""
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:185
+#: static/js/impala/stats/csv_keys.js:185 static/js/zamboni/stats-all.js:15466 static/js/zamboni/stats-min.js:5
 msgid "Download Sources from {0} to {1}"
 msgstr ""
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:189
+#: static/js/impala/stats/csv_keys.js:189 static/js/zamboni/stats-all.js:15470 static/js/zamboni/stats-min.js:5
 msgid "Contributions, last {0} days"
 msgstr ""
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:191
+#: static/js/impala/stats/csv_keys.js:191 static/js/zamboni/stats-all.js:15472 static/js/zamboni/stats-min.js:5
 msgid "Contributions from {0} to {1}"
 msgstr ""
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:195
+#: static/js/impala/stats/csv_keys.js:195 static/js/zamboni/stats-all.js:15476 static/js/zamboni/stats-min.js:5
 msgid "Site Metrics, last {0} days"
 msgstr ""
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:197
+#: static/js/impala/stats/csv_keys.js:197 static/js/zamboni/stats-all.js:15478 static/js/zamboni/stats-min.js:5
 msgid "Site Metrics from {0} to {1}"
 msgstr ""
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:201
+#: static/js/impala/stats/csv_keys.js:201 static/js/zamboni/stats-all.js:15482 static/js/zamboni/stats-min.js:5
 msgid "Add-ons in Use, last {0} days"
 msgstr ""
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:203
+#: static/js/impala/stats/csv_keys.js:203 static/js/zamboni/stats-all.js:15484 static/js/zamboni/stats-min.js:5
 msgid "Add-ons in Use from {0} to {1}"
 msgstr ""
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:207
+#: static/js/impala/stats/csv_keys.js:207 static/js/zamboni/stats-all.js:15488 static/js/zamboni/stats-min.js:5
 msgid "Add-ons Downloaded, last {0} days"
 msgstr ""
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:209
+#: static/js/impala/stats/csv_keys.js:209 static/js/zamboni/stats-all.js:15490 static/js/zamboni/stats-min.js:5
 msgid "Add-ons Downloaded from {0} to {1}"
 msgstr ""
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:213
+#: static/js/impala/stats/csv_keys.js:213 static/js/zamboni/stats-all.js:15494 static/js/zamboni/stats-min.js:5
 msgid "Add-ons Created, last {0} days"
 msgstr ""
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:215
+#: static/js/impala/stats/csv_keys.js:215 static/js/zamboni/stats-all.js:15496 static/js/zamboni/stats-min.js:5
 msgid "Add-ons Created from {0} to {1}"
 msgstr ""
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:219
+#: static/js/impala/stats/csv_keys.js:219 static/js/zamboni/stats-all.js:15500 static/js/zamboni/stats-min.js:5
 msgid "Add-ons Updated, last {0} days"
 msgstr ""
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:221
+#: static/js/impala/stats/csv_keys.js:221 static/js/zamboni/stats-all.js:15502 static/js/zamboni/stats-min.js:5
 msgid "Add-ons Updated from {0} to {1}"
 msgstr ""
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:225
+#: static/js/impala/stats/csv_keys.js:225 static/js/zamboni/stats-all.js:15506 static/js/zamboni/stats-min.js:5
 msgid "Reviews Written, last {0} days"
 msgstr ""
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:227
+#: static/js/impala/stats/csv_keys.js:227 static/js/zamboni/stats-all.js:15508 static/js/zamboni/stats-min.js:5
 msgid "Reviews Written from {0} to {1}"
 msgstr ""
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:231
+#: static/js/impala/stats/csv_keys.js:231 static/js/zamboni/stats-all.js:15512 static/js/zamboni/stats-min.js:5
 msgid "User Signups, last {0} days"
 msgstr ""
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:233
+#: static/js/impala/stats/csv_keys.js:233 static/js/zamboni/stats-all.js:15514 static/js/zamboni/stats-min.js:5
 msgid "User Signups from {0} to {1}"
 msgstr ""
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:237
+#: static/js/impala/stats/csv_keys.js:237 static/js/zamboni/stats-all.js:15518 static/js/zamboni/stats-min.js:5
 msgid "Collections Created, last {0} days"
 msgstr ""
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:239
+#: static/js/impala/stats/csv_keys.js:239 static/js/zamboni/stats-all.js:15520 static/js/zamboni/stats-min.js:5
 msgid "Collections Created from {0} to {1}"
 msgstr ""
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:243
+#: static/js/impala/stats/csv_keys.js:243 static/js/zamboni/stats-all.js:15524 static/js/zamboni/stats-min.js:5
 msgid "Subscribers, last {0} days"
 msgstr ""
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:245
+#: static/js/impala/stats/csv_keys.js:245 static/js/zamboni/stats-all.js:15526 static/js/zamboni/stats-min.js:5
 msgid "Subscribers from {0} to {1}"
 msgstr ""
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:249
+#: static/js/impala/stats/csv_keys.js:249 static/js/zamboni/stats-all.js:15530 static/js/zamboni/stats-min.js:5
 msgid "Ratings, last {0} days"
 msgstr ""
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:251
+#: static/js/impala/stats/csv_keys.js:251 static/js/zamboni/stats-all.js:15532 static/js/zamboni/stats-min.js:5
 msgid "Ratings from {0} to {1}"
 msgstr ""
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:255
+#: static/js/impala/stats/csv_keys.js:255 static/js/zamboni/stats-all.js:15536 static/js/zamboni/stats-min.js:5
 msgid "Sales, last {0} days"
 msgstr ""
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:257
+#: static/js/impala/stats/csv_keys.js:257 static/js/zamboni/stats-all.js:15538 static/js/zamboni/stats-min.js:5
 msgid "Sales from {0} to {1}"
 msgstr ""
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:261
+#: static/js/impala/stats/csv_keys.js:261 static/js/zamboni/stats-all.js:15542 static/js/zamboni/stats-min.js:5
 msgid "Installs, last {0} days"
 msgstr ""
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:263
+#: static/js/impala/stats/csv_keys.js:263 static/js/zamboni/stats-all.js:15544 static/js/zamboni/stats-min.js:5
 msgid "Installs from {0} to {1}"
 msgstr ""
 
 #. L10n: {0} and {1} are integers.
-#: static/js/impala/stats/csv_keys.js:269
+#: static/js/impala/stats/csv_keys.js:269 static/js/zamboni/stats-all.js:15550 static/js/zamboni/stats-min.js:5
 msgid "<b>{0}</b> in last {1} days"
 msgstr ""
 
 #. L10n: {0} is an integer and {1} and {2} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:271 static/js/impala/stats/csv_keys.js:277
+#: static/js/impala/stats/csv_keys.js:271 static/js/impala/stats/csv_keys.js:277 static/js/zamboni/stats-all.js:15552 static/js/zamboni/stats-all.js:15558 static/js/zamboni/stats-min.js:5
 msgid "<b>{0}</b> from {1} to {2}"
 msgstr ""
 
 #. L10n: {0} and {1} are integers.
-#: static/js/impala/stats/csv_keys.js:275
+#: static/js/impala/stats/csv_keys.js:275 static/js/zamboni/stats-all.js:15556 static/js/zamboni/stats-min.js:5
 msgid "<b>{0}</b> average in last {1} days"
 msgstr ""
 
-#: static/js/impala/stats/overview.js:19
+#: static/js/impala/stats/overview.js:19 static/js/zamboni/stats-all.js:16469 static/js/zamboni/stats-min.js:5
 msgid "No data available."
 msgstr ""
 
-#: static/js/impala/stats/table.js:74
+#: static/js/impala/stats/table.js:74 static/js/zamboni/stats-all.js:17209 static/js/zamboni/stats-min.js:5
 msgid "Date"
 msgstr ""
 
-#: static/js/impala/stats/topchart.js:96
+#: static/js/impala/stats/topchart.js:96 static/js/zamboni/stats-all.js:16600 static/js/zamboni/stats-min.js:5
 msgid "Other"
 msgstr ""
 
-#: static/js/zamboni/admin_validation.js:24 static/js/zamboni/devhub.js:1229 static/js/zamboni/editors.js:295
+#: static/js/zamboni/admin-all.js:180 static/js/zamboni/admin-min.js:1 static/js/zamboni/admin_validation.js:24 static/js/zamboni/devhub-all.js:2408 static/js/zamboni/devhub-min.js:2
+#: static/js/zamboni/devhub.js:1229 static/js/zamboni/editors-all.js:15576 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:295
 msgid "Select an application first"
 msgstr ""
 
-#: static/js/zamboni/admin_validation.js:51
+#: static/js/zamboni/admin-all.js:207 static/js/zamboni/admin-min.js:1 static/js/zamboni/admin_validation.js:51
 msgid "Set {0} add-on to a max version of {1} and email the author."
 msgid_plural "Set {0} add-ons to a max version of {1} and email the authors."
 msgstr[0] ""
 msgstr[1] ""
 
-#: static/js/zamboni/admin_validation.js:54
+#: static/js/zamboni/admin-all.js:210 static/js/zamboni/admin-min.js:1 static/js/zamboni/admin_validation.js:54
 msgid "Email author of {2} add-on which failed validation."
 msgid_plural "Email authors of {2} add-ons which failed validation."
 msgstr[0] ""
 msgstr[1] ""
 
-#. L10n: {0} is an app name like Firefox.
-#: static/js/zamboni/buttons.js:66
-msgid "Accept and Install"
-msgstr ""
-
-#: static/js/zamboni/buttons.js:66
-msgid "Add to {0}"
-msgstr ""
-
-#: static/js/zamboni/buttons.js:71
-msgid "Download Now"
-msgstr ""
-
-#: static/js/zamboni/buttons.js:112
-msgid "Add-on has not been updated to support default-to-compatible."
-msgstr ""
-
-#: static/js/zamboni/buttons.js:117
-msgid "You need to be using Firefox 10.0 or higher."
-msgstr ""
-
-#: static/js/zamboni/buttons.js:129
-msgid "Mozilla has marked this version as incompatible with your Firefox version."
-msgstr ""
-
-#. L10n: {0} is an platform like Windows or Linux.
-#: static/js/zamboni/buttons.js:210
-msgid "Install for {0} anyway"
-msgstr ""
-
-#: static/js/zamboni/buttons.js:210
-msgid "Download for {0} anyway"
-msgstr ""
-
-#: static/js/zamboni/buttons.js:267
-msgid "Not available for your platform"
-msgstr ""
-
-#. L10n: {0} is an app name, {1} is the app version.
-#: static/js/zamboni/buttons.js:278 static/js/zamboni/buttons.js:315
-msgid "Not available for {0} {1}"
-msgstr ""
-
-#: static/js/zamboni/buttons.js:341
-msgid "Works with {app} {min} - {max}"
-msgstr ""
-
-#: static/js/zamboni/buttons.js:343
-msgid "View other versions"
-msgstr ""
-
-#: static/js/zamboni/buttons.js:391
-msgid "Only with Firefox — Get Firefox Now!"
-msgstr ""
-
-#: static/js/zamboni/buttons.js:507 static/js/zamboni/mobile/buttons.js:43
-msgid "Sorry, you need a Mozilla-based browser (such as Firefox) to install a search plugin."
-msgstr ""
-
-#: static/js/zamboni/collections.js:229
-msgid "Adding to Favorites&hellip;"
-msgstr ""
-
-#: static/js/zamboni/collections.js:232
-msgid "Removing Favorite&hellip;"
-msgstr ""
-
-#: static/js/zamboni/collections.js:235
-msgid "Add to Favorites"
-msgstr ""
-
-#: static/js/zamboni/collections.js:238
-msgid "Remove from Favorites"
-msgstr ""
-
-#: static/js/zamboni/collections.js:303
-msgid "Pending"
-msgstr ""
-
-#: static/js/zamboni/collections.js:304
-msgid "Add a comment"
-msgstr ""
-
-#: static/js/zamboni/collections.js:304
-msgid "Comment"
-msgstr ""
-
-#: static/js/zamboni/collections.js:305
-msgid "Remove this add-on from the collection"
-msgstr ""
-
-#: static/js/zamboni/collections.js:305 static/js/zamboni/collections.js:334
-msgid "Remove"
-msgstr ""
-
-#: static/js/zamboni/collections.js:334
-msgid "Remove this user as a contributor"
-msgstr ""
-
-#: static/js/zamboni/collections.js:346
-msgid "An email address is required."
-msgstr ""
-
-#: static/js/zamboni/collections.js:364
-msgid "You cannot add yourself as a contributor."
-msgstr ""
-
-#: static/js/zamboni/collections.js:366
-msgid "You have already added that user."
-msgstr ""
-
-#: static/js/zamboni/collections.js:573
-msgid "Add to favorites"
-msgstr ""
-
-#: static/js/zamboni/collections.js:577
-msgid "Remove from favorites"
-msgstr ""
-
-#: static/js/zamboni/collections.js:604
-msgid "Stop following"
-msgstr ""
-
-#: static/js/zamboni/devhub.js:110
+#: static/js/zamboni/devhub-all.js:1289 static/js/zamboni/devhub-min.js:1 static/js/zamboni/devhub.js:110
 msgid "Your browser does not support the video tag"
 msgstr ""
 
-#: static/js/zamboni/devhub.js:371
+#: static/js/zamboni/devhub-all.js:1550 static/js/zamboni/devhub-min.js:1 static/js/zamboni/devhub.js:371
 msgid "Changes Saved"
 msgstr ""
 
-#: static/js/zamboni/devhub.js:387
+#: static/js/zamboni/devhub-all.js:1566 static/js/zamboni/devhub-min.js:1 static/js/zamboni/devhub.js:387
 msgid "Enter a new author's email address"
 msgstr ""
 
-#: static/js/zamboni/devhub.js:536
+#: static/js/zamboni/devhub-all.js:1715 static/js/zamboni/devhub-min.js:1 static/js/zamboni/devhub.js:536
 msgid "There was an error uploading your file."
 msgstr ""
 
-#: static/js/zamboni/devhub.js:681
+#: static/js/zamboni/devhub-all.js:1860 static/js/zamboni/devhub-min.js:1 static/js/zamboni/devhub.js:681
 msgid "{files} file"
 msgid_plural "{files} files"
 msgstr[0] ""
 msgstr[1] ""
 
-#: static/js/zamboni/devhub.js:684
+#: static/js/zamboni/devhub-all.js:1863 static/js/zamboni/devhub-min.js:1 static/js/zamboni/devhub.js:684
 msgid "{reviews} user review"
 msgid_plural "{reviews} user reviews"
 msgstr[0] ""
 msgstr[1] ""
 
-#: static/js/zamboni/devhub.js:796
+#: static/js/zamboni/devhub-all.js:1975 static/js/zamboni/devhub-min.js:2 static/js/zamboni/devhub.js:796
 msgid "Learn more"
 msgstr ""
 
-#: static/js/zamboni/devhub.js:800
+#: static/js/zamboni/devhub-all.js:1979 static/js/zamboni/devhub-min.js:2 static/js/zamboni/devhub.js:800
 msgid "Example"
 msgstr ""
 
-#: static/js/zamboni/devhub.js:1130
+#: static/js/zamboni/devhub-all.js:2309 static/js/zamboni/devhub-min.js:2 static/js/zamboni/devhub.js:1130
 msgid "Image changes being processed"
 msgstr ""
 
-#: static/js/zamboni/devhub.js:1280
+#: static/js/zamboni/devhub-all.js:2459 static/js/zamboni/devhub-min.js:2 static/js/zamboni/devhub.js:1280
 msgid "Must be a valid e-mail address."
+msgstr ""
+
+#: static/js/zamboni/devhub-all.js:2613 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:80
+msgid "All tests passed successfully."
+msgstr ""
+
+#: static/js/zamboni/devhub-all.js:2616 static/js/zamboni/devhub-all.js:3011 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:83 static/js/zamboni/validator.js:478
+msgid "These tests were not run."
+msgstr ""
+
+#: static/js/zamboni/devhub-all.js:2664 static/js/zamboni/devhub-all.js:2677 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:131 static/js/zamboni/validator.js:144
+msgid "Tests"
+msgstr ""
+
+#: static/js/zamboni/devhub-all.js:2779 static/js/zamboni/devhub-all.js:3108 static/js/zamboni/devhub-all.js:3127 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:246
+#: static/js/zamboni/validator.js:575 static/js/zamboni/validator.js:594
+msgid "Error"
+msgstr ""
+
+#: static/js/zamboni/devhub-all.js:2780 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:247
+msgid "Warning"
+msgstr ""
+
+#: static/js/zamboni/devhub-all.js:2794 static/js/zamboni/devhub-min.js:2 static/js/zamboni/files-all.js:5657 static/js/zamboni/files-min.js:3 static/js/zamboni/files.js:411
+#: static/js/zamboni/validator.js:261
+msgid "Ignore this message in future updates"
+msgstr ""
+
+#: static/js/zamboni/devhub-all.js:2817 static/js/zamboni/devhub-min.js:2 static/js/zamboni/files-all.js:5663 static/js/zamboni/files-min.js:3 static/js/zamboni/files.js:417
+#: static/js/zamboni/validator.js:284
+msgid "Severity for automated signing:"
+msgstr ""
+
+#: static/js/zamboni/devhub-all.js:2832 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:299
+msgid "Suggestions for passing automated signing:"
+msgstr ""
+
+#: static/js/zamboni/devhub-all.js:2920 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:387
+msgid "Compatibility Tests"
+msgstr ""
+
+#: static/js/zamboni/devhub-all.js:2999 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:466
+msgid "Add-on failed validation."
+msgstr ""
+
+#: static/js/zamboni/devhub-all.js:3001 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:468
+msgid "Add-on passed validation."
+msgstr ""
+
+#: static/js/zamboni/devhub-all.js:3014 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:481
+msgid "{0} error"
+msgid_plural "{0} errors"
+msgstr[0] ""
+msgstr[1] ""
+
+#: static/js/zamboni/devhub-all.js:3016 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:483
+msgid "{0} warning"
+msgid_plural "{0} warnings"
+msgstr[0] ""
+msgstr[1] ""
+
+#: static/js/zamboni/devhub-all.js:3018 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:485
+msgid "{0} notice"
+msgid_plural "{0} notices"
+msgstr[0] ""
+msgstr[1] ""
+
+#: static/js/zamboni/devhub-all.js:3110 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:577
+msgid "Validation task could not complete or completed with errors"
+msgstr ""
+
+#: static/js/zamboni/devhub-all.js:3128 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:595
+msgid "Internal server error"
 msgstr ""
 
 #: static/js/zamboni/devhub_search.js:8
 msgid "No results found."
 msgstr ""
 
-#: static/js/zamboni/editors.js:121
+#: static/js/zamboni/editors-all.js:15402 static/js/zamboni/editors-min.js:4 static/js/zamboni/editors.js:121
 msgid "{name} was viewing this page first."
 msgstr ""
 
-#: static/js/zamboni/editors.js:171
+#: static/js/zamboni/editors-all.js:15452 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:171
 msgid "Receipt checked by app."
 msgstr ""
 
-#: static/js/zamboni/editors.js:173
+#: static/js/zamboni/editors-all.js:15454 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:173
 msgid "Receipt was not checked by app."
 msgstr ""
 
-#: static/js/zamboni/editors.js:244
+#: static/js/zamboni/editors-all.js:15525 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:244
 msgid "{name} was viewing this add-on first."
 msgstr ""
 
-#: static/js/zamboni/editors.js:255
+#: static/js/zamboni/editors-all.js:15536 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:255
 msgid "Loading&hellip;"
 msgstr ""
 
-#: static/js/zamboni/editors.js:260
+#: static/js/zamboni/editors-all.js:15541 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:260
 msgid "Version Notes"
 msgstr ""
 
-#: static/js/zamboni/editors.js:265
+#: static/js/zamboni/editors-all.js:15546 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:265
 msgid "Notes for Reviewers"
 msgstr ""
 
-#: static/js/zamboni/editors.js:270
+#: static/js/zamboni/editors-all.js:15551 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:270
 msgid "No version notes found"
 msgstr ""
 
-#: static/js/zamboni/editors.js:330
+#: static/js/zamboni/editors-all.js:15611 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:330
 msgid "Average Reviews"
 msgstr ""
 
-#: static/js/zamboni/editors.js:386
+#: static/js/zamboni/editors-all.js:15667 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:386
 msgid "Number of Reviews"
 msgstr ""
 
-#: static/js/zamboni/editors.js:445
+#: static/js/zamboni/editors-all.js:15726 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:445
 msgid "Error loading translation"
 msgstr ""
 
-#: static/js/zamboni/files.js:411 static/js/zamboni/validator.js:261
-msgid "Ignore this message in future updates"
-msgstr ""
-
-#: static/js/zamboni/files.js:417 static/js/zamboni/validator.js:284
-msgid "Severity for automated signing:"
-msgstr ""
-
-#: static/js/zamboni/global.js:410
-msgid "Loading..."
-msgstr ""
-
-#. L10n: {0} is the number of characters left.
-#: static/js/zamboni/global.js:474
-msgid "<b>{0}</b> character left."
-msgid_plural "<b>{0}</b> characters left."
-msgstr[0] ""
-msgstr[1] ""
-
-#: static/js/zamboni/init.js:28
-msgid "This feature is temporarily disabled while we perform website maintenance. Please check back a little later."
-msgstr ""
-
-#: static/js/zamboni/l10n.js:45
-msgid "Remove this localization"
-msgstr ""
-
-#: static/js/zamboni/password-strength.js:20
-msgid "Password strength:"
-msgstr ""
-
-#: static/js/zamboni/password-strength.js:26
-msgid "At least {0} character left."
-msgid_plural "At least {0} characters left."
-msgstr[0] ""
-msgstr[1] ""
-
-#: static/js/zamboni/themes_review.js:176
-msgid "Requested Info"
-msgstr ""
-
-#: static/js/zamboni/themes_review.js:177
-msgid "Flagged"
-msgstr ""
-
-#: static/js/zamboni/themes_review.js:178
-msgid "Duplicate"
-msgstr ""
-
-#: static/js/zamboni/themes_review.js:179
-msgid "Rejected"
-msgstr ""
-
-#: static/js/zamboni/themes_review.js:180
-msgid "Approved"
-msgstr ""
-
-#: static/js/zamboni/themes_review.js:424
-msgid "No results found"
-msgstr ""
-
-#: static/js/zamboni/themes_review_templates.js:31
+#: static/js/zamboni/editors-all.js:15975 static/js/zamboni/editors-min.js:5 static/js/zamboni/themes_review_templates.js:31
 msgid "Theme"
 msgstr ""
 
-#: static/js/zamboni/themes_review_templates.js:33
+#: static/js/zamboni/editors-all.js:15977 static/js/zamboni/editors-min.js:5 static/js/zamboni/themes_review_templates.js:33
 msgid "Reviewer"
 msgstr ""
 
-#: static/js/zamboni/themes_review_templates.js:35
+#: static/js/zamboni/editors-all.js:15979 static/js/zamboni/editors-min.js:5 static/js/zamboni/themes_review_templates.js:35
 msgid "Status"
 msgstr ""
 
-#: static/js/zamboni/validator.js:80
-msgid "All tests passed successfully."
+#: static/js/zamboni/editors-all.js:16196 static/js/zamboni/editors-min.js:5 static/js/zamboni/themes_review.js:176
+msgid "Requested Info"
 msgstr ""
 
-#: static/js/zamboni/validator.js:83 static/js/zamboni/validator.js:478
-msgid "These tests were not run."
+#: static/js/zamboni/editors-all.js:16197 static/js/zamboni/editors-min.js:5 static/js/zamboni/themes_review.js:177
+msgid "Flagged"
 msgstr ""
 
-#: static/js/zamboni/validator.js:131 static/js/zamboni/validator.js:144
-msgid "Tests"
+#: static/js/zamboni/editors-all.js:16198 static/js/zamboni/editors-min.js:5 static/js/zamboni/themes_review.js:178
+msgid "Duplicate"
 msgstr ""
 
-#: static/js/zamboni/validator.js:246 static/js/zamboni/validator.js:575 static/js/zamboni/validator.js:594
-msgid "Error"
+#: static/js/zamboni/editors-all.js:16199 static/js/zamboni/editors-min.js:5 static/js/zamboni/themes_review.js:179
+msgid "Rejected"
 msgstr ""
 
-#: static/js/zamboni/validator.js:247
-msgid "Warning"
+#: static/js/zamboni/editors-all.js:16200 static/js/zamboni/editors-min.js:5 static/js/zamboni/themes_review.js:180
+msgid "Approved"
 msgstr ""
 
-#: static/js/zamboni/validator.js:299
-msgid "Suggestions for passing automated signing:"
+#: static/js/zamboni/editors-all.js:16444 static/js/zamboni/editors-min.js:5 static/js/zamboni/themes_review.js:424
+msgid "No results found"
 msgstr ""
 
-#: static/js/zamboni/validator.js:387
-msgid "Compatibility Tests"
-msgstr ""
-
-#: static/js/zamboni/validator.js:466
-msgid "Add-on failed validation."
-msgstr ""
-
-#: static/js/zamboni/validator.js:468
-msgid "Add-on passed validation."
-msgstr ""
-
-#: static/js/zamboni/validator.js:481
-msgid "{0} error"
-msgid_plural "{0} errors"
-msgstr[0] ""
-msgstr[1] ""
-
-#: static/js/zamboni/validator.js:483
-msgid "{0} warning"
-msgid_plural "{0} warnings"
-msgstr[0] ""
-msgstr[1] ""
-
-#: static/js/zamboni/validator.js:485
-msgid "{0} notice"
-msgid_plural "{0} notices"
-msgstr[0] ""
-msgstr[1] ""
-
-#: static/js/zamboni/validator.js:577
-msgid "Validation task could not complete or completed with errors"
-msgstr ""
-
-#: static/js/zamboni/validator.js:595
-msgid "Internal server error"
-msgstr ""
-
-#: static/js/zamboni/mobile/buttons.js:52
+#: static/js/zamboni/mobile-all.js:15186 static/js/zamboni/mobile/buttons.js:52
 msgid "Not Updated for {0} {1}"
 msgstr ""
 
-#: static/js/zamboni/mobile/buttons.js:53
+#: static/js/zamboni/mobile-all.js:15187 static/js/zamboni/mobile/buttons.js:53
 msgid "Requires Newer Version of {0}"
 msgstr ""
 
-#: static/js/zamboni/mobile/buttons.js:54
+#: static/js/zamboni/mobile-all.js:15188 static/js/zamboni/mobile/buttons.js:54
 msgid "Unreviewed"
 msgstr ""
 
-#: static/js/zamboni/mobile/buttons.js:55
+#: static/js/zamboni/mobile-all.js:15189 static/js/zamboni/mobile/buttons.js:55
 msgid "Experimental <span>(Learn More)</span>"
 msgstr ""
 
-#: static/js/zamboni/mobile/buttons.js:56 static/js/zamboni/mobile/buttons.js:57
+#: static/js/zamboni/mobile-all.js:15190 static/js/zamboni/mobile-all.js:15191 static/js/zamboni/mobile/buttons.js:56 static/js/zamboni/mobile/buttons.js:57
 msgid "Not Available for {0}"
 msgstr ""
 
-#: static/js/zamboni/mobile/buttons.js:58
+#: static/js/zamboni/mobile-all.js:15192 static/js/zamboni/mobile/buttons.js:58
 msgid "Experimental"
 msgstr ""
 
-#: static/js/zamboni/mobile/buttons.js:59
+#: static/js/zamboni/mobile-all.js:15193 static/js/zamboni/mobile/buttons.js:59
 msgid "Themes Require Newer Version of {0}"
 msgstr ""
 
-#: static/js/zamboni/mobile/buttons.js:60
+#: static/js/zamboni/mobile-all.js:15194 static/js/zamboni/mobile/buttons.js:60
 msgid "Themes Require {0}"
 msgstr ""
 
-#: static/js/zamboni/mobile/buttons.js:105
+#: static/js/zamboni/mobile-all.js:15239 static/js/zamboni/mobile/buttons.js:105
 msgid "Installing..."
 msgstr ""
 
-#: static/js/zamboni/mobile/buttons.js:125
+#: static/js/zamboni/mobile-all.js:15259 static/js/zamboni/mobile/buttons.js:125
 msgid "This add-on has been preliminarily reviewed by Mozilla."
 msgstr ""
 
-#: static/js/zamboni/mobile/buttons.js:250
+#: static/js/zamboni/mobile-all.js:15384 static/js/zamboni/mobile/buttons.js:250
 msgid "Keep it"
 msgstr ""
 
-#: static/js/zamboni/mobile/general.js:344
+#: static/js/zamboni/mobile-all.js:16049 static/js/zamboni/mobile-min.js:6 static/js/zamboni/mobile/general.js:344
 msgid "You're trying it on!"
 msgstr ""
 
-#: static/js/zamboni/mobile/general.js:356
+#: static/js/zamboni/mobile-all.js:16061 static/js/zamboni/mobile-min.js:6 static/js/zamboni/mobile/general.js:356
 msgid "Added to Firefox"
 msgstr ""
-

--- a/locale/fi/LC_MESSAGES/django.po
+++ b/locale/fi/LC_MESSAGES/django.po
@@ -6,80 +6,71 @@ msgid ""
 msgstr ""
 "Project-Id-Version: REMORA 0.1\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2016-02-24 21:23+0000\n"
+"POT-Creation-Date: 2016-04-18 15:47+0000\n"
 "PO-Revision-Date: 2016-04-16 20:47+0000\n"
 "Last-Translator: Lasse Liehu <lasse.liehu@gmail.com>\n"
 "Language-Team: Finnish <yllapito@mozilla.fi>\n"
 "Language: fi\n"
 "MIME-Version: 1.0\n"
-"Content-Type: text/plain; charset=utf-8\n"
+"Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 "Generated-By: Babel 2.2.0\n"
-"X-Generator: Pontoon\n"
 
-#: src/olympia/accounts/views.py:52
+#: src/olympia/accounts/views.py:54
 msgid "Your log in attempt could not be parsed. Please try again."
 msgstr ""
 
-#: src/olympia/accounts/views.py:54
+#: src/olympia/accounts/views.py:56
 msgid "Your Firefox Account could not be found. Please try again."
 msgstr ""
 
-#: src/olympia/accounts/views.py:55
+#: src/olympia/accounts/views.py:57
 msgid "You could not be logged in. Please try again."
 msgstr ""
 
-#: src/olympia/accounts/views.py:57
+#: src/olympia/accounts/views.py:59
 msgid "Your account has already been migrated to Firefox Accounts."
 msgstr ""
 
-#: src/olympia/accounts/views.py:59
+#: src/olympia/accounts/views.py:61
 msgid "Your Firefox Account already exists on this site."
 msgstr ""
 
-#: src/olympia/accounts/views.py:108
+#: src/olympia/accounts/views.py:110
 msgid "Great job!"
 msgstr "Hyvää työtä!"
 
-#: src/olympia/accounts/views.py:109
+#: src/olympia/accounts/views.py:111
 msgid "You can now log in to Add-ons with your Firefox Account."
 msgstr ""
 
-#: src/olympia/accounts/views.py:121
+#: src/olympia/accounts/views.py:123
 msgid "Need help?"
 msgstr "Tarvitsetko apua?"
 
-#: src/olympia/addons/buttons.py:180
+#: src/olympia/addons/buttons.py:177
 msgid "Download Now"
 msgstr "Lataa nyt"
 
-#: src/olympia/addons/buttons.py:182
+#: src/olympia/addons/buttons.py:179
 msgid "Download"
 msgstr "Lataa"
 
 #. L10n: please keep &nbsp; in the string so &rarr; does not wrap.
-#: src/olympia/addons/buttons.py:186
+#: src/olympia/addons/buttons.py:183
 msgid "Continue to Download&nbsp;&rarr;"
 msgstr "Jatka lataukseen&nbsp;&rarr;"
 
-#: src/olympia/addons/buttons.py:202 src/olympia/addons/helpers.py:35
-#: src/olympia/addons/views.py:319
-#: src/olympia/addons/templates/addons/impala/details.html:114
-#: src/olympia/addons/templates/addons/impala/listing/items.html:17
-#: src/olympia/addons/templates/addons/mobile/home.html:40
-#: src/olympia/amo/templates/amo/side_nav.html:6
-#: src/olympia/amo/templates/amo/side_nav.html:10
-#: src/olympia/amo/templates/amo/site_nav.html:2
-#: src/olympia/amo/templates/amo/site_nav.html:55
-#: src/olympia/bandwagon/views.py:95 src/olympia/browse/views.py:54
-#: src/olympia/browse/views.py:68 src/olympia/browse/views.py:235
-#: src/olympia/browse/templates/browse/impala/category_landing.html:22
+#: src/olympia/addons/buttons.py:199 src/olympia/addons/helpers.py:35 src/olympia/addons/views.py:333 src/olympia/addons/templates/addons/impala/details.html:111
+#: src/olympia/addons/templates/addons/impala/listing/items.html:17 src/olympia/addons/templates/addons/mobile/home.html:40 src/olympia/amo/templates/amo/side_nav.html:6
+#: src/olympia/amo/templates/amo/side_nav.html:10 src/olympia/amo/templates/amo/site_nav.html:2 src/olympia/amo/templates/amo/site_nav.html:53 src/olympia/bandwagon/views.py:95
+#: src/olympia/browse/views.py:54 src/olympia/browse/views.py:68 src/olympia/browse/views.py:202 src/olympia/browse/templates/browse/impala/category_landing.html:22
 #: src/olympia/browse/templates/browse/personas/mobile/category_landing.html:26
 msgid "Featured"
 msgstr "Suositeltu"
 
-#: src/olympia/addons/buttons.py:221
+#: src/olympia/addons/buttons.py:218
 msgid "Add to {0}"
 msgstr "Lisää {0}iin"
 
@@ -118,8 +109,7 @@ msgstr[1] ""
 
 #: src/olympia/addons/forms.py:117
 #, python-format
-msgid ""
-"All tags must be %s characters or less after invalid characters are removed."
+msgid "All tags must be %s characters or less after invalid characters are removed."
 msgstr ""
 
 #: src/olympia/addons/forms.py:121
@@ -128,45 +118,39 @@ msgid_plural "All tags must be at least {0} characters."
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/olympia/addons/forms.py:234
-msgid ""
-"Categories cannot be changed while your add-on is featured for this "
-"application."
+#: src/olympia/addons/forms.py:238
+msgid "Categories cannot be changed while your add-on is featured for this application."
 msgstr ""
 
 #. L10n: {0} is the number of categories.
-#: src/olympia/addons/forms.py:238
+#: src/olympia/addons/forms.py:242
 msgid "You can have only {0} category."
 msgid_plural "You can have only {0} categories."
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/olympia/addons/forms.py:246
-msgid ""
-"The miscellaneous category cannot be combined with additional categories."
+#: src/olympia/addons/forms.py:250
+msgid "The miscellaneous category cannot be combined with additional categories."
 msgstr ""
 
-#: src/olympia/addons/forms.py:369
+#: src/olympia/addons/forms.py:374
 #, python-format
-msgid ""
-"Before changing your default locale you must have a name, summary, and "
-"description in that locale. You are missing %s."
+msgid "Before changing your default locale you must have a name, summary, and description in that locale. You are missing %s."
 msgstr ""
 
-#: src/olympia/addons/forms.py:484 src/olympia/addons/forms.py:575
+#: src/olympia/addons/forms.py:455 src/olympia/addons/forms.py:546
 msgid "A license must be selected."
 msgstr ""
 
-#: src/olympia/addons/forms.py:556
+#: src/olympia/addons/forms.py:527
 msgid "Give Your Theme a Name."
 msgstr "Anna teemallesi nimi."
 
-#: src/olympia/addons/forms.py:562
-#: src/olympia/devhub/templates/devhub/personas/submit.html:53
+#: src/olympia/addons/forms.py:533 src/olympia/devhub/templates/devhub/personas/submit.html:53
 msgid "Describe your Theme."
 msgstr ""
 
-#: src/olympia/addons/forms.py:704
+#: src/olympia/addons/forms.py:675
 msgid "Enter a new author's email address"
 msgstr ""
 
@@ -175,46 +159,39 @@ msgstr ""
 msgid "Not Reviewed"
 msgstr "Ei tarkastettu"
 
-#: src/olympia/addons/models.py:301
+#: src/olympia/addons/models.py:298
 msgid "Users have the option of contributing more or less than this amount."
 msgstr ""
 
-#: src/olympia/addons/models.py:309
-msgid ""
-"Users will always be asked in the Add-ons Manager (Firefox 4 and above)"
+#: src/olympia/addons/models.py:306
+msgid "Users will always be asked in the Add-ons Manager (Firefox 4 and above). Only applies to desktop."
 msgstr ""
 
 # Column name in a table.
-#: src/olympia/addons/models.py:1804
-#: src/olympia/addons/templates/addons/details_box.html:55
-#: src/olympia/devhub/templates/devhub/index.html:92
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:102
+#: src/olympia/addons/models.py:1802 src/olympia/addons/templates/addons/details_box.html:55 src/olympia/devhub/templates/devhub/index.html:92
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:89
 msgid "Listed"
 msgstr "Listattu"
 
-#: src/olympia/addons/views.py:320
-#: src/olympia/browse/templates/browse/personas/mobile/category_landing.html:27
+#: src/olympia/addons/views.py:334 src/olympia/browse/templates/browse/personas/mobile/category_landing.html:27
 msgid "Popular"
 msgstr "Suosittu"
 
-#: src/olympia/addons/views.py:321 src/olympia/browse/views.py:238
-#: src/olympia/browse/views.py:280 src/olympia/browse/views.py:482
+#: src/olympia/addons/views.py:335 src/olympia/browse/views.py:205 src/olympia/browse/views.py:247 src/olympia/browse/views.py:449
 msgid "Recently Added"
 msgstr "Viimeksi lisätyt"
 
-#: src/olympia/addons/views.py:322 src/olympia/bandwagon/views.py:99
-#: src/olympia/browse/views.py:60 src/olympia/browse/views.py:71
-#: src/olympia/search/forms.py:16 src/olympia/search/forms.py:91
+#: src/olympia/addons/views.py:336 src/olympia/bandwagon/views.py:99 src/olympia/browse/views.py:60 src/olympia/browse/views.py:71 src/olympia/search/forms.py:16 src/olympia/search/forms.py:91
 msgid "Recently Updated"
 msgstr "Viimeksi päivitetyt"
 
-#. l10n: {0} is the addon name
 # %1 is an add-on name.
-#: src/olympia/addons/views.py:520
+#. l10n: {0} is the addon name
+#: src/olympia/addons/views.py:534
 msgid "Contribution for {0}"
 msgstr "Avustus lisäosalle {0}"
 
-#: src/olympia/addons/views.py:613
+#: src/olympia/addons/views.py:627
 msgid "Abuse reported."
 msgstr "Väärinkäyttö ilmoitettu."
 
@@ -222,111 +199,70 @@ msgstr "Väärinkäyttö ilmoitettu."
 msgid "My add-on doesn't fit into any of the categories"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/button.html:27
-#: src/olympia/addons/templates/addons/impala/button.html:11
-#: src/olympia/addons/templates/addons/mobile/button.html:11
+#: src/olympia/addons/templates/addons/button.html:27 src/olympia/addons/templates/addons/impala/button.html:11 src/olympia/addons/templates/addons/mobile/button.html:11
 msgid "No compatible versions"
 msgstr "Ei yhteensopivia versioita"
 
-#: src/olympia/addons/templates/addons/button.html:35
-#: src/olympia/addons/templates/addons/impala/button.html:19
+#: src/olympia/addons/templates/addons/button.html:35 src/olympia/addons/templates/addons/impala/button.html:19
 msgid "Added to Mobile"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/button.html:37
-#: src/olympia/addons/templates/addons/impala/button.html:21
+#: src/olympia/addons/templates/addons/button.html:37 src/olympia/addons/templates/addons/impala/button.html:21
 msgid "Add to Mobile"
 msgstr ""
 
 #. {0} is a platform name like Windows or Mac OS X.
-#: src/olympia/addons/templates/addons/button.html:66
-#: src/olympia/addons/templates/addons/includes/install_button.html:19
+#: src/olympia/addons/templates/addons/button.html:66 src/olympia/addons/templates/addons/includes/install_button.html:19
 msgid "for {0}"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/button.html:82
-#: src/olympia/addons/templates/addons/mobile/button.html:23
+#: src/olympia/addons/templates/addons/button.html:82 src/olympia/addons/templates/addons/mobile/button.html:23
 msgid "View privacy policy"
 msgstr "Näytä tietosuojakäytäntö"
 
-#: src/olympia/addons/templates/addons/button.html:87
-#: src/olympia/addons/templates/addons/details_box.html:133
-#: src/olympia/addons/templates/addons/mobile/button.html:28
+#: src/olympia/addons/templates/addons/button.html:87 src/olympia/addons/templates/addons/details_box.html:133 src/olympia/addons/templates/addons/mobile/button.html:28
 #: src/olympia/discovery/templates/discovery/addons/detail.html:28
 msgid "View End-User License Agreement"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/button.html:92
-#: src/olympia/addons/templates/addons/impala/button.html:54
+#: src/olympia/addons/templates/addons/button.html:92 src/olympia/addons/templates/addons/impala/button.html:54
 #, python-format
-msgid ""
-"This add-on has not been reviewed by Mozilla. <a href=\"%(url)s\">Learn "
-"more</a>"
-msgstr ""
-"Mozilla ei ole tarkastanut tätä lisäosaa. <a href=\"%(url)s\">Lue lisää</a>"
+msgid "This add-on has not been reviewed by Mozilla. <a href=\"%(url)s\">Learn more</a>"
+msgstr "Mozilla ei ole tarkastanut tätä lisäosaa. <a href=\"%(url)s\">Lue lisää</a>"
 
-#: src/olympia/addons/templates/addons/button.html:97
-#: src/olympia/addons/templates/addons/impala/button.html:60
+#: src/olympia/addons/templates/addons/button.html:97 src/olympia/addons/templates/addons/impala/button.html:60
 #, python-format
-msgid ""
-"This add-on has been preliminarily reviewed by Mozilla. <a "
-"href=\"%(url)s\">Learn more</a>"
-msgstr ""
-"Mozilla on alustavasti tarkastanut tämän lisäosan. <a href=\"%(url)s\">Lue "
-"lisää</a>"
+msgid "This add-on has been preliminarily reviewed by Mozilla. <a href=\"%(url)s\">Learn more</a>"
+msgstr "Mozilla on alustavasti tarkastanut tämän lisäosan. <a href=\"%(url)s\">Lue lisää</a>"
 
-#: src/olympia/addons/templates/addons/contribution.html:11
-#: src/olympia/addons/templates/addons/impala/developers.html:44
-msgid ""
-"The developer of this add-on asks that you help support its continued "
-"development by making a small contribution."
-msgstr ""
-"Tämän lisäosan kehittäjä pyytää, että tuet sen jatkuvaa kehittämistä "
-"antamalla pienen lahjoituksen."
+#: src/olympia/addons/templates/addons/contribution.html:11 src/olympia/addons/templates/addons/impala/developers.html:44
+msgid "The developer of this add-on asks that you help support its continued development by making a small contribution."
+msgstr "Tämän lisäosan kehittäjä pyytää, että tuet sen jatkuvaa kehittämistä antamalla pienen lahjoituksen."
 
 #: src/olympia/addons/templates/addons/contribution.html:14
 #, python-format
-msgid ""
-"The developer of this add-on asks that you show your support by making a "
-"donation to the <a href=\"%(charity_url)s\">%(charity_name)s</a>."
+msgid "The developer of this add-on asks that you show your support by making a donation to the <a href=\"%(charity_url)s\">%(charity_name)s</a>."
 msgstr ""
 
 #: src/olympia/addons/templates/addons/contribution.html:19
 #, python-format
-msgid ""
-"The developer of this add-on asks that you show your support by making a "
-"small contribution to <a href=\"%(charity_url)s\">%(charity_name)s</a>."
+msgid "The developer of this add-on asks that you show your support by making a small contribution to <a href=\"%(charity_url)s\">%(charity_name)s</a>."
 msgstr ""
 
-#: src/olympia/addons/templates/addons/contribution.html:30
-#: src/olympia/addons/templates/addons/impala/contribution.html:18
-#: src/olympia/templates/menu_links.html:25
+#: src/olympia/addons/templates/addons/contribution.html:30 src/olympia/addons/templates/addons/impala/contribution.html:18 src/olympia/templates/menu_links.html:25
 msgid "Contribute"
 msgstr "Lahjoita"
 
-#. Click Contribute button OR Install button
 # This is a separator between the graphical [contribute] button and the
 # graphical [download now] button
-#: src/olympia/addons/templates/addons/contribution.html:34
-#: src/olympia/addons/templates/addons/report_abuse.html:26
-#: src/olympia/addons/templates/addons/impala/contribution.html:32
-#: src/olympia/devhub/templates/devhub/addons/ajax_compat_update.html:36
-#: src/olympia/devhub/templates/devhub/addons/profile.html:44
-#: src/olympia/devhub/templates/devhub/addons/edit/admin.html:101
-#: src/olympia/devhub/templates/devhub/addons/edit/basic.html:152
-#: src/olympia/devhub/templates/devhub/addons/edit/details.html:85
-#: src/olympia/devhub/templates/devhub/addons/edit/support.html:67
-#: src/olympia/devhub/templates/devhub/addons/edit/technical.html:166
-#: src/olympia/devhub/templates/devhub/addons/forms_shared/media.html:149
-#: src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:44
-#: src/olympia/devhub/templates/devhub/versions/add_file_modal.html:78
-#: src/olympia/devhub/templates/devhub/versions/edit.html:139
-#: src/olympia/devhub/templates/devhub/versions/list.html:242
-#: src/olympia/devhub/templates/devhub/versions/list.html:276
-#: src/olympia/devhub/templates/devhub/versions/list.html:317
-#: src/olympia/devhub/templates/devhub/versions/list.html:351
-#: src/olympia/reviews/templates/reviews/edit_review.html:16
-#: src/olympia/translations/templates/translations/trans-menu.html:50
+#. Click Contribute button OR Install button
+#: src/olympia/addons/templates/addons/contribution.html:34 src/olympia/addons/templates/addons/report_abuse.html:26 src/olympia/addons/templates/addons/impala/contribution.html:32
+#: src/olympia/devhub/templates/devhub/addons/ajax_compat_update.html:36 src/olympia/devhub/templates/devhub/addons/profile.html:44 src/olympia/devhub/templates/devhub/addons/edit/admin.html:101
+#: src/olympia/devhub/templates/devhub/addons/edit/basic.html:152 src/olympia/devhub/templates/devhub/addons/edit/details.html:85 src/olympia/devhub/templates/devhub/addons/edit/support.html:67
+#: src/olympia/devhub/templates/devhub/addons/edit/technical.html:166 src/olympia/devhub/templates/devhub/addons/forms_shared/media.html:149
+#: src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:43 src/olympia/devhub/templates/devhub/versions/add_file_modal.html:58 src/olympia/devhub/templates/devhub/versions/edit.html:139
+#: src/olympia/devhub/templates/devhub/versions/list.html:239 src/olympia/devhub/templates/devhub/versions/list.html:281 src/olympia/devhub/templates/devhub/versions/list.html:315
+#: src/olympia/devhub/templates/devhub/versions/list.html:349 src/olympia/reviews/templates/reviews/edit_review.html:16 src/olympia/translations/templates/translations/trans-menu.html:50
 #: src/olympia/translations/templates/translations/trans-menu.html:62
 msgid "or"
 msgstr "tai"
@@ -336,32 +272,22 @@ msgid "Suggested Contribution: {0}"
 msgstr "Suositeltu lahjoitus: {0}"
 
 # 100%
-#: src/olympia/addons/templates/addons/contribution.html:48
-#: src/olympia/amo/templates/amo/recaptcha.html:5
-#: src/olympia/versions/templates/versions/version.html:52
+#: src/olympia/addons/templates/addons/contribution.html:48 src/olympia/amo/templates/amo/recaptcha.html:5 src/olympia/versions/templates/versions/version.html:52
 msgid "What's this?"
 msgstr "Mikä tämä on?"
 
 #: src/olympia/addons/templates/addons/contribution.html:63
 #, python-format
-msgid ""
-"The developer of this add-on would like you to consider making a donation to"
-" the <a href=\"%(charity_url)s\">%(charity_name)s</a> if you enjoy using it."
+msgid "The developer of this add-on would like you to consider making a donation to the <a href=\"%(charity_url)s\">%(charity_name)s</a> if you enjoy using it."
 msgstr ""
 
 #: src/olympia/addons/templates/addons/contribution.html:69
 #, python-format
-msgid ""
-"The developer of this add-on would like you to consider making a small "
-"contribution to <a href=\"%(charity_url)s\">%(charity_name)s</a> if you "
-"enjoy using it."
+msgid "The developer of this add-on would like you to consider making a small contribution to <a href=\"%(charity_url)s\">%(charity_name)s</a> if you enjoy using it."
 msgstr ""
 
 #: src/olympia/addons/templates/addons/contribution.html:76
-msgid ""
-"Mozilla is committed to supporting a vibrant and healthy developer "
-"ecosystem. Your optional contribution helps sustain further development of "
-"this add-on."
+msgid "Mozilla is committed to supporting a vibrant and healthy developer ecosystem. Your optional contribution helps sustain further development of this add-on."
 msgstr ""
 
 #: src/olympia/addons/templates/addons/contributions_lightbox.html:5
@@ -370,26 +296,20 @@ msgstr "Tee lahjoitus"
 
 #: src/olympia/addons/templates/addons/contributions_lightbox.html:9
 #, python-format
-msgid ""
-"Help support the continued development of <strong>%(addon_name)s</strong> by"
-" making a small contribution through <a href=\"%(paypal_url)s\">PayPal</a>."
+msgid "Help support the continued development of <strong>%(addon_name)s</strong> by making a small contribution through <a href=\"%(paypal_url)s\">PayPal</a>."
 msgstr ""
 
 #: src/olympia/addons/templates/addons/contributions_lightbox.html:15
 #, python-format
 msgid ""
-"To show your support for <b>%(addon_name)s</b>, the developer asks that you "
-"make a donation to the <a href=\"%(charity_url)s\">%(charity_name)s</a> "
-"through <a href=\"%(paypal_url)s\">PayPal</a>."
+"To show your support for <b>%(addon_name)s</b>, the developer asks that you make a donation to the <a href=\"%(charity_url)s\">%(charity_name)s</a> through <a href=\"%(paypal_url)s\">PayPal</a>."
 msgstr ""
 
 #: src/olympia/addons/templates/addons/contributions_lightbox.html:21
 #, python-format
 msgid ""
-"To show your support for <b>%(addon_name)s</b>, the developer asks that you "
-"make a small contribution to <a "
-"href=\"%(charity_url)s\">%(charity_name)s</a> through <a "
-"href=\"%(paypal_url)s\">PayPal</a>."
+"To show your support for <b>%(addon_name)s</b>, the developer asks that you make a small contribution to <a href=\"%(charity_url)s\">%(charity_name)s</a> through <a href=\"%(paypal_url)s\">PayPal</"
+"a>."
 msgstr ""
 
 #: src/olympia/addons/templates/addons/contributions_lightbox.html:30
@@ -413,8 +333,7 @@ msgstr ""
 msgid "A one-time suggested contribution of {0}"
 msgstr "Suositeltu {0} kertalahjoitus"
 
-#. {0} is a currency symbol (e.g., $),                    {1} is an amount
-#. input
+#. {0} is a currency symbol (e.g., $),                    {1} is an amount input
 #. field
 #: src/olympia/addons/templates/addons/contributions_lightbox.html:64
 msgid "A one-time contribution of {0} {1}"
@@ -424,11 +343,8 @@ msgstr ""
 msgid "Leave a comment or request with your contribution."
 msgstr "Lahjoituksesi oheen liitettävä kommentti tai pyyntö"
 
-#: src/olympia/addons/templates/addons/contributions_lightbox.html:74
-#: src/olympia/bandwagon/templates/bandwagon/ajax_new.html:20
-#: src/olympia/bandwagon/templates/bandwagon/includes/addedit.html:37
-#: src/olympia/reviews/templates/reviews/mobile/add_form.html:13
-#: src/olympia/templates/includes/forms.html:10
+#: src/olympia/addons/templates/addons/contributions_lightbox.html:74 src/olympia/bandwagon/templates/bandwagon/ajax_new.html:20 src/olympia/bandwagon/templates/bandwagon/includes/addedit.html:37
+#: src/olympia/reviews/templates/reviews/mobile/add_form.html:13 src/olympia/templates/includes/forms.html:10
 msgid "(optional)"
 msgstr "(valinnainen)"
 
@@ -448,36 +364,27 @@ msgstr "Ei kiitos"
 msgid "Contribution made, thank you."
 msgstr ""
 
-#: src/olympia/addons/templates/addons/details_box.html:10
-#: src/olympia/discovery/templates/discovery/addons/detail.html:19
+#: src/olympia/addons/templates/addons/details_box.html:10 src/olympia/discovery/templates/discovery/addons/detail.html:19
 msgid "No restart required"
 msgstr "Uudelleenkäynnistystä ei vaadita"
 
 #. This is a caption for a table. {0} is an add-on name.
-#: src/olympia/addons/templates/addons/details_box.html:26
-#: src/olympia/addons/templates/addons/includes/persona.html:9
+#: src/olympia/addons/templates/addons/details_box.html:26 src/olympia/addons/templates/addons/includes/persona.html:9
 msgid "Add-on Information for {0}"
 msgstr "Lisäosan {0} tiedot"
 
-#: src/olympia/addons/templates/addons/details_box.html:30
-#: src/olympia/addons/templates/addons/persona_detail_table.html:3
-#: src/olympia/addons/templates/addons/mobile/details.html:63
-#: src/olympia/addons/templates/addons/mobile/persona_detail_table.html:7
-#: src/olympia/browse/views.py:459 src/olympia/devhub/views.py:75
+#: src/olympia/addons/templates/addons/details_box.html:30 src/olympia/addons/templates/addons/persona_detail_table.html:3 src/olympia/addons/templates/addons/mobile/details.html:63
+#: src/olympia/addons/templates/addons/mobile/persona_detail_table.html:7 src/olympia/browse/views.py:426 src/olympia/devhub/views.py:73
 msgid "Updated"
 msgstr "Päivitetty"
 
-#: src/olympia/addons/templates/addons/details_box.html:38
-#: src/olympia/addons/templates/addons/mobile/details.html:71
-#: src/olympia/devhub/templates/devhub/addons/edit/support.html:43
+#: src/olympia/addons/templates/addons/details_box.html:38 src/olympia/addons/templates/addons/mobile/details.html:71 src/olympia/devhub/templates/devhub/addons/edit/support.html:43
 #: src/olympia/discovery/templates/discovery/addons/detail.html:77
 msgid "Website"
 msgstr "Verkkosivu"
 
 #. This refers to this version's compatible applications, such as Firefox 8.0
-#: src/olympia/addons/templates/addons/details_box.html:47
-#: src/olympia/addons/templates/addons/mobile/details.html:80
-#: src/olympia/search/templates/search/results.html:72
+#: src/olympia/addons/templates/addons/details_box.html:47 src/olympia/addons/templates/addons/mobile/details.html:80 src/olympia/search/templates/search/results.html:72
 #: src/olympia/versions/templates/versions/version.html:21
 msgid "Works with"
 msgstr "Toimii kohteilla"
@@ -486,48 +393,33 @@ msgstr "Toimii kohteilla"
 msgid "Visibility"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/details_box.html:57
-#: src/olympia/devhub/templates/devhub/index.html:94
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:104
+#: src/olympia/addons/templates/addons/details_box.html:57 src/olympia/devhub/templates/devhub/index.html:94 src/olympia/devhub/templates/devhub/includes/addon_details.html:91
 msgid "Hidden"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/details_box.html:59
-#: src/olympia/devhub/templates/devhub/index.html:96
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:106
+#: src/olympia/addons/templates/addons/details_box.html:59 src/olympia/devhub/templates/devhub/index.html:96 src/olympia/devhub/templates/devhub/includes/addon_details.html:93
 msgid "Unlisted"
 msgstr ""
 
 # 75%
-#: src/olympia/addons/templates/addons/details_box.html:67
-#: src/olympia/devhub/templates/devhub/addons/edit/technical.html:44
+#: src/olympia/addons/templates/addons/details_box.html:67 src/olympia/devhub/templates/devhub/addons/edit/technical.html:44
 #, fuzzy
 msgid "Required Add-ons"
 msgstr "Suositellut lisäosat"
 
-#: src/olympia/addons/templates/addons/details_box.html:81
-#: src/olympia/addons/templates/addons/persona_detail_table.html:15
-#: src/olympia/browse/views.py:462 src/olympia/devhub/views.py:78
-#: src/olympia/devhub/views.py:85
-#: src/olympia/discovery/templates/discovery/addons/detail.html:57
-#: src/olympia/reviews/forms.py:62
-#: src/olympia/reviews/templates/reviews/add.html:57
+#: src/olympia/addons/templates/addons/details_box.html:81 src/olympia/addons/templates/addons/persona_detail_table.html:15 src/olympia/browse/views.py:429 src/olympia/devhub/views.py:76
+#: src/olympia/devhub/views.py:83 src/olympia/discovery/templates/discovery/addons/detail.html:57 src/olympia/reviews/forms.py:62 src/olympia/reviews/templates/reviews/add.html:57
 #: src/olympia/reviews/templates/reviews/mobile/review_list.html:18
 msgid "Rating"
 msgstr "Arvosana"
 
 # 100%
-#: src/olympia/addons/templates/addons/details_box.html:85
-#: src/olympia/browse/views.py:461 src/olympia/devhub/views.py:77
-#: src/olympia/devhub/views.py:84
-#: src/olympia/stats/templates/stats/addon_report_menu.html:8
-#: src/olympia/stats/templates/stats/collection_report_menu.html:18
+#: src/olympia/addons/templates/addons/details_box.html:85 src/olympia/browse/views.py:428 src/olympia/devhub/views.py:75 src/olympia/devhub/views.py:82
+#: src/olympia/stats/templates/stats/addon_report_menu.html:8 src/olympia/stats/templates/stats/collection_report_menu.html:18
 msgid "Downloads"
 msgstr "Lataukset"
 
-#: src/olympia/addons/templates/addons/details_box.html:91
-#: src/olympia/addons/templates/addons/details_box.html:103
-#: src/olympia/devhub/templates/devhub/addons/listing/item_actions_theme.html:17
+#: src/olympia/addons/templates/addons/details_box.html:91 src/olympia/addons/templates/addons/details_box.html:103 src/olympia/devhub/templates/devhub/addons/listing/item_actions_theme.html:17
 #: src/olympia/devhub/templates/devhub/personas/edit.html:60
 msgid "View Statistics"
 msgstr "Näytä tilastoja"
@@ -541,18 +433,13 @@ msgid "Abuse Reports"
 msgstr ""
 
 #. The Privacy Policy for this add-on.
-#: src/olympia/addons/templates/addons/details_box.html:121
-#: src/olympia/addons/templates/addons/privacy.html:19
-#: src/olympia/addons/templates/addons/privacy.html:23
-#: src/olympia/addons/templates/addons/impala/button.html:43
-#: src/olympia/addons/templates/addons/impala/details.html:307
-#: src/olympia/devhub/templates/devhub/includes/policy_form.html:20
+#: src/olympia/addons/templates/addons/details_box.html:121 src/olympia/addons/templates/addons/privacy.html:19 src/olympia/addons/templates/addons/privacy.html:23
+#: src/olympia/addons/templates/addons/impala/button.html:43 src/olympia/addons/templates/addons/impala/details.html:312 src/olympia/devhub/templates/devhub/includes/policy_form.html:23
 #: src/olympia/templates/mobile/base_addons.html:87
 msgid "Privacy Policy"
 msgstr "Tietosuojakäytäntö"
 
-#: src/olympia/addons/templates/addons/details_box.html:124
-#: src/olympia/discovery/templates/discovery/addons/detail.html:24
+#: src/olympia/addons/templates/addons/details_box.html:124 src/olympia/discovery/templates/discovery/addons/detail.html:24
 msgid "View Privacy Policy"
 msgstr "Näytä tietosuojakäytäntö"
 
@@ -560,8 +447,7 @@ msgstr "Näytä tietosuojakäytäntö"
 msgid "EULA"
 msgstr "EULA"
 
-#: src/olympia/addons/templates/addons/details_box.html:171
-#: src/olympia/addons/templates/addons/details_box.html:231
+#: src/olympia/addons/templates/addons/details_box.html:171 src/olympia/addons/templates/addons/details_box.html:231
 msgid "More about this add-on"
 msgstr "Lisätietoja tästä lisäosasta"
 
@@ -570,26 +456,21 @@ msgid "Image Gallery"
 msgstr "Kuvagalleria"
 
 # 100%
-#: src/olympia/addons/templates/addons/details_box.html:190
-#: src/olympia/devhub/templates/devhub/addons/edit/technical.html:21
+#: src/olympia/addons/templates/addons/details_box.html:190 src/olympia/devhub/templates/devhub/addons/edit/technical.html:21
 msgid "Developer Comments"
 msgstr "Kehittäjän kommentit"
 
-#: src/olympia/addons/templates/addons/details_box.html:199
-#: src/olympia/addons/templates/addons/impala/details.html:259
+#: src/olympia/addons/templates/addons/details_box.html:199 src/olympia/addons/templates/addons/impala/details.html:264
 msgid "Development Channel"
 msgstr "Kehityskanava"
 
-#: src/olympia/addons/templates/addons/details_box.html:202
-#: src/olympia/addons/templates/addons/mobile/details.html:124
+#: src/olympia/addons/templates/addons/details_box.html:202 src/olympia/addons/templates/addons/mobile/details.html:124
 msgid ""
-"The Development Channel lets you test an experimental new version of this "
-"add-on before it's released to the general public. Once you install the "
-"development version, you will continue to get updates from this channel."
+"The Development Channel lets you test an experimental new version of this add-on before it's released to the general public. Once you install the development version, you will continue to get "
+"updates from this channel."
 msgstr ""
-"Kehityskanavan avulla voit testata lisäosan tekeillä olevia uusia versioita "
-"ennen kuin ne julkaistaan suurelle yleisölle. Kun olet asentanut "
-"kehitysversion, saat jatkossakin päivitykset tältä kanavalta."
+"Kehityskanavan avulla voit testata lisäosan tekeillä olevia uusia versioita ennen kuin ne julkaistaan suurelle yleisölle. Kun olet asentanut kehitysversion, saat jatkossakin päivitykset tältä "
+"kanavalta."
 
 #: src/olympia/addons/templates/addons/details_box.html:207
 msgid "Install development version"
@@ -597,19 +478,13 @@ msgstr "Asenna kehitysversio"
 
 #: src/olympia/addons/templates/addons/details_box.html:211
 msgid ""
-"<strong>Caution:</strong> Development versions of this add-on have not been "
-"reviewed by Mozilla. Once you install a development version you will "
-"continue to receive development updates from this developer. To stop "
-"receiving development updates, reinstall the default version from the link "
-"above."
+"<strong>Caution:</strong> Development versions of this add-on have not been reviewed by Mozilla. Once you install a development version you will continue to receive development updates from this "
+"developer. To stop receiving development updates, reinstall the default version from the link above."
 msgstr ""
-"<strong>Varoitus:</strong> Mozilla ei ole tarkastanut tämän lisäosan "
-"kehitysversioita. Kun asennat kehitysversion, saat jatkossakin kehityksen "
-"päivitykset tältä kehittäjältä. Jos haluat lopettaa kehityspäivitysten "
-"vastaanottamisen, asenna oletusversio yllä olevasta linkistä."
+"<strong>Varoitus:</strong> Mozilla ei ole tarkastanut tämän lisäosan kehitysversioita. Kun asennat kehitysversion, saat jatkossakin kehityksen päivitykset tältä kehittäjältä. Jos haluat lopettaa "
+"kehityspäivitysten vastaanottamisen, asenna oletusversio yllä olevasta linkistä."
 
-#: src/olympia/addons/templates/addons/details_box.html:220
-#: src/olympia/addons/templates/addons/impala/details.html:278
+#: src/olympia/addons/templates/addons/details_box.html:220 src/olympia/addons/templates/addons/impala/details.html:283
 msgid "Version {0}:"
 msgstr "Versio {0}:"
 
@@ -617,55 +492,38 @@ msgstr "Versio {0}:"
 msgid "Nothing to see here!  The developer did not include any details."
 msgstr ""
 
-#: src/olympia/addons/templates/addons/details_box.html:251
-#: src/olympia/devhub/templates/devhub/versions/edit.html:73
-#: src/olympia/editors/templates/editors/review.html:98
+#: src/olympia/addons/templates/addons/details_box.html:251 src/olympia/devhub/templates/devhub/versions/edit.html:73 src/olympia/editors/templates/editors/review.html:98
 msgid "Version Notes"
 msgstr "Versiokommentit"
 
 #. {0} is the name of the add-on.
 #. {0} is the name of the add-on
-#: src/olympia/addons/templates/addons/eula.html:6
-#: src/olympia/discovery/templates/discovery/addons/eula.html:5
+#: src/olympia/addons/templates/addons/eula.html:6 src/olympia/discovery/templates/discovery/addons/eula.html:5
 msgid "End-User License Agreement for {0}"
 msgstr "Loppukäyttäjän lisenssisopimus lisäosalle {0}"
 
-#: src/olympia/addons/templates/addons/eula.html:17
-#: src/olympia/addons/templates/addons/eula.html:21
-#: src/olympia/addons/templates/addons/impala/button.html:48
-#: src/olympia/addons/templates/addons/impala/details.html:316
-#: src/olympia/devhub/templates/devhub/includes/policy_form.html:3
-#: src/olympia/discovery/templates/discovery/addons/eula.html:11
+#: src/olympia/addons/templates/addons/eula.html:17 src/olympia/addons/templates/addons/eula.html:21 src/olympia/addons/templates/addons/impala/button.html:48
+#: src/olympia/addons/templates/addons/impala/details.html:321 src/olympia/devhub/templates/devhub/includes/policy_form.html:3 src/olympia/discovery/templates/discovery/addons/eula.html:11
 msgid "End-User License Agreement"
 msgstr "Loppukäyttäjän lisenssisopimus"
 
-#: src/olympia/addons/templates/addons/eula.html:23
-#: src/olympia/discovery/templates/discovery/addons/eula.html:13
+#: src/olympia/addons/templates/addons/eula.html:23 src/olympia/discovery/templates/discovery/addons/eula.html:13
 #, python-format
-msgid ""
-"%(addon_name)s requires that you accept the following End-User License "
-"Agreement before installation can proceed:"
-msgstr ""
-"%(addon_name)s vaatii, että hyväksyt seuraavan loppukäyttäjän "
-"lisenssisopimuksen ennen asennuksen jatkamista:"
+msgid "%(addon_name)s requires that you accept the following End-User License Agreement before installation can proceed:"
+msgstr "%(addon_name)s vaatii, että hyväksyt seuraavan loppukäyttäjän lisenssisopimuksen ennen asennuksen jatkamista:"
 
-#: src/olympia/addons/templates/addons/eula.html:34
-#: src/olympia/addons/templates/addons/privacy.html:26
+#: src/olympia/addons/templates/addons/eula.html:34 src/olympia/addons/templates/addons/privacy.html:26
 msgid "Back to {0}…"
 msgstr "Palaa lisäosaan {0}…"
 
 # {0} is the application the user is browsing.  Examples:  Thunderbird,
 # Firefox,
 # Sunbird
-#: src/olympia/addons/templates/addons/home.html:3
-#: src/olympia/addons/templates/addons/mobile/home.html:3
-#: src/olympia/amo/helpers.py:235
+#: src/olympia/addons/templates/addons/home.html:3 src/olympia/addons/templates/addons/mobile/home.html:3 src/olympia/amo/helpers.py:235
 msgid "Add-ons for {0}"
 msgstr "{0}in lisäosat"
 
-#: src/olympia/addons/templates/addons/home.html:10
-#: src/olympia/addons/templates/addons/home.html:51
-#: src/olympia/browse/templates/browse/impala/base_listing.html:11
+#: src/olympia/addons/templates/addons/home.html:10 src/olympia/addons/templates/addons/home.html:53 src/olympia/browse/templates/browse/impala/base_listing.html:11
 msgid "Featured Extensions"
 msgstr "Suositellut laajennukset"
 
@@ -675,72 +533,51 @@ msgstr "Suositellut laajennukset"
 msgid "Popular Extensions"
 msgstr "Suosituimmat laajennukset"
 
-#: src/olympia/addons/templates/addons/home.html:42
-#: src/olympia/amo/templates/amo/side_nav.html:3
-#: src/olympia/amo/templates/amo/side_nav.html:11
-#: src/olympia/amo/templates/amo/site_nav.html:3
-#: src/olympia/amo/templates/amo/site_nav.html:25
-#: src/olympia/browse/views.py:236 src/olympia/browse/views.py:281
-#: src/olympia/browse/views.py:481
+#: src/olympia/addons/templates/addons/home.html:44 src/olympia/amo/templates/amo/side_nav.html:3 src/olympia/amo/templates/amo/side_nav.html:11 src/olympia/amo/templates/amo/site_nav.html:3
+#: src/olympia/amo/templates/amo/site_nav.html:25 src/olympia/browse/views.py:203 src/olympia/browse/views.py:248 src/olympia/browse/views.py:448
 msgid "Most Popular"
 msgstr "Suosituimmat"
 
-#: src/olympia/addons/templates/addons/home.html:43
+#: src/olympia/addons/templates/addons/home.html:45
 msgid "All »"
 msgstr "Kaikki »"
 
-#: src/olympia/addons/templates/addons/home.html:52
-#: src/olympia/addons/templates/addons/home.html:61
-#: src/olympia/addons/templates/addons/home.html:70
-#: src/olympia/addons/templates/addons/home.html:78
+#: src/olympia/addons/templates/addons/home.html:54 src/olympia/addons/templates/addons/home.html:63 src/olympia/addons/templates/addons/home.html:72 src/olympia/addons/templates/addons/home.html:80
 #: src/olympia/browse/templates/browse/impala/category_landing.html:36
 msgid "See all »"
 msgstr "Näytä kaikki »"
 
-#: src/olympia/addons/templates/addons/home.html:60
+#: src/olympia/addons/templates/addons/home.html:62
 msgid "Up &amp; Coming Extensions"
 msgstr "Lupaavat laajennukset"
 
-#: src/olympia/addons/templates/addons/home.html:69
-#: src/olympia/browse/templates/browse/personas/category_landing.html:61
-#: src/olympia/discovery/templates/discovery/pane.html:74
+#: src/olympia/addons/templates/addons/home.html:71 src/olympia/browse/templates/browse/personas/category_landing.html:61 src/olympia/discovery/templates/discovery/pane.html:74
 msgid "Featured Themes"
 msgstr "Suositellut teemat"
 
 # 80%
 # 100%
-#: src/olympia/addons/templates/addons/home.html:77
-#: src/olympia/bandwagon/templates/bandwagon/impala/collection_listing.html:5
+#: src/olympia/addons/templates/addons/home.html:79 src/olympia/bandwagon/templates/bandwagon/impala/collection_listing.html:5
 msgid "Featured Collections"
 msgstr "Suositellut kokoelmat"
 
-#: src/olympia/addons/templates/addons/listing_header.html:3
-#: src/olympia/addons/templates/addons/impala/listing/sorter.html:2
-#: src/olympia/amo/templates/amo/mobile/sort_by.html:2
+#: src/olympia/addons/templates/addons/listing_header.html:3 src/olympia/addons/templates/addons/impala/listing/sorter.html:2 src/olympia/amo/templates/amo/mobile/sort_by.html:2
 #: src/olympia/bandwagon/templates/bandwagon/collection_detail.html:118
 msgid "Sort by:"
 msgstr "Järjestys:"
 
 #. {0} is a date.
 #. {0} is a date
-#: src/olympia/addons/templates/addons/macros.html:7
-#: src/olympia/addons/templates/addons/macros.html:72
-#: src/olympia/addons/templates/addons/listing/items_mobile.html:48
-#: src/olympia/addons/templates/addons/listing/macros.html:42
-#: src/olympia/bandwagon/templates/bandwagon/collection_detail.html:50
-#: src/olympia/bandwagon/templates/bandwagon/collection_listing_items.html:40
-#: src/olympia/bandwagon/templates/bandwagon/impala/collection_listing_items.html:40
+#: src/olympia/addons/templates/addons/macros.html:7 src/olympia/addons/templates/addons/macros.html:72 src/olympia/addons/templates/addons/listing/items_mobile.html:48
+#: src/olympia/addons/templates/addons/listing/macros.html:42 src/olympia/bandwagon/templates/bandwagon/collection_detail.html:50
+#: src/olympia/bandwagon/templates/bandwagon/collection_listing_items.html:40 src/olympia/bandwagon/templates/bandwagon/impala/collection_listing_items.html:40
 msgid "Updated {0}"
 msgstr "Päivitetty {0}"
 
 #. {0} is a date.
-#: src/olympia/addons/templates/addons/macros.html:10
-#: src/olympia/addons/templates/addons/macros.html:69
-#: src/olympia/addons/templates/addons/persona_preview.html:21
-#: src/olympia/addons/templates/addons/listing/items_mobile.html:44
-#: src/olympia/addons/templates/addons/listing/macros.html:39
-#: src/olympia/bandwagon/templates/bandwagon/collection_listing_items.html:37
-#: src/olympia/bandwagon/templates/bandwagon/impala/collection_listing_items.html:37
+#: src/olympia/addons/templates/addons/macros.html:10 src/olympia/addons/templates/addons/macros.html:69 src/olympia/addons/templates/addons/persona_preview.html:22
+#: src/olympia/addons/templates/addons/listing/items_mobile.html:44 src/olympia/addons/templates/addons/listing/macros.html:39
+#: src/olympia/bandwagon/templates/bandwagon/collection_listing_items.html:37 src/olympia/bandwagon/templates/bandwagon/impala/collection_listing_items.html:37
 msgid "Added {0}"
 msgstr "Lisätty {0}"
 
@@ -759,18 +596,14 @@ msgstr[0] "%(num)s käyttäjä"
 msgstr[1] "%(num)s käyttäjää"
 
 #. {0} is the number of downloads.
-#: src/olympia/addons/templates/addons/macros.html:53
-#: src/olympia/addons/templates/addons/impala/details.html:61
+#: src/olympia/addons/templates/addons/macros.html:53 src/olympia/addons/templates/addons/impala/details.html:59
 msgid "{0} weekly download"
 msgid_plural "{0} weekly downloads"
 msgstr[0] "{0} viikoittainen lataus"
 msgstr[1] "{0} viikoittaista latausta"
 
 #. {0} is the number of users.
-#: src/olympia/addons/templates/addons/macros.html:61
-#: src/olympia/addons/templates/addons/impala/details.html:54
-#: src/olympia/compat/templates/compat/index.html:71
-#: src/olympia/zadmin/templates/zadmin/compat.html:67
+#: src/olympia/addons/templates/addons/macros.html:61 src/olympia/addons/templates/addons/impala/details.html:52 src/olympia/zadmin/templates/zadmin/compat.html:67
 msgid "{0} user"
 msgid_plural "{0} users"
 msgstr[0] "{0} käyttäjä"
@@ -788,12 +621,8 @@ msgstr ""
 msgid "Return to the addon."
 msgstr "Siirry takaisin lisäosaan"
 
-#: src/olympia/addons/templates/addons/persona_detail.html:17
-#: src/olympia/addons/templates/addons/impala/details.html:106
-#: src/olympia/addons/templates/addons/mobile/details.html:23
-#: src/olympia/addons/templates/addons/mobile/persona_detail.html:21
-#: src/olympia/discovery/templates/discovery/addons/base.html:27
-#: src/olympia/editors/templates/editors/review.html:31
+#: src/olympia/addons/templates/addons/persona_detail.html:17 src/olympia/addons/templates/addons/impala/details.html:103 src/olympia/addons/templates/addons/mobile/details.html:23
+#: src/olympia/addons/templates/addons/mobile/persona_detail.html:21 src/olympia/discovery/templates/discovery/addons/base.html:27 src/olympia/editors/templates/editors/review.html:31
 msgid "by"
 msgstr "tekijänä"
 
@@ -803,8 +632,7 @@ msgid "More {0} Themes"
 msgstr ""
 
 #. {0} is a category name, such as Nature
-#: src/olympia/addons/templates/addons/persona_detail.html:39
-#: src/olympia/addons/templates/addons/mobile/persona_detail.html:66
+#: src/olympia/addons/templates/addons/persona_detail.html:39 src/olympia/addons/templates/addons/mobile/persona_detail.html:66
 msgid "See all {0} Themes"
 msgstr ""
 
@@ -812,146 +640,106 @@ msgstr ""
 msgid "More by this Artist"
 msgstr "Lisää tältä tekijältä"
 
-#: src/olympia/addons/templates/addons/persona_detail.html:52
-#: src/olympia/addons/templates/addons/mobile/persona_detail.html:49
+#: src/olympia/addons/templates/addons/persona_detail.html:52 src/olympia/addons/templates/addons/mobile/persona_detail.html:49
 msgid "See all Themes by this Artist"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/persona_detail.html:71
-#: src/olympia/addons/templates/addons/mobile/home.html:42
-#: src/olympia/amo/templates/amo/side_nav.html:22
-#: src/olympia/browse/templates/browse/personas/mobile/category_landing.html:28
-#: src/olympia/devhub/templates/devhub/addons/edit/basic.html:72
-#: src/olympia/editors/templates/editors/review.html:277
-#: src/olympia/editors/templates/editors/themes/themes.html:34
-#: src/olympia/templates/categories.html:7
+#: src/olympia/addons/templates/addons/persona_detail.html:71 src/olympia/addons/templates/addons/mobile/home.html:42 src/olympia/amo/templates/amo/side_nav.html:22
+#: src/olympia/browse/templates/browse/personas/mobile/category_landing.html:28 src/olympia/devhub/templates/devhub/addons/edit/basic.html:72 src/olympia/editors/templates/editors/review.html:277
+#: src/olympia/editors/templates/editors/themes/themes.html:34 src/olympia/templates/categories.html:7
 msgid "Categories"
 msgstr "Luokat"
 
-#: src/olympia/addons/templates/addons/persona_detail_table.html:10
-#: src/olympia/addons/templates/addons/mobile/persona_detail_table.html:3
-#: src/olympia/editors/templates/editors/themes/deleted.html:19
+#: src/olympia/addons/templates/addons/persona_detail_table.html:10 src/olympia/addons/templates/addons/mobile/persona_detail_table.html:3 src/olympia/editors/templates/editors/themes/deleted.html:19
 #: src/olympia/editors/templates/editors/themes/themes.html:25
 msgid "Artist"
 msgstr "Tekijä"
 
-#: src/olympia/addons/templates/addons/persona_detail_table.html:19
-#: src/olympia/addons/templates/addons/mobile/persona_detail_table.html:14
-#: src/olympia/stats/templates/stats/addon_report_menu.html:17
+#: src/olympia/addons/templates/addons/persona_detail_table.html:19 src/olympia/addons/templates/addons/mobile/persona_detail_table.html:14 src/olympia/stats/templates/stats/addon_report_menu.html:17
 msgid "Daily Users"
 msgstr "Päivittäiset käyttäjät"
 
 #. The License for this add-on.
-#: src/olympia/addons/templates/addons/persona_detail_table.html:26
-#: src/olympia/addons/templates/addons/impala/license.html:17
-#: src/olympia/addons/templates/addons/mobile/persona_detail_table.html:21
-#: src/olympia/devhub/templates/devhub/includes/license_form.html:5
-#: src/olympia/devhub/templates/devhub/versions/edit.html:89
-#: src/olympia/editors/templates/editors/themes/themes.html:41
+#: src/olympia/addons/templates/addons/persona_detail_table.html:26 src/olympia/addons/templates/addons/impala/license.html:17 src/olympia/addons/templates/addons/mobile/persona_detail_table.html:21
+#: src/olympia/devhub/templates/devhub/includes/license_form.html:5 src/olympia/devhub/templates/devhub/versions/edit.html:89 src/olympia/editors/templates/editors/themes/themes.html:41
 msgid "License"
 msgstr "Lisenssi"
 
-#: src/olympia/addons/templates/addons/persona_preview.html:12
-#: src/olympia/constants/base.py:48
+#: src/olympia/addons/templates/addons/persona_preview.html:13 src/olympia/constants/base.py:48
 msgid "Awaiting Review"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/persona_preview.html:14
-#: src/olympia/amo/log.py:180 src/olympia/constants/base.py:42
-#: src/olympia/editors/helpers.py:62
+#: src/olympia/addons/templates/addons/persona_preview.html:15 src/olympia/amo/log.py:180 src/olympia/constants/base.py:42 src/olympia/editors/helpers.py:62
 msgid "Rejected"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/persona_preview.html:16
-#: src/olympia/amo/log.py:159
+#: src/olympia/addons/templates/addons/persona_preview.html:17 src/olympia/amo/log.py:159
 msgid "Approved"
 msgstr ""
 
 #. {0} is the number of users.
-#: src/olympia/addons/templates/addons/persona_preview.html:26
-#: src/olympia/addons/templates/addons/listing/items_mobile.html:36
-#: src/olympia/addons/templates/addons/listing/macros.html:31
+#: src/olympia/addons/templates/addons/persona_preview.html:27 src/olympia/addons/templates/addons/listing/items_mobile.html:36 src/olympia/addons/templates/addons/listing/macros.html:31
 msgid "<strong>{0}</strong> user"
 msgid_plural "<strong>{0}</strong> users"
 msgstr[0] "<strong>{0}</strong> käyttäjä"
 msgstr[1] "<strong>{0}</strong> käyttäjää"
 
-#: src/olympia/addons/templates/addons/persona_preview.html:40
+#: src/olympia/addons/templates/addons/persona_preview.html:41
 msgid "Hover to Preview"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/persona_preview.html:46
-#: src/olympia/addons/templates/addons/persona_preview.html:48
+#: src/olympia/addons/templates/addons/persona_preview.html:47 src/olympia/addons/templates/addons/persona_preview.html:49 src/olympia/addons/templates/addons/persona_preview.html:97
 #: src/olympia/reviews/templates/reviews/add.html:15
 msgid "Add"
 msgstr "Lisää"
 
-#: src/olympia/addons/templates/addons/persona_preview.html:57
-#: src/olympia/bandwagon/templates/bandwagon/ajax_new.html:16
-#: src/olympia/bandwagon/templates/bandwagon/edit.html:19
-#: src/olympia/bandwagon/templates/bandwagon/includes/addedit.html:19
-#: src/olympia/devhub/templates/devhub/addons/edit/admin.html:13
-#: src/olympia/devhub/templates/devhub/addons/edit/basic.html:10
-#: src/olympia/devhub/templates/devhub/addons/edit/details.html:8
-#: src/olympia/devhub/templates/devhub/addons/edit/media.html:6
-#: src/olympia/devhub/templates/devhub/addons/edit/support.html:8
-#: src/olympia/devhub/templates/devhub/addons/edit/technical.html:9
-#: src/olympia/devhub/templates/devhub/addons/submit/describe.html:29
-#: src/olympia/editors/templates/editors/review.html:257
+#: src/olympia/addons/templates/addons/persona_preview.html:58 src/olympia/bandwagon/templates/bandwagon/ajax_new.html:16 src/olympia/bandwagon/templates/bandwagon/edit.html:19
+#: src/olympia/bandwagon/templates/bandwagon/includes/addedit.html:19 src/olympia/devhub/templates/devhub/addons/edit/admin.html:13 src/olympia/devhub/templates/devhub/addons/edit/basic.html:10
+#: src/olympia/devhub/templates/devhub/addons/edit/details.html:8 src/olympia/devhub/templates/devhub/addons/edit/media.html:6 src/olympia/devhub/templates/devhub/addons/edit/support.html:8
+#: src/olympia/devhub/templates/devhub/addons/edit/technical.html:9 src/olympia/devhub/templates/devhub/addons/submit/describe.html:29 src/olympia/editors/templates/editors/review.html:257
 msgid "Edit"
 msgstr "Muokkaa"
 
 #. For datetime formatting, see the table on
 #. http://docs.python.org/library/datetime.html#strftime-and-strptime-behavior
-#: src/olympia/addons/templates/addons/persona_preview.html:66
+#: src/olympia/addons/templates/addons/persona_preview.html:67
 #, python-format
 msgid "%%Y-%%m-%%d"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/persona_preview.html:67
+#: src/olympia/addons/templates/addons/persona_preview.html:68
 msgid "by {0} on {1}"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/persona_preview.html:75
-#: src/olympia/reviews/helpers.py:17
-#: src/olympia/reviews/templates/reviews/review_list.html:63
-#: src/olympia/reviews/templates/reviews/reviews_link.html:21
-#: src/olympia/reviews/templates/reviews/impala/reviews_link.html:16
+#: src/olympia/addons/templates/addons/persona_preview.html:76 src/olympia/reviews/helpers.py:17 src/olympia/reviews/templates/reviews/review_list.html:63
+#: src/olympia/reviews/templates/reviews/reviews_link.html:21 src/olympia/reviews/templates/reviews/impala/reviews_link.html:16
 msgid "Not yet rated"
 msgstr "Ei vielä pisteytetty"
 
-#: src/olympia/addons/templates/addons/persona_preview.html:78
+#: src/olympia/addons/templates/addons/persona_preview.html:79
 msgid "<b>{0}</b> users"
 msgstr "<b>{0}</b> käyttäjää"
 
 #: src/olympia/addons/templates/addons/popups.html:17
-msgid ""
-"To install this add-on and thousands more, <b>get Firefox</b>, a free and "
-"open web browser from Mozilla."
+msgid "To install this add-on and thousands more, <b>get Firefox</b>, a free and open web browser from Mozilla."
 msgstr ""
 
-#: src/olympia/addons/templates/addons/popups.html:21
-#: src/olympia/addons/templates/addons/popups.html:52
+#: src/olympia/addons/templates/addons/popups.html:21 src/olympia/addons/templates/addons/popups.html:52
 msgid "Learn more about Firefox"
 msgstr "Lue lisää Firefoxista"
 
 #: src/olympia/addons/templates/addons/popups.html:22
-msgid "or <b><a class=\"installer\" href=\"{url}\">download anyway</a></b>"
+msgid "or <b><a class=\"button installer\" href=\"{url}\">download anyway</a></b>"
 msgstr ""
 
 #: src/olympia/addons/templates/addons/popups.html:26
 msgid ""
-"<strong>How to Install in Thunderbird</strong> <ol> <li>Download and save "
-"the file to your hard disk.</li> <li>In Mozilla Thunderbird, open Add-ons "
-"from the Tools menu.</li> <li>From the options button next to the add-on "
-"search field, select \"Install Add-on From File...\" and locate the "
-"downloaded add-on.</li> </ol>"
+"<strong>How to Install in Thunderbird</strong> <ol> <li>Download and save the file to your hard disk.</li> <li>In Mozilla Thunderbird, open Add-ons from the Tools menu.</li> <li>From the options "
+"button next to the add-on search field, select \"Install Add-on From File...\" and locate the downloaded add-on.</li> </ol>"
 msgstr ""
 
 #: src/olympia/addons/templates/addons/popups.html:41
-msgid ""
-"To install this Theme, <b>get Thunderbird</b>, a free and open source email "
-"client from Mozilla Messaging and install the Personas Plus add-on."
+msgid "To install this Theme, <b>get Thunderbird</b>, a free and open source email client from Mozilla Messaging and install the Personas Plus add-on."
 msgstr ""
 
 #: src/olympia/addons/templates/addons/popups.html:46
@@ -959,26 +747,20 @@ msgid "Learn more about Thunderbird"
 msgstr ""
 
 #: src/olympia/addons/templates/addons/popups.html:48
-msgid ""
-"To install this Theme and thousands more, <b>get Firefox</b>, a free and "
-"open web browser from Mozilla."
+msgid "To install this Theme and thousands more, <b>get Firefox</b>, a free and open web browser from Mozilla."
 msgstr ""
 
 #: src/olympia/addons/templates/addons/popups.html:60
 #, python-format
 msgid "This add-on has not been updated to work with your version of %(app)s."
-msgstr ""
-"Tätä lisäosaa ei ole päivitetty toimimaan sinun %(app)s-versiosi kanssa."
+msgstr "Tätä lisäosaa ei ole päivitetty toimimaan sinun %(app)s-versiosi kanssa."
 
-#: src/olympia/addons/templates/addons/popups.html:63
-#: src/olympia/addons/templates/addons/popups.html:140
-#: src/olympia/addons/templates/addons/popups.html:150
+#: src/olympia/addons/templates/addons/popups.html:63 src/olympia/addons/templates/addons/popups.html:140 src/olympia/addons/templates/addons/popups.html:150
 msgid "Install Anyway"
 msgstr "Asenna kuitenkin"
 
 #: src/olympia/addons/templates/addons/popups.html:71
-msgid ""
-"This add-on requires a version of Firefox that has not been released yet."
+msgid "This add-on requires a version of Firefox that has not been released yet."
 msgstr "Tämä lisäosa vaatii Firefox-version, jota ei ole vielä julkaistu."
 
 #: src/olympia/addons/templates/addons/popups.html:74
@@ -987,14 +769,11 @@ msgstr ""
 
 #: src/olympia/addons/templates/addons/popups.html:77
 #, python-format
-msgid ""
-"This add-on requires %(app)s {new_version}. You are currently using %(app)s "
-"{old_version}."
+msgid "This add-on requires %(app)s {new_version}. You are currently using %(app)s {old_version}."
 msgstr ""
 
 #. {0} is an app name, like Firefox.
-#: src/olympia/addons/templates/addons/popups.html:82
-#: src/olympia/addons/templates/addons/popups.html:101
+#: src/olympia/addons/templates/addons/popups.html:82 src/olympia/addons/templates/addons/popups.html:101
 msgid "Upgrade {0}"
 msgstr "Päivitä {0}"
 
@@ -1005,36 +784,25 @@ msgstr ""
 
 #: src/olympia/addons/templates/addons/popups.html:96
 #, python-format
-msgid ""
-"This Persona requires %(app)s %(new_version)s. You are currently using "
-"%(app)s {old_version}."
+msgid "This Persona requires %(app)s %(new_version)s. You are currently using %(app)s {old_version}."
 msgstr ""
 
 #: src/olympia/addons/templates/addons/popups.html:108
 msgid ""
-"<strong>Caution:</strong> This add-on has not been reviewed by Mozilla and "
-"can't be installed on release versions of Firefox 43 and above.  Be careful "
-"when installing third-party software that might harm your computer."
+"<strong>Caution:</strong> This add-on has not been reviewed by Mozilla and can't be installed on release versions of Firefox 43 and above.  Be careful when installing third-party software that "
+"might harm your computer."
 msgstr ""
 
 #: src/olympia/addons/templates/addons/popups.html:120
-msgid ""
-"<strong>Please note:</strong> This add-on is not compatible with your "
-"operating system."
-msgstr ""
-"<strong>Huomaa:</strong> Tämä lisäosa ei ole yhteensopiva "
-"käyttöjärjestelmäsi kanssa."
+msgid "<strong>Please note:</strong> This add-on is not compatible with your operating system."
+msgstr "<strong>Huomaa:</strong> Tämä lisäosa ei ole yhteensopiva käyttöjärjestelmäsi kanssa."
 
-#: src/olympia/addons/templates/addons/popups.html:136
-#: src/olympia/addons/templates/addons/impala/button.html:70
+#: src/olympia/addons/templates/addons/popups.html:136 src/olympia/addons/templates/addons/impala/button.html:70
 #, python-format
-msgid ""
-"This add-on is not compatible with your version of %(app)s because of the "
-"following:"
+msgid "This add-on is not compatible with your version of %(app)s because of the following:"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/popups.html:141
-#: src/olympia/addons/templates/addons/popups.html:151
+#: src/olympia/addons/templates/addons/popups.html:141 src/olympia/addons/templates/addons/popups.html:151
 msgid "View other versions"
 msgstr ""
 
@@ -1059,131 +827,85 @@ msgid ""
 "  don't have one.)"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/report_abuse.html:6
-#: src/olympia/addons/templates/addons/report_abuse_full.html:10
-#: src/olympia/addons/templates/addons/impala/details-more.html:23
-#: src/olympia/addons/templates/addons/impala/details.html:328
+#: src/olympia/addons/templates/addons/report_abuse.html:6 src/olympia/addons/templates/addons/report_abuse_full.html:10 src/olympia/addons/templates/addons/impala/details-more.html:23
+#: src/olympia/addons/templates/addons/impala/details.html:333
 msgid "Report Abuse"
 msgstr "Ilmoita väärinkäyttö"
 
 #: src/olympia/addons/templates/addons/report_abuse.html:10
 #, python-format
 msgid ""
-"If you suspect this add-on violates <a href=\"%(url)s\">our policies</a> or "
-"has security or privacy issues, please use the form below to describe your "
-"concerns. Please do not use this form for any other reason."
+"If you suspect this add-on violates <a href=\"%(url)s\">our policies</a> or has security or privacy issues, please use the form below to describe your concerns. Please do not use this form for any "
+"other reason."
 msgstr ""
 
-#: src/olympia/addons/templates/addons/report_abuse.html:24
-#: src/olympia/users/templates/users/report_abuse.html:19
+#: src/olympia/addons/templates/addons/report_abuse.html:24 src/olympia/users/templates/users/report_abuse.html:19
 msgid "Send Report"
 msgstr "Lähetä raportti"
 
-#: src/olympia/addons/templates/addons/report_abuse.html:26
-#: src/olympia/addons/templates/addons/mobile/eula.html:16
-#: src/olympia/addons/templates/addons/mobile/persona_confirm.html:7
-#: src/olympia/devhub/templates/devhub/addons/ajax_compat_update.html:36
-#: src/olympia/devhub/templates/devhub/addons/profile.html:44
-#: src/olympia/devhub/templates/devhub/addons/edit/admin.html:104
-#: src/olympia/devhub/templates/devhub/addons/edit/basic.html:155
-#: src/olympia/devhub/templates/devhub/addons/edit/details.html:88
-#: src/olympia/devhub/templates/devhub/addons/edit/support.html:70
-#: src/olympia/devhub/templates/devhub/addons/edit/technical.html:169
-#: src/olympia/devhub/templates/devhub/addons/forms_shared/media.html:152
-#: src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:44
-#: src/olympia/devhub/templates/devhub/personas/edit.html:222
-#: src/olympia/devhub/templates/devhub/versions/add_file_modal.html:79
-#: src/olympia/devhub/templates/devhub/versions/edit.html:140
-#: src/olympia/devhub/templates/devhub/versions/list.html:208
-#: src/olympia/devhub/templates/devhub/versions/list.html:242
-#: src/olympia/devhub/templates/devhub/versions/list.html:276
-#: src/olympia/devhub/templates/devhub/versions/list.html:317
-#: src/olympia/reviews/templates/reviews/edit_review.html:16
-#: src/olympia/translations/templates/translations/trans-menu.html:50
-#: src/olympia/translations/templates/translations/trans-menu.html:62
-#: src/olympia/zadmin/templates/zadmin/validation.html:105
+#: src/olympia/addons/templates/addons/report_abuse.html:26 src/olympia/addons/templates/addons/mobile/eula.html:16 src/olympia/addons/templates/addons/mobile/persona_confirm.html:7
+#: src/olympia/devhub/templates/devhub/addons/ajax_compat_update.html:36 src/olympia/devhub/templates/devhub/addons/profile.html:44 src/olympia/devhub/templates/devhub/addons/edit/admin.html:104
+#: src/olympia/devhub/templates/devhub/addons/edit/basic.html:155 src/olympia/devhub/templates/devhub/addons/edit/details.html:88 src/olympia/devhub/templates/devhub/addons/edit/support.html:70
+#: src/olympia/devhub/templates/devhub/addons/edit/technical.html:169 src/olympia/devhub/templates/devhub/addons/forms_shared/media.html:152
+#: src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:43 src/olympia/devhub/templates/devhub/personas/edit.html:222 src/olympia/devhub/templates/devhub/versions/add_file_modal.html:59
+#: src/olympia/devhub/templates/devhub/versions/edit.html:140 src/olympia/devhub/templates/devhub/versions/list.html:208 src/olympia/devhub/templates/devhub/versions/list.html:239
+#: src/olympia/devhub/templates/devhub/versions/list.html:281 src/olympia/devhub/templates/devhub/versions/list.html:315 src/olympia/reviews/templates/reviews/edit_review.html:16
+#: src/olympia/translations/templates/translations/trans-menu.html:50 src/olympia/translations/templates/translations/trans-menu.html:62 src/olympia/zadmin/templates/zadmin/validation.html:105
 msgid "Cancel"
 msgstr "Peruuta"
 
-#: src/olympia/addons/templates/addons/review_add_box.html:3
-#: src/olympia/addons/templates/addons/impala/review_add_box.html:5
+#: src/olympia/addons/templates/addons/review_add_box.html:3 src/olympia/addons/templates/addons/impala/review_add_box.html:5
 msgid "What do you think?"
 msgstr "Mitä mieltä olet?"
 
-#: src/olympia/addons/templates/addons/review_add_box.html:7
-#: src/olympia/addons/templates/addons/impala/review_add_box.html:9
+#: src/olympia/addons/templates/addons/review_add_box.html:7 src/olympia/addons/templates/addons/impala/review_add_box.html:9
 #, python-format
 msgid "Please <a href=\"%(login)s\">log in</a> to submit a review"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/review_add_box.html:16
-#: src/olympia/addons/templates/addons/impala/review_add_box.html:18
-#: src/olympia/reviews/templates/reviews/mobile/add_form.html:13
+#: src/olympia/addons/templates/addons/review_add_box.html:16 src/olympia/addons/templates/addons/impala/review_add_box.html:18 src/olympia/reviews/templates/reviews/mobile/add_form.html:13
 msgid "Title:"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/review_add_box.html:17
-#: src/olympia/addons/templates/addons/impala/review_add_box.html:19
-#: src/olympia/reviews/templates/reviews/mobile/add_form.html:17
+#: src/olympia/addons/templates/addons/review_add_box.html:17 src/olympia/addons/templates/addons/impala/review_add_box.html:19 src/olympia/reviews/templates/reviews/mobile/add_form.html:17
 msgid "Review:"
 msgstr "Arvostelu:"
 
-#: src/olympia/addons/templates/addons/review_add_box.html:18
-#: src/olympia/addons/templates/addons/impala/review_add_box.html:20
-#: src/olympia/reviews/templates/reviews/mobile/add_form.html:16
+#: src/olympia/addons/templates/addons/review_add_box.html:18 src/olympia/addons/templates/addons/impala/review_add_box.html:20 src/olympia/reviews/templates/reviews/mobile/add_form.html:16
 msgid "Rating:"
 msgstr "Pisteitä:"
 
-#: src/olympia/addons/templates/addons/review_add_box.html:19
-#: src/olympia/addons/templates/addons/impala/review_add_box.html:21
-#: src/olympia/reviews/templates/reviews/add.html:63
-#: src/olympia/reviews/templates/reviews/edit_review.html:15
-#: src/olympia/reviews/templates/reviews/mobile/add_form.html:18
+#: src/olympia/addons/templates/addons/review_add_box.html:19 src/olympia/addons/templates/addons/impala/review_add_box.html:21 src/olympia/reviews/templates/reviews/add.html:63
+#: src/olympia/reviews/templates/reviews/edit_review.html:15 src/olympia/reviews/templates/reviews/mobile/add_form.html:18
 msgid "Submit review"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/review_add_box.html:24
-#: src/olympia/addons/templates/addons/impala/review_add_box.html:26
-msgid ""
-"Please do not post bug reports in reviews. We do not make your email address"
-" available to add-on developers and they may need to contact you to help "
-"resolve your issue."
+#: src/olympia/addons/templates/addons/review_add_box.html:24 src/olympia/addons/templates/addons/impala/review_add_box.html:26
+msgid "Please do not post bug reports in reviews. We do not make your email address available to add-on developers and they may need to contact you to help resolve your issue."
 msgstr ""
 
-#: src/olympia/addons/templates/addons/review_add_box.html:32
-#: src/olympia/addons/templates/addons/impala/review_add_box.html:35
+#: src/olympia/addons/templates/addons/review_add_box.html:32 src/olympia/addons/templates/addons/impala/review_add_box.html:35
 #, python-format
-msgid ""
-"See the <a href=\"%(support)s\">support section</a> to find out where to get"
-" assistance for this add-on."
+msgid "See the <a href=\"%(support)s\">support section</a> to find out where to get assistance for this add-on."
 msgstr ""
 
-#: src/olympia/addons/templates/addons/review_add_box.html:38
-#: src/olympia/addons/templates/addons/impala/review_add_box.html:42
-#: src/olympia/pages/templates/pages/review_guide.html:3
+#: src/olympia/addons/templates/addons/review_add_box.html:38 src/olympia/addons/templates/addons/impala/review_add_box.html:42 src/olympia/pages/templates/pages/review_guide.html:3
 #: src/olympia/pages/templates/pages/review_guide.html:44
 msgid "Review Guidelines"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/review_list_box.html:5
-#: src/olympia/addons/templates/addons/impala/details-more.html:27
-#: src/olympia/editors/helpers.py:921
-#: src/olympia/reviews/templates/reviews/add.html:14
-#: src/olympia/reviews/templates/reviews/reply.html:14
-#: src/olympia/reviews/templates/reviews/review_list.html:19
+#: src/olympia/addons/templates/addons/review_list_box.html:5 src/olympia/addons/templates/addons/impala/details-more.html:27 src/olympia/editors/helpers.py:1001
+#: src/olympia/reviews/templates/reviews/add.html:14 src/olympia/reviews/templates/reviews/reply.html:14 src/olympia/reviews/templates/reviews/review_list.html:19
 #: src/olympia/reviews/templates/reviews/mobile/review_list.html:26
 msgid "Reviews"
 msgstr "Arvostelut"
 
-#: src/olympia/addons/templates/addons/review_list_box.html:14
-#: src/olympia/addons/templates/addons/impala/review_list_box.html:14
-#: src/olympia/reviews/templates/reviews/review.html:30
+#: src/olympia/addons/templates/addons/review_list_box.html:14 src/olympia/addons/templates/addons/impala/review_list_box.html:14 src/olympia/reviews/templates/reviews/review.html:30
 #, python-format
 msgid "by %(user)s on %(date)s"
 msgstr "kirjoittanut: %(user)s, päiväys: %(date)s"
 
-#: src/olympia/addons/templates/addons/review_list_box.html:19
-#: src/olympia/addons/templates/addons/impala/review_list_box.html:29
+#: src/olympia/addons/templates/addons/review_list_box.html:19 src/olympia/addons/templates/addons/impala/review_list_box.html:29
 msgid "Show the developer's reply to this review"
 msgstr ""
 
@@ -1195,21 +917,16 @@ msgstr[0] "Näytä tämän lisäosan kaikki arvostelut"
 msgstr[1] "Näytä tämän lisäosan kaikki %(cnt)s arvostelua"
 
 # 100%
-#: src/olympia/addons/templates/addons/tags_box.html:3
-#: src/olympia/devhub/templates/devhub/addons/edit/basic.html:118
+#: src/olympia/addons/templates/addons/tags_box.html:3 src/olympia/devhub/templates/devhub/addons/edit/basic.html:118
 msgid "Tags"
 msgstr "Tunnisteet"
 
-#: src/olympia/addons/templates/addons/impala/addon_hovercard.html:7
-#: src/olympia/addons/templates/addons/impala/addon_hovercard.html:9
+#: src/olympia/addons/templates/addons/impala/addon_hovercard.html:7 src/olympia/addons/templates/addons/impala/addon_hovercard.html:9
 msgid "Icon for {0}"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/impala/addon_hovercard.html:34
-#: src/olympia/addons/templates/addons/impala/featured_grid.html:26
-#: src/olympia/addons/templates/addons/impala/theme_grid.html:22
-#: src/olympia/bandwagon/templates/bandwagon/collection_detail.html:31
-#: src/olympia/users/templates/users/helpers/addon_users_list.html:7
+#: src/olympia/addons/templates/addons/impala/addon_hovercard.html:34 src/olympia/addons/templates/addons/impala/featured_grid.html:26 src/olympia/addons/templates/addons/impala/theme_grid.html:22
+#: src/olympia/bandwagon/templates/bandwagon/collection_detail.html:31 src/olympia/users/templates/users/helpers/addon_users_list.html:7
 #, python-format
 msgid "by %(users)s"
 msgstr "tekijänä %(users)s"
@@ -1229,34 +946,18 @@ msgstr "Pidätkö tästä lisäosasta?"
 
 #: src/olympia/addons/templates/addons/impala/contribution.html:43
 #, python-format
-msgid ""
-"The <a href=\"%(meet_url)s\">developer of this add-on</a> asks that you help"
-" support its continued development by making a small contribution."
-msgstr ""
-"<a href=\"%(meet_url)s\">Tämän lisäosan kehittäjä</a> pyytää, että tuet sen "
-"jatkuvaa kehittämistä antamalla pienen lahjoituksen."
+msgid "The <a href=\"%(meet_url)s\">developer of this add-on</a> asks that you help support its continued development by making a small contribution."
+msgstr "<a href=\"%(meet_url)s\">Tämän lisäosan kehittäjä</a> pyytää, että tuet sen jatkuvaa kehittämistä antamalla pienen lahjoituksen."
 
 #: src/olympia/addons/templates/addons/impala/contribution.html:48
 #, python-format
-msgid ""
-"The <a href=\"%(meet_url)s\">developer of this add-on</a> asks that you show"
-" your support by making a donation to the <a "
-"href=\"%(charity_url)s\">%(charity_name)s</a>."
-msgstr ""
-"<a href=\"%(meet_url)s\">Tämän lisäosan kehittäjä</a> pyytää, että "
-"osoittaisit tukesi antamalla lahjoituksen järjestölle <a "
-"href=\"%(charity_url)s\">%(charity_name)s</a>."
+msgid "The <a href=\"%(meet_url)s\">developer of this add-on</a> asks that you show your support by making a donation to the <a href=\"%(charity_url)s\">%(charity_name)s</a>."
+msgstr "<a href=\"%(meet_url)s\">Tämän lisäosan kehittäjä</a> pyytää, että osoittaisit tukesi antamalla lahjoituksen järjestölle <a href=\"%(charity_url)s\">%(charity_name)s</a>."
 
 #: src/olympia/addons/templates/addons/impala/contribution.html:53
 #, python-format
-msgid ""
-"The <a href=\"%(meet_url)s\">developer of this add-on</a> asks that you show"
-" your support by making a small contribution to <a "
-"href=\"%(charity_url)s\">%(charity_name)s</a>."
-msgstr ""
-"<a href=\"%(meet_url)s\">Tämän lisäosan kehittäjä</a> pyytää, että "
-"osoittaisit tukesi antamalla pienen lahjoituksen järjestölle <a "
-"href=\"%(charity_url)s\">%(charity_name)s</a>."
+msgid "The <a href=\"%(meet_url)s\">developer of this add-on</a> asks that you show your support by making a small contribution to <a href=\"%(charity_url)s\">%(charity_name)s</a>."
+msgstr "<a href=\"%(meet_url)s\">Tämän lisäosan kehittäjä</a> pyytää, että osoittaisit tukesi antamalla pienen lahjoituksen järjestölle <a href=\"%(charity_url)s\">%(charity_name)s</a>."
 
 #: src/olympia/addons/templates/addons/impala/dependencies_note.html:4
 msgid "This add-on requires the following add-ons to work properly:"
@@ -1285,32 +986,31 @@ msgid_plural "Other add-ons by these authors"
 msgstr[0] "Muita lisäosia tekijältä %(author)s"
 msgstr[1] "Muita lisäosia samoilta tekijöiltä"
 
-#: src/olympia/addons/templates/addons/impala/details.html:41
+#: src/olympia/addons/templates/addons/impala/details.html:39
 #, python-format
 msgid "<span itemprop=\"ratingCount\">%(num)s</span> user review"
 msgid_plural "<span itemprop=\"ratingCount\">%(num)s</span> user reviews"
 msgstr[0] "<span itemprop=\"ratingCount\">%(num)s</span> arvostelu"
 msgstr[1] "<span itemprop=\"ratingCount\">%(num)s</span> arvostelua"
 
-#: src/olympia/addons/templates/addons/impala/details.html:69
+#: src/olympia/addons/templates/addons/impala/details.html:66
 msgid "View statistics"
 msgstr "Näytä tilastoja"
 
-#: src/olympia/addons/templates/addons/impala/details.html:84
+#: src/olympia/addons/templates/addons/impala/details.html:81
 msgid "Manage"
 msgstr ""
 
 #. {0} is an add-on name.
-#: src/olympia/addons/templates/addons/impala/details.html:96
+#: src/olympia/addons/templates/addons/impala/details.html:93
 msgid "Icon of {0}"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/impala/details.html:103
-#: src/olympia/addons/templates/addons/impala/listing/items.html:14
+#: src/olympia/addons/templates/addons/impala/details.html:100 src/olympia/addons/templates/addons/impala/listing/items.html:14
 msgid "No Restart"
 msgstr "Ei uudelleenkäynnistystä"
 
-#: src/olympia/addons/templates/addons/impala/details.html:127
+#: src/olympia/addons/templates/addons/impala/details.html:124
 #, fuzzy, python-format
 msgid "Meet the Developer: <a href=\"%(url)s\">%(name)s</a>"
 msgid_plural "<a href=\"%(url)s\">Meet the Developers</a>"
@@ -1318,113 +1018,90 @@ msgstr[0] "Tapaa kehittäjä: <a href=\"%(url)s\">%(name)s</a>"
 msgstr[1] "<a href=\"%(url)s\">Tapaa kehittäjät</a>"
 
 # {0} is an add-on name.
-#: src/olympia/addons/templates/addons/impala/details.html:137
+#: src/olympia/addons/templates/addons/impala/details.html:134
 msgid "Learn why {0} was created and find out what's next for this add-on."
-msgstr ""
-"Tutustu miksi {0} luotiin ja lue mitä tälle lisäosalle on seuraavaksi "
-"luvassa."
+msgstr "Tutustu miksi {0} luotiin ja lue mitä tälle lisäosalle on seuraavaksi luvassa."
 
 #. {0} is an index.
-#: src/olympia/addons/templates/addons/impala/details.html:156
+#: src/olympia/addons/templates/addons/impala/details.html:161
 msgid "Add-on screenshot #{0}"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/impala/details.html:182
+#: src/olympia/addons/templates/addons/impala/details.html:187
 msgid "Add-on home page"
 msgstr "Lisäosan kotisivu"
 
-#: src/olympia/addons/templates/addons/impala/details.html:185
+#: src/olympia/addons/templates/addons/impala/details.html:190
 msgid "Support site"
 msgstr "Tukisivusto"
 
-#: src/olympia/addons/templates/addons/impala/details.html:189
+#: src/olympia/addons/templates/addons/impala/details.html:194
 msgid "Support E-mail"
 msgstr "Sähköpostituki"
 
-#: src/olympia/addons/templates/addons/impala/details.html:194
-#: src/olympia/devhub/models.py:378
-#: src/olympia/devhub/templates/devhub/versions/list.html:12
-#: src/olympia/versions/templates/versions/version.html:6
-#: src/olympia/versions/templates/versions/mobile/version.html:6
+#: src/olympia/addons/templates/addons/impala/details.html:199 src/olympia/devhub/models.py:378 src/olympia/devhub/templates/devhub/versions/list.html:12
+#: src/olympia/versions/templates/versions/version.html:6 src/olympia/versions/templates/versions/mobile/version.html:6
 msgid "Version {0}"
 msgstr "Versio {0}"
 
-#: src/olympia/addons/templates/addons/impala/details.html:194
+#: src/olympia/addons/templates/addons/impala/details.html:199
 msgid "Info"
 msgstr "Tiedot"
 
-#: src/olympia/addons/templates/addons/impala/details.html:195
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:129
+#: src/olympia/addons/templates/addons/impala/details.html:200 src/olympia/devhub/templates/devhub/includes/addon_details.html:116
 msgid "Last Updated:"
 msgstr "Päivitetty viimeksi:"
 
-#: src/olympia/addons/templates/addons/impala/details.html:200
+#: src/olympia/addons/templates/addons/impala/details.html:205
 #, python-format
 msgid "Released under <a target=\"_blank\" href=\"%(url)s\">%(name)s</a>"
 msgstr "Julkaistu lisenssillä <a target=\"_blank\" href=\"%(url)s\">%(name)s</a>"
 
-#: src/olympia/addons/templates/addons/impala/details.html:201
-#: src/olympia/addons/templates/addons/impala/details.html:206
-#: src/olympia/amo/helpers.py:398 src/olympia/devhub/forms.py:142
-#: src/olympia/devhub/forms.py:173
-#: src/olympia/versions/templates/versions/version.html:40
-#: src/olympia/versions/templates/versions/version.html:45
+#: src/olympia/addons/templates/addons/impala/details.html:206 src/olympia/addons/templates/addons/impala/details.html:211 src/olympia/amo/helpers.py:398 src/olympia/devhub/forms.py:142
+#: src/olympia/devhub/forms.py:173 src/olympia/versions/templates/versions/version.html:40 src/olympia/versions/templates/versions/version.html:45
 msgid "Custom License"
 msgstr "Muu lisenssi"
 
-#: src/olympia/addons/templates/addons/impala/details.html:205
+#: src/olympia/addons/templates/addons/impala/details.html:210
 #, python-format
 msgid "Released under <a href=\"%(url)s\">%(name)s</a>"
 msgstr "Julkaistu lisenssillä <a href=\"%(url)s\">%(name)s</a>"
 
-#: src/olympia/addons/templates/addons/impala/details.html:217
+#: src/olympia/addons/templates/addons/impala/details.html:222
 msgid "About this Add-on"
 msgstr "Tietoja tästä lisäosasta"
 
-#: src/olympia/addons/templates/addons/impala/details.html:233
+#: src/olympia/addons/templates/addons/impala/details.html:238
 msgid "Developer’s Comments"
 msgstr "Kehittäjän kommentit"
 
-#: src/olympia/addons/templates/addons/impala/details.html:243
+#: src/olympia/addons/templates/addons/impala/details.html:248
 msgid "Version Information"
 msgstr "Versiotiedot"
 
-#: src/olympia/addons/templates/addons/impala/details.html:250
+#: src/olympia/addons/templates/addons/impala/details.html:255
 msgid "See complete version history"
 msgstr "Näytä täysi versiohistoria"
 
-#: src/olympia/addons/templates/addons/impala/details.html:262
+#: src/olympia/addons/templates/addons/impala/details.html:267
 msgid ""
-"The Development Channel lets you test an experimental new version of this "
-"add-on before it's released to the general public. Once you install the "
-"development version, you will continue to get updates from this channel. To "
-"stop receiving development updates, reinstall the default version from the "
-"link above."
+"The Development Channel lets you test an experimental new version of this add-on before it's released to the general public. Once you install the development version, you will continue to get "
+"updates from this channel. To stop receiving development updates, reinstall the default version from the link above."
 msgstr ""
-"Kehityskanavan avulla voit testata lisäosan tekeillä olevia uusia versioita "
-"ennen kuin ne julkaistaan suurelle yleisölle. Kun olet asentanut "
-"kehitysversion, saat jatkossakin päivitykset tältä kanavalta. Voit lopettaa "
-"kehitysversioiden vastaanottamisen asentamalla lisäosan oletusversion "
-"uudelleen yllä olevasta linkistä."
+"Kehityskanavan avulla voit testata lisäosan tekeillä olevia uusia versioita ennen kuin ne julkaistaan suurelle yleisölle. Kun olet asentanut kehitysversion, saat jatkossakin päivitykset tältä "
+"kanavalta. Voit lopettaa kehitysversioiden vastaanottamisen asentamalla lisäosan oletusversion uudelleen yllä olevasta linkistä."
 
-#: src/olympia/addons/templates/addons/impala/details.html:272
-msgid ""
-"<strong>Caution:</strong> Development versions of this add-on have not been "
-"reviewed by Mozilla."
+#: src/olympia/addons/templates/addons/impala/details.html:277
+msgid "<strong>Caution:</strong> Development versions of this add-on have not been reviewed by Mozilla."
 msgstr ""
 
-#: src/olympia/addons/templates/addons/impala/details.html:287
+#: src/olympia/addons/templates/addons/impala/details.html:292
 msgid "See complete development channel history"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/impala/details.html:306
-#: src/olympia/addons/templates/addons/impala/details.html:315
-#: src/olympia/addons/templates/addons/impala/details.html:327
-#: src/olympia/addons/templates/addons/impala/review_add_box.html:4
-#: src/olympia/stats/templates/stats/popup.html:2
-#: src/olympia/stats/templates/stats/popup.html:8
-#: src/olympia/stats/templates/stats/stats.html:202
-#: src/olympia/users/templates/users/profile.html:119
+#: src/olympia/addons/templates/addons/impala/details.html:311 src/olympia/addons/templates/addons/impala/details.html:320 src/olympia/addons/templates/addons/impala/details.html:332
+#: src/olympia/addons/templates/addons/impala/review_add_box.html:4 src/olympia/stats/templates/stats/popup.html:2 src/olympia/stats/templates/stats/popup.html:8
+#: src/olympia/stats/templates/stats/stats.html:204 src/olympia/users/templates/users/profile.html:119
 msgid "close"
 msgstr "sulje"
 
@@ -1433,19 +1110,15 @@ msgstr "sulje"
 msgid "Thank you for installing {0}"
 msgstr "Kiitos, että asensit lisäosan {0}"
 
-#. {0} is an add-on name.
 # %1 is an add-on name.
+#. {0} is an add-on name.
 #: src/olympia/addons/templates/addons/impala/developers.html:12
 msgid "Meet the {0} Developer"
 msgstr "Tapaa lisäosan {0} kehittäjä"
 
 #: src/olympia/addons/templates/addons/impala/developers.html:41
-msgid ""
-"Before downloading this add-on, please consider supporting the development "
-"of this add-on by making a small contribution."
-msgstr ""
-"Ennen kuin lataat tämän lisäosan, harkitse tukevasi lisäosan kehitystä "
-"antamalla pienen lahjoituksen."
+msgid "Before downloading this add-on, please consider supporting the development of this add-on by making a small contribution."
+msgstr "Ennen kuin lataat tämän lisäosan, harkitse tukevasi lisäosan kehitystä antamalla pienen lahjoituksen."
 
 # %1 is an add-on name.
 #: src/olympia/addons/templates/addons/impala/developers.html:80
@@ -1463,9 +1136,7 @@ msgid_plural "About the Developers"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/olympia/addons/templates/addons/impala/developers.html:96
-#: src/olympia/users/templates/users/edit.html:130
-#: src/olympia/users/templates/users/profile.html:26
+#: src/olympia/addons/templates/addons/impala/developers.html:96 src/olympia/users/templates/users/edit.html:130 src/olympia/users/templates/users/profile.html:26
 msgid "No Photo"
 msgstr "Ei kuvaa"
 
@@ -1485,24 +1156,15 @@ msgstr ""
 msgid "Source Code License for {addon}"
 msgstr "Lisäosan {addon} lähdekoodin lisenssi"
 
-#: src/olympia/addons/templates/addons/impala/license.html:21
-#: src/olympia/versions/templates/versions/mobile/version.html:18
+#: src/olympia/addons/templates/addons/impala/license.html:21 src/olympia/versions/templates/versions/mobile/version.html:18
 msgid "Source Code License"
 msgstr "Lähdekoodin lisenssi"
 
-#: src/olympia/addons/templates/addons/impala/persona_grid.html:16
-#: src/olympia/addons/templates/addons/impala/toplist.html:6
-msgid "{0} users"
-msgstr "{0} käyttäjää"
-
-#: src/olympia/addons/templates/addons/impala/review_list_box.html:19
-#: src/olympia/reviews/templates/reviews/review.html:40
+#: src/olympia/addons/templates/addons/impala/review_list_box.html:19 src/olympia/reviews/templates/reviews/review.html:40
 msgid "permalink"
 msgstr "ikilinkki"
 
-#: src/olympia/addons/templates/addons/impala/review_list_box.html:23
-#: src/olympia/editors/templates/editors/queue.html:98
-#: src/olympia/reviews/templates/reviews/review.html:44
+#: src/olympia/addons/templates/addons/impala/review_list_box.html:23 src/olympia/editors/templates/editors/queue.html:104 src/olympia/reviews/templates/reviews/review.html:44
 msgid "translate"
 msgstr "käännä"
 
@@ -1513,8 +1175,7 @@ msgid_plural "See all %(cnt)s user reviews"
 msgstr[0] "Näytä kaikki arvostelut"
 msgstr[1] "Näytä kaikki %(cnt)s arvostelua"
 
-#: src/olympia/addons/templates/addons/impala/review_list_box.html:47
-#: src/olympia/reviews/templates/reviews/review_list.html:84
+#: src/olympia/addons/templates/addons/impala/review_list_box.html:47 src/olympia/reviews/templates/reviews/review_list.html:84
 msgid "This add-on has not yet been reviewed."
 msgstr "Tällä lisäosalla ei ole vielä yhtään käyttäjäarviota."
 
@@ -1522,26 +1183,25 @@ msgstr "Tällä lisäosalla ei ole vielä yhtään käyttäjäarviota."
 msgid "Be the first!"
 msgstr "Ole ensimmäinen!"
 
-#: src/olympia/addons/templates/addons/impala/listing/sorter.html:14
-#: src/olympia/devhub/templates/devhub/addons/listing/item_actions.html:49
+#: src/olympia/addons/templates/addons/impala/toplist.html:6
+msgid "{0} users"
+msgstr "{0} käyttäjää"
+
+#: src/olympia/addons/templates/addons/impala/listing/sorter.html:14 src/olympia/devhub/templates/devhub/addons/listing/item_actions.html:49
 msgid "More"
 msgstr "Lisää"
 
 # 94%
 # 100%
-#: src/olympia/addons/templates/addons/includes/collection_add_widget.html:7
-#: src/olympia/addons/templates/addons/includes/collection_add_widget.html:10
+#: src/olympia/addons/templates/addons/includes/collection_add_widget.html:7 src/olympia/addons/templates/addons/includes/collection_add_widget.html:10
 msgid "Add to collection"
 msgstr "Lisää kokoelmaan"
 
-#: src/olympia/addons/templates/addons/includes/dashboard_tabs.html:4
-#: src/olympia/devhub/templates/devhub/index.html:73
-#: src/olympia/devhub/templates/devhub/nav.html:14
+#: src/olympia/addons/templates/addons/includes/dashboard_tabs.html:4 src/olympia/devhub/templates/devhub/index.html:73 src/olympia/devhub/templates/devhub/nav.html:14
 msgid "My Add-ons"
 msgstr "Lisäosani"
 
-#: src/olympia/addons/templates/addons/includes/dashboard_tabs.html:6
-#: src/olympia/amo/context_processors.py:51
+#: src/olympia/addons/templates/addons/includes/dashboard_tabs.html:6 src/olympia/amo/context_processors.py:50
 msgid "My Themes"
 msgstr ""
 
@@ -1557,8 +1217,7 @@ msgstr ""
 msgid "Approve / Reject"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/includes/persona.html:25
-#: src/olympia/editors/templates/editors/themes/single.html:43
+#: src/olympia/addons/templates/addons/includes/persona.html:25 src/olympia/editors/templates/editors/themes/single.html:43
 msgid "Review History"
 msgstr ""
 
@@ -1579,9 +1238,7 @@ msgid "Not Yet Rated"
 msgstr "Ei vielä arvioitu"
 
 #. {0} is the number of downloads.
-#: src/olympia/addons/templates/addons/listing/items_mobile.html:27
-#: src/olympia/addons/templates/addons/listing/macros.html:24
-#: src/olympia/devhub/templates/devhub/addons/listing/macros.html:15
+#: src/olympia/addons/templates/addons/listing/items_mobile.html:27 src/olympia/addons/templates/addons/listing/macros.html:24 src/olympia/devhub/templates/devhub/addons/listing/macros.html:15
 msgid "<strong>{0}</strong> weekly download"
 msgid_plural "<strong>{0}</strong> weekly downloads"
 msgstr[0] "<strong>{0}</strong> lataus viikossa"
@@ -1595,15 +1252,11 @@ msgstr "Lue lisää"
 msgid "Users"
 msgstr "Käyttäjiä"
 
-#: src/olympia/addons/templates/addons/mobile/details.html:92
-#: src/olympia/browse/views.py:59 src/olympia/browse/views.py:70
-#: src/olympia/search/forms.py:90
+#: src/olympia/addons/templates/addons/mobile/details.html:92 src/olympia/browse/views.py:59 src/olympia/browse/views.py:70 src/olympia/search/forms.py:90
 msgid "Weekly Downloads"
 msgstr "Viikon ladatuimmat"
 
-#: src/olympia/addons/templates/addons/mobile/details.html:99
-#: src/olympia/compat/templates/compat/reporter_detail.html:46
-#: src/olympia/devhub/forms.py:787
+#: src/olympia/addons/templates/addons/mobile/details.html:99 src/olympia/compat/templates/compat/reporter_detail.html:46 src/olympia/devhub/forms.py:788
 #: src/olympia/devhub/templates/devhub/versions/list.html:163
 msgid "Version"
 msgstr "Versio"
@@ -1639,50 +1292,30 @@ msgstr "Lisenssisopimus"
 
 #: src/olympia/addons/templates/addons/mobile/eula.html:5
 #, python-format
-msgid ""
-"%(name)s requires that you accept the following End-User License Agreement "
-"before installation can proceed:"
-msgstr ""
-"%(name)s vaatii, että hyväksyt seuraavan loppukäyttäjän lisenssisopimuksen "
-"ennen asennuksen jatkamista:"
+msgid "%(name)s requires that you accept the following End-User License Agreement before installation can proceed:"
+msgstr "%(name)s vaatii, että hyväksyt seuraavan loppukäyttäjän lisenssisopimuksen ennen asennuksen jatkamista:"
 
 #: src/olympia/addons/templates/addons/mobile/eula.html:15
 msgid "Accept"
 msgstr "Hyväksy"
 
-#: src/olympia/addons/templates/addons/mobile/home.html:10
-#: src/olympia/templates/mobile/base_addons.html:53
+#: src/olympia/addons/templates/addons/mobile/home.html:10 src/olympia/templates/mobile/base_addons.html:53
 msgid "Add-ons are not currently available on Firefox for iOS."
 msgstr ""
 
-#: src/olympia/addons/templates/addons/mobile/home.html:12
-#: src/olympia/templates/mobile/base_addons.html:55
-msgid ""
-"You need Firefox to install add-ons. <a "
-"href=\"http://mozilla.com/mobile\">Learn More&nbsp;&raquo;</a>"
-msgstr ""
-"Tarvitset Firefoxin asentaaksesi lisäosia. <a "
-"href=\"http://mozilla.com/mobile\">Lue lisää&nbsp;&raquo;</a>"
+#: src/olympia/addons/templates/addons/mobile/home.html:12 src/olympia/templates/mobile/base_addons.html:55
+msgid "You need Firefox to install add-ons. <a href=\"http://mozilla.com/mobile\">Learn More&nbsp;&raquo;</a>"
+msgstr "Tarvitset Firefoxin asentaaksesi lisäosia. <a href=\"http://mozilla.com/mobile\">Lue lisää&nbsp;&raquo;</a>"
 
 # {0} is the application name.  Example:  Firefox
-#: src/olympia/addons/templates/addons/mobile/home.html:19
-#: src/olympia/templates/header_title.html:4
-#: src/olympia/templates/impala/header_title.html:3
+#: src/olympia/addons/templates/addons/mobile/home.html:19 src/olympia/templates/header_title.html:4 src/olympia/templates/impala/header_title.html:3
 msgid "Return to the {0} Add-ons homepage"
 msgstr "Palaa {0}-lisäosien etusivulle"
 
-#: src/olympia/addons/templates/addons/mobile/home.html:21
-#: src/olympia/amo/helpers.py:237
-#: src/olympia/bandwagon/templates/bandwagon/edit.html:34
-#: src/olympia/discovery/templates/discovery/pane.html:92
-#: src/olympia/editors/templates/editors/base.html:21
-#: src/olympia/editors/templates/editors/performance.html:72
-#: src/olympia/templates/menu_links.html:4
-#: src/olympia/templates/impala/header_title.html:13
-#: src/olympia/templates/impala/header_title.html:15
-#: src/olympia/templates/impala/header_title.html:19
-#: src/olympia/templates/impala/header_title.html:23
-#: src/olympia/templates/mobile/base_addons.html:47
+#: src/olympia/addons/templates/addons/mobile/home.html:21 src/olympia/amo/helpers.py:237 src/olympia/bandwagon/templates/bandwagon/edit.html:34 src/olympia/discovery/templates/discovery/pane.html:92
+#: src/olympia/editors/templates/editors/base.html:21 src/olympia/editors/templates/editors/performance.html:72 src/olympia/templates/menu_links.html:4
+#: src/olympia/templates/impala/header_title.html:13 src/olympia/templates/impala/header_title.html:15 src/olympia/templates/impala/header_title.html:19
+#: src/olympia/templates/impala/header_title.html:23 src/olympia/templates/mobile/base_addons.html:47
 msgid "Add-ons"
 msgstr "Lisäosat"
 
@@ -1690,48 +1323,28 @@ msgstr "Lisäosat"
 msgid "Easy ways to personalize."
 msgstr "Helppoja tapoja mukauttaa."
 
-#: src/olympia/addons/templates/addons/mobile/home.html:24
-#: src/olympia/devhub/templates/devhub/addons/submit/done.html:47
-#: src/olympia/discovery/templates/discovery/pane.html:34
-#: src/olympia/discovery/templates/discovery/addons/detail.html:16
-#: src/olympia/discovery/templates/discovery/modules/featured.html:21
-#: src/olympia/discovery/templates/discovery/modules/monthly.html:22
+#: src/olympia/addons/templates/addons/mobile/home.html:24 src/olympia/devhub/templates/devhub/addons/submit/done.html:47 src/olympia/discovery/templates/discovery/pane.html:34
+#: src/olympia/discovery/templates/discovery/addons/detail.html:16 src/olympia/discovery/templates/discovery/modules/featured.html:21 src/olympia/discovery/templates/discovery/modules/monthly.html:22
 msgid "Learn More"
 msgstr "Lue lisää"
 
 #: src/olympia/addons/templates/addons/mobile/home.html:26
 msgid ""
-"Add-ons are applications that let you personalize Firefox with extra "
-"functionality and style. Whether you mistype the name of a website or can't "
-"read a busy page, there's an add-on to improve your on-the-go browsing."
+"Add-ons are applications that let you personalize Firefox with extra functionality and style. Whether you mistype the name of a website or can't read a busy page, there's an add-on to improve your "
+"on-the-go browsing."
 msgstr ""
-"Lisäosat ovat sovelluksia, joilla voit lisätä Firefoxiin uusia toimintoja ja"
-" muokata sen tyyliä. Kirjoititpa sitten usein verkkosivujen osoitteita "
-"väärin tai kohtaat silloin tällöin vaikeaselkoisia verkkosivuja, "
-"lisäosahakemistosta löytyy varmasti vaihtoehtoja selaamisen parantamiseen."
+"Lisäosat ovat sovelluksia, joilla voit lisätä Firefoxiin uusia toimintoja ja muokata sen tyyliä. Kirjoititpa sitten usein verkkosivujen osoitteita väärin tai kohtaat silloin tällöin vaikeaselkoisia "
+"verkkosivuja, lisäosahakemistosta löytyy varmasti vaihtoehtoja selaamisen parantamiseen."
 
 #. {0} is a category name. Ex: "Sports"
 #. {0} is a category name, such as Nature.
-#: src/olympia/addons/templates/addons/mobile/home.html:43
-#: src/olympia/amo/templates/amo/site_nav.html:32
-#: src/olympia/browse/feeds.py:107
-#: src/olympia/browse/templates/browse/impala/base_listing.html:38
-#: src/olympia/browse/templates/browse/personas/base.html:6
-#: src/olympia/browse/templates/browse/personas/base.html:42
-#: src/olympia/browse/templates/browse/personas/category_landing.html:21
-#: src/olympia/browse/templates/browse/personas/category_landing.html:23
-#: src/olympia/browse/templates/browse/personas/category_landing.html:38
-#: src/olympia/browse/templates/browse/personas/grid.html:7
-#: src/olympia/browse/templates/browse/personas/grid.html:11
-#: src/olympia/browse/templates/browse/personas/mobile/base.html:7
-#: src/olympia/browse/templates/browse/personas/mobile/category_landing.html:19
-#: src/olympia/constants/base.py:180
-#: src/olympia/devhub/templates/devhub/personas/submit.html:13
-#: src/olympia/editors/helpers.py:105
-#: src/olympia/editors/templates/editors/base.html:26
-#: src/olympia/editors/templates/editors/performance.html:73
-#: src/olympia/search/templates/search/personas.html:39
-#: src/olympia/templates/menu_links.html:9
+#: src/olympia/addons/templates/addons/mobile/home.html:43 src/olympia/amo/templates/amo/site_nav.html:32 src/olympia/browse/feeds.py:107
+#: src/olympia/browse/templates/browse/impala/base_listing.html:38 src/olympia/browse/templates/browse/personas/base.html:6 src/olympia/browse/templates/browse/personas/base.html:42
+#: src/olympia/browse/templates/browse/personas/category_landing.html:21 src/olympia/browse/templates/browse/personas/category_landing.html:23
+#: src/olympia/browse/templates/browse/personas/category_landing.html:38 src/olympia/browse/templates/browse/personas/grid.html:7 src/olympia/browse/templates/browse/personas/grid.html:11
+#: src/olympia/browse/templates/browse/personas/mobile/base.html:7 src/olympia/browse/templates/browse/personas/mobile/category_landing.html:19 src/olympia/constants/base.py:180
+#: src/olympia/devhub/templates/devhub/personas/submit.html:13 src/olympia/editors/helpers.py:107 src/olympia/editors/templates/editors/base.html:26
+#: src/olympia/editors/templates/editors/performance.html:73 src/olympia/search/templates/search/personas.html:39 src/olympia/templates/menu_links.html:9
 msgid "Themes"
 msgstr "Teemat"
 
@@ -1751,20 +1364,13 @@ msgstr "Näytä kaikki suositut lisäosat"
 msgid "More Add-ons"
 msgstr "Lisää lisäosia"
 
-#: src/olympia/addons/templates/addons/mobile/home.html:72
-#: src/olympia/browse/templates/browse/personas/mobile/category_landing.html:64
-#: src/olympia/search/forms.py:14
+#: src/olympia/addons/templates/addons/mobile/home.html:72 src/olympia/browse/templates/browse/personas/mobile/category_landing.html:64 src/olympia/search/forms.py:14
 msgid "Highest Rated"
 msgstr "Parhaiten arvioidut"
 
 # 100%
-#: src/olympia/addons/templates/addons/mobile/home.html:74
-#: src/olympia/amo/templates/amo/side_nav.html:5
-#: src/olympia/amo/templates/amo/site_nav.html:27
-#: src/olympia/amo/templates/amo/site_nav.html:57
-#: src/olympia/bandwagon/views.py:97 src/olympia/browse/views.py:57
-#: src/olympia/browse/views.py:67
-#: src/olympia/browse/templates/browse/personas/mobile/category_landing.html:65
+#: src/olympia/addons/templates/addons/mobile/home.html:74 src/olympia/amo/templates/amo/side_nav.html:5 src/olympia/amo/templates/amo/site_nav.html:27 src/olympia/amo/templates/amo/site_nav.html:55
+#: src/olympia/bandwagon/views.py:97 src/olympia/browse/views.py:57 src/olympia/browse/views.py:67 src/olympia/browse/templates/browse/personas/mobile/category_landing.html:65
 #: src/olympia/search/forms.py:15 src/olympia/search/forms.py:87
 msgid "Newest"
 msgstr "Uusimmat"
@@ -1777,122 +1383,90 @@ msgstr ""
 msgid "Theme Info &raquo;"
 msgstr ""
 
-#: src/olympia/amo/context_processors.py:39
-#: src/olympia/devhub/templates/devhub/nav.html:43
+#: src/olympia/amo/context_processors.py:37 src/olympia/devhub/templates/devhub/nav.html:43
 msgid "Tools"
 msgstr "Työkalut"
 
-#: src/olympia/amo/context_processors.py:48
-#: src/olympia/discovery/templates/discovery/pane_account.html:8
-#: src/olympia/users/templates/users/includes/navigation.html:2
+#: src/olympia/amo/context_processors.py:47 src/olympia/discovery/templates/discovery/pane_account.html:8 src/olympia/users/templates/users/includes/navigation.html:2
 msgid "My Profile"
 msgstr "Profiilini"
 
-#: src/olympia/amo/context_processors.py:54
-#: src/olympia/users/templates/users/edit.html:5
-#: src/olympia/users/templates/users/includes/navigation.html:3
+#: src/olympia/amo/context_processors.py:53 src/olympia/users/templates/users/edit.html:5 src/olympia/users/templates/users/includes/navigation.html:3
 msgid "Account Settings"
 msgstr "Tunnusasetukset"
 
-#: src/olympia/amo/context_processors.py:57
-#: src/olympia/discovery/templates/discovery/pane_account.html:11
-#: src/olympia/users/templates/users/profile.html:83
+#: src/olympia/amo/context_processors.py:56 src/olympia/discovery/templates/discovery/pane_account.html:11 src/olympia/users/templates/users/profile.html:83
 #: src/olympia/users/templates/users/includes/navigation.html:4
 msgid "My Collections"
 msgstr "Kokoelmani"
 
-#: src/olympia/amo/context_processors.py:62
-#: src/olympia/discovery/templates/discovery/pane_account.html:10
-#: src/olympia/users/templates/users/includes/navigation.html:7
+#: src/olympia/amo/context_processors.py:61 src/olympia/discovery/templates/discovery/pane_account.html:10 src/olympia/users/templates/users/includes/navigation.html:7
 msgid "My Favorites"
 msgstr "Suosikkini"
 
-#: src/olympia/amo/context_processors.py:67
-#: src/olympia/discovery/templates/discovery/pane_account.html:13
-#: src/olympia/templates/impala/user_login.html:14
+#: src/olympia/amo/context_processors.py:66 src/olympia/discovery/templates/discovery/pane_account.html:13 src/olympia/templates/impala/user_login.html:14
 #: src/olympia/templates/mobile/header_auth.html:5
 msgid "Log out"
 msgstr "Kirjaudu ulos"
 
-#: src/olympia/amo/context_processors.py:72
-#: src/olympia/devhub/templates/devhub/addons/dashboard.html:4
+#: src/olympia/amo/context_processors.py:71 src/olympia/devhub/templates/devhub/addons/dashboard.html:4
 msgid "Manage My Submissions"
 msgstr ""
 
-#: src/olympia/amo/context_processors.py:75
-#: src/olympia/devhub/templates/devhub/nav.html:27
-#: src/olympia/devhub/templates/devhub/addons/dashboard.html:25
+#: src/olympia/amo/context_processors.py:74 src/olympia/devhub/templates/devhub/nav.html:27 src/olympia/devhub/templates/devhub/addons/dashboard.html:25
 #: src/olympia/devhub/templates/devhub/addons/submit/base.html:4
 msgid "Submit a New Add-on"
 msgstr "Lisää uusi lisäosa"
 
-#: src/olympia/amo/context_processors.py:77
-#: src/olympia/browse/templates/browse/personas/base.html:50
-#: src/olympia/devhub/templates/devhub/index.html:24
+#: src/olympia/amo/context_processors.py:76 src/olympia/browse/templates/browse/personas/base.html:50 src/olympia/devhub/templates/devhub/index.html:24
 #: src/olympia/devhub/templates/devhub/addons/dashboard.html:29
 msgid "Submit a New Theme"
 msgstr ""
 
-#: src/olympia/amo/context_processors.py:79
-#: src/olympia/amo/templates/amo/site_nav.html:87
-#: src/olympia/devhub/helpers.py:36 src/olympia/devhub/helpers.py:68
-#: src/olympia/devhub/helpers.py:102 src/olympia/templates/footer.html:6
-#: src/olympia/templates/menu_links.html:14
+#: src/olympia/amo/context_processors.py:78 src/olympia/amo/templates/amo/site_nav.html:85 src/olympia/devhub/helpers.py:36 src/olympia/devhub/helpers.py:68 src/olympia/devhub/helpers.py:102
+#: src/olympia/templates/footer.html:6 src/olympia/templates/menu_links.html:14
 msgid "Developer Hub"
 msgstr "Kehityskeskus"
 
-#: src/olympia/amo/context_processors.py:83 src/olympia/devhub/views.py:1792
+#: src/olympia/amo/context_processors.py:81 src/olympia/devhub/views.py:1796
 msgid "Manage API Keys"
 msgstr ""
 
-#: src/olympia/amo/context_processors.py:88 src/olympia/editors/helpers.py:82
-#: src/olympia/editors/helpers.py:102
-#: src/olympia/editors/templates/editors/base.html:10
+#: src/olympia/amo/context_processors.py:86 src/olympia/editors/helpers.py:84 src/olympia/editors/helpers.py:104 src/olympia/editors/templates/editors/base.html:10
 msgid "Editor Tools"
 msgstr ""
 
-#: src/olympia/amo/context_processors.py:92
+#: src/olympia/amo/context_processors.py:90
 msgid "Admin Tools"
 msgstr ""
 
-#: src/olympia/amo/fields.py:15
+#: src/olympia/amo/fields.py:20
 msgid "Incorrect, please try again."
 msgstr ""
 
-#: src/olympia/amo/fields.py:16
+#: src/olympia/amo/fields.py:21
 msgid "Error verifying input, please try again."
 msgstr ""
 
-#: src/olympia/amo/fields.py:32
+#: src/olympia/amo/fields.py:37
 msgid "This must be a valid hex color code, such as #000000."
 msgstr ""
 
-#: src/olympia/amo/fields.py:58
+#: src/olympia/amo/fields.py:63
 msgid "Enter at least one value."
 msgstr ""
 
-#: src/olympia/amo/helpers.py:162
-#: src/olympia/amo/templates/amo/site_nav.html:61
-#: src/olympia/bandwagon/templates/bandwagon/add.html:9
-#: src/olympia/bandwagon/templates/bandwagon/collection_detail.html:15
-#: src/olympia/bandwagon/templates/bandwagon/delete.html:9
-#: src/olympia/bandwagon/templates/bandwagon/edit.html:15
-#: src/olympia/bandwagon/templates/bandwagon/user_listing.html:18
-#: src/olympia/bandwagon/templates/bandwagon/user_listing.html:21
-#: src/olympia/bandwagon/templates/bandwagon/impala/collection_listing.html:12
-#: src/olympia/bandwagon/templates/bandwagon/impala/collection_listing.html:20
-#: src/olympia/bandwagon/templates/bandwagon/impala/collection_listing.html:24
-#: src/olympia/bandwagon/templates/bandwagon/impala/collection_sidebar.html:3
-#: src/olympia/bandwagon/templates/bandwagon/includes/collection_sidebar.html:2
-#: src/olympia/bandwagon/templates/bandwagon/mobile/collection_listing.html:3
-#: src/olympia/stats/templates/stats/stats.html:77
-#: src/olympia/templates/menu_links.html:12
+#: src/olympia/amo/helpers.py:162 src/olympia/amo/templates/amo/site_nav.html:59 src/olympia/bandwagon/templates/bandwagon/add.html:9
+#: src/olympia/bandwagon/templates/bandwagon/collection_detail.html:15 src/olympia/bandwagon/templates/bandwagon/delete.html:9 src/olympia/bandwagon/templates/bandwagon/edit.html:15
+#: src/olympia/bandwagon/templates/bandwagon/user_listing.html:18 src/olympia/bandwagon/templates/bandwagon/user_listing.html:21
+#: src/olympia/bandwagon/templates/bandwagon/impala/collection_listing.html:12 src/olympia/bandwagon/templates/bandwagon/impala/collection_listing.html:20
+#: src/olympia/bandwagon/templates/bandwagon/impala/collection_listing.html:24 src/olympia/bandwagon/templates/bandwagon/impala/collection_sidebar.html:3
+#: src/olympia/bandwagon/templates/bandwagon/includes/collection_sidebar.html:2 src/olympia/bandwagon/templates/bandwagon/mobile/collection_listing.html:3
+#: src/olympia/stats/templates/stats/stats.html:33 src/olympia/templates/menu_links.html:12
 msgid "Collections"
 msgstr "Kokoelmat"
 
-#: src/olympia/amo/helpers.py:171
-#: src/olympia/amo/templates/amo/site_nav.html:85
-#: src/olympia/browse/templates/browse/language_tools.html:3
+#: src/olympia/amo/helpers.py:171 src/olympia/amo/templates/amo/site_nav.html:83 src/olympia/browse/templates/browse/language_tools.html:3
 msgid "Dictionaries & Language Packs"
 msgstr "Oikolukusanastot ja kielipaketit"
 
@@ -2046,11 +1620,8 @@ msgstr ""
 
 # 87%
 # 100%
-#: src/olympia/amo/log.py:236
-#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:19
-#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:47
-#: src/olympia/editors/helpers.py:511
-#: src/olympia/editors/templates/editors/themes/history_table.html:11
+#: src/olympia/amo/log.py:236 src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:17 src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:45
+#: src/olympia/editors/helpers.py:584 src/olympia/editors/templates/editors/themes/history_table.html:11
 #, fuzzy
 msgid "Comment"
 msgstr "Kommentit"
@@ -2309,10 +1880,7 @@ msgstr ""
 msgid "{addon} unlisted."
 msgstr ""
 
-#: src/olympia/amo/log.py:592 src/olympia/amo/log.py:598
-#: src/olympia/amo/log.py:612 src/olympia/amo/log.py:618
-#: src/olympia/amo/log.py:624 src/olympia/amo/log.py:630
-#: src/olympia/amo/log.py:636
+#: src/olympia/amo/log.py:592 src/olympia/amo/log.py:598 src/olympia/amo/log.py:612 src/olympia/amo/log.py:618 src/olympia/amo/log.py:624 src/olympia/amo/log.py:630 src/olympia/amo/log.py:636
 msgid "{file} was signed."
 msgstr ""
 
@@ -2326,15 +1894,11 @@ msgid "Not allowed"
 msgstr ""
 
 #: src/olympia/amo/templates/amo/403.html:7
-msgid ""
-"<h1>Oops! Not allowed.</h1> <p>You tried to do something that you weren't "
-"allowed to.</p>"
+msgid "<h1>Oops! Not allowed.</h1> <p>You tried to do something that you weren't allowed to.</p>"
 msgstr ""
 
 #: src/olympia/amo/templates/amo/403.html:12
-msgid ""
-"<p>Try going back to the previous page, refreshing and then trying "
-"again.</p>"
+msgid "<p>Try going back to the previous page, refreshing and then trying again.</p>"
 msgstr ""
 
 #: src/olympia/amo/templates/amo/404.html:3
@@ -2344,20 +1908,12 @@ msgstr "Ei löytynyt"
 #: src/olympia/amo/templates/amo/404.html:6
 #, python-format
 msgid ""
-"<h1>We're sorry, but we can't find what you're looking for.</h1> <p> The "
-"page or file you requested wasn't found on our site. It's possible that you "
-"clicked a link that's out of date, or typed in the address incorrectly. </p>"
-" <ul> <li>If you typed in the address, please double check the "
-"spelling.</li> <li> If you followed a link from somewhere, please let us "
-"know at <a href=\"mailto:webmaster@mozilla.com\">webmaster@mozilla.com</a>. "
-"Tell us where you came from and what you were looking for, and we'll do our "
-"best to fix it. </li> </ul> <p>Or you can just jump over to some of the "
-"popular pages on our website.</p> <ul> <li>Are you interested in a <a "
-"href=\"%(rec)s\">list of featured add-ons</a>?</li> <li> Do you want to <a "
-"href=\"%(search)s\">search for add-ons</a>? You may go to the <a "
-"href=\"%(search)s\">search page</a> or just use the search field above. "
-"</li> <li> If you prefer to start over, just go to the <a href=\"%(home)s"
-"\">add-ons front page</a>. </li> </ul>"
+"<h1>We're sorry, but we can't find what you're looking for.</h1> <p> The page or file you requested wasn't found on our site. It's possible that you clicked a link that's out of date, or typed in "
+"the address incorrectly. </p> <ul> <li>If you typed in the address, please double check the spelling.</li> <li> If you followed a link from somewhere, please let us know at <a href=\"mailto:"
+"webmaster@mozilla.com\">webmaster@mozilla.com</a>. Tell us where you came from and what you were looking for, and we'll do our best to fix it. </li> </ul> <p>Or you can just jump over to some of "
+"the popular pages on our website.</p> <ul> <li>Are you interested in a <a href=\"%(rec)s\">list of featured add-ons</a>?</li> <li> Do you want to <a href=\"%(search)s\">search for add-ons</a>? You "
+"may go to the <a href=\"%(search)s\">search page</a> or just use the search field above. </li> <li> If you prefer to start over, just go to the <a href=\"%(home)s\">add-ons front page</a>. </li> </"
+"ul>"
 msgstr ""
 
 #: src/olympia/amo/templates/amo/500.html:3
@@ -2366,74 +1922,48 @@ msgstr ""
 
 #: src/olympia/amo/templates/amo/500.html:6
 #, python-format
-msgid ""
-"<h1>Oops!  We had an error.</h1> <p>We'll get to fixing that soon.</p> <p> "
-"You can try refreshing the page, or head back to the <a href=\"%(home)s"
-"\">Add-ons homepage</a>. </p>"
+msgid "<h1>Oops!  We had an error.</h1> <p>We'll get to fixing that soon.</p> <p> You can try refreshing the page, or head back to the <a href=\"%(home)s\">Add-ons homepage</a>. </p>"
 msgstr ""
 
 #: src/olympia/amo/templates/amo/license_link.html:10
 msgid "Some rights reserved"
 msgstr ""
 
-#: src/olympia/amo/templates/amo/no_results.html:1
-#: src/olympia/editors/templates/editors/includes/search_results_themes.html:26
+#: src/olympia/amo/templates/amo/no_results.html:1 src/olympia/editors/templates/editors/includes/search_results_themes.html:26
 msgid "No results found"
 msgstr ""
 
 #. abbreviation of 'previous'
-#: src/olympia/amo/templates/amo/paginator.html:6
-#: src/olympia/amo/templates/amo/mobile/paginator.html:4
-#: src/olympia/amo/templates/amo/mobile/paginator.html:6
-#: src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:49
-#: src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:63
-#: src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:76
-#: src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:89
+#: src/olympia/amo/templates/amo/paginator.html:6 src/olympia/amo/templates/amo/mobile/paginator.html:4 src/olympia/amo/templates/amo/mobile/paginator.html:6
+#: src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:49 src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:63
+#: src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:76 src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:89
 #: src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:102
 msgid "Prev"
 msgstr "Edellinen"
 
-#: src/olympia/amo/templates/amo/paginator.html:26
-#: src/olympia/amo/templates/amo/impala/paginator.html:26
-#: src/olympia/amo/templates/amo/mobile/impala_paginator.html:16
-#: src/olympia/amo/templates/amo/mobile/paginator.html:14
-#: src/olympia/amo/templates/amo/mobile/paginator.html:16
-#: src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:51
-#: src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:65
-#: src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:78
-#: src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:91
-#: src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:104
-#: src/olympia/discovery/templates/discovery/pane.html:45
-#: src/olympia/discovery/templates/discovery/addons/detail.html:39
-#: src/olympia/stats/templates/stats/stats.html:167
+#: src/olympia/amo/templates/amo/paginator.html:26 src/olympia/amo/templates/amo/impala/paginator.html:26 src/olympia/amo/templates/amo/mobile/impala_paginator.html:16
+#: src/olympia/amo/templates/amo/mobile/paginator.html:14 src/olympia/amo/templates/amo/mobile/paginator.html:16 src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:51
+#: src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:65 src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:78
+#: src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:91 src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:104
+#: src/olympia/discovery/templates/discovery/pane.html:45 src/olympia/discovery/templates/discovery/addons/detail.html:39 src/olympia/stats/templates/stats/stats.html:169
 msgid "Next"
 msgstr "Seuraava"
 
-#: src/olympia/amo/templates/amo/paginator.html:32
-#: src/olympia/editors/templates/editors/includes/paginator_history.html:11
+#: src/olympia/amo/templates/amo/paginator.html:32 src/olympia/editors/templates/editors/includes/paginator_history.html:11
 #, python-format
-msgid ""
-"Results <strong>%(begin)s</strong>&ndash;<strong>%(end)s</strong> of "
-"<strong>%(count)s</strong>"
-msgstr ""
-"Tulokset <strong>%(begin)s</strong>&ndash;<strong>%(end)s</strong>, yhteensä"
-" <strong>%(count)s</strong>"
+msgid "Results <strong>%(begin)s</strong>&ndash;<strong>%(end)s</strong> of <strong>%(count)s</strong>"
+msgstr "Tulokset <strong>%(begin)s</strong>&ndash;<strong>%(end)s</strong>, yhteensä <strong>%(count)s</strong>"
 
-#: src/olympia/amo/templates/amo/read-only.html:3
-#: src/olympia/amo/templates/amo/read-only.html:7
+#: src/olympia/amo/templates/amo/read-only.html:3 src/olympia/amo/templates/amo/read-only.html:7
 msgid "Maintenance in progress"
 msgstr ""
 
 #: src/olympia/amo/templates/amo/read-only.html:9
-msgid ""
-"This feature is temporarily disabled while we perform website maintenance. "
-"Please use your browser's Back button and try again a little later."
+msgid "This feature is temporarily disabled while we perform website maintenance. Please use your browser's Back button and try again a little later."
 msgstr ""
 
 #: src/olympia/amo/templates/amo/read-only.html:14
-msgid ""
-"Some features on this page are temporarily disabled while we perform website"
-" maintenance. Please try again a little later."
+msgid "Some features on this page are temporarily disabled while we perform website maintenance. Please try again a little later."
 msgstr ""
 
 #: src/olympia/amo/templates/amo/recaptcha.html:4
@@ -2442,20 +1972,12 @@ msgstr "Oletko ihminen?"
 
 #: src/olympia/amo/templates/amo/recaptcha.html:8
 msgid ""
-"<p> Please enter <strong>all the words</strong> below, <strong>separated by "
-"a space if necessary</strong>. </p> <p> If this is hard to read, you can <a "
-"href=\"#\" id=\"recaptcha_different\">try different words</a> or <a "
-"href=\"#\" id=\"recaptcha_audio\">try a different type of challenge</a> "
-"instead. </p>"
+"<p> Please enter <strong>all the words</strong> below, <strong>separated by a space if necessary</strong>. </p> <p> If this is hard to read, you can <a href=\"#\" id=\"recaptcha_different\">try "
+"different words</a> or <a href=\"#\" id=\"recaptcha_audio\">try a different type of challenge</a> instead. </p>"
 msgstr ""
 
-#: src/olympia/amo/templates/amo/side_nav.html:4
-#: src/olympia/amo/templates/amo/side_nav.html:12
-#: src/olympia/amo/templates/amo/site_nav.html:4
-#: src/olympia/amo/templates/amo/site_nav.html:26
-#: src/olympia/browse/views.py:56 src/olympia/browse/views.py:66
-#: src/olympia/browse/views.py:237 src/olympia/browse/views.py:282
-#: src/olympia/search/forms.py:86
+#: src/olympia/amo/templates/amo/side_nav.html:4 src/olympia/amo/templates/amo/side_nav.html:12 src/olympia/amo/templates/amo/site_nav.html:4 src/olympia/amo/templates/amo/site_nav.html:26
+#: src/olympia/browse/views.py:56 src/olympia/browse/views.py:66 src/olympia/browse/views.py:204 src/olympia/browse/views.py:249 src/olympia/search/forms.py:86
 msgid "Top Rated"
 msgstr "Parhaiten arvioidut"
 
@@ -2464,81 +1986,60 @@ msgid "Explore"
 msgstr "Selaa"
 
 # Plural in this context means many of the add-on type
-#: src/olympia/amo/templates/amo/site_nav.html:23
-#: src/olympia/browse/feeds.py:65 src/olympia/browse/feeds.py:78
-#: src/olympia/browse/feeds.py:92 src/olympia/browse/feeds.py:100
-#: src/olympia/browse/templates/browse/base_listing.html:7
-#: src/olympia/browse/templates/browse/creatured.html:10
-#: src/olympia/browse/templates/browse/impala/base_listing.html:37
+#: src/olympia/amo/templates/amo/site_nav.html:23 src/olympia/browse/feeds.py:65 src/olympia/browse/feeds.py:78 src/olympia/browse/feeds.py:92 src/olympia/browse/feeds.py:100
+#: src/olympia/browse/templates/browse/base_listing.html:7 src/olympia/browse/templates/browse/creatured.html:10 src/olympia/browse/templates/browse/impala/base_listing.html:37
 #: src/olympia/constants/base.py:173 src/olympia/templates/menu_links.html:8
 msgid "Extensions"
 msgstr "Laajennukset"
 
-#: src/olympia/amo/templates/amo/site_nav.html:45
+#: src/olympia/amo/templates/amo/site_nav.html:44
 msgid "Want more customization? Try <b>Complete Themes</b>"
 msgstr ""
 
-#: src/olympia/amo/templates/amo/site_nav.html:56
-#: src/olympia/bandwagon/views.py:96
+#: src/olympia/amo/templates/amo/site_nav.html:54 src/olympia/bandwagon/views.py:96
 msgid "Most Followers"
 msgstr "Eniten seuraajia"
 
-#: src/olympia/amo/templates/amo/site_nav.html:68
-#: src/olympia/bandwagon/templates/bandwagon/impala/collection_sidebar.html:16
+#: src/olympia/amo/templates/amo/site_nav.html:66 src/olympia/bandwagon/templates/bandwagon/impala/collection_sidebar.html:16
 #: src/olympia/bandwagon/templates/bandwagon/includes/collection_sidebar.html:18
 msgid "Collections I've Made"
 msgstr "Tekemäni kokoelmat"
 
-#: src/olympia/amo/templates/amo/site_nav.html:70
-#: src/olympia/bandwagon/templates/bandwagon/user_listing.html:4
-#: src/olympia/bandwagon/templates/bandwagon/impala/collection_sidebar.html:13
+#: src/olympia/amo/templates/amo/site_nav.html:68 src/olympia/bandwagon/templates/bandwagon/user_listing.html:4 src/olympia/bandwagon/templates/bandwagon/impala/collection_sidebar.html:13
 #: src/olympia/bandwagon/templates/bandwagon/includes/collection_sidebar.html:15
 msgid "Collections I'm Following"
 msgstr "Seuraamani kokoelmat"
 
-#: src/olympia/amo/templates/amo/site_nav.html:73
-#: src/olympia/bandwagon/templates/bandwagon/impala/collection_sidebar.html:18
-#: src/olympia/bandwagon/templates/bandwagon/includes/collection_sidebar.html:20
-#: src/olympia/users/models.py:512
+#: src/olympia/amo/templates/amo/site_nav.html:71 src/olympia/bandwagon/templates/bandwagon/impala/collection_sidebar.html:18
+#: src/olympia/bandwagon/templates/bandwagon/includes/collection_sidebar.html:20 src/olympia/users/models.py:521
 msgid "My Favorite Add-ons"
 msgstr "Suosikkilisäosani"
 
-#: src/olympia/amo/templates/amo/site_nav.html:78
+#: src/olympia/amo/templates/amo/site_nav.html:76
 msgid "More&hellip;"
 msgstr "Lisää&hellip;"
 
-#: src/olympia/amo/templates/amo/site_nav.html:82
+#: src/olympia/amo/templates/amo/site_nav.html:80
 msgid "Add-ons for Mobile"
 msgstr "Lisäosia mobiiliin"
 
-#: src/olympia/amo/templates/amo/site_nav.html:86
-#: src/olympia/browse/feeds.py:207
-#: src/olympia/browse/templates/browse/search_tools.html:3
-#: src/olympia/constants/base.py:176 src/olympia/templates/menu_links.html:10
+#: src/olympia/amo/templates/amo/site_nav.html:84 src/olympia/browse/feeds.py:207 src/olympia/browse/templates/browse/search_tools.html:3 src/olympia/constants/base.py:176
+#: src/olympia/templates/menu_links.html:10
 msgid "Search Tools"
 msgstr "Hakutyökalut"
 
 #. This is a page range (e.g., Page 1 of 50).
-#: src/olympia/amo/templates/amo/impala/paginator.html:5
-#: src/olympia/amo/templates/amo/mobile/impala_paginator.html:26
+#: src/olympia/amo/templates/amo/impala/paginator.html:5 src/olympia/amo/templates/amo/mobile/impala_paginator.html:26
 #, python-format
-msgid ""
-"Page <a href=\"%(current_pg_url)s\">%(current_pg)s</a> of <a "
-"href=\"%(last_pg_url)s\">%(last_pg)s</a>"
-msgstr ""
-"Sivu <a href=\"%(current_pg_url)s\">%(current_pg)s</a> / <a "
-"href=\"%(last_pg_url)s\">%(last_pg)s</a>"
+msgid "Page <a href=\"%(current_pg_url)s\">%(current_pg)s</a> of <a href=\"%(last_pg_url)s\">%(last_pg)s</a>"
+msgstr "Sivu <a href=\"%(current_pg_url)s\">%(current_pg)s</a> / <a href=\"%(last_pg_url)s\">%(last_pg)s</a>"
 
-#: src/olympia/amo/templates/amo/impala/paginator.html:16
-#: src/olympia/amo/templates/amo/mobile/impala_paginator.html:6
+#: src/olympia/amo/templates/amo/impala/paginator.html:16 src/olympia/amo/templates/amo/mobile/impala_paginator.html:6
 msgid "Jump to first page"
 msgstr "Loikkaa ensimmäiselle sivulle"
 
-#: src/olympia/amo/templates/amo/impala/paginator.html:22
-#: src/olympia/amo/templates/amo/mobile/impala_paginator.html:12
-#: src/olympia/discovery/templates/discovery/pane.html:44
-#: src/olympia/discovery/templates/discovery/addons/detail.html:38
-#: src/olympia/stats/templates/stats/stats.html:164
+#: src/olympia/amo/templates/amo/impala/paginator.html:22 src/olympia/amo/templates/amo/mobile/impala_paginator.html:12 src/olympia/discovery/templates/discovery/pane.html:44
+#: src/olympia/discovery/templates/discovery/addons/detail.html:38 src/olympia/stats/templates/stats/stats.html:166
 msgid "Previous"
 msgstr "Edellinen"
 
@@ -2548,15 +2049,12 @@ msgstr ""
 
 #. First and second arguments are the result range (e.g., 1-20);
 #. third argument is the number of total results (e.g., 1,000).
-#. First and second arguments are the result range (e.g., 1-20);
-#. third
+#. First and second arguments are the result range (e.g., 1-20);              third
 #. argument is the number of total results (e.g., 1,000).
-#: src/olympia/amo/templates/amo/impala/paginator.html:36
-#: src/olympia/amo/templates/amo/mobile/impala_paginator.html:38
+#: src/olympia/amo/templates/amo/impala/paginator.html:36 src/olympia/amo/templates/amo/mobile/impala_paginator.html:38
 #, python-format
 msgid "Showing <b>%(begin)s</b>&ndash;<b>%(end)s</b> of <b>%(count)s</b>"
-msgstr ""
-"Näytetään tulokset <b>%(begin)s</b>&ndash;<b>%(end)s</b> / <b>%(count)s</b>"
+msgstr "Näytetään tulokset <b>%(begin)s</b>&ndash;<b>%(end)s</b> / <b>%(count)s</b>"
 
 #: src/olympia/amo/templates/amo/mobile/paginator.html:10
 msgid "Page {n}"
@@ -2564,41 +2062,53 @@ msgid_plural "Page {n}"
 msgstr[0] "Sivu {n}"
 msgstr[1] "Sivu {n}"
 
-#: src/olympia/amo/templates/services/install.html:38
-#, python-format
-msgid ""
-"If you are not prompted to install %(addon_name)s in a moment, please <a "
-"href=\"%(addon_xpi)s\">click here</a>."
-msgstr ""
-
-#: src/olympia/amo/tests/test_messages.py:57
-#: src/olympia/amo/tests/test_messages.py:58 src/olympia/reviews/forms.py:25
-#: src/olympia/reviews/forms.py:50
-#: src/olympia/reviews/templates/reviews/add.html:56
+#: src/olympia/amo/tests/test_messages.py:56 src/olympia/amo/tests/test_messages.py:57 src/olympia/reviews/forms.py:25 src/olympia/reviews/forms.py:50 src/olympia/reviews/templates/reviews/add.html:56
 #: src/olympia/reviews/templates/reviews/reply.html:30
 msgid "Title"
 msgstr ""
 
-#: src/olympia/amo/tests/test_messages.py:57
-#: src/olympia/amo/tests/test_messages.py:58
+#: src/olympia/amo/tests/test_messages.py:56 src/olympia/amo/tests/test_messages.py:57
 msgid "Body"
 msgstr ""
 
-#: src/olympia/amo/tests/test_messages.py:59
+#: src/olympia/amo/tests/test_messages.py:58
 msgid "Another Title"
 msgstr ""
 
-#: src/olympia/amo/tests/test_messages.py:59
+#: src/olympia/amo/tests/test_messages.py:58
 msgid "Another Body"
 msgstr ""
 
-#: src/olympia/api/views.py:255
-msgid "Not implemented yet."
+#: src/olympia/api/authentication.py:76
+msgid "Signature has expired."
+msgstr ""
+
+#: src/olympia/api/authentication.py:79
+msgid "Error decoding signature."
+msgstr ""
+
+#: src/olympia/api/authentication.py:82
+msgid "Invalid JWT Token."
+msgstr ""
+
+#: src/olympia/api/authentication.py:130
+msgid "Invalid Authorization header. No credentials provided."
+msgstr ""
+
+#: src/olympia/api/authentication.py:133
+msgid "Invalid Authorization header. Credentials string should not contain spaces."
+msgstr ""
+
+#: src/olympia/api/fields.py:29
+msgid "The field must have a length of at least {num} characters."
+msgstr ""
+
+#: src/olympia/api/fields.py:31
+msgid "The language code {lang_code} is invalid."
 msgstr ""
 
 # 76%
-#: src/olympia/applications/views.py:39
-#: src/olympia/applications/templates/applications/appversions.html:3
+#: src/olympia/applications/views.py:39 src/olympia/applications/templates/applications/appversions.html:3
 #, fuzzy
 msgid "Application Versions"
 msgstr "Kelvolliset ohjelmaversiot"
@@ -2612,19 +2122,15 @@ msgid "Valid Application Versions"
 msgstr "Kelvolliset ohjelmaversiot"
 
 #: src/olympia/applications/templates/applications/appversions.html:12
-msgid ""
-"Add-ons submitted to Mozilla Add-ons must have a manifest file with at least"
-" one of the below applications supported. Only the versions listed below are"
-" allowed for these applications."
+msgid "Add-ons submitted to Mozilla Add-ons must have a manifest file with at least one of the below applications supported. Only the versions listed below are allowed for these applications."
 msgstr ""
 
-#: src/olympia/applications/templates/applications/appversions.html:25
+#: src/olympia/applications/templates/applications/appversions.html:25 src/olympia/editors/helpers.py:361
 msgid "GUID"
 msgstr "GUID"
 
 #. {0} is an add-on name.
-#: src/olympia/applications/templates/applications/appversions.html:26
-#: src/olympia/versions/templates/versions/version_list.html:23
+#: src/olympia/applications/templates/applications/appversions.html:26 src/olympia/versions/templates/versions/version_list.html:23
 msgid "Versions"
 msgstr "Versiot"
 
@@ -2634,10 +2140,7 @@ msgstr "http://developer.mozilla.org/en/docs/Install_Manifests"
 
 #: src/olympia/applications/templates/applications/appversions.html:31
 #, python-format
-msgid ""
-"If your supported application does not require a manifest file, you still "
-"must include one with the required properties as specified <a "
-"href=\"%(url)s\">here</a>."
+msgid "If your supported application does not require a manifest file, you still must include one with the required properties as specified <a href=\"%(url)s\">here</a>."
 msgstr ""
 
 #. L10n: {0} is 'Add-ons for <app>'.
@@ -2646,16 +2149,12 @@ msgstr ""
 msgid "Collections :: %s"
 msgstr "Kokoelmat :: %s"
 
-#: src/olympia/bandwagon/feeds.py:50
-#: src/olympia/bandwagon/templates/bandwagon/collection_detail.html:137
-msgid ""
-"Collections are groups of related add-ons that anyone can create and share."
-msgstr ""
-"Kokoelmat ovat toisiinsa liittyvien lisäosien ryhmiä, joita kuka tahansa voi"
-" luoda ja jakaa."
+#: src/olympia/bandwagon/feeds.py:50 src/olympia/bandwagon/templates/bandwagon/collection_detail.html:137
+msgid "Collections are groups of related add-ons that anyone can create and share."
+msgstr "Kokoelmat ovat toisiinsa liittyvien lisäosien ryhmiä, joita kuka tahansa voi luoda ja jakaa."
 
-#. L10n: {0} is a collection name, {1} is 'Add-ons for <app>'.
 # ikkunan otsikko
+#. L10n: {0} is a collection name, {1} is 'Add-ons for <app>'.
 #: src/olympia/bandwagon/feeds.py:70
 msgid "{0} :: Collections :: {1}"
 msgstr "{0} :: Kokoelmat :: {1}"
@@ -2708,8 +2207,7 @@ msgstr ""
 msgid "Icons must be either PNG or JPG."
 msgstr ""
 
-#: src/olympia/bandwagon/forms.py:202 src/olympia/devhub/views.py:1067
-#: src/olympia/users/forms.py:476
+#: src/olympia/bandwagon/forms.py:202 src/olympia/devhub/views.py:1067 src/olympia/users/forms.py:476
 #, python-format
 msgid "Please use images smaller than %dMB."
 msgstr ""
@@ -2735,8 +2233,7 @@ msgstr "Kirjaudu sisään antaaksesi äänesi tälle kokoelmalle"
 
 # 93%
 # 100%
-#: src/olympia/bandwagon/helpers.py:123
-#: src/olympia/bandwagon/templates/bandwagon/favorites_widget.html:2
+#: src/olympia/bandwagon/helpers.py:123 src/olympia/bandwagon/templates/bandwagon/favorites_widget.html:2
 msgid "Add to favorites"
 msgstr ""
 
@@ -2746,20 +2243,13 @@ msgstr ""
 
 # 95%
 # 100%
-#: src/olympia/bandwagon/helpers.py:124
-#: src/olympia/bandwagon/templates/bandwagon/favorites_widget.html:2
+#: src/olympia/bandwagon/helpers.py:124 src/olympia/bandwagon/templates/bandwagon/favorites_widget.html:2
 msgid "Remove from favorites"
 msgstr "Poista suosikeista"
 
-#: src/olympia/bandwagon/views.py:98 src/olympia/bandwagon/views.py:191
-#: src/olympia/browse/views.py:58 src/olympia/browse/views.py:69
-#: src/olympia/browse/views.py:458 src/olympia/devhub/views.py:74
-#: src/olympia/devhub/views.py:82
-#: src/olympia/devhub/templates/devhub/addons/edit/basic.html:20
-#: src/olympia/editors/templates/editors/leaderboard.html:24
-#: src/olympia/editors/templates/editors/themes/queue_list.html:48
-#: src/olympia/search/forms.py:17 src/olympia/search/forms.py:89
-#: src/olympia/users/templates/users/vcard.html:5
+#: src/olympia/bandwagon/views.py:98 src/olympia/bandwagon/views.py:191 src/olympia/browse/views.py:58 src/olympia/browse/views.py:69 src/olympia/browse/views.py:425 src/olympia/devhub/views.py:72
+#: src/olympia/devhub/views.py:80 src/olympia/devhub/templates/devhub/addons/edit/basic.html:20 src/olympia/editors/templates/editors/leaderboard.html:24
+#: src/olympia/editors/templates/editors/themes/queue_list.html:48 src/olympia/search/forms.py:17 src/olympia/search/forms.py:89 src/olympia/users/templates/users/vcard.html:5
 msgid "Name"
 msgstr "Nimi"
 
@@ -2767,8 +2257,7 @@ msgstr "Nimi"
 msgid "Recently Popular"
 msgstr ""
 
-#: src/olympia/bandwagon/views.py:189
-#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:18
+#: src/olympia/bandwagon/views.py:189 src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:16
 msgid "Added"
 msgstr "Lisäyspäivä"
 
@@ -2783,9 +2272,7 @@ msgstr ""
 
 #: src/olympia/bandwagon/views.py:316
 #, python-format
-msgid ""
-"Your new collection is shown below. You can <ahref=\"%(url)s\">edit "
-"additional settings</a> if you'dlike."
+msgid "Your new collection is shown below. You can <a href=\"%(url)s\">edit additional settings</a> if you'd like."
 msgstr ""
 
 #: src/olympia/bandwagon/views.py:322
@@ -2804,32 +2291,24 @@ msgstr ""
 # 89%
 # 82%
 # 100%
-#: src/olympia/bandwagon/templates/bandwagon/add.html:3
-#: src/olympia/bandwagon/templates/bandwagon/add.html:11
-#: src/olympia/bandwagon/templates/bandwagon/includes/collection_sidebar.html:26
+#: src/olympia/bandwagon/templates/bandwagon/add.html:3 src/olympia/bandwagon/templates/bandwagon/add.html:11 src/olympia/bandwagon/templates/bandwagon/includes/collection_sidebar.html:26
 msgid "Create a New Collection"
 msgstr "Luo uusi kokoelma"
 
 # 85%
-#: src/olympia/bandwagon/templates/bandwagon/add.html:9
-#: src/olympia/devhub/templates/devhub/personas/submit.html:14
+#: src/olympia/bandwagon/templates/bandwagon/add.html:9 src/olympia/devhub/templates/devhub/personas/submit.html:14
 #, fuzzy
 msgid "Create"
 msgstr "Luotu"
 
-#: src/olympia/bandwagon/templates/bandwagon/add.html:24
-#: src/olympia/bandwagon/templates/bandwagon/ajax_new.html:28
+#: src/olympia/bandwagon/templates/bandwagon/add.html:24 src/olympia/bandwagon/templates/bandwagon/ajax_new.html:28
 #, python-format
-msgid ""
-"As noted in our <a href=\"%(legal)s\">Legal Notices</a>, individual "
-"collection arrangements are governed by the Creative Commons Attribution "
-"Share-Alike License"
+msgid "As noted in our <a href=\"%(legal)s\">Legal Notices</a>, individual collection arrangements are governed by the Creative Commons Attribution Share-Alike License"
 msgstr ""
 
 # 89%
 # 100%
-#: src/olympia/bandwagon/templates/bandwagon/add.html:33
-#: src/olympia/bandwagon/templates/bandwagon/ajax_new.html:38
+#: src/olympia/bandwagon/templates/bandwagon/add.html:33 src/olympia/bandwagon/templates/bandwagon/ajax_new.html:38
 msgid "Create Collection"
 msgstr "Luo kokoelma"
 
@@ -2859,8 +2338,7 @@ msgstr "Create Collection"
 msgid "Start a New Collection"
 msgstr "Create Collection"
 
-#: src/olympia/bandwagon/templates/bandwagon/ajax_new.html:6
-#: src/olympia/bandwagon/templates/bandwagon/includes/addedit.html:7
+#: src/olympia/bandwagon/templates/bandwagon/ajax_new.html:6 src/olympia/bandwagon/templates/bandwagon/includes/addedit.html:7
 msgid "Name:"
 msgstr "Nimi:"
 
@@ -2871,19 +2349,13 @@ msgstr ""
 #. Link to remove a collection vote
 #: src/olympia/bandwagon/templates/bandwagon/barometer.html:15
 msgid "To rate collections, you must have an add-ons account."
-msgstr ""
-"Jotta voisit arvioida kokoelmia, sinulla pitää olla käyttäjätili Lisäosat-"
-"palvelussa."
+msgstr "Jotta voisit arvioida kokoelmia, sinulla pitää olla käyttäjätili Lisäosat-palvelussa."
 
-#: src/olympia/bandwagon/templates/bandwagon/barometer.html:18
-#: src/olympia/templates/base.html:145
-#: src/olympia/templates/impala/base.html:198
+#: src/olympia/bandwagon/templates/bandwagon/barometer.html:18 src/olympia/templates/base.html:145 src/olympia/templates/impala/base.html:198
 msgid "Create an Add-ons Account"
 msgstr "Luo tili Lisäosat-palveluun"
 
-#: src/olympia/bandwagon/templates/bandwagon/barometer.html:21
-#: src/olympia/templates/base.html:148
-#: src/olympia/templates/impala/base.html:201
+#: src/olympia/bandwagon/templates/bandwagon/barometer.html:21 src/olympia/templates/base.html:148 src/olympia/templates/impala/base.html:201
 #, python-format
 msgid "or <a href=\"%(login)s\">log in to your current account</a>"
 msgstr "tai <a href=\"%(login)s\">kirjaudu sisään käyttäjätilillesi</a>"
@@ -2897,8 +2369,7 @@ msgstr "{0} :: Kokoelmat"
 msgid "private"
 msgstr "yksityinen"
 
-#: src/olympia/bandwagon/templates/bandwagon/collection_detail.html:45
-#: src/olympia/bandwagon/templates/bandwagon/mobile/listing_items.html:9
+#: src/olympia/bandwagon/templates/bandwagon/collection_detail.html:45 src/olympia/bandwagon/templates/bandwagon/mobile/listing_items.html:9
 #, python-format
 msgid "<span>%(num)s</span> follower"
 msgid_plural "<span>%(num)s</span> followers"
@@ -2939,8 +2410,7 @@ msgstr "Muokkaa kokoelmaa"
 
 # 78%
 # 100%
-#: src/olympia/bandwagon/templates/bandwagon/collection_detail.html:88
-#: src/olympia/bandwagon/templates/bandwagon/includes/delete.html:3
+#: src/olympia/bandwagon/templates/bandwagon/collection_detail.html:88 src/olympia/bandwagon/templates/bandwagon/includes/delete.html:3
 msgid "Delete Collection"
 msgstr "Poista kokoelma"
 
@@ -2959,12 +2429,8 @@ msgstr[0] "%(num)s lisäosa tässä kokoelmassa"
 msgstr[1] "%(num)s lisäosaa tässä kokoelmassa"
 
 # 100%
-#: src/olympia/bandwagon/templates/bandwagon/collection_detail.html:125
-#: src/olympia/compat/templates/compat/index.html:25
-#: src/olympia/compat/templates/compat/reporter_detail.html:29
-#: src/olympia/files/templates/files/viewer.html:29
-#: src/olympia/templates/amo_footer.html:17
-#: src/olympia/templates/includes/lang_switcher.html:10
+#: src/olympia/bandwagon/templates/bandwagon/collection_detail.html:125 src/olympia/compat/templates/compat/reporter_detail.html:29 src/olympia/files/templates/files/viewer.html:29
+#: src/olympia/templates/amo_footer.html:17 src/olympia/templates/includes/lang_switcher.html:10
 msgid "Go"
 msgstr "Mene"
 
@@ -2990,18 +2456,14 @@ msgstr "Näytä kaikki kokoelmat tältä käyttäjältä"
 
 #: src/olympia/bandwagon/templates/bandwagon/collection_detail.html:179
 msgid ""
-"Add-ons that you mark as favorites using the <b>Add to Favorites</b> feature"
-" appear below. This collection is currently <b>public</b>, which means "
-"everyone can see it. If you would like to hide it from public view, click "
-"the button below to make it private."
+"Add-ons that you mark as favorites using the <b>Add to Favorites</b> feature appear below. This collection is currently <b>public</b>, which means everyone can see it. If you would like to hide it "
+"from public view, click the button below to make it private."
 msgstr ""
 
 #: src/olympia/bandwagon/templates/bandwagon/collection_detail.html:186
 msgid ""
-"Add-ons that you mark as favorites using the <b>Add to Favorites</b> feature"
-" appear below. This collection is currently <b>private</b>, which means only"
-" you can see it.  If you would like everyone to be able to see your "
-"favorites, click the button below to make it public."
+"Add-ons that you mark as favorites using the <b>Add to Favorites</b> feature appear below. This collection is currently <b>private</b>, which means only you can see it.  If you would like everyone "
+"to be able to see your favorites, click the button below to make it public."
 msgstr ""
 
 # 89%
@@ -3024,23 +2486,20 @@ msgid_plural "<span>%(followers)s</span> followers"
 msgstr[0] ""
 msgstr[1] ""
 
-#. People "follow" collections to get notified of updates.
-#. Like
+#. People "follow" collections to get notified of updates.                    Like
 #. Twitter followers.
 #. People "follow" collections to get notified of updates.
 #. Like Twitter followers.
-#: src/olympia/bandwagon/templates/bandwagon/collection_listing_items.html:10
-#: src/olympia/bandwagon/templates/bandwagon/impala/collection_listing_items.html:18
+#: src/olympia/bandwagon/templates/bandwagon/collection_listing_items.html:10 src/olympia/bandwagon/templates/bandwagon/impala/collection_listing_items.html:18
 #, python-format
 msgid "%(num)s weekly follower"
 msgid_plural "%(num)s weekly followers"
 msgstr[0] "%(num)s viikoittainen seuraaja"
 msgstr[1] "%(num)s viikoittaista seuraajaa"
 
-#. People "follow" collections to get notified of updates.
-#. Like
-#. Twitter followers.
 # 79%
+#. People "follow" collections to get notified of updates.                    Like
+#. Twitter followers.
 #: src/olympia/bandwagon/templates/bandwagon/collection_listing_items.html:18
 #, fuzzy, python-format
 msgid "%(num)s monthly follower"
@@ -3048,33 +2507,28 @@ msgid_plural "%(num)s monthly followers"
 msgstr[0] "%(num)s viikoittainen seuraaja"
 msgstr[1] "%(num)s viikoittaista seuraajaa"
 
-#. People "follow" collections to get notified of updates.
-#. Like
+#. People "follow" collections to get notified of updates.                    Like
 #. Twitter followers.
 #. People "follow" collections to get notified of updates.
 #. Like Twitter followers.
-#: src/olympia/bandwagon/templates/bandwagon/collection_listing_items.html:26
-#: src/olympia/bandwagon/templates/bandwagon/impala/collection_listing_items.html:26
+#: src/olympia/bandwagon/templates/bandwagon/collection_listing_items.html:26 src/olympia/bandwagon/templates/bandwagon/impala/collection_listing_items.html:26
 #, python-format
 msgid "%(num)s follower"
 msgid_plural "%(num)s followers"
 msgstr[0] "%(num)s seuraaja"
 msgstr[1] "%(num)s seuraajaa"
 
-#: src/olympia/bandwagon/templates/bandwagon/collection_listing_items.html:56
-#: src/olympia/bandwagon/templates/bandwagon/impala/collection_listing_items.html:9
+#: src/olympia/bandwagon/templates/bandwagon/collection_listing_items.html:56 src/olympia/bandwagon/templates/bandwagon/impala/collection_listing_items.html:9
 #: src/olympia/devhub/templates/devhub/personas/edit.html:27
 msgid "by {0}"
 msgstr "tekijänä {0}"
 
-#: src/olympia/bandwagon/templates/bandwagon/collection_widgets.html:5
-#: src/olympia/bandwagon/templates/bandwagon/collection_widgets.html:7
+#: src/olympia/bandwagon/templates/bandwagon/collection_widgets.html:5 src/olympia/bandwagon/templates/bandwagon/collection_widgets.html:7
 #: src/olympia/bandwagon/templates/bandwagon/impala/collection_listing_items.html:53
 msgid "Stop Following"
 msgstr "Lopeta seuraaminen"
 
-#: src/olympia/bandwagon/templates/bandwagon/collection_widgets.html:6
-#: src/olympia/bandwagon/templates/bandwagon/collection_widgets.html:7
+#: src/olympia/bandwagon/templates/bandwagon/collection_widgets.html:6 src/olympia/bandwagon/templates/bandwagon/collection_widgets.html:7
 #: src/olympia/bandwagon/templates/bandwagon/impala/collection_listing_items.html:53
 msgid "Follow this Collection"
 msgstr "Seuraa tätä kokoelmaa"
@@ -3086,16 +2540,12 @@ msgid "Edit this Collection"
 msgstr "Muokkaa kokoelmaa"
 
 #. %s is the name of the collection.
-#: src/olympia/bandwagon/templates/bandwagon/delete.html:4
-#: src/olympia/bandwagon/templates/bandwagon/delete.html:15
+#: src/olympia/bandwagon/templates/bandwagon/delete.html:4 src/olympia/bandwagon/templates/bandwagon/delete.html:15
 msgid "Delete {0}"
 msgstr "Poista {0}"
 
-#: src/olympia/bandwagon/templates/bandwagon/delete.html:13
-#: src/olympia/devhub/templates/devhub/addons/listing/item_actions.html:14
-#: src/olympia/devhub/templates/devhub/addons/listing/item_actions_theme.html:28
-#: src/olympia/devhub/templates/devhub/versions/list.html:131
-#: src/olympia/devhub/templates/devhub/versions/list.html:149
+#: src/olympia/bandwagon/templates/bandwagon/delete.html:13 src/olympia/devhub/templates/devhub/addons/listing/item_actions.html:14
+#: src/olympia/devhub/templates/devhub/addons/listing/item_actions_theme.html:28 src/olympia/devhub/templates/devhub/versions/list.html:131 src/olympia/devhub/templates/devhub/versions/list.html:149
 #: src/olympia/devhub/templates/devhub/versions/list.html:166
 msgid "Delete"
 msgstr "Poista"
@@ -3104,35 +2554,24 @@ msgstr "Poista"
 msgid "Are you sure?"
 msgstr "Oletko varma?"
 
-#: src/olympia/bandwagon/templates/bandwagon/delete.html:21
-#: src/olympia/devhub/templates/devhub/personas/edit.html:131
-#: src/olympia/devhub/templates/devhub/personas/edit.html:152
-#: src/olympia/devhub/templates/devhub/personas/edit.html:173
-#: src/olympia/devhub/templates/devhub/personas/submit.html:77
-#: src/olympia/devhub/templates/devhub/personas/submit.html:98
+#: src/olympia/bandwagon/templates/bandwagon/delete.html:21 src/olympia/devhub/templates/devhub/personas/edit.html:131 src/olympia/devhub/templates/devhub/personas/edit.html:152
+#: src/olympia/devhub/templates/devhub/personas/edit.html:173 src/olympia/devhub/templates/devhub/personas/submit.html:77 src/olympia/devhub/templates/devhub/personas/submit.html:98
 #: src/olympia/devhub/templates/devhub/personas/submit.html:119
 msgid "Yes"
 msgstr "Kyllä"
 
-#: src/olympia/bandwagon/templates/bandwagon/delete.html:22
-#: src/olympia/devhub/templates/devhub/personas/edit.html:140
-#: src/olympia/devhub/templates/devhub/personas/edit.html:161
-#: src/olympia/devhub/templates/devhub/personas/edit.html:191
-#: src/olympia/devhub/templates/devhub/personas/submit.html:86
-#: src/olympia/devhub/templates/devhub/personas/submit.html:107
+#: src/olympia/bandwagon/templates/bandwagon/delete.html:22 src/olympia/devhub/templates/devhub/personas/edit.html:140 src/olympia/devhub/templates/devhub/personas/edit.html:161
+#: src/olympia/devhub/templates/devhub/personas/edit.html:191 src/olympia/devhub/templates/devhub/personas/submit.html:86 src/olympia/devhub/templates/devhub/personas/submit.html:107
 #: src/olympia/devhub/templates/devhub/personas/submit.html:137
 msgid "No"
 msgstr "Ei"
 
 #. {0} is the name of the collection.
-#: src/olympia/bandwagon/templates/bandwagon/edit.html:5
-#: src/olympia/bandwagon/templates/bandwagon/edit.html:21
+#: src/olympia/bandwagon/templates/bandwagon/edit.html:5 src/olympia/bandwagon/templates/bandwagon/edit.html:21
 msgid "Edit {0}"
 msgstr "Muokkaa kokoelmaa {0}"
 
-#: src/olympia/bandwagon/templates/bandwagon/edit.html:29
-#: src/olympia/devhub/templates/devhub/addons/edit/details.html:20
-#: src/olympia/editors/templates/editors/themes/themes.html:62
+#: src/olympia/bandwagon/templates/bandwagon/edit.html:29 src/olympia/devhub/templates/devhub/addons/edit/details.html:20 src/olympia/editors/templates/editors/themes/themes.html:62
 msgid "Description"
 msgstr "Kuvaus"
 
@@ -3140,32 +2579,18 @@ msgstr "Kuvaus"
 msgid "Contributors & More"
 msgstr ""
 
-#: src/olympia/bandwagon/templates/bandwagon/edit.html:54
-#: src/olympia/bandwagon/templates/bandwagon/edit.html:67
-#: src/olympia/bandwagon/templates/bandwagon/edit.html:82
-#: src/olympia/devhub/templates/devhub/addons/ajax_compat_update.html:35
-#: src/olympia/devhub/templates/devhub/addons/owner.html:59
-#: src/olympia/devhub/templates/devhub/addons/profile.html:42
-#: src/olympia/devhub/templates/devhub/addons/edit/admin.html:101
-#: src/olympia/devhub/templates/devhub/addons/edit/basic.html:152
-#: src/olympia/devhub/templates/devhub/addons/edit/details.html:85
-#: src/olympia/devhub/templates/devhub/addons/edit/support.html:67
-#: src/olympia/devhub/templates/devhub/addons/edit/technical.html:166
-#: src/olympia/devhub/templates/devhub/addons/forms_shared/media.html:149
-#: src/olympia/devhub/templates/devhub/payments/voluntary.html:64
-#: src/olympia/devhub/templates/devhub/personas/edit.html:35
-#: src/olympia/devhub/templates/devhub/personas/edit.html:304
-#: src/olympia/devhub/templates/devhub/versions/edit.html:139
-#: src/olympia/translations/templates/translations/trans-menu.html:48
+#: src/olympia/bandwagon/templates/bandwagon/edit.html:54 src/olympia/bandwagon/templates/bandwagon/edit.html:67 src/olympia/bandwagon/templates/bandwagon/edit.html:82
+#: src/olympia/devhub/templates/devhub/addons/ajax_compat_update.html:35 src/olympia/devhub/templates/devhub/addons/owner.html:59 src/olympia/devhub/templates/devhub/addons/profile.html:42
+#: src/olympia/devhub/templates/devhub/addons/edit/admin.html:101 src/olympia/devhub/templates/devhub/addons/edit/basic.html:152 src/olympia/devhub/templates/devhub/addons/edit/details.html:85
+#: src/olympia/devhub/templates/devhub/addons/edit/support.html:67 src/olympia/devhub/templates/devhub/addons/edit/technical.html:166
+#: src/olympia/devhub/templates/devhub/addons/forms_shared/media.html:149 src/olympia/devhub/templates/devhub/payments/voluntary.html:64 src/olympia/devhub/templates/devhub/personas/edit.html:35
+#: src/olympia/devhub/templates/devhub/personas/edit.html:304 src/olympia/devhub/templates/devhub/versions/edit.html:139 src/olympia/translations/templates/translations/trans-menu.html:48
 msgid "Save Changes"
 msgstr "Tallenna muutokset"
 
 # <option> text in a <select> for Author role in an add-on.
-#: src/olympia/bandwagon/templates/bandwagon/edit_contributors.html:9
-#: src/olympia/bandwagon/templates/bandwagon/edit_contributors.html:12
-#: src/olympia/bandwagon/templates/bandwagon/edit_contributors.html:17
-#: src/olympia/bandwagon/templates/bandwagon/edit_contributors.html:58
-#: src/olympia/constants/base.py:134
+#: src/olympia/bandwagon/templates/bandwagon/edit_contributors.html:9 src/olympia/bandwagon/templates/bandwagon/edit_contributors.html:12
+#: src/olympia/bandwagon/templates/bandwagon/edit_contributors.html:17 src/olympia/bandwagon/templates/bandwagon/edit_contributors.html:58 src/olympia/constants/base.py:134
 msgid "Owner"
 msgstr ""
 
@@ -3177,10 +2602,8 @@ msgstr ""
 msgid "Remove this user as a contributor"
 msgstr ""
 
-#: src/olympia/bandwagon/templates/bandwagon/edit_contributors.html:18
-#: src/olympia/bandwagon/templates/bandwagon/edit_contributors.html:43
-#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:20
-#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:48
+#: src/olympia/bandwagon/templates/bandwagon/edit_contributors.html:18 src/olympia/bandwagon/templates/bandwagon/edit_contributors.html:43
+#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:18 src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:46
 #: src/olympia/devhub/templates/devhub/addons/ajax_compat_update.html:19
 msgid "Remove"
 msgstr "Poista"
@@ -3191,10 +2614,8 @@ msgstr ""
 
 #: src/olympia/bandwagon/templates/bandwagon/edit_contributors.html:26
 msgid ""
-"You can add multiple contributors to this collection.  A contributor can add"
-" and remove add-ons from this collection, but cannot change its name or "
-"description.  To add a contributor, enter their email in the box below. "
-"Contributors must have a Mozilla Add-ons account."
+"You can add multiple contributors to this collection.  A contributor can add and remove add-ons from this collection, but cannot change its name or description.  To add a contributor, enter their "
+"email in the box below. Contributors must have a Mozilla Add-ons account."
 msgstr ""
 
 # 80%
@@ -3202,9 +2623,7 @@ msgstr ""
 msgid "User"
 msgstr "Käyttäjä"
 
-#: src/olympia/bandwagon/templates/bandwagon/edit_contributors.html:41
-#: src/olympia/devhub/templates/devhub/addons/edit/support.html:20
-#: src/olympia/users/templates/users/delete.html:49
+#: src/olympia/bandwagon/templates/bandwagon/edit_contributors.html:41 src/olympia/devhub/templates/devhub/addons/edit/support.html:20 src/olympia/users/templates/users/delete.html:49
 msgid "Email"
 msgstr "Sähköposti"
 
@@ -3233,25 +2652,14 @@ msgid "Admin Settings"
 msgstr ""
 
 #: src/olympia/bandwagon/templates/bandwagon/edit_contributors.html:76
-msgid ""
-"<b>Warning:</b> By changing the owner of this collection, you will no longer"
-" be able to edit it. You will only be able to add and remove add-ons from "
-"it."
+msgid "<b>Warning:</b> By changing the owner of this collection, you will no longer be able to edit it. You will only be able to add and remove add-ons from it."
 msgstr ""
 
-#: src/olympia/bandwagon/templates/bandwagon/edit_contributors.html:83
-#: src/olympia/devhub/templates/devhub/addons/forms_shared/media.html:157
-#: src/olympia/devhub/templates/devhub/addons/submit/describe.html:69
-#: src/olympia/devhub/templates/devhub/addons/submit/license.html:60
-#: src/olympia/devhub/templates/devhub/addons/submit/upload.html:78
-#: src/olympia/devhub/templates/devhub/payments/tier.html:17
-#: src/olympia/editors/templates/editors/themes/themes.html:111
-#: src/olympia/editors/templates/editors/themes/themes.html:128
-#: src/olympia/editors/templates/editors/themes/themes.html:134
-#: src/olympia/editors/templates/editors/themes/themes.html:141
-#: src/olympia/users/templates/users/fxa_migration_prompt_content.html:10
-#: src/olympia/users/templates/users/login_form.html:42
-#: src/olympia/users/templates/users/mobile/login.html:57
+#: src/olympia/bandwagon/templates/bandwagon/edit_contributors.html:83 src/olympia/devhub/templates/devhub/addons/forms_shared/media.html:157
+#: src/olympia/devhub/templates/devhub/addons/submit/describe.html:69 src/olympia/devhub/templates/devhub/addons/submit/license.html:60 src/olympia/devhub/templates/devhub/addons/submit/upload.html:70
+#: src/olympia/devhub/templates/devhub/payments/tier.html:17 src/olympia/editors/templates/editors/themes/themes.html:111 src/olympia/editors/templates/editors/themes/themes.html:128
+#: src/olympia/editors/templates/editors/themes/themes.html:134 src/olympia/editors/templates/editors/themes/themes.html:141 src/olympia/users/templates/users/fxa_migration_prompt_content.html:10
+#: src/olympia/users/templates/users/login_form.html:42 src/olympia/users/templates/users/mobile/login.html:57
 msgid "Continue"
 msgstr "Jatka"
 
@@ -3290,19 +2698,11 @@ msgstr "Lähiaikojen suosituimmat kokoelmat"
 
 #: src/olympia/bandwagon/templates/bandwagon/impala/collection_listing.html:28
 #, python-format
-msgid ""
-"Collections are groups of related add-ons that anyone can create and share. "
-"Explore collections created by other users or <a href=\"%(url)s\">create "
-"your own</a>."
-msgstr ""
-"Kokoelmat ovat toisiinsa liittyvien lisäosien ryhmiä, joita kuka tahansa voi"
-" luoda ja jakaa. Selaa muiden käyttäjien luomia kokoelmia tai <a "
-"href=\"%(url)s\">luo oma</a> kokoelma."
+msgid "Collections are groups of related add-ons that anyone can create and share. Explore collections created by other users or <a href=\"%(url)s\">create your own</a>."
+msgstr "Kokoelmat ovat toisiinsa liittyvien lisäosien ryhmiä, joita kuka tahansa voi luoda ja jakaa. Selaa muiden käyttäjien luomia kokoelmia tai <a href=\"%(url)s\">luo oma</a> kokoelma."
 
 # 100%
-#: src/olympia/bandwagon/templates/bandwagon/impala/collection_listing.html:37
-#: src/olympia/browse/templates/browse/extensions.html:13
-#: src/olympia/browse/templates/browse/themes.html:14
+#: src/olympia/bandwagon/templates/bandwagon/impala/collection_listing.html:37 src/olympia/browse/templates/browse/extensions.html:13 src/olympia/browse/templates/browse/themes.html:14
 msgid "Subscribe"
 msgstr "Tilaa"
 
@@ -3312,20 +2712,14 @@ msgstr "Seurataan"
 
 # 89%
 # 100%
-#: src/olympia/bandwagon/templates/bandwagon/impala/collection_sidebar.html:22
-#: src/olympia/bandwagon/templates/bandwagon/impala/collection_sidebar.html:28
+#: src/olympia/bandwagon/templates/bandwagon/impala/collection_sidebar.html:22 src/olympia/bandwagon/templates/bandwagon/impala/collection_sidebar.html:28
 #: src/olympia/bandwagon/templates/bandwagon/includes/collection_sidebar.html:32
 msgid "Create a Collection"
 msgstr "Luo kokoelma"
 
-#: src/olympia/bandwagon/templates/bandwagon/impala/collection_sidebar.html:23
-#: src/olympia/bandwagon/templates/bandwagon/includes/collection_sidebar.html:27
-msgid ""
-"Collections make it easy to keep track of favorite add-ons and share your "
-"perfectly customized browser with others."
-msgstr ""
-"Kokoelmien avulla on helppo seurata suosituimpia lisäosia ja jakaa "
-"täydellisesti mukautettu selaimesi muiden kanssa."
+#: src/olympia/bandwagon/templates/bandwagon/impala/collection_sidebar.html:23 src/olympia/bandwagon/templates/bandwagon/includes/collection_sidebar.html:27
+msgid "Collections make it easy to keep track of favorite add-ons and share your perfectly customized browser with others."
+msgstr "Kokoelmien avulla on helppo seurata suosituimpia lisäosia ja jakaa täydellisesti mukautettu selaimesi muiden kanssa."
 
 #: src/olympia/bandwagon/templates/bandwagon/includes/addedit.html:42
 msgid "Collection Icon"
@@ -3336,53 +2730,45 @@ msgid "Reset"
 msgstr "Nollaa"
 
 #: src/olympia/bandwagon/templates/bandwagon/includes/addedit.html:53
-msgid "PNG and JPG supported. Image will be resized to 32x32."
-msgstr "PNG- ja JPG-kuvia tuetaan. Kuvan kooksi muutetaan 32x32."
+msgid "PNG and JPG supported.  Image will be resized to 32x32."
+msgstr ""
 
 #: src/olympia/bandwagon/templates/bandwagon/includes/addedit_errors.html:3
-msgid "There are errors in this form. Please correct them below."
-msgstr "Lomakkeessa on virheitä. Korjaa ne alla."
+msgid "There are errors in this form.  Please correct them below."
+msgstr ""
 
 #: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:2
 msgid "Add-ons in Your Collection"
 msgstr "Kokoelmasi lisäosat"
 
 #: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:4
-msgid ""
-"To include an add-on in this collection, enter its name in the box below and"
-" hit enter. You can also use the <strong>Add to Collection</strong> links "
-"throughout the site to include add-ons later."
+msgid "To include an add-on in this collection, enter its name in the box below and hit enter."
 msgstr ""
-"Lisätäksesi lisäosan tähän kokoelmaan, anna sen nimi alla olevaan laatikkoon"
-" ja paina Enter. Voit käyttää myös <strong>Lisää kokoelmaan</strong> "
-"-linkkejä muilla sivuilla lisätäksesi lisäosia myöhemmin."
 
 # 85%
 # 100%
-#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:17
-#: src/olympia/constants/base.py:400
-#: src/olympia/devhub/templates/devhub/addons/activity.html:62
+#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:15 src/olympia/constants/base.py:400 src/olympia/devhub/templates/devhub/addons/activity.html:62
+#: src/olympia/editors/helpers.py:273 src/olympia/editors/helpers.py:360
 msgid "Add-on"
 msgstr "Lisäosa"
 
-#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:26
+#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:24
 msgid "Enter the name of the add-on to include"
 msgstr "Anna lisättävän lisäosan nimi"
 
-#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:28
+#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:26
 msgid "Add to Collection"
 msgstr "Lisää kokoelmaan"
 
-#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:45
-#: src/olympia/editors/helpers.py:936 src/olympia/editors/helpers.py:956
+#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:43 src/olympia/editors/helpers.py:1016 src/olympia/editors/helpers.py:1036
 msgid "Pending"
 msgstr "Odottaa"
 
-#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:47
+#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:45
 msgid "Add a comment"
 msgstr "Lisää kommentti"
 
-#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:48
+#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:46
 msgid "Remove this add-on from the collection"
 msgstr "Poista lisäosa kokoelmasta"
 
@@ -3394,14 +2780,11 @@ msgstr "KOKOELMAT"
 msgid "Groups of related add-ons that anyone can create."
 msgstr ""
 
-#: src/olympia/blocklist/templates/blocklist/blocked_detail.html:3
-#: src/olympia/blocklist/templates/blocklist/blocked_list.html:3
-#: src/olympia/blocklist/templates/blocklist/blocked_list.html:10
+#: src/olympia/blocklist/templates/blocklist/blocked_detail.html:3 src/olympia/blocklist/templates/blocklist/blocked_list.html:3 src/olympia/blocklist/templates/blocklist/blocked_list.html:10
 msgid "Blocked Add-ons"
 msgstr ""
 
-#: src/olympia/blocklist/templates/blocklist/blocked_detail.html:8
-#: src/olympia/blocklist/templates/blocklist/blocked_list.html:6
+#: src/olympia/blocklist/templates/blocklist/blocked_detail.html:8 src/olympia/blocklist/templates/blocklist/blocked_list.html:6
 msgid "Blocklist"
 msgstr ""
 
@@ -3423,25 +2806,18 @@ msgid "What does this mean?"
 msgstr "Mitä tämä tarkoittaa?"
 
 #: src/olympia/blocklist/templates/blocklist/blocked_detail.html:22
-msgid ""
-"Users are strongly encouraged to disable the problematic add-on or plugin, "
-"but may choose to continue using it if they accept the risks described."
+msgid "Users are strongly encouraged to disable the problematic add-on or plugin, but may choose to continue using it if they accept the risks described."
 msgstr ""
 
 #: src/olympia/blocklist/templates/blocklist/blocked_detail.html:27
-msgid ""
-"The problematic add-on or plugin will be automatically disabled and no "
-"longer usable."
+msgid "The problematic add-on or plugin will be automatically disabled and no longer usable."
 msgstr ""
 
 #: src/olympia/blocklist/templates/blocklist/blocked_detail.html:33
 #, python-format
 msgid ""
-"When Mozilla becomes aware of add-ons, plugins, or other third-party "
-"software that seriously compromises %(app)s security, stability, or "
-"performance and meets <a href=\"%(criteria)s\">certain criteria</a>, the "
-"software may be blocked from general use.  For more information, please read"
-" <a href=\"%(support)s\">this support article</a>."
+"When Mozilla becomes aware of add-ons, plugins, or other third-party software that seriously compromises %(app)s security, stability, or performance and meets <a href=\"%(criteria)s\">certain "
+"criteria</a>, the software may be blocked from general use.  For more information, please read <a href=\"%(support)s\">this support article</a>."
 msgstr ""
 
 #: src/olympia/blocklist/templates/blocklist/blocked_detail.html:44
@@ -3455,9 +2831,7 @@ msgid "Blocked on %(date)s."
 msgstr ""
 
 #: src/olympia/blocklist/templates/blocklist/blocked_list.html:11
-msgid ""
-"The following software is known to cause serious security, stability, or "
-"performance issues with {app}."
+msgid "The following software is known to cause serious security, stability, or performance issues with {app}."
 msgstr ""
 
 #. L10n: %s is a category name.
@@ -3480,8 +2854,7 @@ msgstr "Suositellut lisäosat :: %s"
 #. L10n: %s is an app name.
 #: src/olympia/browse/feeds.py:138
 #, python-format
-msgid ""
-"Here's a few of our favorite add-ons to help you get started customizing %s."
+msgid "Here's a few of our favorite add-ons to help you get started customizing %s."
 msgstr ""
 
 #. L10n: %s is a category name.
@@ -3500,46 +2873,31 @@ msgstr "Hakutyökalut ja hakemiseen liittyvät laajennukset"
 msgid "Search tools"
 msgstr "Hakutyökalut"
 
-#: src/olympia/browse/views.py:55 src/olympia/browse/views.py:65
-#: src/olympia/search/forms.py:85
+#: src/olympia/browse/views.py:55 src/olympia/browse/views.py:65 src/olympia/search/forms.py:85
 msgid "Most Users"
 msgstr "Eniten käyttäjiä"
 
-#: src/olympia/browse/views.py:61 src/olympia/browse/views.py:72
-#: src/olympia/browse/views.py:279
-#: src/olympia/browse/templates/browse/personas/mobile/category_landing.html:63
-#: src/olympia/discovery/templates/discovery/pane.html:67
-#: src/olympia/search/forms.py:92
+#: src/olympia/browse/views.py:61 src/olympia/browse/views.py:72 src/olympia/browse/views.py:246 src/olympia/browse/templates/browse/personas/mobile/category_landing.html:63
+#: src/olympia/discovery/templates/discovery/pane.html:67 src/olympia/search/forms.py:92
 msgid "Up & Coming"
 msgstr "Lupaavat"
 
-#: src/olympia/browse/views.py:460 src/olympia/devhub/views.py:76
-#: src/olympia/devhub/views.py:83
-#: src/olympia/discovery/templates/discovery/addons/detail.html:66
+#: src/olympia/browse/views.py:427 src/olympia/devhub/views.py:74 src/olympia/devhub/views.py:81 src/olympia/discovery/templates/discovery/addons/detail.html:66
 msgid "Created"
 msgstr "Luotu"
 
-#. {0} is the category name. Ex: Sports
 # 76%
 # 100%
-#: src/olympia/browse/templates/browse/creatured.html:5
-#: src/olympia/browse/templates/browse/creatured.html:13
+#. {0} is the category name. Ex: Sports
+#: src/olympia/browse/templates/browse/creatured.html:5 src/olympia/browse/templates/browse/creatured.html:13
 #, fuzzy
 msgid "{0}: Featured Add-ons"
 msgstr "Suositellut lisäosat"
 
-#: src/olympia/browse/templates/browse/creatured.html:12
-#: src/olympia/browse/templates/browse/featured.html:4
-#: src/olympia/browse/templates/browse/featured.html:12
-#: src/olympia/browse/templates/browse/featured.html:13
-#: src/olympia/devhub/templates/devhub/docs/policies-recommended.html:3
-#: src/olympia/devhub/templates/devhub/docs/policies-recommended.html:7
-#: src/olympia/devhub/templates/devhub/docs/policies-recommended.html:9
-#: src/olympia/devhub/templates/devhub/docs/policies.html:21
-#: src/olympia/devhub/templates/devhub/docs/policies.html:90
-#: src/olympia/discovery/modules.py:341
-#: src/olympia/discovery/templates/discovery/pane.html:52
-#: src/olympia/templates/menu_links.html:7
+#: src/olympia/browse/templates/browse/creatured.html:12 src/olympia/browse/templates/browse/featured.html:4 src/olympia/browse/templates/browse/featured.html:12
+#: src/olympia/browse/templates/browse/featured.html:13 src/olympia/devhub/templates/devhub/docs/policies-recommended.html:3 src/olympia/devhub/templates/devhub/docs/policies-recommended.html:7
+#: src/olympia/devhub/templates/devhub/docs/policies-recommended.html:9 src/olympia/devhub/templates/devhub/docs/policies.html:21 src/olympia/devhub/templates/devhub/docs/policies.html:90
+#: src/olympia/discovery/modules.py:341 src/olympia/discovery/templates/discovery/pane.html:52 src/olympia/templates/menu_links.html:7
 msgid "Featured Add-ons"
 msgstr "Suositellut lisäosat"
 
@@ -3550,9 +2908,7 @@ msgstr ""
 
 #: src/olympia/browse/templates/browse/featured.html:15
 #, python-format
-msgid ""
-"Here's a few of our favorite add-ons to help you get started customizing "
-"%(app)s."
+msgid "Here's a few of our favorite add-ons to help you get started customizing %(app)s."
 msgstr ""
 
 #: src/olympia/browse/templates/browse/language_tools.html:9
@@ -3577,23 +2933,18 @@ msgstr "Saatavilla kielelläsi"
 
 #: src/olympia/browse/templates/browse/language_tools.html:38
 msgid "List of language packs and dictionaries available in your locale."
-msgstr ""
-"Lista saatavilla olevista kielipaketeista ja oikolukusanastoista kielelläsi."
+msgstr "Lista saatavilla olevista kielipaketeista ja oikolukusanastoista kielelläsi."
 
-#: src/olympia/browse/templates/browse/language_tools.html:41
-#: src/olympia/browse/templates/browse/language_tools.html:63
+#: src/olympia/browse/templates/browse/language_tools.html:41 src/olympia/browse/templates/browse/language_tools.html:63
 msgid "Language"
 msgstr "Kieli"
 
 # Plural in this context means many of the add-on type
-#: src/olympia/browse/templates/browse/language_tools.html:42
-#: src/olympia/browse/templates/browse/language_tools.html:64
-#: src/olympia/constants/base.py:162
+#: src/olympia/browse/templates/browse/language_tools.html:42 src/olympia/browse/templates/browse/language_tools.html:64 src/olympia/constants/base.py:162
 msgid "Dictionary"
 msgstr "Oikolukusanasto"
 
-#: src/olympia/browse/templates/browse/language_tools.html:43
-#: src/olympia/browse/templates/browse/language_tools.html:65
+#: src/olympia/browse/templates/browse/language_tools.html:43 src/olympia/browse/templates/browse/language_tools.html:65
 msgid "Language Pack"
 msgstr "Kielipaketti"
 
@@ -3611,8 +2962,7 @@ msgid "{0} :: Search Tools"
 msgstr "{0} :: Hakutyökalut"
 
 #. {0} is an integer.
-#: src/olympia/browse/templates/browse/search_tools.html:39
-#: src/olympia/devhub/templates/devhub/addons/dashboard.html:17
+#: src/olympia/browse/templates/browse/search_tools.html:39 src/olympia/devhub/templates/devhub/addons/dashboard.html:17
 msgid "<b>{0}</b> add-on"
 msgid_plural "<b>{0}</b> add-ons"
 msgstr[0] "<b>{0}</b> lisäosa"
@@ -3640,31 +2990,18 @@ msgstr "Lisäresursseja"
 
 #. {0} is an app name, like Firefox.
 #: src/olympia/browse/templates/browse/search_tools.html:93
-msgid ""
-"Learn more about the <a "
-"href=\"http://support.mozilla.com/kb/Search+bar\">search bar</a> in {0}"
-msgstr ""
-"Lue lisää {0}-<a "
-"href=\"http://support.mozilla.com/kb/Search+bar\">hakupalkista</a>"
+msgid "Learn more about the <a href=\"http://support.mozilla.com/kb/Search+bar\">search bar</a> in {0}"
+msgstr "Lue lisää {0}-<a href=\"http://support.mozilla.com/kb/Search+bar\">hakupalkista</a>"
 
 #: src/olympia/browse/templates/browse/search_tools.html:94
-msgid ""
-"Browse through even more search providers at <a "
-"href=\"http://mycroft.mozdev.org/\">mycroft.mozdev.org</a>"
-msgstr ""
-"Löydä vieläkin enemmän hakupalveluntarjoajia osoitteessa <a "
-"href=\"http://mycroft.mozdev.org/\">mycroft.mozdev.org</a>"
+msgid "Browse through even more search providers at <a href=\"http://mycroft.mozdev.org/\">mycroft.mozdev.org</a>"
+msgstr "Löydä vieläkin enemmän hakupalveluntarjoajia osoitteessa <a href=\"http://mycroft.mozdev.org/\">mycroft.mozdev.org</a>"
 
 #: src/olympia/browse/templates/browse/search_tools.html:95
-msgid ""
-"<a "
-"href=\"https://developer.mozilla.org/en/Creating_OpenSearch_plugins_for_Firefox\">Make"
-" your own</a> search tool"
+msgid "<a href=\"https://developer.mozilla.org/en/Creating_OpenSearch_plugins_for_Firefox\">Make your own</a> search tool"
 msgstr ""
 
-#: src/olympia/browse/templates/browse/themes.html:6
-#: src/olympia/browse/templates/browse/themes.html:9
-#: src/olympia/constants/base.py:174
+#: src/olympia/browse/templates/browse/themes.html:6 src/olympia/browse/templates/browse/themes.html:9 src/olympia/constants/base.py:174
 msgid "Complete Themes"
 msgstr "Täydelliset teemat"
 
@@ -3737,24 +3074,17 @@ msgid_plural "See all %(cnt)s extensions in %(name)s &raquo;"
 msgstr[0] "Näytä %(cnt)s lisäosa luokassa %(name)s &raquo;"
 msgstr[1] "Näytä kaikki %(cnt)s lisäosaa luokassa %(name)s &raquo;"
 
-#: src/olympia/browse/templates/browse/mobile/extensions.html:13
-#: src/olympia/compat/templates/compat/index.html:82
-#: src/olympia/devhub/templates/devhub/devhub_search.html:24
-#: src/olympia/devhub/templates/devhub/addons/activity.html:47
-#: src/olympia/search/templates/search/no_results.html:4
-#: src/olympia/search/templates/search/mobile/results.html:36
+#: src/olympia/browse/templates/browse/mobile/extensions.html:13 src/olympia/devhub/templates/devhub/devhub_search.html:24 src/olympia/devhub/templates/devhub/addons/activity.html:47
+#: src/olympia/search/templates/search/no_results.html:4 src/olympia/search/templates/search/mobile/results.html:36
 msgid "No results found."
 msgstr "Osumia ei löytynyt."
 
-#: src/olympia/browse/templates/browse/personas/base.html:6
-#: src/olympia/browse/templates/browse/personas/mobile/base.html:7
+#: src/olympia/browse/templates/browse/personas/base.html:6 src/olympia/browse/templates/browse/personas/mobile/base.html:7
 msgid "{0} Themes"
 msgstr ""
 
 #. {0} is a user's name.
-#: src/olympia/browse/templates/browse/personas/base.html:15
-#: src/olympia/browse/templates/browse/personas/base.html:40
-#: src/olympia/browse/templates/browse/personas/grid.html:8
+#: src/olympia/browse/templates/browse/personas/base.html:15 src/olympia/browse/templates/browse/personas/base.html:40 src/olympia/browse/templates/browse/personas/grid.html:8
 msgid "{0}'s Themes"
 msgstr ""
 
@@ -3774,27 +3104,21 @@ msgstr ""
 msgid "Learn more"
 msgstr "Lue lisää"
 
-#: src/olympia/browse/templates/browse/personas/category_landing.html:6
-#: src/olympia/browse/templates/browse/personas/mobile/category_landing.html:5
+#: src/olympia/browse/templates/browse/personas/category_landing.html:6 src/olympia/browse/templates/browse/personas/mobile/category_landing.html:5
 msgid "View All Recently Added"
 msgstr "Näytä kaikki äskettäin lisätyt"
 
-#: src/olympia/browse/templates/browse/personas/category_landing.html:7
-#: src/olympia/browse/templates/browse/personas/mobile/category_landing.html:6
+#: src/olympia/browse/templates/browse/personas/category_landing.html:7 src/olympia/browse/templates/browse/personas/mobile/category_landing.html:6
 msgid "View All Most Popular"
 msgstr "Näytä kaikki suosituimmat"
 
-#: src/olympia/browse/templates/browse/personas/category_landing.html:8
-#: src/olympia/browse/templates/browse/personas/mobile/category_landing.html:7
+#: src/olympia/browse/templates/browse/personas/category_landing.html:8 src/olympia/browse/templates/browse/personas/mobile/category_landing.html:7
 msgid "View All Top Rated"
 msgstr "Näytä kaikki parhaiten arvioidut"
 
 #: src/olympia/browse/templates/browse/personas/category_landing.html:40
 #, python-format
-msgid ""
-"Over 300,000 designs to personalize your browser! Move your mouse over a "
-"Background Theme to try it on. <a href=\"%(url)s\" class=\"more-info\">Start"
-" exploring</a>"
+msgid "Over 300,000 designs to personalize your browser! Move your mouse over a Background Theme to try it on. <a href=\"%(url)s\" class=\"more-info\">Start exploring</a>"
 msgstr ""
 
 #: src/olympia/browse/templates/browse/personas/category_landing.html:47
@@ -3805,10 +3129,7 @@ msgstr ""
 #. theme.
 #: src/olympia/browse/templates/browse/personas/category_landing.html:50
 #, python-format
-msgid ""
-"Complete Themes transform the look of your browser with styles for the "
-"window frame, address bar, buttons, tabs, and menus. <a href=\"%(url)s\" "
-"class=\"more-info\">Start exploring</a>"
+msgid "Complete Themes transform the look of your browser with styles for the window frame, address bar, buttons, tabs, and menus. <a href=\"%(url)s\" class=\"more-info\">Start exploring</a>"
 msgstr ""
 
 #: src/olympia/browse/templates/browse/personas/category_landing.html:76
@@ -3839,7 +3160,7 @@ msgstr ""
 msgid "All"
 msgstr "Kaikki"
 
-#: src/olympia/compat/forms.py:22 src/olympia/search/views.py:525
+#: src/olympia/compat/forms.py:22 src/olympia/editors/templates/editors/base.html:69 src/olympia/search/views.py:518
 msgid "All Add-ons"
 msgstr "Kaikki lisäosat"
 
@@ -3851,72 +3172,17 @@ msgstr ""
 msgid "Non-binary"
 msgstr ""
 
-#. Review points sources other than add-ons and themes.
-#: src/olympia/compat/views.py:87 src/olympia/constants/base.py:388
-#: src/olympia/devhub/forms.py:162
-#: src/olympia/editors/templates/editors/performance.html:75
-msgid "Other"
-msgstr ""
-
-#: src/olympia/compat/templates/compat/index.html:4
-msgid "Add-on Compatibility Report for {app} {version}"
-msgstr ""
-
-#: src/olympia/compat/templates/compat/index.html:11
-msgid "{app} {version} Compatibility"
-msgstr ""
-
-#: src/olympia/compat/templates/compat/index.html:17
-#, python-format
-msgid "Top 95%% compatible with previous version"
-msgstr ""
-
-#: src/olympia/compat/templates/compat/index.html:18
-#, python-format
-msgid "Top 95%% of all add-ons"
-msgstr ""
-
-#: src/olympia/compat/templates/compat/index.html:19
-msgid "All active add-ons"
-msgstr ""
-
-# 75%
-#: src/olympia/compat/templates/compat/index.html:23
-#: src/olympia/constants/base.py:401
-#, fuzzy
-msgid "App"
-msgstr "Sovellukset"
-
-#: src/olympia/compat/templates/compat/index.html:55
-msgid "Details for add-ons compatible with previous version:"
-msgstr ""
-
-#: src/olympia/compat/templates/compat/index.html:57
-msgid "Show all versions"
-msgstr ""
-
-#: src/olympia/compat/templates/compat/index.html:59
-msgid "Details for add-ons compatible with all versions:"
-msgstr ""
-
-#: src/olympia/compat/templates/compat/index.html:61
-msgid "Show previous version only"
-msgstr ""
-
 # 75%
 #: src/olympia/compat/templates/compat/reporter.html:3
 #, fuzzy
 msgid "Add-on Compatibility Reports"
 msgstr "Lisäosan yhteensopivuuden tarkistus"
 
-#: src/olympia/compat/templates/compat/reporter.html:11
-#: src/olympia/compat/templates/compat/reporter_detail.html:35
+#: src/olympia/compat/templates/compat/reporter.html:11 src/olympia/compat/templates/compat/reporter_detail.html:35
 #, python-format
 msgid ""
-"<p> Reports submitted to us through the <a href=\"%(url_)s\">Add-on "
-"Compatibility Reporter</a> are collected here for developers to view. These "
-"reports help us determine which add-ons will need help supporting an "
-"upcoming Firefox version. </p>"
+"<p> Reports submitted to us through the <a href=\"%(url_)s\">Add-on Compatibility Reporter</a> are collected here for developers to view. These reports help us determine which add-ons will need "
+"help supporting an upcoming Firefox version. </p>"
 msgstr ""
 
 #: src/olympia/compat/templates/compat/reporter.html:18
@@ -3924,8 +3190,7 @@ msgid "Reports for your Add-ons"
 msgstr ""
 
 # 89%
-#: src/olympia/compat/templates/compat/reporter.html:30
-#: src/olympia/compat/templates/compat/reporter_detail.html:9
+#: src/olympia/compat/templates/compat/reporter.html:30 src/olympia/compat/templates/compat/reporter_detail.html:9
 #, fuzzy
 msgid "Add-on Compatibility Center"
 msgstr "Lisäosan yhteensopivuuden tarkistus"
@@ -3934,9 +3199,7 @@ msgstr "Lisäosan yhteensopivuuden tarkistus"
 msgid "Enter the GUID of an add-on below to view any reports we've received."
 msgstr ""
 
-#: src/olympia/compat/templates/compat/reporter_detail.html:3
-#: src/olympia/compat/templates/compat/reporter_detail.html:10
-#: src/olympia/compat/templates/compat/reporter_detail.html:25
+#: src/olympia/compat/templates/compat/reporter_detail.html:3 src/olympia/compat/templates/compat/reporter_detail.html:10 src/olympia/compat/templates/compat/reporter_detail.html:25
 msgid "{addon} Compatibility Reports"
 msgstr ""
 
@@ -3952,8 +3215,7 @@ msgid_plural "{0} problem reports"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/olympia/compat/templates/compat/reporter_detail.html:21
-#: src/olympia/users/templates/users/profile.html:70
+#: src/olympia/compat/templates/compat/reporter_detail.html:21 src/olympia/users/templates/users/profile.html:70
 msgid "View all"
 msgstr ""
 
@@ -3967,10 +3229,8 @@ msgstr ""
 
 # 84%
 # 100%
-#: src/olympia/compat/templates/compat/reporter_detail.html:47
-#: src/olympia/devhub/forms.py:784
-#: src/olympia/devhub/templates/devhub/addons/ajax_compat_update.html:17
-#: src/olympia/editors/forms.py:108 src/olympia/zadmin/forms.py:45
+#: src/olympia/compat/templates/compat/reporter_detail.html:47 src/olympia/devhub/forms.py:785 src/olympia/devhub/templates/devhub/addons/ajax_compat_update.html:17 src/olympia/editors/forms.py:108
+#: src/olympia/editors/forms.py:248 src/olympia/zadmin/forms.py:45
 #, fuzzy
 msgid "Application"
 msgstr "Ohjelmat:"
@@ -3985,8 +3245,7 @@ msgstr ""
 msgid "Platform"
 msgstr "Alusta"
 
-#: src/olympia/compat/templates/compat/reporter_detail.html:50
-#: src/olympia/editors/templates/editors/themes/themes.html:40
+#: src/olympia/compat/templates/compat/reporter_detail.html:50 src/olympia/editors/templates/editors/themes/themes.html:40
 msgid "Submitted"
 msgstr ""
 
@@ -4018,8 +3277,7 @@ msgstr "Thunderbird"
 msgid "SeaMonkey"
 msgstr "SeaMonkey"
 
-#: src/olympia/constants/applications.py:75
-#: src/olympia/pages/templates/pages/sunbird.html:4
+#: src/olympia/constants/applications.py:75 src/olympia/pages/templates/pages/sunbird.html:4
 msgid "Sunbird"
 msgstr "Sunbird"
 
@@ -4068,7 +3326,7 @@ msgid "Preliminarily Reviewed and Awaiting Full Review"
 msgstr ""
 
 # 85%
-#: src/olympia/constants/base.py:33 src/olympia/editors/helpers.py:924
+#: src/olympia/constants/base.py:33 src/olympia/editors/forms.py:258 src/olympia/editors/helpers.py:73 src/olympia/editors/helpers.py:1004
 #: src/olympia/editors/templates/editors/themes/history_table.html:34
 #, fuzzy
 msgid "Deleted"
@@ -4105,13 +3363,11 @@ msgstr "Kehitys"
 msgid "Viewer"
 msgstr ""
 
-#: src/olympia/constants/base.py:137
-#: src/olympia/templates/mobile/header.html:7
+#: src/olympia/constants/base.py:137 src/olympia/templates/mobile/header.html:7
 msgid "Support"
 msgstr "Tuki"
 
-#: src/olympia/constants/base.py:159 src/olympia/constants/base.py:172
-#: src/olympia/constants/platforms.py:10
+#: src/olympia/constants/base.py:159 src/olympia/constants/base.py:172 src/olympia/constants/platforms.py:10
 msgid "Any"
 msgstr "Mikä tahansa"
 
@@ -4141,11 +3397,8 @@ msgstr "Liitännäinen"
 
 # 83%
 # 100%
-#: src/olympia/constants/base.py:167
-#: src/olympia/editors/templates/editors/includes/search_results_themes.html:5
-#: src/olympia/editors/templates/editors/themes/deleted.html:18
-#: src/olympia/editors/templates/editors/themes/history_table.html:8
-#: src/olympia/editors/templates/editors/themes/logs.html:17
+#: src/olympia/constants/base.py:167 src/olympia/editors/templates/editors/includes/search_results_themes.html:5 src/olympia/editors/templates/editors/themes/deleted.html:18
+#: src/olympia/editors/templates/editors/themes/history_table.html:8 src/olympia/editors/templates/editors/themes/logs.html:17
 msgid "Theme"
 msgstr "Teema"
 
@@ -4179,6 +3432,11 @@ msgstr ""
 msgid "Ask before users can download this add-on"
 msgstr ""
 
+#. Review points sources other than add-ons and themes.
+#: src/olympia/constants/base.py:388 src/olympia/devhub/forms.py:162 src/olympia/editors/templates/editors/performance.html:75
+msgid "Other"
+msgstr ""
+
 #: src/olympia/constants/base.py:389
 msgid "Exception"
 msgstr ""
@@ -4190,6 +3448,12 @@ msgstr ""
 #: src/olympia/constants/base.py:391
 msgid "Change"
 msgstr ""
+
+# 75%
+#: src/olympia/constants/base.py:401
+#, fuzzy
+msgid "App"
+msgstr "Sovellukset"
 
 # 87%
 # 100%
@@ -4329,32 +3593,23 @@ msgstr ""
 msgid "Signed of a preliminary review"
 msgstr ""
 
-#: src/olympia/constants/editors.py:14
-#: src/olympia/editors/templates/editors/themes/queue.html:76
-#: src/olympia/editors/templates/editors/themes/themes.html:87
+#: src/olympia/constants/editors.py:14 src/olympia/editors/templates/editors/themes/queue.html:76 src/olympia/editors/templates/editors/themes/themes.html:87
 msgid "Request More Info"
 msgstr ""
 
-#: src/olympia/constants/editors.py:15
-#: src/olympia/editors/templates/editors/themes/queue.html:74
-#: src/olympia/editors/templates/editors/themes/themes.html:91
+#: src/olympia/constants/editors.py:15 src/olympia/editors/templates/editors/themes/queue.html:74 src/olympia/editors/templates/editors/themes/themes.html:91
 msgid "Flag"
 msgstr ""
 
-#: src/olympia/constants/editors.py:16
-#: src/olympia/editors/templates/editors/themes/queue.html:72
-#: src/olympia/editors/templates/editors/themes/themes.html:93
+#: src/olympia/constants/editors.py:16 src/olympia/editors/templates/editors/themes/queue.html:72 src/olympia/editors/templates/editors/themes/themes.html:93
 msgid "Duplicate"
 msgstr ""
 
-#: src/olympia/constants/editors.py:17 src/olympia/editors/helpers.py:502
-#: src/olympia/editors/templates/editors/themes/queue.html:71
-#: src/olympia/editors/templates/editors/themes/themes.html:94
+#: src/olympia/constants/editors.py:17 src/olympia/editors/helpers.py:575 src/olympia/editors/templates/editors/themes/queue.html:71 src/olympia/editors/templates/editors/themes/themes.html:94
 msgid "Reject"
 msgstr ""
 
-#: src/olympia/constants/editors.py:18
-#: src/olympia/editors/templates/editors/themes/queue.html:70
+#: src/olympia/constants/editors.py:18 src/olympia/editors/templates/editors/themes/queue.html:70
 msgid "Approve"
 msgstr ""
 
@@ -4450,7 +3705,7 @@ msgstr "Solaris"
 msgid "Android"
 msgstr "Android"
 
-#: src/olympia/core/apps.py:19
+#: src/olympia/core/apps.py:21
 msgid "Core"
 msgstr ""
 
@@ -4487,9 +3742,7 @@ msgstr ""
 msgid "Message not eligible for annotation"
 msgstr ""
 
-#: src/olympia/devhub/forms.py:124
-#: src/olympia/devhub/templates/devhub/versions/edit.html:94
-#: src/olympia/users/templates/users/edit.html:150
+#: src/olympia/devhub/forms.py:124 src/olympia/devhub/templates/devhub/versions/edit.html:94 src/olympia/users/templates/users/edit.html:150
 msgid "Details"
 msgstr ""
 
@@ -4586,13 +3839,11 @@ msgid "Submit my add-on for manual review."
 msgstr ""
 
 #: src/olympia/devhub/forms.py:537
-msgid "Do not list my add-on on this site (beta)"
+msgid "Do not list my add-on on this site"
 msgstr ""
 
 #: src/olympia/devhub/forms.py:538
-msgid ""
-"Check this option if you intend to distribute your add-on on your own and "
-"only need it to be signed by Mozilla."
+msgid "Check this option if you intend to distribute your add-on on your own and only need it to be signed by Mozilla."
 msgstr ""
 
 #: src/olympia/devhub/forms.py:544
@@ -4600,20 +3851,14 @@ msgid "This add-on will be bundled with an application installer."
 msgstr ""
 
 #: src/olympia/devhub/forms.py:546
-msgid ""
-"Add-ons that are bundled with application installers will be code reviewed "
-"by Mozilla before they are signed and are held to a higher quality standard."
+msgid "Add-ons that are bundled with application installers will be code reviewed by Mozilla before they are signed and are held to a higher quality standard."
 msgstr ""
 
-#: src/olympia/devhub/forms.py:565
-#: src/olympia/devhub/templates/devhub/addons/submit/select-review.html:24
-#: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:42
+#: src/olympia/devhub/forms.py:565 src/olympia/devhub/templates/devhub/addons/submit/select-review.html:24 src/olympia/devhub/templates/devhub/docs/policies-reviews.html:42
 msgid "Full Review"
 msgstr ""
 
-#: src/olympia/devhub/forms.py:566
-#: src/olympia/devhub/templates/devhub/addons/submit/select-review.html:47
-#: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:153
+#: src/olympia/devhub/forms.py:566 src/olympia/devhub/templates/devhub/addons/submit/select-review.html:47 src/olympia/devhub/templates/devhub/docs/policies-reviews.html:153
 msgid "Preliminary Review"
 msgstr ""
 
@@ -4622,59 +3867,51 @@ msgid "Please choose a review nomination type"
 msgstr ""
 
 #: src/olympia/devhub/forms.py:574
-msgid ""
-"A file with a version ending with a|alpha|b|beta|pre|rc and an optional "
-"number is detected as beta."
+msgid "A file with a version ending with a|alpha|b|beta|pre|rc and an optional number is detected as beta."
 msgstr ""
 
 #: src/olympia/devhub/forms.py:592
 #, python-format
-msgid "Version %s already exists"
+msgid "Version %s already exists, or was uploaded before."
 msgstr ""
 
-#: src/olympia/devhub/forms.py:604
-msgid ""
-"Select a valid choice. That choice is not one of the available choices."
+#: src/olympia/devhub/forms.py:605
+msgid "Select a valid choice. That choice is not one of the available choices."
 msgstr ""
 
-#: src/olympia/devhub/forms.py:610
-msgid ""
-"A file with a version ending with a|alpha|b|beta and an optional number is "
-"detected as beta."
+#: src/olympia/devhub/forms.py:611
+msgid "A file with a version ending with a|alpha|b|beta and an optional number is detected as beta."
 msgstr ""
 
-#: src/olympia/devhub/forms.py:633
+#: src/olympia/devhub/forms.py:634
 msgid "You cannot upload any more files for this version."
 msgstr ""
 
-#: src/olympia/devhub/forms.py:639
+#: src/olympia/devhub/forms.py:640
 msgid "Version doesn't match"
 msgstr ""
 
-#: src/olympia/devhub/forms.py:668
-msgid ""
-"You cannot delete a file once the review process has started.  You must "
-"delete the whole version."
+#: src/olympia/devhub/forms.py:669
+msgid "You cannot delete a file once the review process has started.  You must delete the whole version."
 msgstr ""
 
-#: src/olympia/devhub/forms.py:688
+#: src/olympia/devhub/forms.py:689
 msgid "The platform All cannot be combined with specific platforms."
 msgstr ""
 
-#: src/olympia/devhub/forms.py:693
+#: src/olympia/devhub/forms.py:694
 msgid "A platform can only be chosen once."
 msgstr ""
 
-#: src/olympia/devhub/forms.py:706
+#: src/olympia/devhub/forms.py:707
 msgid "A review type must be selected."
 msgstr ""
 
-#: src/olympia/devhub/forms.py:788 src/olympia/editors/forms.py:114
-#: src/olympia/zadmin/forms.py:49 src/olympia/zadmin/forms.py:52
+#: src/olympia/devhub/forms.py:789 src/olympia/editors/forms.py:114 src/olympia/editors/forms.py:254 src/olympia/zadmin/forms.py:49 src/olympia/zadmin/forms.py:52
 msgid "Select an application first"
 msgstr ""
 
-#: src/olympia/devhub/forms.py:840
+#: src/olympia/devhub/forms.py:841
 msgid "There cannot be more than 3 required add-ons."
 msgstr ""
 
@@ -4692,16 +3929,16 @@ msgstr ""
 msgid "Developer Docs"
 msgstr "Kehitysuutiset"
 
-#. L10n: first parameter is the number of errors
 # {0} is a number
+#. L10n: first parameter is the number of errors
 #: src/olympia/devhub/helpers.py:200
 msgid "{0} error"
 msgid_plural "{0} errors"
 msgstr[0] ""
 msgstr[1] ""
 
-#. L10n: first parameter is the number of warnings
 # {0} is a number
+#. L10n: first parameter is the number of warnings
 #: src/olympia/devhub/helpers.py:203
 msgid "{0} warning"
 msgid_plural "{0} warnings"
@@ -4709,93 +3946,86 @@ msgstr[0] ""
 msgstr[1] ""
 
 # 85%
-#: src/olympia/devhub/models.py:375
-#: src/olympia/reviews/templates/reviews/add.html:58
+#: src/olympia/devhub/models.py:375 src/olympia/reviews/templates/reviews/add.html:58
 #, fuzzy
 msgid "Review"
 msgstr "Arvostelu:"
 
-#: src/olympia/devhub/tasks.py:551
+#: src/olympia/devhub/tasks.py:583
 #, python-format
 msgid "%s responded with %s (%s)."
 msgstr ""
 
-#: src/olympia/devhub/tasks.py:555
+#: src/olympia/devhub/tasks.py:587
 #, python-format
 msgid "Connection to \"%s\" timed out."
 msgstr ""
 
-#: src/olympia/devhub/tasks.py:557
+#: src/olympia/devhub/tasks.py:589
 #, python-format
 msgid "Could not contact host at \"%s\"."
 msgstr ""
 
-#: src/olympia/devhub/utils.py:104
+#: src/olympia/devhub/utils.py:105
 #, python-format
-msgid ""
-"Validation generated too many errors/warnings so %s messages were truncated."
-" After addressing the visible messages, you'll be able to see the others."
+msgid "Validation generated too many errors/warnings so %s messages were truncated. After addressing the visible messages, you'll be able to see the others."
 msgstr ""
 
 # 78%
-#: src/olympia/devhub/views.py:183
+#: src/olympia/devhub/views.py:181
 #, fuzzy
 msgid "All My Add-ons"
 msgstr "Kaikki lisäosat"
 
-#: src/olympia/devhub/views.py:210
+#: src/olympia/devhub/views.py:208
 msgid "All Activity"
 msgstr ""
 
-#: src/olympia/devhub/views.py:211
+#: src/olympia/devhub/views.py:209
 msgid "Add-on Updates"
 msgstr ""
 
-#: src/olympia/devhub/views.py:212
+#: src/olympia/devhub/views.py:210
 msgid "Add-on Status"
 msgstr ""
 
 # 75%
 # 100%
-#: src/olympia/devhub/views.py:213
+#: src/olympia/devhub/views.py:211
 #, fuzzy
 msgid "User Collections"
 msgstr "Kokoelmani"
 
-#: src/olympia/devhub/views.py:214
-#: src/olympia/devhub/templates/devhub/docs/policies-maintenance.html:68
-#: src/olympia/pages/templates/pages/dev_faq.html:38
+#: src/olympia/devhub/views.py:212 src/olympia/devhub/templates/devhub/docs/policies-maintenance.html:68 src/olympia/pages/templates/pages/dev_faq.html:38
 #: src/olympia/pages/templates/pages/dev_faq.html:484
 msgid "User Reviews"
 msgstr ""
 
-#: src/olympia/devhub/views.py:327 src/olympia/devhub/views.py:331
-#: src/olympia/devhub/views.py:484 src/olympia/devhub/views.py:513
-#: src/olympia/devhub/views.py:564 src/olympia/devhub/views.py:1150
+#: src/olympia/devhub/views.py:325 src/olympia/devhub/views.py:329 src/olympia/devhub/views.py:484 src/olympia/devhub/views.py:513 src/olympia/devhub/views.py:564 src/olympia/devhub/views.py:1156
 msgid "Changes successfully saved."
 msgstr ""
 
-#: src/olympia/devhub/views.py:334 src/olympia/devhub/views.py:1631
+#: src/olympia/devhub/views.py:332 src/olympia/devhub/views.py:1637
 msgid "Please check the form for errors."
 msgstr ""
 
-#: src/olympia/devhub/views.py:346
+#: src/olympia/devhub/views.py:344
 msgid "Add-on cannot be deleted. Disable this add-on instead."
 msgstr ""
 
-#: src/olympia/devhub/views.py:356
+#: src/olympia/devhub/views.py:354
 msgid "Theme deleted."
 msgstr "Teema poistettu."
 
-#: src/olympia/devhub/views.py:356
+#: src/olympia/devhub/views.py:354
 msgid "Add-on deleted."
 msgstr "Lisäosa poistettu."
 
-#: src/olympia/devhub/views.py:362
+#: src/olympia/devhub/views.py:360
 msgid "URL name was incorrect. Theme was not deleted."
 msgstr ""
 
-#: src/olympia/devhub/views.py:367
+#: src/olympia/devhub/views.py:365
 msgid "URL name was incorrect. Add-on was not deleted."
 msgstr ""
 
@@ -4823,7 +4053,7 @@ msgstr ""
 msgid "Check Add-on Compatibility"
 msgstr ""
 
-#: src/olympia/devhub/views.py:808 src/olympia/signing/views.py:90
+#: src/olympia/devhub/views.py:808 src/olympia/signing/views.py:95
 msgid "You cannot submit this type of add-on"
 msgstr ""
 
@@ -4853,45 +4083,38 @@ msgstr ""
 msgid "There was an error uploading your preview."
 msgstr ""
 
-#: src/olympia/devhub/views.py:1189
+#: src/olympia/devhub/views.py:1195
 #, python-format
 msgid "Version %s disabled."
 msgstr ""
 
-#: src/olympia/devhub/views.py:1193
+#: src/olympia/devhub/views.py:1199
 #, python-format
 msgid "Version %s deleted."
 msgstr ""
 
-#: src/olympia/devhub/views.py:1203
-msgid ""
-"This upload has failed validation, and may lack complete validation results."
-" Please take due care when reviewing it."
+#: src/olympia/devhub/views.py:1209
+msgid "This upload has failed validation, and may lack complete validation results. Please take due care when reviewing it."
 msgstr ""
 
-#: src/olympia/devhub/views.py:1677
+#: src/olympia/devhub/views.py:1683
 msgid "Preliminary Review Requested."
 msgstr ""
 
-#: src/olympia/devhub/views.py:1678
+#: src/olympia/devhub/views.py:1684
 msgid "Full Review Requested."
 msgstr ""
 
-#: src/olympia/devhub/views.py:1779
-msgid ""
-"Your old credentials were revoked and are no longer valid. Be sure to update"
-" all API clients with the new credentials."
+#: src/olympia/devhub/views.py:1783
+msgid "Your old credentials were revoked and are no longer valid. Be sure to update all API clients with the new credentials."
 msgstr ""
 
-#: src/olympia/devhub/views.py:1797
+#: src/olympia/devhub/views.py:1801
 msgid "New API key created"
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/agreement.html:2
-msgid ""
-"Before starting, please read and accept our Firefox Add-on Distribution "
-"Agreement. It also links to our Privacy Notice which explains how we handle "
-"your information."
+msgid "Before starting, please read and accept our Firefox Add-on Distribution Agreement. It also links to our Privacy Notice which explains how we handle your information."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/agreement.html:13
@@ -4906,45 +4129,31 @@ msgstr ""
 msgid "or <a href=\"{0}\">Cancel</a>"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/base.html:23
-#: src/olympia/devhub/templates/devhub/base_impala.html:20
-#: src/olympia/discovery/templates/discovery/addons/base.html:17
+#: src/olympia/devhub/templates/devhub/base.html:23 src/olympia/devhub/templates/devhub/base_impala.html:20 src/olympia/discovery/templates/discovery/addons/base.html:17
 msgid "Back to Add-ons"
 msgstr "Takaisin lisäosiin"
 
 #. {0} is a search term, such as Firebug.
 #. {0} is a search query.
-#: src/olympia/devhub/templates/devhub/devhub_search.html:4
-#: src/olympia/search/templates/search/results.html:9
-#: src/olympia/search/templates/search/mobile/results.html:6
+#: src/olympia/devhub/templates/devhub/devhub_search.html:4 src/olympia/search/templates/search/results.html:9 src/olympia/search/templates/search/mobile/results.html:6
 msgid "{0} :: Search"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/devhub_search.html:6
-#: src/olympia/devhub/templates/devhub/search.html:8
-#: src/olympia/editors/forms.py:435 src/olympia/editors/forms.py:437
-#: src/olympia/editors/templates/editors/queue.html:27
-#: src/olympia/editors/templates/editors/themes/queue_list.html:14
-#: src/olympia/search/templates/search/collections.html:17
-#: src/olympia/search/templates/search/personas.html:18
-#: src/olympia/search/templates/search/results.html:18
-#: src/olympia/search/templates/search/mobile/results.html:8
-#: src/olympia/templates/search.html:14
-#: src/olympia/templates/impala/search.html:18
+#: src/olympia/devhub/templates/devhub/devhub_search.html:6 src/olympia/devhub/templates/devhub/search.html:8 src/olympia/editors/forms.py:534 src/olympia/editors/forms.py:536
+#: src/olympia/editors/templates/editors/queue.html:27 src/olympia/editors/templates/editors/themes/queue_list.html:14 src/olympia/search/templates/search/collections.html:17
+#: src/olympia/search/templates/search/personas.html:18 src/olympia/search/templates/search/results.html:18 src/olympia/search/templates/search/mobile/results.html:8
+#: src/olympia/templates/search.html:14 src/olympia/templates/impala/search.html:18
 msgid "Search"
 msgstr "Etsi"
 
-#: src/olympia/devhub/templates/devhub/devhub_search.html:11
-#: src/olympia/devhub/templates/devhub/devhub_search.html:15
-#: src/olympia/search/templates/search/collections.html:18
+#: src/olympia/devhub/templates/devhub/devhub_search.html:11 src/olympia/devhub/templates/devhub/devhub_search.html:15 src/olympia/search/templates/search/collections.html:18
 #: src/olympia/search/templates/search/personas.html:20
 msgid "Search Results"
 msgstr ""
 
-#. {0} is a search term, such as Firebug.
 # 85%
-#: src/olympia/devhub/templates/devhub/devhub_search.html:13
-#: src/olympia/search/templates/search/results.html:11
+#. {0} is a search term, such as Firebug.
+#: src/olympia/devhub/templates/devhub/devhub_search.html:13 src/olympia/search/templates/search/results.html:11
 #, fuzzy
 msgid "Search Results for \"{0}\""
 msgstr "Hakutulokset avainsanalle \"{0}\""
@@ -4966,9 +4175,7 @@ msgid "AMO Reviewers"
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/index.html:29
-msgid ""
-"Get ahead! Become an AMO Reviewer today and get your add-ons reviewed "
-"faster."
+msgid "Get ahead! Become an AMO Reviewer today and get your add-ons reviewed faster."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/index.html:32
@@ -4981,33 +4188,25 @@ msgstr ""
 
 #: src/olympia/devhub/templates/devhub/index.html:41
 msgid ""
-"Add-ons let millions of Firefox users enhance and customize their browsing "
-"experience. If you're a Web developer and know <a "
-"href=\"https://developer.mozilla.org/docs/Web/HTML\">HTML</a>, <a "
-"href=\"https://developer.mozilla.org/docs/Web/JavaScript\">JavaScript</a>, "
-"and <a href=\"https://developer.mozilla.org/docs/Web/CSS\">CSS</a>, you "
-"already have all the necessary skills to make a great add-on."
+"Add-ons let millions of Firefox users enhance and customize their browsing experience. If you're a Web developer and know <a href=\"https://developer.mozilla.org/docs/Web/HTML\">HTML</a>, <a href="
+"\"https://developer.mozilla.org/docs/Web/JavaScript\">JavaScript</a>, and <a href=\"https://developer.mozilla.org/docs/Web/CSS\">CSS</a>, you already have all the necessary skills to make a great "
+"add-on."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/index.html:51
-msgid ""
-"Head over to the <a href=\"https://developer.mozilla.org/Add-ons\">Mozilla "
-"Developer Network</a> to learn everything you need to know to get started."
+msgid "Head over to the <a href=\"https://developer.mozilla.org/Add-ons\">Mozilla Developer Network</a> to learn everything you need to know to get started."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/index.html:58
 msgid "Start Making Add-ons"
 msgstr "Aloita lisäosien luominen"
 
-#: src/olympia/devhub/templates/devhub/index.html:86
-#: src/olympia/devhub/templates/devhub/addons/listing/items.html:25
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:15
+#: src/olympia/devhub/templates/devhub/index.html:86 src/olympia/devhub/templates/devhub/addons/listing/items.html:25 src/olympia/devhub/templates/devhub/includes/addon_details.html:20
 #: src/olympia/devhub/templates/devhub/personas/edit.html:43
 msgid "Status:"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/index.html:90
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:100
+#: src/olympia/devhub/templates/devhub/index.html:90 src/olympia/devhub/templates/devhub/includes/addon_details.html:87
 msgid "Visibility:"
 msgstr ""
 
@@ -5015,21 +4214,16 @@ msgstr ""
 msgid "Latest Version:"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/index.html:109
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:145
-#: src/olympia/devhub/templates/devhub/personas/edit.html:49
+#: src/olympia/devhub/templates/devhub/index.html:109 src/olympia/devhub/templates/devhub/includes/addon_details.html:131 src/olympia/devhub/templates/devhub/personas/edit.html:49
 msgid "Queue Position:"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/index.html:110
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:146
-#: src/olympia/devhub/templates/devhub/personas/edit.html:50
+#: src/olympia/devhub/templates/devhub/index.html:110 src/olympia/devhub/templates/devhub/includes/addon_details.html:132 src/olympia/devhub/templates/devhub/personas/edit.html:50
 #, python-format
 msgid "%(position)s of %(total)s"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/index.html:120
-#: src/olympia/devhub/templates/devhub/includes/addons_edit_nav.html:19
+#: src/olympia/devhub/templates/devhub/index.html:120 src/olympia/devhub/templates/devhub/includes/addons_edit_nav.html:19
 msgid "Upload New Version"
 msgstr ""
 
@@ -5043,9 +4237,7 @@ msgstr ""
 
 #: src/olympia/devhub/templates/devhub/index.html:136
 #, python-format
-msgid ""
-"Upload an <a href=\"%(addon_url)s\">add-on</a> or <a "
-"href=\"%(theme_url)s\">theme</a> to get started!"
+msgid "Upload an <a href=\"%(addon_url)s\">add-on</a> or <a href=\"%(theme_url)s\">theme</a> to get started!"
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/nav.html:2
@@ -5075,17 +4267,10 @@ msgstr ""
 
 # 80%
 # 100%
-#: src/olympia/devhub/templates/devhub/nav.html:39
-#: src/olympia/devhub/templates/devhub/docs/policies-agreement.html:6
-#: src/olympia/devhub/templates/devhub/docs/policies-contact.html:6
-#: src/olympia/devhub/templates/devhub/docs/policies-maintenance.html:6
-#: src/olympia/devhub/templates/devhub/docs/policies-recommended.html:6
-#: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:6
-#: src/olympia/devhub/templates/devhub/docs/policies-submission.html:6
-#: src/olympia/devhub/templates/devhub/docs/policies.html:3
-#: src/olympia/devhub/templates/devhub/docs/policies.html:9
-#: src/olympia/devhub/templates/devhub/docs/policies.html:38
-#: src/olympia/devhub/templates/devhub/docs/policies.html:39
+#: src/olympia/devhub/templates/devhub/nav.html:39 src/olympia/devhub/templates/devhub/docs/policies-agreement.html:6 src/olympia/devhub/templates/devhub/docs/policies-contact.html:6
+#: src/olympia/devhub/templates/devhub/docs/policies-maintenance.html:6 src/olympia/devhub/templates/devhub/docs/policies-recommended.html:6
+#: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:6 src/olympia/devhub/templates/devhub/docs/policies-submission.html:6 src/olympia/devhub/templates/devhub/docs/policies.html:3
+#: src/olympia/devhub/templates/devhub/docs/policies.html:9 src/olympia/devhub/templates/devhub/docs/policies.html:38 src/olympia/devhub/templates/devhub/docs/policies.html:39
 msgid "Add-on Policies"
 msgstr "Lisäosakäytännöt"
 
@@ -5126,37 +4311,15 @@ msgid "Use the field below to upload your add-on package."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/validate_addon.html:19
-msgid ""
-"After upload, a series of automated validation tests will run to check "
-"compatibility with the following application version:"
+msgid "After upload, a series of automated validation tests will run to check compatibility with the following application version:"
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/validate_addon.html:34
-msgid ""
-"After upload, a series of automated validation tests will be run on your "
-"file."
+msgid "After upload, a series of automated validation tests will be run on your file."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/validate_addon.html:42
-#: src/olympia/devhub/templates/devhub/addons/submit/upload.html:23
+#: src/olympia/devhub/templates/devhub/validate_addon.html:42 src/olympia/devhub/templates/devhub/addons/submit/upload.html:23
 msgid "Do you want your add-on to be distributed on this site?"
-msgstr ""
-
-#: src/olympia/devhub/templates/devhub/validate_addon.html:49
-#: src/olympia/devhub/templates/devhub/addons/submit/upload.html:30
-#: src/olympia/devhub/templates/devhub/versions/add_file_modal.html:14
-#: src/olympia/devhub/templates/devhub/versions/add_file_modal.html:53
-#: src/olympia/devhub/templates/devhub/versions/list.html:298
-msgid "Warning:"
-msgstr "Varoitus:"
-
-#: src/olympia/devhub/templates/devhub/validate_addon.html:50
-#: src/olympia/devhub/templates/devhub/addons/submit/upload.html:31
-#, python-format
-msgid ""
-"Submission of unlisted add-ons for signing is currently in an open beta. "
-"Please <a href=\"%(url)s\" target=\"_blank\">report any bugs</a> that you "
-"encounter."
 msgstr ""
 
 #. first parameter is a filename like lorem-ipsum-1.0.2.xpi
@@ -5176,14 +4339,11 @@ msgstr ""
 msgid "Tested for compatibility against:"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/addons/activity.html:4
-#: src/olympia/devhub/templates/devhub/addons/activity.html:20
+#: src/olympia/devhub/templates/devhub/addons/activity.html:4 src/olympia/devhub/templates/devhub/addons/activity.html:20
 msgid "Recent Activity for My Add-ons"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/addons/activity.html:14
-#: src/olympia/devhub/templates/devhub/addons/activity.html:19
-#: src/olympia/devhub/templates/devhub/addons/dashboard.html:33
+#: src/olympia/devhub/templates/devhub/addons/activity.html:14 src/olympia/devhub/templates/devhub/addons/activity.html:19 src/olympia/devhub/templates/devhub/addons/dashboard.html:33
 msgid "Recent Activity"
 msgstr ""
 
@@ -5205,37 +4365,30 @@ msgstr ""
 msgid "Activity"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/addons/activity.html:83
-#: src/olympia/devhub/templates/devhub/addons/dashboard.html:34
-#: src/olympia/devhub/templates/devhub/addons/dashboard.html:35
-#: src/olympia/devhub/templates/devhub/includes/blog_posts.html:4
-#: src/olympia/devhub/templates/devhub/includes/blog_posts.html:6
+#: src/olympia/devhub/templates/devhub/addons/activity.html:83 src/olympia/devhub/templates/devhub/addons/dashboard.html:34 src/olympia/devhub/templates/devhub/addons/dashboard.html:35
+#: src/olympia/devhub/templates/devhub/includes/blog_posts.html:4 src/olympia/devhub/templates/devhub/includes/blog_posts.html:6
 msgid "Subscribe to this feed"
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/ajax_compat_error.html:7
 #, python-format
 msgid ""
-"This add-on is incompatible with <b>%(app_name)s %(app_version)s</b>, the "
-"latest release of %(app_name)s. Please consider updating your add-on's "
-"compatibility info, or uploading a newer version of this add-on."
+"This add-on is incompatible with <b>%(app_name)s %(app_version)s</b>, the latest release of %(app_name)s. Please consider updating your add-on's compatibility info, or uploading a newer version of "
+"this add-on."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/ajax_compat_error.html:15
 #, python-format
 msgid ""
-"<a href=\"#\" class=\"button compat-update\" data-"
-"updateurl=\"%(update_url)s\">Update Compatibility</a> <a "
-"href=\"%(version_url)s\" class=\"button\">Upload New Version</a> or <a "
-"href=\"#\" class=\"close\">Ignore</a>"
+"<a href=\"#\" class=\"button compat-update\" data-updateurl=\"%(update_url)s\">Update Compatibility</a> <a href=\"%(version_url)s\" class=\"button\">Upload New Version</a> or <a href=\"#\" class="
+"\"close\">Ignore</a>"
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/ajax_compat_status.html:5
 msgid "View and update application compatibility ranges."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/addons/ajax_compat_status.html:6
-#: src/olympia/devhub/templates/devhub/versions/edit.html:44
+#: src/olympia/devhub/templates/devhub/addons/ajax_compat_status.html:6 src/olympia/devhub/templates/devhub/versions/edit.html:44
 msgid "Compatibility"
 msgstr ""
 
@@ -5243,37 +4396,26 @@ msgstr ""
 msgid "Update Compatibility"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/addons/ajax_compat_update.html:4
-msgid ""
-"Adjusting application information here will allow users to install your add-"
-"on even if the install manifest in the package indicates that the add-on is "
-"incompatible."
+#: src/olympia/devhub/templates/devhub/addons/ajax_compat_update.html:4 src/olympia/devhub/templates/devhub/versions/edit.html:45
+msgid "Adjusting application information here will allow users to install your add-on even if the install manifest in the package indicates that the add-on is incompatible."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/ajax_compat_update.html:18
 msgid "Supported Versions"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/addons/ajax_compat_update.html:31
-#: src/olympia/devhub/templates/devhub/versions/edit.html:63
+#: src/olympia/devhub/templates/devhub/addons/ajax_compat_update.html:31 src/olympia/devhub/templates/devhub/versions/edit.html:63
 msgid "Add Another Application&hellip;"
 msgstr ""
 
 # 80%
-#: src/olympia/devhub/templates/devhub/addons/ajax_compat_update.html:38
-#: src/olympia/devhub/templates/devhub/addons/owner.html:86
-#: src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:46
-#: src/olympia/devhub/templates/devhub/versions/list.html:351
-#: src/olympia/devhub/templates/devhub/versions/list.html:353
-#: src/olympia/templates/impala/base.html:132
-#: src/olympia/templates/impala/base.html:143
-#: src/olympia/templates/impala/base.html:161
-#: src/olympia/templates/impala/base.html:171
+#: src/olympia/devhub/templates/devhub/addons/ajax_compat_update.html:38 src/olympia/devhub/templates/devhub/addons/owner.html:86 src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:45
+#: src/olympia/devhub/templates/devhub/versions/list.html:349 src/olympia/devhub/templates/devhub/versions/list.html:351 src/olympia/templates/impala/base.html:129
+#: src/olympia/templates/impala/base.html:140 src/olympia/templates/impala/base.html:158 src/olympia/templates/impala/base.html:168
 msgid "Close"
 msgstr "Sulje"
 
-#: src/olympia/devhub/templates/devhub/addons/dashboard.html:43
-#: src/olympia/zadmin/templates/zadmin/index.html:22
+#: src/olympia/devhub/templates/devhub/addons/dashboard.html:43 src/olympia/zadmin/templates/zadmin/index.html:22
 #, python-format
 msgid "%(ago)s by %(user)s"
 msgstr ""
@@ -5289,31 +4431,23 @@ msgid_plural "<b>{0}</b> themes"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/olympia/devhub/templates/devhub/addons/edit.html:3
-#: src/olympia/devhub/templates/devhub/addons/listing/item_actions.html:25
-#: src/olympia/devhub/templates/devhub/addons/listing/item_actions_theme.html:7
-#: src/olympia/devhub/templates/devhub/includes/addons_edit_nav.html:2
-#: src/olympia/devhub/templates/devhub/personas/edit.html:6
-#: src/olympia/editors/templates/editors/themes/single.html:37
+#: src/olympia/devhub/templates/devhub/addons/edit.html:3 src/olympia/devhub/templates/devhub/addons/listing/item_actions.html:25
+#: src/olympia/devhub/templates/devhub/addons/listing/item_actions_theme.html:7 src/olympia/devhub/templates/devhub/includes/addons_edit_nav.html:2
+#: src/olympia/devhub/templates/devhub/personas/edit.html:6 src/olympia/editors/templates/editors/themes/single.html:37
 msgid "Edit Listing"
 msgstr ""
 
 # 75%
-#: src/olympia/devhub/templates/devhub/addons/edit.html:13
-#: src/olympia/devhub/templates/devhub/includes/macros.html:18
-#: src/olympia/translations/templates/translations/all-locales.html:6
+#: src/olympia/devhub/templates/devhub/addons/edit.html:13 src/olympia/devhub/templates/devhub/includes/macros.html:18 src/olympia/translations/templates/translations/all-locales.html:6
 #, fuzzy
 msgid "None"
 msgstr "ei mitään"
 
-#: src/olympia/devhub/templates/devhub/addons/owner.html:4
-#: src/olympia/devhub/templates/devhub/addons/listing/item_actions.html:52
-#: src/olympia/devhub/templates/devhub/includes/addons_edit_nav.html:3
+#: src/olympia/devhub/templates/devhub/addons/owner.html:4 src/olympia/devhub/templates/devhub/addons/listing/item_actions.html:52 src/olympia/devhub/templates/devhub/includes/addons_edit_nav.html:3
 msgid "Manage Authors & License"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/addons/owner.html:29
-#: src/olympia/editors/templates/editors/review.html:270
+#: src/olympia/devhub/templates/devhub/addons/owner.html:29 src/olympia/editors/helpers.py:362 src/olympia/editors/templates/editors/review.html:270
 msgid "Authors"
 msgstr ""
 
@@ -5323,28 +4457,21 @@ msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/owner.html:78
 msgid ""
-"<p>Add-ons can have any number of authors with 3 possible roles:</p> <ul> "
-"<li><b>Owner:</b> Can manage all aspects of the add-on's listing, including "
-"adding and removing other authors</li> <li><b>Developer:</b> Can manage all "
-"aspects of the add-on's listing, except for adding and removing other "
-"authors and managing payments</li> <li><b>Viewer:</b> Can view the add-on's "
-"settings and statistics, but cannot make any changes</li> </ul>"
+"<p>Add-ons can have any number of authors with 3 possible roles:</p> <ul> <li><b>Owner:</b> Can manage all aspects of the add-on's listing, including adding and removing other authors</li> "
+"<li><b>Developer:</b> Can manage all aspects of the add-on's listing, except for adding and removing other authors and managing payments</li> <li><b>Viewer:</b> Can view the add-on's settings and "
+"statistics, but cannot make any changes</li> </ul>"
 msgstr ""
 
 # 82%
 # 100%
-#: src/olympia/devhub/templates/devhub/addons/profile.html:3
-#: src/olympia/devhub/templates/devhub/addons/listing/item_actions.html:53
-#: src/olympia/devhub/templates/devhub/includes/addons_edit_nav.html:4
+#: src/olympia/devhub/templates/devhub/addons/profile.html:3 src/olympia/devhub/templates/devhub/addons/listing/item_actions.html:53 src/olympia/devhub/templates/devhub/includes/addons_edit_nav.html:4
 #, fuzzy
 msgid "Manage Developer Profile"
 msgstr "Manage Developer Profile"
 
 #: src/olympia/devhub/templates/devhub/addons/profile.html:16
 #, python-format
-msgid ""
-"Your <a href=\"%(url)s\">developer profile</a> is currently "
-"<strong>public</strong> and <strong>required</strong> for contributions."
+msgid "Your <a href=\"%(url)s\">developer profile</a> is currently <strong>public</strong> and <strong>required</strong> for contributions."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/profile.html:22
@@ -5353,9 +4480,7 @@ msgstr "Poista molemmat"
 
 #: src/olympia/devhub/templates/devhub/addons/profile.html:27
 #, python-format
-msgid ""
-"Your <a href=\"%(url)s\">developer profile</a> is currently "
-"<strong>public</strong>."
+msgid "Your <a href=\"%(url)s\">developer profile</a> is currently <strong>public</strong>."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/profile.html:33
@@ -5370,9 +4495,9 @@ msgstr ""
 msgid "Basic Information"
 msgstr ""
 
-#. {0} is the addon name
 # 76%
 # 100%
+#. {0} is the addon name
 #: src/olympia/devhub/templates/devhub/addons/edit/basic.html:17
 #, fuzzy
 msgid "Basic Information for {0}"
@@ -5386,11 +4511,8 @@ msgstr ""
 msgid "Choose a short, unique URL slug for your add-on."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/addons/edit/basic.html:43
-#: src/olympia/devhub/templates/devhub/includes/addons_edit_nav.html:35
-#: src/olympia/devhub/templates/devhub/personas/edit.html:56
-#: src/olympia/editors/templates/editors/review.html:255
-#: src/olympia/editors/templates/editors/themes/single.html:33
+#: src/olympia/devhub/templates/devhub/addons/edit/basic.html:43 src/olympia/devhub/templates/devhub/includes/addons_edit_nav.html:35 src/olympia/devhub/templates/devhub/personas/edit.html:56
+#: src/olympia/editors/templates/editors/review.html:255 src/olympia/editors/templates/editors/themes/single.html:33
 msgid "View Listing"
 msgstr ""
 
@@ -5400,46 +4522,30 @@ msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/basic.html:52
 msgid ""
-"A short explanation of your add-on's basic\n"
-"                          functionality that is displayed in search and browse\n"
-"                          listings, as well as at the top of your add-on's\n"
-"                          details page. It is only relevant for listed add-ons."
+"A short explanation of your add-on's basic functionality that is displayed in search and browse listings, as well as at the top of your add-on's details page. It is only relevant for listed add-ons."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/basic.html:73
-msgid ""
-"Categories are the primary way users browse through add-ons.\n"
-"                        Choose any that fit your add-on's functionality for the most\n"
-"                        exposure. It is only relevant for listed add-ons."
+msgid "Categories are the primary way users browse through add-ons. Choose any that fit your add-on's functionality for the most exposure. It is only relevant for listed add-ons."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/basic.html:90
 #, python-format
 msgid ""
-"Categories cannot be changed while your add-on is featured for this "
-"application. Please email <a href=\"mailto:%(email)s\">%(email)s</a> if "
-"there is a reason you need to modify your categories."
+"Categories cannot be changed while your add-on is featured for this application. Please email <a href=\"mailto:%(email)s\">%(email)s</a> if there is a reason you need to modify your categories."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/basic.html:119
-msgid ""
-"Tags help users find your add-on and should be short\n"
-"                        descriptors such as tabs, toolbar, or twitter.  You\n"
-"                        may have a maximum of {0} tags. It is only relevant\n"
-"                        for listed add-ons."
+msgid "Tags help users find your add-on and should be short descriptors such as tabs, toolbar, or twitter. You may have a maximum of {0} tags. It is only relevant for listed add-ons."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/addons/edit/basic.html:129
-#: src/olympia/devhub/templates/devhub/personas/edit.html:97
-#: src/olympia/devhub/templates/devhub/personas/submit.html:46
+#: src/olympia/devhub/templates/devhub/addons/edit/basic.html:129 src/olympia/devhub/templates/devhub/personas/edit.html:97 src/olympia/devhub/templates/devhub/personas/submit.html:46
 msgid "Comma-separated, minimum of {0} character."
 msgid_plural "Comma-separated, minimum of {0} characters."
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/olympia/devhub/templates/devhub/addons/edit/basic.html:132
-#: src/olympia/devhub/templates/devhub/personas/edit.html:100
-#: src/olympia/devhub/templates/devhub/personas/submit.html:49
+#: src/olympia/devhub/templates/devhub/addons/edit/basic.html:132 src/olympia/devhub/templates/devhub/personas/edit.html:100 src/olympia/devhub/templates/devhub/personas/submit.html:49
 msgid "Example: dark, cinema, noir. Limit 20."
 msgstr ""
 
@@ -5458,39 +4564,26 @@ msgid "Add-on Details for {0}"
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/details.html:22
-msgid ""
-"A longer explanation of features,\n"
-"                          functionality, and other relevant information. This\n"
-"                          field is only displayed on the add-on's details\n"
-"                          page. It is only relevant for listed add-ons."
+msgid "A longer explanation of features, functionality, and other relevant information. This field is only displayed on the add-on's details page. It is only relevant for listed add-ons."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/addons/edit/details.html:44
-#: src/olympia/translations/templates/translations/trans-menu.html:13
+#: src/olympia/devhub/templates/devhub/addons/edit/details.html:44 src/olympia/translations/templates/translations/trans-menu.html:13
 msgid "Default Locale"
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/details.html:45
-msgid ""
-"Information about your add-on is displayed in this locale\n"
-"                        unless you override it with a locale-specific translation.\n"
-"                        It is only relevant for listed add-ons."
+msgid "Information about your add-on is displayed in this locale unless you override it with a locale-specific translation. It is only relevant for listed add-ons."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/addons/edit/details.html:61
-#: src/olympia/users/forms.py:311
-#: src/olympia/users/templates/users/edit.html:122
-#: src/olympia/users/templates/users/register.html:57
+#: src/olympia/devhub/templates/devhub/addons/edit/details.html:61 src/olympia/users/forms.py:311 src/olympia/users/templates/users/edit.html:122 src/olympia/users/templates/users/register.html:57
 #: src/olympia/users/templates/users/vcard.html:22
 msgid "Homepage"
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/details.html:63
 msgid ""
-"If your add-on has another homepage, enter its\n"
-"                          address here. If your website is localized into other\n"
-"                          languages multiple translations of this field can be\n"
-"                          added. It is only relevant for listed add-ons."
+"If your add-on has another homepage, enter its address here. If your website is localized into other languages multiple translations of this field can be added. It is only relevant for listed add-"
+"ons."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/media.html:3
@@ -5501,9 +4594,9 @@ msgstr ""
 msgid "Support Information"
 msgstr "Tukitiedot"
 
-#. {0} is an addon name
 # 77%
 # 100%
+#. {0} is an addon name
 #: src/olympia/devhub/templates/devhub/addons/edit/support.html:15
 #, fuzzy
 msgid "Support Information for {0}"
@@ -5511,19 +4604,14 @@ msgstr "Lisäosan {0} tiedot"
 
 #: src/olympia/devhub/templates/devhub/addons/edit/support.html:22
 msgid ""
-"If you wish to display an e-mail address for support\n"
-"                          inquiries, enter it here. If you have different\n"
-"                          addresses for each language multiple translations of\n"
-"                          this field can be added. It is only relevant for\n"
-"                          listed add-ons."
+"If you wish to display an e-mail address for support inquiries, enter it here. If you have different addresses for each language multiple translations of this field can be added. It is only "
+"relevant for listed add-ons."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/support.html:45
 msgid ""
-"If your add-on has a support website or forum, enter\n"
-"                          its address here. If your website is localized into\n"
-"                          other languages, multiple translations of this field can\n"
-"                          be added. It is only relevant for listed add-ons."
+"If your add-on has a support website or forum, enter its address here. If your website is localized into other languages, multiple translations of this field can be added. It is only relevant for "
+"listed add-ons."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:6
@@ -5537,11 +4625,8 @@ msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:23
 msgid ""
-"Any information end users may want to know that isn't\n"
-"                          necessarily applicable to the add-on summary or description.\n"
-"                          Common uses include listing known major bugs, information on\n"
-"                          how to report bugs, anticipated release date of a new version,\n"
-"                          etc. It is only relevant for listed add-ons."
+"Any information end users may want to know that isn't necessarily applicable to the add-on summary or description. Common uses include listing known major bugs, information on how to report bugs, "
+"anticipated release date of a new version, etc. It is only relevant for listed add-ons."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:46
@@ -5553,9 +4638,7 @@ msgid "Add-on Flags"
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:69
-msgid ""
-"These flags are used to classify add-ons. It is only\n"
-"                        relevant for listed add-ons."
+msgid "These flags are used to classify add-ons. It is only relevant for listed add-ons."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:74
@@ -5571,9 +4654,7 @@ msgid "View Source?"
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:90
-msgid ""
-"Whether the source of your add-on can be displayed in our\n"
-"                        online viewer. It is only relevant for listed add-ons."
+msgid "Whether the source of your add-on can be displayed in our online viewer. It is only relevant for listed add-ons."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:94
@@ -5589,10 +4670,7 @@ msgid "Public Stats?"
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:102
-msgid ""
-"Whether the download and usage stats of your add-on can\n"
-"                        be displayed in our online viewer.\n"
-"                        It is only relevant for listed add-ons."
+msgid "Whether the download and usage stats of your add-on can be displayed in our online viewer. It is only relevant for listed add-ons."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:107
@@ -5608,16 +4686,11 @@ msgid "Upgrade SDK?"
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:116
-msgid ""
-"If selected, we will try to automatically upgrade your\n"
-"                        add-on when a new version of the SDK is released.\n"
-"                        It is only relevant for listed add-ons."
+msgid "If selected, we will try to automatically upgrade your add-on when a new version of the SDK is released. It is only relevant for listed add-ons."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:121
-msgid ""
-"This add-on will be automatically upgraded to new versions of the Add-on "
-"SDK."
+msgid "This add-on will be automatically upgraded to new versions of the Add-on SDK."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:123
@@ -5635,22 +4708,17 @@ msgid "UUID"
 msgstr "UUID"
 
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:132
-msgid ""
-"The UUID of your add-on is specified in its install manifest and uniquely "
-"identifies it. You cannot change your UUID once it has been submitted."
+msgid "The UUID of your add-on is specified in its install manifest and uniquely identifies it. You cannot change your UUID once it has been submitted."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/addons/edit/technical.html:143
-#: src/olympia/devhub/templates/devhub/addons/edit/technical.html:144
+#: src/olympia/devhub/templates/devhub/addons/edit/technical.html:143 src/olympia/devhub/templates/devhub/addons/edit/technical.html:144
 msgid "Whiteboard"
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:146
 msgid ""
-"The whiteboard is the place to provide information relevant to your addon, "
-"whatever the version, to the editor. Use it to provide ways to test the "
-"addon, and any additional information that may help. This whiteboard is also"
-" editable by editors."
+"The whiteboard is the place to provide information relevant to your addon, whatever the version, to the editor. Use it to provide ways to test the addon, and any additional information that may "
+"help. This whiteboard is also editable by editors."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/technical_dependencies.html:9
@@ -5671,10 +4739,8 @@ msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/forms_shared/media.html:16
 msgid ""
-"Upload an icon for your add-on or choose from one of ours. The\n"
-"                      icon is displayed nearly everywhere your add-on is. Uploaded images\n"
-"                      must be one of the following image types: .png, .jpg.\n"
-"                      It is only relevant for listed add-ons."
+"Upload an icon for your add-on or choose from one of ours. The icon is displayed nearly everywhere your add-on is. Uploaded images must be one of the following image types: .png, .jpg. It is only "
+"relevant for listed add-ons."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/forms_shared/media.html:25
@@ -5687,9 +4753,7 @@ msgid "32x32px"
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/forms_shared/media.html:39
-msgid ""
-"Used in listings of add-ons, like search results\n"
-"                            and featured add-ons."
+msgid "Used in listings of add-ons, like search results and featured add-ons."
 msgstr ""
 
 #. The size of the icon
@@ -5729,60 +4793,49 @@ msgstr ""
 msgid "Tests"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/addons/includes/validation_compat_test_results.html:25
-#: src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:5
+#: src/olympia/devhub/templates/devhub/addons/includes/validation_compat_test_results.html:25 src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:5
 #: src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:53
 msgid "General Tests"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/addons/includes/validation_compat_test_results.html:32
-#: src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:9
+#: src/olympia/devhub/templates/devhub/addons/includes/validation_compat_test_results.html:32 src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:9
 #: src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:67
 msgid "Security Tests"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/addons/includes/validation_compat_test_results.html:39
-#: src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:13
+#: src/olympia/devhub/templates/devhub/addons/includes/validation_compat_test_results.html:39 src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:13
 #: src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:80
 msgid "Extension Tests"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/addons/includes/validation_compat_test_results.html:46
-#: src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:17
+#: src/olympia/devhub/templates/devhub/addons/includes/validation_compat_test_results.html:46 src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:17
 #: src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:93
 msgid "Localization Tests"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:21
-#: src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:106
+#: src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:21 src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:106
 msgid "Compatibility Tests"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:29
-#: src/olympia/files/templates/files/viewer.html:142
+#: src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:29 src/olympia/files/templates/files/viewer.html:142
 msgid "Hide messages not required for automated signing"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:35
-#: src/olympia/files/templates/files/viewer.html:150
+#: src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:35 src/olympia/files/templates/files/viewer.html:150
 msgid "Hide messages present in previous version and ignored"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:50
-#: src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:64
-#: src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:77
-#: src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:90
+#: src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:50 src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:64
+#: src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:77 src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:90
 #: src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:103
 msgid "Top"
 msgstr "Alkuun"
 
-#: src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:2
-#: src/olympia/devhub/templates/devhub/personas/edit.html:63
+#: src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:2 src/olympia/devhub/templates/devhub/personas/edit.html:63
 msgid "Delete Theme"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:2
-#: src/olympia/devhub/templates/devhub/versions/list.html:117
+#: src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:2 src/olympia/devhub/templates/devhub/versions/list.html:117
 msgid "Delete Add-on"
 msgstr ""
 
@@ -5791,28 +4844,23 @@ msgid "Deleting your theme will permanently remove it from the site."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:14
-msgid ""
-"Deleting your add-on will permanently remove it from the site and prevent "
-"its GUID from being submitted again by others."
+msgid "Deleting your add-on will permanently remove it from the site and prevent its GUID from being submitted again by others."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:24
-msgid ""
-"Enter the following text confirm your decision:\n"
-"           {slug}"
+msgid "Enter the following text confirm your decision: {slug}"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:34
+#: src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:33
 msgid "Please tell us why you are deleting your theme:"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:36
+#: src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:35
 msgid "Please tell us why you are deleting your add-on:"
 msgstr ""
 
 # 75%
-#: src/olympia/devhub/templates/devhub/addons/listing/item_actions.html:1
-#: src/olympia/devhub/templates/devhub/addons/listing/item_actions_theme.html:1
+#: src/olympia/devhub/templates/devhub/addons/listing/item_actions.html:1 src/olympia/devhub/templates/devhub/addons/listing/item_actions_theme.html:1
 #: src/olympia/editors/templates/editors/review.html:253
 #, fuzzy
 msgid "Actions"
@@ -5846,22 +4894,17 @@ msgstr ""
 msgid "Daily statistics on downloads and users."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/addons/listing/item_actions.html:45
-#: src/olympia/stats/templates/stats/stats.html:75
-#: src/olympia/stats/templates/stats/stats.html:79
-#: src/olympia/stats/templates/stats/stats.html:81
+#: src/olympia/devhub/templates/devhub/addons/listing/item_actions.html:45 src/olympia/stats/templates/stats/stats.html:31 src/olympia/stats/templates/stats/stats.html:35
+#: src/olympia/stats/templates/stats/stats.html:37
 msgid "Statistics"
 msgstr "Tilastot"
 
-#: src/olympia/devhub/templates/devhub/addons/listing/item_actions.html:54
-#: src/olympia/devhub/templates/devhub/includes/addons_edit_nav.html:5
-#: src/olympia/devhub/templates/devhub/payments/payments.html:3
-#: src/olympia/devhub/templates/devhub/payments/tier.html:4
+#: src/olympia/devhub/templates/devhub/addons/listing/item_actions.html:54 src/olympia/devhub/templates/devhub/includes/addons_edit_nav.html:5
+#: src/olympia/devhub/templates/devhub/payments/payments.html:3 src/olympia/devhub/templates/devhub/payments/tier.html:4
 msgid "Manage Payments"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/addons/listing/item_actions.html:55
-#: src/olympia/devhub/templates/devhub/includes/addons_edit_nav.html:6
+#: src/olympia/devhub/templates/devhub/addons/listing/item_actions.html:55 src/olympia/devhub/templates/devhub/includes/addons_edit_nav.html:6
 msgid "Manage Status & Versions"
 msgstr ""
 
@@ -5869,10 +4912,8 @@ msgstr ""
 msgid "View Add-on Listing"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/addons/listing/item_actions.html:64
-#: src/olympia/devhub/templates/devhub/addons/listing/item_actions_theme.html:12
-#: src/olympia/devhub/templates/devhub/includes/addons_edit_nav.html:37
-#: src/olympia/devhub/templates/devhub/personas/edit.html:58
+#: src/olympia/devhub/templates/devhub/addons/listing/item_actions.html:64 src/olympia/devhub/templates/devhub/addons/listing/item_actions_theme.html:12
+#: src/olympia/devhub/templates/devhub/includes/addons_edit_nav.html:37 src/olympia/devhub/templates/devhub/personas/edit.html:58
 msgid "View Recent Changes"
 msgstr ""
 
@@ -5897,9 +4938,7 @@ msgid "Delete this theme."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/listing/items.html:10
-msgid ""
-"This add-on will be deleted automatically after a few days if the submission"
-" process is not completed."
+msgid "This add-on will be deleted automatically after a few days if the submission process is not completed."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/listing/items.html:27
@@ -5911,8 +4950,8 @@ msgstr ""
 msgid "<b>Queue position:</b> %(pos)s of %(total)s"
 msgstr ""
 
-#. {0} is the number of active users.
 # 78%
+#. {0} is the number of active users.
 #: src/olympia/devhub/templates/devhub/addons/listing/macros.html:23
 #, fuzzy
 msgid "<strong>{0}</strong> active user"
@@ -5942,9 +4981,7 @@ msgstr ""
 msgid "The detail page will be:"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/addons/submit/describe.html:24
-#: src/olympia/devhub/templates/devhub/personas/edit.html:89
-#: src/olympia/devhub/templates/devhub/personas/submit.html:38
+#: src/olympia/devhub/templates/devhub/addons/submit/describe.html:24 src/olympia/devhub/templates/devhub/personas/edit.html:89 src/olympia/devhub/templates/devhub/personas/submit.html:38
 msgid "Please use only letters, numbers, underscores, and dashes in your URL."
 msgstr ""
 
@@ -5964,14 +5001,11 @@ msgstr ""
 msgid "The description will appear on the detail page."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/addons/submit/done.html:4
-#: src/olympia/devhub/templates/devhub/personas/submit_done.html:4
+#: src/olympia/devhub/templates/devhub/addons/submit/done.html:4 src/olympia/devhub/templates/devhub/personas/submit_done.html:4
 msgid "Submission Complete"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/addons/submit/done.html:8
-#: src/olympia/devhub/templates/devhub/addons/submit/sidebar.html:13
-#: src/olympia/devhub/templates/devhub/personas/submit_done.html:8
+#: src/olympia/devhub/templates/devhub/addons/submit/done.html:8 src/olympia/devhub/templates/devhub/addons/submit/sidebar.html:13 src/olympia/devhub/templates/devhub/personas/submit_done.html:8
 msgid "You're done!"
 msgstr ""
 
@@ -5984,20 +5018,14 @@ msgid "Your add-on has been submitted to the Full Review queue."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/submit/done.html:18
-msgid ""
-"You'll receive an email once it has been reviewed by an editor. In\n"
-"          the meantime, you and your friends can install it directly from its\n"
-"          details page:"
+msgid "You'll receive an email once it has been reviewed by an editor. In the meantime, you and your friends can install it directly from its details page:"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/addons/submit/done.html:27
-#: src/olympia/devhub/templates/devhub/addons/submit/done.html:77
-#: src/olympia/devhub/templates/devhub/personas/submit_done.html:16
+#: src/olympia/devhub/templates/devhub/addons/submit/done.html:27 src/olympia/devhub/templates/devhub/addons/submit/done.html:77 src/olympia/devhub/templates/devhub/personas/submit_done.html:16
 msgid "Next steps:"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/addons/submit/done.html:32
-#: src/olympia/devhub/templates/devhub/addons/submit/done.html:82
+#: src/olympia/devhub/templates/devhub/addons/submit/done.html:32 src/olympia/devhub/templates/devhub/addons/submit/done.html:82
 msgid "<a href=\"{0}\">Upload</a> another platform-specific file to this version."
 msgstr ""
 
@@ -6006,19 +5034,14 @@ msgid "Provide more details by <a href=\"{0}\">editing its listing</a>."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/submit/done.html:35
-msgid ""
-"Tell your users why you created this in your <a href=\"{0}\">Developer "
-"Profile</a>."
+msgid "Tell your users why you created this in your <a href=\"{0}\">Developer Profile</a>."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/submit/done.html:36
-msgid ""
-"View and subscribe to your add-on's <a href=\"{0}\">activity feed</a> to "
-"stay updated on reviews, collections, and more."
+msgid "View and subscribe to your add-on's <a href=\"{0}\">activity feed</a> to stay updated on reviews, collections, and more."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/addons/submit/done.html:37
-#: src/olympia/devhub/templates/devhub/addons/submit/done.html:86
+#: src/olympia/devhub/templates/devhub/addons/submit/done.html:37 src/olympia/devhub/templates/devhub/addons/submit/done.html:86
 msgid "View approximate review queue <a href=\"{0}\">wait times</a>."
 msgstr ""
 
@@ -6031,13 +5054,11 @@ msgid "Become an AMO Reviewer today and get your add-ons reviewed faster."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/submit/done.html:54
-msgid ""
-"Your add-on has been signed and it's ready to use. You can download it here:"
+msgid "Your add-on has been signed and it's ready to use. You can download it here:"
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/submit/done.html:64
-msgid ""
-"Your add-on has been submitted to the Unlisted Preliminary Review queue."
+msgid "Your add-on has been submitted to the Unlisted Preliminary Review queue."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/submit/done.html:66
@@ -6045,8 +5066,7 @@ msgid "Your add-on has been submitted to the Unlisted Full Review queue."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/submit/done.html:70
-msgid ""
-"You'll receive an email once it has been reviewed by an editor and signed."
+msgid "You'll receive an email once it has been reviewed by an editor and signed."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/submit/done.html:74
@@ -6054,9 +5074,7 @@ msgid "Your add-on will not be publicly available on this website."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/submit/done.html:84
-msgid ""
-"You can upload new versions of your add-on in the <a href=\"{0}\">add-on's "
-"developer page</a>."
+msgid "You can upload new versions of your add-on in the <a href=\"{0}\">add-on's developer page</a>."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/submit/license.html:4
@@ -6068,10 +5086,7 @@ msgid "Step 5. Select a License"
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/submit/license.html:9
-msgid ""
-"We require all add-ons to indicate the terms under which their source code "
-"is licensed. Please select a license from the list below or enter a custom "
-"license."
+msgid "We require all add-ons to indicate the terms under which their source code is licensed. Please select a license from the list below or enter a custom license."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/submit/license.html:18
@@ -6088,9 +5103,8 @@ msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/submit/media.html:9
 msgid ""
-"Custom icons and screenshots draw attention and help users understand what "
-"it does. We strongly recommend uploading a custom icon, as in some areas of "
-"the website, only the icon and name will appear."
+"Custom icons and screenshots draw attention and help users understand what it does. We strongly recommend uploading a custom icon, as in some areas of the website, only the icon and name will "
+"appear."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/submit/select-review.html:5
@@ -6103,17 +5117,13 @@ msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/submit/select-review.html:10
 msgid ""
-"All add-ons hosted in our gallery must be reviewed by an editor before they "
-"appear in categories or search results. While waiting for review, your add-"
-"on can still be accessed through its direct URL. Please choose the review "
-"process below that best fits your add-on."
+"All add-ons hosted in our gallery must be reviewed by an editor before they appear in categories or search results. While waiting for review, your add-on can still be accessed through its direct "
+"URL. Please choose the review process below that best fits your add-on."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/submit/select-review.html:26
 #, python-format
-msgid ""
-"A complete review of your add-on's source and functionality. <a "
-"href=\"%(url)s\">Learn more&hellip;</a>"
+msgid "A complete review of your add-on's source and functionality. <a href=\"%(url)s\">Learn more&hellip;</a>"
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/submit/select-review.html:32
@@ -6142,9 +5152,7 @@ msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/submit/select-review.html:49
 #, python-format
-msgid ""
-"A faster review of your add-on's source for any major problems. <a "
-"href=\"%(url)s\">Learn more&hellip;</a>"
+msgid "A faster review of your add-on's source for any major problems. <a href=\"%(url)s\">Learn more&hellip;</a>"
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/submit/select-review.html:55
@@ -6191,10 +5199,8 @@ msgstr ""
 msgid "Select a review process"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/addons/submit/sidebar.html:18
-#: src/olympia/devhub/templates/devhub/docs/policies-submission.html:3
-#: src/olympia/devhub/templates/devhub/docs/policies-submission.html:7
-#: src/olympia/devhub/templates/devhub/docs/policies-submission.html:9
+#: src/olympia/devhub/templates/devhub/addons/submit/sidebar.html:18 src/olympia/devhub/templates/devhub/docs/policies-submission.html:3
+#: src/olympia/devhub/templates/devhub/docs/policies-submission.html:7 src/olympia/devhub/templates/devhub/docs/policies-submission.html:9
 msgid "Submission Process"
 msgstr ""
 
@@ -6215,24 +5221,18 @@ msgid "Step 2. Upload Your Add-on"
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/submit/upload.html:11
-msgid ""
-"Use the fields below to upload your add-on package and select any platform "
-"restrictions. After upload, a series of automated validation tests will be "
-"run on your file."
+msgid "Use the fields below to upload your add-on package and select any platform restrictions. After upload, a series of automated validation tests will be run on your file."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/addons/submit/upload.html:59
-#: src/olympia/devhub/templates/devhub/versions/add_file_modal.html:39
+#: src/olympia/devhub/templates/devhub/addons/submit/upload.html:51 src/olympia/devhub/templates/devhub/versions/add_file_modal.html:28
 msgid "Which platforms is this file compatible with?"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/addons/submit/upload.html:67
-#: src/olympia/devhub/templates/devhub/versions/add_file_modal.html:65
+#: src/olympia/devhub/templates/devhub/addons/submit/upload.html:59 src/olympia/devhub/templates/devhub/versions/add_file_modal.html:45
 msgid "Administrative overrides"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/api/agreement.html:3
-#: src/olympia/devhub/templates/devhub/api/agreement.html:11
+#: src/olympia/devhub/templates/devhub/api/agreement.html:3 src/olympia/devhub/templates/devhub/api/agreement.html:11
 msgid "Firefox Add-on Distribution Agreement"
 msgstr ""
 
@@ -6242,9 +5242,7 @@ msgstr ""
 
 #: src/olympia/devhub/templates/devhub/api/key.html:20
 #, python-format
-msgid ""
-"For detailed instructions, consult the <a href=\"%(docs_url)s\">API "
-"documentation</a>."
+msgid "For detailed instructions, consult the <a href=\"%(docs_url)s\">API documentation</a>."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/api/key.html:28
@@ -6258,10 +5256,8 @@ msgstr ""
 #: src/olympia/devhub/templates/devhub/api/key.html:37
 #, python-format
 msgid ""
-"To make API requests, send a <a href=\"%(jwt_url)s\">JSON Web Token "
-"(JWT)</a> as the authorization header. You'll need to generate a JWT for "
-"every request as explained in the <a href=\"%(docs_url)s\">API "
-"documentation</a>."
+"To make API requests, send a <a href=\"%(jwt_url)s\">JSON Web Token (JWT)</a> as the authorization header. You'll need to generate a JWT for every request as explained in the <a href=\"%(docs_url)s"
+"\">API documentation</a>."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/api/key.html:47
@@ -6270,9 +5266,7 @@ msgstr ""
 
 #: src/olympia/devhub/templates/devhub/api/key.html:53
 #, python-format
-msgid ""
-"This feature is under active development. If you find a problem please <a "
-"target=\"_blank\" href=\"%(bug_link)s\">report a bug</a>."
+msgid "This feature is under active development. If you find a problem please <a target=\"_blank\" href=\"%(bug_link)s\">report a bug</a>."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/api/key.html:61
@@ -6283,29 +5277,19 @@ msgstr ""
 msgid "Generate new credentials"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/docs/policies-agreement.html:3
-#: src/olympia/devhub/templates/devhub/docs/policies-agreement.html:7
-#: src/olympia/devhub/templates/devhub/docs/policies-agreement.html:9
-#: src/olympia/devhub/templates/devhub/docs/policies.html:24
-#: src/olympia/devhub/templates/devhub/docs/policies.html:103
+#: src/olympia/devhub/templates/devhub/docs/policies-agreement.html:3 src/olympia/devhub/templates/devhub/docs/policies-agreement.html:7
+#: src/olympia/devhub/templates/devhub/docs/policies-agreement.html:9 src/olympia/devhub/templates/devhub/docs/policies.html:24 src/olympia/devhub/templates/devhub/docs/policies.html:103
 msgid "Developer Agreement"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/docs/policies-contact.html:3
-#: src/olympia/devhub/templates/devhub/docs/policies-contact.html:7
-#: src/olympia/devhub/templates/devhub/docs/policies-contact.html:9
-#: src/olympia/devhub/templates/devhub/docs/policies.html:27
-#: src/olympia/devhub/templates/devhub/docs/policies.html:115
+#: src/olympia/devhub/templates/devhub/docs/policies-contact.html:3 src/olympia/devhub/templates/devhub/docs/policies-contact.html:7 src/olympia/devhub/templates/devhub/docs/policies-contact.html:9
+#: src/olympia/devhub/templates/devhub/docs/policies.html:27 src/olympia/devhub/templates/devhub/docs/policies.html:115
 msgid "Contacting Us"
 msgstr "Ota meihin yhteyttä"
 
 #: src/olympia/devhub/templates/devhub/docs/policies-contact.html:12
-msgid ""
-"Thanks for your interest in contacting the Mozilla Add-ons team. Please read"
-" this page carefully to ensure your request goes to the right place."
-msgstr ""
-"Kiitos mielenkiinnostasi yhteydenottoon. Lue tämä sivu huolellisesti, jotta "
-"pyyntösi menee oikeaan paikkaan."
+msgid "Thanks for your interest in contacting the Mozilla Add-ons team. Please read this page carefully to ensure your request goes to the right place."
+msgstr "Kiitos mielenkiinnostasi yhteydenottoon. Lue tämä sivu huolellisesti, jotta pyyntösi menee oikeaan paikkaan."
 
 #: src/olympia/devhub/templates/devhub/docs/policies-contact.html:17
 msgid "Add-on Support"
@@ -6313,14 +5297,11 @@ msgstr "Lisäosien tuki"
 
 #: src/olympia/devhub/templates/devhub/docs/policies-contact.html:19
 msgid ""
-"If you have a support question about a particular add-on, such as \"how do I"
-" use this add-on?\" or \"why doesn't this work properly?\", please contact "
-"that add-on's author through the support channels listed on the add-on's "
-"listing page."
+"If you have a support question about a particular add-on, such as \"how do I use this add-on?\" or \"why doesn't this work properly?\", please contact that add-on's author through the support "
+"channels listed on the add-on's listing page."
 msgstr ""
-"Jos sinulla on kysymyksiä tiettyä lisäosaa koskien, kuten \"kuinka käytän "
-"tätä lisäosaa?\" tai \"miksi tämä ei toimi kunnolla?\", ota yhteyttä "
-"lisäosan luojaan lisäosan sivulla mainittujen tukikanavien kautta."
+"Jos sinulla on kysymyksiä tiettyä lisäosaa koskien, kuten \"kuinka käytän tätä lisäosaa?\" tai \"miksi tämä ei toimi kunnolla?\", ota yhteyttä lisäosan luojaan lisäosan sivulla mainittujen "
+"tukikanavien kautta."
 
 #: src/olympia/devhub/templates/devhub/docs/policies-contact.html:24
 msgid "Add-on Editorial Concerns"
@@ -6333,11 +5314,8 @@ msgstr ""
 #: src/olympia/devhub/templates/devhub/docs/policies-contact.html:26
 #, python-format
 msgid ""
-"If you have a question about an Editor's review of an add-on or want to "
-"report a policy violation, please email %(mail_editors)s. <strong>Almost all"
-" add-on reports fall under this category.</strong> Please be sure to include"
-" a link to the add-on in question and a detailed description of your "
-"question or comment."
+"If you have a question about an Editor's review of an add-on or want to report a policy violation, please email %(mail_editors)s. <strong>Almost all add-on reports fall under this category.</"
+"strong> Please be sure to include a link to the add-on in question and a detailed description of your question or comment."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/docs/policies-contact.html:31
@@ -6351,13 +5329,9 @@ msgstr ""
 #: src/olympia/devhub/templates/devhub/docs/policies-contact.html:36
 #, python-format
 msgid ""
-"If you have discovered a security vulnerability in an add-on, even if it is "
-"not hosted here, Mozilla is very interested in your discovery and will work "
-"with the add-on developer to correct the issue as soon as possible. Add-on "
-"security issues can be reported <a "
-"href=\"http://www.mozilla.org/projects/security/security-bugs-"
-"policy.html\">confidentially</a> in <a "
-"href=\"%(link_bugzilla)s\">Bugzilla</a> or by emailing %(mail_admins)s."
+"If you have discovered a security vulnerability in an add-on, even if it is not hosted here, Mozilla is very interested in your discovery and will work with the add-on developer to correct the "
+"issue as soon as possible. Add-on security issues can be reported <a href=\"http://www.mozilla.org/projects/security/security-bugs-policy.html\">confidentially</a> in <a href=\"%(link_bugzilla)s"
+"\">Bugzilla</a> or by emailing %(mail_admins)s."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/docs/policies-contact.html:42
@@ -6366,13 +5340,11 @@ msgstr ""
 
 #: src/olympia/devhub/templates/devhub/docs/policies-contact.html:44
 msgid ""
-"If you've found a problem with the site, we'd love to fix it. Please <a "
-"href=\"https://github.com/mozilla/olympia/issues\">file a bug report</a> in "
-"GitHub, including the location of the problem and how you encountered it."
+"If you've found a problem with the site, we'd love to fix it. Please <a href=\"https://github.com/mozilla/addons/issues/new\">file a bug report</a> in GitHub, including the location of the problem "
+"and how you encountered it."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/docs/policies-maintenance.html:3
-#: src/olympia/devhub/templates/devhub/docs/policies-maintenance.html:7
+#: src/olympia/devhub/templates/devhub/docs/policies-maintenance.html:3 src/olympia/devhub/templates/devhub/docs/policies-maintenance.html:7
 #: src/olympia/devhub/templates/devhub/docs/policies-maintenance.html:8
 msgid "Maintaining Your Add-ons"
 msgstr ""
@@ -6383,20 +5355,13 @@ msgstr ""
 
 #: src/olympia/devhub/templates/devhub/docs/policies-maintenance.html:12
 msgid ""
-"Developers are encouraged to submit updates to their add-ons to fix bugs, "
-"add features, and otherwise improve their product. New versions of an add-on"
-" must have a <a "
-"href=\"https://developer.mozilla.org/en/Toolkit_version_format\">higher "
-"version number</a> and can be submitted through the Developer Tools "
-"provided. There is no limit to the number of versions that can be submitted,"
-" but please remember that versions must be reviewed by an editor."
+"Developers are encouraged to submit updates to their add-ons to fix bugs, add features, and otherwise improve their product. New versions of an add-on must have a <a href=\"https://developer."
+"mozilla.org/en/Toolkit_version_format\">higher version number</a> and can be submitted through the Developer Tools provided. There is no limit to the number of versions that can be submitted, but "
+"please remember that versions must be reviewed by an editor."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/docs/policies-maintenance.html:18
-msgid ""
-"New versions will be added to a pending review queue, and any additional "
-"versions submitted before the review is completed will move that version to "
-"the end of the queue."
+msgid "New versions will be added to a pending review queue, and any additional versions submitted before the review is completed will move that version to the end of the queue."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/docs/policies-maintenance.html:23
@@ -6409,31 +5374,22 @@ msgstr ""
 
 #: src/olympia/devhub/templates/devhub/docs/policies-maintenance.html:31
 msgid ""
-"To create a beta channel, upload a file with a unique version string that "
-"contains any of the following strings: <code>a,b,alpha,beta,pre,rc</code>, "
-"with an optional number at the end. This text must come at the end of the "
-"version string. If you understand regex format, here's what we look for in "
-"the version number: <code>\"(a|alpha|b|beta|pre|rc)\\d*$\"</code>."
+"To create a beta channel, upload a file with a unique version string that contains any of the following strings: <code>a,b,alpha,beta,pre,rc</code>, with an optional number at the end. This text "
+"must come at the end of the version string. If you understand regex format, here's what we look for in the version number: <code>\"(a|alpha|b|beta|pre|rc)\\d*$\"</code>."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/docs/policies-maintenance.html:37
 msgid ""
-"Once a file meeting this criteria is uploaded to AMO, it will automatically "
-"be marked as a beta version. Users of add-ons with these unique version "
-"numbers will automatically be served the newest beta updates."
+"Once a file meeting this criteria is uploaded to AMO, it will automatically be marked as a beta version. Users of add-ons with these unique version numbers will automatically be served the newest "
+"beta updates."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/docs/policies-maintenance.html:43
 msgid ""
-"While we call these \"Beta versions\", you can use this channel for "
-"nightlies, or alphas, or prerelease versions as you wish. Please note that "
-"there is only one channel for this purpose and all of your users on this "
-"channel will receive the latest add-ons submitted. For instance, if you "
-"upload <code>1.0beta1</code> to the release channel and then upload "
-"<code>1.1alpha1</code>, all users of <code>1.0beta1</code> will be offered "
-"an upgrade to <code>1.1alpha1</code>. Updates are pushed by submission date "
-"and not version number, so users will always get the most recent channel "
-"update regardless of any kind of alphabetical sorting."
+"While we call these \"Beta versions\", you can use this channel for nightlies, or alphas, or prerelease versions as you wish. Please note that there is only one channel for this purpose and all of "
+"your users on this channel will receive the latest add-ons submitted. For instance, if you upload <code>1.0beta1</code> to the release channel and then upload <code>1.1alpha1</code>, all users of "
+"<code>1.0beta1</code> will be offered an upgrade to <code>1.1alpha1</code>. Updates are pushed by submission date and not version number, so users will always get the most recent channel update "
+"regardless of any kind of alphabetical sorting."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/docs/policies-maintenance.html:48
@@ -6442,13 +5398,9 @@ msgstr ""
 
 #: src/olympia/devhub/templates/devhub/docs/policies-maintenance.html:50
 msgid ""
-"Certain situations may arise in which Mozilla requests that an add-on "
-"developer update their add-on within a given time period to address a major "
-"security issue or policy violation. We work with developers to reasonably "
-"accommodate their own schedules, but if the issue is of a serious enough "
-"nature, add-ons that cannot issue an update with the requested fix may be "
-"demoted from fully-reviewed status, disabled, or permanently removed from "
-"the site."
+"Certain situations may arise in which Mozilla requests that an add-on developer update their add-on within a given time period to address a major security issue or policy violation. We work with "
+"developers to reasonably accommodate their own schedules, but if the issue is of a serious enough nature, add-ons that cannot issue an update with the requested fix may be demoted from fully-"
+"reviewed status, disabled, or permanently removed from the site."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/docs/policies-maintenance.html:55
@@ -6457,43 +5409,32 @@ msgstr ""
 
 #: src/olympia/devhub/templates/devhub/docs/policies-maintenance.html:57
 msgid ""
-"Add-ons can have multiple users with permission to update and manage the "
-"listing. Existing authors of an add-on can transfer ownership and add "
-"additional developers to an add-on's listing through the Developer Tools "
-"provided. No interaction with Mozilla representatives is necessary for a "
-"transfer of ownership."
+"Add-ons can have multiple users with permission to update and manage the listing. Existing authors of an add-on can transfer ownership and add additional developers to an add-on's listing through "
+"the Developer Tools provided. No interaction with Mozilla representatives is necessary for a transfer of ownership."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/docs/policies-maintenance.html:63
 #, python-format
-msgid ""
-"Mozilla can assist with granting additional permissions of an add-on's "
-"listing if <a href=\"%(link_contact)s\">contacted</a> by the add-on's "
-"current owner."
+msgid "Mozilla can assist with granting additional permissions of an add-on's listing if <a href=\"%(link_contact)s\">contacted</a> by the add-on's current owner."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/docs/policies-maintenance.html:70
 msgid ""
-"Mozilla encourages its users to offer feedback on their experiences when "
-"using an add-on. This allows other users to determine if the add-on is "
-"stable and useful. It also provides valuable feedback to developers, "
-"allowing them to continuously improve their add-on to meet user needs."
+"Mozilla encourages its users to offer feedback on their experiences when using an add-on. This allows other users to determine if the add-on is stable and useful. It also provides valuable feedback "
+"to developers, allowing them to continuously improve their add-on to meet user needs."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/docs/policies-maintenance.html:76
 #, python-format
 msgid ""
-"Reviews must follow the <a href=\"%(link_guidelines)s\">review "
-"guidelines</a>. Reviews that do not meet these guidelines may be flagged for"
-" moderation, but negative reviews will not be removed unless they provide "
-"false information."
+"Reviews must follow the <a href=\"%(link_guidelines)s\">review guidelines</a>. Reviews that do not meet these guidelines may be flagged for moderation, but negative reviews will not be removed "
+"unless they provide false information."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/docs/policies-maintenance.html:82
 msgid ""
-"Many developers provide a support mechanism, such as a forum, discussion "
-"group, or email address. It is recommended that support questions be posted "
-"via those mediums instead of in an add-on's review section."
+"Many developers provide a support mechanism, such as a forum, discussion group, or email address. It is recommended that support questions be posted via those mediums instead of in an add-on's "
+"review section."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/docs/policies-maintenance.html:87
@@ -6502,31 +5443,21 @@ msgstr ""
 
 #: src/olympia/devhub/templates/devhub/docs/policies-maintenance.html:90
 msgid ""
-"Many add-ons allow their source code to be openly viewed. This does not mean"
-" that the source code is open source or available for use in another add-on."
-" The original author of an add-on retains copyright of their work unless "
-"otherwise noted in the add-on's license."
+"Many add-ons allow their source code to be openly viewed. This does not mean that the source code is open source or available for use in another add-on. The original author of an add-on retains "
+"copyright of their work unless otherwise noted in the add-on's license."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/docs/policies-maintenance.html:96
 msgid ""
-"In the event that we're notified of a copyright or license infringement, we "
-"will take steps to review the situation and determine if an actual "
-"infringement has occurred. If we determine that there is an infringement, we"
-" will remove the offending add-on and contact the author. New add-on "
-"submissions (including updates) containing infringing code will be denied "
-"approval for public status."
+"In the event that we're notified of a copyright or license infringement, we will take steps to review the situation and determine if an actual infringement has occurred. If we determine that there "
+"is an infringement, we will remove the offending add-on and contact the author. New add-on submissions (including updates) containing infringing code will be denied approval for public status."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/docs/policies-maintenance.html:102
-msgid ""
-"If you are unsure of the current copyright status of an add-on's source "
-"code, you must contact the original author and receive explicit permission "
-"before using the source code."
+msgid "If you are unsure of the current copyright status of an add-on's source code, you must contact the original author and receive explicit permission before using the source code."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/docs/policies-maintenance.html:107
-#: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:306
+#: src/olympia/devhub/templates/devhub/docs/policies-maintenance.html:107 src/olympia/devhub/templates/devhub/docs/policies-reviews.html:306
 #: src/olympia/devhub/templates/devhub/docs/policies-submission.html:97
 msgid "Last updated: January 13, 2011"
 msgstr "Päivitetty viimeksi: 13. tammikuuta 2011"
@@ -6534,25 +5465,18 @@ msgstr "Päivitetty viimeksi: 13. tammikuuta 2011"
 #: src/olympia/devhub/templates/devhub/docs/policies-recommended.html:13
 #, python-format
 msgid ""
-"Featured add-ons are top-quality extensions and themes highlighted on <a "
-"href=\"%(link_gallery)s\">AMO</a>, Firefox's Add-ons Manager, and across "
-"other Mozilla websites. These add-ons showcase the power of Firefox "
-"customization and are useful to a wide audience."
+"Featured add-ons are top-quality extensions and themes highlighted on <a href=\"%(link_gallery)s\">AMO</a>, Firefox's Add-ons Manager, and across other Mozilla websites. These add-ons showcase the "
+"power of Firefox customization and are useful to a wide audience."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/docs/policies-recommended.html:19
 msgid ""
-"Featured add-ons are chosen by the Featured Add-ons Advisory Board, a small "
-"group of add-on developers and fans from the Mozilla community who have "
-"volunteered to review and vote on nominations."
+"Featured add-ons are chosen by the Featured Add-ons Advisory Board, a small group of add-on developers and fans from the Mozilla community who have volunteered to review and vote on nominations."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/docs/policies-recommended.html:25
 #, python-format
-msgid ""
-"<a href=\"%(link_featured)s\">Featured extensions</a> are chosen every "
-"month, and <a href=\"%(link_themes)s\">featured complete themes</a> are "
-"chosen every quarter."
+msgid "<a href=\"%(link_featured)s\">Featured extensions</a> are chosen every month, and <a href=\"%(link_themes)s\">featured complete themes</a> are chosen every quarter."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/docs/policies-recommended.html:30
@@ -6560,14 +5484,11 @@ msgid "Criteria for Featured Add-ons"
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/docs/policies-recommended.html:33
-msgid ""
-"Before nominating an add-on to be featured, please ensure it meets the "
-"following criteria:"
+msgid "Before nominating an add-on to be featured, please ensure it meets the following criteria:"
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/docs/policies-recommended.html:39
-msgid ""
-"The add-on must have a complete and informative listing on AMO. This means:"
+msgid "The add-on must have a complete and informative listing on AMO. This means:"
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/docs/policies-recommended.html:41
@@ -6591,14 +5512,11 @@ msgid "updated screenshots of the add-on's functionality"
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/docs/policies-recommended.html:46
-msgid ""
-"must be fully approved by AMO editors (no preliminarily reviewed entries)"
+msgid "must be fully approved by AMO editors (no preliminarily reviewed entries)"
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/docs/policies-recommended.html:48
-msgid ""
-"The add-on must have excellent user reviews and any problems or support "
-"requests must be promptly addressed by the developer."
+msgid "The add-on must have excellent user reviews and any problems or support requests must be promptly addressed by the developer."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/docs/policies-recommended.html:49
@@ -6606,17 +5524,13 @@ msgid "The add-on must have a minimum of 2,000 users."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/docs/policies-recommended.html:50
-msgid ""
-"The add-on must be compatible with the latest release of Firefox and must be"
-" compatible with beta versions 4 weeks before their final release."
+msgid "The add-on must be compatible with the latest release of Firefox and must be compatible with beta versions 4 weeks before their final release."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/docs/policies-recommended.html:51
 msgid ""
-"<strong>Most importantly</strong>, the add-on must have wide consumer appeal"
-" to Firefox's users and be outstanding in nearly every way: user experience,"
-" performance, security, and usefulness or entertainment value. Featured "
-"complete themes must also be visually appealing."
+"<strong>Most importantly</strong>, the add-on must have wide consumer appeal to Firefox's users and be outstanding in nearly every way: user experience, performance, security, and usefulness or "
+"entertainment value. Featured complete themes must also be visually appealing."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/docs/policies-recommended.html:54
@@ -6629,9 +5543,7 @@ msgstr ""
 
 #: src/olympia/devhub/templates/devhub/docs/policies-recommended.html:57
 #, python-format
-msgid ""
-"If you wish to nominate an add-on to be featured and it meets the criteria "
-"above, send an email to %(mail_featured)s with:"
+msgid "If you wish to nominate an add-on to be featured and it meets the criteria above, send an email to %(mail_featured)s with:"
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/docs/policies-recommended.html:62
@@ -6639,22 +5551,17 @@ msgid "the add-on name, URL, and whether you are its developer"
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/docs/policies-recommended.html:63
-msgid ""
-"a short explanation of why the add-on has wide appeal and should be featured"
+msgid "a short explanation of why the add-on has wide appeal and should be featured"
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/docs/policies-recommended.html:64
-msgid ""
-"optionally, links to any external reviews or articles mentioning the add-on"
+msgid "optionally, links to any external reviews or articles mentioning the add-on"
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/docs/policies-recommended.html:68
 msgid ""
-"Add-on nominations are reviewed by the Advisory Board once a month (once "
-"every 3 months for complete theme nominations). Common reasons for rejection"
-" include lacking wide appeal to consumers, a suboptimal user experience, "
-"quality or security issues, incompatibility, and similarity to another "
-"featured add-on. Rejected add-ons cannot be re-nominated within 3 months."
+"Add-on nominations are reviewed by the Advisory Board once a month (once every 3 months for complete theme nominations). Common reasons for rejection include lacking wide appeal to consumers, a "
+"suboptimal user experience, quality or security issues, incompatibility, and similarity to another featured add-on. Rejected add-ons cannot be re-nominated within 3 months."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/docs/policies-recommended.html:73
@@ -6662,32 +5569,23 @@ msgid "Rotating Featured Add-ons"
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/docs/policies-recommended.html:76
-msgid ""
-"Mozilla and the Featured Add-ons Advisory Board regularly evaluate and "
-"rotate out featured add-ons. Some of the most common reasons for add-ons "
-"being removed from the featured list are:"
+msgid "Mozilla and the Featured Add-ons Advisory Board regularly evaluate and rotate out featured add-ons. Some of the most common reasons for add-ons being removed from the featured list are:"
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/docs/policies-recommended.html:83
 msgid ""
-"Lack of growth &mdash; Add-ons that are featured typically experience a "
-"substantial gain in both downloads and active users. If an add-on is not "
-"demonstrating growth in any substantial way, that's a good indicator the "
-"add-on may not be very useful to our users."
+"Lack of growth &mdash; Add-ons that are featured typically experience a substantial gain in both downloads and active users. If an add-on is not demonstrating growth in any substantial way, that's "
+"a good indicator the add-on may not be very useful to our users."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/docs/policies-recommended.html:88
-msgid ""
-"Negative reviews &mdash; Featured add-ons should have a great experience and"
-" very few bugs, so add-ons with many negative reviews may be reconsidered."
+msgid "Negative reviews &mdash; Featured add-ons should have a great experience and very few bugs, so add-ons with many negative reviews may be reconsidered."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/docs/policies-recommended.html:93
 msgid ""
-"Incompatibility with upcoming Firefox versions &mdash; Featured add-ons are "
-"expected to be compatible with stable and beta versions of Firefox. Add-ons "
-"not yet compatible with a Beta version of Firefox four weeks before its "
-"expected release will lose their featured status."
+"Incompatibility with upcoming Firefox versions &mdash; Featured add-ons are expected to be compatible with stable and beta versions of Firefox. Add-ons not yet compatible with a Beta version of "
+"Firefox four weeks before its expected release will lose their featured status."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/docs/policies-recommended.html:99
@@ -6695,121 +5593,87 @@ msgid "Joining the Featured Add-ons Advisory Board"
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/docs/policies-recommended.html:102
-msgid ""
-"Every six months a new Advisory Board is chosen based on applications from "
-"the add-ons community. Members must:"
+msgid "Every six months a new Advisory Board is chosen based on applications from the add-ons community. Members must:"
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/docs/policies-recommended.html:108
-msgid ""
-"be active members of the add-ons community, whether as a developer, "
-"evangelist, or fan"
+msgid "be active members of the add-ons community, whether as a developer, evangelist, or fan"
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/docs/policies-recommended.html:109
-msgid ""
-"commit to trying all the nominations submitted, giving their feedback, and "
-"casting their votes every month"
+msgid "commit to trying all the nominations submitted, giving their feedback, and casting their votes every month"
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/docs/policies-recommended.html:110
-msgid ""
-"abstain from voting on add-ons that they have any business or personal "
-"affiliations with, as well as direct competitors of any such add-ons"
+msgid "abstain from voting on add-ons that they have any business or personal affiliations with, as well as direct competitors of any such add-ons"
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/docs/policies-recommended.html:114
 msgid ""
-"Members of the Mozilla Add-ons team may veto any add-on's selection because "
-"of security, privacy, compatibility, or any other reason, but in general it "
-"is up to the Board to select add-ons to feature."
+"Members of the Mozilla Add-ons team may veto any add-on's selection because of security, privacy, compatibility, or any other reason, but in general it is up to the Board to select add-ons to "
+"feature."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/docs/policies-recommended.html:120
 msgid ""
-"This featured policy only applies to the addons.mozilla.org global list of "
-"featured add-ons. Add-ons featured in other locations are often pulled from "
-"this list, but Mozilla may feature any add-on in other locations without the"
-" Board's consent. Additionally, locale-specific features override the global"
-" defaults, so if a locale has opted to select its own features, some or all "
-"of the global features may not appear in that locale."
+"This featured policy only applies to the addons.mozilla.org global list of featured add-ons. Add-ons featured in other locations are often pulled from this list, but Mozilla may feature any add-on "
+"in other locations without the Board's consent. Additionally, locale-specific features override the global defaults, so if a locale has opted to select its own features, some or all of the global "
+"features may not appear in that locale."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/docs/policies-recommended.html:126
 #, python-format
-msgid ""
-"Follow the <a href=\"%(link_blog)s\">Add-ons Blog</a> or <a "
-"href=\"%(link_twitter)s\">@mozamo</a> on Twitter to learn when the next "
-"application period opens."
+msgid "Follow the <a href=\"%(link_blog)s\">Add-ons Blog</a> or <a href=\"%(link_twitter)s\">@mozamo</a> on Twitter to learn when the next application period opens."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/docs/policies-recommended.html:131
 msgid "Last updated: January 31, 2013"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:3
-#: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:7
-#: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:8
-#: src/olympia/devhub/templates/devhub/docs/policies.html:15
-#: src/olympia/devhub/templates/devhub/docs/policies.html:64
+#: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:3 src/olympia/devhub/templates/devhub/docs/policies-reviews.html:7 src/olympia/devhub/templates/devhub/docs/policies-reviews.html:8
+#: src/olympia/devhub/templates/devhub/docs/policies.html:15 src/olympia/devhub/templates/devhub/docs/policies.html:64
 msgid "Review Process"
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:12
 msgid ""
-"In order to ensure all add-ons hosted in our gallery are safe for users to "
-"install, Mozilla will begin requiring all hosted add-ons to undergo review. "
-"We offer two types of review and developers are free to choose the best fit "
-"for their add-on."
+"In order to ensure all add-ons hosted in our gallery are safe for users to install, Mozilla will begin requiring all hosted add-ons to undergo review. We offer two types of review and developers "
+"are free to choose the best fit for their add-on."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:19
 msgid ""
-"<strong><a href=\"#full\">Full Review</a></strong> &mdash; a thorough "
-"functional and code review of the add-on, appropriate for add-ons ready for "
-"distribution to the masses. All site features are available to these add-"
-"ons."
+"<strong><a href=\"#full\">Full Review</a></strong> &mdash; a thorough functional and code review of the add-on, appropriate for add-ons ready for distribution to the masses. All site features are "
+"available to these add-ons."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:24
 msgid ""
-"<strong><a href=\"#preliminary\">Preliminary Review</a></strong> &mdash; a "
-"faster review intended for experimental add-ons. Preliminary reviews do not "
-"check for functionality or full policy compliance, but the reviewed add-ons "
-"have install button cautions and some feature limitations."
+"<strong><a href=\"#preliminary\">Preliminary Review</a></strong> &mdash; a faster review intended for experimental add-ons. Preliminary reviews do not check for functionality or full policy "
+"compliance, but the reviewed add-ons have install button cautions and some feature limitations."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:31
 msgid ""
-"Detailed descriptions of each option are below. After selecting a review "
-"process at submission, the add-on will be placed in the queue. Add-ons are "
-"reviewed by the <a href=\"https://wiki.mozilla.org/AMO:Editors\">AMO "
-"Editors</a>, a group of talented developers that volunteer to help the "
-"Mozilla project by reviewing add-ons to ensure a stable and safe experience "
-"for users. Developers will receive an email with any updates throughout the "
-"review process."
+"Detailed descriptions of each option are below. After selecting a review process at submission, the add-on will be placed in the queue. Add-ons are reviewed by the <a href=\"https://wiki.mozilla."
+"org/AMO:Editors\">AMO Editors</a>, a group of talented developers that volunteer to help the Mozilla project by reviewing add-ons to ensure a stable and safe experience for users. Developers will "
+"receive an email with any updates throughout the review process."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:37
 msgid ""
-"While waiting for review, add-ons will not appear anywhere in the gallery "
-"publicly, but direct links to the add-on's details page will work. This "
-"allows the author to blog or share the link with friends, inviting them to "
-"try it out, even when not yet reviewed."
+"While waiting for review, add-ons will not appear anywhere in the gallery publicly, but direct links to the add-on's details page will work. This allows the author to blog or share the link with "
+"friends, inviting them to try it out, even when not yet reviewed."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:44
 msgid ""
-"Full reviews are appropriate for add-ons that are well-tested, stable, fast,"
-" and have wide appeal to our users. If you aren't confident that your add-on"
-" meets that criteria, please consider working out the kinks while in "
-"preliminary review and accumulating user feedback first."
+"Full reviews are appropriate for add-ons that are well-tested, stable, fast, and have wide appeal to our users. If you aren't confident that your add-on meets that criteria, please consider working "
+"out the kinks while in preliminary review and accumulating user feedback first."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:50
-msgid ""
-"We aim to perform full reviews in under 10 days, though most add-ons are "
-"reviewed in much less time."
+msgid "We aim to perform full reviews in under 10 days, though most add-ons are reviewed in much less time."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:55
@@ -6821,15 +5685,11 @@ msgid "When performing a full review, editors will:"
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:64
-msgid ""
-"install the add-on, making sure it functions as described and is free of "
-"major defects"
+msgid "install the add-on, making sure it functions as described and is free of major defects"
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:69
-msgid ""
-"perform a source code review, looking for performance and security best "
-"practices"
+msgid "perform a source code review, looking for performance and security best practices"
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:74
@@ -6837,28 +5697,21 @@ msgid "ensure the add-on's privacy policy is in line with its functionality"
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:79
-msgid ""
-"look for compliance with all of Mozilla's policies, detailed in these "
-"documents"
+msgid "look for compliance with all of Mozilla's policies, detailed in these documents"
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:86
-msgid ""
-"Some of the most common issues we see when performing these reviews are:"
+msgid "Some of the most common issues we see when performing these reviews are:"
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:93
 msgid ""
-"<strong>JavaScript namespace pollution</strong> &mdash; the most common "
-"violation. Be sure to <a "
-"href=\"https://developer.mozilla.org/en/XUL_School/JavaScript_Object_Management\">wrap"
-" your loose variables</a>"
+"<strong>JavaScript namespace pollution</strong> &mdash; the most common violation. Be sure to <a href=\"https://developer.mozilla.org/en/XUL_School/JavaScript_Object_Management\">wrap your loose "
+"variables</a>"
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:99
-msgid ""
-"proper preference naming - all preference names should begin with "
-"\"extensions.\", followed by the add-on name or some other unique identifier"
+msgid "proper preference naming - all preference names should begin with \"extensions.\", followed by the add-on name or some other unique identifier"
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:103
@@ -6904,67 +5757,49 @@ msgstr ""
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:117
 #, python-format
 msgid ""
-"For information on how to avoid these problems, please see our <a "
-"href=\"%(link_howto)s\">How-to Library</a>. Some of these practices, such as"
-" binary or obfuscated code, are allowed under certain conditions outlined "
-"below."
+"For information on how to avoid these problems, please see our <a href=\"%(link_howto)s\">How-to Library</a>. Some of these practices, such as binary or obfuscated code, are allowed under certain "
+"conditions outlined below."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:123
 #, python-format
 msgid ""
-"Many of the above restrictions are tested automatically by an extension "
-"scanner that will flag suspicious add-ons for editor review. You can read "
-"more about this scanner in the <a href=\"%(link_validation)s\">Validation "
-"Help</a> document."
+"Many of the above restrictions are tested automatically by an extension scanner that will flag suspicious add-ons for editor review. You can read more about this scanner in the <a href="
+"\"%(link_validation)s\">Validation Help</a> document."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:129
 msgid ""
-"If the add-on is site-specific, it is recommended that a test account is "
-"provided for use during the review process. Additionally, including detailed"
-" testing instructions will allow an editor to better understand how the add-"
-"on functions and expedite the testing process. This information can be "
-"placed in the Notes to Reviewer field when editing a version in the "
-"Developer Hub."
+"If the add-on is site-specific, it is recommended that a test account is provided for use during the review process. Additionally, including detailed testing instructions will allow an editor to "
+"better understand how the add-on functions and expedite the testing process. This information can be placed in the Notes to Reviewer field when editing a version in the Developer Hub."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:134
-#: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:168
+#: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:134 src/olympia/devhub/templates/devhub/docs/policies-reviews.html:168
 msgid "After the Review"
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:136
 msgid ""
-"Once an add-on is granted full review, it will immediately be available in "
-"the gallery, showing in browse and search results with a warning-free "
-"install button. All features, including voluntary contributions and beta "
-"channels will be available."
+"Once an add-on is granted full review, it will immediately be available in the gallery, showing in browse and search results with a warning-free install button. All features, including voluntary "
+"contributions and beta channels will be available."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:142
 msgid ""
-"Subsequent versions of the add-on will automatically be placed in the full "
-"review queue. Until the review is completed, the new version will only be "
-"displayed on the Version History page of the add-on. Once reviewed, the "
-"version will be updated across the site and deployed through the automatic "
-"update service."
+"Subsequent versions of the add-on will automatically be placed in the full review queue. Until the review is completed, the new version will only be displayed on the Version History page of the add-"
+"on. Once reviewed, the version will be updated across the site and deployed through the automatic update service."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:148
 msgid ""
-"If a version does not meet the criteria for full review, it can either be "
-"granted preliminary review or disabled if there is a security concern. The "
-"author will receive an email explaining the action taken and how to fix it. "
-"In most cases, the developer can simply fix the problem and re-submit for "
-"full review."
+"If a version does not meet the criteria for full review, it can either be granted preliminary review or disabled if there is a security concern. The author will receive an email explaining the "
+"action taken and how to fix it. In most cases, the developer can simply fix the problem and re-submit for full review."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:155
 msgid ""
-"Preliminary reviews are appropriate for experimental add-ons and provide a "
-"way to get user testing and feedback without going through the longer, more "
-"thorough review process. We aim to complete these reviews in under 3 days."
+"Preliminary reviews are appropriate for experimental add-ons and provide a way to get user testing and feedback without going through the longer, more thorough review process. We aim to complete "
+"these reviews in under 3 days."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:160
@@ -6973,36 +5808,25 @@ msgstr ""
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:162
 msgid ""
-"When performing a preliminary review, editors will review the source code "
-"for security issues and major policy violations, but will not install the "
-"add-on to test functionality in most cases. Preliminary review will be "
-"granted unless a security vulnerability or major policy violation is "
-"discovered."
+"When performing a preliminary review, editors will review the source code for security issues and major policy violations, but will not install the add-on to test functionality in most cases. "
+"Preliminary review will be granted unless a security vulnerability or major policy violation is discovered."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:171
 msgid ""
-"Once preliminary review is granted, the add-on will be immediately available"
-" in the gallery, showing in browse and search results but ranked lower than "
-"fully-reviewed add-ons. Install buttons will have caution stripes and a "
-"notice that the add-on is experimental and not fully reviewed by Mozilla, "
-"though no click-through is required. Additionally, these add-ons cannot use "
-"the voluntary contributions and beta channel features."
+"Once preliminary review is granted, the add-on will be immediately available in the gallery, showing in browse and search results but ranked lower than fully-reviewed add-ons. Install buttons will "
+"have caution stripes and a notice that the add-on is experimental and not fully reviewed by Mozilla, though no click-through is required. Additionally, these add-ons cannot use the voluntary "
+"contributions and beta channel features."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:177
-msgid ""
-"After being granted preliminary review, Mozilla may later revoke the review "
-"if other serious problems are reported to us by users."
+msgid "After being granted preliminary review, Mozilla may later revoke the review if other serious problems are reported to us by users."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:183
 msgid ""
-"Subsequent versions of the add-on will automatically be placed in the "
-"preliminary review queue. Until the review is completed, the new version "
-"will only be displayed on the Version History page of the add-on. Once "
-"reviewed, the version will be updated across the site and deployed through "
-"the automatic update service."
+"Subsequent versions of the add-on will automatically be placed in the preliminary review queue. Until the review is completed, the new version will only be displayed on the Version History page of "
+"the add-on. Once reviewed, the version will be updated across the site and deployed through the automatic update service."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:188
@@ -7018,41 +5842,29 @@ msgid "The following add-ons are not permitted in any form:"
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:194
-msgid ""
-"Add-ons that embed known <a "
-"href=\"http://en.wikipedia.org/wiki/Spyware\">spyware</a> or <a "
-"href=\"http://en.wikipedia.org/wiki/Malware\">malware</a>"
+msgid "Add-ons that embed known <a href=\"http://en.wikipedia.org/wiki/Spyware\">spyware</a> or <a href=\"http://en.wikipedia.org/wiki/Malware\">malware</a>"
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:199
 msgid ""
-"Illegal and criminal add-ons, such as <a "
-"href=\"http://en.wikipedia.org/wiki/Click_fraud\">click fraud</a> "
-"generators, <a href=\"http://en.wikipedia.org/wiki/Warez\">warez</a> "
-"download and directory assistants, child pornography finders, etc."
+"Illegal and criminal add-ons, such as <a href=\"http://en.wikipedia.org/wiki/Click_fraud\">click fraud</a> generators, <a href=\"http://en.wikipedia.org/wiki/Warez\">warez</a> download and "
+"directory assistants, child pornography finders, etc."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:204
-msgid ""
-"Add-ons whose main purpose is to facilitate access to pornographic material,"
-" or include references to this material in their descriptions"
+msgid "Add-ons whose main purpose is to facilitate access to pornographic material, or include references to this material in their descriptions"
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:210
-msgid ""
-"Add-ons that, upon installation, auto-install or launch installers of non-"
-"Firefox software"
+msgid "Add-ons that, upon installation, auto-install or launch installers of non-Firefox software"
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:215
-msgid ""
-"Add-ons that provide their own update mechanism for code or search engines"
+msgid "Add-ons that provide their own update mechanism for code or search engines"
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:220
-msgid ""
-"Add-ons that make changes to web content in ways that are non-obvious or "
-"difficult to trace by their users"
+msgid "Add-ons that make changes to web content in ways that are non-obvious or difficult to trace by their users"
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:225
@@ -7069,41 +5881,25 @@ msgstr ""
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:238
 msgid ""
-"Surprises can be appropriate in many situations, but they are not welcome "
-"when user security, privacy, and control are at stake. It is extremely "
-"important to be as transparent as possible when submitting an add-on for "
-"hosting on this site. A Mozilla user should be able to easily discern what "
-"the functionality of an add-on is and not be presented with unexpected "
-"experiences post-install."
+"Surprises can be appropriate in many situations, but they are not welcome when user security, privacy, and control are at stake. It is extremely important to be as transparent as possible when "
+"submitting an add-on for hosting on this site. A Mozilla user should be able to easily discern what the functionality of an add-on is and not be presented with unexpected experiences post-install."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:243
 msgid ""
-"<p> Whenever an add-on includes any unexpected* feature that </p> <ul> "
-"<li>compromises user privacy or security (like sending data to third "
-"parties),</li> <li>changes default settings like the homepage or search "
-"engine, or</li> <li>changes settings or features in other add-ons or "
-"deactivates them altogether</li> </ul> <p>the features must adhere to the "
-"following requirements:</p> <ul> <li>The add-on description must clearly "
-"state what changes the add-on makes.</li> <li>All changes must be opt-in, "
-"meaning the user must take non-default action to enact the change.</li> "
-"<li>The opt-in dialog must clearly state the name of the add-on requesting "
-"the change.</li> <li>Uninstalling the add-on restores the user's original "
-"settings if they were changed.</li> </ul> <p>*Unexpected features are those "
-"that are unrelated to the add-on's primary function.</p>"
+"<p> Whenever an add-on includes any unexpected* feature that </p> <ul> <li>compromises user privacy or security (like sending data to third parties),</li> <li>changes default settings like the "
+"homepage or search engine, or</li> <li>changes settings or features in other add-ons or deactivates them altogether</li> </ul> <p>the features must adhere to the following requirements:</p> <ul> "
+"<li>The add-on description must clearly state what changes the add-on makes.</li> <li>All changes must be opt-in, meaning the user must take non-default action to enact the change.</li> <li>The opt-"
+"in dialog must clearly state the name of the add-on requesting the change.</li> <li>Uninstalling the add-on restores the user's original settings if they were changed.</li> </ul> <p>*Unexpected "
+"features are those that are unrelated to the add-on's primary function.</p>"
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:268
-msgid ""
-"These features cannot be introduced into an update of a fully-reviewed add-"
-"on; the opt-in change process must be part of the initial review."
+msgid "These features cannot be introduced into an update of a fully-reviewed add-on; the opt-in change process must be part of the initial review."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:274
-msgid ""
-"These are minimum requirements and not a guarantee that the add-on will be "
-"approved. This section applies to all add-ons hosted on the site, including "
-"preliminarily reviewed add-ons."
+msgid "These are minimum requirements and not a guarantee that the add-on will be approved. This section applies to all add-ons hosted on the site, including preliminarily reviewed add-ons."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:279
@@ -7112,11 +5908,8 @@ msgstr ""
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:282
 msgid ""
-"Add-ons that store or otherwise handle browsing data must support <a "
-"href=\"https://developer.mozilla.org/En/Supporting_private_browsing_mode\">Private"
-" Browsing Mode</a>.  During a Private Browsing session, no browsing data can"
-" be written to disk, and all of this data must be cleared when Firefox quits"
-" or the Private Browsing session ends."
+"Add-ons that store or otherwise handle browsing data must support <a href=\"https://developer.mozilla.org/En/Supporting_private_browsing_mode\">Private Browsing Mode</a>. During a Private Browsing "
+"session, no browsing data can be written to disk, and all of this data must be cleared when Firefox quits or the Private Browsing session ends."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:287
@@ -7125,27 +5918,19 @@ msgstr ""
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:289
 msgid ""
-"Add-ons may contain binary, obfuscated and minified source code, but Mozilla"
-" must be allowed to review a copy of the human-readable source code of each "
-"version of an add-on submitted for review. These add-ons are ineligible for "
-"preliminary review and must choose the full review process."
+"Add-ons may contain binary, obfuscated and minified source code, but Mozilla must be allowed to review a copy of the human-readable source code of each version of an add-on submitted for review. "
+"These add-ons are ineligible for preliminary review and must choose the full review process."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:295
 msgid ""
-"If an add-on contains binary or obfuscated source code, the author will "
-"receive a message when the add-on is reviewed indicating whom to contact at "
-"Mozilla to coordinate review of the source code. This code will be reviewed "
-"by an administrator and will not be shared or redistributed in any way. The "
-"code will only be used for the purpose of reviewing the add-on."
+"If an add-on contains binary or obfuscated source code, the author will receive a message when the add-on is reviewed indicating whom to contact at Mozilla to coordinate review of the source code. "
+"This code will be reviewed by an administrator and will not be shared or redistributed in any way. The code will only be used for the purpose of reviewing the add-on."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:301
 #, python-format
-msgid ""
-"If your add-on contains binary or obfuscated code that you don't own or "
-"can't get the source code for, you may <a href=\"%(link_contact)s\">contact "
-"us</a> for information on how to proceed."
+msgid "If your add-on contains binary or obfuscated code that you don't own or can't get the source code for, you may <a href=\"%(link_contact)s\">contact us</a> for information on how to proceed."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/docs/policies-submission.html:11
@@ -7154,138 +5939,86 @@ msgstr ""
 
 #: src/olympia/devhub/templates/devhub/docs/policies-submission.html:13
 msgid ""
-"Add-ons hosted on Mozilla Add-ons should be of high quality and give users "
-"an improved web experience. We look for the following things when deciding "
-"whether an add-on is appropriate to be public and unrestricted:"
+"Add-ons hosted on Mozilla Add-ons should be of high quality and give users an improved web experience. We look for the following things when deciding whether an add-on is appropriate to be public "
+"and unrestricted:"
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/docs/policies-submission.html:19
 msgid ""
-"<strong>Are you responsive?</strong> We expect that an author who is "
-"promoting their add-on to our applications' many users is responsive to "
-"problem reports, maintains their contact information, and updates their add-"
-"on promptly to keep current with Firefox releases and changes in our "
-"policies. This doesn't mean that you have to reply to every question that "
-"someone posts in the discussions, or that you even need to fix every bug, "
-"but we do expect that you will respond to issues in a manner that's "
-"appropriate to the severity of the issue in question."
+"<strong>Are you responsive?</strong> We expect that an author who is promoting their add-on to our applications' many users is responsive to problem reports, maintains their contact information, "
+"and updates their add-on promptly to keep current with Firefox releases and changes in our policies. This doesn't mean that you have to reply to every question that someone posts in the "
+"discussions, or that you even need to fix every bug, but we do expect that you will respond to issues in a manner that's appropriate to the severity of the issue in question."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/docs/policies-submission.html:25
 msgid ""
-"<strong>Is the add-on clearly and accurately described?</strong> It's of the"
-" utmost importance to us that users get what they expect when they try a new"
-" add-on. Your add-on name should be clear and concise, and you should "
-"refrain from using special characters or numbers to get higher search "
-"rankings or for decorative purposes. Your description should provide details"
-" about what the add-on does, how a user should take advantage of it, and "
-"what the user should expect when they install it. Links to external "
-"documents for detailed instructions are fine, but the description itself "
-"should cover the basics and leave users confident that they know what "
-"they'll get. Also, it is important that you maintain version notes "
-"appropriately as you improve and change your add-on. Users should be able to"
-" see what's new in an add-on they may have tried previously, and should be "
-"made aware of changes that might affect their current use of the add-on when"
-" they update."
+"<strong>Is the add-on clearly and accurately described?</strong> It's of the utmost importance to us that users get what they expect when they try a new add-on. Your add-on name should be clear and "
+"concise, and you should refrain from using special characters or numbers to get higher search rankings or for decorative purposes. Your description should provide details about what the add-on "
+"does, how a user should take advantage of it, and what the user should expect when they install it. Links to external documents for detailed instructions are fine, but the description itself should "
+"cover the basics and leave users confident that they know what they'll get. Also, it is important that you maintain version notes appropriately as you improve and change your add-on. Users should "
+"be able to see what's new in an add-on they may have tried previously, and should be made aware of changes that might affect their current use of the add-on when they update."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/docs/policies-submission.html:31
 msgid ""
-"<strong>Are all privacy and security concerns clearly spelled out?</strong> "
-"This is an aspect of a clear and accurate description, but such an important"
-" one that we feel it deserves specific mention. Many very useful and well-"
-"written add-ons manipulate some form of user data, or can present security "
-"hazards if misused; they are welcome on the site, but they must make it very"
-" clear to users what risks they might encounter, and what they can do to "
-"protect themselves."
+"<strong>Are all privacy and security concerns clearly spelled out?</strong> This is an aspect of a clear and accurate description, but such an important one that we feel it deserves specific "
+"mention. Many very useful and well-written add-ons manipulate some form of user data, or can present security hazards if misused; they are welcome on the site, but they must make it very clear to "
+"users what risks they might encounter, and what they can do to protect themselves."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/docs/policies-submission.html:37
 msgid ""
-"<strong>Has the add-on been well-tested, and is it free of obvious or "
-"serious defects?</strong> One important thing that we look for when "
-"considering an add-on is whether its user reviews indicate that it has "
-"received thorough testing, and that it doesn't have serious problems or "
-"negative impacts on the browser. If reviewers report problems such as major "
-"performance issues, crashes, frequent problems using the functions of the "
-"add-on, or spamming of messages to the error console, you should take those "
-"reports to heart, and re-submit your add-on after you've addressed them as "
-"best you can. We don't expect you to perfectly optimize or have zero bugs "
-"&mdash; Firefox itself undergoes constant improvement in these areas &mdash;"
-" but we do want you to take reasonable efforts to minimize downsides, and to"
-" clearly call out cases where users may be surprised by those that remain."
+"<strong>Has the add-on been well-tested, and is it free of obvious or serious defects?</strong> One important thing that we look for when considering an add-on is whether its user reviews indicate "
+"that it has received thorough testing, and that it doesn't have serious problems or negative impacts on the browser. If reviewers report problems such as major performance issues, crashes, frequent "
+"problems using the functions of the add-on, or spamming of messages to the error console, you should take those reports to heart, and re-submit your add-on after you've addressed them as best you "
+"can. We don't expect you to perfectly optimize or have zero bugs &mdash; Firefox itself undergoes constant improvement in these areas &mdash; but we do want you to take reasonable efforts to "
+"minimize downsides, and to clearly call out cases where users may be surprised by those that remain."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/docs/policies-submission.html:43
 msgid ""
-"<strong>Do the add-on and add-on author both treat the user "
-"respectfully?</strong> Your software should not intrude on the user "
-"unnecessarily, try to trick the user, or conceal any of its activities from "
-"the user. Users (or even non-users) are sometimes rude in their comments, "
-"and while we will do our best to filter out inaccurate reviews as they're "
-"reported to us, we do expect that authors will avoid retaliating with "
-"rudeness of their own."
+"<strong>Do the add-on and add-on author both treat the user respectfully?</strong> Your software should not intrude on the user unnecessarily, try to trick the user, or conceal any of its "
+"activities from the user. Users (or even non-users) are sometimes rude in their comments, and while we will do our best to filter out inaccurate reviews as they're reported to us, we do expect that "
+"authors will avoid retaliating with rudeness of their own."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/docs/policies-submission.html:49
 msgid ""
-"<strong>Is the add-on useful to an appropriately wide portion of Firefox's "
-"users?</strong> Your add-on doesn't need to be the next Greasemonkey or "
-"Firebug, but if it is only useful to people at your company or who are part "
-"of a small web community, we may feel that it's not yet appropriate to put "
-"it in front of all of our users."
+"<strong>Is the add-on useful to an appropriately wide portion of Firefox's users?</strong> Your add-on doesn't need to be the next Greasemonkey or Firebug, but if it is only useful to people at "
+"your company or who are part of a small web community, we may feel that it's not yet appropriate to put it in front of all of our users."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/docs/policies-submission.html:55
 msgid ""
-"We are constantly looking at ways to improve the organization of the site to"
-" better accommodate add-ons that are exemplary in other ways, but are aimed "
-"at only a small community of potential users. Correctly categorizing and "
-"maintaining the metadata of your add-on will help us figure out how we can "
-"surface more of those sorts of add-ons to people who are most likely to "
-"benefit from them."
+"We are constantly looking at ways to improve the organization of the site to better accommodate add-ons that are exemplary in other ways, but are aimed at only a small community of potential users. "
+"Correctly categorizing and maintaining the metadata of your add-on will help us figure out how we can surface more of those sorts of add-ons to people who are most likely to benefit from them."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/docs/policies-submission.html:61
 msgid ""
-"If your add-on just provides bookmarks or other simple access points to your"
-" site, it's probably not appropriate for the gallery. Like the rest of the "
-"Mozilla project, we love web applications and new web services, but Firefox "
-"add-ons should provide an improved browsing experience for the user and not "
-"just be a way to promote a new site or service through a Mozilla Add-ons "
-"listing."
+"If your add-on just provides bookmarks or other simple access points to your site, it's probably not appropriate for the gallery. Like the rest of the Mozilla project, we love web applications and "
+"new web services, but Firefox add-ons should provide an improved browsing experience for the user and not just be a way to promote a new site or service through a Mozilla Add-ons listing."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/docs/policies-submission.html:67
 msgid ""
-"<strong>Is the add-on free of unlicensed trademarks and copyrights?</strong>"
-" Though you may mean no harm to the holder of a trademark, or the owner of a"
-" copyrighted work, we can't host add-ons that infringe on trademarks or "
-"copyrights. If you don't have permission to use a trademarked name or image,"
-" please do not submit your add-on to us. If your add-on includes code that "
-"is copyrighted by someone else, and is not licensed to you to use in your "
-"add-on, please do not submit your add-on to us."
+"<strong>Is the add-on free of unlicensed trademarks and copyrights?</strong> Though you may mean no harm to the holder of a trademark, or the owner of a copyrighted work, we can't host add-ons that "
+"infringe on trademarks or copyrights. If you don't have permission to use a trademarked name or image, please do not submit your add-on to us. If your add-on includes code that is copyrighted by "
+"someone else, and is not licensed to you to use in your add-on, please do not submit your add-on to us."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/docs/policies-submission.html:73
 msgid ""
-"In terms of reuse of source code from other add-ons, if the author has not "
-"clearly stated that you are permitted to use his or her code in your own "
-"work &mdash; such as by placing it under an open source license &mdash; then"
-" you should assume that you do not have the right to do so. You can contact "
-"the author to seek such permission, but we can't provide you with any "
-"special rights to it just because it's listed on the site, or because the "
-"author isn't responding to your request."
+"In terms of reuse of source code from other add-ons, if the author has not clearly stated that you are permitted to use his or her code in your own work &mdash; such as by placing it under an open "
+"source license &mdash; then you should assume that you do not have the right to do so. You can contact the author to seek such permission, but we can't provide you with any special rights to it "
+"just because it's listed on the site, or because the author isn't responding to your request."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/docs/policies-submission.html:79
 msgid ""
-"This applies to the Mozilla Foundation's trademarks as well, including "
-"\"Mozilla\", \"Firefox\", and \"Thunderbird\". The Mozilla policy on "
-"trademark use is designed to protect against confusion, and prevent the "
-"trademarks from being overturned due to lack of protection; please respect "
-"the need for such protection, and help us preserve some of the most valuable"
-" assets of the Mozilla Foundation."
+"This applies to the Mozilla Foundation's trademarks as well, including \"Mozilla\", \"Firefox\", and \"Thunderbird\". The Mozilla policy on trademark use is designed to protect against confusion, "
+"and prevent the trademarks from being overturned due to lack of protection; please respect the need for such protection, and help us preserve some of the most valuable assets of the Mozilla "
+"Foundation."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/docs/policies-submission.html:84
@@ -7294,197 +6027,141 @@ msgstr ""
 
 #: src/olympia/devhub/templates/devhub/docs/policies-submission.html:86
 msgid ""
-"Selecting an appropriate license for your add-on is a very important step in"
-" the submission process. A license specifies the rights you grant on your "
-"source code and is important in protecting your intellectual property."
+"Selecting an appropriate license for your add-on is a very important step in the submission process. A license specifies the rights you grant on your source code and is important in protecting your "
+"intellectual property."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/docs/policies-submission.html:92
 msgid ""
-"During the add-on submission process, you will be presented with a list of "
-"popular licenses to choose from, as well as the ability to specify your own "
-"license. It is best to consult with a legal professional about which license"
-" option is best for you. Choosing the right license for your source code "
-"will help to prevent confusion and code conflicts in the future."
+"During the add-on submission process, you will be presented with a list of popular licenses to choose from, as well as the ability to specify your own license. It is best to consult with a legal "
+"professional about which license option is best for you. Choosing the right license for your source code will help to prevent confusion and code conflicts in the future."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/docs/policies.html:12
-#: src/olympia/devhub/templates/devhub/docs/policies.html:52
+#: src/olympia/devhub/templates/devhub/docs/policies.html:12 src/olympia/devhub/templates/devhub/docs/policies.html:52
 msgid "Add-on Submission"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/docs/policies.html:18
-#: src/olympia/devhub/templates/devhub/docs/policies.html:78
+#: src/olympia/devhub/templates/devhub/docs/policies.html:18 src/olympia/devhub/templates/devhub/docs/policies.html:78
 msgid "Maintaining Your Add-on"
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/docs/policies.html:43
-msgid ""
-"Mozilla is committed to ensuring a great add-ons experience for our users "
-"and developers. Please review the policies below before submitting your add-"
-"on."
+msgid "Mozilla is committed to ensuring a great add-ons experience for our users and developers. Please review the policies below before submitting your add-on."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/docs/policies.html:55
-msgid ""
-"Find out what is expected of add-ons we host and our policies on specific "
-"add-on practices."
+msgid "Find out what is expected of add-ons we host and our policies on specific add-on practices."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/docs/policies.html:67
-msgid ""
-"What happens after your add-on is submitted? Learn about how our Editors "
-"review submissions."
+msgid "What happens after your add-on is submitted? Learn about how our Editors review submissions."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/docs/policies.html:81
-msgid ""
-"Add-on updates, transferring ownership, user reviews, and what to expect "
-"once your add-on is approved."
+msgid "Add-on updates, transferring ownership, user reviews, and what to expect once your add-on is approved."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/docs/policies.html:93
-msgid ""
-"How up-and-coming add-ons become featured and what&#039;s involved in the "
-"process."
+msgid "How up-and-coming add-ons become featured and what&#039;s involved in the process."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/docs/policies.html:106
-msgid ""
-"Terms of Service for submitting your work to our site. Developers are "
-"required to accept this agreement before submission."
+msgid "Terms of Service for submitting your work to our site. Developers are required to accept this agreement before submission."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/docs/policies.html:118
 msgid "How to get in touch with us regarding these policies or your add-on."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:6
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:10
 msgid "You have disabled this add-on"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:20
-msgid ""
-"Your add-on's listing is disabled and is not showing\n"
-"                             anywhere in our gallery or update service."
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:24
+msgid "Your add-on's listing is disabled and is not showing anywhere in our gallery or update service."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:25
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:27
 msgid "Please complete your add-on."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:29
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:30
 msgid "You will receive an email when the review is complete."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:34
-msgid ""
-"You will receive an email when the review is complete. Until\n"
-"                             then, your add-on is not listed in our gallery but can be\n"
-"                             accessed directly from its details page."
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:33
+msgid "You will receive an email when the review is complete. Until then, your add-on is not listed in our gallery but can be accessed directly from its details page."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:38
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:48
-msgid ""
-"You will receive an email when the review is\n"
-"                             complete and your add-on is signed."
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:37 src/olympia/devhub/templates/devhub/includes/addon_details.html:45
+msgid "You will receive an email when the review is complete and your add-on is signed."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:44
-msgid ""
-"You will receive an email when the review is complete. Until\n"
-"                             then, your add-on is not listed in our gallery but can be\n"
-"                             accessed directly from its details page. "
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:41
+msgid "You will receive an email when the review is complete. Until then, your add-on is not listed in our gallery but can be accessed directly from its details page. "
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:54
-msgid ""
-"Your add-on is displayed in our gallery and users are\n"
-"                             receiving automatic updates."
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:49
+msgid "Your add-on is displayed in our gallery and users are receiving automatic updates."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:57
-msgid ""
-"Your add-on has been signed and can be bundled with an\n"
-"                             application installer."
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:52
+msgid "Your add-on has been signed and can be bundled with an application installer."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:63
-msgid ""
-"Your add-on was disabled by a site administrator and is no\n"
-"                             longer shown in our gallery. If you have any questions,\n"
-"                             please email amo-admins@mozilla.org."
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:56
+msgid "Your add-on was disabled by a site administrator and is no longer shown in our gallery. If you have any questions, please email amo-admins@mozilla.org."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:70
-msgid ""
-"Your add-on is displayed in our gallery as experimental\n"
-"                             and users are receiving automatic updates. Some features\n"
-"                             are unavailable to your add-on."
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:62
+msgid "Your add-on is displayed in our gallery as experimental and users are receiving automatic updates. Some features are unavailable to your add-on."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:74
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:66
 msgid "Your add-on has been signed."
 msgstr ""
 
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:69
+msgid ""
+"You will receive an email when the full review is complete. Until then, your add-on is displayed in our gallery as experimental and users are receiving automatic updates. Some features are "
+"unavailable to your add-on."
+msgstr ""
+
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:74
+msgid "You will receive an email when the full review is complete, making you able to bundle your add-on with an application installer."
+msgstr ""
+
 #: src/olympia/devhub/templates/devhub/includes/addon_details.html:79
-msgid ""
-"You will receive an email when the full review is complete.\n"
-"                             Until then, your add-on is displayed in our gallery as\n"
-"                             experimental and users are receiving automatic updates.\n"
-"                             Some features are unavailable to your add-on."
+msgid "All add-ons hosted in our gallery must now be reviewed by an editor. If you wish to continue hosting your add-on, please click to select a review process."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:84
-msgid ""
-"You will receive an email when the full review is\n"
-"                             complete, making you able to bundle your add-on with an\n"
-"                             application installer."
-msgstr ""
-
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:91
-msgid ""
-"All add-ons hosted in our gallery must now be reviewed by an\n"
-"                             editor. If you wish to continue hosting your add-on, please\n"
-"                             click to select a review process."
-msgstr ""
-
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:113
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:100
 msgid "Current Version:"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:115
-msgid ""
-"This is the version of your add-on that will\n"
-"                                           be installed if someone clicks the Install\n"
-"                                           button on addons.mozilla.org. It is only\n"
-"                                           relevant for listed add-ons."
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:102
+msgid "This is the version of your add-on that will be installed if someone clicks the Install button on addons.mozilla.org. It is only relevant for listed add-ons."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:123
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:110
 msgid "Created:"
 msgstr ""
 
 #. {0} is a date. dennis-ignore: E201
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:125
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:131
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:112 src/olympia/devhub/templates/devhub/includes/addon_details.html:118
 #, python-format
 msgid "%%b %%e, %%Y"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:136
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:123
 msgid "Next Version:"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:138
-msgid ""
-"This is the newest uploaded version, however\n"
-"                                           it isn’t live on the site yet."
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:125
+msgid "This is the newest uploaded version, however it isn’t live on the site yet."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:144
-#: src/olympia/devhub/templates/devhub/versions/list.html:30
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:130 src/olympia/devhub/templates/devhub/versions/list.html:30
 msgid "Queues are not reviewed strictly in order"
 msgstr ""
 
@@ -7508,10 +6185,8 @@ msgstr "Manage Developer Profile"
 
 #: src/olympia/devhub/templates/devhub/includes/addons_create_profile.html:24
 msgid ""
-"Your developer profile will tell users about you, why you made this add-on, "
-"and what's next for the add-on. This profile is required for add-ons "
-"requesting contributions, but can be useful for any developer interested in "
-"connecting with users."
+"Your developer profile will tell users about you, why you made this add-on, and what's next for the add-on. This profile is required for add-ons requesting contributions, but can be useful for any "
+"developer interested in connecting with users."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/includes/addons_create_profile.html:32
@@ -7524,15 +6199,11 @@ msgid "<a href=\"%(url)s\"><strong>Update your user profile.</strong></a>"
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/includes/addons_create_profile.html:45
-msgid ""
-"Whether it was an idea while in line at the grocery store or the solution to"
-" one of life's great problems, share your story."
+msgid "Whether it was an idea while in line at the grocery store or the solution to one of life's great problems, share your story."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/includes/addons_create_profile.html:61
-msgid ""
-"Telling your users what's coming soon will give them something to look "
-"forward to."
+msgid "Telling your users what's coming soon will give them something to look forward to."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/includes/addons_edit_nav.html:23
@@ -7564,9 +6235,7 @@ msgid "View the blog &#9658;"
 msgstr "Siirry blogiin &#9658;"
 
 #: src/olympia/devhub/templates/devhub/includes/license_form.html:6
-msgid ""
-"Please choose a license appropriate for the rights you grant on your source code.\n"
-"                  It is only relevant for listed add-ons."
+msgid "Please choose a license appropriate for the rights you grant on your source code. It is only relevant for listed add-ons."
 msgstr ""
 
 #. {0} is a list of HTML tags.
@@ -7582,8 +6251,7 @@ msgstr ""
 msgid "Remove this application"
 msgstr ""
 
-#. {0} is the maximum number of add-on categories allowed.                {1}
-#. is
+#. {0} is the maximum number of add-on categories allowed.                {1} is
 #. the application name.
 #: src/olympia/devhub/templates/devhub/includes/macros.html:70
 msgid "Select <b>up to {0}</b> {1} category for this add-on:"
@@ -7593,20 +6261,16 @@ msgstr[1] ""
 
 #: src/olympia/devhub/templates/devhub/includes/policy_form.html:4
 msgid ""
-"Users will be required to accept the following End-User License Agreement (EULA) prior to installing your add-on. The presence of a EULA significantly affects the number of downloads an add-on receives. Please note that a EULA is not the same as a code license, such as the GPL or MPL.\n"
-"                It is only relevant for listed add-ons."
+"Users will be required to accept the following End-User License Agreement (EULA) prior to installing your add-on. The presence of a EULA significantly affects the number of downloads an add-on "
+"receives. Please note that a EULA is not the same as a code license, such as the GPL or MPL.It is only relevant for listed add-ons."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/policy_form.html:21
-msgid ""
-"If your add-on transmits any data from the user's computer, a privacy policy is required that explains what data is sent and how it is used.\n"
-"                It is only relevant for listed add-ons."
+#: src/olympia/devhub/templates/devhub/includes/policy_form.html:24
+msgid "If your add-on transmits any data from the user's computer, a privacy policy is required that explains what data is sent and how it is used. It is only relevant for listed add-ons."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/includes/source_form_field.html:2
-msgid ""
-"If your add-on contains binary or obfuscated code other than known "
-"libraries, upload its sources for review."
+msgid "If your add-on contains binary or obfuscated code other than known libraries, upload its sources for review."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/includes/source_form_field.html:3
@@ -7614,9 +6278,7 @@ msgid "Read more about the source code review policy."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/includes/version_file.html:20
-msgid ""
-"You cannot remove an individual file after the review process has begun. You"
-" must delete the entire version."
+msgid "You cannot remove an individual file after the review process has begun. You must delete the entire version."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/includes/version_file.html:36
@@ -7645,9 +6307,7 @@ msgid "Voluntary Contributions"
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/payments/payments.html:38
-msgid ""
-"Add-ons enrolled in our contributions program can request voluntary "
-"financial support from users."
+msgid "Add-ons enrolled in our contributions program can request voluntary financial support from users."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/payments/payments.html:40
@@ -7659,9 +6319,7 @@ msgid "Choose when and how users are asked to contribute"
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/payments/payments.html:42
-msgid ""
-"Receive contributions in your PayPal account or send them to an organization"
-" of your choice"
+msgid "Receive contributions in your PayPal account or send them to an organization of your choice"
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/payments/payments.html:46
@@ -7670,17 +6328,14 @@ msgstr ""
 
 #: src/olympia/devhub/templates/devhub/payments/payments.html:53
 #, python-format
-msgid ""
-"Contributions are only available for add-ons with a <a "
-"href=\"%(url)s\">completed developer profile</a>."
+msgid "Contributions are only available for add-ons with a <a href=\"%(url)s\">completed developer profile</a>."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/payments/payments.html:59
 msgid "Contributions are only available for fully reviewed add-ons."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/payments/payments.html:65
-#: src/olympia/devhub/templates/devhub/payments/voluntary.html:2
+#: src/olympia/devhub/templates/devhub/payments/payments.html:65 src/olympia/devhub/templates/devhub/payments/voluntary.html:2
 msgid "Set up Contributions"
 msgstr ""
 
@@ -7696,16 +6351,13 @@ msgstr ""
 # 81%
 # 100%
 # 76%
-#: src/olympia/devhub/templates/devhub/payments/voluntary.html:2
-#: src/olympia/stats/templates/stats/addon_report_menu.html:39
+#: src/olympia/devhub/templates/devhub/payments/voluntary.html:2 src/olympia/stats/templates/stats/addon_report_menu.html:39
 #, fuzzy
 msgid "Contributions"
 msgstr "Contribute"
 
 #: src/olympia/devhub/templates/devhub/payments/voluntary.html:3
-msgid ""
-"Fill in the fields below to begin asking for voluntary contributions from "
-"users."
+msgid "Fill in the fields below to begin asking for voluntary contributions from users."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/payments/voluntary.html:11
@@ -7749,16 +6401,13 @@ msgid "Send a thank-you note?"
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/payments/voluntary.html:47
-msgid ""
-"We'll automatically email users who contribute to your add-on with this "
-"message."
+msgid "We'll automatically email users who contribute to your add-on with this message."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/payments/voluntary.html:49
 msgid ""
-"We recommend thanking the user and telling them how much you appreciate "
-"their support. You might also want to tell them about what's next for your "
-"add-on and about any other add-ons you've made for them to try."
+"We recommend thanking the user and telling them how much you appreciate their support. You might also want to tell them about what's next for your add-on and about any other add-ons you've made for "
+"them to try."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/payments/voluntary.html:64
@@ -7773,132 +6422,94 @@ msgstr ""
 msgid "Transfer ownership"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/personas/edit.html:77
-#: src/olympia/devhub/templates/devhub/personas/submit.html:31
+#: src/olympia/devhub/templates/devhub/personas/edit.html:77 src/olympia/devhub/templates/devhub/personas/submit.html:31
 msgid "Theme Details"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/personas/edit.html:87
-#: src/olympia/devhub/templates/devhub/personas/submit.html:36
+#: src/olympia/devhub/templates/devhub/personas/edit.html:87 src/olympia/devhub/templates/devhub/personas/submit.html:36
 msgid "Supply a pretty URL for your detail page."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/personas/edit.html:92
-#: src/olympia/devhub/templates/devhub/personas/submit.html:41
+#: src/olympia/devhub/templates/devhub/personas/edit.html:92 src/olympia/devhub/templates/devhub/personas/submit.html:41
 msgid "Select the category that best describes your Theme."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/personas/edit.html:95
-#: src/olympia/devhub/templates/devhub/personas/submit.html:44
+#: src/olympia/devhub/templates/devhub/personas/edit.html:95 src/olympia/devhub/templates/devhub/personas/submit.html:44
 msgid "Add some tags to describe your Theme."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/personas/edit.html:106
-msgid ""
-"A short explanation of your theme's\n"
-"                                basic functionality that is displayed in\n"
-"                                search and browse listings, as well as at\n"
-"                                the top of your theme's details page."
+#: src/olympia/devhub/templates/devhub/personas/edit.html:106 src/olympia/devhub/templates/devhub/personas/submit.html:54
+msgid "A short explanation of your theme's basic functionality that is displayed in search and browse listings, as well as at the top of your theme's details page."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/personas/edit.html:122
-#: src/olympia/devhub/templates/devhub/personas/submit.html:68
+#: src/olympia/devhub/templates/devhub/personas/edit.html:122 src/olympia/devhub/templates/devhub/personas/submit.html:68
 msgid "Theme License"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/personas/edit.html:126
-#: src/olympia/devhub/templates/devhub/personas/submit.html:72
+#: src/olympia/devhub/templates/devhub/personas/edit.html:126 src/olympia/devhub/templates/devhub/personas/submit.html:72
 msgid "Can others share your Theme, as long as you're given credit?"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/personas/edit.html:132
-#: src/olympia/devhub/templates/devhub/personas/edit.html:153
-#: src/olympia/devhub/templates/devhub/personas/submit.html:78
+#: src/olympia/devhub/templates/devhub/personas/edit.html:132 src/olympia/devhub/templates/devhub/personas/edit.html:153 src/olympia/devhub/templates/devhub/personas/submit.html:78
 #: src/olympia/devhub/templates/devhub/personas/submit.html:99
-msgid ""
-"The licensor permits others to copy, distribute, display, and perform the "
-"work, including for commercial purposes."
+msgid "The licensor permits others to copy, distribute, display, and perform the work, including for commercial purposes."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/personas/edit.html:141
-#: src/olympia/devhub/templates/devhub/personas/edit.html:162
-#: src/olympia/devhub/templates/devhub/personas/submit.html:87
+#: src/olympia/devhub/templates/devhub/personas/edit.html:141 src/olympia/devhub/templates/devhub/personas/edit.html:162 src/olympia/devhub/templates/devhub/personas/submit.html:87
 #: src/olympia/devhub/templates/devhub/personas/submit.html:108
-msgid ""
-"The licensor permits others to copy, distribute, display, and perform the "
-"work for non-commercial purposes only."
+msgid "The licensor permits others to copy, distribute, display, and perform the work for non-commercial purposes only."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/personas/edit.html:147
-#: src/olympia/devhub/templates/devhub/personas/submit.html:93
+#: src/olympia/devhub/templates/devhub/personas/edit.html:147 src/olympia/devhub/templates/devhub/personas/submit.html:93
 msgid "Can others make commercial use of your Theme?"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/personas/edit.html:168
-#: src/olympia/devhub/templates/devhub/personas/submit.html:114
+#: src/olympia/devhub/templates/devhub/personas/edit.html:168 src/olympia/devhub/templates/devhub/personas/submit.html:114
 msgid "Can others create derivative works from your Theme?"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/personas/edit.html:174
-#: src/olympia/devhub/templates/devhub/personas/submit.html:120
-msgid ""
-"The licensor permits others to copy, distribute, display and perform the "
-"work, as well as make derivative works based on it."
+#: src/olympia/devhub/templates/devhub/personas/edit.html:174 src/olympia/devhub/templates/devhub/personas/submit.html:120
+msgid "The licensor permits others to copy, distribute, display and perform the work, as well as make derivative works based on it."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/personas/edit.html:182
-#: src/olympia/devhub/templates/devhub/personas/submit.html:128
+#: src/olympia/devhub/templates/devhub/personas/edit.html:182 src/olympia/devhub/templates/devhub/personas/submit.html:128
 msgid "Yes, as long as they share alike"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/personas/edit.html:183
-#: src/olympia/devhub/templates/devhub/personas/submit.html:129
-msgid ""
-"The licensor permits others to distribute derivativeworks only under the "
-"same license or one compatible with the one that governs the licensor's "
-"work."
+#: src/olympia/devhub/templates/devhub/personas/edit.html:183 src/olympia/devhub/templates/devhub/personas/submit.html:129
+msgid "The licensor permits others to distribute derivativeworks only under the same license or one compatible with the one that governs the licensor's work."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/personas/edit.html:192
-#: src/olympia/devhub/templates/devhub/personas/submit.html:138
-msgid ""
-"The licensor permits others to copy, distribute and transmit only unaltered "
-"copies of the work — not derivative works based on it."
+#: src/olympia/devhub/templates/devhub/personas/edit.html:192 src/olympia/devhub/templates/devhub/personas/submit.html:138
+msgid "The licensor permits others to copy, distribute and transmit only unaltered copies of the work — not derivative works based on it."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/personas/edit.html:199
-#: src/olympia/devhub/templates/devhub/personas/submit.html:145
+#: src/olympia/devhub/templates/devhub/personas/edit.html:199 src/olympia/devhub/templates/devhub/personas/submit.html:145
 msgid "Your Theme will be released under the following license:"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/personas/edit.html:202
-#: src/olympia/devhub/templates/devhub/personas/submit.html:148
+#: src/olympia/devhub/templates/devhub/personas/edit.html:202 src/olympia/devhub/templates/devhub/personas/submit.html:148
 msgid "Select a different license."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/personas/edit.html:207
-#: src/olympia/devhub/templates/devhub/personas/submit.html:153
+#: src/olympia/devhub/templates/devhub/personas/edit.html:207 src/olympia/devhub/templates/devhub/personas/submit.html:153
 msgid "Select a license for your Theme."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/personas/edit.html:217
-#: src/olympia/devhub/templates/devhub/personas/submit.html:163
+#: src/olympia/devhub/templates/devhub/personas/edit.html:217 src/olympia/devhub/templates/devhub/personas/submit.html:163
 msgid "Theme Design"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/personas/edit.html:221
-#: src/olympia/devhub/templates/devhub/personas/edit.html:224
+#: src/olympia/devhub/templates/devhub/personas/edit.html:221 src/olympia/devhub/templates/devhub/personas/edit.html:224
 msgid "Upload New Design"
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/personas/edit.html:226
-msgid ""
-"Upon upload and form submission, the AMO Team will review your updated "
-"design. Your current design will still be public in the meantime."
+msgid "Upon upload and form submission, the AMO Team will review your updated design. Your current design will still be public in the meantime."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/personas/edit.html:241
-msgid "Your previously resubmitted design,  which is under pending review."
+msgid "Your previously resubmitted design, which is under pending review."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/personas/edit.html:245
@@ -7921,43 +6532,35 @@ msgstr ""
 msgid "Footer"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/personas/edit.html:274
-#: src/olympia/devhub/templates/devhub/personas/submit.html:167
+#: src/olympia/devhub/templates/devhub/personas/edit.html:274 src/olympia/devhub/templates/devhub/personas/submit.html:167
 msgid "Select colors for your Theme."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/personas/edit.html:276
-#: src/olympia/devhub/templates/devhub/personas/submit.html:169
+#: src/olympia/devhub/templates/devhub/personas/edit.html:276 src/olympia/devhub/templates/devhub/personas/submit.html:169
 msgid "Foreground Text"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/personas/edit.html:277
-#: src/olympia/devhub/templates/devhub/personas/submit.html:170
+#: src/olympia/devhub/templates/devhub/personas/edit.html:277 src/olympia/devhub/templates/devhub/personas/submit.html:170
 msgid "This is the color of the tab text."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/personas/edit.html:279
-#: src/olympia/devhub/templates/devhub/personas/submit.html:172
+#: src/olympia/devhub/templates/devhub/personas/edit.html:279 src/olympia/devhub/templates/devhub/personas/submit.html:172
 msgid "Background"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/personas/edit.html:280
-#: src/olympia/devhub/templates/devhub/personas/submit.html:173
+#: src/olympia/devhub/templates/devhub/personas/edit.html:280 src/olympia/devhub/templates/devhub/personas/submit.html:173
 msgid "This is the color of the tabs."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/personas/edit.html:285
-#: src/olympia/devhub/templates/devhub/personas/submit.html:178
+#: src/olympia/devhub/templates/devhub/personas/edit.html:285 src/olympia/devhub/templates/devhub/personas/submit.html:178
 msgid "Preview"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/personas/edit.html:291
-#: src/olympia/devhub/templates/devhub/personas/submit.html:183
+#: src/olympia/devhub/templates/devhub/personas/edit.html:291 src/olympia/devhub/templates/devhub/personas/submit.html:183
 msgid "Your Theme's Name"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/personas/edit.html:294
-#: src/olympia/devhub/templates/devhub/personas/submit.html:186
+#: src/olympia/devhub/templates/devhub/personas/edit.html:294 src/olympia/devhub/templates/devhub/personas/submit.html:186
 #, python-format
 msgid "by <a href=\"%(profile_url)s\" target=\"_blank\">%(user)s</a>"
 msgstr ""
@@ -7968,30 +6571,17 @@ msgstr ""
 
 #: src/olympia/devhub/templates/devhub/personas/submit.html:18
 #, python-format
-msgid ""
-"Background themes let you easily personalize the look of your Firefox. "
-"Submit your own design below, or <a href=\"%(submit_url)s\">learn how to "
-"create one</a>!"
+msgid "Background themes let you easily personalize the look of your Firefox. Submit your own design below, or <a href=\"%(submit_url)s\">learn how to create one</a>!"
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/personas/submit.html:33
 msgid "Give your Theme a name."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/personas/submit.html:54
-msgid ""
-"A short explanation of your theme's\n"
-"                                      basic functionality that is displayed in\n"
-"                                      search and browse listings, as well as at\n"
-"                                      the top of your theme's details page."
-msgstr ""
-
 #: src/olympia/devhub/templates/devhub/personas/submit.html:198
 #, python-format
 msgid ""
-"I agree to the <a href=\"%(agreement_url)s\" target=\"_blank\">Firefox Add-"
-"on Distribution Agreement</a> and to my information being handled as "
-"described in the <a href=\"%(privacy_notice_url)s\" "
+"I agree to the <a href=\"%(agreement_url)s\" target=\"_blank\">Firefox Add-on Distribution Agreement</a> and to my information being handled as described in the <a href=\"%(privacy_notice_url)s\" "
 "target=\"_blank\">Websites, Communications and Cookies Privacy Notice</a>."
 msgstr ""
 
@@ -8000,23 +6590,17 @@ msgid "Submit Theme"
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/personas/submit_done.html:11
-msgid ""
-"Your theme has been submitted to the Review Queue. You'll receive an email "
-"once it has been reviewed, typically within 24 hours."
+msgid "Your theme has been submitted to the Review Queue. You'll receive an email once it has been reviewed, typically within 24 hours."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/personas/submit_done.html:19
 #, python-format
-msgid ""
-"Provide more details about your theme by <a href=\"%(edit_url)s\">editing "
-"its listing</a>."
+msgid "Provide more details about your theme by <a href=\"%(edit_url)s\">editing its listing</a>."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/personas/submit_done.html:25
 #, python-format
-msgid ""
-"View and subscribe to your theme's <a href=\"%(feed_url)s\">activity "
-"feed</a> to stay updated on reviews, collections, and more."
+msgid "View and subscribe to your theme's <a href=\"%(feed_url)s\">activity feed</a> to stay updated on reviews, collections, and more."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/personas/submit_done.html:32
@@ -8032,13 +6616,11 @@ msgstr ""
 msgid "3000 &times; 200 pixels"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/personas/includes/theme_design.html:9
-#: src/olympia/devhub/templates/devhub/personas/includes/theme_design.html:25
+#: src/olympia/devhub/templates/devhub/personas/includes/theme_design.html:9 src/olympia/devhub/templates/devhub/personas/includes/theme_design.html:25
 msgid "300 KB max"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/personas/includes/theme_design.html:10
-#: src/olympia/devhub/templates/devhub/personas/includes/theme_design.html:26
+#: src/olympia/devhub/templates/devhub/personas/includes/theme_design.html:10 src/olympia/devhub/templates/devhub/personas/includes/theme_design.html:26
 msgid "PNG or JPG"
 msgstr ""
 
@@ -8067,53 +6649,31 @@ msgid "Select a different footer image"
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/versions/add_file_modal.html:8
-msgid ""
-"Files added to reviewed versions must be reviewed before they will be "
-"available for download."
+msgid "Files added to reviewed versions must be reviewed before they will be available for download."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/add_file_modal.html:15
-#, python-format
-msgid ""
-"Submission of updates to unlisted add-ons for signing is currently in an "
-"open beta. Manual review may still be required for a large number of add-"
-"ons. Please <a href=\"%(url)s\" target=\"_blank\">report any bugs</a> that "
-"you encounter."
-msgstr ""
-
-#: src/olympia/devhub/templates/devhub/versions/add_file_modal.html:35
+#: src/olympia/devhub/templates/devhub/versions/add_file_modal.html:24
 msgid "Select the target platform for this file."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/add_file_modal.html:46
+#: src/olympia/devhub/templates/devhub/versions/add_file_modal.html:35
 msgid "Which review type would you like to nominate for?"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/add_file_modal.html:51
+#: src/olympia/devhub/templates/devhub/versions/add_file_modal.html:40
 msgid "Only publish this version to my beta channel."
-msgstr ""
-
-#: src/olympia/devhub/templates/devhub/versions/add_file_modal.html:54
-#, python-format
-msgid ""
-"The behavior of the beta channel has changed to accommodate <a "
-"href=\"%(addon_signing_url)s\" target=\"_blank\">mandatory add-on "
-"signing</a>. The new process is currently in an open beta, and may change "
-"significantly in the near future. Please <a href=\"%(issues_url)s\" "
-"target=\"_blank\">report any bugs</a> that you encounter."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/versions/edit.html:5
 msgid "Manage Version {0}"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/edit.html:12
-#: src/olympia/devhub/templates/devhub/versions/list.html:3
+#: src/olympia/devhub/templates/devhub/versions/edit.html:12 src/olympia/devhub/templates/devhub/versions/list.html:3
 msgid "Status & Versions"
 msgstr ""
 
-#. {0} is an add-on name.
 # {0} is the name of the collection
+#. {0} is an add-on name.
 #: src/olympia/devhub/templates/devhub/versions/edit.html:16
 msgid "Manage {0}"
 msgstr ""
@@ -8129,35 +6689,22 @@ msgstr "Tiedostot:"
 msgid "Upload Another File"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/edit.html:45
-msgid ""
-"Adjusting application information here will allow users to install your\n"
-"                          add-on even if the install manifest in the package indicates that the\n"
-"                          add-on is incompatible."
-msgstr ""
-
 #: src/olympia/devhub/templates/devhub/versions/edit.html:74
 msgid ""
-"Information about changes in this release, new features,\n"
-"                              known bugs, and other useful information specific to this\n"
-"                              release/version. This information is also shown in the\n"
-"                              Add-ons Manager when updating."
+"Information about changes in this release, new features, known bugs, and other useful information specific to this release/version. This information is also shown in the Add-ons Manager when "
+"updating."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/versions/edit.html:99
 msgid "Approval Status"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/edit.html:113
-#: src/olympia/editors/templates/editors/review.html:108
+#: src/olympia/devhub/templates/devhub/versions/edit.html:113 src/olympia/editors/templates/editors/review.html:108
 msgid "Notes for Reviewers"
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/versions/edit.html:114
-msgid ""
-"Optionally, enter any information that may be useful\n"
-"                              to the Editor reviewing this add-on, such as test\n"
-"                              account information."
+msgid "Optionally, enter any information that may be useful to the Editor reviewing this add-on, such as test account information."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/versions/edit.html:127
@@ -8165,13 +6712,10 @@ msgid "Source code"
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/versions/edit.html:128
-msgid ""
-"If your add-on contain binary or obfuscated code, make the source available "
-"here for reviewers."
+msgid "If your add-on contain binary or obfuscated code, make the source available here for reviewers."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/edit.html:145
-#: src/olympia/devhub/templates/devhub/versions/edit.html:149
+#: src/olympia/devhub/templates/devhub/versions/edit.html:145 src/olympia/devhub/templates/devhub/versions/edit.html:149
 msgid "Upload a new file"
 msgstr ""
 
@@ -8239,9 +6783,7 @@ msgstr ""
 msgid "Request Preliminary Review"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:80
-#: src/olympia/devhub/templates/devhub/versions/list.html:327
-#: src/olympia/devhub/templates/devhub/versions/list.html:350
+#: src/olympia/devhub/templates/devhub/versions/list.html:80 src/olympia/devhub/templates/devhub/versions/list.html:325 src/olympia/devhub/templates/devhub/versions/list.html:348
 msgid "Cancel Review Request"
 msgstr ""
 
@@ -8254,8 +6796,7 @@ msgid "Listed:"
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/versions/list.html:102
-msgid ""
-"Visible to everyone on {0} and included in search results and listing pages"
+msgid "Visible to everyone on {0} and included in search results and listing pages"
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/versions/list.html:108
@@ -8263,9 +6804,7 @@ msgid "Hidden:"
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/versions/list.html:108
-msgid ""
-"Hosted on {0}, but hidden to anyone but authors. Used to temporarily hide "
-"listings or discontinue them."
+msgid "Hosted on {0}, but hidden to anyone but authors. Used to temporarily hide listings or discontinue them."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/versions/list.html:114
@@ -8273,9 +6812,7 @@ msgid "Unlisted:"
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/versions/list.html:114
-msgid ""
-"Not distributed on {0}. Developers will upload new versions for signing and "
-"distribute the add-ons on their own. (beta)"
+msgid "Not distributed on {0}. Developers will upload new versions for signing and distribute the add-ons on their own."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/versions/list.html:122
@@ -8286,18 +6823,13 @@ msgstr ""
 msgid "Currently on AMO"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:129
-#: src/olympia/devhub/templates/devhub/versions/list.html:147
-#: src/olympia/devhub/templates/devhub/versions/list.html:164
-#: src/olympia/editors/templates/editors/includes/search_results_themes.html:7
-#: src/olympia/editors/templates/editors/themes/queue_list.html:50
+#: src/olympia/devhub/templates/devhub/versions/list.html:129 src/olympia/devhub/templates/devhub/versions/list.html:147 src/olympia/devhub/templates/devhub/versions/list.html:164
+#: src/olympia/editors/templates/editors/includes/search_results_themes.html:7 src/olympia/editors/templates/editors/themes/queue_list.html:50
 msgid "Status"
 msgstr ""
 
 # Header for a column in a table
-#: src/olympia/devhub/templates/devhub/versions/list.html:130
-#: src/olympia/devhub/templates/devhub/versions/list.html:148
-#: src/olympia/devhub/templates/devhub/versions/list.html:165
+#: src/olympia/devhub/templates/devhub/versions/list.html:130 src/olympia/devhub/templates/devhub/versions/list.html:148 src/olympia/devhub/templates/devhub/versions/list.html:165
 #: src/olympia/editors/templates/editors/includes/files_view.html:11
 msgid "Validation"
 msgstr ""
@@ -8319,10 +6851,7 @@ msgid "Full review may not be required"
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/versions/list.html:201
-msgid ""
-"Unlisted add-ons don't need Full Review unless they are distributed as part "
-"of an application installer. Read <a href=\"{link}\" target=\"_blank\">this "
-"documentation</a> for more information."
+msgid "Unlisted add-ons don't need Full Review unless they are distributed as part of an application installer. Read <a href=\"{link}\" target=\"_blank\">this documentation</a> for more information."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/versions/list.html:209
@@ -8335,9 +6864,7 @@ msgstr ""
 
 #: src/olympia/devhub/templates/devhub/versions/list.html:218
 msgid ""
-"You are about to delete the current version of your add-on. This may cause "
-"your add-on status to change, or your listing to lose public visibility, if "
-"this is the only public version of your add-on."
+"You are about to delete the current version of your add-on. This may cause your add-on status to change, or your listing to lose public visibility, if this is the only public version of your add-on."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/versions/list.html:219
@@ -8345,105 +6872,80 @@ msgid "Deleting this version will permanently delete:"
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/versions/list.html:225
-msgid ""
-"<strong>Important:</strong> Once a version has been deleted, you may not "
-"upload a new version with the same version number."
+msgid "<strong>Important:</strong> Once a version has been deleted, you may not upload a new version with the same version number."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/versions/list.html:230
-msgid ""
-"Deleting a version which has already been reviewed\n"
-"               may also cause a significant delay in the review of\n"
-"               your next update."
-msgstr ""
-
-#: src/olympia/devhub/templates/devhub/versions/list.html:233
 msgid "Are you sure you wish to delete this version?"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:238
+#: src/olympia/devhub/templates/devhub/versions/list.html:235
 msgid "Delete Version"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:240
+#: src/olympia/devhub/templates/devhub/versions/list.html:237
 msgid "Disable Version"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:247
+#: src/olympia/devhub/templates/devhub/versions/list.html:244
 msgid "Add a new Version"
 msgstr ""
 
 # 75%
 # 100%
-#: src/olympia/devhub/templates/devhub/versions/list.html:249
+#: src/olympia/devhub/templates/devhub/versions/list.html:246
 #, fuzzy
 msgid "Add Version"
 msgstr "All Versions"
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:256
-#: src/olympia/devhub/templates/devhub/versions/list.html:274
+#: src/olympia/devhub/templates/devhub/versions/list.html:253 src/olympia/devhub/templates/devhub/versions/list.html:279
 msgid "Hide Add-on"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:259
-msgid ""
-"Hiding your add-on will prevent it from appearing anywhere in our gallery "
-"and will stop users from receiving automatic updates."
+#: src/olympia/devhub/templates/devhub/versions/list.html:256
+msgid "Hiding your add-on will prevent it from appearing anywhere in our gallery and will stop users from receiving automatic updates."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:265
+#: src/olympia/devhub/templates/devhub/versions/list.html:263
+msgid "The files awaiting review will be disabled and you will need to upload new versions."
+msgstr ""
+
+#: src/olympia/devhub/templates/devhub/versions/list.html:270
 msgid "Are you sure you wish to hide your add-on?"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:286
-#: src/olympia/devhub/templates/devhub/versions/list.html:315
+#: src/olympia/devhub/templates/devhub/versions/list.html:291 src/olympia/devhub/templates/devhub/versions/list.html:313
 msgid "Unlist Add-on"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:289
+#: src/olympia/devhub/templates/devhub/versions/list.html:294
 #, python-format
 msgid ""
-"Unlisting your add-on will make it (and each of its versions/files) "
-"invisible on this website. It won't show up in searches, won't have a public"
-" facing page, and won't be updated automatically for current users.  It is "
-"recommended for unlisted add-ons to provide a custom <a "
-"href=\"%(update_url)s\" target=\"_blank\">updateURL</a> in their manifest "
-"file for automatic updates."
+"Unlisting your add-on will make it (and each of its versions/files) invisible on this website. It won't show up in searches, won't have a public facing page, and won't be updated automatically for "
+"current users. It is recommended for unlisted add-ons to provide a custom <a href=\"%(update_url)s\" target=\"_blank\">updateURL</a> in their manifest file for automatic updates."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:299
-#, python-format
-msgid ""
-"Switching add-ons to unlisted is currently in an open beta. Please <a "
-"href=\"%(url)s\" target=\"_blank\">report any bugs</a> that you encounter."
-msgstr ""
-
-#: src/olympia/devhub/templates/devhub/versions/list.html:305
+#: src/olympia/devhub/templates/devhub/versions/list.html:303
 msgid "Unlisting an add-on is irreversible!"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:305
+#: src/olympia/devhub/templates/devhub/versions/list.html:303
 msgid "An unlisted add-on cannot be switched to be listed."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:307
+#: src/olympia/devhub/templates/devhub/versions/list.html:305
 msgid "Are you sure you wish to unlist your add-on?"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:330
-msgid ""
-"Canceling your review request will leave your add-on as preliminarily "
-"reviewed."
+#: src/olympia/devhub/templates/devhub/versions/list.html:328
+msgid "Canceling your review request will leave your add-on as preliminarily reviewed."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:335
-msgid ""
-"Canceling your review request will mark your add-on incomplete. If you do "
-"not complete your add-on after several days by re-requesting review, it will"
-" be deleted."
+#: src/olympia/devhub/templates/devhub/versions/list.html:333
+msgid "Canceling your review request will mark your add-on incomplete. If you do not complete your add-on after several days by re-requesting review, it will be deleted."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:343
+#: src/olympia/devhub/templates/devhub/versions/list.html:341
 msgid "Are you sure you wish to cancel your review request?"
 msgstr ""
 
@@ -8476,19 +6978,12 @@ msgid "Translate content on the web from and into over 40 languages."
 msgstr "Käännä verkon sisältöä yli 40 kielelle."
 
 #: src/olympia/discovery/modules.py:171
-msgid ""
-"Easily connect to your social networks, and share or comment on the page "
-"you're visiting."
-msgstr ""
-"Yhdistä helposti sosiaaliset verkkosi ja jaa tai kommentoi sivuja, joilla "
-"vierailet."
+msgid "Easily connect to your social networks, and share or comment on the page you're visiting."
+msgstr "Yhdistä helposti sosiaaliset verkkosi ja jaa tai kommentoi sivuja, joilla vierailet."
 
 #: src/olympia/discovery/modules.py:173
-msgid ""
-"A quick view to compare prices when you shop online or search for flights."
-msgstr ""
-"Vertaile helposti hintoja, kun teet ostoksia verkossa tai etsit sopivaa "
-"lentoa."
+msgid "A quick view to compare prices when you shop online or search for flights."
+msgstr "Vertaile helposti hintoja, kun teet ostoksia verkossa tai etsit sopivaa lentoa."
 
 #: src/olympia/discovery/modules.py:183
 msgid "Firefox 4 Collection"
@@ -8531,9 +7026,7 @@ msgid "Add-ons that help you on your travels!"
 msgstr "Lisäosia, jotka auttavat sinua matkoillasi!"
 
 #: src/olympia/discovery/modules.py:226
-msgid ""
-"Displays a country flag depicting the location of the current website's "
-"server and more."
+msgid "Displays a country flag depicting the location of the current website's server and more."
 msgstr ""
 
 #: src/olympia/discovery/modules.py:228
@@ -8541,9 +7034,7 @@ msgid "FoxClocks let you keep an eye on the time around the world."
 msgstr ""
 
 #: src/olympia/discovery/modules.py:230
-msgid ""
-"Automatically get the lowest price when you shop online or search for "
-"flights."
+msgid "Automatically get the lowest price when you shop online or search for flights."
 msgstr ""
 
 #: src/olympia/discovery/modules.py:240
@@ -8583,9 +7074,7 @@ msgid "Put a Theme on It!"
 msgstr ""
 
 #: src/olympia/discovery/modules.py:281
-msgid ""
-"Visit addons.mozilla.org from Firefox for Android and dress up your mobile "
-"browser to match your style, mood, or the season."
+msgid "Visit addons.mozilla.org from Firefox for Android and dress up your mobile browser to match your style, mood, or the season."
 msgstr ""
 
 #: src/olympia/discovery/modules.py:290
@@ -8613,9 +7102,7 @@ msgid "Protect your privacy online with the add-ons in this collection."
 msgstr ""
 
 #: src/olympia/discovery/modules.py:342
-msgid ""
-"Great add-ons for work, fun, privacy, productivity&hellip; just about "
-"anything!"
+msgid "Great add-ons for work, fun, privacy, productivity&hellip; just about anything!"
 msgstr ""
 
 #: src/olympia/discovery/modules.py:350
@@ -8636,21 +7123,16 @@ msgstr "Mitä ovat lisäosat?"
 
 #: src/olympia/discovery/templates/discovery/pane.html:28
 #, python-format
-msgid ""
-"Add-ons are applications that let you personalize %(app)s with extra "
-"functionality or style. Try a time-saving sidebar, a weather notifier, or a "
-"themed look to make %(app)s your own."
+msgid "Add-ons are applications that let you personalize %(app)s with extra functionality or style. Try a time-saving sidebar, a weather notifier, or a themed look to make %(app)s your own."
 msgstr ""
-"Lisäosat ovat sovelluksia, joilla voit muokata %(app)sin toiminnallisuutta "
-"tai ulkoasua. Kokeile aikaa säästävää sivupalkkia, säätietoilmoituksia tai "
-"teemoja, joilla voit tehdä %(app)sista omanlaisesi."
+"Lisäosat ovat sovelluksia, joilla voit muokata %(app)sin toiminnallisuutta tai ulkoasua. Kokeile aikaa säästävää sivupalkkia, säätietoilmoituksia tai teemoja, joilla voit tehdä %(app)sista "
+"omanlaisesi."
 
 #: src/olympia/discovery/templates/discovery/pane.html:62
 msgid "Learn More About Add-ons"
 msgstr ""
 
-#: src/olympia/discovery/templates/discovery/pane.html:66
-#: src/olympia/discovery/templates/discovery/pane.html:73
+#: src/olympia/discovery/templates/discovery/pane.html:66 src/olympia/discovery/templates/discovery/pane.html:73
 msgid "See all"
 msgstr "Näytä kaikki"
 
@@ -8681,12 +7163,8 @@ msgstr "Hei, {0}"
 
 #: src/olympia/discovery/templates/discovery/pane_account.html:17
 #, python-format
-msgid ""
-"Thanks for using %(app)s and supporting <a href=\"%(url)s\">Mozilla's "
-"mission</a>!"
-msgstr ""
-"Kiitos, että käytät %(app)sia ja tuet <a href=\"%(url)s\">Mozillan "
-"tehtävää</a>!"
+msgid "Thanks for using %(app)s and supporting <a href=\"%(url)s\">Mozilla's mission</a>!"
+msgstr "Kiitos, että käytät %(app)sia ja tuet <a href=\"%(url)s\">Mozillan tehtävää</a>!"
 
 #: src/olympia/discovery/templates/discovery/pane_account.html:23
 msgid "Add-ons downloaded:"
@@ -8710,14 +7188,10 @@ msgstr "Lisäosat mukanasi"
 
 #: src/olympia/discovery/templates/discovery/modules/go-mobile.html:8
 #, python-format
-msgid ""
-"Visit <a href=\"%(url)s\">firefox.com/m</a> to get Firefox on your phone and"
-" personalize your browser anytime, anywhere. Easily discover and install "
-"add-ons from the mobile Add-ons Manager."
+msgid "Visit <a href=\"%(url)s\">firefox.com/m</a> to get Firefox on your phone and personalize your browser anytime, anywhere. Easily discover and install add-ons from the mobile Add-ons Manager."
 msgstr ""
-"Vieraile osoitteessa <a href=\"%(url)s\">firefox.com/m</a> ladataksesi "
-"Firefoxin puhelimeesi ja muokkaa selaintasi missä vain, milloin vain. Voit "
-"etsiä ja asentaa lisäosia helposti lisäosien hallinnan mobiiliversiolla."
+"Vieraile osoitteessa <a href=\"%(url)s\">firefox.com/m</a> ladataksesi Firefoxin puhelimeesi ja muokkaa selaintasi missä vain, milloin vain. Voit etsiä ja asentaa lisäosia helposti lisäosien "
+"hallinnan mobiiliversiolla."
 
 #: src/olympia/discovery/templates/discovery/modules/go-mobile.html:13
 msgid "Get Mobile Add-ons"
@@ -8732,15 +7206,11 @@ msgid "Find great add-ons to help you with all your holiday shopping needs."
 msgstr ""
 
 #: src/olympia/discovery/templates/discovery/modules/holiday.html:13
-msgid ""
-"Install the Amazon Browser Apps and receive special Amazon features right at"
-" your fingertips."
+msgid "Install the Amazon Browser Apps and receive special Amazon features right at your fingertips."
 msgstr ""
 
 #: src/olympia/discovery/templates/discovery/modules/holiday.html:22
-msgid ""
-"Keep an eye on your eBay activity wherever you are on the web when you "
-"install the eBay Sidebar for Firefox."
+msgid "Keep an eye on your eBay activity wherever you are on the web when you install the eBay Sidebar for Firefox."
 msgstr ""
 
 #: src/olympia/discovery/templates/discovery/modules/holiday.html:31
@@ -8818,19 +7288,19 @@ msgstr ""
 msgid "Search by add-on name / author email"
 msgstr ""
 
-#: src/olympia/editors/forms.py:103
+#: src/olympia/editors/forms.py:103 src/olympia/editors/forms.py:244 src/olympia/editors/forms.py:257
 msgid "yes"
 msgstr "kyllä"
 
-#: src/olympia/editors/forms.py:104
+#: src/olympia/editors/forms.py:104 src/olympia/editors/forms.py:244 src/olympia/editors/forms.py:257
 msgid "no"
 msgstr "ei"
 
-#: src/olympia/editors/forms.py:105
+#: src/olympia/editors/forms.py:105 src/olympia/editors/forms.py:245
 msgid "Admin Flag"
 msgstr ""
 
-#: src/olympia/editors/forms.py:113
+#: src/olympia/editors/forms.py:113 src/olympia/editors/forms.py:253
 msgid "Max. Version"
 msgstr ""
 
@@ -8842,57 +7312,59 @@ msgstr ""
 msgid "Add-on Types"
 msgstr ""
 
-#: src/olympia/editors/forms.py:126 src/olympia/editors/helpers.py:267
+#: src/olympia/editors/forms.py:126 src/olympia/editors/helpers.py:279
 msgid "Platforms"
 msgstr "Alustat"
 
+#: src/olympia/editors/forms.py:237
+msgid "Search by add-on name / author email / guid"
+msgstr ""
+
 #. L10n: 0 = platform, 1 = filename, 2 = status message
-#: src/olympia/editors/forms.py:238
+#: src/olympia/editors/forms.py:342
 #, python-format
 msgid "<strong>%s</strong> &middot; %s &middot; %s"
 msgstr ""
 
-#: src/olympia/editors/forms.py:252
+#: src/olympia/editors/forms.py:356
 msgid "Comments:"
 msgstr "Kommentit:"
 
-#: src/olympia/editors/forms.py:256
+#: src/olympia/editors/forms.py:360
 msgid "Operating systems:"
 msgstr ""
 
-#: src/olympia/editors/forms.py:258
+#: src/olympia/editors/forms.py:362
 msgid "Applications:"
 msgstr "Ohjelmat:"
 
-#: src/olympia/editors/forms.py:260
-msgid ""
-"Notify me the next time this add-on is updated. (Subsequent updates will not"
-" generate an email)"
+#: src/olympia/editors/forms.py:364
+msgid "Notify me the next time this add-on is updated. (Subsequent updates will not generate an email)"
 msgstr ""
 
-#: src/olympia/editors/forms.py:265
+#: src/olympia/editors/forms.py:369
 msgid "Clear Admin Review Flag"
 msgstr ""
 
-#: src/olympia/editors/forms.py:267
+#: src/olympia/editors/forms.py:371
 msgid "Clear more info requested flag"
 msgstr ""
 
-#: src/olympia/editors/forms.py:281
+#: src/olympia/editors/forms.py:385
 msgid "Choose a canned response..."
 msgstr ""
 
 #. L10n: Description of what can be searched for.
-#: src/olympia/editors/forms.py:324
+#: src/olympia/editors/forms.py:423
 msgid "theme name"
 msgstr ""
 
-#: src/olympia/editors/forms.py:350
+#: src/olympia/editors/forms.py:449
 msgid "Someone else is reviewing this theme."
 msgstr ""
 
 #. L10n: Description of what can be searched for.
-#: src/olympia/editors/forms.py:447
+#: src/olympia/editors/forms.py:546
 msgid "app, reviewer, or comment"
 msgstr ""
 
@@ -8908,290 +7380,275 @@ msgstr ""
 msgid "Rejected or Unreviewed"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:123 src/olympia/editors/helpers.py:136
+#: src/olympia/editors/helpers.py:125 src/olympia/editors/helpers.py:138
 msgid "Queue"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:124
-#: src/olympia/editors/templates/editors/base.html:50
-#: src/olympia/editors/templates/editors/base.html:65
+#: src/olympia/editors/helpers.py:126 src/olympia/editors/templates/editors/base.html:50 src/olympia/editors/templates/editors/base.html:65
 msgid "Pending Updates"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:125
-#: src/olympia/editors/templates/editors/base.html:48
-#: src/olympia/editors/templates/editors/base.html:63
+#: src/olympia/editors/helpers.py:127 src/olympia/editors/templates/editors/base.html:48 src/olympia/editors/templates/editors/base.html:63
 msgid "Full Reviews"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:126
-#: src/olympia/editors/templates/editors/base.html:52
-#: src/olympia/editors/templates/editors/base.html:67
+#: src/olympia/editors/helpers.py:128 src/olympia/editors/templates/editors/base.html:52 src/olympia/editors/templates/editors/base.html:67
 msgid "Preliminary Reviews"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:127
-#: src/olympia/editors/templates/editors/base.html:54
+#: src/olympia/editors/helpers.py:129 src/olympia/editors/templates/editors/base.html:54
 msgid "Moderated Reviews"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:128
-#: src/olympia/editors/templates/editors/base.html:46
+#: src/olympia/editors/helpers.py:130 src/olympia/editors/templates/editors/base.html:46
 msgid "Fast Track"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:130
+#: src/olympia/editors/helpers.py:132
 msgid "Pending Themes"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:131
-#: src/olympia/editors/templates/editors/themes/queue.html:4
+#: src/olympia/editors/helpers.py:133 src/olympia/editors/templates/editors/themes/queue.html:4
 msgid "Flagged Themes"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:132
+#: src/olympia/editors/helpers.py:134
 msgid "Update Themes"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:137
+#: src/olympia/editors/helpers.py:139
 msgid "Unlisted Pending Updates"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:138
+#: src/olympia/editors/helpers.py:140
 msgid "Unlisted Full Reviews"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:139
+#: src/olympia/editors/helpers.py:141
 msgid "Unlisted Preliminary Reviews"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:170
+#: src/olympia/editors/helpers.py:142
+msgid "Unlisted All Add-ons"
+msgstr ""
+
+#: src/olympia/editors/helpers.py:173
 msgid "Fast Track ({0})"
 msgid_plural "Fast Track ({0})"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/olympia/editors/helpers.py:175
+#: src/olympia/editors/helpers.py:178
 msgid "Full Review ({0})"
 msgid_plural "Full Reviews ({0})"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/olympia/editors/helpers.py:180
+#: src/olympia/editors/helpers.py:183
 msgid "Pending Update ({0})"
 msgid_plural "Pending Updates ({0})"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/olympia/editors/helpers.py:185
+#: src/olympia/editors/helpers.py:188
 msgid "Preliminary Review ({0})"
 msgid_plural "Preliminary Reviews ({0})"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/olympia/editors/helpers.py:190
+#: src/olympia/editors/helpers.py:193
 msgid "Moderated Review ({0})"
 msgid_plural "Moderated Reviews ({0})"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/olympia/editors/helpers.py:196
+#: src/olympia/editors/helpers.py:199
 msgid "Unlisted Full Review ({0})"
 msgid_plural "Unlisted Full Reviews ({0})"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/olympia/editors/helpers.py:201
+#: src/olympia/editors/helpers.py:204
 msgid "Unlisted Pending Update ({0})"
 msgid_plural "Unlisted Pending Updates ({0})"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/olympia/editors/helpers.py:206
+#: src/olympia/editors/helpers.py:209
 msgid "Unlisted Preliminary Review ({0})"
 msgid_plural "Unlisted Preliminary Reviews ({0})"
 msgstr[0] ""
 msgstr[1] ""
 
-# 85%
-# 83%
-# 100%
-#: src/olympia/editors/helpers.py:261
-#, fuzzy
-msgid "Addon"
-msgstr "Lisäosat"
+#: src/olympia/editors/helpers.py:214
+msgid "Unlisted All Add-ons ({0})"
+msgid_plural "Unlisted All Add-ons ({0})"
+msgstr[0] ""
+msgstr[1] ""
 
-#: src/olympia/editors/helpers.py:262
+#: src/olympia/editors/helpers.py:274
 msgid "Type"
 msgstr "Tyyppi"
 
-#: src/olympia/editors/helpers.py:263
+#: src/olympia/editors/helpers.py:275
 msgid "Waiting Time"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:264
-#: src/olympia/editors/templates/editors/review.html:285
+#: src/olympia/editors/helpers.py:276 src/olympia/editors/templates/editors/review.html:285
 msgid "Flags"
 msgstr ""
 
 # 92%
 # 100%
-#: src/olympia/editors/helpers.py:265
+#: src/olympia/editors/helpers.py:277
 #, fuzzy
 msgid "Applications"
 msgstr "Ohjelmat:"
 
-#: src/olympia/editors/helpers.py:270
+#: src/olympia/editors/helpers.py:282
 msgid "Additional"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:285
+#: src/olympia/editors/helpers.py:302
 msgid "Site Specific"
 msgstr "Sivustokohtainen"
 
-#: src/olympia/editors/helpers.py:287
+#: src/olympia/editors/helpers.py:304
 msgid "Requires External Software"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:289
+#: src/olympia/editors/helpers.py:306
 msgid "Binary Components"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:313
+#: src/olympia/editors/helpers.py:339
 msgid "moments ago"
 msgstr ""
 
 #. L10n: first argument is number of minutes
-#: src/olympia/editors/helpers.py:316
+#: src/olympia/editors/helpers.py:342
 msgid "{0} minute"
 msgid_plural "{0} minutes"
 msgstr[0] ""
 msgstr[1] ""
 
 #. L10n: first argument is number of hours
-#: src/olympia/editors/helpers.py:320
+#: src/olympia/editors/helpers.py:346
 msgid "{0} hour"
 msgid_plural "{0} hours"
 msgstr[0] ""
 msgstr[1] ""
 
 #. L10n: first argument is number of days
-#: src/olympia/editors/helpers.py:324
+#: src/olympia/editors/helpers.py:350
 msgid "{0} day"
 msgid_plural "{0} days"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/olympia/editors/helpers.py:488
-msgid "Push to public"
+#: src/olympia/editors/helpers.py:364
+msgid "Last Review"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:490
-msgid "Grant full review"
+#: src/olympia/editors/helpers.py:366
+msgid "Last Update"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:505
-msgid "Request more information"
-msgstr ""
-
-#: src/olympia/editors/helpers.py:508
-msgid "Request super-review"
-msgstr ""
-
-#: src/olympia/editors/helpers.py:519
-msgid "Grant preliminary review"
-msgstr ""
-
-#: src/olympia/editors/helpers.py:520
-msgid "This will mark the files as preliminarily reviewed."
-msgstr ""
-
-#: src/olympia/editors/helpers.py:522
-msgid ""
-"Use this form to request more information from the author. They will receive"
-" an email and be able to answer here. You will be notified by email when "
-"they reply."
-msgstr ""
-
-#: src/olympia/editors/helpers.py:526
-msgid ""
-"If you have concerns about this add-on's security, copyright issues, or "
-"other concerns that an administrator should look into, enter your comments "
-"in the area below. They will be sent to administrators, not the author."
-msgstr ""
-"Jos uskot, että ylläpitäjän tulisi tarkistaa tämä lisäosa turvallisuus-, "
-"tekijänoikeus- tai muiden ongelmien takia, kirjoita tästä kommentteihin "
-"alle. Kommentteja ei lähetetä lisäosan tekijälle vaan vain ylläpidolle."
-
-#: src/olympia/editors/helpers.py:532
-msgid "This will reject the add-on and remove it from the review queue."
-msgstr ""
-
-#: src/olympia/editors/helpers.py:534
-msgid "Make a comment on this version.  The author won't be able to see this."
-msgstr ""
-
-#: src/olympia/editors/helpers.py:538
-msgid "This will reject the files and remove them from the review queue."
-msgstr ""
-
-#: src/olympia/editors/helpers.py:542
-msgid ""
-"This will mark the add-on as preliminarily reviewed. Future versions will "
-"undergo preliminary review."
-msgstr ""
-
-#: src/olympia/editors/helpers.py:547
-msgid ""
-"This will mark the files as preliminarily reviewed. Future versions will "
-"undergo preliminary review."
-msgstr ""
-
-#: src/olympia/editors/helpers.py:552
-msgid "Retain preliminary review"
-msgstr ""
-
-#: src/olympia/editors/helpers.py:553
-msgid ""
-"This will retain the add-on as preliminarily reviewed. Future versions will "
-"undergo preliminary review."
-msgstr ""
-
-#: src/olympia/editors/helpers.py:558
-msgid ""
-"This will approve a sandboxed version of a public add-on to appear on the "
-"public side."
+#: src/olympia/editors/helpers.py:387
+msgid "No Reviews"
 msgstr ""
 
 #: src/olympia/editors/helpers.py:561
-msgid ""
-"This will reject a version of a public add-on and remove it from the queue."
+msgid "Push to public"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:564
-msgid ""
-"This will mark the add-on and its most recent version and files as public. "
-"Future versions will go into the sandbox until they are reviewed by an "
-"editor."
+#: src/olympia/editors/helpers.py:563
+msgid "Grant full review"
 msgstr ""
-"Tämä valinta merkitsee lisäosan ja sen tiedostojen uusimmat versiot "
-"julkiseksi. Tulevat versiot jäävät odottomaan tarkastusta hiekkalaatikkoon."
+
+#: src/olympia/editors/helpers.py:578
+msgid "Request more information"
+msgstr ""
+
+#: src/olympia/editors/helpers.py:581
+msgid "Request super-review"
+msgstr ""
+
+#: src/olympia/editors/helpers.py:592
+msgid "Grant preliminary review"
+msgstr ""
+
+#: src/olympia/editors/helpers.py:593
+msgid "This will mark the files as preliminarily reviewed."
+msgstr ""
+
+#: src/olympia/editors/helpers.py:595
+msgid "Use this form to request more information from the author. They will receive an email and be able to answer here. You will be notified by email when they reply."
+msgstr ""
+
+#: src/olympia/editors/helpers.py:599
+msgid ""
+"If you have concerns about this add-on's security, copyright issues, or other concerns that an administrator should look into, enter your comments in the area below. They will be sent to "
+"administrators, not the author."
+msgstr ""
+"Jos uskot, että ylläpitäjän tulisi tarkistaa tämä lisäosa turvallisuus-, tekijänoikeus- tai muiden ongelmien takia, kirjoita tästä kommentteihin alle. Kommentteja ei lähetetä lisäosan tekijälle "
+"vaan vain ylläpidolle."
+
+#: src/olympia/editors/helpers.py:605
+msgid "This will reject the add-on and remove it from the review queue."
+msgstr ""
+
+#: src/olympia/editors/helpers.py:607
+msgid "Make a comment on this version. The author won't be able to see this."
+msgstr ""
+
+#: src/olympia/editors/helpers.py:611
+msgid "This will reject the files and remove them from the review queue."
+msgstr ""
+
+#: src/olympia/editors/helpers.py:615
+msgid "This will mark the add-on as preliminarily reviewed. Future versions will undergo preliminary review."
+msgstr ""
+
+#: src/olympia/editors/helpers.py:620
+msgid "This will mark the files as preliminarily reviewed. Future versions will undergo preliminary review."
+msgstr ""
+
+#: src/olympia/editors/helpers.py:625
+msgid "Retain preliminary review"
+msgstr ""
+
+#: src/olympia/editors/helpers.py:626
+msgid "This will retain the add-on as preliminarily reviewed. Future versions will undergo preliminary review."
+msgstr ""
+
+#: src/olympia/editors/helpers.py:631
+msgid "This will approve a sandboxed version of a public add-on to appear on the public side."
+msgstr ""
+
+#: src/olympia/editors/helpers.py:634
+msgid "This will reject a version of a public add-on and remove it from the queue."
+msgstr ""
+
+#: src/olympia/editors/helpers.py:637
+msgid "This will mark the add-on and its most recent version and files as public. Future versions will go into the sandbox until they are reviewed by an editor."
+msgstr "Tämä valinta merkitsee lisäosan ja sen tiedostojen uusimmat versiot julkiseksi. Tulevat versiot jäävät odottomaan tarkastusta hiekkalaatikkoon."
 
 # 85%
 # 100%
 # 83%
-#: src/olympia/editors/helpers.py:637
+#: src/olympia/editors/helpers.py:714
 #, fuzzy
 msgid "add-on"
 msgstr "Lisäosa"
 
-#: src/olympia/editors/helpers.py:940 src/olympia/editors/helpers.py:960
+#: src/olympia/editors/helpers.py:1020 src/olympia/editors/helpers.py:1040
 msgid "Flagged"
 msgstr ""
 
 # 85%
 # 100%
-#: src/olympia/editors/helpers.py:944 src/olympia/editors/helpers.py:963
+#: src/olympia/editors/helpers.py:1024 src/olympia/editors/helpers.py:1043
 #, fuzzy
 msgid "Updates"
 msgstr "Päivitä"
@@ -9244,71 +7701,67 @@ msgstr ""
 msgid "A question about your Theme submission"
 msgstr ""
 
-#: src/olympia/editors/views.py:144
+#: src/olympia/editors/views.py:146
 msgid "New Add-ons (Under 5 days)"
 msgstr ""
 
-#: src/olympia/editors/views.py:145
+#: src/olympia/editors/views.py:147
 msgid "Passable (5 to 10 days)"
 msgstr ""
 
-#: src/olympia/editors/views.py:146
+#: src/olympia/editors/views.py:148
 msgid "Overdue (Over 10 days)"
 msgstr ""
 
-#: src/olympia/editors/views.py:532
+#: src/olympia/editors/views.py:539
 msgid "An unknown error occurred"
 msgstr ""
 
-#: src/olympia/editors/views.py:587
+#: src/olympia/editors/views.py:592
 msgid "Self-reviews are not allowed."
 msgstr "Omia lisäosiaan ei voi tarkastaa."
 
-#: src/olympia/editors/views.py:609
+#: src/olympia/editors/views.py:613
 msgid "Review successfully processed."
 msgstr "Arvostelu käsiteltiin."
 
-#: src/olympia/editors/views.py:807
+#: src/olympia/editors/views.py:812
 msgid "was approved"
 msgstr ""
 
-#: src/olympia/editors/views.py:808
+#: src/olympia/editors/views.py:813
 msgid "given preliminary review"
 msgstr ""
 
-#: src/olympia/editors/views.py:809
+#: src/olympia/editors/views.py:814
 msgid "rejected"
 msgstr ""
 
-#: src/olympia/editors/views.py:810
+#: src/olympia/editors/views.py:815
 msgctxt "editors_review_history_nominated_adminreview"
 msgid "escalated"
 msgstr ""
 
-#: src/olympia/editors/views.py:812
+#: src/olympia/editors/views.py:817
 msgid "needs more information"
 msgstr ""
 
-#: src/olympia/editors/views.py:813
+#: src/olympia/editors/views.py:818
 msgid "needs super review"
 msgstr ""
 
-#: src/olympia/editors/views.py:814
+#: src/olympia/editors/views.py:819
 msgid "commented"
 msgstr ""
 
 #: src/olympia/editors/views_themes.py:326
 msgid "{0} theme review successfully processed (+{1} points, {2} total)."
-msgid_plural ""
-"{0} theme reviews successfully processed (+{1} points, {2} total)."
+msgid_plural "{0} theme reviews successfully processed (+{1} points, {2} total)."
 msgstr[0] ""
 msgstr[1] ""
 
 #: src/olympia/editors/views_themes.py:341
-msgid ""
-"Your theme locks have successfully been released. Other reviewers may now "
-"review those released themes. You may have to refresh the page to see the "
-"changes reflected in the table below."
+msgid "Your theme locks have successfully been released. Other reviewers may now review those released themes. You may have to refresh the page to see the changes reflected in the table below."
 msgstr ""
 
 #: src/olympia/editors/templates/editors/abuse_reports.html:4
@@ -9333,9 +7786,7 @@ msgstr ""
 msgid "Return to the Editor Tools homepage"
 msgstr ""
 
-#: src/olympia/editors/templates/editors/base.html:43
-#: src/olympia/editors/templates/editors/themes/base.html:14
-#: src/olympia/editors/templates/editors/themes/base.html:28
+#: src/olympia/editors/templates/editors/base.html:43 src/olympia/editors/templates/editors/themes/base.html:14 src/olympia/editors/templates/editors/themes/base.html:28
 #: src/olympia/editors/templates/editors/themes/queue.html:25
 msgid "Queues"
 msgstr ""
@@ -9344,73 +7795,53 @@ msgstr ""
 msgid "Unlisted Queues"
 msgstr ""
 
-#: src/olympia/editors/templates/editors/base.html:72
-#: src/olympia/editors/templates/editors/performance.html:6
+#: src/olympia/editors/templates/editors/base.html:74 src/olympia/editors/templates/editors/performance.html:6
 msgid "Performance"
 msgstr "Suorituskyky"
 
-#: src/olympia/editors/templates/editors/base.html:75
-#: src/olympia/editors/templates/editors/themes/base.html:19
-#: src/olympia/editors/templates/editors/themes/base.html:38
+#: src/olympia/editors/templates/editors/base.html:77 src/olympia/editors/templates/editors/themes/base.html:19 src/olympia/editors/templates/editors/themes/base.html:38
 msgid "Logs"
 msgstr ""
 
-#: src/olympia/editors/templates/editors/base.html:78
-#: src/olympia/editors/templates/editors/reviewlog.html:4
-#: src/olympia/editors/templates/editors/reviewlog.html:27
+#: src/olympia/editors/templates/editors/base.html:80 src/olympia/editors/templates/editors/reviewlog.html:4 src/olympia/editors/templates/editors/reviewlog.html:27
 msgid "Add-on Review Log"
 msgstr ""
 
-#: src/olympia/editors/templates/editors/base.html:80
-#: src/olympia/editors/templates/editors/eventlog.html:4
-#: src/olympia/editors/templates/editors/eventlog.html:8
+#: src/olympia/editors/templates/editors/base.html:82 src/olympia/editors/templates/editors/eventlog.html:4 src/olympia/editors/templates/editors/eventlog.html:8
 #: src/olympia/editors/templates/editors/eventlog_detail.html:4
 msgid "Moderated Review Log"
 msgstr ""
 
-#: src/olympia/editors/templates/editors/base.html:82
-#: src/olympia/editors/templates/editors/beta_signed_log.html:4
-#: src/olympia/editors/templates/editors/beta_signed_log.html:8
+#: src/olympia/editors/templates/editors/base.html:84 src/olympia/editors/templates/editors/beta_signed_log.html:4 src/olympia/editors/templates/editors/beta_signed_log.html:8
 msgid "Signed Beta Files Log"
 msgstr ""
 
-#: src/olympia/editors/templates/editors/base.html:87
-#: src/olympia/editors/templates/editors/includes/daily-message.html:4
+#: src/olympia/editors/templates/editors/base.html:89 src/olympia/editors/templates/editors/includes/daily-message.html:4
 msgid "Announcement"
 msgstr ""
 
 #. "Filter" is a button label (verb)
-#: src/olympia/editors/templates/editors/beta_signed_log.html:17
-#: src/olympia/editors/templates/editors/eventlog.html:24
-#: src/olympia/editors/templates/editors/reviewlog.html:21
-#: src/olympia/editors/templates/editors/themes/macros.html:45
-#: src/olympia/editors/templates/editors/themes/includes/logs_filter_deleted.html:12
+#: src/olympia/editors/templates/editors/beta_signed_log.html:17 src/olympia/editors/templates/editors/eventlog.html:24 src/olympia/editors/templates/editors/reviewlog.html:21
+#: src/olympia/editors/templates/editors/themes/macros.html:45 src/olympia/editors/templates/editors/themes/includes/logs_filter_deleted.html:12
 msgid "Filter"
 msgstr ""
 
 # 100%
-#: src/olympia/editors/templates/editors/beta_signed_log.html:23
-#: src/olympia/editors/templates/editors/eventlog.html:30
-#: src/olympia/editors/templates/editors/reviewlog.html:34
+#: src/olympia/editors/templates/editors/beta_signed_log.html:23 src/olympia/editors/templates/editors/eventlog.html:30 src/olympia/editors/templates/editors/reviewlog.html:34
 #: src/olympia/editors/templates/editors/themes/logs.html:16
 msgid "Date"
 msgstr "Päiväys"
 
-#: src/olympia/editors/templates/editors/beta_signed_log.html:24
-#: src/olympia/editors/templates/editors/eventlog.html:31
-#: src/olympia/editors/templates/editors/reviewlog.html:35
+#: src/olympia/editors/templates/editors/beta_signed_log.html:24 src/olympia/editors/templates/editors/eventlog.html:31 src/olympia/editors/templates/editors/reviewlog.html:35
 msgid "Event"
 msgstr ""
 
-#: src/olympia/editors/templates/editors/beta_signed_log.html:37
-#: src/olympia/editors/templates/editors/eventlog.html:44
-#: src/olympia/editors/templates/editors/home.html:180
+#: src/olympia/editors/templates/editors/beta_signed_log.html:37 src/olympia/editors/templates/editors/eventlog.html:44 src/olympia/editors/templates/editors/home.html:180
 msgid "More details."
 msgstr ""
 
 # 87%
-#: src/olympia/editors/templates/editors/beta_signed_log.html:46
-#: src/olympia/editors/templates/editors/eventlog.html:53
+#: src/olympia/editors/templates/editors/beta_signed_log.html:46 src/olympia/editors/templates/editors/eventlog.html:53
 #, fuzzy
 msgid "No events found for this period."
 msgstr "Ei tarkastuksia annetulla aikavälillä."
@@ -9461,22 +7892,19 @@ msgid_plural "Preliminary Reviews ({num})"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/olympia/editors/templates/editors/home.html:36
-#: src/olympia/editors/templates/editors/home.html:86
+#: src/olympia/editors/templates/editors/home.html:36 src/olympia/editors/templates/editors/home.html:86
 msgid "Current waiting times:"
 msgstr ""
 
 # 81%
 # 100%
-#: src/olympia/editors/templates/editors/home.html:44
-#: src/olympia/editors/templates/editors/home.html:94
+#: src/olympia/editors/templates/editors/home.html:44 src/olympia/editors/templates/editors/home.html:94
 msgid "{0} add-on"
 msgid_plural "{0} add-ons"
 msgstr[0] "{0} lisäosa"
 msgstr[1] "{0} lisäosaa"
 
-#: src/olympia/editors/templates/editors/home.html:45
-#: src/olympia/editors/templates/editors/home.html:95
+#: src/olympia/editors/templates/editors/home.html:45 src/olympia/editors/templates/editors/home.html:95
 #, python-format
 msgid "{0}%%"
 msgstr ""
@@ -9499,14 +7927,11 @@ msgid_plural "Unlisted Preliminary Reviews ({num})"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/olympia/editors/templates/editors/home.html:109
-#: src/olympia/editors/templates/editors/performance.html:37
-#: src/olympia/editors/templates/editors/themes/home.html:54
+#: src/olympia/editors/templates/editors/home.html:109 src/olympia/editors/templates/editors/performance.html:37 src/olympia/editors/templates/editors/themes/home.html:54
 msgid "Total Reviews"
 msgstr "Tarkastuksia yhteensä"
 
-#: src/olympia/editors/templates/editors/home.html:110
-#: src/olympia/editors/templates/editors/themes/home.html:55
+#: src/olympia/editors/templates/editors/home.html:110 src/olympia/editors/templates/editors/themes/home.html:55
 msgid "Reviews This Month"
 msgstr ""
 
@@ -9514,8 +7939,7 @@ msgstr ""
 msgid "New Editors"
 msgstr "Uudet toimittajat"
 
-#: src/olympia/editors/templates/editors/home.html:126
-#: src/olympia/editors/templates/editors/home.html:141
+#: src/olympia/editors/templates/editors/home.html:126 src/olympia/editors/templates/editors/home.html:141
 msgid "You're #{0} with {1} reviews"
 msgstr ""
 
@@ -9526,13 +7950,11 @@ msgid_plural "Moderated Reviews ({num})"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/olympia/editors/templates/editors/leaderboard.html:3
-#: src/olympia/editors/templates/editors/includes/reviewers_score_bar.html:56
+#: src/olympia/editors/templates/editors/leaderboard.html:3 src/olympia/editors/templates/editors/includes/reviewers_score_bar.html:56
 msgid "Reviewer Leaderboard"
 msgstr ""
 
-#: src/olympia/editors/templates/editors/leaderboard.html:18
-#: src/olympia/editors/templates/editors/performance.html:65
+#: src/olympia/editors/templates/editors/leaderboard.html:18 src/olympia/editors/templates/editors/performance.html:65
 msgid "No review points awarded yet."
 msgstr ""
 
@@ -9552,8 +7974,7 @@ msgstr ""
 msgid "Update message of the day"
 msgstr ""
 
-#: src/olympia/editors/templates/editors/motd.html:15
-#: src/olympia/editors/templates/editors/review.html:224
+#: src/olympia/editors/templates/editors/motd.html:15 src/olympia/editors/templates/editors/review.html:224
 msgid "Save"
 msgstr "Tallenna"
 
@@ -9623,50 +8044,46 @@ msgstr ""
 msgid "clear search"
 msgstr ""
 
-#: src/olympia/editors/templates/editors/queue.html:72
-#: src/olympia/editors/templates/editors/queue.html:122
+#: src/olympia/editors/templates/editors/queue.html:78 src/olympia/editors/templates/editors/queue.html:128
 msgid "Process Reviews"
 msgstr "Käsittele arvostelut"
 
-#: src/olympia/editors/templates/editors/queue.html:80
+#: src/olympia/editors/templates/editors/queue.html:86
 msgid "Moderation actions:"
 msgstr ""
 
-#: src/olympia/editors/templates/editors/queue.html:90
+#: src/olympia/editors/templates/editors/queue.html:96
 #, python-format
 msgid "by %(user)s on %(date)s %(stars)s (%(locale)s)"
 msgstr ""
 
-#: src/olympia/editors/templates/editors/queue.html:106
+#: src/olympia/editors/templates/editors/queue.html:112
 #, python-format
-msgid ""
-"<strong>%(reason)s</strong> <span class=\"light\">Flagged by %(user)s on "
-"%(date)s</span>"
+msgid "<strong>%(reason)s</strong> <span class=\"light\">Flagged by %(user)s on %(date)s</span>"
 msgstr ""
 
-#: src/olympia/editors/templates/editors/queue.html:119
-msgid "All reviews have been moderated.  Good work!"
+#: src/olympia/editors/templates/editors/queue.html:125
+msgid "All reviews have been moderated. Good work!"
 msgstr ""
 
-#: src/olympia/editors/templates/editors/queue.html:161
+#: src/olympia/editors/templates/editors/queue.html:167
 msgid "Version Notes / Notes for Reviewer"
 msgstr ""
 
 # %1 is the queue mode
-#: src/olympia/editors/templates/editors/queue.html:169
+#: src/olympia/editors/templates/editors/queue.html:175
 msgid "There are currently no add-ons of this type to review."
 msgstr "Tällä hetkellä ei ole yhtään tarkastettavia in lisäosia."
 
-#: src/olympia/editors/templates/editors/queue.html:181
-#: src/olympia/editors/templates/editors/themes/queue_list.html:85
+#: src/olympia/editors/templates/editors/queue.html:187 src/olympia/editors/templates/editors/themes/queue_list.html:85
 msgid "Helpful Links:"
 msgstr ""
 
-#: src/olympia/editors/templates/editors/queue.html:182
+#: src/olympia/editors/templates/editors/queue.html:188
 msgid "Add-on Policy"
 msgstr "Lisäosakäytäntö"
 
-#: src/olympia/editors/templates/editors/queue.html:184
+#: src/olympia/editors/templates/editors/queue.html:190
 msgid "Editors' Guide"
 msgstr "Toimittajan opas"
 
@@ -9679,16 +8096,13 @@ msgstr ""
 msgid "Add-on user change history"
 msgstr ""
 
-#: src/olympia/editors/templates/editors/review.html:52
-#: src/olympia/editors/templates/editors/review.html:266
+#: src/olympia/editors/templates/editors/review.html:52 src/olympia/editors/templates/editors/review.html:266
 msgid "Add-on History"
 msgstr ""
 
 #: src/olympia/editors/templates/editors/review.html:64
 #, python-format
-msgid ""
-"Version %(version)s &middot; %(created)s <span class=\"light\">&middot; "
-"%(version_status)s</span>"
+msgid "Version %(version)s &middot; %(created)s <span class=\"light\">&middot; %(version_status)s</span>"
 msgstr ""
 
 #: src/olympia/editors/templates/editors/review.html:73
@@ -9714,17 +8128,14 @@ msgid "This version has not been reviewed."
 msgstr "Tällä lisäosalla ei ole vielä yhtään käyttäjäarviota."
 
 #: src/olympia/editors/templates/editors/review.html:154
-msgid ""
-"You can still submit this form, however only do so if you know it won't "
-"conflict."
+msgid "You can still submit this form, however only do so if you know it won't conflict."
 msgstr ""
 
 #: src/olympia/editors/templates/editors/review.html:161
 msgid "Insert canned response..."
 msgstr ""
 
-#: src/olympia/editors/templates/editors/review.html:167
-#: src/olympia/files/templates/files/viewer.html:54
+#: src/olympia/editors/templates/editors/review.html:167 src/olympia/files/templates/files/viewer.html:54
 msgid "Files:"
 msgstr "Tiedostot:"
 
@@ -9733,23 +8144,18 @@ msgid "Tested on:"
 msgstr ""
 
 #: src/olympia/editors/templates/editors/review.html:220
-msgid ""
-"<strong>Warning!</strong> Another user was viewing this page before you."
+msgid "<strong>Warning!</strong> Another user was viewing this page before you."
 msgstr ""
 
 #: src/olympia/editors/templates/editors/review.html:237
-msgid ""
-"The whiteboard is the place to exchange information relevant to\n"
-"               this addon (whatever the version), between the developer and the\n"
-"               editor. This is visible and editable by both."
+msgid "The whiteboard is the place to exchange information relevant to this addon (whatever the version), between the developer and the editor. This is visible and editable by both."
 msgstr ""
 
 #: src/olympia/editors/templates/editors/review.html:241
 msgid "Update the whiteboard"
 msgstr ""
 
-#: src/olympia/editors/templates/editors/review.html:257
-#: src/olympia/editors/templates/editors/review.html:258
+#: src/olympia/editors/templates/editors/review.html:257 src/olympia/editors/templates/editors/review.html:258
 msgid "(admin)"
 msgstr ""
 
@@ -9777,18 +8183,15 @@ msgstr "Toimittaja"
 msgid "Add-on has been deleted."
 msgstr ""
 
-#: src/olympia/editors/templates/editors/reviewlog.html:59
-#: src/olympia/editors/templates/editors/themes/logs.html:36
+#: src/olympia/editors/templates/editors/reviewlog.html:59 src/olympia/editors/templates/editors/themes/logs.html:36
 msgid "Show Comments"
 msgstr "Näytä kommentit"
 
-#: src/olympia/editors/templates/editors/reviewlog.html:60
-#: src/olympia/editors/templates/editors/themes/logs.html:37
+#: src/olympia/editors/templates/editors/reviewlog.html:60 src/olympia/editors/templates/editors/themes/logs.html:37
 msgid "Hide Comments"
 msgstr "Piilota kommentit"
 
-#: src/olympia/editors/templates/editors/reviewlog.html:72
-#: src/olympia/editors/templates/editors/themes/logs.html:54
+#: src/olympia/editors/templates/editors/reviewlog.html:72 src/olympia/editors/templates/editors/themes/logs.html:54
 msgid "No reviews found for this period."
 msgstr "Ei tarkastuksia annetulla aikavälillä."
 
@@ -9847,11 +8250,8 @@ msgid "You have <span>{0}</span> points."
 msgstr ""
 
 # 88%
-#: src/olympia/editors/templates/editors/includes/search_results_themes.html:6
-#: src/olympia/editors/templates/editors/themes/history_table.html:7
-#: src/olympia/editors/templates/editors/themes/logs.html:19
-#: src/olympia/editors/templates/editors/themes/queue_list.html:49
-#: src/olympia/editors/templates/editors/themes/single.html:26
+#: src/olympia/editors/templates/editors/includes/search_results_themes.html:6 src/olympia/editors/templates/editors/themes/history_table.html:7
+#: src/olympia/editors/templates/editors/themes/logs.html:19 src/olympia/editors/templates/editors/themes/queue_list.html:49 src/olympia/editors/templates/editors/themes/single.html:26
 #: src/olympia/editors/templates/editors/themes/themes.html:45
 #, fuzzy
 msgid "Reviewer"
@@ -9877,8 +8277,7 @@ msgstr ""
 msgid "Review Date"
 msgstr ""
 
-#: src/olympia/editors/templates/editors/themes/history_table.html:9
-#: src/olympia/editors/templates/editors/themes/logs.html:18
+#: src/olympia/editors/templates/editors/themes/history_table.html:9 src/olympia/editors/templates/editors/themes/logs.html:18
 msgid "Action"
 msgstr ""
 
@@ -10025,7 +8424,7 @@ msgstr ""
 msgid "Describe your reason for flagging"
 msgstr ""
 
-#: src/olympia/files/forms.py:88
+#: src/olympia/files/forms.py:90
 msgid "Cannot diff a version against itself"
 msgstr ""
 
@@ -10043,9 +8442,7 @@ msgid "Problems decoding {0}."
 msgstr ""
 
 #: src/olympia/files/helpers.py:186
-msgid ""
-"This file is not viewable online. Please download the file to view the "
-"contents."
+msgid "This file is not viewable online. Please download the file to view the contents."
 msgstr ""
 
 #: src/olympia/files/helpers.py:194
@@ -10062,53 +8459,51 @@ msgstr ""
 msgid "There was an error accessing file %s."
 msgstr ""
 
-#: src/olympia/files/utils.py:343
+#: src/olympia/files/utils.py:340
 msgid "Could not parse uploaded file."
 msgstr ""
 
-#: src/olympia/files/utils.py:380
+#: src/olympia/files/utils.py:377
 msgid "Invalid file name in archive: {0}"
 msgstr ""
 
-#: src/olympia/files/utils.py:388
+#: src/olympia/files/utils.py:385
 msgid "File exceeding size limit in archive: {0}"
 msgstr ""
 
-#: src/olympia/files/utils.py:439
+#: src/olympia/files/utils.py:436
 msgid "Invalid archive."
 msgstr ""
 
-#: src/olympia/files/utils.py:529 src/olympia/files/utils.py:532
+#: src/olympia/files/utils.py:526 src/olympia/files/utils.py:529
 msgid "Could not parse the manifest file."
 msgstr ""
 
-#: src/olympia/files/utils.py:551
+#: src/olympia/files/utils.py:548
 msgid "Could not find an add-on ID."
 msgstr ""
 
-#: src/olympia/files/utils.py:554
+#: src/olympia/files/utils.py:551
 msgid "Add-on ID must be 64 characters or less."
 msgstr ""
 
-#: src/olympia/files/utils.py:556
+#: src/olympia/files/utils.py:553
 msgid "Add-on ID doesn't match add-on."
 msgstr ""
 
-#: src/olympia/files/utils.py:564
+#: src/olympia/files/utils.py:561
 msgid "Duplicate add-on ID found."
 msgstr ""
 
-#: src/olympia/files/utils.py:567
+#: src/olympia/files/utils.py:564
 msgid "Version numbers should have fewer than 32 characters."
 msgstr ""
 
-#: src/olympia/files/utils.py:570
-msgid ""
-"Version numbers should only contain letters, numbers, and these punctuation "
-"characters: +*.-_."
+#: src/olympia/files/utils.py:567
+msgid "Version numbers should only contain letters, numbers, and these punctuation characters: +*.-_."
 msgstr ""
 
-#: src/olympia/files/utils.py:587
+#: src/olympia/files/utils.py:584
 msgid "<em:type> doesn't match add-on"
 msgstr ""
 
@@ -10132,9 +8527,7 @@ msgstr "Lataa nyt"
 
 #: src/olympia/files/templates/files/file.html:4
 #, python-format
-msgid ""
-"Version: %(version)s &bull; Size: %(size)s &bull; MD5 hash: %(md5)s &bull; "
-"Mimetype: %(mimetype)s"
+msgid "Version: %(version)s &bull; Size: %(size)s &bull; MD5 hash: %(md5)s &bull; Mimetype: %(mimetype)s"
 msgstr ""
 
 #: src/olympia/files/templates/files/viewer.html:4
@@ -10173,48 +8566,39 @@ msgstr ""
 msgid "Tab stops:"
 msgstr ""
 
-#: src/olympia/files/templates/files/viewer.html:79
-#: src/olympia/files/templates/files/viewer.html:80
+#: src/olympia/files/templates/files/viewer.html:79 src/olympia/files/templates/files/viewer.html:80
 msgid "Up file"
 msgstr ""
 
-#: src/olympia/files/templates/files/viewer.html:84
-#: src/olympia/files/templates/files/viewer.html:85
+#: src/olympia/files/templates/files/viewer.html:84 src/olympia/files/templates/files/viewer.html:85
 msgid "Down file"
 msgstr ""
 
-#: src/olympia/files/templates/files/viewer.html:90
-#: src/olympia/files/templates/files/viewer.html:91
+#: src/olympia/files/templates/files/viewer.html:90 src/olympia/files/templates/files/viewer.html:91
 msgid "Previous diff"
 msgstr ""
 
-#: src/olympia/files/templates/files/viewer.html:93
-#: src/olympia/files/templates/files/viewer.html:94
+#: src/olympia/files/templates/files/viewer.html:93 src/olympia/files/templates/files/viewer.html:94
 msgid "Previous note"
 msgstr ""
 
-#: src/olympia/files/templates/files/viewer.html:100
-#: src/olympia/files/templates/files/viewer.html:101
+#: src/olympia/files/templates/files/viewer.html:100 src/olympia/files/templates/files/viewer.html:101
 msgid "Next diff"
 msgstr ""
 
-#: src/olympia/files/templates/files/viewer.html:103
-#: src/olympia/files/templates/files/viewer.html:104
+#: src/olympia/files/templates/files/viewer.html:103 src/olympia/files/templates/files/viewer.html:104
 msgid "Next note"
 msgstr ""
 
-#: src/olympia/files/templates/files/viewer.html:109
-#: src/olympia/files/templates/files/viewer.html:110
+#: src/olympia/files/templates/files/viewer.html:109 src/olympia/files/templates/files/viewer.html:110
 msgid "Expand all"
 msgstr ""
 
-#: src/olympia/files/templates/files/viewer.html:114
-#: src/olympia/files/templates/files/viewer.html:115
+#: src/olympia/files/templates/files/viewer.html:114 src/olympia/files/templates/files/viewer.html:115
 msgid "Hide or unhide tree"
 msgstr ""
 
-#: src/olympia/files/templates/files/viewer.html:119
-#: src/olympia/files/templates/files/viewer.html:120
+#: src/olympia/files/templates/files/viewer.html:119 src/olympia/files/templates/files/viewer.html:120
 msgid "Wrap or unwrap text"
 msgstr ""
 
@@ -10224,6 +8608,10 @@ msgstr ""
 
 #: src/olympia/files/templates/files/viewer.html:134
 msgid "Fetching file."
+msgstr ""
+
+#: src/olympia/legacy_api/views.py:255
+msgid "Not implemented yet."
 msgstr ""
 
 #: src/olympia/lib/constants.py:6
@@ -10882,12 +9270,7 @@ msgstr ""
 msgid "Zimbabwe Dollar"
 msgstr ""
 
-#: src/olympia/lib/video/ffmpeg.py:112 src/olympia/lib/video/totem.py:81
-msgid "Videos must be in WebM."
-msgstr ""
-
-#: src/olympia/pages/templates/pages/about.lhtml:3
-#: src/olympia/pages/templates/pages/about.lhtml:10
+#: src/olympia/pages/templates/pages/about.lhtml:3 src/olympia/pages/templates/pages/about.lhtml:10
 msgid "About Mozilla Add-ons"
 msgstr ""
 
@@ -10897,11 +9280,8 @@ msgstr ""
 
 #: src/olympia/pages/templates/pages/about.lhtml:13
 msgid ""
-"addons.mozilla.org, commonly known as \"AMO\", is Mozilla's official site "
-"for add-ons to Mozilla software, such as Firefox, Thunderbird, and "
-"SeaMonkey. Add-ons let you add new features and change the way your browser "
-"or application works.  Take a look around and explore the thousands of ways "
-"to customize the way you do things online."
+"addons.mozilla.org, commonly known as \"AMO\", is Mozilla's official site for add-ons to Mozilla software, such as Firefox, Thunderbird, and SeaMonkey. Add-ons let you add new features and change "
+"the way your browser or application works. Take a look around and explore the thousands of ways to customize the way you do things online."
 msgstr ""
 
 #: src/olympia/pages/templates/pages/about.lhtml:19
@@ -10910,11 +9290,8 @@ msgstr ""
 
 #: src/olympia/pages/templates/pages/about.lhtml:20
 msgid ""
-"The add-ons listed here have been created by thousands of developers from "
-"our community, ranging from individual hobbyists to large corporations. All "
-"publicly listed add-ons are reviewed by a team of editors before being "
-"released. Add-ons marked as Experimental have not been reviewed and should "
-"only be installed with caution."
+"The add-ons listed here have been created by thousands of developers from our community, ranging from individual hobbyists to large corporations. All publicly listed add-ons are reviewed by a team "
+"of editors before being released. Add-ons marked as Experimental have not been reviewed and should only be installed with caution."
 msgstr ""
 
 #: src/olympia/pages/templates/pages/about.lhtml:26
@@ -10922,30 +9299,22 @@ msgid "How do I keep up with what's happening at AMO?"
 msgstr ""
 
 #: src/olympia/pages/templates/pages/about.lhtml:27
-msgid ""
-"There are several ways to find out the latest news from the world of add-"
-"ons:"
+msgid "There are several ways to find out the latest news from the world of add-ons:"
 msgstr ""
 
 #: src/olympia/pages/templates/pages/about.lhtml:29
 #, python-format
-msgid ""
-"Our <a href=\"%(url)s\">Add-ons Blog</a> is regularly updated with "
-"information for both add-on enthusiasts and developers."
+msgid "Our <a href=\"%(url)s\">Add-ons Blog</a> is regularly updated with information for both add-on enthusiasts and developers."
 msgstr ""
 
 #: src/olympia/pages/templates/pages/about.lhtml:32
 #, python-format
-msgid ""
-"We often post news, tips, and tricks to our Twitter account, <a "
-"href=\"%(url)s\">mozamo</a>"
+msgid "We often post news, tips, and tricks to our Twitter account, <a href=\"%(url)s\">mozamo</a>"
 msgstr ""
 
 #: src/olympia/pages/templates/pages/about.lhtml:34
 #, python-format
-msgid ""
-"Our <a href=\"%(url)s\">forums</a> are a good place to interact with the "
-"add-ons community and discuss upcoming changes to AMO."
+msgid "Our <a href=\"%(url)s\">forums</a> are a good place to interact with the add-ons community and discuss upcoming changes to AMO."
 msgstr ""
 
 #: src/olympia/pages/templates/pages/about.lhtml:39
@@ -10953,37 +9322,27 @@ msgid "This sounds great! How can I get involved?"
 msgstr ""
 
 #: src/olympia/pages/templates/pages/about.lhtml:40
-msgid ""
-"There are plenty of ways to get involved. If you're on the technical side:"
+msgid "There are plenty of ways to get involved. If you're on the technical side:"
 msgstr ""
 
 #: src/olympia/pages/templates/pages/about.lhtml:42
 #, python-format
-msgid ""
-"<a href=\"%(url)s\">Make your own add-on</a>. We provide free hosting and "
-"update services and can help you reach a large audience of users."
+msgid "<a href=\"%(url)s\">Make your own add-on</a>. We provide free hosting and update services and can help you reach a large audience of users."
 msgstr ""
 
 #: src/olympia/pages/templates/pages/about.lhtml:45
 #, python-format
-msgid ""
-"If you have add-on development experience, <a href=\"%(url)s\"> become an "
-"editor</a>! Our editors are add-on fans with a technical background who "
-"review add-ons for code quality and stability."
+msgid "If you have add-on development experience, <a href=\"%(url)s\"> become an editor</a>! Our editors are add-on fans with a technical background who review add-ons for code quality and stability."
 msgstr ""
 
 #: src/olympia/pages/templates/pages/about.lhtml:49
 #, python-format
 msgid ""
-"Help improve this website. It's open source, and you can file bugs and "
-"submit patches. <a href=\"%(url)s\"> GitHub</a> contains all of our current "
-"bugs, legacy bugs can still be found in Bugzilla."
+"Help improve this website. It's open source, and you can file bugs and submit patches. <a href=\"%(url)s\"> GitHub</a> contains all of our current bugs, legacy bugs can still be found in Bugzilla."
 msgstr ""
 
 #: src/olympia/pages/templates/pages/about.lhtml:55
-msgid ""
-"If you're interested in add-ons but not quite as technical, there are still "
-"ways to help:"
+msgid "If you're interested in add-ons but not quite as technical, there are still ways to help:"
 msgstr ""
 
 #: src/olympia/pages/templates/pages/about.lhtml:58
@@ -10996,9 +9355,7 @@ msgid "Participate in our <a href=\"%(url)s\">forums</a>."
 msgstr ""
 
 #: src/olympia/pages/templates/pages/about.lhtml:61
-msgid ""
-"Review add-ons on the site. Add-on authors are more likely to improve their "
-"add-ons and write new ones when they know people appreciate their work."
+msgid "Review add-ons on the site. Add-on authors are more likely to improve their add-ons and write new ones when they know people appreciate their work."
 msgstr ""
 
 #: src/olympia/pages/templates/pages/about.lhtml:66
@@ -11008,16 +9365,13 @@ msgstr ""
 #: src/olympia/pages/templates/pages/about.lhtml:67
 #, python-format
 msgid ""
-"A good place to start is our <a href=\"%(faq_url)s\"><abbr "
-"title=\"Frequently Asked Questions\">FAQ</abbr></a>. If you don't find an "
-"answer there, you can <a href=\"%(forum_url)s\"> ask on our forums</a>."
+"A good place to start is our <a href=\"%(faq_url)s\"><abbr title=\"Frequently Asked Questions\">FAQ</abbr></a>. If you don't find an answer there, you can <a href=\"%(forum_url)s\"> ask on our "
+"forums</a>."
 msgstr ""
 
 #: src/olympia/pages/templates/pages/about.lhtml:72
 #, python-format
-msgid ""
-"If you really need to contact someone from the Mozilla team, please see our "
-"<a href=\"%(url)s\"> contact information</a> page."
+msgid "If you really need to contact someone from the Mozilla team, please see our <a href=\"%(url)s\"> contact information</a> page."
 msgstr ""
 
 #: src/olympia/pages/templates/pages/about.lhtml:76
@@ -11027,10 +9381,8 @@ msgstr ""
 #: src/olympia/pages/templates/pages/about.lhtml:77
 #, python-format
 msgid ""
-"Over the years, many people have contributed to this website, including both"
-" volunteers from the community and a dedicated AMO team. A list of "
-"significant contributors can be found on our <a href=\"%(url)s\"> Site "
-"Credits</a> page."
+"Over the years, many people have contributed to this website, including both volunteers from the community and a dedicated AMO team. A list of significant contributors can be found on our <a href="
+"\"%(url)s\"> Site Credits</a> page."
 msgstr ""
 
 # 79%
@@ -11044,9 +9396,7 @@ msgid "Add-on Compatibility Reporter has been installed"
 msgstr ""
 
 #: src/olympia/pages/templates/pages/acr_firstrun.html:28
-msgid ""
-"It’s easy to help us make sure add-ons are updated in time for the release "
-"of the next version of Firefox."
+msgid "It’s easy to help us make sure add-ons are updated in time for the release of the next version of Firefox."
 msgstr ""
 
 #: src/olympia/pages/templates/pages/acr_firstrun.html:35
@@ -11055,35 +9405,27 @@ msgstr ""
 
 #: src/olympia/pages/templates/pages/acr_firstrun.html:40
 msgid ""
-"As you start browsing and using your add-ons, take careful note of anything "
-"that seems different from when you last used the extension. This might be a "
-"display glitch, such as a menu item missing, or something more serious, like"
-" the add-on not working at all or showing errors."
+"As you start browsing and using your add-ons, take careful note of anything that seems different from when you last used the extension. This might be a display glitch, such as a menu item missing, "
+"or something more serious, like the add-on not working at all or showing errors."
 msgstr ""
 
 #: src/olympia/pages/templates/pages/acr_firstrun.html:49
 msgid ""
-"Once you know whether a particular add-on works properly or has problems, "
-"open the Add-ons Manager and click Compatibility next to the add-on to let "
-"Mozilla know what you found in your testing. Submitting a report will help "
-"us tell the add-on developer whether their add-on is working properly in "
-"this version or might need some fixes."
+"Once you know whether a particular add-on works properly or has problems, open the Add-ons Manager and click Compatibility next to the add-on to let Mozilla know what you found in your testing. "
+"Submitting a report will help us tell the add-on developer whether their add-on is working properly in this version or might need some fixes."
 msgstr ""
 
 #: src/olympia/pages/templates/pages/acr_firstrun.html:61
 #, python-format
 msgid ""
-"If you upgrade to a new version of Firefox or update your add-ons, your "
-"reports for the old versions will be hidden to allow you to test the new "
-"version. If you have any questions, please ask in <a href=\"%(url)s\">our "
-"forums</a>."
+"If you upgrade to a new version of Firefox or update your add-ons, your reports for the old versions will be hidden to allow you to test the new version. If you have any questions, please ask in <a "
+"href=\"%(url)s\">our forums</a>."
 msgstr ""
 
 #: src/olympia/pages/templates/pages/acr_firstrun.html:69
 msgid ""
-"Thousands of add-ons are made by our community every year, and your "
-"assistance with compatibility testing helps us make sure these add-ons stay "
-"useful as we strive to provide a great user experience."
+"Thousands of add-ons are made by our community every year, and your assistance with compatibility testing helps us make sure these add-ons stay useful as we strive to provide a great user "
+"experience."
 msgstr ""
 
 #: src/olympia/pages/templates/pages/acr_firstrun.html:75
@@ -11095,12 +9437,8 @@ msgid "Site Credits"
 msgstr "Sivuston tekijät"
 
 #: src/olympia/pages/templates/pages/credits.html:12
-msgid ""
-"Mozilla would like to thank the following people for their contributions to "
-"the addons.mozilla.org project over the years:"
-msgstr ""
-"Mozilla haluaa kiittää seuraavia henkilöitä heidän avustaan addons.mozilla"
-".org-projektin kanssa vuosien varrella."
+msgid "Mozilla would like to thank the following people for their contributions to the addons.mozilla.org project over the years:"
+msgstr "Mozilla haluaa kiittää seuraavia henkilöitä heidän avustaan addons.mozilla.org-projektin kanssa vuosien varrella."
 
 #: src/olympia/pages/templates/pages/credits.html:18
 msgid "Developers &amp; Administrators"
@@ -11133,48 +9471,31 @@ msgstr "Ohjelmisto ja kuvat"
 
 #: src/olympia/pages/templates/pages/credits.html:59
 msgid ""
-"Some icons used are from the <a "
-"href=\"http://www.famfamfam.com/lab/icons/silk/\">famfamfam Silk Icon "
-"Set</a>, licensed under a <a "
-"href=\"http://creativecommons.org/licenses/by/2.5/\">Creative Commons "
-"Attribution 2.5 License</a>."
+"Some icons used are from the <a href=\"http://www.famfamfam.com/lab/icons/silk/\">famfamfam Silk Icon Set</a>, licensed under a <a href=\"http://creativecommons.org/licenses/by/2.5/\">Creative "
+"Commons Attribution 2.5 License</a>."
 msgstr ""
-"Osa kuvista on <a "
-"href=\"http://www.famfamfam.com/lab/icons/silk/\">famfamfam Silk Icon "
-"Set</a> -kokoelmasta, joka on lisensoitu <a "
-"href=\"http://creativecommons.org/licenses/by/2.5/\">Creative Commons "
-"Attribution 2.5 -lisenssillä</a>."
+"Osa kuvista on <a href=\"http://www.famfamfam.com/lab/icons/silk/\">famfamfam Silk Icon Set</a> -kokoelmasta, joka on lisensoitu <a href=\"http://creativecommons.org/licenses/by/2.5/\">Creative "
+"Commons Attribution 2.5 -lisenssillä</a>."
 
 #: src/olympia/pages/templates/pages/credits.html:60
 msgid ""
-"Some icons used are from the <a href=\"http://www.fatcow.com/free-"
-"icons/\">FatCow Farm-Fresh Web Icons Set</a>, licensed under a <a "
-"href=\"http://creativecommons.org/licenses/by/3.0/us/\">Creative Commons "
-"Attribution 3.0 License</a>."
+"Some icons used are from the <a href=\"http://www.fatcow.com/free-icons/\">FatCow Farm-Fresh Web Icons Set</a>, licensed under a <a href=\"http://creativecommons.org/licenses/by/3.0/us/\">Creative "
+"Commons Attribution 3.0 License</a>."
 msgstr ""
-"Osa kuvista on <a href=\"http://www.fatcow.com/free-icons/\">FatCow Farm-"
-"Fresh Web Icons Set</a> -kokoelmasta, joka on lisensoitu <a "
-"href=\"http://creativecommons.org/licenses/by/3.0/us/\">Creative Commons "
-"Attribution 3.0 -lisenssillä</a>."
+"Osa kuvista on <a href=\"http://www.fatcow.com/free-icons/\">FatCow Farm-Fresh Web Icons Set</a> -kokoelmasta, joka on lisensoitu <a href=\"http://creativecommons.org/licenses/by/3.0/us/\">Creative "
+"Commons Attribution 3.0 -lisenssillä</a>."
 
 #: src/olympia/pages/templates/pages/credits.html:61
 msgid ""
-"Some pages use elements of <a "
-"href=\"http://shop.highsoft.com/highcharts.html\">Highcharts</a> (non-"
-"commercial), licensed under a <a href=\"http://creativecommons.org/licenses"
-"/by-nc/3.0/\">Creative Commons Attribution-NonCommercial 3.0 License</a>."
+"Some pages use elements of <a href=\"http://shop.highsoft.com/highcharts.html\">Highcharts</a> (non-commercial), licensed under a <a href=\"http://creativecommons.org/licenses/by-nc/3.0/\">Creative "
+"Commons Attribution-NonCommercial 3.0 License</a>."
 msgstr ""
-"Osa sivuista käyttää <a "
-"href=\"http://shop.highsoft.com/highcharts.html\">Highcharts</a>-elementtejä"
-" (ei-kaupallinen), jotka on lisensoitu <a "
-"href=\"http://creativecommons.org/licenses/by-nc/3.0/\">Creative Commons "
-"Attribution-NonCommercial 3.0 -lisenssillä</a>."
+"Osa sivuista käyttää <a href=\"http://shop.highsoft.com/highcharts.html\">Highcharts</a>-elementtejä (ei-kaupallinen), jotka on lisensoitu <a href=\"http://creativecommons.org/licenses/by-nc/3.0/"
+"\">Creative Commons Attribution-NonCommercial 3.0 -lisenssillä</a>."
 
 #: src/olympia/pages/templates/pages/credits.html:65
 #, python-format
-msgid ""
-"For information on contributing, please see our <a href=\"%(url)s\">wiki "
-"page</a>."
+msgid "For information on contributing, please see our <a href=\"%(url)s\">wiki page</a>."
 msgstr "Lue <a href=\"%(url)s\">wikisivultamme</a> lisää tietoa avustamisesta."
 
 # 76%
@@ -11183,39 +9504,32 @@ msgstr "Lue <a href=\"%(url)s\">wikisivultamme</a> lisää tietoa avustamisesta.
 msgid "Developer FAQ"
 msgstr "Kehityskeskus"
 
-#: src/olympia/pages/templates/pages/dev_faq.html:31
-#: src/olympia/pages/templates/pages/review_guide.html:33
+#: src/olympia/pages/templates/pages/dev_faq.html:31 src/olympia/pages/templates/pages/review_guide.html:33
 msgid "Sections"
 msgstr "Osiot"
 
-#: src/olympia/pages/templates/pages/dev_faq.html:33
-#: src/olympia/pages/templates/pages/dev_faq.html:45
+#: src/olympia/pages/templates/pages/dev_faq.html:33 src/olympia/pages/templates/pages/dev_faq.html:45
 msgid "Developing an Add-on"
 msgstr ""
 
 #. Heading for a list of resources for developers
-#: src/olympia/pages/templates/pages/dev_faq.html:34
-#: src/olympia/pages/templates/pages/dev_faq.html:208
+#: src/olympia/pages/templates/pages/dev_faq.html:34 src/olympia/pages/templates/pages/dev_faq.html:208
 msgid "Support Resources"
 msgstr ""
 
-#: src/olympia/pages/templates/pages/dev_faq.html:35
-#: src/olympia/pages/templates/pages/dev_faq.html:261
+#: src/olympia/pages/templates/pages/dev_faq.html:35 src/olympia/pages/templates/pages/dev_faq.html:261
 msgid "Contributing your Add-on"
 msgstr ""
 
-#: src/olympia/pages/templates/pages/dev_faq.html:36
-#: src/olympia/pages/templates/pages/dev_faq.html:381
+#: src/olympia/pages/templates/pages/dev_faq.html:36 src/olympia/pages/templates/pages/dev_faq.html:381
 msgid "Add-on Review Process"
 msgstr ""
 
-#: src/olympia/pages/templates/pages/dev_faq.html:37
-#: src/olympia/pages/templates/pages/dev_faq.html:444
+#: src/olympia/pages/templates/pages/dev_faq.html:37 src/olympia/pages/templates/pages/dev_faq.html:444
 msgid "Managing Your Add-on"
 msgstr ""
 
-#: src/olympia/pages/templates/pages/dev_faq.html:39
-#: src/olympia/pages/templates/pages/dev_faq.html:528
+#: src/olympia/pages/templates/pages/dev_faq.html:39 src/olympia/pages/templates/pages/dev_faq.html:528
 msgid "References for Open Source Licenses"
 msgstr ""
 
@@ -11228,10 +9542,7 @@ msgstr "Lisäosakehittäjä"
 
 #: src/olympia/pages/templates/pages/dev_faq.html:47
 #, python-format
-msgid ""
-"<h3>How do I build an Add-on?</h3> <p> Mozilla provides documentation on how"
-" to build an add-on via the <a href=\"%(url)s\">Mozilla Developer "
-"Network</a>. </p>"
+msgid "<h3>How do I build an Add-on?</h3> <p> Mozilla provides documentation on how to build an add-on via the <a href=\"%(url)s\">Mozilla Developer Network</a>. </p>"
 msgstr ""
 
 #: src/olympia/pages/templates/pages/dev_faq.html:55
@@ -11252,9 +9563,8 @@ msgstr ""
 
 #: src/olympia/pages/templates/pages/dev_faq.html:68
 msgid ""
-"You will need to have a version of the Mozilla software that you're building"
-" the add-on for and a code editor of your choice. Add-ons can be built for "
-"almost all Mozilla software but are primarily targeted for:"
+"You will need to have a version of the Mozilla software that you're building the add-on for and a code editor of your choice. Add-ons can be built for almost all Mozilla software but are primarily "
+"targeted for:"
 msgstr ""
 
 #: src/olympia/pages/templates/pages/dev_faq.html:82
@@ -11264,18 +9574,13 @@ msgstr ""
 #. This is a list of popular code editors.  Feel free to adjust as you like.
 #: src/olympia/pages/templates/pages/dev_faq.html:85
 msgid ""
-"<li><a href=\"http://komodoide.com/komodo-edit/\">Komodo Edit</a></li> "
-"<li><a href=\"http://macromates.com/\">TextMate</a></li> <li><a href=\"http"
-"://notepad-plus-plus.org/\">Notepad++</a></li> <li><a "
-"href=\"http://www.eclipse.org/\">Eclipse IDE</a></li>"
+"<li><a href=\"http://komodoide.com/komodo-edit/\">Komodo Edit</a></li> <li><a href=\"http://macromates.com/\">TextMate</a></li> <li><a href=\"http://notepad-plus-plus.org/\">Notepad++</a></li> "
+"<li><a href=\"http://www.eclipse.org/\">Eclipse IDE</a></li>"
 msgstr ""
 
 #: src/olympia/pages/templates/pages/dev_faq.html:94
 #, python-format
-msgid ""
-"You can also learn more about setting up your development environment via "
-"the MDN article <a href=\"%(url)s\">Setting up extension development "
-"environment</a>"
+msgid "You can also learn more about setting up your development environment via the MDN article <a href=\"%(url)s\">Setting up extension development environment</a>"
 msgstr ""
 
 #: src/olympia/pages/templates/pages/dev_faq.html:100
@@ -11283,9 +9588,7 @@ msgid "What is a \".xpi\" file?"
 msgstr ""
 
 #: src/olympia/pages/templates/pages/dev_faq.html:102
-msgid ""
-"Extensions are packaged and distributed in ZIP files or Bundles, with the "
-"XPI (pronounced \"zippy\") file extension."
+msgid "Extensions are packaged and distributed in ZIP files or Bundles, with the XPI (pronounced \"zippy\") file extension."
 msgstr ""
 
 #: src/olympia/pages/templates/pages/dev_faq.html:108
@@ -11294,10 +9597,8 @@ msgstr ""
 
 #: src/olympia/pages/templates/pages/dev_faq.html:110
 msgid ""
-"XUL (XML User Interface Language) is Mozilla's XML-based language that lets "
-"you build feature-rich cross platform applications. It provides user "
-"interface widgets like buttons, menus, toolbars, trees, etc that can be used"
-" to enhance add-ons by modifying parts of the browser UI."
+"XUL (XML User Interface Language) is Mozilla's XML-based language that lets you build feature-rich cross platform applications. It provides user interface widgets like buttons, menus, toolbars, "
+"trees, etc that can be used to enhance add-ons by modifying parts of the browser UI."
 msgstr ""
 
 #: src/olympia/pages/templates/pages/dev_faq.html:119
@@ -11307,13 +9608,9 @@ msgstr ""
 #: src/olympia/pages/templates/pages/dev_faq.html:121
 #, python-format
 msgid ""
-"This file, called an <a href=\"%(url)s\">Install Manifest</a>, is used by "
-"Add-on Manager-enabled XUL applications to determine information about an "
-"add-on as it is being installed. It contains metadata identifying the add-"
-"on, providing information about who created it, where more information can "
-"be found about it, which versions of what applications it is compatible "
-"with, how it should be updated, and so on. The format of the Install "
-"Manifest is RDF/XML."
+"This file, called an <a href=\"%(url)s\">Install Manifest</a>, is used by Add-on Manager-enabled XUL applications to determine information about an add-on as it is being installed. It contains "
+"metadata identifying the add-on, providing information about who created it, where more information can be found about it, which versions of what applications it is compatible with, how it should "
+"be updated, and so on. The format of the Install Manifest is RDF/XML."
 msgstr ""
 
 #: src/olympia/pages/templates/pages/dev_faq.html:132
@@ -11321,10 +9618,7 @@ msgid "What does \"maxVersion\" mean?"
 msgstr ""
 
 #: src/olympia/pages/templates/pages/dev_faq.html:134
-msgid ""
-"This determines the maximum version of Firefox you're saying this extension "
-"will work with. Set this to be no newer than the newest currently available "
-"version!"
+msgid "This determines the maximum version of Firefox you're saying this extension will work with. Set this to be no newer than the newest currently available version!"
 msgstr ""
 
 #: src/olympia/pages/templates/pages/dev_faq.html:141
@@ -11334,27 +9628,18 @@ msgstr ""
 #: src/olympia/pages/templates/pages/dev_faq.html:143
 #, python-format
 msgid ""
-"Yes. You can use Mozilla's <a href=\"%(url)s\">XPCOM component object "
-"model</a> to enhance your add-ons. XPCOM components be used and implemented "
-"in JavaScript, Java, and Python in addition to C++."
+"Yes. You can use Mozilla's <a href=\"%(url)s\">XPCOM component object model</a> to enhance your add-ons. XPCOM components be used and implemented in JavaScript, Java, and Python in addition to C++."
 msgstr ""
 
 #: src/olympia/pages/templates/pages/dev_faq.html:150
-msgid ""
-"Can I use a JavaScript library like jQuery, MooTools or Prototype to build "
-"my add-on?"
+msgid "Can I use a JavaScript library like jQuery, MooTools or Prototype to build my add-on?"
 msgstr ""
 
 #: src/olympia/pages/templates/pages/dev_faq.html:152
 msgid ""
-"Yes. It's possible, but some of the functionality provided by these "
-"libraries are available through XPCOM, XUL, and JavaScript. In addition, "
-"authors should take care if libraries modify primitive object prototypes "
-"(String.prototype, Date.prototype, etc.) and/or define global functions (eg."
-" the $ function). These are prone to cause conflict with other add-ons, in "
-"particular if different add-ons use different versions of libraries and so "
-"on. Developers need to be very, very careful with using them.  Mozilla does "
-"not offer documentation on using them to build add-ons."
+"Yes. It's possible, but some of the functionality provided by these libraries are available through XPCOM, XUL, and JavaScript. In addition, authors should take care if libraries modify primitive "
+"object prototypes (String.prototype, Date.prototype, etc.) and/or define global functions (eg. the $ function). These are prone to cause conflict with other add-ons, in particular if different add-"
+"ons use different versions of libraries and so on. Developers need to be very, very careful with using them. Mozilla does not offer documentation on using them to build add-ons."
 msgstr ""
 
 #: src/olympia/pages/templates/pages/dev_faq.html:165
@@ -11367,20 +9652,14 @@ msgid "You can use the <a href=\"%(url)s\">Add-on Debugger</a>."
 msgstr ""
 
 #: src/olympia/pages/templates/pages/dev_faq.html:172
-msgid ""
-"How do I test for compatibility with the latest version of Mozilla software?"
+msgid "How do I test for compatibility with the latest version of Mozilla software?"
 msgstr ""
 
 #: src/olympia/pages/templates/pages/dev_faq.html:174
 msgid ""
-"To ensure compatibility with the latest Mozilla software, it's important to "
-"download updates as they become available and test your add-on to ensure "
-"that it is still functioning as expected. In many cases, the latest version "
-"of Mozilla software may be a beta release. Since these releases at times "
-"introduce architectural changes that may impact the functionality of your "
-"add-on, it's important to be actively involved in the beta process to ensure"
-" that your add-on users are not negatively impacted upon final release of "
-"Mozilla software."
+"To ensure compatibility with the latest Mozilla software, it's important to download updates as they become available and test your add-on to ensure that it is still functioning as expected. In "
+"many cases, the latest version of Mozilla software may be a beta release. Since these releases at times introduce architectural changes that may impact the functionality of your add-on, it's "
+"important to be actively involved in the beta process to ensure that your add-on users are not negatively impacted upon final release of Mozilla software."
 msgstr ""
 
 #: src/olympia/pages/templates/pages/dev_faq.html:185
@@ -11390,11 +9669,8 @@ msgstr ""
 #: src/olympia/pages/templates/pages/dev_faq.html:187
 #, python-format
 msgid ""
-"Poorly written extensions can have a severe impact on the browsing "
-"experience, including on the overall performance of Firefox itself. The "
-"following page contains many good <a href=\"%(url)s\">guides</a> that help "
-"you improve performance, whether you're developing core Mozilla code or an "
-"add-on."
+"Poorly written extensions can have a severe impact on the browsing experience, including on the overall performance of Firefox itself. The following page contains many good <a href=\"%(url)s"
+"\">guides</a> that help you improve performance, whether you're developing core Mozilla code or an add-on."
 msgstr ""
 
 #: src/olympia/pages/templates/pages/dev_faq.html:195
@@ -11404,10 +9680,8 @@ msgstr ""
 #: src/olympia/pages/templates/pages/dev_faq.html:197
 #, python-format
 msgid ""
-"Yes. Details on localizing your add-on can be found in the the <a "
-"href=\"%(l10n_url)s\">Mozilla Developer Network Localization page</a>. <a "
-"href=\"%(bz_url)s\">The BabelZilla project</a> is also a great resource for "
-"learning about localization and volunteering to help translate add-ons."
+"Yes. Details on localizing your add-on can be found in the the <a href=\"%(l10n_url)s\">Mozilla Developer Network Localization page</a>. <a href=\"%(bz_url)s\">The BabelZilla project</a> is also a "
+"great resource for learning about localization and volunteering to help translate add-ons."
 msgstr ""
 
 #: src/olympia/pages/templates/pages/dev_faq.html:210
@@ -11426,9 +9700,7 @@ msgstr ""
 
 #. #jetpack is the name of the IRC channel.  do not change.
 #: src/olympia/pages/templates/pages/dev_faq.html:220
-msgid ""
-"#jetpack (for discussions about the Add-ons SDK and cfx/jpm - formerly known"
-" as Jetpack)"
+msgid "#jetpack (for discussions about the Add-ons SDK and cfx/jpm - formerly known as Jetpack)"
 msgstr ""
 
 #. Label for a link to the extension developers mailing list
@@ -11469,11 +9741,8 @@ msgstr ""
 #: src/olympia/pages/templates/pages/dev_faq.html:248
 #, python-format
 msgid ""
-"Yes. You may find 3rd party developers via the <a href=\"%(forum_url)s"
-"\">Add-ons forum</a>, <a href=\"%(list_url)s\">mozilla.jobs list</a>, <a "
-"href=\"%(mz_url)s\">mozillaZine forums</a> or <a href=\"%(wiki_url)s\">the "
-"Mozilla Wiki</a>. Please note that Mozilla does not offer developer "
-"recommendations."
+"Yes. You may find 3rd party developers via the <a href=\"%(forum_url)s\">Add-ons forum</a>, <a href=\"%(list_url)s\">mozilla.jobs list</a>, <a href=\"%(mz_url)s\">mozillaZine forums</a> or <a href="
+"\"%(wiki_url)s\">the Mozilla Wiki</a>. Please note that Mozilla does not offer developer recommendations."
 msgstr ""
 
 #: src/olympia/pages/templates/pages/dev_faq.html:263
@@ -11483,13 +9752,9 @@ msgstr ""
 #: src/olympia/pages/templates/pages/dev_faq.html:265
 #, python-format
 msgid ""
-"Yes. Many developers choose to host their own add-ons. Choosing to host your"
-" add-on on <a href=\"%(amo_url)s\">Mozilla's add-on site</a>, though, allows"
-" for much greater exposure to your add-on due to the large volume of "
-"visitors to the site.  <a href=\"%(md_url)s\">mozdev.org</a> offers free "
-"project hosting for Mozilla applications and extensions providing developers"
-" with tools to help manage source code, version control, bug tracking and "
-"documentation."
+"Yes. Many developers choose to host their own add-ons. Choosing to host your add-on on <a href=\"%(amo_url)s\">Mozilla's add-on site</a>, though, allows for much greater exposure to your add-on due "
+"to the large volume of visitors to the site. <a href=\"%(md_url)s\">mozdev.org</a> offers free project hosting for Mozilla applications and extensions providing developers with tools to help manage "
+"source code, version control, bug tracking and documentation."
 msgstr ""
 
 #: src/olympia/pages/templates/pages/dev_faq.html:277
@@ -11498,9 +9763,7 @@ msgstr ""
 
 #: src/olympia/pages/templates/pages/dev_faq.html:279
 #, python-format
-msgid ""
-"Yes. You can host your add-on on <a href=\"%(url)s\">Mozilla's add-on "
-"website</a>."
+msgid "Yes. You can host your add-on on <a href=\"%(url)s\">Mozilla's add-on website</a>."
 msgstr ""
 
 #: src/olympia/pages/templates/pages/dev_faq.html:284
@@ -11509,12 +9772,8 @@ msgstr ""
 
 #: src/olympia/pages/templates/pages/dev_faq.html:286
 msgid ""
-"Mozilla's AMO (<a "
-"href=\"https://addons.mozilla.org\">https://addons.mozilla.org</a>) is the "
-"incubator that helps developers build, distribute, and support fantastic "
-"consumer products powered by Mozilla. It provides you the tools and "
-"infrastructure necessary to manage, host and expose your add-on to a massive"
-" base of Mozilla users."
+"Mozilla's AMO (<a href=\"https://addons.mozilla.org\">https://addons.mozilla.org</a>) is the incubator that helps developers build, distribute, and support fantastic consumer products powered by "
+"Mozilla. It provides you the tools and infrastructure necessary to manage, host and expose your add-on to a massive base of Mozilla users."
 msgstr ""
 
 #: src/olympia/pages/templates/pages/dev_faq.html:295
@@ -11523,9 +9782,7 @@ msgstr ""
 
 #: src/olympia/pages/templates/pages/dev_faq.html:297
 #, python-format
-msgid ""
-"Yes. Our <a href=\"%(url)s\">Privacy Policy</a> describes how your "
-"information is managed by Mozilla."
+msgid "Yes. Our <a href=\"%(url)s\">Privacy Policy</a> describes how your information is managed by Mozilla."
 msgstr ""
 
 #: src/olympia/pages/templates/pages/dev_faq.html:302
@@ -11534,25 +9791,19 @@ msgstr ""
 
 #: src/olympia/pages/templates/pages/dev_faq.html:304
 msgid ""
-"The \"Developer Tools\" dashboard is the area that provides you the tools to"
-" successfully manage your add-ons. It provides the functionality necessary "
-"to submit your add-ons to AMO, manage add-on information, and review "
-"statistics."
+"The \"Developer Tools\" dashboard is the area that provides you the tools to successfully manage your add-ons. It provides the functionality necessary to submit your add-ons to AMO, manage add-on "
+"information, and review statistics."
 msgstr ""
 
 #: src/olympia/pages/templates/pages/dev_faq.html:312
-msgid ""
-"Does Mozilla have a policy in place as to what is an acceptable submission?"
+msgid "Does Mozilla have a policy in place as to what is an acceptable submission?"
 msgstr ""
 
 #: src/olympia/pages/templates/pages/dev_faq.html:314
 #, python-format
 msgid ""
-"Yes. Mozilla's <a href=\"%(p_url)s\">Add-on Policy</a> describes what is an "
-"acceptable submission. This policy is subject to change without notice.  In "
-"addition, the AMO editorial team uses the <a href=\"%(g_url)s\">Editors "
-"Reviewing Guide</a> to ensure that your add-on meets specific guidelines for"
-" functionality and security."
+"Yes. Mozilla's <a href=\"%(p_url)s\">Add-on Policy</a> describes what is an acceptable submission. This policy is subject to change without notice. In addition, the AMO editorial team uses the <a "
+"href=\"%(g_url)s\">Editors Reviewing Guide</a> to ensure that your add-on meets specific guidelines for functionality and security."
 msgstr ""
 
 #: src/olympia/pages/templates/pages/dev_faq.html:324
@@ -11562,11 +9813,8 @@ msgstr ""
 #: src/olympia/pages/templates/pages/dev_faq.html:326
 #, python-format
 msgid ""
-"The Developer Tools dashboard will allow you to upload and submit add-ons to"
-" AMO. You must be a registered AMO users before you can submit an add-on. "
-"Before submitting your add-on be sure to you have read the AMO <a "
-"href=\"%(url)s\">Editors Reviewing Guide</a> to ensure that your add-on has "
-"met the guidelines used by editors to review add-ons."
+"The Developer Tools dashboard will allow you to upload and submit add-ons to AMO. You must be a registered AMO users before you can submit an add-on. Before submitting your add-on be sure to you "
+"have read the AMO <a href=\"%(url)s\">Editors Reviewing Guide</a> to ensure that your add-on has met the guidelines used by editors to review add-ons."
 msgstr ""
 
 #: src/olympia/pages/templates/pages/dev_faq.html:336
@@ -11574,9 +9822,7 @@ msgid "What operating system do I choose for my add-on?"
 msgstr ""
 
 #: src/olympia/pages/templates/pages/dev_faq.html:338
-msgid ""
-"You must choose the operating systems on which your add-on will successfully"
-" function."
+msgid "You must choose the operating systems on which your add-on will successfully function."
 msgstr ""
 
 #: src/olympia/pages/templates/pages/dev_faq.html:344
@@ -11585,11 +9831,8 @@ msgstr ""
 
 #: src/olympia/pages/templates/pages/dev_faq.html:346
 msgid ""
-"The choice of category is dependent on what type of audience you are "
-"targeting and the functionality of your add-on. If you're unsure of which "
-"category your add-on falls into, please choose \"Other\". The AMO team may "
-"re-categorize your add-on if it's determined that it's better suited in a "
-"different category."
+"The choice of category is dependent on what type of audience you are targeting and the functionality of your add-on. If you're unsure of which category your add-on falls into, please choose \"Other"
+"\". The AMO team may re-categorize your add-on if it's determined that it's better suited in a different category."
 msgstr ""
 
 #: src/olympia/pages/templates/pages/dev_faq.html:355
@@ -11597,9 +9840,7 @@ msgid "What does \"nominating\" my add-on mean?"
 msgstr ""
 
 #: src/olympia/pages/templates/pages/dev_faq.html:357
-msgid ""
-"Nominated add-ons are new add-ons that the author has nominated to become "
-"public via the Developer Tools."
+msgid "Nominated add-ons are new add-ons that the author has nominated to become public via the Developer Tools."
 msgstr ""
 
 #: src/olympia/pages/templates/pages/dev_faq.html:363
@@ -11607,10 +9848,7 @@ msgid "Can I specify a license agreement for using my add-on?"
 msgstr ""
 
 #: src/olympia/pages/templates/pages/dev_faq.html:365
-msgid ""
-"Yes. You can specify a license agreement when submitting your add-on. You "
-"can also add or update a license agreement via the Developer Tools dashboard"
-" after your add-on has been submitted."
+msgid "Yes. You can specify a license agreement when submitting your add-on. You can also add or update a license agreement via the Developer Tools dashboard after your add-on has been submitted."
 msgstr ""
 
 #: src/olympia/pages/templates/pages/dev_faq.html:372
@@ -11618,10 +9856,7 @@ msgid "Can I include a privacy policy for my add-on?"
 msgstr ""
 
 #: src/olympia/pages/templates/pages/dev_faq.html:374
-msgid ""
-"Yes. You can specify a privacy policy when submitting your add-on. You can "
-"also add or update a privacy policy via the Developer Tools dashboard after "
-"your add-on has been submitted."
+msgid "Yes. You can specify a privacy policy when submitting your add-on. You can also add or update a privacy policy via the Developer Tools dashboard after your add-on has been submitted."
 msgstr ""
 
 #: src/olympia/pages/templates/pages/dev_faq.html:383
@@ -11631,10 +9866,8 @@ msgstr ""
 #: src/olympia/pages/templates/pages/dev_faq.html:385
 #, python-format
 msgid ""
-"All add-ons submitted, whether new or updated, are reviewed to ensure that "
-"Mozilla users have a stable and safe experience. All add-ons submissions are"
-" reviewed using the guidelines outlined in the <a href=\"%(url)s\">Editors "
-"Reviewing Guide</a>."
+"All add-ons submitted, whether new or updated, are reviewed to ensure that Mozilla users have a stable and safe experience. All add-ons submissions are reviewed using the guidelines outlined in the "
+"<a href=\"%(url)s\">Editors Reviewing Guide</a>."
 msgstr ""
 
 #: src/olympia/pages/templates/pages/dev_faq.html:393
@@ -11644,12 +9877,9 @@ msgstr ""
 #: src/olympia/pages/templates/pages/dev_faq.html:395
 #, python-format
 msgid ""
-"Add-ons are reviewed by the AMO Editors, a group of talented developers that"
-" volunteer to help the Mozilla project by reviewing add-ons to ensure a "
-"stable and safe experience for Mozilla users. When communicating with "
-"editors, please be courteous, patient and respectful as they are working "
-"hard to ensure that your add-on is set up correctly and follows the "
-"guidelines outlined in the <a href=\"%(url)s\">Editors Reviewing Guide</a>."
+"Add-ons are reviewed by the AMO Editors, a group of talented developers that volunteer to help the Mozilla project by reviewing add-ons to ensure a stable and safe experience for Mozilla users. "
+"When communicating with editors, please be courteous, patient and respectful as they are working hard to ensure that your add-on is set up correctly and follows the guidelines outlined in the <a "
+"href=\"%(url)s\">Editors Reviewing Guide</a>."
 msgstr ""
 
 #: src/olympia/pages/templates/pages/dev_faq.html:406
@@ -11659,11 +9889,8 @@ msgstr ""
 #: src/olympia/pages/templates/pages/dev_faq.html:408
 #, python-format
 msgid ""
-"The Mozilla editorial team follows the <a href=\"%(url)s\">Editors Reviewing"
-" Guide</a> when testing an add-on for acceptance onto AMO. It is important "
-"that add-on developers review this guide to ensure that common problem areas"
-" are addressed prior to submitting their add-on for review. This will "
-"greatly assist in expediting the review process."
+"The Mozilla editorial team follows the <a href=\"%(url)s\">Editors Reviewing Guide</a> when testing an add-on for acceptance onto AMO. It is important that add-on developers review this guide to "
+"ensure that common problem areas are addressed prior to submitting their add-on for review. This will greatly assist in expediting the review process."
 msgstr ""
 
 #: src/olympia/pages/templates/pages/dev_faq.html:418
@@ -11671,9 +9898,7 @@ msgid "How long will it take for my add-on to be reviewed?"
 msgstr ""
 
 #: src/olympia/pages/templates/pages/dev_faq.html:420
-msgid ""
-"We cannot give a time estimate as to how long it will take before an add-on "
-"is reviewed. Many factors affect the time including the:"
+msgid "We cannot give a time estimate as to how long it will take before an add-on is reviewed. Many factors affect the time including the:"
 msgstr ""
 
 #. part of a list (<li>)
@@ -11694,11 +9919,8 @@ msgstr ""
 #: src/olympia/pages/templates/pages/dev_faq.html:434
 #, python-format
 msgid ""
-"This is why it's very important to read the <a href=\"%(g_url)s\">Editors "
-"Reviewing Guide</a> to ensure that your add-on is setup as expected.  It's "
-"also a good idea to read the blog post, <a "
-"href=\"%(blog_url)s\">Successfully Getting your Add-on Reviewed</a> which "
-"provides excellent insight into ensuring a smooth review of your add-on."
+"This is why it's very important to read the <a href=\"%(g_url)s\">Editors Reviewing Guide</a> to ensure that your add-on is setup as expected. It's also a good idea to read the blog post, <a href="
+"\"%(blog_url)s\">Successfully Getting your Add-on Reviewed</a> which provides excellent insight into ensuring a smooth review of your add-on."
 msgstr ""
 
 #: src/olympia/pages/templates/pages/dev_faq.html:446
@@ -11706,10 +9928,7 @@ msgid "How can I see how many times my add-on has been downloaded?"
 msgstr ""
 
 #: src/olympia/pages/templates/pages/dev_faq.html:448
-msgid ""
-"The Statistics Dashboard found in the Developer Tools dashboard provides "
-"information that can help you determine your add-on downloads since you've "
-"submitted it to AMO."
+msgid "The Statistics Dashboard found in the Developer Tools dashboard provides information that can help you determine your add-on downloads since you've submitted it to AMO."
 msgstr ""
 
 #: src/olympia/pages/templates/pages/dev_faq.html:455
@@ -11718,9 +9937,7 @@ msgstr ""
 
 #: src/olympia/pages/templates/pages/dev_faq.html:457
 msgid ""
-"The Statistics Dashboard found in the Developer Tools dashboard provides "
-"information that can help you determine how many users have been actively "
-"using your add-on since you've submitted it to AMO."
+"The Statistics Dashboard found in the Developer Tools dashboard provides information that can help you determine how many users have been actively using your add-on since you've submitted it to AMO."
 msgstr ""
 
 #: src/olympia/pages/templates/pages/dev_faq.html:464
@@ -11728,10 +9945,7 @@ msgid "How do I submit an update for my add-on?"
 msgstr ""
 
 #: src/olympia/pages/templates/pages/dev_faq.html:466
-msgid ""
-"You can submit an update for your add-on via the Developer Tools dashboard "
-"by choosing the option \"Upload a new version\" and uploading a new .xpi "
-"file for your add-on."
+msgid "You can submit an update for your add-on via the Developer Tools dashboard by choosing the option \"Upload a new version\" and uploading a new .xpi file for your add-on."
 msgstr ""
 
 #: src/olympia/pages/templates/pages/dev_faq.html:473
@@ -11740,39 +9954,30 @@ msgstr ""
 
 #: src/olympia/pages/templates/pages/dev_faq.html:475
 msgid ""
-"That depends. If you are simply changing a description of your add-on or "
-"updating a \"maxVersion\" to ensure compatibility with a new Mozilla "
-"software update, then your add-on does not need to be reviewed again. If, "
-"however, you submit a new updated file, then your add-on update will need to"
-" be reviewed by an editor."
+"That depends. If you are simply changing a description of your add-on or updating a \"maxVersion\" to ensure compatibility with a new Mozilla software update, then your add-on does not need to be "
+"reviewed again. If, however, you submit a new updated file, then your add-on update will need to be reviewed by an editor."
 msgstr ""
 
 #: src/olympia/pages/templates/pages/dev_faq.html:486
-msgid ""
-"How do I reply to a user who has posted a negative review of my add-on?"
+msgid "How do I reply to a user who has posted a negative review of my add-on?"
 msgstr ""
 
 #: src/olympia/pages/templates/pages/dev_faq.html:488
-msgid ""
-"A developer may reply to any review posted to their add-on as long as they "
-"are logged into AMO. In addition, any user can flag a review as:"
+msgid "A developer may reply to any review posted to their add-on as long as they are logged into AMO. In addition, any user can flag a review as:"
 msgstr ""
 
 #. part of a list (<li>)
-#: src/olympia/pages/templates/pages/dev_faq.html:495
-#: src/olympia/reviews/models.py:159
+#: src/olympia/pages/templates/pages/dev_faq.html:495 src/olympia/reviews/models.py:159
 msgid "Spam or otherwise non-review content"
 msgstr ""
 
 #. part of a list (<li>)
-#: src/olympia/pages/templates/pages/dev_faq.html:497
-#: src/olympia/reviews/models.py:160
+#: src/olympia/pages/templates/pages/dev_faq.html:497 src/olympia/reviews/models.py:160
 msgid "Inappropriate language/dialog"
 msgstr ""
 
 #. part of a list (<li>)
-#: src/olympia/pages/templates/pages/dev_faq.html:499
-#: src/olympia/reviews/models.py:161
+#: src/olympia/pages/templates/pages/dev_faq.html:499 src/olympia/reviews/models.py:161
 msgid "Misplaced bug report or support request"
 msgstr ""
 
@@ -11782,10 +9987,7 @@ msgid "Other (provides a pop-up prompt for information)"
 msgstr ""
 
 #: src/olympia/pages/templates/pages/dev_faq.html:504
-msgid ""
-"Currently, AMO does not provide a mechanism to directly communicate with a "
-"reviewer but this feature is being investigated and considered for a future "
-"update."
+msgid "Currently, AMO does not provide a mechanism to directly communicate with a reviewer but this feature is being investigated and considered for a future update."
 msgstr ""
 
 #: src/olympia/pages/templates/pages/dev_faq.html:511
@@ -11793,9 +9995,7 @@ msgid "Can I request that a review be removed if the review is negative?"
 msgstr ""
 
 #: src/olympia/pages/templates/pages/dev_faq.html:513
-msgid ""
-"No. We do not remove negative reviews from add-ons unless they are found to "
-"be false."
+msgid "No. We do not remove negative reviews from add-ons unless they are found to be false."
 msgstr ""
 
 #: src/olympia/pages/templates/pages/dev_faq.html:519
@@ -11803,55 +10003,36 @@ msgid "Can I request that a review be removed if the review is inaccurate?"
 msgstr ""
 
 #: src/olympia/pages/templates/pages/dev_faq.html:521
-msgid ""
-"If an author contacts us and asks for a review containing false or "
-"inaccurate information to be removed, we will review the post and consider "
-"removing it."
+msgid "If an author contacts us and asks for a review containing false or inaccurate information to be removed, we will review the post and consider removing it."
 msgstr ""
 
 #: src/olympia/pages/templates/pages/dev_faq.html:530
 msgid ""
-"Do you need more information about the various open source licenses? Are you"
-" confused as to which license you should select? What rights does a specific"
-" license grant? While nothing replaces reading the full terms of a license, "
-"below are some sites that contain information about some of the key open "
-"source licenses that may help you sort out the differences between them. "
-"These sites are being provided solely for your convenience and as a "
-"reference for your personal use. These resources do not constitute legal "
-"advice nor should they be used in lieu of such advice. Mozilla neither "
-"guarantees nor is responsible for the content of these sites or your "
-"reliance on such content."
+"Do you need more information about the various open source licenses? Are you confused as to which license you should select? What rights does a specific license grant? While nothing replaces "
+"reading the full terms of a license, below are some sites that contain information about some of the key open source licenses that may help you sort out the differences between them. These sites "
+"are being provided solely for your convenience and as a reference for your personal use. These resources do not constitute legal advice nor should they be used in lieu of such advice. Mozilla "
+"neither guarantees nor is responsible for the content of these sites or your reliance on such content."
 msgstr ""
 
 #: src/olympia/pages/templates/pages/dev_faq.html:545
 msgid ""
-"In addition to the full text of the Mozilla Public License(\"MPL\"), this "
-"also provides an annotated version of the MPL and an <abbr "
-"title=\"Frequently Asked Questions\">FAQ</abbr> to help you if you want to "
-"use or distribute code licensed under it."
+"In addition to the full text of the Mozilla Public License(\"MPL\"), this also provides an annotated version of the MPL and an <abbr title=\"Frequently Asked Questions\">FAQ</abbr> to help you if "
+"you want to use or distribute code licensed under it."
 msgstr ""
 
 #: src/olympia/pages/templates/pages/dev_faq.html:559
-msgid ""
-"A table summarizing and comparing how some of the key open source licenses "
-"treat distributions, proprietary software linking, and redistribution of "
-"code with changes."
+msgid "A table summarizing and comparing how some of the key open source licenses treat distributions, proprietary software linking, and redistribution of code with changes."
 msgstr ""
 
 #: src/olympia/pages/templates/pages/dev_faq.html:572
 msgid ""
-"Free Software Foundation provides short summaries of the key open source "
-"licenses, including whether the license qualifies as a free software license"
-" or a copyleft license.  Also includes a discussion of what constitutes a "
-"free software license or a copyleft license (e.g., a Copyleft license is a "
-"general method for making a program or other work free, and requiring all "
-"modified and extended versions of the program to be free as well.)"
+"Free Software Foundation provides short summaries of the key open source licenses, including whether the license qualifies as a free software license or a copyleft license. Also includes a "
+"discussion of what constitutes a free software license or a copyleft license (e.g., a Copyleft license is a general method for making a program or other work free, and requiring all modified and "
+"extended versions of the program to be free as well.)"
 msgstr ""
 
 #: src/olympia/pages/templates/pages/dev_faq.html:589
-msgid ""
-"Open Source Initiative provides the terms of some of the key open source "
-"licenses."
+msgid "Open Source Initiative provides the terms of some of the key open source licenses."
 msgstr ""
 
 #: src/olympia/pages/templates/pages/dev_faq.html:599
@@ -11859,14 +10040,10 @@ msgid "A comparison of known open source licenses on Wikipedia."
 msgstr ""
 
 #: src/olympia/pages/templates/pages/dev_faq.html:605
-msgid ""
-"A site to provide non-judgmental guidance on choosing a license for your "
-"open source project."
+msgid "A site to provide non-judgmental guidance on choosing a license for your open source project."
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:3
-#: src/olympia/pages/templates/pages/faq.html:9
-#: src/olympia/pages/templates/pages/faq.html:10
+#: src/olympia/pages/templates/pages/faq.html:3 src/olympia/pages/templates/pages/faq.html:9 src/olympia/pages/templates/pages/faq.html:10
 msgid "Frequently Asked Questions"
 msgstr "Usein kysyttyjä kysymyksiä"
 
@@ -11881,19 +10058,11 @@ msgstr "Mikä lisäosa on?"
 #: src/olympia/pages/templates/pages/faq.html:16
 #, python-format
 msgid ""
-"Add-ons are small pieces of software that add new features or functionality "
-"to your installation of %(app_name)s. Add-ons can augment %(app_name)s with "
-"new features, foreign language dictionaries, or change its visual "
-"appearance. Through add-ons, you can customize %(app_name)s to meet your "
-"needs and tastes. <a href=\"%(learnmore_url)s\">Learn more about "
-"customization</a>"
+"Add-ons are small pieces of software that add new features or functionality to your installation of %(app_name)s. Add-ons can augment %(app_name)s with new features, foreign language dictionaries, "
+"or change its visual appearance. Through add-ons, you can customize %(app_name)s to meet your needs and tastes. <a href=\"%(learnmore_url)s\">Learn more about customization</a>"
 msgstr ""
-"Lisäosat ovat pieniä ohjelmia, jotka tuovat uusia ominaisuuksia %(app_name)s"
-" -ohjelmaan. Lisäosat voivat lisätä %(app_name)s -ohjelmaasi uusia "
-"ominaisuuksia, vieraiden kielien sanakirjoja tai muuttaa käyttöliittymää. "
-"Lisäosien ansiosta voit muuttaa %(app_name)s -ohjelmaasi tarpeidesi ja "
-"mieltymystesi mukaan. <a href=\"%(learnmore_url)s\">Lisätietoja "
-"mukauttamisesta</a>"
+"Lisäosat ovat pieniä ohjelmia, jotka tuovat uusia ominaisuuksia %(app_name)s -ohjelmaan. Lisäosat voivat lisätä %(app_name)s -ohjelmaasi uusia ominaisuuksia, vieraiden kielien sanakirjoja tai "
+"muuttaa käyttöliittymää. Lisäosien ansiosta voit muuttaa %(app_name)s -ohjelmaasi tarpeidesi ja mieltymystesi mukaan. <a href=\"%(learnmore_url)s\">Lisätietoja mukauttamisesta</a>"
 
 #: src/olympia/pages/templates/pages/faq.html:26
 msgid "Will add-ons work with my web browser or application?"
@@ -11902,27 +10071,14 @@ msgstr "Toimivatko lisäosat verkkoselaimessani tai sovelluksessani?"
 #: src/olympia/pages/templates/pages/faq.html:27
 #, python-format
 msgid ""
-"Add-ons listed in this gallery only work with Mozilla-based applications, "
-"such as <a href=\"%(getfirefox_url)s\">Firefox</a>, <a "
-"href=\"%(getmobile_url)s\">Firefox Mobile</a>, <a "
-"href=\"%(getseamonkey_url)s\">SeaMonkey</a>, and <a "
-"href=\"%(getthunderbird_url)s\">Thunderbird</a>. However, not all add-ons "
-"work with each of those applications or every version of those applications."
-" Each add-on specifies which applications and versions it works with, such "
-"as Firefox 2.0 - 3.6.*. For Firefox add-ons, the install buttons will "
-"indicate whether the add-on is compatible or not."
+"Add-ons listed in this gallery only work with Mozilla-based applications, such as <a href=\"%(getfirefox_url)s\">Firefox</a>, <a href=\"%(getmobile_url)s\">Firefox Mobile</a>, <a href="
+"\"%(getseamonkey_url)s\">SeaMonkey</a>, and <a href=\"%(getthunderbird_url)s\">Thunderbird</a>. However, not all add-ons work with each of those applications or every version of those applications. "
+"Each add-on specifies which applications and versions it works with, such as Firefox 2.0 - 3.6.*. For Firefox add-ons, the install buttons will indicate whether the add-on is compatible or not."
 msgstr ""
-"Tällä sivustolla esitetään vain Mozilla-pohjaisille ohjelmistoille, kuten <a"
-" href=\"%(getfirefox_url)s\">Firefoxille</a>, <a "
-"href=\"%(getmobile_url)s\">Firefox Mobilelle</a>, <a "
-"href=\"%(getseamonkey_url)s\">SeaMonkeylle</a> ja <a "
-"href=\"%(getthunderbird_url)s\">Thunderbirdlle</a> kehitettyjä lisäosia. "
-"Kaikki lisäosat eivät kuitenkaan toimi kaikkien edellä mainittujen "
-"ohjelmistojen kanssa eivätkä välttämättä tietyssä versiossa. Lisäsosan "
-"kehittäjä valitsee, mille ohjelmistoille hän suunnittelee lisäosansa, kuten "
-"Firefoxin versioille 4.0 - 11.0 *. Firefoxin lisäosille asennuspainike näkyy"
-" sinulle aina riippumatta siitä, onko lisäosa yhteensopiva ohjelmistosi "
-"kanssa."
+"Tällä sivustolla esitetään vain Mozilla-pohjaisille ohjelmistoille, kuten <a href=\"%(getfirefox_url)s\">Firefoxille</a>, <a href=\"%(getmobile_url)s\">Firefox Mobilelle</a>, <a href="
+"\"%(getseamonkey_url)s\">SeaMonkeylle</a> ja <a href=\"%(getthunderbird_url)s\">Thunderbirdlle</a> kehitettyjä lisäosia. Kaikki lisäosat eivät kuitenkaan toimi kaikkien edellä mainittujen "
+"ohjelmistojen kanssa eivätkä välttämättä tietyssä versiossa. Lisäsosan kehittäjä valitsee, mille ohjelmistoille hän suunnittelee lisäosansa, kuten Firefoxin versioille 4.0 - 11.0 *. Firefoxin "
+"lisäosille asennuspainike näkyy sinulle aina riippumatta siitä, onko lisäosa yhteensopiva ohjelmistosi kanssa."
 
 #: src/olympia/pages/templates/pages/faq.html:42
 msgid "What are the different types of add-ons?"
@@ -11930,71 +10086,42 @@ msgstr "Minkälaisia lisäosia on tarjolla?"
 
 #: src/olympia/pages/templates/pages/faq.html:43
 #, python-format
-msgid ""
-"There are several kinds of add-ons that customize %(app_name)s in different "
-"ways:"
+msgid "There are several kinds of add-ons that customize %(app_name)s in different ways:"
 msgstr "Voit mukauttaa %(app_name)s -ohjelmistoasi monilla tavoilla:"
 
 #: src/olympia/pages/templates/pages/faq.html:47
 #, python-format
 msgid ""
-"<strong><a href=\"%(browse_url)s\">Extensions</a></strong> add new features "
-"to %(app_name)s or modify existing functionality. There are extensions that "
-"allow you to block advertisements, download videos from websites, integrate "
-"more closely with social websites, and add features you see in other "
-"applications."
+"<strong><a href=\"%(browse_url)s\">Extensions</a></strong> add new features to %(app_name)s or modify existing functionality. There are extensions that allow you to block advertisements, download "
+"videos from websites, integrate more closely with social websites, and add features you see in other applications."
 msgstr ""
-"<strong><a href=\"%(browse_url)s\">Laajennukset</a></strong> lisäävät uusia "
-"ominaisuuksia %(app_name)s -ohjelmistoon tai muuttavat nykyisiä. Laajennus "
-"voi vaikkapa poistaa sivustojen mainokset, tuoda videotukea tai integroida "
-"selaimeesi sosiaalisia verkostoja."
+"<strong><a href=\"%(browse_url)s\">Laajennukset</a></strong> lisäävät uusia ominaisuuksia %(app_name)s -ohjelmistoon tai muuttavat nykyisiä. Laajennus voi vaikkapa poistaa sivustojen mainokset, "
+"tuoda videotukea tai integroida selaimeesi sosiaalisia verkostoja."
 
 #: src/olympia/pages/templates/pages/faq.html:55
 #, python-format
-msgid ""
-"<strong><a href=\"%(browse_url)s\">Complete Themes</a></strong> change the "
-"entire appearance of %(app_name)s, usually including icons, colors, dialogs,"
-" and other visual styles."
+msgid "<strong><a href=\"%(browse_url)s\">Complete Themes</a></strong> change the entire appearance of %(app_name)s, usually including icons, colors, dialogs, and other visual styles."
 msgstr ""
 
 #: src/olympia/pages/templates/pages/faq.html:61
 #, python-format
-msgid ""
-"<strong><a href=\"%(browse_url)s\">Themes</a></strong> are lightweight "
-"themes that use background images to customize your %(app_name)s toolbars."
+msgid "<strong><a href=\"%(browse_url)s\">Themes</a></strong> are lightweight themes that use background images to customize your %(app_name)s toolbars."
 msgstr ""
 
 #: src/olympia/pages/templates/pages/faq.html:66
 #, python-format
-msgid ""
-"<strong><a href=\"%(browse_url)s\">Search Providers</a> </strong> add "
-"additional choices to the search box dropdown. These providers allow you to "
-"quickly search any website."
-msgstr ""
-"<strong><a href=\"%(browse_url)s\">Hakutyökalut</a></strong> lisää uusia "
-"hakukoneita hakupalkkiin. Tämän ansiosta voit helposti etsiä tietoa eri "
-"verkkopalveluista."
+msgid "<strong><a href=\"%(browse_url)s\">Search Providers</a> </strong> add additional choices to the search box dropdown. These providers allow you to quickly search any website."
+msgstr "<strong><a href=\"%(browse_url)s\">Hakutyökalut</a></strong> lisää uusia hakukoneita hakupalkkiin. Tämän ansiosta voit helposti etsiä tietoa eri verkkopalveluista."
 
 #: src/olympia/pages/templates/pages/faq.html:72
 #, python-format
-msgid ""
-"<strong><a href=\"%(browse_url)s\">Dictionaries & Language "
-"Packs</a></strong> add support for additional languages to %(app_name)s."
-msgstr ""
-"<strong><a href=\"%(browse_url)s\">Oikolukusanastot ja "
-"kielipaketit</a></strong> lisäävät %(app_name)s -ohjelmaan tuen muille "
-"kielille."
+msgid "<strong><a href=\"%(browse_url)s\">Dictionaries & Language Packs</a></strong> add support for additional languages to %(app_name)s."
+msgstr "<strong><a href=\"%(browse_url)s\">Oikolukusanastot ja kielipaketit</a></strong> lisäävät %(app_name)s -ohjelmaan tuen muille kielille."
 
 #: src/olympia/pages/templates/pages/faq.html:77
 #, python-format
-msgid ""
-"<strong><a href=\"%(browse_url)s\">Plugins</a></strong> help %(app_name)s "
-"display or understand different types of media, such as Adobe Flash or Apple"
-" Quicktime."
-msgstr ""
-"<strong><a href=\"%(browse_url)s\">Liitännäiset</a></strong> auttavat "
-"%(app_name)s -ohjelmaasi ymmärtämään uusia tiedostomuotoja, kuten Adobe "
-"Flashia tai Apple Quicktimea."
+msgid "<strong><a href=\"%(browse_url)s\">Plugins</a></strong> help %(app_name)s display or understand different types of media, such as Adobe Flash or Apple Quicktime."
+msgstr "<strong><a href=\"%(browse_url)s\">Liitännäiset</a></strong> auttavat %(app_name)s -ohjelmaasi ymmärtämään uusia tiedostomuotoja, kuten Adobe Flashia tai Apple Quicktimea."
 
 #: src/olympia/pages/templates/pages/faq.html:85
 msgid "How do I install, manage, or remove an add-on?"
@@ -12003,13 +10130,9 @@ msgstr "Miten voin asentaa, poistaa tai hallita lisäosiani?"
 #: src/olympia/pages/templates/pages/faq.html:86
 #, python-format
 msgid ""
-"In most cases, add-ons can be installed by simply clicking the install "
-"button provided. Add-ons can be managed, disabled, or uninstalled from the "
-"Add-ons Manager in %(app_name)s. For more detailed instructions, read <a "
-"href=\"%(extension_url)s\">this article on extensions</a> or <a "
-"href=\"%(theme_url)s\">this one for Themes and Complete Themes</a>. If you "
-"have difficulty installing add-ons, see <a "
-"href=\"%(troubleshooting_url)s\">Troubleshooting Extensions and Themes</a>."
+"In most cases, add-ons can be installed by simply clicking the install button provided. Add-ons can be managed, disabled, or uninstalled from the Add-ons Manager in %(app_name)s. For more detailed "
+"instructions, read <a href=\"%(extension_url)s\">this article on extensions</a> or <a href=\"%(theme_url)s\">this one for Themes and Complete Themes</a>. If you have difficulty installing add-ons, "
+"see <a href=\"%(troubleshooting_url)s\">Troubleshooting Extensions and Themes</a>."
 msgstr ""
 
 #: src/olympia/pages/templates/pages/faq.html:100
@@ -12019,11 +10142,8 @@ msgstr ""
 #: src/olympia/pages/templates/pages/faq.html:101
 #, python-format
 msgid ""
-"In Firefox, add-ons marked with \"No restart required\" can be installed "
-"without restarting. These add-ons have been created using the <a "
-"href=\"%(sdk_url)s\">Add-on SDK</a> or <a "
-"href=\"%(bootstrap_url)s\">bootstrapping</a>. Other add-ons will still "
-"require a restart before you can use them."
+"In Firefox, add-ons marked with \"No restart required\" can be installed without restarting. These add-ons have been created using the <a href=\"%(sdk_url)s\">Add-on SDK</a> or <a href="
+"\"%(bootstrap_url)s\">bootstrapping</a>. Other add-ons will still require a restart before you can use them."
 msgstr ""
 
 #: src/olympia/pages/templates/pages/faq.html:110
@@ -12033,13 +10153,9 @@ msgstr ""
 #: src/olympia/pages/templates/pages/faq.html:111
 #, python-format
 msgid ""
-"Add-ons, unlike plugins, are automatically checked for updates once every "
-"day. In Firefox, updates are automatically installed by default. Versions of"
-" Firefox prior to 4 (and other applications) will alert you that updates to "
-"your add-ons are available. <a href=\"%(plugin_url)s\">Plugins</a> are not "
-"currently automatically checked for updates, so be sure to regularly visit "
-"the <a href=\"%(plugincheck_url)s\">Plugin Check</a> page to stay up-to-"
-"date."
+"Add-ons, unlike plugins, are automatically checked for updates once every day. In Firefox, updates are automatically installed by default. Versions of Firefox prior to 4 (and other applications) "
+"will alert you that updates to your add-ons are available. <a href=\"%(plugin_url)s\">Plugins</a> are not currently automatically checked for updates, so be sure to regularly visit the <a href="
+"\"%(plugincheck_url)s\">Plugin Check</a> page to stay up-to-date."
 msgstr ""
 
 #: src/olympia/pages/templates/pages/faq.html:122
@@ -12049,12 +10165,9 @@ msgstr ""
 #: src/olympia/pages/templates/pages/faq.html:123
 #, python-format
 msgid ""
-"Unless clearly marked otherwise, add-ons available from this gallery have "
-"been checked and approved by Mozilla's team of editors and are safe to "
-"install. We recommend that you only install approved add-ons. If you wish to"
-" install unapproved add-ons or add-ons from third-party websites, use "
-"caution as these add-ons may harm your computer or violate your privacy. <a "
-"href=\"%(learnmore_url)s\">Learn more about our approval process</a>"
+"Unless clearly marked otherwise, add-ons available from this gallery have been checked and approved by Mozilla's team of editors and are safe to install. We recommend that you only install approved "
+"add-ons. If you wish to install unapproved add-ons or add-ons from third-party websites, use caution as these add-ons may harm your computer or violate your privacy. <a href=\"%(learnmore_url)s"
+"\">Learn more about our approval process</a>"
 msgstr ""
 
 #: src/olympia/pages/templates/pages/faq.html:133
@@ -12065,30 +10178,21 @@ msgstr ""
 #: src/olympia/pages/templates/pages/faq.html:135
 #, python-format
 msgid ""
-"Most add-ons do not cause a perceivable performance decrease in "
-"%(app_name)s, though installing an excessive number may have adverse "
-"effects. If you suspect an add-on is causing %(app_name)s to be slow, try "
-"disabling it."
+"Most add-ons do not cause a perceivable performance decrease in %(app_name)s, though installing an excessive number may have adverse effects. If you suspect an add-on is causing %(app_name)s to be "
+"slow, try disabling it."
 msgstr ""
 
 #: src/olympia/pages/templates/pages/faq.html:141
 #, python-format
-msgid ""
-"%(app_name)s told me an add-on isn't compatible. Is there a way I can still "
-"use it?"
+msgid "%(app_name)s told me an add-on isn't compatible. Is there a way I can still use it?"
 msgstr ""
 
 #: src/olympia/pages/templates/pages/faq.html:144
 #, python-format
 msgid ""
-"If an add-on isn't compatible with your version of %(app_name)s, it is "
-"usually either because your version of %(app_name)s is outdated or the add-"
-"on author has not yet updated the add-on to be compatible with a newer "
-"version you are using. Mozilla does not recommend trying to circumvent these"
-" compatibility checks, as they can lead to browser instability or in some "
-"cases loss of data. For users who are testing out alpha or beta versions of "
-"Firefox, we offer the <a href=\"%(acr_url)s\">Add-on Compatibility "
-"Reporter</a> to help add-on developers update their compatibility."
+"If an add-on isn't compatible with your version of %(app_name)s, it is usually either because your version of %(app_name)s is outdated or the add-on author has not yet updated the add-on to be "
+"compatible with a newer version you are using. Mozilla does not recommend trying to circumvent these compatibility checks, as they can lead to browser instability or in some cases loss of data. For "
+"users who are testing out alpha or beta versions of Firefox, we offer the <a href=\"%(acr_url)s\">Add-on Compatibility Reporter</a> to help add-on developers update their compatibility."
 msgstr ""
 
 #: src/olympia/pages/templates/pages/faq.html:156
@@ -12098,12 +10202,9 @@ msgstr ""
 #: src/olympia/pages/templates/pages/faq.html:157
 #, python-format
 msgid ""
-"Add-ons are usually created by third-party developers from around the world,"
-" so the best way to get help with an add-on is to look for support links on "
-"the add-on's homepage or contact the developer. If you are having issues "
-"with %(app_name)s that you suspect are related to add-ons you have "
-"installed, <a href=\"%(troubleshooting_url)s\">visit this support "
-"article</a> for troubleshooting tips."
+"Add-ons are usually created by third-party developers from around the world, so the best way to get help with an add-on is to look for support links on the add-on's homepage or contact the "
+"developer. If you are having issues with %(app_name)s that you suspect are related to add-ons you have installed, <a href=\"%(troubleshooting_url)s\">visit this support article</a> for "
+"troubleshooting tips."
 msgstr ""
 
 #: src/olympia/pages/templates/pages/faq.html:169
@@ -12111,19 +10212,13 @@ msgid "Add-on Gallery"
 msgstr ""
 
 #: src/olympia/pages/templates/pages/faq.html:171
-msgid ""
-"How do I choose between add-ons that seem to do the same\n"
-"    thing?"
+msgid "How do I choose between add-ons that seem to do the same thing?"
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:173
+#: src/olympia/pages/templates/pages/faq.html:172
 msgid ""
-"There are often several add-ons that have similar features. To\n"
-"    figure out which is right for you, read the entire description of the\n"
-"    add-on and view its screenshots. If there are still several in the running,\n"
-"    read through the add-on's ratings, user reviews, and statistics to see\n"
-"    which is most liked by other users. Remember that you can also just try\n"
-"    out both and see which you like better."
+"There are often several add-ons that have similar features. To figure out which is right for you, read the entire description of the add-on and view its screenshots. If there are still several in "
+"the running, read through the add-on's ratings, user reviews, and statistics to see which is most liked by other users. Remember that you can also just try out both and see which you like better."
 msgstr ""
 
 #: src/olympia/pages/templates/pages/faq.html:180
@@ -12133,26 +10228,19 @@ msgstr ""
 #: src/olympia/pages/templates/pages/faq.html:181
 #, python-format
 msgid ""
-"With thousands of add-ons available, there's something for everyone. But if "
-"you're looking for a particular add-on and can't find it, you might try "
-"searching on other sites or posting about it in our <a href=\"%(forum_url)s"
-"\">Add-ons </a>forum."
+"With thousands of add-ons available, there's something for everyone. But if you're looking for a particular add-on and can't find it, you might try searching on other sites or posting about it in "
+"our <a href=\"%(forum_url)s\">Add-ons </a>forum."
 msgstr ""
 
 #: src/olympia/pages/templates/pages/faq.html:187
-msgid ""
-"What does it mean if an add-on is \"experimental\" or \"preliminarily "
-"reviewed\"?"
+msgid "What does it mean if an add-on is \"experimental\" or \"preliminarily reviewed\"?"
 msgstr ""
 
 #: src/olympia/pages/templates/pages/faq.html:188
 #, python-format
 msgid ""
-"Experimental add-ons have been checked by our editors to make sure they "
-"don't have security problems, but they may still have bugs or not work "
-"properly. Use caution when installing experimental add-ons and uninstall the"
-" add-on immediately if you notice problems. <a href=\"%(url)s\">Learn more "
-"about our review process</a></dd>"
+"Experimental add-ons have been checked by our editors to make sure they don't have security problems, but they may still have bugs or not work properly. Use caution when installing experimental add-"
+"ons and uninstall the add-on immediately if you notice problems. <a href=\"%(url)s\">Learn more about our review process</a></dd>"
 msgstr ""
 
 #: src/olympia/pages/templates/pages/faq.html:196
@@ -12162,12 +10250,8 @@ msgstr ""
 #: src/olympia/pages/templates/pages/faq.html:197
 #, python-format
 msgid ""
-"While all add-ons publicly available in our gallery are reviewed by an "
-"editor, you may receive a direct link to an add-on that hasn't yet been "
-"reviewed. Use caution when installing these add-ons, as they could harm your"
-" computer or violate your privacy. We recommend that you only install "
-"reviewed add-ons. <a href=\"%(url)s\">Learn more about our review "
-"process</a></dd>"
+"While all add-ons publicly available in our gallery are reviewed by an editor, you may receive a direct link to an add-on that hasn't yet been reviewed. Use caution when installing these add-ons, "
+"as they could harm your computer or violate your privacy. We recommend that you only install reviewed add-ons. <a href=\"%(url)s\">Learn more about our review process</a></dd>"
 msgstr ""
 
 #: src/olympia/pages/templates/pages/faq.html:206
@@ -12175,185 +10259,146 @@ msgid "How much do add-ons cost to purchase?"
 msgstr ""
 
 #: src/olympia/pages/templates/pages/faq.html:207
-msgid ""
-"Add-ons hosted in our gallery are free unless clearly marked\n"
-"    otherwise."
+msgid "Add-ons hosted in our gallery are free unless clearly marked otherwise."
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:210
+#: src/olympia/pages/templates/pages/faq.html:209
 msgid "What does it mean when an add-on asks for contributions?"
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:211
+#: src/olympia/pages/templates/pages/faq.html:210
 msgid ""
-"Some add-on authors request users who enjoy an add-on to\n"
-"        contribute to its development by making a monetary contribution. These\n"
-"        contributions go directly to the developer unless a third party is\n"
-"        indicated, such as the non-profit Mozilla Foundation."
+"Some add-on authors request users who enjoy an add-on to contribute to its development by making a monetary contribution. These contributions go directly to the developer unless a third party is "
+"indicated, such as the non-profit Mozilla Foundation."
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:216
+#: src/olympia/pages/templates/pages/faq.html:215
 msgid "What are beta add-ons?"
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:218
+#: src/olympia/pages/templates/pages/faq.html:217
 msgid ""
-"Beta add-ons are unreviewed versions which represent the\n"
-"        latest work of an add-on author. While different authors have different\n"
-"        standards for beta code quality, you should assume that these add-ons\n"
-"        are less stable than the general add-on releases."
+"Beta add-ons are unreviewed versions which represent the latest work of an add-on author. While different authors have different standards for beta code quality, you should assume that these add-"
+"ons are less stable than the general add-on releases."
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:222
+#: src/olympia/pages/templates/pages/faq.html:221
 msgid ""
-"Please note that when you install an add-on from the \"Beta Version\" "
-"section of an add-on's listing, you will continue to receive updates for "
-"that add-on as they become available. Like the initial version you "
-"installed, all beta releases are unreviewed by Mozilla and may harm your "
-"computer."
+"Please note that when you install an add-on from the \"Beta Version\" section of an add-on's listing, you will continue to receive updates for that add-on as they become available. Like the initial "
+"version you installed, all beta releases are unreviewed by Mozilla and may harm your computer."
+msgstr ""
+
+#: src/olympia/pages/templates/pages/faq.html:228
+msgid "What does it mean when an add-on is flagged as slow?"
 msgstr ""
 
 #: src/olympia/pages/templates/pages/faq.html:229
-msgid ""
-"What does it mean when an add-on is flagged as\n"
-"    slow?"
+msgid "Most add-ons load code and resources at the same time Firefox is starting up. In most cases the impact in start-up time is minimal, but some add-ons can cause a noticeable slowdown."
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:231
-msgid ""
-"Most add-ons load code and resources at the same time Firefox\n"
-"        is starting up. In most cases the impact in start-up time is minimal,\n"
-"        but some add-ons can cause a noticeable slowdown."
-msgstr ""
-
-#: src/olympia/pages/templates/pages/faq.html:236
+#: src/olympia/pages/templates/pages/faq.html:234
 msgid "How do I report an inappropriate or spam user review?"
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:237
+#: src/olympia/pages/templates/pages/faq.html:235
 msgid ""
-"To report a user review of an add-on, log in with your account\n"
-"    and visit the add-on's reviews page. Find the review you wish to report,\n"
-"    click \"Report this review\" and select a reason. Our editorial team will\n"
-"    investigate the review and take appropriate action."
+"To report a user review of an add-on, log in with your account and visit the add-on's reviews page. Find the review you wish to report, click \"Report this review\" and select a reason. Our "
+"editorial team will investigate the review and take appropriate action."
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:242
+#: src/olympia/pages/templates/pages/faq.html:240
 msgid "How do I report a bug or contact the Mozilla Add-ons team?"
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:243
+#: src/olympia/pages/templates/pages/faq.html:241
 #, python-format
 msgid "Please visit our <a href=\"%(contact_url)s\">Contact page</a>."
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:246
+#: src/olympia/pages/templates/pages/faq.html:244
 msgid "What is a Source Code License?"
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:247
+#: src/olympia/pages/templates/pages/faq.html:245
 #, python-format
 msgid ""
-"The source code used to create an add-on is an exclusive copyright of the "
-"add-on author, unless otherwise declared in a source code license. Many add-"
-"ons on this site have <a href=\"%(url)s\" lang=\"en\">open source "
-"licenses</a> that make the source code publicly available for copy and reuse"
-" under conditions determined by the author. Most authors choose widely known"
-" open source licenses like the GPL or BSD licenses instead of making up "
-"their own."
+"The source code used to create an add-on is an exclusive copyright of the add-on author, unless otherwise declared in a source code license. Many add-ons on this site have <a href=\"%(url)s\" lang="
+"\"en\">open source licenses</a> that make the source code publicly available for copy and reuse under conditions determined by the author. Most authors choose widely known open source licenses like "
+"the GPL or BSD licenses instead of making up their own."
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:256
+#: src/olympia/pages/templates/pages/faq.html:254
 #, python-format
-msgid ""
-"Firefox and other Mozilla software are <a href=\"%(url)s\">open source</a>."
+msgid "Firefox and other Mozilla software are <a href=\"%(url)s\">open source</a>."
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:264
+#: src/olympia/pages/templates/pages/faq.html:262
 msgid "Collections and Favorites"
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:267
+#: src/olympia/pages/templates/pages/faq.html:265
 msgid "What is a collection?"
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:268
+#: src/olympia/pages/templates/pages/faq.html:266
 msgid "Collections are groups of related add-ons created by users to share."
-msgstr ""
-"Kokoelmat ovat toisiinsa liittyvien lisäosien ryhmiä, jotka muut käyttäjät "
-"ovat luoneet ja jakaneet."
+msgstr "Kokoelmat ovat toisiinsa liittyvien lisäosien ryhmiä, jotka muut käyttäjät ovat luoneet ja jakaneet."
 
-#: src/olympia/pages/templates/pages/faq.html:270
+#: src/olympia/pages/templates/pages/faq.html:268
 msgid "What is the My Favorites collection?"
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:271
-msgid ""
-"Favorite add-ons are add-ons that you have bookmarked to easily get back to "
-"later. You can add an add-on to your favorites collection by clicking \"Add "
-"to favorites\" on its details page."
+#: src/olympia/pages/templates/pages/faq.html:269
+msgid "Favorite add-ons are add-ons that you have bookmarked to easily get back to later. You can add an add-on to your favorites collection by clicking \"Add to favorites\" on its details page."
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:275
-#: src/olympia/templates/menu_links.html:13
-#: src/olympia/templates/impala/header_title.html:17
+#: src/olympia/pages/templates/pages/faq.html:273 src/olympia/templates/menu_links.html:13 src/olympia/templates/impala/header_title.html:17
 msgid "Mobile Add-ons"
 msgstr "Mobiilin lisäosat"
 
-#: src/olympia/pages/templates/pages/faq.html:278
+#: src/olympia/pages/templates/pages/faq.html:276
 msgid "What are mobile add-ons?"
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:279
+#: src/olympia/pages/templates/pages/faq.html:277
 #, python-format
 msgid ""
-"Mobile add-ons work with <a href=\"%(mobile_url)s\">Firefox for Mobile</a> "
-"and add or modify functionality just like desktop add-ons. You can find add-"
-"ons that work with Firefox for Mobile in our <a "
-"href=\"%(gallery_url)s\">gallery</a>."
+"Mobile add-ons work with <a href=\"%(mobile_url)s\">Firefox for Mobile</a> and add or modify functionality just like desktop add-ons. You can find add-ons that work with Firefox for Mobile in our "
+"<a href=\"%(gallery_url)s\">gallery</a>."
 msgstr ""
 
 # 75%
-#: src/olympia/pages/templates/pages/faq.html:288
+#: src/olympia/pages/templates/pages/faq.html:286
 #, fuzzy
 msgid "Developer Topics"
 msgstr "Kehittäjien keskustelualue"
 
-#: src/olympia/pages/templates/pages/faq.html:289
+#: src/olympia/pages/templates/pages/faq.html:287
 #, python-format
-msgid ""
-"Please see our <a href=\"%(faq_url)s\">Developer FAQ</a> and <a "
-"href=\"%(hub_url)s\">Developer Hub</a> for answers to add-on developer-"
-"related questions."
+msgid "Please see our <a href=\"%(faq_url)s\">Developer FAQ</a> and <a href=\"%(hub_url)s\">Developer Hub</a> for answers to add-on developer-related questions."
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:294
+#: src/olympia/pages/templates/pages/faq.html:292
 msgid "Still have questions?"
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:295
+#: src/olympia/pages/templates/pages/faq.html:293
 #, python-format
-msgid ""
-"For general Firefox support, visit our <a href=\"%(sumo_url)s\">support "
-"website</a>. For general add-on and website questions, visit our <a "
-"href=\"%(forum_url)s\">forum</a>."
+msgid "For general Firefox support, visit our <a href=\"%(sumo_url)s\">support website</a>. For general add-on and website questions, visit our <a href=\"%(forum_url)s\">forum</a>."
 msgstr ""
 
-#: src/olympia/pages/templates/pages/review_guide.html:36
-#: src/olympia/pages/templates/pages/review_guide.html:51
+#: src/olympia/pages/templates/pages/review_guide.html:36 src/olympia/pages/templates/pages/review_guide.html:51
 msgid "Some tips for writing a great review"
 msgstr ""
 
-#: src/olympia/pages/templates/pages/review_guide.html:39
-#: src/olympia/pages/templates/pages/review_guide.html:131
+#: src/olympia/pages/templates/pages/review_guide.html:39 src/olympia/pages/templates/pages/review_guide.html:131
 msgid "Frequently Asked Questions about Reviews"
 msgstr ""
 
 #: src/olympia/pages/templates/pages/review_guide.html:46
 msgid ""
-"Add-on reviews are a way for you to share your opinions about the add-ons "
-"you’ve installed and used. Our review moderation team reserves the right to "
-"refuse or remove any review that does not comply with these guidelines."
+"Add-on reviews are a way for you to share your opinions about the add-ons you’ve installed and used. Our review moderation team reserves the right to refuse or remove any review that does not "
+"comply with these guidelines."
 msgstr ""
 
 #: src/olympia/pages/templates/pages/review_guide.html:53
@@ -12361,8 +10406,7 @@ msgid "Do:"
 msgstr ""
 
 #: src/olympia/pages/templates/pages/review_guide.html:56
-msgid ""
-"Write like you are telling a friend about your experience with the add-on."
+msgid "Write like you are telling a friend about your experience with the add-on."
 msgstr ""
 
 #: src/olympia/pages/templates/pages/review_guide.html:61
@@ -12394,8 +10438,7 @@ msgid "Will you continue to use this add-on?"
 msgstr ""
 
 #: src/olympia/pages/templates/pages/review_guide.html:73
-msgid ""
-"Take a moment to read your review before submitting it to minimize typos."
+msgid "Take a moment to read your review before submitting it to minimize typos."
 msgstr ""
 
 #: src/olympia/pages/templates/pages/review_guide.html:79
@@ -12408,9 +10451,8 @@ msgstr ""
 
 #: src/olympia/pages/templates/pages/review_guide.html:87
 msgid ""
-"Post technical issues, support requests, or feature suggestions. Use the "
-"available support options for each add-on, if available. You can find them "
-"in the side column next to the About this Add-on section."
+"Post technical issues, support requests, or feature suggestions. Use the available support options for each add-on, if available. You can find them in the side column next to the About this Add-on "
+"section."
 msgstr ""
 
 #: src/olympia/pages/templates/pages/review_guide.html:92
@@ -12418,38 +10460,29 @@ msgid "Write reviews for add-ons which you have not personally used."
 msgstr ""
 
 #: src/olympia/pages/templates/pages/review_guide.html:97
-msgid ""
-"Use profanity, sexual language or language that can be construed as hateful."
+msgid "Use profanity, sexual language or language that can be construed as hateful."
 msgstr ""
 
 #: src/olympia/pages/templates/pages/review_guide.html:103
-msgid ""
-"Include HTML, links, source code or code snippets. Reviews are meant to be "
-"text only."
+msgid "Include HTML, links, source code or code snippets. Reviews are meant to be text only."
 msgstr ""
 
 #: src/olympia/pages/templates/pages/review_guide.html:108
-msgid ""
-"Make false statements, disparage add-on authors or personally insult them."
+msgid "Make false statements, disparage add-on authors or personally insult them."
 msgstr ""
 
 #: src/olympia/pages/templates/pages/review_guide.html:114
-msgid ""
-"Include your own or anyone else’s email, phone number, or other personal "
-"details."
+msgid "Include your own or anyone else’s email, phone number, or other personal details."
 msgstr ""
 
 #: src/olympia/pages/templates/pages/review_guide.html:119
-msgid ""
-"Post reviews for an add-on you or your organization wrote or represent."
+msgid "Post reviews for an add-on you or your organization wrote or represent."
 msgstr ""
 
 #: src/olympia/pages/templates/pages/review_guide.html:125
 msgid ""
-"Criticize an add-on for something it’s intended to do. For example, leaving "
-"a negative review of an add-on for displaying ads or requiring data "
-"gathering, when that is the intended purpose of the add-on, or the add-on "
-"requires gathering data to function."
+"Criticize an add-on for something it’s intended to do. For example, leaving a negative review of an add-on for displaying ads or requiring data gathering, when that is the intended purpose of the "
+"add-on, or the add-on requires gathering data to function."
 msgstr ""
 
 #: src/olympia/pages/templates/pages/review_guide.html:133
@@ -12458,10 +10491,8 @@ msgstr ""
 
 #: src/olympia/pages/templates/pages/review_guide.html:135
 msgid ""
-"Please report or flag any questionable reviews by clicking the \"Report this"
-" review\" and it will be submitted to the site for moderation. Our "
-"moderation team will use the Review Guidelines to evaluate whether or not to"
-" delete the review or restore it back to the site."
+"Please report or flag any questionable reviews by clicking the \"Report this review\" and it will be submitted to the site for moderation. Our moderation team will use the Review Guidelines to "
+"evaluate whether or not to delete the review or restore it back to the site."
 msgstr ""
 
 #: src/olympia/pages/templates/pages/review_guide.html:140
@@ -12470,10 +10501,7 @@ msgstr ""
 
 #: src/olympia/pages/templates/pages/review_guide.html:142
 #, python-format
-msgid ""
-"Yes, add-on authors can provide a single response to a review. You can set "
-"up a discussion topic in our <a href=\"%(forum_url)s\">forum</a> to engage "
-"in additional discussion or follow-up."
+msgid "Yes, add-on authors can provide a single response to a review. You can set up a discussion topic in our <a href=\"%(forum_url)s\">forum</a> to engage in additional discussion or follow-up."
 msgstr ""
 
 #: src/olympia/pages/templates/pages/review_guide.html:149
@@ -12482,11 +10510,8 @@ msgstr ""
 
 #: src/olympia/pages/templates/pages/review_guide.html:151
 msgid ""
-"In general, no. But if the review did not meet the review guidelines "
-"outlined above, you can click \"Report this review\" and have it moderated. "
-"If a review included a complaint that is no longer valid due to a new "
-"release of your add-on, we may consider deleting the review. Submit your "
-"detailed request to amo-editors@mozilla.org."
+"In general, no. But if the review did not meet the review guidelines outlined above, you can click \"Report this review\" and have it moderated. If a review included a complaint that is no longer "
+"valid due to a new release of your add-on, we may consider deleting the review. Submit your detailed request to amo-editors@mozilla.org."
 msgstr ""
 
 #: src/olympia/pages/templates/pages/sunbird.html:26
@@ -12495,17 +10520,13 @@ msgstr ""
 
 #: src/olympia/pages/templates/pages/sunbird.html:29
 msgid ""
-"Development on the Sunbird project has halted and its final release was on "
-"March 30, 2010.  We've been proud to host Sunbird add-ons on this site but "
-"as the project is no longer maintained we have disabled our support for the "
-"add-ons."
+"Development on the Sunbird project has halted and its final release was on March 30, 2010. We've been proud to host Sunbird add-ons on this site but as the project is no longer maintained we have "
+"disabled our support for the add-ons."
 msgstr ""
 
 #: src/olympia/pages/templates/pages/sunbird.html:38
 #, python-format
-msgid ""
-"We recommend upgrading to <a href=\"%(tb_url)s\">Thunderbird</a> and <a "
-"href=\"%(lightning_url)s\">Lightning</a>."
+msgid "We recommend upgrading to <a href=\"%(tb_url)s\">Thunderbird</a> and <a href=\"%(lightning_url)s\">Lightning</a>."
 msgstr ""
 
 #: src/olympia/pages/templates/pages/sunbird.html:45
@@ -12543,8 +10564,8 @@ msgstr "Arvostelut lisäosalle %s"
 msgid "Review History for this Addon"
 msgstr ""
 
-#. L10n: This describes the number of stars given out of 5
 # %1 is the number of stars this add-on has
+#. L10n: This describes the number of stars given out of 5
 #: src/olympia/reviews/feeds.py:49
 #, python-format
 msgid "Rated %d out of 5 stars"
@@ -12558,8 +10579,7 @@ msgstr ""
 msgid "Skip for now"
 msgstr ""
 
-#: src/olympia/reviews/forms.py:151
-#: src/olympia/reviews/templates/reviews/review.html:107
+#: src/olympia/reviews/forms.py:151 src/olympia/reviews/templates/reviews/review.html:107
 msgid "Delete review"
 msgstr ""
 
@@ -12578,27 +10598,18 @@ msgstr ""
 #: src/olympia/reviews/templates/reviews/add.html:26
 #, python-format
 msgid ""
-"<h2>Keep these tips in mind:</h2> <ul> <li> Write like you're telling a "
-"friend about your experience with the add-on. Give specifics and helpful "
-"details, such as what features you liked and/or disliked, how easy to use it"
-" is, and any disadvantages it has.  Avoid generic language such as calling "
-"it \"Great\" or \"Bad\" unless you can give reasons why you believe this is "
-"so. </li> <li> Please do not post bug reports in reviews. We do not make "
-"your email address available to add-on developers and they may need to "
-"contact you to help resolve your issue. See the <a "
-"href=\"%(support)s\">support section</a> to find out where to get assistance"
-" for this add-on. </li> <li>Please keep reviews clean, avoid the use of "
-"improper language and do not post any personal information. </li> </ul> "
-"<p>Please read the <a href=\"%(guide)s\" target=\"_blank\">Review "
-"Guidelines</a> for more detail about user add-on reviews.</p>"
+"<h2>Keep these tips in mind:</h2> <ul> <li> Write like you're telling a friend about your experience with the add-on. Give specifics and helpful details, such as what features you liked and/or "
+"disliked, how easy to use it is, and any disadvantages it has. Avoid generic language such as calling it \"Great\" or \"Bad\" unless you can give reasons why you believe this is so. </li> <li> "
+"Please do not post bug reports in reviews. We do not make your email address available to add-on developers and they may need to contact you to help resolve your issue. See the <a href=\"%(support)s"
+"\">support section</a> to find out where to get assistance for this add-on. </li> <li>Please keep reviews clean, avoid the use of improper language and do not post any personal information. </li> </"
+"ul> <p>Please read the <a href=\"%(guide)s\" target=\"_blank\">Review Guidelines</a> for more detail about user add-on reviews.</p>"
 msgstr ""
 
 #: src/olympia/reviews/templates/reviews/reply.html:4
 msgid "Reply to review by {0}"
 msgstr ""
 
-#: src/olympia/reviews/templates/reviews/reply.html:15
-#: src/olympia/reviews/templates/reviews/reply.html:31
+#: src/olympia/reviews/templates/reviews/reply.html:15 src/olympia/reviews/templates/reviews/reply.html:31
 msgid "Reply"
 msgstr ""
 
@@ -12606,8 +10617,7 @@ msgstr ""
 msgid "Write a Reply"
 msgstr ""
 
-#: src/olympia/reviews/templates/reviews/reply.html:36
-#: src/olympia/reviews/templates/reviews/report_review.html:12
+#: src/olympia/reviews/templates/reviews/reply.html:36 src/olympia/reviews/templates/reviews/report_review.html:12
 msgid "Submit"
 msgstr ""
 
@@ -12627,27 +10637,20 @@ msgid "by %(user)s <b>(Developer)</b> on %(date)s"
 msgstr ""
 
 #. {0} is a version number (like 1.01)
-#: src/olympia/reviews/templates/reviews/review.html:50
-#: src/olympia/reviews/templates/reviews/mobile/review_list.html:41
+#: src/olympia/reviews/templates/reviews/review.html:50 src/olympia/reviews/templates/reviews/mobile/review_list.html:41
 msgid "This review is for a previous version of the add-on ({0})."
 msgstr ""
 
 #: src/olympia/reviews/templates/reviews/review.html:56
 #, python-format
-msgid ""
-"This user has a <a href=\"%(user_review_url)s\">previous review</a> of this "
-"add-on."
-msgid_plural ""
-"This user has <a href=\"%(user_review_url)s\">%(cnt)s previous reviews</a> "
-"of this add-on."
+msgid "This user has a <a href=\"%(user_review_url)s\">previous review</a> of this add-on."
+msgid_plural "This user has <a href=\"%(user_review_url)s\">%(cnt)s previous reviews</a> of this add-on."
 msgstr[0] ""
 msgstr[1] ""
 
 #: src/olympia/reviews/templates/reviews/review.html:62
 #, python-format
-msgid ""
-"This user has <a href=\"%(user_review_url)s\">other reviews</a> of this add-"
-"on."
+msgid "This user has <a href=\"%(user_review_url)s\">other reviews</a> of this add-on."
 msgstr ""
 
 #: src/olympia/reviews/templates/reviews/review.html:72
@@ -12680,9 +10683,7 @@ msgid "{0} :: Reviews"
 msgstr ""
 
 #. {0} is an addon name.
-#: src/olympia/reviews/templates/reviews/review_list.html:24
-#: src/olympia/reviews/templates/reviews/mobile/add.html:4
-#: src/olympia/reviews/templates/reviews/mobile/review_list.html:4
+#: src/olympia/reviews/templates/reviews/review_list.html:24 src/olympia/reviews/templates/reviews/mobile/add.html:4 src/olympia/reviews/templates/reviews/mobile/review_list.html:4
 msgid "Reviews for {0}"
 msgstr "Arvostelut lisäosalle {0}"
 
@@ -12721,8 +10722,7 @@ msgstr ""
 msgid "Write a New Review"
 msgstr ""
 
-#: src/olympia/reviews/templates/reviews/review_list.html:81
-#: src/olympia/reviews/templates/reviews/mobile/reviews_link.html:15
+#: src/olympia/reviews/templates/reviews/review_list.html:81 src/olympia/reviews/templates/reviews/mobile/reviews_link.html:15
 msgid "Be the first to write a review."
 msgstr ""
 
@@ -12745,8 +10745,7 @@ msgstr "Pisteitä %d / 5"
 msgid "Rated %(rating)s out of 5 stars"
 msgstr ""
 
-#: src/olympia/reviews/templates/reviews/mobile/add_form.html:3
-#: src/olympia/reviews/templates/reviews/mobile/add_form.html:8
+#: src/olympia/reviews/templates/reviews/mobile/add_form.html:3 src/olympia/reviews/templates/reviews/mobile/add_form.html:8
 msgid "Add a Review"
 msgstr ""
 
@@ -12819,11 +10818,8 @@ msgid "Relevance"
 msgstr "Täsmäävyys"
 
 #: src/olympia/search/helpers.py:24
-msgid ""
-"Results <strong>{0}</strong>-<strong>{1}</strong> of <strong>{2}</strong>"
-msgstr ""
-"Tulokset <strong>{0}</strong>-<strong>{1}</strong>, yhteensä "
-"<strong>{2}</strong>"
+msgid "Results <strong>{0}</strong>-<strong>{1}</strong> of <strong>{2}</strong>"
+msgstr "Tulokset <strong>{0}</strong>-<strong>{1}</strong>, yhteensä <strong>{2}</strong>"
 
 # {0} is a number
 # {1} is a number
@@ -12831,12 +10827,8 @@ msgstr ""
 # {3} is the word the person is searching for
 # {4} is a word (the add-on is tagged with it)
 #: src/olympia/search/helpers.py:44
-msgid ""
-"Showing {0} - {1} of {2} results for <strong>{3}</strong> tagged with "
-"<strong>{4}</strong>"
-msgstr ""
-"Näytetään tulokset {0} - {1} / {2} haulle <strong>{3}</strong> tunnisteella "
-"<strong>{4}</strong>"
+msgid "Showing {0} - {1} of {2} results for <strong>{3}</strong> tagged with <strong>{4}</strong>"
+msgstr "Näytetään tulokset {0} - {1} / {2} haulle <strong>{3}</strong> tunnisteella <strong>{4}</strong>"
 
 # {0} is a number
 # {1} is a number
@@ -12862,29 +10854,27 @@ msgid "Showing {0} - {1} of {2} results"
 msgstr "Näytetään tulokset {0} - {1} / {2}"
 
 #. {0} is an application, like Firefox.
-#: src/olympia/search/views.py:264 src/olympia/templates/base.html:17
-#: src/olympia/templates/impala/base.html:17
-#: src/olympia/templates/mobile/base_addons.html:17
+#: src/olympia/search/views.py:264 src/olympia/templates/base.html:17 src/olympia/templates/impala/base.html:17 src/olympia/templates/mobile/base_addons.html:17
 msgid "{0} Add-ons"
 msgstr "{0}-lisäosat"
 
 #. L10n: {0} is an application, such as Firefox. This means "any version of
 #. Firefox."
-#: src/olympia/search/views.py:554
+#: src/olympia/search/views.py:547
 msgid "Any {0}"
 msgstr ""
 
 #. L10n: "All Systems" means show everything regardless of platform.
-#: src/olympia/search/views.py:589
+#: src/olympia/search/views.py:582
 msgid "All Systems"
 msgstr "Kaikki järjestelmät"
 
-#: src/olympia/search/views.py:600
+#: src/olympia/search/views.py:593
 msgid "All Tags"
 msgstr "Kaikki avainsanat"
 
-#. {0} is the string the user was searching for
 # 75%
+#. {0} is the string the user was searching for
 #: src/olympia/search/templates/search/collections.html:8
 #, fuzzy
 msgid "Collection Search Results for {0}"
@@ -13055,36 +11045,31 @@ msgstr "Jaa tämä lisäosa"
 msgid "Share this Collection"
 msgstr "Jaa tämä kokoelma"
 
-#: src/olympia/signing/views.py:30 src/olympia/templates/base.html:75
-#: src/olympia/templates/impala/base.html:115
-msgid ""
-"Some features are temporarily disabled while we perform website maintenance."
-" We'll be back to full capacity shortly."
-msgstr ""
-"Osa toiminnoista on hetkellisesti poissa käytöstä suorittaessamme "
-"verkkosivun huoltoa. Palaamme täyteen toimintaan pikaisesti."
+#: src/olympia/signing/views.py:33 src/olympia/templates/base.html:71 src/olympia/templates/impala/base.html:112
+msgid "Some features are temporarily disabled while we perform website maintenance. We'll be back to full capacity shortly."
+msgstr "Osa toiminnoista on hetkellisesti poissa käytöstä suorittaessamme verkkosivun huoltoa. Palaamme täyteen toimintaan pikaisesti."
 
-#: src/olympia/signing/views.py:53
+#: src/olympia/signing/views.py:56
 msgid "Could not find add-on with id \"{}\"."
 msgstr ""
 
-#: src/olympia/signing/views.py:67
+#: src/olympia/signing/views.py:70
 msgid "You do not own this addon."
 msgstr ""
 
-#: src/olympia/signing/views.py:82
+#: src/olympia/signing/views.py:87
 msgid "Missing \"upload\" key in multipart file data."
 msgstr ""
 
-#: src/olympia/signing/views.py:96
+#: src/olympia/signing/views.py:101
 msgid "Version does not match the manifest file."
 msgstr ""
 
-#: src/olympia/signing/views.py:100
+#: src/olympia/signing/views.py:105
 msgid "Version already exists."
 msgstr ""
 
-#: src/olympia/signing/views.py:136
+#: src/olympia/signing/views.py:141
 msgid "No uploaded file for that addon and version."
 msgstr ""
 
@@ -13189,8 +11174,7 @@ msgstr "Loppu"
 
 # 85%
 # 100%
-#: src/olympia/stats/templates/stats/popup.html:27
-#: src/olympia/users/templates/users/pwreset_confirm.html:38
+#: src/olympia/stats/templates/stats/popup.html:27 src/olympia/users/templates/users/pwreset_confirm.html:38
 msgid "Update"
 msgstr "Päivitä"
 
@@ -13213,97 +11197,91 @@ msgstr ""
 msgid "Statistics Dashboard :: Add-ons for {0}"
 msgstr "{0} :: Tilastokeskus :: {1}in lisäosat"
 
-#: src/olympia/stats/templates/stats/stats.html:30
-msgid "Controls:"
-msgstr ""
-
-#: src/olympia/stats/templates/stats/stats.html:33
-msgid "reset zoom"
-msgstr ""
-
-#: src/olympia/stats/templates/stats/stats.html:40
-msgid "Group by:"
-msgstr "Järjestä:"
-
-#: src/olympia/stats/templates/stats/stats.html:42
-msgid "day"
-msgstr "päivä"
-
-#: src/olympia/stats/templates/stats/stats.html:45
-msgid "week"
-msgstr "viikko"
-
-#: src/olympia/stats/templates/stats/stats.html:48
-msgid "month"
-msgstr "kuukausi"
-
-#: src/olympia/stats/templates/stats/stats.html:54
-msgid "For last:"
-msgstr "Ajanjakso:"
-
-#: src/olympia/stats/templates/stats/stats.html:57
-msgid "7 days"
-msgstr "7 päivää"
-
-#: src/olympia/stats/templates/stats/stats.html:60
-msgid "30 days"
-msgstr "30 päivää"
-
-#: src/olympia/stats/templates/stats/stats.html:63
-msgid "90 days"
-msgstr "90 päivää"
-
-#: src/olympia/stats/templates/stats/stats.html:66
-msgid "365 days"
-msgstr "365 päivää"
-
-#: src/olympia/stats/templates/stats/stats.html:69
-msgid "Custom..."
-msgstr "Muokattu..."
-
 #. {0} is an add-on name
-#: src/olympia/stats/templates/stats/stats.html:88
-#: src/olympia/stats/templates/stats/stats.html:91
+#: src/olympia/stats/templates/stats/stats.html:44 src/olympia/stats/templates/stats/stats.html:47
 msgid "Statistics for {0}"
 msgstr "Tilastot lisäosalle {0}"
 
-#: src/olympia/stats/templates/stats/stats.html:94
+#: src/olympia/stats/templates/stats/stats.html:50
 msgid "Statistics Dashboard"
 msgstr ""
 
-#: src/olympia/stats/templates/stats/stats.html:104
-msgid ""
-"Statistics processing is currently disabled, so recent data is unavailable. "
-"The statistics are still being collected and this page will be updated soon "
-"with the missing data."
+#: src/olympia/stats/templates/stats/stats.html:57
+msgid "Controls:"
 msgstr ""
 
-#: src/olympia/stats/templates/stats/stats.html:110
+#: src/olympia/stats/templates/stats/stats.html:60
+msgid "reset zoom"
+msgstr ""
+
+#: src/olympia/stats/templates/stats/stats.html:67
+msgid "Group by:"
+msgstr "Järjestä:"
+
+#: src/olympia/stats/templates/stats/stats.html:69
+msgid "day"
+msgstr "päivä"
+
+#: src/olympia/stats/templates/stats/stats.html:72
+msgid "week"
+msgstr "viikko"
+
+#: src/olympia/stats/templates/stats/stats.html:75
+msgid "month"
+msgstr "kuukausi"
+
+#: src/olympia/stats/templates/stats/stats.html:81
+msgid "For last:"
+msgstr "Ajanjakso:"
+
+#: src/olympia/stats/templates/stats/stats.html:84
+msgid "7 days"
+msgstr "7 päivää"
+
+#: src/olympia/stats/templates/stats/stats.html:87
+msgid "30 days"
+msgstr "30 päivää"
+
+#: src/olympia/stats/templates/stats/stats.html:90
+msgid "90 days"
+msgstr "90 päivää"
+
+#: src/olympia/stats/templates/stats/stats.html:93
+msgid "365 days"
+msgstr "365 päivää"
+
+#: src/olympia/stats/templates/stats/stats.html:96
+msgid "Custom..."
+msgstr "Muokattu..."
+
+#: src/olympia/stats/templates/stats/stats.html:106
+msgid "Statistics processing is currently disabled, so recent data is unavailable. The statistics are still being collected and this page will be updated soon with the missing data."
+msgstr ""
+
+#: src/olympia/stats/templates/stats/stats.html:112
 msgid "Loading the latest data&hellip;"
 msgstr "Ladataan viimeisintä dataa&hellip;"
 
-#: src/olympia/stats/templates/stats/stats.html:142
-#: src/olympia/stats/templates/stats/reports/overview.html:25
-#: src/olympia/stats/templates/stats/reports/overview.html:37
+#: src/olympia/stats/templates/stats/stats.html:144 src/olympia/stats/templates/stats/reports/overview.html:25 src/olympia/stats/templates/stats/reports/overview.html:37
 #: src/olympia/stats/templates/stats/reports/overview.html:49
 msgid "No data available."
 msgstr "Ei dataa saatavilla..."
 
-#: src/olympia/stats/templates/stats/stats.html:177
+#: src/olympia/stats/templates/stats/stats.html:179
 msgid "This dashboard is currently <b>public</b>."
 msgstr "Tämä kojelauta on tällähetkellä <b>julkinen</b>."
 
-#: src/olympia/stats/templates/stats/stats.html:179
+#: src/olympia/stats/templates/stats/stats.html:181
 msgid "Contribution stats are currently <b>private</b>."
 msgstr ""
 
 # 86%
-#: src/olympia/stats/templates/stats/stats.html:182
+#: src/olympia/stats/templates/stats/stats.html:184
 #, fuzzy
 msgid "This dashboard is currently <b>private</b>."
 msgstr "Tämä kojelauta on tällähetkellä <b>julkinen</b>."
 
-#: src/olympia/stats/templates/stats/stats.html:185
+#: src/olympia/stats/templates/stats/stats.html:187
 msgid "Change settings."
 msgstr "Muuta asetuksia."
 
@@ -13347,9 +11325,8 @@ msgstr ""
 
 #: src/olympia/stats/templates/stats/reports/downloads.html:10
 msgid ""
-"<h2>How are downloads counted?</h2> <p> Download counts are updated every "
-"evening and only include original add-on downloads, not updates. Downloads "
-"can be broken down by the specific source referring the download. </p>"
+"<h2>How are downloads counted?</h2> <p> Download counts are updated every evening and only include original add-on downloads, not updates. Downloads can be broken down by the specific source "
+"referring the download. </p>"
 msgstr ""
 
 #: src/olympia/stats/templates/stats/reports/locales.html:3
@@ -13364,8 +11341,7 @@ msgstr ""
 msgid "<b>{0}</b> Downloads"
 msgstr "<b>{0}</b> latausta"
 
-#: src/olympia/stats/templates/stats/reports/overview.html:9
-#: src/olympia/stats/templates/stats/reports/overview.html:13
+#: src/olympia/stats/templates/stats/reports/overview.html:9 src/olympia/stats/templates/stats/reports/overview.html:13
 msgid "Loading..."
 msgstr "Ladataan..."
 
@@ -13416,19 +11392,11 @@ msgstr ""
 #: src/olympia/stats/templates/stats/reports/sources.html:10
 #, python-format
 msgid ""
-"<h2>Tracking external sources</h2> <p> If you link to your add-on's details "
-"page or directly to its file from an external site, such as your blog or "
-"website, you can append a parameter to be tracked as an additional download "
-"source on this page. For example, the following links would appear as "
-"sourced by your blog: <dl> <dt>Add-on Details Page</dt> "
-"<dd>https://addons.mozilla.org/addon/%(slug)s?src=<b>external-blog</b></dd> "
-"<dt>Direct File Link</dt> "
-"<dd>https://addons.mozilla.org/downloads/latest/%(id)s/addon-%(id)s-latest.xpi?src=<b"
-">external-blog</b></dd> </dl> <p> Only src parameters that begin with "
-"\"external-\" will be tracked, up to 61 additional characters. Any text "
-"after \"external-\" can be used to describe the source, such as \"external-"
-"blog\", \"external-sidebar\", \"external-campaign225\", etc. The following "
-"URL-safe characters are allowed: <code>a-z A-Z - . _ ~ %% +</code>"
+"<h2>Tracking external sources</h2> <p> If you link to your add-on's details page or directly to its file from an external site, such as your blog or website, you can append a parameter to be "
+"tracked as an additional download source on this page. For example, the following links would appear as sourced by your blog: <dl> <dt>Add-on Details Page</dt> <dd>https://addons.mozilla.org/addon/"
+"%(slug)s?src=<b>external-blog</b></dd> <dt>Direct File Link</dt> <dd>https://addons.mozilla.org/downloads/latest/%(id)s/addon-%(id)s-latest.xpi?src=<b>external-blog</b></dd> </dl> <p> Only src "
+"parameters that begin with \"external-\" will be tracked, up to 61 additional characters. Any text after \"external-\" can be used to describe the source, such as \"external-blog\", \"external-"
+"sidebar\", \"external-campaign225\", etc. The following URL-safe characters are allowed: <code>a-z A-Z - . _ ~ %% +</code>"
 msgstr ""
 
 #: src/olympia/stats/templates/stats/reports/statuses.html:3
@@ -13449,18 +11417,14 @@ msgstr "Keitä ovat päivittäiset käyttäjät?"
 
 #: src/olympia/stats/templates/stats/reports/usage.html:11
 msgid ""
-"<h2>What are daily users?</h2> <p> Themes installed from this site check for"
-" updates once per day. The total number of these update pings is known as "
-"Active Daily Users, or the total number of people using your theme by day. "
-"</p>"
+"<h2>What are daily users?</h2> <p> Themes installed from this site check for updates once per day. The total number of these update pings is known as Active Daily Users, or the total number of "
+"people using your theme by day. </p>"
 msgstr ""
 
 #: src/olympia/stats/templates/stats/reports/usage.html:20
 msgid ""
-"<h2>What are daily users?</h2> <p> Add-ons downloaded from this site check "
-"for updates once per day. The total number of these update pings is known as"
-" Active Daily Users. Daily users can be broken down by add-on version, "
-"operating system, add-on status, application, and locale. </p>"
+"<h2>What are daily users?</h2> <p> Add-ons downloaded from this site check for updates once per day. The total number of these update pings is known as Active Daily Users. Daily users can be broken "
+"down by add-on version, operating system, add-on status, application, and locale. </p>"
 msgstr ""
 
 #: src/olympia/stats/templates/stats/reports/users_created.html:3
@@ -13471,46 +11435,27 @@ msgstr ""
 msgid "Application versions by Date"
 msgstr "Sovellusversiot päivittäin"
 
-# {0} is a number
-#: src/olympia/tags/templates/tags/top_cloud.html:4
-msgid "Top {0} Tags"
-msgstr ""
-
-#. {0} is the current application name
-#: src/olympia/tags/templates/tags/top_cloud.html:14
-msgid "{0} Top Tags"
-msgstr ""
-
-#: src/olympia/templates/amo_footer.html:6
-#: src/olympia/templates/includes/lang_switcher.html:2
+#: src/olympia/templates/amo_footer.html:6 src/olympia/templates/includes/lang_switcher.html:2
 msgid "Other languages"
 msgstr "Muut kielet"
 
-#: src/olympia/templates/base.html:9 src/olympia/templates/impala/base.html:9
-#: src/olympia/templates/mobile/base_addons.html:9
+#: src/olympia/templates/base.html:9 src/olympia/templates/impala/base.html:9 src/olympia/templates/mobile/base_addons.html:9
 msgid "Mozilla Add-ons"
 msgstr "Mozilla-lisäosat"
 
-#: src/olympia/templates/base.html:91
-#: src/olympia/templates/impala/base.html:81
+#: src/olympia/templates/base.html:89 src/olympia/templates/impala/base.html:78
 msgid "Find add-ons for other applications"
 msgstr "Etsi lisäosia muille sovelluksille"
 
-#: src/olympia/templates/base.html:92
-#: src/olympia/templates/impala/base.html:81
+#: src/olympia/templates/base.html:90 src/olympia/templates/impala/base.html:78
 msgid "Other Applications"
 msgstr "Muut ohjelmat"
 
-#: src/olympia/templates/base.html:141
-#: src/olympia/templates/impala/base.html:194
-msgid ""
-"To create your own collections, you must have a Mozilla Add-ons account."
-msgstr ""
-"Jotta voisit luoda omia kokoelmia, sinulla pitää olla käyttäjätili Mozilla "
-"Lisäosat -palvelussa."
+#: src/olympia/templates/base.html:141 src/olympia/templates/impala/base.html:194
+msgid "To create your own collections, you must have a Mozilla Add-ons account."
+msgstr "Jotta voisit luoda omia kokoelmia, sinulla pitää olla käyttäjätili Mozilla Lisäosat -palvelussa."
 
-#: src/olympia/templates/base.html:168
-#: src/olympia/templates/impala/base.html:215
+#: src/olympia/templates/base.html:168 src/olympia/templates/impala/base.html:215
 msgid "Footer logo"
 msgstr ""
 
@@ -13527,21 +11472,19 @@ msgid "View Mobile Site"
 msgstr "Näytä mobiilisivu"
 
 #: src/olympia/templates/copyright.html:7
-msgid "Site Status "
+msgid "Site Status"
 msgstr ""
 
 #: src/olympia/templates/footer.html:3
 msgid "get to know <b>add-ons</b>"
 msgstr "opi tuntemaan <b>lisäosat</b>"
 
-#: src/olympia/templates/footer.html:4
-#: src/olympia/templates/menu_links.html:20
+#: src/olympia/templates/footer.html:4 src/olympia/templates/menu_links.html:20
 msgid "About"
 msgstr "Tietoja"
 
 # Link text to the AMO blog.
-#: src/olympia/templates/footer.html:5
-#: src/olympia/templates/menu_links.html:32
+#: src/olympia/templates/footer.html:5 src/olympia/templates/menu_links.html:32
 msgid "Blog"
 msgstr "Blogi"
 
@@ -13618,9 +11561,7 @@ msgstr "Lakiasiat"
 msgid "Contact Us"
 msgstr "Ota yhteyttä"
 
-#: src/olympia/templates/user_login.html:22
-#: src/olympia/users/templates/users/edit.html:31
-#: src/olympia/users/templates/users/includes/navigation.html:12
+#: src/olympia/templates/user_login.html:22 src/olympia/users/templates/users/edit.html:31 src/olympia/users/templates/users/includes/navigation.html:12
 msgid "My Account"
 msgstr "Tilini"
 
@@ -13628,53 +11569,40 @@ msgstr "Tilini"
 msgid "Welcome, {0}"
 msgstr "Tervetuloa, {0}"
 
-#: src/olympia/templates/user_login.html:41
-#: src/olympia/templates/impala/user_login.html:20
+#: src/olympia/templates/user_login.html:41 src/olympia/templates/impala/user_login.html:20
 #, python-format
 msgid "<a href=\"%(reg)s\">Register</a> or <a href=\"%(login)s\">Log in</a>"
-msgstr ""
-"<a href=\"%(reg)s\">Rekisteröidy</a> tai <a href=\"%(login)s\">kirjaudu "
-"sisään</a>"
+msgstr "<a href=\"%(reg)s\">Rekisteröidy</a> tai <a href=\"%(login)s\">kirjaudu sisään</a>"
 
-#: src/olympia/templates/impala/base.html:126
+#: src/olympia/templates/impala/base.html:123
 #, python-format
-msgid ""
-"To try the thousands of add-ons available here, download <a "
-"href=\"%(url)s\">Mozilla Firefox</a>, a fast, free way to surf the Web!"
-msgstr ""
-"Jos haluat kokeilla tuhansia täällä olevia lisäosia, lataa <a "
-"href=\"%(url)s\">Mozilla Firefox</a>, nopea ja luotettava tapa selata "
-"verkkoa!"
+msgid "To try the thousands of add-ons available here, download <a href=\"%(url)s\">Mozilla Firefox</a>, a fast, free way to surf the Web!"
+msgstr "Jos haluat kokeilla tuhansia täällä olevia lisäosia, lataa <a href=\"%(url)s\">Mozilla Firefox</a>, nopea ja luotettava tapa selata verkkoa!"
 
-#: src/olympia/templates/impala/base.html:138
+#: src/olympia/templates/impala/base.html:135
 #, python-format
-msgid ""
-"Add-ons is switching to Firefox Accounts for login. <a href=\"%(url)s\" "
-"class=\"fxa-login\">Sign in now to transfer your account.</a>"
+msgid "Add-ons is switching to Firefox Accounts for login. <a href=\"%(url)s\" class=\"fxa-login\">Sign in now to transfer your account.</a>"
 msgstr ""
 
 #. {0} is an application, such as Firefox.
-#: src/olympia/templates/impala/base.html:148
+#: src/olympia/templates/impala/base.html:145
 msgid "Welcome to {0} Add-ons."
 msgstr "Tervetuloa {0}-lisäosiin."
 
-#: src/olympia/templates/impala/base.html:151
-msgid ""
-"Choose from thousands of extra features and styles to make Firefox your own."
-msgstr ""
-"Tee Firefoxista juuri sinunlaisesti tuhansilla lisäominaisuuksilla ja "
-"tyyleillä."
+#: src/olympia/templates/impala/base.html:148
+msgid "Choose from thousands of extra features and styles to make Firefox your own."
+msgstr "Tee Firefoxista juuri sinunlaisesti tuhansilla lisäominaisuuksilla ja tyyleillä."
 
-#: src/olympia/templates/impala/base.html:156
+#: src/olympia/templates/impala/base.html:153
 #, python-format
 msgid "Add extra features and styles to make %(app)s your own."
 msgstr ""
 
-#: src/olympia/templates/impala/base.html:164
+#: src/olympia/templates/impala/base.html:161
 msgid "On the go?"
 msgstr "Matkalla?"
 
-#: src/olympia/templates/impala/base.html:166
+#: src/olympia/templates/impala/base.html:163
 msgid "Check out our <a class=\"mobile-link\" href=\"#\">Mobile Add-ons site</a>."
 msgstr "Katso <a class=\"mobile-link\" href=\"#\">mobiililisäosasivumme</a>."
 
@@ -13682,8 +11610,7 @@ msgstr "Katso <a class=\"mobile-link\" href=\"#\">mobiililisäosasivumme</a>."
 msgid "Android Add-ons"
 msgstr "Android-lisäosat"
 
-#: src/olympia/templates/includes/forms.html:2
-#: src/olympia/templates/includes/forms.html:6
+#: src/olympia/templates/includes/forms.html:2 src/olympia/templates/includes/forms.html:6
 msgid "required"
 msgstr "vaaditaan"
 
@@ -13728,17 +11655,13 @@ msgstr "Vieraile Mozillassa"
 msgid "menu"
 msgstr "valikko"
 
-#: src/olympia/templates/mobile/header_auth.html:7
-#: src/olympia/users/templates/users/register.html:41
-#: src/olympia/users/templates/users/register.html:89
+#: src/olympia/templates/mobile/header_auth.html:7 src/olympia/users/templates/users/register.html:41 src/olympia/users/templates/users/register.html:89
 msgid "Register"
 msgstr "Rekisteröidy"
 
 # 83%
 # 100%
-#: src/olympia/templates/mobile/header_auth.html:8
-#: src/olympia/users/templates/users/login_form.html:41
-#: src/olympia/users/templates/users/pwreset_complete.html:15
+#: src/olympia/templates/mobile/header_auth.html:8 src/olympia/users/templates/users/login_form.html:41 src/olympia/users/templates/users/pwreset_complete.html:15
 #: src/olympia/users/templates/users/mobile/login.html:56
 msgid "Log in"
 msgstr "Kirjaudu sisään"
@@ -13749,8 +11672,7 @@ msgstr "Kirjaudu sisään"
 msgid "Localize for: <a id=\"change-locale\" href=\"#\">%(dl)s</a>"
 msgstr ""
 
-#: src/olympia/translations/templates/translations/trans-menu.html:16
-#: src/olympia/translations/templates/translations/trans-menu.html:29
+#: src/olympia/translations/templates/translations/trans-menu.html:16 src/olympia/translations/templates/translations/trans-menu.html:29
 #, python-format
 msgid "%(title)s <em>&middot; %(lang)s</em>"
 msgstr ""
@@ -13765,9 +11687,7 @@ msgstr ""
 
 #. {0} is a language name, like 'French'
 #: src/olympia/translations/templates/translations/trans-menu.html:42
-msgid ""
-"You have unsaved changes in the <b>{0}</b> locale. Would you like to save "
-"your changes before switching locales?"
+msgid "You have unsaved changes in the <b>{0}</b> locale. Would you like to save your changes before switching locales?"
 msgstr ""
 
 #: src/olympia/translations/templates/translations/trans-menu.html:49
@@ -13776,9 +11696,7 @@ msgstr ""
 
 #. {0} is a language name, like 'French'
 #: src/olympia/translations/templates/translations/trans-menu.html:56
-msgid ""
-"Are you sure you want to remove all <b>{0}</b> translations? This cannot be "
-"undone."
+msgid "Are you sure you want to remove all <b>{0}</b> translations? This cannot be undone."
 msgstr ""
 
 #: src/olympia/translations/templates/translations/trans-menu.html:61
@@ -13800,20 +11718,14 @@ msgstr ""
 
 #: src/olympia/users/forms.py:90
 #, python-format
-msgid ""
-"As part of our new password policy, your password must be %s characters or "
-"more. Please update your password by <a href=\"%s\">issuing a password "
-"reset</a>."
+msgid "As part of our new password policy, your password must be %s characters or more. Please update your password by <a href=\"%s\">issuing a password reset</a>."
 msgstr ""
 
 #: src/olympia/users/forms.py:115
-msgid ""
-"You must recover your password through Firefox Accounts. Try logging in "
-"instead."
+msgid "You must recover your password through Firefox Accounts. Try logging in instead."
 msgstr ""
 
-#: src/olympia/users/forms.py:206
-#: src/olympia/users/templates/users/pwreset_confirm.html:24
+#: src/olympia/users/forms.py:206 src/olympia/users/templates/users/pwreset_confirm.html:24
 msgid "New password"
 msgstr "Uusi salasana"
 
@@ -13826,9 +11738,7 @@ msgid "Usernames cannot contain only digits."
 msgstr ""
 
 #: src/olympia/users/forms.py:274
-msgid ""
-"Enter a valid username consisting of letters, numbers, underscores or "
-"hyphens."
+msgid "Enter a valid username consisting of letters, numbers, underscores or hyphens."
 msgstr ""
 
 #: src/olympia/users/forms.py:277
@@ -13839,35 +11749,24 @@ msgstr ""
 msgid "This username is already in use."
 msgstr ""
 
-#: src/olympia/users/forms.py:296
-#: src/olympia/users/templates/users/edit.html:107
+#: src/olympia/users/forms.py:296 src/olympia/users/templates/users/edit.html:107
 msgid "Display Name"
 msgstr "Näyttönimi"
 
-#: src/olympia/users/forms.py:298
-#: src/olympia/users/templates/users/edit.html:112
-#: src/olympia/users/templates/users/vcard.html:10
+#: src/olympia/users/forms.py:298 src/olympia/users/templates/users/edit.html:112 src/olympia/users/templates/users/vcard.html:10
 msgid "Location"
 msgstr "Sijainti"
 
-#: src/olympia/users/forms.py:300
-#: src/olympia/users/templates/users/edit.html:117
-#: src/olympia/users/templates/users/vcard.html:16
+#: src/olympia/users/forms.py:300 src/olympia/users/templates/users/edit.html:117 src/olympia/users/templates/users/vcard.html:16
 msgid "Occupation"
 msgstr "Ammatti"
 
 #: src/olympia/users/forms.py:329
-msgid ""
-"This URL has an invalid format. Valid URLs look like "
-"http://example.com/my_page."
-msgstr ""
-"URL:n muoto on virheellinen. Oikean muotoiset URL:it ovat muotoa "
-"http://esimerkki.com/jokusivu."
+msgid "This URL has an invalid format. Valid URLs look like http://example.com/my_page."
+msgstr "URL:n muoto on virheellinen. Oikean muotoiset URL:it ovat muotoa http://esimerkki.com/jokusivu."
 
 #: src/olympia/users/forms.py:337
-msgid ""
-"Please use an email address from a different provider to complete your "
-"registration."
+msgid "Please use an email address from a different provider to complete your registration."
 msgstr ""
 
 #: src/olympia/users/forms.py:345
@@ -13878,13 +11777,11 @@ msgstr ""
 msgid "The passwords did not match."
 msgstr "Salasanat eivät täsmää."
 
-#: src/olympia/users/forms.py:377
-#: src/olympia/users/templates/users/edit.html:128
+#: src/olympia/users/forms.py:377 src/olympia/users/templates/users/edit.html:128
 msgid "Profile Photo"
 msgstr ""
 
-#: src/olympia/users/forms.py:385
-#: src/olympia/users/templates/users/edit.html:142
+#: src/olympia/users/forms.py:385 src/olympia/users/templates/users/edit.html:142
 msgid "Default locale"
 msgstr ""
 
@@ -13901,9 +11798,7 @@ msgid "Email cannot be changed."
 msgstr ""
 
 #: src/olympia/users/forms.py:541
-msgid ""
-"To anonymize, enter a reason for the change but do not change any other "
-"field."
+msgid "To anonymize, enter a reason for the change but do not change any other field."
 msgstr ""
 
 #: src/olympia/users/forms.py:587
@@ -13933,21 +11828,21 @@ msgstr ""
 
 #. L10n: {id} will be something like "13ad6a", just a random number
 #. to differentiate this user from other anonymous users.
-#: src/olympia/users/models.py:353
+#: src/olympia/users/models.py:362
 msgid "Anonymous user {id}"
 msgstr ""
 
-#: src/olympia/users/models.py:410
+#: src/olympia/users/models.py:419
 msgid "Your account has been restricted"
 msgstr ""
 
-#: src/olympia/users/models.py:480
+#: src/olympia/users/models.py:489
 msgid "Please confirm your email address"
 msgstr ""
 
 # 83%
 # 100%
-#: src/olympia/users/models.py:506
+#: src/olympia/users/models.py:515
 #, fuzzy
 msgid "My Mobile Add-ons"
 msgstr "Hae lisäosia mobiiliin"
@@ -14013,8 +11908,7 @@ msgid "Mozilla needs to contact me about my individual app"
 msgstr ""
 
 #: src/olympia/users/notifications.py:139
-msgid ""
-"Mozilla wants to contact me about relevant App Developer news and surveys"
+msgid "Mozilla wants to contact me about relevant App Developer news and surveys"
 msgstr ""
 
 #: src/olympia/users/notifications.py:150
@@ -14042,10 +11936,7 @@ msgid "Successfully verified!"
 msgstr "Tili vahvistettu."
 
 #: src/olympia/users/views.py:132
-msgid ""
-"An email has been sent to your address to confirm your account. Before you "
-"can log in, you have to activate your account by clicking on the link "
-"provided in this email."
+msgid "An email has been sent to your address to confirm your account. Before you can log in, you have to activate your account by clicking on the link provided in this email."
 msgstr ""
 
 #: src/olympia/users/views.py:136 src/olympia/users/views.py:619
@@ -14070,9 +11961,8 @@ msgstr ""
 
 #: src/olympia/users/views.py:197
 msgid ""
-"An email has been sent to {0} to confirm your new email address. For the "
-"change to take effect, you need to click on the link provided in this email."
-" Until then, you can keep logging in with your current email address."
+"An email has been sent to {0} to confirm your new email address. For the change to take effect, you need to click on the link provided in this email. Until then, you can keep logging in with your "
+"current email address."
 msgstr ""
 
 #: src/olympia/users/views.py:210
@@ -14085,15 +11975,11 @@ msgid "Errors Found"
 msgstr ""
 
 #: src/olympia/users/views.py:225
-msgid ""
-"There were errors in the changes you made. Please correct them and resubmit."
-msgstr ""
-"Tehdyt muutokset olivat virheellisiä. Korjaa virheet ja lähetä tiedot "
-"uudestaan."
+msgid "There were errors in the changes you made. Please correct them and resubmit."
+msgstr "Tehdyt muutokset olivat virheellisiä. Korjaa virheet ja lähetä tiedot uudestaan."
 
 #: src/olympia/users/views.py:273
-msgid ""
-"We're sorry, but you are not eligible to request a t-shirt at this time."
+msgid "We're sorry, but you are not eligible to request a t-shirt at this time."
 msgstr ""
 
 #: src/olympia/users/views.py:329
@@ -14109,18 +11995,14 @@ msgid "Wrong email address or password!"
 msgstr "Sähköpostiosoite tai salasana on virheellinen."
 
 #: src/olympia/users/views.py:434
-msgid ""
-"A link to activate your user account was sent by email to your address {0}. "
-"You have to click it before you can log in."
+msgid "A link to activate your user account was sent by email to your address {0}. You have to click it before you can log in."
 msgstr ""
 
 #: src/olympia/users/views.py:439
 #, python-format
 msgid ""
-"If you did not receive the confirmation email, make sure your email service "
-"did not mark it as \"junk mail\" or \"spam\". If you need to, you can have "
-"us <a href=\"%s\">resend the confirmation message</a> to your email address "
-"mentioned above."
+"If you did not receive the confirmation email, make sure your email service did not mark it as \"junk mail\" or \"spam\". If you need to, you can have us <a href=\"%s\">resend the confirmation "
+"message</a> to your email address mentioned above."
 msgstr ""
 
 #: src/olympia/users/views.py:444
@@ -14141,14 +12023,8 @@ msgstr "Onneksi olkoon! Käyttäjätilisi luonti onnistui."
 
 # %1 is the user's email address
 #: src/olympia/users/views.py:615
-msgid ""
-"An email has been sent to your address {0} to confirm your account. Before "
-"you can log in, you have to activate your account by clicking on the link "
-"provided in this email."
-msgstr ""
-"Sähköpostiosoitteeseesi {0} lähetettiin vahvistusviesti tilin luonnista. "
-"Ennen kuin voit kirjautua sivustolle, tili pitää aktivoida avaamalla "
-"sähköpostissa oleva linkki."
+msgid "An email has been sent to your address {0} to confirm your account. Before you can log in, you have to activate your account by clicking on the link provided in this email."
+msgstr "Sähköpostiosoitteeseesi {0} lähetettiin vahvistusviesti tilin luonnista. Ennen kuin voit kirjautua sivustolle, tili pitää aktivoida avaamalla sähköpostissa oleva linkki."
 
 #: src/olympia/users/views.py:639
 msgid "There are errors in this form"
@@ -14166,24 +12042,19 @@ msgstr ""
 msgid "new"
 msgstr ""
 
-#: src/olympia/users/templates/users/delete.html:4
-#: src/olympia/users/templates/users/delete.html:10
+#: src/olympia/users/templates/users/delete.html:4 src/olympia/users/templates/users/delete.html:10
 msgid "Delete User Account"
 msgstr ""
 
 #: src/olympia/users/templates/users/delete.html:14
 #, python-format
 msgid ""
-"You cannot delete your account if you are listed as an <a href=\"%(link)s\">"
-" author of any add-ons</a>. To delete your account, please have another "
-"person in your development group delete you from the list of authors for "
-"your add-ons. Afterwards you will be able to delete your account here."
+"You cannot delete your account if you are listed as an <a href=\"%(link)s\"> author of any add-ons</a>. To delete your account, please have another person in your development group delete you from "
+"the list of authors for your add-ons. Afterwards you will be able to delete your account here."
 msgstr ""
 
 #: src/olympia/users/templates/users/delete.html:29
-msgid ""
-"By clicking \"delete\" your account is going to be <strong>permanently "
-"removed</strong>. That means:"
+msgid "By clicking \"delete\" your account is going to be <strong>permanently removed</strong>. That means:"
 msgstr ""
 
 #: src/olympia/users/templates/users/delete.html:35
@@ -14192,9 +12063,7 @@ msgid "You will not be able to log into %(site)s anymore."
 msgstr ""
 
 #: src/olympia/users/templates/users/delete.html:40
-msgid ""
-"Your reviews and ratings will not be deleted, but they will no longer be "
-"associated with you."
+msgid "Your reviews and ratings will not be deleted, but they will no longer be associated with you."
 msgstr ""
 
 #: src/olympia/users/templates/users/delete.html:46
@@ -14209,8 +12078,7 @@ msgstr "Ymmärrän, ettei tätä toimintoa voi kumota."
 msgid "Delete my user account now"
 msgstr "Poista käyttäjätunnukseni nyt"
 
-#: src/olympia/users/templates/users/delete_photo.html:3
-#: src/olympia/users/templates/users/delete_photo.html:9
+#: src/olympia/users/templates/users/delete_photo.html:3 src/olympia/users/templates/users/delete_photo.html:9
 msgid "Delete User Photo"
 msgstr "Poista käyttäjäkuva"
 
@@ -14225,25 +12093,18 @@ msgid "Please set your display name"
 msgstr ""
 
 #: src/olympia/users/templates/users/edit.html:21
-msgid ""
-"Please set your display name or username to complete the registration "
-"process."
+msgid "Please set your display name or username to complete the registration process."
 msgstr ""
 
 #: src/olympia/users/templates/users/edit.html:33
 msgid "Manage basic account information, such as username and email address."
-msgstr ""
-"Hallitse tunnuksesi perustietoja, kuten käyttäjätunnusta ja "
-"sähköpostiosoitetta."
+msgstr "Hallitse tunnuksesi perustietoja, kuten käyttäjätunnusta ja sähköpostiosoitetta."
 
-#: src/olympia/users/templates/users/edit.html:39
-#: src/olympia/users/templates/users/register.html:47
+#: src/olympia/users/templates/users/edit.html:39 src/olympia/users/templates/users/register.html:47
 msgid "Username"
 msgstr "Käyttäjätunnus"
 
-#: src/olympia/users/templates/users/edit.html:45
-#: src/olympia/users/templates/users/pwreset_request.html:21
-#: src/olympia/users/templates/users/register.html:62
+#: src/olympia/users/templates/users/edit.html:45 src/olympia/users/templates/users/pwreset_request.html:21 src/olympia/users/templates/users/register.html:62
 msgid "Email Address"
 msgstr "Sähköpostiosoite"
 
@@ -14255,21 +12116,15 @@ msgstr ""
 msgid "Change Password"
 msgstr "Vaihda salasana"
 
-#: src/olympia/users/templates/users/edit.html:68
-#: src/olympia/users/templates/users/login_form.html:22
-#: src/olympia/users/templates/users/register.html:67
+#: src/olympia/users/templates/users/edit.html:68 src/olympia/users/templates/users/login_form.html:22 src/olympia/users/templates/users/register.html:67
 #: src/olympia/users/templates/users/mobile/login.html:37
 msgid "Password"
 msgstr "Salasana"
 
 #: src/olympia/users/templates/users/edit.html:70
 #, python-format
-msgid ""
-"Change your password. If you forgot your password, you can <a "
-"href=\"%(reset_url)s\">use the reset form</a>."
-msgstr ""
-"Vaihda salasanasi. Jos olet unohtanut sen, voit <a "
-"href=\"%(reset_url)s\">käyttää nollauslomaketta</a>."
+msgid "Change your password. If you forgot your password, you can <a href=\"%(reset_url)s\">use the reset form</a>."
+msgstr "Vaihda salasanasi. Jos olet unohtanut sen, voit <a href=\"%(reset_url)s\">käyttää nollauslomaketta</a>."
 
 # 91%
 # 75%
@@ -14293,12 +12148,8 @@ msgid "Profile"
 msgstr "Profiili"
 
 #: src/olympia/users/templates/users/edit.html:100
-msgid ""
-"Give us a bit more information about yourself. All these fields are "
-"optional, but they'll help other users get to know you better."
-msgstr ""
-"Anna meille vähän lisätietoja itsestäsi. Kaikki kentät ovat valinnaisia, "
-"mutta ne auttavat muita tuntemaan sinut paremmin."
+msgid "Give us a bit more information about yourself. All these fields are optional, but they'll help other users get to know you better."
+msgstr "Anna meille vähän lisätietoja itsestäsi. Kaikki kentät ovat valinnaisia, mutta ne auttavat muita tuntemaan sinut paremmin."
 
 #: src/olympia/users/templates/users/edit.html:124
 msgid "This URL will only be visible if you are a developer."
@@ -14313,18 +12164,12 @@ msgid "Delete current photo"
 msgstr "Poista nykyinen kuva"
 
 #: src/olympia/users/templates/users/edit.html:144
-msgid ""
-"This is the default locale used to display information about you (like your "
-"description)."
+msgid "This is the default locale used to display information about you (like your description)."
 msgstr ""
 
 #: src/olympia/users/templates/users/edit.html:152
-msgid ""
-"Introduce yourself to the community, if you like! This text will appear "
-"publicly on your user info page."
-msgstr ""
-"Esittele itsesi yhteisölle, jos haluat! Tämä teksti näkyy julkisesti "
-"käyttäjäprofiilissasi."
+msgid "Introduce yourself to the community, if you like! This text will appear publicly on your user info page."
+msgstr "Esittele itsesi yhteisölle, jos haluat! Tämä teksti näkyy julkisesti käyttäjäprofiilissasi."
 
 #: src/olympia/users/templates/users/edit.html:161
 msgid "Allowed HTML: {0}. Links are forbidden."
@@ -14351,20 +12196,12 @@ msgid "Notifications"
 msgstr "Ilmoitukset"
 
 #: src/olympia/users/templates/users/edit.html:195
-msgid ""
-"From time to time, Mozilla may send you email about upcoming releases and "
-"add-on events. Please select the topics you are interested in."
-msgstr ""
-"Mozilla saattaa lähettää sinulla ajoittain tietoja uusista julkaisuista ja "
-"lisäosatapahtumista. Valitse aiheet, joista olet kiinnostunut."
+msgid "From time to time, Mozilla may send you email about upcoming releases and add-on events. Please select the topics you are interested in."
+msgstr "Mozilla saattaa lähettää sinulla ajoittain tietoja uusista julkaisuista ja lisäosatapahtumista. Valitse aiheet, joista olet kiinnostunut."
 
 #: src/olympia/users/templates/users/edit.html:205
-msgid ""
-"Mozilla reserves the right to contact you individually about specific "
-"concerns with your hosted add-ons."
-msgstr ""
-"Mozilla pidättää oikeuden ottaa sinuun yhteyttä yksilöllisesti lisäosiisi "
-"liittyvien ongelmien johdosta."
+msgid "Mozilla reserves the right to contact you individually about specific concerns with your hosted add-ons."
+msgstr "Mozilla pidättää oikeuden ottaa sinuun yhteyttä yksilöllisesti lisäosiisi liittyvien ongelmien johdosta."
 
 #: src/olympia/users/templates/users/edit.html:215
 msgid "Admin"
@@ -14386,61 +12223,49 @@ msgstr "ei mitään"
 msgid "all"
 msgstr "kaikki"
 
-#: src/olympia/users/templates/users/fxa_migration.html:3
-#: src/olympia/users/templates/users/fxa_migration.html:11
-#: src/olympia/users/templates/users/mobile/fxa_migration.html:3
+#: src/olympia/users/templates/users/fxa_migration.html:3 src/olympia/users/templates/users/fxa_migration.html:11 src/olympia/users/templates/users/mobile/fxa_migration.html:3
 #: src/olympia/users/templates/users/mobile/fxa_migration.html:8
 msgid "Migrate to Firefox Accounts"
 msgstr ""
 
 #: src/olympia/users/templates/users/fxa_migration_prompt_content.html:3
-msgid ""
-"Mozilla Add-ons has transitioned to Firefox Accounts for login. Continue to "
-"complete the simple upgrade process."
+msgid "Mozilla Add-ons has transitioned to Firefox Accounts for login. Continue to complete the simple upgrade process."
 msgstr ""
 
 #: src/olympia/users/templates/users/fxa_migration_prompt_content.html:14
 msgid "Skip"
 msgstr ""
 
-#: src/olympia/users/templates/users/login.html:3
-#: src/olympia/users/templates/users/mobile/login.html:3
+#: src/olympia/users/templates/users/login.html:3 src/olympia/users/templates/users/mobile/login.html:3
 msgid "User Login"
 msgstr "Käyttäjäkirjautuminen"
 
-#: src/olympia/users/templates/users/login.html:13
-#: src/olympia/users/templates/users/mobile/login.html:21
+#: src/olympia/users/templates/users/login.html:13 src/olympia/users/templates/users/mobile/login.html:21
 msgid "Enter your email"
 msgstr "Kirjoita sähköpostiosoitteesi"
 
-#: src/olympia/users/templates/users/login.html:15
-#: src/olympia/users/templates/users/mobile/login.html:23
+#: src/olympia/users/templates/users/login.html:15 src/olympia/users/templates/users/mobile/login.html:23
 msgid "Log In"
 msgstr "Kirjaudu sisään"
 
-#: src/olympia/users/templates/users/login_form.html:17
-#: src/olympia/users/templates/users/mobile/login.html:32
+#: src/olympia/users/templates/users/login_form.html:17 src/olympia/users/templates/users/mobile/login.html:32
 msgid "Email address"
 msgstr "Sähköpostiosoite"
 
-#: src/olympia/users/templates/users/login_form.html:30
-#: src/olympia/users/templates/users/mobile/login.html:44
+#: src/olympia/users/templates/users/login_form.html:30 src/olympia/users/templates/users/mobile/login.html:44
 msgid "Remember me on this device"
 msgstr ""
 
 # This is a header for additional help options
-#: src/olympia/users/templates/users/login_help.html:3
-#: src/olympia/users/templates/users/mobile/login.html:63
+#: src/olympia/users/templates/users/login_help.html:3 src/olympia/users/templates/users/mobile/login.html:63
 msgid "Login Problems?"
 msgstr "Ongelmia sisäänkirjautumisessa?"
 
-#: src/olympia/users/templates/users/login_help.html:5
-#: src/olympia/users/templates/users/mobile/login.html:65
+#: src/olympia/users/templates/users/login_help.html:5 src/olympia/users/templates/users/mobile/login.html:65
 msgid "I don't have an account."
 msgstr "Minulla ei ole käyttäjätiliä."
 
-#: src/olympia/users/templates/users/login_help.html:6
-#: src/olympia/users/templates/users/mobile/login.html:66
+#: src/olympia/users/templates/users/login_help.html:6 src/olympia/users/templates/users/mobile/login.html:66
 msgid "I forgot my password."
 msgstr "Unohdin salasanani."
 
@@ -14449,15 +12274,9 @@ msgstr "Unohdin salasanani."
 msgid "You are now logged in as <strong>%(user_email)s</strong>!"
 msgstr "Olet nyt kirjautuneena tunnuksella <strong>%(user_email)s</strong>!"
 
-#: src/olympia/users/templates/users/newpw_sent.html:3
-#: src/olympia/users/templates/users/newpw_sent.html:8
-#: src/olympia/users/templates/users/pwreset_complete.html:3
-#: src/olympia/users/templates/users/pwreset_confirm.html:4
-#: src/olympia/users/templates/users/pwreset_confirm.html:18
-#: src/olympia/users/templates/users/pwreset_request.html:4
-#: src/olympia/users/templates/users/pwreset_request.html:10
-#: src/olympia/users/templates/users/pwreset_sent.html:3
-#: src/olympia/users/templates/users/pwreset_sent.html:8
+#: src/olympia/users/templates/users/newpw_sent.html:3 src/olympia/users/templates/users/newpw_sent.html:8 src/olympia/users/templates/users/pwreset_complete.html:3
+#: src/olympia/users/templates/users/pwreset_confirm.html:4 src/olympia/users/templates/users/pwreset_confirm.html:18 src/olympia/users/templates/users/pwreset_request.html:4
+#: src/olympia/users/templates/users/pwreset_request.html:10 src/olympia/users/templates/users/pwreset_sent.html:3 src/olympia/users/templates/users/pwreset_sent.html:8
 msgid "Password Reset"
 msgstr "Salasanan nollaaminen"
 
@@ -14475,8 +12294,7 @@ msgstr "Hallitse käyttäjää"
 
 # 75%
 # 100%
-#: src/olympia/users/templates/users/profile.html:18
-#: src/olympia/users/templates/users/report_abuse_full.html:9
+#: src/olympia/users/templates/users/profile.html:18 src/olympia/users/templates/users/report_abuse_full.html:9
 msgid "Report user"
 msgstr "Ilmoita käyttäjä"
 
@@ -14539,32 +12357,24 @@ msgstr "Onnistui!"
 msgid "Password successfully reset."
 msgstr "Salasanan nollaaminen onnistui."
 
-#: src/olympia/users/templates/users/pwreset_confirm.html:13
-#: src/olympia/users/templates/users/pwreset_confirm.html:46
+#: src/olympia/users/templates/users/pwreset_confirm.html:13 src/olympia/users/templates/users/pwreset_confirm.html:46
 msgid "Password reset unsuccessful"
 msgstr ""
 
 #: src/olympia/users/templates/users/pwreset_confirm.html:14
-msgid ""
-"You have migrated to Firefox Accounts. You can no longer change your "
-"password here."
+msgid "You have migrated to Firefox Accounts. You can no longer change your password here."
 msgstr ""
 
-#: src/olympia/users/templates/users/pwreset_confirm.html:31
-#: src/olympia/users/templates/users/register.html:72
+#: src/olympia/users/templates/users/pwreset_confirm.html:31 src/olympia/users/templates/users/register.html:72
 msgid "Confirm password"
 msgstr "Vahvista salasana"
 
 #: src/olympia/users/templates/users/pwreset_confirm.html:47
-msgid ""
-"The password reset link was invalid, possibly because it has already been "
-"used.  Please request a new password reset."
+msgid "The password reset link was invalid, possibly because it has already been used. Please request a new password reset."
 msgstr ""
 
 #: src/olympia/users/templates/users/pwreset_request.html:15
-msgid ""
-"Forgotten your password? Enter your e-mail address below, and we'll e-mail "
-"instructions for setting a new one."
+msgid "Forgotten your password? Enter your e-mail address below, and we'll e-mail instructions for setting a new one."
 msgstr ""
 
 #: src/olympia/users/templates/users/pwreset_request.html:25
@@ -14573,9 +12383,7 @@ msgstr "Lähetä linkki salasanan nollaamiseen"
 
 #: src/olympia/users/templates/users/pwreset_sent.html:10
 msgid ""
-"An email has been sent to the requested account with further information. If"
-" you do not receive an email then please confirm you have entered the same "
-"email address used during account registration."
+"An email has been sent to the requested account with further information. If you do not receive an email then please confirm you have entered the same email address used during account registration."
 msgstr ""
 
 #: src/olympia/users/templates/users/register.html:4
@@ -14587,9 +12395,7 @@ msgid "Why register?"
 msgstr "Miksi rekisteröityä?"
 
 #: src/olympia/users/templates/users/register.html:14
-msgid ""
-"Registration on AMO is <strong>not required</strong> if you simply want to "
-"download and install public add-ons."
+msgid "Registration on AMO is <strong>not required</strong> if you simply want to download and install public add-ons."
 msgstr ""
 
 #: src/olympia/users/templates/users/register.html:16
@@ -14601,30 +12407,20 @@ msgid "You want to submit reviews for add-ons"
 msgstr ""
 
 #: src/olympia/users/templates/users/register.html:19
-msgid ""
-"You want to keep track of your favorite add-on collections or create one "
-"yourself"
+msgid "You want to keep track of your favorite add-on collections or create one yourself"
 msgstr ""
 
 #: src/olympia/users/templates/users/register.html:20
-msgid ""
-"You are an add-on developer and want to upload your add-on for hosting on "
-"AMO"
+msgid "You are an add-on developer and want to upload your add-on for hosting on AMO"
 msgstr ""
 
 #: src/olympia/users/templates/users/register.html:23
-msgid ""
-"Upon successful registration, you will be sent a confirmation email to the "
-"address you provided. Please follow the instructions there to confirm your "
-"account."
+msgid "Upon successful registration, you will be sent a confirmation email to the address you provided. Please follow the instructions there to confirm your account."
 msgstr ""
 
 #: src/olympia/users/templates/users/register.html:30
 #, python-format
-msgid ""
-"If you like, you can read our <a href=\"%(legal)s\" title=\"Legal "
-"Notices\">Legal Notices</a> and <a href=\"%(privacy)s\" title=\"Privacy "
-"Policy\">Privacy Policy</a>."
+msgid "If you like, you can read our <a href=\"%(legal)s\" title=\"Legal Notices\">Legal Notices</a> and <a href=\"%(privacy)s\" title=\"Privacy Policy\">Privacy Policy</a>."
 msgstr ""
 
 #: src/olympia/users/templates/users/register.html:52
@@ -14632,12 +12428,8 @@ msgid "Display name"
 msgstr "Näyttönimi"
 
 #: src/olympia/users/templates/users/report_abuse.html:7
-msgid ""
-"Please describe why you are reporting this user, such as for spam or an "
-"inappropriate picture."
-msgstr ""
-"Kerro, miksi olet ilmoittamassa käyttäjää, kuten roskapostin tai "
-"sopimattoman kuvan takia."
+msgid "Please describe why you are reporting this user, such as for spam or an inappropriate picture."
+msgstr "Kerro, miksi olet ilmoittamassa käyttäjää, kuten roskapostin tai sopimattoman kuvan takia."
 
 # 75%
 # 100%
@@ -14653,32 +12445,24 @@ msgstr ""
 msgid "Special Edition Add-on Creator T-shirt"
 msgstr ""
 
-#: src/olympia/users/templates/users/t-shirt.html:14
-#: src/olympia/users/templates/users/t-shirt.html:120
+#: src/olympia/users/templates/users/t-shirt.html:14 src/olympia/users/templates/users/t-shirt.html:120
 msgid "Note:"
 msgstr ""
 
 #: src/olympia/users/templates/users/t-shirt.html:15
-msgid ""
-"You have already submitted a request for a t-shirt. You may re-submit this "
-"form to update your information, but you will only receive one shirt."
+msgid "You have already submitted a request for a t-shirt. You may re-submit this form to update your information, but you will only receive one shirt."
 msgstr ""
 
 #: src/olympia/users/templates/users/t-shirt.html:26
-msgid ""
-"Thank you for helping to make Firefox the most extensible browser available!"
+msgid "Thank you for helping to make Firefox the most extensible browser available!"
 msgstr ""
 
 #: src/olympia/users/templates/users/t-shirt.html:33
-msgid ""
-"As a thank you gift, we'd like to send you a special-edition, community-"
-"designed t-shirt. To receive your shirt, please fill out the form below."
+msgid "As a thank you gift, we'd like to send you a special-edition, community-designed t-shirt. To receive your shirt, please fill out the form below."
 msgstr ""
 
 #: src/olympia/users/templates/users/t-shirt.html:41
-msgid ""
-"Your contact information will only be used by Mozilla to ship this special "
-"edition t-shirt."
+msgid "Your contact information will only be used by Mozilla to ship this special edition t-shirt."
 msgstr ""
 
 #: src/olympia/users/templates/users/t-shirt.html:60
@@ -14735,19 +12519,13 @@ msgstr ""
 
 #: src/olympia/users/templates/users/t-shirt.html:137
 msgid ""
-"We're sorry, but in order to qualify for our special edition t-shirt, you "
-"must be an add-on developer with at least one listed add-on, one unlisted "
-"but signed add-on, or any number of background themes with a combined total "
-"of 10,000 average daily users."
+"We're sorry, but in order to qualify for our special edition t-shirt, you must be an add-on developer with at least one listed add-on, one unlisted but signed add-on, or any number of background "
+"themes with a combined total of 10,000 average daily users."
 msgstr ""
 
 #: src/olympia/users/templates/users/tougher_password.html:2
-msgid ""
-"For your account a password must contain at least 8 characters including "
-"letters and numbers."
-msgstr ""
-"Tunnuksesi salasanan pitää sisältää vähintään 8 merkkiä ja kirjaimia ja "
-"numeroita."
+msgid "For your account a password must contain at least 8 characters including letters and numbers."
+msgstr "Tunnuksesi salasanan pitää sisältää vähintään 8 merkkiä ja kirjaimia ja numeroita."
 
 #: src/olympia/users/templates/users/unsubscribe.html:2
 msgid "Unsubscribe"
@@ -14759,9 +12537,7 @@ msgstr ""
 
 #: src/olympia/users/templates/users/unsubscribe.html:10
 #, python-format
-msgid ""
-"The email address <strong>%(email)s</strong> will no longer get messages "
-"when:"
+msgid "The email address <strong>%(email)s</strong> will no longer get messages when:"
 msgstr ""
 
 #: src/olympia/users/templates/users/unsubscribe.html:20
@@ -14782,10 +12558,7 @@ msgstr ""
 
 #: src/olympia/users/templates/users/unsubscribe.html:30
 #, python-format
-msgid ""
-"Unfortunately, we weren't able to unsubscribe you.  The link you clicked is "
-"invalid. However, you can unsubscribe still unsubscribe on your <a "
-"href=\"%(edit_url)s\">edit profile page</a>."
+msgid "Unfortunately, we weren't able to unsubscribe you. The link you clicked is invalid. However, you can unsubscribe still unsubscribe on your <a href=\"%(edit_url)s\">edit profile page</a>."
 msgstr ""
 
 #: src/olympia/users/templates/users/vcard.html:2
@@ -14840,15 +12613,15 @@ msgstr "{0} versiohistoria"
 msgid "Version History with Changelogs"
 msgstr "Versiohistoria muutostiedoilla"
 
-#: src/olympia/versions/models.py:314
+#: src/olympia/versions/models.py:313
 msgid "Add-on uses binary components."
 msgstr ""
 
-#: src/olympia/versions/models.py:317
+#: src/olympia/versions/models.py:316
 msgid "Add-on has opted into strict compatibility checking."
 msgstr ""
 
-#: src/olympia/versions/models.py:715
+#: src/olympia/versions/models.py:711
 msgid "{app} {min} and later"
 msgstr ""
 
@@ -14864,23 +12637,19 @@ msgstr "Julkaistu {0}"
 #: src/olympia/versions/templates/versions/version.html:39
 #, python-format
 msgid "Source code released under <a target=\"_blank\" href=\"%(url)s\">%(name)s</a>"
-msgstr ""
-"Lähdekoodi julkaistu lisenssillä <a target=\"_blank\" "
-"href=\"%(url)s\">%(name)s</a>"
+msgstr "Lähdekoodi julkaistu lisenssillä <a target=\"_blank\" href=\"%(url)s\">%(name)s</a>"
 
 #: src/olympia/versions/templates/versions/version.html:44
 #, python-format
 msgid "Source code released under <a href=\"%(url)s\">%(name)s</a>"
-msgstr ""
-"Lähdekoodi julkaistu lisenssillä <a target=\"_blank\" "
-"href=\"%(url)s\">%(name)s</a>"
+msgstr "Lähdekoodi julkaistu lisenssillä <a target=\"_blank\" href=\"%(url)s\">%(name)s</a>"
 
 #: src/olympia/versions/templates/versions/version.html:60
 msgid "View the source"
 msgstr "Näytä lähdekoodi"
 
-#. {0} is an add-on name.
 # {0} is the add-on name
+#. {0} is an add-on name.
 #: src/olympia/versions/templates/versions/version_list.html:26
 msgid "{0} Version History"
 msgstr "{0} versiohistoria"
@@ -14892,20 +12661,14 @@ msgid_plural "<b>{0}</b> versions"
 msgstr[0] "<b>{0}</b> versio"
 msgstr[1] "<b>{0}</b> versiota"
 
-#: src/olympia/versions/templates/versions/version_list.html:35
-#: src/olympia/versions/templates/versions/mobile/version_list.html:14
+#: src/olympia/versions/templates/versions/version_list.html:35 src/olympia/versions/templates/versions/mobile/version_list.html:14
 msgid "Be careful with old versions!"
 msgstr "Ole varovainen vanhojen versioiden kanssa!"
 
-#: src/olympia/versions/templates/versions/version_list.html:36
-#: src/olympia/versions/templates/versions/mobile/version_list.html:15
+#: src/olympia/versions/templates/versions/version_list.html:36 src/olympia/versions/templates/versions/mobile/version_list.html:15
 #, python-format
-msgid ""
-"These versions are displayed for reference and testing purposes. You should "
-"always use the <a href=\"%(url)s\">latest version</a> of an add-on."
-msgstr ""
-"Nämä versiot ovat esillä vertailu- ja testitarkoituksia varten. Sinun "
-"kannattaa käyttää lisäosista aina <a href=\"%(url)s\">uusinta versiota</a>."
+msgid "These versions are displayed for reference and testing purposes. You should always use the <a href=\"%(url)s\">latest version</a> of an add-on."
+msgstr "Nämä versiot ovat esillä vertailu- ja testitarkoituksia varten. Sinun kannattaa käyttää lisäosista aina <a href=\"%(url)s\">uusinta versiota</a>."
 
 #: src/olympia/versions/templates/versions/mobile/version.html:4
 msgid "Beta Version {0}"
@@ -14915,10 +12678,10 @@ msgstr "Beetaversio {0}"
 msgid "Works with:"
 msgstr "Toimii seuraavilla ohjelmaversioilla:"
 
-#. {0} is an add-on name.
 # {0} is the add-on name
 # 78%
 # 100%
+#. {0} is an add-on name.
 #: src/olympia/versions/templates/versions/mobile/version_list.html:12
 msgid "Version History"
 msgstr "Versiohistoria"
@@ -14937,4 +12700,8 @@ msgstr ""
 
 #: src/olympia/zadmin/forms.py:105
 msgid "Log emails instead of sending"
+msgstr ""
+
+#: src/olympia/zadmin/forms.py:215
+msgid "Deleted versions can`t be changed."
 msgstr ""

--- a/locale/fi/LC_MESSAGES/djangojs.po
+++ b/locale/fi/LC_MESSAGES/djangojs.po
@@ -1,1248 +1,1237 @@
-# 
+#
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2016-02-24 21:23+0000\n"
+"POT-Creation-Date: 2016-04-18 15:47+0000\n"
 "PO-Revision-Date: 2016-04-09 14:55+0000\n"
 "Last-Translator: Blue <teemu-vuori@outlook.com>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
-"Language: fi\n"
+"Language: \n"
 "MIME-Version: 1.0\n"
-"Content-Type: text/plain; charset=utf-8\n"
+"Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 "Generated-By: Babel 2.2.0\n"
-"X-Generator: Pontoon\n"
 
-#: static/js/common/ratingwidget.js:31
-msgid "{0} star"
-msgid_plural "{0} stars"
-msgstr[0] "{0} tähti"
-msgstr[1] "{0} tähteä"
-
-#: static/js/common/upload-addon.js:41 static/js/common/upload-image.js:128
-msgid "There was a problem contacting the server."
-msgstr ""
-
-#: static/js/common/upload-addon.js:69
-msgid "Select a file..."
-msgstr "Valitse tiedosto…"
-
-#: static/js/common/upload-addon.js:70
-msgid "Your add-on should end with .xpi, .jar or .xml"
-msgstr ""
-
-#. L10n: {0} is the percent of the file that has been uploaded.
-#: static/js/common/upload-addon.js:104
-#, python-format
-msgid "{0}% complete"
-msgstr ""
-
-#. L10n: "{bytes uploaded} of {total filesize}".
-#: static/js/common/upload-addon.js:107
-msgid "{0} of {1}"
-msgstr ""
-
-#: static/js/common/upload-addon.js:140
-msgid "Cancel"
-msgstr "Peruuta"
-
-#: static/js/common/upload-addon.js:162
-msgid "Uploading {0}"
-msgstr ""
-
-#: static/js/common/upload-addon.js:189
-msgid "Error with {0}"
-msgstr ""
-
-#: static/js/common/upload-addon.js:194
-msgid "Your add-on failed validation with {0} error."
-msgid_plural "Your add-on failed validation with {0} errors."
-msgstr[0] ""
-msgstr[1] ""
-
-#: static/js/common/upload-addon.js:208
-msgid "&hellip;and {0} more"
-msgid_plural "&hellip;and {0} more"
-msgstr[0] ""
-msgstr[1] ""
-
-#: static/js/common/upload-addon.js:222 static/js/common/upload-addon.js:512
-msgid "See full validation report"
-msgstr ""
-
-#: static/js/common/upload-addon.js:234
-msgid "Validating {0}"
-msgstr ""
-
-#. L10n: first argument is an HTTP status code
-#: static/js/common/upload-addon.js:273
-msgid "Received an empty response from the server; status: {0}"
-msgstr ""
-
-#: static/js/common/upload-addon.js:373
-msgid "Unexpected server error while validating."
-msgstr ""
-
-#: static/js/common/upload-addon.js:412
-msgid "Finished validating {0}"
-msgstr ""
-
-#: static/js/common/upload-addon.js:418
-msgid "Your add-on validation timed out, it will be manually reviewed."
-msgstr ""
-
-#: static/js/common/upload-addon.js:421
-msgid "Your add-on was validated with no errors and {0} warning."
-msgid_plural "Your add-on was validated with no errors and {0} warnings."
-msgstr[0] ""
-msgstr[1] ""
-
-#: static/js/common/upload-addon.js:426
-msgid "Your add-on was validated with no errors and {0} message."
-msgid_plural "Your add-on was validated with no errors and {0} messages."
-msgstr[0] ""
-msgstr[1] ""
-
-#: static/js/common/upload-addon.js:431
-msgid "Your add-on was validated with no errors or warnings."
-msgstr ""
-
-#: static/js/common/upload-addon.js:446
-msgid "Your submission will be automatically signed."
-msgstr ""
-
-#: static/js/common/upload-addon.js:465
-msgid "Include detailed version notes (this can be done in the next step)."
-msgstr ""
-
-#: static/js/common/upload-addon.js:466
-msgid ""
-"If your add-on requires an account to a website in order to be fully tested,"
-" include a test username and password in the Notes to Reviewer (this can be "
-"done in the next step)."
-msgstr ""
-
-#: static/js/common/upload-addon.js:467
-msgid ""
-"If your add-on is intended for a limited audience you should choose "
-"Preliminary Review instead of Full Review."
-msgstr ""
-
-#: static/js/common/upload-addon.js:480
-msgid "Add-on submission checklist"
-msgstr ""
-
-#: static/js/common/upload-addon.js:481
-msgid ""
-"Please verify the following points before finalizing your submission. This "
-"will minimize delays or misunderstanding during the review process:"
-msgstr ""
-
-#: static/js/common/upload-addon.js:483
-msgid ""
-"Compiled binaries, as well as minified or obfuscated scripts (excluding "
-"known libraries) need to have their sources submitted separately for review."
-" Make sure that you use the source code upload field to avoid having your "
-"submission rejected."
-msgstr ""
-
-#: static/js/common/upload-addon.js:501
-msgid "The validation process found these issues that can lead to rejections:"
-msgstr ""
-
-#: static/js/common/upload-addon.js:518
-msgid ""
-"If you are unfamiliar with the add-ons review process, you can read about it"
-" here."
-msgstr ""
-
-#: static/js/common/upload-addon.js:555
-msgid "Sorry, no supported platform has been found."
-msgstr ""
-
-#: static/js/common/upload-base.js:57
-msgid "The filetype you uploaded isn't recognized."
-msgstr ""
-
-#: static/js/common/upload-base.js:79
-msgid "You cancelled the upload."
-msgstr ""
-
-#: static/js/common/upload-image.js:97 static/js/impala/users.js:51
-msgid "Images must be either PNG or JPG."
-msgstr ""
-
-#: static/js/common/upload-image.js:101
-msgid "Videos must be in WebM."
-msgstr ""
-
-#: static/js/impala/collections.js:10 static/js/zamboni/collections.js:595
-msgid "Follow this Collection"
-msgstr "Seuraa tätä kokoelmaa"
-
-#: static/js/impala/collections.js:19
-msgid "Stop Following"
-msgstr ""
-
-#: static/js/impala/collections.js:20
-msgid "Following"
-msgstr ""
-
-#. L10n: {0} is an app name.
-#: static/js/impala/listing.js:11 static/js/zamboni/themes.js:13
-msgid "This theme is incompatible with your version of {0}"
-msgstr "Tämä teema ei ole yhteensopiva tämän {0} -version kanssa"
-
-#: static/js/impala/persona_creation.js:60
-msgid "All Rights Reserved"
-msgstr ""
-
-#: static/js/impala/persona_creation.js:64
-msgid "Creative Commons Attribution 3.0"
-msgstr ""
-
-#: static/js/impala/persona_creation.js:69
-msgid "Creative Commons Attribution-NonCommercial 3.0"
-msgstr ""
-
-#: static/js/impala/persona_creation.js:74
-msgid "Creative Commons Attribution-NonCommercial-NoDerivs 3.0"
-msgstr ""
-
-#: static/js/impala/persona_creation.js:79
-msgid "Creative Commons Attribution-NonCommercial-Share Alike 3.0"
-msgstr ""
-
-#: static/js/impala/persona_creation.js:84
-msgid "Creative Commons Attribution-NoDerivs 3.0"
-msgstr ""
-
-#: static/js/impala/persona_creation.js:89
-msgid "Creative Commons Attribution-ShareAlike 3.0"
-msgstr ""
-
-#: static/js/impala/persona_creation.js:292
-msgid "Your Theme's Name"
-msgstr ""
-
-#: static/js/impala/reviews.js:23 static/js/zamboni/reviews.js:18
-msgid "Flagged for review"
-msgstr ""
-
-#: static/js/impala/reviews.js:40 static/js/zamboni/reviews.js:34
-msgid "Your input is required"
-msgstr ""
-
-#: static/js/impala/reviews.js:152 static/js/zamboni/reviews.js:103
-msgid "Marked for deletion"
-msgstr ""
-
-#: static/js/impala/search.js:114
-msgid "Updating results&hellip;"
-msgstr ""
-
-#: static/js/impala/site_suggestions.js:46
-msgid "Category"
-msgstr "Luokka"
-
-#: static/js/impala/suggestions.js:39
-msgid "Search themes for <b>{0}</b>"
-msgstr ""
-
-#: static/js/impala/suggestions.js:41
-msgid "Search apps for <b>{0}</b>"
-msgstr ""
-
-#: static/js/impala/suggestions.js:43
-msgid "Search add-ons for <b>{0}</b>"
-msgstr ""
-
-#: static/js/impala/users.js:33
-msgid "use original"
-msgstr ""
-
-#: static/js/impala/stats/chart.js:267
-msgid "Week of {0}"
-msgstr ""
-
-#: static/js/impala/stats/chart.js:269
-msgid " downloads"
-msgstr ""
-
-#: static/js/impala/stats/chart.js:270
-msgid "{0} users"
-msgstr "{0} käyttäjää"
-
-#: static/js/impala/stats/chart.js:271
-msgid "{0} add-ons"
-msgstr ""
-
-#: static/js/impala/stats/chart.js:272
-msgid "{0} collections"
-msgstr ""
-
-#: static/js/impala/stats/chart.js:273
-msgid "{0} reviews"
-msgstr ""
-
-#: static/js/impala/stats/chart.js:275
-msgid "{0} sales"
-msgstr ""
-
-#: static/js/impala/stats/chart.js:276
-msgid "{0} refunds"
-msgstr ""
-
-#: static/js/impala/stats/chart.js:277
-msgid "{0} installs"
-msgstr ""
-
-#: static/js/impala/stats/chart.js:369 static/js/impala/stats/csv_keys.js:3
-#: static/js/impala/stats/csv_keys.js:109
-msgid "Downloads"
-msgstr "Lataukset"
-
-#: static/js/impala/stats/chart.js:379 static/js/impala/stats/csv_keys.js:6
-#: static/js/impala/stats/csv_keys.js:110
-msgid "Daily Users"
-msgstr "Päivittäiset käyttäjät"
-
-#: static/js/impala/stats/chart.js:410
-msgid "Amount, in USD"
-msgstr ""
-
-#: static/js/impala/stats/chart.js:421 static/js/impala/stats/csv_keys.js:104
-msgid "Number of Contributions"
-msgstr ""
-
-#: static/js/impala/stats/chart.js:447
-msgid "More Info..."
-msgstr ""
-
-#. L10n: {0} is an ISO-formatted date.
-#: static/js/impala/stats/chart.js:451
-msgid "Details for {0}"
-msgstr ""
-
-#: static/js/impala/stats/csv_keys.js:9
-msgid "Collections Created"
-msgstr ""
-
-#: static/js/impala/stats/csv_keys.js:12
-msgid "Add-ons in Use"
-msgstr ""
-
-#: static/js/impala/stats/csv_keys.js:15
-msgid "Add-ons Created"
-msgstr ""
-
-#: static/js/impala/stats/csv_keys.js:18
-msgid "Add-ons Downloaded"
-msgstr ""
-
-#: static/js/impala/stats/csv_keys.js:21
-msgid "Add-ons Updated"
-msgstr ""
-
-#: static/js/impala/stats/csv_keys.js:24
-msgid "Reviews Written"
-msgstr ""
-
-#: static/js/impala/stats/csv_keys.js:27
-msgid "User Signups"
-msgstr ""
-
-#: static/js/impala/stats/csv_keys.js:30
-msgid "Subscribers"
-msgstr ""
-
-#: static/js/impala/stats/csv_keys.js:33
-msgid "Ratings"
-msgstr ""
-
-#: static/js/impala/stats/csv_keys.js:36
-#: static/js/impala/stats/csv_keys.js:114
-msgid "Sales"
-msgstr ""
-
-#: static/js/impala/stats/csv_keys.js:39
-#: static/js/impala/stats/csv_keys.js:113
-msgid "Installs"
-msgstr ""
-
-#: static/js/impala/stats/csv_keys.js:42
-msgid "Unknown"
-msgstr ""
-
-#: static/js/impala/stats/csv_keys.js:43
-msgid "Add-ons Manager"
-msgstr ""
-
-#: static/js/impala/stats/csv_keys.js:44
-msgid "Add-ons Manager Promo"
-msgstr ""
-
-#: static/js/impala/stats/csv_keys.js:45
-msgid "Add-ons Manager Featured"
-msgstr ""
-
-#: static/js/impala/stats/csv_keys.js:46
-msgid "Add-ons Manager Learn More"
-msgstr ""
-
-#: static/js/impala/stats/csv_keys.js:47
-msgid "Search Suggestions"
-msgstr ""
-
-#: static/js/impala/stats/csv_keys.js:48
-msgid "Search Results"
-msgstr ""
-
-#: static/js/impala/stats/csv_keys.js:49 static/js/impala/stats/csv_keys.js:50
-#: static/js/impala/stats/csv_keys.js:51
-msgid "Homepage Promo"
-msgstr ""
-
-#: static/js/impala/stats/csv_keys.js:52 static/js/impala/stats/csv_keys.js:53
-msgid "Homepage Featured"
-msgstr ""
-
-#: static/js/impala/stats/csv_keys.js:54 static/js/impala/stats/csv_keys.js:55
-msgid "Homepage Up and Coming"
-msgstr ""
-
-#: static/js/impala/stats/csv_keys.js:56
-msgid "Homepage Most Popular"
-msgstr ""
-
-#: static/js/impala/stats/csv_keys.js:57 static/js/impala/stats/csv_keys.js:59
-msgid "Detail Page"
-msgstr ""
-
-#: static/js/impala/stats/csv_keys.js:58 static/js/impala/stats/csv_keys.js:60
-msgid "Detail Page (bottom)"
-msgstr ""
-
-#: static/js/impala/stats/csv_keys.js:61
-msgid "Detail Page (Development Channel)"
-msgstr ""
-
-#: static/js/impala/stats/csv_keys.js:62 static/js/impala/stats/csv_keys.js:63
-#: static/js/impala/stats/csv_keys.js:64
-msgid "Often Used With"
-msgstr ""
-
-#: static/js/impala/stats/csv_keys.js:65 static/js/impala/stats/csv_keys.js:66
-msgid "Others By Author"
-msgstr ""
-
-#: static/js/impala/stats/csv_keys.js:67 static/js/impala/stats/csv_keys.js:68
-msgid "Dependencies"
-msgstr ""
-
-#: static/js/impala/stats/csv_keys.js:69 static/js/impala/stats/csv_keys.js:70
-msgid "Upsell"
-msgstr ""
-
-#: static/js/impala/stats/csv_keys.js:71
-msgid "Meet the Developer"
-msgstr ""
-
-#: static/js/impala/stats/csv_keys.js:72
-msgid "User Profile"
-msgstr "Käyttäjäprofiili"
-
-#: static/js/impala/stats/csv_keys.js:73
-msgid "Version History"
-msgstr "Versiohistoria"
-
-#: static/js/impala/stats/csv_keys.js:75
-msgid "Sharing"
-msgstr ""
-
-#: static/js/impala/stats/csv_keys.js:76
-msgid "Category Pages"
-msgstr ""
-
-#: static/js/impala/stats/csv_keys.js:77
-msgid "Collections"
-msgstr ""
-
-#: static/js/impala/stats/csv_keys.js:78 static/js/impala/stats/csv_keys.js:79
-msgid "Category Landing Featured Carousel"
-msgstr ""
-
-#: static/js/impala/stats/csv_keys.js:80 static/js/impala/stats/csv_keys.js:81
-msgid "Category Landing Top Rated"
-msgstr ""
-
-#: static/js/impala/stats/csv_keys.js:82 static/js/impala/stats/csv_keys.js:83
-msgid "Category Landing Most Popular"
-msgstr ""
-
-#: static/js/impala/stats/csv_keys.js:84 static/js/impala/stats/csv_keys.js:85
-msgid "Category Landing Recently Added"
-msgstr ""
-
-#: static/js/impala/stats/csv_keys.js:86 static/js/impala/stats/csv_keys.js:87
-msgid "Browse Listing Featured Sort"
-msgstr ""
-
-#: static/js/impala/stats/csv_keys.js:88 static/js/impala/stats/csv_keys.js:89
-msgid "Browse Listing Users Sort"
-msgstr ""
-
-#: static/js/impala/stats/csv_keys.js:90 static/js/impala/stats/csv_keys.js:91
-msgid "Browse Listing Rating Sort"
-msgstr ""
-
-#: static/js/impala/stats/csv_keys.js:92 static/js/impala/stats/csv_keys.js:93
-msgid "Browse Listing Created Sort"
-msgstr ""
-
-#: static/js/impala/stats/csv_keys.js:94 static/js/impala/stats/csv_keys.js:95
-msgid "Browse Listing Name Sort"
-msgstr ""
-
-#: static/js/impala/stats/csv_keys.js:96 static/js/impala/stats/csv_keys.js:97
-msgid "Browse Listing Popular Sort"
-msgstr ""
-
-#: static/js/impala/stats/csv_keys.js:98 static/js/impala/stats/csv_keys.js:99
-msgid "Browse Listing Updated Sort"
-msgstr ""
-
-#: static/js/impala/stats/csv_keys.js:100
-#: static/js/impala/stats/csv_keys.js:101
-msgid "Browse Listing Up and Coming Sort"
-msgstr ""
-
-#: static/js/impala/stats/csv_keys.js:105
-msgid "Total Amount Contributed"
-msgstr ""
-
-#: static/js/impala/stats/csv_keys.js:106
-msgid "Average Contribution"
-msgstr ""
-
-#: static/js/impala/stats/csv_keys.js:115
-msgid "Usage"
-msgstr ""
-
-#: static/js/impala/stats/csv_keys.js:118
-msgid "Firefox"
-msgstr "Firefox"
-
-#: static/js/impala/stats/csv_keys.js:119
-msgid "Mozilla"
-msgstr "Mozilla"
-
-#: static/js/impala/stats/csv_keys.js:120
-msgid "Thunderbird"
-msgstr "Thunderbird"
-
-#: static/js/impala/stats/csv_keys.js:121
-msgid "Sunbird"
-msgstr "Sunbird"
-
-#: static/js/impala/stats/csv_keys.js:122
-msgid "SeaMonkey"
-msgstr "SeaMonkey"
-
-#: static/js/impala/stats/csv_keys.js:123
-msgid "Fennec"
-msgstr "Fennec"
-
-#: static/js/impala/stats/csv_keys.js:124
-msgid "Android"
-msgstr "Android"
-
-#. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:129
-msgid "Downloads and Daily Users, last {0} days"
-msgstr ""
-
-#. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:131
-msgid "Downloads and Daily Users from {0} to {1}"
-msgstr "Lataukset ja päivittäiset käyttäjät {0} - {1}"
-
-#. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:135
-msgid "Installs and Daily Users, last {0} days"
-msgstr ""
-
-#. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:137
-msgid "Installs and Daily Users from {0} to {1}"
-msgstr ""
-
-#. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:141
-msgid "Downloads, last {0} days"
-msgstr ""
-
-#. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:143
-msgid "Downloads from {0} to {1}"
-msgstr "Lataukset {0} - {1}"
-
-#. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:147
-msgid "Daily Users, last {0} days"
-msgstr ""
-
-#. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:149
-msgid "Daily Users from {0} to {1}"
-msgstr "Päivittäiset käyttäjät {0} - {1}"
-
-#. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:153
-msgid "Applications, last {0} days"
-msgstr ""
-
-#. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:155
-msgid "Applications from {0} to {1}"
-msgstr "Sovellukset {0} - {1}"
-
-#. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:159
-msgid "Platforms, last {0} days"
-msgstr ""
-
-#. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:161
-msgid "Platforms from {0} to {1}"
-msgstr "Alustat {0} - {1}"
-
-#. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:165
-msgid "Languages, last {0} days"
-msgstr ""
-
-#. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:167
-msgid "Languages from {0} to {1}"
-msgstr "Kielet {0} - {1}"
-
-#. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:171
-msgid "Add-on Versions, last {0} days"
-msgstr ""
-
-#. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:173
-msgid "Add-on Versions from {0} to {1}"
-msgstr "Lisäosan versiot {0} - {1}"
-
-#. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:177
-msgid "Add-on Status, last {0} days"
-msgstr ""
-
-#. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:179
-msgid "Add-on Status from {0} to {1}"
-msgstr "Lisäosan tila {0} - {1}"
-
-#. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:183
-msgid "Download Sources, last {0} days"
-msgstr ""
-
-#. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:185
-msgid "Download Sources from {0} to {1}"
-msgstr "Latauslähteet {0} - {1}"
-
-#. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:189
-msgid "Contributions, last {0} days"
-msgstr ""
-
-#. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:191
-msgid "Contributions from {0} to {1}"
-msgstr "Avustukset {0} - {1}"
-
-#. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:195
-msgid "Site Metrics, last {0} days"
-msgstr ""
-
-#. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:197
-msgid "Site Metrics from {0} to {1}"
-msgstr ""
-
-#. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:201
-msgid "Add-ons in Use, last {0} days"
-msgstr ""
-
-#. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:203
-msgid "Add-ons in Use from {0} to {1}"
-msgstr ""
-
-#. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:207
-msgid "Add-ons Downloaded, last {0} days"
-msgstr ""
-
-#. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:209
-msgid "Add-ons Downloaded from {0} to {1}"
-msgstr ""
-
-#. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:213
-msgid "Add-ons Created, last {0} days"
-msgstr ""
-
-#. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:215
-msgid "Add-ons Created from {0} to {1}"
-msgstr ""
-
-#. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:219
-msgid "Add-ons Updated, last {0} days"
-msgstr ""
-
-#. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:221
-msgid "Add-ons Updated from {0} to {1}"
-msgstr ""
-
-#. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:225
-msgid "Reviews Written, last {0} days"
-msgstr ""
-
-#. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:227
-msgid "Reviews Written from {0} to {1}"
-msgstr ""
-
-#. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:231
-msgid "User Signups, last {0} days"
-msgstr ""
-
-#. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:233
-msgid "User Signups from {0} to {1}"
-msgstr ""
-
-#. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:237
-msgid "Collections Created, last {0} days"
-msgstr ""
-
-#. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:239
-msgid "Collections Created from {0} to {1}"
-msgstr ""
-
-#. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:243
-msgid "Subscribers, last {0} days"
-msgstr ""
-
-#. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:245
-msgid "Subscribers from {0} to {1}"
-msgstr ""
-
-#. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:249
-msgid "Ratings, last {0} days"
-msgstr ""
-
-#. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:251
-msgid "Ratings from {0} to {1}"
-msgstr ""
-
-#. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:255
-msgid "Sales, last {0} days"
-msgstr ""
-
-#. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:257
-msgid "Sales from {0} to {1}"
-msgstr ""
-
-#. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:261
-msgid "Installs, last {0} days"
-msgstr ""
-
-#. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:263
-msgid "Installs from {0} to {1}"
-msgstr ""
-
-#. L10n: {0} and {1} are integers.
-#: static/js/impala/stats/csv_keys.js:269
-msgid "<b>{0}</b> in last {1} days"
-msgstr ""
-
-#. L10n: {0} is an integer and {1} and {2} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:271
-#: static/js/impala/stats/csv_keys.js:277
-msgid "<b>{0}</b> from {1} to {2}"
-msgstr "<b>{0}</b> ajanjaksolla {1} - {2}"
-
-#. L10n: {0} and {1} are integers.
-#: static/js/impala/stats/csv_keys.js:275
-msgid "<b>{0}</b> average in last {1} days"
-msgstr ""
-
-#: static/js/impala/stats/overview.js:19
-msgid "No data available."
-msgstr "Ei dataa saatavilla."
-
-#: static/js/impala/stats/table.js:74
-msgid "Date"
-msgstr "Päivä"
-
-#: static/js/impala/stats/topchart.js:96
-msgid "Other"
-msgstr "Muu"
-
-#: static/js/zamboni/admin_validation.js:24 static/js/zamboni/devhub.js:1229
-#: static/js/zamboni/editors.js:295
-msgid "Select an application first"
-msgstr "Valitse ensin sovellus"
-
-#: static/js/zamboni/admin_validation.js:51
-msgid "Set {0} add-on to a max version of {1} and email the author."
-msgid_plural "Set {0} add-ons to a max version of {1} and email the authors."
-msgstr[0] ""
-msgstr[1] ""
-
-#: static/js/zamboni/admin_validation.js:54
-msgid "Email author of {2} add-on which failed validation."
-msgid_plural "Email authors of {2} add-ons which failed validation."
-msgstr[0] ""
-msgstr[1] ""
+#: static/js/common-all.js:1426 static/js/impala-all.js:1511 static/js/zamboni/discovery-all.js:12598 static/js/zamboni/init.js:28 static/js/zamboni/mobile-all.js:14945
+msgid "This feature is temporarily disabled while we perform website maintenance. Please check back a little later."
+msgstr "Tämä toiminto on väliaikaisesti poissa käytöstä, sillä suoritamme verkkosivun huoltoa. Tarkista uudelleen myöhemmin."
 
 #. L10n: {0} is an app name like Firefox.
-#: static/js/zamboni/buttons.js:66
+#: static/js/common-all.js:1837 static/js/impala-all.js:1922 static/js/zamboni/buttons.js:73 static/js/zamboni/discovery-all.js:13108
 msgid "Accept and Install"
 msgstr "Hyväksy ja asenna"
 
-#: static/js/zamboni/buttons.js:66
+#: static/js/common-all.js:1837 static/js/impala-all.js:1922 static/js/zamboni/buttons.js:73 static/js/zamboni/discovery-all.js:13108
 msgid "Add to {0}"
 msgstr "Lisää {0}iin"
 
-#: static/js/zamboni/buttons.js:71
+#: static/js/common-all.js:1842 static/js/impala-all.js:1927 static/js/zamboni/buttons.js:78 static/js/zamboni/discovery-all.js:13113
 msgid "Download Now"
 msgstr "Lataa nyt"
 
-#: static/js/zamboni/buttons.js:112
+#: static/js/common-all.js:1883 static/js/impala-all.js:1968 static/js/zamboni/buttons.js:119 static/js/zamboni/discovery-all.js:13154
 msgid "Add-on has not been updated to support default-to-compatible."
 msgstr ""
 
-#: static/js/zamboni/buttons.js:117
+#: static/js/common-all.js:1888 static/js/impala-all.js:1973 static/js/zamboni/buttons.js:124 static/js/zamboni/discovery-all.js:13159
 msgid "You need to be using Firefox 10.0 or higher."
 msgstr ""
 
-#: static/js/zamboni/buttons.js:129
-msgid ""
-"Mozilla has marked this version as incompatible with your Firefox version."
+#: static/js/common-all.js:1900 static/js/impala-all.js:1985 static/js/zamboni/buttons.js:136 static/js/zamboni/discovery-all.js:13171
+msgid "Mozilla has marked this version as incompatible with your Firefox version."
 msgstr ""
 
 #. L10n: {0} is an platform like Windows or Linux.
-#: static/js/zamboni/buttons.js:210
+#: static/js/common-all.js:1981 static/js/impala-all.js:2066 static/js/zamboni/buttons.js:217 static/js/zamboni/discovery-all.js:13252
 msgid "Install for {0} anyway"
 msgstr "Asenna silti {0}ille"
 
-#: static/js/zamboni/buttons.js:210
+#: static/js/common-all.js:1981 static/js/impala-all.js:2066 static/js/zamboni/buttons.js:217 static/js/zamboni/discovery-all.js:13252
 msgid "Download for {0} anyway"
 msgstr "Lataa silti {0}ille"
 
-#: static/js/zamboni/buttons.js:267
+#: static/js/common-all.js:2038 static/js/impala-all.js:2123 static/js/zamboni/buttons.js:274 static/js/zamboni/discovery-all.js:13309
 msgid "Not available for your platform"
 msgstr "Ei saatavilla alustallesi"
 
 #. L10n: {0} is an app name, {1} is the app version.
-#: static/js/zamboni/buttons.js:278 static/js/zamboni/buttons.js:315
+#: static/js/common-all.js:2049 static/js/common-all.js:2086 static/js/impala-all.js:2134 static/js/impala-all.js:2171 static/js/zamboni/buttons.js:286 static/js/zamboni/buttons.js:324
+#: static/js/zamboni/discovery-all.js:13320 static/js/zamboni/discovery-all.js:13357
 msgid "Not available for {0} {1}"
 msgstr "Ei saatavilla sovellukselle {0} {1}"
 
-#: static/js/zamboni/buttons.js:341
+#: static/js/common-all.js:2112 static/js/impala-all.js:2197 static/js/zamboni/buttons.js:351 static/js/zamboni/discovery-all.js:13383
 msgid "Works with {app} {min} - {max}"
 msgstr ""
 
-#: static/js/zamboni/buttons.js:343
+#: static/js/common-all.js:2114 static/js/impala-all.js:2199 static/js/zamboni/buttons.js:353 static/js/zamboni/discovery-all.js:13385
 msgid "View other versions"
 msgstr ""
 
-#: static/js/zamboni/buttons.js:391
+#: static/js/common-all.js:2162 static/js/impala-all.js:2247 static/js/zamboni/buttons.js:401 static/js/zamboni/discovery-all.js:13433
 msgid "Only with Firefox — Get Firefox Now!"
 msgstr ""
 
-#: static/js/zamboni/buttons.js:507 static/js/zamboni/mobile/buttons.js:43
-msgid ""
-"Sorry, you need a Mozilla-based browser (such as Firefox) to install a "
-"search plugin."
-msgstr ""
-"Pahoittelut, voit asentaa hakulisäosan vain Mozilla-pohjaisiin selaimiin "
-"(kuten Firefox)."
+#: static/js/common-all.js:2278 static/js/impala-all.js:2363 static/js/zamboni/buttons.js:517 static/js/zamboni/discovery-all.js:13549 static/js/zamboni/mobile-all.js:15177
+#: static/js/zamboni/mobile/buttons.js:43
+msgid "Sorry, you need a Mozilla-based browser (such as Firefox) to install a search plugin."
+msgstr "Pahoittelut, voit asentaa hakulisäosan vain Mozilla-pohjaisiin selaimiin (kuten Firefox)."
 
-#: static/js/zamboni/collections.js:229
-msgid "Adding to Favorites&hellip;"
-msgstr ""
-
-#: static/js/zamboni/collections.js:232
-msgid "Removing Favorite&hellip;"
-msgstr ""
-
-#: static/js/zamboni/collections.js:235
-msgid "Add to Favorites"
-msgstr "Lisää suosikkeihin"
-
-#: static/js/zamboni/collections.js:238
-msgid "Remove from Favorites"
-msgstr "Poista suosikeista"
-
-#: static/js/zamboni/collections.js:303
-msgid "Pending"
-msgstr ""
-
-#: static/js/zamboni/collections.js:304
-msgid "Add a comment"
-msgstr "Lisää kommentti"
-
-#: static/js/zamboni/collections.js:304
-msgid "Comment"
-msgstr "Kommentti"
-
-#: static/js/zamboni/collections.js:305
-msgid "Remove this add-on from the collection"
-msgstr "Poista tämä lisäosa kokoelmasta"
-
-#: static/js/zamboni/collections.js:305 static/js/zamboni/collections.js:334
-msgid "Remove"
-msgstr "Poista"
-
-#: static/js/zamboni/collections.js:334
-msgid "Remove this user as a contributor"
-msgstr ""
-
-#: static/js/zamboni/collections.js:346
-msgid "An email address is required."
-msgstr ""
-
-#: static/js/zamboni/collections.js:364
-msgid "You cannot add yourself as a contributor."
-msgstr ""
-
-#: static/js/zamboni/collections.js:366
-msgid "You have already added that user."
-msgstr ""
-
-#: static/js/zamboni/collections.js:573
-msgid "Add to favorites"
-msgstr "Lisää suosikkeihin"
-
-#: static/js/zamboni/collections.js:577
-msgid "Remove from favorites"
-msgstr "Poista suosikeista"
-
-#: static/js/zamboni/collections.js:604
-msgid "Stop following"
-msgstr "Lopeta seuraaminen"
-
-#: static/js/zamboni/devhub.js:110
-msgid "Your browser does not support the video tag"
-msgstr ""
-
-#: static/js/zamboni/devhub.js:371
-msgid "Changes Saved"
-msgstr "Muutokset tallennettiin"
-
-#: static/js/zamboni/devhub.js:387
-msgid "Enter a new author's email address"
-msgstr ""
-
-#: static/js/zamboni/devhub.js:536
-msgid "There was an error uploading your file."
-msgstr ""
-
-#: static/js/zamboni/devhub.js:681
-msgid "{files} file"
-msgid_plural "{files} files"
-msgstr[0] "{files} tiedosto"
-msgstr[1] "{files} tiedostoa"
-
-#: static/js/zamboni/devhub.js:684
-msgid "{reviews} user review"
-msgid_plural "{reviews} user reviews"
-msgstr[0] ""
-msgstr[1] ""
-
-#: static/js/zamboni/devhub.js:796
-msgid "Learn more"
-msgstr "Lue lisää"
-
-#: static/js/zamboni/devhub.js:800
-msgid "Example"
-msgstr "Esimerkki"
-
-#: static/js/zamboni/devhub.js:1130
-msgid "Image changes being processed"
-msgstr ""
-
-#: static/js/zamboni/devhub.js:1280
-msgid "Must be a valid e-mail address."
-msgstr ""
-
-#: static/js/zamboni/devhub_search.js:8
-msgid "No results found."
-msgstr ""
-
-#: static/js/zamboni/editors.js:121
-msgid "{name} was viewing this page first."
-msgstr ""
-
-#: static/js/zamboni/editors.js:171
-msgid "Receipt checked by app."
-msgstr ""
-
-#: static/js/zamboni/editors.js:173
-msgid "Receipt was not checked by app."
-msgstr ""
-
-#: static/js/zamboni/editors.js:244
-msgid "{name} was viewing this add-on first."
-msgstr ""
-
-#: static/js/zamboni/editors.js:255
-msgid "Loading&hellip;"
-msgstr ""
-
-#: static/js/zamboni/editors.js:260
-msgid "Version Notes"
-msgstr ""
-
-#: static/js/zamboni/editors.js:265
-msgid "Notes for Reviewers"
-msgstr ""
-
-#: static/js/zamboni/editors.js:270
-msgid "No version notes found"
-msgstr ""
-
-#: static/js/zamboni/editors.js:330
-msgid "Average Reviews"
-msgstr ""
-
-#: static/js/zamboni/editors.js:386
-msgid "Number of Reviews"
-msgstr ""
-
-#: static/js/zamboni/editors.js:445
-msgid "Error loading translation"
-msgstr ""
-
-#: static/js/zamboni/files.js:411 static/js/zamboni/validator.js:261
-msgid "Ignore this message in future updates"
-msgstr ""
-
-#: static/js/zamboni/files.js:417 static/js/zamboni/validator.js:284
-msgid "Severity for automated signing:"
-msgstr ""
-
-#: static/js/zamboni/global.js:410
+#: static/js/common-all.js:9088 static/js/impala-all.js:9649 static/js/zamboni/global.js:410
 msgid "Loading..."
 msgstr "Ladataan..."
 
 #. L10n: {0} is the number of characters left.
-#: static/js/zamboni/global.js:474
+#: static/js/common-all.js:9152 static/js/impala-all.js:9713 static/js/zamboni/global.js:474
 msgid "<b>{0}</b> character left."
 msgid_plural "<b>{0}</b> characters left."
 msgstr[0] "<b>{0}</b> merkki jäljellä."
 msgstr[1] "<b>{0}</b> merkkiä jäljellä."
 
-#: static/js/zamboni/init.js:28
-msgid ""
-"This feature is temporarily disabled while we perform website maintenance. "
-"Please check back a little later."
-msgstr ""
-"Tämä toiminto on väliaikaisesti poissa käytöstä, sillä suoritamme "
-"verkkosivun huoltoa. Tarkista uudelleen myöhemmin."
+#: static/js/common-all.js:9589 static/js/common-min.js:6 static/js/impala-all.js:10052 static/js/impala-min.js:6 static/js/common/ratingwidget.js:31 static/js/zamboni/mobile-all.js:16123
+#: static/js/zamboni/mobile-min.js:6
+msgid "{0} star"
+msgid_plural "{0} stars"
+msgstr[0] "{0} tähti"
+msgstr[1] "{0} tähteä"
 
-#: static/js/zamboni/l10n.js:45
+#: static/js/common-all.js:9676 static/js/common-min.js:6 static/js/impala-all.js:10139 static/js/impala-min.js:6 static/js/zamboni/l10n.js:45
 msgid "Remove this localization"
 msgstr ""
 
-#: static/js/zamboni/password-strength.js:20
+#: static/js/common-all.js:10193 static/js/common-min.js:6 static/js/impala-all.js:10674 static/js/impala-min.js:6 static/js/zamboni/discovery-all.js:13678
+msgid "close"
+msgstr ""
+
+#: static/js/common-all.js:10860 static/js/common-min.js:6 static/js/impala-all.js:11481 static/js/impala-min.js:6 static/js/impala/reviews.js:23 static/js/zamboni/reviews.js:18
+msgid "Flagged for review"
+msgstr ""
+
+#: static/js/common-all.js:10876 static/js/common-min.js:6 static/js/impala-all.js:11498 static/js/impala-min.js:6 static/js/impala/reviews.js:40 static/js/zamboni/reviews.js:34
+msgid "Your input is required"
+msgstr ""
+
+#: static/js/common-all.js:10945 static/js/common-min.js:6 static/js/impala-all.js:11610 static/js/impala-min.js:7 static/js/impala/reviews.js:152 static/js/zamboni/reviews.js:103
+msgid "Marked for deletion"
+msgstr ""
+
+#: static/js/common-all.js:11573 static/js/common-min.js:7 static/js/impala-all.js:13809 static/js/impala-min.js:8 static/js/zamboni/collections.js:229
+msgid "Adding to Favorites&hellip;"
+msgstr ""
+
+#: static/js/common-all.js:11576 static/js/common-min.js:7 static/js/impala-all.js:13812 static/js/impala-min.js:8 static/js/zamboni/collections.js:232
+msgid "Removing Favorite&hellip;"
+msgstr ""
+
+#: static/js/common-all.js:11579 static/js/common-min.js:7 static/js/impala-all.js:13815 static/js/impala-min.js:8 static/js/zamboni/collections.js:235
+msgid "Add to Favorites"
+msgstr "Lisää suosikkeihin"
+
+#: static/js/common-all.js:11582 static/js/common-min.js:7 static/js/impala-all.js:13818 static/js/impala-min.js:8 static/js/zamboni/collections.js:238
+msgid "Remove from Favorites"
+msgstr "Poista suosikeista"
+
+#: static/js/common-all.js:11647 static/js/common-min.js:7 static/js/impala-all.js:13883 static/js/impala-min.js:8 static/js/zamboni/collections.js:303
+msgid "Pending"
+msgstr ""
+
+#: static/js/common-all.js:11648 static/js/common-min.js:7 static/js/impala-all.js:13884 static/js/impala-min.js:8 static/js/zamboni/collections.js:304
+msgid "Add a comment"
+msgstr "Lisää kommentti"
+
+#: static/js/common-all.js:11648 static/js/common-min.js:7 static/js/impala-all.js:13884 static/js/impala-min.js:8 static/js/zamboni/collections.js:304
+msgid "Comment"
+msgstr "Kommentti"
+
+#: static/js/common-all.js:11649 static/js/common-min.js:7 static/js/impala-all.js:13885 static/js/impala-min.js:8 static/js/zamboni/collections.js:305
+msgid "Remove this add-on from the collection"
+msgstr "Poista tämä lisäosa kokoelmasta"
+
+#: static/js/common-all.js:11649 static/js/common-all.js:11678 static/js/common-min.js:7 static/js/impala-all.js:13885 static/js/impala-all.js:13914 static/js/impala-min.js:8
+#: static/js/zamboni/collections.js:305 static/js/zamboni/collections.js:334
+msgid "Remove"
+msgstr "Poista"
+
+#: static/js/common-all.js:11678 static/js/common-min.js:7 static/js/impala-all.js:13914 static/js/impala-min.js:8 static/js/zamboni/collections.js:334
+msgid "Remove this user as a contributor"
+msgstr ""
+
+#: static/js/common-all.js:11690 static/js/common-min.js:7 static/js/impala-all.js:13926 static/js/impala-min.js:8 static/js/zamboni/collections.js:346
+msgid "An email address is required."
+msgstr ""
+
+#: static/js/common-all.js:11708 static/js/common-min.js:7 static/js/impala-all.js:13944 static/js/impala-min.js:8 static/js/zamboni/collections.js:364
+msgid "You cannot add yourself as a contributor."
+msgstr ""
+
+#: static/js/common-all.js:11710 static/js/common-min.js:7 static/js/impala-all.js:13946 static/js/impala-min.js:8 static/js/zamboni/collections.js:366
+msgid "You have already added that user."
+msgstr ""
+
+#: static/js/common-all.js:11917 static/js/common-min.js:7 static/js/impala-all.js:14153 static/js/impala-min.js:8 static/js/zamboni/collections.js:573
+msgid "Add to favorites"
+msgstr "Lisää suosikkeihin"
+
+#: static/js/common-all.js:11921 static/js/common-min.js:7 static/js/impala-all.js:14157 static/js/impala-min.js:8 static/js/zamboni/collections.js:577
+msgid "Remove from favorites"
+msgstr "Poista suosikeista"
+
+#: static/js/common-all.js:11939 static/js/common-min.js:7 static/js/impala-all.js:14175 static/js/impala-all.js:14233 static/js/impala-min.js:8 static/js/impala/collections.js:10
+#: static/js/zamboni/collections.js:595
+msgid "Follow this Collection"
+msgstr "Seuraa tätä kokoelmaa"
+
+#: static/js/common-all.js:11948 static/js/common-min.js:7 static/js/impala-all.js:14184 static/js/impala-min.js:8 static/js/zamboni/collections.js:604
+msgid "Stop following"
+msgstr "Lopeta seuraaminen"
+
+#: static/js/common-all.js:12096 static/js/common-min.js:7 static/js/zamboni/password-strength.js:20
 msgid "Password strength:"
 msgstr "Salasanan vahvuus:"
 
-#: static/js/zamboni/password-strength.js:26
+#: static/js/common-all.js:12102 static/js/common-min.js:7 static/js/zamboni/password-strength.js:26
 msgid "At least {0} character left."
 msgid_plural "At least {0} characters left."
 msgstr[0] ""
 msgstr[1] ""
 
-#: static/js/zamboni/themes_review.js:176
-msgid "Requested Info"
+#: static/js/common-all.js:12286 static/js/common-min.js:7 static/js/impala-all.js:14632 static/js/impala-min.js:8 static/js/impala/suggestions.js:39
+msgid "Search themes for <b>{0}</b>"
 msgstr ""
 
-#: static/js/zamboni/themes_review.js:177
-msgid "Flagged"
+#: static/js/common-all.js:12288 static/js/common-min.js:7 static/js/impala-all.js:14634 static/js/impala-min.js:8 static/js/impala/suggestions.js:41
+msgid "Search apps for <b>{0}</b>"
 msgstr ""
 
-#: static/js/zamboni/themes_review.js:178
-msgid "Duplicate"
+#: static/js/common-all.js:12290 static/js/common-min.js:7 static/js/impala-all.js:14636 static/js/impala-min.js:8 static/js/impala/suggestions.js:43
+msgid "Search add-ons for <b>{0}</b>"
 msgstr ""
 
-#: static/js/zamboni/themes_review.js:179
-msgid "Rejected"
+#: static/js/common-all.js:12521 static/js/common-min.js:7 static/js/impala-all.js:14867 static/js/impala-min.js:8 static/js/impala/site_suggestions.js:46
+msgid "Category"
+msgstr "Luokka"
+
+#. L10n: {0} is an app name.
+#: static/js/impala-all.js:11632 static/js/impala-min.js:7 static/js/impala/listing.js:11 static/js/zamboni/themes.js:13
+msgid "This theme is incompatible with your version of {0}"
+msgstr "Tämä teema ei ole yhteensopiva tämän {0} -version kanssa"
+
+#: static/js/impala-all.js:12146 static/js/impala-all.js:14331 static/js/impala-min.js:7 static/js/impala-min.js:8 static/js/common/upload-image.js:97 static/js/impala/users.js:51
+#: static/js/zamboni/devhub-all.js:894 static/js/zamboni/devhub-min.js:1
+msgid "Images must be either PNG or JPG."
 msgstr ""
 
-#: static/js/zamboni/themes_review.js:180
-msgid "Approved"
+#: static/js/impala-all.js:12150 static/js/impala-min.js:7 static/js/common/upload-image.js:101 static/js/zamboni/devhub-all.js:898 static/js/zamboni/devhub-min.js:1
+msgid "Videos must be in WebM."
 msgstr ""
 
-#: static/js/zamboni/themes_review.js:424
-msgid "No results found"
+#: static/js/impala-all.js:12177 static/js/impala-min.js:7 static/js/common/upload-addon.js:41 static/js/common/upload-image.js:128 static/js/zamboni/devhub-all.js:272
+#: static/js/zamboni/devhub-all.js:925 static/js/zamboni/devhub-min.js:1
+msgid "There was a problem contacting the server."
 msgstr ""
 
-#: static/js/zamboni/themes_review_templates.js:31
-msgid "Theme"
-msgstr "Teema"
-
-#: static/js/zamboni/themes_review_templates.js:33
-msgid "Reviewer"
+#: static/js/impala-all.js:13298 static/js/impala-min.js:7 static/js/impala/persona_creation.js:60
+msgid "All Rights Reserved"
 msgstr ""
 
-#: static/js/zamboni/themes_review_templates.js:35
-msgid "Status"
-msgstr "Tila"
+#: static/js/impala-all.js:13302 static/js/impala-min.js:7 static/js/impala/persona_creation.js:64
+msgid "Creative Commons Attribution 3.0"
+msgstr ""
 
-#: static/js/zamboni/validator.js:80
+#: static/js/impala-all.js:13307 static/js/impala-min.js:7 static/js/impala/persona_creation.js:69
+msgid "Creative Commons Attribution-NonCommercial 3.0"
+msgstr ""
+
+#: static/js/impala-all.js:13312 static/js/impala-min.js:7 static/js/impala/persona_creation.js:74
+msgid "Creative Commons Attribution-NonCommercial-NoDerivs 3.0"
+msgstr ""
+
+#: static/js/impala-all.js:13317 static/js/impala-min.js:7 static/js/impala/persona_creation.js:79
+msgid "Creative Commons Attribution-NonCommercial-Share Alike 3.0"
+msgstr ""
+
+#: static/js/impala-all.js:13322 static/js/impala-min.js:7 static/js/impala/persona_creation.js:84
+msgid "Creative Commons Attribution-NoDerivs 3.0"
+msgstr ""
+
+#: static/js/impala-all.js:13327 static/js/impala-min.js:7 static/js/impala/persona_creation.js:89
+msgid "Creative Commons Attribution-ShareAlike 3.0"
+msgstr ""
+
+#: static/js/impala-all.js:13530 static/js/impala-min.js:7 static/js/impala/persona_creation.js:292
+msgid "Your Theme's Name"
+msgstr ""
+
+#: static/js/impala-all.js:14242 static/js/impala-min.js:8 static/js/impala/collections.js:19
+msgid "Stop Following"
+msgstr ""
+
+#: static/js/impala-all.js:14243 static/js/impala-min.js:8 static/js/impala/collections.js:20
+msgid "Following"
+msgstr ""
+
+#: static/js/impala-all.js:14313 static/js/impala-min.js:8 static/js/impala/users.js:33
+msgid "use original"
+msgstr ""
+
+#: static/js/impala-all.js:14523 static/js/impala-min.js:8 static/js/impala/search.js:114
+msgid "Updating results&hellip;"
+msgstr ""
+
+#: static/js/common/upload-addon.js:69 static/js/zamboni/devhub-all.js:300 static/js/zamboni/devhub-min.js:1
+msgid "Select a file..."
+msgstr "Valitse tiedosto…"
+
+#: static/js/common/upload-addon.js:70 static/js/zamboni/devhub-all.js:301 static/js/zamboni/devhub-min.js:1
+msgid "Your add-on should end with .xpi, .jar or .xml"
+msgstr ""
+
+#. L10n: {0} is the percent of the file that has been uploaded.
+#: static/js/common/upload-addon.js:104 static/js/zamboni/devhub-all.js:335 static/js/zamboni/devhub-min.js:1
+#, python-format
+msgid "{0}% complete"
+msgstr ""
+
+#. L10n: "{bytes uploaded} of {total filesize}".
+#: static/js/common/upload-addon.js:107 static/js/zamboni/devhub-all.js:338 static/js/zamboni/devhub-min.js:1
+msgid "{0} of {1}"
+msgstr ""
+
+#: static/js/common/upload-addon.js:140 static/js/zamboni/devhub-all.js:371 static/js/zamboni/devhub-min.js:1
+msgid "Cancel"
+msgstr "Peruuta"
+
+#: static/js/common/upload-addon.js:162 static/js/zamboni/devhub-all.js:393 static/js/zamboni/devhub-min.js:1
+msgid "Uploading {0}"
+msgstr ""
+
+#: static/js/common/upload-addon.js:189 static/js/zamboni/devhub-all.js:420 static/js/zamboni/devhub-min.js:1
+msgid "Error with {0}"
+msgstr ""
+
+#: static/js/common/upload-addon.js:194 static/js/zamboni/devhub-all.js:425 static/js/zamboni/devhub-min.js:1
+msgid "Your add-on failed validation with {0} error."
+msgid_plural "Your add-on failed validation with {0} errors."
+msgstr[0] ""
+msgstr[1] ""
+
+#: static/js/common/upload-addon.js:208 static/js/zamboni/devhub-all.js:439 static/js/zamboni/devhub-min.js:1
+msgid "&hellip;and {0} more"
+msgid_plural "&hellip;and {0} more"
+msgstr[0] ""
+msgstr[1] ""
+
+#: static/js/common/upload-addon.js:222 static/js/common/upload-addon.js:497 static/js/zamboni/devhub-all.js:453 static/js/zamboni/devhub-all.js:743 static/js/zamboni/devhub-min.js:1
+msgid "See full validation report"
+msgstr ""
+
+#: static/js/common/upload-addon.js:234 static/js/zamboni/devhub-all.js:465 static/js/zamboni/devhub-min.js:1
+msgid "Validating {0}"
+msgstr ""
+
+#. L10n: first argument is an HTTP status code
+#: static/js/common/upload-addon.js:273 static/js/zamboni/devhub-all.js:504 static/js/zamboni/devhub-min.js:1
+msgid "Received an empty response from the server; status: {0}"
+msgstr ""
+
+#: static/js/common/upload-addon.js:370 static/js/zamboni/devhub-all.js:604 static/js/zamboni/devhub-min.js:1
+msgid "Unexpected server error while validating."
+msgstr ""
+
+#: static/js/common/upload-addon.js:409 static/js/zamboni/devhub-all.js:643 static/js/zamboni/devhub-min.js:1
+msgid "Finished validating {0}"
+msgstr ""
+
+#: static/js/common/upload-addon.js:415 static/js/zamboni/devhub-all.js:649 static/js/zamboni/devhub-min.js:1
+msgid "Your add-on validation timed out, it will be manually reviewed."
+msgstr ""
+
+#: static/js/common/upload-addon.js:418 static/js/zamboni/devhub-all.js:652 static/js/zamboni/devhub-min.js:1
+msgid "Your add-on was validated with no errors and {0} warning."
+msgid_plural "Your add-on was validated with no errors and {0} warnings."
+msgstr[0] ""
+msgstr[1] ""
+
+#: static/js/common/upload-addon.js:423 static/js/zamboni/devhub-all.js:657 static/js/zamboni/devhub-min.js:1
+msgid "Your add-on was validated with no errors and {0} message."
+msgid_plural "Your add-on was validated with no errors and {0} messages."
+msgstr[0] ""
+msgstr[1] ""
+
+#: static/js/common/upload-addon.js:428 static/js/zamboni/devhub-all.js:662 static/js/zamboni/devhub-min.js:1
+msgid "Your add-on was validated with no errors or warnings."
+msgstr ""
+
+#: static/js/common/upload-addon.js:443 static/js/zamboni/devhub-all.js:677 static/js/zamboni/devhub-min.js:1
+msgid "Your submission will be automatically signed."
+msgstr ""
+
+#: static/js/common/upload-addon.js:450 static/js/zamboni/devhub-all.js:696 static/js/zamboni/devhub-min.js:1
+msgid "Include detailed version notes (this can be done in the next step)."
+msgstr ""
+
+#: static/js/common/upload-addon.js:451 static/js/zamboni/devhub-all.js:697 static/js/zamboni/devhub-min.js:1
+msgid "If your add-on requires an account to a website in order to be fully tested, include a test username and password in the Notes to Reviewer (this can be done in the next step)."
+msgstr ""
+
+#: static/js/common/upload-addon.js:452 static/js/zamboni/devhub-all.js:698 static/js/zamboni/devhub-min.js:1
+msgid "If your add-on is intended for a limited audience you should choose Preliminary Review instead of Full Review."
+msgstr ""
+
+#: static/js/common/upload-addon.js:465 static/js/zamboni/devhub-all.js:711 static/js/zamboni/devhub-min.js:1
+msgid "Add-on submission checklist"
+msgstr ""
+
+#: static/js/common/upload-addon.js:466 static/js/zamboni/devhub-all.js:712 static/js/zamboni/devhub-min.js:1
+msgid "Please verify the following points before finalizing your submission. This will minimize delays or misunderstanding during the review process:"
+msgstr ""
+
+#: static/js/common/upload-addon.js:468 static/js/zamboni/devhub-all.js:714 static/js/zamboni/devhub-min.js:1
+msgid ""
+"Compiled binaries, as well as minified or obfuscated scripts (excluding known libraries) need to have their sources submitted separately for review. Make sure that you use the source code upload "
+"field to avoid having your submission rejected."
+msgstr ""
+
+#: static/js/common/upload-addon.js:486 static/js/zamboni/devhub-all.js:732 static/js/zamboni/devhub-min.js:1
+msgid "The validation process found these issues that can lead to rejections:"
+msgstr ""
+
+#: static/js/common/upload-addon.js:503 static/js/zamboni/devhub-all.js:749 static/js/zamboni/devhub-min.js:1
+msgid "If you are unfamiliar with the add-ons review process, you can read about it here."
+msgstr ""
+
+#: static/js/common/upload-addon.js:540 static/js/zamboni/devhub-all.js:786 static/js/zamboni/devhub-min.js:1
+msgid "Sorry, no supported platform has been found."
+msgstr ""
+
+#: static/js/common/upload-base.js:57 static/js/zamboni/devhub-all.js:187 static/js/zamboni/devhub-min.js:1
+msgid "The filetype you uploaded isn't recognized."
+msgstr ""
+
+#: static/js/common/upload-base.js:79 static/js/zamboni/devhub-all.js:209 static/js/zamboni/devhub-min.js:1
+msgid "You cancelled the upload."
+msgstr ""
+
+#: static/js/impala/stats/chart.js:267 static/js/zamboni/stats-all.js:16898 static/js/zamboni/stats-min.js:5
+msgid "Week of {0}"
+msgstr ""
+
+#: static/js/impala/stats/chart.js:269 static/js/zamboni/stats-all.js:16900 static/js/zamboni/stats-min.js:5
+msgid " downloads"
+msgstr ""
+
+#: static/js/impala/stats/chart.js:270 static/js/zamboni/stats-all.js:16901 static/js/zamboni/stats-min.js:5
+msgid "{0} users"
+msgstr "{0} käyttäjää"
+
+#: static/js/impala/stats/chart.js:271 static/js/zamboni/stats-all.js:16902 static/js/zamboni/stats-min.js:5
+msgid "{0} add-ons"
+msgstr ""
+
+#: static/js/impala/stats/chart.js:272 static/js/zamboni/stats-all.js:16903 static/js/zamboni/stats-min.js:5
+msgid "{0} collections"
+msgstr ""
+
+#: static/js/impala/stats/chart.js:273 static/js/zamboni/stats-all.js:16904 static/js/zamboni/stats-min.js:5
+msgid "{0} reviews"
+msgstr ""
+
+#: static/js/impala/stats/chart.js:275 static/js/zamboni/stats-all.js:16906 static/js/zamboni/stats-min.js:5
+msgid "{0} sales"
+msgstr ""
+
+#: static/js/impala/stats/chart.js:276 static/js/zamboni/stats-all.js:16907 static/js/zamboni/stats-min.js:5
+msgid "{0} refunds"
+msgstr ""
+
+#: static/js/impala/stats/chart.js:277 static/js/zamboni/stats-all.js:16908 static/js/zamboni/stats-min.js:5
+msgid "{0} installs"
+msgstr ""
+
+#: static/js/impala/stats/chart.js:369 static/js/impala/stats/csv_keys.js:3 static/js/impala/stats/csv_keys.js:109 static/js/zamboni/stats-all.js:15284 static/js/zamboni/stats-all.js:15390
+#: static/js/zamboni/stats-all.js:17000 static/js/zamboni/stats-min.js:4 static/js/zamboni/stats-min.js:5
+msgid "Downloads"
+msgstr "Lataukset"
+
+#: static/js/impala/stats/chart.js:379 static/js/impala/stats/csv_keys.js:6 static/js/impala/stats/csv_keys.js:110 static/js/zamboni/stats-all.js:15287 static/js/zamboni/stats-all.js:15391
+#: static/js/zamboni/stats-all.js:17010 static/js/zamboni/stats-min.js:4 static/js/zamboni/stats-min.js:5
+msgid "Daily Users"
+msgstr "Päivittäiset käyttäjät"
+
+#: static/js/impala/stats/chart.js:410 static/js/zamboni/stats-all.js:17041 static/js/zamboni/stats-min.js:5
+msgid "Amount, in USD"
+msgstr ""
+
+#: static/js/impala/stats/chart.js:421 static/js/impala/stats/csv_keys.js:104 static/js/zamboni/stats-all.js:15385 static/js/zamboni/stats-all.js:17052 static/js/zamboni/stats-min.js:5
+msgid "Number of Contributions"
+msgstr ""
+
+#: static/js/impala/stats/chart.js:447 static/js/zamboni/stats-all.js:17078 static/js/zamboni/stats-min.js:5
+msgid "More Info..."
+msgstr ""
+
+#. L10n: {0} is an ISO-formatted date.
+#: static/js/impala/stats/chart.js:451 static/js/zamboni/stats-all.js:17082 static/js/zamboni/stats-min.js:5
+msgid "Details for {0}"
+msgstr ""
+
+#: static/js/impala/stats/csv_keys.js:9 static/js/zamboni/stats-all.js:15290 static/js/zamboni/stats-min.js:4
+msgid "Collections Created"
+msgstr ""
+
+#: static/js/impala/stats/csv_keys.js:12 static/js/zamboni/stats-all.js:15293 static/js/zamboni/stats-min.js:4
+msgid "Add-ons in Use"
+msgstr ""
+
+#: static/js/impala/stats/csv_keys.js:15 static/js/zamboni/stats-all.js:15296 static/js/zamboni/stats-min.js:4
+msgid "Add-ons Created"
+msgstr ""
+
+#: static/js/impala/stats/csv_keys.js:18 static/js/zamboni/stats-all.js:15299 static/js/zamboni/stats-min.js:4
+msgid "Add-ons Downloaded"
+msgstr ""
+
+#: static/js/impala/stats/csv_keys.js:21 static/js/zamboni/stats-all.js:15302 static/js/zamboni/stats-min.js:4
+msgid "Add-ons Updated"
+msgstr ""
+
+#: static/js/impala/stats/csv_keys.js:24 static/js/zamboni/stats-all.js:15305 static/js/zamboni/stats-min.js:4
+msgid "Reviews Written"
+msgstr ""
+
+#: static/js/impala/stats/csv_keys.js:27 static/js/zamboni/stats-all.js:15308 static/js/zamboni/stats-min.js:4
+msgid "User Signups"
+msgstr ""
+
+#: static/js/impala/stats/csv_keys.js:30 static/js/zamboni/stats-all.js:15311 static/js/zamboni/stats-min.js:4
+msgid "Subscribers"
+msgstr ""
+
+#: static/js/impala/stats/csv_keys.js:33 static/js/zamboni/stats-all.js:15314 static/js/zamboni/stats-min.js:4
+msgid "Ratings"
+msgstr ""
+
+#: static/js/impala/stats/csv_keys.js:36 static/js/impala/stats/csv_keys.js:114 static/js/zamboni/stats-all.js:15317 static/js/zamboni/stats-all.js:15395 static/js/zamboni/stats-min.js:4
+#: static/js/zamboni/stats-min.js:5
+msgid "Sales"
+msgstr ""
+
+#: static/js/impala/stats/csv_keys.js:39 static/js/impala/stats/csv_keys.js:113 static/js/zamboni/stats-all.js:15320 static/js/zamboni/stats-all.js:15394 static/js/zamboni/stats-min.js:4
+#: static/js/zamboni/stats-min.js:5
+msgid "Installs"
+msgstr ""
+
+#: static/js/impala/stats/csv_keys.js:42 static/js/zamboni/stats-all.js:15323 static/js/zamboni/stats-min.js:4
+msgid "Unknown"
+msgstr ""
+
+#: static/js/impala/stats/csv_keys.js:43 static/js/zamboni/stats-all.js:15324 static/js/zamboni/stats-min.js:4
+msgid "Add-ons Manager"
+msgstr ""
+
+#: static/js/impala/stats/csv_keys.js:44 static/js/zamboni/stats-all.js:15325 static/js/zamboni/stats-min.js:4
+msgid "Add-ons Manager Promo"
+msgstr ""
+
+#: static/js/impala/stats/csv_keys.js:45 static/js/zamboni/stats-all.js:15326 static/js/zamboni/stats-min.js:4
+msgid "Add-ons Manager Featured"
+msgstr ""
+
+#: static/js/impala/stats/csv_keys.js:46 static/js/zamboni/stats-all.js:15327 static/js/zamboni/stats-min.js:4
+msgid "Add-ons Manager Learn More"
+msgstr ""
+
+#: static/js/impala/stats/csv_keys.js:47 static/js/zamboni/stats-all.js:15328 static/js/zamboni/stats-min.js:4
+msgid "Search Suggestions"
+msgstr ""
+
+#: static/js/impala/stats/csv_keys.js:48 static/js/zamboni/stats-all.js:15329 static/js/zamboni/stats-min.js:4
+msgid "Search Results"
+msgstr ""
+
+#: static/js/impala/stats/csv_keys.js:49 static/js/impala/stats/csv_keys.js:50 static/js/impala/stats/csv_keys.js:51 static/js/zamboni/stats-all.js:15330 static/js/zamboni/stats-all.js:15331
+#: static/js/zamboni/stats-all.js:15332 static/js/zamboni/stats-min.js:4
+msgid "Homepage Promo"
+msgstr ""
+
+#: static/js/impala/stats/csv_keys.js:52 static/js/impala/stats/csv_keys.js:53 static/js/zamboni/stats-all.js:15333 static/js/zamboni/stats-all.js:15334 static/js/zamboni/stats-min.js:4
+msgid "Homepage Featured"
+msgstr ""
+
+#: static/js/impala/stats/csv_keys.js:54 static/js/impala/stats/csv_keys.js:55 static/js/zamboni/stats-all.js:15335 static/js/zamboni/stats-all.js:15336 static/js/zamboni/stats-min.js:4
+msgid "Homepage Up and Coming"
+msgstr ""
+
+#: static/js/impala/stats/csv_keys.js:56 static/js/zamboni/stats-all.js:15337 static/js/zamboni/stats-min.js:4
+msgid "Homepage Most Popular"
+msgstr ""
+
+#: static/js/impala/stats/csv_keys.js:57 static/js/impala/stats/csv_keys.js:59 static/js/zamboni/stats-all.js:15338 static/js/zamboni/stats-all.js:15340 static/js/zamboni/stats-min.js:4
+msgid "Detail Page"
+msgstr ""
+
+#: static/js/impala/stats/csv_keys.js:58 static/js/impala/stats/csv_keys.js:60 static/js/zamboni/stats-all.js:15339 static/js/zamboni/stats-all.js:15341 static/js/zamboni/stats-min.js:4
+msgid "Detail Page (bottom)"
+msgstr ""
+
+#: static/js/impala/stats/csv_keys.js:61 static/js/zamboni/stats-all.js:15342 static/js/zamboni/stats-min.js:4
+msgid "Detail Page (Development Channel)"
+msgstr ""
+
+#: static/js/impala/stats/csv_keys.js:62 static/js/impala/stats/csv_keys.js:63 static/js/impala/stats/csv_keys.js:64 static/js/zamboni/stats-all.js:15343 static/js/zamboni/stats-all.js:15344
+#: static/js/zamboni/stats-all.js:15345 static/js/zamboni/stats-min.js:4
+msgid "Often Used With"
+msgstr ""
+
+#: static/js/impala/stats/csv_keys.js:65 static/js/impala/stats/csv_keys.js:66 static/js/zamboni/stats-all.js:15346 static/js/zamboni/stats-all.js:15347 static/js/zamboni/stats-min.js:4
+msgid "Others By Author"
+msgstr ""
+
+#: static/js/impala/stats/csv_keys.js:67 static/js/impala/stats/csv_keys.js:68 static/js/zamboni/stats-all.js:15348 static/js/zamboni/stats-all.js:15349 static/js/zamboni/stats-min.js:4
+msgid "Dependencies"
+msgstr ""
+
+#: static/js/impala/stats/csv_keys.js:69 static/js/impala/stats/csv_keys.js:70 static/js/zamboni/stats-all.js:15350 static/js/zamboni/stats-all.js:15351 static/js/zamboni/stats-min.js:4
+msgid "Upsell"
+msgstr ""
+
+#: static/js/impala/stats/csv_keys.js:71 static/js/zamboni/stats-all.js:15352 static/js/zamboni/stats-min.js:4
+msgid "Meet the Developer"
+msgstr ""
+
+#: static/js/impala/stats/csv_keys.js:72 static/js/zamboni/stats-all.js:15353 static/js/zamboni/stats-min.js:4
+msgid "User Profile"
+msgstr "Käyttäjäprofiili"
+
+#: static/js/impala/stats/csv_keys.js:73 static/js/zamboni/stats-all.js:15354 static/js/zamboni/stats-min.js:4
+msgid "Version History"
+msgstr "Versiohistoria"
+
+#: static/js/impala/stats/csv_keys.js:75 static/js/zamboni/stats-all.js:15356 static/js/zamboni/stats-min.js:4
+msgid "Sharing"
+msgstr ""
+
+#: static/js/impala/stats/csv_keys.js:76 static/js/zamboni/stats-all.js:15357 static/js/zamboni/stats-min.js:4
+msgid "Category Pages"
+msgstr ""
+
+#: static/js/impala/stats/csv_keys.js:77 static/js/zamboni/stats-all.js:15358 static/js/zamboni/stats-min.js:4
+msgid "Collections"
+msgstr ""
+
+#: static/js/impala/stats/csv_keys.js:78 static/js/impala/stats/csv_keys.js:79 static/js/zamboni/stats-all.js:15359 static/js/zamboni/stats-all.js:15360 static/js/zamboni/stats-min.js:4
+msgid "Category Landing Featured Carousel"
+msgstr ""
+
+#: static/js/impala/stats/csv_keys.js:80 static/js/impala/stats/csv_keys.js:81 static/js/zamboni/stats-all.js:15361 static/js/zamboni/stats-all.js:15362 static/js/zamboni/stats-min.js:4
+msgid "Category Landing Top Rated"
+msgstr ""
+
+#: static/js/impala/stats/csv_keys.js:82 static/js/impala/stats/csv_keys.js:83 static/js/zamboni/stats-all.js:15363 static/js/zamboni/stats-all.js:15364 static/js/zamboni/stats-min.js:5
+msgid "Category Landing Most Popular"
+msgstr ""
+
+#: static/js/impala/stats/csv_keys.js:84 static/js/impala/stats/csv_keys.js:85 static/js/zamboni/stats-all.js:15365 static/js/zamboni/stats-all.js:15366 static/js/zamboni/stats-min.js:5
+msgid "Category Landing Recently Added"
+msgstr ""
+
+#: static/js/impala/stats/csv_keys.js:86 static/js/impala/stats/csv_keys.js:87 static/js/zamboni/stats-all.js:15367 static/js/zamboni/stats-all.js:15368 static/js/zamboni/stats-min.js:5
+msgid "Browse Listing Featured Sort"
+msgstr ""
+
+#: static/js/impala/stats/csv_keys.js:88 static/js/impala/stats/csv_keys.js:89 static/js/zamboni/stats-all.js:15369 static/js/zamboni/stats-all.js:15370 static/js/zamboni/stats-min.js:5
+msgid "Browse Listing Users Sort"
+msgstr ""
+
+#: static/js/impala/stats/csv_keys.js:90 static/js/impala/stats/csv_keys.js:91 static/js/zamboni/stats-all.js:15371 static/js/zamboni/stats-all.js:15372 static/js/zamboni/stats-min.js:5
+msgid "Browse Listing Rating Sort"
+msgstr ""
+
+#: static/js/impala/stats/csv_keys.js:92 static/js/impala/stats/csv_keys.js:93 static/js/zamboni/stats-all.js:15373 static/js/zamboni/stats-all.js:15374 static/js/zamboni/stats-min.js:5
+msgid "Browse Listing Created Sort"
+msgstr ""
+
+#: static/js/impala/stats/csv_keys.js:94 static/js/impala/stats/csv_keys.js:95 static/js/zamboni/stats-all.js:15375 static/js/zamboni/stats-all.js:15376 static/js/zamboni/stats-min.js:5
+msgid "Browse Listing Name Sort"
+msgstr ""
+
+#: static/js/impala/stats/csv_keys.js:96 static/js/impala/stats/csv_keys.js:97 static/js/zamboni/stats-all.js:15377 static/js/zamboni/stats-all.js:15378 static/js/zamboni/stats-min.js:5
+msgid "Browse Listing Popular Sort"
+msgstr ""
+
+#: static/js/impala/stats/csv_keys.js:98 static/js/impala/stats/csv_keys.js:99 static/js/zamboni/stats-all.js:15379 static/js/zamboni/stats-all.js:15380 static/js/zamboni/stats-min.js:5
+msgid "Browse Listing Updated Sort"
+msgstr ""
+
+#: static/js/impala/stats/csv_keys.js:100 static/js/impala/stats/csv_keys.js:101 static/js/zamboni/stats-all.js:15381 static/js/zamboni/stats-all.js:15382 static/js/zamboni/stats-min.js:5
+msgid "Browse Listing Up and Coming Sort"
+msgstr ""
+
+#: static/js/impala/stats/csv_keys.js:105 static/js/zamboni/stats-all.js:15386 static/js/zamboni/stats-min.js:5
+msgid "Total Amount Contributed"
+msgstr ""
+
+#: static/js/impala/stats/csv_keys.js:106 static/js/zamboni/stats-all.js:15387 static/js/zamboni/stats-min.js:5
+msgid "Average Contribution"
+msgstr ""
+
+#: static/js/impala/stats/csv_keys.js:115 static/js/zamboni/stats-all.js:15396 static/js/zamboni/stats-min.js:5
+msgid "Usage"
+msgstr ""
+
+#: static/js/impala/stats/csv_keys.js:118 static/js/zamboni/stats-all.js:15399 static/js/zamboni/stats-min.js:5
+msgid "Firefox"
+msgstr "Firefox"
+
+#: static/js/impala/stats/csv_keys.js:119 static/js/zamboni/stats-all.js:15400 static/js/zamboni/stats-min.js:5
+msgid "Mozilla"
+msgstr "Mozilla"
+
+#: static/js/impala/stats/csv_keys.js:120 static/js/zamboni/stats-all.js:15401 static/js/zamboni/stats-min.js:5
+msgid "Thunderbird"
+msgstr "Thunderbird"
+
+#: static/js/impala/stats/csv_keys.js:121 static/js/zamboni/stats-all.js:15402 static/js/zamboni/stats-min.js:5
+msgid "Sunbird"
+msgstr "Sunbird"
+
+#: static/js/impala/stats/csv_keys.js:122 static/js/zamboni/stats-all.js:15403 static/js/zamboni/stats-min.js:5
+msgid "SeaMonkey"
+msgstr "SeaMonkey"
+
+#: static/js/impala/stats/csv_keys.js:123 static/js/zamboni/stats-all.js:15404 static/js/zamboni/stats-min.js:5
+msgid "Fennec"
+msgstr "Fennec"
+
+#: static/js/impala/stats/csv_keys.js:124 static/js/zamboni/stats-all.js:15405 static/js/zamboni/stats-min.js:5
+msgid "Android"
+msgstr "Android"
+
+#. L10n: {0} is an integer.
+#: static/js/impala/stats/csv_keys.js:129 static/js/zamboni/stats-all.js:15410 static/js/zamboni/stats-min.js:5
+msgid "Downloads and Daily Users, last {0} days"
+msgstr ""
+
+#. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
+#: static/js/impala/stats/csv_keys.js:131 static/js/zamboni/stats-all.js:15412 static/js/zamboni/stats-min.js:5
+msgid "Downloads and Daily Users from {0} to {1}"
+msgstr "Lataukset ja päivittäiset käyttäjät {0} - {1}"
+
+#. L10n: {0} is an integer.
+#: static/js/impala/stats/csv_keys.js:135 static/js/zamboni/stats-all.js:15416 static/js/zamboni/stats-min.js:5
+msgid "Installs and Daily Users, last {0} days"
+msgstr ""
+
+#. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
+#: static/js/impala/stats/csv_keys.js:137 static/js/zamboni/stats-all.js:15418 static/js/zamboni/stats-min.js:5
+msgid "Installs and Daily Users from {0} to {1}"
+msgstr ""
+
+#. L10n: {0} is an integer.
+#: static/js/impala/stats/csv_keys.js:141 static/js/zamboni/stats-all.js:15422 static/js/zamboni/stats-min.js:5
+msgid "Downloads, last {0} days"
+msgstr ""
+
+#. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
+#: static/js/impala/stats/csv_keys.js:143 static/js/zamboni/stats-all.js:15424 static/js/zamboni/stats-min.js:5
+msgid "Downloads from {0} to {1}"
+msgstr "Lataukset {0} - {1}"
+
+#. L10n: {0} is an integer.
+#: static/js/impala/stats/csv_keys.js:147 static/js/zamboni/stats-all.js:15428 static/js/zamboni/stats-min.js:5
+msgid "Daily Users, last {0} days"
+msgstr ""
+
+#. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
+#: static/js/impala/stats/csv_keys.js:149 static/js/zamboni/stats-all.js:15430 static/js/zamboni/stats-min.js:5
+msgid "Daily Users from {0} to {1}"
+msgstr "Päivittäiset käyttäjät {0} - {1}"
+
+#. L10n: {0} is an integer.
+#: static/js/impala/stats/csv_keys.js:153 static/js/zamboni/stats-all.js:15434 static/js/zamboni/stats-min.js:5
+msgid "Applications, last {0} days"
+msgstr ""
+
+#. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
+#: static/js/impala/stats/csv_keys.js:155 static/js/zamboni/stats-all.js:15436 static/js/zamboni/stats-min.js:5
+msgid "Applications from {0} to {1}"
+msgstr "Sovellukset {0} - {1}"
+
+#. L10n: {0} is an integer.
+#: static/js/impala/stats/csv_keys.js:159 static/js/zamboni/stats-all.js:15440 static/js/zamboni/stats-min.js:5
+msgid "Platforms, last {0} days"
+msgstr ""
+
+#. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
+#: static/js/impala/stats/csv_keys.js:161 static/js/zamboni/stats-all.js:15442 static/js/zamboni/stats-min.js:5
+msgid "Platforms from {0} to {1}"
+msgstr "Alustat {0} - {1}"
+
+#. L10n: {0} is an integer.
+#: static/js/impala/stats/csv_keys.js:165 static/js/zamboni/stats-all.js:15446 static/js/zamboni/stats-min.js:5
+msgid "Languages, last {0} days"
+msgstr ""
+
+#. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
+#: static/js/impala/stats/csv_keys.js:167 static/js/zamboni/stats-all.js:15448 static/js/zamboni/stats-min.js:5
+msgid "Languages from {0} to {1}"
+msgstr "Kielet {0} - {1}"
+
+#. L10n: {0} is an integer.
+#: static/js/impala/stats/csv_keys.js:171 static/js/zamboni/stats-all.js:15452 static/js/zamboni/stats-min.js:5
+msgid "Add-on Versions, last {0} days"
+msgstr ""
+
+#. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
+#: static/js/impala/stats/csv_keys.js:173 static/js/zamboni/stats-all.js:15454 static/js/zamboni/stats-min.js:5
+msgid "Add-on Versions from {0} to {1}"
+msgstr "Lisäosan versiot {0} - {1}"
+
+#. L10n: {0} is an integer.
+#: static/js/impala/stats/csv_keys.js:177 static/js/zamboni/stats-all.js:15458 static/js/zamboni/stats-min.js:5
+msgid "Add-on Status, last {0} days"
+msgstr ""
+
+#. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
+#: static/js/impala/stats/csv_keys.js:179 static/js/zamboni/stats-all.js:15460 static/js/zamboni/stats-min.js:5
+msgid "Add-on Status from {0} to {1}"
+msgstr "Lisäosan tila {0} - {1}"
+
+#. L10n: {0} is an integer.
+#: static/js/impala/stats/csv_keys.js:183 static/js/zamboni/stats-all.js:15464 static/js/zamboni/stats-min.js:5
+msgid "Download Sources, last {0} days"
+msgstr ""
+
+#. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
+#: static/js/impala/stats/csv_keys.js:185 static/js/zamboni/stats-all.js:15466 static/js/zamboni/stats-min.js:5
+msgid "Download Sources from {0} to {1}"
+msgstr "Latauslähteet {0} - {1}"
+
+#. L10n: {0} is an integer.
+#: static/js/impala/stats/csv_keys.js:189 static/js/zamboni/stats-all.js:15470 static/js/zamboni/stats-min.js:5
+msgid "Contributions, last {0} days"
+msgstr ""
+
+#. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
+#: static/js/impala/stats/csv_keys.js:191 static/js/zamboni/stats-all.js:15472 static/js/zamboni/stats-min.js:5
+msgid "Contributions from {0} to {1}"
+msgstr "Avustukset {0} - {1}"
+
+#. L10n: {0} is an integer.
+#: static/js/impala/stats/csv_keys.js:195 static/js/zamboni/stats-all.js:15476 static/js/zamboni/stats-min.js:5
+msgid "Site Metrics, last {0} days"
+msgstr ""
+
+#. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
+#: static/js/impala/stats/csv_keys.js:197 static/js/zamboni/stats-all.js:15478 static/js/zamboni/stats-min.js:5
+msgid "Site Metrics from {0} to {1}"
+msgstr ""
+
+#. L10n: {0} is an integer.
+#: static/js/impala/stats/csv_keys.js:201 static/js/zamboni/stats-all.js:15482 static/js/zamboni/stats-min.js:5
+msgid "Add-ons in Use, last {0} days"
+msgstr ""
+
+#. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
+#: static/js/impala/stats/csv_keys.js:203 static/js/zamboni/stats-all.js:15484 static/js/zamboni/stats-min.js:5
+msgid "Add-ons in Use from {0} to {1}"
+msgstr ""
+
+#. L10n: {0} is an integer.
+#: static/js/impala/stats/csv_keys.js:207 static/js/zamboni/stats-all.js:15488 static/js/zamboni/stats-min.js:5
+msgid "Add-ons Downloaded, last {0} days"
+msgstr ""
+
+#. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
+#: static/js/impala/stats/csv_keys.js:209 static/js/zamboni/stats-all.js:15490 static/js/zamboni/stats-min.js:5
+msgid "Add-ons Downloaded from {0} to {1}"
+msgstr ""
+
+#. L10n: {0} is an integer.
+#: static/js/impala/stats/csv_keys.js:213 static/js/zamboni/stats-all.js:15494 static/js/zamboni/stats-min.js:5
+msgid "Add-ons Created, last {0} days"
+msgstr ""
+
+#. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
+#: static/js/impala/stats/csv_keys.js:215 static/js/zamboni/stats-all.js:15496 static/js/zamboni/stats-min.js:5
+msgid "Add-ons Created from {0} to {1}"
+msgstr ""
+
+#. L10n: {0} is an integer.
+#: static/js/impala/stats/csv_keys.js:219 static/js/zamboni/stats-all.js:15500 static/js/zamboni/stats-min.js:5
+msgid "Add-ons Updated, last {0} days"
+msgstr ""
+
+#. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
+#: static/js/impala/stats/csv_keys.js:221 static/js/zamboni/stats-all.js:15502 static/js/zamboni/stats-min.js:5
+msgid "Add-ons Updated from {0} to {1}"
+msgstr ""
+
+#. L10n: {0} is an integer.
+#: static/js/impala/stats/csv_keys.js:225 static/js/zamboni/stats-all.js:15506 static/js/zamboni/stats-min.js:5
+msgid "Reviews Written, last {0} days"
+msgstr ""
+
+#. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
+#: static/js/impala/stats/csv_keys.js:227 static/js/zamboni/stats-all.js:15508 static/js/zamboni/stats-min.js:5
+msgid "Reviews Written from {0} to {1}"
+msgstr ""
+
+#. L10n: {0} is an integer.
+#: static/js/impala/stats/csv_keys.js:231 static/js/zamboni/stats-all.js:15512 static/js/zamboni/stats-min.js:5
+msgid "User Signups, last {0} days"
+msgstr ""
+
+#. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
+#: static/js/impala/stats/csv_keys.js:233 static/js/zamboni/stats-all.js:15514 static/js/zamboni/stats-min.js:5
+msgid "User Signups from {0} to {1}"
+msgstr ""
+
+#. L10n: {0} is an integer.
+#: static/js/impala/stats/csv_keys.js:237 static/js/zamboni/stats-all.js:15518 static/js/zamboni/stats-min.js:5
+msgid "Collections Created, last {0} days"
+msgstr ""
+
+#. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
+#: static/js/impala/stats/csv_keys.js:239 static/js/zamboni/stats-all.js:15520 static/js/zamboni/stats-min.js:5
+msgid "Collections Created from {0} to {1}"
+msgstr ""
+
+#. L10n: {0} is an integer.
+#: static/js/impala/stats/csv_keys.js:243 static/js/zamboni/stats-all.js:15524 static/js/zamboni/stats-min.js:5
+msgid "Subscribers, last {0} days"
+msgstr ""
+
+#. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
+#: static/js/impala/stats/csv_keys.js:245 static/js/zamboni/stats-all.js:15526 static/js/zamboni/stats-min.js:5
+msgid "Subscribers from {0} to {1}"
+msgstr ""
+
+#. L10n: {0} is an integer.
+#: static/js/impala/stats/csv_keys.js:249 static/js/zamboni/stats-all.js:15530 static/js/zamboni/stats-min.js:5
+msgid "Ratings, last {0} days"
+msgstr ""
+
+#. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
+#: static/js/impala/stats/csv_keys.js:251 static/js/zamboni/stats-all.js:15532 static/js/zamboni/stats-min.js:5
+msgid "Ratings from {0} to {1}"
+msgstr ""
+
+#. L10n: {0} is an integer.
+#: static/js/impala/stats/csv_keys.js:255 static/js/zamboni/stats-all.js:15536 static/js/zamboni/stats-min.js:5
+msgid "Sales, last {0} days"
+msgstr ""
+
+#. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
+#: static/js/impala/stats/csv_keys.js:257 static/js/zamboni/stats-all.js:15538 static/js/zamboni/stats-min.js:5
+msgid "Sales from {0} to {1}"
+msgstr ""
+
+#. L10n: {0} is an integer.
+#: static/js/impala/stats/csv_keys.js:261 static/js/zamboni/stats-all.js:15542 static/js/zamboni/stats-min.js:5
+msgid "Installs, last {0} days"
+msgstr ""
+
+#. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
+#: static/js/impala/stats/csv_keys.js:263 static/js/zamboni/stats-all.js:15544 static/js/zamboni/stats-min.js:5
+msgid "Installs from {0} to {1}"
+msgstr ""
+
+#. L10n: {0} and {1} are integers.
+#: static/js/impala/stats/csv_keys.js:269 static/js/zamboni/stats-all.js:15550 static/js/zamboni/stats-min.js:5
+msgid "<b>{0}</b> in last {1} days"
+msgstr ""
+
+#. L10n: {0} is an integer and {1} and {2} are dates in YYYY-MM-DD format.
+#: static/js/impala/stats/csv_keys.js:271 static/js/impala/stats/csv_keys.js:277 static/js/zamboni/stats-all.js:15552 static/js/zamboni/stats-all.js:15558 static/js/zamboni/stats-min.js:5
+msgid "<b>{0}</b> from {1} to {2}"
+msgstr "<b>{0}</b> ajanjaksolla {1} - {2}"
+
+#. L10n: {0} and {1} are integers.
+#: static/js/impala/stats/csv_keys.js:275 static/js/zamboni/stats-all.js:15556 static/js/zamboni/stats-min.js:5
+msgid "<b>{0}</b> average in last {1} days"
+msgstr ""
+
+#: static/js/impala/stats/overview.js:19 static/js/zamboni/stats-all.js:16469 static/js/zamboni/stats-min.js:5
+msgid "No data available."
+msgstr "Ei dataa saatavilla."
+
+#: static/js/impala/stats/table.js:74 static/js/zamboni/stats-all.js:17209 static/js/zamboni/stats-min.js:5
+msgid "Date"
+msgstr "Päivä"
+
+#: static/js/impala/stats/topchart.js:96 static/js/zamboni/stats-all.js:16600 static/js/zamboni/stats-min.js:5
+msgid "Other"
+msgstr "Muu"
+
+#: static/js/zamboni/admin-all.js:180 static/js/zamboni/admin-min.js:1 static/js/zamboni/admin_validation.js:24 static/js/zamboni/devhub-all.js:2408 static/js/zamboni/devhub-min.js:2
+#: static/js/zamboni/devhub.js:1229 static/js/zamboni/editors-all.js:15576 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:295
+msgid "Select an application first"
+msgstr "Valitse ensin sovellus"
+
+#: static/js/zamboni/admin-all.js:207 static/js/zamboni/admin-min.js:1 static/js/zamboni/admin_validation.js:51
+msgid "Set {0} add-on to a max version of {1} and email the author."
+msgid_plural "Set {0} add-ons to a max version of {1} and email the authors."
+msgstr[0] ""
+msgstr[1] ""
+
+#: static/js/zamboni/admin-all.js:210 static/js/zamboni/admin-min.js:1 static/js/zamboni/admin_validation.js:54
+msgid "Email author of {2} add-on which failed validation."
+msgid_plural "Email authors of {2} add-ons which failed validation."
+msgstr[0] ""
+msgstr[1] ""
+
+#: static/js/zamboni/devhub-all.js:1289 static/js/zamboni/devhub-min.js:1 static/js/zamboni/devhub.js:110
+msgid "Your browser does not support the video tag"
+msgstr ""
+
+#: static/js/zamboni/devhub-all.js:1550 static/js/zamboni/devhub-min.js:1 static/js/zamboni/devhub.js:371
+msgid "Changes Saved"
+msgstr "Muutokset tallennettiin"
+
+#: static/js/zamboni/devhub-all.js:1566 static/js/zamboni/devhub-min.js:1 static/js/zamboni/devhub.js:387
+msgid "Enter a new author's email address"
+msgstr ""
+
+#: static/js/zamboni/devhub-all.js:1715 static/js/zamboni/devhub-min.js:1 static/js/zamboni/devhub.js:536
+msgid "There was an error uploading your file."
+msgstr ""
+
+#: static/js/zamboni/devhub-all.js:1860 static/js/zamboni/devhub-min.js:1 static/js/zamboni/devhub.js:681
+msgid "{files} file"
+msgid_plural "{files} files"
+msgstr[0] "{files} tiedosto"
+msgstr[1] "{files} tiedostoa"
+
+#: static/js/zamboni/devhub-all.js:1863 static/js/zamboni/devhub-min.js:1 static/js/zamboni/devhub.js:684
+msgid "{reviews} user review"
+msgid_plural "{reviews} user reviews"
+msgstr[0] ""
+msgstr[1] ""
+
+#: static/js/zamboni/devhub-all.js:1975 static/js/zamboni/devhub-min.js:2 static/js/zamboni/devhub.js:796
+msgid "Learn more"
+msgstr "Lue lisää"
+
+#: static/js/zamboni/devhub-all.js:1979 static/js/zamboni/devhub-min.js:2 static/js/zamboni/devhub.js:800
+msgid "Example"
+msgstr "Esimerkki"
+
+#: static/js/zamboni/devhub-all.js:2309 static/js/zamboni/devhub-min.js:2 static/js/zamboni/devhub.js:1130
+msgid "Image changes being processed"
+msgstr ""
+
+#: static/js/zamboni/devhub-all.js:2459 static/js/zamboni/devhub-min.js:2 static/js/zamboni/devhub.js:1280
+msgid "Must be a valid e-mail address."
+msgstr ""
+
+#: static/js/zamboni/devhub-all.js:2613 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:80
 msgid "All tests passed successfully."
 msgstr ""
 
-#: static/js/zamboni/validator.js:83 static/js/zamboni/validator.js:478
+#: static/js/zamboni/devhub-all.js:2616 static/js/zamboni/devhub-all.js:3011 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:83 static/js/zamboni/validator.js:478
 msgid "These tests were not run."
 msgstr ""
 
-#: static/js/zamboni/validator.js:131 static/js/zamboni/validator.js:144
+#: static/js/zamboni/devhub-all.js:2664 static/js/zamboni/devhub-all.js:2677 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:131 static/js/zamboni/validator.js:144
 msgid "Tests"
 msgstr ""
 
-#: static/js/zamboni/validator.js:246 static/js/zamboni/validator.js:575
-#: static/js/zamboni/validator.js:594
+#: static/js/zamboni/devhub-all.js:2779 static/js/zamboni/devhub-all.js:3108 static/js/zamboni/devhub-all.js:3127 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:246
+#: static/js/zamboni/validator.js:575 static/js/zamboni/validator.js:594
 msgid "Error"
 msgstr "Virhe"
 
-#: static/js/zamboni/validator.js:247
+#: static/js/zamboni/devhub-all.js:2780 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:247
 msgid "Warning"
 msgstr "Varoitus"
 
-#: static/js/zamboni/validator.js:299
+#: static/js/zamboni/devhub-all.js:2794 static/js/zamboni/devhub-min.js:2 static/js/zamboni/files-all.js:5657 static/js/zamboni/files-min.js:3 static/js/zamboni/files.js:411
+#: static/js/zamboni/validator.js:261
+msgid "Ignore this message in future updates"
+msgstr ""
+
+#: static/js/zamboni/devhub-all.js:2817 static/js/zamboni/devhub-min.js:2 static/js/zamboni/files-all.js:5663 static/js/zamboni/files-min.js:3 static/js/zamboni/files.js:417
+#: static/js/zamboni/validator.js:284
+msgid "Severity for automated signing:"
+msgstr ""
+
+#: static/js/zamboni/devhub-all.js:2832 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:299
 msgid "Suggestions for passing automated signing:"
 msgstr ""
 
-#: static/js/zamboni/validator.js:387
+#: static/js/zamboni/devhub-all.js:2920 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:387
 msgid "Compatibility Tests"
 msgstr ""
 
-#: static/js/zamboni/validator.js:466
+#: static/js/zamboni/devhub-all.js:2999 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:466
 msgid "Add-on failed validation."
 msgstr ""
 
-#: static/js/zamboni/validator.js:468
+#: static/js/zamboni/devhub-all.js:3001 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:468
 msgid "Add-on passed validation."
 msgstr ""
 
-#: static/js/zamboni/validator.js:481
+#: static/js/zamboni/devhub-all.js:3014 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:481
 msgid "{0} error"
 msgid_plural "{0} errors"
 msgstr[0] "{0} virhe"
 msgstr[1] "{0} virhettä"
 
-#: static/js/zamboni/validator.js:483
+#: static/js/zamboni/devhub-all.js:3016 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:483
 msgid "{0} warning"
 msgid_plural "{0} warnings"
 msgstr[0] "{0} varoitus"
 msgstr[1] "{0} varoitusta"
 
-#: static/js/zamboni/validator.js:485
+#: static/js/zamboni/devhub-all.js:3018 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:485
 msgid "{0} notice"
 msgid_plural "{0} notices"
 msgstr[0] ""
 msgstr[1] ""
 
-#: static/js/zamboni/validator.js:577
+#: static/js/zamboni/devhub-all.js:3110 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:577
 msgid "Validation task could not complete or completed with errors"
 msgstr ""
 
-#: static/js/zamboni/validator.js:595
+#: static/js/zamboni/devhub-all.js:3128 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:595
 msgid "Internal server error"
 msgstr "Palvelimen sisäinen virhe"
 
-#: static/js/zamboni/mobile/buttons.js:52
+#: static/js/zamboni/devhub_search.js:8
+msgid "No results found."
+msgstr ""
+
+#: static/js/zamboni/editors-all.js:15402 static/js/zamboni/editors-min.js:4 static/js/zamboni/editors.js:121
+msgid "{name} was viewing this page first."
+msgstr ""
+
+#: static/js/zamboni/editors-all.js:15452 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:171
+msgid "Receipt checked by app."
+msgstr ""
+
+#: static/js/zamboni/editors-all.js:15454 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:173
+msgid "Receipt was not checked by app."
+msgstr ""
+
+#: static/js/zamboni/editors-all.js:15525 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:244
+msgid "{name} was viewing this add-on first."
+msgstr ""
+
+#: static/js/zamboni/editors-all.js:15536 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:255
+msgid "Loading&hellip;"
+msgstr ""
+
+#: static/js/zamboni/editors-all.js:15541 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:260
+msgid "Version Notes"
+msgstr ""
+
+#: static/js/zamboni/editors-all.js:15546 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:265
+msgid "Notes for Reviewers"
+msgstr ""
+
+#: static/js/zamboni/editors-all.js:15551 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:270
+msgid "No version notes found"
+msgstr ""
+
+#: static/js/zamboni/editors-all.js:15611 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:330
+msgid "Average Reviews"
+msgstr ""
+
+#: static/js/zamboni/editors-all.js:15667 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:386
+msgid "Number of Reviews"
+msgstr ""
+
+#: static/js/zamboni/editors-all.js:15726 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:445
+msgid "Error loading translation"
+msgstr ""
+
+#: static/js/zamboni/editors-all.js:15975 static/js/zamboni/editors-min.js:5 static/js/zamboni/themes_review_templates.js:31
+msgid "Theme"
+msgstr "Teema"
+
+#: static/js/zamboni/editors-all.js:15977 static/js/zamboni/editors-min.js:5 static/js/zamboni/themes_review_templates.js:33
+msgid "Reviewer"
+msgstr ""
+
+#: static/js/zamboni/editors-all.js:15979 static/js/zamboni/editors-min.js:5 static/js/zamboni/themes_review_templates.js:35
+msgid "Status"
+msgstr "Tila"
+
+#: static/js/zamboni/editors-all.js:16196 static/js/zamboni/editors-min.js:5 static/js/zamboni/themes_review.js:176
+msgid "Requested Info"
+msgstr ""
+
+#: static/js/zamboni/editors-all.js:16197 static/js/zamboni/editors-min.js:5 static/js/zamboni/themes_review.js:177
+msgid "Flagged"
+msgstr ""
+
+#: static/js/zamboni/editors-all.js:16198 static/js/zamboni/editors-min.js:5 static/js/zamboni/themes_review.js:178
+msgid "Duplicate"
+msgstr ""
+
+#: static/js/zamboni/editors-all.js:16199 static/js/zamboni/editors-min.js:5 static/js/zamboni/themes_review.js:179
+msgid "Rejected"
+msgstr ""
+
+#: static/js/zamboni/editors-all.js:16200 static/js/zamboni/editors-min.js:5 static/js/zamboni/themes_review.js:180
+msgid "Approved"
+msgstr ""
+
+#: static/js/zamboni/editors-all.js:16444 static/js/zamboni/editors-min.js:5 static/js/zamboni/themes_review.js:424
+msgid "No results found"
+msgstr ""
+
+#: static/js/zamboni/mobile-all.js:15186 static/js/zamboni/mobile/buttons.js:52
 msgid "Not Updated for {0} {1}"
 msgstr ""
 
-#: static/js/zamboni/mobile/buttons.js:53
+#: static/js/zamboni/mobile-all.js:15187 static/js/zamboni/mobile/buttons.js:53
 msgid "Requires Newer Version of {0}"
 msgstr ""
 
-#: static/js/zamboni/mobile/buttons.js:54
+#: static/js/zamboni/mobile-all.js:15188 static/js/zamboni/mobile/buttons.js:54
 msgid "Unreviewed"
 msgstr ""
 
-#: static/js/zamboni/mobile/buttons.js:55
+#: static/js/zamboni/mobile-all.js:15189 static/js/zamboni/mobile/buttons.js:55
 msgid "Experimental <span>(Learn More)</span>"
 msgstr "Kokeellinen <span>(Lue lisää)</span>"
 
-#: static/js/zamboni/mobile/buttons.js:56
-#: static/js/zamboni/mobile/buttons.js:57
+#: static/js/zamboni/mobile-all.js:15190 static/js/zamboni/mobile-all.js:15191 static/js/zamboni/mobile/buttons.js:56 static/js/zamboni/mobile/buttons.js:57
 msgid "Not Available for {0}"
 msgstr ""
 
-#: static/js/zamboni/mobile/buttons.js:58
+#: static/js/zamboni/mobile-all.js:15192 static/js/zamboni/mobile/buttons.js:58
 msgid "Experimental"
 msgstr "Kokeellinen"
 
-#: static/js/zamboni/mobile/buttons.js:59
+#: static/js/zamboni/mobile-all.js:15193 static/js/zamboni/mobile/buttons.js:59
 msgid "Themes Require Newer Version of {0}"
 msgstr ""
 
-#: static/js/zamboni/mobile/buttons.js:60
+#: static/js/zamboni/mobile-all.js:15194 static/js/zamboni/mobile/buttons.js:60
 msgid "Themes Require {0}"
 msgstr ""
 
-#: static/js/zamboni/mobile/buttons.js:105
+#: static/js/zamboni/mobile-all.js:15239 static/js/zamboni/mobile/buttons.js:105
 msgid "Installing..."
 msgstr "Asennetaan..."
 
-#: static/js/zamboni/mobile/buttons.js:125
+#: static/js/zamboni/mobile-all.js:15259 static/js/zamboni/mobile/buttons.js:125
 msgid "This add-on has been preliminarily reviewed by Mozilla."
 msgstr ""
 
-#: static/js/zamboni/mobile/buttons.js:250
+#: static/js/zamboni/mobile-all.js:15384 static/js/zamboni/mobile/buttons.js:250
 msgid "Keep it"
 msgstr ""
 
-#: static/js/zamboni/mobile/general.js:344
+#: static/js/zamboni/mobile-all.js:16049 static/js/zamboni/mobile-min.js:6 static/js/zamboni/mobile/general.js:344
 msgid "You're trying it on!"
 msgstr ""
 
-#: static/js/zamboni/mobile/general.js:356
+#: static/js/zamboni/mobile-all.js:16061 static/js/zamboni/mobile-min.js:6 static/js/zamboni/mobile/general.js:356
 msgid "Added to Firefox"
 msgstr "Lisätty Firefoxiin"

--- a/locale/fr/LC_MESSAGES/django.po
+++ b/locale/fr/LC_MESSAGES/django.po
@@ -5,87 +5,75 @@
 # Pascal Chevrel <pascal.chevrel@free.fr>, 2006-2009.
 # Jean-Bernard Marcon <goofy@babelzilla.org>, 2009-2010.
 # Alexandre Lissy <lissyx@mozfr.org>, 2009, 2010, 2011, 2012, 2013.
-# 
+#
 msgid ""
 msgstr ""
 "Project-Id-Version: REMORA 0.1\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2016-02-24 21:23+0000\n"
+"POT-Creation-Date: 2016-04-18 15:40+0000\n"
 "PO-Revision-Date: 2016-04-09 15:46+0000\n"
 "Last-Translator: Sphinx / Julien G <sphinx_knight@hotmail.fr>\n"
 "Language-Team: français <>\n"
-"Language: fr\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n > 1);\n"
 "Generated-By: Babel 2.2.0\n"
-"X-Generator: Pontoon\n"
-
-#: src/olympia/accounts/views.py:52
-msgid "Your log in attempt could not be parsed. Please try again."
-msgstr ""
-"Votre tentative de connexion n'a pas pu être analysée. Veuillez recommencer."
 
 #: src/olympia/accounts/views.py:54
+msgid "Your log in attempt could not be parsed. Please try again."
+msgstr "Votre tentative de connexion n'a pas pu être analysée. Veuillez recommencer."
+
+#: src/olympia/accounts/views.py:56
 msgid "Your Firefox Account could not be found. Please try again."
 msgstr "Votre compte Firefox n'a pas pu être trouvé. Veuillez réessayer."
 
-#: src/olympia/accounts/views.py:55
+#: src/olympia/accounts/views.py:57
 msgid "You could not be logged in. Please try again."
 msgstr "Votre connexion a échoué. Veuillez recommencer."
 
-#: src/olympia/accounts/views.py:57
+#: src/olympia/accounts/views.py:59
 msgid "Your account has already been migrated to Firefox Accounts."
 msgstr "Votre compte a déjà été migré vers les comptes Firefox."
 
-#: src/olympia/accounts/views.py:59
+#: src/olympia/accounts/views.py:61
 msgid "Your Firefox Account already exists on this site."
 msgstr "Votre compte Firefox existe déjà sur ce site."
 
-#: src/olympia/accounts/views.py:108
+#: src/olympia/accounts/views.py:110
 msgid "Great job!"
 msgstr "C'est fait !"
 
-#: src/olympia/accounts/views.py:109
+#: src/olympia/accounts/views.py:111
 msgid "You can now log in to Add-ons with your Firefox Account."
-msgstr ""
-"Vous pouvez désormais vous connecter aux modules avec votre compte Firefox."
+msgstr "Vous pouvez désormais vous connecter aux modules avec votre compte Firefox."
 
-#: src/olympia/accounts/views.py:121
+#: src/olympia/accounts/views.py:123
 msgid "Need help?"
 msgstr "Besoin d'aide ?"
 
-#: src/olympia/addons/buttons.py:180
+#: src/olympia/addons/buttons.py:177
 msgid "Download Now"
 msgstr "Télécharger maintenant"
 
-#: src/olympia/addons/buttons.py:182
+#: src/olympia/addons/buttons.py:179
 msgid "Download"
 msgstr "Téléchargement"
 
 #. L10n: please keep &nbsp; in the string so &rarr; does not wrap.
-#: src/olympia/addons/buttons.py:186
+#: src/olympia/addons/buttons.py:183
 msgid "Continue to Download&nbsp;&rarr;"
 msgstr "Continuer vers les téléchargements&nbsp;&rarr;"
 
-#: src/olympia/addons/buttons.py:202 src/olympia/addons/helpers.py:35
-#: src/olympia/addons/views.py:319
-#: src/olympia/addons/templates/addons/impala/details.html:114
-#: src/olympia/addons/templates/addons/impala/listing/items.html:17
-#: src/olympia/addons/templates/addons/mobile/home.html:40
-#: src/olympia/amo/templates/amo/side_nav.html:6
-#: src/olympia/amo/templates/amo/side_nav.html:10
-#: src/olympia/amo/templates/amo/site_nav.html:2
-#: src/olympia/amo/templates/amo/site_nav.html:55
-#: src/olympia/bandwagon/views.py:95 src/olympia/browse/views.py:54
-#: src/olympia/browse/views.py:68 src/olympia/browse/views.py:235
-#: src/olympia/browse/templates/browse/impala/category_landing.html:22
+#: src/olympia/addons/buttons.py:199 src/olympia/addons/helpers.py:35 src/olympia/addons/views.py:333 src/olympia/addons/templates/addons/impala/details.html:111
+#: src/olympia/addons/templates/addons/impala/listing/items.html:17 src/olympia/addons/templates/addons/mobile/home.html:40 src/olympia/amo/templates/amo/side_nav.html:6
+#: src/olympia/amo/templates/amo/side_nav.html:10 src/olympia/amo/templates/amo/site_nav.html:2 src/olympia/amo/templates/amo/site_nav.html:53 src/olympia/bandwagon/views.py:95
+#: src/olympia/browse/views.py:54 src/olympia/browse/views.py:68 src/olympia/browse/views.py:202 src/olympia/browse/templates/browse/impala/category_landing.html:22
 #: src/olympia/browse/templates/browse/personas/mobile/category_landing.html:26
 msgid "Featured"
 msgstr "En vedette"
 
-#: src/olympia/addons/buttons.py:221
+#: src/olympia/addons/buttons.py:218
 msgid "Add to {0}"
 msgstr "Ajouter à {0}"
 
@@ -124,11 +112,8 @@ msgstr[1] "Vous avez {0} étiquettes en trop."
 
 #: src/olympia/addons/forms.py:117
 #, python-format
-msgid ""
-"All tags must be %s characters or less after invalid characters are removed."
-msgstr ""
-"Toutes les étiquettes doivent contenir au plus %s caractères après retrait "
-"des invalides."
+msgid "All tags must be %s characters or less after invalid characters are removed."
+msgstr "Toutes les étiquettes doivent contenir au plus %s caractères après retrait des invalides."
 
 #: src/olympia/addons/forms.py:121
 msgid "All tags must be at least {0} character."
@@ -136,49 +121,39 @@ msgid_plural "All tags must be at least {0} characters."
 msgstr[0] "Toutes les étiquettes doivent avoir au moins {0} caractère."
 msgstr[1] "Toutes les étiquettes doivent avoir au moins {0} caractères."
 
-#: src/olympia/addons/forms.py:234
-msgid ""
-"Categories cannot be changed while your add-on is featured for this "
-"application."
-msgstr ""
-"Les catégories ne peuvent pas être changées lorsque votre module est mis en "
-"vedette pour cette application."
+#: src/olympia/addons/forms.py:238
+msgid "Categories cannot be changed while your add-on is featured for this application."
+msgstr "Les catégories ne peuvent pas être changées lorsque votre module est mis en vedette pour cette application."
 
 #. L10n: {0} is the number of categories.
-#: src/olympia/addons/forms.py:238
+#: src/olympia/addons/forms.py:242
 msgid "You can have only {0} category."
 msgid_plural "You can have only {0} categories."
 msgstr[0] "Vous ne pouvez avoir que {0} catégorie."
 msgstr[1] "Vous ne pouvez avoir que {0} catégories."
 
-#: src/olympia/addons/forms.py:246
-msgid ""
-"The miscellaneous category cannot be combined with additional categories."
+#: src/olympia/addons/forms.py:250
+msgid "The miscellaneous category cannot be combined with additional categories."
 msgstr "La catégorie divers ne peut pas être combinée avec d'autres."
 
-#: src/olympia/addons/forms.py:369
+#: src/olympia/addons/forms.py:374
 #, python-format
-msgid ""
-"Before changing your default locale you must have a name, summary, and "
-"description in that locale. You are missing %s."
-msgstr ""
-"Avant de changer votre locale par défaut vous devez avoir un nom, un résumé "
-"et une description dans cette dernière. Il vous manque %s."
+msgid "Before changing your default locale you must have a name, summary, and description in that locale. You are missing %s."
+msgstr "Avant de changer votre locale par défaut vous devez avoir un nom, un résumé et une description dans cette dernière. Il vous manque %s."
 
-#: src/olympia/addons/forms.py:484 src/olympia/addons/forms.py:575
+#: src/olympia/addons/forms.py:455 src/olympia/addons/forms.py:546
 msgid "A license must be selected."
 msgstr "Une licence doit être choisie."
 
-#: src/olympia/addons/forms.py:556
+#: src/olympia/addons/forms.py:527
 msgid "Give Your Theme a Name."
 msgstr "Donnez un nom à votre thème."
 
-#: src/olympia/addons/forms.py:562
-#: src/olympia/devhub/templates/devhub/personas/submit.html:53
+#: src/olympia/addons/forms.py:533 src/olympia/devhub/templates/devhub/personas/submit.html:53
 msgid "Describe your Theme."
 msgstr "Décrivez votre thème."
 
-#: src/olympia/addons/forms.py:704
+#: src/olympia/addons/forms.py:675
 msgid "Enter a new author's email address"
 msgstr "Entrez une addresse de courriel pour le nouvel auteur"
 
@@ -186,50 +161,39 @@ msgstr "Entrez une addresse de courriel pour le nouvel auteur"
 msgid "Not Reviewed"
 msgstr "Pas testé"
 
-#: src/olympia/addons/models.py:301
+#: src/olympia/addons/models.py:298
 msgid "Users have the option of contributing more or less than this amount."
-msgstr ""
-"Les utilisateurs ont la possibilité d'une contribution plus ou moins "
-"importante que celle-ci."
+msgstr "Les utilisateurs ont la possibilité d'une contribution plus ou moins importante que celle-ci."
 
-#: src/olympia/addons/models.py:309
-msgid ""
-"Users will always be asked in the Add-ons Manager (Firefox 4 and above)"
+#: src/olympia/addons/models.py:306
+msgid "Users will always be asked in the Add-ons Manager (Firefox 4 and above). Only applies to desktop."
 msgstr ""
-"Les utilisateurs seront toujours questionnés dans le gestionnaire de modules"
-" complémentaires (Firefox 4 et supérieur)"
 
 # Column name in a table.
-#: src/olympia/addons/models.py:1804
-#: src/olympia/addons/templates/addons/details_box.html:55
-#: src/olympia/devhub/templates/devhub/index.html:92
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:102
+#: src/olympia/addons/models.py:1802 src/olympia/addons/templates/addons/details_box.html:55 src/olympia/devhub/templates/devhub/index.html:92
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:89
 msgid "Listed"
 msgstr "Listé"
 
-#: src/olympia/addons/views.py:320
-#: src/olympia/browse/templates/browse/personas/mobile/category_landing.html:27
+#: src/olympia/addons/views.py:334 src/olympia/browse/templates/browse/personas/mobile/category_landing.html:27
 msgid "Popular"
 msgstr "Populaires"
 
-#: src/olympia/addons/views.py:321 src/olympia/browse/views.py:238
-#: src/olympia/browse/views.py:280 src/olympia/browse/views.py:482
+#: src/olympia/addons/views.py:335 src/olympia/browse/views.py:205 src/olympia/browse/views.py:247 src/olympia/browse/views.py:449
 msgid "Recently Added"
 msgstr "Ajouts récents"
 
-#: src/olympia/addons/views.py:322 src/olympia/bandwagon/views.py:99
-#: src/olympia/browse/views.py:60 src/olympia/browse/views.py:71
-#: src/olympia/search/forms.py:16 src/olympia/search/forms.py:91
+#: src/olympia/addons/views.py:336 src/olympia/bandwagon/views.py:99 src/olympia/browse/views.py:60 src/olympia/browse/views.py:71 src/olympia/search/forms.py:16 src/olympia/search/forms.py:91
 msgid "Recently Updated"
 msgstr "Mises à jour récentes"
 
-#. l10n: {0} is the addon name
 # %1 is an add-on name.
-#: src/olympia/addons/views.py:520
+#. l10n: {0} is the addon name
+#: src/olympia/addons/views.py:534
 msgid "Contribution for {0}"
 msgstr "Contribution pour {0}"
 
-#: src/olympia/addons/views.py:613
+#: src/olympia/addons/views.py:627
 msgid "Abuse reported."
 msgstr "Abus rapporté."
 
@@ -237,119 +201,70 @@ msgstr "Abus rapporté."
 msgid "My add-on doesn't fit into any of the categories"
 msgstr "Mon module ne correspond à aucune de ces catégories"
 
-#: src/olympia/addons/templates/addons/button.html:27
-#: src/olympia/addons/templates/addons/impala/button.html:11
-#: src/olympia/addons/templates/addons/mobile/button.html:11
+#: src/olympia/addons/templates/addons/button.html:27 src/olympia/addons/templates/addons/impala/button.html:11 src/olympia/addons/templates/addons/mobile/button.html:11
 msgid "No compatible versions"
 msgstr "Pas de version compatible"
 
-#: src/olympia/addons/templates/addons/button.html:35
-#: src/olympia/addons/templates/addons/impala/button.html:19
+#: src/olympia/addons/templates/addons/button.html:35 src/olympia/addons/templates/addons/impala/button.html:19
 msgid "Added to Mobile"
 msgstr "Ajouté à Mobile"
 
-#: src/olympia/addons/templates/addons/button.html:37
-#: src/olympia/addons/templates/addons/impala/button.html:21
+#: src/olympia/addons/templates/addons/button.html:37 src/olympia/addons/templates/addons/impala/button.html:21
 msgid "Add to Mobile"
 msgstr "Ajouter à Mobile"
 
 #. {0} is a platform name like Windows or Mac OS X.
-#: src/olympia/addons/templates/addons/button.html:66
-#: src/olympia/addons/templates/addons/includes/install_button.html:19
+#: src/olympia/addons/templates/addons/button.html:66 src/olympia/addons/templates/addons/includes/install_button.html:19
 msgid "for {0}"
 msgstr "Pour {0}"
 
-#: src/olympia/addons/templates/addons/button.html:82
-#: src/olympia/addons/templates/addons/mobile/button.html:23
+#: src/olympia/addons/templates/addons/button.html:82 src/olympia/addons/templates/addons/mobile/button.html:23
 msgid "View privacy policy"
 msgstr "Afficher la politique de confidentialité"
 
-#: src/olympia/addons/templates/addons/button.html:87
-#: src/olympia/addons/templates/addons/details_box.html:133
-#: src/olympia/addons/templates/addons/mobile/button.html:28
+#: src/olympia/addons/templates/addons/button.html:87 src/olympia/addons/templates/addons/details_box.html:133 src/olympia/addons/templates/addons/mobile/button.html:28
 #: src/olympia/discovery/templates/discovery/addons/detail.html:28
 msgid "View End-User License Agreement"
-msgstr ""
-"                  Voir les conditions générales d'utilisation"
-"                "
+msgstr "                  Voir les conditions générales d'utilisation                "
 
-#: src/olympia/addons/templates/addons/button.html:92
-#: src/olympia/addons/templates/addons/impala/button.html:54
+#: src/olympia/addons/templates/addons/button.html:92 src/olympia/addons/templates/addons/impala/button.html:54
 #, python-format
-msgid ""
-"This add-on has not been reviewed by Mozilla. <a href=\"%(url)s\">Learn "
-"more</a>"
-msgstr ""
-"Ce module n'a pas été vérifié par Mozilla. <a href=\"%(url)s\">En savoir "
-"plus</a>"
+msgid "This add-on has not been reviewed by Mozilla. <a href=\"%(url)s\">Learn more</a>"
+msgstr "Ce module n'a pas été vérifié par Mozilla. <a href=\"%(url)s\">En savoir plus</a>"
 
-#: src/olympia/addons/templates/addons/button.html:97
-#: src/olympia/addons/templates/addons/impala/button.html:60
+#: src/olympia/addons/templates/addons/button.html:97 src/olympia/addons/templates/addons/impala/button.html:60
 #, python-format
-msgid ""
-"This add-on has been preliminarily reviewed by Mozilla. <a "
-"href=\"%(url)s\">Learn more</a>"
-msgstr ""
-"Ce module a été partiellement vérifié par Mozilla. <a href=\"%(url)s\">En "
-"savoir plus</a>"
+msgid "This add-on has been preliminarily reviewed by Mozilla. <a href=\"%(url)s\">Learn more</a>"
+msgstr "Ce module a été partiellement vérifié par Mozilla. <a href=\"%(url)s\">En savoir plus</a>"
 
-#: src/olympia/addons/templates/addons/contribution.html:11
-#: src/olympia/addons/templates/addons/impala/developers.html:44
-msgid ""
-"The developer of this add-on asks that you help support its continued "
-"development by making a small contribution."
-msgstr ""
-"Le développeur de ce module vous demande de le soutenir par une modeste "
-"contribution afin de pouvoir poursuivre le développement."
+#: src/olympia/addons/templates/addons/contribution.html:11 src/olympia/addons/templates/addons/impala/developers.html:44
+msgid "The developer of this add-on asks that you help support its continued development by making a small contribution."
+msgstr "Le développeur de ce module vous demande de le soutenir par une modeste contribution afin de pouvoir poursuivre le développement."
 
 #: src/olympia/addons/templates/addons/contribution.html:14
 #, python-format
-msgid ""
-"The developer of this add-on asks that you show your support by making a "
-"donation to the <a href=\"%(charity_url)s\">%(charity_name)s</a>."
-msgstr ""
-"Le développeur de ce module demande que vous affichiez votre soutien en "
-"faisant un don à <a href=\"%(charity_url)s\">%(charity_name)s</a>."
+msgid "The developer of this add-on asks that you show your support by making a donation to the <a href=\"%(charity_url)s\">%(charity_name)s</a>."
+msgstr "Le développeur de ce module demande que vous affichiez votre soutien en faisant un don à <a href=\"%(charity_url)s\">%(charity_name)s</a>."
 
 #: src/olympia/addons/templates/addons/contribution.html:19
 #, python-format
-msgid ""
-"The developer of this add-on asks that you show your support by making a "
-"small contribution to <a href=\"%(charity_url)s\">%(charity_name)s</a>."
-msgstr ""
-"Le développeur de ce module demande que vous affichiez votre soutien en "
-"faisant une petite contribution à <a "
-"href=\"%(charity_url)s\">%(charity_name)s</a>."
+msgid "The developer of this add-on asks that you show your support by making a small contribution to <a href=\"%(charity_url)s\">%(charity_name)s</a>."
+msgstr "Le développeur de ce module demande que vous affichiez votre soutien en faisant une petite contribution à <a href=\"%(charity_url)s\">%(charity_name)s</a>."
 
-#: src/olympia/addons/templates/addons/contribution.html:30
-#: src/olympia/addons/templates/addons/impala/contribution.html:18
-#: src/olympia/templates/menu_links.html:25
+#: src/olympia/addons/templates/addons/contribution.html:30 src/olympia/addons/templates/addons/impala/contribution.html:18 src/olympia/templates/menu_links.html:25
 msgid "Contribute"
 msgstr "Contribuer"
 
-#. Click Contribute button OR Install button
 # This is a separator between the graphical [contribute] button and the
 # graphical [download now] button
-#: src/olympia/addons/templates/addons/contribution.html:34
-#: src/olympia/addons/templates/addons/report_abuse.html:26
-#: src/olympia/addons/templates/addons/impala/contribution.html:32
-#: src/olympia/devhub/templates/devhub/addons/ajax_compat_update.html:36
-#: src/olympia/devhub/templates/devhub/addons/profile.html:44
-#: src/olympia/devhub/templates/devhub/addons/edit/admin.html:101
-#: src/olympia/devhub/templates/devhub/addons/edit/basic.html:152
-#: src/olympia/devhub/templates/devhub/addons/edit/details.html:85
-#: src/olympia/devhub/templates/devhub/addons/edit/support.html:67
-#: src/olympia/devhub/templates/devhub/addons/edit/technical.html:166
-#: src/olympia/devhub/templates/devhub/addons/forms_shared/media.html:149
-#: src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:44
-#: src/olympia/devhub/templates/devhub/versions/add_file_modal.html:78
-#: src/olympia/devhub/templates/devhub/versions/edit.html:139
-#: src/olympia/devhub/templates/devhub/versions/list.html:242
-#: src/olympia/devhub/templates/devhub/versions/list.html:276
-#: src/olympia/devhub/templates/devhub/versions/list.html:317
-#: src/olympia/devhub/templates/devhub/versions/list.html:351
-#: src/olympia/reviews/templates/reviews/edit_review.html:16
-#: src/olympia/translations/templates/translations/trans-menu.html:50
+#. Click Contribute button OR Install button
+#: src/olympia/addons/templates/addons/contribution.html:34 src/olympia/addons/templates/addons/report_abuse.html:26 src/olympia/addons/templates/addons/impala/contribution.html:32
+#: src/olympia/devhub/templates/devhub/addons/ajax_compat_update.html:36 src/olympia/devhub/templates/devhub/addons/profile.html:44 src/olympia/devhub/templates/devhub/addons/edit/admin.html:101
+#: src/olympia/devhub/templates/devhub/addons/edit/basic.html:152 src/olympia/devhub/templates/devhub/addons/edit/details.html:85 src/olympia/devhub/templates/devhub/addons/edit/support.html:67
+#: src/olympia/devhub/templates/devhub/addons/edit/technical.html:166 src/olympia/devhub/templates/devhub/addons/forms_shared/media.html:149
+#: src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:43 src/olympia/devhub/templates/devhub/versions/add_file_modal.html:58 src/olympia/devhub/templates/devhub/versions/edit.html:139
+#: src/olympia/devhub/templates/devhub/versions/list.html:239 src/olympia/devhub/templates/devhub/versions/list.html:281 src/olympia/devhub/templates/devhub/versions/list.html:315
+#: src/olympia/devhub/templates/devhub/versions/list.html:349 src/olympia/reviews/templates/reviews/edit_review.html:16 src/olympia/translations/templates/translations/trans-menu.html:50
 #: src/olympia/translations/templates/translations/trans-menu.html:62
 msgid "or"
 msgstr "ou"
@@ -358,41 +273,23 @@ msgstr "ou"
 msgid "Suggested Contribution: {0}"
 msgstr "Contribution suggérée : {0}"
 
-#: src/olympia/addons/templates/addons/contribution.html:48
-#: src/olympia/amo/templates/amo/recaptcha.html:5
-#: src/olympia/versions/templates/versions/version.html:52
+#: src/olympia/addons/templates/addons/contribution.html:48 src/olympia/amo/templates/amo/recaptcha.html:5 src/olympia/versions/templates/versions/version.html:52
 msgid "What's this?"
 msgstr "Qu'est-ce que c'est ?"
 
 #: src/olympia/addons/templates/addons/contribution.html:63
 #, python-format
-msgid ""
-"The developer of this add-on would like you to consider making a donation to"
-" the <a href=\"%(charity_url)s\">%(charity_name)s</a> if you enjoy using it."
-msgstr ""
-"Le développeur de ce module souhaiterait que vous fassiez un don à <a "
-"href=\"%(charity_url)s\">%(charity_name)s</a> si vous appréciez son module."
+msgid "The developer of this add-on would like you to consider making a donation to the <a href=\"%(charity_url)s\">%(charity_name)s</a> if you enjoy using it."
+msgstr "Le développeur de ce module souhaiterait que vous fassiez un don à <a href=\"%(charity_url)s\">%(charity_name)s</a> si vous appréciez son module."
 
 #: src/olympia/addons/templates/addons/contribution.html:69
 #, python-format
-msgid ""
-"The developer of this add-on would like you to consider making a small "
-"contribution to <a href=\"%(charity_url)s\">%(charity_name)s</a> if you "
-"enjoy using it."
-msgstr ""
-"Le développeur de ce module souhaiterais que vous fassiez une petite "
-"contribution à <a href=\"%(charity_url)s\">%(charity_name)s</a> si vous "
-"appréciez son module."
+msgid "The developer of this add-on would like you to consider making a small contribution to <a href=\"%(charity_url)s\">%(charity_name)s</a> if you enjoy using it."
+msgstr "Le développeur de ce module souhaiterais que vous fassiez une petite contribution à <a href=\"%(charity_url)s\">%(charity_name)s</a> si vous appréciez son module."
 
 #: src/olympia/addons/templates/addons/contribution.html:76
-msgid ""
-"Mozilla is committed to supporting a vibrant and healthy developer "
-"ecosystem. Your optional contribution helps sustain further development of "
-"this add-on."
-msgstr ""
-"Mozilla s'efforce d'aider un écosystème développeur dynamique et stimulant. "
-"Votre contribution optionnelle aide à soutenir de futurs développements sur "
-"ce module."
+msgid "Mozilla is committed to supporting a vibrant and healthy developer ecosystem. Your optional contribution helps sustain further development of this add-on."
+msgstr "Mozilla s'efforce d'aider un écosystème développeur dynamique et stimulant. Votre contribution optionnelle aide à soutenir de futurs développements sur ce module."
 
 #: src/olympia/addons/templates/addons/contributions_lightbox.html:5
 msgid "Make a Contribution"
@@ -400,35 +297,21 @@ msgstr "Faire une contribution"
 
 #: src/olympia/addons/templates/addons/contributions_lightbox.html:9
 #, python-format
-msgid ""
-"Help support the continued development of <strong>%(addon_name)s</strong> by"
-" making a small contribution through <a href=\"%(paypal_url)s\">PayPal</a>."
-msgstr ""
-"Participez au développement continu de <strong>%(addon_name)s</strong> en "
-"faisant une petite contribution via <a href=\"%(paypal_url)s\">PayPal</a>."
+msgid "Help support the continued development of <strong>%(addon_name)s</strong> by making a small contribution through <a href=\"%(paypal_url)s\">PayPal</a>."
+msgstr "Participez au développement continu de <strong>%(addon_name)s</strong> en faisant une petite contribution via <a href=\"%(paypal_url)s\">PayPal</a>."
 
 #: src/olympia/addons/templates/addons/contributions_lightbox.html:15
 #, python-format
-msgid ""
-"To show your support for <b>%(addon_name)s</b>, the developer asks that you "
-"make a donation to the <a href=\"%(charity_url)s\">%(charity_name)s</a> "
-"through <a href=\"%(paypal_url)s\">PayPal</a>."
-msgstr ""
-"Pour montrer votre soutient à <b>%(addon_name)s</b>, le développeur vous "
-"demande de faire un don à <a href=\"%(charity_url)s\">%(charity_name)s</a> "
-"via <a href=\"%(paypal_url)s\">Paypal</a>."
+msgid "To show your support for <b>%(addon_name)s</b>, the developer asks that you make a donation to the <a href=\"%(charity_url)s\">%(charity_name)s</a> through <a href=\"%(paypal_url)s\">PayPal</a>."
+msgstr "Pour montrer votre soutient à <b>%(addon_name)s</b>, le développeur vous demande de faire un don à <a href=\"%(charity_url)s\">%(charity_name)s</a> via <a href=\"%(paypal_url)s\">Paypal</a>."
 
 #: src/olympia/addons/templates/addons/contributions_lightbox.html:21
 #, python-format
 msgid ""
-"To show your support for <b>%(addon_name)s</b>, the developer asks that you "
-"make a small contribution to <a "
-"href=\"%(charity_url)s\">%(charity_name)s</a> through <a "
+"To show your support for <b>%(addon_name)s</b>, the developer asks that you make a small contribution to <a href=\"%(charity_url)s\">%(charity_name)s</a> through <a "
 "href=\"%(paypal_url)s\">PayPal</a>."
 msgstr ""
-"Pour montrer votre soutient à <b>%(addon_name)s</b>, le développeur vous "
-"demande de faire une petite contribution à <a "
-"href=\"%(charity_url)s\">%(charity_name)s</a> via <a "
+"Pour montrer votre soutient à <b>%(addon_name)s</b>, le développeur vous demande de faire une petite contribution à <a href=\"%(charity_url)s\">%(charity_name)s</a> via <a "
 "href=\"%(paypal_url)s\">Paypal</a>."
 
 #: src/olympia/addons/templates/addons/contributions_lightbox.html:30
@@ -452,8 +335,7 @@ msgstr "Le montant de la contribution doit être un nombre."
 msgid "A one-time suggested contribution of {0}"
 msgstr "Une suggestion de contribution unique à hauteur de {0}"
 
-#. {0} is a currency symbol (e.g., $),                    {1} is an amount
-#. input
+#. {0} is a currency symbol (e.g., $),                    {1} is an amount input
 #. field
 #: src/olympia/addons/templates/addons/contributions_lightbox.html:64
 msgid "A one-time contribution of {0} {1}"
@@ -463,11 +345,8 @@ msgstr "Une contribution unique de {0} {1}"
 msgid "Leave a comment or request with your contribution."
 msgstr "Laissez un commentaire ou une requête avec votre contribution."
 
-#: src/olympia/addons/templates/addons/contributions_lightbox.html:74
-#: src/olympia/bandwagon/templates/bandwagon/ajax_new.html:20
-#: src/olympia/bandwagon/templates/bandwagon/includes/addedit.html:37
-#: src/olympia/reviews/templates/reviews/mobile/add_form.html:13
-#: src/olympia/templates/includes/forms.html:10
+#: src/olympia/addons/templates/addons/contributions_lightbox.html:74 src/olympia/bandwagon/templates/bandwagon/ajax_new.html:20 src/olympia/bandwagon/templates/bandwagon/includes/addedit.html:37
+#: src/olympia/reviews/templates/reviews/mobile/add_form.html:13 src/olympia/templates/includes/forms.html:10
 msgid "(optional)"
 msgstr "(facultatif)"
 
@@ -487,36 +366,27 @@ msgstr "Non merci"
 msgid "Contribution made, thank you."
 msgstr "Contribution réalisée, merci."
 
-#: src/olympia/addons/templates/addons/details_box.html:10
-#: src/olympia/discovery/templates/discovery/addons/detail.html:19
+#: src/olympia/addons/templates/addons/details_box.html:10 src/olympia/discovery/templates/discovery/addons/detail.html:19
 msgid "No restart required"
 msgstr "Pas de redémarrage nécessaire"
 
 #. This is a caption for a table. {0} is an add-on name.
-#: src/olympia/addons/templates/addons/details_box.html:26
-#: src/olympia/addons/templates/addons/includes/persona.html:9
+#: src/olympia/addons/templates/addons/details_box.html:26 src/olympia/addons/templates/addons/includes/persona.html:9
 msgid "Add-on Information for {0}"
 msgstr "Information pour le module {0}"
 
-#: src/olympia/addons/templates/addons/details_box.html:30
-#: src/olympia/addons/templates/addons/persona_detail_table.html:3
-#: src/olympia/addons/templates/addons/mobile/details.html:63
-#: src/olympia/addons/templates/addons/mobile/persona_detail_table.html:7
-#: src/olympia/browse/views.py:459 src/olympia/devhub/views.py:75
+#: src/olympia/addons/templates/addons/details_box.html:30 src/olympia/addons/templates/addons/persona_detail_table.html:3 src/olympia/addons/templates/addons/mobile/details.html:63
+#: src/olympia/addons/templates/addons/mobile/persona_detail_table.html:7 src/olympia/browse/views.py:426 src/olympia/devhub/views.py:74
 msgid "Updated"
 msgstr "Mis à jour"
 
-#: src/olympia/addons/templates/addons/details_box.html:38
-#: src/olympia/addons/templates/addons/mobile/details.html:71
-#: src/olympia/devhub/templates/devhub/addons/edit/support.html:43
+#: src/olympia/addons/templates/addons/details_box.html:38 src/olympia/addons/templates/addons/mobile/details.html:71 src/olympia/devhub/templates/devhub/addons/edit/support.html:43
 #: src/olympia/discovery/templates/discovery/addons/detail.html:77
 msgid "Website"
 msgstr "Site Web"
 
 #. This refers to this version's compatible applications, such as Firefox 8.0
-#: src/olympia/addons/templates/addons/details_box.html:47
-#: src/olympia/addons/templates/addons/mobile/details.html:80
-#: src/olympia/search/templates/search/results.html:72
+#: src/olympia/addons/templates/addons/details_box.html:47 src/olympia/addons/templates/addons/mobile/details.html:80 src/olympia/search/templates/search/results.html:72
 #: src/olympia/versions/templates/versions/version.html:21
 msgid "Works with"
 msgstr "Fonctionne avec"
@@ -525,45 +395,30 @@ msgstr "Fonctionne avec"
 msgid "Visibility"
 msgstr "Visibilité"
 
-#: src/olympia/addons/templates/addons/details_box.html:57
-#: src/olympia/devhub/templates/devhub/index.html:94
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:104
+#: src/olympia/addons/templates/addons/details_box.html:57 src/olympia/devhub/templates/devhub/index.html:94 src/olympia/devhub/templates/devhub/includes/addon_details.html:91
 msgid "Hidden"
 msgstr "Caché"
 
-#: src/olympia/addons/templates/addons/details_box.html:59
-#: src/olympia/devhub/templates/devhub/index.html:96
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:106
+#: src/olympia/addons/templates/addons/details_box.html:59 src/olympia/devhub/templates/devhub/index.html:96 src/olympia/devhub/templates/devhub/includes/addon_details.html:93
 msgid "Unlisted"
 msgstr "Hors de la liste"
 
-#: src/olympia/addons/templates/addons/details_box.html:67
-#: src/olympia/devhub/templates/devhub/addons/edit/technical.html:44
+#: src/olympia/addons/templates/addons/details_box.html:67 src/olympia/devhub/templates/devhub/addons/edit/technical.html:44
 msgid "Required Add-ons"
 msgstr "Modules nécessaires"
 
-#: src/olympia/addons/templates/addons/details_box.html:81
-#: src/olympia/addons/templates/addons/persona_detail_table.html:15
-#: src/olympia/browse/views.py:462 src/olympia/devhub/views.py:78
-#: src/olympia/devhub/views.py:85
-#: src/olympia/discovery/templates/discovery/addons/detail.html:57
-#: src/olympia/reviews/forms.py:62
-#: src/olympia/reviews/templates/reviews/add.html:57
+#: src/olympia/addons/templates/addons/details_box.html:81 src/olympia/addons/templates/addons/persona_detail_table.html:15 src/olympia/browse/views.py:429 src/olympia/devhub/views.py:77
+#: src/olympia/devhub/views.py:84 src/olympia/discovery/templates/discovery/addons/detail.html:57 src/olympia/reviews/forms.py:62 src/olympia/reviews/templates/reviews/add.html:57
 #: src/olympia/reviews/templates/reviews/mobile/review_list.html:18
 msgid "Rating"
 msgstr "Appréciation"
 
-#: src/olympia/addons/templates/addons/details_box.html:85
-#: src/olympia/browse/views.py:461 src/olympia/devhub/views.py:77
-#: src/olympia/devhub/views.py:84
-#: src/olympia/stats/templates/stats/addon_report_menu.html:8
-#: src/olympia/stats/templates/stats/collection_report_menu.html:18
+#: src/olympia/addons/templates/addons/details_box.html:85 src/olympia/browse/views.py:428 src/olympia/devhub/views.py:76 src/olympia/devhub/views.py:83
+#: src/olympia/stats/templates/stats/addon_report_menu.html:8 src/olympia/stats/templates/stats/collection_report_menu.html:18
 msgid "Downloads"
 msgstr "Téléchargements"
 
-#: src/olympia/addons/templates/addons/details_box.html:91
-#: src/olympia/addons/templates/addons/details_box.html:103
-#: src/olympia/devhub/templates/devhub/addons/listing/item_actions_theme.html:17
+#: src/olympia/addons/templates/addons/details_box.html:91 src/olympia/addons/templates/addons/details_box.html:103 src/olympia/devhub/templates/devhub/addons/listing/item_actions_theme.html:17
 #: src/olympia/devhub/templates/devhub/personas/edit.html:60
 msgid "View Statistics"
 msgstr "Statistiques"
@@ -577,18 +432,13 @@ msgid "Abuse Reports"
 msgstr "Rapporter un abus"
 
 #. The Privacy Policy for this add-on.
-#: src/olympia/addons/templates/addons/details_box.html:121
-#: src/olympia/addons/templates/addons/privacy.html:19
-#: src/olympia/addons/templates/addons/privacy.html:23
-#: src/olympia/addons/templates/addons/impala/button.html:43
-#: src/olympia/addons/templates/addons/impala/details.html:307
-#: src/olympia/devhub/templates/devhub/includes/policy_form.html:20
+#: src/olympia/addons/templates/addons/details_box.html:121 src/olympia/addons/templates/addons/privacy.html:19 src/olympia/addons/templates/addons/privacy.html:23
+#: src/olympia/addons/templates/addons/impala/button.html:43 src/olympia/addons/templates/addons/impala/details.html:312 src/olympia/devhub/templates/devhub/includes/policy_form.html:23
 #: src/olympia/templates/mobile/base_addons.html:87
 msgid "Privacy Policy"
 msgstr "Politique de confidentialité"
 
-#: src/olympia/addons/templates/addons/details_box.html:124
-#: src/olympia/discovery/templates/discovery/addons/detail.html:24
+#: src/olympia/addons/templates/addons/details_box.html:124 src/olympia/discovery/templates/discovery/addons/detail.html:24
 msgid "View Privacy Policy"
 msgstr "Voir la politique de vie privée"
 
@@ -596,8 +446,7 @@ msgstr "Voir la politique de vie privée"
 msgid "EULA"
 msgstr "CLUF"
 
-#: src/olympia/addons/templates/addons/details_box.html:171
-#: src/olympia/addons/templates/addons/details_box.html:231
+#: src/olympia/addons/templates/addons/details_box.html:171 src/olympia/addons/templates/addons/details_box.html:231
 msgid "More about this add-on"
 msgstr "En savoir plus sur ce module"
 
@@ -605,27 +454,21 @@ msgstr "En savoir plus sur ce module"
 msgid "Image Gallery"
 msgstr "Galerie d'images"
 
-#: src/olympia/addons/templates/addons/details_box.html:190
-#: src/olympia/devhub/templates/devhub/addons/edit/technical.html:21
+#: src/olympia/addons/templates/addons/details_box.html:190 src/olympia/devhub/templates/devhub/addons/edit/technical.html:21
 msgid "Developer Comments"
 msgstr "Commentaires du développeur"
 
-#: src/olympia/addons/templates/addons/details_box.html:199
-#: src/olympia/addons/templates/addons/impala/details.html:259
+#: src/olympia/addons/templates/addons/details_box.html:199 src/olympia/addons/templates/addons/impala/details.html:264
 msgid "Development Channel"
 msgstr "Canal développement"
 
-#: src/olympia/addons/templates/addons/details_box.html:202
-#: src/olympia/addons/templates/addons/mobile/details.html:124
+#: src/olympia/addons/templates/addons/details_box.html:202 src/olympia/addons/templates/addons/mobile/details.html:124
 msgid ""
-"The Development Channel lets you test an experimental new version of this "
-"add-on before it's released to the general public. Once you install the "
-"development version, you will continue to get updates from this channel."
+"The Development Channel lets you test an experimental new version of this add-on before it's released to the general public. Once you install the development version, you will continue to get "
+"updates from this channel."
 msgstr ""
-"Le canal développement vous permet de tester une version expérimentale de ce"
-" module avant qu'il ne soit distribué à tout le monde. Une fois une version "
-"de développement installée, vous continuerez à obtenir les mises à jour de "
-"ce canal."
+"Le canal développement vous permet de tester une version expérimentale de ce module avant qu'il ne soit distribué à tout le monde. Une fois une version de développement installée, vous continuerez "
+"à obtenir les mises à jour de ce canal."
 
 #: src/olympia/addons/templates/addons/details_box.html:207
 msgid "Install development version"
@@ -633,78 +476,52 @@ msgstr "Installer la version de développement"
 
 #: src/olympia/addons/templates/addons/details_box.html:211
 msgid ""
-"<strong>Caution:</strong> Development versions of this add-on have not been "
-"reviewed by Mozilla. Once you install a development version you will "
-"continue to receive development updates from this developer. To stop "
-"receiving development updates, reinstall the default version from the link "
-"above."
+"<strong>Caution:</strong> Development versions of this add-on have not been reviewed by Mozilla. Once you install a development version you will continue to receive development updates from this "
+"developer. To stop receiving development updates, reinstall the default version from the link above."
 msgstr ""
-"<strong>Attention :</strong> Les versions de développement de ce module "
-"n'ont pas été vérifiées par Mozilla. Une fois la version de développement "
-"installée, vous continuerez à recevoir des mises à jour de développement de "
-"la part de ce développeur. Pour cesser, réinstaller la version par défaut du"
-" lien ci-dessous."
+"<strong>Attention :</strong> Les versions de développement de ce module n'ont pas été vérifiées par Mozilla. Une fois la version de développement installée, vous continuerez à recevoir des mises à "
+"jour de développement de la part de ce développeur. Pour cesser, réinstaller la version par défaut du lien ci-dessous."
 
-#: src/olympia/addons/templates/addons/details_box.html:220
-#: src/olympia/addons/templates/addons/impala/details.html:278
+#: src/olympia/addons/templates/addons/details_box.html:220 src/olympia/addons/templates/addons/impala/details.html:283
 msgid "Version {0}:"
 msgstr "Version {0} :"
 
 #: src/olympia/addons/templates/addons/details_box.html:234
-msgid "Nothing to see here!  The developer did not include any details."
-msgstr ""
-"Pas d'autres précisions disponibles. Le développeur n'a pas donné de "
-"détails."
+msgid "Nothing to see here! The developer did not include any details."
+msgstr "Rien à voir ici ! Le développeur n'a donné aucun détail !"
 
-#: src/olympia/addons/templates/addons/details_box.html:251
-#: src/olympia/devhub/templates/devhub/versions/edit.html:73
-#: src/olympia/editors/templates/editors/review.html:98
+#: src/olympia/addons/templates/addons/details_box.html:251 src/olympia/devhub/templates/devhub/versions/edit.html:73 src/olympia/editors/templates/editors/review.html:98
 msgid "Version Notes"
 msgstr "Notes de version"
 
 #. {0} is the name of the add-on.
 #. {0} is the name of the add-on
-#: src/olympia/addons/templates/addons/eula.html:6
-#: src/olympia/discovery/templates/discovery/addons/eula.html:5
+#: src/olympia/addons/templates/addons/eula.html:6 src/olympia/discovery/templates/discovery/addons/eula.html:5
 msgid "End-User License Agreement for {0}"
 msgstr "Contrat de Licence pour l'Utilisateur Final du module {0}"
 
-#: src/olympia/addons/templates/addons/eula.html:17
-#: src/olympia/addons/templates/addons/eula.html:21
-#: src/olympia/addons/templates/addons/impala/button.html:48
-#: src/olympia/addons/templates/addons/impala/details.html:316
-#: src/olympia/devhub/templates/devhub/includes/policy_form.html:3
-#: src/olympia/discovery/templates/discovery/addons/eula.html:11
+#: src/olympia/addons/templates/addons/eula.html:17 src/olympia/addons/templates/addons/eula.html:21 src/olympia/addons/templates/addons/impala/button.html:48
+#: src/olympia/addons/templates/addons/impala/details.html:321 src/olympia/devhub/templates/devhub/includes/policy_form.html:3 src/olympia/discovery/templates/discovery/addons/eula.html:11
 msgid "End-User License Agreement"
 msgstr "Contrat de Licence utilisateur Final"
 
-#: src/olympia/addons/templates/addons/eula.html:23
-#: src/olympia/discovery/templates/discovery/addons/eula.html:13
+#: src/olympia/addons/templates/addons/eula.html:23 src/olympia/discovery/templates/discovery/addons/eula.html:13
 #, python-format
-msgid ""
-"%(addon_name)s requires that you accept the following End-User License "
-"Agreement before installation can proceed:"
-msgstr ""
-"Le module %(addon_name)s nécessite que vous acceptiez le Contrat de Licence "
-"pour l'Utilisateur Final suivant avant de procéder à l'installation :"
+msgid "%(addon_name)s requires that you accept the following End-User License Agreement before installation can proceed:"
+msgstr "Le module %(addon_name)s nécessite que vous acceptiez le Contrat de Licence pour l'Utilisateur Final suivant avant de procéder à l'installation :"
 
-#: src/olympia/addons/templates/addons/eula.html:34
-#: src/olympia/addons/templates/addons/privacy.html:26
+#: src/olympia/addons/templates/addons/eula.html:34 src/olympia/addons/templates/addons/privacy.html:26
 msgid "Back to {0}…"
 msgstr "Revenir à {0} …"
 
 # {0} is the application the user is browsing.  Examples:  Thunderbird,
 # Firefox,
 # Sunbird
-#: src/olympia/addons/templates/addons/home.html:3
-#: src/olympia/addons/templates/addons/mobile/home.html:3
-#: src/olympia/amo/helpers.py:235
+#: src/olympia/addons/templates/addons/home.html:3 src/olympia/addons/templates/addons/mobile/home.html:3 src/olympia/amo/helpers.py:235
 msgid "Add-ons for {0}"
 msgstr "Modules pour {0}"
 
-#: src/olympia/addons/templates/addons/home.html:10
-#: src/olympia/addons/templates/addons/home.html:51
-#: src/olympia/browse/templates/browse/impala/base_listing.html:11
+#: src/olympia/addons/templates/addons/home.html:10 src/olympia/addons/templates/addons/home.html:53 src/olympia/browse/templates/browse/impala/base_listing.html:11
 msgid "Featured Extensions"
 msgstr "Extensions vedettes"
 
@@ -712,69 +529,48 @@ msgstr "Extensions vedettes"
 msgid "Popular Extensions"
 msgstr "Extensions populaires"
 
-#: src/olympia/addons/templates/addons/home.html:42
-#: src/olympia/amo/templates/amo/side_nav.html:3
-#: src/olympia/amo/templates/amo/side_nav.html:11
-#: src/olympia/amo/templates/amo/site_nav.html:3
-#: src/olympia/amo/templates/amo/site_nav.html:25
-#: src/olympia/browse/views.py:236 src/olympia/browse/views.py:281
-#: src/olympia/browse/views.py:481
+#: src/olympia/addons/templates/addons/home.html:44 src/olympia/amo/templates/amo/side_nav.html:3 src/olympia/amo/templates/amo/side_nav.html:11 src/olympia/amo/templates/amo/site_nav.html:3
+#: src/olympia/amo/templates/amo/site_nav.html:25 src/olympia/browse/views.py:203 src/olympia/browse/views.py:248 src/olympia/browse/views.py:448
 msgid "Most Popular"
 msgstr "Les plus populaires"
 
-#: src/olympia/addons/templates/addons/home.html:43
+#: src/olympia/addons/templates/addons/home.html:45
 msgid "All »"
 msgstr "Tous »"
 
-#: src/olympia/addons/templates/addons/home.html:52
-#: src/olympia/addons/templates/addons/home.html:61
-#: src/olympia/addons/templates/addons/home.html:70
-#: src/olympia/addons/templates/addons/home.html:78
+#: src/olympia/addons/templates/addons/home.html:54 src/olympia/addons/templates/addons/home.html:63 src/olympia/addons/templates/addons/home.html:72 src/olympia/addons/templates/addons/home.html:80
 #: src/olympia/browse/templates/browse/impala/category_landing.html:36
 msgid "See all »"
 msgstr "Tout voir »"
 
-#: src/olympia/addons/templates/addons/home.html:60
+#: src/olympia/addons/templates/addons/home.html:62
 msgid "Up &amp; Coming Extensions"
 msgstr "Nouvelles extensions"
 
-#: src/olympia/addons/templates/addons/home.html:69
-#: src/olympia/browse/templates/browse/personas/category_landing.html:61
-#: src/olympia/discovery/templates/discovery/pane.html:74
+#: src/olympia/addons/templates/addons/home.html:71 src/olympia/browse/templates/browse/personas/category_landing.html:61 src/olympia/discovery/templates/discovery/pane.html:74
 msgid "Featured Themes"
 msgstr "Thèmes vedettes"
 
-#: src/olympia/addons/templates/addons/home.html:77
-#: src/olympia/bandwagon/templates/bandwagon/impala/collection_listing.html:5
+#: src/olympia/addons/templates/addons/home.html:79 src/olympia/bandwagon/templates/bandwagon/impala/collection_listing.html:5
 msgid "Featured Collections"
 msgstr "Collections en vedette"
 
-#: src/olympia/addons/templates/addons/listing_header.html:3
-#: src/olympia/addons/templates/addons/impala/listing/sorter.html:2
-#: src/olympia/amo/templates/amo/mobile/sort_by.html:2
+#: src/olympia/addons/templates/addons/listing_header.html:3 src/olympia/addons/templates/addons/impala/listing/sorter.html:2 src/olympia/amo/templates/amo/mobile/sort_by.html:2
 #: src/olympia/bandwagon/templates/bandwagon/collection_detail.html:118
 msgid "Sort by:"
 msgstr "Trier par :"
 
 #. {0} is a date.
 #. {0} is a date
-#: src/olympia/addons/templates/addons/macros.html:7
-#: src/olympia/addons/templates/addons/macros.html:72
-#: src/olympia/addons/templates/addons/listing/items_mobile.html:48
-#: src/olympia/addons/templates/addons/listing/macros.html:42
-#: src/olympia/bandwagon/templates/bandwagon/collection_detail.html:50
-#: src/olympia/bandwagon/templates/bandwagon/collection_listing_items.html:40
-#: src/olympia/bandwagon/templates/bandwagon/impala/collection_listing_items.html:40
+#: src/olympia/addons/templates/addons/macros.html:7 src/olympia/addons/templates/addons/macros.html:72 src/olympia/addons/templates/addons/listing/items_mobile.html:48
+#: src/olympia/addons/templates/addons/listing/macros.html:42 src/olympia/bandwagon/templates/bandwagon/collection_detail.html:50
+#: src/olympia/bandwagon/templates/bandwagon/collection_listing_items.html:40 src/olympia/bandwagon/templates/bandwagon/impala/collection_listing_items.html:40
 msgid "Updated {0}"
 msgstr "Mis à jour le {0}"
 
 #. {0} is a date.
-#: src/olympia/addons/templates/addons/macros.html:10
-#: src/olympia/addons/templates/addons/macros.html:69
-#: src/olympia/addons/templates/addons/persona_preview.html:21
-#: src/olympia/addons/templates/addons/listing/items_mobile.html:44
-#: src/olympia/addons/templates/addons/listing/macros.html:39
-#: src/olympia/bandwagon/templates/bandwagon/collection_listing_items.html:37
+#: src/olympia/addons/templates/addons/macros.html:10 src/olympia/addons/templates/addons/macros.html:69 src/olympia/addons/templates/addons/persona_preview.html:22
+#: src/olympia/addons/templates/addons/listing/items_mobile.html:44 src/olympia/addons/templates/addons/listing/macros.html:39 src/olympia/bandwagon/templates/bandwagon/collection_listing_items.html:37
 #: src/olympia/bandwagon/templates/bandwagon/impala/collection_listing_items.html:37
 msgid "Added {0}"
 msgstr "Ajouté {0}"
@@ -794,18 +590,14 @@ msgstr[0] "%(num)s utilisateur"
 msgstr[1] "%(num)s utilisateurs"
 
 #. {0} is the number of downloads.
-#: src/olympia/addons/templates/addons/macros.html:53
-#: src/olympia/addons/templates/addons/impala/details.html:61
+#: src/olympia/addons/templates/addons/macros.html:53 src/olympia/addons/templates/addons/impala/details.html:59
 msgid "{0} weekly download"
 msgid_plural "{0} weekly downloads"
 msgstr[0] "{0} téléchargement hebdomadaire"
 msgstr[1] "{0} téléchargements hebdomadaires"
 
 #. {0} is the number of users.
-#: src/olympia/addons/templates/addons/macros.html:61
-#: src/olympia/addons/templates/addons/impala/details.html:54
-#: src/olympia/compat/templates/compat/index.html:71
-#: src/olympia/zadmin/templates/zadmin/compat.html:67
+#: src/olympia/addons/templates/addons/macros.html:61 src/olympia/addons/templates/addons/impala/details.html:52 src/olympia/zadmin/templates/zadmin/compat.html:67
 msgid "{0} user"
 msgid_plural "{0} users"
 msgstr[0] "{0} utilisateur"
@@ -823,12 +615,8 @@ msgstr "Paiement réalisé"
 msgid "Return to the addon."
 msgstr "Retourner au module."
 
-#: src/olympia/addons/templates/addons/persona_detail.html:17
-#: src/olympia/addons/templates/addons/impala/details.html:106
-#: src/olympia/addons/templates/addons/mobile/details.html:23
-#: src/olympia/addons/templates/addons/mobile/persona_detail.html:21
-#: src/olympia/discovery/templates/discovery/addons/base.html:27
-#: src/olympia/editors/templates/editors/review.html:31
+#: src/olympia/addons/templates/addons/persona_detail.html:17 src/olympia/addons/templates/addons/impala/details.html:103 src/olympia/addons/templates/addons/mobile/details.html:23
+#: src/olympia/addons/templates/addons/mobile/persona_detail.html:21 src/olympia/discovery/templates/discovery/addons/base.html:27 src/olympia/editors/templates/editors/review.html:31
 msgid "by"
 msgstr "par "
 
@@ -838,8 +626,7 @@ msgid "More {0} Themes"
 msgstr "Plus de thèmes {0}"
 
 #. {0} is a category name, such as Nature
-#: src/olympia/addons/templates/addons/persona_detail.html:39
-#: src/olympia/addons/templates/addons/mobile/persona_detail.html:66
+#: src/olympia/addons/templates/addons/persona_detail.html:39 src/olympia/addons/templates/addons/mobile/persona_detail.html:66
 msgid "See all {0} Themes"
 msgstr "Voir tous les thèmes {0}"
 
@@ -847,189 +634,131 @@ msgstr "Voir tous les thèmes {0}"
 msgid "More by this Artist"
 msgstr "Plus de cet artiste"
 
-#: src/olympia/addons/templates/addons/persona_detail.html:52
-#: src/olympia/addons/templates/addons/mobile/persona_detail.html:49
+#: src/olympia/addons/templates/addons/persona_detail.html:52 src/olympia/addons/templates/addons/mobile/persona_detail.html:49
 msgid "See all Themes by this Artist"
 msgstr "Voir tous les thèmes de cet artiste"
 
-#: src/olympia/addons/templates/addons/persona_detail.html:71
-#: src/olympia/addons/templates/addons/mobile/home.html:42
-#: src/olympia/amo/templates/amo/side_nav.html:22
-#: src/olympia/browse/templates/browse/personas/mobile/category_landing.html:28
-#: src/olympia/devhub/templates/devhub/addons/edit/basic.html:72
-#: src/olympia/editors/templates/editors/review.html:277
-#: src/olympia/editors/templates/editors/themes/themes.html:34
-#: src/olympia/templates/categories.html:7
+#: src/olympia/addons/templates/addons/persona_detail.html:71 src/olympia/addons/templates/addons/mobile/home.html:42 src/olympia/amo/templates/amo/side_nav.html:22
+#: src/olympia/browse/templates/browse/personas/mobile/category_landing.html:28 src/olympia/devhub/templates/devhub/addons/edit/basic.html:72 src/olympia/editors/templates/editors/review.html:277
+#: src/olympia/editors/templates/editors/themes/themes.html:34 src/olympia/templates/categories.html:7
 msgid "Categories"
 msgstr "Catégories"
 
-#: src/olympia/addons/templates/addons/persona_detail_table.html:10
-#: src/olympia/addons/templates/addons/mobile/persona_detail_table.html:3
-#: src/olympia/editors/templates/editors/themes/deleted.html:19
+#: src/olympia/addons/templates/addons/persona_detail_table.html:10 src/olympia/addons/templates/addons/mobile/persona_detail_table.html:3 src/olympia/editors/templates/editors/themes/deleted.html:19
 #: src/olympia/editors/templates/editors/themes/themes.html:25
 msgid "Artist"
 msgstr "Artiste"
 
-#: src/olympia/addons/templates/addons/persona_detail_table.html:19
-#: src/olympia/addons/templates/addons/mobile/persona_detail_table.html:14
-#: src/olympia/stats/templates/stats/addon_report_menu.html:17
+#: src/olympia/addons/templates/addons/persona_detail_table.html:19 src/olympia/addons/templates/addons/mobile/persona_detail_table.html:14 src/olympia/stats/templates/stats/addon_report_menu.html:17
 msgid "Daily Users"
 msgstr "Utilisateurs  quotidiens"
 
 #. The License for this add-on.
-#: src/olympia/addons/templates/addons/persona_detail_table.html:26
-#: src/olympia/addons/templates/addons/impala/license.html:17
-#: src/olympia/addons/templates/addons/mobile/persona_detail_table.html:21
-#: src/olympia/devhub/templates/devhub/includes/license_form.html:5
-#: src/olympia/devhub/templates/devhub/versions/edit.html:89
-#: src/olympia/editors/templates/editors/themes/themes.html:41
+#: src/olympia/addons/templates/addons/persona_detail_table.html:26 src/olympia/addons/templates/addons/impala/license.html:17 src/olympia/addons/templates/addons/mobile/persona_detail_table.html:21
+#: src/olympia/devhub/templates/devhub/includes/license_form.html:5 src/olympia/devhub/templates/devhub/versions/edit.html:89 src/olympia/editors/templates/editors/themes/themes.html:41
 msgid "License"
 msgstr "Licence"
 
-#: src/olympia/addons/templates/addons/persona_preview.html:12
-#: src/olympia/constants/base.py:48
+#: src/olympia/addons/templates/addons/persona_preview.html:13 src/olympia/constants/base.py:48
 msgid "Awaiting Review"
 msgstr "En attente de validation"
 
-#: src/olympia/addons/templates/addons/persona_preview.html:14
-#: src/olympia/amo/log.py:180 src/olympia/constants/base.py:42
-#: src/olympia/editors/helpers.py:62
+#: src/olympia/addons/templates/addons/persona_preview.html:15 src/olympia/amo/log.py:180 src/olympia/constants/base.py:42 src/olympia/editors/helpers.py:62
 msgid "Rejected"
 msgstr "Rejeté"
 
-#: src/olympia/addons/templates/addons/persona_preview.html:16
-#: src/olympia/amo/log.py:159
+#: src/olympia/addons/templates/addons/persona_preview.html:17 src/olympia/amo/log.py:159
 msgid "Approved"
 msgstr "Approuvé"
 
 #. {0} is the number of users.
-#: src/olympia/addons/templates/addons/persona_preview.html:26
-#: src/olympia/addons/templates/addons/listing/items_mobile.html:36
-#: src/olympia/addons/templates/addons/listing/macros.html:31
+#: src/olympia/addons/templates/addons/persona_preview.html:27 src/olympia/addons/templates/addons/listing/items_mobile.html:36 src/olympia/addons/templates/addons/listing/macros.html:31
 msgid "<strong>{0}</strong> user"
 msgid_plural "<strong>{0}</strong> users"
 msgstr[0] "<strong>{0}</strong> utilisateur"
 msgstr[1] "<strong>{0}</strong> utilisateurs"
 
-#: src/olympia/addons/templates/addons/persona_preview.html:40
+#: src/olympia/addons/templates/addons/persona_preview.html:41
 msgid "Hover to Preview"
 msgstr "Survolez pour prévisualiser"
 
-#: src/olympia/addons/templates/addons/persona_preview.html:46
-#: src/olympia/addons/templates/addons/persona_preview.html:48
+#: src/olympia/addons/templates/addons/persona_preview.html:47 src/olympia/addons/templates/addons/persona_preview.html:49 src/olympia/addons/templates/addons/persona_preview.html:97
 #: src/olympia/reviews/templates/reviews/add.html:15
 msgid "Add"
 msgstr "Ajouter"
 
-#: src/olympia/addons/templates/addons/persona_preview.html:57
-#: src/olympia/bandwagon/templates/bandwagon/ajax_new.html:16
-#: src/olympia/bandwagon/templates/bandwagon/edit.html:19
-#: src/olympia/bandwagon/templates/bandwagon/includes/addedit.html:19
-#: src/olympia/devhub/templates/devhub/addons/edit/admin.html:13
-#: src/olympia/devhub/templates/devhub/addons/edit/basic.html:10
-#: src/olympia/devhub/templates/devhub/addons/edit/details.html:8
-#: src/olympia/devhub/templates/devhub/addons/edit/media.html:6
-#: src/olympia/devhub/templates/devhub/addons/edit/support.html:8
-#: src/olympia/devhub/templates/devhub/addons/edit/technical.html:9
-#: src/olympia/devhub/templates/devhub/addons/submit/describe.html:29
-#: src/olympia/editors/templates/editors/review.html:257
+#: src/olympia/addons/templates/addons/persona_preview.html:58 src/olympia/bandwagon/templates/bandwagon/ajax_new.html:16 src/olympia/bandwagon/templates/bandwagon/edit.html:19
+#: src/olympia/bandwagon/templates/bandwagon/includes/addedit.html:19 src/olympia/devhub/templates/devhub/addons/edit/admin.html:13 src/olympia/devhub/templates/devhub/addons/edit/basic.html:10
+#: src/olympia/devhub/templates/devhub/addons/edit/details.html:8 src/olympia/devhub/templates/devhub/addons/edit/media.html:6 src/olympia/devhub/templates/devhub/addons/edit/support.html:8
+#: src/olympia/devhub/templates/devhub/addons/edit/technical.html:9 src/olympia/devhub/templates/devhub/addons/submit/describe.html:29 src/olympia/editors/templates/editors/review.html:257
 msgid "Edit"
 msgstr "Éditer"
 
 #. For datetime formatting, see the table on
 #. http://docs.python.org/library/datetime.html#strftime-and-strptime-behavior
-#: src/olympia/addons/templates/addons/persona_preview.html:66
+#: src/olympia/addons/templates/addons/persona_preview.html:67
 #, python-format
 msgid "%%Y-%%m-%%d"
 msgstr "%%d-%%m-%%Y"
 
-#: src/olympia/addons/templates/addons/persona_preview.html:67
+#: src/olympia/addons/templates/addons/persona_preview.html:68
 msgid "by {0} on {1}"
 msgstr "par {0} le {1}"
 
-#: src/olympia/addons/templates/addons/persona_preview.html:75
-#: src/olympia/reviews/helpers.py:17
-#: src/olympia/reviews/templates/reviews/review_list.html:63
-#: src/olympia/reviews/templates/reviews/reviews_link.html:21
-#: src/olympia/reviews/templates/reviews/impala/reviews_link.html:16
+#: src/olympia/addons/templates/addons/persona_preview.html:76 src/olympia/reviews/helpers.py:17 src/olympia/reviews/templates/reviews/review_list.html:63
+#: src/olympia/reviews/templates/reviews/reviews_link.html:21 src/olympia/reviews/templates/reviews/impala/reviews_link.html:16
 msgid "Not yet rated"
 msgstr "Pas encore évalué"
 
-#: src/olympia/addons/templates/addons/persona_preview.html:78
+#: src/olympia/addons/templates/addons/persona_preview.html:79
 msgid "<b>{0}</b> users"
 msgstr "<b>{0}</b> utilisateurs"
 
 #: src/olympia/addons/templates/addons/popups.html:17
-msgid ""
-"To install this add-on and thousands more, <b>get Firefox</b>, a free and "
-"open web browser from Mozilla."
-msgstr ""
-"Pour installer ce module et des milliers d'autres, <b>obtenez Firefox</b>, "
-"un navigateur web libre et gratuit de Mozilla."
+msgid "To install this add-on and thousands more, <b>get Firefox</b>, a free and open web browser from Mozilla."
+msgstr "Pour installer ce module et des milliers d'autres, <b>obtenez Firefox</b>, un navigateur web libre et gratuit de Mozilla."
 
-#: src/olympia/addons/templates/addons/popups.html:21
-#: src/olympia/addons/templates/addons/popups.html:52
+#: src/olympia/addons/templates/addons/popups.html:21 src/olympia/addons/templates/addons/popups.html:52
 msgid "Learn more about Firefox"
 msgstr "En savoir plus à propos de Firefox"
 
 #: src/olympia/addons/templates/addons/popups.html:22
-msgid "or <b><a class=\"installer\" href=\"{url}\">download anyway</a></b>"
-msgstr "ou <b><a class=\"installer\" href=\"{url}\">télécharger malgré tout</a></b>"
+msgid "or <b><a class=\"button installer\" href=\"{url}\">download anyway</a></b>"
+msgstr ""
 
 #: src/olympia/addons/templates/addons/popups.html:26
 msgid ""
-"<strong>How to Install in Thunderbird</strong> <ol> <li>Download and save "
-"the file to your hard disk.</li> <li>In Mozilla Thunderbird, open Add-ons "
-"from the Tools menu.</li> <li>From the options button next to the add-on "
-"search field, select \"Install Add-on From File...\" and locate the "
-"downloaded add-on.</li> </ol>"
+"<strong>How to Install in Thunderbird</strong> <ol> <li>Download and save the file to your hard disk.</li> <li>In Mozilla Thunderbird, open Add-ons from the Tools menu.</li> <li>From the options "
+"button next to the add-on search field, select \"Install Add-on From File...\" and locate the downloaded add-on.</li> </ol>"
 msgstr ""
-"<strong>Comment procéder à l'installation dans Thunderbird</strong> <ol> "
-"<li>Télécharger et enregistrer le fichier sur votre disque dur.</li> "
-"<li>Dans Mozilla Thunderbird, accédez au menu Modules complémentaires depuis"
-" le menu Outils.</li> <li>Grâce au bouton situé à côté du champ de recherche"
-" de modules, sélectionnez « Installer un module depuis un fichier » et "
-"sélectionnez le module que vous venez de télécharger</li> </ol>"
+"<strong>Comment procéder à l'installation dans Thunderbird</strong> <ol> <li>Télécharger et enregistrer le fichier sur votre disque dur.</li> <li>Dans Mozilla Thunderbird, accédez au menu Modules "
+"complémentaires depuis le menu Outils.</li> <li>Grâce au bouton situé à côté du champ de recherche de modules, sélectionnez « Installer un module depuis un fichier » et sélectionnez le module que "
+"vous venez de télécharger</li> </ol>"
 
 #: src/olympia/addons/templates/addons/popups.html:41
-msgid ""
-"To install this Theme, <b>get Thunderbird</b>, a free and open source email "
-"client from Mozilla Messaging and install the Personas Plus add-on."
-msgstr ""
-"Pour installer ce thème, <b>installez Thunderbird</b>, un client de courriel"
-" libre et gratuit de Mozilla Messaging et installez le module complémentaire"
-" Personas Plus."
+msgid "To install this Theme, <b>get Thunderbird</b>, a free and open source email client from Mozilla Messaging and install the Personas Plus add-on."
+msgstr "Pour installer ce thème, <b>installez Thunderbird</b>, un client de courriel libre et gratuit de Mozilla Messaging et installez le module complémentaire Personas Plus."
 
 #: src/olympia/addons/templates/addons/popups.html:46
 msgid "Learn more about Thunderbird"
 msgstr "En savoir plus à propos de Thunderbird"
 
 #: src/olympia/addons/templates/addons/popups.html:48
-msgid ""
-"To install this Theme and thousands more, <b>get Firefox</b>, a free and "
-"open web browser from Mozilla."
-msgstr ""
-"Pour installer ce thème et des milliers d'autres, <b>installez Firefox</b>, "
-"un navigateur libre et gratuit de Mozilla."
+msgid "To install this Theme and thousands more, <b>get Firefox</b>, a free and open web browser from Mozilla."
+msgstr "Pour installer ce thème et des milliers d'autres, <b>installez Firefox</b>, un navigateur libre et gratuit de Mozilla."
 
 #: src/olympia/addons/templates/addons/popups.html:60
 #, python-format
 msgid "This add-on has not been updated to work with your version of %(app)s."
-msgstr ""
-"Ce module n'a pas été mis à jour pour fonctionner avec votre version de "
-"%(app)s."
+msgstr "Ce module n'a pas été mis à jour pour fonctionner avec votre version de %(app)s."
 
-#: src/olympia/addons/templates/addons/popups.html:63
-#: src/olympia/addons/templates/addons/popups.html:140
-#: src/olympia/addons/templates/addons/popups.html:150
+#: src/olympia/addons/templates/addons/popups.html:63 src/olympia/addons/templates/addons/popups.html:140 src/olympia/addons/templates/addons/popups.html:150
 msgid "Install Anyway"
 msgstr "Installer tout de même"
 
 #: src/olympia/addons/templates/addons/popups.html:71
-msgid ""
-"This add-on requires a version of Firefox that has not been released yet."
-msgstr ""
-"Ce module requiert une version de Firefox qui n'est pas encore sortie."
+msgid "This add-on requires a version of Firefox that has not been released yet."
+msgstr "Ce module requiert une version de Firefox qui n'est pas encore sortie."
 
 #: src/olympia/addons/templates/addons/popups.html:74
 msgid "Help test new Firefox Versions"
@@ -1037,16 +766,11 @@ msgstr "Aidez à tester les nouvelles versions de Firefox"
 
 #: src/olympia/addons/templates/addons/popups.html:77
 #, python-format
-msgid ""
-"This add-on requires %(app)s {new_version}. You are currently using %(app)s "
-"{old_version}."
-msgstr ""
-"Ce module nécessite %(app)s {new_version}. Actuellement, vous utilisez "
-"%(app)s {old_version}."
+msgid "This add-on requires %(app)s {new_version}. You are currently using %(app)s {old_version}."
+msgstr "Ce module nécessite %(app)s {new_version}. Actuellement, vous utilisez %(app)s {old_version}."
 
 #. {0} is an app name, like Firefox.
-#: src/olympia/addons/templates/addons/popups.html:82
-#: src/olympia/addons/templates/addons/popups.html:101
+#: src/olympia/addons/templates/addons/popups.html:82 src/olympia/addons/templates/addons/popups.html:101
 msgid "Upgrade {0}"
 msgstr "Mettre à jour {0}"
 
@@ -1057,44 +781,27 @@ msgstr "ou afficher <a href=\"%(href)s\">les anciennes versions de ce module</a>
 
 #: src/olympia/addons/templates/addons/popups.html:96
 #, python-format
-msgid ""
-"This Persona requires %(app)s %(new_version)s. You are currently using "
-"%(app)s {old_version}."
-msgstr ""
-"Cette Persona nécessite %(app)s %(new_version)s. Or, vous utilisez "
-"actuellement %(app)s {old_version}."
+msgid "This Persona requires %(app)s %(new_version)s. You are currently using %(app)s {old_version}."
+msgstr "Cette Persona nécessite %(app)s %(new_version)s. Or, vous utilisez actuellement %(app)s {old_version}."
 
 #: src/olympia/addons/templates/addons/popups.html:108
 msgid ""
-"<strong>Caution:</strong> This add-on has not been reviewed by Mozilla and "
-"can't be installed on release versions of Firefox 43 and above. Be careful "
-"when installing third-party software that might harm your computer."
+"<strong>Caution:</strong> This add-on has not been reviewed by Mozilla and can't be installed on release versions of Firefox 43 and above. Be careful when installing third-party software that might"
+" harm your computer."
 msgstr ""
-"<strong>Attention&nbsp; :</strong> Ce module n'a pas été examiné par Mozilla"
-" et ne peut pas être installé sur les versions de Firefox 43 et supérieures."
-" Soyez prudent lors de l'installation de logiciels tiers qui pourraient "
-"nuire à votre ordinateur."
+"<strong>Attention&nbsp; :</strong> Ce module n'a pas été examiné par Mozilla et ne peut pas être installé sur les versions de Firefox 43 et supérieures. Soyez prudent lors de l'installation de "
+"logiciels tiers qui pourraient nuire à votre ordinateur."
 
 #: src/olympia/addons/templates/addons/popups.html:120
-msgid ""
-"<strong>Please note:</strong> This add-on is not compatible with your "
-"operating system."
-msgstr ""
-"<strong>Attention :</strong> Ce module n'est pas compatible avec votre "
-"système d'exploitation."
+msgid "<strong>Please note:</strong> This add-on is not compatible with your operating system."
+msgstr "<strong>Attention :</strong> Ce module n'est pas compatible avec votre système d'exploitation."
 
-#: src/olympia/addons/templates/addons/popups.html:136
-#: src/olympia/addons/templates/addons/impala/button.html:70
+#: src/olympia/addons/templates/addons/popups.html:136 src/olympia/addons/templates/addons/impala/button.html:70
 #, python-format
-msgid ""
-"This add-on is not compatible with your version of %(app)s because of the "
-"following:"
-msgstr ""
-"Ce module n'est pas compatible avec votre version de %(app)s à cause des "
-"éléments suivants :"
+msgid "This add-on is not compatible with your version of %(app)s because of the following:"
+msgstr "Ce module n'est pas compatible avec votre version de %(app)s à cause des éléments suivants :"
 
-#: src/olympia/addons/templates/addons/popups.html:141
-#: src/olympia/addons/templates/addons/popups.html:151
+#: src/olympia/addons/templates/addons/popups.html:141 src/olympia/addons/templates/addons/popups.html:151
 msgid "View other versions"
 msgstr "Voir d'autres versions"
 
@@ -1113,152 +820,94 @@ msgid "QR code for add-on"
 msgstr "Code QR pour le module"
 
 #: src/olympia/addons/templates/addons/qr_code.html:6
-msgid ""
-"Want {0} on your mobile Firefox? Scan this QR code to install directly to "
-"your phone. (You'll need a QR reader. Search your phone's marketplace if "
-"don't have one.)"
+msgid "Want {0} on your mobile Firefox? Scan this QR code to install directly to your phone. (You'll need a QR reader. Search your phone's marketplace if don't have one.)"
 msgstr ""
-"Vous voulez {0} sur votre Firefox mobile ? Scannez ce code QR pour "
-"l'installer directement sur votre téléphone. (Vous aurez besoin d'un lecteur"
-" de code QR. Renseignez-vous à propos des applications de votre téléphone si"
-" vous n'en avez pas.)"
+"Vous voulez {0} sur votre Firefox mobile ? Scannez ce code QR pour l'installer directement sur votre téléphone. (Vous aurez besoin d'un lecteur de code QR. Renseignez-vous à propos des applications"
+" de votre téléphone si vous n'en avez pas.)"
 
-#: src/olympia/addons/templates/addons/report_abuse.html:6
-#: src/olympia/addons/templates/addons/report_abuse_full.html:10
-#: src/olympia/addons/templates/addons/impala/details-more.html:23
-#: src/olympia/addons/templates/addons/impala/details.html:328
+#: src/olympia/addons/templates/addons/report_abuse.html:6 src/olympia/addons/templates/addons/report_abuse_full.html:10 src/olympia/addons/templates/addons/impala/details-more.html:23
+#: src/olympia/addons/templates/addons/impala/details.html:333
 msgid "Report Abuse"
 msgstr "Signaler un abus"
 
 #: src/olympia/addons/templates/addons/report_abuse.html:10
 #, python-format
 msgid ""
-"If you suspect this add-on violates <a href=\"%(url)s\">our policies</a> or "
-"has security or privacy issues, please use the form below to describe your "
-"concerns. Please do not use this form for any other reason."
+"If you suspect this add-on violates <a href=\"%(url)s\">our policies</a> or has security or privacy issues, please use the form below to describe your concerns. Please do not use this form for any "
+"other reason."
 msgstr ""
-"Si vous suspectez que ce module viole <a href=\"%(url)s\">nos politiques</a>"
-" ou qu'il est sujet à des problèmes relatifs à la vie privée ou à la "
-"sécurité, merci de remplir le formulaire ci-dessous pour décrire vos "
-"préoccupations. Merci de ne pas utiliser ce formulaire pour autre chose."
+"Si vous suspectez que ce module viole <a href=\"%(url)s\">nos politiques</a> ou qu'il est sujet à des problèmes relatifs à la vie privée ou à la sécurité, merci de remplir le formulaire ci-dessous "
+"pour décrire vos préoccupations. Merci de ne pas utiliser ce formulaire pour autre chose."
 
-#: src/olympia/addons/templates/addons/report_abuse.html:24
-#: src/olympia/users/templates/users/report_abuse.html:19
+#: src/olympia/addons/templates/addons/report_abuse.html:24 src/olympia/users/templates/users/report_abuse.html:19
 msgid "Send Report"
 msgstr "Envoyer un rapport"
 
-#: src/olympia/addons/templates/addons/report_abuse.html:26
-#: src/olympia/addons/templates/addons/mobile/eula.html:16
-#: src/olympia/addons/templates/addons/mobile/persona_confirm.html:7
-#: src/olympia/devhub/templates/devhub/addons/ajax_compat_update.html:36
-#: src/olympia/devhub/templates/devhub/addons/profile.html:44
-#: src/olympia/devhub/templates/devhub/addons/edit/admin.html:104
-#: src/olympia/devhub/templates/devhub/addons/edit/basic.html:155
-#: src/olympia/devhub/templates/devhub/addons/edit/details.html:88
-#: src/olympia/devhub/templates/devhub/addons/edit/support.html:70
-#: src/olympia/devhub/templates/devhub/addons/edit/technical.html:169
-#: src/olympia/devhub/templates/devhub/addons/forms_shared/media.html:152
-#: src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:44
-#: src/olympia/devhub/templates/devhub/personas/edit.html:222
-#: src/olympia/devhub/templates/devhub/versions/add_file_modal.html:79
-#: src/olympia/devhub/templates/devhub/versions/edit.html:140
-#: src/olympia/devhub/templates/devhub/versions/list.html:208
-#: src/olympia/devhub/templates/devhub/versions/list.html:242
-#: src/olympia/devhub/templates/devhub/versions/list.html:276
-#: src/olympia/devhub/templates/devhub/versions/list.html:317
-#: src/olympia/reviews/templates/reviews/edit_review.html:16
-#: src/olympia/translations/templates/translations/trans-menu.html:50
-#: src/olympia/translations/templates/translations/trans-menu.html:62
-#: src/olympia/zadmin/templates/zadmin/validation.html:105
+#: src/olympia/addons/templates/addons/report_abuse.html:26 src/olympia/addons/templates/addons/mobile/eula.html:16 src/olympia/addons/templates/addons/mobile/persona_confirm.html:7
+#: src/olympia/devhub/templates/devhub/addons/ajax_compat_update.html:36 src/olympia/devhub/templates/devhub/addons/profile.html:44 src/olympia/devhub/templates/devhub/addons/edit/admin.html:104
+#: src/olympia/devhub/templates/devhub/addons/edit/basic.html:155 src/olympia/devhub/templates/devhub/addons/edit/details.html:88 src/olympia/devhub/templates/devhub/addons/edit/support.html:70
+#: src/olympia/devhub/templates/devhub/addons/edit/technical.html:169 src/olympia/devhub/templates/devhub/addons/forms_shared/media.html:152
+#: src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:43 src/olympia/devhub/templates/devhub/personas/edit.html:222 src/olympia/devhub/templates/devhub/versions/add_file_modal.html:59
+#: src/olympia/devhub/templates/devhub/versions/edit.html:140 src/olympia/devhub/templates/devhub/versions/list.html:208 src/olympia/devhub/templates/devhub/versions/list.html:239
+#: src/olympia/devhub/templates/devhub/versions/list.html:281 src/olympia/devhub/templates/devhub/versions/list.html:315 src/olympia/reviews/templates/reviews/edit_review.html:16
+#: src/olympia/translations/templates/translations/trans-menu.html:50 src/olympia/translations/templates/translations/trans-menu.html:62 src/olympia/zadmin/templates/zadmin/validation.html:105
 msgid "Cancel"
 msgstr "Annuler"
 
-#: src/olympia/addons/templates/addons/review_add_box.html:3
-#: src/olympia/addons/templates/addons/impala/review_add_box.html:5
+#: src/olympia/addons/templates/addons/review_add_box.html:3 src/olympia/addons/templates/addons/impala/review_add_box.html:5
 msgid "What do you think?"
 msgstr "Qu'en pensez-vous ?"
 
-#: src/olympia/addons/templates/addons/review_add_box.html:7
-#: src/olympia/addons/templates/addons/impala/review_add_box.html:9
+#: src/olympia/addons/templates/addons/review_add_box.html:7 src/olympia/addons/templates/addons/impala/review_add_box.html:9
 #, python-format
 msgid "Please <a href=\"%(login)s\">log in</a> to submit a review"
-msgstr ""
-"Veuillez vous <a href=\"%(login)s\">connecter</a> pour envoyer une critique"
+msgstr "Veuillez vous <a href=\"%(login)s\">connecter</a> pour envoyer une critique"
 
-#: src/olympia/addons/templates/addons/review_add_box.html:16
-#: src/olympia/addons/templates/addons/impala/review_add_box.html:18
-#: src/olympia/reviews/templates/reviews/mobile/add_form.html:13
+#: src/olympia/addons/templates/addons/review_add_box.html:16 src/olympia/addons/templates/addons/impala/review_add_box.html:18 src/olympia/reviews/templates/reviews/mobile/add_form.html:13
 msgid "Title:"
 msgstr "Titre :"
 
-#: src/olympia/addons/templates/addons/review_add_box.html:17
-#: src/olympia/addons/templates/addons/impala/review_add_box.html:19
-#: src/olympia/reviews/templates/reviews/mobile/add_form.html:17
+#: src/olympia/addons/templates/addons/review_add_box.html:17 src/olympia/addons/templates/addons/impala/review_add_box.html:19 src/olympia/reviews/templates/reviews/mobile/add_form.html:17
 msgid "Review:"
 msgstr "Critique :"
 
-#: src/olympia/addons/templates/addons/review_add_box.html:18
-#: src/olympia/addons/templates/addons/impala/review_add_box.html:20
-#: src/olympia/reviews/templates/reviews/mobile/add_form.html:16
+#: src/olympia/addons/templates/addons/review_add_box.html:18 src/olympia/addons/templates/addons/impala/review_add_box.html:20 src/olympia/reviews/templates/reviews/mobile/add_form.html:16
 msgid "Rating:"
 msgstr "Appréciation :"
 
-#: src/olympia/addons/templates/addons/review_add_box.html:19
-#: src/olympia/addons/templates/addons/impala/review_add_box.html:21
-#: src/olympia/reviews/templates/reviews/add.html:63
-#: src/olympia/reviews/templates/reviews/edit_review.html:15
-#: src/olympia/reviews/templates/reviews/mobile/add_form.html:18
+#: src/olympia/addons/templates/addons/review_add_box.html:19 src/olympia/addons/templates/addons/impala/review_add_box.html:21 src/olympia/reviews/templates/reviews/add.html:63
+#: src/olympia/reviews/templates/reviews/edit_review.html:15 src/olympia/reviews/templates/reviews/mobile/add_form.html:18
 msgid "Submit review"
 msgstr "Envoyer une critique"
 
-#: src/olympia/addons/templates/addons/review_add_box.html:24
-#: src/olympia/addons/templates/addons/impala/review_add_box.html:26
-msgid ""
-"Please do not post bug reports in reviews. We do not make your email address"
-" available to add-on developers and they may need to contact you to help "
-"resolve your issue."
+#: src/olympia/addons/templates/addons/review_add_box.html:24 src/olympia/addons/templates/addons/impala/review_add_box.html:26
+msgid "Please do not post bug reports in reviews. We do not make your email address available to add-on developers and they may need to contact you to help resolve your issue."
 msgstr ""
-"Veuillez ne pas poster de rapports de bugs dans vos critiques. Nous ne "
-"donnons pas accès à votre adresse électronique aux développeurs de modules "
-"or ceux-ci pourraient avoir besoin de vous contacter pour résoudre votre "
-"problème."
+"Veuillez ne pas poster de rapports de bugs dans vos critiques. Nous ne donnons pas accès à votre adresse électronique aux développeurs de modules or ceux-ci pourraient avoir besoin de vous "
+"contacter pour résoudre votre problème."
 
-#: src/olympia/addons/templates/addons/review_add_box.html:32
-#: src/olympia/addons/templates/addons/impala/review_add_box.html:35
+#: src/olympia/addons/templates/addons/review_add_box.html:32 src/olympia/addons/templates/addons/impala/review_add_box.html:35
 #, python-format
-msgid ""
-"See the <a href=\"%(support)s\">support section</a> to find out where to get"
-" assistance for this add-on."
-msgstr ""
-"Consultez la <a href=\"%(support)s\">section d'assistance</a> pour toute "
-"question relative à ce module."
+msgid "See the <a href=\"%(support)s\">support section</a> to find out where to get assistance for this add-on."
+msgstr "Consultez la <a href=\"%(support)s\">section d'assistance</a> pour toute question relative à ce module."
 
-#: src/olympia/addons/templates/addons/review_add_box.html:38
-#: src/olympia/addons/templates/addons/impala/review_add_box.html:42
-#: src/olympia/pages/templates/pages/review_guide.html:3
+#: src/olympia/addons/templates/addons/review_add_box.html:38 src/olympia/addons/templates/addons/impala/review_add_box.html:42 src/olympia/pages/templates/pages/review_guide.html:3
 #: src/olympia/pages/templates/pages/review_guide.html:44
 msgid "Review Guidelines"
 msgstr "Instructions pour les critiques"
 
-#: src/olympia/addons/templates/addons/review_list_box.html:5
-#: src/olympia/addons/templates/addons/impala/details-more.html:27
-#: src/olympia/editors/helpers.py:921
-#: src/olympia/reviews/templates/reviews/add.html:14
-#: src/olympia/reviews/templates/reviews/reply.html:14
-#: src/olympia/reviews/templates/reviews/review_list.html:19
+#: src/olympia/addons/templates/addons/review_list_box.html:5 src/olympia/addons/templates/addons/impala/details-more.html:27 src/olympia/editors/helpers.py:1001
+#: src/olympia/reviews/templates/reviews/add.html:14 src/olympia/reviews/templates/reviews/reply.html:14 src/olympia/reviews/templates/reviews/review_list.html:19
 #: src/olympia/reviews/templates/reviews/mobile/review_list.html:26
 msgid "Reviews"
 msgstr "Critiques"
 
-#: src/olympia/addons/templates/addons/review_list_box.html:14
-#: src/olympia/addons/templates/addons/impala/review_list_box.html:14
-#: src/olympia/reviews/templates/reviews/review.html:30
+#: src/olympia/addons/templates/addons/review_list_box.html:14 src/olympia/addons/templates/addons/impala/review_list_box.html:14 src/olympia/reviews/templates/reviews/review.html:30
 #, python-format
 msgid "by %(user)s on %(date)s"
 msgstr "par %(user)s le %(date)s"
 
-#: src/olympia/addons/templates/addons/review_list_box.html:19
-#: src/olympia/addons/templates/addons/impala/review_list_box.html:29
+#: src/olympia/addons/templates/addons/review_list_box.html:19 src/olympia/addons/templates/addons/impala/review_list_box.html:29
 msgid "Show the developer's reply to this review"
 msgstr "Afficher la réponse du développeur à cette revue"
 
@@ -1269,21 +918,16 @@ msgid_plural "See all %(cnt)s reviews of this add-on"
 msgstr[0] "Voir tous les avis sur ce module"
 msgstr[1] "Voir tous les %(cnt)s avis sur ce module"
 
-#: src/olympia/addons/templates/addons/tags_box.html:3
-#: src/olympia/devhub/templates/devhub/addons/edit/basic.html:118
+#: src/olympia/addons/templates/addons/tags_box.html:3 src/olympia/devhub/templates/devhub/addons/edit/basic.html:118
 msgid "Tags"
 msgstr "Étiquettes"
 
-#: src/olympia/addons/templates/addons/impala/addon_hovercard.html:7
-#: src/olympia/addons/templates/addons/impala/addon_hovercard.html:9
+#: src/olympia/addons/templates/addons/impala/addon_hovercard.html:7 src/olympia/addons/templates/addons/impala/addon_hovercard.html:9
 msgid "Icon for {0}"
 msgstr "Icône pour {0}"
 
-#: src/olympia/addons/templates/addons/impala/addon_hovercard.html:34
-#: src/olympia/addons/templates/addons/impala/featured_grid.html:26
-#: src/olympia/addons/templates/addons/impala/theme_grid.html:22
-#: src/olympia/bandwagon/templates/bandwagon/collection_detail.html:31
-#: src/olympia/users/templates/users/helpers/addon_users_list.html:7
+#: src/olympia/addons/templates/addons/impala/addon_hovercard.html:34 src/olympia/addons/templates/addons/impala/featured_grid.html:26 src/olympia/addons/templates/addons/impala/theme_grid.html:22
+#: src/olympia/bandwagon/templates/bandwagon/collection_detail.html:31 src/olympia/users/templates/users/helpers/addon_users_list.html:7
 #, python-format
 msgid "by %(users)s"
 msgstr "par %(users)s"
@@ -1303,39 +947,22 @@ msgstr "Vous appréciez ce module ?"
 
 #: src/olympia/addons/templates/addons/impala/contribution.html:43
 #, python-format
-msgid ""
-"The <a href=\"%(meet_url)s\">developer of this add-on</a> asks that you help"
-" support its continued development by making a small contribution."
-msgstr ""
-"Le <a href=\"%(meet_url)s\">développeur de ce module</a> demande une petite "
-"contribution afin de soutenir la suite du développement."
+msgid "The <a href=\"%(meet_url)s\">developer of this add-on</a> asks that you help support its continued development by making a small contribution."
+msgstr "Le <a href=\"%(meet_url)s\">développeur de ce module</a> demande une petite contribution afin de soutenir la suite du développement."
 
 #: src/olympia/addons/templates/addons/impala/contribution.html:48
 #, python-format
-msgid ""
-"The <a href=\"%(meet_url)s\">developer of this add-on</a> asks that you show"
-" your support by making a donation to the <a "
-"href=\"%(charity_url)s\">%(charity_name)s</a>."
-msgstr ""
-"Le <a href=\"%(meet_url)s\">développeur de ce module</a>, afin de soutenir "
-"la suite du développement, vous demande de faire un don à <a "
-"href=\"%(charity_url)s\">%(charity_name)s</a>."
+msgid "The <a href=\"%(meet_url)s\">developer of this add-on</a> asks that you show your support by making a donation to the <a href=\"%(charity_url)s\">%(charity_name)s</a>."
+msgstr "Le <a href=\"%(meet_url)s\">développeur de ce module</a>, afin de soutenir la suite du développement, vous demande de faire un don à <a href=\"%(charity_url)s\">%(charity_name)s</a>."
 
 #: src/olympia/addons/templates/addons/impala/contribution.html:53
 #, python-format
-msgid ""
-"The <a href=\"%(meet_url)s\">developer of this add-on</a> asks that you show"
-" your support by making a small contribution to <a "
-"href=\"%(charity_url)s\">%(charity_name)s</a>."
-msgstr ""
-"Le <a href=\"%(meet_url)s\">développeur de ce module</a>, afin de soutenir "
-"la suite du développement, vous demande de faire un petit don à <a "
-"href=\"%(charity_url)s\">%(charity_name)s</a>."
+msgid "The <a href=\"%(meet_url)s\">developer of this add-on</a> asks that you show your support by making a small contribution to <a href=\"%(charity_url)s\">%(charity_name)s</a>."
+msgstr "Le <a href=\"%(meet_url)s\">développeur de ce module</a>, afin de soutenir la suite du développement, vous demande de faire un petit don à <a href=\"%(charity_url)s\">%(charity_name)s</a>."
 
 #: src/olympia/addons/templates/addons/impala/dependencies_note.html:4
 msgid "This add-on requires the following add-ons to work properly:"
-msgstr ""
-"Ce module a besoin des modules suivants pour fonctionner correctement :"
+msgstr "Ce module a besoin des modules suivants pour fonctionner correctement :"
 
 #: src/olympia/addons/templates/addons/impala/details-more.html:13
 msgid "Average"
@@ -1360,32 +987,31 @@ msgid_plural "Other add-ons by these authors"
 msgstr[0] "Autre module de %(author)s"
 msgstr[1] "Autres modules par ces développeurs"
 
-#: src/olympia/addons/templates/addons/impala/details.html:41
+#: src/olympia/addons/templates/addons/impala/details.html:39
 #, python-format
 msgid "<span itemprop=\"ratingCount\">%(num)s</span> user review"
 msgid_plural "<span itemprop=\"ratingCount\">%(num)s</span> user reviews"
 msgstr[0] "<span itemprop=\"ratingCount\">%(num)s</span> critique utilisateur"
 msgstr[1] "<span itemprop=\"ratingCount\">%(num)s</span> critiques utilisateur"
 
-#: src/olympia/addons/templates/addons/impala/details.html:69
+#: src/olympia/addons/templates/addons/impala/details.html:66
 msgid "View statistics"
 msgstr "Voir les statistiques"
 
-#: src/olympia/addons/templates/addons/impala/details.html:84
+#: src/olympia/addons/templates/addons/impala/details.html:81
 msgid "Manage"
 msgstr "Gérer"
 
 #. {0} is an add-on name.
-#: src/olympia/addons/templates/addons/impala/details.html:96
+#: src/olympia/addons/templates/addons/impala/details.html:93
 msgid "Icon of {0}"
 msgstr "                  Icône pour {0}                "
 
-#: src/olympia/addons/templates/addons/impala/details.html:103
-#: src/olympia/addons/templates/addons/impala/listing/items.html:14
+#: src/olympia/addons/templates/addons/impala/details.html:100 src/olympia/addons/templates/addons/impala/listing/items.html:14
 msgid "No Restart"
 msgstr "Pas de redémarrage"
 
-#: src/olympia/addons/templates/addons/impala/details.html:127
+#: src/olympia/addons/templates/addons/impala/details.html:124
 #, python-format
 msgid "Meet the Developer: <a href=\"%(url)s\">%(name)s</a>"
 msgid_plural "<a href=\"%(url)s\">Meet the Developers</a>"
@@ -1393,115 +1019,90 @@ msgstr[0] "Rencontrer le développeur&nbsp;: <a href=\"%(url)s\">%(name)s</a>"
 msgstr[1] "<a href=\"%(url)s\">Rencontrer les développeurs</a>"
 
 # {0} is an add-on name.
-#: src/olympia/addons/templates/addons/impala/details.html:137
+#: src/olympia/addons/templates/addons/impala/details.html:134
 msgid "Learn why {0} was created and find out what's next for this add-on."
-msgstr ""
-"Découvrez pourquoi {0} a été créé, et ce qui est prévu pour le futur de ce "
-"module."
+msgstr "Découvrez pourquoi {0} a été créé, et ce qui est prévu pour le futur de ce module."
 
 #. {0} is an index.
-#: src/olympia/addons/templates/addons/impala/details.html:156
+#: src/olympia/addons/templates/addons/impala/details.html:161
 msgid "Add-on screenshot #{0}"
 msgstr "Capture d'écran du module n°{0}"
 
-#: src/olympia/addons/templates/addons/impala/details.html:182
+#: src/olympia/addons/templates/addons/impala/details.html:187
 msgid "Add-on home page"
 msgstr "Page d'accueil du module"
 
-#: src/olympia/addons/templates/addons/impala/details.html:185
+#: src/olympia/addons/templates/addons/impala/details.html:190
 msgid "Support site"
 msgstr "Site d'assistance"
 
-#: src/olympia/addons/templates/addons/impala/details.html:189
+#: src/olympia/addons/templates/addons/impala/details.html:194
 msgid "Support E-mail"
 msgstr "Courriel d'assistance"
 
-#: src/olympia/addons/templates/addons/impala/details.html:194
-#: src/olympia/devhub/models.py:378
-#: src/olympia/devhub/templates/devhub/versions/list.html:12
-#: src/olympia/versions/templates/versions/version.html:6
-#: src/olympia/versions/templates/versions/mobile/version.html:6
+#: src/olympia/addons/templates/addons/impala/details.html:199 src/olympia/devhub/models.py:378 src/olympia/devhub/templates/devhub/versions/list.html:12
+#: src/olympia/versions/templates/versions/version.html:6 src/olympia/versions/templates/versions/mobile/version.html:6
 msgid "Version {0}"
 msgstr "Version {0}"
 
-#: src/olympia/addons/templates/addons/impala/details.html:194
+#: src/olympia/addons/templates/addons/impala/details.html:199
 msgid "Info"
 msgstr "Info"
 
-#: src/olympia/addons/templates/addons/impala/details.html:195
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:129
+#: src/olympia/addons/templates/addons/impala/details.html:200 src/olympia/devhub/templates/devhub/includes/addon_details.html:116
 msgid "Last Updated:"
 msgstr "Dernière mise à jour&nbsp;:"
 
-#: src/olympia/addons/templates/addons/impala/details.html:200
+#: src/olympia/addons/templates/addons/impala/details.html:205
 #, python-format
 msgid "Released under <a target=\"_blank\" href=\"%(url)s\">%(name)s</a>"
 msgstr "Distribué sous la licence <a target=\"_blank\" href=\"%(url)s\">%(name)s</a>"
 
-#: src/olympia/addons/templates/addons/impala/details.html:201
-#: src/olympia/addons/templates/addons/impala/details.html:206
-#: src/olympia/amo/helpers.py:398 src/olympia/devhub/forms.py:142
-#: src/olympia/devhub/forms.py:173
-#: src/olympia/versions/templates/versions/version.html:40
-#: src/olympia/versions/templates/versions/version.html:45
+#: src/olympia/addons/templates/addons/impala/details.html:206 src/olympia/addons/templates/addons/impala/details.html:211 src/olympia/amo/helpers.py:398 src/olympia/devhub/forms.py:142
+#: src/olympia/devhub/forms.py:173 src/olympia/versions/templates/versions/version.html:40 src/olympia/versions/templates/versions/version.html:45
 msgid "Custom License"
 msgstr "Licence personnalisée"
 
-#: src/olympia/addons/templates/addons/impala/details.html:205
+#: src/olympia/addons/templates/addons/impala/details.html:210
 #, python-format
 msgid "Released under <a href=\"%(url)s\">%(name)s</a>"
 msgstr "Distribué sous <a href=\"%(url)s\">%(name)s</a>"
 
-#: src/olympia/addons/templates/addons/impala/details.html:217
+#: src/olympia/addons/templates/addons/impala/details.html:222
 msgid "About this Add-on"
 msgstr "À propos de ce module"
 
-#: src/olympia/addons/templates/addons/impala/details.html:233
+#: src/olympia/addons/templates/addons/impala/details.html:238
 msgid "Developer’s Comments"
 msgstr "Commentaires du développeur"
 
-#: src/olympia/addons/templates/addons/impala/details.html:243
+#: src/olympia/addons/templates/addons/impala/details.html:248
 msgid "Version Information"
 msgstr "Informations de version"
 
-#: src/olympia/addons/templates/addons/impala/details.html:250
+#: src/olympia/addons/templates/addons/impala/details.html:255
 msgid "See complete version history"
 msgstr "Voir l'historique complet de version"
 
-#: src/olympia/addons/templates/addons/impala/details.html:262
+#: src/olympia/addons/templates/addons/impala/details.html:267
 msgid ""
-"The Development Channel lets you test an experimental new version of this "
-"add-on before it's released to the general public. Once you install the "
-"development version, you will continue to get updates from this channel. To "
-"stop receiving development updates, reinstall the default version from the "
-"link above."
+"The Development Channel lets you test an experimental new version of this add-on before it's released to the general public. Once you install the development version, you will continue to get "
+"updates from this channel. To stop receiving development updates, reinstall the default version from the link above."
 msgstr ""
-"Le canal Développement vous permet de tester une version expérimentale de ce"
-" module avant qu'il ne soit distribué au grand public. Une fois que la "
-"version de développement est installée, vous continuerez à recevoir les "
-"mises à jour de ce canal. Pour ne plus les recevoir, réinstaller la version "
-"par défaut depuis le lien ci-dessus."
+"Le canal Développement vous permet de tester une version expérimentale de ce module avant qu'il ne soit distribué au grand public. Une fois que la version de développement est installée, vous "
+"continuerez à recevoir les mises à jour de ce canal. Pour ne plus les recevoir, réinstaller la version par défaut depuis le lien ci-dessus."
 
-#: src/olympia/addons/templates/addons/impala/details.html:272
-msgid ""
-"<strong>Caution:</strong> Development versions of this add-on have not been "
-"reviewed by Mozilla."
-msgstr ""
-"<strong>Attention&nbsp;:</strong> Les versions de développement de ce module"
-" n'ont pas été revues par Mozilla."
+#: src/olympia/addons/templates/addons/impala/details.html:277
+msgid "<strong>Caution:</strong> Development versions of this add-on have not been reviewed by Mozilla."
+msgstr "<strong>Attention&nbsp;:</strong> Les versions de développement de ce module n'ont pas été revues par Mozilla."
 
-#: src/olympia/addons/templates/addons/impala/details.html:287
+#: src/olympia/addons/templates/addons/impala/details.html:292
 msgid "See complete development channel history"
 msgstr "Voir l'intégralité de l'historique de développement"
 
-#: src/olympia/addons/templates/addons/impala/details.html:306
-#: src/olympia/addons/templates/addons/impala/details.html:315
-#: src/olympia/addons/templates/addons/impala/details.html:327
-#: src/olympia/addons/templates/addons/impala/review_add_box.html:4
-#: src/olympia/stats/templates/stats/popup.html:2
-#: src/olympia/stats/templates/stats/popup.html:8
-#: src/olympia/stats/templates/stats/stats.html:202
-#: src/olympia/users/templates/users/profile.html:119
+#: src/olympia/addons/templates/addons/impala/details.html:311 src/olympia/addons/templates/addons/impala/details.html:320 src/olympia/addons/templates/addons/impala/details.html:332
+#: src/olympia/addons/templates/addons/impala/review_add_box.html:4 src/olympia/stats/templates/stats/popup.html:2 src/olympia/stats/templates/stats/popup.html:8
+#: src/olympia/stats/templates/stats/stats.html:204 src/olympia/users/templates/users/profile.html:119
 msgid "close"
 msgstr "fermer"
 
@@ -1510,19 +1111,15 @@ msgstr "fermer"
 msgid "Thank you for installing {0}"
 msgstr "Merci d'avoir installé {0}"
 
-#. {0} is an add-on name.
 # %1 is an add-on name.
+#. {0} is an add-on name.
 #: src/olympia/addons/templates/addons/impala/developers.html:12
 msgid "Meet the {0} Developer"
 msgstr "Rencontrez le développeur de {0}"
 
 #: src/olympia/addons/templates/addons/impala/developers.html:41
-msgid ""
-"Before downloading this add-on, please consider supporting the development "
-"of this add-on by making a small contribution."
-msgstr ""
-"Avant de télécharger ce module, merci de penser à aider son développement en"
-" faisant une petite contribution."
+msgid "Before downloading this add-on, please consider supporting the development of this add-on by making a small contribution."
+msgstr "Avant de télécharger ce module, merci de penser à aider son développement en faisant une petite contribution."
 
 # %1 is an add-on name.
 #: src/olympia/addons/templates/addons/impala/developers.html:80
@@ -1540,9 +1137,7 @@ msgid_plural "About the Developers"
 msgstr[0] "À propos du développeur"
 msgstr[1] "À propos des développeurs"
 
-#: src/olympia/addons/templates/addons/impala/developers.html:96
-#: src/olympia/users/templates/users/edit.html:130
-#: src/olympia/users/templates/users/profile.html:26
+#: src/olympia/addons/templates/addons/impala/developers.html:96 src/olympia/users/templates/users/edit.html:130 src/olympia/users/templates/users/profile.html:26
 msgid "No Photo"
 msgstr "Pas de photo"
 
@@ -1562,24 +1157,15 @@ msgstr "Ce module a été désactivé par un administrateur."
 msgid "Source Code License for {addon}"
 msgstr "Licence du code source pour {addon}"
 
-#: src/olympia/addons/templates/addons/impala/license.html:21
-#: src/olympia/versions/templates/versions/mobile/version.html:18
+#: src/olympia/addons/templates/addons/impala/license.html:21 src/olympia/versions/templates/versions/mobile/version.html:18
 msgid "Source Code License"
 msgstr "Licence du code source"
 
-#: src/olympia/addons/templates/addons/impala/persona_grid.html:16
-#: src/olympia/addons/templates/addons/impala/toplist.html:6
-msgid "{0} users"
-msgstr "{0} utilisateurs"
-
-#: src/olympia/addons/templates/addons/impala/review_list_box.html:19
-#: src/olympia/reviews/templates/reviews/review.html:40
+#: src/olympia/addons/templates/addons/impala/review_list_box.html:19 src/olympia/reviews/templates/reviews/review.html:40
 msgid "permalink"
 msgstr "lien permanent"
 
-#: src/olympia/addons/templates/addons/impala/review_list_box.html:23
-#: src/olympia/editors/templates/editors/queue.html:98
-#: src/olympia/reviews/templates/reviews/review.html:44
+#: src/olympia/addons/templates/addons/impala/review_list_box.html:23 src/olympia/editors/templates/editors/queue.html:104 src/olympia/reviews/templates/reviews/review.html:44
 msgid "translate"
 msgstr "traduire"
 
@@ -1590,8 +1176,7 @@ msgid_plural "See all %(cnt)s user reviews"
 msgstr[0] "Voir tous les commentaires utilisateur"
 msgstr[1] "Voir les %(cnt)s commentaires utilisateur"
 
-#: src/olympia/addons/templates/addons/impala/review_list_box.html:47
-#: src/olympia/reviews/templates/reviews/review_list.html:84
+#: src/olympia/addons/templates/addons/impala/review_list_box.html:47 src/olympia/reviews/templates/reviews/review_list.html:84
 msgid "This add-on has not yet been reviewed."
 msgstr "Ce module n'a pas encore été critiqué."
 
@@ -1599,24 +1184,23 @@ msgstr "Ce module n'a pas encore été critiqué."
 msgid "Be the first!"
 msgstr "Soyez le premier !"
 
-#: src/olympia/addons/templates/addons/impala/listing/sorter.html:14
-#: src/olympia/devhub/templates/devhub/addons/listing/item_actions.html:49
+#: src/olympia/addons/templates/addons/impala/toplist.html:6
+msgid "{0} users"
+msgstr "{0} utilisateurs"
+
+#: src/olympia/addons/templates/addons/impala/listing/sorter.html:14 src/olympia/devhub/templates/devhub/addons/listing/item_actions.html:49
 msgid "More"
 msgstr "Plus"
 
-#: src/olympia/addons/templates/addons/includes/collection_add_widget.html:7
-#: src/olympia/addons/templates/addons/includes/collection_add_widget.html:10
+#: src/olympia/addons/templates/addons/includes/collection_add_widget.html:7 src/olympia/addons/templates/addons/includes/collection_add_widget.html:10
 msgid "Add to collection"
 msgstr "Ajouter à la collection"
 
-#: src/olympia/addons/templates/addons/includes/dashboard_tabs.html:4
-#: src/olympia/devhub/templates/devhub/index.html:73
-#: src/olympia/devhub/templates/devhub/nav.html:14
+#: src/olympia/addons/templates/addons/includes/dashboard_tabs.html:4 src/olympia/devhub/templates/devhub/index.html:73 src/olympia/devhub/templates/devhub/nav.html:14
 msgid "My Add-ons"
 msgstr "Mes modules"
 
-#: src/olympia/addons/templates/addons/includes/dashboard_tabs.html:6
-#: src/olympia/amo/context_processors.py:51
+#: src/olympia/addons/templates/addons/includes/dashboard_tabs.html:6 src/olympia/amo/context_processors.py:52
 msgid "My Themes"
 msgstr "Mes thèmes"
 
@@ -1632,8 +1216,7 @@ msgstr "Modifier le thème"
 msgid "Approve / Reject"
 msgstr "Approuver / Rejeter"
 
-#: src/olympia/addons/templates/addons/includes/persona.html:25
-#: src/olympia/editors/templates/editors/themes/single.html:43
+#: src/olympia/addons/templates/addons/includes/persona.html:25 src/olympia/editors/templates/editors/themes/single.html:43
 msgid "Review History"
 msgstr "Voir l'historique"
 
@@ -1654,9 +1237,7 @@ msgid "Not Yet Rated"
 msgstr "Pas encore notée"
 
 #. {0} is the number of downloads.
-#: src/olympia/addons/templates/addons/listing/items_mobile.html:27
-#: src/olympia/addons/templates/addons/listing/macros.html:24
-#: src/olympia/devhub/templates/devhub/addons/listing/macros.html:15
+#: src/olympia/addons/templates/addons/listing/items_mobile.html:27 src/olympia/addons/templates/addons/listing/macros.html:24 src/olympia/devhub/templates/devhub/addons/listing/macros.html:15
 msgid "<strong>{0}</strong> weekly download"
 msgid_plural "<strong>{0}</strong> weekly downloads"
 msgstr[0] "<strong>{0}</strong> téléchargement hebdomadaire"
@@ -1670,15 +1251,11 @@ msgstr "En savoir plus"
 msgid "Users"
 msgstr "Utilisateurs"
 
-#: src/olympia/addons/templates/addons/mobile/details.html:92
-#: src/olympia/browse/views.py:59 src/olympia/browse/views.py:70
-#: src/olympia/search/forms.py:90
+#: src/olympia/addons/templates/addons/mobile/details.html:92 src/olympia/browse/views.py:59 src/olympia/browse/views.py:70 src/olympia/search/forms.py:90
 msgid "Weekly Downloads"
 msgstr "Téléchargements hebdomadaires"
 
-#: src/olympia/addons/templates/addons/mobile/details.html:99
-#: src/olympia/compat/templates/compat/reporter_detail.html:46
-#: src/olympia/devhub/forms.py:787
+#: src/olympia/addons/templates/addons/mobile/details.html:99 src/olympia/compat/templates/compat/reporter_detail.html:46 src/olympia/devhub/forms.py:788
 #: src/olympia/devhub/templates/devhub/versions/list.html:163
 msgid "Version"
 msgstr "Version"
@@ -1714,52 +1291,29 @@ msgstr "Accord de licence"
 
 #: src/olympia/addons/templates/addons/mobile/eula.html:5
 #, python-format
-msgid ""
-"%(name)s requires that you accept the following End-User License Agreement "
-"before installation can proceed:"
-msgstr ""
-"%(name)s nécessite que vous acceptiez le Contrat de Licence Utilisateur "
-"Final avant de pouvoir l'installer :"
+msgid "%(name)s requires that you accept the following End-User License Agreement before installation can proceed:"
+msgstr "%(name)s nécessite que vous acceptiez le Contrat de Licence Utilisateur Final avant de pouvoir l'installer :"
 
 #: src/olympia/addons/templates/addons/mobile/eula.html:15
 msgid "Accept"
 msgstr "Accepter"
 
-#: src/olympia/addons/templates/addons/mobile/home.html:10
-#: src/olympia/templates/mobile/base_addons.html:53
+#: src/olympia/addons/templates/addons/mobile/home.html:10 src/olympia/templates/mobile/base_addons.html:53
 msgid "Add-ons are not currently available on Firefox for iOS."
-msgstr ""
-"Actuellement, les modules complémentaires ne sont pas disponibles pour "
-"Firefox pour iOS."
+msgstr "Actuellement, les modules complémentaires ne sont pas disponibles pour Firefox pour iOS."
 
-#: src/olympia/addons/templates/addons/mobile/home.html:12
-#: src/olympia/templates/mobile/base_addons.html:55
-msgid ""
-"You need Firefox to install add-ons. <a "
-"href=\"http://mozilla.com/mobile\">Learn More&nbsp;&raquo;</a>"
-msgstr ""
-"Vous avez besoin de Firefox pour installer des modules. <a "
-"href=\"http://mozilla.com/mobile\">En savoir plus&nbsp;&raquo;</a>"
+#: src/olympia/addons/templates/addons/mobile/home.html:12 src/olympia/templates/mobile/base_addons.html:55
+msgid "You need Firefox to install add-ons. <a href=\"http://mozilla.com/mobile\">Learn More&nbsp;&raquo;</a>"
+msgstr "Vous avez besoin de Firefox pour installer des modules. <a href=\"http://mozilla.com/mobile\">En savoir plus&nbsp;&raquo;</a>"
 
 # {0} is the application name.  Example:  Firefox
-#: src/olympia/addons/templates/addons/mobile/home.html:19
-#: src/olympia/templates/header_title.html:4
-#: src/olympia/templates/impala/header_title.html:3
+#: src/olympia/addons/templates/addons/mobile/home.html:19 src/olympia/templates/header_title.html:4 src/olympia/templates/impala/header_title.html:3
 msgid "Return to the {0} Add-ons homepage"
 msgstr "Revenir à la page d'accueil des modules {0}"
 
-#: src/olympia/addons/templates/addons/mobile/home.html:21
-#: src/olympia/amo/helpers.py:237
-#: src/olympia/bandwagon/templates/bandwagon/edit.html:34
-#: src/olympia/discovery/templates/discovery/pane.html:92
-#: src/olympia/editors/templates/editors/base.html:21
-#: src/olympia/editors/templates/editors/performance.html:72
-#: src/olympia/templates/menu_links.html:4
-#: src/olympia/templates/impala/header_title.html:13
-#: src/olympia/templates/impala/header_title.html:15
-#: src/olympia/templates/impala/header_title.html:19
-#: src/olympia/templates/impala/header_title.html:23
-#: src/olympia/templates/mobile/base_addons.html:47
+#: src/olympia/addons/templates/addons/mobile/home.html:21 src/olympia/amo/helpers.py:237 src/olympia/bandwagon/templates/bandwagon/edit.html:34 src/olympia/discovery/templates/discovery/pane.html:92
+#: src/olympia/editors/templates/editors/base.html:21 src/olympia/editors/templates/editors/performance.html:72 src/olympia/templates/menu_links.html:4 src/olympia/templates/impala/header_title.html:13
+#: src/olympia/templates/impala/header_title.html:15 src/olympia/templates/impala/header_title.html:19 src/olympia/templates/impala/header_title.html:23 src/olympia/templates/mobile/base_addons.html:47
 msgid "Add-ons"
 msgstr "Modules"
 
@@ -1767,49 +1321,27 @@ msgstr "Modules"
 msgid "Easy ways to personalize."
 msgstr "Personnalisation facile."
 
-#: src/olympia/addons/templates/addons/mobile/home.html:24
-#: src/olympia/devhub/templates/devhub/addons/submit/done.html:47
-#: src/olympia/discovery/templates/discovery/pane.html:34
-#: src/olympia/discovery/templates/discovery/addons/detail.html:16
-#: src/olympia/discovery/templates/discovery/modules/featured.html:21
-#: src/olympia/discovery/templates/discovery/modules/monthly.html:22
+#: src/olympia/addons/templates/addons/mobile/home.html:24 src/olympia/devhub/templates/devhub/addons/submit/done.html:47 src/olympia/discovery/templates/discovery/pane.html:34
+#: src/olympia/discovery/templates/discovery/addons/detail.html:16 src/olympia/discovery/templates/discovery/modules/featured.html:21 src/olympia/discovery/templates/discovery/modules/monthly.html:22
 msgid "Learn More"
 msgstr "En savoir plus"
 
 #: src/olympia/addons/templates/addons/mobile/home.html:26
 msgid ""
-"Add-ons are applications that let you personalize Firefox with extra "
-"functionality and style. Whether you mistype the name of a website or can't "
-"read a busy page, there's an add-on to improve your on-the-go browsing."
+"Add-ons are applications that let you personalize Firefox with extra functionality and style. Whether you mistype the name of a website or can't read a busy page, there's an add-on to improve your "
+"on-the-go browsing."
 msgstr ""
-"Les modules sont des applications qui vous permettent de personnaliser "
-"Firefox avec des fonctionnalités additionnelles et de changer son apparence."
-" Que vous fassiez des fautes dans le nom d'un site web ou que vous ne "
-"puissiez lire une page surchargée, il y a un module pour améliorer votre "
-"expérience de navigation."
+"Les modules sont des applications qui vous permettent de personnaliser Firefox avec des fonctionnalités additionnelles et de changer son apparence. Que vous fassiez des fautes dans le nom d'un site"
+" web ou que vous ne puissiez lire une page surchargée, il y a un module pour améliorer votre expérience de navigation."
 
 #. {0} is a category name. Ex: "Sports"
 #. {0} is a category name, such as Nature.
-#: src/olympia/addons/templates/addons/mobile/home.html:43
-#: src/olympia/amo/templates/amo/site_nav.html:32
-#: src/olympia/browse/feeds.py:107
-#: src/olympia/browse/templates/browse/impala/base_listing.html:38
-#: src/olympia/browse/templates/browse/personas/base.html:6
-#: src/olympia/browse/templates/browse/personas/base.html:42
-#: src/olympia/browse/templates/browse/personas/category_landing.html:21
-#: src/olympia/browse/templates/browse/personas/category_landing.html:23
-#: src/olympia/browse/templates/browse/personas/category_landing.html:38
-#: src/olympia/browse/templates/browse/personas/grid.html:7
-#: src/olympia/browse/templates/browse/personas/grid.html:11
-#: src/olympia/browse/templates/browse/personas/mobile/base.html:7
-#: src/olympia/browse/templates/browse/personas/mobile/category_landing.html:19
-#: src/olympia/constants/base.py:180
-#: src/olympia/devhub/templates/devhub/personas/submit.html:13
-#: src/olympia/editors/helpers.py:105
-#: src/olympia/editors/templates/editors/base.html:26
-#: src/olympia/editors/templates/editors/performance.html:73
-#: src/olympia/search/templates/search/personas.html:39
-#: src/olympia/templates/menu_links.html:9
+#: src/olympia/addons/templates/addons/mobile/home.html:43 src/olympia/amo/templates/amo/site_nav.html:32 src/olympia/browse/feeds.py:107 src/olympia/browse/templates/browse/impala/base_listing.html:38
+#: src/olympia/browse/templates/browse/personas/base.html:6 src/olympia/browse/templates/browse/personas/base.html:42 src/olympia/browse/templates/browse/personas/category_landing.html:21
+#: src/olympia/browse/templates/browse/personas/category_landing.html:23 src/olympia/browse/templates/browse/personas/category_landing.html:38 src/olympia/browse/templates/browse/personas/grid.html:7
+#: src/olympia/browse/templates/browse/personas/grid.html:11 src/olympia/browse/templates/browse/personas/mobile/base.html:7 src/olympia/browse/templates/browse/personas/mobile/category_landing.html:19
+#: src/olympia/constants/base.py:180 src/olympia/devhub/templates/devhub/personas/submit.html:13 src/olympia/editors/helpers.py:107 src/olympia/editors/templates/editors/base.html:26
+#: src/olympia/editors/templates/editors/performance.html:73 src/olympia/search/templates/search/personas.html:39 src/olympia/templates/menu_links.html:9
 msgid "Themes"
 msgstr "Thèmes"
 
@@ -1825,19 +1357,12 @@ msgstr "Voir tous les modules populaires"
 msgid "More Add-ons"
 msgstr "Plus de modules"
 
-#: src/olympia/addons/templates/addons/mobile/home.html:72
-#: src/olympia/browse/templates/browse/personas/mobile/category_landing.html:64
-#: src/olympia/search/forms.py:14
+#: src/olympia/addons/templates/addons/mobile/home.html:72 src/olympia/browse/templates/browse/personas/mobile/category_landing.html:64 src/olympia/search/forms.py:14
 msgid "Highest Rated"
 msgstr "Les meilleures appréciations"
 
-#: src/olympia/addons/templates/addons/mobile/home.html:74
-#: src/olympia/amo/templates/amo/side_nav.html:5
-#: src/olympia/amo/templates/amo/site_nav.html:27
-#: src/olympia/amo/templates/amo/site_nav.html:57
-#: src/olympia/bandwagon/views.py:97 src/olympia/browse/views.py:57
-#: src/olympia/browse/views.py:67
-#: src/olympia/browse/templates/browse/personas/mobile/category_landing.html:65
+#: src/olympia/addons/templates/addons/mobile/home.html:74 src/olympia/amo/templates/amo/side_nav.html:5 src/olympia/amo/templates/amo/site_nav.html:27 src/olympia/amo/templates/amo/site_nav.html:55
+#: src/olympia/bandwagon/views.py:97 src/olympia/browse/views.py:57 src/olympia/browse/views.py:67 src/olympia/browse/templates/browse/personas/mobile/category_landing.html:65
 #: src/olympia/search/forms.py:15 src/olympia/search/forms.py:87
 msgid "Newest"
 msgstr "Les plus récents"
@@ -1850,124 +1375,88 @@ msgstr "Essayez-la !"
 msgid "Theme Info &raquo;"
 msgstr "Infos du thème &raquo;"
 
-#: src/olympia/amo/context_processors.py:39
-#: src/olympia/devhub/templates/devhub/nav.html:43
+#: src/olympia/amo/context_processors.py:39 src/olympia/devhub/templates/devhub/nav.html:43
 msgid "Tools"
 msgstr "Outils"
 
-#: src/olympia/amo/context_processors.py:48
-#: src/olympia/discovery/templates/discovery/pane_account.html:8
-#: src/olympia/users/templates/users/includes/navigation.html:2
+#: src/olympia/amo/context_processors.py:49 src/olympia/discovery/templates/discovery/pane_account.html:8 src/olympia/users/templates/users/includes/navigation.html:2
 msgid "My Profile"
 msgstr "Mon profil"
 
-#: src/olympia/amo/context_processors.py:54
-#: src/olympia/users/templates/users/edit.html:5
-#: src/olympia/users/templates/users/includes/navigation.html:3
+#: src/olympia/amo/context_processors.py:55 src/olympia/users/templates/users/edit.html:5 src/olympia/users/templates/users/includes/navigation.html:3
 msgid "Account Settings"
 msgstr "Paramètres du compte"
 
-#: src/olympia/amo/context_processors.py:57
-#: src/olympia/discovery/templates/discovery/pane_account.html:11
-#: src/olympia/users/templates/users/profile.html:83
+#: src/olympia/amo/context_processors.py:58 src/olympia/discovery/templates/discovery/pane_account.html:11 src/olympia/users/templates/users/profile.html:83
 #: src/olympia/users/templates/users/includes/navigation.html:4
 msgid "My Collections"
 msgstr "Mes collections"
 
-#: src/olympia/amo/context_processors.py:62
-#: src/olympia/discovery/templates/discovery/pane_account.html:10
-#: src/olympia/users/templates/users/includes/navigation.html:7
+#: src/olympia/amo/context_processors.py:63 src/olympia/discovery/templates/discovery/pane_account.html:10 src/olympia/users/templates/users/includes/navigation.html:7
 msgid "My Favorites"
 msgstr "Mes favoris"
 
-#: src/olympia/amo/context_processors.py:67
-#: src/olympia/discovery/templates/discovery/pane_account.html:13
-#: src/olympia/templates/impala/user_login.html:14
-#: src/olympia/templates/mobile/header_auth.html:5
+#: src/olympia/amo/context_processors.py:68 src/olympia/discovery/templates/discovery/pane_account.html:13 src/olympia/templates/impala/user_login.html:14 src/olympia/templates/mobile/header_auth.html:5
 msgid "Log out"
 msgstr "Déconnexion"
 
-#: src/olympia/amo/context_processors.py:72
-#: src/olympia/devhub/templates/devhub/addons/dashboard.html:4
+#: src/olympia/amo/context_processors.py:73 src/olympia/devhub/templates/devhub/addons/dashboard.html:4
 msgid "Manage My Submissions"
 msgstr "Gérer mes envois"
 
-#: src/olympia/amo/context_processors.py:75
-#: src/olympia/devhub/templates/devhub/nav.html:27
-#: src/olympia/devhub/templates/devhub/addons/dashboard.html:25
+#: src/olympia/amo/context_processors.py:76 src/olympia/devhub/templates/devhub/nav.html:27 src/olympia/devhub/templates/devhub/addons/dashboard.html:25
 #: src/olympia/devhub/templates/devhub/addons/submit/base.html:4
 msgid "Submit a New Add-on"
 msgstr "Proposer un nouveau module"
 
-#: src/olympia/amo/context_processors.py:77
-#: src/olympia/browse/templates/browse/personas/base.html:50
-#: src/olympia/devhub/templates/devhub/index.html:24
+#: src/olympia/amo/context_processors.py:78 src/olympia/browse/templates/browse/personas/base.html:50 src/olympia/devhub/templates/devhub/index.html:24
 #: src/olympia/devhub/templates/devhub/addons/dashboard.html:29
 msgid "Submit a New Theme"
 msgstr "Envoyer un nouveau thème"
 
-#: src/olympia/amo/context_processors.py:79
-#: src/olympia/amo/templates/amo/site_nav.html:87
-#: src/olympia/devhub/helpers.py:36 src/olympia/devhub/helpers.py:68
-#: src/olympia/devhub/helpers.py:102 src/olympia/templates/footer.html:6
-#: src/olympia/templates/menu_links.html:14
+#: src/olympia/amo/context_processors.py:80 src/olympia/amo/templates/amo/site_nav.html:85 src/olympia/devhub/helpers.py:36 src/olympia/devhub/helpers.py:68 src/olympia/devhub/helpers.py:102
+#: src/olympia/templates/footer.html:6 src/olympia/templates/menu_links.html:14
 msgid "Developer Hub"
 msgstr "Pôle développeur"
 
-#: src/olympia/amo/context_processors.py:83 src/olympia/devhub/views.py:1792
+#: src/olympia/amo/context_processors.py:84 src/olympia/devhub/views.py:1799
 msgid "Manage API Keys"
 msgstr "Gérer les clés d'API"
 
-#: src/olympia/amo/context_processors.py:88 src/olympia/editors/helpers.py:82
-#: src/olympia/editors/helpers.py:102
-#: src/olympia/editors/templates/editors/base.html:10
+#: src/olympia/amo/context_processors.py:89 src/olympia/editors/helpers.py:84 src/olympia/editors/helpers.py:104 src/olympia/editors/templates/editors/base.html:10
 msgid "Editor Tools"
 msgstr "Outils de l'éditeur"
 
-#: src/olympia/amo/context_processors.py:92
+#: src/olympia/amo/context_processors.py:93
 msgid "Admin Tools"
 msgstr "Outils d'administration"
 
-#: src/olympia/amo/fields.py:15
+#: src/olympia/amo/fields.py:20
 msgid "Incorrect, please try again."
 msgstr "Incorrect, veuillez réessayer."
 
-#: src/olympia/amo/fields.py:16
+#: src/olympia/amo/fields.py:21
 msgid "Error verifying input, please try again."
-msgstr ""
-"Une erreur s'est produite lors de la vérification, veuillez réessayer."
+msgstr "Une erreur s'est produite lors de la vérification, veuillez réessayer."
 
-#: src/olympia/amo/fields.py:32
+#: src/olympia/amo/fields.py:37
 msgid "This must be a valid hex color code, such as #000000."
-msgstr ""
-"Ceci doit être un code couleur hexadécimal valide, par exemple #000000."
+msgstr "Ceci doit être un code couleur hexadécimal valide, par exemple #000000."
 
-#: src/olympia/amo/fields.py:58
+#: src/olympia/amo/fields.py:63
 msgid "Enter at least one value."
 msgstr "Entrez au moins une valeur."
 
-#: src/olympia/amo/helpers.py:162
-#: src/olympia/amo/templates/amo/site_nav.html:61
-#: src/olympia/bandwagon/templates/bandwagon/add.html:9
-#: src/olympia/bandwagon/templates/bandwagon/collection_detail.html:15
-#: src/olympia/bandwagon/templates/bandwagon/delete.html:9
-#: src/olympia/bandwagon/templates/bandwagon/edit.html:15
-#: src/olympia/bandwagon/templates/bandwagon/user_listing.html:18
-#: src/olympia/bandwagon/templates/bandwagon/user_listing.html:21
-#: src/olympia/bandwagon/templates/bandwagon/impala/collection_listing.html:12
-#: src/olympia/bandwagon/templates/bandwagon/impala/collection_listing.html:20
-#: src/olympia/bandwagon/templates/bandwagon/impala/collection_listing.html:24
-#: src/olympia/bandwagon/templates/bandwagon/impala/collection_sidebar.html:3
-#: src/olympia/bandwagon/templates/bandwagon/includes/collection_sidebar.html:2
-#: src/olympia/bandwagon/templates/bandwagon/mobile/collection_listing.html:3
-#: src/olympia/stats/templates/stats/stats.html:77
-#: src/olympia/templates/menu_links.html:12
+#: src/olympia/amo/helpers.py:162 src/olympia/amo/templates/amo/site_nav.html:59 src/olympia/bandwagon/templates/bandwagon/add.html:9 src/olympia/bandwagon/templates/bandwagon/collection_detail.html:15
+#: src/olympia/bandwagon/templates/bandwagon/delete.html:9 src/olympia/bandwagon/templates/bandwagon/edit.html:15 src/olympia/bandwagon/templates/bandwagon/user_listing.html:18
+#: src/olympia/bandwagon/templates/bandwagon/user_listing.html:21 src/olympia/bandwagon/templates/bandwagon/impala/collection_listing.html:12
+#: src/olympia/bandwagon/templates/bandwagon/impala/collection_listing.html:20 src/olympia/bandwagon/templates/bandwagon/impala/collection_listing.html:24
+#: src/olympia/bandwagon/templates/bandwagon/impala/collection_sidebar.html:3 src/olympia/bandwagon/templates/bandwagon/includes/collection_sidebar.html:2
+#: src/olympia/bandwagon/templates/bandwagon/mobile/collection_listing.html:3 src/olympia/stats/templates/stats/stats.html:33 src/olympia/templates/menu_links.html:12
 msgid "Collections"
 msgstr "Collections"
 
-#: src/olympia/amo/helpers.py:171
-#: src/olympia/amo/templates/amo/site_nav.html:85
-#: src/olympia/browse/templates/browse/language_tools.html:3
+#: src/olympia/amo/helpers.py:171 src/olympia/amo/templates/amo/site_nav.html:83 src/olympia/browse/templates/browse/language_tools.html:3
 msgid "Dictionaries & Language Packs"
 msgstr "Dictionnaires et paquetages linguistiques"
 
@@ -2119,11 +1608,8 @@ msgstr "Super revue demandée"
 msgid "Comment on {addon} {version}."
 msgstr "Commentaire sur {addon} {version}."
 
-#: src/olympia/amo/log.py:236
-#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:19
-#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:47
-#: src/olympia/editors/helpers.py:511
-#: src/olympia/editors/templates/editors/themes/history_table.html:11
+#: src/olympia/amo/log.py:236 src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:17 src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:45
+#: src/olympia/editors/helpers.py:584 src/olympia/editors/templates/editors/themes/history_table.html:11
 msgid "Comment"
 msgstr "Commentaire"
 
@@ -2209,13 +1695,11 @@ msgstr "Version maximale d'application mise à jour en {version}."
 
 #: src/olympia/amo/log.py:359
 msgid "Authors emailed about compatibility of {version}."
-msgstr ""
-"Auteurs notifiés par courriel à propos de la compatibilité de {version}."
+msgstr "Auteurs notifiés par courriel à propos de la compatibilité de {version}."
 
 #: src/olympia/amo/log.py:364
 msgid "Email sent to Author about add-on compatibility."
-msgstr ""
-"Courriel envoyé à l'auteur sur la compatibilité des modules complémentaires."
+msgstr "Courriel envoyé à l'auteur sur la compatibilité des modules complémentaires."
 
 #: src/olympia/amo/log.py:369
 msgid "Password changed."
@@ -2263,8 +1747,7 @@ msgstr "Application désactivée"
 
 #: src/olympia/amo/log.py:425
 msgid "{addon} escalated because of high number of abuse reports."
-msgstr ""
-"{addon} a été escaladé à cause d'un nombre de rapports d'abus important."
+msgstr "{addon} a été escaladé à cause d'un nombre de rapports d'abus important."
 
 #: src/olympia/amo/log.py:426
 msgid "High Abuse Reports"
@@ -2384,10 +1867,7 @@ msgstr "{addon} changement de classification du contenu."
 msgid "{addon} unlisted."
 msgstr "{addon} non listé."
 
-#: src/olympia/amo/log.py:592 src/olympia/amo/log.py:598
-#: src/olympia/amo/log.py:612 src/olympia/amo/log.py:618
-#: src/olympia/amo/log.py:624 src/olympia/amo/log.py:630
-#: src/olympia/amo/log.py:636
+#: src/olympia/amo/log.py:592 src/olympia/amo/log.py:598 src/olympia/amo/log.py:612 src/olympia/amo/log.py:618 src/olympia/amo/log.py:624 src/olympia/amo/log.py:630 src/olympia/amo/log.py:636
 msgid "{file} was signed."
 msgstr "{file} a été signé."
 
@@ -2401,20 +1881,12 @@ msgid "Not allowed"
 msgstr "Non autorisé"
 
 #: src/olympia/amo/templates/amo/403.html:7
-msgid ""
-"<h1>Oops! Not allowed.</h1> <p>You tried to do something that you weren't "
-"allowed to.</p>"
-msgstr ""
-"<h1>Désolé, c'est interdit.</h1> <p>Vous avez tenté d'accéder à une "
-"ressource pour laquelle vous n'avez pas les droits.</p>"
+msgid "<h1>Oops! Not allowed.</h1> <p>You tried to do something that you weren't allowed to.</p>"
+msgstr "<h1>Désolé, c'est interdit.</h1> <p>Vous avez tenté d'accéder à une ressource pour laquelle vous n'avez pas les droits.</p>"
 
 #: src/olympia/amo/templates/amo/403.html:12
-msgid ""
-"<p>Try going back to the previous page, refreshing and then trying "
-"again.</p>"
-msgstr ""
-"<p>Essayez de revenir à la page précédente, recharger et d'essayer "
-"encore.</p>"
+msgid "<p>Try going back to the previous page, refreshing and then trying again.</p>"
+msgstr "<p>Essayez de revenir à la page précédente, recharger et d'essayer encore.</p>"
 
 #: src/olympia/amo/templates/amo/404.html:3
 msgid "Not Found"
@@ -2423,37 +1895,19 @@ msgstr "Non trouvé"
 #: src/olympia/amo/templates/amo/404.html:6
 #, python-format
 msgid ""
-"<h1>We're sorry, but we can't find what you're looking for.</h1> <p> The "
-"page or file you requested wasn't found on our site. It's possible that you "
-"clicked a link that's out of date, or typed in the address incorrectly. </p>"
-" <ul> <li>If you typed in the address, please double check the "
-"spelling.</li> <li> If you followed a link from somewhere, please let us "
-"know at <a href=\"mailto:webmaster@mozilla.com\">webmaster@mozilla.com</a>. "
-"Tell us where you came from and what you were looking for, and we'll do our "
-"best to fix it. </li> </ul> <p>Or you can just jump over to some of the "
-"popular pages on our website.</p> <ul> <li>Are you interested in a <a "
-"href=\"%(rec)s\">list of featured add-ons</a>?</li> <li> Do you want to <a "
-"href=\"%(search)s\">search for add-ons</a>? You may go to the <a "
-"href=\"%(search)s\">search page</a> or just use the search field above. "
-"</li> <li> If you prefer to start over, just go to the <a href=\"%(home)s"
-"\">add-ons front page</a>. </li> </ul>"
+"<h1>We're sorry, but we can't find what you're looking for.</h1> <p> The page or file you requested wasn't found on our site. It's possible that you clicked a link that's out of date, or typed in "
+"the address incorrectly. </p> <ul> <li>If you typed in the address, please double check the spelling.</li> <li> If you followed a link from somewhere, please let us know at <a "
+"href=\"mailto:webmaster@mozilla.com\">webmaster@mozilla.com</a>. Tell us where you came from and what you were looking for, and we'll do our best to fix it. </li> </ul> <p>Or you can just jump over"
+" to some of the popular pages on our website.</p> <ul> <li>Are you interested in a <a href=\"%(rec)s\">list of featured add-ons</a>?</li> <li> Do you want to <a href=\"%(search)s\">search for add-"
+"ons</a>? You may go to the <a href=\"%(search)s\">search page</a> or just use the search field above. </li> <li> If you prefer to start over, just go to the <a href=\"%(home)s\">add-ons front "
+"page</a>. </li> </ul>"
 msgstr ""
-"<h1>Nous sommes désolés, mais nous ne pouvons pas trouver ce que vous "
-"cherchez.</h1> <p> La page ou le fichier que vous vouliez n'a pas été trouvé"
-" sur notre site. Il est possible que vous ayez cliqué sur un lien mort, ou "
-"que l'adresse entrée soit erronée. </p> <ul> <li>Si vous avez tapé "
-"l'adresse, vérifiez-la.</li> <li> Si vous avez suivi un lien, merci de vous "
-"en informer à <a "
-"href=\"mailto:webmaster@mozilla.com\">webmaster@mozilla.com</a>. Dites-nous "
-"d'où vous veniez et ce que vous cherchiez, nous ferons notre maximum pour "
-"faire en sorte de corriger le problème. </li> </ul> <p>Vous pouvez aussi "
-"faire un tour sur nos pages populaires.</p> <ul> <li>Est-ce qu'une <a "
-"href=\"%(rec)s\">liste de modules en vedette</a> vous intéresse ?</li> <li> "
-"Est-ce que vous voulez <a href=\"%(search)s\">rechercher des modules</a> ? "
-"Vous pouvez aller sur la <a href=\"%(search)s\">page de recherche</a> ou "
-"simplement utiliser le champs de recherche ci-dessus. </li> <li> Si vous "
-"voulez recommencer, rendez-vous sur <a href=\"%(home)s\">la page d'accueil "
-"des modules</a>. </li> </ul>"
+"<h1>Nous sommes désolés, mais nous ne pouvons pas trouver ce que vous cherchez.</h1> <p> La page ou le fichier que vous vouliez n'a pas été trouvé sur notre site. Il est possible que vous ayez "
+"cliqué sur un lien mort, ou que l'adresse entrée soit erronée. </p> <ul> <li>Si vous avez tapé l'adresse, vérifiez-la.</li> <li> Si vous avez suivi un lien, merci de vous en informer à <a "
+"href=\"mailto:webmaster@mozilla.com\">webmaster@mozilla.com</a>. Dites-nous d'où vous veniez et ce que vous cherchiez, nous ferons notre maximum pour faire en sorte de corriger le problème. </li> "
+"</ul> <p>Vous pouvez aussi faire un tour sur nos pages populaires.</p> <ul> <li>Est-ce qu'une <a href=\"%(rec)s\">liste de modules en vedette</a> vous intéresse ?</li> <li> Est-ce que vous voulez "
+"<a href=\"%(search)s\">rechercher des modules</a> ? Vous pouvez aller sur la <a href=\"%(search)s\">page de recherche</a> ou simplement utiliser le champs de recherche ci-dessus. </li> <li> Si vous"
+" voulez recommencer, rendez-vous sur <a href=\"%(home)s\">la page d'accueil des modules</a>. </li> </ul>"
 
 #: src/olympia/amo/templates/amo/500.html:3
 msgid "Oops"
@@ -2461,84 +1915,53 @@ msgstr "Oops"
 
 #: src/olympia/amo/templates/amo/500.html:6
 #, python-format
-msgid ""
-"<h1>Oops! We had an error.</h1> <p>We'll get to fixing that soon.</p> <p> "
-"You can try refreshing the page, or head back to the <a href=\"%(home)s"
-"\">Add-ons homepage</a>. </p>"
+msgid "<h1>Oops! We had an error.</h1> <p>We'll get to fixing that soon.</p> <p> You can try refreshing the page, or head back to the <a href=\"%(home)s\">Add-ons homepage</a>. </p>"
 msgstr ""
-"<h1>Oops ! Une erreur a été rencontrée.</h1> <p>Nous allons la corriger "
-"rapidement.</p> <p> Vous pouvez essayer de recharger la page, ou retourner "
-"sur <a href=\"%(home)s\">la page d'accueil</a>. </p>"
+"<h1>Oops ! Une erreur a été rencontrée.</h1> <p>Nous allons la corriger rapidement.</p> <p> Vous pouvez essayer de recharger la page, ou retourner sur <a href=\"%(home)s\">la page d'accueil</a>. "
+"</p>"
 
 #: src/olympia/amo/templates/amo/license_link.html:10
 msgid "Some rights reserved"
 msgstr "Certains droits réservés"
 
-#: src/olympia/amo/templates/amo/no_results.html:1
-#: src/olympia/editors/templates/editors/includes/search_results_themes.html:26
+#: src/olympia/amo/templates/amo/no_results.html:1 src/olympia/editors/templates/editors/includes/search_results_themes.html:26
 msgid "No results found"
 msgstr "Aucun résultat trouvé"
 
 #. abbreviation of 'previous'
-#: src/olympia/amo/templates/amo/paginator.html:6
-#: src/olympia/amo/templates/amo/mobile/paginator.html:4
-#: src/olympia/amo/templates/amo/mobile/paginator.html:6
-#: src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:49
-#: src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:63
-#: src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:76
-#: src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:89
+#: src/olympia/amo/templates/amo/paginator.html:6 src/olympia/amo/templates/amo/mobile/paginator.html:4 src/olympia/amo/templates/amo/mobile/paginator.html:6
+#: src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:49 src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:63
+#: src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:76 src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:89
 #: src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:102
 msgid "Prev"
 msgstr "Préc."
 
-#: src/olympia/amo/templates/amo/paginator.html:26
-#: src/olympia/amo/templates/amo/impala/paginator.html:26
-#: src/olympia/amo/templates/amo/mobile/impala_paginator.html:16
-#: src/olympia/amo/templates/amo/mobile/paginator.html:14
-#: src/olympia/amo/templates/amo/mobile/paginator.html:16
-#: src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:51
-#: src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:65
-#: src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:78
-#: src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:91
-#: src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:104
-#: src/olympia/discovery/templates/discovery/pane.html:45
-#: src/olympia/discovery/templates/discovery/addons/detail.html:39
-#: src/olympia/stats/templates/stats/stats.html:167
+#: src/olympia/amo/templates/amo/paginator.html:26 src/olympia/amo/templates/amo/impala/paginator.html:26 src/olympia/amo/templates/amo/mobile/impala_paginator.html:16
+#: src/olympia/amo/templates/amo/mobile/paginator.html:14 src/olympia/amo/templates/amo/mobile/paginator.html:16 src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:51
+#: src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:65 src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:78
+#: src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:91 src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:104
+#: src/olympia/discovery/templates/discovery/pane.html:45 src/olympia/discovery/templates/discovery/addons/detail.html:39 src/olympia/stats/templates/stats/stats.html:169
 msgid "Next"
 msgstr "Suivant"
 
-#: src/olympia/amo/templates/amo/paginator.html:32
-#: src/olympia/editors/templates/editors/includes/paginator_history.html:11
+#: src/olympia/amo/templates/amo/paginator.html:32 src/olympia/editors/templates/editors/includes/paginator_history.html:11
 #, python-format
-msgid ""
-"Results <strong>%(begin)s</strong>&ndash;<strong>%(end)s</strong> of "
-"<strong>%(count)s</strong>"
-msgstr ""
-"Resultats <strong>%(begin)s</strong>&ndash;<strong>%(end)s</strong> sur "
-"<strong>%(count)s</strong>"
+msgid "Results <strong>%(begin)s</strong>&ndash;<strong>%(end)s</strong> of <strong>%(count)s</strong>"
+msgstr "Resultats <strong>%(begin)s</strong>&ndash;<strong>%(end)s</strong> sur <strong>%(count)s</strong>"
 
-#: src/olympia/amo/templates/amo/read-only.html:3
-#: src/olympia/amo/templates/amo/read-only.html:7
+#: src/olympia/amo/templates/amo/read-only.html:3 src/olympia/amo/templates/amo/read-only.html:7
 msgid "Maintenance in progress"
 msgstr "Maintenance en cours"
 
 #: src/olympia/amo/templates/amo/read-only.html:9
-msgid ""
-"This feature is temporarily disabled while we perform website maintenance. "
-"Please use your browser's Back button and try again a little later."
+msgid "This feature is temporarily disabled while we perform website maintenance. Please use your browser's Back button and try again a little later."
 msgstr ""
-"Cette fonctionnalité est temporairement désactivée pendant que nous "
-"procédons à une maintenance du site web. Merci d'utiliser le bouton "
-"Précédent de votre navigateur et de réessayer un peu plus tard."
+"Cette fonctionnalité est temporairement désactivée pendant que nous procédons à une maintenance du site web. Merci d'utiliser le bouton Précédent de votre navigateur et de réessayer un peu plus "
+"tard."
 
 #: src/olympia/amo/templates/amo/read-only.html:14
-msgid ""
-"Some features on this page are temporarily disabled while we perform website"
-" maintenance. Please try again a little later."
-msgstr ""
-"Certaines fonctionnalités de cette page sont temporairement désactivées "
-"pendant que nous effectuons une maintenance du site web. Merci de réessayer "
-"un peu plus tard."
+msgid "Some features on this page are temporarily disabled while we perform website maintenance. Please try again a little later."
+msgstr "Certaines fonctionnalités de cette page sont temporairement désactivées pendant que nous effectuons une maintenance du site web. Merci de réessayer un peu plus tard."
 
 #: src/olympia/amo/templates/amo/recaptcha.html:4
 msgid "Are you human?"
@@ -2546,25 +1969,14 @@ msgstr "Êtes-vous un être humain ?"
 
 #: src/olympia/amo/templates/amo/recaptcha.html:8
 msgid ""
-"<p> Please enter <strong>all the words</strong> below, <strong>separated by "
-"a space if necessary</strong>. </p> <p> If this is hard to read, you can <a "
-"href=\"#\" id=\"recaptcha_different\">try different words</a> or <a "
-"href=\"#\" id=\"recaptcha_audio\">try a different type of challenge</a> "
-"instead. </p>"
+"<p> Please enter <strong>all the words</strong> below, <strong>separated by a space if necessary</strong>. </p> <p> If this is hard to read, you can <a href=\"#\" id=\"recaptcha_different\">try "
+"different words</a> or <a href=\"#\" id=\"recaptcha_audio\">try a different type of challenge</a> instead. </p>"
 msgstr ""
-"<p> Veuillez saisir <strong>tous les mots</strong> ci-après, <strong>séparés"
-" par des espaces si nécessaire</strong>. </p> <p> Si cela est trop dur à "
-"lire, vous pouvez <a href=\"#\" id=\"recaptcha_different\">essayer "
-"différents mots</a> ou <a href=\"#\" id=\"recaptcha_audio\">essayer un autre"
-" type de challenge</a> à la place. </p>"
+"<p> Veuillez saisir <strong>tous les mots</strong> ci-après, <strong>séparés par des espaces si nécessaire</strong>. </p> <p> Si cela est trop dur à lire, vous pouvez <a href=\"#\" "
+"id=\"recaptcha_different\">essayer différents mots</a> ou <a href=\"#\" id=\"recaptcha_audio\">essayer un autre type de challenge</a> à la place. </p>"
 
-#: src/olympia/amo/templates/amo/side_nav.html:4
-#: src/olympia/amo/templates/amo/side_nav.html:12
-#: src/olympia/amo/templates/amo/site_nav.html:4
-#: src/olympia/amo/templates/amo/site_nav.html:26
-#: src/olympia/browse/views.py:56 src/olympia/browse/views.py:66
-#: src/olympia/browse/views.py:237 src/olympia/browse/views.py:282
-#: src/olympia/search/forms.py:86
+#: src/olympia/amo/templates/amo/side_nav.html:4 src/olympia/amo/templates/amo/side_nav.html:12 src/olympia/amo/templates/amo/site_nav.html:4 src/olympia/amo/templates/amo/site_nav.html:26
+#: src/olympia/browse/views.py:56 src/olympia/browse/views.py:66 src/olympia/browse/views.py:204 src/olympia/browse/views.py:249 src/olympia/search/forms.py:86
 msgid "Top Rated"
 msgstr "Les mieux notés"
 
@@ -2573,83 +1985,59 @@ msgid "Explore"
 msgstr "Explorer"
 
 # Plural in this context means many of the add-on type
-#: src/olympia/amo/templates/amo/site_nav.html:23
-#: src/olympia/browse/feeds.py:65 src/olympia/browse/feeds.py:78
-#: src/olympia/browse/feeds.py:92 src/olympia/browse/feeds.py:100
-#: src/olympia/browse/templates/browse/base_listing.html:7
-#: src/olympia/browse/templates/browse/creatured.html:10
-#: src/olympia/browse/templates/browse/impala/base_listing.html:37
+#: src/olympia/amo/templates/amo/site_nav.html:23 src/olympia/browse/feeds.py:65 src/olympia/browse/feeds.py:78 src/olympia/browse/feeds.py:92 src/olympia/browse/feeds.py:100
+#: src/olympia/browse/templates/browse/base_listing.html:7 src/olympia/browse/templates/browse/creatured.html:10 src/olympia/browse/templates/browse/impala/base_listing.html:37
 #: src/olympia/constants/base.py:173 src/olympia/templates/menu_links.html:8
 msgid "Extensions"
 msgstr "Extensions"
 
-#: src/olympia/amo/templates/amo/site_nav.html:45
+#: src/olympia/amo/templates/amo/site_nav.html:44
 msgid "Want more customization? Try <b>Complete Themes</b>"
-msgstr ""
-"Vous souhaitez personnaliser davantage votre navigateur ? Essayez les "
-"<b>thèmes complets</b>"
+msgstr "Vous souhaitez personnaliser davantage votre navigateur ? Essayez les <b>thèmes complets</b>"
 
-#: src/olympia/amo/templates/amo/site_nav.html:56
-#: src/olympia/bandwagon/views.py:96
+#: src/olympia/amo/templates/amo/site_nav.html:54 src/olympia/bandwagon/views.py:96
 msgid "Most Followers"
 msgstr "Les plus suivis"
 
-#: src/olympia/amo/templates/amo/site_nav.html:68
-#: src/olympia/bandwagon/templates/bandwagon/impala/collection_sidebar.html:16
-#: src/olympia/bandwagon/templates/bandwagon/includes/collection_sidebar.html:18
+#: src/olympia/amo/templates/amo/site_nav.html:66 src/olympia/bandwagon/templates/bandwagon/impala/collection_sidebar.html:16 src/olympia/bandwagon/templates/bandwagon/includes/collection_sidebar.html:18
 msgid "Collections I've Made"
 msgstr "Collections que j'ai faites"
 
-#: src/olympia/amo/templates/amo/site_nav.html:70
-#: src/olympia/bandwagon/templates/bandwagon/user_listing.html:4
-#: src/olympia/bandwagon/templates/bandwagon/impala/collection_sidebar.html:13
+#: src/olympia/amo/templates/amo/site_nav.html:68 src/olympia/bandwagon/templates/bandwagon/user_listing.html:4 src/olympia/bandwagon/templates/bandwagon/impala/collection_sidebar.html:13
 #: src/olympia/bandwagon/templates/bandwagon/includes/collection_sidebar.html:15
 msgid "Collections I'm Following"
 msgstr "Collections que je suis"
 
-#: src/olympia/amo/templates/amo/site_nav.html:73
-#: src/olympia/bandwagon/templates/bandwagon/impala/collection_sidebar.html:18
-#: src/olympia/bandwagon/templates/bandwagon/includes/collection_sidebar.html:20
-#: src/olympia/users/models.py:512
+#: src/olympia/amo/templates/amo/site_nav.html:71 src/olympia/bandwagon/templates/bandwagon/impala/collection_sidebar.html:18 src/olympia/bandwagon/templates/bandwagon/includes/collection_sidebar.html:20
+#: src/olympia/users/models.py:521
 msgid "My Favorite Add-ons"
 msgstr "Mes modules favoris"
 
-#: src/olympia/amo/templates/amo/site_nav.html:78
+#: src/olympia/amo/templates/amo/site_nav.html:76
 msgid "More&hellip;"
 msgstr "Plus &hellip;"
 
-#: src/olympia/amo/templates/amo/site_nav.html:82
+#: src/olympia/amo/templates/amo/site_nav.html:80
 msgid "Add-ons for Mobile"
 msgstr "Modules pour Mobile"
 
-#: src/olympia/amo/templates/amo/site_nav.html:86
-#: src/olympia/browse/feeds.py:207
-#: src/olympia/browse/templates/browse/search_tools.html:3
-#: src/olympia/constants/base.py:176 src/olympia/templates/menu_links.html:10
+#: src/olympia/amo/templates/amo/site_nav.html:84 src/olympia/browse/feeds.py:207 src/olympia/browse/templates/browse/search_tools.html:3 src/olympia/constants/base.py:176
+#: src/olympia/templates/menu_links.html:10
 msgid "Search Tools"
 msgstr "Outils de recherche"
 
 #. This is a page range (e.g., Page 1 of 50).
-#: src/olympia/amo/templates/amo/impala/paginator.html:5
-#: src/olympia/amo/templates/amo/mobile/impala_paginator.html:26
+#: src/olympia/amo/templates/amo/impala/paginator.html:5 src/olympia/amo/templates/amo/mobile/impala_paginator.html:26
 #, python-format
-msgid ""
-"Page <a href=\"%(current_pg_url)s\">%(current_pg)s</a> of <a "
-"href=\"%(last_pg_url)s\">%(last_pg)s</a>"
-msgstr ""
-"Page <a href=\"%(current_pg_url)s\">%(current_pg)s</a> de <a "
-"href=\"%(last_pg_url)s\">%(last_pg)s</a>"
+msgid "Page <a href=\"%(current_pg_url)s\">%(current_pg)s</a> of <a href=\"%(last_pg_url)s\">%(last_pg)s</a>"
+msgstr "Page <a href=\"%(current_pg_url)s\">%(current_pg)s</a> de <a href=\"%(last_pg_url)s\">%(last_pg)s</a>"
 
-#: src/olympia/amo/templates/amo/impala/paginator.html:16
-#: src/olympia/amo/templates/amo/mobile/impala_paginator.html:6
+#: src/olympia/amo/templates/amo/impala/paginator.html:16 src/olympia/amo/templates/amo/mobile/impala_paginator.html:6
 msgid "Jump to first page"
 msgstr "Aller à la première page"
 
-#: src/olympia/amo/templates/amo/impala/paginator.html:22
-#: src/olympia/amo/templates/amo/mobile/impala_paginator.html:12
-#: src/olympia/discovery/templates/discovery/pane.html:44
-#: src/olympia/discovery/templates/discovery/addons/detail.html:38
-#: src/olympia/stats/templates/stats/stats.html:164
+#: src/olympia/amo/templates/amo/impala/paginator.html:22 src/olympia/amo/templates/amo/mobile/impala_paginator.html:12 src/olympia/discovery/templates/discovery/pane.html:44
+#: src/olympia/discovery/templates/discovery/addons/detail.html:38 src/olympia/stats/templates/stats/stats.html:166
 msgid "Previous"
 msgstr "Précédent"
 
@@ -2659,10 +2047,9 @@ msgstr "Aller à la dernière page"
 
 #. First and second arguments are the result range (e.g., 1-20);
 #. third argument is the number of total results (e.g., 1,000).
-#. third
+#. First and second arguments are the result range (e.g., 1-20);              third
 #. argument is the number of total results (e.g., 1,000).
-#: src/olympia/amo/templates/amo/impala/paginator.html:36
-#: src/olympia/amo/templates/amo/mobile/impala_paginator.html:38
+#: src/olympia/amo/templates/amo/impala/paginator.html:36 src/olympia/amo/templates/amo/mobile/impala_paginator.html:38
 #, python-format
 msgid "Showing <b>%(begin)s</b>&ndash;<b>%(end)s</b> of <b>%(count)s</b>"
 msgstr "Affiché <b>%(begin)s</b>&ndash;<b>%(end)s</b> sur <b>%(count)s</b>"
@@ -2673,42 +2060,52 @@ msgid_plural "Page {n}"
 msgstr[0] "Page {n}"
 msgstr[1] "Page {n}"
 
-#: src/olympia/amo/templates/services/install.html:38
-#, python-format
-msgid ""
-"If you are not prompted to install %(addon_name)s in a moment, please <a "
-"href=\"%(addon_xpi)s\">click here</a>."
-msgstr ""
-"Si l'installation de %(addon_name)s ne vous est pas proposé dans quelques "
-"secondes, merci de <a href=\"%(addon_xpi)s\">cliquer ici</a>."
-
-#: src/olympia/amo/tests/test_messages.py:57
-#: src/olympia/amo/tests/test_messages.py:58 src/olympia/reviews/forms.py:25
-#: src/olympia/reviews/forms.py:50
-#: src/olympia/reviews/templates/reviews/add.html:56
+#: src/olympia/amo/tests/test_messages.py:56 src/olympia/amo/tests/test_messages.py:57 src/olympia/reviews/forms.py:25 src/olympia/reviews/forms.py:50 src/olympia/reviews/templates/reviews/add.html:56
 #: src/olympia/reviews/templates/reviews/reply.html:30
 msgid "Title"
 msgstr "Titre"
 
-#: src/olympia/amo/tests/test_messages.py:57
-#: src/olympia/amo/tests/test_messages.py:58
+#: src/olympia/amo/tests/test_messages.py:56 src/olympia/amo/tests/test_messages.py:57
 msgid "Body"
 msgstr "Corps"
 
-#: src/olympia/amo/tests/test_messages.py:59
+#: src/olympia/amo/tests/test_messages.py:58
 msgid "Another Title"
 msgstr "Autre title"
 
-#: src/olympia/amo/tests/test_messages.py:59
+#: src/olympia/amo/tests/test_messages.py:58
 msgid "Another Body"
 msgstr "Autre corps"
 
-#: src/olympia/api/views.py:255
-msgid "Not implemented yet."
-msgstr "Pas encore implémenté"
+#: src/olympia/api/authentication.py:76
+msgid "Signature has expired."
+msgstr ""
 
-#: src/olympia/applications/views.py:39
-#: src/olympia/applications/templates/applications/appversions.html:3
+#: src/olympia/api/authentication.py:79
+msgid "Error decoding signature."
+msgstr ""
+
+#: src/olympia/api/authentication.py:82
+msgid "Invalid JWT Token."
+msgstr ""
+
+#: src/olympia/api/authentication.py:130
+msgid "Invalid Authorization header. No credentials provided."
+msgstr ""
+
+#: src/olympia/api/authentication.py:133
+msgid "Invalid Authorization header. Credentials string should not contain spaces."
+msgstr ""
+
+#: src/olympia/api/fields.py:29
+msgid "The field must have a length of at least {num} characters."
+msgstr ""
+
+#: src/olympia/api/fields.py:31
+msgid "The language code {lang_code} is invalid."
+msgstr ""
+
+#: src/olympia/applications/views.py:39 src/olympia/applications/templates/applications/appversions.html:3
 msgid "Application Versions"
 msgstr "Versions des logiciels"
 
@@ -2721,22 +2118,17 @@ msgid "Valid Application Versions"
 msgstr "Versions valides de l'application"
 
 #: src/olympia/applications/templates/applications/appversions.html:12
-msgid ""
-"Add-ons submitted to Mozilla Add-ons must have a manifest file with at least"
-" one of the below applications supported. Only the versions listed below are"
-" allowed for these applications."
+msgid "Add-ons submitted to Mozilla Add-ons must have a manifest file with at least one of the below applications supported. Only the versions listed below are allowed for these applications."
 msgstr ""
-"Les modules soumis au site Mozilla Add-ons doivent être accompagnés d'un "
-"fichier manifeste qui contient au moins un des logiciels listés ci-dessous. "
-"Seules les versions listées ci-dessous sont autorisées."
+"Les modules soumis au site Mozilla Add-ons doivent être accompagnés d'un fichier manifeste qui contient au moins un des logiciels listés ci-dessous. Seules les versions listées ci-dessous sont "
+"autorisées."
 
-#: src/olympia/applications/templates/applications/appversions.html:25
+#: src/olympia/applications/templates/applications/appversions.html:25 src/olympia/editors/helpers.py:361
 msgid "GUID"
 msgstr "GUID"
 
 #. {0} is an add-on name.
-#: src/olympia/applications/templates/applications/appversions.html:26
-#: src/olympia/versions/templates/versions/version_list.html:23
+#: src/olympia/applications/templates/applications/appversions.html:26 src/olympia/versions/templates/versions/version_list.html:23
 msgid "Versions"
 msgstr "Versions"
 
@@ -2746,14 +2138,8 @@ msgstr "https://developer.mozilla.org/fr/Manifestes_d'installation"
 
 #: src/olympia/applications/templates/applications/appversions.html:31
 #, python-format
-msgid ""
-"If your supported application does not require a manifest file, you still "
-"must include one with the required properties as specified <a "
-"href=\"%(url)s\">here</a>."
-msgstr ""
-"Même si votre logiciel ne requiert pas un fichier manifeste, vous devez "
-"toujours en inclure un avec les propriétés idoines comme spécifié <a "
-"href=\"%(url)s\">ici</a>."
+msgid "If your supported application does not require a manifest file, you still must include one with the required properties as specified <a href=\"%(url)s\">here</a>."
+msgstr "Même si votre logiciel ne requiert pas un fichier manifeste, vous devez toujours en inclure un avec les propriétés idoines comme spécifié <a href=\"%(url)s\">ici</a>."
 
 #. L10n: {0} is 'Add-ons for <app>'.
 #: src/olympia/bandwagon/feeds.py:44
@@ -2761,13 +2147,9 @@ msgstr ""
 msgid "Collections :: %s"
 msgstr "Collections :: %s"
 
-#: src/olympia/bandwagon/feeds.py:50
-#: src/olympia/bandwagon/templates/bandwagon/collection_detail.html:137
-msgid ""
-"Collections are groups of related add-ons that anyone can create and share."
-msgstr ""
-"Les collections sont des groupes de modules liés entre eux que n'importe qui"
-" peut créer et partager."
+#: src/olympia/bandwagon/feeds.py:50 src/olympia/bandwagon/templates/bandwagon/collection_detail.html:137
+msgid "Collections are groups of related add-ons that anyone can create and share."
+msgstr "Les collections sont des groupes de modules liés entre eux que n'importe qui peut créer et partager."
 
 #. L10n: {0} is a collection name, {1} is 'Add-ons for <app>'.
 #: src/olympia/bandwagon/feeds.py:70
@@ -2804,8 +2186,7 @@ msgstr "Icône"
 
 #: src/olympia/bandwagon/forms.py:143
 msgid "Please don't fill out this field, it's used to catch bots"
-msgstr ""
-"Veuillez ne pas saisir ce champ, celui-ci est utilisé pour piéger les robots"
+msgstr "Veuillez ne pas saisir ce champ, celui-ci est utilisé pour piéger les robots"
 
 #: src/olympia/bandwagon/forms.py:167
 msgid "This name cannot be used."
@@ -2819,12 +2200,11 @@ msgstr "Les liens ne sont pas autorisés."
 msgid "This url is already in use by another collection"
 msgstr "Cette adresse est déjà utilisée par une autre collection"
 
-#: src/olympia/bandwagon/forms.py:197 src/olympia/devhub/views.py:1049
+#: src/olympia/bandwagon/forms.py:197 src/olympia/devhub/views.py:1050
 msgid "Icons must be either PNG or JPG."
 msgstr "Les icônes doivent être en PNG ou JPG."
 
-#: src/olympia/bandwagon/forms.py:202 src/olympia/devhub/views.py:1067
-#: src/olympia/users/forms.py:476
+#: src/olympia/bandwagon/forms.py:202 src/olympia/devhub/views.py:1068 src/olympia/users/forms.py:476
 #, python-format
 msgid "Please use images smaller than %dMB."
 msgstr "Merci d'utiliser des images de taille inférieure à %dMo."
@@ -2845,8 +2225,7 @@ msgstr "Retirer mon vote pour cette collection"
 msgid "Log in to vote for this collection"
 msgstr "Connectez-vous pour voter pour cette collection"
 
-#: src/olympia/bandwagon/helpers.py:123
-#: src/olympia/bandwagon/templates/bandwagon/favorites_widget.html:2
+#: src/olympia/bandwagon/helpers.py:123 src/olympia/bandwagon/templates/bandwagon/favorites_widget.html:2
 msgid "Add to favorites"
 msgstr "Ajouter aux favoris"
 
@@ -2854,20 +2233,13 @@ msgstr "Ajouter aux favoris"
 msgid "Favorite"
 msgstr "Favoris"
 
-#: src/olympia/bandwagon/helpers.py:124
-#: src/olympia/bandwagon/templates/bandwagon/favorites_widget.html:2
+#: src/olympia/bandwagon/helpers.py:124 src/olympia/bandwagon/templates/bandwagon/favorites_widget.html:2
 msgid "Remove from favorites"
 msgstr "Enlever des favoris"
 
-#: src/olympia/bandwagon/views.py:98 src/olympia/bandwagon/views.py:191
-#: src/olympia/browse/views.py:58 src/olympia/browse/views.py:69
-#: src/olympia/browse/views.py:458 src/olympia/devhub/views.py:74
-#: src/olympia/devhub/views.py:82
-#: src/olympia/devhub/templates/devhub/addons/edit/basic.html:20
-#: src/olympia/editors/templates/editors/leaderboard.html:24
-#: src/olympia/editors/templates/editors/themes/queue_list.html:48
-#: src/olympia/search/forms.py:17 src/olympia/search/forms.py:89
-#: src/olympia/users/templates/users/vcard.html:5
+#: src/olympia/bandwagon/views.py:98 src/olympia/bandwagon/views.py:191 src/olympia/browse/views.py:58 src/olympia/browse/views.py:69 src/olympia/browse/views.py:425 src/olympia/devhub/views.py:73
+#: src/olympia/devhub/views.py:81 src/olympia/devhub/templates/devhub/addons/edit/basic.html:20 src/olympia/editors/templates/editors/leaderboard.html:24
+#: src/olympia/editors/templates/editors/themes/queue_list.html:48 src/olympia/search/forms.py:17 src/olympia/search/forms.py:89 src/olympia/users/templates/users/vcard.html:5
 msgid "Name"
 msgstr "Nom"
 
@@ -2875,8 +2247,7 @@ msgstr "Nom"
 msgid "Recently Popular"
 msgstr "Dernièrement populaire"
 
-#: src/olympia/bandwagon/views.py:189
-#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:18
+#: src/olympia/bandwagon/views.py:189 src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:16
 msgid "Added"
 msgstr "Ajouté"
 
@@ -2890,10 +2261,8 @@ msgstr "Collection créée !"
 
 #: src/olympia/bandwagon/views.py:316
 #, python-format
-msgid ""
-"Your new collection is shown below. You can <ahref=\"%(url)s\">edit "
-"additional settings</a> if you'dlike."
-msgstr ""
+msgid "Your new collection is shown below. You can <a href=\"%(url)s\">edit additional settings</a> if you'd like."
+msgstr "Votre nouvelle collection est affichée ci-dessous. Vous pouvez <a href=\"%(url)s\">modifier des paramètres additionnels</a> si vous le souhaitez."
 
 #: src/olympia/bandwagon/views.py:322
 msgid "Collection updated!"
@@ -2902,38 +2271,26 @@ msgstr "Collection mise à jour !"
 #: src/olympia/bandwagon/views.py:323
 #, python-format
 msgid "<a href=\"%(url)s\">View your collection</a> to see the changes."
-msgstr ""
-"<a href=\"%(url)s\">Voir votre collection</a> pour observer les changements."
+msgstr "<a href=\"%(url)s\">Voir votre collection</a> pour observer les changements."
 
 #: src/olympia/bandwagon/views.py:579
 msgid "Icon Deleted"
 msgstr "Icône supprimée"
 
-#: src/olympia/bandwagon/templates/bandwagon/add.html:3
-#: src/olympia/bandwagon/templates/bandwagon/add.html:11
-#: src/olympia/bandwagon/templates/bandwagon/includes/collection_sidebar.html:26
+#: src/olympia/bandwagon/templates/bandwagon/add.html:3 src/olympia/bandwagon/templates/bandwagon/add.html:11 src/olympia/bandwagon/templates/bandwagon/includes/collection_sidebar.html:26
 msgid "Create a New Collection"
 msgstr "Créer une nouvelle collection"
 
-#: src/olympia/bandwagon/templates/bandwagon/add.html:9
-#: src/olympia/devhub/templates/devhub/personas/submit.html:14
+#: src/olympia/bandwagon/templates/bandwagon/add.html:9 src/olympia/devhub/templates/devhub/personas/submit.html:14
 msgid "Create"
 msgstr "Créer"
 
-#: src/olympia/bandwagon/templates/bandwagon/add.html:24
-#: src/olympia/bandwagon/templates/bandwagon/ajax_new.html:28
+#: src/olympia/bandwagon/templates/bandwagon/add.html:24 src/olympia/bandwagon/templates/bandwagon/ajax_new.html:28
 #, python-format
-msgid ""
-"As noted in our <a href=\"%(legal)s\">Legal Notices</a>, individual "
-"collection arrangements are governed by the Creative Commons Attribution "
-"Share-Alike License"
-msgstr ""
-"Comme indiqué dans nos <a href=\"%(legal)s\">mentions légales</a>, les "
-"collections individuelles sont mises sous la licence Creative Commons "
-"Attribution Share-Alike License"
+msgid "As noted in our <a href=\"%(legal)s\">Legal Notices</a>, individual collection arrangements are governed by the Creative Commons Attribution Share-Alike License"
+msgstr "Comme indiqué dans nos <a href=\"%(legal)s\">mentions légales</a>, les collections individuelles sont mises sous la licence Creative Commons Attribution Share-Alike License"
 
-#: src/olympia/bandwagon/templates/bandwagon/add.html:33
-#: src/olympia/bandwagon/templates/bandwagon/ajax_new.html:38
+#: src/olympia/bandwagon/templates/bandwagon/add.html:33 src/olympia/bandwagon/templates/bandwagon/ajax_new.html:38
 msgid "Create Collection"
 msgstr "Créer une collection"
 
@@ -2949,8 +2306,7 @@ msgstr "Commencer une nouvelle collection &hellip;"
 msgid "Start a New Collection"
 msgstr "Commencer une nouvelle collection"
 
-#: src/olympia/bandwagon/templates/bandwagon/ajax_new.html:6
-#: src/olympia/bandwagon/templates/bandwagon/includes/addedit.html:7
+#: src/olympia/bandwagon/templates/bandwagon/ajax_new.html:6 src/olympia/bandwagon/templates/bandwagon/includes/addedit.html:7
 msgid "Name:"
 msgstr "Nom :"
 
@@ -2963,15 +2319,11 @@ msgstr "ou <a id=\"collections-new-cancel\" href=\"#\">annuler</a>"
 msgid "To rate collections, you must have an add-ons account."
 msgstr "Pour noter les collections, vous devez avoir un compte."
 
-#: src/olympia/bandwagon/templates/bandwagon/barometer.html:18
-#: src/olympia/templates/base.html:145
-#: src/olympia/templates/impala/base.html:198
+#: src/olympia/bandwagon/templates/bandwagon/barometer.html:18 src/olympia/templates/base.html:145 src/olympia/templates/impala/base.html:198
 msgid "Create an Add-ons Account"
 msgstr "Créer un compte modules"
 
-#: src/olympia/bandwagon/templates/bandwagon/barometer.html:21
-#: src/olympia/templates/base.html:148
-#: src/olympia/templates/impala/base.html:201
+#: src/olympia/bandwagon/templates/bandwagon/barometer.html:21 src/olympia/templates/base.html:148 src/olympia/templates/impala/base.html:201
 #, python-format
 msgid "or <a href=\"%(login)s\">log in to your current account</a>"
 msgstr "ou <a href=\"%(login)s\">se connecter à votre compte</a>"
@@ -2984,8 +2336,7 @@ msgstr "{0} :: Collections"
 msgid "private"
 msgstr "privée"
 
-#: src/olympia/bandwagon/templates/bandwagon/collection_detail.html:45
-#: src/olympia/bandwagon/templates/bandwagon/mobile/listing_items.html:9
+#: src/olympia/bandwagon/templates/bandwagon/collection_detail.html:45 src/olympia/bandwagon/templates/bandwagon/mobile/listing_items.html:9
 #, python-format
 msgid "<span>%(num)s</span> follower"
 msgid_plural "<span>%(num)s</span> followers"
@@ -3020,8 +2371,7 @@ msgstr "Plus d'options :"
 msgid "Edit Collection"
 msgstr "Modifier la collection"
 
-#: src/olympia/bandwagon/templates/bandwagon/collection_detail.html:88
-#: src/olympia/bandwagon/templates/bandwagon/includes/delete.html:3
+#: src/olympia/bandwagon/templates/bandwagon/collection_detail.html:88 src/olympia/bandwagon/templates/bandwagon/includes/delete.html:3
 msgid "Delete Collection"
 msgstr "Supprimer la collection"
 
@@ -3039,12 +2389,8 @@ msgid_plural "%(num)s Add-ons in this Collection"
 msgstr[0] "%(num)s Module dans cette collection"
 msgstr[1] "%(num)s Modules dans cette collection"
 
-#: src/olympia/bandwagon/templates/bandwagon/collection_detail.html:125
-#: src/olympia/compat/templates/compat/index.html:25
-#: src/olympia/compat/templates/compat/reporter_detail.html:29
-#: src/olympia/files/templates/files/viewer.html:29
-#: src/olympia/templates/amo_footer.html:17
-#: src/olympia/templates/includes/lang_switcher.html:10
+#: src/olympia/bandwagon/templates/bandwagon/collection_detail.html:125 src/olympia/compat/templates/compat/reporter_detail.html:29 src/olympia/files/templates/files/viewer.html:29
+#: src/olympia/templates/amo_footer.html:17 src/olympia/templates/includes/lang_switcher.html:10
 msgid "Go"
 msgstr "Ok !"
 
@@ -3070,27 +2416,17 @@ msgstr "Voir toutes les collections de cet utilisateur"
 
 #: src/olympia/bandwagon/templates/bandwagon/collection_detail.html:179
 msgid ""
-"Add-ons that you mark as favorites using the <b>Add to Favorites</b> feature"
-" appear below. This collection is currently <b>public</b>, which means "
-"everyone can see it. If you would like to hide it from public view, click "
-"the button below to make it private."
-msgstr ""
-"Les modules que vous marquez comme favoris avec la fonctionnalité <b>Ajouter"
-" aux favoris</b> apparaissent ci-dessous. Cette collection est pour le "
-"moment <b>publique</b>."
+"Add-ons that you mark as favorites using the <b>Add to Favorites</b> feature appear below. This collection is currently <b>public</b>, which means everyone can see it. If you would like to hide it "
+"from public view, click the button below to make it private."
+msgstr "Les modules que vous marquez comme favoris avec la fonctionnalité <b>Ajouter aux favoris</b> apparaissent ci-dessous. Cette collection est pour le moment <b>publique</b>."
 
 #: src/olympia/bandwagon/templates/bandwagon/collection_detail.html:186
 msgid ""
-"Add-ons that you mark as favorites using the <b>Add to Favorites</b> feature"
-" appear below. This collection is currently <b>private</b>, which means only"
-" you can see it. If you would like everyone to be able to see your "
-"favorites, click the button below to make it public."
+"Add-ons that you mark as favorites using the <b>Add to Favorites</b> feature appear below. This collection is currently <b>private</b>, which means only you can see it. If you would like everyone "
+"to be able to see your favorites, click the button below to make it public."
 msgstr ""
-"Les modules que vous marquez comme favoris avec la fonctionnalité <b>Ajouter"
-" aux favoris</b> apparaissent ci-dessous. Cette collection est pour le "
-"moment <b>privée</b>, ce qui signifie que seul vous pouvez la voir. Si vous "
-"voulez que tout le monde soit en mesure de voir vos favoris, cliquez sur le "
-"bouton ci-dessous pour rendre cette collection publique."
+"Les modules que vous marquez comme favoris avec la fonctionnalité <b>Ajouter aux favoris</b> apparaissent ci-dessous. Cette collection est pour le moment <b>privée</b>, ce qui signifie que seul "
+"vous pouvez la voir. Si vous voulez que tout le monde soit en mesure de voir vos favoris, cliquez sur le bouton ci-dessous pour rendre cette collection publique."
 
 #: src/olympia/bandwagon/templates/bandwagon/collection_detail.html:196
 msgid "My favorite add-ons"
@@ -3110,20 +2446,18 @@ msgid_plural "<span>%(followers)s</span> followers"
 msgstr[0] "<span>%(followers)s</span> suiveur"
 msgstr[1] "<span>%(followers)s</span> suiveurs"
 
-#. People "follow" collections to get notified of updates.
-#. Like
+#. People "follow" collections to get notified of updates.                    Like
 #. Twitter followers.
+#. People "follow" collections to get notified of updates.
 #. Like Twitter followers.
-#: src/olympia/bandwagon/templates/bandwagon/collection_listing_items.html:10
-#: src/olympia/bandwagon/templates/bandwagon/impala/collection_listing_items.html:18
+#: src/olympia/bandwagon/templates/bandwagon/collection_listing_items.html:10 src/olympia/bandwagon/templates/bandwagon/impala/collection_listing_items.html:18
 #, python-format
 msgid "%(num)s weekly follower"
 msgid_plural "%(num)s weekly followers"
 msgstr[0] "%(num)s suiveur hebdomadaire"
 msgstr[1] "%(num)s suiveurs hebdomadaires"
 
-#. People "follow" collections to get notified of updates.
-#. Like
+#. People "follow" collections to get notified of updates.                    Like
 #. Twitter followers.
 #: src/olympia/bandwagon/templates/bandwagon/collection_listing_items.html:18
 #, python-format
@@ -3132,32 +2466,28 @@ msgid_plural "%(num)s monthly followers"
 msgstr[0] "%(num)s suiveur mensuel"
 msgstr[1] "%(num)s suiveurs mensuel"
 
-#. People "follow" collections to get notified of updates.
-#. Like
+#. People "follow" collections to get notified of updates.                    Like
 #. Twitter followers.
+#. People "follow" collections to get notified of updates.
 #. Like Twitter followers.
-#: src/olympia/bandwagon/templates/bandwagon/collection_listing_items.html:26
-#: src/olympia/bandwagon/templates/bandwagon/impala/collection_listing_items.html:26
+#: src/olympia/bandwagon/templates/bandwagon/collection_listing_items.html:26 src/olympia/bandwagon/templates/bandwagon/impala/collection_listing_items.html:26
 #, python-format
 msgid "%(num)s follower"
 msgid_plural "%(num)s followers"
 msgstr[0] "%(num)s suiveur"
 msgstr[1] "%(num)s suiveurs"
 
-#: src/olympia/bandwagon/templates/bandwagon/collection_listing_items.html:56
-#: src/olympia/bandwagon/templates/bandwagon/impala/collection_listing_items.html:9
+#: src/olympia/bandwagon/templates/bandwagon/collection_listing_items.html:56 src/olympia/bandwagon/templates/bandwagon/impala/collection_listing_items.html:9
 #: src/olympia/devhub/templates/devhub/personas/edit.html:27
 msgid "by {0}"
 msgstr "par {0}"
 
-#: src/olympia/bandwagon/templates/bandwagon/collection_widgets.html:5
-#: src/olympia/bandwagon/templates/bandwagon/collection_widgets.html:7
+#: src/olympia/bandwagon/templates/bandwagon/collection_widgets.html:5 src/olympia/bandwagon/templates/bandwagon/collection_widgets.html:7
 #: src/olympia/bandwagon/templates/bandwagon/impala/collection_listing_items.html:53
 msgid "Stop Following"
 msgstr "Arrêter de suivre"
 
-#: src/olympia/bandwagon/templates/bandwagon/collection_widgets.html:6
-#: src/olympia/bandwagon/templates/bandwagon/collection_widgets.html:7
+#: src/olympia/bandwagon/templates/bandwagon/collection_widgets.html:6 src/olympia/bandwagon/templates/bandwagon/collection_widgets.html:7
 #: src/olympia/bandwagon/templates/bandwagon/impala/collection_listing_items.html:53
 msgid "Follow this Collection"
 msgstr "Suivre cette collection"
@@ -3167,16 +2497,12 @@ msgid "Edit this Collection"
 msgstr "Modifier cette collection"
 
 #. %s is the name of the collection.
-#: src/olympia/bandwagon/templates/bandwagon/delete.html:4
-#: src/olympia/bandwagon/templates/bandwagon/delete.html:15
+#: src/olympia/bandwagon/templates/bandwagon/delete.html:4 src/olympia/bandwagon/templates/bandwagon/delete.html:15
 msgid "Delete {0}"
 msgstr "Supprimer {0}"
 
-#: src/olympia/bandwagon/templates/bandwagon/delete.html:13
-#: src/olympia/devhub/templates/devhub/addons/listing/item_actions.html:14
-#: src/olympia/devhub/templates/devhub/addons/listing/item_actions_theme.html:28
-#: src/olympia/devhub/templates/devhub/versions/list.html:131
-#: src/olympia/devhub/templates/devhub/versions/list.html:149
+#: src/olympia/bandwagon/templates/bandwagon/delete.html:13 src/olympia/devhub/templates/devhub/addons/listing/item_actions.html:14
+#: src/olympia/devhub/templates/devhub/addons/listing/item_actions_theme.html:28 src/olympia/devhub/templates/devhub/versions/list.html:131 src/olympia/devhub/templates/devhub/versions/list.html:149
 #: src/olympia/devhub/templates/devhub/versions/list.html:166
 msgid "Delete"
 msgstr "Supprimer"
@@ -3185,35 +2511,24 @@ msgstr "Supprimer"
 msgid "Are you sure?"
 msgstr "Le voulez-vous vraiment ?"
 
-#: src/olympia/bandwagon/templates/bandwagon/delete.html:21
-#: src/olympia/devhub/templates/devhub/personas/edit.html:131
-#: src/olympia/devhub/templates/devhub/personas/edit.html:152
-#: src/olympia/devhub/templates/devhub/personas/edit.html:173
-#: src/olympia/devhub/templates/devhub/personas/submit.html:77
-#: src/olympia/devhub/templates/devhub/personas/submit.html:98
+#: src/olympia/bandwagon/templates/bandwagon/delete.html:21 src/olympia/devhub/templates/devhub/personas/edit.html:131 src/olympia/devhub/templates/devhub/personas/edit.html:152
+#: src/olympia/devhub/templates/devhub/personas/edit.html:173 src/olympia/devhub/templates/devhub/personas/submit.html:77 src/olympia/devhub/templates/devhub/personas/submit.html:98
 #: src/olympia/devhub/templates/devhub/personas/submit.html:119
 msgid "Yes"
 msgstr "Oui"
 
-#: src/olympia/bandwagon/templates/bandwagon/delete.html:22
-#: src/olympia/devhub/templates/devhub/personas/edit.html:140
-#: src/olympia/devhub/templates/devhub/personas/edit.html:161
-#: src/olympia/devhub/templates/devhub/personas/edit.html:191
-#: src/olympia/devhub/templates/devhub/personas/submit.html:86
-#: src/olympia/devhub/templates/devhub/personas/submit.html:107
+#: src/olympia/bandwagon/templates/bandwagon/delete.html:22 src/olympia/devhub/templates/devhub/personas/edit.html:140 src/olympia/devhub/templates/devhub/personas/edit.html:161
+#: src/olympia/devhub/templates/devhub/personas/edit.html:191 src/olympia/devhub/templates/devhub/personas/submit.html:86 src/olympia/devhub/templates/devhub/personas/submit.html:107
 #: src/olympia/devhub/templates/devhub/personas/submit.html:137
 msgid "No"
 msgstr "Non"
 
 #. {0} is the name of the collection.
-#: src/olympia/bandwagon/templates/bandwagon/edit.html:5
-#: src/olympia/bandwagon/templates/bandwagon/edit.html:21
+#: src/olympia/bandwagon/templates/bandwagon/edit.html:5 src/olympia/bandwagon/templates/bandwagon/edit.html:21
 msgid "Edit {0}"
 msgstr "Modifier {0}"
 
-#: src/olympia/bandwagon/templates/bandwagon/edit.html:29
-#: src/olympia/devhub/templates/devhub/addons/edit/details.html:20
-#: src/olympia/editors/templates/editors/themes/themes.html:62
+#: src/olympia/bandwagon/templates/bandwagon/edit.html:29 src/olympia/devhub/templates/devhub/addons/edit/details.html:20 src/olympia/editors/templates/editors/themes/themes.html:62
 msgid "Description"
 msgstr "Description"
 
@@ -3221,32 +2536,18 @@ msgstr "Description"
 msgid "Contributors & More"
 msgstr "Contributeurs et plus"
 
-#: src/olympia/bandwagon/templates/bandwagon/edit.html:54
-#: src/olympia/bandwagon/templates/bandwagon/edit.html:67
-#: src/olympia/bandwagon/templates/bandwagon/edit.html:82
-#: src/olympia/devhub/templates/devhub/addons/ajax_compat_update.html:35
-#: src/olympia/devhub/templates/devhub/addons/owner.html:59
-#: src/olympia/devhub/templates/devhub/addons/profile.html:42
-#: src/olympia/devhub/templates/devhub/addons/edit/admin.html:101
-#: src/olympia/devhub/templates/devhub/addons/edit/basic.html:152
-#: src/olympia/devhub/templates/devhub/addons/edit/details.html:85
-#: src/olympia/devhub/templates/devhub/addons/edit/support.html:67
-#: src/olympia/devhub/templates/devhub/addons/edit/technical.html:166
-#: src/olympia/devhub/templates/devhub/addons/forms_shared/media.html:149
-#: src/olympia/devhub/templates/devhub/payments/voluntary.html:64
-#: src/olympia/devhub/templates/devhub/personas/edit.html:35
-#: src/olympia/devhub/templates/devhub/personas/edit.html:304
-#: src/olympia/devhub/templates/devhub/versions/edit.html:139
-#: src/olympia/translations/templates/translations/trans-menu.html:48
+#: src/olympia/bandwagon/templates/bandwagon/edit.html:54 src/olympia/bandwagon/templates/bandwagon/edit.html:67 src/olympia/bandwagon/templates/bandwagon/edit.html:82
+#: src/olympia/devhub/templates/devhub/addons/ajax_compat_update.html:35 src/olympia/devhub/templates/devhub/addons/owner.html:59 src/olympia/devhub/templates/devhub/addons/profile.html:42
+#: src/olympia/devhub/templates/devhub/addons/edit/admin.html:101 src/olympia/devhub/templates/devhub/addons/edit/basic.html:152 src/olympia/devhub/templates/devhub/addons/edit/details.html:85
+#: src/olympia/devhub/templates/devhub/addons/edit/support.html:67 src/olympia/devhub/templates/devhub/addons/edit/technical.html:166
+#: src/olympia/devhub/templates/devhub/addons/forms_shared/media.html:149 src/olympia/devhub/templates/devhub/payments/voluntary.html:64 src/olympia/devhub/templates/devhub/personas/edit.html:35
+#: src/olympia/devhub/templates/devhub/personas/edit.html:304 src/olympia/devhub/templates/devhub/versions/edit.html:139 src/olympia/translations/templates/translations/trans-menu.html:48
 msgid "Save Changes"
 msgstr "Enregistrer les modifications"
 
 # <option> text in a <select> for Author role in an add-on.
-#: src/olympia/bandwagon/templates/bandwagon/edit_contributors.html:9
-#: src/olympia/bandwagon/templates/bandwagon/edit_contributors.html:12
-#: src/olympia/bandwagon/templates/bandwagon/edit_contributors.html:17
-#: src/olympia/bandwagon/templates/bandwagon/edit_contributors.html:58
-#: src/olympia/constants/base.py:134
+#: src/olympia/bandwagon/templates/bandwagon/edit_contributors.html:9 src/olympia/bandwagon/templates/bandwagon/edit_contributors.html:12
+#: src/olympia/bandwagon/templates/bandwagon/edit_contributors.html:17 src/olympia/bandwagon/templates/bandwagon/edit_contributors.html:58 src/olympia/constants/base.py:134
 msgid "Owner"
 msgstr "Propriétaire"
 
@@ -3258,10 +2559,8 @@ msgstr "Rendre propriétaire"
 msgid "Remove this user as a contributor"
 msgstr "Enlever ce contributeur"
 
-#: src/olympia/bandwagon/templates/bandwagon/edit_contributors.html:18
-#: src/olympia/bandwagon/templates/bandwagon/edit_contributors.html:43
-#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:20
-#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:48
+#: src/olympia/bandwagon/templates/bandwagon/edit_contributors.html:18 src/olympia/bandwagon/templates/bandwagon/edit_contributors.html:43
+#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:18 src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:46
 #: src/olympia/devhub/templates/devhub/addons/ajax_compat_update.html:19
 msgid "Remove"
 msgstr "Supprimer"
@@ -3272,24 +2571,17 @@ msgstr "Contributeurs de la collection"
 
 #: src/olympia/bandwagon/templates/bandwagon/edit_contributors.html:26
 msgid ""
-"You can add multiple contributors to this collection. A contributor can add "
-"and remove add-ons from this collection, but cannot change its name or "
-"description. To add a contributor, enter their email in the box below. "
-"Contributors must have a Mozilla Add-ons account."
+"You can add multiple contributors to this collection. A contributor can add and remove add-ons from this collection, but cannot change its name or description. To add a contributor, enter their "
+"email in the box below. Contributors must have a Mozilla Add-ons account."
 msgstr ""
-"Vous pouvez ajouter de multiples contributeurs à cette collection. Un "
-"contributeur peut ajouter et supprimer des modules de cette collection, mais"
-" ne peut changer son nom ou sa description. Pour ajouter un contributeur, "
-"entrez son adresse courriel dans la zone de texte ci-dessous. Les "
-"contributeurs doivent avoir un compte Mozilla Add-ons."
+"Vous pouvez ajouter de multiples contributeurs à cette collection. Un contributeur peut ajouter et supprimer des modules de cette collection, mais ne peut changer son nom ou sa description. Pour "
+"ajouter un contributeur, entrez son adresse courriel dans la zone de texte ci-dessous. Les contributeurs doivent avoir un compte Mozilla Add-ons."
 
 #: src/olympia/bandwagon/templates/bandwagon/edit_contributors.html:40
 msgid "User"
 msgstr "Utilisateur"
 
-#: src/olympia/bandwagon/templates/bandwagon/edit_contributors.html:41
-#: src/olympia/devhub/templates/devhub/addons/edit/support.html:20
-#: src/olympia/users/templates/users/delete.html:49
+#: src/olympia/bandwagon/templates/bandwagon/edit_contributors.html:41 src/olympia/devhub/templates/devhub/addons/edit/support.html:20 src/olympia/users/templates/users/delete.html:49
 msgid "Email"
 msgstr "Courriel"
 
@@ -3315,28 +2607,14 @@ msgid "Admin Settings"
 msgstr "Paramètres administrateur"
 
 #: src/olympia/bandwagon/templates/bandwagon/edit_contributors.html:76
-msgid ""
-"<b>Warning:</b> By changing the owner of this collection, you will no longer"
-" be able to edit it. You will only be able to add and remove add-ons from "
-"it."
-msgstr ""
-"<b>Attention :</b> En changeant le propriétaire de cette collection, vous ne"
-" serez plus en mesure de la modifier. Vous pourrez uniquement ajouter ou "
-"enlever des modules."
+msgid "<b>Warning:</b> By changing the owner of this collection, you will no longer be able to edit it. You will only be able to add and remove add-ons from it."
+msgstr "<b>Attention :</b> En changeant le propriétaire de cette collection, vous ne serez plus en mesure de la modifier. Vous pourrez uniquement ajouter ou enlever des modules."
 
-#: src/olympia/bandwagon/templates/bandwagon/edit_contributors.html:83
-#: src/olympia/devhub/templates/devhub/addons/forms_shared/media.html:157
-#: src/olympia/devhub/templates/devhub/addons/submit/describe.html:69
-#: src/olympia/devhub/templates/devhub/addons/submit/license.html:60
-#: src/olympia/devhub/templates/devhub/addons/submit/upload.html:78
-#: src/olympia/devhub/templates/devhub/payments/tier.html:17
-#: src/olympia/editors/templates/editors/themes/themes.html:111
-#: src/olympia/editors/templates/editors/themes/themes.html:128
-#: src/olympia/editors/templates/editors/themes/themes.html:134
-#: src/olympia/editors/templates/editors/themes/themes.html:141
-#: src/olympia/users/templates/users/fxa_migration_prompt_content.html:10
-#: src/olympia/users/templates/users/login_form.html:42
-#: src/olympia/users/templates/users/mobile/login.html:57
+#: src/olympia/bandwagon/templates/bandwagon/edit_contributors.html:83 src/olympia/devhub/templates/devhub/addons/forms_shared/media.html:157
+#: src/olympia/devhub/templates/devhub/addons/submit/describe.html:69 src/olympia/devhub/templates/devhub/addons/submit/license.html:60 src/olympia/devhub/templates/devhub/addons/submit/upload.html:70
+#: src/olympia/devhub/templates/devhub/payments/tier.html:17 src/olympia/editors/templates/editors/themes/themes.html:111 src/olympia/editors/templates/editors/themes/themes.html:128
+#: src/olympia/editors/templates/editors/themes/themes.html:134 src/olympia/editors/templates/editors/themes/themes.html:141 src/olympia/users/templates/users/fxa_migration_prompt_content.html:10
+#: src/olympia/users/templates/users/login_form.html:42 src/olympia/users/templates/users/mobile/login.html:57
 msgid "Continue"
 msgstr "Continuer"
 
@@ -3375,18 +2653,12 @@ msgstr "Collections dernièrement populaires"
 
 #: src/olympia/bandwagon/templates/bandwagon/impala/collection_listing.html:28
 #, python-format
-msgid ""
-"Collections are groups of related add-ons that anyone can create and share. "
-"Explore collections created by other users or <a href=\"%(url)s\">create "
-"your own</a>."
+msgid "Collections are groups of related add-ons that anyone can create and share. Explore collections created by other users or <a href=\"%(url)s\">create your own</a>."
 msgstr ""
-"Les collections sont des groupes de modules liés entre eux que n'importe qui"
-" peut créer et partager. Explorez les collections créées par d'autres "
-"utilisateurs ou bien <a href=\"%(url)s\">créez la vôtre</a>."
+"Les collections sont des groupes de modules liés entre eux que n'importe qui peut créer et partager. Explorez les collections créées par d'autres utilisateurs ou bien <a href=\"%(url)s\">créez la "
+"vôtre</a>."
 
-#: src/olympia/bandwagon/templates/bandwagon/impala/collection_listing.html:37
-#: src/olympia/browse/templates/browse/extensions.html:13
-#: src/olympia/browse/templates/browse/themes.html:14
+#: src/olympia/bandwagon/templates/bandwagon/impala/collection_listing.html:37 src/olympia/browse/templates/browse/extensions.html:13 src/olympia/browse/templates/browse/themes.html:14
 msgid "Subscribe"
 msgstr "Inscription"
 
@@ -3394,20 +2666,14 @@ msgstr "Inscription"
 msgid "Following"
 msgstr "Suivi"
 
-#: src/olympia/bandwagon/templates/bandwagon/impala/collection_sidebar.html:22
-#: src/olympia/bandwagon/templates/bandwagon/impala/collection_sidebar.html:28
+#: src/olympia/bandwagon/templates/bandwagon/impala/collection_sidebar.html:22 src/olympia/bandwagon/templates/bandwagon/impala/collection_sidebar.html:28
 #: src/olympia/bandwagon/templates/bandwagon/includes/collection_sidebar.html:32
 msgid "Create a Collection"
 msgstr "Créer une collection"
 
-#: src/olympia/bandwagon/templates/bandwagon/impala/collection_sidebar.html:23
-#: src/olympia/bandwagon/templates/bandwagon/includes/collection_sidebar.html:27
-msgid ""
-"Collections make it easy to keep track of favorite add-ons and share your "
-"perfectly customized browser with others."
-msgstr ""
-"Les collections permettent de facilement garder trace de vos modules favoris"
-" et de partager votre personnalisation du navigateur avec d'autres."
+#: src/olympia/bandwagon/templates/bandwagon/impala/collection_sidebar.html:23 src/olympia/bandwagon/templates/bandwagon/includes/collection_sidebar.html:27
+msgid "Collections make it easy to keep track of favorite add-ons and share your perfectly customized browser with others."
+msgstr "Les collections permettent de facilement garder trace de vos modules favoris et de partager votre personnalisation du navigateur avec d'autres."
 
 #: src/olympia/bandwagon/templates/bandwagon/includes/addedit.html:42
 msgid "Collection Icon"
@@ -3419,8 +2685,7 @@ msgstr "Réinitialisation"
 
 #: src/olympia/bandwagon/templates/bandwagon/includes/addedit.html:53
 msgid "PNG and JPG supported. Image will be resized to 32x32."
-msgstr ""
-"Les formats PNG et JPG sont supportés. L'image sera retaillée en 32x32."
+msgstr "Les formats PNG et JPG sont supportés. L'image sera retaillée en 32x32."
 
 #: src/olympia/bandwagon/templates/bandwagon/includes/addedit_errors.html:3
 msgid "There are errors in this form. Please correct them below."
@@ -3431,40 +2696,31 @@ msgid "Add-ons in Your Collection"
 msgstr "Modules dans votre collection"
 
 #: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:4
-msgid ""
-"To include an add-on in this collection, enter its name in the box below and"
-" hit enter. You can also use the <strong>Add to Collection</strong> links "
-"throughout the site to include add-ons later."
+msgid "To include an add-on in this collection, enter its name in the box below and hit enter."
 msgstr ""
-"Pour inclure un module dans cette collection, entrez son nom dans la zone "
-"ci-dessous puis validez par Entrée. Vous pouvez aussi utiliser les liens "
-"<strong>Ajouter à une collection</strong> parsemés sur le site pour ajouter "
-"des modules plus tard."
 
-#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:17
-#: src/olympia/constants/base.py:400
-#: src/olympia/devhub/templates/devhub/addons/activity.html:62
+#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:15 src/olympia/constants/base.py:400 src/olympia/devhub/templates/devhub/addons/activity.html:62
+#: src/olympia/editors/helpers.py:273 src/olympia/editors/helpers.py:360
 msgid "Add-on"
 msgstr "Module"
 
-#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:26
+#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:24
 msgid "Enter the name of the add-on to include"
 msgstr "Entrez le nom du module à ajouter"
 
-#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:28
+#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:26
 msgid "Add to Collection"
 msgstr "Ajouter à la collection"
 
-#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:45
-#: src/olympia/editors/helpers.py:936 src/olympia/editors/helpers.py:956
+#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:43 src/olympia/editors/helpers.py:1016 src/olympia/editors/helpers.py:1036
 msgid "Pending"
 msgstr "En attente"
 
-#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:47
+#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:45
 msgid "Add a comment"
 msgstr "Ajouter un commentaire"
 
-#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:48
+#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:46
 msgid "Remove this add-on from the collection"
 msgstr "Enlever ce module de la collection"
 
@@ -3476,14 +2732,11 @@ msgstr "Collections"
 msgid "Groups of related add-ons that anyone can create."
 msgstr "Groupes de modules similaires, que tout un chacun peut créer."
 
-#: src/olympia/blocklist/templates/blocklist/blocked_detail.html:3
-#: src/olympia/blocklist/templates/blocklist/blocked_list.html:3
-#: src/olympia/blocklist/templates/blocklist/blocked_list.html:10
+#: src/olympia/blocklist/templates/blocklist/blocked_detail.html:3 src/olympia/blocklist/templates/blocklist/blocked_list.html:3 src/olympia/blocklist/templates/blocklist/blocked_list.html:10
 msgid "Blocked Add-ons"
 msgstr "Modules bloqués"
 
-#: src/olympia/blocklist/templates/blocklist/blocked_detail.html:8
-#: src/olympia/blocklist/templates/blocklist/blocked_list.html:6
+#: src/olympia/blocklist/templates/blocklist/blocked_detail.html:8 src/olympia/blocklist/templates/blocklist/blocked_list.html:6
 msgid "Blocklist"
 msgstr "Liste de blocage"
 
@@ -3505,37 +2758,22 @@ msgid "What does this mean?"
 msgstr "Qu'est-ce que cela signifie ?"
 
 #: src/olympia/blocklist/templates/blocklist/blocked_detail.html:22
-msgid ""
-"Users are strongly encouraged to disable the problematic add-on or plugin, "
-"but may choose to continue using it if they accept the risks described."
-msgstr ""
-"Les utilisateurs sont fortement encouragés à désactiver les modules ou "
-"greffons qui sont problématiques, mais peuvent choisir de continuer à les "
-"utiliser s'ils acceptent les risques décrits."
+msgid "Users are strongly encouraged to disable the problematic add-on or plugin, but may choose to continue using it if they accept the risks described."
+msgstr "Les utilisateurs sont fortement encouragés à désactiver les modules ou greffons qui sont problématiques, mais peuvent choisir de continuer à les utiliser s'ils acceptent les risques décrits."
 
 #: src/olympia/blocklist/templates/blocklist/blocked_detail.html:27
-msgid ""
-"The problematic add-on or plugin will be automatically disabled and no "
-"longer usable."
-msgstr ""
-"Les modules ou greffons qui posent problème seront automatiquement "
-"désactivés et plus utilisables."
+msgid "The problematic add-on or plugin will be automatically disabled and no longer usable."
+msgstr "Les modules ou greffons qui posent problème seront automatiquement désactivés et plus utilisables."
 
 #: src/olympia/blocklist/templates/blocklist/blocked_detail.html:33
 #, python-format
 msgid ""
-"When Mozilla becomes aware of add-ons, plugins, or other third-party "
-"software that seriously compromises %(app)s security, stability, or "
-"performance and meets <a href=\"%(criteria)s\">certain criteria</a>, the "
-"software may be blocked from general use. For more information, please read "
-"<a href=\"%(support)s\">this support article</a>."
+"When Mozilla becomes aware of add-ons, plugins, or other third-party software that seriously compromises %(app)s security, stability, or performance and meets <a href=\"%(criteria)s\">certain "
+"criteria</a>, the software may be blocked from general use. For more information, please read <a href=\"%(support)s\">this support article</a>."
 msgstr ""
-"Quand Mozilla est mis au courant qu'un module, greffon ou tout autre "
-"logiciel tierce-partie peut remettre en cause la sécurité, stabilité ou les "
-"performances de %(app)s et que <a href=\"%(criteria)s\">certain critères</a>"
-" sont réunis, le logiciel peut être bloqué pour l'usage général. Pour plus "
-"d'informations, merci de vous reporter à <a href=\"%(support)s\">cet article"
-" du support</a>."
+"Quand Mozilla est mis au courant qu'un module, greffon ou tout autre logiciel tierce-partie peut remettre en cause la sécurité, stabilité ou les performances de %(app)s et que <a "
+"href=\"%(criteria)s\">certain critères</a> sont réunis, le logiciel peut être bloqué pour l'usage général. Pour plus d'informations, merci de vous reporter à <a href=\"%(support)s\">cet article du "
+"support</a>."
 
 #: src/olympia/blocklist/templates/blocklist/blocked_detail.html:44
 #, python-format
@@ -3548,12 +2786,8 @@ msgid "Blocked on %(date)s."
 msgstr "Bloqué depuis le %(date)s."
 
 #: src/olympia/blocklist/templates/blocklist/blocked_list.html:11
-msgid ""
-"The following software is known to cause serious security, stability, or "
-"performance issues with {app}."
-msgstr ""
-"Les logiciels suivant sont connus pour poser de graves problèmes de "
-"sécurité, stabilité ou de performance avec {app}."
+msgid "The following software is known to cause serious security, stability, or performance issues with {app}."
+msgstr "Les logiciels suivant sont connus pour poser de graves problèmes de sécurité, stabilité ou de performance avec {app}."
 
 #. L10n: %s is a category name.
 #: src/olympia/browse/feeds.py:76 src/olympia/browse/feeds.py:98
@@ -3575,11 +2809,8 @@ msgstr "Modules en vedette :: %s"
 #. L10n: %s is an app name.
 #: src/olympia/browse/feeds.py:138
 #, python-format
-msgid ""
-"Here's a few of our favorite add-ons to help you get started customizing %s."
-msgstr ""
-"Voici quelques-un de nos modules favoris pour vous aider à commencer à "
-"personnaliser %s."
+msgid "Here's a few of our favorite add-ons to help you get started customizing %s."
+msgstr "Voici quelques-un de nos modules favoris pour vous aider à commencer à personnaliser %s."
 
 #. L10n: %s is a category name.
 #: src/olympia/browse/feeds.py:157
@@ -3595,43 +2826,28 @@ msgstr "Outils de recherche et extensions liées à la recherche"
 msgid "Search tools"
 msgstr "Outils de recherche"
 
-#: src/olympia/browse/views.py:55 src/olympia/browse/views.py:65
-#: src/olympia/search/forms.py:85
+#: src/olympia/browse/views.py:55 src/olympia/browse/views.py:65 src/olympia/search/forms.py:85
 msgid "Most Users"
 msgstr "Plus d'utilisateurs"
 
-#: src/olympia/browse/views.py:61 src/olympia/browse/views.py:72
-#: src/olympia/browse/views.py:279
-#: src/olympia/browse/templates/browse/personas/mobile/category_landing.html:63
-#: src/olympia/discovery/templates/discovery/pane.html:67
-#: src/olympia/search/forms.py:92
+#: src/olympia/browse/views.py:61 src/olympia/browse/views.py:72 src/olympia/browse/views.py:246 src/olympia/browse/templates/browse/personas/mobile/category_landing.html:63
+#: src/olympia/discovery/templates/discovery/pane.html:67 src/olympia/search/forms.py:92
 msgid "Up & Coming"
 msgstr "En progression"
 
-#: src/olympia/browse/views.py:460 src/olympia/devhub/views.py:76
-#: src/olympia/devhub/views.py:83
-#: src/olympia/discovery/templates/discovery/addons/detail.html:66
+#: src/olympia/browse/views.py:427 src/olympia/devhub/views.py:75 src/olympia/devhub/views.py:82 src/olympia/discovery/templates/discovery/addons/detail.html:66
 msgid "Created"
 msgstr "Créé"
 
 #. {0} is the category name. Ex: Sports
-#: src/olympia/browse/templates/browse/creatured.html:5
-#: src/olympia/browse/templates/browse/creatured.html:13
+#: src/olympia/browse/templates/browse/creatured.html:5 src/olympia/browse/templates/browse/creatured.html:13
 msgid "{0}: Featured Add-ons"
 msgstr "{0}: Modules en vedette"
 
-#: src/olympia/browse/templates/browse/creatured.html:12
-#: src/olympia/browse/templates/browse/featured.html:4
-#: src/olympia/browse/templates/browse/featured.html:12
-#: src/olympia/browse/templates/browse/featured.html:13
-#: src/olympia/devhub/templates/devhub/docs/policies-recommended.html:3
-#: src/olympia/devhub/templates/devhub/docs/policies-recommended.html:7
-#: src/olympia/devhub/templates/devhub/docs/policies-recommended.html:9
-#: src/olympia/devhub/templates/devhub/docs/policies.html:21
-#: src/olympia/devhub/templates/devhub/docs/policies.html:90
-#: src/olympia/discovery/modules.py:341
-#: src/olympia/discovery/templates/discovery/pane.html:52
-#: src/olympia/templates/menu_links.html:7
+#: src/olympia/browse/templates/browse/creatured.html:12 src/olympia/browse/templates/browse/featured.html:4 src/olympia/browse/templates/browse/featured.html:12
+#: src/olympia/browse/templates/browse/featured.html:13 src/olympia/devhub/templates/devhub/docs/policies-recommended.html:3 src/olympia/devhub/templates/devhub/docs/policies-recommended.html:7
+#: src/olympia/devhub/templates/devhub/docs/policies-recommended.html:9 src/olympia/devhub/templates/devhub/docs/policies.html:21 src/olympia/devhub/templates/devhub/docs/policies.html:90
+#: src/olympia/discovery/modules.py:341 src/olympia/discovery/templates/discovery/pane.html:52 src/olympia/templates/menu_links.html:7
 msgid "Featured Add-ons"
 msgstr "Modules en vedette"
 
@@ -3642,12 +2858,8 @@ msgstr "Pas de module en vedette dans {0}."
 
 #: src/olympia/browse/templates/browse/featured.html:15
 #, python-format
-msgid ""
-"Here's a few of our favorite add-ons to help you get started customizing "
-"%(app)s."
-msgstr ""
-"Voici quelques-un de nos modules favoris pour vous aider à commencer à "
-"adapter %(app)s."
+msgid "Here's a few of our favorite add-ons to help you get started customizing %(app)s."
+msgstr "Voici quelques-un de nos modules favoris pour vous aider à commencer à adapter %(app)s."
 
 #: src/olympia/browse/templates/browse/language_tools.html:9
 msgid "Install Dictionary"
@@ -3671,22 +2883,17 @@ msgstr "Disponible dans votre langue"
 
 #: src/olympia/browse/templates/browse/language_tools.html:38
 msgid "List of language packs and dictionaries available in your locale."
-msgstr ""
-"Liste de paquets de langue et dictionnaires disponibles dans votre langue."
+msgstr "Liste de paquets de langue et dictionnaires disponibles dans votre langue."
 
-#: src/olympia/browse/templates/browse/language_tools.html:41
-#: src/olympia/browse/templates/browse/language_tools.html:63
+#: src/olympia/browse/templates/browse/language_tools.html:41 src/olympia/browse/templates/browse/language_tools.html:63
 msgid "Language"
 msgstr "Langue"
 
-#: src/olympia/browse/templates/browse/language_tools.html:42
-#: src/olympia/browse/templates/browse/language_tools.html:64
-#: src/olympia/constants/base.py:162
+#: src/olympia/browse/templates/browse/language_tools.html:42 src/olympia/browse/templates/browse/language_tools.html:64 src/olympia/constants/base.py:162
 msgid "Dictionary"
 msgstr "Dictionnaire"
 
-#: src/olympia/browse/templates/browse/language_tools.html:43
-#: src/olympia/browse/templates/browse/language_tools.html:65
+#: src/olympia/browse/templates/browse/language_tools.html:43 src/olympia/browse/templates/browse/language_tools.html:65
 msgid "Language Pack"
 msgstr "Pack de langue"
 
@@ -3704,8 +2911,7 @@ msgid "{0} :: Search Tools"
 msgstr "{0} :: Outils de recherche"
 
 #. {0} is an integer.
-#: src/olympia/browse/templates/browse/search_tools.html:39
-#: src/olympia/devhub/templates/devhub/addons/dashboard.html:17
+#: src/olympia/browse/templates/browse/search_tools.html:39 src/olympia/devhub/templates/devhub/addons/dashboard.html:17
 msgid "<b>{0}</b> add-on"
 msgid_plural "<b>{0}</b> add-ons"
 msgstr[0] "<b>{0}</b> module"
@@ -3733,35 +2939,18 @@ msgstr "Ressources supplémentaires"
 
 #. {0} is an app name, like Firefox.
 #: src/olympia/browse/templates/browse/search_tools.html:93
-msgid ""
-"Learn more about the <a "
-"href=\"http://support.mozilla.com/kb/Search+bar\">search bar</a> in {0}"
-msgstr ""
-"En savoir plus sur la <a "
-"href=\"http://support.mozilla.com/kb/Search+bar\">barre de recherche</a> "
-"dans {0}"
+msgid "Learn more about the <a href=\"http://support.mozilla.com/kb/Search+bar\">search bar</a> in {0}"
+msgstr "En savoir plus sur la <a href=\"http://support.mozilla.com/kb/Search+bar\">barre de recherche</a> dans {0}"
 
 #: src/olympia/browse/templates/browse/search_tools.html:94
-msgid ""
-"Browse through even more search providers at <a "
-"href=\"http://mycroft.mozdev.org/\">mycroft.mozdev.org</a>"
-msgstr ""
-"Découvrez encore plus de fournisseurs de moteurs de recherche sur <a "
-"href=\"http://mycroft.mozdev.org/\">mycroft.mozdev.org</a>"
+msgid "Browse through even more search providers at <a href=\"http://mycroft.mozdev.org/\">mycroft.mozdev.org</a>"
+msgstr "Découvrez encore plus de fournisseurs de moteurs de recherche sur <a href=\"http://mycroft.mozdev.org/\">mycroft.mozdev.org</a>"
 
 #: src/olympia/browse/templates/browse/search_tools.html:95
-msgid ""
-"<a "
-"href=\"https://developer.mozilla.org/en/Creating_OpenSearch_plugins_for_Firefox\">Make"
-" your own</a> search tool"
-msgstr ""
-"<a "
-"href=\"https://developer.mozilla.org/Creating_OpenSearch_plugins_for_Firefox\">Réalisez"
-" votre propre outil de recherche</a>"
+msgid "<a href=\"https://developer.mozilla.org/en/Creating_OpenSearch_plugins_for_Firefox\">Make your own</a> search tool"
+msgstr "<a href=\"https://developer.mozilla.org/Creating_OpenSearch_plugins_for_Firefox\">Réalisez votre propre outil de recherche</a>"
 
-#: src/olympia/browse/templates/browse/themes.html:6
-#: src/olympia/browse/templates/browse/themes.html:9
-#: src/olympia/constants/base.py:174
+#: src/olympia/browse/templates/browse/themes.html:6 src/olympia/browse/templates/browse/themes.html:9 src/olympia/constants/base.py:174
 msgid "Complete Themes"
 msgstr "Thèmes complets"
 
@@ -3834,24 +3023,17 @@ msgid_plural "See all %(cnt)s extensions in %(name)s &raquo;"
 msgstr[0] "Voir l'extension %(cnt)s dans %(name)s &raquo;"
 msgstr[1] "Voir les %(cnt)s extensions dans %(name)s &raquo;"
 
-#: src/olympia/browse/templates/browse/mobile/extensions.html:13
-#: src/olympia/compat/templates/compat/index.html:82
-#: src/olympia/devhub/templates/devhub/devhub_search.html:24
-#: src/olympia/devhub/templates/devhub/addons/activity.html:47
-#: src/olympia/search/templates/search/no_results.html:4
-#: src/olympia/search/templates/search/mobile/results.html:36
+#: src/olympia/browse/templates/browse/mobile/extensions.html:13 src/olympia/devhub/templates/devhub/devhub_search.html:24 src/olympia/devhub/templates/devhub/addons/activity.html:47
+#: src/olympia/search/templates/search/no_results.html:4 src/olympia/search/templates/search/mobile/results.html:36
 msgid "No results found."
 msgstr "Aucun résultat."
 
-#: src/olympia/browse/templates/browse/personas/base.html:6
-#: src/olympia/browse/templates/browse/personas/mobile/base.html:7
+#: src/olympia/browse/templates/browse/personas/base.html:6 src/olympia/browse/templates/browse/personas/mobile/base.html:7
 msgid "{0} Themes"
 msgstr "{0} Thèmes"
 
 #. {0} is a user's name.
-#: src/olympia/browse/templates/browse/personas/base.html:15
-#: src/olympia/browse/templates/browse/personas/base.html:40
-#: src/olympia/browse/templates/browse/personas/grid.html:8
+#: src/olympia/browse/templates/browse/personas/base.html:15 src/olympia/browse/templates/browse/personas/base.html:40 src/olympia/browse/templates/browse/personas/grid.html:8
 msgid "{0}'s Themes"
 msgstr "Thèmes de {0}"
 
@@ -3865,38 +3047,28 @@ msgstr "Créer votre propre thème"
 
 #: src/olympia/browse/templates/browse/personas/base.html:46
 msgid "Your browser, your style! Dress it up with a design of your own!"
-msgstr ""
-"Votre navigateur, avec votre style ! Habillez-le avec un design personnel !"
+msgstr "Votre navigateur, avec votre style ! Habillez-le avec un design personnel !"
 
 #: src/olympia/browse/templates/browse/personas/base.html:51
 msgid "Learn more"
 msgstr "En savoir plus"
 
-#: src/olympia/browse/templates/browse/personas/category_landing.html:6
-#: src/olympia/browse/templates/browse/personas/mobile/category_landing.html:5
+#: src/olympia/browse/templates/browse/personas/category_landing.html:6 src/olympia/browse/templates/browse/personas/mobile/category_landing.html:5
 msgid "View All Recently Added"
 msgstr "Voir tous les ajouts récents"
 
-#: src/olympia/browse/templates/browse/personas/category_landing.html:7
-#: src/olympia/browse/templates/browse/personas/mobile/category_landing.html:6
+#: src/olympia/browse/templates/browse/personas/category_landing.html:7 src/olympia/browse/templates/browse/personas/mobile/category_landing.html:6
 msgid "View All Most Popular"
 msgstr "Voir tous les plus populaires"
 
-#: src/olympia/browse/templates/browse/personas/category_landing.html:8
-#: src/olympia/browse/templates/browse/personas/mobile/category_landing.html:7
+#: src/olympia/browse/templates/browse/personas/category_landing.html:8 src/olympia/browse/templates/browse/personas/mobile/category_landing.html:7
 msgid "View All Top Rated"
 msgstr "Voir tous les mieux notés"
 
 #: src/olympia/browse/templates/browse/personas/category_landing.html:40
 #, python-format
-msgid ""
-"Over 300,000 designs to personalize your browser! Move your mouse over a "
-"Background Theme to try it on. <a href=\"%(url)s\" class=\"more-info\">Start"
-" exploring</a>"
-msgstr ""
-"Plus de 300 000 thèmes pour personnaliser votre navigateur ! Déplacez votre "
-"pointeur sur l'un des thèmes pour l'essayer. <a href=\"%(url)s\" class"
-"=\"more-info\">Commencez l'exploration</a>"
+msgid "Over 300,000 designs to personalize your browser! Move your mouse over a Background Theme to try it on. <a href=\"%(url)s\" class=\"more-info\">Start exploring</a>"
+msgstr "Plus de 300 000 thèmes pour personnaliser votre navigateur ! Déplacez votre pointeur sur l'un des thèmes pour l'essayer. <a href=\"%(url)s\" class=\"more-info\">Commencez l'exploration</a>"
 
 #: src/olympia/browse/templates/browse/personas/category_landing.html:47
 msgid "Want more personalization?"
@@ -3906,15 +3078,10 @@ msgstr "Vous voulez plus de personnalisation ?"
 #. theme.
 #: src/olympia/browse/templates/browse/personas/category_landing.html:50
 #, python-format
-msgid ""
-"Complete Themes transform the look of your browser with styles for the "
-"window frame, address bar, buttons, tabs, and menus. <a href=\"%(url)s\" "
-"class=\"more-info\">Start exploring</a>"
+msgid "Complete Themes transform the look of your browser with styles for the window frame, address bar, buttons, tabs, and menus. <a href=\"%(url)s\" class=\"more-info\">Start exploring</a>"
 msgstr ""
-"Les thèmes complets transforment l'apparence de votre navigateur avec des "
-"styles pour les bords de fenêtres, la barre d'adresse, les boutons, les "
-"onglets et les menus. <a href=\"%(url)s\" class=\"more-info\">Commencez "
-"l'exploration</a>"
+"Les thèmes complets transforment l'apparence de votre navigateur avec des styles pour les bords de fenêtres, la barre d'adresse, les boutons, les onglets et les menus. <a href=\"%(url)s\" class"
+"=\"more-info\">Commencez l'exploration</a>"
 
 #: src/olympia/browse/templates/browse/personas/category_landing.html:76
 msgid "Up & Coming Themes"
@@ -3944,7 +3111,7 @@ msgstr "&laquo; Tous les thèmes"
 msgid "All"
 msgstr "Toutes"
 
-#: src/olympia/compat/forms.py:22 src/olympia/search/views.py:525
+#: src/olympia/compat/forms.py:22 src/olympia/editors/templates/editors/base.html:69 src/olympia/search/views.py:518
 msgid "All Add-ons"
 msgstr "Tous les modules"
 
@@ -3956,93 +3123,32 @@ msgstr "Binaire"
 msgid "Non-binary"
 msgstr "Non binaire"
 
-#. Review points sources other than add-ons and themes.
-#: src/olympia/compat/views.py:87 src/olympia/constants/base.py:388
-#: src/olympia/devhub/forms.py:162
-#: src/olympia/editors/templates/editors/performance.html:75
-msgid "Other"
-msgstr "Autre"
-
-#: src/olympia/compat/templates/compat/index.html:4
-msgid "Add-on Compatibility Report for {app} {version}"
-msgstr "Rapport de compatibilité du module {app} {version}"
-
-#: src/olympia/compat/templates/compat/index.html:11
-msgid "{app} {version} Compatibility"
-msgstr "{app} {version} compatibilité"
-
-#: src/olympia/compat/templates/compat/index.html:17
-#, python-format
-msgid "Top 95%% compatible with previous version"
-msgstr ""
-
-#: src/olympia/compat/templates/compat/index.html:18
-#, python-format
-msgid "Top 95%% of all add-ons"
-msgstr ""
-
-#: src/olympia/compat/templates/compat/index.html:19
-msgid "All active add-ons"
-msgstr "Tous modules actifs"
-
-#: src/olympia/compat/templates/compat/index.html:23
-#: src/olympia/constants/base.py:401
-msgid "App"
-msgstr "App"
-
-#: src/olympia/compat/templates/compat/index.html:55
-msgid "Details for add-ons compatible with previous version:"
-msgstr "Détails pour les modules compatibles avec la version précédente :"
-
-#: src/olympia/compat/templates/compat/index.html:57
-msgid "Show all versions"
-msgstr "Afficher toutes les versions"
-
-#: src/olympia/compat/templates/compat/index.html:59
-msgid "Details for add-ons compatible with all versions:"
-msgstr "Détails pour les modules compatibles avec toutes les versions :"
-
-#: src/olympia/compat/templates/compat/index.html:61
-msgid "Show previous version only"
-msgstr "Afficher uniquement les versions précédentes"
-
 #: src/olympia/compat/templates/compat/reporter.html:3
 msgid "Add-on Compatibility Reports"
 msgstr "Rapports de compatibilité du module"
 
-#: src/olympia/compat/templates/compat/reporter.html:11
-#: src/olympia/compat/templates/compat/reporter_detail.html:35
+#: src/olympia/compat/templates/compat/reporter.html:11 src/olympia/compat/templates/compat/reporter_detail.html:35
 #, python-format
 msgid ""
-"<p> Reports submitted to us through the <a href=\"%(url_)s\">Add-on "
-"Compatibility Reporter</a> are collected here for developers to view. These "
-"reports help us determine which add-ons will need help supporting an "
-"upcoming Firefox version. </p>"
+"<p> Reports submitted to us through the <a href=\"%(url_)s\">Add-on Compatibility Reporter</a> are collected here for developers to view. These reports help us determine which add-ons will need "
+"help supporting an upcoming Firefox version. </p>"
 msgstr ""
-"<p> Les rapports qui nous sont transmis via le <a "
-"href=\"%(url_)s\">Rapporteur de compatibilité de module</a> sont collectés "
-"ici pour que les développeurs puissent les voir. Ces rapports nous aident à "
-"déterminer quels modules auront besoin d'aide pour une prochaine version de "
-"Firefox. </p>"
+"<p> Les rapports qui nous sont transmis via le <a href=\"%(url_)s\">Rapporteur de compatibilité de module</a> sont collectés ici pour que les développeurs puissent les voir. Ces rapports nous "
+"aident à déterminer quels modules auront besoin d'aide pour une prochaine version de Firefox. </p>"
 
 #: src/olympia/compat/templates/compat/reporter.html:18
 msgid "Reports for your Add-ons"
 msgstr "Rapports pour vos modules"
 
-#: src/olympia/compat/templates/compat/reporter.html:30
-#: src/olympia/compat/templates/compat/reporter_detail.html:9
+#: src/olympia/compat/templates/compat/reporter.html:30 src/olympia/compat/templates/compat/reporter_detail.html:9
 msgid "Add-on Compatibility Center"
 msgstr "Centre de compatibilité de module"
 
 #: src/olympia/compat/templates/compat/reporter.html:34
 msgid "Enter the GUID of an add-on below to view any reports we've received."
-msgstr ""
-"Entrer ci-dessous l'identifiant GUID d'un module pour voir les rapports que "
-"nous avons reçus."
+msgstr "Entrer ci-dessous l'identifiant GUID d'un module pour voir les rapports que nous avons reçus."
 
-#: src/olympia/compat/templates/compat/reporter_detail.html:3
-#: src/olympia/compat/templates/compat/reporter_detail.html:10
-#: src/olympia/compat/templates/compat/reporter_detail.html:25
+#: src/olympia/compat/templates/compat/reporter_detail.html:3 src/olympia/compat/templates/compat/reporter_detail.html:10 src/olympia/compat/templates/compat/reporter_detail.html:25
 msgid "{addon} Compatibility Reports"
 msgstr "Rapports de compatibilité pour {addon}"
 
@@ -4058,8 +3164,7 @@ msgid_plural "{0} problem reports"
 msgstr[0] "{0} rapport de problèmes"
 msgstr[1] "{0} rapports de problèmes"
 
-#: src/olympia/compat/templates/compat/reporter_detail.html:21
-#: src/olympia/users/templates/users/profile.html:70
+#: src/olympia/compat/templates/compat/reporter_detail.html:21 src/olympia/users/templates/users/profile.html:70
 msgid "View all"
 msgstr "Voir tout"
 
@@ -4071,10 +3176,8 @@ msgstr "Filtrer par Application"
 msgid "Report Type"
 msgstr "Type de rapport"
 
-#: src/olympia/compat/templates/compat/reporter_detail.html:47
-#: src/olympia/devhub/forms.py:784
-#: src/olympia/devhub/templates/devhub/addons/ajax_compat_update.html:17
-#: src/olympia/editors/forms.py:108 src/olympia/zadmin/forms.py:45
+#: src/olympia/compat/templates/compat/reporter_detail.html:47 src/olympia/devhub/forms.py:785 src/olympia/devhub/templates/devhub/addons/ajax_compat_update.html:17 src/olympia/editors/forms.py:108
+#: src/olympia/editors/forms.py:248 src/olympia/zadmin/forms.py:45
 msgid "Application"
 msgstr "Application"
 
@@ -4086,8 +3189,7 @@ msgstr "Identifiant de compilation"
 msgid "Platform"
 msgstr "Plateforme"
 
-#: src/olympia/compat/templates/compat/reporter_detail.html:50
-#: src/olympia/editors/templates/editors/themes/themes.html:40
+#: src/olympia/compat/templates/compat/reporter_detail.html:50 src/olympia/editors/templates/editors/themes/themes.html:40
 msgid "Submitted"
 msgstr "Proposé"
 
@@ -4115,8 +3217,7 @@ msgstr "Thunderbird"
 msgid "SeaMonkey"
 msgstr "SeaMonkey"
 
-#: src/olympia/constants/applications.py:75
-#: src/olympia/pages/templates/pages/sunbird.html:4
+#: src/olympia/constants/applications.py:75 src/olympia/pages/templates/pages/sunbird.html:4
 msgid "Sunbird"
 msgstr "Sunbird"
 
@@ -4164,7 +3265,7 @@ msgstr "Revue préliminaire effectuée"
 msgid "Preliminarily Reviewed and Awaiting Full Review"
 msgstr "Revue préliminaire effectuée et en attente d'une revue complète"
 
-#: src/olympia/constants/base.py:33 src/olympia/editors/helpers.py:924
+#: src/olympia/constants/base.py:33 src/olympia/editors/forms.py:258 src/olympia/editors/helpers.py:73 src/olympia/editors/helpers.py:1004
 #: src/olympia/editors/templates/editors/themes/history_table.html:34
 msgid "Deleted"
 msgstr "Supprimé"
@@ -4198,13 +3299,11 @@ msgstr "Développeur"
 msgid "Viewer"
 msgstr "Visualiseur"
 
-#: src/olympia/constants/base.py:137
-#: src/olympia/templates/mobile/header.html:7
+#: src/olympia/constants/base.py:137 src/olympia/templates/mobile/header.html:7
 msgid "Support"
 msgstr "Assistance"
 
-#: src/olympia/constants/base.py:159 src/olympia/constants/base.py:172
-#: src/olympia/constants/platforms.py:10
+#: src/olympia/constants/base.py:159 src/olympia/constants/base.py:172 src/olympia/constants/platforms.py:10
 msgid "Any"
 msgstr "Tous"
 
@@ -4232,11 +3331,8 @@ msgstr "Pack de langue (module)"
 msgid "Plugin"
 msgstr "Plugin"
 
-#: src/olympia/constants/base.py:167
-#: src/olympia/editors/templates/editors/includes/search_results_themes.html:5
-#: src/olympia/editors/templates/editors/themes/deleted.html:18
-#: src/olympia/editors/templates/editors/themes/history_table.html:8
-#: src/olympia/editors/templates/editors/themes/logs.html:17
+#: src/olympia/constants/base.py:167 src/olympia/editors/templates/editors/includes/search_results_themes.html:5 src/olympia/editors/templates/editors/themes/deleted.html:18
+#: src/olympia/editors/templates/editors/themes/history_table.html:8 src/olympia/editors/templates/editors/themes/logs.html:17
 msgid "Theme"
 msgstr "Thème"
 
@@ -4264,15 +3360,16 @@ msgstr "Demander uniquement sur la page de ce module et le profil développeur"
 
 #: src/olympia/constants/base.py:272
 msgid "Ask after users start downloading this add-on"
-msgstr ""
-"Demander aux utilisateurs une fois qu'ils ont commencé à télécharger ce "
-"module"
+msgstr "Demander aux utilisateurs une fois qu'ils ont commencé à télécharger ce module"
 
 #: src/olympia/constants/base.py:273
 msgid "Ask before users can download this add-on"
-msgstr ""
-"Demander aux utilisateurs avant qu'ils n'aient commencé à télécharger ce "
-"module"
+msgstr "Demander aux utilisateurs avant qu'ils n'aient commencé à télécharger ce module"
+
+#. Review points sources other than add-ons and themes.
+#: src/olympia/constants/base.py:388 src/olympia/devhub/forms.py:162 src/olympia/editors/templates/editors/performance.html:75
+msgid "Other"
+msgstr "Autre"
 
 #: src/olympia/constants/base.py:389
 msgid "Exception"
@@ -4285,6 +3382,10 @@ msgstr "Sortie"
 #: src/olympia/constants/base.py:391
 msgid "Change"
 msgstr "Changement"
+
+#: src/olympia/constants/base.py:401
+msgid "App"
+msgstr "App"
 
 #: src/olympia/constants/base.py:402
 msgid "Persona"
@@ -4422,32 +3523,23 @@ msgstr "Signé pour une revue complète"
 msgid "Signed of a preliminary review"
 msgstr "Signé pour une revue préliminaire"
 
-#: src/olympia/constants/editors.py:14
-#: src/olympia/editors/templates/editors/themes/queue.html:76
-#: src/olympia/editors/templates/editors/themes/themes.html:87
+#: src/olympia/constants/editors.py:14 src/olympia/editors/templates/editors/themes/queue.html:76 src/olympia/editors/templates/editors/themes/themes.html:87
 msgid "Request More Info"
 msgstr "Demander plus d'informations"
 
-#: src/olympia/constants/editors.py:15
-#: src/olympia/editors/templates/editors/themes/queue.html:74
-#: src/olympia/editors/templates/editors/themes/themes.html:91
+#: src/olympia/constants/editors.py:15 src/olympia/editors/templates/editors/themes/queue.html:74 src/olympia/editors/templates/editors/themes/themes.html:91
 msgid "Flag"
 msgstr "Étiqueter"
 
-#: src/olympia/constants/editors.py:16
-#: src/olympia/editors/templates/editors/themes/queue.html:72
-#: src/olympia/editors/templates/editors/themes/themes.html:93
+#: src/olympia/constants/editors.py:16 src/olympia/editors/templates/editors/themes/queue.html:72 src/olympia/editors/templates/editors/themes/themes.html:93
 msgid "Duplicate"
 msgstr "Dupliquer"
 
-#: src/olympia/constants/editors.py:17 src/olympia/editors/helpers.py:502
-#: src/olympia/editors/templates/editors/themes/queue.html:71
-#: src/olympia/editors/templates/editors/themes/themes.html:94
+#: src/olympia/constants/editors.py:17 src/olympia/editors/helpers.py:575 src/olympia/editors/templates/editors/themes/queue.html:71 src/olympia/editors/templates/editors/themes/themes.html:94
 msgid "Reject"
 msgstr "Rejeter"
 
-#: src/olympia/constants/editors.py:18
-#: src/olympia/editors/templates/editors/themes/queue.html:70
+#: src/olympia/constants/editors.py:18 src/olympia/editors/templates/editors/themes/queue.html:70
 msgid "Approve"
 msgstr "Approuver"
 
@@ -4543,7 +3635,7 @@ msgstr "Solaris"
 msgid "Android"
 msgstr "Android"
 
-#: src/olympia/core/apps.py:19
+#: src/olympia/core/apps.py:21
 msgid "Core"
 msgstr ""
 
@@ -4580,9 +3672,7 @@ msgstr "Objet JSON invalide"
 msgid "Message not eligible for annotation"
 msgstr "Ce message ne peut être utilisé comme annotation"
 
-#: src/olympia/devhub/forms.py:124
-#: src/olympia/devhub/templates/devhub/versions/edit.html:94
-#: src/olympia/users/templates/users/edit.html:150
+#: src/olympia/devhub/forms.py:124 src/olympia/devhub/templates/devhub/versions/edit.html:94 src/olympia/users/templates/users/edit.html:150
 msgid "Details"
 msgstr "Détails"
 
@@ -4604,9 +3694,7 @@ msgstr "Ce module possède des conditions générales d'utilisation."
 
 #: src/olympia/devhub/forms.py:234
 msgid "Please specify your add-on's End-User License Agreement:"
-msgstr ""
-"Veuillez définir les conditions générales d'utilisation de votre module "
-"complémentaire&nbsp;:"
+msgstr "Veuillez définir les conditions générales d'utilisation de votre module complémentaire&nbsp;:"
 
 #: src/olympia/devhub/forms.py:237
 msgid "This add-on has a Privacy Policy"
@@ -4654,9 +3742,7 @@ msgstr "Impossible de valider l'identifiant PayPal."
 
 #: src/olympia/devhub/forms.py:388
 msgid "Unsupported file type, please upload an archive file {extensions}."
-msgstr ""
-"Ce type de fichier n'est pas supporté, veuillez transférer une archive "
-"{extensions}."
+msgstr "Ce type de fichier n'est pas supporté, veuillez transférer une archive {extensions}."
 
 #: src/olympia/devhub/forms.py:407
 msgid "View current"
@@ -4683,39 +3769,26 @@ msgid "Submit my add-on for manual review."
 msgstr "Envoyer mon module pour une revue manuelle."
 
 #: src/olympia/devhub/forms.py:537
-msgid "Do not list my add-on on this site (beta)"
-msgstr "Ne pas lister mon module sur ce site (beta)"
+msgid "Do not list my add-on on this site"
+msgstr ""
 
 #: src/olympia/devhub/forms.py:538
-msgid ""
-"Check this option if you intend to distribute your add-on on your own and "
-"only need it to be signed by Mozilla."
-msgstr ""
-"Cochez cette option si vous souhaitez distribuer votre module vous-même et "
-"qu'il doit uniquement être signé par Mozilla."
+msgid "Check this option if you intend to distribute your add-on on your own and only need it to be signed by Mozilla."
+msgstr "Cochez cette option si vous souhaitez distribuer votre module vous-même et qu'il doit uniquement être signé par Mozilla."
 
 #: src/olympia/devhub/forms.py:544
 msgid "This add-on will be bundled with an application installer."
 msgstr "Ce module sera intégré dans un installateur d'application."
 
 #: src/olympia/devhub/forms.py:546
-msgid ""
-"Add-ons that are bundled with application installers will be code reviewed "
-"by Mozilla before they are signed and are held to a higher quality standard."
-msgstr ""
-"Les modules qui sont intégrés dans des installateurs d'application verront "
-"leur code revu par Mozilla avant leur signature. Un niveau de qualité "
-"supérieur sera attendu pour ces modules."
+msgid "Add-ons that are bundled with application installers will be code reviewed by Mozilla before they are signed and are held to a higher quality standard."
+msgstr "Les modules qui sont intégrés dans des installateurs d'application verront leur code revu par Mozilla avant leur signature. Un niveau de qualité supérieur sera attendu pour ces modules."
 
-#: src/olympia/devhub/forms.py:565
-#: src/olympia/devhub/templates/devhub/addons/submit/select-review.html:24
-#: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:42
+#: src/olympia/devhub/forms.py:565 src/olympia/devhub/templates/devhub/addons/submit/select-review.html:24 src/olympia/devhub/templates/devhub/docs/policies-reviews.html:42
 msgid "Full Review"
 msgstr "Revue complète"
 
-#: src/olympia/devhub/forms.py:566
-#: src/olympia/devhub/templates/devhub/addons/submit/select-review.html:47
-#: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:153
+#: src/olympia/devhub/forms.py:566 src/olympia/devhub/templates/devhub/addons/submit/select-review.html:47 src/olympia/devhub/templates/devhub/docs/policies-reviews.html:153
 msgid "Preliminary Review"
 msgstr "Revue préliminaire"
 
@@ -4724,69 +3797,51 @@ msgid "Please choose a review nomination type"
 msgstr "Veuillez choisir un type de nomination pour les revues"
 
 #: src/olympia/devhub/forms.py:574
-msgid ""
-"A file with a version ending with a|alpha|b|beta|pre|rc and an optional "
-"number is detected as beta."
-msgstr ""
-"Un fichier dont la version se termine par a|alpha|b|beta|pre|rc, "
-"éventuellement suivi par un nombre, est considéré comme beta."
+msgid "A file with a version ending with a|alpha|b|beta|pre|rc and an optional number is detected as beta."
+msgstr "Un fichier dont la version se termine par a|alpha|b|beta|pre|rc, éventuellement suivi par un nombre, est considéré comme beta."
 
 #: src/olympia/devhub/forms.py:592
 #, python-format
-msgid "Version %s already exists"
-msgstr "Version %s déjà existante"
-
-#: src/olympia/devhub/forms.py:604
-msgid ""
-"Select a valid choice. That choice is not one of the available choices."
+msgid "Version %s already exists, or was uploaded before."
 msgstr ""
-"Sélectionnez un choix valide. Ce choix ne fait pas partie des choix "
-"disponibles."
 
-#: src/olympia/devhub/forms.py:610
-msgid ""
-"A file with a version ending with a|alpha|b|beta and an optional number is "
-"detected as beta."
-msgstr ""
-"Un fichier dont la version se termine par a|alpha|b|beta, éventuellement "
-"suivi par un nombre, est considéré comme beta."
+#: src/olympia/devhub/forms.py:605
+msgid "Select a valid choice. That choice is not one of the available choices."
+msgstr "Sélectionnez un choix valide. Ce choix ne fait pas partie des choix disponibles."
 
-#: src/olympia/devhub/forms.py:633
+#: src/olympia/devhub/forms.py:611
+msgid "A file with a version ending with a|alpha|b|beta and an optional number is detected as beta."
+msgstr "Un fichier dont la version se termine par a|alpha|b|beta, éventuellement suivi par un nombre, est considéré comme beta."
+
+#: src/olympia/devhub/forms.py:634
 msgid "You cannot upload any more files for this version."
 msgstr "Vous ne pouvez plus envoyer de fichier pour cette version."
 
-#: src/olympia/devhub/forms.py:639
+#: src/olympia/devhub/forms.py:640
 msgid "Version doesn't match"
 msgstr "Version ne correspondant pas"
 
-#: src/olympia/devhub/forms.py:668
-msgid ""
-"You cannot delete a file once the review process has started. You must "
-"delete the whole version."
-msgstr ""
-"Vous ne pouvez pas supprimer un fichier une fois le processus de revue "
-"démarré. Vous devez supprimer la version complète."
+#: src/olympia/devhub/forms.py:669
+msgid "You cannot delete a file once the review process has started. You must delete the whole version."
+msgstr "Vous ne pouvez pas supprimer un fichier une fois le processus de revue démarré. Vous devez supprimer la version complète."
 
-#: src/olympia/devhub/forms.py:688
+#: src/olympia/devhub/forms.py:689
 msgid "The platform All cannot be combined with specific platforms."
-msgstr ""
-"La plateforme « Toutes » ne peut être combinée avec des plateformes "
-"spécifiques."
+msgstr "La plateforme « Toutes » ne peut être combinée avec des plateformes spécifiques."
 
-#: src/olympia/devhub/forms.py:693
+#: src/olympia/devhub/forms.py:694
 msgid "A platform can only be chosen once."
 msgstr "Une plateforme ne peut être choisie qu'une fois."
 
-#: src/olympia/devhub/forms.py:706
+#: src/olympia/devhub/forms.py:707
 msgid "A review type must be selected."
 msgstr "Un type de revue doit être sélectionné."
 
-#: src/olympia/devhub/forms.py:788 src/olympia/editors/forms.py:114
-#: src/olympia/zadmin/forms.py:49 src/olympia/zadmin/forms.py:52
+#: src/olympia/devhub/forms.py:789 src/olympia/editors/forms.py:114 src/olympia/editors/forms.py:254 src/olympia/zadmin/forms.py:49 src/olympia/zadmin/forms.py:52
 msgid "Select an application first"
 msgstr "Sélectionnez d'abord une application"
 
-#: src/olympia/devhub/forms.py:840
+#: src/olympia/devhub/forms.py:841
 msgid "There cannot be more than 3 required add-ons."
 msgstr "Il ne peut pas y avoir plus de trois modules nécessaires."
 
@@ -4802,214 +3857,188 @@ msgstr "Mes propositions"
 msgid "Developer Docs"
 msgstr "Documentations développeur"
 
-#. L10n: first parameter is the number of errors
 # {0} is a number
+#. L10n: first parameter is the number of errors
 #: src/olympia/devhub/helpers.py:200
 msgid "{0} error"
 msgid_plural "{0} errors"
 msgstr[0] "{0} erreur"
 msgstr[1] "{0} erreurs"
 
-#. L10n: first parameter is the number of warnings
 # {0} is a number
+#. L10n: first parameter is the number of warnings
 #: src/olympia/devhub/helpers.py:203
 msgid "{0} warning"
 msgid_plural "{0} warnings"
 msgstr[0] "{0} avertissement"
 msgstr[1] "{0} avertissements"
 
-#: src/olympia/devhub/models.py:375
-#: src/olympia/reviews/templates/reviews/add.html:58
+#: src/olympia/devhub/models.py:375 src/olympia/reviews/templates/reviews/add.html:58
 msgid "Review"
 msgstr "Critique"
 
-#: src/olympia/devhub/tasks.py:551
+#: src/olympia/devhub/tasks.py:583
 #, python-format
 msgid "%s responded with %s (%s)."
 msgstr "%s a répondu avec %s (%s)."
 
-#: src/olympia/devhub/tasks.py:555
+#: src/olympia/devhub/tasks.py:587
 #, python-format
 msgid "Connection to \"%s\" timed out."
 msgstr "Connexion à « %s » expiré."
 
-#: src/olympia/devhub/tasks.py:557
+#: src/olympia/devhub/tasks.py:589
 #, python-format
 msgid "Could not contact host at \"%s\"."
 msgstr "Impossible de contacter l'hôte « %s »."
 
-#: src/olympia/devhub/utils.py:104
+#: src/olympia/devhub/utils.py:105
 #, python-format
-msgid ""
-"Validation generated too many errors/warnings so %s messages were truncated."
-" After addressing the visible messages, you'll be able to see the others."
-msgstr ""
-"La validation a généré trop d'erreurs et/ou d'avertissements, et %s messages"
-" ont été tronqués. Après avoir corrigé les messages visibles, vous pourrez "
-"voir les autres."
+msgid "Validation generated too many errors/warnings so %s messages were truncated. After addressing the visible messages, you'll be able to see the others."
+msgstr "La validation a généré trop d'erreurs et/ou d'avertissements, et %s messages ont été tronqués. Après avoir corrigé les messages visibles, vous pourrez voir les autres."
 
-#: src/olympia/devhub/views.py:183
+#: src/olympia/devhub/views.py:182
 msgid "All My Add-ons"
 msgstr "Tous mes modules"
 
-#: src/olympia/devhub/views.py:210
+#: src/olympia/devhub/views.py:209
 msgid "All Activity"
 msgstr "Toute l'activité"
 
-#: src/olympia/devhub/views.py:211
+#: src/olympia/devhub/views.py:210
 msgid "Add-on Updates"
 msgstr "Mises à jour du module"
 
-#: src/olympia/devhub/views.py:212
+#: src/olympia/devhub/views.py:211
 msgid "Add-on Status"
 msgstr "Statut du module"
 
-#: src/olympia/devhub/views.py:213
+#: src/olympia/devhub/views.py:212
 msgid "User Collections"
 msgstr "Collections de l'utilisateur"
 
-#: src/olympia/devhub/views.py:214
-#: src/olympia/devhub/templates/devhub/docs/policies-maintenance.html:68
-#: src/olympia/pages/templates/pages/dev_faq.html:38
+#: src/olympia/devhub/views.py:213 src/olympia/devhub/templates/devhub/docs/policies-maintenance.html:68 src/olympia/pages/templates/pages/dev_faq.html:38
 #: src/olympia/pages/templates/pages/dev_faq.html:484
 msgid "User Reviews"
 msgstr "Commentaires de l'utilisateur"
 
-#: src/olympia/devhub/views.py:327 src/olympia/devhub/views.py:331
-#: src/olympia/devhub/views.py:484 src/olympia/devhub/views.py:513
-#: src/olympia/devhub/views.py:564 src/olympia/devhub/views.py:1150
+#: src/olympia/devhub/views.py:326 src/olympia/devhub/views.py:330 src/olympia/devhub/views.py:485 src/olympia/devhub/views.py:514 src/olympia/devhub/views.py:565 src/olympia/devhub/views.py:1157
 msgid "Changes successfully saved."
 msgstr "Modifications enregistrées avec succès."
 
-#: src/olympia/devhub/views.py:334 src/olympia/devhub/views.py:1631
+#: src/olympia/devhub/views.py:333 src/olympia/devhub/views.py:1638
 msgid "Please check the form for errors."
 msgstr "Merci de vérifier les erreurs dans le formulaire."
 
-#: src/olympia/devhub/views.py:346
+#: src/olympia/devhub/views.py:345
 msgid "Add-on cannot be deleted. Disable this add-on instead."
 msgstr "Le module ne peut pas être supprimé. Vous devez le désactiver."
 
-#: src/olympia/devhub/views.py:356
+#: src/olympia/devhub/views.py:355
 msgid "Theme deleted."
 msgstr "Thème supprimé."
 
-#: src/olympia/devhub/views.py:356
+#: src/olympia/devhub/views.py:355
 msgid "Add-on deleted."
 msgstr "Module supprimé"
 
-#: src/olympia/devhub/views.py:362
+#: src/olympia/devhub/views.py:361
 msgid "URL name was incorrect. Theme was not deleted."
 msgstr "Le nom de l'URL était incorrect. Le thème n'a pas été supprimé."
 
-#: src/olympia/devhub/views.py:367
+#: src/olympia/devhub/views.py:366
 msgid "URL name was incorrect. Add-on was not deleted."
 msgstr "Le nom de l'URL était incorrect. Le module n'a pas été supprimé."
 
-#: src/olympia/devhub/views.py:449
+#: src/olympia/devhub/views.py:450
 msgid "An author has been added to your add-on"
 msgstr "Un auteur a été ajouté à votre module complémentaire"
 
-#: src/olympia/devhub/views.py:456
+#: src/olympia/devhub/views.py:457
 msgid "An author has a role changed on your add-on"
 msgstr "Le rôle d'un auteur a été modifié sur votre module"
 
-#: src/olympia/devhub/views.py:476
+#: src/olympia/devhub/views.py:477
 msgid "An author has been removed from your add-on"
 msgstr "Un auteur a été retiré de votre module"
 
-#: src/olympia/devhub/views.py:519
+#: src/olympia/devhub/views.py:520
 msgid "There were errors in your submission."
 msgstr "Il y avait des erreurs dans votre envoi."
 
-#: src/olympia/devhub/views.py:583
+#: src/olympia/devhub/views.py:584
 msgid "Validate Add-on"
 msgstr "Valider le module"
 
-#: src/olympia/devhub/views.py:594
+#: src/olympia/devhub/views.py:595
 msgid "Check Add-on Compatibility"
 msgstr "Vérifier la compatibilité du module"
 
-#: src/olympia/devhub/views.py:808 src/olympia/signing/views.py:90
+#: src/olympia/devhub/views.py:809 src/olympia/signing/views.py:95
 msgid "You cannot submit this type of add-on"
 msgstr "Vous ne pouvez pas envoyer ce type de module"
 
-#: src/olympia/devhub/views.py:1051 src/olympia/users/forms.py:471
+#: src/olympia/devhub/views.py:1052 src/olympia/users/forms.py:471
 msgid "Images must be either PNG or JPG."
 msgstr "Les images doivent être au format PNG ou JPG."
 
-#: src/olympia/devhub/views.py:1055
+#: src/olympia/devhub/views.py:1056
 msgid "Icons cannot be animated."
 msgstr "Les icônes ne peuvent pas être animées."
 
-#: src/olympia/devhub/views.py:1057
+#: src/olympia/devhub/views.py:1058
 msgid "Images cannot be animated."
 msgstr "Les images ne peuvent pas être animées."
 
-#: src/olympia/devhub/views.py:1070
+#: src/olympia/devhub/views.py:1071
 #, python-format
 msgid "Images cannot be larger than %dKB."
 msgstr "Les images ne peuvent pas dépasser %dKiO."
 
 #. L10n: {0} is an image width (in pixels), {1} is a height.
-#: src/olympia/devhub/views.py:1080
+#: src/olympia/devhub/views.py:1081
 msgid "Image must be exactly {0} pixels wide and {1} pixels tall."
-msgstr ""
-"L'image doit faire exactement {0} pixels en largeur et {1} pixels en "
-"hauteur."
+msgstr "L'image doit faire exactement {0} pixels en largeur et {1} pixels en hauteur."
 
-#: src/olympia/devhub/views.py:1087
+#: src/olympia/devhub/views.py:1088
 msgid "There was an error uploading your preview."
 msgstr "Une erreur est survenue pendant l'envoi de votre aperçu."
 
-#: src/olympia/devhub/views.py:1189
+#: src/olympia/devhub/views.py:1196
 #, python-format
 msgid "Version %s disabled."
 msgstr "Version %s désactivée."
 
-#: src/olympia/devhub/views.py:1193
+#: src/olympia/devhub/views.py:1200
 #, python-format
 msgid "Version %s deleted."
 msgstr "Version %s supprimée."
 
-#: src/olympia/devhub/views.py:1203
-msgid ""
-"This upload has failed validation, and may lack complete validation results."
-" Please take due care when reviewing it."
-msgstr ""
-"Cet envoi a échoué à la validation, et pourrait n'avoir aucun résultat de "
-"validation. Merci de faire très attention pendant son test."
+#: src/olympia/devhub/views.py:1210
+msgid "This upload has failed validation, and may lack complete validation results. Please take due care when reviewing it."
+msgstr "Cet envoi a échoué à la validation, et pourrait n'avoir aucun résultat de validation. Merci de faire très attention pendant son test."
 
-#: src/olympia/devhub/views.py:1677
+#: src/olympia/devhub/views.py:1684
 msgid "Preliminary Review Requested."
 msgstr "Revue préliminaire demandée."
 
-#: src/olympia/devhub/views.py:1678
+#: src/olympia/devhub/views.py:1685
 msgid "Full Review Requested."
 msgstr "Revue complète demandée."
 
-#: src/olympia/devhub/views.py:1779
-msgid ""
-"Your old credentials were revoked and are no longer valid. Be sure to update"
-" all API clients with the new credentials."
-msgstr ""
-"Vos anciennes informations d'authentification ont été révoquées et ne sont "
-"plus valides. Veillez à mettre à jour tous les clients d'API avec les "
-"nouvelles informations d'authentification."
+#: src/olympia/devhub/views.py:1786
+msgid "Your old credentials were revoked and are no longer valid. Be sure to update all API clients with the new credentials."
+msgstr "Vos anciennes informations d'authentification ont été révoquées et ne sont plus valides. Veillez à mettre à jour tous les clients d'API avec les nouvelles informations d'authentification."
 
-#: src/olympia/devhub/views.py:1797
+#: src/olympia/devhub/views.py:1804
 msgid "New API key created"
 msgstr "Nouvelle clé d'API créée."
 
 #: src/olympia/devhub/templates/devhub/agreement.html:2
-msgid ""
-"Before starting, please read and accept our Firefox Add-on Distribution "
-"Agreement. It also links to our Privacy Notice which explains how we handle "
-"your information."
+msgid "Before starting, please read and accept our Firefox Add-on Distribution Agreement. It also links to our Privacy Notice which explains how we handle your information."
 msgstr ""
-"Avant de commencer, veuillez lire et accepter l'accord de distribution pour "
-"les modules complémentaires Firefox. Celui-ci possède un lien vers notre "
-"politique de confidentialité qui explique comment nous gérons les "
-"informations vous concernant."
+"Avant de commencer, veuillez lire et accepter l'accord de distribution pour les modules complémentaires Firefox. Celui-ci possède un lien vers notre politique de confidentialité qui explique "
+"comment nous gérons les informations vous concernant."
 
 #: src/olympia/devhub/templates/devhub/agreement.html:13
 msgid "Printable Version"
@@ -5023,44 +4052,30 @@ msgstr "J'accepte cet accord"
 msgid "or <a href=\"{0}\">Cancel</a>"
 msgstr "ou <a href=\"{0}\">Annuler</a>"
 
-#: src/olympia/devhub/templates/devhub/base.html:23
-#: src/olympia/devhub/templates/devhub/base_impala.html:20
-#: src/olympia/discovery/templates/discovery/addons/base.html:17
+#: src/olympia/devhub/templates/devhub/base.html:23 src/olympia/devhub/templates/devhub/base_impala.html:20 src/olympia/discovery/templates/discovery/addons/base.html:17
 msgid "Back to Add-ons"
 msgstr "Retour aux modules"
 
 #. {0} is a search term, such as Firebug.
 #. {0} is a search query.
-#: src/olympia/devhub/templates/devhub/devhub_search.html:4
-#: src/olympia/search/templates/search/results.html:9
-#: src/olympia/search/templates/search/mobile/results.html:6
+#: src/olympia/devhub/templates/devhub/devhub_search.html:4 src/olympia/search/templates/search/results.html:9 src/olympia/search/templates/search/mobile/results.html:6
 msgid "{0} :: Search"
 msgstr "{0} :: Recherche"
 
-#: src/olympia/devhub/templates/devhub/devhub_search.html:6
-#: src/olympia/devhub/templates/devhub/search.html:8
-#: src/olympia/editors/forms.py:435 src/olympia/editors/forms.py:437
-#: src/olympia/editors/templates/editors/queue.html:27
-#: src/olympia/editors/templates/editors/themes/queue_list.html:14
-#: src/olympia/search/templates/search/collections.html:17
-#: src/olympia/search/templates/search/personas.html:18
-#: src/olympia/search/templates/search/results.html:18
-#: src/olympia/search/templates/search/mobile/results.html:8
-#: src/olympia/templates/search.html:14
+#: src/olympia/devhub/templates/devhub/devhub_search.html:6 src/olympia/devhub/templates/devhub/search.html:8 src/olympia/editors/forms.py:534 src/olympia/editors/forms.py:536
+#: src/olympia/editors/templates/editors/queue.html:27 src/olympia/editors/templates/editors/themes/queue_list.html:14 src/olympia/search/templates/search/collections.html:17
+#: src/olympia/search/templates/search/personas.html:18 src/olympia/search/templates/search/results.html:18 src/olympia/search/templates/search/mobile/results.html:8 src/olympia/templates/search.html:14
 #: src/olympia/templates/impala/search.html:18
 msgid "Search"
 msgstr "Recherche"
 
-#: src/olympia/devhub/templates/devhub/devhub_search.html:11
-#: src/olympia/devhub/templates/devhub/devhub_search.html:15
-#: src/olympia/search/templates/search/collections.html:18
+#: src/olympia/devhub/templates/devhub/devhub_search.html:11 src/olympia/devhub/templates/devhub/devhub_search.html:15 src/olympia/search/templates/search/collections.html:18
 #: src/olympia/search/templates/search/personas.html:20
 msgid "Search Results"
 msgstr "Résultats de recherche"
 
 #. {0} is a search term, such as Firebug.
-#: src/olympia/devhub/templates/devhub/devhub_search.html:13
-#: src/olympia/search/templates/search/results.html:11
+#: src/olympia/devhub/templates/devhub/devhub_search.html:13 src/olympia/search/templates/search/results.html:11
 msgid "Search Results for \"{0}\""
 msgstr "Résultats de recherche pour « {0} »"
 
@@ -5081,12 +4096,8 @@ msgid "AMO Reviewers"
 msgstr "Relecteurs AMO"
 
 #: src/olympia/devhub/templates/devhub/index.html:29
-msgid ""
-"Get ahead! Become an AMO Reviewer today and get your add-ons reviewed "
-"faster."
-msgstr ""
-"Allez-y&nbsp;! Devenez un relecteur AMO dès aujourd'hui et accélérez la "
-"revue des modules."
+msgid "Get ahead! Become an AMO Reviewer today and get your add-ons reviewed faster."
+msgstr "Allez-y&nbsp;! Devenez un relecteur AMO dès aujourd'hui et accélérez la revue des modules."
 
 #: src/olympia/devhub/templates/devhub/index.html:32
 msgid "Become an AMO Reviewer"
@@ -5098,42 +4109,28 @@ msgstr "Tout savoir sur les modules complémentaires"
 
 #: src/olympia/devhub/templates/devhub/index.html:41
 msgid ""
-"Add-ons let millions of Firefox users enhance and customize their browsing "
-"experience. If you're a Web developer and know <a "
-"href=\"https://developer.mozilla.org/docs/Web/HTML\">HTML</a>, <a "
-"href=\"https://developer.mozilla.org/docs/Web/JavaScript\">JavaScript</a>, "
-"and <a href=\"https://developer.mozilla.org/docs/Web/CSS\">CSS</a>, you "
-"already have all the necessary skills to make a great add-on."
+"Add-ons let millions of Firefox users enhance and customize their browsing experience. If you're a Web developer and know <a href=\"https://developer.mozilla.org/docs/Web/HTML\">HTML</a>, <a "
+"href=\"https://developer.mozilla.org/docs/Web/JavaScript\">JavaScript</a>, and <a href=\"https://developer.mozilla.org/docs/Web/CSS\">CSS</a>, you already have all the necessary skills to make a "
+"great add-on."
 msgstr ""
-"Les modules complémentaires permettent aux millions d'utilisateurs de "
-"Firefox d'améliorer et de personnaliser leur façon de naviguer. Si vous êtes"
-" un développeur web et que vous connaissez <a "
-"href=\"https://developer.mozilla.org/docs/Web/HTML\">HTML</a>, <a "
-"href=\"https://developer.mozilla.org/docs/Web/JavaScript\">JavaScript</a> et"
-" <a href=\"https://developer.mozilla.org/docs/Web/CSS\">CSS</a>, vous avez "
-"toutes les cartes en main pour construire un super module."
+"Les modules complémentaires permettent aux millions d'utilisateurs de Firefox d'améliorer et de personnaliser leur façon de naviguer. Si vous êtes un développeur web et que vous connaissez <a "
+"href=\"https://developer.mozilla.org/docs/Web/HTML\">HTML</a>, <a href=\"https://developer.mozilla.org/docs/Web/JavaScript\">JavaScript</a> et <a "
+"href=\"https://developer.mozilla.org/docs/Web/CSS\">CSS</a>, vous avez toutes les cartes en main pour construire un super module."
 
 #: src/olympia/devhub/templates/devhub/index.html:51
-msgid ""
-"Head over to the <a href=\"https://developer.mozilla.org/Add-ons\">Mozilla "
-"Developer Network</a> to learn everything you need to know to get started."
-msgstr ""
-"Dirigez-vous vers <a href=\"https://developer.mozilla.org/Add-ons\">Mozilla "
-"Developer Network</a> pour apprendre tout ce qu'il faut pour démarrer."
+msgid "Head over to the <a href=\"https://developer.mozilla.org/Add-ons\">Mozilla Developer Network</a> to learn everything you need to know to get started."
+msgstr "Dirigez-vous vers <a href=\"https://developer.mozilla.org/Add-ons\">Mozilla Developer Network</a> pour apprendre tout ce qu'il faut pour démarrer."
 
 #: src/olympia/devhub/templates/devhub/index.html:58
 msgid "Start Making Add-ons"
 msgstr "Commencer à créer des modules"
 
-#: src/olympia/devhub/templates/devhub/index.html:86
-#: src/olympia/devhub/templates/devhub/addons/listing/items.html:25
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:15
+#: src/olympia/devhub/templates/devhub/index.html:86 src/olympia/devhub/templates/devhub/addons/listing/items.html:25 src/olympia/devhub/templates/devhub/includes/addon_details.html:20
 #: src/olympia/devhub/templates/devhub/personas/edit.html:43
 msgid "Status:"
 msgstr "Statut :"
 
-#: src/olympia/devhub/templates/devhub/index.html:90
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:100
+#: src/olympia/devhub/templates/devhub/index.html:90 src/olympia/devhub/templates/devhub/includes/addon_details.html:87
 msgid "Visibility:"
 msgstr "Visibilité&nbsp;:"
 
@@ -5141,21 +4138,16 @@ msgstr "Visibilité&nbsp;:"
 msgid "Latest Version:"
 msgstr "Dernière version :"
 
-#: src/olympia/devhub/templates/devhub/index.html:109
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:145
-#: src/olympia/devhub/templates/devhub/personas/edit.html:49
+#: src/olympia/devhub/templates/devhub/index.html:109 src/olympia/devhub/templates/devhub/includes/addon_details.html:131 src/olympia/devhub/templates/devhub/personas/edit.html:49
 msgid "Queue Position:"
 msgstr "Position dans la file :"
 
-#: src/olympia/devhub/templates/devhub/index.html:110
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:146
-#: src/olympia/devhub/templates/devhub/personas/edit.html:50
+#: src/olympia/devhub/templates/devhub/index.html:110 src/olympia/devhub/templates/devhub/includes/addon_details.html:132 src/olympia/devhub/templates/devhub/personas/edit.html:50
 #, python-format
 msgid "%(position)s of %(total)s"
 msgstr "%(position)s de %(total)s"
 
-#: src/olympia/devhub/templates/devhub/index.html:120
-#: src/olympia/devhub/templates/devhub/includes/addons_edit_nav.html:19
+#: src/olympia/devhub/templates/devhub/index.html:120 src/olympia/devhub/templates/devhub/includes/addons_edit_nav.html:19
 msgid "Upload New Version"
 msgstr "Envoyer une nouvelle version"
 
@@ -5169,12 +4161,8 @@ msgstr "Publiez votre module&nbsp;!"
 
 #: src/olympia/devhub/templates/devhub/index.html:136
 #, python-format
-msgid ""
-"Upload an <a href=\"%(addon_url)s\">add-on</a> or <a "
-"href=\"%(theme_url)s\">theme</a> to get started!"
-msgstr ""
-"Pour commencer, envoyez un <a href=\"%(addon_url)s\">module</a> ou un <a "
-"href=\"%(theme_url)s\">thème</a>&nbsp;!"
+msgid "Upload an <a href=\"%(addon_url)s\">add-on</a> or <a href=\"%(theme_url)s\">theme</a> to get started!"
+msgstr "Pour commencer, envoyez un <a href=\"%(addon_url)s\">module</a> ou un <a href=\"%(theme_url)s\">thème</a>&nbsp;!"
 
 #: src/olympia/devhub/templates/devhub/nav.html:2
 msgid "Return to the DevHub homepage"
@@ -5201,17 +4189,10 @@ msgstr "Développement d'extension"
 msgid "Lightweight Themes"
 msgstr "Thèmes légers"
 
-#: src/olympia/devhub/templates/devhub/nav.html:39
-#: src/olympia/devhub/templates/devhub/docs/policies-agreement.html:6
-#: src/olympia/devhub/templates/devhub/docs/policies-contact.html:6
-#: src/olympia/devhub/templates/devhub/docs/policies-maintenance.html:6
-#: src/olympia/devhub/templates/devhub/docs/policies-recommended.html:6
-#: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:6
-#: src/olympia/devhub/templates/devhub/docs/policies-submission.html:6
-#: src/olympia/devhub/templates/devhub/docs/policies.html:3
-#: src/olympia/devhub/templates/devhub/docs/policies.html:9
-#: src/olympia/devhub/templates/devhub/docs/policies.html:38
-#: src/olympia/devhub/templates/devhub/docs/policies.html:39
+#: src/olympia/devhub/templates/devhub/nav.html:39 src/olympia/devhub/templates/devhub/docs/policies-agreement.html:6 src/olympia/devhub/templates/devhub/docs/policies-contact.html:6
+#: src/olympia/devhub/templates/devhub/docs/policies-maintenance.html:6 src/olympia/devhub/templates/devhub/docs/policies-recommended.html:6
+#: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:6 src/olympia/devhub/templates/devhub/docs/policies-submission.html:6 src/olympia/devhub/templates/devhub/docs/policies.html:3
+#: src/olympia/devhub/templates/devhub/docs/policies.html:9 src/olympia/devhub/templates/devhub/docs/policies.html:38 src/olympia/devhub/templates/devhub/docs/policies.html:39
 msgid "Add-on Policies"
 msgstr "Politiques des modules"
 
@@ -5252,46 +4233,16 @@ msgid "Use the field below to upload your add-on package."
 msgstr "Utilisez le champ ci-dessous pour envoyer votre paquet de module."
 
 #: src/olympia/devhub/templates/devhub/validate_addon.html:19
-msgid ""
-"After upload, a series of automated validation tests will run to check "
-"compatibility with the following application version:"
-msgstr ""
-"Après un envoi, une série de tests de validation automatiques seront "
-"exécutés pour vérifier la compatibilité avec les versions des applications "
-"suivantes :"
+msgid "After upload, a series of automated validation tests will run to check compatibility with the following application version:"
+msgstr "Après un envoi, une série de tests de validation automatiques seront exécutés pour vérifier la compatibilité avec les versions des applications suivantes :"
 
 #: src/olympia/devhub/templates/devhub/validate_addon.html:34
-msgid ""
-"After upload, a series of automated validation tests will be run on your "
-"file."
-msgstr ""
-"Après un envoi, une série de tests de validation automatiques seront "
-"exécutés sur votre fichier."
+msgid "After upload, a series of automated validation tests will be run on your file."
+msgstr "Après un envoi, une série de tests de validation automatiques seront exécutés sur votre fichier."
 
-#: src/olympia/devhub/templates/devhub/validate_addon.html:42
-#: src/olympia/devhub/templates/devhub/addons/submit/upload.html:23
+#: src/olympia/devhub/templates/devhub/validate_addon.html:42 src/olympia/devhub/templates/devhub/addons/submit/upload.html:23
 msgid "Do you want your add-on to be distributed on this site?"
 msgstr "Souhaitez-vous que votre module soit distribué sur ce site&nbsp;?"
-
-#: src/olympia/devhub/templates/devhub/validate_addon.html:49
-#: src/olympia/devhub/templates/devhub/addons/submit/upload.html:30
-#: src/olympia/devhub/templates/devhub/versions/add_file_modal.html:14
-#: src/olympia/devhub/templates/devhub/versions/add_file_modal.html:53
-#: src/olympia/devhub/templates/devhub/versions/list.html:298
-msgid "Warning:"
-msgstr "Attention&nbsp;:"
-
-#: src/olympia/devhub/templates/devhub/validate_addon.html:50
-#: src/olympia/devhub/templates/devhub/addons/submit/upload.html:31
-#, python-format
-msgid ""
-"Submission of unlisted add-ons for signing is currently in an open beta. "
-"Please <a href=\"%(url)s\" target=\"_blank\">report any bugs</a> that you "
-"encounter."
-msgstr ""
-"La soumission des modules non-répertoriés et en attente de signature est au "
-"stade expérimental. Veuillez <a href=\"%(url)s\" target=\"_blank\">faire "
-"remonter les anomalies</a> que vous rencontrez."
 
 #. first parameter is a filename like lorem-ipsum-1.0.2.xpi
 #: src/olympia/devhub/templates/devhub/validation.html:5
@@ -5310,14 +4261,11 @@ msgstr "Validé à :"
 msgid "Tested for compatibility against:"
 msgstr "Compatibilité testée avec :"
 
-#: src/olympia/devhub/templates/devhub/addons/activity.html:4
-#: src/olympia/devhub/templates/devhub/addons/activity.html:20
+#: src/olympia/devhub/templates/devhub/addons/activity.html:4 src/olympia/devhub/templates/devhub/addons/activity.html:20
 msgid "Recent Activity for My Add-ons"
 msgstr "Activité récente pour mes modules"
 
-#: src/olympia/devhub/templates/devhub/addons/activity.html:14
-#: src/olympia/devhub/templates/devhub/addons/activity.html:19
-#: src/olympia/devhub/templates/devhub/addons/dashboard.html:33
+#: src/olympia/devhub/templates/devhub/addons/activity.html:14 src/olympia/devhub/templates/devhub/addons/activity.html:19 src/olympia/devhub/templates/devhub/addons/dashboard.html:33
 msgid "Recent Activity"
 msgstr "Activité récente"
 
@@ -5339,45 +4287,34 @@ msgstr "Affiner les activités"
 msgid "Activity"
 msgstr "Activité"
 
-#: src/olympia/devhub/templates/devhub/addons/activity.html:83
-#: src/olympia/devhub/templates/devhub/addons/dashboard.html:34
-#: src/olympia/devhub/templates/devhub/addons/dashboard.html:35
-#: src/olympia/devhub/templates/devhub/includes/blog_posts.html:4
-#: src/olympia/devhub/templates/devhub/includes/blog_posts.html:6
+#: src/olympia/devhub/templates/devhub/addons/activity.html:83 src/olympia/devhub/templates/devhub/addons/dashboard.html:34 src/olympia/devhub/templates/devhub/addons/dashboard.html:35
+#: src/olympia/devhub/templates/devhub/includes/blog_posts.html:4 src/olympia/devhub/templates/devhub/includes/blog_posts.html:6
 msgid "Subscribe to this feed"
 msgstr "S'inscrire à ce flux"
 
 #: src/olympia/devhub/templates/devhub/addons/ajax_compat_error.html:7
 #, python-format
 msgid ""
-"This add-on is incompatible with <b>%(app_name)s %(app_version)s</b>, the "
-"latest release of %(app_name)s. Please consider updating your add-on's "
-"compatibility info, or uploading a newer version of this add-on."
+"This add-on is incompatible with <b>%(app_name)s %(app_version)s</b>, the latest release of %(app_name)s. Please consider updating your add-on's compatibility info, or uploading a newer version of "
+"this add-on."
 msgstr ""
-"Ce module n'est pas compatible avec <b>%(app_name)s %(app_version)s</b>, la "
-"dernière version de %(app_name)s. Merci de mettre à jour les informations de"
-" compatibilité de votre module, ou d'en envoyer une nouvelle version."
+"Ce module n'est pas compatible avec <b>%(app_name)s %(app_version)s</b>, la dernière version de %(app_name)s. Merci de mettre à jour les informations de compatibilité de votre module, ou d'en "
+"envoyer une nouvelle version."
 
 #: src/olympia/devhub/templates/devhub/addons/ajax_compat_error.html:15
 #, python-format
 msgid ""
-"<a href=\"#\" class=\"button compat-update\" data-"
-"updateurl=\"%(update_url)s\">Update Compatibility</a> <a "
-"href=\"%(version_url)s\" class=\"button\">Upload New Version</a> or <a "
-"href=\"#\" class=\"close\">Ignore</a>"
+"<a href=\"#\" class=\"button compat-update\" data-updateurl=\"%(update_url)s\">Update Compatibility</a> <a href=\"%(version_url)s\" class=\"button\">Upload New Version</a> or <a href=\"#\" "
+"class=\"close\">Ignore</a>"
 msgstr ""
-"<a href=\"#\" class=\"button compat-update\" data-"
-"updateurl=\"%(update_url)s\">Mettre à jour la compatibilité</a> <a "
-"href=\"%(version_url)s\" class=\"button\">Envoyer une nouvelle version</a> "
-"ou <a href=\"#\" class=\"close\">Ignorer</a>"
+"<a href=\"#\" class=\"button compat-update\" data-updateurl=\"%(update_url)s\">Mettre à jour la compatibilité</a> <a href=\"%(version_url)s\" class=\"button\">Envoyer une nouvelle version</a> ou <a"
+" href=\"#\" class=\"close\">Ignorer</a>"
 
 #: src/olympia/devhub/templates/devhub/addons/ajax_compat_status.html:5
 msgid "View and update application compatibility ranges."
-msgstr ""
-"Voir et mettre à jour les intervalles de compatibilité des applications."
+msgstr "Voir et mettre à jour les intervalles de compatibilité des applications."
 
-#: src/olympia/devhub/templates/devhub/addons/ajax_compat_status.html:6
-#: src/olympia/devhub/templates/devhub/versions/edit.html:44
+#: src/olympia/devhub/templates/devhub/addons/ajax_compat_status.html:6 src/olympia/devhub/templates/devhub/versions/edit.html:44
 msgid "Compatibility"
 msgstr "Compatibilité"
 
@@ -5385,39 +4322,25 @@ msgstr "Compatibilité"
 msgid "Update Compatibility"
 msgstr "Mettre à jour la compatibilité"
 
-#: src/olympia/devhub/templates/devhub/addons/ajax_compat_update.html:4
-msgid ""
-"Adjusting application information here will allow users to install your add-"
-"on even if the install manifest in the package indicates that the add-on is "
-"incompatible."
-msgstr ""
-"Adapter les informations des applications ici permettra aux utilisateurs "
-"d'installer votre module, même si le manifeste d'installation dans le paquet"
-" indique que le module est incompatible."
+#: src/olympia/devhub/templates/devhub/addons/ajax_compat_update.html:4 src/olympia/devhub/templates/devhub/versions/edit.html:45
+msgid "Adjusting application information here will allow users to install your add-on even if the install manifest in the package indicates that the add-on is incompatible."
+msgstr "Adapter les informations des applications ici permettra aux utilisateurs d'installer votre module, même si le manifeste d'installation dans le paquet indique que le module est incompatible."
 
 #: src/olympia/devhub/templates/devhub/addons/ajax_compat_update.html:18
 msgid "Supported Versions"
 msgstr "Versions supportées"
 
-#: src/olympia/devhub/templates/devhub/addons/ajax_compat_update.html:31
-#: src/olympia/devhub/templates/devhub/versions/edit.html:63
+#: src/olympia/devhub/templates/devhub/addons/ajax_compat_update.html:31 src/olympia/devhub/templates/devhub/versions/edit.html:63
 msgid "Add Another Application&hellip;"
 msgstr "Ajouter une autre application &hellip;"
 
-#: src/olympia/devhub/templates/devhub/addons/ajax_compat_update.html:38
-#: src/olympia/devhub/templates/devhub/addons/owner.html:86
-#: src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:46
-#: src/olympia/devhub/templates/devhub/versions/list.html:351
-#: src/olympia/devhub/templates/devhub/versions/list.html:353
-#: src/olympia/templates/impala/base.html:132
-#: src/olympia/templates/impala/base.html:143
-#: src/olympia/templates/impala/base.html:161
-#: src/olympia/templates/impala/base.html:171
+#: src/olympia/devhub/templates/devhub/addons/ajax_compat_update.html:38 src/olympia/devhub/templates/devhub/addons/owner.html:86 src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:45
+#: src/olympia/devhub/templates/devhub/versions/list.html:349 src/olympia/devhub/templates/devhub/versions/list.html:351 src/olympia/templates/impala/base.html:129
+#: src/olympia/templates/impala/base.html:140 src/olympia/templates/impala/base.html:158 src/olympia/templates/impala/base.html:168
 msgid "Close"
 msgstr "Fermer"
 
-#: src/olympia/devhub/templates/devhub/addons/dashboard.html:43
-#: src/olympia/zadmin/templates/zadmin/index.html:22
+#: src/olympia/devhub/templates/devhub/addons/dashboard.html:43 src/olympia/zadmin/templates/zadmin/index.html:22
 #, python-format
 msgid "%(ago)s by %(user)s"
 msgstr "%(ago)s par %(user)s"
@@ -5433,29 +4356,21 @@ msgid_plural "<b>{0}</b> themes"
 msgstr[0] "<b>{0}</b> thème"
 msgstr[1] "<b>{0}</b> thèmes"
 
-#: src/olympia/devhub/templates/devhub/addons/edit.html:3
-#: src/olympia/devhub/templates/devhub/addons/listing/item_actions.html:25
-#: src/olympia/devhub/templates/devhub/addons/listing/item_actions_theme.html:7
-#: src/olympia/devhub/templates/devhub/includes/addons_edit_nav.html:2
-#: src/olympia/devhub/templates/devhub/personas/edit.html:6
-#: src/olympia/editors/templates/editors/themes/single.html:37
+#: src/olympia/devhub/templates/devhub/addons/edit.html:3 src/olympia/devhub/templates/devhub/addons/listing/item_actions.html:25
+#: src/olympia/devhub/templates/devhub/addons/listing/item_actions_theme.html:7 src/olympia/devhub/templates/devhub/includes/addons_edit_nav.html:2
+#: src/olympia/devhub/templates/devhub/personas/edit.html:6 src/olympia/editors/templates/editors/themes/single.html:37
 msgid "Edit Listing"
 msgstr "Modifier les informations"
 
-#: src/olympia/devhub/templates/devhub/addons/edit.html:13
-#: src/olympia/devhub/templates/devhub/includes/macros.html:18
-#: src/olympia/translations/templates/translations/all-locales.html:6
+#: src/olympia/devhub/templates/devhub/addons/edit.html:13 src/olympia/devhub/templates/devhub/includes/macros.html:18 src/olympia/translations/templates/translations/all-locales.html:6
 msgid "None"
 msgstr "Aucun"
 
-#: src/olympia/devhub/templates/devhub/addons/owner.html:4
-#: src/olympia/devhub/templates/devhub/addons/listing/item_actions.html:52
-#: src/olympia/devhub/templates/devhub/includes/addons_edit_nav.html:3
+#: src/olympia/devhub/templates/devhub/addons/owner.html:4 src/olympia/devhub/templates/devhub/addons/listing/item_actions.html:52 src/olympia/devhub/templates/devhub/includes/addons_edit_nav.html:3
 msgid "Manage Authors & License"
 msgstr "Gérer les auteurs et la licence"
 
-#: src/olympia/devhub/templates/devhub/addons/owner.html:29
-#: src/olympia/editors/templates/editors/review.html:270
+#: src/olympia/devhub/templates/devhub/addons/owner.html:29 src/olympia/editors/helpers.py:362 src/olympia/editors/templates/editors/review.html:270
 msgid "Authors"
 msgstr "Auteurs"
 
@@ -5465,36 +4380,22 @@ msgstr "À propos des rôles des auteurs"
 
 #: src/olympia/devhub/templates/devhub/addons/owner.html:78
 msgid ""
-"<p>Add-ons can have any number of authors with 3 possible roles:</p> <ul> "
-"<li><b>Owner:</b> Can manage all aspects of the add-on's listing, including "
-"adding and removing other authors</li> <li><b>Developer:</b> Can manage all "
-"aspects of the add-on's listing, except for adding and removing other "
-"authors and managing payments</li> <li><b>Viewer:</b> Can view the add-on's "
-"settings and statistics, but cannot make any changes</li> </ul>"
+"<p>Add-ons can have any number of authors with 3 possible roles:</p> <ul> <li><b>Owner:</b> Can manage all aspects of the add-on's listing, including adding and removing other authors</li> "
+"<li><b>Developer:</b> Can manage all aspects of the add-on's listing, except for adding and removing other authors and managing payments</li> <li><b>Viewer:</b> Can view the add-on's settings and "
+"statistics, but cannot make any changes</li> </ul>"
 msgstr ""
-"<p>Les modules peuvent avoir autant d'auteurs que souhaité avec trois rôles "
-"possibles :</p> <ul> <li><b>Propriétaire :</b> Peut gérer tous les aspects "
-"du module, dont l'ajout et le retrait d'auteurs</li> <li><b>Dévloppeur :</b>"
-" Peut gérer tous les aspects du module, sauf l'ajout et le retrait d'auteurs"
-" ainsi que la gestion des paiements</li> <li><b>Observateur :</b> Peut voir "
-"toutes les statistiques et paramètres du module, mais ne peut faire aucun "
-"changement</li> </ul>"
+"<p>Les modules peuvent avoir autant d'auteurs que souhaité avec trois rôles possibles :</p> <ul> <li><b>Propriétaire :</b> Peut gérer tous les aspects du module, dont l'ajout et le retrait "
+"d'auteurs</li> <li><b>Dévloppeur :</b> Peut gérer tous les aspects du module, sauf l'ajout et le retrait d'auteurs ainsi que la gestion des paiements</li> <li><b>Observateur :</b> Peut voir toutes "
+"les statistiques et paramètres du module, mais ne peut faire aucun changement</li> </ul>"
 
-#: src/olympia/devhub/templates/devhub/addons/profile.html:3
-#: src/olympia/devhub/templates/devhub/addons/listing/item_actions.html:53
-#: src/olympia/devhub/templates/devhub/includes/addons_edit_nav.html:4
+#: src/olympia/devhub/templates/devhub/addons/profile.html:3 src/olympia/devhub/templates/devhub/addons/listing/item_actions.html:53 src/olympia/devhub/templates/devhub/includes/addons_edit_nav.html:4
 msgid "Manage Developer Profile"
 msgstr "Gérer le profil développeur"
 
 #: src/olympia/devhub/templates/devhub/addons/profile.html:16
 #, python-format
-msgid ""
-"Your <a href=\"%(url)s\">developer profile</a> is currently "
-"<strong>public</strong> and <strong>required</strong> for contributions."
-msgstr ""
-"Votre <a href=\"%(url)s\">profil développeur</a> est actuellement "
-"<strong>public</strong> et <strong>nécessaire</strong> pour des "
-"contributions."
+msgid "Your <a href=\"%(url)s\">developer profile</a> is currently <strong>public</strong> and <strong>required</strong> for contributions."
+msgstr "Votre <a href=\"%(url)s\">profil développeur</a> est actuellement <strong>public</strong> et <strong>nécessaire</strong> pour des contributions."
 
 #: src/olympia/devhub/templates/devhub/addons/profile.html:22
 msgid "Remove Both"
@@ -5502,12 +4403,8 @@ msgstr "Enlever les deux"
 
 #: src/olympia/devhub/templates/devhub/addons/profile.html:27
 #, python-format
-msgid ""
-"Your <a href=\"%(url)s\">developer profile</a> is currently "
-"<strong>public</strong>."
-msgstr ""
-"Votre <a href=\"%(url)s\">profil développeur</a> est actuellement "
-"<strong>public</strong>."
+msgid "Your <a href=\"%(url)s\">developer profile</a> is currently <strong>public</strong>."
+msgstr "Votre <a href=\"%(url)s\">profil développeur</a> est actuellement <strong>public</strong>."
 
 #: src/olympia/devhub/templates/devhub/addons/profile.html:33
 msgid "Remove Profile"
@@ -5532,15 +4429,10 @@ msgstr "Adresse URL du module"
 
 #: src/olympia/devhub/templates/devhub/addons/edit/basic.html:33
 msgid "Choose a short, unique URL slug for your add-on."
-msgstr ""
-"Choisissez une adresse URL courte, unique et sans caractères spéciaux pour "
-"votre module"
+msgstr "Choisissez une adresse URL courte, unique et sans caractères spéciaux pour votre module"
 
-#: src/olympia/devhub/templates/devhub/addons/edit/basic.html:43
-#: src/olympia/devhub/templates/devhub/includes/addons_edit_nav.html:35
-#: src/olympia/devhub/templates/devhub/personas/edit.html:56
-#: src/olympia/editors/templates/editors/review.html:255
-#: src/olympia/editors/templates/editors/themes/single.html:33
+#: src/olympia/devhub/templates/devhub/addons/edit/basic.html:43 src/olympia/devhub/templates/devhub/includes/addons_edit_nav.html:35 src/olympia/devhub/templates/devhub/personas/edit.html:56
+#: src/olympia/editors/templates/editors/review.html:255 src/olympia/editors/templates/editors/themes/single.html:33
 msgid "View Listing"
 msgstr "Page de l'application"
 
@@ -5549,60 +4441,37 @@ msgid "Summary"
 msgstr "Résumé"
 
 #: src/olympia/devhub/templates/devhub/addons/edit/basic.html:52
-msgid ""
-"A short explanation of your add-on's basic functionality that is displayed "
-"in search and browse listings, as well as at the top of your add-on's "
-"details page. It is only relevant for listed add-ons."
+msgid "A short explanation of your add-on's basic functionality that is displayed in search and browse listings, as well as at the top of your add-on's details page. It is only relevant for listed add-ons."
 msgstr ""
-"Une brève explication de la fonctionnalité offerte par votre module qui sera"
-" affiché dans les résultats de recherche, les écrans de navigation et en "
-"haut de la page consacrée à votre module. Celle-ci est uniquement pertinente"
-" pour les modules répertoriés."
+"Une brève explication de la fonctionnalité offerte par votre module qui sera affiché dans les résultats de recherche, les écrans de navigation et en haut de la page consacrée à votre module. Celle-"
+"ci est uniquement pertinente pour les modules répertoriés."
 
 #: src/olympia/devhub/templates/devhub/addons/edit/basic.html:73
-msgid ""
-"Categories are the primary way users browse through add-ons. Choose any that"
-" fit your add-on's functionality for the most exposure. It is only relevant "
-"for listed add-ons."
+msgid "Categories are the primary way users browse through add-ons. Choose any that fit your add-on's functionality for the most exposure. It is only relevant for listed add-ons."
 msgstr ""
-"Pour naviguer entre les modules, les utilisateurs utilisent principalement "
-"les catégories. Choisissez les catégories qui correspondent à la "
-"fonctionnalité de votre module. Ce champ est uniquement utile pour les "
-"modules répertoriés."
+"Pour naviguer entre les modules, les utilisateurs utilisent principalement les catégories. Choisissez les catégories qui correspondent à la fonctionnalité de votre module. Ce champ est uniquement "
+"utile pour les modules répertoriés."
 
 #: src/olympia/devhub/templates/devhub/addons/edit/basic.html:90
 #, python-format
-msgid ""
-"Categories cannot be changed while your add-on is featured for this "
-"application. Please email <a href=\"mailto:%(email)s\">%(email)s</a> if "
-"there is a reason you need to modify your categories."
+msgid "Categories cannot be changed while your add-on is featured for this application. Please email <a href=\"mailto:%(email)s\">%(email)s</a> if there is a reason you need to modify your categories."
 msgstr ""
-"Les catégories ne peuvent être changées pendant que votre module est en "
-"vedette pour cette application. Merci d'envoyer un courriel à <a "
-"href=\"mailto:%(email)s\">%(email)s</a> s'il y a une raison nécessitant de "
-"changer vos catégories."
+"Les catégories ne peuvent être changées pendant que votre module est en vedette pour cette application. Merci d'envoyer un courriel à <a href=\"mailto:%(email)s\">%(email)s</a> s'il y a une raison "
+"nécessitant de changer vos catégories."
 
 #: src/olympia/devhub/templates/devhub/addons/edit/basic.html:119
-msgid ""
-"Tags help users find your add-on and should be short descriptors such as "
-"tabs, toolbar, or twitter. You may have a maximum of {0} tags. It is only "
-"relevant for listed add-ons."
+msgid "Tags help users find your add-on and should be short descriptors such as tabs, toolbar, or twitter. You may have a maximum of {0} tags. It is only relevant for listed add-ons."
 msgstr ""
-"Les étiquettes aident les utilisateurs à trouver votre module. Ce sont des "
-"descripteurs courts comme twitter, onglets. Vous pouvez au maximum utiliser "
-"{0} étiquettes. Ce champ est uniquement utile pour les modules répertoriés."
+"Les étiquettes aident les utilisateurs à trouver votre module. Ce sont des descripteurs courts comme twitter, onglets. Vous pouvez au maximum utiliser {0} étiquettes. Ce champ est uniquement utile "
+"pour les modules répertoriés."
 
-#: src/olympia/devhub/templates/devhub/addons/edit/basic.html:129
-#: src/olympia/devhub/templates/devhub/personas/edit.html:97
-#: src/olympia/devhub/templates/devhub/personas/submit.html:46
+#: src/olympia/devhub/templates/devhub/addons/edit/basic.html:129 src/olympia/devhub/templates/devhub/personas/edit.html:97 src/olympia/devhub/templates/devhub/personas/submit.html:46
 msgid "Comma-separated, minimum of {0} character."
 msgid_plural "Comma-separated, minimum of {0} characters."
 msgstr[0] "Séparées par une virgule, avec au minimum {0} caractère."
 msgstr[1] "Séparées par une virgule, avec au minimum {0} caractères."
 
-#: src/olympia/devhub/templates/devhub/addons/edit/basic.html:132
-#: src/olympia/devhub/templates/devhub/personas/edit.html:100
-#: src/olympia/devhub/templates/devhub/personas/submit.html:49
+#: src/olympia/devhub/templates/devhub/addons/edit/basic.html:132 src/olympia/devhub/templates/devhub/personas/edit.html:100 src/olympia/devhub/templates/devhub/personas/submit.html:49
 msgid "Example: dark, cinema, noir. Limit 20."
 msgstr "Exemple : noir, cinéma. Limité à 20."
 
@@ -5621,48 +4490,33 @@ msgid "Add-on Details for {0}"
 msgstr "Détails du module {0}"
 
 #: src/olympia/devhub/templates/devhub/addons/edit/details.html:22
-msgid ""
-"A longer explanation of features, functionality, and other relevant "
-"information. This field is only displayed on the add-on's details page. It "
-"is only relevant for listed add-ons."
+msgid "A longer explanation of features, functionality, and other relevant information. This field is only displayed on the add-on's details page. It is only relevant for listed add-ons."
 msgstr ""
-"Une explication plus détaillée des fonctionnalités et autres informations "
-"relatives à votre module. Ce champ est uniquement affiché sur la page dédiée"
-" à votre module. Ce champ est uniquement utile pour les modules répertoriés."
+"Une explication plus détaillée des fonctionnalités et autres informations relatives à votre module. Ce champ est uniquement affiché sur la page dédiée à votre module. Ce champ est uniquement utile "
+"pour les modules répertoriés."
 
-#: src/olympia/devhub/templates/devhub/addons/edit/details.html:44
-#: src/olympia/translations/templates/translations/trans-menu.html:13
+#: src/olympia/devhub/templates/devhub/addons/edit/details.html:44 src/olympia/translations/templates/translations/trans-menu.html:13
 msgid "Default Locale"
 msgstr "Locale par défaut"
 
 #: src/olympia/devhub/templates/devhub/addons/edit/details.html:45
-msgid ""
-"Information about your add-on is displayed in this locale unless you "
-"override it with a locale-specific translation. It is only relevant for "
-"listed add-ons."
+msgid "Information about your add-on is displayed in this locale unless you override it with a locale-specific translation. It is only relevant for listed add-ons."
 msgstr ""
-"Des informations qui déterminent si votre module est affiché dans cette "
-"locale à moins que vous ne proposiez une traduction pour cette locale. Ce "
-"champ est uniquement utile pour les modules répertoriés."
+"Des informations qui déterminent si votre module est affiché dans cette locale à moins que vous ne proposiez une traduction pour cette locale. Ce champ est uniquement utile pour les modules "
+"répertoriés."
 
-#: src/olympia/devhub/templates/devhub/addons/edit/details.html:61
-#: src/olympia/users/forms.py:311
-#: src/olympia/users/templates/users/edit.html:122
-#: src/olympia/users/templates/users/register.html:57
+#: src/olympia/devhub/templates/devhub/addons/edit/details.html:61 src/olympia/users/forms.py:311 src/olympia/users/templates/users/edit.html:122 src/olympia/users/templates/users/register.html:57
 #: src/olympia/users/templates/users/vcard.html:22
 msgid "Homepage"
 msgstr "Page d'accueil"
 
 #: src/olympia/devhub/templates/devhub/addons/edit/details.html:63
 msgid ""
-"If your add-on has another homepage, enter its address here. If your website"
-" is localized into other languages multiple translations of this field can "
-"be added. It is only relevant for listed add-ons."
+"If your add-on has another homepage, enter its address here. If your website is localized into other languages multiple translations of this field can be added. It is only relevant for listed add-"
+"ons."
 msgstr ""
-"Si vous avez une autre page pour votre module, saisissez son adresse ici. Si"
-" votre site web est localisé en plusieurs langues, les différentes "
-"traductions de ce champ peuvent être ajoutées. Ce champ est uniquement utile"
-" pour les modules répertoriés."
+"Si vous avez une autre page pour votre module, saisissez son adresse ici. Si votre site web est localisé en plusieurs langues, les différentes traductions de ce champ peuvent être ajoutées. Ce "
+"champ est uniquement utile pour les modules répertoriés."
 
 #: src/olympia/devhub/templates/devhub/addons/edit/media.html:3
 msgid "Images"
@@ -5679,26 +4533,19 @@ msgstr "Informations d'assistance pour {0}"
 
 #: src/olympia/devhub/templates/devhub/addons/edit/support.html:22
 msgid ""
-"If you wish to display an e-mail address for support inquiries, enter it "
-"here. If you have different addresses for each language multiple "
-"translations of this field can be added. It is only relevant for listed add-"
-"ons."
+"If you wish to display an e-mail address for support inquiries, enter it here. If you have different addresses for each language multiple translations of this field can be added. It is only "
+"relevant for listed add-ons."
 msgstr ""
-"Si vous souhaitez afficher une adresse électronique pour les demandes de "
-"support, saisissez-là ici. Si vous avez différentes adresses pour chaque "
-"langue, vous pouvez ajouter les différentes traductions de ce champ. Ce "
-"champ est uniquement utile pour les modules répertoriés."
+"Si vous souhaitez afficher une adresse électronique pour les demandes de support, saisissez-là ici. Si vous avez différentes adresses pour chaque langue, vous pouvez ajouter les différentes "
+"traductions de ce champ. Ce champ est uniquement utile pour les modules répertoriés."
 
 #: src/olympia/devhub/templates/devhub/addons/edit/support.html:45
 msgid ""
-"If your add-on has a support website or forum, enter its address here. If "
-"your website is localized into other languages, multiple translations of "
-"this field can be added. It is only relevant for listed add-ons."
+"If your add-on has a support website or forum, enter its address here. If your website is localized into other languages, multiple translations of this field can be added. It is only relevant for "
+"listed add-ons."
 msgstr ""
-"Si vous disposez d'une site d'aide ou d'un forum consacré à votre module, "
-"saisissez l'adresse ici. Si votre site web est disponible en plusieurs "
-"langues, vous pouvez ajouter les différentes traductions de ce champ. Ce "
-"champ est uniquement utile pour les modules répertoriés."
+"Si vous disposez d'une site d'aide ou d'un forum consacré à votre module, saisissez l'adresse ici. Si votre site web est disponible en plusieurs langues, vous pouvez ajouter les différentes "
+"traductions de ce champ. Ce champ est uniquement utile pour les modules répertoriés."
 
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:6
 msgid "Technical Details"
@@ -5711,16 +4558,11 @@ msgstr "Détails techniques pour {0}"
 
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:23
 msgid ""
-"Any information end users may want to know that isn't necessarily applicable"
-" to the add-on summary or description. Common uses include listing known "
-"major bugs, information on how to report bugs, anticipated release date of a"
-" new version, etc. It is only relevant for listed add-ons."
+"Any information end users may want to know that isn't necessarily applicable to the add-on summary or description. Common uses include listing known major bugs, information on how to report bugs, "
+"anticipated release date of a new version, etc. It is only relevant for listed add-ons."
 msgstr ""
-"Un utilisateur final de ces informations devrait pouvoir savoir qu'elles ne "
-"s'appliquent pas forcément au résumé ou à la description du module. On "
-"fournit habituellement la liste des bogues connus, des informations sur la "
-"façon de faire remonter les problèmes, les prévisions de publication pour "
-"les futures versions etc. Ceci ne s'applique qu'aux modules répertoriés."
+"Un utilisateur final de ces informations devrait pouvoir savoir qu'elles ne s'appliquent pas forcément au résumé ou à la description du module. On fournit habituellement la liste des bogues connus,"
+" des informations sur la façon de faire remonter les problèmes, les prévisions de publication pour les futures versions etc. Ceci ne s'applique qu'aux modules répertoriés."
 
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:46
 msgid "Limit 3"
@@ -5731,12 +4573,8 @@ msgid "Add-on Flags"
 msgstr "Drapeaux du module"
 
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:69
-msgid ""
-"These flags are used to classify add-ons. It is only relevant for listed "
-"add-ons."
-msgstr ""
-"Ces indicateurs de catégories sont utilisés pour classer les modules. Ceci "
-"est uniquement pertinent pour les modules répertoriés."
+msgid "These flags are used to classify add-ons. It is only relevant for listed add-ons."
+msgstr "Ces indicateurs de catégories sont utilisés pour classer les modules. Ceci est uniquement pertinent pour les modules répertoriés."
 
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:74
 msgid "This is a site-specific add-on."
@@ -5751,12 +4589,8 @@ msgid "View Source?"
 msgstr "Voir le code source ?"
 
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:90
-msgid ""
-"Whether the source of your add-on can be displayed in our online viewer. It "
-"is only relevant for listed add-ons."
-msgstr ""
-"Si le code source de votre module peut être affiché dans notre visionneuse "
-"en ligne. Ceci est uniquement pertinent pour les modules répertoriés."
+msgid "Whether the source of your add-on can be displayed in our online viewer. It is only relevant for listed add-ons."
+msgstr "Si le code source de votre module peut être affiché dans notre visionneuse en ligne. Ceci est uniquement pertinent pour les modules répertoriés."
 
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:94
 msgid "This add-on's source code is publicly viewable."
@@ -5771,13 +4605,8 @@ msgid "Public Stats?"
 msgstr "Statistiques publiques ?"
 
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:102
-msgid ""
-"Whether the download and usage stats of your add-on can be displayed in our "
-"online viewer. It is only relevant for listed add-ons."
-msgstr ""
-"Si les statistiques de téléchargement et d'utilisation peuvent être "
-"affichées dans notre visionneuse en ligne. Ceci est uniquement pertinent "
-"pour les modules répertoriés."
+msgid "Whether the download and usage stats of your add-on can be displayed in our online viewer. It is only relevant for listed add-ons."
+msgstr "Si les statistiques de téléchargement et d'utilisation peuvent être affichées dans notre visionneuse en ligne. Ceci est uniquement pertinent pour les modules répertoriés."
 
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:107
 msgid "This add-on's stats are publicly viewable."
@@ -5792,21 +4621,14 @@ msgid "Upgrade SDK?"
 msgstr "Mettre à jour le SDK ?"
 
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:116
-msgid ""
-"If selected, we will try to automatically upgrade your add-on when a new "
-"version of the SDK is released. It is only relevant for listed add-ons."
+msgid "If selected, we will try to automatically upgrade your add-on when a new version of the SDK is released. It is only relevant for listed add-ons."
 msgstr ""
-"Si vous sélectionnez cette option, nous allons essayer de mettre "
-"automatiquement à jour votre Add-on quand une nouvelle version du SDK sera "
-"disponible. Ceci est pertinent uniquement pour les modules répertoriés."
+"Si vous sélectionnez cette option, nous allons essayer de mettre automatiquement à jour votre Add-on quand une nouvelle version du SDK sera disponible. Ceci est pertinent uniquement pour les "
+"modules répertoriés."
 
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:121
-msgid ""
-"This add-on will be automatically upgraded to new versions of the Add-on "
-"SDK."
-msgstr ""
-"Ce module sera automatiquement mis à jour avec les nouvelles versions du SDK"
-" Modules."
+msgid "This add-on will be automatically upgraded to new versions of the Add-on SDK."
+msgstr "Ce module sera automatiquement mis à jour avec les nouvelles versions du SDK Modules."
 
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:123
 msgid "No, this add-on will be upgraded manually."
@@ -5821,31 +4643,20 @@ msgid "UUID"
 msgstr "UUID"
 
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:132
-msgid ""
-"The UUID of your add-on is specified in its install manifest and uniquely "
-"identifies it. You cannot change your UUID once it has been submitted."
-msgstr ""
-"Le UUID de votre module est spécifié dans le manifeste d'installation et "
-"l'identifie de manière unique. Vous ne pouvez pas changer cet UUID une fois "
-"que vous avez publié votre extension."
+msgid "The UUID of your add-on is specified in its install manifest and uniquely identifies it. You cannot change your UUID once it has been submitted."
+msgstr "Le UUID de votre module est spécifié dans le manifeste d'installation et l'identifie de manière unique. Vous ne pouvez pas changer cet UUID une fois que vous avez publié votre extension."
 
-#: src/olympia/devhub/templates/devhub/addons/edit/technical.html:143
-#: src/olympia/devhub/templates/devhub/addons/edit/technical.html:144
+#: src/olympia/devhub/templates/devhub/addons/edit/technical.html:143 src/olympia/devhub/templates/devhub/addons/edit/technical.html:144
 msgid "Whiteboard"
 msgstr "Tableau blanc"
 
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:146
 msgid ""
-"The whiteboard is the place to provide information relevant to your addon, "
-"whatever the version, to the editor. Use it to provide ways to test the "
-"addon, and any additional information that may help. This whiteboard is also"
-" editable by editors."
+"The whiteboard is the place to provide information relevant to your addon, whatever the version, to the editor. Use it to provide ways to test the addon, and any additional information that may "
+"help. This whiteboard is also editable by editors."
 msgstr ""
-"Le tableau est un endroit qui vous permet de fournir des informations "
-"relatives à votre module, quelle que soit la version afin que l'éditeur "
-"puisse les consulter. Vous pouvez l'utiliser pour fournir des méthodes pour "
-"tester le module voire toute autre information qui pourrait être utile. Ce "
-"tableau peut également être édité par les éditeurs."
+"Le tableau est un endroit qui vous permet de fournir des informations relatives à votre module, quelle que soit la version afin que l'éditeur puisse les consulter. Vous pouvez l'utiliser pour "
+"fournir des méthodes pour tester le module voire toute autre information qui pourrait être utile. Ce tableau peut également être édité par les éditeurs."
 
 #: src/olympia/devhub/templates/devhub/addons/edit/technical_dependencies.html:9
 msgid "Remove this dependent add-on"
@@ -5865,15 +4676,11 @@ msgstr "Icône du module"
 
 #: src/olympia/devhub/templates/devhub/addons/forms_shared/media.html:16
 msgid ""
-"Upload an icon for your add-on or choose from one of ours. The icon is "
-"displayed nearly everywhere your add-on is. Uploaded images must be one of "
-"the following image types: .png, .jpg. It is only relevant for listed add-"
-"ons."
+"Upload an icon for your add-on or choose from one of ours. The icon is displayed nearly everywhere your add-on is. Uploaded images must be one of the following image types: .png, .jpg. It is only "
+"relevant for listed add-ons."
 msgstr ""
-"Envoyez une icône pour votre module ou choisissez-en une parmi les nôtres. "
-"L'icône est affiché à presque tous les endroit où apparaît votre module. Le "
-"type de l'image transférée doit être .png ou .jpg. L'envoi d'icône ne "
-"s'applique qu'aux modules répertoriés."
+"Envoyez une icône pour votre module ou choisissez-en une parmi les nôtres. L'icône est affiché à presque tous les endroit où apparaît votre module. Le type de l'image transférée doit être .png ou "
+".jpg. L'envoi d'icône ne s'applique qu'aux modules répertoriés."
 
 #: src/olympia/devhub/templates/devhub/addons/forms_shared/media.html:25
 msgid "Select an icon for your add-on:"
@@ -5886,9 +4693,7 @@ msgstr "32x32 px"
 
 #: src/olympia/devhub/templates/devhub/addons/forms_shared/media.html:39
 msgid "Used in listings of add-ons, like search results and featured add-ons."
-msgstr ""
-"Utilisé dans les listings de modules tels que les résultats de recherche et "
-"les modules en vedette."
+msgstr "Utilisé dans les listings de modules tels que les résultats de recherche et les modules en vedette."
 
 #. The size of the icon
 #: src/olympia/devhub/templates/devhub/addons/forms_shared/media.html:48
@@ -5905,9 +4710,7 @@ msgstr "Envoyer une icône personnalisée ..."
 
 #: src/olympia/devhub/templates/devhub/addons/forms_shared/media.html:65
 msgid "PNG and JPG supported. Icons resized to 64x64 pixels if larger."
-msgstr ""
-"PNG et JPEG sont supportés. Les icônes seront redimensionnées à 64x64 pixels"
-" si elles dépassent."
+msgstr "PNG et JPEG sont supportés. Les icônes seront redimensionnées à 64x64 pixels si elles dépassent."
 
 #: src/olympia/devhub/templates/devhub/addons/forms_shared/media.html:83
 msgid "Screenshots"
@@ -5915,9 +4718,7 @@ msgstr "Captures d'écran"
 
 #: src/olympia/devhub/templates/devhub/addons/forms_shared/media.html:89
 msgid "Please provide at least one screen shot of your add-on:"
-msgstr ""
-"Merci de fournir au moins une capture d'écran ou une vidéo de votre module"
-" :"
+msgstr "Merci de fournir au moins une capture d'écran ou une vidéo de votre module :"
 
 #: src/olympia/devhub/templates/devhub/addons/forms_shared/media.html:114
 msgid "Please provide a caption for this screenshot:"
@@ -5931,64 +4732,49 @@ msgstr "Ajouter une capture d'écran ..."
 msgid "Tests"
 msgstr "Tests"
 
-#: src/olympia/devhub/templates/devhub/addons/includes/validation_compat_test_results.html:25
-#: src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:5
+#: src/olympia/devhub/templates/devhub/addons/includes/validation_compat_test_results.html:25 src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:5
 #: src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:53
 msgid "General Tests"
 msgstr "Tests généraux"
 
-#: src/olympia/devhub/templates/devhub/addons/includes/validation_compat_test_results.html:32
-#: src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:9
+#: src/olympia/devhub/templates/devhub/addons/includes/validation_compat_test_results.html:32 src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:9
 #: src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:67
 msgid "Security Tests"
 msgstr "Tests de sécurité"
 
-#: src/olympia/devhub/templates/devhub/addons/includes/validation_compat_test_results.html:39
-#: src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:13
+#: src/olympia/devhub/templates/devhub/addons/includes/validation_compat_test_results.html:39 src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:13
 #: src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:80
 msgid "Extension Tests"
 msgstr "Tests des extensions"
 
-#: src/olympia/devhub/templates/devhub/addons/includes/validation_compat_test_results.html:46
-#: src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:17
+#: src/olympia/devhub/templates/devhub/addons/includes/validation_compat_test_results.html:46 src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:17
 #: src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:93
 msgid "Localization Tests"
 msgstr "Tests de localisation"
 
-#: src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:21
-#: src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:106
+#: src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:21 src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:106
 msgid "Compatibility Tests"
 msgstr "Tests de compatibilité"
 
-#: src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:29
-#: src/olympia/files/templates/files/viewer.html:142
+#: src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:29 src/olympia/files/templates/files/viewer.html:142
 msgid "Hide messages not required for automated signing"
-msgstr ""
-"Cacher les messages qui ne sont pas nécessaires pour la signature "
-"automatique"
+msgstr "Cacher les messages qui ne sont pas nécessaires pour la signature automatique"
 
-#: src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:35
-#: src/olympia/files/templates/files/viewer.html:150
+#: src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:35 src/olympia/files/templates/files/viewer.html:150
 msgid "Hide messages present in previous version and ignored"
-msgstr ""
-"Cacher les messages qui étaient présents dans les versions précédentes et "
-"qui étaient ignorés"
+msgstr "Cacher les messages qui étaient présents dans les versions précédentes et qui étaient ignorés"
 
-#: src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:50
-#: src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:64
-#: src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:77
-#: src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:90
+#: src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:50 src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:64
+#: src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:77 src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:90
 #: src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:103
 msgid "Top"
 msgstr "Haut de page"
 
-#: src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:2
-#: src/olympia/devhub/templates/devhub/personas/edit.html:63
+#: src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:2 src/olympia/devhub/templates/devhub/personas/edit.html:63
 msgid "Delete Theme"
 msgstr "Supprimer le thème"
 
-#: src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:2
-#: src/olympia/devhub/templates/devhub/versions/list.html:117
+#: src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:2 src/olympia/devhub/templates/devhub/versions/list.html:117
 msgid "Delete Add-on"
 msgstr "Supprimer le module"
 
@@ -5997,29 +4783,22 @@ msgid "Deleting your theme will permanently remove it from the site."
 msgstr "Supprimer votre thème l'effacera de manière permanence du site."
 
 #: src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:14
-msgid ""
-"Deleting your add-on will permanently remove it from the site and prevent "
-"its GUID from being submitted again by others."
-msgstr ""
-"La suppression de votre module entraînera la suppression définitive du site "
-"et empêchera le GUID associé d'être soumis par d'autres personnes."
+msgid "Deleting your add-on will permanently remove it from the site and prevent its GUID from being submitted again by others."
+msgstr "La suppression de votre module entraînera la suppression définitive du site et empêchera le GUID associé d'être soumis par d'autres personnes."
 
 #: src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:24
-msgid ""
-"Enter the following text confirm your decision:\n"
-"           {slug}"
+msgid "Enter the following text confirm your decision: {slug}"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:34
+#: src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:33
 msgid "Please tell us why you are deleting your theme:"
 msgstr "Merci de nous indiquer pourquoi vous supprimez votre thème :"
 
-#: src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:36
+#: src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:35
 msgid "Please tell us why you are deleting your add-on:"
 msgstr "Merci de nous indiquer pourquoi vous supprimez votre module :"
 
-#: src/olympia/devhub/templates/devhub/addons/listing/item_actions.html:1
-#: src/olympia/devhub/templates/devhub/addons/listing/item_actions_theme.html:1
+#: src/olympia/devhub/templates/devhub/addons/listing/item_actions.html:1 src/olympia/devhub/templates/devhub/addons/listing/item_actions_theme.html:1
 #: src/olympia/editors/templates/editors/review.html:253
 msgid "Actions"
 msgstr "Actions"
@@ -6052,22 +4831,17 @@ msgstr "Nouvelle version"
 msgid "Daily statistics on downloads and users."
 msgstr "Statistiques quotidiennes sur les téléchargements et utilisateurs."
 
-#: src/olympia/devhub/templates/devhub/addons/listing/item_actions.html:45
-#: src/olympia/stats/templates/stats/stats.html:75
-#: src/olympia/stats/templates/stats/stats.html:79
-#: src/olympia/stats/templates/stats/stats.html:81
+#: src/olympia/devhub/templates/devhub/addons/listing/item_actions.html:45 src/olympia/stats/templates/stats/stats.html:31 src/olympia/stats/templates/stats/stats.html:35
+#: src/olympia/stats/templates/stats/stats.html:37
 msgid "Statistics"
 msgstr "Statistiques"
 
-#: src/olympia/devhub/templates/devhub/addons/listing/item_actions.html:54
-#: src/olympia/devhub/templates/devhub/includes/addons_edit_nav.html:5
-#: src/olympia/devhub/templates/devhub/payments/payments.html:3
+#: src/olympia/devhub/templates/devhub/addons/listing/item_actions.html:54 src/olympia/devhub/templates/devhub/includes/addons_edit_nav.html:5 src/olympia/devhub/templates/devhub/payments/payments.html:3
 #: src/olympia/devhub/templates/devhub/payments/tier.html:4
 msgid "Manage Payments"
 msgstr "Gérer les paiements"
 
-#: src/olympia/devhub/templates/devhub/addons/listing/item_actions.html:55
-#: src/olympia/devhub/templates/devhub/includes/addons_edit_nav.html:6
+#: src/olympia/devhub/templates/devhub/addons/listing/item_actions.html:55 src/olympia/devhub/templates/devhub/includes/addons_edit_nav.html:6
 msgid "Manage Status & Versions"
 msgstr "Gérer les statuts et versions"
 
@@ -6075,10 +4849,8 @@ msgstr "Gérer les statuts et versions"
 msgid "View Add-on Listing"
 msgstr "Voir le listing du module"
 
-#: src/olympia/devhub/templates/devhub/addons/listing/item_actions.html:64
-#: src/olympia/devhub/templates/devhub/addons/listing/item_actions_theme.html:12
-#: src/olympia/devhub/templates/devhub/includes/addons_edit_nav.html:37
-#: src/olympia/devhub/templates/devhub/personas/edit.html:58
+#: src/olympia/devhub/templates/devhub/addons/listing/item_actions.html:64 src/olympia/devhub/templates/devhub/addons/listing/item_actions_theme.html:12
+#: src/olympia/devhub/templates/devhub/includes/addons_edit_nav.html:37 src/olympia/devhub/templates/devhub/personas/edit.html:58
 msgid "View Recent Changes"
 msgstr "Voir les changements récents"
 
@@ -6103,12 +4875,8 @@ msgid "Delete this theme."
 msgstr "Supprimer ce thème."
 
 #: src/olympia/devhub/templates/devhub/addons/listing/items.html:10
-msgid ""
-"This add-on will be deleted automatically after a few days if the submission"
-" process is not completed."
-msgstr ""
-"Ce module sera supprimé automatiquement après quelques jours si le "
-"processus de soumission n'est pas terminé."
+msgid "This add-on will be deleted automatically after a few days if the submission process is not completed."
+msgstr "Ce module sera supprimé automatiquement après quelques jours si le processus de soumission n'est pas terminé."
 
 #: src/olympia/devhub/templates/devhub/addons/listing/items.html:27
 msgid "Disabled"
@@ -6146,13 +4914,9 @@ msgstr "Nom et version :"
 msgid "The detail page will be:"
 msgstr "La page de détail sera :"
 
-#: src/olympia/devhub/templates/devhub/addons/submit/describe.html:24
-#: src/olympia/devhub/templates/devhub/personas/edit.html:89
-#: src/olympia/devhub/templates/devhub/personas/submit.html:38
+#: src/olympia/devhub/templates/devhub/addons/submit/describe.html:24 src/olympia/devhub/templates/devhub/personas/edit.html:89 src/olympia/devhub/templates/devhub/personas/submit.html:38
 msgid "Please use only letters, numbers, underscores, and dashes in your URL."
-msgstr ""
-"Merci de n'utiliser que des lettres, chiffres, soulignements et tirets dans "
-"votre adresse URL."
+msgstr "Merci de n'utiliser que des lettres, chiffres, soulignements et tirets dans votre adresse URL."
 
 #: src/olympia/devhub/templates/devhub/addons/submit/describe.html:34
 msgid "Provide a brief summary:"
@@ -6170,14 +4934,11 @@ msgstr "Fournissez une description plus détaillée :"
 msgid "The description will appear on the detail page."
 msgstr "La description apparaitra sur la page de détail."
 
-#: src/olympia/devhub/templates/devhub/addons/submit/done.html:4
-#: src/olympia/devhub/templates/devhub/personas/submit_done.html:4
+#: src/olympia/devhub/templates/devhub/addons/submit/done.html:4 src/olympia/devhub/templates/devhub/personas/submit_done.html:4
 msgid "Submission Complete"
 msgstr "Envoi terminé"
 
-#: src/olympia/devhub/templates/devhub/addons/submit/done.html:8
-#: src/olympia/devhub/templates/devhub/addons/submit/sidebar.html:13
-#: src/olympia/devhub/templates/devhub/personas/submit_done.html:8
+#: src/olympia/devhub/templates/devhub/addons/submit/done.html:8 src/olympia/devhub/templates/devhub/addons/submit/sidebar.html:13 src/olympia/devhub/templates/devhub/personas/submit_done.html:8
 msgid "You're done!"
 msgstr "C'est fini !"
 
@@ -6190,56 +4951,32 @@ msgid "Your add-on has been submitted to the Full Review queue."
 msgstr "Votre module a été envoyé dans la file des revues complètes."
 
 #: src/olympia/devhub/templates/devhub/addons/submit/done.html:18
-msgid ""
-"You'll receive an email once it has been reviewed by an editor. In the "
-"meantime, you and your friends can install it directly from its details "
-"page:"
-msgstr ""
-"Vous recevrez un courriel une fois que vérification aura-t-été faite par "
-"un éditeur. En attendant, vous et vos amis pouvez l'installer en allant "
-"directement sur la page de détails :"
+msgid "You'll receive an email once it has been reviewed by an editor. In the meantime, you and your friends can install it directly from its details page:"
+msgstr "Vous recevrez un courriel une fois que vérification aura-t-été faite par un éditeur. En attendant, vous et vos amis pouvez l'installer en allant directement sur la page de détails :"
 
-#: src/olympia/devhub/templates/devhub/addons/submit/done.html:27
-#: src/olympia/devhub/templates/devhub/addons/submit/done.html:77
-#: src/olympia/devhub/templates/devhub/personas/submit_done.html:16
+#: src/olympia/devhub/templates/devhub/addons/submit/done.html:27 src/olympia/devhub/templates/devhub/addons/submit/done.html:77 src/olympia/devhub/templates/devhub/personas/submit_done.html:16
 msgid "Next steps:"
 msgstr "Prochaines étapes :"
 
-#: src/olympia/devhub/templates/devhub/addons/submit/done.html:32
-#: src/olympia/devhub/templates/devhub/addons/submit/done.html:82
+#: src/olympia/devhub/templates/devhub/addons/submit/done.html:32 src/olympia/devhub/templates/devhub/addons/submit/done.html:82
 msgid "<a href=\"{0}\">Upload</a> another platform-specific file to this version."
-msgstr ""
-"<a href=\"{0}\">Envoyer</a> un autre fichier spécifique à une plateforme "
-"pour cette version."
+msgstr "<a href=\"{0}\">Envoyer</a> un autre fichier spécifique à une plateforme pour cette version."
 
 #: src/olympia/devhub/templates/devhub/addons/submit/done.html:34
 msgid "Provide more details by <a href=\"{0}\">editing its listing</a>."
-msgstr ""
-"Fournissez plus de détails en <a href=\"{0}\">modifiant l'entrée de "
-"liste</a>."
+msgstr "Fournissez plus de détails en <a href=\"{0}\">modifiant l'entrée de liste</a>."
 
 #: src/olympia/devhub/templates/devhub/addons/submit/done.html:35
-msgid ""
-"Tell your users why you created this in your <a href=\"{0}\">Developer "
-"Profile</a>."
-msgstr ""
-"Dites à vos utilisateurs pourquoi vous l'avez créé dans votre <a "
-"href=\"{0}\">profil développeur</a>."
+msgid "Tell your users why you created this in your <a href=\"{0}\">Developer Profile</a>."
+msgstr "Dites à vos utilisateurs pourquoi vous l'avez créé dans votre <a href=\"{0}\">profil développeur</a>."
 
 #: src/olympia/devhub/templates/devhub/addons/submit/done.html:36
-msgid ""
-"View and subscribe to your add-on's <a href=\"{0}\">activity feed</a> to "
-"stay updated on reviews, collections, and more."
-msgstr ""
-"Voir et souscrire au <a href=\"{0}\">flux d'activité</a> de votre module "
-"pour rester averti des revues, collections et plus."
+msgid "View and subscribe to your add-on's <a href=\"{0}\">activity feed</a> to stay updated on reviews, collections, and more."
+msgstr "Voir et souscrire au <a href=\"{0}\">flux d'activité</a> de votre module pour rester averti des revues, collections et plus."
 
-#: src/olympia/devhub/templates/devhub/addons/submit/done.html:37
-#: src/olympia/devhub/templates/devhub/addons/submit/done.html:86
+#: src/olympia/devhub/templates/devhub/addons/submit/done.html:37 src/olympia/devhub/templates/devhub/addons/submit/done.html:86
 msgid "View approximate review queue <a href=\"{0}\">wait times</a>."
-msgstr ""
-"Voir le <a href=\"{0}\">temps d'attente</a> approximatif dans la file de "
-"revue."
+msgstr "Voir le <a href=\"{0}\">temps d'attente</a> approximatif dans la file de revue."
 
 #: src/olympia/devhub/templates/devhub/addons/submit/done.html:42
 msgid "Get Ahead in the Review Queue!"
@@ -6247,47 +4984,31 @@ msgstr "Avancez dans la file de revue&nbsp;!"
 
 #: src/olympia/devhub/templates/devhub/addons/submit/done.html:45
 msgid "Become an AMO Reviewer today and get your add-ons reviewed faster."
-msgstr ""
-"Devenez un relecteur AMO dès aujourd'hui et accélérez la revue des modules."
+msgstr "Devenez un relecteur AMO dès aujourd'hui et accélérez la revue des modules."
 
 #: src/olympia/devhub/templates/devhub/addons/submit/done.html:54
-msgid ""
-"Your add-on has been signed and it's ready to use. You can download it here:"
-msgstr ""
-"Votre module a été signé et peut être utilisé. Vous pouvez le télécharger "
-"ici&nbsp;:"
+msgid "Your add-on has been signed and it's ready to use. You can download it here:"
+msgstr "Votre module a été signé et peut être utilisé. Vous pouvez le télécharger ici&nbsp;:"
 
 #: src/olympia/devhub/templates/devhub/addons/submit/done.html:64
-msgid ""
-"Your add-on has been submitted to the Unlisted Preliminary Review queue."
-msgstr ""
-"Votre module a été envoyé dans la file de revue préliminaire pour les "
-"modules non-répertoriés."
+msgid "Your add-on has been submitted to the Unlisted Preliminary Review queue."
+msgstr "Votre module a été envoyé dans la file de revue préliminaire pour les modules non-répertoriés."
 
 #: src/olympia/devhub/templates/devhub/addons/submit/done.html:66
 msgid "Your add-on has been submitted to the Unlisted Full Review queue."
-msgstr ""
-"Votre module a été envoyé dans la file de revue complète pour les modules "
-"non-répertoriés."
+msgstr "Votre module a été envoyé dans la file de revue complète pour les modules non-répertoriés."
 
 #: src/olympia/devhub/templates/devhub/addons/submit/done.html:70
-msgid ""
-"You'll receive an email once it has been reviewed by an editor and signed."
-msgstr ""
-"Vous recevrez un courrier électronique une fois qu'il aura été revu par un "
-"éditeur puis signé."
+msgid "You'll receive an email once it has been reviewed by an editor and signed."
+msgstr "Vous recevrez un courrier électronique une fois qu'il aura été revu par un éditeur puis signé."
 
 #: src/olympia/devhub/templates/devhub/addons/submit/done.html:74
 msgid "Your add-on will not be publicly available on this website."
 msgstr "Votre module ne sera pas disponible publiquement sur ce site web."
 
 #: src/olympia/devhub/templates/devhub/addons/submit/done.html:84
-msgid ""
-"You can upload new versions of your add-on in the <a href=\"{0}\">add-on's "
-"developer page</a>."
-msgstr ""
-"Vous pouvez envoyer de nouvelles versions de votre module dans la <a "
-"href=\"{0}\">page destinée aux développeurs de modules</a>."
+msgid "You can upload new versions of your add-on in the <a href=\"{0}\">add-on's developer page</a>."
+msgstr "Vous pouvez envoyer de nouvelles versions de votre module dans la <a href=\"{0}\">page destinée aux développeurs de modules</a>."
 
 #: src/olympia/devhub/templates/devhub/addons/submit/license.html:4
 msgid "Step 5"
@@ -6298,14 +5019,8 @@ msgid "Step 5. Select a License"
 msgstr "Étape 5. Choisir une licence"
 
 #: src/olympia/devhub/templates/devhub/addons/submit/license.html:9
-msgid ""
-"We require all add-ons to indicate the terms under which their source code "
-"is licensed. Please select a license from the list below or enter a custom "
-"license."
-msgstr ""
-"Nous demandons à tous les modules d'indiquer la licence de leur code source."
-" Merci de choisir une licence dans la liste ci-dessous ou d'indiquer une "
-"licence personnalisée."
+msgid "We require all add-ons to indicate the terms under which their source code is licensed. Please select a license from the list below or enter a custom license."
+msgstr "Nous demandons à tous les modules d'indiquer la licence de leur code source. Merci de choisir une licence dans la liste ci-dessous ou d'indiquer une licence personnalisée."
 
 #: src/olympia/devhub/templates/devhub/addons/submit/license.html:18
 msgid "Select a license for your add-on:"
@@ -6321,14 +5036,11 @@ msgstr "Étape 4. Ajouter des images"
 
 #: src/olympia/devhub/templates/devhub/addons/submit/media.html:9
 msgid ""
-"Custom icons and screenshots draw attention and help users understand what "
-"it does. We strongly recommend uploading a custom icon, as in some areas of "
-"the website, only the icon and name will appear."
+"Custom icons and screenshots draw attention and help users understand what it does. We strongly recommend uploading a custom icon, as in some areas of the website, only the icon and name will "
+"appear."
 msgstr ""
-"Des captures d'écran et des icônes personnalisées captent l'attention des "
-"utilisateurs et les aident à comprendre ce que cela permet de faire. Nous "
-"vous recommandons fortement d'envoyer une icône personnalisée étant donné "
-"qu'à certains endroits du site, elle seule et le nom seront visibles."
+"Des captures d'écran et des icônes personnalisées captent l'attention des utilisateurs et les aident à comprendre ce que cela permet de faire. Nous vous recommandons fortement d'envoyer une icône "
+"personnalisée étant donné qu'à certains endroits du site, elle seule et le nom seront visibles."
 
 #: src/olympia/devhub/templates/devhub/addons/submit/select-review.html:5
 msgid "Step 6"
@@ -6340,25 +5052,16 @@ msgstr "Étape 6. Sélection d'un processus de revue"
 
 #: src/olympia/devhub/templates/devhub/addons/submit/select-review.html:10
 msgid ""
-"All add-ons hosted in our gallery must be reviewed by an editor before they "
-"appear in categories or search results. While waiting for review, your add-"
-"on can still be accessed through its direct URL. Please choose the review "
-"process below that best fits your add-on."
+"All add-ons hosted in our gallery must be reviewed by an editor before they appear in categories or search results. While waiting for review, your add-on can still be accessed through its direct "
+"URL. Please choose the review process below that best fits your add-on."
 msgstr ""
-"Tous les modules hébergés dans notre galerie doivent être vérifiés par un "
-"éditeur avant d'apparaitre dans les catégories ou les résultats de "
-"recherche. Pendant cette période d'attente, vous pouvez toujours accéder à "
-"votre module via son adresse directe. Merci de choisir le processus de revue"
-" qui convient le mieux à votre module."
+"Tous les modules hébergés dans notre galerie doivent être vérifiés par un éditeur avant d'apparaitre dans les catégories ou les résultats de recherche. Pendant cette période d'attente, vous pouvez "
+"toujours accéder à votre module via son adresse directe. Merci de choisir le processus de revue qui convient le mieux à votre module."
 
 #: src/olympia/devhub/templates/devhub/addons/submit/select-review.html:26
 #, python-format
-msgid ""
-"A complete review of your add-on's source and functionality. <a "
-"href=\"%(url)s\">Learn more&hellip;</a>"
-msgstr ""
-"Une revue complète du code source et des fonctionnalités de votre module. <a"
-" href=\"%(url)s\">En savoir plus &hellip;</a>"
+msgid "A complete review of your add-on's source and functionality. <a href=\"%(url)s\">Learn more&hellip;</a>"
+msgstr "Une revue complète du code source et des fonctionnalités de votre module. <a href=\"%(url)s\">En savoir plus &hellip;</a>"
 
 #: src/olympia/devhub/templates/devhub/addons/submit/select-review.html:32
 msgid "Appropriate for polished add-ons"
@@ -6378,8 +5081,7 @@ msgstr "Vérification des versions suivantes dans les 5 jours"
 
 #: src/olympia/devhub/templates/devhub/addons/submit/select-review.html:36
 msgid "Warning-free installation and no feature limitations"
-msgstr ""
-"Installation sans avertissement et aucune limitation de fonctionnalité"
+msgstr "Installation sans avertissement et aucune limitation de fonctionnalité"
 
 #: src/olympia/devhub/templates/devhub/addons/submit/select-review.html:40
 msgid "Choose Full Review"
@@ -6387,12 +5089,8 @@ msgstr "Choisir une revue complète"
 
 #: src/olympia/devhub/templates/devhub/addons/submit/select-review.html:49
 #, python-format
-msgid ""
-"A faster review of your add-on's source for any major problems. <a "
-"href=\"%(url)s\">Learn more&hellip;</a>"
-msgstr ""
-"Une revue rapide du code source de votre module pour vérifier l'absence de "
-"problème grave. <a href=\"%(url)s\">En savoir plus &hellip;</a>"
+msgid "A faster review of your add-on's source for any major problems. <a href=\"%(url)s\">Learn more&hellip;</a>"
+msgstr "Une revue rapide du code source de votre module pour vérifier l'absence de problème grave. <a href=\"%(url)s\">En savoir plus &hellip;</a>"
 
 #: src/olympia/devhub/templates/devhub/addons/submit/select-review.html:55
 msgid "Appropriate for experimental add-ons"
@@ -6438,10 +5136,8 @@ msgstr "Sélectionnez une licence"
 msgid "Select a review process"
 msgstr "Sélectionnez un processus de revue"
 
-#: src/olympia/devhub/templates/devhub/addons/submit/sidebar.html:18
-#: src/olympia/devhub/templates/devhub/docs/policies-submission.html:3
-#: src/olympia/devhub/templates/devhub/docs/policies-submission.html:7
-#: src/olympia/devhub/templates/devhub/docs/policies-submission.html:9
+#: src/olympia/devhub/templates/devhub/addons/submit/sidebar.html:18 src/olympia/devhub/templates/devhub/docs/policies-submission.html:3
+#: src/olympia/devhub/templates/devhub/docs/policies-submission.html:7 src/olympia/devhub/templates/devhub/docs/policies-submission.html:9
 msgid "Submission Process"
 msgstr "Processus d'envoi"
 
@@ -6462,29 +5158,20 @@ msgid "Step 2. Upload Your Add-on"
 msgstr "Étape 2. Envoyer votre module"
 
 #: src/olympia/devhub/templates/devhub/addons/submit/upload.html:11
-msgid ""
-"Use the fields below to upload your add-on package and select any platform "
-"restrictions. After upload, a series of automated validation tests will be "
-"run on your file."
+msgid "Use the fields below to upload your add-on package and select any platform restrictions. After upload, a series of automated validation tests will be run on your file."
 msgstr ""
-"Utilisez les champs ci-dessous pour envoyer le paquet de votre module et "
-"sélectionnez toutes restrictions liées aux plateformes. Après envoi, une "
-"série de tests automatisés seront exécutés sur votre fichier."
+"Utilisez les champs ci-dessous pour envoyer le paquet de votre module et sélectionnez toutes restrictions liées aux plateformes. Après envoi, une série de tests automatisés seront exécutés sur "
+"votre fichier."
 
-#: src/olympia/devhub/templates/devhub/addons/submit/upload.html:59
-#: src/olympia/devhub/templates/devhub/versions/add_file_modal.html:39
+#: src/olympia/devhub/templates/devhub/addons/submit/upload.html:51 src/olympia/devhub/templates/devhub/versions/add_file_modal.html:28
 msgid "Which platforms is this file compatible with?"
-msgstr ""
-"Quelles sont les plateformes avec lesquelles le fichier est "
-"compatible&nbsp;?"
+msgstr "Quelles sont les plateformes avec lesquelles le fichier est compatible&nbsp;?"
 
-#: src/olympia/devhub/templates/devhub/addons/submit/upload.html:67
-#: src/olympia/devhub/templates/devhub/versions/add_file_modal.html:65
+#: src/olympia/devhub/templates/devhub/addons/submit/upload.html:59 src/olympia/devhub/templates/devhub/versions/add_file_modal.html:45
 msgid "Administrative overrides"
 msgstr "Dérogations administratives"
 
-#: src/olympia/devhub/templates/devhub/api/agreement.html:3
-#: src/olympia/devhub/templates/devhub/api/agreement.html:11
+#: src/olympia/devhub/templates/devhub/api/agreement.html:3 src/olympia/devhub/templates/devhub/api/agreement.html:11
 msgid "Firefox Add-on Distribution Agreement"
 msgstr "Accord de distribution des modules complémentaires Firefox"
 
@@ -6494,12 +5181,8 @@ msgstr "Informations d'authentification pour l'API"
 
 #: src/olympia/devhub/templates/devhub/api/key.html:20
 #, python-format
-msgid ""
-"For detailed instructions, consult the <a href=\"%(docs_url)s\">API "
-"documentation</a>."
-msgstr ""
-"Pour plus de renseignements, consultez la <a "
-"href=\"%(docs_url)s\">documentation de l'API</a>."
+msgid "For detailed instructions, consult the <a href=\"%(docs_url)s\">API documentation</a>."
+msgstr "Pour plus de renseignements, consultez la <a href=\"%(docs_url)s\">documentation de l'API</a>."
 
 #: src/olympia/devhub/templates/devhub/api/key.html:28
 msgid "JWT issuer"
@@ -6512,31 +5195,20 @@ msgstr "Secret JWT"
 #: src/olympia/devhub/templates/devhub/api/key.html:37
 #, python-format
 msgid ""
-"To make API requests, send a <a href=\"%(jwt_url)s\">JSON Web Token "
-"(JWT)</a> as the authorization header. You'll need to generate a JWT for "
-"every request as explained in the <a href=\"%(docs_url)s\">API "
-"documentation</a>."
+"To make API requests, send a <a href=\"%(jwt_url)s\">JSON Web Token (JWT)</a> as the authorization header. You'll need to generate a JWT for every request as explained in the <a "
+"href=\"%(docs_url)s\">API documentation</a>."
 msgstr ""
-"Pour effectuer des requêtes sur l'API, envoyez un <a "
-"href=\"%(jwt_url)s\">jeton web JSON (JWT pour <i>JSON Web Token</i>)</a> "
-"dans l'en-tête d'autorisation. Vous devrez générer un JWT pour chaque "
-"requête, comme indiqué dans <a href=\"%(docs_url)s\">la documentation "
-"d'API</a>."
+"Pour effectuer des requêtes sur l'API, envoyez un <a href=\"%(jwt_url)s\">jeton web JSON (JWT pour <i>JSON Web Token</i>)</a> dans l'en-tête d'autorisation. Vous devrez générer un JWT pour chaque "
+"requête, comme indiqué dans <a href=\"%(docs_url)s\">la documentation d'API</a>."
 
 #: src/olympia/devhub/templates/devhub/api/key.html:47
 msgid "You don't have any API credentials yet."
-msgstr ""
-"Vous n'avez pas encore d'informations pour vous authentifier avec l'API."
+msgstr "Vous n'avez pas encore d'informations pour vous authentifier avec l'API."
 
 #: src/olympia/devhub/templates/devhub/api/key.html:53
 #, python-format
-msgid ""
-"This feature is under active development. If you find a problem please <a "
-"target=\"_blank\" href=\"%(bug_link)s\">report a bug</a>."
-msgstr ""
-"Cette fonctionnalité est en cours de développement. Si vous constatez un "
-"problème, veuillez <a target=\"_blank\" href=\"%(bug_link)s\">rapporter un "
-"bogue</a>."
+msgid "This feature is under active development. If you find a problem please <a target=\"_blank\" href=\"%(bug_link)s\">report a bug</a>."
+msgstr "Cette fonctionnalité est en cours de développement. Si vous constatez un problème, veuillez <a target=\"_blank\" href=\"%(bug_link)s\">rapporter un bogue</a>."
 
 #: src/olympia/devhub/templates/devhub/api/key.html:61
 msgid "Revoke and regenerate credentials"
@@ -6546,30 +5218,19 @@ msgstr "Révoquer et régénérer les informations d'authentification"
 msgid "Generate new credentials"
 msgstr "Générer de nouvelles informations d'authentification"
 
-#: src/olympia/devhub/templates/devhub/docs/policies-agreement.html:3
-#: src/olympia/devhub/templates/devhub/docs/policies-agreement.html:7
-#: src/olympia/devhub/templates/devhub/docs/policies-agreement.html:9
-#: src/olympia/devhub/templates/devhub/docs/policies.html:24
-#: src/olympia/devhub/templates/devhub/docs/policies.html:103
+#: src/olympia/devhub/templates/devhub/docs/policies-agreement.html:3 src/olympia/devhub/templates/devhub/docs/policies-agreement.html:7 src/olympia/devhub/templates/devhub/docs/policies-agreement.html:9
+#: src/olympia/devhub/templates/devhub/docs/policies.html:24 src/olympia/devhub/templates/devhub/docs/policies.html:103
 msgid "Developer Agreement"
 msgstr "Accord développeur"
 
-#: src/olympia/devhub/templates/devhub/docs/policies-contact.html:3
-#: src/olympia/devhub/templates/devhub/docs/policies-contact.html:7
-#: src/olympia/devhub/templates/devhub/docs/policies-contact.html:9
-#: src/olympia/devhub/templates/devhub/docs/policies.html:27
-#: src/olympia/devhub/templates/devhub/docs/policies.html:115
+#: src/olympia/devhub/templates/devhub/docs/policies-contact.html:3 src/olympia/devhub/templates/devhub/docs/policies-contact.html:7 src/olympia/devhub/templates/devhub/docs/policies-contact.html:9
+#: src/olympia/devhub/templates/devhub/docs/policies.html:27 src/olympia/devhub/templates/devhub/docs/policies.html:115
 msgid "Contacting Us"
 msgstr "Nous contacter"
 
 #: src/olympia/devhub/templates/devhub/docs/policies-contact.html:12
-msgid ""
-"Thanks for your interest in contacting the Mozilla Add-ons team. Please read"
-" this page carefully to ensure your request goes to the right place."
-msgstr ""
-"Merci de votre intérêt pour contacter l'équipe Mozilla Add-ons. Merci de "
-"lire avec attention cette page pour être sûr que votre requête arrive au bon"
-" endroit."
+msgid "Thanks for your interest in contacting the Mozilla Add-ons team. Please read this page carefully to ensure your request goes to the right place."
+msgstr "Merci de votre intérêt pour contacter l'équipe Mozilla Add-ons. Merci de lire avec attention cette page pour être sûr que votre requête arrive au bon endroit."
 
 #: src/olympia/devhub/templates/devhub/docs/policies-contact.html:17
 msgid "Add-on Support"
@@ -6577,15 +5238,11 @@ msgstr "Assistance module"
 
 #: src/olympia/devhub/templates/devhub/docs/policies-contact.html:19
 msgid ""
-"If you have a support question about a particular add-on, such as \"how do I"
-" use this add-on?\" or \"why doesn't this work properly?\", please contact "
-"that add-on's author through the support channels listed on the add-on's "
-"listing page."
+"If you have a support question about a particular add-on, such as \"how do I use this add-on?\" or \"why doesn't this work properly?\", please contact that add-on's author through the support "
+"channels listed on the add-on's listing page."
 msgstr ""
-"Si vous avez une question à propos d'un module précis, telle que « Comment "
-"utiliser ce module ? » ou « Pourquoi cela ne fonctionne-t-il pas "
-"correctement ? », merci de contacter le développeur du module via les canaux"
-" d'assistance présents sur la page du module."
+"Si vous avez une question à propos d'un module précis, telle que « Comment utiliser ce module ? » ou « Pourquoi cela ne fonctionne-t-il pas correctement ? », merci de contacter le développeur du "
+"module via les canaux d'assistance présents sur la page du module."
 
 #: src/olympia/devhub/templates/devhub/docs/policies-contact.html:24
 msgid "Add-on Editorial Concerns"
@@ -6598,18 +5255,12 @@ msgstr "amo-editors at mozilla dot org"
 #: src/olympia/devhub/templates/devhub/docs/policies-contact.html:26
 #, python-format
 msgid ""
-"If you have a question about an Editor's review of an add-on or want to "
-"report a policy violation, please email %(mail_editors)s. <strong>Almost all"
-" add-on reports fall under this category.</strong> Please be sure to include"
-" a link to the add-on in question and a detailed description of your "
-"question or comment."
+"If you have a question about an Editor's review of an add-on or want to report a policy violation, please email %(mail_editors)s. <strong>Almost all add-on reports fall under this "
+"category.</strong> Please be sure to include a link to the add-on in question and a detailed description of your question or comment."
 msgstr ""
-"Si vous avez une question à propos de la revue d'un éditeur sur un module, "
-"ou que vous souhaitez rapporter une violation de la politique, merci de "
-"contacter par courriel %(mail_editors)s. <strong>Quasiment tous les rapports"
-" à propos d'un module tombent dans cette catégorie.</strong> Merci de vous "
-"assurer d'inclure un lien vers le module en question et une description "
-"détaillée de votre question ou commentaire."
+"Si vous avez une question à propos de la revue d'un éditeur sur un module, ou que vous souhaitez rapporter une violation de la politique, merci de contacter par courriel %(mail_editors)s. "
+"<strong>Quasiment tous les rapports à propos d'un module tombent dans cette catégorie.</strong> Merci de vous assurer d'inclure un lien vers le module en question et une description détaillée de "
+"votre question ou commentaire."
 
 #: src/olympia/devhub/templates/devhub/docs/policies-contact.html:31
 msgid "Add-on Security Vulnerabilities"
@@ -6622,21 +5273,13 @@ msgstr "amo-admins à mozilla point org"
 #: src/olympia/devhub/templates/devhub/docs/policies-contact.html:36
 #, python-format
 msgid ""
-"If you have discovered a security vulnerability in an add-on, even if it is "
-"not hosted here, Mozilla is very interested in your discovery and will work "
-"with the add-on developer to correct the issue as soon as possible. Add-on "
-"security issues can be reported <a "
-"href=\"http://www.mozilla.org/projects/security/security-bugs-"
-"policy.html\">confidentially</a> in <a "
+"If you have discovered a security vulnerability in an add-on, even if it is not hosted here, Mozilla is very interested in your discovery and will work with the add-on developer to correct the "
+"issue as soon as possible. Add-on security issues can be reported <a href=\"http://www.mozilla.org/projects/security/security-bugs-policy.html\">confidentially</a> in <a "
 "href=\"%(link_bugzilla)s\">Bugzilla</a> or by emailing %(mail_admins)s."
 msgstr ""
-"Si vous avez découvert une vulnérabilité de sécurité dans un module, même "
-"s'il n'est pas hébergé ici, Mozilla est très intéressée par votre découverte"
-" et travaillera avec le développeur du module pour l'aider à corriger le "
-"plus rapidement possible le problème. Les failles de sécurités des modules "
-"peuvent être rapportées à <a href=\"http://www.mozilla.org/projects/security"
-"/security-bugs-policy.html\">confidentiellement</a> dans <a "
-"href=\"%(link_bugzilla)s\">Bugzilla</a> ou par courriel à %(mail_admins)s."
+"Si vous avez découvert une vulnérabilité de sécurité dans un module, même s'il n'est pas hébergé ici, Mozilla est très intéressée par votre découverte et travaillera avec le développeur du module "
+"pour l'aider à corriger le plus rapidement possible le problème. Les failles de sécurités des modules peuvent être rapportées à <a href=\"http://www.mozilla.org/projects/security/security-bugs-"
+"policy.html\">confidentiellement</a> dans <a href=\"%(link_bugzilla)s\">Bugzilla</a> ou par courriel à %(mail_admins)s."
 
 #: src/olympia/devhub/templates/devhub/docs/policies-contact.html:42
 msgid "Website Functionality & Development"
@@ -6644,17 +5287,11 @@ msgstr "Développement et fonctionnalités du site web"
 
 #: src/olympia/devhub/templates/devhub/docs/policies-contact.html:44
 msgid ""
-"If you've found a problem with the site, we'd love to fix it. Please <a "
-"href=\"https://github.com/mozilla/olympia/issues\">file a bug report</a> in "
-"GitHub, including the location of the problem and how you encountered it."
+"If you've found a problem with the site, we'd love to fix it. Please <a href=\"https://github.com/mozilla/addons/issues/new\">file a bug report</a> in GitHub, including the location of the problem "
+"and how you encountered it."
 msgstr ""
-"Si vous avez rencontré un problème sur le site, nous aimerions pouvoir le "
-"corriger. Merci <a href=\"https://github.com/mozilla/olympia/issues\">de "
-"rapporter la bogue</a> dans GitHub en précisant l'endroit où vous avez eu le"
-" problème."
 
-#: src/olympia/devhub/templates/devhub/docs/policies-maintenance.html:3
-#: src/olympia/devhub/templates/devhub/docs/policies-maintenance.html:7
+#: src/olympia/devhub/templates/devhub/docs/policies-maintenance.html:3 src/olympia/devhub/templates/devhub/docs/policies-maintenance.html:7
 #: src/olympia/devhub/templates/devhub/docs/policies-maintenance.html:8
 msgid "Maintaining Your Add-ons"
 msgstr "Maintenance de vos modules"
@@ -6665,32 +5302,17 @@ msgstr "Envoyer de nouvelles versions de votre module"
 
 #: src/olympia/devhub/templates/devhub/docs/policies-maintenance.html:12
 msgid ""
-"Developers are encouraged to submit updates to their add-ons to fix bugs, "
-"add features, and otherwise improve their product. New versions of an add-on"
-" must have a <a "
-"href=\"https://developer.mozilla.org/en/Toolkit_version_format\">higher "
-"version number</a> and can be submitted through the Developer Tools "
-"provided. There is no limit to the number of versions that can be submitted,"
-" but please remember that versions must be reviewed by an editor."
+"Developers are encouraged to submit updates to their add-ons to fix bugs, add features, and otherwise improve their product. New versions of an add-on must have a <a "
+"href=\"https://developer.mozilla.org/en/Toolkit_version_format\">higher version number</a> and can be submitted through the Developer Tools provided. There is no limit to the number of versions "
+"that can be submitted, but please remember that versions must be reviewed by an editor."
 msgstr ""
-"Les développeurs sont encouragés à envoyer des mises à jour de leurs modules"
-" pour corriger les bugs, ajouter des fonctionnalités et plus généralement "
-"améliorer leur produit. Les nouvelles versions d'un module doivent avoir un "
-"<a href=\"https://developer.mozilla.org/en/Toolkit_version_format\">numéro "
-"de version supérieur</a> et peuvent être envoyées via les outils pour le "
-"développeur fournis. Il n'y a pas de limite au nombre de versions qui "
-"peuvent être envoyées, mais merci de vous souvenir qu'elles devront être "
-"revues par un éditeur."
+"Les développeurs sont encouragés à envoyer des mises à jour de leurs modules pour corriger les bugs, ajouter des fonctionnalités et plus généralement améliorer leur produit. Les nouvelles versions "
+"d'un module doivent avoir un <a href=\"https://developer.mozilla.org/en/Toolkit_version_format\">numéro de version supérieur</a> et peuvent être envoyées via les outils pour le développeur fournis."
+" Il n'y a pas de limite au nombre de versions qui peuvent être envoyées, mais merci de vous souvenir qu'elles devront être revues par un éditeur."
 
 #: src/olympia/devhub/templates/devhub/docs/policies-maintenance.html:18
-msgid ""
-"New versions will be added to a pending review queue, and any additional "
-"versions submitted before the review is completed will move that version to "
-"the end of the queue."
-msgstr ""
-"Les nouvelles versions seront ajoutées à une file d'attente de revue, et "
-"toute nouvelle version envoyée avant la fin de la revue sera renvoyée à la "
-"fin de la file."
+msgid "New versions will be added to a pending review queue, and any additional versions submitted before the review is completed will move that version to the end of the queue."
+msgstr "Les nouvelles versions seront ajoutées à une file d'attente de revue, et toute nouvelle version envoyée avant la fin de la revue sera renvoyée à la fin de la file."
 
 #: src/olympia/devhub/templates/devhub/docs/policies-maintenance.html:23
 msgid "How do I submit a Beta add-on?"
@@ -6698,58 +5320,36 @@ msgstr "Comment envoyer un module bêta ?"
 
 #: src/olympia/devhub/templates/devhub/docs/policies-maintenance.html:25
 msgid "Beta channels are only available to fully-reviewed add-ons."
-msgstr ""
-"Les canaux bêta sont uniquement accessibles aux modules totalement vérifiés."
+msgstr "Les canaux bêta sont uniquement accessibles aux modules totalement vérifiés."
 
 #: src/olympia/devhub/templates/devhub/docs/policies-maintenance.html:31
 msgid ""
-"To create a beta channel, upload a file with a unique version string that "
-"contains any of the following strings: <code>a,b,alpha,beta,pre,rc</code>, "
-"with an optional number at the end. This text must come at the end of the "
-"version string. If you understand regex format, here's what we look for in "
-"the version number: <code>\"(a|alpha|b|beta|pre|rc)\\d*$\"</code>."
+"To create a beta channel, upload a file with a unique version string that contains any of the following strings: <code>a,b,alpha,beta,pre,rc</code>, with an optional number at the end. This text "
+"must come at the end of the version string. If you understand regex format, here's what we look for in the version number: <code>\"(a|alpha|b|beta|pre|rc)\\d*$\"</code>."
 msgstr ""
-"Pour créer un canal beta, envoyer un fichier avec une chaîne de version "
-"unique contenant l'une des chaînes suivantes : "
-"<code>a,b,alpha,beta,pre,rc</code>, avec un nombre optionnel à la fin. Ce "
-"texte doit être à la fin de la chaîne de version. Si vous comprenez les "
-"expressions rationnelles, voici ce que nous cherchons dans le numéro de "
-"version : <code>\"(a|alpha|b|beta|pre|rc)\\d*$\"</code>."
+"Pour créer un canal beta, envoyer un fichier avec une chaîne de version unique contenant l'une des chaînes suivantes : <code>a,b,alpha,beta,pre,rc</code>, avec un nombre optionnel à la fin. Ce "
+"texte doit être à la fin de la chaîne de version. Si vous comprenez les expressions rationnelles, voici ce que nous cherchons dans le numéro de version : "
+"<code>\"(a|alpha|b|beta|pre|rc)\\d*$\"</code>."
 
 #: src/olympia/devhub/templates/devhub/docs/policies-maintenance.html:37
 msgid ""
-"Once a file meeting this criteria is uploaded to AMO, it will automatically "
-"be marked as a beta version. Users of add-ons with these unique version "
-"numbers will automatically be served the newest beta updates."
+"Once a file meeting this criteria is uploaded to AMO, it will automatically be marked as a beta version. Users of add-ons with these unique version numbers will automatically be served the newest "
+"beta updates."
 msgstr ""
-"Une fois qu'un fichier correspondant à ces critères a été envoyé sur AMO, il"
-" sera automatiquement marqué comme version beta. Les utilisateurs de ces "
-"modules avec ces numéros de version unique recevront automatiquement la "
-"dernière mise à jour beta."
+"Une fois qu'un fichier correspondant à ces critères a été envoyé sur AMO, il sera automatiquement marqué comme version beta. Les utilisateurs de ces modules avec ces numéros de version unique "
+"recevront automatiquement la dernière mise à jour beta."
 
 #: src/olympia/devhub/templates/devhub/docs/policies-maintenance.html:43
 msgid ""
-"While we call these \"Beta versions\", you can use this channel for "
-"nightlies, or alphas, or prerelease versions as you wish. Please note that "
-"there is only one channel for this purpose and all of your users on this "
-"channel will receive the latest add-ons submitted. For instance, if you "
-"upload <code>1.0beta1</code> to the release channel and then upload "
-"<code>1.1alpha1</code>, all users of <code>1.0beta1</code> will be offered "
-"an upgrade to <code>1.1alpha1</code>. Updates are pushed by submission date "
-"and not version number, so users will always get the most recent channel "
-"update regardless of any kind of alphabetical sorting."
+"While we call these \"Beta versions\", you can use this channel for nightlies, or alphas, or prerelease versions as you wish. Please note that there is only one channel for this purpose and all of "
+"your users on this channel will receive the latest add-ons submitted. For instance, if you upload <code>1.0beta1</code> to the release channel and then upload <code>1.1alpha1</code>, all users of "
+"<code>1.0beta1</code> will be offered an upgrade to <code>1.1alpha1</code>. Updates are pushed by submission date and not version number, so users will always get the most recent channel update "
+"regardless of any kind of alphabetical sorting."
 msgstr ""
-"Bien que nous appelions ces versions « Versions Beta », vous pouvez utiliser"
-" ce canal pour des versions quotidiennes, ou alpha, ou des pré-versions, "
-"comme vous le souhaitez. Merci de noter qu'il n'existe qu'un seul canal pour"
-" ce but et que tous vos utilisateurs recevront les derniers modules envoyés."
-" Ainsi, si vous envoyez  <code>1.0beta1</code> dans le canal des sorties et "
-"ensuite <code>1.1alpha1</code>, tous les utilisateurs de "
-"<code>1.0beta1</code> se verront proposer la mise à jour vers "
-"<code>1.1alpha1</code>. Les mises à jour sont envoyées par dates d'envoi et "
-"pas par numéro de version de sorte que les utilisateurs reçoivent toujours "
-"la dernière mise à jour, sans s'inquiéter d'un quelconque ordre "
-"alphabétique."
+"Bien que nous appelions ces versions « Versions Beta », vous pouvez utiliser ce canal pour des versions quotidiennes, ou alpha, ou des pré-versions, comme vous le souhaitez. Merci de noter qu'il "
+"n'existe qu'un seul canal pour ce but et que tous vos utilisateurs recevront les derniers modules envoyés. Ainsi, si vous envoyez  <code>1.0beta1</code> dans le canal des sorties et ensuite "
+"<code>1.1alpha1</code>, tous les utilisateurs de <code>1.0beta1</code> se verront proposer la mise à jour vers <code>1.1alpha1</code>. Les mises à jour sont envoyées par dates d'envoi et pas par "
+"numéro de version de sorte que les utilisateurs reçoivent toujours la dernière mise à jour, sans s'inquiéter d'un quelconque ordre alphabétique."
 
 #: src/olympia/devhub/templates/devhub/docs/policies-maintenance.html:48
 msgid "Required Updates"
@@ -6757,21 +5357,13 @@ msgstr "Mises à jour requises"
 
 #: src/olympia/devhub/templates/devhub/docs/policies-maintenance.html:50
 msgid ""
-"Certain situations may arise in which Mozilla requests that an add-on "
-"developer update their add-on within a given time period to address a major "
-"security issue or policy violation. We work with developers to reasonably "
-"accommodate their own schedules, but if the issue is of a serious enough "
-"nature, add-ons that cannot issue an update with the requested fix may be "
-"demoted from fully-reviewed status, disabled, or permanently removed from "
-"the site."
+"Certain situations may arise in which Mozilla requests that an add-on developer update their add-on within a given time period to address a major security issue or policy violation. We work with "
+"developers to reasonably accommodate their own schedules, but if the issue is of a serious enough nature, add-ons that cannot issue an update with the requested fix may be demoted from fully-"
+"reviewed status, disabled, or permanently removed from the site."
 msgstr ""
-"Certaines situations peuvent se présenter où Mozilla demande à un "
-"développeur de module de mettre à jour son module dans un laps de temps "
-"donné pour corriger une faille de sécurité majeure ou une violation de la "
-"politique. Nous travaillons avec les développeurs pour adapter leur "
-"planification, mais si la faille est suffisamment grave, les modules qui ne "
-"peuvent proposer de mise à jour avec la correction demandée pourront être "
-"déclassés, désactivés voire retirés de manière permanente du site."
+"Certaines situations peuvent se présenter où Mozilla demande à un développeur de module de mettre à jour son module dans un laps de temps donné pour corriger une faille de sécurité majeure ou une "
+"violation de la politique. Nous travaillons avec les développeurs pour adapter leur planification, mais si la faille est suffisamment grave, les modules qui ne peuvent proposer de mise à jour avec "
+"la correction demandée pourront être déclassés, désactivés voire retirés de manière permanente du site."
 
 #: src/olympia/devhub/templates/devhub/docs/policies-maintenance.html:55
 msgid "Transfer of Ownership"
@@ -6779,67 +5371,41 @@ msgstr "Transfert de propriété"
 
 #: src/olympia/devhub/templates/devhub/docs/policies-maintenance.html:57
 msgid ""
-"Add-ons can have multiple users with permission to update and manage the "
-"listing. Existing authors of an add-on can transfer ownership and add "
-"additional developers to an add-on's listing through the Developer Tools "
-"provided. No interaction with Mozilla representatives is necessary for a "
-"transfer of ownership."
+"Add-ons can have multiple users with permission to update and manage the listing. Existing authors of an add-on can transfer ownership and add additional developers to an add-on's listing through "
+"the Developer Tools provided. No interaction with Mozilla representatives is necessary for a transfer of ownership."
 msgstr ""
-"Les modules peuvent avoir plusieurs utilisateurs avec la permission de "
-"mettre à jour et gérer le listing. Les auteurs existant d'un module peuvent "
-"transférer la propriété et ajouter de nouveaux développeurs au module via "
-"les outils pour le développeur fournis. Aucune interaction avec des "
-"représentants de Mozilla n'est nécessaire pour un tel transfert de "
-"propriété."
+"Les modules peuvent avoir plusieurs utilisateurs avec la permission de mettre à jour et gérer le listing. Les auteurs existant d'un module peuvent transférer la propriété et ajouter de nouveaux "
+"développeurs au module via les outils pour le développeur fournis. Aucune interaction avec des représentants de Mozilla n'est nécessaire pour un tel transfert de propriété."
 
 #: src/olympia/devhub/templates/devhub/docs/policies-maintenance.html:63
 #, python-format
-msgid ""
-"Mozilla can assist with granting additional permissions of an add-on's "
-"listing if <a href=\"%(link_contact)s\">contacted</a> by the add-on's "
-"current owner."
-msgstr ""
-"Mozilla peut aider à donner des permissions supplémentaires sur le listing "
-"d'un module uniquement si <a href=\"%(link_contact)s\">contacté</a> par le "
-"propriétaire courant du module."
+msgid "Mozilla can assist with granting additional permissions of an add-on's listing if <a href=\"%(link_contact)s\">contacted</a> by the add-on's current owner."
+msgstr "Mozilla peut aider à donner des permissions supplémentaires sur le listing d'un module uniquement si <a href=\"%(link_contact)s\">contacté</a> par le propriétaire courant du module."
 
 #: src/olympia/devhub/templates/devhub/docs/policies-maintenance.html:70
 msgid ""
-"Mozilla encourages its users to offer feedback on their experiences when "
-"using an add-on. This allows other users to determine if the add-on is "
-"stable and useful. It also provides valuable feedback to developers, "
-"allowing them to continuously improve their add-on to meet user needs."
+"Mozilla encourages its users to offer feedback on their experiences when using an add-on. This allows other users to determine if the add-on is stable and useful. It also provides valuable feedback"
+" to developers, allowing them to continuously improve their add-on to meet user needs."
 msgstr ""
-"Mozilla encourage ses utilisateurs à donner un retour de leur expérience "
-"lorsqu'ils utilisent un module. Ceci permet aux autres utilisateurs de "
-"savoir si un module est stable et utile. Cela fournit aussi un retour aux "
-"développeurs, leur permettant d'améliorer en permanence leur module pour "
-"correspondre aux besoins des utilisateurs."
+"Mozilla encourage ses utilisateurs à donner un retour de leur expérience lorsqu'ils utilisent un module. Ceci permet aux autres utilisateurs de savoir si un module est stable et utile. Cela fournit"
+" aussi un retour aux développeurs, leur permettant d'améliorer en permanence leur module pour correspondre aux besoins des utilisateurs."
 
 #: src/olympia/devhub/templates/devhub/docs/policies-maintenance.html:76
 #, python-format
 msgid ""
-"Reviews must follow the <a href=\"%(link_guidelines)s\">review "
-"guidelines</a>. Reviews that do not meet these guidelines may be flagged for"
-" moderation, but negative reviews will not be removed unless they provide "
-"false information."
+"Reviews must follow the <a href=\"%(link_guidelines)s\">review guidelines</a>. Reviews that do not meet these guidelines may be flagged for moderation, but negative reviews will not be removed "
+"unless they provide false information."
 msgstr ""
-"Les éditeurs doivent suivre les <a href=\"%(link_guidelines)s\">directives "
-"de revue</a>. Les revues qui ne correspondent pas à ces directives pourront "
-"être notifiées pour modération, mais les critiques négatives ne seront pas "
-"retirées sauf si elles fournissent de mauvaises informations."
+"Les éditeurs doivent suivre les <a href=\"%(link_guidelines)s\">directives de revue</a>. Les revues qui ne correspondent pas à ces directives pourront être notifiées pour modération, mais les "
+"critiques négatives ne seront pas retirées sauf si elles fournissent de mauvaises informations."
 
 #: src/olympia/devhub/templates/devhub/docs/policies-maintenance.html:82
 msgid ""
-"Many developers provide a support mechanism, such as a forum, discussion "
-"group, or email address. It is recommended that support questions be posted "
-"via those mediums instead of in an add-on's review section."
+"Many developers provide a support mechanism, such as a forum, discussion group, or email address. It is recommended that support questions be posted via those mediums instead of in an add-on's "
+"review section."
 msgstr ""
-"De nombreux développeurs proposent un système pour l'assistance, tel un "
-"forum, un groupe de discussion ou une adresse courriel. Il est recommandé "
-"d'utiliser ces moyens de communications pour signaler des problèmes et poser"
-" des questions plutôt que la partie commentaires de la page de chaque "
-"module."
+"De nombreux développeurs proposent un système pour l'assistance, tel un forum, un groupe de discussion ou une adresse courriel. Il est recommandé d'utiliser ces moyens de communications pour "
+"signaler des problèmes et poser des questions plutôt que la partie commentaires de la page de chaque module."
 
 #: src/olympia/devhub/templates/devhub/docs/policies-maintenance.html:87
 msgid "Code Disputes"
@@ -6847,44 +5413,26 @@ msgstr "Disputes de code"
 
 #: src/olympia/devhub/templates/devhub/docs/policies-maintenance.html:90
 msgid ""
-"Many add-ons allow their source code to be openly viewed. This does not mean"
-" that the source code is open source or available for use in another add-on."
-" The original author of an add-on retains copyright of their work unless "
-"otherwise noted in the add-on's license."
+"Many add-ons allow their source code to be openly viewed. This does not mean that the source code is open source or available for use in another add-on. The original author of an add-on retains "
+"copyright of their work unless otherwise noted in the add-on's license."
 msgstr ""
-"Beaucoup de modules permettent de voir leur code source librement. Cela ne "
-"signifie pas que le code source est sous licence libre ou utilisable dans un"
-" autre module. L'auteur d'un module a tous les droits sur son travail sauf "
-"mention contraire dans la licence."
+"Beaucoup de modules permettent de voir leur code source librement. Cela ne signifie pas que le code source est sous licence libre ou utilisable dans un autre module. L'auteur d'un module a tous les"
+" droits sur son travail sauf mention contraire dans la licence."
 
 #: src/olympia/devhub/templates/devhub/docs/policies-maintenance.html:96
 msgid ""
-"In the event that we're notified of a copyright or license infringement, we "
-"will take steps to review the situation and determine if an actual "
-"infringement has occurred. If we determine that there is an infringement, we"
-" will remove the offending add-on and contact the author. New add-on "
-"submissions (including updates) containing infringing code will be denied "
-"approval for public status."
+"In the event that we're notified of a copyright or license infringement, we will take steps to review the situation and determine if an actual infringement has occurred. If we determine that there "
+"is an infringement, we will remove the offending add-on and contact the author. New add-on submissions (including updates) containing infringing code will be denied approval for public status."
 msgstr ""
-"Dans l'hypothèse que nous soyons notifiés d'une infraction au droit d'auteur"
-" ou de licence, nous prendrons les mesures nécessaires pour voir la "
-"situation et déterminer si effectivement il y a eu infraction. Si nous "
-"déterminons que c'est le cas, nous retirerons le module concerné et "
-"contacterons l'auteur. Les futurs envois de modules (dont les mises à jour) "
-"contenant du code concerné ne pourront obtenir le statut de public."
+"Dans l'hypothèse que nous soyons notifiés d'une infraction au droit d'auteur ou de licence, nous prendrons les mesures nécessaires pour voir la situation et déterminer si effectivement il y a eu "
+"infraction. Si nous déterminons que c'est le cas, nous retirerons le module concerné et contacterons l'auteur. Les futurs envois de modules (dont les mises à jour) contenant du code concerné ne "
+"pourront obtenir le statut de public."
 
 #: src/olympia/devhub/templates/devhub/docs/policies-maintenance.html:102
-msgid ""
-"If you are unsure of the current copyright status of an add-on's source "
-"code, you must contact the original author and receive explicit permission "
-"before using the source code."
-msgstr ""
-"Si vous n'êtes pas certain du statut du code source de votre module, vous "
-"devriez contacter l'auteur originel et recevoir une permission explicite "
-"avant d'utiliser le code source."
+msgid "If you are unsure of the current copyright status of an add-on's source code, you must contact the original author and receive explicit permission before using the source code."
+msgstr "Si vous n'êtes pas certain du statut du code source de votre module, vous devriez contacter l'auteur originel et recevoir une permission explicite avant d'utiliser le code source."
 
-#: src/olympia/devhub/templates/devhub/docs/policies-maintenance.html:107
-#: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:306
+#: src/olympia/devhub/templates/devhub/docs/policies-maintenance.html:107 src/olympia/devhub/templates/devhub/docs/policies-reviews.html:306
 #: src/olympia/devhub/templates/devhub/docs/policies-submission.html:97
 msgid "Last updated: January 13, 2011"
 msgstr "Dernière mise à jour : 13 janvier 2011"
@@ -6892,57 +5440,34 @@ msgstr "Dernière mise à jour : 13 janvier 2011"
 #: src/olympia/devhub/templates/devhub/docs/policies-recommended.html:13
 #, python-format
 msgid ""
-"Featured add-ons are top-quality extensions and themes highlighted on <a "
-"href=\"%(link_gallery)s\">AMO</a>, Firefox's Add-ons Manager, and across "
-"other Mozilla websites. These add-ons showcase the power of Firefox "
-"customization and are useful to a wide audience."
+"Featured add-ons are top-quality extensions and themes highlighted on <a href=\"%(link_gallery)s\">AMO</a>, Firefox's Add-ons Manager, and across other Mozilla websites. These add-ons showcase the "
+"power of Firefox customization and are useful to a wide audience."
 msgstr ""
-"Les modules en vedettes sont des extensions de haute qualité et des thèmes "
-"mis en valeur sur <a href=\"%(link_gallery)s\">AMO</a>, le gestionnaire de "
-"modules de Firefox, ainsi que sur d'autres sites web Mozilla. Ces modules "
-"montrent la puissance de personnalisation intrinsèque à Firefox et sont "
-"utiles pour une large part du public."
+"Les modules en vedettes sont des extensions de haute qualité et des thèmes mis en valeur sur <a href=\"%(link_gallery)s\">AMO</a>, le gestionnaire de modules de Firefox, ainsi que sur d'autres "
+"sites web Mozilla. Ces modules montrent la puissance de personnalisation intrinsèque à Firefox et sont utiles pour une large part du public."
 
 #: src/olympia/devhub/templates/devhub/docs/policies-recommended.html:19
-msgid ""
-"Featured add-ons are chosen by the Featured Add-ons Advisory Board, a small "
-"group of add-on developers and fans from the Mozilla community who have "
-"volunteered to review and vote on nominations."
+msgid "Featured add-ons are chosen by the Featured Add-ons Advisory Board, a small group of add-on developers and fans from the Mozilla community who have volunteered to review and vote on nominations."
 msgstr ""
-"Les modules vedettes sont sélectionnés par le conseil d'administration des "
-"modules vedettes, un petit groupe de développeurs de modules et de membres "
-"de la communauté Mozilla qui s'engagent volontairement à tester et voter "
-"pour ces nominations."
+"Les modules vedettes sont sélectionnés par le conseil d'administration des modules vedettes, un petit groupe de développeurs de modules et de membres de la communauté Mozilla qui s'engagent "
+"volontairement à tester et voter pour ces nominations."
 
 #: src/olympia/devhub/templates/devhub/docs/policies-recommended.html:25
 #, python-format
-msgid ""
-"<a href=\"%(link_featured)s\">Featured extensions</a> are chosen every "
-"month, and <a href=\"%(link_themes)s\">featured complete themes</a> are "
-"chosen every quarter."
-msgstr ""
-"Les <a href=\"%(link_featured)s\">extensions vedettes</a> sont sélectionnés "
-"tous les mois, et les <a href=\"%(link_themes)s\">thèmes complets "
-"vedettes</a> sont choisis tous les trimestres."
+msgid "<a href=\"%(link_featured)s\">Featured extensions</a> are chosen every month, and <a href=\"%(link_themes)s\">featured complete themes</a> are chosen every quarter."
+msgstr "Les <a href=\"%(link_featured)s\">extensions vedettes</a> sont sélectionnés tous les mois, et les <a href=\"%(link_themes)s\">thèmes complets vedettes</a> sont choisis tous les trimestres."
 
 #: src/olympia/devhub/templates/devhub/docs/policies-recommended.html:30
 msgid "Criteria for Featured Add-ons"
 msgstr "Critères pour les modules en vedette"
 
 #: src/olympia/devhub/templates/devhub/docs/policies-recommended.html:33
-msgid ""
-"Before nominating an add-on to be featured, please ensure it meets the "
-"following criteria:"
-msgstr ""
-"Avant de nominer un module pour être en vedette, assurez-vous qu'il soit "
-"conforme aux critères :"
+msgid "Before nominating an add-on to be featured, please ensure it meets the following criteria:"
+msgstr "Avant de nominer un module pour être en vedette, assurez-vous qu'il soit conforme aux critères :"
 
 #: src/olympia/devhub/templates/devhub/docs/policies-recommended.html:39
-msgid ""
-"The add-on must have a complete and informative listing on AMO. This means:"
-msgstr ""
-"Le module doit avoir une présentation complète et informative sur AMO. Cela "
-"implique :"
+msgid "The add-on must have a complete and informative listing on AMO. This means:"
+msgstr "Le module doit avoir une présentation complète et informative sur AMO. Cela implique :"
 
 #: src/olympia/devhub/templates/devhub/docs/policies-recommended.html:41
 msgid "a 64-pixel custom icon"
@@ -6958,52 +5483,35 @@ msgstr "un résumé clair et concis des fonctionnalités"
 
 #: src/olympia/devhub/templates/devhub/docs/policies-recommended.html:44
 msgid "detailed description and privacy policy, if applicable"
-msgstr ""
-"une description détaillée ainsi qu'une politique de confidentialité, si "
-"nécessaire"
+msgstr "une description détaillée ainsi qu'une politique de confidentialité, si nécessaire"
 
 #: src/olympia/devhub/templates/devhub/docs/policies-recommended.html:45
 msgid "updated screenshots of the add-on's functionality"
 msgstr "des captures d'écran à jour des fonctionnalités"
 
 #: src/olympia/devhub/templates/devhub/docs/policies-recommended.html:46
-msgid ""
-"must be fully approved by AMO editors (no preliminarily reviewed entries)"
+msgid "must be fully approved by AMO editors (no preliminarily reviewed entries)"
 msgstr "approbation finalisée par les éditeurs AMO"
 
 #: src/olympia/devhub/templates/devhub/docs/policies-recommended.html:48
-msgid ""
-"The add-on must have excellent user reviews and any problems or support "
-"requests must be promptly addressed by the developer."
-msgstr ""
-"Le module doit avoir d'excellentes critiques de la part des utilisateurs, et"
-" tout problème ou requête d'assistance doit être rapidement prise en charge "
-"par le développeur."
+msgid "The add-on must have excellent user reviews and any problems or support requests must be promptly addressed by the developer."
+msgstr "Le module doit avoir d'excellentes critiques de la part des utilisateurs, et tout problème ou requête d'assistance doit être rapidement prise en charge par le développeur."
 
 #: src/olympia/devhub/templates/devhub/docs/policies-recommended.html:49
 msgid "The add-on must have a minimum of 2,000 users."
 msgstr "Au moins 2000 personnes doivent utiliser le module."
 
 #: src/olympia/devhub/templates/devhub/docs/policies-recommended.html:50
-msgid ""
-"The add-on must be compatible with the latest release of Firefox and must be"
-" compatible with beta versions 4 weeks before their final release."
-msgstr ""
-"Le module doit être compatible avec la dernière version de Firefox et doit "
-"être compatible avec les versions bêta 4 semaines avant la version finale."
+msgid "The add-on must be compatible with the latest release of Firefox and must be compatible with beta versions 4 weeks before their final release."
+msgstr "Le module doit être compatible avec la dernière version de Firefox et doit être compatible avec les versions bêta 4 semaines avant la version finale."
 
 #: src/olympia/devhub/templates/devhub/docs/policies-recommended.html:51
 msgid ""
-"<strong>Most importantly</strong>, the add-on must have wide consumer appeal"
-" to Firefox's users and be outstanding in nearly every way: user experience,"
-" performance, security, and usefulness or entertainment value. Featured "
-"complete themes must also be visually appealing."
+"<strong>Most importantly</strong>, the add-on must have wide consumer appeal to Firefox's users and be outstanding in nearly every way: user experience, performance, security, and usefulness or "
+"entertainment value. Featured complete themes must also be visually appealing."
 msgstr ""
-"<strong>Plus important</strong>, le module doit avoir une large base "
-"d'utilisateurs Firefox et être quasi-parfait sur de nombreux points : "
-"expérience utilisateur, performances, sécurité, et service rendu ou valeur "
-"de divertissement. Les thèmes complets en vedette doivent également être "
-"particulièrement avenant visuellement."
+"<strong>Plus important</strong>, le module doit avoir une large base d'utilisateurs Firefox et être quasi-parfait sur de nombreux points : expérience utilisateur, performances, sécurité, et service"
+" rendu ou valeur de divertissement. Les thèmes complets en vedette doivent également être particulièrement avenant visuellement."
 
 #: src/olympia/devhub/templates/devhub/docs/policies-recommended.html:54
 msgid "Nominating an Add-on"
@@ -7015,271 +5523,165 @@ msgstr "amo-featured at mozilla dot org"
 
 #: src/olympia/devhub/templates/devhub/docs/policies-recommended.html:57
 #, python-format
-msgid ""
-"If you wish to nominate an add-on to be featured and it meets the criteria "
-"above, send an email to %(mail_featured)s with:"
-msgstr ""
-"Si vous voulez nominer un module pour qu'il soit mis en vedette et qu'il "
-"correspond aux critères précédents, envoyez un courriel à %(mail_featured)s "
-"avec :"
+msgid "If you wish to nominate an add-on to be featured and it meets the criteria above, send an email to %(mail_featured)s with:"
+msgstr "Si vous voulez nominer un module pour qu'il soit mis en vedette et qu'il correspond aux critères précédents, envoyez un courriel à %(mail_featured)s avec :"
 
 #: src/olympia/devhub/templates/devhub/docs/policies-recommended.html:62
 msgid "the add-on name, URL, and whether you are its developer"
 msgstr "le nom du module, son URL et si vous êtes son développeur"
 
 #: src/olympia/devhub/templates/devhub/docs/policies-recommended.html:63
-msgid ""
-"a short explanation of why the add-on has wide appeal and should be featured"
-msgstr ""
-"une courte explication pour dire pourquoi l'extension a un fort potentiel et"
-" devrait être mis en vedette"
+msgid "a short explanation of why the add-on has wide appeal and should be featured"
+msgstr "une courte explication pour dire pourquoi l'extension a un fort potentiel et devrait être mis en vedette"
 
 #: src/olympia/devhub/templates/devhub/docs/policies-recommended.html:64
-msgid ""
-"optionally, links to any external reviews or articles mentioning the add-on"
-msgstr ""
-"optionnellement, des liens vers des critiques ou des articles externes "
-"mentionnant le module"
+msgid "optionally, links to any external reviews or articles mentioning the add-on"
+msgstr "optionnellement, des liens vers des critiques ou des articles externes mentionnant le module"
 
 #: src/olympia/devhub/templates/devhub/docs/policies-recommended.html:68
 msgid ""
-"Add-on nominations are reviewed by the Advisory Board once a month (once "
-"every 3 months for complete theme nominations). Common reasons for rejection"
-" include lacking wide appeal to consumers, a suboptimal user experience, "
-"quality or security issues, incompatibility, and similarity to another "
-"featured add-on. Rejected add-ons cannot be re-nominated within 3 months."
+"Add-on nominations are reviewed by the Advisory Board once a month (once every 3 months for complete theme nominations). Common reasons for rejection include lacking wide appeal to consumers, a "
+"suboptimal user experience, quality or security issues, incompatibility, and similarity to another featured add-on. Rejected add-ons cannot be re-nominated within 3 months."
 msgstr ""
-"Les propositions de modules sont revues une fois par mois par le comité "
-"consultatif (une fois tous les 3 mois pour les propositions des thèmes "
-"complets). Les raisons provoquant généralement un rejet incluent un manque "
-"d'attrait envers les utilisateurs, une ergonomie approximative, des "
-"problèmes de qualité, de sécurité ou d'incompatibilité et une ressemblance "
-"trop forte avec un autre module mis en avant. Les modules qui sont refusés "
-"ne pourront être proposés pendant les 3 mois qui suivent."
+"Les propositions de modules sont revues une fois par mois par le comité consultatif (une fois tous les 3 mois pour les propositions des thèmes complets). Les raisons provoquant généralement un "
+"rejet incluent un manque d'attrait envers les utilisateurs, une ergonomie approximative, des problèmes de qualité, de sécurité ou d'incompatibilité et une ressemblance trop forte avec un autre "
+"module mis en avant. Les modules qui sont refusés ne pourront être proposés pendant les 3 mois qui suivent."
 
 #: src/olympia/devhub/templates/devhub/docs/policies-recommended.html:73
 msgid "Rotating Featured Add-ons"
 msgstr "Rotation des modules en vedette"
 
 #: src/olympia/devhub/templates/devhub/docs/policies-recommended.html:76
-msgid ""
-"Mozilla and the Featured Add-ons Advisory Board regularly evaluate and "
-"rotate out featured add-ons. Some of the most common reasons for add-ons "
-"being removed from the featured list are:"
+msgid "Mozilla and the Featured Add-ons Advisory Board regularly evaluate and rotate out featured add-ons. Some of the most common reasons for add-ons being removed from the featured list are:"
 msgstr ""
-"Mozilla et le Conseil Consultatif des Modules Vedettes évaluent "
-"régulièrement et effectuent une rotation des modules en vedette. Quelques-"
-"unes des raisons courantes pour qu'un module soit retiré de la liste sont :"
+"Mozilla et le Conseil Consultatif des Modules Vedettes évaluent régulièrement et effectuent une rotation des modules en vedette. Quelques-unes des raisons courantes pour qu'un module soit retiré de"
+" la liste sont :"
 
 #: src/olympia/devhub/templates/devhub/docs/policies-recommended.html:83
 msgid ""
-"Lack of growth &mdash; Add-ons that are featured typically experience a "
-"substantial gain in both downloads and active users. If an add-on is not "
-"demonstrating growth in any substantial way, that's a good indicator the "
-"add-on may not be very useful to our users."
+"Lack of growth &mdash; Add-ons that are featured typically experience a substantial gain in both downloads and active users. If an add-on is not demonstrating growth in any substantial way, that's "
+"a good indicator the add-on may not be very useful to our users."
 msgstr ""
-"Le manque de croissance &mdash; Les modules mis en vedettes voient en "
-"général leur utilisation croître de manière non négligeable tant en "
-"téléchargements qu'en utilisateurs actifs. Si un module ne montre pas ce "
-"comportement, c'est un bon signe qu'il n'est peut-être pas indispensable à "
-"la base des utilisateurs."
+"Le manque de croissance &mdash; Les modules mis en vedettes voient en général leur utilisation croître de manière non négligeable tant en téléchargements qu'en utilisateurs actifs. Si un module ne "
+"montre pas ce comportement, c'est un bon signe qu'il n'est peut-être pas indispensable à la base des utilisateurs."
 
 #: src/olympia/devhub/templates/devhub/docs/policies-recommended.html:88
-msgid ""
-"Negative reviews &mdash; Featured add-ons should have a great experience and"
-" very few bugs, so add-ons with many negative reviews may be reconsidered."
-msgstr ""
-"Critiques négatives &mdash; Les modules en vedette doivent fournir une bonne"
-" expérience et très peu de bugs, les modules avec beaucoup de critiques "
-"négatives pourront donc être écartés."
+msgid "Negative reviews &mdash; Featured add-ons should have a great experience and very few bugs, so add-ons with many negative reviews may be reconsidered."
+msgstr "Critiques négatives &mdash; Les modules en vedette doivent fournir une bonne expérience et très peu de bugs, les modules avec beaucoup de critiques négatives pourront donc être écartés."
 
 #: src/olympia/devhub/templates/devhub/docs/policies-recommended.html:93
 msgid ""
-"Incompatibility with upcoming Firefox versions &mdash; Featured add-ons are "
-"expected to be compatible with stable and beta versions of Firefox. Add-ons "
-"not yet compatible with a Beta version of Firefox four weeks before its "
-"expected release will lose their featured status."
+"Incompatibility with upcoming Firefox versions &mdash; Featured add-ons are expected to be compatible with stable and beta versions of Firefox. Add-ons not yet compatible with a Beta version of "
+"Firefox four weeks before its expected release will lose their featured status."
 msgstr ""
-"Incompatibilité avec les prochaines versions de Firefox &mdash; Les modules "
-"en vedettes doivent être compatibles avec les versions stable et bêta de "
-"Firefox. Les modules non encore compatibles quatre semaines avant la date de"
-" sortie attendue perdront leur statut de vedette."
+"Incompatibilité avec les prochaines versions de Firefox &mdash; Les modules en vedettes doivent être compatibles avec les versions stable et bêta de Firefox. Les modules non encore compatibles "
+"quatre semaines avant la date de sortie attendue perdront leur statut de vedette."
 
 #: src/olympia/devhub/templates/devhub/docs/policies-recommended.html:99
 msgid "Joining the Featured Add-ons Advisory Board"
 msgstr "Rejoindre le Conseil Consultatif des Modules Vedettes"
 
 #: src/olympia/devhub/templates/devhub/docs/policies-recommended.html:102
-msgid ""
-"Every six months a new Advisory Board is chosen based on applications from "
-"the add-ons community. Members must:"
-msgstr ""
-"Tous les six mois, un nouveau Conseil Consultatif est choisi parmi les "
-"postulants de la communauté. Les membres doivent :"
+msgid "Every six months a new Advisory Board is chosen based on applications from the add-ons community. Members must:"
+msgstr "Tous les six mois, un nouveau Conseil Consultatif est choisi parmi les postulants de la communauté. Les membres doivent :"
 
 #: src/olympia/devhub/templates/devhub/docs/policies-recommended.html:108
-msgid ""
-"be active members of the add-ons community, whether as a developer, "
-"evangelist, or fan"
-msgstr ""
-"être des membres actifs de la communauté des modules, que ce soit "
-"développeur, évangéliste ou fan"
+msgid "be active members of the add-ons community, whether as a developer, evangelist, or fan"
+msgstr "être des membres actifs de la communauté des modules, que ce soit développeur, évangéliste ou fan"
 
 #: src/olympia/devhub/templates/devhub/docs/policies-recommended.html:109
-msgid ""
-"commit to trying all the nominations submitted, giving their feedback, and "
-"casting their votes every month"
-msgstr ""
-"s'engager à essayer toutes les extensions proposées, donner leur retour et "
-"faire leurs votes tous les mois"
+msgid "commit to trying all the nominations submitted, giving their feedback, and casting their votes every month"
+msgstr "s'engager à essayer toutes les extensions proposées, donner leur retour et faire leurs votes tous les mois"
 
 #: src/olympia/devhub/templates/devhub/docs/policies-recommended.html:110
-msgid ""
-"abstain from voting on add-ons that they have any business or personal "
-"affiliations with, as well as direct competitors of any such add-ons"
-msgstr ""
-"s'abstenir de voter sur des modules qui entrent en conflit d'intérêt ou des "
-"concurrents directs de tels modules"
+msgid "abstain from voting on add-ons that they have any business or personal affiliations with, as well as direct competitors of any such add-ons"
+msgstr "s'abstenir de voter sur des modules qui entrent en conflit d'intérêt ou des concurrents directs de tels modules"
 
 #: src/olympia/devhub/templates/devhub/docs/policies-recommended.html:114
 msgid ""
-"Members of the Mozilla Add-ons team may veto any add-on's selection because "
-"of security, privacy, compatibility, or any other reason, but in general it "
-"is up to the Board to select add-ons to feature."
+"Members of the Mozilla Add-ons team may veto any add-on's selection because of security, privacy, compatibility, or any other reason, but in general it is up to the Board to select add-ons to "
+"feature."
 msgstr ""
-"Les membres de l'équipe Mozilla Add-ons peuvent poser leur veto sur la "
-"sélection de n'importe quel module pour des raisons de sécurité, vie privée,"
-" compatibilité, ou n'importe quelle autre raison, mais en général il revient"
-" au Conseil de choisir les modules à promouvoir."
+"Les membres de l'équipe Mozilla Add-ons peuvent poser leur veto sur la sélection de n'importe quel module pour des raisons de sécurité, vie privée, compatibilité, ou n'importe quelle autre raison, "
+"mais en général il revient au Conseil de choisir les modules à promouvoir."
 
 #: src/olympia/devhub/templates/devhub/docs/policies-recommended.html:120
 msgid ""
-"This featured policy only applies to the addons.mozilla.org global list of "
-"featured add-ons. Add-ons featured in other locations are often pulled from "
-"this list, but Mozilla may feature any add-on in other locations without the"
-" Board's consent. Additionally, locale-specific features override the global"
-" defaults, so if a locale has opted to select its own features, some or all "
-"of the global features may not appear in that locale."
+"This featured policy only applies to the addons.mozilla.org global list of featured add-ons. Add-ons featured in other locations are often pulled from this list, but Mozilla may feature any add-on "
+"in other locations without the Board's consent. Additionally, locale-specific features override the global defaults, so if a locale has opted to select its own features, some or all of the global "
+"features may not appear in that locale."
 msgstr ""
-"Cette politique ce mise en vedette s'applique uniquement à la liste globale "
-"de modules en vedettes du site addons.mozilla.org. Les modules mis en valeur"
-" dans d'autres endroits sont souvent tirés de cette liste, mais Mozilla se "
-"réserve le droit de choisir n'importe quel module dans d'autres zones sans "
-"le consentement du Conseil. De plus, les spécificités locales sont "
-"prioritaires sur les choix mondiaux, donc si une langue ou une communauté a "
-"choisit ses propres vedettes, tout ou partie de la sélection mondiale peut "
-"ne pas apparaître dans ce cas."
+"Cette politique ce mise en vedette s'applique uniquement à la liste globale de modules en vedettes du site addons.mozilla.org. Les modules mis en valeur dans d'autres endroits sont souvent tirés de"
+" cette liste, mais Mozilla se réserve le droit de choisir n'importe quel module dans d'autres zones sans le consentement du Conseil. De plus, les spécificités locales sont prioritaires sur les "
+"choix mondiaux, donc si une langue ou une communauté a choisit ses propres vedettes, tout ou partie de la sélection mondiale peut ne pas apparaître dans ce cas."
 
 #: src/olympia/devhub/templates/devhub/docs/policies-recommended.html:126
 #, python-format
-msgid ""
-"Follow the <a href=\"%(link_blog)s\">Add-ons Blog</a> or <a "
-"href=\"%(link_twitter)s\">@mozamo</a> on Twitter to learn when the next "
-"application period opens."
-msgstr ""
-"Suivez le <a href=\"%(link_blog)s\">Blog Add-ons</a> ou <a "
-"href=\"%(link_twitter)s\">@mozamo</a> sur Twitter pour savoir quand "
-"s'ouvrent les recrutements."
+msgid "Follow the <a href=\"%(link_blog)s\">Add-ons Blog</a> or <a href=\"%(link_twitter)s\">@mozamo</a> on Twitter to learn when the next application period opens."
+msgstr "Suivez le <a href=\"%(link_blog)s\">Blog Add-ons</a> ou <a href=\"%(link_twitter)s\">@mozamo</a> sur Twitter pour savoir quand s'ouvrent les recrutements."
 
 #: src/olympia/devhub/templates/devhub/docs/policies-recommended.html:131
 msgid "Last updated: January 31, 2013"
 msgstr "Dernière mise à jour : 31 janvier 2013"
 
-#: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:3
-#: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:7
-#: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:8
-#: src/olympia/devhub/templates/devhub/docs/policies.html:15
-#: src/olympia/devhub/templates/devhub/docs/policies.html:64
+#: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:3 src/olympia/devhub/templates/devhub/docs/policies-reviews.html:7 src/olympia/devhub/templates/devhub/docs/policies-reviews.html:8
+#: src/olympia/devhub/templates/devhub/docs/policies.html:15 src/olympia/devhub/templates/devhub/docs/policies.html:64
 msgid "Review Process"
 msgstr "Processus de revue"
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:12
 msgid ""
-"In order to ensure all add-ons hosted in our gallery are safe for users to "
-"install, Mozilla will begin requiring all hosted add-ons to undergo review. "
-"We offer two types of review and developers are free to choose the best fit "
-"for their add-on."
+"In order to ensure all add-ons hosted in our gallery are safe for users to install, Mozilla will begin requiring all hosted add-ons to undergo review. We offer two types of review and developers "
+"are free to choose the best fit for their add-on."
 msgstr ""
-"Pour s'assurer que tous les modules hébergés sur notre galerie sont sûrs, "
-"Mozilla va commencer à faire une revue de tous les modules hébergés. Nous "
-"offrons deux types de revues et les développeurs sont libres de choisir "
-"celle qui leur convient le plus."
+"Pour s'assurer que tous les modules hébergés sur notre galerie sont sûrs, Mozilla va commencer à faire une revue de tous les modules hébergés. Nous offrons deux types de revues et les développeurs "
+"sont libres de choisir celle qui leur convient le plus."
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:19
 msgid ""
-"<strong><a href=\"#full\">Full Review</a></strong> &mdash; a thorough "
-"functional and code review of the add-on, appropriate for add-ons ready for "
-"distribution to the masses. All site features are available to these add-"
-"ons."
+"<strong><a href=\"#full\">Full Review</a></strong> &mdash; a thorough functional and code review of the add-on, appropriate for add-ons ready for distribution to the masses. All site features are "
+"available to these add-ons."
 msgstr ""
-"<strong><a href=\"#full\">Revue complète</a></strong> &mdash; une revue "
-"fonctionnel et du code complète du module, approprié pour les modules prêts "
-"à être distribués au grand public. Toutes les fonctionnalités du site sont "
-"accessibles pour ces modules."
+"<strong><a href=\"#full\">Revue complète</a></strong> &mdash; une revue fonctionnel et du code complète du module, approprié pour les modules prêts à être distribués au grand public. Toutes les "
+"fonctionnalités du site sont accessibles pour ces modules."
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:24
 msgid ""
-"<strong><a href=\"#preliminary\">Preliminary Review</a></strong> &mdash; a "
-"faster review intended for experimental add-ons. Preliminary reviews do not "
-"check for functionality or full policy compliance, but the reviewed add-ons "
-"have install button cautions and some feature limitations."
+"<strong><a href=\"#preliminary\">Preliminary Review</a></strong> &mdash; a faster review intended for experimental add-ons. Preliminary reviews do not check for functionality or full policy "
+"compliance, but the reviewed add-ons have install button cautions and some feature limitations."
 msgstr ""
-"<strong><a href=\"#preliminary\">Revue préliminaire</a></strong> &mdash; une"
-" revue plus rapide pour les modules expérimentaux. Les revues préliminaires "
-"ne vérifient pas les fonctionnalités ou la conformité à l'intégralité de la "
-"politique, mais les modules concernés ont un avertissement sur le bouton "
-"d'installation ainsi que quelques limitations en fonctionnalités."
+"<strong><a href=\"#preliminary\">Revue préliminaire</a></strong> &mdash; une revue plus rapide pour les modules expérimentaux. Les revues préliminaires ne vérifient pas les fonctionnalités ou la "
+"conformité à l'intégralité de la politique, mais les modules concernés ont un avertissement sur le bouton d'installation ainsi que quelques limitations en fonctionnalités."
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:31
 msgid ""
-"Detailed descriptions of each option are below. After selecting a review "
-"process at submission, the add-on will be placed in the queue. Add-ons are "
-"reviewed by the <a href=\"https://wiki.mozilla.org/AMO:Editors\">AMO "
-"Editors</a>, a group of talented developers that volunteer to help the "
-"Mozilla project by reviewing add-ons to ensure a stable and safe experience "
-"for users. Developers will receive an email with any updates throughout the "
-"review process."
+"Detailed descriptions of each option are below. After selecting a review process at submission, the add-on will be placed in the queue. Add-ons are reviewed by the <a "
+"href=\"https://wiki.mozilla.org/AMO:Editors\">AMO Editors</a>, a group of talented developers that volunteer to help the Mozilla project by reviewing add-ons to ensure a stable and safe experience "
+"for users. Developers will receive an email with any updates throughout the review process."
 msgstr ""
-"Des descriptions détaillées de chacune des options sont ci-dessous. Les "
-"modules sont testés par les <a "
-"href=\"https://wiki.mozilla.org/AMO:Editors\">Éditeurs AMO</a>, un groupe de"
-" développeurs talentueux qui se portent volontaires pour aider le projet "
-"Mozilla en testant les modules pour s'assurer qu'ils soient sûrs et stables."
-" Les développeurs recevront un courriel qui les informe des avancées à "
-"chaque étape du processus de revue."
+"Des descriptions détaillées de chacune des options sont ci-dessous. Les modules sont testés par les <a href=\"https://wiki.mozilla.org/AMO:Editors\">Éditeurs AMO</a>, un groupe de développeurs "
+"talentueux qui se portent volontaires pour aider le projet Mozilla en testant les modules pour s'assurer qu'ils soient sûrs et stables. Les développeurs recevront un courriel qui les informe des "
+"avancées à chaque étape du processus de revue."
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:37
 msgid ""
-"While waiting for review, add-ons will not appear anywhere in the gallery "
-"publicly, but direct links to the add-on's details page will work. This "
-"allows the author to blog or share the link with friends, inviting them to "
-"try it out, even when not yet reviewed."
+"While waiting for review, add-ons will not appear anywhere in the gallery publicly, but direct links to the add-on's details page will work. This allows the author to blog or share the link with "
+"friends, inviting them to try it out, even when not yet reviewed."
 msgstr ""
-"En attendant la revue, les modules n'apparaitront nul part dans la galerie "
-"publiquement, mais des liens directs vers la page de détails du module "
-"fonctionneront. Ceci permet à l'auteur de partager le lien avec ses amis, "
-"pour les inviter à tester, avant qu'il ne soit vérifié."
+"En attendant la revue, les modules n'apparaitront nul part dans la galerie publiquement, mais des liens directs vers la page de détails du module fonctionneront. Ceci permet à l'auteur de partager "
+"le lien avec ses amis, pour les inviter à tester, avant qu'il ne soit vérifié."
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:44
 msgid ""
-"Full reviews are appropriate for add-ons that are well-tested, stable, fast,"
-" and have wide appeal to our users. If you aren't confident that your add-on"
-" meets that criteria, please consider working out the kinks while in "
-"preliminary review and accumulating user feedback first."
+"Full reviews are appropriate for add-ons that are well-tested, stable, fast, and have wide appeal to our users. If you aren't confident that your add-on meets that criteria, please consider working"
+" out the kinks while in preliminary review and accumulating user feedback first."
 msgstr ""
-"Les revues complètes sont appropriées pour des modules qui sont bien testés,"
-" stables, rapides, et présentent un intérêt certain pour nos utilisateurs. "
-"Si vous n'êtes pas sûr que votre module corresponde à ces critères, merci de"
-" démêler la situation avec une revue préliminaire et d'accumuler des retours"
-" utilisateurs en premier lieu."
+"Les revues complètes sont appropriées pour des modules qui sont bien testés, stables, rapides, et présentent un intérêt certain pour nos utilisateurs. Si vous n'êtes pas sûr que votre module "
+"corresponde à ces critères, merci de démêler la situation avec une revue préliminaire et d'accumuler des retours utilisateurs en premier lieu."
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:50
-msgid ""
-"We aim to perform full reviews in under 10 days, though most add-ons are "
-"reviewed in much less time."
-msgstr ""
-"Nous avons pour objectif de faire des revues complètes en moins de 10 jours,"
-" même si la majorité des modules vérifiés le sont en moins de temps."
+msgid "We aim to perform full reviews in under 10 days, though most add-ons are reviewed in much less time."
+msgstr "Nous avons pour objectif de faire des revues complètes en moins de 10 jours, même si la majorité des modules vérifiés le sont en moins de temps."
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:55
 msgid "Testing Methods &amp; Common Issues"
@@ -7290,60 +5692,36 @@ msgid "When performing a full review, editors will:"
 msgstr "Lors d'une revue complète, les éditeurs vont :"
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:64
-msgid ""
-"install the add-on, making sure it functions as described and is free of "
-"major defects"
-msgstr ""
-"installer le module, s'assurer qu'il fonctionne comme décrit et qu'il n'a "
-"pas de défaut majeur"
+msgid "install the add-on, making sure it functions as described and is free of major defects"
+msgstr "installer le module, s'assurer qu'il fonctionne comme décrit et qu'il n'a pas de défaut majeur"
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:69
-msgid ""
-"perform a source code review, looking for performance and security best "
-"practices"
-msgstr ""
-"faire une revue du code source, regarder les bonnes pratiques de performance"
-" et de sécurité"
+msgid "perform a source code review, looking for performance and security best practices"
+msgstr "faire une revue du code source, regarder les bonnes pratiques de performance et de sécurité"
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:74
 msgid "ensure the add-on's privacy policy is in line with its functionality"
-msgstr ""
-"s'assurer que la politique de vie privée est en accord avec ses "
-"fonctionnalités"
+msgstr "s'assurer que la politique de vie privée est en accord avec ses fonctionnalités"
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:79
-msgid ""
-"look for compliance with all of Mozilla's policies, detailed in these "
-"documents"
-msgstr ""
-"vérifier la conformité à la totalité des politiques de Mozilla, détaillées "
-"dans ces documents"
+msgid "look for compliance with all of Mozilla's policies, detailed in these documents"
+msgstr "vérifier la conformité à la totalité des politiques de Mozilla, détaillées dans ces documents"
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:86
-msgid ""
-"Some of the most common issues we see when performing these reviews are:"
-msgstr ""
-"Quelques-uns des problèmes les plus courants lors de ces revues sont :"
+msgid "Some of the most common issues we see when performing these reviews are:"
+msgstr "Quelques-uns des problèmes les plus courants lors de ces revues sont :"
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:93
 msgid ""
-"<strong>JavaScript namespace pollution</strong> &mdash; the most common "
-"violation. Be sure to <a "
-"href=\"https://developer.mozilla.org/en/XUL_School/JavaScript_Object_Management\">wrap"
-" your loose variables</a>"
+"<strong>JavaScript namespace pollution</strong> &mdash; the most common violation. Be sure to <a href=\"https://developer.mozilla.org/en/XUL_School/JavaScript_Object_Management\">wrap your loose "
+"variables</a>"
 msgstr ""
-"<strong>Pollution de l'espace de nommage JavaScript</strong> &mdash; la "
-"violation la plus courante. Assurez-vous de <a "
-"href=\"https://developer.mozilla.org/en/XUL_School/JavaScript_Object_Management\">protéger"
-" vos variables lâches</a>"
+"<strong>Pollution de l'espace de nommage JavaScript</strong> &mdash; la violation la plus courante. Assurez-vous de <a "
+"href=\"https://developer.mozilla.org/en/XUL_School/JavaScript_Object_Management\">protéger vos variables lâches</a>"
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:99
-msgid ""
-"proper preference naming - all preference names should begin with "
-"\"extensions.\", followed by the add-on name or some other unique identifier"
-msgstr ""
-"nommage correct des préférences - toutes les préférences devraient commencer"
-" par « extensions. », suivi du nom du module ou autre identifiant unique"
+msgid "proper preference naming - all preference names should begin with \"extensions.\", followed by the add-on name or some other unique identifier"
+msgstr "nommage correct des préférences - toutes les préférences devraient commencer par « extensions. », suivi du nom du module ou autre identifiant unique"
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:103
 msgid "remote JavaScript execution or injection"
@@ -7383,107 +5761,70 @@ msgstr "conflits potentiels avec d'autres modules"
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:113
 msgid "application start-up or page load performance degradation"
-msgstr ""
-"dégradation des performances de chargement des pages ou du démarrage de "
-"l'application"
+msgstr "dégradation des performances de chargement des pages ou du démarrage de l'application"
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:117
 #, python-format
 msgid ""
-"For information on how to avoid these problems, please see our <a "
-"href=\"%(link_howto)s\">How-to Library</a>. Some of these practices, such as"
-" binary or obfuscated code, are allowed under certain conditions outlined "
-"below."
+"For information on how to avoid these problems, please see our <a href=\"%(link_howto)s\">How-to Library</a>. Some of these practices, such as binary or obfuscated code, are allowed under certain "
+"conditions outlined below."
 msgstr ""
-"Pour plus d'informations sur la manière d'éviter ces problèmes, consultez "
-"notre <a href=\"%(link_howto)s\">bibliothèque d'aide</a>. Certaines de ces "
-"pratiques, telles que les binaires ou le code obfusqué, sont autorisées sous"
-" certaines conditions détaillées ci-dessous."
+"Pour plus d'informations sur la manière d'éviter ces problèmes, consultez notre <a href=\"%(link_howto)s\">bibliothèque d'aide</a>. Certaines de ces pratiques, telles que les binaires ou le code "
+"obfusqué, sont autorisées sous certaines conditions détaillées ci-dessous."
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:123
 #, python-format
 msgid ""
-"Many of the above restrictions are tested automatically by an extension "
-"scanner that will flag suspicious add-ons for editor review. You can read "
-"more about this scanner in the <a href=\"%(link_validation)s\">Validation "
-"Help</a> document."
+"Many of the above restrictions are tested automatically by an extension scanner that will flag suspicious add-ons for editor review. You can read more about this scanner in the <a "
+"href=\"%(link_validation)s\">Validation Help</a> document."
 msgstr ""
-"Beaucoup des restrictions ci-dessus sont testées automatiquement par un "
-"scanner d'extension qui va notifier les modules suspects pour une revue par "
-"un éditeur. Vous pouvez en apprendre plus sur ce scanner dans le document <a"
-" href=\"%(link_validation)s\">aide à la validation</a>."
+"Beaucoup des restrictions ci-dessus sont testées automatiquement par un scanner d'extension qui va notifier les modules suspects pour une revue par un éditeur. Vous pouvez en apprendre plus sur ce "
+"scanner dans le document <a href=\"%(link_validation)s\">aide à la validation</a>."
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:129
 msgid ""
-"If the add-on is site-specific, it is recommended that a test account is "
-"provided for use during the review process. Additionally, including detailed"
-" testing instructions will allow an editor to better understand how the add-"
-"on functions and expedite the testing process. This information can be "
-"placed in the Notes to Reviewer field when editing a version in the "
-"Developer Hub."
+"If the add-on is site-specific, it is recommended that a test account is provided for use during the review process. Additionally, including detailed testing instructions will allow an editor to "
+"better understand how the add-on functions and expedite the testing process. This information can be placed in the Notes to Reviewer field when editing a version in the Developer Hub."
 msgstr ""
-"Si le module est spécifique à un site, il est recommandé qu'un compte de "
-"test soit fourni pour l'utiliser pendant le processus de revue. De plus, "
-"l'inclusion d'instructions de test détaillée permettra à l'éditeur de mieux "
-"comprendre comment le module fonctionne et tester plus rapidement. Cette "
-"information peut être placée dans le champ Notes au testeur lors de "
-"l'édition d'une version dans le Hub développeur."
+"Si le module est spécifique à un site, il est recommandé qu'un compte de test soit fourni pour l'utiliser pendant le processus de revue. De plus, l'inclusion d'instructions de test détaillée "
+"permettra à l'éditeur de mieux comprendre comment le module fonctionne et tester plus rapidement. Cette information peut être placée dans le champ Notes au testeur lors de l'édition d'une version "
+"dans le Hub développeur."
 
-#: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:134
-#: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:168
+#: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:134 src/olympia/devhub/templates/devhub/docs/policies-reviews.html:168
 msgid "After the Review"
 msgstr "Après la revue"
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:136
 msgid ""
-"Once an add-on is granted full review, it will immediately be available in "
-"the gallery, showing in browse and search results with a warning-free "
-"install button. All features, including voluntary contributions and beta "
-"channels will be available."
+"Once an add-on is granted full review, it will immediately be available in the gallery, showing in browse and search results with a warning-free install button. All features, including voluntary "
+"contributions and beta channels will be available."
 msgstr ""
-"Une fois qu'un module a passé la revue complète, il sera immédiatement "
-"disponible dans la galerie, affiché dans les résultats de recherche avec un "
-"bouton d'installation sans avertissement. Toutes les fonctionnalités, dont "
-"les contributions volontaires et les canaux beta seront disponibles."
+"Une fois qu'un module a passé la revue complète, il sera immédiatement disponible dans la galerie, affiché dans les résultats de recherche avec un bouton d'installation sans avertissement. Toutes "
+"les fonctionnalités, dont les contributions volontaires et les canaux beta seront disponibles."
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:142
 msgid ""
-"Subsequent versions of the add-on will automatically be placed in the full "
-"review queue. Until the review is completed, the new version will only be "
-"displayed on the Version History page of the add-on. Once reviewed, the "
-"version will be updated across the site and deployed through the automatic "
-"update service."
+"Subsequent versions of the add-on will automatically be placed in the full review queue. Until the review is completed, the new version will only be displayed on the Version History page of the "
+"add-on. Once reviewed, the version will be updated across the site and deployed through the automatic update service."
 msgstr ""
-"Les versions suivantes du module seront automatiquement placées dans la file"
-" d'attente de revue complète. Jusqu'à ce que celle-ci soit réalisée, la "
-"nouvelle version ne sera uniquement accessible qu'à partir de l'historique "
-"de version sur la page du module. Une fois vérifié, la version sera mise à "
-"jour dans le site et déployée via le système de mises à jour."
+"Les versions suivantes du module seront automatiquement placées dans la file d'attente de revue complète. Jusqu'à ce que celle-ci soit réalisée, la nouvelle version ne sera uniquement accessible "
+"qu'à partir de l'historique de version sur la page du module. Une fois vérifié, la version sera mise à jour dans le site et déployée via le système de mises à jour."
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:148
 msgid ""
-"If a version does not meet the criteria for full review, it can either be "
-"granted preliminary review or disabled if there is a security concern. The "
-"author will receive an email explaining the action taken and how to fix it. "
-"In most cases, the developer can simply fix the problem and re-submit for "
-"full review."
+"If a version does not meet the criteria for full review, it can either be granted preliminary review or disabled if there is a security concern. The author will receive an email explaining the "
+"action taken and how to fix it. In most cases, the developer can simply fix the problem and re-submit for full review."
 msgstr ""
-"Si une version ne correspond pas aux critères de revue complète, elle peut "
-"être promue en revue préliminaire ou désactivée s'il y a un problème de "
-"sécurité. L'auteur recevra un courriel expliquant l'action prise et comment "
-"corriger. Dans la plupart des cas, le développeur peut simplement corriger "
-"le problème et ré-envoyer pour revue complète."
+"Si une version ne correspond pas aux critères de revue complète, elle peut être promue en revue préliminaire ou désactivée s'il y a un problème de sécurité. L'auteur recevra un courriel expliquant "
+"l'action prise et comment corriger. Dans la plupart des cas, le développeur peut simplement corriger le problème et ré-envoyer pour revue complète."
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:155
 msgid ""
-"Preliminary reviews are appropriate for experimental add-ons and provide a "
-"way to get user testing and feedback without going through the longer, more "
-"thorough review process. We aim to complete these reviews in under 3 days."
+"Preliminary reviews are appropriate for experimental add-ons and provide a way to get user testing and feedback without going through the longer, more thorough review process. We aim to complete "
+"these reviews in under 3 days."
 msgstr ""
-"Les revues préliminaires sont appropriées pour les modules expérimentaux et "
-"fournissent une manière d'avoir des tests utilisateurs et des retours sans "
-"avoir à suivre le processus de revue plus long et plus profond. Nous visons "
-"un objectif de faire ces revues en moins de trois jours."
+"Les revues préliminaires sont appropriées pour les modules expérimentaux et fournissent une manière d'avoir des tests utilisateurs et des retours sans avoir à suivre le processus de revue plus long"
+" et plus profond. Nous visons un objectif de faire ces revues en moins de trois jours."
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:160
 msgid "Testing Methods"
@@ -7491,58 +5832,33 @@ msgstr "Méthodes de tests"
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:162
 msgid ""
-"When performing a preliminary review, editors will review the source code "
-"for security issues and major policy violations, but will not install the "
-"add-on to test functionality in most cases. Preliminary review will be "
-"granted unless a security vulnerability or major policy violation is "
-"discovered."
+"When performing a preliminary review, editors will review the source code for security issues and major policy violations, but will not install the add-on to test functionality in most cases. "
+"Preliminary review will be granted unless a security vulnerability or major policy violation is discovered."
 msgstr ""
-"Quand une revue préliminaire est effectuée, les éditeurs vont vérifier le "
-"code source pour des problèmes de sécurité et des violations graves de la "
-"politique, mais n'installeront pas le module pour en tester les "
-"fonctionnalités dans la plupart des cas. Les revues préliminaires seront "
-"accordées sauf si une vulnérabilité de sécurité ou une violation grave de la"
-" politique est découverte."
+"Quand une revue préliminaire est effectuée, les éditeurs vont vérifier le code source pour des problèmes de sécurité et des violations graves de la politique, mais n'installeront pas le module pour"
+" en tester les fonctionnalités dans la plupart des cas. Les revues préliminaires seront accordées sauf si une vulnérabilité de sécurité ou une violation grave de la politique est découverte."
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:171
 msgid ""
-"Once preliminary review is granted, the add-on will be immediately available"
-" in the gallery, showing in browse and search results but ranked lower than "
-"fully-reviewed add-ons. Install buttons will have caution stripes and a "
-"notice that the add-on is experimental and not fully reviewed by Mozilla, "
-"though no click-through is required. Additionally, these add-ons cannot use "
-"the voluntary contributions and beta channel features."
+"Once preliminary review is granted, the add-on will be immediately available in the gallery, showing in browse and search results but ranked lower than fully-reviewed add-ons. Install buttons will "
+"have caution stripes and a notice that the add-on is experimental and not fully reviewed by Mozilla, though no click-through is required. Additionally, these add-ons cannot use the voluntary "
+"contributions and beta channel features."
 msgstr ""
-"Une fois la revue préliminaire accordée, le module sera immédiatement "
-"disponible dans la galerie, affiché dans les pages de parcours et de "
-"résultats de recherche, mais rangé plus bas que les modules complètement "
-"vérifiés. Les boutons d'installation auront un avertissement pour signaler "
-"que le module est expérimental et non complètement vérifié par Mozilla, "
-"cependant, aucun clic supplémentaire ne sera nécessaire. De plus, ces "
-"modules ne peuvent utiliser les contributions volontaires et les "
-"fonctionnalités du canal bêta."
+"Une fois la revue préliminaire accordée, le module sera immédiatement disponible dans la galerie, affiché dans les pages de parcours et de résultats de recherche, mais rangé plus bas que les "
+"modules complètement vérifiés. Les boutons d'installation auront un avertissement pour signaler que le module est expérimental et non complètement vérifié par Mozilla, cependant, aucun clic "
+"supplémentaire ne sera nécessaire. De plus, ces modules ne peuvent utiliser les contributions volontaires et les fonctionnalités du canal bêta."
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:177
-msgid ""
-"After being granted preliminary review, Mozilla may later revoke the review "
-"if other serious problems are reported to us by users."
-msgstr ""
-"Après avoir accordé la revue préliminaire, Mozilla peut la révoquer plus "
-"tard si des problèmes graves sont rapportés par des utilisateurs."
+msgid "After being granted preliminary review, Mozilla may later revoke the review if other serious problems are reported to us by users."
+msgstr "Après avoir accordé la revue préliminaire, Mozilla peut la révoquer plus tard si des problèmes graves sont rapportés par des utilisateurs."
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:183
 msgid ""
-"Subsequent versions of the add-on will automatically be placed in the "
-"preliminary review queue. Until the review is completed, the new version "
-"will only be displayed on the Version History page of the add-on. Once "
-"reviewed, the version will be updated across the site and deployed through "
-"the automatic update service."
+"Subsequent versions of the add-on will automatically be placed in the preliminary review queue. Until the review is completed, the new version will only be displayed on the Version History page of "
+"the add-on. Once reviewed, the version will be updated across the site and deployed through the automatic update service."
 msgstr ""
-"Les versions suivantes du module seront automatiquement placées dans la file"
-" d'attente de revue préliminaire. Jusqu'à ce que celle-ci soit réalisée, la"
-" nouvelle version ne sera uniquement accessible qu'à partir de l'historique"
-" de version sur la page du module. Une fois vérifiée, la version sera mise "
-"à jour dans le site et déployée via le système de mises à jour."
+"Les versions suivantes du module seront automatiquement placées dans la file d'attente de revue préliminaire. Jusqu'à ce que celle-ci soit réalisée, la nouvelle version ne sera uniquement "
+"accessible qu'à partir de l'historique de version sur la page du module. Une fois vérifiée, la version sera mise à jour dans le site et déployée via le système de mises à jour."
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:188
 msgid "Policies on Specific Add-on Practices"
@@ -7554,75 +5870,45 @@ msgstr "Modules interdits"
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:190
 msgid "The following add-ons are not permitted in any form:"
-msgstr ""
-"Les modules suivants ne sont autorisés sous quelque forme que ce soit :"
+msgstr "Les modules suivants ne sont autorisés sous quelque forme que ce soit :"
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:194
-msgid ""
-"Add-ons that embed known <a "
-"href=\"http://en.wikipedia.org/wiki/Spyware\">spyware</a> or <a "
-"href=\"http://en.wikipedia.org/wiki/Malware\">malware</a>"
+msgid "Add-ons that embed known <a href=\"http://en.wikipedia.org/wiki/Spyware\">spyware</a> or <a href=\"http://en.wikipedia.org/wiki/Malware\">malware</a>"
 msgstr ""
-"Modules qui embarquent des <a "
-"href=\"http://fr.wikipedia.org/wiki/Logiciel_espion\">logiciels espions</a> "
-"connus ou <a "
-"href=\"http://fr.wikipedia.org/wiki/Logiciel_malveillant\">logiciels "
+"Modules qui embarquent des <a href=\"http://fr.wikipedia.org/wiki/Logiciel_espion\">logiciels espions</a> connus ou <a href=\"http://fr.wikipedia.org/wiki/Logiciel_malveillant\">logiciels "
 "malveillants</a>"
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:199
 msgid ""
-"Illegal and criminal add-ons, such as <a "
-"href=\"http://en.wikipedia.org/wiki/Click_fraud\">click fraud</a> "
-"generators, <a href=\"http://en.wikipedia.org/wiki/Warez\">warez</a> "
-"download and directory assistants, child pornography finders, etc."
+"Illegal and criminal add-ons, such as <a href=\"http://en.wikipedia.org/wiki/Click_fraud\">click fraud</a> generators, <a href=\"http://en.wikipedia.org/wiki/Warez\">warez</a> download and "
+"directory assistants, child pornography finders, etc."
 msgstr ""
-"Les modules illégaux et criminels, tels les générateurs de <a "
-"href=\"http://fr.wikipedia.org/wiki/Fraude_au_clic\">fraude au clic</a>, "
-"assistants pour trouver et télécharger du <a "
-"href=\"http://fr.wikipedia.org/wiki/Warez\">warez</a>, outils pour trouver "
-"de la pédopornographie, etc."
+"Les modules illégaux et criminels, tels les générateurs de <a href=\"http://fr.wikipedia.org/wiki/Fraude_au_clic\">fraude au clic</a>, assistants pour trouver et télécharger du <a "
+"href=\"http://fr.wikipedia.org/wiki/Warez\">warez</a>, outils pour trouver de la pédopornographie, etc."
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:204
-msgid ""
-"Add-ons whose main purpose is to facilitate access to pornographic material,"
-" or include references to this material in their descriptions"
-msgstr ""
-"Les modules dont le but principal est de faciliter l'accès à de la "
-"pornographie ou qui en incluent des références dans leur description"
+msgid "Add-ons whose main purpose is to facilitate access to pornographic material, or include references to this material in their descriptions"
+msgstr "Les modules dont le but principal est de faciliter l'accès à de la pornographie ou qui en incluent des références dans leur description"
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:210
-msgid ""
-"Add-ons that, upon installation, auto-install or launch installers of non-"
-"Firefox software"
-msgstr ""
-"Les modules qui, à l'installation, installent automatiquement ou lancent des"
-" installeurs pour des logiciels non Firefox"
+msgid "Add-ons that, upon installation, auto-install or launch installers of non-Firefox software"
+msgstr "Les modules qui, à l'installation, installent automatiquement ou lancent des installeurs pour des logiciels non Firefox"
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:215
-msgid ""
-"Add-ons that provide their own update mechanism for code or search engines"
-msgstr ""
-"Les modules qui fournissent leur propre mécanisme de mise à jour pour le "
-"code ou les moteurs de recherche"
+msgid "Add-ons that provide their own update mechanism for code or search engines"
+msgstr "Les modules qui fournissent leur propre mécanisme de mise à jour pour le code ou les moteurs de recherche"
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:220
-msgid ""
-"Add-ons that make changes to web content in ways that are non-obvious or "
-"difficult to trace by their users"
-msgstr ""
-"Les modules qui font des changements au contenu web de manière non évidente "
-"ou difficile à tracer par les utilisateurs"
+msgid "Add-ons that make changes to web content in ways that are non-obvious or difficult to trace by their users"
+msgstr "Les modules qui font des changements au contenu web de manière non évidente ou difficile à tracer par les utilisateurs"
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:225
 msgid "Add-ons that snoop on or intercept the network traffic of other users"
-msgstr ""
-"Les modules qui écoutent ou interceptent le trafic réseau d'autres "
-"utilisateurs"
+msgstr "Les modules qui écoutent ou interceptent le trafic réseau d'autres utilisateurs"
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:230
 msgid "Conduit-based toolbars without explicit pre-approval"
-msgstr ""
-"Les barres d'outils basées sur Conduit sans approbation préalable explicite"
+msgstr "Les barres d'outils basées sur Conduit sans approbation préalable explicite"
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:236
 msgid "Changing of Defaults and Unexpected Features"
@@ -7630,70 +5916,35 @@ msgstr "Changements de paramètres par défaut et fonctionnalités inattendues"
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:238
 msgid ""
-"Surprises can be appropriate in many situations, but they are not welcome "
-"when user security, privacy, and control are at stake. It is extremely "
-"important to be as transparent as possible when submitting an add-on for "
-"hosting on this site. A Mozilla user should be able to easily discern what "
-"the functionality of an add-on is and not be presented with unexpected "
-"experiences post-install."
+"Surprises can be appropriate in many situations, but they are not welcome when user security, privacy, and control are at stake. It is extremely important to be as transparent as possible when "
+"submitting an add-on for hosting on this site. A Mozilla user should be able to easily discern what the functionality of an add-on is and not be presented with unexpected experiences post-install."
 msgstr ""
-"Les surprises peuvent être appropriées dans beaucoup de situations, mais "
-"elles ne le sont pas quand la sécurité, la vie privée et le contrôle des "
-"utilisateurs sont en jeu. Il est extrêmement important d'être aussi "
-"transparent que possible lors de l'envoi d'un module pour l'héberger sur ce "
-"site. Un utilisateur Mozilla doit être en mesure de facilement discerner les"
-" fonctionnalités du module et ne pas se retrouver avec une expérience "
-"bizarre après l'installation."
+"Les surprises peuvent être appropriées dans beaucoup de situations, mais elles ne le sont pas quand la sécurité, la vie privée et le contrôle des utilisateurs sont en jeu. Il est extrêmement "
+"important d'être aussi transparent que possible lors de l'envoi d'un module pour l'héberger sur ce site. Un utilisateur Mozilla doit être en mesure de facilement discerner les fonctionnalités du "
+"module et ne pas se retrouver avec une expérience bizarre après l'installation."
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:243
 msgid ""
-"<p> Whenever an add-on includes any unexpected* feature that </p> <ul> "
-"<li>compromises user privacy or security (like sending data to third "
-"parties),</li> <li>changes default settings like the homepage or search "
-"engine, or</li> <li>changes settings or features in other add-ons or "
-"deactivates them altogether</li> </ul> <p>the features must adhere to the "
-"following requirements:</p> <ul> <li>The add-on description must clearly "
-"state what changes the add-on makes.</li> <li>All changes must be opt-in, "
-"meaning the user must take non-default action to enact the change.</li> "
-"<li>The opt-in dialog must clearly state the name of the add-on requesting "
-"the change.</li> <li>Uninstalling the add-on restores the user's original "
-"settings if they were changed.</li> </ul> <p>*Unexpected features are those "
-"that are unrelated to the add-on's primary function.</p>"
+"<p> Whenever an add-on includes any unexpected* feature that </p> <ul> <li>compromises user privacy or security (like sending data to third parties),</li> <li>changes default settings like the "
+"homepage or search engine, or</li> <li>changes settings or features in other add-ons or deactivates them altogether</li> </ul> <p>the features must adhere to the following requirements:</p> <ul> "
+"<li>The add-on description must clearly state what changes the add-on makes.</li> <li>All changes must be opt-in, meaning the user must take non-default action to enact the change.</li> <li>The "
+"opt-in dialog must clearly state the name of the add-on requesting the change.</li> <li>Uninstalling the add-on restores the user's original settings if they were changed.</li> </ul> <p>*Unexpected"
+" features are those that are unrelated to the add-on's primary function.</p>"
 msgstr ""
-"<p> Quand un module contient des fonctionnalités inattendues* qui </p> <ul> "
-"<li>compromettent la sécurité ou la vie privée des utilisateurs (comme "
-"l'envoi de données à des parties tierces),</li> <li>modifient des paramètres"
-" par défaut comme la page d'accueil ou le moteur de recherche, ou</li> "
-"<li>modifient des paramètres ou fonctionnalités d'autres modules ou les "
-"désactivent</li> </ul> <p>les fonctionnalités doivent correspondre aux "
-"besoins suivants :</p> <ul> <li>La description du module doit clairement "
-"indiquer quels sont les changements opérés.</li> <li>Tous les changements "
-"doivent être opt-in, c'est à dire que l'utilisateur doit valider "
-"consciemment l'application des changements.</li> <li>La boîte de dialogue "
-"opt-in doit clairement faire apparaître le module qui nécessite le "
-"changement.</li> <li>La désinstallation du module rétablit les paramètres "
-"originaux de l'utilisateur s'ils ont été altérés.</li> </ul> <p>*Les "
-"fonctionnalités inattendues sont celles qui ne sont pas en rapport avec la "
-"fonction principale du module.</p>"
+"<p> Quand un module contient des fonctionnalités inattendues* qui </p> <ul> <li>compromettent la sécurité ou la vie privée des utilisateurs (comme l'envoi de données à des parties tierces),</li> "
+"<li>modifient des paramètres par défaut comme la page d'accueil ou le moteur de recherche, ou</li> <li>modifient des paramètres ou fonctionnalités d'autres modules ou les désactivent</li> </ul> "
+"<p>les fonctionnalités doivent correspondre aux besoins suivants :</p> <ul> <li>La description du module doit clairement indiquer quels sont les changements opérés.</li> <li>Tous les changements "
+"doivent être opt-in, c'est à dire que l'utilisateur doit valider consciemment l'application des changements.</li> <li>La boîte de dialogue opt-in doit clairement faire apparaître le module qui "
+"nécessite le changement.</li> <li>La désinstallation du module rétablit les paramètres originaux de l'utilisateur s'ils ont été altérés.</li> </ul> <p>*Les fonctionnalités inattendues sont celles "
+"qui ne sont pas en rapport avec la fonction principale du module.</p>"
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:268
-msgid ""
-"These features cannot be introduced into an update of a fully-reviewed add-"
-"on; the opt-in change process must be part of the initial review."
-msgstr ""
-"Ces fonctionnalités ne peuvent être introduites dans une mise à jour d'un "
-"module complètement vérifié ; le processus de changement opt-in doit faire "
-"partie de la revue initiale."
+msgid "These features cannot be introduced into an update of a fully-reviewed add-on; the opt-in change process must be part of the initial review."
+msgstr "Ces fonctionnalités ne peuvent être introduites dans une mise à jour d'un module complètement vérifié ; le processus de changement opt-in doit faire partie de la revue initiale."
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:274
-msgid ""
-"These are minimum requirements and not a guarantee that the add-on will be "
-"approved. This section applies to all add-ons hosted on the site, including "
-"preliminarily reviewed add-ons."
-msgstr ""
-"Ce sont des pré-requis nécessaires et pas une garantie que le module sera "
-"approuvé. Cette section s'applique à tous les modules hébergés sur le site, "
-"dont ceux en revue préliminaire."
+msgid "These are minimum requirements and not a guarantee that the add-on will be approved. This section applies to all add-ons hosted on the site, including preliminarily reviewed add-ons."
+msgstr "Ce sont des pré-requis nécessaires et pas une garantie que le module sera approuvé. Cette section s'applique à tous les modules hébergés sur le site, dont ceux en revue préliminaire."
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:279
 msgid "Private Browsing Mode"
@@ -7701,18 +5952,11 @@ msgstr "Mode de navigation privée"
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:282
 msgid ""
-"Add-ons that store or otherwise handle browsing data must support <a "
-"href=\"https://developer.mozilla.org/En/Supporting_private_browsing_mode\">Private"
-" Browsing Mode</a>. During a Private Browsing session, no browsing data can "
-"be written to disk, and all of this data must be cleared when Firefox quits "
-"or the Private Browsing session ends."
+"Add-ons that store or otherwise handle browsing data must support <a href=\"https://developer.mozilla.org/En/Supporting_private_browsing_mode\">Private Browsing Mode</a>. During a Private Browsing "
+"session, no browsing data can be written to disk, and all of this data must be cleared when Firefox quits or the Private Browsing session ends."
 msgstr ""
-"Les modules qui stockent ou manipulent des données de navigation doivent "
-"supporter le <a "
-"href=\"https://developer.mozilla.org/En/Supporting_private_browsing_mode\">mode"
-" de navigation privée</a>. Pendant une navigation en mode privé, aucune "
-"donnée ne peut être écrite sur le disque, et toutes les données doivent être"
-" effacées lorsque Firefox est fermé ou que le mode privé est quitté."
+"Les modules qui stockent ou manipulent des données de navigation doivent supporter le <a href=\"https://developer.mozilla.org/En/Supporting_private_browsing_mode\">mode de navigation privée</a>. "
+"Pendant une navigation en mode privé, aucune donnée ne peut être écrite sur le disque, et toutes les données doivent être effacées lorsque Firefox est fermé ou que le mode privé est quitté."
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:287
 msgid "Binary Components & Obfuscated Code"
@@ -7720,41 +5964,26 @@ msgstr "Composants binaires et code obfusqué"
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:289
 msgid ""
-"Add-ons may contain binary, obfuscated and minified source code, but Mozilla"
-" must be allowed to review a copy of the human-readable source code of each "
-"version of an add-on submitted for review. These add-ons are ineligible for "
-"preliminary review and must choose the full review process."
+"Add-ons may contain binary, obfuscated and minified source code, but Mozilla must be allowed to review a copy of the human-readable source code of each version of an add-on submitted for review. "
+"These add-ons are ineligible for preliminary review and must choose the full review process."
 msgstr ""
-"Les modules peuvent contenir des binaires, du code source obfusqué ou "
-"minifié, mais Mozilla doit pouvoir vérifier une copie lisible par un humain "
-"du code source de charge version proposée à vérification. Ces modules ne "
-"sont donc pas acceptés pour le processus de revue préliminaire et doivent "
-"choisir la revue complète."
+"Les modules peuvent contenir des binaires, du code source obfusqué ou minifié, mais Mozilla doit pouvoir vérifier une copie lisible par un humain du code source de charge version proposée à "
+"vérification. Ces modules ne sont donc pas acceptés pour le processus de revue préliminaire et doivent choisir la revue complète."
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:295
 msgid ""
-"If an add-on contains binary or obfuscated source code, the author will "
-"receive a message when the add-on is reviewed indicating whom to contact at "
-"Mozilla to coordinate review of the source code. This code will be reviewed "
-"by an administrator and will not be shared or redistributed in any way. The "
-"code will only be used for the purpose of reviewing the add-on."
+"If an add-on contains binary or obfuscated source code, the author will receive a message when the add-on is reviewed indicating whom to contact at Mozilla to coordinate review of the source code. "
+"This code will be reviewed by an administrator and will not be shared or redistributed in any way. The code will only be used for the purpose of reviewing the add-on."
 msgstr ""
-"Si un module contient des binaires ou du code obfusqué, l'auteur recevra un "
-"message quand le module est revu lui indiquant qui contacter chez Mozilla "
-"pour se coordonner pour la revue de code. Ce code sera revu par un "
-"administrateur et ne sera pas partagé ni redistribué. Le code sera "
-"uniquement utilisé afin de vérifier le module."
+"Si un module contient des binaires ou du code obfusqué, l'auteur recevra un message quand le module est revu lui indiquant qui contacter chez Mozilla pour se coordonner pour la revue de code. Ce "
+"code sera revu par un administrateur et ne sera pas partagé ni redistribué. Le code sera uniquement utilisé afin de vérifier le module."
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:301
 #, python-format
-msgid ""
-"If your add-on contains binary or obfuscated code that you don't own or "
-"can't get the source code for, you may <a href=\"%(link_contact)s\">contact "
-"us</a> for information on how to proceed."
+msgid "If your add-on contains binary or obfuscated code that you don't own or can't get the source code for, you may <a href=\"%(link_contact)s\">contact us</a> for information on how to proceed."
 msgstr ""
-"Si votre module contient des binaires ou du code obfusqué ne vous "
-"appartenant pas ou dont vous n'avez pas le code source, vous pouvez <a "
-"href=\"%(link_contact)s\">nous contacter</a> pour savoir comment procéder."
+"Si votre module contient des binaires ou du code obfusqué ne vous appartenant pas ou dont vous n'avez pas le code source, vous pouvez <a href=\"%(link_contact)s\">nous contacter</a> pour savoir "
+"comment procéder."
 
 #: src/olympia/devhub/templates/devhub/docs/policies-submission.html:11
 msgid "Criteria for Submission"
@@ -7762,238 +5991,127 @@ msgstr "Critères d'envoi"
 
 #: src/olympia/devhub/templates/devhub/docs/policies-submission.html:13
 msgid ""
-"Add-ons hosted on Mozilla Add-ons should be of high quality and give users "
-"an improved web experience. We look for the following things when deciding "
-"whether an add-on is appropriate to be public and unrestricted:"
+"Add-ons hosted on Mozilla Add-ons should be of high quality and give users an improved web experience. We look for the following things when deciding whether an add-on is appropriate to be public "
+"and unrestricted:"
 msgstr ""
-"Les modules hébergés sur Mozilla Add-ons doivent être de grande qualité et "
-"donner et améliorer l'expérience de l'utilisateur. Afin de décider si un "
-"module est adapté pour être diffusé sans restriction, nous vérifions les "
-"points suivants :"
+"Les modules hébergés sur Mozilla Add-ons doivent être de grande qualité et donner et améliorer l'expérience de l'utilisateur. Afin de décider si un module est adapté pour être diffusé sans "
+"restriction, nous vérifions les points suivants :"
 
 #: src/olympia/devhub/templates/devhub/docs/policies-submission.html:19
 msgid ""
-"<strong>Are you responsive?</strong> We expect that an author who is "
-"promoting their add-on to our applications' many users is responsive to "
-"problem reports, maintains their contact information, and updates their add-"
-"on promptly to keep current with Firefox releases and changes in our "
-"policies. This doesn't mean that you have to reply to every question that "
-"someone posts in the discussions, or that you even need to fix every bug, "
-"but we do expect that you will respond to issues in a manner that's "
-"appropriate to the severity of the issue in question."
+"<strong>Are you responsive?</strong> We expect that an author who is promoting their add-on to our applications' many users is responsive to problem reports, maintains their contact information, "
+"and updates their add-on promptly to keep current with Firefox releases and changes in our policies. This doesn't mean that you have to reply to every question that someone posts in the "
+"discussions, or that you even need to fix every bug, but we do expect that you will respond to issues in a manner that's appropriate to the severity of the issue in question."
 msgstr ""
-"<strong>Êtes vous réactif ?</strong> Nous attendons qu'un auteur qui promeut"
-" son module pour tous les utilisateurs de nos applications soit réactif aux "
-"rapports de problèmes, maintienne les informations de contact et mette à "
-"jour son module rapidement pour rester compatible avec les modifications de "
-"Firefox et de nos politiques. Ceci ne signifie pas que vous devez répondre à"
-" toute question que quelqu'un pose dans les discussions ou que vous devez "
-"corriger chaque bug, mais nous attendons que vous preniez en charge les "
-"problèmes à leur juste valeur."
+"<strong>Êtes vous réactif ?</strong> Nous attendons qu'un auteur qui promeut son module pour tous les utilisateurs de nos applications soit réactif aux rapports de problèmes, maintienne les "
+"informations de contact et mette à jour son module rapidement pour rester compatible avec les modifications de Firefox et de nos politiques. Ceci ne signifie pas que vous devez répondre à toute "
+"question que quelqu'un pose dans les discussions ou que vous devez corriger chaque bug, mais nous attendons que vous preniez en charge les problèmes à leur juste valeur."
 
 #: src/olympia/devhub/templates/devhub/docs/policies-submission.html:25
 msgid ""
-"<strong>Is the add-on clearly and accurately described?</strong> It's of the"
-" utmost importance to us that users get what they expect when they try a new"
-" add-on. Your add-on name should be clear and concise, and you should "
-"refrain from using special characters or numbers to get higher search "
-"rankings or for decorative purposes. Your description should provide details"
-" about what the add-on does, how a user should take advantage of it, and "
-"what the user should expect when they install it. Links to external "
-"documents for detailed instructions are fine, but the description itself "
-"should cover the basics and leave users confident that they know what "
-"they'll get. Also, it is important that you maintain version notes "
-"appropriately as you improve and change your add-on. Users should be able to"
-" see what's new in an add-on they may have tried previously, and should be "
-"made aware of changes that might affect their current use of the add-on when"
-" they update."
+"<strong>Is the add-on clearly and accurately described?</strong> It's of the utmost importance to us that users get what they expect when they try a new add-on. Your add-on name should be clear and"
+" concise, and you should refrain from using special characters or numbers to get higher search rankings or for decorative purposes. Your description should provide details about what the add-on "
+"does, how a user should take advantage of it, and what the user should expect when they install it. Links to external documents for detailed instructions are fine, but the description itself should"
+" cover the basics and leave users confident that they know what they'll get. Also, it is important that you maintain version notes appropriately as you improve and change your add-on. Users should "
+"be able to see what's new in an add-on they may have tried previously, and should be made aware of changes that might affect their current use of the add-on when they update."
 msgstr ""
-"<strong>Est-ce que le module est décrit de manière correcte ?</strong> Il "
-"est de la plus haute importance pour nous que les utilisateurs obtiennent ce"
-" qu'ils attendaient quand ils essayent un nouveau module. Le nom de votre "
-"module doit être clair et concis, et vous devriez éviter d'utiliser des "
-"caractères spéciaux ou des chiffres pour obtenir de meilleurs classements "
-"dans les recherche ou pour faire joli. Votre description doit fournir les "
-"détails à propos de ce que le module fait, comment un utilisateur peut en "
-"tirer avantage, et ce à quoi il devrait s'attendre en l'installant. Des "
-"liens vers des documents externes sont acceptés, mais la description elle-"
-"même devrait couvrir la base et laisser une bonne impression de ce qu'ils "
-"vont obtenir aux utilisateurs. De plus, il est important que vous mainteniez"
-" les notes de version de manière appropriée quand vous améliorez et changez "
-"votre module. Les utilisateurs devraient être capable de voir ce qu'un "
-"module apporte de plus par rapport à la fois précédente où ils l'avaient "
-"essayé, et devraient être avertis des changements qui pourraient affecter "
-"leur utilisation actuelle quand ils font la mise à jour."
+"<strong>Est-ce que le module est décrit de manière correcte ?</strong> Il est de la plus haute importance pour nous que les utilisateurs obtiennent ce qu'ils attendaient quand ils essayent un "
+"nouveau module. Le nom de votre module doit être clair et concis, et vous devriez éviter d'utiliser des caractères spéciaux ou des chiffres pour obtenir de meilleurs classements dans les recherche "
+"ou pour faire joli. Votre description doit fournir les détails à propos de ce que le module fait, comment un utilisateur peut en tirer avantage, et ce à quoi il devrait s'attendre en l'installant. "
+"Des liens vers des documents externes sont acceptés, mais la description elle-même devrait couvrir la base et laisser une bonne impression de ce qu'ils vont obtenir aux utilisateurs. De plus, il "
+"est important que vous mainteniez les notes de version de manière appropriée quand vous améliorez et changez votre module. Les utilisateurs devraient être capable de voir ce qu'un module apporte de"
+" plus par rapport à la fois précédente où ils l'avaient essayé, et devraient être avertis des changements qui pourraient affecter leur utilisation actuelle quand ils font la mise à jour."
 
 #: src/olympia/devhub/templates/devhub/docs/policies-submission.html:31
 msgid ""
-"<strong>Are all privacy and security concerns clearly spelled out?</strong> "
-"This is an aspect of a clear and accurate description, but such an important"
-" one that we feel it deserves specific mention. Many very useful and well-"
-"written add-ons manipulate some form of user data, or can present security "
-"hazards if misused; they are welcome on the site, but they must make it very"
-" clear to users what risks they might encounter, and what they can do to "
-"protect themselves."
+"<strong>Are all privacy and security concerns clearly spelled out?</strong> This is an aspect of a clear and accurate description, but such an important one that we feel it deserves specific "
+"mention. Many very useful and well-written add-ons manipulate some form of user data, or can present security hazards if misused; they are welcome on the site, but they must make it very clear to "
+"users what risks they might encounter, and what they can do to protect themselves."
 msgstr ""
-"<strong>Est-ce que toutes les préoccupations de sécurité et de vie privée "
-"sont traitées ?</strong> C'est un aspect d'une description claire et "
-"précise, mais tellement important que nous pensons qu'il mérite une mention "
-"spécifique. Beaucoup de modules très utiles et bien écrits manipulent des "
-"données de l'utilisateur ou peuvent présenter des risques de sécurité s'ils "
-"sont mal utilisés ; ils sont bienvenus sur le site, mais ils doivent "
-"indiquer clairement aux utilisateurs quels risques ils encourent, et ce "
-"qu'ils peuvent faire pour se protéger."
+"<strong>Est-ce que toutes les préoccupations de sécurité et de vie privée sont traitées ?</strong> C'est un aspect d'une description claire et précise, mais tellement important que nous pensons "
+"qu'il mérite une mention spécifique. Beaucoup de modules très utiles et bien écrits manipulent des données de l'utilisateur ou peuvent présenter des risques de sécurité s'ils sont mal utilisés ; "
+"ils sont bienvenus sur le site, mais ils doivent indiquer clairement aux utilisateurs quels risques ils encourent, et ce qu'ils peuvent faire pour se protéger."
 
 #: src/olympia/devhub/templates/devhub/docs/policies-submission.html:37
 msgid ""
-"<strong>Has the add-on been well-tested, and is it free of obvious or "
-"serious defects?</strong> One important thing that we look for when "
-"considering an add-on is whether its user reviews indicate that it has "
-"received thorough testing, and that it doesn't have serious problems or "
-"negative impacts on the browser. If reviewers report problems such as major "
-"performance issues, crashes, frequent problems using the functions of the "
-"add-on, or spamming of messages to the error console, you should take those "
-"reports to heart, and re-submit your add-on after you've addressed them as "
-"best you can. We don't expect you to perfectly optimize or have zero bugs "
-"&mdash; Firefox itself undergoes constant improvement in these areas &mdash;"
-" but we do want you to take reasonable efforts to minimize downsides, and to"
-" clearly call out cases where users may be surprised by those that remain."
+"<strong>Has the add-on been well-tested, and is it free of obvious or serious defects?</strong> One important thing that we look for when considering an add-on is whether its user reviews indicate "
+"that it has received thorough testing, and that it doesn't have serious problems or negative impacts on the browser. If reviewers report problems such as major performance issues, crashes, frequent"
+" problems using the functions of the add-on, or spamming of messages to the error console, you should take those reports to heart, and re-submit your add-on after you've addressed them as best you "
+"can. We don't expect you to perfectly optimize or have zero bugs &mdash; Firefox itself undergoes constant improvement in these areas &mdash; but we do want you to take reasonable efforts to "
+"minimize downsides, and to clearly call out cases where users may be surprised by those that remain."
 msgstr ""
-"<strong>Le module a-t-il été testé correctement, et est-il exempt de défauts"
-" sérieux et évidents ?</strong> Une chose importante qui est auscultée "
-"lorsque nous étudions un module est si les critiques des utilisateurs "
-"indiquent qu'il a reçu assez de tests et qu'il ne présente pas de grave "
-"problème ou d'impact négatif sur le navigateur. Si les testeurs rapportent "
-"des problèmes tels des grosses pertes de performances, plantages, problèmes "
-"fréquents lors de l'utilisation du module, surcharge de messages dans la "
-"console d'erreur, vous devriez prendre ces rapports à cœur et ré-envoyer "
-"votre module après avoir corrigé du mieux que vous pouvez. Nous n'attendons "
-"pas une optimisation parfaite ou zéro problème &mdash; Firefox lui-même est "
-"en constante amélioration de ce côté là &mdash; mais nous voulons que vous "
-"fassiez des efforts raisonnables pour minimiser les problèmes et clairement "
-"identifier ce que les utilisateurs peuvent rencontrer."
+"<strong>Le module a-t-il été testé correctement, et est-il exempt de défauts sérieux et évidents ?</strong> Une chose importante qui est auscultée lorsque nous étudions un module est si les "
+"critiques des utilisateurs indiquent qu'il a reçu assez de tests et qu'il ne présente pas de grave problème ou d'impact négatif sur le navigateur. Si les testeurs rapportent des problèmes tels des "
+"grosses pertes de performances, plantages, problèmes fréquents lors de l'utilisation du module, surcharge de messages dans la console d'erreur, vous devriez prendre ces rapports à cœur et "
+"ré-envoyer votre module après avoir corrigé du mieux que vous pouvez. Nous n'attendons pas une optimisation parfaite ou zéro problème &mdash; Firefox lui-même est en constante amélioration de ce "
+"côté là &mdash; mais nous voulons que vous fassiez des efforts raisonnables pour minimiser les problèmes et clairement identifier ce que les utilisateurs peuvent rencontrer."
 
 #: src/olympia/devhub/templates/devhub/docs/policies-submission.html:43
 msgid ""
-"<strong>Do the add-on and add-on author both treat the user "
-"respectfully?</strong> Your software should not intrude on the user "
-"unnecessarily, try to trick the user, or conceal any of its activities from "
-"the user. Users (or even non-users) are sometimes rude in their comments, "
-"and while we will do our best to filter out inaccurate reviews as they're "
-"reported to us, we do expect that authors will avoid retaliating with "
-"rudeness of their own."
+"<strong>Do the add-on and add-on author both treat the user respectfully?</strong> Your software should not intrude on the user unnecessarily, try to trick the user, or conceal any of its "
+"activities from the user. Users (or even non-users) are sometimes rude in their comments, and while we will do our best to filter out inaccurate reviews as they're reported to us, we do expect that"
+" authors will avoid retaliating with rudeness of their own."
 msgstr ""
-"<strong>Le module et son auteur traitent-ils avec respect l'utilisateur "
-"?</strong> Votre logiciel ne devrait pas s'introduire de manière inutile "
-"dans la vie de l'utilisateur, essayer de le piéger, ou dissimuler l'une de "
-"ses activités à l'utilisateur. Les utilisateurs (ou non utilisateurs) sont "
-"parfois durs dans leurs commentaires et bien que nous fassions de notre "
-"mieux pour retirer les critiques invalides lorsqu'elles nous sont "
-"rapportées, nous attendons que les auteurs ne se vengent pas en réponse."
+"<strong>Le module et son auteur traitent-ils avec respect l'utilisateur ?</strong> Votre logiciel ne devrait pas s'introduire de manière inutile dans la vie de l'utilisateur, essayer de le piéger, "
+"ou dissimuler l'une de ses activités à l'utilisateur. Les utilisateurs (ou non utilisateurs) sont parfois durs dans leurs commentaires et bien que nous fassions de notre mieux pour retirer les "
+"critiques invalides lorsqu'elles nous sont rapportées, nous attendons que les auteurs ne se vengent pas en réponse."
 
 #: src/olympia/devhub/templates/devhub/docs/policies-submission.html:49
 msgid ""
-"<strong>Is the add-on useful to an appropriately wide portion of Firefox's "
-"users?</strong> Your add-on doesn't need to be the next Greasemonkey or "
-"Firebug, but if it is only useful to people at your company or who are part "
-"of a small web community, we may feel that it's not yet appropriate to put "
-"it in front of all of our users."
+"<strong>Is the add-on useful to an appropriately wide portion of Firefox's users?</strong> Your add-on doesn't need to be the next Greasemonkey or Firebug, but if it is only useful to people at "
+"your company or who are part of a small web community, we may feel that it's not yet appropriate to put it in front of all of our users."
 msgstr ""
-"<strong>Est-ce que le module est utile à une part suffisamment large des "
-"utilisateurs de Firefox ?</strong> Votre module n'a pas besoin d'être le "
-"prochain Greasemonkey ou Firebug, mais s'il est uniquement utile à des gens "
-"de votre société ou qui font partie d'une petite communauté web, nous "
-"pensons qu'il n'est peut-être pas judicieux de le mettre devant tous nos "
-"utilisateurs."
+"<strong>Est-ce que le module est utile à une part suffisamment large des utilisateurs de Firefox ?</strong> Votre module n'a pas besoin d'être le prochain Greasemonkey ou Firebug, mais s'il est "
+"uniquement utile à des gens de votre société ou qui font partie d'une petite communauté web, nous pensons qu'il n'est peut-être pas judicieux de le mettre devant tous nos utilisateurs."
 
 #: src/olympia/devhub/templates/devhub/docs/policies-submission.html:55
 msgid ""
-"We are constantly looking at ways to improve the organization of the site to"
-" better accommodate add-ons that are exemplary in other ways, but are aimed "
-"at only a small community of potential users. Correctly categorizing and "
-"maintaining the metadata of your add-on will help us figure out how we can "
-"surface more of those sorts of add-ons to people who are most likely to "
-"benefit from them."
+"We are constantly looking at ways to improve the organization of the site to better accommodate add-ons that are exemplary in other ways, but are aimed at only a small community of potential users."
+" Correctly categorizing and maintaining the metadata of your add-on will help us figure out how we can surface more of those sorts of add-ons to people who are most likely to benefit from them."
 msgstr ""
-"Nous cherchons en permanence à améliorer l'organisation du site pour mieux "
-"accueillir les modules qui sont exemplaires dans d'autres champs mais qui "
-"ciblent uniquement une petite portion d'utilisateurs potentiels. Catégoriser"
-" correctement et maintenir les méta-données de votre module nous aidera à "
-"savoir comment faire ressortir plus de ce genre de modules aux gens qui sont"
-" les plus à même de les apprécier."
+"Nous cherchons en permanence à améliorer l'organisation du site pour mieux accueillir les modules qui sont exemplaires dans d'autres champs mais qui ciblent uniquement une petite portion "
+"d'utilisateurs potentiels. Catégoriser correctement et maintenir les méta-données de votre module nous aidera à savoir comment faire ressortir plus de ce genre de modules aux gens qui sont les plus"
+" à même de les apprécier."
 
 #: src/olympia/devhub/templates/devhub/docs/policies-submission.html:61
 msgid ""
-"If your add-on just provides bookmarks or other simple access points to your"
-" site, it's probably not appropriate for the gallery. Like the rest of the "
-"Mozilla project, we love web applications and new web services, but Firefox "
-"add-ons should provide an improved browsing experience for the user and not "
-"just be a way to promote a new site or service through a Mozilla Add-ons "
-"listing."
+"If your add-on just provides bookmarks or other simple access points to your site, it's probably not appropriate for the gallery. Like the rest of the Mozilla project, we love web applications and "
+"new web services, but Firefox add-ons should provide an improved browsing experience for the user and not just be a way to promote a new site or service through a Mozilla Add-ons listing."
 msgstr ""
-"Si votre module fournit uniquement des marque-pages ou d'autres points "
-"d'accès simples vers votre site, il n'a probablement pas sa place dans la "
-"galerie. Comme le reste du projet Mozilla, nous aimons les applications web "
-"et les nouveaux services web, mais les modules Firefox doivent proposer une "
-"expérience de navigation améliorer pour l'utilisateur et pas uniquement être"
-" une manière de promouvoir un nouveau site web ou service via Mozilla Add-"
-"ons."
+"Si votre module fournit uniquement des marque-pages ou d'autres points d'accès simples vers votre site, il n'a probablement pas sa place dans la galerie. Comme le reste du projet Mozilla, nous "
+"aimons les applications web et les nouveaux services web, mais les modules Firefox doivent proposer une expérience de navigation améliorer pour l'utilisateur et pas uniquement être une manière de "
+"promouvoir un nouveau site web ou service via Mozilla Add-ons."
 
 #: src/olympia/devhub/templates/devhub/docs/policies-submission.html:67
 msgid ""
-"<strong>Is the add-on free of unlicensed trademarks and copyrights?</strong>"
-" Though you may mean no harm to the holder of a trademark, or the owner of a"
-" copyrighted work, we can't host add-ons that infringe on trademarks or "
-"copyrights. If you don't have permission to use a trademarked name or image,"
-" please do not submit your add-on to us. If your add-on includes code that "
-"is copyrighted by someone else, and is not licensed to you to use in your "
-"add-on, please do not submit your add-on to us."
+"<strong>Is the add-on free of unlicensed trademarks and copyrights?</strong> Though you may mean no harm to the holder of a trademark, or the owner of a copyrighted work, we can't host add-ons that"
+" infringe on trademarks or copyrights. If you don't have permission to use a trademarked name or image, please do not submit your add-on to us. If your add-on includes code that is copyrighted by "
+"someone else, and is not licensed to you to use in your add-on, please do not submit your add-on to us."
 msgstr ""
-"<strong>Le module est-il libre de tout élément du droit des marques sans "
-"licence ou copyright ?</strong> Même si vous ne voulez pas faire de mal au "
-"propriétaire d'une marque déposée, ou au propriétaire d'un travail couvert "
-"part le droit d'auteur, nous ne pouvons pas héberger les modules qui sont en"
-" infraction avec le droit des marques ou le droit d'auteur. Si vous n'avez "
-"pas la permission d'utiliser une marque déposée ou une image, merci de ne "
-"pas envoyer votre module. Si votre module inclut du code dont les droits "
-"sont en possession de quelqu'un d'autre et qu'il ne vous a pas donné "
-"l'autorisation de l'utiliser dans votre module, merci de ne pas envoyer "
-"votre module."
+"<strong>Le module est-il libre de tout élément du droit des marques sans licence ou copyright ?</strong> Même si vous ne voulez pas faire de mal au propriétaire d'une marque déposée, ou au "
+"propriétaire d'un travail couvert part le droit d'auteur, nous ne pouvons pas héberger les modules qui sont en infraction avec le droit des marques ou le droit d'auteur. Si vous n'avez pas la "
+"permission d'utiliser une marque déposée ou une image, merci de ne pas envoyer votre module. Si votre module inclut du code dont les droits sont en possession de quelqu'un d'autre et qu'il ne vous "
+"a pas donné l'autorisation de l'utiliser dans votre module, merci de ne pas envoyer votre module."
 
 #: src/olympia/devhub/templates/devhub/docs/policies-submission.html:73
 msgid ""
-"In terms of reuse of source code from other add-ons, if the author has not "
-"clearly stated that you are permitted to use his or her code in your own "
-"work &mdash; such as by placing it under an open source license &mdash; then"
-" you should assume that you do not have the right to do so. You can contact "
-"the author to seek such permission, but we can't provide you with any "
-"special rights to it just because it's listed on the site, or because the "
-"author isn't responding to your request."
+"In terms of reuse of source code from other add-ons, if the author has not clearly stated that you are permitted to use his or her code in your own work &mdash; such as by placing it under an open "
+"source license &mdash; then you should assume that you do not have the right to do so. You can contact the author to seek such permission, but we can't provide you with any special rights to it "
+"just because it's listed on the site, or because the author isn't responding to your request."
 msgstr ""
-"En terme de réutilisation de code depuis d'autres modules, si l'auteur n'a "
-"pas clairement indiqué que vous avez le droit de réutiliser son code pour "
-"votre propre travail &mdash; par exemple en le mettant sous licence libre "
-"&mdash; alors vous devez considérer que vous ne pouvez pas. Vous pouvez "
-"essayer de contacter l'auteur pour obtenir sa permission, mais nous ne "
-"pouvons pas vous donner de droit spécial juste parce qu'il est présent sur "
-"le site, ou parce que l'auteur ne réponds pas à votre demande."
+"En terme de réutilisation de code depuis d'autres modules, si l'auteur n'a pas clairement indiqué que vous avez le droit de réutiliser son code pour votre propre travail &mdash; par exemple en le "
+"mettant sous licence libre &mdash; alors vous devez considérer que vous ne pouvez pas. Vous pouvez essayer de contacter l'auteur pour obtenir sa permission, mais nous ne pouvons pas vous donner de "
+"droit spécial juste parce qu'il est présent sur le site, ou parce que l'auteur ne réponds pas à votre demande."
 
 #: src/olympia/devhub/templates/devhub/docs/policies-submission.html:79
 msgid ""
-"This applies to the Mozilla Foundation's trademarks as well, including "
-"\"Mozilla\", \"Firefox\", and \"Thunderbird\". The Mozilla policy on "
-"trademark use is designed to protect against confusion, and prevent the "
-"trademarks from being overturned due to lack of protection; please respect "
-"the need for such protection, and help us preserve some of the most valuable"
-" assets of the Mozilla Foundation."
+"This applies to the Mozilla Foundation's trademarks as well, including \"Mozilla\", \"Firefox\", and \"Thunderbird\". The Mozilla policy on trademark use is designed to protect against confusion, "
+"and prevent the trademarks from being overturned due to lack of protection; please respect the need for such protection, and help us preserve some of the most valuable assets of the Mozilla "
+"Foundation."
 msgstr ""
-"Ceci s'applique aux marques déposées de la Fondation Mozilla également, "
-"notamment « Mozilla », « Firefox » et « Thunderbird ». La politique de "
-"Mozilla relative à l'utilisation des marques déposées est prévue pour "
-"protéger de la confusion, et éviter de perdre la propriété des marques par "
-"manque de protection ; merci de respecter le besoin d'une telle protection "
-"et de nous aider à préserver l'un des éléments les plus importants de la "
-"Fondation Mozilla."
+"Ceci s'applique aux marques déposées de la Fondation Mozilla également, notamment « Mozilla », « Firefox » et « Thunderbird ». La politique de Mozilla relative à l'utilisation des marques déposées "
+"est prévue pour protéger de la confusion, et éviter de perdre la propriété des marques par manque de protection ; merci de respecter le besoin d'une telle protection et de nous aider à préserver "
+"l'un des éléments les plus importants de la Fondation Mozilla."
 
 #: src/olympia/devhub/templates/devhub/docs/policies-submission.html:84
 msgid "Licensing"
@@ -8001,252 +6119,151 @@ msgstr "Licences"
 
 #: src/olympia/devhub/templates/devhub/docs/policies-submission.html:86
 msgid ""
-"Selecting an appropriate license for your add-on is a very important step in"
-" the submission process. A license specifies the rights you grant on your "
-"source code and is important in protecting your intellectual property."
+"Selecting an appropriate license for your add-on is a very important step in the submission process. A license specifies the rights you grant on your source code and is important in protecting your"
+" intellectual property."
 msgstr ""
-"Sélectionner la licence adaptée à votre module est une étape critique dans "
-"le processus d'envoi. Une licence définit les droits que vous donnez sur "
-"votre code source et est importante pour protéger votre propriété "
-"intellectuelle."
+"Sélectionner la licence adaptée à votre module est une étape critique dans le processus d'envoi. Une licence définit les droits que vous donnez sur votre code source et est importante pour protéger"
+" votre propriété intellectuelle."
 
 #: src/olympia/devhub/templates/devhub/docs/policies-submission.html:92
 msgid ""
-"During the add-on submission process, you will be presented with a list of "
-"popular licenses to choose from, as well as the ability to specify your own "
-"license. It is best to consult with a legal professional about which license"
-" option is best for you. Choosing the right license for your source code "
-"will help to prevent confusion and code conflicts in the future."
+"During the add-on submission process, you will be presented with a list of popular licenses to choose from, as well as the ability to specify your own license. It is best to consult with a legal "
+"professional about which license option is best for you. Choosing the right license for your source code will help to prevent confusion and code conflicts in the future."
 msgstr ""
-"Pendant le processus d'envoi, une liste de licences populaires vous sera "
-"proposée pour choisir l'une d'elles, ainsi que la possibilité de définir "
-"votre propre licence. Il est toujours recommandé de contacter un "
-"professionnel du droit pour le choix de la licence. Choisir la bonne licence"
-" pour votre code source vous aidera à éviter des confusions et des conflits "
-"de code dans le futur."
+"Pendant le processus d'envoi, une liste de licences populaires vous sera proposée pour choisir l'une d'elles, ainsi que la possibilité de définir votre propre licence. Il est toujours recommandé de"
+" contacter un professionnel du droit pour le choix de la licence. Choisir la bonne licence pour votre code source vous aidera à éviter des confusions et des conflits de code dans le futur."
 
-#: src/olympia/devhub/templates/devhub/docs/policies.html:12
-#: src/olympia/devhub/templates/devhub/docs/policies.html:52
+#: src/olympia/devhub/templates/devhub/docs/policies.html:12 src/olympia/devhub/templates/devhub/docs/policies.html:52
 msgid "Add-on Submission"
 msgstr "Envoi du module"
 
-#: src/olympia/devhub/templates/devhub/docs/policies.html:18
-#: src/olympia/devhub/templates/devhub/docs/policies.html:78
+#: src/olympia/devhub/templates/devhub/docs/policies.html:18 src/olympia/devhub/templates/devhub/docs/policies.html:78
 msgid "Maintaining Your Add-on"
 msgstr "Maintenir votre module"
 
 #: src/olympia/devhub/templates/devhub/docs/policies.html:43
-msgid ""
-"Mozilla is committed to ensuring a great add-ons experience for our users "
-"and developers. Please review the policies below before submitting your add-"
-"on."
+msgid "Mozilla is committed to ensuring a great add-ons experience for our users and developers. Please review the policies below before submitting your add-on."
 msgstr ""
-"Mozilla s'attache à fournir une excellente expérience avec les modules, que "
-"ce soit pour les utilisateurs ou les développeurs. Merci de prendre "
-"connaissance des politiques ci-dessous avant d'envoyer votre module."
+"Mozilla s'attache à fournir une excellente expérience avec les modules, que ce soit pour les utilisateurs ou les développeurs. Merci de prendre connaissance des politiques ci-dessous avant "
+"d'envoyer votre module."
 
 #: src/olympia/devhub/templates/devhub/docs/policies.html:55
-msgid ""
-"Find out what is expected of add-ons we host and our policies on specific "
-"add-on practices."
-msgstr ""
-"Découvrez ce qui est attendu des modules que nous hébergeons et nos "
-"politiques sur les pratiques pour les modules spécifiques."
+msgid "Find out what is expected of add-ons we host and our policies on specific add-on practices."
+msgstr "Découvrez ce qui est attendu des modules que nous hébergeons et nos politiques sur les pratiques pour les modules spécifiques."
 
 #: src/olympia/devhub/templates/devhub/docs/policies.html:67
-msgid ""
-"What happens after your add-on is submitted? Learn about how our Editors "
-"review submissions."
-msgstr ""
-"Qu'est-ce qui arrive une fois que votre module est envoyé ? En apprendre "
-"plus sur la manière de vérifier les envois de nos Éditeurs."
+msgid "What happens after your add-on is submitted? Learn about how our Editors review submissions."
+msgstr "Qu'est-ce qui arrive une fois que votre module est envoyé ? En apprendre plus sur la manière de vérifier les envois de nos Éditeurs."
 
 #: src/olympia/devhub/templates/devhub/docs/policies.html:81
-msgid ""
-"Add-on updates, transferring ownership, user reviews, and what to expect "
-"once your add-on is approved."
-msgstr ""
-"Mises à jour de module, transfert de propriété, critiques utilisateurs, et "
-"qu'attendre une fois que votre module est accepté."
+msgid "Add-on updates, transferring ownership, user reviews, and what to expect once your add-on is approved."
+msgstr "Mises à jour de module, transfert de propriété, critiques utilisateurs, et qu'attendre une fois que votre module est accepté."
 
 #: src/olympia/devhub/templates/devhub/docs/policies.html:93
-msgid ""
-"How up-and-coming add-ons become featured and what&#039;s involved in the "
-"process."
-msgstr ""
-"Comment les modules deviennent vedettes et qu'est-ce qui importe dans ce "
-"processus."
+msgid "How up-and-coming add-ons become featured and what&#039;s involved in the process."
+msgstr "Comment les modules deviennent vedettes et qu'est-ce qui importe dans ce processus."
 
 #: src/olympia/devhub/templates/devhub/docs/policies.html:106
-msgid ""
-"Terms of Service for submitting your work to our site. Developers are "
-"required to accept this agreement before submission."
-msgstr ""
-"Conditions d'utilisation pour envoyer votre travail sur notre site. Les "
-"développeurs doivent accepter cet accord avant envoi."
+msgid "Terms of Service for submitting your work to our site. Developers are required to accept this agreement before submission."
+msgstr "Conditions d'utilisation pour envoyer votre travail sur notre site. Les développeurs doivent accepter cet accord avant envoi."
 
 #: src/olympia/devhub/templates/devhub/docs/policies.html:118
 msgid "How to get in touch with us regarding these policies or your add-on."
-msgstr ""
-"Comment prendre contact avec nous à propos de ces politiques ou de votre "
-"module."
+msgstr "Comment prendre contact avec nous à propos de ces politiques ou de votre module."
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:6
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:10
 msgid "You have disabled this add-on"
 msgstr "Vous avez désactivé ce module"
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:20
-msgid ""
-"Your add-on's listing is disabled and is not showing anywhere in our gallery"
-" or update service."
-msgstr ""
-"L'affichage de votre module sur les listes est désactivé&nbsp;; il "
-"n'apparaît plus dans notre galerie ou dans notre service de mise à jour."
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:24
+msgid "Your add-on's listing is disabled and is not showing anywhere in our gallery or update service."
+msgstr "L'affichage de votre module sur les listes est désactivé&nbsp;; il n'apparaît plus dans notre galerie ou dans notre service de mise à jour."
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:25
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:27
 msgid "Please complete your add-on."
 msgstr "Veuillez compléter votre module."
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:29
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:30
 msgid "You will receive an email when the review is complete."
-msgstr ""
-"Vous recevrez un courrier électronique lorsque la revue sera terminée."
+msgstr "Vous recevrez un courrier électronique lorsque la revue sera terminée."
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:34
-msgid ""
-"You will receive an email when the review is complete. Until then, your add-"
-"on is not listed in our gallery but can be accessed directly from its "
-"details page."
-msgstr ""
-"Vous recevrez un courriel quand la revue sera finie. En attendant, votre "
-"module ne sera pas accessible via la galerie mais vous pourrez y accéder "
-"directement."
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:33
+msgid "You will receive an email when the review is complete. Until then, your add-on is not listed in our gallery but can be accessed directly from its details page."
+msgstr "Vous recevrez un courriel quand la revue sera finie. En attendant, votre module ne sera pas accessible via la galerie mais vous pourrez y accéder directement."
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:38
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:48
-msgid ""
-"You will receive an email when the review is complete and your add-on is "
-"signed."
-msgstr ""
-"Vous recevrez un courrier électronique lorsque la revue sera terminée et que"
-" votre module sera signé."
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:37 src/olympia/devhub/templates/devhub/includes/addon_details.html:45
+msgid "You will receive an email when the review is complete and your add-on is signed."
+msgstr "Vous recevrez un courrier électronique lorsque la revue sera terminée et que votre module sera signé."
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:44
-msgid ""
-"You will receive an email when the review is complete. Until then, your add-"
-"on is not listed in our gallery but can be accessed directly from its "
-"details page."
-msgstr ""
-"Vous recevrez un courriel quand la revue sera finie. En attendant, votre "
-"module ne sera pas accessible via la galerie mais vous pourrez y accéder "
-"directement."
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:41
+msgid "You will receive an email when the review is complete. Until then, your add-on is not listed in our gallery but can be accessed directly from its details page."
+msgstr "Vous recevrez un courriel quand la revue sera finie. En attendant, votre module ne sera pas accessible via la galerie mais vous pourrez y accéder directement."
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:54
-msgid ""
-"Your add-on is displayed in our gallery and users are receiving automatic "
-"updates."
-msgstr ""
-"Votre module est affiché dans notre galerie et les utilisateurs reçoivent "
-"les mises à jour automatiques."
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:49
+msgid "Your add-on is displayed in our gallery and users are receiving automatic updates."
+msgstr "Votre module est affiché dans notre galerie et les utilisateurs reçoivent les mises à jour automatiques."
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:57
-msgid ""
-"Your add-on has been signed and can be bundled with an application "
-"installer."
-msgstr ""
-"Votre module a été signé et peut être intégré dans un installateur "
-"d'application."
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:52
+msgid "Your add-on has been signed and can be bundled with an application installer."
+msgstr "Votre module a été signé et peut être intégré dans un installateur d'application."
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:63
-msgid ""
-"Your add-on was disabled by a site administrator and is no longer shown in "
-"our gallery. If you have any questions, please email amo-admins@mozilla.org."
-msgstr ""
-"Votre module a été désactivé par un administrateur du site, il n'apparaît "
-"plus dans notre galerie. Si vous avez des questions, veuillez envoyer un "
-"courrier électronique à amo-admins@mozilla.org."
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:56
+msgid "Your add-on was disabled by a site administrator and is no longer shown in our gallery. If you have any questions, please email amo-admins@mozilla.org."
+msgstr "Votre module a été désactivé par un administrateur du site, il n'apparaît plus dans notre galerie. Si vous avez des questions, veuillez envoyer un courrier électronique à amo-admins@mozilla.org."
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:70
-msgid ""
-"Your add-on is displayed in our gallery as experimental and users are "
-"receiving automatic updates. Some features are unavailable to your add-on."
-msgstr ""
-"Votre module est affiché dans notre galerie comme expérimental et ses "
-"utilisateurs reçoivent les mises à jour. Certaines fonctionnalités ne sont "
-"pas disponibles pour votre module."
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:62
+msgid "Your add-on is displayed in our gallery as experimental and users are receiving automatic updates. Some features are unavailable to your add-on."
+msgstr "Votre module est affiché dans notre galerie comme expérimental et ses utilisateurs reçoivent les mises à jour. Certaines fonctionnalités ne sont pas disponibles pour votre module."
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:74
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:66
 msgid "Your add-on has been signed."
 msgstr "Votre module a été signé."
 
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:69
+msgid ""
+"You will receive an email when the full review is complete. Until then, your add-on is displayed in our gallery as experimental and users are receiving automatic updates. Some features are "
+"unavailable to your add-on."
+msgstr ""
+"Vous recevrez un courriel quand la vérification complète sera finie. En attendant, votre module est visible comme expérimental dans notre galerie et ses utilisateurs reçoivent les mises à jour. "
+"Certaines fonctionnalités ne sont pas disponibles pour votre module."
+
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:74
+msgid "You will receive an email when the full review is complete, making you able to bundle your add-on with an application installer."
+msgstr "Vous recevrez un courrier électronique lorsque la revue complète aura été effectuée, cela vous permettra d'intégrer votre module dans un installateur d'application."
+
 #: src/olympia/devhub/templates/devhub/includes/addon_details.html:79
-msgid ""
-"You will receive an email when the full review is complete. Until then, your"
-" add-on is displayed in our gallery as experimental and users are receiving "
-"automatic updates. Some features are unavailable to your add-on."
+msgid "All add-ons hosted in our gallery must now be reviewed by an editor. If you wish to continue hosting your add-on, please click to select a review process."
 msgstr ""
-"Vous recevrez un courriel quand la vérification complète sera finie. En "
-"attendant, votre module est visible comme expérimental dans notre galerie et"
-" ses utilisateurs reçoivent les mises à jour. Certaines fonctionnalités ne "
-"sont pas disponibles pour votre module."
+"Tous les modules qui sont hébergés dans notre galerie doivent être revus par un éditeur. Si vous souhaitez continuer à héberger votre module, veuillez cliquer pour sélectionner un processus de "
+"revue."
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:84
-msgid ""
-"You will receive an email when the full review is complete, making you able "
-"to bundle your add-on with an application installer."
-msgstr ""
-"Vous recevrez un courrier électronique lorsque la revue complète aura été "
-"effectuée, cela vous permettra d'intégrer votre module dans un installateur "
-"d'application."
-
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:91
-msgid ""
-"All add-ons hosted in our gallery must now be reviewed by an editor. If you "
-"wish to continue hosting your add-on, please click to select a review "
-"process."
-msgstr ""
-"Tous les modules qui sont hébergés dans notre galerie doivent être revus par"
-" un éditeur. Si vous souhaitez continuer à héberger votre module, veuillez "
-"cliquer pour sélectionner un processus de revue."
-
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:113
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:100
 msgid "Current Version:"
 msgstr "Version actuelle&nbsp;:"
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:115
-msgid ""
-"This is the version of your add-on that will be installed if someone clicks "
-"the Install button on addons.mozilla.org. It is only relevant for listed "
-"add-ons."
-msgstr ""
-"C'est la version de votre module qui sera installée lorsque quelqu'un clique"
-" sur le bouton Installer sur addons.mozilla.org. Ce champ est uniquement "
-"pertinent pour les modules répertoriés."
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:102
+msgid "This is the version of your add-on that will be installed if someone clicks the Install button on addons.mozilla.org. It is only relevant for listed add-ons."
+msgstr "C'est la version de votre module qui sera installée lorsque quelqu'un clique sur le bouton Installer sur addons.mozilla.org. Ce champ est uniquement pertinent pour les modules répertoriés."
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:123
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:110
 msgid "Created:"
 msgstr "Créé le&nbsp;:"
 
 #. {0} is a date. dennis-ignore: E201
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:125
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:131
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:112 src/olympia/devhub/templates/devhub/includes/addon_details.html:118
 #, python-format
 msgid "%%b %%e, %%Y"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:136
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:123
 msgid "Next Version:"
 msgstr "Prochaine version&nbsp;:"
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:138
-msgid ""
-"This is the newest uploaded version, however it isn’t live on the site yet."
-msgstr ""
-"C'est la dernière version envoyée, cependant elle n'est pas encore publiée "
-"sur le site."
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:125
+msgid "This is the newest uploaded version, however it isn’t live on the site yet."
+msgstr "C'est la dernière version envoyée, cependant elle n'est pas encore publiée sur le site."
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:144
-#: src/olympia/devhub/templates/devhub/versions/list.html:30
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:130 src/olympia/devhub/templates/devhub/versions/list.html:30
 msgid "Queues are not reviewed strictly in order"
 msgstr "Les files ne sont pas revues dans un ordre strict"
 
@@ -8264,16 +6281,11 @@ msgstr "Créer un profil développeur"
 
 #: src/olympia/devhub/templates/devhub/includes/addons_create_profile.html:24
 msgid ""
-"Your developer profile will tell users about you, why you made this add-on, "
-"and what's next for the add-on. This profile is required for add-ons "
-"requesting contributions, but can be useful for any developer interested in "
-"connecting with users."
+"Your developer profile will tell users about you, why you made this add-on, and what's next for the add-on. This profile is required for add-ons requesting contributions, but can be useful for any "
+"developer interested in connecting with users."
 msgstr ""
-"Votre profil développeur parle de vous aux utilisateurs, pourquoi vous avez "
-"réalisé ce module, et quel est son avenir. Ce profil est nécessaire pour les"
-" modules qui requièrent des contributions, mais il peut être utile pour "
-"n'importe quel développeur qui cherche à entrer en contact avec ses "
-"utilisateurs."
+"Votre profil développeur parle de vous aux utilisateurs, pourquoi vous avez réalisé ce module, et quel est son avenir. Ce profil est nécessaire pour les modules qui requièrent des contributions, "
+"mais il peut être utile pour n'importe quel développeur qui cherche à entrer en contact avec ses utilisateurs."
 
 #: src/olympia/devhub/templates/devhub/includes/addons_create_profile.html:32
 msgid "Make sure your user profile is up to date."
@@ -8282,25 +6294,15 @@ msgstr "Assurez-vous que votre profil utilisateur est à jour."
 #: src/olympia/devhub/templates/devhub/includes/addons_create_profile.html:34
 #, python-format
 msgid "<a href=\"%(url)s\"><strong>Update your user profile.</strong></a>"
-msgstr ""
-"<a href=\"%(url)s\"><strong>Mettez à jour votre profil "
-"utilisateur.</strong></a>"
+msgstr "<a href=\"%(url)s\"><strong>Mettez à jour votre profil utilisateur.</strong></a>"
 
 #: src/olympia/devhub/templates/devhub/includes/addons_create_profile.html:45
-msgid ""
-"Whether it was an idea while in line at the grocery store or the solution to"
-" one of life's great problems, share your story."
-msgstr ""
-"Que ce soit une idée qui vous est venue dans la file d'attente du marchand "
-"de légumes ou bien une solution à l'un des grands problèmes de la vie, "
-"partagez votre histoire."
+msgid "Whether it was an idea while in line at the grocery store or the solution to one of life's great problems, share your story."
+msgstr "Que ce soit une idée qui vous est venue dans la file d'attente du marchand de légumes ou bien une solution à l'un des grands problèmes de la vie, partagez votre histoire."
 
 #: src/olympia/devhub/templates/devhub/includes/addons_create_profile.html:61
-msgid ""
-"Telling your users what's coming soon will give them something to look "
-"forward to."
-msgstr ""
-"Dire à vos utilisateurs ce qui est prévu pour leur mettre l'eau à la bouche."
+msgid "Telling your users what's coming soon will give them something to look forward to."
+msgstr "Dire à vos utilisateurs ce qui est prévu pour leur mettre l'eau à la bouche."
 
 #: src/olympia/devhub/templates/devhub/includes/addons_edit_nav.html:23
 msgid "View All"
@@ -8331,13 +6333,8 @@ msgid "View the blog &#9658;"
 msgstr "Voir le blog &#9658;"
 
 #: src/olympia/devhub/templates/devhub/includes/license_form.html:6
-msgid ""
-"Please choose a license appropriate for the rights you grant on your source "
-"code. It is only relevant for listed add-ons."
-msgstr ""
-"Veuillez choisir une licence appropriée pour les droits que vous souhaitez "
-"appliquer à votre code source. Ce champ est uniquement pertinent pour les "
-"modules répertoriés."
+msgid "Please choose a license appropriate for the rights you grant on your source code. It is only relevant for listed add-ons."
+msgstr "Veuillez choisir une licence appropriée pour les droits que vous souhaitez appliquer à votre code source. Ce champ est uniquement pertinent pour les modules répertoriés."
 
 #. {0} is a list of HTML tags.
 #: src/olympia/devhub/templates/devhub/includes/macros.html:7
@@ -8352,8 +6349,7 @@ msgstr "Un peu de HTML supporté"
 msgid "Remove this application"
 msgstr "Enlever cette application"
 
-#. {0} is the maximum number of add-on categories allowed.                {1}
-#. is
+#. {0} is the maximum number of add-on categories allowed.                {1} is
 #. the application name.
 #: src/olympia/devhub/templates/devhub/includes/macros.html:70
 msgid "Select <b>up to {0}</b> {1} category for this add-on:"
@@ -8363,50 +6359,27 @@ msgstr[1] "Sélectionnez <b>jusqu'à {0}</b> {1} catégories pour ce module :"
 
 #: src/olympia/devhub/templates/devhub/includes/policy_form.html:4
 msgid ""
-"Users will be required to accept the following End-User License Agreement "
-"(EULA) prior to installing your add-on. The presence of a EULA significantly"
-" affects the number of downloads an add-on receives. Please note that a EULA"
-" is not the same as a code license, such as the GPL or MPL. It is only "
-"relevant for listed add-ons."
+"Users will be required to accept the following End-User License Agreement (EULA) prior to installing your add-on. The presence of a EULA significantly affects the number of downloads an add-on "
+"receives. Please note that a EULA is not the same as a code license, such as the GPL or MPL.It is only relevant for listed add-ons."
 msgstr ""
-"Les utilisateurs devront accepter l'accord de licence utilisateur final "
-"(EULA) avant de pouvoir installer le module. La présence d'un accord impacte"
-" le nombre de téléchargement de façon significative. Remarque&nbsp;: un "
-"accord de licence n'est pas la même chose qu'une licence de code comme la "
-"GPL ou la MPL. Ce champ est uniquement pertinent pour les modules "
-"répertoriés."
 
-#: src/olympia/devhub/templates/devhub/includes/policy_form.html:21
-msgid ""
-"If your add-on transmits any data from the user's computer, a privacy policy"
-" is required that explains what data is sent and how it is used. It is only "
-"relevant for listed add-ons."
+#: src/olympia/devhub/templates/devhub/includes/policy_form.html:24
+msgid "If your add-on transmits any data from the user's computer, a privacy policy is required that explains what data is sent and how it is used. It is only relevant for listed add-ons."
 msgstr ""
-"Si vous module transmet des données depuis l'ordinateur de l'utilisateur, "
-"une politique de confidentialité est nécessaire pour expliquer les données "
-"qui sont envoyées et comment elles sont appelées. Ce champ est uniquement "
-"pertinent pour les modules répertoriés."
+"Si vous module transmet des données depuis l'ordinateur de l'utilisateur, une politique de confidentialité est nécessaire pour expliquer les données qui sont envoyées et comment elles sont "
+"appelées. Ce champ est uniquement pertinent pour les modules répertoriés."
 
 #: src/olympia/devhub/templates/devhub/includes/source_form_field.html:2
-msgid ""
-"If your add-on contains binary or obfuscated code other than known "
-"libraries, upload its sources for review."
-msgstr ""
-"Si votre module contient des fichiers binaires ou du code compressé qui "
-"n'est pas celui de bibliothèques connues, veuillez envoyer les fichiers "
-"sources afin qu'ils soient revus."
+msgid "If your add-on contains binary or obfuscated code other than known libraries, upload its sources for review."
+msgstr "Si votre module contient des fichiers binaires ou du code compressé qui n'est pas celui de bibliothèques connues, veuillez envoyer les fichiers sources afin qu'ils soient revus."
 
 #: src/olympia/devhub/templates/devhub/includes/source_form_field.html:3
 msgid "Read more about the source code review policy."
 msgstr "En savoir plus sur la politique de revue du code source."
 
 #: src/olympia/devhub/templates/devhub/includes/version_file.html:20
-msgid ""
-"You cannot remove an individual file after the review process has begun. You"
-" must delete the entire version."
-msgstr ""
-"Vous ne pouvez pas supprimer un fichier seul une fois le processus de revue "
-"démarré. Vous devez supprimer la version complète."
+msgid "You cannot remove an individual file after the review process has begun. You must delete the entire version."
+msgstr "Vous ne pouvez pas supprimer un fichier seul une fois le processus de revue démarré. Vous devez supprimer la version complète."
 
 #: src/olympia/devhub/templates/devhub/includes/version_file.html:36
 msgid "This file will be deleted on save."
@@ -8418,9 +6391,7 @@ msgstr "Annuler"
 
 #: src/olympia/devhub/templates/devhub/payments/payments.html:21
 msgid "You are currently requesting <b>contributions</b> from users"
-msgstr ""
-"Vous demandez actuellement des <b>contributions</b> de la part des "
-"utilisateurs"
+msgstr "Vous demandez actuellement des <b>contributions</b> de la part des utilisateurs"
 
 #: src/olympia/devhub/templates/devhub/payments/payments.html:24
 #, python-format
@@ -8436,55 +6407,35 @@ msgid "Voluntary Contributions"
 msgstr "Contributions volontaire"
 
 #: src/olympia/devhub/templates/devhub/payments/payments.html:38
-msgid ""
-"Add-ons enrolled in our contributions program can request voluntary "
-"financial support from users."
-msgstr ""
-"Les modules inscrits au programme de contributions peuvent demander une "
-"assistance financière de la part des utilisateurs, sur la base du "
-"volontariat."
+msgid "Add-ons enrolled in our contributions program can request voluntary financial support from users."
+msgstr "Les modules inscrits au programme de contributions peuvent demander une assistance financière de la part des utilisateurs, sur la base du volontariat."
 
 #: src/olympia/devhub/templates/devhub/payments/payments.html:40
 msgid "Encourage users to support your add-on through your Developer Profile"
-msgstr ""
-"Encouragez les utilisateurs à soutenir votre module via votre profil "
-"développeur"
+msgstr "Encouragez les utilisateurs à soutenir votre module via votre profil développeur"
 
 #: src/olympia/devhub/templates/devhub/payments/payments.html:41
 msgid "Choose when and how users are asked to contribute"
-msgstr ""
-"Choisissez quand et comment les utilisateurs sont sollicités pour contribuer"
+msgstr "Choisissez quand et comment les utilisateurs sont sollicités pour contribuer"
 
 #: src/olympia/devhub/templates/devhub/payments/payments.html:42
-msgid ""
-"Receive contributions in your PayPal account or send them to an organization"
-" of your choice"
-msgstr ""
-"Recevoir des contributions dans votre compte PayPal ou bien les envoyer à "
-"une organisation de votre choix"
+msgid "Receive contributions in your PayPal account or send them to an organization of your choice"
+msgstr "Recevoir des contributions dans votre compte PayPal ou bien les envoyer à une organisation de votre choix"
 
 #: src/olympia/devhub/templates/devhub/payments/payments.html:46
 msgid "Contributions are only available for listed add-ons."
-msgstr ""
-"Les contributions sont uniquement disponibles pour les modules répertoriés."
+msgstr "Les contributions sont uniquement disponibles pour les modules répertoriés."
 
 #: src/olympia/devhub/templates/devhub/payments/payments.html:53
 #, python-format
-msgid ""
-"Contributions are only available for add-ons with a <a "
-"href=\"%(url)s\">completed developer profile</a>."
-msgstr ""
-"Les paiements sont uniquement disponibles pour les modules dont le <a "
-"href=\"%(url)s\">profil développeur est complet</a>."
+msgid "Contributions are only available for add-ons with a <a href=\"%(url)s\">completed developer profile</a>."
+msgstr "Les paiements sont uniquement disponibles pour les modules dont le <a href=\"%(url)s\">profil développeur est complet</a>."
 
 #: src/olympia/devhub/templates/devhub/payments/payments.html:59
 msgid "Contributions are only available for fully reviewed add-ons."
-msgstr ""
-"Les contributions sont uniquement accessibles aux modules ayant été "
-"complètement vérifiés."
+msgstr "Les contributions sont uniquement accessibles aux modules ayant été complètement vérifiés."
 
-#: src/olympia/devhub/templates/devhub/payments/payments.html:65
-#: src/olympia/devhub/templates/devhub/payments/voluntary.html:2
+#: src/olympia/devhub/templates/devhub/payments/payments.html:65 src/olympia/devhub/templates/devhub/payments/voluntary.html:2
 msgid "Set up Contributions"
 msgstr "Configurer les contributions"
 
@@ -8497,18 +6448,13 @@ msgstr "Étape 2. Tarification et disponibilité"
 msgid "or <a href=\"%(cancel)s\">Cancel</a>"
 msgstr "ou <a href=\"%(cancel)s\">Annuler</a>"
 
-#: src/olympia/devhub/templates/devhub/payments/voluntary.html:2
-#: src/olympia/stats/templates/stats/addon_report_menu.html:39
+#: src/olympia/devhub/templates/devhub/payments/voluntary.html:2 src/olympia/stats/templates/stats/addon_report_menu.html:39
 msgid "Contributions"
 msgstr "Contributions"
 
 #: src/olympia/devhub/templates/devhub/payments/voluntary.html:3
-msgid ""
-"Fill in the fields below to begin asking for voluntary contributions from "
-"users."
-msgstr ""
-"Remplissez les champs ci-dessous pour commencer à demander des contributions"
-" volontaires de la part des utilisateurs."
+msgid "Fill in the fields below to begin asking for voluntary contributions from users."
+msgstr "Remplissez les champs ci-dessous pour commencer à demander des contributions volontaires de la part des utilisateurs."
 
 #: src/olympia/devhub/templates/devhub/payments/voluntary.html:11
 msgid "Who will receive contributions to this add-on?"
@@ -8544,31 +6490,23 @@ msgstr "(Exemple : 3.99)"
 
 #: src/olympia/devhub/templates/devhub/payments/voluntary.html:39
 msgid "When should users be asked for contributions?"
-msgstr ""
-"Quand les utilisateurs doivent-ils être sollicités pour contributions ?"
+msgstr "Quand les utilisateurs doivent-ils être sollicités pour contributions ?"
 
 #: src/olympia/devhub/templates/devhub/payments/voluntary.html:44
 msgid "Send a thank-you note?"
 msgstr "Envoyer une note de remerciement ?"
 
 #: src/olympia/devhub/templates/devhub/payments/voluntary.html:47
-msgid ""
-"We'll automatically email users who contribute to your add-on with this "
-"message."
-msgstr ""
-"Nous enverrons automatiquement un courriel aux utilisateurs qui contribuent "
-"à votre module avec ce message."
+msgid "We'll automatically email users who contribute to your add-on with this message."
+msgstr "Nous enverrons automatiquement un courriel aux utilisateurs qui contribuent à votre module avec ce message."
 
 #: src/olympia/devhub/templates/devhub/payments/voluntary.html:49
 msgid ""
-"We recommend thanking the user and telling them how much you appreciate "
-"their support. You might also want to tell them about what's next for your "
-"add-on and about any other add-ons you've made for them to try."
+"We recommend thanking the user and telling them how much you appreciate their support. You might also want to tell them about what's next for your add-on and about any other add-ons you've made for"
+" them to try."
 msgstr ""
-"Nous vous recommandons de remercier l'utilisateur et lui dire combien vous "
-"appréciez leur aide. Vous pourriez également leur donner des informations "
-"sur le futur du module et leur parler de vos éventuels autres modules pour "
-"qu'ils les essayent."
+"Nous vous recommandons de remercier l'utilisateur et lui dire combien vous appréciez leur aide. Vous pourriez également leur donner des informations sur le futur du module et leur parler de vos "
+"éventuels autres modules pour qu'ils les essayent."
 
 #: src/olympia/devhub/templates/devhub/payments/voluntary.html:64
 msgid "Activate Contributions"
@@ -8582,148 +6520,91 @@ msgstr "ou <a id=\"setup-cancel\" href=\"#\">Annuler</a>"
 msgid "Transfer ownership"
 msgstr "Transférer la propriété"
 
-#: src/olympia/devhub/templates/devhub/personas/edit.html:77
-#: src/olympia/devhub/templates/devhub/personas/submit.html:31
+#: src/olympia/devhub/templates/devhub/personas/edit.html:77 src/olympia/devhub/templates/devhub/personas/submit.html:31
 msgid "Theme Details"
 msgstr "Détails du thème"
 
-#: src/olympia/devhub/templates/devhub/personas/edit.html:87
-#: src/olympia/devhub/templates/devhub/personas/submit.html:36
+#: src/olympia/devhub/templates/devhub/personas/edit.html:87 src/olympia/devhub/templates/devhub/personas/submit.html:36
 msgid "Supply a pretty URL for your detail page."
 msgstr "Donnez une adresse URL jolie pour votre page de détails."
 
-#: src/olympia/devhub/templates/devhub/personas/edit.html:92
-#: src/olympia/devhub/templates/devhub/personas/submit.html:41
+#: src/olympia/devhub/templates/devhub/personas/edit.html:92 src/olympia/devhub/templates/devhub/personas/submit.html:41
 msgid "Select the category that best describes your Theme."
 msgstr "Sélectionnez la catégorie qui correspond le mieux à votre thème."
 
-#: src/olympia/devhub/templates/devhub/personas/edit.html:95
-#: src/olympia/devhub/templates/devhub/personas/submit.html:44
+#: src/olympia/devhub/templates/devhub/personas/edit.html:95 src/olympia/devhub/templates/devhub/personas/submit.html:44
 msgid "Add some tags to describe your Theme."
 msgstr "Ajoutez des étiquettes pour décrire votre thème."
 
-#: src/olympia/devhub/templates/devhub/personas/edit.html:106
-msgid ""
-"A short explanation of your theme's basic functionality that is displayed in"
-" search and browse listings, as well as at the top of your theme's details "
-"page."
-msgstr ""
-"Une courte explication des fonctionnalités de base de votre thème, qui sera "
-"affichée dans les listes et résultats de recherche ainsi qu'en haut de la "
-"page de détails."
+#: src/olympia/devhub/templates/devhub/personas/edit.html:106 src/olympia/devhub/templates/devhub/personas/submit.html:54
+msgid "A short explanation of your theme's basic functionality that is displayed in search and browse listings, as well as at the top of your theme's details page."
+msgstr "Une courte explication des fonctionnalités de base de votre thème, qui sera affichée dans les listes et résultats de recherche ainsi qu'en haut de la page de détails."
 
-#: src/olympia/devhub/templates/devhub/personas/edit.html:122
-#: src/olympia/devhub/templates/devhub/personas/submit.html:68
+#: src/olympia/devhub/templates/devhub/personas/edit.html:122 src/olympia/devhub/templates/devhub/personas/submit.html:68
 msgid "Theme License"
 msgstr "Licence du thème"
 
-#: src/olympia/devhub/templates/devhub/personas/edit.html:126
-#: src/olympia/devhub/templates/devhub/personas/submit.html:72
+#: src/olympia/devhub/templates/devhub/personas/edit.html:126 src/olympia/devhub/templates/devhub/personas/submit.html:72
 msgid "Can others share your Theme, as long as you're given credit?"
-msgstr ""
-"Les autres peuvent-ils partager votre thème du moment qu'ils vous citent "
-"comme auteur ?"
+msgstr "Les autres peuvent-ils partager votre thème du moment qu'ils vous citent comme auteur ?"
 
-#: src/olympia/devhub/templates/devhub/personas/edit.html:132
-#: src/olympia/devhub/templates/devhub/personas/edit.html:153
-#: src/olympia/devhub/templates/devhub/personas/submit.html:78
+#: src/olympia/devhub/templates/devhub/personas/edit.html:132 src/olympia/devhub/templates/devhub/personas/edit.html:153 src/olympia/devhub/templates/devhub/personas/submit.html:78
 #: src/olympia/devhub/templates/devhub/personas/submit.html:99
-msgid ""
-"The licensor permits others to copy, distribute, display, and perform the "
-"work, including for commercial purposes."
-msgstr ""
-"L'ayant droit donne le droit aux autres de copier, distribuer, afficher et "
-"utiliser le travail, notamment pour des objectifs commerciaux."
+msgid "The licensor permits others to copy, distribute, display, and perform the work, including for commercial purposes."
+msgstr "L'ayant droit donne le droit aux autres de copier, distribuer, afficher et utiliser le travail, notamment pour des objectifs commerciaux."
 
-#: src/olympia/devhub/templates/devhub/personas/edit.html:141
-#: src/olympia/devhub/templates/devhub/personas/edit.html:162
-#: src/olympia/devhub/templates/devhub/personas/submit.html:87
+#: src/olympia/devhub/templates/devhub/personas/edit.html:141 src/olympia/devhub/templates/devhub/personas/edit.html:162 src/olympia/devhub/templates/devhub/personas/submit.html:87
 #: src/olympia/devhub/templates/devhub/personas/submit.html:108
-msgid ""
-"The licensor permits others to copy, distribute, display, and perform the "
-"work for non-commercial purposes only."
-msgstr ""
-"L'ayant droit donne le droit aux autres de copier, distribuer, afficher et "
-"utiliser le travail uniquement dans un but non commercial."
+msgid "The licensor permits others to copy, distribute, display, and perform the work for non-commercial purposes only."
+msgstr "L'ayant droit donne le droit aux autres de copier, distribuer, afficher et utiliser le travail uniquement dans un but non commercial."
 
-#: src/olympia/devhub/templates/devhub/personas/edit.html:147
-#: src/olympia/devhub/templates/devhub/personas/submit.html:93
+#: src/olympia/devhub/templates/devhub/personas/edit.html:147 src/olympia/devhub/templates/devhub/personas/submit.html:93
 msgid "Can others make commercial use of your Theme?"
-msgstr ""
-"Les autres peuvent-ils faire une utilisation commerciale de votre thème ?"
+msgstr "Les autres peuvent-ils faire une utilisation commerciale de votre thème ?"
 
-#: src/olympia/devhub/templates/devhub/personas/edit.html:168
-#: src/olympia/devhub/templates/devhub/personas/submit.html:114
+#: src/olympia/devhub/templates/devhub/personas/edit.html:168 src/olympia/devhub/templates/devhub/personas/submit.html:114
 msgid "Can others create derivative works from your Theme?"
 msgstr "Les autres peuvent-ils faire des travaux dérivés de votre thème ?"
 
-#: src/olympia/devhub/templates/devhub/personas/edit.html:174
-#: src/olympia/devhub/templates/devhub/personas/submit.html:120
-msgid ""
-"The licensor permits others to copy, distribute, display and perform the "
-"work, as well as make derivative works based on it."
-msgstr ""
-"L'ayant droit donne le droit aux autres de copier, distribuer, afficher et "
-"utiliser le travail ainsi que d'en faire des dérivés."
+#: src/olympia/devhub/templates/devhub/personas/edit.html:174 src/olympia/devhub/templates/devhub/personas/submit.html:120
+msgid "The licensor permits others to copy, distribute, display and perform the work, as well as make derivative works based on it."
+msgstr "L'ayant droit donne le droit aux autres de copier, distribuer, afficher et utiliser le travail ainsi que d'en faire des dérivés."
 
-#: src/olympia/devhub/templates/devhub/personas/edit.html:182
-#: src/olympia/devhub/templates/devhub/personas/submit.html:128
+#: src/olympia/devhub/templates/devhub/personas/edit.html:182 src/olympia/devhub/templates/devhub/personas/submit.html:128
 msgid "Yes, as long as they share alike"
 msgstr "Oui, du moment qu'ils partagent de manière identique"
 
-#: src/olympia/devhub/templates/devhub/personas/edit.html:183
-#: src/olympia/devhub/templates/devhub/personas/submit.html:129
-msgid ""
-"The licensor permits others to distribute derivativeworks only under the "
-"same license or one compatible with the one that governs the licensor's "
-"work."
-msgstr ""
-"L'ayant droit donne le droit aux autres de distribuer des travaux dérivés "
-"uniquement sous la même licence ou une licence compatible avec celle du "
-"travail de l'auteur originel."
+#: src/olympia/devhub/templates/devhub/personas/edit.html:183 src/olympia/devhub/templates/devhub/personas/submit.html:129
+msgid "The licensor permits others to distribute derivativeworks only under the same license or one compatible with the one that governs the licensor's work."
+msgstr "L'ayant droit donne le droit aux autres de distribuer des travaux dérivés uniquement sous la même licence ou une licence compatible avec celle du travail de l'auteur originel."
 
-#: src/olympia/devhub/templates/devhub/personas/edit.html:192
-#: src/olympia/devhub/templates/devhub/personas/submit.html:138
-msgid ""
-"The licensor permits others to copy, distribute and transmit only unaltered "
-"copies of the work — not derivative works based on it."
-msgstr ""
-"L'ayant droit donne le droit aux autres de copier, distribuer et transmettre"
-" uniquement des copies non altérées de l'œuvre."
+#: src/olympia/devhub/templates/devhub/personas/edit.html:192 src/olympia/devhub/templates/devhub/personas/submit.html:138
+msgid "The licensor permits others to copy, distribute and transmit only unaltered copies of the work — not derivative works based on it."
+msgstr "L'ayant droit donne le droit aux autres de copier, distribuer et transmettre uniquement des copies non altérées de l'œuvre."
 
-#: src/olympia/devhub/templates/devhub/personas/edit.html:199
-#: src/olympia/devhub/templates/devhub/personas/submit.html:145
+#: src/olympia/devhub/templates/devhub/personas/edit.html:199 src/olympia/devhub/templates/devhub/personas/submit.html:145
 msgid "Your Theme will be released under the following license:"
 msgstr "Votre thème sera mis à disposition sous la licence suivante :"
 
-#: src/olympia/devhub/templates/devhub/personas/edit.html:202
-#: src/olympia/devhub/templates/devhub/personas/submit.html:148
+#: src/olympia/devhub/templates/devhub/personas/edit.html:202 src/olympia/devhub/templates/devhub/personas/submit.html:148
 msgid "Select a different license."
 msgstr "Sélectionnez une licence différente."
 
-#: src/olympia/devhub/templates/devhub/personas/edit.html:207
-#: src/olympia/devhub/templates/devhub/personas/submit.html:153
+#: src/olympia/devhub/templates/devhub/personas/edit.html:207 src/olympia/devhub/templates/devhub/personas/submit.html:153
 msgid "Select a license for your Theme."
 msgstr "Sélectionnez une licence pour votre thème."
 
-#: src/olympia/devhub/templates/devhub/personas/edit.html:217
-#: src/olympia/devhub/templates/devhub/personas/submit.html:163
+#: src/olympia/devhub/templates/devhub/personas/edit.html:217 src/olympia/devhub/templates/devhub/personas/submit.html:163
 msgid "Theme Design"
 msgstr "Design du thème"
 
-#: src/olympia/devhub/templates/devhub/personas/edit.html:221
-#: src/olympia/devhub/templates/devhub/personas/edit.html:224
+#: src/olympia/devhub/templates/devhub/personas/edit.html:221 src/olympia/devhub/templates/devhub/personas/edit.html:224
 msgid "Upload New Design"
 msgstr "Envoyer un nouveau design"
 
 #: src/olympia/devhub/templates/devhub/personas/edit.html:226
-msgid ""
-"Upon upload and form submission, the AMO Team will review your updated "
-"design. Your current design will still be public in the meantime."
-msgstr ""
-"Après envoi et validation du formulaire, l'équipe AMO validera votre design "
-"mis à jour. Vos designs actuels restent public en attendant cette "
-"validation."
+msgid "Upon upload and form submission, the AMO Team will review your updated design. Your current design will still be public in the meantime."
+msgstr "Après envoi et validation du formulaire, l'équipe AMO validera votre design mis à jour. Vos designs actuels restent public en attendant cette validation."
 
 #: src/olympia/devhub/templates/devhub/personas/edit.html:241
 msgid "Your previously resubmitted design, which is under pending review."
@@ -8749,43 +6630,35 @@ msgstr "Entête"
 msgid "Footer"
 msgstr "Pied de page"
 
-#: src/olympia/devhub/templates/devhub/personas/edit.html:274
-#: src/olympia/devhub/templates/devhub/personas/submit.html:167
+#: src/olympia/devhub/templates/devhub/personas/edit.html:274 src/olympia/devhub/templates/devhub/personas/submit.html:167
 msgid "Select colors for your Theme."
 msgstr "Sélectionnez les couleurs de votre thème."
 
-#: src/olympia/devhub/templates/devhub/personas/edit.html:276
-#: src/olympia/devhub/templates/devhub/personas/submit.html:169
+#: src/olympia/devhub/templates/devhub/personas/edit.html:276 src/olympia/devhub/templates/devhub/personas/submit.html:169
 msgid "Foreground Text"
 msgstr "Texte d'avant plan"
 
-#: src/olympia/devhub/templates/devhub/personas/edit.html:277
-#: src/olympia/devhub/templates/devhub/personas/submit.html:170
+#: src/olympia/devhub/templates/devhub/personas/edit.html:277 src/olympia/devhub/templates/devhub/personas/submit.html:170
 msgid "This is the color of the tab text."
 msgstr "Ceci est la couleur du texte de l'onglet."
 
-#: src/olympia/devhub/templates/devhub/personas/edit.html:279
-#: src/olympia/devhub/templates/devhub/personas/submit.html:172
+#: src/olympia/devhub/templates/devhub/personas/edit.html:279 src/olympia/devhub/templates/devhub/personas/submit.html:172
 msgid "Background"
 msgstr "Arrière plan"
 
-#: src/olympia/devhub/templates/devhub/personas/edit.html:280
-#: src/olympia/devhub/templates/devhub/personas/submit.html:173
+#: src/olympia/devhub/templates/devhub/personas/edit.html:280 src/olympia/devhub/templates/devhub/personas/submit.html:173
 msgid "This is the color of the tabs."
 msgstr "Ceci est la couleur des onglets."
 
-#: src/olympia/devhub/templates/devhub/personas/edit.html:285
-#: src/olympia/devhub/templates/devhub/personas/submit.html:178
+#: src/olympia/devhub/templates/devhub/personas/edit.html:285 src/olympia/devhub/templates/devhub/personas/submit.html:178
 msgid "Preview"
 msgstr "Aperçu"
 
-#: src/olympia/devhub/templates/devhub/personas/edit.html:291
-#: src/olympia/devhub/templates/devhub/personas/submit.html:183
+#: src/olympia/devhub/templates/devhub/personas/edit.html:291 src/olympia/devhub/templates/devhub/personas/submit.html:183
 msgid "Your Theme's Name"
 msgstr "Nom de votre thème"
 
-#: src/olympia/devhub/templates/devhub/personas/edit.html:294
-#: src/olympia/devhub/templates/devhub/personas/submit.html:186
+#: src/olympia/devhub/templates/devhub/personas/edit.html:294 src/olympia/devhub/templates/devhub/personas/submit.html:186
 #, python-format
 msgid "by <a href=\"%(profile_url)s\" target=\"_blank\">%(user)s</a>"
 msgstr "par <a href=\"%(profile_url)s\" target=\"_blank\">%(user)s</a>"
@@ -8796,72 +6669,39 @@ msgstr "Créer un nouveau thème"
 
 #: src/olympia/devhub/templates/devhub/personas/submit.html:18
 #, python-format
-msgid ""
-"Background themes let you easily personalize the look of your Firefox. "
-"Submit your own design below, or <a href=\"%(submit_url)s\">learn how to "
-"create one</a>!"
-msgstr ""
-"Les thèmes d'arrière plan vous permettent de facilement personnaliser le "
-"look de votre Firefox. Envoyez le votre ci-dessous, ou <a "
-"href=\"%(submit_url)s\">apprenez comment en créer un</a> !"
+msgid "Background themes let you easily personalize the look of your Firefox. Submit your own design below, or <a href=\"%(submit_url)s\">learn how to create one</a>!"
+msgstr "Les thèmes d'arrière plan vous permettent de facilement personnaliser le look de votre Firefox. Envoyez le votre ci-dessous, ou <a href=\"%(submit_url)s\">apprenez comment en créer un</a> !"
 
 #: src/olympia/devhub/templates/devhub/personas/submit.html:33
 msgid "Give your Theme a name."
 msgstr "Donnez un nom à votre thème."
 
-#: src/olympia/devhub/templates/devhub/personas/submit.html:54
-msgid ""
-"A short explanation of your theme's basic functionality that is displayed in"
-" search and browse listings, as well as at the top of your theme's details "
-"page."
-msgstr ""
-"Une courte explication des fonctionnalités de base de votre thème, qui sera "
-"affichée dans les listes et résultats de recherche ainsi qu'en haut de la "
-"page de détails."
-
 #: src/olympia/devhub/templates/devhub/personas/submit.html:198
 #, python-format
 msgid ""
-"I agree to the <a href=\"%(agreement_url)s\" target=\"_blank\">Firefox Add-"
-"on Distribution Agreement</a> and to my information being handled as "
-"described in the <a href=\"%(privacy_notice_url)s\" "
+"I agree to the <a href=\"%(agreement_url)s\" target=\"_blank\">Firefox Add-on Distribution Agreement</a> and to my information being handled as described in the <a href=\"%(privacy_notice_url)s\" "
 "target=\"_blank\">Websites, Communications and Cookies Privacy Notice</a>."
 msgstr ""
-"J'accepte <a href=\"%(agreement_url)s\" target=\"_blank\">l'accord de "
-"distribution des modules complémentaires Firefox</a> et j'accepte que les "
-"informations qui me concernent soient gérées comme décrit dans <a "
-"href=\"%(privacy_notice_url)s\" target=\"_blank\">la note de confidentialité"
-" relative aux sites web, aux communications et aux cookies</a>."
+"J'accepte <a href=\"%(agreement_url)s\" target=\"_blank\">l'accord de distribution des modules complémentaires Firefox</a> et j'accepte que les informations qui me concernent soient gérées comme "
+"décrit dans <a href=\"%(privacy_notice_url)s\" target=\"_blank\">la note de confidentialité relative aux sites web, aux communications et aux cookies</a>."
 
 #: src/olympia/devhub/templates/devhub/personas/submit.html:205
 msgid "Submit Theme"
 msgstr "Envoyer le thème"
 
 #: src/olympia/devhub/templates/devhub/personas/submit_done.html:11
-msgid ""
-"Your theme has been submitted to the Review Queue. You'll receive an email "
-"once it has been reviewed, typically within 24 hours."
-msgstr ""
-"Votre thème a été ajouté à la liste de modération. Vous recevrez une "
-"courriel une fois modéré, généralement dans les 24 heures."
+msgid "Your theme has been submitted to the Review Queue. You'll receive an email once it has been reviewed, typically within 24 hours."
+msgstr "Votre thème a été ajouté à la liste de modération. Vous recevrez une courriel une fois modéré, généralement dans les 24 heures."
 
 #: src/olympia/devhub/templates/devhub/personas/submit_done.html:19
 #, python-format
-msgid ""
-"Provide more details about your theme by <a href=\"%(edit_url)s\">editing "
-"its listing</a>."
-msgstr ""
-"Fournissez plus de détails sur votre thème en <a "
-"href=\"%(edit_url)s\">éditant son listing</a>."
+msgid "Provide more details about your theme by <a href=\"%(edit_url)s\">editing its listing</a>."
+msgstr "Fournissez plus de détails sur votre thème en <a href=\"%(edit_url)s\">éditant son listing</a>."
 
 #: src/olympia/devhub/templates/devhub/personas/submit_done.html:25
 #, python-format
-msgid ""
-"View and subscribe to your theme's <a href=\"%(feed_url)s\">activity "
-"feed</a> to stay updated on reviews, collections, and more."
-msgstr ""
-"Voir et souscrire au <a href=\"%(feed_url)s\">flux d'activité</a> de votre "
-"thème pour rester au courant de ses validation, collections et plus encore."
+msgid "View and subscribe to your theme's <a href=\"%(feed_url)s\">activity feed</a> to stay updated on reviews, collections, and more."
+msgstr "Voir et souscrire au <a href=\"%(feed_url)s\">flux d'activité</a> de votre thème pour rester au courant de ses validation, collections et plus encore."
 
 #: src/olympia/devhub/templates/devhub/personas/submit_done.html:32
 #, python-format
@@ -8876,13 +6716,11 @@ msgstr "Sélectionnez une image d'entête pour votre thème."
 msgid "3000 &times; 200 pixels"
 msgstr "3000 &times; 200 pixels"
 
-#: src/olympia/devhub/templates/devhub/personas/includes/theme_design.html:9
-#: src/olympia/devhub/templates/devhub/personas/includes/theme_design.html:25
+#: src/olympia/devhub/templates/devhub/personas/includes/theme_design.html:9 src/olympia/devhub/templates/devhub/personas/includes/theme_design.html:25
 msgid "300 KB max"
 msgstr "300 KiO max"
 
-#: src/olympia/devhub/templates/devhub/personas/includes/theme_design.html:10
-#: src/olympia/devhub/templates/devhub/personas/includes/theme_design.html:26
+#: src/olympia/devhub/templates/devhub/personas/includes/theme_design.html:10 src/olympia/devhub/templates/devhub/personas/includes/theme_design.html:26
 msgid "PNG or JPG"
 msgstr "PNG ou JPG"
 
@@ -8911,66 +6749,31 @@ msgid "Select a different footer image"
 msgstr "Sélectionnez une image de pied de page différente pour votre Persona."
 
 #: src/olympia/devhub/templates/devhub/versions/add_file_modal.html:8
-msgid ""
-"Files added to reviewed versions must be reviewed before they will be "
-"available for download."
-msgstr ""
-"Les fichiers ajoutés à une version déjà vérifiée doivent être revus avant "
-"qu'ils ne soient disponibles au téléchargement."
+msgid "Files added to reviewed versions must be reviewed before they will be available for download."
+msgstr "Les fichiers ajoutés à une version déjà vérifiée doivent être revus avant qu'ils ne soient disponibles au téléchargement."
 
-#: src/olympia/devhub/templates/devhub/versions/add_file_modal.html:15
-#, python-format
-msgid ""
-"Submission of updates to unlisted add-ons for signing is currently in an "
-"open beta. Manual review may still be required for a large number of add-"
-"ons. Please <a href=\"%(url)s\" target=\"_blank\">report any bugs</a> that "
-"you encounter."
-msgstr ""
-"La soumission des mises à jour de modules non-répertoriés et en attente de "
-"signature est au stade expérimental. La révision manuelle peut s'avérer "
-"encore nécessaire pour un grand nombre de modules. Veuillez <a "
-"href=\"%(url)s\" target=\"_blank\">faire remonter les anomalies</a> que vous"
-" rencontrez."
-
-#: src/olympia/devhub/templates/devhub/versions/add_file_modal.html:35
+#: src/olympia/devhub/templates/devhub/versions/add_file_modal.html:24
 msgid "Select the target platform for this file."
 msgstr "Sélectionnez la plateforme cible pour ce fichier"
 
-#: src/olympia/devhub/templates/devhub/versions/add_file_modal.html:46
+#: src/olympia/devhub/templates/devhub/versions/add_file_modal.html:35
 msgid "Which review type would you like to nominate for?"
 msgstr "Pour quel type de revue souhaitez-vous vous inscrire&nbsp;?"
 
-#: src/olympia/devhub/templates/devhub/versions/add_file_modal.html:51
+#: src/olympia/devhub/templates/devhub/versions/add_file_modal.html:40
 msgid "Only publish this version to my beta channel."
 msgstr "Publier uniquement cette version sur le canal beta."
-
-#: src/olympia/devhub/templates/devhub/versions/add_file_modal.html:54
-#, python-format
-msgid ""
-"The behavior of the beta channel has changed to accommodate <a "
-"href=\"%(addon_signing_url)s\" target=\"_blank\">mandatory add-on "
-"signing</a>. The new process is currently in an open beta, and may change "
-"significantly in the near future. Please <a href=\"%(issues_url)s\" "
-"target=\"_blank\">report any bugs</a> that you encounter."
-msgstr ""
-"Le comportement du canal beta a été modifié pour gérer <a "
-"href=\"%(addon_signing_url)s\" target=\"_blank\">la signature obligatoire "
-"des modules</a>. Ce nouveau processus est actuellement en beta ouverte et "
-"peut être modifié dans un futur proche. Nous vous remercions de <a "
-"href=\"%(issues_url)s\" target=\"_blank\">rapporter les bogues</a> que vous "
-"rencontrez."
 
 #: src/olympia/devhub/templates/devhub/versions/edit.html:5
 msgid "Manage Version {0}"
 msgstr "Gérer la version {0}"
 
-#: src/olympia/devhub/templates/devhub/versions/edit.html:12
-#: src/olympia/devhub/templates/devhub/versions/list.html:3
+#: src/olympia/devhub/templates/devhub/versions/edit.html:12 src/olympia/devhub/templates/devhub/versions/list.html:3
 msgid "Status & Versions"
 msgstr "Statut et versions"
 
-#. {0} is an add-on name.
 # {0} is the name of the collection
+#. {0} is an add-on name.
 #: src/olympia/devhub/templates/devhub/versions/edit.html:16
 msgid "Manage {0}"
 msgstr "Gérer {0}"
@@ -8983,58 +6786,35 @@ msgstr "Fichiers"
 msgid "Upload Another File"
 msgstr "Envoyer un autre fichier"
 
-#: src/olympia/devhub/templates/devhub/versions/edit.html:45
-msgid ""
-"Adjusting application information here will allow users to install your add-"
-"on even if the install manifest in the package indicates that the add-on is "
-"incompatible."
-msgstr ""
-"Adapter les informations des applications ici permettra aux utilisateurs "
-"d'installer votre module, même si le manifeste d'installation dans le paquet"
-" indique que le module est incompatible."
-
 #: src/olympia/devhub/templates/devhub/versions/edit.html:74
 msgid ""
-"Information about changes in this release, new features, known bugs, and "
-"other useful information specific to this release/version. This information "
-"is also shown in the Add-ons Manager when updating."
+"Information about changes in this release, new features, known bugs, and other useful information specific to this release/version. This information is also shown in the Add-ons Manager when "
+"updating."
 msgstr ""
-"Information à propos des changements de cette versions, nouvelles "
-"fonctionnalités, problèmes connus et autres informations spécifiques à cette"
-" version. Cette information est également affichée dans le gestionnaire de "
-"modules complémentaires lors des mises à jour."
+"Information à propos des changements de cette versions, nouvelles fonctionnalités, problèmes connus et autres informations spécifiques à cette version. Cette information est également affichée dans"
+" le gestionnaire de modules complémentaires lors des mises à jour."
 
 #: src/olympia/devhub/templates/devhub/versions/edit.html:99
 msgid "Approval Status"
 msgstr "Statut d'approbation"
 
-#: src/olympia/devhub/templates/devhub/versions/edit.html:113
-#: src/olympia/editors/templates/editors/review.html:108
+#: src/olympia/devhub/templates/devhub/versions/edit.html:113 src/olympia/editors/templates/editors/review.html:108
 msgid "Notes for Reviewers"
 msgstr "Notes aux testeurs"
 
 #: src/olympia/devhub/templates/devhub/versions/edit.html:114
-msgid ""
-"Optionally, enter any information that may be useful to the Editor reviewing"
-" this add-on, such as test account information."
-msgstr ""
-"Optionnellement, entrez toute information qui peut être utile à l'Éditeur "
-"qui vérifiera ce module, tels que des comptes de test."
+msgid "Optionally, enter any information that may be useful to the Editor reviewing this add-on, such as test account information."
+msgstr "Optionnellement, entrez toute information qui peut être utile à l'Éditeur qui vérifiera ce module, tels que des comptes de test."
 
 #: src/olympia/devhub/templates/devhub/versions/edit.html:127
 msgid "Source code"
 msgstr "Code source"
 
 #: src/olympia/devhub/templates/devhub/versions/edit.html:128
-msgid ""
-"If your add-on contain binary or obfuscated code, make the source available "
-"here for reviewers."
-msgstr ""
-"Si votre module contient du code binaire ou compacté, mettez ici les sources"
-" à disposition pour les relecteurs."
+msgid "If your add-on contain binary or obfuscated code, make the source available here for reviewers."
+msgstr "Si votre module contient du code binaire ou compacté, mettez ici les sources à disposition pour les relecteurs."
 
-#: src/olympia/devhub/templates/devhub/versions/edit.html:145
-#: src/olympia/devhub/templates/devhub/versions/edit.html:149
+#: src/olympia/devhub/templates/devhub/versions/edit.html:145 src/olympia/devhub/templates/devhub/versions/edit.html:149
 msgid "Upload a new file"
 msgstr "Envoyer un nouveau fichier"
 
@@ -9101,9 +6881,7 @@ msgstr "Demander une revue complète"
 msgid "Request Preliminary Review"
 msgstr "Demander une revue préliminaire"
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:80
-#: src/olympia/devhub/templates/devhub/versions/list.html:327
-#: src/olympia/devhub/templates/devhub/versions/list.html:350
+#: src/olympia/devhub/templates/devhub/versions/list.html:80 src/olympia/devhub/templates/devhub/versions/list.html:325 src/olympia/devhub/templates/devhub/versions/list.html:348
 msgid "Cancel Review Request"
 msgstr "Annuler la demande de revue"
 
@@ -9116,36 +6894,24 @@ msgid "Listed:"
 msgstr "Répertorié&nbsp;:"
 
 #: src/olympia/devhub/templates/devhub/versions/list.html:102
-msgid ""
-"Visible to everyone on {0} and included in search results and listing pages"
-msgstr ""
-"Visible sur {0} et inclus dans les résultats de recherche et les pages "
-"listant les modules"
+msgid "Visible to everyone on {0} and included in search results and listing pages"
+msgstr "Visible sur {0} et inclus dans les résultats de recherche et les pages listant les modules"
 
 #: src/olympia/devhub/templates/devhub/versions/list.html:108
 msgid "Hidden:"
 msgstr "Masqué&nbsp;:"
 
 #: src/olympia/devhub/templates/devhub/versions/list.html:108
-msgid ""
-"Hosted on {0}, but hidden to anyone but authors. Used to temporarily hide "
-"listings or discontinue them."
-msgstr ""
-"Hébergé sur {0} mais visible uniquement pour les auteurs. Utilisé pour que "
-"le module n'apparaisse plus sur les listes, temporairement ou "
-"définitivement."
+msgid "Hosted on {0}, but hidden to anyone but authors. Used to temporarily hide listings or discontinue them."
+msgstr "Hébergé sur {0} mais visible uniquement pour les auteurs. Utilisé pour que le module n'apparaisse plus sur les listes, temporairement ou définitivement."
 
 #: src/olympia/devhub/templates/devhub/versions/list.html:114
 msgid "Unlisted:"
 msgstr "Non répertorié&nbsp;:"
 
 #: src/olympia/devhub/templates/devhub/versions/list.html:114
-msgid ""
-"Not distributed on {0}. Developers will upload new versions for signing and "
-"distribute the add-ons on their own. (beta)"
+msgid "Not distributed on {0}. Developers will upload new versions for signing and distribute the add-ons on their own."
 msgstr ""
-"Non distribué sur {0}. Les développeurs fourniront des nouvelles versions "
-"afin qu'elles soient signées et distribueront les modules eux-mêmes (beta)."
 
 #: src/olympia/devhub/templates/devhub/versions/list.html:122
 msgid "Current versions"
@@ -9155,18 +6921,13 @@ msgstr "Versions courantes"
 msgid "Currently on AMO"
 msgstr "Actuellement sur AMO"
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:129
-#: src/olympia/devhub/templates/devhub/versions/list.html:147
-#: src/olympia/devhub/templates/devhub/versions/list.html:164
-#: src/olympia/editors/templates/editors/includes/search_results_themes.html:7
-#: src/olympia/editors/templates/editors/themes/queue_list.html:50
+#: src/olympia/devhub/templates/devhub/versions/list.html:129 src/olympia/devhub/templates/devhub/versions/list.html:147 src/olympia/devhub/templates/devhub/versions/list.html:164
+#: src/olympia/editors/templates/editors/includes/search_results_themes.html:7 src/olympia/editors/templates/editors/themes/queue_list.html:50
 msgid "Status"
 msgstr "Statut"
 
 # Header for a column in a table
-#: src/olympia/devhub/templates/devhub/versions/list.html:130
-#: src/olympia/devhub/templates/devhub/versions/list.html:148
-#: src/olympia/devhub/templates/devhub/versions/list.html:165
+#: src/olympia/devhub/templates/devhub/versions/list.html:130 src/olympia/devhub/templates/devhub/versions/list.html:148 src/olympia/devhub/templates/devhub/versions/list.html:165
 #: src/olympia/editors/templates/editors/includes/files_view.html:11
 msgid "Validation"
 msgstr "Validation"
@@ -9188,15 +6949,10 @@ msgid "Full review may not be required"
 msgstr "Une revue complète n'est peut-être pas nécessaire"
 
 #: src/olympia/devhub/templates/devhub/versions/list.html:201
-msgid ""
-"Unlisted add-ons don't need Full Review unless they are distributed as part "
-"of an application installer. Read <a href=\"{link}\" target=\"_blank\">this "
-"documentation</a> for more information."
+msgid "Unlisted add-ons don't need Full Review unless they are distributed as part of an application installer. Read <a href=\"{link}\" target=\"_blank\">this documentation</a> for more information."
 msgstr ""
-"Une revue complète n'est pas nécessaire pour les modules non répertoriés à "
-"moins qu'ils soient distribués au sein d'un installateur d'application. "
-"Veuillez lire <a href=\"{link}\" target=\"_blank\">la documentation</a> pour"
-" plus d'informations."
+"Une revue complète n'est pas nécessaire pour les modules non répertoriés à moins qu'ils soient distribués au sein d'un installateur d'application. Veuillez lire <a href=\"{link}\" "
+"target=\"_blank\">la documentation</a> pour plus d'informations."
 
 #: src/olympia/devhub/templates/devhub/versions/list.html:209
 msgid "Request full review"
@@ -9207,138 +6963,90 @@ msgid "Delete Version {version}"
 msgstr "Supprimer la version {version}"
 
 #: src/olympia/devhub/templates/devhub/versions/list.html:218
-msgid ""
-"You are about to delete the current version of your add-on. This may cause "
-"your add-on status to change, or your listing to lose public visibility, if "
-"this is the only public version of your add-on."
+msgid "You are about to delete the current version of your add-on. This may cause your add-on status to change, or your listing to lose public visibility, if this is the only public version of your add-on."
 msgstr ""
-"Vous êtes sur le point de supprimer la version actuelle de votre module. "
-"Cela peut modifier le statut de votre module et la visibilité de celui-ci "
-"peut décroître si cette version est la seule qui soit publique pour ce "
-"module."
+"Vous êtes sur le point de supprimer la version actuelle de votre module. Cela peut modifier le statut de votre module et la visibilité de celui-ci peut décroître si cette version est la seule qui "
+"soit publique pour ce module."
 
 #: src/olympia/devhub/templates/devhub/versions/list.html:219
 msgid "Deleting this version will permanently delete:"
 msgstr "Supprimer cette version va effacer définitivement :"
 
 #: src/olympia/devhub/templates/devhub/versions/list.html:225
-msgid ""
-"<strong>Important:</strong> Once a version has been deleted, you may not "
-"upload a new version with the same version number."
-msgstr ""
-"<strong>Important&nbsp;:</strong> Une fois qu'une version a été supprimée, "
-"vous ne pouvez plus envoyer une nouvelle version possédant le même numéro de"
-" version."
+msgid "<strong>Important:</strong> Once a version has been deleted, you may not upload a new version with the same version number."
+msgstr "<strong>Important&nbsp;:</strong> Une fois qu'une version a été supprimée, vous ne pouvez plus envoyer une nouvelle version possédant le même numéro de version."
 
 #: src/olympia/devhub/templates/devhub/versions/list.html:230
-msgid ""
-"Deleting a version which has already been reviewed may also cause a "
-"significant delay in the review of your next update."
-msgstr ""
-"Supprimer une version qui a déjà été revue peut également entraîner un "
-"retard significatif pour la revue de la prochaine mise à jour."
-
-#: src/olympia/devhub/templates/devhub/versions/list.html:233
 msgid "Are you sure you wish to delete this version?"
 msgstr "Êtes-vous sûr de vouloir supprimer cette version ?"
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:238
+#: src/olympia/devhub/templates/devhub/versions/list.html:235
 msgid "Delete Version"
 msgstr "Supprimer la version"
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:240
+#: src/olympia/devhub/templates/devhub/versions/list.html:237
 msgid "Disable Version"
 msgstr "Désactiver la version"
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:247
+#: src/olympia/devhub/templates/devhub/versions/list.html:244
 msgid "Add a new Version"
 msgstr "Ajouter une nouvelle version"
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:249
+#: src/olympia/devhub/templates/devhub/versions/list.html:246
 msgid "Add Version"
 msgstr "Ajouter une version"
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:256
-#: src/olympia/devhub/templates/devhub/versions/list.html:274
+#: src/olympia/devhub/templates/devhub/versions/list.html:253 src/olympia/devhub/templates/devhub/versions/list.html:279
 msgid "Hide Add-on"
 msgstr "Masquer le module"
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:259
-msgid ""
-"Hiding your add-on will prevent it from appearing anywhere in our gallery "
-"and will stop users from receiving automatic updates."
-msgstr ""
-"Masquer le module empêchera que celui apparaisse dans la galerie et que les "
-"utilisateurs reçoivent des mises à jour automatiques."
+#: src/olympia/devhub/templates/devhub/versions/list.html:256
+msgid "Hiding your add-on will prevent it from appearing anywhere in our gallery and will stop users from receiving automatic updates."
+msgstr "Masquer le module empêchera que celui apparaisse dans la galerie et que les utilisateurs reçoivent des mises à jour automatiques."
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:265
+#: src/olympia/devhub/templates/devhub/versions/list.html:263
+msgid "The files awaiting review will be disabled and you will need to upload new versions."
+msgstr ""
+
+#: src/olympia/devhub/templates/devhub/versions/list.html:270
 msgid "Are you sure you wish to hide your add-on?"
 msgstr "Êtes-vous certain-e de vouloir masquer ce module&nbsp;?"
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:286
-#: src/olympia/devhub/templates/devhub/versions/list.html:315
+#: src/olympia/devhub/templates/devhub/versions/list.html:291 src/olympia/devhub/templates/devhub/versions/list.html:313
 msgid "Unlist Add-on"
 msgstr "Déférencer ce module"
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:289
+#: src/olympia/devhub/templates/devhub/versions/list.html:294
 #, python-format
 msgid ""
-"Unlisting your add-on will make it (and each of its versions/files) "
-"invisible on this website. It won't show up in searches, won't have a public"
-" facing page, and won't be updated automatically for current users. It is "
-"recommended for unlisted add-ons to provide a custom <a "
-"href=\"%(update_url)s\" target=\"_blank\">updateURL</a> in their manifest "
-"file for automatic updates."
+"Unlisting your add-on will make it (and each of its versions/files) invisible on this website. It won't show up in searches, won't have a public facing page, and won't be updated automatically for "
+"current users. It is recommended for unlisted add-ons to provide a custom <a href=\"%(update_url)s\" target=\"_blank\">updateURL</a> in their manifest file for automatic updates."
 msgstr ""
-"Retirer votre module de la liste le rendra invisible sur ce site web (de "
-"même que ses autres versions ou fichiers). Il n'apparaitra pas lors des "
-"recherches, n'aura pas une page publique et ne sera pas mis à jour pour les "
-"utilisateurs actuels. Il est recommandé pour les modules non listés de "
-"prévoir une URL de mise à jour personnalisée <a href=\"%(update_url)s\" "
-"target=\"_blank\">updateURL</a> dans leur fichier manifeste pour les mises à"
-" jour automatiques."
+"Retirer votre module de la liste le rendra invisible sur ce site web (de même que ses autres versions ou fichiers). Il n'apparaitra pas lors des recherches, n'aura pas une page publique et ne sera "
+"pas mis à jour pour les utilisateurs actuels. Il est recommandé pour les modules non listés de prévoir une URL de mise à jour personnalisée <a href=\"%(update_url)s\" "
+"target=\"_blank\">updateURL</a> dans leur fichier manifeste pour les mises à jour automatiques."
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:299
-#, python-format
-msgid ""
-"Switching add-ons to unlisted is currently in an open beta. Please <a "
-"href=\"%(url)s\" target=\"_blank\">report any bugs</a> that you encounter."
-msgstr ""
-"Le transfert des modules à la catégorie « non-répertorié » est au stade "
-"expérimental. Veuillez <a href=\"%(url)s\" target=\"_blank\">faire remonter "
-"les anomalies</a> que vous rencontrez."
-
-#: src/olympia/devhub/templates/devhub/versions/list.html:305
+#: src/olympia/devhub/templates/devhub/versions/list.html:303
 msgid "Unlisting an add-on is irreversible!"
 msgstr "Le déréférencement d'un module est irréversible&nbsp;!"
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:305
+#: src/olympia/devhub/templates/devhub/versions/list.html:303
 msgid "An unlisted add-on cannot be switched to be listed."
 msgstr "Un module déréférencé ne peut plus être répertorié."
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:307
+#: src/olympia/devhub/templates/devhub/versions/list.html:305
 msgid "Are you sure you wish to unlist your add-on?"
 msgstr "Voulez-vous vraiment déréférencer votre module&nbsp;?"
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:330
-msgid ""
-"Canceling your review request will leave your add-on as preliminarily "
-"reviewed."
-msgstr ""
-"Annuler la demande de revue laissera votre module comme revu de manière "
-"préliminaire."
+#: src/olympia/devhub/templates/devhub/versions/list.html:328
+msgid "Canceling your review request will leave your add-on as preliminarily reviewed."
+msgstr "Annuler la demande de revue laissera votre module comme revu de manière préliminaire."
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:335
-msgid ""
-"Canceling your review request will mark your add-on incomplete. If you do "
-"not complete your add-on after several days by re-requesting review, it will"
-" be deleted."
-msgstr ""
-"Annuler la demande de revue marquera votre module comme incomplet. Si vous "
-"ne complétez pas votre module après plusieurs jours, en re-demandant une "
-"revue, il sera supprimé."
+#: src/olympia/devhub/templates/devhub/versions/list.html:333
+msgid "Canceling your review request will mark your add-on incomplete. If you do not complete your add-on after several days by re-requesting review, it will be deleted."
+msgstr "Annuler la demande de revue marquera votre module comme incomplet. Si vous ne complétez pas votre module après plusieurs jours, en re-demandant une revue, il sera supprimé."
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:343
+#: src/olympia/devhub/templates/devhub/versions/list.html:341
 msgid "Are you sure you wish to cancel your review request?"
 msgstr "Voulez-vous vraiment annuler votre requête de revue ?"
 
@@ -9371,19 +7079,12 @@ msgid "Translate content on the web from and into over 40 languages."
 msgstr "Traduire le contenu sur le web entre plus de 40 langues."
 
 #: src/olympia/discovery/modules.py:171
-msgid ""
-"Easily connect to your social networks, and share or comment on the page "
-"you're visiting."
-msgstr ""
-"Connexion facile à vos réseaux sociaux, partagez ou commentez la page que "
-"vous visitez."
+msgid "Easily connect to your social networks, and share or comment on the page you're visiting."
+msgstr "Connexion facile à vos réseaux sociaux, partagez ou commentez la page que vous visitez."
 
 #: src/olympia/discovery/modules.py:173
-msgid ""
-"A quick view to compare prices when you shop online or search for flights."
-msgstr ""
-"Une vue rapide pour comparer les prix lorsque vous achetez en ligne ou "
-"préparez un voyage en avion."
+msgid "A quick view to compare prices when you shop online or search for flights."
+msgstr "Une vue rapide pour comparer les prix lorsque vous achetez en ligne ou préparez un voyage en avion."
 
 #: src/olympia/discovery/modules.py:183
 msgid "Firefox 4 Collection"
@@ -9426,25 +7127,16 @@ msgid "Add-ons that help you on your travels!"
 msgstr "Modules qui vous seront utiles pour vos voyages !"
 
 #: src/olympia/discovery/modules.py:226
-msgid ""
-"Displays a country flag depicting the location of the current website's "
-"server and more."
-msgstr ""
-"Affiche un drapeau du pays représentant la localisation du serveur du site "
-"web et plus."
+msgid "Displays a country flag depicting the location of the current website's server and more."
+msgstr "Affiche un drapeau du pays représentant la localisation du serveur du site web et plus."
 
 #: src/olympia/discovery/modules.py:228
 msgid "FoxClocks let you keep an eye on the time around the world."
-msgstr ""
-"FoxClocks vous permet de garder un œil sur le temps à travers le monde."
+msgstr "FoxClocks vous permet de garder un œil sur le temps à travers le monde."
 
 #: src/olympia/discovery/modules.py:230
-msgid ""
-"Automatically get the lowest price when you shop online or search for "
-"flights."
-msgstr ""
-"Obtenir automatiquement le prix le plus bas lorsque vous achetez en ligne ou"
-" que vous cherchez des vols."
+msgid "Automatically get the lowest price when you shop online or search for flights."
+msgstr "Obtenir automatiquement le prix le plus bas lorsque vous achetez en ligne ou que vous cherchez des vols."
 
 #: src/olympia/discovery/modules.py:240
 msgid "A+ add-ons for School"
@@ -9452,9 +7144,7 @@ msgstr "Modules A+ pour l'École"
 
 #: src/olympia/discovery/modules.py:241
 msgid "Add-ons for teachers, parents, and students heading back to school."
-msgstr ""
-"Des modules pour les enseignants, parents, et étudiants qui retournent à "
-"l'école."
+msgstr "Des modules pour les enseignants, parents, et étudiants qui retournent à l'école."
 
 #: src/olympia/discovery/modules.py:246
 msgid "Would you like to know which websites you can trust?"
@@ -9485,12 +7175,8 @@ msgid "Put a Theme on It!"
 msgstr "Mettez-lui un thème !"
 
 #: src/olympia/discovery/modules.py:281
-msgid ""
-"Visit addons.mozilla.org from Firefox for Android and dress up your mobile "
-"browser to match your style, mood, or the season."
-msgstr ""
-"Visitez addons.mozilla.org depuis Firefox pour Android et habillez votre "
-"navigateur mobile pour correspondre à votre style, humeur ou à la saison."
+msgid "Visit addons.mozilla.org from Firefox for Android and dress up your mobile browser to match your style, mood, or the season."
+msgstr "Visitez addons.mozilla.org depuis Firefox pour Android et habillez votre navigateur mobile pour correspondre à votre style, humeur ou à la saison."
 
 #: src/olympia/discovery/modules.py:290
 msgid "Get up and move!"
@@ -9514,16 +7200,11 @@ msgstr "Navigation sans soucis"
 
 #: src/olympia/discovery/modules.py:333
 msgid "Protect your privacy online with the add-ons in this collection."
-msgstr ""
-"Protégez votre vie privée en ligne avec les modules de cette collection."
+msgstr "Protégez votre vie privée en ligne avec les modules de cette collection."
 
 #: src/olympia/discovery/modules.py:342
-msgid ""
-"Great add-ons for work, fun, privacy, productivity&hellip; just about "
-"anything!"
-msgstr ""
-"D'excellents modules pour travailler, s'amuser, protéger votre vie privée ou"
-" améliorer votre productivité &hellip; pour tout !"
+msgid "Great add-ons for work, fun, privacy, productivity&hellip; just about anything!"
+msgstr "D'excellents modules pour travailler, s'amuser, protéger votre vie privée ou améliorer votre productivité &hellip; pour tout !"
 
 #: src/olympia/discovery/modules.py:350
 msgid "Add-ons for Australis Contest Winners"
@@ -9543,22 +7224,16 @@ msgstr "Que sont les modules ?"
 
 #: src/olympia/discovery/templates/discovery/pane.html:28
 #, python-format
-msgid ""
-"Add-ons are applications that let you personalize %(app)s with extra "
-"functionality or style. Try a time-saving sidebar, a weather notifier, or a "
-"themed look to make %(app)s your own."
+msgid "Add-ons are applications that let you personalize %(app)s with extra functionality or style. Try a time-saving sidebar, a weather notifier, or a themed look to make %(app)s your own."
 msgstr ""
-"Les modules complémentaires sont des applications permettant de "
-"personnaliser %(app)s avec des fonctionnalités ou des styles "
-"supplémentaires. Gagnez du temps avec un panneau latéral, surveillez la "
+"Les modules complémentaires sont des applications permettant de personnaliser %(app)s avec des fonctionnalités ou des styles supplémentaires. Gagnez du temps avec un panneau latéral, surveillez la "
 "météo ou changez l'apparence de %(app)s à votre guise."
 
 #: src/olympia/discovery/templates/discovery/pane.html:62
 msgid "Learn More About Add-ons"
 msgstr "En apprendre plus à propos des modules"
 
-#: src/olympia/discovery/templates/discovery/pane.html:66
-#: src/olympia/discovery/templates/discovery/pane.html:73
+#: src/olympia/discovery/templates/discovery/pane.html:66 src/olympia/discovery/templates/discovery/pane.html:73
 msgid "See all"
 msgstr "Voir tous"
 
@@ -9589,12 +7264,8 @@ msgstr "Bonjour, {0}"
 
 #: src/olympia/discovery/templates/discovery/pane_account.html:17
 #, python-format
-msgid ""
-"Thanks for using %(app)s and supporting <a href=\"%(url)s\">Mozilla's "
-"mission</a>!"
-msgstr ""
-"Merci d'utiliser %(app)s et de soutenir <a href=\"%(url)s\">la mission de "
-"Mozilla</a> !"
+msgid "Thanks for using %(app)s and supporting <a href=\"%(url)s\">Mozilla's mission</a>!"
+msgstr "Merci d'utiliser %(app)s et de soutenir <a href=\"%(url)s\">la mission de Mozilla</a> !"
 
 #: src/olympia/discovery/templates/discovery/pane_account.html:23
 msgid "Add-ons downloaded:"
@@ -9618,15 +7289,10 @@ msgstr "D'autres modules sur le pouce"
 
 #: src/olympia/discovery/templates/discovery/modules/go-mobile.html:8
 #, python-format
-msgid ""
-"Visit <a href=\"%(url)s\">firefox.com/m</a> to get Firefox on your phone and"
-" personalize your browser anytime, anywhere. Easily discover and install "
-"add-ons from the mobile Add-ons Manager."
+msgid "Visit <a href=\"%(url)s\">firefox.com/m</a> to get Firefox on your phone and personalize your browser anytime, anywhere. Easily discover and install add-ons from the mobile Add-ons Manager."
 msgstr ""
-"Visitez <a href=\"%(url)s\">firefox.com/m</a> pour obtenir Firefox sur votre"
-" téléphone, et personnaliser votre navigateur quand vous le voulez, où vous "
-"le voulez. Découvrez et installer facilement de nouveaux modules via le "
-"gestionnaire de modules mobile."
+"Visitez <a href=\"%(url)s\">firefox.com/m</a> pour obtenir Firefox sur votre téléphone, et personnaliser votre navigateur quand vous le voulez, où vous le voulez. Découvrez et installer facilement "
+"de nouveaux modules via le gestionnaire de modules mobile."
 
 #: src/olympia/discovery/templates/discovery/modules/go-mobile.html:13
 msgid "Get Mobile Add-ons"
@@ -9638,30 +7304,19 @@ msgstr "Achetez intelligemment en cette saison"
 
 #: src/olympia/discovery/templates/discovery/modules/holiday.html:5
 msgid "Find great add-ons to help you with all your holiday shopping needs."
-msgstr ""
-"Découvrez de super modules pour vous aider dans vos achats saisonniers."
+msgstr "Découvrez de super modules pour vous aider dans vos achats saisonniers."
 
 #: src/olympia/discovery/templates/discovery/modules/holiday.html:13
-msgid ""
-"Install the Amazon Browser Apps and receive special Amazon features right at"
-" your fingertips."
-msgstr ""
-"Installez l'application Amazon Browser et recevez des fonctionnalités "
-"spéciales d'Amazon directement sous vos doigts."
+msgid "Install the Amazon Browser Apps and receive special Amazon features right at your fingertips."
+msgstr "Installez l'application Amazon Browser et recevez des fonctionnalités spéciales d'Amazon directement sous vos doigts."
 
 #: src/olympia/discovery/templates/discovery/modules/holiday.html:22
-msgid ""
-"Keep an eye on your eBay activity wherever you are on the web when you "
-"install the eBay Sidebar for Firefox."
-msgstr ""
-"Gardez un œil sur votre activité eBay où que vous soyez sur le web grâce à "
-"cette barre latérale eBay pour Firefox."
+msgid "Keep an eye on your eBay activity wherever you are on the web when you install the eBay Sidebar for Firefox."
+msgstr "Gardez un œil sur votre activité eBay où que vous soyez sur le web grâce à cette barre latérale eBay pour Firefox."
 
 #: src/olympia/discovery/templates/discovery/modules/holiday.html:31
 msgid "See the entire holiday shopping add-on collection."
-msgstr ""
-"Découvrir la totalité de la collection de modules pour les achats "
-"saisonniers."
+msgstr "Découvrir la totalité de la collection de modules pour les achats saisonniers."
 
 #: src/olympia/discovery/templates/discovery/modules/monthly.html:8
 msgid "Mozilla&rsquo;s Pick of the Month!"
@@ -9734,19 +7389,19 @@ msgstr "module, éditeur ou commentaire"
 msgid "Search by add-on name / author email"
 msgstr "Rechercher par nom de module / courriel d'auteur"
 
-#: src/olympia/editors/forms.py:103
+#: src/olympia/editors/forms.py:103 src/olympia/editors/forms.py:244 src/olympia/editors/forms.py:257
 msgid "yes"
 msgstr "oui"
 
-#: src/olympia/editors/forms.py:104
+#: src/olympia/editors/forms.py:104 src/olympia/editors/forms.py:244 src/olympia/editors/forms.py:257
 msgid "no"
 msgstr "non"
 
-#: src/olympia/editors/forms.py:105
+#: src/olympia/editors/forms.py:105 src/olympia/editors/forms.py:245
 msgid "Admin Flag"
 msgstr "Étiquette Admin"
 
-#: src/olympia/editors/forms.py:113
+#: src/olympia/editors/forms.py:113 src/olympia/editors/forms.py:253
 msgid "Max. Version"
 msgstr "Version maximum"
 
@@ -9758,59 +7413,59 @@ msgstr "Jours depuis l'envoi"
 msgid "Add-on Types"
 msgstr "Types de modules"
 
-#: src/olympia/editors/forms.py:126 src/olympia/editors/helpers.py:267
+#: src/olympia/editors/forms.py:126 src/olympia/editors/helpers.py:279
 msgid "Platforms"
 msgstr "Plateformes"
 
+#: src/olympia/editors/forms.py:237
+msgid "Search by add-on name / author email / guid"
+msgstr ""
+
 #. L10n: 0 = platform, 1 = filename, 2 = status message
-#: src/olympia/editors/forms.py:238
+#: src/olympia/editors/forms.py:342
 #, python-format
 msgid "<strong>%s</strong> &middot; %s &middot; %s"
 msgstr "<strong>%s</strong> &middot; %s &middot; %s"
 
-#: src/olympia/editors/forms.py:252
+#: src/olympia/editors/forms.py:356
 msgid "Comments:"
 msgstr "Commentaires :"
 
-#: src/olympia/editors/forms.py:256
+#: src/olympia/editors/forms.py:360
 msgid "Operating systems:"
 msgstr "Systèmes d'exploitation :"
 
-#: src/olympia/editors/forms.py:258
+#: src/olympia/editors/forms.py:362
 msgid "Applications:"
 msgstr "Applications :"
 
-#: src/olympia/editors/forms.py:260
-msgid ""
-"Notify me the next time this add-on is updated. (Subsequent updates will not"
-" generate an email)"
-msgstr ""
-"Me notifier la prochaine fois que ce module est mis à jour. (les mises à "
-"jours suivantes ne génèreront pas de message)"
+#: src/olympia/editors/forms.py:364
+msgid "Notify me the next time this add-on is updated. (Subsequent updates will not generate an email)"
+msgstr "Me notifier la prochaine fois que ce module est mis à jour. (les mises à jours suivantes ne génèreront pas de message)"
 
-#: src/olympia/editors/forms.py:265
+#: src/olympia/editors/forms.py:369
 msgid "Clear Admin Review Flag"
 msgstr "Enlever le drapeau de demande de revue administrateur"
 
-#: src/olympia/editors/forms.py:267
+#: src/olympia/editors/forms.py:371
 msgid "Clear more info requested flag"
 msgstr "Supprimer l'indicateur de demande d'information"
 
-#: src/olympia/editors/forms.py:281
+#: src/olympia/editors/forms.py:385
 msgid "Choose a canned response..."
 msgstr "Choisissez une réponse enregistrée ..."
 
 #. L10n: Description of what can be searched for.
-#: src/olympia/editors/forms.py:324
+#: src/olympia/editors/forms.py:423
 msgid "theme name"
 msgstr "nom du thème"
 
-#: src/olympia/editors/forms.py:350
+#: src/olympia/editors/forms.py:449
 msgid "Someone else is reviewing this theme."
 msgstr "Quelqu'un d'autre est en train de vérifier ce thème."
 
 #. L10n: Description of what can be searched for.
-#: src/olympia/editors/forms.py:447
+#: src/olympia/editors/forms.py:546
 msgid "app, reviewer, or comment"
 msgstr "application, éditeur ou commentaire"
 
@@ -9826,295 +7481,266 @@ msgstr "En attente d'une revue préliminaire"
 msgid "Rejected or Unreviewed"
 msgstr "Rejeté ou non validé"
 
-#: src/olympia/editors/helpers.py:123 src/olympia/editors/helpers.py:136
+#: src/olympia/editors/helpers.py:125 src/olympia/editors/helpers.py:138
 msgid "Queue"
 msgstr "En file d'attente"
 
-#: src/olympia/editors/helpers.py:124
-#: src/olympia/editors/templates/editors/base.html:50
-#: src/olympia/editors/templates/editors/base.html:65
+#: src/olympia/editors/helpers.py:126 src/olympia/editors/templates/editors/base.html:50 src/olympia/editors/templates/editors/base.html:65
 msgid "Pending Updates"
 msgstr "Mises à jour en attentes"
 
-#: src/olympia/editors/helpers.py:125
-#: src/olympia/editors/templates/editors/base.html:48
-#: src/olympia/editors/templates/editors/base.html:63
+#: src/olympia/editors/helpers.py:127 src/olympia/editors/templates/editors/base.html:48 src/olympia/editors/templates/editors/base.html:63
 msgid "Full Reviews"
 msgstr "Revues complètes"
 
-#: src/olympia/editors/helpers.py:126
-#: src/olympia/editors/templates/editors/base.html:52
-#: src/olympia/editors/templates/editors/base.html:67
+#: src/olympia/editors/helpers.py:128 src/olympia/editors/templates/editors/base.html:52 src/olympia/editors/templates/editors/base.html:67
 msgid "Preliminary Reviews"
 msgstr "Revues préliminaires"
 
-#: src/olympia/editors/helpers.py:127
-#: src/olympia/editors/templates/editors/base.html:54
+#: src/olympia/editors/helpers.py:129 src/olympia/editors/templates/editors/base.html:54
 msgid "Moderated Reviews"
 msgstr "Revues modérées"
 
-#: src/olympia/editors/helpers.py:128
-#: src/olympia/editors/templates/editors/base.html:46
+#: src/olympia/editors/helpers.py:130 src/olympia/editors/templates/editors/base.html:46
 msgid "Fast Track"
 msgstr "Suivi rapide"
 
-#: src/olympia/editors/helpers.py:130
+#: src/olympia/editors/helpers.py:132
 msgid "Pending Themes"
 msgstr "Thèmes en attente"
 
-#: src/olympia/editors/helpers.py:131
-#: src/olympia/editors/templates/editors/themes/queue.html:4
+#: src/olympia/editors/helpers.py:133 src/olympia/editors/templates/editors/themes/queue.html:4
 msgid "Flagged Themes"
 msgstr "Thèmes notés"
 
-#: src/olympia/editors/helpers.py:132
+#: src/olympia/editors/helpers.py:134
 msgid "Update Themes"
 msgstr "Mettre à jour les thèmes"
 
-#: src/olympia/editors/helpers.py:137
+#: src/olympia/editors/helpers.py:139
 msgid "Unlisted Pending Updates"
 msgstr "Mises à jour en attente pour les modules déréférencés"
 
-#: src/olympia/editors/helpers.py:138
+#: src/olympia/editors/helpers.py:140
 msgid "Unlisted Full Reviews"
 msgstr "Revues complètes pour les modules déréférencés"
 
-#: src/olympia/editors/helpers.py:139
+#: src/olympia/editors/helpers.py:141
 msgid "Unlisted Preliminary Reviews"
 msgstr "Revues préliminaires pour les modules déréférencés"
 
-#: src/olympia/editors/helpers.py:170
+#: src/olympia/editors/helpers.py:142
+msgid "Unlisted All Add-ons"
+msgstr ""
+
+#: src/olympia/editors/helpers.py:173
 msgid "Fast Track ({0})"
 msgid_plural "Fast Track ({0})"
 msgstr[0] "Suivi rapide ({0})"
 msgstr[1] "Suivi rapide ({0})"
 
-#: src/olympia/editors/helpers.py:175
+#: src/olympia/editors/helpers.py:178
 msgid "Full Review ({0})"
 msgid_plural "Full Reviews ({0})"
 msgstr[0] "Revue complète ({0})"
 msgstr[1] "Revues complètes ({0})"
 
-#: src/olympia/editors/helpers.py:180
+#: src/olympia/editors/helpers.py:183
 msgid "Pending Update ({0})"
 msgid_plural "Pending Updates ({0})"
 msgstr[0] "Mise à jour en attente ({0})"
 msgstr[1] "Mises à jour en attente ({0})"
 
-#: src/olympia/editors/helpers.py:185
+#: src/olympia/editors/helpers.py:188
 msgid "Preliminary Review ({0})"
 msgid_plural "Preliminary Reviews ({0})"
 msgstr[0] "Revue préliminaire ({0})"
 msgstr[1] "Revues préliminaires ({0})"
 
-#: src/olympia/editors/helpers.py:190
+#: src/olympia/editors/helpers.py:193
 msgid "Moderated Review ({0})"
 msgid_plural "Moderated Reviews ({0})"
 msgstr[0] "Revue modérée ({0})"
 msgstr[1] "Revues modérées ({0})"
 
-#: src/olympia/editors/helpers.py:196
+#: src/olympia/editors/helpers.py:199
 msgid "Unlisted Full Review ({0})"
 msgid_plural "Unlisted Full Reviews ({0})"
 msgstr[0] "Revue complète pour les modules déréférencés ({0})"
 msgstr[1] "Revues complètes pour les modules déréférencés ({0})"
 
-#: src/olympia/editors/helpers.py:201
+#: src/olympia/editors/helpers.py:204
 msgid "Unlisted Pending Update ({0})"
 msgid_plural "Unlisted Pending Updates ({0})"
 msgstr[0] "Mise à jour en attente pour les modules déréférencés ({0})"
 msgstr[1] "Mises à jour en attente pour les modules déréférencés ({0})"
 
-#: src/olympia/editors/helpers.py:206
+#: src/olympia/editors/helpers.py:209
 msgid "Unlisted Preliminary Review ({0})"
 msgid_plural "Unlisted Preliminary Reviews ({0})"
 msgstr[0] "Revue préliminaire pour les modules déréférencés ({0})"
 msgstr[1] "Revues préliminaires pour les modules déréférencés ({0})"
 
-#: src/olympia/editors/helpers.py:261
-msgid "Addon"
-msgstr "Module"
+#: src/olympia/editors/helpers.py:214
+msgid "Unlisted All Add-ons ({0})"
+msgid_plural "Unlisted All Add-ons ({0})"
+msgstr[0] ""
+msgstr[1] ""
 
-#: src/olympia/editors/helpers.py:262
+#: src/olympia/editors/helpers.py:274
 msgid "Type"
 msgstr "Type"
 
-#: src/olympia/editors/helpers.py:263
+#: src/olympia/editors/helpers.py:275
 msgid "Waiting Time"
 msgstr "Temps d'attente"
 
-#: src/olympia/editors/helpers.py:264
-#: src/olympia/editors/templates/editors/review.html:285
+#: src/olympia/editors/helpers.py:276 src/olympia/editors/templates/editors/review.html:285
 msgid "Flags"
 msgstr "Drapeaux"
 
-#: src/olympia/editors/helpers.py:265
+#: src/olympia/editors/helpers.py:277
 msgid "Applications"
 msgstr "Applications"
 
-#: src/olympia/editors/helpers.py:270
+#: src/olympia/editors/helpers.py:282
 msgid "Additional"
 msgstr "Complémentaire"
 
-#: src/olympia/editors/helpers.py:285
+#: src/olympia/editors/helpers.py:302
 msgid "Site Specific"
 msgstr "Propre au site"
 
-#: src/olympia/editors/helpers.py:287
+#: src/olympia/editors/helpers.py:304
 msgid "Requires External Software"
 msgstr "Nécessite un logiciel externe"
 
-#: src/olympia/editors/helpers.py:289
+#: src/olympia/editors/helpers.py:306
 msgid "Binary Components"
 msgstr "Composants binaires"
 
-#: src/olympia/editors/helpers.py:313
+#: src/olympia/editors/helpers.py:339
 msgid "moments ago"
 msgstr "il y a peu"
 
 #. L10n: first argument is number of minutes
-#: src/olympia/editors/helpers.py:316
+#: src/olympia/editors/helpers.py:342
 msgid "{0} minute"
 msgid_plural "{0} minutes"
 msgstr[0] "{0} minute"
 msgstr[1] "{0} minutes"
 
 #. L10n: first argument is number of hours
-#: src/olympia/editors/helpers.py:320
+#: src/olympia/editors/helpers.py:346
 msgid "{0} hour"
 msgid_plural "{0} hours"
 msgstr[0] "{0} heure"
 msgstr[1] "{0} heures"
 
 #. L10n: first argument is number of days
-#: src/olympia/editors/helpers.py:324
+#: src/olympia/editors/helpers.py:350
 msgid "{0} day"
 msgid_plural "{0} days"
 msgstr[0] "{0} jour"
 msgstr[1] "{0} jours"
 
-#: src/olympia/editors/helpers.py:488
+#: src/olympia/editors/helpers.py:364
+msgid "Last Review"
+msgstr ""
+
+#: src/olympia/editors/helpers.py:366
+msgid "Last Update"
+msgstr ""
+
+#: src/olympia/editors/helpers.py:387
+msgid "No Reviews"
+msgstr ""
+
+#: src/olympia/editors/helpers.py:561
 msgid "Push to public"
 msgstr "Envoyer au public"
 
-#: src/olympia/editors/helpers.py:490
+#: src/olympia/editors/helpers.py:563
 msgid "Grant full review"
 msgstr "Accorder une revue complète"
 
-#: src/olympia/editors/helpers.py:505
+#: src/olympia/editors/helpers.py:578
 msgid "Request more information"
 msgstr "Demander plus d'informations"
 
-#: src/olympia/editors/helpers.py:508
+#: src/olympia/editors/helpers.py:581
 msgid "Request super-review"
 msgstr "Demander une super-revue"
 
-#: src/olympia/editors/helpers.py:519
+#: src/olympia/editors/helpers.py:592
 msgid "Grant preliminary review"
 msgstr "Accorder la revue préliminaire"
 
-#: src/olympia/editors/helpers.py:520
+#: src/olympia/editors/helpers.py:593
 msgid "This will mark the files as preliminarily reviewed."
 msgstr "Ceci marquera les fichiers comme validés préliminairement."
 
-#: src/olympia/editors/helpers.py:522
-msgid ""
-"Use this form to request more information from the author. They will receive"
-" an email and be able to answer here. You will be notified by email when "
-"they reply."
-msgstr ""
-"Utilisez ce formulaire pour demander plus d'informations de la part de "
-"l'auteur. Un courriel lui sera adressé et il pourra répondre ici. Vous serez"
-" notifié par courriel de leur réponse."
+#: src/olympia/editors/helpers.py:595
+msgid "Use this form to request more information from the author. They will receive an email and be able to answer here. You will be notified by email when they reply."
+msgstr "Utilisez ce formulaire pour demander plus d'informations de la part de l'auteur. Un courriel lui sera adressé et il pourra répondre ici. Vous serez notifié par courriel de leur réponse."
 
-#: src/olympia/editors/helpers.py:526
+#: src/olympia/editors/helpers.py:599
 msgid ""
-"If you have concerns about this add-on's security, copyright issues, or "
-"other concerns that an administrator should look into, enter your comments "
-"in the area below. They will be sent to administrators, not the author."
+"If you have concerns about this add-on's security, copyright issues, or other concerns that an administrator should look into, enter your comments in the area below. They will be sent to "
+"administrators, not the author."
 msgstr ""
-"Si vous avez des doutes relatifs à la sécurité de ce module, au respect du "
-"droit d'auteur, ou tout autre doute qu'un administrateur devrait vérifier, "
-"indiquez vos commentaires dans la zone ci-dessous. Ils seront envoyés à "
-"l'administrateur, pas à l'auteur."
+"Si vous avez des doutes relatifs à la sécurité de ce module, au respect du droit d'auteur, ou tout autre doute qu'un administrateur devrait vérifier, indiquez vos commentaires dans la zone ci-"
+"dessous. Ils seront envoyés à l'administrateur, pas à l'auteur."
 
-#: src/olympia/editors/helpers.py:532
+#: src/olympia/editors/helpers.py:605
 msgid "This will reject the add-on and remove it from the review queue."
-msgstr ""
-"Ceci rejette le module et le supprime de la file d'attente des revues."
+msgstr "Ceci rejette le module et le supprime de la file d'attente des revues."
 
-#: src/olympia/editors/helpers.py:534
+#: src/olympia/editors/helpers.py:607
 msgid "Make a comment on this version. The author won't be able to see this."
-msgstr ""
-"Faire un commentaire sur cette version. L'auteur ne pourra pas le voir."
+msgstr "Faire un commentaire sur cette version. L'auteur ne pourra pas le voir."
 
-#: src/olympia/editors/helpers.py:538
+#: src/olympia/editors/helpers.py:611
 msgid "This will reject the files and remove them from the review queue."
-msgstr ""
-"Ceci rejette les fichiers et les retire de la file d'attente de revues."
+msgstr "Ceci rejette les fichiers et les retire de la file d'attente de revues."
 
-#: src/olympia/editors/helpers.py:542
-msgid ""
-"This will mark the add-on as preliminarily reviewed. Future versions will "
-"undergo preliminary review."
-msgstr ""
-"Ceci marquera le module comme revu de manière préliminaire. Les versions "
-"suivantes passeront une revue préliminaire."
+#: src/olympia/editors/helpers.py:615
+msgid "This will mark the add-on as preliminarily reviewed. Future versions will undergo preliminary review."
+msgstr "Ceci marquera le module comme revu de manière préliminaire. Les versions suivantes passeront une revue préliminaire."
 
-#: src/olympia/editors/helpers.py:547
-msgid ""
-"This will mark the files as preliminarily reviewed. Future versions will "
-"undergo preliminary review."
-msgstr ""
-"Ceci marquera le module comme revue de manière préliminaire. Les versions "
-"suivantes passeront une revue préliminaire."
+#: src/olympia/editors/helpers.py:620
+msgid "This will mark the files as preliminarily reviewed. Future versions will undergo preliminary review."
+msgstr "Ceci marquera le module comme revue de manière préliminaire. Les versions suivantes passeront une revue préliminaire."
 
-#: src/olympia/editors/helpers.py:552
+#: src/olympia/editors/helpers.py:625
 msgid "Retain preliminary review"
 msgstr "Retenir la revue préliminaire"
 
-#: src/olympia/editors/helpers.py:553
-msgid ""
-"This will retain the add-on as preliminarily reviewed. Future versions will "
-"undergo preliminary review."
-msgstr ""
-"Ceci retiendra le module comme revu de manière préliminaire. Les versions "
-"suivantes passeront une revue préliminaire."
+#: src/olympia/editors/helpers.py:626
+msgid "This will retain the add-on as preliminarily reviewed. Future versions will undergo preliminary review."
+msgstr "Ceci retiendra le module comme revu de manière préliminaire. Les versions suivantes passeront une revue préliminaire."
 
-#: src/olympia/editors/helpers.py:558
-msgid ""
-"This will approve a sandboxed version of a public add-on to appear on the "
-"public side."
-msgstr ""
-"Ceci approuvera le passage d'une version publique d'un module depuis le "
-"bac-à-sable vers la partie publique du site."
+#: src/olympia/editors/helpers.py:631
+msgid "This will approve a sandboxed version of a public add-on to appear on the public side."
+msgstr "Ceci approuvera le passage d'une version publique d'un module depuis le bac-à-sable vers la partie publique du site."
 
-#: src/olympia/editors/helpers.py:561
-msgid ""
-"This will reject a version of a public add-on and remove it from the queue."
-msgstr ""
-"Ceci rejettera une version publique d'un module et la supprimera de la file "
-"d'attente."
-
-#: src/olympia/editors/helpers.py:564
-msgid ""
-"This will mark the add-on and its most recent version and files as public. "
-"Future versions will go into the sandbox until they are reviewed by an "
-"editor."
-msgstr ""
-"Ceci marquera le module et ses plus récentes versions et fichiers comme "
-"public. Les versions futures iront dans le bac-à-sable jusqu'à ce qu'elles "
-"soient vérifiées par un éditeur."
+#: src/olympia/editors/helpers.py:634
+msgid "This will reject a version of a public add-on and remove it from the queue."
+msgstr "Ceci rejettera une version publique d'un module et la supprimera de la file d'attente."
 
 #: src/olympia/editors/helpers.py:637
+msgid "This will mark the add-on and its most recent version and files as public. Future versions will go into the sandbox until they are reviewed by an editor."
+msgstr "Ceci marquera le module et ses plus récentes versions et fichiers comme public. Les versions futures iront dans le bac-à-sable jusqu'à ce qu'elles soient vérifiées par un éditeur."
+
+#: src/olympia/editors/helpers.py:714
 msgid "add-on"
 msgstr "module"
 
-#: src/olympia/editors/helpers.py:940 src/olympia/editors/helpers.py:960
+#: src/olympia/editors/helpers.py:1020 src/olympia/editors/helpers.py:1040
 msgid "Flagged"
 msgstr "Noté"
 
-#: src/olympia/editors/helpers.py:944 src/olympia/editors/helpers.py:963
+#: src/olympia/editors/helpers.py:1024 src/olympia/editors/helpers.py:1043
 msgid "Updates"
 msgstr "Mises à jour"
 
@@ -10166,77 +7792,70 @@ msgstr "Thème envoyé marqué pour vérification"
 msgid "A question about your Theme submission"
 msgstr "Une question à propos de votre envoi de thème"
 
-#: src/olympia/editors/views.py:144
+#: src/olympia/editors/views.py:146
 msgid "New Add-ons (Under 5 days)"
 msgstr "Nouveaux modules (moins de 5 jours)"
 
-#: src/olympia/editors/views.py:145
+#: src/olympia/editors/views.py:147
 msgid "Passable (5 to 10 days)"
 msgstr "Tièdes (5 à 10 jours)"
 
-#: src/olympia/editors/views.py:146
+#: src/olympia/editors/views.py:148
 msgid "Overdue (Over 10 days)"
 msgstr "Dépassés (plus de 10 jours)"
 
-#: src/olympia/editors/views.py:532
+#: src/olympia/editors/views.py:539
 msgid "An unknown error occurred"
 msgstr "Une erreur inconnue est survenue"
 
-#: src/olympia/editors/views.py:587
+#: src/olympia/editors/views.py:592
 msgid "Self-reviews are not allowed."
 msgstr "Les auto-revues ne sont pas autorisées."
 
-#: src/olympia/editors/views.py:609
+#: src/olympia/editors/views.py:613
 msgid "Review successfully processed."
 msgstr "Revue complétée avec succès."
 
-#: src/olympia/editors/views.py:807
+#: src/olympia/editors/views.py:812
 msgid "was approved"
 msgstr "a été approuvé"
 
-#: src/olympia/editors/views.py:808
+#: src/olympia/editors/views.py:813
 msgid "given preliminary review"
 msgstr "a reçu une revue préliminaire"
 
-#: src/olympia/editors/views.py:809
+#: src/olympia/editors/views.py:814
 msgid "rejected"
 msgstr "rejeté"
 
-#: src/olympia/editors/views.py:810
+#: src/olympia/editors/views.py:815
 msgctxt "editors_review_history_nominated_adminreview"
 msgid "escalated"
 msgstr "escaladé"
 
-#: src/olympia/editors/views.py:812
+#: src/olympia/editors/views.py:817
 msgid "needs more information"
 msgstr "besoin de plus d'informations"
 
-#: src/olympia/editors/views.py:813
+#: src/olympia/editors/views.py:818
 msgid "needs super review"
 msgstr "besoin d'une super-revue"
 
-#: src/olympia/editors/views.py:814
+#: src/olympia/editors/views.py:819
 msgid "commented"
 msgstr "a été commenté"
 
 #: src/olympia/editors/views_themes.py:326
 msgid "{0} theme review successfully processed (+{1} points, {2} total)."
-msgid_plural ""
-"{0} theme reviews successfully processed (+{1} points, {2} total)."
-msgstr[0] ""
-"{0} validation de thème réalisée avec succès (+{1} points, {2} au total)."
-msgstr[1] ""
-"{0} validation de thèmes réalisées avec succès (+{1} points, {2} au total)."
+msgid_plural "{0} theme reviews successfully processed (+{1} points, {2} total)."
+msgstr[0] "{0} validation de thème réalisée avec succès (+{1} points, {2} au total)."
+msgstr[1] "{0} validation de thèmes réalisées avec succès (+{1} points, {2} au total)."
 
 #: src/olympia/editors/views_themes.py:341
-msgid ""
-"Your theme locks have successfully been released. Other reviewers may now "
-"review those released themes. You may have to refresh the page to see the "
-"changes reflected in the table below."
+msgid "Your theme locks have successfully been released. Other reviewers may now review those released themes. You may have to refresh the page to see the changes reflected in the table below."
 msgstr ""
-"Les verrous de votre thème ont été rendus avec succès. D'autres validateurs "
-"peuvent maintenant vérifier ces thèmes. Vous devrez recharger la page pour "
-"voir les changements dans le tableau ci-dessous."
+"Les verrous de votre thème ont été rendus avec succès. D'autres validateurs peuvent maintenant vérifier ces thèmes. Vous devrez recharger la page pour voir les changements dans le tableau ci-"
+"dessous."
 
 #: src/olympia/editors/templates/editors/abuse_reports.html:4
 msgid "{addon} :: Abuse Reports"
@@ -10260,9 +7879,7 @@ msgstr "<i>anonyme</i> le %(date)s [%(ip_address)s]"
 msgid "Return to the Editor Tools homepage"
 msgstr "Retourner à la page d'accueil des outils pour l'éditeur"
 
-#: src/olympia/editors/templates/editors/base.html:43
-#: src/olympia/editors/templates/editors/themes/base.html:14
-#: src/olympia/editors/templates/editors/themes/base.html:28
+#: src/olympia/editors/templates/editors/base.html:43 src/olympia/editors/templates/editors/themes/base.html:14 src/olympia/editors/templates/editors/themes/base.html:28
 #: src/olympia/editors/templates/editors/themes/queue.html:25
 msgid "Queues"
 msgstr "Files d'attente"
@@ -10271,71 +7888,51 @@ msgstr "Files d'attente"
 msgid "Unlisted Queues"
 msgstr "Files pour les modules déréférencés"
 
-#: src/olympia/editors/templates/editors/base.html:72
-#: src/olympia/editors/templates/editors/performance.html:6
+#: src/olympia/editors/templates/editors/base.html:74 src/olympia/editors/templates/editors/performance.html:6
 msgid "Performance"
 msgstr "Performance"
 
-#: src/olympia/editors/templates/editors/base.html:75
-#: src/olympia/editors/templates/editors/themes/base.html:19
-#: src/olympia/editors/templates/editors/themes/base.html:38
+#: src/olympia/editors/templates/editors/base.html:77 src/olympia/editors/templates/editors/themes/base.html:19 src/olympia/editors/templates/editors/themes/base.html:38
 msgid "Logs"
 msgstr "Journaux"
 
-#: src/olympia/editors/templates/editors/base.html:78
-#: src/olympia/editors/templates/editors/reviewlog.html:4
-#: src/olympia/editors/templates/editors/reviewlog.html:27
+#: src/olympia/editors/templates/editors/base.html:80 src/olympia/editors/templates/editors/reviewlog.html:4 src/olympia/editors/templates/editors/reviewlog.html:27
 msgid "Add-on Review Log"
 msgstr "Journal de revue du module"
 
-#: src/olympia/editors/templates/editors/base.html:80
-#: src/olympia/editors/templates/editors/eventlog.html:4
-#: src/olympia/editors/templates/editors/eventlog.html:8
+#: src/olympia/editors/templates/editors/base.html:82 src/olympia/editors/templates/editors/eventlog.html:4 src/olympia/editors/templates/editors/eventlog.html:8
 #: src/olympia/editors/templates/editors/eventlog_detail.html:4
 msgid "Moderated Review Log"
 msgstr "Journal de revue modéré"
 
-#: src/olympia/editors/templates/editors/base.html:82
-#: src/olympia/editors/templates/editors/beta_signed_log.html:4
-#: src/olympia/editors/templates/editors/beta_signed_log.html:8
+#: src/olympia/editors/templates/editors/base.html:84 src/olympia/editors/templates/editors/beta_signed_log.html:4 src/olympia/editors/templates/editors/beta_signed_log.html:8
 msgid "Signed Beta Files Log"
 msgstr "Journal pour les fichiers beta signés"
 
-#: src/olympia/editors/templates/editors/base.html:87
-#: src/olympia/editors/templates/editors/includes/daily-message.html:4
+#: src/olympia/editors/templates/editors/base.html:89 src/olympia/editors/templates/editors/includes/daily-message.html:4
 msgid "Announcement"
 msgstr "Annonce"
 
 #. "Filter" is a button label (verb)
-#: src/olympia/editors/templates/editors/beta_signed_log.html:17
-#: src/olympia/editors/templates/editors/eventlog.html:24
-#: src/olympia/editors/templates/editors/reviewlog.html:21
-#: src/olympia/editors/templates/editors/themes/macros.html:45
-#: src/olympia/editors/templates/editors/themes/includes/logs_filter_deleted.html:12
+#: src/olympia/editors/templates/editors/beta_signed_log.html:17 src/olympia/editors/templates/editors/eventlog.html:24 src/olympia/editors/templates/editors/reviewlog.html:21
+#: src/olympia/editors/templates/editors/themes/macros.html:45 src/olympia/editors/templates/editors/themes/includes/logs_filter_deleted.html:12
 msgid "Filter"
 msgstr "Filtrer"
 
-#: src/olympia/editors/templates/editors/beta_signed_log.html:23
-#: src/olympia/editors/templates/editors/eventlog.html:30
-#: src/olympia/editors/templates/editors/reviewlog.html:34
+#: src/olympia/editors/templates/editors/beta_signed_log.html:23 src/olympia/editors/templates/editors/eventlog.html:30 src/olympia/editors/templates/editors/reviewlog.html:34
 #: src/olympia/editors/templates/editors/themes/logs.html:16
 msgid "Date"
 msgstr "Date"
 
-#: src/olympia/editors/templates/editors/beta_signed_log.html:24
-#: src/olympia/editors/templates/editors/eventlog.html:31
-#: src/olympia/editors/templates/editors/reviewlog.html:35
+#: src/olympia/editors/templates/editors/beta_signed_log.html:24 src/olympia/editors/templates/editors/eventlog.html:31 src/olympia/editors/templates/editors/reviewlog.html:35
 msgid "Event"
 msgstr "Évènement"
 
-#: src/olympia/editors/templates/editors/beta_signed_log.html:37
-#: src/olympia/editors/templates/editors/eventlog.html:44
-#: src/olympia/editors/templates/editors/home.html:180
+#: src/olympia/editors/templates/editors/beta_signed_log.html:37 src/olympia/editors/templates/editors/eventlog.html:44 src/olympia/editors/templates/editors/home.html:180
 msgid "More details."
 msgstr "Plus de détails."
 
-#: src/olympia/editors/templates/editors/beta_signed_log.html:46
-#: src/olympia/editors/templates/editors/eventlog.html:53
+#: src/olympia/editors/templates/editors/beta_signed_log.html:46 src/olympia/editors/templates/editors/eventlog.html:53
 msgid "No events found for this period."
 msgstr "Pas d'évènement trouvé pour cette période."
 
@@ -10385,20 +7982,17 @@ msgid_plural "Preliminary Reviews ({num})"
 msgstr[0] "Revue préliminaire ({num})"
 msgstr[1] "Revues préliminaires ({num})"
 
-#: src/olympia/editors/templates/editors/home.html:36
-#: src/olympia/editors/templates/editors/home.html:86
+#: src/olympia/editors/templates/editors/home.html:36 src/olympia/editors/templates/editors/home.html:86
 msgid "Current waiting times:"
 msgstr "Derniers temps d'attente :"
 
-#: src/olympia/editors/templates/editors/home.html:44
-#: src/olympia/editors/templates/editors/home.html:94
+#: src/olympia/editors/templates/editors/home.html:44 src/olympia/editors/templates/editors/home.html:94
 msgid "{0} add-on"
 msgid_plural "{0} add-ons"
 msgstr[0] "{0} module"
 msgstr[1] "{0} modules"
 
-#: src/olympia/editors/templates/editors/home.html:45
-#: src/olympia/editors/templates/editors/home.html:95
+#: src/olympia/editors/templates/editors/home.html:45 src/olympia/editors/templates/editors/home.html:95
 #, python-format
 msgid "{0}%%"
 msgstr ""
@@ -10421,14 +8015,11 @@ msgid_plural "Unlisted Preliminary Reviews ({num})"
 msgstr[0] "Revue préliminaire pour les modules déréférencés ({num})"
 msgstr[1] "Revues préliminaires pour les modules déréférencés ({num})"
 
-#: src/olympia/editors/templates/editors/home.html:109
-#: src/olympia/editors/templates/editors/performance.html:37
-#: src/olympia/editors/templates/editors/themes/home.html:54
+#: src/olympia/editors/templates/editors/home.html:109 src/olympia/editors/templates/editors/performance.html:37 src/olympia/editors/templates/editors/themes/home.html:54
 msgid "Total Reviews"
 msgstr "Total des revues"
 
-#: src/olympia/editors/templates/editors/home.html:110
-#: src/olympia/editors/templates/editors/themes/home.html:55
+#: src/olympia/editors/templates/editors/home.html:110 src/olympia/editors/templates/editors/themes/home.html:55
 msgid "Reviews This Month"
 msgstr "Revues du mois"
 
@@ -10436,8 +8027,7 @@ msgstr "Revues du mois"
 msgid "New Editors"
 msgstr "Nouveaux éditeurs"
 
-#: src/olympia/editors/templates/editors/home.html:126
-#: src/olympia/editors/templates/editors/home.html:141
+#: src/olympia/editors/templates/editors/home.html:126 src/olympia/editors/templates/editors/home.html:141
 msgid "You're #{0} with {1} reviews"
 msgstr "Vous êtes #{0} avec {1} tests"
 
@@ -10448,13 +8038,11 @@ msgid_plural "Moderated Reviews ({num})"
 msgstr[0] "Revue modérée ({num})"
 msgstr[1] "Revues modérées ({num})"
 
-#: src/olympia/editors/templates/editors/leaderboard.html:3
-#: src/olympia/editors/templates/editors/includes/reviewers_score_bar.html:56
+#: src/olympia/editors/templates/editors/leaderboard.html:3 src/olympia/editors/templates/editors/includes/reviewers_score_bar.html:56
 msgid "Reviewer Leaderboard"
 msgstr "Récapitulatif de l'éditeur"
 
-#: src/olympia/editors/templates/editors/leaderboard.html:18
-#: src/olympia/editors/templates/editors/performance.html:65
+#: src/olympia/editors/templates/editors/leaderboard.html:18 src/olympia/editors/templates/editors/performance.html:65
 msgid "No review points awarded yet."
 msgstr "Pas encore de point de vérification gagné."
 
@@ -10474,8 +8062,7 @@ msgstr "Message du jour"
 msgid "Update message of the day"
 msgstr "Mettre à jour le message du jour"
 
-#: src/olympia/editors/templates/editors/motd.html:15
-#: src/olympia/editors/templates/editors/review.html:224
+#: src/olympia/editors/templates/editors/motd.html:15 src/olympia/editors/templates/editors/review.html:224
 msgid "Save"
 msgstr "Sauvegarder"
 
@@ -10543,51 +8130,45 @@ msgstr "Recherche avancée"
 msgid "clear search"
 msgstr "effacer la recherche"
 
-#: src/olympia/editors/templates/editors/queue.html:72
-#: src/olympia/editors/templates/editors/queue.html:122
+#: src/olympia/editors/templates/editors/queue.html:78 src/olympia/editors/templates/editors/queue.html:128
 msgid "Process Reviews"
 msgstr "Procéder aux revues"
 
-#: src/olympia/editors/templates/editors/queue.html:80
+#: src/olympia/editors/templates/editors/queue.html:86
 msgid "Moderation actions:"
 msgstr "Actions de modération :"
 
-#: src/olympia/editors/templates/editors/queue.html:90
+#: src/olympia/editors/templates/editors/queue.html:96
 #, python-format
 msgid "by %(user)s on %(date)s %(stars)s (%(locale)s)"
 msgstr "par %(user)s le %(date)s %(stars)s (%(locale)s)"
 
-#: src/olympia/editors/templates/editors/queue.html:106
+#: src/olympia/editors/templates/editors/queue.html:112
 #, python-format
-msgid ""
-"<strong>%(reason)s</strong> <span class=\"light\">Flagged by %(user)s on "
-"%(date)s</span>"
-msgstr ""
-"<strong>%(reason)s</strong> <span class=\"light\">Noté par %(user)s le "
-"%(date)s</span>"
+msgid "<strong>%(reason)s</strong> <span class=\"light\">Flagged by %(user)s on %(date)s</span>"
+msgstr "<strong>%(reason)s</strong> <span class=\"light\">Noté par %(user)s le %(date)s</span>"
 
-#: src/olympia/editors/templates/editors/queue.html:119
+#: src/olympia/editors/templates/editors/queue.html:125
 msgid "All reviews have been moderated. Good work!"
 msgstr "Toutes les revues ont été modérées. Bon travail !"
 
-#: src/olympia/editors/templates/editors/queue.html:161
+#: src/olympia/editors/templates/editors/queue.html:167
 msgid "Version Notes / Notes for Reviewer"
 msgstr "Notes de version / Notes pour le testeur"
 
-#: src/olympia/editors/templates/editors/queue.html:169
+#: src/olympia/editors/templates/editors/queue.html:175
 msgid "There are currently no add-ons of this type to review."
 msgstr "Il n'y a actuellement aucun module de ce type à vérifier."
 
-#: src/olympia/editors/templates/editors/queue.html:181
-#: src/olympia/editors/templates/editors/themes/queue_list.html:85
+#: src/olympia/editors/templates/editors/queue.html:187 src/olympia/editors/templates/editors/themes/queue_list.html:85
 msgid "Helpful Links:"
 msgstr "Liens utiles :"
 
-#: src/olympia/editors/templates/editors/queue.html:182
+#: src/olympia/editors/templates/editors/queue.html:188
 msgid "Add-on Policy"
 msgstr "Politique du module"
 
-#: src/olympia/editors/templates/editors/queue.html:184
+#: src/olympia/editors/templates/editors/queue.html:190
 msgid "Editors' Guide"
 msgstr "Guide des éditeurs"
 
@@ -10600,19 +8181,14 @@ msgstr "Revue {0}"
 msgid "Add-on user change history"
 msgstr "Historique des modifications de l'utilisateur de module"
 
-#: src/olympia/editors/templates/editors/review.html:52
-#: src/olympia/editors/templates/editors/review.html:266
+#: src/olympia/editors/templates/editors/review.html:52 src/olympia/editors/templates/editors/review.html:266
 msgid "Add-on History"
 msgstr "Historique du module"
 
 #: src/olympia/editors/templates/editors/review.html:64
 #, python-format
-msgid ""
-"Version %(version)s &middot; %(created)s <span class=\"light\">&middot; "
-"%(version_status)s</span>"
-msgstr ""
-"Version %(version)s &middot; %(created)s <span class=\"light\">&middot; "
-"%(version_status)s</span>"
+msgid "Version %(version)s &middot; %(created)s <span class=\"light\">&middot; %(version_status)s</span>"
+msgstr "Version %(version)s &middot; %(created)s <span class=\"light\">&middot; %(version_status)s</span>"
 
 #: src/olympia/editors/templates/editors/review.html:73
 msgid "Compatibility:"
@@ -10635,19 +8211,14 @@ msgid "This version has not been reviewed."
 msgstr "Cette version n'a pas été revue."
 
 #: src/olympia/editors/templates/editors/review.html:154
-msgid ""
-"You can still submit this form, however only do so if you know it won't "
-"conflict."
-msgstr ""
-"Vous pouvez toujours envoyer ce formulaire, cependant ne le faites que si "
-"vous savez que cela n'entrera pas en conflit."
+msgid "You can still submit this form, however only do so if you know it won't conflict."
+msgstr "Vous pouvez toujours envoyer ce formulaire, cependant ne le faites que si vous savez que cela n'entrera pas en conflit."
 
 #: src/olympia/editors/templates/editors/review.html:161
 msgid "Insert canned response..."
 msgstr "Insérez une réponse enregistrée ..."
 
-#: src/olympia/editors/templates/editors/review.html:167
-#: src/olympia/files/templates/files/viewer.html:54
+#: src/olympia/editors/templates/editors/review.html:167 src/olympia/files/templates/files/viewer.html:54
 msgid "Files:"
 msgstr "Fichiers :"
 
@@ -10656,28 +8227,18 @@ msgid "Tested on:"
 msgstr "Testé sur :"
 
 #: src/olympia/editors/templates/editors/review.html:220
-msgid ""
-"<strong>Warning!</strong> Another user was viewing this page before you."
-msgstr ""
-"<strong>Attention !</strong> Un autre utilisateur regardait cette page avant"
-" vous."
+msgid "<strong>Warning!</strong> Another user was viewing this page before you."
+msgstr "<strong>Attention !</strong> Un autre utilisateur regardait cette page avant vous."
 
 #: src/olympia/editors/templates/editors/review.html:237
-msgid ""
-"The whiteboard is the place to exchange information relevant to this addon "
-"(whatever the version), between the developer and the editor. This is "
-"visible and editable by both."
-msgstr ""
-"Le tableau blanc est un endroit pour échanger des informations relatives au "
-"module (quelle que soit la version) entre le développeur et l'éditeur. Le "
-"tableau peut être vu et édité par les deux."
+msgid "The whiteboard is the place to exchange information relevant to this addon (whatever the version), between the developer and the editor. This is visible and editable by both."
+msgstr "Le tableau blanc est un endroit pour échanger des informations relatives au module (quelle que soit la version) entre le développeur et l'éditeur. Le tableau peut être vu et édité par les deux."
 
 #: src/olympia/editors/templates/editors/review.html:241
 msgid "Update the whiteboard"
 msgstr "Mettre à jour le tableau blanc"
 
-#: src/olympia/editors/templates/editors/review.html:257
-#: src/olympia/editors/templates/editors/review.html:258
+#: src/olympia/editors/templates/editors/review.html:257 src/olympia/editors/templates/editors/review.html:258
 msgid "(admin)"
 msgstr "(admin)"
 
@@ -10705,18 +8266,15 @@ msgstr "Éditeur"
 msgid "Add-on has been deleted."
 msgstr "Le module a été supprimé."
 
-#: src/olympia/editors/templates/editors/reviewlog.html:59
-#: src/olympia/editors/templates/editors/themes/logs.html:36
+#: src/olympia/editors/templates/editors/reviewlog.html:59 src/olympia/editors/templates/editors/themes/logs.html:36
 msgid "Show Comments"
 msgstr "Voir les commentaires"
 
-#: src/olympia/editors/templates/editors/reviewlog.html:60
-#: src/olympia/editors/templates/editors/themes/logs.html:37
+#: src/olympia/editors/templates/editors/reviewlog.html:60 src/olympia/editors/templates/editors/themes/logs.html:37
 msgid "Hide Comments"
 msgstr "Cacher les commentaires"
 
-#: src/olympia/editors/templates/editors/reviewlog.html:72
-#: src/olympia/editors/templates/editors/themes/logs.html:54
+#: src/olympia/editors/templates/editors/reviewlog.html:72 src/olympia/editors/templates/editors/themes/logs.html:54
 msgid "No reviews found for this period."
 msgstr "Pas de revue trouvée pour cette période."
 
@@ -10774,12 +8332,8 @@ msgstr "Toujours"
 msgid "You have <span>{0}</span> points."
 msgstr "Vous avez <span>{0}</span> points."
 
-#: src/olympia/editors/templates/editors/includes/search_results_themes.html:6
-#: src/olympia/editors/templates/editors/themes/history_table.html:7
-#: src/olympia/editors/templates/editors/themes/logs.html:19
-#: src/olympia/editors/templates/editors/themes/queue_list.html:49
-#: src/olympia/editors/templates/editors/themes/single.html:26
-#: src/olympia/editors/templates/editors/themes/themes.html:45
+#: src/olympia/editors/templates/editors/includes/search_results_themes.html:6 src/olympia/editors/templates/editors/themes/history_table.html:7 src/olympia/editors/templates/editors/themes/logs.html:19
+#: src/olympia/editors/templates/editors/themes/queue_list.html:49 src/olympia/editors/templates/editors/themes/single.html:26 src/olympia/editors/templates/editors/themes/themes.html:45
 msgid "Reviewer"
 msgstr "Testeur"
 
@@ -10803,8 +8357,7 @@ msgstr "Historique de vérification de thème pour {0}"
 msgid "Review Date"
 msgstr "Date de vérification"
 
-#: src/olympia/editors/templates/editors/themes/history_table.html:9
-#: src/olympia/editors/templates/editors/themes/logs.html:18
+#: src/olympia/editors/templates/editors/themes/history_table.html:9 src/olympia/editors/templates/editors/themes/logs.html:18
 msgid "Action"
 msgstr "Action"
 
@@ -10951,7 +8504,7 @@ msgstr "Poser une question à l'artiste"
 msgid "Describe your reason for flagging"
 msgstr "Décrivez votre raison pour l'étiquetage"
 
-#: src/olympia/files/forms.py:88
+#: src/olympia/files/forms.py:90
 msgid "Cannot diff a version against itself"
 msgstr "Impossible de calculer une différence entre deux versions identiques"
 
@@ -10969,12 +8522,8 @@ msgid "Problems decoding {0}."
 msgstr "Problèmes pendant le décodage de {0}."
 
 #: src/olympia/files/helpers.py:186
-msgid ""
-"This file is not viewable online. Please download the file to view the "
-"contents."
-msgstr ""
-"Ce fichier ne peut être visualisé en ligne. Merci de le télécharger pour "
-"voir son contenu."
+msgid "This file is not viewable online. Please download the file to view the contents."
+msgstr "Ce fichier ne peut être visualisé en ligne. Merci de le télécharger pour voir son contenu."
 
 #: src/olympia/files/helpers.py:194
 msgid "This file is a directory."
@@ -10990,55 +8539,51 @@ msgstr "Une erreur est survenue pendant l'accès au fichier %s. %s."
 msgid "There was an error accessing file %s."
 msgstr "Une erreur est survenue pendant l'accès au fichier %s."
 
-#: src/olympia/files/utils.py:343
+#: src/olympia/files/utils.py:340
 msgid "Could not parse uploaded file."
 msgstr "Impossible de lire le fichier envoyé."
 
-#: src/olympia/files/utils.py:380
+#: src/olympia/files/utils.py:377
 msgid "Invalid file name in archive: {0}"
 msgstr "Nom de fichier invalide dans l'archive : {0}"
 
-#: src/olympia/files/utils.py:388
+#: src/olympia/files/utils.py:385
 msgid "File exceeding size limit in archive: {0}"
 msgstr "Fichier dépassant la taille limite dans l'archive : {0}"
 
-#: src/olympia/files/utils.py:439
+#: src/olympia/files/utils.py:436
 msgid "Invalid archive."
 msgstr "Archive invalide."
 
-#: src/olympia/files/utils.py:529 src/olympia/files/utils.py:532
+#: src/olympia/files/utils.py:526 src/olympia/files/utils.py:529
 msgid "Could not parse the manifest file."
 msgstr "Impossible d'analyser le fichier manifeste."
 
-#: src/olympia/files/utils.py:551
+#: src/olympia/files/utils.py:548
 msgid "Could not find an add-on ID."
 msgstr "Impossible de trouver un identifiant de module."
 
-#: src/olympia/files/utils.py:554
+#: src/olympia/files/utils.py:551
 msgid "Add-on ID must be 64 characters or less."
 msgstr "Un identifiant de module doit mesurer moins de 64 caractères."
 
-#: src/olympia/files/utils.py:556
+#: src/olympia/files/utils.py:553
 msgid "Add-on ID doesn't match add-on."
 msgstr "L'identifiant ne correspond à aucun module."
 
-#: src/olympia/files/utils.py:564
+#: src/olympia/files/utils.py:561
 msgid "Duplicate add-on ID found."
 msgstr "Un identifiant identique a été trouvé."
 
-#: src/olympia/files/utils.py:567
+#: src/olympia/files/utils.py:564
 msgid "Version numbers should have fewer than 32 characters."
 msgstr "Les numéros de versions doivent comprendre moins de 32 caractères."
 
-#: src/olympia/files/utils.py:570
-msgid ""
-"Version numbers should only contain letters, numbers, and these punctuation "
-"characters: +*.-_."
-msgstr ""
-"Les numéros de versions doivent uniquement contenir des lettres, des "
-"chiffres, et les caractères suivants : +*.-_."
+#: src/olympia/files/utils.py:567
+msgid "Version numbers should only contain letters, numbers, and these punctuation characters: +*.-_."
+msgstr "Les numéros de versions doivent uniquement contenir des lettres, des chiffres, et les caractères suivants : +*.-_."
 
-#: src/olympia/files/utils.py:587
+#: src/olympia/files/utils.py:584
 msgid "<em:type> doesn't match add-on"
 msgstr "<em:type> ne correspond pas au module"
 
@@ -11056,12 +8601,8 @@ msgstr "Télécharger {0}"
 
 #: src/olympia/files/templates/files/file.html:4
 #, python-format
-msgid ""
-"Version: %(version)s &bull; Size: %(size)s &bull; MD5 hash: %(md5)s &bull; "
-"Mimetype: %(mimetype)s"
-msgstr ""
-"Version : %(version)s &bull; Taille : %(size)s &bull; Empreinte MD5 : "
-"%(md5)s &bull; Type MIME : %(mimetype)s"
+msgid "Version: %(version)s &bull; Size: %(size)s &bull; MD5 hash: %(md5)s &bull; Mimetype: %(mimetype)s"
+msgstr "Version : %(version)s &bull; Taille : %(size)s &bull; Empreinte MD5 : %(md5)s &bull; Type MIME : %(mimetype)s"
 
 #: src/olympia/files/templates/files/viewer.html:4
 msgid "File Compare :: Editor tools"
@@ -11099,48 +8640,39 @@ msgstr "Version du SDK Module :"
 msgid "Tab stops:"
 msgstr "Arrêts tabulation :"
 
-#: src/olympia/files/templates/files/viewer.html:79
-#: src/olympia/files/templates/files/viewer.html:80
+#: src/olympia/files/templates/files/viewer.html:79 src/olympia/files/templates/files/viewer.html:80
 msgid "Up file"
 msgstr "Monter le fichier"
 
-#: src/olympia/files/templates/files/viewer.html:84
-#: src/olympia/files/templates/files/viewer.html:85
+#: src/olympia/files/templates/files/viewer.html:84 src/olympia/files/templates/files/viewer.html:85
 msgid "Down file"
 msgstr "Descendre le fichier"
 
-#: src/olympia/files/templates/files/viewer.html:90
-#: src/olympia/files/templates/files/viewer.html:91
+#: src/olympia/files/templates/files/viewer.html:90 src/olympia/files/templates/files/viewer.html:91
 msgid "Previous diff"
 msgstr "Différence précédente"
 
-#: src/olympia/files/templates/files/viewer.html:93
-#: src/olympia/files/templates/files/viewer.html:94
+#: src/olympia/files/templates/files/viewer.html:93 src/olympia/files/templates/files/viewer.html:94
 msgid "Previous note"
 msgstr "Note précédente"
 
-#: src/olympia/files/templates/files/viewer.html:100
-#: src/olympia/files/templates/files/viewer.html:101
+#: src/olympia/files/templates/files/viewer.html:100 src/olympia/files/templates/files/viewer.html:101
 msgid "Next diff"
 msgstr "Différence suivante"
 
-#: src/olympia/files/templates/files/viewer.html:103
-#: src/olympia/files/templates/files/viewer.html:104
+#: src/olympia/files/templates/files/viewer.html:103 src/olympia/files/templates/files/viewer.html:104
 msgid "Next note"
 msgstr "Note suivante"
 
-#: src/olympia/files/templates/files/viewer.html:109
-#: src/olympia/files/templates/files/viewer.html:110
+#: src/olympia/files/templates/files/viewer.html:109 src/olympia/files/templates/files/viewer.html:110
 msgid "Expand all"
 msgstr "Tout développer"
 
-#: src/olympia/files/templates/files/viewer.html:114
-#: src/olympia/files/templates/files/viewer.html:115
+#: src/olympia/files/templates/files/viewer.html:114 src/olympia/files/templates/files/viewer.html:115
 msgid "Hide or unhide tree"
 msgstr "Cacher ou afficher l'arbre"
 
-#: src/olympia/files/templates/files/viewer.html:119
-#: src/olympia/files/templates/files/viewer.html:120
+#: src/olympia/files/templates/files/viewer.html:119 src/olympia/files/templates/files/viewer.html:120
 msgid "Wrap or unwrap text"
 msgstr "Ajouter/retirer des retours à la ligne"
 
@@ -11151,6 +8683,10 @@ msgstr "Pas de fichier dans le fichier envoyé."
 #: src/olympia/files/templates/files/viewer.html:134
 msgid "Fetching file."
 msgstr "Récupération du fichier."
+
+#: src/olympia/legacy_api/views.py:255
+msgid "Not implemented yet."
+msgstr "Pas encore implémenté"
 
 #: src/olympia/lib/constants.py:6
 msgid "United Arab Emirates Dirham"
@@ -11808,12 +9344,7 @@ msgstr "Kwacha zambien"
 msgid "Zimbabwe Dollar"
 msgstr ""
 
-#: src/olympia/lib/video/ffmpeg.py:112 src/olympia/lib/video/totem.py:81
-msgid "Videos must be in WebM."
-msgstr "Les vidéos doivent être au format WebM."
-
-#: src/olympia/pages/templates/pages/about.lhtml:3
-#: src/olympia/pages/templates/pages/about.lhtml:10
+#: src/olympia/pages/templates/pages/about.lhtml:3 src/olympia/pages/templates/pages/about.lhtml:10
 msgid "About Mozilla Add-ons"
 msgstr "À propos de Mozilla Add-ons"
 
@@ -11823,18 +9354,11 @@ msgstr "Qu'est-ce que ce site ?"
 
 #: src/olympia/pages/templates/pages/about.lhtml:13
 msgid ""
-"addons.mozilla.org, commonly known as \"AMO\", is Mozilla's official site "
-"for add-ons to Mozilla software, such as Firefox, Thunderbird, and "
-"SeaMonkey. Add-ons let you add new features and change the way your browser "
-"or application works. Take a look around and explore the thousands of ways "
-"to customize the way you do things online."
+"addons.mozilla.org, commonly known as \"AMO\", is Mozilla's official site for add-ons to Mozilla software, such as Firefox, Thunderbird, and SeaMonkey. Add-ons let you add new features and change "
+"the way your browser or application works. Take a look around and explore the thousands of ways to customize the way you do things online."
 msgstr ""
-"addons.mozilla.org, plus communément appelé « AMO », est le site officiel de"
-" Mozilla pour les modules disponibles pour les logiciels Mozilla tels "
-"Firefox, Thunderbird et SeaMonkey. Les modules vous permettent d'ajouter de "
-"nouvelles fonctionnalités et de changer le comportement de votre navigateur "
-"ou application. Jetez un œil et explorer les milliers de possibilités qui "
-"vous sont offertes."
+"addons.mozilla.org, plus communément appelé « AMO », est le site officiel de Mozilla pour les modules disponibles pour les logiciels Mozilla tels Firefox, Thunderbird et SeaMonkey. Les modules vous"
+" permettent d'ajouter de nouvelles fonctionnalités et de changer le comportement de votre navigateur ou application. Jetez un œil et explorer les milliers de possibilités qui vous sont offertes."
 
 #: src/olympia/pages/templates/pages/about.lhtml:19
 msgid "Who creates these add-ons?"
@@ -11842,109 +9366,65 @@ msgstr "Qui créé ces modules ?"
 
 #: src/olympia/pages/templates/pages/about.lhtml:20
 msgid ""
-"The add-ons listed here have been created by thousands of developers from "
-"our community, ranging from individual hobbyists to large corporations. All "
-"publicly listed add-ons are reviewed by a team of editors before being "
-"released. Add-ons marked as Experimental have not been reviewed and should "
-"only be installed with caution."
+"The add-ons listed here have been created by thousands of developers from our community, ranging from individual hobbyists to large corporations. All publicly listed add-ons are reviewed by a team "
+"of editors before being released. Add-ons marked as Experimental have not been reviewed and should only be installed with caution."
 msgstr ""
-"Les modules visibles ici ont été créés par des milliers de développeurs de "
-"notre communauté, allant des amateurs hobbyistes à de grandes sociétés. Tous"
-" les modules disponibles publiquement ont été vérifiés par une équipe "
-"d'éditeurs avant d'être mis à disposition. Les modules marqués Expérimentaux"
-" n'ont pas été vérifiés et doivent être installés avec attention."
+"Les modules visibles ici ont été créés par des milliers de développeurs de notre communauté, allant des amateurs hobbyistes à de grandes sociétés. Tous les modules disponibles publiquement ont été "
+"vérifiés par une équipe d'éditeurs avant d'être mis à disposition. Les modules marqués Expérimentaux n'ont pas été vérifiés et doivent être installés avec attention."
 
 #: src/olympia/pages/templates/pages/about.lhtml:26
 msgid "How do I keep up with what's happening at AMO?"
 msgstr "Comment me tenir à jour à propos de ce qui se passe sur AMO ?"
 
 #: src/olympia/pages/templates/pages/about.lhtml:27
-msgid ""
-"There are several ways to find out the latest news from the world of add-"
-"ons:"
-msgstr ""
-"Il existe plusieurs manières d'être tenu au courant des dernières nouvelles "
-"du monde des modules :"
+msgid "There are several ways to find out the latest news from the world of add-ons:"
+msgstr "Il existe plusieurs manières d'être tenu au courant des dernières nouvelles du monde des modules :"
 
 #: src/olympia/pages/templates/pages/about.lhtml:29
 #, python-format
-msgid ""
-"Our <a href=\"%(url)s\">Add-ons Blog</a> is regularly updated with "
-"information for both add-on enthusiasts and developers."
-msgstr ""
-"Notre <a href=\"%(url)s\">blog module</a> est régulièrement mis à jour avec "
-"des informations pour les technophiles et les développeurs."
+msgid "Our <a href=\"%(url)s\">Add-ons Blog</a> is regularly updated with information for both add-on enthusiasts and developers."
+msgstr "Notre <a href=\"%(url)s\">blog module</a> est régulièrement mis à jour avec des informations pour les technophiles et les développeurs."
 
 #: src/olympia/pages/templates/pages/about.lhtml:32
 #, python-format
-msgid ""
-"We often post news, tips, and tricks to our Twitter account, <a "
-"href=\"%(url)s\">mozamo</a>"
-msgstr ""
-"Nous proposons souvent des nouvelles, des trucs et astuces sur notre compte "
-"Twitter, <a href=\"%(url)s\">mozamo</a>"
+msgid "We often post news, tips, and tricks to our Twitter account, <a href=\"%(url)s\">mozamo</a>"
+msgstr "Nous proposons souvent des nouvelles, des trucs et astuces sur notre compte Twitter, <a href=\"%(url)s\">mozamo</a>"
 
 #: src/olympia/pages/templates/pages/about.lhtml:34
 #, python-format
-msgid ""
-"Our <a href=\"%(url)s\">forums</a> are a good place to interact with the "
-"add-ons community and discuss upcoming changes to AMO."
-msgstr ""
-"Nos <a href=\"%(url)s\">forums</a> sont un bon endroit pour échanger avec la"
-" communauté et discuter des changements à venir."
+msgid "Our <a href=\"%(url)s\">forums</a> are a good place to interact with the add-ons community and discuss upcoming changes to AMO."
+msgstr "Nos <a href=\"%(url)s\">forums</a> sont un bon endroit pour échanger avec la communauté et discuter des changements à venir."
 
 #: src/olympia/pages/templates/pages/about.lhtml:39
 msgid "This sounds great! How can I get involved?"
 msgstr "Ça a l'air super ! Comment vous aider ?"
 
 #: src/olympia/pages/templates/pages/about.lhtml:40
-msgid ""
-"There are plenty of ways to get involved. If you're on the technical side:"
-msgstr ""
-"Il existe de nombreuses manières de contribuer. Si vous êtes plutôt "
-"technique :"
+msgid "There are plenty of ways to get involved. If you're on the technical side:"
+msgstr "Il existe de nombreuses manières de contribuer. Si vous êtes plutôt technique :"
 
 #: src/olympia/pages/templates/pages/about.lhtml:42
 #, python-format
-msgid ""
-"<a href=\"%(url)s\">Make your own add-on</a>. We provide free hosting and "
-"update services and can help you reach a large audience of users."
-msgstr ""
-"<a href=\"%(url)s\">Créez votre propre module</a>. Nous fournissons un "
-"hébergement gratuit et des services pour la mise à jour et pouvons vous "
-"aider à atteindre une grande audience."
+msgid "<a href=\"%(url)s\">Make your own add-on</a>. We provide free hosting and update services and can help you reach a large audience of users."
+msgstr "<a href=\"%(url)s\">Créez votre propre module</a>. Nous fournissons un hébergement gratuit et des services pour la mise à jour et pouvons vous aider à atteindre une grande audience."
 
 #: src/olympia/pages/templates/pages/about.lhtml:45
 #, python-format
-msgid ""
-"If you have add-on development experience, <a href=\"%(url)s\"> become an "
-"editor</a>! Our editors are add-on fans with a technical background who "
-"review add-ons for code quality and stability."
+msgid "If you have add-on development experience, <a href=\"%(url)s\"> become an editor</a>! Our editors are add-on fans with a technical background who review add-ons for code quality and stability."
 msgstr ""
-"Si vous avez de l'expérience en matière de développement de modules, <a "
-"href=\"%(url)s\">devenez éditeur</a> ! Nos éditeurs sont des accrocs de "
-"modules avec un bon bagage technique pour vérifier la qualité du code et la "
-"stabilité."
+"Si vous avez de l'expérience en matière de développement de modules, <a href=\"%(url)s\">devenez éditeur</a> ! Nos éditeurs sont des accrocs de modules avec un bon bagage technique pour vérifier la"
+" qualité du code et la stabilité."
 
 #: src/olympia/pages/templates/pages/about.lhtml:49
 #, python-format
-msgid ""
-"Help improve this website. It's open source, and you can file bugs and "
-"submit patches. <a href=\"%(url)s\"> GitHub</a> contains all of our current "
-"bugs, legacy bugs can still be found in Bugzilla."
+msgid "Help improve this website. It's open source, and you can file bugs and submit patches. <a href=\"%(url)s\"> GitHub</a> contains all of our current bugs, legacy bugs can still be found in Bugzilla."
 msgstr ""
-"Vous pouvez nous aider à améliorer ce site. Celui-ci est <i>open source</i>,"
-" vous pouvez rapporter des bogues et proposer des correctifs. <a "
-"href=\"%(url)s\">GitHub</a> liste les bogues actuelles, Bugzilla contient "
-"les bogues historiques."
+"Vous pouvez nous aider à améliorer ce site. Celui-ci est <i>open source</i>, vous pouvez rapporter des bogues et proposer des correctifs. <a href=\"%(url)s\">GitHub</a> liste les bogues actuelles, "
+"Bugzilla contient les bogues historiques."
 
 #: src/olympia/pages/templates/pages/about.lhtml:55
-msgid ""
-"If you're interested in add-ons but not quite as technical, there are still "
-"ways to help:"
-msgstr ""
-"Si vous êtes intéressés mais que vous n'êtes pas trop technique, vous pouvez"
-" toujours nous aider :"
+msgid "If you're interested in add-ons but not quite as technical, there are still ways to help:"
+msgstr "Si vous êtes intéressés mais que vous n'êtes pas trop technique, vous pouvez toujours nous aider :"
 
 #: src/olympia/pages/templates/pages/about.lhtml:58
 msgid "Tell your friends! Let people know which add-ons you use."
@@ -11956,13 +9436,8 @@ msgid "Participate in our <a href=\"%(url)s\">forums</a>."
 msgstr "Participez à nos <a href=\"%(url)s\">forums</a>."
 
 #: src/olympia/pages/templates/pages/about.lhtml:61
-msgid ""
-"Review add-ons on the site. Add-on authors are more likely to improve their "
-"add-ons and write new ones when they know people appreciate their work."
-msgstr ""
-"Testez les modules sur le site. Les auteurs sont plus enclins à améliorer "
-"leur module et à en écrire de nouveaux quand ils savent que leur travail est"
-" apprécié."
+msgid "Review add-ons on the site. Add-on authors are more likely to improve their add-ons and write new ones when they know people appreciate their work."
+msgstr "Testez les modules sur le site. Les auteurs sont plus enclins à améliorer leur module et à en écrire de nouveaux quand ils savent que leur travail est apprécié."
 
 #: src/olympia/pages/templates/pages/about.lhtml:66
 msgid "I have a question"
@@ -11971,22 +9446,16 @@ msgstr "J'ai une question"
 #: src/olympia/pages/templates/pages/about.lhtml:67
 #, python-format
 msgid ""
-"A good place to start is our <a href=\"%(faq_url)s\"><abbr "
-"title=\"Frequently Asked Questions\">FAQ</abbr></a>. If you don't find an "
-"answer there, you can <a href=\"%(forum_url)s\"> ask on our forums</a>."
+"A good place to start is our <a href=\"%(faq_url)s\"><abbr title=\"Frequently Asked Questions\">FAQ</abbr></a>. If you don't find an answer there, you can <a href=\"%(forum_url)s\"> ask on our "
+"forums</a>."
 msgstr ""
-"Un bon point de départ est notre <a href=\"%(faq_url)s\"><abbr title=\"Foire"
-" Aux Questions\">FAQ</abbr></a>. Si vous n'y trouvez pas votre réponse, vous"
-" pouvez toujours <a href=\"%(forum_url)s\"> demander dans nos forums</a>."
+"Un bon point de départ est notre <a href=\"%(faq_url)s\"><abbr title=\"Foire Aux Questions\">FAQ</abbr></a>. Si vous n'y trouvez pas votre réponse, vous pouvez toujours <a href=\"%(forum_url)s\"> "
+"demander dans nos forums</a>."
 
 #: src/olympia/pages/templates/pages/about.lhtml:72
 #, python-format
-msgid ""
-"If you really need to contact someone from the Mozilla team, please see our "
-"<a href=\"%(url)s\"> contact information</a> page."
-msgstr ""
-"Si vous avez besoin de prendre contact avec quelqu'un de l'équipe Mozilla, "
-"merci de vous référer à notre page <a href=\"%(url)s\">contacts</a>."
+msgid "If you really need to contact someone from the Mozilla team, please see our <a href=\"%(url)s\"> contact information</a> page."
+msgstr "Si vous avez besoin de prendre contact avec quelqu'un de l'équipe Mozilla, merci de vous référer à notre page <a href=\"%(url)s\">contacts</a>."
 
 #: src/olympia/pages/templates/pages/about.lhtml:76
 msgid "Who works on this website?"
@@ -11995,15 +9464,11 @@ msgstr "Qui travaille sur ce site ?"
 #: src/olympia/pages/templates/pages/about.lhtml:77
 #, python-format
 msgid ""
-"Over the years, many people have contributed to this website, including both"
-" volunteers from the community and a dedicated AMO team. A list of "
-"significant contributors can be found on our <a href=\"%(url)s\"> Site "
-"Credits</a> page."
+"Over the years, many people have contributed to this website, including both volunteers from the community and a dedicated AMO team. A list of significant contributors can be found on our <a "
+"href=\"%(url)s\"> Site Credits</a> page."
 msgstr ""
-"Au travers des années, de nombreuses personnes ont contribué à ce site, à la"
-" fois des volontaires de la communauté et une équipe dédiée de Mozilla. Une "
-"liste des contributeurs importants peut être obtenue sur notre page <a "
-"href=\"%(url)s\">crédits</a>."
+"Au travers des années, de nombreuses personnes ont contribué à ce site, à la fois des volontaires de la communauté et une équipe dédiée de Mozilla. Une liste des contributeurs importants peut être "
+"obtenue sur notre page <a href=\"%(url)s\">crédits</a>."
 
 #: src/olympia/pages/templates/pages/acr_firstrun.html:4
 msgid "Add-on Compatibility Reporter"
@@ -12014,68 +9479,45 @@ msgid "Add-on Compatibility Reporter has been installed"
 msgstr "Le rapporteur de compatibilité de module a été installé"
 
 #: src/olympia/pages/templates/pages/acr_firstrun.html:28
-msgid ""
-"It’s easy to help us make sure add-ons are updated in time for the release "
-"of the next version of Firefox."
-msgstr ""
-"C'est facile de nous aider à nous assurer que les modules sont mis à jour à "
-"temps pour les sorties des versions prochaines de Firefox."
+msgid "It’s easy to help us make sure add-ons are updated in time for the release of the next version of Firefox."
+msgstr "C'est facile de nous aider à nous assurer que les modules sont mis à jour à temps pour les sorties des versions prochaines de Firefox."
 
 #: src/olympia/pages/templates/pages/acr_firstrun.html:35
 msgid "Here’s how to get started reporting add-on compatibility:"
-msgstr ""
-"Voici comment se lancer dans la vérification de compatibilité d'un module :"
+msgstr "Voici comment se lancer dans la vérification de compatibilité d'un module :"
 
 #: src/olympia/pages/templates/pages/acr_firstrun.html:40
 msgid ""
-"As you start browsing and using your add-ons, take careful note of anything "
-"that seems different from when you last used the extension. This might be a "
-"display glitch, such as a menu item missing, or something more serious, like"
-" the add-on not working at all or showing errors."
+"As you start browsing and using your add-ons, take careful note of anything that seems different from when you last used the extension. This might be a display glitch, such as a menu item missing, "
+"or something more serious, like the add-on not working at all or showing errors."
 msgstr ""
-"Dès que vous commencez à naviguer et à utiliser vos modules, prenez "
-"attentivement des notes sur ce qui semble différent de la dernière fois que "
-"vous avez utilisé l'extension. Cela peut être une erreur d'affichage, comme "
-"un élément de menu manquant, ou quelque chose de plus grave, par exemple le "
-"module ne fonctionnant plus du tout ou affichant des erreurs."
+"Dès que vous commencez à naviguer et à utiliser vos modules, prenez attentivement des notes sur ce qui semble différent de la dernière fois que vous avez utilisé l'extension. Cela peut être une "
+"erreur d'affichage, comme un élément de menu manquant, ou quelque chose de plus grave, par exemple le module ne fonctionnant plus du tout ou affichant des erreurs."
 
 #: src/olympia/pages/templates/pages/acr_firstrun.html:49
 msgid ""
-"Once you know whether a particular add-on works properly or has problems, "
-"open the Add-ons Manager and click Compatibility next to the add-on to let "
-"Mozilla know what you found in your testing. Submitting a report will help "
-"us tell the add-on developer whether their add-on is working properly in "
-"this version or might need some fixes."
+"Once you know whether a particular add-on works properly or has problems, open the Add-ons Manager and click Compatibility next to the add-on to let Mozilla know what you found in your testing. "
+"Submitting a report will help us tell the add-on developer whether their add-on is working properly in this version or might need some fixes."
 msgstr ""
-"Une fois que vous savez qu'un module précis fonctionne bien ou a des soucis,"
-" ouvrez le gestionnaire de modules complémentaires, et cliquez sur « "
-"Compatibilité » situé à côté du module pour indiquer à Mozilla ce que vous "
-"avez découvert pendant vos tests. Envoyer un rapport nous aidera à tenir au "
-"courant le développeur de module quant au bon fonctionnement de son module."
+"Une fois que vous savez qu'un module précis fonctionne bien ou a des soucis, ouvrez le gestionnaire de modules complémentaires, et cliquez sur « Compatibilité » situé à côté du module pour indiquer"
+" à Mozilla ce que vous avez découvert pendant vos tests. Envoyer un rapport nous aidera à tenir au courant le développeur de module quant au bon fonctionnement de son module."
 
 #: src/olympia/pages/templates/pages/acr_firstrun.html:61
 #, python-format
 msgid ""
-"If you upgrade to a new version of Firefox or update your add-ons, your "
-"reports for the old versions will be hidden to allow you to test the new "
-"version. If you have any questions, please ask in <a href=\"%(url)s\">our "
-"forums</a>."
+"If you upgrade to a new version of Firefox or update your add-ons, your reports for the old versions will be hidden to allow you to test the new version. If you have any questions, please ask in <a"
+" href=\"%(url)s\">our forums</a>."
 msgstr ""
-"Si vous mettez à jour vers une nouvelle version de Firefox ou de vos "
-"modules, vos rapports pour les anciennes versions seront cachés pour vous "
-"permettre de tester la nouvelle version. Pour toute question, merci de "
-"demander dans <a href=\"%(url)s\">nos forums</a>."
+"Si vous mettez à jour vers une nouvelle version de Firefox ou de vos modules, vos rapports pour les anciennes versions seront cachés pour vous permettre de tester la nouvelle version. Pour toute "
+"question, merci de demander dans <a href=\"%(url)s\">nos forums</a>."
 
 #: src/olympia/pages/templates/pages/acr_firstrun.html:69
 msgid ""
-"Thousands of add-ons are made by our community every year, and your "
-"assistance with compatibility testing helps us make sure these add-ons stay "
-"useful as we strive to provide a great user experience."
+"Thousands of add-ons are made by our community every year, and your assistance with compatibility testing helps us make sure these add-ons stay useful as we strive to provide a great user "
+"experience."
 msgstr ""
-"Des milliers de modules sont fait par notre communauté toute l'année, et "
-"votre aide pour vérifier la compatibilité nous aide à nous assurer que les "
-"modules continuent à être utilisables pendant que nous nous efforçons de "
-"fournir une expérience utilisateur toujours améliorée."
+"Des milliers de modules sont fait par notre communauté toute l'année, et votre aide pour vérifier la compatibilité nous aide à nous assurer que les modules continuent à être utilisables pendant que"
+" nous nous efforçons de fournir une expérience utilisateur toujours améliorée."
 
 #: src/olympia/pages/templates/pages/acr_firstrun.html:75
 msgid "Thank you!"
@@ -12086,12 +9528,8 @@ msgid "Site Credits"
 msgstr "Crédits du site"
 
 #: src/olympia/pages/templates/pages/credits.html:12
-msgid ""
-"Mozilla would like to thank the following people for their contributions to "
-"the addons.mozilla.org project over the years:"
-msgstr ""
-"Mozilla aimerait remercier les personnes suivantes pour leur contribution au"
-" projet addons.mozilla.org durant toutes ces années :"
+msgid "Mozilla would like to thank the following people for their contributions to the addons.mozilla.org project over the years:"
+msgstr "Mozilla aimerait remercier les personnes suivantes pour leur contribution au projet addons.mozilla.org durant toutes ces années :"
 
 #: src/olympia/pages/templates/pages/credits.html:18
 msgid "Developers &amp; Administrators"
@@ -12124,88 +9562,63 @@ msgstr "Logiciel et images"
 
 #: src/olympia/pages/templates/pages/credits.html:59
 msgid ""
-"Some icons used are from the <a "
-"href=\"http://www.famfamfam.com/lab/icons/silk/\">famfamfam Silk Icon "
-"Set</a>, licensed under a <a "
-"href=\"http://creativecommons.org/licenses/by/2.5/\">Creative Commons "
-"Attribution 2.5 License</a>."
+"Some icons used are from the <a href=\"http://www.famfamfam.com/lab/icons/silk/\">famfamfam Silk Icon Set</a>, licensed under a <a href=\"http://creativecommons.org/licenses/by/2.5/\">Creative "
+"Commons Attribution 2.5 License</a>."
 msgstr ""
-"Certaines icônes utilisées proviennent du <a "
-"href=\"http://www.famfamfam.com/lab/icons/silk/\">jeu d'icônes famfamfam "
-"Silk</a> sous licence <a "
-"href=\"http://creativecommons.org/licenses/by/2.5/\">Creative Commons "
-"Attribution 2.5</a>."
+"Certaines icônes utilisées proviennent du <a href=\"http://www.famfamfam.com/lab/icons/silk/\">jeu d'icônes famfamfam Silk</a> sous licence <a "
+"href=\"http://creativecommons.org/licenses/by/2.5/\">Creative Commons Attribution 2.5</a>."
 
 #: src/olympia/pages/templates/pages/credits.html:60
 msgid ""
-"Some icons used are from the <a href=\"http://www.fatcow.com/free-"
-"icons/\">FatCow Farm-Fresh Web Icons Set</a>, licensed under a <a "
-"href=\"http://creativecommons.org/licenses/by/3.0/us/\">Creative Commons "
-"Attribution 3.0 License</a>."
+"Some icons used are from the <a href=\"http://www.fatcow.com/free-icons/\">FatCow Farm-Fresh Web Icons Set</a>, licensed under a <a href=\"http://creativecommons.org/licenses/by/3.0/us/\">Creative "
+"Commons Attribution 3.0 License</a>."
 msgstr ""
-"Certaines icônes utilisées proviennent du <a href=\"http://www.fatcow.com"
-"/free-icons/\">jeu d'icônes FatCow Farm-Fresh Web</a> sous licence <a "
-"href=\"http://creativecommons.org/licenses/by/3.0/us/\">Creative Commons "
-"Attribution 3.0</a>."
+"Certaines icônes utilisées proviennent du <a href=\"http://www.fatcow.com/free-icons/\">jeu d'icônes FatCow Farm-Fresh Web</a> sous licence <a "
+"href=\"http://creativecommons.org/licenses/by/3.0/us/\">Creative Commons Attribution 3.0</a>."
 
 #: src/olympia/pages/templates/pages/credits.html:61
 msgid ""
-"Some pages use elements of <a "
-"href=\"http://shop.highsoft.com/highcharts.html\">Highcharts</a> (non-"
-"commercial), licensed under a <a href=\"http://creativecommons.org/licenses"
-"/by-nc/3.0/\">Creative Commons Attribution-NonCommercial 3.0 License</a>."
+"Some pages use elements of <a href=\"http://shop.highsoft.com/highcharts.html\">Highcharts</a> (non-commercial), licensed under a <a href=\"http://creativecommons.org/licenses/by-nc/3.0/\">Creative"
+" Commons Attribution-NonCommercial 3.0 License</a>."
 msgstr ""
-"Certaines pages utilisent des éléments de <a "
-"href=\"http://shop.highsoft.com/highcharts.html\">Highcharts</a> (non-"
-"commercial), sous licence <a href=\"http://creativecommons.org/licenses/by-"
+"Certaines pages utilisent des éléments de <a href=\"http://shop.highsoft.com/highcharts.html\">Highcharts</a> (non-commercial), sous licence <a href=\"http://creativecommons.org/licenses/by-"
 "nc/3.0/\">Creative Commons Attribution-NonCommercial 3.0 License</a>."
 
 #: src/olympia/pages/templates/pages/credits.html:65
 #, python-format
-msgid ""
-"For information on contributing, please see our <a href=\"%(url)s\">wiki "
-"page</a>."
-msgstr ""
-"Pour plus d'informations sur la manière de contribuer, merci de consulter "
-"le <a href=\"%(url)s\">wiki</a>."
+msgid "For information on contributing, please see our <a href=\"%(url)s\">wiki page</a>."
+msgstr "Pour plus d'informations sur la manière de contribuer, merci de consulter le <a href=\"%(url)s\">wiki</a>."
 
 #: src/olympia/pages/templates/pages/dev_faq.html:4
 msgid "Developer FAQ"
 msgstr "FAQ du développeur"
 
-#: src/olympia/pages/templates/pages/dev_faq.html:31
-#: src/olympia/pages/templates/pages/review_guide.html:33
+#: src/olympia/pages/templates/pages/dev_faq.html:31 src/olympia/pages/templates/pages/review_guide.html:33
 msgid "Sections"
 msgstr "Sections"
 
-#: src/olympia/pages/templates/pages/dev_faq.html:33
-#: src/olympia/pages/templates/pages/dev_faq.html:45
+#: src/olympia/pages/templates/pages/dev_faq.html:33 src/olympia/pages/templates/pages/dev_faq.html:45
 msgid "Developing an Add-on"
 msgstr "Développer un module"
 
 #. Heading for a list of resources for developers
-#: src/olympia/pages/templates/pages/dev_faq.html:34
-#: src/olympia/pages/templates/pages/dev_faq.html:208
+#: src/olympia/pages/templates/pages/dev_faq.html:34 src/olympia/pages/templates/pages/dev_faq.html:208
 msgid "Support Resources"
 msgstr "Ressources d'assistance"
 
-#: src/olympia/pages/templates/pages/dev_faq.html:35
-#: src/olympia/pages/templates/pages/dev_faq.html:261
+#: src/olympia/pages/templates/pages/dev_faq.html:35 src/olympia/pages/templates/pages/dev_faq.html:261
 msgid "Contributing your Add-on"
 msgstr "Contribuer votre module"
 
-#: src/olympia/pages/templates/pages/dev_faq.html:36
-#: src/olympia/pages/templates/pages/dev_faq.html:381
+#: src/olympia/pages/templates/pages/dev_faq.html:36 src/olympia/pages/templates/pages/dev_faq.html:381
 msgid "Add-on Review Process"
 msgstr "Processus de revue de module"
 
-#: src/olympia/pages/templates/pages/dev_faq.html:37
-#: src/olympia/pages/templates/pages/dev_faq.html:444
+#: src/olympia/pages/templates/pages/dev_faq.html:37 src/olympia/pages/templates/pages/dev_faq.html:444
 msgid "Managing Your Add-on"
 msgstr "Gérer votre module"
 
-#: src/olympia/pages/templates/pages/dev_faq.html:39
-#: src/olympia/pages/templates/pages/dev_faq.html:528
+#: src/olympia/pages/templates/pages/dev_faq.html:39 src/olympia/pages/templates/pages/dev_faq.html:528
 msgid "References for Open Source Licenses"
 msgstr "Références pour les licences libres"
 
@@ -12215,14 +9628,10 @@ msgstr "FAQ du développeur de module"
 
 #: src/olympia/pages/templates/pages/dev_faq.html:47
 #, python-format
-msgid ""
-"<h3>How do I build an Add-on?</h3> <p> Mozilla provides documentation on how"
-" to build an add-on via the <a href=\"%(url)s\">Mozilla Developer "
-"Network</a>. </p>"
+msgid "<h3>How do I build an Add-on?</h3> <p> Mozilla provides documentation on how to build an add-on via the <a href=\"%(url)s\">Mozilla Developer Network</a>. </p>"
 msgstr ""
-"<h3>Comment construire un module complémentaire&nbsp;?</h3> <p> Mozilla "
-"fournit de la documentation sur <a href=\"%(url)s\">Mozilla Developer "
-"Network</a> qui explique comment construire un module. </p>"
+"<h3>Comment construire un module complémentaire&nbsp;?</h3> <p> Mozilla fournit de la documentation sur <a href=\"%(url)s\">Mozilla Developer Network</a> qui explique comment construire un module. "
+"</p>"
 
 #: src/olympia/pages/templates/pages/dev_faq.html:55
 msgid "Other resources include:"
@@ -12230,9 +9639,7 @@ msgstr "Les autres ressources incluent :"
 
 #: src/olympia/pages/templates/pages/dev_faq.html:59
 msgid "\"How to develop a Firefox extension\" post in the Add-ons Blog"
-msgstr ""
-"Le billet «&nbsp;Comment développer une extension Firefox&nbsp;» sur le blog"
-" dédié aux modules"
+msgstr "Le billet «&nbsp;Comment développer une extension Firefox&nbsp;» sur le blog dédié aux modules"
 
 #: src/olympia/pages/templates/pages/dev_faq.html:62
 msgid "Mozilla Add-ons Blog"
@@ -12244,14 +9651,11 @@ msgstr "De quels outils j'ai besoin pour construire un module ?"
 
 #: src/olympia/pages/templates/pages/dev_faq.html:68
 msgid ""
-"You will need to have a version of the Mozilla software that you're building"
-" the add-on for and a code editor of your choice. Add-ons can be built for "
-"almost all Mozilla software but are primarily targeted for:"
+"You will need to have a version of the Mozilla software that you're building the add-on for and a code editor of your choice. Add-ons can be built for almost all Mozilla software but are primarily "
+"targeted for:"
 msgstr ""
-"Vous devrez avoir une version du logiciel Mozilla pour lequel vous "
-"construisez un module.ainsi que l'éditeur de code de votre choix. Les "
-"modules peuvent être construits pour tous les logiciels Mozilla mais ciblent"
-" prioritairement :"
+"Vous devrez avoir une version du logiciel Mozilla pour lequel vous construisez un module.ainsi que l'éditeur de code de votre choix. Les modules peuvent être construits pour tous les logiciels "
+"Mozilla mais ciblent prioritairement :"
 
 #: src/olympia/pages/templates/pages/dev_faq.html:82
 msgid "Popular code editors include:"
@@ -12260,38 +9664,24 @@ msgstr "Des éditeurs de code populaires :"
 #. This is a list of popular code editors.  Feel free to adjust as you like.
 #: src/olympia/pages/templates/pages/dev_faq.html:85
 msgid ""
-"<li><a href=\"http://komodoide.com/komodo-edit/\">Komodo Edit</a></li> "
-"<li><a href=\"http://macromates.com/\">TextMate</a></li> <li><a href=\"http"
-"://notepad-plus-plus.org/\">Notepad++</a></li> <li><a "
-"href=\"http://www.eclipse.org/\">Eclipse IDE</a></li>"
+"<li><a href=\"http://komodoide.com/komodo-edit/\">Komodo Edit</a></li> <li><a href=\"http://macromates.com/\">TextMate</a></li> <li><a href=\"http://notepad-plus-plus.org/\">Notepad++</a></li> "
+"<li><a href=\"http://www.eclipse.org/\">Eclipse IDE</a></li>"
 msgstr ""
-"<li><a href=\"http://komodoide.com/komodo-edit/\">Komodo Edit</a></li> "
-"<li><a href=\"http://macromates.com/\">TextMate</a></li> <li><a href=\"http"
-"://notepad-plus-plus.org/\">Notepad++</a></li> <li><a "
-"href=\"http://www.eclipse.org/\">Eclipse</a></li>"
+"<li><a href=\"http://komodoide.com/komodo-edit/\">Komodo Edit</a></li> <li><a href=\"http://macromates.com/\">TextMate</a></li> <li><a href=\"http://notepad-plus-plus.org/\">Notepad++</a></li> "
+"<li><a href=\"http://www.eclipse.org/\">Eclipse</a></li>"
 
 #: src/olympia/pages/templates/pages/dev_faq.html:94
 #, python-format
-msgid ""
-"You can also learn more about setting up your development environment via "
-"the MDN article <a href=\"%(url)s\">Setting up extension development "
-"environment</a>"
-msgstr ""
-"Vous pouvez également apprendre à mettre en place votre environnement de "
-"développement grâce à l'article de MDN <a href=\"%(url)s\">Mettre en place "
-"votre environnement de développement</a>"
+msgid "You can also learn more about setting up your development environment via the MDN article <a href=\"%(url)s\">Setting up extension development environment</a>"
+msgstr "Vous pouvez également apprendre à mettre en place votre environnement de développement grâce à l'article de MDN <a href=\"%(url)s\">Mettre en place votre environnement de développement</a>"
 
 #: src/olympia/pages/templates/pages/dev_faq.html:100
 msgid "What is a \".xpi\" file?"
 msgstr "Qu'est-ce qu'un fichier « .xpi » ?"
 
 #: src/olympia/pages/templates/pages/dev_faq.html:102
-msgid ""
-"Extensions are packaged and distributed in ZIP files or Bundles, with the "
-"XPI (pronounced \"zippy\") file extension."
-msgstr ""
-"Les extensions sont empaquetées et distribuées dans des fichiers Zip ou "
-"Bundles, avec l'extension XPI (pronnoncer « zippy »)"
+msgid "Extensions are packaged and distributed in ZIP files or Bundles, with the XPI (pronounced \"zippy\") file extension."
+msgstr "Les extensions sont empaquetées et distribuées dans des fichiers Zip ou Bundles, avec l'extension XPI (pronnoncer « zippy »)"
 
 #: src/olympia/pages/templates/pages/dev_faq.html:108
 msgid "What is XUL?"
@@ -12299,17 +9689,11 @@ msgstr "Qu'est-ce que XUL ?"
 
 #: src/olympia/pages/templates/pages/dev_faq.html:110
 msgid ""
-"XUL (XML User Interface Language) is Mozilla's XML-based language that lets "
-"you build feature-rich cross platform applications. It provides user "
-"interface widgets like buttons, menus, toolbars, trees, etc that can be used"
-" to enhance add-ons by modifying parts of the browser UI."
+"XUL (XML User Interface Language) is Mozilla's XML-based language that lets you build feature-rich cross platform applications. It provides user interface widgets like buttons, menus, toolbars, "
+"trees, etc that can be used to enhance add-ons by modifying parts of the browser UI."
 msgstr ""
-"XUL (XML User Interface Language) est le langage basé sur XML de Mozilla qui"
-" vous permet de construire des applications multi-plateformes riches. Il met"
-" à disposition des éléments d'interface utilisateur comme des boutons, des "
-"menus, des barres d'outils, des arbres, etc., pouvant être utilisés pour "
-"améliorer les modules en modifiant des parties de l'interface utilisateur du"
-" navigateur."
+"XUL (XML User Interface Language) est le langage basé sur XML de Mozilla qui vous permet de construire des applications multi-plateformes riches. Il met à disposition des éléments d'interface "
+"utilisateur comme des boutons, des menus, des barres d'outils, des arbres, etc., pouvant être utilisés pour améliorer les modules en modifiant des parties de l'interface utilisateur du navigateur."
 
 #: src/olympia/pages/templates/pages/dev_faq.html:119
 msgid "What is the \"install.rdf\" file used for?"
@@ -12318,36 +9702,23 @@ msgstr "À quoi le fichier « install.rdf » sert-il ?"
 #: src/olympia/pages/templates/pages/dev_faq.html:121
 #, python-format
 msgid ""
-"This file, called an <a href=\"%(url)s\">Install Manifest</a>, is used by "
-"Add-on Manager-enabled XUL applications to determine information about an "
-"add-on as it is being installed. It contains metadata identifying the add-"
-"on, providing information about who created it, where more information can "
-"be found about it, which versions of what applications it is compatible "
-"with, how it should be updated, and so on. The format of the Install "
-"Manifest is RDF/XML."
+"This file, called an <a href=\"%(url)s\">Install Manifest</a>, is used by Add-on Manager-enabled XUL applications to determine information about an add-on as it is being installed. It contains "
+"metadata identifying the add-on, providing information about who created it, where more information can be found about it, which versions of what applications it is compatible with, how it should "
+"be updated, and so on. The format of the Install Manifest is RDF/XML."
 msgstr ""
-"Ce fichier, appelé <a href=\"%(url)s\">manifeste d'installation</a>, est "
-"utilisé par les applications XUL qui ont un gestionnaire de modules pour "
-"déterminer les informations d'un module pendant son installation. Il "
-"contient des méta-données qui identifient le mlodule, fournissant des "
-"informations sur son créateur, où plus d'informations peuvent être trouvées,"
-" quelles versions d'applications sont compatibles, comment il doit être mis "
-"à jour, et d'autres choses encore. Le format du manifeste d'installation est"
-" RDF/XML."
+"Ce fichier, appelé <a href=\"%(url)s\">manifeste d'installation</a>, est utilisé par les applications XUL qui ont un gestionnaire de modules pour déterminer les informations d'un module pendant son"
+" installation. Il contient des méta-données qui identifient le mlodule, fournissant des informations sur son créateur, où plus d'informations peuvent être trouvées, quelles versions d'applications "
+"sont compatibles, comment il doit être mis à jour, et d'autres choses encore. Le format du manifeste d'installation est RDF/XML."
 
 #: src/olympia/pages/templates/pages/dev_faq.html:132
 msgid "What does \"maxVersion\" mean?"
 msgstr "Qu'est-ce que « maxVersion » signifie ?"
 
 #: src/olympia/pages/templates/pages/dev_faq.html:134
-msgid ""
-"This determines the maximum version of Firefox you're saying this extension "
-"will work with. Set this to be no newer than the newest currently available "
-"version!"
+msgid "This determines the maximum version of Firefox you're saying this extension will work with. Set this to be no newer than the newest currently available version!"
 msgstr ""
-"Ceci détermine la version  maximale de Firefox pour laquelle vous déclarez "
-"que cette extension fonctionne. Configurez-le avec une version pas plus "
-"grande que la dernière version actuellement disponible !"
+"Ceci détermine la version  maximale de Firefox pour laquelle vous déclarez que cette extension fonctionne. Configurez-le avec une version pas plus grande que la dernière version actuellement "
+"disponible !"
 
 #: src/olympia/pages/templates/pages/dev_faq.html:141
 msgid "Can my add-on contain binary components?"
@@ -12355,45 +9726,25 @@ msgstr "Mon module peut-il contenir des composants binaires ?"
 
 #: src/olympia/pages/templates/pages/dev_faq.html:143
 #, python-format
-msgid ""
-"Yes. You can use Mozilla's <a href=\"%(url)s\">XPCOM component object "
-"model</a> to enhance your add-ons. XPCOM components be used and implemented "
-"in JavaScript, Java, and Python in addition to C++."
+msgid "Yes. You can use Mozilla's <a href=\"%(url)s\">XPCOM component object model</a> to enhance your add-ons. XPCOM components be used and implemented in JavaScript, Java, and Python in addition to C++."
 msgstr ""
-"Oui. Vous pouvez utiliser le <a href=\"%(url)s\">modèle de composant objet "
-"XPCOM</a> de Mozilla pour améliorer vos modules. Les composants XPCOM "
-"peuvent être utilisés et implémentés en JavaScript, Java et Python en plus "
-"du C++."
+"Oui. Vous pouvez utiliser le <a href=\"%(url)s\">modèle de composant objet XPCOM</a> de Mozilla pour améliorer vos modules. Les composants XPCOM peuvent être utilisés et implémentés en JavaScript, "
+"Java et Python en plus du C++."
 
 #: src/olympia/pages/templates/pages/dev_faq.html:150
-msgid ""
-"Can I use a JavaScript library like jQuery, MooTools or Prototype to build "
-"my add-on?"
-msgstr ""
-"Est-ce que je peux utiliser une bibliothèque JavaScript comme jQuery, "
-"MooTools ou Prototype pour construire mon module ?"
+msgid "Can I use a JavaScript library like jQuery, MooTools or Prototype to build my add-on?"
+msgstr "Est-ce que je peux utiliser une bibliothèque JavaScript comme jQuery, MooTools ou Prototype pour construire mon module ?"
 
 #: src/olympia/pages/templates/pages/dev_faq.html:152
 msgid ""
-"Yes. It's possible, but some of the functionality provided by these "
-"libraries are available through XPCOM, XUL, and JavaScript. In addition, "
-"authors should take care if libraries modify primitive object prototypes "
-"(String.prototype, Date.prototype, etc.) and/or define global functions (eg."
-" the $ function). These are prone to cause conflict with other add-ons, in "
-"particular if different add-ons use different versions of libraries and so "
-"on. Developers need to be very, very careful with using them. Mozilla does "
-"not offer documentation on using them to build add-ons."
+"Yes. It's possible, but some of the functionality provided by these libraries are available through XPCOM, XUL, and JavaScript. In addition, authors should take care if libraries modify primitive "
+"object prototypes (String.prototype, Date.prototype, etc.) and/or define global functions (eg. the $ function). These are prone to cause conflict with other add-ons, in particular if different add-"
+"ons use different versions of libraries and so on. Developers need to be very, very careful with using them. Mozilla does not offer documentation on using them to build add-ons."
 msgstr ""
-"Oui, c'est possible mais certaines des fonctionnalités offertes par ces "
-"bibliothèques sont disponibles avec XPCOM, XUL et JavaScript. De plus, les "
-"auteurs devraient s'assurer que les bibliothèques utilisées ne modifient pas"
-" les prototypes des objets primitifs (String.prototype, Date.prototype, "
-"etc.) ou qu'elles ne définissent pas de fonctions globales (la fonction $ "
-"par exemple). De telles modifications peuvent entraîner des conflits avec "
-"d'autres modules qui utiliseraient d'autres versions de ces bibliothèques. "
-"Elles doivent donc être manipulées avec la plus grande précaution. Mozilla "
-"ne fournit pas de documentation pour construire des modules qui "
-"utiliseraient ces bibliothèques."
+"Oui, c'est possible mais certaines des fonctionnalités offertes par ces bibliothèques sont disponibles avec XPCOM, XUL et JavaScript. De plus, les auteurs devraient s'assurer que les bibliothèques "
+"utilisées ne modifient pas les prototypes des objets primitifs (String.prototype, Date.prototype, etc.) ou qu'elles ne définissent pas de fonctions globales (la fonction $ par exemple). De telles "
+"modifications peuvent entraîner des conflits avec d'autres modules qui utiliseraient d'autres versions de ces bibliothèques. Elles doivent donc être manipulées avec la plus grande précaution. "
+"Mozilla ne fournit pas de documentation pour construire des modules qui utiliseraient ces bibliothèques."
 
 #: src/olympia/pages/templates/pages/dev_faq.html:165
 msgid "How do I debug my add-on?"
@@ -12402,37 +9753,22 @@ msgstr "Comment déboguer mon module&nbsp;?"
 #: src/olympia/pages/templates/pages/dev_faq.html:167
 #, python-format
 msgid "You can use the <a href=\"%(url)s\">Add-on Debugger</a>."
-msgstr ""
-"Vous pouvez utiliser <a href=\"%(url)s\">le débogueur de module "
-"complémentaire</a>."
+msgstr "Vous pouvez utiliser <a href=\"%(url)s\">le débogueur de module complémentaire</a>."
 
 #: src/olympia/pages/templates/pages/dev_faq.html:172
-msgid ""
-"How do I test for compatibility with the latest version of Mozilla software?"
-msgstr ""
-"Comment puis-je tester la compatibilité avec la dernière version du logiciel"
-" Mozilla ?"
+msgid "How do I test for compatibility with the latest version of Mozilla software?"
+msgstr "Comment puis-je tester la compatibilité avec la dernière version du logiciel Mozilla ?"
 
 #: src/olympia/pages/templates/pages/dev_faq.html:174
 msgid ""
-"To ensure compatibility with the latest Mozilla software, it's important to "
-"download updates as they become available and test your add-on to ensure "
-"that it is still functioning as expected. In many cases, the latest version "
-"of Mozilla software may be a beta release. Since these releases at times "
-"introduce architectural changes that may impact the functionality of your "
-"add-on, it's important to be actively involved in the beta process to ensure"
-" that your add-on users are not negatively impacted upon final release of "
-"Mozilla software."
+"To ensure compatibility with the latest Mozilla software, it's important to download updates as they become available and test your add-on to ensure that it is still functioning as expected. In "
+"many cases, the latest version of Mozilla software may be a beta release. Since these releases at times introduce architectural changes that may impact the functionality of your add-on, it's "
+"important to be actively involved in the beta process to ensure that your add-on users are not negatively impacted upon final release of Mozilla software."
 msgstr ""
-"Afin d'assurer la compatibilité avec les derniers logiciels Mozilla, il est "
-"important de télécharger les mises à jour dès qu'elles sont disponibles et "
-"de tester votre module pour vous assurez qu'il continue de fonctionner "
-"correctement. Dans de nombreux cas, la version la plus récente est la "
-"version beta. Parfois des modifications importantes sont introduites et "
-"impactent les fonctionnalités de votre module, il est donc important de "
-"s'impliquer activement dans les tests des versions beta afin que les "
-"utilisateurs de votre module ne soient pas impactés de façon négative lors "
-"du lancement de la version finale du logiciel Mozilla."
+"Afin d'assurer la compatibilité avec les derniers logiciels Mozilla, il est important de télécharger les mises à jour dès qu'elles sont disponibles et de tester votre module pour vous assurez qu'il"
+" continue de fonctionner correctement. Dans de nombreux cas, la version la plus récente est la version beta. Parfois des modifications importantes sont introduites et impactent les fonctionnalités "
+"de votre module, il est donc important de s'impliquer activement dans les tests des versions beta afin que les utilisateurs de votre module ne soient pas impactés de façon négative lors du "
+"lancement de la version finale du logiciel Mozilla."
 
 #: src/olympia/pages/templates/pages/dev_faq.html:185
 msgid "How to improve the performance of my add-on?"
@@ -12441,18 +9777,11 @@ msgstr "Comment améliorer les performances de mon module&nbsp;?"
 #: src/olympia/pages/templates/pages/dev_faq.html:187
 #, python-format
 msgid ""
-"Poorly written extensions can have a severe impact on the browsing "
-"experience, including on the overall performance of Firefox itself. The "
-"following page contains many good <a href=\"%(url)s\">guides</a> that help "
-"you improve performance, whether you're developing core Mozilla code or an "
-"add-on."
+"Poorly written extensions can have a severe impact on the browsing experience, including on the overall performance of Firefox itself. The following page contains many good <a "
+"href=\"%(url)s\">guides</a> that help you improve performance, whether you're developing core Mozilla code or an add-on."
 msgstr ""
-"Les extensions développées médiocrement peuvent avoir un grave impact sur "
-"l'expérience de navigation et notamment sur les performances générales de "
-"Firefox. La page suivante contient de nombreux <a "
-"href=\"%(url)s\">guides</a> de qualité pour vous aider à améliorer les "
-"performances, que vous développiez un module complémentaire ou un produit "
-"Mozilla."
+"Les extensions développées médiocrement peuvent avoir un grave impact sur l'expérience de navigation et notamment sur les performances générales de Firefox. La page suivante contient de nombreux <a"
+" href=\"%(url)s\">guides</a> de qualité pour vous aider à améliorer les performances, que vous développiez un module complémentaire ou un produit Mozilla."
 
 #: src/olympia/pages/templates/pages/dev_faq.html:195
 msgid "Can my add-on support multiple locales?"
@@ -12461,21 +9790,15 @@ msgstr "Mon module peut-il proposer plusieurs langues ?"
 #: src/olympia/pages/templates/pages/dev_faq.html:197
 #, python-format
 msgid ""
-"Yes. Details on localizing your add-on can be found in the the <a "
-"href=\"%(l10n_url)s\">Mozilla Developer Network Localization page</a>. <a "
-"href=\"%(bz_url)s\">The BabelZilla project</a> is also a great resource for "
-"learning about localization and volunteering to help translate add-ons."
+"Yes. Details on localizing your add-on can be found in the the <a href=\"%(l10n_url)s\">Mozilla Developer Network Localization page</a>. <a href=\"%(bz_url)s\">The BabelZilla project</a> is also a "
+"great resource for learning about localization and volunteering to help translate add-ons."
 msgstr ""
-"Oui. Des informations sur la localisation des modules sont disponibles sur "
-"<a href=\"%(l10n_url)s\">la page dédiée à ce sujet sur MDN</a>. <a "
-"href=\"%(bz_url)s\">Le projet BabelZilla</a> est également une ressource "
-"très utile pour apprendre à localiser et contribuer à la traduction des "
-"modules."
+"Oui. Des informations sur la localisation des modules sont disponibles sur <a href=\"%(l10n_url)s\">la page dédiée à ce sujet sur MDN</a>. <a href=\"%(bz_url)s\">Le projet BabelZilla</a> est "
+"également une ressource très utile pour apprendre à localiser et contribuer à la traduction des modules."
 
 #: src/olympia/pages/templates/pages/dev_faq.html:210
 msgid "I need some advice building my add-on. Where can I find help?"
-msgstr ""
-"J'ai besoin d'aide pour construire mon module. Où puis-je en trouver ?"
+msgstr "J'ai besoin d'aide pour construire mon module. Où puis-je en trouver ?"
 
 #. #extdev is the name of the IRC channel.  do not change.
 #: src/olympia/pages/templates/pages/dev_faq.html:216
@@ -12489,12 +9812,8 @@ msgstr "#amo (pour l'assistance liée à l'hébergement de votre module sur AMO)
 
 #. #jetpack is the name of the IRC channel.  do not change.
 #: src/olympia/pages/templates/pages/dev_faq.html:220
-msgid ""
-"#jetpack (for discussions about the Add-ons SDK and cfx/jpm - formerly known"
-" as Jetpack)"
-msgstr ""
-"#jetpack (canal anglophone pour discuter sur le SDK des modules et sur "
-"cfx/jpm, anciennement connu sous le nom de Jetpack)"
+msgid "#jetpack (for discussions about the Add-ons SDK and cfx/jpm - formerly known as Jetpack)"
+msgstr "#jetpack (canal anglophone pour discuter sur le SDK des modules et sur cfx/jpm, anciennement connu sous le nom de Jetpack)"
 
 #. Label for a link to the extension developers mailing list
 #: src/olympia/pages/templates/pages/dev_faq.html:225
@@ -12529,24 +9848,16 @@ msgstr "Non."
 
 #: src/olympia/pages/templates/pages/dev_faq.html:246
 msgid "Are there 3rd party developers that I can hire to build my add-on?"
-msgstr ""
-"Est-ce que je peux embaucher un développeur tiers pour faire mon module ?"
+msgstr "Est-ce que je peux embaucher un développeur tiers pour faire mon module ?"
 
 #: src/olympia/pages/templates/pages/dev_faq.html:248
 #, python-format
 msgid ""
-"Yes. You may find 3rd party developers via the <a href=\"%(forum_url)s"
-"\">Add-ons forum</a>, <a href=\"%(list_url)s\">mozilla.jobs list</a>, <a "
-"href=\"%(mz_url)s\">mozillaZine forums</a> or <a href=\"%(wiki_url)s\">the "
-"Mozilla Wiki</a>. Please note that Mozilla does not offer developer "
-"recommendations."
+"Yes. You may find 3rd party developers via the <a href=\"%(forum_url)s\">Add-ons forum</a>, <a href=\"%(list_url)s\">mozilla.jobs list</a>, <a href=\"%(mz_url)s\">mozillaZine forums</a> or <a "
+"href=\"%(wiki_url)s\">the Mozilla Wiki</a>. Please note that Mozilla does not offer developer recommendations."
 msgstr ""
-"Oui. Vous pouvez trouver des développeurs tiers sur <a "
-"href=\"%(forum_url)s\">le forum dédié aux modules</a>, <a "
-"href=\"%(list_url)s\">la liste de diffusion mozilla.jobs</a>, <a "
-"href=\"%(mz_url)s\">les forums mozillaZine</a> ou sur <a "
-"href=\"%(wiki_url)s\">le wiki Mozilla</a>. Note&nbsp;: Mozilla ne recommande"
-" aucun développeur en particulier."
+"Oui. Vous pouvez trouver des développeurs tiers sur <a href=\"%(forum_url)s\">le forum dédié aux modules</a>, <a href=\"%(list_url)s\">la liste de diffusion mozilla.jobs</a>, <a "
+"href=\"%(mz_url)s\">les forums mozillaZine</a> ou sur <a href=\"%(wiki_url)s\">le wiki Mozilla</a>. Note&nbsp;: Mozilla ne recommande aucun développeur en particulier."
 
 #: src/olympia/pages/templates/pages/dev_faq.html:263
 msgid "Can I host my own add-on?"
@@ -12555,21 +9866,13 @@ msgstr "Est-ce que je peux héberger mon propre module ?"
 #: src/olympia/pages/templates/pages/dev_faq.html:265
 #, python-format
 msgid ""
-"Yes. Many developers choose to host their own add-ons. Choosing to host your"
-" add-on on <a href=\"%(amo_url)s\">Mozilla's add-on site</a>, though, allows"
-" for much greater exposure to your add-on due to the large volume of "
-"visitors to the site. <a href=\"%(md_url)s\">mozdev.org</a> offers free "
-"project hosting for Mozilla applications and extensions providing developers"
-" with tools to help manage source code, version control, bug tracking and "
-"documentation."
+"Yes. Many developers choose to host their own add-ons. Choosing to host your add-on on <a href=\"%(amo_url)s\">Mozilla's add-on site</a>, though, allows for much greater exposure to your add-on due"
+" to the large volume of visitors to the site. <a href=\"%(md_url)s\">mozdev.org</a> offers free project hosting for Mozilla applications and extensions providing developers with tools to help "
+"manage source code, version control, bug tracking and documentation."
 msgstr ""
-"Oui. Beaucoup de développeurs choisissent d'héberger leur propre modles. "
-"Choisir d'héberger son module sur le <a href=\"%(amo_url)s\">site des "
-"modules Mozilla</a>, surtout, permet de bénéficier de l'exposition liée au "
-"gros volume de visiteurs sur le site. <a href=\"%(md_url)s\">mozdev.org</a> "
-"propose un hébergement de projet gratuit pour les applications Mozilla et "
-"les extensions, fournissant aux développeurs les outils pour gérer code "
-"source, versions, suivi de bugs et documentation."
+"Oui. Beaucoup de développeurs choisissent d'héberger leur propre modles. Choisir d'héberger son module sur le <a href=\"%(amo_url)s\">site des modules Mozilla</a>, surtout, permet de bénéficier de "
+"l'exposition liée au gros volume de visiteurs sur le site. <a href=\"%(md_url)s\">mozdev.org</a> propose un hébergement de projet gratuit pour les applications Mozilla et les extensions, "
+"fournissant aux développeurs les outils pour gérer code source, versions, suivi de bugs et documentation."
 
 #: src/olympia/pages/templates/pages/dev_faq.html:277
 msgid "Can Mozilla host my add-on?"
@@ -12577,12 +9880,8 @@ msgstr "Est-ce que Mozilla peut héberger mon module ?"
 
 #: src/olympia/pages/templates/pages/dev_faq.html:279
 #, python-format
-msgid ""
-"Yes. You can host your add-on on <a href=\"%(url)s\">Mozilla's add-on "
-"website</a>."
-msgstr ""
-"Oui. Vous pouvez héberger votre module sur le <a href=\"%(url)s\">site des "
-"modules Mozilla</a>."
+msgid "Yes. You can host your add-on on <a href=\"%(url)s\">Mozilla's add-on website</a>."
+msgstr "Oui. Vous pouvez héberger votre module sur le <a href=\"%(url)s\">site des modules Mozilla</a>."
 
 #: src/olympia/pages/templates/pages/dev_faq.html:284
 msgid "What is AMO?"
@@ -12590,19 +9889,11 @@ msgstr "Qu'est-ce qu'AMO ?"
 
 #: src/olympia/pages/templates/pages/dev_faq.html:286
 msgid ""
-"Mozilla's AMO (<a "
-"href=\"https://addons.mozilla.org\">https://addons.mozilla.org</a>) is the "
-"incubator that helps developers build, distribute, and support fantastic "
-"consumer products powered by Mozilla. It provides you the tools and "
-"infrastructure necessary to manage, host and expose your add-on to a massive"
-" base of Mozilla users."
+"Mozilla's AMO (<a href=\"https://addons.mozilla.org\">https://addons.mozilla.org</a>) is the incubator that helps developers build, distribute, and support fantastic consumer products powered by "
+"Mozilla. It provides you the tools and infrastructure necessary to manage, host and expose your add-on to a massive base of Mozilla users."
 msgstr ""
-"AMO (<a href=\"https://addons.mozilla.org\">https://addons.mozilla.org</a>) "
-"est l'incubateur qui aide les développeurs à construire, distribuer et "
-"proposer des produits fantastiques aux consommateurs, soutenu par Mozilla. "
-"Il met à disposition les outils et l'infrastructure nécessaire pour gérer, "
-"héberger et rendre visible votre module à une large base d'utilisateurs "
-"Mozilla."
+"AMO (<a href=\"https://addons.mozilla.org\">https://addons.mozilla.org</a>) est l'incubateur qui aide les développeurs à construire, distribuer et proposer des produits fantastiques aux "
+"consommateurs, soutenu par Mozilla. Il met à disposition les outils et l'infrastructure nécessaire pour gérer, héberger et rendre visible votre module à une large base d'utilisateurs Mozilla."
 
 #: src/olympia/pages/templates/pages/dev_faq.html:295
 msgid "Does Mozilla keep my account information private?"
@@ -12610,12 +9901,8 @@ msgstr "Est-ce que Mozilla garde secrètes les informations de mon compte ?"
 
 #: src/olympia/pages/templates/pages/dev_faq.html:297
 #, python-format
-msgid ""
-"Yes. Our <a href=\"%(url)s\">Privacy Policy</a> describes how your "
-"information is managed by Mozilla."
-msgstr ""
-"Oui. Notre <a href=\"%(url)s\">politique de confidentialité</a> décrit "
-"comment vos informations sont gérées par Mozilla."
+msgid "Yes. Our <a href=\"%(url)s\">Privacy Policy</a> describes how your information is managed by Mozilla."
+msgstr "Oui. Notre <a href=\"%(url)s\">politique de confidentialité</a> décrit comment vos informations sont gérées par Mozilla."
 
 #: src/olympia/pages/templates/pages/dev_faq.html:302
 msgid "What are the \"developer tools\" listed on AMO?"
@@ -12623,38 +9910,25 @@ msgstr "Quels sont les « outils de développement » listés sur AMO&nbsp;?"
 
 #: src/olympia/pages/templates/pages/dev_faq.html:304
 msgid ""
-"The \"Developer Tools\" dashboard is the area that provides you the tools to"
-" successfully manage your add-ons. It provides the functionality necessary "
-"to submit your add-ons to AMO, manage add-on information, and review "
-"statistics."
+"The \"Developer Tools\" dashboard is the area that provides you the tools to successfully manage your add-ons. It provides the functionality necessary to submit your add-ons to AMO, manage add-on "
+"information, and review statistics."
 msgstr ""
-"Le tableau de bord « Outils du développeur » est une zone qui met à votre "
-"disposition les outils pour gérer vos modules avec succès. Il fournit les "
-"fonctionnalités nécessaires pour envoyer vos modules sur AMO, gérer les "
-"informations du module, et voir les statistiques."
+"Le tableau de bord « Outils du développeur » est une zone qui met à votre disposition les outils pour gérer vos modules avec succès. Il fournit les fonctionnalités nécessaires pour envoyer vos "
+"modules sur AMO, gérer les informations du module, et voir les statistiques."
 
 #: src/olympia/pages/templates/pages/dev_faq.html:312
-msgid ""
-"Does Mozilla have a policy in place as to what is an acceptable submission?"
-msgstr ""
-"Est-ce que Mozilla a une politique en place sur ce qu'est une proposition "
-"acceptable ?"
+msgid "Does Mozilla have a policy in place as to what is an acceptable submission?"
+msgstr "Est-ce que Mozilla a une politique en place sur ce qu'est une proposition acceptable ?"
 
 #: src/olympia/pages/templates/pages/dev_faq.html:314
 #, python-format
 msgid ""
-"Yes. Mozilla's <a href=\"%(p_url)s\">Add-on Policy</a> describes what is an "
-"acceptable submission. This policy is subject to change without notice. In "
-"addition, the AMO editorial team uses the <a href=\"%(g_url)s\">Editors "
-"Reviewing Guide</a> to ensure that your add-on meets specific guidelines for"
-" functionality and security."
+"Yes. Mozilla's <a href=\"%(p_url)s\">Add-on Policy</a> describes what is an acceptable submission. This policy is subject to change without notice. In addition, the AMO editorial team uses the <a "
+"href=\"%(g_url)s\">Editors Reviewing Guide</a> to ensure that your add-on meets specific guidelines for functionality and security."
 msgstr ""
-"Oui. La <a href=\"%(p_url)s\">politique de module</a> de Mozilla décrit ce "
-"qu'est une proposition acceptable. Cette politique est sujette à changement "
-"sans avertissement préalable. De plus, l'équipe éditoriale d'AMO utilise le "
-"<a href=\"%(g_url)s\">guide de revue des éditeurs</a> pour s'assurer que "
-"votre module correspond à une certaine ligne de conduite quant aux "
-"fonctionnalités et à la sécurité."
+"Oui. La <a href=\"%(p_url)s\">politique de module</a> de Mozilla décrit ce qu'est une proposition acceptable. Cette politique est sujette à changement sans avertissement préalable. De plus, "
+"l'équipe éditoriale d'AMO utilise le <a href=\"%(g_url)s\">guide de revue des éditeurs</a> pour s'assurer que votre module correspond à une certaine ligne de conduite quant aux fonctionnalités et à"
+" la sécurité."
 
 #: src/olympia/pages/templates/pages/dev_faq.html:324
 msgid "How do I submit my add-on for review?"
@@ -12663,30 +9937,20 @@ msgstr "Comment puis-je envoyer mon module pour une revue ?"
 #: src/olympia/pages/templates/pages/dev_faq.html:326
 #, python-format
 msgid ""
-"The Developer Tools dashboard will allow you to upload and submit add-ons to"
-" AMO. You must be a registered AMO users before you can submit an add-on. "
-"Before submitting your add-on be sure to you have read the AMO <a "
-"href=\"%(url)s\">Editors Reviewing Guide</a> to ensure that your add-on has "
-"met the guidelines used by editors to review add-ons."
+"The Developer Tools dashboard will allow you to upload and submit add-ons to AMO. You must be a registered AMO users before you can submit an add-on. Before submitting your add-on be sure to you "
+"have read the AMO <a href=\"%(url)s\">Editors Reviewing Guide</a> to ensure that your add-on has met the guidelines used by editors to review add-ons."
 msgstr ""
-"Le tableau de bord des outils du développeur vous permet de charger et "
-"envoyer vos modules sur AMO. Vous devez être un utilisateur inscrit sur AMO "
-"avant de proposer un module. Avant l'envoi de votre module, assuez-vous "
-"d'avoir lu le <a href=\"%(url)s\">guide de revue des éditeurs</a> pour être "
-"sûr que votre module correspond à la ligne de conduite utilisée par les "
-"éditeurs pour évaluer les modules."
+"Le tableau de bord des outils du développeur vous permet de charger et envoyer vos modules sur AMO. Vous devez être un utilisateur inscrit sur AMO avant de proposer un module. Avant l'envoi de "
+"votre module, assuez-vous d'avoir lu le <a href=\"%(url)s\">guide de revue des éditeurs</a> pour être sûr que votre module correspond à la ligne de conduite utilisée par les éditeurs pour évaluer "
+"les modules."
 
 #: src/olympia/pages/templates/pages/dev_faq.html:336
 msgid "What operating system do I choose for my add-on?"
 msgstr "Quel système d'exploitation dois-je choisir pour mon module ?"
 
 #: src/olympia/pages/templates/pages/dev_faq.html:338
-msgid ""
-"You must choose the operating systems on which your add-on will successfully"
-" function."
-msgstr ""
-"Vous devez choisir les systèmes d'exploitation sur lesquels votre module "
-"fontionnera avec succès."
+msgid "You must choose the operating systems on which your add-on will successfully function."
+msgstr "Vous devez choisir les systèmes d'exploitation sur lesquels votre module fontionnera avec succès."
 
 #: src/olympia/pages/templates/pages/dev_faq.html:344
 msgid "What category do I choose for my add-on?"
@@ -12694,58 +9958,39 @@ msgstr "Quelle catégorie dois-je choisir pour mon module ?"
 
 #: src/olympia/pages/templates/pages/dev_faq.html:346
 msgid ""
-"The choice of category is dependent on what type of audience you are "
-"targeting and the functionality of your add-on. If you're unsure of which "
-"category your add-on falls into, please choose \"Other\". The AMO team may "
-"re-categorize your add-on if it's determined that it's better suited in a "
-"different category."
+"The choice of category is dependent on what type of audience you are targeting and the functionality of your add-on. If you're unsure of which category your add-on falls into, please choose "
+"\"Other\". The AMO team may re-categorize your add-on if it's determined that it's better suited in a different category."
 msgstr ""
-"Le choix de la catégorie dépend dy type d'audience que vous visez et des "
-"fonctionnalités de votre module. Si vous n'êtes pas certain de la catégorie "
-"dans laquelle votre module doit appartenir, merci de choisir « Autres ». "
-"L'équipe AMO se garde le droit de recatégoriser votre module s'il correspond"
-" mieux à une autre."
+"Le choix de la catégorie dépend dy type d'audience que vous visez et des fonctionnalités de votre module. Si vous n'êtes pas certain de la catégorie dans laquelle votre module doit appartenir, "
+"merci de choisir « Autres ». L'équipe AMO se garde le droit de recatégoriser votre module s'il correspond mieux à une autre."
 
 #: src/olympia/pages/templates/pages/dev_faq.html:355
 msgid "What does \"nominating\" my add-on mean?"
 msgstr "Qu'est-ce que « nominer » mon module signifie ?"
 
 #: src/olympia/pages/templates/pages/dev_faq.html:357
-msgid ""
-"Nominated add-ons are new add-ons that the author has nominated to become "
-"public via the Developer Tools."
-msgstr ""
-"Les modules nominés sont les nouveaux modules que l'auteur a nominé pour "
-"devenir public via les outils développeur."
+msgid "Nominated add-ons are new add-ons that the author has nominated to become public via the Developer Tools."
+msgstr "Les modules nominés sont les nouveaux modules que l'auteur a nominé pour devenir public via les outils développeur."
 
 #: src/olympia/pages/templates/pages/dev_faq.html:363
 msgid "Can I specify a license agreement for using my add-on?"
 msgstr "Puis-je préciser une licence particulière pour utiliser mon module ?"
 
 #: src/olympia/pages/templates/pages/dev_faq.html:365
-msgid ""
-"Yes. You can specify a license agreement when submitting your add-on. You "
-"can also add or update a license agreement via the Developer Tools dashboard"
-" after your add-on has been submitted."
+msgid "Yes. You can specify a license agreement when submitting your add-on. You can also add or update a license agreement via the Developer Tools dashboard after your add-on has been submitted."
 msgstr ""
-"Oui. Vous pouvez préciser une licence particulière lorsque vous proposez "
-"votre module. Vous pouvez aussi ajouter ou mettre à jour une licence via le "
-"tableau de bord outils du développeur après envoi de votre module."
+"Oui. Vous pouvez préciser une licence particulière lorsque vous proposez votre module. Vous pouvez aussi ajouter ou mettre à jour une licence via le tableau de bord outils du développeur après "
+"envoi de votre module."
 
 #: src/olympia/pages/templates/pages/dev_faq.html:372
 msgid "Can I include a privacy policy for my add-on?"
 msgstr "Puis-je inclure une politique de vie privée pour mon module ?"
 
 #: src/olympia/pages/templates/pages/dev_faq.html:374
-msgid ""
-"Yes. You can specify a privacy policy when submitting your add-on. You can "
-"also add or update a privacy policy via the Developer Tools dashboard after "
-"your add-on has been submitted."
+msgid "Yes. You can specify a privacy policy when submitting your add-on. You can also add or update a privacy policy via the Developer Tools dashboard after your add-on has been submitted."
 msgstr ""
-"Oui. Vous pouvez préciser une politique de vie privée lorsque vous proposez "
-"votre module. Vous pouvez aussi ajouter ou mettre à jour une politique de "
-"vie privée via le tableau de bord outils du développeur après envoi de votre"
-" module."
+"Oui. Vous pouvez préciser une politique de vie privée lorsque vous proposez votre module. Vous pouvez aussi ajouter ou mettre à jour une politique de vie privée via le tableau de bord outils du "
+"développeur après envoi de votre module."
 
 #: src/olympia/pages/templates/pages/dev_faq.html:383
 msgid "Why must my add-on be reviewed?"
@@ -12754,15 +9999,11 @@ msgstr "Pourquoi mon module doit-il être revu ?"
 #: src/olympia/pages/templates/pages/dev_faq.html:385
 #, python-format
 msgid ""
-"All add-ons submitted, whether new or updated, are reviewed to ensure that "
-"Mozilla users have a stable and safe experience. All add-ons submissions are"
-" reviewed using the guidelines outlined in the <a href=\"%(url)s\">Editors "
-"Reviewing Guide</a>."
+"All add-ons submitted, whether new or updated, are reviewed to ensure that Mozilla users have a stable and safe experience. All add-ons submissions are reviewed using the guidelines outlined in the"
+" <a href=\"%(url)s\">Editors Reviewing Guide</a>."
 msgstr ""
-"Tous les modules envoyés, qu'ils soient nouveaux ou mis à jours, sont "
-"vérifiés pour s'assurer que les utilisateurs de Mozilla n'auront pas de "
-"surprise. Tous les envois de module sont vérifiés suivant les directives "
-"édictées dans le <a href=\"%(url)s\">guide de revue des éditeurs</a>."
+"Tous les modules envoyés, qu'ils soient nouveaux ou mis à jours, sont vérifiés pour s'assurer que les utilisateurs de Mozilla n'auront pas de surprise. Tous les envois de module sont vérifiés "
+"suivant les directives édictées dans le <a href=\"%(url)s\">guide de revue des éditeurs</a>."
 
 #: src/olympia/pages/templates/pages/dev_faq.html:393
 msgid "Who reviews my add-on?"
@@ -12771,52 +10012,34 @@ msgstr "Qui fait la revue de mon module ?"
 #: src/olympia/pages/templates/pages/dev_faq.html:395
 #, python-format
 msgid ""
-"Add-ons are reviewed by the AMO Editors, a group of talented developers that"
-" volunteer to help the Mozilla project by reviewing add-ons to ensure a "
-"stable and safe experience for Mozilla users. When communicating with "
-"editors, please be courteous, patient and respectful as they are working "
-"hard to ensure that your add-on is set up correctly and follows the "
-"guidelines outlined in the <a href=\"%(url)s\">Editors Reviewing Guide</a>."
+"Add-ons are reviewed by the AMO Editors, a group of talented developers that volunteer to help the Mozilla project by reviewing add-ons to ensure a stable and safe experience for Mozilla users. "
+"When communicating with editors, please be courteous, patient and respectful as they are working hard to ensure that your add-on is set up correctly and follows the guidelines outlined in the <a "
+"href=\"%(url)s\">Editors Reviewing Guide</a>."
 msgstr ""
-"Les modules sont revus par les éditeurs AMO, un groupe de talentueux "
-"développeurs volontaires qui aident le projet Mozilla en vérifiant les "
-"modules complémentaires afin que les utilisateurs bénéficient de logiciels "
-"stables et sécurisés. Lorsque vous discutez avec les éditeurs, veillez à "
-"être poli, patient et respectueux. Les éditeurs travaillent dur pour "
-"s'assurer que votre module puisse être installé correctement et respecte les"
-" règles indiquées dans le <a href=\"%(url)s\">guide de revue</a>."
+"Les modules sont revus par les éditeurs AMO, un groupe de talentueux développeurs volontaires qui aident le projet Mozilla en vérifiant les modules complémentaires afin que les utilisateurs "
+"bénéficient de logiciels stables et sécurisés. Lorsque vous discutez avec les éditeurs, veillez à être poli, patient et respectueux. Les éditeurs travaillent dur pour s'assurer que votre module "
+"puisse être installé correctement et respecte les règles indiquées dans le <a href=\"%(url)s\">guide de revue</a>."
 
 #: src/olympia/pages/templates/pages/dev_faq.html:406
 msgid "What are the guidelines used to review my add-on?"
-msgstr ""
-"Quelles sont les lignes directrices utilisées pour vérifier mon module ?"
+msgstr "Quelles sont les lignes directrices utilisées pour vérifier mon module ?"
 
 #: src/olympia/pages/templates/pages/dev_faq.html:408
 #, python-format
 msgid ""
-"The Mozilla editorial team follows the <a href=\"%(url)s\">Editors Reviewing"
-" Guide</a> when testing an add-on for acceptance onto AMO. It is important "
-"that add-on developers review this guide to ensure that common problem areas"
-" are addressed prior to submitting their add-on for review. This will "
-"greatly assist in expediting the review process."
+"The Mozilla editorial team follows the <a href=\"%(url)s\">Editors Reviewing Guide</a> when testing an add-on for acceptance onto AMO. It is important that add-on developers review this guide to "
+"ensure that common problem areas are addressed prior to submitting their add-on for review. This will greatly assist in expediting the review process."
 msgstr ""
-"Lorsqu'elle vérifie la conformité d'un module pour AMO, l'équipe éditoriale "
-"Mozilla suit le <a href=\"%(url)s\">guide de revue</a>. Il est important que"
-" les développeurs de modules lisent ce guide avant d'envoyer un module pour "
-"mieux résoudre les éventuels problèmes. Cela aidera à accélérer le processus"
-" de revue."
+"Lorsqu'elle vérifie la conformité d'un module pour AMO, l'équipe éditoriale Mozilla suit le <a href=\"%(url)s\">guide de revue</a>. Il est important que les développeurs de modules lisent ce guide "
+"avant d'envoyer un module pour mieux résoudre les éventuels problèmes. Cela aidera à accélérer le processus de revue."
 
 #: src/olympia/pages/templates/pages/dev_faq.html:418
 msgid "How long will it take for my add-on to be reviewed?"
 msgstr "Combien de temps compter pour la revue de mon module ?"
 
 #: src/olympia/pages/templates/pages/dev_faq.html:420
-msgid ""
-"We cannot give a time estimate as to how long it will take before an add-on "
-"is reviewed. Many factors affect the time including the:"
-msgstr ""
-"Nous ne pouvons pas donner une estimation du temps nécessaire à la revue "
-"d'un module. Beaucoup de facteurs ont une incidence, dont :"
+msgid "We cannot give a time estimate as to how long it will take before an add-on is reviewed. Many factors affect the time including the:"
+msgstr "Nous ne pouvons pas donner une estimation du temps nécessaire à la revue d'un module. Beaucoup de facteurs ont une incidence, dont :"
 
 #. part of a list (<li>)
 #: src/olympia/pages/templates/pages/dev_faq.html:427
@@ -12836,62 +10059,41 @@ msgstr "nombre de problèmes découverts"
 #: src/olympia/pages/templates/pages/dev_faq.html:434
 #, python-format
 msgid ""
-"This is why it's very important to read the <a href=\"%(g_url)s\">Editors "
-"Reviewing Guide</a> to ensure that your add-on is setup as expected. It's "
-"also a good idea to read the blog post, <a "
-"href=\"%(blog_url)s\">Successfully Getting your Add-on Reviewed</a> which "
-"provides excellent insight into ensuring a smooth review of your add-on."
+"This is why it's very important to read the <a href=\"%(g_url)s\">Editors Reviewing Guide</a> to ensure that your add-on is setup as expected. It's also a good idea to read the blog post, <a "
+"href=\"%(blog_url)s\">Successfully Getting your Add-on Reviewed</a> which provides excellent insight into ensuring a smooth review of your add-on."
 msgstr ""
-"C'est pour cela qu'il est très important de lire le <a "
-"href=\"%(g_url)s\">guide de revue des éditeurs</a> pour s'assurer que votre "
-"module est configuré comme attendu. C'est également une bonne idée de lire "
-"le billet, <a href=\"%(blog_url)s\">Successfully Getting your Add-on "
-"Reviewed</a> qui fournit d'excellentes pistes pour assurer une revue aussi "
-"douce que possible de votre module."
+"C'est pour cela qu'il est très important de lire le <a href=\"%(g_url)s\">guide de revue des éditeurs</a> pour s'assurer que votre module est configuré comme attendu. C'est également une bonne idée"
+" de lire le billet, <a href=\"%(blog_url)s\">Successfully Getting your Add-on Reviewed</a> qui fournit d'excellentes pistes pour assurer une revue aussi douce que possible de votre module."
 
 #: src/olympia/pages/templates/pages/dev_faq.html:446
 msgid "How can I see how many times my add-on has been downloaded?"
 msgstr "Comment voir combien de fois mon module a été téléchargé ?"
 
 #: src/olympia/pages/templates/pages/dev_faq.html:448
-msgid ""
-"The Statistics Dashboard found in the Developer Tools dashboard provides "
-"information that can help you determine your add-on downloads since you've "
-"submitted it to AMO."
+msgid "The Statistics Dashboard found in the Developer Tools dashboard provides information that can help you determine your add-on downloads since you've submitted it to AMO."
 msgstr ""
-"Le tableau de bord des statistiques peut être trouvé dans le tableau de bord"
-" des outils du développeur et contient des informations qui vous permettent "
-"de savoir le nombre de téléchargements de votre module depuis qu'il a été "
-"envoyé sur AMO."
+"Le tableau de bord des statistiques peut être trouvé dans le tableau de bord des outils du développeur et contient des informations qui vous permettent de savoir le nombre de téléchargements de "
+"votre module depuis qu'il a été envoyé sur AMO."
 
 #: src/olympia/pages/templates/pages/dev_faq.html:455
 msgid "How can I see how many active users are using my add-on?"
 msgstr "Comment voir combien d'utilisateurs actifs utilisent mon module ?"
 
 #: src/olympia/pages/templates/pages/dev_faq.html:457
-msgid ""
-"The Statistics Dashboard found in the Developer Tools dashboard provides "
-"information that can help you determine how many users have been actively "
-"using your add-on since you've submitted it to AMO."
+msgid "The Statistics Dashboard found in the Developer Tools dashboard provides information that can help you determine how many users have been actively using your add-on since you've submitted it to AMO."
 msgstr ""
-"Le tableau de bord des statistiques peut être trouvé dans le tableau de bord"
-" des outils du développeur et contient des informations qui vous permettent "
-"de savoir le nombre d'utilisateurs actifs de votre module depuis qu'il a été"
-" envoyé sur AMO."
+"Le tableau de bord des statistiques peut être trouvé dans le tableau de bord des outils du développeur et contient des informations qui vous permettent de savoir le nombre d'utilisateurs actifs de "
+"votre module depuis qu'il a été envoyé sur AMO."
 
 #: src/olympia/pages/templates/pages/dev_faq.html:464
 msgid "How do I submit an update for my add-on?"
 msgstr "Comment puis-je envoyer une mise à jour pour mon module ?"
 
 #: src/olympia/pages/templates/pages/dev_faq.html:466
-msgid ""
-"You can submit an update for your add-on via the Developer Tools dashboard "
-"by choosing the option \"Upload a new version\" and uploading a new .xpi "
-"file for your add-on."
+msgid "You can submit an update for your add-on via the Developer Tools dashboard by choosing the option \"Upload a new version\" and uploading a new .xpi file for your add-on."
 msgstr ""
-"Vous pouvez envoyer une mise à jour de votre module via le tableau de bord "
-"des outils du développeur en choisissant l'option « Envoyer une nouvelle "
-"version » et en chargeant en nouveau fichier .xpi pour votre module."
+"Vous pouvez envoyer une mise à jour de votre module via le tableau de bord des outils du développeur en choisissant l'option « Envoyer une nouvelle version » et en chargeant en nouveau fichier .xpi"
+" pour votre module."
 
 #: src/olympia/pages/templates/pages/dev_faq.html:473
 msgid "Does my update need to be reviewed by editors?"
@@ -12899,179 +10101,109 @@ msgstr "Ma mise à jour a-t-elle besoin d'être vérifiée par les éditeurs."
 
 #: src/olympia/pages/templates/pages/dev_faq.html:475
 msgid ""
-"That depends. If you are simply changing a description of your add-on or "
-"updating a \"maxVersion\" to ensure compatibility with a new Mozilla "
-"software update, then your add-on does not need to be reviewed again. If, "
-"however, you submit a new updated file, then your add-on update will need to"
-" be reviewed by an editor."
+"That depends. If you are simply changing a description of your add-on or updating a \"maxVersion\" to ensure compatibility with a new Mozilla software update, then your add-on does not need to be "
+"reviewed again. If, however, you submit a new updated file, then your add-on update will need to be reviewed by an editor."
 msgstr ""
-"Cela dépend. Si vous faites seulement un changement de description ou que "
-"vous mettez à jour la valeur « maxVersion » pour assurer la compatibilité "
-"avec une nouvelle version, alors votre module n'a pas besoin d'être "
-"revérifié. Par contre, si vous envoyez un nouveau fichier, alors votre mise "
-"à jour sera vérifiée par un éditeur."
+"Cela dépend. Si vous faites seulement un changement de description ou que vous mettez à jour la valeur « maxVersion » pour assurer la compatibilité avec une nouvelle version, alors votre module n'a"
+" pas besoin d'être revérifié. Par contre, si vous envoyez un nouveau fichier, alors votre mise à jour sera vérifiée par un éditeur."
 
 #: src/olympia/pages/templates/pages/dev_faq.html:486
-msgid ""
-"How do I reply to a user who has posted a negative review of my add-on?"
-msgstr ""
-"Comment puis-je répondre à un utilisateur qui a posté un commentaire négatif"
-" sur mon module ?"
+msgid "How do I reply to a user who has posted a negative review of my add-on?"
+msgstr "Comment puis-je répondre à un utilisateur qui a posté un commentaire négatif sur mon module ?"
 
 #: src/olympia/pages/templates/pages/dev_faq.html:488
-msgid ""
-"A developer may reply to any review posted to their add-on as long as they "
-"are logged into AMO. In addition, any user can flag a review as:"
-msgstr ""
-"Un développeur peut répondre à tout commentaire posté sur son module du "
-"moment qu'il est connecté sur AMO. En plus, tout utilisateur peut étiquetter"
-" un commentaire comme :"
+msgid "A developer may reply to any review posted to their add-on as long as they are logged into AMO. In addition, any user can flag a review as:"
+msgstr "Un développeur peut répondre à tout commentaire posté sur son module du moment qu'il est connecté sur AMO. En plus, tout utilisateur peut étiquetter un commentaire comme :"
 
 #. part of a list (<li>)
-#: src/olympia/pages/templates/pages/dev_faq.html:495
-#: src/olympia/reviews/models.py:159
+#: src/olympia/pages/templates/pages/dev_faq.html:495 src/olympia/reviews/models.py:159
 msgid "Spam or otherwise non-review content"
 msgstr "Spam ou contenu qui n'est pas une critique du module"
 
 #. part of a list (<li>)
-#: src/olympia/pages/templates/pages/dev_faq.html:497
-#: src/olympia/reviews/models.py:160
+#: src/olympia/pages/templates/pages/dev_faq.html:497 src/olympia/reviews/models.py:160
 msgid "Inappropriate language/dialog"
 msgstr "Langage inapproprié"
 
 #. part of a list (<li>)
-#: src/olympia/pages/templates/pages/dev_faq.html:499
-#: src/olympia/reviews/models.py:161
+#: src/olympia/pages/templates/pages/dev_faq.html:499 src/olympia/reviews/models.py:161
 msgid "Misplaced bug report or support request"
 msgstr "Rapport de bogue ou demande d'assistance inadéquate dans ce contexte"
 
 #. part of a list (<li>)
 #: src/olympia/pages/templates/pages/dev_faq.html:501
 msgid "Other (provides a pop-up prompt for information)"
-msgstr ""
-"Autre (fournit une fenêtre surgissante pour fournir plus d'informations)"
+msgstr "Autre (fournit une fenêtre surgissante pour fournir plus d'informations)"
 
 #: src/olympia/pages/templates/pages/dev_faq.html:504
-msgid ""
-"Currently, AMO does not provide a mechanism to directly communicate with a "
-"reviewer but this feature is being investigated and considered for a future "
-"update."
-msgstr ""
-"Actuellement, AMO ne propose pas de mécanisme pour directement communiquer "
-"avec un testeur mais cette fonctionnalité est actuellement à l'étude et "
-"pourra venir dans une future mise à jour."
+msgid "Currently, AMO does not provide a mechanism to directly communicate with a reviewer but this feature is being investigated and considered for a future update."
+msgstr "Actuellement, AMO ne propose pas de mécanisme pour directement communiquer avec un testeur mais cette fonctionnalité est actuellement à l'étude et pourra venir dans une future mise à jour."
 
 #: src/olympia/pages/templates/pages/dev_faq.html:511
 msgid "Can I request that a review be removed if the review is negative?"
 msgstr "Puis-je demander le retrait d'un commentaire négatif ?"
 
 #: src/olympia/pages/templates/pages/dev_faq.html:513
-msgid ""
-"No. We do not remove negative reviews from add-ons unless they are found to "
-"be false."
-msgstr ""
-"Non. Nous ne supprimons pas les commentaires négatifs des modules à moins "
-"qu'ils s'avèrent qu'ils soient faux."
+msgid "No. We do not remove negative reviews from add-ons unless they are found to be false."
+msgstr "Non. Nous ne supprimons pas les commentaires négatifs des modules à moins qu'ils s'avèrent qu'ils soient faux."
 
 #: src/olympia/pages/templates/pages/dev_faq.html:519
 msgid "Can I request that a review be removed if the review is inaccurate?"
 msgstr "Puis-je demander le retrait d'un commentaire qui est inexact ?"
 
 #: src/olympia/pages/templates/pages/dev_faq.html:521
-msgid ""
-"If an author contacts us and asks for a review containing false or "
-"inaccurate information to be removed, we will review the post and consider "
-"removing it."
-msgstr ""
-"Si un auteur nous contacte et nous demande le retrait d'un commentaire faux "
-"ou inexact, nous vérifierons celui-ci et pourrons éventuellement le retirer."
+msgid "If an author contacts us and asks for a review containing false or inaccurate information to be removed, we will review the post and consider removing it."
+msgstr "Si un auteur nous contacte et nous demande le retrait d'un commentaire faux ou inexact, nous vérifierons celui-ci et pourrons éventuellement le retirer."
 
 #: src/olympia/pages/templates/pages/dev_faq.html:530
 msgid ""
-"Do you need more information about the various open source licenses? Are you"
-" confused as to which license you should select? What rights does a specific"
-" license grant? While nothing replaces reading the full terms of a license, "
-"below are some sites that contain information about some of the key open "
-"source licenses that may help you sort out the differences between them. "
-"These sites are being provided solely for your convenience and as a "
-"reference for your personal use. These resources do not constitute legal "
-"advice nor should they be used in lieu of such advice. Mozilla neither "
-"guarantees nor is responsible for the content of these sites or your "
-"reliance on such content."
+"Do you need more information about the various open source licenses? Are you confused as to which license you should select? What rights does a specific license grant? While nothing replaces "
+"reading the full terms of a license, below are some sites that contain information about some of the key open source licenses that may help you sort out the differences between them. These sites "
+"are being provided solely for your convenience and as a reference for your personal use. These resources do not constitute legal advice nor should they be used in lieu of such advice. Mozilla "
+"neither guarantees nor is responsible for the content of these sites or your reliance on such content."
 msgstr ""
-"Vous avez besoin d'aide au sujet de la variété de licences open source ? "
-"Vous êtes perdus quant à la licence à adopter ? Quels sont les droits qu'une"
-" licence précise donne ? Bien que rien ne remplacera la lecture attentive de"
-" tous les termes de la licence, ci-dessous vous trouverez quelques sites qui"
-" contiennent des informations à propos des licences open sources principales"
-" et pourront vous aider à faire votre choix. Ces sites sont donnés à titre "
-"indicatif pour votre utilisation personnelle. Ces ressources ne sont en "
-"aucun cas des conseils ayant valeur légale et ne devraient être utilisés "
-"comme tels. Mozilla ne garantie ni n'est responsable pour le contenu de ces "
-"sites ou votre confiance dans ce contenu."
+"Vous avez besoin d'aide au sujet de la variété de licences open source ? Vous êtes perdus quant à la licence à adopter ? Quels sont les droits qu'une licence précise donne ? Bien que rien ne "
+"remplacera la lecture attentive de tous les termes de la licence, ci-dessous vous trouverez quelques sites qui contiennent des informations à propos des licences open sources principales et "
+"pourront vous aider à faire votre choix. Ces sites sont donnés à titre indicatif pour votre utilisation personnelle. Ces ressources ne sont en aucun cas des conseils ayant valeur légale et ne "
+"devraient être utilisés comme tels. Mozilla ne garantie ni n'est responsable pour le contenu de ces sites ou votre confiance dans ce contenu."
 
 #: src/olympia/pages/templates/pages/dev_faq.html:545
 msgid ""
-"In addition to the full text of the Mozilla Public License(\"MPL\"), this "
-"also provides an annotated version of the MPL and an <abbr "
-"title=\"Frequently Asked Questions\">FAQ</abbr> to help you if you want to "
-"use or distribute code licensed under it."
+"In addition to the full text of the Mozilla Public License(\"MPL\"), this also provides an annotated version of the MPL and an <abbr title=\"Frequently Asked Questions\">FAQ</abbr> to help you if "
+"you want to use or distribute code licensed under it."
 msgstr ""
-"En plus du texte complet de la Mozilla Public License (« MPL »), ceci "
-"fournit également une version annotée de la MPL et une <abbr title=\"Foire "
-"Aux Questions\">FAQ</abbr> pour vous aider si vous voulez utiliser ou "
-"distribuer du code sous cette licence."
+"En plus du texte complet de la Mozilla Public License (« MPL »), ceci fournit également une version annotée de la MPL et une <abbr title=\"Foire Aux Questions\">FAQ</abbr> pour vous aider si vous "
+"voulez utiliser ou distribuer du code sous cette licence."
 
 #: src/olympia/pages/templates/pages/dev_faq.html:559
-msgid ""
-"A table summarizing and comparing how some of the key open source licenses "
-"treat distributions, proprietary software linking, and redistribution of "
-"code with changes."
+msgid "A table summarizing and comparing how some of the key open source licenses treat distributions, proprietary software linking, and redistribution of code with changes."
 msgstr ""
-"Un tableau résumant et comparant comment certaines des licences open sources"
-" principales traitent la distribution, le lien avec les logiciels "
-"propriétaires et la redistribution du code avec des changements."
+"Un tableau résumant et comparant comment certaines des licences open sources principales traitent la distribution, le lien avec les logiciels propriétaires et la redistribution du code avec des "
+"changements."
 
 #: src/olympia/pages/templates/pages/dev_faq.html:572
 msgid ""
-"Free Software Foundation provides short summaries of the key open source "
-"licenses, including whether the license qualifies as a free software license"
-" or a copyleft license. Also includes a discussion of what constitutes a "
-"free software license or a copyleft license (e.g., a Copyleft license is a "
-"general method for making a program or other work free, and requiring all "
-"modified and extended versions of the program to be free as well.)"
+"Free Software Foundation provides short summaries of the key open source licenses, including whether the license qualifies as a free software license or a copyleft license. Also includes a "
+"discussion of what constitutes a free software license or a copyleft license (e.g., a Copyleft license is a general method for making a program or other work free, and requiring all modified and "
+"extended versions of the program to be free as well.)"
 msgstr ""
-"La Free Software Foundation propose un court résumé des licences open "
-"source, incluant la qualification de licence logiciel libre ou licence "
-"copyleft. Cela inclus une discussion sur ce qui constitue une licence "
-"logiciel libre ou une licence copyleft (e.g., une licence copyleft est une "
-"méthode générale pour rendre un programme ou autre création libre, et "
-"imposer que toute version modifiée et étendue de celui-ci soient libres "
-"également)."
+"La Free Software Foundation propose un court résumé des licences open source, incluant la qualification de licence logiciel libre ou licence copyleft. Cela inclus une discussion sur ce qui "
+"constitue une licence logiciel libre ou une licence copyleft (e.g., une licence copyleft est une méthode générale pour rendre un programme ou autre création libre, et imposer que toute version "
+"modifiée et étendue de celui-ci soient libres également)."
 
 #: src/olympia/pages/templates/pages/dev_faq.html:589
-msgid ""
-"Open Source Initiative provides the terms of some of the key open source "
-"licenses."
-msgstr ""
-"L'Open Source Initiative donne les termes de certaines des licences open "
-"sources principales."
+msgid "Open Source Initiative provides the terms of some of the key open source licenses."
+msgstr "L'Open Source Initiative donne les termes de certaines des licences open sources principales."
 
 #: src/olympia/pages/templates/pages/dev_faq.html:599
 msgid "A comparison of known open source licenses on Wikipedia."
 msgstr "Une comparaison des licences <i>open source</i> sur Wikipédia."
 
 #: src/olympia/pages/templates/pages/dev_faq.html:605
-msgid ""
-"A site to provide non-judgmental guidance on choosing a license for your "
-"open source project."
-msgstr ""
-"Un site objectif pour vous aider à choisir une licence pour votre projet "
-"<i>open source</i>."
+msgid "A site to provide non-judgmental guidance on choosing a license for your open source project."
+msgstr "Un site objectif pour vous aider à choisir une licence pour votre projet <i>open source</i>."
 
-#: src/olympia/pages/templates/pages/faq.html:3
-#: src/olympia/pages/templates/pages/faq.html:9
-#: src/olympia/pages/templates/pages/faq.html:10
+#: src/olympia/pages/templates/pages/faq.html:3 src/olympia/pages/templates/pages/faq.html:9 src/olympia/pages/templates/pages/faq.html:10
 msgid "Frequently Asked Questions"
 msgstr "Foire Aux Questions"
 
@@ -13086,49 +10218,29 @@ msgstr "Qu'est-ce qu'un module ?"
 #: src/olympia/pages/templates/pages/faq.html:16
 #, python-format
 msgid ""
-"Add-ons are small pieces of software that add new features or functionality "
-"to your installation of %(app_name)s. Add-ons can augment %(app_name)s with "
-"new features, foreign language dictionaries, or change its visual "
-"appearance. Through add-ons, you can customize %(app_name)s to meet your "
-"needs and tastes. <a href=\"%(learnmore_url)s\">Learn more about "
-"customization</a>"
+"Add-ons are small pieces of software that add new features or functionality to your installation of %(app_name)s. Add-ons can augment %(app_name)s with new features, foreign language dictionaries, "
+"or change its visual appearance. Through add-ons, you can customize %(app_name)s to meet your needs and tastes. <a href=\"%(learnmore_url)s\">Learn more about customization</a>"
 msgstr ""
-"Les modules sont de petits morceaux de logiciel qui ajoutent de nouvelles "
-"fonctionnalités à votre installation de %(app_name)s. Les modules peuvent "
-"améliorer %(app_name)s en proposant de nouvelles fonctionnalités, des "
-"dictionnaires de langues étrangères ou changer son apparence. Grâce aux "
-"modules, vous pouvez personnaliser %(app_name)s conformément à vos goûts et "
-"besoins. <a href=\"%(learnmore_url)s\">En savoir plus sur la "
-"personnalisation</a>"
+"Les modules sont de petits morceaux de logiciel qui ajoutent de nouvelles fonctionnalités à votre installation de %(app_name)s. Les modules peuvent améliorer %(app_name)s en proposant de nouvelles "
+"fonctionnalités, des dictionnaires de langues étrangères ou changer son apparence. Grâce aux modules, vous pouvez personnaliser %(app_name)s conformément à vos goûts et besoins. <a "
+"href=\"%(learnmore_url)s\">En savoir plus sur la personnalisation</a>"
 
 #: src/olympia/pages/templates/pages/faq.html:26
 msgid "Will add-ons work with my web browser or application?"
-msgstr ""
-"Les modules fonctionnent-ils avec mon navigateur web ou mon application ?"
+msgstr "Les modules fonctionnent-ils avec mon navigateur web ou mon application ?"
 
 #: src/olympia/pages/templates/pages/faq.html:27
 #, python-format
 msgid ""
-"Add-ons listed in this gallery only work with Mozilla-based applications, "
-"such as <a href=\"%(getfirefox_url)s\">Firefox</a>, <a "
-"href=\"%(getmobile_url)s\">Firefox Mobile</a>, <a "
-"href=\"%(getseamonkey_url)s\">SeaMonkey</a>, and <a "
-"href=\"%(getthunderbird_url)s\">Thunderbird</a>. However, not all add-ons "
-"work with each of those applications or every version of those applications."
-" Each add-on specifies which applications and versions it works with, such "
-"as Firefox 2.0 - 3.6.*. For Firefox add-ons, the install buttons will "
-"indicate whether the add-on is compatible or not."
+"Add-ons listed in this gallery only work with Mozilla-based applications, such as <a href=\"%(getfirefox_url)s\">Firefox</a>, <a href=\"%(getmobile_url)s\">Firefox Mobile</a>, <a "
+"href=\"%(getseamonkey_url)s\">SeaMonkey</a>, and <a href=\"%(getthunderbird_url)s\">Thunderbird</a>. However, not all add-ons work with each of those applications or every version of those "
+"applications. Each add-on specifies which applications and versions it works with, such as Firefox 2.0 - 3.6.*. For Firefox add-ons, the install buttons will indicate whether the add-on is "
+"compatible or not."
 msgstr ""
-"Les modules listés dans cette galerie ne fonctionnent qu'avec les "
-"applications Mozilla, telles que <a href=\"%(getfirefox_url)s\">Firefox</a>,"
-" <a href=\"%(getmobile_url)s\">Firefox Mobile</a>, <a "
-"href=\"%(getseamonkey_url)s\">SeaMonkey</a>, and <a "
-"href=\"%(getthunderbird_url)s\">Thunderbird</a>. Cependant, tous les modules"
-" ne fonctionnent pas sur chacune de ces applications ou chaque version de "
-"ces dernières. Chaque module spécifie les applications et versions avec "
-"lesquelles il fonctionne, comme par exemple Firefox 2.0 - 3.6.*. Pour les "
-"modules Firefox, le bouton d'installation indiquera si le module est "
-"compatible ou non."
+"Les modules listés dans cette galerie ne fonctionnent qu'avec les applications Mozilla, telles que <a href=\"%(getfirefox_url)s\">Firefox</a>, <a href=\"%(getmobile_url)s\">Firefox Mobile</a>, <a "
+"href=\"%(getseamonkey_url)s\">SeaMonkey</a>, and <a href=\"%(getthunderbird_url)s\">Thunderbird</a>. Cependant, tous les modules ne fonctionnent pas sur chacune de ces applications ou chaque "
+"version de ces dernières. Chaque module spécifie les applications et versions avec lesquelles il fonctionne, comme par exemple Firefox 2.0 - 3.6.*. Pour les modules Firefox, le bouton "
+"d'installation indiquera si le module est compatible ou non."
 
 #: src/olympia/pages/templates/pages/faq.html:42
 msgid "What are the different types of add-ons?"
@@ -13136,80 +10248,45 @@ msgstr "Quels sont les différents types de modules ?"
 
 #: src/olympia/pages/templates/pages/faq.html:43
 #, python-format
-msgid ""
-"There are several kinds of add-ons that customize %(app_name)s in different "
-"ways:"
-msgstr ""
-"Il y a plusieurs types de modules pour personnaliser %(app_name)s de "
-"différentes manières :"
+msgid "There are several kinds of add-ons that customize %(app_name)s in different ways:"
+msgstr "Il y a plusieurs types de modules pour personnaliser %(app_name)s de différentes manières :"
 
 #: src/olympia/pages/templates/pages/faq.html:47
 #, python-format
 msgid ""
-"<strong><a href=\"%(browse_url)s\">Extensions</a></strong> add new features "
-"to %(app_name)s or modify existing functionality. There are extensions that "
-"allow you to block advertisements, download videos from websites, integrate "
-"more closely with social websites, and add features you see in other "
-"applications."
+"<strong><a href=\"%(browse_url)s\">Extensions</a></strong> add new features to %(app_name)s or modify existing functionality. There are extensions that allow you to block advertisements, download "
+"videos from websites, integrate more closely with social websites, and add features you see in other applications."
 msgstr ""
-"<strong><a href=\"%(browse_url)s\">Extensions</a></strong> pour ajouter de "
-"nouvelles fonctionnalités à %(app_name)s ou modifier les fonctionnalités "
-"existantes. Il existe des extensions qui permettent de bloquer les "
-"publicités, télécharger des vidéos depuis des sites web, permettre une plus "
-"grande intégration aux sites web sociaux, et ajouter des fonctionnalités "
-"présentes dans d'autres applications."
+"<strong><a href=\"%(browse_url)s\">Extensions</a></strong> pour ajouter de nouvelles fonctionnalités à %(app_name)s ou modifier les fonctionnalités existantes. Il existe des extensions qui "
+"permettent de bloquer les publicités, télécharger des vidéos depuis des sites web, permettre une plus grande intégration aux sites web sociaux, et ajouter des fonctionnalités présentes dans "
+"d'autres applications."
 
 #: src/olympia/pages/templates/pages/faq.html:55
 #, python-format
-msgid ""
-"<strong><a href=\"%(browse_url)s\">Complete Themes</a></strong> change the "
-"entire appearance of %(app_name)s, usually including icons, colors, dialogs,"
-" and other visual styles."
-msgstr ""
-"<strong><a href=\"%(browse_url)s\">Thèmes complets</a></strong> pour changer"
-" complètement l'apparence de %(app_name)s, notamment les icônes, couleurs, "
-"dialogues, et autres éléments visuels."
+msgid "<strong><a href=\"%(browse_url)s\">Complete Themes</a></strong> change the entire appearance of %(app_name)s, usually including icons, colors, dialogs, and other visual styles."
+msgstr "<strong><a href=\"%(browse_url)s\">Thèmes complets</a></strong> pour changer complètement l'apparence de %(app_name)s, notamment les icônes, couleurs, dialogues, et autres éléments visuels."
 
 #: src/olympia/pages/templates/pages/faq.html:61
 #, python-format
-msgid ""
-"<strong><a href=\"%(browse_url)s\">Themes</a></strong> are lightweight "
-"themes that use background images to customize your %(app_name)s toolbars."
-msgstr ""
-"<strong><a href=\"%(browse_url)s\">Thèmes</a></strong> sont des thèmes "
-"légers qui utilisent une image d'arrière plan pour personnaliser vos barres "
-"d'outils dans %(app_name)s."
+msgid "<strong><a href=\"%(browse_url)s\">Themes</a></strong> are lightweight themes that use background images to customize your %(app_name)s toolbars."
+msgstr "<strong><a href=\"%(browse_url)s\">Thèmes</a></strong> sont des thèmes légers qui utilisent une image d'arrière plan pour personnaliser vos barres d'outils dans %(app_name)s."
 
 #: src/olympia/pages/templates/pages/faq.html:66
 #, python-format
-msgid ""
-"<strong><a href=\"%(browse_url)s\">Search Providers</a> </strong> add "
-"additional choices to the search box dropdown. These providers allow you to "
-"quickly search any website."
+msgid "<strong><a href=\"%(browse_url)s\">Search Providers</a> </strong> add additional choices to the search box dropdown. These providers allow you to quickly search any website."
 msgstr ""
-"<strong><a href=\"%(browse_url)s\">Moteurs de recherche</a> </strong> pour "
-"ajouter de nouveaux choix à la sélection des moteurs de recherche. Ces "
-"fournisseurs vous permettent de rechercher simplement n'importe quel site."
+"<strong><a href=\"%(browse_url)s\">Moteurs de recherche</a> </strong> pour ajouter de nouveaux choix à la sélection des moteurs de recherche. Ces fournisseurs vous permettent de rechercher "
+"simplement n'importe quel site."
 
 #: src/olympia/pages/templates/pages/faq.html:72
 #, python-format
-msgid ""
-"<strong><a href=\"%(browse_url)s\">Dictionaries & Language "
-"Packs</a></strong> add support for additional languages to %(app_name)s."
-msgstr ""
-"<strong><a href=\"%(browse_url)s\">Dictionnaires et packs de "
-"langue</a></strong> pour ajouter de nouvelles langues à %(app_name)s."
+msgid "<strong><a href=\"%(browse_url)s\">Dictionaries & Language Packs</a></strong> add support for additional languages to %(app_name)s."
+msgstr "<strong><a href=\"%(browse_url)s\">Dictionnaires et packs de langue</a></strong> pour ajouter de nouvelles langues à %(app_name)s."
 
 #: src/olympia/pages/templates/pages/faq.html:77
 #, python-format
-msgid ""
-"<strong><a href=\"%(browse_url)s\">Plugins</a></strong> help %(app_name)s "
-"display or understand different types of media, such as Adobe Flash or Apple"
-" Quicktime."
-msgstr ""
-"<strong><a href=\"%(browse_url)s\">Greffons</a></strong> pour aider "
-"%(app_name)s à afficher ou comprendre différents types de média tels que  "
-"Adobe Flash ou Apple Quicktime."
+msgid "<strong><a href=\"%(browse_url)s\">Plugins</a></strong> help %(app_name)s display or understand different types of media, such as Adobe Flash or Apple Quicktime."
+msgstr "<strong><a href=\"%(browse_url)s\">Greffons</a></strong> pour aider %(app_name)s à afficher ou comprendre différents types de média tels que  Adobe Flash ou Apple Quicktime."
 
 #: src/olympia/pages/templates/pages/faq.html:85
 msgid "How do I install, manage, or remove an add-on?"
@@ -13218,23 +10295,14 @@ msgstr "Comment installer, gérer ou supprimer un module ?"
 #: src/olympia/pages/templates/pages/faq.html:86
 #, python-format
 msgid ""
-"In most cases, add-ons can be installed by simply clicking the install "
-"button provided. Add-ons can be managed, disabled, or uninstalled from the "
-"Add-ons Manager in %(app_name)s. For more detailed instructions, read <a "
-"href=\"%(extension_url)s\">this article on extensions</a> or <a "
-"href=\"%(theme_url)s\">this one for Themes and Complete Themes</a>. If you "
-"have difficulty installing add-ons, see <a "
-"href=\"%(troubleshooting_url)s\">Troubleshooting Extensions and Themes</a>."
+"In most cases, add-ons can be installed by simply clicking the install button provided. Add-ons can be managed, disabled, or uninstalled from the Add-ons Manager in %(app_name)s. For more detailed "
+"instructions, read <a href=\"%(extension_url)s\">this article on extensions</a> or <a href=\"%(theme_url)s\">this one for Themes and Complete Themes</a>. If you have difficulty installing add-ons, "
+"see <a href=\"%(troubleshooting_url)s\">Troubleshooting Extensions and Themes</a>."
 msgstr ""
-"Dans la plupart des cas, les modules peuvent être simplement installés en "
-"cliquant sur le bouton d'installation fournis. Les modules peuvent être "
-"gérés, désactivés ou désinstallés depuis le gestionnaire de modules de "
-"%(app_name)s. Pour des instructions plus détaillées, référez-vous à <a "
-"href=\"%(extension_url)s\">cet article sur les extensions</a> ou <a "
-"href=\"%(theme_url)s\">celui-ci pour les thèmes et les thèmes complets</a>. "
-"Si vous rencontrez des difficultés à installer des modules, consultez <a "
-"href=\"%(troubleshooting_url)s\">Résolutions des problèmes d'extensions et "
-"de thèmes</a>."
+"Dans la plupart des cas, les modules peuvent être simplement installés en cliquant sur le bouton d'installation fournis. Les modules peuvent être gérés, désactivés ou désinstallés depuis le "
+"gestionnaire de modules de %(app_name)s. Pour des instructions plus détaillées, référez-vous à <a href=\"%(extension_url)s\">cet article sur les extensions</a> ou <a href=\"%(theme_url)s\">celui-ci"
+" pour les thèmes et les thèmes complets</a>. Si vous rencontrez des difficultés à installer des modules, consultez <a href=\"%(troubleshooting_url)s\">Résolutions des problèmes d'extensions et de "
+"thèmes</a>."
 
 #: src/olympia/pages/templates/pages/faq.html:100
 msgid "How do I install add-ons without restarting Firefox?"
@@ -13243,17 +10311,11 @@ msgstr "Comment puis-je installer des modules sans redémarrer Firefox ?"
 #: src/olympia/pages/templates/pages/faq.html:101
 #, python-format
 msgid ""
-"In Firefox, add-ons marked with \"No restart required\" can be installed "
-"without restarting. These add-ons have been created using the <a "
-"href=\"%(sdk_url)s\">Add-on SDK</a> or <a "
-"href=\"%(bootstrap_url)s\">bootstrapping</a>. Other add-ons will still "
-"require a restart before you can use them."
+"In Firefox, add-ons marked with \"No restart required\" can be installed without restarting. These add-ons have been created using the <a href=\"%(sdk_url)s\">Add-on SDK</a> or <a "
+"href=\"%(bootstrap_url)s\">bootstrapping</a>. Other add-ons will still require a restart before you can use them."
 msgstr ""
-"Avec Firefox, les modules signalés par « Pas de redémarrage nécessaire » "
-"peuvent être installés sans redémarrer. Ces modules ont été créés avec le <a"
-" href=\"%(sdk_url)s\">Kit de développement Module</a> ou <a "
-"href=\"%(bootstrap_url)s\">bootstrappé</a>. Les autres modules ont toujours "
-"besoin d'un redémarrage avant d'être utilisés."
+"Avec Firefox, les modules signalés par « Pas de redémarrage nécessaire » peuvent être installés sans redémarrer. Ces modules ont été créés avec le <a href=\"%(sdk_url)s\">Kit de développement "
+"Module</a> ou <a href=\"%(bootstrap_url)s\">bootstrappé</a>. Les autres modules ont toujours besoin d'un redémarrage avant d'être utilisés."
 
 #: src/olympia/pages/templates/pages/faq.html:110
 msgid "How do I keep add-ons up-to-date?"
@@ -13262,22 +10324,13 @@ msgstr "Comment garder à jour les modules ?"
 #: src/olympia/pages/templates/pages/faq.html:111
 #, python-format
 msgid ""
-"Add-ons, unlike plugins, are automatically checked for updates once every "
-"day. In Firefox, updates are automatically installed by default. Versions of"
-" Firefox prior to 4 (and other applications) will alert you that updates to "
-"your add-ons are available. <a href=\"%(plugin_url)s\">Plugins</a> are not "
-"currently automatically checked for updates, so be sure to regularly visit "
-"the <a href=\"%(plugincheck_url)s\">Plugin Check</a> page to stay up-to-"
-"date."
+"Add-ons, unlike plugins, are automatically checked for updates once every day. In Firefox, updates are automatically installed by default. Versions of Firefox prior to 4 (and other applications) "
+"will alert you that updates to your add-ons are available. <a href=\"%(plugin_url)s\">Plugins</a> are not currently automatically checked for updates, so be sure to regularly visit the <a "
+"href=\"%(plugincheck_url)s\">Plugin Check</a> page to stay up-to-date."
 msgstr ""
-"Les modules, contrairement aux greffons, sont automatiquement mis à jour "
-"quotidiennement. Dans Firefox, les mises à jour seront automatiquement "
-"installées par défaut. Les versions précédentes de Firefox et les autres "
-"applications vous alertent de la disponibilité d'une nouvelle version de vos"
-" modules. Les <a href=\"%(plugin_url)s\">greffons</a> ne sont pas, à l'heure"
-" actuelle, automatiquement vérifiés pour s'assurer d'une mise à jour "
-"existante, vous devrez vous rendre régulièrement sur la page <a "
-"href=\"%(plugincheck_url)s\">vérification des greffons</a> pour rester à "
+"Les modules, contrairement aux greffons, sont automatiquement mis à jour quotidiennement. Dans Firefox, les mises à jour seront automatiquement installées par défaut. Les versions précédentes de "
+"Firefox et les autres applications vous alertent de la disponibilité d'une nouvelle version de vos modules. Les <a href=\"%(plugin_url)s\">greffons</a> ne sont pas, à l'heure actuelle, "
+"automatiquement vérifiés pour s'assurer d'une mise à jour existante, vous devrez vous rendre régulièrement sur la page <a href=\"%(plugincheck_url)s\">vérification des greffons</a> pour rester à "
 "jour."
 
 #: src/olympia/pages/templates/pages/faq.html:122
@@ -13287,21 +10340,13 @@ msgstr "Est-ce que les modules sont sûrs à installer ?"
 #: src/olympia/pages/templates/pages/faq.html:123
 #, python-format
 msgid ""
-"Unless clearly marked otherwise, add-ons available from this gallery have "
-"been checked and approved by Mozilla's team of editors and are safe to "
-"install. We recommend that you only install approved add-ons. If you wish to"
-" install unapproved add-ons or add-ons from third-party websites, use "
-"caution as these add-ons may harm your computer or violate your privacy. <a "
+"Unless clearly marked otherwise, add-ons available from this gallery have been checked and approved by Mozilla's team of editors and are safe to install. We recommend that you only install approved"
+" add-ons. If you wish to install unapproved add-ons or add-ons from third-party websites, use caution as these add-ons may harm your computer or violate your privacy. <a "
 "href=\"%(learnmore_url)s\">Learn more about our approval process</a>"
 msgstr ""
-"Sauf mention contraire clairement notifiée, les modules disponibles depuis "
-"cette galerie ont été vérifiés et approuvés par l'équipe des éditeurs de "
-"Mozilla et peuvent être installés sans inquiétude. Nous vous recommandons de"
-" n'installer que les modules approuvés. Si vous voulez installer des modules"
-" non approuvés ou des modules provenant de sites web tiers, faites-le avec "
-"précaution car ces modules pourraient altérer votre configuration ou violer "
-"votre vie privée. <a href=\"%(learnmore_url)s\">En savoir plus à propos du "
-"processus d'approbation</a>"
+"Sauf mention contraire clairement notifiée, les modules disponibles depuis cette galerie ont été vérifiés et approuvés par l'équipe des éditeurs de Mozilla et peuvent être installés sans "
+"inquiétude. Nous vous recommandons de n'installer que les modules approuvés. Si vous voulez installer des modules non approuvés ou des modules provenant de sites web tiers, faites-le avec "
+"précaution car ces modules pourraient altérer votre configuration ou violer votre vie privée. <a href=\"%(learnmore_url)s\">En savoir plus à propos du processus d'approbation</a>"
 
 #: src/olympia/pages/templates/pages/faq.html:133
 #, python-format
@@ -13311,46 +10356,28 @@ msgstr "Est-ce que les modules peuvent rendre %(app_name)s plus lent ?"
 #: src/olympia/pages/templates/pages/faq.html:135
 #, python-format
 msgid ""
-"Most add-ons do not cause a perceivable performance decrease in "
-"%(app_name)s, though installing an excessive number may have adverse "
-"effects. If you suspect an add-on is causing %(app_name)s to be slow, try "
-"disabling it."
+"Most add-ons do not cause a perceivable performance decrease in %(app_name)s, though installing an excessive number may have adverse effects. If you suspect an add-on is causing %(app_name)s to be "
+"slow, try disabling it."
 msgstr ""
-"La plupart des modules ne diminuent pas les performances de façon sensible "
-"dans %(app_name)s. En revanche, installer un nombre excessif de modules peut"
-" avoir des effets indésirables. Si vous pensez qu'un module ralentit "
-"%(app_name)s, essayez de le désactiver."
+"La plupart des modules ne diminuent pas les performances de façon sensible dans %(app_name)s. En revanche, installer un nombre excessif de modules peut avoir des effets indésirables. Si vous pensez"
+" qu'un module ralentit %(app_name)s, essayez de le désactiver."
 
 #: src/olympia/pages/templates/pages/faq.html:141
 #, python-format
-msgid ""
-"%(app_name)s told me an add-on isn't compatible. Is there a way I can still "
-"use it?"
-msgstr ""
-"%(app_name)s m'indique qu'un module n'est pas compatible. Existe-t-il une "
-"solution pour que je puisse continuer à l'utiliser ?"
+msgid "%(app_name)s told me an add-on isn't compatible. Is there a way I can still use it?"
+msgstr "%(app_name)s m'indique qu'un module n'est pas compatible. Existe-t-il une solution pour que je puisse continuer à l'utiliser ?"
 
 #: src/olympia/pages/templates/pages/faq.html:144
 #, python-format
 msgid ""
-"If an add-on isn't compatible with your version of %(app_name)s, it is "
-"usually either because your version of %(app_name)s is outdated or the add-"
-"on author has not yet updated the add-on to be compatible with a newer "
-"version you are using. Mozilla does not recommend trying to circumvent these"
-" compatibility checks, as they can lead to browser instability or in some "
-"cases loss of data. For users who are testing out alpha or beta versions of "
-"Firefox, we offer the <a href=\"%(acr_url)s\">Add-on Compatibility "
-"Reporter</a> to help add-on developers update their compatibility."
+"If an add-on isn't compatible with your version of %(app_name)s, it is usually either because your version of %(app_name)s is outdated or the add-on author has not yet updated the add-on to be "
+"compatible with a newer version you are using. Mozilla does not recommend trying to circumvent these compatibility checks, as they can lead to browser instability or in some cases loss of data. For"
+" users who are testing out alpha or beta versions of Firefox, we offer the <a href=\"%(acr_url)s\">Add-on Compatibility Reporter</a> to help add-on developers update their compatibility."
 msgstr ""
-"Si un module n'est pas compatible avec votre version de %(app_name)s, c'est "
-"souvent soit parce que votre version de %(app_name)s n'est pas à jour ou que"
-" l'auteur du module ne l'a pas encore mis à jour pour être compatible avec "
-"votre nouvelle version. Mozilla ne vous encourage pas à essayer de "
-"circonvenir ces tests de compatibilité, puisque cela peut entraîner une "
-"instabilité ou dans certains cas des pertes de données. Pour les "
-"utilisateurs qui testent des versions alpha ou bêta de Firefox, nous "
-"proposons le <a href=\"%(acr_url)s\">module rapporteur de compatibilité</a> "
-"pour aider les développeurs de modules à mettre à jour."
+"Si un module n'est pas compatible avec votre version de %(app_name)s, c'est souvent soit parce que votre version de %(app_name)s n'est pas à jour ou que l'auteur du module ne l'a pas encore mis à "
+"jour pour être compatible avec votre nouvelle version. Mozilla ne vous encourage pas à essayer de circonvenir ces tests de compatibilité, puisque cela peut entraîner une instabilité ou dans "
+"certains cas des pertes de données. Pour les utilisateurs qui testent des versions alpha ou bêta de Firefox, nous proposons le <a href=\"%(acr_url)s\">module rapporteur de compatibilité</a> pour "
+"aider les développeurs de modules à mettre à jour."
 
 #: src/olympia/pages/templates/pages/faq.html:156
 msgid "What if I have problems with an add-on?"
@@ -13359,20 +10386,13 @@ msgstr "Et si j'ai un problème avec un module ?"
 #: src/olympia/pages/templates/pages/faq.html:157
 #, python-format
 msgid ""
-"Add-ons are usually created by third-party developers from around the world,"
-" so the best way to get help with an add-on is to look for support links on "
-"the add-on's homepage or contact the developer. If you are having issues "
-"with %(app_name)s that you suspect are related to add-ons you have "
-"installed, <a href=\"%(troubleshooting_url)s\">visit this support "
-"article</a> for troubleshooting tips."
+"Add-ons are usually created by third-party developers from around the world, so the best way to get help with an add-on is to look for support links on the add-on's homepage or contact the "
+"developer. If you are having issues with %(app_name)s that you suspect are related to add-ons you have installed, <a href=\"%(troubleshooting_url)s\">visit this support article</a> for "
+"troubleshooting tips."
 msgstr ""
-"Les modules sont généralement créés par des développeurs tiers provenant du "
-"monde entier, le meilleur moyen de trouver de l'aide à propos d'un module "
-"est de chercher des liens pour l'assistance sur la page d'accueil du module "
-"ou de contacter son développeur. Si vous avez des problèmes avec "
-"%(app_name)s que vous suspectez être liés à des modules que vous avez "
-"installés, <a href=\"%(troubleshooting_url)s\">rendez-vous sur cette page "
-"d'assistance</a> pour des indications pour trouver le soucis."
+"Les modules sont généralement créés par des développeurs tiers provenant du monde entier, le meilleur moyen de trouver de l'aide à propos d'un module est de chercher des liens pour l'assistance sur"
+" la page d'accueil du module ou de contacter son développeur. Si vous avez des problèmes avec %(app_name)s que vous suspectez être liés à des modules que vous avez installés, <a "
+"href=\"%(troubleshooting_url)s\">rendez-vous sur cette page d'assistance</a> pour des indications pour trouver le soucis."
 
 #: src/olympia/pages/templates/pages/faq.html:169
 msgid "Add-on Gallery"
@@ -13382,22 +10402,14 @@ msgstr "Galerie de modules"
 msgid "How do I choose between add-ons that seem to do the same thing?"
 msgstr "Comment choisir entre des modules qui semblent faire la même chose ?"
 
-#: src/olympia/pages/templates/pages/faq.html:173
+#: src/olympia/pages/templates/pages/faq.html:172
 msgid ""
-"There are often several add-ons that have similar features. To figure out "
-"which is right for you, read the entire description of the add-on and view "
-"its screenshots. If there are still several in the running, read through the"
-" add-on's ratings, user reviews, and statistics to see which is most liked "
-"by other users. Remember that you can also just try out both and see which "
-"you like better."
+"There are often several add-ons that have similar features. To figure out which is right for you, read the entire description of the add-on and view its screenshots. If there are still several in "
+"the running, read through the add-on's ratings, user reviews, and statistics to see which is most liked by other users. Remember that you can also just try out both and see which you like better."
 msgstr ""
-"Il y a souvent plusieurs modules avec des fonctionnalités similaires. Pour "
-"déterminer lequel vous convient, lisez la description complète de chaque "
-"module et regardez ses captures d'écran. S'il y a toujours plusieurs modules"
-" qui retiennent votre attention, lisez les commentaires des utilisateurs, "
-"leurs notes, et les statistiques pour voir lequel est le plus apprécié par "
-"les autres utilisateurs. Rappelez-vous également que vous pouvez aussi les "
-"essayer tous et voir lequel vous convient le mieux."
+"Il y a souvent plusieurs modules avec des fonctionnalités similaires. Pour déterminer lequel vous convient, lisez la description complète de chaque module et regardez ses captures d'écran. S'il y a"
+" toujours plusieurs modules qui retiennent votre attention, lisez les commentaires des utilisateurs, leurs notes, et les statistiques pour voir lequel est le plus apprécié par les autres "
+"utilisateurs. Rappelez-vous également que vous pouvez aussi les essayer tous et voir lequel vous convient le mieux."
 
 #: src/olympia/pages/templates/pages/faq.html:180
 msgid "What if I can't find an add-on I'm looking for?"
@@ -13406,39 +10418,25 @@ msgstr "Et si je ne trouve pas un module que je cherche ?"
 #: src/olympia/pages/templates/pages/faq.html:181
 #, python-format
 msgid ""
-"With thousands of add-ons available, there's something for everyone. But if "
-"you're looking for a particular add-on and can't find it, you might try "
-"searching on other sites or posting about it in our <a href=\"%(forum_url)s"
-"\">Add-ons </a>forum."
+"With thousands of add-ons available, there's something for everyone. But if you're looking for a particular add-on and can't find it, you might try searching on other sites or posting about it in "
+"our <a href=\"%(forum_url)s\">Add-ons </a>forum."
 msgstr ""
-"Des milliers de modules sont disponibles, il y en a pour tous les goûts. Si "
-"vous cherchez un module en particulier et que vous ne le trouvez pas, "
-"recherchez sur d'autres sites ou rédigez un message sur <a "
-"href=\"%(forum_url)s\">le forum dédié aux modules</a>."
+"Des milliers de modules sont disponibles, il y en a pour tous les goûts. Si vous cherchez un module en particulier et que vous ne le trouvez pas, recherchez sur d'autres sites ou rédigez un message"
+" sur <a href=\"%(forum_url)s\">le forum dédié aux modules</a>."
 
 #: src/olympia/pages/templates/pages/faq.html:187
-msgid ""
-"What does it mean if an add-on is \"experimental\" or \"preliminarily "
-"reviewed\"?"
-msgstr ""
-"Qu'est-ce que cela signifie lorsqu'un module est « expérimental » ou « revu "
-"de manière préliminaire » ?"
+msgid "What does it mean if an add-on is \"experimental\" or \"preliminarily reviewed\"?"
+msgstr "Qu'est-ce que cela signifie lorsqu'un module est « expérimental » ou « revu de manière préliminaire » ?"
 
 #: src/olympia/pages/templates/pages/faq.html:188
 #, python-format
 msgid ""
-"Experimental add-ons have been checked by our editors to make sure they "
-"don't have security problems, but they may still have bugs or not work "
-"properly. Use caution when installing experimental add-ons and uninstall the"
-" add-on immediately if you notice problems. <a href=\"%(url)s\">Learn more "
-"about our review process</a></dd>"
+"Experimental add-ons have been checked by our editors to make sure they don't have security problems, but they may still have bugs or not work properly. Use caution when installing experimental "
+"add-ons and uninstall the add-on immediately if you notice problems. <a href=\"%(url)s\">Learn more about our review process</a></dd>"
 msgstr ""
-"Les modules expérimentaux ont été vérifiés par nos éditeurs pour s'assurer "
-"qu'ils ne présentent pas de problème de sécurité, mais ils peuvent toujours "
-"contenir des défauts ou ne pas fonctionner correctement. Faites attention "
-"lorsque vous installez des modules expérimentaux et désinstallez-les "
-"immédiatement si vous remarquez des problèmes. <a href=\"%(url)s\">En savoir"
-" plus sur notre processus de revue</a></dd>"
+"Les modules expérimentaux ont été vérifiés par nos éditeurs pour s'assurer qu'ils ne présentent pas de problème de sécurité, mais ils peuvent toujours contenir des défauts ou ne pas fonctionner "
+"correctement. Faites attention lorsque vous installez des modules expérimentaux et désinstallez-les immédiatement si vous remarquez des problèmes. <a href=\"%(url)s\">En savoir plus sur notre "
+"processus de revue</a></dd>"
 
 #: src/olympia/pages/templates/pages/faq.html:196
 msgid "What does it mean if an add-on is \"not reviewed\"?"
@@ -13447,265 +10445,186 @@ msgstr "Qu'est-ce que cela signifie lorsqu'un module n'est « pas vérifié » ?
 #: src/olympia/pages/templates/pages/faq.html:197
 #, python-format
 msgid ""
-"While all add-ons publicly available in our gallery are reviewed by an "
-"editor, you may receive a direct link to an add-on that hasn't yet been "
-"reviewed. Use caution when installing these add-ons, as they could harm your"
-" computer or violate your privacy. We recommend that you only install "
-"reviewed add-ons. <a href=\"%(url)s\">Learn more about our review "
-"process</a></dd>"
+"While all add-ons publicly available in our gallery are reviewed by an editor, you may receive a direct link to an add-on that hasn't yet been reviewed. Use caution when installing these add-ons, "
+"as they could harm your computer or violate your privacy. We recommend that you only install reviewed add-ons. <a href=\"%(url)s\">Learn more about our review process</a></dd>"
 msgstr ""
-"Bien que tous les modules visibles dans notre galerie aient été vérifiés par"
-" un éditeur, vous pouvez recevoir un lien direct vers un module qui n'a pas "
-"été vérifié. Faites attention lorsque vous installez ces modules, étant "
-"donné qu'ils pourraient altérer votre configuration ou ne pas respecter "
-"votre vie privée. Nous vous recommandons de n'installer que des modules "
-"vérifiés. <a href=\"%(url)s\">En savoir plus sur notre processus de "
-"revue</a></dd>"
+"Bien que tous les modules visibles dans notre galerie aient été vérifiés par un éditeur, vous pouvez recevoir un lien direct vers un module qui n'a pas été vérifié. Faites attention lorsque vous "
+"installez ces modules, étant donné qu'ils pourraient altérer votre configuration ou ne pas respecter votre vie privée. Nous vous recommandons de n'installer que des modules vérifiés. <a "
+"href=\"%(url)s\">En savoir plus sur notre processus de revue</a></dd>"
 
 #: src/olympia/pages/templates/pages/faq.html:206
 msgid "How much do add-ons cost to purchase?"
 msgstr "Combien coûtent les modules ?"
 
 #: src/olympia/pages/templates/pages/faq.html:207
-msgid ""
-"Add-ons hosted in our gallery are free unless clearly marked otherwise."
-msgstr ""
-"Les modules hébergés dans notre galerie sont gratuits, sauf mention "
-"contraire."
+msgid "Add-ons hosted in our gallery are free unless clearly marked otherwise."
+msgstr "Les modules hébergés dans notre galerie sont gratuits, sauf mention contraire."
+
+#: src/olympia/pages/templates/pages/faq.html:209
+msgid "What does it mean when an add-on asks for contributions?"
+msgstr "Qu'est-ce que cela signifie lorsqu'un module demande une contribution ?"
 
 #: src/olympia/pages/templates/pages/faq.html:210
-msgid "What does it mean when an add-on asks for contributions?"
-msgstr ""
-"Qu'est-ce que cela signifie lorsqu'un module demande une contribution ?"
-
-#: src/olympia/pages/templates/pages/faq.html:211
 msgid ""
-"Some add-on authors request users who enjoy an add-on to contribute to its "
-"development by making a monetary contribution. These contributions go "
-"directly to the developer unless a third party is indicated, such as the "
-"non-profit Mozilla Foundation."
+"Some add-on authors request users who enjoy an add-on to contribute to its development by making a monetary contribution. These contributions go directly to the developer unless a third party is "
+"indicated, such as the non-profit Mozilla Foundation."
 msgstr ""
-"Certains auteurs de module demandent à ce que les utilisateurs qui "
-"apprécient un module contribuent à son développement par un don. Ces "
-"contributions vont directement au développeur sauf si une tierce partie est "
-"indiquée, comme la fondation à but non lucratif Mozilla."
+"Certains auteurs de module demandent à ce que les utilisateurs qui apprécient un module contribuent à son développement par un don. Ces contributions vont directement au développeur sauf si une "
+"tierce partie est indiquée, comme la fondation à but non lucratif Mozilla."
 
-#: src/olympia/pages/templates/pages/faq.html:216
+#: src/olympia/pages/templates/pages/faq.html:215
 msgid "What are beta add-ons?"
 msgstr "Que sont les modules bêta ?"
 
-#: src/olympia/pages/templates/pages/faq.html:218
+#: src/olympia/pages/templates/pages/faq.html:217
 msgid ""
-"Beta add-ons are unreviewed versions which represent the latest work of an "
-"add-on author. While different authors have different standards for beta "
-"code quality, you should assume that these add-ons are less stable than the "
-"general add-on releases."
+"Beta add-ons are unreviewed versions which represent the latest work of an add-on author. While different authors have different standards for beta code quality, you should assume that these add-"
+"ons are less stable than the general add-on releases."
 msgstr ""
-"Les versions bêtas sont des versions non testées qui correspondent aux "
-"dernières avancée du développeur d'un module. Bien que les auteurs aient des"
-" critères de qualité différents pour du code bêta, vous devriez considérer "
-"que ces modules sont moins stables que les versions publiées."
+"Les versions bêtas sont des versions non testées qui correspondent aux dernières avancée du développeur d'un module. Bien que les auteurs aient des critères de qualité différents pour du code bêta,"
+" vous devriez considérer que ces modules sont moins stables que les versions publiées."
 
-#: src/olympia/pages/templates/pages/faq.html:222
+#: src/olympia/pages/templates/pages/faq.html:221
 msgid ""
-"Please note that when you install an add-on from the \"Beta Version\" "
-"section of an add-on's listing, you will continue to receive updates for "
-"that add-on as they become available. Like the initial version you "
-"installed, all beta releases are unreviewed by Mozilla and may harm your "
-"computer."
+"Please note that when you install an add-on from the \"Beta Version\" section of an add-on's listing, you will continue to receive updates for that add-on as they become available. Like the initial"
+" version you installed, all beta releases are unreviewed by Mozilla and may harm your computer."
 msgstr ""
-"Merci de noter que lorsque vous installez un module de la section « version "
-"bêta », vous continuerez à recevoir les mises à jour disponibles pour ce "
-"module. À la manière de la première version que vous installez, toutes les "
-"mises à jour bêta ne sont pas testées par Mozilla et pourraient endommager "
-"votre configuration."
+"Merci de noter que lorsque vous installez un module de la section « version bêta », vous continuerez à recevoir les mises à jour disponibles pour ce module. À la manière de la première version que "
+"vous installez, toutes les mises à jour bêta ne sont pas testées par Mozilla et pourraient endommager votre configuration."
+
+#: src/olympia/pages/templates/pages/faq.html:228
+msgid "What does it mean when an add-on is flagged as slow?"
+msgstr "Qu'est-ce que cela signifie lorsqu'un module est étiqueté comme lent ?"
 
 #: src/olympia/pages/templates/pages/faq.html:229
-msgid "What does it mean when an add-on is flagged as slow?"
+msgid "Most add-ons load code and resources at the same time Firefox is starting up. In most cases the impact in start-up time is minimal, but some add-ons can cause a noticeable slowdown."
 msgstr ""
-"Qu'est-ce que cela signifie lorsqu'un module est étiqueté comme lent ?"
+"La plupart des modules chargent leur code et les ressources nécessaire au démarrage de Firefox. Dans la plupart des cas, l'impact sur le démarrage est minimal mais certains modules peuvent ralentir"
+" cette étape de façon sensible."
 
-#: src/olympia/pages/templates/pages/faq.html:231
-msgid ""
-"Most add-ons load code and resources at the same time Firefox is starting "
-"up. In most cases the impact in start-up time is minimal, but some add-ons "
-"can cause a noticeable slowdown."
-msgstr ""
-"La plupart des modules chargent leur code et les ressources nécessaire au "
-"démarrage de Firefox. Dans la plupart des cas, l'impact sur le démarrage est"
-" minimal mais certains modules peuvent ralentir cette étape de façon "
-"sensible."
-
-#: src/olympia/pages/templates/pages/faq.html:236
+#: src/olympia/pages/templates/pages/faq.html:234
 msgid "How do I report an inappropriate or spam user review?"
 msgstr "Comment notifier un commentaire inapproprié ou spam ?"
 
-#: src/olympia/pages/templates/pages/faq.html:237
+#: src/olympia/pages/templates/pages/faq.html:235
 msgid ""
-"To report a user review of an add-on, log in with your account and visit the"
-" add-on's reviews page. Find the review you wish to report, click \"Report "
-"this review\" and select a reason. Our editorial team will investigate the "
-"review and take appropriate action."
+"To report a user review of an add-on, log in with your account and visit the add-on's reviews page. Find the review you wish to report, click \"Report this review\" and select a reason. Our "
+"editorial team will investigate the review and take appropriate action."
 msgstr ""
-"Pour notifier une revue utilisateur d'un module, connectez-vous avec votre "
-"compte et visitez la page de critiques du module. Trouvez la revue que vous "
-"souhaitez notifier, et cliquer « Notifier cette revue », puis choisissez une"
-" raison. Notre équipe éditoriale vérifiera la revue et prendra les mesures "
-"appropriées."
+"Pour notifier une revue utilisateur d'un module, connectez-vous avec votre compte et visitez la page de critiques du module. Trouvez la revue que vous souhaitez notifier, et cliquer « Notifier "
+"cette revue », puis choisissez une raison. Notre équipe éditoriale vérifiera la revue et prendra les mesures appropriées."
 
-#: src/olympia/pages/templates/pages/faq.html:242
+#: src/olympia/pages/templates/pages/faq.html:240
 msgid "How do I report a bug or contact the Mozilla Add-ons team?"
 msgstr "Comment rapporter un problème ou contacter l'équipe Mozilla Add-ons ?"
 
-#: src/olympia/pages/templates/pages/faq.html:243
+#: src/olympia/pages/templates/pages/faq.html:241
 #, python-format
 msgid "Please visit our <a href=\"%(contact_url)s\">Contact page</a>."
 msgstr "Merci de consulter notre <a href=\"%(contact_url)s\">page de contact</a>."
 
-#: src/olympia/pages/templates/pages/faq.html:246
+#: src/olympia/pages/templates/pages/faq.html:244
 msgid "What is a Source Code License?"
 msgstr "Qu'est-ce qu'une licence de code souce ?"
 
-#: src/olympia/pages/templates/pages/faq.html:247
+#: src/olympia/pages/templates/pages/faq.html:245
 #, python-format
 msgid ""
-"The source code used to create an add-on is an exclusive copyright of the "
-"add-on author, unless otherwise declared in a source code license. Many add-"
-"ons on this site have <a href=\"%(url)s\" lang=\"en\">open source "
-"licenses</a> that make the source code publicly available for copy and reuse"
-" under conditions determined by the author. Most authors choose widely known"
-" open source licenses like the GPL or BSD licenses instead of making up "
-"their own."
+"The source code used to create an add-on is an exclusive copyright of the add-on author, unless otherwise declared in a source code license. Many add-ons on this site have <a href=\"%(url)s\" "
+"lang=\"en\">open source licenses</a> that make the source code publicly available for copy and reuse under conditions determined by the author. Most authors choose widely known open source licenses"
+" like the GPL or BSD licenses instead of making up their own."
 msgstr ""
-"Le code source utilisé pour créer un module est sous le copyright exclusif "
-"de l'auteur, sauf mention contraire dans la licence du code source. De "
-"nombreux modules sur ce site ont une <a href=\"%(url)s\" lang=\"en\">licence"
-" libre</a> qui rend le code source publiquement disponible pour la copie et "
-"la réutilisation sous des conditions déterminées par l'auteur. La majorité "
-"des auteurs utilisent des licences libres connues telles que la GPL ou la "
-"BSD, plutôt que de créer la leur."
+"Le code source utilisé pour créer un module est sous le copyright exclusif de l'auteur, sauf mention contraire dans la licence du code source. De nombreux modules sur ce site ont une <a "
+"href=\"%(url)s\" lang=\"en\">licence libre</a> qui rend le code source publiquement disponible pour la copie et la réutilisation sous des conditions déterminées par l'auteur. La majorité des "
+"auteurs utilisent des licences libres connues telles que la GPL ou la BSD, plutôt que de créer la leur."
 
-#: src/olympia/pages/templates/pages/faq.html:256
+#: src/olympia/pages/templates/pages/faq.html:254
 #, python-format
-msgid ""
-"Firefox and other Mozilla software are <a href=\"%(url)s\">open source</a>."
-msgstr ""
-"Firefox et les autres logiciels de Mozilla sont <a href=\"%(url)s\">des "
-"logiciels libres</a>."
+msgid "Firefox and other Mozilla software are <a href=\"%(url)s\">open source</a>."
+msgstr "Firefox et les autres logiciels de Mozilla sont <a href=\"%(url)s\">des logiciels libres</a>."
 
-#: src/olympia/pages/templates/pages/faq.html:264
+#: src/olympia/pages/templates/pages/faq.html:262
 msgid "Collections and Favorites"
 msgstr "Collections et favoris"
 
-#: src/olympia/pages/templates/pages/faq.html:267
+#: src/olympia/pages/templates/pages/faq.html:265
 msgid "What is a collection?"
 msgstr "Qu'est-ce qu'une collection ?"
 
-#: src/olympia/pages/templates/pages/faq.html:268
+#: src/olympia/pages/templates/pages/faq.html:266
 msgid "Collections are groups of related add-ons created by users to share."
-msgstr ""
-"Les collections sont des groupes de modules liés entre eux créés par les "
-"utilisateurs pour les partager."
+msgstr "Les collections sont des groupes de modules liés entre eux créés par les utilisateurs pour les partager."
 
-#: src/olympia/pages/templates/pages/faq.html:270
+#: src/olympia/pages/templates/pages/faq.html:268
 msgid "What is the My Favorites collection?"
 msgstr "Qu'est-ce que ma collection favorite ?"
 
-#: src/olympia/pages/templates/pages/faq.html:271
-msgid ""
-"Favorite add-ons are add-ons that you have bookmarked to easily get back to "
-"later. You can add an add-on to your favorites collection by clicking \"Add "
-"to favorites\" on its details page."
+#: src/olympia/pages/templates/pages/faq.html:269
+msgid "Favorite add-ons are add-ons that you have bookmarked to easily get back to later. You can add an add-on to your favorites collection by clicking \"Add to favorites\" on its details page."
 msgstr ""
-"Les modules favoris sont des modules dont vous gardez trace pour y revenir "
-"facilement plus tard. Vous pouvez ajouter un module à votre collection de "
-"favoris en cliquant « Ajouter aux favoris » sur sa page des détails."
+"Les modules favoris sont des modules dont vous gardez trace pour y revenir facilement plus tard. Vous pouvez ajouter un module à votre collection de favoris en cliquant « Ajouter aux favoris » sur "
+"sa page des détails."
 
-#: src/olympia/pages/templates/pages/faq.html:275
-#: src/olympia/templates/menu_links.html:13
-#: src/olympia/templates/impala/header_title.html:17
+#: src/olympia/pages/templates/pages/faq.html:273 src/olympia/templates/menu_links.html:13 src/olympia/templates/impala/header_title.html:17
 msgid "Mobile Add-ons"
 msgstr "Modules mobile"
 
-#: src/olympia/pages/templates/pages/faq.html:278
+#: src/olympia/pages/templates/pages/faq.html:276
 msgid "What are mobile add-ons?"
 msgstr "Que sont les modules mobiles ?"
 
-#: src/olympia/pages/templates/pages/faq.html:279
+#: src/olympia/pages/templates/pages/faq.html:277
 #, python-format
 msgid ""
-"Mobile add-ons work with <a href=\"%(mobile_url)s\">Firefox for Mobile</a> "
-"and add or modify functionality just like desktop add-ons. You can find add-"
-"ons that work with Firefox for Mobile in our <a "
-"href=\"%(gallery_url)s\">gallery</a>."
+"Mobile add-ons work with <a href=\"%(mobile_url)s\">Firefox for Mobile</a> and add or modify functionality just like desktop add-ons. You can find add-ons that work with Firefox for Mobile in our "
+"<a href=\"%(gallery_url)s\">gallery</a>."
 msgstr ""
-"Les modules mobiles fonctionnent avec <a href=\"%(mobile_url)s\">Firefox "
-"pour Mobile</a> et ajoutent ou modifient des fonctionnalités de la même "
-"manière que les modules pour Firefox. Vous pouvez trouver des modules "
-"compatibles Firefox pour Mobile dans notre <a "
-"href=\"%(gallery_url)s\">galerie</a>."
+"Les modules mobiles fonctionnent avec <a href=\"%(mobile_url)s\">Firefox pour Mobile</a> et ajoutent ou modifient des fonctionnalités de la même manière que les modules pour Firefox. Vous pouvez "
+"trouver des modules compatibles Firefox pour Mobile dans notre <a href=\"%(gallery_url)s\">galerie</a>."
 
-#: src/olympia/pages/templates/pages/faq.html:288
+#: src/olympia/pages/templates/pages/faq.html:286
 msgid "Developer Topics"
 msgstr "Sujets développeurs"
 
-#: src/olympia/pages/templates/pages/faq.html:289
+#: src/olympia/pages/templates/pages/faq.html:287
 #, python-format
-msgid ""
-"Please see our <a href=\"%(faq_url)s\">Developer FAQ</a> and <a "
-"href=\"%(hub_url)s\">Developer Hub</a> for answers to add-on developer-"
-"related questions."
-msgstr ""
-"Merci de consulter notre <a href=\"%(faq_url)s\">FAQ développeurs</a> et le "
-"<a href=\"%(hub_url)s\">point de rencontre développeur</a> pour des réponses"
-" aux questions des développeurs de modules."
+msgid "Please see our <a href=\"%(faq_url)s\">Developer FAQ</a> and <a href=\"%(hub_url)s\">Developer Hub</a> for answers to add-on developer-related questions."
+msgstr "Merci de consulter notre <a href=\"%(faq_url)s\">FAQ développeurs</a> et le <a href=\"%(hub_url)s\">point de rencontre développeur</a> pour des réponses aux questions des développeurs de modules."
 
-#: src/olympia/pages/templates/pages/faq.html:294
+#: src/olympia/pages/templates/pages/faq.html:292
 msgid "Still have questions?"
 msgstr "Vous avez toujours des questions ?"
 
-#: src/olympia/pages/templates/pages/faq.html:295
+#: src/olympia/pages/templates/pages/faq.html:293
 #, python-format
-msgid ""
-"For general Firefox support, visit our <a href=\"%(sumo_url)s\">support "
-"website</a>. For general add-on and website questions, visit our <a "
-"href=\"%(forum_url)s\">forum</a>."
+msgid "For general Firefox support, visit our <a href=\"%(sumo_url)s\">support website</a>. For general add-on and website questions, visit our <a href=\"%(forum_url)s\">forum</a>."
 msgstr ""
-"Pour une assistance générale sur Firefox, visitez notre <a "
-"href=\"%(sumo_url)s\">site web d'assistance</a>. Pour des questions "
-"générales sur les modules et le site web, visitez notre <a "
+"Pour une assistance générale sur Firefox, visitez notre <a href=\"%(sumo_url)s\">site web d'assistance</a>. Pour des questions générales sur les modules et le site web, visitez notre <a "
 "href=\"%(forum_url)s\">forum</a>."
 
-#: src/olympia/pages/templates/pages/review_guide.html:36
-#: src/olympia/pages/templates/pages/review_guide.html:51
+#: src/olympia/pages/templates/pages/review_guide.html:36 src/olympia/pages/templates/pages/review_guide.html:51
 msgid "Some tips for writing a great review"
 msgstr "Quelques astuces pour une bonne revue"
 
-#: src/olympia/pages/templates/pages/review_guide.html:39
-#: src/olympia/pages/templates/pages/review_guide.html:131
+#: src/olympia/pages/templates/pages/review_guide.html:39 src/olympia/pages/templates/pages/review_guide.html:131
 msgid "Frequently Asked Questions about Reviews"
 msgstr "Foire aux questions à propos des commentaires"
 
 #: src/olympia/pages/templates/pages/review_guide.html:46
 msgid ""
-"Add-on reviews are a way for you to share your opinions about the add-ons "
-"you’ve installed and used. Our review moderation team reserves the right to "
-"refuse or remove any review that does not comply with these guidelines."
+"Add-on reviews are a way for you to share your opinions about the add-ons you’ve installed and used. Our review moderation team reserves the right to refuse or remove any review that does not "
+"comply with these guidelines."
 msgstr ""
-"Les commentaires vous permettent de partager votre opinion sur les modules "
-"que vous avez installés et utilisés. Notre équipe de modération se réserve "
-"le droit de refuser ou de supprimer tout commentaire qui ne respecterait pas"
-" ces règles."
+"Les commentaires vous permettent de partager votre opinion sur les modules que vous avez installés et utilisés. Notre équipe de modération se réserve le droit de refuser ou de supprimer tout "
+"commentaire qui ne respecterait pas ces règles."
 
 #: src/olympia/pages/templates/pages/review_guide.html:53
 msgid "Do:"
 msgstr "À faire :"
 
 #: src/olympia/pages/templates/pages/review_guide.html:56
-msgid ""
-"Write like you are telling a friend about your experience with the add-on."
-msgstr ""
-"Écrire comme si vous parliez à un ami de votre expérience avec le module."
+msgid "Write like you are telling a friend about your experience with the add-on."
+msgstr "Écrire comme si vous parliez à un ami de votre expérience avec le module."
 
 #: src/olympia/pages/templates/pages/review_guide.html:61
 msgid "Keep reviews concise and easy to understand."
@@ -13736,11 +10655,8 @@ msgid "Will you continue to use this add-on?"
 msgstr "Continuerez-vous d'utiliser ce module ?"
 
 #: src/olympia/pages/templates/pages/review_guide.html:73
-msgid ""
-"Take a moment to read your review before submitting it to minimize typos."
-msgstr ""
-"Prenez quelques instants pour relire votre commentaire afin d'éviter de "
-"l'envoyer avec des fautes d'orthographe."
+msgid "Take a moment to read your review before submitting it to minimize typos."
+msgstr "Prenez quelques instants pour relire votre commentaire afin d'éviter de l'envoyer avec des fautes d'orthographe."
 
 #: src/olympia/pages/templates/pages/review_guide.html:79
 msgid "Don’t:"
@@ -13748,74 +10664,47 @@ msgstr "À ne pas faire :"
 
 #: src/olympia/pages/templates/pages/review_guide.html:82
 msgid "Submit one-word reviews such as \"Great!\", \"wonderful,\" or \"bad.\""
-msgstr ""
-"Soumettez des commentaires en très peu de mots comme « Super », « Génial » "
-"ou « Mauvais », « Code pourri »."
+msgstr "Soumettez des commentaires en très peu de mots comme « Super », « Génial » ou « Mauvais », « Code pourri »."
 
 #: src/olympia/pages/templates/pages/review_guide.html:87
 msgid ""
-"Post technical issues, support requests, or feature suggestions. Use the "
-"available support options for each add-on, if available. You can find them "
-"in the side column next to the About this Add-on section."
+"Post technical issues, support requests, or feature suggestions. Use the available support options for each add-on, if available. You can find them in the side column next to the About this Add-on "
+"section."
 msgstr ""
-"Postez des questions techniques, des demandes d’'aide ou des suggestions de "
-"fonctionnalité. Utilisez les options d’aide disponibles pour chaque module, "
-"le cas échéant. Vous pouvez les trouver dans la colonne à côté de la section"
-" À propos du module."
+"Postez des questions techniques, des demandes d’'aide ou des suggestions de fonctionnalité. Utilisez les options d’aide disponibles pour chaque module, le cas échéant. Vous pouvez les trouver dans "
+"la colonne à côté de la section À propos du module."
 
 #: src/olympia/pages/templates/pages/review_guide.html:92
 msgid "Write reviews for add-ons which you have not personally used."
-msgstr ""
-"Écrire des commentaires sur des modules que vous n'avez pas utilisé "
-"personnellement."
+msgstr "Écrire des commentaires sur des modules que vous n'avez pas utilisé personnellement."
 
 #: src/olympia/pages/templates/pages/review_guide.html:97
-msgid ""
-"Use profanity, sexual language or language that can be construed as hateful."
-msgstr ""
-"Utiliser un vocabulaire inapproprié (jurons, références sexuelles, odieux)."
+msgid "Use profanity, sexual language or language that can be construed as hateful."
+msgstr "Utiliser un vocabulaire inapproprié (jurons, références sexuelles, odieux)."
 
 #: src/olympia/pages/templates/pages/review_guide.html:103
-msgid ""
-"Include HTML, links, source code or code snippets. Reviews are meant to be "
-"text only."
-msgstr ""
-"Vous pouvez inclure du HTML, des liens, du code source ou des fragments de "
-"code. Les commentaires sont censés être uniquement du texte."
+msgid "Include HTML, links, source code or code snippets. Reviews are meant to be text only."
+msgstr "Vous pouvez inclure du HTML, des liens, du code source ou des fragments de code. Les commentaires sont censés être uniquement du texte."
 
 #: src/olympia/pages/templates/pages/review_guide.html:108
-msgid ""
-"Make false statements, disparage add-on authors or personally insult them."
-msgstr ""
-"Faire de fausses affirmations, dénigrer les auteurs de module, ou les "
-"insulter."
+msgid "Make false statements, disparage add-on authors or personally insult them."
+msgstr "Faire de fausses affirmations, dénigrer les auteurs de module, ou les insulter."
 
 #: src/olympia/pages/templates/pages/review_guide.html:114
-msgid ""
-"Include your own or anyone else’s email, phone number, or other personal "
-"details."
-msgstr ""
-"Indiquez votre propre adresse électronique ou celle de quelqu’un d'autre, un"
-" numéro de téléphone ou d’autres informations personnelles."
+msgid "Include your own or anyone else’s email, phone number, or other personal details."
+msgstr "Indiquez votre propre adresse électronique ou celle de quelqu’un d'autre, un numéro de téléphone ou d’autres informations personnelles."
 
 #: src/olympia/pages/templates/pages/review_guide.html:119
-msgid ""
-"Post reviews for an add-on you or your organization wrote or represent."
-msgstr ""
-"Envoyer des commentaires pour un module que vous ou votre organisation avez "
-"écrit ou représentez."
+msgid "Post reviews for an add-on you or your organization wrote or represent."
+msgstr "Envoyer des commentaires pour un module que vous ou votre organisation avez écrit ou représentez."
 
 #: src/olympia/pages/templates/pages/review_guide.html:125
 msgid ""
-"Criticize an add-on for something it’s intended to do. For example, leaving "
-"a negative review of an add-on for displaying ads or requiring data "
-"gathering, when that is the intended purpose of the add-on, or the add-on "
-"requires gathering data to function."
+"Criticize an add-on for something it’s intended to do. For example, leaving a negative review of an add-on for displaying ads or requiring data gathering, when that is the intended purpose of the "
+"add-on, or the add-on requires gathering data to function."
 msgstr ""
-"Critiquez un module pour quelque chose qu’il est censé faire. Par exemple, "
-"laissez une critique négative d'un module pour afficher des publicités ou "
-"nécessitant la collecte de données, lorsque c'est l'objectif visé par le "
-"module, ou si le module nécessite la collecte de données pour fonctionner."
+"Critiquez un module pour quelque chose qu’il est censé faire. Par exemple, laissez une critique négative d'un module pour afficher des publicités ou nécessitant la collecte de données, lorsque "
+"c'est l'objectif visé par le module, ou si le module nécessite la collecte de données pour fonctionner."
 
 #: src/olympia/pages/templates/pages/review_guide.html:133
 msgid "How can I report a problematic review?"
@@ -13823,16 +10712,11 @@ msgstr "Comment puis-je rapporter un commentaire problématique ?"
 
 #: src/olympia/pages/templates/pages/review_guide.html:135
 msgid ""
-"Please report or flag any questionable reviews by clicking the \"Report this"
-" review\" and it will be submitted to the site for moderation. Our "
-"moderation team will use the Review Guidelines to evaluate whether or not to"
-" delete the review or restore it back to the site."
+"Please report or flag any questionable reviews by clicking the \"Report this review\" and it will be submitted to the site for moderation. Our moderation team will use the Review Guidelines to "
+"evaluate whether or not to delete the review or restore it back to the site."
 msgstr ""
-"Veuillez rapporter ou marquer tout commentaires douteux en cliquant sur « "
-"Signaler ce commentaire » et il sera présenté sur le site de la modération. "
-"Notre équipe de modération utilisera les directives pour les commentaires et"
-" évaluera s'il faut ou non supprimer le commentaire ou le rétablir sur le "
-"site."
+"Veuillez rapporter ou marquer tout commentaires douteux en cliquant sur « Signaler ce commentaire » et il sera présenté sur le site de la modération. Notre équipe de modération utilisera les "
+"directives pour les commentaires et évaluera s'il faut ou non supprimer le commentaire ou le rétablir sur le site."
 
 #: src/olympia/pages/templates/pages/review_guide.html:140
 msgid "I’m an add-on author, can I respond to reviews?"
@@ -13840,36 +10724,23 @@ msgstr "Je suis auteur de module, puis-je répondre aux commentaires ?"
 
 #: src/olympia/pages/templates/pages/review_guide.html:142
 #, python-format
-msgid ""
-"Yes, add-on authors can provide a single response to a review. You can set "
-"up a discussion topic in our <a href=\"%(forum_url)s\">forum</a> to engage "
-"in additional discussion or follow-up."
+msgid "Yes, add-on authors can provide a single response to a review. You can set up a discussion topic in our <a href=\"%(forum_url)s\">forum</a> to engage in additional discussion or follow-up."
 msgstr ""
-"Oui, les auteurs le module peuvent donner une réponse unique à une revue. "
-"Vous pouvez lancer un sujet de discussion dans notre <a "
-"href=\"%(forum_url)s\">forum</a> pour engager des discussions "
+"Oui, les auteurs le module peuvent donner une réponse unique à une revue. Vous pouvez lancer un sujet de discussion dans notre <a href=\"%(forum_url)s\">forum</a> pour engager des discussions "
 "supplémentaires ou avoir du suivi."
 
 #: src/olympia/pages/templates/pages/review_guide.html:149
 msgid "I’m an add-on author, can I delete unfavorable reviews or ratings?"
-msgstr ""
-"Je suis auteur de module, puis-je supprimer les commentaires et notes "
-"défavorables ?"
+msgstr "Je suis auteur de module, puis-je supprimer les commentaires et notes défavorables ?"
 
 #: src/olympia/pages/templates/pages/review_guide.html:151
 msgid ""
-"In general, no. But if the review did not meet the review guidelines "
-"outlined above, you can click \"Report this review\" and have it moderated. "
-"If a review included a complaint that is no longer valid due to a new "
-"release of your add-on, we may consider deleting the review. Submit your "
-"detailed request to amo-editors@mozilla.org."
+"In general, no. But if the review did not meet the review guidelines outlined above, you can click \"Report this review\" and have it moderated. If a review included a complaint that is no longer "
+"valid due to a new release of your add-on, we may consider deleting the review. Submit your detailed request to amo-editors@mozilla.org."
 msgstr ""
-"En général, non. Mais si la revue ne respectait pas les lignes directrices "
-"décrites ci-dessus, vous pouvez cliquez sur « Signaler cette revue » et "
-"demander qu’elle soit modérée. Si une revue comprenait une observation qui "
-"n'est plus valide en raison d'une nouvelle version de votre module, nous "
-"pouvons envisager la suppression de la revue. Soumettez votre demande "
-"détaillée à amo-editors@mozilla.org."
+"En général, non. Mais si la revue ne respectait pas les lignes directrices décrites ci-dessus, vous pouvez cliquez sur « Signaler cette revue » et demander qu’elle soit modérée. Si une revue "
+"comprenait une observation qui n'est plus valide en raison d'une nouvelle version de votre module, nous pouvons envisager la suppression de la revue. Soumettez votre demande détaillée à amo-"
+"editors@mozilla.org."
 
 #: src/olympia/pages/templates/pages/sunbird.html:26
 msgid "Sunbird has retired"
@@ -13877,24 +10748,16 @@ msgstr "Sunbird a pris sa retraite"
 
 #: src/olympia/pages/templates/pages/sunbird.html:29
 msgid ""
-"Development on the Sunbird project has halted and its final release was on "
-"March 30, 2010. We've been proud to host Sunbird add-ons on this site but as"
-" the project is no longer maintained we have disabled our support for the "
-"add-ons."
+"Development on the Sunbird project has halted and its final release was on March 30, 2010. We've been proud to host Sunbird add-ons on this site but as the project is no longer maintained we have "
+"disabled our support for the add-ons."
 msgstr ""
-"Le développement du projet Sunbird s'est arrêté et la dernière version a été"
-" publiée le 30 mars 2010. Nous avons été fiers d'héberger les modules "
-"Sunbird sur ce site, mais étant donné que le projet n'est plus maintenu nous"
-" avons désactivé toute assistance pour les modules."
+"Le développement du projet Sunbird s'est arrêté et la dernière version a été publiée le 30 mars 2010. Nous avons été fiers d'héberger les modules Sunbird sur ce site, mais étant donné que le projet"
+" n'est plus maintenu nous avons désactivé toute assistance pour les modules."
 
 #: src/olympia/pages/templates/pages/sunbird.html:38
 #, python-format
-msgid ""
-"We recommend upgrading to <a href=\"%(tb_url)s\">Thunderbird</a> and <a "
-"href=\"%(lightning_url)s\">Lightning</a>."
-msgstr ""
-"Il est conseillé de passer à <a href=\"%(tb_url)s\">Thunderbird</a> avec <a "
-"href=\"%(lightning_url)s\">Lightning</a>."
+msgid "We recommend upgrading to <a href=\"%(tb_url)s\">Thunderbird</a> and <a href=\"%(lightning_url)s\">Lightning</a>."
+msgstr "Il est conseillé de passer à <a href=\"%(tb_url)s\">Thunderbird</a> avec <a href=\"%(lightning_url)s\">Lightning</a>."
 
 #: src/olympia/pages/templates/pages/sunbird.html:45
 msgid "Read more about Sunbird"
@@ -13902,9 +10765,7 @@ msgstr "En savoir plus à propos de Sunbird"
 
 #: src/olympia/paypal/__init__.py:25
 msgid "There was an error communicating with PayPal. Please try again later."
-msgstr ""
-"Une erreur s'est produite pendant la communication avec Paypal. Merci de "
-"réessayer plus tard."
+msgstr "Une erreur s'est produite pendant la communication avec Paypal. Merci de réessayer plus tard."
 
 #: src/olympia/paypal/__init__.py:50
 msgid "There was an error with this currency."
@@ -13912,9 +10773,7 @@ msgstr "Il y a eu une erreur avec cette monnaie."
 
 #: src/olympia/paypal/__init__.py:68
 msgid "The amount is too small for conversion into the receiver's currency."
-msgstr ""
-"Le montant est trop faible pour une conversion dans la monnaie du "
-"destinataire."
+msgstr "Le montant est trop faible pour une conversion dans la monnaie du destinataire."
 
 #: src/olympia/paypal/__init__.py:70
 msgid "The buyer and seller must have different PayPal accounts."
@@ -13949,8 +10808,7 @@ msgstr "Conserver la revue ; retirer les étiquettes"
 msgid "Skip for now"
 msgstr "Passer pour le moment"
 
-#: src/olympia/reviews/forms.py:151
-#: src/olympia/reviews/templates/reviews/review.html:107
+#: src/olympia/reviews/forms.py:151 src/olympia/reviews/templates/reviews/review.html:107
 msgid "Delete review"
 msgstr "Supprimer la critique"
 
@@ -13960,9 +10818,7 @@ msgstr "Autre (veuillez préciser)"
 
 #: src/olympia/reviews/views.py:149
 msgid "Thanks; this review has been flagged for editor approval."
-msgstr ""
-"Merci. Cette critique est maintenant en attente d'approbation par un "
-"modérateur."
+msgstr "Merci. Cette critique est maintenant en attente d'approbation par un modérateur."
 
 #: src/olympia/reviews/templates/reviews/add.html:4
 msgid "Add a review for {0}"
@@ -13971,43 +10827,24 @@ msgstr "Ajouter une critique sur {0}"
 #: src/olympia/reviews/templates/reviews/add.html:26
 #, python-format
 msgid ""
-"<h2>Keep these tips in mind:</h2> <ul> <li> Write like you're telling a "
-"friend about your experience with the add-on. Give specifics and helpful "
-"details, such as what features you liked and/or disliked, how easy to use it"
-" is, and any disadvantages it has. Avoid generic language such as calling it"
-" \"Great\" or \"Bad\" unless you can give reasons why you believe this is "
-"so. </li> <li> Please do not post bug reports in reviews. We do not make "
-"your email address available to add-on developers and they may need to "
-"contact you to help resolve your issue. See the <a "
-"href=\"%(support)s\">support section</a> to find out where to get assistance"
-" for this add-on. </li> <li>Please keep reviews clean, avoid the use of "
-"improper language and do not post any personal information. </li> </ul> "
-"<p>Please read the <a href=\"%(guide)s\" target=\"_blank\">Review "
-"Guidelines</a> for more detail about user add-on reviews.</p>"
+"<h2>Keep these tips in mind:</h2> <ul> <li> Write like you're telling a friend about your experience with the add-on. Give specifics and helpful details, such as what features you liked and/or "
+"disliked, how easy to use it is, and any disadvantages it has. Avoid generic language such as calling it \"Great\" or \"Bad\" unless you can give reasons why you believe this is so. </li> <li> "
+"Please do not post bug reports in reviews. We do not make your email address available to add-on developers and they may need to contact you to help resolve your issue. See the <a "
+"href=\"%(support)s\">support section</a> to find out where to get assistance for this add-on. </li> <li>Please keep reviews clean, avoid the use of improper language and do not post any personal "
+"information. </li> </ul> <p>Please read the <a href=\"%(guide)s\" target=\"_blank\">Review Guidelines</a> for more detail about user add-on reviews.</p>"
 msgstr ""
-"<h2>Gardez ceci en mémoire :</h2> <ul> <li> Écrivez comme vous le feriez à "
-"un ami pour lui raconter votre expérience avec le module. Donnez des détails"
-" précis et utiles, tels les fonctionnalités que vous avez appréciées ou non,"
-" la simplicité d'utilisation, et quels points faibles il comporte. Évitez "
-"les expressions trop générales "
-"telles&nbsp;«&nbsp;Super&nbsp;»&nbsp;ou&nbsp;«&nbsp;Nul&nbsp;»&nbsp;à moins "
-"que vous ne puissiez justifier.</li> <li> Merci de ne pas poster de rapport "
-"de bugs ici. Les développeurs de module n'ont pas accès à votre adresse "
-"courriel et ils pourraient avoir besoin de vous contacter pour corriger "
-"votre problème. Référez-vous à la <a href=\"%(support)s\">section "
-"assistance</a> pour savoir comment obtenir de l'aide pour ce module. </li> "
-"<li>Merci d'éviter l'utilisation d'un vocabulaire inapproprié dans les "
-"critiques et de ne pas poster d'information personnelle. </li> </ul> "
-"<p>Merci de lire les <a href=\"%(guide)s\" target=\"_blank\">lignes "
-"directrices pour les critiques</a> pour plus de détails sur les critiques "
-"des utilisateurs.</p>"
+"<h2>Gardez ceci en mémoire :</h2> <ul> <li> Écrivez comme vous le feriez à un ami pour lui raconter votre expérience avec le module. Donnez des détails précis et utiles, tels les fonctionnalités "
+"que vous avez appréciées ou non, la simplicité d'utilisation, et quels points faibles il comporte. Évitez les expressions trop générales "
+"telles&nbsp;«&nbsp;Super&nbsp;»&nbsp;ou&nbsp;«&nbsp;Nul&nbsp;»&nbsp;à moins que vous ne puissiez justifier.</li> <li> Merci de ne pas poster de rapport de bugs ici. Les développeurs de module n'ont"
+" pas accès à votre adresse courriel et ils pourraient avoir besoin de vous contacter pour corriger votre problème. Référez-vous à la <a href=\"%(support)s\">section assistance</a> pour savoir "
+"comment obtenir de l'aide pour ce module. </li> <li>Merci d'éviter l'utilisation d'un vocabulaire inapproprié dans les critiques et de ne pas poster d'information personnelle. </li> </ul> <p>Merci "
+"de lire les <a href=\"%(guide)s\" target=\"_blank\">lignes directrices pour les critiques</a> pour plus de détails sur les critiques des utilisateurs.</p>"
 
 #: src/olympia/reviews/templates/reviews/reply.html:4
 msgid "Reply to review by {0}"
 msgstr "Répondre à la vérification de {0}"
 
-#: src/olympia/reviews/templates/reviews/reply.html:15
-#: src/olympia/reviews/templates/reviews/reply.html:31
+#: src/olympia/reviews/templates/reviews/reply.html:15 src/olympia/reviews/templates/reviews/reply.html:31
 msgid "Reply"
 msgstr "Répondre"
 
@@ -14015,8 +10852,7 @@ msgstr "Répondre"
 msgid "Write a Reply"
 msgstr "Écrire une réponse"
 
-#: src/olympia/reviews/templates/reviews/reply.html:36
-#: src/olympia/reviews/templates/reviews/report_review.html:12
+#: src/olympia/reviews/templates/reviews/reply.html:36 src/olympia/reviews/templates/reviews/report_review.html:12
 msgid "Submit"
 msgstr "Proposer"
 
@@ -14036,34 +10872,21 @@ msgid "by %(user)s <b>(Developer)</b> on %(date)s"
 msgstr "par %(user)s <b>(développeur)</b> le %(date)s"
 
 #. {0} is a version number (like 1.01)
-#: src/olympia/reviews/templates/reviews/review.html:50
-#: src/olympia/reviews/templates/reviews/mobile/review_list.html:41
+#: src/olympia/reviews/templates/reviews/review.html:50 src/olympia/reviews/templates/reviews/mobile/review_list.html:41
 msgid "This review is for a previous version of the add-on ({0})."
 msgstr "Cette critique est pour une version précédente du module ({0})."
 
 #: src/olympia/reviews/templates/reviews/review.html:56
 #, python-format
-msgid ""
-"This user has a <a href=\"%(user_review_url)s\">previous review</a> of this "
-"add-on."
-msgid_plural ""
-"This user has <a href=\"%(user_review_url)s\">%(cnt)s previous reviews</a> "
-"of this add-on."
-msgstr[0] ""
-"Cet utilisateur a une <a href=\"%(user_review_url)s\">revue précédente</a> "
-"sur ce module."
-msgstr[1] ""
-"Cet utilisateur a <a href=\"%(user_review_url)s\">%(cnt)s revues "
-"précédentes</a> sur ce module."
+msgid "This user has a <a href=\"%(user_review_url)s\">previous review</a> of this add-on."
+msgid_plural "This user has <a href=\"%(user_review_url)s\">%(cnt)s previous reviews</a> of this add-on."
+msgstr[0] "Cet utilisateur a une <a href=\"%(user_review_url)s\">revue précédente</a> sur ce module."
+msgstr[1] "Cet utilisateur a <a href=\"%(user_review_url)s\">%(cnt)s revues précédentes</a> sur ce module."
 
 #: src/olympia/reviews/templates/reviews/review.html:62
 #, python-format
-msgid ""
-"This user has <a href=\"%(user_review_url)s\">other reviews</a> of this add-"
-"on."
-msgstr ""
-"Cet utilisateur a <a href=\"%(user_review_url)s\">d'autres revues</a> sur ce"
-" module."
+msgid "This user has <a href=\"%(user_review_url)s\">other reviews</a> of this add-on."
+msgstr "Cet utilisateur a <a href=\"%(user_review_url)s\">d'autres revues</a> sur ce module."
 
 #: src/olympia/reviews/templates/reviews/review.html:72
 msgid "Flagged for review"
@@ -14095,9 +10918,7 @@ msgid "{0} :: Reviews"
 msgstr "{0} :: Vérifications"
 
 #. {0} is an addon name.
-#: src/olympia/reviews/templates/reviews/review_list.html:24
-#: src/olympia/reviews/templates/reviews/mobile/add.html:4
-#: src/olympia/reviews/templates/reviews/mobile/review_list.html:4
+#: src/olympia/reviews/templates/reviews/review_list.html:24 src/olympia/reviews/templates/reviews/mobile/add.html:4 src/olympia/reviews/templates/reviews/mobile/review_list.html:4
 msgid "Reviews for {0}"
 msgstr "Critiques de {0}"
 
@@ -14133,8 +10954,7 @@ msgstr "<strong>Moyenne</strong> (%(total)s)"
 msgid "Write a New Review"
 msgstr "Écrire un nouvel avis"
 
-#: src/olympia/reviews/templates/reviews/review_list.html:81
-#: src/olympia/reviews/templates/reviews/mobile/reviews_link.html:15
+#: src/olympia/reviews/templates/reviews/review_list.html:81 src/olympia/reviews/templates/reviews/mobile/reviews_link.html:15
 msgid "Be the first to write a review."
 msgstr "Soyez le premier à écrire une critique."
 
@@ -14153,8 +10973,7 @@ msgstr "Noté {0} sur 5 étoiles"
 msgid "Rated %(rating)s out of 5 stars"
 msgstr "Noté %(rating)s sur 5 étoiles"
 
-#: src/olympia/reviews/templates/reviews/mobile/add_form.html:3
-#: src/olympia/reviews/templates/reviews/mobile/add_form.html:8
+#: src/olympia/reviews/templates/reviews/mobile/add_form.html:3 src/olympia/reviews/templates/reviews/mobile/add_form.html:8
 msgid "Add a Review"
 msgstr "Ajouter une critique"
 
@@ -14225,10 +11044,8 @@ msgid "Relevance"
 msgstr "Pertinence"
 
 #: src/olympia/search/helpers.py:24
-msgid ""
-"Results <strong>{0}</strong>-<strong>{1}</strong> of <strong>{2}</strong>"
-msgstr ""
-"Résultats<strong>{0}</strong>-<strong>{1}</strong> sur <strong>{2}</strong>"
+msgid "Results <strong>{0}</strong>-<strong>{1}</strong> of <strong>{2}</strong>"
+msgstr "Résultats<strong>{0}</strong>-<strong>{1}</strong> sur <strong>{2}</strong>"
 
 # {0} is a number
 # {1} is a number
@@ -14236,12 +11053,8 @@ msgstr ""
 # {3} is the word the person is searching for
 # {4} is a word (the add-on is tagged with it)
 #: src/olympia/search/helpers.py:44
-msgid ""
-"Showing {0} - {1} of {2} results for <strong>{3}</strong> tagged with "
-"<strong>{4}</strong>"
-msgstr ""
-"Affichage de {0} - {1} sur {2} résultats pour <strong>{3}</strong> avec "
-"l'étiquette<strong>{4}</strong>"
+msgid "Showing {0} - {1} of {2} results for <strong>{3}</strong> tagged with <strong>{4}</strong>"
+msgstr "Affichage de {0} - {1} sur {2} résultats pour <strong>{3}</strong> avec l'étiquette<strong>{4}</strong>"
 
 # {0} is a number
 # {1} is a number
@@ -14257,9 +11070,7 @@ msgstr "Affichage de {0} - {1} sur {2} résultats pour <strong>{3}</strong>"
 # {3} is a word (the add-on is tagged with it)
 #: src/olympia/search/helpers.py:52
 msgid "Showing {0} - {1} of {2} results tagged with <strong>{3}</strong>"
-msgstr ""
-"Affichage de {0} - {1} sur {2} résultats avec le l'étiquette "
-"<strong>{3}</strong>"
+msgstr "Affichage de {0} - {1} sur {2} résultats avec le l'étiquette <strong>{3}</strong>"
 
 # {0} is a number
 # {1} is a number
@@ -14269,24 +11080,22 @@ msgid "Showing {0} - {1} of {2} results"
 msgstr "Affichage de {0} - {1} sur {2} résultats"
 
 #. {0} is an application, like Firefox.
-#: src/olympia/search/views.py:264 src/olympia/templates/base.html:17
-#: src/olympia/templates/impala/base.html:17
-#: src/olympia/templates/mobile/base_addons.html:17
+#: src/olympia/search/views.py:264 src/olympia/templates/base.html:17 src/olympia/templates/impala/base.html:17 src/olympia/templates/mobile/base_addons.html:17
 msgid "{0} Add-ons"
 msgstr "{0} Modules"
 
 #. L10n: {0} is an application, such as Firefox. This means "any version of
 #. Firefox."
-#: src/olympia/search/views.py:554
+#: src/olympia/search/views.py:547
 msgid "Any {0}"
 msgstr "Quel que soit {0}"
 
 #. L10n: "All Systems" means show everything regardless of platform.
-#: src/olympia/search/views.py:589
+#: src/olympia/search/views.py:582
 msgid "All Systems"
 msgstr "Tous les systèmes"
 
-#: src/olympia/search/views.py:600
+#: src/olympia/search/views.py:593
 msgid "All Tags"
 msgstr "Toutes les étiquettes"
 
@@ -14305,9 +11114,7 @@ msgstr "Recherche non disponible"
 
 #: src/olympia/search/templates/search/down.html:6
 msgid "Search is temporarily unavailable. Please try again in a few minutes."
-msgstr ""
-"La recherche est temporairement indisponible. Merci de réessayer dans "
-"quelques minutes."
+msgstr "La recherche est temporairement indisponible. Merci de réessayer dans quelques minutes."
 
 #. {0} is the string the user was searching for
 #: src/olympia/search/templates/search/personas.html:9
@@ -14462,37 +11269,31 @@ msgstr "Partager ce module"
 msgid "Share this Collection"
 msgstr "Partager cette collection"
 
-#: src/olympia/signing/views.py:30 src/olympia/templates/base.html:75
-#: src/olympia/templates/impala/base.html:115
-msgid ""
-"Some features are temporarily disabled while we perform website maintenance."
-" We'll be back to full capacity shortly."
-msgstr ""
-"Certaines fonctionnalités sont temporairement désactivées pendant que nous "
-"effectuons une maintenance du site web. Nous serons bientôt de retour à "
-"capacité maximale."
+#: src/olympia/signing/views.py:33 src/olympia/templates/base.html:71 src/olympia/templates/impala/base.html:112
+msgid "Some features are temporarily disabled while we perform website maintenance. We'll be back to full capacity shortly."
+msgstr "Certaines fonctionnalités sont temporairement désactivées pendant que nous effectuons une maintenance du site web. Nous serons bientôt de retour à capacité maximale."
 
-#: src/olympia/signing/views.py:53
+#: src/olympia/signing/views.py:56
 msgid "Could not find add-on with id \"{}\"."
 msgstr "Impossible de trouver le module dont l'identifiant est « {} »."
 
-#: src/olympia/signing/views.py:67
+#: src/olympia/signing/views.py:70
 msgid "You do not own this addon."
 msgstr "Vous n'êtes pas propriétaire de ce module."
 
-#: src/olympia/signing/views.py:82
+#: src/olympia/signing/views.py:87
 msgid "Missing \"upload\" key in multipart file data."
 msgstr "La clé « upload » est absente du fichier de données multipart."
 
-#: src/olympia/signing/views.py:96
+#: src/olympia/signing/views.py:101
 msgid "Version does not match the manifest file."
 msgstr "La version ne correspond pas au fichier manifeste."
 
-#: src/olympia/signing/views.py:100
+#: src/olympia/signing/views.py:105
 msgid "Version already exists."
 msgstr "La version existe déjà."
 
-#: src/olympia/signing/views.py:136
+#: src/olympia/signing/views.py:141
 msgid "No uploaded file for that addon and version."
 msgstr "Aucun fichier envoyé pour ce module et cette version."
 
@@ -14584,8 +11385,7 @@ msgstr "De"
 msgid "To"
 msgstr "À"
 
-#: src/olympia/stats/templates/stats/popup.html:27
-#: src/olympia/users/templates/users/pwreset_confirm.html:38
+#: src/olympia/stats/templates/stats/popup.html:27 src/olympia/users/templates/users/pwreset_confirm.html:38
 msgid "Update"
 msgstr "Actualiser"
 
@@ -14606,99 +11406,91 @@ msgstr "{0} :: Tableau de bord des statistiques"
 msgid "Statistics Dashboard :: Add-ons for {0}"
 msgstr "Tableau de bord des statistiques :: Modules pour {0}"
 
-#: src/olympia/stats/templates/stats/stats.html:30
-msgid "Controls:"
-msgstr "Contrôles :"
-
-#: src/olympia/stats/templates/stats/stats.html:33
-msgid "reset zoom"
-msgstr "réinitialiser zoom"
-
-#: src/olympia/stats/templates/stats/stats.html:40
-msgid "Group by:"
-msgstr "Grouper par :"
-
-#: src/olympia/stats/templates/stats/stats.html:42
-msgid "day"
-msgstr "jour"
-
-#: src/olympia/stats/templates/stats/stats.html:45
-msgid "week"
-msgstr "semaine"
-
-#: src/olympia/stats/templates/stats/stats.html:48
-msgid "month"
-msgstr "mois"
-
-#: src/olympia/stats/templates/stats/stats.html:54
-msgid "For last:"
-msgstr "Depuis :"
-
-#: src/olympia/stats/templates/stats/stats.html:57
-msgid "7 days"
-msgstr "7 jours"
-
-#: src/olympia/stats/templates/stats/stats.html:60
-msgid "30 days"
-msgstr "30 jours"
-
-#: src/olympia/stats/templates/stats/stats.html:63
-msgid "90 days"
-msgstr "90 jours"
-
-#: src/olympia/stats/templates/stats/stats.html:66
-msgid "365 days"
-msgstr "365 jours"
-
-#: src/olympia/stats/templates/stats/stats.html:69
-msgid "Custom..."
-msgstr "Personnalisé ..."
-
 #. {0} is an add-on name
-#: src/olympia/stats/templates/stats/stats.html:88
-#: src/olympia/stats/templates/stats/stats.html:91
+#: src/olympia/stats/templates/stats/stats.html:44 src/olympia/stats/templates/stats/stats.html:47
 msgid "Statistics for {0}"
 msgstr "Statistiques pour {0}"
 
-#: src/olympia/stats/templates/stats/stats.html:94
+#: src/olympia/stats/templates/stats/stats.html:50
 msgid "Statistics Dashboard"
 msgstr "Tableau de bord des statistiques"
 
-#: src/olympia/stats/templates/stats/stats.html:104
-msgid ""
-"Statistics processing is currently disabled, so recent data is unavailable. "
-"The statistics are still being collected and this page will be updated soon "
-"with the missing data."
-msgstr ""
-"Le traitement des statistiques est actuellement désactivé et les données "
-"récentes sont donc indisponibles. Les statistiques continuent d'être "
-"collectées et cette page sera bientôt mise à jour avec les données "
-"manquantes."
+#: src/olympia/stats/templates/stats/stats.html:57
+msgid "Controls:"
+msgstr "Contrôles :"
 
-#: src/olympia/stats/templates/stats/stats.html:110
+#: src/olympia/stats/templates/stats/stats.html:60
+msgid "reset zoom"
+msgstr "réinitialiser zoom"
+
+#: src/olympia/stats/templates/stats/stats.html:67
+msgid "Group by:"
+msgstr "Grouper par :"
+
+#: src/olympia/stats/templates/stats/stats.html:69
+msgid "day"
+msgstr "jour"
+
+#: src/olympia/stats/templates/stats/stats.html:72
+msgid "week"
+msgstr "semaine"
+
+#: src/olympia/stats/templates/stats/stats.html:75
+msgid "month"
+msgstr "mois"
+
+#: src/olympia/stats/templates/stats/stats.html:81
+msgid "For last:"
+msgstr "Depuis :"
+
+#: src/olympia/stats/templates/stats/stats.html:84
+msgid "7 days"
+msgstr "7 jours"
+
+#: src/olympia/stats/templates/stats/stats.html:87
+msgid "30 days"
+msgstr "30 jours"
+
+#: src/olympia/stats/templates/stats/stats.html:90
+msgid "90 days"
+msgstr "90 jours"
+
+#: src/olympia/stats/templates/stats/stats.html:93
+msgid "365 days"
+msgstr "365 jours"
+
+#: src/olympia/stats/templates/stats/stats.html:96
+msgid "Custom..."
+msgstr "Personnalisé ..."
+
+#: src/olympia/stats/templates/stats/stats.html:106
+msgid "Statistics processing is currently disabled, so recent data is unavailable. The statistics are still being collected and this page will be updated soon with the missing data."
+msgstr ""
+"Le traitement des statistiques est actuellement désactivé et les données récentes sont donc indisponibles. Les statistiques continuent d'être collectées et cette page sera bientôt mise à jour avec "
+"les données manquantes."
+
+#: src/olympia/stats/templates/stats/stats.html:112
 msgid "Loading the latest data&hellip;"
 msgstr "Chargement des dernières données &hellip;"
 
-#: src/olympia/stats/templates/stats/stats.html:142
-#: src/olympia/stats/templates/stats/reports/overview.html:25
-#: src/olympia/stats/templates/stats/reports/overview.html:37
+#: src/olympia/stats/templates/stats/stats.html:144 src/olympia/stats/templates/stats/reports/overview.html:25 src/olympia/stats/templates/stats/reports/overview.html:37
 #: src/olympia/stats/templates/stats/reports/overview.html:49
 msgid "No data available."
 msgstr "Pas de données disponible."
 
-#: src/olympia/stats/templates/stats/stats.html:177
+#: src/olympia/stats/templates/stats/stats.html:179
 msgid "This dashboard is currently <b>public</b>."
 msgstr "Ce tableau de bord est actuellement <b>public</b>."
 
-#: src/olympia/stats/templates/stats/stats.html:179
+#: src/olympia/stats/templates/stats/stats.html:181
 msgid "Contribution stats are currently <b>private</b>."
 msgstr "Les statistiques de contribution sont actuellement <b>privées</b>"
 
-#: src/olympia/stats/templates/stats/stats.html:182
+#: src/olympia/stats/templates/stats/stats.html:184
 msgid "This dashboard is currently <b>private</b>."
 msgstr "Ce tableau de bord est actuellement <b>privé</b>."
 
-#: src/olympia/stats/templates/stats/stats.html:185
+#: src/olympia/stats/templates/stats/stats.html:187
 msgid "Change settings."
 msgstr "Changer les paramètres."
 
@@ -14740,15 +11532,11 @@ msgstr "Comment les téléchargements sont-ils comptabilisés ?"
 
 #: src/olympia/stats/templates/stats/reports/downloads.html:10
 msgid ""
-"<h2>How are downloads counted?</h2> <p> Download counts are updated every "
-"evening and only include original add-on downloads, not updates. Downloads "
-"can be broken down by the specific source referring the download. </p>"
+"<h2>How are downloads counted?</h2> <p> Download counts are updated every evening and only include original add-on downloads, not updates. Downloads can be broken down by the specific source "
+"referring the download. </p>"
 msgstr ""
-"<h2>Comment les téléchargements sont-ils comptabilisés ?</h2> <p> Les "
-"statistiques de téléchargements sont mises à jour toutes les nuits et ne "
-"contiennent que les téléchargements nouveaux, pas les mises à jour. Ces "
-"informations peuvent être classifiées par rapport à la source d'origine "
-"du téléchargement.</p>"
+"<h2>Comment les téléchargements sont-ils comptabilisés ?</h2> <p> Les statistiques de téléchargements sont mises à jour toutes les nuits et ne contiennent que les téléchargements nouveaux, "
+"pas les mises à jour. Ces informations peuvent être classifiées par rapport à la source d'origine du téléchargement.</p>"
 
 #: src/olympia/stats/templates/stats/reports/locales.html:3
 msgid "User languages by Date"
@@ -14762,8 +11550,7 @@ msgstr "Utilisation de la plateforme par date"
 msgid "<b>{0}</b> Downloads"
 msgstr "<b>{0}</b> téléchargements"
 
-#: src/olympia/stats/templates/stats/reports/overview.html:9
-#: src/olympia/stats/templates/stats/reports/overview.html:13
+#: src/olympia/stats/templates/stats/reports/overview.html:9 src/olympia/stats/templates/stats/reports/overview.html:13
 msgid "Loading..."
 msgstr "Chargement &hellip;"
 
@@ -14814,34 +11601,17 @@ msgstr "À propos du suivi des sources externes ..."
 #: src/olympia/stats/templates/stats/reports/sources.html:10
 #, python-format
 msgid ""
-"<h2>Tracking external sources</h2> <p> If you link to your add-on's details "
-"page or directly to its file from an external site, such as your blog or "
-"website, you can append a parameter to be tracked as an additional download "
-"source on this page. For example, the following links would appear as "
-"sourced by your blog: <dl> <dt>Add-on Details Page</dt> "
-"<dd>https://addons.mozilla.org/addon/%(slug)s?src=<b>external-blog</b></dd> "
-"<dt>Direct File Link</dt> "
-"<dd>https://addons.mozilla.org/downloads/latest/%(id)s/addon-%(id)s-latest.xpi?src=<b"
-">external-blog</b></dd> </dl> <p> Only src parameters that begin with "
-"\"external-\" will be tracked, up to 61 additional characters. Any text "
-"after \"external-\" can be used to describe the source, such as \"external-"
-"blog\", \"external-sidebar\", \"external-campaign225\", etc. The following "
-"URL-safe characters are allowed: <code>a-z A-Z - . _ ~ %% +</code>"
+"<h2>Tracking external sources</h2> <p> If you link to your add-on's details page or directly to its file from an external site, such as your blog or website, you can append a parameter to be "
+"tracked as an additional download source on this page. For example, the following links would appear as sourced by your blog: <dl> <dt>Add-on Details Page</dt> "
+"<dd>https://addons.mozilla.org/addon/%(slug)s?src=<b>external-blog</b></dd> <dt>Direct File Link</dt> <dd>https://addons.mozilla.org/downloads/latest/%(id)s/addon-%(id)s-latest.xpi?src=<b>external-"
+"blog</b></dd> </dl> <p> Only src parameters that begin with \"external-\" will be tracked, up to 61 additional characters. Any text after \"external-\" can be used to describe the source, such as "
+"\"external-blog\", \"external-sidebar\", \"external-campaign225\", etc. The following URL-safe characters are allowed: <code>a-z A-Z - . _ ~ %% +</code>"
 msgstr ""
-"<h2>Suivi des sources externes</h2> <p> Si vous faites un lien vers la page "
-"de détails de votre module ou directement sur le fichier depuis un site "
-"externe, comme votre blog, vous pouvez ajouter un paramètre à suivre comme "
-"source additionnelle de téléchargements. Par exemple, les liens suivants "
-"apparaitront comme étant sourcés depuis votre blog : <dl> <dt>Page de "
-"détails du module</dt> <dd>https://addons.mozilla.org/addon/%(slug)s?src=<b"
-">external-blog</b></dd> <dt>Lien direct</dt> "
-"<dd>https://addons.mozilla.org/downloads/latest/%(id)s/addon-%(id)s-latest.xpi?src=<b"
-">external-blog</b></dd> </dl> <p> Seuls les paramètres src qui commencent "
-"avec « external- » seront suivi, avec un maximum de 61 caractères "
-"supplémentaires. Tout texte après « external- » peut être utilisé pour "
-"décrire la source, comme par exemple « external-blog », « external-sidebar "
-"», « external-campaign225 », etc. Les caractères suivants sont autorisés : "
-"<code>a-z A-Z - . _ ~ %% +</code>"
+"<h2>Suivi des sources externes</h2> <p> Si vous faites un lien vers la page de détails de votre module ou directement sur le fichier depuis un site externe, comme votre blog, vous pouvez ajouter un"
+" paramètre à suivre comme source additionnelle de téléchargements. Par exemple, les liens suivants apparaitront comme étant sourcés depuis votre blog : <dl> <dt>Page de détails du module</dt> "
+"<dd>https://addons.mozilla.org/addon/%(slug)s?src=<b>external-blog</b></dd> <dt>Lien direct</dt> <dd>https://addons.mozilla.org/downloads/latest/%(id)s/addon-%(id)s-latest.xpi?src=<b>external-"
+"blog</b></dd> </dl> <p> Seuls les paramètres src qui commencent avec « external- » seront suivi, avec un maximum de 61 caractères supplémentaires. Tout texte après « external- » peut être utilisé "
+"pour décrire la source, comme par exemple « external-blog », « external-sidebar », « external-campaign225 », etc. Les caractères suivants sont autorisés : <code>a-z A-Z - . _ ~ %% +</code>"
 
 #: src/olympia/stats/templates/stats/reports/statuses.html:3
 msgid "Add-on Status by Date"
@@ -14861,29 +11631,20 @@ msgstr "Que sont les utilisateurs journaliers ?"
 
 #: src/olympia/stats/templates/stats/reports/usage.html:11
 msgid ""
-"<h2>What are daily users?</h2> <p> Themes installed from this site check for"
-" updates once per day. The total number of these update pings is known as "
-"Active Daily Users, or the total number of people using your theme by day. "
-"</p>"
+"<h2>What are daily users?</h2> <p> Themes installed from this site check for updates once per day. The total number of these update pings is known as Active Daily Users, or the total number of "
+"people using your theme by day. </p>"
 msgstr ""
-"<h2>Que sont les utilisateurs journaliers ?</h2> <p> Les thèmes installés "
-"depuis ce site vérifient l'existence de mises à jour une fois par jour. Le "
-"nombre de ces vérification est identifié comme less utilisateurs quotidiens "
-"actifs, ou le nombre de gens qui utilisent votre thème tous les jours. </p>"
+"<h2>Que sont les utilisateurs journaliers ?</h2> <p> Les thèmes installés depuis ce site vérifient l'existence de mises à jour une fois par jour. Le nombre de ces vérification est identifié comme "
+"less utilisateurs quotidiens actifs, ou le nombre de gens qui utilisent votre thème tous les jours. </p>"
 
 #: src/olympia/stats/templates/stats/reports/usage.html:20
 msgid ""
-"<h2>What are daily users?</h2> <p> Add-ons downloaded from this site check "
-"for updates once per day. The total number of these update pings is known as"
-" Active Daily Users. Daily users can be broken down by add-on version, "
-"operating system, add-on status, application, and locale. </p>"
+"<h2>What are daily users?</h2> <p> Add-ons downloaded from this site check for updates once per day. The total number of these update pings is known as Active Daily Users. Daily users can be broken"
+" down by add-on version, operating system, add-on status, application, and locale. </p>"
 msgstr ""
-"<h2>Que sont les utilisateurs journaliers ?</h2> <p> Les modules "
-"téléchargés depuis ce site vérifient l'existence de mises à jour une "
-"fois par jour. Le nombre total de ces notifications est utilisé pour former"
-" ce qui est appelé Utilisateurs journaliers actifs. Ces utilisateurs "
-"peuvent être classifiés suivant la version du module, le système "
-"d'exploitation, l'état du module, l'application et la langue.</p>"
+"<h2>Que sont les utilisateurs journaliers ?</h2> <p> Les modules téléchargés depuis ce site vérifient l'existence de mises à jour une fois par jour. Le nombre total de ces notifications est "
+"utilisé pour former ce qui est appelé Utilisateurs journaliers actifs. Ces utilisateurs peuvent être classifiés suivant la version du module, le système d'exploitation, l'état du module, "
+"l'application et la langue.</p>"
 
 #: src/olympia/stats/templates/stats/reports/users_created.html:3
 msgid "User Signups by Date"
@@ -14893,46 +11654,27 @@ msgstr "Connexions de l'utilisateur par date"
 msgid "Application versions by Date"
 msgstr "Versions de l'application par date"
 
-# {0} is a number
-#: src/olympia/tags/templates/tags/top_cloud.html:4
-msgid "Top {0} Tags"
-msgstr "Les {0} étiquettes les plus populaires"
-
-#. {0} is the current application name
-#: src/olympia/tags/templates/tags/top_cloud.html:14
-msgid "{0} Top Tags"
-msgstr "Étiquettes populaires {0}"
-
-#: src/olympia/templates/amo_footer.html:6
-#: src/olympia/templates/includes/lang_switcher.html:2
+#: src/olympia/templates/amo_footer.html:6 src/olympia/templates/includes/lang_switcher.html:2
 msgid "Other languages"
 msgstr "Autres langues"
 
-#: src/olympia/templates/base.html:9 src/olympia/templates/impala/base.html:9
-#: src/olympia/templates/mobile/base_addons.html:9
+#: src/olympia/templates/base.html:9 src/olympia/templates/impala/base.html:9 src/olympia/templates/mobile/base_addons.html:9
 msgid "Mozilla Add-ons"
 msgstr "Modules Mozilla"
 
-#: src/olympia/templates/base.html:91
-#: src/olympia/templates/impala/base.html:81
+#: src/olympia/templates/base.html:89 src/olympia/templates/impala/base.html:78
 msgid "Find add-ons for other applications"
 msgstr "Trouver des modules pour d'autres logiciels"
 
-#: src/olympia/templates/base.html:92
-#: src/olympia/templates/impala/base.html:81
+#: src/olympia/templates/base.html:90 src/olympia/templates/impala/base.html:78
 msgid "Other Applications"
 msgstr "Autres applications"
 
-#: src/olympia/templates/base.html:141
-#: src/olympia/templates/impala/base.html:194
-msgid ""
-"To create your own collections, you must have a Mozilla Add-ons account."
-msgstr ""
-"Pour créer vos propres collections, vous devez avoir un compte Mozilla Add-"
-"ons."
+#: src/olympia/templates/base.html:141 src/olympia/templates/impala/base.html:194
+msgid "To create your own collections, you must have a Mozilla Add-ons account."
+msgstr "Pour créer vos propres collections, vous devez avoir un compte Mozilla Add-ons."
 
-#: src/olympia/templates/base.html:168
-#: src/olympia/templates/impala/base.html:215
+#: src/olympia/templates/base.html:168 src/olympia/templates/impala/base.html:215
 msgid "Footer logo"
 msgstr "Logo de bas de page"
 
@@ -14956,14 +11698,12 @@ msgstr "Statut du site"
 msgid "get to know <b>add-ons</b>"
 msgstr "découvrez les <b>modules</b>"
 
-#: src/olympia/templates/footer.html:4
-#: src/olympia/templates/menu_links.html:20
+#: src/olympia/templates/footer.html:4 src/olympia/templates/menu_links.html:20
 msgid "About"
 msgstr "À propos"
 
 # Link text to the AMO blog.
-#: src/olympia/templates/footer.html:5
-#: src/olympia/templates/menu_links.html:32
+#: src/olympia/templates/footer.html:5 src/olympia/templates/menu_links.html:32
 msgid "Blog"
 msgstr "Blog"
 
@@ -15040,9 +11780,7 @@ msgstr "Légal"
 msgid "Contact Us"
 msgstr "Nous contacter"
 
-#: src/olympia/templates/user_login.html:22
-#: src/olympia/users/templates/users/edit.html:31
-#: src/olympia/users/templates/users/includes/navigation.html:12
+#: src/olympia/templates/user_login.html:22 src/olympia/users/templates/users/edit.html:31 src/olympia/users/templates/users/includes/navigation.html:12
 msgid "My Account"
 msgstr "Mon compte"
 
@@ -15050,56 +11788,40 @@ msgstr "Mon compte"
 msgid "Welcome, {0}"
 msgstr "Bienvenue, {0}"
 
-#: src/olympia/templates/user_login.html:41
-#: src/olympia/templates/impala/user_login.html:20
+#: src/olympia/templates/user_login.html:41 src/olympia/templates/impala/user_login.html:20
 #, python-format
 msgid "<a href=\"%(reg)s\">Register</a> or <a href=\"%(login)s\">Log in</a>"
 msgstr "<a href=\"%(reg)s\">S'inscrire</a> ou <a href=\"%(login)s\">Se connecter</a>"
 
-#: src/olympia/templates/impala/base.html:126
+#: src/olympia/templates/impala/base.html:123
 #, python-format
-msgid ""
-"To try the thousands of add-ons available here, download <a "
-"href=\"%(url)s\">Mozilla Firefox</a>, a fast, free way to surf the Web!"
-msgstr ""
-"Pour essayer les milliers de modules disponibles ici, téléchargez <a "
-"href=\"%(url)s\">Mozilla Firefox</a>, une manière rapide et libre de surfer "
-"sur le Web !"
+msgid "To try the thousands of add-ons available here, download <a href=\"%(url)s\">Mozilla Firefox</a>, a fast, free way to surf the Web!"
+msgstr "Pour essayer les milliers de modules disponibles ici, téléchargez <a href=\"%(url)s\">Mozilla Firefox</a>, une manière rapide et libre de surfer sur le Web !"
 
-#: src/olympia/templates/impala/base.html:138
+#: src/olympia/templates/impala/base.html:135
 #, python-format
-msgid ""
-"Add-ons is switching to Firefox Accounts for login. <a href=\"%(url)s\" "
-"class=\"fxa-login\">Sign in now to transfer your account.</a>"
-msgstr ""
-"Les modules vont utiliser les comptes Firefox pour la connexion. <a "
-"href=\"%(url)s\" class=\"fxa-login\">Connectez-vous afin de transférer votre"
-" compte.</a>"
+msgid "Add-ons is switching to Firefox Accounts for login. <a href=\"%(url)s\" class=\"fxa-login\">Sign in now to transfer your account.</a>"
+msgstr "Les modules vont utiliser les comptes Firefox pour la connexion. <a href=\"%(url)s\" class=\"fxa-login\">Connectez-vous afin de transférer votre compte.</a>"
 
 #. {0} is an application, such as Firefox.
-#: src/olympia/templates/impala/base.html:148
+#: src/olympia/templates/impala/base.html:145
 msgid "Welcome to {0} Add-ons."
 msgstr "Bienvenue sur {0} Add-ons."
 
-#: src/olympia/templates/impala/base.html:151
-msgid ""
-"Choose from thousands of extra features and styles to make Firefox your own."
-msgstr ""
-"Choisissez parmi les milliers de fonctionnalités et styles supplémentaires "
-"pour personnaliser votre Firefox."
+#: src/olympia/templates/impala/base.html:148
+msgid "Choose from thousands of extra features and styles to make Firefox your own."
+msgstr "Choisissez parmi les milliers de fonctionnalités et styles supplémentaires pour personnaliser votre Firefox."
 
-#: src/olympia/templates/impala/base.html:156
+#: src/olympia/templates/impala/base.html:153
 #, python-format
 msgid "Add extra features and styles to make %(app)s your own."
-msgstr ""
-"Ajoutez fonctionnalités et styles supplémentaires pour personnaliser votre "
-"%(app)s."
+msgstr "Ajoutez fonctionnalités et styles supplémentaires pour personnaliser votre %(app)s."
 
-#: src/olympia/templates/impala/base.html:164
+#: src/olympia/templates/impala/base.html:161
 msgid "On the go?"
 msgstr "Sur le pouce ?"
 
-#: src/olympia/templates/impala/base.html:166
+#: src/olympia/templates/impala/base.html:163
 msgid "Check out our <a class=\"mobile-link\" href=\"#\">Mobile Add-ons site</a>."
 msgstr "Allez voir notre <a class=\"mobile-link\" href=\"#\">site Modules Mobile</a>."
 
@@ -15107,8 +11829,7 @@ msgstr "Allez voir notre <a class=\"mobile-link\" href=\"#\">site Modules Mobile
 msgid "Android Add-ons"
 msgstr "Modules Android"
 
-#: src/olympia/templates/includes/forms.html:2
-#: src/olympia/templates/includes/forms.html:6
+#: src/olympia/templates/includes/forms.html:2 src/olympia/templates/includes/forms.html:6
 msgid "required"
 msgstr "requis"
 
@@ -15153,15 +11874,11 @@ msgstr "Visitez Mozilla"
 msgid "menu"
 msgstr "menu"
 
-#: src/olympia/templates/mobile/header_auth.html:7
-#: src/olympia/users/templates/users/register.html:41
-#: src/olympia/users/templates/users/register.html:89
+#: src/olympia/templates/mobile/header_auth.html:7 src/olympia/users/templates/users/register.html:41 src/olympia/users/templates/users/register.html:89
 msgid "Register"
 msgstr "Inscription"
 
-#: src/olympia/templates/mobile/header_auth.html:8
-#: src/olympia/users/templates/users/login_form.html:41
-#: src/olympia/users/templates/users/pwreset_complete.html:15
+#: src/olympia/templates/mobile/header_auth.html:8 src/olympia/users/templates/users/login_form.html:41 src/olympia/users/templates/users/pwreset_complete.html:15
 #: src/olympia/users/templates/users/mobile/login.html:56
 msgid "Log in"
 msgstr "Connexion"
@@ -15172,8 +11889,7 @@ msgstr "Connexion"
 msgid "Localize for: <a id=\"change-locale\" href=\"#\">%(dl)s</a>"
 msgstr "Traduire en : <a id=\"change-locale\" href=\"#\">%(dl)s</a>"
 
-#: src/olympia/translations/templates/translations/trans-menu.html:16
-#: src/olympia/translations/templates/translations/trans-menu.html:29
+#: src/olympia/translations/templates/translations/trans-menu.html:16 src/olympia/translations/templates/translations/trans-menu.html:29
 #, python-format
 msgid "%(title)s <em>&middot; %(lang)s</em>"
 msgstr "%(title)s <em>&middot; %(lang)s</em>"
@@ -15188,12 +11904,8 @@ msgstr "Nouvelles locales"
 
 #. {0} is a language name, like 'French'
 #: src/olympia/translations/templates/translations/trans-menu.html:42
-msgid ""
-"You have unsaved changes in the <b>{0}</b> locale. Would you like to save "
-"your changes before switching locales?"
-msgstr ""
-"Vous avez des changements non sauvegardés dans la langue <b>{0}</b>. Voulez-"
-"vous les sauvegarder avant de changer de locale ?"
+msgid "You have unsaved changes in the <b>{0}</b> locale. Would you like to save your changes before switching locales?"
+msgstr "Vous avez des changements non sauvegardés dans la langue <b>{0}</b>. Voulez-vous les sauvegarder avant de changer de locale ?"
 
 #: src/olympia/translations/templates/translations/trans-menu.html:49
 msgid "Discard Changes"
@@ -15201,12 +11913,8 @@ msgstr "Annuler les changements"
 
 #. {0} is a language name, like 'French'
 #: src/olympia/translations/templates/translations/trans-menu.html:56
-msgid ""
-"Are you sure you want to remove all <b>{0}</b> translations? This cannot be "
-"undone."
-msgstr ""
-"Êtes-vous certain de vouloir retirer toutes les traductions de <b>{0}</b> ? "
-"Cette opération ne pourra pas être annulée."
+msgid "Are you sure you want to remove all <b>{0}</b> translations? This cannot be undone."
+msgstr "Êtes-vous certain de vouloir retirer toutes les traductions de <b>{0}</b> ? Cette opération ne pourra pas être annulée."
 
 #: src/olympia/translations/templates/translations/trans-menu.html:61
 msgid "Delete Locale"
@@ -15227,25 +11935,16 @@ msgstr "Ce mot de passe n'est pas autorisé."
 
 #: src/olympia/users/forms.py:90
 #, python-format
-msgid ""
-"As part of our new password policy, your password must be %s characters or "
-"more. Please update your password by <a href=\"%s\">issuing a password "
-"reset</a>."
+msgid "As part of our new password policy, your password must be %s characters or more. Please update your password by <a href=\"%s\">issuing a password reset</a>."
 msgstr ""
-"Dans le cadre de nos nouvelles mesures sur les mots de passe, votre mot de "
-"passe doit contenir au moins %s caractères. Veuillez mettre à jour votre mot"
-" de passe en <a href=\"%s\">réinitialisant votre mot de passe</a>."
+"Dans le cadre de nos nouvelles mesures sur les mots de passe, votre mot de passe doit contenir au moins %s caractères. Veuillez mettre à jour votre mot de passe en <a href=\"%s\">réinitialisant "
+"votre mot de passe</a>."
 
 #: src/olympia/users/forms.py:115
-msgid ""
-"You must recover your password through Firefox Accounts. Try logging in "
-"instead."
-msgstr ""
-"Vous devez récupérer votre mot de passe via Firefox Accounts. Essayez de "
-"vous connecter."
+msgid "You must recover your password through Firefox Accounts. Try logging in instead."
+msgstr "Vous devez récupérer votre mot de passe via Firefox Accounts. Essayez de vous connecter."
 
-#: src/olympia/users/forms.py:206
-#: src/olympia/users/templates/users/pwreset_confirm.html:24
+#: src/olympia/users/forms.py:206 src/olympia/users/templates/users/pwreset_confirm.html:24
 msgid "New password"
 msgstr "Nouveau mot de passe"
 
@@ -15258,12 +11957,8 @@ msgid "Usernames cannot contain only digits."
 msgstr "Les noms d'utilisateur ne peuvent pas contenir que des chiffres."
 
 #: src/olympia/users/forms.py:274
-msgid ""
-"Enter a valid username consisting of letters, numbers, underscores or "
-"hyphens."
-msgstr ""
-"Entrez un nom d'utilisateur valide, composé de lettres, nombres, "
-"soulignements ou traits d'union."
+msgid "Enter a valid username consisting of letters, numbers, underscores or hyphens."
+msgstr "Entrez un nom d'utilisateur valide, composé de lettres, nombres, soulignements ou traits d'union."
 
 #: src/olympia/users/forms.py:277
 msgid "This username cannot be used."
@@ -15273,38 +11968,25 @@ msgstr "Ce nom d'utilisateur ne peut pas être utilisé."
 msgid "This username is already in use."
 msgstr "Ce nom d'utilisateur est déjà utilisé."
 
-#: src/olympia/users/forms.py:296
-#: src/olympia/users/templates/users/edit.html:107
+#: src/olympia/users/forms.py:296 src/olympia/users/templates/users/edit.html:107
 msgid "Display Name"
 msgstr "Nom affiché"
 
-#: src/olympia/users/forms.py:298
-#: src/olympia/users/templates/users/edit.html:112
-#: src/olympia/users/templates/users/vcard.html:10
+#: src/olympia/users/forms.py:298 src/olympia/users/templates/users/edit.html:112 src/olympia/users/templates/users/vcard.html:10
 msgid "Location"
 msgstr "Pays"
 
-#: src/olympia/users/forms.py:300
-#: src/olympia/users/templates/users/edit.html:117
-#: src/olympia/users/templates/users/vcard.html:16
+#: src/olympia/users/forms.py:300 src/olympia/users/templates/users/edit.html:117 src/olympia/users/templates/users/vcard.html:16
 msgid "Occupation"
 msgstr "Profession"
 
 #: src/olympia/users/forms.py:329
-msgid ""
-"This URL has an invalid format. Valid URLs look like "
-"http://example.com/my_page."
-msgstr ""
-"Cette URL a un format non valide. Une URL valide ressemble à ceci : "
-"http://exemple.com/ma_page."
+msgid "This URL has an invalid format. Valid URLs look like http://example.com/my_page."
+msgstr "Cette URL a un format non valide. Une URL valide ressemble à ceci : http://exemple.com/ma_page."
 
 #: src/olympia/users/forms.py:337
-msgid ""
-"Please use an email address from a different provider to complete your "
-"registration."
-msgstr ""
-"Merci d'utiliser une adresse courriel d'un autre fournisseur pour terminer "
-"votre inscription."
+msgid "Please use an email address from a different provider to complete your registration."
+msgstr "Merci d'utiliser une adresse courriel d'un autre fournisseur pour terminer votre inscription."
 
 #: src/olympia/users/forms.py:345
 msgid "This display name cannot be used."
@@ -15314,21 +11996,17 @@ msgstr "Ce nom public ne peut pas être utilisé."
 msgid "The passwords did not match."
 msgstr "Les mots de passe ne correspondent pas."
 
-#: src/olympia/users/forms.py:377
-#: src/olympia/users/templates/users/edit.html:128
+#: src/olympia/users/forms.py:377 src/olympia/users/templates/users/edit.html:128
 msgid "Profile Photo"
 msgstr "Photo de profil"
 
-#: src/olympia/users/forms.py:385
-#: src/olympia/users/templates/users/edit.html:142
+#: src/olympia/users/forms.py:385 src/olympia/users/templates/users/edit.html:142
 msgid "Default locale"
 msgstr "Locale par défaut"
 
 #: src/olympia/users/forms.py:412
 msgid "Firefox Accounts users cannot currently change their email address."
-msgstr ""
-"Les utilisateurs de comptes Firefox ne peuvent pas actuellement modifier "
-"leur adresse électronique."
+msgstr "Les utilisateurs de comptes Firefox ne peuvent pas actuellement modifier leur adresse électronique."
 
 #: src/olympia/users/forms.py:446
 msgid "Wrong password entered!"
@@ -15339,12 +12017,8 @@ msgid "Email cannot be changed."
 msgstr "L'adresse électronique ne peut pas être modifiée."
 
 #: src/olympia/users/forms.py:541
-msgid ""
-"To anonymize, enter a reason for the change but do not change any other "
-"field."
-msgstr ""
-"Pour anonymiser, indiquez une raison pour le changement mais ne faites "
-"aucune modification aux autres champs."
+msgid "To anonymize, enter a reason for the change but do not change any other field."
+msgstr "Pour anonymiser, indiquez une raison pour le changement mais ne faites aucune modification aux autres champs."
 
 #: src/olympia/users/forms.py:587
 msgid "Please enter at least one name to blacklist."
@@ -15373,19 +12047,19 @@ msgstr "Pas d'utilisateur ayant cette adresse courriel."
 
 #. L10n: {id} will be something like "13ad6a", just a random number
 #. to differentiate this user from other anonymous users.
-#: src/olympia/users/models.py:353
+#: src/olympia/users/models.py:362
 msgid "Anonymous user {id}"
 msgstr "Utilisateur anonyme {id}"
 
-#: src/olympia/users/models.py:410
+#: src/olympia/users/models.py:419
 msgid "Your account has been restricted"
 msgstr "Votre compte a été restreint"
 
-#: src/olympia/users/models.py:480
+#: src/olympia/users/models.py:489
 msgid "Please confirm your email address"
 msgstr "Veuillez confirmer votre adresse électronique"
 
-#: src/olympia/users/models.py:506
+#: src/olympia/users/models.py:515
 msgid "My Mobile Add-ons"
 msgstr "Mes modules mobiles"
 
@@ -15411,9 +12085,7 @@ msgstr "la compatibilité de mon module a été mise à jour avec succès"
 
 #: src/olympia/users/notifications.py:57
 msgid "my sdk-based add-on is upgraded successfully"
-msgstr ""
-"la compatibilité de mon module utilisant le sdk a été mise à jour avec "
-"succès"
+msgstr "la compatibilité de mon module utilisant le sdk a été mise à jour avec succès"
 
 #: src/olympia/users/notifications.py:66
 msgid "someone writes a review of my add-on"
@@ -15433,9 +12105,7 @@ msgstr "la compatibilité de mon module n'a pas pu être mise à jour"
 
 #: src/olympia/users/notifications.py:99
 msgid "my sdk-based add-on cannot be upgraded"
-msgstr ""
-"la compatibilité de mon module utilisant le sdk n'a pas pu être mise à "
-"jour"
+msgstr "la compatibilité de mon module utilisant le sdk n'a pas pu être mise à jour"
 
 #: src/olympia/users/notifications.py:108
 msgid "my add-on is reviewed by an editor"
@@ -15451,21 +12121,15 @@ msgstr "mon application est vérifié par un éditeur"
 
 #: src/olympia/users/notifications.py:132
 msgid "Mozilla needs to contact me about my individual app"
-msgstr ""
-"Mozilla a besoin de me contacter à propos de mon application individuelle"
+msgstr "Mozilla a besoin de me contacter à propos de mon application individuelle"
 
 #: src/olympia/users/notifications.py:139
-msgid ""
-"Mozilla wants to contact me about relevant App Developer news and surveys"
-msgstr ""
-"Mozilla veut me contacter à propos de nouvelles et sondages liés pour les "
-"développeurs d'application"
+msgid "Mozilla wants to contact me about relevant App Developer news and surveys"
+msgstr "Mozilla veut me contacter à propos de nouvelles et sondages liés pour les développeurs d'application"
 
 #: src/olympia/users/notifications.py:150
 msgid "Mozilla wants to contact me about new regions added to the Marketplace"
-msgstr ""
-"Mozilla veut me contacter à propos de nouvelles régions prises en charge par"
-" le Marketplace"
+msgstr "Mozilla veut me contacter à propos de nouvelles régions prises en charge par le Marketplace"
 
 #: src/olympia/users/notifications.py:158
 msgid "User Notifications"
@@ -15488,14 +12152,10 @@ msgid "Successfully verified!"
 msgstr "Vérification réussie !"
 
 #: src/olympia/users/views.py:132
-msgid ""
-"An email has been sent to your address to confirm your account. Before you "
-"can log in, you have to activate your account by clicking on the link "
-"provided in this email."
+msgid "An email has been sent to your address to confirm your account. Before you can log in, you have to activate your account by clicking on the link provided in this email."
 msgstr ""
-"Un courrier électronique a été envoyé à votre adresse pour confirmer votre "
-"compte. Avant de pouvoir vous connecter, vous devez activer votre compte en "
-"cliquant sur le lien fourni dans ce courrier électronique."
+"Un courrier électronique a été envoyé à votre adresse pour confirmer votre compte. Avant de pouvoir vous connecter, vous devez activer votre compte en cliquant sur le lien fourni dans ce courrier "
+"électronique."
 
 #: src/olympia/users/views.py:136 src/olympia/users/views.py:619
 msgid "Confirmation Email Sent"
@@ -15519,14 +12179,11 @@ msgstr "Courriel de confirmation envoyé"
 
 #: src/olympia/users/views.py:197
 msgid ""
-"An email has been sent to {0} to confirm your new email address. For the "
-"change to take effect, you need to click on the link provided in this email."
-" Until then, you can keep logging in with your current email address."
+"An email has been sent to {0} to confirm your new email address. For the change to take effect, you need to click on the link provided in this email. Until then, you can keep logging in with your "
+"current email address."
 msgstr ""
-"Un courriel a été envoyé à {0} pour confirmer votre nouvelle adresse. Pour "
-"que le changement soit effectif, vous devez cliquer sur le lien fournit dans"
-" le courriel. En attendant, vous pouvez toujours vous connecter avec "
-"l'adresse courriel actuelle."
+"Un courriel a été envoyé à {0} pour confirmer votre nouvelle adresse. Pour que le changement soit effectif, vous devez cliquer sur le lien fournit dans le courriel. En attendant, vous pouvez "
+"toujours vous connecter avec l'adresse courriel actuelle."
 
 #: src/olympia/users/views.py:210
 #, python-format
@@ -15538,18 +12195,12 @@ msgid "Errors Found"
 msgstr "Erreurs détectées"
 
 #: src/olympia/users/views.py:225
-msgid ""
-"There were errors in the changes you made. Please correct them and resubmit."
-msgstr ""
-"Les changements que vous avez effectués contenaient des erreurs. Veuillez "
-"les corriger avant d'envoyer le formulaire à nouveau."
+msgid "There were errors in the changes you made. Please correct them and resubmit."
+msgstr "Les changements que vous avez effectués contenaient des erreurs. Veuillez les corriger avant d'envoyer le formulaire à nouveau."
 
 #: src/olympia/users/views.py:273
-msgid ""
-"We're sorry, but you are not eligible to request a t-shirt at this time."
-msgstr ""
-"Nous sommes désolés mais vous n'avez, pour le moment, pas le droit de "
-"demander un t-shirt."
+msgid "We're sorry, but you are not eligible to request a t-shirt at this time."
+msgstr "Nous sommes désolés mais vous n'avez, pour le moment, pas le droit de demander un t-shirt."
 
 #: src/olympia/users/views.py:329
 msgid "Your email address was changed successfully"
@@ -15564,25 +12215,17 @@ msgid "Wrong email address or password!"
 msgstr "Courriel ou mot de passe erroné !"
 
 #: src/olympia/users/views.py:434
-msgid ""
-"A link to activate your user account was sent by email to your address {0}. "
-"You have to click it before you can log in."
-msgstr ""
-"Un lien pour activer votre compte utilisateur a été envoyé par courriel à "
-"l'adresse {0}. Vous devez cliquer dessus avant de pouvoir vous connecter."
+msgid "A link to activate your user account was sent by email to your address {0}. You have to click it before you can log in."
+msgstr "Un lien pour activer votre compte utilisateur a été envoyé par courriel à l'adresse {0}. Vous devez cliquer dessus avant de pouvoir vous connecter."
 
 #: src/olympia/users/views.py:439
 #, python-format
 msgid ""
-"If you did not receive the confirmation email, make sure your email service "
-"did not mark it as \"junk mail\" or \"spam\". If you need to, you can have "
-"us <a href=\"%s\">resend the confirmation message</a> to your email address "
-"mentioned above."
+"If you did not receive the confirmation email, make sure your email service did not mark it as \"junk mail\" or \"spam\". If you need to, you can have us <a href=\"%s\">resend the confirmation "
+"message</a> to your email address mentioned above."
 msgstr ""
-"Si vous n'avez pas reçu le courriel de confirmation, assez-vous que votre "
-"service de courriel ne l'a pas classé en « pourriel ». Si besoin, il est "
-"possible de <a href=\"%s\">ré-envoyer le message de confirmation</a> à "
-"l'adresse courriel mentionnée précédemment."
+"Si vous n'avez pas reçu le courriel de confirmation, assez-vous que votre service de courriel ne l'a pas classé en « pourriel ». Si besoin, il est possible de <a href=\"%s\">ré-envoyer le message "
+"de confirmation</a> à l'adresse courriel mentionnée précédemment."
 
 #: src/olympia/users/views.py:444
 msgid "Activation Email Sent"
@@ -15602,14 +12245,8 @@ msgstr "Félicitations ! Votre compte utilisateur a bien été créé."
 
 # %1 is the user's email address
 #: src/olympia/users/views.py:615
-msgid ""
-"An email has been sent to your address {0} to confirm your account. Before "
-"you can log in, you have to activate your account by clicking on the link "
-"provided in this email."
-msgstr ""
-"Un courriel a été envoyé à votre adresse {0} afin de confirmer votre compte."
-" Avant de pouvoir vous connecter, vous devez activer votre compte en "
-"cliquant sur le lien fourni dans ce message."
+msgid "An email has been sent to your address {0} to confirm your account. Before you can log in, you have to activate your account by clicking on the link provided in this email."
+msgstr "Un courriel a été envoyé à votre adresse {0} afin de confirmer votre compte. Avant de pouvoir vous connecter, vous devez activer votre compte en cliquant sur le lien fourni dans ce message."
 
 #: src/olympia/users/views.py:639
 msgid "There are errors in this form"
@@ -15627,32 +12264,22 @@ msgstr "Utilisateur signalé."
 msgid "new"
 msgstr "nouveau"
 
-#: src/olympia/users/templates/users/delete.html:4
-#: src/olympia/users/templates/users/delete.html:10
+#: src/olympia/users/templates/users/delete.html:4 src/olympia/users/templates/users/delete.html:10
 msgid "Delete User Account"
 msgstr "Supprimer le compte utilisateur"
 
 #: src/olympia/users/templates/users/delete.html:14
 #, python-format
 msgid ""
-"You cannot delete your account if you are listed as an <a href=\"%(link)s\">"
-" author of any add-ons</a>. To delete your account, please have another "
-"person in your development group delete you from the list of authors for "
-"your add-ons. Afterwards you will be able to delete your account here."
+"You cannot delete your account if you are listed as an <a href=\"%(link)s\"> author of any add-ons</a>. To delete your account, please have another person in your development group delete you from "
+"the list of authors for your add-ons. Afterwards you will be able to delete your account here."
 msgstr ""
-"Vous ne pouvez pas supprimer votre compte si vous êtes listés en tant <a "
-"href=\"%(link)s\">qu'auteur de l'un de ces modules</a>. Pour supprimer votre"
-" compte, faites en sorte qu'une autre personne de l'équipe de développement "
-"de ces modules vous retire de la liste des auteurs. Une fois ceci réalisé, "
-"vous pourrez supprimer votre compte."
+"Vous ne pouvez pas supprimer votre compte si vous êtes listés en tant <a href=\"%(link)s\">qu'auteur de l'un de ces modules</a>. Pour supprimer votre compte, faites en sorte qu'une autre personne "
+"de l'équipe de développement de ces modules vous retire de la liste des auteurs. Une fois ceci réalisé, vous pourrez supprimer votre compte."
 
 #: src/olympia/users/templates/users/delete.html:29
-msgid ""
-"By clicking \"delete\" your account is going to be <strong>permanently "
-"removed</strong>. That means:"
-msgstr ""
-"En cliquant sur «&nbsp;supprimer&nbsp;», votre compte sera <strong>supprimé "
-"de façon permanente</strong>. Cela signifie que&nbsp;:"
+msgid "By clicking \"delete\" your account is going to be <strong>permanently removed</strong>. That means:"
+msgstr "En cliquant sur «&nbsp;supprimer&nbsp;», votre compte sera <strong>supprimé de façon permanente</strong>. Cela signifie que&nbsp;:"
 
 #: src/olympia/users/templates/users/delete.html:35
 #, python-format
@@ -15660,12 +12287,8 @@ msgid "You will not be able to log into %(site)s anymore."
 msgstr "Vous ne pourrez plus vous connecter sur %(site)s."
 
 #: src/olympia/users/templates/users/delete.html:40
-msgid ""
-"Your reviews and ratings will not be deleted, but they will no longer be "
-"associated with you."
-msgstr ""
-"Vos revues et vos notes ne seront pas supprimées mais vous n'y serez plus "
-"associé-e."
+msgid "Your reviews and ratings will not be deleted, but they will no longer be associated with you."
+msgstr "Vos revues et vos notes ne seront pas supprimées mais vous n'y serez plus associé-e."
 
 #: src/olympia/users/templates/users/delete.html:46
 msgid "Confirm account deletion"
@@ -15679,8 +12302,7 @@ msgstr "Je comprends que cette étape ne peut pas être annulée."
 msgid "Delete my user account now"
 msgstr "Supprimer mon compte utilisateur maintenant"
 
-#: src/olympia/users/templates/users/delete_photo.html:3
-#: src/olympia/users/templates/users/delete_photo.html:9
+#: src/olympia/users/templates/users/delete_photo.html:3 src/olympia/users/templates/users/delete_photo.html:9
 msgid "Delete User Photo"
 msgstr "Supprimer la photo de l'utilisateur"
 
@@ -15693,27 +12315,18 @@ msgid "Please set your display name"
 msgstr "Veuillez indiquer votre nom d'utilisateur"
 
 #: src/olympia/users/templates/users/edit.html:21
-msgid ""
-"Please set your display name or username to complete the registration "
-"process."
-msgstr ""
-"Veuillez indiquer votre nom ou un nom d'utilisateur pour terminer le "
-"processus d'inscription."
+msgid "Please set your display name or username to complete the registration process."
+msgstr "Veuillez indiquer votre nom ou un nom d'utilisateur pour terminer le processus d'inscription."
 
 #: src/olympia/users/templates/users/edit.html:33
 msgid "Manage basic account information, such as username and email address."
-msgstr ""
-"Gérer des informations de base du compte, comme le nom d'utilisateur et "
-"l'adresse courriel."
+msgstr "Gérer des informations de base du compte, comme le nom d'utilisateur et l'adresse courriel."
 
-#: src/olympia/users/templates/users/edit.html:39
-#: src/olympia/users/templates/users/register.html:47
+#: src/olympia/users/templates/users/edit.html:39 src/olympia/users/templates/users/register.html:47
 msgid "Username"
 msgstr "Nom d'utilisateur"
 
-#: src/olympia/users/templates/users/edit.html:45
-#: src/olympia/users/templates/users/pwreset_request.html:21
-#: src/olympia/users/templates/users/register.html:62
+#: src/olympia/users/templates/users/edit.html:45 src/olympia/users/templates/users/pwreset_request.html:21 src/olympia/users/templates/users/register.html:62
 msgid "Email Address"
 msgstr "Adresse électronique"
 
@@ -15725,21 +12338,15 @@ msgstr "Gérer le compte Firefox…"
 msgid "Change Password"
 msgstr "Changer mon mot de passe"
 
-#: src/olympia/users/templates/users/edit.html:68
-#: src/olympia/users/templates/users/login_form.html:22
-#: src/olympia/users/templates/users/register.html:67
+#: src/olympia/users/templates/users/edit.html:68 src/olympia/users/templates/users/login_form.html:22 src/olympia/users/templates/users/register.html:67
 #: src/olympia/users/templates/users/mobile/login.html:37
 msgid "Password"
 msgstr "Mot de passe"
 
 #: src/olympia/users/templates/users/edit.html:70
 #, python-format
-msgid ""
-"Change your password. If you forgot your password, you can <a "
-"href=\"%(reset_url)s\">use the reset form</a>."
-msgstr ""
-"Changer votre mot de passe. Si vous l'oubliez, vous pouvez <a "
-"href=\"%(reset_url)s\">utiliser le formulaire de remise à zéro</a>. "
+msgid "Change your password. If you forgot your password, you can <a href=\"%(reset_url)s\">use the reset form</a>."
+msgstr "Changer votre mot de passe. Si vous l'oubliez, vous pouvez <a href=\"%(reset_url)s\">utiliser le formulaire de remise à zéro</a>. "
 
 #: src/olympia/users/templates/users/edit.html:76
 msgid "Old Password"
@@ -15758,12 +12365,8 @@ msgid "Profile"
 msgstr "Profil"
 
 #: src/olympia/users/templates/users/edit.html:100
-msgid ""
-"Give us a bit more information about yourself. All these fields are "
-"optional, but they'll help other users get to know you better."
-msgstr ""
-"Dites-nous en plus à propos de vous. Tous les champs sont optionnels mais "
-"ils aideront les autres utilisateurs à mieux vous connaître."
+msgid "Give us a bit more information about yourself. All these fields are optional, but they'll help other users get to know you better."
+msgstr "Dites-nous en plus à propos de vous. Tous les champs sont optionnels mais ils aideront les autres utilisateurs à mieux vous connaître."
 
 #: src/olympia/users/templates/users/edit.html:124
 msgid "This URL will only be visible if you are a developer."
@@ -15778,20 +12381,12 @@ msgid "Delete current photo"
 msgstr "Supprimer la photo actuelle"
 
 #: src/olympia/users/templates/users/edit.html:144
-msgid ""
-"This is the default locale used to display information about you (like your "
-"description)."
-msgstr ""
-"Il s'agit de la locale (langue) par défaut utilisée pour afficher des "
-"informations sur vous (comme votre description)."
+msgid "This is the default locale used to display information about you (like your description)."
+msgstr "Il s'agit de la locale (langue) par défaut utilisée pour afficher des informations sur vous (comme votre description)."
 
 #: src/olympia/users/templates/users/edit.html:152
-msgid ""
-"Introduce yourself to the community, if you like! This text will appear "
-"publicly on your user info page."
-msgstr ""
-"Présentez-vous à la communauté, si vous le souhaitez ! Ce texte apparaitra "
-"publiquement sur votre page."
+msgid "Introduce yourself to the community, if you like! This text will appear publicly on your user info page."
+msgstr "Présentez-vous à la communauté, si vous le souhaitez ! Ce texte apparaitra publiquement sur votre page."
 
 #: src/olympia/users/templates/users/edit.html:161
 msgid "Allowed HTML: {0}. Links are forbidden."
@@ -15818,21 +12413,12 @@ msgid "Notifications"
 msgstr "Notifications"
 
 #: src/olympia/users/templates/users/edit.html:195
-msgid ""
-"From time to time, Mozilla may send you email about upcoming releases and "
-"add-on events. Please select the topics you are interested in."
-msgstr ""
-"De temps en temps, Mozilla peut vous envoyer un courriel à propos des "
-"sorties à venir et des événements sur les modules. Merci d'indiquer les "
-"sujets qui vous intéressent."
+msgid "From time to time, Mozilla may send you email about upcoming releases and add-on events. Please select the topics you are interested in."
+msgstr "De temps en temps, Mozilla peut vous envoyer un courriel à propos des sorties à venir et des événements sur les modules. Merci d'indiquer les sujets qui vous intéressent."
 
 #: src/olympia/users/templates/users/edit.html:205
-msgid ""
-"Mozilla reserves the right to contact you individually about specific "
-"concerns with your hosted add-ons."
-msgstr ""
-"Mozilla se réserve le droit de vous contacter personnellement pour des "
-"problèmes particuliers liés à vos modules hébergés."
+msgid "Mozilla reserves the right to contact you individually about specific concerns with your hosted add-ons."
+msgstr "Mozilla se réserve le droit de vous contacter personnellement pour des problèmes particuliers liés à vos modules hébergés."
 
 #: src/olympia/users/templates/users/edit.html:215
 msgid "Admin"
@@ -15854,81 +12440,60 @@ msgstr "aucun"
 msgid "all"
 msgstr "tous"
 
-#: src/olympia/users/templates/users/fxa_migration.html:3
-#: src/olympia/users/templates/users/fxa_migration.html:11
-#: src/olympia/users/templates/users/mobile/fxa_migration.html:3
+#: src/olympia/users/templates/users/fxa_migration.html:3 src/olympia/users/templates/users/fxa_migration.html:11 src/olympia/users/templates/users/mobile/fxa_migration.html:3
 #: src/olympia/users/templates/users/mobile/fxa_migration.html:8
 msgid "Migrate to Firefox Accounts"
 msgstr "Migrer vers Firefox Accounts"
 
 #: src/olympia/users/templates/users/fxa_migration_prompt_content.html:3
-msgid ""
-"Mozilla Add-ons has transitioned to Firefox Accounts for login. Continue to "
-"complete the simple upgrade process."
-msgstr ""
-"Le site de modules Mozilla utilise désormais Firefox Accounts pour la "
-"connexion. Poursuivez pour terminer le processus de mise à jour."
+msgid "Mozilla Add-ons has transitioned to Firefox Accounts for login. Continue to complete the simple upgrade process."
+msgstr "Le site de modules Mozilla utilise désormais Firefox Accounts pour la connexion. Poursuivez pour terminer le processus de mise à jour."
 
 #: src/olympia/users/templates/users/fxa_migration_prompt_content.html:14
 msgid "Skip"
 msgstr "Passer"
 
-#: src/olympia/users/templates/users/login.html:3
-#: src/olympia/users/templates/users/mobile/login.html:3
+#: src/olympia/users/templates/users/login.html:3 src/olympia/users/templates/users/mobile/login.html:3
 msgid "User Login"
 msgstr "Connexion utilisateur"
 
-#: src/olympia/users/templates/users/login.html:13
-#: src/olympia/users/templates/users/mobile/login.html:21
+#: src/olympia/users/templates/users/login.html:13 src/olympia/users/templates/users/mobile/login.html:21
 msgid "Enter your email"
 msgstr "Veuillez saisir votre adresse électronique"
 
-#: src/olympia/users/templates/users/login.html:15
-#: src/olympia/users/templates/users/mobile/login.html:23
+#: src/olympia/users/templates/users/login.html:15 src/olympia/users/templates/users/mobile/login.html:23
 msgid "Log In"
 msgstr "Connexion"
 
-#: src/olympia/users/templates/users/login_form.html:17
-#: src/olympia/users/templates/users/mobile/login.html:32
+#: src/olympia/users/templates/users/login_form.html:17 src/olympia/users/templates/users/mobile/login.html:32
 msgid "Email address"
 msgstr "Adresse électronique"
 
-#: src/olympia/users/templates/users/login_form.html:30
-#: src/olympia/users/templates/users/mobile/login.html:44
+#: src/olympia/users/templates/users/login_form.html:30 src/olympia/users/templates/users/mobile/login.html:44
 msgid "Remember me on this device"
 msgstr "Se souvenir de moi sur ce périphérique"
 
 # This is a header for additional help options
-#: src/olympia/users/templates/users/login_help.html:3
-#: src/olympia/users/templates/users/mobile/login.html:63
+#: src/olympia/users/templates/users/login_help.html:3 src/olympia/users/templates/users/mobile/login.html:63
 msgid "Login Problems?"
 msgstr "Des problèmes de connexion ?"
 
-#: src/olympia/users/templates/users/login_help.html:5
-#: src/olympia/users/templates/users/mobile/login.html:65
+#: src/olympia/users/templates/users/login_help.html:5 src/olympia/users/templates/users/mobile/login.html:65
 msgid "I don't have an account."
 msgstr "Je n'ai pas de compte."
 
-#: src/olympia/users/templates/users/login_help.html:6
-#: src/olympia/users/templates/users/mobile/login.html:66
+#: src/olympia/users/templates/users/login_help.html:6 src/olympia/users/templates/users/mobile/login.html:66
 msgid "I forgot my password."
 msgstr "J'ai oublié mon mot de passe."
 
 #: src/olympia/users/templates/users/login_modal.html:3
 #, python-format
 msgid "You are now logged in as <strong>%(user_email)s</strong>!"
-msgstr ""
-"Vous êtes maintenant connecté en tant que <strong>%(user_email)s</strong>!"
+msgstr "Vous êtes maintenant connecté en tant que <strong>%(user_email)s</strong>!"
 
-#: src/olympia/users/templates/users/newpw_sent.html:3
-#: src/olympia/users/templates/users/newpw_sent.html:8
-#: src/olympia/users/templates/users/pwreset_complete.html:3
-#: src/olympia/users/templates/users/pwreset_confirm.html:4
-#: src/olympia/users/templates/users/pwreset_confirm.html:18
-#: src/olympia/users/templates/users/pwreset_request.html:4
-#: src/olympia/users/templates/users/pwreset_request.html:10
-#: src/olympia/users/templates/users/pwreset_sent.html:3
-#: src/olympia/users/templates/users/pwreset_sent.html:8
+#: src/olympia/users/templates/users/newpw_sent.html:3 src/olympia/users/templates/users/newpw_sent.html:8 src/olympia/users/templates/users/pwreset_complete.html:3
+#: src/olympia/users/templates/users/pwreset_confirm.html:4 src/olympia/users/templates/users/pwreset_confirm.html:18 src/olympia/users/templates/users/pwreset_request.html:4
+#: src/olympia/users/templates/users/pwreset_request.html:10 src/olympia/users/templates/users/pwreset_sent.html:3 src/olympia/users/templates/users/pwreset_sent.html:8
 msgid "Password Reset"
 msgstr "Réinitialisation du mot de passe"
 
@@ -15944,8 +12509,7 @@ msgstr "Édition du profil"
 msgid "Manage user"
 msgstr "Gérer l'utilisateur"
 
-#: src/olympia/users/templates/users/profile.html:18
-#: src/olympia/users/templates/users/report_abuse_full.html:9
+#: src/olympia/users/templates/users/profile.html:18 src/olympia/users/templates/users/report_abuse_full.html:9
 msgid "Report user"
 msgstr "Signaler un problème avec cet utilisateur"
 
@@ -16008,54 +12572,33 @@ msgstr "Bravo !"
 msgid "Password successfully reset."
 msgstr "Mot de passe réinitialisé avec succès."
 
-#: src/olympia/users/templates/users/pwreset_confirm.html:13
-#: src/olympia/users/templates/users/pwreset_confirm.html:46
+#: src/olympia/users/templates/users/pwreset_confirm.html:13 src/olympia/users/templates/users/pwreset_confirm.html:46
 msgid "Password reset unsuccessful"
 msgstr "Réinitialisation du mot de passe échouée"
 
 #: src/olympia/users/templates/users/pwreset_confirm.html:14
-msgid ""
-"You have migrated to Firefox Accounts. You can no longer change your "
-"password here."
-msgstr ""
-"Vous avez migré vers Firefox Accounts. Vous ne pouvez plus modifier votre "
-"mot de passe ici."
+msgid "You have migrated to Firefox Accounts. You can no longer change your password here."
+msgstr "Vous avez migré vers Firefox Accounts. Vous ne pouvez plus modifier votre mot de passe ici."
 
-#: src/olympia/users/templates/users/pwreset_confirm.html:31
-#: src/olympia/users/templates/users/register.html:72
+#: src/olympia/users/templates/users/pwreset_confirm.html:31 src/olympia/users/templates/users/register.html:72
 msgid "Confirm password"
 msgstr "Confirmez le mot de passe"
 
 #: src/olympia/users/templates/users/pwreset_confirm.html:47
-msgid ""
-"The password reset link was invalid, possibly because it has already been "
-"used. Please request a new password reset."
-msgstr ""
-"Le lien de réinitialisation de votre mot de passe était invalide, "
-"probablement parce qu'il a déjà été utilisé. Merci de reformuler une demande"
-" de réinitialisation de mot de passe."
+msgid "The password reset link was invalid, possibly because it has already been used. Please request a new password reset."
+msgstr "Le lien de réinitialisation de votre mot de passe était invalide, probablement parce qu'il a déjà été utilisé. Merci de reformuler une demande de réinitialisation de mot de passe."
 
 #: src/olympia/users/templates/users/pwreset_request.html:15
-msgid ""
-"Forgotten your password? Enter your e-mail address below, and we'll e-mail "
-"instructions for setting a new one."
-msgstr ""
-"Mot de passe oublié ? Indiquez votre adresse électronique ci-dessous, et "
-"nous vous enverrons les instructions pour en définir un nouveau."
+msgid "Forgotten your password? Enter your e-mail address below, and we'll e-mail instructions for setting a new one."
+msgstr "Mot de passe oublié ? Indiquez votre adresse électronique ci-dessous, et nous vous enverrons les instructions pour en définir un nouveau."
 
 #: src/olympia/users/templates/users/pwreset_request.html:25
 msgid "Send password reset link"
 msgstr "Envoyer un lien pour réinitialiser le mot de passe"
 
 #: src/olympia/users/templates/users/pwreset_sent.html:10
-msgid ""
-"An email has been sent to the requested account with further information. If"
-" you do not receive an email then please confirm you have entered the same "
-"email address used during account registration."
-msgstr ""
-"Un courriel a été envoyé au compte demandé contenant de plus amples "
-"informations. Si vous ne le recevez pas merci de vous assurer d'avoir entré "
-"la même adresse que lors de votre inscription."
+msgid "An email has been sent to the requested account with further information. If you do not receive an email then please confirm you have entered the same email address used during account registration."
+msgstr "Un courriel a été envoyé au compte demandé contenant de plus amples informations. Si vous ne le recevez pas merci de vous assurer d'avoir entré la même adresse que lors de votre inscription."
 
 #: src/olympia/users/templates/users/register.html:4
 msgid "New User Registration"
@@ -16066,12 +12609,8 @@ msgid "Why register?"
 msgstr "Pourquoi s'inscrire ?"
 
 #: src/olympia/users/templates/users/register.html:14
-msgid ""
-"Registration on AMO is <strong>not required</strong> if you simply want to "
-"download and install public add-ons."
-msgstr ""
-"L'inscription sur AMO n’est <strong>pas obligatoire</strong> si vous "
-"souhaitez simplement télécharger et installer les modules publics."
+msgid "Registration on AMO is <strong>not required</strong> if you simply want to download and install public add-ons."
+msgstr "L'inscription sur AMO n’est <strong>pas obligatoire</strong> si vous souhaitez simplement télécharger et installer les modules publics."
 
 #: src/olympia/users/templates/users/register.html:16
 msgid "You only need to register if:"
@@ -16082,41 +12621,22 @@ msgid "You want to submit reviews for add-ons"
 msgstr "Vous voulez donner votre avis pour des modules"
 
 #: src/olympia/users/templates/users/register.html:19
-msgid ""
-"You want to keep track of your favorite add-on collections or create one "
-"yourself"
-msgstr ""
-"Vous voulez suivre vos collections favorites de modules ou bien en créer une"
-" vous-même"
+msgid "You want to keep track of your favorite add-on collections or create one yourself"
+msgstr "Vous voulez suivre vos collections favorites de modules ou bien en créer une vous-même"
 
 #: src/olympia/users/templates/users/register.html:20
-msgid ""
-"You are an add-on developer and want to upload your add-on for hosting on "
-"AMO"
-msgstr ""
-"Vous êtes un développeur de module et souhaitez envoyer votre module pour "
-"qu'il soit hébergé sur AMO"
+msgid "You are an add-on developer and want to upload your add-on for hosting on AMO"
+msgstr "Vous êtes un développeur de module et souhaitez envoyer votre module pour qu'il soit hébergé sur AMO"
 
 #: src/olympia/users/templates/users/register.html:23
-msgid ""
-"Upon successful registration, you will be sent a confirmation email to the "
-"address you provided. Please follow the instructions there to confirm your "
-"account."
-msgstr ""
-"Lorsque votre inscription est réussie, vous recevez un courriel de "
-"confirmation à l'adresse fournie. Veuillez suivre les instructions pour "
-"confirmer votre compte."
+msgid "Upon successful registration, you will be sent a confirmation email to the address you provided. Please follow the instructions there to confirm your account."
+msgstr "Lorsque votre inscription est réussie, vous recevez un courriel de confirmation à l'adresse fournie. Veuillez suivre les instructions pour confirmer votre compte."
 
 #: src/olympia/users/templates/users/register.html:30
 #, python-format
-msgid ""
-"If you like, you can read our <a href=\"%(legal)s\" title=\"Legal "
-"Notices\">Legal Notices</a> and <a href=\"%(privacy)s\" title=\"Privacy "
-"Policy\">Privacy Policy</a>."
+msgid "If you like, you can read our <a href=\"%(legal)s\" title=\"Legal Notices\">Legal Notices</a> and <a href=\"%(privacy)s\" title=\"Privacy Policy\">Privacy Policy</a>."
 msgstr ""
-"Si vous le souhaitez, vous pouvez lire nos <a href=\"%(legal)s\" "
-"title=\"Legal Notices\">Mentions légales</a> et notre <a "
-"href=\"%(privacy)s\" title=\"Privacy Policy\">Politique de "
+"Si vous le souhaitez, vous pouvez lire nos <a href=\"%(legal)s\" title=\"Legal Notices\">Mentions légales</a> et notre <a href=\"%(privacy)s\" title=\"Privacy Policy\">Politique de "
 "confidentialité</a>."
 
 #: src/olympia/users/templates/users/register.html:52
@@ -16124,12 +12644,8 @@ msgid "Display name"
 msgstr "Nom affiché"
 
 #: src/olympia/users/templates/users/report_abuse.html:7
-msgid ""
-"Please describe why you are reporting this user, such as for spam or an "
-"inappropriate picture."
-msgstr ""
-"Merci de décrire pourquoi vous signalez cet utilisateur, par exemple en cas "
-"de spam ou pour une photo inappropriée."
+msgid "Please describe why you are reporting this user, such as for spam or an inappropriate picture."
+msgstr "Merci de décrire pourquoi vous signalez cet utilisateur, par exemple en cas de spam ou pour une photo inappropriée."
 
 #: src/olympia/users/templates/users/report_abuse_full.html:3
 msgid "Report user {0}"
@@ -16143,43 +12659,25 @@ msgstr "Commande de t-shirt"
 msgid "Special Edition Add-on Creator T-shirt"
 msgstr "T-shirt édition spéciale pour les créateurs de modules"
 
-#: src/olympia/users/templates/users/t-shirt.html:14
-#: src/olympia/users/templates/users/t-shirt.html:120
+#: src/olympia/users/templates/users/t-shirt.html:14 src/olympia/users/templates/users/t-shirt.html:120
 msgid "Note:"
 msgstr "Note&nbsp;:"
 
 #: src/olympia/users/templates/users/t-shirt.html:15
-msgid ""
-"You have already submitted a request for a t-shirt. You may re-submit this "
-"form to update your information, but you will only receive one shirt."
-msgstr ""
-"Vous avez déjà fait une demande pour un t-shirt. Vous pouvez soumettre à "
-"nouveau ce formulaire pour mettre à jour vos informations, mais vous ne "
-"recevrez qu'un t-shirt."
+msgid "You have already submitted a request for a t-shirt. You may re-submit this form to update your information, but you will only receive one shirt."
+msgstr "Vous avez déjà fait une demande pour un t-shirt. Vous pouvez soumettre à nouveau ce formulaire pour mettre à jour vos informations, mais vous ne recevrez qu'un t-shirt."
 
 #: src/olympia/users/templates/users/t-shirt.html:26
-msgid ""
-"Thank you for helping to make Firefox the most extensible browser available!"
-msgstr ""
-"Merci de contribuer à faire de Firefox le navigateur le plus personnalisable"
-" qui existe&nbsp;!"
+msgid "Thank you for helping to make Firefox the most extensible browser available!"
+msgstr "Merci de contribuer à faire de Firefox le navigateur le plus personnalisable qui existe&nbsp;!"
 
 #: src/olympia/users/templates/users/t-shirt.html:33
-msgid ""
-"As a thank you gift, we'd like to send you a special-edition, community-"
-"designed t-shirt. To receive your shirt, please fill out the form below."
-msgstr ""
-"Pour vous remercier, nous aimerions vous envoyer un t-shirt en édition "
-"spéciale, destiné à la communauté. Pour recevoir votre t-shirt, veuillez "
-"remplir le formulaire ci-dessous."
+msgid "As a thank you gift, we'd like to send you a special-edition, community-designed t-shirt. To receive your shirt, please fill out the form below."
+msgstr "Pour vous remercier, nous aimerions vous envoyer un t-shirt en édition spéciale, destiné à la communauté. Pour recevoir votre t-shirt, veuillez remplir le formulaire ci-dessous."
 
 #: src/olympia/users/templates/users/t-shirt.html:41
-msgid ""
-"Your contact information will only be used by Mozilla to ship this special "
-"edition t-shirt."
-msgstr ""
-"Vos coordonnées serviront seulement à Mozilla pour expédier ce t-shirt "
-"édition spéciale."
+msgid "Your contact information will only be used by Mozilla to ship this special edition t-shirt."
+msgstr "Vos coordonnées serviront seulement à Mozilla pour expédier ce t-shirt édition spéciale."
 
 #: src/olympia/users/templates/users/t-shirt.html:60
 msgid "Mailing Address"
@@ -16235,23 +12733,15 @@ msgstr "Demander un t-shirt"
 
 #: src/olympia/users/templates/users/t-shirt.html:137
 msgid ""
-"We're sorry, but in order to qualify for our special edition t-shirt, you "
-"must be an add-on developer with at least one listed add-on, one unlisted "
-"but signed add-on, or any number of background themes with a combined total "
-"of 10,000 average daily users."
+"We're sorry, but in order to qualify for our special edition t-shirt, you must be an add-on developer with at least one listed add-on, one unlisted but signed add-on, or any number of background "
+"themes with a combined total of 10,000 average daily users."
 msgstr ""
-"Nous sommes désolés, mais pour bénéficier de notre t-shirt édition spéciale,"
-" vous devez être un développeur de modules avec au moins un module "
-"répertorié mais signé, ou un nombre quelconque de thèmes avec un total de 10"
-" 000 utilisateurs quotidiens en moyenne."
+"Nous sommes désolés, mais pour bénéficier de notre t-shirt édition spéciale, vous devez être un développeur de modules avec au moins un module répertorié mais signé, ou un nombre quelconque de "
+"thèmes avec un total de 10 000 utilisateurs quotidiens en moyenne."
 
 #: src/olympia/users/templates/users/tougher_password.html:2
-msgid ""
-"For your account a password must contain at least 8 characters including "
-"letters and numbers."
-msgstr ""
-"Pour votre compte un mot de passe doit contenir au moins 8 caractères dont "
-"des lettres et des chiffres."
+msgid "For your account a password must contain at least 8 characters including letters and numbers."
+msgstr "Pour votre compte un mot de passe doit contenir au moins 8 caractères dont des lettres et des chiffres."
 
 #: src/olympia/users/templates/users/unsubscribe.html:2
 msgid "Unsubscribe"
@@ -16263,12 +12753,8 @@ msgstr "Vous êtes désinscrit avec succès !"
 
 #: src/olympia/users/templates/users/unsubscribe.html:10
 #, python-format
-msgid ""
-"The email address <strong>%(email)s</strong> will no longer get messages "
-"when:"
-msgstr ""
-"L'adresse de courriel <strong>%(email)s</strong> ne recevra plus de message "
-"lorsque :"
+msgid "The email address <strong>%(email)s</strong> will no longer get messages when:"
+msgstr "L'adresse de courriel <strong>%(email)s</strong> ne recevra plus de message lorsque :"
 
 #: src/olympia/users/templates/users/unsubscribe.html:20
 msgid "More Actions:"
@@ -16288,15 +12774,10 @@ msgstr "Nous n'avons pas pu vous désinscrire"
 
 #: src/olympia/users/templates/users/unsubscribe.html:30
 #, python-format
-msgid ""
-"Unfortunately, we weren't able to unsubscribe you. The link you clicked is "
-"invalid. However, you can unsubscribe still unsubscribe on your <a "
-"href=\"%(edit_url)s\">edit profile page</a>."
+msgid "Unfortunately, we weren't able to unsubscribe you. The link you clicked is invalid. However, you can unsubscribe still unsubscribe on your <a href=\"%(edit_url)s\">edit profile page</a>."
 msgstr ""
-"Malheureusement, nous n'avons pas été en mesure de vous désinscrire. Le lien"
-" sur lequel vous avez cliqué est invalide. Cependant, vous pouvez toujours "
-"vous désinscrire via votre <a href=\"%(edit_url)s\">page d'édition du "
-"profil</a>."
+"Malheureusement, nous n'avons pas été en mesure de vous désinscrire. Le lien sur lequel vous avez cliqué est invalide. Cependant, vous pouvez toujours vous désinscrire via votre <a "
+"href=\"%(edit_url)s\">page d'édition du profil</a>."
 
 #: src/olympia/users/templates/users/vcard.html:2
 msgid "Developer Information"
@@ -16349,15 +12830,15 @@ msgstr "%s Historique des versions"
 msgid "Version History with Changelogs"
 msgstr "Historique des versions et modifications correspondantes"
 
-#: src/olympia/versions/models.py:314
+#: src/olympia/versions/models.py:313
 msgid "Add-on uses binary components."
 msgstr "Module contenant des composants binaires."
 
-#: src/olympia/versions/models.py:317
+#: src/olympia/versions/models.py:316
 msgid "Add-on has opted into strict compatibility checking."
 msgstr "Le module a opté pour une vérification de compatibilité stricte."
 
-#: src/olympia/versions/models.py:715
+#: src/olympia/versions/models.py:711
 msgid "{app} {min} and later"
 msgstr "{app} {min} et supérieures"
 
@@ -16373,9 +12854,7 @@ msgstr "Publié {0}"
 #: src/olympia/versions/templates/versions/version.html:39
 #, python-format
 msgid "Source code released under <a target=\"_blank\" href=\"%(url)s\">%(name)s</a>"
-msgstr ""
-"Code source disponible sous la licence <a target=\"_blank\" "
-"href=\"%(url)s\">%(name)s</a>"
+msgstr "Code source disponible sous la licence <a target=\"_blank\" href=\"%(url)s\">%(name)s</a>"
 
 #: src/olympia/versions/templates/versions/version.html:44
 #, python-format
@@ -16386,8 +12865,8 @@ msgstr "Code source disponible sous la licence <a href=\"%(url)s\">%(name)s</a>"
 msgid "View the source"
 msgstr "Afficher la source"
 
-#. {0} is an add-on name.
 # {0} is the add-on name
+#. {0} is an add-on name.
 #: src/olympia/versions/templates/versions/version_list.html:26
 msgid "{0} Version History"
 msgstr "Historique de version de {0}"
@@ -16399,21 +12878,14 @@ msgid_plural "<b>{0}</b> versions"
 msgstr[0] "Version affichée : {0}"
 msgstr[1] "<b>{0}</b> versions"
 
-#: src/olympia/versions/templates/versions/version_list.html:35
-#: src/olympia/versions/templates/versions/mobile/version_list.html:14
+#: src/olympia/versions/templates/versions/version_list.html:35 src/olympia/versions/templates/versions/mobile/version_list.html:14
 msgid "Be careful with old versions!"
 msgstr "Méfiez-vous des anciennes versions !"
 
-#: src/olympia/versions/templates/versions/version_list.html:36
-#: src/olympia/versions/templates/versions/mobile/version_list.html:15
+#: src/olympia/versions/templates/versions/version_list.html:36 src/olympia/versions/templates/versions/mobile/version_list.html:15
 #, python-format
-msgid ""
-"These versions are displayed for reference and testing purposes. You should "
-"always use the <a href=\"%(url)s\">latest version</a> of an add-on."
-msgstr ""
-"Ces versions sont affichées pour informations et à titre d'essais. Vous "
-"devriez toujours utiliser la <a href=\"%(url)s\">dernière version</a> d'un "
-"module."
+msgid "These versions are displayed for reference and testing purposes. You should always use the <a href=\"%(url)s\">latest version</a> of an add-on."
+msgstr "Ces versions sont affichées pour informations et à titre d'essais. Vous devriez toujours utiliser la <a href=\"%(url)s\">dernière version</a> d'un module."
 
 #: src/olympia/versions/templates/versions/mobile/version.html:4
 msgid "Beta Version {0}"
@@ -16443,3 +12915,8 @@ msgstr "Envoyer un courriel à la fin"
 #: src/olympia/zadmin/forms.py:105
 msgid "Log emails instead of sending"
 msgstr "Archiver les courriels au lieu de les envoyer."
+
+#: src/olympia/zadmin/forms.py:215
+msgid "Deleted versions can`t be changed."
+msgstr ""
+

--- a/locale/fr/LC_MESSAGES/djangojs.po
+++ b/locale/fr/LC_MESSAGES/djangojs.po
@@ -7,136 +7,393 @@ msgid ""
 msgstr ""
 "Project-Id-Version: REMORA 0.1\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2016-02-24 21:23+0000\n"
+"POT-Creation-Date: 2016-04-18 15:47+0000\n"
 "PO-Revision-Date: 2015-10-17 12:19+0000\n"
 "Last-Translator: goofy <goofy@babelzilla.org>\n"
 "Language-Team: français <>\n"
+"Language: \n"
 "MIME-Version: 1.0\n"
-"Content-Type: text/plain; charset=utf-8\n"
+"Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Generated-By: Babel 2.2.0\n"
 
-#: static/js/common/ratingwidget.js:31
+#: static/js/common-all.js:1426 static/js/impala-all.js:1511 static/js/zamboni/discovery-all.js:12598 static/js/zamboni/init.js:28 static/js/zamboni/mobile-all.js:14945
+msgid "This feature is temporarily disabled while we perform website maintenance. Please check back a little later."
+msgstr "Cette fonctionnalité est désactivée temporairement pendant la maintenance. Merci de revenir un peu plus tard."
+
+#. L10n: {0} is an app name like Firefox.
+#: static/js/common-all.js:1837 static/js/impala-all.js:1922 static/js/zamboni/buttons.js:73 static/js/zamboni/discovery-all.js:13108
+msgid "Accept and Install"
+msgstr "Accepter et installer"
+
+#: static/js/common-all.js:1837 static/js/impala-all.js:1922 static/js/zamboni/buttons.js:73 static/js/zamboni/discovery-all.js:13108
+msgid "Add to {0}"
+msgstr "Ajouter à {0}"
+
+#: static/js/common-all.js:1842 static/js/impala-all.js:1927 static/js/zamboni/buttons.js:78 static/js/zamboni/discovery-all.js:13113
+msgid "Download Now"
+msgstr "Télécharger maintenant"
+
+#: static/js/common-all.js:1883 static/js/impala-all.js:1968 static/js/zamboni/buttons.js:119 static/js/zamboni/discovery-all.js:13154
+msgid "Add-on has not been updated to support default-to-compatible."
+msgstr "Le module n'a pas été mis à jour pour se conformer à default-to-compatible."
+
+#: static/js/common-all.js:1888 static/js/impala-all.js:1973 static/js/zamboni/buttons.js:124 static/js/zamboni/discovery-all.js:13159
+msgid "You need to be using Firefox 10.0 or higher."
+msgstr "Vous devez utiliser Firefox 10.0 ou plus récent.s"
+
+#: static/js/common-all.js:1900 static/js/impala-all.js:1985 static/js/zamboni/buttons.js:136 static/js/zamboni/discovery-all.js:13171
+msgid "Mozilla has marked this version as incompatible with your Firefox version."
+msgstr "Mozilla a marqué cette version comme incompatible avec votre version de Firefox."
+
+#. L10n: {0} is an platform like Windows or Linux.
+#: static/js/common-all.js:1981 static/js/impala-all.js:2066 static/js/zamboni/buttons.js:217 static/js/zamboni/discovery-all.js:13252
+msgid "Install for {0} anyway"
+msgstr "Installer tout de même pour {0}"
+
+#: static/js/common-all.js:1981 static/js/impala-all.js:2066 static/js/zamboni/buttons.js:217 static/js/zamboni/discovery-all.js:13252
+msgid "Download for {0} anyway"
+msgstr "Télécharger tout de même pour {0}"
+
+#: static/js/common-all.js:2038 static/js/impala-all.js:2123 static/js/zamboni/buttons.js:274 static/js/zamboni/discovery-all.js:13309
+msgid "Not available for your platform"
+msgstr "Non disponible sur votre plateforme"
+
+#. L10n: {0} is an app name, {1} is the app version.
+#: static/js/common-all.js:2049 static/js/common-all.js:2086 static/js/impala-all.js:2134 static/js/impala-all.js:2171 static/js/zamboni/buttons.js:286 static/js/zamboni/buttons.js:324
+#: static/js/zamboni/discovery-all.js:13320 static/js/zamboni/discovery-all.js:13357
+msgid "Not available for {0} {1}"
+msgstr "Non disponible pour {0} {1}"
+
+#: static/js/common-all.js:2112 static/js/impala-all.js:2197 static/js/zamboni/buttons.js:351 static/js/zamboni/discovery-all.js:13383
+msgid "Works with {app} {min} - {max}"
+msgstr "Fonctionne avec {app} {min} - {max}"
+
+#: static/js/common-all.js:2114 static/js/impala-all.js:2199 static/js/zamboni/buttons.js:353 static/js/zamboni/discovery-all.js:13385
+msgid "View other versions"
+msgstr "Voir d'autres versions"
+
+#: static/js/common-all.js:2162 static/js/impala-all.js:2247 static/js/zamboni/buttons.js:401 static/js/zamboni/discovery-all.js:13433
+msgid "Only with Firefox — Get Firefox Now!"
+msgstr "Uniquement disponible sur Firefox — Obtenez Firefox dès maintenant !"
+
+#: static/js/common-all.js:2278 static/js/impala-all.js:2363 static/js/zamboni/buttons.js:517 static/js/zamboni/discovery-all.js:13549 static/js/zamboni/mobile-all.js:15177
+#: static/js/zamboni/mobile/buttons.js:43
+msgid "Sorry, you need a Mozilla-based browser (such as Firefox) to install a search plugin."
+msgstr "Désolé, vous devez utiliser un navigateur Mozilla (tel que Firefox) pour installer un moteur de recherche."
+
+#: static/js/common-all.js:9088 static/js/impala-all.js:9649 static/js/zamboni/global.js:410
+msgid "Loading..."
+msgstr "Chargement ..."
+
+#. L10n: {0} is the number of characters left.
+#: static/js/common-all.js:9152 static/js/impala-all.js:9713 static/js/zamboni/global.js:474
+msgid "<b>{0}</b> character left."
+msgid_plural "<b>{0}</b> characters left."
+msgstr[0] "<b>{0}</b> caractère restant."
+msgstr[1] "<b>{0}</b> caractères restants."
+
+#: static/js/common-all.js:9589 static/js/common-min.js:6 static/js/impala-all.js:10052 static/js/impala-min.js:6 static/js/common/ratingwidget.js:31 static/js/zamboni/mobile-all.js:16123
+#: static/js/zamboni/mobile-min.js:6
 msgid "{0} star"
 msgid_plural "{0} stars"
 msgstr[0] "{0} étoile"
 msgstr[1] "{0} étoiles"
 
-#: static/js/common/upload-addon.js:41 static/js/common/upload-image.js:128
+#: static/js/common-all.js:9676 static/js/common-min.js:6 static/js/impala-all.js:10139 static/js/impala-min.js:6 static/js/zamboni/l10n.js:45
+msgid "Remove this localization"
+msgstr "Retirer cette localisation"
+
+#: static/js/common-all.js:10193 static/js/common-min.js:6 static/js/impala-all.js:10674 static/js/impala-min.js:6 static/js/zamboni/discovery-all.js:13678
+msgid "close"
+msgstr ""
+
+#: static/js/common-all.js:10860 static/js/common-min.js:6 static/js/impala-all.js:11481 static/js/impala-min.js:6 static/js/impala/reviews.js:23 static/js/zamboni/reviews.js:18
+msgid "Flagged for review"
+msgstr "Étiqueter pour revue"
+
+#: static/js/common-all.js:10876 static/js/common-min.js:6 static/js/impala-all.js:11498 static/js/impala-min.js:6 static/js/impala/reviews.js:40 static/js/zamboni/reviews.js:34
+msgid "Your input is required"
+msgstr "Votre avis est demandé"
+
+#: static/js/common-all.js:10945 static/js/common-min.js:6 static/js/impala-all.js:11610 static/js/impala-min.js:7 static/js/impala/reviews.js:152 static/js/zamboni/reviews.js:103
+msgid "Marked for deletion"
+msgstr "Marqué pour suppression"
+
+#: static/js/common-all.js:11573 static/js/common-min.js:7 static/js/impala-all.js:13809 static/js/impala-min.js:8 static/js/zamboni/collections.js:229
+msgid "Adding to Favorites&hellip;"
+msgstr "Ajouter au Favoris &hellip;"
+
+#: static/js/common-all.js:11576 static/js/common-min.js:7 static/js/impala-all.js:13812 static/js/impala-min.js:8 static/js/zamboni/collections.js:232
+msgid "Removing Favorite&hellip;"
+msgstr "Retirer des Favoris &hellip;"
+
+#: static/js/common-all.js:11579 static/js/common-min.js:7 static/js/impala-all.js:13815 static/js/impala-min.js:8 static/js/zamboni/collections.js:235
+msgid "Add to Favorites"
+msgstr "Ajouter aux favoris"
+
+#: static/js/common-all.js:11582 static/js/common-min.js:7 static/js/impala-all.js:13818 static/js/impala-min.js:8 static/js/zamboni/collections.js:238
+msgid "Remove from Favorites"
+msgstr "Supprimer des favoris"
+
+#: static/js/common-all.js:11647 static/js/common-min.js:7 static/js/impala-all.js:13883 static/js/impala-min.js:8 static/js/zamboni/collections.js:303
+msgid "Pending"
+msgstr "En attente"
+
+#: static/js/common-all.js:11648 static/js/common-min.js:7 static/js/impala-all.js:13884 static/js/impala-min.js:8 static/js/zamboni/collections.js:304
+msgid "Add a comment"
+msgstr "Ajouter un commentaire"
+
+#: static/js/common-all.js:11648 static/js/common-min.js:7 static/js/impala-all.js:13884 static/js/impala-min.js:8 static/js/zamboni/collections.js:304
+msgid "Comment"
+msgstr "Commentaire"
+
+#: static/js/common-all.js:11649 static/js/common-min.js:7 static/js/impala-all.js:13885 static/js/impala-min.js:8 static/js/zamboni/collections.js:305
+msgid "Remove this add-on from the collection"
+msgstr "Retirer ce module de la collection"
+
+#: static/js/common-all.js:11649 static/js/common-all.js:11678 static/js/common-min.js:7 static/js/impala-all.js:13885 static/js/impala-all.js:13914 static/js/impala-min.js:8
+#: static/js/zamboni/collections.js:305 static/js/zamboni/collections.js:334
+msgid "Remove"
+msgstr "Retirer"
+
+#: static/js/common-all.js:11678 static/js/common-min.js:7 static/js/impala-all.js:13914 static/js/impala-min.js:8 static/js/zamboni/collections.js:334
+msgid "Remove this user as a contributor"
+msgstr "Retirer cet utilisateur en tant que contributeur"
+
+#: static/js/common-all.js:11690 static/js/common-min.js:7 static/js/impala-all.js:13926 static/js/impala-min.js:8 static/js/zamboni/collections.js:346
+msgid "An email address is required."
+msgstr "Une adresse de courriel est nécessaire."
+
+#: static/js/common-all.js:11708 static/js/common-min.js:7 static/js/impala-all.js:13944 static/js/impala-min.js:8 static/js/zamboni/collections.js:364
+msgid "You cannot add yourself as a contributor."
+msgstr "Vous ne pouvez pas vous rajouter comme contributeur."
+
+#: static/js/common-all.js:11710 static/js/common-min.js:7 static/js/impala-all.js:13946 static/js/impala-min.js:8 static/js/zamboni/collections.js:366
+msgid "You have already added that user."
+msgstr "Vous avez déjà ajouté cet utilisateur."
+
+#: static/js/common-all.js:11917 static/js/common-min.js:7 static/js/impala-all.js:14153 static/js/impala-min.js:8 static/js/zamboni/collections.js:573
+msgid "Add to favorites"
+msgstr "Ajouter aux favoris"
+
+#: static/js/common-all.js:11921 static/js/common-min.js:7 static/js/impala-all.js:14157 static/js/impala-min.js:8 static/js/zamboni/collections.js:577
+msgid "Remove from favorites"
+msgstr "Supprimer des favoris"
+
+#: static/js/common-all.js:11939 static/js/common-min.js:7 static/js/impala-all.js:14175 static/js/impala-all.js:14233 static/js/impala-min.js:8 static/js/impala/collections.js:10
+#: static/js/zamboni/collections.js:595
+msgid "Follow this Collection"
+msgstr "Suivre cette collection"
+
+#: static/js/common-all.js:11948 static/js/common-min.js:7 static/js/impala-all.js:14184 static/js/impala-min.js:8 static/js/zamboni/collections.js:604
+msgid "Stop following"
+msgstr "Ne plus suivre"
+
+#: static/js/common-all.js:12096 static/js/common-min.js:7 static/js/zamboni/password-strength.js:20
+msgid "Password strength:"
+msgstr "Robustesse du mot de passe"
+
+#: static/js/common-all.js:12102 static/js/common-min.js:7 static/js/zamboni/password-strength.js:26
+msgid "At least {0} character left."
+msgid_plural "At least {0} characters left."
+msgstr[0] "Au moins {0} caractère manquant."
+msgstr[1] "Au moins {0} caractères manquants."
+
+#: static/js/common-all.js:12286 static/js/common-min.js:7 static/js/impala-all.js:14632 static/js/impala-min.js:8 static/js/impala/suggestions.js:39
+msgid "Search themes for <b>{0}</b>"
+msgstr "Rechercher des thèmes pour <b>{0}</b>"
+
+#: static/js/common-all.js:12288 static/js/common-min.js:7 static/js/impala-all.js:14634 static/js/impala-min.js:8 static/js/impala/suggestions.js:41
+msgid "Search apps for <b>{0}</b>"
+msgstr "Recherche d'applications pour <b>{0}</b>"
+
+#: static/js/common-all.js:12290 static/js/common-min.js:7 static/js/impala-all.js:14636 static/js/impala-min.js:8 static/js/impala/suggestions.js:43
+msgid "Search add-ons for <b>{0}</b>"
+msgstr "Recherche de modules pour <b>{0}</b>"
+
+#: static/js/common-all.js:12521 static/js/common-min.js:7 static/js/impala-all.js:14867 static/js/impala-min.js:8 static/js/impala/site_suggestions.js:46
+msgid "Category"
+msgstr "Catégorie"
+
+#. L10n: {0} is an app name.
+#: static/js/impala-all.js:11632 static/js/impala-min.js:7 static/js/impala/listing.js:11 static/js/zamboni/themes.js:13
+msgid "This theme is incompatible with your version of {0}"
+msgstr "Ce thème est incompatible avec votre version de {0}"
+
+#: static/js/impala-all.js:12146 static/js/impala-all.js:14331 static/js/impala-min.js:7 static/js/impala-min.js:8 static/js/common/upload-image.js:97 static/js/impala/users.js:51
+#: static/js/zamboni/devhub-all.js:894 static/js/zamboni/devhub-min.js:1
+msgid "Images must be either PNG or JPG."
+msgstr "Les images doivent être au format PNG ou JPG."
+
+#: static/js/impala-all.js:12150 static/js/impala-min.js:7 static/js/common/upload-image.js:101 static/js/zamboni/devhub-all.js:898 static/js/zamboni/devhub-min.js:1
+msgid "Videos must be in WebM."
+msgstr "La vidéo doit être au format WebM."
+
+#: static/js/impala-all.js:12177 static/js/impala-min.js:7 static/js/common/upload-addon.js:41 static/js/common/upload-image.js:128 static/js/zamboni/devhub-all.js:272
+#: static/js/zamboni/devhub-all.js:925 static/js/zamboni/devhub-min.js:1
 msgid "There was a problem contacting the server."
 msgstr "Une erreur est survenue pendant le contact du serveur."
 
-#: static/js/common/upload-addon.js:69
+#: static/js/impala-all.js:13298 static/js/impala-min.js:7 static/js/impala/persona_creation.js:60
+msgid "All Rights Reserved"
+msgstr "Tous droits réservés"
+
+#: static/js/impala-all.js:13302 static/js/impala-min.js:7 static/js/impala/persona_creation.js:64
+msgid "Creative Commons Attribution 3.0"
+msgstr "Creative Commons Attribution 3.0"
+
+#: static/js/impala-all.js:13307 static/js/impala-min.js:7 static/js/impala/persona_creation.js:69
+msgid "Creative Commons Attribution-NonCommercial 3.0"
+msgstr "Creative Commons Attribution-NonCommercial 3.0"
+
+#: static/js/impala-all.js:13312 static/js/impala-min.js:7 static/js/impala/persona_creation.js:74
+msgid "Creative Commons Attribution-NonCommercial-NoDerivs 3.0"
+msgstr "Creative Commons Attribution-NonCommercial-NoDerivs 3.0"
+
+#: static/js/impala-all.js:13317 static/js/impala-min.js:7 static/js/impala/persona_creation.js:79
+msgid "Creative Commons Attribution-NonCommercial-Share Alike 3.0"
+msgstr "Creative Commons Attribution-NonCommercial-Share Alike 3.0"
+
+#: static/js/impala-all.js:13322 static/js/impala-min.js:7 static/js/impala/persona_creation.js:84
+msgid "Creative Commons Attribution-NoDerivs 3.0"
+msgstr "Creative Commons Attribution-NoDerivs 3.0"
+
+#: static/js/impala-all.js:13327 static/js/impala-min.js:7 static/js/impala/persona_creation.js:89
+msgid "Creative Commons Attribution-ShareAlike 3.0"
+msgstr "Creative Commons Attribution-ShareAlike 3.0"
+
+#: static/js/impala-all.js:13530 static/js/impala-min.js:7 static/js/impala/persona_creation.js:292
+msgid "Your Theme's Name"
+msgstr "Le nom de votre thème"
+
+#: static/js/impala-all.js:14242 static/js/impala-min.js:8 static/js/impala/collections.js:19
+msgid "Stop Following"
+msgstr "Arrêter le suivi"
+
+#: static/js/impala-all.js:14243 static/js/impala-min.js:8 static/js/impala/collections.js:20
+msgid "Following"
+msgstr "Suivi"
+
+#: static/js/impala-all.js:14313 static/js/impala-min.js:8 static/js/impala/users.js:33
+msgid "use original"
+msgstr "utiliser l'original"
+
+#: static/js/impala-all.js:14523 static/js/impala-min.js:8 static/js/impala/search.js:114
+msgid "Updating results&hellip;"
+msgstr "Mise à jour des résultats &hellip;"
+
+#: static/js/common/upload-addon.js:69 static/js/zamboni/devhub-all.js:300 static/js/zamboni/devhub-min.js:1
 msgid "Select a file..."
 msgstr "Sélectionnez un fichier ..."
 
-#: static/js/common/upload-addon.js:70
+#: static/js/common/upload-addon.js:70 static/js/zamboni/devhub-all.js:301 static/js/zamboni/devhub-min.js:1
 msgid "Your add-on should end with .xpi, .jar or .xml"
 msgstr "Le nom de votre module doit se finir par .xpi, .jar ou .xml"
 
 #. L10n: {0} is the percent of the file that has been uploaded.
-#: static/js/common/upload-addon.js:104
+#: static/js/common/upload-addon.js:104 static/js/zamboni/devhub-all.js:335 static/js/zamboni/devhub-min.js:1
 #, python-format
 msgid "{0}% complete"
 msgstr "{0}% terminé"
 
 #. L10n: "{bytes uploaded} of {total filesize}".
-#: static/js/common/upload-addon.js:107
+#: static/js/common/upload-addon.js:107 static/js/zamboni/devhub-all.js:338 static/js/zamboni/devhub-min.js:1
 msgid "{0} of {1}"
 msgstr "{0} sur {1}"
 
-#: static/js/common/upload-addon.js:140
+#: static/js/common/upload-addon.js:140 static/js/zamboni/devhub-all.js:371 static/js/zamboni/devhub-min.js:1
 msgid "Cancel"
 msgstr "Annuler"
 
-#: static/js/common/upload-addon.js:162
+#: static/js/common/upload-addon.js:162 static/js/zamboni/devhub-all.js:393 static/js/zamboni/devhub-min.js:1
 msgid "Uploading {0}"
 msgstr "Envoi de {0}"
 
-#: static/js/common/upload-addon.js:189
+#: static/js/common/upload-addon.js:189 static/js/zamboni/devhub-all.js:420 static/js/zamboni/devhub-min.js:1
 msgid "Error with {0}"
 msgstr "Erreur avec {0}"
 
-#: static/js/common/upload-addon.js:194
+#: static/js/common/upload-addon.js:194 static/js/zamboni/devhub-all.js:425 static/js/zamboni/devhub-min.js:1
 msgid "Your add-on failed validation with {0} error."
 msgid_plural "Your add-on failed validation with {0} errors."
 msgstr[0] "Votre module n'a pas passé la validation et a généré {0} erreur."
 msgstr[1] "Votre module n'a pas passé la validation et a généré {0} erreurs."
 
-#: static/js/common/upload-addon.js:208
+#: static/js/common/upload-addon.js:208 static/js/zamboni/devhub-all.js:439 static/js/zamboni/devhub-min.js:1
 msgid "&hellip;and {0} more"
 msgid_plural "&hellip;and {0} more"
 msgstr[0] "&hellip; et {0} plus"
 msgstr[1] "&hellip; et {0} plus"
 
-#: static/js/common/upload-addon.js:222 static/js/common/upload-addon.js:512
+#: static/js/common/upload-addon.js:222 static/js/common/upload-addon.js:497 static/js/zamboni/devhub-all.js:453 static/js/zamboni/devhub-all.js:743 static/js/zamboni/devhub-min.js:1
 msgid "See full validation report"
 msgstr "Voir le rapport de validation complet"
 
-#: static/js/common/upload-addon.js:234
+#: static/js/common/upload-addon.js:234 static/js/zamboni/devhub-all.js:465 static/js/zamboni/devhub-min.js:1
 msgid "Validating {0}"
 msgstr "Validation {0}"
 
 #. L10n: first argument is an HTTP status code
-#: static/js/common/upload-addon.js:273
+#: static/js/common/upload-addon.js:273 static/js/zamboni/devhub-all.js:504 static/js/zamboni/devhub-min.js:1
 msgid "Received an empty response from the server; status: {0}"
 msgstr "Réception d'une réponse vide depuis le serveur ; statut : {0}"
 
-#: static/js/common/upload-addon.js:373
+#: static/js/common/upload-addon.js:370 static/js/zamboni/devhub-all.js:604 static/js/zamboni/devhub-min.js:1
 msgid "Unexpected server error while validating."
 msgstr "Erreur serveur inattendue pendant la validation."
 
-#: static/js/common/upload-addon.js:412
+#: static/js/common/upload-addon.js:409 static/js/zamboni/devhub-all.js:643 static/js/zamboni/devhub-min.js:1
 msgid "Finished validating {0}"
 msgstr "Validation finie {0}"
 
-#: static/js/common/upload-addon.js:418
+#: static/js/common/upload-addon.js:415 static/js/zamboni/devhub-all.js:649 static/js/zamboni/devhub-min.js:1
 msgid "Your add-on validation timed out, it will be manually reviewed."
 msgstr "La validation de votre module n'a pu être effectuée à temps, il sera revu manuellement."
 
-#: static/js/common/upload-addon.js:421
+#: static/js/common/upload-addon.js:418 static/js/zamboni/devhub-all.js:652 static/js/zamboni/devhub-min.js:1
 msgid "Your add-on was validated with no errors and {0} warning."
 msgid_plural "Your add-on was validated with no errors and {0} warnings."
 msgstr[0] "Votre module a été validé sans erreur et avec {0} avertissement."
 msgstr[1] "Votre module a été validé sans erreur et avec {0} avertissements."
 
-#: static/js/common/upload-addon.js:426
+#: static/js/common/upload-addon.js:423 static/js/zamboni/devhub-all.js:657 static/js/zamboni/devhub-min.js:1
 msgid "Your add-on was validated with no errors and {0} message."
 msgid_plural "Your add-on was validated with no errors and {0} messages."
 msgstr[0] "Votre module a été validé sans erreur et avec {0} message."
 msgstr[1] "Votre module a été validé sans erreur et avec {0} messages."
 
-#: static/js/common/upload-addon.js:431
+#: static/js/common/upload-addon.js:428 static/js/zamboni/devhub-all.js:662 static/js/zamboni/devhub-min.js:1
 msgid "Your add-on was validated with no errors or warnings."
 msgstr "La validation de votre extension s'est déroulée sans erreur ni avertissement."
 
-#: static/js/common/upload-addon.js:446
+#: static/js/common/upload-addon.js:443 static/js/zamboni/devhub-all.js:677 static/js/zamboni/devhub-min.js:1
 msgid "Your submission will be automatically signed."
 msgstr "Votre envoi sera signé automatiquement."
 
-#: static/js/common/upload-addon.js:465
+#: static/js/common/upload-addon.js:450 static/js/zamboni/devhub-all.js:696 static/js/zamboni/devhub-min.js:1
 msgid "Include detailed version notes (this can be done in the next step)."
 msgstr "Ajouter des notes de version détaillées (cela peut être effectué lors de la prochaine étape)."
 
-#: static/js/common/upload-addon.js:466
+#: static/js/common/upload-addon.js:451 static/js/zamboni/devhub-all.js:697 static/js/zamboni/devhub-min.js:1
 msgid "If your add-on requires an account to a website in order to be fully tested, include a test username and password in the Notes to Reviewer (this can be done in the next step)."
 msgstr ""
 "S'il est nécessaire d'avoir un compte sur un site web pour que votre module soit testé, ajoutez un nom d'utilisateur et un mot de passe d'un compte de test dans les notes pour le réviseur (cela "
 "peut être effectué à la prochaine étape)."
 
-#: static/js/common/upload-addon.js:467
+#: static/js/common/upload-addon.js:452 static/js/zamboni/devhub-all.js:698 static/js/zamboni/devhub-min.js:1
 msgid "If your add-on is intended for a limited audience you should choose Preliminary Review instead of Full Review."
 msgstr "Si votre module est destiné à un public restreint, ,vous devriez sélectionner une revue préliminaire plutôt qu'une revue complète."
 
-#: static/js/common/upload-addon.js:480
+#: static/js/common/upload-addon.js:465 static/js/zamboni/devhub-all.js:711 static/js/zamboni/devhub-min.js:1
 msgid "Add-on submission checklist"
 msgstr "Liste de points à vérifier pour l'envoi d'un module"
 
-#: static/js/common/upload-addon.js:481
+#: static/js/common/upload-addon.js:466 static/js/zamboni/devhub-all.js:712 static/js/zamboni/devhub-min.js:1
 msgid "Please verify the following points before finalizing your submission. This will minimize delays or misunderstanding during the review process:"
 msgstr "Veuillez vérifier les points suivants avant de finaliser votre envoi. Cela réduira le délai ou les incompréhensions lors du processus de revue :"
 
-#: static/js/common/upload-addon.js:483
+#: static/js/common/upload-addon.js:468 static/js/zamboni/devhub-all.js:714 static/js/zamboni/devhub-min.js:1
 msgid ""
 "Compiled binaries, as well as minified or obfuscated scripts (excluding known libraries) need to have their sources submitted separately for review. Make sure that you use the source code upload "
 "field to avoid having your submission rejected."
@@ -144,1080 +401,844 @@ msgstr ""
 "Les fichiers sources des fichiers binaires compilés, des scripts minifiés ou obfusqués (à l'exception des bibliothèques connues) doivent être envoyés pour être revus séparément. Assurez-vous "
 "d'utiliser le champ permettant d'envoyer le code source pour éviter que votre envoi soit rejeté."
 
-#: static/js/common/upload-addon.js:501
+#: static/js/common/upload-addon.js:486 static/js/zamboni/devhub-all.js:732 static/js/zamboni/devhub-min.js:1
 msgid "The validation process found these issues that can lead to rejections:"
 msgstr "Le processus de validation a détecté ces problèmes qui peuvent entraîner des rejets :"
 
-#: static/js/common/upload-addon.js:518
+#: static/js/common/upload-addon.js:503 static/js/zamboni/devhub-all.js:749 static/js/zamboni/devhub-min.js:1
 msgid "If you are unfamiliar with the add-ons review process, you can read about it here."
 msgstr "Si vous ne connaissez pas le processus de revue des modules, vous pouvez en apprendre plus ici."
 
-#: static/js/common/upload-addon.js:555
+#: static/js/common/upload-addon.js:540 static/js/zamboni/devhub-all.js:786 static/js/zamboni/devhub-min.js:1
 msgid "Sorry, no supported platform has been found."
 msgstr "Désolé, aucune plateforme supportée n'a été trouvée."
 
-#: static/js/common/upload-base.js:57
+#: static/js/common/upload-base.js:57 static/js/zamboni/devhub-all.js:187 static/js/zamboni/devhub-min.js:1
 msgid "The filetype you uploaded isn't recognized."
 msgstr "Le type de fichier que vous avez envoyé n'est pas reconnu."
 
-#: static/js/common/upload-base.js:79
+#: static/js/common/upload-base.js:79 static/js/zamboni/devhub-all.js:209 static/js/zamboni/devhub-min.js:1
 msgid "You cancelled the upload."
 msgstr "Vous avez annulé l'envoi."
 
-#: static/js/common/upload-image.js:97 static/js/impala/users.js:51
-msgid "Images must be either PNG or JPG."
-msgstr "Les images doivent être au format PNG ou JPG."
-
-#: static/js/common/upload-image.js:101
-msgid "Videos must be in WebM."
-msgstr "La vidéo doit être au format WebM."
-
-#: static/js/impala/collections.js:10 static/js/zamboni/collections.js:595
-msgid "Follow this Collection"
-msgstr "Suivre cette collection"
-
-#: static/js/impala/collections.js:19
-msgid "Stop Following"
-msgstr "Arrêter le suivi"
-
-#: static/js/impala/collections.js:20
-msgid "Following"
-msgstr "Suivi"
-
-#. L10n: {0} is an app name.
-#: static/js/impala/listing.js:11 static/js/zamboni/themes.js:13
-msgid "This theme is incompatible with your version of {0}"
-msgstr "Ce thème est incompatible avec votre version de {0}"
-
-#: static/js/impala/persona_creation.js:60
-msgid "All Rights Reserved"
-msgstr "Tous droits réservés"
-
-#: static/js/impala/persona_creation.js:64
-msgid "Creative Commons Attribution 3.0"
-msgstr "Creative Commons Attribution 3.0"
-
-#: static/js/impala/persona_creation.js:69
-msgid "Creative Commons Attribution-NonCommercial 3.0"
-msgstr "Creative Commons Attribution-NonCommercial 3.0"
-
-#: static/js/impala/persona_creation.js:74
-msgid "Creative Commons Attribution-NonCommercial-NoDerivs 3.0"
-msgstr "Creative Commons Attribution-NonCommercial-NoDerivs 3.0"
-
-#: static/js/impala/persona_creation.js:79
-msgid "Creative Commons Attribution-NonCommercial-Share Alike 3.0"
-msgstr "Creative Commons Attribution-NonCommercial-Share Alike 3.0"
-
-#: static/js/impala/persona_creation.js:84
-msgid "Creative Commons Attribution-NoDerivs 3.0"
-msgstr "Creative Commons Attribution-NoDerivs 3.0"
-
-#: static/js/impala/persona_creation.js:89
-msgid "Creative Commons Attribution-ShareAlike 3.0"
-msgstr "Creative Commons Attribution-ShareAlike 3.0"
-
-#: static/js/impala/persona_creation.js:292
-msgid "Your Theme's Name"
-msgstr "Le nom de votre thème"
-
-#: static/js/impala/reviews.js:23 static/js/zamboni/reviews.js:18
-msgid "Flagged for review"
-msgstr "Étiqueter pour revue"
-
-#: static/js/impala/reviews.js:40 static/js/zamboni/reviews.js:34
-msgid "Your input is required"
-msgstr "Votre avis est demandé"
-
-#: static/js/impala/reviews.js:152 static/js/zamboni/reviews.js:103
-msgid "Marked for deletion"
-msgstr "Marqué pour suppression"
-
-#: static/js/impala/search.js:114
-msgid "Updating results&hellip;"
-msgstr "Mise à jour des résultats &hellip;"
-
-#: static/js/impala/site_suggestions.js:46
-msgid "Category"
-msgstr "Catégorie"
-
-#: static/js/impala/suggestions.js:39
-msgid "Search themes for <b>{0}</b>"
-msgstr "Rechercher des thèmes pour <b>{0}</b>"
-
-#: static/js/impala/suggestions.js:41
-msgid "Search apps for <b>{0}</b>"
-msgstr "Recherche d'applications pour <b>{0}</b>"
-
-#: static/js/impala/suggestions.js:43
-msgid "Search add-ons for <b>{0}</b>"
-msgstr "Recherche de modules pour <b>{0}</b>"
-
-#: static/js/impala/users.js:33
-msgid "use original"
-msgstr "utiliser l'original"
-
-#: static/js/impala/stats/chart.js:267
+#: static/js/impala/stats/chart.js:267 static/js/zamboni/stats-all.js:16898 static/js/zamboni/stats-min.js:5
 msgid "Week of {0}"
 msgstr "Semaine de {0}"
 
-#: static/js/impala/stats/chart.js:269
+#: static/js/impala/stats/chart.js:269 static/js/zamboni/stats-all.js:16900 static/js/zamboni/stats-min.js:5
 msgid " downloads"
-msgstr " téléchargements"
+msgstr ""
 
-#: static/js/impala/stats/chart.js:270
+#: static/js/impala/stats/chart.js:270 static/js/zamboni/stats-all.js:16901 static/js/zamboni/stats-min.js:5
 msgid "{0} users"
 msgstr "{0} utilisateurs"
 
-#: static/js/impala/stats/chart.js:271
+#: static/js/impala/stats/chart.js:271 static/js/zamboni/stats-all.js:16902 static/js/zamboni/stats-min.js:5
 msgid "{0} add-ons"
 msgstr "{0} modules"
 
-#: static/js/impala/stats/chart.js:272
+#: static/js/impala/stats/chart.js:272 static/js/zamboni/stats-all.js:16903 static/js/zamboni/stats-min.js:5
 msgid "{0} collections"
 msgstr "{0} collections"
 
-#: static/js/impala/stats/chart.js:273
+#: static/js/impala/stats/chart.js:273 static/js/zamboni/stats-all.js:16904 static/js/zamboni/stats-min.js:5
 msgid "{0} reviews"
 msgstr "{0} critiques"
 
-#: static/js/impala/stats/chart.js:275
+#: static/js/impala/stats/chart.js:275 static/js/zamboni/stats-all.js:16906 static/js/zamboni/stats-min.js:5
 msgid "{0} sales"
 msgstr "{0} ventes"
 
-#: static/js/impala/stats/chart.js:276
+#: static/js/impala/stats/chart.js:276 static/js/zamboni/stats-all.js:16907 static/js/zamboni/stats-min.js:5
 msgid "{0} refunds"
 msgstr "{0} remboursements"
 
-#: static/js/impala/stats/chart.js:277
+#: static/js/impala/stats/chart.js:277 static/js/zamboni/stats-all.js:16908 static/js/zamboni/stats-min.js:5
 msgid "{0} installs"
 msgstr "{0} installations"
 
-#: static/js/impala/stats/chart.js:369 static/js/impala/stats/csv_keys.js:3 static/js/impala/stats/csv_keys.js:109
+#: static/js/impala/stats/chart.js:369 static/js/impala/stats/csv_keys.js:3 static/js/impala/stats/csv_keys.js:109 static/js/zamboni/stats-all.js:15284 static/js/zamboni/stats-all.js:15390
+#: static/js/zamboni/stats-all.js:17000 static/js/zamboni/stats-min.js:4 static/js/zamboni/stats-min.js:5
 msgid "Downloads"
 msgstr "Téléchargements"
 
-#: static/js/impala/stats/chart.js:379 static/js/impala/stats/csv_keys.js:6 static/js/impala/stats/csv_keys.js:110
+#: static/js/impala/stats/chart.js:379 static/js/impala/stats/csv_keys.js:6 static/js/impala/stats/csv_keys.js:110 static/js/zamboni/stats-all.js:15287 static/js/zamboni/stats-all.js:15391
+#: static/js/zamboni/stats-all.js:17010 static/js/zamboni/stats-min.js:4 static/js/zamboni/stats-min.js:5
 msgid "Daily Users"
 msgstr "Utilisateurs journaliers"
 
-#: static/js/impala/stats/chart.js:410
+#: static/js/impala/stats/chart.js:410 static/js/zamboni/stats-all.js:17041 static/js/zamboni/stats-min.js:5
 msgid "Amount, in USD"
 msgstr "Montant, en dollars US"
 
-#: static/js/impala/stats/chart.js:421 static/js/impala/stats/csv_keys.js:104
+#: static/js/impala/stats/chart.js:421 static/js/impala/stats/csv_keys.js:104 static/js/zamboni/stats-all.js:15385 static/js/zamboni/stats-all.js:17052 static/js/zamboni/stats-min.js:5
 msgid "Number of Contributions"
 msgstr "Nombre de contributions"
 
-#: static/js/impala/stats/chart.js:447
+#: static/js/impala/stats/chart.js:447 static/js/zamboni/stats-all.js:17078 static/js/zamboni/stats-min.js:5
 msgid "More Info..."
 msgstr "Plus d'informations ..."
 
 #. L10n: {0} is an ISO-formatted date.
-#: static/js/impala/stats/chart.js:451
+#: static/js/impala/stats/chart.js:451 static/js/zamboni/stats-all.js:17082 static/js/zamboni/stats-min.js:5
 msgid "Details for {0}"
 msgstr "Détails pour le {0}"
 
-#: static/js/impala/stats/csv_keys.js:9
+#: static/js/impala/stats/csv_keys.js:9 static/js/zamboni/stats-all.js:15290 static/js/zamboni/stats-min.js:4
 msgid "Collections Created"
 msgstr "Collections créées"
 
-#: static/js/impala/stats/csv_keys.js:12
+#: static/js/impala/stats/csv_keys.js:12 static/js/zamboni/stats-all.js:15293 static/js/zamboni/stats-min.js:4
 msgid "Add-ons in Use"
 msgstr "Modules utilisés"
 
-#: static/js/impala/stats/csv_keys.js:15
+#: static/js/impala/stats/csv_keys.js:15 static/js/zamboni/stats-all.js:15296 static/js/zamboni/stats-min.js:4
 msgid "Add-ons Created"
 msgstr "Modules créés"
 
-#: static/js/impala/stats/csv_keys.js:18
+#: static/js/impala/stats/csv_keys.js:18 static/js/zamboni/stats-all.js:15299 static/js/zamboni/stats-min.js:4
 msgid "Add-ons Downloaded"
 msgstr "Modules téléchargés"
 
-#: static/js/impala/stats/csv_keys.js:21
+#: static/js/impala/stats/csv_keys.js:21 static/js/zamboni/stats-all.js:15302 static/js/zamboni/stats-min.js:4
 msgid "Add-ons Updated"
 msgstr "Modules mis à jour"
 
-#: static/js/impala/stats/csv_keys.js:24
+#: static/js/impala/stats/csv_keys.js:24 static/js/zamboni/stats-all.js:15305 static/js/zamboni/stats-min.js:4
 msgid "Reviews Written"
 msgstr "Critiques écrites"
 
-#: static/js/impala/stats/csv_keys.js:27
+#: static/js/impala/stats/csv_keys.js:27 static/js/zamboni/stats-all.js:15308 static/js/zamboni/stats-min.js:4
 msgid "User Signups"
 msgstr "Connexions de l'utilisateur"
 
-#: static/js/impala/stats/csv_keys.js:30
+#: static/js/impala/stats/csv_keys.js:30 static/js/zamboni/stats-all.js:15311 static/js/zamboni/stats-min.js:4
 msgid "Subscribers"
 msgstr "Souscripteurs"
 
-#: static/js/impala/stats/csv_keys.js:33
+#: static/js/impala/stats/csv_keys.js:33 static/js/zamboni/stats-all.js:15314 static/js/zamboni/stats-min.js:4
 msgid "Ratings"
 msgstr "Notes"
 
-#: static/js/impala/stats/csv_keys.js:36 static/js/impala/stats/csv_keys.js:114
+#: static/js/impala/stats/csv_keys.js:36 static/js/impala/stats/csv_keys.js:114 static/js/zamboni/stats-all.js:15317 static/js/zamboni/stats-all.js:15395 static/js/zamboni/stats-min.js:4
+#: static/js/zamboni/stats-min.js:5
 msgid "Sales"
 msgstr "Ventes"
 
-#: static/js/impala/stats/csv_keys.js:39 static/js/impala/stats/csv_keys.js:113
+#: static/js/impala/stats/csv_keys.js:39 static/js/impala/stats/csv_keys.js:113 static/js/zamboni/stats-all.js:15320 static/js/zamboni/stats-all.js:15394 static/js/zamboni/stats-min.js:4
+#: static/js/zamboni/stats-min.js:5
 msgid "Installs"
 msgstr "Installations"
 
-#: static/js/impala/stats/csv_keys.js:42
+#: static/js/impala/stats/csv_keys.js:42 static/js/zamboni/stats-all.js:15323 static/js/zamboni/stats-min.js:4
 msgid "Unknown"
 msgstr "Inconnu"
 
-#: static/js/impala/stats/csv_keys.js:43
+#: static/js/impala/stats/csv_keys.js:43 static/js/zamboni/stats-all.js:15324 static/js/zamboni/stats-min.js:4
 msgid "Add-ons Manager"
 msgstr "Gestionnaire des modules"
 
-#: static/js/impala/stats/csv_keys.js:44
+#: static/js/impala/stats/csv_keys.js:44 static/js/zamboni/stats-all.js:15325 static/js/zamboni/stats-min.js:4
 msgid "Add-ons Manager Promo"
 msgstr "Promu avec le gestionnaire de modules"
 
-#: static/js/impala/stats/csv_keys.js:45
+#: static/js/impala/stats/csv_keys.js:45 static/js/zamboni/stats-all.js:15326 static/js/zamboni/stats-min.js:4
 msgid "Add-ons Manager Featured"
 msgstr "Mis en avant avec le gestionnaire de modules"
 
-#: static/js/impala/stats/csv_keys.js:46
+#: static/js/impala/stats/csv_keys.js:46 static/js/zamboni/stats-all.js:15327 static/js/zamboni/stats-min.js:4
 msgid "Add-ons Manager Learn More"
 msgstr "Affiché dans la section « En savoir plus » du gestionnaire de modules"
 
-#: static/js/impala/stats/csv_keys.js:47
+#: static/js/impala/stats/csv_keys.js:47 static/js/zamboni/stats-all.js:15328 static/js/zamboni/stats-min.js:4
 msgid "Search Suggestions"
 msgstr "Suggestions de recherche"
 
-#: static/js/impala/stats/csv_keys.js:48
+#: static/js/impala/stats/csv_keys.js:48 static/js/zamboni/stats-all.js:15329 static/js/zamboni/stats-min.js:4
 msgid "Search Results"
 msgstr "Résultats de la recherche"
 
-#: static/js/impala/stats/csv_keys.js:49 static/js/impala/stats/csv_keys.js:50 static/js/impala/stats/csv_keys.js:51
+#: static/js/impala/stats/csv_keys.js:49 static/js/impala/stats/csv_keys.js:50 static/js/impala/stats/csv_keys.js:51 static/js/zamboni/stats-all.js:15330 static/js/zamboni/stats-all.js:15331
+#: static/js/zamboni/stats-all.js:15332 static/js/zamboni/stats-min.js:4
 msgid "Homepage Promo"
 msgstr "Promotion en page d'accueil"
 
-#: static/js/impala/stats/csv_keys.js:52 static/js/impala/stats/csv_keys.js:53
+#: static/js/impala/stats/csv_keys.js:52 static/js/impala/stats/csv_keys.js:53 static/js/zamboni/stats-all.js:15333 static/js/zamboni/stats-all.js:15334 static/js/zamboni/stats-min.js:4
 msgid "Homepage Featured"
 msgstr "Vedette en page d'accueil"
 
-#: static/js/impala/stats/csv_keys.js:54 static/js/impala/stats/csv_keys.js:55
+#: static/js/impala/stats/csv_keys.js:54 static/js/impala/stats/csv_keys.js:55 static/js/zamboni/stats-all.js:15335 static/js/zamboni/stats-all.js:15336 static/js/zamboni/stats-min.js:4
 msgid "Homepage Up and Coming"
 msgstr "Nouveautés en page d'accueil"
 
-#: static/js/impala/stats/csv_keys.js:56
+#: static/js/impala/stats/csv_keys.js:56 static/js/zamboni/stats-all.js:15337 static/js/zamboni/stats-min.js:4
 msgid "Homepage Most Popular"
 msgstr "Les plus populaires en page d'accueil"
 
-#: static/js/impala/stats/csv_keys.js:57 static/js/impala/stats/csv_keys.js:59
+#: static/js/impala/stats/csv_keys.js:57 static/js/impala/stats/csv_keys.js:59 static/js/zamboni/stats-all.js:15338 static/js/zamboni/stats-all.js:15340 static/js/zamboni/stats-min.js:4
 msgid "Detail Page"
 msgstr "Page de détail"
 
-#: static/js/impala/stats/csv_keys.js:58 static/js/impala/stats/csv_keys.js:60
+#: static/js/impala/stats/csv_keys.js:58 static/js/impala/stats/csv_keys.js:60 static/js/zamboni/stats-all.js:15339 static/js/zamboni/stats-all.js:15341 static/js/zamboni/stats-min.js:4
 msgid "Detail Page (bottom)"
 msgstr "Page de détail (bas)"
 
-#: static/js/impala/stats/csv_keys.js:61
+#: static/js/impala/stats/csv_keys.js:61 static/js/zamboni/stats-all.js:15342 static/js/zamboni/stats-min.js:4
 msgid "Detail Page (Development Channel)"
 msgstr "Page de détail (canal développement)"
 
-#: static/js/impala/stats/csv_keys.js:62 static/js/impala/stats/csv_keys.js:63 static/js/impala/stats/csv_keys.js:64
+#: static/js/impala/stats/csv_keys.js:62 static/js/impala/stats/csv_keys.js:63 static/js/impala/stats/csv_keys.js:64 static/js/zamboni/stats-all.js:15343 static/js/zamboni/stats-all.js:15344
+#: static/js/zamboni/stats-all.js:15345 static/js/zamboni/stats-min.js:4
 msgid "Often Used With"
 msgstr "Fréquemment utilisé avec"
 
-#: static/js/impala/stats/csv_keys.js:65 static/js/impala/stats/csv_keys.js:66
+#: static/js/impala/stats/csv_keys.js:65 static/js/impala/stats/csv_keys.js:66 static/js/zamboni/stats-all.js:15346 static/js/zamboni/stats-all.js:15347 static/js/zamboni/stats-min.js:4
 msgid "Others By Author"
 msgstr "D'autres de cet auteur"
 
-#: static/js/impala/stats/csv_keys.js:67 static/js/impala/stats/csv_keys.js:68
+#: static/js/impala/stats/csv_keys.js:67 static/js/impala/stats/csv_keys.js:68 static/js/zamboni/stats-all.js:15348 static/js/zamboni/stats-all.js:15349 static/js/zamboni/stats-min.js:4
 msgid "Dependencies"
 msgstr "Dépendances"
 
-#: static/js/impala/stats/csv_keys.js:69 static/js/impala/stats/csv_keys.js:70
+#: static/js/impala/stats/csv_keys.js:69 static/js/impala/stats/csv_keys.js:70 static/js/zamboni/stats-all.js:15350 static/js/zamboni/stats-all.js:15351 static/js/zamboni/stats-min.js:4
 msgid "Upsell"
 msgstr "Montée en gamme"
 
-#: static/js/impala/stats/csv_keys.js:71
+#: static/js/impala/stats/csv_keys.js:71 static/js/zamboni/stats-all.js:15352 static/js/zamboni/stats-min.js:4
 msgid "Meet the Developer"
 msgstr "Rencontrer le développeur"
 
-#: static/js/impala/stats/csv_keys.js:72
+#: static/js/impala/stats/csv_keys.js:72 static/js/zamboni/stats-all.js:15353 static/js/zamboni/stats-min.js:4
 msgid "User Profile"
 msgstr "Profil utilisateur"
 
-#: static/js/impala/stats/csv_keys.js:73
+#: static/js/impala/stats/csv_keys.js:73 static/js/zamboni/stats-all.js:15354 static/js/zamboni/stats-min.js:4
 msgid "Version History"
 msgstr "Historique de versions"
 
-#: static/js/impala/stats/csv_keys.js:75
+#: static/js/impala/stats/csv_keys.js:75 static/js/zamboni/stats-all.js:15356 static/js/zamboni/stats-min.js:4
 msgid "Sharing"
 msgstr "Partage"
 
-#: static/js/impala/stats/csv_keys.js:76
+#: static/js/impala/stats/csv_keys.js:76 static/js/zamboni/stats-all.js:15357 static/js/zamboni/stats-min.js:4
 msgid "Category Pages"
 msgstr "Pages de catégorie"
 
-#: static/js/impala/stats/csv_keys.js:77
+#: static/js/impala/stats/csv_keys.js:77 static/js/zamboni/stats-all.js:15358 static/js/zamboni/stats-min.js:4
 msgid "Collections"
 msgstr "Collections"
 
-#: static/js/impala/stats/csv_keys.js:78 static/js/impala/stats/csv_keys.js:79
+#: static/js/impala/stats/csv_keys.js:78 static/js/impala/stats/csv_keys.js:79 static/js/zamboni/stats-all.js:15359 static/js/zamboni/stats-all.js:15360 static/js/zamboni/stats-min.js:4
 msgid "Category Landing Featured Carousel"
 msgstr "Catégorie d'accueil du caroussel des vedettes"
 
-#: static/js/impala/stats/csv_keys.js:80 static/js/impala/stats/csv_keys.js:81
+#: static/js/impala/stats/csv_keys.js:80 static/js/impala/stats/csv_keys.js:81 static/js/zamboni/stats-all.js:15361 static/js/zamboni/stats-all.js:15362 static/js/zamboni/stats-min.js:4
 msgid "Category Landing Top Rated"
 msgstr "Catégorie d'accueil des mieux notées"
 
-#: static/js/impala/stats/csv_keys.js:82 static/js/impala/stats/csv_keys.js:83
+#: static/js/impala/stats/csv_keys.js:82 static/js/impala/stats/csv_keys.js:83 static/js/zamboni/stats-all.js:15363 static/js/zamboni/stats-all.js:15364 static/js/zamboni/stats-min.js:5
 msgid "Category Landing Most Popular"
 msgstr "Catégorie d'accueil des plus populaires"
 
-#: static/js/impala/stats/csv_keys.js:84 static/js/impala/stats/csv_keys.js:85
+#: static/js/impala/stats/csv_keys.js:84 static/js/impala/stats/csv_keys.js:85 static/js/zamboni/stats-all.js:15365 static/js/zamboni/stats-all.js:15366 static/js/zamboni/stats-min.js:5
 msgid "Category Landing Recently Added"
 msgstr "Catégorie d'accueil des derniers ajouts"
 
-#: static/js/impala/stats/csv_keys.js:86 static/js/impala/stats/csv_keys.js:87
+#: static/js/impala/stats/csv_keys.js:86 static/js/impala/stats/csv_keys.js:87 static/js/zamboni/stats-all.js:15367 static/js/zamboni/stats-all.js:15368 static/js/zamboni/stats-min.js:5
 msgid "Browse Listing Featured Sort"
 msgstr "Parcourir la liste de tri des vedettes"
 
-#: static/js/impala/stats/csv_keys.js:88 static/js/impala/stats/csv_keys.js:89
+#: static/js/impala/stats/csv_keys.js:88 static/js/impala/stats/csv_keys.js:89 static/js/zamboni/stats-all.js:15369 static/js/zamboni/stats-all.js:15370 static/js/zamboni/stats-min.js:5
 msgid "Browse Listing Users Sort"
 msgstr "Parcourir la liste de tri des utilisateurs"
 
-#: static/js/impala/stats/csv_keys.js:90 static/js/impala/stats/csv_keys.js:91
+#: static/js/impala/stats/csv_keys.js:90 static/js/impala/stats/csv_keys.js:91 static/js/zamboni/stats-all.js:15371 static/js/zamboni/stats-all.js:15372 static/js/zamboni/stats-min.js:5
 msgid "Browse Listing Rating Sort"
 msgstr "Parcourir la liste de tri des notes"
 
-#: static/js/impala/stats/csv_keys.js:92 static/js/impala/stats/csv_keys.js:93
+#: static/js/impala/stats/csv_keys.js:92 static/js/impala/stats/csv_keys.js:93 static/js/zamboni/stats-all.js:15373 static/js/zamboni/stats-all.js:15374 static/js/zamboni/stats-min.js:5
 msgid "Browse Listing Created Sort"
 msgstr "Parcourir la liste de tri des créations"
 
-#: static/js/impala/stats/csv_keys.js:94 static/js/impala/stats/csv_keys.js:95
+#: static/js/impala/stats/csv_keys.js:94 static/js/impala/stats/csv_keys.js:95 static/js/zamboni/stats-all.js:15375 static/js/zamboni/stats-all.js:15376 static/js/zamboni/stats-min.js:5
 msgid "Browse Listing Name Sort"
 msgstr "Parcourir la liste de tri des noms"
 
-#: static/js/impala/stats/csv_keys.js:96 static/js/impala/stats/csv_keys.js:97
+#: static/js/impala/stats/csv_keys.js:96 static/js/impala/stats/csv_keys.js:97 static/js/zamboni/stats-all.js:15377 static/js/zamboni/stats-all.js:15378 static/js/zamboni/stats-min.js:5
 msgid "Browse Listing Popular Sort"
 msgstr "Parcourir la liste de tri des populaires"
 
-#: static/js/impala/stats/csv_keys.js:98 static/js/impala/stats/csv_keys.js:99
+#: static/js/impala/stats/csv_keys.js:98 static/js/impala/stats/csv_keys.js:99 static/js/zamboni/stats-all.js:15379 static/js/zamboni/stats-all.js:15380 static/js/zamboni/stats-min.js:5
 msgid "Browse Listing Updated Sort"
 msgstr "Parcourir la liste de tri des mis à jour"
 
-#: static/js/impala/stats/csv_keys.js:100 static/js/impala/stats/csv_keys.js:101
+#: static/js/impala/stats/csv_keys.js:100 static/js/impala/stats/csv_keys.js:101 static/js/zamboni/stats-all.js:15381 static/js/zamboni/stats-all.js:15382 static/js/zamboni/stats-min.js:5
 msgid "Browse Listing Up and Coming Sort"
 msgstr "Parcourir la liste de tri des nouveautés à venir"
 
-#: static/js/impala/stats/csv_keys.js:105
+#: static/js/impala/stats/csv_keys.js:105 static/js/zamboni/stats-all.js:15386 static/js/zamboni/stats-min.js:5
 msgid "Total Amount Contributed"
 msgstr "Montant total contribué"
 
-#: static/js/impala/stats/csv_keys.js:106
+#: static/js/impala/stats/csv_keys.js:106 static/js/zamboni/stats-all.js:15387 static/js/zamboni/stats-min.js:5
 msgid "Average Contribution"
 msgstr "Contribution moyenne"
 
-#: static/js/impala/stats/csv_keys.js:115
+#: static/js/impala/stats/csv_keys.js:115 static/js/zamboni/stats-all.js:15396 static/js/zamboni/stats-min.js:5
 msgid "Usage"
 msgstr "Utilisation"
 
-#: static/js/impala/stats/csv_keys.js:118
+#: static/js/impala/stats/csv_keys.js:118 static/js/zamboni/stats-all.js:15399 static/js/zamboni/stats-min.js:5
 msgid "Firefox"
 msgstr "Firefox"
 
-#: static/js/impala/stats/csv_keys.js:119
+#: static/js/impala/stats/csv_keys.js:119 static/js/zamboni/stats-all.js:15400 static/js/zamboni/stats-min.js:5
 msgid "Mozilla"
 msgstr "Mozilla"
 
-#: static/js/impala/stats/csv_keys.js:120
+#: static/js/impala/stats/csv_keys.js:120 static/js/zamboni/stats-all.js:15401 static/js/zamboni/stats-min.js:5
 msgid "Thunderbird"
 msgstr "Thunderbird"
 
-#: static/js/impala/stats/csv_keys.js:121
+#: static/js/impala/stats/csv_keys.js:121 static/js/zamboni/stats-all.js:15402 static/js/zamboni/stats-min.js:5
 msgid "Sunbird"
 msgstr "Sunbird"
 
-#: static/js/impala/stats/csv_keys.js:122
+#: static/js/impala/stats/csv_keys.js:122 static/js/zamboni/stats-all.js:15403 static/js/zamboni/stats-min.js:5
 msgid "SeaMonkey"
 msgstr "SeaMonkey"
 
-#: static/js/impala/stats/csv_keys.js:123
+#: static/js/impala/stats/csv_keys.js:123 static/js/zamboni/stats-all.js:15404 static/js/zamboni/stats-min.js:5
 msgid "Fennec"
 msgstr "Fennec"
 
-#: static/js/impala/stats/csv_keys.js:124
+#: static/js/impala/stats/csv_keys.js:124 static/js/zamboni/stats-all.js:15405 static/js/zamboni/stats-min.js:5
 msgid "Android"
 msgstr "Android"
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:129
+#: static/js/impala/stats/csv_keys.js:129 static/js/zamboni/stats-all.js:15410 static/js/zamboni/stats-min.js:5
 msgid "Downloads and Daily Users, last {0} days"
 msgstr "Téléchargements et utilisateurs quotidiens, derniers {0} jours"
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:131
+#: static/js/impala/stats/csv_keys.js:131 static/js/zamboni/stats-all.js:15412 static/js/zamboni/stats-min.js:5
 msgid "Downloads and Daily Users from {0} to {1}"
 msgstr "Téléchargements et utilisateurs journaliers du {0} au {1}"
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:135
+#: static/js/impala/stats/csv_keys.js:135 static/js/zamboni/stats-all.js:15416 static/js/zamboni/stats-min.js:5
 msgid "Installs and Daily Users, last {0} days"
 msgstr "Installations et utilisateurs quotidiens, derniers {0} jours"
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:137
+#: static/js/impala/stats/csv_keys.js:137 static/js/zamboni/stats-all.js:15418 static/js/zamboni/stats-min.js:5
 msgid "Installs and Daily Users from {0} to {1}"
 msgstr "Installations et utilisateurs quotidiens du {0} au {1}"
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:141
+#: static/js/impala/stats/csv_keys.js:141 static/js/zamboni/stats-all.js:15422 static/js/zamboni/stats-min.js:5
 msgid "Downloads, last {0} days"
 msgstr "Téléchargements, derniers {0} jours"
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:143
+#: static/js/impala/stats/csv_keys.js:143 static/js/zamboni/stats-all.js:15424 static/js/zamboni/stats-min.js:5
 msgid "Downloads from {0} to {1}"
 msgstr "Téléchargements du {0} au {1}"
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:147
+#: static/js/impala/stats/csv_keys.js:147 static/js/zamboni/stats-all.js:15428 static/js/zamboni/stats-min.js:5
 msgid "Daily Users, last {0} days"
 msgstr "Utilisateurs quotidiens, derniers {0} jours"
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:149
+#: static/js/impala/stats/csv_keys.js:149 static/js/zamboni/stats-all.js:15430 static/js/zamboni/stats-min.js:5
 msgid "Daily Users from {0} to {1}"
 msgstr "Utilisateurs journaliers du {0} au {1}"
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:153
+#: static/js/impala/stats/csv_keys.js:153 static/js/zamboni/stats-all.js:15434 static/js/zamboni/stats-min.js:5
 msgid "Applications, last {0} days"
 msgstr "Applications, derniers {0} jours"
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:155
+#: static/js/impala/stats/csv_keys.js:155 static/js/zamboni/stats-all.js:15436 static/js/zamboni/stats-min.js:5
 msgid "Applications from {0} to {1}"
 msgstr "Applications du {0} au {1}"
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:159
+#: static/js/impala/stats/csv_keys.js:159 static/js/zamboni/stats-all.js:15440 static/js/zamboni/stats-min.js:5
 msgid "Platforms, last {0} days"
 msgstr "Platformes, derniers {0} jours"
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:161
+#: static/js/impala/stats/csv_keys.js:161 static/js/zamboni/stats-all.js:15442 static/js/zamboni/stats-min.js:5
 msgid "Platforms from {0} to {1}"
 msgstr "Plateformes du {0} au {1}"
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:165
+#: static/js/impala/stats/csv_keys.js:165 static/js/zamboni/stats-all.js:15446 static/js/zamboni/stats-min.js:5
 msgid "Languages, last {0} days"
 msgstr "Langages, derniers {0} jours"
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:167
+#: static/js/impala/stats/csv_keys.js:167 static/js/zamboni/stats-all.js:15448 static/js/zamboni/stats-min.js:5
 msgid "Languages from {0} to {1}"
 msgstr "Langages du {0} au {1}"
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:171
+#: static/js/impala/stats/csv_keys.js:171 static/js/zamboni/stats-all.js:15452 static/js/zamboni/stats-min.js:5
 msgid "Add-on Versions, last {0} days"
 msgstr "Versions du module, derniers {0} jours"
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:173
+#: static/js/impala/stats/csv_keys.js:173 static/js/zamboni/stats-all.js:15454 static/js/zamboni/stats-min.js:5
 msgid "Add-on Versions from {0} to {1}"
 msgstr "Versions du module du {0} au {1}"
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:177
+#: static/js/impala/stats/csv_keys.js:177 static/js/zamboni/stats-all.js:15458 static/js/zamboni/stats-min.js:5
 msgid "Add-on Status, last {0} days"
 msgstr "Statut du module, derniers {0} jours"
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:179
+#: static/js/impala/stats/csv_keys.js:179 static/js/zamboni/stats-all.js:15460 static/js/zamboni/stats-min.js:5
 msgid "Add-on Status from {0} to {1}"
 msgstr "Statut du module du {0} au {1}"
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:183
+#: static/js/impala/stats/csv_keys.js:183 static/js/zamboni/stats-all.js:15464 static/js/zamboni/stats-min.js:5
 msgid "Download Sources, last {0} days"
 msgstr "Sources de téléchargement, derniers {0} jours"
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:185
+#: static/js/impala/stats/csv_keys.js:185 static/js/zamboni/stats-all.js:15466 static/js/zamboni/stats-min.js:5
 msgid "Download Sources from {0} to {1}"
 msgstr "Sources de téléchargement du {0} au {1}"
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:189
+#: static/js/impala/stats/csv_keys.js:189 static/js/zamboni/stats-all.js:15470 static/js/zamboni/stats-min.js:5
 msgid "Contributions, last {0} days"
 msgstr "Contributions, derniers {0} jours"
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:191
+#: static/js/impala/stats/csv_keys.js:191 static/js/zamboni/stats-all.js:15472 static/js/zamboni/stats-min.js:5
 msgid "Contributions from {0} to {1}"
 msgstr "Contributions du {0} au {1}"
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:195
+#: static/js/impala/stats/csv_keys.js:195 static/js/zamboni/stats-all.js:15476 static/js/zamboni/stats-min.js:5
 msgid "Site Metrics, last {0} days"
 msgstr "Statistiques du site, derniers {0} jours"
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:197
+#: static/js/impala/stats/csv_keys.js:197 static/js/zamboni/stats-all.js:15478 static/js/zamboni/stats-min.js:5
 msgid "Site Metrics from {0} to {1}"
 msgstr "Statistiques du site du {0} au {1}"
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:201
+#: static/js/impala/stats/csv_keys.js:201 static/js/zamboni/stats-all.js:15482 static/js/zamboni/stats-min.js:5
 msgid "Add-ons in Use, last {0} days"
 msgstr "Modules utilisés, derniers {0} jours"
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:203
+#: static/js/impala/stats/csv_keys.js:203 static/js/zamboni/stats-all.js:15484 static/js/zamboni/stats-min.js:5
 msgid "Add-ons in Use from {0} to {1}"
 msgstr "Modules utilisés du {0} au {1}"
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:207
+#: static/js/impala/stats/csv_keys.js:207 static/js/zamboni/stats-all.js:15488 static/js/zamboni/stats-min.js:5
 msgid "Add-ons Downloaded, last {0} days"
 msgstr "Modules téléchargés, derniers {0} jours"
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:209
+#: static/js/impala/stats/csv_keys.js:209 static/js/zamboni/stats-all.js:15490 static/js/zamboni/stats-min.js:5
 msgid "Add-ons Downloaded from {0} to {1}"
 msgstr "Modules téléchargés du {0} au {1}"
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:213
+#: static/js/impala/stats/csv_keys.js:213 static/js/zamboni/stats-all.js:15494 static/js/zamboni/stats-min.js:5
 msgid "Add-ons Created, last {0} days"
 msgstr "Modules créés, derniers {0} jours"
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:215
+#: static/js/impala/stats/csv_keys.js:215 static/js/zamboni/stats-all.js:15496 static/js/zamboni/stats-min.js:5
 msgid "Add-ons Created from {0} to {1}"
 msgstr "Modules créés du {0} au {1}"
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:219
+#: static/js/impala/stats/csv_keys.js:219 static/js/zamboni/stats-all.js:15500 static/js/zamboni/stats-min.js:5
 msgid "Add-ons Updated, last {0} days"
 msgstr "Modules mis à jour, derniers {0} jours"
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:221
+#: static/js/impala/stats/csv_keys.js:221 static/js/zamboni/stats-all.js:15502 static/js/zamboni/stats-min.js:5
 msgid "Add-ons Updated from {0} to {1}"
 msgstr "Modules mis à jour du {0} au {1}"
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:225
+#: static/js/impala/stats/csv_keys.js:225 static/js/zamboni/stats-all.js:15506 static/js/zamboni/stats-min.js:5
 msgid "Reviews Written, last {0} days"
 msgstr "Critiques écrites, derniers {0} jours"
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:227
+#: static/js/impala/stats/csv_keys.js:227 static/js/zamboni/stats-all.js:15508 static/js/zamboni/stats-min.js:5
 msgid "Reviews Written from {0} to {1}"
 msgstr "Critiques écrites du {0} au {1}"
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:231
+#: static/js/impala/stats/csv_keys.js:231 static/js/zamboni/stats-all.js:15512 static/js/zamboni/stats-min.js:5
 msgid "User Signups, last {0} days"
 msgstr "Connexions de l'utilisateur, derniers {0} jours"
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:233
+#: static/js/impala/stats/csv_keys.js:233 static/js/zamboni/stats-all.js:15514 static/js/zamboni/stats-min.js:5
 msgid "User Signups from {0} to {1}"
 msgstr "Connexions de l'utilisateur du {0} au {1}"
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:237
+#: static/js/impala/stats/csv_keys.js:237 static/js/zamboni/stats-all.js:15518 static/js/zamboni/stats-min.js:5
 msgid "Collections Created, last {0} days"
 msgstr "Collections créées, derniers {0} jours"
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:239
+#: static/js/impala/stats/csv_keys.js:239 static/js/zamboni/stats-all.js:15520 static/js/zamboni/stats-min.js:5
 msgid "Collections Created from {0} to {1}"
 msgstr "Collections créées du {0} au {1}"
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:243
+#: static/js/impala/stats/csv_keys.js:243 static/js/zamboni/stats-all.js:15524 static/js/zamboni/stats-min.js:5
 msgid "Subscribers, last {0} days"
 msgstr "Souscripteurs, derniers {0} jours"
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:245
+#: static/js/impala/stats/csv_keys.js:245 static/js/zamboni/stats-all.js:15526 static/js/zamboni/stats-min.js:5
 msgid "Subscribers from {0} to {1}"
 msgstr "Souscripteurs du {0} au {1}"
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:249
+#: static/js/impala/stats/csv_keys.js:249 static/js/zamboni/stats-all.js:15530 static/js/zamboni/stats-min.js:5
 msgid "Ratings, last {0} days"
 msgstr "Notes, derniers {0} jours"
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:251
+#: static/js/impala/stats/csv_keys.js:251 static/js/zamboni/stats-all.js:15532 static/js/zamboni/stats-min.js:5
 msgid "Ratings from {0} to {1}"
 msgstr "Notes du {0} au {1}"
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:255
+#: static/js/impala/stats/csv_keys.js:255 static/js/zamboni/stats-all.js:15536 static/js/zamboni/stats-min.js:5
 msgid "Sales, last {0} days"
 msgstr "Ventes, derniers {0} jours"
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:257
+#: static/js/impala/stats/csv_keys.js:257 static/js/zamboni/stats-all.js:15538 static/js/zamboni/stats-min.js:5
 msgid "Sales from {0} to {1}"
 msgstr "Ventes du {0} au {1}"
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:261
+#: static/js/impala/stats/csv_keys.js:261 static/js/zamboni/stats-all.js:15542 static/js/zamboni/stats-min.js:5
 msgid "Installs, last {0} days"
 msgstr "Installations, derniers {0} jours"
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:263
+#: static/js/impala/stats/csv_keys.js:263 static/js/zamboni/stats-all.js:15544 static/js/zamboni/stats-min.js:5
 msgid "Installs from {0} to {1}"
 msgstr "Installations du {0} au {1}"
 
 #. L10n: {0} and {1} are integers.
-#: static/js/impala/stats/csv_keys.js:269
+#: static/js/impala/stats/csv_keys.js:269 static/js/zamboni/stats-all.js:15550 static/js/zamboni/stats-min.js:5
 msgid "<b>{0}</b> in last {1} days"
 msgstr "<b>{0}</b> dans les derniers {1} jours"
 
 #. L10n: {0} is an integer and {1} and {2} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:271 static/js/impala/stats/csv_keys.js:277
+#: static/js/impala/stats/csv_keys.js:271 static/js/impala/stats/csv_keys.js:277 static/js/zamboni/stats-all.js:15552 static/js/zamboni/stats-all.js:15558 static/js/zamboni/stats-min.js:5
 msgid "<b>{0}</b> from {1} to {2}"
 msgstr "<b>{0}</b> du {1} au {2}"
 
 #. L10n: {0} and {1} are integers.
-#: static/js/impala/stats/csv_keys.js:275
+#: static/js/impala/stats/csv_keys.js:275 static/js/zamboni/stats-all.js:15556 static/js/zamboni/stats-min.js:5
 msgid "<b>{0}</b> average in last {1} days"
 msgstr "<b>{0}</b> en moyenne les derniers {1} jours"
 
-#: static/js/impala/stats/overview.js:19
+#: static/js/impala/stats/overview.js:19 static/js/zamboni/stats-all.js:16469 static/js/zamboni/stats-min.js:5
 msgid "No data available."
 msgstr "Pas de donnée disponible."
 
-#: static/js/impala/stats/table.js:74
+#: static/js/impala/stats/table.js:74 static/js/zamboni/stats-all.js:17209 static/js/zamboni/stats-min.js:5
 msgid "Date"
 msgstr "Date"
 
-#: static/js/impala/stats/topchart.js:96
+#: static/js/impala/stats/topchart.js:96 static/js/zamboni/stats-all.js:16600 static/js/zamboni/stats-min.js:5
 msgid "Other"
 msgstr "Autre"
 
-#: static/js/zamboni/admin_validation.js:24 static/js/zamboni/devhub.js:1229 static/js/zamboni/editors.js:295
+#: static/js/zamboni/admin-all.js:180 static/js/zamboni/admin-min.js:1 static/js/zamboni/admin_validation.js:24 static/js/zamboni/devhub-all.js:2408 static/js/zamboni/devhub-min.js:2
+#: static/js/zamboni/devhub.js:1229 static/js/zamboni/editors-all.js:15576 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:295
 msgid "Select an application first"
 msgstr "Sélectionnez d'abord une application"
 
-#: static/js/zamboni/admin_validation.js:51
+#: static/js/zamboni/admin-all.js:207 static/js/zamboni/admin-min.js:1 static/js/zamboni/admin_validation.js:51
 msgid "Set {0} add-on to a max version of {1} and email the author."
 msgid_plural "Set {0} add-ons to a max version of {1} and email the authors."
 msgstr[0] "Définir pour le module {0} une version maximale de {1} et envoyer un courriel à l'auteur."
 msgstr[1] "Définir pour les modules {0} une version maximale de {1} et envoyer un courriel aux auteurs."
 
-#: static/js/zamboni/admin_validation.js:54
+#: static/js/zamboni/admin-all.js:210 static/js/zamboni/admin-min.js:1 static/js/zamboni/admin_validation.js:54
 msgid "Email author of {2} add-on which failed validation."
 msgid_plural "Email authors of {2} add-ons which failed validation."
 msgstr[0] "Adresse électronique de l'auteur du module {2} dont la vérification a échoué."
 msgstr[1] "Adresses électroniques des auteurs des modules {2} dont la vérification a échoué."
 
-#. L10n: {0} is an app name like Firefox.
-#: static/js/zamboni/buttons.js:66
-msgid "Accept and Install"
-msgstr "Accepter et installer"
-
-#: static/js/zamboni/buttons.js:66
-msgid "Add to {0}"
-msgstr "Ajouter à {0}"
-
-#: static/js/zamboni/buttons.js:71
-msgid "Download Now"
-msgstr "Télécharger maintenant"
-
-#: static/js/zamboni/buttons.js:112
-msgid "Add-on has not been updated to support default-to-compatible."
-msgstr "Le module n'a pas été mis à jour pour se conformer à default-to-compatible."
-
-#: static/js/zamboni/buttons.js:117
-msgid "You need to be using Firefox 10.0 or higher."
-msgstr "Vous devez utiliser Firefox 10.0 ou plus récent.s"
-
-#: static/js/zamboni/buttons.js:129
-msgid "Mozilla has marked this version as incompatible with your Firefox version."
-msgstr "Mozilla a marqué cette version comme incompatible avec votre version de Firefox."
-
-#. L10n: {0} is an platform like Windows or Linux.
-#: static/js/zamboni/buttons.js:210
-msgid "Install for {0} anyway"
-msgstr "Installer tout de même pour {0}"
-
-#: static/js/zamboni/buttons.js:210
-msgid "Download for {0} anyway"
-msgstr "Télécharger tout de même pour {0}"
-
-#: static/js/zamboni/buttons.js:267
-msgid "Not available for your platform"
-msgstr "Non disponible sur votre plateforme"
-
-#. L10n: {0} is an app name, {1} is the app version.
-#: static/js/zamboni/buttons.js:278 static/js/zamboni/buttons.js:315
-msgid "Not available for {0} {1}"
-msgstr "Non disponible pour {0} {1}"
-
-#: static/js/zamboni/buttons.js:341
-msgid "Works with {app} {min} - {max}"
-msgstr "Fonctionne avec {app} {min} - {max}"
-
-#: static/js/zamboni/buttons.js:343
-msgid "View other versions"
-msgstr "Voir d'autres versions"
-
-#: static/js/zamboni/buttons.js:391
-msgid "Only with Firefox — Get Firefox Now!"
-msgstr "Uniquement disponible sur Firefox — Obtenez Firefox dès maintenant !"
-
-#: static/js/zamboni/buttons.js:507 static/js/zamboni/mobile/buttons.js:43
-msgid "Sorry, you need a Mozilla-based browser (such as Firefox) to install a search plugin."
-msgstr "Désolé, vous devez utiliser un navigateur Mozilla (tel que Firefox) pour installer un moteur de recherche."
-
-#: static/js/zamboni/collections.js:229
-msgid "Adding to Favorites&hellip;"
-msgstr "Ajouter au Favoris &hellip;"
-
-#: static/js/zamboni/collections.js:232
-msgid "Removing Favorite&hellip;"
-msgstr "Retirer des Favoris &hellip;"
-
-#: static/js/zamboni/collections.js:235
-msgid "Add to Favorites"
-msgstr "Ajouter aux favoris"
-
-#: static/js/zamboni/collections.js:238
-msgid "Remove from Favorites"
-msgstr "Supprimer des favoris"
-
-#: static/js/zamboni/collections.js:303
-msgid "Pending"
-msgstr "En attente"
-
-#: static/js/zamboni/collections.js:304
-msgid "Add a comment"
-msgstr "Ajouter un commentaire"
-
-#: static/js/zamboni/collections.js:304
-msgid "Comment"
-msgstr "Commentaire"
-
-#: static/js/zamboni/collections.js:305
-msgid "Remove this add-on from the collection"
-msgstr "Retirer ce module de la collection"
-
-#: static/js/zamboni/collections.js:305 static/js/zamboni/collections.js:334
-msgid "Remove"
-msgstr "Retirer"
-
-#: static/js/zamboni/collections.js:334
-msgid "Remove this user as a contributor"
-msgstr "Retirer cet utilisateur en tant que contributeur"
-
-#: static/js/zamboni/collections.js:346
-msgid "An email address is required."
-msgstr "Une adresse de courriel est nécessaire."
-
-#: static/js/zamboni/collections.js:364
-msgid "You cannot add yourself as a contributor."
-msgstr "Vous ne pouvez pas vous rajouter comme contributeur."
-
-#: static/js/zamboni/collections.js:366
-msgid "You have already added that user."
-msgstr "Vous avez déjà ajouté cet utilisateur."
-
-#: static/js/zamboni/collections.js:573
-msgid "Add to favorites"
-msgstr "Ajouter aux favoris"
-
-#: static/js/zamboni/collections.js:577
-msgid "Remove from favorites"
-msgstr "Supprimer des favoris"
-
-#: static/js/zamboni/collections.js:604
-msgid "Stop following"
-msgstr "Ne plus suivre"
-
-#: static/js/zamboni/devhub.js:110
+#: static/js/zamboni/devhub-all.js:1289 static/js/zamboni/devhub-min.js:1 static/js/zamboni/devhub.js:110
 msgid "Your browser does not support the video tag"
 msgstr "Votre navigateur ne supporte pas la balise vidéo"
 
-#: static/js/zamboni/devhub.js:371
+#: static/js/zamboni/devhub-all.js:1550 static/js/zamboni/devhub-min.js:1 static/js/zamboni/devhub.js:371
 msgid "Changes Saved"
 msgstr "Changements enregistrés"
 
-#: static/js/zamboni/devhub.js:387
+#: static/js/zamboni/devhub-all.js:1566 static/js/zamboni/devhub-min.js:1 static/js/zamboni/devhub.js:387
 msgid "Enter a new author's email address"
 msgstr "Entrer l'adresse courriel d'un nouvel auteur"
 
-#: static/js/zamboni/devhub.js:536
+#: static/js/zamboni/devhub-all.js:1715 static/js/zamboni/devhub-min.js:1 static/js/zamboni/devhub.js:536
 msgid "There was an error uploading your file."
 msgstr "Une erreur est survenue pendant l'envoi de votre fichier."
 
-#: static/js/zamboni/devhub.js:681
+#: static/js/zamboni/devhub-all.js:1860 static/js/zamboni/devhub-min.js:1 static/js/zamboni/devhub.js:681
 msgid "{files} file"
 msgid_plural "{files} files"
 msgstr[0] "{files} fichier"
 msgstr[1] "{files} fichiers"
 
-#: static/js/zamboni/devhub.js:684
+#: static/js/zamboni/devhub-all.js:1863 static/js/zamboni/devhub-min.js:1 static/js/zamboni/devhub.js:684
 msgid "{reviews} user review"
 msgid_plural "{reviews} user reviews"
 msgstr[0] "{reviews} revue utilisateur"
 msgstr[1] "{reviews} revues utilisateur"
 
-#: static/js/zamboni/devhub.js:796
+#: static/js/zamboni/devhub-all.js:1975 static/js/zamboni/devhub-min.js:2 static/js/zamboni/devhub.js:796
 msgid "Learn more"
 msgstr "En savoir plus"
 
-#: static/js/zamboni/devhub.js:800
+#: static/js/zamboni/devhub-all.js:1979 static/js/zamboni/devhub-min.js:2 static/js/zamboni/devhub.js:800
 msgid "Example"
 msgstr "Exemple"
 
-#: static/js/zamboni/devhub.js:1130
+#: static/js/zamboni/devhub-all.js:2309 static/js/zamboni/devhub-min.js:2 static/js/zamboni/devhub.js:1130
 msgid "Image changes being processed"
 msgstr "Changements d'images en cours"
 
-#: static/js/zamboni/devhub.js:1280
+#: static/js/zamboni/devhub-all.js:2459 static/js/zamboni/devhub-min.js:2 static/js/zamboni/devhub.js:1280
 msgid "Must be a valid e-mail address."
 msgstr "Doit être une adresse courriel valide."
 
-#: static/js/zamboni/devhub_search.js:8
-msgid "No results found."
-msgstr "Aucun résultat trouvé."
-
-#: static/js/zamboni/editors.js:121
-msgid "{name} was viewing this page first."
-msgstr "{name} visitait cette page en premier."
-
-#: static/js/zamboni/editors.js:171
-msgid "Receipt checked by app."
-msgstr "Reçu vérifié par l'application."
-
-#: static/js/zamboni/editors.js:173
-msgid "Receipt was not checked by app."
-msgstr "Reçu non vérifié par l'application."
-
-#: static/js/zamboni/editors.js:244
-msgid "{name} was viewing this add-on first."
-msgstr "{name} regardait ce module en premier."
-
-#: static/js/zamboni/editors.js:255
-msgid "Loading&hellip;"
-msgstr "Chargement &hellip;"
-
-#: static/js/zamboni/editors.js:260
-msgid "Version Notes"
-msgstr "Notes de version"
-
-#: static/js/zamboni/editors.js:265
-msgid "Notes for Reviewers"
-msgstr "Notes aux testeurs"
-
-#: static/js/zamboni/editors.js:270
-msgid "No version notes found"
-msgstr "Pas de note de version"
-
-#: static/js/zamboni/editors.js:330
-msgid "Average Reviews"
-msgstr "Revues moyennes"
-
-#: static/js/zamboni/editors.js:386
-msgid "Number of Reviews"
-msgstr "Nombre de revues"
-
-#: static/js/zamboni/editors.js:445
-msgid "Error loading translation"
-msgstr "Erreur au chargement de la traduction"
-
-#: static/js/zamboni/files.js:411 static/js/zamboni/validator.js:261
-msgid "Ignore this message in future updates"
-msgstr "Ignorer ce message lors de futures mises à jour"
-
-#: static/js/zamboni/files.js:417 static/js/zamboni/validator.js:284
-msgid "Severity for automated signing:"
-msgstr "Degré d'acceptation pour la signature automatique :"
-
-#: static/js/zamboni/global.js:410
-msgid "Loading..."
-msgstr "Chargement ..."
-
-#. L10n: {0} is the number of characters left.
-#: static/js/zamboni/global.js:474
-msgid "<b>{0}</b> character left."
-msgid_plural "<b>{0}</b> characters left."
-msgstr[0] "<b>{0}</b> caractère restant."
-msgstr[1] "<b>{0}</b> caractères restants."
-
-#: static/js/zamboni/init.js:28
-msgid "This feature is temporarily disabled while we perform website maintenance. Please check back a little later."
-msgstr "Cette fonctionnalité est désactivée temporairement pendant la maintenance. Merci de revenir un peu plus tard."
-
-#: static/js/zamboni/l10n.js:45
-msgid "Remove this localization"
-msgstr "Retirer cette localisation"
-
-#: static/js/zamboni/password-strength.js:20
-msgid "Password strength:"
-msgstr "Robustesse du mot de passe"
-
-#: static/js/zamboni/password-strength.js:26
-msgid "At least {0} character left."
-msgid_plural "At least {0} characters left."
-msgstr[0] "Au moins {0} caractère manquant."
-msgstr[1] "Au moins {0} caractères manquants."
-
-#: static/js/zamboni/themes_review.js:176
-msgid "Requested Info"
-msgstr "Infos demandées"
-
-#: static/js/zamboni/themes_review.js:177
-msgid "Flagged"
-msgstr "Marqué"
-
-#: static/js/zamboni/themes_review.js:178
-msgid "Duplicate"
-msgstr "Doublon"
-
-#: static/js/zamboni/themes_review.js:179
-msgid "Rejected"
-msgstr "Rejeté"
-
-#: static/js/zamboni/themes_review.js:180
-msgid "Approved"
-msgstr "Approuvé"
-
-#: static/js/zamboni/themes_review.js:424
-msgid "No results found"
-msgstr "Aucun résultat trouvé"
-
-#: static/js/zamboni/themes_review_templates.js:31
-msgid "Theme"
-msgstr "Thème"
-
-#: static/js/zamboni/themes_review_templates.js:33
-msgid "Reviewer"
-msgstr "Réviseur"
-
-#: static/js/zamboni/themes_review_templates.js:35
-msgid "Status"
-msgstr "Statut"
-
-#: static/js/zamboni/validator.js:80
+#: static/js/zamboni/devhub-all.js:2613 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:80
 msgid "All tests passed successfully."
 msgstr "Tous les tests ont été validés avec succès."
 
-#: static/js/zamboni/validator.js:83 static/js/zamboni/validator.js:478
+#: static/js/zamboni/devhub-all.js:2616 static/js/zamboni/devhub-all.js:3011 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:83 static/js/zamboni/validator.js:478
 msgid "These tests were not run."
 msgstr "Ces tests n'ont pas été exécutés."
 
-#: static/js/zamboni/validator.js:131 static/js/zamboni/validator.js:144
+#: static/js/zamboni/devhub-all.js:2664 static/js/zamboni/devhub-all.js:2677 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:131 static/js/zamboni/validator.js:144
 msgid "Tests"
 msgstr "Tests"
 
-#: static/js/zamboni/validator.js:246 static/js/zamboni/validator.js:575 static/js/zamboni/validator.js:594
+#: static/js/zamboni/devhub-all.js:2779 static/js/zamboni/devhub-all.js:3108 static/js/zamboni/devhub-all.js:3127 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:246
+#: static/js/zamboni/validator.js:575 static/js/zamboni/validator.js:594
 msgid "Error"
 msgstr "Erreur"
 
-#: static/js/zamboni/validator.js:247
+#: static/js/zamboni/devhub-all.js:2780 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:247
 msgid "Warning"
 msgstr "Avertissement"
 
-#: static/js/zamboni/validator.js:299
+#: static/js/zamboni/devhub-all.js:2794 static/js/zamboni/devhub-min.js:2 static/js/zamboni/files-all.js:5657 static/js/zamboni/files-min.js:3 static/js/zamboni/files.js:411
+#: static/js/zamboni/validator.js:261
+msgid "Ignore this message in future updates"
+msgstr "Ignorer ce message lors de futures mises à jour"
+
+#: static/js/zamboni/devhub-all.js:2817 static/js/zamboni/devhub-min.js:2 static/js/zamboni/files-all.js:5663 static/js/zamboni/files-min.js:3 static/js/zamboni/files.js:417
+#: static/js/zamboni/validator.js:284
+msgid "Severity for automated signing:"
+msgstr "Degré d'acceptation pour la signature automatique :"
+
+#: static/js/zamboni/devhub-all.js:2832 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:299
 msgid "Suggestions for passing automated signing:"
 msgstr "Suggestions pour obtenir la signature automatique :"
 
-#: static/js/zamboni/validator.js:387
+#: static/js/zamboni/devhub-all.js:2920 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:387
 msgid "Compatibility Tests"
 msgstr "Tests de compatibilité"
 
-#: static/js/zamboni/validator.js:466
+#: static/js/zamboni/devhub-all.js:2999 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:466
 msgid "Add-on failed validation."
 msgstr "Validation du module en échec."
 
-#: static/js/zamboni/validator.js:468
+#: static/js/zamboni/devhub-all.js:3001 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:468
 msgid "Add-on passed validation."
 msgstr "Validation du module réussie."
 
-#: static/js/zamboni/validator.js:481
+#: static/js/zamboni/devhub-all.js:3014 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:481
 msgid "{0} error"
 msgid_plural "{0} errors"
 msgstr[0] "{0} erreur"
 msgstr[1] "{0} erreurs"
 
-#: static/js/zamboni/validator.js:483
+#: static/js/zamboni/devhub-all.js:3016 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:483
 msgid "{0} warning"
 msgid_plural "{0} warnings"
 msgstr[0] "{0} avertissement"
 msgstr[1] "{0} avertissements"
 
-#: static/js/zamboni/validator.js:485
+#: static/js/zamboni/devhub-all.js:3018 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:485
 msgid "{0} notice"
 msgid_plural "{0} notices"
 msgstr[0] "{0} note"
 msgstr[1] "{0} notes"
 
-#: static/js/zamboni/validator.js:577
+#: static/js/zamboni/devhub-all.js:3110 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:577
 msgid "Validation task could not complete or completed with errors"
 msgstr "La validation n'a pas pu s'achever ou s'est achevée avec des erreurs"
 
-#: static/js/zamboni/validator.js:595
+#: static/js/zamboni/devhub-all.js:3128 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:595
 msgid "Internal server error"
 msgstr "Erreur interne du serveur"
 
-#: static/js/zamboni/mobile/buttons.js:52
+#: static/js/zamboni/devhub_search.js:8
+msgid "No results found."
+msgstr "Aucun résultat trouvé."
+
+#: static/js/zamboni/editors-all.js:15402 static/js/zamboni/editors-min.js:4 static/js/zamboni/editors.js:121
+msgid "{name} was viewing this page first."
+msgstr "{name} visitait cette page en premier."
+
+#: static/js/zamboni/editors-all.js:15452 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:171
+msgid "Receipt checked by app."
+msgstr "Reçu vérifié par l'application."
+
+#: static/js/zamboni/editors-all.js:15454 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:173
+msgid "Receipt was not checked by app."
+msgstr "Reçu non vérifié par l'application."
+
+#: static/js/zamboni/editors-all.js:15525 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:244
+msgid "{name} was viewing this add-on first."
+msgstr "{name} regardait ce module en premier."
+
+#: static/js/zamboni/editors-all.js:15536 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:255
+msgid "Loading&hellip;"
+msgstr "Chargement &hellip;"
+
+#: static/js/zamboni/editors-all.js:15541 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:260
+msgid "Version Notes"
+msgstr "Notes de version"
+
+#: static/js/zamboni/editors-all.js:15546 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:265
+msgid "Notes for Reviewers"
+msgstr "Notes aux testeurs"
+
+#: static/js/zamboni/editors-all.js:15551 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:270
+msgid "No version notes found"
+msgstr "Pas de note de version"
+
+#: static/js/zamboni/editors-all.js:15611 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:330
+msgid "Average Reviews"
+msgstr "Revues moyennes"
+
+#: static/js/zamboni/editors-all.js:15667 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:386
+msgid "Number of Reviews"
+msgstr "Nombre de revues"
+
+#: static/js/zamboni/editors-all.js:15726 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:445
+msgid "Error loading translation"
+msgstr "Erreur au chargement de la traduction"
+
+#: static/js/zamboni/editors-all.js:15975 static/js/zamboni/editors-min.js:5 static/js/zamboni/themes_review_templates.js:31
+msgid "Theme"
+msgstr "Thème"
+
+#: static/js/zamboni/editors-all.js:15977 static/js/zamboni/editors-min.js:5 static/js/zamboni/themes_review_templates.js:33
+msgid "Reviewer"
+msgstr "Réviseur"
+
+#: static/js/zamboni/editors-all.js:15979 static/js/zamboni/editors-min.js:5 static/js/zamboni/themes_review_templates.js:35
+msgid "Status"
+msgstr "Statut"
+
+#: static/js/zamboni/editors-all.js:16196 static/js/zamboni/editors-min.js:5 static/js/zamboni/themes_review.js:176
+msgid "Requested Info"
+msgstr "Infos demandées"
+
+#: static/js/zamboni/editors-all.js:16197 static/js/zamboni/editors-min.js:5 static/js/zamboni/themes_review.js:177
+msgid "Flagged"
+msgstr "Marqué"
+
+#: static/js/zamboni/editors-all.js:16198 static/js/zamboni/editors-min.js:5 static/js/zamboni/themes_review.js:178
+msgid "Duplicate"
+msgstr "Doublon"
+
+#: static/js/zamboni/editors-all.js:16199 static/js/zamboni/editors-min.js:5 static/js/zamboni/themes_review.js:179
+msgid "Rejected"
+msgstr "Rejeté"
+
+#: static/js/zamboni/editors-all.js:16200 static/js/zamboni/editors-min.js:5 static/js/zamboni/themes_review.js:180
+msgid "Approved"
+msgstr "Approuvé"
+
+#: static/js/zamboni/editors-all.js:16444 static/js/zamboni/editors-min.js:5 static/js/zamboni/themes_review.js:424
+msgid "No results found"
+msgstr "Aucun résultat trouvé"
+
+#: static/js/zamboni/mobile-all.js:15186 static/js/zamboni/mobile/buttons.js:52
 msgid "Not Updated for {0} {1}"
 msgstr "Non mis à jour pour {0} {1}"
 
-#: static/js/zamboni/mobile/buttons.js:53
+#: static/js/zamboni/mobile-all.js:15187 static/js/zamboni/mobile/buttons.js:53
 msgid "Requires Newer Version of {0}"
 msgstr "Nécessite une nouvelle version de {0}"
 
-#: static/js/zamboni/mobile/buttons.js:54
+#: static/js/zamboni/mobile-all.js:15188 static/js/zamboni/mobile/buttons.js:54
 msgid "Unreviewed"
 msgstr "Non revu"
 
-#: static/js/zamboni/mobile/buttons.js:55
+#: static/js/zamboni/mobile-all.js:15189 static/js/zamboni/mobile/buttons.js:55
 msgid "Experimental <span>(Learn More)</span>"
 msgstr "Expérimental <span>(En savoir plus)</span>"
 
-#: static/js/zamboni/mobile/buttons.js:56 static/js/zamboni/mobile/buttons.js:57
+#: static/js/zamboni/mobile-all.js:15190 static/js/zamboni/mobile-all.js:15191 static/js/zamboni/mobile/buttons.js:56 static/js/zamboni/mobile/buttons.js:57
 msgid "Not Available for {0}"
 msgstr "Indisponible pour {0}"
 
-#: static/js/zamboni/mobile/buttons.js:58
+#: static/js/zamboni/mobile-all.js:15192 static/js/zamboni/mobile/buttons.js:58
 msgid "Experimental"
 msgstr "Expérimental"
 
-#: static/js/zamboni/mobile/buttons.js:59
+#: static/js/zamboni/mobile-all.js:15193 static/js/zamboni/mobile/buttons.js:59
 msgid "Themes Require Newer Version of {0}"
 msgstr "Les thèmes nécessitent une nouvelle version de {0}"
 
-#: static/js/zamboni/mobile/buttons.js:60
+#: static/js/zamboni/mobile-all.js:15194 static/js/zamboni/mobile/buttons.js:60
 msgid "Themes Require {0}"
 msgstr "Les thèmes nécessitent {0}"
 
-#: static/js/zamboni/mobile/buttons.js:105
+#: static/js/zamboni/mobile-all.js:15239 static/js/zamboni/mobile/buttons.js:105
 msgid "Installing..."
 msgstr "Installation ..."
 
-#: static/js/zamboni/mobile/buttons.js:125
+#: static/js/zamboni/mobile-all.js:15259 static/js/zamboni/mobile/buttons.js:125
 msgid "This add-on has been preliminarily reviewed by Mozilla."
 msgstr "Ce module a été revu de manière préliminaire par Mozilla."
 
-#: static/js/zamboni/mobile/buttons.js:250
+#: static/js/zamboni/mobile-all.js:15384 static/js/zamboni/mobile/buttons.js:250
 msgid "Keep it"
 msgstr "Gardez-le"
 
-#: static/js/zamboni/mobile/general.js:344
+#: static/js/zamboni/mobile-all.js:16049 static/js/zamboni/mobile-min.js:6 static/js/zamboni/mobile/general.js:344
 msgid "You're trying it on!"
 msgstr "Vous l'essayez !"
 
-#: static/js/zamboni/mobile/general.js:356
+#: static/js/zamboni/mobile-all.js:16061 static/js/zamboni/mobile-min.js:6 static/js/zamboni/mobile/general.js:356
 msgid "Added to Firefox"
 msgstr "Ajouté à Firefox"
-

--- a/locale/fy_NL/LC_MESSAGES/django.po
+++ b/locale/fy_NL/LC_MESSAGES/django.po
@@ -7,69 +7,70 @@ msgid ""
 msgstr ""
 "Project-Id-Version: REMORA 0.1\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2016-02-24 21:23+0000\n"
+"POT-Creation-Date: 2016-04-18 15:47+0000\n"
 "PO-Revision-Date: 2008-09-22 13:20-0700\n"
 "Last-Translator: Wil Clouser <wclouser@mozilla.com>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
+"Language: \n"
 "MIME-Version: 1.0\n"
-"Content-Type: text/plain; charset=utf-8\n"
+"Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Generated-By: Babel 2.2.0\n"
 
-#: src/olympia/accounts/views.py:52
+#: src/olympia/accounts/views.py:54
 msgid "Your log in attempt could not be parsed. Please try again."
 msgstr ""
 
-#: src/olympia/accounts/views.py:54
+#: src/olympia/accounts/views.py:56
 msgid "Your Firefox Account could not be found. Please try again."
 msgstr ""
 
-#: src/olympia/accounts/views.py:55
+#: src/olympia/accounts/views.py:57
 msgid "You could not be logged in. Please try again."
 msgstr ""
 
-#: src/olympia/accounts/views.py:57
+#: src/olympia/accounts/views.py:59
 msgid "Your account has already been migrated to Firefox Accounts."
 msgstr ""
 
-#: src/olympia/accounts/views.py:59
+#: src/olympia/accounts/views.py:61
 msgid "Your Firefox Account already exists on this site."
 msgstr ""
 
-#: src/olympia/accounts/views.py:108
+#: src/olympia/accounts/views.py:110
 msgid "Great job!"
 msgstr ""
 
-#: src/olympia/accounts/views.py:109
+#: src/olympia/accounts/views.py:111
 msgid "You can now log in to Add-ons with your Firefox Account."
 msgstr ""
 
-#: src/olympia/accounts/views.py:121
+#: src/olympia/accounts/views.py:123
 msgid "Need help?"
 msgstr ""
 
-#: src/olympia/addons/buttons.py:180
+#: src/olympia/addons/buttons.py:177
 msgid "Download Now"
 msgstr ""
 
-#: src/olympia/addons/buttons.py:182
+#: src/olympia/addons/buttons.py:179
 msgid "Download"
 msgstr ""
 
 #. L10n: please keep &nbsp; in the string so &rarr; does not wrap.
-#: src/olympia/addons/buttons.py:186
+#: src/olympia/addons/buttons.py:183
 msgid "Continue to Download&nbsp;&rarr;"
 msgstr ""
 
-#: src/olympia/addons/buttons.py:202 src/olympia/addons/helpers.py:35 src/olympia/addons/views.py:319 src/olympia/addons/templates/addons/impala/details.html:114
+#: src/olympia/addons/buttons.py:199 src/olympia/addons/helpers.py:35 src/olympia/addons/views.py:333 src/olympia/addons/templates/addons/impala/details.html:111
 #: src/olympia/addons/templates/addons/impala/listing/items.html:17 src/olympia/addons/templates/addons/mobile/home.html:40 src/olympia/amo/templates/amo/side_nav.html:6
-#: src/olympia/amo/templates/amo/side_nav.html:10 src/olympia/amo/templates/amo/site_nav.html:2 src/olympia/amo/templates/amo/site_nav.html:55 src/olympia/bandwagon/views.py:95
-#: src/olympia/browse/views.py:54 src/olympia/browse/views.py:68 src/olympia/browse/views.py:235 src/olympia/browse/templates/browse/impala/category_landing.html:22
+#: src/olympia/amo/templates/amo/side_nav.html:10 src/olympia/amo/templates/amo/site_nav.html:2 src/olympia/amo/templates/amo/site_nav.html:53 src/olympia/bandwagon/views.py:95
+#: src/olympia/browse/views.py:54 src/olympia/browse/views.py:68 src/olympia/browse/views.py:202 src/olympia/browse/templates/browse/impala/category_landing.html:22
 #: src/olympia/browse/templates/browse/personas/mobile/category_landing.html:26
 msgid "Featured"
 msgstr ""
 
-#: src/olympia/addons/buttons.py:221
+#: src/olympia/addons/buttons.py:218
 msgid "Add to {0}"
 msgstr ""
 
@@ -117,39 +118,39 @@ msgid_plural "All tags must be at least {0} characters."
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/olympia/addons/forms.py:234
+#: src/olympia/addons/forms.py:238
 msgid "Categories cannot be changed while your add-on is featured for this application."
 msgstr ""
 
 #. L10n: {0} is the number of categories.
-#: src/olympia/addons/forms.py:238
+#: src/olympia/addons/forms.py:242
 msgid "You can have only {0} category."
 msgid_plural "You can have only {0} categories."
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/olympia/addons/forms.py:246
+#: src/olympia/addons/forms.py:250
 msgid "The miscellaneous category cannot be combined with additional categories."
 msgstr ""
 
-#: src/olympia/addons/forms.py:369
+#: src/olympia/addons/forms.py:374
 #, python-format
 msgid "Before changing your default locale you must have a name, summary, and description in that locale. You are missing %s."
 msgstr ""
 
-#: src/olympia/addons/forms.py:484 src/olympia/addons/forms.py:575
+#: src/olympia/addons/forms.py:455 src/olympia/addons/forms.py:546
 msgid "A license must be selected."
 msgstr ""
 
-#: src/olympia/addons/forms.py:556
+#: src/olympia/addons/forms.py:527
 msgid "Give Your Theme a Name."
 msgstr ""
 
-#: src/olympia/addons/forms.py:562 src/olympia/devhub/templates/devhub/personas/submit.html:53
+#: src/olympia/addons/forms.py:533 src/olympia/devhub/templates/devhub/personas/submit.html:53
 msgid "Describe your Theme."
 msgstr ""
 
-#: src/olympia/addons/forms.py:704
+#: src/olympia/addons/forms.py:675
 msgid "Enter a new author's email address"
 msgstr ""
 
@@ -157,43 +158,43 @@ msgstr ""
 msgid "Not Reviewed"
 msgstr ""
 
-#: src/olympia/addons/models.py:301
+#: src/olympia/addons/models.py:298
 #, fuzzy
 msgid "Users have the option of contributing more or less than this amount."
 msgstr "Users have the option of contributing more or less than this amount."
 
-#: src/olympia/addons/models.py:309
-msgid "Users will always be asked in the Add-ons Manager (Firefox 4 and above)"
+#: src/olympia/addons/models.py:306
+msgid "Users will always be asked in the Add-ons Manager (Firefox 4 and above). Only applies to desktop."
 msgstr ""
 
 # Column name in a table.
-#: src/olympia/addons/models.py:1804 src/olympia/addons/templates/addons/details_box.html:55 src/olympia/devhub/templates/devhub/index.html:92
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:102
+#: src/olympia/addons/models.py:1802 src/olympia/addons/templates/addons/details_box.html:55 src/olympia/devhub/templates/devhub/index.html:92
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:89
 #, fuzzy
 msgid "Listed"
 msgstr "Listed"
 
-#: src/olympia/addons/views.py:320 src/olympia/browse/templates/browse/personas/mobile/category_landing.html:27
+#: src/olympia/addons/views.py:334 src/olympia/browse/templates/browse/personas/mobile/category_landing.html:27
 msgid "Popular"
 msgstr ""
 
-#: src/olympia/addons/views.py:321 src/olympia/browse/views.py:238 src/olympia/browse/views.py:280 src/olympia/browse/views.py:482
+#: src/olympia/addons/views.py:335 src/olympia/browse/views.py:205 src/olympia/browse/views.py:247 src/olympia/browse/views.py:449
 #, fuzzy
 msgid "Recently Added"
 msgstr "Recently Added"
 
-#: src/olympia/addons/views.py:322 src/olympia/bandwagon/views.py:99 src/olympia/browse/views.py:60 src/olympia/browse/views.py:71 src/olympia/search/forms.py:16 src/olympia/search/forms.py:91
+#: src/olympia/addons/views.py:336 src/olympia/bandwagon/views.py:99 src/olympia/browse/views.py:60 src/olympia/browse/views.py:71 src/olympia/search/forms.py:16 src/olympia/search/forms.py:91
 msgid "Recently Updated"
 msgstr ""
 
 # %1 is an add-on name.
 #. l10n: {0} is the addon name
-#: src/olympia/addons/views.py:520
+#: src/olympia/addons/views.py:534
 #, fuzzy
 msgid "Contribution for {0}"
 msgstr "Contribution for {0}"
 
-#: src/olympia/addons/views.py:613
+#: src/olympia/addons/views.py:627
 msgid "Abuse reported."
 msgstr ""
 
@@ -265,9 +266,9 @@ msgstr "Contribute"
 #: src/olympia/devhub/templates/devhub/addons/ajax_compat_update.html:36 src/olympia/devhub/templates/devhub/addons/profile.html:44 src/olympia/devhub/templates/devhub/addons/edit/admin.html:101
 #: src/olympia/devhub/templates/devhub/addons/edit/basic.html:152 src/olympia/devhub/templates/devhub/addons/edit/details.html:85 src/olympia/devhub/templates/devhub/addons/edit/support.html:67
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:166 src/olympia/devhub/templates/devhub/addons/forms_shared/media.html:149
-#: src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:44 src/olympia/devhub/templates/devhub/versions/add_file_modal.html:78 src/olympia/devhub/templates/devhub/versions/edit.html:139
-#: src/olympia/devhub/templates/devhub/versions/list.html:242 src/olympia/devhub/templates/devhub/versions/list.html:276 src/olympia/devhub/templates/devhub/versions/list.html:317
-#: src/olympia/devhub/templates/devhub/versions/list.html:351 src/olympia/reviews/templates/reviews/edit_review.html:16 src/olympia/translations/templates/translations/trans-menu.html:50
+#: src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:43 src/olympia/devhub/templates/devhub/versions/add_file_modal.html:58 src/olympia/devhub/templates/devhub/versions/edit.html:139
+#: src/olympia/devhub/templates/devhub/versions/list.html:239 src/olympia/devhub/templates/devhub/versions/list.html:281 src/olympia/devhub/templates/devhub/versions/list.html:315
+#: src/olympia/devhub/templates/devhub/versions/list.html:349 src/olympia/reviews/templates/reviews/edit_review.html:16 src/olympia/translations/templates/translations/trans-menu.html:50
 #: src/olympia/translations/templates/translations/trans-menu.html:62
 #, fuzzy
 msgid "or"
@@ -380,7 +381,7 @@ msgid "Add-on Information for {0}"
 msgstr ""
 
 #: src/olympia/addons/templates/addons/details_box.html:30 src/olympia/addons/templates/addons/persona_detail_table.html:3 src/olympia/addons/templates/addons/mobile/details.html:63
-#: src/olympia/addons/templates/addons/mobile/persona_detail_table.html:7 src/olympia/browse/views.py:459 src/olympia/devhub/views.py:75
+#: src/olympia/addons/templates/addons/mobile/persona_detail_table.html:7 src/olympia/browse/views.py:426 src/olympia/devhub/views.py:73
 #, fuzzy
 msgid "Updated"
 msgstr "Updated"
@@ -401,11 +402,11 @@ msgstr "Works with"
 msgid "Visibility"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/details_box.html:57 src/olympia/devhub/templates/devhub/index.html:94 src/olympia/devhub/templates/devhub/includes/addon_details.html:104
+#: src/olympia/addons/templates/addons/details_box.html:57 src/olympia/devhub/templates/devhub/index.html:94 src/olympia/devhub/templates/devhub/includes/addon_details.html:91
 msgid "Hidden"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/details_box.html:59 src/olympia/devhub/templates/devhub/index.html:96 src/olympia/devhub/templates/devhub/includes/addon_details.html:106
+#: src/olympia/addons/templates/addons/details_box.html:59 src/olympia/devhub/templates/devhub/index.html:96 src/olympia/devhub/templates/devhub/includes/addon_details.html:93
 msgid "Unlisted"
 msgstr ""
 
@@ -413,13 +414,13 @@ msgstr ""
 msgid "Required Add-ons"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/details_box.html:81 src/olympia/addons/templates/addons/persona_detail_table.html:15 src/olympia/browse/views.py:462 src/olympia/devhub/views.py:78
-#: src/olympia/devhub/views.py:85 src/olympia/discovery/templates/discovery/addons/detail.html:57 src/olympia/reviews/forms.py:62 src/olympia/reviews/templates/reviews/add.html:57
+#: src/olympia/addons/templates/addons/details_box.html:81 src/olympia/addons/templates/addons/persona_detail_table.html:15 src/olympia/browse/views.py:429 src/olympia/devhub/views.py:76
+#: src/olympia/devhub/views.py:83 src/olympia/discovery/templates/discovery/addons/detail.html:57 src/olympia/reviews/forms.py:62 src/olympia/reviews/templates/reviews/add.html:57
 #: src/olympia/reviews/templates/reviews/mobile/review_list.html:18
 msgid "Rating"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/details_box.html:85 src/olympia/browse/views.py:461 src/olympia/devhub/views.py:77 src/olympia/devhub/views.py:84
+#: src/olympia/addons/templates/addons/details_box.html:85 src/olympia/browse/views.py:428 src/olympia/devhub/views.py:75 src/olympia/devhub/views.py:82
 #: src/olympia/stats/templates/stats/addon_report_menu.html:8 src/olympia/stats/templates/stats/collection_report_menu.html:18
 msgid "Downloads"
 msgstr ""
@@ -440,7 +441,7 @@ msgstr ""
 
 #. The Privacy Policy for this add-on.
 #: src/olympia/addons/templates/addons/details_box.html:121 src/olympia/addons/templates/addons/privacy.html:19 src/olympia/addons/templates/addons/privacy.html:23
-#: src/olympia/addons/templates/addons/impala/button.html:43 src/olympia/addons/templates/addons/impala/details.html:307 src/olympia/devhub/templates/devhub/includes/policy_form.html:20
+#: src/olympia/addons/templates/addons/impala/button.html:43 src/olympia/addons/templates/addons/impala/details.html:312 src/olympia/devhub/templates/devhub/includes/policy_form.html:23
 #: src/olympia/templates/mobile/base_addons.html:87
 msgid "Privacy Policy"
 msgstr ""
@@ -468,7 +469,7 @@ msgstr "Image Gallery"
 msgid "Developer Comments"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/details_box.html:199 src/olympia/addons/templates/addons/impala/details.html:259
+#: src/olympia/addons/templates/addons/details_box.html:199 src/olympia/addons/templates/addons/impala/details.html:264
 msgid "Development Channel"
 msgstr ""
 
@@ -488,7 +489,7 @@ msgid ""
 "developer. To stop receiving development updates, reinstall the default version from the link above."
 msgstr ""
 
-#: src/olympia/addons/templates/addons/details_box.html:220 src/olympia/addons/templates/addons/impala/details.html:278
+#: src/olympia/addons/templates/addons/details_box.html:220 src/olympia/addons/templates/addons/impala/details.html:283
 msgid "Version {0}:"
 msgstr ""
 
@@ -507,7 +508,7 @@ msgid "End-User License Agreement for {0}"
 msgstr ""
 
 #: src/olympia/addons/templates/addons/eula.html:17 src/olympia/addons/templates/addons/eula.html:21 src/olympia/addons/templates/addons/impala/button.html:48
-#: src/olympia/addons/templates/addons/impala/details.html:316 src/olympia/devhub/templates/devhub/includes/policy_form.html:3 src/olympia/discovery/templates/discovery/addons/eula.html:11
+#: src/olympia/addons/templates/addons/impala/details.html:321 src/olympia/devhub/templates/devhub/includes/policy_form.html:3 src/olympia/discovery/templates/discovery/addons/eula.html:11
 #, fuzzy
 msgid "End-User License Agreement"
 msgstr "End-User License Agreement"
@@ -528,7 +529,7 @@ msgstr ""
 msgid "Add-ons for {0}"
 msgstr "{0} Add-ons"
 
-#: src/olympia/addons/templates/addons/home.html:10 src/olympia/addons/templates/addons/home.html:51 src/olympia/browse/templates/browse/impala/base_listing.html:11
+#: src/olympia/addons/templates/addons/home.html:10 src/olympia/addons/templates/addons/home.html:53 src/olympia/browse/templates/browse/impala/base_listing.html:11
 msgid "Featured Extensions"
 msgstr ""
 
@@ -536,29 +537,29 @@ msgstr ""
 msgid "Popular Extensions"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/home.html:42 src/olympia/amo/templates/amo/side_nav.html:3 src/olympia/amo/templates/amo/side_nav.html:11 src/olympia/amo/templates/amo/site_nav.html:3
-#: src/olympia/amo/templates/amo/site_nav.html:25 src/olympia/browse/views.py:236 src/olympia/browse/views.py:281 src/olympia/browse/views.py:481
+#: src/olympia/addons/templates/addons/home.html:44 src/olympia/amo/templates/amo/side_nav.html:3 src/olympia/amo/templates/amo/side_nav.html:11 src/olympia/amo/templates/amo/site_nav.html:3
+#: src/olympia/amo/templates/amo/site_nav.html:25 src/olympia/browse/views.py:203 src/olympia/browse/views.py:248 src/olympia/browse/views.py:448
 msgid "Most Popular"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/home.html:43
+#: src/olympia/addons/templates/addons/home.html:45
 msgid "All »"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/home.html:52 src/olympia/addons/templates/addons/home.html:61 src/olympia/addons/templates/addons/home.html:70 src/olympia/addons/templates/addons/home.html:78
+#: src/olympia/addons/templates/addons/home.html:54 src/olympia/addons/templates/addons/home.html:63 src/olympia/addons/templates/addons/home.html:72 src/olympia/addons/templates/addons/home.html:80
 #: src/olympia/browse/templates/browse/impala/category_landing.html:36
 msgid "See all »"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/home.html:60
+#: src/olympia/addons/templates/addons/home.html:62
 msgid "Up &amp; Coming Extensions"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/home.html:69 src/olympia/browse/templates/browse/personas/category_landing.html:61 src/olympia/discovery/templates/discovery/pane.html:74
+#: src/olympia/addons/templates/addons/home.html:71 src/olympia/browse/templates/browse/personas/category_landing.html:61 src/olympia/discovery/templates/discovery/pane.html:74
 msgid "Featured Themes"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/home.html:77 src/olympia/bandwagon/templates/bandwagon/impala/collection_listing.html:5
+#: src/olympia/addons/templates/addons/home.html:79 src/olympia/bandwagon/templates/bandwagon/impala/collection_listing.html:5
 msgid "Featured Collections"
 msgstr ""
 
@@ -577,7 +578,7 @@ msgid "Updated {0}"
 msgstr ""
 
 #. {0} is a date.
-#: src/olympia/addons/templates/addons/macros.html:10 src/olympia/addons/templates/addons/macros.html:69 src/olympia/addons/templates/addons/persona_preview.html:21
+#: src/olympia/addons/templates/addons/macros.html:10 src/olympia/addons/templates/addons/macros.html:69 src/olympia/addons/templates/addons/persona_preview.html:22
 #: src/olympia/addons/templates/addons/listing/items_mobile.html:44 src/olympia/addons/templates/addons/listing/macros.html:39
 #: src/olympia/bandwagon/templates/bandwagon/collection_listing_items.html:37 src/olympia/bandwagon/templates/bandwagon/impala/collection_listing_items.html:37
 msgid "Added {0}"
@@ -598,15 +599,14 @@ msgstr[0] ""
 msgstr[1] ""
 
 #. {0} is the number of downloads.
-#: src/olympia/addons/templates/addons/macros.html:53 src/olympia/addons/templates/addons/impala/details.html:61
+#: src/olympia/addons/templates/addons/macros.html:53 src/olympia/addons/templates/addons/impala/details.html:59
 msgid "{0} weekly download"
 msgid_plural "{0} weekly downloads"
 msgstr[0] ""
 msgstr[1] ""
 
 #. {0} is the number of users.
-#: src/olympia/addons/templates/addons/macros.html:61 src/olympia/addons/templates/addons/impala/details.html:54 src/olympia/compat/templates/compat/index.html:71
-#: src/olympia/zadmin/templates/zadmin/compat.html:67
+#: src/olympia/addons/templates/addons/macros.html:61 src/olympia/addons/templates/addons/impala/details.html:52 src/olympia/zadmin/templates/zadmin/compat.html:67
 msgid "{0} user"
 msgid_plural "{0} users"
 msgstr[0] ""
@@ -624,7 +624,7 @@ msgstr ""
 msgid "Return to the addon."
 msgstr ""
 
-#: src/olympia/addons/templates/addons/persona_detail.html:17 src/olympia/addons/templates/addons/impala/details.html:106 src/olympia/addons/templates/addons/mobile/details.html:23
+#: src/olympia/addons/templates/addons/persona_detail.html:17 src/olympia/addons/templates/addons/impala/details.html:103 src/olympia/addons/templates/addons/mobile/details.html:23
 #: src/olympia/addons/templates/addons/mobile/persona_detail.html:21 src/olympia/discovery/templates/discovery/addons/base.html:27 src/olympia/editors/templates/editors/review.html:31
 #, fuzzy
 msgid "by"
@@ -670,34 +670,35 @@ msgstr ""
 msgid "License"
 msgstr "License"
 
-#: src/olympia/addons/templates/addons/persona_preview.html:12 src/olympia/constants/base.py:48
+#: src/olympia/addons/templates/addons/persona_preview.html:13 src/olympia/constants/base.py:48
 msgid "Awaiting Review"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/persona_preview.html:14 src/olympia/amo/log.py:180 src/olympia/constants/base.py:42 src/olympia/editors/helpers.py:62
+#: src/olympia/addons/templates/addons/persona_preview.html:15 src/olympia/amo/log.py:180 src/olympia/constants/base.py:42 src/olympia/editors/helpers.py:62
 msgid "Rejected"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/persona_preview.html:16 src/olympia/amo/log.py:159
+#: src/olympia/addons/templates/addons/persona_preview.html:17 src/olympia/amo/log.py:159
 msgid "Approved"
 msgstr ""
 
 #. {0} is the number of users.
-#: src/olympia/addons/templates/addons/persona_preview.html:26 src/olympia/addons/templates/addons/listing/items_mobile.html:36 src/olympia/addons/templates/addons/listing/macros.html:31
+#: src/olympia/addons/templates/addons/persona_preview.html:27 src/olympia/addons/templates/addons/listing/items_mobile.html:36 src/olympia/addons/templates/addons/listing/macros.html:31
 msgid "<strong>{0}</strong> user"
 msgid_plural "<strong>{0}</strong> users"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/olympia/addons/templates/addons/persona_preview.html:40
+#: src/olympia/addons/templates/addons/persona_preview.html:41
 msgid "Hover to Preview"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/persona_preview.html:46 src/olympia/addons/templates/addons/persona_preview.html:48 src/olympia/reviews/templates/reviews/add.html:15
+#: src/olympia/addons/templates/addons/persona_preview.html:47 src/olympia/addons/templates/addons/persona_preview.html:49 src/olympia/addons/templates/addons/persona_preview.html:97
+#: src/olympia/reviews/templates/reviews/add.html:15
 msgid "Add"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/persona_preview.html:57 src/olympia/bandwagon/templates/bandwagon/ajax_new.html:16 src/olympia/bandwagon/templates/bandwagon/edit.html:19
+#: src/olympia/addons/templates/addons/persona_preview.html:58 src/olympia/bandwagon/templates/bandwagon/ajax_new.html:16 src/olympia/bandwagon/templates/bandwagon/edit.html:19
 #: src/olympia/bandwagon/templates/bandwagon/includes/addedit.html:19 src/olympia/devhub/templates/devhub/addons/edit/admin.html:13 src/olympia/devhub/templates/devhub/addons/edit/basic.html:10
 #: src/olympia/devhub/templates/devhub/addons/edit/details.html:8 src/olympia/devhub/templates/devhub/addons/edit/media.html:6 src/olympia/devhub/templates/devhub/addons/edit/support.html:8
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:9 src/olympia/devhub/templates/devhub/addons/submit/describe.html:29 src/olympia/editors/templates/editors/review.html:257
@@ -706,23 +707,23 @@ msgstr ""
 
 #. For datetime formatting, see the table on
 #. http://docs.python.org/library/datetime.html#strftime-and-strptime-behavior
-#: src/olympia/addons/templates/addons/persona_preview.html:66
+#: src/olympia/addons/templates/addons/persona_preview.html:67
 #, python-format
 msgid "%%Y-%%m-%%d"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/persona_preview.html:67
+#: src/olympia/addons/templates/addons/persona_preview.html:68
 #, fuzzy
 msgid "by {0} on {1}"
 msgstr "by {0} on {1}"
 
-#: src/olympia/addons/templates/addons/persona_preview.html:75 src/olympia/reviews/helpers.py:17 src/olympia/reviews/templates/reviews/review_list.html:63
+#: src/olympia/addons/templates/addons/persona_preview.html:76 src/olympia/reviews/helpers.py:17 src/olympia/reviews/templates/reviews/review_list.html:63
 #: src/olympia/reviews/templates/reviews/reviews_link.html:21 src/olympia/reviews/templates/reviews/impala/reviews_link.html:16
 #, fuzzy
 msgid "Not yet rated"
 msgstr "Not yet rated"
 
-#: src/olympia/addons/templates/addons/persona_preview.html:78
+#: src/olympia/addons/templates/addons/persona_preview.html:79
 msgid "<b>{0}</b> users"
 msgstr ""
 
@@ -735,7 +736,7 @@ msgid "Learn more about Firefox"
 msgstr ""
 
 #: src/olympia/addons/templates/addons/popups.html:22
-msgid "or <b><a class=\"installer\" href=\"{url}\">download anyway</a></b>"
+msgid "or <b><a class=\"button installer\" href=\"{url}\">download anyway</a></b>"
 msgstr ""
 
 #: src/olympia/addons/templates/addons/popups.html:26
@@ -834,7 +835,7 @@ msgid ""
 msgstr ""
 
 #: src/olympia/addons/templates/addons/report_abuse.html:6 src/olympia/addons/templates/addons/report_abuse_full.html:10 src/olympia/addons/templates/addons/impala/details-more.html:23
-#: src/olympia/addons/templates/addons/impala/details.html:328
+#: src/olympia/addons/templates/addons/impala/details.html:333
 msgid "Report Abuse"
 msgstr ""
 
@@ -853,9 +854,9 @@ msgstr ""
 #: src/olympia/devhub/templates/devhub/addons/ajax_compat_update.html:36 src/olympia/devhub/templates/devhub/addons/profile.html:44 src/olympia/devhub/templates/devhub/addons/edit/admin.html:104
 #: src/olympia/devhub/templates/devhub/addons/edit/basic.html:155 src/olympia/devhub/templates/devhub/addons/edit/details.html:88 src/olympia/devhub/templates/devhub/addons/edit/support.html:70
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:169 src/olympia/devhub/templates/devhub/addons/forms_shared/media.html:152
-#: src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:44 src/olympia/devhub/templates/devhub/personas/edit.html:222 src/olympia/devhub/templates/devhub/versions/add_file_modal.html:79
-#: src/olympia/devhub/templates/devhub/versions/edit.html:140 src/olympia/devhub/templates/devhub/versions/list.html:208 src/olympia/devhub/templates/devhub/versions/list.html:242
-#: src/olympia/devhub/templates/devhub/versions/list.html:276 src/olympia/devhub/templates/devhub/versions/list.html:317 src/olympia/reviews/templates/reviews/edit_review.html:16
+#: src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:43 src/olympia/devhub/templates/devhub/personas/edit.html:222 src/olympia/devhub/templates/devhub/versions/add_file_modal.html:59
+#: src/olympia/devhub/templates/devhub/versions/edit.html:140 src/olympia/devhub/templates/devhub/versions/list.html:208 src/olympia/devhub/templates/devhub/versions/list.html:239
+#: src/olympia/devhub/templates/devhub/versions/list.html:281 src/olympia/devhub/templates/devhub/versions/list.html:315 src/olympia/reviews/templates/reviews/edit_review.html:16
 #: src/olympia/translations/templates/translations/trans-menu.html:50 src/olympia/translations/templates/translations/trans-menu.html:62 src/olympia/zadmin/templates/zadmin/validation.html:105
 msgid "Cancel"
 msgstr ""
@@ -905,7 +906,7 @@ msgstr ""
 msgid "Review Guidelines"
 msgstr "Review Guidelines"
 
-#: src/olympia/addons/templates/addons/review_list_box.html:5 src/olympia/addons/templates/addons/impala/details-more.html:27 src/olympia/editors/helpers.py:921
+#: src/olympia/addons/templates/addons/review_list_box.html:5 src/olympia/addons/templates/addons/impala/details-more.html:27 src/olympia/editors/helpers.py:1001
 #: src/olympia/reviews/templates/reviews/add.html:14 src/olympia/reviews/templates/reviews/reply.html:14 src/olympia/reviews/templates/reviews/review_list.html:19
 #: src/olympia/reviews/templates/reviews/mobile/review_list.html:26
 #, fuzzy
@@ -997,31 +998,31 @@ msgid_plural "Other add-ons by these authors"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/olympia/addons/templates/addons/impala/details.html:41
+#: src/olympia/addons/templates/addons/impala/details.html:39
 #, python-format
 msgid "<span itemprop=\"ratingCount\">%(num)s</span> user review"
 msgid_plural "<span itemprop=\"ratingCount\">%(num)s</span> user reviews"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/olympia/addons/templates/addons/impala/details.html:69
+#: src/olympia/addons/templates/addons/impala/details.html:66
 msgid "View statistics"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/impala/details.html:84
+#: src/olympia/addons/templates/addons/impala/details.html:81
 msgid "Manage"
 msgstr ""
 
 #. {0} is an add-on name.
-#: src/olympia/addons/templates/addons/impala/details.html:96
+#: src/olympia/addons/templates/addons/impala/details.html:93
 msgid "Icon of {0}"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/impala/details.html:103 src/olympia/addons/templates/addons/impala/listing/items.html:14
+#: src/olympia/addons/templates/addons/impala/details.html:100 src/olympia/addons/templates/addons/impala/listing/items.html:14
 msgid "No Restart"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/impala/details.html:127
+#: src/olympia/addons/templates/addons/impala/details.html:124
 #, python-format
 msgid "Meet the Developer: <a href=\"%(url)s\">%(name)s</a>"
 msgid_plural "<a href=\"%(url)s\">Meet the Developers</a>"
@@ -1029,90 +1030,90 @@ msgstr[0] ""
 msgstr[1] ""
 
 # {0} is an add-on name.
-#: src/olympia/addons/templates/addons/impala/details.html:137
+#: src/olympia/addons/templates/addons/impala/details.html:134
 #, fuzzy
 msgid "Learn why {0} was created and find out what's next for this add-on."
 msgstr "Learn why {0} was created and find out what's next for this add-on."
 
 #. {0} is an index.
-#: src/olympia/addons/templates/addons/impala/details.html:156
+#: src/olympia/addons/templates/addons/impala/details.html:161
 msgid "Add-on screenshot #{0}"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/impala/details.html:182
+#: src/olympia/addons/templates/addons/impala/details.html:187
 msgid "Add-on home page"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/impala/details.html:185
+#: src/olympia/addons/templates/addons/impala/details.html:190
 msgid "Support site"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/impala/details.html:189
+#: src/olympia/addons/templates/addons/impala/details.html:194
 msgid "Support E-mail"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/impala/details.html:194 src/olympia/devhub/models.py:378 src/olympia/devhub/templates/devhub/versions/list.html:12
+#: src/olympia/addons/templates/addons/impala/details.html:199 src/olympia/devhub/models.py:378 src/olympia/devhub/templates/devhub/versions/list.html:12
 #: src/olympia/versions/templates/versions/version.html:6 src/olympia/versions/templates/versions/mobile/version.html:6
 msgid "Version {0}"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/impala/details.html:194
+#: src/olympia/addons/templates/addons/impala/details.html:199
 msgid "Info"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/impala/details.html:195 src/olympia/devhub/templates/devhub/includes/addon_details.html:129
+#: src/olympia/addons/templates/addons/impala/details.html:200 src/olympia/devhub/templates/devhub/includes/addon_details.html:116
 msgid "Last Updated:"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/impala/details.html:200
+#: src/olympia/addons/templates/addons/impala/details.html:205
 #, python-format
 msgid "Released under <a target=\"_blank\" href=\"%(url)s\">%(name)s</a>"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/impala/details.html:201 src/olympia/addons/templates/addons/impala/details.html:206 src/olympia/amo/helpers.py:398 src/olympia/devhub/forms.py:142
+#: src/olympia/addons/templates/addons/impala/details.html:206 src/olympia/addons/templates/addons/impala/details.html:211 src/olympia/amo/helpers.py:398 src/olympia/devhub/forms.py:142
 #: src/olympia/devhub/forms.py:173 src/olympia/versions/templates/versions/version.html:40 src/olympia/versions/templates/versions/version.html:45
 #, fuzzy
 msgid "Custom License"
 msgstr "Custom License"
 
-#: src/olympia/addons/templates/addons/impala/details.html:205
+#: src/olympia/addons/templates/addons/impala/details.html:210
 #, python-format
 msgid "Released under <a href=\"%(url)s\">%(name)s</a>"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/impala/details.html:217
+#: src/olympia/addons/templates/addons/impala/details.html:222
 msgid "About this Add-on"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/impala/details.html:233
+#: src/olympia/addons/templates/addons/impala/details.html:238
 msgid "Developer’s Comments"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/impala/details.html:243
+#: src/olympia/addons/templates/addons/impala/details.html:248
 msgid "Version Information"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/impala/details.html:250
+#: src/olympia/addons/templates/addons/impala/details.html:255
 msgid "See complete version history"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/impala/details.html:262
+#: src/olympia/addons/templates/addons/impala/details.html:267
 msgid ""
 "The Development Channel lets you test an experimental new version of this add-on before it's released to the general public. Once you install the development version, you will continue to get "
 "updates from this channel. To stop receiving development updates, reinstall the default version from the link above."
 msgstr ""
 
-#: src/olympia/addons/templates/addons/impala/details.html:272
+#: src/olympia/addons/templates/addons/impala/details.html:277
 msgid "<strong>Caution:</strong> Development versions of this add-on have not been reviewed by Mozilla."
 msgstr ""
 
-#: src/olympia/addons/templates/addons/impala/details.html:287
+#: src/olympia/addons/templates/addons/impala/details.html:292
 msgid "See complete development channel history"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/impala/details.html:306 src/olympia/addons/templates/addons/impala/details.html:315 src/olympia/addons/templates/addons/impala/details.html:327
+#: src/olympia/addons/templates/addons/impala/details.html:311 src/olympia/addons/templates/addons/impala/details.html:320 src/olympia/addons/templates/addons/impala/details.html:332
 #: src/olympia/addons/templates/addons/impala/review_add_box.html:4 src/olympia/stats/templates/stats/popup.html:2 src/olympia/stats/templates/stats/popup.html:8
-#: src/olympia/stats/templates/stats/stats.html:202 src/olympia/users/templates/users/profile.html:119
+#: src/olympia/stats/templates/stats/stats.html:204 src/olympia/users/templates/users/profile.html:119
 msgid "close"
 msgstr ""
 
@@ -1176,15 +1177,11 @@ msgstr ""
 msgid "Source Code License"
 msgstr "Source Code License"
 
-#: src/olympia/addons/templates/addons/impala/persona_grid.html:16 src/olympia/addons/templates/addons/impala/toplist.html:6
-msgid "{0} users"
-msgstr ""
-
 #: src/olympia/addons/templates/addons/impala/review_list_box.html:19 src/olympia/reviews/templates/reviews/review.html:40
 msgid "permalink"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/impala/review_list_box.html:23 src/olympia/editors/templates/editors/queue.html:98 src/olympia/reviews/templates/reviews/review.html:44
+#: src/olympia/addons/templates/addons/impala/review_list_box.html:23 src/olympia/editors/templates/editors/queue.html:104 src/olympia/reviews/templates/reviews/review.html:44
 msgid "translate"
 msgstr ""
 
@@ -1203,6 +1200,10 @@ msgstr ""
 msgid "Be the first!"
 msgstr ""
 
+#: src/olympia/addons/templates/addons/impala/toplist.html:6
+msgid "{0} users"
+msgstr ""
+
 #: src/olympia/addons/templates/addons/impala/listing/sorter.html:14 src/olympia/devhub/templates/devhub/addons/listing/item_actions.html:49
 msgid "More"
 msgstr ""
@@ -1216,7 +1217,7 @@ msgstr ""
 msgid "My Add-ons"
 msgstr "My Add-ons"
 
-#: src/olympia/addons/templates/addons/includes/dashboard_tabs.html:6 src/olympia/amo/context_processors.py:51
+#: src/olympia/addons/templates/addons/includes/dashboard_tabs.html:6 src/olympia/amo/context_processors.py:50
 msgid "My Themes"
 msgstr ""
 
@@ -1271,7 +1272,7 @@ msgstr ""
 msgid "Weekly Downloads"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/mobile/details.html:99 src/olympia/compat/templates/compat/reporter_detail.html:46 src/olympia/devhub/forms.py:787
+#: src/olympia/addons/templates/addons/mobile/details.html:99 src/olympia/compat/templates/compat/reporter_detail.html:46 src/olympia/devhub/forms.py:788
 #: src/olympia/devhub/templates/devhub/versions/list.html:163
 #, fuzzy
 msgid "Version"
@@ -1359,7 +1360,7 @@ msgstr ""
 #: src/olympia/browse/templates/browse/personas/category_landing.html:21 src/olympia/browse/templates/browse/personas/category_landing.html:23
 #: src/olympia/browse/templates/browse/personas/category_landing.html:38 src/olympia/browse/templates/browse/personas/grid.html:7 src/olympia/browse/templates/browse/personas/grid.html:11
 #: src/olympia/browse/templates/browse/personas/mobile/base.html:7 src/olympia/browse/templates/browse/personas/mobile/category_landing.html:19 src/olympia/constants/base.py:180
-#: src/olympia/devhub/templates/devhub/personas/submit.html:13 src/olympia/editors/helpers.py:105 src/olympia/editors/templates/editors/base.html:26
+#: src/olympia/devhub/templates/devhub/personas/submit.html:13 src/olympia/editors/helpers.py:107 src/olympia/editors/templates/editors/base.html:26
 #: src/olympia/editors/templates/editors/performance.html:73 src/olympia/search/templates/search/personas.html:39 src/olympia/templates/menu_links.html:9
 msgid "Themes"
 msgstr ""
@@ -1380,7 +1381,7 @@ msgstr ""
 msgid "Highest Rated"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/mobile/home.html:74 src/olympia/amo/templates/amo/side_nav.html:5 src/olympia/amo/templates/amo/site_nav.html:27 src/olympia/amo/templates/amo/site_nav.html:57
+#: src/olympia/addons/templates/addons/mobile/home.html:74 src/olympia/amo/templates/amo/side_nav.html:5 src/olympia/amo/templates/amo/site_nav.html:27 src/olympia/amo/templates/amo/site_nav.html:55
 #: src/olympia/bandwagon/views.py:97 src/olympia/browse/views.py:57 src/olympia/browse/views.py:67 src/olympia/browse/templates/browse/personas/mobile/category_landing.html:65
 #: src/olympia/search/forms.py:15 src/olympia/search/forms.py:87
 msgid "Newest"
@@ -1394,95 +1395,95 @@ msgstr ""
 msgid "Theme Info &raquo;"
 msgstr ""
 
-#: src/olympia/amo/context_processors.py:39 src/olympia/devhub/templates/devhub/nav.html:43
+#: src/olympia/amo/context_processors.py:37 src/olympia/devhub/templates/devhub/nav.html:43
 #, fuzzy
 msgid "Tools"
 msgstr "Tools"
 
-#: src/olympia/amo/context_processors.py:48 src/olympia/discovery/templates/discovery/pane_account.html:8 src/olympia/users/templates/users/includes/navigation.html:2
+#: src/olympia/amo/context_processors.py:47 src/olympia/discovery/templates/discovery/pane_account.html:8 src/olympia/users/templates/users/includes/navigation.html:2
 msgid "My Profile"
 msgstr ""
 
-#: src/olympia/amo/context_processors.py:54 src/olympia/users/templates/users/edit.html:5 src/olympia/users/templates/users/includes/navigation.html:3
+#: src/olympia/amo/context_processors.py:53 src/olympia/users/templates/users/edit.html:5 src/olympia/users/templates/users/includes/navigation.html:3
 msgid "Account Settings"
 msgstr ""
 
-#: src/olympia/amo/context_processors.py:57 src/olympia/discovery/templates/discovery/pane_account.html:11 src/olympia/users/templates/users/profile.html:83
+#: src/olympia/amo/context_processors.py:56 src/olympia/discovery/templates/discovery/pane_account.html:11 src/olympia/users/templates/users/profile.html:83
 #: src/olympia/users/templates/users/includes/navigation.html:4
 #, fuzzy
 msgid "My Collections"
 msgstr "My Collections"
 
-#: src/olympia/amo/context_processors.py:62 src/olympia/discovery/templates/discovery/pane_account.html:10 src/olympia/users/templates/users/includes/navigation.html:7
+#: src/olympia/amo/context_processors.py:61 src/olympia/discovery/templates/discovery/pane_account.html:10 src/olympia/users/templates/users/includes/navigation.html:7
 #, fuzzy
 msgid "My Favorites"
 msgstr "My Favorites"
 
-#: src/olympia/amo/context_processors.py:67 src/olympia/discovery/templates/discovery/pane_account.html:13 src/olympia/templates/impala/user_login.html:14
+#: src/olympia/amo/context_processors.py:66 src/olympia/discovery/templates/discovery/pane_account.html:13 src/olympia/templates/impala/user_login.html:14
 #: src/olympia/templates/mobile/header_auth.html:5
 #, fuzzy
 msgid "Log out"
 msgstr "Log out"
 
-#: src/olympia/amo/context_processors.py:72 src/olympia/devhub/templates/devhub/addons/dashboard.html:4
+#: src/olympia/amo/context_processors.py:71 src/olympia/devhub/templates/devhub/addons/dashboard.html:4
 msgid "Manage My Submissions"
 msgstr ""
 
-#: src/olympia/amo/context_processors.py:75 src/olympia/devhub/templates/devhub/nav.html:27 src/olympia/devhub/templates/devhub/addons/dashboard.html:25
+#: src/olympia/amo/context_processors.py:74 src/olympia/devhub/templates/devhub/nav.html:27 src/olympia/devhub/templates/devhub/addons/dashboard.html:25
 #: src/olympia/devhub/templates/devhub/addons/submit/base.html:4
 msgid "Submit a New Add-on"
 msgstr ""
 
-#: src/olympia/amo/context_processors.py:77 src/olympia/browse/templates/browse/personas/base.html:50 src/olympia/devhub/templates/devhub/index.html:24
+#: src/olympia/amo/context_processors.py:76 src/olympia/browse/templates/browse/personas/base.html:50 src/olympia/devhub/templates/devhub/index.html:24
 #: src/olympia/devhub/templates/devhub/addons/dashboard.html:29
 msgid "Submit a New Theme"
 msgstr ""
 
-#: src/olympia/amo/context_processors.py:79 src/olympia/amo/templates/amo/site_nav.html:87 src/olympia/devhub/helpers.py:36 src/olympia/devhub/helpers.py:68 src/olympia/devhub/helpers.py:102
+#: src/olympia/amo/context_processors.py:78 src/olympia/amo/templates/amo/site_nav.html:85 src/olympia/devhub/helpers.py:36 src/olympia/devhub/helpers.py:68 src/olympia/devhub/helpers.py:102
 #: src/olympia/templates/footer.html:6 src/olympia/templates/menu_links.html:14
 msgid "Developer Hub"
 msgstr ""
 
-#: src/olympia/amo/context_processors.py:83 src/olympia/devhub/views.py:1792
+#: src/olympia/amo/context_processors.py:81 src/olympia/devhub/views.py:1796
 msgid "Manage API Keys"
 msgstr ""
 
-#: src/olympia/amo/context_processors.py:88 src/olympia/editors/helpers.py:82 src/olympia/editors/helpers.py:102 src/olympia/editors/templates/editors/base.html:10
+#: src/olympia/amo/context_processors.py:86 src/olympia/editors/helpers.py:84 src/olympia/editors/helpers.py:104 src/olympia/editors/templates/editors/base.html:10
 msgid "Editor Tools"
 msgstr ""
 
-#: src/olympia/amo/context_processors.py:92
+#: src/olympia/amo/context_processors.py:90
 msgid "Admin Tools"
 msgstr ""
 
-#: src/olympia/amo/fields.py:15
+#: src/olympia/amo/fields.py:20
 msgid "Incorrect, please try again."
 msgstr ""
 
-#: src/olympia/amo/fields.py:16
+#: src/olympia/amo/fields.py:21
 msgid "Error verifying input, please try again."
 msgstr ""
 
-#: src/olympia/amo/fields.py:32
+#: src/olympia/amo/fields.py:37
 msgid "This must be a valid hex color code, such as #000000."
 msgstr ""
 
-#: src/olympia/amo/fields.py:58
+#: src/olympia/amo/fields.py:63
 msgid "Enter at least one value."
 msgstr ""
 
-#: src/olympia/amo/helpers.py:162 src/olympia/amo/templates/amo/site_nav.html:61 src/olympia/bandwagon/templates/bandwagon/add.html:9
+#: src/olympia/amo/helpers.py:162 src/olympia/amo/templates/amo/site_nav.html:59 src/olympia/bandwagon/templates/bandwagon/add.html:9
 #: src/olympia/bandwagon/templates/bandwagon/collection_detail.html:15 src/olympia/bandwagon/templates/bandwagon/delete.html:9 src/olympia/bandwagon/templates/bandwagon/edit.html:15
 #: src/olympia/bandwagon/templates/bandwagon/user_listing.html:18 src/olympia/bandwagon/templates/bandwagon/user_listing.html:21
 #: src/olympia/bandwagon/templates/bandwagon/impala/collection_listing.html:12 src/olympia/bandwagon/templates/bandwagon/impala/collection_listing.html:20
 #: src/olympia/bandwagon/templates/bandwagon/impala/collection_listing.html:24 src/olympia/bandwagon/templates/bandwagon/impala/collection_sidebar.html:3
 #: src/olympia/bandwagon/templates/bandwagon/includes/collection_sidebar.html:2 src/olympia/bandwagon/templates/bandwagon/mobile/collection_listing.html:3
-#: src/olympia/stats/templates/stats/stats.html:77 src/olympia/templates/menu_links.html:12
+#: src/olympia/stats/templates/stats/stats.html:33 src/olympia/templates/menu_links.html:12
 #, fuzzy
 msgid "Collections"
 msgstr "Collections"
 
-#: src/olympia/amo/helpers.py:171 src/olympia/amo/templates/amo/site_nav.html:85 src/olympia/browse/templates/browse/language_tools.html:3
+#: src/olympia/amo/helpers.py:171 src/olympia/amo/templates/amo/site_nav.html:83 src/olympia/browse/templates/browse/language_tools.html:3
 msgid "Dictionaries & Language Packs"
 msgstr ""
 
@@ -1634,8 +1635,8 @@ msgstr ""
 msgid "Comment on {addon} {version}."
 msgstr ""
 
-#: src/olympia/amo/log.py:236 src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:19 src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:47
-#: src/olympia/editors/helpers.py:511 src/olympia/editors/templates/editors/themes/history_table.html:11
+#: src/olympia/amo/log.py:236 src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:17 src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:45
+#: src/olympia/editors/helpers.py:584 src/olympia/editors/templates/editors/themes/history_table.html:11
 msgid "Comment"
 msgstr ""
 
@@ -1959,7 +1960,7 @@ msgstr "Prev"
 #: src/olympia/amo/templates/amo/mobile/paginator.html:14 src/olympia/amo/templates/amo/mobile/paginator.html:16 src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:51
 #: src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:65 src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:78
 #: src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:91 src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:104
-#: src/olympia/discovery/templates/discovery/pane.html:45 src/olympia/discovery/templates/discovery/addons/detail.html:39 src/olympia/stats/templates/stats/stats.html:167
+#: src/olympia/discovery/templates/discovery/pane.html:45 src/olympia/discovery/templates/discovery/addons/detail.html:39 src/olympia/stats/templates/stats/stats.html:169
 #, fuzzy
 msgid "Next"
 msgstr "Next"
@@ -1993,7 +1994,7 @@ msgid ""
 msgstr ""
 
 #: src/olympia/amo/templates/amo/side_nav.html:4 src/olympia/amo/templates/amo/side_nav.html:12 src/olympia/amo/templates/amo/site_nav.html:4 src/olympia/amo/templates/amo/site_nav.html:26
-#: src/olympia/browse/views.py:56 src/olympia/browse/views.py:66 src/olympia/browse/views.py:237 src/olympia/browse/views.py:282 src/olympia/search/forms.py:86
+#: src/olympia/browse/views.py:56 src/olympia/browse/views.py:66 src/olympia/browse/views.py:204 src/olympia/browse/views.py:249 src/olympia/search/forms.py:86
 #, fuzzy
 msgid "Top Rated"
 msgstr "Top Rated"
@@ -2010,38 +2011,38 @@ msgstr ""
 msgid "Extensions"
 msgstr "Extensions"
 
-#: src/olympia/amo/templates/amo/site_nav.html:45
+#: src/olympia/amo/templates/amo/site_nav.html:44
 msgid "Want more customization? Try <b>Complete Themes</b>"
 msgstr ""
 
-#: src/olympia/amo/templates/amo/site_nav.html:56 src/olympia/bandwagon/views.py:96
+#: src/olympia/amo/templates/amo/site_nav.html:54 src/olympia/bandwagon/views.py:96
 msgid "Most Followers"
 msgstr ""
 
-#: src/olympia/amo/templates/amo/site_nav.html:68 src/olympia/bandwagon/templates/bandwagon/impala/collection_sidebar.html:16
+#: src/olympia/amo/templates/amo/site_nav.html:66 src/olympia/bandwagon/templates/bandwagon/impala/collection_sidebar.html:16
 #: src/olympia/bandwagon/templates/bandwagon/includes/collection_sidebar.html:18
 msgid "Collections I've Made"
 msgstr ""
 
-#: src/olympia/amo/templates/amo/site_nav.html:70 src/olympia/bandwagon/templates/bandwagon/user_listing.html:4 src/olympia/bandwagon/templates/bandwagon/impala/collection_sidebar.html:13
+#: src/olympia/amo/templates/amo/site_nav.html:68 src/olympia/bandwagon/templates/bandwagon/user_listing.html:4 src/olympia/bandwagon/templates/bandwagon/impala/collection_sidebar.html:13
 #: src/olympia/bandwagon/templates/bandwagon/includes/collection_sidebar.html:15
 msgid "Collections I'm Following"
 msgstr ""
 
-#: src/olympia/amo/templates/amo/site_nav.html:73 src/olympia/bandwagon/templates/bandwagon/impala/collection_sidebar.html:18
-#: src/olympia/bandwagon/templates/bandwagon/includes/collection_sidebar.html:20 src/olympia/users/models.py:512
+#: src/olympia/amo/templates/amo/site_nav.html:71 src/olympia/bandwagon/templates/bandwagon/impala/collection_sidebar.html:18
+#: src/olympia/bandwagon/templates/bandwagon/includes/collection_sidebar.html:20 src/olympia/users/models.py:521
 msgid "My Favorite Add-ons"
 msgstr ""
 
-#: src/olympia/amo/templates/amo/site_nav.html:78
+#: src/olympia/amo/templates/amo/site_nav.html:76
 msgid "More&hellip;"
 msgstr ""
 
-#: src/olympia/amo/templates/amo/site_nav.html:82
+#: src/olympia/amo/templates/amo/site_nav.html:80
 msgid "Add-ons for Mobile"
 msgstr ""
 
-#: src/olympia/amo/templates/amo/site_nav.html:86 src/olympia/browse/feeds.py:207 src/olympia/browse/templates/browse/search_tools.html:3 src/olympia/constants/base.py:176
+#: src/olympia/amo/templates/amo/site_nav.html:84 src/olympia/browse/feeds.py:207 src/olympia/browse/templates/browse/search_tools.html:3 src/olympia/constants/base.py:176
 #: src/olympia/templates/menu_links.html:10
 msgid "Search Tools"
 msgstr ""
@@ -2057,7 +2058,7 @@ msgid "Jump to first page"
 msgstr ""
 
 #: src/olympia/amo/templates/amo/impala/paginator.html:22 src/olympia/amo/templates/amo/mobile/impala_paginator.html:12 src/olympia/discovery/templates/discovery/pane.html:44
-#: src/olympia/discovery/templates/discovery/addons/detail.html:38 src/olympia/stats/templates/stats/stats.html:164
+#: src/olympia/discovery/templates/discovery/addons/detail.html:38 src/olympia/stats/templates/stats/stats.html:166
 msgid "Previous"
 msgstr ""
 
@@ -2080,30 +2081,49 @@ msgid_plural "Page {n}"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/olympia/amo/templates/services/install.html:38
-#, python-format
-msgid "If you are not prompted to install %(addon_name)s in a moment, please <a href=\"%(addon_xpi)s\">click here</a>."
-msgstr ""
-
-#: src/olympia/amo/tests/test_messages.py:57 src/olympia/amo/tests/test_messages.py:58 src/olympia/reviews/forms.py:25 src/olympia/reviews/forms.py:50 src/olympia/reviews/templates/reviews/add.html:56
+#: src/olympia/amo/tests/test_messages.py:56 src/olympia/amo/tests/test_messages.py:57 src/olympia/reviews/forms.py:25 src/olympia/reviews/forms.py:50 src/olympia/reviews/templates/reviews/add.html:56
 #: src/olympia/reviews/templates/reviews/reply.html:30
 msgid "Title"
 msgstr ""
 
-#: src/olympia/amo/tests/test_messages.py:57 src/olympia/amo/tests/test_messages.py:58
+#: src/olympia/amo/tests/test_messages.py:56 src/olympia/amo/tests/test_messages.py:57
 msgid "Body"
 msgstr ""
 
-#: src/olympia/amo/tests/test_messages.py:59
+#: src/olympia/amo/tests/test_messages.py:58
 msgid "Another Title"
 msgstr ""
 
-#: src/olympia/amo/tests/test_messages.py:59
+#: src/olympia/amo/tests/test_messages.py:58
 msgid "Another Body"
 msgstr ""
 
-#: src/olympia/api/views.py:255
-msgid "Not implemented yet."
+#: src/olympia/api/authentication.py:76
+msgid "Signature has expired."
+msgstr ""
+
+#: src/olympia/api/authentication.py:79
+msgid "Error decoding signature."
+msgstr ""
+
+#: src/olympia/api/authentication.py:82
+msgid "Invalid JWT Token."
+msgstr ""
+
+#: src/olympia/api/authentication.py:130
+msgid "Invalid Authorization header. No credentials provided."
+msgstr ""
+
+#: src/olympia/api/authentication.py:133
+msgid "Invalid Authorization header. Credentials string should not contain spaces."
+msgstr ""
+
+#: src/olympia/api/fields.py:29
+msgid "The field must have a length of at least {num} characters."
+msgstr ""
+
+#: src/olympia/api/fields.py:31
+msgid "The language code {lang_code} is invalid."
 msgstr ""
 
 #: src/olympia/applications/views.py:39 src/olympia/applications/templates/applications/appversions.html:3
@@ -2124,7 +2144,7 @@ msgstr "Valid Application Versions"
 msgid "Add-ons submitted to Mozilla Add-ons must have a manifest file with at least one of the below applications supported. Only the versions listed below are allowed for these applications."
 msgstr ""
 
-#: src/olympia/applications/templates/applications/appversions.html:25
+#: src/olympia/applications/templates/applications/appversions.html:25 src/olympia/editors/helpers.py:361
 #, fuzzy
 msgid "GUID"
 msgstr "GUID"
@@ -2245,8 +2265,8 @@ msgstr ""
 msgid "Remove from favorites"
 msgstr ""
 
-#: src/olympia/bandwagon/views.py:98 src/olympia/bandwagon/views.py:191 src/olympia/browse/views.py:58 src/olympia/browse/views.py:69 src/olympia/browse/views.py:458 src/olympia/devhub/views.py:74
-#: src/olympia/devhub/views.py:82 src/olympia/devhub/templates/devhub/addons/edit/basic.html:20 src/olympia/editors/templates/editors/leaderboard.html:24
+#: src/olympia/bandwagon/views.py:98 src/olympia/bandwagon/views.py:191 src/olympia/browse/views.py:58 src/olympia/browse/views.py:69 src/olympia/browse/views.py:425 src/olympia/devhub/views.py:72
+#: src/olympia/devhub/views.py:80 src/olympia/devhub/templates/devhub/addons/edit/basic.html:20 src/olympia/editors/templates/editors/leaderboard.html:24
 #: src/olympia/editors/templates/editors/themes/queue_list.html:48 src/olympia/search/forms.py:17 src/olympia/search/forms.py:89 src/olympia/users/templates/users/vcard.html:5
 msgid "Name"
 msgstr ""
@@ -2255,7 +2275,7 @@ msgstr ""
 msgid "Recently Popular"
 msgstr ""
 
-#: src/olympia/bandwagon/views.py:189 src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:18
+#: src/olympia/bandwagon/views.py:189 src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:16
 msgid "Added"
 msgstr ""
 
@@ -2269,7 +2289,7 @@ msgstr ""
 
 #: src/olympia/bandwagon/views.py:316
 #, python-format
-msgid "Your new collection is shown below. You can <ahref=\"%(url)s\">edit additional settings</a> if you'dlike."
+msgid "Your new collection is shown below. You can <a href=\"%(url)s\">edit additional settings</a> if you'd like."
 msgstr ""
 
 #: src/olympia/bandwagon/views.py:322
@@ -2398,8 +2418,8 @@ msgid_plural "%(num)s Add-ons in this Collection"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/olympia/bandwagon/templates/bandwagon/collection_detail.html:125 src/olympia/compat/templates/compat/index.html:25 src/olympia/compat/templates/compat/reporter_detail.html:29
-#: src/olympia/files/templates/files/viewer.html:29 src/olympia/templates/amo_footer.html:17 src/olympia/templates/includes/lang_switcher.html:10
+#: src/olympia/bandwagon/templates/bandwagon/collection_detail.html:125 src/olympia/compat/templates/compat/reporter_detail.html:29 src/olympia/files/templates/files/viewer.html:29
+#: src/olympia/templates/amo_footer.html:17 src/olympia/templates/includes/lang_switcher.html:10
 msgid "Go"
 msgstr ""
 
@@ -2572,7 +2592,7 @@ msgid "Remove this user as a contributor"
 msgstr ""
 
 #: src/olympia/bandwagon/templates/bandwagon/edit_contributors.html:18 src/olympia/bandwagon/templates/bandwagon/edit_contributors.html:43
-#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:20 src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:48
+#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:18 src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:46
 #: src/olympia/devhub/templates/devhub/addons/ajax_compat_update.html:19
 msgid "Remove"
 msgstr ""
@@ -2623,7 +2643,7 @@ msgid "<b>Warning:</b> By changing the owner of this collection, you will no lon
 msgstr ""
 
 #: src/olympia/bandwagon/templates/bandwagon/edit_contributors.html:83 src/olympia/devhub/templates/devhub/addons/forms_shared/media.html:157
-#: src/olympia/devhub/templates/devhub/addons/submit/describe.html:69 src/olympia/devhub/templates/devhub/addons/submit/license.html:60 src/olympia/devhub/templates/devhub/addons/submit/upload.html:78
+#: src/olympia/devhub/templates/devhub/addons/submit/describe.html:69 src/olympia/devhub/templates/devhub/addons/submit/license.html:60 src/olympia/devhub/templates/devhub/addons/submit/upload.html:70
 #: src/olympia/devhub/templates/devhub/payments/tier.html:17 src/olympia/editors/templates/editors/themes/themes.html:111 src/olympia/editors/templates/editors/themes/themes.html:128
 #: src/olympia/editors/templates/editors/themes/themes.html:134 src/olympia/editors/templates/editors/themes/themes.html:141 src/olympia/users/templates/users/fxa_migration_prompt_content.html:10
 #: src/olympia/users/templates/users/login_form.html:42 src/olympia/users/templates/users/mobile/login.html:57
@@ -2708,32 +2728,32 @@ msgid "Add-ons in Your Collection"
 msgstr ""
 
 #: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:4
-msgid ""
-"To include an add-on in this collection, enter its name in the box below and hit enter.  You can also use the <strong>Add to Collection</strong> links throughout the site to include add-ons later."
+msgid "To include an add-on in this collection, enter its name in the box below and hit enter."
 msgstr ""
 
-#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:17 src/olympia/constants/base.py:400 src/olympia/devhub/templates/devhub/addons/activity.html:62
+#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:15 src/olympia/constants/base.py:400 src/olympia/devhub/templates/devhub/addons/activity.html:62
+#: src/olympia/editors/helpers.py:273 src/olympia/editors/helpers.py:360
 msgid "Add-on"
 msgstr ""
 
-#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:26
+#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:24
 msgid "Enter the name of the add-on to include"
 msgstr ""
 
-#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:28
+#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:26
 #, fuzzy
 msgid "Add to Collection"
 msgstr "Add to Collection"
 
-#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:45 src/olympia/editors/helpers.py:936 src/olympia/editors/helpers.py:956
+#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:43 src/olympia/editors/helpers.py:1016 src/olympia/editors/helpers.py:1036
 msgid "Pending"
 msgstr ""
 
-#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:47
+#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:45
 msgid "Add a comment"
 msgstr ""
 
-#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:48
+#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:46
 msgid "Remove this add-on from the collection"
 msgstr ""
 
@@ -2840,12 +2860,12 @@ msgstr ""
 msgid "Most Users"
 msgstr ""
 
-#: src/olympia/browse/views.py:61 src/olympia/browse/views.py:72 src/olympia/browse/views.py:279 src/olympia/browse/templates/browse/personas/mobile/category_landing.html:63
+#: src/olympia/browse/views.py:61 src/olympia/browse/views.py:72 src/olympia/browse/views.py:246 src/olympia/browse/templates/browse/personas/mobile/category_landing.html:63
 #: src/olympia/discovery/templates/discovery/pane.html:67 src/olympia/search/forms.py:92
 msgid "Up & Coming"
 msgstr ""
 
-#: src/olympia/browse/views.py:460 src/olympia/devhub/views.py:76 src/olympia/devhub/views.py:83 src/olympia/discovery/templates/discovery/addons/detail.html:66
+#: src/olympia/browse/views.py:427 src/olympia/devhub/views.py:74 src/olympia/devhub/views.py:81 src/olympia/discovery/templates/discovery/addons/detail.html:66
 #, fuzzy
 msgid "Created"
 msgstr "Created"
@@ -3042,8 +3062,8 @@ msgid_plural "See all %(cnt)s extensions in %(name)s &raquo;"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/olympia/browse/templates/browse/mobile/extensions.html:13 src/olympia/compat/templates/compat/index.html:82 src/olympia/devhub/templates/devhub/devhub_search.html:24
-#: src/olympia/devhub/templates/devhub/addons/activity.html:47 src/olympia/search/templates/search/no_results.html:4 src/olympia/search/templates/search/mobile/results.html:36
+#: src/olympia/browse/templates/browse/mobile/extensions.html:13 src/olympia/devhub/templates/devhub/devhub_search.html:24 src/olympia/devhub/templates/devhub/addons/activity.html:47
+#: src/olympia/search/templates/search/no_results.html:4 src/olympia/search/templates/search/mobile/results.html:36
 #, fuzzy
 msgid "No results found."
 msgstr "No results found."
@@ -3130,7 +3150,7 @@ msgstr ""
 msgid "All"
 msgstr ""
 
-#: src/olympia/compat/forms.py:22 src/olympia/search/views.py:525
+#: src/olympia/compat/forms.py:22 src/olympia/editors/templates/editors/base.html:69 src/olympia/search/views.py:518
 msgid "All Add-ons"
 msgstr ""
 
@@ -3140,54 +3160,6 @@ msgstr ""
 
 #: src/olympia/compat/forms.py:24
 msgid "Non-binary"
-msgstr ""
-
-#. Review points sources other than add-ons and themes.
-#: src/olympia/compat/views.py:87 src/olympia/constants/base.py:388 src/olympia/devhub/forms.py:162 src/olympia/editors/templates/editors/performance.html:75
-#, fuzzy
-msgid "Other"
-msgstr "Other"
-
-#: src/olympia/compat/templates/compat/index.html:4
-msgid "Add-on Compatibility Report for {app} {version}"
-msgstr ""
-
-#: src/olympia/compat/templates/compat/index.html:11
-msgid "{app} {version} Compatibility"
-msgstr ""
-
-#: src/olympia/compat/templates/compat/index.html:17
-#, python-format
-msgid "Top 95%% compatible with previous version"
-msgstr ""
-
-#: src/olympia/compat/templates/compat/index.html:18
-#, python-format
-msgid "Top 95%% of all add-ons"
-msgstr ""
-
-#: src/olympia/compat/templates/compat/index.html:19
-msgid "All active add-ons"
-msgstr ""
-
-#: src/olympia/compat/templates/compat/index.html:23 src/olympia/constants/base.py:401
-msgid "App"
-msgstr ""
-
-#: src/olympia/compat/templates/compat/index.html:55
-msgid "Details for add-ons compatible with previous version:"
-msgstr ""
-
-#: src/olympia/compat/templates/compat/index.html:57
-msgid "Show all versions"
-msgstr ""
-
-#: src/olympia/compat/templates/compat/index.html:59
-msgid "Details for add-ons compatible with all versions:"
-msgstr ""
-
-#: src/olympia/compat/templates/compat/index.html:61
-msgid "Show previous version only"
 msgstr ""
 
 #: src/olympia/compat/templates/compat/reporter.html:3
@@ -3241,8 +3213,8 @@ msgstr ""
 msgid "Report Type"
 msgstr ""
 
-#: src/olympia/compat/templates/compat/reporter_detail.html:47 src/olympia/devhub/forms.py:784 src/olympia/devhub/templates/devhub/addons/ajax_compat_update.html:17 src/olympia/editors/forms.py:108
-#: src/olympia/zadmin/forms.py:45
+#: src/olympia/compat/templates/compat/reporter_detail.html:47 src/olympia/devhub/forms.py:785 src/olympia/devhub/templates/devhub/addons/ajax_compat_update.html:17 src/olympia/editors/forms.py:108
+#: src/olympia/editors/forms.py:248 src/olympia/zadmin/forms.py:45
 msgid "Application"
 msgstr ""
 
@@ -3335,7 +3307,8 @@ msgstr ""
 msgid "Preliminarily Reviewed and Awaiting Full Review"
 msgstr ""
 
-#: src/olympia/constants/base.py:33 src/olympia/editors/helpers.py:924 src/olympia/editors/templates/editors/themes/history_table.html:34
+#: src/olympia/constants/base.py:33 src/olympia/editors/forms.py:258 src/olympia/editors/helpers.py:73 src/olympia/editors/helpers.py:1004
+#: src/olympia/editors/templates/editors/themes/history_table.html:34
 msgid "Deleted"
 msgstr ""
 
@@ -3444,6 +3417,12 @@ msgstr ""
 msgid "Ask before users can download this add-on"
 msgstr ""
 
+#. Review points sources other than add-ons and themes.
+#: src/olympia/constants/base.py:388 src/olympia/devhub/forms.py:162 src/olympia/editors/templates/editors/performance.html:75
+#, fuzzy
+msgid "Other"
+msgstr "Other"
+
 #: src/olympia/constants/base.py:389
 msgid "Exception"
 msgstr ""
@@ -3454,6 +3433,10 @@ msgstr ""
 
 #: src/olympia/constants/base.py:391
 msgid "Change"
+msgstr ""
+
+#: src/olympia/constants/base.py:401
+msgid "App"
 msgstr ""
 
 #: src/olympia/constants/base.py:402
@@ -3604,7 +3587,7 @@ msgstr ""
 msgid "Duplicate"
 msgstr ""
 
-#: src/olympia/constants/editors.py:17 src/olympia/editors/helpers.py:502 src/olympia/editors/templates/editors/themes/queue.html:71 src/olympia/editors/templates/editors/themes/themes.html:94
+#: src/olympia/constants/editors.py:17 src/olympia/editors/helpers.py:575 src/olympia/editors/templates/editors/themes/queue.html:71 src/olympia/editors/templates/editors/themes/themes.html:94
 msgid "Reject"
 msgstr ""
 
@@ -3704,7 +3687,7 @@ msgstr ""
 msgid "Android"
 msgstr ""
 
-#: src/olympia/core/apps.py:19
+#: src/olympia/core/apps.py:21
 msgid "Core"
 msgstr ""
 
@@ -3839,7 +3822,7 @@ msgid "Submit my add-on for manual review."
 msgstr ""
 
 #: src/olympia/devhub/forms.py:537
-msgid "Do not list my add-on on this site (beta)"
+msgid "Do not list my add-on on this site"
 msgstr ""
 
 #: src/olympia/devhub/forms.py:538
@@ -3872,46 +3855,46 @@ msgstr ""
 
 #: src/olympia/devhub/forms.py:592
 #, python-format
-msgid "Version %s already exists"
+msgid "Version %s already exists, or was uploaded before."
 msgstr ""
 
-#: src/olympia/devhub/forms.py:604
+#: src/olympia/devhub/forms.py:605
 msgid "Select a valid choice. That choice is not one of the available choices."
 msgstr ""
 
-#: src/olympia/devhub/forms.py:610
+#: src/olympia/devhub/forms.py:611
 msgid "A file with a version ending with a|alpha|b|beta and an optional number is detected as beta."
 msgstr ""
 
-#: src/olympia/devhub/forms.py:633
+#: src/olympia/devhub/forms.py:634
 msgid "You cannot upload any more files for this version."
 msgstr ""
 
-#: src/olympia/devhub/forms.py:639
+#: src/olympia/devhub/forms.py:640
 msgid "Version doesn't match"
 msgstr ""
 
-#: src/olympia/devhub/forms.py:668
+#: src/olympia/devhub/forms.py:669
 msgid "You cannot delete a file once the review process has started.  You must delete the whole version."
 msgstr ""
 
-#: src/olympia/devhub/forms.py:688
+#: src/olympia/devhub/forms.py:689
 msgid "The platform All cannot be combined with specific platforms."
 msgstr ""
 
-#: src/olympia/devhub/forms.py:693
+#: src/olympia/devhub/forms.py:694
 msgid "A platform can only be chosen once."
 msgstr ""
 
-#: src/olympia/devhub/forms.py:706
+#: src/olympia/devhub/forms.py:707
 msgid "A review type must be selected."
 msgstr ""
 
-#: src/olympia/devhub/forms.py:788 src/olympia/editors/forms.py:114 src/olympia/zadmin/forms.py:49 src/olympia/zadmin/forms.py:52
+#: src/olympia/devhub/forms.py:789 src/olympia/editors/forms.py:114 src/olympia/editors/forms.py:254 src/olympia/zadmin/forms.py:49 src/olympia/zadmin/forms.py:52
 msgid "Select an application first"
 msgstr ""
 
-#: src/olympia/devhub/forms.py:840
+#: src/olympia/devhub/forms.py:841
 msgid "There cannot be more than 3 required add-ons."
 msgstr ""
 
@@ -3950,76 +3933,76 @@ msgstr[1] "{0} warnings"
 msgid "Review"
 msgstr "Review"
 
-#: src/olympia/devhub/tasks.py:551
+#: src/olympia/devhub/tasks.py:583
 #, python-format
 msgid "%s responded with %s (%s)."
 msgstr ""
 
-#: src/olympia/devhub/tasks.py:555
+#: src/olympia/devhub/tasks.py:587
 #, python-format
 msgid "Connection to \"%s\" timed out."
 msgstr ""
 
-#: src/olympia/devhub/tasks.py:557
+#: src/olympia/devhub/tasks.py:589
 #, python-format
 msgid "Could not contact host at \"%s\"."
 msgstr ""
 
-#: src/olympia/devhub/utils.py:104
+#: src/olympia/devhub/utils.py:105
 #, python-format
 msgid "Validation generated too many errors/warnings so %s messages were truncated. After addressing the visible messages, you'll be able to see the others."
 msgstr ""
 
-#: src/olympia/devhub/views.py:183
+#: src/olympia/devhub/views.py:181
 msgid "All My Add-ons"
 msgstr ""
 
-#: src/olympia/devhub/views.py:210
+#: src/olympia/devhub/views.py:208
 msgid "All Activity"
 msgstr ""
 
-#: src/olympia/devhub/views.py:211
+#: src/olympia/devhub/views.py:209
 msgid "Add-on Updates"
 msgstr ""
 
-#: src/olympia/devhub/views.py:212
+#: src/olympia/devhub/views.py:210
 msgid "Add-on Status"
 msgstr ""
 
-#: src/olympia/devhub/views.py:213
+#: src/olympia/devhub/views.py:211
 msgid "User Collections"
 msgstr ""
 
-#: src/olympia/devhub/views.py:214 src/olympia/devhub/templates/devhub/docs/policies-maintenance.html:68 src/olympia/pages/templates/pages/dev_faq.html:38
+#: src/olympia/devhub/views.py:212 src/olympia/devhub/templates/devhub/docs/policies-maintenance.html:68 src/olympia/pages/templates/pages/dev_faq.html:38
 #: src/olympia/pages/templates/pages/dev_faq.html:484
 msgid "User Reviews"
 msgstr ""
 
-#: src/olympia/devhub/views.py:327 src/olympia/devhub/views.py:331 src/olympia/devhub/views.py:484 src/olympia/devhub/views.py:513 src/olympia/devhub/views.py:564 src/olympia/devhub/views.py:1150
+#: src/olympia/devhub/views.py:325 src/olympia/devhub/views.py:329 src/olympia/devhub/views.py:484 src/olympia/devhub/views.py:513 src/olympia/devhub/views.py:564 src/olympia/devhub/views.py:1156
 msgid "Changes successfully saved."
 msgstr ""
 
-#: src/olympia/devhub/views.py:334 src/olympia/devhub/views.py:1631
+#: src/olympia/devhub/views.py:332 src/olympia/devhub/views.py:1637
 msgid "Please check the form for errors."
 msgstr ""
 
-#: src/olympia/devhub/views.py:346
+#: src/olympia/devhub/views.py:344
 msgid "Add-on cannot be deleted. Disable this add-on instead."
 msgstr ""
 
-#: src/olympia/devhub/views.py:356
+#: src/olympia/devhub/views.py:354
 msgid "Theme deleted."
 msgstr ""
 
-#: src/olympia/devhub/views.py:356
+#: src/olympia/devhub/views.py:354
 msgid "Add-on deleted."
 msgstr ""
 
-#: src/olympia/devhub/views.py:362
+#: src/olympia/devhub/views.py:360
 msgid "URL name was incorrect. Theme was not deleted."
 msgstr ""
 
-#: src/olympia/devhub/views.py:367
+#: src/olympia/devhub/views.py:365
 msgid "URL name was incorrect. Add-on was not deleted."
 msgstr ""
 
@@ -4047,7 +4030,7 @@ msgstr ""
 msgid "Check Add-on Compatibility"
 msgstr ""
 
-#: src/olympia/devhub/views.py:808 src/olympia/signing/views.py:90
+#: src/olympia/devhub/views.py:808 src/olympia/signing/views.py:95
 msgid "You cannot submit this type of add-on"
 msgstr ""
 
@@ -4077,33 +4060,33 @@ msgstr ""
 msgid "There was an error uploading your preview."
 msgstr ""
 
-#: src/olympia/devhub/views.py:1189
+#: src/olympia/devhub/views.py:1195
 #, python-format
 msgid "Version %s disabled."
 msgstr ""
 
-#: src/olympia/devhub/views.py:1193
+#: src/olympia/devhub/views.py:1199
 #, python-format
 msgid "Version %s deleted."
 msgstr ""
 
-#: src/olympia/devhub/views.py:1203
+#: src/olympia/devhub/views.py:1209
 msgid "This upload has failed validation, and may lack complete validation results. Please take due care when reviewing it."
 msgstr ""
 
-#: src/olympia/devhub/views.py:1677
+#: src/olympia/devhub/views.py:1683
 msgid "Preliminary Review Requested."
 msgstr ""
 
-#: src/olympia/devhub/views.py:1678
+#: src/olympia/devhub/views.py:1684
 msgid "Full Review Requested."
 msgstr ""
 
-#: src/olympia/devhub/views.py:1779
+#: src/olympia/devhub/views.py:1783
 msgid "Your old credentials were revoked and are no longer valid. Be sure to update all API clients with the new credentials."
 msgstr ""
 
-#: src/olympia/devhub/views.py:1797
+#: src/olympia/devhub/views.py:1801
 msgid "New API key created"
 msgstr ""
 
@@ -4133,7 +4116,7 @@ msgstr ""
 msgid "{0} :: Search"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/devhub_search.html:6 src/olympia/devhub/templates/devhub/search.html:8 src/olympia/editors/forms.py:435 src/olympia/editors/forms.py:437
+#: src/olympia/devhub/templates/devhub/devhub_search.html:6 src/olympia/devhub/templates/devhub/search.html:8 src/olympia/editors/forms.py:534 src/olympia/editors/forms.py:536
 #: src/olympia/editors/templates/editors/queue.html:27 src/olympia/editors/templates/editors/themes/queue_list.html:14 src/olympia/search/templates/search/collections.html:17
 #: src/olympia/search/templates/search/personas.html:18 src/olympia/search/templates/search/results.html:18 src/olympia/search/templates/search/mobile/results.html:8
 #: src/olympia/templates/search.html:14 src/olympia/templates/impala/search.html:18
@@ -4194,12 +4177,12 @@ msgstr ""
 msgid "Start Making Add-ons"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/index.html:86 src/olympia/devhub/templates/devhub/addons/listing/items.html:25 src/olympia/devhub/templates/devhub/includes/addon_details.html:15
+#: src/olympia/devhub/templates/devhub/index.html:86 src/olympia/devhub/templates/devhub/addons/listing/items.html:25 src/olympia/devhub/templates/devhub/includes/addon_details.html:20
 #: src/olympia/devhub/templates/devhub/personas/edit.html:43
 msgid "Status:"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/index.html:90 src/olympia/devhub/templates/devhub/includes/addon_details.html:100
+#: src/olympia/devhub/templates/devhub/index.html:90 src/olympia/devhub/templates/devhub/includes/addon_details.html:87
 msgid "Visibility:"
 msgstr ""
 
@@ -4207,11 +4190,11 @@ msgstr ""
 msgid "Latest Version:"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/index.html:109 src/olympia/devhub/templates/devhub/includes/addon_details.html:145 src/olympia/devhub/templates/devhub/personas/edit.html:49
+#: src/olympia/devhub/templates/devhub/index.html:109 src/olympia/devhub/templates/devhub/includes/addon_details.html:131 src/olympia/devhub/templates/devhub/personas/edit.html:49
 msgid "Queue Position:"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/index.html:110 src/olympia/devhub/templates/devhub/includes/addon_details.html:146 src/olympia/devhub/templates/devhub/personas/edit.html:50
+#: src/olympia/devhub/templates/devhub/index.html:110 src/olympia/devhub/templates/devhub/includes/addon_details.html:132 src/olympia/devhub/templates/devhub/personas/edit.html:50
 #, python-format
 msgid "%(position)s of %(total)s"
 msgstr ""
@@ -4313,16 +4296,6 @@ msgstr ""
 msgid "Do you want your add-on to be distributed on this site?"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/validate_addon.html:49 src/olympia/devhub/templates/devhub/addons/submit/upload.html:30 src/olympia/devhub/templates/devhub/versions/add_file_modal.html:14
-#: src/olympia/devhub/templates/devhub/versions/add_file_modal.html:53 src/olympia/devhub/templates/devhub/versions/list.html:298
-msgid "Warning:"
-msgstr ""
-
-#: src/olympia/devhub/templates/devhub/validate_addon.html:50 src/olympia/devhub/templates/devhub/addons/submit/upload.html:31
-#, python-format
-msgid "Submission of unlisted add-ons for signing is currently in an open beta. Please <a href=\"%(url)s\" target=\"_blank\">report any bugs</a> that you encounter."
-msgstr ""
-
 #. first parameter is a filename like lorem-ipsum-1.0.2.xpi
 #: src/olympia/devhub/templates/devhub/validation.html:5
 msgid "Validation Results for {0}"
@@ -4397,7 +4370,7 @@ msgstr ""
 msgid "Update Compatibility"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/addons/ajax_compat_update.html:4
+#: src/olympia/devhub/templates/devhub/addons/ajax_compat_update.html:4 src/olympia/devhub/templates/devhub/versions/edit.html:45
 msgid "Adjusting application information here will allow users to install your add-on even if the install manifest in the package indicates that the add-on is incompatible."
 msgstr ""
 
@@ -4409,9 +4382,9 @@ msgstr ""
 msgid "Add Another Application&hellip;"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/addons/ajax_compat_update.html:38 src/olympia/devhub/templates/devhub/addons/owner.html:86 src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:46
-#: src/olympia/devhub/templates/devhub/versions/list.html:351 src/olympia/devhub/templates/devhub/versions/list.html:353 src/olympia/templates/impala/base.html:132
-#: src/olympia/templates/impala/base.html:143 src/olympia/templates/impala/base.html:161 src/olympia/templates/impala/base.html:171
+#: src/olympia/devhub/templates/devhub/addons/ajax_compat_update.html:38 src/olympia/devhub/templates/devhub/addons/owner.html:86 src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:45
+#: src/olympia/devhub/templates/devhub/versions/list.html:349 src/olympia/devhub/templates/devhub/versions/list.html:351 src/olympia/templates/impala/base.html:129
+#: src/olympia/templates/impala/base.html:140 src/olympia/templates/impala/base.html:158 src/olympia/templates/impala/base.html:168
 msgid "Close"
 msgstr ""
 
@@ -4445,7 +4418,7 @@ msgstr ""
 msgid "Manage Authors & License"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/addons/owner.html:29 src/olympia/editors/templates/editors/review.html:270
+#: src/olympia/devhub/templates/devhub/addons/owner.html:29 src/olympia/editors/helpers.py:362 src/olympia/editors/templates/editors/review.html:270
 #, fuzzy
 msgid "Authors"
 msgstr "Authors"
@@ -4517,17 +4490,11 @@ msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/basic.html:52
 msgid ""
-"A short explanation of your add-on's basic\n"
-"                          functionality that is displayed in search and browse\n"
-"                          listings, as well as at the top of your add-on's\n"
-"                          details page. It is only relevant for listed add-ons."
+"A short explanation of your add-on's basic functionality that is displayed in search and browse listings, as well as at the top of your add-on's details page. It is only relevant for listed add-ons."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/basic.html:73
-msgid ""
-"Categories are the primary way users browse through add-ons.\n"
-"                        Choose any that fit your add-on's functionality for the most\n"
-"                        exposure. It is only relevant for listed add-ons."
+msgid "Categories are the primary way users browse through add-ons. Choose any that fit your add-on's functionality for the most exposure. It is only relevant for listed add-ons."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/basic.html:90
@@ -4537,11 +4504,7 @@ msgid ""
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/basic.html:119
-msgid ""
-"Tags help users find your add-on and should be short\n"
-"                        descriptors such as tabs, toolbar, or twitter.  You\n"
-"                        may have a maximum of {0} tags. It is only relevant\n"
-"                        for listed add-ons."
+msgid "Tags help users find your add-on and should be short descriptors such as tabs, toolbar, or twitter. You may have a maximum of {0} tags. It is only relevant for listed add-ons."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/basic.html:129 src/olympia/devhub/templates/devhub/personas/edit.html:97 src/olympia/devhub/templates/devhub/personas/submit.html:46
@@ -4569,11 +4532,7 @@ msgid "Add-on Details for {0}"
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/details.html:22
-msgid ""
-"A longer explanation of features,\n"
-"                          functionality, and other relevant information. This\n"
-"                          field is only displayed on the add-on's details\n"
-"                          page. It is only relevant for listed add-ons."
+msgid "A longer explanation of features, functionality, and other relevant information. This field is only displayed on the add-on's details page. It is only relevant for listed add-ons."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/details.html:44 src/olympia/translations/templates/translations/trans-menu.html:13
@@ -4582,10 +4541,7 @@ msgid "Default Locale"
 msgstr "Default Locale"
 
 #: src/olympia/devhub/templates/devhub/addons/edit/details.html:45
-msgid ""
-"Information about your add-on is displayed in this locale\n"
-"                        unless you override it with a locale-specific translation.\n"
-"                        It is only relevant for listed add-ons."
+msgid "Information about your add-on is displayed in this locale unless you override it with a locale-specific translation. It is only relevant for listed add-ons."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/details.html:61 src/olympia/users/forms.py:311 src/olympia/users/templates/users/edit.html:122 src/olympia/users/templates/users/register.html:57
@@ -4595,10 +4551,8 @@ msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/details.html:63
 msgid ""
-"If your add-on has another homepage, enter its\n"
-"                          address here. If your website is localized into other\n"
-"                          languages multiple translations of this field can be\n"
-"                          added. It is only relevant for listed add-ons."
+"If your add-on has another homepage, enter its address here. If your website is localized into other languages multiple translations of this field can be added. It is only relevant for listed add-"
+"ons."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/media.html:3
@@ -4616,19 +4570,14 @@ msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/support.html:22
 msgid ""
-"If you wish to display an e-mail address for support\n"
-"                          inquiries, enter it here. If you have different\n"
-"                          addresses for each language multiple translations of\n"
-"                          this field can be added. It is only relevant for\n"
-"                          listed add-ons."
+"If you wish to display an e-mail address for support inquiries, enter it here. If you have different addresses for each language multiple translations of this field can be added. It is only "
+"relevant for listed add-ons."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/support.html:45
 msgid ""
-"If your add-on has a support website or forum, enter\n"
-"                          its address here. If your website is localized into\n"
-"                          other languages, multiple translations of this field can\n"
-"                          be added. It is only relevant for listed add-ons."
+"If your add-on has a support website or forum, enter its address here. If your website is localized into other languages, multiple translations of this field can be added. It is only relevant for "
+"listed add-ons."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:6
@@ -4642,11 +4591,8 @@ msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:23
 msgid ""
-"Any information end users may want to know that isn't\n"
-"                          necessarily applicable to the add-on summary or description.\n"
-"                          Common uses include listing known major bugs, information on\n"
-"                          how to report bugs, anticipated release date of a new version,\n"
-"                          etc. It is only relevant for listed add-ons."
+"Any information end users may want to know that isn't necessarily applicable to the add-on summary or description. Common uses include listing known major bugs, information on how to report bugs, "
+"anticipated release date of a new version, etc. It is only relevant for listed add-ons."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:46
@@ -4658,9 +4604,7 @@ msgid "Add-on Flags"
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:69
-msgid ""
-"These flags are used to classify add-ons. It is only\n"
-"                        relevant for listed add-ons."
+msgid "These flags are used to classify add-ons. It is only relevant for listed add-ons."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:74
@@ -4676,9 +4620,7 @@ msgid "View Source?"
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:90
-msgid ""
-"Whether the source of your add-on can be displayed in our\n"
-"                        online viewer. It is only relevant for listed add-ons."
+msgid "Whether the source of your add-on can be displayed in our online viewer. It is only relevant for listed add-ons."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:94
@@ -4694,10 +4636,7 @@ msgid "Public Stats?"
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:102
-msgid ""
-"Whether the download and usage stats of your add-on can\n"
-"                        be displayed in our online viewer.\n"
-"                        It is only relevant for listed add-ons."
+msgid "Whether the download and usage stats of your add-on can be displayed in our online viewer. It is only relevant for listed add-ons."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:107
@@ -4713,10 +4652,7 @@ msgid "Upgrade SDK?"
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:116
-msgid ""
-"If selected, we will try to automatically upgrade your\n"
-"                        add-on when a new version of the SDK is released.\n"
-"                        It is only relevant for listed add-ons."
+msgid "If selected, we will try to automatically upgrade your add-on when a new version of the SDK is released. It is only relevant for listed add-ons."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:121
@@ -4767,10 +4703,8 @@ msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/forms_shared/media.html:16
 msgid ""
-"Upload an icon for your add-on or choose from one of ours. The\n"
-"                      icon is displayed nearly everywhere your add-on is. Uploaded images\n"
-"                      must be one of the following image types: .png, .jpg.\n"
-"                      It is only relevant for listed add-ons."
+"Upload an icon for your add-on or choose from one of ours. The icon is displayed nearly everywhere your add-on is. Uploaded images must be one of the following image types: .png, .jpg. It is only "
+"relevant for listed add-ons."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/forms_shared/media.html:25
@@ -4783,9 +4717,7 @@ msgid "32x32px"
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/forms_shared/media.html:39
-msgid ""
-"Used in listings of add-ons, like search results\n"
-"                            and featured add-ons."
+msgid "Used in listings of add-ons, like search results and featured add-ons."
 msgstr ""
 
 #. The size of the icon
@@ -4881,16 +4813,14 @@ msgid "Deleting your add-on will permanently remove it from the site and prevent
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:24
-msgid ""
-"Enter the following text confirm your decision:\n"
-"           {slug}"
+msgid "Enter the following text confirm your decision: {slug}"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:34
+#: src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:33
 msgid "Please tell us why you are deleting your theme:"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:36
+#: src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:35
 msgid "Please tell us why you are deleting your add-on:"
 msgstr ""
 
@@ -4928,8 +4858,8 @@ msgstr "New Version"
 msgid "Daily statistics on downloads and users."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/addons/listing/item_actions.html:45 src/olympia/stats/templates/stats/stats.html:75 src/olympia/stats/templates/stats/stats.html:79
-#: src/olympia/stats/templates/stats/stats.html:81
+#: src/olympia/devhub/templates/devhub/addons/listing/item_actions.html:45 src/olympia/stats/templates/stats/stats.html:31 src/olympia/stats/templates/stats/stats.html:35
+#: src/olympia/stats/templates/stats/stats.html:37
 #, fuzzy
 msgid "Statistics"
 msgstr "Statistics"
@@ -5050,10 +4980,7 @@ msgid "Your add-on has been submitted to the Full Review queue."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/submit/done.html:18
-msgid ""
-"You'll receive an email once it has been reviewed by an editor. In\n"
-"          the meantime, you and your friends can install it directly from its\n"
-"          details page:"
+msgid "You'll receive an email once it has been reviewed by an editor. In the meantime, you and your friends can install it directly from its details page:"
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/submit/done.html:27 src/olympia/devhub/templates/devhub/addons/submit/done.html:77 src/olympia/devhub/templates/devhub/personas/submit_done.html:16
@@ -5259,11 +5186,11 @@ msgstr ""
 msgid "Use the fields below to upload your add-on package and select any platform restrictions. After upload, a series of automated validation tests will be run on your file."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/addons/submit/upload.html:59 src/olympia/devhub/templates/devhub/versions/add_file_modal.html:39
+#: src/olympia/devhub/templates/devhub/addons/submit/upload.html:51 src/olympia/devhub/templates/devhub/versions/add_file_modal.html:28
 msgid "Which platforms is this file compatible with?"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/addons/submit/upload.html:67 src/olympia/devhub/templates/devhub/versions/add_file_modal.html:65
+#: src/olympia/devhub/templates/devhub/addons/submit/upload.html:59 src/olympia/devhub/templates/devhub/versions/add_file_modal.html:45
 msgid "Administrative overrides"
 msgstr ""
 
@@ -5373,8 +5300,8 @@ msgstr ""
 
 #: src/olympia/devhub/templates/devhub/docs/policies-contact.html:44
 msgid ""
-"If you've found a problem with the site, we'd love to fix it. Please <a href=\"https://github.com/mozilla/olympia/issues\">file a bug report</a> in GitHub, including the location of the problem and "
-"how you encountered it."
+"If you've found a problem with the site, we'd love to fix it. Please <a href=\"https://github.com/mozilla/addons/issues/new\">file a bug report</a> in GitHub, including the location of the problem "
+"and how you encountered it."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/docs/policies-maintenance.html:3 src/olympia/devhub/templates/devhub/docs/policies-maintenance.html:7
@@ -5941,7 +5868,7 @@ msgstr ""
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:282
 msgid ""
-"Add-ons that store or otherwise handle browsing data must support <a href=\"https://developer.mozilla.org/En/Supporting_private_browsing_mode\">Private Browsing Mode</a>.  During a Private Browsing "
+"Add-ons that store or otherwise handle browsing data must support <a href=\"https://developer.mozilla.org/En/Supporting_private_browsing_mode\">Private Browsing Mode</a>. During a Private Browsing "
 "session, no browsing data can be written to disk, and all of this data must be cleared when Firefox quits or the Private Browsing session ends."
 msgstr ""
 
@@ -6106,129 +6033,95 @@ msgstr ""
 msgid "How to get in touch with us regarding these policies or your add-on."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:6
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:10
 msgid "You have disabled this add-on"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:20
-msgid ""
-"Your add-on's listing is disabled and is not showing\n"
-"                             anywhere in our gallery or update service."
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:24
+msgid "Your add-on's listing is disabled and is not showing anywhere in our gallery or update service."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:25
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:27
 msgid "Please complete your add-on."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:29
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:30
 msgid "You will receive an email when the review is complete."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:34
-msgid ""
-"You will receive an email when the review is complete. Until\n"
-"                             then, your add-on is not listed in our gallery but can be\n"
-"                             accessed directly from its details page."
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:33
+msgid "You will receive an email when the review is complete. Until then, your add-on is not listed in our gallery but can be accessed directly from its details page."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:38 src/olympia/devhub/templates/devhub/includes/addon_details.html:48
-msgid ""
-"You will receive an email when the review is\n"
-"                             complete and your add-on is signed."
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:37 src/olympia/devhub/templates/devhub/includes/addon_details.html:45
+msgid "You will receive an email when the review is complete and your add-on is signed."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:44
-msgid ""
-"You will receive an email when the review is complete. Until\n"
-"                             then, your add-on is not listed in our gallery but can be\n"
-"                             accessed directly from its details page. "
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:41
+msgid "You will receive an email when the review is complete. Until then, your add-on is not listed in our gallery but can be accessed directly from its details page. "
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:54
-msgid ""
-"Your add-on is displayed in our gallery and users are\n"
-"                             receiving automatic updates."
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:49
+msgid "Your add-on is displayed in our gallery and users are receiving automatic updates."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:57
-msgid ""
-"Your add-on has been signed and can be bundled with an\n"
-"                             application installer."
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:52
+msgid "Your add-on has been signed and can be bundled with an application installer."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:63
-msgid ""
-"Your add-on was disabled by a site administrator and is no\n"
-"                             longer shown in our gallery. If you have any questions,\n"
-"                             please email amo-admins@mozilla.org."
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:56
+msgid "Your add-on was disabled by a site administrator and is no longer shown in our gallery. If you have any questions, please email amo-admins@mozilla.org."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:70
-msgid ""
-"Your add-on is displayed in our gallery as experimental\n"
-"                             and users are receiving automatic updates. Some features\n"
-"                             are unavailable to your add-on."
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:62
+msgid "Your add-on is displayed in our gallery as experimental and users are receiving automatic updates. Some features are unavailable to your add-on."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:74
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:66
 msgid "Your add-on has been signed."
 msgstr ""
 
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:69
+msgid ""
+"You will receive an email when the full review is complete. Until then, your add-on is displayed in our gallery as experimental and users are receiving automatic updates. Some features are "
+"unavailable to your add-on."
+msgstr ""
+
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:74
+msgid "You will receive an email when the full review is complete, making you able to bundle your add-on with an application installer."
+msgstr ""
+
 #: src/olympia/devhub/templates/devhub/includes/addon_details.html:79
-msgid ""
-"You will receive an email when the full review is complete.\n"
-"                             Until then, your add-on is displayed in our gallery as\n"
-"                             experimental and users are receiving automatic updates.\n"
-"                             Some features are unavailable to your add-on."
+msgid "All add-ons hosted in our gallery must now be reviewed by an editor. If you wish to continue hosting your add-on, please click to select a review process."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:84
-msgid ""
-"You will receive an email when the full review is\n"
-"                             complete, making you able to bundle your add-on with an\n"
-"                             application installer."
-msgstr ""
-
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:91
-msgid ""
-"All add-ons hosted in our gallery must now be reviewed by an\n"
-"                             editor. If you wish to continue hosting your add-on, please\n"
-"                             click to select a review process."
-msgstr ""
-
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:113
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:100
 msgid "Current Version:"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:115
-msgid ""
-"This is the version of your add-on that will\n"
-"                                           be installed if someone clicks the Install\n"
-"                                           button on addons.mozilla.org. It is only\n"
-"                                           relevant for listed add-ons."
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:102
+msgid "This is the version of your add-on that will be installed if someone clicks the Install button on addons.mozilla.org. It is only relevant for listed add-ons."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:123
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:110
 msgid "Created:"
 msgstr ""
 
 #. {0} is a date. dennis-ignore: E201
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:125 src/olympia/devhub/templates/devhub/includes/addon_details.html:131
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:112 src/olympia/devhub/templates/devhub/includes/addon_details.html:118
 #, python-format
 msgid "%%b %%e, %%Y"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:136
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:123
 msgid "Next Version:"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:138
-msgid ""
-"This is the newest uploaded version, however\n"
-"                                           it isn’t live on the site yet."
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:125
+msgid "This is the newest uploaded version, however it isn’t live on the site yet."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:144 src/olympia/devhub/templates/devhub/versions/list.html:30
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:130 src/olympia/devhub/templates/devhub/versions/list.html:30
 msgid "Queues are not reviewed strictly in order"
 msgstr ""
 
@@ -6296,9 +6189,7 @@ msgid "View the blog &#9658;"
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/includes/license_form.html:6
-msgid ""
-"Please choose a license appropriate for the rights you grant on your source code.\n"
-"                  It is only relevant for listed add-ons."
+msgid "Please choose a license appropriate for the rights you grant on your source code. It is only relevant for listed add-ons."
 msgstr ""
 
 #. {0} is a list of HTML tags.
@@ -6325,14 +6216,11 @@ msgstr[1] ""
 #: src/olympia/devhub/templates/devhub/includes/policy_form.html:4
 msgid ""
 "Users will be required to accept the following End-User License Agreement (EULA) prior to installing your add-on. The presence of a EULA significantly affects the number of downloads an add-on "
-"receives. Please note that a EULA is not the same as a code license, such as the GPL or MPL.\n"
-"                It is only relevant for listed add-ons."
+"receives. Please note that a EULA is not the same as a code license, such as the GPL or MPL.It is only relevant for listed add-ons."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/policy_form.html:21
-msgid ""
-"If your add-on transmits any data from the user's computer, a privacy policy is required that explains what data is sent and how it is used.\n"
-"                It is only relevant for listed add-ons."
+#: src/olympia/devhub/templates/devhub/includes/policy_form.html:24
+msgid "If your add-on transmits any data from the user's computer, a privacy policy is required that explains what data is sent and how it is used. It is only relevant for listed add-ons."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/includes/source_form_field.html:2
@@ -6501,12 +6389,8 @@ msgstr ""
 msgid "Add some tags to describe your Theme."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/personas/edit.html:106
-msgid ""
-"A short explanation of your theme's\n"
-"                                basic functionality that is displayed in\n"
-"                                search and browse listings, as well as at\n"
-"                                the top of your theme's details page."
+#: src/olympia/devhub/templates/devhub/personas/edit.html:106 src/olympia/devhub/templates/devhub/personas/submit.html:54
+msgid "A short explanation of your theme's basic functionality that is displayed in search and browse listings, as well as at the top of your theme's details page."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/personas/edit.html:122 src/olympia/devhub/templates/devhub/personas/submit.html:68
@@ -6576,7 +6460,7 @@ msgid "Upon upload and form submission, the AMO Team will review your updated de
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/personas/edit.html:241
-msgid "Your previously resubmitted design,  which is under pending review."
+msgid "Your previously resubmitted design, which is under pending review."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/personas/edit.html:245
@@ -6643,14 +6527,6 @@ msgstr ""
 
 #: src/olympia/devhub/templates/devhub/personas/submit.html:33
 msgid "Give your Theme a name."
-msgstr ""
-
-#: src/olympia/devhub/templates/devhub/personas/submit.html:54
-msgid ""
-"A short explanation of your theme's\n"
-"                                      basic functionality that is displayed in\n"
-"                                      search and browse listings, as well as at\n"
-"                                      the top of your theme's details page."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/personas/submit.html:198
@@ -6727,30 +6603,16 @@ msgstr ""
 msgid "Files added to reviewed versions must be reviewed before they will be available for download."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/add_file_modal.html:15
-#, python-format
-msgid ""
-"Submission of updates to unlisted add-ons for signing is currently in an open beta. Manual review may still be required for a large number of add-ons. Please <a href=\"%(url)s\" target=\"_blank"
-"\">report any bugs</a> that you encounter."
-msgstr ""
-
-#: src/olympia/devhub/templates/devhub/versions/add_file_modal.html:35
+#: src/olympia/devhub/templates/devhub/versions/add_file_modal.html:24
 msgid "Select the target platform for this file."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/add_file_modal.html:46
+#: src/olympia/devhub/templates/devhub/versions/add_file_modal.html:35
 msgid "Which review type would you like to nominate for?"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/add_file_modal.html:51
+#: src/olympia/devhub/templates/devhub/versions/add_file_modal.html:40
 msgid "Only publish this version to my beta channel."
-msgstr ""
-
-#: src/olympia/devhub/templates/devhub/versions/add_file_modal.html:54
-#, python-format
-msgid ""
-"The behavior of the beta channel has changed to accommodate <a href=\"%(addon_signing_url)s\" target=\"_blank\">mandatory add-on signing</a>. The new process is currently in an open beta, and may "
-"change significantly in the near future. Please <a href=\"%(issues_url)s\" target=\"_blank\">report any bugs</a> that you encounter."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/versions/edit.html:5
@@ -6776,19 +6638,10 @@ msgstr ""
 msgid "Upload Another File"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/edit.html:45
-msgid ""
-"Adjusting application information here will allow users to install your\n"
-"                          add-on even if the install manifest in the package indicates that the\n"
-"                          add-on is incompatible."
-msgstr ""
-
 #: src/olympia/devhub/templates/devhub/versions/edit.html:74
 msgid ""
-"Information about changes in this release, new features,\n"
-"                              known bugs, and other useful information specific to this\n"
-"                              release/version. This information is also shown in the\n"
-"                              Add-ons Manager when updating."
+"Information about changes in this release, new features, known bugs, and other useful information specific to this release/version. This information is also shown in the Add-ons Manager when "
+"updating."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/versions/edit.html:99
@@ -6800,10 +6653,7 @@ msgid "Notes for Reviewers"
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/versions/edit.html:114
-msgid ""
-"Optionally, enter any information that may be useful\n"
-"                              to the Editor reviewing this add-on, such as test\n"
-"                              account information."
+msgid "Optionally, enter any information that may be useful to the Editor reviewing this add-on, such as test account information."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/versions/edit.html:127
@@ -6881,7 +6731,7 @@ msgstr ""
 msgid "Request Preliminary Review"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:80 src/olympia/devhub/templates/devhub/versions/list.html:327 src/olympia/devhub/templates/devhub/versions/list.html:350
+#: src/olympia/devhub/templates/devhub/versions/list.html:80 src/olympia/devhub/templates/devhub/versions/list.html:325 src/olympia/devhub/templates/devhub/versions/list.html:348
 msgid "Cancel Review Request"
 msgstr ""
 
@@ -6910,7 +6760,7 @@ msgid "Unlisted:"
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/versions/list.html:114
-msgid "Not distributed on {0}. Developers will upload new versions for signing and distribute the add-ons on their own. (beta)"
+msgid "Not distributed on {0}. Developers will upload new versions for signing and distribute the add-ons on their own."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/versions/list.html:122
@@ -6975,81 +6825,73 @@ msgid "<strong>Important:</strong> Once a version has been deleted, you may not 
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/versions/list.html:230
-msgid ""
-"Deleting a version which has already been reviewed\n"
-"               may also cause a significant delay in the review of\n"
-"               your next update."
-msgstr ""
-
-#: src/olympia/devhub/templates/devhub/versions/list.html:233
 msgid "Are you sure you wish to delete this version?"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:238
+#: src/olympia/devhub/templates/devhub/versions/list.html:235
 msgid "Delete Version"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:240
+#: src/olympia/devhub/templates/devhub/versions/list.html:237
 msgid "Disable Version"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:247
+#: src/olympia/devhub/templates/devhub/versions/list.html:244
 msgid "Add a new Version"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:249
+#: src/olympia/devhub/templates/devhub/versions/list.html:246
 msgid "Add Version"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:256 src/olympia/devhub/templates/devhub/versions/list.html:274
+#: src/olympia/devhub/templates/devhub/versions/list.html:253 src/olympia/devhub/templates/devhub/versions/list.html:279
 msgid "Hide Add-on"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:259
+#: src/olympia/devhub/templates/devhub/versions/list.html:256
 msgid "Hiding your add-on will prevent it from appearing anywhere in our gallery and will stop users from receiving automatic updates."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:265
+#: src/olympia/devhub/templates/devhub/versions/list.html:263
+msgid "The files awaiting review will be disabled and you will need to upload new versions."
+msgstr ""
+
+#: src/olympia/devhub/templates/devhub/versions/list.html:270
 msgid "Are you sure you wish to hide your add-on?"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:286 src/olympia/devhub/templates/devhub/versions/list.html:315
+#: src/olympia/devhub/templates/devhub/versions/list.html:291 src/olympia/devhub/templates/devhub/versions/list.html:313
 msgid "Unlist Add-on"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:289
+#: src/olympia/devhub/templates/devhub/versions/list.html:294
 #, python-format
 msgid ""
 "Unlisting your add-on will make it (and each of its versions/files) invisible on this website. It won't show up in searches, won't have a public facing page, and won't be updated automatically for "
-"current users.  It is recommended for unlisted add-ons to provide a custom <a href=\"%(update_url)s\" target=\"_blank\">updateURL</a> in their manifest file for automatic updates."
+"current users. It is recommended for unlisted add-ons to provide a custom <a href=\"%(update_url)s\" target=\"_blank\">updateURL</a> in their manifest file for automatic updates."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:299
-#, python-format
-msgid "Switching add-ons to unlisted is currently in an open beta. Please <a href=\"%(url)s\" target=\"_blank\">report any bugs</a> that you encounter."
-msgstr ""
-
-#: src/olympia/devhub/templates/devhub/versions/list.html:305
+#: src/olympia/devhub/templates/devhub/versions/list.html:303
 msgid "Unlisting an add-on is irreversible!"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:305
+#: src/olympia/devhub/templates/devhub/versions/list.html:303
 msgid "An unlisted add-on cannot be switched to be listed."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:307
+#: src/olympia/devhub/templates/devhub/versions/list.html:305
 msgid "Are you sure you wish to unlist your add-on?"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:330
+#: src/olympia/devhub/templates/devhub/versions/list.html:328
 msgid "Canceling your review request will leave your add-on as preliminarily reviewed."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:335
+#: src/olympia/devhub/templates/devhub/versions/list.html:333
 msgid "Canceling your review request will mark your add-on incomplete. If you do not complete your add-on after several days by re-requesting review, it will be deleted."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:343
+#: src/olympia/devhub/templates/devhub/versions/list.html:341
 msgid "Are you sure you wish to cancel your review request?"
 msgstr ""
 
@@ -7391,19 +7233,19 @@ msgstr ""
 msgid "Search by add-on name / author email"
 msgstr ""
 
-#: src/olympia/editors/forms.py:103
+#: src/olympia/editors/forms.py:103 src/olympia/editors/forms.py:244 src/olympia/editors/forms.py:257
 msgid "yes"
 msgstr ""
 
-#: src/olympia/editors/forms.py:104
+#: src/olympia/editors/forms.py:104 src/olympia/editors/forms.py:244 src/olympia/editors/forms.py:257
 msgid "no"
 msgstr ""
 
-#: src/olympia/editors/forms.py:105
+#: src/olympia/editors/forms.py:105 src/olympia/editors/forms.py:245
 msgid "Admin Flag"
 msgstr ""
 
-#: src/olympia/editors/forms.py:113
+#: src/olympia/editors/forms.py:113 src/olympia/editors/forms.py:253
 msgid "Max. Version"
 msgstr ""
 
@@ -7415,56 +7257,60 @@ msgstr ""
 msgid "Add-on Types"
 msgstr ""
 
-#: src/olympia/editors/forms.py:126 src/olympia/editors/helpers.py:267
+#: src/olympia/editors/forms.py:126 src/olympia/editors/helpers.py:279
 #, fuzzy
 msgid "Platforms"
 msgstr "Platforms"
 
+#: src/olympia/editors/forms.py:237
+msgid "Search by add-on name / author email / guid"
+msgstr ""
+
 #. L10n: 0 = platform, 1 = filename, 2 = status message
-#: src/olympia/editors/forms.py:238
+#: src/olympia/editors/forms.py:342
 #, python-format
 msgid "<strong>%s</strong> &middot; %s &middot; %s"
 msgstr ""
 
-#: src/olympia/editors/forms.py:252
+#: src/olympia/editors/forms.py:356
 msgid "Comments:"
 msgstr ""
 
-#: src/olympia/editors/forms.py:256
+#: src/olympia/editors/forms.py:360
 msgid "Operating systems:"
 msgstr ""
 
-#: src/olympia/editors/forms.py:258
+#: src/olympia/editors/forms.py:362
 msgid "Applications:"
 msgstr ""
 
-#: src/olympia/editors/forms.py:260
+#: src/olympia/editors/forms.py:364
 msgid "Notify me the next time this add-on is updated. (Subsequent updates will not generate an email)"
 msgstr ""
 
-#: src/olympia/editors/forms.py:265
+#: src/olympia/editors/forms.py:369
 msgid "Clear Admin Review Flag"
 msgstr ""
 
-#: src/olympia/editors/forms.py:267
+#: src/olympia/editors/forms.py:371
 msgid "Clear more info requested flag"
 msgstr ""
 
-#: src/olympia/editors/forms.py:281
+#: src/olympia/editors/forms.py:385
 msgid "Choose a canned response..."
 msgstr ""
 
 #. L10n: Description of what can be searched for.
-#: src/olympia/editors/forms.py:324
+#: src/olympia/editors/forms.py:423
 msgid "theme name"
 msgstr ""
 
-#: src/olympia/editors/forms.py:350
+#: src/olympia/editors/forms.py:449
 msgid "Someone else is reviewing this theme."
 msgstr ""
 
 #. L10n: Description of what can be searched for.
-#: src/olympia/editors/forms.py:447
+#: src/olympia/editors/forms.py:546
 msgid "app, reviewer, or comment"
 msgstr ""
 
@@ -7480,246 +7326,264 @@ msgstr ""
 msgid "Rejected or Unreviewed"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:123 src/olympia/editors/helpers.py:136
+#: src/olympia/editors/helpers.py:125 src/olympia/editors/helpers.py:138
 msgid "Queue"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:124 src/olympia/editors/templates/editors/base.html:50 src/olympia/editors/templates/editors/base.html:65
+#: src/olympia/editors/helpers.py:126 src/olympia/editors/templates/editors/base.html:50 src/olympia/editors/templates/editors/base.html:65
 msgid "Pending Updates"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:125 src/olympia/editors/templates/editors/base.html:48 src/olympia/editors/templates/editors/base.html:63
+#: src/olympia/editors/helpers.py:127 src/olympia/editors/templates/editors/base.html:48 src/olympia/editors/templates/editors/base.html:63
 msgid "Full Reviews"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:126 src/olympia/editors/templates/editors/base.html:52 src/olympia/editors/templates/editors/base.html:67
+#: src/olympia/editors/helpers.py:128 src/olympia/editors/templates/editors/base.html:52 src/olympia/editors/templates/editors/base.html:67
 msgid "Preliminary Reviews"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:127 src/olympia/editors/templates/editors/base.html:54
+#: src/olympia/editors/helpers.py:129 src/olympia/editors/templates/editors/base.html:54
 msgid "Moderated Reviews"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:128 src/olympia/editors/templates/editors/base.html:46
+#: src/olympia/editors/helpers.py:130 src/olympia/editors/templates/editors/base.html:46
 msgid "Fast Track"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:130
+#: src/olympia/editors/helpers.py:132
 msgid "Pending Themes"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:131 src/olympia/editors/templates/editors/themes/queue.html:4
+#: src/olympia/editors/helpers.py:133 src/olympia/editors/templates/editors/themes/queue.html:4
 msgid "Flagged Themes"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:132
+#: src/olympia/editors/helpers.py:134
 msgid "Update Themes"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:137
+#: src/olympia/editors/helpers.py:139
 msgid "Unlisted Pending Updates"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:138
+#: src/olympia/editors/helpers.py:140
 msgid "Unlisted Full Reviews"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:139
+#: src/olympia/editors/helpers.py:141
 msgid "Unlisted Preliminary Reviews"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:170
+#: src/olympia/editors/helpers.py:142
+msgid "Unlisted All Add-ons"
+msgstr ""
+
+#: src/olympia/editors/helpers.py:173
 msgid "Fast Track ({0})"
 msgid_plural "Fast Track ({0})"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/olympia/editors/helpers.py:175
+#: src/olympia/editors/helpers.py:178
 msgid "Full Review ({0})"
 msgid_plural "Full Reviews ({0})"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/olympia/editors/helpers.py:180
+#: src/olympia/editors/helpers.py:183
 msgid "Pending Update ({0})"
 msgid_plural "Pending Updates ({0})"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/olympia/editors/helpers.py:185
+#: src/olympia/editors/helpers.py:188
 msgid "Preliminary Review ({0})"
 msgid_plural "Preliminary Reviews ({0})"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/olympia/editors/helpers.py:190
+#: src/olympia/editors/helpers.py:193
 msgid "Moderated Review ({0})"
 msgid_plural "Moderated Reviews ({0})"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/olympia/editors/helpers.py:196
+#: src/olympia/editors/helpers.py:199
 msgid "Unlisted Full Review ({0})"
 msgid_plural "Unlisted Full Reviews ({0})"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/olympia/editors/helpers.py:201
+#: src/olympia/editors/helpers.py:204
 msgid "Unlisted Pending Update ({0})"
 msgid_plural "Unlisted Pending Updates ({0})"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/olympia/editors/helpers.py:206
+#: src/olympia/editors/helpers.py:209
 msgid "Unlisted Preliminary Review ({0})"
 msgid_plural "Unlisted Preliminary Reviews ({0})"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/olympia/editors/helpers.py:261
-msgid "Addon"
-msgstr ""
+#: src/olympia/editors/helpers.py:214
+msgid "Unlisted All Add-ons ({0})"
+msgid_plural "Unlisted All Add-ons ({0})"
+msgstr[0] ""
+msgstr[1] ""
 
-#: src/olympia/editors/helpers.py:262
+#: src/olympia/editors/helpers.py:274
 msgid "Type"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:263
+#: src/olympia/editors/helpers.py:275
 msgid "Waiting Time"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:264 src/olympia/editors/templates/editors/review.html:285
+#: src/olympia/editors/helpers.py:276 src/olympia/editors/templates/editors/review.html:285
 msgid "Flags"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:265
+#: src/olympia/editors/helpers.py:277
 msgid "Applications"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:270
+#: src/olympia/editors/helpers.py:282
 msgid "Additional"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:285
+#: src/olympia/editors/helpers.py:302
 msgid "Site Specific"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:287
+#: src/olympia/editors/helpers.py:304
 msgid "Requires External Software"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:289
+#: src/olympia/editors/helpers.py:306
 msgid "Binary Components"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:313
+#: src/olympia/editors/helpers.py:339
 msgid "moments ago"
 msgstr ""
 
 #. L10n: first argument is number of minutes
-#: src/olympia/editors/helpers.py:316
+#: src/olympia/editors/helpers.py:342
 msgid "{0} minute"
 msgid_plural "{0} minutes"
 msgstr[0] ""
 msgstr[1] ""
 
 #. L10n: first argument is number of hours
-#: src/olympia/editors/helpers.py:320
+#: src/olympia/editors/helpers.py:346
 msgid "{0} hour"
 msgid_plural "{0} hours"
 msgstr[0] ""
 msgstr[1] ""
 
 #. L10n: first argument is number of days
-#: src/olympia/editors/helpers.py:324
+#: src/olympia/editors/helpers.py:350
 msgid "{0} day"
 msgid_plural "{0} days"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/olympia/editors/helpers.py:488
+#: src/olympia/editors/helpers.py:364
+msgid "Last Review"
+msgstr ""
+
+#: src/olympia/editors/helpers.py:366
+msgid "Last Update"
+msgstr ""
+
+#: src/olympia/editors/helpers.py:387
+msgid "No Reviews"
+msgstr ""
+
+#: src/olympia/editors/helpers.py:561
 msgid "Push to public"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:490
+#: src/olympia/editors/helpers.py:563
 msgid "Grant full review"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:505
+#: src/olympia/editors/helpers.py:578
 msgid "Request more information"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:508
+#: src/olympia/editors/helpers.py:581
 msgid "Request super-review"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:519
+#: src/olympia/editors/helpers.py:592
 msgid "Grant preliminary review"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:520
+#: src/olympia/editors/helpers.py:593
 msgid "This will mark the files as preliminarily reviewed."
 msgstr ""
 
-#: src/olympia/editors/helpers.py:522
+#: src/olympia/editors/helpers.py:595
 msgid "Use this form to request more information from the author. They will receive an email and be able to answer here. You will be notified by email when they reply."
 msgstr ""
 
-#: src/olympia/editors/helpers.py:526
+#: src/olympia/editors/helpers.py:599
 msgid ""
 "If you have concerns about this add-on's security, copyright issues, or other concerns that an administrator should look into, enter your comments in the area below. They will be sent to "
 "administrators, not the author."
 msgstr ""
 
-#: src/olympia/editors/helpers.py:532
+#: src/olympia/editors/helpers.py:605
 msgid "This will reject the add-on and remove it from the review queue."
 msgstr ""
 
-#: src/olympia/editors/helpers.py:534
-msgid "Make a comment on this version.  The author won't be able to see this."
+#: src/olympia/editors/helpers.py:607
+msgid "Make a comment on this version. The author won't be able to see this."
 msgstr ""
 
-#: src/olympia/editors/helpers.py:538
+#: src/olympia/editors/helpers.py:611
 msgid "This will reject the files and remove them from the review queue."
 msgstr ""
 
-#: src/olympia/editors/helpers.py:542
+#: src/olympia/editors/helpers.py:615
 msgid "This will mark the add-on as preliminarily reviewed. Future versions will undergo preliminary review."
 msgstr ""
 
-#: src/olympia/editors/helpers.py:547
+#: src/olympia/editors/helpers.py:620
 msgid "This will mark the files as preliminarily reviewed. Future versions will undergo preliminary review."
 msgstr ""
 
-#: src/olympia/editors/helpers.py:552
+#: src/olympia/editors/helpers.py:625
 msgid "Retain preliminary review"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:553
+#: src/olympia/editors/helpers.py:626
 msgid "This will retain the add-on as preliminarily reviewed. Future versions will undergo preliminary review."
 msgstr ""
 
-#: src/olympia/editors/helpers.py:558
+#: src/olympia/editors/helpers.py:631
 msgid "This will approve a sandboxed version of a public add-on to appear on the public side."
 msgstr ""
 
-#: src/olympia/editors/helpers.py:561
+#: src/olympia/editors/helpers.py:634
 msgid "This will reject a version of a public add-on and remove it from the queue."
 msgstr ""
 
-#: src/olympia/editors/helpers.py:564
+#: src/olympia/editors/helpers.py:637
 msgid "This will mark the add-on and its most recent version and files as public. Future versions will go into the sandbox until they are reviewed by an editor."
 msgstr ""
 
-#: src/olympia/editors/helpers.py:637
+#: src/olympia/editors/helpers.py:714
 msgid "add-on"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:940 src/olympia/editors/helpers.py:960
+#: src/olympia/editors/helpers.py:1020 src/olympia/editors/helpers.py:1040
 msgid "Flagged"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:944 src/olympia/editors/helpers.py:963
+#: src/olympia/editors/helpers.py:1024 src/olympia/editors/helpers.py:1043
 msgid "Updates"
 msgstr ""
 
@@ -7771,56 +7635,56 @@ msgstr ""
 msgid "A question about your Theme submission"
 msgstr ""
 
-#: src/olympia/editors/views.py:144
+#: src/olympia/editors/views.py:146
 msgid "New Add-ons (Under 5 days)"
 msgstr ""
 
-#: src/olympia/editors/views.py:145
+#: src/olympia/editors/views.py:147
 msgid "Passable (5 to 10 days)"
 msgstr ""
 
-#: src/olympia/editors/views.py:146
+#: src/olympia/editors/views.py:148
 msgid "Overdue (Over 10 days)"
 msgstr ""
 
-#: src/olympia/editors/views.py:532
+#: src/olympia/editors/views.py:539
 msgid "An unknown error occurred"
 msgstr ""
 
-#: src/olympia/editors/views.py:587
+#: src/olympia/editors/views.py:592
 msgid "Self-reviews are not allowed."
 msgstr ""
 
-#: src/olympia/editors/views.py:609
+#: src/olympia/editors/views.py:613
 msgid "Review successfully processed."
 msgstr ""
 
-#: src/olympia/editors/views.py:807
+#: src/olympia/editors/views.py:812
 msgid "was approved"
 msgstr ""
 
-#: src/olympia/editors/views.py:808
+#: src/olympia/editors/views.py:813
 msgid "given preliminary review"
 msgstr ""
 
-#: src/olympia/editors/views.py:809
+#: src/olympia/editors/views.py:814
 msgid "rejected"
 msgstr ""
 
-#: src/olympia/editors/views.py:810
+#: src/olympia/editors/views.py:815
 msgctxt "editors_review_history_nominated_adminreview"
 msgid "escalated"
 msgstr ""
 
-#: src/olympia/editors/views.py:812
+#: src/olympia/editors/views.py:817
 msgid "needs more information"
 msgstr ""
 
-#: src/olympia/editors/views.py:813
+#: src/olympia/editors/views.py:818
 msgid "needs super review"
 msgstr ""
 
-#: src/olympia/editors/views.py:814
+#: src/olympia/editors/views.py:819
 msgid "commented"
 msgstr ""
 
@@ -7865,29 +7729,29 @@ msgstr ""
 msgid "Unlisted Queues"
 msgstr ""
 
-#: src/olympia/editors/templates/editors/base.html:72 src/olympia/editors/templates/editors/performance.html:6
+#: src/olympia/editors/templates/editors/base.html:74 src/olympia/editors/templates/editors/performance.html:6
 #, fuzzy
 msgid "Performance"
 msgstr "Performance"
 
-#: src/olympia/editors/templates/editors/base.html:75 src/olympia/editors/templates/editors/themes/base.html:19 src/olympia/editors/templates/editors/themes/base.html:38
+#: src/olympia/editors/templates/editors/base.html:77 src/olympia/editors/templates/editors/themes/base.html:19 src/olympia/editors/templates/editors/themes/base.html:38
 msgid "Logs"
 msgstr ""
 
-#: src/olympia/editors/templates/editors/base.html:78 src/olympia/editors/templates/editors/reviewlog.html:4 src/olympia/editors/templates/editors/reviewlog.html:27
+#: src/olympia/editors/templates/editors/base.html:80 src/olympia/editors/templates/editors/reviewlog.html:4 src/olympia/editors/templates/editors/reviewlog.html:27
 msgid "Add-on Review Log"
 msgstr ""
 
-#: src/olympia/editors/templates/editors/base.html:80 src/olympia/editors/templates/editors/eventlog.html:4 src/olympia/editors/templates/editors/eventlog.html:8
+#: src/olympia/editors/templates/editors/base.html:82 src/olympia/editors/templates/editors/eventlog.html:4 src/olympia/editors/templates/editors/eventlog.html:8
 #: src/olympia/editors/templates/editors/eventlog_detail.html:4
 msgid "Moderated Review Log"
 msgstr ""
 
-#: src/olympia/editors/templates/editors/base.html:82 src/olympia/editors/templates/editors/beta_signed_log.html:4 src/olympia/editors/templates/editors/beta_signed_log.html:8
+#: src/olympia/editors/templates/editors/base.html:84 src/olympia/editors/templates/editors/beta_signed_log.html:4 src/olympia/editors/templates/editors/beta_signed_log.html:8
 msgid "Signed Beta Files Log"
 msgstr ""
 
-#: src/olympia/editors/templates/editors/base.html:87 src/olympia/editors/templates/editors/includes/daily-message.html:4
+#: src/olympia/editors/templates/editors/base.html:89 src/olympia/editors/templates/editors/includes/daily-message.html:4
 msgid "Announcement"
 msgstr ""
 
@@ -8108,45 +7972,45 @@ msgstr ""
 msgid "clear search"
 msgstr ""
 
-#: src/olympia/editors/templates/editors/queue.html:72 src/olympia/editors/templates/editors/queue.html:122
+#: src/olympia/editors/templates/editors/queue.html:78 src/olympia/editors/templates/editors/queue.html:128
 msgid "Process Reviews"
 msgstr ""
 
-#: src/olympia/editors/templates/editors/queue.html:80
+#: src/olympia/editors/templates/editors/queue.html:86
 msgid "Moderation actions:"
 msgstr ""
 
-#: src/olympia/editors/templates/editors/queue.html:90
+#: src/olympia/editors/templates/editors/queue.html:96
 #, python-format
 msgid "by %(user)s on %(date)s %(stars)s (%(locale)s)"
 msgstr ""
 
-#: src/olympia/editors/templates/editors/queue.html:106
+#: src/olympia/editors/templates/editors/queue.html:112
 #, python-format
 msgid "<strong>%(reason)s</strong> <span class=\"light\">Flagged by %(user)s on %(date)s</span>"
 msgstr ""
 
-#: src/olympia/editors/templates/editors/queue.html:119
-msgid "All reviews have been moderated.  Good work!"
+#: src/olympia/editors/templates/editors/queue.html:125
+msgid "All reviews have been moderated. Good work!"
 msgstr ""
 
-#: src/olympia/editors/templates/editors/queue.html:161
+#: src/olympia/editors/templates/editors/queue.html:167
 msgid "Version Notes / Notes for Reviewer"
 msgstr ""
 
-#: src/olympia/editors/templates/editors/queue.html:169
+#: src/olympia/editors/templates/editors/queue.html:175
 msgid "There are currently no add-ons of this type to review."
 msgstr ""
 
-#: src/olympia/editors/templates/editors/queue.html:181 src/olympia/editors/templates/editors/themes/queue_list.html:85
+#: src/olympia/editors/templates/editors/queue.html:187 src/olympia/editors/templates/editors/themes/queue_list.html:85
 msgid "Helpful Links:"
 msgstr ""
 
-#: src/olympia/editors/templates/editors/queue.html:182
+#: src/olympia/editors/templates/editors/queue.html:188
 msgid "Add-on Policy"
 msgstr ""
 
-#: src/olympia/editors/templates/editors/queue.html:184
+#: src/olympia/editors/templates/editors/queue.html:190
 msgid "Editors' Guide"
 msgstr ""
 
@@ -8209,10 +8073,7 @@ msgid "<strong>Warning!</strong> Another user was viewing this page before you."
 msgstr ""
 
 #: src/olympia/editors/templates/editors/review.html:237
-msgid ""
-"The whiteboard is the place to exchange information relevant to\n"
-"               this addon (whatever the version), between the developer and the\n"
-"               editor. This is visible and editable by both."
+msgid "The whiteboard is the place to exchange information relevant to this addon (whatever the version), between the developer and the editor. This is visible and editable by both."
 msgstr ""
 
 #: src/olympia/editors/templates/editors/review.html:241
@@ -8486,7 +8347,7 @@ msgstr ""
 msgid "Describe your reason for flagging"
 msgstr ""
 
-#: src/olympia/files/forms.py:88
+#: src/olympia/files/forms.py:90
 msgid "Cannot diff a version against itself"
 msgstr ""
 
@@ -8521,51 +8382,51 @@ msgstr ""
 msgid "There was an error accessing file %s."
 msgstr ""
 
-#: src/olympia/files/utils.py:343
+#: src/olympia/files/utils.py:340
 msgid "Could not parse uploaded file."
 msgstr ""
 
-#: src/olympia/files/utils.py:380
+#: src/olympia/files/utils.py:377
 msgid "Invalid file name in archive: {0}"
 msgstr ""
 
-#: src/olympia/files/utils.py:388
+#: src/olympia/files/utils.py:385
 msgid "File exceeding size limit in archive: {0}"
 msgstr ""
 
-#: src/olympia/files/utils.py:439
+#: src/olympia/files/utils.py:436
 msgid "Invalid archive."
 msgstr ""
 
-#: src/olympia/files/utils.py:529 src/olympia/files/utils.py:532
+#: src/olympia/files/utils.py:526 src/olympia/files/utils.py:529
 msgid "Could not parse the manifest file."
 msgstr ""
 
-#: src/olympia/files/utils.py:551
+#: src/olympia/files/utils.py:548
 msgid "Could not find an add-on ID."
 msgstr ""
 
-#: src/olympia/files/utils.py:554
+#: src/olympia/files/utils.py:551
 msgid "Add-on ID must be 64 characters or less."
 msgstr ""
 
-#: src/olympia/files/utils.py:556
+#: src/olympia/files/utils.py:553
 msgid "Add-on ID doesn't match add-on."
 msgstr ""
 
-#: src/olympia/files/utils.py:564
+#: src/olympia/files/utils.py:561
 msgid "Duplicate add-on ID found."
 msgstr ""
 
-#: src/olympia/files/utils.py:567
+#: src/olympia/files/utils.py:564
 msgid "Version numbers should have fewer than 32 characters."
 msgstr ""
 
-#: src/olympia/files/utils.py:570
+#: src/olympia/files/utils.py:567
 msgid "Version numbers should only contain letters, numbers, and these punctuation characters: +*.-_."
 msgstr ""
 
-#: src/olympia/files/utils.py:587
+#: src/olympia/files/utils.py:584
 msgid "<em:type> doesn't match add-on"
 msgstr ""
 
@@ -8664,6 +8525,10 @@ msgstr ""
 
 #: src/olympia/files/templates/files/viewer.html:134
 msgid "Fetching file."
+msgstr ""
+
+#: src/olympia/legacy_api/views.py:255
+msgid "Not implemented yet."
 msgstr ""
 
 #: src/olympia/lib/constants.py:6
@@ -9322,10 +9187,6 @@ msgstr ""
 msgid "Zimbabwe Dollar"
 msgstr ""
 
-#: src/olympia/lib/video/ffmpeg.py:112 src/olympia/lib/video/totem.py:81
-msgid "Videos must be in WebM."
-msgstr ""
-
 #: src/olympia/pages/templates/pages/about.lhtml:3 src/olympia/pages/templates/pages/about.lhtml:10
 msgid "About Mozilla Add-ons"
 msgstr ""
@@ -9337,7 +9198,7 @@ msgstr ""
 #: src/olympia/pages/templates/pages/about.lhtml:13
 msgid ""
 "addons.mozilla.org, commonly known as \"AMO\", is Mozilla's official site for add-ons to Mozilla software, such as Firefox, Thunderbird, and SeaMonkey. Add-ons let you add new features and change "
-"the way your browser or application works.  Take a look around and explore the thousands of ways to customize the way you do things online."
+"the way your browser or application works. Take a look around and explore the thousands of ways to customize the way you do things online."
 msgstr ""
 
 #: src/olympia/pages/templates/pages/about.lhtml:19
@@ -9682,7 +9543,7 @@ msgstr ""
 msgid ""
 "Yes. It's possible, but some of the functionality provided by these libraries are available through XPCOM, XUL, and JavaScript. In addition, authors should take care if libraries modify primitive "
 "object prototypes (String.prototype, Date.prototype, etc.) and/or define global functions (eg. the $ function). These are prone to cause conflict with other add-ons, in particular if different add-"
-"ons use different versions of libraries and so on. Developers need to be very, very careful with using them.  Mozilla does not offer documentation on using them to build add-ons."
+"ons use different versions of libraries and so on. Developers need to be very, very careful with using them. Mozilla does not offer documentation on using them to build add-ons."
 msgstr ""
 
 #: src/olympia/pages/templates/pages/dev_faq.html:165
@@ -9796,8 +9657,8 @@ msgstr ""
 #, python-format
 msgid ""
 "Yes. Many developers choose to host their own add-ons. Choosing to host your add-on on <a href=\"%(amo_url)s\">Mozilla's add-on site</a>, though, allows for much greater exposure to your add-on due "
-"to the large volume of visitors to the site.  <a href=\"%(md_url)s\">mozdev.org</a> offers free project hosting for Mozilla applications and extensions providing developers with tools to help "
-"manage source code, version control, bug tracking and documentation."
+"to the large volume of visitors to the site. <a href=\"%(md_url)s\">mozdev.org</a> offers free project hosting for Mozilla applications and extensions providing developers with tools to help manage "
+"source code, version control, bug tracking and documentation."
 msgstr ""
 
 #: src/olympia/pages/templates/pages/dev_faq.html:277
@@ -9845,7 +9706,7 @@ msgstr ""
 #: src/olympia/pages/templates/pages/dev_faq.html:314
 #, python-format
 msgid ""
-"Yes. Mozilla's <a href=\"%(p_url)s\">Add-on Policy</a> describes what is an acceptable submission. This policy is subject to change without notice.  In addition, the AMO editorial team uses the <a "
+"Yes. Mozilla's <a href=\"%(p_url)s\">Add-on Policy</a> describes what is an acceptable submission. This policy is subject to change without notice. In addition, the AMO editorial team uses the <a "
 "href=\"%(g_url)s\">Editors Reviewing Guide</a> to ensure that your add-on meets specific guidelines for functionality and security."
 msgstr ""
 
@@ -9962,7 +9823,7 @@ msgstr ""
 #: src/olympia/pages/templates/pages/dev_faq.html:434
 #, python-format
 msgid ""
-"This is why it's very important to read the <a href=\"%(g_url)s\">Editors Reviewing Guide</a> to ensure that your add-on is setup as expected.  It's also a good idea to read the blog post, <a href="
+"This is why it's very important to read the <a href=\"%(g_url)s\">Editors Reviewing Guide</a> to ensure that your add-on is setup as expected. It's also a good idea to read the blog post, <a href="
 "\"%(blog_url)s\">Successfully Getting your Add-on Reviewed</a> which provides excellent insight into ensuring a smooth review of your add-on."
 msgstr ""
 
@@ -10072,7 +9933,7 @@ msgstr ""
 
 #: src/olympia/pages/templates/pages/dev_faq.html:572
 msgid ""
-"Free Software Foundation provides short summaries of the key open source licenses, including whether the license qualifies as a free software license or a copyleft license.  Also includes a "
+"Free Software Foundation provides short summaries of the key open source licenses, including whether the license qualifies as a free software license or a copyleft license. Also includes a "
 "discussion of what constitutes a free software license or a copyleft license (e.g., a Copyleft license is a general method for making a program or other work free, and requiring all modified and "
 "extended versions of the program to be free as well.)"
 msgstr ""
@@ -10250,19 +10111,13 @@ msgid "Add-on Gallery"
 msgstr ""
 
 #: src/olympia/pages/templates/pages/faq.html:171
-msgid ""
-"How do I choose between add-ons that seem to do the same\n"
-"    thing?"
+msgid "How do I choose between add-ons that seem to do the same thing?"
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:173
+#: src/olympia/pages/templates/pages/faq.html:172
 msgid ""
-"There are often several add-ons that have similar features. To\n"
-"    figure out which is right for you, read the entire description of the\n"
-"    add-on and view its screenshots. If there are still several in the running,\n"
-"    read through the add-on's ratings, user reviews, and statistics to see\n"
-"    which is most liked by other users. Remember that you can also just try\n"
-"    out both and see which you like better."
+"There are often several add-ons that have similar features. To figure out which is right for you, read the entire description of the add-on and view its screenshots. If there are still several in "
+"the running, read through the add-on's ratings, user reviews, and statistics to see which is most liked by other users. Remember that you can also just try out both and see which you like better."
 msgstr ""
 
 #: src/olympia/pages/templates/pages/faq.html:180
@@ -10303,80 +10158,67 @@ msgid "How much do add-ons cost to purchase?"
 msgstr ""
 
 #: src/olympia/pages/templates/pages/faq.html:207
-msgid ""
-"Add-ons hosted in our gallery are free unless clearly marked\n"
-"    otherwise."
+msgid "Add-ons hosted in our gallery are free unless clearly marked otherwise."
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:210
+#: src/olympia/pages/templates/pages/faq.html:209
 msgid "What does it mean when an add-on asks for contributions?"
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:211
+#: src/olympia/pages/templates/pages/faq.html:210
 msgid ""
-"Some add-on authors request users who enjoy an add-on to\n"
-"        contribute to its development by making a monetary contribution. These\n"
-"        contributions go directly to the developer unless a third party is\n"
-"        indicated, such as the non-profit Mozilla Foundation."
+"Some add-on authors request users who enjoy an add-on to contribute to its development by making a monetary contribution. These contributions go directly to the developer unless a third party is "
+"indicated, such as the non-profit Mozilla Foundation."
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:216
+#: src/olympia/pages/templates/pages/faq.html:215
 msgid "What are beta add-ons?"
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:218
+#: src/olympia/pages/templates/pages/faq.html:217
 msgid ""
-"Beta add-ons are unreviewed versions which represent the\n"
-"        latest work of an add-on author. While different authors have different\n"
-"        standards for beta code quality, you should assume that these add-ons\n"
-"        are less stable than the general add-on releases."
+"Beta add-ons are unreviewed versions which represent the latest work of an add-on author. While different authors have different standards for beta code quality, you should assume that these add-"
+"ons are less stable than the general add-on releases."
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:222
+#: src/olympia/pages/templates/pages/faq.html:221
 msgid ""
 "Please note that when you install an add-on from the \"Beta Version\" section of an add-on's listing, you will continue to receive updates for that add-on as they become available. Like the initial "
 "version you installed, all beta releases are unreviewed by Mozilla and may harm your computer."
 msgstr ""
 
+#: src/olympia/pages/templates/pages/faq.html:228
+msgid "What does it mean when an add-on is flagged as slow?"
+msgstr ""
+
 #: src/olympia/pages/templates/pages/faq.html:229
-msgid ""
-"What does it mean when an add-on is flagged as\n"
-"    slow?"
+msgid "Most add-ons load code and resources at the same time Firefox is starting up. In most cases the impact in start-up time is minimal, but some add-ons can cause a noticeable slowdown."
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:231
-msgid ""
-"Most add-ons load code and resources at the same time Firefox\n"
-"        is starting up. In most cases the impact in start-up time is minimal,\n"
-"        but some add-ons can cause a noticeable slowdown."
-msgstr ""
-
-#: src/olympia/pages/templates/pages/faq.html:236
+#: src/olympia/pages/templates/pages/faq.html:234
 msgid "How do I report an inappropriate or spam user review?"
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:237
+#: src/olympia/pages/templates/pages/faq.html:235
 msgid ""
-"To report a user review of an add-on, log in with your account\n"
-"    and visit the add-on's reviews page. Find the review you wish to report,\n"
-"    click \"Report this review\" and select a reason. Our editorial team will\n"
-"    investigate the review and take appropriate action."
+"To report a user review of an add-on, log in with your account and visit the add-on's reviews page. Find the review you wish to report, click \"Report this review\" and select a reason. Our "
+"editorial team will investigate the review and take appropriate action."
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:242
+#: src/olympia/pages/templates/pages/faq.html:240
 msgid "How do I report a bug or contact the Mozilla Add-ons team?"
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:243
+#: src/olympia/pages/templates/pages/faq.html:241
 #, python-format
 msgid "Please visit our <a href=\"%(contact_url)s\">Contact page</a>."
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:246
+#: src/olympia/pages/templates/pages/faq.html:244
 msgid "What is a Source Code License?"
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:247
+#: src/olympia/pages/templates/pages/faq.html:245
 #, python-format
 msgid ""
 "The source code used to create an add-on is an exclusive copyright of the add-on author, unless otherwise declared in a source code license. Many add-ons on this site have <a href=\"%(url)s\" lang="
@@ -10384,60 +10226,60 @@ msgid ""
 "the GPL or BSD licenses instead of making up their own."
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:256
+#: src/olympia/pages/templates/pages/faq.html:254
 #, python-format
 msgid "Firefox and other Mozilla software are <a href=\"%(url)s\">open source</a>."
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:264
+#: src/olympia/pages/templates/pages/faq.html:262
 msgid "Collections and Favorites"
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:267
+#: src/olympia/pages/templates/pages/faq.html:265
 msgid "What is a collection?"
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:268
+#: src/olympia/pages/templates/pages/faq.html:266
 msgid "Collections are groups of related add-ons created by users to share."
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:270
+#: src/olympia/pages/templates/pages/faq.html:268
 msgid "What is the My Favorites collection?"
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:271
+#: src/olympia/pages/templates/pages/faq.html:269
 msgid "Favorite add-ons are add-ons that you have bookmarked to easily get back to later. You can add an add-on to your favorites collection by clicking \"Add to favorites\" on its details page."
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:275 src/olympia/templates/menu_links.html:13 src/olympia/templates/impala/header_title.html:17
+#: src/olympia/pages/templates/pages/faq.html:273 src/olympia/templates/menu_links.html:13 src/olympia/templates/impala/header_title.html:17
 msgid "Mobile Add-ons"
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:278
+#: src/olympia/pages/templates/pages/faq.html:276
 msgid "What are mobile add-ons?"
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:279
+#: src/olympia/pages/templates/pages/faq.html:277
 #, python-format
 msgid ""
 "Mobile add-ons work with <a href=\"%(mobile_url)s\">Firefox for Mobile</a> and add or modify functionality just like desktop add-ons. You can find add-ons that work with Firefox for Mobile in our "
 "<a href=\"%(gallery_url)s\">gallery</a>."
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:288
+#: src/olympia/pages/templates/pages/faq.html:286
 msgid "Developer Topics"
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:289
+#: src/olympia/pages/templates/pages/faq.html:287
 #, python-format
 msgid "Please see our <a href=\"%(faq_url)s\">Developer FAQ</a> and <a href=\"%(hub_url)s\">Developer Hub</a> for answers to add-on developer-related questions."
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:294
+#: src/olympia/pages/templates/pages/faq.html:292
 msgid "Still have questions?"
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:295
+#: src/olympia/pages/templates/pages/faq.html:293
 #, python-format
 msgid "For general Firefox support, visit our <a href=\"%(sumo_url)s\">support website</a>. For general add-on and website questions, visit our <a href=\"%(forum_url)s\">forum</a>."
 msgstr ""
@@ -10575,7 +10417,7 @@ msgstr ""
 
 #: src/olympia/pages/templates/pages/sunbird.html:29
 msgid ""
-"Development on the Sunbird project has halted and its final release was on March 30, 2010.  We've been proud to host Sunbird add-ons on this site but as the project is no longer maintained we have "
+"Development on the Sunbird project has halted and its final release was on March 30, 2010. We've been proud to host Sunbird add-ons on this site but as the project is no longer maintained we have "
 "disabled our support for the add-ons."
 msgstr ""
 
@@ -10656,7 +10498,7 @@ msgstr ""
 #, python-format
 msgid ""
 "<h2>Keep these tips in mind:</h2> <ul> <li> Write like you're telling a friend about your experience with the add-on. Give specifics and helpful details, such as what features you liked and/or "
-"disliked, how easy to use it is, and any disadvantages it has.  Avoid generic language such as calling it \"Great\" or \"Bad\" unless you can give reasons why you believe this is so. </li> <li> "
+"disliked, how easy to use it is, and any disadvantages it has. Avoid generic language such as calling it \"Great\" or \"Bad\" unless you can give reasons why you believe this is so. </li> <li> "
 "Please do not post bug reports in reviews. We do not make your email address available to add-on developers and they may need to contact you to help resolve your issue. See the <a href=\"%(support)s"
 "\">support section</a> to find out where to get assistance for this add-on. </li> <li>Please keep reviews clean, avoid the use of improper language and do not post any personal information. </li> </"
 "ul> <p>Please read the <a href=\"%(guide)s\" target=\"_blank\">Review Guidelines</a> for more detail about user add-on reviews.</p>"
@@ -10919,16 +10761,16 @@ msgstr ""
 
 #. L10n: {0} is an application, such as Firefox. This means "any version of
 #. Firefox."
-#: src/olympia/search/views.py:554
+#: src/olympia/search/views.py:547
 msgid "Any {0}"
 msgstr ""
 
 #. L10n: "All Systems" means show everything regardless of platform.
-#: src/olympia/search/views.py:589
+#: src/olympia/search/views.py:582
 msgid "All Systems"
 msgstr ""
 
-#: src/olympia/search/views.py:600
+#: src/olympia/search/views.py:593
 msgid "All Tags"
 msgstr ""
 
@@ -11106,31 +10948,31 @@ msgstr "Share this Add-on"
 msgid "Share this Collection"
 msgstr "Create Collection"
 
-#: src/olympia/signing/views.py:30 src/olympia/templates/base.html:75 src/olympia/templates/impala/base.html:115
+#: src/olympia/signing/views.py:33 src/olympia/templates/base.html:71 src/olympia/templates/impala/base.html:112
 msgid "Some features are temporarily disabled while we perform website maintenance. We'll be back to full capacity shortly."
 msgstr ""
 
-#: src/olympia/signing/views.py:53
+#: src/olympia/signing/views.py:56
 msgid "Could not find add-on with id \"{}\"."
 msgstr ""
 
-#: src/olympia/signing/views.py:67
+#: src/olympia/signing/views.py:70
 msgid "You do not own this addon."
 msgstr ""
 
-#: src/olympia/signing/views.py:82
+#: src/olympia/signing/views.py:87
 msgid "Missing \"upload\" key in multipart file data."
 msgstr ""
 
-#: src/olympia/signing/views.py:96
+#: src/olympia/signing/views.py:101
 msgid "Version does not match the manifest file."
 msgstr ""
 
-#: src/olympia/signing/views.py:100
+#: src/olympia/signing/views.py:105
 msgid "Version already exists."
 msgstr ""
 
-#: src/olympia/signing/views.py:136
+#: src/olympia/signing/views.py:141
 msgid "No uploaded file for that addon and version."
 msgstr ""
 
@@ -11243,90 +11085,90 @@ msgstr ""
 msgid "Statistics Dashboard :: Add-ons for {0}"
 msgstr ""
 
-#: src/olympia/stats/templates/stats/stats.html:30
-msgid "Controls:"
-msgstr ""
-
-#: src/olympia/stats/templates/stats/stats.html:33
-msgid "reset zoom"
-msgstr ""
-
-#: src/olympia/stats/templates/stats/stats.html:40
-msgid "Group by:"
-msgstr ""
-
-#: src/olympia/stats/templates/stats/stats.html:42
-msgid "day"
-msgstr ""
-
-#: src/olympia/stats/templates/stats/stats.html:45
-msgid "week"
-msgstr ""
-
-#: src/olympia/stats/templates/stats/stats.html:48
-msgid "month"
-msgstr ""
-
-#: src/olympia/stats/templates/stats/stats.html:54
-msgid "For last:"
-msgstr ""
-
-#: src/olympia/stats/templates/stats/stats.html:57
-msgid "7 days"
-msgstr ""
-
-#: src/olympia/stats/templates/stats/stats.html:60
-msgid "30 days"
-msgstr ""
-
-#: src/olympia/stats/templates/stats/stats.html:63
-msgid "90 days"
-msgstr ""
-
-#: src/olympia/stats/templates/stats/stats.html:66
-msgid "365 days"
-msgstr ""
-
-#: src/olympia/stats/templates/stats/stats.html:69
-msgid "Custom..."
-msgstr ""
-
 #. {0} is an add-on name
-#: src/olympia/stats/templates/stats/stats.html:88 src/olympia/stats/templates/stats/stats.html:91
+#: src/olympia/stats/templates/stats/stats.html:44 src/olympia/stats/templates/stats/stats.html:47
 #, fuzzy
 msgid "Statistics for {0}"
 msgstr "Statistics for {0}"
 
-#: src/olympia/stats/templates/stats/stats.html:94
+#: src/olympia/stats/templates/stats/stats.html:50
 msgid "Statistics Dashboard"
 msgstr ""
 
-#: src/olympia/stats/templates/stats/stats.html:104
+#: src/olympia/stats/templates/stats/stats.html:57
+msgid "Controls:"
+msgstr ""
+
+#: src/olympia/stats/templates/stats/stats.html:60
+msgid "reset zoom"
+msgstr ""
+
+#: src/olympia/stats/templates/stats/stats.html:67
+msgid "Group by:"
+msgstr ""
+
+#: src/olympia/stats/templates/stats/stats.html:69
+msgid "day"
+msgstr ""
+
+#: src/olympia/stats/templates/stats/stats.html:72
+msgid "week"
+msgstr ""
+
+#: src/olympia/stats/templates/stats/stats.html:75
+msgid "month"
+msgstr ""
+
+#: src/olympia/stats/templates/stats/stats.html:81
+msgid "For last:"
+msgstr ""
+
+#: src/olympia/stats/templates/stats/stats.html:84
+msgid "7 days"
+msgstr ""
+
+#: src/olympia/stats/templates/stats/stats.html:87
+msgid "30 days"
+msgstr ""
+
+#: src/olympia/stats/templates/stats/stats.html:90
+msgid "90 days"
+msgstr ""
+
+#: src/olympia/stats/templates/stats/stats.html:93
+msgid "365 days"
+msgstr ""
+
+#: src/olympia/stats/templates/stats/stats.html:96
+msgid "Custom..."
+msgstr ""
+
+#: src/olympia/stats/templates/stats/stats.html:106
 msgid "Statistics processing is currently disabled, so recent data is unavailable. The statistics are still being collected and this page will be updated soon with the missing data."
 msgstr ""
 
-#: src/olympia/stats/templates/stats/stats.html:110
+#: src/olympia/stats/templates/stats/stats.html:112
 msgid "Loading the latest data&hellip;"
 msgstr ""
 
-#: src/olympia/stats/templates/stats/stats.html:142 src/olympia/stats/templates/stats/reports/overview.html:25 src/olympia/stats/templates/stats/reports/overview.html:37
+#: src/olympia/stats/templates/stats/stats.html:144 src/olympia/stats/templates/stats/reports/overview.html:25 src/olympia/stats/templates/stats/reports/overview.html:37
 #: src/olympia/stats/templates/stats/reports/overview.html:49
 msgid "No data available."
 msgstr ""
 
-#: src/olympia/stats/templates/stats/stats.html:177
+#: src/olympia/stats/templates/stats/stats.html:179
 msgid "This dashboard is currently <b>public</b>."
 msgstr ""
 
-#: src/olympia/stats/templates/stats/stats.html:179
+#: src/olympia/stats/templates/stats/stats.html:181
 msgid "Contribution stats are currently <b>private</b>."
 msgstr ""
 
-#: src/olympia/stats/templates/stats/stats.html:182
+#: src/olympia/stats/templates/stats/stats.html:184
 msgid "This dashboard is currently <b>private</b>."
 msgstr ""
 
-#: src/olympia/stats/templates/stats/stats.html:185
+#: src/olympia/stats/templates/stats/stats.html:187
 msgid "Change settings."
 msgstr ""
 
@@ -11478,17 +11320,6 @@ msgstr ""
 msgid "Application versions by Date"
 msgstr ""
 
-# {0} is a number
-#: src/olympia/tags/templates/tags/top_cloud.html:4
-#, fuzzy
-msgid "Top {0} Tags"
-msgstr "Top {0} Tags"
-
-#. {0} is the current application name
-#: src/olympia/tags/templates/tags/top_cloud.html:14
-msgid "{0} Top Tags"
-msgstr ""
-
 #: src/olympia/templates/amo_footer.html:6 src/olympia/templates/includes/lang_switcher.html:2
 msgid "Other languages"
 msgstr ""
@@ -11497,12 +11328,12 @@ msgstr ""
 msgid "Mozilla Add-ons"
 msgstr ""
 
-#: src/olympia/templates/base.html:91 src/olympia/templates/impala/base.html:81
+#: src/olympia/templates/base.html:89 src/olympia/templates/impala/base.html:78
 #, fuzzy
 msgid "Find add-ons for other applications"
 msgstr "Find add-ons for other applications"
 
-#: src/olympia/templates/base.html:92 src/olympia/templates/impala/base.html:81
+#: src/olympia/templates/base.html:90 src/olympia/templates/impala/base.html:78
 #, fuzzy
 msgid "Other Applications"
 msgstr "Other Applications"
@@ -11529,7 +11360,7 @@ msgid "View Mobile Site"
 msgstr ""
 
 #: src/olympia/templates/copyright.html:7
-msgid "Site Status "
+msgid "Site Status"
 msgstr ""
 
 #: src/olympia/templates/footer.html:3
@@ -11634,35 +11465,35 @@ msgstr ""
 msgid "<a href=\"%(reg)s\">Register</a> or <a href=\"%(login)s\">Log in</a>"
 msgstr ""
 
-#: src/olympia/templates/impala/base.html:126
+#: src/olympia/templates/impala/base.html:123
 #, python-format
 msgid "To try the thousands of add-ons available here, download <a href=\"%(url)s\">Mozilla Firefox</a>, a fast, free way to surf the Web!"
 msgstr ""
 
-#: src/olympia/templates/impala/base.html:138
+#: src/olympia/templates/impala/base.html:135
 #, python-format
 msgid "Add-ons is switching to Firefox Accounts for login. <a href=\"%(url)s\" class=\"fxa-login\">Sign in now to transfer your account.</a>"
 msgstr ""
 
 #. {0} is an application, such as Firefox.
-#: src/olympia/templates/impala/base.html:148
+#: src/olympia/templates/impala/base.html:145
 msgid "Welcome to {0} Add-ons."
 msgstr ""
 
-#: src/olympia/templates/impala/base.html:151
+#: src/olympia/templates/impala/base.html:148
 msgid "Choose from thousands of extra features and styles to make Firefox your own."
 msgstr ""
 
-#: src/olympia/templates/impala/base.html:156
+#: src/olympia/templates/impala/base.html:153
 #, python-format
 msgid "Add extra features and styles to make %(app)s your own."
 msgstr ""
 
-#: src/olympia/templates/impala/base.html:164
+#: src/olympia/templates/impala/base.html:161
 msgid "On the go?"
 msgstr ""
 
-#: src/olympia/templates/impala/base.html:166
+#: src/olympia/templates/impala/base.html:163
 msgid "Check out our <a class=\"mobile-link\" href=\"#\">Mobile Add-ons site</a>."
 msgstr ""
 
@@ -11891,19 +11722,19 @@ msgstr ""
 
 #. L10n: {id} will be something like "13ad6a", just a random number
 #. to differentiate this user from other anonymous users.
-#: src/olympia/users/models.py:353
+#: src/olympia/users/models.py:362
 msgid "Anonymous user {id}"
 msgstr ""
 
-#: src/olympia/users/models.py:410
+#: src/olympia/users/models.py:419
 msgid "Your account has been restricted"
 msgstr ""
 
-#: src/olympia/users/models.py:480
+#: src/olympia/users/models.py:489
 msgid "Please confirm your email address"
 msgstr ""
 
-#: src/olympia/users/models.py:506
+#: src/olympia/users/models.py:515
 msgid "My Mobile Add-ons"
 msgstr ""
 
@@ -12190,7 +12021,7 @@ msgstr "Password"
 
 #: src/olympia/users/templates/users/edit.html:70
 #, python-format
-msgid "Change your password.  If you forgot your password, you can <a href=\"%(reset_url)s\">use the reset form</a>."
+msgid "Change your password. If you forgot your password, you can <a href=\"%(reset_url)s\">use the reset form</a>."
 msgstr ""
 
 #: src/olympia/users/templates/users/edit.html:76
@@ -12210,7 +12041,7 @@ msgid "Profile"
 msgstr ""
 
 #: src/olympia/users/templates/users/edit.html:100
-msgid "Give us a bit more information about yourself.  All these fields are optional, but they'll help other users get to know you better."
+msgid "Give us a bit more information about yourself. All these fields are optional, but they'll help other users get to know you better."
 msgstr ""
 
 #: src/olympia/users/templates/users/edit.html:124
@@ -12443,7 +12274,7 @@ msgid "Confirm password"
 msgstr "Confirm password"
 
 #: src/olympia/users/templates/users/pwreset_confirm.html:47
-msgid "The password reset link was invalid, possibly because it has already been used.  Please request a new password reset."
+msgid "The password reset link was invalid, possibly because it has already been used. Please request a new password reset."
 msgstr ""
 
 #: src/olympia/users/templates/users/pwreset_request.html:15
@@ -12630,7 +12461,7 @@ msgstr ""
 
 #: src/olympia/users/templates/users/unsubscribe.html:30
 #, python-format
-msgid "Unfortunately, we weren't able to unsubscribe you.  The link you clicked is invalid. However, you can unsubscribe still unsubscribe on your <a href=\"%(edit_url)s\">edit profile page</a>."
+msgid "Unfortunately, we weren't able to unsubscribe you. The link you clicked is invalid. However, you can unsubscribe still unsubscribe on your <a href=\"%(edit_url)s\">edit profile page</a>."
 msgstr ""
 
 #: src/olympia/users/templates/users/vcard.html:2
@@ -12687,15 +12518,15 @@ msgstr ""
 msgid "Version History with Changelogs"
 msgstr "Version History with Changelogs"
 
-#: src/olympia/versions/models.py:314
+#: src/olympia/versions/models.py:313
 msgid "Add-on uses binary components."
 msgstr ""
 
-#: src/olympia/versions/models.py:317
+#: src/olympia/versions/models.py:316
 msgid "Add-on has opted into strict compatibility checking."
 msgstr ""
 
-#: src/olympia/versions/models.py:715
+#: src/olympia/versions/models.py:711
 msgid "{app} {min} and later"
 msgstr ""
 
@@ -12775,4 +12606,8 @@ msgstr ""
 
 #: src/olympia/zadmin/forms.py:105
 msgid "Log emails instead of sending"
+msgstr ""
+
+#: src/olympia/zadmin/forms.py:215
+msgid "Deleted versions can`t be changed."
 msgstr ""

--- a/locale/fy_NL/LC_MESSAGES/djangojs.po
+++ b/locale/fy_NL/LC_MESSAGES/djangojs.po
@@ -1,1215 +1,1235 @@
-
 msgid ""
 msgstr ""
 "Project-Id-Version: AMO-JS 0.1\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2016-02-24 21:23+0000\n"
+"POT-Creation-Date: 2016-04-18 15:47+0000\n"
 "PO-Revision-Date: 2008-09-22 13:20-0700\n"
 "Last-Translator: Wil Clouser <wclouser@mozilla.com>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
+"Language: \n"
 "MIME-Version: 1.0\n"
-"Content-Type: text/plain; charset=utf-8\n"
+"Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Generated-By: Babel 2.2.0\n"
 
-#: static/js/common/ratingwidget.js:31
+#: static/js/common-all.js:1426 static/js/impala-all.js:1511 static/js/zamboni/discovery-all.js:12598 static/js/zamboni/init.js:28 static/js/zamboni/mobile-all.js:14945
+msgid "This feature is temporarily disabled while we perform website maintenance. Please check back a little later."
+msgstr ""
+
+#. L10n: {0} is an app name like Firefox.
+#: static/js/common-all.js:1837 static/js/impala-all.js:1922 static/js/zamboni/buttons.js:73 static/js/zamboni/discovery-all.js:13108
+msgid "Accept and Install"
+msgstr ""
+
+#: static/js/common-all.js:1837 static/js/impala-all.js:1922 static/js/zamboni/buttons.js:73 static/js/zamboni/discovery-all.js:13108
+msgid "Add to {0}"
+msgstr ""
+
+#: static/js/common-all.js:1842 static/js/impala-all.js:1927 static/js/zamboni/buttons.js:78 static/js/zamboni/discovery-all.js:13113
+msgid "Download Now"
+msgstr ""
+
+#: static/js/common-all.js:1883 static/js/impala-all.js:1968 static/js/zamboni/buttons.js:119 static/js/zamboni/discovery-all.js:13154
+msgid "Add-on has not been updated to support default-to-compatible."
+msgstr ""
+
+#: static/js/common-all.js:1888 static/js/impala-all.js:1973 static/js/zamboni/buttons.js:124 static/js/zamboni/discovery-all.js:13159
+msgid "You need to be using Firefox 10.0 or higher."
+msgstr ""
+
+#: static/js/common-all.js:1900 static/js/impala-all.js:1985 static/js/zamboni/buttons.js:136 static/js/zamboni/discovery-all.js:13171
+msgid "Mozilla has marked this version as incompatible with your Firefox version."
+msgstr ""
+
+#. L10n: {0} is an platform like Windows or Linux.
+#: static/js/common-all.js:1981 static/js/impala-all.js:2066 static/js/zamboni/buttons.js:217 static/js/zamboni/discovery-all.js:13252
+msgid "Install for {0} anyway"
+msgstr ""
+
+#: static/js/common-all.js:1981 static/js/impala-all.js:2066 static/js/zamboni/buttons.js:217 static/js/zamboni/discovery-all.js:13252
+msgid "Download for {0} anyway"
+msgstr ""
+
+#: static/js/common-all.js:2038 static/js/impala-all.js:2123 static/js/zamboni/buttons.js:274 static/js/zamboni/discovery-all.js:13309
+msgid "Not available for your platform"
+msgstr ""
+
+#. L10n: {0} is an app name, {1} is the app version.
+#: static/js/common-all.js:2049 static/js/common-all.js:2086 static/js/impala-all.js:2134 static/js/impala-all.js:2171 static/js/zamboni/buttons.js:286 static/js/zamboni/buttons.js:324
+#: static/js/zamboni/discovery-all.js:13320 static/js/zamboni/discovery-all.js:13357
+msgid "Not available for {0} {1}"
+msgstr ""
+
+#: static/js/common-all.js:2112 static/js/impala-all.js:2197 static/js/zamboni/buttons.js:351 static/js/zamboni/discovery-all.js:13383
+msgid "Works with {app} {min} - {max}"
+msgstr ""
+
+#: static/js/common-all.js:2114 static/js/impala-all.js:2199 static/js/zamboni/buttons.js:353 static/js/zamboni/discovery-all.js:13385
+msgid "View other versions"
+msgstr ""
+
+#: static/js/common-all.js:2162 static/js/impala-all.js:2247 static/js/zamboni/buttons.js:401 static/js/zamboni/discovery-all.js:13433
+msgid "Only with Firefox — Get Firefox Now!"
+msgstr ""
+
+#: static/js/common-all.js:2278 static/js/impala-all.js:2363 static/js/zamboni/buttons.js:517 static/js/zamboni/discovery-all.js:13549 static/js/zamboni/mobile-all.js:15177
+#: static/js/zamboni/mobile/buttons.js:43
+msgid "Sorry, you need a Mozilla-based browser (such as Firefox) to install a search plugin."
+msgstr ""
+
+#: static/js/common-all.js:9088 static/js/impala-all.js:9649 static/js/zamboni/global.js:410
+msgid "Loading..."
+msgstr ""
+
+#. L10n: {0} is the number of characters left.
+#: static/js/common-all.js:9152 static/js/impala-all.js:9713 static/js/zamboni/global.js:474
+msgid "<b>{0}</b> character left."
+msgid_plural "<b>{0}</b> characters left."
+msgstr[0] ""
+msgstr[1] ""
+
+#: static/js/common-all.js:9589 static/js/common-min.js:6 static/js/impala-all.js:10052 static/js/impala-min.js:6 static/js/common/ratingwidget.js:31 static/js/zamboni/mobile-all.js:16123
+#: static/js/zamboni/mobile-min.js:6
 msgid "{0} star"
 msgid_plural "{0} stars"
 msgstr[0] ""
 msgstr[1] ""
 
-#: static/js/common/upload-addon.js:41 static/js/common/upload-image.js:128
+#: static/js/common-all.js:9676 static/js/common-min.js:6 static/js/impala-all.js:10139 static/js/impala-min.js:6 static/js/zamboni/l10n.js:45
+msgid "Remove this localization"
+msgstr ""
+
+#: static/js/common-all.js:10193 static/js/common-min.js:6 static/js/impala-all.js:10674 static/js/impala-min.js:6 static/js/zamboni/discovery-all.js:13678
+msgid "close"
+msgstr ""
+
+#: static/js/common-all.js:10860 static/js/common-min.js:6 static/js/impala-all.js:11481 static/js/impala-min.js:6 static/js/impala/reviews.js:23 static/js/zamboni/reviews.js:18
+msgid "Flagged for review"
+msgstr ""
+
+#: static/js/common-all.js:10876 static/js/common-min.js:6 static/js/impala-all.js:11498 static/js/impala-min.js:6 static/js/impala/reviews.js:40 static/js/zamboni/reviews.js:34
+msgid "Your input is required"
+msgstr ""
+
+#: static/js/common-all.js:10945 static/js/common-min.js:6 static/js/impala-all.js:11610 static/js/impala-min.js:7 static/js/impala/reviews.js:152 static/js/zamboni/reviews.js:103
+msgid "Marked for deletion"
+msgstr ""
+
+#: static/js/common-all.js:11573 static/js/common-min.js:7 static/js/impala-all.js:13809 static/js/impala-min.js:8 static/js/zamboni/collections.js:229
+msgid "Adding to Favorites&hellip;"
+msgstr ""
+
+#: static/js/common-all.js:11576 static/js/common-min.js:7 static/js/impala-all.js:13812 static/js/impala-min.js:8 static/js/zamboni/collections.js:232
+msgid "Removing Favorite&hellip;"
+msgstr ""
+
+#: static/js/common-all.js:11579 static/js/common-min.js:7 static/js/impala-all.js:13815 static/js/impala-min.js:8 static/js/zamboni/collections.js:235
+msgid "Add to Favorites"
+msgstr ""
+
+#: static/js/common-all.js:11582 static/js/common-min.js:7 static/js/impala-all.js:13818 static/js/impala-min.js:8 static/js/zamboni/collections.js:238
+msgid "Remove from Favorites"
+msgstr ""
+
+#: static/js/common-all.js:11647 static/js/common-min.js:7 static/js/impala-all.js:13883 static/js/impala-min.js:8 static/js/zamboni/collections.js:303
+msgid "Pending"
+msgstr ""
+
+#: static/js/common-all.js:11648 static/js/common-min.js:7 static/js/impala-all.js:13884 static/js/impala-min.js:8 static/js/zamboni/collections.js:304
+msgid "Add a comment"
+msgstr ""
+
+#: static/js/common-all.js:11648 static/js/common-min.js:7 static/js/impala-all.js:13884 static/js/impala-min.js:8 static/js/zamboni/collections.js:304
+msgid "Comment"
+msgstr ""
+
+#: static/js/common-all.js:11649 static/js/common-min.js:7 static/js/impala-all.js:13885 static/js/impala-min.js:8 static/js/zamboni/collections.js:305
+msgid "Remove this add-on from the collection"
+msgstr ""
+
+#: static/js/common-all.js:11649 static/js/common-all.js:11678 static/js/common-min.js:7 static/js/impala-all.js:13885 static/js/impala-all.js:13914 static/js/impala-min.js:8
+#: static/js/zamboni/collections.js:305 static/js/zamboni/collections.js:334
+msgid "Remove"
+msgstr ""
+
+#: static/js/common-all.js:11678 static/js/common-min.js:7 static/js/impala-all.js:13914 static/js/impala-min.js:8 static/js/zamboni/collections.js:334
+msgid "Remove this user as a contributor"
+msgstr ""
+
+#: static/js/common-all.js:11690 static/js/common-min.js:7 static/js/impala-all.js:13926 static/js/impala-min.js:8 static/js/zamboni/collections.js:346
+msgid "An email address is required."
+msgstr ""
+
+#: static/js/common-all.js:11708 static/js/common-min.js:7 static/js/impala-all.js:13944 static/js/impala-min.js:8 static/js/zamboni/collections.js:364
+msgid "You cannot add yourself as a contributor."
+msgstr ""
+
+#: static/js/common-all.js:11710 static/js/common-min.js:7 static/js/impala-all.js:13946 static/js/impala-min.js:8 static/js/zamboni/collections.js:366
+msgid "You have already added that user."
+msgstr ""
+
+#: static/js/common-all.js:11917 static/js/common-min.js:7 static/js/impala-all.js:14153 static/js/impala-min.js:8 static/js/zamboni/collections.js:573
+msgid "Add to favorites"
+msgstr ""
+
+#: static/js/common-all.js:11921 static/js/common-min.js:7 static/js/impala-all.js:14157 static/js/impala-min.js:8 static/js/zamboni/collections.js:577
+msgid "Remove from favorites"
+msgstr ""
+
+#: static/js/common-all.js:11939 static/js/common-min.js:7 static/js/impala-all.js:14175 static/js/impala-all.js:14233 static/js/impala-min.js:8 static/js/impala/collections.js:10
+#: static/js/zamboni/collections.js:595
+msgid "Follow this Collection"
+msgstr ""
+
+#: static/js/common-all.js:11948 static/js/common-min.js:7 static/js/impala-all.js:14184 static/js/impala-min.js:8 static/js/zamboni/collections.js:604
+msgid "Stop following"
+msgstr ""
+
+#: static/js/common-all.js:12096 static/js/common-min.js:7 static/js/zamboni/password-strength.js:20
+msgid "Password strength:"
+msgstr ""
+
+#: static/js/common-all.js:12102 static/js/common-min.js:7 static/js/zamboni/password-strength.js:26
+msgid "At least {0} character left."
+msgid_plural "At least {0} characters left."
+msgstr[0] ""
+msgstr[1] ""
+
+#: static/js/common-all.js:12286 static/js/common-min.js:7 static/js/impala-all.js:14632 static/js/impala-min.js:8 static/js/impala/suggestions.js:39
+msgid "Search themes for <b>{0}</b>"
+msgstr ""
+
+#: static/js/common-all.js:12288 static/js/common-min.js:7 static/js/impala-all.js:14634 static/js/impala-min.js:8 static/js/impala/suggestions.js:41
+msgid "Search apps for <b>{0}</b>"
+msgstr ""
+
+#: static/js/common-all.js:12290 static/js/common-min.js:7 static/js/impala-all.js:14636 static/js/impala-min.js:8 static/js/impala/suggestions.js:43
+msgid "Search add-ons for <b>{0}</b>"
+msgstr ""
+
+#: static/js/common-all.js:12521 static/js/common-min.js:7 static/js/impala-all.js:14867 static/js/impala-min.js:8 static/js/impala/site_suggestions.js:46
+msgid "Category"
+msgstr ""
+
+#. L10n: {0} is an app name.
+#: static/js/impala-all.js:11632 static/js/impala-min.js:7 static/js/impala/listing.js:11 static/js/zamboni/themes.js:13
+msgid "This theme is incompatible with your version of {0}"
+msgstr ""
+
+#: static/js/impala-all.js:12146 static/js/impala-all.js:14331 static/js/impala-min.js:7 static/js/impala-min.js:8 static/js/common/upload-image.js:97 static/js/impala/users.js:51
+#: static/js/zamboni/devhub-all.js:894 static/js/zamboni/devhub-min.js:1
+msgid "Images must be either PNG or JPG."
+msgstr ""
+
+#: static/js/impala-all.js:12150 static/js/impala-min.js:7 static/js/common/upload-image.js:101 static/js/zamboni/devhub-all.js:898 static/js/zamboni/devhub-min.js:1
+msgid "Videos must be in WebM."
+msgstr ""
+
+#: static/js/impala-all.js:12177 static/js/impala-min.js:7 static/js/common/upload-addon.js:41 static/js/common/upload-image.js:128 static/js/zamboni/devhub-all.js:272
+#: static/js/zamboni/devhub-all.js:925 static/js/zamboni/devhub-min.js:1
 msgid "There was a problem contacting the server."
 msgstr ""
 
-#: static/js/common/upload-addon.js:69
+#: static/js/impala-all.js:13298 static/js/impala-min.js:7 static/js/impala/persona_creation.js:60
+msgid "All Rights Reserved"
+msgstr ""
+
+#: static/js/impala-all.js:13302 static/js/impala-min.js:7 static/js/impala/persona_creation.js:64
+msgid "Creative Commons Attribution 3.0"
+msgstr ""
+
+#: static/js/impala-all.js:13307 static/js/impala-min.js:7 static/js/impala/persona_creation.js:69
+msgid "Creative Commons Attribution-NonCommercial 3.0"
+msgstr ""
+
+#: static/js/impala-all.js:13312 static/js/impala-min.js:7 static/js/impala/persona_creation.js:74
+msgid "Creative Commons Attribution-NonCommercial-NoDerivs 3.0"
+msgstr ""
+
+#: static/js/impala-all.js:13317 static/js/impala-min.js:7 static/js/impala/persona_creation.js:79
+msgid "Creative Commons Attribution-NonCommercial-Share Alike 3.0"
+msgstr ""
+
+#: static/js/impala-all.js:13322 static/js/impala-min.js:7 static/js/impala/persona_creation.js:84
+msgid "Creative Commons Attribution-NoDerivs 3.0"
+msgstr ""
+
+#: static/js/impala-all.js:13327 static/js/impala-min.js:7 static/js/impala/persona_creation.js:89
+msgid "Creative Commons Attribution-ShareAlike 3.0"
+msgstr ""
+
+#: static/js/impala-all.js:13530 static/js/impala-min.js:7 static/js/impala/persona_creation.js:292
+msgid "Your Theme's Name"
+msgstr ""
+
+#: static/js/impala-all.js:14242 static/js/impala-min.js:8 static/js/impala/collections.js:19
+msgid "Stop Following"
+msgstr ""
+
+#: static/js/impala-all.js:14243 static/js/impala-min.js:8 static/js/impala/collections.js:20
+msgid "Following"
+msgstr ""
+
+#: static/js/impala-all.js:14313 static/js/impala-min.js:8 static/js/impala/users.js:33
+msgid "use original"
+msgstr ""
+
+#: static/js/impala-all.js:14523 static/js/impala-min.js:8 static/js/impala/search.js:114
+msgid "Updating results&hellip;"
+msgstr ""
+
+#: static/js/common/upload-addon.js:69 static/js/zamboni/devhub-all.js:300 static/js/zamboni/devhub-min.js:1
 msgid "Select a file..."
 msgstr ""
 
-#: static/js/common/upload-addon.js:70
+#: static/js/common/upload-addon.js:70 static/js/zamboni/devhub-all.js:301 static/js/zamboni/devhub-min.js:1
 msgid "Your add-on should end with .xpi, .jar or .xml"
 msgstr ""
 
 #. L10n: {0} is the percent of the file that has been uploaded.
-#: static/js/common/upload-addon.js:104
+#: static/js/common/upload-addon.js:104 static/js/zamboni/devhub-all.js:335 static/js/zamboni/devhub-min.js:1
 #, python-format
 msgid "{0}% complete"
 msgstr ""
 
 #. L10n: "{bytes uploaded} of {total filesize}".
-#: static/js/common/upload-addon.js:107
+#: static/js/common/upload-addon.js:107 static/js/zamboni/devhub-all.js:338 static/js/zamboni/devhub-min.js:1
 msgid "{0} of {1}"
 msgstr ""
 
-#: static/js/common/upload-addon.js:140
+#: static/js/common/upload-addon.js:140 static/js/zamboni/devhub-all.js:371 static/js/zamboni/devhub-min.js:1
 msgid "Cancel"
 msgstr ""
 
-#: static/js/common/upload-addon.js:162
+#: static/js/common/upload-addon.js:162 static/js/zamboni/devhub-all.js:393 static/js/zamboni/devhub-min.js:1
 msgid "Uploading {0}"
 msgstr ""
 
-#: static/js/common/upload-addon.js:189
+#: static/js/common/upload-addon.js:189 static/js/zamboni/devhub-all.js:420 static/js/zamboni/devhub-min.js:1
 msgid "Error with {0}"
 msgstr ""
 
-#: static/js/common/upload-addon.js:194
+#: static/js/common/upload-addon.js:194 static/js/zamboni/devhub-all.js:425 static/js/zamboni/devhub-min.js:1
 msgid "Your add-on failed validation with {0} error."
 msgid_plural "Your add-on failed validation with {0} errors."
 msgstr[0] ""
 msgstr[1] ""
 
-#: static/js/common/upload-addon.js:208
+#: static/js/common/upload-addon.js:208 static/js/zamboni/devhub-all.js:439 static/js/zamboni/devhub-min.js:1
 msgid "&hellip;and {0} more"
 msgid_plural "&hellip;and {0} more"
 msgstr[0] ""
 msgstr[1] ""
 
-#: static/js/common/upload-addon.js:222 static/js/common/upload-addon.js:512
+#: static/js/common/upload-addon.js:222 static/js/common/upload-addon.js:497 static/js/zamboni/devhub-all.js:453 static/js/zamboni/devhub-all.js:743 static/js/zamboni/devhub-min.js:1
 msgid "See full validation report"
 msgstr ""
 
-#: static/js/common/upload-addon.js:234
+#: static/js/common/upload-addon.js:234 static/js/zamboni/devhub-all.js:465 static/js/zamboni/devhub-min.js:1
 msgid "Validating {0}"
 msgstr ""
 
 #. L10n: first argument is an HTTP status code
-#: static/js/common/upload-addon.js:273
+#: static/js/common/upload-addon.js:273 static/js/zamboni/devhub-all.js:504 static/js/zamboni/devhub-min.js:1
 msgid "Received an empty response from the server; status: {0}"
 msgstr ""
 
-#: static/js/common/upload-addon.js:373
+#: static/js/common/upload-addon.js:370 static/js/zamboni/devhub-all.js:604 static/js/zamboni/devhub-min.js:1
 msgid "Unexpected server error while validating."
 msgstr ""
 
-#: static/js/common/upload-addon.js:412
+#: static/js/common/upload-addon.js:409 static/js/zamboni/devhub-all.js:643 static/js/zamboni/devhub-min.js:1
 msgid "Finished validating {0}"
 msgstr ""
 
-#: static/js/common/upload-addon.js:418
+#: static/js/common/upload-addon.js:415 static/js/zamboni/devhub-all.js:649 static/js/zamboni/devhub-min.js:1
 msgid "Your add-on validation timed out, it will be manually reviewed."
 msgstr ""
 
-#: static/js/common/upload-addon.js:421
+#: static/js/common/upload-addon.js:418 static/js/zamboni/devhub-all.js:652 static/js/zamboni/devhub-min.js:1
 msgid "Your add-on was validated with no errors and {0} warning."
 msgid_plural "Your add-on was validated with no errors and {0} warnings."
 msgstr[0] ""
 msgstr[1] ""
 
-#: static/js/common/upload-addon.js:426
+#: static/js/common/upload-addon.js:423 static/js/zamboni/devhub-all.js:657 static/js/zamboni/devhub-min.js:1
 msgid "Your add-on was validated with no errors and {0} message."
 msgid_plural "Your add-on was validated with no errors and {0} messages."
 msgstr[0] ""
 msgstr[1] ""
 
-#: static/js/common/upload-addon.js:431
+#: static/js/common/upload-addon.js:428 static/js/zamboni/devhub-all.js:662 static/js/zamboni/devhub-min.js:1
 msgid "Your add-on was validated with no errors or warnings."
 msgstr ""
 
-#: static/js/common/upload-addon.js:446
+#: static/js/common/upload-addon.js:443 static/js/zamboni/devhub-all.js:677 static/js/zamboni/devhub-min.js:1
 msgid "Your submission will be automatically signed."
 msgstr ""
 
-#: static/js/common/upload-addon.js:465
+#: static/js/common/upload-addon.js:450 static/js/zamboni/devhub-all.js:696 static/js/zamboni/devhub-min.js:1
 msgid "Include detailed version notes (this can be done in the next step)."
 msgstr ""
 
-#: static/js/common/upload-addon.js:466
+#: static/js/common/upload-addon.js:451 static/js/zamboni/devhub-all.js:697 static/js/zamboni/devhub-min.js:1
 msgid "If your add-on requires an account to a website in order to be fully tested, include a test username and password in the Notes to Reviewer (this can be done in the next step)."
 msgstr ""
 
-#: static/js/common/upload-addon.js:467
+#: static/js/common/upload-addon.js:452 static/js/zamboni/devhub-all.js:698 static/js/zamboni/devhub-min.js:1
 msgid "If your add-on is intended for a limited audience you should choose Preliminary Review instead of Full Review."
 msgstr ""
 
-#: static/js/common/upload-addon.js:480
+#: static/js/common/upload-addon.js:465 static/js/zamboni/devhub-all.js:711 static/js/zamboni/devhub-min.js:1
 msgid "Add-on submission checklist"
 msgstr ""
 
-#: static/js/common/upload-addon.js:481
+#: static/js/common/upload-addon.js:466 static/js/zamboni/devhub-all.js:712 static/js/zamboni/devhub-min.js:1
 msgid "Please verify the following points before finalizing your submission. This will minimize delays or misunderstanding during the review process:"
 msgstr ""
 
-#: static/js/common/upload-addon.js:483
+#: static/js/common/upload-addon.js:468 static/js/zamboni/devhub-all.js:714 static/js/zamboni/devhub-min.js:1
 msgid ""
 "Compiled binaries, as well as minified or obfuscated scripts (excluding known libraries) need to have their sources submitted separately for review. Make sure that you use the source code upload "
 "field to avoid having your submission rejected."
 msgstr ""
 
-#: static/js/common/upload-addon.js:501
+#: static/js/common/upload-addon.js:486 static/js/zamboni/devhub-all.js:732 static/js/zamboni/devhub-min.js:1
 msgid "The validation process found these issues that can lead to rejections:"
 msgstr ""
 
-#: static/js/common/upload-addon.js:518
+#: static/js/common/upload-addon.js:503 static/js/zamboni/devhub-all.js:749 static/js/zamboni/devhub-min.js:1
 msgid "If you are unfamiliar with the add-ons review process, you can read about it here."
 msgstr ""
 
-#: static/js/common/upload-addon.js:555
+#: static/js/common/upload-addon.js:540 static/js/zamboni/devhub-all.js:786 static/js/zamboni/devhub-min.js:1
 msgid "Sorry, no supported platform has been found."
 msgstr ""
 
-#: static/js/common/upload-base.js:57
+#: static/js/common/upload-base.js:57 static/js/zamboni/devhub-all.js:187 static/js/zamboni/devhub-min.js:1
 msgid "The filetype you uploaded isn't recognized."
 msgstr ""
 
-#: static/js/common/upload-base.js:79
+#: static/js/common/upload-base.js:79 static/js/zamboni/devhub-all.js:209 static/js/zamboni/devhub-min.js:1
 msgid "You cancelled the upload."
 msgstr ""
 
-#: static/js/common/upload-image.js:97 static/js/impala/users.js:51
-msgid "Images must be either PNG or JPG."
-msgstr ""
-
-#: static/js/common/upload-image.js:101
-msgid "Videos must be in WebM."
-msgstr ""
-
-#: static/js/impala/collections.js:10 static/js/zamboni/collections.js:595
-msgid "Follow this Collection"
-msgstr ""
-
-#: static/js/impala/collections.js:19
-msgid "Stop Following"
-msgstr ""
-
-#: static/js/impala/collections.js:20
-msgid "Following"
-msgstr ""
-
-#. L10n: {0} is an app name.
-#: static/js/impala/listing.js:11 static/js/zamboni/themes.js:13
-msgid "This theme is incompatible with your version of {0}"
-msgstr ""
-
-#: static/js/impala/persona_creation.js:60
-msgid "All Rights Reserved"
-msgstr ""
-
-#: static/js/impala/persona_creation.js:64
-msgid "Creative Commons Attribution 3.0"
-msgstr ""
-
-#: static/js/impala/persona_creation.js:69
-msgid "Creative Commons Attribution-NonCommercial 3.0"
-msgstr ""
-
-#: static/js/impala/persona_creation.js:74
-msgid "Creative Commons Attribution-NonCommercial-NoDerivs 3.0"
-msgstr ""
-
-#: static/js/impala/persona_creation.js:79
-msgid "Creative Commons Attribution-NonCommercial-Share Alike 3.0"
-msgstr ""
-
-#: static/js/impala/persona_creation.js:84
-msgid "Creative Commons Attribution-NoDerivs 3.0"
-msgstr ""
-
-#: static/js/impala/persona_creation.js:89
-msgid "Creative Commons Attribution-ShareAlike 3.0"
-msgstr ""
-
-#: static/js/impala/persona_creation.js:292
-msgid "Your Theme's Name"
-msgstr ""
-
-#: static/js/impala/reviews.js:23 static/js/zamboni/reviews.js:18
-msgid "Flagged for review"
-msgstr ""
-
-#: static/js/impala/reviews.js:40 static/js/zamboni/reviews.js:34
-msgid "Your input is required"
-msgstr ""
-
-#: static/js/impala/reviews.js:152 static/js/zamboni/reviews.js:103
-msgid "Marked for deletion"
-msgstr ""
-
-#: static/js/impala/search.js:114
-msgid "Updating results&hellip;"
-msgstr ""
-
-#: static/js/impala/site_suggestions.js:46
-msgid "Category"
-msgstr ""
-
-#: static/js/impala/suggestions.js:39
-msgid "Search themes for <b>{0}</b>"
-msgstr ""
-
-#: static/js/impala/suggestions.js:41
-msgid "Search apps for <b>{0}</b>"
-msgstr ""
-
-#: static/js/impala/suggestions.js:43
-msgid "Search add-ons for <b>{0}</b>"
-msgstr ""
-
-#: static/js/impala/users.js:33
-msgid "use original"
-msgstr ""
-
-#: static/js/impala/stats/chart.js:267
+#: static/js/impala/stats/chart.js:267 static/js/zamboni/stats-all.js:16898 static/js/zamboni/stats-min.js:5
 msgid "Week of {0}"
 msgstr ""
 
-#: static/js/impala/stats/chart.js:269
+#: static/js/impala/stats/chart.js:269 static/js/zamboni/stats-all.js:16900 static/js/zamboni/stats-min.js:5
 msgid " downloads"
 msgstr ""
 
-#: static/js/impala/stats/chart.js:270
+#: static/js/impala/stats/chart.js:270 static/js/zamboni/stats-all.js:16901 static/js/zamboni/stats-min.js:5
 msgid "{0} users"
 msgstr ""
 
-#: static/js/impala/stats/chart.js:271
+#: static/js/impala/stats/chart.js:271 static/js/zamboni/stats-all.js:16902 static/js/zamboni/stats-min.js:5
 msgid "{0} add-ons"
 msgstr ""
 
-#: static/js/impala/stats/chart.js:272
+#: static/js/impala/stats/chart.js:272 static/js/zamboni/stats-all.js:16903 static/js/zamboni/stats-min.js:5
 msgid "{0} collections"
 msgstr ""
 
-#: static/js/impala/stats/chart.js:273
+#: static/js/impala/stats/chart.js:273 static/js/zamboni/stats-all.js:16904 static/js/zamboni/stats-min.js:5
 msgid "{0} reviews"
 msgstr ""
 
-#: static/js/impala/stats/chart.js:275
+#: static/js/impala/stats/chart.js:275 static/js/zamboni/stats-all.js:16906 static/js/zamboni/stats-min.js:5
 msgid "{0} sales"
 msgstr ""
 
-#: static/js/impala/stats/chart.js:276
+#: static/js/impala/stats/chart.js:276 static/js/zamboni/stats-all.js:16907 static/js/zamboni/stats-min.js:5
 msgid "{0} refunds"
 msgstr ""
 
-#: static/js/impala/stats/chart.js:277
+#: static/js/impala/stats/chart.js:277 static/js/zamboni/stats-all.js:16908 static/js/zamboni/stats-min.js:5
 msgid "{0} installs"
 msgstr ""
 
-#: static/js/impala/stats/chart.js:369 static/js/impala/stats/csv_keys.js:3 static/js/impala/stats/csv_keys.js:109
+#: static/js/impala/stats/chart.js:369 static/js/impala/stats/csv_keys.js:3 static/js/impala/stats/csv_keys.js:109 static/js/zamboni/stats-all.js:15284 static/js/zamboni/stats-all.js:15390
+#: static/js/zamboni/stats-all.js:17000 static/js/zamboni/stats-min.js:4 static/js/zamboni/stats-min.js:5
 msgid "Downloads"
 msgstr ""
 
-#: static/js/impala/stats/chart.js:379 static/js/impala/stats/csv_keys.js:6 static/js/impala/stats/csv_keys.js:110
+#: static/js/impala/stats/chart.js:379 static/js/impala/stats/csv_keys.js:6 static/js/impala/stats/csv_keys.js:110 static/js/zamboni/stats-all.js:15287 static/js/zamboni/stats-all.js:15391
+#: static/js/zamboni/stats-all.js:17010 static/js/zamboni/stats-min.js:4 static/js/zamboni/stats-min.js:5
 msgid "Daily Users"
 msgstr ""
 
-#: static/js/impala/stats/chart.js:410
+#: static/js/impala/stats/chart.js:410 static/js/zamboni/stats-all.js:17041 static/js/zamboni/stats-min.js:5
 msgid "Amount, in USD"
 msgstr ""
 
-#: static/js/impala/stats/chart.js:421 static/js/impala/stats/csv_keys.js:104
+#: static/js/impala/stats/chart.js:421 static/js/impala/stats/csv_keys.js:104 static/js/zamboni/stats-all.js:15385 static/js/zamboni/stats-all.js:17052 static/js/zamboni/stats-min.js:5
 msgid "Number of Contributions"
 msgstr ""
 
-#: static/js/impala/stats/chart.js:447
+#: static/js/impala/stats/chart.js:447 static/js/zamboni/stats-all.js:17078 static/js/zamboni/stats-min.js:5
 msgid "More Info..."
 msgstr ""
 
 #. L10n: {0} is an ISO-formatted date.
-#: static/js/impala/stats/chart.js:451
+#: static/js/impala/stats/chart.js:451 static/js/zamboni/stats-all.js:17082 static/js/zamboni/stats-min.js:5
 msgid "Details for {0}"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:9
+#: static/js/impala/stats/csv_keys.js:9 static/js/zamboni/stats-all.js:15290 static/js/zamboni/stats-min.js:4
 msgid "Collections Created"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:12
+#: static/js/impala/stats/csv_keys.js:12 static/js/zamboni/stats-all.js:15293 static/js/zamboni/stats-min.js:4
 msgid "Add-ons in Use"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:15
+#: static/js/impala/stats/csv_keys.js:15 static/js/zamboni/stats-all.js:15296 static/js/zamboni/stats-min.js:4
 msgid "Add-ons Created"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:18
+#: static/js/impala/stats/csv_keys.js:18 static/js/zamboni/stats-all.js:15299 static/js/zamboni/stats-min.js:4
 msgid "Add-ons Downloaded"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:21
+#: static/js/impala/stats/csv_keys.js:21 static/js/zamboni/stats-all.js:15302 static/js/zamboni/stats-min.js:4
 msgid "Add-ons Updated"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:24
+#: static/js/impala/stats/csv_keys.js:24 static/js/zamboni/stats-all.js:15305 static/js/zamboni/stats-min.js:4
 msgid "Reviews Written"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:27
+#: static/js/impala/stats/csv_keys.js:27 static/js/zamboni/stats-all.js:15308 static/js/zamboni/stats-min.js:4
 msgid "User Signups"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:30
+#: static/js/impala/stats/csv_keys.js:30 static/js/zamboni/stats-all.js:15311 static/js/zamboni/stats-min.js:4
 msgid "Subscribers"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:33
+#: static/js/impala/stats/csv_keys.js:33 static/js/zamboni/stats-all.js:15314 static/js/zamboni/stats-min.js:4
 msgid "Ratings"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:36 static/js/impala/stats/csv_keys.js:114
+#: static/js/impala/stats/csv_keys.js:36 static/js/impala/stats/csv_keys.js:114 static/js/zamboni/stats-all.js:15317 static/js/zamboni/stats-all.js:15395 static/js/zamboni/stats-min.js:4
+#: static/js/zamboni/stats-min.js:5
 msgid "Sales"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:39 static/js/impala/stats/csv_keys.js:113
+#: static/js/impala/stats/csv_keys.js:39 static/js/impala/stats/csv_keys.js:113 static/js/zamboni/stats-all.js:15320 static/js/zamboni/stats-all.js:15394 static/js/zamboni/stats-min.js:4
+#: static/js/zamboni/stats-min.js:5
 msgid "Installs"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:42
+#: static/js/impala/stats/csv_keys.js:42 static/js/zamboni/stats-all.js:15323 static/js/zamboni/stats-min.js:4
 msgid "Unknown"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:43
+#: static/js/impala/stats/csv_keys.js:43 static/js/zamboni/stats-all.js:15324 static/js/zamboni/stats-min.js:4
 msgid "Add-ons Manager"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:44
+#: static/js/impala/stats/csv_keys.js:44 static/js/zamboni/stats-all.js:15325 static/js/zamboni/stats-min.js:4
 msgid "Add-ons Manager Promo"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:45
+#: static/js/impala/stats/csv_keys.js:45 static/js/zamboni/stats-all.js:15326 static/js/zamboni/stats-min.js:4
 msgid "Add-ons Manager Featured"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:46
+#: static/js/impala/stats/csv_keys.js:46 static/js/zamboni/stats-all.js:15327 static/js/zamboni/stats-min.js:4
 msgid "Add-ons Manager Learn More"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:47
+#: static/js/impala/stats/csv_keys.js:47 static/js/zamboni/stats-all.js:15328 static/js/zamboni/stats-min.js:4
 msgid "Search Suggestions"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:48
+#: static/js/impala/stats/csv_keys.js:48 static/js/zamboni/stats-all.js:15329 static/js/zamboni/stats-min.js:4
 msgid "Search Results"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:49 static/js/impala/stats/csv_keys.js:50 static/js/impala/stats/csv_keys.js:51
+#: static/js/impala/stats/csv_keys.js:49 static/js/impala/stats/csv_keys.js:50 static/js/impala/stats/csv_keys.js:51 static/js/zamboni/stats-all.js:15330 static/js/zamboni/stats-all.js:15331
+#: static/js/zamboni/stats-all.js:15332 static/js/zamboni/stats-min.js:4
 msgid "Homepage Promo"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:52 static/js/impala/stats/csv_keys.js:53
+#: static/js/impala/stats/csv_keys.js:52 static/js/impala/stats/csv_keys.js:53 static/js/zamboni/stats-all.js:15333 static/js/zamboni/stats-all.js:15334 static/js/zamboni/stats-min.js:4
 msgid "Homepage Featured"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:54 static/js/impala/stats/csv_keys.js:55
+#: static/js/impala/stats/csv_keys.js:54 static/js/impala/stats/csv_keys.js:55 static/js/zamboni/stats-all.js:15335 static/js/zamboni/stats-all.js:15336 static/js/zamboni/stats-min.js:4
 msgid "Homepage Up and Coming"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:56
+#: static/js/impala/stats/csv_keys.js:56 static/js/zamboni/stats-all.js:15337 static/js/zamboni/stats-min.js:4
 msgid "Homepage Most Popular"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:57 static/js/impala/stats/csv_keys.js:59
+#: static/js/impala/stats/csv_keys.js:57 static/js/impala/stats/csv_keys.js:59 static/js/zamboni/stats-all.js:15338 static/js/zamboni/stats-all.js:15340 static/js/zamboni/stats-min.js:4
 msgid "Detail Page"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:58 static/js/impala/stats/csv_keys.js:60
+#: static/js/impala/stats/csv_keys.js:58 static/js/impala/stats/csv_keys.js:60 static/js/zamboni/stats-all.js:15339 static/js/zamboni/stats-all.js:15341 static/js/zamboni/stats-min.js:4
 msgid "Detail Page (bottom)"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:61
+#: static/js/impala/stats/csv_keys.js:61 static/js/zamboni/stats-all.js:15342 static/js/zamboni/stats-min.js:4
 msgid "Detail Page (Development Channel)"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:62 static/js/impala/stats/csv_keys.js:63 static/js/impala/stats/csv_keys.js:64
+#: static/js/impala/stats/csv_keys.js:62 static/js/impala/stats/csv_keys.js:63 static/js/impala/stats/csv_keys.js:64 static/js/zamboni/stats-all.js:15343 static/js/zamboni/stats-all.js:15344
+#: static/js/zamboni/stats-all.js:15345 static/js/zamboni/stats-min.js:4
 msgid "Often Used With"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:65 static/js/impala/stats/csv_keys.js:66
+#: static/js/impala/stats/csv_keys.js:65 static/js/impala/stats/csv_keys.js:66 static/js/zamboni/stats-all.js:15346 static/js/zamboni/stats-all.js:15347 static/js/zamboni/stats-min.js:4
 msgid "Others By Author"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:67 static/js/impala/stats/csv_keys.js:68
+#: static/js/impala/stats/csv_keys.js:67 static/js/impala/stats/csv_keys.js:68 static/js/zamboni/stats-all.js:15348 static/js/zamboni/stats-all.js:15349 static/js/zamboni/stats-min.js:4
 msgid "Dependencies"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:69 static/js/impala/stats/csv_keys.js:70
+#: static/js/impala/stats/csv_keys.js:69 static/js/impala/stats/csv_keys.js:70 static/js/zamboni/stats-all.js:15350 static/js/zamboni/stats-all.js:15351 static/js/zamboni/stats-min.js:4
 msgid "Upsell"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:71
+#: static/js/impala/stats/csv_keys.js:71 static/js/zamboni/stats-all.js:15352 static/js/zamboni/stats-min.js:4
 msgid "Meet the Developer"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:72
+#: static/js/impala/stats/csv_keys.js:72 static/js/zamboni/stats-all.js:15353 static/js/zamboni/stats-min.js:4
 msgid "User Profile"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:73
+#: static/js/impala/stats/csv_keys.js:73 static/js/zamboni/stats-all.js:15354 static/js/zamboni/stats-min.js:4
 msgid "Version History"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:75
+#: static/js/impala/stats/csv_keys.js:75 static/js/zamboni/stats-all.js:15356 static/js/zamboni/stats-min.js:4
 msgid "Sharing"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:76
+#: static/js/impala/stats/csv_keys.js:76 static/js/zamboni/stats-all.js:15357 static/js/zamboni/stats-min.js:4
 msgid "Category Pages"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:77
+#: static/js/impala/stats/csv_keys.js:77 static/js/zamboni/stats-all.js:15358 static/js/zamboni/stats-min.js:4
 msgid "Collections"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:78 static/js/impala/stats/csv_keys.js:79
+#: static/js/impala/stats/csv_keys.js:78 static/js/impala/stats/csv_keys.js:79 static/js/zamboni/stats-all.js:15359 static/js/zamboni/stats-all.js:15360 static/js/zamboni/stats-min.js:4
 msgid "Category Landing Featured Carousel"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:80 static/js/impala/stats/csv_keys.js:81
+#: static/js/impala/stats/csv_keys.js:80 static/js/impala/stats/csv_keys.js:81 static/js/zamboni/stats-all.js:15361 static/js/zamboni/stats-all.js:15362 static/js/zamboni/stats-min.js:4
 msgid "Category Landing Top Rated"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:82 static/js/impala/stats/csv_keys.js:83
+#: static/js/impala/stats/csv_keys.js:82 static/js/impala/stats/csv_keys.js:83 static/js/zamboni/stats-all.js:15363 static/js/zamboni/stats-all.js:15364 static/js/zamboni/stats-min.js:5
 msgid "Category Landing Most Popular"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:84 static/js/impala/stats/csv_keys.js:85
+#: static/js/impala/stats/csv_keys.js:84 static/js/impala/stats/csv_keys.js:85 static/js/zamboni/stats-all.js:15365 static/js/zamboni/stats-all.js:15366 static/js/zamboni/stats-min.js:5
 msgid "Category Landing Recently Added"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:86 static/js/impala/stats/csv_keys.js:87
+#: static/js/impala/stats/csv_keys.js:86 static/js/impala/stats/csv_keys.js:87 static/js/zamboni/stats-all.js:15367 static/js/zamboni/stats-all.js:15368 static/js/zamboni/stats-min.js:5
 msgid "Browse Listing Featured Sort"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:88 static/js/impala/stats/csv_keys.js:89
+#: static/js/impala/stats/csv_keys.js:88 static/js/impala/stats/csv_keys.js:89 static/js/zamboni/stats-all.js:15369 static/js/zamboni/stats-all.js:15370 static/js/zamboni/stats-min.js:5
 msgid "Browse Listing Users Sort"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:90 static/js/impala/stats/csv_keys.js:91
+#: static/js/impala/stats/csv_keys.js:90 static/js/impala/stats/csv_keys.js:91 static/js/zamboni/stats-all.js:15371 static/js/zamboni/stats-all.js:15372 static/js/zamboni/stats-min.js:5
 msgid "Browse Listing Rating Sort"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:92 static/js/impala/stats/csv_keys.js:93
+#: static/js/impala/stats/csv_keys.js:92 static/js/impala/stats/csv_keys.js:93 static/js/zamboni/stats-all.js:15373 static/js/zamboni/stats-all.js:15374 static/js/zamboni/stats-min.js:5
 msgid "Browse Listing Created Sort"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:94 static/js/impala/stats/csv_keys.js:95
+#: static/js/impala/stats/csv_keys.js:94 static/js/impala/stats/csv_keys.js:95 static/js/zamboni/stats-all.js:15375 static/js/zamboni/stats-all.js:15376 static/js/zamboni/stats-min.js:5
 msgid "Browse Listing Name Sort"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:96 static/js/impala/stats/csv_keys.js:97
+#: static/js/impala/stats/csv_keys.js:96 static/js/impala/stats/csv_keys.js:97 static/js/zamboni/stats-all.js:15377 static/js/zamboni/stats-all.js:15378 static/js/zamboni/stats-min.js:5
 msgid "Browse Listing Popular Sort"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:98 static/js/impala/stats/csv_keys.js:99
+#: static/js/impala/stats/csv_keys.js:98 static/js/impala/stats/csv_keys.js:99 static/js/zamboni/stats-all.js:15379 static/js/zamboni/stats-all.js:15380 static/js/zamboni/stats-min.js:5
 msgid "Browse Listing Updated Sort"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:100 static/js/impala/stats/csv_keys.js:101
+#: static/js/impala/stats/csv_keys.js:100 static/js/impala/stats/csv_keys.js:101 static/js/zamboni/stats-all.js:15381 static/js/zamboni/stats-all.js:15382 static/js/zamboni/stats-min.js:5
 msgid "Browse Listing Up and Coming Sort"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:105
+#: static/js/impala/stats/csv_keys.js:105 static/js/zamboni/stats-all.js:15386 static/js/zamboni/stats-min.js:5
 msgid "Total Amount Contributed"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:106
+#: static/js/impala/stats/csv_keys.js:106 static/js/zamboni/stats-all.js:15387 static/js/zamboni/stats-min.js:5
 msgid "Average Contribution"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:115
+#: static/js/impala/stats/csv_keys.js:115 static/js/zamboni/stats-all.js:15396 static/js/zamboni/stats-min.js:5
 msgid "Usage"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:118
+#: static/js/impala/stats/csv_keys.js:118 static/js/zamboni/stats-all.js:15399 static/js/zamboni/stats-min.js:5
 msgid "Firefox"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:119
+#: static/js/impala/stats/csv_keys.js:119 static/js/zamboni/stats-all.js:15400 static/js/zamboni/stats-min.js:5
 msgid "Mozilla"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:120
+#: static/js/impala/stats/csv_keys.js:120 static/js/zamboni/stats-all.js:15401 static/js/zamboni/stats-min.js:5
 msgid "Thunderbird"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:121
+#: static/js/impala/stats/csv_keys.js:121 static/js/zamboni/stats-all.js:15402 static/js/zamboni/stats-min.js:5
 msgid "Sunbird"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:122
+#: static/js/impala/stats/csv_keys.js:122 static/js/zamboni/stats-all.js:15403 static/js/zamboni/stats-min.js:5
 msgid "SeaMonkey"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:123
+#: static/js/impala/stats/csv_keys.js:123 static/js/zamboni/stats-all.js:15404 static/js/zamboni/stats-min.js:5
 msgid "Fennec"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:124
+#: static/js/impala/stats/csv_keys.js:124 static/js/zamboni/stats-all.js:15405 static/js/zamboni/stats-min.js:5
 msgid "Android"
 msgstr ""
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:129
+#: static/js/impala/stats/csv_keys.js:129 static/js/zamboni/stats-all.js:15410 static/js/zamboni/stats-min.js:5
 msgid "Downloads and Daily Users, last {0} days"
 msgstr ""
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:131
+#: static/js/impala/stats/csv_keys.js:131 static/js/zamboni/stats-all.js:15412 static/js/zamboni/stats-min.js:5
 msgid "Downloads and Daily Users from {0} to {1}"
 msgstr ""
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:135
+#: static/js/impala/stats/csv_keys.js:135 static/js/zamboni/stats-all.js:15416 static/js/zamboni/stats-min.js:5
 msgid "Installs and Daily Users, last {0} days"
 msgstr ""
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:137
+#: static/js/impala/stats/csv_keys.js:137 static/js/zamboni/stats-all.js:15418 static/js/zamboni/stats-min.js:5
 msgid "Installs and Daily Users from {0} to {1}"
 msgstr ""
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:141
+#: static/js/impala/stats/csv_keys.js:141 static/js/zamboni/stats-all.js:15422 static/js/zamboni/stats-min.js:5
 msgid "Downloads, last {0} days"
 msgstr ""
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:143
+#: static/js/impala/stats/csv_keys.js:143 static/js/zamboni/stats-all.js:15424 static/js/zamboni/stats-min.js:5
 msgid "Downloads from {0} to {1}"
 msgstr ""
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:147
+#: static/js/impala/stats/csv_keys.js:147 static/js/zamboni/stats-all.js:15428 static/js/zamboni/stats-min.js:5
 msgid "Daily Users, last {0} days"
 msgstr ""
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:149
+#: static/js/impala/stats/csv_keys.js:149 static/js/zamboni/stats-all.js:15430 static/js/zamboni/stats-min.js:5
 msgid "Daily Users from {0} to {1}"
 msgstr ""
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:153
+#: static/js/impala/stats/csv_keys.js:153 static/js/zamboni/stats-all.js:15434 static/js/zamboni/stats-min.js:5
 msgid "Applications, last {0} days"
 msgstr ""
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:155
+#: static/js/impala/stats/csv_keys.js:155 static/js/zamboni/stats-all.js:15436 static/js/zamboni/stats-min.js:5
 msgid "Applications from {0} to {1}"
 msgstr ""
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:159
+#: static/js/impala/stats/csv_keys.js:159 static/js/zamboni/stats-all.js:15440 static/js/zamboni/stats-min.js:5
 msgid "Platforms, last {0} days"
 msgstr ""
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:161
+#: static/js/impala/stats/csv_keys.js:161 static/js/zamboni/stats-all.js:15442 static/js/zamboni/stats-min.js:5
 msgid "Platforms from {0} to {1}"
 msgstr ""
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:165
+#: static/js/impala/stats/csv_keys.js:165 static/js/zamboni/stats-all.js:15446 static/js/zamboni/stats-min.js:5
 msgid "Languages, last {0} days"
 msgstr ""
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:167
+#: static/js/impala/stats/csv_keys.js:167 static/js/zamboni/stats-all.js:15448 static/js/zamboni/stats-min.js:5
 msgid "Languages from {0} to {1}"
 msgstr ""
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:171
+#: static/js/impala/stats/csv_keys.js:171 static/js/zamboni/stats-all.js:15452 static/js/zamboni/stats-min.js:5
 msgid "Add-on Versions, last {0} days"
 msgstr ""
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:173
+#: static/js/impala/stats/csv_keys.js:173 static/js/zamboni/stats-all.js:15454 static/js/zamboni/stats-min.js:5
 msgid "Add-on Versions from {0} to {1}"
 msgstr ""
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:177
+#: static/js/impala/stats/csv_keys.js:177 static/js/zamboni/stats-all.js:15458 static/js/zamboni/stats-min.js:5
 msgid "Add-on Status, last {0} days"
 msgstr ""
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:179
+#: static/js/impala/stats/csv_keys.js:179 static/js/zamboni/stats-all.js:15460 static/js/zamboni/stats-min.js:5
 msgid "Add-on Status from {0} to {1}"
 msgstr ""
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:183
+#: static/js/impala/stats/csv_keys.js:183 static/js/zamboni/stats-all.js:15464 static/js/zamboni/stats-min.js:5
 msgid "Download Sources, last {0} days"
 msgstr ""
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:185
+#: static/js/impala/stats/csv_keys.js:185 static/js/zamboni/stats-all.js:15466 static/js/zamboni/stats-min.js:5
 msgid "Download Sources from {0} to {1}"
 msgstr ""
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:189
+#: static/js/impala/stats/csv_keys.js:189 static/js/zamboni/stats-all.js:15470 static/js/zamboni/stats-min.js:5
 msgid "Contributions, last {0} days"
 msgstr ""
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:191
+#: static/js/impala/stats/csv_keys.js:191 static/js/zamboni/stats-all.js:15472 static/js/zamboni/stats-min.js:5
 msgid "Contributions from {0} to {1}"
 msgstr ""
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:195
+#: static/js/impala/stats/csv_keys.js:195 static/js/zamboni/stats-all.js:15476 static/js/zamboni/stats-min.js:5
 msgid "Site Metrics, last {0} days"
 msgstr ""
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:197
+#: static/js/impala/stats/csv_keys.js:197 static/js/zamboni/stats-all.js:15478 static/js/zamboni/stats-min.js:5
 msgid "Site Metrics from {0} to {1}"
 msgstr ""
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:201
+#: static/js/impala/stats/csv_keys.js:201 static/js/zamboni/stats-all.js:15482 static/js/zamboni/stats-min.js:5
 msgid "Add-ons in Use, last {0} days"
 msgstr ""
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:203
+#: static/js/impala/stats/csv_keys.js:203 static/js/zamboni/stats-all.js:15484 static/js/zamboni/stats-min.js:5
 msgid "Add-ons in Use from {0} to {1}"
 msgstr ""
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:207
+#: static/js/impala/stats/csv_keys.js:207 static/js/zamboni/stats-all.js:15488 static/js/zamboni/stats-min.js:5
 msgid "Add-ons Downloaded, last {0} days"
 msgstr ""
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:209
+#: static/js/impala/stats/csv_keys.js:209 static/js/zamboni/stats-all.js:15490 static/js/zamboni/stats-min.js:5
 msgid "Add-ons Downloaded from {0} to {1}"
 msgstr ""
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:213
+#: static/js/impala/stats/csv_keys.js:213 static/js/zamboni/stats-all.js:15494 static/js/zamboni/stats-min.js:5
 msgid "Add-ons Created, last {0} days"
 msgstr ""
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:215
+#: static/js/impala/stats/csv_keys.js:215 static/js/zamboni/stats-all.js:15496 static/js/zamboni/stats-min.js:5
 msgid "Add-ons Created from {0} to {1}"
 msgstr ""
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:219
+#: static/js/impala/stats/csv_keys.js:219 static/js/zamboni/stats-all.js:15500 static/js/zamboni/stats-min.js:5
 msgid "Add-ons Updated, last {0} days"
 msgstr ""
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:221
+#: static/js/impala/stats/csv_keys.js:221 static/js/zamboni/stats-all.js:15502 static/js/zamboni/stats-min.js:5
 msgid "Add-ons Updated from {0} to {1}"
 msgstr ""
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:225
+#: static/js/impala/stats/csv_keys.js:225 static/js/zamboni/stats-all.js:15506 static/js/zamboni/stats-min.js:5
 msgid "Reviews Written, last {0} days"
 msgstr ""
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:227
+#: static/js/impala/stats/csv_keys.js:227 static/js/zamboni/stats-all.js:15508 static/js/zamboni/stats-min.js:5
 msgid "Reviews Written from {0} to {1}"
 msgstr ""
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:231
+#: static/js/impala/stats/csv_keys.js:231 static/js/zamboni/stats-all.js:15512 static/js/zamboni/stats-min.js:5
 msgid "User Signups, last {0} days"
 msgstr ""
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:233
+#: static/js/impala/stats/csv_keys.js:233 static/js/zamboni/stats-all.js:15514 static/js/zamboni/stats-min.js:5
 msgid "User Signups from {0} to {1}"
 msgstr ""
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:237
+#: static/js/impala/stats/csv_keys.js:237 static/js/zamboni/stats-all.js:15518 static/js/zamboni/stats-min.js:5
 msgid "Collections Created, last {0} days"
 msgstr ""
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:239
+#: static/js/impala/stats/csv_keys.js:239 static/js/zamboni/stats-all.js:15520 static/js/zamboni/stats-min.js:5
 msgid "Collections Created from {0} to {1}"
 msgstr ""
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:243
+#: static/js/impala/stats/csv_keys.js:243 static/js/zamboni/stats-all.js:15524 static/js/zamboni/stats-min.js:5
 msgid "Subscribers, last {0} days"
 msgstr ""
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:245
+#: static/js/impala/stats/csv_keys.js:245 static/js/zamboni/stats-all.js:15526 static/js/zamboni/stats-min.js:5
 msgid "Subscribers from {0} to {1}"
 msgstr ""
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:249
+#: static/js/impala/stats/csv_keys.js:249 static/js/zamboni/stats-all.js:15530 static/js/zamboni/stats-min.js:5
 msgid "Ratings, last {0} days"
 msgstr ""
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:251
+#: static/js/impala/stats/csv_keys.js:251 static/js/zamboni/stats-all.js:15532 static/js/zamboni/stats-min.js:5
 msgid "Ratings from {0} to {1}"
 msgstr ""
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:255
+#: static/js/impala/stats/csv_keys.js:255 static/js/zamboni/stats-all.js:15536 static/js/zamboni/stats-min.js:5
 msgid "Sales, last {0} days"
 msgstr ""
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:257
+#: static/js/impala/stats/csv_keys.js:257 static/js/zamboni/stats-all.js:15538 static/js/zamboni/stats-min.js:5
 msgid "Sales from {0} to {1}"
 msgstr ""
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:261
+#: static/js/impala/stats/csv_keys.js:261 static/js/zamboni/stats-all.js:15542 static/js/zamboni/stats-min.js:5
 msgid "Installs, last {0} days"
 msgstr ""
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:263
+#: static/js/impala/stats/csv_keys.js:263 static/js/zamboni/stats-all.js:15544 static/js/zamboni/stats-min.js:5
 msgid "Installs from {0} to {1}"
 msgstr ""
 
 #. L10n: {0} and {1} are integers.
-#: static/js/impala/stats/csv_keys.js:269
+#: static/js/impala/stats/csv_keys.js:269 static/js/zamboni/stats-all.js:15550 static/js/zamboni/stats-min.js:5
 msgid "<b>{0}</b> in last {1} days"
 msgstr ""
 
 #. L10n: {0} is an integer and {1} and {2} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:271 static/js/impala/stats/csv_keys.js:277
+#: static/js/impala/stats/csv_keys.js:271 static/js/impala/stats/csv_keys.js:277 static/js/zamboni/stats-all.js:15552 static/js/zamboni/stats-all.js:15558 static/js/zamboni/stats-min.js:5
 msgid "<b>{0}</b> from {1} to {2}"
 msgstr ""
 
 #. L10n: {0} and {1} are integers.
-#: static/js/impala/stats/csv_keys.js:275
+#: static/js/impala/stats/csv_keys.js:275 static/js/zamboni/stats-all.js:15556 static/js/zamboni/stats-min.js:5
 msgid "<b>{0}</b> average in last {1} days"
 msgstr ""
 
-#: static/js/impala/stats/overview.js:19
+#: static/js/impala/stats/overview.js:19 static/js/zamboni/stats-all.js:16469 static/js/zamboni/stats-min.js:5
 msgid "No data available."
 msgstr ""
 
-#: static/js/impala/stats/table.js:74
+#: static/js/impala/stats/table.js:74 static/js/zamboni/stats-all.js:17209 static/js/zamboni/stats-min.js:5
 msgid "Date"
 msgstr ""
 
-#: static/js/impala/stats/topchart.js:96
+#: static/js/impala/stats/topchart.js:96 static/js/zamboni/stats-all.js:16600 static/js/zamboni/stats-min.js:5
 msgid "Other"
 msgstr ""
 
-#: static/js/zamboni/admin_validation.js:24 static/js/zamboni/devhub.js:1229 static/js/zamboni/editors.js:295
+#: static/js/zamboni/admin-all.js:180 static/js/zamboni/admin-min.js:1 static/js/zamboni/admin_validation.js:24 static/js/zamboni/devhub-all.js:2408 static/js/zamboni/devhub-min.js:2
+#: static/js/zamboni/devhub.js:1229 static/js/zamboni/editors-all.js:15576 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:295
 msgid "Select an application first"
 msgstr ""
 
-#: static/js/zamboni/admin_validation.js:51
+#: static/js/zamboni/admin-all.js:207 static/js/zamboni/admin-min.js:1 static/js/zamboni/admin_validation.js:51
 msgid "Set {0} add-on to a max version of {1} and email the author."
 msgid_plural "Set {0} add-ons to a max version of {1} and email the authors."
 msgstr[0] ""
 msgstr[1] ""
 
-#: static/js/zamboni/admin_validation.js:54
+#: static/js/zamboni/admin-all.js:210 static/js/zamboni/admin-min.js:1 static/js/zamboni/admin_validation.js:54
 msgid "Email author of {2} add-on which failed validation."
 msgid_plural "Email authors of {2} add-ons which failed validation."
 msgstr[0] ""
 msgstr[1] ""
 
-#. L10n: {0} is an app name like Firefox.
-#: static/js/zamboni/buttons.js:66
-msgid "Accept and Install"
-msgstr ""
-
-#: static/js/zamboni/buttons.js:66
-msgid "Add to {0}"
-msgstr ""
-
-#: static/js/zamboni/buttons.js:71
-msgid "Download Now"
-msgstr ""
-
-#: static/js/zamboni/buttons.js:112
-msgid "Add-on has not been updated to support default-to-compatible."
-msgstr ""
-
-#: static/js/zamboni/buttons.js:117
-msgid "You need to be using Firefox 10.0 or higher."
-msgstr ""
-
-#: static/js/zamboni/buttons.js:129
-msgid "Mozilla has marked this version as incompatible with your Firefox version."
-msgstr ""
-
-#. L10n: {0} is an platform like Windows or Linux.
-#: static/js/zamboni/buttons.js:210
-msgid "Install for {0} anyway"
-msgstr ""
-
-#: static/js/zamboni/buttons.js:210
-msgid "Download for {0} anyway"
-msgstr ""
-
-#: static/js/zamboni/buttons.js:267
-msgid "Not available for your platform"
-msgstr ""
-
-#. L10n: {0} is an app name, {1} is the app version.
-#: static/js/zamboni/buttons.js:278 static/js/zamboni/buttons.js:315
-msgid "Not available for {0} {1}"
-msgstr ""
-
-#: static/js/zamboni/buttons.js:341
-msgid "Works with {app} {min} - {max}"
-msgstr ""
-
-#: static/js/zamboni/buttons.js:343
-msgid "View other versions"
-msgstr ""
-
-#: static/js/zamboni/buttons.js:391
-msgid "Only with Firefox — Get Firefox Now!"
-msgstr ""
-
-#: static/js/zamboni/buttons.js:507 static/js/zamboni/mobile/buttons.js:43
-msgid "Sorry, you need a Mozilla-based browser (such as Firefox) to install a search plugin."
-msgstr ""
-
-#: static/js/zamboni/collections.js:229
-msgid "Adding to Favorites&hellip;"
-msgstr ""
-
-#: static/js/zamboni/collections.js:232
-msgid "Removing Favorite&hellip;"
-msgstr ""
-
-#: static/js/zamboni/collections.js:235
-msgid "Add to Favorites"
-msgstr ""
-
-#: static/js/zamboni/collections.js:238
-msgid "Remove from Favorites"
-msgstr ""
-
-#: static/js/zamboni/collections.js:303
-msgid "Pending"
-msgstr ""
-
-#: static/js/zamboni/collections.js:304
-msgid "Add a comment"
-msgstr ""
-
-#: static/js/zamboni/collections.js:304
-msgid "Comment"
-msgstr ""
-
-#: static/js/zamboni/collections.js:305
-msgid "Remove this add-on from the collection"
-msgstr ""
-
-#: static/js/zamboni/collections.js:305 static/js/zamboni/collections.js:334
-msgid "Remove"
-msgstr ""
-
-#: static/js/zamboni/collections.js:334
-msgid "Remove this user as a contributor"
-msgstr ""
-
-#: static/js/zamboni/collections.js:346
-msgid "An email address is required."
-msgstr ""
-
-#: static/js/zamboni/collections.js:364
-msgid "You cannot add yourself as a contributor."
-msgstr ""
-
-#: static/js/zamboni/collections.js:366
-msgid "You have already added that user."
-msgstr ""
-
-#: static/js/zamboni/collections.js:573
-msgid "Add to favorites"
-msgstr ""
-
-#: static/js/zamboni/collections.js:577
-msgid "Remove from favorites"
-msgstr ""
-
-#: static/js/zamboni/collections.js:604
-msgid "Stop following"
-msgstr ""
-
-#: static/js/zamboni/devhub.js:110
+#: static/js/zamboni/devhub-all.js:1289 static/js/zamboni/devhub-min.js:1 static/js/zamboni/devhub.js:110
 msgid "Your browser does not support the video tag"
 msgstr ""
 
-#: static/js/zamboni/devhub.js:371
+#: static/js/zamboni/devhub-all.js:1550 static/js/zamboni/devhub-min.js:1 static/js/zamboni/devhub.js:371
 msgid "Changes Saved"
 msgstr ""
 
-#: static/js/zamboni/devhub.js:387
+#: static/js/zamboni/devhub-all.js:1566 static/js/zamboni/devhub-min.js:1 static/js/zamboni/devhub.js:387
 msgid "Enter a new author's email address"
 msgstr ""
 
-#: static/js/zamboni/devhub.js:536
+#: static/js/zamboni/devhub-all.js:1715 static/js/zamboni/devhub-min.js:1 static/js/zamboni/devhub.js:536
 msgid "There was an error uploading your file."
 msgstr ""
 
-#: static/js/zamboni/devhub.js:681
+#: static/js/zamboni/devhub-all.js:1860 static/js/zamboni/devhub-min.js:1 static/js/zamboni/devhub.js:681
 msgid "{files} file"
 msgid_plural "{files} files"
 msgstr[0] ""
 msgstr[1] ""
 
-#: static/js/zamboni/devhub.js:684
+#: static/js/zamboni/devhub-all.js:1863 static/js/zamboni/devhub-min.js:1 static/js/zamboni/devhub.js:684
 msgid "{reviews} user review"
 msgid_plural "{reviews} user reviews"
 msgstr[0] ""
 msgstr[1] ""
 
-#: static/js/zamboni/devhub.js:796
+#: static/js/zamboni/devhub-all.js:1975 static/js/zamboni/devhub-min.js:2 static/js/zamboni/devhub.js:796
 msgid "Learn more"
 msgstr ""
 
-#: static/js/zamboni/devhub.js:800
+#: static/js/zamboni/devhub-all.js:1979 static/js/zamboni/devhub-min.js:2 static/js/zamboni/devhub.js:800
 msgid "Example"
 msgstr ""
 
-#: static/js/zamboni/devhub.js:1130
+#: static/js/zamboni/devhub-all.js:2309 static/js/zamboni/devhub-min.js:2 static/js/zamboni/devhub.js:1130
 msgid "Image changes being processed"
 msgstr ""
 
-#: static/js/zamboni/devhub.js:1280
+#: static/js/zamboni/devhub-all.js:2459 static/js/zamboni/devhub-min.js:2 static/js/zamboni/devhub.js:1280
 msgid "Must be a valid e-mail address."
+msgstr ""
+
+#: static/js/zamboni/devhub-all.js:2613 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:80
+msgid "All tests passed successfully."
+msgstr ""
+
+#: static/js/zamboni/devhub-all.js:2616 static/js/zamboni/devhub-all.js:3011 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:83 static/js/zamboni/validator.js:478
+msgid "These tests were not run."
+msgstr ""
+
+#: static/js/zamboni/devhub-all.js:2664 static/js/zamboni/devhub-all.js:2677 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:131 static/js/zamboni/validator.js:144
+msgid "Tests"
+msgstr ""
+
+#: static/js/zamboni/devhub-all.js:2779 static/js/zamboni/devhub-all.js:3108 static/js/zamboni/devhub-all.js:3127 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:246
+#: static/js/zamboni/validator.js:575 static/js/zamboni/validator.js:594
+msgid "Error"
+msgstr ""
+
+#: static/js/zamboni/devhub-all.js:2780 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:247
+msgid "Warning"
+msgstr ""
+
+#: static/js/zamboni/devhub-all.js:2794 static/js/zamboni/devhub-min.js:2 static/js/zamboni/files-all.js:5657 static/js/zamboni/files-min.js:3 static/js/zamboni/files.js:411
+#: static/js/zamboni/validator.js:261
+msgid "Ignore this message in future updates"
+msgstr ""
+
+#: static/js/zamboni/devhub-all.js:2817 static/js/zamboni/devhub-min.js:2 static/js/zamboni/files-all.js:5663 static/js/zamboni/files-min.js:3 static/js/zamboni/files.js:417
+#: static/js/zamboni/validator.js:284
+msgid "Severity for automated signing:"
+msgstr ""
+
+#: static/js/zamboni/devhub-all.js:2832 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:299
+msgid "Suggestions for passing automated signing:"
+msgstr ""
+
+#: static/js/zamboni/devhub-all.js:2920 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:387
+msgid "Compatibility Tests"
+msgstr ""
+
+#: static/js/zamboni/devhub-all.js:2999 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:466
+msgid "Add-on failed validation."
+msgstr ""
+
+#: static/js/zamboni/devhub-all.js:3001 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:468
+msgid "Add-on passed validation."
+msgstr ""
+
+#: static/js/zamboni/devhub-all.js:3014 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:481
+msgid "{0} error"
+msgid_plural "{0} errors"
+msgstr[0] ""
+msgstr[1] ""
+
+#: static/js/zamboni/devhub-all.js:3016 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:483
+msgid "{0} warning"
+msgid_plural "{0} warnings"
+msgstr[0] ""
+msgstr[1] ""
+
+#: static/js/zamboni/devhub-all.js:3018 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:485
+msgid "{0} notice"
+msgid_plural "{0} notices"
+msgstr[0] ""
+msgstr[1] ""
+
+#: static/js/zamboni/devhub-all.js:3110 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:577
+msgid "Validation task could not complete or completed with errors"
+msgstr ""
+
+#: static/js/zamboni/devhub-all.js:3128 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:595
+msgid "Internal server error"
 msgstr ""
 
 #: static/js/zamboni/devhub_search.js:8
 msgid "No results found."
 msgstr ""
 
-#: static/js/zamboni/editors.js:121
+#: static/js/zamboni/editors-all.js:15402 static/js/zamboni/editors-min.js:4 static/js/zamboni/editors.js:121
 msgid "{name} was viewing this page first."
 msgstr ""
 
-#: static/js/zamboni/editors.js:171
+#: static/js/zamboni/editors-all.js:15452 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:171
 msgid "Receipt checked by app."
 msgstr ""
 
-#: static/js/zamboni/editors.js:173
+#: static/js/zamboni/editors-all.js:15454 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:173
 msgid "Receipt was not checked by app."
 msgstr ""
 
-#: static/js/zamboni/editors.js:244
+#: static/js/zamboni/editors-all.js:15525 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:244
 msgid "{name} was viewing this add-on first."
 msgstr ""
 
-#: static/js/zamboni/editors.js:255
+#: static/js/zamboni/editors-all.js:15536 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:255
 msgid "Loading&hellip;"
 msgstr ""
 
-#: static/js/zamboni/editors.js:260
+#: static/js/zamboni/editors-all.js:15541 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:260
 msgid "Version Notes"
 msgstr ""
 
-#: static/js/zamboni/editors.js:265
+#: static/js/zamboni/editors-all.js:15546 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:265
 msgid "Notes for Reviewers"
 msgstr ""
 
-#: static/js/zamboni/editors.js:270
+#: static/js/zamboni/editors-all.js:15551 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:270
 msgid "No version notes found"
 msgstr ""
 
-#: static/js/zamboni/editors.js:330
+#: static/js/zamboni/editors-all.js:15611 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:330
 msgid "Average Reviews"
 msgstr ""
 
-#: static/js/zamboni/editors.js:386
+#: static/js/zamboni/editors-all.js:15667 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:386
 msgid "Number of Reviews"
 msgstr ""
 
-#: static/js/zamboni/editors.js:445
+#: static/js/zamboni/editors-all.js:15726 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:445
 msgid "Error loading translation"
 msgstr ""
 
-#: static/js/zamboni/files.js:411 static/js/zamboni/validator.js:261
-msgid "Ignore this message in future updates"
-msgstr ""
-
-#: static/js/zamboni/files.js:417 static/js/zamboni/validator.js:284
-msgid "Severity for automated signing:"
-msgstr ""
-
-#: static/js/zamboni/global.js:410
-msgid "Loading..."
-msgstr ""
-
-#. L10n: {0} is the number of characters left.
-#: static/js/zamboni/global.js:474
-msgid "<b>{0}</b> character left."
-msgid_plural "<b>{0}</b> characters left."
-msgstr[0] ""
-msgstr[1] ""
-
-#: static/js/zamboni/init.js:28
-msgid "This feature is temporarily disabled while we perform website maintenance. Please check back a little later."
-msgstr ""
-
-#: static/js/zamboni/l10n.js:45
-msgid "Remove this localization"
-msgstr ""
-
-#: static/js/zamboni/password-strength.js:20
-msgid "Password strength:"
-msgstr ""
-
-#: static/js/zamboni/password-strength.js:26
-msgid "At least {0} character left."
-msgid_plural "At least {0} characters left."
-msgstr[0] ""
-msgstr[1] ""
-
-#: static/js/zamboni/themes_review.js:176
-msgid "Requested Info"
-msgstr ""
-
-#: static/js/zamboni/themes_review.js:177
-msgid "Flagged"
-msgstr ""
-
-#: static/js/zamboni/themes_review.js:178
-msgid "Duplicate"
-msgstr ""
-
-#: static/js/zamboni/themes_review.js:179
-msgid "Rejected"
-msgstr ""
-
-#: static/js/zamboni/themes_review.js:180
-msgid "Approved"
-msgstr ""
-
-#: static/js/zamboni/themes_review.js:424
-msgid "No results found"
-msgstr ""
-
-#: static/js/zamboni/themes_review_templates.js:31
+#: static/js/zamboni/editors-all.js:15975 static/js/zamboni/editors-min.js:5 static/js/zamboni/themes_review_templates.js:31
 msgid "Theme"
 msgstr ""
 
-#: static/js/zamboni/themes_review_templates.js:33
+#: static/js/zamboni/editors-all.js:15977 static/js/zamboni/editors-min.js:5 static/js/zamboni/themes_review_templates.js:33
 msgid "Reviewer"
 msgstr ""
 
-#: static/js/zamboni/themes_review_templates.js:35
+#: static/js/zamboni/editors-all.js:15979 static/js/zamboni/editors-min.js:5 static/js/zamboni/themes_review_templates.js:35
 msgid "Status"
 msgstr ""
 
-#: static/js/zamboni/validator.js:80
-msgid "All tests passed successfully."
+#: static/js/zamboni/editors-all.js:16196 static/js/zamboni/editors-min.js:5 static/js/zamboni/themes_review.js:176
+msgid "Requested Info"
 msgstr ""
 
-#: static/js/zamboni/validator.js:83 static/js/zamboni/validator.js:478
-msgid "These tests were not run."
+#: static/js/zamboni/editors-all.js:16197 static/js/zamboni/editors-min.js:5 static/js/zamboni/themes_review.js:177
+msgid "Flagged"
 msgstr ""
 
-#: static/js/zamboni/validator.js:131 static/js/zamboni/validator.js:144
-msgid "Tests"
+#: static/js/zamboni/editors-all.js:16198 static/js/zamboni/editors-min.js:5 static/js/zamboni/themes_review.js:178
+msgid "Duplicate"
 msgstr ""
 
-#: static/js/zamboni/validator.js:246 static/js/zamboni/validator.js:575 static/js/zamboni/validator.js:594
-msgid "Error"
+#: static/js/zamboni/editors-all.js:16199 static/js/zamboni/editors-min.js:5 static/js/zamboni/themes_review.js:179
+msgid "Rejected"
 msgstr ""
 
-#: static/js/zamboni/validator.js:247
-msgid "Warning"
+#: static/js/zamboni/editors-all.js:16200 static/js/zamboni/editors-min.js:5 static/js/zamboni/themes_review.js:180
+msgid "Approved"
 msgstr ""
 
-#: static/js/zamboni/validator.js:299
-msgid "Suggestions for passing automated signing:"
+#: static/js/zamboni/editors-all.js:16444 static/js/zamboni/editors-min.js:5 static/js/zamboni/themes_review.js:424
+msgid "No results found"
 msgstr ""
 
-#: static/js/zamboni/validator.js:387
-msgid "Compatibility Tests"
-msgstr ""
-
-#: static/js/zamboni/validator.js:466
-msgid "Add-on failed validation."
-msgstr ""
-
-#: static/js/zamboni/validator.js:468
-msgid "Add-on passed validation."
-msgstr ""
-
-#: static/js/zamboni/validator.js:481
-msgid "{0} error"
-msgid_plural "{0} errors"
-msgstr[0] ""
-msgstr[1] ""
-
-#: static/js/zamboni/validator.js:483
-msgid "{0} warning"
-msgid_plural "{0} warnings"
-msgstr[0] ""
-msgstr[1] ""
-
-#: static/js/zamboni/validator.js:485
-msgid "{0} notice"
-msgid_plural "{0} notices"
-msgstr[0] ""
-msgstr[1] ""
-
-#: static/js/zamboni/validator.js:577
-msgid "Validation task could not complete or completed with errors"
-msgstr ""
-
-#: static/js/zamboni/validator.js:595
-msgid "Internal server error"
-msgstr ""
-
-#: static/js/zamboni/mobile/buttons.js:52
+#: static/js/zamboni/mobile-all.js:15186 static/js/zamboni/mobile/buttons.js:52
 msgid "Not Updated for {0} {1}"
 msgstr ""
 
-#: static/js/zamboni/mobile/buttons.js:53
+#: static/js/zamboni/mobile-all.js:15187 static/js/zamboni/mobile/buttons.js:53
 msgid "Requires Newer Version of {0}"
 msgstr ""
 
-#: static/js/zamboni/mobile/buttons.js:54
+#: static/js/zamboni/mobile-all.js:15188 static/js/zamboni/mobile/buttons.js:54
 msgid "Unreviewed"
 msgstr ""
 
-#: static/js/zamboni/mobile/buttons.js:55
+#: static/js/zamboni/mobile-all.js:15189 static/js/zamboni/mobile/buttons.js:55
 msgid "Experimental <span>(Learn More)</span>"
 msgstr ""
 
-#: static/js/zamboni/mobile/buttons.js:56 static/js/zamboni/mobile/buttons.js:57
+#: static/js/zamboni/mobile-all.js:15190 static/js/zamboni/mobile-all.js:15191 static/js/zamboni/mobile/buttons.js:56 static/js/zamboni/mobile/buttons.js:57
 msgid "Not Available for {0}"
 msgstr ""
 
-#: static/js/zamboni/mobile/buttons.js:58
+#: static/js/zamboni/mobile-all.js:15192 static/js/zamboni/mobile/buttons.js:58
 msgid "Experimental"
 msgstr ""
 
-#: static/js/zamboni/mobile/buttons.js:59
+#: static/js/zamboni/mobile-all.js:15193 static/js/zamboni/mobile/buttons.js:59
 msgid "Themes Require Newer Version of {0}"
 msgstr ""
 
-#: static/js/zamboni/mobile/buttons.js:60
+#: static/js/zamboni/mobile-all.js:15194 static/js/zamboni/mobile/buttons.js:60
 msgid "Themes Require {0}"
 msgstr ""
 
-#: static/js/zamboni/mobile/buttons.js:105
+#: static/js/zamboni/mobile-all.js:15239 static/js/zamboni/mobile/buttons.js:105
 msgid "Installing..."
 msgstr ""
 
-#: static/js/zamboni/mobile/buttons.js:125
+#: static/js/zamboni/mobile-all.js:15259 static/js/zamboni/mobile/buttons.js:125
 msgid "This add-on has been preliminarily reviewed by Mozilla."
 msgstr ""
 
-#: static/js/zamboni/mobile/buttons.js:250
+#: static/js/zamboni/mobile-all.js:15384 static/js/zamboni/mobile/buttons.js:250
 msgid "Keep it"
 msgstr ""
 
-#: static/js/zamboni/mobile/general.js:344
+#: static/js/zamboni/mobile-all.js:16049 static/js/zamboni/mobile-min.js:6 static/js/zamboni/mobile/general.js:344
 msgid "You're trying it on!"
 msgstr ""
 
-#: static/js/zamboni/mobile/general.js:356
+#: static/js/zamboni/mobile-all.js:16061 static/js/zamboni/mobile-min.js:6 static/js/zamboni/mobile/general.js:356
 msgid "Added to Firefox"
 msgstr ""
-

--- a/locale/ga_IE/LC_MESSAGES/django.po
+++ b/locale/ga_IE/LC_MESSAGES/django.po
@@ -7,69 +7,70 @@ msgid ""
 msgstr ""
 "Project-Id-Version: REMORA 0.1\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2016-02-24 21:23+0000\n"
+"POT-Creation-Date: 2016-04-18 15:47+0000\n"
 "PO-Revision-Date: 2008-04-08 00:00-0600\n"
 "Last-Translator: Kevin Scannell <kscanne@gmail.com>\n"
 "Language-Team: Irish <gaeilge-gnulinux@lists.sourceforge.net>\n"
+"Language: ga\n"
 "MIME-Version: 1.0\n"
-"Content-Type: text/plain; charset=utf-8\n"
+"Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Generated-By: Babel 2.2.0\n"
 
-#: src/olympia/accounts/views.py:52
+#: src/olympia/accounts/views.py:54
 msgid "Your log in attempt could not be parsed. Please try again."
 msgstr ""
 
-#: src/olympia/accounts/views.py:54
+#: src/olympia/accounts/views.py:56
 msgid "Your Firefox Account could not be found. Please try again."
 msgstr ""
 
-#: src/olympia/accounts/views.py:55
+#: src/olympia/accounts/views.py:57
 msgid "You could not be logged in. Please try again."
 msgstr ""
 
-#: src/olympia/accounts/views.py:57
+#: src/olympia/accounts/views.py:59
 msgid "Your account has already been migrated to Firefox Accounts."
 msgstr ""
 
-#: src/olympia/accounts/views.py:59
+#: src/olympia/accounts/views.py:61
 msgid "Your Firefox Account already exists on this site."
 msgstr ""
 
-#: src/olympia/accounts/views.py:108
+#: src/olympia/accounts/views.py:110
 msgid "Great job!"
 msgstr ""
 
-#: src/olympia/accounts/views.py:109
+#: src/olympia/accounts/views.py:111
 msgid "You can now log in to Add-ons with your Firefox Account."
 msgstr ""
 
-#: src/olympia/accounts/views.py:121
+#: src/olympia/accounts/views.py:123
 msgid "Need help?"
 msgstr ""
 
-#: src/olympia/addons/buttons.py:180
+#: src/olympia/addons/buttons.py:177
 msgid "Download Now"
 msgstr "Íosluchtaigh Anois"
 
-#: src/olympia/addons/buttons.py:182
+#: src/olympia/addons/buttons.py:179
 msgid "Download"
 msgstr "Íosluchtaigh"
 
 #. L10n: please keep &nbsp; in the string so &rarr; does not wrap.
-#: src/olympia/addons/buttons.py:186
+#: src/olympia/addons/buttons.py:183
 msgid "Continue to Download&nbsp;&rarr;"
 msgstr "Leathanach Íosluchtaithe&nbsp;&rarr;"
 
-#: src/olympia/addons/buttons.py:202 src/olympia/addons/helpers.py:35 src/olympia/addons/views.py:319 src/olympia/addons/templates/addons/impala/details.html:114
+#: src/olympia/addons/buttons.py:199 src/olympia/addons/helpers.py:35 src/olympia/addons/views.py:333 src/olympia/addons/templates/addons/impala/details.html:111
 #: src/olympia/addons/templates/addons/impala/listing/items.html:17 src/olympia/addons/templates/addons/mobile/home.html:40 src/olympia/amo/templates/amo/side_nav.html:6
-#: src/olympia/amo/templates/amo/side_nav.html:10 src/olympia/amo/templates/amo/site_nav.html:2 src/olympia/amo/templates/amo/site_nav.html:55 src/olympia/bandwagon/views.py:95
-#: src/olympia/browse/views.py:54 src/olympia/browse/views.py:68 src/olympia/browse/views.py:235 src/olympia/browse/templates/browse/impala/category_landing.html:22
+#: src/olympia/amo/templates/amo/side_nav.html:10 src/olympia/amo/templates/amo/site_nav.html:2 src/olympia/amo/templates/amo/site_nav.html:53 src/olympia/bandwagon/views.py:95
+#: src/olympia/browse/views.py:54 src/olympia/browse/views.py:68 src/olympia/browse/views.py:202 src/olympia/browse/templates/browse/impala/category_landing.html:22
 #: src/olympia/browse/templates/browse/personas/mobile/category_landing.html:26
 msgid "Featured"
 msgstr "Mór-Le-Rá"
 
-#: src/olympia/addons/buttons.py:221
+#: src/olympia/addons/buttons.py:218
 msgid "Add to {0}"
 msgstr "Cuir le {0}"
 
@@ -92,9 +93,6 @@ msgid "Invalid tag: {0}"
 msgid_plural "Invalid tags: {0}"
 msgstr[0] "Clib neamhbhailí: {0}"
 msgstr[1] "Clibeanna neamhbhailí: {0}"
-msgstr[2] "Clibeanna neamhbhailí: {0}"
-msgstr[3] "Clibeanna neamhbhailí: {0}"
-msgstr[4] "Clibeanna neamhbhailí: {0}"
 
 #. L10n: {0} is a single tag or a comma-separated list of tags.
 #: src/olympia/addons/forms.py:103
@@ -102,18 +100,12 @@ msgid "\"{0}\" is a reserved tag and cannot be used."
 msgid_plural "\"{0}\" are reserved tags and cannot be used."
 msgstr[0] "Tá an chlib \"{0}\" in áirithe agus níl cead agat é a úsáid."
 msgstr[1] "Tá na clibeanna \"{0}\" in áirithe agus níl cead agat é a úsáid."
-msgstr[2] "Tá na clibeanna \"{0}\" in áirithe agus níl cead agat é a úsáid."
-msgstr[3] "Tá na clibeanna \"{0}\" in áirithe agus níl cead agat é a úsáid."
-msgstr[4] "Tá na clibeanna \"{0}\" in áirithe agus níl cead agat é a úsáid."
 
 #: src/olympia/addons/forms.py:111
 msgid "You have {0} too many tags."
 msgid_plural "You have {0} too many tags."
 msgstr[0] ""
 msgstr[1] ""
-msgstr[2] ""
-msgstr[3] ""
-msgstr[4] ""
 
 #: src/olympia/addons/forms.py:117
 #, python-format
@@ -125,46 +117,40 @@ msgid "All tags must be at least {0} character."
 msgid_plural "All tags must be at least {0} characters."
 msgstr[0] "Ní mór {0} charachtar ar a laghad a bheith i gclib."
 msgstr[1] "Ní mór {0} charachtar ar a laghad a bheith i gclib."
-msgstr[2] "Ní mór {0} charachtar ar a laghad a bheith i gclib."
-msgstr[3] "Ní mór {0} charachtar ar a laghad a bheith i gclib."
-msgstr[4] "Ní mór {0} charachtar ar a laghad a bheith i gclib."
 
-#: src/olympia/addons/forms.py:234
+#: src/olympia/addons/forms.py:238
 msgid "Categories cannot be changed while your add-on is featured for this application."
 msgstr ""
 
 #. L10n: {0} is the number of categories.
-#: src/olympia/addons/forms.py:238
+#: src/olympia/addons/forms.py:242
 msgid "You can have only {0} category."
 msgid_plural "You can have only {0} categories."
 msgstr[0] "Ní cheadaítear níos mó ná {0} chatagóir."
 msgstr[1] "Ní cheadaítear níos mó ná {0} chatagóir."
-msgstr[2] "Ní cheadaítear níos mó ná {0} chatagóir."
-msgstr[3] "Ní cheadaítear níos mó ná {0} gcatagóir."
-msgstr[4] "Ní cheadaítear níos mó ná {0} catagóir."
 
-#: src/olympia/addons/forms.py:246
+#: src/olympia/addons/forms.py:250
 msgid "The miscellaneous category cannot be combined with additional categories."
 msgstr "Ní féidir an chatagóir Éagsúil a chur le chéile le catagóirí breise."
 
-#: src/olympia/addons/forms.py:369
+#: src/olympia/addons/forms.py:374
 #, python-format
 msgid "Before changing your default locale you must have a name, summary, and description in that locale. You are missing %s."
 msgstr "Sular féidir leat an logchaighdeán réamhshocraithe a athrú, tá ainm, achoimre, agus cur síos sa teanga sin de dhíth. Tá %s ar iarraidh."
 
-#: src/olympia/addons/forms.py:484 src/olympia/addons/forms.py:575
+#: src/olympia/addons/forms.py:455 src/olympia/addons/forms.py:546
 msgid "A license must be selected."
 msgstr "Ní mór duit ceadúnas a roghnú."
 
-#: src/olympia/addons/forms.py:556
+#: src/olympia/addons/forms.py:527
 msgid "Give Your Theme a Name."
 msgstr "Cuir ainm ar do théama."
 
-#: src/olympia/addons/forms.py:562 src/olympia/devhub/templates/devhub/personas/submit.html:53
+#: src/olympia/addons/forms.py:533 src/olympia/devhub/templates/devhub/personas/submit.html:53
 msgid "Describe your Theme."
 msgstr "Déan cur síos ar do Théama."
 
-#: src/olympia/addons/forms.py:704
+#: src/olympia/addons/forms.py:675
 msgid "Enter a new author's email address"
 msgstr ""
 
@@ -172,38 +158,38 @@ msgstr ""
 msgid "Not Reviewed"
 msgstr "Gan Léirmheas"
 
-#: src/olympia/addons/models.py:301
+#: src/olympia/addons/models.py:298
 msgid "Users have the option of contributing more or less than this amount."
 msgstr "Beidh úsáideoirí in ann níos mó nó níos lú ná an méid seo a thabhairt."
 
-#: src/olympia/addons/models.py:309
-msgid "Users will always be asked in the Add-ons Manager (Firefox 4 and above)"
-msgstr "Cuirfear ceist ar úsáideoirí i gcónaí i mBainisteoir na mBreiseán (Firefox 4 agus níos déanaí)"
+#: src/olympia/addons/models.py:306
+msgid "Users will always be asked in the Add-ons Manager (Firefox 4 and above). Only applies to desktop."
+msgstr ""
 
-#: src/olympia/addons/models.py:1804 src/olympia/addons/templates/addons/details_box.html:55 src/olympia/devhub/templates/devhub/index.html:92
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:102
+#: src/olympia/addons/models.py:1802 src/olympia/addons/templates/addons/details_box.html:55 src/olympia/devhub/templates/devhub/index.html:92
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:89
 msgid "Listed"
 msgstr "Liostaithe"
 
-#: src/olympia/addons/views.py:320 src/olympia/browse/templates/browse/personas/mobile/category_landing.html:27
+#: src/olympia/addons/views.py:334 src/olympia/browse/templates/browse/personas/mobile/category_landing.html:27
 msgid "Popular"
 msgstr "Éileamh Is Mó"
 
-#: src/olympia/addons/views.py:321 src/olympia/browse/views.py:238 src/olympia/browse/views.py:280 src/olympia/browse/views.py:482
+#: src/olympia/addons/views.py:335 src/olympia/browse/views.py:205 src/olympia/browse/views.py:247 src/olympia/browse/views.py:449
 msgid "Recently Added"
 msgstr "Curtha Leis Le Déanaí"
 
-#: src/olympia/addons/views.py:322 src/olympia/bandwagon/views.py:99 src/olympia/browse/views.py:60 src/olympia/browse/views.py:71 src/olympia/search/forms.py:16 src/olympia/search/forms.py:91
+#: src/olympia/addons/views.py:336 src/olympia/bandwagon/views.py:99 src/olympia/browse/views.py:60 src/olympia/browse/views.py:71 src/olympia/search/forms.py:16 src/olympia/search/forms.py:91
 msgid "Recently Updated"
 msgstr "Nuashonraithe Le Déanaí"
 
 # %1 is an add-on name.
 #. l10n: {0} is the addon name
-#: src/olympia/addons/views.py:520
+#: src/olympia/addons/views.py:534
 msgid "Contribution for {0}"
 msgstr "Deontais le haghaidh {0}"
 
-#: src/olympia/addons/views.py:613
+#: src/olympia/addons/views.py:627
 msgid "Abuse reported."
 msgstr "Rinneadh tuairisc ar dhrochúsáid."
 
@@ -272,9 +258,9 @@ msgstr "Tabhair deontas"
 #: src/olympia/devhub/templates/devhub/addons/ajax_compat_update.html:36 src/olympia/devhub/templates/devhub/addons/profile.html:44 src/olympia/devhub/templates/devhub/addons/edit/admin.html:101
 #: src/olympia/devhub/templates/devhub/addons/edit/basic.html:152 src/olympia/devhub/templates/devhub/addons/edit/details.html:85 src/olympia/devhub/templates/devhub/addons/edit/support.html:67
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:166 src/olympia/devhub/templates/devhub/addons/forms_shared/media.html:149
-#: src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:44 src/olympia/devhub/templates/devhub/versions/add_file_modal.html:78 src/olympia/devhub/templates/devhub/versions/edit.html:139
-#: src/olympia/devhub/templates/devhub/versions/list.html:242 src/olympia/devhub/templates/devhub/versions/list.html:276 src/olympia/devhub/templates/devhub/versions/list.html:317
-#: src/olympia/devhub/templates/devhub/versions/list.html:351 src/olympia/reviews/templates/reviews/edit_review.html:16 src/olympia/translations/templates/translations/trans-menu.html:50
+#: src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:43 src/olympia/devhub/templates/devhub/versions/add_file_modal.html:58 src/olympia/devhub/templates/devhub/versions/edit.html:139
+#: src/olympia/devhub/templates/devhub/versions/list.html:239 src/olympia/devhub/templates/devhub/versions/list.html:281 src/olympia/devhub/templates/devhub/versions/list.html:315
+#: src/olympia/devhub/templates/devhub/versions/list.html:349 src/olympia/reviews/templates/reviews/edit_review.html:16 src/olympia/translations/templates/translations/trans-menu.html:50
 #: src/olympia/translations/templates/translations/trans-menu.html:62
 msgid "or"
 msgstr "nó"
@@ -389,7 +375,7 @@ msgid "Add-on Information for {0}"
 msgstr "Eolas faoi Bhreiseán {0}"
 
 #: src/olympia/addons/templates/addons/details_box.html:30 src/olympia/addons/templates/addons/persona_detail_table.html:3 src/olympia/addons/templates/addons/mobile/details.html:63
-#: src/olympia/addons/templates/addons/mobile/persona_detail_table.html:7 src/olympia/browse/views.py:459 src/olympia/devhub/views.py:75
+#: src/olympia/addons/templates/addons/mobile/persona_detail_table.html:7 src/olympia/browse/views.py:426 src/olympia/devhub/views.py:73
 msgid "Updated"
 msgstr "Nuashonraithe"
 
@@ -408,11 +394,11 @@ msgstr "Feidhmíonn sé le"
 msgid "Visibility"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/details_box.html:57 src/olympia/devhub/templates/devhub/index.html:94 src/olympia/devhub/templates/devhub/includes/addon_details.html:104
+#: src/olympia/addons/templates/addons/details_box.html:57 src/olympia/devhub/templates/devhub/index.html:94 src/olympia/devhub/templates/devhub/includes/addon_details.html:91
 msgid "Hidden"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/details_box.html:59 src/olympia/devhub/templates/devhub/index.html:96 src/olympia/devhub/templates/devhub/includes/addon_details.html:106
+#: src/olympia/addons/templates/addons/details_box.html:59 src/olympia/devhub/templates/devhub/index.html:96 src/olympia/devhub/templates/devhub/includes/addon_details.html:93
 msgid "Unlisted"
 msgstr ""
 
@@ -420,13 +406,13 @@ msgstr ""
 msgid "Required Add-ons"
 msgstr "Breiseáin Riachtanacha"
 
-#: src/olympia/addons/templates/addons/details_box.html:81 src/olympia/addons/templates/addons/persona_detail_table.html:15 src/olympia/browse/views.py:462 src/olympia/devhub/views.py:78
-#: src/olympia/devhub/views.py:85 src/olympia/discovery/templates/discovery/addons/detail.html:57 src/olympia/reviews/forms.py:62 src/olympia/reviews/templates/reviews/add.html:57
+#: src/olympia/addons/templates/addons/details_box.html:81 src/olympia/addons/templates/addons/persona_detail_table.html:15 src/olympia/browse/views.py:429 src/olympia/devhub/views.py:76
+#: src/olympia/devhub/views.py:83 src/olympia/discovery/templates/discovery/addons/detail.html:57 src/olympia/reviews/forms.py:62 src/olympia/reviews/templates/reviews/add.html:57
 #: src/olympia/reviews/templates/reviews/mobile/review_list.html:18
 msgid "Rating"
 msgstr "Rátáil"
 
-#: src/olympia/addons/templates/addons/details_box.html:85 src/olympia/browse/views.py:461 src/olympia/devhub/views.py:77 src/olympia/devhub/views.py:84
+#: src/olympia/addons/templates/addons/details_box.html:85 src/olympia/browse/views.py:428 src/olympia/devhub/views.py:75 src/olympia/devhub/views.py:82
 #: src/olympia/stats/templates/stats/addon_report_menu.html:8 src/olympia/stats/templates/stats/collection_report_menu.html:18
 msgid "Downloads"
 msgstr "Íosluchtuithe"
@@ -446,7 +432,7 @@ msgstr "Tuairiscí ar Dhrochúsáid"
 
 #. The Privacy Policy for this add-on.
 #: src/olympia/addons/templates/addons/details_box.html:121 src/olympia/addons/templates/addons/privacy.html:19 src/olympia/addons/templates/addons/privacy.html:23
-#: src/olympia/addons/templates/addons/impala/button.html:43 src/olympia/addons/templates/addons/impala/details.html:307 src/olympia/devhub/templates/devhub/includes/policy_form.html:20
+#: src/olympia/addons/templates/addons/impala/button.html:43 src/olympia/addons/templates/addons/impala/details.html:312 src/olympia/devhub/templates/devhub/includes/policy_form.html:23
 #: src/olympia/templates/mobile/base_addons.html:87
 msgid "Privacy Policy"
 msgstr "Polasaí Príobháideachta"
@@ -471,7 +457,7 @@ msgstr "Gailearaí Íomhánna"
 msgid "Developer Comments"
 msgstr "Nótaí Tráchta ón Fhorbróir"
 
-#: src/olympia/addons/templates/addons/details_box.html:199 src/olympia/addons/templates/addons/impala/details.html:259
+#: src/olympia/addons/templates/addons/details_box.html:199 src/olympia/addons/templates/addons/impala/details.html:264
 msgid "Development Channel"
 msgstr "Cainéal Forbartha"
 
@@ -491,13 +477,13 @@ msgid ""
 "developer. To stop receiving development updates, reinstall the default version from the link above."
 msgstr ""
 
-#: src/olympia/addons/templates/addons/details_box.html:220 src/olympia/addons/templates/addons/impala/details.html:278
+#: src/olympia/addons/templates/addons/details_box.html:220 src/olympia/addons/templates/addons/impala/details.html:283
 msgid "Version {0}:"
 msgstr "Leagan {0}:"
 
 #: src/olympia/addons/templates/addons/details_box.html:234
-msgid "Nothing to see here! The developer did not include any details."
-msgstr "Níl aon rud suimiúil anseo! Níor chuir an forbróir aon mhionsonraí san áireamh."
+msgid "Nothing to see here!  The developer did not include any details."
+msgstr ""
 
 #: src/olympia/addons/templates/addons/details_box.html:251 src/olympia/devhub/templates/devhub/versions/edit.html:73 src/olympia/editors/templates/editors/review.html:98
 msgid "Version Notes"
@@ -510,7 +496,7 @@ msgid "End-User License Agreement for {0}"
 msgstr "Comhaontú Ceadúnais Úsáideoir Deiridh le haghaidh {0}"
 
 #: src/olympia/addons/templates/addons/eula.html:17 src/olympia/addons/templates/addons/eula.html:21 src/olympia/addons/templates/addons/impala/button.html:48
-#: src/olympia/addons/templates/addons/impala/details.html:316 src/olympia/devhub/templates/devhub/includes/policy_form.html:3 src/olympia/discovery/templates/discovery/addons/eula.html:11
+#: src/olympia/addons/templates/addons/impala/details.html:321 src/olympia/devhub/templates/devhub/includes/policy_form.html:3 src/olympia/discovery/templates/discovery/addons/eula.html:11
 msgid "End-User License Agreement"
 msgstr "Comhaontú Ceadúnais"
 
@@ -529,7 +515,7 @@ msgstr "Ar ais go {0}…"
 msgid "Add-ons for {0}"
 msgstr "Breiseáin le haghaidh {0}"
 
-#: src/olympia/addons/templates/addons/home.html:10 src/olympia/addons/templates/addons/home.html:51 src/olympia/browse/templates/browse/impala/base_listing.html:11
+#: src/olympia/addons/templates/addons/home.html:10 src/olympia/addons/templates/addons/home.html:53 src/olympia/browse/templates/browse/impala/base_listing.html:11
 msgid "Featured Extensions"
 msgstr "Eisínteachtaí Mór-Le-Rá"
 
@@ -537,29 +523,29 @@ msgstr "Eisínteachtaí Mór-Le-Rá"
 msgid "Popular Extensions"
 msgstr "Eisínteachtaí: Éileamh Is Mó"
 
-#: src/olympia/addons/templates/addons/home.html:42 src/olympia/amo/templates/amo/side_nav.html:3 src/olympia/amo/templates/amo/side_nav.html:11 src/olympia/amo/templates/amo/site_nav.html:3
-#: src/olympia/amo/templates/amo/site_nav.html:25 src/olympia/browse/views.py:236 src/olympia/browse/views.py:281 src/olympia/browse/views.py:481
+#: src/olympia/addons/templates/addons/home.html:44 src/olympia/amo/templates/amo/side_nav.html:3 src/olympia/amo/templates/amo/side_nav.html:11 src/olympia/amo/templates/amo/site_nav.html:3
+#: src/olympia/amo/templates/amo/site_nav.html:25 src/olympia/browse/views.py:203 src/olympia/browse/views.py:248 src/olympia/browse/views.py:448
 msgid "Most Popular"
 msgstr "Éileamh Is Mó"
 
-#: src/olympia/addons/templates/addons/home.html:43
+#: src/olympia/addons/templates/addons/home.html:45
 msgid "All »"
 msgstr "Uile »"
 
-#: src/olympia/addons/templates/addons/home.html:52 src/olympia/addons/templates/addons/home.html:61 src/olympia/addons/templates/addons/home.html:70 src/olympia/addons/templates/addons/home.html:78
+#: src/olympia/addons/templates/addons/home.html:54 src/olympia/addons/templates/addons/home.html:63 src/olympia/addons/templates/addons/home.html:72 src/olympia/addons/templates/addons/home.html:80
 #: src/olympia/browse/templates/browse/impala/category_landing.html:36
 msgid "See all »"
 msgstr "Uile »"
 
-#: src/olympia/addons/templates/addons/home.html:60
+#: src/olympia/addons/templates/addons/home.html:62
 msgid "Up &amp; Coming Extensions"
 msgstr "Eisínteachtaí ag Teacht Chun Cinn"
 
-#: src/olympia/addons/templates/addons/home.html:69 src/olympia/browse/templates/browse/personas/category_landing.html:61 src/olympia/discovery/templates/discovery/pane.html:74
+#: src/olympia/addons/templates/addons/home.html:71 src/olympia/browse/templates/browse/personas/category_landing.html:61 src/olympia/discovery/templates/discovery/pane.html:74
 msgid "Featured Themes"
 msgstr "Téamaí Mór-Le-Rá"
 
-#: src/olympia/addons/templates/addons/home.html:77 src/olympia/bandwagon/templates/bandwagon/impala/collection_listing.html:5
+#: src/olympia/addons/templates/addons/home.html:79 src/olympia/bandwagon/templates/bandwagon/impala/collection_listing.html:5
 msgid "Featured Collections"
 msgstr "Bailiúcháin Mhór-Le-Rá"
 
@@ -577,7 +563,7 @@ msgid "Updated {0}"
 msgstr "Nuashonraithe {0}"
 
 #. {0} is a date.
-#: src/olympia/addons/templates/addons/macros.html:10 src/olympia/addons/templates/addons/macros.html:69 src/olympia/addons/templates/addons/persona_preview.html:21
+#: src/olympia/addons/templates/addons/macros.html:10 src/olympia/addons/templates/addons/macros.html:69 src/olympia/addons/templates/addons/persona_preview.html:22
 #: src/olympia/addons/templates/addons/listing/items_mobile.html:44 src/olympia/addons/templates/addons/listing/macros.html:39
 #: src/olympia/bandwagon/templates/bandwagon/collection_listing_items.html:37 src/olympia/bandwagon/templates/bandwagon/impala/collection_listing_items.html:37
 msgid "Added {0}"
@@ -589,9 +575,6 @@ msgid "%(num)s weekly download"
 msgid_plural "%(num)s weekly downloads"
 msgstr[0] "%(num)s íosluchtú sa tseachtain"
 msgstr[1] "%(num)s íosluchtú sa tseachtain"
-msgstr[2] "%(num)s íosluchtú sa tseachtain"
-msgstr[3] "%(num)s n-íosluchtú sa tseachtain"
-msgstr[4] "%(num)s íosluchtú sa tseachtain"
 
 #: src/olympia/addons/templates/addons/macros.html:28
 #, python-format
@@ -599,30 +582,20 @@ msgid "%(num)s user"
 msgid_plural "%(num)s users"
 msgstr[0] "%(num)s úsáideoir"
 msgstr[1] "%(num)s úsáideoir"
-msgstr[2] "%(num)s úsáideoir"
-msgstr[3] "%(num)s n-úsáideoir"
-msgstr[4] "%(num)s úsáideoir"
 
 #. {0} is the number of downloads.
-#: src/olympia/addons/templates/addons/macros.html:53 src/olympia/addons/templates/addons/impala/details.html:61
+#: src/olympia/addons/templates/addons/macros.html:53 src/olympia/addons/templates/addons/impala/details.html:59
 msgid "{0} weekly download"
 msgid_plural "{0} weekly downloads"
 msgstr[0] "{0} íosluchtú sa tseachtain"
 msgstr[1] "{0} íosluchtú sa tseachtain"
-msgstr[2] "{0} íosluchtú sa tseachtain"
-msgstr[3] "{0} n-íosluchtú sa tseachtain"
-msgstr[4] "{0} íosluchtú sa tseachtain"
 
 #. {0} is the number of users.
-#: src/olympia/addons/templates/addons/macros.html:61 src/olympia/addons/templates/addons/impala/details.html:54 src/olympia/compat/templates/compat/index.html:71
-#: src/olympia/zadmin/templates/zadmin/compat.html:67
+#: src/olympia/addons/templates/addons/macros.html:61 src/olympia/addons/templates/addons/impala/details.html:52 src/olympia/zadmin/templates/zadmin/compat.html:67
 msgid "{0} user"
 msgid_plural "{0} users"
 msgstr[0] "{0} úsáideoir"
 msgstr[1] "{0} úsáideoir"
-msgstr[2] "{0} úsáideoir"
-msgstr[3] "{0} n-úsáideoir"
-msgstr[4] "{0} úsáideoir"
 
 #: src/olympia/addons/templates/addons/paypal_result.html:12
 msgid "Payment cancelled"
@@ -636,7 +609,7 @@ msgstr "Íocaíocht curtha i gcrích"
 msgid "Return to the addon."
 msgstr "Fill ar an mbreiseán."
 
-#: src/olympia/addons/templates/addons/persona_detail.html:17 src/olympia/addons/templates/addons/impala/details.html:106 src/olympia/addons/templates/addons/mobile/details.html:23
+#: src/olympia/addons/templates/addons/persona_detail.html:17 src/olympia/addons/templates/addons/impala/details.html:103 src/olympia/addons/templates/addons/mobile/details.html:23
 #: src/olympia/addons/templates/addons/mobile/persona_detail.html:21 src/olympia/discovery/templates/discovery/addons/base.html:27 src/olympia/editors/templates/editors/review.html:31
 msgid "by"
 msgstr "le"
@@ -680,37 +653,35 @@ msgstr "Úsáideoirí Laethúla"
 msgid "License"
 msgstr "Ceadúnas"
 
-#: src/olympia/addons/templates/addons/persona_preview.html:12 src/olympia/constants/base.py:48
+#: src/olympia/addons/templates/addons/persona_preview.html:13 src/olympia/constants/base.py:48
 msgid "Awaiting Review"
 msgstr "Ag feitheamh le Réamhscrúdú"
 
-#: src/olympia/addons/templates/addons/persona_preview.html:14 src/olympia/amo/log.py:180 src/olympia/constants/base.py:42 src/olympia/editors/helpers.py:62
+#: src/olympia/addons/templates/addons/persona_preview.html:15 src/olympia/amo/log.py:180 src/olympia/constants/base.py:42 src/olympia/editors/helpers.py:62
 msgid "Rejected"
 msgstr "Diúltaithe"
 
-#: src/olympia/addons/templates/addons/persona_preview.html:16 src/olympia/amo/log.py:159
+#: src/olympia/addons/templates/addons/persona_preview.html:17 src/olympia/amo/log.py:159
 msgid "Approved"
 msgstr "Ceadaithe"
 
 #. {0} is the number of users.
-#: src/olympia/addons/templates/addons/persona_preview.html:26 src/olympia/addons/templates/addons/listing/items_mobile.html:36 src/olympia/addons/templates/addons/listing/macros.html:31
+#: src/olympia/addons/templates/addons/persona_preview.html:27 src/olympia/addons/templates/addons/listing/items_mobile.html:36 src/olympia/addons/templates/addons/listing/macros.html:31
 msgid "<strong>{0}</strong> user"
 msgid_plural "<strong>{0}</strong> users"
 msgstr[0] "<strong>{0}</strong> úsáideoir"
 msgstr[1] "<strong>{0}</strong> úsáideoir"
-msgstr[2] "<strong>{0}</strong> úsáideoir"
-msgstr[3] "<strong>{0}</strong> n-úsáideoir"
-msgstr[4] "<strong>{0}</strong> úsáideoir"
 
-#: src/olympia/addons/templates/addons/persona_preview.html:40
+#: src/olympia/addons/templates/addons/persona_preview.html:41
 msgid "Hover to Preview"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/persona_preview.html:46 src/olympia/addons/templates/addons/persona_preview.html:48 src/olympia/reviews/templates/reviews/add.html:15
+#: src/olympia/addons/templates/addons/persona_preview.html:47 src/olympia/addons/templates/addons/persona_preview.html:49 src/olympia/addons/templates/addons/persona_preview.html:97
+#: src/olympia/reviews/templates/reviews/add.html:15
 msgid "Add"
 msgstr "Cuir Leis"
 
-#: src/olympia/addons/templates/addons/persona_preview.html:57 src/olympia/bandwagon/templates/bandwagon/ajax_new.html:16 src/olympia/bandwagon/templates/bandwagon/edit.html:19
+#: src/olympia/addons/templates/addons/persona_preview.html:58 src/olympia/bandwagon/templates/bandwagon/ajax_new.html:16 src/olympia/bandwagon/templates/bandwagon/edit.html:19
 #: src/olympia/bandwagon/templates/bandwagon/includes/addedit.html:19 src/olympia/devhub/templates/devhub/addons/edit/admin.html:13 src/olympia/devhub/templates/devhub/addons/edit/basic.html:10
 #: src/olympia/devhub/templates/devhub/addons/edit/details.html:8 src/olympia/devhub/templates/devhub/addons/edit/media.html:6 src/olympia/devhub/templates/devhub/addons/edit/support.html:8
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:9 src/olympia/devhub/templates/devhub/addons/submit/describe.html:29 src/olympia/editors/templates/editors/review.html:257
@@ -719,21 +690,21 @@ msgstr "Eagar"
 
 #. For datetime formatting, see the table on
 #. http://docs.python.org/library/datetime.html#strftime-and-strptime-behavior
-#: src/olympia/addons/templates/addons/persona_preview.html:66
+#: src/olympia/addons/templates/addons/persona_preview.html:67
 #, python-format
 msgid "%%Y-%%m-%%d"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/persona_preview.html:67
+#: src/olympia/addons/templates/addons/persona_preview.html:68
 msgid "by {0} on {1}"
 msgstr "le {0} ar {1}"
 
-#: src/olympia/addons/templates/addons/persona_preview.html:75 src/olympia/reviews/helpers.py:17 src/olympia/reviews/templates/reviews/review_list.html:63
+#: src/olympia/addons/templates/addons/persona_preview.html:76 src/olympia/reviews/helpers.py:17 src/olympia/reviews/templates/reviews/review_list.html:63
 #: src/olympia/reviews/templates/reviews/reviews_link.html:21 src/olympia/reviews/templates/reviews/impala/reviews_link.html:16
 msgid "Not yet rated"
 msgstr "Gan rátáil fós"
 
-#: src/olympia/addons/templates/addons/persona_preview.html:78
+#: src/olympia/addons/templates/addons/persona_preview.html:79
 msgid "<b>{0}</b> users"
 msgstr "<b>{0}</b> úsáideoir"
 
@@ -746,8 +717,8 @@ msgid "Learn more about Firefox"
 msgstr "Tuilleadh eolais faoi Firefox"
 
 #: src/olympia/addons/templates/addons/popups.html:22
-msgid "or <b><a class=\"installer\" href=\"{url}\">download anyway</a></b>"
-msgstr "nó <b><a class=\"installer\" href=\"{url}\">íosluchtaigh mar sin féin</a></b>"
+msgid "or <b><a class=\"button installer\" href=\"{url}\">download anyway</a></b>"
+msgstr ""
 
 #: src/olympia/addons/templates/addons/popups.html:26
 msgid ""
@@ -847,7 +818,7 @@ msgid ""
 msgstr ""
 
 #: src/olympia/addons/templates/addons/report_abuse.html:6 src/olympia/addons/templates/addons/report_abuse_full.html:10 src/olympia/addons/templates/addons/impala/details-more.html:23
-#: src/olympia/addons/templates/addons/impala/details.html:328
+#: src/olympia/addons/templates/addons/impala/details.html:333
 msgid "Report Abuse"
 msgstr "Déan Tuairisc ar Dhrochúsáid"
 
@@ -868,9 +839,9 @@ msgstr "Seol Tuairisc"
 #: src/olympia/devhub/templates/devhub/addons/ajax_compat_update.html:36 src/olympia/devhub/templates/devhub/addons/profile.html:44 src/olympia/devhub/templates/devhub/addons/edit/admin.html:104
 #: src/olympia/devhub/templates/devhub/addons/edit/basic.html:155 src/olympia/devhub/templates/devhub/addons/edit/details.html:88 src/olympia/devhub/templates/devhub/addons/edit/support.html:70
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:169 src/olympia/devhub/templates/devhub/addons/forms_shared/media.html:152
-#: src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:44 src/olympia/devhub/templates/devhub/personas/edit.html:222 src/olympia/devhub/templates/devhub/versions/add_file_modal.html:79
-#: src/olympia/devhub/templates/devhub/versions/edit.html:140 src/olympia/devhub/templates/devhub/versions/list.html:208 src/olympia/devhub/templates/devhub/versions/list.html:242
-#: src/olympia/devhub/templates/devhub/versions/list.html:276 src/olympia/devhub/templates/devhub/versions/list.html:317 src/olympia/reviews/templates/reviews/edit_review.html:16
+#: src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:43 src/olympia/devhub/templates/devhub/personas/edit.html:222 src/olympia/devhub/templates/devhub/versions/add_file_modal.html:59
+#: src/olympia/devhub/templates/devhub/versions/edit.html:140 src/olympia/devhub/templates/devhub/versions/list.html:208 src/olympia/devhub/templates/devhub/versions/list.html:239
+#: src/olympia/devhub/templates/devhub/versions/list.html:281 src/olympia/devhub/templates/devhub/versions/list.html:315 src/olympia/reviews/templates/reviews/edit_review.html:16
 #: src/olympia/translations/templates/translations/trans-menu.html:50 src/olympia/translations/templates/translations/trans-menu.html:62 src/olympia/zadmin/templates/zadmin/validation.html:105
 msgid "Cancel"
 msgstr "Cealaigh"
@@ -917,7 +888,7 @@ msgstr "Féach ar an <a href=\"%(support)s\">Leathanach Tacaíochta</a> chun cab
 msgid "Review Guidelines"
 msgstr "Treoirlínte do Léirmheasanna"
 
-#: src/olympia/addons/templates/addons/review_list_box.html:5 src/olympia/addons/templates/addons/impala/details-more.html:27 src/olympia/editors/helpers.py:921
+#: src/olympia/addons/templates/addons/review_list_box.html:5 src/olympia/addons/templates/addons/impala/details-more.html:27 src/olympia/editors/helpers.py:1001
 #: src/olympia/reviews/templates/reviews/add.html:14 src/olympia/reviews/templates/reviews/reply.html:14 src/olympia/reviews/templates/reviews/review_list.html:19
 #: src/olympia/reviews/templates/reviews/mobile/review_list.html:26
 msgid "Reviews"
@@ -938,9 +909,6 @@ msgid "See all reviews of this add-on"
 msgid_plural "See all %(cnt)s reviews of this add-on"
 msgstr[0] "Taispeáin gach léirmheas ar an mbreiseán seo"
 msgstr[1] "Taispeáin na %(cnt)s léirmheas ar an mbreiseán seo"
-msgstr[2] "Taispeáin na %(cnt)s léirmheas ar an mbreiseán seo"
-msgstr[3] "Taispeáin na %(cnt)s léirmheas ar an mbreiseán seo"
-msgstr[4] "Taispeáin na %(cnt)s léirmheas ar an mbreiseán seo"
 
 # #-#-#-#-#  chromemessengermessenger.properties.po (firefox)  #-#-#-#-#
 # for the Tag picker in search and mail views.
@@ -1012,131 +980,122 @@ msgid "Other add-ons by %(author)s"
 msgid_plural "Other add-ons by these authors"
 msgstr[0] "Breiseáin eile le %(author)s"
 msgstr[1] "Breiseáin eile leis na húdair seo"
-msgstr[2] "Breiseáin eile leis na húdair seo"
-msgstr[3] "Breiseáin eile leis na húdair seo"
-msgstr[4] "Breiseáin eile leis na húdair seo"
 
-#: src/olympia/addons/templates/addons/impala/details.html:41
+#: src/olympia/addons/templates/addons/impala/details.html:39
 #, python-format
 msgid "<span itemprop=\"ratingCount\">%(num)s</span> user review"
 msgid_plural "<span itemprop=\"ratingCount\">%(num)s</span> user reviews"
 msgstr[0] "<span itemprop=\"ratingCount\">%(num)s</span> léirmheas ó úsáideoirí"
 msgstr[1] "<span itemprop=\"ratingCount\">%(num)s</span> léirmheas ó úsáideoirí"
-msgstr[2] "<span itemprop=\"ratingCount\">%(num)s</span> léirmheas ó úsáideoirí"
-msgstr[3] "<span itemprop=\"ratingCount\">%(num)s</span> léirmheas ó úsáideoirí"
-msgstr[4] "<span itemprop=\"ratingCount\">%(num)s</span> léirmheas ó úsáideoirí"
 
-#: src/olympia/addons/templates/addons/impala/details.html:69
+#: src/olympia/addons/templates/addons/impala/details.html:66
 msgid "View statistics"
 msgstr "Amharc ar staitisticí"
 
-#: src/olympia/addons/templates/addons/impala/details.html:84
+#: src/olympia/addons/templates/addons/impala/details.html:81
 msgid "Manage"
 msgstr "Bainistigh"
 
 #. {0} is an add-on name.
-#: src/olympia/addons/templates/addons/impala/details.html:96
+#: src/olympia/addons/templates/addons/impala/details.html:93
 msgid "Icon of {0}"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/impala/details.html:103 src/olympia/addons/templates/addons/impala/listing/items.html:14
+#: src/olympia/addons/templates/addons/impala/details.html:100 src/olympia/addons/templates/addons/impala/listing/items.html:14
 msgid "No Restart"
 msgstr "Gan Atosú"
 
-#: src/olympia/addons/templates/addons/impala/details.html:127
+#: src/olympia/addons/templates/addons/impala/details.html:124
 #, fuzzy, python-format
 msgid "Meet the Developer: <a href=\"%(url)s\">%(name)s</a>"
 msgid_plural "<a href=\"%(url)s\">Meet the Developers</a>"
 msgstr[0] "Téigh in aithne ar an bhforbróir: <a href=\"%(url)s\">%(name)s</a>"
 msgstr[1] "<a href=\"%(url)s\">Téigh in aithne ar na forbróirí</a>"
-msgstr[2] "<a href=\"%(url)s\">Téigh in aithne ar na forbróirí</a>"
-msgstr[3] "<a href=\"%(url)s\">Téigh in aithne ar na forbróirí</a>"
-msgstr[4] "<a href=\"%(url)s\">Téigh in aithne ar na forbróirí</a>"
 
 # {0} is an add-on name.
-#: src/olympia/addons/templates/addons/impala/details.html:137
+#: src/olympia/addons/templates/addons/impala/details.html:134
 msgid "Learn why {0} was created and find out what's next for this add-on."
 msgstr "Cén fáth a raibh {0} cruthaithe, agus céard atá i ndán don bhreiseán seo."
 
 #. {0} is an index.
-#: src/olympia/addons/templates/addons/impala/details.html:156
+#: src/olympia/addons/templates/addons/impala/details.html:161
 msgid "Add-on screenshot #{0}"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/impala/details.html:182
+#: src/olympia/addons/templates/addons/impala/details.html:187
 msgid "Add-on home page"
 msgstr "Leathanach baile an bhreiseáin"
 
-#: src/olympia/addons/templates/addons/impala/details.html:185
+#: src/olympia/addons/templates/addons/impala/details.html:190
 msgid "Support site"
 msgstr "Suíomh tacaíochta"
 
-#: src/olympia/addons/templates/addons/impala/details.html:189
+#: src/olympia/addons/templates/addons/impala/details.html:194
 msgid "Support E-mail"
 msgstr "Ríomhphost tacaíochta"
 
-#: src/olympia/addons/templates/addons/impala/details.html:194 src/olympia/devhub/models.py:378 src/olympia/devhub/templates/devhub/versions/list.html:12
+#: src/olympia/addons/templates/addons/impala/details.html:199 src/olympia/devhub/models.py:378 src/olympia/devhub/templates/devhub/versions/list.html:12
 #: src/olympia/versions/templates/versions/version.html:6 src/olympia/versions/templates/versions/mobile/version.html:6
 msgid "Version {0}"
 msgstr "Leagan {0}"
 
-#: src/olympia/addons/templates/addons/impala/details.html:194
+#: src/olympia/addons/templates/addons/impala/details.html:199
 msgid "Info"
 msgstr "Eolas"
 
-#: src/olympia/addons/templates/addons/impala/details.html:195 src/olympia/devhub/templates/devhub/includes/addon_details.html:129
+#: src/olympia/addons/templates/addons/impala/details.html:200 src/olympia/devhub/templates/devhub/includes/addon_details.html:116
 msgid "Last Updated:"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/impala/details.html:200
+#: src/olympia/addons/templates/addons/impala/details.html:205
 #, python-format
 msgid "Released under <a target=\"_blank\" href=\"%(url)s\">%(name)s</a>"
 msgstr "Ceadúnas: <a target=\"_blank\" href=\"%(url)s\">%(name)s</a>"
 
-#: src/olympia/addons/templates/addons/impala/details.html:201 src/olympia/addons/templates/addons/impala/details.html:206 src/olympia/amo/helpers.py:398 src/olympia/devhub/forms.py:142
+#: src/olympia/addons/templates/addons/impala/details.html:206 src/olympia/addons/templates/addons/impala/details.html:211 src/olympia/amo/helpers.py:398 src/olympia/devhub/forms.py:142
 #: src/olympia/devhub/forms.py:173 src/olympia/versions/templates/versions/version.html:40 src/olympia/versions/templates/versions/version.html:45
 msgid "Custom License"
 msgstr "Ceadúnas Saincheaptha"
 
-#: src/olympia/addons/templates/addons/impala/details.html:205
+#: src/olympia/addons/templates/addons/impala/details.html:210
 #, python-format
 msgid "Released under <a href=\"%(url)s\">%(name)s</a>"
 msgstr "Ceadúnas: <a href=\"%(url)s\">%(name)s</a>"
 
-#: src/olympia/addons/templates/addons/impala/details.html:217
+#: src/olympia/addons/templates/addons/impala/details.html:222
 msgid "About this Add-on"
 msgstr "Maidir leis an mbreiseán seo"
 
-#: src/olympia/addons/templates/addons/impala/details.html:233
+#: src/olympia/addons/templates/addons/impala/details.html:238
 msgid "Developer’s Comments"
 msgstr "Nótaí ón Fhorbróir"
 
-#: src/olympia/addons/templates/addons/impala/details.html:243
+#: src/olympia/addons/templates/addons/impala/details.html:248
 msgid "Version Information"
 msgstr "Eolas faoin Leagan"
 
-#: src/olympia/addons/templates/addons/impala/details.html:250
+#: src/olympia/addons/templates/addons/impala/details.html:255
 msgid "See complete version history"
 msgstr "Stair iomlán na leaganacha"
 
-#: src/olympia/addons/templates/addons/impala/details.html:262
+#: src/olympia/addons/templates/addons/impala/details.html:267
 msgid ""
 "The Development Channel lets you test an experimental new version of this add-on before it's released to the general public. Once you install the development version, you will continue to get "
 "updates from this channel. To stop receiving development updates, reinstall the default version from the link above."
 msgstr ""
 
-#: src/olympia/addons/templates/addons/impala/details.html:272
+#: src/olympia/addons/templates/addons/impala/details.html:277
 msgid "<strong>Caution:</strong> Development versions of this add-on have not been reviewed by Mozilla."
 msgstr ""
 
-#: src/olympia/addons/templates/addons/impala/details.html:287
+#: src/olympia/addons/templates/addons/impala/details.html:292
 msgid "See complete development channel history"
 msgstr ""
 
 # This refers to closing a small pop-up window
-#: src/olympia/addons/templates/addons/impala/details.html:306 src/olympia/addons/templates/addons/impala/details.html:315 src/olympia/addons/templates/addons/impala/details.html:327
+#: src/olympia/addons/templates/addons/impala/details.html:311 src/olympia/addons/templates/addons/impala/details.html:320 src/olympia/addons/templates/addons/impala/details.html:332
 #: src/olympia/addons/templates/addons/impala/review_add_box.html:4 src/olympia/stats/templates/stats/popup.html:2 src/olympia/stats/templates/stats/popup.html:8
-#: src/olympia/stats/templates/stats/stats.html:202 src/olympia/users/templates/users/profile.html:119
+#: src/olympia/stats/templates/stats/stats.html:204 src/olympia/users/templates/users/profile.html:119
 msgid "close"
 msgstr "dún"
 
@@ -1170,9 +1129,6 @@ msgid "About the Developer"
 msgid_plural "About the Developers"
 msgstr[0] "Maidir leis an bhforbróir"
 msgstr[1] "Maidir leis na forbróirí"
-msgstr[2] "Maidir leis na forbróirí"
-msgstr[3] "Maidir leis na forbróirí"
-msgstr[4] "Maidir leis na forbróirí"
 
 #: src/olympia/addons/templates/addons/impala/developers.html:96 src/olympia/users/templates/users/edit.html:130 src/olympia/users/templates/users/profile.html:26
 msgid "No Photo"
@@ -1198,15 +1154,11 @@ msgstr "Ceadúnas an chóid fhoinsigh le haghaidh {addon}"
 msgid "Source Code License"
 msgstr "Ceadúnas an Chóid Fhoinsigh"
 
-#: src/olympia/addons/templates/addons/impala/persona_grid.html:16 src/olympia/addons/templates/addons/impala/toplist.html:6
-msgid "{0} users"
-msgstr "{0} úsáideoir"
-
 #: src/olympia/addons/templates/addons/impala/review_list_box.html:19 src/olympia/reviews/templates/reviews/review.html:40
 msgid "permalink"
 msgstr "buan-nasc"
 
-#: src/olympia/addons/templates/addons/impala/review_list_box.html:23 src/olympia/editors/templates/editors/queue.html:98 src/olympia/reviews/templates/reviews/review.html:44
+#: src/olympia/addons/templates/addons/impala/review_list_box.html:23 src/olympia/editors/templates/editors/queue.html:104 src/olympia/reviews/templates/reviews/review.html:44
 msgid "translate"
 msgstr ""
 
@@ -1216,9 +1168,6 @@ msgid "See all user reviews"
 msgid_plural "See all %(cnt)s user reviews"
 msgstr[0] "Féach ar gach léirmheas"
 msgstr[1] "Féach ar an %(cnt)s léirmheas"
-msgstr[2] "Féach ar na %(cnt)s léirmheas"
-msgstr[3] "Féach ar na %(cnt)s léirmheas"
-msgstr[4] "Féach ar na %(cnt)s léirmheas"
 
 #: src/olympia/addons/templates/addons/impala/review_list_box.html:47 src/olympia/reviews/templates/reviews/review_list.html:84
 msgid "This add-on has not yet been reviewed."
@@ -1227,6 +1176,10 @@ msgstr "Níl aon léirmheas déanta ar an mbreiseán seo."
 #: src/olympia/addons/templates/addons/impala/review_list_box.html:50
 msgid "Be the first!"
 msgstr "Déan an chéad cheann!"
+
+#: src/olympia/addons/templates/addons/impala/toplist.html:6
+msgid "{0} users"
+msgstr "{0} úsáideoir"
 
 #: src/olympia/addons/templates/addons/impala/listing/sorter.html:14 src/olympia/devhub/templates/devhub/addons/listing/item_actions.html:49
 msgid "More"
@@ -1240,7 +1193,7 @@ msgstr "Cuir le bailiúchán"
 msgid "My Add-ons"
 msgstr "Mo Chuid Breiseán"
 
-#: src/olympia/addons/templates/addons/includes/dashboard_tabs.html:6 src/olympia/amo/context_processors.py:51
+#: src/olympia/addons/templates/addons/includes/dashboard_tabs.html:6 src/olympia/amo/context_processors.py:50
 msgid "My Themes"
 msgstr "Mo Chuid Téamaí"
 
@@ -1282,9 +1235,6 @@ msgid "<strong>{0}</strong> weekly download"
 msgid_plural "<strong>{0}</strong> weekly downloads"
 msgstr[0] "<strong>{0}</strong> íosluchtú sa tseachtain"
 msgstr[1] "<strong>{0}</strong> íosluchtú sa tseachtain"
-msgstr[2] "<strong>{0}</strong> íosluchtú sa tseachtain"
-msgstr[3] "<strong>{0}</strong> n-íosluchtú sa tseachtain"
-msgstr[4] "<strong>{0}</strong> íosluchtú sa tseachtain"
 
 #: src/olympia/addons/templates/addons/mobile/details.html:32
 msgid "Read More"
@@ -1298,7 +1248,7 @@ msgstr "Úsáideoirí"
 msgid "Weekly Downloads"
 msgstr "Íosluchtuithe sa tSeachtain"
 
-#: src/olympia/addons/templates/addons/mobile/details.html:99 src/olympia/compat/templates/compat/reporter_detail.html:46 src/olympia/devhub/forms.py:787
+#: src/olympia/addons/templates/addons/mobile/details.html:99 src/olympia/compat/templates/compat/reporter_detail.html:46 src/olympia/devhub/forms.py:788
 #: src/olympia/devhub/templates/devhub/versions/list.html:163
 msgid "Version"
 msgstr "Leagan"
@@ -1383,7 +1333,7 @@ msgstr ""
 #: src/olympia/browse/templates/browse/personas/category_landing.html:21 src/olympia/browse/templates/browse/personas/category_landing.html:23
 #: src/olympia/browse/templates/browse/personas/category_landing.html:38 src/olympia/browse/templates/browse/personas/grid.html:7 src/olympia/browse/templates/browse/personas/grid.html:11
 #: src/olympia/browse/templates/browse/personas/mobile/base.html:7 src/olympia/browse/templates/browse/personas/mobile/category_landing.html:19 src/olympia/constants/base.py:180
-#: src/olympia/devhub/templates/devhub/personas/submit.html:13 src/olympia/editors/helpers.py:105 src/olympia/editors/templates/editors/base.html:26
+#: src/olympia/devhub/templates/devhub/personas/submit.html:13 src/olympia/editors/helpers.py:107 src/olympia/editors/templates/editors/base.html:26
 #: src/olympia/editors/templates/editors/performance.html:73 src/olympia/search/templates/search/personas.html:39 src/olympia/templates/menu_links.html:9
 msgid "Themes"
 msgstr "Téamaí"
@@ -1405,7 +1355,7 @@ msgid "Highest Rated"
 msgstr "Rátáil Is Airde"
 
 # "sort by"
-#: src/olympia/addons/templates/addons/mobile/home.html:74 src/olympia/amo/templates/amo/side_nav.html:5 src/olympia/amo/templates/amo/site_nav.html:27 src/olympia/amo/templates/amo/site_nav.html:57
+#: src/olympia/addons/templates/addons/mobile/home.html:74 src/olympia/amo/templates/amo/side_nav.html:5 src/olympia/amo/templates/amo/site_nav.html:27 src/olympia/amo/templates/amo/site_nav.html:55
 #: src/olympia/bandwagon/views.py:97 src/olympia/browse/views.py:57 src/olympia/browse/views.py:67 src/olympia/browse/templates/browse/personas/mobile/category_landing.html:65
 #: src/olympia/search/forms.py:15 src/olympia/search/forms.py:87
 msgid "Newest"
@@ -1419,90 +1369,90 @@ msgstr "Bain triail as!"
 msgid "Theme Info &raquo;"
 msgstr ""
 
-#: src/olympia/amo/context_processors.py:39 src/olympia/devhub/templates/devhub/nav.html:43
+#: src/olympia/amo/context_processors.py:37 src/olympia/devhub/templates/devhub/nav.html:43
 msgid "Tools"
 msgstr "Uirlisí"
 
-#: src/olympia/amo/context_processors.py:48 src/olympia/discovery/templates/discovery/pane_account.html:8 src/olympia/users/templates/users/includes/navigation.html:2
+#: src/olympia/amo/context_processors.py:47 src/olympia/discovery/templates/discovery/pane_account.html:8 src/olympia/users/templates/users/includes/navigation.html:2
 msgid "My Profile"
 msgstr "Mo Phróifíl"
 
-#: src/olympia/amo/context_processors.py:54 src/olympia/users/templates/users/edit.html:5 src/olympia/users/templates/users/includes/navigation.html:3
+#: src/olympia/amo/context_processors.py:53 src/olympia/users/templates/users/edit.html:5 src/olympia/users/templates/users/includes/navigation.html:3
 msgid "Account Settings"
 msgstr "Socruithe Cuntais"
 
-#: src/olympia/amo/context_processors.py:57 src/olympia/discovery/templates/discovery/pane_account.html:11 src/olympia/users/templates/users/profile.html:83
+#: src/olympia/amo/context_processors.py:56 src/olympia/discovery/templates/discovery/pane_account.html:11 src/olympia/users/templates/users/profile.html:83
 #: src/olympia/users/templates/users/includes/navigation.html:4
 msgid "My Collections"
 msgstr "Mo Chuid Bailiúchán"
 
-#: src/olympia/amo/context_processors.py:62 src/olympia/discovery/templates/discovery/pane_account.html:10 src/olympia/users/templates/users/includes/navigation.html:7
+#: src/olympia/amo/context_processors.py:61 src/olympia/discovery/templates/discovery/pane_account.html:10 src/olympia/users/templates/users/includes/navigation.html:7
 msgid "My Favorites"
 msgstr "Na Breiseáin Is Ansa Liom"
 
-#: src/olympia/amo/context_processors.py:67 src/olympia/discovery/templates/discovery/pane_account.html:13 src/olympia/templates/impala/user_login.html:14
+#: src/olympia/amo/context_processors.py:66 src/olympia/discovery/templates/discovery/pane_account.html:13 src/olympia/templates/impala/user_login.html:14
 #: src/olympia/templates/mobile/header_auth.html:5
 msgid "Log out"
 msgstr "Logáil amach"
 
-#: src/olympia/amo/context_processors.py:72 src/olympia/devhub/templates/devhub/addons/dashboard.html:4
+#: src/olympia/amo/context_processors.py:71 src/olympia/devhub/templates/devhub/addons/dashboard.html:4
 msgid "Manage My Submissions"
 msgstr "Mo Chuid Breiseán is Téamaí"
 
-#: src/olympia/amo/context_processors.py:75 src/olympia/devhub/templates/devhub/nav.html:27 src/olympia/devhub/templates/devhub/addons/dashboard.html:25
+#: src/olympia/amo/context_processors.py:74 src/olympia/devhub/templates/devhub/nav.html:27 src/olympia/devhub/templates/devhub/addons/dashboard.html:25
 #: src/olympia/devhub/templates/devhub/addons/submit/base.html:4
 msgid "Submit a New Add-on"
 msgstr "Seol Breiseán Nua"
 
-#: src/olympia/amo/context_processors.py:77 src/olympia/browse/templates/browse/personas/base.html:50 src/olympia/devhub/templates/devhub/index.html:24
+#: src/olympia/amo/context_processors.py:76 src/olympia/browse/templates/browse/personas/base.html:50 src/olympia/devhub/templates/devhub/index.html:24
 #: src/olympia/devhub/templates/devhub/addons/dashboard.html:29
 msgid "Submit a New Theme"
 msgstr "Seol Téama Nua Chugainn"
 
-#: src/olympia/amo/context_processors.py:79 src/olympia/amo/templates/amo/site_nav.html:87 src/olympia/devhub/helpers.py:36 src/olympia/devhub/helpers.py:68 src/olympia/devhub/helpers.py:102
+#: src/olympia/amo/context_processors.py:78 src/olympia/amo/templates/amo/site_nav.html:85 src/olympia/devhub/helpers.py:36 src/olympia/devhub/helpers.py:68 src/olympia/devhub/helpers.py:102
 #: src/olympia/templates/footer.html:6 src/olympia/templates/menu_links.html:14
 msgid "Developer Hub"
 msgstr "Lárionad Forbartha"
 
-#: src/olympia/amo/context_processors.py:83 src/olympia/devhub/views.py:1792
+#: src/olympia/amo/context_processors.py:81 src/olympia/devhub/views.py:1796
 msgid "Manage API Keys"
 msgstr ""
 
-#: src/olympia/amo/context_processors.py:88 src/olympia/editors/helpers.py:82 src/olympia/editors/helpers.py:102 src/olympia/editors/templates/editors/base.html:10
+#: src/olympia/amo/context_processors.py:86 src/olympia/editors/helpers.py:84 src/olympia/editors/helpers.py:104 src/olympia/editors/templates/editors/base.html:10
 msgid "Editor Tools"
 msgstr "Uirlisí Eagarthóireachta"
 
-#: src/olympia/amo/context_processors.py:92
+#: src/olympia/amo/context_processors.py:90
 msgid "Admin Tools"
 msgstr "Uirlisí Riaracháin"
 
-#: src/olympia/amo/fields.py:15
+#: src/olympia/amo/fields.py:20
 msgid "Incorrect, please try again."
 msgstr ""
 
-#: src/olympia/amo/fields.py:16
+#: src/olympia/amo/fields.py:21
 msgid "Error verifying input, please try again."
 msgstr ""
 
-#: src/olympia/amo/fields.py:32
+#: src/olympia/amo/fields.py:37
 msgid "This must be a valid hex color code, such as #000000."
 msgstr ""
 
-#: src/olympia/amo/fields.py:58
+#: src/olympia/amo/fields.py:63
 msgid "Enter at least one value."
 msgstr "Cuir isteach luach amháin ar a laghad."
 
-#: src/olympia/amo/helpers.py:162 src/olympia/amo/templates/amo/site_nav.html:61 src/olympia/bandwagon/templates/bandwagon/add.html:9
+#: src/olympia/amo/helpers.py:162 src/olympia/amo/templates/amo/site_nav.html:59 src/olympia/bandwagon/templates/bandwagon/add.html:9
 #: src/olympia/bandwagon/templates/bandwagon/collection_detail.html:15 src/olympia/bandwagon/templates/bandwagon/delete.html:9 src/olympia/bandwagon/templates/bandwagon/edit.html:15
 #: src/olympia/bandwagon/templates/bandwagon/user_listing.html:18 src/olympia/bandwagon/templates/bandwagon/user_listing.html:21
 #: src/olympia/bandwagon/templates/bandwagon/impala/collection_listing.html:12 src/olympia/bandwagon/templates/bandwagon/impala/collection_listing.html:20
 #: src/olympia/bandwagon/templates/bandwagon/impala/collection_listing.html:24 src/olympia/bandwagon/templates/bandwagon/impala/collection_sidebar.html:3
 #: src/olympia/bandwagon/templates/bandwagon/includes/collection_sidebar.html:2 src/olympia/bandwagon/templates/bandwagon/mobile/collection_listing.html:3
-#: src/olympia/stats/templates/stats/stats.html:77 src/olympia/templates/menu_links.html:12
+#: src/olympia/stats/templates/stats/stats.html:33 src/olympia/templates/menu_links.html:12
 msgid "Collections"
 msgstr "Bailiúcháin"
 
-#: src/olympia/amo/helpers.py:171 src/olympia/amo/templates/amo/site_nav.html:85 src/olympia/browse/templates/browse/language_tools.html:3
+#: src/olympia/amo/helpers.py:171 src/olympia/amo/templates/amo/site_nav.html:83 src/olympia/browse/templates/browse/language_tools.html:3
 msgid "Dictionaries & Language Packs"
 msgstr "Foclóirí agus Pacáistí Teanga"
 
@@ -1654,8 +1604,8 @@ msgstr ""
 msgid "Comment on {addon} {version}."
 msgstr "Nóta tráchta ar {addon} {version}."
 
-#: src/olympia/amo/log.py:236 src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:19 src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:47
-#: src/olympia/editors/helpers.py:511 src/olympia/editors/templates/editors/themes/history_table.html:11
+#: src/olympia/amo/log.py:236 src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:17 src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:45
+#: src/olympia/editors/helpers.py:584 src/olympia/editors/templates/editors/themes/history_table.html:11
 msgid "Comment"
 msgstr "Nóta"
 
@@ -1978,7 +1928,7 @@ msgstr "Roimhe Seo"
 #: src/olympia/amo/templates/amo/mobile/paginator.html:14 src/olympia/amo/templates/amo/mobile/paginator.html:16 src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:51
 #: src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:65 src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:78
 #: src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:91 src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:104
-#: src/olympia/discovery/templates/discovery/pane.html:45 src/olympia/discovery/templates/discovery/addons/detail.html:39 src/olympia/stats/templates/stats/stats.html:167
+#: src/olympia/discovery/templates/discovery/pane.html:45 src/olympia/discovery/templates/discovery/addons/detail.html:39 src/olympia/stats/templates/stats/stats.html:169
 msgid "Next"
 msgstr "Ar Aghaidh"
 
@@ -2010,7 +1960,7 @@ msgid ""
 msgstr ""
 
 #: src/olympia/amo/templates/amo/side_nav.html:4 src/olympia/amo/templates/amo/side_nav.html:12 src/olympia/amo/templates/amo/site_nav.html:4 src/olympia/amo/templates/amo/site_nav.html:26
-#: src/olympia/browse/views.py:56 src/olympia/browse/views.py:66 src/olympia/browse/views.py:237 src/olympia/browse/views.py:282 src/olympia/search/forms.py:86
+#: src/olympia/browse/views.py:56 src/olympia/browse/views.py:66 src/olympia/browse/views.py:204 src/olympia/browse/views.py:249 src/olympia/search/forms.py:86
 msgid "Top Rated"
 msgstr "Rátálacha is airde"
 
@@ -2024,38 +1974,38 @@ msgstr "Taiscéal"
 msgid "Extensions"
 msgstr "Eisínteachtaí"
 
-#: src/olympia/amo/templates/amo/site_nav.html:45
+#: src/olympia/amo/templates/amo/site_nav.html:44
 msgid "Want more customization? Try <b>Complete Themes</b>"
 msgstr ""
 
-#: src/olympia/amo/templates/amo/site_nav.html:56 src/olympia/bandwagon/views.py:96
+#: src/olympia/amo/templates/amo/site_nav.html:54 src/olympia/bandwagon/views.py:96
 msgid "Most Followers"
 msgstr "Líon is mó leantóirí"
 
-#: src/olympia/amo/templates/amo/site_nav.html:68 src/olympia/bandwagon/templates/bandwagon/impala/collection_sidebar.html:16
+#: src/olympia/amo/templates/amo/site_nav.html:66 src/olympia/bandwagon/templates/bandwagon/impala/collection_sidebar.html:16
 #: src/olympia/bandwagon/templates/bandwagon/includes/collection_sidebar.html:18
 msgid "Collections I've Made"
 msgstr "Bailiúcháin a Chruthaigh Mé"
 
-#: src/olympia/amo/templates/amo/site_nav.html:70 src/olympia/bandwagon/templates/bandwagon/user_listing.html:4 src/olympia/bandwagon/templates/bandwagon/impala/collection_sidebar.html:13
+#: src/olympia/amo/templates/amo/site_nav.html:68 src/olympia/bandwagon/templates/bandwagon/user_listing.html:4 src/olympia/bandwagon/templates/bandwagon/impala/collection_sidebar.html:13
 #: src/olympia/bandwagon/templates/bandwagon/includes/collection_sidebar.html:15
 msgid "Collections I'm Following"
 msgstr "Bailiúcháin a Leanaim"
 
-#: src/olympia/amo/templates/amo/site_nav.html:73 src/olympia/bandwagon/templates/bandwagon/impala/collection_sidebar.html:18
-#: src/olympia/bandwagon/templates/bandwagon/includes/collection_sidebar.html:20 src/olympia/users/models.py:512
+#: src/olympia/amo/templates/amo/site_nav.html:71 src/olympia/bandwagon/templates/bandwagon/impala/collection_sidebar.html:18
+#: src/olympia/bandwagon/templates/bandwagon/includes/collection_sidebar.html:20 src/olympia/users/models.py:521
 msgid "My Favorite Add-ons"
 msgstr "Na Breiseáin Is Ansa Liom"
 
-#: src/olympia/amo/templates/amo/site_nav.html:78
+#: src/olympia/amo/templates/amo/site_nav.html:76
 msgid "More&hellip;"
 msgstr "Tuilleadh&hellip;"
 
-#: src/olympia/amo/templates/amo/site_nav.html:82
+#: src/olympia/amo/templates/amo/site_nav.html:80
 msgid "Add-ons for Mobile"
 msgstr "Breiseáin Shoghluaiste"
 
-#: src/olympia/amo/templates/amo/site_nav.html:86 src/olympia/browse/feeds.py:207 src/olympia/browse/templates/browse/search_tools.html:3 src/olympia/constants/base.py:176
+#: src/olympia/amo/templates/amo/site_nav.html:84 src/olympia/browse/feeds.py:207 src/olympia/browse/templates/browse/search_tools.html:3 src/olympia/constants/base.py:176
 #: src/olympia/templates/menu_links.html:10
 msgid "Search Tools"
 msgstr "Uirlisí Cuardaigh"
@@ -2071,7 +2021,7 @@ msgid "Jump to first page"
 msgstr "An chéad leathanach"
 
 #: src/olympia/amo/templates/amo/impala/paginator.html:22 src/olympia/amo/templates/amo/mobile/impala_paginator.html:12 src/olympia/discovery/templates/discovery/pane.html:44
-#: src/olympia/discovery/templates/discovery/addons/detail.html:38 src/olympia/stats/templates/stats/stats.html:164
+#: src/olympia/discovery/templates/discovery/addons/detail.html:38 src/olympia/stats/templates/stats/stats.html:166
 msgid "Previous"
 msgstr "Siar"
 
@@ -2093,35 +2043,51 @@ msgid "Page {n}"
 msgid_plural "Page {n}"
 msgstr[0] "Leathanach {n}"
 msgstr[1] "Leathanach {n}"
-msgstr[2] "Leathanach {n}"
-msgstr[3] "Leathanach {n}"
-msgstr[4] "Leathanach {n}"
 
-#: src/olympia/amo/templates/services/install.html:38
-#, python-format
-msgid "If you are not prompted to install %(addon_name)s in a moment, please <a href=\"%(addon_xpi)s\">click here</a>."
-msgstr ""
-
-#: src/olympia/amo/tests/test_messages.py:57 src/olympia/amo/tests/test_messages.py:58 src/olympia/reviews/forms.py:25 src/olympia/reviews/forms.py:50 src/olympia/reviews/templates/reviews/add.html:56
+#: src/olympia/amo/tests/test_messages.py:56 src/olympia/amo/tests/test_messages.py:57 src/olympia/reviews/forms.py:25 src/olympia/reviews/forms.py:50 src/olympia/reviews/templates/reviews/add.html:56
 #: src/olympia/reviews/templates/reviews/reply.html:30
 msgid "Title"
 msgstr "Teideal"
 
-#: src/olympia/amo/tests/test_messages.py:57 src/olympia/amo/tests/test_messages.py:58
+#: src/olympia/amo/tests/test_messages.py:56 src/olympia/amo/tests/test_messages.py:57
 msgid "Body"
 msgstr "Corp"
 
-#: src/olympia/amo/tests/test_messages.py:59
+#: src/olympia/amo/tests/test_messages.py:58
 msgid "Another Title"
 msgstr "Teideal Eile"
 
-#: src/olympia/amo/tests/test_messages.py:59
+#: src/olympia/amo/tests/test_messages.py:58
 msgid "Another Body"
 msgstr "Corp Eile"
 
-#: src/olympia/api/views.py:255
-msgid "Not implemented yet."
-msgstr "Níl sé seo ar fáil fós."
+#: src/olympia/api/authentication.py:76
+msgid "Signature has expired."
+msgstr ""
+
+#: src/olympia/api/authentication.py:79
+msgid "Error decoding signature."
+msgstr ""
+
+#: src/olympia/api/authentication.py:82
+msgid "Invalid JWT Token."
+msgstr ""
+
+#: src/olympia/api/authentication.py:130
+msgid "Invalid Authorization header. No credentials provided."
+msgstr ""
+
+#: src/olympia/api/authentication.py:133
+msgid "Invalid Authorization header. Credentials string should not contain spaces."
+msgstr ""
+
+#: src/olympia/api/fields.py:29
+msgid "The field must have a length of at least {num} characters."
+msgstr ""
+
+#: src/olympia/api/fields.py:31
+msgid "The language code {lang_code} is invalid."
+msgstr ""
 
 #: src/olympia/applications/views.py:39 src/olympia/applications/templates/applications/appversions.html:3
 msgid "Application Versions"
@@ -2139,7 +2105,7 @@ msgstr "Leaganacha Bailí an Fheidhmchláir"
 msgid "Add-ons submitted to Mozilla Add-ons must have a manifest file with at least one of the below applications supported. Only the versions listed below are allowed for these applications."
 msgstr ""
 
-#: src/olympia/applications/templates/applications/appversions.html:25
+#: src/olympia/applications/templates/applications/appversions.html:25 src/olympia/editors/helpers.py:361
 msgid "GUID"
 msgstr "GUID"
 
@@ -2253,8 +2219,8 @@ msgstr "Ceanán"
 msgid "Remove from favorites"
 msgstr "Bain ó na ceanáin"
 
-#: src/olympia/bandwagon/views.py:98 src/olympia/bandwagon/views.py:191 src/olympia/browse/views.py:58 src/olympia/browse/views.py:69 src/olympia/browse/views.py:458 src/olympia/devhub/views.py:74
-#: src/olympia/devhub/views.py:82 src/olympia/devhub/templates/devhub/addons/edit/basic.html:20 src/olympia/editors/templates/editors/leaderboard.html:24
+#: src/olympia/bandwagon/views.py:98 src/olympia/bandwagon/views.py:191 src/olympia/browse/views.py:58 src/olympia/browse/views.py:69 src/olympia/browse/views.py:425 src/olympia/devhub/views.py:72
+#: src/olympia/devhub/views.py:80 src/olympia/devhub/templates/devhub/addons/edit/basic.html:20 src/olympia/editors/templates/editors/leaderboard.html:24
 #: src/olympia/editors/templates/editors/themes/queue_list.html:48 src/olympia/search/forms.py:17 src/olympia/search/forms.py:89 src/olympia/users/templates/users/vcard.html:5
 msgid "Name"
 msgstr "Ainm"
@@ -2263,7 +2229,7 @@ msgstr "Ainm"
 msgid "Recently Popular"
 msgstr "Éileamh Is Mó Le Déanaí"
 
-#: src/olympia/bandwagon/views.py:189 src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:18
+#: src/olympia/bandwagon/views.py:189 src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:16
 msgid "Added"
 msgstr "Cruthaithe"
 
@@ -2277,7 +2243,7 @@ msgstr "Bailiúchán cruthaithe!"
 
 #: src/olympia/bandwagon/views.py:316
 #, python-format
-msgid "Your new collection is shown below. You can <ahref=\"%(url)s\">edit additional settings</a> if you'dlike."
+msgid "Your new collection is shown below. You can <a href=\"%(url)s\">edit additional settings</a> if you'd like."
 msgstr ""
 
 #: src/olympia/bandwagon/views.py:322
@@ -2358,9 +2324,6 @@ msgid "<span>%(num)s</span> follower"
 msgid_plural "<span>%(num)s</span> followers"
 msgstr[0] "<span>%(num)s</span> leantóir"
 msgstr[1] "<span>%(num)s</span> leantóir"
-msgstr[2] "<span>%(num)s</span> leantóir"
-msgstr[3] "<span>%(num)s</span> leantóir"
-msgstr[4] "<span>%(num)s</span> leantóir"
 
 #: src/olympia/bandwagon/templates/bandwagon/collection_detail.html:54
 msgid "About this Collection"
@@ -2400,9 +2363,6 @@ msgid "%(num)s Theme in this Collection"
 msgid_plural "%(num)s Themes in this Collection"
 msgstr[0] "%(num)s Téama sa Bhailiúchán seo"
 msgstr[1] "%(num)s Théama sa Bhailiúchán seo"
-msgstr[2] "%(num)s Théama sa Bhailiúchán seo"
-msgstr[3] "%(num)s dTéama sa Bhailiúchán seo"
-msgstr[4] "%(num)s Téama sa Bhailiúchán seo"
 
 #: src/olympia/bandwagon/templates/bandwagon/collection_detail.html:111
 #, python-format
@@ -2410,12 +2370,9 @@ msgid "%(num)s Add-on in this Collection"
 msgid_plural "%(num)s Add-ons in this Collection"
 msgstr[0] "%(num)s Bhreiseán sa Bhailiúchán seo"
 msgstr[1] "%(num)s Bhreiseán sa Bhailiúchán seo"
-msgstr[2] "%(num)s Bhreiseán sa Bhailiúchán seo"
-msgstr[3] "%(num)s mBreiseán sa Bhailiúchán seo"
-msgstr[4] "%(num)s Breiseán sa Bhailiúchán seo"
 
-#: src/olympia/bandwagon/templates/bandwagon/collection_detail.html:125 src/olympia/compat/templates/compat/index.html:25 src/olympia/compat/templates/compat/reporter_detail.html:29
-#: src/olympia/files/templates/files/viewer.html:29 src/olympia/templates/amo_footer.html:17 src/olympia/templates/includes/lang_switcher.html:10
+#: src/olympia/bandwagon/templates/bandwagon/collection_detail.html:125 src/olympia/compat/templates/compat/reporter_detail.html:29 src/olympia/files/templates/files/viewer.html:29
+#: src/olympia/templates/amo_footer.html:17 src/olympia/templates/includes/lang_switcher.html:10
 msgid "Go"
 msgstr "Ar Aghaidh"
 
@@ -2461,9 +2418,6 @@ msgid "<span>%(addons)s</span> add-on"
 msgid_plural "<span>%(addons)s</span> add-ons"
 msgstr[0] "<span>%(addons)s</span> bhreiseán"
 msgstr[1] "<span>%(addons)s</span> bhreiseán"
-msgstr[2] "<span>%(addons)s</span> bhreiseán"
-msgstr[3] "<span>%(addons)s</span> mbreiseán"
-msgstr[4] "<span>%(addons)s</span> breiseán"
 
 #: src/olympia/bandwagon/templates/bandwagon/collection_grid.html:32
 #, python-format
@@ -2471,9 +2425,6 @@ msgid "<span>%(followers)s</span> follower"
 msgid_plural "<span>%(followers)s</span> followers"
 msgstr[0] "<span>%(followers)s</span> leantóir"
 msgstr[1] "<span>%(followers)s</span> leantóir"
-msgstr[2] "<span>%(followers)s</span> leantóir"
-msgstr[3] "<span>%(followers)s</span> leantóir"
-msgstr[4] "<span>%(followers)s</span> leantóir"
 
 #. People "follow" collections to get notified of updates.                    Like
 #. Twitter followers.
@@ -2485,9 +2436,6 @@ msgid "%(num)s weekly follower"
 msgid_plural "%(num)s weekly followers"
 msgstr[0] "%(num)s leantóir seachtainiúil"
 msgstr[1] "%(num)s leantóir seachtainiúil"
-msgstr[2] "%(num)s leantóir seachtainiúil"
-msgstr[3] "%(num)s leantóir seachtainiúil"
-msgstr[4] "%(num)s leantóir seachtainiúil"
 
 #. People "follow" collections to get notified of updates.                    Like
 #. Twitter followers.
@@ -2497,9 +2445,6 @@ msgid "%(num)s monthly follower"
 msgid_plural "%(num)s monthly followers"
 msgstr[0] "%(num)s leantóir míosúil"
 msgstr[1] "%(num)s leantóir míosúil"
-msgstr[2] "%(num)s leantóir míosúil"
-msgstr[3] "%(num)s leantóir míosúil"
-msgstr[4] "%(num)s leantóir míosúil"
 
 #. People "follow" collections to get notified of updates.                    Like
 #. Twitter followers.
@@ -2511,9 +2456,6 @@ msgid "%(num)s follower"
 msgid_plural "%(num)s followers"
 msgstr[0] "%(num)s leantóir"
 msgstr[1] "%(num)s leantóir"
-msgstr[2] "%(num)s leantóir"
-msgstr[3] "%(num)s leantóir"
-msgstr[4] "%(num)s leantóir"
 
 #: src/olympia/bandwagon/templates/bandwagon/collection_listing_items.html:56 src/olympia/bandwagon/templates/bandwagon/impala/collection_listing_items.html:9
 #: src/olympia/devhub/templates/devhub/personas/edit.html:27
@@ -2597,7 +2539,7 @@ msgid "Remove this user as a contributor"
 msgstr "Bain an t-úsáideoir seo ó na rannpháirtithe"
 
 #: src/olympia/bandwagon/templates/bandwagon/edit_contributors.html:18 src/olympia/bandwagon/templates/bandwagon/edit_contributors.html:43
-#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:20 src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:48
+#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:18 src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:46
 #: src/olympia/devhub/templates/devhub/addons/ajax_compat_update.html:19
 msgid "Remove"
 msgstr "Bain"
@@ -2645,7 +2587,7 @@ msgid "<b>Warning:</b> By changing the owner of this collection, you will no lon
 msgstr "<b>Rabhadh:</b> Má athraíonn tú úinéir an bhailiúcháin seo, ní bheidh tú in ann é a chur in eagar amach anseo.  Beidh tú in ann breiseáin a chur leis nó a bhaint uaidh amháin."
 
 #: src/olympia/bandwagon/templates/bandwagon/edit_contributors.html:83 src/olympia/devhub/templates/devhub/addons/forms_shared/media.html:157
-#: src/olympia/devhub/templates/devhub/addons/submit/describe.html:69 src/olympia/devhub/templates/devhub/addons/submit/license.html:60 src/olympia/devhub/templates/devhub/addons/submit/upload.html:78
+#: src/olympia/devhub/templates/devhub/addons/submit/describe.html:69 src/olympia/devhub/templates/devhub/addons/submit/license.html:60 src/olympia/devhub/templates/devhub/addons/submit/upload.html:70
 #: src/olympia/devhub/templates/devhub/payments/tier.html:17 src/olympia/editors/templates/editors/themes/themes.html:111 src/olympia/editors/templates/editors/themes/themes.html:128
 #: src/olympia/editors/templates/editors/themes/themes.html:134 src/olympia/editors/templates/editors/themes/themes.html:141 src/olympia/users/templates/users/fxa_migration_prompt_content.html:10
 #: src/olympia/users/templates/users/login_form.html:42 src/olympia/users/templates/users/mobile/login.html:57
@@ -2716,43 +2658,43 @@ msgid "Reset"
 msgstr "Bánaigh"
 
 #: src/olympia/bandwagon/templates/bandwagon/includes/addedit.html:53
-msgid "PNG and JPG supported. Image will be resized to 32x32."
-msgstr "Tacaítear le PNG agus JPG. Athrófar méid na híomhá go 32×32."
+msgid "PNG and JPG supported.  Image will be resized to 32x32."
+msgstr ""
 
 #: src/olympia/bandwagon/templates/bandwagon/includes/addedit_errors.html:3
-msgid "There are errors in this form. Please correct them below."
-msgstr "Tá earráidí san fhoirm seo. Ceartaigh iad le do thoil."
+msgid "There are errors in this form.  Please correct them below."
+msgstr ""
 
 #: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:2
 msgid "Add-ons in Your Collection"
 msgstr "Breiséain i do Bhailiúchán"
 
 #: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:4
-msgid ""
-"To include an add-on in this collection, enter its name in the box below and hit enter.  You can also use the <strong>Add to Collection</strong> links throughout the site to include add-ons later."
+msgid "To include an add-on in this collection, enter its name in the box below and hit enter."
 msgstr ""
 
-#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:17 src/olympia/constants/base.py:400 src/olympia/devhub/templates/devhub/addons/activity.html:62
+#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:15 src/olympia/constants/base.py:400 src/olympia/devhub/templates/devhub/addons/activity.html:62
+#: src/olympia/editors/helpers.py:273 src/olympia/editors/helpers.py:360
 msgid "Add-on"
 msgstr "Breiseán"
 
-#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:26
+#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:24
 msgid "Enter the name of the add-on to include"
 msgstr "Cuir isteach ainm an bhreiseáin le cur leis"
 
-#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:28
+#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:26
 msgid "Add to Collection"
 msgstr "Cuir le Bailiúchán"
 
-#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:45 src/olympia/editors/helpers.py:936 src/olympia/editors/helpers.py:956
+#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:43 src/olympia/editors/helpers.py:1016 src/olympia/editors/helpers.py:1036
 msgid "Pending"
 msgstr "Ar feitheamh"
 
-#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:47
+#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:45
 msgid "Add a comment"
 msgstr "Cuir nóta tráchta leis"
 
-#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:48
+#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:46
 msgid "Remove this add-on from the collection"
 msgstr "Bain an breiseán seo ón bhailiúchán"
 
@@ -2859,12 +2801,12 @@ msgstr "Uirlisí cuardaigh"
 msgid "Most Users"
 msgstr "Líon is mó úsáideoirí"
 
-#: src/olympia/browse/views.py:61 src/olympia/browse/views.py:72 src/olympia/browse/views.py:279 src/olympia/browse/templates/browse/personas/mobile/category_landing.html:63
+#: src/olympia/browse/views.py:61 src/olympia/browse/views.py:72 src/olympia/browse/views.py:246 src/olympia/browse/templates/browse/personas/mobile/category_landing.html:63
 #: src/olympia/discovery/templates/discovery/pane.html:67 src/olympia/search/forms.py:92
 msgid "Up & Coming"
 msgstr "Teacht Chun Cinn"
 
-#: src/olympia/browse/views.py:460 src/olympia/devhub/views.py:76 src/olympia/devhub/views.py:83 src/olympia/discovery/templates/discovery/addons/detail.html:66
+#: src/olympia/browse/views.py:427 src/olympia/devhub/views.py:74 src/olympia/devhub/views.py:81 src/olympia/discovery/templates/discovery/addons/detail.html:66
 msgid "Created"
 msgstr "Cruthaithe"
 
@@ -2945,9 +2887,6 @@ msgid "<b>{0}</b> add-on"
 msgid_plural "<b>{0}</b> add-ons"
 msgstr[0] "<b>{0}</b> bhreiseán"
 msgstr[1] "<b>{0}</b> bhreiseán"
-msgstr[2] "<b>{0}</b> bhreiseán"
-msgstr[3] "<b>{0}</b> mbreiseán"
-msgstr[4] "<b>{0}</b> breiseán"
 
 #: src/olympia/browse/templates/browse/search_tools.html:61
 msgid "Search Extensions"
@@ -3054,12 +2993,9 @@ msgid "See the %(cnt)s extension in %(name)s &raquo;"
 msgid_plural "See all %(cnt)s extensions in %(name)s &raquo;"
 msgstr[0] "Féach ar an %(cnt)s eisínteacht i %(name)s &raquo;"
 msgstr[1] "Féach ar an %(cnt)s eisínteacht i %(name)s &raquo;"
-msgstr[2] "Féach ar na %(cnt)s eisínteacht i %(name)s &raquo;"
-msgstr[3] "Féach ar na %(cnt)s eisínteacht i %(name)s &raquo;"
-msgstr[4] "Féach ar na %(cnt)s eisínteacht i %(name)s &raquo;"
 
-#: src/olympia/browse/templates/browse/mobile/extensions.html:13 src/olympia/compat/templates/compat/index.html:82 src/olympia/devhub/templates/devhub/devhub_search.html:24
-#: src/olympia/devhub/templates/devhub/addons/activity.html:47 src/olympia/search/templates/search/no_results.html:4 src/olympia/search/templates/search/mobile/results.html:36
+#: src/olympia/browse/templates/browse/mobile/extensions.html:13 src/olympia/devhub/templates/devhub/devhub_search.html:24 src/olympia/devhub/templates/devhub/addons/activity.html:47
+#: src/olympia/search/templates/search/no_results.html:4 src/olympia/search/templates/search/mobile/results.html:36
 msgid "No results found."
 msgstr "Níor aimsíodh aon rud."
 
@@ -3144,7 +3080,7 @@ msgstr ""
 msgid "All"
 msgstr "Uile"
 
-#: src/olympia/compat/forms.py:22 src/olympia/search/views.py:525
+#: src/olympia/compat/forms.py:22 src/olympia/editors/templates/editors/base.html:69 src/olympia/search/views.py:518
 msgid "All Add-ons"
 msgstr "Gach Breiseán"
 
@@ -3155,53 +3091,6 @@ msgstr "Dénártha"
 #: src/olympia/compat/forms.py:24
 msgid "Non-binary"
 msgstr "Neamhdhénártha"
-
-#. Review points sources other than add-ons and themes.
-#: src/olympia/compat/views.py:87 src/olympia/constants/base.py:388 src/olympia/devhub/forms.py:162 src/olympia/editors/templates/editors/performance.html:75
-msgid "Other"
-msgstr "Eile"
-
-#: src/olympia/compat/templates/compat/index.html:4
-msgid "Add-on Compatibility Report for {app} {version}"
-msgstr ""
-
-#: src/olympia/compat/templates/compat/index.html:11
-msgid "{app} {version} Compatibility"
-msgstr "Comhoiriúnacht {app} {version}"
-
-#: src/olympia/compat/templates/compat/index.html:17
-#, python-format
-msgid "Top 95%% compatible with previous version"
-msgstr ""
-
-#: src/olympia/compat/templates/compat/index.html:18
-#, python-format
-msgid "Top 95%% of all add-ons"
-msgstr ""
-
-#: src/olympia/compat/templates/compat/index.html:19
-msgid "All active add-ons"
-msgstr "Gach breiseán gníomhach"
-
-#: src/olympia/compat/templates/compat/index.html:23 src/olympia/constants/base.py:401
-msgid "App"
-msgstr "Aip"
-
-#: src/olympia/compat/templates/compat/index.html:55
-msgid "Details for add-ons compatible with previous version:"
-msgstr ""
-
-#: src/olympia/compat/templates/compat/index.html:57
-msgid "Show all versions"
-msgstr "Taispeáin gach leagan"
-
-#: src/olympia/compat/templates/compat/index.html:59
-msgid "Details for add-ons compatible with all versions:"
-msgstr ""
-
-#: src/olympia/compat/templates/compat/index.html:61
-msgid "Show previous version only"
-msgstr "Taispeáin seanleaganacha amháin"
 
 #: src/olympia/compat/templates/compat/reporter.html:3
 msgid "Add-on Compatibility Reports"
@@ -3235,18 +3124,12 @@ msgid "{0} success report"
 msgid_plural "{0} success reports"
 msgstr[0] ""
 msgstr[1] ""
-msgstr[2] ""
-msgstr[3] ""
-msgstr[4] ""
 
 #: src/olympia/compat/templates/compat/reporter_detail.html:17
 msgid "{0} problem report"
 msgid_plural "{0} problem reports"
 msgstr[0] "{0} tuairisc ar fhadhb"
 msgstr[1] "{0} thuairisc ar fhadhbanna"
-msgstr[2] "{0} thuairisc ar fhadhbanna"
-msgstr[3] "{0} dtuairisc ar fhadhbanna"
-msgstr[4] "{0} tuairisc ar fhadhbanna"
 
 #: src/olympia/compat/templates/compat/reporter_detail.html:21 src/olympia/users/templates/users/profile.html:70
 msgid "View all"
@@ -3260,8 +3143,8 @@ msgstr "Scag de réir feidhmchláir"
 msgid "Report Type"
 msgstr "Cineál Tuairisce"
 
-#: src/olympia/compat/templates/compat/reporter_detail.html:47 src/olympia/devhub/forms.py:784 src/olympia/devhub/templates/devhub/addons/ajax_compat_update.html:17 src/olympia/editors/forms.py:108
-#: src/olympia/zadmin/forms.py:45
+#: src/olympia/compat/templates/compat/reporter_detail.html:47 src/olympia/devhub/forms.py:785 src/olympia/devhub/templates/devhub/addons/ajax_compat_update.html:17 src/olympia/editors/forms.py:108
+#: src/olympia/editors/forms.py:248 src/olympia/zadmin/forms.py:45
 msgid "Application"
 msgstr "Feidhmchlár"
 
@@ -3356,7 +3239,8 @@ msgstr "Réamhscrúdú Déanta"
 msgid "Preliminarily Reviewed and Awaiting Full Review"
 msgstr "Réamhscrúdú Déanta, ag fanacht le Scrúdú Iomlán anois"
 
-#: src/olympia/constants/base.py:33 src/olympia/editors/helpers.py:924 src/olympia/editors/templates/editors/themes/history_table.html:34
+#: src/olympia/constants/base.py:33 src/olympia/editors/forms.py:258 src/olympia/editors/helpers.py:73 src/olympia/editors/helpers.py:1004
+#: src/olympia/editors/templates/editors/themes/history_table.html:34
 msgid "Deleted"
 msgstr "Scriosta"
 
@@ -3455,6 +3339,11 @@ msgstr ""
 msgid "Ask before users can download this add-on"
 msgstr ""
 
+#. Review points sources other than add-ons and themes.
+#: src/olympia/constants/base.py:388 src/olympia/devhub/forms.py:162 src/olympia/editors/templates/editors/performance.html:75
+msgid "Other"
+msgstr "Eile"
+
 #: src/olympia/constants/base.py:389
 msgid "Exception"
 msgstr "Eisceacht"
@@ -3466,6 +3355,10 @@ msgstr "Leagan"
 #: src/olympia/constants/base.py:391
 msgid "Change"
 msgstr "Athraigh"
+
+#: src/olympia/constants/base.py:401
+msgid "App"
+msgstr "Aip"
 
 #: src/olympia/constants/base.py:402
 msgid "Persona"
@@ -3615,7 +3508,7 @@ msgstr "Cuir Bratach Leis"
 msgid "Duplicate"
 msgstr "Cóipeáil"
 
-#: src/olympia/constants/editors.py:17 src/olympia/editors/helpers.py:502 src/olympia/editors/templates/editors/themes/queue.html:71 src/olympia/editors/templates/editors/themes/themes.html:94
+#: src/olympia/constants/editors.py:17 src/olympia/editors/helpers.py:575 src/olympia/editors/templates/editors/themes/queue.html:71 src/olympia/editors/templates/editors/themes/themes.html:94
 msgid "Reject"
 msgstr "Diúltaigh"
 
@@ -3716,7 +3609,7 @@ msgstr "Solaris"
 msgid "Android"
 msgstr "Android"
 
-#: src/olympia/core/apps.py:19
+#: src/olympia/core/apps.py:21
 msgid "Core"
 msgstr ""
 
@@ -3850,7 +3743,7 @@ msgid "Submit my add-on for manual review."
 msgstr ""
 
 #: src/olympia/devhub/forms.py:537
-msgid "Do not list my add-on on this site (beta)"
+msgid "Do not list my add-on on this site"
 msgstr ""
 
 #: src/olympia/devhub/forms.py:538
@@ -3883,46 +3776,46 @@ msgstr ""
 
 #: src/olympia/devhub/forms.py:592
 #, python-format
-msgid "Version %s already exists"
-msgstr "Tá leagan %s ann cheana"
+msgid "Version %s already exists, or was uploaded before."
+msgstr ""
 
-#: src/olympia/devhub/forms.py:604
+#: src/olympia/devhub/forms.py:605
 msgid "Select a valid choice. That choice is not one of the available choices."
 msgstr ""
 
-#: src/olympia/devhub/forms.py:610
+#: src/olympia/devhub/forms.py:611
 msgid "A file with a version ending with a|alpha|b|beta and an optional number is detected as beta."
 msgstr ""
 
-#: src/olympia/devhub/forms.py:633
+#: src/olympia/devhub/forms.py:634
 msgid "You cannot upload any more files for this version."
 msgstr "Ní féidir leat tuilleadh comhad a uasluchtú le haghaidh an leagain seo."
 
-#: src/olympia/devhub/forms.py:639
+#: src/olympia/devhub/forms.py:640
 msgid "Version doesn't match"
 msgstr "Níl an leagan comhoiriúnach"
 
-#: src/olympia/devhub/forms.py:668
+#: src/olympia/devhub/forms.py:669
 msgid "You cannot delete a file once the review process has started.  You must delete the whole version."
 msgstr ""
 
-#: src/olympia/devhub/forms.py:688
+#: src/olympia/devhub/forms.py:689
 msgid "The platform All cannot be combined with specific platforms."
 msgstr ""
 
-#: src/olympia/devhub/forms.py:693
+#: src/olympia/devhub/forms.py:694
 msgid "A platform can only be chosen once."
 msgstr "Ní féidir ardán a roghnú ach uair amháin."
 
-#: src/olympia/devhub/forms.py:706
+#: src/olympia/devhub/forms.py:707
 msgid "A review type must be selected."
 msgstr ""
 
-#: src/olympia/devhub/forms.py:788 src/olympia/editors/forms.py:114 src/olympia/zadmin/forms.py:49 src/olympia/zadmin/forms.py:52
+#: src/olympia/devhub/forms.py:789 src/olympia/editors/forms.py:114 src/olympia/editors/forms.py:254 src/olympia/zadmin/forms.py:49 src/olympia/zadmin/forms.py:52
 msgid "Select an application first"
 msgstr "Roghnaigh feidhmchlár i dtosach báire"
 
-#: src/olympia/devhub/forms.py:840
+#: src/olympia/devhub/forms.py:841
 msgid "There cannot be more than 3 required add-ons."
 msgstr "Ní cheadaítear níos mó ná 3 bhreiseán riachtanach."
 
@@ -3945,9 +3838,6 @@ msgid "{0} error"
 msgid_plural "{0} errors"
 msgstr[0] "{0} earráid"
 msgstr[1] "{0} earráid"
-msgstr[2] "{0} earráid"
-msgstr[3] "{0} n-earráid"
-msgstr[4] "{0} earráid"
 
 # {0} is a number
 #. L10n: first parameter is the number of warnings
@@ -3956,84 +3846,81 @@ msgid "{0} warning"
 msgid_plural "{0} warnings"
 msgstr[0] "{0} rabhadh"
 msgstr[1] "{0} rabhadh"
-msgstr[2] "{0} rabhadh"
-msgstr[3] "{0} rabhadh"
-msgstr[4] "{0} rabhadh"
 
 #: src/olympia/devhub/models.py:375 src/olympia/reviews/templates/reviews/add.html:58
 msgid "Review"
 msgstr "Léirmheas"
 
-#: src/olympia/devhub/tasks.py:551
+#: src/olympia/devhub/tasks.py:583
 #, python-format
 msgid "%s responded with %s (%s)."
 msgstr ""
 
-#: src/olympia/devhub/tasks.py:555
+#: src/olympia/devhub/tasks.py:587
 #, python-format
 msgid "Connection to \"%s\" timed out."
 msgstr "Ceangal le \"%s\" thar am."
 
-#: src/olympia/devhub/tasks.py:557
+#: src/olympia/devhub/tasks.py:589
 #, python-format
 msgid "Could not contact host at \"%s\"."
 msgstr "Níorbh fhéidir dul i dteagmháil le hóstríomhaire \"%s\"."
 
-#: src/olympia/devhub/utils.py:104
+#: src/olympia/devhub/utils.py:105
 #, python-format
 msgid "Validation generated too many errors/warnings so %s messages were truncated. After addressing the visible messages, you'll be able to see the others."
 msgstr ""
 
-#: src/olympia/devhub/views.py:183
+#: src/olympia/devhub/views.py:181
 msgid "All My Add-ons"
 msgstr "Mo Bhreiseáin Go Léir"
 
-#: src/olympia/devhub/views.py:210
+#: src/olympia/devhub/views.py:208
 msgid "All Activity"
 msgstr "An Ghníomhaíocht Go Léir"
 
-#: src/olympia/devhub/views.py:211
+#: src/olympia/devhub/views.py:209
 msgid "Add-on Updates"
 msgstr "Nuashonruithe Breiseán"
 
-#: src/olympia/devhub/views.py:212
+#: src/olympia/devhub/views.py:210
 msgid "Add-on Status"
 msgstr "Stádas an Bhreiseáin"
 
-#: src/olympia/devhub/views.py:213
+#: src/olympia/devhub/views.py:211
 msgid "User Collections"
 msgstr "Bailiúcháin Úsáideoira"
 
-#: src/olympia/devhub/views.py:214 src/olympia/devhub/templates/devhub/docs/policies-maintenance.html:68 src/olympia/pages/templates/pages/dev_faq.html:38
+#: src/olympia/devhub/views.py:212 src/olympia/devhub/templates/devhub/docs/policies-maintenance.html:68 src/olympia/pages/templates/pages/dev_faq.html:38
 #: src/olympia/pages/templates/pages/dev_faq.html:484
 msgid "User Reviews"
 msgstr "Léirmheasanna ó Úsáideoirí"
 
-#: src/olympia/devhub/views.py:327 src/olympia/devhub/views.py:331 src/olympia/devhub/views.py:484 src/olympia/devhub/views.py:513 src/olympia/devhub/views.py:564 src/olympia/devhub/views.py:1150
+#: src/olympia/devhub/views.py:325 src/olympia/devhub/views.py:329 src/olympia/devhub/views.py:484 src/olympia/devhub/views.py:513 src/olympia/devhub/views.py:564 src/olympia/devhub/views.py:1156
 msgid "Changes successfully saved."
 msgstr "Sábháladh na hathruithe."
 
-#: src/olympia/devhub/views.py:334 src/olympia/devhub/views.py:1631
+#: src/olympia/devhub/views.py:332 src/olympia/devhub/views.py:1637
 msgid "Please check the form for errors."
 msgstr ""
 
-#: src/olympia/devhub/views.py:346
+#: src/olympia/devhub/views.py:344
 msgid "Add-on cannot be deleted. Disable this add-on instead."
 msgstr "Ní féidir an breiseán a scriosadh. Ba chóir duit é a dhíchumasú."
 
-#: src/olympia/devhub/views.py:356
+#: src/olympia/devhub/views.py:354
 msgid "Theme deleted."
 msgstr "Scriosadh an téama."
 
-#: src/olympia/devhub/views.py:356
+#: src/olympia/devhub/views.py:354
 msgid "Add-on deleted."
 msgstr "Scriosadh an breiseán."
 
-#: src/olympia/devhub/views.py:362
+#: src/olympia/devhub/views.py:360
 msgid "URL name was incorrect. Theme was not deleted."
 msgstr ""
 
-#: src/olympia/devhub/views.py:367
+#: src/olympia/devhub/views.py:365
 msgid "URL name was incorrect. Add-on was not deleted."
 msgstr ""
 
@@ -4061,7 +3948,7 @@ msgstr "Bailíochtaigh Breiseán"
 msgid "Check Add-on Compatibility"
 msgstr ""
 
-#: src/olympia/devhub/views.py:808 src/olympia/signing/views.py:90
+#: src/olympia/devhub/views.py:808 src/olympia/signing/views.py:95
 msgid "You cannot submit this type of add-on"
 msgstr ""
 
@@ -4091,33 +3978,33 @@ msgstr ""
 msgid "There was an error uploading your preview."
 msgstr "Tharla earráid agus do réamhamharc á uasluchtú."
 
-#: src/olympia/devhub/views.py:1189
+#: src/olympia/devhub/views.py:1195
 #, python-format
 msgid "Version %s disabled."
 msgstr ""
 
-#: src/olympia/devhub/views.py:1193
+#: src/olympia/devhub/views.py:1199
 #, python-format
 msgid "Version %s deleted."
 msgstr "Scriosadh leagan %s."
 
-#: src/olympia/devhub/views.py:1203
+#: src/olympia/devhub/views.py:1209
 msgid "This upload has failed validation, and may lack complete validation results. Please take due care when reviewing it."
 msgstr ""
 
-#: src/olympia/devhub/views.py:1677
+#: src/olympia/devhub/views.py:1683
 msgid "Preliminary Review Requested."
 msgstr "Iarradh Réamhscrúdú."
 
-#: src/olympia/devhub/views.py:1678
+#: src/olympia/devhub/views.py:1684
 msgid "Full Review Requested."
 msgstr "Iarradh Scrúdú Iomlán."
 
-#: src/olympia/devhub/views.py:1779
+#: src/olympia/devhub/views.py:1783
 msgid "Your old credentials were revoked and are no longer valid. Be sure to update all API clients with the new credentials."
 msgstr ""
 
-#: src/olympia/devhub/views.py:1797
+#: src/olympia/devhub/views.py:1801
 msgid "New API key created"
 msgstr ""
 
@@ -4148,7 +4035,7 @@ msgid "{0} :: Search"
 msgstr "{0} :: Cuardaigh"
 
 # all of these look good as verbs as of 8 Feb 2011
-#: src/olympia/devhub/templates/devhub/devhub_search.html:6 src/olympia/devhub/templates/devhub/search.html:8 src/olympia/editors/forms.py:435 src/olympia/editors/forms.py:437
+#: src/olympia/devhub/templates/devhub/devhub_search.html:6 src/olympia/devhub/templates/devhub/search.html:8 src/olympia/editors/forms.py:534 src/olympia/editors/forms.py:536
 #: src/olympia/editors/templates/editors/queue.html:27 src/olympia/editors/templates/editors/themes/queue_list.html:14 src/olympia/search/templates/search/collections.html:17
 #: src/olympia/search/templates/search/personas.html:18 src/olympia/search/templates/search/results.html:18 src/olympia/search/templates/search/mobile/results.html:8
 #: src/olympia/templates/search.html:14 src/olympia/templates/impala/search.html:18
@@ -4208,12 +4095,12 @@ msgstr ""
 msgid "Start Making Add-ons"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/index.html:86 src/olympia/devhub/templates/devhub/addons/listing/items.html:25 src/olympia/devhub/templates/devhub/includes/addon_details.html:15
+#: src/olympia/devhub/templates/devhub/index.html:86 src/olympia/devhub/templates/devhub/addons/listing/items.html:25 src/olympia/devhub/templates/devhub/includes/addon_details.html:20
 #: src/olympia/devhub/templates/devhub/personas/edit.html:43
 msgid "Status:"
 msgstr "Stádas:"
 
-#: src/olympia/devhub/templates/devhub/index.html:90 src/olympia/devhub/templates/devhub/includes/addon_details.html:100
+#: src/olympia/devhub/templates/devhub/index.html:90 src/olympia/devhub/templates/devhub/includes/addon_details.html:87
 msgid "Visibility:"
 msgstr ""
 
@@ -4221,11 +4108,11 @@ msgstr ""
 msgid "Latest Version:"
 msgstr "Leagan Is Déanaí:"
 
-#: src/olympia/devhub/templates/devhub/index.html:109 src/olympia/devhub/templates/devhub/includes/addon_details.html:145 src/olympia/devhub/templates/devhub/personas/edit.html:49
+#: src/olympia/devhub/templates/devhub/index.html:109 src/olympia/devhub/templates/devhub/includes/addon_details.html:131 src/olympia/devhub/templates/devhub/personas/edit.html:49
 msgid "Queue Position:"
 msgstr "Ionad sa Chiú:"
 
-#: src/olympia/devhub/templates/devhub/index.html:110 src/olympia/devhub/templates/devhub/includes/addon_details.html:146 src/olympia/devhub/templates/devhub/personas/edit.html:50
+#: src/olympia/devhub/templates/devhub/index.html:110 src/olympia/devhub/templates/devhub/includes/addon_details.html:132 src/olympia/devhub/templates/devhub/personas/edit.html:50
 #, python-format
 msgid "%(position)s of %(total)s"
 msgstr "%(position)s as %(total)s"
@@ -4327,16 +4214,6 @@ msgstr ""
 msgid "Do you want your add-on to be distributed on this site?"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/validate_addon.html:49 src/olympia/devhub/templates/devhub/addons/submit/upload.html:30 src/olympia/devhub/templates/devhub/versions/add_file_modal.html:14
-#: src/olympia/devhub/templates/devhub/versions/add_file_modal.html:53 src/olympia/devhub/templates/devhub/versions/list.html:298
-msgid "Warning:"
-msgstr ""
-
-#: src/olympia/devhub/templates/devhub/validate_addon.html:50 src/olympia/devhub/templates/devhub/addons/submit/upload.html:31
-#, python-format
-msgid "Submission of unlisted add-ons for signing is currently in an open beta. Please <a href=\"%(url)s\" target=\"_blank\">report any bugs</a> that you encounter."
-msgstr ""
-
 #. first parameter is a filename like lorem-ipsum-1.0.2.xpi
 #: src/olympia/devhub/templates/devhub/validation.html:5
 msgid "Validation Results for {0}"
@@ -4413,7 +4290,7 @@ msgstr "Comhoiriúnacht"
 msgid "Update Compatibility"
 msgstr "Nuashonraigh Comhoiriúnacht"
 
-#: src/olympia/devhub/templates/devhub/addons/ajax_compat_update.html:4
+#: src/olympia/devhub/templates/devhub/addons/ajax_compat_update.html:4 src/olympia/devhub/templates/devhub/versions/edit.html:45
 msgid "Adjusting application information here will allow users to install your add-on even if the install manifest in the package indicates that the add-on is incompatible."
 msgstr ""
 
@@ -4425,9 +4302,9 @@ msgstr "Leaganacha a dTacaítear Leo"
 msgid "Add Another Application&hellip;"
 msgstr "Cuir Feidhmchlár Eile Leis&hellip;"
 
-#: src/olympia/devhub/templates/devhub/addons/ajax_compat_update.html:38 src/olympia/devhub/templates/devhub/addons/owner.html:86 src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:46
-#: src/olympia/devhub/templates/devhub/versions/list.html:351 src/olympia/devhub/templates/devhub/versions/list.html:353 src/olympia/templates/impala/base.html:132
-#: src/olympia/templates/impala/base.html:143 src/olympia/templates/impala/base.html:161 src/olympia/templates/impala/base.html:171
+#: src/olympia/devhub/templates/devhub/addons/ajax_compat_update.html:38 src/olympia/devhub/templates/devhub/addons/owner.html:86 src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:45
+#: src/olympia/devhub/templates/devhub/versions/list.html:349 src/olympia/devhub/templates/devhub/versions/list.html:351 src/olympia/templates/impala/base.html:129
+#: src/olympia/templates/impala/base.html:140 src/olympia/templates/impala/base.html:158 src/olympia/templates/impala/base.html:168
 msgid "Close"
 msgstr "Dún"
 
@@ -4446,9 +4323,6 @@ msgid "<b>{0}</b> theme"
 msgid_plural "<b>{0}</b> themes"
 msgstr[0] "<b>{0}</b> téama"
 msgstr[1] "<b>{0}</b> théama"
-msgstr[2] "<b>{0}</b> théama"
-msgstr[3] "<b>{0}</b> dtéama"
-msgstr[4] "<b>{0}</b> téama"
 
 #: src/olympia/devhub/templates/devhub/addons/edit.html:3 src/olympia/devhub/templates/devhub/addons/listing/item_actions.html:25
 #: src/olympia/devhub/templates/devhub/addons/listing/item_actions_theme.html:7 src/olympia/devhub/templates/devhub/includes/addons_edit_nav.html:2
@@ -4464,7 +4338,7 @@ msgstr "Gan sonrú"
 msgid "Manage Authors & License"
 msgstr "Bainistigh Údair agus Ceadúnas"
 
-#: src/olympia/devhub/templates/devhub/addons/owner.html:29 src/olympia/editors/templates/editors/review.html:270
+#: src/olympia/devhub/templates/devhub/addons/owner.html:29 src/olympia/editors/helpers.py:362 src/olympia/editors/templates/editors/review.html:270
 msgid "Authors"
 msgstr "Údair"
 
@@ -4533,17 +4407,11 @@ msgstr "Achoimre"
 
 #: src/olympia/devhub/templates/devhub/addons/edit/basic.html:52
 msgid ""
-"A short explanation of your add-on's basic\n"
-"                          functionality that is displayed in search and browse\n"
-"                          listings, as well as at the top of your add-on's\n"
-"                          details page. It is only relevant for listed add-ons."
+"A short explanation of your add-on's basic functionality that is displayed in search and browse listings, as well as at the top of your add-on's details page. It is only relevant for listed add-ons."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/basic.html:73
-msgid ""
-"Categories are the primary way users browse through add-ons.\n"
-"                        Choose any that fit your add-on's functionality for the most\n"
-"                        exposure. It is only relevant for listed add-ons."
+msgid "Categories are the primary way users browse through add-ons. Choose any that fit your add-on's functionality for the most exposure. It is only relevant for listed add-ons."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/basic.html:90
@@ -4553,11 +4421,7 @@ msgid ""
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/basic.html:119
-msgid ""
-"Tags help users find your add-on and should be short\n"
-"                        descriptors such as tabs, toolbar, or twitter.  You\n"
-"                        may have a maximum of {0} tags. It is only relevant\n"
-"                        for listed add-ons."
+msgid "Tags help users find your add-on and should be short descriptors such as tabs, toolbar, or twitter. You may have a maximum of {0} tags. It is only relevant for listed add-ons."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/basic.html:129 src/olympia/devhub/templates/devhub/personas/edit.html:97 src/olympia/devhub/templates/devhub/personas/submit.html:46
@@ -4565,9 +4429,6 @@ msgid "Comma-separated, minimum of {0} character."
 msgid_plural "Comma-separated, minimum of {0} characters."
 msgstr[0] "Scartha ag camóga, {0} carachtar ar a laghad."
 msgstr[1] "Scartha ag camóga, {0} carachtar ar a laghad."
-msgstr[2] "Scartha ag camóga, {0} carachtar ar a laghad."
-msgstr[3] "Scartha ag camóga, {0} carachtar ar a laghad."
-msgstr[4] "Scartha ag camóga, {0} carachtar ar a laghad."
 
 #: src/olympia/devhub/templates/devhub/addons/edit/basic.html:132 src/olympia/devhub/templates/devhub/personas/edit.html:100 src/olympia/devhub/templates/devhub/personas/submit.html:49
 msgid "Example: dark, cinema, noir. Limit 20."
@@ -4578,9 +4439,6 @@ msgid "Reserved tag:"
 msgid_plural "Reserved tags:"
 msgstr[0] "Clib in áirithe:"
 msgstr[1] "Clibeanna in áirithe:"
-msgstr[2] "Clibeanna in áirithe:"
-msgstr[3] "Clibeanna in áirithe:"
-msgstr[4] "Clibeanna in áirithe:"
 
 #: src/olympia/devhub/templates/devhub/addons/edit/details.html:5
 msgid "Add-on Details"
@@ -4591,11 +4449,7 @@ msgid "Add-on Details for {0}"
 msgstr "Mionsonraí Bhreiseán {0}"
 
 #: src/olympia/devhub/templates/devhub/addons/edit/details.html:22
-msgid ""
-"A longer explanation of features,\n"
-"                          functionality, and other relevant information. This\n"
-"                          field is only displayed on the add-on's details\n"
-"                          page. It is only relevant for listed add-ons."
+msgid "A longer explanation of features, functionality, and other relevant information. This field is only displayed on the add-on's details page. It is only relevant for listed add-ons."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/details.html:44 src/olympia/translations/templates/translations/trans-menu.html:13
@@ -4603,10 +4457,7 @@ msgid "Default Locale"
 msgstr "Teanga Réamhshocraithe"
 
 #: src/olympia/devhub/templates/devhub/addons/edit/details.html:45
-msgid ""
-"Information about your add-on is displayed in this locale\n"
-"                        unless you override it with a locale-specific translation.\n"
-"                        It is only relevant for listed add-ons."
+msgid "Information about your add-on is displayed in this locale unless you override it with a locale-specific translation. It is only relevant for listed add-ons."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/details.html:61 src/olympia/users/forms.py:311 src/olympia/users/templates/users/edit.html:122 src/olympia/users/templates/users/register.html:57
@@ -4616,10 +4467,8 @@ msgstr "Leathanach Baile"
 
 #: src/olympia/devhub/templates/devhub/addons/edit/details.html:63
 msgid ""
-"If your add-on has another homepage, enter its\n"
-"                          address here. If your website is localized into other\n"
-"                          languages multiple translations of this field can be\n"
-"                          added. It is only relevant for listed add-ons."
+"If your add-on has another homepage, enter its address here. If your website is localized into other languages multiple translations of this field can be added. It is only relevant for listed add-"
+"ons."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/media.html:3
@@ -4637,19 +4486,14 @@ msgstr "Eolas Tacaíochta le haghaidh {0}"
 
 #: src/olympia/devhub/templates/devhub/addons/edit/support.html:22
 msgid ""
-"If you wish to display an e-mail address for support\n"
-"                          inquiries, enter it here. If you have different\n"
-"                          addresses for each language multiple translations of\n"
-"                          this field can be added. It is only relevant for\n"
-"                          listed add-ons."
+"If you wish to display an e-mail address for support inquiries, enter it here. If you have different addresses for each language multiple translations of this field can be added. It is only "
+"relevant for listed add-ons."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/support.html:45
 msgid ""
-"If your add-on has a support website or forum, enter\n"
-"                          its address here. If your website is localized into\n"
-"                          other languages, multiple translations of this field can\n"
-"                          be added. It is only relevant for listed add-ons."
+"If your add-on has a support website or forum, enter its address here. If your website is localized into other languages, multiple translations of this field can be added. It is only relevant for "
+"listed add-ons."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:6
@@ -4663,11 +4507,8 @@ msgstr "Mionsonraí Teicniúla le haghaidh {0}"
 
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:23
 msgid ""
-"Any information end users may want to know that isn't\n"
-"                          necessarily applicable to the add-on summary or description.\n"
-"                          Common uses include listing known major bugs, information on\n"
-"                          how to report bugs, anticipated release date of a new version,\n"
-"                          etc. It is only relevant for listed add-ons."
+"Any information end users may want to know that isn't necessarily applicable to the add-on summary or description. Common uses include listing known major bugs, information on how to report bugs, "
+"anticipated release date of a new version, etc. It is only relevant for listed add-ons."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:46
@@ -4679,9 +4520,7 @@ msgid "Add-on Flags"
 msgstr "Bratacha an Bhreiseáin"
 
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:69
-msgid ""
-"These flags are used to classify add-ons. It is only\n"
-"                        relevant for listed add-ons."
+msgid "These flags are used to classify add-ons. It is only relevant for listed add-ons."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:74
@@ -4697,9 +4536,7 @@ msgid "View Source?"
 msgstr "Féach ar an gcód foinseach?"
 
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:90
-msgid ""
-"Whether the source of your add-on can be displayed in our\n"
-"                        online viewer. It is only relevant for listed add-ons."
+msgid "Whether the source of your add-on can be displayed in our online viewer. It is only relevant for listed add-ons."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:94
@@ -4715,10 +4552,7 @@ msgid "Public Stats?"
 msgstr "Staitisticí Poiblí?"
 
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:102
-msgid ""
-"Whether the download and usage stats of your add-on can\n"
-"                        be displayed in our online viewer.\n"
-"                        It is only relevant for listed add-ons."
+msgid "Whether the download and usage stats of your add-on can be displayed in our online viewer. It is only relevant for listed add-ons."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:107
@@ -4734,10 +4568,7 @@ msgid "Upgrade SDK?"
 msgstr "Nuashonraigh an SDK?"
 
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:116
-msgid ""
-"If selected, we will try to automatically upgrade your\n"
-"                        add-on when a new version of the SDK is released.\n"
-"                        It is only relevant for listed add-ons."
+msgid "If selected, we will try to automatically upgrade your add-on when a new version of the SDK is released. It is only relevant for listed add-ons."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:121
@@ -4788,10 +4619,8 @@ msgstr "Deilbhín an bhreiseáin"
 
 #: src/olympia/devhub/templates/devhub/addons/forms_shared/media.html:16
 msgid ""
-"Upload an icon for your add-on or choose from one of ours. The\n"
-"                      icon is displayed nearly everywhere your add-on is. Uploaded images\n"
-"                      must be one of the following image types: .png, .jpg.\n"
-"                      It is only relevant for listed add-ons."
+"Upload an icon for your add-on or choose from one of ours. The icon is displayed nearly everywhere your add-on is. Uploaded images must be one of the following image types: .png, .jpg. It is only "
+"relevant for listed add-ons."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/forms_shared/media.html:25
@@ -4899,16 +4728,14 @@ msgid "Deleting your add-on will permanently remove it from the site and prevent
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:24
-msgid ""
-"Enter the following text confirm your decision:\n"
-"           {slug}"
+msgid "Enter the following text confirm your decision: {slug}"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:34
+#: src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:33
 msgid "Please tell us why you are deleting your theme:"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:36
+#: src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:35
 msgid "Please tell us why you are deleting your add-on:"
 msgstr ""
 
@@ -4945,8 +4772,8 @@ msgstr "Leagan Nua"
 msgid "Daily statistics on downloads and users."
 msgstr "Staitisticí laethúla ar líon íosluchtuithe agus úsáideoirí."
 
-#: src/olympia/devhub/templates/devhub/addons/listing/item_actions.html:45 src/olympia/stats/templates/stats/stats.html:75 src/olympia/stats/templates/stats/stats.html:79
-#: src/olympia/stats/templates/stats/stats.html:81
+#: src/olympia/devhub/templates/devhub/addons/listing/item_actions.html:45 src/olympia/stats/templates/stats/stats.html:31 src/olympia/stats/templates/stats/stats.html:35
+#: src/olympia/stats/templates/stats/stats.html:37
 msgid "Statistics"
 msgstr "Staitisticí"
 
@@ -5007,9 +4834,6 @@ msgid "<strong>{0}</strong> active user"
 msgid_plural "<strong>{0}</strong> active users"
 msgstr[0] "<strong>{0}</strong> úsáideoir gníomhach"
 msgstr[1] "<strong>{0}</strong> úsáideoir gníomhach"
-msgstr[2] "<strong>{0}</strong> úsáideoir gníomhach"
-msgstr[3] "<strong>{0}</strong> n-úsáideoir gníomhach"
-msgstr[4] "<strong>{0}</strong> úsáideoir gníomhach"
 
 #: src/olympia/devhub/templates/devhub/addons/submit/base.html:11
 msgid "Submit Add-on"
@@ -5068,10 +4892,7 @@ msgid "Your add-on has been submitted to the Full Review queue."
 msgstr "Cuireadh do bhreiseán sa chiú le haghaidh Scrúdaithe Iomláin."
 
 #: src/olympia/devhub/templates/devhub/addons/submit/done.html:18
-msgid ""
-"You'll receive an email once it has been reviewed by an editor. In\n"
-"          the meantime, you and your friends can install it directly from its\n"
-"          details page:"
+msgid "You'll receive an email once it has been reviewed by an editor. In the meantime, you and your friends can install it directly from its details page:"
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/submit/done.html:27 src/olympia/devhub/templates/devhub/addons/submit/done.html:77 src/olympia/devhub/templates/devhub/personas/submit_done.html:16
@@ -5279,11 +5100,11 @@ msgstr "Céim 2. Uasluchtaigh Do Bhreiseán"
 msgid "Use the fields below to upload your add-on package and select any platform restrictions. After upload, a series of automated validation tests will be run on your file."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/addons/submit/upload.html:59 src/olympia/devhub/templates/devhub/versions/add_file_modal.html:39
+#: src/olympia/devhub/templates/devhub/addons/submit/upload.html:51 src/olympia/devhub/templates/devhub/versions/add_file_modal.html:28
 msgid "Which platforms is this file compatible with?"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/addons/submit/upload.html:67 src/olympia/devhub/templates/devhub/versions/add_file_modal.html:65
+#: src/olympia/devhub/templates/devhub/addons/submit/upload.html:59 src/olympia/devhub/templates/devhub/versions/add_file_modal.html:45
 msgid "Administrative overrides"
 msgstr ""
 
@@ -5393,8 +5214,8 @@ msgstr ""
 
 #: src/olympia/devhub/templates/devhub/docs/policies-contact.html:44
 msgid ""
-"If you've found a problem with the site, we'd love to fix it. Please <a href=\"https://github.com/mozilla/olympia/issues\">file a bug report</a> in GitHub, including the location of the problem and "
-"how you encountered it."
+"If you've found a problem with the site, we'd love to fix it. Please <a href=\"https://github.com/mozilla/addons/issues/new\">file a bug report</a> in GitHub, including the location of the problem "
+"and how you encountered it."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/docs/policies-maintenance.html:3 src/olympia/devhub/templates/devhub/docs/policies-maintenance.html:7
@@ -5961,7 +5782,7 @@ msgstr ""
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:282
 msgid ""
-"Add-ons that store or otherwise handle browsing data must support <a href=\"https://developer.mozilla.org/En/Supporting_private_browsing_mode\">Private Browsing Mode</a>.  During a Private Browsing "
+"Add-ons that store or otherwise handle browsing data must support <a href=\"https://developer.mozilla.org/En/Supporting_private_browsing_mode\">Private Browsing Mode</a>. During a Private Browsing "
 "session, no browsing data can be written to disk, and all of this data must be cleared when Firefox quits or the Private Browsing session ends."
 msgstr ""
 
@@ -6126,129 +5947,95 @@ msgstr ""
 msgid "How to get in touch with us regarding these policies or your add-on."
 msgstr "Conas is féidir dul i dteagmháil linn maidir leis na bpolasaithe seo."
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:6
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:10
 msgid "You have disabled this add-on"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:20
-msgid ""
-"Your add-on's listing is disabled and is not showing\n"
-"                             anywhere in our gallery or update service."
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:24
+msgid "Your add-on's listing is disabled and is not showing anywhere in our gallery or update service."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:25
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:27
 msgid "Please complete your add-on."
 msgstr "Cuir do bhreiseán i gcrích anois."
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:29
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:30
 msgid "You will receive an email when the review is complete."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:34
-msgid ""
-"You will receive an email when the review is complete. Until\n"
-"                             then, your add-on is not listed in our gallery but can be\n"
-"                             accessed directly from its details page."
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:33
+msgid "You will receive an email when the review is complete. Until then, your add-on is not listed in our gallery but can be accessed directly from its details page."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:38 src/olympia/devhub/templates/devhub/includes/addon_details.html:48
-msgid ""
-"You will receive an email when the review is\n"
-"                             complete and your add-on is signed."
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:37 src/olympia/devhub/templates/devhub/includes/addon_details.html:45
+msgid "You will receive an email when the review is complete and your add-on is signed."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:44
-msgid ""
-"You will receive an email when the review is complete. Until\n"
-"                             then, your add-on is not listed in our gallery but can be\n"
-"                             accessed directly from its details page. "
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:41
+msgid "You will receive an email when the review is complete. Until then, your add-on is not listed in our gallery but can be accessed directly from its details page. "
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:54
-msgid ""
-"Your add-on is displayed in our gallery and users are\n"
-"                             receiving automatic updates."
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:49
+msgid "Your add-on is displayed in our gallery and users are receiving automatic updates."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:57
-msgid ""
-"Your add-on has been signed and can be bundled with an\n"
-"                             application installer."
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:52
+msgid "Your add-on has been signed and can be bundled with an application installer."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:63
-msgid ""
-"Your add-on was disabled by a site administrator and is no\n"
-"                             longer shown in our gallery. If you have any questions,\n"
-"                             please email amo-admins@mozilla.org."
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:56
+msgid "Your add-on was disabled by a site administrator and is no longer shown in our gallery. If you have any questions, please email amo-admins@mozilla.org."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:70
-msgid ""
-"Your add-on is displayed in our gallery as experimental\n"
-"                             and users are receiving automatic updates. Some features\n"
-"                             are unavailable to your add-on."
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:62
+msgid "Your add-on is displayed in our gallery as experimental and users are receiving automatic updates. Some features are unavailable to your add-on."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:74
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:66
 msgid "Your add-on has been signed."
 msgstr ""
 
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:69
+msgid ""
+"You will receive an email when the full review is complete. Until then, your add-on is displayed in our gallery as experimental and users are receiving automatic updates. Some features are "
+"unavailable to your add-on."
+msgstr ""
+
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:74
+msgid "You will receive an email when the full review is complete, making you able to bundle your add-on with an application installer."
+msgstr ""
+
 #: src/olympia/devhub/templates/devhub/includes/addon_details.html:79
-msgid ""
-"You will receive an email when the full review is complete.\n"
-"                             Until then, your add-on is displayed in our gallery as\n"
-"                             experimental and users are receiving automatic updates.\n"
-"                             Some features are unavailable to your add-on."
+msgid "All add-ons hosted in our gallery must now be reviewed by an editor. If you wish to continue hosting your add-on, please click to select a review process."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:84
-msgid ""
-"You will receive an email when the full review is\n"
-"                             complete, making you able to bundle your add-on with an\n"
-"                             application installer."
-msgstr ""
-
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:91
-msgid ""
-"All add-ons hosted in our gallery must now be reviewed by an\n"
-"                             editor. If you wish to continue hosting your add-on, please\n"
-"                             click to select a review process."
-msgstr ""
-
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:113
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:100
 msgid "Current Version:"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:115
-msgid ""
-"This is the version of your add-on that will\n"
-"                                           be installed if someone clicks the Install\n"
-"                                           button on addons.mozilla.org. It is only\n"
-"                                           relevant for listed add-ons."
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:102
+msgid "This is the version of your add-on that will be installed if someone clicks the Install button on addons.mozilla.org. It is only relevant for listed add-ons."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:123
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:110
 msgid "Created:"
 msgstr ""
 
 #. {0} is a date. dennis-ignore: E201
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:125 src/olympia/devhub/templates/devhub/includes/addon_details.html:131
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:112 src/olympia/devhub/templates/devhub/includes/addon_details.html:118
 #, python-format
 msgid "%%b %%e, %%Y"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:136
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:123
 msgid "Next Version:"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:138
-msgid ""
-"This is the newest uploaded version, however\n"
-"                                           it isn’t live on the site yet."
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:125
+msgid "This is the newest uploaded version, however it isn’t live on the site yet."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:144 src/olympia/devhub/templates/devhub/versions/list.html:30
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:130 src/olympia/devhub/templates/devhub/versions/list.html:30
 msgid "Queues are not reviewed strictly in order"
 msgstr ""
 
@@ -6316,9 +6103,7 @@ msgid "View the blog &#9658;"
 msgstr "Léig an blag &#9658;"
 
 #: src/olympia/devhub/templates/devhub/includes/license_form.html:6
-msgid ""
-"Please choose a license appropriate for the rights you grant on your source code.\n"
-"                  It is only relevant for listed add-ons."
+msgid "Please choose a license appropriate for the rights you grant on your source code. It is only relevant for listed add-ons."
 msgstr ""
 
 #. {0} is a list of HTML tags.
@@ -6341,21 +6126,15 @@ msgid "Select <b>up to {0}</b> {1} category for this add-on:"
 msgid_plural "Select <b>up to {0}</b> {1} categories for this add-on:"
 msgstr[0] ""
 msgstr[1] ""
-msgstr[2] ""
-msgstr[3] ""
-msgstr[4] ""
 
 #: src/olympia/devhub/templates/devhub/includes/policy_form.html:4
 msgid ""
 "Users will be required to accept the following End-User License Agreement (EULA) prior to installing your add-on. The presence of a EULA significantly affects the number of downloads an add-on "
-"receives. Please note that a EULA is not the same as a code license, such as the GPL or MPL.\n"
-"                It is only relevant for listed add-ons."
+"receives. Please note that a EULA is not the same as a code license, such as the GPL or MPL.It is only relevant for listed add-ons."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/policy_form.html:21
-msgid ""
-"If your add-on transmits any data from the user's computer, a privacy policy is required that explains what data is sent and how it is used.\n"
-"                It is only relevant for listed add-ons."
+#: src/olympia/devhub/templates/devhub/includes/policy_form.html:24
+msgid "If your add-on transmits any data from the user's computer, a privacy policy is required that explains what data is sent and how it is used. It is only relevant for listed add-ons."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/includes/source_form_field.html:2
@@ -6523,12 +6302,8 @@ msgstr ""
 msgid "Add some tags to describe your Theme."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/personas/edit.html:106
-msgid ""
-"A short explanation of your theme's\n"
-"                                basic functionality that is displayed in\n"
-"                                search and browse listings, as well as at\n"
-"                                the top of your theme's details page."
+#: src/olympia/devhub/templates/devhub/personas/edit.html:106 src/olympia/devhub/templates/devhub/personas/submit.html:54
+msgid "A short explanation of your theme's basic functionality that is displayed in search and browse listings, as well as at the top of your theme's details page."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/personas/edit.html:122 src/olympia/devhub/templates/devhub/personas/submit.html:68
@@ -6598,7 +6373,7 @@ msgid "Upon upload and form submission, the AMO Team will review your updated de
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/personas/edit.html:241
-msgid "Your previously resubmitted design,  which is under pending review."
+msgid "Your previously resubmitted design, which is under pending review."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/personas/edit.html:245
@@ -6665,14 +6440,6 @@ msgstr ""
 
 #: src/olympia/devhub/templates/devhub/personas/submit.html:33
 msgid "Give your Theme a name."
-msgstr ""
-
-#: src/olympia/devhub/templates/devhub/personas/submit.html:54
-msgid ""
-"A short explanation of your theme's\n"
-"                                      basic functionality that is displayed in\n"
-"                                      search and browse listings, as well as at\n"
-"                                      the top of your theme's details page."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/personas/submit.html:198
@@ -6749,30 +6516,16 @@ msgstr ""
 msgid "Files added to reviewed versions must be reviewed before they will be available for download."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/add_file_modal.html:15
-#, python-format
-msgid ""
-"Submission of updates to unlisted add-ons for signing is currently in an open beta. Manual review may still be required for a large number of add-ons. Please <a href=\"%(url)s\" target=\"_blank"
-"\">report any bugs</a> that you encounter."
-msgstr ""
-
-#: src/olympia/devhub/templates/devhub/versions/add_file_modal.html:35
+#: src/olympia/devhub/templates/devhub/versions/add_file_modal.html:24
 msgid "Select the target platform for this file."
 msgstr "Roghnaigh ardán le haghaidh an chomhaid seo."
 
-#: src/olympia/devhub/templates/devhub/versions/add_file_modal.html:46
+#: src/olympia/devhub/templates/devhub/versions/add_file_modal.html:35
 msgid "Which review type would you like to nominate for?"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/add_file_modal.html:51
+#: src/olympia/devhub/templates/devhub/versions/add_file_modal.html:40
 msgid "Only publish this version to my beta channel."
-msgstr ""
-
-#: src/olympia/devhub/templates/devhub/versions/add_file_modal.html:54
-#, python-format
-msgid ""
-"The behavior of the beta channel has changed to accommodate <a href=\"%(addon_signing_url)s\" target=\"_blank\">mandatory add-on signing</a>. The new process is currently in an open beta, and may "
-"change significantly in the near future. Please <a href=\"%(issues_url)s\" target=\"_blank\">report any bugs</a> that you encounter."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/versions/edit.html:5
@@ -6797,19 +6550,10 @@ msgstr "Comhaid:"
 msgid "Upload Another File"
 msgstr "Uasluchtaigh Comhad Eile"
 
-#: src/olympia/devhub/templates/devhub/versions/edit.html:45
-msgid ""
-"Adjusting application information here will allow users to install your\n"
-"                          add-on even if the install manifest in the package indicates that the\n"
-"                          add-on is incompatible."
-msgstr ""
-
 #: src/olympia/devhub/templates/devhub/versions/edit.html:74
 msgid ""
-"Information about changes in this release, new features,\n"
-"                              known bugs, and other useful information specific to this\n"
-"                              release/version. This information is also shown in the\n"
-"                              Add-ons Manager when updating."
+"Information about changes in this release, new features, known bugs, and other useful information specific to this release/version. This information is also shown in the Add-ons Manager when "
+"updating."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/versions/edit.html:99
@@ -6821,10 +6565,7 @@ msgid "Notes for Reviewers"
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/versions/edit.html:114
-msgid ""
-"Optionally, enter any information that may be useful\n"
-"                              to the Editor reviewing this add-on, such as test\n"
-"                              account information."
+msgid "Optionally, enter any information that may be useful to the Editor reviewing this add-on, such as test account information."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/versions/edit.html:127
@@ -6876,9 +6617,6 @@ msgid "{0} file"
 msgid_plural "{0} files"
 msgstr[0] ""
 msgstr[1] ""
-msgstr[2] ""
-msgstr[3] ""
-msgstr[4] ""
 
 #: src/olympia/devhub/templates/devhub/versions/list.html:25
 msgid "0 files"
@@ -6905,7 +6643,7 @@ msgstr "Iarr Scrúdú Iomlán"
 msgid "Request Preliminary Review"
 msgstr "Iarr Réamhscrúdú"
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:80 src/olympia/devhub/templates/devhub/versions/list.html:327 src/olympia/devhub/templates/devhub/versions/list.html:350
+#: src/olympia/devhub/templates/devhub/versions/list.html:80 src/olympia/devhub/templates/devhub/versions/list.html:325 src/olympia/devhub/templates/devhub/versions/list.html:348
 msgid "Cancel Review Request"
 msgstr "Cuir an Scrúdú Ar Ceal"
 
@@ -6934,7 +6672,7 @@ msgid "Unlisted:"
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/versions/list.html:114
-msgid "Not distributed on {0}. Developers will upload new versions for signing and distribute the add-ons on their own. (beta)"
+msgid "Not distributed on {0}. Developers will upload new versions for signing and distribute the add-ons on their own."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/versions/list.html:122
@@ -6998,81 +6736,73 @@ msgid "<strong>Important:</strong> Once a version has been deleted, you may not 
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/versions/list.html:230
-msgid ""
-"Deleting a version which has already been reviewed\n"
-"               may also cause a significant delay in the review of\n"
-"               your next update."
-msgstr ""
-
-#: src/olympia/devhub/templates/devhub/versions/list.html:233
 msgid "Are you sure you wish to delete this version?"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:238
+#: src/olympia/devhub/templates/devhub/versions/list.html:235
 msgid "Delete Version"
 msgstr "Scrios Leagan"
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:240
+#: src/olympia/devhub/templates/devhub/versions/list.html:237
 msgid "Disable Version"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:247
+#: src/olympia/devhub/templates/devhub/versions/list.html:244
 msgid "Add a new Version"
 msgstr "Cuir leagan nua leis"
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:249
+#: src/olympia/devhub/templates/devhub/versions/list.html:246
 msgid "Add Version"
 msgstr "Cuir leagan leis"
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:256 src/olympia/devhub/templates/devhub/versions/list.html:274
+#: src/olympia/devhub/templates/devhub/versions/list.html:253 src/olympia/devhub/templates/devhub/versions/list.html:279
 msgid "Hide Add-on"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:259
+#: src/olympia/devhub/templates/devhub/versions/list.html:256
 msgid "Hiding your add-on will prevent it from appearing anywhere in our gallery and will stop users from receiving automatic updates."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:265
+#: src/olympia/devhub/templates/devhub/versions/list.html:263
+msgid "The files awaiting review will be disabled and you will need to upload new versions."
+msgstr ""
+
+#: src/olympia/devhub/templates/devhub/versions/list.html:270
 msgid "Are you sure you wish to hide your add-on?"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:286 src/olympia/devhub/templates/devhub/versions/list.html:315
+#: src/olympia/devhub/templates/devhub/versions/list.html:291 src/olympia/devhub/templates/devhub/versions/list.html:313
 msgid "Unlist Add-on"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:289
+#: src/olympia/devhub/templates/devhub/versions/list.html:294
 #, python-format
 msgid ""
 "Unlisting your add-on will make it (and each of its versions/files) invisible on this website. It won't show up in searches, won't have a public facing page, and won't be updated automatically for "
-"current users.  It is recommended for unlisted add-ons to provide a custom <a href=\"%(update_url)s\" target=\"_blank\">updateURL</a> in their manifest file for automatic updates."
+"current users. It is recommended for unlisted add-ons to provide a custom <a href=\"%(update_url)s\" target=\"_blank\">updateURL</a> in their manifest file for automatic updates."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:299
-#, python-format
-msgid "Switching add-ons to unlisted is currently in an open beta. Please <a href=\"%(url)s\" target=\"_blank\">report any bugs</a> that you encounter."
-msgstr ""
-
-#: src/olympia/devhub/templates/devhub/versions/list.html:305
+#: src/olympia/devhub/templates/devhub/versions/list.html:303
 msgid "Unlisting an add-on is irreversible!"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:305
+#: src/olympia/devhub/templates/devhub/versions/list.html:303
 msgid "An unlisted add-on cannot be switched to be listed."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:307
+#: src/olympia/devhub/templates/devhub/versions/list.html:305
 msgid "Are you sure you wish to unlist your add-on?"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:330
+#: src/olympia/devhub/templates/devhub/versions/list.html:328
 msgid "Canceling your review request will leave your add-on as preliminarily reviewed."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:335
+#: src/olympia/devhub/templates/devhub/versions/list.html:333
 msgid "Canceling your review request will mark your add-on incomplete. If you do not complete your add-on after several days by re-requesting review, it will be deleted."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:343
+#: src/olympia/devhub/templates/devhub/versions/list.html:341
 msgid "Are you sure you wish to cancel your review request?"
 msgstr "An bhfuil tú cinnte gur mhaith leat an scrúdú a chur ar ceal?"
 
@@ -7413,19 +7143,19 @@ msgstr "breiseán, eagarthóir nó nóta tráchta"
 msgid "Search by add-on name / author email"
 msgstr "Cuardaigh ainm an bhreiseáin / seoladh ríomhphoist an údair"
 
-#: src/olympia/editors/forms.py:103
+#: src/olympia/editors/forms.py:103 src/olympia/editors/forms.py:244 src/olympia/editors/forms.py:257
 msgid "yes"
 msgstr "tá"
 
-#: src/olympia/editors/forms.py:104
+#: src/olympia/editors/forms.py:104 src/olympia/editors/forms.py:244 src/olympia/editors/forms.py:257
 msgid "no"
 msgstr "níl"
 
-#: src/olympia/editors/forms.py:105
+#: src/olympia/editors/forms.py:105 src/olympia/editors/forms.py:245
 msgid "Admin Flag"
 msgstr "Bratach Riarthóra"
 
-#: src/olympia/editors/forms.py:113
+#: src/olympia/editors/forms.py:113 src/olympia/editors/forms.py:253
 msgid "Max. Version"
 msgstr "Leagan Is Mó"
 
@@ -7437,55 +7167,59 @@ msgstr "Laethanta ó gur seoladh é"
 msgid "Add-on Types"
 msgstr "Cineálacha Breiseáin"
 
-#: src/olympia/editors/forms.py:126 src/olympia/editors/helpers.py:267
+#: src/olympia/editors/forms.py:126 src/olympia/editors/helpers.py:279
 msgid "Platforms"
 msgstr "Ardáin"
 
+#: src/olympia/editors/forms.py:237
+msgid "Search by add-on name / author email / guid"
+msgstr ""
+
 #. L10n: 0 = platform, 1 = filename, 2 = status message
-#: src/olympia/editors/forms.py:238
+#: src/olympia/editors/forms.py:342
 #, python-format
 msgid "<strong>%s</strong> &middot; %s &middot; %s"
 msgstr "<strong>%s</strong> &middot; %s &middot; %s"
 
-#: src/olympia/editors/forms.py:252
+#: src/olympia/editors/forms.py:356
 msgid "Comments:"
 msgstr "Nótaí:"
 
-#: src/olympia/editors/forms.py:256
+#: src/olympia/editors/forms.py:360
 msgid "Operating systems:"
 msgstr "Córais oibriúcháin:"
 
-#: src/olympia/editors/forms.py:258
+#: src/olympia/editors/forms.py:362
 msgid "Applications:"
 msgstr "Feidhmchláir:"
 
-#: src/olympia/editors/forms.py:260
+#: src/olympia/editors/forms.py:364
 msgid "Notify me the next time this add-on is updated. (Subsequent updates will not generate an email)"
 msgstr ""
 
-#: src/olympia/editors/forms.py:265
+#: src/olympia/editors/forms.py:369
 msgid "Clear Admin Review Flag"
 msgstr ""
 
-#: src/olympia/editors/forms.py:267
+#: src/olympia/editors/forms.py:371
 msgid "Clear more info requested flag"
 msgstr ""
 
-#: src/olympia/editors/forms.py:281
+#: src/olympia/editors/forms.py:385
 msgid "Choose a canned response..."
 msgstr ""
 
 #. L10n: Description of what can be searched for.
-#: src/olympia/editors/forms.py:324
+#: src/olympia/editors/forms.py:423
 msgid "theme name"
 msgstr ""
 
-#: src/olympia/editors/forms.py:350
+#: src/olympia/editors/forms.py:449
 msgid "Someone else is reviewing this theme."
 msgstr ""
 
 #. L10n: Description of what can be searched for.
-#: src/olympia/editors/forms.py:447
+#: src/olympia/editors/forms.py:546
 msgid "app, reviewer, or comment"
 msgstr ""
 
@@ -7501,225 +7235,210 @@ msgstr ""
 msgid "Rejected or Unreviewed"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:123 src/olympia/editors/helpers.py:136
+#: src/olympia/editors/helpers.py:125 src/olympia/editors/helpers.py:138
 msgid "Queue"
 msgstr "Ciú"
 
-#: src/olympia/editors/helpers.py:124 src/olympia/editors/templates/editors/base.html:50 src/olympia/editors/templates/editors/base.html:65
+#: src/olympia/editors/helpers.py:126 src/olympia/editors/templates/editors/base.html:50 src/olympia/editors/templates/editors/base.html:65
 msgid "Pending Updates"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:125 src/olympia/editors/templates/editors/base.html:48 src/olympia/editors/templates/editors/base.html:63
+#: src/olympia/editors/helpers.py:127 src/olympia/editors/templates/editors/base.html:48 src/olympia/editors/templates/editors/base.html:63
 msgid "Full Reviews"
 msgstr "Scrúduithe Iomlána"
 
-#: src/olympia/editors/helpers.py:126 src/olympia/editors/templates/editors/base.html:52 src/olympia/editors/templates/editors/base.html:67
+#: src/olympia/editors/helpers.py:128 src/olympia/editors/templates/editors/base.html:52 src/olympia/editors/templates/editors/base.html:67
 msgid "Preliminary Reviews"
 msgstr "Réamhscrúduithe"
 
-#: src/olympia/editors/helpers.py:127 src/olympia/editors/templates/editors/base.html:54
+#: src/olympia/editors/helpers.py:129 src/olympia/editors/templates/editors/base.html:54
 msgid "Moderated Reviews"
 msgstr "Scrúduithe le Ceannasaí"
 
-#: src/olympia/editors/helpers.py:128 src/olympia/editors/templates/editors/base.html:46
+#: src/olympia/editors/helpers.py:130 src/olympia/editors/templates/editors/base.html:46
 msgid "Fast Track"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:130
+#: src/olympia/editors/helpers.py:132
 msgid "Pending Themes"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:131 src/olympia/editors/templates/editors/themes/queue.html:4
+#: src/olympia/editors/helpers.py:133 src/olympia/editors/templates/editors/themes/queue.html:4
 msgid "Flagged Themes"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:132
+#: src/olympia/editors/helpers.py:134
 msgid "Update Themes"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:137
+#: src/olympia/editors/helpers.py:139
 msgid "Unlisted Pending Updates"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:138
+#: src/olympia/editors/helpers.py:140
 msgid "Unlisted Full Reviews"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:139
+#: src/olympia/editors/helpers.py:141
 msgid "Unlisted Preliminary Reviews"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:170
+#: src/olympia/editors/helpers.py:142
+msgid "Unlisted All Add-ons"
+msgstr ""
+
+#: src/olympia/editors/helpers.py:173
 msgid "Fast Track ({0})"
 msgid_plural "Fast Track ({0})"
 msgstr[0] "Modh Mear ({0})"
 msgstr[1] "Modh Mear ({0})"
-msgstr[2] "Modh Mear ({0})"
-msgstr[3] "Modh Mear ({0})"
-msgstr[4] "Modh Mear ({0})"
 
-#: src/olympia/editors/helpers.py:175
+#: src/olympia/editors/helpers.py:178
 msgid "Full Review ({0})"
 msgid_plural "Full Reviews ({0})"
 msgstr[0] ""
 msgstr[1] ""
-msgstr[2] ""
-msgstr[3] ""
-msgstr[4] ""
 
-#: src/olympia/editors/helpers.py:180
+#: src/olympia/editors/helpers.py:183
 msgid "Pending Update ({0})"
 msgid_plural "Pending Updates ({0})"
 msgstr[0] "Nuashonrú Ar Feitheamh ({0})"
 msgstr[1] "Nuashonruithe Ar Feitheamh ({0})"
-msgstr[2] "Nuashonruithe Ar Feitheamh ({0})"
-msgstr[3] "Nuashonruithe Ar Feitheamh ({0})"
-msgstr[4] "Nuashonruithe Ar Feitheamh ({0})"
 
-#: src/olympia/editors/helpers.py:185
+#: src/olympia/editors/helpers.py:188
 msgid "Preliminary Review ({0})"
 msgid_plural "Preliminary Reviews ({0})"
 msgstr[0] ""
 msgstr[1] ""
-msgstr[2] ""
-msgstr[3] ""
-msgstr[4] ""
 
-#: src/olympia/editors/helpers.py:190
+#: src/olympia/editors/helpers.py:193
 msgid "Moderated Review ({0})"
 msgid_plural "Moderated Reviews ({0})"
 msgstr[0] ""
 msgstr[1] ""
-msgstr[2] ""
-msgstr[3] ""
-msgstr[4] ""
 
-#: src/olympia/editors/helpers.py:196
+#: src/olympia/editors/helpers.py:199
 msgid "Unlisted Full Review ({0})"
 msgid_plural "Unlisted Full Reviews ({0})"
 msgstr[0] ""
 msgstr[1] ""
-msgstr[2] ""
-msgstr[3] ""
-msgstr[4] ""
 
-#: src/olympia/editors/helpers.py:201
+#: src/olympia/editors/helpers.py:204
 msgid "Unlisted Pending Update ({0})"
 msgid_plural "Unlisted Pending Updates ({0})"
 msgstr[0] ""
 msgstr[1] ""
-msgstr[2] ""
-msgstr[3] ""
-msgstr[4] ""
 
-#: src/olympia/editors/helpers.py:206
+#: src/olympia/editors/helpers.py:209
 msgid "Unlisted Preliminary Review ({0})"
 msgid_plural "Unlisted Preliminary Reviews ({0})"
 msgstr[0] ""
 msgstr[1] ""
-msgstr[2] ""
-msgstr[3] ""
-msgstr[4] ""
 
-#: src/olympia/editors/helpers.py:261
-msgid "Addon"
-msgstr "Breiseán"
+#: src/olympia/editors/helpers.py:214
+msgid "Unlisted All Add-ons ({0})"
+msgid_plural "Unlisted All Add-ons ({0})"
+msgstr[0] ""
+msgstr[1] ""
 
-#: src/olympia/editors/helpers.py:262
+#: src/olympia/editors/helpers.py:274
 msgid "Type"
 msgstr "Cineál"
 
-#: src/olympia/editors/helpers.py:263
+#: src/olympia/editors/helpers.py:275
 msgid "Waiting Time"
 msgstr "Am Feithimh"
 
-#: src/olympia/editors/helpers.py:264 src/olympia/editors/templates/editors/review.html:285
+#: src/olympia/editors/helpers.py:276 src/olympia/editors/templates/editors/review.html:285
 msgid "Flags"
 msgstr "Bratacha"
 
-#: src/olympia/editors/helpers.py:265
+#: src/olympia/editors/helpers.py:277
 msgid "Applications"
 msgstr "Feidhmchláir"
 
-#: src/olympia/editors/helpers.py:270
+#: src/olympia/editors/helpers.py:282
 msgid "Additional"
 msgstr "Breise"
 
-#: src/olympia/editors/helpers.py:285
+#: src/olympia/editors/helpers.py:302
 msgid "Site Specific"
 msgstr "Sainiúil do Shuíomh"
 
-#: src/olympia/editors/helpers.py:287
+#: src/olympia/editors/helpers.py:304
 msgid "Requires External Software"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:289
+#: src/olympia/editors/helpers.py:306
 msgid "Binary Components"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:313
+#: src/olympia/editors/helpers.py:339
 msgid "moments ago"
 msgstr "soicindí ó shin"
 
 #. L10n: first argument is number of minutes
-#: src/olympia/editors/helpers.py:316
+#: src/olympia/editors/helpers.py:342
 msgid "{0} minute"
 msgid_plural "{0} minutes"
 msgstr[0] "{0} nóiméad"
 msgstr[1] "{0} nóiméad"
-msgstr[2] "{0} nóiméad"
-msgstr[3] "{0} nóiméad"
-msgstr[4] "{0} nóiméad"
 
 #. L10n: first argument is number of hours
-#: src/olympia/editors/helpers.py:320
+#: src/olympia/editors/helpers.py:346
 msgid "{0} hour"
 msgid_plural "{0} hours"
 msgstr[0] "{0} uair"
 msgstr[1] "{0} uair"
-msgstr[2] "{0} huaire"
-msgstr[3] "{0} n-uaire"
-msgstr[4] "{0} uair"
 
 #. L10n: first argument is number of days
-#: src/olympia/editors/helpers.py:324
+#: src/olympia/editors/helpers.py:350
 msgid "{0} day"
 msgid_plural "{0} days"
 msgstr[0] "{0} lá"
 msgstr[1] "{0} lá"
-msgstr[2] "{0} lá"
-msgstr[3] "{0} lá"
-msgstr[4] "{0} lá"
 
-#: src/olympia/editors/helpers.py:488
+#: src/olympia/editors/helpers.py:364
+msgid "Last Review"
+msgstr ""
+
+#: src/olympia/editors/helpers.py:366
+msgid "Last Update"
+msgstr ""
+
+#: src/olympia/editors/helpers.py:387
+msgid "No Reviews"
+msgstr ""
+
+#: src/olympia/editors/helpers.py:561
 msgid "Push to public"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:490
+#: src/olympia/editors/helpers.py:563
 msgid "Grant full review"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:505
+#: src/olympia/editors/helpers.py:578
 msgid "Request more information"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:508
+#: src/olympia/editors/helpers.py:581
 msgid "Request super-review"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:519
+#: src/olympia/editors/helpers.py:592
 msgid "Grant preliminary review"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:520
+#: src/olympia/editors/helpers.py:593
 msgid "This will mark the files as preliminarily reviewed."
 msgstr ""
 
-#: src/olympia/editors/helpers.py:522
+#: src/olympia/editors/helpers.py:595
 msgid "Use this form to request more information from the author. They will receive an email and be able to answer here. You will be notified by email when they reply."
 msgstr ""
 
-#: src/olympia/editors/helpers.py:526
+#: src/olympia/editors/helpers.py:599
 msgid ""
 "If you have concerns about this add-on's security, copyright issues, or other concerns that an administrator should look into, enter your comments in the area below. They will be sent to "
 "administrators, not the author."
@@ -7727,55 +7446,55 @@ msgstr ""
 "Má tá imní ort maidir le slándáil an bhreiseáin seo, cúrsaí cóipchirt, nó aon rud eile ba chóir do riarthóir a iniúchadh, cuir do chuid smaointe sa bhosca thíos.  Seolfar iad chuig riarthóirí an "
 "tsuímh (in ionad an údair)."
 
-#: src/olympia/editors/helpers.py:532
+#: src/olympia/editors/helpers.py:605
 msgid "This will reject the add-on and remove it from the review queue."
 msgstr ""
 
-#: src/olympia/editors/helpers.py:534
-msgid "Make a comment on this version.  The author won't be able to see this."
+#: src/olympia/editors/helpers.py:607
+msgid "Make a comment on this version. The author won't be able to see this."
 msgstr ""
 
-#: src/olympia/editors/helpers.py:538
+#: src/olympia/editors/helpers.py:611
 msgid "This will reject the files and remove them from the review queue."
 msgstr ""
 
-#: src/olympia/editors/helpers.py:542
+#: src/olympia/editors/helpers.py:615
 msgid "This will mark the add-on as preliminarily reviewed. Future versions will undergo preliminary review."
 msgstr ""
 
-#: src/olympia/editors/helpers.py:547
+#: src/olympia/editors/helpers.py:620
 msgid "This will mark the files as preliminarily reviewed. Future versions will undergo preliminary review."
 msgstr ""
 
-#: src/olympia/editors/helpers.py:552
+#: src/olympia/editors/helpers.py:625
 msgid "Retain preliminary review"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:553
+#: src/olympia/editors/helpers.py:626
 msgid "This will retain the add-on as preliminarily reviewed. Future versions will undergo preliminary review."
 msgstr ""
 
-#: src/olympia/editors/helpers.py:558
+#: src/olympia/editors/helpers.py:631
 msgid "This will approve a sandboxed version of a public add-on to appear on the public side."
 msgstr "Cuirfidh sé seo leagan atá sa bhosca gainimh de bhreiseán poiblí ar an taobh poiblí."
 
-#: src/olympia/editors/helpers.py:561
+#: src/olympia/editors/helpers.py:634
 msgid "This will reject a version of a public add-on and remove it from the queue."
 msgstr ""
 
-#: src/olympia/editors/helpers.py:564
+#: src/olympia/editors/helpers.py:637
 msgid "This will mark the add-on and its most recent version and files as public. Future versions will go into the sandbox until they are reviewed by an editor."
 msgstr "Cuirfidh sé seo an breiseán agus an leagan is déanaí de ar an taobh poiblí. Rachaidh leaganacha amach anseo sa bhosca gainimh go dtí go ndéanfaidh eagarthóir iniúchadh orthu."
 
-#: src/olympia/editors/helpers.py:637
+#: src/olympia/editors/helpers.py:714
 msgid "add-on"
 msgstr "breiseán"
 
-#: src/olympia/editors/helpers.py:940 src/olympia/editors/helpers.py:960
+#: src/olympia/editors/helpers.py:1020 src/olympia/editors/helpers.py:1040
 msgid "Flagged"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:944 src/olympia/editors/helpers.py:963
+#: src/olympia/editors/helpers.py:1024 src/olympia/editors/helpers.py:1043
 msgid "Updates"
 msgstr "Nuashonruithe"
 
@@ -7827,56 +7546,56 @@ msgstr ""
 msgid "A question about your Theme submission"
 msgstr ""
 
-#: src/olympia/editors/views.py:144
+#: src/olympia/editors/views.py:146
 msgid "New Add-ons (Under 5 days)"
 msgstr ""
 
-#: src/olympia/editors/views.py:145
+#: src/olympia/editors/views.py:147
 msgid "Passable (5 to 10 days)"
 msgstr ""
 
-#: src/olympia/editors/views.py:146
+#: src/olympia/editors/views.py:148
 msgid "Overdue (Over 10 days)"
 msgstr ""
 
-#: src/olympia/editors/views.py:532
+#: src/olympia/editors/views.py:539
 msgid "An unknown error occurred"
 msgstr ""
 
-#: src/olympia/editors/views.py:587
+#: src/olympia/editors/views.py:592
 msgid "Self-reviews are not allowed."
 msgstr "Níl cead agat do bhreiseán féin a iniúchadh."
 
-#: src/olympia/editors/views.py:609
+#: src/olympia/editors/views.py:613
 msgid "Review successfully processed."
 msgstr "Próiseáladh an léirmheas."
 
-#: src/olympia/editors/views.py:807
+#: src/olympia/editors/views.py:812
 msgid "was approved"
 msgstr "ceadaithe"
 
-#: src/olympia/editors/views.py:808
+#: src/olympia/editors/views.py:813
 msgid "given preliminary review"
 msgstr "réamhscrúdú déanta"
 
-#: src/olympia/editors/views.py:809
+#: src/olympia/editors/views.py:814
 msgid "rejected"
 msgstr "diúltaithe"
 
-#: src/olympia/editors/views.py:810
+#: src/olympia/editors/views.py:815
 msgctxt "editors_review_history_nominated_adminreview"
 msgid "escalated"
 msgstr "géaraithe"
 
-#: src/olympia/editors/views.py:812
+#: src/olympia/editors/views.py:817
 msgid "needs more information"
 msgstr ""
 
-#: src/olympia/editors/views.py:813
+#: src/olympia/editors/views.py:818
 msgid "needs super review"
 msgstr ""
 
-#: src/olympia/editors/views.py:814
+#: src/olympia/editors/views.py:819
 msgid "commented"
 msgstr ""
 
@@ -7885,9 +7604,6 @@ msgid "{0} theme review successfully processed (+{1} points, {2} total)."
 msgid_plural "{0} theme reviews successfully processed (+{1} points, {2} total)."
 msgstr[0] ""
 msgstr[1] ""
-msgstr[2] ""
-msgstr[3] ""
-msgstr[4] ""
 
 #: src/olympia/editors/views_themes.py:341
 msgid "Your theme locks have successfully been released. Other reviewers may now review those released themes. You may have to refresh the page to see the changes reflected in the table below."
@@ -7924,28 +7640,28 @@ msgstr "Ciúnna"
 msgid "Unlisted Queues"
 msgstr ""
 
-#: src/olympia/editors/templates/editors/base.html:72 src/olympia/editors/templates/editors/performance.html:6
+#: src/olympia/editors/templates/editors/base.html:74 src/olympia/editors/templates/editors/performance.html:6
 msgid "Performance"
 msgstr "Feidhmíocht"
 
-#: src/olympia/editors/templates/editors/base.html:75 src/olympia/editors/templates/editors/themes/base.html:19 src/olympia/editors/templates/editors/themes/base.html:38
+#: src/olympia/editors/templates/editors/base.html:77 src/olympia/editors/templates/editors/themes/base.html:19 src/olympia/editors/templates/editors/themes/base.html:38
 msgid "Logs"
 msgstr "Logchomhaid"
 
-#: src/olympia/editors/templates/editors/base.html:78 src/olympia/editors/templates/editors/reviewlog.html:4 src/olympia/editors/templates/editors/reviewlog.html:27
+#: src/olympia/editors/templates/editors/base.html:80 src/olympia/editors/templates/editors/reviewlog.html:4 src/olympia/editors/templates/editors/reviewlog.html:27
 msgid "Add-on Review Log"
 msgstr ""
 
-#: src/olympia/editors/templates/editors/base.html:80 src/olympia/editors/templates/editors/eventlog.html:4 src/olympia/editors/templates/editors/eventlog.html:8
+#: src/olympia/editors/templates/editors/base.html:82 src/olympia/editors/templates/editors/eventlog.html:4 src/olympia/editors/templates/editors/eventlog.html:8
 #: src/olympia/editors/templates/editors/eventlog_detail.html:4
 msgid "Moderated Review Log"
 msgstr ""
 
-#: src/olympia/editors/templates/editors/base.html:82 src/olympia/editors/templates/editors/beta_signed_log.html:4 src/olympia/editors/templates/editors/beta_signed_log.html:8
+#: src/olympia/editors/templates/editors/base.html:84 src/olympia/editors/templates/editors/beta_signed_log.html:4 src/olympia/editors/templates/editors/beta_signed_log.html:8
 msgid "Signed Beta Files Log"
 msgstr ""
 
-#: src/olympia/editors/templates/editors/base.html:87 src/olympia/editors/templates/editors/includes/daily-message.html:4
+#: src/olympia/editors/templates/editors/base.html:89 src/olympia/editors/templates/editors/includes/daily-message.html:4
 msgid "Announcement"
 msgstr "Fógra"
 
@@ -8005,27 +7721,18 @@ msgid "Full Review ({num})"
 msgid_plural "Full Reviews ({num})"
 msgstr[0] ""
 msgstr[1] ""
-msgstr[2] ""
-msgstr[3] ""
-msgstr[4] ""
 
 #: src/olympia/editors/templates/editors/home.html:18
 msgid "Pending Update ({num})"
 msgid_plural "Pending Updates ({num})"
 msgstr[0] "Nuashonrú Ar Feitheamh ({num})"
 msgstr[1] "Nuashonruithe Ar Feitheamh ({num})"
-msgstr[2] "Nuashonruithe Ar Feitheamh ({num})"
-msgstr[3] "Nuashonruithe Ar Feitheamh ({num})"
-msgstr[4] "Nuashonruithe Ar Feitheamh ({num})"
 
 #: src/olympia/editors/templates/editors/home.html:25
 msgid "Preliminary Review ({num})"
 msgid_plural "Preliminary Reviews ({num})"
 msgstr[0] ""
 msgstr[1] ""
-msgstr[2] ""
-msgstr[3] ""
-msgstr[4] ""
 
 #: src/olympia/editors/templates/editors/home.html:36 src/olympia/editors/templates/editors/home.html:86
 msgid "Current waiting times:"
@@ -8036,9 +7743,6 @@ msgid "{0} add-on"
 msgid_plural "{0} add-ons"
 msgstr[0] "{0} bhreiseán"
 msgstr[1] "{0} bhreiseán"
-msgstr[2] "{0} bhreiseán"
-msgstr[3] "{0} mbreiseán"
-msgstr[4] "{0} breiseán"
 
 #: src/olympia/editors/templates/editors/home.html:45 src/olympia/editors/templates/editors/home.html:95
 #, python-format
@@ -8050,27 +7754,18 @@ msgid "Unlisted Full Review ({num})"
 msgid_plural "Unlisted Full Reviews ({num})"
 msgstr[0] ""
 msgstr[1] ""
-msgstr[2] ""
-msgstr[3] ""
-msgstr[4] ""
 
 #: src/olympia/editors/templates/editors/home.html:68
 msgid "Unlisted Pending Update ({num})"
 msgid_plural "Unlisted Pending Updates ({num})"
 msgstr[0] ""
 msgstr[1] ""
-msgstr[2] ""
-msgstr[3] ""
-msgstr[4] ""
 
 #: src/olympia/editors/templates/editors/home.html:75
 msgid "Unlisted Preliminary Review ({num})"
 msgid_plural "Unlisted Preliminary Reviews ({num})"
 msgstr[0] ""
 msgstr[1] ""
-msgstr[2] ""
-msgstr[3] ""
-msgstr[4] ""
 
 #: src/olympia/editors/templates/editors/home.html:109 src/olympia/editors/templates/editors/performance.html:37 src/olympia/editors/templates/editors/themes/home.html:54
 msgid "Total Reviews"
@@ -8094,9 +7789,6 @@ msgid "Moderated Review ({num})"
 msgid_plural "Moderated Reviews ({num})"
 msgstr[0] ""
 msgstr[1] ""
-msgstr[2] ""
-msgstr[3] ""
-msgstr[4] ""
 
 #: src/olympia/editors/templates/editors/leaderboard.html:3 src/olympia/editors/templates/editors/includes/reviewers_score_bar.html:56
 msgid "Reviewer Leaderboard"
@@ -8190,46 +7882,46 @@ msgstr "Cuardach Casta"
 msgid "clear search"
 msgstr "glan an cuardach"
 
-#: src/olympia/editors/templates/editors/queue.html:72 src/olympia/editors/templates/editors/queue.html:122
+#: src/olympia/editors/templates/editors/queue.html:78 src/olympia/editors/templates/editors/queue.html:128
 msgid "Process Reviews"
 msgstr "Próiseáil Léirmheasanna"
 
-#: src/olympia/editors/templates/editors/queue.html:80
+#: src/olympia/editors/templates/editors/queue.html:86
 msgid "Moderation actions:"
 msgstr ""
 
-#: src/olympia/editors/templates/editors/queue.html:90
+#: src/olympia/editors/templates/editors/queue.html:96
 #, python-format
 msgid "by %(user)s on %(date)s %(stars)s (%(locale)s)"
 msgstr "le %(user)s ar %(date)s %(stars)s (%(locale)s)"
 
-#: src/olympia/editors/templates/editors/queue.html:106
+#: src/olympia/editors/templates/editors/queue.html:112
 #, python-format
 msgid "<strong>%(reason)s</strong> <span class=\"light\">Flagged by %(user)s on %(date)s</span>"
 msgstr ""
 
-#: src/olympia/editors/templates/editors/queue.html:119
-msgid "All reviews have been moderated.  Good work!"
+#: src/olympia/editors/templates/editors/queue.html:125
+msgid "All reviews have been moderated. Good work!"
 msgstr ""
 
-#: src/olympia/editors/templates/editors/queue.html:161
+#: src/olympia/editors/templates/editors/queue.html:167
 msgid "Version Notes / Notes for Reviewer"
 msgstr ""
 
 # %1 is the queue mode
-#: src/olympia/editors/templates/editors/queue.html:169
+#: src/olympia/editors/templates/editors/queue.html:175
 msgid "There are currently no add-ons of this type to review."
 msgstr "Níl aon bhreiseáin den chineál seo le hiniúchadh faoi láthair."
 
-#: src/olympia/editors/templates/editors/queue.html:181 src/olympia/editors/templates/editors/themes/queue_list.html:85
+#: src/olympia/editors/templates/editors/queue.html:187 src/olympia/editors/templates/editors/themes/queue_list.html:85
 msgid "Helpful Links:"
 msgstr "Nascanna Cabhracha:"
 
-#: src/olympia/editors/templates/editors/queue.html:182
+#: src/olympia/editors/templates/editors/queue.html:188
 msgid "Add-on Policy"
 msgstr "Polasaí Breiseáin"
 
-#: src/olympia/editors/templates/editors/queue.html:184
+#: src/olympia/editors/templates/editors/queue.html:190
 msgid "Editors' Guide"
 msgstr "Lámhleabhar d'Eagarthóirí"
 
@@ -8292,10 +7984,7 @@ msgid "<strong>Warning!</strong> Another user was viewing this page before you."
 msgstr ""
 
 #: src/olympia/editors/templates/editors/review.html:237
-msgid ""
-"The whiteboard is the place to exchange information relevant to\n"
-"               this addon (whatever the version), between the developer and the\n"
-"               editor. This is visible and editable by both."
+msgid "The whiteboard is the place to exchange information relevant to this addon (whatever the version), between the developer and the editor. This is visible and editable by both."
 msgstr ""
 
 #: src/olympia/editors/templates/editors/review.html:241
@@ -8439,27 +8128,18 @@ msgid "{num} Pending Theme Review"
 msgid_plural "{num} Pending Theme Reviews"
 msgstr[0] ""
 msgstr[1] ""
-msgstr[2] ""
-msgstr[3] ""
-msgstr[4] ""
 
 #: src/olympia/editors/templates/editors/themes/home.html:27
 msgid "{num} Flagged Review"
 msgid_plural "{num} Flagged Reviews"
 msgstr[0] ""
 msgstr[1] ""
-msgstr[2] ""
-msgstr[3] ""
-msgstr[4] ""
 
 #: src/olympia/editors/templates/editors/themes/home.html:34
 msgid "{num} Update"
 msgid_plural "{num} Updates"
 msgstr[0] ""
 msgstr[1] ""
-msgstr[2] ""
-msgstr[3] ""
-msgstr[4] ""
 
 #: src/olympia/editors/templates/editors/themes/logs.html:4
 msgid "Theme Review Log"
@@ -8578,7 +8258,7 @@ msgstr ""
 msgid "Describe your reason for flagging"
 msgstr ""
 
-#: src/olympia/files/forms.py:88
+#: src/olympia/files/forms.py:90
 msgid "Cannot diff a version against itself"
 msgstr ""
 
@@ -8613,51 +8293,51 @@ msgstr "Tharla earráid agus comhad %s á rochtain. %s."
 msgid "There was an error accessing file %s."
 msgstr "Tharla earráid agus comhad %s á rochtain."
 
-#: src/olympia/files/utils.py:343
+#: src/olympia/files/utils.py:340
 msgid "Could not parse uploaded file."
 msgstr "Níorbh fhéidir an comhad uasluchtaithe a pharsáil."
 
-#: src/olympia/files/utils.py:380
+#: src/olympia/files/utils.py:377
 msgid "Invalid file name in archive: {0}"
 msgstr ""
 
-#: src/olympia/files/utils.py:388
+#: src/olympia/files/utils.py:385
 msgid "File exceeding size limit in archive: {0}"
 msgstr ""
 
-#: src/olympia/files/utils.py:439
+#: src/olympia/files/utils.py:436
 msgid "Invalid archive."
 msgstr "Cartlann neamhbhailí."
 
-#: src/olympia/files/utils.py:529 src/olympia/files/utils.py:532
+#: src/olympia/files/utils.py:526 src/olympia/files/utils.py:529
 msgid "Could not parse the manifest file."
 msgstr ""
 
-#: src/olympia/files/utils.py:551
+#: src/olympia/files/utils.py:548
 msgid "Could not find an add-on ID."
 msgstr ""
 
-#: src/olympia/files/utils.py:554
+#: src/olympia/files/utils.py:551
 msgid "Add-on ID must be 64 characters or less."
 msgstr ""
 
-#: src/olympia/files/utils.py:556
+#: src/olympia/files/utils.py:553
 msgid "Add-on ID doesn't match add-on."
 msgstr ""
 
-#: src/olympia/files/utils.py:564
+#: src/olympia/files/utils.py:561
 msgid "Duplicate add-on ID found."
 msgstr ""
 
-#: src/olympia/files/utils.py:567
+#: src/olympia/files/utils.py:564
 msgid "Version numbers should have fewer than 32 characters."
 msgstr ""
 
-#: src/olympia/files/utils.py:570
+#: src/olympia/files/utils.py:567
 msgid "Version numbers should only contain letters, numbers, and these punctuation characters: +*.-_."
 msgstr ""
 
-#: src/olympia/files/utils.py:587
+#: src/olympia/files/utils.py:584
 msgid "<em:type> doesn't match add-on"
 msgstr ""
 
@@ -8757,6 +8437,10 @@ msgstr ""
 #: src/olympia/files/templates/files/viewer.html:134
 msgid "Fetching file."
 msgstr "Comhad á fháil."
+
+#: src/olympia/legacy_api/views.py:255
+msgid "Not implemented yet."
+msgstr "Níl sé seo ar fáil fós."
 
 #: src/olympia/lib/constants.py:6
 msgid "United Arab Emirates Dirham"
@@ -9414,10 +9098,6 @@ msgstr ""
 msgid "Zimbabwe Dollar"
 msgstr ""
 
-#: src/olympia/lib/video/ffmpeg.py:112 src/olympia/lib/video/totem.py:81
-msgid "Videos must be in WebM."
-msgstr ""
-
 #: src/olympia/pages/templates/pages/about.lhtml:3 src/olympia/pages/templates/pages/about.lhtml:10
 msgid "About Mozilla Add-ons"
 msgstr ""
@@ -9429,7 +9109,7 @@ msgstr ""
 #: src/olympia/pages/templates/pages/about.lhtml:13
 msgid ""
 "addons.mozilla.org, commonly known as \"AMO\", is Mozilla's official site for add-ons to Mozilla software, such as Firefox, Thunderbird, and SeaMonkey. Add-ons let you add new features and change "
-"the way your browser or application works.  Take a look around and explore the thousands of ways to customize the way you do things online."
+"the way your browser or application works. Take a look around and explore the thousands of ways to customize the way you do things online."
 msgstr ""
 
 #: src/olympia/pages/templates/pages/about.lhtml:19
@@ -9776,7 +9456,7 @@ msgstr ""
 msgid ""
 "Yes. It's possible, but some of the functionality provided by these libraries are available through XPCOM, XUL, and JavaScript. In addition, authors should take care if libraries modify primitive "
 "object prototypes (String.prototype, Date.prototype, etc.) and/or define global functions (eg. the $ function). These are prone to cause conflict with other add-ons, in particular if different add-"
-"ons use different versions of libraries and so on. Developers need to be very, very careful with using them.  Mozilla does not offer documentation on using them to build add-ons."
+"ons use different versions of libraries and so on. Developers need to be very, very careful with using them. Mozilla does not offer documentation on using them to build add-ons."
 msgstr ""
 
 #: src/olympia/pages/templates/pages/dev_faq.html:165
@@ -9890,8 +9570,8 @@ msgstr ""
 #, python-format
 msgid ""
 "Yes. Many developers choose to host their own add-ons. Choosing to host your add-on on <a href=\"%(amo_url)s\">Mozilla's add-on site</a>, though, allows for much greater exposure to your add-on due "
-"to the large volume of visitors to the site.  <a href=\"%(md_url)s\">mozdev.org</a> offers free project hosting for Mozilla applications and extensions providing developers with tools to help "
-"manage source code, version control, bug tracking and documentation."
+"to the large volume of visitors to the site. <a href=\"%(md_url)s\">mozdev.org</a> offers free project hosting for Mozilla applications and extensions providing developers with tools to help manage "
+"source code, version control, bug tracking and documentation."
 msgstr ""
 
 #: src/olympia/pages/templates/pages/dev_faq.html:277
@@ -9939,7 +9619,7 @@ msgstr ""
 #: src/olympia/pages/templates/pages/dev_faq.html:314
 #, python-format
 msgid ""
-"Yes. Mozilla's <a href=\"%(p_url)s\">Add-on Policy</a> describes what is an acceptable submission. This policy is subject to change without notice.  In addition, the AMO editorial team uses the <a "
+"Yes. Mozilla's <a href=\"%(p_url)s\">Add-on Policy</a> describes what is an acceptable submission. This policy is subject to change without notice. In addition, the AMO editorial team uses the <a "
 "href=\"%(g_url)s\">Editors Reviewing Guide</a> to ensure that your add-on meets specific guidelines for functionality and security."
 msgstr ""
 
@@ -10056,7 +9736,7 @@ msgstr ""
 #: src/olympia/pages/templates/pages/dev_faq.html:434
 #, python-format
 msgid ""
-"This is why it's very important to read the <a href=\"%(g_url)s\">Editors Reviewing Guide</a> to ensure that your add-on is setup as expected.  It's also a good idea to read the blog post, <a href="
+"This is why it's very important to read the <a href=\"%(g_url)s\">Editors Reviewing Guide</a> to ensure that your add-on is setup as expected. It's also a good idea to read the blog post, <a href="
 "\"%(blog_url)s\">Successfully Getting your Add-on Reviewed</a> which provides excellent insight into ensuring a smooth review of your add-on."
 msgstr ""
 
@@ -10163,7 +9843,7 @@ msgstr ""
 
 #: src/olympia/pages/templates/pages/dev_faq.html:572
 msgid ""
-"Free Software Foundation provides short summaries of the key open source licenses, including whether the license qualifies as a free software license or a copyleft license.  Also includes a "
+"Free Software Foundation provides short summaries of the key open source licenses, including whether the license qualifies as a free software license or a copyleft license. Also includes a "
 "discussion of what constitutes a free software license or a copyleft license (e.g., a Copyleft license is a general method for making a program or other work free, and requiring all modified and "
 "extended versions of the program to be free as well.)"
 msgstr ""
@@ -10341,19 +10021,13 @@ msgid "Add-on Gallery"
 msgstr "Gailearaí na mBreiseán"
 
 #: src/olympia/pages/templates/pages/faq.html:171
-msgid ""
-"How do I choose between add-ons that seem to do the same\n"
-"    thing?"
+msgid "How do I choose between add-ons that seem to do the same thing?"
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:173
+#: src/olympia/pages/templates/pages/faq.html:172
 msgid ""
-"There are often several add-ons that have similar features. To\n"
-"    figure out which is right for you, read the entire description of the\n"
-"    add-on and view its screenshots. If there are still several in the running,\n"
-"    read through the add-on's ratings, user reviews, and statistics to see\n"
-"    which is most liked by other users. Remember that you can also just try\n"
-"    out both and see which you like better."
+"There are often several add-ons that have similar features. To figure out which is right for you, read the entire description of the add-on and view its screenshots. If there are still several in "
+"the running, read through the add-on's ratings, user reviews, and statistics to see which is most liked by other users. Remember that you can also just try out both and see which you like better."
 msgstr ""
 
 #: src/olympia/pages/templates/pages/faq.html:180
@@ -10394,80 +10068,67 @@ msgid "How much do add-ons cost to purchase?"
 msgstr ""
 
 #: src/olympia/pages/templates/pages/faq.html:207
-msgid ""
-"Add-ons hosted in our gallery are free unless clearly marked\n"
-"    otherwise."
+msgid "Add-ons hosted in our gallery are free unless clearly marked otherwise."
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:210
+#: src/olympia/pages/templates/pages/faq.html:209
 msgid "What does it mean when an add-on asks for contributions?"
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:211
+#: src/olympia/pages/templates/pages/faq.html:210
 msgid ""
-"Some add-on authors request users who enjoy an add-on to\n"
-"        contribute to its development by making a monetary contribution. These\n"
-"        contributions go directly to the developer unless a third party is\n"
-"        indicated, such as the non-profit Mozilla Foundation."
+"Some add-on authors request users who enjoy an add-on to contribute to its development by making a monetary contribution. These contributions go directly to the developer unless a third party is "
+"indicated, such as the non-profit Mozilla Foundation."
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:216
+#: src/olympia/pages/templates/pages/faq.html:215
 msgid "What are beta add-ons?"
 msgstr "Cad is Breiseán Béite ann?"
 
-#: src/olympia/pages/templates/pages/faq.html:218
+#: src/olympia/pages/templates/pages/faq.html:217
 msgid ""
-"Beta add-ons are unreviewed versions which represent the\n"
-"        latest work of an add-on author. While different authors have different\n"
-"        standards for beta code quality, you should assume that these add-ons\n"
-"        are less stable than the general add-on releases."
+"Beta add-ons are unreviewed versions which represent the latest work of an add-on author. While different authors have different standards for beta code quality, you should assume that these add-"
+"ons are less stable than the general add-on releases."
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:222
+#: src/olympia/pages/templates/pages/faq.html:221
 msgid ""
 "Please note that when you install an add-on from the \"Beta Version\" section of an add-on's listing, you will continue to receive updates for that add-on as they become available. Like the initial "
 "version you installed, all beta releases are unreviewed by Mozilla and may harm your computer."
 msgstr ""
 
+#: src/olympia/pages/templates/pages/faq.html:228
+msgid "What does it mean when an add-on is flagged as slow?"
+msgstr ""
+
 #: src/olympia/pages/templates/pages/faq.html:229
-msgid ""
-"What does it mean when an add-on is flagged as\n"
-"    slow?"
+msgid "Most add-ons load code and resources at the same time Firefox is starting up. In most cases the impact in start-up time is minimal, but some add-ons can cause a noticeable slowdown."
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:231
-msgid ""
-"Most add-ons load code and resources at the same time Firefox\n"
-"        is starting up. In most cases the impact in start-up time is minimal,\n"
-"        but some add-ons can cause a noticeable slowdown."
-msgstr ""
-
-#: src/olympia/pages/templates/pages/faq.html:236
+#: src/olympia/pages/templates/pages/faq.html:234
 msgid "How do I report an inappropriate or spam user review?"
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:237
+#: src/olympia/pages/templates/pages/faq.html:235
 msgid ""
-"To report a user review of an add-on, log in with your account\n"
-"    and visit the add-on's reviews page. Find the review you wish to report,\n"
-"    click \"Report this review\" and select a reason. Our editorial team will\n"
-"    investigate the review and take appropriate action."
+"To report a user review of an add-on, log in with your account and visit the add-on's reviews page. Find the review you wish to report, click \"Report this review\" and select a reason. Our "
+"editorial team will investigate the review and take appropriate action."
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:242
+#: src/olympia/pages/templates/pages/faq.html:240
 msgid "How do I report a bug or contact the Mozilla Add-ons team?"
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:243
+#: src/olympia/pages/templates/pages/faq.html:241
 #, python-format
 msgid "Please visit our <a href=\"%(contact_url)s\">Contact page</a>."
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:246
+#: src/olympia/pages/templates/pages/faq.html:244
 msgid "What is a Source Code License?"
 msgstr "Cad is Ceadúnas Cóid Fhoinsigh ann?"
 
-#: src/olympia/pages/templates/pages/faq.html:247
+#: src/olympia/pages/templates/pages/faq.html:245
 #, python-format
 msgid ""
 "The source code used to create an add-on is an exclusive copyright of the add-on author, unless otherwise declared in a source code license. Many add-ons on this site have <a href=\"%(url)s\" lang="
@@ -10475,60 +10136,60 @@ msgid ""
 "the GPL or BSD licenses instead of making up their own."
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:256
+#: src/olympia/pages/templates/pages/faq.html:254
 #, python-format
 msgid "Firefox and other Mozilla software are <a href=\"%(url)s\">open source</a>."
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:264
+#: src/olympia/pages/templates/pages/faq.html:262
 msgid "Collections and Favorites"
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:267
+#: src/olympia/pages/templates/pages/faq.html:265
 msgid "What is a collection?"
 msgstr "Cad is Bailiúchán ann?"
 
-#: src/olympia/pages/templates/pages/faq.html:268
+#: src/olympia/pages/templates/pages/faq.html:266
 msgid "Collections are groups of related add-ons created by users to share."
 msgstr "Is éard atá i mBailiúchán ná grúpa de bhreiseáin cosúil le chéile cruthaithe ag úsáideoirí."
 
-#: src/olympia/pages/templates/pages/faq.html:270
+#: src/olympia/pages/templates/pages/faq.html:268
 msgid "What is the My Favorites collection?"
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:271
+#: src/olympia/pages/templates/pages/faq.html:269
 msgid "Favorite add-ons are add-ons that you have bookmarked to easily get back to later. You can add an add-on to your favorites collection by clicking \"Add to favorites\" on its details page."
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:275 src/olympia/templates/menu_links.html:13 src/olympia/templates/impala/header_title.html:17
+#: src/olympia/pages/templates/pages/faq.html:273 src/olympia/templates/menu_links.html:13 src/olympia/templates/impala/header_title.html:17
 msgid "Mobile Add-ons"
 msgstr "Breiseáin Shoghluaiste"
 
-#: src/olympia/pages/templates/pages/faq.html:278
+#: src/olympia/pages/templates/pages/faq.html:276
 msgid "What are mobile add-ons?"
 msgstr "Cad is Breiseán Soghluaiste ann?"
 
-#: src/olympia/pages/templates/pages/faq.html:279
+#: src/olympia/pages/templates/pages/faq.html:277
 #, python-format
 msgid ""
 "Mobile add-ons work with <a href=\"%(mobile_url)s\">Firefox for Mobile</a> and add or modify functionality just like desktop add-ons. You can find add-ons that work with Firefox for Mobile in our "
 "<a href=\"%(gallery_url)s\">gallery</a>."
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:288
+#: src/olympia/pages/templates/pages/faq.html:286
 msgid "Developer Topics"
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:289
+#: src/olympia/pages/templates/pages/faq.html:287
 #, python-format
 msgid "Please see our <a href=\"%(faq_url)s\">Developer FAQ</a> and <a href=\"%(hub_url)s\">Developer Hub</a> for answers to add-on developer-related questions."
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:294
+#: src/olympia/pages/templates/pages/faq.html:292
 msgid "Still have questions?"
 msgstr "Ceisteanna agat orainn fós?"
 
-#: src/olympia/pages/templates/pages/faq.html:295
+#: src/olympia/pages/templates/pages/faq.html:293
 #, python-format
 msgid "For general Firefox support, visit our <a href=\"%(sumo_url)s\">support website</a>. For general add-on and website questions, visit our <a href=\"%(forum_url)s\">forum</a>."
 msgstr ""
@@ -10666,7 +10327,7 @@ msgstr ""
 
 #: src/olympia/pages/templates/pages/sunbird.html:29
 msgid ""
-"Development on the Sunbird project has halted and its final release was on March 30, 2010.  We've been proud to host Sunbird add-ons on this site but as the project is no longer maintained we have "
+"Development on the Sunbird project has halted and its final release was on March 30, 2010. We've been proud to host Sunbird add-ons on this site but as the project is no longer maintained we have "
 "disabled our support for the add-ons."
 msgstr ""
 
@@ -10744,7 +10405,7 @@ msgstr "Déan léirmheas ar {0}"
 #, python-format
 msgid ""
 "<h2>Keep these tips in mind:</h2> <ul> <li> Write like you're telling a friend about your experience with the add-on. Give specifics and helpful details, such as what features you liked and/or "
-"disliked, how easy to use it is, and any disadvantages it has.  Avoid generic language such as calling it \"Great\" or \"Bad\" unless you can give reasons why you believe this is so. </li> <li> "
+"disliked, how easy to use it is, and any disadvantages it has. Avoid generic language such as calling it \"Great\" or \"Bad\" unless you can give reasons why you believe this is so. </li> <li> "
 "Please do not post bug reports in reviews. We do not make your email address available to add-on developers and they may need to contact you to help resolve your issue. See the <a href=\"%(support)s"
 "\">support section</a> to find out where to get assistance for this add-on. </li> <li>Please keep reviews clean, avoid the use of improper language and do not post any personal information. </li> </"
 "ul> <p>Please read the <a href=\"%(guide)s\" target=\"_blank\">Review Guidelines</a> for more detail about user add-on reviews.</p>"
@@ -10792,9 +10453,6 @@ msgid "This user has a <a href=\"%(user_review_url)s\">previous review</a> of th
 msgid_plural "This user has <a href=\"%(user_review_url)s\">%(cnt)s previous reviews</a> of this add-on."
 msgstr[0] "Rinne an t-úsáideoir seo <a href=\"%(user_review_url)s\">léirmheas</a> ar an mbreiseán seo cheana."
 msgstr[1] "Rinne an t-úsáideoir seo <a href=\"%(user_review_url)s\">%(cnt)s léirmheas</a> ar an mbreiseán seo cheana."
-msgstr[2] "Rinne an t-úsáideoir seo <a href=\"%(user_review_url)s\">%(cnt)s léirmheas</a> ar an mbreiseán seo cheana."
-msgstr[3] "Rinne an t-úsáideoir seo <a href=\"%(user_review_url)s\">%(cnt)s léirmheas</a> ar an mbreiseán seo cheana."
-msgstr[4] "Rinne an t-úsáideoir seo <a href=\"%(user_review_url)s\">%(cnt)s léirmheas</a> ar an mbreiseán seo cheana."
 
 #: src/olympia/reviews/templates/reviews/review.html:62
 #, python-format
@@ -10841,9 +10499,6 @@ msgid "<b>{0}</b> review for this add-on"
 msgid_plural "<b>{0}</b> reviews for this add-on"
 msgstr[0] "<b>{0}</b> léirmheas ar an mbreiseán seo"
 msgstr[1] "<b>{0}</b> léirmheas ar an mbreiseán seo"
-msgstr[2] "<b>{0}</b> léirmheas ar an mbreiseán seo"
-msgstr[3] "<b>{0}</b> léirmheas ar an mbreiseán seo"
-msgstr[4] "<b>{0}</b> léirmheas ar an mbreiseán seo"
 
 #. {0} is a developer's name.
 #: src/olympia/reviews/templates/reviews/review_list.html:33
@@ -10856,9 +10511,6 @@ msgid "Review for %(addon)s by %(user)s"
 msgid_plural "Reviews for %(addon)s by %(user)s"
 msgstr[0] "Léirmheas ar %(addon)s le %(user)s"
 msgstr[1] "Léirmheasanna ar %(addon)s le %(user)s"
-msgstr[2] "Léirmheasanna ar %(addon)s le %(user)s"
-msgstr[3] "Léirmheasanna ar %(addon)s le %(user)s"
-msgstr[4] "Léirmheasanna ar %(addon)s le %(user)s"
 
 #: src/olympia/reviews/templates/reviews/review_list.html:42
 msgid "No reviews found."
@@ -10882,9 +10534,6 @@ msgid "{num} review"
 msgid_plural "{num} reviews"
 msgstr[0] "{num} léirmheas"
 msgstr[1] "{num} léirmheas"
-msgstr[2] "{num} léirmheas"
-msgstr[3] "{num} léirmheas"
-msgstr[4] "{num} léirmheas"
 
 #: src/olympia/reviews/templates/reviews/impala/reviews_rating.html:1
 msgid "Rated {0} out of 5 stars"
@@ -10912,9 +10561,6 @@ msgid "Average from {0} Rating"
 msgid_plural "Average from {0} Ratings"
 msgstr[0] "Meánrátáil (ó {0} rátáil)"
 msgstr[1] "Meánrátáil (ó {0} rátáil)"
-msgstr[2] "Meánrátáil (ó {0} rátáil)"
-msgstr[3] "Meánrátáil (ó {0} rátáil)"
-msgstr[4] "Meánrátáil (ó {0} rátáil)"
 
 #: src/olympia/reviews/templates/reviews/mobile/review_list.html:34
 #, python-format
@@ -10931,9 +10577,6 @@ msgid "See All Reviews"
 msgid_plural "See All %(cnt)s Reviews"
 msgstr[0] ""
 msgstr[1] ""
-msgstr[2] ""
-msgstr[3] ""
-msgstr[4] ""
 
 #: src/olympia/search/forms.py:11
 msgid "Most popular this week"
@@ -11014,16 +10657,16 @@ msgstr "Breiseáin {0}"
 
 #. L10n: {0} is an application, such as Firefox. This means "any version of
 #. Firefox."
-#: src/olympia/search/views.py:554
+#: src/olympia/search/views.py:547
 msgid "Any {0}"
 msgstr "{0} ar bith"
 
 #. L10n: "All Systems" means show everything regardless of platform.
-#: src/olympia/search/views.py:589
+#: src/olympia/search/views.py:582
 msgid "All Systems"
 msgstr "Gach Córas"
 
-#: src/olympia/search/views.py:600
+#: src/olympia/search/views.py:593
 msgid "All Tags"
 msgstr "Gach Clib"
 
@@ -11068,9 +10711,6 @@ msgid "<b>{0}</b> matching result"
 msgid_plural "<b>{0}</b> matching results"
 msgstr[0] "<b>{0}</b> toradh comhoiriúnach"
 msgstr[1] "<b>{0}</b> thoradh comhoiriúnach"
-msgstr[2] "<b>{0}</b> thoradh comhoiriúnach"
-msgstr[3] "<b>{0}</b> dtoradh comhoiriúnach"
-msgstr[4] "<b>{0}</b> toradh comhoiriúnach"
 
 #: src/olympia/search/templates/search/results.html:67
 msgid "Filter Results"
@@ -11093,9 +10733,6 @@ msgid "{0} post"
 msgid_plural "{0} posts"
 msgstr[0] "{0} phostáil"
 msgstr[1] "{0} phostáil"
-msgstr[2] "{0} phostáil"
-msgstr[3] "{0} bpostáil"
-msgstr[4] "{0} postáil"
 
 #: src/olympia/sharing/__init__.py:20
 msgid "Post to Facebook"
@@ -11106,9 +10743,6 @@ msgid "{0} Like"
 msgid_plural "{0} Likes"
 msgstr[0] ""
 msgstr[1] ""
-msgstr[2] ""
-msgstr[3] ""
-msgstr[4] ""
 
 #: src/olympia/sharing/__init__.py:30
 msgid "Tweet on Twitter"
@@ -11119,9 +10753,6 @@ msgid "{0} tweet"
 msgid_plural "{0} tweets"
 msgstr[0] "{0} ghiolc"
 msgstr[1] "{0} ghiolc"
-msgstr[2] "{0} ghiolc"
-msgstr[3] "{0} ngiolc"
-msgstr[4] "{0} giolc"
 
 #: src/olympia/sharing/__init__.py:40
 msgid "Share on g+"
@@ -11156,9 +10787,6 @@ msgid "{0} post on localservice1"
 msgid_plural "{0} posts on localservice1"
 msgstr[0] ""
 msgstr[1] ""
-msgstr[2] ""
-msgstr[3] ""
-msgstr[4] ""
 
 #. L10n: Only change if you have reason! wiki.mozilla.org/AMO:Localizers
 #: src/olympia/sharing/__init__.py:76
@@ -11181,9 +10809,6 @@ msgid "{0} post on localservice2"
 msgid_plural "{0} posts on localservice2"
 msgstr[0] ""
 msgstr[1] ""
-msgstr[2] ""
-msgstr[3] ""
-msgstr[4] ""
 
 #. L10n: Only change if you have reason! wiki.mozilla.org/AMO:Localizers
 #: src/olympia/sharing/__init__.py:91
@@ -11206,9 +10831,6 @@ msgid "{0} post on localservice3"
 msgid_plural "{0} posts on localservice3"
 msgstr[0] ""
 msgstr[1] ""
-msgstr[2] ""
-msgstr[3] ""
-msgstr[4] ""
 
 #: src/olympia/sharing/templates/sharing/sharing_widget.html:2
 msgid "Share this Add-on"
@@ -11218,31 +10840,31 @@ msgstr "Comhroinn an Breiseán seo"
 msgid "Share this Collection"
 msgstr "Comhroinn an Bailiúchán seo"
 
-#: src/olympia/signing/views.py:30 src/olympia/templates/base.html:75 src/olympia/templates/impala/base.html:115
+#: src/olympia/signing/views.py:33 src/olympia/templates/base.html:71 src/olympia/templates/impala/base.html:112
 msgid "Some features are temporarily disabled while we perform website maintenance. We'll be back to full capacity shortly."
 msgstr ""
 
-#: src/olympia/signing/views.py:53
+#: src/olympia/signing/views.py:56
 msgid "Could not find add-on with id \"{}\"."
 msgstr ""
 
-#: src/olympia/signing/views.py:67
+#: src/olympia/signing/views.py:70
 msgid "You do not own this addon."
 msgstr ""
 
-#: src/olympia/signing/views.py:82
+#: src/olympia/signing/views.py:87
 msgid "Missing \"upload\" key in multipart file data."
 msgstr ""
 
-#: src/olympia/signing/views.py:96
+#: src/olympia/signing/views.py:101
 msgid "Version does not match the manifest file."
 msgstr ""
 
-#: src/olympia/signing/views.py:100
+#: src/olympia/signing/views.py:105
 msgid "Version already exists."
 msgstr ""
 
-#: src/olympia/signing/views.py:136
+#: src/olympia/signing/views.py:141
 msgid "No uploaded file for that addon and version."
 msgstr ""
 
@@ -11355,90 +10977,90 @@ msgstr "{0} :: Clár na Staitisticí"
 msgid "Statistics Dashboard :: Add-ons for {0}"
 msgstr "Clár na Staitisticí :: Breiseáin {0}"
 
-#: src/olympia/stats/templates/stats/stats.html:30
-msgid "Controls:"
-msgstr "Rialtáin:"
-
-#: src/olympia/stats/templates/stats/stats.html:33
-msgid "reset zoom"
-msgstr ""
-
-#: src/olympia/stats/templates/stats/stats.html:40
-msgid "Group by:"
-msgstr "Grúpáil de réir:"
-
-#: src/olympia/stats/templates/stats/stats.html:42
-msgid "day"
-msgstr "lá"
-
-#: src/olympia/stats/templates/stats/stats.html:45
-msgid "week"
-msgstr "seachtain"
-
-#: src/olympia/stats/templates/stats/stats.html:48
-msgid "month"
-msgstr "mí"
-
-#: src/olympia/stats/templates/stats/stats.html:54
-msgid "For last:"
-msgstr "Le déanaí:"
-
-#: src/olympia/stats/templates/stats/stats.html:57
-msgid "7 days"
-msgstr "7 lá"
-
-#: src/olympia/stats/templates/stats/stats.html:60
-msgid "30 days"
-msgstr "30 lá"
-
-#: src/olympia/stats/templates/stats/stats.html:63
-msgid "90 days"
-msgstr "90 lá"
-
-#: src/olympia/stats/templates/stats/stats.html:66
-msgid "365 days"
-msgstr "365 lá"
-
-#: src/olympia/stats/templates/stats/stats.html:69
-msgid "Custom..."
-msgstr "Saincheap..."
-
 # %1 is the name of a collection
 #. {0} is an add-on name
-#: src/olympia/stats/templates/stats/stats.html:88 src/olympia/stats/templates/stats/stats.html:91
+#: src/olympia/stats/templates/stats/stats.html:44 src/olympia/stats/templates/stats/stats.html:47
 msgid "Statistics for {0}"
 msgstr "Staitisticí le haghaidh {0}"
 
-#: src/olympia/stats/templates/stats/stats.html:94
+#: src/olympia/stats/templates/stats/stats.html:50
 msgid "Statistics Dashboard"
 msgstr "Clár na Staitisticí"
 
-#: src/olympia/stats/templates/stats/stats.html:104
+#: src/olympia/stats/templates/stats/stats.html:57
+msgid "Controls:"
+msgstr "Rialtáin:"
+
+#: src/olympia/stats/templates/stats/stats.html:60
+msgid "reset zoom"
+msgstr ""
+
+#: src/olympia/stats/templates/stats/stats.html:67
+msgid "Group by:"
+msgstr "Grúpáil de réir:"
+
+#: src/olympia/stats/templates/stats/stats.html:69
+msgid "day"
+msgstr "lá"
+
+#: src/olympia/stats/templates/stats/stats.html:72
+msgid "week"
+msgstr "seachtain"
+
+#: src/olympia/stats/templates/stats/stats.html:75
+msgid "month"
+msgstr "mí"
+
+#: src/olympia/stats/templates/stats/stats.html:81
+msgid "For last:"
+msgstr "Le déanaí:"
+
+#: src/olympia/stats/templates/stats/stats.html:84
+msgid "7 days"
+msgstr "7 lá"
+
+#: src/olympia/stats/templates/stats/stats.html:87
+msgid "30 days"
+msgstr "30 lá"
+
+#: src/olympia/stats/templates/stats/stats.html:90
+msgid "90 days"
+msgstr "90 lá"
+
+#: src/olympia/stats/templates/stats/stats.html:93
+msgid "365 days"
+msgstr "365 lá"
+
+#: src/olympia/stats/templates/stats/stats.html:96
+msgid "Custom..."
+msgstr "Saincheap..."
+
+#: src/olympia/stats/templates/stats/stats.html:106
 msgid "Statistics processing is currently disabled, so recent data is unavailable. The statistics are still being collected and this page will be updated soon with the missing data."
 msgstr ""
 
-#: src/olympia/stats/templates/stats/stats.html:110
+#: src/olympia/stats/templates/stats/stats.html:112
 msgid "Loading the latest data&hellip;"
 msgstr "Sonraí is déanaí á luchtú&hellip;"
 
-#: src/olympia/stats/templates/stats/stats.html:142 src/olympia/stats/templates/stats/reports/overview.html:25 src/olympia/stats/templates/stats/reports/overview.html:37
+#: src/olympia/stats/templates/stats/stats.html:144 src/olympia/stats/templates/stats/reports/overview.html:25 src/olympia/stats/templates/stats/reports/overview.html:37
 #: src/olympia/stats/templates/stats/reports/overview.html:49
 msgid "No data available."
 msgstr "Níl aon sonraí ar fáil."
 
-#: src/olympia/stats/templates/stats/stats.html:177
+#: src/olympia/stats/templates/stats/stats.html:179
 msgid "This dashboard is currently <b>public</b>."
 msgstr "Tá an painéal seo <b>poiblí</b> faoi láthair."
 
-#: src/olympia/stats/templates/stats/stats.html:179
+#: src/olympia/stats/templates/stats/stats.html:181
 msgid "Contribution stats are currently <b>private</b>."
 msgstr ""
 
-#: src/olympia/stats/templates/stats/stats.html:182
+#: src/olympia/stats/templates/stats/stats.html:184
 msgid "This dashboard is currently <b>private</b>."
 msgstr "Tá an painéal seo <b>príobháideach</b> faoi láthair."
 
-#: src/olympia/stats/templates/stats/stats.html:185
+#: src/olympia/stats/templates/stats/stats.html:187
 msgid "Change settings."
 msgstr ""
 
@@ -11590,16 +11212,6 @@ msgstr ""
 msgid "Application versions by Date"
 msgstr "Leaganacha an fheidhmchláir de réir Dáta"
 
-# {0} is a number
-#: src/olympia/tags/templates/tags/top_cloud.html:4
-msgid "Top {0} Tags"
-msgstr "Na {0} clib is coitianta"
-
-#. {0} is the current application name
-#: src/olympia/tags/templates/tags/top_cloud.html:14
-msgid "{0} Top Tags"
-msgstr "Clibeanna is coitianta: {0}"
-
 #: src/olympia/templates/amo_footer.html:6 src/olympia/templates/includes/lang_switcher.html:2
 msgid "Other languages"
 msgstr "Teangacha eile"
@@ -11608,11 +11220,11 @@ msgstr "Teangacha eile"
 msgid "Mozilla Add-ons"
 msgstr "Breiseáin Mozilla"
 
-#: src/olympia/templates/base.html:91 src/olympia/templates/impala/base.html:81
+#: src/olympia/templates/base.html:89 src/olympia/templates/impala/base.html:78
 msgid "Find add-ons for other applications"
 msgstr "Aimsigh breiseáin le haghaidh feidhmchlár eile"
 
-#: src/olympia/templates/base.html:92 src/olympia/templates/impala/base.html:81
+#: src/olympia/templates/base.html:90 src/olympia/templates/impala/base.html:78
 msgid "Other Applications"
 msgstr "Feidhmchláir Eile"
 
@@ -11637,7 +11249,7 @@ msgid "View Mobile Site"
 msgstr "Suíomh Soghluaiste"
 
 #: src/olympia/templates/copyright.html:7
-msgid "Site Status "
+msgid "Site Status"
 msgstr ""
 
 #: src/olympia/templates/footer.html:3
@@ -11737,35 +11349,35 @@ msgstr "Fáilte romhat a {0}"
 msgid "<a href=\"%(reg)s\">Register</a> or <a href=\"%(login)s\">Log in</a>"
 msgstr "<a href=\"%(reg)s\">Cláraigh</a> nó <a href=\"%(login)s\">Logáil isteach</a>"
 
-#: src/olympia/templates/impala/base.html:126
+#: src/olympia/templates/impala/base.html:123
 #, python-format
 msgid "To try the thousands of add-ons available here, download <a href=\"%(url)s\">Mozilla Firefox</a>, a fast, free way to surf the Web!"
 msgstr "Chun triail a bhaint as na mílte breiseán ar fáil anseo, íosluchtaigh <a href=\"%(url)s\">Mozilla Firefox</a>, bealach tapa, saor in aisce leis an nGréasán a bhrabhsáil!"
 
-#: src/olympia/templates/impala/base.html:138
+#: src/olympia/templates/impala/base.html:135
 #, python-format
 msgid "Add-ons is switching to Firefox Accounts for login. <a href=\"%(url)s\" class=\"fxa-login\">Sign in now to transfer your account.</a>"
 msgstr ""
 
 #. {0} is an application, such as Firefox.
-#: src/olympia/templates/impala/base.html:148
+#: src/olympia/templates/impala/base.html:145
 msgid "Welcome to {0} Add-ons."
 msgstr "Fáilte go Breiseáin {0}."
 
-#: src/olympia/templates/impala/base.html:151
+#: src/olympia/templates/impala/base.html:148
 msgid "Choose from thousands of extra features and styles to make Firefox your own."
 msgstr ""
 
-#: src/olympia/templates/impala/base.html:156
+#: src/olympia/templates/impala/base.html:153
 #, python-format
 msgid "Add extra features and styles to make %(app)s your own."
 msgstr ""
 
-#: src/olympia/templates/impala/base.html:164
+#: src/olympia/templates/impala/base.html:161
 msgid "On the go?"
 msgstr "Sa siúl?"
 
-#: src/olympia/templates/impala/base.html:166
+#: src/olympia/templates/impala/base.html:163
 msgid "Check out our <a class=\"mobile-link\" href=\"#\">Mobile Add-ons site</a>."
 msgstr "Déan cuairt ar ár <a class=\"mobile-link\" href=\"#\">suíomh Breiseán Soghluaiste</a>."
 
@@ -11989,19 +11601,19 @@ msgstr "Níl aon úsáideoir leis an seoladh ríomhphoist sin."
 
 #. L10n: {id} will be something like "13ad6a", just a random number
 #. to differentiate this user from other anonymous users.
-#: src/olympia/users/models.py:353
+#: src/olympia/users/models.py:362
 msgid "Anonymous user {id}"
 msgstr ""
 
-#: src/olympia/users/models.py:410
+#: src/olympia/users/models.py:419
 msgid "Your account has been restricted"
 msgstr ""
 
-#: src/olympia/users/models.py:480
+#: src/olympia/users/models.py:489
 msgid "Please confirm your email address"
 msgstr "Deimhnigh do sheoladh ríomhphoist le do thoil"
 
-#: src/olympia/users/models.py:506
+#: src/olympia/users/models.py:515
 msgid "My Mobile Add-ons"
 msgstr "Mo Chuid Breiseán Soghluaiste"
 
@@ -12279,7 +11891,7 @@ msgstr "Focal Faire"
 
 #: src/olympia/users/templates/users/edit.html:70
 #, python-format
-msgid "Change your password.  If you forgot your password, you can <a href=\"%(reset_url)s\">use the reset form</a>."
+msgid "Change your password. If you forgot your password, you can <a href=\"%(reset_url)s\">use the reset form</a>."
 msgstr ""
 
 #: src/olympia/users/templates/users/edit.html:76
@@ -12299,7 +11911,7 @@ msgid "Profile"
 msgstr "Próifíl"
 
 #: src/olympia/users/templates/users/edit.html:100
-msgid "Give us a bit more information about yourself.  All these fields are optional, but they'll help other users get to know you better."
+msgid "Give us a bit more information about yourself. All these fields are optional, but they'll help other users get to know you better."
 msgstr ""
 
 #: src/olympia/users/templates/users/edit.html:124
@@ -12519,7 +12131,7 @@ msgid "Confirm password"
 msgstr "Dearbhaigh an focal faire"
 
 #: src/olympia/users/templates/users/pwreset_confirm.html:47
-msgid "The password reset link was invalid, possibly because it has already been used.  Please request a new password reset."
+msgid "The password reset link was invalid, possibly because it has already been used. Please request a new password reset."
 msgstr ""
 
 #: src/olympia/users/templates/users/pwreset_request.html:15
@@ -12705,7 +12317,7 @@ msgstr "Ní rabhamar in ann thú a dhíliostáil"
 
 #: src/olympia/users/templates/users/unsubscribe.html:30
 #, python-format
-msgid "Unfortunately, we weren't able to unsubscribe you.  The link you clicked is invalid. However, you can unsubscribe still unsubscribe on your <a href=\"%(edit_url)s\">edit profile page</a>."
+msgid "Unfortunately, we weren't able to unsubscribe you. The link you clicked is invalid. However, you can unsubscribe still unsubscribe on your <a href=\"%(edit_url)s\">edit profile page</a>."
 msgstr ""
 
 #: src/olympia/users/templates/users/vcard.html:2
@@ -12738,9 +12350,6 @@ msgid "%(num)s theme"
 msgid_plural "%(num)s themes"
 msgstr[0] ""
 msgstr[1] ""
-msgstr[2] ""
-msgstr[3] ""
-msgstr[4] ""
 
 #: src/olympia/users/templates/users/vcard.html:62
 #, python-format
@@ -12748,9 +12357,6 @@ msgid "%(num)s add-on"
 msgid_plural "%(num)s add-ons"
 msgstr[0] "%(num)s bhreiseán"
 msgstr[1] "%(num)s bhreiseán"
-msgstr[2] "%(num)s bhreiseán"
-msgstr[3] "%(num)s mbreiseán"
-msgstr[4] "%(num)s breiseán"
 
 #: src/olympia/users/templates/users/vcard.html:75
 msgid "Average rating of developer's add-ons"
@@ -12765,15 +12371,15 @@ msgstr "Stair na Leaganacha %s"
 msgid "Version History with Changelogs"
 msgstr "Stair na Leaganacha le Logchomhaid Athruithe"
 
-#: src/olympia/versions/models.py:314
+#: src/olympia/versions/models.py:313
 msgid "Add-on uses binary components."
 msgstr "Úsáideann an breiseán seo comhpháirteanna dénártha."
 
-#: src/olympia/versions/models.py:317
+#: src/olympia/versions/models.py:316
 msgid "Add-on has opted into strict compatibility checking."
 msgstr ""
 
-#: src/olympia/versions/models.py:715
+#: src/olympia/versions/models.py:711
 msgid "{app} {min} and later"
 msgstr "{app} {min} agus níos déanaí"
 
@@ -12812,9 +12418,6 @@ msgid "<b>{0}</b> version"
 msgid_plural "<b>{0}</b> versions"
 msgstr[0] "<b>{0}</b> leagan"
 msgstr[1] "<b>{0}</b> leagan"
-msgstr[2] "<b>{0}</b> leagan"
-msgstr[3] "<b>{0}</b> leagan"
-msgstr[4] "<b>{0}</b> leagan"
 
 #: src/olympia/versions/templates/versions/version_list.html:35 src/olympia/versions/templates/versions/mobile/version_list.html:14
 msgid "Be careful with old versions!"
@@ -12852,4 +12455,8 @@ msgstr "Ríomhphost nuair a bheidh sé críochnaithe"
 
 #: src/olympia/zadmin/forms.py:105
 msgid "Log emails instead of sending"
+msgstr ""
+
+#: src/olympia/zadmin/forms.py:215
+msgid "Deleted versions can`t be changed."
 msgstr ""

--- a/locale/ga_IE/LC_MESSAGES/djangojs.po
+++ b/locale/ga_IE/LC_MESSAGES/djangojs.po
@@ -1,1257 +1,1235 @@
-
 msgid ""
 msgstr ""
 "Project-Id-Version: AMO-JS 0.1\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2016-02-24 21:23+0000\n"
+"POT-Creation-Date: 2016-04-18 15:47+0000\n"
 "PO-Revision-Date: 2008-04-08 00:00-0600\n"
 "Last-Translator: Kevin Scannell <kscanne@gmail.com>\n"
 "Language-Team: Irish <gaeilge-gnulinux@lists.sourceforge.net>\n"
+"Language: ga\n"
 "MIME-Version: 1.0\n"
-"Content-Type: text/plain; charset=utf-8\n"
+"Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Generated-By: Babel 2.2.0\n"
 
-#: static/js/common/ratingwidget.js:31
+#: static/js/common-all.js:1426 static/js/impala-all.js:1511 static/js/zamboni/discovery-all.js:12598 static/js/zamboni/init.js:28 static/js/zamboni/mobile-all.js:14945
+msgid "This feature is temporarily disabled while we perform website maintenance. Please check back a little later."
+msgstr "Níl an ghné seo ar fáil faoi láthair agus cúram á dhéanamh ar an suíomh.  Tar ar ais chugainn ar ball."
+
+#. L10n: {0} is an app name like Firefox.
+#: static/js/common-all.js:1837 static/js/impala-all.js:1922 static/js/zamboni/buttons.js:73 static/js/zamboni/discovery-all.js:13108
+msgid "Accept and Install"
+msgstr "Glac Leis agus Suiteáil"
+
+#: static/js/common-all.js:1837 static/js/impala-all.js:1922 static/js/zamboni/buttons.js:73 static/js/zamboni/discovery-all.js:13108
+msgid "Add to {0}"
+msgstr "Cuir le {0}"
+
+#: static/js/common-all.js:1842 static/js/impala-all.js:1927 static/js/zamboni/buttons.js:78 static/js/zamboni/discovery-all.js:13113
+msgid "Download Now"
+msgstr "Íosluchtaigh Anois"
+
+#: static/js/common-all.js:1883 static/js/impala-all.js:1968 static/js/zamboni/buttons.js:119 static/js/zamboni/discovery-all.js:13154
+msgid "Add-on has not been updated to support default-to-compatible."
+msgstr ""
+
+#: static/js/common-all.js:1888 static/js/impala-all.js:1973 static/js/zamboni/buttons.js:124 static/js/zamboni/discovery-all.js:13159
+msgid "You need to be using Firefox 10.0 or higher."
+msgstr ""
+
+#: static/js/common-all.js:1900 static/js/impala-all.js:1985 static/js/zamboni/buttons.js:136 static/js/zamboni/discovery-all.js:13171
+msgid "Mozilla has marked this version as incompatible with your Firefox version."
+msgstr ""
+
+#. L10n: {0} is an platform like Windows or Linux.
+#: static/js/common-all.js:1981 static/js/impala-all.js:2066 static/js/zamboni/buttons.js:217 static/js/zamboni/discovery-all.js:13252
+msgid "Install for {0} anyway"
+msgstr "Suiteáil ar {0} mar sin féin"
+
+#: static/js/common-all.js:1981 static/js/impala-all.js:2066 static/js/zamboni/buttons.js:217 static/js/zamboni/discovery-all.js:13252
+msgid "Download for {0} anyway"
+msgstr "Íosluchtaigh le haghaidh {0} mar sin féin"
+
+#: static/js/common-all.js:2038 static/js/impala-all.js:2123 static/js/zamboni/buttons.js:274 static/js/zamboni/discovery-all.js:13309
+msgid "Not available for your platform"
+msgstr "Níl sé ar fáil ar d'ardán"
+
+#. L10n: {0} is an app name, {1} is the app version.
+#: static/js/common-all.js:2049 static/js/common-all.js:2086 static/js/impala-all.js:2134 static/js/impala-all.js:2171 static/js/zamboni/buttons.js:286 static/js/zamboni/buttons.js:324
+#: static/js/zamboni/discovery-all.js:13320 static/js/zamboni/discovery-all.js:13357
+msgid "Not available for {0} {1}"
+msgstr "Níl sé ar fáil le haghaidh {0} {1}"
+
+#: static/js/common-all.js:2112 static/js/impala-all.js:2197 static/js/zamboni/buttons.js:351 static/js/zamboni/discovery-all.js:13383
+msgid "Works with {app} {min} - {max}"
+msgstr "Feidhmíonn sé le {app} {min} - {max}"
+
+#: static/js/common-all.js:2114 static/js/impala-all.js:2199 static/js/zamboni/buttons.js:353 static/js/zamboni/discovery-all.js:13385
+msgid "View other versions"
+msgstr "Féach ar leaganacha eile"
+
+#: static/js/common-all.js:2162 static/js/impala-all.js:2247 static/js/zamboni/buttons.js:401 static/js/zamboni/discovery-all.js:13433
+msgid "Only with Firefox — Get Firefox Now!"
+msgstr ""
+
+#: static/js/common-all.js:2278 static/js/impala-all.js:2363 static/js/zamboni/buttons.js:517 static/js/zamboni/discovery-all.js:13549 static/js/zamboni/mobile-all.js:15177
+#: static/js/zamboni/mobile/buttons.js:43
+msgid "Sorry, you need a Mozilla-based browser (such as Firefox) to install a search plugin."
+msgstr "Tá brabhsálaí de chuid Mozilla (mar shampla Firefox) de dhíth ort chun breiseán cuardaigh a shuiteáil."
+
+#: static/js/common-all.js:9088 static/js/impala-all.js:9649 static/js/zamboni/global.js:410
+msgid "Loading..."
+msgstr "Á Luchtú..."
+
+#. L10n: {0} is the number of characters left.
+#: static/js/common-all.js:9152 static/js/impala-all.js:9713 static/js/zamboni/global.js:474
+msgid "<b>{0}</b> character left."
+msgid_plural "<b>{0}</b> characters left."
+msgstr[0] "<b>{0}</b> charachtar fágtha."
+msgstr[1] "<b>{0}</b> charachtar fágtha."
+
+#: static/js/common-all.js:9589 static/js/common-min.js:6 static/js/impala-all.js:10052 static/js/impala-min.js:6 static/js/common/ratingwidget.js:31 static/js/zamboni/mobile-all.js:16123
+#: static/js/zamboni/mobile-min.js:6
 msgid "{0} star"
 msgid_plural "{0} stars"
 msgstr[0] "{0} réiltín"
 msgstr[1] "{0} réiltín"
-msgstr[2] "{0} réiltín"
-msgstr[3] "{0} réiltín"
-msgstr[4] "{0} réiltín"
 
-#: static/js/common/upload-addon.js:41 static/js/common/upload-image.js:128
+#: static/js/common-all.js:9676 static/js/common-min.js:6 static/js/impala-all.js:10139 static/js/impala-min.js:6 static/js/zamboni/l10n.js:45
+msgid "Remove this localization"
+msgstr "Bain an logánú seo"
+
+#: static/js/common-all.js:10193 static/js/common-min.js:6 static/js/impala-all.js:10674 static/js/impala-min.js:6 static/js/zamboni/discovery-all.js:13678
+msgid "close"
+msgstr ""
+
+#: static/js/common-all.js:10860 static/js/common-min.js:6 static/js/impala-all.js:11481 static/js/impala-min.js:6 static/js/impala/reviews.js:23 static/js/zamboni/reviews.js:18
+msgid "Flagged for review"
+msgstr ""
+
+#: static/js/common-all.js:10876 static/js/common-min.js:6 static/js/impala-all.js:11498 static/js/impala-min.js:6 static/js/impala/reviews.js:40 static/js/zamboni/reviews.js:34
+msgid "Your input is required"
+msgstr ""
+
+#: static/js/common-all.js:10945 static/js/common-min.js:6 static/js/impala-all.js:11610 static/js/impala-min.js:7 static/js/impala/reviews.js:152 static/js/zamboni/reviews.js:103
+msgid "Marked for deletion"
+msgstr ""
+
+#: static/js/common-all.js:11573 static/js/common-min.js:7 static/js/impala-all.js:13809 static/js/impala-min.js:8 static/js/zamboni/collections.js:229
+msgid "Adding to Favorites&hellip;"
+msgstr "Á chur leis na Ceanáin&hellip;"
+
+#: static/js/common-all.js:11576 static/js/common-min.js:7 static/js/impala-all.js:13812 static/js/impala-min.js:8 static/js/zamboni/collections.js:232
+msgid "Removing Favorite&hellip;"
+msgstr "Ceanán á bhaint&hellip;"
+
+#: static/js/common-all.js:11579 static/js/common-min.js:7 static/js/impala-all.js:13815 static/js/impala-min.js:8 static/js/zamboni/collections.js:235
+msgid "Add to Favorites"
+msgstr "Cuir leis na Ceanáin"
+
+#: static/js/common-all.js:11582 static/js/common-min.js:7 static/js/impala-all.js:13818 static/js/impala-min.js:8 static/js/zamboni/collections.js:238
+msgid "Remove from Favorites"
+msgstr "Bain ó na Ceanáin"
+
+#: static/js/common-all.js:11647 static/js/common-min.js:7 static/js/impala-all.js:13883 static/js/impala-min.js:8 static/js/zamboni/collections.js:303
+msgid "Pending"
+msgstr "Ar Feitheamh"
+
+#: static/js/common-all.js:11648 static/js/common-min.js:7 static/js/impala-all.js:13884 static/js/impala-min.js:8 static/js/zamboni/collections.js:304
+msgid "Add a comment"
+msgstr "Cuir nóta leis"
+
+#: static/js/common-all.js:11648 static/js/common-min.js:7 static/js/impala-all.js:13884 static/js/impala-min.js:8 static/js/zamboni/collections.js:304
+msgid "Comment"
+msgstr "Nóta"
+
+#: static/js/common-all.js:11649 static/js/common-min.js:7 static/js/impala-all.js:13885 static/js/impala-min.js:8 static/js/zamboni/collections.js:305
+msgid "Remove this add-on from the collection"
+msgstr "Bain an breiseán seo ón bhailiúchán"
+
+#: static/js/common-all.js:11649 static/js/common-all.js:11678 static/js/common-min.js:7 static/js/impala-all.js:13885 static/js/impala-all.js:13914 static/js/impala-min.js:8
+#: static/js/zamboni/collections.js:305 static/js/zamboni/collections.js:334
+msgid "Remove"
+msgstr "Bain"
+
+#: static/js/common-all.js:11678 static/js/common-min.js:7 static/js/impala-all.js:13914 static/js/impala-min.js:8 static/js/zamboni/collections.js:334
+msgid "Remove this user as a contributor"
+msgstr "Bain an t-úsáideoir seo ó na rannpháirtithe"
+
+#: static/js/common-all.js:11690 static/js/common-min.js:7 static/js/impala-all.js:13926 static/js/impala-min.js:8 static/js/zamboni/collections.js:346
+msgid "An email address is required."
+msgstr ""
+
+#: static/js/common-all.js:11708 static/js/common-min.js:7 static/js/impala-all.js:13944 static/js/impala-min.js:8 static/js/zamboni/collections.js:364
+msgid "You cannot add yourself as a contributor."
+msgstr ""
+
+#: static/js/common-all.js:11710 static/js/common-min.js:7 static/js/impala-all.js:13946 static/js/impala-min.js:8 static/js/zamboni/collections.js:366
+msgid "You have already added that user."
+msgstr "Tá an t-úsáideoir sin ann cheana."
+
+#: static/js/common-all.js:11917 static/js/common-min.js:7 static/js/impala-all.js:14153 static/js/impala-min.js:8 static/js/zamboni/collections.js:573
+msgid "Add to favorites"
+msgstr "Cuir leis na ceanáin"
+
+#: static/js/common-all.js:11921 static/js/common-min.js:7 static/js/impala-all.js:14157 static/js/impala-min.js:8 static/js/zamboni/collections.js:577
+msgid "Remove from favorites"
+msgstr "Bain ó na ceanáin"
+
+#: static/js/common-all.js:11939 static/js/common-min.js:7 static/js/impala-all.js:14175 static/js/impala-all.js:14233 static/js/impala-min.js:8 static/js/impala/collections.js:10
+#: static/js/zamboni/collections.js:595
+msgid "Follow this Collection"
+msgstr "Lean an Bailiúchán seo"
+
+#: static/js/common-all.js:11948 static/js/common-min.js:7 static/js/impala-all.js:14184 static/js/impala-min.js:8 static/js/zamboni/collections.js:604
+msgid "Stop following"
+msgstr "Ná bí dá leanúint"
+
+#: static/js/common-all.js:12096 static/js/common-min.js:7 static/js/zamboni/password-strength.js:20
+msgid "Password strength:"
+msgstr "Neart an fhocail fhaire:"
+
+#: static/js/common-all.js:12102 static/js/common-min.js:7 static/js/zamboni/password-strength.js:26
+msgid "At least {0} character left."
+msgid_plural "At least {0} characters left."
+msgstr[0] "{0} charachtar fágtha ar a laghad."
+msgstr[1] "{0} charachtar fágtha ar a laghad."
+
+#: static/js/common-all.js:12286 static/js/common-min.js:7 static/js/impala-all.js:14632 static/js/impala-min.js:8 static/js/impala/suggestions.js:39
+msgid "Search themes for <b>{0}</b>"
+msgstr ""
+
+#: static/js/common-all.js:12288 static/js/common-min.js:7 static/js/impala-all.js:14634 static/js/impala-min.js:8 static/js/impala/suggestions.js:41
+msgid "Search apps for <b>{0}</b>"
+msgstr ""
+
+#: static/js/common-all.js:12290 static/js/common-min.js:7 static/js/impala-all.js:14636 static/js/impala-min.js:8 static/js/impala/suggestions.js:43
+msgid "Search add-ons for <b>{0}</b>"
+msgstr ""
+
+#: static/js/common-all.js:12521 static/js/common-min.js:7 static/js/impala-all.js:14867 static/js/impala-min.js:8 static/js/impala/site_suggestions.js:46
+msgid "Category"
+msgstr "Catagóir"
+
+#. L10n: {0} is an app name.
+#: static/js/impala-all.js:11632 static/js/impala-min.js:7 static/js/impala/listing.js:11 static/js/zamboni/themes.js:13
+msgid "This theme is incompatible with your version of {0}"
+msgstr "Níl an téama seo comhoiriúnach do do leagan de {0}"
+
+#: static/js/impala-all.js:12146 static/js/impala-all.js:14331 static/js/impala-min.js:7 static/js/impala-min.js:8 static/js/common/upload-image.js:97 static/js/impala/users.js:51
+#: static/js/zamboni/devhub-all.js:894 static/js/zamboni/devhub-min.js:1
+msgid "Images must be either PNG or JPG."
+msgstr ""
+
+#: static/js/impala-all.js:12150 static/js/impala-min.js:7 static/js/common/upload-image.js:101 static/js/zamboni/devhub-all.js:898 static/js/zamboni/devhub-min.js:1
+msgid "Videos must be in WebM."
+msgstr ""
+
+#: static/js/impala-all.js:12177 static/js/impala-min.js:7 static/js/common/upload-addon.js:41 static/js/common/upload-image.js:128 static/js/zamboni/devhub-all.js:272
+#: static/js/zamboni/devhub-all.js:925 static/js/zamboni/devhub-min.js:1
 msgid "There was a problem contacting the server."
 msgstr ""
 
-#: static/js/common/upload-addon.js:69
+#: static/js/impala-all.js:13298 static/js/impala-min.js:7 static/js/impala/persona_creation.js:60
+msgid "All Rights Reserved"
+msgstr ""
+
+#: static/js/impala-all.js:13302 static/js/impala-min.js:7 static/js/impala/persona_creation.js:64
+msgid "Creative Commons Attribution 3.0"
+msgstr "Creative Commons Attribution 3.0"
+
+#: static/js/impala-all.js:13307 static/js/impala-min.js:7 static/js/impala/persona_creation.js:69
+msgid "Creative Commons Attribution-NonCommercial 3.0"
+msgstr "Creative Commons Attribution-NonCommercial 3.0"
+
+#: static/js/impala-all.js:13312 static/js/impala-min.js:7 static/js/impala/persona_creation.js:74
+msgid "Creative Commons Attribution-NonCommercial-NoDerivs 3.0"
+msgstr "Creative Commons Attribution-NonCommercial-NoDerivs 3.0"
+
+#: static/js/impala-all.js:13317 static/js/impala-min.js:7 static/js/impala/persona_creation.js:79
+msgid "Creative Commons Attribution-NonCommercial-Share Alike 3.0"
+msgstr "Creative Commons Attribution-NonCommercial-Share Alike 3.0"
+
+#: static/js/impala-all.js:13322 static/js/impala-min.js:7 static/js/impala/persona_creation.js:84
+msgid "Creative Commons Attribution-NoDerivs 3.0"
+msgstr "Creative Commons Attribution-NoDerivs 3.0"
+
+#: static/js/impala-all.js:13327 static/js/impala-min.js:7 static/js/impala/persona_creation.js:89
+msgid "Creative Commons Attribution-ShareAlike 3.0"
+msgstr "Creative Commons Attribution-ShareAlike 3.0"
+
+#: static/js/impala-all.js:13530 static/js/impala-min.js:7 static/js/impala/persona_creation.js:292
+msgid "Your Theme's Name"
+msgstr "Ainm Do Théama"
+
+#: static/js/impala-all.js:14242 static/js/impala-min.js:8 static/js/impala/collections.js:19
+msgid "Stop Following"
+msgstr ""
+
+#: static/js/impala-all.js:14243 static/js/impala-min.js:8 static/js/impala/collections.js:20
+msgid "Following"
+msgstr ""
+
+#: static/js/impala-all.js:14313 static/js/impala-min.js:8 static/js/impala/users.js:33
+msgid "use original"
+msgstr ""
+
+#: static/js/impala-all.js:14523 static/js/impala-min.js:8 static/js/impala/search.js:114
+msgid "Updating results&hellip;"
+msgstr ""
+
+#: static/js/common/upload-addon.js:69 static/js/zamboni/devhub-all.js:300 static/js/zamboni/devhub-min.js:1
 msgid "Select a file..."
 msgstr "Roghnaigh comhad..."
 
-#: static/js/common/upload-addon.js:70
+#: static/js/common/upload-addon.js:70 static/js/zamboni/devhub-all.js:301 static/js/zamboni/devhub-min.js:1
 msgid "Your add-on should end with .xpi, .jar or .xml"
 msgstr "Ba chóir duit an breiseán a chur i gcomhad .xpi, .jar, nó .xml"
 
 #. L10n: {0} is the percent of the file that has been uploaded.
-#: static/js/common/upload-addon.js:104
+#: static/js/common/upload-addon.js:104 static/js/zamboni/devhub-all.js:335 static/js/zamboni/devhub-min.js:1
 #, python-format
 msgid "{0}% complete"
 msgstr "{0}% críochnaithe"
 
 #. L10n: "{bytes uploaded} of {total filesize}".
-#: static/js/common/upload-addon.js:107
+#: static/js/common/upload-addon.js:107 static/js/zamboni/devhub-all.js:338 static/js/zamboni/devhub-min.js:1
 msgid "{0} of {1}"
 msgstr "{0} as {1}"
 
-#: static/js/common/upload-addon.js:140
+#: static/js/common/upload-addon.js:140 static/js/zamboni/devhub-all.js:371 static/js/zamboni/devhub-min.js:1
 msgid "Cancel"
 msgstr "Cealaigh"
 
-#: static/js/common/upload-addon.js:162
+#: static/js/common/upload-addon.js:162 static/js/zamboni/devhub-all.js:393 static/js/zamboni/devhub-min.js:1
 msgid "Uploading {0}"
 msgstr "{0} á uasluchtú"
 
-#: static/js/common/upload-addon.js:189
+#: static/js/common/upload-addon.js:189 static/js/zamboni/devhub-all.js:420 static/js/zamboni/devhub-min.js:1
 msgid "Error with {0}"
 msgstr "Earráid le {0}"
 
-#: static/js/common/upload-addon.js:194
+#: static/js/common/upload-addon.js:194 static/js/zamboni/devhub-all.js:425 static/js/zamboni/devhub-min.js:1
 msgid "Your add-on failed validation with {0} error."
 msgid_plural "Your add-on failed validation with {0} errors."
 msgstr[0] "Níor éirigh le bailíochtú do bhreiseáin; bhí {0} earráid ann."
 msgstr[1] "Níor éirigh le bailíochtú do bhreiseáin; bhí {0} earráid ann."
-msgstr[2] "Níor éirigh le bailíochtú do bhreiseáin; bhí {0} earráid ann."
-msgstr[3] "Níor éirigh le bailíochtú do bhreiseáin; bhí {0} n-earráid ann."
-msgstr[4] "Níor éirigh le bailíochtú do bhreiseáin; bhí {0} earráid ann."
 
-#: static/js/common/upload-addon.js:208
+#: static/js/common/upload-addon.js:208 static/js/zamboni/devhub-all.js:439 static/js/zamboni/devhub-min.js:1
 msgid "&hellip;and {0} more"
 msgid_plural "&hellip;and {0} more"
 msgstr[0] "&hellip;agus ceann amháin eile"
 msgstr[1] "&hellip;agus {0} cheann eile"
-msgstr[2] "&hellip;agus {0} cinn eile"
-msgstr[3] "&hellip;agus {0} gcinn eile"
-msgstr[4] "&hellip;agus {0} ceann eile"
 
-#: static/js/common/upload-addon.js:222 static/js/common/upload-addon.js:512
+#: static/js/common/upload-addon.js:222 static/js/common/upload-addon.js:497 static/js/zamboni/devhub-all.js:453 static/js/zamboni/devhub-all.js:743 static/js/zamboni/devhub-min.js:1
 msgid "See full validation report"
 msgstr "Tuairisc iomlán ón bhailíochtóir"
 
-#: static/js/common/upload-addon.js:234
+#: static/js/common/upload-addon.js:234 static/js/zamboni/devhub-all.js:465 static/js/zamboni/devhub-min.js:1
 msgid "Validating {0}"
 msgstr "{0} á bhailíochtú"
 
 #. L10n: first argument is an HTTP status code
-#: static/js/common/upload-addon.js:273
+#: static/js/common/upload-addon.js:273 static/js/zamboni/devhub-all.js:504 static/js/zamboni/devhub-min.js:1
 msgid "Received an empty response from the server; status: {0}"
 msgstr "Fuarthas freagra folamh ón bhfreastalaí; stádas: {0}"
 
-#: static/js/common/upload-addon.js:373
+#: static/js/common/upload-addon.js:370 static/js/zamboni/devhub-all.js:604 static/js/zamboni/devhub-min.js:1
 msgid "Unexpected server error while validating."
 msgstr "Earráid fhreastalaí gan súil leis le linn bailíochtaithe."
 
-#: static/js/common/upload-addon.js:412
+#: static/js/common/upload-addon.js:409 static/js/zamboni/devhub-all.js:643 static/js/zamboni/devhub-min.js:1
 msgid "Finished validating {0}"
 msgstr "Bailíochtú {0} críochnaithe"
 
-#: static/js/common/upload-addon.js:418
+#: static/js/common/upload-addon.js:415 static/js/zamboni/devhub-all.js:649 static/js/zamboni/devhub-min.js:1
 msgid "Your add-on validation timed out, it will be manually reviewed."
 msgstr ""
 
-#: static/js/common/upload-addon.js:421
+#: static/js/common/upload-addon.js:418 static/js/zamboni/devhub-all.js:652 static/js/zamboni/devhub-min.js:1
 msgid "Your add-on was validated with no errors and {0} warning."
 msgid_plural "Your add-on was validated with no errors and {0} warnings."
 msgstr[0] ""
 msgstr[1] ""
-msgstr[2] ""
-msgstr[3] ""
-msgstr[4] ""
 
-#: static/js/common/upload-addon.js:426
+#: static/js/common/upload-addon.js:423 static/js/zamboni/devhub-all.js:657 static/js/zamboni/devhub-min.js:1
 msgid "Your add-on was validated with no errors and {0} message."
 msgid_plural "Your add-on was validated with no errors and {0} messages."
 msgstr[0] ""
 msgstr[1] ""
-msgstr[2] ""
-msgstr[3] ""
-msgstr[4] ""
 
-#: static/js/common/upload-addon.js:431
+#: static/js/common/upload-addon.js:428 static/js/zamboni/devhub-all.js:662 static/js/zamboni/devhub-min.js:1
 msgid "Your add-on was validated with no errors or warnings."
 msgstr ""
 
-#: static/js/common/upload-addon.js:446
+#: static/js/common/upload-addon.js:443 static/js/zamboni/devhub-all.js:677 static/js/zamboni/devhub-min.js:1
 msgid "Your submission will be automatically signed."
 msgstr ""
 
-#: static/js/common/upload-addon.js:465
+#: static/js/common/upload-addon.js:450 static/js/zamboni/devhub-all.js:696 static/js/zamboni/devhub-min.js:1
 msgid "Include detailed version notes (this can be done in the next step)."
 msgstr ""
 
-#: static/js/common/upload-addon.js:466
+#: static/js/common/upload-addon.js:451 static/js/zamboni/devhub-all.js:697 static/js/zamboni/devhub-min.js:1
 msgid "If your add-on requires an account to a website in order to be fully tested, include a test username and password in the Notes to Reviewer (this can be done in the next step)."
 msgstr ""
 
-#: static/js/common/upload-addon.js:467
+#: static/js/common/upload-addon.js:452 static/js/zamboni/devhub-all.js:698 static/js/zamboni/devhub-min.js:1
 msgid "If your add-on is intended for a limited audience you should choose Preliminary Review instead of Full Review."
 msgstr ""
 
-#: static/js/common/upload-addon.js:480
+#: static/js/common/upload-addon.js:465 static/js/zamboni/devhub-all.js:711 static/js/zamboni/devhub-min.js:1
 msgid "Add-on submission checklist"
 msgstr ""
 
-#: static/js/common/upload-addon.js:481
+#: static/js/common/upload-addon.js:466 static/js/zamboni/devhub-all.js:712 static/js/zamboni/devhub-min.js:1
 msgid "Please verify the following points before finalizing your submission. This will minimize delays or misunderstanding during the review process:"
 msgstr ""
 
-#: static/js/common/upload-addon.js:483
+#: static/js/common/upload-addon.js:468 static/js/zamboni/devhub-all.js:714 static/js/zamboni/devhub-min.js:1
 msgid ""
 "Compiled binaries, as well as minified or obfuscated scripts (excluding known libraries) need to have their sources submitted separately for review. Make sure that you use the source code upload "
 "field to avoid having your submission rejected."
 msgstr ""
 
-#: static/js/common/upload-addon.js:501
+#: static/js/common/upload-addon.js:486 static/js/zamboni/devhub-all.js:732 static/js/zamboni/devhub-min.js:1
 msgid "The validation process found these issues that can lead to rejections:"
 msgstr ""
 
-#: static/js/common/upload-addon.js:518
+#: static/js/common/upload-addon.js:503 static/js/zamboni/devhub-all.js:749 static/js/zamboni/devhub-min.js:1
 msgid "If you are unfamiliar with the add-ons review process, you can read about it here."
 msgstr ""
 
-#: static/js/common/upload-addon.js:555
+#: static/js/common/upload-addon.js:540 static/js/zamboni/devhub-all.js:786 static/js/zamboni/devhub-min.js:1
 msgid "Sorry, no supported platform has been found."
 msgstr ""
 
-#: static/js/common/upload-base.js:57
+#: static/js/common/upload-base.js:57 static/js/zamboni/devhub-all.js:187 static/js/zamboni/devhub-min.js:1
 msgid "The filetype you uploaded isn't recognized."
 msgstr ""
 
-#: static/js/common/upload-base.js:79
+#: static/js/common/upload-base.js:79 static/js/zamboni/devhub-all.js:209 static/js/zamboni/devhub-min.js:1
 msgid "You cancelled the upload."
 msgstr "Chealaigh tú an t-uasluchtú."
 
-#: static/js/common/upload-image.js:97 static/js/impala/users.js:51
-msgid "Images must be either PNG or JPG."
-msgstr ""
-
-#: static/js/common/upload-image.js:101
-msgid "Videos must be in WebM."
-msgstr ""
-
-#: static/js/impala/collections.js:10 static/js/zamboni/collections.js:595
-msgid "Follow this Collection"
-msgstr "Lean an Bailiúchán seo"
-
-#: static/js/impala/collections.js:19
-msgid "Stop Following"
-msgstr ""
-
-#: static/js/impala/collections.js:20
-msgid "Following"
-msgstr ""
-
-#. L10n: {0} is an app name.
-#: static/js/impala/listing.js:11 static/js/zamboni/themes.js:13
-msgid "This theme is incompatible with your version of {0}"
-msgstr "Níl an téama seo comhoiriúnach do do leagan de {0}"
-
-#: static/js/impala/persona_creation.js:60
-msgid "All Rights Reserved"
-msgstr ""
-
-#: static/js/impala/persona_creation.js:64
-msgid "Creative Commons Attribution 3.0"
-msgstr "Creative Commons Attribution 3.0"
-
-#: static/js/impala/persona_creation.js:69
-msgid "Creative Commons Attribution-NonCommercial 3.0"
-msgstr "Creative Commons Attribution-NonCommercial 3.0"
-
-#: static/js/impala/persona_creation.js:74
-msgid "Creative Commons Attribution-NonCommercial-NoDerivs 3.0"
-msgstr "Creative Commons Attribution-NonCommercial-NoDerivs 3.0"
-
-#: static/js/impala/persona_creation.js:79
-msgid "Creative Commons Attribution-NonCommercial-Share Alike 3.0"
-msgstr "Creative Commons Attribution-NonCommercial-Share Alike 3.0"
-
-#: static/js/impala/persona_creation.js:84
-msgid "Creative Commons Attribution-NoDerivs 3.0"
-msgstr "Creative Commons Attribution-NoDerivs 3.0"
-
-#: static/js/impala/persona_creation.js:89
-msgid "Creative Commons Attribution-ShareAlike 3.0"
-msgstr "Creative Commons Attribution-ShareAlike 3.0"
-
-#: static/js/impala/persona_creation.js:292
-msgid "Your Theme's Name"
-msgstr "Ainm Do Théama"
-
-#: static/js/impala/reviews.js:23 static/js/zamboni/reviews.js:18
-msgid "Flagged for review"
-msgstr ""
-
-#: static/js/impala/reviews.js:40 static/js/zamboni/reviews.js:34
-msgid "Your input is required"
-msgstr ""
-
-#: static/js/impala/reviews.js:152 static/js/zamboni/reviews.js:103
-msgid "Marked for deletion"
-msgstr ""
-
-#: static/js/impala/search.js:114
-msgid "Updating results&hellip;"
-msgstr ""
-
-#: static/js/impala/site_suggestions.js:46
-msgid "Category"
-msgstr "Catagóir"
-
-#: static/js/impala/suggestions.js:39
-msgid "Search themes for <b>{0}</b>"
-msgstr ""
-
-#: static/js/impala/suggestions.js:41
-msgid "Search apps for <b>{0}</b>"
-msgstr ""
-
-#: static/js/impala/suggestions.js:43
-msgid "Search add-ons for <b>{0}</b>"
-msgstr ""
-
-#: static/js/impala/users.js:33
-msgid "use original"
-msgstr ""
-
-#: static/js/impala/stats/chart.js:267
+#: static/js/impala/stats/chart.js:267 static/js/zamboni/stats-all.js:16898 static/js/zamboni/stats-min.js:5
 msgid "Week of {0}"
 msgstr ""
 
-#: static/js/impala/stats/chart.js:269
+#: static/js/impala/stats/chart.js:269 static/js/zamboni/stats-all.js:16900 static/js/zamboni/stats-min.js:5
 msgid " downloads"
 msgstr ""
 
-#: static/js/impala/stats/chart.js:270
+#: static/js/impala/stats/chart.js:270 static/js/zamboni/stats-all.js:16901 static/js/zamboni/stats-min.js:5
 msgid "{0} users"
 msgstr ""
 
-#: static/js/impala/stats/chart.js:271
+#: static/js/impala/stats/chart.js:271 static/js/zamboni/stats-all.js:16902 static/js/zamboni/stats-min.js:5
 msgid "{0} add-ons"
 msgstr ""
 
-#: static/js/impala/stats/chart.js:272
+#: static/js/impala/stats/chart.js:272 static/js/zamboni/stats-all.js:16903 static/js/zamboni/stats-min.js:5
 msgid "{0} collections"
 msgstr ""
 
-#: static/js/impala/stats/chart.js:273
+#: static/js/impala/stats/chart.js:273 static/js/zamboni/stats-all.js:16904 static/js/zamboni/stats-min.js:5
 msgid "{0} reviews"
 msgstr ""
 
-#: static/js/impala/stats/chart.js:275
+#: static/js/impala/stats/chart.js:275 static/js/zamboni/stats-all.js:16906 static/js/zamboni/stats-min.js:5
 msgid "{0} sales"
 msgstr ""
 
-#: static/js/impala/stats/chart.js:276
+#: static/js/impala/stats/chart.js:276 static/js/zamboni/stats-all.js:16907 static/js/zamboni/stats-min.js:5
 msgid "{0} refunds"
 msgstr ""
 
-#: static/js/impala/stats/chart.js:277
+#: static/js/impala/stats/chart.js:277 static/js/zamboni/stats-all.js:16908 static/js/zamboni/stats-min.js:5
 msgid "{0} installs"
 msgstr ""
 
-#: static/js/impala/stats/chart.js:369 static/js/impala/stats/csv_keys.js:3 static/js/impala/stats/csv_keys.js:109
+#: static/js/impala/stats/chart.js:369 static/js/impala/stats/csv_keys.js:3 static/js/impala/stats/csv_keys.js:109 static/js/zamboni/stats-all.js:15284 static/js/zamboni/stats-all.js:15390
+#: static/js/zamboni/stats-all.js:17000 static/js/zamboni/stats-min.js:4 static/js/zamboni/stats-min.js:5
 msgid "Downloads"
 msgstr ""
 
-#: static/js/impala/stats/chart.js:379 static/js/impala/stats/csv_keys.js:6 static/js/impala/stats/csv_keys.js:110
+#: static/js/impala/stats/chart.js:379 static/js/impala/stats/csv_keys.js:6 static/js/impala/stats/csv_keys.js:110 static/js/zamboni/stats-all.js:15287 static/js/zamboni/stats-all.js:15391
+#: static/js/zamboni/stats-all.js:17010 static/js/zamboni/stats-min.js:4 static/js/zamboni/stats-min.js:5
 msgid "Daily Users"
 msgstr ""
 
-#: static/js/impala/stats/chart.js:410
+#: static/js/impala/stats/chart.js:410 static/js/zamboni/stats-all.js:17041 static/js/zamboni/stats-min.js:5
 msgid "Amount, in USD"
 msgstr ""
 
-#: static/js/impala/stats/chart.js:421 static/js/impala/stats/csv_keys.js:104
+#: static/js/impala/stats/chart.js:421 static/js/impala/stats/csv_keys.js:104 static/js/zamboni/stats-all.js:15385 static/js/zamboni/stats-all.js:17052 static/js/zamboni/stats-min.js:5
 msgid "Number of Contributions"
 msgstr ""
 
-#: static/js/impala/stats/chart.js:447
+#: static/js/impala/stats/chart.js:447 static/js/zamboni/stats-all.js:17078 static/js/zamboni/stats-min.js:5
 msgid "More Info..."
 msgstr "Tuilleadh Eolais..."
 
 #. L10n: {0} is an ISO-formatted date.
-#: static/js/impala/stats/chart.js:451
+#: static/js/impala/stats/chart.js:451 static/js/zamboni/stats-all.js:17082 static/js/zamboni/stats-min.js:5
 msgid "Details for {0}"
 msgstr "Mionsonraí: {0}"
 
-#: static/js/impala/stats/csv_keys.js:9
+#: static/js/impala/stats/csv_keys.js:9 static/js/zamboni/stats-all.js:15290 static/js/zamboni/stats-min.js:4
 msgid "Collections Created"
 msgstr "Bailiúcháin Cruthaithe"
 
-#: static/js/impala/stats/csv_keys.js:12
+#: static/js/impala/stats/csv_keys.js:12 static/js/zamboni/stats-all.js:15293 static/js/zamboni/stats-min.js:4
 msgid "Add-ons in Use"
 msgstr "Breiseáin in Úsáid"
 
-#: static/js/impala/stats/csv_keys.js:15
+#: static/js/impala/stats/csv_keys.js:15 static/js/zamboni/stats-all.js:15296 static/js/zamboni/stats-min.js:4
 msgid "Add-ons Created"
 msgstr "Breiseáin Cruthaithe"
 
-#: static/js/impala/stats/csv_keys.js:18
+#: static/js/impala/stats/csv_keys.js:18 static/js/zamboni/stats-all.js:15299 static/js/zamboni/stats-min.js:4
 msgid "Add-ons Downloaded"
 msgstr "Breiseáin Íosluchtaithe"
 
-#: static/js/impala/stats/csv_keys.js:21
+#: static/js/impala/stats/csv_keys.js:21 static/js/zamboni/stats-all.js:15302 static/js/zamboni/stats-min.js:4
 msgid "Add-ons Updated"
 msgstr "Breiseáin Nuashonraithe"
 
-#: static/js/impala/stats/csv_keys.js:24
+#: static/js/impala/stats/csv_keys.js:24 static/js/zamboni/stats-all.js:15305 static/js/zamboni/stats-min.js:4
 msgid "Reviews Written"
 msgstr "Léirmheasanna Scríofa"
 
-#: static/js/impala/stats/csv_keys.js:27
+#: static/js/impala/stats/csv_keys.js:27 static/js/zamboni/stats-all.js:15308 static/js/zamboni/stats-min.js:4
 msgid "User Signups"
 msgstr "Úsáideoirí Cláraithe"
 
-#: static/js/impala/stats/csv_keys.js:30
+#: static/js/impala/stats/csv_keys.js:30 static/js/zamboni/stats-all.js:15311 static/js/zamboni/stats-min.js:4
 msgid "Subscribers"
 msgstr "Síntiúsóirí"
 
-#: static/js/impala/stats/csv_keys.js:33
+#: static/js/impala/stats/csv_keys.js:33 static/js/zamboni/stats-all.js:15314 static/js/zamboni/stats-min.js:4
 msgid "Ratings"
 msgstr "Rátálacha"
 
-#: static/js/impala/stats/csv_keys.js:36 static/js/impala/stats/csv_keys.js:114
+#: static/js/impala/stats/csv_keys.js:36 static/js/impala/stats/csv_keys.js:114 static/js/zamboni/stats-all.js:15317 static/js/zamboni/stats-all.js:15395 static/js/zamboni/stats-min.js:4
+#: static/js/zamboni/stats-min.js:5
 msgid "Sales"
 msgstr "Díolacháin"
 
-#: static/js/impala/stats/csv_keys.js:39 static/js/impala/stats/csv_keys.js:113
+#: static/js/impala/stats/csv_keys.js:39 static/js/impala/stats/csv_keys.js:113 static/js/zamboni/stats-all.js:15320 static/js/zamboni/stats-all.js:15394 static/js/zamboni/stats-min.js:4
+#: static/js/zamboni/stats-min.js:5
 msgid "Installs"
 msgstr "Suiteáilte"
 
-#: static/js/impala/stats/csv_keys.js:42
+#: static/js/impala/stats/csv_keys.js:42 static/js/zamboni/stats-all.js:15323 static/js/zamboni/stats-min.js:4
 msgid "Unknown"
 msgstr "Anaithnid"
 
-#: static/js/impala/stats/csv_keys.js:43
+#: static/js/impala/stats/csv_keys.js:43 static/js/zamboni/stats-all.js:15324 static/js/zamboni/stats-min.js:4
 msgid "Add-ons Manager"
 msgstr "Bainisteoir na mBreiseán"
 
-#: static/js/impala/stats/csv_keys.js:44
+#: static/js/impala/stats/csv_keys.js:44 static/js/zamboni/stats-all.js:15325 static/js/zamboni/stats-min.js:4
 msgid "Add-ons Manager Promo"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:45
+#: static/js/impala/stats/csv_keys.js:45 static/js/zamboni/stats-all.js:15326 static/js/zamboni/stats-min.js:4
 msgid "Add-ons Manager Featured"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:46
+#: static/js/impala/stats/csv_keys.js:46 static/js/zamboni/stats-all.js:15327 static/js/zamboni/stats-min.js:4
 msgid "Add-ons Manager Learn More"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:47
+#: static/js/impala/stats/csv_keys.js:47 static/js/zamboni/stats-all.js:15328 static/js/zamboni/stats-min.js:4
 msgid "Search Suggestions"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:48
+#: static/js/impala/stats/csv_keys.js:48 static/js/zamboni/stats-all.js:15329 static/js/zamboni/stats-min.js:4
 msgid "Search Results"
 msgstr "Torthaí an Chuardaigh"
 
-#: static/js/impala/stats/csv_keys.js:49 static/js/impala/stats/csv_keys.js:50 static/js/impala/stats/csv_keys.js:51
+#: static/js/impala/stats/csv_keys.js:49 static/js/impala/stats/csv_keys.js:50 static/js/impala/stats/csv_keys.js:51 static/js/zamboni/stats-all.js:15330 static/js/zamboni/stats-all.js:15331
+#: static/js/zamboni/stats-all.js:15332 static/js/zamboni/stats-min.js:4
 msgid "Homepage Promo"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:52 static/js/impala/stats/csv_keys.js:53
+#: static/js/impala/stats/csv_keys.js:52 static/js/impala/stats/csv_keys.js:53 static/js/zamboni/stats-all.js:15333 static/js/zamboni/stats-all.js:15334 static/js/zamboni/stats-min.js:4
 msgid "Homepage Featured"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:54 static/js/impala/stats/csv_keys.js:55
+#: static/js/impala/stats/csv_keys.js:54 static/js/impala/stats/csv_keys.js:55 static/js/zamboni/stats-all.js:15335 static/js/zamboni/stats-all.js:15336 static/js/zamboni/stats-min.js:4
 msgid "Homepage Up and Coming"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:56
+#: static/js/impala/stats/csv_keys.js:56 static/js/zamboni/stats-all.js:15337 static/js/zamboni/stats-min.js:4
 msgid "Homepage Most Popular"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:57 static/js/impala/stats/csv_keys.js:59
+#: static/js/impala/stats/csv_keys.js:57 static/js/impala/stats/csv_keys.js:59 static/js/zamboni/stats-all.js:15338 static/js/zamboni/stats-all.js:15340 static/js/zamboni/stats-min.js:4
 msgid "Detail Page"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:58 static/js/impala/stats/csv_keys.js:60
+#: static/js/impala/stats/csv_keys.js:58 static/js/impala/stats/csv_keys.js:60 static/js/zamboni/stats-all.js:15339 static/js/zamboni/stats-all.js:15341 static/js/zamboni/stats-min.js:4
 msgid "Detail Page (bottom)"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:61
+#: static/js/impala/stats/csv_keys.js:61 static/js/zamboni/stats-all.js:15342 static/js/zamboni/stats-min.js:4
 msgid "Detail Page (Development Channel)"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:62 static/js/impala/stats/csv_keys.js:63 static/js/impala/stats/csv_keys.js:64
+#: static/js/impala/stats/csv_keys.js:62 static/js/impala/stats/csv_keys.js:63 static/js/impala/stats/csv_keys.js:64 static/js/zamboni/stats-all.js:15343 static/js/zamboni/stats-all.js:15344
+#: static/js/zamboni/stats-all.js:15345 static/js/zamboni/stats-min.js:4
 msgid "Often Used With"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:65 static/js/impala/stats/csv_keys.js:66
+#: static/js/impala/stats/csv_keys.js:65 static/js/impala/stats/csv_keys.js:66 static/js/zamboni/stats-all.js:15346 static/js/zamboni/stats-all.js:15347 static/js/zamboni/stats-min.js:4
 msgid "Others By Author"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:67 static/js/impala/stats/csv_keys.js:68
+#: static/js/impala/stats/csv_keys.js:67 static/js/impala/stats/csv_keys.js:68 static/js/zamboni/stats-all.js:15348 static/js/zamboni/stats-all.js:15349 static/js/zamboni/stats-min.js:4
 msgid "Dependencies"
 msgstr "Spleáchóga"
 
-#: static/js/impala/stats/csv_keys.js:69 static/js/impala/stats/csv_keys.js:70
+#: static/js/impala/stats/csv_keys.js:69 static/js/impala/stats/csv_keys.js:70 static/js/zamboni/stats-all.js:15350 static/js/zamboni/stats-all.js:15351 static/js/zamboni/stats-min.js:4
 msgid "Upsell"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:71
+#: static/js/impala/stats/csv_keys.js:71 static/js/zamboni/stats-all.js:15352 static/js/zamboni/stats-min.js:4
 msgid "Meet the Developer"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:72
+#: static/js/impala/stats/csv_keys.js:72 static/js/zamboni/stats-all.js:15353 static/js/zamboni/stats-min.js:4
 msgid "User Profile"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:73
+#: static/js/impala/stats/csv_keys.js:73 static/js/zamboni/stats-all.js:15354 static/js/zamboni/stats-min.js:4
 msgid "Version History"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:75
+#: static/js/impala/stats/csv_keys.js:75 static/js/zamboni/stats-all.js:15356 static/js/zamboni/stats-min.js:4
 msgid "Sharing"
 msgstr "Comhroinnt"
 
-#: static/js/impala/stats/csv_keys.js:76
+#: static/js/impala/stats/csv_keys.js:76 static/js/zamboni/stats-all.js:15357 static/js/zamboni/stats-min.js:4
 msgid "Category Pages"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:77
+#: static/js/impala/stats/csv_keys.js:77 static/js/zamboni/stats-all.js:15358 static/js/zamboni/stats-min.js:4
 msgid "Collections"
 msgstr "Bailiúcháin"
 
-#: static/js/impala/stats/csv_keys.js:78 static/js/impala/stats/csv_keys.js:79
+#: static/js/impala/stats/csv_keys.js:78 static/js/impala/stats/csv_keys.js:79 static/js/zamboni/stats-all.js:15359 static/js/zamboni/stats-all.js:15360 static/js/zamboni/stats-min.js:4
 msgid "Category Landing Featured Carousel"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:80 static/js/impala/stats/csv_keys.js:81
+#: static/js/impala/stats/csv_keys.js:80 static/js/impala/stats/csv_keys.js:81 static/js/zamboni/stats-all.js:15361 static/js/zamboni/stats-all.js:15362 static/js/zamboni/stats-min.js:4
 msgid "Category Landing Top Rated"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:82 static/js/impala/stats/csv_keys.js:83
+#: static/js/impala/stats/csv_keys.js:82 static/js/impala/stats/csv_keys.js:83 static/js/zamboni/stats-all.js:15363 static/js/zamboni/stats-all.js:15364 static/js/zamboni/stats-min.js:5
 msgid "Category Landing Most Popular"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:84 static/js/impala/stats/csv_keys.js:85
+#: static/js/impala/stats/csv_keys.js:84 static/js/impala/stats/csv_keys.js:85 static/js/zamboni/stats-all.js:15365 static/js/zamboni/stats-all.js:15366 static/js/zamboni/stats-min.js:5
 msgid "Category Landing Recently Added"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:86 static/js/impala/stats/csv_keys.js:87
+#: static/js/impala/stats/csv_keys.js:86 static/js/impala/stats/csv_keys.js:87 static/js/zamboni/stats-all.js:15367 static/js/zamboni/stats-all.js:15368 static/js/zamboni/stats-min.js:5
 msgid "Browse Listing Featured Sort"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:88 static/js/impala/stats/csv_keys.js:89
+#: static/js/impala/stats/csv_keys.js:88 static/js/impala/stats/csv_keys.js:89 static/js/zamboni/stats-all.js:15369 static/js/zamboni/stats-all.js:15370 static/js/zamboni/stats-min.js:5
 msgid "Browse Listing Users Sort"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:90 static/js/impala/stats/csv_keys.js:91
+#: static/js/impala/stats/csv_keys.js:90 static/js/impala/stats/csv_keys.js:91 static/js/zamboni/stats-all.js:15371 static/js/zamboni/stats-all.js:15372 static/js/zamboni/stats-min.js:5
 msgid "Browse Listing Rating Sort"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:92 static/js/impala/stats/csv_keys.js:93
+#: static/js/impala/stats/csv_keys.js:92 static/js/impala/stats/csv_keys.js:93 static/js/zamboni/stats-all.js:15373 static/js/zamboni/stats-all.js:15374 static/js/zamboni/stats-min.js:5
 msgid "Browse Listing Created Sort"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:94 static/js/impala/stats/csv_keys.js:95
+#: static/js/impala/stats/csv_keys.js:94 static/js/impala/stats/csv_keys.js:95 static/js/zamboni/stats-all.js:15375 static/js/zamboni/stats-all.js:15376 static/js/zamboni/stats-min.js:5
 msgid "Browse Listing Name Sort"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:96 static/js/impala/stats/csv_keys.js:97
+#: static/js/impala/stats/csv_keys.js:96 static/js/impala/stats/csv_keys.js:97 static/js/zamboni/stats-all.js:15377 static/js/zamboni/stats-all.js:15378 static/js/zamboni/stats-min.js:5
 msgid "Browse Listing Popular Sort"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:98 static/js/impala/stats/csv_keys.js:99
+#: static/js/impala/stats/csv_keys.js:98 static/js/impala/stats/csv_keys.js:99 static/js/zamboni/stats-all.js:15379 static/js/zamboni/stats-all.js:15380 static/js/zamboni/stats-min.js:5
 msgid "Browse Listing Updated Sort"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:100 static/js/impala/stats/csv_keys.js:101
+#: static/js/impala/stats/csv_keys.js:100 static/js/impala/stats/csv_keys.js:101 static/js/zamboni/stats-all.js:15381 static/js/zamboni/stats-all.js:15382 static/js/zamboni/stats-min.js:5
 msgid "Browse Listing Up and Coming Sort"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:105
+#: static/js/impala/stats/csv_keys.js:105 static/js/zamboni/stats-all.js:15386 static/js/zamboni/stats-min.js:5
 msgid "Total Amount Contributed"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:106
+#: static/js/impala/stats/csv_keys.js:106 static/js/zamboni/stats-all.js:15387 static/js/zamboni/stats-min.js:5
 msgid "Average Contribution"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:115
+#: static/js/impala/stats/csv_keys.js:115 static/js/zamboni/stats-all.js:15396 static/js/zamboni/stats-min.js:5
 msgid "Usage"
 msgstr "Úsáid"
 
-#: static/js/impala/stats/csv_keys.js:118
+#: static/js/impala/stats/csv_keys.js:118 static/js/zamboni/stats-all.js:15399 static/js/zamboni/stats-min.js:5
 msgid "Firefox"
 msgstr "Firefox"
 
-#: static/js/impala/stats/csv_keys.js:119
+#: static/js/impala/stats/csv_keys.js:119 static/js/zamboni/stats-all.js:15400 static/js/zamboni/stats-min.js:5
 msgid "Mozilla"
 msgstr "Mozilla"
 
-#: static/js/impala/stats/csv_keys.js:120
+#: static/js/impala/stats/csv_keys.js:120 static/js/zamboni/stats-all.js:15401 static/js/zamboni/stats-min.js:5
 msgid "Thunderbird"
 msgstr "Thunderbird"
 
-#: static/js/impala/stats/csv_keys.js:121
+#: static/js/impala/stats/csv_keys.js:121 static/js/zamboni/stats-all.js:15402 static/js/zamboni/stats-min.js:5
 msgid "Sunbird"
 msgstr "Sunbird"
 
-#: static/js/impala/stats/csv_keys.js:122
+#: static/js/impala/stats/csv_keys.js:122 static/js/zamboni/stats-all.js:15403 static/js/zamboni/stats-min.js:5
 msgid "SeaMonkey"
 msgstr "SeaMonkey"
 
-#: static/js/impala/stats/csv_keys.js:123
+#: static/js/impala/stats/csv_keys.js:123 static/js/zamboni/stats-all.js:15404 static/js/zamboni/stats-min.js:5
 msgid "Fennec"
 msgstr "Fennec"
 
-#: static/js/impala/stats/csv_keys.js:124
+#: static/js/impala/stats/csv_keys.js:124 static/js/zamboni/stats-all.js:15405 static/js/zamboni/stats-min.js:5
 msgid "Android"
 msgstr ""
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:129
+#: static/js/impala/stats/csv_keys.js:129 static/js/zamboni/stats-all.js:15410 static/js/zamboni/stats-min.js:5
 msgid "Downloads and Daily Users, last {0} days"
 msgstr ""
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:131
+#: static/js/impala/stats/csv_keys.js:131 static/js/zamboni/stats-all.js:15412 static/js/zamboni/stats-min.js:5
 msgid "Downloads and Daily Users from {0} to {1}"
 msgstr ""
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:135
+#: static/js/impala/stats/csv_keys.js:135 static/js/zamboni/stats-all.js:15416 static/js/zamboni/stats-min.js:5
 msgid "Installs and Daily Users, last {0} days"
 msgstr ""
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:137
+#: static/js/impala/stats/csv_keys.js:137 static/js/zamboni/stats-all.js:15418 static/js/zamboni/stats-min.js:5
 msgid "Installs and Daily Users from {0} to {1}"
 msgstr ""
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:141
+#: static/js/impala/stats/csv_keys.js:141 static/js/zamboni/stats-all.js:15422 static/js/zamboni/stats-min.js:5
 msgid "Downloads, last {0} days"
 msgstr ""
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:143
+#: static/js/impala/stats/csv_keys.js:143 static/js/zamboni/stats-all.js:15424 static/js/zamboni/stats-min.js:5
 msgid "Downloads from {0} to {1}"
 msgstr ""
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:147
+#: static/js/impala/stats/csv_keys.js:147 static/js/zamboni/stats-all.js:15428 static/js/zamboni/stats-min.js:5
 msgid "Daily Users, last {0} days"
 msgstr ""
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:149
+#: static/js/impala/stats/csv_keys.js:149 static/js/zamboni/stats-all.js:15430 static/js/zamboni/stats-min.js:5
 msgid "Daily Users from {0} to {1}"
 msgstr ""
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:153
+#: static/js/impala/stats/csv_keys.js:153 static/js/zamboni/stats-all.js:15434 static/js/zamboni/stats-min.js:5
 msgid "Applications, last {0} days"
 msgstr "Feidhmchláir, {0} lá is déanaí"
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:155
+#: static/js/impala/stats/csv_keys.js:155 static/js/zamboni/stats-all.js:15436 static/js/zamboni/stats-min.js:5
 msgid "Applications from {0} to {1}"
 msgstr "Feidhmchláir ó {0} go {1}"
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:159
+#: static/js/impala/stats/csv_keys.js:159 static/js/zamboni/stats-all.js:15440 static/js/zamboni/stats-min.js:5
 msgid "Platforms, last {0} days"
 msgstr "Ardáin, {0} lá is déanaí"
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:161
+#: static/js/impala/stats/csv_keys.js:161 static/js/zamboni/stats-all.js:15442 static/js/zamboni/stats-min.js:5
 msgid "Platforms from {0} to {1}"
 msgstr "Ardáin ó {0} go {1}"
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:165
+#: static/js/impala/stats/csv_keys.js:165 static/js/zamboni/stats-all.js:15446 static/js/zamboni/stats-min.js:5
 msgid "Languages, last {0} days"
 msgstr "Teangacha, {0} lá is déanaí"
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:167
+#: static/js/impala/stats/csv_keys.js:167 static/js/zamboni/stats-all.js:15448 static/js/zamboni/stats-min.js:5
 msgid "Languages from {0} to {1}"
 msgstr "Teangacha ó {0} go {1}"
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:171
+#: static/js/impala/stats/csv_keys.js:171 static/js/zamboni/stats-all.js:15452 static/js/zamboni/stats-min.js:5
 msgid "Add-on Versions, last {0} days"
 msgstr ""
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:173
+#: static/js/impala/stats/csv_keys.js:173 static/js/zamboni/stats-all.js:15454 static/js/zamboni/stats-min.js:5
 msgid "Add-on Versions from {0} to {1}"
 msgstr ""
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:177
+#: static/js/impala/stats/csv_keys.js:177 static/js/zamboni/stats-all.js:15458 static/js/zamboni/stats-min.js:5
 msgid "Add-on Status, last {0} days"
 msgstr ""
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:179
+#: static/js/impala/stats/csv_keys.js:179 static/js/zamboni/stats-all.js:15460 static/js/zamboni/stats-min.js:5
 msgid "Add-on Status from {0} to {1}"
 msgstr ""
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:183
+#: static/js/impala/stats/csv_keys.js:183 static/js/zamboni/stats-all.js:15464 static/js/zamboni/stats-min.js:5
 msgid "Download Sources, last {0} days"
 msgstr ""
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:185
+#: static/js/impala/stats/csv_keys.js:185 static/js/zamboni/stats-all.js:15466 static/js/zamboni/stats-min.js:5
 msgid "Download Sources from {0} to {1}"
 msgstr ""
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:189
+#: static/js/impala/stats/csv_keys.js:189 static/js/zamboni/stats-all.js:15470 static/js/zamboni/stats-min.js:5
 msgid "Contributions, last {0} days"
 msgstr ""
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:191
+#: static/js/impala/stats/csv_keys.js:191 static/js/zamboni/stats-all.js:15472 static/js/zamboni/stats-min.js:5
 msgid "Contributions from {0} to {1}"
 msgstr ""
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:195
+#: static/js/impala/stats/csv_keys.js:195 static/js/zamboni/stats-all.js:15476 static/js/zamboni/stats-min.js:5
 msgid "Site Metrics, last {0} days"
 msgstr ""
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:197
+#: static/js/impala/stats/csv_keys.js:197 static/js/zamboni/stats-all.js:15478 static/js/zamboni/stats-min.js:5
 msgid "Site Metrics from {0} to {1}"
 msgstr ""
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:201
+#: static/js/impala/stats/csv_keys.js:201 static/js/zamboni/stats-all.js:15482 static/js/zamboni/stats-min.js:5
 msgid "Add-ons in Use, last {0} days"
 msgstr ""
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:203
+#: static/js/impala/stats/csv_keys.js:203 static/js/zamboni/stats-all.js:15484 static/js/zamboni/stats-min.js:5
 msgid "Add-ons in Use from {0} to {1}"
 msgstr ""
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:207
+#: static/js/impala/stats/csv_keys.js:207 static/js/zamboni/stats-all.js:15488 static/js/zamboni/stats-min.js:5
 msgid "Add-ons Downloaded, last {0} days"
 msgstr ""
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:209
+#: static/js/impala/stats/csv_keys.js:209 static/js/zamboni/stats-all.js:15490 static/js/zamboni/stats-min.js:5
 msgid "Add-ons Downloaded from {0} to {1}"
 msgstr ""
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:213
+#: static/js/impala/stats/csv_keys.js:213 static/js/zamboni/stats-all.js:15494 static/js/zamboni/stats-min.js:5
 msgid "Add-ons Created, last {0} days"
 msgstr ""
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:215
+#: static/js/impala/stats/csv_keys.js:215 static/js/zamboni/stats-all.js:15496 static/js/zamboni/stats-min.js:5
 msgid "Add-ons Created from {0} to {1}"
 msgstr ""
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:219
+#: static/js/impala/stats/csv_keys.js:219 static/js/zamboni/stats-all.js:15500 static/js/zamboni/stats-min.js:5
 msgid "Add-ons Updated, last {0} days"
 msgstr ""
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:221
+#: static/js/impala/stats/csv_keys.js:221 static/js/zamboni/stats-all.js:15502 static/js/zamboni/stats-min.js:5
 msgid "Add-ons Updated from {0} to {1}"
 msgstr ""
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:225
+#: static/js/impala/stats/csv_keys.js:225 static/js/zamboni/stats-all.js:15506 static/js/zamboni/stats-min.js:5
 msgid "Reviews Written, last {0} days"
 msgstr ""
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:227
+#: static/js/impala/stats/csv_keys.js:227 static/js/zamboni/stats-all.js:15508 static/js/zamboni/stats-min.js:5
 msgid "Reviews Written from {0} to {1}"
 msgstr ""
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:231
+#: static/js/impala/stats/csv_keys.js:231 static/js/zamboni/stats-all.js:15512 static/js/zamboni/stats-min.js:5
 msgid "User Signups, last {0} days"
 msgstr ""
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:233
+#: static/js/impala/stats/csv_keys.js:233 static/js/zamboni/stats-all.js:15514 static/js/zamboni/stats-min.js:5
 msgid "User Signups from {0} to {1}"
 msgstr ""
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:237
+#: static/js/impala/stats/csv_keys.js:237 static/js/zamboni/stats-all.js:15518 static/js/zamboni/stats-min.js:5
 msgid "Collections Created, last {0} days"
 msgstr ""
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:239
+#: static/js/impala/stats/csv_keys.js:239 static/js/zamboni/stats-all.js:15520 static/js/zamboni/stats-min.js:5
 msgid "Collections Created from {0} to {1}"
 msgstr ""
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:243
+#: static/js/impala/stats/csv_keys.js:243 static/js/zamboni/stats-all.js:15524 static/js/zamboni/stats-min.js:5
 msgid "Subscribers, last {0} days"
 msgstr ""
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:245
+#: static/js/impala/stats/csv_keys.js:245 static/js/zamboni/stats-all.js:15526 static/js/zamboni/stats-min.js:5
 msgid "Subscribers from {0} to {1}"
 msgstr ""
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:249
+#: static/js/impala/stats/csv_keys.js:249 static/js/zamboni/stats-all.js:15530 static/js/zamboni/stats-min.js:5
 msgid "Ratings, last {0} days"
 msgstr ""
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:251
+#: static/js/impala/stats/csv_keys.js:251 static/js/zamboni/stats-all.js:15532 static/js/zamboni/stats-min.js:5
 msgid "Ratings from {0} to {1}"
 msgstr ""
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:255
+#: static/js/impala/stats/csv_keys.js:255 static/js/zamboni/stats-all.js:15536 static/js/zamboni/stats-min.js:5
 msgid "Sales, last {0} days"
 msgstr ""
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:257
+#: static/js/impala/stats/csv_keys.js:257 static/js/zamboni/stats-all.js:15538 static/js/zamboni/stats-min.js:5
 msgid "Sales from {0} to {1}"
 msgstr ""
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:261
+#: static/js/impala/stats/csv_keys.js:261 static/js/zamboni/stats-all.js:15542 static/js/zamboni/stats-min.js:5
 msgid "Installs, last {0} days"
 msgstr ""
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:263
+#: static/js/impala/stats/csv_keys.js:263 static/js/zamboni/stats-all.js:15544 static/js/zamboni/stats-min.js:5
 msgid "Installs from {0} to {1}"
 msgstr ""
 
 #. L10n: {0} and {1} are integers.
-#: static/js/impala/stats/csv_keys.js:269
+#: static/js/impala/stats/csv_keys.js:269 static/js/zamboni/stats-all.js:15550 static/js/zamboni/stats-min.js:5
 msgid "<b>{0}</b> in last {1} days"
 msgstr ""
 
 #. L10n: {0} is an integer and {1} and {2} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:271 static/js/impala/stats/csv_keys.js:277
+#: static/js/impala/stats/csv_keys.js:271 static/js/impala/stats/csv_keys.js:277 static/js/zamboni/stats-all.js:15552 static/js/zamboni/stats-all.js:15558 static/js/zamboni/stats-min.js:5
 msgid "<b>{0}</b> from {1} to {2}"
 msgstr ""
 
 #. L10n: {0} and {1} are integers.
-#: static/js/impala/stats/csv_keys.js:275
+#: static/js/impala/stats/csv_keys.js:275 static/js/zamboni/stats-all.js:15556 static/js/zamboni/stats-min.js:5
 msgid "<b>{0}</b> average in last {1} days"
 msgstr ""
 
-#: static/js/impala/stats/overview.js:19
+#: static/js/impala/stats/overview.js:19 static/js/zamboni/stats-all.js:16469 static/js/zamboni/stats-min.js:5
 msgid "No data available."
 msgstr ""
 
-#: static/js/impala/stats/table.js:74
+#: static/js/impala/stats/table.js:74 static/js/zamboni/stats-all.js:17209 static/js/zamboni/stats-min.js:5
 msgid "Date"
 msgstr "Dáta"
 
-#: static/js/impala/stats/topchart.js:96
+#: static/js/impala/stats/topchart.js:96 static/js/zamboni/stats-all.js:16600 static/js/zamboni/stats-min.js:5
 msgid "Other"
 msgstr "Eile"
 
-#: static/js/zamboni/admin_validation.js:24 static/js/zamboni/devhub.js:1229 static/js/zamboni/editors.js:295
+#: static/js/zamboni/admin-all.js:180 static/js/zamboni/admin-min.js:1 static/js/zamboni/admin_validation.js:24 static/js/zamboni/devhub-all.js:2408 static/js/zamboni/devhub-min.js:2
+#: static/js/zamboni/devhub.js:1229 static/js/zamboni/editors-all.js:15576 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:295
 msgid "Select an application first"
 msgstr "Roghnaigh feidhmchlár i dtosach báire"
 
-#: static/js/zamboni/admin_validation.js:51
+#: static/js/zamboni/admin-all.js:207 static/js/zamboni/admin-min.js:1 static/js/zamboni/admin_validation.js:51
 msgid "Set {0} add-on to a max version of {1} and email the author."
 msgid_plural "Set {0} add-ons to a max version of {1} and email the authors."
 msgstr[0] ""
 msgstr[1] ""
-msgstr[2] ""
-msgstr[3] ""
-msgstr[4] ""
 
-#: static/js/zamboni/admin_validation.js:54
+#: static/js/zamboni/admin-all.js:210 static/js/zamboni/admin-min.js:1 static/js/zamboni/admin_validation.js:54
 msgid "Email author of {2} add-on which failed validation."
 msgid_plural "Email authors of {2} add-ons which failed validation."
 msgstr[0] ""
 msgstr[1] ""
-msgstr[2] ""
-msgstr[3] ""
-msgstr[4] ""
 
-#. L10n: {0} is an app name like Firefox.
-#: static/js/zamboni/buttons.js:66
-msgid "Accept and Install"
-msgstr "Glac Leis agus Suiteáil"
-
-#: static/js/zamboni/buttons.js:66
-msgid "Add to {0}"
-msgstr "Cuir le {0}"
-
-#: static/js/zamboni/buttons.js:71
-msgid "Download Now"
-msgstr "Íosluchtaigh Anois"
-
-#: static/js/zamboni/buttons.js:112
-msgid "Add-on has not been updated to support default-to-compatible."
-msgstr ""
-
-#: static/js/zamboni/buttons.js:117
-msgid "You need to be using Firefox 10.0 or higher."
-msgstr ""
-
-#: static/js/zamboni/buttons.js:129
-msgid "Mozilla has marked this version as incompatible with your Firefox version."
-msgstr ""
-
-#. L10n: {0} is an platform like Windows or Linux.
-#: static/js/zamboni/buttons.js:210
-msgid "Install for {0} anyway"
-msgstr "Suiteáil ar {0} mar sin féin"
-
-#: static/js/zamboni/buttons.js:210
-msgid "Download for {0} anyway"
-msgstr "Íosluchtaigh le haghaidh {0} mar sin féin"
-
-#: static/js/zamboni/buttons.js:267
-msgid "Not available for your platform"
-msgstr "Níl sé ar fáil ar d'ardán"
-
-#. L10n: {0} is an app name, {1} is the app version.
-#: static/js/zamboni/buttons.js:278 static/js/zamboni/buttons.js:315
-msgid "Not available for {0} {1}"
-msgstr "Níl sé ar fáil le haghaidh {0} {1}"
-
-#: static/js/zamboni/buttons.js:341
-msgid "Works with {app} {min} - {max}"
-msgstr "Feidhmíonn sé le {app} {min} - {max}"
-
-#: static/js/zamboni/buttons.js:343
-msgid "View other versions"
-msgstr "Féach ar leaganacha eile"
-
-#: static/js/zamboni/buttons.js:391
-msgid "Only with Firefox — Get Firefox Now!"
-msgstr ""
-
-#: static/js/zamboni/buttons.js:507 static/js/zamboni/mobile/buttons.js:43
-msgid "Sorry, you need a Mozilla-based browser (such as Firefox) to install a search plugin."
-msgstr "Tá brabhsálaí de chuid Mozilla (mar shampla Firefox) de dhíth ort chun breiseán cuardaigh a shuiteáil."
-
-#: static/js/zamboni/collections.js:229
-msgid "Adding to Favorites&hellip;"
-msgstr "Á chur leis na Ceanáin&hellip;"
-
-#: static/js/zamboni/collections.js:232
-msgid "Removing Favorite&hellip;"
-msgstr "Ceanán á bhaint&hellip;"
-
-#: static/js/zamboni/collections.js:235
-msgid "Add to Favorites"
-msgstr "Cuir leis na Ceanáin"
-
-#: static/js/zamboni/collections.js:238
-msgid "Remove from Favorites"
-msgstr "Bain ó na Ceanáin"
-
-#: static/js/zamboni/collections.js:303
-msgid "Pending"
-msgstr "Ar Feitheamh"
-
-#: static/js/zamboni/collections.js:304
-msgid "Add a comment"
-msgstr "Cuir nóta leis"
-
-#: static/js/zamboni/collections.js:304
-msgid "Comment"
-msgstr "Nóta"
-
-#: static/js/zamboni/collections.js:305
-msgid "Remove this add-on from the collection"
-msgstr "Bain an breiseán seo ón bhailiúchán"
-
-#: static/js/zamboni/collections.js:305 static/js/zamboni/collections.js:334
-msgid "Remove"
-msgstr "Bain"
-
-#: static/js/zamboni/collections.js:334
-msgid "Remove this user as a contributor"
-msgstr "Bain an t-úsáideoir seo ó na rannpháirtithe"
-
-#: static/js/zamboni/collections.js:346
-msgid "An email address is required."
-msgstr ""
-
-#: static/js/zamboni/collections.js:364
-msgid "You cannot add yourself as a contributor."
-msgstr ""
-
-#: static/js/zamboni/collections.js:366
-msgid "You have already added that user."
-msgstr "Tá an t-úsáideoir sin ann cheana."
-
-#: static/js/zamboni/collections.js:573
-msgid "Add to favorites"
-msgstr "Cuir leis na ceanáin"
-
-#: static/js/zamboni/collections.js:577
-msgid "Remove from favorites"
-msgstr "Bain ó na ceanáin"
-
-#: static/js/zamboni/collections.js:604
-msgid "Stop following"
-msgstr "Ná bí dá leanúint"
-
-#: static/js/zamboni/devhub.js:110
+#: static/js/zamboni/devhub-all.js:1289 static/js/zamboni/devhub-min.js:1 static/js/zamboni/devhub.js:110
 msgid "Your browser does not support the video tag"
 msgstr "Ní thacaíonn do bhrabhsálaí leis an gclib 'video'"
 
-#: static/js/zamboni/devhub.js:371
+#: static/js/zamboni/devhub-all.js:1550 static/js/zamboni/devhub-min.js:1 static/js/zamboni/devhub.js:371
 msgid "Changes Saved"
 msgstr "Sábháladh na hAthruithe"
 
-#: static/js/zamboni/devhub.js:387
+#: static/js/zamboni/devhub-all.js:1566 static/js/zamboni/devhub-min.js:1 static/js/zamboni/devhub.js:387
 msgid "Enter a new author's email address"
 msgstr ""
 
-#: static/js/zamboni/devhub.js:536
+#: static/js/zamboni/devhub-all.js:1715 static/js/zamboni/devhub-min.js:1 static/js/zamboni/devhub.js:536
 msgid "There was an error uploading your file."
 msgstr "Tharla earráid agus do chomhad á uasluchtú."
 
-#: static/js/zamboni/devhub.js:681
+#: static/js/zamboni/devhub-all.js:1860 static/js/zamboni/devhub-min.js:1 static/js/zamboni/devhub.js:681
 msgid "{files} file"
 msgid_plural "{files} files"
 msgstr[0] "{files} chomhad"
 msgstr[1] "{files} chomhad"
-msgstr[2] "{files} chomhad"
-msgstr[3] "{files} gcomhad"
-msgstr[4] "{files} comhad"
 
-#: static/js/zamboni/devhub.js:684
+#: static/js/zamboni/devhub-all.js:1863 static/js/zamboni/devhub-min.js:1 static/js/zamboni/devhub.js:684
 msgid "{reviews} user review"
 msgid_plural "{reviews} user reviews"
 msgstr[0] ""
 msgstr[1] ""
-msgstr[2] ""
-msgstr[3] ""
-msgstr[4] ""
 
-#: static/js/zamboni/devhub.js:796
+#: static/js/zamboni/devhub-all.js:1975 static/js/zamboni/devhub-min.js:2 static/js/zamboni/devhub.js:796
 msgid "Learn more"
 msgstr "Tuilleadh eolais"
 
-#: static/js/zamboni/devhub.js:800
+#: static/js/zamboni/devhub-all.js:1979 static/js/zamboni/devhub-min.js:2 static/js/zamboni/devhub.js:800
 msgid "Example"
 msgstr "Sampla"
 
-#: static/js/zamboni/devhub.js:1130
+#: static/js/zamboni/devhub-all.js:2309 static/js/zamboni/devhub-min.js:2 static/js/zamboni/devhub.js:1130
 msgid "Image changes being processed"
 msgstr ""
 
-#: static/js/zamboni/devhub.js:1280
+#: static/js/zamboni/devhub-all.js:2459 static/js/zamboni/devhub-min.js:2 static/js/zamboni/devhub.js:1280
 msgid "Must be a valid e-mail address."
 msgstr ""
+
+#: static/js/zamboni/devhub-all.js:2613 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:80
+msgid "All tests passed successfully."
+msgstr "D'éirigh le gach tástáil."
+
+#: static/js/zamboni/devhub-all.js:2616 static/js/zamboni/devhub-all.js:3011 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:83 static/js/zamboni/validator.js:478
+msgid "These tests were not run."
+msgstr ""
+
+#: static/js/zamboni/devhub-all.js:2664 static/js/zamboni/devhub-all.js:2677 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:131 static/js/zamboni/validator.js:144
+msgid "Tests"
+msgstr "Tástálacha"
+
+#: static/js/zamboni/devhub-all.js:2779 static/js/zamboni/devhub-all.js:3108 static/js/zamboni/devhub-all.js:3127 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:246
+#: static/js/zamboni/validator.js:575 static/js/zamboni/validator.js:594
+msgid "Error"
+msgstr "Earráid"
+
+#: static/js/zamboni/devhub-all.js:2780 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:247
+msgid "Warning"
+msgstr "Rabhadh"
+
+#: static/js/zamboni/devhub-all.js:2794 static/js/zamboni/devhub-min.js:2 static/js/zamboni/files-all.js:5657 static/js/zamboni/files-min.js:3 static/js/zamboni/files.js:411
+#: static/js/zamboni/validator.js:261
+msgid "Ignore this message in future updates"
+msgstr ""
+
+#: static/js/zamboni/devhub-all.js:2817 static/js/zamboni/devhub-min.js:2 static/js/zamboni/files-all.js:5663 static/js/zamboni/files-min.js:3 static/js/zamboni/files.js:417
+#: static/js/zamboni/validator.js:284
+msgid "Severity for automated signing:"
+msgstr ""
+
+#: static/js/zamboni/devhub-all.js:2832 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:299
+msgid "Suggestions for passing automated signing:"
+msgstr ""
+
+#: static/js/zamboni/devhub-all.js:2920 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:387
+msgid "Compatibility Tests"
+msgstr "Tástálacha Comhoiriúnachta"
+
+#: static/js/zamboni/devhub-all.js:2999 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:466
+msgid "Add-on failed validation."
+msgstr "Níor éirigh le bailíochtú an bhreiseáin."
+
+#: static/js/zamboni/devhub-all.js:3001 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:468
+msgid "Add-on passed validation."
+msgstr "D'éirigh le bailíochtú an bhreiseáin."
+
+#: static/js/zamboni/devhub-all.js:3014 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:481
+msgid "{0} error"
+msgid_plural "{0} errors"
+msgstr[0] "{0} earráid"
+msgstr[1] "{0} earráid"
+
+#: static/js/zamboni/devhub-all.js:3016 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:483
+msgid "{0} warning"
+msgid_plural "{0} warnings"
+msgstr[0] "{0} rabhadh"
+msgstr[1] "{0} rabhadh"
+
+#: static/js/zamboni/devhub-all.js:3018 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:485
+msgid "{0} notice"
+msgid_plural "{0} notices"
+msgstr[0] ""
+msgstr[1] ""
+
+#: static/js/zamboni/devhub-all.js:3110 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:577
+msgid "Validation task could not complete or completed with errors"
+msgstr "Níorbh fhéidir an bailíochtú a chur i gcrích, nó chríochnaigh sé le hearráidí"
+
+#: static/js/zamboni/devhub-all.js:3128 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:595
+msgid "Internal server error"
+msgstr "Earráid inmheánach leis an bhfreastalaí"
 
 #: static/js/zamboni/devhub_search.js:8
 msgid "No results found."
 msgstr ""
 
-#: static/js/zamboni/editors.js:121
+#: static/js/zamboni/editors-all.js:15402 static/js/zamboni/editors-min.js:4 static/js/zamboni/editors.js:121
 msgid "{name} was viewing this page first."
 msgstr "Bhí {name} ag féachaint ar an leathanach seo ar dtús."
 
-#: static/js/zamboni/editors.js:171
+#: static/js/zamboni/editors-all.js:15452 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:171
 msgid "Receipt checked by app."
 msgstr ""
 
-#: static/js/zamboni/editors.js:173
+#: static/js/zamboni/editors-all.js:15454 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:173
 msgid "Receipt was not checked by app."
 msgstr ""
 
-#: static/js/zamboni/editors.js:244
+#: static/js/zamboni/editors-all.js:15525 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:244
 msgid "{name} was viewing this add-on first."
 msgstr ""
 
-#: static/js/zamboni/editors.js:255
+#: static/js/zamboni/editors-all.js:15536 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:255
 msgid "Loading&hellip;"
 msgstr "Á luchtú&hellip;"
 
-#: static/js/zamboni/editors.js:260
+#: static/js/zamboni/editors-all.js:15541 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:260
 msgid "Version Notes"
 msgstr "Nótaí Eisiúna"
 
-#: static/js/zamboni/editors.js:265
+#: static/js/zamboni/editors-all.js:15546 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:265
 msgid "Notes for Reviewers"
 msgstr ""
 
-#: static/js/zamboni/editors.js:270
+#: static/js/zamboni/editors-all.js:15551 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:270
 msgid "No version notes found"
 msgstr ""
 
-#: static/js/zamboni/editors.js:330
+#: static/js/zamboni/editors-all.js:15611 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:330
 msgid "Average Reviews"
 msgstr ""
 
-#: static/js/zamboni/editors.js:386
+#: static/js/zamboni/editors-all.js:15667 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:386
 msgid "Number of Reviews"
 msgstr ""
 
-#: static/js/zamboni/editors.js:445
+#: static/js/zamboni/editors-all.js:15726 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:445
 msgid "Error loading translation"
 msgstr ""
 
-#: static/js/zamboni/files.js:411 static/js/zamboni/validator.js:261
-msgid "Ignore this message in future updates"
-msgstr ""
-
-#: static/js/zamboni/files.js:417 static/js/zamboni/validator.js:284
-msgid "Severity for automated signing:"
-msgstr ""
-
-#: static/js/zamboni/global.js:410
-msgid "Loading..."
-msgstr "Á Luchtú..."
-
-#. L10n: {0} is the number of characters left.
-#: static/js/zamboni/global.js:474
-msgid "<b>{0}</b> character left."
-msgid_plural "<b>{0}</b> characters left."
-msgstr[0] "<b>{0}</b> charachtar fágtha."
-msgstr[1] "<b>{0}</b> charachtar fágtha."
-msgstr[2] "<b>{0}</b> charachtar fágtha."
-msgstr[3] "<b>{0}</b> gcarachtar fágtha."
-msgstr[4] "<b>{0}</b> carachtar fágtha."
-
-#: static/js/zamboni/init.js:28
-msgid "This feature is temporarily disabled while we perform website maintenance. Please check back a little later."
-msgstr "Níl an ghné seo ar fáil faoi láthair agus cúram á dhéanamh ar an suíomh.  Tar ar ais chugainn ar ball."
-
-#: static/js/zamboni/l10n.js:45
-msgid "Remove this localization"
-msgstr "Bain an logánú seo"
-
-#: static/js/zamboni/password-strength.js:20
-msgid "Password strength:"
-msgstr "Neart an fhocail fhaire:"
-
-#: static/js/zamboni/password-strength.js:26
-msgid "At least {0} character left."
-msgid_plural "At least {0} characters left."
-msgstr[0] "{0} charachtar fágtha ar a laghad."
-msgstr[1] "{0} charachtar fágtha ar a laghad."
-msgstr[2] "{0} charachtar fágtha ar a laghad."
-msgstr[3] "{0} gcarachtar fágtha ar a laghad."
-msgstr[4] "{0} carachtar fágtha ar a laghad."
-
-#: static/js/zamboni/themes_review.js:176
-msgid "Requested Info"
-msgstr ""
-
-#: static/js/zamboni/themes_review.js:177
-msgid "Flagged"
-msgstr ""
-
-#: static/js/zamboni/themes_review.js:178
-msgid "Duplicate"
-msgstr ""
-
-#: static/js/zamboni/themes_review.js:179
-msgid "Rejected"
-msgstr "Diúltaithe"
-
-#: static/js/zamboni/themes_review.js:180
-msgid "Approved"
-msgstr "Ceadaithe"
-
-#: static/js/zamboni/themes_review.js:424
-msgid "No results found"
-msgstr ""
-
-#: static/js/zamboni/themes_review_templates.js:31
+#: static/js/zamboni/editors-all.js:15975 static/js/zamboni/editors-min.js:5 static/js/zamboni/themes_review_templates.js:31
 msgid "Theme"
 msgstr ""
 
-#: static/js/zamboni/themes_review_templates.js:33
+#: static/js/zamboni/editors-all.js:15977 static/js/zamboni/editors-min.js:5 static/js/zamboni/themes_review_templates.js:33
 msgid "Reviewer"
 msgstr ""
 
-#: static/js/zamboni/themes_review_templates.js:35
+#: static/js/zamboni/editors-all.js:15979 static/js/zamboni/editors-min.js:5 static/js/zamboni/themes_review_templates.js:35
 msgid "Status"
 msgstr ""
 
-#: static/js/zamboni/validator.js:80
-msgid "All tests passed successfully."
-msgstr "D'éirigh le gach tástáil."
-
-#: static/js/zamboni/validator.js:83 static/js/zamboni/validator.js:478
-msgid "These tests were not run."
+#: static/js/zamboni/editors-all.js:16196 static/js/zamboni/editors-min.js:5 static/js/zamboni/themes_review.js:176
+msgid "Requested Info"
 msgstr ""
 
-#: static/js/zamboni/validator.js:131 static/js/zamboni/validator.js:144
-msgid "Tests"
-msgstr "Tástálacha"
-
-#: static/js/zamboni/validator.js:246 static/js/zamboni/validator.js:575 static/js/zamboni/validator.js:594
-msgid "Error"
-msgstr "Earráid"
-
-#: static/js/zamboni/validator.js:247
-msgid "Warning"
-msgstr "Rabhadh"
-
-#: static/js/zamboni/validator.js:299
-msgid "Suggestions for passing automated signing:"
+#: static/js/zamboni/editors-all.js:16197 static/js/zamboni/editors-min.js:5 static/js/zamboni/themes_review.js:177
+msgid "Flagged"
 msgstr ""
 
-#: static/js/zamboni/validator.js:387
-msgid "Compatibility Tests"
-msgstr "Tástálacha Comhoiriúnachta"
+#: static/js/zamboni/editors-all.js:16198 static/js/zamboni/editors-min.js:5 static/js/zamboni/themes_review.js:178
+msgid "Duplicate"
+msgstr ""
 
-#: static/js/zamboni/validator.js:466
-msgid "Add-on failed validation."
-msgstr "Níor éirigh le bailíochtú an bhreiseáin."
+#: static/js/zamboni/editors-all.js:16199 static/js/zamboni/editors-min.js:5 static/js/zamboni/themes_review.js:179
+msgid "Rejected"
+msgstr "Diúltaithe"
 
-#: static/js/zamboni/validator.js:468
-msgid "Add-on passed validation."
-msgstr "D'éirigh le bailíochtú an bhreiseáin."
+#: static/js/zamboni/editors-all.js:16200 static/js/zamboni/editors-min.js:5 static/js/zamboni/themes_review.js:180
+msgid "Approved"
+msgstr "Ceadaithe"
 
-#: static/js/zamboni/validator.js:481
-msgid "{0} error"
-msgid_plural "{0} errors"
-msgstr[0] "{0} earráid"
-msgstr[1] "{0} earráid"
-msgstr[2] "{0} earráid"
-msgstr[3] "{0} n-earráid"
-msgstr[4] "{0} earráid"
+#: static/js/zamboni/editors-all.js:16444 static/js/zamboni/editors-min.js:5 static/js/zamboni/themes_review.js:424
+msgid "No results found"
+msgstr ""
 
-#: static/js/zamboni/validator.js:483
-msgid "{0} warning"
-msgid_plural "{0} warnings"
-msgstr[0] "{0} rabhadh"
-msgstr[1] "{0} rabhadh"
-msgstr[2] "{0} rabhadh"
-msgstr[3] "{0} rabhadh"
-msgstr[4] "{0} rabhadh"
-
-#: static/js/zamboni/validator.js:485
-msgid "{0} notice"
-msgid_plural "{0} notices"
-msgstr[0] ""
-msgstr[1] ""
-msgstr[2] ""
-msgstr[3] ""
-msgstr[4] ""
-
-#: static/js/zamboni/validator.js:577
-msgid "Validation task could not complete or completed with errors"
-msgstr "Níorbh fhéidir an bailíochtú a chur i gcrích, nó chríochnaigh sé le hearráidí"
-
-#: static/js/zamboni/validator.js:595
-msgid "Internal server error"
-msgstr "Earráid inmheánach leis an bhfreastalaí"
-
-#: static/js/zamboni/mobile/buttons.js:52
+#: static/js/zamboni/mobile-all.js:15186 static/js/zamboni/mobile/buttons.js:52
 msgid "Not Updated for {0} {1}"
 msgstr ""
 
-#: static/js/zamboni/mobile/buttons.js:53
+#: static/js/zamboni/mobile-all.js:15187 static/js/zamboni/mobile/buttons.js:53
 msgid "Requires Newer Version of {0}"
 msgstr ""
 
-#: static/js/zamboni/mobile/buttons.js:54
+#: static/js/zamboni/mobile-all.js:15188 static/js/zamboni/mobile/buttons.js:54
 msgid "Unreviewed"
 msgstr "Gan léirmheas"
 
-#: static/js/zamboni/mobile/buttons.js:55
+#: static/js/zamboni/mobile-all.js:15189 static/js/zamboni/mobile/buttons.js:55
 msgid "Experimental <span>(Learn More)</span>"
 msgstr "Turgnamhach <span>(Tuilleadh Eolais)</span>"
 
-#: static/js/zamboni/mobile/buttons.js:56 static/js/zamboni/mobile/buttons.js:57
+#: static/js/zamboni/mobile-all.js:15190 static/js/zamboni/mobile-all.js:15191 static/js/zamboni/mobile/buttons.js:56 static/js/zamboni/mobile/buttons.js:57
 msgid "Not Available for {0}"
 msgstr ""
 
-#: static/js/zamboni/mobile/buttons.js:58
+#: static/js/zamboni/mobile-all.js:15192 static/js/zamboni/mobile/buttons.js:58
 msgid "Experimental"
 msgstr "Turgnamhach"
 
-#: static/js/zamboni/mobile/buttons.js:59
+#: static/js/zamboni/mobile-all.js:15193 static/js/zamboni/mobile/buttons.js:59
 msgid "Themes Require Newer Version of {0}"
 msgstr ""
 
-#: static/js/zamboni/mobile/buttons.js:60
+#: static/js/zamboni/mobile-all.js:15194 static/js/zamboni/mobile/buttons.js:60
 msgid "Themes Require {0}"
 msgstr ""
 
-#: static/js/zamboni/mobile/buttons.js:105
+#: static/js/zamboni/mobile-all.js:15239 static/js/zamboni/mobile/buttons.js:105
 msgid "Installing..."
 msgstr "Á Shuiteáil..."
 
-#: static/js/zamboni/mobile/buttons.js:125
+#: static/js/zamboni/mobile-all.js:15259 static/js/zamboni/mobile/buttons.js:125
 msgid "This add-on has been preliminarily reviewed by Mozilla."
 msgstr ""
 
-#: static/js/zamboni/mobile/buttons.js:250
+#: static/js/zamboni/mobile-all.js:15384 static/js/zamboni/mobile/buttons.js:250
 msgid "Keep it"
 msgstr "Coinnigh é"
 
-#: static/js/zamboni/mobile/general.js:344
+#: static/js/zamboni/mobile-all.js:16049 static/js/zamboni/mobile-min.js:6 static/js/zamboni/mobile/general.js:344
 msgid "You're trying it on!"
 msgstr ""
 
-#: static/js/zamboni/mobile/general.js:356
+#: static/js/zamboni/mobile-all.js:16061 static/js/zamboni/mobile-min.js:6 static/js/zamboni/mobile/general.js:356
 msgid "Added to Firefox"
 msgstr "Curtha le Firefox"
-

--- a/locale/gd/LC_MESSAGES/django.po
+++ b/locale/gd/LC_MESSAGES/django.po
@@ -3,69 +3,70 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2016-02-24 21:23+0000\n"
+"POT-Creation-Date: 2016-04-18 15:47+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
+"Language: \n"
 "MIME-Version: 1.0\n"
-"Content-Type: text/plain; charset=utf-8\n"
+"Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Generated-By: Babel 2.2.0\n"
 
-#: src/olympia/accounts/views.py:52
+#: src/olympia/accounts/views.py:54
 msgid "Your log in attempt could not be parsed. Please try again."
 msgstr ""
 
-#: src/olympia/accounts/views.py:54
+#: src/olympia/accounts/views.py:56
 msgid "Your Firefox Account could not be found. Please try again."
 msgstr ""
 
-#: src/olympia/accounts/views.py:55
+#: src/olympia/accounts/views.py:57
 msgid "You could not be logged in. Please try again."
 msgstr ""
 
-#: src/olympia/accounts/views.py:57
+#: src/olympia/accounts/views.py:59
 msgid "Your account has already been migrated to Firefox Accounts."
 msgstr ""
 
-#: src/olympia/accounts/views.py:59
+#: src/olympia/accounts/views.py:61
 msgid "Your Firefox Account already exists on this site."
 msgstr ""
 
-#: src/olympia/accounts/views.py:108
+#: src/olympia/accounts/views.py:110
 msgid "Great job!"
 msgstr ""
 
-#: src/olympia/accounts/views.py:109
+#: src/olympia/accounts/views.py:111
 msgid "You can now log in to Add-ons with your Firefox Account."
 msgstr ""
 
-#: src/olympia/accounts/views.py:121
+#: src/olympia/accounts/views.py:123
 msgid "Need help?"
 msgstr ""
 
-#: src/olympia/addons/buttons.py:180
+#: src/olympia/addons/buttons.py:177
 msgid "Download Now"
 msgstr ""
 
-#: src/olympia/addons/buttons.py:182
+#: src/olympia/addons/buttons.py:179
 msgid "Download"
 msgstr ""
 
 #. L10n: please keep &nbsp; in the string so &rarr; does not wrap.
-#: src/olympia/addons/buttons.py:186
+#: src/olympia/addons/buttons.py:183
 msgid "Continue to Download&nbsp;&rarr;"
 msgstr ""
 
-#: src/olympia/addons/buttons.py:202 src/olympia/addons/helpers.py:35 src/olympia/addons/views.py:319 src/olympia/addons/templates/addons/impala/details.html:114
+#: src/olympia/addons/buttons.py:199 src/olympia/addons/helpers.py:35 src/olympia/addons/views.py:333 src/olympia/addons/templates/addons/impala/details.html:111
 #: src/olympia/addons/templates/addons/impala/listing/items.html:17 src/olympia/addons/templates/addons/mobile/home.html:40 src/olympia/amo/templates/amo/side_nav.html:6
-#: src/olympia/amo/templates/amo/side_nav.html:10 src/olympia/amo/templates/amo/site_nav.html:2 src/olympia/amo/templates/amo/site_nav.html:55 src/olympia/bandwagon/views.py:95
-#: src/olympia/browse/views.py:54 src/olympia/browse/views.py:68 src/olympia/browse/views.py:235 src/olympia/browse/templates/browse/impala/category_landing.html:22
+#: src/olympia/amo/templates/amo/side_nav.html:10 src/olympia/amo/templates/amo/site_nav.html:2 src/olympia/amo/templates/amo/site_nav.html:53 src/olympia/bandwagon/views.py:95
+#: src/olympia/browse/views.py:54 src/olympia/browse/views.py:68 src/olympia/browse/views.py:202 src/olympia/browse/templates/browse/impala/category_landing.html:22
 #: src/olympia/browse/templates/browse/personas/mobile/category_landing.html:26
 msgid "Featured"
 msgstr ""
 
-#: src/olympia/addons/buttons.py:221
+#: src/olympia/addons/buttons.py:218
 msgid "Add to {0}"
 msgstr ""
 
@@ -113,39 +114,39 @@ msgid_plural "All tags must be at least {0} characters."
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/olympia/addons/forms.py:234
+#: src/olympia/addons/forms.py:238
 msgid "Categories cannot be changed while your add-on is featured for this application."
 msgstr ""
 
 #. L10n: {0} is the number of categories.
-#: src/olympia/addons/forms.py:238
+#: src/olympia/addons/forms.py:242
 msgid "You can have only {0} category."
 msgid_plural "You can have only {0} categories."
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/olympia/addons/forms.py:246
+#: src/olympia/addons/forms.py:250
 msgid "The miscellaneous category cannot be combined with additional categories."
 msgstr ""
 
-#: src/olympia/addons/forms.py:369
+#: src/olympia/addons/forms.py:374
 #, python-format
 msgid "Before changing your default locale you must have a name, summary, and description in that locale. You are missing %s."
 msgstr ""
 
-#: src/olympia/addons/forms.py:484 src/olympia/addons/forms.py:575
+#: src/olympia/addons/forms.py:455 src/olympia/addons/forms.py:546
 msgid "A license must be selected."
 msgstr ""
 
-#: src/olympia/addons/forms.py:556
+#: src/olympia/addons/forms.py:527
 msgid "Give Your Theme a Name."
 msgstr ""
 
-#: src/olympia/addons/forms.py:562 src/olympia/devhub/templates/devhub/personas/submit.html:53
+#: src/olympia/addons/forms.py:533 src/olympia/devhub/templates/devhub/personas/submit.html:53
 msgid "Describe your Theme."
 msgstr ""
 
-#: src/olympia/addons/forms.py:704
+#: src/olympia/addons/forms.py:675
 msgid "Enter a new author's email address"
 msgstr ""
 
@@ -153,37 +154,37 @@ msgstr ""
 msgid "Not Reviewed"
 msgstr ""
 
-#: src/olympia/addons/models.py:301
+#: src/olympia/addons/models.py:298
 msgid "Users have the option of contributing more or less than this amount."
 msgstr ""
 
-#: src/olympia/addons/models.py:309
-msgid "Users will always be asked in the Add-ons Manager (Firefox 4 and above)"
+#: src/olympia/addons/models.py:306
+msgid "Users will always be asked in the Add-ons Manager (Firefox 4 and above). Only applies to desktop."
 msgstr ""
 
-#: src/olympia/addons/models.py:1804 src/olympia/addons/templates/addons/details_box.html:55 src/olympia/devhub/templates/devhub/index.html:92
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:102
+#: src/olympia/addons/models.py:1802 src/olympia/addons/templates/addons/details_box.html:55 src/olympia/devhub/templates/devhub/index.html:92
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:89
 msgid "Listed"
 msgstr ""
 
-#: src/olympia/addons/views.py:320 src/olympia/browse/templates/browse/personas/mobile/category_landing.html:27
+#: src/olympia/addons/views.py:334 src/olympia/browse/templates/browse/personas/mobile/category_landing.html:27
 msgid "Popular"
 msgstr ""
 
-#: src/olympia/addons/views.py:321 src/olympia/browse/views.py:238 src/olympia/browse/views.py:280 src/olympia/browse/views.py:482
+#: src/olympia/addons/views.py:335 src/olympia/browse/views.py:205 src/olympia/browse/views.py:247 src/olympia/browse/views.py:449
 msgid "Recently Added"
 msgstr ""
 
-#: src/olympia/addons/views.py:322 src/olympia/bandwagon/views.py:99 src/olympia/browse/views.py:60 src/olympia/browse/views.py:71 src/olympia/search/forms.py:16 src/olympia/search/forms.py:91
+#: src/olympia/addons/views.py:336 src/olympia/bandwagon/views.py:99 src/olympia/browse/views.py:60 src/olympia/browse/views.py:71 src/olympia/search/forms.py:16 src/olympia/search/forms.py:91
 msgid "Recently Updated"
 msgstr ""
 
 #. l10n: {0} is the addon name
-#: src/olympia/addons/views.py:520
+#: src/olympia/addons/views.py:534
 msgid "Contribution for {0}"
 msgstr ""
 
-#: src/olympia/addons/views.py:613
+#: src/olympia/addons/views.py:627
 msgid "Abuse reported."
 msgstr ""
 
@@ -250,9 +251,9 @@ msgstr ""
 #: src/olympia/devhub/templates/devhub/addons/ajax_compat_update.html:36 src/olympia/devhub/templates/devhub/addons/profile.html:44 src/olympia/devhub/templates/devhub/addons/edit/admin.html:101
 #: src/olympia/devhub/templates/devhub/addons/edit/basic.html:152 src/olympia/devhub/templates/devhub/addons/edit/details.html:85 src/olympia/devhub/templates/devhub/addons/edit/support.html:67
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:166 src/olympia/devhub/templates/devhub/addons/forms_shared/media.html:149
-#: src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:44 src/olympia/devhub/templates/devhub/versions/add_file_modal.html:78 src/olympia/devhub/templates/devhub/versions/edit.html:139
-#: src/olympia/devhub/templates/devhub/versions/list.html:242 src/olympia/devhub/templates/devhub/versions/list.html:276 src/olympia/devhub/templates/devhub/versions/list.html:317
-#: src/olympia/devhub/templates/devhub/versions/list.html:351 src/olympia/reviews/templates/reviews/edit_review.html:16 src/olympia/translations/templates/translations/trans-menu.html:50
+#: src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:43 src/olympia/devhub/templates/devhub/versions/add_file_modal.html:58 src/olympia/devhub/templates/devhub/versions/edit.html:139
+#: src/olympia/devhub/templates/devhub/versions/list.html:239 src/olympia/devhub/templates/devhub/versions/list.html:281 src/olympia/devhub/templates/devhub/versions/list.html:315
+#: src/olympia/devhub/templates/devhub/versions/list.html:349 src/olympia/reviews/templates/reviews/edit_review.html:16 src/olympia/translations/templates/translations/trans-menu.html:50
 #: src/olympia/translations/templates/translations/trans-menu.html:62
 msgid "or"
 msgstr ""
@@ -363,7 +364,7 @@ msgid "Add-on Information for {0}"
 msgstr ""
 
 #: src/olympia/addons/templates/addons/details_box.html:30 src/olympia/addons/templates/addons/persona_detail_table.html:3 src/olympia/addons/templates/addons/mobile/details.html:63
-#: src/olympia/addons/templates/addons/mobile/persona_detail_table.html:7 src/olympia/browse/views.py:459 src/olympia/devhub/views.py:75
+#: src/olympia/addons/templates/addons/mobile/persona_detail_table.html:7 src/olympia/browse/views.py:426 src/olympia/devhub/views.py:73
 msgid "Updated"
 msgstr ""
 
@@ -382,11 +383,11 @@ msgstr ""
 msgid "Visibility"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/details_box.html:57 src/olympia/devhub/templates/devhub/index.html:94 src/olympia/devhub/templates/devhub/includes/addon_details.html:104
+#: src/olympia/addons/templates/addons/details_box.html:57 src/olympia/devhub/templates/devhub/index.html:94 src/olympia/devhub/templates/devhub/includes/addon_details.html:91
 msgid "Hidden"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/details_box.html:59 src/olympia/devhub/templates/devhub/index.html:96 src/olympia/devhub/templates/devhub/includes/addon_details.html:106
+#: src/olympia/addons/templates/addons/details_box.html:59 src/olympia/devhub/templates/devhub/index.html:96 src/olympia/devhub/templates/devhub/includes/addon_details.html:93
 msgid "Unlisted"
 msgstr ""
 
@@ -394,13 +395,13 @@ msgstr ""
 msgid "Required Add-ons"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/details_box.html:81 src/olympia/addons/templates/addons/persona_detail_table.html:15 src/olympia/browse/views.py:462 src/olympia/devhub/views.py:78
-#: src/olympia/devhub/views.py:85 src/olympia/discovery/templates/discovery/addons/detail.html:57 src/olympia/reviews/forms.py:62 src/olympia/reviews/templates/reviews/add.html:57
+#: src/olympia/addons/templates/addons/details_box.html:81 src/olympia/addons/templates/addons/persona_detail_table.html:15 src/olympia/browse/views.py:429 src/olympia/devhub/views.py:76
+#: src/olympia/devhub/views.py:83 src/olympia/discovery/templates/discovery/addons/detail.html:57 src/olympia/reviews/forms.py:62 src/olympia/reviews/templates/reviews/add.html:57
 #: src/olympia/reviews/templates/reviews/mobile/review_list.html:18
 msgid "Rating"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/details_box.html:85 src/olympia/browse/views.py:461 src/olympia/devhub/views.py:77 src/olympia/devhub/views.py:84
+#: src/olympia/addons/templates/addons/details_box.html:85 src/olympia/browse/views.py:428 src/olympia/devhub/views.py:75 src/olympia/devhub/views.py:82
 #: src/olympia/stats/templates/stats/addon_report_menu.html:8 src/olympia/stats/templates/stats/collection_report_menu.html:18
 msgid "Downloads"
 msgstr ""
@@ -420,7 +421,7 @@ msgstr ""
 
 #. The Privacy Policy for this add-on.
 #: src/olympia/addons/templates/addons/details_box.html:121 src/olympia/addons/templates/addons/privacy.html:19 src/olympia/addons/templates/addons/privacy.html:23
-#: src/olympia/addons/templates/addons/impala/button.html:43 src/olympia/addons/templates/addons/impala/details.html:307 src/olympia/devhub/templates/devhub/includes/policy_form.html:20
+#: src/olympia/addons/templates/addons/impala/button.html:43 src/olympia/addons/templates/addons/impala/details.html:312 src/olympia/devhub/templates/devhub/includes/policy_form.html:23
 #: src/olympia/templates/mobile/base_addons.html:87
 msgid "Privacy Policy"
 msgstr ""
@@ -445,7 +446,7 @@ msgstr ""
 msgid "Developer Comments"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/details_box.html:199 src/olympia/addons/templates/addons/impala/details.html:259
+#: src/olympia/addons/templates/addons/details_box.html:199 src/olympia/addons/templates/addons/impala/details.html:264
 msgid "Development Channel"
 msgstr ""
 
@@ -465,7 +466,7 @@ msgid ""
 "developer. To stop receiving development updates, reinstall the default version from the link above."
 msgstr ""
 
-#: src/olympia/addons/templates/addons/details_box.html:220 src/olympia/addons/templates/addons/impala/details.html:278
+#: src/olympia/addons/templates/addons/details_box.html:220 src/olympia/addons/templates/addons/impala/details.html:283
 msgid "Version {0}:"
 msgstr ""
 
@@ -484,7 +485,7 @@ msgid "End-User License Agreement for {0}"
 msgstr ""
 
 #: src/olympia/addons/templates/addons/eula.html:17 src/olympia/addons/templates/addons/eula.html:21 src/olympia/addons/templates/addons/impala/button.html:48
-#: src/olympia/addons/templates/addons/impala/details.html:316 src/olympia/devhub/templates/devhub/includes/policy_form.html:3 src/olympia/discovery/templates/discovery/addons/eula.html:11
+#: src/olympia/addons/templates/addons/impala/details.html:321 src/olympia/devhub/templates/devhub/includes/policy_form.html:3 src/olympia/discovery/templates/discovery/addons/eula.html:11
 msgid "End-User License Agreement"
 msgstr ""
 
@@ -501,7 +502,7 @@ msgstr ""
 msgid "Add-ons for {0}"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/home.html:10 src/olympia/addons/templates/addons/home.html:51 src/olympia/browse/templates/browse/impala/base_listing.html:11
+#: src/olympia/addons/templates/addons/home.html:10 src/olympia/addons/templates/addons/home.html:53 src/olympia/browse/templates/browse/impala/base_listing.html:11
 msgid "Featured Extensions"
 msgstr ""
 
@@ -509,29 +510,29 @@ msgstr ""
 msgid "Popular Extensions"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/home.html:42 src/olympia/amo/templates/amo/side_nav.html:3 src/olympia/amo/templates/amo/side_nav.html:11 src/olympia/amo/templates/amo/site_nav.html:3
-#: src/olympia/amo/templates/amo/site_nav.html:25 src/olympia/browse/views.py:236 src/olympia/browse/views.py:281 src/olympia/browse/views.py:481
+#: src/olympia/addons/templates/addons/home.html:44 src/olympia/amo/templates/amo/side_nav.html:3 src/olympia/amo/templates/amo/side_nav.html:11 src/olympia/amo/templates/amo/site_nav.html:3
+#: src/olympia/amo/templates/amo/site_nav.html:25 src/olympia/browse/views.py:203 src/olympia/browse/views.py:248 src/olympia/browse/views.py:448
 msgid "Most Popular"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/home.html:43
+#: src/olympia/addons/templates/addons/home.html:45
 msgid "All »"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/home.html:52 src/olympia/addons/templates/addons/home.html:61 src/olympia/addons/templates/addons/home.html:70 src/olympia/addons/templates/addons/home.html:78
+#: src/olympia/addons/templates/addons/home.html:54 src/olympia/addons/templates/addons/home.html:63 src/olympia/addons/templates/addons/home.html:72 src/olympia/addons/templates/addons/home.html:80
 #: src/olympia/browse/templates/browse/impala/category_landing.html:36
 msgid "See all »"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/home.html:60
+#: src/olympia/addons/templates/addons/home.html:62
 msgid "Up &amp; Coming Extensions"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/home.html:69 src/olympia/browse/templates/browse/personas/category_landing.html:61 src/olympia/discovery/templates/discovery/pane.html:74
+#: src/olympia/addons/templates/addons/home.html:71 src/olympia/browse/templates/browse/personas/category_landing.html:61 src/olympia/discovery/templates/discovery/pane.html:74
 msgid "Featured Themes"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/home.html:77 src/olympia/bandwagon/templates/bandwagon/impala/collection_listing.html:5
+#: src/olympia/addons/templates/addons/home.html:79 src/olympia/bandwagon/templates/bandwagon/impala/collection_listing.html:5
 msgid "Featured Collections"
 msgstr ""
 
@@ -549,7 +550,7 @@ msgid "Updated {0}"
 msgstr ""
 
 #. {0} is a date.
-#: src/olympia/addons/templates/addons/macros.html:10 src/olympia/addons/templates/addons/macros.html:69 src/olympia/addons/templates/addons/persona_preview.html:21
+#: src/olympia/addons/templates/addons/macros.html:10 src/olympia/addons/templates/addons/macros.html:69 src/olympia/addons/templates/addons/persona_preview.html:22
 #: src/olympia/addons/templates/addons/listing/items_mobile.html:44 src/olympia/addons/templates/addons/listing/macros.html:39
 #: src/olympia/bandwagon/templates/bandwagon/collection_listing_items.html:37 src/olympia/bandwagon/templates/bandwagon/impala/collection_listing_items.html:37
 msgid "Added {0}"
@@ -570,15 +571,14 @@ msgstr[0] ""
 msgstr[1] ""
 
 #. {0} is the number of downloads.
-#: src/olympia/addons/templates/addons/macros.html:53 src/olympia/addons/templates/addons/impala/details.html:61
+#: src/olympia/addons/templates/addons/macros.html:53 src/olympia/addons/templates/addons/impala/details.html:59
 msgid "{0} weekly download"
 msgid_plural "{0} weekly downloads"
 msgstr[0] ""
 msgstr[1] ""
 
 #. {0} is the number of users.
-#: src/olympia/addons/templates/addons/macros.html:61 src/olympia/addons/templates/addons/impala/details.html:54 src/olympia/compat/templates/compat/index.html:71
-#: src/olympia/zadmin/templates/zadmin/compat.html:67
+#: src/olympia/addons/templates/addons/macros.html:61 src/olympia/addons/templates/addons/impala/details.html:52 src/olympia/zadmin/templates/zadmin/compat.html:67
 msgid "{0} user"
 msgid_plural "{0} users"
 msgstr[0] ""
@@ -596,7 +596,7 @@ msgstr ""
 msgid "Return to the addon."
 msgstr ""
 
-#: src/olympia/addons/templates/addons/persona_detail.html:17 src/olympia/addons/templates/addons/impala/details.html:106 src/olympia/addons/templates/addons/mobile/details.html:23
+#: src/olympia/addons/templates/addons/persona_detail.html:17 src/olympia/addons/templates/addons/impala/details.html:103 src/olympia/addons/templates/addons/mobile/details.html:23
 #: src/olympia/addons/templates/addons/mobile/persona_detail.html:21 src/olympia/discovery/templates/discovery/addons/base.html:27 src/olympia/editors/templates/editors/review.html:31
 msgid "by"
 msgstr ""
@@ -640,34 +640,35 @@ msgstr ""
 msgid "License"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/persona_preview.html:12 src/olympia/constants/base.py:48
+#: src/olympia/addons/templates/addons/persona_preview.html:13 src/olympia/constants/base.py:48
 msgid "Awaiting Review"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/persona_preview.html:14 src/olympia/amo/log.py:180 src/olympia/constants/base.py:42 src/olympia/editors/helpers.py:62
+#: src/olympia/addons/templates/addons/persona_preview.html:15 src/olympia/amo/log.py:180 src/olympia/constants/base.py:42 src/olympia/editors/helpers.py:62
 msgid "Rejected"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/persona_preview.html:16 src/olympia/amo/log.py:159
+#: src/olympia/addons/templates/addons/persona_preview.html:17 src/olympia/amo/log.py:159
 msgid "Approved"
 msgstr ""
 
 #. {0} is the number of users.
-#: src/olympia/addons/templates/addons/persona_preview.html:26 src/olympia/addons/templates/addons/listing/items_mobile.html:36 src/olympia/addons/templates/addons/listing/macros.html:31
+#: src/olympia/addons/templates/addons/persona_preview.html:27 src/olympia/addons/templates/addons/listing/items_mobile.html:36 src/olympia/addons/templates/addons/listing/macros.html:31
 msgid "<strong>{0}</strong> user"
 msgid_plural "<strong>{0}</strong> users"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/olympia/addons/templates/addons/persona_preview.html:40
+#: src/olympia/addons/templates/addons/persona_preview.html:41
 msgid "Hover to Preview"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/persona_preview.html:46 src/olympia/addons/templates/addons/persona_preview.html:48 src/olympia/reviews/templates/reviews/add.html:15
+#: src/olympia/addons/templates/addons/persona_preview.html:47 src/olympia/addons/templates/addons/persona_preview.html:49 src/olympia/addons/templates/addons/persona_preview.html:97
+#: src/olympia/reviews/templates/reviews/add.html:15
 msgid "Add"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/persona_preview.html:57 src/olympia/bandwagon/templates/bandwagon/ajax_new.html:16 src/olympia/bandwagon/templates/bandwagon/edit.html:19
+#: src/olympia/addons/templates/addons/persona_preview.html:58 src/olympia/bandwagon/templates/bandwagon/ajax_new.html:16 src/olympia/bandwagon/templates/bandwagon/edit.html:19
 #: src/olympia/bandwagon/templates/bandwagon/includes/addedit.html:19 src/olympia/devhub/templates/devhub/addons/edit/admin.html:13 src/olympia/devhub/templates/devhub/addons/edit/basic.html:10
 #: src/olympia/devhub/templates/devhub/addons/edit/details.html:8 src/olympia/devhub/templates/devhub/addons/edit/media.html:6 src/olympia/devhub/templates/devhub/addons/edit/support.html:8
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:9 src/olympia/devhub/templates/devhub/addons/submit/describe.html:29 src/olympia/editors/templates/editors/review.html:257
@@ -676,21 +677,21 @@ msgstr ""
 
 #. For datetime formatting, see the table on
 #. http://docs.python.org/library/datetime.html#strftime-and-strptime-behavior
-#: src/olympia/addons/templates/addons/persona_preview.html:66
+#: src/olympia/addons/templates/addons/persona_preview.html:67
 #, python-format
 msgid "%%Y-%%m-%%d"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/persona_preview.html:67
+#: src/olympia/addons/templates/addons/persona_preview.html:68
 msgid "by {0} on {1}"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/persona_preview.html:75 src/olympia/reviews/helpers.py:17 src/olympia/reviews/templates/reviews/review_list.html:63
+#: src/olympia/addons/templates/addons/persona_preview.html:76 src/olympia/reviews/helpers.py:17 src/olympia/reviews/templates/reviews/review_list.html:63
 #: src/olympia/reviews/templates/reviews/reviews_link.html:21 src/olympia/reviews/templates/reviews/impala/reviews_link.html:16
 msgid "Not yet rated"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/persona_preview.html:78
+#: src/olympia/addons/templates/addons/persona_preview.html:79
 msgid "<b>{0}</b> users"
 msgstr ""
 
@@ -703,7 +704,7 @@ msgid "Learn more about Firefox"
 msgstr ""
 
 #: src/olympia/addons/templates/addons/popups.html:22
-msgid "or <b><a class=\"installer\" href=\"{url}\">download anyway</a></b>"
+msgid "or <b><a class=\"button installer\" href=\"{url}\">download anyway</a></b>"
 msgstr ""
 
 #: src/olympia/addons/templates/addons/popups.html:26
@@ -802,7 +803,7 @@ msgid ""
 msgstr ""
 
 #: src/olympia/addons/templates/addons/report_abuse.html:6 src/olympia/addons/templates/addons/report_abuse_full.html:10 src/olympia/addons/templates/addons/impala/details-more.html:23
-#: src/olympia/addons/templates/addons/impala/details.html:328
+#: src/olympia/addons/templates/addons/impala/details.html:333
 msgid "Report Abuse"
 msgstr ""
 
@@ -821,9 +822,9 @@ msgstr ""
 #: src/olympia/devhub/templates/devhub/addons/ajax_compat_update.html:36 src/olympia/devhub/templates/devhub/addons/profile.html:44 src/olympia/devhub/templates/devhub/addons/edit/admin.html:104
 #: src/olympia/devhub/templates/devhub/addons/edit/basic.html:155 src/olympia/devhub/templates/devhub/addons/edit/details.html:88 src/olympia/devhub/templates/devhub/addons/edit/support.html:70
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:169 src/olympia/devhub/templates/devhub/addons/forms_shared/media.html:152
-#: src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:44 src/olympia/devhub/templates/devhub/personas/edit.html:222 src/olympia/devhub/templates/devhub/versions/add_file_modal.html:79
-#: src/olympia/devhub/templates/devhub/versions/edit.html:140 src/olympia/devhub/templates/devhub/versions/list.html:208 src/olympia/devhub/templates/devhub/versions/list.html:242
-#: src/olympia/devhub/templates/devhub/versions/list.html:276 src/olympia/devhub/templates/devhub/versions/list.html:317 src/olympia/reviews/templates/reviews/edit_review.html:16
+#: src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:43 src/olympia/devhub/templates/devhub/personas/edit.html:222 src/olympia/devhub/templates/devhub/versions/add_file_modal.html:59
+#: src/olympia/devhub/templates/devhub/versions/edit.html:140 src/olympia/devhub/templates/devhub/versions/list.html:208 src/olympia/devhub/templates/devhub/versions/list.html:239
+#: src/olympia/devhub/templates/devhub/versions/list.html:281 src/olympia/devhub/templates/devhub/versions/list.html:315 src/olympia/reviews/templates/reviews/edit_review.html:16
 #: src/olympia/translations/templates/translations/trans-menu.html:50 src/olympia/translations/templates/translations/trans-menu.html:62 src/olympia/zadmin/templates/zadmin/validation.html:105
 msgid "Cancel"
 msgstr ""
@@ -868,7 +869,7 @@ msgstr ""
 msgid "Review Guidelines"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/review_list_box.html:5 src/olympia/addons/templates/addons/impala/details-more.html:27 src/olympia/editors/helpers.py:921
+#: src/olympia/addons/templates/addons/review_list_box.html:5 src/olympia/addons/templates/addons/impala/details-more.html:27 src/olympia/editors/helpers.py:1001
 #: src/olympia/reviews/templates/reviews/add.html:14 src/olympia/reviews/templates/reviews/reply.html:14 src/olympia/reviews/templates/reviews/review_list.html:19
 #: src/olympia/reviews/templates/reviews/mobile/review_list.html:26
 msgid "Reviews"
@@ -959,119 +960,119 @@ msgid_plural "Other add-ons by these authors"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/olympia/addons/templates/addons/impala/details.html:41
+#: src/olympia/addons/templates/addons/impala/details.html:39
 #, python-format
 msgid "<span itemprop=\"ratingCount\">%(num)s</span> user review"
 msgid_plural "<span itemprop=\"ratingCount\">%(num)s</span> user reviews"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/olympia/addons/templates/addons/impala/details.html:69
+#: src/olympia/addons/templates/addons/impala/details.html:66
 msgid "View statistics"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/impala/details.html:84
+#: src/olympia/addons/templates/addons/impala/details.html:81
 msgid "Manage"
 msgstr ""
 
 #. {0} is an add-on name.
-#: src/olympia/addons/templates/addons/impala/details.html:96
+#: src/olympia/addons/templates/addons/impala/details.html:93
 msgid "Icon of {0}"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/impala/details.html:103 src/olympia/addons/templates/addons/impala/listing/items.html:14
+#: src/olympia/addons/templates/addons/impala/details.html:100 src/olympia/addons/templates/addons/impala/listing/items.html:14
 msgid "No Restart"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/impala/details.html:127
+#: src/olympia/addons/templates/addons/impala/details.html:124
 #, python-format
 msgid "Meet the Developer: <a href=\"%(url)s\">%(name)s</a>"
 msgid_plural "<a href=\"%(url)s\">Meet the Developers</a>"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/olympia/addons/templates/addons/impala/details.html:137
+#: src/olympia/addons/templates/addons/impala/details.html:134
 msgid "Learn why {0} was created and find out what's next for this add-on."
 msgstr ""
 
 #. {0} is an index.
-#: src/olympia/addons/templates/addons/impala/details.html:156
+#: src/olympia/addons/templates/addons/impala/details.html:161
 msgid "Add-on screenshot #{0}"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/impala/details.html:182
+#: src/olympia/addons/templates/addons/impala/details.html:187
 msgid "Add-on home page"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/impala/details.html:185
+#: src/olympia/addons/templates/addons/impala/details.html:190
 msgid "Support site"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/impala/details.html:189
+#: src/olympia/addons/templates/addons/impala/details.html:194
 msgid "Support E-mail"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/impala/details.html:194 src/olympia/devhub/models.py:378 src/olympia/devhub/templates/devhub/versions/list.html:12
+#: src/olympia/addons/templates/addons/impala/details.html:199 src/olympia/devhub/models.py:378 src/olympia/devhub/templates/devhub/versions/list.html:12
 #: src/olympia/versions/templates/versions/version.html:6 src/olympia/versions/templates/versions/mobile/version.html:6
 msgid "Version {0}"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/impala/details.html:194
+#: src/olympia/addons/templates/addons/impala/details.html:199
 msgid "Info"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/impala/details.html:195 src/olympia/devhub/templates/devhub/includes/addon_details.html:129
+#: src/olympia/addons/templates/addons/impala/details.html:200 src/olympia/devhub/templates/devhub/includes/addon_details.html:116
 msgid "Last Updated:"
-msgstr ""
-
-#: src/olympia/addons/templates/addons/impala/details.html:200
-#, python-format
-msgid "Released under <a target=\"_blank\" href=\"%(url)s\">%(name)s</a>"
-msgstr ""
-
-#: src/olympia/addons/templates/addons/impala/details.html:201 src/olympia/addons/templates/addons/impala/details.html:206 src/olympia/amo/helpers.py:398 src/olympia/devhub/forms.py:142
-#: src/olympia/devhub/forms.py:173 src/olympia/versions/templates/versions/version.html:40 src/olympia/versions/templates/versions/version.html:45
-msgid "Custom License"
 msgstr ""
 
 #: src/olympia/addons/templates/addons/impala/details.html:205
 #, python-format
+msgid "Released under <a target=\"_blank\" href=\"%(url)s\">%(name)s</a>"
+msgstr ""
+
+#: src/olympia/addons/templates/addons/impala/details.html:206 src/olympia/addons/templates/addons/impala/details.html:211 src/olympia/amo/helpers.py:398 src/olympia/devhub/forms.py:142
+#: src/olympia/devhub/forms.py:173 src/olympia/versions/templates/versions/version.html:40 src/olympia/versions/templates/versions/version.html:45
+msgid "Custom License"
+msgstr ""
+
+#: src/olympia/addons/templates/addons/impala/details.html:210
+#, python-format
 msgid "Released under <a href=\"%(url)s\">%(name)s</a>"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/impala/details.html:217
+#: src/olympia/addons/templates/addons/impala/details.html:222
 msgid "About this Add-on"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/impala/details.html:233
+#: src/olympia/addons/templates/addons/impala/details.html:238
 msgid "Developer’s Comments"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/impala/details.html:243
+#: src/olympia/addons/templates/addons/impala/details.html:248
 msgid "Version Information"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/impala/details.html:250
+#: src/olympia/addons/templates/addons/impala/details.html:255
 msgid "See complete version history"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/impala/details.html:262
+#: src/olympia/addons/templates/addons/impala/details.html:267
 msgid ""
 "The Development Channel lets you test an experimental new version of this add-on before it's released to the general public. Once you install the development version, you will continue to get "
 "updates from this channel. To stop receiving development updates, reinstall the default version from the link above."
 msgstr ""
 
-#: src/olympia/addons/templates/addons/impala/details.html:272
+#: src/olympia/addons/templates/addons/impala/details.html:277
 msgid "<strong>Caution:</strong> Development versions of this add-on have not been reviewed by Mozilla."
 msgstr ""
 
-#: src/olympia/addons/templates/addons/impala/details.html:287
+#: src/olympia/addons/templates/addons/impala/details.html:292
 msgid "See complete development channel history"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/impala/details.html:306 src/olympia/addons/templates/addons/impala/details.html:315 src/olympia/addons/templates/addons/impala/details.html:327
+#: src/olympia/addons/templates/addons/impala/details.html:311 src/olympia/addons/templates/addons/impala/details.html:320 src/olympia/addons/templates/addons/impala/details.html:332
 #: src/olympia/addons/templates/addons/impala/review_add_box.html:4 src/olympia/stats/templates/stats/popup.html:2 src/olympia/stats/templates/stats/popup.html:8
-#: src/olympia/stats/templates/stats/stats.html:202 src/olympia/users/templates/users/profile.html:119
+#: src/olympia/stats/templates/stats/stats.html:204 src/olympia/users/templates/users/profile.html:119
 msgid "close"
 msgstr ""
 
@@ -1127,15 +1128,11 @@ msgstr ""
 msgid "Source Code License"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/impala/persona_grid.html:16 src/olympia/addons/templates/addons/impala/toplist.html:6
-msgid "{0} users"
-msgstr ""
-
 #: src/olympia/addons/templates/addons/impala/review_list_box.html:19 src/olympia/reviews/templates/reviews/review.html:40
 msgid "permalink"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/impala/review_list_box.html:23 src/olympia/editors/templates/editors/queue.html:98 src/olympia/reviews/templates/reviews/review.html:44
+#: src/olympia/addons/templates/addons/impala/review_list_box.html:23 src/olympia/editors/templates/editors/queue.html:104 src/olympia/reviews/templates/reviews/review.html:44
 msgid "translate"
 msgstr ""
 
@@ -1154,6 +1151,10 @@ msgstr ""
 msgid "Be the first!"
 msgstr ""
 
+#: src/olympia/addons/templates/addons/impala/toplist.html:6
+msgid "{0} users"
+msgstr ""
+
 #: src/olympia/addons/templates/addons/impala/listing/sorter.html:14 src/olympia/devhub/templates/devhub/addons/listing/item_actions.html:49
 msgid "More"
 msgstr ""
@@ -1166,7 +1167,7 @@ msgstr ""
 msgid "My Add-ons"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/includes/dashboard_tabs.html:6 src/olympia/amo/context_processors.py:51
+#: src/olympia/addons/templates/addons/includes/dashboard_tabs.html:6 src/olympia/amo/context_processors.py:50
 msgid "My Themes"
 msgstr ""
 
@@ -1221,7 +1222,7 @@ msgstr ""
 msgid "Weekly Downloads"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/mobile/details.html:99 src/olympia/compat/templates/compat/reporter_detail.html:46 src/olympia/devhub/forms.py:787
+#: src/olympia/addons/templates/addons/mobile/details.html:99 src/olympia/compat/templates/compat/reporter_detail.html:46 src/olympia/devhub/forms.py:788
 #: src/olympia/devhub/templates/devhub/versions/list.html:163
 msgid "Version"
 msgstr ""
@@ -1305,7 +1306,7 @@ msgstr ""
 #: src/olympia/browse/templates/browse/personas/category_landing.html:21 src/olympia/browse/templates/browse/personas/category_landing.html:23
 #: src/olympia/browse/templates/browse/personas/category_landing.html:38 src/olympia/browse/templates/browse/personas/grid.html:7 src/olympia/browse/templates/browse/personas/grid.html:11
 #: src/olympia/browse/templates/browse/personas/mobile/base.html:7 src/olympia/browse/templates/browse/personas/mobile/category_landing.html:19 src/olympia/constants/base.py:180
-#: src/olympia/devhub/templates/devhub/personas/submit.html:13 src/olympia/editors/helpers.py:105 src/olympia/editors/templates/editors/base.html:26
+#: src/olympia/devhub/templates/devhub/personas/submit.html:13 src/olympia/editors/helpers.py:107 src/olympia/editors/templates/editors/base.html:26
 #: src/olympia/editors/templates/editors/performance.html:73 src/olympia/search/templates/search/personas.html:39 src/olympia/templates/menu_links.html:9
 msgid "Themes"
 msgstr ""
@@ -1326,7 +1327,7 @@ msgstr ""
 msgid "Highest Rated"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/mobile/home.html:74 src/olympia/amo/templates/amo/side_nav.html:5 src/olympia/amo/templates/amo/site_nav.html:27 src/olympia/amo/templates/amo/site_nav.html:57
+#: src/olympia/addons/templates/addons/mobile/home.html:74 src/olympia/amo/templates/amo/side_nav.html:5 src/olympia/amo/templates/amo/site_nav.html:27 src/olympia/amo/templates/amo/site_nav.html:55
 #: src/olympia/bandwagon/views.py:97 src/olympia/browse/views.py:57 src/olympia/browse/views.py:67 src/olympia/browse/templates/browse/personas/mobile/category_landing.html:65
 #: src/olympia/search/forms.py:15 src/olympia/search/forms.py:87
 msgid "Newest"
@@ -1340,90 +1341,90 @@ msgstr ""
 msgid "Theme Info &raquo;"
 msgstr ""
 
-#: src/olympia/amo/context_processors.py:39 src/olympia/devhub/templates/devhub/nav.html:43
+#: src/olympia/amo/context_processors.py:37 src/olympia/devhub/templates/devhub/nav.html:43
 msgid "Tools"
 msgstr ""
 
-#: src/olympia/amo/context_processors.py:48 src/olympia/discovery/templates/discovery/pane_account.html:8 src/olympia/users/templates/users/includes/navigation.html:2
+#: src/olympia/amo/context_processors.py:47 src/olympia/discovery/templates/discovery/pane_account.html:8 src/olympia/users/templates/users/includes/navigation.html:2
 msgid "My Profile"
 msgstr ""
 
-#: src/olympia/amo/context_processors.py:54 src/olympia/users/templates/users/edit.html:5 src/olympia/users/templates/users/includes/navigation.html:3
+#: src/olympia/amo/context_processors.py:53 src/olympia/users/templates/users/edit.html:5 src/olympia/users/templates/users/includes/navigation.html:3
 msgid "Account Settings"
 msgstr ""
 
-#: src/olympia/amo/context_processors.py:57 src/olympia/discovery/templates/discovery/pane_account.html:11 src/olympia/users/templates/users/profile.html:83
+#: src/olympia/amo/context_processors.py:56 src/olympia/discovery/templates/discovery/pane_account.html:11 src/olympia/users/templates/users/profile.html:83
 #: src/olympia/users/templates/users/includes/navigation.html:4
 msgid "My Collections"
 msgstr ""
 
-#: src/olympia/amo/context_processors.py:62 src/olympia/discovery/templates/discovery/pane_account.html:10 src/olympia/users/templates/users/includes/navigation.html:7
+#: src/olympia/amo/context_processors.py:61 src/olympia/discovery/templates/discovery/pane_account.html:10 src/olympia/users/templates/users/includes/navigation.html:7
 msgid "My Favorites"
 msgstr ""
 
-#: src/olympia/amo/context_processors.py:67 src/olympia/discovery/templates/discovery/pane_account.html:13 src/olympia/templates/impala/user_login.html:14
+#: src/olympia/amo/context_processors.py:66 src/olympia/discovery/templates/discovery/pane_account.html:13 src/olympia/templates/impala/user_login.html:14
 #: src/olympia/templates/mobile/header_auth.html:5
 msgid "Log out"
 msgstr ""
 
-#: src/olympia/amo/context_processors.py:72 src/olympia/devhub/templates/devhub/addons/dashboard.html:4
+#: src/olympia/amo/context_processors.py:71 src/olympia/devhub/templates/devhub/addons/dashboard.html:4
 msgid "Manage My Submissions"
 msgstr ""
 
-#: src/olympia/amo/context_processors.py:75 src/olympia/devhub/templates/devhub/nav.html:27 src/olympia/devhub/templates/devhub/addons/dashboard.html:25
+#: src/olympia/amo/context_processors.py:74 src/olympia/devhub/templates/devhub/nav.html:27 src/olympia/devhub/templates/devhub/addons/dashboard.html:25
 #: src/olympia/devhub/templates/devhub/addons/submit/base.html:4
 msgid "Submit a New Add-on"
 msgstr ""
 
-#: src/olympia/amo/context_processors.py:77 src/olympia/browse/templates/browse/personas/base.html:50 src/olympia/devhub/templates/devhub/index.html:24
+#: src/olympia/amo/context_processors.py:76 src/olympia/browse/templates/browse/personas/base.html:50 src/olympia/devhub/templates/devhub/index.html:24
 #: src/olympia/devhub/templates/devhub/addons/dashboard.html:29
 msgid "Submit a New Theme"
 msgstr ""
 
-#: src/olympia/amo/context_processors.py:79 src/olympia/amo/templates/amo/site_nav.html:87 src/olympia/devhub/helpers.py:36 src/olympia/devhub/helpers.py:68 src/olympia/devhub/helpers.py:102
+#: src/olympia/amo/context_processors.py:78 src/olympia/amo/templates/amo/site_nav.html:85 src/olympia/devhub/helpers.py:36 src/olympia/devhub/helpers.py:68 src/olympia/devhub/helpers.py:102
 #: src/olympia/templates/footer.html:6 src/olympia/templates/menu_links.html:14
 msgid "Developer Hub"
 msgstr ""
 
-#: src/olympia/amo/context_processors.py:83 src/olympia/devhub/views.py:1792
+#: src/olympia/amo/context_processors.py:81 src/olympia/devhub/views.py:1796
 msgid "Manage API Keys"
 msgstr ""
 
-#: src/olympia/amo/context_processors.py:88 src/olympia/editors/helpers.py:82 src/olympia/editors/helpers.py:102 src/olympia/editors/templates/editors/base.html:10
+#: src/olympia/amo/context_processors.py:86 src/olympia/editors/helpers.py:84 src/olympia/editors/helpers.py:104 src/olympia/editors/templates/editors/base.html:10
 msgid "Editor Tools"
 msgstr ""
 
-#: src/olympia/amo/context_processors.py:92
+#: src/olympia/amo/context_processors.py:90
 msgid "Admin Tools"
 msgstr ""
 
-#: src/olympia/amo/fields.py:15
+#: src/olympia/amo/fields.py:20
 msgid "Incorrect, please try again."
 msgstr ""
 
-#: src/olympia/amo/fields.py:16
+#: src/olympia/amo/fields.py:21
 msgid "Error verifying input, please try again."
 msgstr ""
 
-#: src/olympia/amo/fields.py:32
+#: src/olympia/amo/fields.py:37
 msgid "This must be a valid hex color code, such as #000000."
 msgstr ""
 
-#: src/olympia/amo/fields.py:58
+#: src/olympia/amo/fields.py:63
 msgid "Enter at least one value."
 msgstr ""
 
-#: src/olympia/amo/helpers.py:162 src/olympia/amo/templates/amo/site_nav.html:61 src/olympia/bandwagon/templates/bandwagon/add.html:9
+#: src/olympia/amo/helpers.py:162 src/olympia/amo/templates/amo/site_nav.html:59 src/olympia/bandwagon/templates/bandwagon/add.html:9
 #: src/olympia/bandwagon/templates/bandwagon/collection_detail.html:15 src/olympia/bandwagon/templates/bandwagon/delete.html:9 src/olympia/bandwagon/templates/bandwagon/edit.html:15
 #: src/olympia/bandwagon/templates/bandwagon/user_listing.html:18 src/olympia/bandwagon/templates/bandwagon/user_listing.html:21
 #: src/olympia/bandwagon/templates/bandwagon/impala/collection_listing.html:12 src/olympia/bandwagon/templates/bandwagon/impala/collection_listing.html:20
 #: src/olympia/bandwagon/templates/bandwagon/impala/collection_listing.html:24 src/olympia/bandwagon/templates/bandwagon/impala/collection_sidebar.html:3
 #: src/olympia/bandwagon/templates/bandwagon/includes/collection_sidebar.html:2 src/olympia/bandwagon/templates/bandwagon/mobile/collection_listing.html:3
-#: src/olympia/stats/templates/stats/stats.html:77 src/olympia/templates/menu_links.html:12
+#: src/olympia/stats/templates/stats/stats.html:33 src/olympia/templates/menu_links.html:12
 msgid "Collections"
 msgstr ""
 
-#: src/olympia/amo/helpers.py:171 src/olympia/amo/templates/amo/site_nav.html:85 src/olympia/browse/templates/browse/language_tools.html:3
+#: src/olympia/amo/helpers.py:171 src/olympia/amo/templates/amo/site_nav.html:83 src/olympia/browse/templates/browse/language_tools.html:3
 msgid "Dictionaries & Language Packs"
 msgstr ""
 
@@ -1575,8 +1576,8 @@ msgstr ""
 msgid "Comment on {addon} {version}."
 msgstr ""
 
-#: src/olympia/amo/log.py:236 src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:19 src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:47
-#: src/olympia/editors/helpers.py:511 src/olympia/editors/templates/editors/themes/history_table.html:11
+#: src/olympia/amo/log.py:236 src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:17 src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:45
+#: src/olympia/editors/helpers.py:584 src/olympia/editors/templates/editors/themes/history_table.html:11
 msgid "Comment"
 msgstr ""
 
@@ -1899,7 +1900,7 @@ msgstr ""
 #: src/olympia/amo/templates/amo/mobile/paginator.html:14 src/olympia/amo/templates/amo/mobile/paginator.html:16 src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:51
 #: src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:65 src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:78
 #: src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:91 src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:104
-#: src/olympia/discovery/templates/discovery/pane.html:45 src/olympia/discovery/templates/discovery/addons/detail.html:39 src/olympia/stats/templates/stats/stats.html:167
+#: src/olympia/discovery/templates/discovery/pane.html:45 src/olympia/discovery/templates/discovery/addons/detail.html:39 src/olympia/stats/templates/stats/stats.html:169
 msgid "Next"
 msgstr ""
 
@@ -1931,7 +1932,7 @@ msgid ""
 msgstr ""
 
 #: src/olympia/amo/templates/amo/side_nav.html:4 src/olympia/amo/templates/amo/side_nav.html:12 src/olympia/amo/templates/amo/site_nav.html:4 src/olympia/amo/templates/amo/site_nav.html:26
-#: src/olympia/browse/views.py:56 src/olympia/browse/views.py:66 src/olympia/browse/views.py:237 src/olympia/browse/views.py:282 src/olympia/search/forms.py:86
+#: src/olympia/browse/views.py:56 src/olympia/browse/views.py:66 src/olympia/browse/views.py:204 src/olympia/browse/views.py:249 src/olympia/search/forms.py:86
 msgid "Top Rated"
 msgstr ""
 
@@ -1945,38 +1946,38 @@ msgstr ""
 msgid "Extensions"
 msgstr ""
 
-#: src/olympia/amo/templates/amo/site_nav.html:45
+#: src/olympia/amo/templates/amo/site_nav.html:44
 msgid "Want more customization? Try <b>Complete Themes</b>"
 msgstr ""
 
-#: src/olympia/amo/templates/amo/site_nav.html:56 src/olympia/bandwagon/views.py:96
+#: src/olympia/amo/templates/amo/site_nav.html:54 src/olympia/bandwagon/views.py:96
 msgid "Most Followers"
 msgstr ""
 
-#: src/olympia/amo/templates/amo/site_nav.html:68 src/olympia/bandwagon/templates/bandwagon/impala/collection_sidebar.html:16
+#: src/olympia/amo/templates/amo/site_nav.html:66 src/olympia/bandwagon/templates/bandwagon/impala/collection_sidebar.html:16
 #: src/olympia/bandwagon/templates/bandwagon/includes/collection_sidebar.html:18
 msgid "Collections I've Made"
 msgstr ""
 
-#: src/olympia/amo/templates/amo/site_nav.html:70 src/olympia/bandwagon/templates/bandwagon/user_listing.html:4 src/olympia/bandwagon/templates/bandwagon/impala/collection_sidebar.html:13
+#: src/olympia/amo/templates/amo/site_nav.html:68 src/olympia/bandwagon/templates/bandwagon/user_listing.html:4 src/olympia/bandwagon/templates/bandwagon/impala/collection_sidebar.html:13
 #: src/olympia/bandwagon/templates/bandwagon/includes/collection_sidebar.html:15
 msgid "Collections I'm Following"
 msgstr ""
 
-#: src/olympia/amo/templates/amo/site_nav.html:73 src/olympia/bandwagon/templates/bandwagon/impala/collection_sidebar.html:18
-#: src/olympia/bandwagon/templates/bandwagon/includes/collection_sidebar.html:20 src/olympia/users/models.py:512
+#: src/olympia/amo/templates/amo/site_nav.html:71 src/olympia/bandwagon/templates/bandwagon/impala/collection_sidebar.html:18
+#: src/olympia/bandwagon/templates/bandwagon/includes/collection_sidebar.html:20 src/olympia/users/models.py:521
 msgid "My Favorite Add-ons"
 msgstr ""
 
-#: src/olympia/amo/templates/amo/site_nav.html:78
+#: src/olympia/amo/templates/amo/site_nav.html:76
 msgid "More&hellip;"
 msgstr ""
 
-#: src/olympia/amo/templates/amo/site_nav.html:82
+#: src/olympia/amo/templates/amo/site_nav.html:80
 msgid "Add-ons for Mobile"
 msgstr ""
 
-#: src/olympia/amo/templates/amo/site_nav.html:86 src/olympia/browse/feeds.py:207 src/olympia/browse/templates/browse/search_tools.html:3 src/olympia/constants/base.py:176
+#: src/olympia/amo/templates/amo/site_nav.html:84 src/olympia/browse/feeds.py:207 src/olympia/browse/templates/browse/search_tools.html:3 src/olympia/constants/base.py:176
 #: src/olympia/templates/menu_links.html:10
 msgid "Search Tools"
 msgstr ""
@@ -1992,7 +1993,7 @@ msgid "Jump to first page"
 msgstr ""
 
 #: src/olympia/amo/templates/amo/impala/paginator.html:22 src/olympia/amo/templates/amo/mobile/impala_paginator.html:12 src/olympia/discovery/templates/discovery/pane.html:44
-#: src/olympia/discovery/templates/discovery/addons/detail.html:38 src/olympia/stats/templates/stats/stats.html:164
+#: src/olympia/discovery/templates/discovery/addons/detail.html:38 src/olympia/stats/templates/stats/stats.html:166
 msgid "Previous"
 msgstr ""
 
@@ -2015,30 +2016,49 @@ msgid_plural "Page {n}"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/olympia/amo/templates/services/install.html:38
-#, python-format
-msgid "If you are not prompted to install %(addon_name)s in a moment, please <a href=\"%(addon_xpi)s\">click here</a>."
-msgstr ""
-
-#: src/olympia/amo/tests/test_messages.py:57 src/olympia/amo/tests/test_messages.py:58 src/olympia/reviews/forms.py:25 src/olympia/reviews/forms.py:50 src/olympia/reviews/templates/reviews/add.html:56
+#: src/olympia/amo/tests/test_messages.py:56 src/olympia/amo/tests/test_messages.py:57 src/olympia/reviews/forms.py:25 src/olympia/reviews/forms.py:50 src/olympia/reviews/templates/reviews/add.html:56
 #: src/olympia/reviews/templates/reviews/reply.html:30
 msgid "Title"
 msgstr ""
 
-#: src/olympia/amo/tests/test_messages.py:57 src/olympia/amo/tests/test_messages.py:58
+#: src/olympia/amo/tests/test_messages.py:56 src/olympia/amo/tests/test_messages.py:57
 msgid "Body"
 msgstr ""
 
-#: src/olympia/amo/tests/test_messages.py:59
+#: src/olympia/amo/tests/test_messages.py:58
 msgid "Another Title"
 msgstr ""
 
-#: src/olympia/amo/tests/test_messages.py:59
+#: src/olympia/amo/tests/test_messages.py:58
 msgid "Another Body"
 msgstr ""
 
-#: src/olympia/api/views.py:255
-msgid "Not implemented yet."
+#: src/olympia/api/authentication.py:76
+msgid "Signature has expired."
+msgstr ""
+
+#: src/olympia/api/authentication.py:79
+msgid "Error decoding signature."
+msgstr ""
+
+#: src/olympia/api/authentication.py:82
+msgid "Invalid JWT Token."
+msgstr ""
+
+#: src/olympia/api/authentication.py:130
+msgid "Invalid Authorization header. No credentials provided."
+msgstr ""
+
+#: src/olympia/api/authentication.py:133
+msgid "Invalid Authorization header. Credentials string should not contain spaces."
+msgstr ""
+
+#: src/olympia/api/fields.py:29
+msgid "The field must have a length of at least {num} characters."
+msgstr ""
+
+#: src/olympia/api/fields.py:31
+msgid "The language code {lang_code} is invalid."
 msgstr ""
 
 #: src/olympia/applications/views.py:39 src/olympia/applications/templates/applications/appversions.html:3
@@ -2057,7 +2077,7 @@ msgstr ""
 msgid "Add-ons submitted to Mozilla Add-ons must have a manifest file with at least one of the below applications supported. Only the versions listed below are allowed for these applications."
 msgstr ""
 
-#: src/olympia/applications/templates/applications/appversions.html:25
+#: src/olympia/applications/templates/applications/appversions.html:25 src/olympia/editors/helpers.py:361
 msgid "GUID"
 msgstr ""
 
@@ -2171,8 +2191,8 @@ msgstr ""
 msgid "Remove from favorites"
 msgstr ""
 
-#: src/olympia/bandwagon/views.py:98 src/olympia/bandwagon/views.py:191 src/olympia/browse/views.py:58 src/olympia/browse/views.py:69 src/olympia/browse/views.py:458 src/olympia/devhub/views.py:74
-#: src/olympia/devhub/views.py:82 src/olympia/devhub/templates/devhub/addons/edit/basic.html:20 src/olympia/editors/templates/editors/leaderboard.html:24
+#: src/olympia/bandwagon/views.py:98 src/olympia/bandwagon/views.py:191 src/olympia/browse/views.py:58 src/olympia/browse/views.py:69 src/olympia/browse/views.py:425 src/olympia/devhub/views.py:72
+#: src/olympia/devhub/views.py:80 src/olympia/devhub/templates/devhub/addons/edit/basic.html:20 src/olympia/editors/templates/editors/leaderboard.html:24
 #: src/olympia/editors/templates/editors/themes/queue_list.html:48 src/olympia/search/forms.py:17 src/olympia/search/forms.py:89 src/olympia/users/templates/users/vcard.html:5
 msgid "Name"
 msgstr ""
@@ -2181,7 +2201,7 @@ msgstr ""
 msgid "Recently Popular"
 msgstr ""
 
-#: src/olympia/bandwagon/views.py:189 src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:18
+#: src/olympia/bandwagon/views.py:189 src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:16
 msgid "Added"
 msgstr ""
 
@@ -2195,7 +2215,7 @@ msgstr ""
 
 #: src/olympia/bandwagon/views.py:316
 #, python-format
-msgid "Your new collection is shown below. You can <ahref=\"%(url)s\">edit additional settings</a> if you'dlike."
+msgid "Your new collection is shown below. You can <a href=\"%(url)s\">edit additional settings</a> if you'd like."
 msgstr ""
 
 #: src/olympia/bandwagon/views.py:322
@@ -2323,8 +2343,8 @@ msgid_plural "%(num)s Add-ons in this Collection"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/olympia/bandwagon/templates/bandwagon/collection_detail.html:125 src/olympia/compat/templates/compat/index.html:25 src/olympia/compat/templates/compat/reporter_detail.html:29
-#: src/olympia/files/templates/files/viewer.html:29 src/olympia/templates/amo_footer.html:17 src/olympia/templates/includes/lang_switcher.html:10
+#: src/olympia/bandwagon/templates/bandwagon/collection_detail.html:125 src/olympia/compat/templates/compat/reporter_detail.html:29 src/olympia/files/templates/files/viewer.html:29
+#: src/olympia/templates/amo_footer.html:17 src/olympia/templates/includes/lang_switcher.html:10
 msgid "Go"
 msgstr ""
 
@@ -2491,7 +2511,7 @@ msgid "Remove this user as a contributor"
 msgstr ""
 
 #: src/olympia/bandwagon/templates/bandwagon/edit_contributors.html:18 src/olympia/bandwagon/templates/bandwagon/edit_contributors.html:43
-#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:20 src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:48
+#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:18 src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:46
 #: src/olympia/devhub/templates/devhub/addons/ajax_compat_update.html:19
 msgid "Remove"
 msgstr ""
@@ -2539,7 +2559,7 @@ msgid "<b>Warning:</b> By changing the owner of this collection, you will no lon
 msgstr ""
 
 #: src/olympia/bandwagon/templates/bandwagon/edit_contributors.html:83 src/olympia/devhub/templates/devhub/addons/forms_shared/media.html:157
-#: src/olympia/devhub/templates/devhub/addons/submit/describe.html:69 src/olympia/devhub/templates/devhub/addons/submit/license.html:60 src/olympia/devhub/templates/devhub/addons/submit/upload.html:78
+#: src/olympia/devhub/templates/devhub/addons/submit/describe.html:69 src/olympia/devhub/templates/devhub/addons/submit/license.html:60 src/olympia/devhub/templates/devhub/addons/submit/upload.html:70
 #: src/olympia/devhub/templates/devhub/payments/tier.html:17 src/olympia/editors/templates/editors/themes/themes.html:111 src/olympia/editors/templates/editors/themes/themes.html:128
 #: src/olympia/editors/templates/editors/themes/themes.html:134 src/olympia/editors/templates/editors/themes/themes.html:141 src/olympia/users/templates/users/fxa_migration_prompt_content.html:10
 #: src/olympia/users/templates/users/login_form.html:42 src/olympia/users/templates/users/mobile/login.html:57
@@ -2622,31 +2642,31 @@ msgid "Add-ons in Your Collection"
 msgstr ""
 
 #: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:4
-msgid ""
-"To include an add-on in this collection, enter its name in the box below and hit enter.  You can also use the <strong>Add to Collection</strong> links throughout the site to include add-ons later."
+msgid "To include an add-on in this collection, enter its name in the box below and hit enter."
 msgstr ""
 
-#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:17 src/olympia/constants/base.py:400 src/olympia/devhub/templates/devhub/addons/activity.html:62
+#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:15 src/olympia/constants/base.py:400 src/olympia/devhub/templates/devhub/addons/activity.html:62
+#: src/olympia/editors/helpers.py:273 src/olympia/editors/helpers.py:360
 msgid "Add-on"
 msgstr ""
 
-#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:26
+#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:24
 msgid "Enter the name of the add-on to include"
 msgstr ""
 
-#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:28
+#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:26
 msgid "Add to Collection"
 msgstr ""
 
-#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:45 src/olympia/editors/helpers.py:936 src/olympia/editors/helpers.py:956
+#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:43 src/olympia/editors/helpers.py:1016 src/olympia/editors/helpers.py:1036
 msgid "Pending"
 msgstr ""
 
-#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:47
+#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:45
 msgid "Add a comment"
 msgstr ""
 
-#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:48
+#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:46
 msgid "Remove this add-on from the collection"
 msgstr ""
 
@@ -2753,12 +2773,12 @@ msgstr ""
 msgid "Most Users"
 msgstr ""
 
-#: src/olympia/browse/views.py:61 src/olympia/browse/views.py:72 src/olympia/browse/views.py:279 src/olympia/browse/templates/browse/personas/mobile/category_landing.html:63
+#: src/olympia/browse/views.py:61 src/olympia/browse/views.py:72 src/olympia/browse/views.py:246 src/olympia/browse/templates/browse/personas/mobile/category_landing.html:63
 #: src/olympia/discovery/templates/discovery/pane.html:67 src/olympia/search/forms.py:92
 msgid "Up & Coming"
 msgstr ""
 
-#: src/olympia/browse/views.py:460 src/olympia/devhub/views.py:76 src/olympia/devhub/views.py:83 src/olympia/discovery/templates/discovery/addons/detail.html:66
+#: src/olympia/browse/views.py:427 src/olympia/devhub/views.py:74 src/olympia/devhub/views.py:81 src/olympia/discovery/templates/discovery/addons/detail.html:66
 msgid "Created"
 msgstr ""
 
@@ -2946,8 +2966,8 @@ msgid_plural "See all %(cnt)s extensions in %(name)s &raquo;"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/olympia/browse/templates/browse/mobile/extensions.html:13 src/olympia/compat/templates/compat/index.html:82 src/olympia/devhub/templates/devhub/devhub_search.html:24
-#: src/olympia/devhub/templates/devhub/addons/activity.html:47 src/olympia/search/templates/search/no_results.html:4 src/olympia/search/templates/search/mobile/results.html:36
+#: src/olympia/browse/templates/browse/mobile/extensions.html:13 src/olympia/devhub/templates/devhub/devhub_search.html:24 src/olympia/devhub/templates/devhub/addons/activity.html:47
+#: src/olympia/search/templates/search/no_results.html:4 src/olympia/search/templates/search/mobile/results.html:36
 msgid "No results found."
 msgstr ""
 
@@ -3032,7 +3052,7 @@ msgstr ""
 msgid "All"
 msgstr ""
 
-#: src/olympia/compat/forms.py:22 src/olympia/search/views.py:525
+#: src/olympia/compat/forms.py:22 src/olympia/editors/templates/editors/base.html:69 src/olympia/search/views.py:518
 msgid "All Add-ons"
 msgstr ""
 
@@ -3042,53 +3062,6 @@ msgstr ""
 
 #: src/olympia/compat/forms.py:24
 msgid "Non-binary"
-msgstr ""
-
-#. Review points sources other than add-ons and themes.
-#: src/olympia/compat/views.py:87 src/olympia/constants/base.py:388 src/olympia/devhub/forms.py:162 src/olympia/editors/templates/editors/performance.html:75
-msgid "Other"
-msgstr ""
-
-#: src/olympia/compat/templates/compat/index.html:4
-msgid "Add-on Compatibility Report for {app} {version}"
-msgstr ""
-
-#: src/olympia/compat/templates/compat/index.html:11
-msgid "{app} {version} Compatibility"
-msgstr ""
-
-#: src/olympia/compat/templates/compat/index.html:17
-#, python-format
-msgid "Top 95%% compatible with previous version"
-msgstr ""
-
-#: src/olympia/compat/templates/compat/index.html:18
-#, python-format
-msgid "Top 95%% of all add-ons"
-msgstr ""
-
-#: src/olympia/compat/templates/compat/index.html:19
-msgid "All active add-ons"
-msgstr ""
-
-#: src/olympia/compat/templates/compat/index.html:23 src/olympia/constants/base.py:401
-msgid "App"
-msgstr ""
-
-#: src/olympia/compat/templates/compat/index.html:55
-msgid "Details for add-ons compatible with previous version:"
-msgstr ""
-
-#: src/olympia/compat/templates/compat/index.html:57
-msgid "Show all versions"
-msgstr ""
-
-#: src/olympia/compat/templates/compat/index.html:59
-msgid "Details for add-ons compatible with all versions:"
-msgstr ""
-
-#: src/olympia/compat/templates/compat/index.html:61
-msgid "Show previous version only"
 msgstr ""
 
 #: src/olympia/compat/templates/compat/reporter.html:3
@@ -3142,8 +3115,8 @@ msgstr ""
 msgid "Report Type"
 msgstr ""
 
-#: src/olympia/compat/templates/compat/reporter_detail.html:47 src/olympia/devhub/forms.py:784 src/olympia/devhub/templates/devhub/addons/ajax_compat_update.html:17 src/olympia/editors/forms.py:108
-#: src/olympia/zadmin/forms.py:45
+#: src/olympia/compat/templates/compat/reporter_detail.html:47 src/olympia/devhub/forms.py:785 src/olympia/devhub/templates/devhub/addons/ajax_compat_update.html:17 src/olympia/editors/forms.py:108
+#: src/olympia/editors/forms.py:248 src/olympia/zadmin/forms.py:45
 msgid "Application"
 msgstr ""
 
@@ -3231,7 +3204,8 @@ msgstr ""
 msgid "Preliminarily Reviewed and Awaiting Full Review"
 msgstr ""
 
-#: src/olympia/constants/base.py:33 src/olympia/editors/helpers.py:924 src/olympia/editors/templates/editors/themes/history_table.html:34
+#: src/olympia/constants/base.py:33 src/olympia/editors/forms.py:258 src/olympia/editors/helpers.py:73 src/olympia/editors/helpers.py:1004
+#: src/olympia/editors/templates/editors/themes/history_table.html:34
 msgid "Deleted"
 msgstr ""
 
@@ -3328,6 +3302,11 @@ msgstr ""
 msgid "Ask before users can download this add-on"
 msgstr ""
 
+#. Review points sources other than add-ons and themes.
+#: src/olympia/constants/base.py:388 src/olympia/devhub/forms.py:162 src/olympia/editors/templates/editors/performance.html:75
+msgid "Other"
+msgstr ""
+
 #: src/olympia/constants/base.py:389
 msgid "Exception"
 msgstr ""
@@ -3338,6 +3317,10 @@ msgstr ""
 
 #: src/olympia/constants/base.py:391
 msgid "Change"
+msgstr ""
+
+#: src/olympia/constants/base.py:401
+msgid "App"
 msgstr ""
 
 #: src/olympia/constants/base.py:402
@@ -3488,7 +3471,7 @@ msgstr ""
 msgid "Duplicate"
 msgstr ""
 
-#: src/olympia/constants/editors.py:17 src/olympia/editors/helpers.py:502 src/olympia/editors/templates/editors/themes/queue.html:71 src/olympia/editors/templates/editors/themes/themes.html:94
+#: src/olympia/constants/editors.py:17 src/olympia/editors/helpers.py:575 src/olympia/editors/templates/editors/themes/queue.html:71 src/olympia/editors/templates/editors/themes/themes.html:94
 msgid "Reject"
 msgstr ""
 
@@ -3588,7 +3571,7 @@ msgstr ""
 msgid "Android"
 msgstr ""
 
-#: src/olympia/core/apps.py:19
+#: src/olympia/core/apps.py:21
 msgid "Core"
 msgstr ""
 
@@ -3722,7 +3705,7 @@ msgid "Submit my add-on for manual review."
 msgstr ""
 
 #: src/olympia/devhub/forms.py:537
-msgid "Do not list my add-on on this site (beta)"
+msgid "Do not list my add-on on this site"
 msgstr ""
 
 #: src/olympia/devhub/forms.py:538
@@ -3755,46 +3738,46 @@ msgstr ""
 
 #: src/olympia/devhub/forms.py:592
 #, python-format
-msgid "Version %s already exists"
+msgid "Version %s already exists, or was uploaded before."
 msgstr ""
 
-#: src/olympia/devhub/forms.py:604
+#: src/olympia/devhub/forms.py:605
 msgid "Select a valid choice. That choice is not one of the available choices."
 msgstr ""
 
-#: src/olympia/devhub/forms.py:610
+#: src/olympia/devhub/forms.py:611
 msgid "A file with a version ending with a|alpha|b|beta and an optional number is detected as beta."
 msgstr ""
 
-#: src/olympia/devhub/forms.py:633
+#: src/olympia/devhub/forms.py:634
 msgid "You cannot upload any more files for this version."
 msgstr ""
 
-#: src/olympia/devhub/forms.py:639
+#: src/olympia/devhub/forms.py:640
 msgid "Version doesn't match"
 msgstr ""
 
-#: src/olympia/devhub/forms.py:668
+#: src/olympia/devhub/forms.py:669
 msgid "You cannot delete a file once the review process has started.  You must delete the whole version."
 msgstr ""
 
-#: src/olympia/devhub/forms.py:688
+#: src/olympia/devhub/forms.py:689
 msgid "The platform All cannot be combined with specific platforms."
 msgstr ""
 
-#: src/olympia/devhub/forms.py:693
+#: src/olympia/devhub/forms.py:694
 msgid "A platform can only be chosen once."
 msgstr ""
 
-#: src/olympia/devhub/forms.py:706
+#: src/olympia/devhub/forms.py:707
 msgid "A review type must be selected."
 msgstr ""
 
-#: src/olympia/devhub/forms.py:788 src/olympia/editors/forms.py:114 src/olympia/zadmin/forms.py:49 src/olympia/zadmin/forms.py:52
+#: src/olympia/devhub/forms.py:789 src/olympia/editors/forms.py:114 src/olympia/editors/forms.py:254 src/olympia/zadmin/forms.py:49 src/olympia/zadmin/forms.py:52
 msgid "Select an application first"
 msgstr ""
 
-#: src/olympia/devhub/forms.py:840
+#: src/olympia/devhub/forms.py:841
 msgid "There cannot be more than 3 required add-ons."
 msgstr ""
 
@@ -3828,76 +3811,76 @@ msgstr[1] ""
 msgid "Review"
 msgstr ""
 
-#: src/olympia/devhub/tasks.py:551
+#: src/olympia/devhub/tasks.py:583
 #, python-format
 msgid "%s responded with %s (%s)."
 msgstr ""
 
-#: src/olympia/devhub/tasks.py:555
+#: src/olympia/devhub/tasks.py:587
 #, python-format
 msgid "Connection to \"%s\" timed out."
 msgstr ""
 
-#: src/olympia/devhub/tasks.py:557
+#: src/olympia/devhub/tasks.py:589
 #, python-format
 msgid "Could not contact host at \"%s\"."
 msgstr ""
 
-#: src/olympia/devhub/utils.py:104
+#: src/olympia/devhub/utils.py:105
 #, python-format
 msgid "Validation generated too many errors/warnings so %s messages were truncated. After addressing the visible messages, you'll be able to see the others."
 msgstr ""
 
-#: src/olympia/devhub/views.py:183
+#: src/olympia/devhub/views.py:181
 msgid "All My Add-ons"
 msgstr ""
 
-#: src/olympia/devhub/views.py:210
+#: src/olympia/devhub/views.py:208
 msgid "All Activity"
 msgstr ""
 
-#: src/olympia/devhub/views.py:211
+#: src/olympia/devhub/views.py:209
 msgid "Add-on Updates"
 msgstr ""
 
-#: src/olympia/devhub/views.py:212
+#: src/olympia/devhub/views.py:210
 msgid "Add-on Status"
 msgstr ""
 
-#: src/olympia/devhub/views.py:213
+#: src/olympia/devhub/views.py:211
 msgid "User Collections"
 msgstr ""
 
-#: src/olympia/devhub/views.py:214 src/olympia/devhub/templates/devhub/docs/policies-maintenance.html:68 src/olympia/pages/templates/pages/dev_faq.html:38
+#: src/olympia/devhub/views.py:212 src/olympia/devhub/templates/devhub/docs/policies-maintenance.html:68 src/olympia/pages/templates/pages/dev_faq.html:38
 #: src/olympia/pages/templates/pages/dev_faq.html:484
 msgid "User Reviews"
 msgstr ""
 
-#: src/olympia/devhub/views.py:327 src/olympia/devhub/views.py:331 src/olympia/devhub/views.py:484 src/olympia/devhub/views.py:513 src/olympia/devhub/views.py:564 src/olympia/devhub/views.py:1150
+#: src/olympia/devhub/views.py:325 src/olympia/devhub/views.py:329 src/olympia/devhub/views.py:484 src/olympia/devhub/views.py:513 src/olympia/devhub/views.py:564 src/olympia/devhub/views.py:1156
 msgid "Changes successfully saved."
 msgstr ""
 
-#: src/olympia/devhub/views.py:334 src/olympia/devhub/views.py:1631
+#: src/olympia/devhub/views.py:332 src/olympia/devhub/views.py:1637
 msgid "Please check the form for errors."
 msgstr ""
 
-#: src/olympia/devhub/views.py:346
+#: src/olympia/devhub/views.py:344
 msgid "Add-on cannot be deleted. Disable this add-on instead."
 msgstr ""
 
-#: src/olympia/devhub/views.py:356
+#: src/olympia/devhub/views.py:354
 msgid "Theme deleted."
 msgstr ""
 
-#: src/olympia/devhub/views.py:356
+#: src/olympia/devhub/views.py:354
 msgid "Add-on deleted."
 msgstr ""
 
-#: src/olympia/devhub/views.py:362
+#: src/olympia/devhub/views.py:360
 msgid "URL name was incorrect. Theme was not deleted."
 msgstr ""
 
-#: src/olympia/devhub/views.py:367
+#: src/olympia/devhub/views.py:365
 msgid "URL name was incorrect. Add-on was not deleted."
 msgstr ""
 
@@ -3925,7 +3908,7 @@ msgstr ""
 msgid "Check Add-on Compatibility"
 msgstr ""
 
-#: src/olympia/devhub/views.py:808 src/olympia/signing/views.py:90
+#: src/olympia/devhub/views.py:808 src/olympia/signing/views.py:95
 msgid "You cannot submit this type of add-on"
 msgstr ""
 
@@ -3955,33 +3938,33 @@ msgstr ""
 msgid "There was an error uploading your preview."
 msgstr ""
 
-#: src/olympia/devhub/views.py:1189
+#: src/olympia/devhub/views.py:1195
 #, python-format
 msgid "Version %s disabled."
 msgstr ""
 
-#: src/olympia/devhub/views.py:1193
+#: src/olympia/devhub/views.py:1199
 #, python-format
 msgid "Version %s deleted."
 msgstr ""
 
-#: src/olympia/devhub/views.py:1203
+#: src/olympia/devhub/views.py:1209
 msgid "This upload has failed validation, and may lack complete validation results. Please take due care when reviewing it."
 msgstr ""
 
-#: src/olympia/devhub/views.py:1677
+#: src/olympia/devhub/views.py:1683
 msgid "Preliminary Review Requested."
 msgstr ""
 
-#: src/olympia/devhub/views.py:1678
+#: src/olympia/devhub/views.py:1684
 msgid "Full Review Requested."
 msgstr ""
 
-#: src/olympia/devhub/views.py:1779
+#: src/olympia/devhub/views.py:1783
 msgid "Your old credentials were revoked and are no longer valid. Be sure to update all API clients with the new credentials."
 msgstr ""
 
-#: src/olympia/devhub/views.py:1797
+#: src/olympia/devhub/views.py:1801
 msgid "New API key created"
 msgstr ""
 
@@ -4011,7 +3994,7 @@ msgstr ""
 msgid "{0} :: Search"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/devhub_search.html:6 src/olympia/devhub/templates/devhub/search.html:8 src/olympia/editors/forms.py:435 src/olympia/editors/forms.py:437
+#: src/olympia/devhub/templates/devhub/devhub_search.html:6 src/olympia/devhub/templates/devhub/search.html:8 src/olympia/editors/forms.py:534 src/olympia/editors/forms.py:536
 #: src/olympia/editors/templates/editors/queue.html:27 src/olympia/editors/templates/editors/themes/queue_list.html:14 src/olympia/search/templates/search/collections.html:17
 #: src/olympia/search/templates/search/personas.html:18 src/olympia/search/templates/search/results.html:18 src/olympia/search/templates/search/mobile/results.html:8
 #: src/olympia/templates/search.html:14 src/olympia/templates/impala/search.html:18
@@ -4071,12 +4054,12 @@ msgstr ""
 msgid "Start Making Add-ons"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/index.html:86 src/olympia/devhub/templates/devhub/addons/listing/items.html:25 src/olympia/devhub/templates/devhub/includes/addon_details.html:15
+#: src/olympia/devhub/templates/devhub/index.html:86 src/olympia/devhub/templates/devhub/addons/listing/items.html:25 src/olympia/devhub/templates/devhub/includes/addon_details.html:20
 #: src/olympia/devhub/templates/devhub/personas/edit.html:43
 msgid "Status:"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/index.html:90 src/olympia/devhub/templates/devhub/includes/addon_details.html:100
+#: src/olympia/devhub/templates/devhub/index.html:90 src/olympia/devhub/templates/devhub/includes/addon_details.html:87
 msgid "Visibility:"
 msgstr ""
 
@@ -4084,11 +4067,11 @@ msgstr ""
 msgid "Latest Version:"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/index.html:109 src/olympia/devhub/templates/devhub/includes/addon_details.html:145 src/olympia/devhub/templates/devhub/personas/edit.html:49
+#: src/olympia/devhub/templates/devhub/index.html:109 src/olympia/devhub/templates/devhub/includes/addon_details.html:131 src/olympia/devhub/templates/devhub/personas/edit.html:49
 msgid "Queue Position:"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/index.html:110 src/olympia/devhub/templates/devhub/includes/addon_details.html:146 src/olympia/devhub/templates/devhub/personas/edit.html:50
+#: src/olympia/devhub/templates/devhub/index.html:110 src/olympia/devhub/templates/devhub/includes/addon_details.html:132 src/olympia/devhub/templates/devhub/personas/edit.html:50
 #, python-format
 msgid "%(position)s of %(total)s"
 msgstr ""
@@ -4190,16 +4173,6 @@ msgstr ""
 msgid "Do you want your add-on to be distributed on this site?"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/validate_addon.html:49 src/olympia/devhub/templates/devhub/addons/submit/upload.html:30 src/olympia/devhub/templates/devhub/versions/add_file_modal.html:14
-#: src/olympia/devhub/templates/devhub/versions/add_file_modal.html:53 src/olympia/devhub/templates/devhub/versions/list.html:298
-msgid "Warning:"
-msgstr ""
-
-#: src/olympia/devhub/templates/devhub/validate_addon.html:50 src/olympia/devhub/templates/devhub/addons/submit/upload.html:31
-#, python-format
-msgid "Submission of unlisted add-ons for signing is currently in an open beta. Please <a href=\"%(url)s\" target=\"_blank\">report any bugs</a> that you encounter."
-msgstr ""
-
 #. first parameter is a filename like lorem-ipsum-1.0.2.xpi
 #: src/olympia/devhub/templates/devhub/validation.html:5
 msgid "Validation Results for {0}"
@@ -4274,7 +4247,7 @@ msgstr ""
 msgid "Update Compatibility"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/addons/ajax_compat_update.html:4
+#: src/olympia/devhub/templates/devhub/addons/ajax_compat_update.html:4 src/olympia/devhub/templates/devhub/versions/edit.html:45
 msgid "Adjusting application information here will allow users to install your add-on even if the install manifest in the package indicates that the add-on is incompatible."
 msgstr ""
 
@@ -4286,9 +4259,9 @@ msgstr ""
 msgid "Add Another Application&hellip;"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/addons/ajax_compat_update.html:38 src/olympia/devhub/templates/devhub/addons/owner.html:86 src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:46
-#: src/olympia/devhub/templates/devhub/versions/list.html:351 src/olympia/devhub/templates/devhub/versions/list.html:353 src/olympia/templates/impala/base.html:132
-#: src/olympia/templates/impala/base.html:143 src/olympia/templates/impala/base.html:161 src/olympia/templates/impala/base.html:171
+#: src/olympia/devhub/templates/devhub/addons/ajax_compat_update.html:38 src/olympia/devhub/templates/devhub/addons/owner.html:86 src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:45
+#: src/olympia/devhub/templates/devhub/versions/list.html:349 src/olympia/devhub/templates/devhub/versions/list.html:351 src/olympia/templates/impala/base.html:129
+#: src/olympia/templates/impala/base.html:140 src/olympia/templates/impala/base.html:158 src/olympia/templates/impala/base.html:168
 msgid "Close"
 msgstr ""
 
@@ -4322,7 +4295,7 @@ msgstr ""
 msgid "Manage Authors & License"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/addons/owner.html:29 src/olympia/editors/templates/editors/review.html:270
+#: src/olympia/devhub/templates/devhub/addons/owner.html:29 src/olympia/editors/helpers.py:362 src/olympia/editors/templates/editors/review.html:270
 msgid "Authors"
 msgstr ""
 
@@ -4391,17 +4364,11 @@ msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/basic.html:52
 msgid ""
-"A short explanation of your add-on's basic\n"
-"                          functionality that is displayed in search and browse\n"
-"                          listings, as well as at the top of your add-on's\n"
-"                          details page. It is only relevant for listed add-ons."
+"A short explanation of your add-on's basic functionality that is displayed in search and browse listings, as well as at the top of your add-on's details page. It is only relevant for listed add-ons."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/basic.html:73
-msgid ""
-"Categories are the primary way users browse through add-ons.\n"
-"                        Choose any that fit your add-on's functionality for the most\n"
-"                        exposure. It is only relevant for listed add-ons."
+msgid "Categories are the primary way users browse through add-ons. Choose any that fit your add-on's functionality for the most exposure. It is only relevant for listed add-ons."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/basic.html:90
@@ -4411,11 +4378,7 @@ msgid ""
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/basic.html:119
-msgid ""
-"Tags help users find your add-on and should be short\n"
-"                        descriptors such as tabs, toolbar, or twitter.  You\n"
-"                        may have a maximum of {0} tags. It is only relevant\n"
-"                        for listed add-ons."
+msgid "Tags help users find your add-on and should be short descriptors such as tabs, toolbar, or twitter. You may have a maximum of {0} tags. It is only relevant for listed add-ons."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/basic.html:129 src/olympia/devhub/templates/devhub/personas/edit.html:97 src/olympia/devhub/templates/devhub/personas/submit.html:46
@@ -4443,11 +4406,7 @@ msgid "Add-on Details for {0}"
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/details.html:22
-msgid ""
-"A longer explanation of features,\n"
-"                          functionality, and other relevant information. This\n"
-"                          field is only displayed on the add-on's details\n"
-"                          page. It is only relevant for listed add-ons."
+msgid "A longer explanation of features, functionality, and other relevant information. This field is only displayed on the add-on's details page. It is only relevant for listed add-ons."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/details.html:44 src/olympia/translations/templates/translations/trans-menu.html:13
@@ -4455,10 +4414,7 @@ msgid "Default Locale"
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/details.html:45
-msgid ""
-"Information about your add-on is displayed in this locale\n"
-"                        unless you override it with a locale-specific translation.\n"
-"                        It is only relevant for listed add-ons."
+msgid "Information about your add-on is displayed in this locale unless you override it with a locale-specific translation. It is only relevant for listed add-ons."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/details.html:61 src/olympia/users/forms.py:311 src/olympia/users/templates/users/edit.html:122 src/olympia/users/templates/users/register.html:57
@@ -4468,10 +4424,8 @@ msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/details.html:63
 msgid ""
-"If your add-on has another homepage, enter its\n"
-"                          address here. If your website is localized into other\n"
-"                          languages multiple translations of this field can be\n"
-"                          added. It is only relevant for listed add-ons."
+"If your add-on has another homepage, enter its address here. If your website is localized into other languages multiple translations of this field can be added. It is only relevant for listed add-"
+"ons."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/media.html:3
@@ -4489,19 +4443,14 @@ msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/support.html:22
 msgid ""
-"If you wish to display an e-mail address for support\n"
-"                          inquiries, enter it here. If you have different\n"
-"                          addresses for each language multiple translations of\n"
-"                          this field can be added. It is only relevant for\n"
-"                          listed add-ons."
+"If you wish to display an e-mail address for support inquiries, enter it here. If you have different addresses for each language multiple translations of this field can be added. It is only "
+"relevant for listed add-ons."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/support.html:45
 msgid ""
-"If your add-on has a support website or forum, enter\n"
-"                          its address here. If your website is localized into\n"
-"                          other languages, multiple translations of this field can\n"
-"                          be added. It is only relevant for listed add-ons."
+"If your add-on has a support website or forum, enter its address here. If your website is localized into other languages, multiple translations of this field can be added. It is only relevant for "
+"listed add-ons."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:6
@@ -4515,11 +4464,8 @@ msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:23
 msgid ""
-"Any information end users may want to know that isn't\n"
-"                          necessarily applicable to the add-on summary or description.\n"
-"                          Common uses include listing known major bugs, information on\n"
-"                          how to report bugs, anticipated release date of a new version,\n"
-"                          etc. It is only relevant for listed add-ons."
+"Any information end users may want to know that isn't necessarily applicable to the add-on summary or description. Common uses include listing known major bugs, information on how to report bugs, "
+"anticipated release date of a new version, etc. It is only relevant for listed add-ons."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:46
@@ -4531,9 +4477,7 @@ msgid "Add-on Flags"
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:69
-msgid ""
-"These flags are used to classify add-ons. It is only\n"
-"                        relevant for listed add-ons."
+msgid "These flags are used to classify add-ons. It is only relevant for listed add-ons."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:74
@@ -4549,9 +4493,7 @@ msgid "View Source?"
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:90
-msgid ""
-"Whether the source of your add-on can be displayed in our\n"
-"                        online viewer. It is only relevant for listed add-ons."
+msgid "Whether the source of your add-on can be displayed in our online viewer. It is only relevant for listed add-ons."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:94
@@ -4567,10 +4509,7 @@ msgid "Public Stats?"
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:102
-msgid ""
-"Whether the download and usage stats of your add-on can\n"
-"                        be displayed in our online viewer.\n"
-"                        It is only relevant for listed add-ons."
+msgid "Whether the download and usage stats of your add-on can be displayed in our online viewer. It is only relevant for listed add-ons."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:107
@@ -4586,10 +4525,7 @@ msgid "Upgrade SDK?"
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:116
-msgid ""
-"If selected, we will try to automatically upgrade your\n"
-"                        add-on when a new version of the SDK is released.\n"
-"                        It is only relevant for listed add-ons."
+msgid "If selected, we will try to automatically upgrade your add-on when a new version of the SDK is released. It is only relevant for listed add-ons."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:121
@@ -4640,10 +4576,8 @@ msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/forms_shared/media.html:16
 msgid ""
-"Upload an icon for your add-on or choose from one of ours. The\n"
-"                      icon is displayed nearly everywhere your add-on is. Uploaded images\n"
-"                      must be one of the following image types: .png, .jpg.\n"
-"                      It is only relevant for listed add-ons."
+"Upload an icon for your add-on or choose from one of ours. The icon is displayed nearly everywhere your add-on is. Uploaded images must be one of the following image types: .png, .jpg. It is only "
+"relevant for listed add-ons."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/forms_shared/media.html:25
@@ -4656,9 +4590,7 @@ msgid "32x32px"
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/forms_shared/media.html:39
-msgid ""
-"Used in listings of add-ons, like search results\n"
-"                            and featured add-ons."
+msgid "Used in listings of add-ons, like search results and featured add-ons."
 msgstr ""
 
 #. The size of the icon
@@ -4753,16 +4685,14 @@ msgid "Deleting your add-on will permanently remove it from the site and prevent
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:24
-msgid ""
-"Enter the following text confirm your decision:\n"
-"           {slug}"
+msgid "Enter the following text confirm your decision: {slug}"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:34
+#: src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:33
 msgid "Please tell us why you are deleting your theme:"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:36
+#: src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:35
 msgid "Please tell us why you are deleting your add-on:"
 msgstr ""
 
@@ -4799,8 +4729,8 @@ msgstr ""
 msgid "Daily statistics on downloads and users."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/addons/listing/item_actions.html:45 src/olympia/stats/templates/stats/stats.html:75 src/olympia/stats/templates/stats/stats.html:79
-#: src/olympia/stats/templates/stats/stats.html:81
+#: src/olympia/devhub/templates/devhub/addons/listing/item_actions.html:45 src/olympia/stats/templates/stats/stats.html:31 src/olympia/stats/templates/stats/stats.html:35
+#: src/olympia/stats/templates/stats/stats.html:37
 msgid "Statistics"
 msgstr ""
 
@@ -4919,10 +4849,7 @@ msgid "Your add-on has been submitted to the Full Review queue."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/submit/done.html:18
-msgid ""
-"You'll receive an email once it has been reviewed by an editor. In\n"
-"          the meantime, you and your friends can install it directly from its\n"
-"          details page:"
+msgid "You'll receive an email once it has been reviewed by an editor. In the meantime, you and your friends can install it directly from its details page:"
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/submit/done.html:27 src/olympia/devhub/templates/devhub/addons/submit/done.html:77 src/olympia/devhub/templates/devhub/personas/submit_done.html:16
@@ -5128,11 +5055,11 @@ msgstr ""
 msgid "Use the fields below to upload your add-on package and select any platform restrictions. After upload, a series of automated validation tests will be run on your file."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/addons/submit/upload.html:59 src/olympia/devhub/templates/devhub/versions/add_file_modal.html:39
+#: src/olympia/devhub/templates/devhub/addons/submit/upload.html:51 src/olympia/devhub/templates/devhub/versions/add_file_modal.html:28
 msgid "Which platforms is this file compatible with?"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/addons/submit/upload.html:67 src/olympia/devhub/templates/devhub/versions/add_file_modal.html:65
+#: src/olympia/devhub/templates/devhub/addons/submit/upload.html:59 src/olympia/devhub/templates/devhub/versions/add_file_modal.html:45
 msgid "Administrative overrides"
 msgstr ""
 
@@ -5242,8 +5169,8 @@ msgstr ""
 
 #: src/olympia/devhub/templates/devhub/docs/policies-contact.html:44
 msgid ""
-"If you've found a problem with the site, we'd love to fix it. Please <a href=\"https://github.com/mozilla/olympia/issues\">file a bug report</a> in GitHub, including the location of the problem and "
-"how you encountered it."
+"If you've found a problem with the site, we'd love to fix it. Please <a href=\"https://github.com/mozilla/addons/issues/new\">file a bug report</a> in GitHub, including the location of the problem "
+"and how you encountered it."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/docs/policies-maintenance.html:3 src/olympia/devhub/templates/devhub/docs/policies-maintenance.html:7
@@ -5810,7 +5737,7 @@ msgstr ""
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:282
 msgid ""
-"Add-ons that store or otherwise handle browsing data must support <a href=\"https://developer.mozilla.org/En/Supporting_private_browsing_mode\">Private Browsing Mode</a>.  During a Private Browsing "
+"Add-ons that store or otherwise handle browsing data must support <a href=\"https://developer.mozilla.org/En/Supporting_private_browsing_mode\">Private Browsing Mode</a>. During a Private Browsing "
 "session, no browsing data can be written to disk, and all of this data must be cleared when Firefox quits or the Private Browsing session ends."
 msgstr ""
 
@@ -5975,129 +5902,95 @@ msgstr ""
 msgid "How to get in touch with us regarding these policies or your add-on."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:6
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:10
 msgid "You have disabled this add-on"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:20
-msgid ""
-"Your add-on's listing is disabled and is not showing\n"
-"                             anywhere in our gallery or update service."
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:24
+msgid "Your add-on's listing is disabled and is not showing anywhere in our gallery or update service."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:25
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:27
 msgid "Please complete your add-on."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:29
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:30
 msgid "You will receive an email when the review is complete."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:34
-msgid ""
-"You will receive an email when the review is complete. Until\n"
-"                             then, your add-on is not listed in our gallery but can be\n"
-"                             accessed directly from its details page."
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:33
+msgid "You will receive an email when the review is complete. Until then, your add-on is not listed in our gallery but can be accessed directly from its details page."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:38 src/olympia/devhub/templates/devhub/includes/addon_details.html:48
-msgid ""
-"You will receive an email when the review is\n"
-"                             complete and your add-on is signed."
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:37 src/olympia/devhub/templates/devhub/includes/addon_details.html:45
+msgid "You will receive an email when the review is complete and your add-on is signed."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:44
-msgid ""
-"You will receive an email when the review is complete. Until\n"
-"                             then, your add-on is not listed in our gallery but can be\n"
-"                             accessed directly from its details page. "
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:41
+msgid "You will receive an email when the review is complete. Until then, your add-on is not listed in our gallery but can be accessed directly from its details page. "
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:54
-msgid ""
-"Your add-on is displayed in our gallery and users are\n"
-"                             receiving automatic updates."
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:49
+msgid "Your add-on is displayed in our gallery and users are receiving automatic updates."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:57
-msgid ""
-"Your add-on has been signed and can be bundled with an\n"
-"                             application installer."
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:52
+msgid "Your add-on has been signed and can be bundled with an application installer."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:63
-msgid ""
-"Your add-on was disabled by a site administrator and is no\n"
-"                             longer shown in our gallery. If you have any questions,\n"
-"                             please email amo-admins@mozilla.org."
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:56
+msgid "Your add-on was disabled by a site administrator and is no longer shown in our gallery. If you have any questions, please email amo-admins@mozilla.org."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:70
-msgid ""
-"Your add-on is displayed in our gallery as experimental\n"
-"                             and users are receiving automatic updates. Some features\n"
-"                             are unavailable to your add-on."
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:62
+msgid "Your add-on is displayed in our gallery as experimental and users are receiving automatic updates. Some features are unavailable to your add-on."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:74
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:66
 msgid "Your add-on has been signed."
 msgstr ""
 
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:69
+msgid ""
+"You will receive an email when the full review is complete. Until then, your add-on is displayed in our gallery as experimental and users are receiving automatic updates. Some features are "
+"unavailable to your add-on."
+msgstr ""
+
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:74
+msgid "You will receive an email when the full review is complete, making you able to bundle your add-on with an application installer."
+msgstr ""
+
 #: src/olympia/devhub/templates/devhub/includes/addon_details.html:79
-msgid ""
-"You will receive an email when the full review is complete.\n"
-"                             Until then, your add-on is displayed in our gallery as\n"
-"                             experimental and users are receiving automatic updates.\n"
-"                             Some features are unavailable to your add-on."
+msgid "All add-ons hosted in our gallery must now be reviewed by an editor. If you wish to continue hosting your add-on, please click to select a review process."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:84
-msgid ""
-"You will receive an email when the full review is\n"
-"                             complete, making you able to bundle your add-on with an\n"
-"                             application installer."
-msgstr ""
-
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:91
-msgid ""
-"All add-ons hosted in our gallery must now be reviewed by an\n"
-"                             editor. If you wish to continue hosting your add-on, please\n"
-"                             click to select a review process."
-msgstr ""
-
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:113
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:100
 msgid "Current Version:"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:115
-msgid ""
-"This is the version of your add-on that will\n"
-"                                           be installed if someone clicks the Install\n"
-"                                           button on addons.mozilla.org. It is only\n"
-"                                           relevant for listed add-ons."
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:102
+msgid "This is the version of your add-on that will be installed if someone clicks the Install button on addons.mozilla.org. It is only relevant for listed add-ons."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:123
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:110
 msgid "Created:"
 msgstr ""
 
 #. {0} is a date. dennis-ignore: E201
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:125 src/olympia/devhub/templates/devhub/includes/addon_details.html:131
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:112 src/olympia/devhub/templates/devhub/includes/addon_details.html:118
 #, python-format
 msgid "%%b %%e, %%Y"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:136
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:123
 msgid "Next Version:"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:138
-msgid ""
-"This is the newest uploaded version, however\n"
-"                                           it isn’t live on the site yet."
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:125
+msgid "This is the newest uploaded version, however it isn’t live on the site yet."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:144 src/olympia/devhub/templates/devhub/versions/list.html:30
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:130 src/olympia/devhub/templates/devhub/versions/list.html:30
 msgid "Queues are not reviewed strictly in order"
 msgstr ""
 
@@ -6165,9 +6058,7 @@ msgid "View the blog &#9658;"
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/includes/license_form.html:6
-msgid ""
-"Please choose a license appropriate for the rights you grant on your source code.\n"
-"                  It is only relevant for listed add-ons."
+msgid "Please choose a license appropriate for the rights you grant on your source code. It is only relevant for listed add-ons."
 msgstr ""
 
 #. {0} is a list of HTML tags.
@@ -6194,14 +6085,11 @@ msgstr[1] ""
 #: src/olympia/devhub/templates/devhub/includes/policy_form.html:4
 msgid ""
 "Users will be required to accept the following End-User License Agreement (EULA) prior to installing your add-on. The presence of a EULA significantly affects the number of downloads an add-on "
-"receives. Please note that a EULA is not the same as a code license, such as the GPL or MPL.\n"
-"                It is only relevant for listed add-ons."
+"receives. Please note that a EULA is not the same as a code license, such as the GPL or MPL.It is only relevant for listed add-ons."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/policy_form.html:21
-msgid ""
-"If your add-on transmits any data from the user's computer, a privacy policy is required that explains what data is sent and how it is used.\n"
-"                It is only relevant for listed add-ons."
+#: src/olympia/devhub/templates/devhub/includes/policy_form.html:24
+msgid "If your add-on transmits any data from the user's computer, a privacy policy is required that explains what data is sent and how it is used. It is only relevant for listed add-ons."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/includes/source_form_field.html:2
@@ -6369,12 +6257,8 @@ msgstr ""
 msgid "Add some tags to describe your Theme."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/personas/edit.html:106
-msgid ""
-"A short explanation of your theme's\n"
-"                                basic functionality that is displayed in\n"
-"                                search and browse listings, as well as at\n"
-"                                the top of your theme's details page."
+#: src/olympia/devhub/templates/devhub/personas/edit.html:106 src/olympia/devhub/templates/devhub/personas/submit.html:54
+msgid "A short explanation of your theme's basic functionality that is displayed in search and browse listings, as well as at the top of your theme's details page."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/personas/edit.html:122 src/olympia/devhub/templates/devhub/personas/submit.html:68
@@ -6444,7 +6328,7 @@ msgid "Upon upload and form submission, the AMO Team will review your updated de
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/personas/edit.html:241
-msgid "Your previously resubmitted design,  which is under pending review."
+msgid "Your previously resubmitted design, which is under pending review."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/personas/edit.html:245
@@ -6511,14 +6395,6 @@ msgstr ""
 
 #: src/olympia/devhub/templates/devhub/personas/submit.html:33
 msgid "Give your Theme a name."
-msgstr ""
-
-#: src/olympia/devhub/templates/devhub/personas/submit.html:54
-msgid ""
-"A short explanation of your theme's\n"
-"                                      basic functionality that is displayed in\n"
-"                                      search and browse listings, as well as at\n"
-"                                      the top of your theme's details page."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/personas/submit.html:198
@@ -6595,30 +6471,16 @@ msgstr ""
 msgid "Files added to reviewed versions must be reviewed before they will be available for download."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/add_file_modal.html:15
-#, python-format
-msgid ""
-"Submission of updates to unlisted add-ons for signing is currently in an open beta. Manual review may still be required for a large number of add-ons. Please <a href=\"%(url)s\" target=\"_blank"
-"\">report any bugs</a> that you encounter."
-msgstr ""
-
-#: src/olympia/devhub/templates/devhub/versions/add_file_modal.html:35
+#: src/olympia/devhub/templates/devhub/versions/add_file_modal.html:24
 msgid "Select the target platform for this file."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/add_file_modal.html:46
+#: src/olympia/devhub/templates/devhub/versions/add_file_modal.html:35
 msgid "Which review type would you like to nominate for?"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/add_file_modal.html:51
+#: src/olympia/devhub/templates/devhub/versions/add_file_modal.html:40
 msgid "Only publish this version to my beta channel."
-msgstr ""
-
-#: src/olympia/devhub/templates/devhub/versions/add_file_modal.html:54
-#, python-format
-msgid ""
-"The behavior of the beta channel has changed to accommodate <a href=\"%(addon_signing_url)s\" target=\"_blank\">mandatory add-on signing</a>. The new process is currently in an open beta, and may "
-"change significantly in the near future. Please <a href=\"%(issues_url)s\" target=\"_blank\">report any bugs</a> that you encounter."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/versions/edit.html:5
@@ -6642,19 +6504,10 @@ msgstr ""
 msgid "Upload Another File"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/edit.html:45
-msgid ""
-"Adjusting application information here will allow users to install your\n"
-"                          add-on even if the install manifest in the package indicates that the\n"
-"                          add-on is incompatible."
-msgstr ""
-
 #: src/olympia/devhub/templates/devhub/versions/edit.html:74
 msgid ""
-"Information about changes in this release, new features,\n"
-"                              known bugs, and other useful information specific to this\n"
-"                              release/version. This information is also shown in the\n"
-"                              Add-ons Manager when updating."
+"Information about changes in this release, new features, known bugs, and other useful information specific to this release/version. This information is also shown in the Add-ons Manager when "
+"updating."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/versions/edit.html:99
@@ -6666,10 +6519,7 @@ msgid "Notes for Reviewers"
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/versions/edit.html:114
-msgid ""
-"Optionally, enter any information that may be useful\n"
-"                              to the Editor reviewing this add-on, such as test\n"
-"                              account information."
+msgid "Optionally, enter any information that may be useful to the Editor reviewing this add-on, such as test account information."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/versions/edit.html:127
@@ -6747,7 +6597,7 @@ msgstr ""
 msgid "Request Preliminary Review"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:80 src/olympia/devhub/templates/devhub/versions/list.html:327 src/olympia/devhub/templates/devhub/versions/list.html:350
+#: src/olympia/devhub/templates/devhub/versions/list.html:80 src/olympia/devhub/templates/devhub/versions/list.html:325 src/olympia/devhub/templates/devhub/versions/list.html:348
 msgid "Cancel Review Request"
 msgstr ""
 
@@ -6776,7 +6626,7 @@ msgid "Unlisted:"
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/versions/list.html:114
-msgid "Not distributed on {0}. Developers will upload new versions for signing and distribute the add-ons on their own. (beta)"
+msgid "Not distributed on {0}. Developers will upload new versions for signing and distribute the add-ons on their own."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/versions/list.html:122
@@ -6839,81 +6689,73 @@ msgid "<strong>Important:</strong> Once a version has been deleted, you may not 
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/versions/list.html:230
-msgid ""
-"Deleting a version which has already been reviewed\n"
-"               may also cause a significant delay in the review of\n"
-"               your next update."
-msgstr ""
-
-#: src/olympia/devhub/templates/devhub/versions/list.html:233
 msgid "Are you sure you wish to delete this version?"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:238
+#: src/olympia/devhub/templates/devhub/versions/list.html:235
 msgid "Delete Version"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:240
+#: src/olympia/devhub/templates/devhub/versions/list.html:237
 msgid "Disable Version"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:247
+#: src/olympia/devhub/templates/devhub/versions/list.html:244
 msgid "Add a new Version"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:249
+#: src/olympia/devhub/templates/devhub/versions/list.html:246
 msgid "Add Version"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:256 src/olympia/devhub/templates/devhub/versions/list.html:274
+#: src/olympia/devhub/templates/devhub/versions/list.html:253 src/olympia/devhub/templates/devhub/versions/list.html:279
 msgid "Hide Add-on"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:259
+#: src/olympia/devhub/templates/devhub/versions/list.html:256
 msgid "Hiding your add-on will prevent it from appearing anywhere in our gallery and will stop users from receiving automatic updates."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:265
+#: src/olympia/devhub/templates/devhub/versions/list.html:263
+msgid "The files awaiting review will be disabled and you will need to upload new versions."
+msgstr ""
+
+#: src/olympia/devhub/templates/devhub/versions/list.html:270
 msgid "Are you sure you wish to hide your add-on?"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:286 src/olympia/devhub/templates/devhub/versions/list.html:315
+#: src/olympia/devhub/templates/devhub/versions/list.html:291 src/olympia/devhub/templates/devhub/versions/list.html:313
 msgid "Unlist Add-on"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:289
+#: src/olympia/devhub/templates/devhub/versions/list.html:294
 #, python-format
 msgid ""
 "Unlisting your add-on will make it (and each of its versions/files) invisible on this website. It won't show up in searches, won't have a public facing page, and won't be updated automatically for "
-"current users.  It is recommended for unlisted add-ons to provide a custom <a href=\"%(update_url)s\" target=\"_blank\">updateURL</a> in their manifest file for automatic updates."
+"current users. It is recommended for unlisted add-ons to provide a custom <a href=\"%(update_url)s\" target=\"_blank\">updateURL</a> in their manifest file for automatic updates."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:299
-#, python-format
-msgid "Switching add-ons to unlisted is currently in an open beta. Please <a href=\"%(url)s\" target=\"_blank\">report any bugs</a> that you encounter."
-msgstr ""
-
-#: src/olympia/devhub/templates/devhub/versions/list.html:305
+#: src/olympia/devhub/templates/devhub/versions/list.html:303
 msgid "Unlisting an add-on is irreversible!"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:305
+#: src/olympia/devhub/templates/devhub/versions/list.html:303
 msgid "An unlisted add-on cannot be switched to be listed."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:307
+#: src/olympia/devhub/templates/devhub/versions/list.html:305
 msgid "Are you sure you wish to unlist your add-on?"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:330
+#: src/olympia/devhub/templates/devhub/versions/list.html:328
 msgid "Canceling your review request will leave your add-on as preliminarily reviewed."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:335
+#: src/olympia/devhub/templates/devhub/versions/list.html:333
 msgid "Canceling your review request will mark your add-on incomplete. If you do not complete your add-on after several days by re-requesting review, it will be deleted."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:343
+#: src/olympia/devhub/templates/devhub/versions/list.html:341
 msgid "Are you sure you wish to cancel your review request?"
 msgstr ""
 
@@ -7252,19 +7094,19 @@ msgstr ""
 msgid "Search by add-on name / author email"
 msgstr ""
 
-#: src/olympia/editors/forms.py:103
+#: src/olympia/editors/forms.py:103 src/olympia/editors/forms.py:244 src/olympia/editors/forms.py:257
 msgid "yes"
 msgstr ""
 
-#: src/olympia/editors/forms.py:104
+#: src/olympia/editors/forms.py:104 src/olympia/editors/forms.py:244 src/olympia/editors/forms.py:257
 msgid "no"
 msgstr ""
 
-#: src/olympia/editors/forms.py:105
+#: src/olympia/editors/forms.py:105 src/olympia/editors/forms.py:245
 msgid "Admin Flag"
 msgstr ""
 
-#: src/olympia/editors/forms.py:113
+#: src/olympia/editors/forms.py:113 src/olympia/editors/forms.py:253
 msgid "Max. Version"
 msgstr ""
 
@@ -7276,55 +7118,59 @@ msgstr ""
 msgid "Add-on Types"
 msgstr ""
 
-#: src/olympia/editors/forms.py:126 src/olympia/editors/helpers.py:267
+#: src/olympia/editors/forms.py:126 src/olympia/editors/helpers.py:279
 msgid "Platforms"
 msgstr ""
 
+#: src/olympia/editors/forms.py:237
+msgid "Search by add-on name / author email / guid"
+msgstr ""
+
 #. L10n: 0 = platform, 1 = filename, 2 = status message
-#: src/olympia/editors/forms.py:238
+#: src/olympia/editors/forms.py:342
 #, python-format
 msgid "<strong>%s</strong> &middot; %s &middot; %s"
 msgstr ""
 
-#: src/olympia/editors/forms.py:252
+#: src/olympia/editors/forms.py:356
 msgid "Comments:"
 msgstr ""
 
-#: src/olympia/editors/forms.py:256
+#: src/olympia/editors/forms.py:360
 msgid "Operating systems:"
 msgstr ""
 
-#: src/olympia/editors/forms.py:258
+#: src/olympia/editors/forms.py:362
 msgid "Applications:"
 msgstr ""
 
-#: src/olympia/editors/forms.py:260
+#: src/olympia/editors/forms.py:364
 msgid "Notify me the next time this add-on is updated. (Subsequent updates will not generate an email)"
 msgstr ""
 
-#: src/olympia/editors/forms.py:265
+#: src/olympia/editors/forms.py:369
 msgid "Clear Admin Review Flag"
 msgstr ""
 
-#: src/olympia/editors/forms.py:267
+#: src/olympia/editors/forms.py:371
 msgid "Clear more info requested flag"
 msgstr ""
 
-#: src/olympia/editors/forms.py:281
+#: src/olympia/editors/forms.py:385
 msgid "Choose a canned response..."
 msgstr ""
 
 #. L10n: Description of what can be searched for.
-#: src/olympia/editors/forms.py:324
+#: src/olympia/editors/forms.py:423
 msgid "theme name"
 msgstr ""
 
-#: src/olympia/editors/forms.py:350
+#: src/olympia/editors/forms.py:449
 msgid "Someone else is reviewing this theme."
 msgstr ""
 
 #. L10n: Description of what can be searched for.
-#: src/olympia/editors/forms.py:447
+#: src/olympia/editors/forms.py:546
 msgid "app, reviewer, or comment"
 msgstr ""
 
@@ -7340,246 +7186,264 @@ msgstr ""
 msgid "Rejected or Unreviewed"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:123 src/olympia/editors/helpers.py:136
+#: src/olympia/editors/helpers.py:125 src/olympia/editors/helpers.py:138
 msgid "Queue"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:124 src/olympia/editors/templates/editors/base.html:50 src/olympia/editors/templates/editors/base.html:65
+#: src/olympia/editors/helpers.py:126 src/olympia/editors/templates/editors/base.html:50 src/olympia/editors/templates/editors/base.html:65
 msgid "Pending Updates"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:125 src/olympia/editors/templates/editors/base.html:48 src/olympia/editors/templates/editors/base.html:63
+#: src/olympia/editors/helpers.py:127 src/olympia/editors/templates/editors/base.html:48 src/olympia/editors/templates/editors/base.html:63
 msgid "Full Reviews"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:126 src/olympia/editors/templates/editors/base.html:52 src/olympia/editors/templates/editors/base.html:67
+#: src/olympia/editors/helpers.py:128 src/olympia/editors/templates/editors/base.html:52 src/olympia/editors/templates/editors/base.html:67
 msgid "Preliminary Reviews"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:127 src/olympia/editors/templates/editors/base.html:54
+#: src/olympia/editors/helpers.py:129 src/olympia/editors/templates/editors/base.html:54
 msgid "Moderated Reviews"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:128 src/olympia/editors/templates/editors/base.html:46
+#: src/olympia/editors/helpers.py:130 src/olympia/editors/templates/editors/base.html:46
 msgid "Fast Track"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:130
+#: src/olympia/editors/helpers.py:132
 msgid "Pending Themes"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:131 src/olympia/editors/templates/editors/themes/queue.html:4
+#: src/olympia/editors/helpers.py:133 src/olympia/editors/templates/editors/themes/queue.html:4
 msgid "Flagged Themes"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:132
+#: src/olympia/editors/helpers.py:134
 msgid "Update Themes"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:137
+#: src/olympia/editors/helpers.py:139
 msgid "Unlisted Pending Updates"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:138
+#: src/olympia/editors/helpers.py:140
 msgid "Unlisted Full Reviews"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:139
+#: src/olympia/editors/helpers.py:141
 msgid "Unlisted Preliminary Reviews"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:170
+#: src/olympia/editors/helpers.py:142
+msgid "Unlisted All Add-ons"
+msgstr ""
+
+#: src/olympia/editors/helpers.py:173
 msgid "Fast Track ({0})"
 msgid_plural "Fast Track ({0})"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/olympia/editors/helpers.py:175
+#: src/olympia/editors/helpers.py:178
 msgid "Full Review ({0})"
 msgid_plural "Full Reviews ({0})"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/olympia/editors/helpers.py:180
+#: src/olympia/editors/helpers.py:183
 msgid "Pending Update ({0})"
 msgid_plural "Pending Updates ({0})"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/olympia/editors/helpers.py:185
+#: src/olympia/editors/helpers.py:188
 msgid "Preliminary Review ({0})"
 msgid_plural "Preliminary Reviews ({0})"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/olympia/editors/helpers.py:190
+#: src/olympia/editors/helpers.py:193
 msgid "Moderated Review ({0})"
 msgid_plural "Moderated Reviews ({0})"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/olympia/editors/helpers.py:196
+#: src/olympia/editors/helpers.py:199
 msgid "Unlisted Full Review ({0})"
 msgid_plural "Unlisted Full Reviews ({0})"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/olympia/editors/helpers.py:201
+#: src/olympia/editors/helpers.py:204
 msgid "Unlisted Pending Update ({0})"
 msgid_plural "Unlisted Pending Updates ({0})"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/olympia/editors/helpers.py:206
+#: src/olympia/editors/helpers.py:209
 msgid "Unlisted Preliminary Review ({0})"
 msgid_plural "Unlisted Preliminary Reviews ({0})"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/olympia/editors/helpers.py:261
-msgid "Addon"
-msgstr ""
+#: src/olympia/editors/helpers.py:214
+msgid "Unlisted All Add-ons ({0})"
+msgid_plural "Unlisted All Add-ons ({0})"
+msgstr[0] ""
+msgstr[1] ""
 
-#: src/olympia/editors/helpers.py:262
+#: src/olympia/editors/helpers.py:274
 msgid "Type"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:263
+#: src/olympia/editors/helpers.py:275
 msgid "Waiting Time"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:264 src/olympia/editors/templates/editors/review.html:285
+#: src/olympia/editors/helpers.py:276 src/olympia/editors/templates/editors/review.html:285
 msgid "Flags"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:265
+#: src/olympia/editors/helpers.py:277
 msgid "Applications"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:270
+#: src/olympia/editors/helpers.py:282
 msgid "Additional"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:285
+#: src/olympia/editors/helpers.py:302
 msgid "Site Specific"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:287
+#: src/olympia/editors/helpers.py:304
 msgid "Requires External Software"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:289
+#: src/olympia/editors/helpers.py:306
 msgid "Binary Components"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:313
+#: src/olympia/editors/helpers.py:339
 msgid "moments ago"
 msgstr ""
 
 #. L10n: first argument is number of minutes
-#: src/olympia/editors/helpers.py:316
+#: src/olympia/editors/helpers.py:342
 msgid "{0} minute"
 msgid_plural "{0} minutes"
 msgstr[0] ""
 msgstr[1] ""
 
 #. L10n: first argument is number of hours
-#: src/olympia/editors/helpers.py:320
+#: src/olympia/editors/helpers.py:346
 msgid "{0} hour"
 msgid_plural "{0} hours"
 msgstr[0] ""
 msgstr[1] ""
 
 #. L10n: first argument is number of days
-#: src/olympia/editors/helpers.py:324
+#: src/olympia/editors/helpers.py:350
 msgid "{0} day"
 msgid_plural "{0} days"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/olympia/editors/helpers.py:488
+#: src/olympia/editors/helpers.py:364
+msgid "Last Review"
+msgstr ""
+
+#: src/olympia/editors/helpers.py:366
+msgid "Last Update"
+msgstr ""
+
+#: src/olympia/editors/helpers.py:387
+msgid "No Reviews"
+msgstr ""
+
+#: src/olympia/editors/helpers.py:561
 msgid "Push to public"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:490
+#: src/olympia/editors/helpers.py:563
 msgid "Grant full review"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:505
+#: src/olympia/editors/helpers.py:578
 msgid "Request more information"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:508
+#: src/olympia/editors/helpers.py:581
 msgid "Request super-review"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:519
+#: src/olympia/editors/helpers.py:592
 msgid "Grant preliminary review"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:520
+#: src/olympia/editors/helpers.py:593
 msgid "This will mark the files as preliminarily reviewed."
 msgstr ""
 
-#: src/olympia/editors/helpers.py:522
+#: src/olympia/editors/helpers.py:595
 msgid "Use this form to request more information from the author. They will receive an email and be able to answer here. You will be notified by email when they reply."
 msgstr ""
 
-#: src/olympia/editors/helpers.py:526
+#: src/olympia/editors/helpers.py:599
 msgid ""
 "If you have concerns about this add-on's security, copyright issues, or other concerns that an administrator should look into, enter your comments in the area below. They will be sent to "
 "administrators, not the author."
 msgstr ""
 
-#: src/olympia/editors/helpers.py:532
+#: src/olympia/editors/helpers.py:605
 msgid "This will reject the add-on and remove it from the review queue."
 msgstr ""
 
-#: src/olympia/editors/helpers.py:534
-msgid "Make a comment on this version.  The author won't be able to see this."
+#: src/olympia/editors/helpers.py:607
+msgid "Make a comment on this version. The author won't be able to see this."
 msgstr ""
 
-#: src/olympia/editors/helpers.py:538
+#: src/olympia/editors/helpers.py:611
 msgid "This will reject the files and remove them from the review queue."
 msgstr ""
 
-#: src/olympia/editors/helpers.py:542
+#: src/olympia/editors/helpers.py:615
 msgid "This will mark the add-on as preliminarily reviewed. Future versions will undergo preliminary review."
 msgstr ""
 
-#: src/olympia/editors/helpers.py:547
+#: src/olympia/editors/helpers.py:620
 msgid "This will mark the files as preliminarily reviewed. Future versions will undergo preliminary review."
 msgstr ""
 
-#: src/olympia/editors/helpers.py:552
+#: src/olympia/editors/helpers.py:625
 msgid "Retain preliminary review"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:553
+#: src/olympia/editors/helpers.py:626
 msgid "This will retain the add-on as preliminarily reviewed. Future versions will undergo preliminary review."
 msgstr ""
 
-#: src/olympia/editors/helpers.py:558
+#: src/olympia/editors/helpers.py:631
 msgid "This will approve a sandboxed version of a public add-on to appear on the public side."
 msgstr ""
 
-#: src/olympia/editors/helpers.py:561
+#: src/olympia/editors/helpers.py:634
 msgid "This will reject a version of a public add-on and remove it from the queue."
 msgstr ""
 
-#: src/olympia/editors/helpers.py:564
+#: src/olympia/editors/helpers.py:637
 msgid "This will mark the add-on and its most recent version and files as public. Future versions will go into the sandbox until they are reviewed by an editor."
 msgstr ""
 
-#: src/olympia/editors/helpers.py:637
+#: src/olympia/editors/helpers.py:714
 msgid "add-on"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:940 src/olympia/editors/helpers.py:960
+#: src/olympia/editors/helpers.py:1020 src/olympia/editors/helpers.py:1040
 msgid "Flagged"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:944 src/olympia/editors/helpers.py:963
+#: src/olympia/editors/helpers.py:1024 src/olympia/editors/helpers.py:1043
 msgid "Updates"
 msgstr ""
 
@@ -7631,56 +7495,56 @@ msgstr ""
 msgid "A question about your Theme submission"
 msgstr ""
 
-#: src/olympia/editors/views.py:144
+#: src/olympia/editors/views.py:146
 msgid "New Add-ons (Under 5 days)"
 msgstr ""
 
-#: src/olympia/editors/views.py:145
+#: src/olympia/editors/views.py:147
 msgid "Passable (5 to 10 days)"
 msgstr ""
 
-#: src/olympia/editors/views.py:146
+#: src/olympia/editors/views.py:148
 msgid "Overdue (Over 10 days)"
 msgstr ""
 
-#: src/olympia/editors/views.py:532
+#: src/olympia/editors/views.py:539
 msgid "An unknown error occurred"
 msgstr ""
 
-#: src/olympia/editors/views.py:587
+#: src/olympia/editors/views.py:592
 msgid "Self-reviews are not allowed."
 msgstr ""
 
-#: src/olympia/editors/views.py:609
+#: src/olympia/editors/views.py:613
 msgid "Review successfully processed."
 msgstr ""
 
-#: src/olympia/editors/views.py:807
+#: src/olympia/editors/views.py:812
 msgid "was approved"
 msgstr ""
 
-#: src/olympia/editors/views.py:808
+#: src/olympia/editors/views.py:813
 msgid "given preliminary review"
 msgstr ""
 
-#: src/olympia/editors/views.py:809
+#: src/olympia/editors/views.py:814
 msgid "rejected"
 msgstr ""
 
-#: src/olympia/editors/views.py:810
+#: src/olympia/editors/views.py:815
 msgctxt "editors_review_history_nominated_adminreview"
 msgid "escalated"
 msgstr ""
 
-#: src/olympia/editors/views.py:812
+#: src/olympia/editors/views.py:817
 msgid "needs more information"
 msgstr ""
 
-#: src/olympia/editors/views.py:813
+#: src/olympia/editors/views.py:818
 msgid "needs super review"
 msgstr ""
 
-#: src/olympia/editors/views.py:814
+#: src/olympia/editors/views.py:819
 msgid "commented"
 msgstr ""
 
@@ -7725,28 +7589,28 @@ msgstr ""
 msgid "Unlisted Queues"
 msgstr ""
 
-#: src/olympia/editors/templates/editors/base.html:72 src/olympia/editors/templates/editors/performance.html:6
+#: src/olympia/editors/templates/editors/base.html:74 src/olympia/editors/templates/editors/performance.html:6
 msgid "Performance"
 msgstr ""
 
-#: src/olympia/editors/templates/editors/base.html:75 src/olympia/editors/templates/editors/themes/base.html:19 src/olympia/editors/templates/editors/themes/base.html:38
+#: src/olympia/editors/templates/editors/base.html:77 src/olympia/editors/templates/editors/themes/base.html:19 src/olympia/editors/templates/editors/themes/base.html:38
 msgid "Logs"
 msgstr ""
 
-#: src/olympia/editors/templates/editors/base.html:78 src/olympia/editors/templates/editors/reviewlog.html:4 src/olympia/editors/templates/editors/reviewlog.html:27
+#: src/olympia/editors/templates/editors/base.html:80 src/olympia/editors/templates/editors/reviewlog.html:4 src/olympia/editors/templates/editors/reviewlog.html:27
 msgid "Add-on Review Log"
 msgstr ""
 
-#: src/olympia/editors/templates/editors/base.html:80 src/olympia/editors/templates/editors/eventlog.html:4 src/olympia/editors/templates/editors/eventlog.html:8
+#: src/olympia/editors/templates/editors/base.html:82 src/olympia/editors/templates/editors/eventlog.html:4 src/olympia/editors/templates/editors/eventlog.html:8
 #: src/olympia/editors/templates/editors/eventlog_detail.html:4
 msgid "Moderated Review Log"
 msgstr ""
 
-#: src/olympia/editors/templates/editors/base.html:82 src/olympia/editors/templates/editors/beta_signed_log.html:4 src/olympia/editors/templates/editors/beta_signed_log.html:8
+#: src/olympia/editors/templates/editors/base.html:84 src/olympia/editors/templates/editors/beta_signed_log.html:4 src/olympia/editors/templates/editors/beta_signed_log.html:8
 msgid "Signed Beta Files Log"
 msgstr ""
 
-#: src/olympia/editors/templates/editors/base.html:87 src/olympia/editors/templates/editors/includes/daily-message.html:4
+#: src/olympia/editors/templates/editors/base.html:89 src/olympia/editors/templates/editors/includes/daily-message.html:4
 msgid "Announcement"
 msgstr ""
 
@@ -7967,45 +7831,45 @@ msgstr ""
 msgid "clear search"
 msgstr ""
 
-#: src/olympia/editors/templates/editors/queue.html:72 src/olympia/editors/templates/editors/queue.html:122
+#: src/olympia/editors/templates/editors/queue.html:78 src/olympia/editors/templates/editors/queue.html:128
 msgid "Process Reviews"
 msgstr ""
 
-#: src/olympia/editors/templates/editors/queue.html:80
+#: src/olympia/editors/templates/editors/queue.html:86
 msgid "Moderation actions:"
 msgstr ""
 
-#: src/olympia/editors/templates/editors/queue.html:90
+#: src/olympia/editors/templates/editors/queue.html:96
 #, python-format
 msgid "by %(user)s on %(date)s %(stars)s (%(locale)s)"
 msgstr ""
 
-#: src/olympia/editors/templates/editors/queue.html:106
+#: src/olympia/editors/templates/editors/queue.html:112
 #, python-format
 msgid "<strong>%(reason)s</strong> <span class=\"light\">Flagged by %(user)s on %(date)s</span>"
 msgstr ""
 
-#: src/olympia/editors/templates/editors/queue.html:119
-msgid "All reviews have been moderated.  Good work!"
+#: src/olympia/editors/templates/editors/queue.html:125
+msgid "All reviews have been moderated. Good work!"
 msgstr ""
 
-#: src/olympia/editors/templates/editors/queue.html:161
+#: src/olympia/editors/templates/editors/queue.html:167
 msgid "Version Notes / Notes for Reviewer"
 msgstr ""
 
-#: src/olympia/editors/templates/editors/queue.html:169
+#: src/olympia/editors/templates/editors/queue.html:175
 msgid "There are currently no add-ons of this type to review."
 msgstr ""
 
-#: src/olympia/editors/templates/editors/queue.html:181 src/olympia/editors/templates/editors/themes/queue_list.html:85
+#: src/olympia/editors/templates/editors/queue.html:187 src/olympia/editors/templates/editors/themes/queue_list.html:85
 msgid "Helpful Links:"
 msgstr ""
 
-#: src/olympia/editors/templates/editors/queue.html:182
+#: src/olympia/editors/templates/editors/queue.html:188
 msgid "Add-on Policy"
 msgstr ""
 
-#: src/olympia/editors/templates/editors/queue.html:184
+#: src/olympia/editors/templates/editors/queue.html:190
 msgid "Editors' Guide"
 msgstr ""
 
@@ -8068,10 +7932,7 @@ msgid "<strong>Warning!</strong> Another user was viewing this page before you."
 msgstr ""
 
 #: src/olympia/editors/templates/editors/review.html:237
-msgid ""
-"The whiteboard is the place to exchange information relevant to\n"
-"               this addon (whatever the version), between the developer and the\n"
-"               editor. This is visible and editable by both."
+msgid "The whiteboard is the place to exchange information relevant to this addon (whatever the version), between the developer and the editor. This is visible and editable by both."
 msgstr ""
 
 #: src/olympia/editors/templates/editors/review.html:241
@@ -8345,7 +8206,7 @@ msgstr ""
 msgid "Describe your reason for flagging"
 msgstr ""
 
-#: src/olympia/files/forms.py:88
+#: src/olympia/files/forms.py:90
 msgid "Cannot diff a version against itself"
 msgstr ""
 
@@ -8380,51 +8241,51 @@ msgstr ""
 msgid "There was an error accessing file %s."
 msgstr ""
 
-#: src/olympia/files/utils.py:343
+#: src/olympia/files/utils.py:340
 msgid "Could not parse uploaded file."
 msgstr ""
 
-#: src/olympia/files/utils.py:380
+#: src/olympia/files/utils.py:377
 msgid "Invalid file name in archive: {0}"
 msgstr ""
 
-#: src/olympia/files/utils.py:388
+#: src/olympia/files/utils.py:385
 msgid "File exceeding size limit in archive: {0}"
 msgstr ""
 
-#: src/olympia/files/utils.py:439
+#: src/olympia/files/utils.py:436
 msgid "Invalid archive."
 msgstr ""
 
-#: src/olympia/files/utils.py:529 src/olympia/files/utils.py:532
+#: src/olympia/files/utils.py:526 src/olympia/files/utils.py:529
 msgid "Could not parse the manifest file."
 msgstr ""
 
-#: src/olympia/files/utils.py:551
+#: src/olympia/files/utils.py:548
 msgid "Could not find an add-on ID."
 msgstr ""
 
-#: src/olympia/files/utils.py:554
+#: src/olympia/files/utils.py:551
 msgid "Add-on ID must be 64 characters or less."
 msgstr ""
 
-#: src/olympia/files/utils.py:556
+#: src/olympia/files/utils.py:553
 msgid "Add-on ID doesn't match add-on."
 msgstr ""
 
-#: src/olympia/files/utils.py:564
+#: src/olympia/files/utils.py:561
 msgid "Duplicate add-on ID found."
 msgstr ""
 
-#: src/olympia/files/utils.py:567
+#: src/olympia/files/utils.py:564
 msgid "Version numbers should have fewer than 32 characters."
 msgstr ""
 
-#: src/olympia/files/utils.py:570
+#: src/olympia/files/utils.py:567
 msgid "Version numbers should only contain letters, numbers, and these punctuation characters: +*.-_."
 msgstr ""
 
-#: src/olympia/files/utils.py:587
+#: src/olympia/files/utils.py:584
 msgid "<em:type> doesn't match add-on"
 msgstr ""
 
@@ -8523,6 +8384,10 @@ msgstr ""
 
 #: src/olympia/files/templates/files/viewer.html:134
 msgid "Fetching file."
+msgstr ""
+
+#: src/olympia/legacy_api/views.py:255
+msgid "Not implemented yet."
 msgstr ""
 
 #: src/olympia/lib/constants.py:6
@@ -9181,10 +9046,6 @@ msgstr ""
 msgid "Zimbabwe Dollar"
 msgstr ""
 
-#: src/olympia/lib/video/ffmpeg.py:112 src/olympia/lib/video/totem.py:81
-msgid "Videos must be in WebM."
-msgstr ""
-
 #: src/olympia/pages/templates/pages/about.lhtml:3 src/olympia/pages/templates/pages/about.lhtml:10
 msgid "About Mozilla Add-ons"
 msgstr ""
@@ -9196,7 +9057,7 @@ msgstr ""
 #: src/olympia/pages/templates/pages/about.lhtml:13
 msgid ""
 "addons.mozilla.org, commonly known as \"AMO\", is Mozilla's official site for add-ons to Mozilla software, such as Firefox, Thunderbird, and SeaMonkey. Add-ons let you add new features and change "
-"the way your browser or application works.  Take a look around and explore the thousands of ways to customize the way you do things online."
+"the way your browser or application works. Take a look around and explore the thousands of ways to customize the way you do things online."
 msgstr ""
 
 #: src/olympia/pages/templates/pages/about.lhtml:19
@@ -9541,7 +9402,7 @@ msgstr ""
 msgid ""
 "Yes. It's possible, but some of the functionality provided by these libraries are available through XPCOM, XUL, and JavaScript. In addition, authors should take care if libraries modify primitive "
 "object prototypes (String.prototype, Date.prototype, etc.) and/or define global functions (eg. the $ function). These are prone to cause conflict with other add-ons, in particular if different add-"
-"ons use different versions of libraries and so on. Developers need to be very, very careful with using them.  Mozilla does not offer documentation on using them to build add-ons."
+"ons use different versions of libraries and so on. Developers need to be very, very careful with using them. Mozilla does not offer documentation on using them to build add-ons."
 msgstr ""
 
 #: src/olympia/pages/templates/pages/dev_faq.html:165
@@ -9655,8 +9516,8 @@ msgstr ""
 #, python-format
 msgid ""
 "Yes. Many developers choose to host their own add-ons. Choosing to host your add-on on <a href=\"%(amo_url)s\">Mozilla's add-on site</a>, though, allows for much greater exposure to your add-on due "
-"to the large volume of visitors to the site.  <a href=\"%(md_url)s\">mozdev.org</a> offers free project hosting for Mozilla applications and extensions providing developers with tools to help "
-"manage source code, version control, bug tracking and documentation."
+"to the large volume of visitors to the site. <a href=\"%(md_url)s\">mozdev.org</a> offers free project hosting for Mozilla applications and extensions providing developers with tools to help manage "
+"source code, version control, bug tracking and documentation."
 msgstr ""
 
 #: src/olympia/pages/templates/pages/dev_faq.html:277
@@ -9704,7 +9565,7 @@ msgstr ""
 #: src/olympia/pages/templates/pages/dev_faq.html:314
 #, python-format
 msgid ""
-"Yes. Mozilla's <a href=\"%(p_url)s\">Add-on Policy</a> describes what is an acceptable submission. This policy is subject to change without notice.  In addition, the AMO editorial team uses the <a "
+"Yes. Mozilla's <a href=\"%(p_url)s\">Add-on Policy</a> describes what is an acceptable submission. This policy is subject to change without notice. In addition, the AMO editorial team uses the <a "
 "href=\"%(g_url)s\">Editors Reviewing Guide</a> to ensure that your add-on meets specific guidelines for functionality and security."
 msgstr ""
 
@@ -9821,7 +9682,7 @@ msgstr ""
 #: src/olympia/pages/templates/pages/dev_faq.html:434
 #, python-format
 msgid ""
-"This is why it's very important to read the <a href=\"%(g_url)s\">Editors Reviewing Guide</a> to ensure that your add-on is setup as expected.  It's also a good idea to read the blog post, <a href="
+"This is why it's very important to read the <a href=\"%(g_url)s\">Editors Reviewing Guide</a> to ensure that your add-on is setup as expected. It's also a good idea to read the blog post, <a href="
 "\"%(blog_url)s\">Successfully Getting your Add-on Reviewed</a> which provides excellent insight into ensuring a smooth review of your add-on."
 msgstr ""
 
@@ -9928,7 +9789,7 @@ msgstr ""
 
 #: src/olympia/pages/templates/pages/dev_faq.html:572
 msgid ""
-"Free Software Foundation provides short summaries of the key open source licenses, including whether the license qualifies as a free software license or a copyleft license.  Also includes a "
+"Free Software Foundation provides short summaries of the key open source licenses, including whether the license qualifies as a free software license or a copyleft license. Also includes a "
 "discussion of what constitutes a free software license or a copyleft license (e.g., a Copyleft license is a general method for making a program or other work free, and requiring all modified and "
 "extended versions of the program to be free as well.)"
 msgstr ""
@@ -10106,19 +9967,13 @@ msgid "Add-on Gallery"
 msgstr ""
 
 #: src/olympia/pages/templates/pages/faq.html:171
-msgid ""
-"How do I choose between add-ons that seem to do the same\n"
-"    thing?"
+msgid "How do I choose between add-ons that seem to do the same thing?"
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:173
+#: src/olympia/pages/templates/pages/faq.html:172
 msgid ""
-"There are often several add-ons that have similar features. To\n"
-"    figure out which is right for you, read the entire description of the\n"
-"    add-on and view its screenshots. If there are still several in the running,\n"
-"    read through the add-on's ratings, user reviews, and statistics to see\n"
-"    which is most liked by other users. Remember that you can also just try\n"
-"    out both and see which you like better."
+"There are often several add-ons that have similar features. To figure out which is right for you, read the entire description of the add-on and view its screenshots. If there are still several in "
+"the running, read through the add-on's ratings, user reviews, and statistics to see which is most liked by other users. Remember that you can also just try out both and see which you like better."
 msgstr ""
 
 #: src/olympia/pages/templates/pages/faq.html:180
@@ -10159,80 +10014,67 @@ msgid "How much do add-ons cost to purchase?"
 msgstr ""
 
 #: src/olympia/pages/templates/pages/faq.html:207
-msgid ""
-"Add-ons hosted in our gallery are free unless clearly marked\n"
-"    otherwise."
+msgid "Add-ons hosted in our gallery are free unless clearly marked otherwise."
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:210
+#: src/olympia/pages/templates/pages/faq.html:209
 msgid "What does it mean when an add-on asks for contributions?"
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:211
+#: src/olympia/pages/templates/pages/faq.html:210
 msgid ""
-"Some add-on authors request users who enjoy an add-on to\n"
-"        contribute to its development by making a monetary contribution. These\n"
-"        contributions go directly to the developer unless a third party is\n"
-"        indicated, such as the non-profit Mozilla Foundation."
+"Some add-on authors request users who enjoy an add-on to contribute to its development by making a monetary contribution. These contributions go directly to the developer unless a third party is "
+"indicated, such as the non-profit Mozilla Foundation."
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:216
+#: src/olympia/pages/templates/pages/faq.html:215
 msgid "What are beta add-ons?"
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:218
+#: src/olympia/pages/templates/pages/faq.html:217
 msgid ""
-"Beta add-ons are unreviewed versions which represent the\n"
-"        latest work of an add-on author. While different authors have different\n"
-"        standards for beta code quality, you should assume that these add-ons\n"
-"        are less stable than the general add-on releases."
+"Beta add-ons are unreviewed versions which represent the latest work of an add-on author. While different authors have different standards for beta code quality, you should assume that these add-"
+"ons are less stable than the general add-on releases."
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:222
+#: src/olympia/pages/templates/pages/faq.html:221
 msgid ""
 "Please note that when you install an add-on from the \"Beta Version\" section of an add-on's listing, you will continue to receive updates for that add-on as they become available. Like the initial "
 "version you installed, all beta releases are unreviewed by Mozilla and may harm your computer."
 msgstr ""
 
+#: src/olympia/pages/templates/pages/faq.html:228
+msgid "What does it mean when an add-on is flagged as slow?"
+msgstr ""
+
 #: src/olympia/pages/templates/pages/faq.html:229
-msgid ""
-"What does it mean when an add-on is flagged as\n"
-"    slow?"
+msgid "Most add-ons load code and resources at the same time Firefox is starting up. In most cases the impact in start-up time is minimal, but some add-ons can cause a noticeable slowdown."
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:231
-msgid ""
-"Most add-ons load code and resources at the same time Firefox\n"
-"        is starting up. In most cases the impact in start-up time is minimal,\n"
-"        but some add-ons can cause a noticeable slowdown."
-msgstr ""
-
-#: src/olympia/pages/templates/pages/faq.html:236
+#: src/olympia/pages/templates/pages/faq.html:234
 msgid "How do I report an inappropriate or spam user review?"
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:237
+#: src/olympia/pages/templates/pages/faq.html:235
 msgid ""
-"To report a user review of an add-on, log in with your account\n"
-"    and visit the add-on's reviews page. Find the review you wish to report,\n"
-"    click \"Report this review\" and select a reason. Our editorial team will\n"
-"    investigate the review and take appropriate action."
+"To report a user review of an add-on, log in with your account and visit the add-on's reviews page. Find the review you wish to report, click \"Report this review\" and select a reason. Our "
+"editorial team will investigate the review and take appropriate action."
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:242
+#: src/olympia/pages/templates/pages/faq.html:240
 msgid "How do I report a bug or contact the Mozilla Add-ons team?"
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:243
+#: src/olympia/pages/templates/pages/faq.html:241
 #, python-format
 msgid "Please visit our <a href=\"%(contact_url)s\">Contact page</a>."
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:246
+#: src/olympia/pages/templates/pages/faq.html:244
 msgid "What is a Source Code License?"
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:247
+#: src/olympia/pages/templates/pages/faq.html:245
 #, python-format
 msgid ""
 "The source code used to create an add-on is an exclusive copyright of the add-on author, unless otherwise declared in a source code license. Many add-ons on this site have <a href=\"%(url)s\" lang="
@@ -10240,60 +10082,60 @@ msgid ""
 "the GPL or BSD licenses instead of making up their own."
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:256
+#: src/olympia/pages/templates/pages/faq.html:254
 #, python-format
 msgid "Firefox and other Mozilla software are <a href=\"%(url)s\">open source</a>."
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:264
+#: src/olympia/pages/templates/pages/faq.html:262
 msgid "Collections and Favorites"
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:267
+#: src/olympia/pages/templates/pages/faq.html:265
 msgid "What is a collection?"
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:268
+#: src/olympia/pages/templates/pages/faq.html:266
 msgid "Collections are groups of related add-ons created by users to share."
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:270
+#: src/olympia/pages/templates/pages/faq.html:268
 msgid "What is the My Favorites collection?"
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:271
+#: src/olympia/pages/templates/pages/faq.html:269
 msgid "Favorite add-ons are add-ons that you have bookmarked to easily get back to later. You can add an add-on to your favorites collection by clicking \"Add to favorites\" on its details page."
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:275 src/olympia/templates/menu_links.html:13 src/olympia/templates/impala/header_title.html:17
+#: src/olympia/pages/templates/pages/faq.html:273 src/olympia/templates/menu_links.html:13 src/olympia/templates/impala/header_title.html:17
 msgid "Mobile Add-ons"
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:278
+#: src/olympia/pages/templates/pages/faq.html:276
 msgid "What are mobile add-ons?"
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:279
+#: src/olympia/pages/templates/pages/faq.html:277
 #, python-format
 msgid ""
 "Mobile add-ons work with <a href=\"%(mobile_url)s\">Firefox for Mobile</a> and add or modify functionality just like desktop add-ons. You can find add-ons that work with Firefox for Mobile in our "
 "<a href=\"%(gallery_url)s\">gallery</a>."
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:288
+#: src/olympia/pages/templates/pages/faq.html:286
 msgid "Developer Topics"
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:289
+#: src/olympia/pages/templates/pages/faq.html:287
 #, python-format
 msgid "Please see our <a href=\"%(faq_url)s\">Developer FAQ</a> and <a href=\"%(hub_url)s\">Developer Hub</a> for answers to add-on developer-related questions."
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:294
+#: src/olympia/pages/templates/pages/faq.html:292
 msgid "Still have questions?"
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:295
+#: src/olympia/pages/templates/pages/faq.html:293
 #, python-format
 msgid "For general Firefox support, visit our <a href=\"%(sumo_url)s\">support website</a>. For general add-on and website questions, visit our <a href=\"%(forum_url)s\">forum</a>."
 msgstr ""
@@ -10431,7 +10273,7 @@ msgstr ""
 
 #: src/olympia/pages/templates/pages/sunbird.html:29
 msgid ""
-"Development on the Sunbird project has halted and its final release was on March 30, 2010.  We've been proud to host Sunbird add-ons on this site but as the project is no longer maintained we have "
+"Development on the Sunbird project has halted and its final release was on March 30, 2010. We've been proud to host Sunbird add-ons on this site but as the project is no longer maintained we have "
 "disabled our support for the add-ons."
 msgstr ""
 
@@ -10509,7 +10351,7 @@ msgstr ""
 #, python-format
 msgid ""
 "<h2>Keep these tips in mind:</h2> <ul> <li> Write like you're telling a friend about your experience with the add-on. Give specifics and helpful details, such as what features you liked and/or "
-"disliked, how easy to use it is, and any disadvantages it has.  Avoid generic language such as calling it \"Great\" or \"Bad\" unless you can give reasons why you believe this is so. </li> <li> "
+"disliked, how easy to use it is, and any disadvantages it has. Avoid generic language such as calling it \"Great\" or \"Bad\" unless you can give reasons why you believe this is so. </li> <li> "
 "Please do not post bug reports in reviews. We do not make your email address available to add-on developers and they may need to contact you to help resolve your issue. See the <a href=\"%(support)s"
 "\">support section</a> to find out where to get assistance for this add-on. </li> <li>Please keep reviews clean, avoid the use of improper language and do not post any personal information. </li> </"
 "ul> <p>Please read the <a href=\"%(guide)s\" target=\"_blank\">Review Guidelines</a> for more detail about user add-on reviews.</p>"
@@ -10745,16 +10587,16 @@ msgstr ""
 
 #. L10n: {0} is an application, such as Firefox. This means "any version of
 #. Firefox."
-#: src/olympia/search/views.py:554
+#: src/olympia/search/views.py:547
 msgid "Any {0}"
 msgstr ""
 
 #. L10n: "All Systems" means show everything regardless of platform.
-#: src/olympia/search/views.py:589
+#: src/olympia/search/views.py:582
 msgid "All Systems"
 msgstr ""
 
-#: src/olympia/search/views.py:600
+#: src/olympia/search/views.py:593
 msgid "All Tags"
 msgstr ""
 
@@ -10928,31 +10770,31 @@ msgstr ""
 msgid "Share this Collection"
 msgstr ""
 
-#: src/olympia/signing/views.py:30 src/olympia/templates/base.html:75 src/olympia/templates/impala/base.html:115
+#: src/olympia/signing/views.py:33 src/olympia/templates/base.html:71 src/olympia/templates/impala/base.html:112
 msgid "Some features are temporarily disabled while we perform website maintenance. We'll be back to full capacity shortly."
 msgstr ""
 
-#: src/olympia/signing/views.py:53
+#: src/olympia/signing/views.py:56
 msgid "Could not find add-on with id \"{}\"."
 msgstr ""
 
-#: src/olympia/signing/views.py:67
+#: src/olympia/signing/views.py:70
 msgid "You do not own this addon."
 msgstr ""
 
-#: src/olympia/signing/views.py:82
+#: src/olympia/signing/views.py:87
 msgid "Missing \"upload\" key in multipart file data."
 msgstr ""
 
-#: src/olympia/signing/views.py:96
+#: src/olympia/signing/views.py:101
 msgid "Version does not match the manifest file."
 msgstr ""
 
-#: src/olympia/signing/views.py:100
+#: src/olympia/signing/views.py:105
 msgid "Version already exists."
 msgstr ""
 
-#: src/olympia/signing/views.py:136
+#: src/olympia/signing/views.py:141
 msgid "No uploaded file for that addon and version."
 msgstr ""
 
@@ -11065,89 +10907,89 @@ msgstr ""
 msgid "Statistics Dashboard :: Add-ons for {0}"
 msgstr ""
 
-#: src/olympia/stats/templates/stats/stats.html:30
-msgid "Controls:"
-msgstr ""
-
-#: src/olympia/stats/templates/stats/stats.html:33
-msgid "reset zoom"
-msgstr ""
-
-#: src/olympia/stats/templates/stats/stats.html:40
-msgid "Group by:"
-msgstr ""
-
-#: src/olympia/stats/templates/stats/stats.html:42
-msgid "day"
-msgstr ""
-
-#: src/olympia/stats/templates/stats/stats.html:45
-msgid "week"
-msgstr ""
-
-#: src/olympia/stats/templates/stats/stats.html:48
-msgid "month"
-msgstr ""
-
-#: src/olympia/stats/templates/stats/stats.html:54
-msgid "For last:"
-msgstr ""
-
-#: src/olympia/stats/templates/stats/stats.html:57
-msgid "7 days"
-msgstr ""
-
-#: src/olympia/stats/templates/stats/stats.html:60
-msgid "30 days"
-msgstr ""
-
-#: src/olympia/stats/templates/stats/stats.html:63
-msgid "90 days"
-msgstr ""
-
-#: src/olympia/stats/templates/stats/stats.html:66
-msgid "365 days"
-msgstr ""
-
-#: src/olympia/stats/templates/stats/stats.html:69
-msgid "Custom..."
-msgstr ""
-
 #. {0} is an add-on name
-#: src/olympia/stats/templates/stats/stats.html:88 src/olympia/stats/templates/stats/stats.html:91
+#: src/olympia/stats/templates/stats/stats.html:44 src/olympia/stats/templates/stats/stats.html:47
 msgid "Statistics for {0}"
 msgstr ""
 
-#: src/olympia/stats/templates/stats/stats.html:94
+#: src/olympia/stats/templates/stats/stats.html:50
 msgid "Statistics Dashboard"
 msgstr ""
 
-#: src/olympia/stats/templates/stats/stats.html:104
+#: src/olympia/stats/templates/stats/stats.html:57
+msgid "Controls:"
+msgstr ""
+
+#: src/olympia/stats/templates/stats/stats.html:60
+msgid "reset zoom"
+msgstr ""
+
+#: src/olympia/stats/templates/stats/stats.html:67
+msgid "Group by:"
+msgstr ""
+
+#: src/olympia/stats/templates/stats/stats.html:69
+msgid "day"
+msgstr ""
+
+#: src/olympia/stats/templates/stats/stats.html:72
+msgid "week"
+msgstr ""
+
+#: src/olympia/stats/templates/stats/stats.html:75
+msgid "month"
+msgstr ""
+
+#: src/olympia/stats/templates/stats/stats.html:81
+msgid "For last:"
+msgstr ""
+
+#: src/olympia/stats/templates/stats/stats.html:84
+msgid "7 days"
+msgstr ""
+
+#: src/olympia/stats/templates/stats/stats.html:87
+msgid "30 days"
+msgstr ""
+
+#: src/olympia/stats/templates/stats/stats.html:90
+msgid "90 days"
+msgstr ""
+
+#: src/olympia/stats/templates/stats/stats.html:93
+msgid "365 days"
+msgstr ""
+
+#: src/olympia/stats/templates/stats/stats.html:96
+msgid "Custom..."
+msgstr ""
+
+#: src/olympia/stats/templates/stats/stats.html:106
 msgid "Statistics processing is currently disabled, so recent data is unavailable. The statistics are still being collected and this page will be updated soon with the missing data."
 msgstr ""
 
-#: src/olympia/stats/templates/stats/stats.html:110
+#: src/olympia/stats/templates/stats/stats.html:112
 msgid "Loading the latest data&hellip;"
 msgstr ""
 
-#: src/olympia/stats/templates/stats/stats.html:142 src/olympia/stats/templates/stats/reports/overview.html:25 src/olympia/stats/templates/stats/reports/overview.html:37
+#: src/olympia/stats/templates/stats/stats.html:144 src/olympia/stats/templates/stats/reports/overview.html:25 src/olympia/stats/templates/stats/reports/overview.html:37
 #: src/olympia/stats/templates/stats/reports/overview.html:49
 msgid "No data available."
 msgstr ""
 
-#: src/olympia/stats/templates/stats/stats.html:177
+#: src/olympia/stats/templates/stats/stats.html:179
 msgid "This dashboard is currently <b>public</b>."
 msgstr ""
 
-#: src/olympia/stats/templates/stats/stats.html:179
+#: src/olympia/stats/templates/stats/stats.html:181
 msgid "Contribution stats are currently <b>private</b>."
 msgstr ""
 
-#: src/olympia/stats/templates/stats/stats.html:182
+#: src/olympia/stats/templates/stats/stats.html:184
 msgid "This dashboard is currently <b>private</b>."
 msgstr ""
 
-#: src/olympia/stats/templates/stats/stats.html:185
+#: src/olympia/stats/templates/stats/stats.html:187
 msgid "Change settings."
 msgstr ""
 
@@ -11299,15 +11141,6 @@ msgstr ""
 msgid "Application versions by Date"
 msgstr ""
 
-#: src/olympia/tags/templates/tags/top_cloud.html:4
-msgid "Top {0} Tags"
-msgstr ""
-
-#. {0} is the current application name
-#: src/olympia/tags/templates/tags/top_cloud.html:14
-msgid "{0} Top Tags"
-msgstr ""
-
 #: src/olympia/templates/amo_footer.html:6 src/olympia/templates/includes/lang_switcher.html:2
 msgid "Other languages"
 msgstr ""
@@ -11316,11 +11149,11 @@ msgstr ""
 msgid "Mozilla Add-ons"
 msgstr ""
 
-#: src/olympia/templates/base.html:91 src/olympia/templates/impala/base.html:81
+#: src/olympia/templates/base.html:89 src/olympia/templates/impala/base.html:78
 msgid "Find add-ons for other applications"
 msgstr ""
 
-#: src/olympia/templates/base.html:92 src/olympia/templates/impala/base.html:81
+#: src/olympia/templates/base.html:90 src/olympia/templates/impala/base.html:78
 msgid "Other Applications"
 msgstr ""
 
@@ -11345,7 +11178,7 @@ msgid "View Mobile Site"
 msgstr ""
 
 #: src/olympia/templates/copyright.html:7
-msgid "Site Status "
+msgid "Site Status"
 msgstr ""
 
 #: src/olympia/templates/footer.html:3
@@ -11445,35 +11278,35 @@ msgstr ""
 msgid "<a href=\"%(reg)s\">Register</a> or <a href=\"%(login)s\">Log in</a>"
 msgstr ""
 
-#: src/olympia/templates/impala/base.html:126
+#: src/olympia/templates/impala/base.html:123
 #, python-format
 msgid "To try the thousands of add-ons available here, download <a href=\"%(url)s\">Mozilla Firefox</a>, a fast, free way to surf the Web!"
 msgstr ""
 
-#: src/olympia/templates/impala/base.html:138
+#: src/olympia/templates/impala/base.html:135
 #, python-format
 msgid "Add-ons is switching to Firefox Accounts for login. <a href=\"%(url)s\" class=\"fxa-login\">Sign in now to transfer your account.</a>"
 msgstr ""
 
 #. {0} is an application, such as Firefox.
-#: src/olympia/templates/impala/base.html:148
+#: src/olympia/templates/impala/base.html:145
 msgid "Welcome to {0} Add-ons."
 msgstr ""
 
-#: src/olympia/templates/impala/base.html:151
+#: src/olympia/templates/impala/base.html:148
 msgid "Choose from thousands of extra features and styles to make Firefox your own."
 msgstr ""
 
-#: src/olympia/templates/impala/base.html:156
+#: src/olympia/templates/impala/base.html:153
 #, python-format
 msgid "Add extra features and styles to make %(app)s your own."
 msgstr ""
 
-#: src/olympia/templates/impala/base.html:164
+#: src/olympia/templates/impala/base.html:161
 msgid "On the go?"
 msgstr ""
 
-#: src/olympia/templates/impala/base.html:166
+#: src/olympia/templates/impala/base.html:163
 msgid "Check out our <a class=\"mobile-link\" href=\"#\">Mobile Add-ons site</a>."
 msgstr ""
 
@@ -11697,19 +11530,19 @@ msgstr ""
 
 #. L10n: {id} will be something like "13ad6a", just a random number
 #. to differentiate this user from other anonymous users.
-#: src/olympia/users/models.py:353
+#: src/olympia/users/models.py:362
 msgid "Anonymous user {id}"
 msgstr ""
 
-#: src/olympia/users/models.py:410
+#: src/olympia/users/models.py:419
 msgid "Your account has been restricted"
 msgstr ""
 
-#: src/olympia/users/models.py:480
+#: src/olympia/users/models.py:489
 msgid "Please confirm your email address"
 msgstr ""
 
-#: src/olympia/users/models.py:506
+#: src/olympia/users/models.py:515
 msgid "My Mobile Add-ons"
 msgstr ""
 
@@ -11986,7 +11819,7 @@ msgstr ""
 
 #: src/olympia/users/templates/users/edit.html:70
 #, python-format
-msgid "Change your password.  If you forgot your password, you can <a href=\"%(reset_url)s\">use the reset form</a>."
+msgid "Change your password. If you forgot your password, you can <a href=\"%(reset_url)s\">use the reset form</a>."
 msgstr ""
 
 #: src/olympia/users/templates/users/edit.html:76
@@ -12006,7 +11839,7 @@ msgid "Profile"
 msgstr ""
 
 #: src/olympia/users/templates/users/edit.html:100
-msgid "Give us a bit more information about yourself.  All these fields are optional, but they'll help other users get to know you better."
+msgid "Give us a bit more information about yourself. All these fields are optional, but they'll help other users get to know you better."
 msgstr ""
 
 #: src/olympia/users/templates/users/edit.html:124
@@ -12222,7 +12055,7 @@ msgid "Confirm password"
 msgstr ""
 
 #: src/olympia/users/templates/users/pwreset_confirm.html:47
-msgid "The password reset link was invalid, possibly because it has already been used.  Please request a new password reset."
+msgid "The password reset link was invalid, possibly because it has already been used. Please request a new password reset."
 msgstr ""
 
 #: src/olympia/users/templates/users/pwreset_request.html:15
@@ -12408,7 +12241,7 @@ msgstr ""
 
 #: src/olympia/users/templates/users/unsubscribe.html:30
 #, python-format
-msgid "Unfortunately, we weren't able to unsubscribe you.  The link you clicked is invalid. However, you can unsubscribe still unsubscribe on your <a href=\"%(edit_url)s\">edit profile page</a>."
+msgid "Unfortunately, we weren't able to unsubscribe you. The link you clicked is invalid. However, you can unsubscribe still unsubscribe on your <a href=\"%(edit_url)s\">edit profile page</a>."
 msgstr ""
 
 #: src/olympia/users/templates/users/vcard.html:2
@@ -12462,15 +12295,15 @@ msgstr ""
 msgid "Version History with Changelogs"
 msgstr ""
 
-#: src/olympia/versions/models.py:314
+#: src/olympia/versions/models.py:313
 msgid "Add-on uses binary components."
 msgstr ""
 
-#: src/olympia/versions/models.py:317
+#: src/olympia/versions/models.py:316
 msgid "Add-on has opted into strict compatibility checking."
 msgstr ""
 
-#: src/olympia/versions/models.py:715
+#: src/olympia/versions/models.py:711
 msgid "{app} {min} and later"
 msgstr ""
 
@@ -12545,4 +12378,8 @@ msgstr ""
 
 #: src/olympia/zadmin/forms.py:105
 msgid "Log emails instead of sending"
+msgstr ""
+
+#: src/olympia/zadmin/forms.py:215
+msgid "Deleted versions can`t be changed."
 msgstr ""

--- a/locale/gd/LC_MESSAGES/djangojs.po
+++ b/locale/gd/LC_MESSAGES/djangojs.po
@@ -1,1216 +1,1236 @@
-
 #, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2016-02-24 21:23+0000\n"
+"POT-Creation-Date: 2016-04-18 15:47+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
+"Language: \n"
 "MIME-Version: 1.0\n"
-"Content-Type: text/plain; charset=utf-8\n"
+"Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Generated-By: Babel 2.2.0\n"
 
-#: static/js/common/ratingwidget.js:31
+#: static/js/common-all.js:1426 static/js/impala-all.js:1511 static/js/zamboni/discovery-all.js:12598 static/js/zamboni/init.js:28 static/js/zamboni/mobile-all.js:14945
+msgid "This feature is temporarily disabled while we perform website maintenance. Please check back a little later."
+msgstr ""
+
+#. L10n: {0} is an app name like Firefox.
+#: static/js/common-all.js:1837 static/js/impala-all.js:1922 static/js/zamboni/buttons.js:73 static/js/zamboni/discovery-all.js:13108
+msgid "Accept and Install"
+msgstr ""
+
+#: static/js/common-all.js:1837 static/js/impala-all.js:1922 static/js/zamboni/buttons.js:73 static/js/zamboni/discovery-all.js:13108
+msgid "Add to {0}"
+msgstr ""
+
+#: static/js/common-all.js:1842 static/js/impala-all.js:1927 static/js/zamboni/buttons.js:78 static/js/zamboni/discovery-all.js:13113
+msgid "Download Now"
+msgstr ""
+
+#: static/js/common-all.js:1883 static/js/impala-all.js:1968 static/js/zamboni/buttons.js:119 static/js/zamboni/discovery-all.js:13154
+msgid "Add-on has not been updated to support default-to-compatible."
+msgstr ""
+
+#: static/js/common-all.js:1888 static/js/impala-all.js:1973 static/js/zamboni/buttons.js:124 static/js/zamboni/discovery-all.js:13159
+msgid "You need to be using Firefox 10.0 or higher."
+msgstr ""
+
+#: static/js/common-all.js:1900 static/js/impala-all.js:1985 static/js/zamboni/buttons.js:136 static/js/zamboni/discovery-all.js:13171
+msgid "Mozilla has marked this version as incompatible with your Firefox version."
+msgstr ""
+
+#. L10n: {0} is an platform like Windows or Linux.
+#: static/js/common-all.js:1981 static/js/impala-all.js:2066 static/js/zamboni/buttons.js:217 static/js/zamboni/discovery-all.js:13252
+msgid "Install for {0} anyway"
+msgstr ""
+
+#: static/js/common-all.js:1981 static/js/impala-all.js:2066 static/js/zamboni/buttons.js:217 static/js/zamboni/discovery-all.js:13252
+msgid "Download for {0} anyway"
+msgstr ""
+
+#: static/js/common-all.js:2038 static/js/impala-all.js:2123 static/js/zamboni/buttons.js:274 static/js/zamboni/discovery-all.js:13309
+msgid "Not available for your platform"
+msgstr ""
+
+#. L10n: {0} is an app name, {1} is the app version.
+#: static/js/common-all.js:2049 static/js/common-all.js:2086 static/js/impala-all.js:2134 static/js/impala-all.js:2171 static/js/zamboni/buttons.js:286 static/js/zamboni/buttons.js:324
+#: static/js/zamboni/discovery-all.js:13320 static/js/zamboni/discovery-all.js:13357
+msgid "Not available for {0} {1}"
+msgstr ""
+
+#: static/js/common-all.js:2112 static/js/impala-all.js:2197 static/js/zamboni/buttons.js:351 static/js/zamboni/discovery-all.js:13383
+msgid "Works with {app} {min} - {max}"
+msgstr ""
+
+#: static/js/common-all.js:2114 static/js/impala-all.js:2199 static/js/zamboni/buttons.js:353 static/js/zamboni/discovery-all.js:13385
+msgid "View other versions"
+msgstr ""
+
+#: static/js/common-all.js:2162 static/js/impala-all.js:2247 static/js/zamboni/buttons.js:401 static/js/zamboni/discovery-all.js:13433
+msgid "Only with Firefox — Get Firefox Now!"
+msgstr ""
+
+#: static/js/common-all.js:2278 static/js/impala-all.js:2363 static/js/zamboni/buttons.js:517 static/js/zamboni/discovery-all.js:13549 static/js/zamboni/mobile-all.js:15177
+#: static/js/zamboni/mobile/buttons.js:43
+msgid "Sorry, you need a Mozilla-based browser (such as Firefox) to install a search plugin."
+msgstr ""
+
+#: static/js/common-all.js:9088 static/js/impala-all.js:9649 static/js/zamboni/global.js:410
+msgid "Loading..."
+msgstr ""
+
+#. L10n: {0} is the number of characters left.
+#: static/js/common-all.js:9152 static/js/impala-all.js:9713 static/js/zamboni/global.js:474
+msgid "<b>{0}</b> character left."
+msgid_plural "<b>{0}</b> characters left."
+msgstr[0] ""
+msgstr[1] ""
+
+#: static/js/common-all.js:9589 static/js/common-min.js:6 static/js/impala-all.js:10052 static/js/impala-min.js:6 static/js/common/ratingwidget.js:31 static/js/zamboni/mobile-all.js:16123
+#: static/js/zamboni/mobile-min.js:6
 msgid "{0} star"
 msgid_plural "{0} stars"
 msgstr[0] ""
 msgstr[1] ""
 
-#: static/js/common/upload-addon.js:41 static/js/common/upload-image.js:128
+#: static/js/common-all.js:9676 static/js/common-min.js:6 static/js/impala-all.js:10139 static/js/impala-min.js:6 static/js/zamboni/l10n.js:45
+msgid "Remove this localization"
+msgstr ""
+
+#: static/js/common-all.js:10193 static/js/common-min.js:6 static/js/impala-all.js:10674 static/js/impala-min.js:6 static/js/zamboni/discovery-all.js:13678
+msgid "close"
+msgstr ""
+
+#: static/js/common-all.js:10860 static/js/common-min.js:6 static/js/impala-all.js:11481 static/js/impala-min.js:6 static/js/impala/reviews.js:23 static/js/zamboni/reviews.js:18
+msgid "Flagged for review"
+msgstr ""
+
+#: static/js/common-all.js:10876 static/js/common-min.js:6 static/js/impala-all.js:11498 static/js/impala-min.js:6 static/js/impala/reviews.js:40 static/js/zamboni/reviews.js:34
+msgid "Your input is required"
+msgstr ""
+
+#: static/js/common-all.js:10945 static/js/common-min.js:6 static/js/impala-all.js:11610 static/js/impala-min.js:7 static/js/impala/reviews.js:152 static/js/zamboni/reviews.js:103
+msgid "Marked for deletion"
+msgstr ""
+
+#: static/js/common-all.js:11573 static/js/common-min.js:7 static/js/impala-all.js:13809 static/js/impala-min.js:8 static/js/zamboni/collections.js:229
+msgid "Adding to Favorites&hellip;"
+msgstr ""
+
+#: static/js/common-all.js:11576 static/js/common-min.js:7 static/js/impala-all.js:13812 static/js/impala-min.js:8 static/js/zamboni/collections.js:232
+msgid "Removing Favorite&hellip;"
+msgstr ""
+
+#: static/js/common-all.js:11579 static/js/common-min.js:7 static/js/impala-all.js:13815 static/js/impala-min.js:8 static/js/zamboni/collections.js:235
+msgid "Add to Favorites"
+msgstr ""
+
+#: static/js/common-all.js:11582 static/js/common-min.js:7 static/js/impala-all.js:13818 static/js/impala-min.js:8 static/js/zamboni/collections.js:238
+msgid "Remove from Favorites"
+msgstr ""
+
+#: static/js/common-all.js:11647 static/js/common-min.js:7 static/js/impala-all.js:13883 static/js/impala-min.js:8 static/js/zamboni/collections.js:303
+msgid "Pending"
+msgstr ""
+
+#: static/js/common-all.js:11648 static/js/common-min.js:7 static/js/impala-all.js:13884 static/js/impala-min.js:8 static/js/zamboni/collections.js:304
+msgid "Add a comment"
+msgstr ""
+
+#: static/js/common-all.js:11648 static/js/common-min.js:7 static/js/impala-all.js:13884 static/js/impala-min.js:8 static/js/zamboni/collections.js:304
+msgid "Comment"
+msgstr ""
+
+#: static/js/common-all.js:11649 static/js/common-min.js:7 static/js/impala-all.js:13885 static/js/impala-min.js:8 static/js/zamboni/collections.js:305
+msgid "Remove this add-on from the collection"
+msgstr ""
+
+#: static/js/common-all.js:11649 static/js/common-all.js:11678 static/js/common-min.js:7 static/js/impala-all.js:13885 static/js/impala-all.js:13914 static/js/impala-min.js:8
+#: static/js/zamboni/collections.js:305 static/js/zamboni/collections.js:334
+msgid "Remove"
+msgstr ""
+
+#: static/js/common-all.js:11678 static/js/common-min.js:7 static/js/impala-all.js:13914 static/js/impala-min.js:8 static/js/zamboni/collections.js:334
+msgid "Remove this user as a contributor"
+msgstr ""
+
+#: static/js/common-all.js:11690 static/js/common-min.js:7 static/js/impala-all.js:13926 static/js/impala-min.js:8 static/js/zamboni/collections.js:346
+msgid "An email address is required."
+msgstr ""
+
+#: static/js/common-all.js:11708 static/js/common-min.js:7 static/js/impala-all.js:13944 static/js/impala-min.js:8 static/js/zamboni/collections.js:364
+msgid "You cannot add yourself as a contributor."
+msgstr ""
+
+#: static/js/common-all.js:11710 static/js/common-min.js:7 static/js/impala-all.js:13946 static/js/impala-min.js:8 static/js/zamboni/collections.js:366
+msgid "You have already added that user."
+msgstr ""
+
+#: static/js/common-all.js:11917 static/js/common-min.js:7 static/js/impala-all.js:14153 static/js/impala-min.js:8 static/js/zamboni/collections.js:573
+msgid "Add to favorites"
+msgstr ""
+
+#: static/js/common-all.js:11921 static/js/common-min.js:7 static/js/impala-all.js:14157 static/js/impala-min.js:8 static/js/zamboni/collections.js:577
+msgid "Remove from favorites"
+msgstr ""
+
+#: static/js/common-all.js:11939 static/js/common-min.js:7 static/js/impala-all.js:14175 static/js/impala-all.js:14233 static/js/impala-min.js:8 static/js/impala/collections.js:10
+#: static/js/zamboni/collections.js:595
+msgid "Follow this Collection"
+msgstr ""
+
+#: static/js/common-all.js:11948 static/js/common-min.js:7 static/js/impala-all.js:14184 static/js/impala-min.js:8 static/js/zamboni/collections.js:604
+msgid "Stop following"
+msgstr ""
+
+#: static/js/common-all.js:12096 static/js/common-min.js:7 static/js/zamboni/password-strength.js:20
+msgid "Password strength:"
+msgstr ""
+
+#: static/js/common-all.js:12102 static/js/common-min.js:7 static/js/zamboni/password-strength.js:26
+msgid "At least {0} character left."
+msgid_plural "At least {0} characters left."
+msgstr[0] ""
+msgstr[1] ""
+
+#: static/js/common-all.js:12286 static/js/common-min.js:7 static/js/impala-all.js:14632 static/js/impala-min.js:8 static/js/impala/suggestions.js:39
+msgid "Search themes for <b>{0}</b>"
+msgstr ""
+
+#: static/js/common-all.js:12288 static/js/common-min.js:7 static/js/impala-all.js:14634 static/js/impala-min.js:8 static/js/impala/suggestions.js:41
+msgid "Search apps for <b>{0}</b>"
+msgstr ""
+
+#: static/js/common-all.js:12290 static/js/common-min.js:7 static/js/impala-all.js:14636 static/js/impala-min.js:8 static/js/impala/suggestions.js:43
+msgid "Search add-ons for <b>{0}</b>"
+msgstr ""
+
+#: static/js/common-all.js:12521 static/js/common-min.js:7 static/js/impala-all.js:14867 static/js/impala-min.js:8 static/js/impala/site_suggestions.js:46
+msgid "Category"
+msgstr ""
+
+#. L10n: {0} is an app name.
+#: static/js/impala-all.js:11632 static/js/impala-min.js:7 static/js/impala/listing.js:11 static/js/zamboni/themes.js:13
+msgid "This theme is incompatible with your version of {0}"
+msgstr ""
+
+#: static/js/impala-all.js:12146 static/js/impala-all.js:14331 static/js/impala-min.js:7 static/js/impala-min.js:8 static/js/common/upload-image.js:97 static/js/impala/users.js:51
+#: static/js/zamboni/devhub-all.js:894 static/js/zamboni/devhub-min.js:1
+msgid "Images must be either PNG or JPG."
+msgstr ""
+
+#: static/js/impala-all.js:12150 static/js/impala-min.js:7 static/js/common/upload-image.js:101 static/js/zamboni/devhub-all.js:898 static/js/zamboni/devhub-min.js:1
+msgid "Videos must be in WebM."
+msgstr ""
+
+#: static/js/impala-all.js:12177 static/js/impala-min.js:7 static/js/common/upload-addon.js:41 static/js/common/upload-image.js:128 static/js/zamboni/devhub-all.js:272
+#: static/js/zamboni/devhub-all.js:925 static/js/zamboni/devhub-min.js:1
 msgid "There was a problem contacting the server."
 msgstr ""
 
-#: static/js/common/upload-addon.js:69
+#: static/js/impala-all.js:13298 static/js/impala-min.js:7 static/js/impala/persona_creation.js:60
+msgid "All Rights Reserved"
+msgstr ""
+
+#: static/js/impala-all.js:13302 static/js/impala-min.js:7 static/js/impala/persona_creation.js:64
+msgid "Creative Commons Attribution 3.0"
+msgstr ""
+
+#: static/js/impala-all.js:13307 static/js/impala-min.js:7 static/js/impala/persona_creation.js:69
+msgid "Creative Commons Attribution-NonCommercial 3.0"
+msgstr ""
+
+#: static/js/impala-all.js:13312 static/js/impala-min.js:7 static/js/impala/persona_creation.js:74
+msgid "Creative Commons Attribution-NonCommercial-NoDerivs 3.0"
+msgstr ""
+
+#: static/js/impala-all.js:13317 static/js/impala-min.js:7 static/js/impala/persona_creation.js:79
+msgid "Creative Commons Attribution-NonCommercial-Share Alike 3.0"
+msgstr ""
+
+#: static/js/impala-all.js:13322 static/js/impala-min.js:7 static/js/impala/persona_creation.js:84
+msgid "Creative Commons Attribution-NoDerivs 3.0"
+msgstr ""
+
+#: static/js/impala-all.js:13327 static/js/impala-min.js:7 static/js/impala/persona_creation.js:89
+msgid "Creative Commons Attribution-ShareAlike 3.0"
+msgstr ""
+
+#: static/js/impala-all.js:13530 static/js/impala-min.js:7 static/js/impala/persona_creation.js:292
+msgid "Your Theme's Name"
+msgstr ""
+
+#: static/js/impala-all.js:14242 static/js/impala-min.js:8 static/js/impala/collections.js:19
+msgid "Stop Following"
+msgstr ""
+
+#: static/js/impala-all.js:14243 static/js/impala-min.js:8 static/js/impala/collections.js:20
+msgid "Following"
+msgstr ""
+
+#: static/js/impala-all.js:14313 static/js/impala-min.js:8 static/js/impala/users.js:33
+msgid "use original"
+msgstr ""
+
+#: static/js/impala-all.js:14523 static/js/impala-min.js:8 static/js/impala/search.js:114
+msgid "Updating results&hellip;"
+msgstr ""
+
+#: static/js/common/upload-addon.js:69 static/js/zamboni/devhub-all.js:300 static/js/zamboni/devhub-min.js:1
 msgid "Select a file..."
 msgstr ""
 
-#: static/js/common/upload-addon.js:70
+#: static/js/common/upload-addon.js:70 static/js/zamboni/devhub-all.js:301 static/js/zamboni/devhub-min.js:1
 msgid "Your add-on should end with .xpi, .jar or .xml"
 msgstr ""
 
 #. L10n: {0} is the percent of the file that has been uploaded.
-#: static/js/common/upload-addon.js:104
+#: static/js/common/upload-addon.js:104 static/js/zamboni/devhub-all.js:335 static/js/zamboni/devhub-min.js:1
 #, python-format
 msgid "{0}% complete"
 msgstr ""
 
 #. L10n: "{bytes uploaded} of {total filesize}".
-#: static/js/common/upload-addon.js:107
+#: static/js/common/upload-addon.js:107 static/js/zamboni/devhub-all.js:338 static/js/zamboni/devhub-min.js:1
 msgid "{0} of {1}"
 msgstr ""
 
-#: static/js/common/upload-addon.js:140
+#: static/js/common/upload-addon.js:140 static/js/zamboni/devhub-all.js:371 static/js/zamboni/devhub-min.js:1
 msgid "Cancel"
 msgstr ""
 
-#: static/js/common/upload-addon.js:162
+#: static/js/common/upload-addon.js:162 static/js/zamboni/devhub-all.js:393 static/js/zamboni/devhub-min.js:1
 msgid "Uploading {0}"
 msgstr ""
 
-#: static/js/common/upload-addon.js:189
+#: static/js/common/upload-addon.js:189 static/js/zamboni/devhub-all.js:420 static/js/zamboni/devhub-min.js:1
 msgid "Error with {0}"
 msgstr ""
 
-#: static/js/common/upload-addon.js:194
+#: static/js/common/upload-addon.js:194 static/js/zamboni/devhub-all.js:425 static/js/zamboni/devhub-min.js:1
 msgid "Your add-on failed validation with {0} error."
 msgid_plural "Your add-on failed validation with {0} errors."
 msgstr[0] ""
 msgstr[1] ""
 
-#: static/js/common/upload-addon.js:208
+#: static/js/common/upload-addon.js:208 static/js/zamboni/devhub-all.js:439 static/js/zamboni/devhub-min.js:1
 msgid "&hellip;and {0} more"
 msgid_plural "&hellip;and {0} more"
 msgstr[0] ""
 msgstr[1] ""
 
-#: static/js/common/upload-addon.js:222 static/js/common/upload-addon.js:512
+#: static/js/common/upload-addon.js:222 static/js/common/upload-addon.js:497 static/js/zamboni/devhub-all.js:453 static/js/zamboni/devhub-all.js:743 static/js/zamboni/devhub-min.js:1
 msgid "See full validation report"
 msgstr ""
 
-#: static/js/common/upload-addon.js:234
+#: static/js/common/upload-addon.js:234 static/js/zamboni/devhub-all.js:465 static/js/zamboni/devhub-min.js:1
 msgid "Validating {0}"
 msgstr ""
 
 #. L10n: first argument is an HTTP status code
-#: static/js/common/upload-addon.js:273
+#: static/js/common/upload-addon.js:273 static/js/zamboni/devhub-all.js:504 static/js/zamboni/devhub-min.js:1
 msgid "Received an empty response from the server; status: {0}"
 msgstr ""
 
-#: static/js/common/upload-addon.js:373
+#: static/js/common/upload-addon.js:370 static/js/zamboni/devhub-all.js:604 static/js/zamboni/devhub-min.js:1
 msgid "Unexpected server error while validating."
 msgstr ""
 
-#: static/js/common/upload-addon.js:412
+#: static/js/common/upload-addon.js:409 static/js/zamboni/devhub-all.js:643 static/js/zamboni/devhub-min.js:1
 msgid "Finished validating {0}"
 msgstr ""
 
-#: static/js/common/upload-addon.js:418
+#: static/js/common/upload-addon.js:415 static/js/zamboni/devhub-all.js:649 static/js/zamboni/devhub-min.js:1
 msgid "Your add-on validation timed out, it will be manually reviewed."
 msgstr ""
 
-#: static/js/common/upload-addon.js:421
+#: static/js/common/upload-addon.js:418 static/js/zamboni/devhub-all.js:652 static/js/zamboni/devhub-min.js:1
 msgid "Your add-on was validated with no errors and {0} warning."
 msgid_plural "Your add-on was validated with no errors and {0} warnings."
 msgstr[0] ""
 msgstr[1] ""
 
-#: static/js/common/upload-addon.js:426
+#: static/js/common/upload-addon.js:423 static/js/zamboni/devhub-all.js:657 static/js/zamboni/devhub-min.js:1
 msgid "Your add-on was validated with no errors and {0} message."
 msgid_plural "Your add-on was validated with no errors and {0} messages."
 msgstr[0] ""
 msgstr[1] ""
 
-#: static/js/common/upload-addon.js:431
+#: static/js/common/upload-addon.js:428 static/js/zamboni/devhub-all.js:662 static/js/zamboni/devhub-min.js:1
 msgid "Your add-on was validated with no errors or warnings."
 msgstr ""
 
-#: static/js/common/upload-addon.js:446
+#: static/js/common/upload-addon.js:443 static/js/zamboni/devhub-all.js:677 static/js/zamboni/devhub-min.js:1
 msgid "Your submission will be automatically signed."
 msgstr ""
 
-#: static/js/common/upload-addon.js:465
+#: static/js/common/upload-addon.js:450 static/js/zamboni/devhub-all.js:696 static/js/zamboni/devhub-min.js:1
 msgid "Include detailed version notes (this can be done in the next step)."
 msgstr ""
 
-#: static/js/common/upload-addon.js:466
+#: static/js/common/upload-addon.js:451 static/js/zamboni/devhub-all.js:697 static/js/zamboni/devhub-min.js:1
 msgid "If your add-on requires an account to a website in order to be fully tested, include a test username and password in the Notes to Reviewer (this can be done in the next step)."
 msgstr ""
 
-#: static/js/common/upload-addon.js:467
+#: static/js/common/upload-addon.js:452 static/js/zamboni/devhub-all.js:698 static/js/zamboni/devhub-min.js:1
 msgid "If your add-on is intended for a limited audience you should choose Preliminary Review instead of Full Review."
 msgstr ""
 
-#: static/js/common/upload-addon.js:480
+#: static/js/common/upload-addon.js:465 static/js/zamboni/devhub-all.js:711 static/js/zamboni/devhub-min.js:1
 msgid "Add-on submission checklist"
 msgstr ""
 
-#: static/js/common/upload-addon.js:481
+#: static/js/common/upload-addon.js:466 static/js/zamboni/devhub-all.js:712 static/js/zamboni/devhub-min.js:1
 msgid "Please verify the following points before finalizing your submission. This will minimize delays or misunderstanding during the review process:"
 msgstr ""
 
-#: static/js/common/upload-addon.js:483
+#: static/js/common/upload-addon.js:468 static/js/zamboni/devhub-all.js:714 static/js/zamboni/devhub-min.js:1
 msgid ""
 "Compiled binaries, as well as minified or obfuscated scripts (excluding known libraries) need to have their sources submitted separately for review. Make sure that you use the source code upload "
 "field to avoid having your submission rejected."
 msgstr ""
 
-#: static/js/common/upload-addon.js:501
+#: static/js/common/upload-addon.js:486 static/js/zamboni/devhub-all.js:732 static/js/zamboni/devhub-min.js:1
 msgid "The validation process found these issues that can lead to rejections:"
 msgstr ""
 
-#: static/js/common/upload-addon.js:518
+#: static/js/common/upload-addon.js:503 static/js/zamboni/devhub-all.js:749 static/js/zamboni/devhub-min.js:1
 msgid "If you are unfamiliar with the add-ons review process, you can read about it here."
 msgstr ""
 
-#: static/js/common/upload-addon.js:555
+#: static/js/common/upload-addon.js:540 static/js/zamboni/devhub-all.js:786 static/js/zamboni/devhub-min.js:1
 msgid "Sorry, no supported platform has been found."
 msgstr ""
 
-#: static/js/common/upload-base.js:57
+#: static/js/common/upload-base.js:57 static/js/zamboni/devhub-all.js:187 static/js/zamboni/devhub-min.js:1
 msgid "The filetype you uploaded isn't recognized."
 msgstr ""
 
-#: static/js/common/upload-base.js:79
+#: static/js/common/upload-base.js:79 static/js/zamboni/devhub-all.js:209 static/js/zamboni/devhub-min.js:1
 msgid "You cancelled the upload."
 msgstr ""
 
-#: static/js/common/upload-image.js:97 static/js/impala/users.js:51
-msgid "Images must be either PNG or JPG."
-msgstr ""
-
-#: static/js/common/upload-image.js:101
-msgid "Videos must be in WebM."
-msgstr ""
-
-#: static/js/impala/collections.js:10 static/js/zamboni/collections.js:595
-msgid "Follow this Collection"
-msgstr ""
-
-#: static/js/impala/collections.js:19
-msgid "Stop Following"
-msgstr ""
-
-#: static/js/impala/collections.js:20
-msgid "Following"
-msgstr ""
-
-#. L10n: {0} is an app name.
-#: static/js/impala/listing.js:11 static/js/zamboni/themes.js:13
-msgid "This theme is incompatible with your version of {0}"
-msgstr ""
-
-#: static/js/impala/persona_creation.js:60
-msgid "All Rights Reserved"
-msgstr ""
-
-#: static/js/impala/persona_creation.js:64
-msgid "Creative Commons Attribution 3.0"
-msgstr ""
-
-#: static/js/impala/persona_creation.js:69
-msgid "Creative Commons Attribution-NonCommercial 3.0"
-msgstr ""
-
-#: static/js/impala/persona_creation.js:74
-msgid "Creative Commons Attribution-NonCommercial-NoDerivs 3.0"
-msgstr ""
-
-#: static/js/impala/persona_creation.js:79
-msgid "Creative Commons Attribution-NonCommercial-Share Alike 3.0"
-msgstr ""
-
-#: static/js/impala/persona_creation.js:84
-msgid "Creative Commons Attribution-NoDerivs 3.0"
-msgstr ""
-
-#: static/js/impala/persona_creation.js:89
-msgid "Creative Commons Attribution-ShareAlike 3.0"
-msgstr ""
-
-#: static/js/impala/persona_creation.js:292
-msgid "Your Theme's Name"
-msgstr ""
-
-#: static/js/impala/reviews.js:23 static/js/zamboni/reviews.js:18
-msgid "Flagged for review"
-msgstr ""
-
-#: static/js/impala/reviews.js:40 static/js/zamboni/reviews.js:34
-msgid "Your input is required"
-msgstr ""
-
-#: static/js/impala/reviews.js:152 static/js/zamboni/reviews.js:103
-msgid "Marked for deletion"
-msgstr ""
-
-#: static/js/impala/search.js:114
-msgid "Updating results&hellip;"
-msgstr ""
-
-#: static/js/impala/site_suggestions.js:46
-msgid "Category"
-msgstr ""
-
-#: static/js/impala/suggestions.js:39
-msgid "Search themes for <b>{0}</b>"
-msgstr ""
-
-#: static/js/impala/suggestions.js:41
-msgid "Search apps for <b>{0}</b>"
-msgstr ""
-
-#: static/js/impala/suggestions.js:43
-msgid "Search add-ons for <b>{0}</b>"
-msgstr ""
-
-#: static/js/impala/users.js:33
-msgid "use original"
-msgstr ""
-
-#: static/js/impala/stats/chart.js:267
+#: static/js/impala/stats/chart.js:267 static/js/zamboni/stats-all.js:16898 static/js/zamboni/stats-min.js:5
 msgid "Week of {0}"
 msgstr ""
 
-#: static/js/impala/stats/chart.js:269
+#: static/js/impala/stats/chart.js:269 static/js/zamboni/stats-all.js:16900 static/js/zamboni/stats-min.js:5
 msgid " downloads"
 msgstr ""
 
-#: static/js/impala/stats/chart.js:270
+#: static/js/impala/stats/chart.js:270 static/js/zamboni/stats-all.js:16901 static/js/zamboni/stats-min.js:5
 msgid "{0} users"
 msgstr ""
 
-#: static/js/impala/stats/chart.js:271
+#: static/js/impala/stats/chart.js:271 static/js/zamboni/stats-all.js:16902 static/js/zamboni/stats-min.js:5
 msgid "{0} add-ons"
 msgstr ""
 
-#: static/js/impala/stats/chart.js:272
+#: static/js/impala/stats/chart.js:272 static/js/zamboni/stats-all.js:16903 static/js/zamboni/stats-min.js:5
 msgid "{0} collections"
 msgstr ""
 
-#: static/js/impala/stats/chart.js:273
+#: static/js/impala/stats/chart.js:273 static/js/zamboni/stats-all.js:16904 static/js/zamboni/stats-min.js:5
 msgid "{0} reviews"
 msgstr ""
 
-#: static/js/impala/stats/chart.js:275
+#: static/js/impala/stats/chart.js:275 static/js/zamboni/stats-all.js:16906 static/js/zamboni/stats-min.js:5
 msgid "{0} sales"
 msgstr ""
 
-#: static/js/impala/stats/chart.js:276
+#: static/js/impala/stats/chart.js:276 static/js/zamboni/stats-all.js:16907 static/js/zamboni/stats-min.js:5
 msgid "{0} refunds"
 msgstr ""
 
-#: static/js/impala/stats/chart.js:277
+#: static/js/impala/stats/chart.js:277 static/js/zamboni/stats-all.js:16908 static/js/zamboni/stats-min.js:5
 msgid "{0} installs"
 msgstr ""
 
-#: static/js/impala/stats/chart.js:369 static/js/impala/stats/csv_keys.js:3 static/js/impala/stats/csv_keys.js:109
+#: static/js/impala/stats/chart.js:369 static/js/impala/stats/csv_keys.js:3 static/js/impala/stats/csv_keys.js:109 static/js/zamboni/stats-all.js:15284 static/js/zamboni/stats-all.js:15390
+#: static/js/zamboni/stats-all.js:17000 static/js/zamboni/stats-min.js:4 static/js/zamboni/stats-min.js:5
 msgid "Downloads"
 msgstr ""
 
-#: static/js/impala/stats/chart.js:379 static/js/impala/stats/csv_keys.js:6 static/js/impala/stats/csv_keys.js:110
+#: static/js/impala/stats/chart.js:379 static/js/impala/stats/csv_keys.js:6 static/js/impala/stats/csv_keys.js:110 static/js/zamboni/stats-all.js:15287 static/js/zamboni/stats-all.js:15391
+#: static/js/zamboni/stats-all.js:17010 static/js/zamboni/stats-min.js:4 static/js/zamboni/stats-min.js:5
 msgid "Daily Users"
 msgstr ""
 
-#: static/js/impala/stats/chart.js:410
+#: static/js/impala/stats/chart.js:410 static/js/zamboni/stats-all.js:17041 static/js/zamboni/stats-min.js:5
 msgid "Amount, in USD"
 msgstr ""
 
-#: static/js/impala/stats/chart.js:421 static/js/impala/stats/csv_keys.js:104
+#: static/js/impala/stats/chart.js:421 static/js/impala/stats/csv_keys.js:104 static/js/zamboni/stats-all.js:15385 static/js/zamboni/stats-all.js:17052 static/js/zamboni/stats-min.js:5
 msgid "Number of Contributions"
 msgstr ""
 
-#: static/js/impala/stats/chart.js:447
+#: static/js/impala/stats/chart.js:447 static/js/zamboni/stats-all.js:17078 static/js/zamboni/stats-min.js:5
 msgid "More Info..."
 msgstr ""
 
 #. L10n: {0} is an ISO-formatted date.
-#: static/js/impala/stats/chart.js:451
+#: static/js/impala/stats/chart.js:451 static/js/zamboni/stats-all.js:17082 static/js/zamboni/stats-min.js:5
 msgid "Details for {0}"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:9
+#: static/js/impala/stats/csv_keys.js:9 static/js/zamboni/stats-all.js:15290 static/js/zamboni/stats-min.js:4
 msgid "Collections Created"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:12
+#: static/js/impala/stats/csv_keys.js:12 static/js/zamboni/stats-all.js:15293 static/js/zamboni/stats-min.js:4
 msgid "Add-ons in Use"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:15
+#: static/js/impala/stats/csv_keys.js:15 static/js/zamboni/stats-all.js:15296 static/js/zamboni/stats-min.js:4
 msgid "Add-ons Created"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:18
+#: static/js/impala/stats/csv_keys.js:18 static/js/zamboni/stats-all.js:15299 static/js/zamboni/stats-min.js:4
 msgid "Add-ons Downloaded"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:21
+#: static/js/impala/stats/csv_keys.js:21 static/js/zamboni/stats-all.js:15302 static/js/zamboni/stats-min.js:4
 msgid "Add-ons Updated"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:24
+#: static/js/impala/stats/csv_keys.js:24 static/js/zamboni/stats-all.js:15305 static/js/zamboni/stats-min.js:4
 msgid "Reviews Written"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:27
+#: static/js/impala/stats/csv_keys.js:27 static/js/zamboni/stats-all.js:15308 static/js/zamboni/stats-min.js:4
 msgid "User Signups"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:30
+#: static/js/impala/stats/csv_keys.js:30 static/js/zamboni/stats-all.js:15311 static/js/zamboni/stats-min.js:4
 msgid "Subscribers"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:33
+#: static/js/impala/stats/csv_keys.js:33 static/js/zamboni/stats-all.js:15314 static/js/zamboni/stats-min.js:4
 msgid "Ratings"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:36 static/js/impala/stats/csv_keys.js:114
+#: static/js/impala/stats/csv_keys.js:36 static/js/impala/stats/csv_keys.js:114 static/js/zamboni/stats-all.js:15317 static/js/zamboni/stats-all.js:15395 static/js/zamboni/stats-min.js:4
+#: static/js/zamboni/stats-min.js:5
 msgid "Sales"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:39 static/js/impala/stats/csv_keys.js:113
+#: static/js/impala/stats/csv_keys.js:39 static/js/impala/stats/csv_keys.js:113 static/js/zamboni/stats-all.js:15320 static/js/zamboni/stats-all.js:15394 static/js/zamboni/stats-min.js:4
+#: static/js/zamboni/stats-min.js:5
 msgid "Installs"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:42
+#: static/js/impala/stats/csv_keys.js:42 static/js/zamboni/stats-all.js:15323 static/js/zamboni/stats-min.js:4
 msgid "Unknown"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:43
+#: static/js/impala/stats/csv_keys.js:43 static/js/zamboni/stats-all.js:15324 static/js/zamboni/stats-min.js:4
 msgid "Add-ons Manager"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:44
+#: static/js/impala/stats/csv_keys.js:44 static/js/zamboni/stats-all.js:15325 static/js/zamboni/stats-min.js:4
 msgid "Add-ons Manager Promo"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:45
+#: static/js/impala/stats/csv_keys.js:45 static/js/zamboni/stats-all.js:15326 static/js/zamboni/stats-min.js:4
 msgid "Add-ons Manager Featured"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:46
+#: static/js/impala/stats/csv_keys.js:46 static/js/zamboni/stats-all.js:15327 static/js/zamboni/stats-min.js:4
 msgid "Add-ons Manager Learn More"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:47
+#: static/js/impala/stats/csv_keys.js:47 static/js/zamboni/stats-all.js:15328 static/js/zamboni/stats-min.js:4
 msgid "Search Suggestions"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:48
+#: static/js/impala/stats/csv_keys.js:48 static/js/zamboni/stats-all.js:15329 static/js/zamboni/stats-min.js:4
 msgid "Search Results"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:49 static/js/impala/stats/csv_keys.js:50 static/js/impala/stats/csv_keys.js:51
+#: static/js/impala/stats/csv_keys.js:49 static/js/impala/stats/csv_keys.js:50 static/js/impala/stats/csv_keys.js:51 static/js/zamboni/stats-all.js:15330 static/js/zamboni/stats-all.js:15331
+#: static/js/zamboni/stats-all.js:15332 static/js/zamboni/stats-min.js:4
 msgid "Homepage Promo"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:52 static/js/impala/stats/csv_keys.js:53
+#: static/js/impala/stats/csv_keys.js:52 static/js/impala/stats/csv_keys.js:53 static/js/zamboni/stats-all.js:15333 static/js/zamboni/stats-all.js:15334 static/js/zamboni/stats-min.js:4
 msgid "Homepage Featured"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:54 static/js/impala/stats/csv_keys.js:55
+#: static/js/impala/stats/csv_keys.js:54 static/js/impala/stats/csv_keys.js:55 static/js/zamboni/stats-all.js:15335 static/js/zamboni/stats-all.js:15336 static/js/zamboni/stats-min.js:4
 msgid "Homepage Up and Coming"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:56
+#: static/js/impala/stats/csv_keys.js:56 static/js/zamboni/stats-all.js:15337 static/js/zamboni/stats-min.js:4
 msgid "Homepage Most Popular"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:57 static/js/impala/stats/csv_keys.js:59
+#: static/js/impala/stats/csv_keys.js:57 static/js/impala/stats/csv_keys.js:59 static/js/zamboni/stats-all.js:15338 static/js/zamboni/stats-all.js:15340 static/js/zamboni/stats-min.js:4
 msgid "Detail Page"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:58 static/js/impala/stats/csv_keys.js:60
+#: static/js/impala/stats/csv_keys.js:58 static/js/impala/stats/csv_keys.js:60 static/js/zamboni/stats-all.js:15339 static/js/zamboni/stats-all.js:15341 static/js/zamboni/stats-min.js:4
 msgid "Detail Page (bottom)"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:61
+#: static/js/impala/stats/csv_keys.js:61 static/js/zamboni/stats-all.js:15342 static/js/zamboni/stats-min.js:4
 msgid "Detail Page (Development Channel)"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:62 static/js/impala/stats/csv_keys.js:63 static/js/impala/stats/csv_keys.js:64
+#: static/js/impala/stats/csv_keys.js:62 static/js/impala/stats/csv_keys.js:63 static/js/impala/stats/csv_keys.js:64 static/js/zamboni/stats-all.js:15343 static/js/zamboni/stats-all.js:15344
+#: static/js/zamboni/stats-all.js:15345 static/js/zamboni/stats-min.js:4
 msgid "Often Used With"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:65 static/js/impala/stats/csv_keys.js:66
+#: static/js/impala/stats/csv_keys.js:65 static/js/impala/stats/csv_keys.js:66 static/js/zamboni/stats-all.js:15346 static/js/zamboni/stats-all.js:15347 static/js/zamboni/stats-min.js:4
 msgid "Others By Author"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:67 static/js/impala/stats/csv_keys.js:68
+#: static/js/impala/stats/csv_keys.js:67 static/js/impala/stats/csv_keys.js:68 static/js/zamboni/stats-all.js:15348 static/js/zamboni/stats-all.js:15349 static/js/zamboni/stats-min.js:4
 msgid "Dependencies"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:69 static/js/impala/stats/csv_keys.js:70
+#: static/js/impala/stats/csv_keys.js:69 static/js/impala/stats/csv_keys.js:70 static/js/zamboni/stats-all.js:15350 static/js/zamboni/stats-all.js:15351 static/js/zamboni/stats-min.js:4
 msgid "Upsell"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:71
+#: static/js/impala/stats/csv_keys.js:71 static/js/zamboni/stats-all.js:15352 static/js/zamboni/stats-min.js:4
 msgid "Meet the Developer"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:72
+#: static/js/impala/stats/csv_keys.js:72 static/js/zamboni/stats-all.js:15353 static/js/zamboni/stats-min.js:4
 msgid "User Profile"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:73
+#: static/js/impala/stats/csv_keys.js:73 static/js/zamboni/stats-all.js:15354 static/js/zamboni/stats-min.js:4
 msgid "Version History"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:75
+#: static/js/impala/stats/csv_keys.js:75 static/js/zamboni/stats-all.js:15356 static/js/zamboni/stats-min.js:4
 msgid "Sharing"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:76
+#: static/js/impala/stats/csv_keys.js:76 static/js/zamboni/stats-all.js:15357 static/js/zamboni/stats-min.js:4
 msgid "Category Pages"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:77
+#: static/js/impala/stats/csv_keys.js:77 static/js/zamboni/stats-all.js:15358 static/js/zamboni/stats-min.js:4
 msgid "Collections"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:78 static/js/impala/stats/csv_keys.js:79
+#: static/js/impala/stats/csv_keys.js:78 static/js/impala/stats/csv_keys.js:79 static/js/zamboni/stats-all.js:15359 static/js/zamboni/stats-all.js:15360 static/js/zamboni/stats-min.js:4
 msgid "Category Landing Featured Carousel"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:80 static/js/impala/stats/csv_keys.js:81
+#: static/js/impala/stats/csv_keys.js:80 static/js/impala/stats/csv_keys.js:81 static/js/zamboni/stats-all.js:15361 static/js/zamboni/stats-all.js:15362 static/js/zamboni/stats-min.js:4
 msgid "Category Landing Top Rated"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:82 static/js/impala/stats/csv_keys.js:83
+#: static/js/impala/stats/csv_keys.js:82 static/js/impala/stats/csv_keys.js:83 static/js/zamboni/stats-all.js:15363 static/js/zamboni/stats-all.js:15364 static/js/zamboni/stats-min.js:5
 msgid "Category Landing Most Popular"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:84 static/js/impala/stats/csv_keys.js:85
+#: static/js/impala/stats/csv_keys.js:84 static/js/impala/stats/csv_keys.js:85 static/js/zamboni/stats-all.js:15365 static/js/zamboni/stats-all.js:15366 static/js/zamboni/stats-min.js:5
 msgid "Category Landing Recently Added"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:86 static/js/impala/stats/csv_keys.js:87
+#: static/js/impala/stats/csv_keys.js:86 static/js/impala/stats/csv_keys.js:87 static/js/zamboni/stats-all.js:15367 static/js/zamboni/stats-all.js:15368 static/js/zamboni/stats-min.js:5
 msgid "Browse Listing Featured Sort"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:88 static/js/impala/stats/csv_keys.js:89
+#: static/js/impala/stats/csv_keys.js:88 static/js/impala/stats/csv_keys.js:89 static/js/zamboni/stats-all.js:15369 static/js/zamboni/stats-all.js:15370 static/js/zamboni/stats-min.js:5
 msgid "Browse Listing Users Sort"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:90 static/js/impala/stats/csv_keys.js:91
+#: static/js/impala/stats/csv_keys.js:90 static/js/impala/stats/csv_keys.js:91 static/js/zamboni/stats-all.js:15371 static/js/zamboni/stats-all.js:15372 static/js/zamboni/stats-min.js:5
 msgid "Browse Listing Rating Sort"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:92 static/js/impala/stats/csv_keys.js:93
+#: static/js/impala/stats/csv_keys.js:92 static/js/impala/stats/csv_keys.js:93 static/js/zamboni/stats-all.js:15373 static/js/zamboni/stats-all.js:15374 static/js/zamboni/stats-min.js:5
 msgid "Browse Listing Created Sort"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:94 static/js/impala/stats/csv_keys.js:95
+#: static/js/impala/stats/csv_keys.js:94 static/js/impala/stats/csv_keys.js:95 static/js/zamboni/stats-all.js:15375 static/js/zamboni/stats-all.js:15376 static/js/zamboni/stats-min.js:5
 msgid "Browse Listing Name Sort"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:96 static/js/impala/stats/csv_keys.js:97
+#: static/js/impala/stats/csv_keys.js:96 static/js/impala/stats/csv_keys.js:97 static/js/zamboni/stats-all.js:15377 static/js/zamboni/stats-all.js:15378 static/js/zamboni/stats-min.js:5
 msgid "Browse Listing Popular Sort"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:98 static/js/impala/stats/csv_keys.js:99
+#: static/js/impala/stats/csv_keys.js:98 static/js/impala/stats/csv_keys.js:99 static/js/zamboni/stats-all.js:15379 static/js/zamboni/stats-all.js:15380 static/js/zamboni/stats-min.js:5
 msgid "Browse Listing Updated Sort"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:100 static/js/impala/stats/csv_keys.js:101
+#: static/js/impala/stats/csv_keys.js:100 static/js/impala/stats/csv_keys.js:101 static/js/zamboni/stats-all.js:15381 static/js/zamboni/stats-all.js:15382 static/js/zamboni/stats-min.js:5
 msgid "Browse Listing Up and Coming Sort"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:105
+#: static/js/impala/stats/csv_keys.js:105 static/js/zamboni/stats-all.js:15386 static/js/zamboni/stats-min.js:5
 msgid "Total Amount Contributed"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:106
+#: static/js/impala/stats/csv_keys.js:106 static/js/zamboni/stats-all.js:15387 static/js/zamboni/stats-min.js:5
 msgid "Average Contribution"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:115
+#: static/js/impala/stats/csv_keys.js:115 static/js/zamboni/stats-all.js:15396 static/js/zamboni/stats-min.js:5
 msgid "Usage"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:118
+#: static/js/impala/stats/csv_keys.js:118 static/js/zamboni/stats-all.js:15399 static/js/zamboni/stats-min.js:5
 msgid "Firefox"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:119
+#: static/js/impala/stats/csv_keys.js:119 static/js/zamboni/stats-all.js:15400 static/js/zamboni/stats-min.js:5
 msgid "Mozilla"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:120
+#: static/js/impala/stats/csv_keys.js:120 static/js/zamboni/stats-all.js:15401 static/js/zamboni/stats-min.js:5
 msgid "Thunderbird"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:121
+#: static/js/impala/stats/csv_keys.js:121 static/js/zamboni/stats-all.js:15402 static/js/zamboni/stats-min.js:5
 msgid "Sunbird"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:122
+#: static/js/impala/stats/csv_keys.js:122 static/js/zamboni/stats-all.js:15403 static/js/zamboni/stats-min.js:5
 msgid "SeaMonkey"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:123
+#: static/js/impala/stats/csv_keys.js:123 static/js/zamboni/stats-all.js:15404 static/js/zamboni/stats-min.js:5
 msgid "Fennec"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:124
+#: static/js/impala/stats/csv_keys.js:124 static/js/zamboni/stats-all.js:15405 static/js/zamboni/stats-min.js:5
 msgid "Android"
 msgstr ""
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:129
+#: static/js/impala/stats/csv_keys.js:129 static/js/zamboni/stats-all.js:15410 static/js/zamboni/stats-min.js:5
 msgid "Downloads and Daily Users, last {0} days"
 msgstr ""
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:131
+#: static/js/impala/stats/csv_keys.js:131 static/js/zamboni/stats-all.js:15412 static/js/zamboni/stats-min.js:5
 msgid "Downloads and Daily Users from {0} to {1}"
 msgstr ""
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:135
+#: static/js/impala/stats/csv_keys.js:135 static/js/zamboni/stats-all.js:15416 static/js/zamboni/stats-min.js:5
 msgid "Installs and Daily Users, last {0} days"
 msgstr ""
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:137
+#: static/js/impala/stats/csv_keys.js:137 static/js/zamboni/stats-all.js:15418 static/js/zamboni/stats-min.js:5
 msgid "Installs and Daily Users from {0} to {1}"
 msgstr ""
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:141
+#: static/js/impala/stats/csv_keys.js:141 static/js/zamboni/stats-all.js:15422 static/js/zamboni/stats-min.js:5
 msgid "Downloads, last {0} days"
 msgstr ""
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:143
+#: static/js/impala/stats/csv_keys.js:143 static/js/zamboni/stats-all.js:15424 static/js/zamboni/stats-min.js:5
 msgid "Downloads from {0} to {1}"
 msgstr ""
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:147
+#: static/js/impala/stats/csv_keys.js:147 static/js/zamboni/stats-all.js:15428 static/js/zamboni/stats-min.js:5
 msgid "Daily Users, last {0} days"
 msgstr ""
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:149
+#: static/js/impala/stats/csv_keys.js:149 static/js/zamboni/stats-all.js:15430 static/js/zamboni/stats-min.js:5
 msgid "Daily Users from {0} to {1}"
 msgstr ""
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:153
+#: static/js/impala/stats/csv_keys.js:153 static/js/zamboni/stats-all.js:15434 static/js/zamboni/stats-min.js:5
 msgid "Applications, last {0} days"
 msgstr ""
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:155
+#: static/js/impala/stats/csv_keys.js:155 static/js/zamboni/stats-all.js:15436 static/js/zamboni/stats-min.js:5
 msgid "Applications from {0} to {1}"
 msgstr ""
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:159
+#: static/js/impala/stats/csv_keys.js:159 static/js/zamboni/stats-all.js:15440 static/js/zamboni/stats-min.js:5
 msgid "Platforms, last {0} days"
 msgstr ""
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:161
+#: static/js/impala/stats/csv_keys.js:161 static/js/zamboni/stats-all.js:15442 static/js/zamboni/stats-min.js:5
 msgid "Platforms from {0} to {1}"
 msgstr ""
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:165
+#: static/js/impala/stats/csv_keys.js:165 static/js/zamboni/stats-all.js:15446 static/js/zamboni/stats-min.js:5
 msgid "Languages, last {0} days"
 msgstr ""
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:167
+#: static/js/impala/stats/csv_keys.js:167 static/js/zamboni/stats-all.js:15448 static/js/zamboni/stats-min.js:5
 msgid "Languages from {0} to {1}"
 msgstr ""
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:171
+#: static/js/impala/stats/csv_keys.js:171 static/js/zamboni/stats-all.js:15452 static/js/zamboni/stats-min.js:5
 msgid "Add-on Versions, last {0} days"
 msgstr ""
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:173
+#: static/js/impala/stats/csv_keys.js:173 static/js/zamboni/stats-all.js:15454 static/js/zamboni/stats-min.js:5
 msgid "Add-on Versions from {0} to {1}"
 msgstr ""
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:177
+#: static/js/impala/stats/csv_keys.js:177 static/js/zamboni/stats-all.js:15458 static/js/zamboni/stats-min.js:5
 msgid "Add-on Status, last {0} days"
 msgstr ""
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:179
+#: static/js/impala/stats/csv_keys.js:179 static/js/zamboni/stats-all.js:15460 static/js/zamboni/stats-min.js:5
 msgid "Add-on Status from {0} to {1}"
 msgstr ""
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:183
+#: static/js/impala/stats/csv_keys.js:183 static/js/zamboni/stats-all.js:15464 static/js/zamboni/stats-min.js:5
 msgid "Download Sources, last {0} days"
 msgstr ""
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:185
+#: static/js/impala/stats/csv_keys.js:185 static/js/zamboni/stats-all.js:15466 static/js/zamboni/stats-min.js:5
 msgid "Download Sources from {0} to {1}"
 msgstr ""
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:189
+#: static/js/impala/stats/csv_keys.js:189 static/js/zamboni/stats-all.js:15470 static/js/zamboni/stats-min.js:5
 msgid "Contributions, last {0} days"
 msgstr ""
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:191
+#: static/js/impala/stats/csv_keys.js:191 static/js/zamboni/stats-all.js:15472 static/js/zamboni/stats-min.js:5
 msgid "Contributions from {0} to {1}"
 msgstr ""
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:195
+#: static/js/impala/stats/csv_keys.js:195 static/js/zamboni/stats-all.js:15476 static/js/zamboni/stats-min.js:5
 msgid "Site Metrics, last {0} days"
 msgstr ""
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:197
+#: static/js/impala/stats/csv_keys.js:197 static/js/zamboni/stats-all.js:15478 static/js/zamboni/stats-min.js:5
 msgid "Site Metrics from {0} to {1}"
 msgstr ""
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:201
+#: static/js/impala/stats/csv_keys.js:201 static/js/zamboni/stats-all.js:15482 static/js/zamboni/stats-min.js:5
 msgid "Add-ons in Use, last {0} days"
 msgstr ""
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:203
+#: static/js/impala/stats/csv_keys.js:203 static/js/zamboni/stats-all.js:15484 static/js/zamboni/stats-min.js:5
 msgid "Add-ons in Use from {0} to {1}"
 msgstr ""
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:207
+#: static/js/impala/stats/csv_keys.js:207 static/js/zamboni/stats-all.js:15488 static/js/zamboni/stats-min.js:5
 msgid "Add-ons Downloaded, last {0} days"
 msgstr ""
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:209
+#: static/js/impala/stats/csv_keys.js:209 static/js/zamboni/stats-all.js:15490 static/js/zamboni/stats-min.js:5
 msgid "Add-ons Downloaded from {0} to {1}"
 msgstr ""
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:213
+#: static/js/impala/stats/csv_keys.js:213 static/js/zamboni/stats-all.js:15494 static/js/zamboni/stats-min.js:5
 msgid "Add-ons Created, last {0} days"
 msgstr ""
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:215
+#: static/js/impala/stats/csv_keys.js:215 static/js/zamboni/stats-all.js:15496 static/js/zamboni/stats-min.js:5
 msgid "Add-ons Created from {0} to {1}"
 msgstr ""
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:219
+#: static/js/impala/stats/csv_keys.js:219 static/js/zamboni/stats-all.js:15500 static/js/zamboni/stats-min.js:5
 msgid "Add-ons Updated, last {0} days"
 msgstr ""
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:221
+#: static/js/impala/stats/csv_keys.js:221 static/js/zamboni/stats-all.js:15502 static/js/zamboni/stats-min.js:5
 msgid "Add-ons Updated from {0} to {1}"
 msgstr ""
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:225
+#: static/js/impala/stats/csv_keys.js:225 static/js/zamboni/stats-all.js:15506 static/js/zamboni/stats-min.js:5
 msgid "Reviews Written, last {0} days"
 msgstr ""
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:227
+#: static/js/impala/stats/csv_keys.js:227 static/js/zamboni/stats-all.js:15508 static/js/zamboni/stats-min.js:5
 msgid "Reviews Written from {0} to {1}"
 msgstr ""
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:231
+#: static/js/impala/stats/csv_keys.js:231 static/js/zamboni/stats-all.js:15512 static/js/zamboni/stats-min.js:5
 msgid "User Signups, last {0} days"
 msgstr ""
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:233
+#: static/js/impala/stats/csv_keys.js:233 static/js/zamboni/stats-all.js:15514 static/js/zamboni/stats-min.js:5
 msgid "User Signups from {0} to {1}"
 msgstr ""
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:237
+#: static/js/impala/stats/csv_keys.js:237 static/js/zamboni/stats-all.js:15518 static/js/zamboni/stats-min.js:5
 msgid "Collections Created, last {0} days"
 msgstr ""
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:239
+#: static/js/impala/stats/csv_keys.js:239 static/js/zamboni/stats-all.js:15520 static/js/zamboni/stats-min.js:5
 msgid "Collections Created from {0} to {1}"
 msgstr ""
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:243
+#: static/js/impala/stats/csv_keys.js:243 static/js/zamboni/stats-all.js:15524 static/js/zamboni/stats-min.js:5
 msgid "Subscribers, last {0} days"
 msgstr ""
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:245
+#: static/js/impala/stats/csv_keys.js:245 static/js/zamboni/stats-all.js:15526 static/js/zamboni/stats-min.js:5
 msgid "Subscribers from {0} to {1}"
 msgstr ""
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:249
+#: static/js/impala/stats/csv_keys.js:249 static/js/zamboni/stats-all.js:15530 static/js/zamboni/stats-min.js:5
 msgid "Ratings, last {0} days"
 msgstr ""
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:251
+#: static/js/impala/stats/csv_keys.js:251 static/js/zamboni/stats-all.js:15532 static/js/zamboni/stats-min.js:5
 msgid "Ratings from {0} to {1}"
 msgstr ""
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:255
+#: static/js/impala/stats/csv_keys.js:255 static/js/zamboni/stats-all.js:15536 static/js/zamboni/stats-min.js:5
 msgid "Sales, last {0} days"
 msgstr ""
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:257
+#: static/js/impala/stats/csv_keys.js:257 static/js/zamboni/stats-all.js:15538 static/js/zamboni/stats-min.js:5
 msgid "Sales from {0} to {1}"
 msgstr ""
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:261
+#: static/js/impala/stats/csv_keys.js:261 static/js/zamboni/stats-all.js:15542 static/js/zamboni/stats-min.js:5
 msgid "Installs, last {0} days"
 msgstr ""
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:263
+#: static/js/impala/stats/csv_keys.js:263 static/js/zamboni/stats-all.js:15544 static/js/zamboni/stats-min.js:5
 msgid "Installs from {0} to {1}"
 msgstr ""
 
 #. L10n: {0} and {1} are integers.
-#: static/js/impala/stats/csv_keys.js:269
+#: static/js/impala/stats/csv_keys.js:269 static/js/zamboni/stats-all.js:15550 static/js/zamboni/stats-min.js:5
 msgid "<b>{0}</b> in last {1} days"
 msgstr ""
 
 #. L10n: {0} is an integer and {1} and {2} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:271 static/js/impala/stats/csv_keys.js:277
+#: static/js/impala/stats/csv_keys.js:271 static/js/impala/stats/csv_keys.js:277 static/js/zamboni/stats-all.js:15552 static/js/zamboni/stats-all.js:15558 static/js/zamboni/stats-min.js:5
 msgid "<b>{0}</b> from {1} to {2}"
 msgstr ""
 
 #. L10n: {0} and {1} are integers.
-#: static/js/impala/stats/csv_keys.js:275
+#: static/js/impala/stats/csv_keys.js:275 static/js/zamboni/stats-all.js:15556 static/js/zamboni/stats-min.js:5
 msgid "<b>{0}</b> average in last {1} days"
 msgstr ""
 
-#: static/js/impala/stats/overview.js:19
+#: static/js/impala/stats/overview.js:19 static/js/zamboni/stats-all.js:16469 static/js/zamboni/stats-min.js:5
 msgid "No data available."
 msgstr ""
 
-#: static/js/impala/stats/table.js:74
+#: static/js/impala/stats/table.js:74 static/js/zamboni/stats-all.js:17209 static/js/zamboni/stats-min.js:5
 msgid "Date"
 msgstr ""
 
-#: static/js/impala/stats/topchart.js:96
+#: static/js/impala/stats/topchart.js:96 static/js/zamboni/stats-all.js:16600 static/js/zamboni/stats-min.js:5
 msgid "Other"
 msgstr ""
 
-#: static/js/zamboni/admin_validation.js:24 static/js/zamboni/devhub.js:1229 static/js/zamboni/editors.js:295
+#: static/js/zamboni/admin-all.js:180 static/js/zamboni/admin-min.js:1 static/js/zamboni/admin_validation.js:24 static/js/zamboni/devhub-all.js:2408 static/js/zamboni/devhub-min.js:2
+#: static/js/zamboni/devhub.js:1229 static/js/zamboni/editors-all.js:15576 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:295
 msgid "Select an application first"
 msgstr ""
 
-#: static/js/zamboni/admin_validation.js:51
+#: static/js/zamboni/admin-all.js:207 static/js/zamboni/admin-min.js:1 static/js/zamboni/admin_validation.js:51
 msgid "Set {0} add-on to a max version of {1} and email the author."
 msgid_plural "Set {0} add-ons to a max version of {1} and email the authors."
 msgstr[0] ""
 msgstr[1] ""
 
-#: static/js/zamboni/admin_validation.js:54
+#: static/js/zamboni/admin-all.js:210 static/js/zamboni/admin-min.js:1 static/js/zamboni/admin_validation.js:54
 msgid "Email author of {2} add-on which failed validation."
 msgid_plural "Email authors of {2} add-ons which failed validation."
 msgstr[0] ""
 msgstr[1] ""
 
-#. L10n: {0} is an app name like Firefox.
-#: static/js/zamboni/buttons.js:66
-msgid "Accept and Install"
-msgstr ""
-
-#: static/js/zamboni/buttons.js:66
-msgid "Add to {0}"
-msgstr ""
-
-#: static/js/zamboni/buttons.js:71
-msgid "Download Now"
-msgstr ""
-
-#: static/js/zamboni/buttons.js:112
-msgid "Add-on has not been updated to support default-to-compatible."
-msgstr ""
-
-#: static/js/zamboni/buttons.js:117
-msgid "You need to be using Firefox 10.0 or higher."
-msgstr ""
-
-#: static/js/zamboni/buttons.js:129
-msgid "Mozilla has marked this version as incompatible with your Firefox version."
-msgstr ""
-
-#. L10n: {0} is an platform like Windows or Linux.
-#: static/js/zamboni/buttons.js:210
-msgid "Install for {0} anyway"
-msgstr ""
-
-#: static/js/zamboni/buttons.js:210
-msgid "Download for {0} anyway"
-msgstr ""
-
-#: static/js/zamboni/buttons.js:267
-msgid "Not available for your platform"
-msgstr ""
-
-#. L10n: {0} is an app name, {1} is the app version.
-#: static/js/zamboni/buttons.js:278 static/js/zamboni/buttons.js:315
-msgid "Not available for {0} {1}"
-msgstr ""
-
-#: static/js/zamboni/buttons.js:341
-msgid "Works with {app} {min} - {max}"
-msgstr ""
-
-#: static/js/zamboni/buttons.js:343
-msgid "View other versions"
-msgstr ""
-
-#: static/js/zamboni/buttons.js:391
-msgid "Only with Firefox — Get Firefox Now!"
-msgstr ""
-
-#: static/js/zamboni/buttons.js:507 static/js/zamboni/mobile/buttons.js:43
-msgid "Sorry, you need a Mozilla-based browser (such as Firefox) to install a search plugin."
-msgstr ""
-
-#: static/js/zamboni/collections.js:229
-msgid "Adding to Favorites&hellip;"
-msgstr ""
-
-#: static/js/zamboni/collections.js:232
-msgid "Removing Favorite&hellip;"
-msgstr ""
-
-#: static/js/zamboni/collections.js:235
-msgid "Add to Favorites"
-msgstr ""
-
-#: static/js/zamboni/collections.js:238
-msgid "Remove from Favorites"
-msgstr ""
-
-#: static/js/zamboni/collections.js:303
-msgid "Pending"
-msgstr ""
-
-#: static/js/zamboni/collections.js:304
-msgid "Add a comment"
-msgstr ""
-
-#: static/js/zamboni/collections.js:304
-msgid "Comment"
-msgstr ""
-
-#: static/js/zamboni/collections.js:305
-msgid "Remove this add-on from the collection"
-msgstr ""
-
-#: static/js/zamboni/collections.js:305 static/js/zamboni/collections.js:334
-msgid "Remove"
-msgstr ""
-
-#: static/js/zamboni/collections.js:334
-msgid "Remove this user as a contributor"
-msgstr ""
-
-#: static/js/zamboni/collections.js:346
-msgid "An email address is required."
-msgstr ""
-
-#: static/js/zamboni/collections.js:364
-msgid "You cannot add yourself as a contributor."
-msgstr ""
-
-#: static/js/zamboni/collections.js:366
-msgid "You have already added that user."
-msgstr ""
-
-#: static/js/zamboni/collections.js:573
-msgid "Add to favorites"
-msgstr ""
-
-#: static/js/zamboni/collections.js:577
-msgid "Remove from favorites"
-msgstr ""
-
-#: static/js/zamboni/collections.js:604
-msgid "Stop following"
-msgstr ""
-
-#: static/js/zamboni/devhub.js:110
+#: static/js/zamboni/devhub-all.js:1289 static/js/zamboni/devhub-min.js:1 static/js/zamboni/devhub.js:110
 msgid "Your browser does not support the video tag"
 msgstr ""
 
-#: static/js/zamboni/devhub.js:371
+#: static/js/zamboni/devhub-all.js:1550 static/js/zamboni/devhub-min.js:1 static/js/zamboni/devhub.js:371
 msgid "Changes Saved"
 msgstr ""
 
-#: static/js/zamboni/devhub.js:387
+#: static/js/zamboni/devhub-all.js:1566 static/js/zamboni/devhub-min.js:1 static/js/zamboni/devhub.js:387
 msgid "Enter a new author's email address"
 msgstr ""
 
-#: static/js/zamboni/devhub.js:536
+#: static/js/zamboni/devhub-all.js:1715 static/js/zamboni/devhub-min.js:1 static/js/zamboni/devhub.js:536
 msgid "There was an error uploading your file."
 msgstr ""
 
-#: static/js/zamboni/devhub.js:681
+#: static/js/zamboni/devhub-all.js:1860 static/js/zamboni/devhub-min.js:1 static/js/zamboni/devhub.js:681
 msgid "{files} file"
 msgid_plural "{files} files"
 msgstr[0] ""
 msgstr[1] ""
 
-#: static/js/zamboni/devhub.js:684
+#: static/js/zamboni/devhub-all.js:1863 static/js/zamboni/devhub-min.js:1 static/js/zamboni/devhub.js:684
 msgid "{reviews} user review"
 msgid_plural "{reviews} user reviews"
 msgstr[0] ""
 msgstr[1] ""
 
-#: static/js/zamboni/devhub.js:796
+#: static/js/zamboni/devhub-all.js:1975 static/js/zamboni/devhub-min.js:2 static/js/zamboni/devhub.js:796
 msgid "Learn more"
 msgstr ""
 
-#: static/js/zamboni/devhub.js:800
+#: static/js/zamboni/devhub-all.js:1979 static/js/zamboni/devhub-min.js:2 static/js/zamboni/devhub.js:800
 msgid "Example"
 msgstr ""
 
-#: static/js/zamboni/devhub.js:1130
+#: static/js/zamboni/devhub-all.js:2309 static/js/zamboni/devhub-min.js:2 static/js/zamboni/devhub.js:1130
 msgid "Image changes being processed"
 msgstr ""
 
-#: static/js/zamboni/devhub.js:1280
+#: static/js/zamboni/devhub-all.js:2459 static/js/zamboni/devhub-min.js:2 static/js/zamboni/devhub.js:1280
 msgid "Must be a valid e-mail address."
+msgstr ""
+
+#: static/js/zamboni/devhub-all.js:2613 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:80
+msgid "All tests passed successfully."
+msgstr ""
+
+#: static/js/zamboni/devhub-all.js:2616 static/js/zamboni/devhub-all.js:3011 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:83 static/js/zamboni/validator.js:478
+msgid "These tests were not run."
+msgstr ""
+
+#: static/js/zamboni/devhub-all.js:2664 static/js/zamboni/devhub-all.js:2677 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:131 static/js/zamboni/validator.js:144
+msgid "Tests"
+msgstr ""
+
+#: static/js/zamboni/devhub-all.js:2779 static/js/zamboni/devhub-all.js:3108 static/js/zamboni/devhub-all.js:3127 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:246
+#: static/js/zamboni/validator.js:575 static/js/zamboni/validator.js:594
+msgid "Error"
+msgstr ""
+
+#: static/js/zamboni/devhub-all.js:2780 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:247
+msgid "Warning"
+msgstr ""
+
+#: static/js/zamboni/devhub-all.js:2794 static/js/zamboni/devhub-min.js:2 static/js/zamboni/files-all.js:5657 static/js/zamboni/files-min.js:3 static/js/zamboni/files.js:411
+#: static/js/zamboni/validator.js:261
+msgid "Ignore this message in future updates"
+msgstr ""
+
+#: static/js/zamboni/devhub-all.js:2817 static/js/zamboni/devhub-min.js:2 static/js/zamboni/files-all.js:5663 static/js/zamboni/files-min.js:3 static/js/zamboni/files.js:417
+#: static/js/zamboni/validator.js:284
+msgid "Severity for automated signing:"
+msgstr ""
+
+#: static/js/zamboni/devhub-all.js:2832 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:299
+msgid "Suggestions for passing automated signing:"
+msgstr ""
+
+#: static/js/zamboni/devhub-all.js:2920 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:387
+msgid "Compatibility Tests"
+msgstr ""
+
+#: static/js/zamboni/devhub-all.js:2999 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:466
+msgid "Add-on failed validation."
+msgstr ""
+
+#: static/js/zamboni/devhub-all.js:3001 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:468
+msgid "Add-on passed validation."
+msgstr ""
+
+#: static/js/zamboni/devhub-all.js:3014 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:481
+msgid "{0} error"
+msgid_plural "{0} errors"
+msgstr[0] ""
+msgstr[1] ""
+
+#: static/js/zamboni/devhub-all.js:3016 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:483
+msgid "{0} warning"
+msgid_plural "{0} warnings"
+msgstr[0] ""
+msgstr[1] ""
+
+#: static/js/zamboni/devhub-all.js:3018 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:485
+msgid "{0} notice"
+msgid_plural "{0} notices"
+msgstr[0] ""
+msgstr[1] ""
+
+#: static/js/zamboni/devhub-all.js:3110 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:577
+msgid "Validation task could not complete or completed with errors"
+msgstr ""
+
+#: static/js/zamboni/devhub-all.js:3128 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:595
+msgid "Internal server error"
 msgstr ""
 
 #: static/js/zamboni/devhub_search.js:8
 msgid "No results found."
 msgstr ""
 
-#: static/js/zamboni/editors.js:121
+#: static/js/zamboni/editors-all.js:15402 static/js/zamboni/editors-min.js:4 static/js/zamboni/editors.js:121
 msgid "{name} was viewing this page first."
 msgstr ""
 
-#: static/js/zamboni/editors.js:171
+#: static/js/zamboni/editors-all.js:15452 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:171
 msgid "Receipt checked by app."
 msgstr ""
 
-#: static/js/zamboni/editors.js:173
+#: static/js/zamboni/editors-all.js:15454 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:173
 msgid "Receipt was not checked by app."
 msgstr ""
 
-#: static/js/zamboni/editors.js:244
+#: static/js/zamboni/editors-all.js:15525 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:244
 msgid "{name} was viewing this add-on first."
 msgstr ""
 
-#: static/js/zamboni/editors.js:255
+#: static/js/zamboni/editors-all.js:15536 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:255
 msgid "Loading&hellip;"
 msgstr ""
 
-#: static/js/zamboni/editors.js:260
+#: static/js/zamboni/editors-all.js:15541 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:260
 msgid "Version Notes"
 msgstr ""
 
-#: static/js/zamboni/editors.js:265
+#: static/js/zamboni/editors-all.js:15546 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:265
 msgid "Notes for Reviewers"
 msgstr ""
 
-#: static/js/zamboni/editors.js:270
+#: static/js/zamboni/editors-all.js:15551 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:270
 msgid "No version notes found"
 msgstr ""
 
-#: static/js/zamboni/editors.js:330
+#: static/js/zamboni/editors-all.js:15611 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:330
 msgid "Average Reviews"
 msgstr ""
 
-#: static/js/zamboni/editors.js:386
+#: static/js/zamboni/editors-all.js:15667 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:386
 msgid "Number of Reviews"
 msgstr ""
 
-#: static/js/zamboni/editors.js:445
+#: static/js/zamboni/editors-all.js:15726 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:445
 msgid "Error loading translation"
 msgstr ""
 
-#: static/js/zamboni/files.js:411 static/js/zamboni/validator.js:261
-msgid "Ignore this message in future updates"
-msgstr ""
-
-#: static/js/zamboni/files.js:417 static/js/zamboni/validator.js:284
-msgid "Severity for automated signing:"
-msgstr ""
-
-#: static/js/zamboni/global.js:410
-msgid "Loading..."
-msgstr ""
-
-#. L10n: {0} is the number of characters left.
-#: static/js/zamboni/global.js:474
-msgid "<b>{0}</b> character left."
-msgid_plural "<b>{0}</b> characters left."
-msgstr[0] ""
-msgstr[1] ""
-
-#: static/js/zamboni/init.js:28
-msgid "This feature is temporarily disabled while we perform website maintenance. Please check back a little later."
-msgstr ""
-
-#: static/js/zamboni/l10n.js:45
-msgid "Remove this localization"
-msgstr ""
-
-#: static/js/zamboni/password-strength.js:20
-msgid "Password strength:"
-msgstr ""
-
-#: static/js/zamboni/password-strength.js:26
-msgid "At least {0} character left."
-msgid_plural "At least {0} characters left."
-msgstr[0] ""
-msgstr[1] ""
-
-#: static/js/zamboni/themes_review.js:176
-msgid "Requested Info"
-msgstr ""
-
-#: static/js/zamboni/themes_review.js:177
-msgid "Flagged"
-msgstr ""
-
-#: static/js/zamboni/themes_review.js:178
-msgid "Duplicate"
-msgstr ""
-
-#: static/js/zamboni/themes_review.js:179
-msgid "Rejected"
-msgstr ""
-
-#: static/js/zamboni/themes_review.js:180
-msgid "Approved"
-msgstr ""
-
-#: static/js/zamboni/themes_review.js:424
-msgid "No results found"
-msgstr ""
-
-#: static/js/zamboni/themes_review_templates.js:31
+#: static/js/zamboni/editors-all.js:15975 static/js/zamboni/editors-min.js:5 static/js/zamboni/themes_review_templates.js:31
 msgid "Theme"
 msgstr ""
 
-#: static/js/zamboni/themes_review_templates.js:33
+#: static/js/zamboni/editors-all.js:15977 static/js/zamboni/editors-min.js:5 static/js/zamboni/themes_review_templates.js:33
 msgid "Reviewer"
 msgstr ""
 
-#: static/js/zamboni/themes_review_templates.js:35
+#: static/js/zamboni/editors-all.js:15979 static/js/zamboni/editors-min.js:5 static/js/zamboni/themes_review_templates.js:35
 msgid "Status"
 msgstr ""
 
-#: static/js/zamboni/validator.js:80
-msgid "All tests passed successfully."
+#: static/js/zamboni/editors-all.js:16196 static/js/zamboni/editors-min.js:5 static/js/zamboni/themes_review.js:176
+msgid "Requested Info"
 msgstr ""
 
-#: static/js/zamboni/validator.js:83 static/js/zamboni/validator.js:478
-msgid "These tests were not run."
+#: static/js/zamboni/editors-all.js:16197 static/js/zamboni/editors-min.js:5 static/js/zamboni/themes_review.js:177
+msgid "Flagged"
 msgstr ""
 
-#: static/js/zamboni/validator.js:131 static/js/zamboni/validator.js:144
-msgid "Tests"
+#: static/js/zamboni/editors-all.js:16198 static/js/zamboni/editors-min.js:5 static/js/zamboni/themes_review.js:178
+msgid "Duplicate"
 msgstr ""
 
-#: static/js/zamboni/validator.js:246 static/js/zamboni/validator.js:575 static/js/zamboni/validator.js:594
-msgid "Error"
+#: static/js/zamboni/editors-all.js:16199 static/js/zamboni/editors-min.js:5 static/js/zamboni/themes_review.js:179
+msgid "Rejected"
 msgstr ""
 
-#: static/js/zamboni/validator.js:247
-msgid "Warning"
+#: static/js/zamboni/editors-all.js:16200 static/js/zamboni/editors-min.js:5 static/js/zamboni/themes_review.js:180
+msgid "Approved"
 msgstr ""
 
-#: static/js/zamboni/validator.js:299
-msgid "Suggestions for passing automated signing:"
+#: static/js/zamboni/editors-all.js:16444 static/js/zamboni/editors-min.js:5 static/js/zamboni/themes_review.js:424
+msgid "No results found"
 msgstr ""
 
-#: static/js/zamboni/validator.js:387
-msgid "Compatibility Tests"
-msgstr ""
-
-#: static/js/zamboni/validator.js:466
-msgid "Add-on failed validation."
-msgstr ""
-
-#: static/js/zamboni/validator.js:468
-msgid "Add-on passed validation."
-msgstr ""
-
-#: static/js/zamboni/validator.js:481
-msgid "{0} error"
-msgid_plural "{0} errors"
-msgstr[0] ""
-msgstr[1] ""
-
-#: static/js/zamboni/validator.js:483
-msgid "{0} warning"
-msgid_plural "{0} warnings"
-msgstr[0] ""
-msgstr[1] ""
-
-#: static/js/zamboni/validator.js:485
-msgid "{0} notice"
-msgid_plural "{0} notices"
-msgstr[0] ""
-msgstr[1] ""
-
-#: static/js/zamboni/validator.js:577
-msgid "Validation task could not complete or completed with errors"
-msgstr ""
-
-#: static/js/zamboni/validator.js:595
-msgid "Internal server error"
-msgstr ""
-
-#: static/js/zamboni/mobile/buttons.js:52
+#: static/js/zamboni/mobile-all.js:15186 static/js/zamboni/mobile/buttons.js:52
 msgid "Not Updated for {0} {1}"
 msgstr ""
 
-#: static/js/zamboni/mobile/buttons.js:53
+#: static/js/zamboni/mobile-all.js:15187 static/js/zamboni/mobile/buttons.js:53
 msgid "Requires Newer Version of {0}"
 msgstr ""
 
-#: static/js/zamboni/mobile/buttons.js:54
+#: static/js/zamboni/mobile-all.js:15188 static/js/zamboni/mobile/buttons.js:54
 msgid "Unreviewed"
 msgstr ""
 
-#: static/js/zamboni/mobile/buttons.js:55
+#: static/js/zamboni/mobile-all.js:15189 static/js/zamboni/mobile/buttons.js:55
 msgid "Experimental <span>(Learn More)</span>"
 msgstr ""
 
-#: static/js/zamboni/mobile/buttons.js:56 static/js/zamboni/mobile/buttons.js:57
+#: static/js/zamboni/mobile-all.js:15190 static/js/zamboni/mobile-all.js:15191 static/js/zamboni/mobile/buttons.js:56 static/js/zamboni/mobile/buttons.js:57
 msgid "Not Available for {0}"
 msgstr ""
 
-#: static/js/zamboni/mobile/buttons.js:58
+#: static/js/zamboni/mobile-all.js:15192 static/js/zamboni/mobile/buttons.js:58
 msgid "Experimental"
 msgstr ""
 
-#: static/js/zamboni/mobile/buttons.js:59
+#: static/js/zamboni/mobile-all.js:15193 static/js/zamboni/mobile/buttons.js:59
 msgid "Themes Require Newer Version of {0}"
 msgstr ""
 
-#: static/js/zamboni/mobile/buttons.js:60
+#: static/js/zamboni/mobile-all.js:15194 static/js/zamboni/mobile/buttons.js:60
 msgid "Themes Require {0}"
 msgstr ""
 
-#: static/js/zamboni/mobile/buttons.js:105
+#: static/js/zamboni/mobile-all.js:15239 static/js/zamboni/mobile/buttons.js:105
 msgid "Installing..."
 msgstr ""
 
-#: static/js/zamboni/mobile/buttons.js:125
+#: static/js/zamboni/mobile-all.js:15259 static/js/zamboni/mobile/buttons.js:125
 msgid "This add-on has been preliminarily reviewed by Mozilla."
 msgstr ""
 
-#: static/js/zamboni/mobile/buttons.js:250
+#: static/js/zamboni/mobile-all.js:15384 static/js/zamboni/mobile/buttons.js:250
 msgid "Keep it"
 msgstr ""
 
-#: static/js/zamboni/mobile/general.js:344
+#: static/js/zamboni/mobile-all.js:16049 static/js/zamboni/mobile-min.js:6 static/js/zamboni/mobile/general.js:344
 msgid "You're trying it on!"
 msgstr ""
 
-#: static/js/zamboni/mobile/general.js:356
+#: static/js/zamboni/mobile-all.js:16061 static/js/zamboni/mobile-min.js:6 static/js/zamboni/mobile/general.js:356
 msgid "Added to Firefox"
 msgstr ""
-

--- a/locale/gl/LC_MESSAGES/django.po
+++ b/locale/gl/LC_MESSAGES/django.po
@@ -3,69 +3,70 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2016-02-24 21:23+0000\n"
+"POT-Creation-Date: 2016-04-18 15:47+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
+"Language: \n"
 "MIME-Version: 1.0\n"
-"Content-Type: text/plain; charset=utf-8\n"
+"Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Generated-By: Babel 2.2.0\n"
 
-#: src/olympia/accounts/views.py:52
+#: src/olympia/accounts/views.py:54
 msgid "Your log in attempt could not be parsed. Please try again."
 msgstr ""
 
-#: src/olympia/accounts/views.py:54
+#: src/olympia/accounts/views.py:56
 msgid "Your Firefox Account could not be found. Please try again."
 msgstr ""
 
-#: src/olympia/accounts/views.py:55
+#: src/olympia/accounts/views.py:57
 msgid "You could not be logged in. Please try again."
 msgstr ""
 
-#: src/olympia/accounts/views.py:57
+#: src/olympia/accounts/views.py:59
 msgid "Your account has already been migrated to Firefox Accounts."
 msgstr ""
 
-#: src/olympia/accounts/views.py:59
+#: src/olympia/accounts/views.py:61
 msgid "Your Firefox Account already exists on this site."
 msgstr ""
 
-#: src/olympia/accounts/views.py:108
+#: src/olympia/accounts/views.py:110
 msgid "Great job!"
 msgstr ""
 
-#: src/olympia/accounts/views.py:109
+#: src/olympia/accounts/views.py:111
 msgid "You can now log in to Add-ons with your Firefox Account."
 msgstr ""
 
-#: src/olympia/accounts/views.py:121
+#: src/olympia/accounts/views.py:123
 msgid "Need help?"
 msgstr ""
 
-#: src/olympia/addons/buttons.py:180
+#: src/olympia/addons/buttons.py:177
 msgid "Download Now"
 msgstr ""
 
-#: src/olympia/addons/buttons.py:182
+#: src/olympia/addons/buttons.py:179
 msgid "Download"
 msgstr ""
 
 #. L10n: please keep &nbsp; in the string so &rarr; does not wrap.
-#: src/olympia/addons/buttons.py:186
+#: src/olympia/addons/buttons.py:183
 msgid "Continue to Download&nbsp;&rarr;"
 msgstr ""
 
-#: src/olympia/addons/buttons.py:202 src/olympia/addons/helpers.py:35 src/olympia/addons/views.py:319 src/olympia/addons/templates/addons/impala/details.html:114
+#: src/olympia/addons/buttons.py:199 src/olympia/addons/helpers.py:35 src/olympia/addons/views.py:333 src/olympia/addons/templates/addons/impala/details.html:111
 #: src/olympia/addons/templates/addons/impala/listing/items.html:17 src/olympia/addons/templates/addons/mobile/home.html:40 src/olympia/amo/templates/amo/side_nav.html:6
-#: src/olympia/amo/templates/amo/side_nav.html:10 src/olympia/amo/templates/amo/site_nav.html:2 src/olympia/amo/templates/amo/site_nav.html:55 src/olympia/bandwagon/views.py:95
-#: src/olympia/browse/views.py:54 src/olympia/browse/views.py:68 src/olympia/browse/views.py:235 src/olympia/browse/templates/browse/impala/category_landing.html:22
+#: src/olympia/amo/templates/amo/side_nav.html:10 src/olympia/amo/templates/amo/site_nav.html:2 src/olympia/amo/templates/amo/site_nav.html:53 src/olympia/bandwagon/views.py:95
+#: src/olympia/browse/views.py:54 src/olympia/browse/views.py:68 src/olympia/browse/views.py:202 src/olympia/browse/templates/browse/impala/category_landing.html:22
 #: src/olympia/browse/templates/browse/personas/mobile/category_landing.html:26
 msgid "Featured"
 msgstr ""
 
-#: src/olympia/addons/buttons.py:221
+#: src/olympia/addons/buttons.py:218
 msgid "Add to {0}"
 msgstr ""
 
@@ -113,39 +114,39 @@ msgid_plural "All tags must be at least {0} characters."
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/olympia/addons/forms.py:234
+#: src/olympia/addons/forms.py:238
 msgid "Categories cannot be changed while your add-on is featured for this application."
 msgstr ""
 
 #. L10n: {0} is the number of categories.
-#: src/olympia/addons/forms.py:238
+#: src/olympia/addons/forms.py:242
 msgid "You can have only {0} category."
 msgid_plural "You can have only {0} categories."
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/olympia/addons/forms.py:246
+#: src/olympia/addons/forms.py:250
 msgid "The miscellaneous category cannot be combined with additional categories."
 msgstr ""
 
-#: src/olympia/addons/forms.py:369
+#: src/olympia/addons/forms.py:374
 #, python-format
 msgid "Before changing your default locale you must have a name, summary, and description in that locale. You are missing %s."
 msgstr ""
 
-#: src/olympia/addons/forms.py:484 src/olympia/addons/forms.py:575
+#: src/olympia/addons/forms.py:455 src/olympia/addons/forms.py:546
 msgid "A license must be selected."
 msgstr ""
 
-#: src/olympia/addons/forms.py:556
+#: src/olympia/addons/forms.py:527
 msgid "Give Your Theme a Name."
 msgstr ""
 
-#: src/olympia/addons/forms.py:562 src/olympia/devhub/templates/devhub/personas/submit.html:53
+#: src/olympia/addons/forms.py:533 src/olympia/devhub/templates/devhub/personas/submit.html:53
 msgid "Describe your Theme."
 msgstr ""
 
-#: src/olympia/addons/forms.py:704
+#: src/olympia/addons/forms.py:675
 msgid "Enter a new author's email address"
 msgstr ""
 
@@ -153,37 +154,37 @@ msgstr ""
 msgid "Not Reviewed"
 msgstr ""
 
-#: src/olympia/addons/models.py:301
+#: src/olympia/addons/models.py:298
 msgid "Users have the option of contributing more or less than this amount."
 msgstr ""
 
-#: src/olympia/addons/models.py:309
-msgid "Users will always be asked in the Add-ons Manager (Firefox 4 and above)"
+#: src/olympia/addons/models.py:306
+msgid "Users will always be asked in the Add-ons Manager (Firefox 4 and above). Only applies to desktop."
 msgstr ""
 
-#: src/olympia/addons/models.py:1804 src/olympia/addons/templates/addons/details_box.html:55 src/olympia/devhub/templates/devhub/index.html:92
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:102
+#: src/olympia/addons/models.py:1802 src/olympia/addons/templates/addons/details_box.html:55 src/olympia/devhub/templates/devhub/index.html:92
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:89
 msgid "Listed"
 msgstr ""
 
-#: src/olympia/addons/views.py:320 src/olympia/browse/templates/browse/personas/mobile/category_landing.html:27
+#: src/olympia/addons/views.py:334 src/olympia/browse/templates/browse/personas/mobile/category_landing.html:27
 msgid "Popular"
 msgstr ""
 
-#: src/olympia/addons/views.py:321 src/olympia/browse/views.py:238 src/olympia/browse/views.py:280 src/olympia/browse/views.py:482
+#: src/olympia/addons/views.py:335 src/olympia/browse/views.py:205 src/olympia/browse/views.py:247 src/olympia/browse/views.py:449
 msgid "Recently Added"
 msgstr ""
 
-#: src/olympia/addons/views.py:322 src/olympia/bandwagon/views.py:99 src/olympia/browse/views.py:60 src/olympia/browse/views.py:71 src/olympia/search/forms.py:16 src/olympia/search/forms.py:91
+#: src/olympia/addons/views.py:336 src/olympia/bandwagon/views.py:99 src/olympia/browse/views.py:60 src/olympia/browse/views.py:71 src/olympia/search/forms.py:16 src/olympia/search/forms.py:91
 msgid "Recently Updated"
 msgstr ""
 
 #. l10n: {0} is the addon name
-#: src/olympia/addons/views.py:520
+#: src/olympia/addons/views.py:534
 msgid "Contribution for {0}"
 msgstr ""
 
-#: src/olympia/addons/views.py:613
+#: src/olympia/addons/views.py:627
 msgid "Abuse reported."
 msgstr ""
 
@@ -250,9 +251,9 @@ msgstr ""
 #: src/olympia/devhub/templates/devhub/addons/ajax_compat_update.html:36 src/olympia/devhub/templates/devhub/addons/profile.html:44 src/olympia/devhub/templates/devhub/addons/edit/admin.html:101
 #: src/olympia/devhub/templates/devhub/addons/edit/basic.html:152 src/olympia/devhub/templates/devhub/addons/edit/details.html:85 src/olympia/devhub/templates/devhub/addons/edit/support.html:67
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:166 src/olympia/devhub/templates/devhub/addons/forms_shared/media.html:149
-#: src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:44 src/olympia/devhub/templates/devhub/versions/add_file_modal.html:78 src/olympia/devhub/templates/devhub/versions/edit.html:139
-#: src/olympia/devhub/templates/devhub/versions/list.html:242 src/olympia/devhub/templates/devhub/versions/list.html:276 src/olympia/devhub/templates/devhub/versions/list.html:317
-#: src/olympia/devhub/templates/devhub/versions/list.html:351 src/olympia/reviews/templates/reviews/edit_review.html:16 src/olympia/translations/templates/translations/trans-menu.html:50
+#: src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:43 src/olympia/devhub/templates/devhub/versions/add_file_modal.html:58 src/olympia/devhub/templates/devhub/versions/edit.html:139
+#: src/olympia/devhub/templates/devhub/versions/list.html:239 src/olympia/devhub/templates/devhub/versions/list.html:281 src/olympia/devhub/templates/devhub/versions/list.html:315
+#: src/olympia/devhub/templates/devhub/versions/list.html:349 src/olympia/reviews/templates/reviews/edit_review.html:16 src/olympia/translations/templates/translations/trans-menu.html:50
 #: src/olympia/translations/templates/translations/trans-menu.html:62
 msgid "or"
 msgstr ""
@@ -363,7 +364,7 @@ msgid "Add-on Information for {0}"
 msgstr ""
 
 #: src/olympia/addons/templates/addons/details_box.html:30 src/olympia/addons/templates/addons/persona_detail_table.html:3 src/olympia/addons/templates/addons/mobile/details.html:63
-#: src/olympia/addons/templates/addons/mobile/persona_detail_table.html:7 src/olympia/browse/views.py:459 src/olympia/devhub/views.py:75
+#: src/olympia/addons/templates/addons/mobile/persona_detail_table.html:7 src/olympia/browse/views.py:426 src/olympia/devhub/views.py:73
 msgid "Updated"
 msgstr ""
 
@@ -382,11 +383,11 @@ msgstr ""
 msgid "Visibility"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/details_box.html:57 src/olympia/devhub/templates/devhub/index.html:94 src/olympia/devhub/templates/devhub/includes/addon_details.html:104
+#: src/olympia/addons/templates/addons/details_box.html:57 src/olympia/devhub/templates/devhub/index.html:94 src/olympia/devhub/templates/devhub/includes/addon_details.html:91
 msgid "Hidden"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/details_box.html:59 src/olympia/devhub/templates/devhub/index.html:96 src/olympia/devhub/templates/devhub/includes/addon_details.html:106
+#: src/olympia/addons/templates/addons/details_box.html:59 src/olympia/devhub/templates/devhub/index.html:96 src/olympia/devhub/templates/devhub/includes/addon_details.html:93
 msgid "Unlisted"
 msgstr ""
 
@@ -394,13 +395,13 @@ msgstr ""
 msgid "Required Add-ons"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/details_box.html:81 src/olympia/addons/templates/addons/persona_detail_table.html:15 src/olympia/browse/views.py:462 src/olympia/devhub/views.py:78
-#: src/olympia/devhub/views.py:85 src/olympia/discovery/templates/discovery/addons/detail.html:57 src/olympia/reviews/forms.py:62 src/olympia/reviews/templates/reviews/add.html:57
+#: src/olympia/addons/templates/addons/details_box.html:81 src/olympia/addons/templates/addons/persona_detail_table.html:15 src/olympia/browse/views.py:429 src/olympia/devhub/views.py:76
+#: src/olympia/devhub/views.py:83 src/olympia/discovery/templates/discovery/addons/detail.html:57 src/olympia/reviews/forms.py:62 src/olympia/reviews/templates/reviews/add.html:57
 #: src/olympia/reviews/templates/reviews/mobile/review_list.html:18
 msgid "Rating"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/details_box.html:85 src/olympia/browse/views.py:461 src/olympia/devhub/views.py:77 src/olympia/devhub/views.py:84
+#: src/olympia/addons/templates/addons/details_box.html:85 src/olympia/browse/views.py:428 src/olympia/devhub/views.py:75 src/olympia/devhub/views.py:82
 #: src/olympia/stats/templates/stats/addon_report_menu.html:8 src/olympia/stats/templates/stats/collection_report_menu.html:18
 msgid "Downloads"
 msgstr ""
@@ -420,7 +421,7 @@ msgstr ""
 
 #. The Privacy Policy for this add-on.
 #: src/olympia/addons/templates/addons/details_box.html:121 src/olympia/addons/templates/addons/privacy.html:19 src/olympia/addons/templates/addons/privacy.html:23
-#: src/olympia/addons/templates/addons/impala/button.html:43 src/olympia/addons/templates/addons/impala/details.html:307 src/olympia/devhub/templates/devhub/includes/policy_form.html:20
+#: src/olympia/addons/templates/addons/impala/button.html:43 src/olympia/addons/templates/addons/impala/details.html:312 src/olympia/devhub/templates/devhub/includes/policy_form.html:23
 #: src/olympia/templates/mobile/base_addons.html:87
 msgid "Privacy Policy"
 msgstr ""
@@ -445,7 +446,7 @@ msgstr ""
 msgid "Developer Comments"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/details_box.html:199 src/olympia/addons/templates/addons/impala/details.html:259
+#: src/olympia/addons/templates/addons/details_box.html:199 src/olympia/addons/templates/addons/impala/details.html:264
 msgid "Development Channel"
 msgstr ""
 
@@ -465,7 +466,7 @@ msgid ""
 "developer. To stop receiving development updates, reinstall the default version from the link above."
 msgstr ""
 
-#: src/olympia/addons/templates/addons/details_box.html:220 src/olympia/addons/templates/addons/impala/details.html:278
+#: src/olympia/addons/templates/addons/details_box.html:220 src/olympia/addons/templates/addons/impala/details.html:283
 msgid "Version {0}:"
 msgstr ""
 
@@ -484,7 +485,7 @@ msgid "End-User License Agreement for {0}"
 msgstr ""
 
 #: src/olympia/addons/templates/addons/eula.html:17 src/olympia/addons/templates/addons/eula.html:21 src/olympia/addons/templates/addons/impala/button.html:48
-#: src/olympia/addons/templates/addons/impala/details.html:316 src/olympia/devhub/templates/devhub/includes/policy_form.html:3 src/olympia/discovery/templates/discovery/addons/eula.html:11
+#: src/olympia/addons/templates/addons/impala/details.html:321 src/olympia/devhub/templates/devhub/includes/policy_form.html:3 src/olympia/discovery/templates/discovery/addons/eula.html:11
 msgid "End-User License Agreement"
 msgstr ""
 
@@ -501,7 +502,7 @@ msgstr ""
 msgid "Add-ons for {0}"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/home.html:10 src/olympia/addons/templates/addons/home.html:51 src/olympia/browse/templates/browse/impala/base_listing.html:11
+#: src/olympia/addons/templates/addons/home.html:10 src/olympia/addons/templates/addons/home.html:53 src/olympia/browse/templates/browse/impala/base_listing.html:11
 msgid "Featured Extensions"
 msgstr ""
 
@@ -509,29 +510,29 @@ msgstr ""
 msgid "Popular Extensions"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/home.html:42 src/olympia/amo/templates/amo/side_nav.html:3 src/olympia/amo/templates/amo/side_nav.html:11 src/olympia/amo/templates/amo/site_nav.html:3
-#: src/olympia/amo/templates/amo/site_nav.html:25 src/olympia/browse/views.py:236 src/olympia/browse/views.py:281 src/olympia/browse/views.py:481
+#: src/olympia/addons/templates/addons/home.html:44 src/olympia/amo/templates/amo/side_nav.html:3 src/olympia/amo/templates/amo/side_nav.html:11 src/olympia/amo/templates/amo/site_nav.html:3
+#: src/olympia/amo/templates/amo/site_nav.html:25 src/olympia/browse/views.py:203 src/olympia/browse/views.py:248 src/olympia/browse/views.py:448
 msgid "Most Popular"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/home.html:43
+#: src/olympia/addons/templates/addons/home.html:45
 msgid "All »"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/home.html:52 src/olympia/addons/templates/addons/home.html:61 src/olympia/addons/templates/addons/home.html:70 src/olympia/addons/templates/addons/home.html:78
+#: src/olympia/addons/templates/addons/home.html:54 src/olympia/addons/templates/addons/home.html:63 src/olympia/addons/templates/addons/home.html:72 src/olympia/addons/templates/addons/home.html:80
 #: src/olympia/browse/templates/browse/impala/category_landing.html:36
 msgid "See all »"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/home.html:60
+#: src/olympia/addons/templates/addons/home.html:62
 msgid "Up &amp; Coming Extensions"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/home.html:69 src/olympia/browse/templates/browse/personas/category_landing.html:61 src/olympia/discovery/templates/discovery/pane.html:74
+#: src/olympia/addons/templates/addons/home.html:71 src/olympia/browse/templates/browse/personas/category_landing.html:61 src/olympia/discovery/templates/discovery/pane.html:74
 msgid "Featured Themes"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/home.html:77 src/olympia/bandwagon/templates/bandwagon/impala/collection_listing.html:5
+#: src/olympia/addons/templates/addons/home.html:79 src/olympia/bandwagon/templates/bandwagon/impala/collection_listing.html:5
 msgid "Featured Collections"
 msgstr ""
 
@@ -549,7 +550,7 @@ msgid "Updated {0}"
 msgstr ""
 
 #. {0} is a date.
-#: src/olympia/addons/templates/addons/macros.html:10 src/olympia/addons/templates/addons/macros.html:69 src/olympia/addons/templates/addons/persona_preview.html:21
+#: src/olympia/addons/templates/addons/macros.html:10 src/olympia/addons/templates/addons/macros.html:69 src/olympia/addons/templates/addons/persona_preview.html:22
 #: src/olympia/addons/templates/addons/listing/items_mobile.html:44 src/olympia/addons/templates/addons/listing/macros.html:39
 #: src/olympia/bandwagon/templates/bandwagon/collection_listing_items.html:37 src/olympia/bandwagon/templates/bandwagon/impala/collection_listing_items.html:37
 msgid "Added {0}"
@@ -570,15 +571,14 @@ msgstr[0] ""
 msgstr[1] ""
 
 #. {0} is the number of downloads.
-#: src/olympia/addons/templates/addons/macros.html:53 src/olympia/addons/templates/addons/impala/details.html:61
+#: src/olympia/addons/templates/addons/macros.html:53 src/olympia/addons/templates/addons/impala/details.html:59
 msgid "{0} weekly download"
 msgid_plural "{0} weekly downloads"
 msgstr[0] ""
 msgstr[1] ""
 
 #. {0} is the number of users.
-#: src/olympia/addons/templates/addons/macros.html:61 src/olympia/addons/templates/addons/impala/details.html:54 src/olympia/compat/templates/compat/index.html:71
-#: src/olympia/zadmin/templates/zadmin/compat.html:67
+#: src/olympia/addons/templates/addons/macros.html:61 src/olympia/addons/templates/addons/impala/details.html:52 src/olympia/zadmin/templates/zadmin/compat.html:67
 msgid "{0} user"
 msgid_plural "{0} users"
 msgstr[0] ""
@@ -596,7 +596,7 @@ msgstr ""
 msgid "Return to the addon."
 msgstr ""
 
-#: src/olympia/addons/templates/addons/persona_detail.html:17 src/olympia/addons/templates/addons/impala/details.html:106 src/olympia/addons/templates/addons/mobile/details.html:23
+#: src/olympia/addons/templates/addons/persona_detail.html:17 src/olympia/addons/templates/addons/impala/details.html:103 src/olympia/addons/templates/addons/mobile/details.html:23
 #: src/olympia/addons/templates/addons/mobile/persona_detail.html:21 src/olympia/discovery/templates/discovery/addons/base.html:27 src/olympia/editors/templates/editors/review.html:31
 msgid "by"
 msgstr ""
@@ -640,34 +640,35 @@ msgstr ""
 msgid "License"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/persona_preview.html:12 src/olympia/constants/base.py:48
+#: src/olympia/addons/templates/addons/persona_preview.html:13 src/olympia/constants/base.py:48
 msgid "Awaiting Review"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/persona_preview.html:14 src/olympia/amo/log.py:180 src/olympia/constants/base.py:42 src/olympia/editors/helpers.py:62
+#: src/olympia/addons/templates/addons/persona_preview.html:15 src/olympia/amo/log.py:180 src/olympia/constants/base.py:42 src/olympia/editors/helpers.py:62
 msgid "Rejected"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/persona_preview.html:16 src/olympia/amo/log.py:159
+#: src/olympia/addons/templates/addons/persona_preview.html:17 src/olympia/amo/log.py:159
 msgid "Approved"
 msgstr ""
 
 #. {0} is the number of users.
-#: src/olympia/addons/templates/addons/persona_preview.html:26 src/olympia/addons/templates/addons/listing/items_mobile.html:36 src/olympia/addons/templates/addons/listing/macros.html:31
+#: src/olympia/addons/templates/addons/persona_preview.html:27 src/olympia/addons/templates/addons/listing/items_mobile.html:36 src/olympia/addons/templates/addons/listing/macros.html:31
 msgid "<strong>{0}</strong> user"
 msgid_plural "<strong>{0}</strong> users"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/olympia/addons/templates/addons/persona_preview.html:40
+#: src/olympia/addons/templates/addons/persona_preview.html:41
 msgid "Hover to Preview"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/persona_preview.html:46 src/olympia/addons/templates/addons/persona_preview.html:48 src/olympia/reviews/templates/reviews/add.html:15
+#: src/olympia/addons/templates/addons/persona_preview.html:47 src/olympia/addons/templates/addons/persona_preview.html:49 src/olympia/addons/templates/addons/persona_preview.html:97
+#: src/olympia/reviews/templates/reviews/add.html:15
 msgid "Add"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/persona_preview.html:57 src/olympia/bandwagon/templates/bandwagon/ajax_new.html:16 src/olympia/bandwagon/templates/bandwagon/edit.html:19
+#: src/olympia/addons/templates/addons/persona_preview.html:58 src/olympia/bandwagon/templates/bandwagon/ajax_new.html:16 src/olympia/bandwagon/templates/bandwagon/edit.html:19
 #: src/olympia/bandwagon/templates/bandwagon/includes/addedit.html:19 src/olympia/devhub/templates/devhub/addons/edit/admin.html:13 src/olympia/devhub/templates/devhub/addons/edit/basic.html:10
 #: src/olympia/devhub/templates/devhub/addons/edit/details.html:8 src/olympia/devhub/templates/devhub/addons/edit/media.html:6 src/olympia/devhub/templates/devhub/addons/edit/support.html:8
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:9 src/olympia/devhub/templates/devhub/addons/submit/describe.html:29 src/olympia/editors/templates/editors/review.html:257
@@ -676,21 +677,21 @@ msgstr ""
 
 #. For datetime formatting, see the table on
 #. http://docs.python.org/library/datetime.html#strftime-and-strptime-behavior
-#: src/olympia/addons/templates/addons/persona_preview.html:66
+#: src/olympia/addons/templates/addons/persona_preview.html:67
 #, python-format
 msgid "%%Y-%%m-%%d"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/persona_preview.html:67
+#: src/olympia/addons/templates/addons/persona_preview.html:68
 msgid "by {0} on {1}"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/persona_preview.html:75 src/olympia/reviews/helpers.py:17 src/olympia/reviews/templates/reviews/review_list.html:63
+#: src/olympia/addons/templates/addons/persona_preview.html:76 src/olympia/reviews/helpers.py:17 src/olympia/reviews/templates/reviews/review_list.html:63
 #: src/olympia/reviews/templates/reviews/reviews_link.html:21 src/olympia/reviews/templates/reviews/impala/reviews_link.html:16
 msgid "Not yet rated"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/persona_preview.html:78
+#: src/olympia/addons/templates/addons/persona_preview.html:79
 msgid "<b>{0}</b> users"
 msgstr ""
 
@@ -703,7 +704,7 @@ msgid "Learn more about Firefox"
 msgstr ""
 
 #: src/olympia/addons/templates/addons/popups.html:22
-msgid "or <b><a class=\"installer\" href=\"{url}\">download anyway</a></b>"
+msgid "or <b><a class=\"button installer\" href=\"{url}\">download anyway</a></b>"
 msgstr ""
 
 #: src/olympia/addons/templates/addons/popups.html:26
@@ -802,7 +803,7 @@ msgid ""
 msgstr ""
 
 #: src/olympia/addons/templates/addons/report_abuse.html:6 src/olympia/addons/templates/addons/report_abuse_full.html:10 src/olympia/addons/templates/addons/impala/details-more.html:23
-#: src/olympia/addons/templates/addons/impala/details.html:328
+#: src/olympia/addons/templates/addons/impala/details.html:333
 msgid "Report Abuse"
 msgstr ""
 
@@ -821,9 +822,9 @@ msgstr ""
 #: src/olympia/devhub/templates/devhub/addons/ajax_compat_update.html:36 src/olympia/devhub/templates/devhub/addons/profile.html:44 src/olympia/devhub/templates/devhub/addons/edit/admin.html:104
 #: src/olympia/devhub/templates/devhub/addons/edit/basic.html:155 src/olympia/devhub/templates/devhub/addons/edit/details.html:88 src/olympia/devhub/templates/devhub/addons/edit/support.html:70
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:169 src/olympia/devhub/templates/devhub/addons/forms_shared/media.html:152
-#: src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:44 src/olympia/devhub/templates/devhub/personas/edit.html:222 src/olympia/devhub/templates/devhub/versions/add_file_modal.html:79
-#: src/olympia/devhub/templates/devhub/versions/edit.html:140 src/olympia/devhub/templates/devhub/versions/list.html:208 src/olympia/devhub/templates/devhub/versions/list.html:242
-#: src/olympia/devhub/templates/devhub/versions/list.html:276 src/olympia/devhub/templates/devhub/versions/list.html:317 src/olympia/reviews/templates/reviews/edit_review.html:16
+#: src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:43 src/olympia/devhub/templates/devhub/personas/edit.html:222 src/olympia/devhub/templates/devhub/versions/add_file_modal.html:59
+#: src/olympia/devhub/templates/devhub/versions/edit.html:140 src/olympia/devhub/templates/devhub/versions/list.html:208 src/olympia/devhub/templates/devhub/versions/list.html:239
+#: src/olympia/devhub/templates/devhub/versions/list.html:281 src/olympia/devhub/templates/devhub/versions/list.html:315 src/olympia/reviews/templates/reviews/edit_review.html:16
 #: src/olympia/translations/templates/translations/trans-menu.html:50 src/olympia/translations/templates/translations/trans-menu.html:62 src/olympia/zadmin/templates/zadmin/validation.html:105
 msgid "Cancel"
 msgstr ""
@@ -868,7 +869,7 @@ msgstr ""
 msgid "Review Guidelines"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/review_list_box.html:5 src/olympia/addons/templates/addons/impala/details-more.html:27 src/olympia/editors/helpers.py:921
+#: src/olympia/addons/templates/addons/review_list_box.html:5 src/olympia/addons/templates/addons/impala/details-more.html:27 src/olympia/editors/helpers.py:1001
 #: src/olympia/reviews/templates/reviews/add.html:14 src/olympia/reviews/templates/reviews/reply.html:14 src/olympia/reviews/templates/reviews/review_list.html:19
 #: src/olympia/reviews/templates/reviews/mobile/review_list.html:26
 msgid "Reviews"
@@ -959,119 +960,119 @@ msgid_plural "Other add-ons by these authors"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/olympia/addons/templates/addons/impala/details.html:41
+#: src/olympia/addons/templates/addons/impala/details.html:39
 #, python-format
 msgid "<span itemprop=\"ratingCount\">%(num)s</span> user review"
 msgid_plural "<span itemprop=\"ratingCount\">%(num)s</span> user reviews"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/olympia/addons/templates/addons/impala/details.html:69
+#: src/olympia/addons/templates/addons/impala/details.html:66
 msgid "View statistics"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/impala/details.html:84
+#: src/olympia/addons/templates/addons/impala/details.html:81
 msgid "Manage"
 msgstr ""
 
 #. {0} is an add-on name.
-#: src/olympia/addons/templates/addons/impala/details.html:96
+#: src/olympia/addons/templates/addons/impala/details.html:93
 msgid "Icon of {0}"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/impala/details.html:103 src/olympia/addons/templates/addons/impala/listing/items.html:14
+#: src/olympia/addons/templates/addons/impala/details.html:100 src/olympia/addons/templates/addons/impala/listing/items.html:14
 msgid "No Restart"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/impala/details.html:127
+#: src/olympia/addons/templates/addons/impala/details.html:124
 #, python-format
 msgid "Meet the Developer: <a href=\"%(url)s\">%(name)s</a>"
 msgid_plural "<a href=\"%(url)s\">Meet the Developers</a>"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/olympia/addons/templates/addons/impala/details.html:137
+#: src/olympia/addons/templates/addons/impala/details.html:134
 msgid "Learn why {0} was created and find out what's next for this add-on."
 msgstr ""
 
 #. {0} is an index.
-#: src/olympia/addons/templates/addons/impala/details.html:156
+#: src/olympia/addons/templates/addons/impala/details.html:161
 msgid "Add-on screenshot #{0}"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/impala/details.html:182
+#: src/olympia/addons/templates/addons/impala/details.html:187
 msgid "Add-on home page"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/impala/details.html:185
+#: src/olympia/addons/templates/addons/impala/details.html:190
 msgid "Support site"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/impala/details.html:189
+#: src/olympia/addons/templates/addons/impala/details.html:194
 msgid "Support E-mail"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/impala/details.html:194 src/olympia/devhub/models.py:378 src/olympia/devhub/templates/devhub/versions/list.html:12
+#: src/olympia/addons/templates/addons/impala/details.html:199 src/olympia/devhub/models.py:378 src/olympia/devhub/templates/devhub/versions/list.html:12
 #: src/olympia/versions/templates/versions/version.html:6 src/olympia/versions/templates/versions/mobile/version.html:6
 msgid "Version {0}"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/impala/details.html:194
+#: src/olympia/addons/templates/addons/impala/details.html:199
 msgid "Info"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/impala/details.html:195 src/olympia/devhub/templates/devhub/includes/addon_details.html:129
+#: src/olympia/addons/templates/addons/impala/details.html:200 src/olympia/devhub/templates/devhub/includes/addon_details.html:116
 msgid "Last Updated:"
-msgstr ""
-
-#: src/olympia/addons/templates/addons/impala/details.html:200
-#, python-format
-msgid "Released under <a target=\"_blank\" href=\"%(url)s\">%(name)s</a>"
-msgstr ""
-
-#: src/olympia/addons/templates/addons/impala/details.html:201 src/olympia/addons/templates/addons/impala/details.html:206 src/olympia/amo/helpers.py:398 src/olympia/devhub/forms.py:142
-#: src/olympia/devhub/forms.py:173 src/olympia/versions/templates/versions/version.html:40 src/olympia/versions/templates/versions/version.html:45
-msgid "Custom License"
 msgstr ""
 
 #: src/olympia/addons/templates/addons/impala/details.html:205
 #, python-format
+msgid "Released under <a target=\"_blank\" href=\"%(url)s\">%(name)s</a>"
+msgstr ""
+
+#: src/olympia/addons/templates/addons/impala/details.html:206 src/olympia/addons/templates/addons/impala/details.html:211 src/olympia/amo/helpers.py:398 src/olympia/devhub/forms.py:142
+#: src/olympia/devhub/forms.py:173 src/olympia/versions/templates/versions/version.html:40 src/olympia/versions/templates/versions/version.html:45
+msgid "Custom License"
+msgstr ""
+
+#: src/olympia/addons/templates/addons/impala/details.html:210
+#, python-format
 msgid "Released under <a href=\"%(url)s\">%(name)s</a>"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/impala/details.html:217
+#: src/olympia/addons/templates/addons/impala/details.html:222
 msgid "About this Add-on"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/impala/details.html:233
+#: src/olympia/addons/templates/addons/impala/details.html:238
 msgid "Developer’s Comments"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/impala/details.html:243
+#: src/olympia/addons/templates/addons/impala/details.html:248
 msgid "Version Information"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/impala/details.html:250
+#: src/olympia/addons/templates/addons/impala/details.html:255
 msgid "See complete version history"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/impala/details.html:262
+#: src/olympia/addons/templates/addons/impala/details.html:267
 msgid ""
 "The Development Channel lets you test an experimental new version of this add-on before it's released to the general public. Once you install the development version, you will continue to get "
 "updates from this channel. To stop receiving development updates, reinstall the default version from the link above."
 msgstr ""
 
-#: src/olympia/addons/templates/addons/impala/details.html:272
+#: src/olympia/addons/templates/addons/impala/details.html:277
 msgid "<strong>Caution:</strong> Development versions of this add-on have not been reviewed by Mozilla."
 msgstr ""
 
-#: src/olympia/addons/templates/addons/impala/details.html:287
+#: src/olympia/addons/templates/addons/impala/details.html:292
 msgid "See complete development channel history"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/impala/details.html:306 src/olympia/addons/templates/addons/impala/details.html:315 src/olympia/addons/templates/addons/impala/details.html:327
+#: src/olympia/addons/templates/addons/impala/details.html:311 src/olympia/addons/templates/addons/impala/details.html:320 src/olympia/addons/templates/addons/impala/details.html:332
 #: src/olympia/addons/templates/addons/impala/review_add_box.html:4 src/olympia/stats/templates/stats/popup.html:2 src/olympia/stats/templates/stats/popup.html:8
-#: src/olympia/stats/templates/stats/stats.html:202 src/olympia/users/templates/users/profile.html:119
+#: src/olympia/stats/templates/stats/stats.html:204 src/olympia/users/templates/users/profile.html:119
 msgid "close"
 msgstr ""
 
@@ -1127,15 +1128,11 @@ msgstr ""
 msgid "Source Code License"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/impala/persona_grid.html:16 src/olympia/addons/templates/addons/impala/toplist.html:6
-msgid "{0} users"
-msgstr ""
-
 #: src/olympia/addons/templates/addons/impala/review_list_box.html:19 src/olympia/reviews/templates/reviews/review.html:40
 msgid "permalink"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/impala/review_list_box.html:23 src/olympia/editors/templates/editors/queue.html:98 src/olympia/reviews/templates/reviews/review.html:44
+#: src/olympia/addons/templates/addons/impala/review_list_box.html:23 src/olympia/editors/templates/editors/queue.html:104 src/olympia/reviews/templates/reviews/review.html:44
 msgid "translate"
 msgstr ""
 
@@ -1154,6 +1151,10 @@ msgstr ""
 msgid "Be the first!"
 msgstr ""
 
+#: src/olympia/addons/templates/addons/impala/toplist.html:6
+msgid "{0} users"
+msgstr ""
+
 #: src/olympia/addons/templates/addons/impala/listing/sorter.html:14 src/olympia/devhub/templates/devhub/addons/listing/item_actions.html:49
 msgid "More"
 msgstr ""
@@ -1166,7 +1167,7 @@ msgstr ""
 msgid "My Add-ons"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/includes/dashboard_tabs.html:6 src/olympia/amo/context_processors.py:51
+#: src/olympia/addons/templates/addons/includes/dashboard_tabs.html:6 src/olympia/amo/context_processors.py:50
 msgid "My Themes"
 msgstr ""
 
@@ -1221,7 +1222,7 @@ msgstr ""
 msgid "Weekly Downloads"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/mobile/details.html:99 src/olympia/compat/templates/compat/reporter_detail.html:46 src/olympia/devhub/forms.py:787
+#: src/olympia/addons/templates/addons/mobile/details.html:99 src/olympia/compat/templates/compat/reporter_detail.html:46 src/olympia/devhub/forms.py:788
 #: src/olympia/devhub/templates/devhub/versions/list.html:163
 msgid "Version"
 msgstr ""
@@ -1305,7 +1306,7 @@ msgstr ""
 #: src/olympia/browse/templates/browse/personas/category_landing.html:21 src/olympia/browse/templates/browse/personas/category_landing.html:23
 #: src/olympia/browse/templates/browse/personas/category_landing.html:38 src/olympia/browse/templates/browse/personas/grid.html:7 src/olympia/browse/templates/browse/personas/grid.html:11
 #: src/olympia/browse/templates/browse/personas/mobile/base.html:7 src/olympia/browse/templates/browse/personas/mobile/category_landing.html:19 src/olympia/constants/base.py:180
-#: src/olympia/devhub/templates/devhub/personas/submit.html:13 src/olympia/editors/helpers.py:105 src/olympia/editors/templates/editors/base.html:26
+#: src/olympia/devhub/templates/devhub/personas/submit.html:13 src/olympia/editors/helpers.py:107 src/olympia/editors/templates/editors/base.html:26
 #: src/olympia/editors/templates/editors/performance.html:73 src/olympia/search/templates/search/personas.html:39 src/olympia/templates/menu_links.html:9
 msgid "Themes"
 msgstr ""
@@ -1326,7 +1327,7 @@ msgstr ""
 msgid "Highest Rated"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/mobile/home.html:74 src/olympia/amo/templates/amo/side_nav.html:5 src/olympia/amo/templates/amo/site_nav.html:27 src/olympia/amo/templates/amo/site_nav.html:57
+#: src/olympia/addons/templates/addons/mobile/home.html:74 src/olympia/amo/templates/amo/side_nav.html:5 src/olympia/amo/templates/amo/site_nav.html:27 src/olympia/amo/templates/amo/site_nav.html:55
 #: src/olympia/bandwagon/views.py:97 src/olympia/browse/views.py:57 src/olympia/browse/views.py:67 src/olympia/browse/templates/browse/personas/mobile/category_landing.html:65
 #: src/olympia/search/forms.py:15 src/olympia/search/forms.py:87
 msgid "Newest"
@@ -1340,90 +1341,90 @@ msgstr ""
 msgid "Theme Info &raquo;"
 msgstr ""
 
-#: src/olympia/amo/context_processors.py:39 src/olympia/devhub/templates/devhub/nav.html:43
+#: src/olympia/amo/context_processors.py:37 src/olympia/devhub/templates/devhub/nav.html:43
 msgid "Tools"
 msgstr ""
 
-#: src/olympia/amo/context_processors.py:48 src/olympia/discovery/templates/discovery/pane_account.html:8 src/olympia/users/templates/users/includes/navigation.html:2
+#: src/olympia/amo/context_processors.py:47 src/olympia/discovery/templates/discovery/pane_account.html:8 src/olympia/users/templates/users/includes/navigation.html:2
 msgid "My Profile"
 msgstr ""
 
-#: src/olympia/amo/context_processors.py:54 src/olympia/users/templates/users/edit.html:5 src/olympia/users/templates/users/includes/navigation.html:3
+#: src/olympia/amo/context_processors.py:53 src/olympia/users/templates/users/edit.html:5 src/olympia/users/templates/users/includes/navigation.html:3
 msgid "Account Settings"
 msgstr ""
 
-#: src/olympia/amo/context_processors.py:57 src/olympia/discovery/templates/discovery/pane_account.html:11 src/olympia/users/templates/users/profile.html:83
+#: src/olympia/amo/context_processors.py:56 src/olympia/discovery/templates/discovery/pane_account.html:11 src/olympia/users/templates/users/profile.html:83
 #: src/olympia/users/templates/users/includes/navigation.html:4
 msgid "My Collections"
 msgstr ""
 
-#: src/olympia/amo/context_processors.py:62 src/olympia/discovery/templates/discovery/pane_account.html:10 src/olympia/users/templates/users/includes/navigation.html:7
+#: src/olympia/amo/context_processors.py:61 src/olympia/discovery/templates/discovery/pane_account.html:10 src/olympia/users/templates/users/includes/navigation.html:7
 msgid "My Favorites"
 msgstr ""
 
-#: src/olympia/amo/context_processors.py:67 src/olympia/discovery/templates/discovery/pane_account.html:13 src/olympia/templates/impala/user_login.html:14
+#: src/olympia/amo/context_processors.py:66 src/olympia/discovery/templates/discovery/pane_account.html:13 src/olympia/templates/impala/user_login.html:14
 #: src/olympia/templates/mobile/header_auth.html:5
 msgid "Log out"
 msgstr ""
 
-#: src/olympia/amo/context_processors.py:72 src/olympia/devhub/templates/devhub/addons/dashboard.html:4
+#: src/olympia/amo/context_processors.py:71 src/olympia/devhub/templates/devhub/addons/dashboard.html:4
 msgid "Manage My Submissions"
 msgstr ""
 
-#: src/olympia/amo/context_processors.py:75 src/olympia/devhub/templates/devhub/nav.html:27 src/olympia/devhub/templates/devhub/addons/dashboard.html:25
+#: src/olympia/amo/context_processors.py:74 src/olympia/devhub/templates/devhub/nav.html:27 src/olympia/devhub/templates/devhub/addons/dashboard.html:25
 #: src/olympia/devhub/templates/devhub/addons/submit/base.html:4
 msgid "Submit a New Add-on"
 msgstr ""
 
-#: src/olympia/amo/context_processors.py:77 src/olympia/browse/templates/browse/personas/base.html:50 src/olympia/devhub/templates/devhub/index.html:24
+#: src/olympia/amo/context_processors.py:76 src/olympia/browse/templates/browse/personas/base.html:50 src/olympia/devhub/templates/devhub/index.html:24
 #: src/olympia/devhub/templates/devhub/addons/dashboard.html:29
 msgid "Submit a New Theme"
 msgstr ""
 
-#: src/olympia/amo/context_processors.py:79 src/olympia/amo/templates/amo/site_nav.html:87 src/olympia/devhub/helpers.py:36 src/olympia/devhub/helpers.py:68 src/olympia/devhub/helpers.py:102
+#: src/olympia/amo/context_processors.py:78 src/olympia/amo/templates/amo/site_nav.html:85 src/olympia/devhub/helpers.py:36 src/olympia/devhub/helpers.py:68 src/olympia/devhub/helpers.py:102
 #: src/olympia/templates/footer.html:6 src/olympia/templates/menu_links.html:14
 msgid "Developer Hub"
 msgstr ""
 
-#: src/olympia/amo/context_processors.py:83 src/olympia/devhub/views.py:1792
+#: src/olympia/amo/context_processors.py:81 src/olympia/devhub/views.py:1796
 msgid "Manage API Keys"
 msgstr ""
 
-#: src/olympia/amo/context_processors.py:88 src/olympia/editors/helpers.py:82 src/olympia/editors/helpers.py:102 src/olympia/editors/templates/editors/base.html:10
+#: src/olympia/amo/context_processors.py:86 src/olympia/editors/helpers.py:84 src/olympia/editors/helpers.py:104 src/olympia/editors/templates/editors/base.html:10
 msgid "Editor Tools"
 msgstr ""
 
-#: src/olympia/amo/context_processors.py:92
+#: src/olympia/amo/context_processors.py:90
 msgid "Admin Tools"
 msgstr ""
 
-#: src/olympia/amo/fields.py:15
+#: src/olympia/amo/fields.py:20
 msgid "Incorrect, please try again."
 msgstr ""
 
-#: src/olympia/amo/fields.py:16
+#: src/olympia/amo/fields.py:21
 msgid "Error verifying input, please try again."
 msgstr ""
 
-#: src/olympia/amo/fields.py:32
+#: src/olympia/amo/fields.py:37
 msgid "This must be a valid hex color code, such as #000000."
 msgstr ""
 
-#: src/olympia/amo/fields.py:58
+#: src/olympia/amo/fields.py:63
 msgid "Enter at least one value."
 msgstr ""
 
-#: src/olympia/amo/helpers.py:162 src/olympia/amo/templates/amo/site_nav.html:61 src/olympia/bandwagon/templates/bandwagon/add.html:9
+#: src/olympia/amo/helpers.py:162 src/olympia/amo/templates/amo/site_nav.html:59 src/olympia/bandwagon/templates/bandwagon/add.html:9
 #: src/olympia/bandwagon/templates/bandwagon/collection_detail.html:15 src/olympia/bandwagon/templates/bandwagon/delete.html:9 src/olympia/bandwagon/templates/bandwagon/edit.html:15
 #: src/olympia/bandwagon/templates/bandwagon/user_listing.html:18 src/olympia/bandwagon/templates/bandwagon/user_listing.html:21
 #: src/olympia/bandwagon/templates/bandwagon/impala/collection_listing.html:12 src/olympia/bandwagon/templates/bandwagon/impala/collection_listing.html:20
 #: src/olympia/bandwagon/templates/bandwagon/impala/collection_listing.html:24 src/olympia/bandwagon/templates/bandwagon/impala/collection_sidebar.html:3
 #: src/olympia/bandwagon/templates/bandwagon/includes/collection_sidebar.html:2 src/olympia/bandwagon/templates/bandwagon/mobile/collection_listing.html:3
-#: src/olympia/stats/templates/stats/stats.html:77 src/olympia/templates/menu_links.html:12
+#: src/olympia/stats/templates/stats/stats.html:33 src/olympia/templates/menu_links.html:12
 msgid "Collections"
 msgstr ""
 
-#: src/olympia/amo/helpers.py:171 src/olympia/amo/templates/amo/site_nav.html:85 src/olympia/browse/templates/browse/language_tools.html:3
+#: src/olympia/amo/helpers.py:171 src/olympia/amo/templates/amo/site_nav.html:83 src/olympia/browse/templates/browse/language_tools.html:3
 msgid "Dictionaries & Language Packs"
 msgstr ""
 
@@ -1575,8 +1576,8 @@ msgstr ""
 msgid "Comment on {addon} {version}."
 msgstr ""
 
-#: src/olympia/amo/log.py:236 src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:19 src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:47
-#: src/olympia/editors/helpers.py:511 src/olympia/editors/templates/editors/themes/history_table.html:11
+#: src/olympia/amo/log.py:236 src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:17 src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:45
+#: src/olympia/editors/helpers.py:584 src/olympia/editors/templates/editors/themes/history_table.html:11
 msgid "Comment"
 msgstr ""
 
@@ -1899,7 +1900,7 @@ msgstr ""
 #: src/olympia/amo/templates/amo/mobile/paginator.html:14 src/olympia/amo/templates/amo/mobile/paginator.html:16 src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:51
 #: src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:65 src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:78
 #: src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:91 src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:104
-#: src/olympia/discovery/templates/discovery/pane.html:45 src/olympia/discovery/templates/discovery/addons/detail.html:39 src/olympia/stats/templates/stats/stats.html:167
+#: src/olympia/discovery/templates/discovery/pane.html:45 src/olympia/discovery/templates/discovery/addons/detail.html:39 src/olympia/stats/templates/stats/stats.html:169
 msgid "Next"
 msgstr ""
 
@@ -1931,7 +1932,7 @@ msgid ""
 msgstr ""
 
 #: src/olympia/amo/templates/amo/side_nav.html:4 src/olympia/amo/templates/amo/side_nav.html:12 src/olympia/amo/templates/amo/site_nav.html:4 src/olympia/amo/templates/amo/site_nav.html:26
-#: src/olympia/browse/views.py:56 src/olympia/browse/views.py:66 src/olympia/browse/views.py:237 src/olympia/browse/views.py:282 src/olympia/search/forms.py:86
+#: src/olympia/browse/views.py:56 src/olympia/browse/views.py:66 src/olympia/browse/views.py:204 src/olympia/browse/views.py:249 src/olympia/search/forms.py:86
 msgid "Top Rated"
 msgstr ""
 
@@ -1945,38 +1946,38 @@ msgstr ""
 msgid "Extensions"
 msgstr ""
 
-#: src/olympia/amo/templates/amo/site_nav.html:45
+#: src/olympia/amo/templates/amo/site_nav.html:44
 msgid "Want more customization? Try <b>Complete Themes</b>"
 msgstr ""
 
-#: src/olympia/amo/templates/amo/site_nav.html:56 src/olympia/bandwagon/views.py:96
+#: src/olympia/amo/templates/amo/site_nav.html:54 src/olympia/bandwagon/views.py:96
 msgid "Most Followers"
 msgstr ""
 
-#: src/olympia/amo/templates/amo/site_nav.html:68 src/olympia/bandwagon/templates/bandwagon/impala/collection_sidebar.html:16
+#: src/olympia/amo/templates/amo/site_nav.html:66 src/olympia/bandwagon/templates/bandwagon/impala/collection_sidebar.html:16
 #: src/olympia/bandwagon/templates/bandwagon/includes/collection_sidebar.html:18
 msgid "Collections I've Made"
 msgstr ""
 
-#: src/olympia/amo/templates/amo/site_nav.html:70 src/olympia/bandwagon/templates/bandwagon/user_listing.html:4 src/olympia/bandwagon/templates/bandwagon/impala/collection_sidebar.html:13
+#: src/olympia/amo/templates/amo/site_nav.html:68 src/olympia/bandwagon/templates/bandwagon/user_listing.html:4 src/olympia/bandwagon/templates/bandwagon/impala/collection_sidebar.html:13
 #: src/olympia/bandwagon/templates/bandwagon/includes/collection_sidebar.html:15
 msgid "Collections I'm Following"
 msgstr ""
 
-#: src/olympia/amo/templates/amo/site_nav.html:73 src/olympia/bandwagon/templates/bandwagon/impala/collection_sidebar.html:18
-#: src/olympia/bandwagon/templates/bandwagon/includes/collection_sidebar.html:20 src/olympia/users/models.py:512
+#: src/olympia/amo/templates/amo/site_nav.html:71 src/olympia/bandwagon/templates/bandwagon/impala/collection_sidebar.html:18
+#: src/olympia/bandwagon/templates/bandwagon/includes/collection_sidebar.html:20 src/olympia/users/models.py:521
 msgid "My Favorite Add-ons"
 msgstr ""
 
-#: src/olympia/amo/templates/amo/site_nav.html:78
+#: src/olympia/amo/templates/amo/site_nav.html:76
 msgid "More&hellip;"
 msgstr ""
 
-#: src/olympia/amo/templates/amo/site_nav.html:82
+#: src/olympia/amo/templates/amo/site_nav.html:80
 msgid "Add-ons for Mobile"
 msgstr ""
 
-#: src/olympia/amo/templates/amo/site_nav.html:86 src/olympia/browse/feeds.py:207 src/olympia/browse/templates/browse/search_tools.html:3 src/olympia/constants/base.py:176
+#: src/olympia/amo/templates/amo/site_nav.html:84 src/olympia/browse/feeds.py:207 src/olympia/browse/templates/browse/search_tools.html:3 src/olympia/constants/base.py:176
 #: src/olympia/templates/menu_links.html:10
 msgid "Search Tools"
 msgstr ""
@@ -1992,7 +1993,7 @@ msgid "Jump to first page"
 msgstr ""
 
 #: src/olympia/amo/templates/amo/impala/paginator.html:22 src/olympia/amo/templates/amo/mobile/impala_paginator.html:12 src/olympia/discovery/templates/discovery/pane.html:44
-#: src/olympia/discovery/templates/discovery/addons/detail.html:38 src/olympia/stats/templates/stats/stats.html:164
+#: src/olympia/discovery/templates/discovery/addons/detail.html:38 src/olympia/stats/templates/stats/stats.html:166
 msgid "Previous"
 msgstr ""
 
@@ -2015,30 +2016,49 @@ msgid_plural "Page {n}"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/olympia/amo/templates/services/install.html:38
-#, python-format
-msgid "If you are not prompted to install %(addon_name)s in a moment, please <a href=\"%(addon_xpi)s\">click here</a>."
-msgstr ""
-
-#: src/olympia/amo/tests/test_messages.py:57 src/olympia/amo/tests/test_messages.py:58 src/olympia/reviews/forms.py:25 src/olympia/reviews/forms.py:50 src/olympia/reviews/templates/reviews/add.html:56
+#: src/olympia/amo/tests/test_messages.py:56 src/olympia/amo/tests/test_messages.py:57 src/olympia/reviews/forms.py:25 src/olympia/reviews/forms.py:50 src/olympia/reviews/templates/reviews/add.html:56
 #: src/olympia/reviews/templates/reviews/reply.html:30
 msgid "Title"
 msgstr ""
 
-#: src/olympia/amo/tests/test_messages.py:57 src/olympia/amo/tests/test_messages.py:58
+#: src/olympia/amo/tests/test_messages.py:56 src/olympia/amo/tests/test_messages.py:57
 msgid "Body"
 msgstr ""
 
-#: src/olympia/amo/tests/test_messages.py:59
+#: src/olympia/amo/tests/test_messages.py:58
 msgid "Another Title"
 msgstr ""
 
-#: src/olympia/amo/tests/test_messages.py:59
+#: src/olympia/amo/tests/test_messages.py:58
 msgid "Another Body"
 msgstr ""
 
-#: src/olympia/api/views.py:255
-msgid "Not implemented yet."
+#: src/olympia/api/authentication.py:76
+msgid "Signature has expired."
+msgstr ""
+
+#: src/olympia/api/authentication.py:79
+msgid "Error decoding signature."
+msgstr ""
+
+#: src/olympia/api/authentication.py:82
+msgid "Invalid JWT Token."
+msgstr ""
+
+#: src/olympia/api/authentication.py:130
+msgid "Invalid Authorization header. No credentials provided."
+msgstr ""
+
+#: src/olympia/api/authentication.py:133
+msgid "Invalid Authorization header. Credentials string should not contain spaces."
+msgstr ""
+
+#: src/olympia/api/fields.py:29
+msgid "The field must have a length of at least {num} characters."
+msgstr ""
+
+#: src/olympia/api/fields.py:31
+msgid "The language code {lang_code} is invalid."
 msgstr ""
 
 #: src/olympia/applications/views.py:39 src/olympia/applications/templates/applications/appversions.html:3
@@ -2057,7 +2077,7 @@ msgstr ""
 msgid "Add-ons submitted to Mozilla Add-ons must have a manifest file with at least one of the below applications supported. Only the versions listed below are allowed for these applications."
 msgstr ""
 
-#: src/olympia/applications/templates/applications/appversions.html:25
+#: src/olympia/applications/templates/applications/appversions.html:25 src/olympia/editors/helpers.py:361
 msgid "GUID"
 msgstr ""
 
@@ -2171,8 +2191,8 @@ msgstr ""
 msgid "Remove from favorites"
 msgstr ""
 
-#: src/olympia/bandwagon/views.py:98 src/olympia/bandwagon/views.py:191 src/olympia/browse/views.py:58 src/olympia/browse/views.py:69 src/olympia/browse/views.py:458 src/olympia/devhub/views.py:74
-#: src/olympia/devhub/views.py:82 src/olympia/devhub/templates/devhub/addons/edit/basic.html:20 src/olympia/editors/templates/editors/leaderboard.html:24
+#: src/olympia/bandwagon/views.py:98 src/olympia/bandwagon/views.py:191 src/olympia/browse/views.py:58 src/olympia/browse/views.py:69 src/olympia/browse/views.py:425 src/olympia/devhub/views.py:72
+#: src/olympia/devhub/views.py:80 src/olympia/devhub/templates/devhub/addons/edit/basic.html:20 src/olympia/editors/templates/editors/leaderboard.html:24
 #: src/olympia/editors/templates/editors/themes/queue_list.html:48 src/olympia/search/forms.py:17 src/olympia/search/forms.py:89 src/olympia/users/templates/users/vcard.html:5
 msgid "Name"
 msgstr ""
@@ -2181,7 +2201,7 @@ msgstr ""
 msgid "Recently Popular"
 msgstr ""
 
-#: src/olympia/bandwagon/views.py:189 src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:18
+#: src/olympia/bandwagon/views.py:189 src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:16
 msgid "Added"
 msgstr ""
 
@@ -2195,7 +2215,7 @@ msgstr ""
 
 #: src/olympia/bandwagon/views.py:316
 #, python-format
-msgid "Your new collection is shown below. You can <ahref=\"%(url)s\">edit additional settings</a> if you'dlike."
+msgid "Your new collection is shown below. You can <a href=\"%(url)s\">edit additional settings</a> if you'd like."
 msgstr ""
 
 #: src/olympia/bandwagon/views.py:322
@@ -2323,8 +2343,8 @@ msgid_plural "%(num)s Add-ons in this Collection"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/olympia/bandwagon/templates/bandwagon/collection_detail.html:125 src/olympia/compat/templates/compat/index.html:25 src/olympia/compat/templates/compat/reporter_detail.html:29
-#: src/olympia/files/templates/files/viewer.html:29 src/olympia/templates/amo_footer.html:17 src/olympia/templates/includes/lang_switcher.html:10
+#: src/olympia/bandwagon/templates/bandwagon/collection_detail.html:125 src/olympia/compat/templates/compat/reporter_detail.html:29 src/olympia/files/templates/files/viewer.html:29
+#: src/olympia/templates/amo_footer.html:17 src/olympia/templates/includes/lang_switcher.html:10
 msgid "Go"
 msgstr ""
 
@@ -2491,7 +2511,7 @@ msgid "Remove this user as a contributor"
 msgstr ""
 
 #: src/olympia/bandwagon/templates/bandwagon/edit_contributors.html:18 src/olympia/bandwagon/templates/bandwagon/edit_contributors.html:43
-#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:20 src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:48
+#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:18 src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:46
 #: src/olympia/devhub/templates/devhub/addons/ajax_compat_update.html:19
 msgid "Remove"
 msgstr ""
@@ -2539,7 +2559,7 @@ msgid "<b>Warning:</b> By changing the owner of this collection, you will no lon
 msgstr ""
 
 #: src/olympia/bandwagon/templates/bandwagon/edit_contributors.html:83 src/olympia/devhub/templates/devhub/addons/forms_shared/media.html:157
-#: src/olympia/devhub/templates/devhub/addons/submit/describe.html:69 src/olympia/devhub/templates/devhub/addons/submit/license.html:60 src/olympia/devhub/templates/devhub/addons/submit/upload.html:78
+#: src/olympia/devhub/templates/devhub/addons/submit/describe.html:69 src/olympia/devhub/templates/devhub/addons/submit/license.html:60 src/olympia/devhub/templates/devhub/addons/submit/upload.html:70
 #: src/olympia/devhub/templates/devhub/payments/tier.html:17 src/olympia/editors/templates/editors/themes/themes.html:111 src/olympia/editors/templates/editors/themes/themes.html:128
 #: src/olympia/editors/templates/editors/themes/themes.html:134 src/olympia/editors/templates/editors/themes/themes.html:141 src/olympia/users/templates/users/fxa_migration_prompt_content.html:10
 #: src/olympia/users/templates/users/login_form.html:42 src/olympia/users/templates/users/mobile/login.html:57
@@ -2622,31 +2642,31 @@ msgid "Add-ons in Your Collection"
 msgstr ""
 
 #: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:4
-msgid ""
-"To include an add-on in this collection, enter its name in the box below and hit enter.  You can also use the <strong>Add to Collection</strong> links throughout the site to include add-ons later."
+msgid "To include an add-on in this collection, enter its name in the box below and hit enter."
 msgstr ""
 
-#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:17 src/olympia/constants/base.py:400 src/olympia/devhub/templates/devhub/addons/activity.html:62
+#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:15 src/olympia/constants/base.py:400 src/olympia/devhub/templates/devhub/addons/activity.html:62
+#: src/olympia/editors/helpers.py:273 src/olympia/editors/helpers.py:360
 msgid "Add-on"
 msgstr ""
 
-#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:26
+#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:24
 msgid "Enter the name of the add-on to include"
 msgstr ""
 
-#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:28
+#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:26
 msgid "Add to Collection"
 msgstr ""
 
-#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:45 src/olympia/editors/helpers.py:936 src/olympia/editors/helpers.py:956
+#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:43 src/olympia/editors/helpers.py:1016 src/olympia/editors/helpers.py:1036
 msgid "Pending"
 msgstr ""
 
-#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:47
+#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:45
 msgid "Add a comment"
 msgstr ""
 
-#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:48
+#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:46
 msgid "Remove this add-on from the collection"
 msgstr ""
 
@@ -2753,12 +2773,12 @@ msgstr ""
 msgid "Most Users"
 msgstr ""
 
-#: src/olympia/browse/views.py:61 src/olympia/browse/views.py:72 src/olympia/browse/views.py:279 src/olympia/browse/templates/browse/personas/mobile/category_landing.html:63
+#: src/olympia/browse/views.py:61 src/olympia/browse/views.py:72 src/olympia/browse/views.py:246 src/olympia/browse/templates/browse/personas/mobile/category_landing.html:63
 #: src/olympia/discovery/templates/discovery/pane.html:67 src/olympia/search/forms.py:92
 msgid "Up & Coming"
 msgstr ""
 
-#: src/olympia/browse/views.py:460 src/olympia/devhub/views.py:76 src/olympia/devhub/views.py:83 src/olympia/discovery/templates/discovery/addons/detail.html:66
+#: src/olympia/browse/views.py:427 src/olympia/devhub/views.py:74 src/olympia/devhub/views.py:81 src/olympia/discovery/templates/discovery/addons/detail.html:66
 msgid "Created"
 msgstr ""
 
@@ -2946,8 +2966,8 @@ msgid_plural "See all %(cnt)s extensions in %(name)s &raquo;"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/olympia/browse/templates/browse/mobile/extensions.html:13 src/olympia/compat/templates/compat/index.html:82 src/olympia/devhub/templates/devhub/devhub_search.html:24
-#: src/olympia/devhub/templates/devhub/addons/activity.html:47 src/olympia/search/templates/search/no_results.html:4 src/olympia/search/templates/search/mobile/results.html:36
+#: src/olympia/browse/templates/browse/mobile/extensions.html:13 src/olympia/devhub/templates/devhub/devhub_search.html:24 src/olympia/devhub/templates/devhub/addons/activity.html:47
+#: src/olympia/search/templates/search/no_results.html:4 src/olympia/search/templates/search/mobile/results.html:36
 msgid "No results found."
 msgstr ""
 
@@ -3032,7 +3052,7 @@ msgstr ""
 msgid "All"
 msgstr ""
 
-#: src/olympia/compat/forms.py:22 src/olympia/search/views.py:525
+#: src/olympia/compat/forms.py:22 src/olympia/editors/templates/editors/base.html:69 src/olympia/search/views.py:518
 msgid "All Add-ons"
 msgstr ""
 
@@ -3042,53 +3062,6 @@ msgstr ""
 
 #: src/olympia/compat/forms.py:24
 msgid "Non-binary"
-msgstr ""
-
-#. Review points sources other than add-ons and themes.
-#: src/olympia/compat/views.py:87 src/olympia/constants/base.py:388 src/olympia/devhub/forms.py:162 src/olympia/editors/templates/editors/performance.html:75
-msgid "Other"
-msgstr ""
-
-#: src/olympia/compat/templates/compat/index.html:4
-msgid "Add-on Compatibility Report for {app} {version}"
-msgstr ""
-
-#: src/olympia/compat/templates/compat/index.html:11
-msgid "{app} {version} Compatibility"
-msgstr ""
-
-#: src/olympia/compat/templates/compat/index.html:17
-#, python-format
-msgid "Top 95%% compatible with previous version"
-msgstr ""
-
-#: src/olympia/compat/templates/compat/index.html:18
-#, python-format
-msgid "Top 95%% of all add-ons"
-msgstr ""
-
-#: src/olympia/compat/templates/compat/index.html:19
-msgid "All active add-ons"
-msgstr ""
-
-#: src/olympia/compat/templates/compat/index.html:23 src/olympia/constants/base.py:401
-msgid "App"
-msgstr ""
-
-#: src/olympia/compat/templates/compat/index.html:55
-msgid "Details for add-ons compatible with previous version:"
-msgstr ""
-
-#: src/olympia/compat/templates/compat/index.html:57
-msgid "Show all versions"
-msgstr ""
-
-#: src/olympia/compat/templates/compat/index.html:59
-msgid "Details for add-ons compatible with all versions:"
-msgstr ""
-
-#: src/olympia/compat/templates/compat/index.html:61
-msgid "Show previous version only"
 msgstr ""
 
 #: src/olympia/compat/templates/compat/reporter.html:3
@@ -3142,8 +3115,8 @@ msgstr ""
 msgid "Report Type"
 msgstr ""
 
-#: src/olympia/compat/templates/compat/reporter_detail.html:47 src/olympia/devhub/forms.py:784 src/olympia/devhub/templates/devhub/addons/ajax_compat_update.html:17 src/olympia/editors/forms.py:108
-#: src/olympia/zadmin/forms.py:45
+#: src/olympia/compat/templates/compat/reporter_detail.html:47 src/olympia/devhub/forms.py:785 src/olympia/devhub/templates/devhub/addons/ajax_compat_update.html:17 src/olympia/editors/forms.py:108
+#: src/olympia/editors/forms.py:248 src/olympia/zadmin/forms.py:45
 msgid "Application"
 msgstr ""
 
@@ -3231,7 +3204,8 @@ msgstr ""
 msgid "Preliminarily Reviewed and Awaiting Full Review"
 msgstr ""
 
-#: src/olympia/constants/base.py:33 src/olympia/editors/helpers.py:924 src/olympia/editors/templates/editors/themes/history_table.html:34
+#: src/olympia/constants/base.py:33 src/olympia/editors/forms.py:258 src/olympia/editors/helpers.py:73 src/olympia/editors/helpers.py:1004
+#: src/olympia/editors/templates/editors/themes/history_table.html:34
 msgid "Deleted"
 msgstr ""
 
@@ -3328,6 +3302,11 @@ msgstr ""
 msgid "Ask before users can download this add-on"
 msgstr ""
 
+#. Review points sources other than add-ons and themes.
+#: src/olympia/constants/base.py:388 src/olympia/devhub/forms.py:162 src/olympia/editors/templates/editors/performance.html:75
+msgid "Other"
+msgstr ""
+
 #: src/olympia/constants/base.py:389
 msgid "Exception"
 msgstr ""
@@ -3338,6 +3317,10 @@ msgstr ""
 
 #: src/olympia/constants/base.py:391
 msgid "Change"
+msgstr ""
+
+#: src/olympia/constants/base.py:401
+msgid "App"
 msgstr ""
 
 #: src/olympia/constants/base.py:402
@@ -3488,7 +3471,7 @@ msgstr ""
 msgid "Duplicate"
 msgstr ""
 
-#: src/olympia/constants/editors.py:17 src/olympia/editors/helpers.py:502 src/olympia/editors/templates/editors/themes/queue.html:71 src/olympia/editors/templates/editors/themes/themes.html:94
+#: src/olympia/constants/editors.py:17 src/olympia/editors/helpers.py:575 src/olympia/editors/templates/editors/themes/queue.html:71 src/olympia/editors/templates/editors/themes/themes.html:94
 msgid "Reject"
 msgstr ""
 
@@ -3588,7 +3571,7 @@ msgstr ""
 msgid "Android"
 msgstr ""
 
-#: src/olympia/core/apps.py:19
+#: src/olympia/core/apps.py:21
 msgid "Core"
 msgstr ""
 
@@ -3722,7 +3705,7 @@ msgid "Submit my add-on for manual review."
 msgstr ""
 
 #: src/olympia/devhub/forms.py:537
-msgid "Do not list my add-on on this site (beta)"
+msgid "Do not list my add-on on this site"
 msgstr ""
 
 #: src/olympia/devhub/forms.py:538
@@ -3755,46 +3738,46 @@ msgstr ""
 
 #: src/olympia/devhub/forms.py:592
 #, python-format
-msgid "Version %s already exists"
+msgid "Version %s already exists, or was uploaded before."
 msgstr ""
 
-#: src/olympia/devhub/forms.py:604
+#: src/olympia/devhub/forms.py:605
 msgid "Select a valid choice. That choice is not one of the available choices."
 msgstr ""
 
-#: src/olympia/devhub/forms.py:610
+#: src/olympia/devhub/forms.py:611
 msgid "A file with a version ending with a|alpha|b|beta and an optional number is detected as beta."
 msgstr ""
 
-#: src/olympia/devhub/forms.py:633
+#: src/olympia/devhub/forms.py:634
 msgid "You cannot upload any more files for this version."
 msgstr ""
 
-#: src/olympia/devhub/forms.py:639
+#: src/olympia/devhub/forms.py:640
 msgid "Version doesn't match"
 msgstr ""
 
-#: src/olympia/devhub/forms.py:668
+#: src/olympia/devhub/forms.py:669
 msgid "You cannot delete a file once the review process has started.  You must delete the whole version."
 msgstr ""
 
-#: src/olympia/devhub/forms.py:688
+#: src/olympia/devhub/forms.py:689
 msgid "The platform All cannot be combined with specific platforms."
 msgstr ""
 
-#: src/olympia/devhub/forms.py:693
+#: src/olympia/devhub/forms.py:694
 msgid "A platform can only be chosen once."
 msgstr ""
 
-#: src/olympia/devhub/forms.py:706
+#: src/olympia/devhub/forms.py:707
 msgid "A review type must be selected."
 msgstr ""
 
-#: src/olympia/devhub/forms.py:788 src/olympia/editors/forms.py:114 src/olympia/zadmin/forms.py:49 src/olympia/zadmin/forms.py:52
+#: src/olympia/devhub/forms.py:789 src/olympia/editors/forms.py:114 src/olympia/editors/forms.py:254 src/olympia/zadmin/forms.py:49 src/olympia/zadmin/forms.py:52
 msgid "Select an application first"
 msgstr ""
 
-#: src/olympia/devhub/forms.py:840
+#: src/olympia/devhub/forms.py:841
 msgid "There cannot be more than 3 required add-ons."
 msgstr ""
 
@@ -3828,76 +3811,76 @@ msgstr[1] ""
 msgid "Review"
 msgstr ""
 
-#: src/olympia/devhub/tasks.py:551
+#: src/olympia/devhub/tasks.py:583
 #, python-format
 msgid "%s responded with %s (%s)."
 msgstr ""
 
-#: src/olympia/devhub/tasks.py:555
+#: src/olympia/devhub/tasks.py:587
 #, python-format
 msgid "Connection to \"%s\" timed out."
 msgstr ""
 
-#: src/olympia/devhub/tasks.py:557
+#: src/olympia/devhub/tasks.py:589
 #, python-format
 msgid "Could not contact host at \"%s\"."
 msgstr ""
 
-#: src/olympia/devhub/utils.py:104
+#: src/olympia/devhub/utils.py:105
 #, python-format
 msgid "Validation generated too many errors/warnings so %s messages were truncated. After addressing the visible messages, you'll be able to see the others."
 msgstr ""
 
-#: src/olympia/devhub/views.py:183
+#: src/olympia/devhub/views.py:181
 msgid "All My Add-ons"
 msgstr ""
 
-#: src/olympia/devhub/views.py:210
+#: src/olympia/devhub/views.py:208
 msgid "All Activity"
 msgstr ""
 
-#: src/olympia/devhub/views.py:211
+#: src/olympia/devhub/views.py:209
 msgid "Add-on Updates"
 msgstr ""
 
-#: src/olympia/devhub/views.py:212
+#: src/olympia/devhub/views.py:210
 msgid "Add-on Status"
 msgstr ""
 
-#: src/olympia/devhub/views.py:213
+#: src/olympia/devhub/views.py:211
 msgid "User Collections"
 msgstr ""
 
-#: src/olympia/devhub/views.py:214 src/olympia/devhub/templates/devhub/docs/policies-maintenance.html:68 src/olympia/pages/templates/pages/dev_faq.html:38
+#: src/olympia/devhub/views.py:212 src/olympia/devhub/templates/devhub/docs/policies-maintenance.html:68 src/olympia/pages/templates/pages/dev_faq.html:38
 #: src/olympia/pages/templates/pages/dev_faq.html:484
 msgid "User Reviews"
 msgstr ""
 
-#: src/olympia/devhub/views.py:327 src/olympia/devhub/views.py:331 src/olympia/devhub/views.py:484 src/olympia/devhub/views.py:513 src/olympia/devhub/views.py:564 src/olympia/devhub/views.py:1150
+#: src/olympia/devhub/views.py:325 src/olympia/devhub/views.py:329 src/olympia/devhub/views.py:484 src/olympia/devhub/views.py:513 src/olympia/devhub/views.py:564 src/olympia/devhub/views.py:1156
 msgid "Changes successfully saved."
 msgstr ""
 
-#: src/olympia/devhub/views.py:334 src/olympia/devhub/views.py:1631
+#: src/olympia/devhub/views.py:332 src/olympia/devhub/views.py:1637
 msgid "Please check the form for errors."
 msgstr ""
 
-#: src/olympia/devhub/views.py:346
+#: src/olympia/devhub/views.py:344
 msgid "Add-on cannot be deleted. Disable this add-on instead."
 msgstr ""
 
-#: src/olympia/devhub/views.py:356
+#: src/olympia/devhub/views.py:354
 msgid "Theme deleted."
 msgstr ""
 
-#: src/olympia/devhub/views.py:356
+#: src/olympia/devhub/views.py:354
 msgid "Add-on deleted."
 msgstr ""
 
-#: src/olympia/devhub/views.py:362
+#: src/olympia/devhub/views.py:360
 msgid "URL name was incorrect. Theme was not deleted."
 msgstr ""
 
-#: src/olympia/devhub/views.py:367
+#: src/olympia/devhub/views.py:365
 msgid "URL name was incorrect. Add-on was not deleted."
 msgstr ""
 
@@ -3925,7 +3908,7 @@ msgstr ""
 msgid "Check Add-on Compatibility"
 msgstr ""
 
-#: src/olympia/devhub/views.py:808 src/olympia/signing/views.py:90
+#: src/olympia/devhub/views.py:808 src/olympia/signing/views.py:95
 msgid "You cannot submit this type of add-on"
 msgstr ""
 
@@ -3955,33 +3938,33 @@ msgstr ""
 msgid "There was an error uploading your preview."
 msgstr ""
 
-#: src/olympia/devhub/views.py:1189
+#: src/olympia/devhub/views.py:1195
 #, python-format
 msgid "Version %s disabled."
 msgstr ""
 
-#: src/olympia/devhub/views.py:1193
+#: src/olympia/devhub/views.py:1199
 #, python-format
 msgid "Version %s deleted."
 msgstr ""
 
-#: src/olympia/devhub/views.py:1203
+#: src/olympia/devhub/views.py:1209
 msgid "This upload has failed validation, and may lack complete validation results. Please take due care when reviewing it."
 msgstr ""
 
-#: src/olympia/devhub/views.py:1677
+#: src/olympia/devhub/views.py:1683
 msgid "Preliminary Review Requested."
 msgstr ""
 
-#: src/olympia/devhub/views.py:1678
+#: src/olympia/devhub/views.py:1684
 msgid "Full Review Requested."
 msgstr ""
 
-#: src/olympia/devhub/views.py:1779
+#: src/olympia/devhub/views.py:1783
 msgid "Your old credentials were revoked and are no longer valid. Be sure to update all API clients with the new credentials."
 msgstr ""
 
-#: src/olympia/devhub/views.py:1797
+#: src/olympia/devhub/views.py:1801
 msgid "New API key created"
 msgstr ""
 
@@ -4011,7 +3994,7 @@ msgstr ""
 msgid "{0} :: Search"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/devhub_search.html:6 src/olympia/devhub/templates/devhub/search.html:8 src/olympia/editors/forms.py:435 src/olympia/editors/forms.py:437
+#: src/olympia/devhub/templates/devhub/devhub_search.html:6 src/olympia/devhub/templates/devhub/search.html:8 src/olympia/editors/forms.py:534 src/olympia/editors/forms.py:536
 #: src/olympia/editors/templates/editors/queue.html:27 src/olympia/editors/templates/editors/themes/queue_list.html:14 src/olympia/search/templates/search/collections.html:17
 #: src/olympia/search/templates/search/personas.html:18 src/olympia/search/templates/search/results.html:18 src/olympia/search/templates/search/mobile/results.html:8
 #: src/olympia/templates/search.html:14 src/olympia/templates/impala/search.html:18
@@ -4071,12 +4054,12 @@ msgstr ""
 msgid "Start Making Add-ons"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/index.html:86 src/olympia/devhub/templates/devhub/addons/listing/items.html:25 src/olympia/devhub/templates/devhub/includes/addon_details.html:15
+#: src/olympia/devhub/templates/devhub/index.html:86 src/olympia/devhub/templates/devhub/addons/listing/items.html:25 src/olympia/devhub/templates/devhub/includes/addon_details.html:20
 #: src/olympia/devhub/templates/devhub/personas/edit.html:43
 msgid "Status:"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/index.html:90 src/olympia/devhub/templates/devhub/includes/addon_details.html:100
+#: src/olympia/devhub/templates/devhub/index.html:90 src/olympia/devhub/templates/devhub/includes/addon_details.html:87
 msgid "Visibility:"
 msgstr ""
 
@@ -4084,11 +4067,11 @@ msgstr ""
 msgid "Latest Version:"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/index.html:109 src/olympia/devhub/templates/devhub/includes/addon_details.html:145 src/olympia/devhub/templates/devhub/personas/edit.html:49
+#: src/olympia/devhub/templates/devhub/index.html:109 src/olympia/devhub/templates/devhub/includes/addon_details.html:131 src/olympia/devhub/templates/devhub/personas/edit.html:49
 msgid "Queue Position:"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/index.html:110 src/olympia/devhub/templates/devhub/includes/addon_details.html:146 src/olympia/devhub/templates/devhub/personas/edit.html:50
+#: src/olympia/devhub/templates/devhub/index.html:110 src/olympia/devhub/templates/devhub/includes/addon_details.html:132 src/olympia/devhub/templates/devhub/personas/edit.html:50
 #, python-format
 msgid "%(position)s of %(total)s"
 msgstr ""
@@ -4190,16 +4173,6 @@ msgstr ""
 msgid "Do you want your add-on to be distributed on this site?"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/validate_addon.html:49 src/olympia/devhub/templates/devhub/addons/submit/upload.html:30 src/olympia/devhub/templates/devhub/versions/add_file_modal.html:14
-#: src/olympia/devhub/templates/devhub/versions/add_file_modal.html:53 src/olympia/devhub/templates/devhub/versions/list.html:298
-msgid "Warning:"
-msgstr ""
-
-#: src/olympia/devhub/templates/devhub/validate_addon.html:50 src/olympia/devhub/templates/devhub/addons/submit/upload.html:31
-#, python-format
-msgid "Submission of unlisted add-ons for signing is currently in an open beta. Please <a href=\"%(url)s\" target=\"_blank\">report any bugs</a> that you encounter."
-msgstr ""
-
 #. first parameter is a filename like lorem-ipsum-1.0.2.xpi
 #: src/olympia/devhub/templates/devhub/validation.html:5
 msgid "Validation Results for {0}"
@@ -4274,7 +4247,7 @@ msgstr ""
 msgid "Update Compatibility"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/addons/ajax_compat_update.html:4
+#: src/olympia/devhub/templates/devhub/addons/ajax_compat_update.html:4 src/olympia/devhub/templates/devhub/versions/edit.html:45
 msgid "Adjusting application information here will allow users to install your add-on even if the install manifest in the package indicates that the add-on is incompatible."
 msgstr ""
 
@@ -4286,9 +4259,9 @@ msgstr ""
 msgid "Add Another Application&hellip;"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/addons/ajax_compat_update.html:38 src/olympia/devhub/templates/devhub/addons/owner.html:86 src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:46
-#: src/olympia/devhub/templates/devhub/versions/list.html:351 src/olympia/devhub/templates/devhub/versions/list.html:353 src/olympia/templates/impala/base.html:132
-#: src/olympia/templates/impala/base.html:143 src/olympia/templates/impala/base.html:161 src/olympia/templates/impala/base.html:171
+#: src/olympia/devhub/templates/devhub/addons/ajax_compat_update.html:38 src/olympia/devhub/templates/devhub/addons/owner.html:86 src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:45
+#: src/olympia/devhub/templates/devhub/versions/list.html:349 src/olympia/devhub/templates/devhub/versions/list.html:351 src/olympia/templates/impala/base.html:129
+#: src/olympia/templates/impala/base.html:140 src/olympia/templates/impala/base.html:158 src/olympia/templates/impala/base.html:168
 msgid "Close"
 msgstr ""
 
@@ -4322,7 +4295,7 @@ msgstr ""
 msgid "Manage Authors & License"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/addons/owner.html:29 src/olympia/editors/templates/editors/review.html:270
+#: src/olympia/devhub/templates/devhub/addons/owner.html:29 src/olympia/editors/helpers.py:362 src/olympia/editors/templates/editors/review.html:270
 msgid "Authors"
 msgstr ""
 
@@ -4391,17 +4364,11 @@ msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/basic.html:52
 msgid ""
-"A short explanation of your add-on's basic\n"
-"                          functionality that is displayed in search and browse\n"
-"                          listings, as well as at the top of your add-on's\n"
-"                          details page. It is only relevant for listed add-ons."
+"A short explanation of your add-on's basic functionality that is displayed in search and browse listings, as well as at the top of your add-on's details page. It is only relevant for listed add-ons."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/basic.html:73
-msgid ""
-"Categories are the primary way users browse through add-ons.\n"
-"                        Choose any that fit your add-on's functionality for the most\n"
-"                        exposure. It is only relevant for listed add-ons."
+msgid "Categories are the primary way users browse through add-ons. Choose any that fit your add-on's functionality for the most exposure. It is only relevant for listed add-ons."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/basic.html:90
@@ -4411,11 +4378,7 @@ msgid ""
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/basic.html:119
-msgid ""
-"Tags help users find your add-on and should be short\n"
-"                        descriptors such as tabs, toolbar, or twitter.  You\n"
-"                        may have a maximum of {0} tags. It is only relevant\n"
-"                        for listed add-ons."
+msgid "Tags help users find your add-on and should be short descriptors such as tabs, toolbar, or twitter. You may have a maximum of {0} tags. It is only relevant for listed add-ons."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/basic.html:129 src/olympia/devhub/templates/devhub/personas/edit.html:97 src/olympia/devhub/templates/devhub/personas/submit.html:46
@@ -4443,11 +4406,7 @@ msgid "Add-on Details for {0}"
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/details.html:22
-msgid ""
-"A longer explanation of features,\n"
-"                          functionality, and other relevant information. This\n"
-"                          field is only displayed on the add-on's details\n"
-"                          page. It is only relevant for listed add-ons."
+msgid "A longer explanation of features, functionality, and other relevant information. This field is only displayed on the add-on's details page. It is only relevant for listed add-ons."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/details.html:44 src/olympia/translations/templates/translations/trans-menu.html:13
@@ -4455,10 +4414,7 @@ msgid "Default Locale"
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/details.html:45
-msgid ""
-"Information about your add-on is displayed in this locale\n"
-"                        unless you override it with a locale-specific translation.\n"
-"                        It is only relevant for listed add-ons."
+msgid "Information about your add-on is displayed in this locale unless you override it with a locale-specific translation. It is only relevant for listed add-ons."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/details.html:61 src/olympia/users/forms.py:311 src/olympia/users/templates/users/edit.html:122 src/olympia/users/templates/users/register.html:57
@@ -4468,10 +4424,8 @@ msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/details.html:63
 msgid ""
-"If your add-on has another homepage, enter its\n"
-"                          address here. If your website is localized into other\n"
-"                          languages multiple translations of this field can be\n"
-"                          added. It is only relevant for listed add-ons."
+"If your add-on has another homepage, enter its address here. If your website is localized into other languages multiple translations of this field can be added. It is only relevant for listed add-"
+"ons."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/media.html:3
@@ -4489,19 +4443,14 @@ msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/support.html:22
 msgid ""
-"If you wish to display an e-mail address for support\n"
-"                          inquiries, enter it here. If you have different\n"
-"                          addresses for each language multiple translations of\n"
-"                          this field can be added. It is only relevant for\n"
-"                          listed add-ons."
+"If you wish to display an e-mail address for support inquiries, enter it here. If you have different addresses for each language multiple translations of this field can be added. It is only "
+"relevant for listed add-ons."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/support.html:45
 msgid ""
-"If your add-on has a support website or forum, enter\n"
-"                          its address here. If your website is localized into\n"
-"                          other languages, multiple translations of this field can\n"
-"                          be added. It is only relevant for listed add-ons."
+"If your add-on has a support website or forum, enter its address here. If your website is localized into other languages, multiple translations of this field can be added. It is only relevant for "
+"listed add-ons."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:6
@@ -4515,11 +4464,8 @@ msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:23
 msgid ""
-"Any information end users may want to know that isn't\n"
-"                          necessarily applicable to the add-on summary or description.\n"
-"                          Common uses include listing known major bugs, information on\n"
-"                          how to report bugs, anticipated release date of a new version,\n"
-"                          etc. It is only relevant for listed add-ons."
+"Any information end users may want to know that isn't necessarily applicable to the add-on summary or description. Common uses include listing known major bugs, information on how to report bugs, "
+"anticipated release date of a new version, etc. It is only relevant for listed add-ons."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:46
@@ -4531,9 +4477,7 @@ msgid "Add-on Flags"
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:69
-msgid ""
-"These flags are used to classify add-ons. It is only\n"
-"                        relevant for listed add-ons."
+msgid "These flags are used to classify add-ons. It is only relevant for listed add-ons."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:74
@@ -4549,9 +4493,7 @@ msgid "View Source?"
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:90
-msgid ""
-"Whether the source of your add-on can be displayed in our\n"
-"                        online viewer. It is only relevant for listed add-ons."
+msgid "Whether the source of your add-on can be displayed in our online viewer. It is only relevant for listed add-ons."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:94
@@ -4567,10 +4509,7 @@ msgid "Public Stats?"
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:102
-msgid ""
-"Whether the download and usage stats of your add-on can\n"
-"                        be displayed in our online viewer.\n"
-"                        It is only relevant for listed add-ons."
+msgid "Whether the download and usage stats of your add-on can be displayed in our online viewer. It is only relevant for listed add-ons."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:107
@@ -4586,10 +4525,7 @@ msgid "Upgrade SDK?"
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:116
-msgid ""
-"If selected, we will try to automatically upgrade your\n"
-"                        add-on when a new version of the SDK is released.\n"
-"                        It is only relevant for listed add-ons."
+msgid "If selected, we will try to automatically upgrade your add-on when a new version of the SDK is released. It is only relevant for listed add-ons."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:121
@@ -4640,10 +4576,8 @@ msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/forms_shared/media.html:16
 msgid ""
-"Upload an icon for your add-on or choose from one of ours. The\n"
-"                      icon is displayed nearly everywhere your add-on is. Uploaded images\n"
-"                      must be one of the following image types: .png, .jpg.\n"
-"                      It is only relevant for listed add-ons."
+"Upload an icon for your add-on or choose from one of ours. The icon is displayed nearly everywhere your add-on is. Uploaded images must be one of the following image types: .png, .jpg. It is only "
+"relevant for listed add-ons."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/forms_shared/media.html:25
@@ -4656,9 +4590,7 @@ msgid "32x32px"
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/forms_shared/media.html:39
-msgid ""
-"Used in listings of add-ons, like search results\n"
-"                            and featured add-ons."
+msgid "Used in listings of add-ons, like search results and featured add-ons."
 msgstr ""
 
 #. The size of the icon
@@ -4753,16 +4685,14 @@ msgid "Deleting your add-on will permanently remove it from the site and prevent
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:24
-msgid ""
-"Enter the following text confirm your decision:\n"
-"           {slug}"
+msgid "Enter the following text confirm your decision: {slug}"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:34
+#: src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:33
 msgid "Please tell us why you are deleting your theme:"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:36
+#: src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:35
 msgid "Please tell us why you are deleting your add-on:"
 msgstr ""
 
@@ -4799,8 +4729,8 @@ msgstr ""
 msgid "Daily statistics on downloads and users."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/addons/listing/item_actions.html:45 src/olympia/stats/templates/stats/stats.html:75 src/olympia/stats/templates/stats/stats.html:79
-#: src/olympia/stats/templates/stats/stats.html:81
+#: src/olympia/devhub/templates/devhub/addons/listing/item_actions.html:45 src/olympia/stats/templates/stats/stats.html:31 src/olympia/stats/templates/stats/stats.html:35
+#: src/olympia/stats/templates/stats/stats.html:37
 msgid "Statistics"
 msgstr ""
 
@@ -4919,10 +4849,7 @@ msgid "Your add-on has been submitted to the Full Review queue."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/submit/done.html:18
-msgid ""
-"You'll receive an email once it has been reviewed by an editor. In\n"
-"          the meantime, you and your friends can install it directly from its\n"
-"          details page:"
+msgid "You'll receive an email once it has been reviewed by an editor. In the meantime, you and your friends can install it directly from its details page:"
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/submit/done.html:27 src/olympia/devhub/templates/devhub/addons/submit/done.html:77 src/olympia/devhub/templates/devhub/personas/submit_done.html:16
@@ -5128,11 +5055,11 @@ msgstr ""
 msgid "Use the fields below to upload your add-on package and select any platform restrictions. After upload, a series of automated validation tests will be run on your file."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/addons/submit/upload.html:59 src/olympia/devhub/templates/devhub/versions/add_file_modal.html:39
+#: src/olympia/devhub/templates/devhub/addons/submit/upload.html:51 src/olympia/devhub/templates/devhub/versions/add_file_modal.html:28
 msgid "Which platforms is this file compatible with?"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/addons/submit/upload.html:67 src/olympia/devhub/templates/devhub/versions/add_file_modal.html:65
+#: src/olympia/devhub/templates/devhub/addons/submit/upload.html:59 src/olympia/devhub/templates/devhub/versions/add_file_modal.html:45
 msgid "Administrative overrides"
 msgstr ""
 
@@ -5242,8 +5169,8 @@ msgstr ""
 
 #: src/olympia/devhub/templates/devhub/docs/policies-contact.html:44
 msgid ""
-"If you've found a problem with the site, we'd love to fix it. Please <a href=\"https://github.com/mozilla/olympia/issues\">file a bug report</a> in GitHub, including the location of the problem and "
-"how you encountered it."
+"If you've found a problem with the site, we'd love to fix it. Please <a href=\"https://github.com/mozilla/addons/issues/new\">file a bug report</a> in GitHub, including the location of the problem "
+"and how you encountered it."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/docs/policies-maintenance.html:3 src/olympia/devhub/templates/devhub/docs/policies-maintenance.html:7
@@ -5810,7 +5737,7 @@ msgstr ""
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:282
 msgid ""
-"Add-ons that store or otherwise handle browsing data must support <a href=\"https://developer.mozilla.org/En/Supporting_private_browsing_mode\">Private Browsing Mode</a>.  During a Private Browsing "
+"Add-ons that store or otherwise handle browsing data must support <a href=\"https://developer.mozilla.org/En/Supporting_private_browsing_mode\">Private Browsing Mode</a>. During a Private Browsing "
 "session, no browsing data can be written to disk, and all of this data must be cleared when Firefox quits or the Private Browsing session ends."
 msgstr ""
 
@@ -5975,129 +5902,95 @@ msgstr ""
 msgid "How to get in touch with us regarding these policies or your add-on."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:6
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:10
 msgid "You have disabled this add-on"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:20
-msgid ""
-"Your add-on's listing is disabled and is not showing\n"
-"                             anywhere in our gallery or update service."
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:24
+msgid "Your add-on's listing is disabled and is not showing anywhere in our gallery or update service."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:25
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:27
 msgid "Please complete your add-on."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:29
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:30
 msgid "You will receive an email when the review is complete."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:34
-msgid ""
-"You will receive an email when the review is complete. Until\n"
-"                             then, your add-on is not listed in our gallery but can be\n"
-"                             accessed directly from its details page."
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:33
+msgid "You will receive an email when the review is complete. Until then, your add-on is not listed in our gallery but can be accessed directly from its details page."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:38 src/olympia/devhub/templates/devhub/includes/addon_details.html:48
-msgid ""
-"You will receive an email when the review is\n"
-"                             complete and your add-on is signed."
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:37 src/olympia/devhub/templates/devhub/includes/addon_details.html:45
+msgid "You will receive an email when the review is complete and your add-on is signed."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:44
-msgid ""
-"You will receive an email when the review is complete. Until\n"
-"                             then, your add-on is not listed in our gallery but can be\n"
-"                             accessed directly from its details page. "
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:41
+msgid "You will receive an email when the review is complete. Until then, your add-on is not listed in our gallery but can be accessed directly from its details page. "
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:54
-msgid ""
-"Your add-on is displayed in our gallery and users are\n"
-"                             receiving automatic updates."
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:49
+msgid "Your add-on is displayed in our gallery and users are receiving automatic updates."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:57
-msgid ""
-"Your add-on has been signed and can be bundled with an\n"
-"                             application installer."
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:52
+msgid "Your add-on has been signed and can be bundled with an application installer."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:63
-msgid ""
-"Your add-on was disabled by a site administrator and is no\n"
-"                             longer shown in our gallery. If you have any questions,\n"
-"                             please email amo-admins@mozilla.org."
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:56
+msgid "Your add-on was disabled by a site administrator and is no longer shown in our gallery. If you have any questions, please email amo-admins@mozilla.org."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:70
-msgid ""
-"Your add-on is displayed in our gallery as experimental\n"
-"                             and users are receiving automatic updates. Some features\n"
-"                             are unavailable to your add-on."
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:62
+msgid "Your add-on is displayed in our gallery as experimental and users are receiving automatic updates. Some features are unavailable to your add-on."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:74
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:66
 msgid "Your add-on has been signed."
 msgstr ""
 
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:69
+msgid ""
+"You will receive an email when the full review is complete. Until then, your add-on is displayed in our gallery as experimental and users are receiving automatic updates. Some features are "
+"unavailable to your add-on."
+msgstr ""
+
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:74
+msgid "You will receive an email when the full review is complete, making you able to bundle your add-on with an application installer."
+msgstr ""
+
 #: src/olympia/devhub/templates/devhub/includes/addon_details.html:79
-msgid ""
-"You will receive an email when the full review is complete.\n"
-"                             Until then, your add-on is displayed in our gallery as\n"
-"                             experimental and users are receiving automatic updates.\n"
-"                             Some features are unavailable to your add-on."
+msgid "All add-ons hosted in our gallery must now be reviewed by an editor. If you wish to continue hosting your add-on, please click to select a review process."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:84
-msgid ""
-"You will receive an email when the full review is\n"
-"                             complete, making you able to bundle your add-on with an\n"
-"                             application installer."
-msgstr ""
-
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:91
-msgid ""
-"All add-ons hosted in our gallery must now be reviewed by an\n"
-"                             editor. If you wish to continue hosting your add-on, please\n"
-"                             click to select a review process."
-msgstr ""
-
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:113
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:100
 msgid "Current Version:"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:115
-msgid ""
-"This is the version of your add-on that will\n"
-"                                           be installed if someone clicks the Install\n"
-"                                           button on addons.mozilla.org. It is only\n"
-"                                           relevant for listed add-ons."
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:102
+msgid "This is the version of your add-on that will be installed if someone clicks the Install button on addons.mozilla.org. It is only relevant for listed add-ons."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:123
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:110
 msgid "Created:"
 msgstr ""
 
 #. {0} is a date. dennis-ignore: E201
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:125 src/olympia/devhub/templates/devhub/includes/addon_details.html:131
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:112 src/olympia/devhub/templates/devhub/includes/addon_details.html:118
 #, python-format
 msgid "%%b %%e, %%Y"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:136
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:123
 msgid "Next Version:"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:138
-msgid ""
-"This is the newest uploaded version, however\n"
-"                                           it isn’t live on the site yet."
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:125
+msgid "This is the newest uploaded version, however it isn’t live on the site yet."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:144 src/olympia/devhub/templates/devhub/versions/list.html:30
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:130 src/olympia/devhub/templates/devhub/versions/list.html:30
 msgid "Queues are not reviewed strictly in order"
 msgstr ""
 
@@ -6165,9 +6058,7 @@ msgid "View the blog &#9658;"
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/includes/license_form.html:6
-msgid ""
-"Please choose a license appropriate for the rights you grant on your source code.\n"
-"                  It is only relevant for listed add-ons."
+msgid "Please choose a license appropriate for the rights you grant on your source code. It is only relevant for listed add-ons."
 msgstr ""
 
 #. {0} is a list of HTML tags.
@@ -6194,14 +6085,11 @@ msgstr[1] ""
 #: src/olympia/devhub/templates/devhub/includes/policy_form.html:4
 msgid ""
 "Users will be required to accept the following End-User License Agreement (EULA) prior to installing your add-on. The presence of a EULA significantly affects the number of downloads an add-on "
-"receives. Please note that a EULA is not the same as a code license, such as the GPL or MPL.\n"
-"                It is only relevant for listed add-ons."
+"receives. Please note that a EULA is not the same as a code license, such as the GPL or MPL.It is only relevant for listed add-ons."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/policy_form.html:21
-msgid ""
-"If your add-on transmits any data from the user's computer, a privacy policy is required that explains what data is sent and how it is used.\n"
-"                It is only relevant for listed add-ons."
+#: src/olympia/devhub/templates/devhub/includes/policy_form.html:24
+msgid "If your add-on transmits any data from the user's computer, a privacy policy is required that explains what data is sent and how it is used. It is only relevant for listed add-ons."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/includes/source_form_field.html:2
@@ -6369,12 +6257,8 @@ msgstr ""
 msgid "Add some tags to describe your Theme."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/personas/edit.html:106
-msgid ""
-"A short explanation of your theme's\n"
-"                                basic functionality that is displayed in\n"
-"                                search and browse listings, as well as at\n"
-"                                the top of your theme's details page."
+#: src/olympia/devhub/templates/devhub/personas/edit.html:106 src/olympia/devhub/templates/devhub/personas/submit.html:54
+msgid "A short explanation of your theme's basic functionality that is displayed in search and browse listings, as well as at the top of your theme's details page."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/personas/edit.html:122 src/olympia/devhub/templates/devhub/personas/submit.html:68
@@ -6444,7 +6328,7 @@ msgid "Upon upload and form submission, the AMO Team will review your updated de
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/personas/edit.html:241
-msgid "Your previously resubmitted design,  which is under pending review."
+msgid "Your previously resubmitted design, which is under pending review."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/personas/edit.html:245
@@ -6511,14 +6395,6 @@ msgstr ""
 
 #: src/olympia/devhub/templates/devhub/personas/submit.html:33
 msgid "Give your Theme a name."
-msgstr ""
-
-#: src/olympia/devhub/templates/devhub/personas/submit.html:54
-msgid ""
-"A short explanation of your theme's\n"
-"                                      basic functionality that is displayed in\n"
-"                                      search and browse listings, as well as at\n"
-"                                      the top of your theme's details page."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/personas/submit.html:198
@@ -6595,30 +6471,16 @@ msgstr ""
 msgid "Files added to reviewed versions must be reviewed before they will be available for download."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/add_file_modal.html:15
-#, python-format
-msgid ""
-"Submission of updates to unlisted add-ons for signing is currently in an open beta. Manual review may still be required for a large number of add-ons. Please <a href=\"%(url)s\" target=\"_blank"
-"\">report any bugs</a> that you encounter."
-msgstr ""
-
-#: src/olympia/devhub/templates/devhub/versions/add_file_modal.html:35
+#: src/olympia/devhub/templates/devhub/versions/add_file_modal.html:24
 msgid "Select the target platform for this file."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/add_file_modal.html:46
+#: src/olympia/devhub/templates/devhub/versions/add_file_modal.html:35
 msgid "Which review type would you like to nominate for?"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/add_file_modal.html:51
+#: src/olympia/devhub/templates/devhub/versions/add_file_modal.html:40
 msgid "Only publish this version to my beta channel."
-msgstr ""
-
-#: src/olympia/devhub/templates/devhub/versions/add_file_modal.html:54
-#, python-format
-msgid ""
-"The behavior of the beta channel has changed to accommodate <a href=\"%(addon_signing_url)s\" target=\"_blank\">mandatory add-on signing</a>. The new process is currently in an open beta, and may "
-"change significantly in the near future. Please <a href=\"%(issues_url)s\" target=\"_blank\">report any bugs</a> that you encounter."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/versions/edit.html:5
@@ -6642,19 +6504,10 @@ msgstr ""
 msgid "Upload Another File"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/edit.html:45
-msgid ""
-"Adjusting application information here will allow users to install your\n"
-"                          add-on even if the install manifest in the package indicates that the\n"
-"                          add-on is incompatible."
-msgstr ""
-
 #: src/olympia/devhub/templates/devhub/versions/edit.html:74
 msgid ""
-"Information about changes in this release, new features,\n"
-"                              known bugs, and other useful information specific to this\n"
-"                              release/version. This information is also shown in the\n"
-"                              Add-ons Manager when updating."
+"Information about changes in this release, new features, known bugs, and other useful information specific to this release/version. This information is also shown in the Add-ons Manager when "
+"updating."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/versions/edit.html:99
@@ -6666,10 +6519,7 @@ msgid "Notes for Reviewers"
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/versions/edit.html:114
-msgid ""
-"Optionally, enter any information that may be useful\n"
-"                              to the Editor reviewing this add-on, such as test\n"
-"                              account information."
+msgid "Optionally, enter any information that may be useful to the Editor reviewing this add-on, such as test account information."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/versions/edit.html:127
@@ -6747,7 +6597,7 @@ msgstr ""
 msgid "Request Preliminary Review"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:80 src/olympia/devhub/templates/devhub/versions/list.html:327 src/olympia/devhub/templates/devhub/versions/list.html:350
+#: src/olympia/devhub/templates/devhub/versions/list.html:80 src/olympia/devhub/templates/devhub/versions/list.html:325 src/olympia/devhub/templates/devhub/versions/list.html:348
 msgid "Cancel Review Request"
 msgstr ""
 
@@ -6776,7 +6626,7 @@ msgid "Unlisted:"
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/versions/list.html:114
-msgid "Not distributed on {0}. Developers will upload new versions for signing and distribute the add-ons on their own. (beta)"
+msgid "Not distributed on {0}. Developers will upload new versions for signing and distribute the add-ons on their own."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/versions/list.html:122
@@ -6839,81 +6689,73 @@ msgid "<strong>Important:</strong> Once a version has been deleted, you may not 
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/versions/list.html:230
-msgid ""
-"Deleting a version which has already been reviewed\n"
-"               may also cause a significant delay in the review of\n"
-"               your next update."
-msgstr ""
-
-#: src/olympia/devhub/templates/devhub/versions/list.html:233
 msgid "Are you sure you wish to delete this version?"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:238
+#: src/olympia/devhub/templates/devhub/versions/list.html:235
 msgid "Delete Version"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:240
+#: src/olympia/devhub/templates/devhub/versions/list.html:237
 msgid "Disable Version"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:247
+#: src/olympia/devhub/templates/devhub/versions/list.html:244
 msgid "Add a new Version"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:249
+#: src/olympia/devhub/templates/devhub/versions/list.html:246
 msgid "Add Version"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:256 src/olympia/devhub/templates/devhub/versions/list.html:274
+#: src/olympia/devhub/templates/devhub/versions/list.html:253 src/olympia/devhub/templates/devhub/versions/list.html:279
 msgid "Hide Add-on"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:259
+#: src/olympia/devhub/templates/devhub/versions/list.html:256
 msgid "Hiding your add-on will prevent it from appearing anywhere in our gallery and will stop users from receiving automatic updates."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:265
+#: src/olympia/devhub/templates/devhub/versions/list.html:263
+msgid "The files awaiting review will be disabled and you will need to upload new versions."
+msgstr ""
+
+#: src/olympia/devhub/templates/devhub/versions/list.html:270
 msgid "Are you sure you wish to hide your add-on?"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:286 src/olympia/devhub/templates/devhub/versions/list.html:315
+#: src/olympia/devhub/templates/devhub/versions/list.html:291 src/olympia/devhub/templates/devhub/versions/list.html:313
 msgid "Unlist Add-on"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:289
+#: src/olympia/devhub/templates/devhub/versions/list.html:294
 #, python-format
 msgid ""
 "Unlisting your add-on will make it (and each of its versions/files) invisible on this website. It won't show up in searches, won't have a public facing page, and won't be updated automatically for "
-"current users.  It is recommended for unlisted add-ons to provide a custom <a href=\"%(update_url)s\" target=\"_blank\">updateURL</a> in their manifest file for automatic updates."
+"current users. It is recommended for unlisted add-ons to provide a custom <a href=\"%(update_url)s\" target=\"_blank\">updateURL</a> in their manifest file for automatic updates."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:299
-#, python-format
-msgid "Switching add-ons to unlisted is currently in an open beta. Please <a href=\"%(url)s\" target=\"_blank\">report any bugs</a> that you encounter."
-msgstr ""
-
-#: src/olympia/devhub/templates/devhub/versions/list.html:305
+#: src/olympia/devhub/templates/devhub/versions/list.html:303
 msgid "Unlisting an add-on is irreversible!"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:305
+#: src/olympia/devhub/templates/devhub/versions/list.html:303
 msgid "An unlisted add-on cannot be switched to be listed."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:307
+#: src/olympia/devhub/templates/devhub/versions/list.html:305
 msgid "Are you sure you wish to unlist your add-on?"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:330
+#: src/olympia/devhub/templates/devhub/versions/list.html:328
 msgid "Canceling your review request will leave your add-on as preliminarily reviewed."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:335
+#: src/olympia/devhub/templates/devhub/versions/list.html:333
 msgid "Canceling your review request will mark your add-on incomplete. If you do not complete your add-on after several days by re-requesting review, it will be deleted."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:343
+#: src/olympia/devhub/templates/devhub/versions/list.html:341
 msgid "Are you sure you wish to cancel your review request?"
 msgstr ""
 
@@ -7252,19 +7094,19 @@ msgstr ""
 msgid "Search by add-on name / author email"
 msgstr ""
 
-#: src/olympia/editors/forms.py:103
+#: src/olympia/editors/forms.py:103 src/olympia/editors/forms.py:244 src/olympia/editors/forms.py:257
 msgid "yes"
 msgstr ""
 
-#: src/olympia/editors/forms.py:104
+#: src/olympia/editors/forms.py:104 src/olympia/editors/forms.py:244 src/olympia/editors/forms.py:257
 msgid "no"
 msgstr ""
 
-#: src/olympia/editors/forms.py:105
+#: src/olympia/editors/forms.py:105 src/olympia/editors/forms.py:245
 msgid "Admin Flag"
 msgstr ""
 
-#: src/olympia/editors/forms.py:113
+#: src/olympia/editors/forms.py:113 src/olympia/editors/forms.py:253
 msgid "Max. Version"
 msgstr ""
 
@@ -7276,55 +7118,59 @@ msgstr ""
 msgid "Add-on Types"
 msgstr ""
 
-#: src/olympia/editors/forms.py:126 src/olympia/editors/helpers.py:267
+#: src/olympia/editors/forms.py:126 src/olympia/editors/helpers.py:279
 msgid "Platforms"
 msgstr ""
 
+#: src/olympia/editors/forms.py:237
+msgid "Search by add-on name / author email / guid"
+msgstr ""
+
 #. L10n: 0 = platform, 1 = filename, 2 = status message
-#: src/olympia/editors/forms.py:238
+#: src/olympia/editors/forms.py:342
 #, python-format
 msgid "<strong>%s</strong> &middot; %s &middot; %s"
 msgstr ""
 
-#: src/olympia/editors/forms.py:252
+#: src/olympia/editors/forms.py:356
 msgid "Comments:"
 msgstr ""
 
-#: src/olympia/editors/forms.py:256
+#: src/olympia/editors/forms.py:360
 msgid "Operating systems:"
 msgstr ""
 
-#: src/olympia/editors/forms.py:258
+#: src/olympia/editors/forms.py:362
 msgid "Applications:"
 msgstr ""
 
-#: src/olympia/editors/forms.py:260
+#: src/olympia/editors/forms.py:364
 msgid "Notify me the next time this add-on is updated. (Subsequent updates will not generate an email)"
 msgstr ""
 
-#: src/olympia/editors/forms.py:265
+#: src/olympia/editors/forms.py:369
 msgid "Clear Admin Review Flag"
 msgstr ""
 
-#: src/olympia/editors/forms.py:267
+#: src/olympia/editors/forms.py:371
 msgid "Clear more info requested flag"
 msgstr ""
 
-#: src/olympia/editors/forms.py:281
+#: src/olympia/editors/forms.py:385
 msgid "Choose a canned response..."
 msgstr ""
 
 #. L10n: Description of what can be searched for.
-#: src/olympia/editors/forms.py:324
+#: src/olympia/editors/forms.py:423
 msgid "theme name"
 msgstr ""
 
-#: src/olympia/editors/forms.py:350
+#: src/olympia/editors/forms.py:449
 msgid "Someone else is reviewing this theme."
 msgstr ""
 
 #. L10n: Description of what can be searched for.
-#: src/olympia/editors/forms.py:447
+#: src/olympia/editors/forms.py:546
 msgid "app, reviewer, or comment"
 msgstr ""
 
@@ -7340,246 +7186,264 @@ msgstr ""
 msgid "Rejected or Unreviewed"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:123 src/olympia/editors/helpers.py:136
+#: src/olympia/editors/helpers.py:125 src/olympia/editors/helpers.py:138
 msgid "Queue"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:124 src/olympia/editors/templates/editors/base.html:50 src/olympia/editors/templates/editors/base.html:65
+#: src/olympia/editors/helpers.py:126 src/olympia/editors/templates/editors/base.html:50 src/olympia/editors/templates/editors/base.html:65
 msgid "Pending Updates"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:125 src/olympia/editors/templates/editors/base.html:48 src/olympia/editors/templates/editors/base.html:63
+#: src/olympia/editors/helpers.py:127 src/olympia/editors/templates/editors/base.html:48 src/olympia/editors/templates/editors/base.html:63
 msgid "Full Reviews"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:126 src/olympia/editors/templates/editors/base.html:52 src/olympia/editors/templates/editors/base.html:67
+#: src/olympia/editors/helpers.py:128 src/olympia/editors/templates/editors/base.html:52 src/olympia/editors/templates/editors/base.html:67
 msgid "Preliminary Reviews"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:127 src/olympia/editors/templates/editors/base.html:54
+#: src/olympia/editors/helpers.py:129 src/olympia/editors/templates/editors/base.html:54
 msgid "Moderated Reviews"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:128 src/olympia/editors/templates/editors/base.html:46
+#: src/olympia/editors/helpers.py:130 src/olympia/editors/templates/editors/base.html:46
 msgid "Fast Track"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:130
+#: src/olympia/editors/helpers.py:132
 msgid "Pending Themes"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:131 src/olympia/editors/templates/editors/themes/queue.html:4
+#: src/olympia/editors/helpers.py:133 src/olympia/editors/templates/editors/themes/queue.html:4
 msgid "Flagged Themes"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:132
+#: src/olympia/editors/helpers.py:134
 msgid "Update Themes"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:137
+#: src/olympia/editors/helpers.py:139
 msgid "Unlisted Pending Updates"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:138
+#: src/olympia/editors/helpers.py:140
 msgid "Unlisted Full Reviews"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:139
+#: src/olympia/editors/helpers.py:141
 msgid "Unlisted Preliminary Reviews"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:170
+#: src/olympia/editors/helpers.py:142
+msgid "Unlisted All Add-ons"
+msgstr ""
+
+#: src/olympia/editors/helpers.py:173
 msgid "Fast Track ({0})"
 msgid_plural "Fast Track ({0})"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/olympia/editors/helpers.py:175
+#: src/olympia/editors/helpers.py:178
 msgid "Full Review ({0})"
 msgid_plural "Full Reviews ({0})"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/olympia/editors/helpers.py:180
+#: src/olympia/editors/helpers.py:183
 msgid "Pending Update ({0})"
 msgid_plural "Pending Updates ({0})"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/olympia/editors/helpers.py:185
+#: src/olympia/editors/helpers.py:188
 msgid "Preliminary Review ({0})"
 msgid_plural "Preliminary Reviews ({0})"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/olympia/editors/helpers.py:190
+#: src/olympia/editors/helpers.py:193
 msgid "Moderated Review ({0})"
 msgid_plural "Moderated Reviews ({0})"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/olympia/editors/helpers.py:196
+#: src/olympia/editors/helpers.py:199
 msgid "Unlisted Full Review ({0})"
 msgid_plural "Unlisted Full Reviews ({0})"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/olympia/editors/helpers.py:201
+#: src/olympia/editors/helpers.py:204
 msgid "Unlisted Pending Update ({0})"
 msgid_plural "Unlisted Pending Updates ({0})"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/olympia/editors/helpers.py:206
+#: src/olympia/editors/helpers.py:209
 msgid "Unlisted Preliminary Review ({0})"
 msgid_plural "Unlisted Preliminary Reviews ({0})"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/olympia/editors/helpers.py:261
-msgid "Addon"
-msgstr ""
+#: src/olympia/editors/helpers.py:214
+msgid "Unlisted All Add-ons ({0})"
+msgid_plural "Unlisted All Add-ons ({0})"
+msgstr[0] ""
+msgstr[1] ""
 
-#: src/olympia/editors/helpers.py:262
+#: src/olympia/editors/helpers.py:274
 msgid "Type"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:263
+#: src/olympia/editors/helpers.py:275
 msgid "Waiting Time"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:264 src/olympia/editors/templates/editors/review.html:285
+#: src/olympia/editors/helpers.py:276 src/olympia/editors/templates/editors/review.html:285
 msgid "Flags"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:265
+#: src/olympia/editors/helpers.py:277
 msgid "Applications"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:270
+#: src/olympia/editors/helpers.py:282
 msgid "Additional"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:285
+#: src/olympia/editors/helpers.py:302
 msgid "Site Specific"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:287
+#: src/olympia/editors/helpers.py:304
 msgid "Requires External Software"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:289
+#: src/olympia/editors/helpers.py:306
 msgid "Binary Components"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:313
+#: src/olympia/editors/helpers.py:339
 msgid "moments ago"
 msgstr ""
 
 #. L10n: first argument is number of minutes
-#: src/olympia/editors/helpers.py:316
+#: src/olympia/editors/helpers.py:342
 msgid "{0} minute"
 msgid_plural "{0} minutes"
 msgstr[0] ""
 msgstr[1] ""
 
 #. L10n: first argument is number of hours
-#: src/olympia/editors/helpers.py:320
+#: src/olympia/editors/helpers.py:346
 msgid "{0} hour"
 msgid_plural "{0} hours"
 msgstr[0] ""
 msgstr[1] ""
 
 #. L10n: first argument is number of days
-#: src/olympia/editors/helpers.py:324
+#: src/olympia/editors/helpers.py:350
 msgid "{0} day"
 msgid_plural "{0} days"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/olympia/editors/helpers.py:488
+#: src/olympia/editors/helpers.py:364
+msgid "Last Review"
+msgstr ""
+
+#: src/olympia/editors/helpers.py:366
+msgid "Last Update"
+msgstr ""
+
+#: src/olympia/editors/helpers.py:387
+msgid "No Reviews"
+msgstr ""
+
+#: src/olympia/editors/helpers.py:561
 msgid "Push to public"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:490
+#: src/olympia/editors/helpers.py:563
 msgid "Grant full review"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:505
+#: src/olympia/editors/helpers.py:578
 msgid "Request more information"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:508
+#: src/olympia/editors/helpers.py:581
 msgid "Request super-review"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:519
+#: src/olympia/editors/helpers.py:592
 msgid "Grant preliminary review"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:520
+#: src/olympia/editors/helpers.py:593
 msgid "This will mark the files as preliminarily reviewed."
 msgstr ""
 
-#: src/olympia/editors/helpers.py:522
+#: src/olympia/editors/helpers.py:595
 msgid "Use this form to request more information from the author. They will receive an email and be able to answer here. You will be notified by email when they reply."
 msgstr ""
 
-#: src/olympia/editors/helpers.py:526
+#: src/olympia/editors/helpers.py:599
 msgid ""
 "If you have concerns about this add-on's security, copyright issues, or other concerns that an administrator should look into, enter your comments in the area below. They will be sent to "
 "administrators, not the author."
 msgstr ""
 
-#: src/olympia/editors/helpers.py:532
+#: src/olympia/editors/helpers.py:605
 msgid "This will reject the add-on and remove it from the review queue."
 msgstr ""
 
-#: src/olympia/editors/helpers.py:534
-msgid "Make a comment on this version.  The author won't be able to see this."
+#: src/olympia/editors/helpers.py:607
+msgid "Make a comment on this version. The author won't be able to see this."
 msgstr ""
 
-#: src/olympia/editors/helpers.py:538
+#: src/olympia/editors/helpers.py:611
 msgid "This will reject the files and remove them from the review queue."
 msgstr ""
 
-#: src/olympia/editors/helpers.py:542
+#: src/olympia/editors/helpers.py:615
 msgid "This will mark the add-on as preliminarily reviewed. Future versions will undergo preliminary review."
 msgstr ""
 
-#: src/olympia/editors/helpers.py:547
+#: src/olympia/editors/helpers.py:620
 msgid "This will mark the files as preliminarily reviewed. Future versions will undergo preliminary review."
 msgstr ""
 
-#: src/olympia/editors/helpers.py:552
+#: src/olympia/editors/helpers.py:625
 msgid "Retain preliminary review"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:553
+#: src/olympia/editors/helpers.py:626
 msgid "This will retain the add-on as preliminarily reviewed. Future versions will undergo preliminary review."
 msgstr ""
 
-#: src/olympia/editors/helpers.py:558
+#: src/olympia/editors/helpers.py:631
 msgid "This will approve a sandboxed version of a public add-on to appear on the public side."
 msgstr ""
 
-#: src/olympia/editors/helpers.py:561
+#: src/olympia/editors/helpers.py:634
 msgid "This will reject a version of a public add-on and remove it from the queue."
 msgstr ""
 
-#: src/olympia/editors/helpers.py:564
+#: src/olympia/editors/helpers.py:637
 msgid "This will mark the add-on and its most recent version and files as public. Future versions will go into the sandbox until they are reviewed by an editor."
 msgstr ""
 
-#: src/olympia/editors/helpers.py:637
+#: src/olympia/editors/helpers.py:714
 msgid "add-on"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:940 src/olympia/editors/helpers.py:960
+#: src/olympia/editors/helpers.py:1020 src/olympia/editors/helpers.py:1040
 msgid "Flagged"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:944 src/olympia/editors/helpers.py:963
+#: src/olympia/editors/helpers.py:1024 src/olympia/editors/helpers.py:1043
 msgid "Updates"
 msgstr ""
 
@@ -7631,56 +7495,56 @@ msgstr ""
 msgid "A question about your Theme submission"
 msgstr ""
 
-#: src/olympia/editors/views.py:144
+#: src/olympia/editors/views.py:146
 msgid "New Add-ons (Under 5 days)"
 msgstr ""
 
-#: src/olympia/editors/views.py:145
+#: src/olympia/editors/views.py:147
 msgid "Passable (5 to 10 days)"
 msgstr ""
 
-#: src/olympia/editors/views.py:146
+#: src/olympia/editors/views.py:148
 msgid "Overdue (Over 10 days)"
 msgstr ""
 
-#: src/olympia/editors/views.py:532
+#: src/olympia/editors/views.py:539
 msgid "An unknown error occurred"
 msgstr ""
 
-#: src/olympia/editors/views.py:587
+#: src/olympia/editors/views.py:592
 msgid "Self-reviews are not allowed."
 msgstr ""
 
-#: src/olympia/editors/views.py:609
+#: src/olympia/editors/views.py:613
 msgid "Review successfully processed."
 msgstr ""
 
-#: src/olympia/editors/views.py:807
+#: src/olympia/editors/views.py:812
 msgid "was approved"
 msgstr ""
 
-#: src/olympia/editors/views.py:808
+#: src/olympia/editors/views.py:813
 msgid "given preliminary review"
 msgstr ""
 
-#: src/olympia/editors/views.py:809
+#: src/olympia/editors/views.py:814
 msgid "rejected"
 msgstr ""
 
-#: src/olympia/editors/views.py:810
+#: src/olympia/editors/views.py:815
 msgctxt "editors_review_history_nominated_adminreview"
 msgid "escalated"
 msgstr ""
 
-#: src/olympia/editors/views.py:812
+#: src/olympia/editors/views.py:817
 msgid "needs more information"
 msgstr ""
 
-#: src/olympia/editors/views.py:813
+#: src/olympia/editors/views.py:818
 msgid "needs super review"
 msgstr ""
 
-#: src/olympia/editors/views.py:814
+#: src/olympia/editors/views.py:819
 msgid "commented"
 msgstr ""
 
@@ -7725,28 +7589,28 @@ msgstr ""
 msgid "Unlisted Queues"
 msgstr ""
 
-#: src/olympia/editors/templates/editors/base.html:72 src/olympia/editors/templates/editors/performance.html:6
+#: src/olympia/editors/templates/editors/base.html:74 src/olympia/editors/templates/editors/performance.html:6
 msgid "Performance"
 msgstr ""
 
-#: src/olympia/editors/templates/editors/base.html:75 src/olympia/editors/templates/editors/themes/base.html:19 src/olympia/editors/templates/editors/themes/base.html:38
+#: src/olympia/editors/templates/editors/base.html:77 src/olympia/editors/templates/editors/themes/base.html:19 src/olympia/editors/templates/editors/themes/base.html:38
 msgid "Logs"
 msgstr ""
 
-#: src/olympia/editors/templates/editors/base.html:78 src/olympia/editors/templates/editors/reviewlog.html:4 src/olympia/editors/templates/editors/reviewlog.html:27
+#: src/olympia/editors/templates/editors/base.html:80 src/olympia/editors/templates/editors/reviewlog.html:4 src/olympia/editors/templates/editors/reviewlog.html:27
 msgid "Add-on Review Log"
 msgstr ""
 
-#: src/olympia/editors/templates/editors/base.html:80 src/olympia/editors/templates/editors/eventlog.html:4 src/olympia/editors/templates/editors/eventlog.html:8
+#: src/olympia/editors/templates/editors/base.html:82 src/olympia/editors/templates/editors/eventlog.html:4 src/olympia/editors/templates/editors/eventlog.html:8
 #: src/olympia/editors/templates/editors/eventlog_detail.html:4
 msgid "Moderated Review Log"
 msgstr ""
 
-#: src/olympia/editors/templates/editors/base.html:82 src/olympia/editors/templates/editors/beta_signed_log.html:4 src/olympia/editors/templates/editors/beta_signed_log.html:8
+#: src/olympia/editors/templates/editors/base.html:84 src/olympia/editors/templates/editors/beta_signed_log.html:4 src/olympia/editors/templates/editors/beta_signed_log.html:8
 msgid "Signed Beta Files Log"
 msgstr ""
 
-#: src/olympia/editors/templates/editors/base.html:87 src/olympia/editors/templates/editors/includes/daily-message.html:4
+#: src/olympia/editors/templates/editors/base.html:89 src/olympia/editors/templates/editors/includes/daily-message.html:4
 msgid "Announcement"
 msgstr ""
 
@@ -7967,45 +7831,45 @@ msgstr ""
 msgid "clear search"
 msgstr ""
 
-#: src/olympia/editors/templates/editors/queue.html:72 src/olympia/editors/templates/editors/queue.html:122
+#: src/olympia/editors/templates/editors/queue.html:78 src/olympia/editors/templates/editors/queue.html:128
 msgid "Process Reviews"
 msgstr ""
 
-#: src/olympia/editors/templates/editors/queue.html:80
+#: src/olympia/editors/templates/editors/queue.html:86
 msgid "Moderation actions:"
 msgstr ""
 
-#: src/olympia/editors/templates/editors/queue.html:90
+#: src/olympia/editors/templates/editors/queue.html:96
 #, python-format
 msgid "by %(user)s on %(date)s %(stars)s (%(locale)s)"
 msgstr ""
 
-#: src/olympia/editors/templates/editors/queue.html:106
+#: src/olympia/editors/templates/editors/queue.html:112
 #, python-format
 msgid "<strong>%(reason)s</strong> <span class=\"light\">Flagged by %(user)s on %(date)s</span>"
 msgstr ""
 
-#: src/olympia/editors/templates/editors/queue.html:119
-msgid "All reviews have been moderated.  Good work!"
+#: src/olympia/editors/templates/editors/queue.html:125
+msgid "All reviews have been moderated. Good work!"
 msgstr ""
 
-#: src/olympia/editors/templates/editors/queue.html:161
+#: src/olympia/editors/templates/editors/queue.html:167
 msgid "Version Notes / Notes for Reviewer"
 msgstr ""
 
-#: src/olympia/editors/templates/editors/queue.html:169
+#: src/olympia/editors/templates/editors/queue.html:175
 msgid "There are currently no add-ons of this type to review."
 msgstr ""
 
-#: src/olympia/editors/templates/editors/queue.html:181 src/olympia/editors/templates/editors/themes/queue_list.html:85
+#: src/olympia/editors/templates/editors/queue.html:187 src/olympia/editors/templates/editors/themes/queue_list.html:85
 msgid "Helpful Links:"
 msgstr ""
 
-#: src/olympia/editors/templates/editors/queue.html:182
+#: src/olympia/editors/templates/editors/queue.html:188
 msgid "Add-on Policy"
 msgstr ""
 
-#: src/olympia/editors/templates/editors/queue.html:184
+#: src/olympia/editors/templates/editors/queue.html:190
 msgid "Editors' Guide"
 msgstr ""
 
@@ -8068,10 +7932,7 @@ msgid "<strong>Warning!</strong> Another user was viewing this page before you."
 msgstr ""
 
 #: src/olympia/editors/templates/editors/review.html:237
-msgid ""
-"The whiteboard is the place to exchange information relevant to\n"
-"               this addon (whatever the version), between the developer and the\n"
-"               editor. This is visible and editable by both."
+msgid "The whiteboard is the place to exchange information relevant to this addon (whatever the version), between the developer and the editor. This is visible and editable by both."
 msgstr ""
 
 #: src/olympia/editors/templates/editors/review.html:241
@@ -8345,7 +8206,7 @@ msgstr ""
 msgid "Describe your reason for flagging"
 msgstr ""
 
-#: src/olympia/files/forms.py:88
+#: src/olympia/files/forms.py:90
 msgid "Cannot diff a version against itself"
 msgstr ""
 
@@ -8380,51 +8241,51 @@ msgstr ""
 msgid "There was an error accessing file %s."
 msgstr ""
 
-#: src/olympia/files/utils.py:343
+#: src/olympia/files/utils.py:340
 msgid "Could not parse uploaded file."
 msgstr ""
 
-#: src/olympia/files/utils.py:380
+#: src/olympia/files/utils.py:377
 msgid "Invalid file name in archive: {0}"
 msgstr ""
 
-#: src/olympia/files/utils.py:388
+#: src/olympia/files/utils.py:385
 msgid "File exceeding size limit in archive: {0}"
 msgstr ""
 
-#: src/olympia/files/utils.py:439
+#: src/olympia/files/utils.py:436
 msgid "Invalid archive."
 msgstr ""
 
-#: src/olympia/files/utils.py:529 src/olympia/files/utils.py:532
+#: src/olympia/files/utils.py:526 src/olympia/files/utils.py:529
 msgid "Could not parse the manifest file."
 msgstr ""
 
-#: src/olympia/files/utils.py:551
+#: src/olympia/files/utils.py:548
 msgid "Could not find an add-on ID."
 msgstr ""
 
-#: src/olympia/files/utils.py:554
+#: src/olympia/files/utils.py:551
 msgid "Add-on ID must be 64 characters or less."
 msgstr ""
 
-#: src/olympia/files/utils.py:556
+#: src/olympia/files/utils.py:553
 msgid "Add-on ID doesn't match add-on."
 msgstr ""
 
-#: src/olympia/files/utils.py:564
+#: src/olympia/files/utils.py:561
 msgid "Duplicate add-on ID found."
 msgstr ""
 
-#: src/olympia/files/utils.py:567
+#: src/olympia/files/utils.py:564
 msgid "Version numbers should have fewer than 32 characters."
 msgstr ""
 
-#: src/olympia/files/utils.py:570
+#: src/olympia/files/utils.py:567
 msgid "Version numbers should only contain letters, numbers, and these punctuation characters: +*.-_."
 msgstr ""
 
-#: src/olympia/files/utils.py:587
+#: src/olympia/files/utils.py:584
 msgid "<em:type> doesn't match add-on"
 msgstr ""
 
@@ -8523,6 +8384,10 @@ msgstr ""
 
 #: src/olympia/files/templates/files/viewer.html:134
 msgid "Fetching file."
+msgstr ""
+
+#: src/olympia/legacy_api/views.py:255
+msgid "Not implemented yet."
 msgstr ""
 
 #: src/olympia/lib/constants.py:6
@@ -9181,10 +9046,6 @@ msgstr ""
 msgid "Zimbabwe Dollar"
 msgstr ""
 
-#: src/olympia/lib/video/ffmpeg.py:112 src/olympia/lib/video/totem.py:81
-msgid "Videos must be in WebM."
-msgstr ""
-
 #: src/olympia/pages/templates/pages/about.lhtml:3 src/olympia/pages/templates/pages/about.lhtml:10
 msgid "About Mozilla Add-ons"
 msgstr ""
@@ -9196,7 +9057,7 @@ msgstr ""
 #: src/olympia/pages/templates/pages/about.lhtml:13
 msgid ""
 "addons.mozilla.org, commonly known as \"AMO\", is Mozilla's official site for add-ons to Mozilla software, such as Firefox, Thunderbird, and SeaMonkey. Add-ons let you add new features and change "
-"the way your browser or application works.  Take a look around and explore the thousands of ways to customize the way you do things online."
+"the way your browser or application works. Take a look around and explore the thousands of ways to customize the way you do things online."
 msgstr ""
 
 #: src/olympia/pages/templates/pages/about.lhtml:19
@@ -9541,7 +9402,7 @@ msgstr ""
 msgid ""
 "Yes. It's possible, but some of the functionality provided by these libraries are available through XPCOM, XUL, and JavaScript. In addition, authors should take care if libraries modify primitive "
 "object prototypes (String.prototype, Date.prototype, etc.) and/or define global functions (eg. the $ function). These are prone to cause conflict with other add-ons, in particular if different add-"
-"ons use different versions of libraries and so on. Developers need to be very, very careful with using them.  Mozilla does not offer documentation on using them to build add-ons."
+"ons use different versions of libraries and so on. Developers need to be very, very careful with using them. Mozilla does not offer documentation on using them to build add-ons."
 msgstr ""
 
 #: src/olympia/pages/templates/pages/dev_faq.html:165
@@ -9655,8 +9516,8 @@ msgstr ""
 #, python-format
 msgid ""
 "Yes. Many developers choose to host their own add-ons. Choosing to host your add-on on <a href=\"%(amo_url)s\">Mozilla's add-on site</a>, though, allows for much greater exposure to your add-on due "
-"to the large volume of visitors to the site.  <a href=\"%(md_url)s\">mozdev.org</a> offers free project hosting for Mozilla applications and extensions providing developers with tools to help "
-"manage source code, version control, bug tracking and documentation."
+"to the large volume of visitors to the site. <a href=\"%(md_url)s\">mozdev.org</a> offers free project hosting for Mozilla applications and extensions providing developers with tools to help manage "
+"source code, version control, bug tracking and documentation."
 msgstr ""
 
 #: src/olympia/pages/templates/pages/dev_faq.html:277
@@ -9704,7 +9565,7 @@ msgstr ""
 #: src/olympia/pages/templates/pages/dev_faq.html:314
 #, python-format
 msgid ""
-"Yes. Mozilla's <a href=\"%(p_url)s\">Add-on Policy</a> describes what is an acceptable submission. This policy is subject to change without notice.  In addition, the AMO editorial team uses the <a "
+"Yes. Mozilla's <a href=\"%(p_url)s\">Add-on Policy</a> describes what is an acceptable submission. This policy is subject to change without notice. In addition, the AMO editorial team uses the <a "
 "href=\"%(g_url)s\">Editors Reviewing Guide</a> to ensure that your add-on meets specific guidelines for functionality and security."
 msgstr ""
 
@@ -9821,7 +9682,7 @@ msgstr ""
 #: src/olympia/pages/templates/pages/dev_faq.html:434
 #, python-format
 msgid ""
-"This is why it's very important to read the <a href=\"%(g_url)s\">Editors Reviewing Guide</a> to ensure that your add-on is setup as expected.  It's also a good idea to read the blog post, <a href="
+"This is why it's very important to read the <a href=\"%(g_url)s\">Editors Reviewing Guide</a> to ensure that your add-on is setup as expected. It's also a good idea to read the blog post, <a href="
 "\"%(blog_url)s\">Successfully Getting your Add-on Reviewed</a> which provides excellent insight into ensuring a smooth review of your add-on."
 msgstr ""
 
@@ -9928,7 +9789,7 @@ msgstr ""
 
 #: src/olympia/pages/templates/pages/dev_faq.html:572
 msgid ""
-"Free Software Foundation provides short summaries of the key open source licenses, including whether the license qualifies as a free software license or a copyleft license.  Also includes a "
+"Free Software Foundation provides short summaries of the key open source licenses, including whether the license qualifies as a free software license or a copyleft license. Also includes a "
 "discussion of what constitutes a free software license or a copyleft license (e.g., a Copyleft license is a general method for making a program or other work free, and requiring all modified and "
 "extended versions of the program to be free as well.)"
 msgstr ""
@@ -10106,19 +9967,13 @@ msgid "Add-on Gallery"
 msgstr ""
 
 #: src/olympia/pages/templates/pages/faq.html:171
-msgid ""
-"How do I choose between add-ons that seem to do the same\n"
-"    thing?"
+msgid "How do I choose between add-ons that seem to do the same thing?"
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:173
+#: src/olympia/pages/templates/pages/faq.html:172
 msgid ""
-"There are often several add-ons that have similar features. To\n"
-"    figure out which is right for you, read the entire description of the\n"
-"    add-on and view its screenshots. If there are still several in the running,\n"
-"    read through the add-on's ratings, user reviews, and statistics to see\n"
-"    which is most liked by other users. Remember that you can also just try\n"
-"    out both and see which you like better."
+"There are often several add-ons that have similar features. To figure out which is right for you, read the entire description of the add-on and view its screenshots. If there are still several in "
+"the running, read through the add-on's ratings, user reviews, and statistics to see which is most liked by other users. Remember that you can also just try out both and see which you like better."
 msgstr ""
 
 #: src/olympia/pages/templates/pages/faq.html:180
@@ -10159,80 +10014,67 @@ msgid "How much do add-ons cost to purchase?"
 msgstr ""
 
 #: src/olympia/pages/templates/pages/faq.html:207
-msgid ""
-"Add-ons hosted in our gallery are free unless clearly marked\n"
-"    otherwise."
+msgid "Add-ons hosted in our gallery are free unless clearly marked otherwise."
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:210
+#: src/olympia/pages/templates/pages/faq.html:209
 msgid "What does it mean when an add-on asks for contributions?"
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:211
+#: src/olympia/pages/templates/pages/faq.html:210
 msgid ""
-"Some add-on authors request users who enjoy an add-on to\n"
-"        contribute to its development by making a monetary contribution. These\n"
-"        contributions go directly to the developer unless a third party is\n"
-"        indicated, such as the non-profit Mozilla Foundation."
+"Some add-on authors request users who enjoy an add-on to contribute to its development by making a monetary contribution. These contributions go directly to the developer unless a third party is "
+"indicated, such as the non-profit Mozilla Foundation."
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:216
+#: src/olympia/pages/templates/pages/faq.html:215
 msgid "What are beta add-ons?"
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:218
+#: src/olympia/pages/templates/pages/faq.html:217
 msgid ""
-"Beta add-ons are unreviewed versions which represent the\n"
-"        latest work of an add-on author. While different authors have different\n"
-"        standards for beta code quality, you should assume that these add-ons\n"
-"        are less stable than the general add-on releases."
+"Beta add-ons are unreviewed versions which represent the latest work of an add-on author. While different authors have different standards for beta code quality, you should assume that these add-"
+"ons are less stable than the general add-on releases."
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:222
+#: src/olympia/pages/templates/pages/faq.html:221
 msgid ""
 "Please note that when you install an add-on from the \"Beta Version\" section of an add-on's listing, you will continue to receive updates for that add-on as they become available. Like the initial "
 "version you installed, all beta releases are unreviewed by Mozilla and may harm your computer."
 msgstr ""
 
+#: src/olympia/pages/templates/pages/faq.html:228
+msgid "What does it mean when an add-on is flagged as slow?"
+msgstr ""
+
 #: src/olympia/pages/templates/pages/faq.html:229
-msgid ""
-"What does it mean when an add-on is flagged as\n"
-"    slow?"
+msgid "Most add-ons load code and resources at the same time Firefox is starting up. In most cases the impact in start-up time is minimal, but some add-ons can cause a noticeable slowdown."
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:231
-msgid ""
-"Most add-ons load code and resources at the same time Firefox\n"
-"        is starting up. In most cases the impact in start-up time is minimal,\n"
-"        but some add-ons can cause a noticeable slowdown."
-msgstr ""
-
-#: src/olympia/pages/templates/pages/faq.html:236
+#: src/olympia/pages/templates/pages/faq.html:234
 msgid "How do I report an inappropriate or spam user review?"
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:237
+#: src/olympia/pages/templates/pages/faq.html:235
 msgid ""
-"To report a user review of an add-on, log in with your account\n"
-"    and visit the add-on's reviews page. Find the review you wish to report,\n"
-"    click \"Report this review\" and select a reason. Our editorial team will\n"
-"    investigate the review and take appropriate action."
+"To report a user review of an add-on, log in with your account and visit the add-on's reviews page. Find the review you wish to report, click \"Report this review\" and select a reason. Our "
+"editorial team will investigate the review and take appropriate action."
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:242
+#: src/olympia/pages/templates/pages/faq.html:240
 msgid "How do I report a bug or contact the Mozilla Add-ons team?"
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:243
+#: src/olympia/pages/templates/pages/faq.html:241
 #, python-format
 msgid "Please visit our <a href=\"%(contact_url)s\">Contact page</a>."
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:246
+#: src/olympia/pages/templates/pages/faq.html:244
 msgid "What is a Source Code License?"
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:247
+#: src/olympia/pages/templates/pages/faq.html:245
 #, python-format
 msgid ""
 "The source code used to create an add-on is an exclusive copyright of the add-on author, unless otherwise declared in a source code license. Many add-ons on this site have <a href=\"%(url)s\" lang="
@@ -10240,60 +10082,60 @@ msgid ""
 "the GPL or BSD licenses instead of making up their own."
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:256
+#: src/olympia/pages/templates/pages/faq.html:254
 #, python-format
 msgid "Firefox and other Mozilla software are <a href=\"%(url)s\">open source</a>."
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:264
+#: src/olympia/pages/templates/pages/faq.html:262
 msgid "Collections and Favorites"
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:267
+#: src/olympia/pages/templates/pages/faq.html:265
 msgid "What is a collection?"
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:268
+#: src/olympia/pages/templates/pages/faq.html:266
 msgid "Collections are groups of related add-ons created by users to share."
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:270
+#: src/olympia/pages/templates/pages/faq.html:268
 msgid "What is the My Favorites collection?"
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:271
+#: src/olympia/pages/templates/pages/faq.html:269
 msgid "Favorite add-ons are add-ons that you have bookmarked to easily get back to later. You can add an add-on to your favorites collection by clicking \"Add to favorites\" on its details page."
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:275 src/olympia/templates/menu_links.html:13 src/olympia/templates/impala/header_title.html:17
+#: src/olympia/pages/templates/pages/faq.html:273 src/olympia/templates/menu_links.html:13 src/olympia/templates/impala/header_title.html:17
 msgid "Mobile Add-ons"
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:278
+#: src/olympia/pages/templates/pages/faq.html:276
 msgid "What are mobile add-ons?"
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:279
+#: src/olympia/pages/templates/pages/faq.html:277
 #, python-format
 msgid ""
 "Mobile add-ons work with <a href=\"%(mobile_url)s\">Firefox for Mobile</a> and add or modify functionality just like desktop add-ons. You can find add-ons that work with Firefox for Mobile in our "
 "<a href=\"%(gallery_url)s\">gallery</a>."
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:288
+#: src/olympia/pages/templates/pages/faq.html:286
 msgid "Developer Topics"
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:289
+#: src/olympia/pages/templates/pages/faq.html:287
 #, python-format
 msgid "Please see our <a href=\"%(faq_url)s\">Developer FAQ</a> and <a href=\"%(hub_url)s\">Developer Hub</a> for answers to add-on developer-related questions."
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:294
+#: src/olympia/pages/templates/pages/faq.html:292
 msgid "Still have questions?"
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:295
+#: src/olympia/pages/templates/pages/faq.html:293
 #, python-format
 msgid "For general Firefox support, visit our <a href=\"%(sumo_url)s\">support website</a>. For general add-on and website questions, visit our <a href=\"%(forum_url)s\">forum</a>."
 msgstr ""
@@ -10431,7 +10273,7 @@ msgstr ""
 
 #: src/olympia/pages/templates/pages/sunbird.html:29
 msgid ""
-"Development on the Sunbird project has halted and its final release was on March 30, 2010.  We've been proud to host Sunbird add-ons on this site but as the project is no longer maintained we have "
+"Development on the Sunbird project has halted and its final release was on March 30, 2010. We've been proud to host Sunbird add-ons on this site but as the project is no longer maintained we have "
 "disabled our support for the add-ons."
 msgstr ""
 
@@ -10509,7 +10351,7 @@ msgstr ""
 #, python-format
 msgid ""
 "<h2>Keep these tips in mind:</h2> <ul> <li> Write like you're telling a friend about your experience with the add-on. Give specifics and helpful details, such as what features you liked and/or "
-"disliked, how easy to use it is, and any disadvantages it has.  Avoid generic language such as calling it \"Great\" or \"Bad\" unless you can give reasons why you believe this is so. </li> <li> "
+"disliked, how easy to use it is, and any disadvantages it has. Avoid generic language such as calling it \"Great\" or \"Bad\" unless you can give reasons why you believe this is so. </li> <li> "
 "Please do not post bug reports in reviews. We do not make your email address available to add-on developers and they may need to contact you to help resolve your issue. See the <a href=\"%(support)s"
 "\">support section</a> to find out where to get assistance for this add-on. </li> <li>Please keep reviews clean, avoid the use of improper language and do not post any personal information. </li> </"
 "ul> <p>Please read the <a href=\"%(guide)s\" target=\"_blank\">Review Guidelines</a> for more detail about user add-on reviews.</p>"
@@ -10745,16 +10587,16 @@ msgstr ""
 
 #. L10n: {0} is an application, such as Firefox. This means "any version of
 #. Firefox."
-#: src/olympia/search/views.py:554
+#: src/olympia/search/views.py:547
 msgid "Any {0}"
 msgstr ""
 
 #. L10n: "All Systems" means show everything regardless of platform.
-#: src/olympia/search/views.py:589
+#: src/olympia/search/views.py:582
 msgid "All Systems"
 msgstr ""
 
-#: src/olympia/search/views.py:600
+#: src/olympia/search/views.py:593
 msgid "All Tags"
 msgstr ""
 
@@ -10928,31 +10770,31 @@ msgstr ""
 msgid "Share this Collection"
 msgstr ""
 
-#: src/olympia/signing/views.py:30 src/olympia/templates/base.html:75 src/olympia/templates/impala/base.html:115
+#: src/olympia/signing/views.py:33 src/olympia/templates/base.html:71 src/olympia/templates/impala/base.html:112
 msgid "Some features are temporarily disabled while we perform website maintenance. We'll be back to full capacity shortly."
 msgstr ""
 
-#: src/olympia/signing/views.py:53
+#: src/olympia/signing/views.py:56
 msgid "Could not find add-on with id \"{}\"."
 msgstr ""
 
-#: src/olympia/signing/views.py:67
+#: src/olympia/signing/views.py:70
 msgid "You do not own this addon."
 msgstr ""
 
-#: src/olympia/signing/views.py:82
+#: src/olympia/signing/views.py:87
 msgid "Missing \"upload\" key in multipart file data."
 msgstr ""
 
-#: src/olympia/signing/views.py:96
+#: src/olympia/signing/views.py:101
 msgid "Version does not match the manifest file."
 msgstr ""
 
-#: src/olympia/signing/views.py:100
+#: src/olympia/signing/views.py:105
 msgid "Version already exists."
 msgstr ""
 
-#: src/olympia/signing/views.py:136
+#: src/olympia/signing/views.py:141
 msgid "No uploaded file for that addon and version."
 msgstr ""
 
@@ -11065,89 +10907,89 @@ msgstr ""
 msgid "Statistics Dashboard :: Add-ons for {0}"
 msgstr ""
 
-#: src/olympia/stats/templates/stats/stats.html:30
-msgid "Controls:"
-msgstr ""
-
-#: src/olympia/stats/templates/stats/stats.html:33
-msgid "reset zoom"
-msgstr ""
-
-#: src/olympia/stats/templates/stats/stats.html:40
-msgid "Group by:"
-msgstr ""
-
-#: src/olympia/stats/templates/stats/stats.html:42
-msgid "day"
-msgstr ""
-
-#: src/olympia/stats/templates/stats/stats.html:45
-msgid "week"
-msgstr ""
-
-#: src/olympia/stats/templates/stats/stats.html:48
-msgid "month"
-msgstr ""
-
-#: src/olympia/stats/templates/stats/stats.html:54
-msgid "For last:"
-msgstr ""
-
-#: src/olympia/stats/templates/stats/stats.html:57
-msgid "7 days"
-msgstr ""
-
-#: src/olympia/stats/templates/stats/stats.html:60
-msgid "30 days"
-msgstr ""
-
-#: src/olympia/stats/templates/stats/stats.html:63
-msgid "90 days"
-msgstr ""
-
-#: src/olympia/stats/templates/stats/stats.html:66
-msgid "365 days"
-msgstr ""
-
-#: src/olympia/stats/templates/stats/stats.html:69
-msgid "Custom..."
-msgstr ""
-
 #. {0} is an add-on name
-#: src/olympia/stats/templates/stats/stats.html:88 src/olympia/stats/templates/stats/stats.html:91
+#: src/olympia/stats/templates/stats/stats.html:44 src/olympia/stats/templates/stats/stats.html:47
 msgid "Statistics for {0}"
 msgstr ""
 
-#: src/olympia/stats/templates/stats/stats.html:94
+#: src/olympia/stats/templates/stats/stats.html:50
 msgid "Statistics Dashboard"
 msgstr ""
 
-#: src/olympia/stats/templates/stats/stats.html:104
+#: src/olympia/stats/templates/stats/stats.html:57
+msgid "Controls:"
+msgstr ""
+
+#: src/olympia/stats/templates/stats/stats.html:60
+msgid "reset zoom"
+msgstr ""
+
+#: src/olympia/stats/templates/stats/stats.html:67
+msgid "Group by:"
+msgstr ""
+
+#: src/olympia/stats/templates/stats/stats.html:69
+msgid "day"
+msgstr ""
+
+#: src/olympia/stats/templates/stats/stats.html:72
+msgid "week"
+msgstr ""
+
+#: src/olympia/stats/templates/stats/stats.html:75
+msgid "month"
+msgstr ""
+
+#: src/olympia/stats/templates/stats/stats.html:81
+msgid "For last:"
+msgstr ""
+
+#: src/olympia/stats/templates/stats/stats.html:84
+msgid "7 days"
+msgstr ""
+
+#: src/olympia/stats/templates/stats/stats.html:87
+msgid "30 days"
+msgstr ""
+
+#: src/olympia/stats/templates/stats/stats.html:90
+msgid "90 days"
+msgstr ""
+
+#: src/olympia/stats/templates/stats/stats.html:93
+msgid "365 days"
+msgstr ""
+
+#: src/olympia/stats/templates/stats/stats.html:96
+msgid "Custom..."
+msgstr ""
+
+#: src/olympia/stats/templates/stats/stats.html:106
 msgid "Statistics processing is currently disabled, so recent data is unavailable. The statistics are still being collected and this page will be updated soon with the missing data."
 msgstr ""
 
-#: src/olympia/stats/templates/stats/stats.html:110
+#: src/olympia/stats/templates/stats/stats.html:112
 msgid "Loading the latest data&hellip;"
 msgstr ""
 
-#: src/olympia/stats/templates/stats/stats.html:142 src/olympia/stats/templates/stats/reports/overview.html:25 src/olympia/stats/templates/stats/reports/overview.html:37
+#: src/olympia/stats/templates/stats/stats.html:144 src/olympia/stats/templates/stats/reports/overview.html:25 src/olympia/stats/templates/stats/reports/overview.html:37
 #: src/olympia/stats/templates/stats/reports/overview.html:49
 msgid "No data available."
 msgstr ""
 
-#: src/olympia/stats/templates/stats/stats.html:177
+#: src/olympia/stats/templates/stats/stats.html:179
 msgid "This dashboard is currently <b>public</b>."
 msgstr ""
 
-#: src/olympia/stats/templates/stats/stats.html:179
+#: src/olympia/stats/templates/stats/stats.html:181
 msgid "Contribution stats are currently <b>private</b>."
 msgstr ""
 
-#: src/olympia/stats/templates/stats/stats.html:182
+#: src/olympia/stats/templates/stats/stats.html:184
 msgid "This dashboard is currently <b>private</b>."
 msgstr ""
 
-#: src/olympia/stats/templates/stats/stats.html:185
+#: src/olympia/stats/templates/stats/stats.html:187
 msgid "Change settings."
 msgstr ""
 
@@ -11299,15 +11141,6 @@ msgstr ""
 msgid "Application versions by Date"
 msgstr ""
 
-#: src/olympia/tags/templates/tags/top_cloud.html:4
-msgid "Top {0} Tags"
-msgstr ""
-
-#. {0} is the current application name
-#: src/olympia/tags/templates/tags/top_cloud.html:14
-msgid "{0} Top Tags"
-msgstr ""
-
 #: src/olympia/templates/amo_footer.html:6 src/olympia/templates/includes/lang_switcher.html:2
 msgid "Other languages"
 msgstr ""
@@ -11316,11 +11149,11 @@ msgstr ""
 msgid "Mozilla Add-ons"
 msgstr ""
 
-#: src/olympia/templates/base.html:91 src/olympia/templates/impala/base.html:81
+#: src/olympia/templates/base.html:89 src/olympia/templates/impala/base.html:78
 msgid "Find add-ons for other applications"
 msgstr ""
 
-#: src/olympia/templates/base.html:92 src/olympia/templates/impala/base.html:81
+#: src/olympia/templates/base.html:90 src/olympia/templates/impala/base.html:78
 msgid "Other Applications"
 msgstr ""
 
@@ -11345,7 +11178,7 @@ msgid "View Mobile Site"
 msgstr ""
 
 #: src/olympia/templates/copyright.html:7
-msgid "Site Status "
+msgid "Site Status"
 msgstr ""
 
 #: src/olympia/templates/footer.html:3
@@ -11445,35 +11278,35 @@ msgstr ""
 msgid "<a href=\"%(reg)s\">Register</a> or <a href=\"%(login)s\">Log in</a>"
 msgstr ""
 
-#: src/olympia/templates/impala/base.html:126
+#: src/olympia/templates/impala/base.html:123
 #, python-format
 msgid "To try the thousands of add-ons available here, download <a href=\"%(url)s\">Mozilla Firefox</a>, a fast, free way to surf the Web!"
 msgstr ""
 
-#: src/olympia/templates/impala/base.html:138
+#: src/olympia/templates/impala/base.html:135
 #, python-format
 msgid "Add-ons is switching to Firefox Accounts for login. <a href=\"%(url)s\" class=\"fxa-login\">Sign in now to transfer your account.</a>"
 msgstr ""
 
 #. {0} is an application, such as Firefox.
-#: src/olympia/templates/impala/base.html:148
+#: src/olympia/templates/impala/base.html:145
 msgid "Welcome to {0} Add-ons."
 msgstr ""
 
-#: src/olympia/templates/impala/base.html:151
+#: src/olympia/templates/impala/base.html:148
 msgid "Choose from thousands of extra features and styles to make Firefox your own."
 msgstr ""
 
-#: src/olympia/templates/impala/base.html:156
+#: src/olympia/templates/impala/base.html:153
 #, python-format
 msgid "Add extra features and styles to make %(app)s your own."
 msgstr ""
 
-#: src/olympia/templates/impala/base.html:164
+#: src/olympia/templates/impala/base.html:161
 msgid "On the go?"
 msgstr ""
 
-#: src/olympia/templates/impala/base.html:166
+#: src/olympia/templates/impala/base.html:163
 msgid "Check out our <a class=\"mobile-link\" href=\"#\">Mobile Add-ons site</a>."
 msgstr ""
 
@@ -11697,19 +11530,19 @@ msgstr ""
 
 #. L10n: {id} will be something like "13ad6a", just a random number
 #. to differentiate this user from other anonymous users.
-#: src/olympia/users/models.py:353
+#: src/olympia/users/models.py:362
 msgid "Anonymous user {id}"
 msgstr ""
 
-#: src/olympia/users/models.py:410
+#: src/olympia/users/models.py:419
 msgid "Your account has been restricted"
 msgstr ""
 
-#: src/olympia/users/models.py:480
+#: src/olympia/users/models.py:489
 msgid "Please confirm your email address"
 msgstr ""
 
-#: src/olympia/users/models.py:506
+#: src/olympia/users/models.py:515
 msgid "My Mobile Add-ons"
 msgstr ""
 
@@ -11986,7 +11819,7 @@ msgstr ""
 
 #: src/olympia/users/templates/users/edit.html:70
 #, python-format
-msgid "Change your password.  If you forgot your password, you can <a href=\"%(reset_url)s\">use the reset form</a>."
+msgid "Change your password. If you forgot your password, you can <a href=\"%(reset_url)s\">use the reset form</a>."
 msgstr ""
 
 #: src/olympia/users/templates/users/edit.html:76
@@ -12006,7 +11839,7 @@ msgid "Profile"
 msgstr ""
 
 #: src/olympia/users/templates/users/edit.html:100
-msgid "Give us a bit more information about yourself.  All these fields are optional, but they'll help other users get to know you better."
+msgid "Give us a bit more information about yourself. All these fields are optional, but they'll help other users get to know you better."
 msgstr ""
 
 #: src/olympia/users/templates/users/edit.html:124
@@ -12222,7 +12055,7 @@ msgid "Confirm password"
 msgstr ""
 
 #: src/olympia/users/templates/users/pwreset_confirm.html:47
-msgid "The password reset link was invalid, possibly because it has already been used.  Please request a new password reset."
+msgid "The password reset link was invalid, possibly because it has already been used. Please request a new password reset."
 msgstr ""
 
 #: src/olympia/users/templates/users/pwreset_request.html:15
@@ -12408,7 +12241,7 @@ msgstr ""
 
 #: src/olympia/users/templates/users/unsubscribe.html:30
 #, python-format
-msgid "Unfortunately, we weren't able to unsubscribe you.  The link you clicked is invalid. However, you can unsubscribe still unsubscribe on your <a href=\"%(edit_url)s\">edit profile page</a>."
+msgid "Unfortunately, we weren't able to unsubscribe you. The link you clicked is invalid. However, you can unsubscribe still unsubscribe on your <a href=\"%(edit_url)s\">edit profile page</a>."
 msgstr ""
 
 #: src/olympia/users/templates/users/vcard.html:2
@@ -12462,15 +12295,15 @@ msgstr ""
 msgid "Version History with Changelogs"
 msgstr ""
 
-#: src/olympia/versions/models.py:314
+#: src/olympia/versions/models.py:313
 msgid "Add-on uses binary components."
 msgstr ""
 
-#: src/olympia/versions/models.py:317
+#: src/olympia/versions/models.py:316
 msgid "Add-on has opted into strict compatibility checking."
 msgstr ""
 
-#: src/olympia/versions/models.py:715
+#: src/olympia/versions/models.py:711
 msgid "{app} {min} and later"
 msgstr ""
 
@@ -12545,4 +12378,8 @@ msgstr ""
 
 #: src/olympia/zadmin/forms.py:105
 msgid "Log emails instead of sending"
+msgstr ""
+
+#: src/olympia/zadmin/forms.py:215
+msgid "Deleted versions can`t be changed."
 msgstr ""

--- a/locale/gl/LC_MESSAGES/djangojs.po
+++ b/locale/gl/LC_MESSAGES/djangojs.po
@@ -1,1216 +1,1236 @@
-
 #, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2016-02-24 21:23+0000\n"
+"POT-Creation-Date: 2016-04-18 15:47+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
+"Language: \n"
 "MIME-Version: 1.0\n"
-"Content-Type: text/plain; charset=utf-8\n"
+"Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Generated-By: Babel 2.2.0\n"
 
-#: static/js/common/ratingwidget.js:31
+#: static/js/common-all.js:1426 static/js/impala-all.js:1511 static/js/zamboni/discovery-all.js:12598 static/js/zamboni/init.js:28 static/js/zamboni/mobile-all.js:14945
+msgid "This feature is temporarily disabled while we perform website maintenance. Please check back a little later."
+msgstr ""
+
+#. L10n: {0} is an app name like Firefox.
+#: static/js/common-all.js:1837 static/js/impala-all.js:1922 static/js/zamboni/buttons.js:73 static/js/zamboni/discovery-all.js:13108
+msgid "Accept and Install"
+msgstr ""
+
+#: static/js/common-all.js:1837 static/js/impala-all.js:1922 static/js/zamboni/buttons.js:73 static/js/zamboni/discovery-all.js:13108
+msgid "Add to {0}"
+msgstr ""
+
+#: static/js/common-all.js:1842 static/js/impala-all.js:1927 static/js/zamboni/buttons.js:78 static/js/zamboni/discovery-all.js:13113
+msgid "Download Now"
+msgstr ""
+
+#: static/js/common-all.js:1883 static/js/impala-all.js:1968 static/js/zamboni/buttons.js:119 static/js/zamboni/discovery-all.js:13154
+msgid "Add-on has not been updated to support default-to-compatible."
+msgstr ""
+
+#: static/js/common-all.js:1888 static/js/impala-all.js:1973 static/js/zamboni/buttons.js:124 static/js/zamboni/discovery-all.js:13159
+msgid "You need to be using Firefox 10.0 or higher."
+msgstr ""
+
+#: static/js/common-all.js:1900 static/js/impala-all.js:1985 static/js/zamboni/buttons.js:136 static/js/zamboni/discovery-all.js:13171
+msgid "Mozilla has marked this version as incompatible with your Firefox version."
+msgstr ""
+
+#. L10n: {0} is an platform like Windows or Linux.
+#: static/js/common-all.js:1981 static/js/impala-all.js:2066 static/js/zamboni/buttons.js:217 static/js/zamboni/discovery-all.js:13252
+msgid "Install for {0} anyway"
+msgstr ""
+
+#: static/js/common-all.js:1981 static/js/impala-all.js:2066 static/js/zamboni/buttons.js:217 static/js/zamboni/discovery-all.js:13252
+msgid "Download for {0} anyway"
+msgstr ""
+
+#: static/js/common-all.js:2038 static/js/impala-all.js:2123 static/js/zamboni/buttons.js:274 static/js/zamboni/discovery-all.js:13309
+msgid "Not available for your platform"
+msgstr ""
+
+#. L10n: {0} is an app name, {1} is the app version.
+#: static/js/common-all.js:2049 static/js/common-all.js:2086 static/js/impala-all.js:2134 static/js/impala-all.js:2171 static/js/zamboni/buttons.js:286 static/js/zamboni/buttons.js:324
+#: static/js/zamboni/discovery-all.js:13320 static/js/zamboni/discovery-all.js:13357
+msgid "Not available for {0} {1}"
+msgstr ""
+
+#: static/js/common-all.js:2112 static/js/impala-all.js:2197 static/js/zamboni/buttons.js:351 static/js/zamboni/discovery-all.js:13383
+msgid "Works with {app} {min} - {max}"
+msgstr ""
+
+#: static/js/common-all.js:2114 static/js/impala-all.js:2199 static/js/zamboni/buttons.js:353 static/js/zamboni/discovery-all.js:13385
+msgid "View other versions"
+msgstr ""
+
+#: static/js/common-all.js:2162 static/js/impala-all.js:2247 static/js/zamboni/buttons.js:401 static/js/zamboni/discovery-all.js:13433
+msgid "Only with Firefox — Get Firefox Now!"
+msgstr ""
+
+#: static/js/common-all.js:2278 static/js/impala-all.js:2363 static/js/zamboni/buttons.js:517 static/js/zamboni/discovery-all.js:13549 static/js/zamboni/mobile-all.js:15177
+#: static/js/zamboni/mobile/buttons.js:43
+msgid "Sorry, you need a Mozilla-based browser (such as Firefox) to install a search plugin."
+msgstr ""
+
+#: static/js/common-all.js:9088 static/js/impala-all.js:9649 static/js/zamboni/global.js:410
+msgid "Loading..."
+msgstr ""
+
+#. L10n: {0} is the number of characters left.
+#: static/js/common-all.js:9152 static/js/impala-all.js:9713 static/js/zamboni/global.js:474
+msgid "<b>{0}</b> character left."
+msgid_plural "<b>{0}</b> characters left."
+msgstr[0] ""
+msgstr[1] ""
+
+#: static/js/common-all.js:9589 static/js/common-min.js:6 static/js/impala-all.js:10052 static/js/impala-min.js:6 static/js/common/ratingwidget.js:31 static/js/zamboni/mobile-all.js:16123
+#: static/js/zamboni/mobile-min.js:6
 msgid "{0} star"
 msgid_plural "{0} stars"
 msgstr[0] ""
 msgstr[1] ""
 
-#: static/js/common/upload-addon.js:41 static/js/common/upload-image.js:128
+#: static/js/common-all.js:9676 static/js/common-min.js:6 static/js/impala-all.js:10139 static/js/impala-min.js:6 static/js/zamboni/l10n.js:45
+msgid "Remove this localization"
+msgstr ""
+
+#: static/js/common-all.js:10193 static/js/common-min.js:6 static/js/impala-all.js:10674 static/js/impala-min.js:6 static/js/zamboni/discovery-all.js:13678
+msgid "close"
+msgstr ""
+
+#: static/js/common-all.js:10860 static/js/common-min.js:6 static/js/impala-all.js:11481 static/js/impala-min.js:6 static/js/impala/reviews.js:23 static/js/zamboni/reviews.js:18
+msgid "Flagged for review"
+msgstr ""
+
+#: static/js/common-all.js:10876 static/js/common-min.js:6 static/js/impala-all.js:11498 static/js/impala-min.js:6 static/js/impala/reviews.js:40 static/js/zamboni/reviews.js:34
+msgid "Your input is required"
+msgstr ""
+
+#: static/js/common-all.js:10945 static/js/common-min.js:6 static/js/impala-all.js:11610 static/js/impala-min.js:7 static/js/impala/reviews.js:152 static/js/zamboni/reviews.js:103
+msgid "Marked for deletion"
+msgstr ""
+
+#: static/js/common-all.js:11573 static/js/common-min.js:7 static/js/impala-all.js:13809 static/js/impala-min.js:8 static/js/zamboni/collections.js:229
+msgid "Adding to Favorites&hellip;"
+msgstr ""
+
+#: static/js/common-all.js:11576 static/js/common-min.js:7 static/js/impala-all.js:13812 static/js/impala-min.js:8 static/js/zamboni/collections.js:232
+msgid "Removing Favorite&hellip;"
+msgstr ""
+
+#: static/js/common-all.js:11579 static/js/common-min.js:7 static/js/impala-all.js:13815 static/js/impala-min.js:8 static/js/zamboni/collections.js:235
+msgid "Add to Favorites"
+msgstr ""
+
+#: static/js/common-all.js:11582 static/js/common-min.js:7 static/js/impala-all.js:13818 static/js/impala-min.js:8 static/js/zamboni/collections.js:238
+msgid "Remove from Favorites"
+msgstr ""
+
+#: static/js/common-all.js:11647 static/js/common-min.js:7 static/js/impala-all.js:13883 static/js/impala-min.js:8 static/js/zamboni/collections.js:303
+msgid "Pending"
+msgstr ""
+
+#: static/js/common-all.js:11648 static/js/common-min.js:7 static/js/impala-all.js:13884 static/js/impala-min.js:8 static/js/zamboni/collections.js:304
+msgid "Add a comment"
+msgstr ""
+
+#: static/js/common-all.js:11648 static/js/common-min.js:7 static/js/impala-all.js:13884 static/js/impala-min.js:8 static/js/zamboni/collections.js:304
+msgid "Comment"
+msgstr ""
+
+#: static/js/common-all.js:11649 static/js/common-min.js:7 static/js/impala-all.js:13885 static/js/impala-min.js:8 static/js/zamboni/collections.js:305
+msgid "Remove this add-on from the collection"
+msgstr ""
+
+#: static/js/common-all.js:11649 static/js/common-all.js:11678 static/js/common-min.js:7 static/js/impala-all.js:13885 static/js/impala-all.js:13914 static/js/impala-min.js:8
+#: static/js/zamboni/collections.js:305 static/js/zamboni/collections.js:334
+msgid "Remove"
+msgstr ""
+
+#: static/js/common-all.js:11678 static/js/common-min.js:7 static/js/impala-all.js:13914 static/js/impala-min.js:8 static/js/zamboni/collections.js:334
+msgid "Remove this user as a contributor"
+msgstr ""
+
+#: static/js/common-all.js:11690 static/js/common-min.js:7 static/js/impala-all.js:13926 static/js/impala-min.js:8 static/js/zamboni/collections.js:346
+msgid "An email address is required."
+msgstr ""
+
+#: static/js/common-all.js:11708 static/js/common-min.js:7 static/js/impala-all.js:13944 static/js/impala-min.js:8 static/js/zamboni/collections.js:364
+msgid "You cannot add yourself as a contributor."
+msgstr ""
+
+#: static/js/common-all.js:11710 static/js/common-min.js:7 static/js/impala-all.js:13946 static/js/impala-min.js:8 static/js/zamboni/collections.js:366
+msgid "You have already added that user."
+msgstr ""
+
+#: static/js/common-all.js:11917 static/js/common-min.js:7 static/js/impala-all.js:14153 static/js/impala-min.js:8 static/js/zamboni/collections.js:573
+msgid "Add to favorites"
+msgstr ""
+
+#: static/js/common-all.js:11921 static/js/common-min.js:7 static/js/impala-all.js:14157 static/js/impala-min.js:8 static/js/zamboni/collections.js:577
+msgid "Remove from favorites"
+msgstr ""
+
+#: static/js/common-all.js:11939 static/js/common-min.js:7 static/js/impala-all.js:14175 static/js/impala-all.js:14233 static/js/impala-min.js:8 static/js/impala/collections.js:10
+#: static/js/zamboni/collections.js:595
+msgid "Follow this Collection"
+msgstr ""
+
+#: static/js/common-all.js:11948 static/js/common-min.js:7 static/js/impala-all.js:14184 static/js/impala-min.js:8 static/js/zamboni/collections.js:604
+msgid "Stop following"
+msgstr ""
+
+#: static/js/common-all.js:12096 static/js/common-min.js:7 static/js/zamboni/password-strength.js:20
+msgid "Password strength:"
+msgstr ""
+
+#: static/js/common-all.js:12102 static/js/common-min.js:7 static/js/zamboni/password-strength.js:26
+msgid "At least {0} character left."
+msgid_plural "At least {0} characters left."
+msgstr[0] ""
+msgstr[1] ""
+
+#: static/js/common-all.js:12286 static/js/common-min.js:7 static/js/impala-all.js:14632 static/js/impala-min.js:8 static/js/impala/suggestions.js:39
+msgid "Search themes for <b>{0}</b>"
+msgstr ""
+
+#: static/js/common-all.js:12288 static/js/common-min.js:7 static/js/impala-all.js:14634 static/js/impala-min.js:8 static/js/impala/suggestions.js:41
+msgid "Search apps for <b>{0}</b>"
+msgstr ""
+
+#: static/js/common-all.js:12290 static/js/common-min.js:7 static/js/impala-all.js:14636 static/js/impala-min.js:8 static/js/impala/suggestions.js:43
+msgid "Search add-ons for <b>{0}</b>"
+msgstr ""
+
+#: static/js/common-all.js:12521 static/js/common-min.js:7 static/js/impala-all.js:14867 static/js/impala-min.js:8 static/js/impala/site_suggestions.js:46
+msgid "Category"
+msgstr ""
+
+#. L10n: {0} is an app name.
+#: static/js/impala-all.js:11632 static/js/impala-min.js:7 static/js/impala/listing.js:11 static/js/zamboni/themes.js:13
+msgid "This theme is incompatible with your version of {0}"
+msgstr ""
+
+#: static/js/impala-all.js:12146 static/js/impala-all.js:14331 static/js/impala-min.js:7 static/js/impala-min.js:8 static/js/common/upload-image.js:97 static/js/impala/users.js:51
+#: static/js/zamboni/devhub-all.js:894 static/js/zamboni/devhub-min.js:1
+msgid "Images must be either PNG or JPG."
+msgstr ""
+
+#: static/js/impala-all.js:12150 static/js/impala-min.js:7 static/js/common/upload-image.js:101 static/js/zamboni/devhub-all.js:898 static/js/zamboni/devhub-min.js:1
+msgid "Videos must be in WebM."
+msgstr ""
+
+#: static/js/impala-all.js:12177 static/js/impala-min.js:7 static/js/common/upload-addon.js:41 static/js/common/upload-image.js:128 static/js/zamboni/devhub-all.js:272
+#: static/js/zamboni/devhub-all.js:925 static/js/zamboni/devhub-min.js:1
 msgid "There was a problem contacting the server."
 msgstr ""
 
-#: static/js/common/upload-addon.js:69
+#: static/js/impala-all.js:13298 static/js/impala-min.js:7 static/js/impala/persona_creation.js:60
+msgid "All Rights Reserved"
+msgstr ""
+
+#: static/js/impala-all.js:13302 static/js/impala-min.js:7 static/js/impala/persona_creation.js:64
+msgid "Creative Commons Attribution 3.0"
+msgstr ""
+
+#: static/js/impala-all.js:13307 static/js/impala-min.js:7 static/js/impala/persona_creation.js:69
+msgid "Creative Commons Attribution-NonCommercial 3.0"
+msgstr ""
+
+#: static/js/impala-all.js:13312 static/js/impala-min.js:7 static/js/impala/persona_creation.js:74
+msgid "Creative Commons Attribution-NonCommercial-NoDerivs 3.0"
+msgstr ""
+
+#: static/js/impala-all.js:13317 static/js/impala-min.js:7 static/js/impala/persona_creation.js:79
+msgid "Creative Commons Attribution-NonCommercial-Share Alike 3.0"
+msgstr ""
+
+#: static/js/impala-all.js:13322 static/js/impala-min.js:7 static/js/impala/persona_creation.js:84
+msgid "Creative Commons Attribution-NoDerivs 3.0"
+msgstr ""
+
+#: static/js/impala-all.js:13327 static/js/impala-min.js:7 static/js/impala/persona_creation.js:89
+msgid "Creative Commons Attribution-ShareAlike 3.0"
+msgstr ""
+
+#: static/js/impala-all.js:13530 static/js/impala-min.js:7 static/js/impala/persona_creation.js:292
+msgid "Your Theme's Name"
+msgstr ""
+
+#: static/js/impala-all.js:14242 static/js/impala-min.js:8 static/js/impala/collections.js:19
+msgid "Stop Following"
+msgstr ""
+
+#: static/js/impala-all.js:14243 static/js/impala-min.js:8 static/js/impala/collections.js:20
+msgid "Following"
+msgstr ""
+
+#: static/js/impala-all.js:14313 static/js/impala-min.js:8 static/js/impala/users.js:33
+msgid "use original"
+msgstr ""
+
+#: static/js/impala-all.js:14523 static/js/impala-min.js:8 static/js/impala/search.js:114
+msgid "Updating results&hellip;"
+msgstr ""
+
+#: static/js/common/upload-addon.js:69 static/js/zamboni/devhub-all.js:300 static/js/zamboni/devhub-min.js:1
 msgid "Select a file..."
 msgstr ""
 
-#: static/js/common/upload-addon.js:70
+#: static/js/common/upload-addon.js:70 static/js/zamboni/devhub-all.js:301 static/js/zamboni/devhub-min.js:1
 msgid "Your add-on should end with .xpi, .jar or .xml"
 msgstr ""
 
 #. L10n: {0} is the percent of the file that has been uploaded.
-#: static/js/common/upload-addon.js:104
+#: static/js/common/upload-addon.js:104 static/js/zamboni/devhub-all.js:335 static/js/zamboni/devhub-min.js:1
 #, python-format
 msgid "{0}% complete"
 msgstr ""
 
 #. L10n: "{bytes uploaded} of {total filesize}".
-#: static/js/common/upload-addon.js:107
+#: static/js/common/upload-addon.js:107 static/js/zamboni/devhub-all.js:338 static/js/zamboni/devhub-min.js:1
 msgid "{0} of {1}"
 msgstr ""
 
-#: static/js/common/upload-addon.js:140
+#: static/js/common/upload-addon.js:140 static/js/zamboni/devhub-all.js:371 static/js/zamboni/devhub-min.js:1
 msgid "Cancel"
 msgstr ""
 
-#: static/js/common/upload-addon.js:162
+#: static/js/common/upload-addon.js:162 static/js/zamboni/devhub-all.js:393 static/js/zamboni/devhub-min.js:1
 msgid "Uploading {0}"
 msgstr ""
 
-#: static/js/common/upload-addon.js:189
+#: static/js/common/upload-addon.js:189 static/js/zamboni/devhub-all.js:420 static/js/zamboni/devhub-min.js:1
 msgid "Error with {0}"
 msgstr ""
 
-#: static/js/common/upload-addon.js:194
+#: static/js/common/upload-addon.js:194 static/js/zamboni/devhub-all.js:425 static/js/zamboni/devhub-min.js:1
 msgid "Your add-on failed validation with {0} error."
 msgid_plural "Your add-on failed validation with {0} errors."
 msgstr[0] ""
 msgstr[1] ""
 
-#: static/js/common/upload-addon.js:208
+#: static/js/common/upload-addon.js:208 static/js/zamboni/devhub-all.js:439 static/js/zamboni/devhub-min.js:1
 msgid "&hellip;and {0} more"
 msgid_plural "&hellip;and {0} more"
 msgstr[0] ""
 msgstr[1] ""
 
-#: static/js/common/upload-addon.js:222 static/js/common/upload-addon.js:512
+#: static/js/common/upload-addon.js:222 static/js/common/upload-addon.js:497 static/js/zamboni/devhub-all.js:453 static/js/zamboni/devhub-all.js:743 static/js/zamboni/devhub-min.js:1
 msgid "See full validation report"
 msgstr ""
 
-#: static/js/common/upload-addon.js:234
+#: static/js/common/upload-addon.js:234 static/js/zamboni/devhub-all.js:465 static/js/zamboni/devhub-min.js:1
 msgid "Validating {0}"
 msgstr ""
 
 #. L10n: first argument is an HTTP status code
-#: static/js/common/upload-addon.js:273
+#: static/js/common/upload-addon.js:273 static/js/zamboni/devhub-all.js:504 static/js/zamboni/devhub-min.js:1
 msgid "Received an empty response from the server; status: {0}"
 msgstr ""
 
-#: static/js/common/upload-addon.js:373
+#: static/js/common/upload-addon.js:370 static/js/zamboni/devhub-all.js:604 static/js/zamboni/devhub-min.js:1
 msgid "Unexpected server error while validating."
 msgstr ""
 
-#: static/js/common/upload-addon.js:412
+#: static/js/common/upload-addon.js:409 static/js/zamboni/devhub-all.js:643 static/js/zamboni/devhub-min.js:1
 msgid "Finished validating {0}"
 msgstr ""
 
-#: static/js/common/upload-addon.js:418
+#: static/js/common/upload-addon.js:415 static/js/zamboni/devhub-all.js:649 static/js/zamboni/devhub-min.js:1
 msgid "Your add-on validation timed out, it will be manually reviewed."
 msgstr ""
 
-#: static/js/common/upload-addon.js:421
+#: static/js/common/upload-addon.js:418 static/js/zamboni/devhub-all.js:652 static/js/zamboni/devhub-min.js:1
 msgid "Your add-on was validated with no errors and {0} warning."
 msgid_plural "Your add-on was validated with no errors and {0} warnings."
 msgstr[0] ""
 msgstr[1] ""
 
-#: static/js/common/upload-addon.js:426
+#: static/js/common/upload-addon.js:423 static/js/zamboni/devhub-all.js:657 static/js/zamboni/devhub-min.js:1
 msgid "Your add-on was validated with no errors and {0} message."
 msgid_plural "Your add-on was validated with no errors and {0} messages."
 msgstr[0] ""
 msgstr[1] ""
 
-#: static/js/common/upload-addon.js:431
+#: static/js/common/upload-addon.js:428 static/js/zamboni/devhub-all.js:662 static/js/zamboni/devhub-min.js:1
 msgid "Your add-on was validated with no errors or warnings."
 msgstr ""
 
-#: static/js/common/upload-addon.js:446
+#: static/js/common/upload-addon.js:443 static/js/zamboni/devhub-all.js:677 static/js/zamboni/devhub-min.js:1
 msgid "Your submission will be automatically signed."
 msgstr ""
 
-#: static/js/common/upload-addon.js:465
+#: static/js/common/upload-addon.js:450 static/js/zamboni/devhub-all.js:696 static/js/zamboni/devhub-min.js:1
 msgid "Include detailed version notes (this can be done in the next step)."
 msgstr ""
 
-#: static/js/common/upload-addon.js:466
+#: static/js/common/upload-addon.js:451 static/js/zamboni/devhub-all.js:697 static/js/zamboni/devhub-min.js:1
 msgid "If your add-on requires an account to a website in order to be fully tested, include a test username and password in the Notes to Reviewer (this can be done in the next step)."
 msgstr ""
 
-#: static/js/common/upload-addon.js:467
+#: static/js/common/upload-addon.js:452 static/js/zamboni/devhub-all.js:698 static/js/zamboni/devhub-min.js:1
 msgid "If your add-on is intended for a limited audience you should choose Preliminary Review instead of Full Review."
 msgstr ""
 
-#: static/js/common/upload-addon.js:480
+#: static/js/common/upload-addon.js:465 static/js/zamboni/devhub-all.js:711 static/js/zamboni/devhub-min.js:1
 msgid "Add-on submission checklist"
 msgstr ""
 
-#: static/js/common/upload-addon.js:481
+#: static/js/common/upload-addon.js:466 static/js/zamboni/devhub-all.js:712 static/js/zamboni/devhub-min.js:1
 msgid "Please verify the following points before finalizing your submission. This will minimize delays or misunderstanding during the review process:"
 msgstr ""
 
-#: static/js/common/upload-addon.js:483
+#: static/js/common/upload-addon.js:468 static/js/zamboni/devhub-all.js:714 static/js/zamboni/devhub-min.js:1
 msgid ""
 "Compiled binaries, as well as minified or obfuscated scripts (excluding known libraries) need to have their sources submitted separately for review. Make sure that you use the source code upload "
 "field to avoid having your submission rejected."
 msgstr ""
 
-#: static/js/common/upload-addon.js:501
+#: static/js/common/upload-addon.js:486 static/js/zamboni/devhub-all.js:732 static/js/zamboni/devhub-min.js:1
 msgid "The validation process found these issues that can lead to rejections:"
 msgstr ""
 
-#: static/js/common/upload-addon.js:518
+#: static/js/common/upload-addon.js:503 static/js/zamboni/devhub-all.js:749 static/js/zamboni/devhub-min.js:1
 msgid "If you are unfamiliar with the add-ons review process, you can read about it here."
 msgstr ""
 
-#: static/js/common/upload-addon.js:555
+#: static/js/common/upload-addon.js:540 static/js/zamboni/devhub-all.js:786 static/js/zamboni/devhub-min.js:1
 msgid "Sorry, no supported platform has been found."
 msgstr ""
 
-#: static/js/common/upload-base.js:57
+#: static/js/common/upload-base.js:57 static/js/zamboni/devhub-all.js:187 static/js/zamboni/devhub-min.js:1
 msgid "The filetype you uploaded isn't recognized."
 msgstr ""
 
-#: static/js/common/upload-base.js:79
+#: static/js/common/upload-base.js:79 static/js/zamboni/devhub-all.js:209 static/js/zamboni/devhub-min.js:1
 msgid "You cancelled the upload."
 msgstr ""
 
-#: static/js/common/upload-image.js:97 static/js/impala/users.js:51
-msgid "Images must be either PNG or JPG."
-msgstr ""
-
-#: static/js/common/upload-image.js:101
-msgid "Videos must be in WebM."
-msgstr ""
-
-#: static/js/impala/collections.js:10 static/js/zamboni/collections.js:595
-msgid "Follow this Collection"
-msgstr ""
-
-#: static/js/impala/collections.js:19
-msgid "Stop Following"
-msgstr ""
-
-#: static/js/impala/collections.js:20
-msgid "Following"
-msgstr ""
-
-#. L10n: {0} is an app name.
-#: static/js/impala/listing.js:11 static/js/zamboni/themes.js:13
-msgid "This theme is incompatible with your version of {0}"
-msgstr ""
-
-#: static/js/impala/persona_creation.js:60
-msgid "All Rights Reserved"
-msgstr ""
-
-#: static/js/impala/persona_creation.js:64
-msgid "Creative Commons Attribution 3.0"
-msgstr ""
-
-#: static/js/impala/persona_creation.js:69
-msgid "Creative Commons Attribution-NonCommercial 3.0"
-msgstr ""
-
-#: static/js/impala/persona_creation.js:74
-msgid "Creative Commons Attribution-NonCommercial-NoDerivs 3.0"
-msgstr ""
-
-#: static/js/impala/persona_creation.js:79
-msgid "Creative Commons Attribution-NonCommercial-Share Alike 3.0"
-msgstr ""
-
-#: static/js/impala/persona_creation.js:84
-msgid "Creative Commons Attribution-NoDerivs 3.0"
-msgstr ""
-
-#: static/js/impala/persona_creation.js:89
-msgid "Creative Commons Attribution-ShareAlike 3.0"
-msgstr ""
-
-#: static/js/impala/persona_creation.js:292
-msgid "Your Theme's Name"
-msgstr ""
-
-#: static/js/impala/reviews.js:23 static/js/zamboni/reviews.js:18
-msgid "Flagged for review"
-msgstr ""
-
-#: static/js/impala/reviews.js:40 static/js/zamboni/reviews.js:34
-msgid "Your input is required"
-msgstr ""
-
-#: static/js/impala/reviews.js:152 static/js/zamboni/reviews.js:103
-msgid "Marked for deletion"
-msgstr ""
-
-#: static/js/impala/search.js:114
-msgid "Updating results&hellip;"
-msgstr ""
-
-#: static/js/impala/site_suggestions.js:46
-msgid "Category"
-msgstr ""
-
-#: static/js/impala/suggestions.js:39
-msgid "Search themes for <b>{0}</b>"
-msgstr ""
-
-#: static/js/impala/suggestions.js:41
-msgid "Search apps for <b>{0}</b>"
-msgstr ""
-
-#: static/js/impala/suggestions.js:43
-msgid "Search add-ons for <b>{0}</b>"
-msgstr ""
-
-#: static/js/impala/users.js:33
-msgid "use original"
-msgstr ""
-
-#: static/js/impala/stats/chart.js:267
+#: static/js/impala/stats/chart.js:267 static/js/zamboni/stats-all.js:16898 static/js/zamboni/stats-min.js:5
 msgid "Week of {0}"
 msgstr ""
 
-#: static/js/impala/stats/chart.js:269
+#: static/js/impala/stats/chart.js:269 static/js/zamboni/stats-all.js:16900 static/js/zamboni/stats-min.js:5
 msgid " downloads"
 msgstr ""
 
-#: static/js/impala/stats/chart.js:270
+#: static/js/impala/stats/chart.js:270 static/js/zamboni/stats-all.js:16901 static/js/zamboni/stats-min.js:5
 msgid "{0} users"
 msgstr ""
 
-#: static/js/impala/stats/chart.js:271
+#: static/js/impala/stats/chart.js:271 static/js/zamboni/stats-all.js:16902 static/js/zamboni/stats-min.js:5
 msgid "{0} add-ons"
 msgstr ""
 
-#: static/js/impala/stats/chart.js:272
+#: static/js/impala/stats/chart.js:272 static/js/zamboni/stats-all.js:16903 static/js/zamboni/stats-min.js:5
 msgid "{0} collections"
 msgstr ""
 
-#: static/js/impala/stats/chart.js:273
+#: static/js/impala/stats/chart.js:273 static/js/zamboni/stats-all.js:16904 static/js/zamboni/stats-min.js:5
 msgid "{0} reviews"
 msgstr ""
 
-#: static/js/impala/stats/chart.js:275
+#: static/js/impala/stats/chart.js:275 static/js/zamboni/stats-all.js:16906 static/js/zamboni/stats-min.js:5
 msgid "{0} sales"
 msgstr ""
 
-#: static/js/impala/stats/chart.js:276
+#: static/js/impala/stats/chart.js:276 static/js/zamboni/stats-all.js:16907 static/js/zamboni/stats-min.js:5
 msgid "{0} refunds"
 msgstr ""
 
-#: static/js/impala/stats/chart.js:277
+#: static/js/impala/stats/chart.js:277 static/js/zamboni/stats-all.js:16908 static/js/zamboni/stats-min.js:5
 msgid "{0} installs"
 msgstr ""
 
-#: static/js/impala/stats/chart.js:369 static/js/impala/stats/csv_keys.js:3 static/js/impala/stats/csv_keys.js:109
+#: static/js/impala/stats/chart.js:369 static/js/impala/stats/csv_keys.js:3 static/js/impala/stats/csv_keys.js:109 static/js/zamboni/stats-all.js:15284 static/js/zamboni/stats-all.js:15390
+#: static/js/zamboni/stats-all.js:17000 static/js/zamboni/stats-min.js:4 static/js/zamboni/stats-min.js:5
 msgid "Downloads"
 msgstr ""
 
-#: static/js/impala/stats/chart.js:379 static/js/impala/stats/csv_keys.js:6 static/js/impala/stats/csv_keys.js:110
+#: static/js/impala/stats/chart.js:379 static/js/impala/stats/csv_keys.js:6 static/js/impala/stats/csv_keys.js:110 static/js/zamboni/stats-all.js:15287 static/js/zamboni/stats-all.js:15391
+#: static/js/zamboni/stats-all.js:17010 static/js/zamboni/stats-min.js:4 static/js/zamboni/stats-min.js:5
 msgid "Daily Users"
 msgstr ""
 
-#: static/js/impala/stats/chart.js:410
+#: static/js/impala/stats/chart.js:410 static/js/zamboni/stats-all.js:17041 static/js/zamboni/stats-min.js:5
 msgid "Amount, in USD"
 msgstr ""
 
-#: static/js/impala/stats/chart.js:421 static/js/impala/stats/csv_keys.js:104
+#: static/js/impala/stats/chart.js:421 static/js/impala/stats/csv_keys.js:104 static/js/zamboni/stats-all.js:15385 static/js/zamboni/stats-all.js:17052 static/js/zamboni/stats-min.js:5
 msgid "Number of Contributions"
 msgstr ""
 
-#: static/js/impala/stats/chart.js:447
+#: static/js/impala/stats/chart.js:447 static/js/zamboni/stats-all.js:17078 static/js/zamboni/stats-min.js:5
 msgid "More Info..."
 msgstr ""
 
 #. L10n: {0} is an ISO-formatted date.
-#: static/js/impala/stats/chart.js:451
+#: static/js/impala/stats/chart.js:451 static/js/zamboni/stats-all.js:17082 static/js/zamboni/stats-min.js:5
 msgid "Details for {0}"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:9
+#: static/js/impala/stats/csv_keys.js:9 static/js/zamboni/stats-all.js:15290 static/js/zamboni/stats-min.js:4
 msgid "Collections Created"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:12
+#: static/js/impala/stats/csv_keys.js:12 static/js/zamboni/stats-all.js:15293 static/js/zamboni/stats-min.js:4
 msgid "Add-ons in Use"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:15
+#: static/js/impala/stats/csv_keys.js:15 static/js/zamboni/stats-all.js:15296 static/js/zamboni/stats-min.js:4
 msgid "Add-ons Created"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:18
+#: static/js/impala/stats/csv_keys.js:18 static/js/zamboni/stats-all.js:15299 static/js/zamboni/stats-min.js:4
 msgid "Add-ons Downloaded"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:21
+#: static/js/impala/stats/csv_keys.js:21 static/js/zamboni/stats-all.js:15302 static/js/zamboni/stats-min.js:4
 msgid "Add-ons Updated"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:24
+#: static/js/impala/stats/csv_keys.js:24 static/js/zamboni/stats-all.js:15305 static/js/zamboni/stats-min.js:4
 msgid "Reviews Written"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:27
+#: static/js/impala/stats/csv_keys.js:27 static/js/zamboni/stats-all.js:15308 static/js/zamboni/stats-min.js:4
 msgid "User Signups"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:30
+#: static/js/impala/stats/csv_keys.js:30 static/js/zamboni/stats-all.js:15311 static/js/zamboni/stats-min.js:4
 msgid "Subscribers"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:33
+#: static/js/impala/stats/csv_keys.js:33 static/js/zamboni/stats-all.js:15314 static/js/zamboni/stats-min.js:4
 msgid "Ratings"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:36 static/js/impala/stats/csv_keys.js:114
+#: static/js/impala/stats/csv_keys.js:36 static/js/impala/stats/csv_keys.js:114 static/js/zamboni/stats-all.js:15317 static/js/zamboni/stats-all.js:15395 static/js/zamboni/stats-min.js:4
+#: static/js/zamboni/stats-min.js:5
 msgid "Sales"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:39 static/js/impala/stats/csv_keys.js:113
+#: static/js/impala/stats/csv_keys.js:39 static/js/impala/stats/csv_keys.js:113 static/js/zamboni/stats-all.js:15320 static/js/zamboni/stats-all.js:15394 static/js/zamboni/stats-min.js:4
+#: static/js/zamboni/stats-min.js:5
 msgid "Installs"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:42
+#: static/js/impala/stats/csv_keys.js:42 static/js/zamboni/stats-all.js:15323 static/js/zamboni/stats-min.js:4
 msgid "Unknown"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:43
+#: static/js/impala/stats/csv_keys.js:43 static/js/zamboni/stats-all.js:15324 static/js/zamboni/stats-min.js:4
 msgid "Add-ons Manager"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:44
+#: static/js/impala/stats/csv_keys.js:44 static/js/zamboni/stats-all.js:15325 static/js/zamboni/stats-min.js:4
 msgid "Add-ons Manager Promo"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:45
+#: static/js/impala/stats/csv_keys.js:45 static/js/zamboni/stats-all.js:15326 static/js/zamboni/stats-min.js:4
 msgid "Add-ons Manager Featured"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:46
+#: static/js/impala/stats/csv_keys.js:46 static/js/zamboni/stats-all.js:15327 static/js/zamboni/stats-min.js:4
 msgid "Add-ons Manager Learn More"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:47
+#: static/js/impala/stats/csv_keys.js:47 static/js/zamboni/stats-all.js:15328 static/js/zamboni/stats-min.js:4
 msgid "Search Suggestions"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:48
+#: static/js/impala/stats/csv_keys.js:48 static/js/zamboni/stats-all.js:15329 static/js/zamboni/stats-min.js:4
 msgid "Search Results"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:49 static/js/impala/stats/csv_keys.js:50 static/js/impala/stats/csv_keys.js:51
+#: static/js/impala/stats/csv_keys.js:49 static/js/impala/stats/csv_keys.js:50 static/js/impala/stats/csv_keys.js:51 static/js/zamboni/stats-all.js:15330 static/js/zamboni/stats-all.js:15331
+#: static/js/zamboni/stats-all.js:15332 static/js/zamboni/stats-min.js:4
 msgid "Homepage Promo"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:52 static/js/impala/stats/csv_keys.js:53
+#: static/js/impala/stats/csv_keys.js:52 static/js/impala/stats/csv_keys.js:53 static/js/zamboni/stats-all.js:15333 static/js/zamboni/stats-all.js:15334 static/js/zamboni/stats-min.js:4
 msgid "Homepage Featured"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:54 static/js/impala/stats/csv_keys.js:55
+#: static/js/impala/stats/csv_keys.js:54 static/js/impala/stats/csv_keys.js:55 static/js/zamboni/stats-all.js:15335 static/js/zamboni/stats-all.js:15336 static/js/zamboni/stats-min.js:4
 msgid "Homepage Up and Coming"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:56
+#: static/js/impala/stats/csv_keys.js:56 static/js/zamboni/stats-all.js:15337 static/js/zamboni/stats-min.js:4
 msgid "Homepage Most Popular"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:57 static/js/impala/stats/csv_keys.js:59
+#: static/js/impala/stats/csv_keys.js:57 static/js/impala/stats/csv_keys.js:59 static/js/zamboni/stats-all.js:15338 static/js/zamboni/stats-all.js:15340 static/js/zamboni/stats-min.js:4
 msgid "Detail Page"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:58 static/js/impala/stats/csv_keys.js:60
+#: static/js/impala/stats/csv_keys.js:58 static/js/impala/stats/csv_keys.js:60 static/js/zamboni/stats-all.js:15339 static/js/zamboni/stats-all.js:15341 static/js/zamboni/stats-min.js:4
 msgid "Detail Page (bottom)"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:61
+#: static/js/impala/stats/csv_keys.js:61 static/js/zamboni/stats-all.js:15342 static/js/zamboni/stats-min.js:4
 msgid "Detail Page (Development Channel)"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:62 static/js/impala/stats/csv_keys.js:63 static/js/impala/stats/csv_keys.js:64
+#: static/js/impala/stats/csv_keys.js:62 static/js/impala/stats/csv_keys.js:63 static/js/impala/stats/csv_keys.js:64 static/js/zamboni/stats-all.js:15343 static/js/zamboni/stats-all.js:15344
+#: static/js/zamboni/stats-all.js:15345 static/js/zamboni/stats-min.js:4
 msgid "Often Used With"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:65 static/js/impala/stats/csv_keys.js:66
+#: static/js/impala/stats/csv_keys.js:65 static/js/impala/stats/csv_keys.js:66 static/js/zamboni/stats-all.js:15346 static/js/zamboni/stats-all.js:15347 static/js/zamboni/stats-min.js:4
 msgid "Others By Author"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:67 static/js/impala/stats/csv_keys.js:68
+#: static/js/impala/stats/csv_keys.js:67 static/js/impala/stats/csv_keys.js:68 static/js/zamboni/stats-all.js:15348 static/js/zamboni/stats-all.js:15349 static/js/zamboni/stats-min.js:4
 msgid "Dependencies"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:69 static/js/impala/stats/csv_keys.js:70
+#: static/js/impala/stats/csv_keys.js:69 static/js/impala/stats/csv_keys.js:70 static/js/zamboni/stats-all.js:15350 static/js/zamboni/stats-all.js:15351 static/js/zamboni/stats-min.js:4
 msgid "Upsell"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:71
+#: static/js/impala/stats/csv_keys.js:71 static/js/zamboni/stats-all.js:15352 static/js/zamboni/stats-min.js:4
 msgid "Meet the Developer"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:72
+#: static/js/impala/stats/csv_keys.js:72 static/js/zamboni/stats-all.js:15353 static/js/zamboni/stats-min.js:4
 msgid "User Profile"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:73
+#: static/js/impala/stats/csv_keys.js:73 static/js/zamboni/stats-all.js:15354 static/js/zamboni/stats-min.js:4
 msgid "Version History"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:75
+#: static/js/impala/stats/csv_keys.js:75 static/js/zamboni/stats-all.js:15356 static/js/zamboni/stats-min.js:4
 msgid "Sharing"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:76
+#: static/js/impala/stats/csv_keys.js:76 static/js/zamboni/stats-all.js:15357 static/js/zamboni/stats-min.js:4
 msgid "Category Pages"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:77
+#: static/js/impala/stats/csv_keys.js:77 static/js/zamboni/stats-all.js:15358 static/js/zamboni/stats-min.js:4
 msgid "Collections"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:78 static/js/impala/stats/csv_keys.js:79
+#: static/js/impala/stats/csv_keys.js:78 static/js/impala/stats/csv_keys.js:79 static/js/zamboni/stats-all.js:15359 static/js/zamboni/stats-all.js:15360 static/js/zamboni/stats-min.js:4
 msgid "Category Landing Featured Carousel"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:80 static/js/impala/stats/csv_keys.js:81
+#: static/js/impala/stats/csv_keys.js:80 static/js/impala/stats/csv_keys.js:81 static/js/zamboni/stats-all.js:15361 static/js/zamboni/stats-all.js:15362 static/js/zamboni/stats-min.js:4
 msgid "Category Landing Top Rated"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:82 static/js/impala/stats/csv_keys.js:83
+#: static/js/impala/stats/csv_keys.js:82 static/js/impala/stats/csv_keys.js:83 static/js/zamboni/stats-all.js:15363 static/js/zamboni/stats-all.js:15364 static/js/zamboni/stats-min.js:5
 msgid "Category Landing Most Popular"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:84 static/js/impala/stats/csv_keys.js:85
+#: static/js/impala/stats/csv_keys.js:84 static/js/impala/stats/csv_keys.js:85 static/js/zamboni/stats-all.js:15365 static/js/zamboni/stats-all.js:15366 static/js/zamboni/stats-min.js:5
 msgid "Category Landing Recently Added"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:86 static/js/impala/stats/csv_keys.js:87
+#: static/js/impala/stats/csv_keys.js:86 static/js/impala/stats/csv_keys.js:87 static/js/zamboni/stats-all.js:15367 static/js/zamboni/stats-all.js:15368 static/js/zamboni/stats-min.js:5
 msgid "Browse Listing Featured Sort"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:88 static/js/impala/stats/csv_keys.js:89
+#: static/js/impala/stats/csv_keys.js:88 static/js/impala/stats/csv_keys.js:89 static/js/zamboni/stats-all.js:15369 static/js/zamboni/stats-all.js:15370 static/js/zamboni/stats-min.js:5
 msgid "Browse Listing Users Sort"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:90 static/js/impala/stats/csv_keys.js:91
+#: static/js/impala/stats/csv_keys.js:90 static/js/impala/stats/csv_keys.js:91 static/js/zamboni/stats-all.js:15371 static/js/zamboni/stats-all.js:15372 static/js/zamboni/stats-min.js:5
 msgid "Browse Listing Rating Sort"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:92 static/js/impala/stats/csv_keys.js:93
+#: static/js/impala/stats/csv_keys.js:92 static/js/impala/stats/csv_keys.js:93 static/js/zamboni/stats-all.js:15373 static/js/zamboni/stats-all.js:15374 static/js/zamboni/stats-min.js:5
 msgid "Browse Listing Created Sort"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:94 static/js/impala/stats/csv_keys.js:95
+#: static/js/impala/stats/csv_keys.js:94 static/js/impala/stats/csv_keys.js:95 static/js/zamboni/stats-all.js:15375 static/js/zamboni/stats-all.js:15376 static/js/zamboni/stats-min.js:5
 msgid "Browse Listing Name Sort"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:96 static/js/impala/stats/csv_keys.js:97
+#: static/js/impala/stats/csv_keys.js:96 static/js/impala/stats/csv_keys.js:97 static/js/zamboni/stats-all.js:15377 static/js/zamboni/stats-all.js:15378 static/js/zamboni/stats-min.js:5
 msgid "Browse Listing Popular Sort"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:98 static/js/impala/stats/csv_keys.js:99
+#: static/js/impala/stats/csv_keys.js:98 static/js/impala/stats/csv_keys.js:99 static/js/zamboni/stats-all.js:15379 static/js/zamboni/stats-all.js:15380 static/js/zamboni/stats-min.js:5
 msgid "Browse Listing Updated Sort"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:100 static/js/impala/stats/csv_keys.js:101
+#: static/js/impala/stats/csv_keys.js:100 static/js/impala/stats/csv_keys.js:101 static/js/zamboni/stats-all.js:15381 static/js/zamboni/stats-all.js:15382 static/js/zamboni/stats-min.js:5
 msgid "Browse Listing Up and Coming Sort"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:105
+#: static/js/impala/stats/csv_keys.js:105 static/js/zamboni/stats-all.js:15386 static/js/zamboni/stats-min.js:5
 msgid "Total Amount Contributed"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:106
+#: static/js/impala/stats/csv_keys.js:106 static/js/zamboni/stats-all.js:15387 static/js/zamboni/stats-min.js:5
 msgid "Average Contribution"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:115
+#: static/js/impala/stats/csv_keys.js:115 static/js/zamboni/stats-all.js:15396 static/js/zamboni/stats-min.js:5
 msgid "Usage"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:118
+#: static/js/impala/stats/csv_keys.js:118 static/js/zamboni/stats-all.js:15399 static/js/zamboni/stats-min.js:5
 msgid "Firefox"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:119
+#: static/js/impala/stats/csv_keys.js:119 static/js/zamboni/stats-all.js:15400 static/js/zamboni/stats-min.js:5
 msgid "Mozilla"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:120
+#: static/js/impala/stats/csv_keys.js:120 static/js/zamboni/stats-all.js:15401 static/js/zamboni/stats-min.js:5
 msgid "Thunderbird"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:121
+#: static/js/impala/stats/csv_keys.js:121 static/js/zamboni/stats-all.js:15402 static/js/zamboni/stats-min.js:5
 msgid "Sunbird"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:122
+#: static/js/impala/stats/csv_keys.js:122 static/js/zamboni/stats-all.js:15403 static/js/zamboni/stats-min.js:5
 msgid "SeaMonkey"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:123
+#: static/js/impala/stats/csv_keys.js:123 static/js/zamboni/stats-all.js:15404 static/js/zamboni/stats-min.js:5
 msgid "Fennec"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:124
+#: static/js/impala/stats/csv_keys.js:124 static/js/zamboni/stats-all.js:15405 static/js/zamboni/stats-min.js:5
 msgid "Android"
 msgstr ""
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:129
+#: static/js/impala/stats/csv_keys.js:129 static/js/zamboni/stats-all.js:15410 static/js/zamboni/stats-min.js:5
 msgid "Downloads and Daily Users, last {0} days"
 msgstr ""
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:131
+#: static/js/impala/stats/csv_keys.js:131 static/js/zamboni/stats-all.js:15412 static/js/zamboni/stats-min.js:5
 msgid "Downloads and Daily Users from {0} to {1}"
 msgstr ""
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:135
+#: static/js/impala/stats/csv_keys.js:135 static/js/zamboni/stats-all.js:15416 static/js/zamboni/stats-min.js:5
 msgid "Installs and Daily Users, last {0} days"
 msgstr ""
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:137
+#: static/js/impala/stats/csv_keys.js:137 static/js/zamboni/stats-all.js:15418 static/js/zamboni/stats-min.js:5
 msgid "Installs and Daily Users from {0} to {1}"
 msgstr ""
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:141
+#: static/js/impala/stats/csv_keys.js:141 static/js/zamboni/stats-all.js:15422 static/js/zamboni/stats-min.js:5
 msgid "Downloads, last {0} days"
 msgstr ""
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:143
+#: static/js/impala/stats/csv_keys.js:143 static/js/zamboni/stats-all.js:15424 static/js/zamboni/stats-min.js:5
 msgid "Downloads from {0} to {1}"
 msgstr ""
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:147
+#: static/js/impala/stats/csv_keys.js:147 static/js/zamboni/stats-all.js:15428 static/js/zamboni/stats-min.js:5
 msgid "Daily Users, last {0} days"
 msgstr ""
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:149
+#: static/js/impala/stats/csv_keys.js:149 static/js/zamboni/stats-all.js:15430 static/js/zamboni/stats-min.js:5
 msgid "Daily Users from {0} to {1}"
 msgstr ""
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:153
+#: static/js/impala/stats/csv_keys.js:153 static/js/zamboni/stats-all.js:15434 static/js/zamboni/stats-min.js:5
 msgid "Applications, last {0} days"
 msgstr ""
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:155
+#: static/js/impala/stats/csv_keys.js:155 static/js/zamboni/stats-all.js:15436 static/js/zamboni/stats-min.js:5
 msgid "Applications from {0} to {1}"
 msgstr ""
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:159
+#: static/js/impala/stats/csv_keys.js:159 static/js/zamboni/stats-all.js:15440 static/js/zamboni/stats-min.js:5
 msgid "Platforms, last {0} days"
 msgstr ""
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:161
+#: static/js/impala/stats/csv_keys.js:161 static/js/zamboni/stats-all.js:15442 static/js/zamboni/stats-min.js:5
 msgid "Platforms from {0} to {1}"
 msgstr ""
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:165
+#: static/js/impala/stats/csv_keys.js:165 static/js/zamboni/stats-all.js:15446 static/js/zamboni/stats-min.js:5
 msgid "Languages, last {0} days"
 msgstr ""
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:167
+#: static/js/impala/stats/csv_keys.js:167 static/js/zamboni/stats-all.js:15448 static/js/zamboni/stats-min.js:5
 msgid "Languages from {0} to {1}"
 msgstr ""
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:171
+#: static/js/impala/stats/csv_keys.js:171 static/js/zamboni/stats-all.js:15452 static/js/zamboni/stats-min.js:5
 msgid "Add-on Versions, last {0} days"
 msgstr ""
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:173
+#: static/js/impala/stats/csv_keys.js:173 static/js/zamboni/stats-all.js:15454 static/js/zamboni/stats-min.js:5
 msgid "Add-on Versions from {0} to {1}"
 msgstr ""
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:177
+#: static/js/impala/stats/csv_keys.js:177 static/js/zamboni/stats-all.js:15458 static/js/zamboni/stats-min.js:5
 msgid "Add-on Status, last {0} days"
 msgstr ""
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:179
+#: static/js/impala/stats/csv_keys.js:179 static/js/zamboni/stats-all.js:15460 static/js/zamboni/stats-min.js:5
 msgid "Add-on Status from {0} to {1}"
 msgstr ""
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:183
+#: static/js/impala/stats/csv_keys.js:183 static/js/zamboni/stats-all.js:15464 static/js/zamboni/stats-min.js:5
 msgid "Download Sources, last {0} days"
 msgstr ""
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:185
+#: static/js/impala/stats/csv_keys.js:185 static/js/zamboni/stats-all.js:15466 static/js/zamboni/stats-min.js:5
 msgid "Download Sources from {0} to {1}"
 msgstr ""
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:189
+#: static/js/impala/stats/csv_keys.js:189 static/js/zamboni/stats-all.js:15470 static/js/zamboni/stats-min.js:5
 msgid "Contributions, last {0} days"
 msgstr ""
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:191
+#: static/js/impala/stats/csv_keys.js:191 static/js/zamboni/stats-all.js:15472 static/js/zamboni/stats-min.js:5
 msgid "Contributions from {0} to {1}"
 msgstr ""
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:195
+#: static/js/impala/stats/csv_keys.js:195 static/js/zamboni/stats-all.js:15476 static/js/zamboni/stats-min.js:5
 msgid "Site Metrics, last {0} days"
 msgstr ""
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:197
+#: static/js/impala/stats/csv_keys.js:197 static/js/zamboni/stats-all.js:15478 static/js/zamboni/stats-min.js:5
 msgid "Site Metrics from {0} to {1}"
 msgstr ""
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:201
+#: static/js/impala/stats/csv_keys.js:201 static/js/zamboni/stats-all.js:15482 static/js/zamboni/stats-min.js:5
 msgid "Add-ons in Use, last {0} days"
 msgstr ""
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:203
+#: static/js/impala/stats/csv_keys.js:203 static/js/zamboni/stats-all.js:15484 static/js/zamboni/stats-min.js:5
 msgid "Add-ons in Use from {0} to {1}"
 msgstr ""
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:207
+#: static/js/impala/stats/csv_keys.js:207 static/js/zamboni/stats-all.js:15488 static/js/zamboni/stats-min.js:5
 msgid "Add-ons Downloaded, last {0} days"
 msgstr ""
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:209
+#: static/js/impala/stats/csv_keys.js:209 static/js/zamboni/stats-all.js:15490 static/js/zamboni/stats-min.js:5
 msgid "Add-ons Downloaded from {0} to {1}"
 msgstr ""
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:213
+#: static/js/impala/stats/csv_keys.js:213 static/js/zamboni/stats-all.js:15494 static/js/zamboni/stats-min.js:5
 msgid "Add-ons Created, last {0} days"
 msgstr ""
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:215
+#: static/js/impala/stats/csv_keys.js:215 static/js/zamboni/stats-all.js:15496 static/js/zamboni/stats-min.js:5
 msgid "Add-ons Created from {0} to {1}"
 msgstr ""
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:219
+#: static/js/impala/stats/csv_keys.js:219 static/js/zamboni/stats-all.js:15500 static/js/zamboni/stats-min.js:5
 msgid "Add-ons Updated, last {0} days"
 msgstr ""
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:221
+#: static/js/impala/stats/csv_keys.js:221 static/js/zamboni/stats-all.js:15502 static/js/zamboni/stats-min.js:5
 msgid "Add-ons Updated from {0} to {1}"
 msgstr ""
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:225
+#: static/js/impala/stats/csv_keys.js:225 static/js/zamboni/stats-all.js:15506 static/js/zamboni/stats-min.js:5
 msgid "Reviews Written, last {0} days"
 msgstr ""
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:227
+#: static/js/impala/stats/csv_keys.js:227 static/js/zamboni/stats-all.js:15508 static/js/zamboni/stats-min.js:5
 msgid "Reviews Written from {0} to {1}"
 msgstr ""
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:231
+#: static/js/impala/stats/csv_keys.js:231 static/js/zamboni/stats-all.js:15512 static/js/zamboni/stats-min.js:5
 msgid "User Signups, last {0} days"
 msgstr ""
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:233
+#: static/js/impala/stats/csv_keys.js:233 static/js/zamboni/stats-all.js:15514 static/js/zamboni/stats-min.js:5
 msgid "User Signups from {0} to {1}"
 msgstr ""
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:237
+#: static/js/impala/stats/csv_keys.js:237 static/js/zamboni/stats-all.js:15518 static/js/zamboni/stats-min.js:5
 msgid "Collections Created, last {0} days"
 msgstr ""
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:239
+#: static/js/impala/stats/csv_keys.js:239 static/js/zamboni/stats-all.js:15520 static/js/zamboni/stats-min.js:5
 msgid "Collections Created from {0} to {1}"
 msgstr ""
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:243
+#: static/js/impala/stats/csv_keys.js:243 static/js/zamboni/stats-all.js:15524 static/js/zamboni/stats-min.js:5
 msgid "Subscribers, last {0} days"
 msgstr ""
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:245
+#: static/js/impala/stats/csv_keys.js:245 static/js/zamboni/stats-all.js:15526 static/js/zamboni/stats-min.js:5
 msgid "Subscribers from {0} to {1}"
 msgstr ""
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:249
+#: static/js/impala/stats/csv_keys.js:249 static/js/zamboni/stats-all.js:15530 static/js/zamboni/stats-min.js:5
 msgid "Ratings, last {0} days"
 msgstr ""
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:251
+#: static/js/impala/stats/csv_keys.js:251 static/js/zamboni/stats-all.js:15532 static/js/zamboni/stats-min.js:5
 msgid "Ratings from {0} to {1}"
 msgstr ""
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:255
+#: static/js/impala/stats/csv_keys.js:255 static/js/zamboni/stats-all.js:15536 static/js/zamboni/stats-min.js:5
 msgid "Sales, last {0} days"
 msgstr ""
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:257
+#: static/js/impala/stats/csv_keys.js:257 static/js/zamboni/stats-all.js:15538 static/js/zamboni/stats-min.js:5
 msgid "Sales from {0} to {1}"
 msgstr ""
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:261
+#: static/js/impala/stats/csv_keys.js:261 static/js/zamboni/stats-all.js:15542 static/js/zamboni/stats-min.js:5
 msgid "Installs, last {0} days"
 msgstr ""
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:263
+#: static/js/impala/stats/csv_keys.js:263 static/js/zamboni/stats-all.js:15544 static/js/zamboni/stats-min.js:5
 msgid "Installs from {0} to {1}"
 msgstr ""
 
 #. L10n: {0} and {1} are integers.
-#: static/js/impala/stats/csv_keys.js:269
+#: static/js/impala/stats/csv_keys.js:269 static/js/zamboni/stats-all.js:15550 static/js/zamboni/stats-min.js:5
 msgid "<b>{0}</b> in last {1} days"
 msgstr ""
 
 #. L10n: {0} is an integer and {1} and {2} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:271 static/js/impala/stats/csv_keys.js:277
+#: static/js/impala/stats/csv_keys.js:271 static/js/impala/stats/csv_keys.js:277 static/js/zamboni/stats-all.js:15552 static/js/zamboni/stats-all.js:15558 static/js/zamboni/stats-min.js:5
 msgid "<b>{0}</b> from {1} to {2}"
 msgstr ""
 
 #. L10n: {0} and {1} are integers.
-#: static/js/impala/stats/csv_keys.js:275
+#: static/js/impala/stats/csv_keys.js:275 static/js/zamboni/stats-all.js:15556 static/js/zamboni/stats-min.js:5
 msgid "<b>{0}</b> average in last {1} days"
 msgstr ""
 
-#: static/js/impala/stats/overview.js:19
+#: static/js/impala/stats/overview.js:19 static/js/zamboni/stats-all.js:16469 static/js/zamboni/stats-min.js:5
 msgid "No data available."
 msgstr ""
 
-#: static/js/impala/stats/table.js:74
+#: static/js/impala/stats/table.js:74 static/js/zamboni/stats-all.js:17209 static/js/zamboni/stats-min.js:5
 msgid "Date"
 msgstr ""
 
-#: static/js/impala/stats/topchart.js:96
+#: static/js/impala/stats/topchart.js:96 static/js/zamboni/stats-all.js:16600 static/js/zamboni/stats-min.js:5
 msgid "Other"
 msgstr ""
 
-#: static/js/zamboni/admin_validation.js:24 static/js/zamboni/devhub.js:1229 static/js/zamboni/editors.js:295
+#: static/js/zamboni/admin-all.js:180 static/js/zamboni/admin-min.js:1 static/js/zamboni/admin_validation.js:24 static/js/zamboni/devhub-all.js:2408 static/js/zamboni/devhub-min.js:2
+#: static/js/zamboni/devhub.js:1229 static/js/zamboni/editors-all.js:15576 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:295
 msgid "Select an application first"
 msgstr ""
 
-#: static/js/zamboni/admin_validation.js:51
+#: static/js/zamboni/admin-all.js:207 static/js/zamboni/admin-min.js:1 static/js/zamboni/admin_validation.js:51
 msgid "Set {0} add-on to a max version of {1} and email the author."
 msgid_plural "Set {0} add-ons to a max version of {1} and email the authors."
 msgstr[0] ""
 msgstr[1] ""
 
-#: static/js/zamboni/admin_validation.js:54
+#: static/js/zamboni/admin-all.js:210 static/js/zamboni/admin-min.js:1 static/js/zamboni/admin_validation.js:54
 msgid "Email author of {2} add-on which failed validation."
 msgid_plural "Email authors of {2} add-ons which failed validation."
 msgstr[0] ""
 msgstr[1] ""
 
-#. L10n: {0} is an app name like Firefox.
-#: static/js/zamboni/buttons.js:66
-msgid "Accept and Install"
-msgstr ""
-
-#: static/js/zamboni/buttons.js:66
-msgid "Add to {0}"
-msgstr ""
-
-#: static/js/zamboni/buttons.js:71
-msgid "Download Now"
-msgstr ""
-
-#: static/js/zamboni/buttons.js:112
-msgid "Add-on has not been updated to support default-to-compatible."
-msgstr ""
-
-#: static/js/zamboni/buttons.js:117
-msgid "You need to be using Firefox 10.0 or higher."
-msgstr ""
-
-#: static/js/zamboni/buttons.js:129
-msgid "Mozilla has marked this version as incompatible with your Firefox version."
-msgstr ""
-
-#. L10n: {0} is an platform like Windows or Linux.
-#: static/js/zamboni/buttons.js:210
-msgid "Install for {0} anyway"
-msgstr ""
-
-#: static/js/zamboni/buttons.js:210
-msgid "Download for {0} anyway"
-msgstr ""
-
-#: static/js/zamboni/buttons.js:267
-msgid "Not available for your platform"
-msgstr ""
-
-#. L10n: {0} is an app name, {1} is the app version.
-#: static/js/zamboni/buttons.js:278 static/js/zamboni/buttons.js:315
-msgid "Not available for {0} {1}"
-msgstr ""
-
-#: static/js/zamboni/buttons.js:341
-msgid "Works with {app} {min} - {max}"
-msgstr ""
-
-#: static/js/zamboni/buttons.js:343
-msgid "View other versions"
-msgstr ""
-
-#: static/js/zamboni/buttons.js:391
-msgid "Only with Firefox — Get Firefox Now!"
-msgstr ""
-
-#: static/js/zamboni/buttons.js:507 static/js/zamboni/mobile/buttons.js:43
-msgid "Sorry, you need a Mozilla-based browser (such as Firefox) to install a search plugin."
-msgstr ""
-
-#: static/js/zamboni/collections.js:229
-msgid "Adding to Favorites&hellip;"
-msgstr ""
-
-#: static/js/zamboni/collections.js:232
-msgid "Removing Favorite&hellip;"
-msgstr ""
-
-#: static/js/zamboni/collections.js:235
-msgid "Add to Favorites"
-msgstr ""
-
-#: static/js/zamboni/collections.js:238
-msgid "Remove from Favorites"
-msgstr ""
-
-#: static/js/zamboni/collections.js:303
-msgid "Pending"
-msgstr ""
-
-#: static/js/zamboni/collections.js:304
-msgid "Add a comment"
-msgstr ""
-
-#: static/js/zamboni/collections.js:304
-msgid "Comment"
-msgstr ""
-
-#: static/js/zamboni/collections.js:305
-msgid "Remove this add-on from the collection"
-msgstr ""
-
-#: static/js/zamboni/collections.js:305 static/js/zamboni/collections.js:334
-msgid "Remove"
-msgstr ""
-
-#: static/js/zamboni/collections.js:334
-msgid "Remove this user as a contributor"
-msgstr ""
-
-#: static/js/zamboni/collections.js:346
-msgid "An email address is required."
-msgstr ""
-
-#: static/js/zamboni/collections.js:364
-msgid "You cannot add yourself as a contributor."
-msgstr ""
-
-#: static/js/zamboni/collections.js:366
-msgid "You have already added that user."
-msgstr ""
-
-#: static/js/zamboni/collections.js:573
-msgid "Add to favorites"
-msgstr ""
-
-#: static/js/zamboni/collections.js:577
-msgid "Remove from favorites"
-msgstr ""
-
-#: static/js/zamboni/collections.js:604
-msgid "Stop following"
-msgstr ""
-
-#: static/js/zamboni/devhub.js:110
+#: static/js/zamboni/devhub-all.js:1289 static/js/zamboni/devhub-min.js:1 static/js/zamboni/devhub.js:110
 msgid "Your browser does not support the video tag"
 msgstr ""
 
-#: static/js/zamboni/devhub.js:371
+#: static/js/zamboni/devhub-all.js:1550 static/js/zamboni/devhub-min.js:1 static/js/zamboni/devhub.js:371
 msgid "Changes Saved"
 msgstr ""
 
-#: static/js/zamboni/devhub.js:387
+#: static/js/zamboni/devhub-all.js:1566 static/js/zamboni/devhub-min.js:1 static/js/zamboni/devhub.js:387
 msgid "Enter a new author's email address"
 msgstr ""
 
-#: static/js/zamboni/devhub.js:536
+#: static/js/zamboni/devhub-all.js:1715 static/js/zamboni/devhub-min.js:1 static/js/zamboni/devhub.js:536
 msgid "There was an error uploading your file."
 msgstr ""
 
-#: static/js/zamboni/devhub.js:681
+#: static/js/zamboni/devhub-all.js:1860 static/js/zamboni/devhub-min.js:1 static/js/zamboni/devhub.js:681
 msgid "{files} file"
 msgid_plural "{files} files"
 msgstr[0] ""
 msgstr[1] ""
 
-#: static/js/zamboni/devhub.js:684
+#: static/js/zamboni/devhub-all.js:1863 static/js/zamboni/devhub-min.js:1 static/js/zamboni/devhub.js:684
 msgid "{reviews} user review"
 msgid_plural "{reviews} user reviews"
 msgstr[0] ""
 msgstr[1] ""
 
-#: static/js/zamboni/devhub.js:796
+#: static/js/zamboni/devhub-all.js:1975 static/js/zamboni/devhub-min.js:2 static/js/zamboni/devhub.js:796
 msgid "Learn more"
 msgstr ""
 
-#: static/js/zamboni/devhub.js:800
+#: static/js/zamboni/devhub-all.js:1979 static/js/zamboni/devhub-min.js:2 static/js/zamboni/devhub.js:800
 msgid "Example"
 msgstr ""
 
-#: static/js/zamboni/devhub.js:1130
+#: static/js/zamboni/devhub-all.js:2309 static/js/zamboni/devhub-min.js:2 static/js/zamboni/devhub.js:1130
 msgid "Image changes being processed"
 msgstr ""
 
-#: static/js/zamboni/devhub.js:1280
+#: static/js/zamboni/devhub-all.js:2459 static/js/zamboni/devhub-min.js:2 static/js/zamboni/devhub.js:1280
 msgid "Must be a valid e-mail address."
+msgstr ""
+
+#: static/js/zamboni/devhub-all.js:2613 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:80
+msgid "All tests passed successfully."
+msgstr ""
+
+#: static/js/zamboni/devhub-all.js:2616 static/js/zamboni/devhub-all.js:3011 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:83 static/js/zamboni/validator.js:478
+msgid "These tests were not run."
+msgstr ""
+
+#: static/js/zamboni/devhub-all.js:2664 static/js/zamboni/devhub-all.js:2677 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:131 static/js/zamboni/validator.js:144
+msgid "Tests"
+msgstr ""
+
+#: static/js/zamboni/devhub-all.js:2779 static/js/zamboni/devhub-all.js:3108 static/js/zamboni/devhub-all.js:3127 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:246
+#: static/js/zamboni/validator.js:575 static/js/zamboni/validator.js:594
+msgid "Error"
+msgstr ""
+
+#: static/js/zamboni/devhub-all.js:2780 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:247
+msgid "Warning"
+msgstr ""
+
+#: static/js/zamboni/devhub-all.js:2794 static/js/zamboni/devhub-min.js:2 static/js/zamboni/files-all.js:5657 static/js/zamboni/files-min.js:3 static/js/zamboni/files.js:411
+#: static/js/zamboni/validator.js:261
+msgid "Ignore this message in future updates"
+msgstr ""
+
+#: static/js/zamboni/devhub-all.js:2817 static/js/zamboni/devhub-min.js:2 static/js/zamboni/files-all.js:5663 static/js/zamboni/files-min.js:3 static/js/zamboni/files.js:417
+#: static/js/zamboni/validator.js:284
+msgid "Severity for automated signing:"
+msgstr ""
+
+#: static/js/zamboni/devhub-all.js:2832 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:299
+msgid "Suggestions for passing automated signing:"
+msgstr ""
+
+#: static/js/zamboni/devhub-all.js:2920 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:387
+msgid "Compatibility Tests"
+msgstr ""
+
+#: static/js/zamboni/devhub-all.js:2999 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:466
+msgid "Add-on failed validation."
+msgstr ""
+
+#: static/js/zamboni/devhub-all.js:3001 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:468
+msgid "Add-on passed validation."
+msgstr ""
+
+#: static/js/zamboni/devhub-all.js:3014 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:481
+msgid "{0} error"
+msgid_plural "{0} errors"
+msgstr[0] ""
+msgstr[1] ""
+
+#: static/js/zamboni/devhub-all.js:3016 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:483
+msgid "{0} warning"
+msgid_plural "{0} warnings"
+msgstr[0] ""
+msgstr[1] ""
+
+#: static/js/zamboni/devhub-all.js:3018 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:485
+msgid "{0} notice"
+msgid_plural "{0} notices"
+msgstr[0] ""
+msgstr[1] ""
+
+#: static/js/zamboni/devhub-all.js:3110 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:577
+msgid "Validation task could not complete or completed with errors"
+msgstr ""
+
+#: static/js/zamboni/devhub-all.js:3128 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:595
+msgid "Internal server error"
 msgstr ""
 
 #: static/js/zamboni/devhub_search.js:8
 msgid "No results found."
 msgstr ""
 
-#: static/js/zamboni/editors.js:121
+#: static/js/zamboni/editors-all.js:15402 static/js/zamboni/editors-min.js:4 static/js/zamboni/editors.js:121
 msgid "{name} was viewing this page first."
 msgstr ""
 
-#: static/js/zamboni/editors.js:171
+#: static/js/zamboni/editors-all.js:15452 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:171
 msgid "Receipt checked by app."
 msgstr ""
 
-#: static/js/zamboni/editors.js:173
+#: static/js/zamboni/editors-all.js:15454 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:173
 msgid "Receipt was not checked by app."
 msgstr ""
 
-#: static/js/zamboni/editors.js:244
+#: static/js/zamboni/editors-all.js:15525 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:244
 msgid "{name} was viewing this add-on first."
 msgstr ""
 
-#: static/js/zamboni/editors.js:255
+#: static/js/zamboni/editors-all.js:15536 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:255
 msgid "Loading&hellip;"
 msgstr ""
 
-#: static/js/zamboni/editors.js:260
+#: static/js/zamboni/editors-all.js:15541 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:260
 msgid "Version Notes"
 msgstr ""
 
-#: static/js/zamboni/editors.js:265
+#: static/js/zamboni/editors-all.js:15546 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:265
 msgid "Notes for Reviewers"
 msgstr ""
 
-#: static/js/zamboni/editors.js:270
+#: static/js/zamboni/editors-all.js:15551 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:270
 msgid "No version notes found"
 msgstr ""
 
-#: static/js/zamboni/editors.js:330
+#: static/js/zamboni/editors-all.js:15611 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:330
 msgid "Average Reviews"
 msgstr ""
 
-#: static/js/zamboni/editors.js:386
+#: static/js/zamboni/editors-all.js:15667 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:386
 msgid "Number of Reviews"
 msgstr ""
 
-#: static/js/zamboni/editors.js:445
+#: static/js/zamboni/editors-all.js:15726 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:445
 msgid "Error loading translation"
 msgstr ""
 
-#: static/js/zamboni/files.js:411 static/js/zamboni/validator.js:261
-msgid "Ignore this message in future updates"
-msgstr ""
-
-#: static/js/zamboni/files.js:417 static/js/zamboni/validator.js:284
-msgid "Severity for automated signing:"
-msgstr ""
-
-#: static/js/zamboni/global.js:410
-msgid "Loading..."
-msgstr ""
-
-#. L10n: {0} is the number of characters left.
-#: static/js/zamboni/global.js:474
-msgid "<b>{0}</b> character left."
-msgid_plural "<b>{0}</b> characters left."
-msgstr[0] ""
-msgstr[1] ""
-
-#: static/js/zamboni/init.js:28
-msgid "This feature is temporarily disabled while we perform website maintenance. Please check back a little later."
-msgstr ""
-
-#: static/js/zamboni/l10n.js:45
-msgid "Remove this localization"
-msgstr ""
-
-#: static/js/zamboni/password-strength.js:20
-msgid "Password strength:"
-msgstr ""
-
-#: static/js/zamboni/password-strength.js:26
-msgid "At least {0} character left."
-msgid_plural "At least {0} characters left."
-msgstr[0] ""
-msgstr[1] ""
-
-#: static/js/zamboni/themes_review.js:176
-msgid "Requested Info"
-msgstr ""
-
-#: static/js/zamboni/themes_review.js:177
-msgid "Flagged"
-msgstr ""
-
-#: static/js/zamboni/themes_review.js:178
-msgid "Duplicate"
-msgstr ""
-
-#: static/js/zamboni/themes_review.js:179
-msgid "Rejected"
-msgstr ""
-
-#: static/js/zamboni/themes_review.js:180
-msgid "Approved"
-msgstr ""
-
-#: static/js/zamboni/themes_review.js:424
-msgid "No results found"
-msgstr ""
-
-#: static/js/zamboni/themes_review_templates.js:31
+#: static/js/zamboni/editors-all.js:15975 static/js/zamboni/editors-min.js:5 static/js/zamboni/themes_review_templates.js:31
 msgid "Theme"
 msgstr ""
 
-#: static/js/zamboni/themes_review_templates.js:33
+#: static/js/zamboni/editors-all.js:15977 static/js/zamboni/editors-min.js:5 static/js/zamboni/themes_review_templates.js:33
 msgid "Reviewer"
 msgstr ""
 
-#: static/js/zamboni/themes_review_templates.js:35
+#: static/js/zamboni/editors-all.js:15979 static/js/zamboni/editors-min.js:5 static/js/zamboni/themes_review_templates.js:35
 msgid "Status"
 msgstr ""
 
-#: static/js/zamboni/validator.js:80
-msgid "All tests passed successfully."
+#: static/js/zamboni/editors-all.js:16196 static/js/zamboni/editors-min.js:5 static/js/zamboni/themes_review.js:176
+msgid "Requested Info"
 msgstr ""
 
-#: static/js/zamboni/validator.js:83 static/js/zamboni/validator.js:478
-msgid "These tests were not run."
+#: static/js/zamboni/editors-all.js:16197 static/js/zamboni/editors-min.js:5 static/js/zamboni/themes_review.js:177
+msgid "Flagged"
 msgstr ""
 
-#: static/js/zamboni/validator.js:131 static/js/zamboni/validator.js:144
-msgid "Tests"
+#: static/js/zamboni/editors-all.js:16198 static/js/zamboni/editors-min.js:5 static/js/zamboni/themes_review.js:178
+msgid "Duplicate"
 msgstr ""
 
-#: static/js/zamboni/validator.js:246 static/js/zamboni/validator.js:575 static/js/zamboni/validator.js:594
-msgid "Error"
+#: static/js/zamboni/editors-all.js:16199 static/js/zamboni/editors-min.js:5 static/js/zamboni/themes_review.js:179
+msgid "Rejected"
 msgstr ""
 
-#: static/js/zamboni/validator.js:247
-msgid "Warning"
+#: static/js/zamboni/editors-all.js:16200 static/js/zamboni/editors-min.js:5 static/js/zamboni/themes_review.js:180
+msgid "Approved"
 msgstr ""
 
-#: static/js/zamboni/validator.js:299
-msgid "Suggestions for passing automated signing:"
+#: static/js/zamboni/editors-all.js:16444 static/js/zamboni/editors-min.js:5 static/js/zamboni/themes_review.js:424
+msgid "No results found"
 msgstr ""
 
-#: static/js/zamboni/validator.js:387
-msgid "Compatibility Tests"
-msgstr ""
-
-#: static/js/zamboni/validator.js:466
-msgid "Add-on failed validation."
-msgstr ""
-
-#: static/js/zamboni/validator.js:468
-msgid "Add-on passed validation."
-msgstr ""
-
-#: static/js/zamboni/validator.js:481
-msgid "{0} error"
-msgid_plural "{0} errors"
-msgstr[0] ""
-msgstr[1] ""
-
-#: static/js/zamboni/validator.js:483
-msgid "{0} warning"
-msgid_plural "{0} warnings"
-msgstr[0] ""
-msgstr[1] ""
-
-#: static/js/zamboni/validator.js:485
-msgid "{0} notice"
-msgid_plural "{0} notices"
-msgstr[0] ""
-msgstr[1] ""
-
-#: static/js/zamboni/validator.js:577
-msgid "Validation task could not complete or completed with errors"
-msgstr ""
-
-#: static/js/zamboni/validator.js:595
-msgid "Internal server error"
-msgstr ""
-
-#: static/js/zamboni/mobile/buttons.js:52
+#: static/js/zamboni/mobile-all.js:15186 static/js/zamboni/mobile/buttons.js:52
 msgid "Not Updated for {0} {1}"
 msgstr ""
 
-#: static/js/zamboni/mobile/buttons.js:53
+#: static/js/zamboni/mobile-all.js:15187 static/js/zamboni/mobile/buttons.js:53
 msgid "Requires Newer Version of {0}"
 msgstr ""
 
-#: static/js/zamboni/mobile/buttons.js:54
+#: static/js/zamboni/mobile-all.js:15188 static/js/zamboni/mobile/buttons.js:54
 msgid "Unreviewed"
 msgstr ""
 
-#: static/js/zamboni/mobile/buttons.js:55
+#: static/js/zamboni/mobile-all.js:15189 static/js/zamboni/mobile/buttons.js:55
 msgid "Experimental <span>(Learn More)</span>"
 msgstr ""
 
-#: static/js/zamboni/mobile/buttons.js:56 static/js/zamboni/mobile/buttons.js:57
+#: static/js/zamboni/mobile-all.js:15190 static/js/zamboni/mobile-all.js:15191 static/js/zamboni/mobile/buttons.js:56 static/js/zamboni/mobile/buttons.js:57
 msgid "Not Available for {0}"
 msgstr ""
 
-#: static/js/zamboni/mobile/buttons.js:58
+#: static/js/zamboni/mobile-all.js:15192 static/js/zamboni/mobile/buttons.js:58
 msgid "Experimental"
 msgstr ""
 
-#: static/js/zamboni/mobile/buttons.js:59
+#: static/js/zamboni/mobile-all.js:15193 static/js/zamboni/mobile/buttons.js:59
 msgid "Themes Require Newer Version of {0}"
 msgstr ""
 
-#: static/js/zamboni/mobile/buttons.js:60
+#: static/js/zamboni/mobile-all.js:15194 static/js/zamboni/mobile/buttons.js:60
 msgid "Themes Require {0}"
 msgstr ""
 
-#: static/js/zamboni/mobile/buttons.js:105
+#: static/js/zamboni/mobile-all.js:15239 static/js/zamboni/mobile/buttons.js:105
 msgid "Installing..."
 msgstr ""
 
-#: static/js/zamboni/mobile/buttons.js:125
+#: static/js/zamboni/mobile-all.js:15259 static/js/zamboni/mobile/buttons.js:125
 msgid "This add-on has been preliminarily reviewed by Mozilla."
 msgstr ""
 
-#: static/js/zamboni/mobile/buttons.js:250
+#: static/js/zamboni/mobile-all.js:15384 static/js/zamboni/mobile/buttons.js:250
 msgid "Keep it"
 msgstr ""
 
-#: static/js/zamboni/mobile/general.js:344
+#: static/js/zamboni/mobile-all.js:16049 static/js/zamboni/mobile-min.js:6 static/js/zamboni/mobile/general.js:344
 msgid "You're trying it on!"
 msgstr ""
 
-#: static/js/zamboni/mobile/general.js:356
+#: static/js/zamboni/mobile-all.js:16061 static/js/zamboni/mobile-min.js:6 static/js/zamboni/mobile/general.js:356
 msgid "Added to Firefox"
 msgstr ""
-

--- a/locale/gu/LC_MESSAGES/django.po
+++ b/locale/gu/LC_MESSAGES/django.po
@@ -3,69 +3,70 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2016-02-24 21:23+0000\n"
+"POT-Creation-Date: 2016-04-18 15:47+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
+"Language: \n"
 "MIME-Version: 1.0\n"
-"Content-Type: text/plain; charset=utf-8\n"
+"Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Generated-By: Babel 2.2.0\n"
 
-#: src/olympia/accounts/views.py:52
+#: src/olympia/accounts/views.py:54
 msgid "Your log in attempt could not be parsed. Please try again."
 msgstr ""
 
-#: src/olympia/accounts/views.py:54
+#: src/olympia/accounts/views.py:56
 msgid "Your Firefox Account could not be found. Please try again."
 msgstr ""
 
-#: src/olympia/accounts/views.py:55
+#: src/olympia/accounts/views.py:57
 msgid "You could not be logged in. Please try again."
 msgstr ""
 
-#: src/olympia/accounts/views.py:57
+#: src/olympia/accounts/views.py:59
 msgid "Your account has already been migrated to Firefox Accounts."
 msgstr ""
 
-#: src/olympia/accounts/views.py:59
+#: src/olympia/accounts/views.py:61
 msgid "Your Firefox Account already exists on this site."
 msgstr ""
 
-#: src/olympia/accounts/views.py:108
+#: src/olympia/accounts/views.py:110
 msgid "Great job!"
 msgstr ""
 
-#: src/olympia/accounts/views.py:109
+#: src/olympia/accounts/views.py:111
 msgid "You can now log in to Add-ons with your Firefox Account."
 msgstr ""
 
-#: src/olympia/accounts/views.py:121
+#: src/olympia/accounts/views.py:123
 msgid "Need help?"
 msgstr ""
 
-#: src/olympia/addons/buttons.py:180
+#: src/olympia/addons/buttons.py:177
 msgid "Download Now"
 msgstr ""
 
-#: src/olympia/addons/buttons.py:182
+#: src/olympia/addons/buttons.py:179
 msgid "Download"
 msgstr ""
 
 #. L10n: please keep &nbsp; in the string so &rarr; does not wrap.
-#: src/olympia/addons/buttons.py:186
+#: src/olympia/addons/buttons.py:183
 msgid "Continue to Download&nbsp;&rarr;"
 msgstr ""
 
-#: src/olympia/addons/buttons.py:202 src/olympia/addons/helpers.py:35 src/olympia/addons/views.py:319 src/olympia/addons/templates/addons/impala/details.html:114
+#: src/olympia/addons/buttons.py:199 src/olympia/addons/helpers.py:35 src/olympia/addons/views.py:333 src/olympia/addons/templates/addons/impala/details.html:111
 #: src/olympia/addons/templates/addons/impala/listing/items.html:17 src/olympia/addons/templates/addons/mobile/home.html:40 src/olympia/amo/templates/amo/side_nav.html:6
-#: src/olympia/amo/templates/amo/side_nav.html:10 src/olympia/amo/templates/amo/site_nav.html:2 src/olympia/amo/templates/amo/site_nav.html:55 src/olympia/bandwagon/views.py:95
-#: src/olympia/browse/views.py:54 src/olympia/browse/views.py:68 src/olympia/browse/views.py:235 src/olympia/browse/templates/browse/impala/category_landing.html:22
+#: src/olympia/amo/templates/amo/side_nav.html:10 src/olympia/amo/templates/amo/site_nav.html:2 src/olympia/amo/templates/amo/site_nav.html:53 src/olympia/bandwagon/views.py:95
+#: src/olympia/browse/views.py:54 src/olympia/browse/views.py:68 src/olympia/browse/views.py:202 src/olympia/browse/templates/browse/impala/category_landing.html:22
 #: src/olympia/browse/templates/browse/personas/mobile/category_landing.html:26
 msgid "Featured"
 msgstr ""
 
-#: src/olympia/addons/buttons.py:221
+#: src/olympia/addons/buttons.py:218
 msgid "Add to {0}"
 msgstr ""
 
@@ -113,39 +114,39 @@ msgid_plural "All tags must be at least {0} characters."
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/olympia/addons/forms.py:234
+#: src/olympia/addons/forms.py:238
 msgid "Categories cannot be changed while your add-on is featured for this application."
 msgstr ""
 
 #. L10n: {0} is the number of categories.
-#: src/olympia/addons/forms.py:238
+#: src/olympia/addons/forms.py:242
 msgid "You can have only {0} category."
 msgid_plural "You can have only {0} categories."
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/olympia/addons/forms.py:246
+#: src/olympia/addons/forms.py:250
 msgid "The miscellaneous category cannot be combined with additional categories."
 msgstr ""
 
-#: src/olympia/addons/forms.py:369
+#: src/olympia/addons/forms.py:374
 #, python-format
 msgid "Before changing your default locale you must have a name, summary, and description in that locale. You are missing %s."
 msgstr ""
 
-#: src/olympia/addons/forms.py:484 src/olympia/addons/forms.py:575
+#: src/olympia/addons/forms.py:455 src/olympia/addons/forms.py:546
 msgid "A license must be selected."
 msgstr ""
 
-#: src/olympia/addons/forms.py:556
+#: src/olympia/addons/forms.py:527
 msgid "Give Your Theme a Name."
 msgstr ""
 
-#: src/olympia/addons/forms.py:562 src/olympia/devhub/templates/devhub/personas/submit.html:53
+#: src/olympia/addons/forms.py:533 src/olympia/devhub/templates/devhub/personas/submit.html:53
 msgid "Describe your Theme."
 msgstr ""
 
-#: src/olympia/addons/forms.py:704
+#: src/olympia/addons/forms.py:675
 msgid "Enter a new author's email address"
 msgstr ""
 
@@ -153,37 +154,37 @@ msgstr ""
 msgid "Not Reviewed"
 msgstr ""
 
-#: src/olympia/addons/models.py:301
+#: src/olympia/addons/models.py:298
 msgid "Users have the option of contributing more or less than this amount."
 msgstr ""
 
-#: src/olympia/addons/models.py:309
-msgid "Users will always be asked in the Add-ons Manager (Firefox 4 and above)"
+#: src/olympia/addons/models.py:306
+msgid "Users will always be asked in the Add-ons Manager (Firefox 4 and above). Only applies to desktop."
 msgstr ""
 
-#: src/olympia/addons/models.py:1804 src/olympia/addons/templates/addons/details_box.html:55 src/olympia/devhub/templates/devhub/index.html:92
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:102
+#: src/olympia/addons/models.py:1802 src/olympia/addons/templates/addons/details_box.html:55 src/olympia/devhub/templates/devhub/index.html:92
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:89
 msgid "Listed"
 msgstr ""
 
-#: src/olympia/addons/views.py:320 src/olympia/browse/templates/browse/personas/mobile/category_landing.html:27
+#: src/olympia/addons/views.py:334 src/olympia/browse/templates/browse/personas/mobile/category_landing.html:27
 msgid "Popular"
 msgstr ""
 
-#: src/olympia/addons/views.py:321 src/olympia/browse/views.py:238 src/olympia/browse/views.py:280 src/olympia/browse/views.py:482
+#: src/olympia/addons/views.py:335 src/olympia/browse/views.py:205 src/olympia/browse/views.py:247 src/olympia/browse/views.py:449
 msgid "Recently Added"
 msgstr ""
 
-#: src/olympia/addons/views.py:322 src/olympia/bandwagon/views.py:99 src/olympia/browse/views.py:60 src/olympia/browse/views.py:71 src/olympia/search/forms.py:16 src/olympia/search/forms.py:91
+#: src/olympia/addons/views.py:336 src/olympia/bandwagon/views.py:99 src/olympia/browse/views.py:60 src/olympia/browse/views.py:71 src/olympia/search/forms.py:16 src/olympia/search/forms.py:91
 msgid "Recently Updated"
 msgstr ""
 
 #. l10n: {0} is the addon name
-#: src/olympia/addons/views.py:520
+#: src/olympia/addons/views.py:534
 msgid "Contribution for {0}"
 msgstr ""
 
-#: src/olympia/addons/views.py:613
+#: src/olympia/addons/views.py:627
 msgid "Abuse reported."
 msgstr ""
 
@@ -250,9 +251,9 @@ msgstr ""
 #: src/olympia/devhub/templates/devhub/addons/ajax_compat_update.html:36 src/olympia/devhub/templates/devhub/addons/profile.html:44 src/olympia/devhub/templates/devhub/addons/edit/admin.html:101
 #: src/olympia/devhub/templates/devhub/addons/edit/basic.html:152 src/olympia/devhub/templates/devhub/addons/edit/details.html:85 src/olympia/devhub/templates/devhub/addons/edit/support.html:67
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:166 src/olympia/devhub/templates/devhub/addons/forms_shared/media.html:149
-#: src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:44 src/olympia/devhub/templates/devhub/versions/add_file_modal.html:78 src/olympia/devhub/templates/devhub/versions/edit.html:139
-#: src/olympia/devhub/templates/devhub/versions/list.html:242 src/olympia/devhub/templates/devhub/versions/list.html:276 src/olympia/devhub/templates/devhub/versions/list.html:317
-#: src/olympia/devhub/templates/devhub/versions/list.html:351 src/olympia/reviews/templates/reviews/edit_review.html:16 src/olympia/translations/templates/translations/trans-menu.html:50
+#: src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:43 src/olympia/devhub/templates/devhub/versions/add_file_modal.html:58 src/olympia/devhub/templates/devhub/versions/edit.html:139
+#: src/olympia/devhub/templates/devhub/versions/list.html:239 src/olympia/devhub/templates/devhub/versions/list.html:281 src/olympia/devhub/templates/devhub/versions/list.html:315
+#: src/olympia/devhub/templates/devhub/versions/list.html:349 src/olympia/reviews/templates/reviews/edit_review.html:16 src/olympia/translations/templates/translations/trans-menu.html:50
 #: src/olympia/translations/templates/translations/trans-menu.html:62
 msgid "or"
 msgstr ""
@@ -363,7 +364,7 @@ msgid "Add-on Information for {0}"
 msgstr ""
 
 #: src/olympia/addons/templates/addons/details_box.html:30 src/olympia/addons/templates/addons/persona_detail_table.html:3 src/olympia/addons/templates/addons/mobile/details.html:63
-#: src/olympia/addons/templates/addons/mobile/persona_detail_table.html:7 src/olympia/browse/views.py:459 src/olympia/devhub/views.py:75
+#: src/olympia/addons/templates/addons/mobile/persona_detail_table.html:7 src/olympia/browse/views.py:426 src/olympia/devhub/views.py:73
 msgid "Updated"
 msgstr ""
 
@@ -382,11 +383,11 @@ msgstr ""
 msgid "Visibility"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/details_box.html:57 src/olympia/devhub/templates/devhub/index.html:94 src/olympia/devhub/templates/devhub/includes/addon_details.html:104
+#: src/olympia/addons/templates/addons/details_box.html:57 src/olympia/devhub/templates/devhub/index.html:94 src/olympia/devhub/templates/devhub/includes/addon_details.html:91
 msgid "Hidden"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/details_box.html:59 src/olympia/devhub/templates/devhub/index.html:96 src/olympia/devhub/templates/devhub/includes/addon_details.html:106
+#: src/olympia/addons/templates/addons/details_box.html:59 src/olympia/devhub/templates/devhub/index.html:96 src/olympia/devhub/templates/devhub/includes/addon_details.html:93
 msgid "Unlisted"
 msgstr ""
 
@@ -394,13 +395,13 @@ msgstr ""
 msgid "Required Add-ons"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/details_box.html:81 src/olympia/addons/templates/addons/persona_detail_table.html:15 src/olympia/browse/views.py:462 src/olympia/devhub/views.py:78
-#: src/olympia/devhub/views.py:85 src/olympia/discovery/templates/discovery/addons/detail.html:57 src/olympia/reviews/forms.py:62 src/olympia/reviews/templates/reviews/add.html:57
+#: src/olympia/addons/templates/addons/details_box.html:81 src/olympia/addons/templates/addons/persona_detail_table.html:15 src/olympia/browse/views.py:429 src/olympia/devhub/views.py:76
+#: src/olympia/devhub/views.py:83 src/olympia/discovery/templates/discovery/addons/detail.html:57 src/olympia/reviews/forms.py:62 src/olympia/reviews/templates/reviews/add.html:57
 #: src/olympia/reviews/templates/reviews/mobile/review_list.html:18
 msgid "Rating"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/details_box.html:85 src/olympia/browse/views.py:461 src/olympia/devhub/views.py:77 src/olympia/devhub/views.py:84
+#: src/olympia/addons/templates/addons/details_box.html:85 src/olympia/browse/views.py:428 src/olympia/devhub/views.py:75 src/olympia/devhub/views.py:82
 #: src/olympia/stats/templates/stats/addon_report_menu.html:8 src/olympia/stats/templates/stats/collection_report_menu.html:18
 msgid "Downloads"
 msgstr ""
@@ -420,7 +421,7 @@ msgstr ""
 
 #. The Privacy Policy for this add-on.
 #: src/olympia/addons/templates/addons/details_box.html:121 src/olympia/addons/templates/addons/privacy.html:19 src/olympia/addons/templates/addons/privacy.html:23
-#: src/olympia/addons/templates/addons/impala/button.html:43 src/olympia/addons/templates/addons/impala/details.html:307 src/olympia/devhub/templates/devhub/includes/policy_form.html:20
+#: src/olympia/addons/templates/addons/impala/button.html:43 src/olympia/addons/templates/addons/impala/details.html:312 src/olympia/devhub/templates/devhub/includes/policy_form.html:23
 #: src/olympia/templates/mobile/base_addons.html:87
 msgid "Privacy Policy"
 msgstr ""
@@ -445,7 +446,7 @@ msgstr ""
 msgid "Developer Comments"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/details_box.html:199 src/olympia/addons/templates/addons/impala/details.html:259
+#: src/olympia/addons/templates/addons/details_box.html:199 src/olympia/addons/templates/addons/impala/details.html:264
 msgid "Development Channel"
 msgstr ""
 
@@ -465,7 +466,7 @@ msgid ""
 "developer. To stop receiving development updates, reinstall the default version from the link above."
 msgstr ""
 
-#: src/olympia/addons/templates/addons/details_box.html:220 src/olympia/addons/templates/addons/impala/details.html:278
+#: src/olympia/addons/templates/addons/details_box.html:220 src/olympia/addons/templates/addons/impala/details.html:283
 msgid "Version {0}:"
 msgstr ""
 
@@ -484,7 +485,7 @@ msgid "End-User License Agreement for {0}"
 msgstr ""
 
 #: src/olympia/addons/templates/addons/eula.html:17 src/olympia/addons/templates/addons/eula.html:21 src/olympia/addons/templates/addons/impala/button.html:48
-#: src/olympia/addons/templates/addons/impala/details.html:316 src/olympia/devhub/templates/devhub/includes/policy_form.html:3 src/olympia/discovery/templates/discovery/addons/eula.html:11
+#: src/olympia/addons/templates/addons/impala/details.html:321 src/olympia/devhub/templates/devhub/includes/policy_form.html:3 src/olympia/discovery/templates/discovery/addons/eula.html:11
 msgid "End-User License Agreement"
 msgstr ""
 
@@ -501,7 +502,7 @@ msgstr ""
 msgid "Add-ons for {0}"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/home.html:10 src/olympia/addons/templates/addons/home.html:51 src/olympia/browse/templates/browse/impala/base_listing.html:11
+#: src/olympia/addons/templates/addons/home.html:10 src/olympia/addons/templates/addons/home.html:53 src/olympia/browse/templates/browse/impala/base_listing.html:11
 msgid "Featured Extensions"
 msgstr ""
 
@@ -509,29 +510,29 @@ msgstr ""
 msgid "Popular Extensions"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/home.html:42 src/olympia/amo/templates/amo/side_nav.html:3 src/olympia/amo/templates/amo/side_nav.html:11 src/olympia/amo/templates/amo/site_nav.html:3
-#: src/olympia/amo/templates/amo/site_nav.html:25 src/olympia/browse/views.py:236 src/olympia/browse/views.py:281 src/olympia/browse/views.py:481
+#: src/olympia/addons/templates/addons/home.html:44 src/olympia/amo/templates/amo/side_nav.html:3 src/olympia/amo/templates/amo/side_nav.html:11 src/olympia/amo/templates/amo/site_nav.html:3
+#: src/olympia/amo/templates/amo/site_nav.html:25 src/olympia/browse/views.py:203 src/olympia/browse/views.py:248 src/olympia/browse/views.py:448
 msgid "Most Popular"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/home.html:43
+#: src/olympia/addons/templates/addons/home.html:45
 msgid "All »"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/home.html:52 src/olympia/addons/templates/addons/home.html:61 src/olympia/addons/templates/addons/home.html:70 src/olympia/addons/templates/addons/home.html:78
+#: src/olympia/addons/templates/addons/home.html:54 src/olympia/addons/templates/addons/home.html:63 src/olympia/addons/templates/addons/home.html:72 src/olympia/addons/templates/addons/home.html:80
 #: src/olympia/browse/templates/browse/impala/category_landing.html:36
 msgid "See all »"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/home.html:60
+#: src/olympia/addons/templates/addons/home.html:62
 msgid "Up &amp; Coming Extensions"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/home.html:69 src/olympia/browse/templates/browse/personas/category_landing.html:61 src/olympia/discovery/templates/discovery/pane.html:74
+#: src/olympia/addons/templates/addons/home.html:71 src/olympia/browse/templates/browse/personas/category_landing.html:61 src/olympia/discovery/templates/discovery/pane.html:74
 msgid "Featured Themes"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/home.html:77 src/olympia/bandwagon/templates/bandwagon/impala/collection_listing.html:5
+#: src/olympia/addons/templates/addons/home.html:79 src/olympia/bandwagon/templates/bandwagon/impala/collection_listing.html:5
 msgid "Featured Collections"
 msgstr ""
 
@@ -549,7 +550,7 @@ msgid "Updated {0}"
 msgstr ""
 
 #. {0} is a date.
-#: src/olympia/addons/templates/addons/macros.html:10 src/olympia/addons/templates/addons/macros.html:69 src/olympia/addons/templates/addons/persona_preview.html:21
+#: src/olympia/addons/templates/addons/macros.html:10 src/olympia/addons/templates/addons/macros.html:69 src/olympia/addons/templates/addons/persona_preview.html:22
 #: src/olympia/addons/templates/addons/listing/items_mobile.html:44 src/olympia/addons/templates/addons/listing/macros.html:39
 #: src/olympia/bandwagon/templates/bandwagon/collection_listing_items.html:37 src/olympia/bandwagon/templates/bandwagon/impala/collection_listing_items.html:37
 msgid "Added {0}"
@@ -570,15 +571,14 @@ msgstr[0] ""
 msgstr[1] ""
 
 #. {0} is the number of downloads.
-#: src/olympia/addons/templates/addons/macros.html:53 src/olympia/addons/templates/addons/impala/details.html:61
+#: src/olympia/addons/templates/addons/macros.html:53 src/olympia/addons/templates/addons/impala/details.html:59
 msgid "{0} weekly download"
 msgid_plural "{0} weekly downloads"
 msgstr[0] ""
 msgstr[1] ""
 
 #. {0} is the number of users.
-#: src/olympia/addons/templates/addons/macros.html:61 src/olympia/addons/templates/addons/impala/details.html:54 src/olympia/compat/templates/compat/index.html:71
-#: src/olympia/zadmin/templates/zadmin/compat.html:67
+#: src/olympia/addons/templates/addons/macros.html:61 src/olympia/addons/templates/addons/impala/details.html:52 src/olympia/zadmin/templates/zadmin/compat.html:67
 msgid "{0} user"
 msgid_plural "{0} users"
 msgstr[0] ""
@@ -596,7 +596,7 @@ msgstr ""
 msgid "Return to the addon."
 msgstr ""
 
-#: src/olympia/addons/templates/addons/persona_detail.html:17 src/olympia/addons/templates/addons/impala/details.html:106 src/olympia/addons/templates/addons/mobile/details.html:23
+#: src/olympia/addons/templates/addons/persona_detail.html:17 src/olympia/addons/templates/addons/impala/details.html:103 src/olympia/addons/templates/addons/mobile/details.html:23
 #: src/olympia/addons/templates/addons/mobile/persona_detail.html:21 src/olympia/discovery/templates/discovery/addons/base.html:27 src/olympia/editors/templates/editors/review.html:31
 msgid "by"
 msgstr ""
@@ -640,34 +640,35 @@ msgstr ""
 msgid "License"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/persona_preview.html:12 src/olympia/constants/base.py:48
+#: src/olympia/addons/templates/addons/persona_preview.html:13 src/olympia/constants/base.py:48
 msgid "Awaiting Review"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/persona_preview.html:14 src/olympia/amo/log.py:180 src/olympia/constants/base.py:42 src/olympia/editors/helpers.py:62
+#: src/olympia/addons/templates/addons/persona_preview.html:15 src/olympia/amo/log.py:180 src/olympia/constants/base.py:42 src/olympia/editors/helpers.py:62
 msgid "Rejected"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/persona_preview.html:16 src/olympia/amo/log.py:159
+#: src/olympia/addons/templates/addons/persona_preview.html:17 src/olympia/amo/log.py:159
 msgid "Approved"
 msgstr ""
 
 #. {0} is the number of users.
-#: src/olympia/addons/templates/addons/persona_preview.html:26 src/olympia/addons/templates/addons/listing/items_mobile.html:36 src/olympia/addons/templates/addons/listing/macros.html:31
+#: src/olympia/addons/templates/addons/persona_preview.html:27 src/olympia/addons/templates/addons/listing/items_mobile.html:36 src/olympia/addons/templates/addons/listing/macros.html:31
 msgid "<strong>{0}</strong> user"
 msgid_plural "<strong>{0}</strong> users"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/olympia/addons/templates/addons/persona_preview.html:40
+#: src/olympia/addons/templates/addons/persona_preview.html:41
 msgid "Hover to Preview"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/persona_preview.html:46 src/olympia/addons/templates/addons/persona_preview.html:48 src/olympia/reviews/templates/reviews/add.html:15
+#: src/olympia/addons/templates/addons/persona_preview.html:47 src/olympia/addons/templates/addons/persona_preview.html:49 src/olympia/addons/templates/addons/persona_preview.html:97
+#: src/olympia/reviews/templates/reviews/add.html:15
 msgid "Add"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/persona_preview.html:57 src/olympia/bandwagon/templates/bandwagon/ajax_new.html:16 src/olympia/bandwagon/templates/bandwagon/edit.html:19
+#: src/olympia/addons/templates/addons/persona_preview.html:58 src/olympia/bandwagon/templates/bandwagon/ajax_new.html:16 src/olympia/bandwagon/templates/bandwagon/edit.html:19
 #: src/olympia/bandwagon/templates/bandwagon/includes/addedit.html:19 src/olympia/devhub/templates/devhub/addons/edit/admin.html:13 src/olympia/devhub/templates/devhub/addons/edit/basic.html:10
 #: src/olympia/devhub/templates/devhub/addons/edit/details.html:8 src/olympia/devhub/templates/devhub/addons/edit/media.html:6 src/olympia/devhub/templates/devhub/addons/edit/support.html:8
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:9 src/olympia/devhub/templates/devhub/addons/submit/describe.html:29 src/olympia/editors/templates/editors/review.html:257
@@ -676,21 +677,21 @@ msgstr ""
 
 #. For datetime formatting, see the table on
 #. http://docs.python.org/library/datetime.html#strftime-and-strptime-behavior
-#: src/olympia/addons/templates/addons/persona_preview.html:66
+#: src/olympia/addons/templates/addons/persona_preview.html:67
 #, python-format
 msgid "%%Y-%%m-%%d"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/persona_preview.html:67
+#: src/olympia/addons/templates/addons/persona_preview.html:68
 msgid "by {0} on {1}"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/persona_preview.html:75 src/olympia/reviews/helpers.py:17 src/olympia/reviews/templates/reviews/review_list.html:63
+#: src/olympia/addons/templates/addons/persona_preview.html:76 src/olympia/reviews/helpers.py:17 src/olympia/reviews/templates/reviews/review_list.html:63
 #: src/olympia/reviews/templates/reviews/reviews_link.html:21 src/olympia/reviews/templates/reviews/impala/reviews_link.html:16
 msgid "Not yet rated"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/persona_preview.html:78
+#: src/olympia/addons/templates/addons/persona_preview.html:79
 msgid "<b>{0}</b> users"
 msgstr ""
 
@@ -703,7 +704,7 @@ msgid "Learn more about Firefox"
 msgstr ""
 
 #: src/olympia/addons/templates/addons/popups.html:22
-msgid "or <b><a class=\"installer\" href=\"{url}\">download anyway</a></b>"
+msgid "or <b><a class=\"button installer\" href=\"{url}\">download anyway</a></b>"
 msgstr ""
 
 #: src/olympia/addons/templates/addons/popups.html:26
@@ -802,7 +803,7 @@ msgid ""
 msgstr ""
 
 #: src/olympia/addons/templates/addons/report_abuse.html:6 src/olympia/addons/templates/addons/report_abuse_full.html:10 src/olympia/addons/templates/addons/impala/details-more.html:23
-#: src/olympia/addons/templates/addons/impala/details.html:328
+#: src/olympia/addons/templates/addons/impala/details.html:333
 msgid "Report Abuse"
 msgstr ""
 
@@ -821,9 +822,9 @@ msgstr ""
 #: src/olympia/devhub/templates/devhub/addons/ajax_compat_update.html:36 src/olympia/devhub/templates/devhub/addons/profile.html:44 src/olympia/devhub/templates/devhub/addons/edit/admin.html:104
 #: src/olympia/devhub/templates/devhub/addons/edit/basic.html:155 src/olympia/devhub/templates/devhub/addons/edit/details.html:88 src/olympia/devhub/templates/devhub/addons/edit/support.html:70
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:169 src/olympia/devhub/templates/devhub/addons/forms_shared/media.html:152
-#: src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:44 src/olympia/devhub/templates/devhub/personas/edit.html:222 src/olympia/devhub/templates/devhub/versions/add_file_modal.html:79
-#: src/olympia/devhub/templates/devhub/versions/edit.html:140 src/olympia/devhub/templates/devhub/versions/list.html:208 src/olympia/devhub/templates/devhub/versions/list.html:242
-#: src/olympia/devhub/templates/devhub/versions/list.html:276 src/olympia/devhub/templates/devhub/versions/list.html:317 src/olympia/reviews/templates/reviews/edit_review.html:16
+#: src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:43 src/olympia/devhub/templates/devhub/personas/edit.html:222 src/olympia/devhub/templates/devhub/versions/add_file_modal.html:59
+#: src/olympia/devhub/templates/devhub/versions/edit.html:140 src/olympia/devhub/templates/devhub/versions/list.html:208 src/olympia/devhub/templates/devhub/versions/list.html:239
+#: src/olympia/devhub/templates/devhub/versions/list.html:281 src/olympia/devhub/templates/devhub/versions/list.html:315 src/olympia/reviews/templates/reviews/edit_review.html:16
 #: src/olympia/translations/templates/translations/trans-menu.html:50 src/olympia/translations/templates/translations/trans-menu.html:62 src/olympia/zadmin/templates/zadmin/validation.html:105
 msgid "Cancel"
 msgstr ""
@@ -868,7 +869,7 @@ msgstr ""
 msgid "Review Guidelines"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/review_list_box.html:5 src/olympia/addons/templates/addons/impala/details-more.html:27 src/olympia/editors/helpers.py:921
+#: src/olympia/addons/templates/addons/review_list_box.html:5 src/olympia/addons/templates/addons/impala/details-more.html:27 src/olympia/editors/helpers.py:1001
 #: src/olympia/reviews/templates/reviews/add.html:14 src/olympia/reviews/templates/reviews/reply.html:14 src/olympia/reviews/templates/reviews/review_list.html:19
 #: src/olympia/reviews/templates/reviews/mobile/review_list.html:26
 msgid "Reviews"
@@ -959,119 +960,119 @@ msgid_plural "Other add-ons by these authors"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/olympia/addons/templates/addons/impala/details.html:41
+#: src/olympia/addons/templates/addons/impala/details.html:39
 #, python-format
 msgid "<span itemprop=\"ratingCount\">%(num)s</span> user review"
 msgid_plural "<span itemprop=\"ratingCount\">%(num)s</span> user reviews"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/olympia/addons/templates/addons/impala/details.html:69
+#: src/olympia/addons/templates/addons/impala/details.html:66
 msgid "View statistics"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/impala/details.html:84
+#: src/olympia/addons/templates/addons/impala/details.html:81
 msgid "Manage"
 msgstr ""
 
 #. {0} is an add-on name.
-#: src/olympia/addons/templates/addons/impala/details.html:96
+#: src/olympia/addons/templates/addons/impala/details.html:93
 msgid "Icon of {0}"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/impala/details.html:103 src/olympia/addons/templates/addons/impala/listing/items.html:14
+#: src/olympia/addons/templates/addons/impala/details.html:100 src/olympia/addons/templates/addons/impala/listing/items.html:14
 msgid "No Restart"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/impala/details.html:127
+#: src/olympia/addons/templates/addons/impala/details.html:124
 #, python-format
 msgid "Meet the Developer: <a href=\"%(url)s\">%(name)s</a>"
 msgid_plural "<a href=\"%(url)s\">Meet the Developers</a>"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/olympia/addons/templates/addons/impala/details.html:137
+#: src/olympia/addons/templates/addons/impala/details.html:134
 msgid "Learn why {0} was created and find out what's next for this add-on."
 msgstr ""
 
 #. {0} is an index.
-#: src/olympia/addons/templates/addons/impala/details.html:156
+#: src/olympia/addons/templates/addons/impala/details.html:161
 msgid "Add-on screenshot #{0}"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/impala/details.html:182
+#: src/olympia/addons/templates/addons/impala/details.html:187
 msgid "Add-on home page"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/impala/details.html:185
+#: src/olympia/addons/templates/addons/impala/details.html:190
 msgid "Support site"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/impala/details.html:189
+#: src/olympia/addons/templates/addons/impala/details.html:194
 msgid "Support E-mail"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/impala/details.html:194 src/olympia/devhub/models.py:378 src/olympia/devhub/templates/devhub/versions/list.html:12
+#: src/olympia/addons/templates/addons/impala/details.html:199 src/olympia/devhub/models.py:378 src/olympia/devhub/templates/devhub/versions/list.html:12
 #: src/olympia/versions/templates/versions/version.html:6 src/olympia/versions/templates/versions/mobile/version.html:6
 msgid "Version {0}"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/impala/details.html:194
+#: src/olympia/addons/templates/addons/impala/details.html:199
 msgid "Info"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/impala/details.html:195 src/olympia/devhub/templates/devhub/includes/addon_details.html:129
+#: src/olympia/addons/templates/addons/impala/details.html:200 src/olympia/devhub/templates/devhub/includes/addon_details.html:116
 msgid "Last Updated:"
-msgstr ""
-
-#: src/olympia/addons/templates/addons/impala/details.html:200
-#, python-format
-msgid "Released under <a target=\"_blank\" href=\"%(url)s\">%(name)s</a>"
-msgstr ""
-
-#: src/olympia/addons/templates/addons/impala/details.html:201 src/olympia/addons/templates/addons/impala/details.html:206 src/olympia/amo/helpers.py:398 src/olympia/devhub/forms.py:142
-#: src/olympia/devhub/forms.py:173 src/olympia/versions/templates/versions/version.html:40 src/olympia/versions/templates/versions/version.html:45
-msgid "Custom License"
 msgstr ""
 
 #: src/olympia/addons/templates/addons/impala/details.html:205
 #, python-format
+msgid "Released under <a target=\"_blank\" href=\"%(url)s\">%(name)s</a>"
+msgstr ""
+
+#: src/olympia/addons/templates/addons/impala/details.html:206 src/olympia/addons/templates/addons/impala/details.html:211 src/olympia/amo/helpers.py:398 src/olympia/devhub/forms.py:142
+#: src/olympia/devhub/forms.py:173 src/olympia/versions/templates/versions/version.html:40 src/olympia/versions/templates/versions/version.html:45
+msgid "Custom License"
+msgstr ""
+
+#: src/olympia/addons/templates/addons/impala/details.html:210
+#, python-format
 msgid "Released under <a href=\"%(url)s\">%(name)s</a>"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/impala/details.html:217
+#: src/olympia/addons/templates/addons/impala/details.html:222
 msgid "About this Add-on"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/impala/details.html:233
+#: src/olympia/addons/templates/addons/impala/details.html:238
 msgid "Developer’s Comments"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/impala/details.html:243
+#: src/olympia/addons/templates/addons/impala/details.html:248
 msgid "Version Information"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/impala/details.html:250
+#: src/olympia/addons/templates/addons/impala/details.html:255
 msgid "See complete version history"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/impala/details.html:262
+#: src/olympia/addons/templates/addons/impala/details.html:267
 msgid ""
 "The Development Channel lets you test an experimental new version of this add-on before it's released to the general public. Once you install the development version, you will continue to get "
 "updates from this channel. To stop receiving development updates, reinstall the default version from the link above."
 msgstr ""
 
-#: src/olympia/addons/templates/addons/impala/details.html:272
+#: src/olympia/addons/templates/addons/impala/details.html:277
 msgid "<strong>Caution:</strong> Development versions of this add-on have not been reviewed by Mozilla."
 msgstr ""
 
-#: src/olympia/addons/templates/addons/impala/details.html:287
+#: src/olympia/addons/templates/addons/impala/details.html:292
 msgid "See complete development channel history"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/impala/details.html:306 src/olympia/addons/templates/addons/impala/details.html:315 src/olympia/addons/templates/addons/impala/details.html:327
+#: src/olympia/addons/templates/addons/impala/details.html:311 src/olympia/addons/templates/addons/impala/details.html:320 src/olympia/addons/templates/addons/impala/details.html:332
 #: src/olympia/addons/templates/addons/impala/review_add_box.html:4 src/olympia/stats/templates/stats/popup.html:2 src/olympia/stats/templates/stats/popup.html:8
-#: src/olympia/stats/templates/stats/stats.html:202 src/olympia/users/templates/users/profile.html:119
+#: src/olympia/stats/templates/stats/stats.html:204 src/olympia/users/templates/users/profile.html:119
 msgid "close"
 msgstr ""
 
@@ -1127,15 +1128,11 @@ msgstr ""
 msgid "Source Code License"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/impala/persona_grid.html:16 src/olympia/addons/templates/addons/impala/toplist.html:6
-msgid "{0} users"
-msgstr ""
-
 #: src/olympia/addons/templates/addons/impala/review_list_box.html:19 src/olympia/reviews/templates/reviews/review.html:40
 msgid "permalink"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/impala/review_list_box.html:23 src/olympia/editors/templates/editors/queue.html:98 src/olympia/reviews/templates/reviews/review.html:44
+#: src/olympia/addons/templates/addons/impala/review_list_box.html:23 src/olympia/editors/templates/editors/queue.html:104 src/olympia/reviews/templates/reviews/review.html:44
 msgid "translate"
 msgstr ""
 
@@ -1154,6 +1151,10 @@ msgstr ""
 msgid "Be the first!"
 msgstr ""
 
+#: src/olympia/addons/templates/addons/impala/toplist.html:6
+msgid "{0} users"
+msgstr ""
+
 #: src/olympia/addons/templates/addons/impala/listing/sorter.html:14 src/olympia/devhub/templates/devhub/addons/listing/item_actions.html:49
 msgid "More"
 msgstr ""
@@ -1166,7 +1167,7 @@ msgstr ""
 msgid "My Add-ons"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/includes/dashboard_tabs.html:6 src/olympia/amo/context_processors.py:51
+#: src/olympia/addons/templates/addons/includes/dashboard_tabs.html:6 src/olympia/amo/context_processors.py:50
 msgid "My Themes"
 msgstr ""
 
@@ -1221,7 +1222,7 @@ msgstr ""
 msgid "Weekly Downloads"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/mobile/details.html:99 src/olympia/compat/templates/compat/reporter_detail.html:46 src/olympia/devhub/forms.py:787
+#: src/olympia/addons/templates/addons/mobile/details.html:99 src/olympia/compat/templates/compat/reporter_detail.html:46 src/olympia/devhub/forms.py:788
 #: src/olympia/devhub/templates/devhub/versions/list.html:163
 msgid "Version"
 msgstr ""
@@ -1305,7 +1306,7 @@ msgstr ""
 #: src/olympia/browse/templates/browse/personas/category_landing.html:21 src/olympia/browse/templates/browse/personas/category_landing.html:23
 #: src/olympia/browse/templates/browse/personas/category_landing.html:38 src/olympia/browse/templates/browse/personas/grid.html:7 src/olympia/browse/templates/browse/personas/grid.html:11
 #: src/olympia/browse/templates/browse/personas/mobile/base.html:7 src/olympia/browse/templates/browse/personas/mobile/category_landing.html:19 src/olympia/constants/base.py:180
-#: src/olympia/devhub/templates/devhub/personas/submit.html:13 src/olympia/editors/helpers.py:105 src/olympia/editors/templates/editors/base.html:26
+#: src/olympia/devhub/templates/devhub/personas/submit.html:13 src/olympia/editors/helpers.py:107 src/olympia/editors/templates/editors/base.html:26
 #: src/olympia/editors/templates/editors/performance.html:73 src/olympia/search/templates/search/personas.html:39 src/olympia/templates/menu_links.html:9
 msgid "Themes"
 msgstr ""
@@ -1326,7 +1327,7 @@ msgstr ""
 msgid "Highest Rated"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/mobile/home.html:74 src/olympia/amo/templates/amo/side_nav.html:5 src/olympia/amo/templates/amo/site_nav.html:27 src/olympia/amo/templates/amo/site_nav.html:57
+#: src/olympia/addons/templates/addons/mobile/home.html:74 src/olympia/amo/templates/amo/side_nav.html:5 src/olympia/amo/templates/amo/site_nav.html:27 src/olympia/amo/templates/amo/site_nav.html:55
 #: src/olympia/bandwagon/views.py:97 src/olympia/browse/views.py:57 src/olympia/browse/views.py:67 src/olympia/browse/templates/browse/personas/mobile/category_landing.html:65
 #: src/olympia/search/forms.py:15 src/olympia/search/forms.py:87
 msgid "Newest"
@@ -1340,90 +1341,90 @@ msgstr ""
 msgid "Theme Info &raquo;"
 msgstr ""
 
-#: src/olympia/amo/context_processors.py:39 src/olympia/devhub/templates/devhub/nav.html:43
+#: src/olympia/amo/context_processors.py:37 src/olympia/devhub/templates/devhub/nav.html:43
 msgid "Tools"
 msgstr ""
 
-#: src/olympia/amo/context_processors.py:48 src/olympia/discovery/templates/discovery/pane_account.html:8 src/olympia/users/templates/users/includes/navigation.html:2
+#: src/olympia/amo/context_processors.py:47 src/olympia/discovery/templates/discovery/pane_account.html:8 src/olympia/users/templates/users/includes/navigation.html:2
 msgid "My Profile"
 msgstr ""
 
-#: src/olympia/amo/context_processors.py:54 src/olympia/users/templates/users/edit.html:5 src/olympia/users/templates/users/includes/navigation.html:3
+#: src/olympia/amo/context_processors.py:53 src/olympia/users/templates/users/edit.html:5 src/olympia/users/templates/users/includes/navigation.html:3
 msgid "Account Settings"
 msgstr ""
 
-#: src/olympia/amo/context_processors.py:57 src/olympia/discovery/templates/discovery/pane_account.html:11 src/olympia/users/templates/users/profile.html:83
+#: src/olympia/amo/context_processors.py:56 src/olympia/discovery/templates/discovery/pane_account.html:11 src/olympia/users/templates/users/profile.html:83
 #: src/olympia/users/templates/users/includes/navigation.html:4
 msgid "My Collections"
 msgstr ""
 
-#: src/olympia/amo/context_processors.py:62 src/olympia/discovery/templates/discovery/pane_account.html:10 src/olympia/users/templates/users/includes/navigation.html:7
+#: src/olympia/amo/context_processors.py:61 src/olympia/discovery/templates/discovery/pane_account.html:10 src/olympia/users/templates/users/includes/navigation.html:7
 msgid "My Favorites"
 msgstr ""
 
-#: src/olympia/amo/context_processors.py:67 src/olympia/discovery/templates/discovery/pane_account.html:13 src/olympia/templates/impala/user_login.html:14
+#: src/olympia/amo/context_processors.py:66 src/olympia/discovery/templates/discovery/pane_account.html:13 src/olympia/templates/impala/user_login.html:14
 #: src/olympia/templates/mobile/header_auth.html:5
 msgid "Log out"
 msgstr ""
 
-#: src/olympia/amo/context_processors.py:72 src/olympia/devhub/templates/devhub/addons/dashboard.html:4
+#: src/olympia/amo/context_processors.py:71 src/olympia/devhub/templates/devhub/addons/dashboard.html:4
 msgid "Manage My Submissions"
 msgstr ""
 
-#: src/olympia/amo/context_processors.py:75 src/olympia/devhub/templates/devhub/nav.html:27 src/olympia/devhub/templates/devhub/addons/dashboard.html:25
+#: src/olympia/amo/context_processors.py:74 src/olympia/devhub/templates/devhub/nav.html:27 src/olympia/devhub/templates/devhub/addons/dashboard.html:25
 #: src/olympia/devhub/templates/devhub/addons/submit/base.html:4
 msgid "Submit a New Add-on"
 msgstr ""
 
-#: src/olympia/amo/context_processors.py:77 src/olympia/browse/templates/browse/personas/base.html:50 src/olympia/devhub/templates/devhub/index.html:24
+#: src/olympia/amo/context_processors.py:76 src/olympia/browse/templates/browse/personas/base.html:50 src/olympia/devhub/templates/devhub/index.html:24
 #: src/olympia/devhub/templates/devhub/addons/dashboard.html:29
 msgid "Submit a New Theme"
 msgstr ""
 
-#: src/olympia/amo/context_processors.py:79 src/olympia/amo/templates/amo/site_nav.html:87 src/olympia/devhub/helpers.py:36 src/olympia/devhub/helpers.py:68 src/olympia/devhub/helpers.py:102
+#: src/olympia/amo/context_processors.py:78 src/olympia/amo/templates/amo/site_nav.html:85 src/olympia/devhub/helpers.py:36 src/olympia/devhub/helpers.py:68 src/olympia/devhub/helpers.py:102
 #: src/olympia/templates/footer.html:6 src/olympia/templates/menu_links.html:14
 msgid "Developer Hub"
 msgstr ""
 
-#: src/olympia/amo/context_processors.py:83 src/olympia/devhub/views.py:1792
+#: src/olympia/amo/context_processors.py:81 src/olympia/devhub/views.py:1796
 msgid "Manage API Keys"
 msgstr ""
 
-#: src/olympia/amo/context_processors.py:88 src/olympia/editors/helpers.py:82 src/olympia/editors/helpers.py:102 src/olympia/editors/templates/editors/base.html:10
+#: src/olympia/amo/context_processors.py:86 src/olympia/editors/helpers.py:84 src/olympia/editors/helpers.py:104 src/olympia/editors/templates/editors/base.html:10
 msgid "Editor Tools"
 msgstr ""
 
-#: src/olympia/amo/context_processors.py:92
+#: src/olympia/amo/context_processors.py:90
 msgid "Admin Tools"
 msgstr ""
 
-#: src/olympia/amo/fields.py:15
+#: src/olympia/amo/fields.py:20
 msgid "Incorrect, please try again."
 msgstr ""
 
-#: src/olympia/amo/fields.py:16
+#: src/olympia/amo/fields.py:21
 msgid "Error verifying input, please try again."
 msgstr ""
 
-#: src/olympia/amo/fields.py:32
+#: src/olympia/amo/fields.py:37
 msgid "This must be a valid hex color code, such as #000000."
 msgstr ""
 
-#: src/olympia/amo/fields.py:58
+#: src/olympia/amo/fields.py:63
 msgid "Enter at least one value."
 msgstr ""
 
-#: src/olympia/amo/helpers.py:162 src/olympia/amo/templates/amo/site_nav.html:61 src/olympia/bandwagon/templates/bandwagon/add.html:9
+#: src/olympia/amo/helpers.py:162 src/olympia/amo/templates/amo/site_nav.html:59 src/olympia/bandwagon/templates/bandwagon/add.html:9
 #: src/olympia/bandwagon/templates/bandwagon/collection_detail.html:15 src/olympia/bandwagon/templates/bandwagon/delete.html:9 src/olympia/bandwagon/templates/bandwagon/edit.html:15
 #: src/olympia/bandwagon/templates/bandwagon/user_listing.html:18 src/olympia/bandwagon/templates/bandwagon/user_listing.html:21
 #: src/olympia/bandwagon/templates/bandwagon/impala/collection_listing.html:12 src/olympia/bandwagon/templates/bandwagon/impala/collection_listing.html:20
 #: src/olympia/bandwagon/templates/bandwagon/impala/collection_listing.html:24 src/olympia/bandwagon/templates/bandwagon/impala/collection_sidebar.html:3
 #: src/olympia/bandwagon/templates/bandwagon/includes/collection_sidebar.html:2 src/olympia/bandwagon/templates/bandwagon/mobile/collection_listing.html:3
-#: src/olympia/stats/templates/stats/stats.html:77 src/olympia/templates/menu_links.html:12
+#: src/olympia/stats/templates/stats/stats.html:33 src/olympia/templates/menu_links.html:12
 msgid "Collections"
 msgstr ""
 
-#: src/olympia/amo/helpers.py:171 src/olympia/amo/templates/amo/site_nav.html:85 src/olympia/browse/templates/browse/language_tools.html:3
+#: src/olympia/amo/helpers.py:171 src/olympia/amo/templates/amo/site_nav.html:83 src/olympia/browse/templates/browse/language_tools.html:3
 msgid "Dictionaries & Language Packs"
 msgstr ""
 
@@ -1575,8 +1576,8 @@ msgstr ""
 msgid "Comment on {addon} {version}."
 msgstr ""
 
-#: src/olympia/amo/log.py:236 src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:19 src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:47
-#: src/olympia/editors/helpers.py:511 src/olympia/editors/templates/editors/themes/history_table.html:11
+#: src/olympia/amo/log.py:236 src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:17 src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:45
+#: src/olympia/editors/helpers.py:584 src/olympia/editors/templates/editors/themes/history_table.html:11
 msgid "Comment"
 msgstr ""
 
@@ -1899,7 +1900,7 @@ msgstr ""
 #: src/olympia/amo/templates/amo/mobile/paginator.html:14 src/olympia/amo/templates/amo/mobile/paginator.html:16 src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:51
 #: src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:65 src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:78
 #: src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:91 src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:104
-#: src/olympia/discovery/templates/discovery/pane.html:45 src/olympia/discovery/templates/discovery/addons/detail.html:39 src/olympia/stats/templates/stats/stats.html:167
+#: src/olympia/discovery/templates/discovery/pane.html:45 src/olympia/discovery/templates/discovery/addons/detail.html:39 src/olympia/stats/templates/stats/stats.html:169
 msgid "Next"
 msgstr ""
 
@@ -1931,7 +1932,7 @@ msgid ""
 msgstr ""
 
 #: src/olympia/amo/templates/amo/side_nav.html:4 src/olympia/amo/templates/amo/side_nav.html:12 src/olympia/amo/templates/amo/site_nav.html:4 src/olympia/amo/templates/amo/site_nav.html:26
-#: src/olympia/browse/views.py:56 src/olympia/browse/views.py:66 src/olympia/browse/views.py:237 src/olympia/browse/views.py:282 src/olympia/search/forms.py:86
+#: src/olympia/browse/views.py:56 src/olympia/browse/views.py:66 src/olympia/browse/views.py:204 src/olympia/browse/views.py:249 src/olympia/search/forms.py:86
 msgid "Top Rated"
 msgstr ""
 
@@ -1945,38 +1946,38 @@ msgstr ""
 msgid "Extensions"
 msgstr ""
 
-#: src/olympia/amo/templates/amo/site_nav.html:45
+#: src/olympia/amo/templates/amo/site_nav.html:44
 msgid "Want more customization? Try <b>Complete Themes</b>"
 msgstr ""
 
-#: src/olympia/amo/templates/amo/site_nav.html:56 src/olympia/bandwagon/views.py:96
+#: src/olympia/amo/templates/amo/site_nav.html:54 src/olympia/bandwagon/views.py:96
 msgid "Most Followers"
 msgstr ""
 
-#: src/olympia/amo/templates/amo/site_nav.html:68 src/olympia/bandwagon/templates/bandwagon/impala/collection_sidebar.html:16
+#: src/olympia/amo/templates/amo/site_nav.html:66 src/olympia/bandwagon/templates/bandwagon/impala/collection_sidebar.html:16
 #: src/olympia/bandwagon/templates/bandwagon/includes/collection_sidebar.html:18
 msgid "Collections I've Made"
 msgstr ""
 
-#: src/olympia/amo/templates/amo/site_nav.html:70 src/olympia/bandwagon/templates/bandwagon/user_listing.html:4 src/olympia/bandwagon/templates/bandwagon/impala/collection_sidebar.html:13
+#: src/olympia/amo/templates/amo/site_nav.html:68 src/olympia/bandwagon/templates/bandwagon/user_listing.html:4 src/olympia/bandwagon/templates/bandwagon/impala/collection_sidebar.html:13
 #: src/olympia/bandwagon/templates/bandwagon/includes/collection_sidebar.html:15
 msgid "Collections I'm Following"
 msgstr ""
 
-#: src/olympia/amo/templates/amo/site_nav.html:73 src/olympia/bandwagon/templates/bandwagon/impala/collection_sidebar.html:18
-#: src/olympia/bandwagon/templates/bandwagon/includes/collection_sidebar.html:20 src/olympia/users/models.py:512
+#: src/olympia/amo/templates/amo/site_nav.html:71 src/olympia/bandwagon/templates/bandwagon/impala/collection_sidebar.html:18
+#: src/olympia/bandwagon/templates/bandwagon/includes/collection_sidebar.html:20 src/olympia/users/models.py:521
 msgid "My Favorite Add-ons"
 msgstr ""
 
-#: src/olympia/amo/templates/amo/site_nav.html:78
+#: src/olympia/amo/templates/amo/site_nav.html:76
 msgid "More&hellip;"
 msgstr ""
 
-#: src/olympia/amo/templates/amo/site_nav.html:82
+#: src/olympia/amo/templates/amo/site_nav.html:80
 msgid "Add-ons for Mobile"
 msgstr ""
 
-#: src/olympia/amo/templates/amo/site_nav.html:86 src/olympia/browse/feeds.py:207 src/olympia/browse/templates/browse/search_tools.html:3 src/olympia/constants/base.py:176
+#: src/olympia/amo/templates/amo/site_nav.html:84 src/olympia/browse/feeds.py:207 src/olympia/browse/templates/browse/search_tools.html:3 src/olympia/constants/base.py:176
 #: src/olympia/templates/menu_links.html:10
 msgid "Search Tools"
 msgstr ""
@@ -1992,7 +1993,7 @@ msgid "Jump to first page"
 msgstr ""
 
 #: src/olympia/amo/templates/amo/impala/paginator.html:22 src/olympia/amo/templates/amo/mobile/impala_paginator.html:12 src/olympia/discovery/templates/discovery/pane.html:44
-#: src/olympia/discovery/templates/discovery/addons/detail.html:38 src/olympia/stats/templates/stats/stats.html:164
+#: src/olympia/discovery/templates/discovery/addons/detail.html:38 src/olympia/stats/templates/stats/stats.html:166
 msgid "Previous"
 msgstr ""
 
@@ -2015,30 +2016,49 @@ msgid_plural "Page {n}"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/olympia/amo/templates/services/install.html:38
-#, python-format
-msgid "If you are not prompted to install %(addon_name)s in a moment, please <a href=\"%(addon_xpi)s\">click here</a>."
-msgstr ""
-
-#: src/olympia/amo/tests/test_messages.py:57 src/olympia/amo/tests/test_messages.py:58 src/olympia/reviews/forms.py:25 src/olympia/reviews/forms.py:50 src/olympia/reviews/templates/reviews/add.html:56
+#: src/olympia/amo/tests/test_messages.py:56 src/olympia/amo/tests/test_messages.py:57 src/olympia/reviews/forms.py:25 src/olympia/reviews/forms.py:50 src/olympia/reviews/templates/reviews/add.html:56
 #: src/olympia/reviews/templates/reviews/reply.html:30
 msgid "Title"
 msgstr ""
 
-#: src/olympia/amo/tests/test_messages.py:57 src/olympia/amo/tests/test_messages.py:58
+#: src/olympia/amo/tests/test_messages.py:56 src/olympia/amo/tests/test_messages.py:57
 msgid "Body"
 msgstr ""
 
-#: src/olympia/amo/tests/test_messages.py:59
+#: src/olympia/amo/tests/test_messages.py:58
 msgid "Another Title"
 msgstr ""
 
-#: src/olympia/amo/tests/test_messages.py:59
+#: src/olympia/amo/tests/test_messages.py:58
 msgid "Another Body"
 msgstr ""
 
-#: src/olympia/api/views.py:255
-msgid "Not implemented yet."
+#: src/olympia/api/authentication.py:76
+msgid "Signature has expired."
+msgstr ""
+
+#: src/olympia/api/authentication.py:79
+msgid "Error decoding signature."
+msgstr ""
+
+#: src/olympia/api/authentication.py:82
+msgid "Invalid JWT Token."
+msgstr ""
+
+#: src/olympia/api/authentication.py:130
+msgid "Invalid Authorization header. No credentials provided."
+msgstr ""
+
+#: src/olympia/api/authentication.py:133
+msgid "Invalid Authorization header. Credentials string should not contain spaces."
+msgstr ""
+
+#: src/olympia/api/fields.py:29
+msgid "The field must have a length of at least {num} characters."
+msgstr ""
+
+#: src/olympia/api/fields.py:31
+msgid "The language code {lang_code} is invalid."
 msgstr ""
 
 #: src/olympia/applications/views.py:39 src/olympia/applications/templates/applications/appversions.html:3
@@ -2057,7 +2077,7 @@ msgstr ""
 msgid "Add-ons submitted to Mozilla Add-ons must have a manifest file with at least one of the below applications supported. Only the versions listed below are allowed for these applications."
 msgstr ""
 
-#: src/olympia/applications/templates/applications/appversions.html:25
+#: src/olympia/applications/templates/applications/appversions.html:25 src/olympia/editors/helpers.py:361
 msgid "GUID"
 msgstr ""
 
@@ -2171,8 +2191,8 @@ msgstr ""
 msgid "Remove from favorites"
 msgstr ""
 
-#: src/olympia/bandwagon/views.py:98 src/olympia/bandwagon/views.py:191 src/olympia/browse/views.py:58 src/olympia/browse/views.py:69 src/olympia/browse/views.py:458 src/olympia/devhub/views.py:74
-#: src/olympia/devhub/views.py:82 src/olympia/devhub/templates/devhub/addons/edit/basic.html:20 src/olympia/editors/templates/editors/leaderboard.html:24
+#: src/olympia/bandwagon/views.py:98 src/olympia/bandwagon/views.py:191 src/olympia/browse/views.py:58 src/olympia/browse/views.py:69 src/olympia/browse/views.py:425 src/olympia/devhub/views.py:72
+#: src/olympia/devhub/views.py:80 src/olympia/devhub/templates/devhub/addons/edit/basic.html:20 src/olympia/editors/templates/editors/leaderboard.html:24
 #: src/olympia/editors/templates/editors/themes/queue_list.html:48 src/olympia/search/forms.py:17 src/olympia/search/forms.py:89 src/olympia/users/templates/users/vcard.html:5
 msgid "Name"
 msgstr ""
@@ -2181,7 +2201,7 @@ msgstr ""
 msgid "Recently Popular"
 msgstr ""
 
-#: src/olympia/bandwagon/views.py:189 src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:18
+#: src/olympia/bandwagon/views.py:189 src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:16
 msgid "Added"
 msgstr ""
 
@@ -2195,7 +2215,7 @@ msgstr ""
 
 #: src/olympia/bandwagon/views.py:316
 #, python-format
-msgid "Your new collection is shown below. You can <ahref=\"%(url)s\">edit additional settings</a> if you'dlike."
+msgid "Your new collection is shown below. You can <a href=\"%(url)s\">edit additional settings</a> if you'd like."
 msgstr ""
 
 #: src/olympia/bandwagon/views.py:322
@@ -2323,8 +2343,8 @@ msgid_plural "%(num)s Add-ons in this Collection"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/olympia/bandwagon/templates/bandwagon/collection_detail.html:125 src/olympia/compat/templates/compat/index.html:25 src/olympia/compat/templates/compat/reporter_detail.html:29
-#: src/olympia/files/templates/files/viewer.html:29 src/olympia/templates/amo_footer.html:17 src/olympia/templates/includes/lang_switcher.html:10
+#: src/olympia/bandwagon/templates/bandwagon/collection_detail.html:125 src/olympia/compat/templates/compat/reporter_detail.html:29 src/olympia/files/templates/files/viewer.html:29
+#: src/olympia/templates/amo_footer.html:17 src/olympia/templates/includes/lang_switcher.html:10
 msgid "Go"
 msgstr ""
 
@@ -2491,7 +2511,7 @@ msgid "Remove this user as a contributor"
 msgstr ""
 
 #: src/olympia/bandwagon/templates/bandwagon/edit_contributors.html:18 src/olympia/bandwagon/templates/bandwagon/edit_contributors.html:43
-#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:20 src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:48
+#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:18 src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:46
 #: src/olympia/devhub/templates/devhub/addons/ajax_compat_update.html:19
 msgid "Remove"
 msgstr ""
@@ -2539,7 +2559,7 @@ msgid "<b>Warning:</b> By changing the owner of this collection, you will no lon
 msgstr ""
 
 #: src/olympia/bandwagon/templates/bandwagon/edit_contributors.html:83 src/olympia/devhub/templates/devhub/addons/forms_shared/media.html:157
-#: src/olympia/devhub/templates/devhub/addons/submit/describe.html:69 src/olympia/devhub/templates/devhub/addons/submit/license.html:60 src/olympia/devhub/templates/devhub/addons/submit/upload.html:78
+#: src/olympia/devhub/templates/devhub/addons/submit/describe.html:69 src/olympia/devhub/templates/devhub/addons/submit/license.html:60 src/olympia/devhub/templates/devhub/addons/submit/upload.html:70
 #: src/olympia/devhub/templates/devhub/payments/tier.html:17 src/olympia/editors/templates/editors/themes/themes.html:111 src/olympia/editors/templates/editors/themes/themes.html:128
 #: src/olympia/editors/templates/editors/themes/themes.html:134 src/olympia/editors/templates/editors/themes/themes.html:141 src/olympia/users/templates/users/fxa_migration_prompt_content.html:10
 #: src/olympia/users/templates/users/login_form.html:42 src/olympia/users/templates/users/mobile/login.html:57
@@ -2622,31 +2642,31 @@ msgid "Add-ons in Your Collection"
 msgstr ""
 
 #: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:4
-msgid ""
-"To include an add-on in this collection, enter its name in the box below and hit enter.  You can also use the <strong>Add to Collection</strong> links throughout the site to include add-ons later."
+msgid "To include an add-on in this collection, enter its name in the box below and hit enter."
 msgstr ""
 
-#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:17 src/olympia/constants/base.py:400 src/olympia/devhub/templates/devhub/addons/activity.html:62
+#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:15 src/olympia/constants/base.py:400 src/olympia/devhub/templates/devhub/addons/activity.html:62
+#: src/olympia/editors/helpers.py:273 src/olympia/editors/helpers.py:360
 msgid "Add-on"
 msgstr ""
 
-#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:26
+#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:24
 msgid "Enter the name of the add-on to include"
 msgstr ""
 
-#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:28
+#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:26
 msgid "Add to Collection"
 msgstr ""
 
-#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:45 src/olympia/editors/helpers.py:936 src/olympia/editors/helpers.py:956
+#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:43 src/olympia/editors/helpers.py:1016 src/olympia/editors/helpers.py:1036
 msgid "Pending"
 msgstr ""
 
-#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:47
+#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:45
 msgid "Add a comment"
 msgstr ""
 
-#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:48
+#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:46
 msgid "Remove this add-on from the collection"
 msgstr ""
 
@@ -2753,12 +2773,12 @@ msgstr ""
 msgid "Most Users"
 msgstr ""
 
-#: src/olympia/browse/views.py:61 src/olympia/browse/views.py:72 src/olympia/browse/views.py:279 src/olympia/browse/templates/browse/personas/mobile/category_landing.html:63
+#: src/olympia/browse/views.py:61 src/olympia/browse/views.py:72 src/olympia/browse/views.py:246 src/olympia/browse/templates/browse/personas/mobile/category_landing.html:63
 #: src/olympia/discovery/templates/discovery/pane.html:67 src/olympia/search/forms.py:92
 msgid "Up & Coming"
 msgstr ""
 
-#: src/olympia/browse/views.py:460 src/olympia/devhub/views.py:76 src/olympia/devhub/views.py:83 src/olympia/discovery/templates/discovery/addons/detail.html:66
+#: src/olympia/browse/views.py:427 src/olympia/devhub/views.py:74 src/olympia/devhub/views.py:81 src/olympia/discovery/templates/discovery/addons/detail.html:66
 msgid "Created"
 msgstr ""
 
@@ -2946,8 +2966,8 @@ msgid_plural "See all %(cnt)s extensions in %(name)s &raquo;"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/olympia/browse/templates/browse/mobile/extensions.html:13 src/olympia/compat/templates/compat/index.html:82 src/olympia/devhub/templates/devhub/devhub_search.html:24
-#: src/olympia/devhub/templates/devhub/addons/activity.html:47 src/olympia/search/templates/search/no_results.html:4 src/olympia/search/templates/search/mobile/results.html:36
+#: src/olympia/browse/templates/browse/mobile/extensions.html:13 src/olympia/devhub/templates/devhub/devhub_search.html:24 src/olympia/devhub/templates/devhub/addons/activity.html:47
+#: src/olympia/search/templates/search/no_results.html:4 src/olympia/search/templates/search/mobile/results.html:36
 msgid "No results found."
 msgstr ""
 
@@ -3032,7 +3052,7 @@ msgstr ""
 msgid "All"
 msgstr ""
 
-#: src/olympia/compat/forms.py:22 src/olympia/search/views.py:525
+#: src/olympia/compat/forms.py:22 src/olympia/editors/templates/editors/base.html:69 src/olympia/search/views.py:518
 msgid "All Add-ons"
 msgstr ""
 
@@ -3042,53 +3062,6 @@ msgstr ""
 
 #: src/olympia/compat/forms.py:24
 msgid "Non-binary"
-msgstr ""
-
-#. Review points sources other than add-ons and themes.
-#: src/olympia/compat/views.py:87 src/olympia/constants/base.py:388 src/olympia/devhub/forms.py:162 src/olympia/editors/templates/editors/performance.html:75
-msgid "Other"
-msgstr ""
-
-#: src/olympia/compat/templates/compat/index.html:4
-msgid "Add-on Compatibility Report for {app} {version}"
-msgstr ""
-
-#: src/olympia/compat/templates/compat/index.html:11
-msgid "{app} {version} Compatibility"
-msgstr ""
-
-#: src/olympia/compat/templates/compat/index.html:17
-#, python-format
-msgid "Top 95%% compatible with previous version"
-msgstr ""
-
-#: src/olympia/compat/templates/compat/index.html:18
-#, python-format
-msgid "Top 95%% of all add-ons"
-msgstr ""
-
-#: src/olympia/compat/templates/compat/index.html:19
-msgid "All active add-ons"
-msgstr ""
-
-#: src/olympia/compat/templates/compat/index.html:23 src/olympia/constants/base.py:401
-msgid "App"
-msgstr ""
-
-#: src/olympia/compat/templates/compat/index.html:55
-msgid "Details for add-ons compatible with previous version:"
-msgstr ""
-
-#: src/olympia/compat/templates/compat/index.html:57
-msgid "Show all versions"
-msgstr ""
-
-#: src/olympia/compat/templates/compat/index.html:59
-msgid "Details for add-ons compatible with all versions:"
-msgstr ""
-
-#: src/olympia/compat/templates/compat/index.html:61
-msgid "Show previous version only"
 msgstr ""
 
 #: src/olympia/compat/templates/compat/reporter.html:3
@@ -3142,8 +3115,8 @@ msgstr ""
 msgid "Report Type"
 msgstr ""
 
-#: src/olympia/compat/templates/compat/reporter_detail.html:47 src/olympia/devhub/forms.py:784 src/olympia/devhub/templates/devhub/addons/ajax_compat_update.html:17 src/olympia/editors/forms.py:108
-#: src/olympia/zadmin/forms.py:45
+#: src/olympia/compat/templates/compat/reporter_detail.html:47 src/olympia/devhub/forms.py:785 src/olympia/devhub/templates/devhub/addons/ajax_compat_update.html:17 src/olympia/editors/forms.py:108
+#: src/olympia/editors/forms.py:248 src/olympia/zadmin/forms.py:45
 msgid "Application"
 msgstr ""
 
@@ -3231,7 +3204,8 @@ msgstr ""
 msgid "Preliminarily Reviewed and Awaiting Full Review"
 msgstr ""
 
-#: src/olympia/constants/base.py:33 src/olympia/editors/helpers.py:924 src/olympia/editors/templates/editors/themes/history_table.html:34
+#: src/olympia/constants/base.py:33 src/olympia/editors/forms.py:258 src/olympia/editors/helpers.py:73 src/olympia/editors/helpers.py:1004
+#: src/olympia/editors/templates/editors/themes/history_table.html:34
 msgid "Deleted"
 msgstr ""
 
@@ -3328,6 +3302,11 @@ msgstr ""
 msgid "Ask before users can download this add-on"
 msgstr ""
 
+#. Review points sources other than add-ons and themes.
+#: src/olympia/constants/base.py:388 src/olympia/devhub/forms.py:162 src/olympia/editors/templates/editors/performance.html:75
+msgid "Other"
+msgstr ""
+
 #: src/olympia/constants/base.py:389
 msgid "Exception"
 msgstr ""
@@ -3338,6 +3317,10 @@ msgstr ""
 
 #: src/olympia/constants/base.py:391
 msgid "Change"
+msgstr ""
+
+#: src/olympia/constants/base.py:401
+msgid "App"
 msgstr ""
 
 #: src/olympia/constants/base.py:402
@@ -3488,7 +3471,7 @@ msgstr ""
 msgid "Duplicate"
 msgstr ""
 
-#: src/olympia/constants/editors.py:17 src/olympia/editors/helpers.py:502 src/olympia/editors/templates/editors/themes/queue.html:71 src/olympia/editors/templates/editors/themes/themes.html:94
+#: src/olympia/constants/editors.py:17 src/olympia/editors/helpers.py:575 src/olympia/editors/templates/editors/themes/queue.html:71 src/olympia/editors/templates/editors/themes/themes.html:94
 msgid "Reject"
 msgstr ""
 
@@ -3588,7 +3571,7 @@ msgstr ""
 msgid "Android"
 msgstr ""
 
-#: src/olympia/core/apps.py:19
+#: src/olympia/core/apps.py:21
 msgid "Core"
 msgstr ""
 
@@ -3722,7 +3705,7 @@ msgid "Submit my add-on for manual review."
 msgstr ""
 
 #: src/olympia/devhub/forms.py:537
-msgid "Do not list my add-on on this site (beta)"
+msgid "Do not list my add-on on this site"
 msgstr ""
 
 #: src/olympia/devhub/forms.py:538
@@ -3755,46 +3738,46 @@ msgstr ""
 
 #: src/olympia/devhub/forms.py:592
 #, python-format
-msgid "Version %s already exists"
+msgid "Version %s already exists, or was uploaded before."
 msgstr ""
 
-#: src/olympia/devhub/forms.py:604
+#: src/olympia/devhub/forms.py:605
 msgid "Select a valid choice. That choice is not one of the available choices."
 msgstr ""
 
-#: src/olympia/devhub/forms.py:610
+#: src/olympia/devhub/forms.py:611
 msgid "A file with a version ending with a|alpha|b|beta and an optional number is detected as beta."
 msgstr ""
 
-#: src/olympia/devhub/forms.py:633
+#: src/olympia/devhub/forms.py:634
 msgid "You cannot upload any more files for this version."
 msgstr ""
 
-#: src/olympia/devhub/forms.py:639
+#: src/olympia/devhub/forms.py:640
 msgid "Version doesn't match"
 msgstr ""
 
-#: src/olympia/devhub/forms.py:668
+#: src/olympia/devhub/forms.py:669
 msgid "You cannot delete a file once the review process has started.  You must delete the whole version."
 msgstr ""
 
-#: src/olympia/devhub/forms.py:688
+#: src/olympia/devhub/forms.py:689
 msgid "The platform All cannot be combined with specific platforms."
 msgstr ""
 
-#: src/olympia/devhub/forms.py:693
+#: src/olympia/devhub/forms.py:694
 msgid "A platform can only be chosen once."
 msgstr ""
 
-#: src/olympia/devhub/forms.py:706
+#: src/olympia/devhub/forms.py:707
 msgid "A review type must be selected."
 msgstr ""
 
-#: src/olympia/devhub/forms.py:788 src/olympia/editors/forms.py:114 src/olympia/zadmin/forms.py:49 src/olympia/zadmin/forms.py:52
+#: src/olympia/devhub/forms.py:789 src/olympia/editors/forms.py:114 src/olympia/editors/forms.py:254 src/olympia/zadmin/forms.py:49 src/olympia/zadmin/forms.py:52
 msgid "Select an application first"
 msgstr ""
 
-#: src/olympia/devhub/forms.py:840
+#: src/olympia/devhub/forms.py:841
 msgid "There cannot be more than 3 required add-ons."
 msgstr ""
 
@@ -3828,76 +3811,76 @@ msgstr[1] ""
 msgid "Review"
 msgstr ""
 
-#: src/olympia/devhub/tasks.py:551
+#: src/olympia/devhub/tasks.py:583
 #, python-format
 msgid "%s responded with %s (%s)."
 msgstr ""
 
-#: src/olympia/devhub/tasks.py:555
+#: src/olympia/devhub/tasks.py:587
 #, python-format
 msgid "Connection to \"%s\" timed out."
 msgstr ""
 
-#: src/olympia/devhub/tasks.py:557
+#: src/olympia/devhub/tasks.py:589
 #, python-format
 msgid "Could not contact host at \"%s\"."
 msgstr ""
 
-#: src/olympia/devhub/utils.py:104
+#: src/olympia/devhub/utils.py:105
 #, python-format
 msgid "Validation generated too many errors/warnings so %s messages were truncated. After addressing the visible messages, you'll be able to see the others."
 msgstr ""
 
-#: src/olympia/devhub/views.py:183
+#: src/olympia/devhub/views.py:181
 msgid "All My Add-ons"
 msgstr ""
 
-#: src/olympia/devhub/views.py:210
+#: src/olympia/devhub/views.py:208
 msgid "All Activity"
 msgstr ""
 
-#: src/olympia/devhub/views.py:211
+#: src/olympia/devhub/views.py:209
 msgid "Add-on Updates"
 msgstr ""
 
-#: src/olympia/devhub/views.py:212
+#: src/olympia/devhub/views.py:210
 msgid "Add-on Status"
 msgstr ""
 
-#: src/olympia/devhub/views.py:213
+#: src/olympia/devhub/views.py:211
 msgid "User Collections"
 msgstr ""
 
-#: src/olympia/devhub/views.py:214 src/olympia/devhub/templates/devhub/docs/policies-maintenance.html:68 src/olympia/pages/templates/pages/dev_faq.html:38
+#: src/olympia/devhub/views.py:212 src/olympia/devhub/templates/devhub/docs/policies-maintenance.html:68 src/olympia/pages/templates/pages/dev_faq.html:38
 #: src/olympia/pages/templates/pages/dev_faq.html:484
 msgid "User Reviews"
 msgstr ""
 
-#: src/olympia/devhub/views.py:327 src/olympia/devhub/views.py:331 src/olympia/devhub/views.py:484 src/olympia/devhub/views.py:513 src/olympia/devhub/views.py:564 src/olympia/devhub/views.py:1150
+#: src/olympia/devhub/views.py:325 src/olympia/devhub/views.py:329 src/olympia/devhub/views.py:484 src/olympia/devhub/views.py:513 src/olympia/devhub/views.py:564 src/olympia/devhub/views.py:1156
 msgid "Changes successfully saved."
 msgstr ""
 
-#: src/olympia/devhub/views.py:334 src/olympia/devhub/views.py:1631
+#: src/olympia/devhub/views.py:332 src/olympia/devhub/views.py:1637
 msgid "Please check the form for errors."
 msgstr ""
 
-#: src/olympia/devhub/views.py:346
+#: src/olympia/devhub/views.py:344
 msgid "Add-on cannot be deleted. Disable this add-on instead."
 msgstr ""
 
-#: src/olympia/devhub/views.py:356
+#: src/olympia/devhub/views.py:354
 msgid "Theme deleted."
 msgstr ""
 
-#: src/olympia/devhub/views.py:356
+#: src/olympia/devhub/views.py:354
 msgid "Add-on deleted."
 msgstr ""
 
-#: src/olympia/devhub/views.py:362
+#: src/olympia/devhub/views.py:360
 msgid "URL name was incorrect. Theme was not deleted."
 msgstr ""
 
-#: src/olympia/devhub/views.py:367
+#: src/olympia/devhub/views.py:365
 msgid "URL name was incorrect. Add-on was not deleted."
 msgstr ""
 
@@ -3925,7 +3908,7 @@ msgstr ""
 msgid "Check Add-on Compatibility"
 msgstr ""
 
-#: src/olympia/devhub/views.py:808 src/olympia/signing/views.py:90
+#: src/olympia/devhub/views.py:808 src/olympia/signing/views.py:95
 msgid "You cannot submit this type of add-on"
 msgstr ""
 
@@ -3955,33 +3938,33 @@ msgstr ""
 msgid "There was an error uploading your preview."
 msgstr ""
 
-#: src/olympia/devhub/views.py:1189
+#: src/olympia/devhub/views.py:1195
 #, python-format
 msgid "Version %s disabled."
 msgstr ""
 
-#: src/olympia/devhub/views.py:1193
+#: src/olympia/devhub/views.py:1199
 #, python-format
 msgid "Version %s deleted."
 msgstr ""
 
-#: src/olympia/devhub/views.py:1203
+#: src/olympia/devhub/views.py:1209
 msgid "This upload has failed validation, and may lack complete validation results. Please take due care when reviewing it."
 msgstr ""
 
-#: src/olympia/devhub/views.py:1677
+#: src/olympia/devhub/views.py:1683
 msgid "Preliminary Review Requested."
 msgstr ""
 
-#: src/olympia/devhub/views.py:1678
+#: src/olympia/devhub/views.py:1684
 msgid "Full Review Requested."
 msgstr ""
 
-#: src/olympia/devhub/views.py:1779
+#: src/olympia/devhub/views.py:1783
 msgid "Your old credentials were revoked and are no longer valid. Be sure to update all API clients with the new credentials."
 msgstr ""
 
-#: src/olympia/devhub/views.py:1797
+#: src/olympia/devhub/views.py:1801
 msgid "New API key created"
 msgstr ""
 
@@ -4011,7 +3994,7 @@ msgstr ""
 msgid "{0} :: Search"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/devhub_search.html:6 src/olympia/devhub/templates/devhub/search.html:8 src/olympia/editors/forms.py:435 src/olympia/editors/forms.py:437
+#: src/olympia/devhub/templates/devhub/devhub_search.html:6 src/olympia/devhub/templates/devhub/search.html:8 src/olympia/editors/forms.py:534 src/olympia/editors/forms.py:536
 #: src/olympia/editors/templates/editors/queue.html:27 src/olympia/editors/templates/editors/themes/queue_list.html:14 src/olympia/search/templates/search/collections.html:17
 #: src/olympia/search/templates/search/personas.html:18 src/olympia/search/templates/search/results.html:18 src/olympia/search/templates/search/mobile/results.html:8
 #: src/olympia/templates/search.html:14 src/olympia/templates/impala/search.html:18
@@ -4071,12 +4054,12 @@ msgstr ""
 msgid "Start Making Add-ons"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/index.html:86 src/olympia/devhub/templates/devhub/addons/listing/items.html:25 src/olympia/devhub/templates/devhub/includes/addon_details.html:15
+#: src/olympia/devhub/templates/devhub/index.html:86 src/olympia/devhub/templates/devhub/addons/listing/items.html:25 src/olympia/devhub/templates/devhub/includes/addon_details.html:20
 #: src/olympia/devhub/templates/devhub/personas/edit.html:43
 msgid "Status:"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/index.html:90 src/olympia/devhub/templates/devhub/includes/addon_details.html:100
+#: src/olympia/devhub/templates/devhub/index.html:90 src/olympia/devhub/templates/devhub/includes/addon_details.html:87
 msgid "Visibility:"
 msgstr ""
 
@@ -4084,11 +4067,11 @@ msgstr ""
 msgid "Latest Version:"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/index.html:109 src/olympia/devhub/templates/devhub/includes/addon_details.html:145 src/olympia/devhub/templates/devhub/personas/edit.html:49
+#: src/olympia/devhub/templates/devhub/index.html:109 src/olympia/devhub/templates/devhub/includes/addon_details.html:131 src/olympia/devhub/templates/devhub/personas/edit.html:49
 msgid "Queue Position:"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/index.html:110 src/olympia/devhub/templates/devhub/includes/addon_details.html:146 src/olympia/devhub/templates/devhub/personas/edit.html:50
+#: src/olympia/devhub/templates/devhub/index.html:110 src/olympia/devhub/templates/devhub/includes/addon_details.html:132 src/olympia/devhub/templates/devhub/personas/edit.html:50
 #, python-format
 msgid "%(position)s of %(total)s"
 msgstr ""
@@ -4190,16 +4173,6 @@ msgstr ""
 msgid "Do you want your add-on to be distributed on this site?"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/validate_addon.html:49 src/olympia/devhub/templates/devhub/addons/submit/upload.html:30 src/olympia/devhub/templates/devhub/versions/add_file_modal.html:14
-#: src/olympia/devhub/templates/devhub/versions/add_file_modal.html:53 src/olympia/devhub/templates/devhub/versions/list.html:298
-msgid "Warning:"
-msgstr ""
-
-#: src/olympia/devhub/templates/devhub/validate_addon.html:50 src/olympia/devhub/templates/devhub/addons/submit/upload.html:31
-#, python-format
-msgid "Submission of unlisted add-ons for signing is currently in an open beta. Please <a href=\"%(url)s\" target=\"_blank\">report any bugs</a> that you encounter."
-msgstr ""
-
 #. first parameter is a filename like lorem-ipsum-1.0.2.xpi
 #: src/olympia/devhub/templates/devhub/validation.html:5
 msgid "Validation Results for {0}"
@@ -4274,7 +4247,7 @@ msgstr ""
 msgid "Update Compatibility"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/addons/ajax_compat_update.html:4
+#: src/olympia/devhub/templates/devhub/addons/ajax_compat_update.html:4 src/olympia/devhub/templates/devhub/versions/edit.html:45
 msgid "Adjusting application information here will allow users to install your add-on even if the install manifest in the package indicates that the add-on is incompatible."
 msgstr ""
 
@@ -4286,9 +4259,9 @@ msgstr ""
 msgid "Add Another Application&hellip;"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/addons/ajax_compat_update.html:38 src/olympia/devhub/templates/devhub/addons/owner.html:86 src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:46
-#: src/olympia/devhub/templates/devhub/versions/list.html:351 src/olympia/devhub/templates/devhub/versions/list.html:353 src/olympia/templates/impala/base.html:132
-#: src/olympia/templates/impala/base.html:143 src/olympia/templates/impala/base.html:161 src/olympia/templates/impala/base.html:171
+#: src/olympia/devhub/templates/devhub/addons/ajax_compat_update.html:38 src/olympia/devhub/templates/devhub/addons/owner.html:86 src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:45
+#: src/olympia/devhub/templates/devhub/versions/list.html:349 src/olympia/devhub/templates/devhub/versions/list.html:351 src/olympia/templates/impala/base.html:129
+#: src/olympia/templates/impala/base.html:140 src/olympia/templates/impala/base.html:158 src/olympia/templates/impala/base.html:168
 msgid "Close"
 msgstr ""
 
@@ -4322,7 +4295,7 @@ msgstr ""
 msgid "Manage Authors & License"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/addons/owner.html:29 src/olympia/editors/templates/editors/review.html:270
+#: src/olympia/devhub/templates/devhub/addons/owner.html:29 src/olympia/editors/helpers.py:362 src/olympia/editors/templates/editors/review.html:270
 msgid "Authors"
 msgstr ""
 
@@ -4391,17 +4364,11 @@ msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/basic.html:52
 msgid ""
-"A short explanation of your add-on's basic\n"
-"                          functionality that is displayed in search and browse\n"
-"                          listings, as well as at the top of your add-on's\n"
-"                          details page. It is only relevant for listed add-ons."
+"A short explanation of your add-on's basic functionality that is displayed in search and browse listings, as well as at the top of your add-on's details page. It is only relevant for listed add-ons."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/basic.html:73
-msgid ""
-"Categories are the primary way users browse through add-ons.\n"
-"                        Choose any that fit your add-on's functionality for the most\n"
-"                        exposure. It is only relevant for listed add-ons."
+msgid "Categories are the primary way users browse through add-ons. Choose any that fit your add-on's functionality for the most exposure. It is only relevant for listed add-ons."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/basic.html:90
@@ -4411,11 +4378,7 @@ msgid ""
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/basic.html:119
-msgid ""
-"Tags help users find your add-on and should be short\n"
-"                        descriptors such as tabs, toolbar, or twitter.  You\n"
-"                        may have a maximum of {0} tags. It is only relevant\n"
-"                        for listed add-ons."
+msgid "Tags help users find your add-on and should be short descriptors such as tabs, toolbar, or twitter. You may have a maximum of {0} tags. It is only relevant for listed add-ons."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/basic.html:129 src/olympia/devhub/templates/devhub/personas/edit.html:97 src/olympia/devhub/templates/devhub/personas/submit.html:46
@@ -4443,11 +4406,7 @@ msgid "Add-on Details for {0}"
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/details.html:22
-msgid ""
-"A longer explanation of features,\n"
-"                          functionality, and other relevant information. This\n"
-"                          field is only displayed on the add-on's details\n"
-"                          page. It is only relevant for listed add-ons."
+msgid "A longer explanation of features, functionality, and other relevant information. This field is only displayed on the add-on's details page. It is only relevant for listed add-ons."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/details.html:44 src/olympia/translations/templates/translations/trans-menu.html:13
@@ -4455,10 +4414,7 @@ msgid "Default Locale"
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/details.html:45
-msgid ""
-"Information about your add-on is displayed in this locale\n"
-"                        unless you override it with a locale-specific translation.\n"
-"                        It is only relevant for listed add-ons."
+msgid "Information about your add-on is displayed in this locale unless you override it with a locale-specific translation. It is only relevant for listed add-ons."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/details.html:61 src/olympia/users/forms.py:311 src/olympia/users/templates/users/edit.html:122 src/olympia/users/templates/users/register.html:57
@@ -4468,10 +4424,8 @@ msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/details.html:63
 msgid ""
-"If your add-on has another homepage, enter its\n"
-"                          address here. If your website is localized into other\n"
-"                          languages multiple translations of this field can be\n"
-"                          added. It is only relevant for listed add-ons."
+"If your add-on has another homepage, enter its address here. If your website is localized into other languages multiple translations of this field can be added. It is only relevant for listed add-"
+"ons."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/media.html:3
@@ -4489,19 +4443,14 @@ msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/support.html:22
 msgid ""
-"If you wish to display an e-mail address for support\n"
-"                          inquiries, enter it here. If you have different\n"
-"                          addresses for each language multiple translations of\n"
-"                          this field can be added. It is only relevant for\n"
-"                          listed add-ons."
+"If you wish to display an e-mail address for support inquiries, enter it here. If you have different addresses for each language multiple translations of this field can be added. It is only "
+"relevant for listed add-ons."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/support.html:45
 msgid ""
-"If your add-on has a support website or forum, enter\n"
-"                          its address here. If your website is localized into\n"
-"                          other languages, multiple translations of this field can\n"
-"                          be added. It is only relevant for listed add-ons."
+"If your add-on has a support website or forum, enter its address here. If your website is localized into other languages, multiple translations of this field can be added. It is only relevant for "
+"listed add-ons."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:6
@@ -4515,11 +4464,8 @@ msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:23
 msgid ""
-"Any information end users may want to know that isn't\n"
-"                          necessarily applicable to the add-on summary or description.\n"
-"                          Common uses include listing known major bugs, information on\n"
-"                          how to report bugs, anticipated release date of a new version,\n"
-"                          etc. It is only relevant for listed add-ons."
+"Any information end users may want to know that isn't necessarily applicable to the add-on summary or description. Common uses include listing known major bugs, information on how to report bugs, "
+"anticipated release date of a new version, etc. It is only relevant for listed add-ons."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:46
@@ -4531,9 +4477,7 @@ msgid "Add-on Flags"
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:69
-msgid ""
-"These flags are used to classify add-ons. It is only\n"
-"                        relevant for listed add-ons."
+msgid "These flags are used to classify add-ons. It is only relevant for listed add-ons."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:74
@@ -4549,9 +4493,7 @@ msgid "View Source?"
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:90
-msgid ""
-"Whether the source of your add-on can be displayed in our\n"
-"                        online viewer. It is only relevant for listed add-ons."
+msgid "Whether the source of your add-on can be displayed in our online viewer. It is only relevant for listed add-ons."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:94
@@ -4567,10 +4509,7 @@ msgid "Public Stats?"
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:102
-msgid ""
-"Whether the download and usage stats of your add-on can\n"
-"                        be displayed in our online viewer.\n"
-"                        It is only relevant for listed add-ons."
+msgid "Whether the download and usage stats of your add-on can be displayed in our online viewer. It is only relevant for listed add-ons."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:107
@@ -4586,10 +4525,7 @@ msgid "Upgrade SDK?"
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:116
-msgid ""
-"If selected, we will try to automatically upgrade your\n"
-"                        add-on when a new version of the SDK is released.\n"
-"                        It is only relevant for listed add-ons."
+msgid "If selected, we will try to automatically upgrade your add-on when a new version of the SDK is released. It is only relevant for listed add-ons."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:121
@@ -4640,10 +4576,8 @@ msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/forms_shared/media.html:16
 msgid ""
-"Upload an icon for your add-on or choose from one of ours. The\n"
-"                      icon is displayed nearly everywhere your add-on is. Uploaded images\n"
-"                      must be one of the following image types: .png, .jpg.\n"
-"                      It is only relevant for listed add-ons."
+"Upload an icon for your add-on or choose from one of ours. The icon is displayed nearly everywhere your add-on is. Uploaded images must be one of the following image types: .png, .jpg. It is only "
+"relevant for listed add-ons."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/forms_shared/media.html:25
@@ -4656,9 +4590,7 @@ msgid "32x32px"
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/forms_shared/media.html:39
-msgid ""
-"Used in listings of add-ons, like search results\n"
-"                            and featured add-ons."
+msgid "Used in listings of add-ons, like search results and featured add-ons."
 msgstr ""
 
 #. The size of the icon
@@ -4753,16 +4685,14 @@ msgid "Deleting your add-on will permanently remove it from the site and prevent
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:24
-msgid ""
-"Enter the following text confirm your decision:\n"
-"           {slug}"
+msgid "Enter the following text confirm your decision: {slug}"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:34
+#: src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:33
 msgid "Please tell us why you are deleting your theme:"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:36
+#: src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:35
 msgid "Please tell us why you are deleting your add-on:"
 msgstr ""
 
@@ -4799,8 +4729,8 @@ msgstr ""
 msgid "Daily statistics on downloads and users."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/addons/listing/item_actions.html:45 src/olympia/stats/templates/stats/stats.html:75 src/olympia/stats/templates/stats/stats.html:79
-#: src/olympia/stats/templates/stats/stats.html:81
+#: src/olympia/devhub/templates/devhub/addons/listing/item_actions.html:45 src/olympia/stats/templates/stats/stats.html:31 src/olympia/stats/templates/stats/stats.html:35
+#: src/olympia/stats/templates/stats/stats.html:37
 msgid "Statistics"
 msgstr ""
 
@@ -4919,10 +4849,7 @@ msgid "Your add-on has been submitted to the Full Review queue."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/submit/done.html:18
-msgid ""
-"You'll receive an email once it has been reviewed by an editor. In\n"
-"          the meantime, you and your friends can install it directly from its\n"
-"          details page:"
+msgid "You'll receive an email once it has been reviewed by an editor. In the meantime, you and your friends can install it directly from its details page:"
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/submit/done.html:27 src/olympia/devhub/templates/devhub/addons/submit/done.html:77 src/olympia/devhub/templates/devhub/personas/submit_done.html:16
@@ -5128,11 +5055,11 @@ msgstr ""
 msgid "Use the fields below to upload your add-on package and select any platform restrictions. After upload, a series of automated validation tests will be run on your file."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/addons/submit/upload.html:59 src/olympia/devhub/templates/devhub/versions/add_file_modal.html:39
+#: src/olympia/devhub/templates/devhub/addons/submit/upload.html:51 src/olympia/devhub/templates/devhub/versions/add_file_modal.html:28
 msgid "Which platforms is this file compatible with?"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/addons/submit/upload.html:67 src/olympia/devhub/templates/devhub/versions/add_file_modal.html:65
+#: src/olympia/devhub/templates/devhub/addons/submit/upload.html:59 src/olympia/devhub/templates/devhub/versions/add_file_modal.html:45
 msgid "Administrative overrides"
 msgstr ""
 
@@ -5242,8 +5169,8 @@ msgstr ""
 
 #: src/olympia/devhub/templates/devhub/docs/policies-contact.html:44
 msgid ""
-"If you've found a problem with the site, we'd love to fix it. Please <a href=\"https://github.com/mozilla/olympia/issues\">file a bug report</a> in GitHub, including the location of the problem and "
-"how you encountered it."
+"If you've found a problem with the site, we'd love to fix it. Please <a href=\"https://github.com/mozilla/addons/issues/new\">file a bug report</a> in GitHub, including the location of the problem "
+"and how you encountered it."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/docs/policies-maintenance.html:3 src/olympia/devhub/templates/devhub/docs/policies-maintenance.html:7
@@ -5810,7 +5737,7 @@ msgstr ""
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:282
 msgid ""
-"Add-ons that store or otherwise handle browsing data must support <a href=\"https://developer.mozilla.org/En/Supporting_private_browsing_mode\">Private Browsing Mode</a>.  During a Private Browsing "
+"Add-ons that store or otherwise handle browsing data must support <a href=\"https://developer.mozilla.org/En/Supporting_private_browsing_mode\">Private Browsing Mode</a>. During a Private Browsing "
 "session, no browsing data can be written to disk, and all of this data must be cleared when Firefox quits or the Private Browsing session ends."
 msgstr ""
 
@@ -5975,129 +5902,95 @@ msgstr ""
 msgid "How to get in touch with us regarding these policies or your add-on."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:6
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:10
 msgid "You have disabled this add-on"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:20
-msgid ""
-"Your add-on's listing is disabled and is not showing\n"
-"                             anywhere in our gallery or update service."
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:24
+msgid "Your add-on's listing is disabled and is not showing anywhere in our gallery or update service."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:25
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:27
 msgid "Please complete your add-on."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:29
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:30
 msgid "You will receive an email when the review is complete."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:34
-msgid ""
-"You will receive an email when the review is complete. Until\n"
-"                             then, your add-on is not listed in our gallery but can be\n"
-"                             accessed directly from its details page."
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:33
+msgid "You will receive an email when the review is complete. Until then, your add-on is not listed in our gallery but can be accessed directly from its details page."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:38 src/olympia/devhub/templates/devhub/includes/addon_details.html:48
-msgid ""
-"You will receive an email when the review is\n"
-"                             complete and your add-on is signed."
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:37 src/olympia/devhub/templates/devhub/includes/addon_details.html:45
+msgid "You will receive an email when the review is complete and your add-on is signed."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:44
-msgid ""
-"You will receive an email when the review is complete. Until\n"
-"                             then, your add-on is not listed in our gallery but can be\n"
-"                             accessed directly from its details page. "
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:41
+msgid "You will receive an email when the review is complete. Until then, your add-on is not listed in our gallery but can be accessed directly from its details page. "
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:54
-msgid ""
-"Your add-on is displayed in our gallery and users are\n"
-"                             receiving automatic updates."
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:49
+msgid "Your add-on is displayed in our gallery and users are receiving automatic updates."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:57
-msgid ""
-"Your add-on has been signed and can be bundled with an\n"
-"                             application installer."
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:52
+msgid "Your add-on has been signed and can be bundled with an application installer."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:63
-msgid ""
-"Your add-on was disabled by a site administrator and is no\n"
-"                             longer shown in our gallery. If you have any questions,\n"
-"                             please email amo-admins@mozilla.org."
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:56
+msgid "Your add-on was disabled by a site administrator and is no longer shown in our gallery. If you have any questions, please email amo-admins@mozilla.org."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:70
-msgid ""
-"Your add-on is displayed in our gallery as experimental\n"
-"                             and users are receiving automatic updates. Some features\n"
-"                             are unavailable to your add-on."
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:62
+msgid "Your add-on is displayed in our gallery as experimental and users are receiving automatic updates. Some features are unavailable to your add-on."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:74
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:66
 msgid "Your add-on has been signed."
 msgstr ""
 
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:69
+msgid ""
+"You will receive an email when the full review is complete. Until then, your add-on is displayed in our gallery as experimental and users are receiving automatic updates. Some features are "
+"unavailable to your add-on."
+msgstr ""
+
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:74
+msgid "You will receive an email when the full review is complete, making you able to bundle your add-on with an application installer."
+msgstr ""
+
 #: src/olympia/devhub/templates/devhub/includes/addon_details.html:79
-msgid ""
-"You will receive an email when the full review is complete.\n"
-"                             Until then, your add-on is displayed in our gallery as\n"
-"                             experimental and users are receiving automatic updates.\n"
-"                             Some features are unavailable to your add-on."
+msgid "All add-ons hosted in our gallery must now be reviewed by an editor. If you wish to continue hosting your add-on, please click to select a review process."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:84
-msgid ""
-"You will receive an email when the full review is\n"
-"                             complete, making you able to bundle your add-on with an\n"
-"                             application installer."
-msgstr ""
-
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:91
-msgid ""
-"All add-ons hosted in our gallery must now be reviewed by an\n"
-"                             editor. If you wish to continue hosting your add-on, please\n"
-"                             click to select a review process."
-msgstr ""
-
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:113
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:100
 msgid "Current Version:"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:115
-msgid ""
-"This is the version of your add-on that will\n"
-"                                           be installed if someone clicks the Install\n"
-"                                           button on addons.mozilla.org. It is only\n"
-"                                           relevant for listed add-ons."
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:102
+msgid "This is the version of your add-on that will be installed if someone clicks the Install button on addons.mozilla.org. It is only relevant for listed add-ons."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:123
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:110
 msgid "Created:"
 msgstr ""
 
 #. {0} is a date. dennis-ignore: E201
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:125 src/olympia/devhub/templates/devhub/includes/addon_details.html:131
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:112 src/olympia/devhub/templates/devhub/includes/addon_details.html:118
 #, python-format
 msgid "%%b %%e, %%Y"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:136
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:123
 msgid "Next Version:"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:138
-msgid ""
-"This is the newest uploaded version, however\n"
-"                                           it isn’t live on the site yet."
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:125
+msgid "This is the newest uploaded version, however it isn’t live on the site yet."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:144 src/olympia/devhub/templates/devhub/versions/list.html:30
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:130 src/olympia/devhub/templates/devhub/versions/list.html:30
 msgid "Queues are not reviewed strictly in order"
 msgstr ""
 
@@ -6165,9 +6058,7 @@ msgid "View the blog &#9658;"
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/includes/license_form.html:6
-msgid ""
-"Please choose a license appropriate for the rights you grant on your source code.\n"
-"                  It is only relevant for listed add-ons."
+msgid "Please choose a license appropriate for the rights you grant on your source code. It is only relevant for listed add-ons."
 msgstr ""
 
 #. {0} is a list of HTML tags.
@@ -6194,14 +6085,11 @@ msgstr[1] ""
 #: src/olympia/devhub/templates/devhub/includes/policy_form.html:4
 msgid ""
 "Users will be required to accept the following End-User License Agreement (EULA) prior to installing your add-on. The presence of a EULA significantly affects the number of downloads an add-on "
-"receives. Please note that a EULA is not the same as a code license, such as the GPL or MPL.\n"
-"                It is only relevant for listed add-ons."
+"receives. Please note that a EULA is not the same as a code license, such as the GPL or MPL.It is only relevant for listed add-ons."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/policy_form.html:21
-msgid ""
-"If your add-on transmits any data from the user's computer, a privacy policy is required that explains what data is sent and how it is used.\n"
-"                It is only relevant for listed add-ons."
+#: src/olympia/devhub/templates/devhub/includes/policy_form.html:24
+msgid "If your add-on transmits any data from the user's computer, a privacy policy is required that explains what data is sent and how it is used. It is only relevant for listed add-ons."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/includes/source_form_field.html:2
@@ -6369,12 +6257,8 @@ msgstr ""
 msgid "Add some tags to describe your Theme."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/personas/edit.html:106
-msgid ""
-"A short explanation of your theme's\n"
-"                                basic functionality that is displayed in\n"
-"                                search and browse listings, as well as at\n"
-"                                the top of your theme's details page."
+#: src/olympia/devhub/templates/devhub/personas/edit.html:106 src/olympia/devhub/templates/devhub/personas/submit.html:54
+msgid "A short explanation of your theme's basic functionality that is displayed in search and browse listings, as well as at the top of your theme's details page."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/personas/edit.html:122 src/olympia/devhub/templates/devhub/personas/submit.html:68
@@ -6444,7 +6328,7 @@ msgid "Upon upload and form submission, the AMO Team will review your updated de
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/personas/edit.html:241
-msgid "Your previously resubmitted design,  which is under pending review."
+msgid "Your previously resubmitted design, which is under pending review."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/personas/edit.html:245
@@ -6511,14 +6395,6 @@ msgstr ""
 
 #: src/olympia/devhub/templates/devhub/personas/submit.html:33
 msgid "Give your Theme a name."
-msgstr ""
-
-#: src/olympia/devhub/templates/devhub/personas/submit.html:54
-msgid ""
-"A short explanation of your theme's\n"
-"                                      basic functionality that is displayed in\n"
-"                                      search and browse listings, as well as at\n"
-"                                      the top of your theme's details page."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/personas/submit.html:198
@@ -6595,30 +6471,16 @@ msgstr ""
 msgid "Files added to reviewed versions must be reviewed before they will be available for download."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/add_file_modal.html:15
-#, python-format
-msgid ""
-"Submission of updates to unlisted add-ons for signing is currently in an open beta. Manual review may still be required for a large number of add-ons. Please <a href=\"%(url)s\" target=\"_blank"
-"\">report any bugs</a> that you encounter."
-msgstr ""
-
-#: src/olympia/devhub/templates/devhub/versions/add_file_modal.html:35
+#: src/olympia/devhub/templates/devhub/versions/add_file_modal.html:24
 msgid "Select the target platform for this file."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/add_file_modal.html:46
+#: src/olympia/devhub/templates/devhub/versions/add_file_modal.html:35
 msgid "Which review type would you like to nominate for?"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/add_file_modal.html:51
+#: src/olympia/devhub/templates/devhub/versions/add_file_modal.html:40
 msgid "Only publish this version to my beta channel."
-msgstr ""
-
-#: src/olympia/devhub/templates/devhub/versions/add_file_modal.html:54
-#, python-format
-msgid ""
-"The behavior of the beta channel has changed to accommodate <a href=\"%(addon_signing_url)s\" target=\"_blank\">mandatory add-on signing</a>. The new process is currently in an open beta, and may "
-"change significantly in the near future. Please <a href=\"%(issues_url)s\" target=\"_blank\">report any bugs</a> that you encounter."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/versions/edit.html:5
@@ -6642,19 +6504,10 @@ msgstr ""
 msgid "Upload Another File"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/edit.html:45
-msgid ""
-"Adjusting application information here will allow users to install your\n"
-"                          add-on even if the install manifest in the package indicates that the\n"
-"                          add-on is incompatible."
-msgstr ""
-
 #: src/olympia/devhub/templates/devhub/versions/edit.html:74
 msgid ""
-"Information about changes in this release, new features,\n"
-"                              known bugs, and other useful information specific to this\n"
-"                              release/version. This information is also shown in the\n"
-"                              Add-ons Manager when updating."
+"Information about changes in this release, new features, known bugs, and other useful information specific to this release/version. This information is also shown in the Add-ons Manager when "
+"updating."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/versions/edit.html:99
@@ -6666,10 +6519,7 @@ msgid "Notes for Reviewers"
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/versions/edit.html:114
-msgid ""
-"Optionally, enter any information that may be useful\n"
-"                              to the Editor reviewing this add-on, such as test\n"
-"                              account information."
+msgid "Optionally, enter any information that may be useful to the Editor reviewing this add-on, such as test account information."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/versions/edit.html:127
@@ -6747,7 +6597,7 @@ msgstr ""
 msgid "Request Preliminary Review"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:80 src/olympia/devhub/templates/devhub/versions/list.html:327 src/olympia/devhub/templates/devhub/versions/list.html:350
+#: src/olympia/devhub/templates/devhub/versions/list.html:80 src/olympia/devhub/templates/devhub/versions/list.html:325 src/olympia/devhub/templates/devhub/versions/list.html:348
 msgid "Cancel Review Request"
 msgstr ""
 
@@ -6776,7 +6626,7 @@ msgid "Unlisted:"
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/versions/list.html:114
-msgid "Not distributed on {0}. Developers will upload new versions for signing and distribute the add-ons on their own. (beta)"
+msgid "Not distributed on {0}. Developers will upload new versions for signing and distribute the add-ons on their own."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/versions/list.html:122
@@ -6839,81 +6689,73 @@ msgid "<strong>Important:</strong> Once a version has been deleted, you may not 
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/versions/list.html:230
-msgid ""
-"Deleting a version which has already been reviewed\n"
-"               may also cause a significant delay in the review of\n"
-"               your next update."
-msgstr ""
-
-#: src/olympia/devhub/templates/devhub/versions/list.html:233
 msgid "Are you sure you wish to delete this version?"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:238
+#: src/olympia/devhub/templates/devhub/versions/list.html:235
 msgid "Delete Version"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:240
+#: src/olympia/devhub/templates/devhub/versions/list.html:237
 msgid "Disable Version"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:247
+#: src/olympia/devhub/templates/devhub/versions/list.html:244
 msgid "Add a new Version"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:249
+#: src/olympia/devhub/templates/devhub/versions/list.html:246
 msgid "Add Version"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:256 src/olympia/devhub/templates/devhub/versions/list.html:274
+#: src/olympia/devhub/templates/devhub/versions/list.html:253 src/olympia/devhub/templates/devhub/versions/list.html:279
 msgid "Hide Add-on"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:259
+#: src/olympia/devhub/templates/devhub/versions/list.html:256
 msgid "Hiding your add-on will prevent it from appearing anywhere in our gallery and will stop users from receiving automatic updates."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:265
+#: src/olympia/devhub/templates/devhub/versions/list.html:263
+msgid "The files awaiting review will be disabled and you will need to upload new versions."
+msgstr ""
+
+#: src/olympia/devhub/templates/devhub/versions/list.html:270
 msgid "Are you sure you wish to hide your add-on?"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:286 src/olympia/devhub/templates/devhub/versions/list.html:315
+#: src/olympia/devhub/templates/devhub/versions/list.html:291 src/olympia/devhub/templates/devhub/versions/list.html:313
 msgid "Unlist Add-on"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:289
+#: src/olympia/devhub/templates/devhub/versions/list.html:294
 #, python-format
 msgid ""
 "Unlisting your add-on will make it (and each of its versions/files) invisible on this website. It won't show up in searches, won't have a public facing page, and won't be updated automatically for "
-"current users.  It is recommended for unlisted add-ons to provide a custom <a href=\"%(update_url)s\" target=\"_blank\">updateURL</a> in their manifest file for automatic updates."
+"current users. It is recommended for unlisted add-ons to provide a custom <a href=\"%(update_url)s\" target=\"_blank\">updateURL</a> in their manifest file for automatic updates."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:299
-#, python-format
-msgid "Switching add-ons to unlisted is currently in an open beta. Please <a href=\"%(url)s\" target=\"_blank\">report any bugs</a> that you encounter."
-msgstr ""
-
-#: src/olympia/devhub/templates/devhub/versions/list.html:305
+#: src/olympia/devhub/templates/devhub/versions/list.html:303
 msgid "Unlisting an add-on is irreversible!"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:305
+#: src/olympia/devhub/templates/devhub/versions/list.html:303
 msgid "An unlisted add-on cannot be switched to be listed."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:307
+#: src/olympia/devhub/templates/devhub/versions/list.html:305
 msgid "Are you sure you wish to unlist your add-on?"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:330
+#: src/olympia/devhub/templates/devhub/versions/list.html:328
 msgid "Canceling your review request will leave your add-on as preliminarily reviewed."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:335
+#: src/olympia/devhub/templates/devhub/versions/list.html:333
 msgid "Canceling your review request will mark your add-on incomplete. If you do not complete your add-on after several days by re-requesting review, it will be deleted."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:343
+#: src/olympia/devhub/templates/devhub/versions/list.html:341
 msgid "Are you sure you wish to cancel your review request?"
 msgstr ""
 
@@ -7252,19 +7094,19 @@ msgstr ""
 msgid "Search by add-on name / author email"
 msgstr ""
 
-#: src/olympia/editors/forms.py:103
+#: src/olympia/editors/forms.py:103 src/olympia/editors/forms.py:244 src/olympia/editors/forms.py:257
 msgid "yes"
 msgstr ""
 
-#: src/olympia/editors/forms.py:104
+#: src/olympia/editors/forms.py:104 src/olympia/editors/forms.py:244 src/olympia/editors/forms.py:257
 msgid "no"
 msgstr ""
 
-#: src/olympia/editors/forms.py:105
+#: src/olympia/editors/forms.py:105 src/olympia/editors/forms.py:245
 msgid "Admin Flag"
 msgstr ""
 
-#: src/olympia/editors/forms.py:113
+#: src/olympia/editors/forms.py:113 src/olympia/editors/forms.py:253
 msgid "Max. Version"
 msgstr ""
 
@@ -7276,55 +7118,59 @@ msgstr ""
 msgid "Add-on Types"
 msgstr ""
 
-#: src/olympia/editors/forms.py:126 src/olympia/editors/helpers.py:267
+#: src/olympia/editors/forms.py:126 src/olympia/editors/helpers.py:279
 msgid "Platforms"
 msgstr ""
 
+#: src/olympia/editors/forms.py:237
+msgid "Search by add-on name / author email / guid"
+msgstr ""
+
 #. L10n: 0 = platform, 1 = filename, 2 = status message
-#: src/olympia/editors/forms.py:238
+#: src/olympia/editors/forms.py:342
 #, python-format
 msgid "<strong>%s</strong> &middot; %s &middot; %s"
 msgstr ""
 
-#: src/olympia/editors/forms.py:252
+#: src/olympia/editors/forms.py:356
 msgid "Comments:"
 msgstr ""
 
-#: src/olympia/editors/forms.py:256
+#: src/olympia/editors/forms.py:360
 msgid "Operating systems:"
 msgstr ""
 
-#: src/olympia/editors/forms.py:258
+#: src/olympia/editors/forms.py:362
 msgid "Applications:"
 msgstr ""
 
-#: src/olympia/editors/forms.py:260
+#: src/olympia/editors/forms.py:364
 msgid "Notify me the next time this add-on is updated. (Subsequent updates will not generate an email)"
 msgstr ""
 
-#: src/olympia/editors/forms.py:265
+#: src/olympia/editors/forms.py:369
 msgid "Clear Admin Review Flag"
 msgstr ""
 
-#: src/olympia/editors/forms.py:267
+#: src/olympia/editors/forms.py:371
 msgid "Clear more info requested flag"
 msgstr ""
 
-#: src/olympia/editors/forms.py:281
+#: src/olympia/editors/forms.py:385
 msgid "Choose a canned response..."
 msgstr ""
 
 #. L10n: Description of what can be searched for.
-#: src/olympia/editors/forms.py:324
+#: src/olympia/editors/forms.py:423
 msgid "theme name"
 msgstr ""
 
-#: src/olympia/editors/forms.py:350
+#: src/olympia/editors/forms.py:449
 msgid "Someone else is reviewing this theme."
 msgstr ""
 
 #. L10n: Description of what can be searched for.
-#: src/olympia/editors/forms.py:447
+#: src/olympia/editors/forms.py:546
 msgid "app, reviewer, or comment"
 msgstr ""
 
@@ -7340,246 +7186,264 @@ msgstr ""
 msgid "Rejected or Unreviewed"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:123 src/olympia/editors/helpers.py:136
+#: src/olympia/editors/helpers.py:125 src/olympia/editors/helpers.py:138
 msgid "Queue"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:124 src/olympia/editors/templates/editors/base.html:50 src/olympia/editors/templates/editors/base.html:65
+#: src/olympia/editors/helpers.py:126 src/olympia/editors/templates/editors/base.html:50 src/olympia/editors/templates/editors/base.html:65
 msgid "Pending Updates"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:125 src/olympia/editors/templates/editors/base.html:48 src/olympia/editors/templates/editors/base.html:63
+#: src/olympia/editors/helpers.py:127 src/olympia/editors/templates/editors/base.html:48 src/olympia/editors/templates/editors/base.html:63
 msgid "Full Reviews"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:126 src/olympia/editors/templates/editors/base.html:52 src/olympia/editors/templates/editors/base.html:67
+#: src/olympia/editors/helpers.py:128 src/olympia/editors/templates/editors/base.html:52 src/olympia/editors/templates/editors/base.html:67
 msgid "Preliminary Reviews"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:127 src/olympia/editors/templates/editors/base.html:54
+#: src/olympia/editors/helpers.py:129 src/olympia/editors/templates/editors/base.html:54
 msgid "Moderated Reviews"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:128 src/olympia/editors/templates/editors/base.html:46
+#: src/olympia/editors/helpers.py:130 src/olympia/editors/templates/editors/base.html:46
 msgid "Fast Track"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:130
+#: src/olympia/editors/helpers.py:132
 msgid "Pending Themes"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:131 src/olympia/editors/templates/editors/themes/queue.html:4
+#: src/olympia/editors/helpers.py:133 src/olympia/editors/templates/editors/themes/queue.html:4
 msgid "Flagged Themes"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:132
+#: src/olympia/editors/helpers.py:134
 msgid "Update Themes"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:137
+#: src/olympia/editors/helpers.py:139
 msgid "Unlisted Pending Updates"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:138
+#: src/olympia/editors/helpers.py:140
 msgid "Unlisted Full Reviews"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:139
+#: src/olympia/editors/helpers.py:141
 msgid "Unlisted Preliminary Reviews"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:170
+#: src/olympia/editors/helpers.py:142
+msgid "Unlisted All Add-ons"
+msgstr ""
+
+#: src/olympia/editors/helpers.py:173
 msgid "Fast Track ({0})"
 msgid_plural "Fast Track ({0})"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/olympia/editors/helpers.py:175
+#: src/olympia/editors/helpers.py:178
 msgid "Full Review ({0})"
 msgid_plural "Full Reviews ({0})"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/olympia/editors/helpers.py:180
+#: src/olympia/editors/helpers.py:183
 msgid "Pending Update ({0})"
 msgid_plural "Pending Updates ({0})"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/olympia/editors/helpers.py:185
+#: src/olympia/editors/helpers.py:188
 msgid "Preliminary Review ({0})"
 msgid_plural "Preliminary Reviews ({0})"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/olympia/editors/helpers.py:190
+#: src/olympia/editors/helpers.py:193
 msgid "Moderated Review ({0})"
 msgid_plural "Moderated Reviews ({0})"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/olympia/editors/helpers.py:196
+#: src/olympia/editors/helpers.py:199
 msgid "Unlisted Full Review ({0})"
 msgid_plural "Unlisted Full Reviews ({0})"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/olympia/editors/helpers.py:201
+#: src/olympia/editors/helpers.py:204
 msgid "Unlisted Pending Update ({0})"
 msgid_plural "Unlisted Pending Updates ({0})"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/olympia/editors/helpers.py:206
+#: src/olympia/editors/helpers.py:209
 msgid "Unlisted Preliminary Review ({0})"
 msgid_plural "Unlisted Preliminary Reviews ({0})"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/olympia/editors/helpers.py:261
-msgid "Addon"
-msgstr ""
+#: src/olympia/editors/helpers.py:214
+msgid "Unlisted All Add-ons ({0})"
+msgid_plural "Unlisted All Add-ons ({0})"
+msgstr[0] ""
+msgstr[1] ""
 
-#: src/olympia/editors/helpers.py:262
+#: src/olympia/editors/helpers.py:274
 msgid "Type"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:263
+#: src/olympia/editors/helpers.py:275
 msgid "Waiting Time"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:264 src/olympia/editors/templates/editors/review.html:285
+#: src/olympia/editors/helpers.py:276 src/olympia/editors/templates/editors/review.html:285
 msgid "Flags"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:265
+#: src/olympia/editors/helpers.py:277
 msgid "Applications"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:270
+#: src/olympia/editors/helpers.py:282
 msgid "Additional"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:285
+#: src/olympia/editors/helpers.py:302
 msgid "Site Specific"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:287
+#: src/olympia/editors/helpers.py:304
 msgid "Requires External Software"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:289
+#: src/olympia/editors/helpers.py:306
 msgid "Binary Components"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:313
+#: src/olympia/editors/helpers.py:339
 msgid "moments ago"
 msgstr ""
 
 #. L10n: first argument is number of minutes
-#: src/olympia/editors/helpers.py:316
+#: src/olympia/editors/helpers.py:342
 msgid "{0} minute"
 msgid_plural "{0} minutes"
 msgstr[0] ""
 msgstr[1] ""
 
 #. L10n: first argument is number of hours
-#: src/olympia/editors/helpers.py:320
+#: src/olympia/editors/helpers.py:346
 msgid "{0} hour"
 msgid_plural "{0} hours"
 msgstr[0] ""
 msgstr[1] ""
 
 #. L10n: first argument is number of days
-#: src/olympia/editors/helpers.py:324
+#: src/olympia/editors/helpers.py:350
 msgid "{0} day"
 msgid_plural "{0} days"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/olympia/editors/helpers.py:488
+#: src/olympia/editors/helpers.py:364
+msgid "Last Review"
+msgstr ""
+
+#: src/olympia/editors/helpers.py:366
+msgid "Last Update"
+msgstr ""
+
+#: src/olympia/editors/helpers.py:387
+msgid "No Reviews"
+msgstr ""
+
+#: src/olympia/editors/helpers.py:561
 msgid "Push to public"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:490
+#: src/olympia/editors/helpers.py:563
 msgid "Grant full review"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:505
+#: src/olympia/editors/helpers.py:578
 msgid "Request more information"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:508
+#: src/olympia/editors/helpers.py:581
 msgid "Request super-review"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:519
+#: src/olympia/editors/helpers.py:592
 msgid "Grant preliminary review"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:520
+#: src/olympia/editors/helpers.py:593
 msgid "This will mark the files as preliminarily reviewed."
 msgstr ""
 
-#: src/olympia/editors/helpers.py:522
+#: src/olympia/editors/helpers.py:595
 msgid "Use this form to request more information from the author. They will receive an email and be able to answer here. You will be notified by email when they reply."
 msgstr ""
 
-#: src/olympia/editors/helpers.py:526
+#: src/olympia/editors/helpers.py:599
 msgid ""
 "If you have concerns about this add-on's security, copyright issues, or other concerns that an administrator should look into, enter your comments in the area below. They will be sent to "
 "administrators, not the author."
 msgstr ""
 
-#: src/olympia/editors/helpers.py:532
+#: src/olympia/editors/helpers.py:605
 msgid "This will reject the add-on and remove it from the review queue."
 msgstr ""
 
-#: src/olympia/editors/helpers.py:534
-msgid "Make a comment on this version.  The author won't be able to see this."
+#: src/olympia/editors/helpers.py:607
+msgid "Make a comment on this version. The author won't be able to see this."
 msgstr ""
 
-#: src/olympia/editors/helpers.py:538
+#: src/olympia/editors/helpers.py:611
 msgid "This will reject the files and remove them from the review queue."
 msgstr ""
 
-#: src/olympia/editors/helpers.py:542
+#: src/olympia/editors/helpers.py:615
 msgid "This will mark the add-on as preliminarily reviewed. Future versions will undergo preliminary review."
 msgstr ""
 
-#: src/olympia/editors/helpers.py:547
+#: src/olympia/editors/helpers.py:620
 msgid "This will mark the files as preliminarily reviewed. Future versions will undergo preliminary review."
 msgstr ""
 
-#: src/olympia/editors/helpers.py:552
+#: src/olympia/editors/helpers.py:625
 msgid "Retain preliminary review"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:553
+#: src/olympia/editors/helpers.py:626
 msgid "This will retain the add-on as preliminarily reviewed. Future versions will undergo preliminary review."
 msgstr ""
 
-#: src/olympia/editors/helpers.py:558
+#: src/olympia/editors/helpers.py:631
 msgid "This will approve a sandboxed version of a public add-on to appear on the public side."
 msgstr ""
 
-#: src/olympia/editors/helpers.py:561
+#: src/olympia/editors/helpers.py:634
 msgid "This will reject a version of a public add-on and remove it from the queue."
 msgstr ""
 
-#: src/olympia/editors/helpers.py:564
+#: src/olympia/editors/helpers.py:637
 msgid "This will mark the add-on and its most recent version and files as public. Future versions will go into the sandbox until they are reviewed by an editor."
 msgstr ""
 
-#: src/olympia/editors/helpers.py:637
+#: src/olympia/editors/helpers.py:714
 msgid "add-on"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:940 src/olympia/editors/helpers.py:960
+#: src/olympia/editors/helpers.py:1020 src/olympia/editors/helpers.py:1040
 msgid "Flagged"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:944 src/olympia/editors/helpers.py:963
+#: src/olympia/editors/helpers.py:1024 src/olympia/editors/helpers.py:1043
 msgid "Updates"
 msgstr ""
 
@@ -7631,56 +7495,56 @@ msgstr ""
 msgid "A question about your Theme submission"
 msgstr ""
 
-#: src/olympia/editors/views.py:144
+#: src/olympia/editors/views.py:146
 msgid "New Add-ons (Under 5 days)"
 msgstr ""
 
-#: src/olympia/editors/views.py:145
+#: src/olympia/editors/views.py:147
 msgid "Passable (5 to 10 days)"
 msgstr ""
 
-#: src/olympia/editors/views.py:146
+#: src/olympia/editors/views.py:148
 msgid "Overdue (Over 10 days)"
 msgstr ""
 
-#: src/olympia/editors/views.py:532
+#: src/olympia/editors/views.py:539
 msgid "An unknown error occurred"
 msgstr ""
 
-#: src/olympia/editors/views.py:587
+#: src/olympia/editors/views.py:592
 msgid "Self-reviews are not allowed."
 msgstr ""
 
-#: src/olympia/editors/views.py:609
+#: src/olympia/editors/views.py:613
 msgid "Review successfully processed."
 msgstr ""
 
-#: src/olympia/editors/views.py:807
+#: src/olympia/editors/views.py:812
 msgid "was approved"
 msgstr ""
 
-#: src/olympia/editors/views.py:808
+#: src/olympia/editors/views.py:813
 msgid "given preliminary review"
 msgstr ""
 
-#: src/olympia/editors/views.py:809
+#: src/olympia/editors/views.py:814
 msgid "rejected"
 msgstr ""
 
-#: src/olympia/editors/views.py:810
+#: src/olympia/editors/views.py:815
 msgctxt "editors_review_history_nominated_adminreview"
 msgid "escalated"
 msgstr ""
 
-#: src/olympia/editors/views.py:812
+#: src/olympia/editors/views.py:817
 msgid "needs more information"
 msgstr ""
 
-#: src/olympia/editors/views.py:813
+#: src/olympia/editors/views.py:818
 msgid "needs super review"
 msgstr ""
 
-#: src/olympia/editors/views.py:814
+#: src/olympia/editors/views.py:819
 msgid "commented"
 msgstr ""
 
@@ -7725,28 +7589,28 @@ msgstr ""
 msgid "Unlisted Queues"
 msgstr ""
 
-#: src/olympia/editors/templates/editors/base.html:72 src/olympia/editors/templates/editors/performance.html:6
+#: src/olympia/editors/templates/editors/base.html:74 src/olympia/editors/templates/editors/performance.html:6
 msgid "Performance"
 msgstr ""
 
-#: src/olympia/editors/templates/editors/base.html:75 src/olympia/editors/templates/editors/themes/base.html:19 src/olympia/editors/templates/editors/themes/base.html:38
+#: src/olympia/editors/templates/editors/base.html:77 src/olympia/editors/templates/editors/themes/base.html:19 src/olympia/editors/templates/editors/themes/base.html:38
 msgid "Logs"
 msgstr ""
 
-#: src/olympia/editors/templates/editors/base.html:78 src/olympia/editors/templates/editors/reviewlog.html:4 src/olympia/editors/templates/editors/reviewlog.html:27
+#: src/olympia/editors/templates/editors/base.html:80 src/olympia/editors/templates/editors/reviewlog.html:4 src/olympia/editors/templates/editors/reviewlog.html:27
 msgid "Add-on Review Log"
 msgstr ""
 
-#: src/olympia/editors/templates/editors/base.html:80 src/olympia/editors/templates/editors/eventlog.html:4 src/olympia/editors/templates/editors/eventlog.html:8
+#: src/olympia/editors/templates/editors/base.html:82 src/olympia/editors/templates/editors/eventlog.html:4 src/olympia/editors/templates/editors/eventlog.html:8
 #: src/olympia/editors/templates/editors/eventlog_detail.html:4
 msgid "Moderated Review Log"
 msgstr ""
 
-#: src/olympia/editors/templates/editors/base.html:82 src/olympia/editors/templates/editors/beta_signed_log.html:4 src/olympia/editors/templates/editors/beta_signed_log.html:8
+#: src/olympia/editors/templates/editors/base.html:84 src/olympia/editors/templates/editors/beta_signed_log.html:4 src/olympia/editors/templates/editors/beta_signed_log.html:8
 msgid "Signed Beta Files Log"
 msgstr ""
 
-#: src/olympia/editors/templates/editors/base.html:87 src/olympia/editors/templates/editors/includes/daily-message.html:4
+#: src/olympia/editors/templates/editors/base.html:89 src/olympia/editors/templates/editors/includes/daily-message.html:4
 msgid "Announcement"
 msgstr ""
 
@@ -7967,45 +7831,45 @@ msgstr ""
 msgid "clear search"
 msgstr ""
 
-#: src/olympia/editors/templates/editors/queue.html:72 src/olympia/editors/templates/editors/queue.html:122
+#: src/olympia/editors/templates/editors/queue.html:78 src/olympia/editors/templates/editors/queue.html:128
 msgid "Process Reviews"
 msgstr ""
 
-#: src/olympia/editors/templates/editors/queue.html:80
+#: src/olympia/editors/templates/editors/queue.html:86
 msgid "Moderation actions:"
 msgstr ""
 
-#: src/olympia/editors/templates/editors/queue.html:90
+#: src/olympia/editors/templates/editors/queue.html:96
 #, python-format
 msgid "by %(user)s on %(date)s %(stars)s (%(locale)s)"
 msgstr ""
 
-#: src/olympia/editors/templates/editors/queue.html:106
+#: src/olympia/editors/templates/editors/queue.html:112
 #, python-format
 msgid "<strong>%(reason)s</strong> <span class=\"light\">Flagged by %(user)s on %(date)s</span>"
 msgstr ""
 
-#: src/olympia/editors/templates/editors/queue.html:119
-msgid "All reviews have been moderated.  Good work!"
+#: src/olympia/editors/templates/editors/queue.html:125
+msgid "All reviews have been moderated. Good work!"
 msgstr ""
 
-#: src/olympia/editors/templates/editors/queue.html:161
+#: src/olympia/editors/templates/editors/queue.html:167
 msgid "Version Notes / Notes for Reviewer"
 msgstr ""
 
-#: src/olympia/editors/templates/editors/queue.html:169
+#: src/olympia/editors/templates/editors/queue.html:175
 msgid "There are currently no add-ons of this type to review."
 msgstr ""
 
-#: src/olympia/editors/templates/editors/queue.html:181 src/olympia/editors/templates/editors/themes/queue_list.html:85
+#: src/olympia/editors/templates/editors/queue.html:187 src/olympia/editors/templates/editors/themes/queue_list.html:85
 msgid "Helpful Links:"
 msgstr ""
 
-#: src/olympia/editors/templates/editors/queue.html:182
+#: src/olympia/editors/templates/editors/queue.html:188
 msgid "Add-on Policy"
 msgstr ""
 
-#: src/olympia/editors/templates/editors/queue.html:184
+#: src/olympia/editors/templates/editors/queue.html:190
 msgid "Editors' Guide"
 msgstr ""
 
@@ -8068,10 +7932,7 @@ msgid "<strong>Warning!</strong> Another user was viewing this page before you."
 msgstr ""
 
 #: src/olympia/editors/templates/editors/review.html:237
-msgid ""
-"The whiteboard is the place to exchange information relevant to\n"
-"               this addon (whatever the version), between the developer and the\n"
-"               editor. This is visible and editable by both."
+msgid "The whiteboard is the place to exchange information relevant to this addon (whatever the version), between the developer and the editor. This is visible and editable by both."
 msgstr ""
 
 #: src/olympia/editors/templates/editors/review.html:241
@@ -8345,7 +8206,7 @@ msgstr ""
 msgid "Describe your reason for flagging"
 msgstr ""
 
-#: src/olympia/files/forms.py:88
+#: src/olympia/files/forms.py:90
 msgid "Cannot diff a version against itself"
 msgstr ""
 
@@ -8380,51 +8241,51 @@ msgstr ""
 msgid "There was an error accessing file %s."
 msgstr ""
 
-#: src/olympia/files/utils.py:343
+#: src/olympia/files/utils.py:340
 msgid "Could not parse uploaded file."
 msgstr ""
 
-#: src/olympia/files/utils.py:380
+#: src/olympia/files/utils.py:377
 msgid "Invalid file name in archive: {0}"
 msgstr ""
 
-#: src/olympia/files/utils.py:388
+#: src/olympia/files/utils.py:385
 msgid "File exceeding size limit in archive: {0}"
 msgstr ""
 
-#: src/olympia/files/utils.py:439
+#: src/olympia/files/utils.py:436
 msgid "Invalid archive."
 msgstr ""
 
-#: src/olympia/files/utils.py:529 src/olympia/files/utils.py:532
+#: src/olympia/files/utils.py:526 src/olympia/files/utils.py:529
 msgid "Could not parse the manifest file."
 msgstr ""
 
-#: src/olympia/files/utils.py:551
+#: src/olympia/files/utils.py:548
 msgid "Could not find an add-on ID."
 msgstr ""
 
-#: src/olympia/files/utils.py:554
+#: src/olympia/files/utils.py:551
 msgid "Add-on ID must be 64 characters or less."
 msgstr ""
 
-#: src/olympia/files/utils.py:556
+#: src/olympia/files/utils.py:553
 msgid "Add-on ID doesn't match add-on."
 msgstr ""
 
-#: src/olympia/files/utils.py:564
+#: src/olympia/files/utils.py:561
 msgid "Duplicate add-on ID found."
 msgstr ""
 
-#: src/olympia/files/utils.py:567
+#: src/olympia/files/utils.py:564
 msgid "Version numbers should have fewer than 32 characters."
 msgstr ""
 
-#: src/olympia/files/utils.py:570
+#: src/olympia/files/utils.py:567
 msgid "Version numbers should only contain letters, numbers, and these punctuation characters: +*.-_."
 msgstr ""
 
-#: src/olympia/files/utils.py:587
+#: src/olympia/files/utils.py:584
 msgid "<em:type> doesn't match add-on"
 msgstr ""
 
@@ -8523,6 +8384,10 @@ msgstr ""
 
 #: src/olympia/files/templates/files/viewer.html:134
 msgid "Fetching file."
+msgstr ""
+
+#: src/olympia/legacy_api/views.py:255
+msgid "Not implemented yet."
 msgstr ""
 
 #: src/olympia/lib/constants.py:6
@@ -9181,10 +9046,6 @@ msgstr ""
 msgid "Zimbabwe Dollar"
 msgstr ""
 
-#: src/olympia/lib/video/ffmpeg.py:112 src/olympia/lib/video/totem.py:81
-msgid "Videos must be in WebM."
-msgstr ""
-
 #: src/olympia/pages/templates/pages/about.lhtml:3 src/olympia/pages/templates/pages/about.lhtml:10
 msgid "About Mozilla Add-ons"
 msgstr ""
@@ -9196,7 +9057,7 @@ msgstr ""
 #: src/olympia/pages/templates/pages/about.lhtml:13
 msgid ""
 "addons.mozilla.org, commonly known as \"AMO\", is Mozilla's official site for add-ons to Mozilla software, such as Firefox, Thunderbird, and SeaMonkey. Add-ons let you add new features and change "
-"the way your browser or application works.  Take a look around and explore the thousands of ways to customize the way you do things online."
+"the way your browser or application works. Take a look around and explore the thousands of ways to customize the way you do things online."
 msgstr ""
 
 #: src/olympia/pages/templates/pages/about.lhtml:19
@@ -9541,7 +9402,7 @@ msgstr ""
 msgid ""
 "Yes. It's possible, but some of the functionality provided by these libraries are available through XPCOM, XUL, and JavaScript. In addition, authors should take care if libraries modify primitive "
 "object prototypes (String.prototype, Date.prototype, etc.) and/or define global functions (eg. the $ function). These are prone to cause conflict with other add-ons, in particular if different add-"
-"ons use different versions of libraries and so on. Developers need to be very, very careful with using them.  Mozilla does not offer documentation on using them to build add-ons."
+"ons use different versions of libraries and so on. Developers need to be very, very careful with using them. Mozilla does not offer documentation on using them to build add-ons."
 msgstr ""
 
 #: src/olympia/pages/templates/pages/dev_faq.html:165
@@ -9655,8 +9516,8 @@ msgstr ""
 #, python-format
 msgid ""
 "Yes. Many developers choose to host their own add-ons. Choosing to host your add-on on <a href=\"%(amo_url)s\">Mozilla's add-on site</a>, though, allows for much greater exposure to your add-on due "
-"to the large volume of visitors to the site.  <a href=\"%(md_url)s\">mozdev.org</a> offers free project hosting for Mozilla applications and extensions providing developers with tools to help "
-"manage source code, version control, bug tracking and documentation."
+"to the large volume of visitors to the site. <a href=\"%(md_url)s\">mozdev.org</a> offers free project hosting for Mozilla applications and extensions providing developers with tools to help manage "
+"source code, version control, bug tracking and documentation."
 msgstr ""
 
 #: src/olympia/pages/templates/pages/dev_faq.html:277
@@ -9704,7 +9565,7 @@ msgstr ""
 #: src/olympia/pages/templates/pages/dev_faq.html:314
 #, python-format
 msgid ""
-"Yes. Mozilla's <a href=\"%(p_url)s\">Add-on Policy</a> describes what is an acceptable submission. This policy is subject to change without notice.  In addition, the AMO editorial team uses the <a "
+"Yes. Mozilla's <a href=\"%(p_url)s\">Add-on Policy</a> describes what is an acceptable submission. This policy is subject to change without notice. In addition, the AMO editorial team uses the <a "
 "href=\"%(g_url)s\">Editors Reviewing Guide</a> to ensure that your add-on meets specific guidelines for functionality and security."
 msgstr ""
 
@@ -9821,7 +9682,7 @@ msgstr ""
 #: src/olympia/pages/templates/pages/dev_faq.html:434
 #, python-format
 msgid ""
-"This is why it's very important to read the <a href=\"%(g_url)s\">Editors Reviewing Guide</a> to ensure that your add-on is setup as expected.  It's also a good idea to read the blog post, <a href="
+"This is why it's very important to read the <a href=\"%(g_url)s\">Editors Reviewing Guide</a> to ensure that your add-on is setup as expected. It's also a good idea to read the blog post, <a href="
 "\"%(blog_url)s\">Successfully Getting your Add-on Reviewed</a> which provides excellent insight into ensuring a smooth review of your add-on."
 msgstr ""
 
@@ -9928,7 +9789,7 @@ msgstr ""
 
 #: src/olympia/pages/templates/pages/dev_faq.html:572
 msgid ""
-"Free Software Foundation provides short summaries of the key open source licenses, including whether the license qualifies as a free software license or a copyleft license.  Also includes a "
+"Free Software Foundation provides short summaries of the key open source licenses, including whether the license qualifies as a free software license or a copyleft license. Also includes a "
 "discussion of what constitutes a free software license or a copyleft license (e.g., a Copyleft license is a general method for making a program or other work free, and requiring all modified and "
 "extended versions of the program to be free as well.)"
 msgstr ""
@@ -10106,19 +9967,13 @@ msgid "Add-on Gallery"
 msgstr ""
 
 #: src/olympia/pages/templates/pages/faq.html:171
-msgid ""
-"How do I choose between add-ons that seem to do the same\n"
-"    thing?"
+msgid "How do I choose between add-ons that seem to do the same thing?"
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:173
+#: src/olympia/pages/templates/pages/faq.html:172
 msgid ""
-"There are often several add-ons that have similar features. To\n"
-"    figure out which is right for you, read the entire description of the\n"
-"    add-on and view its screenshots. If there are still several in the running,\n"
-"    read through the add-on's ratings, user reviews, and statistics to see\n"
-"    which is most liked by other users. Remember that you can also just try\n"
-"    out both and see which you like better."
+"There are often several add-ons that have similar features. To figure out which is right for you, read the entire description of the add-on and view its screenshots. If there are still several in "
+"the running, read through the add-on's ratings, user reviews, and statistics to see which is most liked by other users. Remember that you can also just try out both and see which you like better."
 msgstr ""
 
 #: src/olympia/pages/templates/pages/faq.html:180
@@ -10159,80 +10014,67 @@ msgid "How much do add-ons cost to purchase?"
 msgstr ""
 
 #: src/olympia/pages/templates/pages/faq.html:207
-msgid ""
-"Add-ons hosted in our gallery are free unless clearly marked\n"
-"    otherwise."
+msgid "Add-ons hosted in our gallery are free unless clearly marked otherwise."
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:210
+#: src/olympia/pages/templates/pages/faq.html:209
 msgid "What does it mean when an add-on asks for contributions?"
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:211
+#: src/olympia/pages/templates/pages/faq.html:210
 msgid ""
-"Some add-on authors request users who enjoy an add-on to\n"
-"        contribute to its development by making a monetary contribution. These\n"
-"        contributions go directly to the developer unless a third party is\n"
-"        indicated, such as the non-profit Mozilla Foundation."
+"Some add-on authors request users who enjoy an add-on to contribute to its development by making a monetary contribution. These contributions go directly to the developer unless a third party is "
+"indicated, such as the non-profit Mozilla Foundation."
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:216
+#: src/olympia/pages/templates/pages/faq.html:215
 msgid "What are beta add-ons?"
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:218
+#: src/olympia/pages/templates/pages/faq.html:217
 msgid ""
-"Beta add-ons are unreviewed versions which represent the\n"
-"        latest work of an add-on author. While different authors have different\n"
-"        standards for beta code quality, you should assume that these add-ons\n"
-"        are less stable than the general add-on releases."
+"Beta add-ons are unreviewed versions which represent the latest work of an add-on author. While different authors have different standards for beta code quality, you should assume that these add-"
+"ons are less stable than the general add-on releases."
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:222
+#: src/olympia/pages/templates/pages/faq.html:221
 msgid ""
 "Please note that when you install an add-on from the \"Beta Version\" section of an add-on's listing, you will continue to receive updates for that add-on as they become available. Like the initial "
 "version you installed, all beta releases are unreviewed by Mozilla and may harm your computer."
 msgstr ""
 
+#: src/olympia/pages/templates/pages/faq.html:228
+msgid "What does it mean when an add-on is flagged as slow?"
+msgstr ""
+
 #: src/olympia/pages/templates/pages/faq.html:229
-msgid ""
-"What does it mean when an add-on is flagged as\n"
-"    slow?"
+msgid "Most add-ons load code and resources at the same time Firefox is starting up. In most cases the impact in start-up time is minimal, but some add-ons can cause a noticeable slowdown."
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:231
-msgid ""
-"Most add-ons load code and resources at the same time Firefox\n"
-"        is starting up. In most cases the impact in start-up time is minimal,\n"
-"        but some add-ons can cause a noticeable slowdown."
-msgstr ""
-
-#: src/olympia/pages/templates/pages/faq.html:236
+#: src/olympia/pages/templates/pages/faq.html:234
 msgid "How do I report an inappropriate or spam user review?"
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:237
+#: src/olympia/pages/templates/pages/faq.html:235
 msgid ""
-"To report a user review of an add-on, log in with your account\n"
-"    and visit the add-on's reviews page. Find the review you wish to report,\n"
-"    click \"Report this review\" and select a reason. Our editorial team will\n"
-"    investigate the review and take appropriate action."
+"To report a user review of an add-on, log in with your account and visit the add-on's reviews page. Find the review you wish to report, click \"Report this review\" and select a reason. Our "
+"editorial team will investigate the review and take appropriate action."
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:242
+#: src/olympia/pages/templates/pages/faq.html:240
 msgid "How do I report a bug or contact the Mozilla Add-ons team?"
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:243
+#: src/olympia/pages/templates/pages/faq.html:241
 #, python-format
 msgid "Please visit our <a href=\"%(contact_url)s\">Contact page</a>."
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:246
+#: src/olympia/pages/templates/pages/faq.html:244
 msgid "What is a Source Code License?"
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:247
+#: src/olympia/pages/templates/pages/faq.html:245
 #, python-format
 msgid ""
 "The source code used to create an add-on is an exclusive copyright of the add-on author, unless otherwise declared in a source code license. Many add-ons on this site have <a href=\"%(url)s\" lang="
@@ -10240,60 +10082,60 @@ msgid ""
 "the GPL or BSD licenses instead of making up their own."
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:256
+#: src/olympia/pages/templates/pages/faq.html:254
 #, python-format
 msgid "Firefox and other Mozilla software are <a href=\"%(url)s\">open source</a>."
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:264
+#: src/olympia/pages/templates/pages/faq.html:262
 msgid "Collections and Favorites"
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:267
+#: src/olympia/pages/templates/pages/faq.html:265
 msgid "What is a collection?"
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:268
+#: src/olympia/pages/templates/pages/faq.html:266
 msgid "Collections are groups of related add-ons created by users to share."
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:270
+#: src/olympia/pages/templates/pages/faq.html:268
 msgid "What is the My Favorites collection?"
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:271
+#: src/olympia/pages/templates/pages/faq.html:269
 msgid "Favorite add-ons are add-ons that you have bookmarked to easily get back to later. You can add an add-on to your favorites collection by clicking \"Add to favorites\" on its details page."
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:275 src/olympia/templates/menu_links.html:13 src/olympia/templates/impala/header_title.html:17
+#: src/olympia/pages/templates/pages/faq.html:273 src/olympia/templates/menu_links.html:13 src/olympia/templates/impala/header_title.html:17
 msgid "Mobile Add-ons"
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:278
+#: src/olympia/pages/templates/pages/faq.html:276
 msgid "What are mobile add-ons?"
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:279
+#: src/olympia/pages/templates/pages/faq.html:277
 #, python-format
 msgid ""
 "Mobile add-ons work with <a href=\"%(mobile_url)s\">Firefox for Mobile</a> and add or modify functionality just like desktop add-ons. You can find add-ons that work with Firefox for Mobile in our "
 "<a href=\"%(gallery_url)s\">gallery</a>."
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:288
+#: src/olympia/pages/templates/pages/faq.html:286
 msgid "Developer Topics"
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:289
+#: src/olympia/pages/templates/pages/faq.html:287
 #, python-format
 msgid "Please see our <a href=\"%(faq_url)s\">Developer FAQ</a> and <a href=\"%(hub_url)s\">Developer Hub</a> for answers to add-on developer-related questions."
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:294
+#: src/olympia/pages/templates/pages/faq.html:292
 msgid "Still have questions?"
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:295
+#: src/olympia/pages/templates/pages/faq.html:293
 #, python-format
 msgid "For general Firefox support, visit our <a href=\"%(sumo_url)s\">support website</a>. For general add-on and website questions, visit our <a href=\"%(forum_url)s\">forum</a>."
 msgstr ""
@@ -10431,7 +10273,7 @@ msgstr ""
 
 #: src/olympia/pages/templates/pages/sunbird.html:29
 msgid ""
-"Development on the Sunbird project has halted and its final release was on March 30, 2010.  We've been proud to host Sunbird add-ons on this site but as the project is no longer maintained we have "
+"Development on the Sunbird project has halted and its final release was on March 30, 2010. We've been proud to host Sunbird add-ons on this site but as the project is no longer maintained we have "
 "disabled our support for the add-ons."
 msgstr ""
 
@@ -10509,7 +10351,7 @@ msgstr ""
 #, python-format
 msgid ""
 "<h2>Keep these tips in mind:</h2> <ul> <li> Write like you're telling a friend about your experience with the add-on. Give specifics and helpful details, such as what features you liked and/or "
-"disliked, how easy to use it is, and any disadvantages it has.  Avoid generic language such as calling it \"Great\" or \"Bad\" unless you can give reasons why you believe this is so. </li> <li> "
+"disliked, how easy to use it is, and any disadvantages it has. Avoid generic language such as calling it \"Great\" or \"Bad\" unless you can give reasons why you believe this is so. </li> <li> "
 "Please do not post bug reports in reviews. We do not make your email address available to add-on developers and they may need to contact you to help resolve your issue. See the <a href=\"%(support)s"
 "\">support section</a> to find out where to get assistance for this add-on. </li> <li>Please keep reviews clean, avoid the use of improper language and do not post any personal information. </li> </"
 "ul> <p>Please read the <a href=\"%(guide)s\" target=\"_blank\">Review Guidelines</a> for more detail about user add-on reviews.</p>"
@@ -10745,16 +10587,16 @@ msgstr ""
 
 #. L10n: {0} is an application, such as Firefox. This means "any version of
 #. Firefox."
-#: src/olympia/search/views.py:554
+#: src/olympia/search/views.py:547
 msgid "Any {0}"
 msgstr ""
 
 #. L10n: "All Systems" means show everything regardless of platform.
-#: src/olympia/search/views.py:589
+#: src/olympia/search/views.py:582
 msgid "All Systems"
 msgstr ""
 
-#: src/olympia/search/views.py:600
+#: src/olympia/search/views.py:593
 msgid "All Tags"
 msgstr ""
 
@@ -10928,31 +10770,31 @@ msgstr ""
 msgid "Share this Collection"
 msgstr ""
 
-#: src/olympia/signing/views.py:30 src/olympia/templates/base.html:75 src/olympia/templates/impala/base.html:115
+#: src/olympia/signing/views.py:33 src/olympia/templates/base.html:71 src/olympia/templates/impala/base.html:112
 msgid "Some features are temporarily disabled while we perform website maintenance. We'll be back to full capacity shortly."
 msgstr ""
 
-#: src/olympia/signing/views.py:53
+#: src/olympia/signing/views.py:56
 msgid "Could not find add-on with id \"{}\"."
 msgstr ""
 
-#: src/olympia/signing/views.py:67
+#: src/olympia/signing/views.py:70
 msgid "You do not own this addon."
 msgstr ""
 
-#: src/olympia/signing/views.py:82
+#: src/olympia/signing/views.py:87
 msgid "Missing \"upload\" key in multipart file data."
 msgstr ""
 
-#: src/olympia/signing/views.py:96
+#: src/olympia/signing/views.py:101
 msgid "Version does not match the manifest file."
 msgstr ""
 
-#: src/olympia/signing/views.py:100
+#: src/olympia/signing/views.py:105
 msgid "Version already exists."
 msgstr ""
 
-#: src/olympia/signing/views.py:136
+#: src/olympia/signing/views.py:141
 msgid "No uploaded file for that addon and version."
 msgstr ""
 
@@ -11065,89 +10907,89 @@ msgstr ""
 msgid "Statistics Dashboard :: Add-ons for {0}"
 msgstr ""
 
-#: src/olympia/stats/templates/stats/stats.html:30
-msgid "Controls:"
-msgstr ""
-
-#: src/olympia/stats/templates/stats/stats.html:33
-msgid "reset zoom"
-msgstr ""
-
-#: src/olympia/stats/templates/stats/stats.html:40
-msgid "Group by:"
-msgstr ""
-
-#: src/olympia/stats/templates/stats/stats.html:42
-msgid "day"
-msgstr ""
-
-#: src/olympia/stats/templates/stats/stats.html:45
-msgid "week"
-msgstr ""
-
-#: src/olympia/stats/templates/stats/stats.html:48
-msgid "month"
-msgstr ""
-
-#: src/olympia/stats/templates/stats/stats.html:54
-msgid "For last:"
-msgstr ""
-
-#: src/olympia/stats/templates/stats/stats.html:57
-msgid "7 days"
-msgstr ""
-
-#: src/olympia/stats/templates/stats/stats.html:60
-msgid "30 days"
-msgstr ""
-
-#: src/olympia/stats/templates/stats/stats.html:63
-msgid "90 days"
-msgstr ""
-
-#: src/olympia/stats/templates/stats/stats.html:66
-msgid "365 days"
-msgstr ""
-
-#: src/olympia/stats/templates/stats/stats.html:69
-msgid "Custom..."
-msgstr ""
-
 #. {0} is an add-on name
-#: src/olympia/stats/templates/stats/stats.html:88 src/olympia/stats/templates/stats/stats.html:91
+#: src/olympia/stats/templates/stats/stats.html:44 src/olympia/stats/templates/stats/stats.html:47
 msgid "Statistics for {0}"
 msgstr ""
 
-#: src/olympia/stats/templates/stats/stats.html:94
+#: src/olympia/stats/templates/stats/stats.html:50
 msgid "Statistics Dashboard"
 msgstr ""
 
-#: src/olympia/stats/templates/stats/stats.html:104
+#: src/olympia/stats/templates/stats/stats.html:57
+msgid "Controls:"
+msgstr ""
+
+#: src/olympia/stats/templates/stats/stats.html:60
+msgid "reset zoom"
+msgstr ""
+
+#: src/olympia/stats/templates/stats/stats.html:67
+msgid "Group by:"
+msgstr ""
+
+#: src/olympia/stats/templates/stats/stats.html:69
+msgid "day"
+msgstr ""
+
+#: src/olympia/stats/templates/stats/stats.html:72
+msgid "week"
+msgstr ""
+
+#: src/olympia/stats/templates/stats/stats.html:75
+msgid "month"
+msgstr ""
+
+#: src/olympia/stats/templates/stats/stats.html:81
+msgid "For last:"
+msgstr ""
+
+#: src/olympia/stats/templates/stats/stats.html:84
+msgid "7 days"
+msgstr ""
+
+#: src/olympia/stats/templates/stats/stats.html:87
+msgid "30 days"
+msgstr ""
+
+#: src/olympia/stats/templates/stats/stats.html:90
+msgid "90 days"
+msgstr ""
+
+#: src/olympia/stats/templates/stats/stats.html:93
+msgid "365 days"
+msgstr ""
+
+#: src/olympia/stats/templates/stats/stats.html:96
+msgid "Custom..."
+msgstr ""
+
+#: src/olympia/stats/templates/stats/stats.html:106
 msgid "Statistics processing is currently disabled, so recent data is unavailable. The statistics are still being collected and this page will be updated soon with the missing data."
 msgstr ""
 
-#: src/olympia/stats/templates/stats/stats.html:110
+#: src/olympia/stats/templates/stats/stats.html:112
 msgid "Loading the latest data&hellip;"
 msgstr ""
 
-#: src/olympia/stats/templates/stats/stats.html:142 src/olympia/stats/templates/stats/reports/overview.html:25 src/olympia/stats/templates/stats/reports/overview.html:37
+#: src/olympia/stats/templates/stats/stats.html:144 src/olympia/stats/templates/stats/reports/overview.html:25 src/olympia/stats/templates/stats/reports/overview.html:37
 #: src/olympia/stats/templates/stats/reports/overview.html:49
 msgid "No data available."
 msgstr ""
 
-#: src/olympia/stats/templates/stats/stats.html:177
+#: src/olympia/stats/templates/stats/stats.html:179
 msgid "This dashboard is currently <b>public</b>."
 msgstr ""
 
-#: src/olympia/stats/templates/stats/stats.html:179
+#: src/olympia/stats/templates/stats/stats.html:181
 msgid "Contribution stats are currently <b>private</b>."
 msgstr ""
 
-#: src/olympia/stats/templates/stats/stats.html:182
+#: src/olympia/stats/templates/stats/stats.html:184
 msgid "This dashboard is currently <b>private</b>."
 msgstr ""
 
-#: src/olympia/stats/templates/stats/stats.html:185
+#: src/olympia/stats/templates/stats/stats.html:187
 msgid "Change settings."
 msgstr ""
 
@@ -11299,15 +11141,6 @@ msgstr ""
 msgid "Application versions by Date"
 msgstr ""
 
-#: src/olympia/tags/templates/tags/top_cloud.html:4
-msgid "Top {0} Tags"
-msgstr ""
-
-#. {0} is the current application name
-#: src/olympia/tags/templates/tags/top_cloud.html:14
-msgid "{0} Top Tags"
-msgstr ""
-
 #: src/olympia/templates/amo_footer.html:6 src/olympia/templates/includes/lang_switcher.html:2
 msgid "Other languages"
 msgstr ""
@@ -11316,11 +11149,11 @@ msgstr ""
 msgid "Mozilla Add-ons"
 msgstr ""
 
-#: src/olympia/templates/base.html:91 src/olympia/templates/impala/base.html:81
+#: src/olympia/templates/base.html:89 src/olympia/templates/impala/base.html:78
 msgid "Find add-ons for other applications"
 msgstr ""
 
-#: src/olympia/templates/base.html:92 src/olympia/templates/impala/base.html:81
+#: src/olympia/templates/base.html:90 src/olympia/templates/impala/base.html:78
 msgid "Other Applications"
 msgstr ""
 
@@ -11345,7 +11178,7 @@ msgid "View Mobile Site"
 msgstr ""
 
 #: src/olympia/templates/copyright.html:7
-msgid "Site Status "
+msgid "Site Status"
 msgstr ""
 
 #: src/olympia/templates/footer.html:3
@@ -11445,35 +11278,35 @@ msgstr ""
 msgid "<a href=\"%(reg)s\">Register</a> or <a href=\"%(login)s\">Log in</a>"
 msgstr ""
 
-#: src/olympia/templates/impala/base.html:126
+#: src/olympia/templates/impala/base.html:123
 #, python-format
 msgid "To try the thousands of add-ons available here, download <a href=\"%(url)s\">Mozilla Firefox</a>, a fast, free way to surf the Web!"
 msgstr ""
 
-#: src/olympia/templates/impala/base.html:138
+#: src/olympia/templates/impala/base.html:135
 #, python-format
 msgid "Add-ons is switching to Firefox Accounts for login. <a href=\"%(url)s\" class=\"fxa-login\">Sign in now to transfer your account.</a>"
 msgstr ""
 
 #. {0} is an application, such as Firefox.
-#: src/olympia/templates/impala/base.html:148
+#: src/olympia/templates/impala/base.html:145
 msgid "Welcome to {0} Add-ons."
 msgstr ""
 
-#: src/olympia/templates/impala/base.html:151
+#: src/olympia/templates/impala/base.html:148
 msgid "Choose from thousands of extra features and styles to make Firefox your own."
 msgstr ""
 
-#: src/olympia/templates/impala/base.html:156
+#: src/olympia/templates/impala/base.html:153
 #, python-format
 msgid "Add extra features and styles to make %(app)s your own."
 msgstr ""
 
-#: src/olympia/templates/impala/base.html:164
+#: src/olympia/templates/impala/base.html:161
 msgid "On the go?"
 msgstr ""
 
-#: src/olympia/templates/impala/base.html:166
+#: src/olympia/templates/impala/base.html:163
 msgid "Check out our <a class=\"mobile-link\" href=\"#\">Mobile Add-ons site</a>."
 msgstr ""
 
@@ -11697,19 +11530,19 @@ msgstr ""
 
 #. L10n: {id} will be something like "13ad6a", just a random number
 #. to differentiate this user from other anonymous users.
-#: src/olympia/users/models.py:353
+#: src/olympia/users/models.py:362
 msgid "Anonymous user {id}"
 msgstr ""
 
-#: src/olympia/users/models.py:410
+#: src/olympia/users/models.py:419
 msgid "Your account has been restricted"
 msgstr ""
 
-#: src/olympia/users/models.py:480
+#: src/olympia/users/models.py:489
 msgid "Please confirm your email address"
 msgstr ""
 
-#: src/olympia/users/models.py:506
+#: src/olympia/users/models.py:515
 msgid "My Mobile Add-ons"
 msgstr ""
 
@@ -11986,7 +11819,7 @@ msgstr ""
 
 #: src/olympia/users/templates/users/edit.html:70
 #, python-format
-msgid "Change your password.  If you forgot your password, you can <a href=\"%(reset_url)s\">use the reset form</a>."
+msgid "Change your password. If you forgot your password, you can <a href=\"%(reset_url)s\">use the reset form</a>."
 msgstr ""
 
 #: src/olympia/users/templates/users/edit.html:76
@@ -12006,7 +11839,7 @@ msgid "Profile"
 msgstr ""
 
 #: src/olympia/users/templates/users/edit.html:100
-msgid "Give us a bit more information about yourself.  All these fields are optional, but they'll help other users get to know you better."
+msgid "Give us a bit more information about yourself. All these fields are optional, but they'll help other users get to know you better."
 msgstr ""
 
 #: src/olympia/users/templates/users/edit.html:124
@@ -12222,7 +12055,7 @@ msgid "Confirm password"
 msgstr ""
 
 #: src/olympia/users/templates/users/pwreset_confirm.html:47
-msgid "The password reset link was invalid, possibly because it has already been used.  Please request a new password reset."
+msgid "The password reset link was invalid, possibly because it has already been used. Please request a new password reset."
 msgstr ""
 
 #: src/olympia/users/templates/users/pwreset_request.html:15
@@ -12408,7 +12241,7 @@ msgstr ""
 
 #: src/olympia/users/templates/users/unsubscribe.html:30
 #, python-format
-msgid "Unfortunately, we weren't able to unsubscribe you.  The link you clicked is invalid. However, you can unsubscribe still unsubscribe on your <a href=\"%(edit_url)s\">edit profile page</a>."
+msgid "Unfortunately, we weren't able to unsubscribe you. The link you clicked is invalid. However, you can unsubscribe still unsubscribe on your <a href=\"%(edit_url)s\">edit profile page</a>."
 msgstr ""
 
 #: src/olympia/users/templates/users/vcard.html:2
@@ -12462,15 +12295,15 @@ msgstr ""
 msgid "Version History with Changelogs"
 msgstr ""
 
-#: src/olympia/versions/models.py:314
+#: src/olympia/versions/models.py:313
 msgid "Add-on uses binary components."
 msgstr ""
 
-#: src/olympia/versions/models.py:317
+#: src/olympia/versions/models.py:316
 msgid "Add-on has opted into strict compatibility checking."
 msgstr ""
 
-#: src/olympia/versions/models.py:715
+#: src/olympia/versions/models.py:711
 msgid "{app} {min} and later"
 msgstr ""
 
@@ -12545,4 +12378,8 @@ msgstr ""
 
 #: src/olympia/zadmin/forms.py:105
 msgid "Log emails instead of sending"
+msgstr ""
+
+#: src/olympia/zadmin/forms.py:215
+msgid "Deleted versions can`t be changed."
 msgstr ""

--- a/locale/gu/LC_MESSAGES/djangojs.po
+++ b/locale/gu/LC_MESSAGES/djangojs.po
@@ -1,1216 +1,1236 @@
-
 #, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2016-02-24 21:23+0000\n"
+"POT-Creation-Date: 2016-04-18 15:47+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
+"Language: \n"
 "MIME-Version: 1.0\n"
-"Content-Type: text/plain; charset=utf-8\n"
+"Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Generated-By: Babel 2.2.0\n"
 
-#: static/js/common/ratingwidget.js:31
+#: static/js/common-all.js:1426 static/js/impala-all.js:1511 static/js/zamboni/discovery-all.js:12598 static/js/zamboni/init.js:28 static/js/zamboni/mobile-all.js:14945
+msgid "This feature is temporarily disabled while we perform website maintenance. Please check back a little later."
+msgstr ""
+
+#. L10n: {0} is an app name like Firefox.
+#: static/js/common-all.js:1837 static/js/impala-all.js:1922 static/js/zamboni/buttons.js:73 static/js/zamboni/discovery-all.js:13108
+msgid "Accept and Install"
+msgstr ""
+
+#: static/js/common-all.js:1837 static/js/impala-all.js:1922 static/js/zamboni/buttons.js:73 static/js/zamboni/discovery-all.js:13108
+msgid "Add to {0}"
+msgstr ""
+
+#: static/js/common-all.js:1842 static/js/impala-all.js:1927 static/js/zamboni/buttons.js:78 static/js/zamboni/discovery-all.js:13113
+msgid "Download Now"
+msgstr ""
+
+#: static/js/common-all.js:1883 static/js/impala-all.js:1968 static/js/zamboni/buttons.js:119 static/js/zamboni/discovery-all.js:13154
+msgid "Add-on has not been updated to support default-to-compatible."
+msgstr ""
+
+#: static/js/common-all.js:1888 static/js/impala-all.js:1973 static/js/zamboni/buttons.js:124 static/js/zamboni/discovery-all.js:13159
+msgid "You need to be using Firefox 10.0 or higher."
+msgstr ""
+
+#: static/js/common-all.js:1900 static/js/impala-all.js:1985 static/js/zamboni/buttons.js:136 static/js/zamboni/discovery-all.js:13171
+msgid "Mozilla has marked this version as incompatible with your Firefox version."
+msgstr ""
+
+#. L10n: {0} is an platform like Windows or Linux.
+#: static/js/common-all.js:1981 static/js/impala-all.js:2066 static/js/zamboni/buttons.js:217 static/js/zamboni/discovery-all.js:13252
+msgid "Install for {0} anyway"
+msgstr ""
+
+#: static/js/common-all.js:1981 static/js/impala-all.js:2066 static/js/zamboni/buttons.js:217 static/js/zamboni/discovery-all.js:13252
+msgid "Download for {0} anyway"
+msgstr ""
+
+#: static/js/common-all.js:2038 static/js/impala-all.js:2123 static/js/zamboni/buttons.js:274 static/js/zamboni/discovery-all.js:13309
+msgid "Not available for your platform"
+msgstr ""
+
+#. L10n: {0} is an app name, {1} is the app version.
+#: static/js/common-all.js:2049 static/js/common-all.js:2086 static/js/impala-all.js:2134 static/js/impala-all.js:2171 static/js/zamboni/buttons.js:286 static/js/zamboni/buttons.js:324
+#: static/js/zamboni/discovery-all.js:13320 static/js/zamboni/discovery-all.js:13357
+msgid "Not available for {0} {1}"
+msgstr ""
+
+#: static/js/common-all.js:2112 static/js/impala-all.js:2197 static/js/zamboni/buttons.js:351 static/js/zamboni/discovery-all.js:13383
+msgid "Works with {app} {min} - {max}"
+msgstr ""
+
+#: static/js/common-all.js:2114 static/js/impala-all.js:2199 static/js/zamboni/buttons.js:353 static/js/zamboni/discovery-all.js:13385
+msgid "View other versions"
+msgstr ""
+
+#: static/js/common-all.js:2162 static/js/impala-all.js:2247 static/js/zamboni/buttons.js:401 static/js/zamboni/discovery-all.js:13433
+msgid "Only with Firefox — Get Firefox Now!"
+msgstr ""
+
+#: static/js/common-all.js:2278 static/js/impala-all.js:2363 static/js/zamboni/buttons.js:517 static/js/zamboni/discovery-all.js:13549 static/js/zamboni/mobile-all.js:15177
+#: static/js/zamboni/mobile/buttons.js:43
+msgid "Sorry, you need a Mozilla-based browser (such as Firefox) to install a search plugin."
+msgstr ""
+
+#: static/js/common-all.js:9088 static/js/impala-all.js:9649 static/js/zamboni/global.js:410
+msgid "Loading..."
+msgstr ""
+
+#. L10n: {0} is the number of characters left.
+#: static/js/common-all.js:9152 static/js/impala-all.js:9713 static/js/zamboni/global.js:474
+msgid "<b>{0}</b> character left."
+msgid_plural "<b>{0}</b> characters left."
+msgstr[0] ""
+msgstr[1] ""
+
+#: static/js/common-all.js:9589 static/js/common-min.js:6 static/js/impala-all.js:10052 static/js/impala-min.js:6 static/js/common/ratingwidget.js:31 static/js/zamboni/mobile-all.js:16123
+#: static/js/zamboni/mobile-min.js:6
 msgid "{0} star"
 msgid_plural "{0} stars"
 msgstr[0] ""
 msgstr[1] ""
 
-#: static/js/common/upload-addon.js:41 static/js/common/upload-image.js:128
+#: static/js/common-all.js:9676 static/js/common-min.js:6 static/js/impala-all.js:10139 static/js/impala-min.js:6 static/js/zamboni/l10n.js:45
+msgid "Remove this localization"
+msgstr ""
+
+#: static/js/common-all.js:10193 static/js/common-min.js:6 static/js/impala-all.js:10674 static/js/impala-min.js:6 static/js/zamboni/discovery-all.js:13678
+msgid "close"
+msgstr ""
+
+#: static/js/common-all.js:10860 static/js/common-min.js:6 static/js/impala-all.js:11481 static/js/impala-min.js:6 static/js/impala/reviews.js:23 static/js/zamboni/reviews.js:18
+msgid "Flagged for review"
+msgstr ""
+
+#: static/js/common-all.js:10876 static/js/common-min.js:6 static/js/impala-all.js:11498 static/js/impala-min.js:6 static/js/impala/reviews.js:40 static/js/zamboni/reviews.js:34
+msgid "Your input is required"
+msgstr ""
+
+#: static/js/common-all.js:10945 static/js/common-min.js:6 static/js/impala-all.js:11610 static/js/impala-min.js:7 static/js/impala/reviews.js:152 static/js/zamboni/reviews.js:103
+msgid "Marked for deletion"
+msgstr ""
+
+#: static/js/common-all.js:11573 static/js/common-min.js:7 static/js/impala-all.js:13809 static/js/impala-min.js:8 static/js/zamboni/collections.js:229
+msgid "Adding to Favorites&hellip;"
+msgstr ""
+
+#: static/js/common-all.js:11576 static/js/common-min.js:7 static/js/impala-all.js:13812 static/js/impala-min.js:8 static/js/zamboni/collections.js:232
+msgid "Removing Favorite&hellip;"
+msgstr ""
+
+#: static/js/common-all.js:11579 static/js/common-min.js:7 static/js/impala-all.js:13815 static/js/impala-min.js:8 static/js/zamboni/collections.js:235
+msgid "Add to Favorites"
+msgstr ""
+
+#: static/js/common-all.js:11582 static/js/common-min.js:7 static/js/impala-all.js:13818 static/js/impala-min.js:8 static/js/zamboni/collections.js:238
+msgid "Remove from Favorites"
+msgstr ""
+
+#: static/js/common-all.js:11647 static/js/common-min.js:7 static/js/impala-all.js:13883 static/js/impala-min.js:8 static/js/zamboni/collections.js:303
+msgid "Pending"
+msgstr ""
+
+#: static/js/common-all.js:11648 static/js/common-min.js:7 static/js/impala-all.js:13884 static/js/impala-min.js:8 static/js/zamboni/collections.js:304
+msgid "Add a comment"
+msgstr ""
+
+#: static/js/common-all.js:11648 static/js/common-min.js:7 static/js/impala-all.js:13884 static/js/impala-min.js:8 static/js/zamboni/collections.js:304
+msgid "Comment"
+msgstr ""
+
+#: static/js/common-all.js:11649 static/js/common-min.js:7 static/js/impala-all.js:13885 static/js/impala-min.js:8 static/js/zamboni/collections.js:305
+msgid "Remove this add-on from the collection"
+msgstr ""
+
+#: static/js/common-all.js:11649 static/js/common-all.js:11678 static/js/common-min.js:7 static/js/impala-all.js:13885 static/js/impala-all.js:13914 static/js/impala-min.js:8
+#: static/js/zamboni/collections.js:305 static/js/zamboni/collections.js:334
+msgid "Remove"
+msgstr ""
+
+#: static/js/common-all.js:11678 static/js/common-min.js:7 static/js/impala-all.js:13914 static/js/impala-min.js:8 static/js/zamboni/collections.js:334
+msgid "Remove this user as a contributor"
+msgstr ""
+
+#: static/js/common-all.js:11690 static/js/common-min.js:7 static/js/impala-all.js:13926 static/js/impala-min.js:8 static/js/zamboni/collections.js:346
+msgid "An email address is required."
+msgstr ""
+
+#: static/js/common-all.js:11708 static/js/common-min.js:7 static/js/impala-all.js:13944 static/js/impala-min.js:8 static/js/zamboni/collections.js:364
+msgid "You cannot add yourself as a contributor."
+msgstr ""
+
+#: static/js/common-all.js:11710 static/js/common-min.js:7 static/js/impala-all.js:13946 static/js/impala-min.js:8 static/js/zamboni/collections.js:366
+msgid "You have already added that user."
+msgstr ""
+
+#: static/js/common-all.js:11917 static/js/common-min.js:7 static/js/impala-all.js:14153 static/js/impala-min.js:8 static/js/zamboni/collections.js:573
+msgid "Add to favorites"
+msgstr ""
+
+#: static/js/common-all.js:11921 static/js/common-min.js:7 static/js/impala-all.js:14157 static/js/impala-min.js:8 static/js/zamboni/collections.js:577
+msgid "Remove from favorites"
+msgstr ""
+
+#: static/js/common-all.js:11939 static/js/common-min.js:7 static/js/impala-all.js:14175 static/js/impala-all.js:14233 static/js/impala-min.js:8 static/js/impala/collections.js:10
+#: static/js/zamboni/collections.js:595
+msgid "Follow this Collection"
+msgstr ""
+
+#: static/js/common-all.js:11948 static/js/common-min.js:7 static/js/impala-all.js:14184 static/js/impala-min.js:8 static/js/zamboni/collections.js:604
+msgid "Stop following"
+msgstr ""
+
+#: static/js/common-all.js:12096 static/js/common-min.js:7 static/js/zamboni/password-strength.js:20
+msgid "Password strength:"
+msgstr ""
+
+#: static/js/common-all.js:12102 static/js/common-min.js:7 static/js/zamboni/password-strength.js:26
+msgid "At least {0} character left."
+msgid_plural "At least {0} characters left."
+msgstr[0] ""
+msgstr[1] ""
+
+#: static/js/common-all.js:12286 static/js/common-min.js:7 static/js/impala-all.js:14632 static/js/impala-min.js:8 static/js/impala/suggestions.js:39
+msgid "Search themes for <b>{0}</b>"
+msgstr ""
+
+#: static/js/common-all.js:12288 static/js/common-min.js:7 static/js/impala-all.js:14634 static/js/impala-min.js:8 static/js/impala/suggestions.js:41
+msgid "Search apps for <b>{0}</b>"
+msgstr ""
+
+#: static/js/common-all.js:12290 static/js/common-min.js:7 static/js/impala-all.js:14636 static/js/impala-min.js:8 static/js/impala/suggestions.js:43
+msgid "Search add-ons for <b>{0}</b>"
+msgstr ""
+
+#: static/js/common-all.js:12521 static/js/common-min.js:7 static/js/impala-all.js:14867 static/js/impala-min.js:8 static/js/impala/site_suggestions.js:46
+msgid "Category"
+msgstr ""
+
+#. L10n: {0} is an app name.
+#: static/js/impala-all.js:11632 static/js/impala-min.js:7 static/js/impala/listing.js:11 static/js/zamboni/themes.js:13
+msgid "This theme is incompatible with your version of {0}"
+msgstr ""
+
+#: static/js/impala-all.js:12146 static/js/impala-all.js:14331 static/js/impala-min.js:7 static/js/impala-min.js:8 static/js/common/upload-image.js:97 static/js/impala/users.js:51
+#: static/js/zamboni/devhub-all.js:894 static/js/zamboni/devhub-min.js:1
+msgid "Images must be either PNG or JPG."
+msgstr ""
+
+#: static/js/impala-all.js:12150 static/js/impala-min.js:7 static/js/common/upload-image.js:101 static/js/zamboni/devhub-all.js:898 static/js/zamboni/devhub-min.js:1
+msgid "Videos must be in WebM."
+msgstr ""
+
+#: static/js/impala-all.js:12177 static/js/impala-min.js:7 static/js/common/upload-addon.js:41 static/js/common/upload-image.js:128 static/js/zamboni/devhub-all.js:272
+#: static/js/zamboni/devhub-all.js:925 static/js/zamboni/devhub-min.js:1
 msgid "There was a problem contacting the server."
 msgstr ""
 
-#: static/js/common/upload-addon.js:69
+#: static/js/impala-all.js:13298 static/js/impala-min.js:7 static/js/impala/persona_creation.js:60
+msgid "All Rights Reserved"
+msgstr ""
+
+#: static/js/impala-all.js:13302 static/js/impala-min.js:7 static/js/impala/persona_creation.js:64
+msgid "Creative Commons Attribution 3.0"
+msgstr ""
+
+#: static/js/impala-all.js:13307 static/js/impala-min.js:7 static/js/impala/persona_creation.js:69
+msgid "Creative Commons Attribution-NonCommercial 3.0"
+msgstr ""
+
+#: static/js/impala-all.js:13312 static/js/impala-min.js:7 static/js/impala/persona_creation.js:74
+msgid "Creative Commons Attribution-NonCommercial-NoDerivs 3.0"
+msgstr ""
+
+#: static/js/impala-all.js:13317 static/js/impala-min.js:7 static/js/impala/persona_creation.js:79
+msgid "Creative Commons Attribution-NonCommercial-Share Alike 3.0"
+msgstr ""
+
+#: static/js/impala-all.js:13322 static/js/impala-min.js:7 static/js/impala/persona_creation.js:84
+msgid "Creative Commons Attribution-NoDerivs 3.0"
+msgstr ""
+
+#: static/js/impala-all.js:13327 static/js/impala-min.js:7 static/js/impala/persona_creation.js:89
+msgid "Creative Commons Attribution-ShareAlike 3.0"
+msgstr ""
+
+#: static/js/impala-all.js:13530 static/js/impala-min.js:7 static/js/impala/persona_creation.js:292
+msgid "Your Theme's Name"
+msgstr ""
+
+#: static/js/impala-all.js:14242 static/js/impala-min.js:8 static/js/impala/collections.js:19
+msgid "Stop Following"
+msgstr ""
+
+#: static/js/impala-all.js:14243 static/js/impala-min.js:8 static/js/impala/collections.js:20
+msgid "Following"
+msgstr ""
+
+#: static/js/impala-all.js:14313 static/js/impala-min.js:8 static/js/impala/users.js:33
+msgid "use original"
+msgstr ""
+
+#: static/js/impala-all.js:14523 static/js/impala-min.js:8 static/js/impala/search.js:114
+msgid "Updating results&hellip;"
+msgstr ""
+
+#: static/js/common/upload-addon.js:69 static/js/zamboni/devhub-all.js:300 static/js/zamboni/devhub-min.js:1
 msgid "Select a file..."
 msgstr ""
 
-#: static/js/common/upload-addon.js:70
+#: static/js/common/upload-addon.js:70 static/js/zamboni/devhub-all.js:301 static/js/zamboni/devhub-min.js:1
 msgid "Your add-on should end with .xpi, .jar or .xml"
 msgstr ""
 
 #. L10n: {0} is the percent of the file that has been uploaded.
-#: static/js/common/upload-addon.js:104
+#: static/js/common/upload-addon.js:104 static/js/zamboni/devhub-all.js:335 static/js/zamboni/devhub-min.js:1
 #, python-format
 msgid "{0}% complete"
 msgstr ""
 
 #. L10n: "{bytes uploaded} of {total filesize}".
-#: static/js/common/upload-addon.js:107
+#: static/js/common/upload-addon.js:107 static/js/zamboni/devhub-all.js:338 static/js/zamboni/devhub-min.js:1
 msgid "{0} of {1}"
 msgstr ""
 
-#: static/js/common/upload-addon.js:140
+#: static/js/common/upload-addon.js:140 static/js/zamboni/devhub-all.js:371 static/js/zamboni/devhub-min.js:1
 msgid "Cancel"
 msgstr ""
 
-#: static/js/common/upload-addon.js:162
+#: static/js/common/upload-addon.js:162 static/js/zamboni/devhub-all.js:393 static/js/zamboni/devhub-min.js:1
 msgid "Uploading {0}"
 msgstr ""
 
-#: static/js/common/upload-addon.js:189
+#: static/js/common/upload-addon.js:189 static/js/zamboni/devhub-all.js:420 static/js/zamboni/devhub-min.js:1
 msgid "Error with {0}"
 msgstr ""
 
-#: static/js/common/upload-addon.js:194
+#: static/js/common/upload-addon.js:194 static/js/zamboni/devhub-all.js:425 static/js/zamboni/devhub-min.js:1
 msgid "Your add-on failed validation with {0} error."
 msgid_plural "Your add-on failed validation with {0} errors."
 msgstr[0] ""
 msgstr[1] ""
 
-#: static/js/common/upload-addon.js:208
+#: static/js/common/upload-addon.js:208 static/js/zamboni/devhub-all.js:439 static/js/zamboni/devhub-min.js:1
 msgid "&hellip;and {0} more"
 msgid_plural "&hellip;and {0} more"
 msgstr[0] ""
 msgstr[1] ""
 
-#: static/js/common/upload-addon.js:222 static/js/common/upload-addon.js:512
+#: static/js/common/upload-addon.js:222 static/js/common/upload-addon.js:497 static/js/zamboni/devhub-all.js:453 static/js/zamboni/devhub-all.js:743 static/js/zamboni/devhub-min.js:1
 msgid "See full validation report"
 msgstr ""
 
-#: static/js/common/upload-addon.js:234
+#: static/js/common/upload-addon.js:234 static/js/zamboni/devhub-all.js:465 static/js/zamboni/devhub-min.js:1
 msgid "Validating {0}"
 msgstr ""
 
 #. L10n: first argument is an HTTP status code
-#: static/js/common/upload-addon.js:273
+#: static/js/common/upload-addon.js:273 static/js/zamboni/devhub-all.js:504 static/js/zamboni/devhub-min.js:1
 msgid "Received an empty response from the server; status: {0}"
 msgstr ""
 
-#: static/js/common/upload-addon.js:373
+#: static/js/common/upload-addon.js:370 static/js/zamboni/devhub-all.js:604 static/js/zamboni/devhub-min.js:1
 msgid "Unexpected server error while validating."
 msgstr ""
 
-#: static/js/common/upload-addon.js:412
+#: static/js/common/upload-addon.js:409 static/js/zamboni/devhub-all.js:643 static/js/zamboni/devhub-min.js:1
 msgid "Finished validating {0}"
 msgstr ""
 
-#: static/js/common/upload-addon.js:418
+#: static/js/common/upload-addon.js:415 static/js/zamboni/devhub-all.js:649 static/js/zamboni/devhub-min.js:1
 msgid "Your add-on validation timed out, it will be manually reviewed."
 msgstr ""
 
-#: static/js/common/upload-addon.js:421
+#: static/js/common/upload-addon.js:418 static/js/zamboni/devhub-all.js:652 static/js/zamboni/devhub-min.js:1
 msgid "Your add-on was validated with no errors and {0} warning."
 msgid_plural "Your add-on was validated with no errors and {0} warnings."
 msgstr[0] ""
 msgstr[1] ""
 
-#: static/js/common/upload-addon.js:426
+#: static/js/common/upload-addon.js:423 static/js/zamboni/devhub-all.js:657 static/js/zamboni/devhub-min.js:1
 msgid "Your add-on was validated with no errors and {0} message."
 msgid_plural "Your add-on was validated with no errors and {0} messages."
 msgstr[0] ""
 msgstr[1] ""
 
-#: static/js/common/upload-addon.js:431
+#: static/js/common/upload-addon.js:428 static/js/zamboni/devhub-all.js:662 static/js/zamboni/devhub-min.js:1
 msgid "Your add-on was validated with no errors or warnings."
 msgstr ""
 
-#: static/js/common/upload-addon.js:446
+#: static/js/common/upload-addon.js:443 static/js/zamboni/devhub-all.js:677 static/js/zamboni/devhub-min.js:1
 msgid "Your submission will be automatically signed."
 msgstr ""
 
-#: static/js/common/upload-addon.js:465
+#: static/js/common/upload-addon.js:450 static/js/zamboni/devhub-all.js:696 static/js/zamboni/devhub-min.js:1
 msgid "Include detailed version notes (this can be done in the next step)."
 msgstr ""
 
-#: static/js/common/upload-addon.js:466
+#: static/js/common/upload-addon.js:451 static/js/zamboni/devhub-all.js:697 static/js/zamboni/devhub-min.js:1
 msgid "If your add-on requires an account to a website in order to be fully tested, include a test username and password in the Notes to Reviewer (this can be done in the next step)."
 msgstr ""
 
-#: static/js/common/upload-addon.js:467
+#: static/js/common/upload-addon.js:452 static/js/zamboni/devhub-all.js:698 static/js/zamboni/devhub-min.js:1
 msgid "If your add-on is intended for a limited audience you should choose Preliminary Review instead of Full Review."
 msgstr ""
 
-#: static/js/common/upload-addon.js:480
+#: static/js/common/upload-addon.js:465 static/js/zamboni/devhub-all.js:711 static/js/zamboni/devhub-min.js:1
 msgid "Add-on submission checklist"
 msgstr ""
 
-#: static/js/common/upload-addon.js:481
+#: static/js/common/upload-addon.js:466 static/js/zamboni/devhub-all.js:712 static/js/zamboni/devhub-min.js:1
 msgid "Please verify the following points before finalizing your submission. This will minimize delays or misunderstanding during the review process:"
 msgstr ""
 
-#: static/js/common/upload-addon.js:483
+#: static/js/common/upload-addon.js:468 static/js/zamboni/devhub-all.js:714 static/js/zamboni/devhub-min.js:1
 msgid ""
 "Compiled binaries, as well as minified or obfuscated scripts (excluding known libraries) need to have their sources submitted separately for review. Make sure that you use the source code upload "
 "field to avoid having your submission rejected."
 msgstr ""
 
-#: static/js/common/upload-addon.js:501
+#: static/js/common/upload-addon.js:486 static/js/zamboni/devhub-all.js:732 static/js/zamboni/devhub-min.js:1
 msgid "The validation process found these issues that can lead to rejections:"
 msgstr ""
 
-#: static/js/common/upload-addon.js:518
+#: static/js/common/upload-addon.js:503 static/js/zamboni/devhub-all.js:749 static/js/zamboni/devhub-min.js:1
 msgid "If you are unfamiliar with the add-ons review process, you can read about it here."
 msgstr ""
 
-#: static/js/common/upload-addon.js:555
+#: static/js/common/upload-addon.js:540 static/js/zamboni/devhub-all.js:786 static/js/zamboni/devhub-min.js:1
 msgid "Sorry, no supported platform has been found."
 msgstr ""
 
-#: static/js/common/upload-base.js:57
+#: static/js/common/upload-base.js:57 static/js/zamboni/devhub-all.js:187 static/js/zamboni/devhub-min.js:1
 msgid "The filetype you uploaded isn't recognized."
 msgstr ""
 
-#: static/js/common/upload-base.js:79
+#: static/js/common/upload-base.js:79 static/js/zamboni/devhub-all.js:209 static/js/zamboni/devhub-min.js:1
 msgid "You cancelled the upload."
 msgstr ""
 
-#: static/js/common/upload-image.js:97 static/js/impala/users.js:51
-msgid "Images must be either PNG or JPG."
-msgstr ""
-
-#: static/js/common/upload-image.js:101
-msgid "Videos must be in WebM."
-msgstr ""
-
-#: static/js/impala/collections.js:10 static/js/zamboni/collections.js:595
-msgid "Follow this Collection"
-msgstr ""
-
-#: static/js/impala/collections.js:19
-msgid "Stop Following"
-msgstr ""
-
-#: static/js/impala/collections.js:20
-msgid "Following"
-msgstr ""
-
-#. L10n: {0} is an app name.
-#: static/js/impala/listing.js:11 static/js/zamboni/themes.js:13
-msgid "This theme is incompatible with your version of {0}"
-msgstr ""
-
-#: static/js/impala/persona_creation.js:60
-msgid "All Rights Reserved"
-msgstr ""
-
-#: static/js/impala/persona_creation.js:64
-msgid "Creative Commons Attribution 3.0"
-msgstr ""
-
-#: static/js/impala/persona_creation.js:69
-msgid "Creative Commons Attribution-NonCommercial 3.0"
-msgstr ""
-
-#: static/js/impala/persona_creation.js:74
-msgid "Creative Commons Attribution-NonCommercial-NoDerivs 3.0"
-msgstr ""
-
-#: static/js/impala/persona_creation.js:79
-msgid "Creative Commons Attribution-NonCommercial-Share Alike 3.0"
-msgstr ""
-
-#: static/js/impala/persona_creation.js:84
-msgid "Creative Commons Attribution-NoDerivs 3.0"
-msgstr ""
-
-#: static/js/impala/persona_creation.js:89
-msgid "Creative Commons Attribution-ShareAlike 3.0"
-msgstr ""
-
-#: static/js/impala/persona_creation.js:292
-msgid "Your Theme's Name"
-msgstr ""
-
-#: static/js/impala/reviews.js:23 static/js/zamboni/reviews.js:18
-msgid "Flagged for review"
-msgstr ""
-
-#: static/js/impala/reviews.js:40 static/js/zamboni/reviews.js:34
-msgid "Your input is required"
-msgstr ""
-
-#: static/js/impala/reviews.js:152 static/js/zamboni/reviews.js:103
-msgid "Marked for deletion"
-msgstr ""
-
-#: static/js/impala/search.js:114
-msgid "Updating results&hellip;"
-msgstr ""
-
-#: static/js/impala/site_suggestions.js:46
-msgid "Category"
-msgstr ""
-
-#: static/js/impala/suggestions.js:39
-msgid "Search themes for <b>{0}</b>"
-msgstr ""
-
-#: static/js/impala/suggestions.js:41
-msgid "Search apps for <b>{0}</b>"
-msgstr ""
-
-#: static/js/impala/suggestions.js:43
-msgid "Search add-ons for <b>{0}</b>"
-msgstr ""
-
-#: static/js/impala/users.js:33
-msgid "use original"
-msgstr ""
-
-#: static/js/impala/stats/chart.js:267
+#: static/js/impala/stats/chart.js:267 static/js/zamboni/stats-all.js:16898 static/js/zamboni/stats-min.js:5
 msgid "Week of {0}"
 msgstr ""
 
-#: static/js/impala/stats/chart.js:269
+#: static/js/impala/stats/chart.js:269 static/js/zamboni/stats-all.js:16900 static/js/zamboni/stats-min.js:5
 msgid " downloads"
 msgstr ""
 
-#: static/js/impala/stats/chart.js:270
+#: static/js/impala/stats/chart.js:270 static/js/zamboni/stats-all.js:16901 static/js/zamboni/stats-min.js:5
 msgid "{0} users"
 msgstr ""
 
-#: static/js/impala/stats/chart.js:271
+#: static/js/impala/stats/chart.js:271 static/js/zamboni/stats-all.js:16902 static/js/zamboni/stats-min.js:5
 msgid "{0} add-ons"
 msgstr ""
 
-#: static/js/impala/stats/chart.js:272
+#: static/js/impala/stats/chart.js:272 static/js/zamboni/stats-all.js:16903 static/js/zamboni/stats-min.js:5
 msgid "{0} collections"
 msgstr ""
 
-#: static/js/impala/stats/chart.js:273
+#: static/js/impala/stats/chart.js:273 static/js/zamboni/stats-all.js:16904 static/js/zamboni/stats-min.js:5
 msgid "{0} reviews"
 msgstr ""
 
-#: static/js/impala/stats/chart.js:275
+#: static/js/impala/stats/chart.js:275 static/js/zamboni/stats-all.js:16906 static/js/zamboni/stats-min.js:5
 msgid "{0} sales"
 msgstr ""
 
-#: static/js/impala/stats/chart.js:276
+#: static/js/impala/stats/chart.js:276 static/js/zamboni/stats-all.js:16907 static/js/zamboni/stats-min.js:5
 msgid "{0} refunds"
 msgstr ""
 
-#: static/js/impala/stats/chart.js:277
+#: static/js/impala/stats/chart.js:277 static/js/zamboni/stats-all.js:16908 static/js/zamboni/stats-min.js:5
 msgid "{0} installs"
 msgstr ""
 
-#: static/js/impala/stats/chart.js:369 static/js/impala/stats/csv_keys.js:3 static/js/impala/stats/csv_keys.js:109
+#: static/js/impala/stats/chart.js:369 static/js/impala/stats/csv_keys.js:3 static/js/impala/stats/csv_keys.js:109 static/js/zamboni/stats-all.js:15284 static/js/zamboni/stats-all.js:15390
+#: static/js/zamboni/stats-all.js:17000 static/js/zamboni/stats-min.js:4 static/js/zamboni/stats-min.js:5
 msgid "Downloads"
 msgstr ""
 
-#: static/js/impala/stats/chart.js:379 static/js/impala/stats/csv_keys.js:6 static/js/impala/stats/csv_keys.js:110
+#: static/js/impala/stats/chart.js:379 static/js/impala/stats/csv_keys.js:6 static/js/impala/stats/csv_keys.js:110 static/js/zamboni/stats-all.js:15287 static/js/zamboni/stats-all.js:15391
+#: static/js/zamboni/stats-all.js:17010 static/js/zamboni/stats-min.js:4 static/js/zamboni/stats-min.js:5
 msgid "Daily Users"
 msgstr ""
 
-#: static/js/impala/stats/chart.js:410
+#: static/js/impala/stats/chart.js:410 static/js/zamboni/stats-all.js:17041 static/js/zamboni/stats-min.js:5
 msgid "Amount, in USD"
 msgstr ""
 
-#: static/js/impala/stats/chart.js:421 static/js/impala/stats/csv_keys.js:104
+#: static/js/impala/stats/chart.js:421 static/js/impala/stats/csv_keys.js:104 static/js/zamboni/stats-all.js:15385 static/js/zamboni/stats-all.js:17052 static/js/zamboni/stats-min.js:5
 msgid "Number of Contributions"
 msgstr ""
 
-#: static/js/impala/stats/chart.js:447
+#: static/js/impala/stats/chart.js:447 static/js/zamboni/stats-all.js:17078 static/js/zamboni/stats-min.js:5
 msgid "More Info..."
 msgstr ""
 
 #. L10n: {0} is an ISO-formatted date.
-#: static/js/impala/stats/chart.js:451
+#: static/js/impala/stats/chart.js:451 static/js/zamboni/stats-all.js:17082 static/js/zamboni/stats-min.js:5
 msgid "Details for {0}"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:9
+#: static/js/impala/stats/csv_keys.js:9 static/js/zamboni/stats-all.js:15290 static/js/zamboni/stats-min.js:4
 msgid "Collections Created"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:12
+#: static/js/impala/stats/csv_keys.js:12 static/js/zamboni/stats-all.js:15293 static/js/zamboni/stats-min.js:4
 msgid "Add-ons in Use"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:15
+#: static/js/impala/stats/csv_keys.js:15 static/js/zamboni/stats-all.js:15296 static/js/zamboni/stats-min.js:4
 msgid "Add-ons Created"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:18
+#: static/js/impala/stats/csv_keys.js:18 static/js/zamboni/stats-all.js:15299 static/js/zamboni/stats-min.js:4
 msgid "Add-ons Downloaded"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:21
+#: static/js/impala/stats/csv_keys.js:21 static/js/zamboni/stats-all.js:15302 static/js/zamboni/stats-min.js:4
 msgid "Add-ons Updated"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:24
+#: static/js/impala/stats/csv_keys.js:24 static/js/zamboni/stats-all.js:15305 static/js/zamboni/stats-min.js:4
 msgid "Reviews Written"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:27
+#: static/js/impala/stats/csv_keys.js:27 static/js/zamboni/stats-all.js:15308 static/js/zamboni/stats-min.js:4
 msgid "User Signups"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:30
+#: static/js/impala/stats/csv_keys.js:30 static/js/zamboni/stats-all.js:15311 static/js/zamboni/stats-min.js:4
 msgid "Subscribers"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:33
+#: static/js/impala/stats/csv_keys.js:33 static/js/zamboni/stats-all.js:15314 static/js/zamboni/stats-min.js:4
 msgid "Ratings"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:36 static/js/impala/stats/csv_keys.js:114
+#: static/js/impala/stats/csv_keys.js:36 static/js/impala/stats/csv_keys.js:114 static/js/zamboni/stats-all.js:15317 static/js/zamboni/stats-all.js:15395 static/js/zamboni/stats-min.js:4
+#: static/js/zamboni/stats-min.js:5
 msgid "Sales"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:39 static/js/impala/stats/csv_keys.js:113
+#: static/js/impala/stats/csv_keys.js:39 static/js/impala/stats/csv_keys.js:113 static/js/zamboni/stats-all.js:15320 static/js/zamboni/stats-all.js:15394 static/js/zamboni/stats-min.js:4
+#: static/js/zamboni/stats-min.js:5
 msgid "Installs"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:42
+#: static/js/impala/stats/csv_keys.js:42 static/js/zamboni/stats-all.js:15323 static/js/zamboni/stats-min.js:4
 msgid "Unknown"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:43
+#: static/js/impala/stats/csv_keys.js:43 static/js/zamboni/stats-all.js:15324 static/js/zamboni/stats-min.js:4
 msgid "Add-ons Manager"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:44
+#: static/js/impala/stats/csv_keys.js:44 static/js/zamboni/stats-all.js:15325 static/js/zamboni/stats-min.js:4
 msgid "Add-ons Manager Promo"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:45
+#: static/js/impala/stats/csv_keys.js:45 static/js/zamboni/stats-all.js:15326 static/js/zamboni/stats-min.js:4
 msgid "Add-ons Manager Featured"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:46
+#: static/js/impala/stats/csv_keys.js:46 static/js/zamboni/stats-all.js:15327 static/js/zamboni/stats-min.js:4
 msgid "Add-ons Manager Learn More"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:47
+#: static/js/impala/stats/csv_keys.js:47 static/js/zamboni/stats-all.js:15328 static/js/zamboni/stats-min.js:4
 msgid "Search Suggestions"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:48
+#: static/js/impala/stats/csv_keys.js:48 static/js/zamboni/stats-all.js:15329 static/js/zamboni/stats-min.js:4
 msgid "Search Results"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:49 static/js/impala/stats/csv_keys.js:50 static/js/impala/stats/csv_keys.js:51
+#: static/js/impala/stats/csv_keys.js:49 static/js/impala/stats/csv_keys.js:50 static/js/impala/stats/csv_keys.js:51 static/js/zamboni/stats-all.js:15330 static/js/zamboni/stats-all.js:15331
+#: static/js/zamboni/stats-all.js:15332 static/js/zamboni/stats-min.js:4
 msgid "Homepage Promo"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:52 static/js/impala/stats/csv_keys.js:53
+#: static/js/impala/stats/csv_keys.js:52 static/js/impala/stats/csv_keys.js:53 static/js/zamboni/stats-all.js:15333 static/js/zamboni/stats-all.js:15334 static/js/zamboni/stats-min.js:4
 msgid "Homepage Featured"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:54 static/js/impala/stats/csv_keys.js:55
+#: static/js/impala/stats/csv_keys.js:54 static/js/impala/stats/csv_keys.js:55 static/js/zamboni/stats-all.js:15335 static/js/zamboni/stats-all.js:15336 static/js/zamboni/stats-min.js:4
 msgid "Homepage Up and Coming"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:56
+#: static/js/impala/stats/csv_keys.js:56 static/js/zamboni/stats-all.js:15337 static/js/zamboni/stats-min.js:4
 msgid "Homepage Most Popular"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:57 static/js/impala/stats/csv_keys.js:59
+#: static/js/impala/stats/csv_keys.js:57 static/js/impala/stats/csv_keys.js:59 static/js/zamboni/stats-all.js:15338 static/js/zamboni/stats-all.js:15340 static/js/zamboni/stats-min.js:4
 msgid "Detail Page"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:58 static/js/impala/stats/csv_keys.js:60
+#: static/js/impala/stats/csv_keys.js:58 static/js/impala/stats/csv_keys.js:60 static/js/zamboni/stats-all.js:15339 static/js/zamboni/stats-all.js:15341 static/js/zamboni/stats-min.js:4
 msgid "Detail Page (bottom)"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:61
+#: static/js/impala/stats/csv_keys.js:61 static/js/zamboni/stats-all.js:15342 static/js/zamboni/stats-min.js:4
 msgid "Detail Page (Development Channel)"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:62 static/js/impala/stats/csv_keys.js:63 static/js/impala/stats/csv_keys.js:64
+#: static/js/impala/stats/csv_keys.js:62 static/js/impala/stats/csv_keys.js:63 static/js/impala/stats/csv_keys.js:64 static/js/zamboni/stats-all.js:15343 static/js/zamboni/stats-all.js:15344
+#: static/js/zamboni/stats-all.js:15345 static/js/zamboni/stats-min.js:4
 msgid "Often Used With"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:65 static/js/impala/stats/csv_keys.js:66
+#: static/js/impala/stats/csv_keys.js:65 static/js/impala/stats/csv_keys.js:66 static/js/zamboni/stats-all.js:15346 static/js/zamboni/stats-all.js:15347 static/js/zamboni/stats-min.js:4
 msgid "Others By Author"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:67 static/js/impala/stats/csv_keys.js:68
+#: static/js/impala/stats/csv_keys.js:67 static/js/impala/stats/csv_keys.js:68 static/js/zamboni/stats-all.js:15348 static/js/zamboni/stats-all.js:15349 static/js/zamboni/stats-min.js:4
 msgid "Dependencies"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:69 static/js/impala/stats/csv_keys.js:70
+#: static/js/impala/stats/csv_keys.js:69 static/js/impala/stats/csv_keys.js:70 static/js/zamboni/stats-all.js:15350 static/js/zamboni/stats-all.js:15351 static/js/zamboni/stats-min.js:4
 msgid "Upsell"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:71
+#: static/js/impala/stats/csv_keys.js:71 static/js/zamboni/stats-all.js:15352 static/js/zamboni/stats-min.js:4
 msgid "Meet the Developer"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:72
+#: static/js/impala/stats/csv_keys.js:72 static/js/zamboni/stats-all.js:15353 static/js/zamboni/stats-min.js:4
 msgid "User Profile"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:73
+#: static/js/impala/stats/csv_keys.js:73 static/js/zamboni/stats-all.js:15354 static/js/zamboni/stats-min.js:4
 msgid "Version History"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:75
+#: static/js/impala/stats/csv_keys.js:75 static/js/zamboni/stats-all.js:15356 static/js/zamboni/stats-min.js:4
 msgid "Sharing"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:76
+#: static/js/impala/stats/csv_keys.js:76 static/js/zamboni/stats-all.js:15357 static/js/zamboni/stats-min.js:4
 msgid "Category Pages"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:77
+#: static/js/impala/stats/csv_keys.js:77 static/js/zamboni/stats-all.js:15358 static/js/zamboni/stats-min.js:4
 msgid "Collections"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:78 static/js/impala/stats/csv_keys.js:79
+#: static/js/impala/stats/csv_keys.js:78 static/js/impala/stats/csv_keys.js:79 static/js/zamboni/stats-all.js:15359 static/js/zamboni/stats-all.js:15360 static/js/zamboni/stats-min.js:4
 msgid "Category Landing Featured Carousel"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:80 static/js/impala/stats/csv_keys.js:81
+#: static/js/impala/stats/csv_keys.js:80 static/js/impala/stats/csv_keys.js:81 static/js/zamboni/stats-all.js:15361 static/js/zamboni/stats-all.js:15362 static/js/zamboni/stats-min.js:4
 msgid "Category Landing Top Rated"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:82 static/js/impala/stats/csv_keys.js:83
+#: static/js/impala/stats/csv_keys.js:82 static/js/impala/stats/csv_keys.js:83 static/js/zamboni/stats-all.js:15363 static/js/zamboni/stats-all.js:15364 static/js/zamboni/stats-min.js:5
 msgid "Category Landing Most Popular"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:84 static/js/impala/stats/csv_keys.js:85
+#: static/js/impala/stats/csv_keys.js:84 static/js/impala/stats/csv_keys.js:85 static/js/zamboni/stats-all.js:15365 static/js/zamboni/stats-all.js:15366 static/js/zamboni/stats-min.js:5
 msgid "Category Landing Recently Added"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:86 static/js/impala/stats/csv_keys.js:87
+#: static/js/impala/stats/csv_keys.js:86 static/js/impala/stats/csv_keys.js:87 static/js/zamboni/stats-all.js:15367 static/js/zamboni/stats-all.js:15368 static/js/zamboni/stats-min.js:5
 msgid "Browse Listing Featured Sort"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:88 static/js/impala/stats/csv_keys.js:89
+#: static/js/impala/stats/csv_keys.js:88 static/js/impala/stats/csv_keys.js:89 static/js/zamboni/stats-all.js:15369 static/js/zamboni/stats-all.js:15370 static/js/zamboni/stats-min.js:5
 msgid "Browse Listing Users Sort"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:90 static/js/impala/stats/csv_keys.js:91
+#: static/js/impala/stats/csv_keys.js:90 static/js/impala/stats/csv_keys.js:91 static/js/zamboni/stats-all.js:15371 static/js/zamboni/stats-all.js:15372 static/js/zamboni/stats-min.js:5
 msgid "Browse Listing Rating Sort"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:92 static/js/impala/stats/csv_keys.js:93
+#: static/js/impala/stats/csv_keys.js:92 static/js/impala/stats/csv_keys.js:93 static/js/zamboni/stats-all.js:15373 static/js/zamboni/stats-all.js:15374 static/js/zamboni/stats-min.js:5
 msgid "Browse Listing Created Sort"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:94 static/js/impala/stats/csv_keys.js:95
+#: static/js/impala/stats/csv_keys.js:94 static/js/impala/stats/csv_keys.js:95 static/js/zamboni/stats-all.js:15375 static/js/zamboni/stats-all.js:15376 static/js/zamboni/stats-min.js:5
 msgid "Browse Listing Name Sort"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:96 static/js/impala/stats/csv_keys.js:97
+#: static/js/impala/stats/csv_keys.js:96 static/js/impala/stats/csv_keys.js:97 static/js/zamboni/stats-all.js:15377 static/js/zamboni/stats-all.js:15378 static/js/zamboni/stats-min.js:5
 msgid "Browse Listing Popular Sort"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:98 static/js/impala/stats/csv_keys.js:99
+#: static/js/impala/stats/csv_keys.js:98 static/js/impala/stats/csv_keys.js:99 static/js/zamboni/stats-all.js:15379 static/js/zamboni/stats-all.js:15380 static/js/zamboni/stats-min.js:5
 msgid "Browse Listing Updated Sort"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:100 static/js/impala/stats/csv_keys.js:101
+#: static/js/impala/stats/csv_keys.js:100 static/js/impala/stats/csv_keys.js:101 static/js/zamboni/stats-all.js:15381 static/js/zamboni/stats-all.js:15382 static/js/zamboni/stats-min.js:5
 msgid "Browse Listing Up and Coming Sort"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:105
+#: static/js/impala/stats/csv_keys.js:105 static/js/zamboni/stats-all.js:15386 static/js/zamboni/stats-min.js:5
 msgid "Total Amount Contributed"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:106
+#: static/js/impala/stats/csv_keys.js:106 static/js/zamboni/stats-all.js:15387 static/js/zamboni/stats-min.js:5
 msgid "Average Contribution"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:115
+#: static/js/impala/stats/csv_keys.js:115 static/js/zamboni/stats-all.js:15396 static/js/zamboni/stats-min.js:5
 msgid "Usage"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:118
+#: static/js/impala/stats/csv_keys.js:118 static/js/zamboni/stats-all.js:15399 static/js/zamboni/stats-min.js:5
 msgid "Firefox"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:119
+#: static/js/impala/stats/csv_keys.js:119 static/js/zamboni/stats-all.js:15400 static/js/zamboni/stats-min.js:5
 msgid "Mozilla"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:120
+#: static/js/impala/stats/csv_keys.js:120 static/js/zamboni/stats-all.js:15401 static/js/zamboni/stats-min.js:5
 msgid "Thunderbird"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:121
+#: static/js/impala/stats/csv_keys.js:121 static/js/zamboni/stats-all.js:15402 static/js/zamboni/stats-min.js:5
 msgid "Sunbird"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:122
+#: static/js/impala/stats/csv_keys.js:122 static/js/zamboni/stats-all.js:15403 static/js/zamboni/stats-min.js:5
 msgid "SeaMonkey"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:123
+#: static/js/impala/stats/csv_keys.js:123 static/js/zamboni/stats-all.js:15404 static/js/zamboni/stats-min.js:5
 msgid "Fennec"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:124
+#: static/js/impala/stats/csv_keys.js:124 static/js/zamboni/stats-all.js:15405 static/js/zamboni/stats-min.js:5
 msgid "Android"
 msgstr ""
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:129
+#: static/js/impala/stats/csv_keys.js:129 static/js/zamboni/stats-all.js:15410 static/js/zamboni/stats-min.js:5
 msgid "Downloads and Daily Users, last {0} days"
 msgstr ""
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:131
+#: static/js/impala/stats/csv_keys.js:131 static/js/zamboni/stats-all.js:15412 static/js/zamboni/stats-min.js:5
 msgid "Downloads and Daily Users from {0} to {1}"
 msgstr ""
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:135
+#: static/js/impala/stats/csv_keys.js:135 static/js/zamboni/stats-all.js:15416 static/js/zamboni/stats-min.js:5
 msgid "Installs and Daily Users, last {0} days"
 msgstr ""
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:137
+#: static/js/impala/stats/csv_keys.js:137 static/js/zamboni/stats-all.js:15418 static/js/zamboni/stats-min.js:5
 msgid "Installs and Daily Users from {0} to {1}"
 msgstr ""
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:141
+#: static/js/impala/stats/csv_keys.js:141 static/js/zamboni/stats-all.js:15422 static/js/zamboni/stats-min.js:5
 msgid "Downloads, last {0} days"
 msgstr ""
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:143
+#: static/js/impala/stats/csv_keys.js:143 static/js/zamboni/stats-all.js:15424 static/js/zamboni/stats-min.js:5
 msgid "Downloads from {0} to {1}"
 msgstr ""
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:147
+#: static/js/impala/stats/csv_keys.js:147 static/js/zamboni/stats-all.js:15428 static/js/zamboni/stats-min.js:5
 msgid "Daily Users, last {0} days"
 msgstr ""
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:149
+#: static/js/impala/stats/csv_keys.js:149 static/js/zamboni/stats-all.js:15430 static/js/zamboni/stats-min.js:5
 msgid "Daily Users from {0} to {1}"
 msgstr ""
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:153
+#: static/js/impala/stats/csv_keys.js:153 static/js/zamboni/stats-all.js:15434 static/js/zamboni/stats-min.js:5
 msgid "Applications, last {0} days"
 msgstr ""
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:155
+#: static/js/impala/stats/csv_keys.js:155 static/js/zamboni/stats-all.js:15436 static/js/zamboni/stats-min.js:5
 msgid "Applications from {0} to {1}"
 msgstr ""
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:159
+#: static/js/impala/stats/csv_keys.js:159 static/js/zamboni/stats-all.js:15440 static/js/zamboni/stats-min.js:5
 msgid "Platforms, last {0} days"
 msgstr ""
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:161
+#: static/js/impala/stats/csv_keys.js:161 static/js/zamboni/stats-all.js:15442 static/js/zamboni/stats-min.js:5
 msgid "Platforms from {0} to {1}"
 msgstr ""
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:165
+#: static/js/impala/stats/csv_keys.js:165 static/js/zamboni/stats-all.js:15446 static/js/zamboni/stats-min.js:5
 msgid "Languages, last {0} days"
 msgstr ""
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:167
+#: static/js/impala/stats/csv_keys.js:167 static/js/zamboni/stats-all.js:15448 static/js/zamboni/stats-min.js:5
 msgid "Languages from {0} to {1}"
 msgstr ""
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:171
+#: static/js/impala/stats/csv_keys.js:171 static/js/zamboni/stats-all.js:15452 static/js/zamboni/stats-min.js:5
 msgid "Add-on Versions, last {0} days"
 msgstr ""
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:173
+#: static/js/impala/stats/csv_keys.js:173 static/js/zamboni/stats-all.js:15454 static/js/zamboni/stats-min.js:5
 msgid "Add-on Versions from {0} to {1}"
 msgstr ""
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:177
+#: static/js/impala/stats/csv_keys.js:177 static/js/zamboni/stats-all.js:15458 static/js/zamboni/stats-min.js:5
 msgid "Add-on Status, last {0} days"
 msgstr ""
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:179
+#: static/js/impala/stats/csv_keys.js:179 static/js/zamboni/stats-all.js:15460 static/js/zamboni/stats-min.js:5
 msgid "Add-on Status from {0} to {1}"
 msgstr ""
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:183
+#: static/js/impala/stats/csv_keys.js:183 static/js/zamboni/stats-all.js:15464 static/js/zamboni/stats-min.js:5
 msgid "Download Sources, last {0} days"
 msgstr ""
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:185
+#: static/js/impala/stats/csv_keys.js:185 static/js/zamboni/stats-all.js:15466 static/js/zamboni/stats-min.js:5
 msgid "Download Sources from {0} to {1}"
 msgstr ""
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:189
+#: static/js/impala/stats/csv_keys.js:189 static/js/zamboni/stats-all.js:15470 static/js/zamboni/stats-min.js:5
 msgid "Contributions, last {0} days"
 msgstr ""
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:191
+#: static/js/impala/stats/csv_keys.js:191 static/js/zamboni/stats-all.js:15472 static/js/zamboni/stats-min.js:5
 msgid "Contributions from {0} to {1}"
 msgstr ""
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:195
+#: static/js/impala/stats/csv_keys.js:195 static/js/zamboni/stats-all.js:15476 static/js/zamboni/stats-min.js:5
 msgid "Site Metrics, last {0} days"
 msgstr ""
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:197
+#: static/js/impala/stats/csv_keys.js:197 static/js/zamboni/stats-all.js:15478 static/js/zamboni/stats-min.js:5
 msgid "Site Metrics from {0} to {1}"
 msgstr ""
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:201
+#: static/js/impala/stats/csv_keys.js:201 static/js/zamboni/stats-all.js:15482 static/js/zamboni/stats-min.js:5
 msgid "Add-ons in Use, last {0} days"
 msgstr ""
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:203
+#: static/js/impala/stats/csv_keys.js:203 static/js/zamboni/stats-all.js:15484 static/js/zamboni/stats-min.js:5
 msgid "Add-ons in Use from {0} to {1}"
 msgstr ""
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:207
+#: static/js/impala/stats/csv_keys.js:207 static/js/zamboni/stats-all.js:15488 static/js/zamboni/stats-min.js:5
 msgid "Add-ons Downloaded, last {0} days"
 msgstr ""
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:209
+#: static/js/impala/stats/csv_keys.js:209 static/js/zamboni/stats-all.js:15490 static/js/zamboni/stats-min.js:5
 msgid "Add-ons Downloaded from {0} to {1}"
 msgstr ""
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:213
+#: static/js/impala/stats/csv_keys.js:213 static/js/zamboni/stats-all.js:15494 static/js/zamboni/stats-min.js:5
 msgid "Add-ons Created, last {0} days"
 msgstr ""
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:215
+#: static/js/impala/stats/csv_keys.js:215 static/js/zamboni/stats-all.js:15496 static/js/zamboni/stats-min.js:5
 msgid "Add-ons Created from {0} to {1}"
 msgstr ""
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:219
+#: static/js/impala/stats/csv_keys.js:219 static/js/zamboni/stats-all.js:15500 static/js/zamboni/stats-min.js:5
 msgid "Add-ons Updated, last {0} days"
 msgstr ""
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:221
+#: static/js/impala/stats/csv_keys.js:221 static/js/zamboni/stats-all.js:15502 static/js/zamboni/stats-min.js:5
 msgid "Add-ons Updated from {0} to {1}"
 msgstr ""
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:225
+#: static/js/impala/stats/csv_keys.js:225 static/js/zamboni/stats-all.js:15506 static/js/zamboni/stats-min.js:5
 msgid "Reviews Written, last {0} days"
 msgstr ""
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:227
+#: static/js/impala/stats/csv_keys.js:227 static/js/zamboni/stats-all.js:15508 static/js/zamboni/stats-min.js:5
 msgid "Reviews Written from {0} to {1}"
 msgstr ""
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:231
+#: static/js/impala/stats/csv_keys.js:231 static/js/zamboni/stats-all.js:15512 static/js/zamboni/stats-min.js:5
 msgid "User Signups, last {0} days"
 msgstr ""
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:233
+#: static/js/impala/stats/csv_keys.js:233 static/js/zamboni/stats-all.js:15514 static/js/zamboni/stats-min.js:5
 msgid "User Signups from {0} to {1}"
 msgstr ""
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:237
+#: static/js/impala/stats/csv_keys.js:237 static/js/zamboni/stats-all.js:15518 static/js/zamboni/stats-min.js:5
 msgid "Collections Created, last {0} days"
 msgstr ""
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:239
+#: static/js/impala/stats/csv_keys.js:239 static/js/zamboni/stats-all.js:15520 static/js/zamboni/stats-min.js:5
 msgid "Collections Created from {0} to {1}"
 msgstr ""
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:243
+#: static/js/impala/stats/csv_keys.js:243 static/js/zamboni/stats-all.js:15524 static/js/zamboni/stats-min.js:5
 msgid "Subscribers, last {0} days"
 msgstr ""
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:245
+#: static/js/impala/stats/csv_keys.js:245 static/js/zamboni/stats-all.js:15526 static/js/zamboni/stats-min.js:5
 msgid "Subscribers from {0} to {1}"
 msgstr ""
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:249
+#: static/js/impala/stats/csv_keys.js:249 static/js/zamboni/stats-all.js:15530 static/js/zamboni/stats-min.js:5
 msgid "Ratings, last {0} days"
 msgstr ""
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:251
+#: static/js/impala/stats/csv_keys.js:251 static/js/zamboni/stats-all.js:15532 static/js/zamboni/stats-min.js:5
 msgid "Ratings from {0} to {1}"
 msgstr ""
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:255
+#: static/js/impala/stats/csv_keys.js:255 static/js/zamboni/stats-all.js:15536 static/js/zamboni/stats-min.js:5
 msgid "Sales, last {0} days"
 msgstr ""
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:257
+#: static/js/impala/stats/csv_keys.js:257 static/js/zamboni/stats-all.js:15538 static/js/zamboni/stats-min.js:5
 msgid "Sales from {0} to {1}"
 msgstr ""
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:261
+#: static/js/impala/stats/csv_keys.js:261 static/js/zamboni/stats-all.js:15542 static/js/zamboni/stats-min.js:5
 msgid "Installs, last {0} days"
 msgstr ""
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:263
+#: static/js/impala/stats/csv_keys.js:263 static/js/zamboni/stats-all.js:15544 static/js/zamboni/stats-min.js:5
 msgid "Installs from {0} to {1}"
 msgstr ""
 
 #. L10n: {0} and {1} are integers.
-#: static/js/impala/stats/csv_keys.js:269
+#: static/js/impala/stats/csv_keys.js:269 static/js/zamboni/stats-all.js:15550 static/js/zamboni/stats-min.js:5
 msgid "<b>{0}</b> in last {1} days"
 msgstr ""
 
 #. L10n: {0} is an integer and {1} and {2} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:271 static/js/impala/stats/csv_keys.js:277
+#: static/js/impala/stats/csv_keys.js:271 static/js/impala/stats/csv_keys.js:277 static/js/zamboni/stats-all.js:15552 static/js/zamboni/stats-all.js:15558 static/js/zamboni/stats-min.js:5
 msgid "<b>{0}</b> from {1} to {2}"
 msgstr ""
 
 #. L10n: {0} and {1} are integers.
-#: static/js/impala/stats/csv_keys.js:275
+#: static/js/impala/stats/csv_keys.js:275 static/js/zamboni/stats-all.js:15556 static/js/zamboni/stats-min.js:5
 msgid "<b>{0}</b> average in last {1} days"
 msgstr ""
 
-#: static/js/impala/stats/overview.js:19
+#: static/js/impala/stats/overview.js:19 static/js/zamboni/stats-all.js:16469 static/js/zamboni/stats-min.js:5
 msgid "No data available."
 msgstr ""
 
-#: static/js/impala/stats/table.js:74
+#: static/js/impala/stats/table.js:74 static/js/zamboni/stats-all.js:17209 static/js/zamboni/stats-min.js:5
 msgid "Date"
 msgstr ""
 
-#: static/js/impala/stats/topchart.js:96
+#: static/js/impala/stats/topchart.js:96 static/js/zamboni/stats-all.js:16600 static/js/zamboni/stats-min.js:5
 msgid "Other"
 msgstr ""
 
-#: static/js/zamboni/admin_validation.js:24 static/js/zamboni/devhub.js:1229 static/js/zamboni/editors.js:295
+#: static/js/zamboni/admin-all.js:180 static/js/zamboni/admin-min.js:1 static/js/zamboni/admin_validation.js:24 static/js/zamboni/devhub-all.js:2408 static/js/zamboni/devhub-min.js:2
+#: static/js/zamboni/devhub.js:1229 static/js/zamboni/editors-all.js:15576 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:295
 msgid "Select an application first"
 msgstr ""
 
-#: static/js/zamboni/admin_validation.js:51
+#: static/js/zamboni/admin-all.js:207 static/js/zamboni/admin-min.js:1 static/js/zamboni/admin_validation.js:51
 msgid "Set {0} add-on to a max version of {1} and email the author."
 msgid_plural "Set {0} add-ons to a max version of {1} and email the authors."
 msgstr[0] ""
 msgstr[1] ""
 
-#: static/js/zamboni/admin_validation.js:54
+#: static/js/zamboni/admin-all.js:210 static/js/zamboni/admin-min.js:1 static/js/zamboni/admin_validation.js:54
 msgid "Email author of {2} add-on which failed validation."
 msgid_plural "Email authors of {2} add-ons which failed validation."
 msgstr[0] ""
 msgstr[1] ""
 
-#. L10n: {0} is an app name like Firefox.
-#: static/js/zamboni/buttons.js:66
-msgid "Accept and Install"
-msgstr ""
-
-#: static/js/zamboni/buttons.js:66
-msgid "Add to {0}"
-msgstr ""
-
-#: static/js/zamboni/buttons.js:71
-msgid "Download Now"
-msgstr ""
-
-#: static/js/zamboni/buttons.js:112
-msgid "Add-on has not been updated to support default-to-compatible."
-msgstr ""
-
-#: static/js/zamboni/buttons.js:117
-msgid "You need to be using Firefox 10.0 or higher."
-msgstr ""
-
-#: static/js/zamboni/buttons.js:129
-msgid "Mozilla has marked this version as incompatible with your Firefox version."
-msgstr ""
-
-#. L10n: {0} is an platform like Windows or Linux.
-#: static/js/zamboni/buttons.js:210
-msgid "Install for {0} anyway"
-msgstr ""
-
-#: static/js/zamboni/buttons.js:210
-msgid "Download for {0} anyway"
-msgstr ""
-
-#: static/js/zamboni/buttons.js:267
-msgid "Not available for your platform"
-msgstr ""
-
-#. L10n: {0} is an app name, {1} is the app version.
-#: static/js/zamboni/buttons.js:278 static/js/zamboni/buttons.js:315
-msgid "Not available for {0} {1}"
-msgstr ""
-
-#: static/js/zamboni/buttons.js:341
-msgid "Works with {app} {min} - {max}"
-msgstr ""
-
-#: static/js/zamboni/buttons.js:343
-msgid "View other versions"
-msgstr ""
-
-#: static/js/zamboni/buttons.js:391
-msgid "Only with Firefox — Get Firefox Now!"
-msgstr ""
-
-#: static/js/zamboni/buttons.js:507 static/js/zamboni/mobile/buttons.js:43
-msgid "Sorry, you need a Mozilla-based browser (such as Firefox) to install a search plugin."
-msgstr ""
-
-#: static/js/zamboni/collections.js:229
-msgid "Adding to Favorites&hellip;"
-msgstr ""
-
-#: static/js/zamboni/collections.js:232
-msgid "Removing Favorite&hellip;"
-msgstr ""
-
-#: static/js/zamboni/collections.js:235
-msgid "Add to Favorites"
-msgstr ""
-
-#: static/js/zamboni/collections.js:238
-msgid "Remove from Favorites"
-msgstr ""
-
-#: static/js/zamboni/collections.js:303
-msgid "Pending"
-msgstr ""
-
-#: static/js/zamboni/collections.js:304
-msgid "Add a comment"
-msgstr ""
-
-#: static/js/zamboni/collections.js:304
-msgid "Comment"
-msgstr ""
-
-#: static/js/zamboni/collections.js:305
-msgid "Remove this add-on from the collection"
-msgstr ""
-
-#: static/js/zamboni/collections.js:305 static/js/zamboni/collections.js:334
-msgid "Remove"
-msgstr ""
-
-#: static/js/zamboni/collections.js:334
-msgid "Remove this user as a contributor"
-msgstr ""
-
-#: static/js/zamboni/collections.js:346
-msgid "An email address is required."
-msgstr ""
-
-#: static/js/zamboni/collections.js:364
-msgid "You cannot add yourself as a contributor."
-msgstr ""
-
-#: static/js/zamboni/collections.js:366
-msgid "You have already added that user."
-msgstr ""
-
-#: static/js/zamboni/collections.js:573
-msgid "Add to favorites"
-msgstr ""
-
-#: static/js/zamboni/collections.js:577
-msgid "Remove from favorites"
-msgstr ""
-
-#: static/js/zamboni/collections.js:604
-msgid "Stop following"
-msgstr ""
-
-#: static/js/zamboni/devhub.js:110
+#: static/js/zamboni/devhub-all.js:1289 static/js/zamboni/devhub-min.js:1 static/js/zamboni/devhub.js:110
 msgid "Your browser does not support the video tag"
 msgstr ""
 
-#: static/js/zamboni/devhub.js:371
+#: static/js/zamboni/devhub-all.js:1550 static/js/zamboni/devhub-min.js:1 static/js/zamboni/devhub.js:371
 msgid "Changes Saved"
 msgstr ""
 
-#: static/js/zamboni/devhub.js:387
+#: static/js/zamboni/devhub-all.js:1566 static/js/zamboni/devhub-min.js:1 static/js/zamboni/devhub.js:387
 msgid "Enter a new author's email address"
 msgstr ""
 
-#: static/js/zamboni/devhub.js:536
+#: static/js/zamboni/devhub-all.js:1715 static/js/zamboni/devhub-min.js:1 static/js/zamboni/devhub.js:536
 msgid "There was an error uploading your file."
 msgstr ""
 
-#: static/js/zamboni/devhub.js:681
+#: static/js/zamboni/devhub-all.js:1860 static/js/zamboni/devhub-min.js:1 static/js/zamboni/devhub.js:681
 msgid "{files} file"
 msgid_plural "{files} files"
 msgstr[0] ""
 msgstr[1] ""
 
-#: static/js/zamboni/devhub.js:684
+#: static/js/zamboni/devhub-all.js:1863 static/js/zamboni/devhub-min.js:1 static/js/zamboni/devhub.js:684
 msgid "{reviews} user review"
 msgid_plural "{reviews} user reviews"
 msgstr[0] ""
 msgstr[1] ""
 
-#: static/js/zamboni/devhub.js:796
+#: static/js/zamboni/devhub-all.js:1975 static/js/zamboni/devhub-min.js:2 static/js/zamboni/devhub.js:796
 msgid "Learn more"
 msgstr ""
 
-#: static/js/zamboni/devhub.js:800
+#: static/js/zamboni/devhub-all.js:1979 static/js/zamboni/devhub-min.js:2 static/js/zamboni/devhub.js:800
 msgid "Example"
 msgstr ""
 
-#: static/js/zamboni/devhub.js:1130
+#: static/js/zamboni/devhub-all.js:2309 static/js/zamboni/devhub-min.js:2 static/js/zamboni/devhub.js:1130
 msgid "Image changes being processed"
 msgstr ""
 
-#: static/js/zamboni/devhub.js:1280
+#: static/js/zamboni/devhub-all.js:2459 static/js/zamboni/devhub-min.js:2 static/js/zamboni/devhub.js:1280
 msgid "Must be a valid e-mail address."
+msgstr ""
+
+#: static/js/zamboni/devhub-all.js:2613 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:80
+msgid "All tests passed successfully."
+msgstr ""
+
+#: static/js/zamboni/devhub-all.js:2616 static/js/zamboni/devhub-all.js:3011 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:83 static/js/zamboni/validator.js:478
+msgid "These tests were not run."
+msgstr ""
+
+#: static/js/zamboni/devhub-all.js:2664 static/js/zamboni/devhub-all.js:2677 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:131 static/js/zamboni/validator.js:144
+msgid "Tests"
+msgstr ""
+
+#: static/js/zamboni/devhub-all.js:2779 static/js/zamboni/devhub-all.js:3108 static/js/zamboni/devhub-all.js:3127 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:246
+#: static/js/zamboni/validator.js:575 static/js/zamboni/validator.js:594
+msgid "Error"
+msgstr ""
+
+#: static/js/zamboni/devhub-all.js:2780 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:247
+msgid "Warning"
+msgstr ""
+
+#: static/js/zamboni/devhub-all.js:2794 static/js/zamboni/devhub-min.js:2 static/js/zamboni/files-all.js:5657 static/js/zamboni/files-min.js:3 static/js/zamboni/files.js:411
+#: static/js/zamboni/validator.js:261
+msgid "Ignore this message in future updates"
+msgstr ""
+
+#: static/js/zamboni/devhub-all.js:2817 static/js/zamboni/devhub-min.js:2 static/js/zamboni/files-all.js:5663 static/js/zamboni/files-min.js:3 static/js/zamboni/files.js:417
+#: static/js/zamboni/validator.js:284
+msgid "Severity for automated signing:"
+msgstr ""
+
+#: static/js/zamboni/devhub-all.js:2832 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:299
+msgid "Suggestions for passing automated signing:"
+msgstr ""
+
+#: static/js/zamboni/devhub-all.js:2920 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:387
+msgid "Compatibility Tests"
+msgstr ""
+
+#: static/js/zamboni/devhub-all.js:2999 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:466
+msgid "Add-on failed validation."
+msgstr ""
+
+#: static/js/zamboni/devhub-all.js:3001 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:468
+msgid "Add-on passed validation."
+msgstr ""
+
+#: static/js/zamboni/devhub-all.js:3014 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:481
+msgid "{0} error"
+msgid_plural "{0} errors"
+msgstr[0] ""
+msgstr[1] ""
+
+#: static/js/zamboni/devhub-all.js:3016 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:483
+msgid "{0} warning"
+msgid_plural "{0} warnings"
+msgstr[0] ""
+msgstr[1] ""
+
+#: static/js/zamboni/devhub-all.js:3018 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:485
+msgid "{0} notice"
+msgid_plural "{0} notices"
+msgstr[0] ""
+msgstr[1] ""
+
+#: static/js/zamboni/devhub-all.js:3110 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:577
+msgid "Validation task could not complete or completed with errors"
+msgstr ""
+
+#: static/js/zamboni/devhub-all.js:3128 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:595
+msgid "Internal server error"
 msgstr ""
 
 #: static/js/zamboni/devhub_search.js:8
 msgid "No results found."
 msgstr ""
 
-#: static/js/zamboni/editors.js:121
+#: static/js/zamboni/editors-all.js:15402 static/js/zamboni/editors-min.js:4 static/js/zamboni/editors.js:121
 msgid "{name} was viewing this page first."
 msgstr ""
 
-#: static/js/zamboni/editors.js:171
+#: static/js/zamboni/editors-all.js:15452 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:171
 msgid "Receipt checked by app."
 msgstr ""
 
-#: static/js/zamboni/editors.js:173
+#: static/js/zamboni/editors-all.js:15454 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:173
 msgid "Receipt was not checked by app."
 msgstr ""
 
-#: static/js/zamboni/editors.js:244
+#: static/js/zamboni/editors-all.js:15525 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:244
 msgid "{name} was viewing this add-on first."
 msgstr ""
 
-#: static/js/zamboni/editors.js:255
+#: static/js/zamboni/editors-all.js:15536 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:255
 msgid "Loading&hellip;"
 msgstr ""
 
-#: static/js/zamboni/editors.js:260
+#: static/js/zamboni/editors-all.js:15541 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:260
 msgid "Version Notes"
 msgstr ""
 
-#: static/js/zamboni/editors.js:265
+#: static/js/zamboni/editors-all.js:15546 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:265
 msgid "Notes for Reviewers"
 msgstr ""
 
-#: static/js/zamboni/editors.js:270
+#: static/js/zamboni/editors-all.js:15551 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:270
 msgid "No version notes found"
 msgstr ""
 
-#: static/js/zamboni/editors.js:330
+#: static/js/zamboni/editors-all.js:15611 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:330
 msgid "Average Reviews"
 msgstr ""
 
-#: static/js/zamboni/editors.js:386
+#: static/js/zamboni/editors-all.js:15667 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:386
 msgid "Number of Reviews"
 msgstr ""
 
-#: static/js/zamboni/editors.js:445
+#: static/js/zamboni/editors-all.js:15726 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:445
 msgid "Error loading translation"
 msgstr ""
 
-#: static/js/zamboni/files.js:411 static/js/zamboni/validator.js:261
-msgid "Ignore this message in future updates"
-msgstr ""
-
-#: static/js/zamboni/files.js:417 static/js/zamboni/validator.js:284
-msgid "Severity for automated signing:"
-msgstr ""
-
-#: static/js/zamboni/global.js:410
-msgid "Loading..."
-msgstr ""
-
-#. L10n: {0} is the number of characters left.
-#: static/js/zamboni/global.js:474
-msgid "<b>{0}</b> character left."
-msgid_plural "<b>{0}</b> characters left."
-msgstr[0] ""
-msgstr[1] ""
-
-#: static/js/zamboni/init.js:28
-msgid "This feature is temporarily disabled while we perform website maintenance. Please check back a little later."
-msgstr ""
-
-#: static/js/zamboni/l10n.js:45
-msgid "Remove this localization"
-msgstr ""
-
-#: static/js/zamboni/password-strength.js:20
-msgid "Password strength:"
-msgstr ""
-
-#: static/js/zamboni/password-strength.js:26
-msgid "At least {0} character left."
-msgid_plural "At least {0} characters left."
-msgstr[0] ""
-msgstr[1] ""
-
-#: static/js/zamboni/themes_review.js:176
-msgid "Requested Info"
-msgstr ""
-
-#: static/js/zamboni/themes_review.js:177
-msgid "Flagged"
-msgstr ""
-
-#: static/js/zamboni/themes_review.js:178
-msgid "Duplicate"
-msgstr ""
-
-#: static/js/zamboni/themes_review.js:179
-msgid "Rejected"
-msgstr ""
-
-#: static/js/zamboni/themes_review.js:180
-msgid "Approved"
-msgstr ""
-
-#: static/js/zamboni/themes_review.js:424
-msgid "No results found"
-msgstr ""
-
-#: static/js/zamboni/themes_review_templates.js:31
+#: static/js/zamboni/editors-all.js:15975 static/js/zamboni/editors-min.js:5 static/js/zamboni/themes_review_templates.js:31
 msgid "Theme"
 msgstr ""
 
-#: static/js/zamboni/themes_review_templates.js:33
+#: static/js/zamboni/editors-all.js:15977 static/js/zamboni/editors-min.js:5 static/js/zamboni/themes_review_templates.js:33
 msgid "Reviewer"
 msgstr ""
 
-#: static/js/zamboni/themes_review_templates.js:35
+#: static/js/zamboni/editors-all.js:15979 static/js/zamboni/editors-min.js:5 static/js/zamboni/themes_review_templates.js:35
 msgid "Status"
 msgstr ""
 
-#: static/js/zamboni/validator.js:80
-msgid "All tests passed successfully."
+#: static/js/zamboni/editors-all.js:16196 static/js/zamboni/editors-min.js:5 static/js/zamboni/themes_review.js:176
+msgid "Requested Info"
 msgstr ""
 
-#: static/js/zamboni/validator.js:83 static/js/zamboni/validator.js:478
-msgid "These tests were not run."
+#: static/js/zamboni/editors-all.js:16197 static/js/zamboni/editors-min.js:5 static/js/zamboni/themes_review.js:177
+msgid "Flagged"
 msgstr ""
 
-#: static/js/zamboni/validator.js:131 static/js/zamboni/validator.js:144
-msgid "Tests"
+#: static/js/zamboni/editors-all.js:16198 static/js/zamboni/editors-min.js:5 static/js/zamboni/themes_review.js:178
+msgid "Duplicate"
 msgstr ""
 
-#: static/js/zamboni/validator.js:246 static/js/zamboni/validator.js:575 static/js/zamboni/validator.js:594
-msgid "Error"
+#: static/js/zamboni/editors-all.js:16199 static/js/zamboni/editors-min.js:5 static/js/zamboni/themes_review.js:179
+msgid "Rejected"
 msgstr ""
 
-#: static/js/zamboni/validator.js:247
-msgid "Warning"
+#: static/js/zamboni/editors-all.js:16200 static/js/zamboni/editors-min.js:5 static/js/zamboni/themes_review.js:180
+msgid "Approved"
 msgstr ""
 
-#: static/js/zamboni/validator.js:299
-msgid "Suggestions for passing automated signing:"
+#: static/js/zamboni/editors-all.js:16444 static/js/zamboni/editors-min.js:5 static/js/zamboni/themes_review.js:424
+msgid "No results found"
 msgstr ""
 
-#: static/js/zamboni/validator.js:387
-msgid "Compatibility Tests"
-msgstr ""
-
-#: static/js/zamboni/validator.js:466
-msgid "Add-on failed validation."
-msgstr ""
-
-#: static/js/zamboni/validator.js:468
-msgid "Add-on passed validation."
-msgstr ""
-
-#: static/js/zamboni/validator.js:481
-msgid "{0} error"
-msgid_plural "{0} errors"
-msgstr[0] ""
-msgstr[1] ""
-
-#: static/js/zamboni/validator.js:483
-msgid "{0} warning"
-msgid_plural "{0} warnings"
-msgstr[0] ""
-msgstr[1] ""
-
-#: static/js/zamboni/validator.js:485
-msgid "{0} notice"
-msgid_plural "{0} notices"
-msgstr[0] ""
-msgstr[1] ""
-
-#: static/js/zamboni/validator.js:577
-msgid "Validation task could not complete or completed with errors"
-msgstr ""
-
-#: static/js/zamboni/validator.js:595
-msgid "Internal server error"
-msgstr ""
-
-#: static/js/zamboni/mobile/buttons.js:52
+#: static/js/zamboni/mobile-all.js:15186 static/js/zamboni/mobile/buttons.js:52
 msgid "Not Updated for {0} {1}"
 msgstr ""
 
-#: static/js/zamboni/mobile/buttons.js:53
+#: static/js/zamboni/mobile-all.js:15187 static/js/zamboni/mobile/buttons.js:53
 msgid "Requires Newer Version of {0}"
 msgstr ""
 
-#: static/js/zamboni/mobile/buttons.js:54
+#: static/js/zamboni/mobile-all.js:15188 static/js/zamboni/mobile/buttons.js:54
 msgid "Unreviewed"
 msgstr ""
 
-#: static/js/zamboni/mobile/buttons.js:55
+#: static/js/zamboni/mobile-all.js:15189 static/js/zamboni/mobile/buttons.js:55
 msgid "Experimental <span>(Learn More)</span>"
 msgstr ""
 
-#: static/js/zamboni/mobile/buttons.js:56 static/js/zamboni/mobile/buttons.js:57
+#: static/js/zamboni/mobile-all.js:15190 static/js/zamboni/mobile-all.js:15191 static/js/zamboni/mobile/buttons.js:56 static/js/zamboni/mobile/buttons.js:57
 msgid "Not Available for {0}"
 msgstr ""
 
-#: static/js/zamboni/mobile/buttons.js:58
+#: static/js/zamboni/mobile-all.js:15192 static/js/zamboni/mobile/buttons.js:58
 msgid "Experimental"
 msgstr ""
 
-#: static/js/zamboni/mobile/buttons.js:59
+#: static/js/zamboni/mobile-all.js:15193 static/js/zamboni/mobile/buttons.js:59
 msgid "Themes Require Newer Version of {0}"
 msgstr ""
 
-#: static/js/zamboni/mobile/buttons.js:60
+#: static/js/zamboni/mobile-all.js:15194 static/js/zamboni/mobile/buttons.js:60
 msgid "Themes Require {0}"
 msgstr ""
 
-#: static/js/zamboni/mobile/buttons.js:105
+#: static/js/zamboni/mobile-all.js:15239 static/js/zamboni/mobile/buttons.js:105
 msgid "Installing..."
 msgstr ""
 
-#: static/js/zamboni/mobile/buttons.js:125
+#: static/js/zamboni/mobile-all.js:15259 static/js/zamboni/mobile/buttons.js:125
 msgid "This add-on has been preliminarily reviewed by Mozilla."
 msgstr ""
 
-#: static/js/zamboni/mobile/buttons.js:250
+#: static/js/zamboni/mobile-all.js:15384 static/js/zamboni/mobile/buttons.js:250
 msgid "Keep it"
 msgstr ""
 
-#: static/js/zamboni/mobile/general.js:344
+#: static/js/zamboni/mobile-all.js:16049 static/js/zamboni/mobile-min.js:6 static/js/zamboni/mobile/general.js:344
 msgid "You're trying it on!"
 msgstr ""
 
-#: static/js/zamboni/mobile/general.js:356
+#: static/js/zamboni/mobile-all.js:16061 static/js/zamboni/mobile-min.js:6 static/js/zamboni/mobile/general.js:356
 msgid "Added to Firefox"
 msgstr ""
-

--- a/locale/he/LC_MESSAGES/django.po
+++ b/locale/he/LC_MESSAGES/django.po
@@ -7,71 +7,72 @@ msgid ""
 msgstr ""
 "Project-Id-Version: REMORA 0.1\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2016-02-24 21:23+0000\n"
+"POT-Creation-Date: 2016-04-18 15:47+0000\n"
 "PO-Revision-Date: 2012-03-17 13:10+0200\n"
 "Last-Translator: amire80 <amir.aharoni@mail.huji.ac.il>\n"
 "Language-Team: Hebrew\n"
+"Language: \n"
 "MIME-Version: 1.0\n"
-"Content-Type: text/plain; charset=utf-8\n"
+"Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Generated-By: Babel 2.2.0\n"
 
-#: src/olympia/accounts/views.py:52
+#: src/olympia/accounts/views.py:54
 msgid "Your log in attempt could not be parsed. Please try again."
 msgstr ""
 
-#: src/olympia/accounts/views.py:54
+#: src/olympia/accounts/views.py:56
 msgid "Your Firefox Account could not be found. Please try again."
 msgstr ""
 
-#: src/olympia/accounts/views.py:55
+#: src/olympia/accounts/views.py:57
 msgid "You could not be logged in. Please try again."
 msgstr ""
 
-#: src/olympia/accounts/views.py:57
+#: src/olympia/accounts/views.py:59
 msgid "Your account has already been migrated to Firefox Accounts."
 msgstr ""
 
-#: src/olympia/accounts/views.py:59
+#: src/olympia/accounts/views.py:61
 msgid "Your Firefox Account already exists on this site."
 msgstr ""
 
-#: src/olympia/accounts/views.py:108
+#: src/olympia/accounts/views.py:110
 msgid "Great job!"
 msgstr ""
 
-#: src/olympia/accounts/views.py:109
+#: src/olympia/accounts/views.py:111
 msgid "You can now log in to Add-ons with your Firefox Account."
 msgstr ""
 
-#: src/olympia/accounts/views.py:121
+#: src/olympia/accounts/views.py:123
 msgid "Need help?"
 msgstr ""
 
-#: src/olympia/addons/buttons.py:180
+#: src/olympia/addons/buttons.py:177
 msgid "Download Now"
 msgstr "להוריד עכשיו"
 
 # 88%
 # 100%
-#: src/olympia/addons/buttons.py:182
+#: src/olympia/addons/buttons.py:179
 msgid "Download"
 msgstr "להוריד"
 
 #. L10n: please keep &nbsp; in the string so &rarr; does not wrap.
-#: src/olympia/addons/buttons.py:186
+#: src/olympia/addons/buttons.py:183
 msgid "Continue to Download&nbsp;&rarr;"
 msgstr "מעבר להורדה&nbsp;&larr;"
 
-#: src/olympia/addons/buttons.py:202 src/olympia/addons/helpers.py:35 src/olympia/addons/views.py:319 src/olympia/addons/templates/addons/impala/details.html:114
+#: src/olympia/addons/buttons.py:199 src/olympia/addons/helpers.py:35 src/olympia/addons/views.py:333 src/olympia/addons/templates/addons/impala/details.html:111
 #: src/olympia/addons/templates/addons/impala/listing/items.html:17 src/olympia/addons/templates/addons/mobile/home.html:40 src/olympia/amo/templates/amo/side_nav.html:6
-#: src/olympia/amo/templates/amo/side_nav.html:10 src/olympia/amo/templates/amo/site_nav.html:2 src/olympia/amo/templates/amo/site_nav.html:55 src/olympia/bandwagon/views.py:95
-#: src/olympia/browse/views.py:54 src/olympia/browse/views.py:68 src/olympia/browse/views.py:235 src/olympia/browse/templates/browse/impala/category_landing.html:22
+#: src/olympia/amo/templates/amo/side_nav.html:10 src/olympia/amo/templates/amo/site_nav.html:2 src/olympia/amo/templates/amo/site_nav.html:53 src/olympia/bandwagon/views.py:95
+#: src/olympia/browse/views.py:54 src/olympia/browse/views.py:68 src/olympia/browse/views.py:202 src/olympia/browse/templates/browse/impala/category_landing.html:22
 #: src/olympia/browse/templates/browse/personas/mobile/category_landing.html:26
 msgid "Featured"
 msgstr ""
 
-#: src/olympia/addons/buttons.py:221
+#: src/olympia/addons/buttons.py:218
 msgid "Add to {0}"
 msgstr "הוספה אל {0}"
 
@@ -119,39 +120,39 @@ msgid_plural "All tags must be at least {0} characters."
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/olympia/addons/forms.py:234
+#: src/olympia/addons/forms.py:238
 msgid "Categories cannot be changed while your add-on is featured for this application."
 msgstr ""
 
 #. L10n: {0} is the number of categories.
-#: src/olympia/addons/forms.py:238
+#: src/olympia/addons/forms.py:242
 msgid "You can have only {0} category."
 msgid_plural "You can have only {0} categories."
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/olympia/addons/forms.py:246
+#: src/olympia/addons/forms.py:250
 msgid "The miscellaneous category cannot be combined with additional categories."
 msgstr ""
 
-#: src/olympia/addons/forms.py:369
+#: src/olympia/addons/forms.py:374
 #, python-format
 msgid "Before changing your default locale you must have a name, summary, and description in that locale. You are missing %s."
 msgstr ""
 
-#: src/olympia/addons/forms.py:484 src/olympia/addons/forms.py:575
+#: src/olympia/addons/forms.py:455 src/olympia/addons/forms.py:546
 msgid "A license must be selected."
 msgstr ""
 
-#: src/olympia/addons/forms.py:556
+#: src/olympia/addons/forms.py:527
 msgid "Give Your Theme a Name."
 msgstr ""
 
-#: src/olympia/addons/forms.py:562 src/olympia/devhub/templates/devhub/personas/submit.html:53
+#: src/olympia/addons/forms.py:533 src/olympia/devhub/templates/devhub/personas/submit.html:53
 msgid "Describe your Theme."
 msgstr ""
 
-#: src/olympia/addons/forms.py:704
+#: src/olympia/addons/forms.py:675
 msgid "Enter a new author's email address"
 msgstr ""
 
@@ -159,41 +160,41 @@ msgstr ""
 msgid "Not Reviewed"
 msgstr ""
 
-#: src/olympia/addons/models.py:301
+#: src/olympia/addons/models.py:298
 msgid "Users have the option of contributing more or less than this amount."
 msgstr "למשתמשים יש אפשרות לתרום יותר או פחות מהסכום הזה."
 
-#: src/olympia/addons/models.py:309
-msgid "Users will always be asked in the Add-ons Manager (Firefox 4 and above)"
+#: src/olympia/addons/models.py:306
+msgid "Users will always be asked in the Add-ons Manager (Firefox 4 and above). Only applies to desktop."
 msgstr ""
 
 # Column name in a table.
-#: src/olympia/addons/models.py:1804 src/olympia/addons/templates/addons/details_box.html:55 src/olympia/devhub/templates/devhub/index.html:92
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:102
+#: src/olympia/addons/models.py:1802 src/olympia/addons/templates/addons/details_box.html:55 src/olympia/devhub/templates/devhub/index.html:92
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:89
 msgid "Listed"
 msgstr "ברשימה"
 
-#: src/olympia/addons/views.py:320 src/olympia/browse/templates/browse/personas/mobile/category_landing.html:27
+#: src/olympia/addons/views.py:334 src/olympia/browse/templates/browse/personas/mobile/category_landing.html:27
 msgid "Popular"
 msgstr "פופולרי"
 
-#: src/olympia/addons/views.py:321 src/olympia/browse/views.py:238 src/olympia/browse/views.py:280 src/olympia/browse/views.py:482
+#: src/olympia/addons/views.py:335 src/olympia/browse/views.py:205 src/olympia/browse/views.py:247 src/olympia/browse/views.py:449
 msgid "Recently Added"
 msgstr "התווסף לאחרונה"
 
 # 75%
 # 100%
-#: src/olympia/addons/views.py:322 src/olympia/bandwagon/views.py:99 src/olympia/browse/views.py:60 src/olympia/browse/views.py:71 src/olympia/search/forms.py:16 src/olympia/search/forms.py:91
+#: src/olympia/addons/views.py:336 src/olympia/bandwagon/views.py:99 src/olympia/browse/views.py:60 src/olympia/browse/views.py:71 src/olympia/search/forms.py:16 src/olympia/search/forms.py:91
 msgid "Recently Updated"
 msgstr "עודכן לאחרונה"
 
 # %1 is an add-on name.
 #. l10n: {0} is the addon name
-#: src/olympia/addons/views.py:520
+#: src/olympia/addons/views.py:534
 msgid "Contribution for {0}"
 msgstr "תרומה עבור {0}"
 
-#: src/olympia/addons/views.py:613
+#: src/olympia/addons/views.py:627
 msgid "Abuse reported."
 msgstr "השימוש לרעה דווח."
 
@@ -262,9 +263,9 @@ msgstr "לתרום"
 #: src/olympia/devhub/templates/devhub/addons/ajax_compat_update.html:36 src/olympia/devhub/templates/devhub/addons/profile.html:44 src/olympia/devhub/templates/devhub/addons/edit/admin.html:101
 #: src/olympia/devhub/templates/devhub/addons/edit/basic.html:152 src/olympia/devhub/templates/devhub/addons/edit/details.html:85 src/olympia/devhub/templates/devhub/addons/edit/support.html:67
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:166 src/olympia/devhub/templates/devhub/addons/forms_shared/media.html:149
-#: src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:44 src/olympia/devhub/templates/devhub/versions/add_file_modal.html:78 src/olympia/devhub/templates/devhub/versions/edit.html:139
-#: src/olympia/devhub/templates/devhub/versions/list.html:242 src/olympia/devhub/templates/devhub/versions/list.html:276 src/olympia/devhub/templates/devhub/versions/list.html:317
-#: src/olympia/devhub/templates/devhub/versions/list.html:351 src/olympia/reviews/templates/reviews/edit_review.html:16 src/olympia/translations/templates/translations/trans-menu.html:50
+#: src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:43 src/olympia/devhub/templates/devhub/versions/add_file_modal.html:58 src/olympia/devhub/templates/devhub/versions/edit.html:139
+#: src/olympia/devhub/templates/devhub/versions/list.html:239 src/olympia/devhub/templates/devhub/versions/list.html:281 src/olympia/devhub/templates/devhub/versions/list.html:315
+#: src/olympia/devhub/templates/devhub/versions/list.html:349 src/olympia/reviews/templates/reviews/edit_review.html:16 src/olympia/translations/templates/translations/trans-menu.html:50
 #: src/olympia/translations/templates/translations/trans-menu.html:62
 msgid "or"
 msgstr "או"
@@ -376,7 +377,7 @@ msgid "Add-on Information for {0}"
 msgstr "מידע על בתוספת עבור {0}"
 
 #: src/olympia/addons/templates/addons/details_box.html:30 src/olympia/addons/templates/addons/persona_detail_table.html:3 src/olympia/addons/templates/addons/mobile/details.html:63
-#: src/olympia/addons/templates/addons/mobile/persona_detail_table.html:7 src/olympia/browse/views.py:459 src/olympia/devhub/views.py:75
+#: src/olympia/addons/templates/addons/mobile/persona_detail_table.html:7 src/olympia/browse/views.py:426 src/olympia/devhub/views.py:73
 msgid "Updated"
 msgstr "התעדכן"
 
@@ -395,11 +396,11 @@ msgstr "עובד עם"
 msgid "Visibility"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/details_box.html:57 src/olympia/devhub/templates/devhub/index.html:94 src/olympia/devhub/templates/devhub/includes/addon_details.html:104
+#: src/olympia/addons/templates/addons/details_box.html:57 src/olympia/devhub/templates/devhub/index.html:94 src/olympia/devhub/templates/devhub/includes/addon_details.html:91
 msgid "Hidden"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/details_box.html:59 src/olympia/devhub/templates/devhub/index.html:96 src/olympia/devhub/templates/devhub/includes/addon_details.html:106
+#: src/olympia/addons/templates/addons/details_box.html:59 src/olympia/devhub/templates/devhub/index.html:96 src/olympia/devhub/templates/devhub/includes/addon_details.html:93
 msgid "Unlisted"
 msgstr ""
 
@@ -408,14 +409,14 @@ msgid "Required Add-ons"
 msgstr ""
 
 # 100%
-#: src/olympia/addons/templates/addons/details_box.html:81 src/olympia/addons/templates/addons/persona_detail_table.html:15 src/olympia/browse/views.py:462 src/olympia/devhub/views.py:78
-#: src/olympia/devhub/views.py:85 src/olympia/discovery/templates/discovery/addons/detail.html:57 src/olympia/reviews/forms.py:62 src/olympia/reviews/templates/reviews/add.html:57
+#: src/olympia/addons/templates/addons/details_box.html:81 src/olympia/addons/templates/addons/persona_detail_table.html:15 src/olympia/browse/views.py:429 src/olympia/devhub/views.py:76
+#: src/olympia/devhub/views.py:83 src/olympia/discovery/templates/discovery/addons/detail.html:57 src/olympia/reviews/forms.py:62 src/olympia/reviews/templates/reviews/add.html:57
 #: src/olympia/reviews/templates/reviews/mobile/review_list.html:18
 msgid "Rating"
 msgstr "דירוג"
 
 # 100%
-#: src/olympia/addons/templates/addons/details_box.html:85 src/olympia/browse/views.py:461 src/olympia/devhub/views.py:77 src/olympia/devhub/views.py:84
+#: src/olympia/addons/templates/addons/details_box.html:85 src/olympia/browse/views.py:428 src/olympia/devhub/views.py:75 src/olympia/devhub/views.py:82
 #: src/olympia/stats/templates/stats/addon_report_menu.html:8 src/olympia/stats/templates/stats/collection_report_menu.html:18
 msgid "Downloads"
 msgstr "הורדות"
@@ -435,7 +436,7 @@ msgstr ""
 
 #. The Privacy Policy for this add-on.
 #: src/olympia/addons/templates/addons/details_box.html:121 src/olympia/addons/templates/addons/privacy.html:19 src/olympia/addons/templates/addons/privacy.html:23
-#: src/olympia/addons/templates/addons/impala/button.html:43 src/olympia/addons/templates/addons/impala/details.html:307 src/olympia/devhub/templates/devhub/includes/policy_form.html:20
+#: src/olympia/addons/templates/addons/impala/button.html:43 src/olympia/addons/templates/addons/impala/details.html:312 src/olympia/devhub/templates/devhub/includes/policy_form.html:23
 #: src/olympia/templates/mobile/base_addons.html:87
 msgid "Privacy Policy"
 msgstr "מדיניות פרטיות"
@@ -463,7 +464,7 @@ msgstr "גלריית תמונות"
 msgid "Developer Comments"
 msgstr "הערות מפתח"
 
-#: src/olympia/addons/templates/addons/details_box.html:199 src/olympia/addons/templates/addons/impala/details.html:259
+#: src/olympia/addons/templates/addons/details_box.html:199 src/olympia/addons/templates/addons/impala/details.html:264
 msgid "Development Channel"
 msgstr "ערוץ פיתוח"
 
@@ -483,7 +484,7 @@ msgid ""
 "developer. To stop receiving development updates, reinstall the default version from the link above."
 msgstr ""
 
-#: src/olympia/addons/templates/addons/details_box.html:220 src/olympia/addons/templates/addons/impala/details.html:278
+#: src/olympia/addons/templates/addons/details_box.html:220 src/olympia/addons/templates/addons/impala/details.html:283
 msgid "Version {0}:"
 msgstr "גרסה {0}:"
 
@@ -504,7 +505,7 @@ msgid "End-User License Agreement for {0}"
 msgstr "הסכם רישיון עם משתמש קצה עבור {0}"
 
 #: src/olympia/addons/templates/addons/eula.html:17 src/olympia/addons/templates/addons/eula.html:21 src/olympia/addons/templates/addons/impala/button.html:48
-#: src/olympia/addons/templates/addons/impala/details.html:316 src/olympia/devhub/templates/devhub/includes/policy_form.html:3 src/olympia/discovery/templates/discovery/addons/eula.html:11
+#: src/olympia/addons/templates/addons/impala/details.html:321 src/olympia/devhub/templates/devhub/includes/policy_form.html:3 src/olympia/discovery/templates/discovery/addons/eula.html:11
 msgid "End-User License Agreement"
 msgstr "הסכם רישיון עם משתמש קצה"
 
@@ -523,7 +524,7 @@ msgstr "חזרה אל {0}"
 msgid "Add-ons for {0}"
 msgstr "תוספות עבור {0}"
 
-#: src/olympia/addons/templates/addons/home.html:10 src/olympia/addons/templates/addons/home.html:51 src/olympia/browse/templates/browse/impala/base_listing.html:11
+#: src/olympia/addons/templates/addons/home.html:10 src/olympia/addons/templates/addons/home.html:53 src/olympia/browse/templates/browse/impala/base_listing.html:11
 msgid "Featured Extensions"
 msgstr "תוספות מומלצות"
 
@@ -531,31 +532,31 @@ msgstr "תוספות מומלצות"
 msgid "Popular Extensions"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/home.html:42 src/olympia/amo/templates/amo/side_nav.html:3 src/olympia/amo/templates/amo/side_nav.html:11 src/olympia/amo/templates/amo/site_nav.html:3
-#: src/olympia/amo/templates/amo/site_nav.html:25 src/olympia/browse/views.py:236 src/olympia/browse/views.py:281 src/olympia/browse/views.py:481
+#: src/olympia/addons/templates/addons/home.html:44 src/olympia/amo/templates/amo/side_nav.html:3 src/olympia/amo/templates/amo/side_nav.html:11 src/olympia/amo/templates/amo/site_nav.html:3
+#: src/olympia/amo/templates/amo/site_nav.html:25 src/olympia/browse/views.py:203 src/olympia/browse/views.py:248 src/olympia/browse/views.py:448
 msgid "Most Popular"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/home.html:43
+#: src/olympia/addons/templates/addons/home.html:45
 msgid "All »"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/home.html:52 src/olympia/addons/templates/addons/home.html:61 src/olympia/addons/templates/addons/home.html:70 src/olympia/addons/templates/addons/home.html:78
+#: src/olympia/addons/templates/addons/home.html:54 src/olympia/addons/templates/addons/home.html:63 src/olympia/addons/templates/addons/home.html:72 src/olympia/addons/templates/addons/home.html:80
 #: src/olympia/browse/templates/browse/impala/category_landing.html:36
 msgid "See all »"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/home.html:60
+#: src/olympia/addons/templates/addons/home.html:62
 msgid "Up &amp; Coming Extensions"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/home.html:69 src/olympia/browse/templates/browse/personas/category_landing.html:61 src/olympia/discovery/templates/discovery/pane.html:74
+#: src/olympia/addons/templates/addons/home.html:71 src/olympia/browse/templates/browse/personas/category_landing.html:61 src/olympia/discovery/templates/discovery/pane.html:74
 msgid "Featured Themes"
 msgstr ""
 
 # 80%
 # 100%
-#: src/olympia/addons/templates/addons/home.html:77 src/olympia/bandwagon/templates/bandwagon/impala/collection_listing.html:5
+#: src/olympia/addons/templates/addons/home.html:79 src/olympia/bandwagon/templates/bandwagon/impala/collection_listing.html:5
 #, fuzzy
 msgid "Featured Collections"
 msgstr "אוספים קשורים"
@@ -574,7 +575,7 @@ msgid "Updated {0}"
 msgstr ""
 
 #. {0} is a date.
-#: src/olympia/addons/templates/addons/macros.html:10 src/olympia/addons/templates/addons/macros.html:69 src/olympia/addons/templates/addons/persona_preview.html:21
+#: src/olympia/addons/templates/addons/macros.html:10 src/olympia/addons/templates/addons/macros.html:69 src/olympia/addons/templates/addons/persona_preview.html:22
 #: src/olympia/addons/templates/addons/listing/items_mobile.html:44 src/olympia/addons/templates/addons/listing/macros.html:39
 #: src/olympia/bandwagon/templates/bandwagon/collection_listing_items.html:37 src/olympia/bandwagon/templates/bandwagon/impala/collection_listing_items.html:37
 msgid "Added {0}"
@@ -595,15 +596,14 @@ msgstr[0] ""
 msgstr[1] ""
 
 #. {0} is the number of downloads.
-#: src/olympia/addons/templates/addons/macros.html:53 src/olympia/addons/templates/addons/impala/details.html:61
+#: src/olympia/addons/templates/addons/macros.html:53 src/olympia/addons/templates/addons/impala/details.html:59
 msgid "{0} weekly download"
 msgid_plural "{0} weekly downloads"
 msgstr[0] "הורדה אחת בשבוע"
 msgstr[1] "{0} הורדות בשבוע"
 
 #. {0} is the number of users.
-#: src/olympia/addons/templates/addons/macros.html:61 src/olympia/addons/templates/addons/impala/details.html:54 src/olympia/compat/templates/compat/index.html:71
-#: src/olympia/zadmin/templates/zadmin/compat.html:67
+#: src/olympia/addons/templates/addons/macros.html:61 src/olympia/addons/templates/addons/impala/details.html:52 src/olympia/zadmin/templates/zadmin/compat.html:67
 msgid "{0} user"
 msgid_plural "{0} users"
 msgstr[0] "משתמש אחד"
@@ -621,7 +621,7 @@ msgstr ""
 msgid "Return to the addon."
 msgstr ""
 
-#: src/olympia/addons/templates/addons/persona_detail.html:17 src/olympia/addons/templates/addons/impala/details.html:106 src/olympia/addons/templates/addons/mobile/details.html:23
+#: src/olympia/addons/templates/addons/persona_detail.html:17 src/olympia/addons/templates/addons/impala/details.html:103 src/olympia/addons/templates/addons/mobile/details.html:23
 #: src/olympia/addons/templates/addons/mobile/persona_detail.html:21 src/olympia/discovery/templates/discovery/addons/base.html:27 src/olympia/editors/templates/editors/review.html:31
 msgid "by"
 msgstr "מאת"
@@ -665,34 +665,35 @@ msgstr ""
 msgid "License"
 msgstr "רישיון"
 
-#: src/olympia/addons/templates/addons/persona_preview.html:12 src/olympia/constants/base.py:48
+#: src/olympia/addons/templates/addons/persona_preview.html:13 src/olympia/constants/base.py:48
 msgid "Awaiting Review"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/persona_preview.html:14 src/olympia/amo/log.py:180 src/olympia/constants/base.py:42 src/olympia/editors/helpers.py:62
+#: src/olympia/addons/templates/addons/persona_preview.html:15 src/olympia/amo/log.py:180 src/olympia/constants/base.py:42 src/olympia/editors/helpers.py:62
 msgid "Rejected"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/persona_preview.html:16 src/olympia/amo/log.py:159
+#: src/olympia/addons/templates/addons/persona_preview.html:17 src/olympia/amo/log.py:159
 msgid "Approved"
 msgstr ""
 
 #. {0} is the number of users.
-#: src/olympia/addons/templates/addons/persona_preview.html:26 src/olympia/addons/templates/addons/listing/items_mobile.html:36 src/olympia/addons/templates/addons/listing/macros.html:31
+#: src/olympia/addons/templates/addons/persona_preview.html:27 src/olympia/addons/templates/addons/listing/items_mobile.html:36 src/olympia/addons/templates/addons/listing/macros.html:31
 msgid "<strong>{0}</strong> user"
 msgid_plural "<strong>{0}</strong> users"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/olympia/addons/templates/addons/persona_preview.html:40
+#: src/olympia/addons/templates/addons/persona_preview.html:41
 msgid "Hover to Preview"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/persona_preview.html:46 src/olympia/addons/templates/addons/persona_preview.html:48 src/olympia/reviews/templates/reviews/add.html:15
+#: src/olympia/addons/templates/addons/persona_preview.html:47 src/olympia/addons/templates/addons/persona_preview.html:49 src/olympia/addons/templates/addons/persona_preview.html:97
+#: src/olympia/reviews/templates/reviews/add.html:15
 msgid "Add"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/persona_preview.html:57 src/olympia/bandwagon/templates/bandwagon/ajax_new.html:16 src/olympia/bandwagon/templates/bandwagon/edit.html:19
+#: src/olympia/addons/templates/addons/persona_preview.html:58 src/olympia/bandwagon/templates/bandwagon/ajax_new.html:16 src/olympia/bandwagon/templates/bandwagon/edit.html:19
 #: src/olympia/bandwagon/templates/bandwagon/includes/addedit.html:19 src/olympia/devhub/templates/devhub/addons/edit/admin.html:13 src/olympia/devhub/templates/devhub/addons/edit/basic.html:10
 #: src/olympia/devhub/templates/devhub/addons/edit/details.html:8 src/olympia/devhub/templates/devhub/addons/edit/media.html:6 src/olympia/devhub/templates/devhub/addons/edit/support.html:8
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:9 src/olympia/devhub/templates/devhub/addons/submit/describe.html:29 src/olympia/editors/templates/editors/review.html:257
@@ -701,21 +702,21 @@ msgstr ""
 
 #. For datetime formatting, see the table on
 #. http://docs.python.org/library/datetime.html#strftime-and-strptime-behavior
-#: src/olympia/addons/templates/addons/persona_preview.html:66
+#: src/olympia/addons/templates/addons/persona_preview.html:67
 #, python-format
 msgid "%%Y-%%m-%%d"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/persona_preview.html:67
+#: src/olympia/addons/templates/addons/persona_preview.html:68
 msgid "by {0} on {1}"
 msgstr "מאת {0} בתאריך {1}"
 
-#: src/olympia/addons/templates/addons/persona_preview.html:75 src/olympia/reviews/helpers.py:17 src/olympia/reviews/templates/reviews/review_list.html:63
+#: src/olympia/addons/templates/addons/persona_preview.html:76 src/olympia/reviews/helpers.py:17 src/olympia/reviews/templates/reviews/review_list.html:63
 #: src/olympia/reviews/templates/reviews/reviews_link.html:21 src/olympia/reviews/templates/reviews/impala/reviews_link.html:16
 msgid "Not yet rated"
 msgstr "טרם דורג"
 
-#: src/olympia/addons/templates/addons/persona_preview.html:78
+#: src/olympia/addons/templates/addons/persona_preview.html:79
 msgid "<b>{0}</b> users"
 msgstr ""
 
@@ -728,7 +729,7 @@ msgid "Learn more about Firefox"
 msgstr ""
 
 #: src/olympia/addons/templates/addons/popups.html:22
-msgid "or <b><a class=\"installer\" href=\"{url}\">download anyway</a></b>"
+msgid "or <b><a class=\"button installer\" href=\"{url}\">download anyway</a></b>"
 msgstr ""
 
 #: src/olympia/addons/templates/addons/popups.html:26
@@ -827,7 +828,7 @@ msgid ""
 msgstr ""
 
 #: src/olympia/addons/templates/addons/report_abuse.html:6 src/olympia/addons/templates/addons/report_abuse_full.html:10 src/olympia/addons/templates/addons/impala/details-more.html:23
-#: src/olympia/addons/templates/addons/impala/details.html:328
+#: src/olympia/addons/templates/addons/impala/details.html:333
 msgid "Report Abuse"
 msgstr ""
 
@@ -846,9 +847,9 @@ msgstr ""
 #: src/olympia/devhub/templates/devhub/addons/ajax_compat_update.html:36 src/olympia/devhub/templates/devhub/addons/profile.html:44 src/olympia/devhub/templates/devhub/addons/edit/admin.html:104
 #: src/olympia/devhub/templates/devhub/addons/edit/basic.html:155 src/olympia/devhub/templates/devhub/addons/edit/details.html:88 src/olympia/devhub/templates/devhub/addons/edit/support.html:70
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:169 src/olympia/devhub/templates/devhub/addons/forms_shared/media.html:152
-#: src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:44 src/olympia/devhub/templates/devhub/personas/edit.html:222 src/olympia/devhub/templates/devhub/versions/add_file_modal.html:79
-#: src/olympia/devhub/templates/devhub/versions/edit.html:140 src/olympia/devhub/templates/devhub/versions/list.html:208 src/olympia/devhub/templates/devhub/versions/list.html:242
-#: src/olympia/devhub/templates/devhub/versions/list.html:276 src/olympia/devhub/templates/devhub/versions/list.html:317 src/olympia/reviews/templates/reviews/edit_review.html:16
+#: src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:43 src/olympia/devhub/templates/devhub/personas/edit.html:222 src/olympia/devhub/templates/devhub/versions/add_file_modal.html:59
+#: src/olympia/devhub/templates/devhub/versions/edit.html:140 src/olympia/devhub/templates/devhub/versions/list.html:208 src/olympia/devhub/templates/devhub/versions/list.html:239
+#: src/olympia/devhub/templates/devhub/versions/list.html:281 src/olympia/devhub/templates/devhub/versions/list.html:315 src/olympia/reviews/templates/reviews/edit_review.html:16
 #: src/olympia/translations/templates/translations/trans-menu.html:50 src/olympia/translations/templates/translations/trans-menu.html:62 src/olympia/zadmin/templates/zadmin/validation.html:105
 msgid "Cancel"
 msgstr "ביטול"
@@ -893,7 +894,7 @@ msgstr ""
 msgid "Review Guidelines"
 msgstr "מדריך סקירה"
 
-#: src/olympia/addons/templates/addons/review_list_box.html:5 src/olympia/addons/templates/addons/impala/details-more.html:27 src/olympia/editors/helpers.py:921
+#: src/olympia/addons/templates/addons/review_list_box.html:5 src/olympia/addons/templates/addons/impala/details-more.html:27 src/olympia/editors/helpers.py:1001
 #: src/olympia/reviews/templates/reviews/add.html:14 src/olympia/reviews/templates/reviews/reply.html:14 src/olympia/reviews/templates/reviews/review_list.html:19
 #: src/olympia/reviews/templates/reviews/mobile/review_list.html:26
 msgid "Reviews"
@@ -985,31 +986,31 @@ msgid_plural "Other add-ons by these authors"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/olympia/addons/templates/addons/impala/details.html:41
+#: src/olympia/addons/templates/addons/impala/details.html:39
 #, python-format
 msgid "<span itemprop=\"ratingCount\">%(num)s</span> user review"
 msgid_plural "<span itemprop=\"ratingCount\">%(num)s</span> user reviews"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/olympia/addons/templates/addons/impala/details.html:69
+#: src/olympia/addons/templates/addons/impala/details.html:66
 msgid "View statistics"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/impala/details.html:84
+#: src/olympia/addons/templates/addons/impala/details.html:81
 msgid "Manage"
 msgstr ""
 
 #. {0} is an add-on name.
-#: src/olympia/addons/templates/addons/impala/details.html:96
+#: src/olympia/addons/templates/addons/impala/details.html:93
 msgid "Icon of {0}"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/impala/details.html:103 src/olympia/addons/templates/addons/impala/listing/items.html:14
+#: src/olympia/addons/templates/addons/impala/details.html:100 src/olympia/addons/templates/addons/impala/listing/items.html:14
 msgid "No Restart"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/impala/details.html:127
+#: src/olympia/addons/templates/addons/impala/details.html:124
 #, python-format
 msgid "Meet the Developer: <a href=\"%(url)s\">%(name)s</a>"
 msgid_plural "<a href=\"%(url)s\">Meet the Developers</a>"
@@ -1017,88 +1018,88 @@ msgstr[0] ""
 msgstr[1] ""
 
 # {0} is an add-on name.
-#: src/olympia/addons/templates/addons/impala/details.html:137
+#: src/olympia/addons/templates/addons/impala/details.html:134
 msgid "Learn why {0} was created and find out what's next for this add-on."
 msgstr "מידע על הסיבה שבגינה נוצרה התוספת {0} ועל עתידה."
 
 #. {0} is an index.
-#: src/olympia/addons/templates/addons/impala/details.html:156
+#: src/olympia/addons/templates/addons/impala/details.html:161
 msgid "Add-on screenshot #{0}"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/impala/details.html:182
+#: src/olympia/addons/templates/addons/impala/details.html:187
 msgid "Add-on home page"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/impala/details.html:185
+#: src/olympia/addons/templates/addons/impala/details.html:190
 msgid "Support site"
 msgstr "אתר תמיכה"
 
-#: src/olympia/addons/templates/addons/impala/details.html:189
+#: src/olympia/addons/templates/addons/impala/details.html:194
 msgid "Support E-mail"
 msgstr "כתוב דוא״ל לתמיכה"
 
-#: src/olympia/addons/templates/addons/impala/details.html:194 src/olympia/devhub/models.py:378 src/olympia/devhub/templates/devhub/versions/list.html:12
+#: src/olympia/addons/templates/addons/impala/details.html:199 src/olympia/devhub/models.py:378 src/olympia/devhub/templates/devhub/versions/list.html:12
 #: src/olympia/versions/templates/versions/version.html:6 src/olympia/versions/templates/versions/mobile/version.html:6
 msgid "Version {0}"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/impala/details.html:194
+#: src/olympia/addons/templates/addons/impala/details.html:199
 msgid "Info"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/impala/details.html:195 src/olympia/devhub/templates/devhub/includes/addon_details.html:129
+#: src/olympia/addons/templates/addons/impala/details.html:200 src/olympia/devhub/templates/devhub/includes/addon_details.html:116
 msgid "Last Updated:"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/impala/details.html:200
+#: src/olympia/addons/templates/addons/impala/details.html:205
 #, python-format
 msgid "Released under <a target=\"_blank\" href=\"%(url)s\">%(name)s</a>"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/impala/details.html:201 src/olympia/addons/templates/addons/impala/details.html:206 src/olympia/amo/helpers.py:398 src/olympia/devhub/forms.py:142
+#: src/olympia/addons/templates/addons/impala/details.html:206 src/olympia/addons/templates/addons/impala/details.html:211 src/olympia/amo/helpers.py:398 src/olympia/devhub/forms.py:142
 #: src/olympia/devhub/forms.py:173 src/olympia/versions/templates/versions/version.html:40 src/olympia/versions/templates/versions/version.html:45
 msgid "Custom License"
 msgstr "רישיון מותאם אישית"
 
-#: src/olympia/addons/templates/addons/impala/details.html:205
+#: src/olympia/addons/templates/addons/impala/details.html:210
 #, python-format
 msgid "Released under <a href=\"%(url)s\">%(name)s</a>"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/impala/details.html:217
+#: src/olympia/addons/templates/addons/impala/details.html:222
 msgid "About this Add-on"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/impala/details.html:233
+#: src/olympia/addons/templates/addons/impala/details.html:238
 msgid "Developer’s Comments"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/impala/details.html:243
+#: src/olympia/addons/templates/addons/impala/details.html:248
 msgid "Version Information"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/impala/details.html:250
+#: src/olympia/addons/templates/addons/impala/details.html:255
 msgid "See complete version history"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/impala/details.html:262
+#: src/olympia/addons/templates/addons/impala/details.html:267
 msgid ""
 "The Development Channel lets you test an experimental new version of this add-on before it's released to the general public. Once you install the development version, you will continue to get "
 "updates from this channel. To stop receiving development updates, reinstall the default version from the link above."
 msgstr ""
 
-#: src/olympia/addons/templates/addons/impala/details.html:272
+#: src/olympia/addons/templates/addons/impala/details.html:277
 msgid "<strong>Caution:</strong> Development versions of this add-on have not been reviewed by Mozilla."
 msgstr ""
 
-#: src/olympia/addons/templates/addons/impala/details.html:287
+#: src/olympia/addons/templates/addons/impala/details.html:292
 msgid "See complete development channel history"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/impala/details.html:306 src/olympia/addons/templates/addons/impala/details.html:315 src/olympia/addons/templates/addons/impala/details.html:327
+#: src/olympia/addons/templates/addons/impala/details.html:311 src/olympia/addons/templates/addons/impala/details.html:320 src/olympia/addons/templates/addons/impala/details.html:332
 #: src/olympia/addons/templates/addons/impala/review_add_box.html:4 src/olympia/stats/templates/stats/popup.html:2 src/olympia/stats/templates/stats/popup.html:8
-#: src/olympia/stats/templates/stats/stats.html:202 src/olympia/users/templates/users/profile.html:119
+#: src/olympia/stats/templates/stats/stats.html:204 src/olympia/users/templates/users/profile.html:119
 msgid "close"
 msgstr ""
 
@@ -1157,15 +1158,11 @@ msgstr "רישיון קוד מקור עבור {addon}"
 msgid "Source Code License"
 msgstr "רישיון קוד מקור"
 
-#: src/olympia/addons/templates/addons/impala/persona_grid.html:16 src/olympia/addons/templates/addons/impala/toplist.html:6
-msgid "{0} users"
-msgstr ""
-
 #: src/olympia/addons/templates/addons/impala/review_list_box.html:19 src/olympia/reviews/templates/reviews/review.html:40
 msgid "permalink"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/impala/review_list_box.html:23 src/olympia/editors/templates/editors/queue.html:98 src/olympia/reviews/templates/reviews/review.html:44
+#: src/olympia/addons/templates/addons/impala/review_list_box.html:23 src/olympia/editors/templates/editors/queue.html:104 src/olympia/reviews/templates/reviews/review.html:44
 msgid "translate"
 msgstr ""
 
@@ -1184,6 +1181,10 @@ msgstr ""
 msgid "Be the first!"
 msgstr "בוא להיות הראשון!"
 
+#: src/olympia/addons/templates/addons/impala/toplist.html:6
+msgid "{0} users"
+msgstr ""
+
 #: src/olympia/addons/templates/addons/impala/listing/sorter.html:14 src/olympia/devhub/templates/devhub/addons/listing/item_actions.html:49
 msgid "More"
 msgstr "עוד"
@@ -1199,7 +1200,7 @@ msgstr "הוסף לאוסף"
 msgid "My Add-ons"
 msgstr "התוספות שלי"
 
-#: src/olympia/addons/templates/addons/includes/dashboard_tabs.html:6 src/olympia/amo/context_processors.py:51
+#: src/olympia/addons/templates/addons/includes/dashboard_tabs.html:6 src/olympia/amo/context_processors.py:50
 msgid "My Themes"
 msgstr ""
 
@@ -1257,7 +1258,7 @@ msgstr ""
 msgid "Weekly Downloads"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/mobile/details.html:99 src/olympia/compat/templates/compat/reporter_detail.html:46 src/olympia/devhub/forms.py:787
+#: src/olympia/addons/templates/addons/mobile/details.html:99 src/olympia/compat/templates/compat/reporter_detail.html:46 src/olympia/devhub/forms.py:788
 #: src/olympia/devhub/templates/devhub/versions/list.html:163
 msgid "Version"
 msgstr "גרסה"
@@ -1342,7 +1343,7 @@ msgstr ""
 #: src/olympia/browse/templates/browse/personas/category_landing.html:21 src/olympia/browse/templates/browse/personas/category_landing.html:23
 #: src/olympia/browse/templates/browse/personas/category_landing.html:38 src/olympia/browse/templates/browse/personas/grid.html:7 src/olympia/browse/templates/browse/personas/grid.html:11
 #: src/olympia/browse/templates/browse/personas/mobile/base.html:7 src/olympia/browse/templates/browse/personas/mobile/category_landing.html:19 src/olympia/constants/base.py:180
-#: src/olympia/devhub/templates/devhub/personas/submit.html:13 src/olympia/editors/helpers.py:105 src/olympia/editors/templates/editors/base.html:26
+#: src/olympia/devhub/templates/devhub/personas/submit.html:13 src/olympia/editors/helpers.py:107 src/olympia/editors/templates/editors/base.html:26
 #: src/olympia/editors/templates/editors/performance.html:73 src/olympia/search/templates/search/personas.html:39 src/olympia/templates/menu_links.html:9
 msgid "Themes"
 msgstr ""
@@ -1368,7 +1369,7 @@ msgid "Highest Rated"
 msgstr "בעלות הדירוגים הגבוהים ביותר"
 
 # 100%
-#: src/olympia/addons/templates/addons/mobile/home.html:74 src/olympia/amo/templates/amo/side_nav.html:5 src/olympia/amo/templates/amo/site_nav.html:27 src/olympia/amo/templates/amo/site_nav.html:57
+#: src/olympia/addons/templates/addons/mobile/home.html:74 src/olympia/amo/templates/amo/side_nav.html:5 src/olympia/amo/templates/amo/site_nav.html:27 src/olympia/amo/templates/amo/site_nav.html:55
 #: src/olympia/bandwagon/views.py:97 src/olympia/browse/views.py:57 src/olympia/browse/views.py:67 src/olympia/browse/templates/browse/personas/mobile/category_landing.html:65
 #: src/olympia/search/forms.py:15 src/olympia/search/forms.py:87
 msgid "Newest"
@@ -1382,90 +1383,90 @@ msgstr ""
 msgid "Theme Info &raquo;"
 msgstr ""
 
-#: src/olympia/amo/context_processors.py:39 src/olympia/devhub/templates/devhub/nav.html:43
+#: src/olympia/amo/context_processors.py:37 src/olympia/devhub/templates/devhub/nav.html:43
 msgid "Tools"
 msgstr "כלים"
 
-#: src/olympia/amo/context_processors.py:48 src/olympia/discovery/templates/discovery/pane_account.html:8 src/olympia/users/templates/users/includes/navigation.html:2
+#: src/olympia/amo/context_processors.py:47 src/olympia/discovery/templates/discovery/pane_account.html:8 src/olympia/users/templates/users/includes/navigation.html:2
 msgid "My Profile"
 msgstr ""
 
-#: src/olympia/amo/context_processors.py:54 src/olympia/users/templates/users/edit.html:5 src/olympia/users/templates/users/includes/navigation.html:3
+#: src/olympia/amo/context_processors.py:53 src/olympia/users/templates/users/edit.html:5 src/olympia/users/templates/users/includes/navigation.html:3
 msgid "Account Settings"
 msgstr ""
 
-#: src/olympia/amo/context_processors.py:57 src/olympia/discovery/templates/discovery/pane_account.html:11 src/olympia/users/templates/users/profile.html:83
+#: src/olympia/amo/context_processors.py:56 src/olympia/discovery/templates/discovery/pane_account.html:11 src/olympia/users/templates/users/profile.html:83
 #: src/olympia/users/templates/users/includes/navigation.html:4
 msgid "My Collections"
 msgstr "האוספים שלי"
 
-#: src/olympia/amo/context_processors.py:62 src/olympia/discovery/templates/discovery/pane_account.html:10 src/olympia/users/templates/users/includes/navigation.html:7
+#: src/olympia/amo/context_processors.py:61 src/olympia/discovery/templates/discovery/pane_account.html:10 src/olympia/users/templates/users/includes/navigation.html:7
 msgid "My Favorites"
 msgstr "המועדפים שלי"
 
-#: src/olympia/amo/context_processors.py:67 src/olympia/discovery/templates/discovery/pane_account.html:13 src/olympia/templates/impala/user_login.html:14
+#: src/olympia/amo/context_processors.py:66 src/olympia/discovery/templates/discovery/pane_account.html:13 src/olympia/templates/impala/user_login.html:14
 #: src/olympia/templates/mobile/header_auth.html:5
 msgid "Log out"
 msgstr "התנתקות"
 
-#: src/olympia/amo/context_processors.py:72 src/olympia/devhub/templates/devhub/addons/dashboard.html:4
+#: src/olympia/amo/context_processors.py:71 src/olympia/devhub/templates/devhub/addons/dashboard.html:4
 msgid "Manage My Submissions"
 msgstr ""
 
-#: src/olympia/amo/context_processors.py:75 src/olympia/devhub/templates/devhub/nav.html:27 src/olympia/devhub/templates/devhub/addons/dashboard.html:25
+#: src/olympia/amo/context_processors.py:74 src/olympia/devhub/templates/devhub/nav.html:27 src/olympia/devhub/templates/devhub/addons/dashboard.html:25
 #: src/olympia/devhub/templates/devhub/addons/submit/base.html:4
 msgid "Submit a New Add-on"
 msgstr "שליחת תוספת חדשה"
 
-#: src/olympia/amo/context_processors.py:77 src/olympia/browse/templates/browse/personas/base.html:50 src/olympia/devhub/templates/devhub/index.html:24
+#: src/olympia/amo/context_processors.py:76 src/olympia/browse/templates/browse/personas/base.html:50 src/olympia/devhub/templates/devhub/index.html:24
 #: src/olympia/devhub/templates/devhub/addons/dashboard.html:29
 msgid "Submit a New Theme"
 msgstr ""
 
-#: src/olympia/amo/context_processors.py:79 src/olympia/amo/templates/amo/site_nav.html:87 src/olympia/devhub/helpers.py:36 src/olympia/devhub/helpers.py:68 src/olympia/devhub/helpers.py:102
+#: src/olympia/amo/context_processors.py:78 src/olympia/amo/templates/amo/site_nav.html:85 src/olympia/devhub/helpers.py:36 src/olympia/devhub/helpers.py:68 src/olympia/devhub/helpers.py:102
 #: src/olympia/templates/footer.html:6 src/olympia/templates/menu_links.html:14
 msgid "Developer Hub"
 msgstr "מקום מפגש למפתחים"
 
-#: src/olympia/amo/context_processors.py:83 src/olympia/devhub/views.py:1792
+#: src/olympia/amo/context_processors.py:81 src/olympia/devhub/views.py:1796
 msgid "Manage API Keys"
 msgstr ""
 
-#: src/olympia/amo/context_processors.py:88 src/olympia/editors/helpers.py:82 src/olympia/editors/helpers.py:102 src/olympia/editors/templates/editors/base.html:10
+#: src/olympia/amo/context_processors.py:86 src/olympia/editors/helpers.py:84 src/olympia/editors/helpers.py:104 src/olympia/editors/templates/editors/base.html:10
 msgid "Editor Tools"
 msgstr "כלי עורך"
 
-#: src/olympia/amo/context_processors.py:92
+#: src/olympia/amo/context_processors.py:90
 msgid "Admin Tools"
 msgstr "כלי מנהל"
 
-#: src/olympia/amo/fields.py:15
+#: src/olympia/amo/fields.py:20
 msgid "Incorrect, please try again."
 msgstr ""
 
-#: src/olympia/amo/fields.py:16
+#: src/olympia/amo/fields.py:21
 msgid "Error verifying input, please try again."
 msgstr ""
 
-#: src/olympia/amo/fields.py:32
+#: src/olympia/amo/fields.py:37
 msgid "This must be a valid hex color code, such as #000000."
 msgstr ""
 
-#: src/olympia/amo/fields.py:58
+#: src/olympia/amo/fields.py:63
 msgid "Enter at least one value."
 msgstr ""
 
-#: src/olympia/amo/helpers.py:162 src/olympia/amo/templates/amo/site_nav.html:61 src/olympia/bandwagon/templates/bandwagon/add.html:9
+#: src/olympia/amo/helpers.py:162 src/olympia/amo/templates/amo/site_nav.html:59 src/olympia/bandwagon/templates/bandwagon/add.html:9
 #: src/olympia/bandwagon/templates/bandwagon/collection_detail.html:15 src/olympia/bandwagon/templates/bandwagon/delete.html:9 src/olympia/bandwagon/templates/bandwagon/edit.html:15
 #: src/olympia/bandwagon/templates/bandwagon/user_listing.html:18 src/olympia/bandwagon/templates/bandwagon/user_listing.html:21
 #: src/olympia/bandwagon/templates/bandwagon/impala/collection_listing.html:12 src/olympia/bandwagon/templates/bandwagon/impala/collection_listing.html:20
 #: src/olympia/bandwagon/templates/bandwagon/impala/collection_listing.html:24 src/olympia/bandwagon/templates/bandwagon/impala/collection_sidebar.html:3
 #: src/olympia/bandwagon/templates/bandwagon/includes/collection_sidebar.html:2 src/olympia/bandwagon/templates/bandwagon/mobile/collection_listing.html:3
-#: src/olympia/stats/templates/stats/stats.html:77 src/olympia/templates/menu_links.html:12
+#: src/olympia/stats/templates/stats/stats.html:33 src/olympia/templates/menu_links.html:12
 msgid "Collections"
 msgstr "אוספים"
 
-#: src/olympia/amo/helpers.py:171 src/olympia/amo/templates/amo/site_nav.html:85 src/olympia/browse/templates/browse/language_tools.html:3
+#: src/olympia/amo/helpers.py:171 src/olympia/amo/templates/amo/site_nav.html:83 src/olympia/browse/templates/browse/language_tools.html:3
 msgid "Dictionaries & Language Packs"
 msgstr "מילונים וחבילות שפה"
 
@@ -1617,8 +1618,8 @@ msgstr ""
 msgid "Comment on {addon} {version}."
 msgstr ""
 
-#: src/olympia/amo/log.py:236 src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:19 src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:47
-#: src/olympia/editors/helpers.py:511 src/olympia/editors/templates/editors/themes/history_table.html:11
+#: src/olympia/amo/log.py:236 src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:17 src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:45
+#: src/olympia/editors/helpers.py:584 src/olympia/editors/templates/editors/themes/history_table.html:11
 msgid "Comment"
 msgstr ""
 
@@ -1918,8 +1919,8 @@ msgstr "אוי"
 
 #: src/olympia/amo/templates/amo/500.html:6
 #, python-format
-msgid "<h1>Oops! We had an error.</h1> <p>We'll get to fixing that soon.</p> <p> You can try refreshing the page, or head back to the <a href=\"%(home)s\">Add-ons homepage</a>. </p>"
-msgstr "<h1>אוי! אירעה לנו שגיאה.</h1> <p>אנחנו נתקן את זה בקרוב.</p> <p> נסו לרענן את הדף, או בואו חזרה אל <a href=\"%(home)s\">דף התוספות</a>. </p>"
+msgid "<h1>Oops!  We had an error.</h1> <p>We'll get to fixing that soon.</p> <p> You can try refreshing the page, or head back to the <a href=\"%(home)s\">Add-ons homepage</a>. </p>"
+msgstr ""
 
 #: src/olympia/amo/templates/amo/license_link.html:10
 msgid "Some rights reserved"
@@ -1941,7 +1942,7 @@ msgstr "קודם"
 #: src/olympia/amo/templates/amo/mobile/paginator.html:14 src/olympia/amo/templates/amo/mobile/paginator.html:16 src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:51
 #: src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:65 src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:78
 #: src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:91 src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:104
-#: src/olympia/discovery/templates/discovery/pane.html:45 src/olympia/discovery/templates/discovery/addons/detail.html:39 src/olympia/stats/templates/stats/stats.html:167
+#: src/olympia/discovery/templates/discovery/pane.html:45 src/olympia/discovery/templates/discovery/addons/detail.html:39 src/olympia/stats/templates/stats/stats.html:169
 msgid "Next"
 msgstr "הבא"
 
@@ -1973,7 +1974,7 @@ msgid ""
 msgstr ""
 
 #: src/olympia/amo/templates/amo/side_nav.html:4 src/olympia/amo/templates/amo/side_nav.html:12 src/olympia/amo/templates/amo/site_nav.html:4 src/olympia/amo/templates/amo/site_nav.html:26
-#: src/olympia/browse/views.py:56 src/olympia/browse/views.py:66 src/olympia/browse/views.py:237 src/olympia/browse/views.py:282 src/olympia/search/forms.py:86
+#: src/olympia/browse/views.py:56 src/olympia/browse/views.py:66 src/olympia/browse/views.py:204 src/olympia/browse/views.py:249 src/olympia/search/forms.py:86
 msgid "Top Rated"
 msgstr "דורגו הכי גבוה"
 
@@ -1988,38 +1989,38 @@ msgstr ""
 msgid "Extensions"
 msgstr "הרחבות"
 
-#: src/olympia/amo/templates/amo/site_nav.html:45
+#: src/olympia/amo/templates/amo/site_nav.html:44
 msgid "Want more customization? Try <b>Complete Themes</b>"
 msgstr ""
 
-#: src/olympia/amo/templates/amo/site_nav.html:56 src/olympia/bandwagon/views.py:96
+#: src/olympia/amo/templates/amo/site_nav.html:54 src/olympia/bandwagon/views.py:96
 msgid "Most Followers"
 msgstr ""
 
-#: src/olympia/amo/templates/amo/site_nav.html:68 src/olympia/bandwagon/templates/bandwagon/impala/collection_sidebar.html:16
+#: src/olympia/amo/templates/amo/site_nav.html:66 src/olympia/bandwagon/templates/bandwagon/impala/collection_sidebar.html:16
 #: src/olympia/bandwagon/templates/bandwagon/includes/collection_sidebar.html:18
 msgid "Collections I've Made"
 msgstr ""
 
-#: src/olympia/amo/templates/amo/site_nav.html:70 src/olympia/bandwagon/templates/bandwagon/user_listing.html:4 src/olympia/bandwagon/templates/bandwagon/impala/collection_sidebar.html:13
+#: src/olympia/amo/templates/amo/site_nav.html:68 src/olympia/bandwagon/templates/bandwagon/user_listing.html:4 src/olympia/bandwagon/templates/bandwagon/impala/collection_sidebar.html:13
 #: src/olympia/bandwagon/templates/bandwagon/includes/collection_sidebar.html:15
 msgid "Collections I'm Following"
 msgstr ""
 
-#: src/olympia/amo/templates/amo/site_nav.html:73 src/olympia/bandwagon/templates/bandwagon/impala/collection_sidebar.html:18
-#: src/olympia/bandwagon/templates/bandwagon/includes/collection_sidebar.html:20 src/olympia/users/models.py:512
+#: src/olympia/amo/templates/amo/site_nav.html:71 src/olympia/bandwagon/templates/bandwagon/impala/collection_sidebar.html:18
+#: src/olympia/bandwagon/templates/bandwagon/includes/collection_sidebar.html:20 src/olympia/users/models.py:521
 msgid "My Favorite Add-ons"
 msgstr ""
 
-#: src/olympia/amo/templates/amo/site_nav.html:78
+#: src/olympia/amo/templates/amo/site_nav.html:76
 msgid "More&hellip;"
 msgstr ""
 
-#: src/olympia/amo/templates/amo/site_nav.html:82
+#: src/olympia/amo/templates/amo/site_nav.html:80
 msgid "Add-ons for Mobile"
 msgstr ""
 
-#: src/olympia/amo/templates/amo/site_nav.html:86 src/olympia/browse/feeds.py:207 src/olympia/browse/templates/browse/search_tools.html:3 src/olympia/constants/base.py:176
+#: src/olympia/amo/templates/amo/site_nav.html:84 src/olympia/browse/feeds.py:207 src/olympia/browse/templates/browse/search_tools.html:3 src/olympia/constants/base.py:176
 #: src/olympia/templates/menu_links.html:10
 msgid "Search Tools"
 msgstr ""
@@ -2035,7 +2036,7 @@ msgid "Jump to first page"
 msgstr ""
 
 #: src/olympia/amo/templates/amo/impala/paginator.html:22 src/olympia/amo/templates/amo/mobile/impala_paginator.html:12 src/olympia/discovery/templates/discovery/pane.html:44
-#: src/olympia/discovery/templates/discovery/addons/detail.html:38 src/olympia/stats/templates/stats/stats.html:164
+#: src/olympia/discovery/templates/discovery/addons/detail.html:38 src/olympia/stats/templates/stats/stats.html:166
 msgid "Previous"
 msgstr ""
 
@@ -2058,30 +2059,49 @@ msgid_plural "Page {n}"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/olympia/amo/templates/services/install.html:38
-#, python-format
-msgid "If you are not prompted to install %(addon_name)s in a moment, please <a href=\"%(addon_xpi)s\">click here</a>."
-msgstr ""
-
-#: src/olympia/amo/tests/test_messages.py:57 src/olympia/amo/tests/test_messages.py:58 src/olympia/reviews/forms.py:25 src/olympia/reviews/forms.py:50 src/olympia/reviews/templates/reviews/add.html:56
+#: src/olympia/amo/tests/test_messages.py:56 src/olympia/amo/tests/test_messages.py:57 src/olympia/reviews/forms.py:25 src/olympia/reviews/forms.py:50 src/olympia/reviews/templates/reviews/add.html:56
 #: src/olympia/reviews/templates/reviews/reply.html:30
 msgid "Title"
 msgstr ""
 
-#: src/olympia/amo/tests/test_messages.py:57 src/olympia/amo/tests/test_messages.py:58
+#: src/olympia/amo/tests/test_messages.py:56 src/olympia/amo/tests/test_messages.py:57
 msgid "Body"
 msgstr ""
 
-#: src/olympia/amo/tests/test_messages.py:59
+#: src/olympia/amo/tests/test_messages.py:58
 msgid "Another Title"
 msgstr ""
 
-#: src/olympia/amo/tests/test_messages.py:59
+#: src/olympia/amo/tests/test_messages.py:58
 msgid "Another Body"
 msgstr ""
 
-#: src/olympia/api/views.py:255
-msgid "Not implemented yet."
+#: src/olympia/api/authentication.py:76
+msgid "Signature has expired."
+msgstr ""
+
+#: src/olympia/api/authentication.py:79
+msgid "Error decoding signature."
+msgstr ""
+
+#: src/olympia/api/authentication.py:82
+msgid "Invalid JWT Token."
+msgstr ""
+
+#: src/olympia/api/authentication.py:130
+msgid "Invalid Authorization header. No credentials provided."
+msgstr ""
+
+#: src/olympia/api/authentication.py:133
+msgid "Invalid Authorization header. Credentials string should not contain spaces."
+msgstr ""
+
+#: src/olympia/api/fields.py:29
+msgid "The field must have a length of at least {num} characters."
+msgstr ""
+
+#: src/olympia/api/fields.py:31
+msgid "The language code {lang_code} is invalid."
 msgstr ""
 
 #: src/olympia/applications/views.py:39 src/olympia/applications/templates/applications/appversions.html:3
@@ -2100,7 +2120,7 @@ msgstr "גירסאות ישום חוקיות"
 msgid "Add-ons submitted to Mozilla Add-ons must have a manifest file with at least one of the below applications supported. Only the versions listed below are allowed for these applications."
 msgstr ""
 
-#: src/olympia/applications/templates/applications/appversions.html:25
+#: src/olympia/applications/templates/applications/appversions.html:25 src/olympia/editors/helpers.py:361
 msgid "GUID"
 msgstr "מזהה GUID"
 
@@ -2224,8 +2244,8 @@ msgstr ""
 msgid "Remove from favorites"
 msgstr "הסר ממועדפים"
 
-#: src/olympia/bandwagon/views.py:98 src/olympia/bandwagon/views.py:191 src/olympia/browse/views.py:58 src/olympia/browse/views.py:69 src/olympia/browse/views.py:458 src/olympia/devhub/views.py:74
-#: src/olympia/devhub/views.py:82 src/olympia/devhub/templates/devhub/addons/edit/basic.html:20 src/olympia/editors/templates/editors/leaderboard.html:24
+#: src/olympia/bandwagon/views.py:98 src/olympia/bandwagon/views.py:191 src/olympia/browse/views.py:58 src/olympia/browse/views.py:69 src/olympia/browse/views.py:425 src/olympia/devhub/views.py:72
+#: src/olympia/devhub/views.py:80 src/olympia/devhub/templates/devhub/addons/edit/basic.html:20 src/olympia/editors/templates/editors/leaderboard.html:24
 #: src/olympia/editors/templates/editors/themes/queue_list.html:48 src/olympia/search/forms.py:17 src/olympia/search/forms.py:89 src/olympia/users/templates/users/vcard.html:5
 msgid "Name"
 msgstr ""
@@ -2234,7 +2254,7 @@ msgstr ""
 msgid "Recently Popular"
 msgstr ""
 
-#: src/olympia/bandwagon/views.py:189 src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:18
+#: src/olympia/bandwagon/views.py:189 src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:16
 msgid "Added"
 msgstr ""
 
@@ -2249,7 +2269,7 @@ msgstr ""
 
 #: src/olympia/bandwagon/views.py:316
 #, python-format
-msgid "Your new collection is shown below. You can <ahref=\"%(url)s\">edit additional settings</a> if you'dlike."
+msgid "Your new collection is shown below. You can <a href=\"%(url)s\">edit additional settings</a> if you'd like."
 msgstr ""
 
 #: src/olympia/bandwagon/views.py:322
@@ -2405,8 +2425,8 @@ msgstr[0] ""
 msgstr[1] ""
 
 # 100%
-#: src/olympia/bandwagon/templates/bandwagon/collection_detail.html:125 src/olympia/compat/templates/compat/index.html:25 src/olympia/compat/templates/compat/reporter_detail.html:29
-#: src/olympia/files/templates/files/viewer.html:29 src/olympia/templates/amo_footer.html:17 src/olympia/templates/includes/lang_switcher.html:10
+#: src/olympia/bandwagon/templates/bandwagon/collection_detail.html:125 src/olympia/compat/templates/compat/reporter_detail.html:29 src/olympia/files/templates/files/viewer.html:29
+#: src/olympia/templates/amo_footer.html:17 src/olympia/templates/includes/lang_switcher.html:10
 msgid "Go"
 msgstr "לך"
 
@@ -2577,7 +2597,7 @@ msgid "Remove this user as a contributor"
 msgstr ""
 
 #: src/olympia/bandwagon/templates/bandwagon/edit_contributors.html:18 src/olympia/bandwagon/templates/bandwagon/edit_contributors.html:43
-#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:20 src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:48
+#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:18 src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:46
 #: src/olympia/devhub/templates/devhub/addons/ajax_compat_update.html:19
 msgid "Remove"
 msgstr ""
@@ -2629,7 +2649,7 @@ msgid "<b>Warning:</b> By changing the owner of this collection, you will no lon
 msgstr ""
 
 #: src/olympia/bandwagon/templates/bandwagon/edit_contributors.html:83 src/olympia/devhub/templates/devhub/addons/forms_shared/media.html:157
-#: src/olympia/devhub/templates/devhub/addons/submit/describe.html:69 src/olympia/devhub/templates/devhub/addons/submit/license.html:60 src/olympia/devhub/templates/devhub/addons/submit/upload.html:78
+#: src/olympia/devhub/templates/devhub/addons/submit/describe.html:69 src/olympia/devhub/templates/devhub/addons/submit/license.html:60 src/olympia/devhub/templates/devhub/addons/submit/upload.html:70
 #: src/olympia/devhub/templates/devhub/payments/tier.html:17 src/olympia/editors/templates/editors/themes/themes.html:111 src/olympia/editors/templates/editors/themes/themes.html:128
 #: src/olympia/editors/templates/editors/themes/themes.html:134 src/olympia/editors/templates/editors/themes/themes.html:141 src/olympia/users/templates/users/fxa_migration_prompt_content.html:10
 #: src/olympia/users/templates/users/login_form.html:42 src/olympia/users/templates/users/mobile/login.html:57
@@ -2718,31 +2738,31 @@ msgid "Add-ons in Your Collection"
 msgstr ""
 
 #: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:4
-msgid ""
-"To include an add-on in this collection, enter its name in the box below and hit enter.  You can also use the <strong>Add to Collection</strong> links throughout the site to include add-ons later."
+msgid "To include an add-on in this collection, enter its name in the box below and hit enter."
 msgstr ""
 
-#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:17 src/olympia/constants/base.py:400 src/olympia/devhub/templates/devhub/addons/activity.html:62
+#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:15 src/olympia/constants/base.py:400 src/olympia/devhub/templates/devhub/addons/activity.html:62
+#: src/olympia/editors/helpers.py:273 src/olympia/editors/helpers.py:360
 msgid "Add-on"
 msgstr ""
 
-#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:26
+#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:24
 msgid "Enter the name of the add-on to include"
 msgstr ""
 
-#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:28
+#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:26
 msgid "Add to Collection"
 msgstr "הוספה לאוסף"
 
-#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:45 src/olympia/editors/helpers.py:936 src/olympia/editors/helpers.py:956
+#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:43 src/olympia/editors/helpers.py:1016 src/olympia/editors/helpers.py:1036
 msgid "Pending"
 msgstr ""
 
-#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:47
+#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:45
 msgid "Add a comment"
 msgstr ""
 
-#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:48
+#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:46
 msgid "Remove this add-on from the collection"
 msgstr ""
 
@@ -2849,12 +2869,12 @@ msgstr ""
 msgid "Most Users"
 msgstr ""
 
-#: src/olympia/browse/views.py:61 src/olympia/browse/views.py:72 src/olympia/browse/views.py:279 src/olympia/browse/templates/browse/personas/mobile/category_landing.html:63
+#: src/olympia/browse/views.py:61 src/olympia/browse/views.py:72 src/olympia/browse/views.py:246 src/olympia/browse/templates/browse/personas/mobile/category_landing.html:63
 #: src/olympia/discovery/templates/discovery/pane.html:67 src/olympia/search/forms.py:92
 msgid "Up & Coming"
 msgstr ""
 
-#: src/olympia/browse/views.py:460 src/olympia/devhub/views.py:76 src/olympia/devhub/views.py:83 src/olympia/discovery/templates/discovery/addons/detail.html:66
+#: src/olympia/browse/views.py:427 src/olympia/devhub/views.py:74 src/olympia/devhub/views.py:81 src/olympia/discovery/templates/discovery/addons/detail.html:66
 msgid "Created"
 msgstr "נוצרה"
 
@@ -3046,8 +3066,8 @@ msgid_plural "See all %(cnt)s extensions in %(name)s &raquo;"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/olympia/browse/templates/browse/mobile/extensions.html:13 src/olympia/compat/templates/compat/index.html:82 src/olympia/devhub/templates/devhub/devhub_search.html:24
-#: src/olympia/devhub/templates/devhub/addons/activity.html:47 src/olympia/search/templates/search/no_results.html:4 src/olympia/search/templates/search/mobile/results.html:36
+#: src/olympia/browse/templates/browse/mobile/extensions.html:13 src/olympia/devhub/templates/devhub/devhub_search.html:24 src/olympia/devhub/templates/devhub/addons/activity.html:47
+#: src/olympia/search/templates/search/no_results.html:4 src/olympia/search/templates/search/mobile/results.html:36
 msgid "No results found."
 msgstr "לא נמצאו תוצאות."
 
@@ -3132,7 +3152,7 @@ msgstr ""
 msgid "All"
 msgstr ""
 
-#: src/olympia/compat/forms.py:22 src/olympia/search/views.py:525
+#: src/olympia/compat/forms.py:22 src/olympia/editors/templates/editors/base.html:69 src/olympia/search/views.py:518
 msgid "All Add-ons"
 msgstr ""
 
@@ -3142,53 +3162,6 @@ msgstr ""
 
 #: src/olympia/compat/forms.py:24
 msgid "Non-binary"
-msgstr ""
-
-#. Review points sources other than add-ons and themes.
-#: src/olympia/compat/views.py:87 src/olympia/constants/base.py:388 src/olympia/devhub/forms.py:162 src/olympia/editors/templates/editors/performance.html:75
-msgid "Other"
-msgstr "אחר"
-
-#: src/olympia/compat/templates/compat/index.html:4
-msgid "Add-on Compatibility Report for {app} {version}"
-msgstr ""
-
-#: src/olympia/compat/templates/compat/index.html:11
-msgid "{app} {version} Compatibility"
-msgstr ""
-
-#: src/olympia/compat/templates/compat/index.html:17
-#, python-format
-msgid "Top 95%% compatible with previous version"
-msgstr ""
-
-#: src/olympia/compat/templates/compat/index.html:18
-#, python-format
-msgid "Top 95%% of all add-ons"
-msgstr ""
-
-#: src/olympia/compat/templates/compat/index.html:19
-msgid "All active add-ons"
-msgstr ""
-
-#: src/olympia/compat/templates/compat/index.html:23 src/olympia/constants/base.py:401
-msgid "App"
-msgstr ""
-
-#: src/olympia/compat/templates/compat/index.html:55
-msgid "Details for add-ons compatible with previous version:"
-msgstr ""
-
-#: src/olympia/compat/templates/compat/index.html:57
-msgid "Show all versions"
-msgstr ""
-
-#: src/olympia/compat/templates/compat/index.html:59
-msgid "Details for add-ons compatible with all versions:"
-msgstr ""
-
-#: src/olympia/compat/templates/compat/index.html:61
-msgid "Show previous version only"
 msgstr ""
 
 #: src/olympia/compat/templates/compat/reporter.html:3
@@ -3242,8 +3215,8 @@ msgstr ""
 msgid "Report Type"
 msgstr ""
 
-#: src/olympia/compat/templates/compat/reporter_detail.html:47 src/olympia/devhub/forms.py:784 src/olympia/devhub/templates/devhub/addons/ajax_compat_update.html:17 src/olympia/editors/forms.py:108
-#: src/olympia/zadmin/forms.py:45
+#: src/olympia/compat/templates/compat/reporter_detail.html:47 src/olympia/devhub/forms.py:785 src/olympia/devhub/templates/devhub/addons/ajax_compat_update.html:17 src/olympia/editors/forms.py:108
+#: src/olympia/editors/forms.py:248 src/olympia/zadmin/forms.py:45
 msgid "Application"
 msgstr ""
 
@@ -3334,7 +3307,8 @@ msgstr ""
 msgid "Preliminarily Reviewed and Awaiting Full Review"
 msgstr ""
 
-#: src/olympia/constants/base.py:33 src/olympia/editors/helpers.py:924 src/olympia/editors/templates/editors/themes/history_table.html:34
+#: src/olympia/constants/base.py:33 src/olympia/editors/forms.py:258 src/olympia/editors/helpers.py:73 src/olympia/editors/helpers.py:1004
+#: src/olympia/editors/templates/editors/themes/history_table.html:34
 msgid "Deleted"
 msgstr ""
 
@@ -3437,6 +3411,11 @@ msgstr ""
 msgid "Ask before users can download this add-on"
 msgstr ""
 
+#. Review points sources other than add-ons and themes.
+#: src/olympia/constants/base.py:388 src/olympia/devhub/forms.py:162 src/olympia/editors/templates/editors/performance.html:75
+msgid "Other"
+msgstr "אחר"
+
 #: src/olympia/constants/base.py:389
 msgid "Exception"
 msgstr ""
@@ -3447,6 +3426,10 @@ msgstr ""
 
 #: src/olympia/constants/base.py:391
 msgid "Change"
+msgstr ""
+
+#: src/olympia/constants/base.py:401
+msgid "App"
 msgstr ""
 
 #: src/olympia/constants/base.py:402
@@ -3597,7 +3580,7 @@ msgstr ""
 msgid "Duplicate"
 msgstr ""
 
-#: src/olympia/constants/editors.py:17 src/olympia/editors/helpers.py:502 src/olympia/editors/templates/editors/themes/queue.html:71 src/olympia/editors/templates/editors/themes/themes.html:94
+#: src/olympia/constants/editors.py:17 src/olympia/editors/helpers.py:575 src/olympia/editors/templates/editors/themes/queue.html:71 src/olympia/editors/templates/editors/themes/themes.html:94
 msgid "Reject"
 msgstr ""
 
@@ -3697,7 +3680,7 @@ msgstr ""
 msgid "Android"
 msgstr ""
 
-#: src/olympia/core/apps.py:19
+#: src/olympia/core/apps.py:21
 msgid "Core"
 msgstr ""
 
@@ -3831,7 +3814,7 @@ msgid "Submit my add-on for manual review."
 msgstr ""
 
 #: src/olympia/devhub/forms.py:537
-msgid "Do not list my add-on on this site (beta)"
+msgid "Do not list my add-on on this site"
 msgstr ""
 
 #: src/olympia/devhub/forms.py:538
@@ -3864,46 +3847,46 @@ msgstr ""
 
 #: src/olympia/devhub/forms.py:592
 #, python-format
-msgid "Version %s already exists"
+msgid "Version %s already exists, or was uploaded before."
 msgstr ""
 
-#: src/olympia/devhub/forms.py:604
+#: src/olympia/devhub/forms.py:605
 msgid "Select a valid choice. That choice is not one of the available choices."
 msgstr ""
 
-#: src/olympia/devhub/forms.py:610
+#: src/olympia/devhub/forms.py:611
 msgid "A file with a version ending with a|alpha|b|beta and an optional number is detected as beta."
 msgstr ""
 
-#: src/olympia/devhub/forms.py:633
+#: src/olympia/devhub/forms.py:634
 msgid "You cannot upload any more files for this version."
 msgstr ""
 
-#: src/olympia/devhub/forms.py:639
+#: src/olympia/devhub/forms.py:640
 msgid "Version doesn't match"
 msgstr ""
 
-#: src/olympia/devhub/forms.py:668
+#: src/olympia/devhub/forms.py:669
 msgid "You cannot delete a file once the review process has started.  You must delete the whole version."
 msgstr ""
 
-#: src/olympia/devhub/forms.py:688
+#: src/olympia/devhub/forms.py:689
 msgid "The platform All cannot be combined with specific platforms."
 msgstr ""
 
-#: src/olympia/devhub/forms.py:693
+#: src/olympia/devhub/forms.py:694
 msgid "A platform can only be chosen once."
 msgstr ""
 
-#: src/olympia/devhub/forms.py:706
+#: src/olympia/devhub/forms.py:707
 msgid "A review type must be selected."
 msgstr ""
 
-#: src/olympia/devhub/forms.py:788 src/olympia/editors/forms.py:114 src/olympia/zadmin/forms.py:49 src/olympia/zadmin/forms.py:52
+#: src/olympia/devhub/forms.py:789 src/olympia/editors/forms.py:114 src/olympia/editors/forms.py:254 src/olympia/zadmin/forms.py:49 src/olympia/zadmin/forms.py:52
 msgid "Select an application first"
 msgstr ""
 
-#: src/olympia/devhub/forms.py:840
+#: src/olympia/devhub/forms.py:841
 msgid "There cannot be more than 3 required add-ons."
 msgstr ""
 
@@ -3939,79 +3922,79 @@ msgstr[1] "{0} אזהרות"
 msgid "Review"
 msgstr "סקירה"
 
-#: src/olympia/devhub/tasks.py:551
+#: src/olympia/devhub/tasks.py:583
 #, python-format
 msgid "%s responded with %s (%s)."
 msgstr ""
 
-#: src/olympia/devhub/tasks.py:555
+#: src/olympia/devhub/tasks.py:587
 #, python-format
 msgid "Connection to \"%s\" timed out."
 msgstr ""
 
-#: src/olympia/devhub/tasks.py:557
+#: src/olympia/devhub/tasks.py:589
 #, python-format
 msgid "Could not contact host at \"%s\"."
 msgstr ""
 
-#: src/olympia/devhub/utils.py:104
+#: src/olympia/devhub/utils.py:105
 #, python-format
 msgid "Validation generated too many errors/warnings so %s messages were truncated. After addressing the visible messages, you'll be able to see the others."
 msgstr ""
 
-#: src/olympia/devhub/views.py:183
+#: src/olympia/devhub/views.py:181
 msgid "All My Add-ons"
 msgstr ""
 
-#: src/olympia/devhub/views.py:210
+#: src/olympia/devhub/views.py:208
 msgid "All Activity"
 msgstr ""
 
-#: src/olympia/devhub/views.py:211
+#: src/olympia/devhub/views.py:209
 msgid "Add-on Updates"
 msgstr ""
 
-#: src/olympia/devhub/views.py:212
+#: src/olympia/devhub/views.py:210
 msgid "Add-on Status"
 msgstr ""
 
 # 75%
 # 100%
-#: src/olympia/devhub/views.py:213
+#: src/olympia/devhub/views.py:211
 #, fuzzy
 msgid "User Collections"
 msgstr "האוספים שלי"
 
-#: src/olympia/devhub/views.py:214 src/olympia/devhub/templates/devhub/docs/policies-maintenance.html:68 src/olympia/pages/templates/pages/dev_faq.html:38
+#: src/olympia/devhub/views.py:212 src/olympia/devhub/templates/devhub/docs/policies-maintenance.html:68 src/olympia/pages/templates/pages/dev_faq.html:38
 #: src/olympia/pages/templates/pages/dev_faq.html:484
 msgid "User Reviews"
 msgstr "ביקורות משתמשים"
 
-#: src/olympia/devhub/views.py:327 src/olympia/devhub/views.py:331 src/olympia/devhub/views.py:484 src/olympia/devhub/views.py:513 src/olympia/devhub/views.py:564 src/olympia/devhub/views.py:1150
+#: src/olympia/devhub/views.py:325 src/olympia/devhub/views.py:329 src/olympia/devhub/views.py:484 src/olympia/devhub/views.py:513 src/olympia/devhub/views.py:564 src/olympia/devhub/views.py:1156
 msgid "Changes successfully saved."
 msgstr ""
 
-#: src/olympia/devhub/views.py:334 src/olympia/devhub/views.py:1631
+#: src/olympia/devhub/views.py:332 src/olympia/devhub/views.py:1637
 msgid "Please check the form for errors."
 msgstr ""
 
-#: src/olympia/devhub/views.py:346
+#: src/olympia/devhub/views.py:344
 msgid "Add-on cannot be deleted. Disable this add-on instead."
 msgstr ""
 
-#: src/olympia/devhub/views.py:356
+#: src/olympia/devhub/views.py:354
 msgid "Theme deleted."
 msgstr ""
 
-#: src/olympia/devhub/views.py:356
+#: src/olympia/devhub/views.py:354
 msgid "Add-on deleted."
 msgstr ""
 
-#: src/olympia/devhub/views.py:362
+#: src/olympia/devhub/views.py:360
 msgid "URL name was incorrect. Theme was not deleted."
 msgstr ""
 
-#: src/olympia/devhub/views.py:367
+#: src/olympia/devhub/views.py:365
 msgid "URL name was incorrect. Add-on was not deleted."
 msgstr ""
 
@@ -4039,7 +4022,7 @@ msgstr ""
 msgid "Check Add-on Compatibility"
 msgstr ""
 
-#: src/olympia/devhub/views.py:808 src/olympia/signing/views.py:90
+#: src/olympia/devhub/views.py:808 src/olympia/signing/views.py:95
 msgid "You cannot submit this type of add-on"
 msgstr ""
 
@@ -4069,33 +4052,33 @@ msgstr ""
 msgid "There was an error uploading your preview."
 msgstr ""
 
-#: src/olympia/devhub/views.py:1189
+#: src/olympia/devhub/views.py:1195
 #, python-format
 msgid "Version %s disabled."
 msgstr ""
 
-#: src/olympia/devhub/views.py:1193
+#: src/olympia/devhub/views.py:1199
 #, python-format
 msgid "Version %s deleted."
 msgstr ""
 
-#: src/olympia/devhub/views.py:1203
+#: src/olympia/devhub/views.py:1209
 msgid "This upload has failed validation, and may lack complete validation results. Please take due care when reviewing it."
 msgstr ""
 
-#: src/olympia/devhub/views.py:1677
+#: src/olympia/devhub/views.py:1683
 msgid "Preliminary Review Requested."
 msgstr ""
 
-#: src/olympia/devhub/views.py:1678
+#: src/olympia/devhub/views.py:1684
 msgid "Full Review Requested."
 msgstr ""
 
-#: src/olympia/devhub/views.py:1779
+#: src/olympia/devhub/views.py:1783
 msgid "Your old credentials were revoked and are no longer valid. Be sure to update all API clients with the new credentials."
 msgstr ""
 
-#: src/olympia/devhub/views.py:1797
+#: src/olympia/devhub/views.py:1801
 msgid "New API key created"
 msgstr ""
 
@@ -4125,7 +4108,7 @@ msgstr ""
 msgid "{0} :: Search"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/devhub_search.html:6 src/olympia/devhub/templates/devhub/search.html:8 src/olympia/editors/forms.py:435 src/olympia/editors/forms.py:437
+#: src/olympia/devhub/templates/devhub/devhub_search.html:6 src/olympia/devhub/templates/devhub/search.html:8 src/olympia/editors/forms.py:534 src/olympia/editors/forms.py:536
 #: src/olympia/editors/templates/editors/queue.html:27 src/olympia/editors/templates/editors/themes/queue_list.html:14 src/olympia/search/templates/search/collections.html:17
 #: src/olympia/search/templates/search/personas.html:18 src/olympia/search/templates/search/results.html:18 src/olympia/search/templates/search/mobile/results.html:8
 #: src/olympia/templates/search.html:14 src/olympia/templates/impala/search.html:18
@@ -4185,12 +4168,12 @@ msgstr ""
 msgid "Start Making Add-ons"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/index.html:86 src/olympia/devhub/templates/devhub/addons/listing/items.html:25 src/olympia/devhub/templates/devhub/includes/addon_details.html:15
+#: src/olympia/devhub/templates/devhub/index.html:86 src/olympia/devhub/templates/devhub/addons/listing/items.html:25 src/olympia/devhub/templates/devhub/includes/addon_details.html:20
 #: src/olympia/devhub/templates/devhub/personas/edit.html:43
 msgid "Status:"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/index.html:90 src/olympia/devhub/templates/devhub/includes/addon_details.html:100
+#: src/olympia/devhub/templates/devhub/index.html:90 src/olympia/devhub/templates/devhub/includes/addon_details.html:87
 msgid "Visibility:"
 msgstr ""
 
@@ -4198,11 +4181,11 @@ msgstr ""
 msgid "Latest Version:"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/index.html:109 src/olympia/devhub/templates/devhub/includes/addon_details.html:145 src/olympia/devhub/templates/devhub/personas/edit.html:49
+#: src/olympia/devhub/templates/devhub/index.html:109 src/olympia/devhub/templates/devhub/includes/addon_details.html:131 src/olympia/devhub/templates/devhub/personas/edit.html:49
 msgid "Queue Position:"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/index.html:110 src/olympia/devhub/templates/devhub/includes/addon_details.html:146 src/olympia/devhub/templates/devhub/personas/edit.html:50
+#: src/olympia/devhub/templates/devhub/index.html:110 src/olympia/devhub/templates/devhub/includes/addon_details.html:132 src/olympia/devhub/templates/devhub/personas/edit.html:50
 #, python-format
 msgid "%(position)s of %(total)s"
 msgstr ""
@@ -4304,16 +4287,6 @@ msgstr ""
 msgid "Do you want your add-on to be distributed on this site?"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/validate_addon.html:49 src/olympia/devhub/templates/devhub/addons/submit/upload.html:30 src/olympia/devhub/templates/devhub/versions/add_file_modal.html:14
-#: src/olympia/devhub/templates/devhub/versions/add_file_modal.html:53 src/olympia/devhub/templates/devhub/versions/list.html:298
-msgid "Warning:"
-msgstr ""
-
-#: src/olympia/devhub/templates/devhub/validate_addon.html:50 src/olympia/devhub/templates/devhub/addons/submit/upload.html:31
-#, python-format
-msgid "Submission of unlisted add-ons for signing is currently in an open beta. Please <a href=\"%(url)s\" target=\"_blank\">report any bugs</a> that you encounter."
-msgstr ""
-
 #. first parameter is a filename like lorem-ipsum-1.0.2.xpi
 #: src/olympia/devhub/templates/devhub/validation.html:5
 msgid "Validation Results for {0}"
@@ -4388,7 +4361,7 @@ msgstr ""
 msgid "Update Compatibility"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/addons/ajax_compat_update.html:4
+#: src/olympia/devhub/templates/devhub/addons/ajax_compat_update.html:4 src/olympia/devhub/templates/devhub/versions/edit.html:45
 msgid "Adjusting application information here will allow users to install your add-on even if the install manifest in the package indicates that the add-on is incompatible."
 msgstr ""
 
@@ -4400,9 +4373,9 @@ msgstr ""
 msgid "Add Another Application&hellip;"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/addons/ajax_compat_update.html:38 src/olympia/devhub/templates/devhub/addons/owner.html:86 src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:46
-#: src/olympia/devhub/templates/devhub/versions/list.html:351 src/olympia/devhub/templates/devhub/versions/list.html:353 src/olympia/templates/impala/base.html:132
-#: src/olympia/templates/impala/base.html:143 src/olympia/templates/impala/base.html:161 src/olympia/templates/impala/base.html:171
+#: src/olympia/devhub/templates/devhub/addons/ajax_compat_update.html:38 src/olympia/devhub/templates/devhub/addons/owner.html:86 src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:45
+#: src/olympia/devhub/templates/devhub/versions/list.html:349 src/olympia/devhub/templates/devhub/versions/list.html:351 src/olympia/templates/impala/base.html:129
+#: src/olympia/templates/impala/base.html:140 src/olympia/templates/impala/base.html:158 src/olympia/templates/impala/base.html:168
 msgid "Close"
 msgstr ""
 
@@ -4436,7 +4409,7 @@ msgstr ""
 msgid "Manage Authors & License"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/addons/owner.html:29 src/olympia/editors/templates/editors/review.html:270
+#: src/olympia/devhub/templates/devhub/addons/owner.html:29 src/olympia/editors/helpers.py:362 src/olympia/editors/templates/editors/review.html:270
 msgid "Authors"
 msgstr "מפתחים"
 
@@ -4505,17 +4478,11 @@ msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/basic.html:52
 msgid ""
-"A short explanation of your add-on's basic\n"
-"                          functionality that is displayed in search and browse\n"
-"                          listings, as well as at the top of your add-on's\n"
-"                          details page. It is only relevant for listed add-ons."
+"A short explanation of your add-on's basic functionality that is displayed in search and browse listings, as well as at the top of your add-on's details page. It is only relevant for listed add-ons."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/basic.html:73
-msgid ""
-"Categories are the primary way users browse through add-ons.\n"
-"                        Choose any that fit your add-on's functionality for the most\n"
-"                        exposure. It is only relevant for listed add-ons."
+msgid "Categories are the primary way users browse through add-ons. Choose any that fit your add-on's functionality for the most exposure. It is only relevant for listed add-ons."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/basic.html:90
@@ -4525,11 +4492,7 @@ msgid ""
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/basic.html:119
-msgid ""
-"Tags help users find your add-on and should be short\n"
-"                        descriptors such as tabs, toolbar, or twitter.  You\n"
-"                        may have a maximum of {0} tags. It is only relevant\n"
-"                        for listed add-ons."
+msgid "Tags help users find your add-on and should be short descriptors such as tabs, toolbar, or twitter. You may have a maximum of {0} tags. It is only relevant for listed add-ons."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/basic.html:129 src/olympia/devhub/templates/devhub/personas/edit.html:97 src/olympia/devhub/templates/devhub/personas/submit.html:46
@@ -4557,11 +4520,7 @@ msgid "Add-on Details for {0}"
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/details.html:22
-msgid ""
-"A longer explanation of features,\n"
-"                          functionality, and other relevant information. This\n"
-"                          field is only displayed on the add-on's details\n"
-"                          page. It is only relevant for listed add-ons."
+msgid "A longer explanation of features, functionality, and other relevant information. This field is only displayed on the add-on's details page. It is only relevant for listed add-ons."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/details.html:44 src/olympia/translations/templates/translations/trans-menu.html:13
@@ -4569,10 +4528,7 @@ msgid "Default Locale"
 msgstr "מיקום לפי בררת המחדל"
 
 #: src/olympia/devhub/templates/devhub/addons/edit/details.html:45
-msgid ""
-"Information about your add-on is displayed in this locale\n"
-"                        unless you override it with a locale-specific translation.\n"
-"                        It is only relevant for listed add-ons."
+msgid "Information about your add-on is displayed in this locale unless you override it with a locale-specific translation. It is only relevant for listed add-ons."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/details.html:61 src/olympia/users/forms.py:311 src/olympia/users/templates/users/edit.html:122 src/olympia/users/templates/users/register.html:57
@@ -4582,10 +4538,8 @@ msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/details.html:63
 msgid ""
-"If your add-on has another homepage, enter its\n"
-"                          address here. If your website is localized into other\n"
-"                          languages multiple translations of this field can be\n"
-"                          added. It is only relevant for listed add-ons."
+"If your add-on has another homepage, enter its address here. If your website is localized into other languages multiple translations of this field can be added. It is only relevant for listed add-"
+"ons."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/media.html:3
@@ -4603,19 +4557,14 @@ msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/support.html:22
 msgid ""
-"If you wish to display an e-mail address for support\n"
-"                          inquiries, enter it here. If you have different\n"
-"                          addresses for each language multiple translations of\n"
-"                          this field can be added. It is only relevant for\n"
-"                          listed add-ons."
+"If you wish to display an e-mail address for support inquiries, enter it here. If you have different addresses for each language multiple translations of this field can be added. It is only "
+"relevant for listed add-ons."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/support.html:45
 msgid ""
-"If your add-on has a support website or forum, enter\n"
-"                          its address here. If your website is localized into\n"
-"                          other languages, multiple translations of this field can\n"
-"                          be added. It is only relevant for listed add-ons."
+"If your add-on has a support website or forum, enter its address here. If your website is localized into other languages, multiple translations of this field can be added. It is only relevant for "
+"listed add-ons."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:6
@@ -4629,11 +4578,8 @@ msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:23
 msgid ""
-"Any information end users may want to know that isn't\n"
-"                          necessarily applicable to the add-on summary or description.\n"
-"                          Common uses include listing known major bugs, information on\n"
-"                          how to report bugs, anticipated release date of a new version,\n"
-"                          etc. It is only relevant for listed add-ons."
+"Any information end users may want to know that isn't necessarily applicable to the add-on summary or description. Common uses include listing known major bugs, information on how to report bugs, "
+"anticipated release date of a new version, etc. It is only relevant for listed add-ons."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:46
@@ -4645,9 +4591,7 @@ msgid "Add-on Flags"
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:69
-msgid ""
-"These flags are used to classify add-ons. It is only\n"
-"                        relevant for listed add-ons."
+msgid "These flags are used to classify add-ons. It is only relevant for listed add-ons."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:74
@@ -4663,9 +4607,7 @@ msgid "View Source?"
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:90
-msgid ""
-"Whether the source of your add-on can be displayed in our\n"
-"                        online viewer. It is only relevant for listed add-ons."
+msgid "Whether the source of your add-on can be displayed in our online viewer. It is only relevant for listed add-ons."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:94
@@ -4681,10 +4623,7 @@ msgid "Public Stats?"
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:102
-msgid ""
-"Whether the download and usage stats of your add-on can\n"
-"                        be displayed in our online viewer.\n"
-"                        It is only relevant for listed add-ons."
+msgid "Whether the download and usage stats of your add-on can be displayed in our online viewer. It is only relevant for listed add-ons."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:107
@@ -4700,10 +4639,7 @@ msgid "Upgrade SDK?"
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:116
-msgid ""
-"If selected, we will try to automatically upgrade your\n"
-"                        add-on when a new version of the SDK is released.\n"
-"                        It is only relevant for listed add-ons."
+msgid "If selected, we will try to automatically upgrade your add-on when a new version of the SDK is released. It is only relevant for listed add-ons."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:121
@@ -4756,10 +4692,8 @@ msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/forms_shared/media.html:16
 msgid ""
-"Upload an icon for your add-on or choose from one of ours. The\n"
-"                      icon is displayed nearly everywhere your add-on is. Uploaded images\n"
-"                      must be one of the following image types: .png, .jpg.\n"
-"                      It is only relevant for listed add-ons."
+"Upload an icon for your add-on or choose from one of ours. The icon is displayed nearly everywhere your add-on is. Uploaded images must be one of the following image types: .png, .jpg. It is only "
+"relevant for listed add-ons."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/forms_shared/media.html:25
@@ -4772,9 +4706,7 @@ msgid "32x32px"
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/forms_shared/media.html:39
-msgid ""
-"Used in listings of add-ons, like search results\n"
-"                            and featured add-ons."
+msgid "Used in listings of add-ons, like search results and featured add-ons."
 msgstr ""
 
 #. The size of the icon
@@ -4869,16 +4801,14 @@ msgid "Deleting your add-on will permanently remove it from the site and prevent
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:24
-msgid ""
-"Enter the following text confirm your decision:\n"
-"           {slug}"
+msgid "Enter the following text confirm your decision: {slug}"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:34
+#: src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:33
 msgid "Please tell us why you are deleting your theme:"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:36
+#: src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:35
 msgid "Please tell us why you are deleting your add-on:"
 msgstr ""
 
@@ -4915,8 +4845,8 @@ msgstr "גרסה חדשה"
 msgid "Daily statistics on downloads and users."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/addons/listing/item_actions.html:45 src/olympia/stats/templates/stats/stats.html:75 src/olympia/stats/templates/stats/stats.html:79
-#: src/olympia/stats/templates/stats/stats.html:81
+#: src/olympia/devhub/templates/devhub/addons/listing/item_actions.html:45 src/olympia/stats/templates/stats/stats.html:31 src/olympia/stats/templates/stats/stats.html:35
+#: src/olympia/stats/templates/stats/stats.html:37
 msgid "Statistics"
 msgstr "סטטיסטיקות"
 
@@ -5035,10 +4965,7 @@ msgid "Your add-on has been submitted to the Full Review queue."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/submit/done.html:18
-msgid ""
-"You'll receive an email once it has been reviewed by an editor. In\n"
-"          the meantime, you and your friends can install it directly from its\n"
-"          details page:"
+msgid "You'll receive an email once it has been reviewed by an editor. In the meantime, you and your friends can install it directly from its details page:"
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/submit/done.html:27 src/olympia/devhub/templates/devhub/addons/submit/done.html:77 src/olympia/devhub/templates/devhub/personas/submit_done.html:16
@@ -5244,11 +5171,11 @@ msgstr ""
 msgid "Use the fields below to upload your add-on package and select any platform restrictions. After upload, a series of automated validation tests will be run on your file."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/addons/submit/upload.html:59 src/olympia/devhub/templates/devhub/versions/add_file_modal.html:39
+#: src/olympia/devhub/templates/devhub/addons/submit/upload.html:51 src/olympia/devhub/templates/devhub/versions/add_file_modal.html:28
 msgid "Which platforms is this file compatible with?"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/addons/submit/upload.html:67 src/olympia/devhub/templates/devhub/versions/add_file_modal.html:65
+#: src/olympia/devhub/templates/devhub/addons/submit/upload.html:59 src/olympia/devhub/templates/devhub/versions/add_file_modal.html:45
 msgid "Administrative overrides"
 msgstr ""
 
@@ -5358,8 +5285,8 @@ msgstr ""
 
 #: src/olympia/devhub/templates/devhub/docs/policies-contact.html:44
 msgid ""
-"If you've found a problem with the site, we'd love to fix it. Please <a href=\"https://github.com/mozilla/olympia/issues\">file a bug report</a> in GitHub, including the location of the problem and "
-"how you encountered it."
+"If you've found a problem with the site, we'd love to fix it. Please <a href=\"https://github.com/mozilla/addons/issues/new\">file a bug report</a> in GitHub, including the location of the problem "
+"and how you encountered it."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/docs/policies-maintenance.html:3 src/olympia/devhub/templates/devhub/docs/policies-maintenance.html:7
@@ -5926,7 +5853,7 @@ msgstr ""
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:282
 msgid ""
-"Add-ons that store or otherwise handle browsing data must support <a href=\"https://developer.mozilla.org/En/Supporting_private_browsing_mode\">Private Browsing Mode</a>.  During a Private Browsing "
+"Add-ons that store or otherwise handle browsing data must support <a href=\"https://developer.mozilla.org/En/Supporting_private_browsing_mode\">Private Browsing Mode</a>. During a Private Browsing "
 "session, no browsing data can be written to disk, and all of this data must be cleared when Firefox quits or the Private Browsing session ends."
 msgstr ""
 
@@ -6091,129 +6018,95 @@ msgstr ""
 msgid "How to get in touch with us regarding these policies or your add-on."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:6
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:10
 msgid "You have disabled this add-on"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:20
-msgid ""
-"Your add-on's listing is disabled and is not showing\n"
-"                             anywhere in our gallery or update service."
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:24
+msgid "Your add-on's listing is disabled and is not showing anywhere in our gallery or update service."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:25
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:27
 msgid "Please complete your add-on."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:29
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:30
 msgid "You will receive an email when the review is complete."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:34
-msgid ""
-"You will receive an email when the review is complete. Until\n"
-"                             then, your add-on is not listed in our gallery but can be\n"
-"                             accessed directly from its details page."
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:33
+msgid "You will receive an email when the review is complete. Until then, your add-on is not listed in our gallery but can be accessed directly from its details page."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:38 src/olympia/devhub/templates/devhub/includes/addon_details.html:48
-msgid ""
-"You will receive an email when the review is\n"
-"                             complete and your add-on is signed."
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:37 src/olympia/devhub/templates/devhub/includes/addon_details.html:45
+msgid "You will receive an email when the review is complete and your add-on is signed."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:44
-msgid ""
-"You will receive an email when the review is complete. Until\n"
-"                             then, your add-on is not listed in our gallery but can be\n"
-"                             accessed directly from its details page. "
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:41
+msgid "You will receive an email when the review is complete. Until then, your add-on is not listed in our gallery but can be accessed directly from its details page. "
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:54
-msgid ""
-"Your add-on is displayed in our gallery and users are\n"
-"                             receiving automatic updates."
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:49
+msgid "Your add-on is displayed in our gallery and users are receiving automatic updates."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:57
-msgid ""
-"Your add-on has been signed and can be bundled with an\n"
-"                             application installer."
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:52
+msgid "Your add-on has been signed and can be bundled with an application installer."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:63
-msgid ""
-"Your add-on was disabled by a site administrator and is no\n"
-"                             longer shown in our gallery. If you have any questions,\n"
-"                             please email amo-admins@mozilla.org."
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:56
+msgid "Your add-on was disabled by a site administrator and is no longer shown in our gallery. If you have any questions, please email amo-admins@mozilla.org."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:70
-msgid ""
-"Your add-on is displayed in our gallery as experimental\n"
-"                             and users are receiving automatic updates. Some features\n"
-"                             are unavailable to your add-on."
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:62
+msgid "Your add-on is displayed in our gallery as experimental and users are receiving automatic updates. Some features are unavailable to your add-on."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:74
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:66
 msgid "Your add-on has been signed."
 msgstr ""
 
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:69
+msgid ""
+"You will receive an email when the full review is complete. Until then, your add-on is displayed in our gallery as experimental and users are receiving automatic updates. Some features are "
+"unavailable to your add-on."
+msgstr ""
+
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:74
+msgid "You will receive an email when the full review is complete, making you able to bundle your add-on with an application installer."
+msgstr ""
+
 #: src/olympia/devhub/templates/devhub/includes/addon_details.html:79
-msgid ""
-"You will receive an email when the full review is complete.\n"
-"                             Until then, your add-on is displayed in our gallery as\n"
-"                             experimental and users are receiving automatic updates.\n"
-"                             Some features are unavailable to your add-on."
+msgid "All add-ons hosted in our gallery must now be reviewed by an editor. If you wish to continue hosting your add-on, please click to select a review process."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:84
-msgid ""
-"You will receive an email when the full review is\n"
-"                             complete, making you able to bundle your add-on with an\n"
-"                             application installer."
-msgstr ""
-
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:91
-msgid ""
-"All add-ons hosted in our gallery must now be reviewed by an\n"
-"                             editor. If you wish to continue hosting your add-on, please\n"
-"                             click to select a review process."
-msgstr ""
-
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:113
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:100
 msgid "Current Version:"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:115
-msgid ""
-"This is the version of your add-on that will\n"
-"                                           be installed if someone clicks the Install\n"
-"                                           button on addons.mozilla.org. It is only\n"
-"                                           relevant for listed add-ons."
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:102
+msgid "This is the version of your add-on that will be installed if someone clicks the Install button on addons.mozilla.org. It is only relevant for listed add-ons."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:123
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:110
 msgid "Created:"
 msgstr ""
 
 #. {0} is a date. dennis-ignore: E201
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:125 src/olympia/devhub/templates/devhub/includes/addon_details.html:131
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:112 src/olympia/devhub/templates/devhub/includes/addon_details.html:118
 #, python-format
 msgid "%%b %%e, %%Y"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:136
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:123
 msgid "Next Version:"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:138
-msgid ""
-"This is the newest uploaded version, however\n"
-"                                           it isn’t live on the site yet."
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:125
+msgid "This is the newest uploaded version, however it isn’t live on the site yet."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:144 src/olympia/devhub/templates/devhub/versions/list.html:30
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:130 src/olympia/devhub/templates/devhub/versions/list.html:30
 msgid "Queues are not reviewed strictly in order"
 msgstr ""
 
@@ -6287,9 +6180,7 @@ msgid "View the blog &#9658;"
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/includes/license_form.html:6
-msgid ""
-"Please choose a license appropriate for the rights you grant on your source code.\n"
-"                  It is only relevant for listed add-ons."
+msgid "Please choose a license appropriate for the rights you grant on your source code. It is only relevant for listed add-ons."
 msgstr ""
 
 #. {0} is a list of HTML tags.
@@ -6316,14 +6207,11 @@ msgstr[1] ""
 #: src/olympia/devhub/templates/devhub/includes/policy_form.html:4
 msgid ""
 "Users will be required to accept the following End-User License Agreement (EULA) prior to installing your add-on. The presence of a EULA significantly affects the number of downloads an add-on "
-"receives. Please note that a EULA is not the same as a code license, such as the GPL or MPL.\n"
-"                It is only relevant for listed add-ons."
+"receives. Please note that a EULA is not the same as a code license, such as the GPL or MPL.It is only relevant for listed add-ons."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/policy_form.html:21
-msgid ""
-"If your add-on transmits any data from the user's computer, a privacy policy is required that explains what data is sent and how it is used.\n"
-"                It is only relevant for listed add-ons."
+#: src/olympia/devhub/templates/devhub/includes/policy_form.html:24
+msgid "If your add-on transmits any data from the user's computer, a privacy policy is required that explains what data is sent and how it is used. It is only relevant for listed add-ons."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/includes/source_form_field.html:2
@@ -6491,12 +6379,8 @@ msgstr ""
 msgid "Add some tags to describe your Theme."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/personas/edit.html:106
-msgid ""
-"A short explanation of your theme's\n"
-"                                basic functionality that is displayed in\n"
-"                                search and browse listings, as well as at\n"
-"                                the top of your theme's details page."
+#: src/olympia/devhub/templates/devhub/personas/edit.html:106 src/olympia/devhub/templates/devhub/personas/submit.html:54
+msgid "A short explanation of your theme's basic functionality that is displayed in search and browse listings, as well as at the top of your theme's details page."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/personas/edit.html:122 src/olympia/devhub/templates/devhub/personas/submit.html:68
@@ -6566,7 +6450,7 @@ msgid "Upon upload and form submission, the AMO Team will review your updated de
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/personas/edit.html:241
-msgid "Your previously resubmitted design,  which is under pending review."
+msgid "Your previously resubmitted design, which is under pending review."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/personas/edit.html:245
@@ -6633,14 +6517,6 @@ msgstr ""
 
 #: src/olympia/devhub/templates/devhub/personas/submit.html:33
 msgid "Give your Theme a name."
-msgstr ""
-
-#: src/olympia/devhub/templates/devhub/personas/submit.html:54
-msgid ""
-"A short explanation of your theme's\n"
-"                                      basic functionality that is displayed in\n"
-"                                      search and browse listings, as well as at\n"
-"                                      the top of your theme's details page."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/personas/submit.html:198
@@ -6717,30 +6593,16 @@ msgstr ""
 msgid "Files added to reviewed versions must be reviewed before they will be available for download."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/add_file_modal.html:15
-#, python-format
-msgid ""
-"Submission of updates to unlisted add-ons for signing is currently in an open beta. Manual review may still be required for a large number of add-ons. Please <a href=\"%(url)s\" target=\"_blank"
-"\">report any bugs</a> that you encounter."
-msgstr ""
-
-#: src/olympia/devhub/templates/devhub/versions/add_file_modal.html:35
+#: src/olympia/devhub/templates/devhub/versions/add_file_modal.html:24
 msgid "Select the target platform for this file."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/add_file_modal.html:46
+#: src/olympia/devhub/templates/devhub/versions/add_file_modal.html:35
 msgid "Which review type would you like to nominate for?"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/add_file_modal.html:51
+#: src/olympia/devhub/templates/devhub/versions/add_file_modal.html:40
 msgid "Only publish this version to my beta channel."
-msgstr ""
-
-#: src/olympia/devhub/templates/devhub/versions/add_file_modal.html:54
-#, python-format
-msgid ""
-"The behavior of the beta channel has changed to accommodate <a href=\"%(addon_signing_url)s\" target=\"_blank\">mandatory add-on signing</a>. The new process is currently in an open beta, and may "
-"change significantly in the near future. Please <a href=\"%(issues_url)s\" target=\"_blank\">report any bugs</a> that you encounter."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/versions/edit.html:5
@@ -6765,19 +6627,10 @@ msgstr ""
 msgid "Upload Another File"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/edit.html:45
-msgid ""
-"Adjusting application information here will allow users to install your\n"
-"                          add-on even if the install manifest in the package indicates that the\n"
-"                          add-on is incompatible."
-msgstr ""
-
 #: src/olympia/devhub/templates/devhub/versions/edit.html:74
 msgid ""
-"Information about changes in this release, new features,\n"
-"                              known bugs, and other useful information specific to this\n"
-"                              release/version. This information is also shown in the\n"
-"                              Add-ons Manager when updating."
+"Information about changes in this release, new features, known bugs, and other useful information specific to this release/version. This information is also shown in the Add-ons Manager when "
+"updating."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/versions/edit.html:99
@@ -6789,10 +6642,7 @@ msgid "Notes for Reviewers"
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/versions/edit.html:114
-msgid ""
-"Optionally, enter any information that may be useful\n"
-"                              to the Editor reviewing this add-on, such as test\n"
-"                              account information."
+msgid "Optionally, enter any information that may be useful to the Editor reviewing this add-on, such as test account information."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/versions/edit.html:127
@@ -6870,7 +6720,7 @@ msgstr ""
 msgid "Request Preliminary Review"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:80 src/olympia/devhub/templates/devhub/versions/list.html:327 src/olympia/devhub/templates/devhub/versions/list.html:350
+#: src/olympia/devhub/templates/devhub/versions/list.html:80 src/olympia/devhub/templates/devhub/versions/list.html:325 src/olympia/devhub/templates/devhub/versions/list.html:348
 msgid "Cancel Review Request"
 msgstr ""
 
@@ -6899,7 +6749,7 @@ msgid "Unlisted:"
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/versions/list.html:114
-msgid "Not distributed on {0}. Developers will upload new versions for signing and distribute the add-ons on their own. (beta)"
+msgid "Not distributed on {0}. Developers will upload new versions for signing and distribute the add-ons on their own."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/versions/list.html:122
@@ -6963,84 +6813,76 @@ msgid "<strong>Important:</strong> Once a version has been deleted, you may not 
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/versions/list.html:230
-msgid ""
-"Deleting a version which has already been reviewed\n"
-"               may also cause a significant delay in the review of\n"
-"               your next update."
-msgstr ""
-
-#: src/olympia/devhub/templates/devhub/versions/list.html:233
 msgid "Are you sure you wish to delete this version?"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:238
+#: src/olympia/devhub/templates/devhub/versions/list.html:235
 msgid "Delete Version"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:240
+#: src/olympia/devhub/templates/devhub/versions/list.html:237
 msgid "Disable Version"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:247
+#: src/olympia/devhub/templates/devhub/versions/list.html:244
 msgid "Add a new Version"
 msgstr ""
 
 # 75%
 # 100%
-#: src/olympia/devhub/templates/devhub/versions/list.html:249
+#: src/olympia/devhub/templates/devhub/versions/list.html:246
 #, fuzzy
 msgid "Add Version"
 msgstr "All Versions"
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:256 src/olympia/devhub/templates/devhub/versions/list.html:274
+#: src/olympia/devhub/templates/devhub/versions/list.html:253 src/olympia/devhub/templates/devhub/versions/list.html:279
 msgid "Hide Add-on"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:259
+#: src/olympia/devhub/templates/devhub/versions/list.html:256
 msgid "Hiding your add-on will prevent it from appearing anywhere in our gallery and will stop users from receiving automatic updates."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:265
+#: src/olympia/devhub/templates/devhub/versions/list.html:263
+msgid "The files awaiting review will be disabled and you will need to upload new versions."
+msgstr ""
+
+#: src/olympia/devhub/templates/devhub/versions/list.html:270
 msgid "Are you sure you wish to hide your add-on?"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:286 src/olympia/devhub/templates/devhub/versions/list.html:315
+#: src/olympia/devhub/templates/devhub/versions/list.html:291 src/olympia/devhub/templates/devhub/versions/list.html:313
 msgid "Unlist Add-on"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:289
+#: src/olympia/devhub/templates/devhub/versions/list.html:294
 #, python-format
 msgid ""
 "Unlisting your add-on will make it (and each of its versions/files) invisible on this website. It won't show up in searches, won't have a public facing page, and won't be updated automatically for "
-"current users.  It is recommended for unlisted add-ons to provide a custom <a href=\"%(update_url)s\" target=\"_blank\">updateURL</a> in their manifest file for automatic updates."
+"current users. It is recommended for unlisted add-ons to provide a custom <a href=\"%(update_url)s\" target=\"_blank\">updateURL</a> in their manifest file for automatic updates."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:299
-#, python-format
-msgid "Switching add-ons to unlisted is currently in an open beta. Please <a href=\"%(url)s\" target=\"_blank\">report any bugs</a> that you encounter."
-msgstr ""
-
-#: src/olympia/devhub/templates/devhub/versions/list.html:305
+#: src/olympia/devhub/templates/devhub/versions/list.html:303
 msgid "Unlisting an add-on is irreversible!"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:305
+#: src/olympia/devhub/templates/devhub/versions/list.html:303
 msgid "An unlisted add-on cannot be switched to be listed."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:307
+#: src/olympia/devhub/templates/devhub/versions/list.html:305
 msgid "Are you sure you wish to unlist your add-on?"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:330
+#: src/olympia/devhub/templates/devhub/versions/list.html:328
 msgid "Canceling your review request will leave your add-on as preliminarily reviewed."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:335
+#: src/olympia/devhub/templates/devhub/versions/list.html:333
 msgid "Canceling your review request will mark your add-on incomplete. If you do not complete your add-on after several days by re-requesting review, it will be deleted."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:343
+#: src/olympia/devhub/templates/devhub/versions/list.html:341
 msgid "Are you sure you wish to cancel your review request?"
 msgstr ""
 
@@ -7387,19 +7229,19 @@ msgstr ""
 msgid "Search by add-on name / author email"
 msgstr ""
 
-#: src/olympia/editors/forms.py:103
+#: src/olympia/editors/forms.py:103 src/olympia/editors/forms.py:244 src/olympia/editors/forms.py:257
 msgid "yes"
 msgstr ""
 
-#: src/olympia/editors/forms.py:104
+#: src/olympia/editors/forms.py:104 src/olympia/editors/forms.py:244 src/olympia/editors/forms.py:257
 msgid "no"
 msgstr ""
 
-#: src/olympia/editors/forms.py:105
+#: src/olympia/editors/forms.py:105 src/olympia/editors/forms.py:245
 msgid "Admin Flag"
 msgstr ""
 
-#: src/olympia/editors/forms.py:113
+#: src/olympia/editors/forms.py:113 src/olympia/editors/forms.py:253
 msgid "Max. Version"
 msgstr ""
 
@@ -7411,55 +7253,59 @@ msgstr ""
 msgid "Add-on Types"
 msgstr ""
 
-#: src/olympia/editors/forms.py:126 src/olympia/editors/helpers.py:267
+#: src/olympia/editors/forms.py:126 src/olympia/editors/helpers.py:279
 msgid "Platforms"
 msgstr "פלטפורמות"
 
+#: src/olympia/editors/forms.py:237
+msgid "Search by add-on name / author email / guid"
+msgstr ""
+
 #. L10n: 0 = platform, 1 = filename, 2 = status message
-#: src/olympia/editors/forms.py:238
+#: src/olympia/editors/forms.py:342
 #, python-format
 msgid "<strong>%s</strong> &middot; %s &middot; %s"
 msgstr ""
 
-#: src/olympia/editors/forms.py:252
+#: src/olympia/editors/forms.py:356
 msgid "Comments:"
 msgstr ""
 
-#: src/olympia/editors/forms.py:256
+#: src/olympia/editors/forms.py:360
 msgid "Operating systems:"
 msgstr ""
 
-#: src/olympia/editors/forms.py:258
+#: src/olympia/editors/forms.py:362
 msgid "Applications:"
 msgstr ""
 
-#: src/olympia/editors/forms.py:260
+#: src/olympia/editors/forms.py:364
 msgid "Notify me the next time this add-on is updated. (Subsequent updates will not generate an email)"
 msgstr ""
 
-#: src/olympia/editors/forms.py:265
+#: src/olympia/editors/forms.py:369
 msgid "Clear Admin Review Flag"
 msgstr ""
 
-#: src/olympia/editors/forms.py:267
+#: src/olympia/editors/forms.py:371
 msgid "Clear more info requested flag"
 msgstr ""
 
-#: src/olympia/editors/forms.py:281
+#: src/olympia/editors/forms.py:385
 msgid "Choose a canned response..."
 msgstr ""
 
 #. L10n: Description of what can be searched for.
-#: src/olympia/editors/forms.py:324
+#: src/olympia/editors/forms.py:423
 msgid "theme name"
 msgstr ""
 
-#: src/olympia/editors/forms.py:350
+#: src/olympia/editors/forms.py:449
 msgid "Someone else is reviewing this theme."
 msgstr ""
 
 #. L10n: Description of what can be searched for.
-#: src/olympia/editors/forms.py:447
+#: src/olympia/editors/forms.py:546
 msgid "app, reviewer, or comment"
 msgstr ""
 
@@ -7475,246 +7321,264 @@ msgstr ""
 msgid "Rejected or Unreviewed"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:123 src/olympia/editors/helpers.py:136
+#: src/olympia/editors/helpers.py:125 src/olympia/editors/helpers.py:138
 msgid "Queue"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:124 src/olympia/editors/templates/editors/base.html:50 src/olympia/editors/templates/editors/base.html:65
+#: src/olympia/editors/helpers.py:126 src/olympia/editors/templates/editors/base.html:50 src/olympia/editors/templates/editors/base.html:65
 msgid "Pending Updates"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:125 src/olympia/editors/templates/editors/base.html:48 src/olympia/editors/templates/editors/base.html:63
+#: src/olympia/editors/helpers.py:127 src/olympia/editors/templates/editors/base.html:48 src/olympia/editors/templates/editors/base.html:63
 msgid "Full Reviews"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:126 src/olympia/editors/templates/editors/base.html:52 src/olympia/editors/templates/editors/base.html:67
+#: src/olympia/editors/helpers.py:128 src/olympia/editors/templates/editors/base.html:52 src/olympia/editors/templates/editors/base.html:67
 msgid "Preliminary Reviews"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:127 src/olympia/editors/templates/editors/base.html:54
+#: src/olympia/editors/helpers.py:129 src/olympia/editors/templates/editors/base.html:54
 msgid "Moderated Reviews"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:128 src/olympia/editors/templates/editors/base.html:46
+#: src/olympia/editors/helpers.py:130 src/olympia/editors/templates/editors/base.html:46
 msgid "Fast Track"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:130
+#: src/olympia/editors/helpers.py:132
 msgid "Pending Themes"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:131 src/olympia/editors/templates/editors/themes/queue.html:4
+#: src/olympia/editors/helpers.py:133 src/olympia/editors/templates/editors/themes/queue.html:4
 msgid "Flagged Themes"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:132
+#: src/olympia/editors/helpers.py:134
 msgid "Update Themes"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:137
+#: src/olympia/editors/helpers.py:139
 msgid "Unlisted Pending Updates"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:138
+#: src/olympia/editors/helpers.py:140
 msgid "Unlisted Full Reviews"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:139
+#: src/olympia/editors/helpers.py:141
 msgid "Unlisted Preliminary Reviews"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:170
+#: src/olympia/editors/helpers.py:142
+msgid "Unlisted All Add-ons"
+msgstr ""
+
+#: src/olympia/editors/helpers.py:173
 msgid "Fast Track ({0})"
 msgid_plural "Fast Track ({0})"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/olympia/editors/helpers.py:175
+#: src/olympia/editors/helpers.py:178
 msgid "Full Review ({0})"
 msgid_plural "Full Reviews ({0})"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/olympia/editors/helpers.py:180
+#: src/olympia/editors/helpers.py:183
 msgid "Pending Update ({0})"
 msgid_plural "Pending Updates ({0})"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/olympia/editors/helpers.py:185
+#: src/olympia/editors/helpers.py:188
 msgid "Preliminary Review ({0})"
 msgid_plural "Preliminary Reviews ({0})"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/olympia/editors/helpers.py:190
+#: src/olympia/editors/helpers.py:193
 msgid "Moderated Review ({0})"
 msgid_plural "Moderated Reviews ({0})"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/olympia/editors/helpers.py:196
+#: src/olympia/editors/helpers.py:199
 msgid "Unlisted Full Review ({0})"
 msgid_plural "Unlisted Full Reviews ({0})"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/olympia/editors/helpers.py:201
+#: src/olympia/editors/helpers.py:204
 msgid "Unlisted Pending Update ({0})"
 msgid_plural "Unlisted Pending Updates ({0})"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/olympia/editors/helpers.py:206
+#: src/olympia/editors/helpers.py:209
 msgid "Unlisted Preliminary Review ({0})"
 msgid_plural "Unlisted Preliminary Reviews ({0})"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/olympia/editors/helpers.py:261
-msgid "Addon"
-msgstr ""
+#: src/olympia/editors/helpers.py:214
+msgid "Unlisted All Add-ons ({0})"
+msgid_plural "Unlisted All Add-ons ({0})"
+msgstr[0] ""
+msgstr[1] ""
 
-#: src/olympia/editors/helpers.py:262
+#: src/olympia/editors/helpers.py:274
 msgid "Type"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:263
+#: src/olympia/editors/helpers.py:275
 msgid "Waiting Time"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:264 src/olympia/editors/templates/editors/review.html:285
+#: src/olympia/editors/helpers.py:276 src/olympia/editors/templates/editors/review.html:285
 msgid "Flags"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:265
+#: src/olympia/editors/helpers.py:277
 msgid "Applications"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:270
+#: src/olympia/editors/helpers.py:282
 msgid "Additional"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:285
+#: src/olympia/editors/helpers.py:302
 msgid "Site Specific"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:287
+#: src/olympia/editors/helpers.py:304
 msgid "Requires External Software"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:289
+#: src/olympia/editors/helpers.py:306
 msgid "Binary Components"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:313
+#: src/olympia/editors/helpers.py:339
 msgid "moments ago"
 msgstr ""
 
 #. L10n: first argument is number of minutes
-#: src/olympia/editors/helpers.py:316
+#: src/olympia/editors/helpers.py:342
 msgid "{0} minute"
 msgid_plural "{0} minutes"
 msgstr[0] ""
 msgstr[1] ""
 
 #. L10n: first argument is number of hours
-#: src/olympia/editors/helpers.py:320
+#: src/olympia/editors/helpers.py:346
 msgid "{0} hour"
 msgid_plural "{0} hours"
 msgstr[0] ""
 msgstr[1] ""
 
 #. L10n: first argument is number of days
-#: src/olympia/editors/helpers.py:324
+#: src/olympia/editors/helpers.py:350
 msgid "{0} day"
 msgid_plural "{0} days"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/olympia/editors/helpers.py:488
+#: src/olympia/editors/helpers.py:364
+msgid "Last Review"
+msgstr ""
+
+#: src/olympia/editors/helpers.py:366
+msgid "Last Update"
+msgstr ""
+
+#: src/olympia/editors/helpers.py:387
+msgid "No Reviews"
+msgstr ""
+
+#: src/olympia/editors/helpers.py:561
 msgid "Push to public"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:490
+#: src/olympia/editors/helpers.py:563
 msgid "Grant full review"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:505
+#: src/olympia/editors/helpers.py:578
 msgid "Request more information"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:508
+#: src/olympia/editors/helpers.py:581
 msgid "Request super-review"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:519
+#: src/olympia/editors/helpers.py:592
 msgid "Grant preliminary review"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:520
+#: src/olympia/editors/helpers.py:593
 msgid "This will mark the files as preliminarily reviewed."
 msgstr ""
 
-#: src/olympia/editors/helpers.py:522
+#: src/olympia/editors/helpers.py:595
 msgid "Use this form to request more information from the author. They will receive an email and be able to answer here. You will be notified by email when they reply."
 msgstr ""
 
-#: src/olympia/editors/helpers.py:526
+#: src/olympia/editors/helpers.py:599
 msgid ""
 "If you have concerns about this add-on's security, copyright issues, or other concerns that an administrator should look into, enter your comments in the area below. They will be sent to "
 "administrators, not the author."
 msgstr ""
 
-#: src/olympia/editors/helpers.py:532
+#: src/olympia/editors/helpers.py:605
 msgid "This will reject the add-on and remove it from the review queue."
 msgstr ""
 
-#: src/olympia/editors/helpers.py:534
-msgid "Make a comment on this version.  The author won't be able to see this."
+#: src/olympia/editors/helpers.py:607
+msgid "Make a comment on this version. The author won't be able to see this."
 msgstr ""
 
-#: src/olympia/editors/helpers.py:538
+#: src/olympia/editors/helpers.py:611
 msgid "This will reject the files and remove them from the review queue."
 msgstr ""
 
-#: src/olympia/editors/helpers.py:542
+#: src/olympia/editors/helpers.py:615
 msgid "This will mark the add-on as preliminarily reviewed. Future versions will undergo preliminary review."
 msgstr ""
 
-#: src/olympia/editors/helpers.py:547
+#: src/olympia/editors/helpers.py:620
 msgid "This will mark the files as preliminarily reviewed. Future versions will undergo preliminary review."
 msgstr ""
 
-#: src/olympia/editors/helpers.py:552
+#: src/olympia/editors/helpers.py:625
 msgid "Retain preliminary review"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:553
+#: src/olympia/editors/helpers.py:626
 msgid "This will retain the add-on as preliminarily reviewed. Future versions will undergo preliminary review."
 msgstr ""
 
-#: src/olympia/editors/helpers.py:558
+#: src/olympia/editors/helpers.py:631
 msgid "This will approve a sandboxed version of a public add-on to appear on the public side."
 msgstr ""
 
-#: src/olympia/editors/helpers.py:561
+#: src/olympia/editors/helpers.py:634
 msgid "This will reject a version of a public add-on and remove it from the queue."
 msgstr ""
 
-#: src/olympia/editors/helpers.py:564
+#: src/olympia/editors/helpers.py:637
 msgid "This will mark the add-on and its most recent version and files as public. Future versions will go into the sandbox until they are reviewed by an editor."
 msgstr ""
 
-#: src/olympia/editors/helpers.py:637
+#: src/olympia/editors/helpers.py:714
 msgid "add-on"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:940 src/olympia/editors/helpers.py:960
+#: src/olympia/editors/helpers.py:1020 src/olympia/editors/helpers.py:1040
 msgid "Flagged"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:944 src/olympia/editors/helpers.py:963
+#: src/olympia/editors/helpers.py:1024 src/olympia/editors/helpers.py:1043
 msgid "Updates"
 msgstr ""
 
@@ -7766,56 +7630,56 @@ msgstr ""
 msgid "A question about your Theme submission"
 msgstr ""
 
-#: src/olympia/editors/views.py:144
+#: src/olympia/editors/views.py:146
 msgid "New Add-ons (Under 5 days)"
 msgstr ""
 
-#: src/olympia/editors/views.py:145
+#: src/olympia/editors/views.py:147
 msgid "Passable (5 to 10 days)"
 msgstr ""
 
-#: src/olympia/editors/views.py:146
+#: src/olympia/editors/views.py:148
 msgid "Overdue (Over 10 days)"
 msgstr ""
 
-#: src/olympia/editors/views.py:532
+#: src/olympia/editors/views.py:539
 msgid "An unknown error occurred"
 msgstr ""
 
-#: src/olympia/editors/views.py:587
+#: src/olympia/editors/views.py:592
 msgid "Self-reviews are not allowed."
 msgstr ""
 
-#: src/olympia/editors/views.py:609
+#: src/olympia/editors/views.py:613
 msgid "Review successfully processed."
 msgstr ""
 
-#: src/olympia/editors/views.py:807
+#: src/olympia/editors/views.py:812
 msgid "was approved"
 msgstr ""
 
-#: src/olympia/editors/views.py:808
+#: src/olympia/editors/views.py:813
 msgid "given preliminary review"
 msgstr ""
 
-#: src/olympia/editors/views.py:809
+#: src/olympia/editors/views.py:814
 msgid "rejected"
 msgstr ""
 
-#: src/olympia/editors/views.py:810
+#: src/olympia/editors/views.py:815
 msgctxt "editors_review_history_nominated_adminreview"
 msgid "escalated"
 msgstr ""
 
-#: src/olympia/editors/views.py:812
+#: src/olympia/editors/views.py:817
 msgid "needs more information"
 msgstr ""
 
-#: src/olympia/editors/views.py:813
+#: src/olympia/editors/views.py:818
 msgid "needs super review"
 msgstr ""
 
-#: src/olympia/editors/views.py:814
+#: src/olympia/editors/views.py:819
 msgid "commented"
 msgstr ""
 
@@ -7860,28 +7724,28 @@ msgstr ""
 msgid "Unlisted Queues"
 msgstr ""
 
-#: src/olympia/editors/templates/editors/base.html:72 src/olympia/editors/templates/editors/performance.html:6
+#: src/olympia/editors/templates/editors/base.html:74 src/olympia/editors/templates/editors/performance.html:6
 msgid "Performance"
 msgstr "ביצועים"
 
-#: src/olympia/editors/templates/editors/base.html:75 src/olympia/editors/templates/editors/themes/base.html:19 src/olympia/editors/templates/editors/themes/base.html:38
+#: src/olympia/editors/templates/editors/base.html:77 src/olympia/editors/templates/editors/themes/base.html:19 src/olympia/editors/templates/editors/themes/base.html:38
 msgid "Logs"
 msgstr ""
 
-#: src/olympia/editors/templates/editors/base.html:78 src/olympia/editors/templates/editors/reviewlog.html:4 src/olympia/editors/templates/editors/reviewlog.html:27
+#: src/olympia/editors/templates/editors/base.html:80 src/olympia/editors/templates/editors/reviewlog.html:4 src/olympia/editors/templates/editors/reviewlog.html:27
 msgid "Add-on Review Log"
 msgstr ""
 
-#: src/olympia/editors/templates/editors/base.html:80 src/olympia/editors/templates/editors/eventlog.html:4 src/olympia/editors/templates/editors/eventlog.html:8
+#: src/olympia/editors/templates/editors/base.html:82 src/olympia/editors/templates/editors/eventlog.html:4 src/olympia/editors/templates/editors/eventlog.html:8
 #: src/olympia/editors/templates/editors/eventlog_detail.html:4
 msgid "Moderated Review Log"
 msgstr ""
 
-#: src/olympia/editors/templates/editors/base.html:82 src/olympia/editors/templates/editors/beta_signed_log.html:4 src/olympia/editors/templates/editors/beta_signed_log.html:8
+#: src/olympia/editors/templates/editors/base.html:84 src/olympia/editors/templates/editors/beta_signed_log.html:4 src/olympia/editors/templates/editors/beta_signed_log.html:8
 msgid "Signed Beta Files Log"
 msgstr ""
 
-#: src/olympia/editors/templates/editors/base.html:87 src/olympia/editors/templates/editors/includes/daily-message.html:4
+#: src/olympia/editors/templates/editors/base.html:89 src/olympia/editors/templates/editors/includes/daily-message.html:4
 msgid "Announcement"
 msgstr ""
 
@@ -8102,45 +7966,45 @@ msgstr ""
 msgid "clear search"
 msgstr ""
 
-#: src/olympia/editors/templates/editors/queue.html:72 src/olympia/editors/templates/editors/queue.html:122
+#: src/olympia/editors/templates/editors/queue.html:78 src/olympia/editors/templates/editors/queue.html:128
 msgid "Process Reviews"
 msgstr ""
 
-#: src/olympia/editors/templates/editors/queue.html:80
+#: src/olympia/editors/templates/editors/queue.html:86
 msgid "Moderation actions:"
 msgstr ""
 
-#: src/olympia/editors/templates/editors/queue.html:90
+#: src/olympia/editors/templates/editors/queue.html:96
 #, python-format
 msgid "by %(user)s on %(date)s %(stars)s (%(locale)s)"
 msgstr ""
 
-#: src/olympia/editors/templates/editors/queue.html:106
+#: src/olympia/editors/templates/editors/queue.html:112
 #, python-format
 msgid "<strong>%(reason)s</strong> <span class=\"light\">Flagged by %(user)s on %(date)s</span>"
 msgstr ""
 
-#: src/olympia/editors/templates/editors/queue.html:119
-msgid "All reviews have been moderated.  Good work!"
+#: src/olympia/editors/templates/editors/queue.html:125
+msgid "All reviews have been moderated. Good work!"
 msgstr ""
 
-#: src/olympia/editors/templates/editors/queue.html:161
+#: src/olympia/editors/templates/editors/queue.html:167
 msgid "Version Notes / Notes for Reviewer"
 msgstr ""
 
-#: src/olympia/editors/templates/editors/queue.html:169
+#: src/olympia/editors/templates/editors/queue.html:175
 msgid "There are currently no add-ons of this type to review."
 msgstr ""
 
-#: src/olympia/editors/templates/editors/queue.html:181 src/olympia/editors/templates/editors/themes/queue_list.html:85
+#: src/olympia/editors/templates/editors/queue.html:187 src/olympia/editors/templates/editors/themes/queue_list.html:85
 msgid "Helpful Links:"
 msgstr ""
 
-#: src/olympia/editors/templates/editors/queue.html:182
+#: src/olympia/editors/templates/editors/queue.html:188
 msgid "Add-on Policy"
 msgstr ""
 
-#: src/olympia/editors/templates/editors/queue.html:184
+#: src/olympia/editors/templates/editors/queue.html:190
 msgid "Editors' Guide"
 msgstr ""
 
@@ -8203,10 +8067,7 @@ msgid "<strong>Warning!</strong> Another user was viewing this page before you."
 msgstr ""
 
 #: src/olympia/editors/templates/editors/review.html:237
-msgid ""
-"The whiteboard is the place to exchange information relevant to\n"
-"               this addon (whatever the version), between the developer and the\n"
-"               editor. This is visible and editable by both."
+msgid "The whiteboard is the place to exchange information relevant to this addon (whatever the version), between the developer and the editor. This is visible and editable by both."
 msgstr ""
 
 #: src/olympia/editors/templates/editors/review.html:241
@@ -8480,7 +8341,7 @@ msgstr ""
 msgid "Describe your reason for flagging"
 msgstr ""
 
-#: src/olympia/files/forms.py:88
+#: src/olympia/files/forms.py:90
 msgid "Cannot diff a version against itself"
 msgstr ""
 
@@ -8515,51 +8376,51 @@ msgstr ""
 msgid "There was an error accessing file %s."
 msgstr ""
 
-#: src/olympia/files/utils.py:343
+#: src/olympia/files/utils.py:340
 msgid "Could not parse uploaded file."
 msgstr ""
 
-#: src/olympia/files/utils.py:380
+#: src/olympia/files/utils.py:377
 msgid "Invalid file name in archive: {0}"
 msgstr ""
 
-#: src/olympia/files/utils.py:388
+#: src/olympia/files/utils.py:385
 msgid "File exceeding size limit in archive: {0}"
 msgstr ""
 
-#: src/olympia/files/utils.py:439
+#: src/olympia/files/utils.py:436
 msgid "Invalid archive."
 msgstr ""
 
-#: src/olympia/files/utils.py:529 src/olympia/files/utils.py:532
+#: src/olympia/files/utils.py:526 src/olympia/files/utils.py:529
 msgid "Could not parse the manifest file."
 msgstr ""
 
-#: src/olympia/files/utils.py:551
+#: src/olympia/files/utils.py:548
 msgid "Could not find an add-on ID."
 msgstr ""
 
-#: src/olympia/files/utils.py:554
+#: src/olympia/files/utils.py:551
 msgid "Add-on ID must be 64 characters or less."
 msgstr ""
 
-#: src/olympia/files/utils.py:556
+#: src/olympia/files/utils.py:553
 msgid "Add-on ID doesn't match add-on."
 msgstr ""
 
-#: src/olympia/files/utils.py:564
+#: src/olympia/files/utils.py:561
 msgid "Duplicate add-on ID found."
 msgstr ""
 
-#: src/olympia/files/utils.py:567
+#: src/olympia/files/utils.py:564
 msgid "Version numbers should have fewer than 32 characters."
 msgstr ""
 
-#: src/olympia/files/utils.py:570
+#: src/olympia/files/utils.py:567
 msgid "Version numbers should only contain letters, numbers, and these punctuation characters: +*.-_."
 msgstr ""
 
-#: src/olympia/files/utils.py:587
+#: src/olympia/files/utils.py:584
 msgid "<em:type> doesn't match add-on"
 msgstr ""
 
@@ -8658,6 +8519,10 @@ msgstr ""
 
 #: src/olympia/files/templates/files/viewer.html:134
 msgid "Fetching file."
+msgstr ""
+
+#: src/olympia/legacy_api/views.py:255
+msgid "Not implemented yet."
 msgstr ""
 
 #: src/olympia/lib/constants.py:6
@@ -9316,10 +9181,6 @@ msgstr ""
 msgid "Zimbabwe Dollar"
 msgstr ""
 
-#: src/olympia/lib/video/ffmpeg.py:112 src/olympia/lib/video/totem.py:81
-msgid "Videos must be in WebM."
-msgstr ""
-
 #: src/olympia/pages/templates/pages/about.lhtml:3 src/olympia/pages/templates/pages/about.lhtml:10
 msgid "About Mozilla Add-ons"
 msgstr ""
@@ -9331,7 +9192,7 @@ msgstr ""
 #: src/olympia/pages/templates/pages/about.lhtml:13
 msgid ""
 "addons.mozilla.org, commonly known as \"AMO\", is Mozilla's official site for add-ons to Mozilla software, such as Firefox, Thunderbird, and SeaMonkey. Add-ons let you add new features and change "
-"the way your browser or application works.  Take a look around and explore the thousands of ways to customize the way you do things online."
+"the way your browser or application works. Take a look around and explore the thousands of ways to customize the way you do things online."
 msgstr ""
 
 #: src/olympia/pages/templates/pages/about.lhtml:19
@@ -9676,7 +9537,7 @@ msgstr ""
 msgid ""
 "Yes. It's possible, but some of the functionality provided by these libraries are available through XPCOM, XUL, and JavaScript. In addition, authors should take care if libraries modify primitive "
 "object prototypes (String.prototype, Date.prototype, etc.) and/or define global functions (eg. the $ function). These are prone to cause conflict with other add-ons, in particular if different add-"
-"ons use different versions of libraries and so on. Developers need to be very, very careful with using them.  Mozilla does not offer documentation on using them to build add-ons."
+"ons use different versions of libraries and so on. Developers need to be very, very careful with using them. Mozilla does not offer documentation on using them to build add-ons."
 msgstr ""
 
 #: src/olympia/pages/templates/pages/dev_faq.html:165
@@ -9790,8 +9651,8 @@ msgstr ""
 #, python-format
 msgid ""
 "Yes. Many developers choose to host their own add-ons. Choosing to host your add-on on <a href=\"%(amo_url)s\">Mozilla's add-on site</a>, though, allows for much greater exposure to your add-on due "
-"to the large volume of visitors to the site.  <a href=\"%(md_url)s\">mozdev.org</a> offers free project hosting for Mozilla applications and extensions providing developers with tools to help "
-"manage source code, version control, bug tracking and documentation."
+"to the large volume of visitors to the site. <a href=\"%(md_url)s\">mozdev.org</a> offers free project hosting for Mozilla applications and extensions providing developers with tools to help manage "
+"source code, version control, bug tracking and documentation."
 msgstr ""
 
 #: src/olympia/pages/templates/pages/dev_faq.html:277
@@ -9839,7 +9700,7 @@ msgstr ""
 #: src/olympia/pages/templates/pages/dev_faq.html:314
 #, python-format
 msgid ""
-"Yes. Mozilla's <a href=\"%(p_url)s\">Add-on Policy</a> describes what is an acceptable submission. This policy is subject to change without notice.  In addition, the AMO editorial team uses the <a "
+"Yes. Mozilla's <a href=\"%(p_url)s\">Add-on Policy</a> describes what is an acceptable submission. This policy is subject to change without notice. In addition, the AMO editorial team uses the <a "
 "href=\"%(g_url)s\">Editors Reviewing Guide</a> to ensure that your add-on meets specific guidelines for functionality and security."
 msgstr ""
 
@@ -9956,7 +9817,7 @@ msgstr ""
 #: src/olympia/pages/templates/pages/dev_faq.html:434
 #, python-format
 msgid ""
-"This is why it's very important to read the <a href=\"%(g_url)s\">Editors Reviewing Guide</a> to ensure that your add-on is setup as expected.  It's also a good idea to read the blog post, <a href="
+"This is why it's very important to read the <a href=\"%(g_url)s\">Editors Reviewing Guide</a> to ensure that your add-on is setup as expected. It's also a good idea to read the blog post, <a href="
 "\"%(blog_url)s\">Successfully Getting your Add-on Reviewed</a> which provides excellent insight into ensuring a smooth review of your add-on."
 msgstr ""
 
@@ -10063,7 +9924,7 @@ msgstr ""
 
 #: src/olympia/pages/templates/pages/dev_faq.html:572
 msgid ""
-"Free Software Foundation provides short summaries of the key open source licenses, including whether the license qualifies as a free software license or a copyleft license.  Also includes a "
+"Free Software Foundation provides short summaries of the key open source licenses, including whether the license qualifies as a free software license or a copyleft license. Also includes a "
 "discussion of what constitutes a free software license or a copyleft license (e.g., a Copyleft license is a general method for making a program or other work free, and requiring all modified and "
 "extended versions of the program to be free as well.)"
 msgstr ""
@@ -10241,19 +10102,13 @@ msgid "Add-on Gallery"
 msgstr ""
 
 #: src/olympia/pages/templates/pages/faq.html:171
-msgid ""
-"How do I choose between add-ons that seem to do the same\n"
-"    thing?"
+msgid "How do I choose between add-ons that seem to do the same thing?"
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:173
+#: src/olympia/pages/templates/pages/faq.html:172
 msgid ""
-"There are often several add-ons that have similar features. To\n"
-"    figure out which is right for you, read the entire description of the\n"
-"    add-on and view its screenshots. If there are still several in the running,\n"
-"    read through the add-on's ratings, user reviews, and statistics to see\n"
-"    which is most liked by other users. Remember that you can also just try\n"
-"    out both and see which you like better."
+"There are often several add-ons that have similar features. To figure out which is right for you, read the entire description of the add-on and view its screenshots. If there are still several in "
+"the running, read through the add-on's ratings, user reviews, and statistics to see which is most liked by other users. Remember that you can also just try out both and see which you like better."
 msgstr ""
 
 #: src/olympia/pages/templates/pages/faq.html:180
@@ -10294,80 +10149,67 @@ msgid "How much do add-ons cost to purchase?"
 msgstr ""
 
 #: src/olympia/pages/templates/pages/faq.html:207
-msgid ""
-"Add-ons hosted in our gallery are free unless clearly marked\n"
-"    otherwise."
+msgid "Add-ons hosted in our gallery are free unless clearly marked otherwise."
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:210
+#: src/olympia/pages/templates/pages/faq.html:209
 msgid "What does it mean when an add-on asks for contributions?"
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:211
+#: src/olympia/pages/templates/pages/faq.html:210
 msgid ""
-"Some add-on authors request users who enjoy an add-on to\n"
-"        contribute to its development by making a monetary contribution. These\n"
-"        contributions go directly to the developer unless a third party is\n"
-"        indicated, such as the non-profit Mozilla Foundation."
+"Some add-on authors request users who enjoy an add-on to contribute to its development by making a monetary contribution. These contributions go directly to the developer unless a third party is "
+"indicated, such as the non-profit Mozilla Foundation."
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:216
+#: src/olympia/pages/templates/pages/faq.html:215
 msgid "What are beta add-ons?"
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:218
+#: src/olympia/pages/templates/pages/faq.html:217
 msgid ""
-"Beta add-ons are unreviewed versions which represent the\n"
-"        latest work of an add-on author. While different authors have different\n"
-"        standards for beta code quality, you should assume that these add-ons\n"
-"        are less stable than the general add-on releases."
+"Beta add-ons are unreviewed versions which represent the latest work of an add-on author. While different authors have different standards for beta code quality, you should assume that these add-"
+"ons are less stable than the general add-on releases."
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:222
+#: src/olympia/pages/templates/pages/faq.html:221
 msgid ""
 "Please note that when you install an add-on from the \"Beta Version\" section of an add-on's listing, you will continue to receive updates for that add-on as they become available. Like the initial "
 "version you installed, all beta releases are unreviewed by Mozilla and may harm your computer."
 msgstr ""
 
+#: src/olympia/pages/templates/pages/faq.html:228
+msgid "What does it mean when an add-on is flagged as slow?"
+msgstr ""
+
 #: src/olympia/pages/templates/pages/faq.html:229
-msgid ""
-"What does it mean when an add-on is flagged as\n"
-"    slow?"
+msgid "Most add-ons load code and resources at the same time Firefox is starting up. In most cases the impact in start-up time is minimal, but some add-ons can cause a noticeable slowdown."
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:231
-msgid ""
-"Most add-ons load code and resources at the same time Firefox\n"
-"        is starting up. In most cases the impact in start-up time is minimal,\n"
-"        but some add-ons can cause a noticeable slowdown."
-msgstr ""
-
-#: src/olympia/pages/templates/pages/faq.html:236
+#: src/olympia/pages/templates/pages/faq.html:234
 msgid "How do I report an inappropriate or spam user review?"
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:237
+#: src/olympia/pages/templates/pages/faq.html:235
 msgid ""
-"To report a user review of an add-on, log in with your account\n"
-"    and visit the add-on's reviews page. Find the review you wish to report,\n"
-"    click \"Report this review\" and select a reason. Our editorial team will\n"
-"    investigate the review and take appropriate action."
+"To report a user review of an add-on, log in with your account and visit the add-on's reviews page. Find the review you wish to report, click \"Report this review\" and select a reason. Our "
+"editorial team will investigate the review and take appropriate action."
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:242
+#: src/olympia/pages/templates/pages/faq.html:240
 msgid "How do I report a bug or contact the Mozilla Add-ons team?"
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:243
+#: src/olympia/pages/templates/pages/faq.html:241
 #, python-format
 msgid "Please visit our <a href=\"%(contact_url)s\">Contact page</a>."
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:246
+#: src/olympia/pages/templates/pages/faq.html:244
 msgid "What is a Source Code License?"
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:247
+#: src/olympia/pages/templates/pages/faq.html:245
 #, python-format
 msgid ""
 "The source code used to create an add-on is an exclusive copyright of the add-on author, unless otherwise declared in a source code license. Many add-ons on this site have <a href=\"%(url)s\" lang="
@@ -10375,63 +10217,63 @@ msgid ""
 "the GPL or BSD licenses instead of making up their own."
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:256
+#: src/olympia/pages/templates/pages/faq.html:254
 #, python-format
 msgid "Firefox and other Mozilla software are <a href=\"%(url)s\">open source</a>."
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:264
+#: src/olympia/pages/templates/pages/faq.html:262
 msgid "Collections and Favorites"
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:267
+#: src/olympia/pages/templates/pages/faq.html:265
 msgid "What is a collection?"
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:268
+#: src/olympia/pages/templates/pages/faq.html:266
 msgid "Collections are groups of related add-ons created by users to share."
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:270
+#: src/olympia/pages/templates/pages/faq.html:268
 msgid "What is the My Favorites collection?"
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:271
+#: src/olympia/pages/templates/pages/faq.html:269
 msgid "Favorite add-ons are add-ons that you have bookmarked to easily get back to later. You can add an add-on to your favorites collection by clicking \"Add to favorites\" on its details page."
 msgstr ""
 
 # 75%
 # 78%
 # 100%
-#: src/olympia/pages/templates/pages/faq.html:275 src/olympia/templates/menu_links.html:13 src/olympia/templates/impala/header_title.html:17
+#: src/olympia/pages/templates/pages/faq.html:273 src/olympia/templates/menu_links.html:13 src/olympia/templates/impala/header_title.html:17
 msgid "Mobile Add-ons"
 msgstr "תוספות עבור מכשירים ניידים"
 
-#: src/olympia/pages/templates/pages/faq.html:278
+#: src/olympia/pages/templates/pages/faq.html:276
 msgid "What are mobile add-ons?"
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:279
+#: src/olympia/pages/templates/pages/faq.html:277
 #, python-format
 msgid ""
 "Mobile add-ons work with <a href=\"%(mobile_url)s\">Firefox for Mobile</a> and add or modify functionality just like desktop add-ons. You can find add-ons that work with Firefox for Mobile in our "
 "<a href=\"%(gallery_url)s\">gallery</a>."
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:288
+#: src/olympia/pages/templates/pages/faq.html:286
 msgid "Developer Topics"
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:289
+#: src/olympia/pages/templates/pages/faq.html:287
 #, python-format
 msgid "Please see our <a href=\"%(faq_url)s\">Developer FAQ</a> and <a href=\"%(hub_url)s\">Developer Hub</a> for answers to add-on developer-related questions."
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:294
+#: src/olympia/pages/templates/pages/faq.html:292
 msgid "Still have questions?"
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:295
+#: src/olympia/pages/templates/pages/faq.html:293
 #, python-format
 msgid "For general Firefox support, visit our <a href=\"%(sumo_url)s\">support website</a>. For general add-on and website questions, visit our <a href=\"%(forum_url)s\">forum</a>."
 msgstr ""
@@ -10569,7 +10411,7 @@ msgstr ""
 
 #: src/olympia/pages/templates/pages/sunbird.html:29
 msgid ""
-"Development on the Sunbird project has halted and its final release was on March 30, 2010.  We've been proud to host Sunbird add-ons on this site but as the project is no longer maintained we have "
+"Development on the Sunbird project has halted and its final release was on March 30, 2010. We've been proud to host Sunbird add-ons on this site but as the project is no longer maintained we have "
 "disabled our support for the add-ons."
 msgstr ""
 
@@ -10648,7 +10490,7 @@ msgstr ""
 #, python-format
 msgid ""
 "<h2>Keep these tips in mind:</h2> <ul> <li> Write like you're telling a friend about your experience with the add-on. Give specifics and helpful details, such as what features you liked and/or "
-"disliked, how easy to use it is, and any disadvantages it has.  Avoid generic language such as calling it \"Great\" or \"Bad\" unless you can give reasons why you believe this is so. </li> <li> "
+"disliked, how easy to use it is, and any disadvantages it has. Avoid generic language such as calling it \"Great\" or \"Bad\" unless you can give reasons why you believe this is so. </li> <li> "
 "Please do not post bug reports in reviews. We do not make your email address available to add-on developers and they may need to contact you to help resolve your issue. See the <a href=\"%(support)s"
 "\">support section</a> to find out where to get assistance for this add-on. </li> <li>Please keep reviews clean, avoid the use of improper language and do not post any personal information. </li> </"
 "ul> <p>Please read the <a href=\"%(guide)s\" target=\"_blank\">Review Guidelines</a> for more detail about user add-on reviews.</p>"
@@ -10906,16 +10748,16 @@ msgstr ""
 
 #. L10n: {0} is an application, such as Firefox. This means "any version of
 #. Firefox."
-#: src/olympia/search/views.py:554
+#: src/olympia/search/views.py:547
 msgid "Any {0}"
 msgstr ""
 
 #. L10n: "All Systems" means show everything regardless of platform.
-#: src/olympia/search/views.py:589
+#: src/olympia/search/views.py:582
 msgid "All Systems"
 msgstr ""
 
-#: src/olympia/search/views.py:600
+#: src/olympia/search/views.py:593
 msgid "All Tags"
 msgstr ""
 
@@ -11090,31 +10932,31 @@ msgstr "לשתף את התוספת הזאת"
 msgid "Share this Collection"
 msgstr "צור אוספים"
 
-#: src/olympia/signing/views.py:30 src/olympia/templates/base.html:75 src/olympia/templates/impala/base.html:115
+#: src/olympia/signing/views.py:33 src/olympia/templates/base.html:71 src/olympia/templates/impala/base.html:112
 msgid "Some features are temporarily disabled while we perform website maintenance. We'll be back to full capacity shortly."
 msgstr ""
 
-#: src/olympia/signing/views.py:53
+#: src/olympia/signing/views.py:56
 msgid "Could not find add-on with id \"{}\"."
 msgstr ""
 
-#: src/olympia/signing/views.py:67
+#: src/olympia/signing/views.py:70
 msgid "You do not own this addon."
 msgstr ""
 
-#: src/olympia/signing/views.py:82
+#: src/olympia/signing/views.py:87
 msgid "Missing \"upload\" key in multipart file data."
 msgstr ""
 
-#: src/olympia/signing/views.py:96
+#: src/olympia/signing/views.py:101
 msgid "Version does not match the manifest file."
 msgstr ""
 
-#: src/olympia/signing/views.py:100
+#: src/olympia/signing/views.py:105
 msgid "Version already exists."
 msgstr ""
 
-#: src/olympia/signing/views.py:136
+#: src/olympia/signing/views.py:141
 msgid "No uploaded file for that addon and version."
 msgstr ""
 
@@ -11230,89 +11072,89 @@ msgstr ""
 msgid "Statistics Dashboard :: Add-ons for {0}"
 msgstr ""
 
-#: src/olympia/stats/templates/stats/stats.html:30
-msgid "Controls:"
-msgstr ""
-
-#: src/olympia/stats/templates/stats/stats.html:33
-msgid "reset zoom"
-msgstr ""
-
-#: src/olympia/stats/templates/stats/stats.html:40
-msgid "Group by:"
-msgstr ""
-
-#: src/olympia/stats/templates/stats/stats.html:42
-msgid "day"
-msgstr ""
-
-#: src/olympia/stats/templates/stats/stats.html:45
-msgid "week"
-msgstr ""
-
-#: src/olympia/stats/templates/stats/stats.html:48
-msgid "month"
-msgstr ""
-
-#: src/olympia/stats/templates/stats/stats.html:54
-msgid "For last:"
-msgstr ""
-
-#: src/olympia/stats/templates/stats/stats.html:57
-msgid "7 days"
-msgstr ""
-
-#: src/olympia/stats/templates/stats/stats.html:60
-msgid "30 days"
-msgstr ""
-
-#: src/olympia/stats/templates/stats/stats.html:63
-msgid "90 days"
-msgstr ""
-
-#: src/olympia/stats/templates/stats/stats.html:66
-msgid "365 days"
-msgstr ""
-
-#: src/olympia/stats/templates/stats/stats.html:69
-msgid "Custom..."
-msgstr ""
-
 #. {0} is an add-on name
-#: src/olympia/stats/templates/stats/stats.html:88 src/olympia/stats/templates/stats/stats.html:91
+#: src/olympia/stats/templates/stats/stats.html:44 src/olympia/stats/templates/stats/stats.html:47
 msgid "Statistics for {0}"
 msgstr "סטיסטיקות ל-{0}"
 
-#: src/olympia/stats/templates/stats/stats.html:94
+#: src/olympia/stats/templates/stats/stats.html:50
 msgid "Statistics Dashboard"
 msgstr ""
 
-#: src/olympia/stats/templates/stats/stats.html:104
+#: src/olympia/stats/templates/stats/stats.html:57
+msgid "Controls:"
+msgstr ""
+
+#: src/olympia/stats/templates/stats/stats.html:60
+msgid "reset zoom"
+msgstr ""
+
+#: src/olympia/stats/templates/stats/stats.html:67
+msgid "Group by:"
+msgstr ""
+
+#: src/olympia/stats/templates/stats/stats.html:69
+msgid "day"
+msgstr ""
+
+#: src/olympia/stats/templates/stats/stats.html:72
+msgid "week"
+msgstr ""
+
+#: src/olympia/stats/templates/stats/stats.html:75
+msgid "month"
+msgstr ""
+
+#: src/olympia/stats/templates/stats/stats.html:81
+msgid "For last:"
+msgstr ""
+
+#: src/olympia/stats/templates/stats/stats.html:84
+msgid "7 days"
+msgstr ""
+
+#: src/olympia/stats/templates/stats/stats.html:87
+msgid "30 days"
+msgstr ""
+
+#: src/olympia/stats/templates/stats/stats.html:90
+msgid "90 days"
+msgstr ""
+
+#: src/olympia/stats/templates/stats/stats.html:93
+msgid "365 days"
+msgstr ""
+
+#: src/olympia/stats/templates/stats/stats.html:96
+msgid "Custom..."
+msgstr ""
+
+#: src/olympia/stats/templates/stats/stats.html:106
 msgid "Statistics processing is currently disabled, so recent data is unavailable. The statistics are still being collected and this page will be updated soon with the missing data."
 msgstr ""
 
-#: src/olympia/stats/templates/stats/stats.html:110
+#: src/olympia/stats/templates/stats/stats.html:112
 msgid "Loading the latest data&hellip;"
 msgstr ""
 
-#: src/olympia/stats/templates/stats/stats.html:142 src/olympia/stats/templates/stats/reports/overview.html:25 src/olympia/stats/templates/stats/reports/overview.html:37
+#: src/olympia/stats/templates/stats/stats.html:144 src/olympia/stats/templates/stats/reports/overview.html:25 src/olympia/stats/templates/stats/reports/overview.html:37
 #: src/olympia/stats/templates/stats/reports/overview.html:49
 msgid "No data available."
 msgstr ""
 
-#: src/olympia/stats/templates/stats/stats.html:177
+#: src/olympia/stats/templates/stats/stats.html:179
 msgid "This dashboard is currently <b>public</b>."
 msgstr ""
 
-#: src/olympia/stats/templates/stats/stats.html:179
+#: src/olympia/stats/templates/stats/stats.html:181
 msgid "Contribution stats are currently <b>private</b>."
 msgstr ""
 
-#: src/olympia/stats/templates/stats/stats.html:182
+#: src/olympia/stats/templates/stats/stats.html:184
 msgid "This dashboard is currently <b>private</b>."
 msgstr ""
 
-#: src/olympia/stats/templates/stats/stats.html:185
+#: src/olympia/stats/templates/stats/stats.html:187
 msgid "Change settings."
 msgstr ""
 
@@ -11464,16 +11306,6 @@ msgstr ""
 msgid "Application versions by Date"
 msgstr ""
 
-# {0} is a number
-#: src/olympia/tags/templates/tags/top_cloud.html:4
-msgid "Top {0} Tags"
-msgstr "{0} התגים הנפוצים ביותר"
-
-#. {0} is the current application name
-#: src/olympia/tags/templates/tags/top_cloud.html:14
-msgid "{0} Top Tags"
-msgstr ""
-
 #: src/olympia/templates/amo_footer.html:6 src/olympia/templates/includes/lang_switcher.html:2
 msgid "Other languages"
 msgstr ""
@@ -11487,11 +11319,11 @@ msgstr ""
 msgid "Mozilla Add-ons"
 msgstr "התוספות שלי"
 
-#: src/olympia/templates/base.html:91 src/olympia/templates/impala/base.html:81
+#: src/olympia/templates/base.html:89 src/olympia/templates/impala/base.html:78
 msgid "Find add-ons for other applications"
 msgstr "מצא תוספות ליישומים אחרים"
 
-#: src/olympia/templates/base.html:92 src/olympia/templates/impala/base.html:81
+#: src/olympia/templates/base.html:90 src/olympia/templates/impala/base.html:78
 msgid "Other Applications"
 msgstr "יישומים אחרים"
 
@@ -11516,7 +11348,7 @@ msgid "View Mobile Site"
 msgstr ""
 
 #: src/olympia/templates/copyright.html:7
-msgid "Site Status "
+msgid "Site Status"
 msgstr ""
 
 #: src/olympia/templates/footer.html:3
@@ -11619,35 +11451,35 @@ msgstr ""
 msgid "<a href=\"%(reg)s\">Register</a> or <a href=\"%(login)s\">Log in</a>"
 msgstr ""
 
-#: src/olympia/templates/impala/base.html:126
+#: src/olympia/templates/impala/base.html:123
 #, python-format
 msgid "To try the thousands of add-ons available here, download <a href=\"%(url)s\">Mozilla Firefox</a>, a fast, free way to surf the Web!"
 msgstr ""
 
-#: src/olympia/templates/impala/base.html:138
+#: src/olympia/templates/impala/base.html:135
 #, python-format
 msgid "Add-ons is switching to Firefox Accounts for login. <a href=\"%(url)s\" class=\"fxa-login\">Sign in now to transfer your account.</a>"
 msgstr ""
 
 #. {0} is an application, such as Firefox.
-#: src/olympia/templates/impala/base.html:148
+#: src/olympia/templates/impala/base.html:145
 msgid "Welcome to {0} Add-ons."
 msgstr ""
 
-#: src/olympia/templates/impala/base.html:151
+#: src/olympia/templates/impala/base.html:148
 msgid "Choose from thousands of extra features and styles to make Firefox your own."
 msgstr ""
 
-#: src/olympia/templates/impala/base.html:156
+#: src/olympia/templates/impala/base.html:153
 #, python-format
 msgid "Add extra features and styles to make %(app)s your own."
 msgstr ""
 
-#: src/olympia/templates/impala/base.html:164
+#: src/olympia/templates/impala/base.html:161
 msgid "On the go?"
 msgstr "בדרכים?"
 
-#: src/olympia/templates/impala/base.html:166
+#: src/olympia/templates/impala/base.html:163
 msgid "Check out our <a class=\"mobile-link\" href=\"#\">Mobile Add-ons site</a>."
 msgstr ""
 
@@ -11873,15 +11705,15 @@ msgstr ""
 
 #. L10n: {id} will be something like "13ad6a", just a random number
 #. to differentiate this user from other anonymous users.
-#: src/olympia/users/models.py:353
+#: src/olympia/users/models.py:362
 msgid "Anonymous user {id}"
 msgstr ""
 
-#: src/olympia/users/models.py:410
+#: src/olympia/users/models.py:419
 msgid "Your account has been restricted"
 msgstr ""
 
-#: src/olympia/users/models.py:480
+#: src/olympia/users/models.py:489
 msgid "Please confirm your email address"
 msgstr ""
 
@@ -11889,7 +11721,7 @@ msgstr ""
 # 78%
 # 82%
 # 100%
-#: src/olympia/users/models.py:506
+#: src/olympia/users/models.py:515
 #, fuzzy
 msgid "My Mobile Add-ons"
 msgstr "התוספות שלי"
@@ -12171,7 +12003,7 @@ msgstr "ססמה"
 
 #: src/olympia/users/templates/users/edit.html:70
 #, python-format
-msgid "Change your password.  If you forgot your password, you can <a href=\"%(reset_url)s\">use the reset form</a>."
+msgid "Change your password. If you forgot your password, you can <a href=\"%(reset_url)s\">use the reset form</a>."
 msgstr ""
 
 # 91%
@@ -12196,7 +12028,7 @@ msgid "Profile"
 msgstr ""
 
 #: src/olympia/users/templates/users/edit.html:100
-msgid "Give us a bit more information about yourself.  All these fields are optional, but they'll help other users get to know you better."
+msgid "Give us a bit more information about yourself. All these fields are optional, but they'll help other users get to know you better."
 msgstr ""
 
 #: src/olympia/users/templates/users/edit.html:124
@@ -12602,7 +12434,7 @@ msgstr ""
 
 #: src/olympia/users/templates/users/unsubscribe.html:30
 #, python-format
-msgid "Unfortunately, we weren't able to unsubscribe you.  The link you clicked is invalid. However, you can unsubscribe still unsubscribe on your <a href=\"%(edit_url)s\">edit profile page</a>."
+msgid "Unfortunately, we weren't able to unsubscribe you. The link you clicked is invalid. However, you can unsubscribe still unsubscribe on your <a href=\"%(edit_url)s\">edit profile page</a>."
 msgstr ""
 
 #: src/olympia/users/templates/users/vcard.html:2
@@ -12659,15 +12491,15 @@ msgstr "היסטוריית הגרסאות של %s"
 msgid "Version History with Changelogs"
 msgstr "היסטורית גירסאות עם רישום שינויים"
 
-#: src/olympia/versions/models.py:314
+#: src/olympia/versions/models.py:313
 msgid "Add-on uses binary components."
 msgstr ""
 
-#: src/olympia/versions/models.py:317
+#: src/olympia/versions/models.py:316
 msgid "Add-on has opted into strict compatibility checking."
 msgstr ""
 
-#: src/olympia/versions/models.py:715
+#: src/olympia/versions/models.py:711
 msgid "{app} {min} and later"
 msgstr ""
 
@@ -12744,4 +12576,8 @@ msgstr ""
 
 #: src/olympia/zadmin/forms.py:105
 msgid "Log emails instead of sending"
+msgstr ""
+
+#: src/olympia/zadmin/forms.py:215
+msgid "Deleted versions can`t be changed."
 msgstr ""

--- a/locale/he/LC_MESSAGES/djangojs.po
+++ b/locale/he/LC_MESSAGES/djangojs.po
@@ -1,1216 +1,1236 @@
-
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2016-02-24 21:23+0000\n"
+"POT-Creation-Date: 2016-04-18 15:47+0000\n"
 "PO-Revision-Date: 2011-12-24 11:49+0200\n"
 "Last-Translator: amire80 <amir.aharoni@mail.huji.ac.il>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
+"Language: \n"
 "MIME-Version: 1.0\n"
-"Content-Type: text/plain; charset=utf-8\n"
+"Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Generated-By: Babel 2.2.0\n"
 
-#: static/js/common/ratingwidget.js:31
+#: static/js/common-all.js:1426 static/js/impala-all.js:1511 static/js/zamboni/discovery-all.js:12598 static/js/zamboni/init.js:28 static/js/zamboni/mobile-all.js:14945
+msgid "This feature is temporarily disabled while we perform website maintenance. Please check back a little later."
+msgstr "האפשרות הזאת כבויה זמנית בזמן שאנחנו עושים עבודות תחזוקה באתר. נא לבדוק מאוחר יותר."
+
+#. L10n: {0} is an app name like Firefox.
+#: static/js/common-all.js:1837 static/js/impala-all.js:1922 static/js/zamboni/buttons.js:73 static/js/zamboni/discovery-all.js:13108
+msgid "Accept and Install"
+msgstr "לקבל ולהתקין"
+
+#: static/js/common-all.js:1837 static/js/impala-all.js:1922 static/js/zamboni/buttons.js:73 static/js/zamboni/discovery-all.js:13108
+msgid "Add to {0}"
+msgstr "להוסיף אל {0}"
+
+#: static/js/common-all.js:1842 static/js/impala-all.js:1927 static/js/zamboni/buttons.js:78 static/js/zamboni/discovery-all.js:13113
+msgid "Download Now"
+msgstr "להוריד עכשיו"
+
+#: static/js/common-all.js:1883 static/js/impala-all.js:1968 static/js/zamboni/buttons.js:119 static/js/zamboni/discovery-all.js:13154
+msgid "Add-on has not been updated to support default-to-compatible."
+msgstr ""
+
+#: static/js/common-all.js:1888 static/js/impala-all.js:1973 static/js/zamboni/buttons.js:124 static/js/zamboni/discovery-all.js:13159
+msgid "You need to be using Firefox 10.0 or higher."
+msgstr ""
+
+#: static/js/common-all.js:1900 static/js/impala-all.js:1985 static/js/zamboni/buttons.js:136 static/js/zamboni/discovery-all.js:13171
+msgid "Mozilla has marked this version as incompatible with your Firefox version."
+msgstr ""
+
+#. L10n: {0} is an platform like Windows or Linux.
+#: static/js/common-all.js:1981 static/js/impala-all.js:2066 static/js/zamboni/buttons.js:217 static/js/zamboni/discovery-all.js:13252
+msgid "Install for {0} anyway"
+msgstr "להתקין עבור {0} בכל זאת"
+
+#: static/js/common-all.js:1981 static/js/impala-all.js:2066 static/js/zamboni/buttons.js:217 static/js/zamboni/discovery-all.js:13252
+msgid "Download for {0} anyway"
+msgstr "להוריד עבור {0} בכל זאת"
+
+#: static/js/common-all.js:2038 static/js/impala-all.js:2123 static/js/zamboni/buttons.js:274 static/js/zamboni/discovery-all.js:13309
+msgid "Not available for your platform"
+msgstr "לא זמין לפלטפורמה שלך"
+
+#. L10n: {0} is an app name, {1} is the app version.
+#: static/js/common-all.js:2049 static/js/common-all.js:2086 static/js/impala-all.js:2134 static/js/impala-all.js:2171 static/js/zamboni/buttons.js:286 static/js/zamboni/buttons.js:324
+#: static/js/zamboni/discovery-all.js:13320 static/js/zamboni/discovery-all.js:13357
+msgid "Not available for {0} {1}"
+msgstr "לא זמין עובר {0} גרסה {1}"
+
+#: static/js/common-all.js:2112 static/js/impala-all.js:2197 static/js/zamboni/buttons.js:351 static/js/zamboni/discovery-all.js:13383
+msgid "Works with {app} {min} - {max}"
+msgstr ""
+
+#: static/js/common-all.js:2114 static/js/impala-all.js:2199 static/js/zamboni/buttons.js:353 static/js/zamboni/discovery-all.js:13385
+msgid "View other versions"
+msgstr ""
+
+#: static/js/common-all.js:2162 static/js/impala-all.js:2247 static/js/zamboni/buttons.js:401 static/js/zamboni/discovery-all.js:13433
+msgid "Only with Firefox — Get Firefox Now!"
+msgstr ""
+
+#: static/js/common-all.js:2278 static/js/impala-all.js:2363 static/js/zamboni/buttons.js:517 static/js/zamboni/discovery-all.js:13549 static/js/zamboni/mobile-all.js:15177
+#: static/js/zamboni/mobile/buttons.js:43
+msgid "Sorry, you need a Mozilla-based browser (such as Firefox) to install a search plugin."
+msgstr "סליחה, אבל זה צריך להיות דפדפן ממשפחת מוזילה (כגון פיירפוקס) כדי להתקין תוספת חיפוש."
+
+#: static/js/common-all.js:9088 static/js/impala-all.js:9649 static/js/zamboni/global.js:410
+msgid "Loading..."
+msgstr ""
+
+#. L10n: {0} is the number of characters left.
+#: static/js/common-all.js:9152 static/js/impala-all.js:9713 static/js/zamboni/global.js:474
+msgid "<b>{0}</b> character left."
+msgid_plural "<b>{0}</b> characters left."
+msgstr[0] "נותר תו <b>אחד</b>."
+msgstr[1] "נותרו <b>{0}</b> תווים."
+
+#: static/js/common-all.js:9589 static/js/common-min.js:6 static/js/impala-all.js:10052 static/js/impala-min.js:6 static/js/common/ratingwidget.js:31 static/js/zamboni/mobile-all.js:16123
+#: static/js/zamboni/mobile-min.js:6
 msgid "{0} star"
 msgid_plural "{0} stars"
 msgstr[0] "כוכב אחד"
 msgstr[1] "{0} כוכבים"
 
-#: static/js/common/upload-addon.js:41 static/js/common/upload-image.js:128
+#: static/js/common-all.js:9676 static/js/common-min.js:6 static/js/impala-all.js:10139 static/js/impala-min.js:6 static/js/zamboni/l10n.js:45
+msgid "Remove this localization"
+msgstr "להסיר את התרגום הזה"
+
+#: static/js/common-all.js:10193 static/js/common-min.js:6 static/js/impala-all.js:10674 static/js/impala-min.js:6 static/js/zamboni/discovery-all.js:13678
+msgid "close"
+msgstr ""
+
+#: static/js/common-all.js:10860 static/js/common-min.js:6 static/js/impala-all.js:11481 static/js/impala-min.js:6 static/js/impala/reviews.js:23 static/js/zamboni/reviews.js:18
+msgid "Flagged for review"
+msgstr "מסומן לסקירה"
+
+#: static/js/common-all.js:10876 static/js/common-min.js:6 static/js/impala-all.js:11498 static/js/impala-min.js:6 static/js/impala/reviews.js:40 static/js/zamboni/reviews.js:34
+msgid "Your input is required"
+msgstr "דרוש מידע מכם"
+
+#: static/js/common-all.js:10945 static/js/common-min.js:6 static/js/impala-all.js:11610 static/js/impala-min.js:7 static/js/impala/reviews.js:152 static/js/zamboni/reviews.js:103
+msgid "Marked for deletion"
+msgstr "מסומן למחיקה"
+
+#: static/js/common-all.js:11573 static/js/common-min.js:7 static/js/impala-all.js:13809 static/js/impala-min.js:8 static/js/zamboni/collections.js:229
+msgid "Adding to Favorites&hellip;"
+msgstr "להוסיף למועדפים&hellip;"
+
+#: static/js/common-all.js:11576 static/js/common-min.js:7 static/js/impala-all.js:13812 static/js/impala-min.js:8 static/js/zamboni/collections.js:232
+msgid "Removing Favorite&hellip;"
+msgstr "הסרת מועדף&hellip;"
+
+#: static/js/common-all.js:11579 static/js/common-min.js:7 static/js/impala-all.js:13815 static/js/impala-min.js:8 static/js/zamboni/collections.js:235
+msgid "Add to Favorites"
+msgstr "הוספה למועדפים"
+
+#: static/js/common-all.js:11582 static/js/common-min.js:7 static/js/impala-all.js:13818 static/js/impala-min.js:8 static/js/zamboni/collections.js:238
+msgid "Remove from Favorites"
+msgstr "הסרה ממועדפים"
+
+#: static/js/common-all.js:11647 static/js/common-min.js:7 static/js/impala-all.js:13883 static/js/impala-min.js:8 static/js/zamboni/collections.js:303
+msgid "Pending"
+msgstr "בהמתנה"
+
+#: static/js/common-all.js:11648 static/js/common-min.js:7 static/js/impala-all.js:13884 static/js/impala-min.js:8 static/js/zamboni/collections.js:304
+msgid "Add a comment"
+msgstr "הוספת תגובה"
+
+#: static/js/common-all.js:11648 static/js/common-min.js:7 static/js/impala-all.js:13884 static/js/impala-min.js:8 static/js/zamboni/collections.js:304
+msgid "Comment"
+msgstr "תגובה"
+
+#: static/js/common-all.js:11649 static/js/common-min.js:7 static/js/impala-all.js:13885 static/js/impala-min.js:8 static/js/zamboni/collections.js:305
+msgid "Remove this add-on from the collection"
+msgstr "הסרת התוספת הזאת מהאוסף"
+
+#: static/js/common-all.js:11649 static/js/common-all.js:11678 static/js/common-min.js:7 static/js/impala-all.js:13885 static/js/impala-all.js:13914 static/js/impala-min.js:8
+#: static/js/zamboni/collections.js:305 static/js/zamboni/collections.js:334
+msgid "Remove"
+msgstr "הסרה"
+
+#: static/js/common-all.js:11678 static/js/common-min.js:7 static/js/impala-all.js:13914 static/js/impala-min.js:8 static/js/zamboni/collections.js:334
+msgid "Remove this user as a contributor"
+msgstr "להסיר את המשתמש הזה מתורמים"
+
+#: static/js/common-all.js:11690 static/js/common-min.js:7 static/js/impala-all.js:13926 static/js/impala-min.js:8 static/js/zamboni/collections.js:346
+msgid "An email address is required."
+msgstr ""
+
+#: static/js/common-all.js:11708 static/js/common-min.js:7 static/js/impala-all.js:13944 static/js/impala-min.js:8 static/js/zamboni/collections.js:364
+msgid "You cannot add yourself as a contributor."
+msgstr ""
+
+#: static/js/common-all.js:11710 static/js/common-min.js:7 static/js/impala-all.js:13946 static/js/impala-min.js:8 static/js/zamboni/collections.js:366
+msgid "You have already added that user."
+msgstr ""
+
+#: static/js/common-all.js:11917 static/js/common-min.js:7 static/js/impala-all.js:14153 static/js/impala-min.js:8 static/js/zamboni/collections.js:573
+msgid "Add to favorites"
+msgstr "הוספת למועדפים"
+
+#: static/js/common-all.js:11921 static/js/common-min.js:7 static/js/impala-all.js:14157 static/js/impala-min.js:8 static/js/zamboni/collections.js:577
+msgid "Remove from favorites"
+msgstr "הסרה ממועדפים"
+
+#: static/js/common-all.js:11939 static/js/common-min.js:7 static/js/impala-all.js:14175 static/js/impala-all.js:14233 static/js/impala-min.js:8 static/js/impala/collections.js:10
+#: static/js/zamboni/collections.js:595
+msgid "Follow this Collection"
+msgstr "מעקב אחרי האוסף הזה"
+
+#: static/js/common-all.js:11948 static/js/common-min.js:7 static/js/impala-all.js:14184 static/js/impala-min.js:8 static/js/zamboni/collections.js:604
+msgid "Stop following"
+msgstr "הפסקת מעקב"
+
+#: static/js/common-all.js:12096 static/js/common-min.js:7 static/js/zamboni/password-strength.js:20
+msgid "Password strength:"
+msgstr "חוזק ססמה:"
+
+#: static/js/common-all.js:12102 static/js/common-min.js:7 static/js/zamboni/password-strength.js:26
+msgid "At least {0} character left."
+msgid_plural "At least {0} characters left."
+msgstr[0] "נשאר לפחות עוד תו אחד."
+msgstr[1] "נשארו לפחות עוד {0} תווים."
+
+#: static/js/common-all.js:12286 static/js/common-min.js:7 static/js/impala-all.js:14632 static/js/impala-min.js:8 static/js/impala/suggestions.js:39
+msgid "Search themes for <b>{0}</b>"
+msgstr ""
+
+#: static/js/common-all.js:12288 static/js/common-min.js:7 static/js/impala-all.js:14634 static/js/impala-min.js:8 static/js/impala/suggestions.js:41
+msgid "Search apps for <b>{0}</b>"
+msgstr ""
+
+#: static/js/common-all.js:12290 static/js/common-min.js:7 static/js/impala-all.js:14636 static/js/impala-min.js:8 static/js/impala/suggestions.js:43
+msgid "Search add-ons for <b>{0}</b>"
+msgstr ""
+
+#: static/js/common-all.js:12521 static/js/common-min.js:7 static/js/impala-all.js:14867 static/js/impala-min.js:8 static/js/impala/site_suggestions.js:46
+msgid "Category"
+msgstr ""
+
+#. L10n: {0} is an app name.
+#: static/js/impala-all.js:11632 static/js/impala-min.js:7 static/js/impala/listing.js:11 static/js/zamboni/themes.js:13
+msgid "This theme is incompatible with your version of {0}"
+msgstr "ערכת הנושא הזאת אינה תואמת לגרסתך שמספרה {0}"
+
+#: static/js/impala-all.js:12146 static/js/impala-all.js:14331 static/js/impala-min.js:7 static/js/impala-min.js:8 static/js/common/upload-image.js:97 static/js/impala/users.js:51
+#: static/js/zamboni/devhub-all.js:894 static/js/zamboni/devhub-min.js:1
+msgid "Images must be either PNG or JPG."
+msgstr ""
+
+#: static/js/impala-all.js:12150 static/js/impala-min.js:7 static/js/common/upload-image.js:101 static/js/zamboni/devhub-all.js:898 static/js/zamboni/devhub-min.js:1
+msgid "Videos must be in WebM."
+msgstr ""
+
+#: static/js/impala-all.js:12177 static/js/impala-min.js:7 static/js/common/upload-addon.js:41 static/js/common/upload-image.js:128 static/js/zamboni/devhub-all.js:272
+#: static/js/zamboni/devhub-all.js:925 static/js/zamboni/devhub-min.js:1
 msgid "There was a problem contacting the server."
 msgstr "הייתה בעיה ביצירת קשר עם השרת."
 
-#: static/js/common/upload-addon.js:69
+#: static/js/impala-all.js:13298 static/js/impala-min.js:7 static/js/impala/persona_creation.js:60
+msgid "All Rights Reserved"
+msgstr ""
+
+#: static/js/impala-all.js:13302 static/js/impala-min.js:7 static/js/impala/persona_creation.js:64
+msgid "Creative Commons Attribution 3.0"
+msgstr ""
+
+#: static/js/impala-all.js:13307 static/js/impala-min.js:7 static/js/impala/persona_creation.js:69
+msgid "Creative Commons Attribution-NonCommercial 3.0"
+msgstr ""
+
+#: static/js/impala-all.js:13312 static/js/impala-min.js:7 static/js/impala/persona_creation.js:74
+msgid "Creative Commons Attribution-NonCommercial-NoDerivs 3.0"
+msgstr ""
+
+#: static/js/impala-all.js:13317 static/js/impala-min.js:7 static/js/impala/persona_creation.js:79
+msgid "Creative Commons Attribution-NonCommercial-Share Alike 3.0"
+msgstr ""
+
+#: static/js/impala-all.js:13322 static/js/impala-min.js:7 static/js/impala/persona_creation.js:84
+msgid "Creative Commons Attribution-NoDerivs 3.0"
+msgstr ""
+
+#: static/js/impala-all.js:13327 static/js/impala-min.js:7 static/js/impala/persona_creation.js:89
+msgid "Creative Commons Attribution-ShareAlike 3.0"
+msgstr ""
+
+#: static/js/impala-all.js:13530 static/js/impala-min.js:7 static/js/impala/persona_creation.js:292
+msgid "Your Theme's Name"
+msgstr ""
+
+#: static/js/impala-all.js:14242 static/js/impala-min.js:8 static/js/impala/collections.js:19
+msgid "Stop Following"
+msgstr ""
+
+#: static/js/impala-all.js:14243 static/js/impala-min.js:8 static/js/impala/collections.js:20
+msgid "Following"
+msgstr ""
+
+#: static/js/impala-all.js:14313 static/js/impala-min.js:8 static/js/impala/users.js:33
+msgid "use original"
+msgstr ""
+
+#: static/js/impala-all.js:14523 static/js/impala-min.js:8 static/js/impala/search.js:114
+msgid "Updating results&hellip;"
+msgstr ""
+
+#: static/js/common/upload-addon.js:69 static/js/zamboni/devhub-all.js:300 static/js/zamboni/devhub-min.js:1
 msgid "Select a file..."
 msgstr "בחירת קובץ..."
 
-#: static/js/common/upload-addon.js:70
+#: static/js/common/upload-addon.js:70 static/js/zamboni/devhub-all.js:301 static/js/zamboni/devhub-min.js:1
 msgid "Your add-on should end with .xpi, .jar or .xml"
 msgstr "התוספת שלך צריכה להסתיים ב־‎.xpi‏, ‎.jar או ‎.xml"
 
 #. L10n: {0} is the percent of the file that has been uploaded.
-#: static/js/common/upload-addon.js:104
+#: static/js/common/upload-addon.js:104 static/js/zamboni/devhub-all.js:335 static/js/zamboni/devhub-min.js:1
 #, fuzzy, python-format
 msgid "{0}% complete"
 msgstr "אחוזי השלמה: {0}%"
 
 #. L10n: "{bytes uploaded} of {total filesize}".
-#: static/js/common/upload-addon.js:107
+#: static/js/common/upload-addon.js:107 static/js/zamboni/devhub-all.js:338 static/js/zamboni/devhub-min.js:1
 msgid "{0} of {1}"
 msgstr "{0} מתוך {1}"
 
-#: static/js/common/upload-addon.js:140
+#: static/js/common/upload-addon.js:140 static/js/zamboni/devhub-all.js:371 static/js/zamboni/devhub-min.js:1
 msgid "Cancel"
 msgstr "ביטול"
 
-#: static/js/common/upload-addon.js:162
+#: static/js/common/upload-addon.js:162 static/js/zamboni/devhub-all.js:393 static/js/zamboni/devhub-min.js:1
 msgid "Uploading {0}"
 msgstr "העלאת {0}"
 
-#: static/js/common/upload-addon.js:189
+#: static/js/common/upload-addon.js:189 static/js/zamboni/devhub-all.js:420 static/js/zamboni/devhub-min.js:1
 msgid "Error with {0}"
 msgstr "שגיאה עם {0}"
 
-#: static/js/common/upload-addon.js:194
+#: static/js/common/upload-addon.js:194 static/js/zamboni/devhub-all.js:425 static/js/zamboni/devhub-min.js:1
 msgid "Your add-on failed validation with {0} error."
 msgid_plural "Your add-on failed validation with {0} errors."
 msgstr[0] "בדיקת התוספת שלך נכשלה עם שגיאה אחת."
 msgstr[1] "בדיקת התוספת שלך נכשלה עם {0} שגיאות."
 
-#: static/js/common/upload-addon.js:208
+#: static/js/common/upload-addon.js:208 static/js/zamboni/devhub-all.js:439 static/js/zamboni/devhub-min.js:1
 msgid "&hellip;and {0} more"
 msgid_plural "&hellip;and {0} more"
 msgstr[0] "&hellip;ועוד אחד"
 msgstr[1] "&hellip;ועוד {0}"
 
-#: static/js/common/upload-addon.js:222 static/js/common/upload-addon.js:512
+#: static/js/common/upload-addon.js:222 static/js/common/upload-addon.js:497 static/js/zamboni/devhub-all.js:453 static/js/zamboni/devhub-all.js:743 static/js/zamboni/devhub-min.js:1
 msgid "See full validation report"
 msgstr "ר׳ דו״ח בדיקה"
 
-#: static/js/common/upload-addon.js:234
+#: static/js/common/upload-addon.js:234 static/js/zamboni/devhub-all.js:465 static/js/zamboni/devhub-min.js:1
 msgid "Validating {0}"
 msgstr "בדיקת {0}"
 
 #. L10n: first argument is an HTTP status code
-#: static/js/common/upload-addon.js:273
+#: static/js/common/upload-addon.js:273 static/js/zamboni/devhub-all.js:504 static/js/zamboni/devhub-min.js:1
 msgid "Received an empty response from the server; status: {0}"
 msgstr "התקבלה תשובה ריקה מהשרת; מצב: {0}"
 
-#: static/js/common/upload-addon.js:373
+#: static/js/common/upload-addon.js:370 static/js/zamboni/devhub-all.js:604 static/js/zamboni/devhub-min.js:1
 msgid "Unexpected server error while validating."
 msgstr "שגיאה בלתי־צפויה בשרת בזמן בדיקה."
 
-#: static/js/common/upload-addon.js:412
+#: static/js/common/upload-addon.js:409 static/js/zamboni/devhub-all.js:643 static/js/zamboni/devhub-min.js:1
 msgid "Finished validating {0}"
 msgstr "בדיקת {0} הסתיימה"
 
-#: static/js/common/upload-addon.js:418
+#: static/js/common/upload-addon.js:415 static/js/zamboni/devhub-all.js:649 static/js/zamboni/devhub-min.js:1
 msgid "Your add-on validation timed out, it will be manually reviewed."
 msgstr ""
 
-#: static/js/common/upload-addon.js:421
+#: static/js/common/upload-addon.js:418 static/js/zamboni/devhub-all.js:652 static/js/zamboni/devhub-min.js:1
 msgid "Your add-on was validated with no errors and {0} warning."
 msgid_plural "Your add-on was validated with no errors and {0} warnings."
 msgstr[0] ""
 msgstr[1] ""
 
-#: static/js/common/upload-addon.js:426
+#: static/js/common/upload-addon.js:423 static/js/zamboni/devhub-all.js:657 static/js/zamboni/devhub-min.js:1
 msgid "Your add-on was validated with no errors and {0} message."
 msgid_plural "Your add-on was validated with no errors and {0} messages."
 msgstr[0] ""
 msgstr[1] ""
 
-#: static/js/common/upload-addon.js:431
+#: static/js/common/upload-addon.js:428 static/js/zamboni/devhub-all.js:662 static/js/zamboni/devhub-min.js:1
 msgid "Your add-on was validated with no errors or warnings."
 msgstr ""
 
-#: static/js/common/upload-addon.js:446
+#: static/js/common/upload-addon.js:443 static/js/zamboni/devhub-all.js:677 static/js/zamboni/devhub-min.js:1
 msgid "Your submission will be automatically signed."
 msgstr ""
 
-#: static/js/common/upload-addon.js:465
+#: static/js/common/upload-addon.js:450 static/js/zamboni/devhub-all.js:696 static/js/zamboni/devhub-min.js:1
 msgid "Include detailed version notes (this can be done in the next step)."
 msgstr ""
 
-#: static/js/common/upload-addon.js:466
+#: static/js/common/upload-addon.js:451 static/js/zamboni/devhub-all.js:697 static/js/zamboni/devhub-min.js:1
 msgid "If your add-on requires an account to a website in order to be fully tested, include a test username and password in the Notes to Reviewer (this can be done in the next step)."
 msgstr ""
 
-#: static/js/common/upload-addon.js:467
+#: static/js/common/upload-addon.js:452 static/js/zamboni/devhub-all.js:698 static/js/zamboni/devhub-min.js:1
 msgid "If your add-on is intended for a limited audience you should choose Preliminary Review instead of Full Review."
 msgstr ""
 
-#: static/js/common/upload-addon.js:480
+#: static/js/common/upload-addon.js:465 static/js/zamboni/devhub-all.js:711 static/js/zamboni/devhub-min.js:1
 msgid "Add-on submission checklist"
 msgstr ""
 
-#: static/js/common/upload-addon.js:481
+#: static/js/common/upload-addon.js:466 static/js/zamboni/devhub-all.js:712 static/js/zamboni/devhub-min.js:1
 msgid "Please verify the following points before finalizing your submission. This will minimize delays or misunderstanding during the review process:"
 msgstr ""
 
-#: static/js/common/upload-addon.js:483
+#: static/js/common/upload-addon.js:468 static/js/zamboni/devhub-all.js:714 static/js/zamboni/devhub-min.js:1
 msgid ""
 "Compiled binaries, as well as minified or obfuscated scripts (excluding known libraries) need to have their sources submitted separately for review. Make sure that you use the source code upload "
 "field to avoid having your submission rejected."
 msgstr ""
 
-#: static/js/common/upload-addon.js:501
+#: static/js/common/upload-addon.js:486 static/js/zamboni/devhub-all.js:732 static/js/zamboni/devhub-min.js:1
 msgid "The validation process found these issues that can lead to rejections:"
 msgstr ""
 
-#: static/js/common/upload-addon.js:518
+#: static/js/common/upload-addon.js:503 static/js/zamboni/devhub-all.js:749 static/js/zamboni/devhub-min.js:1
 msgid "If you are unfamiliar with the add-ons review process, you can read about it here."
 msgstr ""
 
-#: static/js/common/upload-addon.js:555
+#: static/js/common/upload-addon.js:540 static/js/zamboni/devhub-all.js:786 static/js/zamboni/devhub-min.js:1
 msgid "Sorry, no supported platform has been found."
 msgstr ""
 
-#: static/js/common/upload-base.js:57
+#: static/js/common/upload-base.js:57 static/js/zamboni/devhub-all.js:187 static/js/zamboni/devhub-min.js:1
 msgid "The filetype you uploaded isn't recognized."
 msgstr "סוג הקובץ שהעלית אינו מזוהה."
 
-#: static/js/common/upload-base.js:79
+#: static/js/common/upload-base.js:79 static/js/zamboni/devhub-all.js:209 static/js/zamboni/devhub-min.js:1
 msgid "You cancelled the upload."
 msgstr "ביטלת את ההעלאה."
 
-#: static/js/common/upload-image.js:97 static/js/impala/users.js:51
-msgid "Images must be either PNG or JPG."
-msgstr ""
-
-#: static/js/common/upload-image.js:101
-msgid "Videos must be in WebM."
-msgstr ""
-
-#: static/js/impala/collections.js:10 static/js/zamboni/collections.js:595
-msgid "Follow this Collection"
-msgstr "מעקב אחרי האוסף הזה"
-
-#: static/js/impala/collections.js:19
-msgid "Stop Following"
-msgstr ""
-
-#: static/js/impala/collections.js:20
-msgid "Following"
-msgstr ""
-
-#. L10n: {0} is an app name.
-#: static/js/impala/listing.js:11 static/js/zamboni/themes.js:13
-msgid "This theme is incompatible with your version of {0}"
-msgstr "ערכת הנושא הזאת אינה תואמת לגרסתך שמספרה {0}"
-
-#: static/js/impala/persona_creation.js:60
-msgid "All Rights Reserved"
-msgstr ""
-
-#: static/js/impala/persona_creation.js:64
-msgid "Creative Commons Attribution 3.0"
-msgstr ""
-
-#: static/js/impala/persona_creation.js:69
-msgid "Creative Commons Attribution-NonCommercial 3.0"
-msgstr ""
-
-#: static/js/impala/persona_creation.js:74
-msgid "Creative Commons Attribution-NonCommercial-NoDerivs 3.0"
-msgstr ""
-
-#: static/js/impala/persona_creation.js:79
-msgid "Creative Commons Attribution-NonCommercial-Share Alike 3.0"
-msgstr ""
-
-#: static/js/impala/persona_creation.js:84
-msgid "Creative Commons Attribution-NoDerivs 3.0"
-msgstr ""
-
-#: static/js/impala/persona_creation.js:89
-msgid "Creative Commons Attribution-ShareAlike 3.0"
-msgstr ""
-
-#: static/js/impala/persona_creation.js:292
-msgid "Your Theme's Name"
-msgstr ""
-
-#: static/js/impala/reviews.js:23 static/js/zamboni/reviews.js:18
-msgid "Flagged for review"
-msgstr "מסומן לסקירה"
-
-#: static/js/impala/reviews.js:40 static/js/zamboni/reviews.js:34
-msgid "Your input is required"
-msgstr "דרוש מידע מכם"
-
-#: static/js/impala/reviews.js:152 static/js/zamboni/reviews.js:103
-msgid "Marked for deletion"
-msgstr "מסומן למחיקה"
-
-#: static/js/impala/search.js:114
-msgid "Updating results&hellip;"
-msgstr ""
-
-#: static/js/impala/site_suggestions.js:46
-msgid "Category"
-msgstr ""
-
-#: static/js/impala/suggestions.js:39
-msgid "Search themes for <b>{0}</b>"
-msgstr ""
-
-#: static/js/impala/suggestions.js:41
-msgid "Search apps for <b>{0}</b>"
-msgstr ""
-
-#: static/js/impala/suggestions.js:43
-msgid "Search add-ons for <b>{0}</b>"
-msgstr ""
-
-#: static/js/impala/users.js:33
-msgid "use original"
-msgstr ""
-
-#: static/js/impala/stats/chart.js:267
+#: static/js/impala/stats/chart.js:267 static/js/zamboni/stats-all.js:16898 static/js/zamboni/stats-min.js:5
 msgid "Week of {0}"
 msgstr ""
 
-#: static/js/impala/stats/chart.js:269
+#: static/js/impala/stats/chart.js:269 static/js/zamboni/stats-all.js:16900 static/js/zamboni/stats-min.js:5
 msgid " downloads"
 msgstr ""
 
-#: static/js/impala/stats/chart.js:270
+#: static/js/impala/stats/chart.js:270 static/js/zamboni/stats-all.js:16901 static/js/zamboni/stats-min.js:5
 msgid "{0} users"
 msgstr ""
 
-#: static/js/impala/stats/chart.js:271
+#: static/js/impala/stats/chart.js:271 static/js/zamboni/stats-all.js:16902 static/js/zamboni/stats-min.js:5
 msgid "{0} add-ons"
 msgstr ""
 
-#: static/js/impala/stats/chart.js:272
+#: static/js/impala/stats/chart.js:272 static/js/zamboni/stats-all.js:16903 static/js/zamboni/stats-min.js:5
 msgid "{0} collections"
 msgstr ""
 
-#: static/js/impala/stats/chart.js:273
+#: static/js/impala/stats/chart.js:273 static/js/zamboni/stats-all.js:16904 static/js/zamboni/stats-min.js:5
 msgid "{0} reviews"
 msgstr ""
 
-#: static/js/impala/stats/chart.js:275
+#: static/js/impala/stats/chart.js:275 static/js/zamboni/stats-all.js:16906 static/js/zamboni/stats-min.js:5
 msgid "{0} sales"
 msgstr ""
 
-#: static/js/impala/stats/chart.js:276
+#: static/js/impala/stats/chart.js:276 static/js/zamboni/stats-all.js:16907 static/js/zamboni/stats-min.js:5
 msgid "{0} refunds"
 msgstr ""
 
-#: static/js/impala/stats/chart.js:277
+#: static/js/impala/stats/chart.js:277 static/js/zamboni/stats-all.js:16908 static/js/zamboni/stats-min.js:5
 msgid "{0} installs"
 msgstr ""
 
-#: static/js/impala/stats/chart.js:369 static/js/impala/stats/csv_keys.js:3 static/js/impala/stats/csv_keys.js:109
+#: static/js/impala/stats/chart.js:369 static/js/impala/stats/csv_keys.js:3 static/js/impala/stats/csv_keys.js:109 static/js/zamboni/stats-all.js:15284 static/js/zamboni/stats-all.js:15390
+#: static/js/zamboni/stats-all.js:17000 static/js/zamboni/stats-min.js:4 static/js/zamboni/stats-min.js:5
 msgid "Downloads"
 msgstr ""
 
-#: static/js/impala/stats/chart.js:379 static/js/impala/stats/csv_keys.js:6 static/js/impala/stats/csv_keys.js:110
+#: static/js/impala/stats/chart.js:379 static/js/impala/stats/csv_keys.js:6 static/js/impala/stats/csv_keys.js:110 static/js/zamboni/stats-all.js:15287 static/js/zamboni/stats-all.js:15391
+#: static/js/zamboni/stats-all.js:17010 static/js/zamboni/stats-min.js:4 static/js/zamboni/stats-min.js:5
 msgid "Daily Users"
 msgstr ""
 
-#: static/js/impala/stats/chart.js:410
+#: static/js/impala/stats/chart.js:410 static/js/zamboni/stats-all.js:17041 static/js/zamboni/stats-min.js:5
 msgid "Amount, in USD"
 msgstr ""
 
-#: static/js/impala/stats/chart.js:421 static/js/impala/stats/csv_keys.js:104
+#: static/js/impala/stats/chart.js:421 static/js/impala/stats/csv_keys.js:104 static/js/zamboni/stats-all.js:15385 static/js/zamboni/stats-all.js:17052 static/js/zamboni/stats-min.js:5
 msgid "Number of Contributions"
 msgstr ""
 
-#: static/js/impala/stats/chart.js:447
+#: static/js/impala/stats/chart.js:447 static/js/zamboni/stats-all.js:17078 static/js/zamboni/stats-min.js:5
 msgid "More Info..."
 msgstr ""
 
 #. L10n: {0} is an ISO-formatted date.
-#: static/js/impala/stats/chart.js:451
+#: static/js/impala/stats/chart.js:451 static/js/zamboni/stats-all.js:17082 static/js/zamboni/stats-min.js:5
 msgid "Details for {0}"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:9
+#: static/js/impala/stats/csv_keys.js:9 static/js/zamboni/stats-all.js:15290 static/js/zamboni/stats-min.js:4
 msgid "Collections Created"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:12
+#: static/js/impala/stats/csv_keys.js:12 static/js/zamboni/stats-all.js:15293 static/js/zamboni/stats-min.js:4
 msgid "Add-ons in Use"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:15
+#: static/js/impala/stats/csv_keys.js:15 static/js/zamboni/stats-all.js:15296 static/js/zamboni/stats-min.js:4
 msgid "Add-ons Created"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:18
+#: static/js/impala/stats/csv_keys.js:18 static/js/zamboni/stats-all.js:15299 static/js/zamboni/stats-min.js:4
 msgid "Add-ons Downloaded"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:21
+#: static/js/impala/stats/csv_keys.js:21 static/js/zamboni/stats-all.js:15302 static/js/zamboni/stats-min.js:4
 msgid "Add-ons Updated"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:24
+#: static/js/impala/stats/csv_keys.js:24 static/js/zamboni/stats-all.js:15305 static/js/zamboni/stats-min.js:4
 msgid "Reviews Written"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:27
+#: static/js/impala/stats/csv_keys.js:27 static/js/zamboni/stats-all.js:15308 static/js/zamboni/stats-min.js:4
 msgid "User Signups"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:30
+#: static/js/impala/stats/csv_keys.js:30 static/js/zamboni/stats-all.js:15311 static/js/zamboni/stats-min.js:4
 msgid "Subscribers"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:33
+#: static/js/impala/stats/csv_keys.js:33 static/js/zamboni/stats-all.js:15314 static/js/zamboni/stats-min.js:4
 msgid "Ratings"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:36 static/js/impala/stats/csv_keys.js:114
+#: static/js/impala/stats/csv_keys.js:36 static/js/impala/stats/csv_keys.js:114 static/js/zamboni/stats-all.js:15317 static/js/zamboni/stats-all.js:15395 static/js/zamboni/stats-min.js:4
+#: static/js/zamboni/stats-min.js:5
 msgid "Sales"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:39 static/js/impala/stats/csv_keys.js:113
+#: static/js/impala/stats/csv_keys.js:39 static/js/impala/stats/csv_keys.js:113 static/js/zamboni/stats-all.js:15320 static/js/zamboni/stats-all.js:15394 static/js/zamboni/stats-min.js:4
+#: static/js/zamboni/stats-min.js:5
 msgid "Installs"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:42
+#: static/js/impala/stats/csv_keys.js:42 static/js/zamboni/stats-all.js:15323 static/js/zamboni/stats-min.js:4
 msgid "Unknown"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:43
+#: static/js/impala/stats/csv_keys.js:43 static/js/zamboni/stats-all.js:15324 static/js/zamboni/stats-min.js:4
 msgid "Add-ons Manager"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:44
+#: static/js/impala/stats/csv_keys.js:44 static/js/zamboni/stats-all.js:15325 static/js/zamboni/stats-min.js:4
 msgid "Add-ons Manager Promo"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:45
+#: static/js/impala/stats/csv_keys.js:45 static/js/zamboni/stats-all.js:15326 static/js/zamboni/stats-min.js:4
 msgid "Add-ons Manager Featured"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:46
+#: static/js/impala/stats/csv_keys.js:46 static/js/zamboni/stats-all.js:15327 static/js/zamboni/stats-min.js:4
 msgid "Add-ons Manager Learn More"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:47
+#: static/js/impala/stats/csv_keys.js:47 static/js/zamboni/stats-all.js:15328 static/js/zamboni/stats-min.js:4
 msgid "Search Suggestions"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:48
+#: static/js/impala/stats/csv_keys.js:48 static/js/zamboni/stats-all.js:15329 static/js/zamboni/stats-min.js:4
 msgid "Search Results"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:49 static/js/impala/stats/csv_keys.js:50 static/js/impala/stats/csv_keys.js:51
+#: static/js/impala/stats/csv_keys.js:49 static/js/impala/stats/csv_keys.js:50 static/js/impala/stats/csv_keys.js:51 static/js/zamboni/stats-all.js:15330 static/js/zamboni/stats-all.js:15331
+#: static/js/zamboni/stats-all.js:15332 static/js/zamboni/stats-min.js:4
 msgid "Homepage Promo"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:52 static/js/impala/stats/csv_keys.js:53
+#: static/js/impala/stats/csv_keys.js:52 static/js/impala/stats/csv_keys.js:53 static/js/zamboni/stats-all.js:15333 static/js/zamboni/stats-all.js:15334 static/js/zamboni/stats-min.js:4
 msgid "Homepage Featured"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:54 static/js/impala/stats/csv_keys.js:55
+#: static/js/impala/stats/csv_keys.js:54 static/js/impala/stats/csv_keys.js:55 static/js/zamboni/stats-all.js:15335 static/js/zamboni/stats-all.js:15336 static/js/zamboni/stats-min.js:4
 msgid "Homepage Up and Coming"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:56
+#: static/js/impala/stats/csv_keys.js:56 static/js/zamboni/stats-all.js:15337 static/js/zamboni/stats-min.js:4
 msgid "Homepage Most Popular"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:57 static/js/impala/stats/csv_keys.js:59
+#: static/js/impala/stats/csv_keys.js:57 static/js/impala/stats/csv_keys.js:59 static/js/zamboni/stats-all.js:15338 static/js/zamboni/stats-all.js:15340 static/js/zamboni/stats-min.js:4
 msgid "Detail Page"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:58 static/js/impala/stats/csv_keys.js:60
+#: static/js/impala/stats/csv_keys.js:58 static/js/impala/stats/csv_keys.js:60 static/js/zamboni/stats-all.js:15339 static/js/zamboni/stats-all.js:15341 static/js/zamboni/stats-min.js:4
 msgid "Detail Page (bottom)"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:61
+#: static/js/impala/stats/csv_keys.js:61 static/js/zamboni/stats-all.js:15342 static/js/zamboni/stats-min.js:4
 msgid "Detail Page (Development Channel)"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:62 static/js/impala/stats/csv_keys.js:63 static/js/impala/stats/csv_keys.js:64
+#: static/js/impala/stats/csv_keys.js:62 static/js/impala/stats/csv_keys.js:63 static/js/impala/stats/csv_keys.js:64 static/js/zamboni/stats-all.js:15343 static/js/zamboni/stats-all.js:15344
+#: static/js/zamboni/stats-all.js:15345 static/js/zamboni/stats-min.js:4
 msgid "Often Used With"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:65 static/js/impala/stats/csv_keys.js:66
+#: static/js/impala/stats/csv_keys.js:65 static/js/impala/stats/csv_keys.js:66 static/js/zamboni/stats-all.js:15346 static/js/zamboni/stats-all.js:15347 static/js/zamboni/stats-min.js:4
 msgid "Others By Author"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:67 static/js/impala/stats/csv_keys.js:68
+#: static/js/impala/stats/csv_keys.js:67 static/js/impala/stats/csv_keys.js:68 static/js/zamboni/stats-all.js:15348 static/js/zamboni/stats-all.js:15349 static/js/zamboni/stats-min.js:4
 msgid "Dependencies"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:69 static/js/impala/stats/csv_keys.js:70
+#: static/js/impala/stats/csv_keys.js:69 static/js/impala/stats/csv_keys.js:70 static/js/zamboni/stats-all.js:15350 static/js/zamboni/stats-all.js:15351 static/js/zamboni/stats-min.js:4
 msgid "Upsell"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:71
+#: static/js/impala/stats/csv_keys.js:71 static/js/zamboni/stats-all.js:15352 static/js/zamboni/stats-min.js:4
 msgid "Meet the Developer"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:72
+#: static/js/impala/stats/csv_keys.js:72 static/js/zamboni/stats-all.js:15353 static/js/zamboni/stats-min.js:4
 msgid "User Profile"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:73
+#: static/js/impala/stats/csv_keys.js:73 static/js/zamboni/stats-all.js:15354 static/js/zamboni/stats-min.js:4
 msgid "Version History"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:75
+#: static/js/impala/stats/csv_keys.js:75 static/js/zamboni/stats-all.js:15356 static/js/zamboni/stats-min.js:4
 msgid "Sharing"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:76
+#: static/js/impala/stats/csv_keys.js:76 static/js/zamboni/stats-all.js:15357 static/js/zamboni/stats-min.js:4
 msgid "Category Pages"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:77
+#: static/js/impala/stats/csv_keys.js:77 static/js/zamboni/stats-all.js:15358 static/js/zamboni/stats-min.js:4
 msgid "Collections"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:78 static/js/impala/stats/csv_keys.js:79
+#: static/js/impala/stats/csv_keys.js:78 static/js/impala/stats/csv_keys.js:79 static/js/zamboni/stats-all.js:15359 static/js/zamboni/stats-all.js:15360 static/js/zamboni/stats-min.js:4
 msgid "Category Landing Featured Carousel"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:80 static/js/impala/stats/csv_keys.js:81
+#: static/js/impala/stats/csv_keys.js:80 static/js/impala/stats/csv_keys.js:81 static/js/zamboni/stats-all.js:15361 static/js/zamboni/stats-all.js:15362 static/js/zamboni/stats-min.js:4
 msgid "Category Landing Top Rated"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:82 static/js/impala/stats/csv_keys.js:83
+#: static/js/impala/stats/csv_keys.js:82 static/js/impala/stats/csv_keys.js:83 static/js/zamboni/stats-all.js:15363 static/js/zamboni/stats-all.js:15364 static/js/zamboni/stats-min.js:5
 msgid "Category Landing Most Popular"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:84 static/js/impala/stats/csv_keys.js:85
+#: static/js/impala/stats/csv_keys.js:84 static/js/impala/stats/csv_keys.js:85 static/js/zamboni/stats-all.js:15365 static/js/zamboni/stats-all.js:15366 static/js/zamboni/stats-min.js:5
 msgid "Category Landing Recently Added"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:86 static/js/impala/stats/csv_keys.js:87
+#: static/js/impala/stats/csv_keys.js:86 static/js/impala/stats/csv_keys.js:87 static/js/zamboni/stats-all.js:15367 static/js/zamboni/stats-all.js:15368 static/js/zamboni/stats-min.js:5
 msgid "Browse Listing Featured Sort"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:88 static/js/impala/stats/csv_keys.js:89
+#: static/js/impala/stats/csv_keys.js:88 static/js/impala/stats/csv_keys.js:89 static/js/zamboni/stats-all.js:15369 static/js/zamboni/stats-all.js:15370 static/js/zamboni/stats-min.js:5
 msgid "Browse Listing Users Sort"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:90 static/js/impala/stats/csv_keys.js:91
+#: static/js/impala/stats/csv_keys.js:90 static/js/impala/stats/csv_keys.js:91 static/js/zamboni/stats-all.js:15371 static/js/zamboni/stats-all.js:15372 static/js/zamboni/stats-min.js:5
 msgid "Browse Listing Rating Sort"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:92 static/js/impala/stats/csv_keys.js:93
+#: static/js/impala/stats/csv_keys.js:92 static/js/impala/stats/csv_keys.js:93 static/js/zamboni/stats-all.js:15373 static/js/zamboni/stats-all.js:15374 static/js/zamboni/stats-min.js:5
 msgid "Browse Listing Created Sort"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:94 static/js/impala/stats/csv_keys.js:95
+#: static/js/impala/stats/csv_keys.js:94 static/js/impala/stats/csv_keys.js:95 static/js/zamboni/stats-all.js:15375 static/js/zamboni/stats-all.js:15376 static/js/zamboni/stats-min.js:5
 msgid "Browse Listing Name Sort"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:96 static/js/impala/stats/csv_keys.js:97
+#: static/js/impala/stats/csv_keys.js:96 static/js/impala/stats/csv_keys.js:97 static/js/zamboni/stats-all.js:15377 static/js/zamboni/stats-all.js:15378 static/js/zamboni/stats-min.js:5
 msgid "Browse Listing Popular Sort"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:98 static/js/impala/stats/csv_keys.js:99
+#: static/js/impala/stats/csv_keys.js:98 static/js/impala/stats/csv_keys.js:99 static/js/zamboni/stats-all.js:15379 static/js/zamboni/stats-all.js:15380 static/js/zamboni/stats-min.js:5
 msgid "Browse Listing Updated Sort"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:100 static/js/impala/stats/csv_keys.js:101
+#: static/js/impala/stats/csv_keys.js:100 static/js/impala/stats/csv_keys.js:101 static/js/zamboni/stats-all.js:15381 static/js/zamboni/stats-all.js:15382 static/js/zamboni/stats-min.js:5
 msgid "Browse Listing Up and Coming Sort"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:105
+#: static/js/impala/stats/csv_keys.js:105 static/js/zamboni/stats-all.js:15386 static/js/zamboni/stats-min.js:5
 msgid "Total Amount Contributed"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:106
+#: static/js/impala/stats/csv_keys.js:106 static/js/zamboni/stats-all.js:15387 static/js/zamboni/stats-min.js:5
 msgid "Average Contribution"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:115
+#: static/js/impala/stats/csv_keys.js:115 static/js/zamboni/stats-all.js:15396 static/js/zamboni/stats-min.js:5
 msgid "Usage"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:118
+#: static/js/impala/stats/csv_keys.js:118 static/js/zamboni/stats-all.js:15399 static/js/zamboni/stats-min.js:5
 msgid "Firefox"
 msgstr "פיירפוקס"
 
-#: static/js/impala/stats/csv_keys.js:119
+#: static/js/impala/stats/csv_keys.js:119 static/js/zamboni/stats-all.js:15400 static/js/zamboni/stats-min.js:5
 msgid "Mozilla"
 msgstr "מוזילה"
 
-#: static/js/impala/stats/csv_keys.js:120
+#: static/js/impala/stats/csv_keys.js:120 static/js/zamboni/stats-all.js:15401 static/js/zamboni/stats-min.js:5
 msgid "Thunderbird"
 msgstr "ת׳נדרבירד"
 
-#: static/js/impala/stats/csv_keys.js:121
+#: static/js/impala/stats/csv_keys.js:121 static/js/zamboni/stats-all.js:15402 static/js/zamboni/stats-min.js:5
 msgid "Sunbird"
 msgstr "סנבירד"
 
-#: static/js/impala/stats/csv_keys.js:122
+#: static/js/impala/stats/csv_keys.js:122 static/js/zamboni/stats-all.js:15403 static/js/zamboni/stats-min.js:5
 msgid "SeaMonkey"
 msgstr "סימנקי"
 
-#: static/js/impala/stats/csv_keys.js:123
+#: static/js/impala/stats/csv_keys.js:123 static/js/zamboni/stats-all.js:15404 static/js/zamboni/stats-min.js:5
 msgid "Fennec"
 msgstr "פֿנק"
 
-#: static/js/impala/stats/csv_keys.js:124
+#: static/js/impala/stats/csv_keys.js:124 static/js/zamboni/stats-all.js:15405 static/js/zamboni/stats-min.js:5
 msgid "Android"
 msgstr ""
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:129
+#: static/js/impala/stats/csv_keys.js:129 static/js/zamboni/stats-all.js:15410 static/js/zamboni/stats-min.js:5
 msgid "Downloads and Daily Users, last {0} days"
 msgstr ""
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:131
+#: static/js/impala/stats/csv_keys.js:131 static/js/zamboni/stats-all.js:15412 static/js/zamboni/stats-min.js:5
 msgid "Downloads and Daily Users from {0} to {1}"
 msgstr ""
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:135
+#: static/js/impala/stats/csv_keys.js:135 static/js/zamboni/stats-all.js:15416 static/js/zamboni/stats-min.js:5
 msgid "Installs and Daily Users, last {0} days"
 msgstr ""
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:137
+#: static/js/impala/stats/csv_keys.js:137 static/js/zamboni/stats-all.js:15418 static/js/zamboni/stats-min.js:5
 msgid "Installs and Daily Users from {0} to {1}"
 msgstr ""
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:141
+#: static/js/impala/stats/csv_keys.js:141 static/js/zamboni/stats-all.js:15422 static/js/zamboni/stats-min.js:5
 msgid "Downloads, last {0} days"
 msgstr ""
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:143
+#: static/js/impala/stats/csv_keys.js:143 static/js/zamboni/stats-all.js:15424 static/js/zamboni/stats-min.js:5
 msgid "Downloads from {0} to {1}"
 msgstr ""
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:147
+#: static/js/impala/stats/csv_keys.js:147 static/js/zamboni/stats-all.js:15428 static/js/zamboni/stats-min.js:5
 msgid "Daily Users, last {0} days"
 msgstr ""
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:149
+#: static/js/impala/stats/csv_keys.js:149 static/js/zamboni/stats-all.js:15430 static/js/zamboni/stats-min.js:5
 msgid "Daily Users from {0} to {1}"
 msgstr ""
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:153
+#: static/js/impala/stats/csv_keys.js:153 static/js/zamboni/stats-all.js:15434 static/js/zamboni/stats-min.js:5
 msgid "Applications, last {0} days"
 msgstr ""
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:155
+#: static/js/impala/stats/csv_keys.js:155 static/js/zamboni/stats-all.js:15436 static/js/zamboni/stats-min.js:5
 msgid "Applications from {0} to {1}"
 msgstr ""
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:159
+#: static/js/impala/stats/csv_keys.js:159 static/js/zamboni/stats-all.js:15440 static/js/zamboni/stats-min.js:5
 msgid "Platforms, last {0} days"
 msgstr ""
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:161
+#: static/js/impala/stats/csv_keys.js:161 static/js/zamboni/stats-all.js:15442 static/js/zamboni/stats-min.js:5
 msgid "Platforms from {0} to {1}"
 msgstr ""
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:165
+#: static/js/impala/stats/csv_keys.js:165 static/js/zamboni/stats-all.js:15446 static/js/zamboni/stats-min.js:5
 msgid "Languages, last {0} days"
 msgstr ""
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:167
+#: static/js/impala/stats/csv_keys.js:167 static/js/zamboni/stats-all.js:15448 static/js/zamboni/stats-min.js:5
 msgid "Languages from {0} to {1}"
 msgstr ""
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:171
+#: static/js/impala/stats/csv_keys.js:171 static/js/zamboni/stats-all.js:15452 static/js/zamboni/stats-min.js:5
 msgid "Add-on Versions, last {0} days"
 msgstr ""
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:173
+#: static/js/impala/stats/csv_keys.js:173 static/js/zamboni/stats-all.js:15454 static/js/zamboni/stats-min.js:5
 msgid "Add-on Versions from {0} to {1}"
 msgstr ""
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:177
+#: static/js/impala/stats/csv_keys.js:177 static/js/zamboni/stats-all.js:15458 static/js/zamboni/stats-min.js:5
 msgid "Add-on Status, last {0} days"
 msgstr ""
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:179
+#: static/js/impala/stats/csv_keys.js:179 static/js/zamboni/stats-all.js:15460 static/js/zamboni/stats-min.js:5
 msgid "Add-on Status from {0} to {1}"
 msgstr ""
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:183
+#: static/js/impala/stats/csv_keys.js:183 static/js/zamboni/stats-all.js:15464 static/js/zamboni/stats-min.js:5
 msgid "Download Sources, last {0} days"
 msgstr ""
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:185
+#: static/js/impala/stats/csv_keys.js:185 static/js/zamboni/stats-all.js:15466 static/js/zamboni/stats-min.js:5
 msgid "Download Sources from {0} to {1}"
 msgstr ""
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:189
+#: static/js/impala/stats/csv_keys.js:189 static/js/zamboni/stats-all.js:15470 static/js/zamboni/stats-min.js:5
 msgid "Contributions, last {0} days"
 msgstr ""
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:191
+#: static/js/impala/stats/csv_keys.js:191 static/js/zamboni/stats-all.js:15472 static/js/zamboni/stats-min.js:5
 msgid "Contributions from {0} to {1}"
 msgstr ""
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:195
+#: static/js/impala/stats/csv_keys.js:195 static/js/zamboni/stats-all.js:15476 static/js/zamboni/stats-min.js:5
 msgid "Site Metrics, last {0} days"
 msgstr ""
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:197
+#: static/js/impala/stats/csv_keys.js:197 static/js/zamboni/stats-all.js:15478 static/js/zamboni/stats-min.js:5
 msgid "Site Metrics from {0} to {1}"
 msgstr ""
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:201
+#: static/js/impala/stats/csv_keys.js:201 static/js/zamboni/stats-all.js:15482 static/js/zamboni/stats-min.js:5
 msgid "Add-ons in Use, last {0} days"
 msgstr ""
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:203
+#: static/js/impala/stats/csv_keys.js:203 static/js/zamboni/stats-all.js:15484 static/js/zamboni/stats-min.js:5
 msgid "Add-ons in Use from {0} to {1}"
 msgstr ""
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:207
+#: static/js/impala/stats/csv_keys.js:207 static/js/zamboni/stats-all.js:15488 static/js/zamboni/stats-min.js:5
 msgid "Add-ons Downloaded, last {0} days"
 msgstr ""
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:209
+#: static/js/impala/stats/csv_keys.js:209 static/js/zamboni/stats-all.js:15490 static/js/zamboni/stats-min.js:5
 msgid "Add-ons Downloaded from {0} to {1}"
 msgstr ""
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:213
+#: static/js/impala/stats/csv_keys.js:213 static/js/zamboni/stats-all.js:15494 static/js/zamboni/stats-min.js:5
 msgid "Add-ons Created, last {0} days"
 msgstr ""
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:215
+#: static/js/impala/stats/csv_keys.js:215 static/js/zamboni/stats-all.js:15496 static/js/zamboni/stats-min.js:5
 msgid "Add-ons Created from {0} to {1}"
 msgstr ""
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:219
+#: static/js/impala/stats/csv_keys.js:219 static/js/zamboni/stats-all.js:15500 static/js/zamboni/stats-min.js:5
 msgid "Add-ons Updated, last {0} days"
 msgstr ""
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:221
+#: static/js/impala/stats/csv_keys.js:221 static/js/zamboni/stats-all.js:15502 static/js/zamboni/stats-min.js:5
 msgid "Add-ons Updated from {0} to {1}"
 msgstr ""
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:225
+#: static/js/impala/stats/csv_keys.js:225 static/js/zamboni/stats-all.js:15506 static/js/zamboni/stats-min.js:5
 msgid "Reviews Written, last {0} days"
 msgstr ""
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:227
+#: static/js/impala/stats/csv_keys.js:227 static/js/zamboni/stats-all.js:15508 static/js/zamboni/stats-min.js:5
 msgid "Reviews Written from {0} to {1}"
 msgstr ""
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:231
+#: static/js/impala/stats/csv_keys.js:231 static/js/zamboni/stats-all.js:15512 static/js/zamboni/stats-min.js:5
 msgid "User Signups, last {0} days"
 msgstr ""
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:233
+#: static/js/impala/stats/csv_keys.js:233 static/js/zamboni/stats-all.js:15514 static/js/zamboni/stats-min.js:5
 msgid "User Signups from {0} to {1}"
 msgstr ""
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:237
+#: static/js/impala/stats/csv_keys.js:237 static/js/zamboni/stats-all.js:15518 static/js/zamboni/stats-min.js:5
 msgid "Collections Created, last {0} days"
 msgstr ""
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:239
+#: static/js/impala/stats/csv_keys.js:239 static/js/zamboni/stats-all.js:15520 static/js/zamboni/stats-min.js:5
 msgid "Collections Created from {0} to {1}"
 msgstr ""
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:243
+#: static/js/impala/stats/csv_keys.js:243 static/js/zamboni/stats-all.js:15524 static/js/zamboni/stats-min.js:5
 msgid "Subscribers, last {0} days"
 msgstr ""
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:245
+#: static/js/impala/stats/csv_keys.js:245 static/js/zamboni/stats-all.js:15526 static/js/zamboni/stats-min.js:5
 msgid "Subscribers from {0} to {1}"
 msgstr ""
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:249
+#: static/js/impala/stats/csv_keys.js:249 static/js/zamboni/stats-all.js:15530 static/js/zamboni/stats-min.js:5
 msgid "Ratings, last {0} days"
 msgstr ""
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:251
+#: static/js/impala/stats/csv_keys.js:251 static/js/zamboni/stats-all.js:15532 static/js/zamboni/stats-min.js:5
 msgid "Ratings from {0} to {1}"
 msgstr ""
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:255
+#: static/js/impala/stats/csv_keys.js:255 static/js/zamboni/stats-all.js:15536 static/js/zamboni/stats-min.js:5
 msgid "Sales, last {0} days"
 msgstr ""
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:257
+#: static/js/impala/stats/csv_keys.js:257 static/js/zamboni/stats-all.js:15538 static/js/zamboni/stats-min.js:5
 msgid "Sales from {0} to {1}"
 msgstr ""
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:261
+#: static/js/impala/stats/csv_keys.js:261 static/js/zamboni/stats-all.js:15542 static/js/zamboni/stats-min.js:5
 msgid "Installs, last {0} days"
 msgstr ""
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:263
+#: static/js/impala/stats/csv_keys.js:263 static/js/zamboni/stats-all.js:15544 static/js/zamboni/stats-min.js:5
 msgid "Installs from {0} to {1}"
 msgstr ""
 
 #. L10n: {0} and {1} are integers.
-#: static/js/impala/stats/csv_keys.js:269
+#: static/js/impala/stats/csv_keys.js:269 static/js/zamboni/stats-all.js:15550 static/js/zamboni/stats-min.js:5
 msgid "<b>{0}</b> in last {1} days"
 msgstr ""
 
 #. L10n: {0} is an integer and {1} and {2} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:271 static/js/impala/stats/csv_keys.js:277
+#: static/js/impala/stats/csv_keys.js:271 static/js/impala/stats/csv_keys.js:277 static/js/zamboni/stats-all.js:15552 static/js/zamboni/stats-all.js:15558 static/js/zamboni/stats-min.js:5
 msgid "<b>{0}</b> from {1} to {2}"
 msgstr ""
 
 #. L10n: {0} and {1} are integers.
-#: static/js/impala/stats/csv_keys.js:275
+#: static/js/impala/stats/csv_keys.js:275 static/js/zamboni/stats-all.js:15556 static/js/zamboni/stats-min.js:5
 msgid "<b>{0}</b> average in last {1} days"
 msgstr ""
 
-#: static/js/impala/stats/overview.js:19
+#: static/js/impala/stats/overview.js:19 static/js/zamboni/stats-all.js:16469 static/js/zamboni/stats-min.js:5
 msgid "No data available."
 msgstr ""
 
-#: static/js/impala/stats/table.js:74
+#: static/js/impala/stats/table.js:74 static/js/zamboni/stats-all.js:17209 static/js/zamboni/stats-min.js:5
 msgid "Date"
 msgstr ""
 
-#: static/js/impala/stats/topchart.js:96
+#: static/js/impala/stats/topchart.js:96 static/js/zamboni/stats-all.js:16600 static/js/zamboni/stats-min.js:5
 msgid "Other"
 msgstr "אחר"
 
-#: static/js/zamboni/admin_validation.js:24 static/js/zamboni/devhub.js:1229 static/js/zamboni/editors.js:295
+#: static/js/zamboni/admin-all.js:180 static/js/zamboni/admin-min.js:1 static/js/zamboni/admin_validation.js:24 static/js/zamboni/devhub-all.js:2408 static/js/zamboni/devhub-min.js:2
+#: static/js/zamboni/devhub.js:1229 static/js/zamboni/editors-all.js:15576 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:295
 msgid "Select an application first"
 msgstr "תחילה יש לבחור יישום"
 
-#: static/js/zamboni/admin_validation.js:51
+#: static/js/zamboni/admin-all.js:207 static/js/zamboni/admin-min.js:1 static/js/zamboni/admin_validation.js:51
 #, fuzzy
 msgid "Set {0} add-on to a max version of {1} and email the author."
 msgid_plural "Set {0} add-ons to a max version of {1} and email the authors."
 msgstr[0] "להגדיר תוספת אחת לגרסת מרבית של {1} ולשלוח מכתב למפתח."
 msgstr[1] "להגדיר {0} תוספות לגרסת מרבית של {1} ולשלוח מכתב למפתח."
 
-#: static/js/zamboni/admin_validation.js:54
+#: static/js/zamboni/admin-all.js:210 static/js/zamboni/admin-min.js:1 static/js/zamboni/admin_validation.js:54
 msgid "Email author of {2} add-on which failed validation."
 msgid_plural "Email authors of {2} add-ons which failed validation."
 msgstr[0] ""
 msgstr[1] ""
 
-#. L10n: {0} is an app name like Firefox.
-#: static/js/zamboni/buttons.js:66
-msgid "Accept and Install"
-msgstr "לקבל ולהתקין"
-
-#: static/js/zamboni/buttons.js:66
-msgid "Add to {0}"
-msgstr "להוסיף אל {0}"
-
-#: static/js/zamboni/buttons.js:71
-msgid "Download Now"
-msgstr "להוריד עכשיו"
-
-#: static/js/zamboni/buttons.js:112
-msgid "Add-on has not been updated to support default-to-compatible."
-msgstr ""
-
-#: static/js/zamboni/buttons.js:117
-msgid "You need to be using Firefox 10.0 or higher."
-msgstr ""
-
-#: static/js/zamboni/buttons.js:129
-msgid "Mozilla has marked this version as incompatible with your Firefox version."
-msgstr ""
-
-#. L10n: {0} is an platform like Windows or Linux.
-#: static/js/zamboni/buttons.js:210
-msgid "Install for {0} anyway"
-msgstr "להתקין עבור {0} בכל זאת"
-
-#: static/js/zamboni/buttons.js:210
-msgid "Download for {0} anyway"
-msgstr "להוריד עבור {0} בכל זאת"
-
-#: static/js/zamboni/buttons.js:267
-msgid "Not available for your platform"
-msgstr "לא זמין לפלטפורמה שלך"
-
-#. L10n: {0} is an app name, {1} is the app version.
-#: static/js/zamboni/buttons.js:278 static/js/zamboni/buttons.js:315
-msgid "Not available for {0} {1}"
-msgstr "לא זמין עובר {0} גרסה {1}"
-
-#: static/js/zamboni/buttons.js:341
-msgid "Works with {app} {min} - {max}"
-msgstr ""
-
-#: static/js/zamboni/buttons.js:343
-msgid "View other versions"
-msgstr ""
-
-#: static/js/zamboni/buttons.js:391
-msgid "Only with Firefox — Get Firefox Now!"
-msgstr ""
-
-#: static/js/zamboni/buttons.js:507 static/js/zamboni/mobile/buttons.js:43
-msgid "Sorry, you need a Mozilla-based browser (such as Firefox) to install a search plugin."
-msgstr "סליחה, אבל זה צריך להיות דפדפן ממשפחת מוזילה (כגון פיירפוקס) כדי להתקין תוספת חיפוש."
-
-#: static/js/zamboni/collections.js:229
-msgid "Adding to Favorites&hellip;"
-msgstr "להוסיף למועדפים&hellip;"
-
-#: static/js/zamboni/collections.js:232
-msgid "Removing Favorite&hellip;"
-msgstr "הסרת מועדף&hellip;"
-
-#: static/js/zamboni/collections.js:235
-msgid "Add to Favorites"
-msgstr "הוספה למועדפים"
-
-#: static/js/zamboni/collections.js:238
-msgid "Remove from Favorites"
-msgstr "הסרה ממועדפים"
-
-#: static/js/zamboni/collections.js:303
-msgid "Pending"
-msgstr "בהמתנה"
-
-#: static/js/zamboni/collections.js:304
-msgid "Add a comment"
-msgstr "הוספת תגובה"
-
-#: static/js/zamboni/collections.js:304
-msgid "Comment"
-msgstr "תגובה"
-
-#: static/js/zamboni/collections.js:305
-msgid "Remove this add-on from the collection"
-msgstr "הסרת התוספת הזאת מהאוסף"
-
-#: static/js/zamboni/collections.js:305 static/js/zamboni/collections.js:334
-msgid "Remove"
-msgstr "הסרה"
-
-#: static/js/zamboni/collections.js:334
-msgid "Remove this user as a contributor"
-msgstr "להסיר את המשתמש הזה מתורמים"
-
-#: static/js/zamboni/collections.js:346
-msgid "An email address is required."
-msgstr ""
-
-#: static/js/zamboni/collections.js:364
-msgid "You cannot add yourself as a contributor."
-msgstr ""
-
-#: static/js/zamboni/collections.js:366
-msgid "You have already added that user."
-msgstr ""
-
-#: static/js/zamboni/collections.js:573
-msgid "Add to favorites"
-msgstr "הוספת למועדפים"
-
-#: static/js/zamboni/collections.js:577
-msgid "Remove from favorites"
-msgstr "הסרה ממועדפים"
-
-#: static/js/zamboni/collections.js:604
-msgid "Stop following"
-msgstr "הפסקת מעקב"
-
-#: static/js/zamboni/devhub.js:110
+#: static/js/zamboni/devhub-all.js:1289 static/js/zamboni/devhub-min.js:1 static/js/zamboni/devhub.js:110
 msgid "Your browser does not support the video tag"
 msgstr "הדפדפן שלך אינו תומך בתג video"
 
-#: static/js/zamboni/devhub.js:371
+#: static/js/zamboni/devhub-all.js:1550 static/js/zamboni/devhub-min.js:1 static/js/zamboni/devhub.js:371
 msgid "Changes Saved"
 msgstr "השינויים נשמרו"
 
-#: static/js/zamboni/devhub.js:387
+#: static/js/zamboni/devhub-all.js:1566 static/js/zamboni/devhub-min.js:1 static/js/zamboni/devhub.js:387
 msgid "Enter a new author's email address"
 msgstr "הוספת כתובת דוא״ל של מפתח חדש"
 
-#: static/js/zamboni/devhub.js:536
+#: static/js/zamboni/devhub-all.js:1715 static/js/zamboni/devhub-min.js:1 static/js/zamboni/devhub.js:536
 msgid "There was an error uploading your file."
 msgstr "אירעה שגיאה בהעלאת הקובץ שלך."
 
-#: static/js/zamboni/devhub.js:681
+#: static/js/zamboni/devhub-all.js:1860 static/js/zamboni/devhub-min.js:1 static/js/zamboni/devhub.js:681
 msgid "{files} file"
 msgid_plural "{files} files"
 msgstr[0] "קובץ אחד"
 msgstr[1] "{files} קבצים"
 
-#: static/js/zamboni/devhub.js:684
+#: static/js/zamboni/devhub-all.js:1863 static/js/zamboni/devhub-min.js:1 static/js/zamboni/devhub.js:684
 msgid "{reviews} user review"
 msgid_plural "{reviews} user reviews"
 msgstr[0] ""
 msgstr[1] ""
 
-#: static/js/zamboni/devhub.js:796
+#: static/js/zamboni/devhub-all.js:1975 static/js/zamboni/devhub-min.js:2 static/js/zamboni/devhub.js:796
 msgid "Learn more"
 msgstr "מידע נוסף"
 
-#: static/js/zamboni/devhub.js:800
+#: static/js/zamboni/devhub-all.js:1979 static/js/zamboni/devhub-min.js:2 static/js/zamboni/devhub.js:800
 msgid "Example"
 msgstr "דוגמה"
 
-#: static/js/zamboni/devhub.js:1130
+#: static/js/zamboni/devhub-all.js:2309 static/js/zamboni/devhub-min.js:2 static/js/zamboni/devhub.js:1130
 msgid "Image changes being processed"
 msgstr "מתבצע עיבוד שינויים בתמונות"
 
-#: static/js/zamboni/devhub.js:1280
+#: static/js/zamboni/devhub-all.js:2459 static/js/zamboni/devhub-min.js:2 static/js/zamboni/devhub.js:1280
 msgid "Must be a valid e-mail address."
 msgstr ""
 
-#: static/js/zamboni/devhub_search.js:8
-msgid "No results found."
-msgstr ""
-
-#: static/js/zamboni/editors.js:121
-msgid "{name} was viewing this page first."
-msgstr "{name} צפה בדף הזה ראשון."
-
-#: static/js/zamboni/editors.js:171
-msgid "Receipt checked by app."
-msgstr ""
-
-#: static/js/zamboni/editors.js:173
-msgid "Receipt was not checked by app."
-msgstr ""
-
-#: static/js/zamboni/editors.js:244
-msgid "{name} was viewing this add-on first."
-msgstr ""
-
-#: static/js/zamboni/editors.js:255
-msgid "Loading&hellip;"
-msgstr "טעינה&hellip;"
-
-#: static/js/zamboni/editors.js:260
-msgid "Version Notes"
-msgstr ""
-
-#: static/js/zamboni/editors.js:265
-msgid "Notes for Reviewers"
-msgstr ""
-
-#: static/js/zamboni/editors.js:270
-msgid "No version notes found"
-msgstr "נמצאו הערות גרסה"
-
-#: static/js/zamboni/editors.js:330
-msgid "Average Reviews"
-msgstr ""
-
-#: static/js/zamboni/editors.js:386
-msgid "Number of Reviews"
-msgstr ""
-
-#: static/js/zamboni/editors.js:445
-msgid "Error loading translation"
-msgstr ""
-
-#: static/js/zamboni/files.js:411 static/js/zamboni/validator.js:261
-msgid "Ignore this message in future updates"
-msgstr ""
-
-#: static/js/zamboni/files.js:417 static/js/zamboni/validator.js:284
-msgid "Severity for automated signing:"
-msgstr ""
-
-#: static/js/zamboni/global.js:410
-msgid "Loading..."
-msgstr ""
-
-#. L10n: {0} is the number of characters left.
-#: static/js/zamboni/global.js:474
-msgid "<b>{0}</b> character left."
-msgid_plural "<b>{0}</b> characters left."
-msgstr[0] "נותר תו <b>אחד</b>."
-msgstr[1] "נותרו <b>{0}</b> תווים."
-
-#: static/js/zamboni/init.js:28
-msgid "This feature is temporarily disabled while we perform website maintenance. Please check back a little later."
-msgstr "האפשרות הזאת כבויה זמנית בזמן שאנחנו עושים עבודות תחזוקה באתר. נא לבדוק מאוחר יותר."
-
-#: static/js/zamboni/l10n.js:45
-msgid "Remove this localization"
-msgstr "להסיר את התרגום הזה"
-
-#: static/js/zamboni/password-strength.js:20
-msgid "Password strength:"
-msgstr "חוזק ססמה:"
-
-#: static/js/zamboni/password-strength.js:26
-msgid "At least {0} character left."
-msgid_plural "At least {0} characters left."
-msgstr[0] "נשאר לפחות עוד תו אחד."
-msgstr[1] "נשארו לפחות עוד {0} תווים."
-
-#: static/js/zamboni/themes_review.js:176
-msgid "Requested Info"
-msgstr ""
-
-#: static/js/zamboni/themes_review.js:177
-msgid "Flagged"
-msgstr ""
-
-#: static/js/zamboni/themes_review.js:178
-msgid "Duplicate"
-msgstr ""
-
-#: static/js/zamboni/themes_review.js:179
-msgid "Rejected"
-msgstr ""
-
-#: static/js/zamboni/themes_review.js:180
-msgid "Approved"
-msgstr ""
-
-#: static/js/zamboni/themes_review.js:424
-msgid "No results found"
-msgstr ""
-
-#: static/js/zamboni/themes_review_templates.js:31
-msgid "Theme"
-msgstr ""
-
-#: static/js/zamboni/themes_review_templates.js:33
-msgid "Reviewer"
-msgstr ""
-
-#: static/js/zamboni/themes_review_templates.js:35
-msgid "Status"
-msgstr ""
-
-#: static/js/zamboni/validator.js:80
+#: static/js/zamboni/devhub-all.js:2613 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:80
 msgid "All tests passed successfully."
 msgstr "כל הבדיקות עברו בהצלחה."
 
-#: static/js/zamboni/validator.js:83 static/js/zamboni/validator.js:478
+#: static/js/zamboni/devhub-all.js:2616 static/js/zamboni/devhub-all.js:3011 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:83 static/js/zamboni/validator.js:478
 msgid "These tests were not run."
 msgstr "הבדיקות האלו לא רצו."
 
-#: static/js/zamboni/validator.js:131 static/js/zamboni/validator.js:144
+#: static/js/zamboni/devhub-all.js:2664 static/js/zamboni/devhub-all.js:2677 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:131 static/js/zamboni/validator.js:144
 msgid "Tests"
 msgstr "בדיקות"
 
-#: static/js/zamboni/validator.js:246 static/js/zamboni/validator.js:575 static/js/zamboni/validator.js:594
+#: static/js/zamboni/devhub-all.js:2779 static/js/zamboni/devhub-all.js:3108 static/js/zamboni/devhub-all.js:3127 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:246
+#: static/js/zamboni/validator.js:575 static/js/zamboni/validator.js:594
 msgid "Error"
 msgstr "שגיאה"
 
-#: static/js/zamboni/validator.js:247
+#: static/js/zamboni/devhub-all.js:2780 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:247
 msgid "Warning"
 msgstr "אזהרה"
 
-#: static/js/zamboni/validator.js:299
+#: static/js/zamboni/devhub-all.js:2794 static/js/zamboni/devhub-min.js:2 static/js/zamboni/files-all.js:5657 static/js/zamboni/files-min.js:3 static/js/zamboni/files.js:411
+#: static/js/zamboni/validator.js:261
+msgid "Ignore this message in future updates"
+msgstr ""
+
+#: static/js/zamboni/devhub-all.js:2817 static/js/zamboni/devhub-min.js:2 static/js/zamboni/files-all.js:5663 static/js/zamboni/files-min.js:3 static/js/zamboni/files.js:417
+#: static/js/zamboni/validator.js:284
+msgid "Severity for automated signing:"
+msgstr ""
+
+#: static/js/zamboni/devhub-all.js:2832 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:299
 msgid "Suggestions for passing automated signing:"
 msgstr ""
 
-#: static/js/zamboni/validator.js:387
+#: static/js/zamboni/devhub-all.js:2920 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:387
 msgid "Compatibility Tests"
 msgstr "בדיקות תאימות"
 
-#: static/js/zamboni/validator.js:466
+#: static/js/zamboni/devhub-all.js:2999 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:466
 msgid "Add-on failed validation."
 msgstr "התוספת נכשלה בבדיקה."
 
-#: static/js/zamboni/validator.js:468
+#: static/js/zamboni/devhub-all.js:3001 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:468
 msgid "Add-on passed validation."
 msgstr "התוספת עברה את הבדיקה."
 
-#: static/js/zamboni/validator.js:481
+#: static/js/zamboni/devhub-all.js:3014 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:481
 msgid "{0} error"
 msgid_plural "{0} errors"
 msgstr[0] "שגיאה אחת"
 msgstr[1] "{0} שגיאות"
 
-#: static/js/zamboni/validator.js:483
+#: static/js/zamboni/devhub-all.js:3016 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:483
 msgid "{0} warning"
 msgid_plural "{0} warnings"
 msgstr[0] "אזהרה אחת"
 msgstr[1] "{0} אזהרות"
 
-#: static/js/zamboni/validator.js:485
+#: static/js/zamboni/devhub-all.js:3018 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:485
 msgid "{0} notice"
 msgid_plural "{0} notices"
 msgstr[0] ""
 msgstr[1] ""
 
-#: static/js/zamboni/validator.js:577
+#: static/js/zamboni/devhub-all.js:3110 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:577
 msgid "Validation task could not complete or completed with errors"
 msgstr "משימת הבדיקה לא הושלמה או הושלמה עם שגיאות"
 
-#: static/js/zamboni/validator.js:595
+#: static/js/zamboni/devhub-all.js:3128 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:595
 msgid "Internal server error"
 msgstr "שגיאה פנימית בשרת"
 
-#: static/js/zamboni/mobile/buttons.js:52
+#: static/js/zamboni/devhub_search.js:8
+msgid "No results found."
+msgstr ""
+
+#: static/js/zamboni/editors-all.js:15402 static/js/zamboni/editors-min.js:4 static/js/zamboni/editors.js:121
+msgid "{name} was viewing this page first."
+msgstr "{name} צפה בדף הזה ראשון."
+
+#: static/js/zamboni/editors-all.js:15452 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:171
+msgid "Receipt checked by app."
+msgstr ""
+
+#: static/js/zamboni/editors-all.js:15454 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:173
+msgid "Receipt was not checked by app."
+msgstr ""
+
+#: static/js/zamboni/editors-all.js:15525 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:244
+msgid "{name} was viewing this add-on first."
+msgstr ""
+
+#: static/js/zamboni/editors-all.js:15536 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:255
+msgid "Loading&hellip;"
+msgstr "טעינה&hellip;"
+
+#: static/js/zamboni/editors-all.js:15541 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:260
+msgid "Version Notes"
+msgstr ""
+
+#: static/js/zamboni/editors-all.js:15546 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:265
+msgid "Notes for Reviewers"
+msgstr ""
+
+#: static/js/zamboni/editors-all.js:15551 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:270
+msgid "No version notes found"
+msgstr "נמצאו הערות גרסה"
+
+#: static/js/zamboni/editors-all.js:15611 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:330
+msgid "Average Reviews"
+msgstr ""
+
+#: static/js/zamboni/editors-all.js:15667 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:386
+msgid "Number of Reviews"
+msgstr ""
+
+#: static/js/zamboni/editors-all.js:15726 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:445
+msgid "Error loading translation"
+msgstr ""
+
+#: static/js/zamboni/editors-all.js:15975 static/js/zamboni/editors-min.js:5 static/js/zamboni/themes_review_templates.js:31
+msgid "Theme"
+msgstr ""
+
+#: static/js/zamboni/editors-all.js:15977 static/js/zamboni/editors-min.js:5 static/js/zamboni/themes_review_templates.js:33
+msgid "Reviewer"
+msgstr ""
+
+#: static/js/zamboni/editors-all.js:15979 static/js/zamboni/editors-min.js:5 static/js/zamboni/themes_review_templates.js:35
+msgid "Status"
+msgstr ""
+
+#: static/js/zamboni/editors-all.js:16196 static/js/zamboni/editors-min.js:5 static/js/zamboni/themes_review.js:176
+msgid "Requested Info"
+msgstr ""
+
+#: static/js/zamboni/editors-all.js:16197 static/js/zamboni/editors-min.js:5 static/js/zamboni/themes_review.js:177
+msgid "Flagged"
+msgstr ""
+
+#: static/js/zamboni/editors-all.js:16198 static/js/zamboni/editors-min.js:5 static/js/zamboni/themes_review.js:178
+msgid "Duplicate"
+msgstr ""
+
+#: static/js/zamboni/editors-all.js:16199 static/js/zamboni/editors-min.js:5 static/js/zamboni/themes_review.js:179
+msgid "Rejected"
+msgstr ""
+
+#: static/js/zamboni/editors-all.js:16200 static/js/zamboni/editors-min.js:5 static/js/zamboni/themes_review.js:180
+msgid "Approved"
+msgstr ""
+
+#: static/js/zamboni/editors-all.js:16444 static/js/zamboni/editors-min.js:5 static/js/zamboni/themes_review.js:424
+msgid "No results found"
+msgstr ""
+
+#: static/js/zamboni/mobile-all.js:15186 static/js/zamboni/mobile/buttons.js:52
 msgid "Not Updated for {0} {1}"
 msgstr "לא עודכן עבור {0} גרסה {1}"
 
-#: static/js/zamboni/mobile/buttons.js:53
+#: static/js/zamboni/mobile-all.js:15187 static/js/zamboni/mobile/buttons.js:53
 msgid "Requires Newer Version of {0}"
 msgstr "נדרשת גרסה חדשה של {0}"
 
-#: static/js/zamboni/mobile/buttons.js:54
+#: static/js/zamboni/mobile-all.js:15188 static/js/zamboni/mobile/buttons.js:54
 msgid "Unreviewed"
 msgstr "לא נסקר"
 
-#: static/js/zamboni/mobile/buttons.js:55
+#: static/js/zamboni/mobile-all.js:15189 static/js/zamboni/mobile/buttons.js:55
 msgid "Experimental <span>(Learn More)</span>"
 msgstr "ניסיוני <span>(מידע נוסף)</span>"
 
-#: static/js/zamboni/mobile/buttons.js:56 static/js/zamboni/mobile/buttons.js:57
+#: static/js/zamboni/mobile-all.js:15190 static/js/zamboni/mobile-all.js:15191 static/js/zamboni/mobile/buttons.js:56 static/js/zamboni/mobile/buttons.js:57
 msgid "Not Available for {0}"
 msgstr "לא זמין עבור {0}"
 
-#: static/js/zamboni/mobile/buttons.js:58
+#: static/js/zamboni/mobile-all.js:15192 static/js/zamboni/mobile/buttons.js:58
 msgid "Experimental"
 msgstr "ניסיוני"
 
-#: static/js/zamboni/mobile/buttons.js:59
+#: static/js/zamboni/mobile-all.js:15193 static/js/zamboni/mobile/buttons.js:59
 msgid "Themes Require Newer Version of {0}"
 msgstr ""
 
-#: static/js/zamboni/mobile/buttons.js:60
+#: static/js/zamboni/mobile-all.js:15194 static/js/zamboni/mobile/buttons.js:60
 msgid "Themes Require {0}"
 msgstr ""
 
-#: static/js/zamboni/mobile/buttons.js:105
+#: static/js/zamboni/mobile-all.js:15239 static/js/zamboni/mobile/buttons.js:105
 msgid "Installing..."
 msgstr ""
 
-#: static/js/zamboni/mobile/buttons.js:125
+#: static/js/zamboni/mobile-all.js:15259 static/js/zamboni/mobile/buttons.js:125
 msgid "This add-on has been preliminarily reviewed by Mozilla."
 msgstr "התוספת הזאת נסקרה באופן ראשוני על־ידי מוזילה."
 
-#: static/js/zamboni/mobile/buttons.js:250
+#: static/js/zamboni/mobile-all.js:15384 static/js/zamboni/mobile/buttons.js:250
 msgid "Keep it"
 msgstr "להשאיר את זה"
 
-#: static/js/zamboni/mobile/general.js:344
+#: static/js/zamboni/mobile-all.js:16049 static/js/zamboni/mobile-min.js:6 static/js/zamboni/mobile/general.js:344
 msgid "You're trying it on!"
 msgstr "אתה מנסה את זה!"
 
-#: static/js/zamboni/mobile/general.js:356
+#: static/js/zamboni/mobile-all.js:16061 static/js/zamboni/mobile-min.js:6 static/js/zamboni/mobile/general.js:356
 msgid "Added to Firefox"
 msgstr "הוסף לפיירפוקס"
-

--- a/locale/hi_IN/LC_MESSAGES/django.po
+++ b/locale/hi_IN/LC_MESSAGES/django.po
@@ -3,69 +3,70 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2016-02-24 21:23+0000\n"
+"POT-Creation-Date: 2016-04-18 15:47+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
+"Language: \n"
 "MIME-Version: 1.0\n"
-"Content-Type: text/plain; charset=utf-8\n"
+"Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Generated-By: Babel 2.2.0\n"
 
-#: src/olympia/accounts/views.py:52
+#: src/olympia/accounts/views.py:54
 msgid "Your log in attempt could not be parsed. Please try again."
 msgstr ""
 
-#: src/olympia/accounts/views.py:54
+#: src/olympia/accounts/views.py:56
 msgid "Your Firefox Account could not be found. Please try again."
 msgstr ""
 
-#: src/olympia/accounts/views.py:55
+#: src/olympia/accounts/views.py:57
 msgid "You could not be logged in. Please try again."
 msgstr ""
 
-#: src/olympia/accounts/views.py:57
+#: src/olympia/accounts/views.py:59
 msgid "Your account has already been migrated to Firefox Accounts."
 msgstr ""
 
-#: src/olympia/accounts/views.py:59
+#: src/olympia/accounts/views.py:61
 msgid "Your Firefox Account already exists on this site."
 msgstr ""
 
-#: src/olympia/accounts/views.py:108
+#: src/olympia/accounts/views.py:110
 msgid "Great job!"
 msgstr ""
 
-#: src/olympia/accounts/views.py:109
+#: src/olympia/accounts/views.py:111
 msgid "You can now log in to Add-ons with your Firefox Account."
 msgstr ""
 
-#: src/olympia/accounts/views.py:121
+#: src/olympia/accounts/views.py:123
 msgid "Need help?"
 msgstr ""
 
-#: src/olympia/addons/buttons.py:180
+#: src/olympia/addons/buttons.py:177
 msgid "Download Now"
 msgstr ""
 
-#: src/olympia/addons/buttons.py:182
+#: src/olympia/addons/buttons.py:179
 msgid "Download"
 msgstr ""
 
 #. L10n: please keep &nbsp; in the string so &rarr; does not wrap.
-#: src/olympia/addons/buttons.py:186
+#: src/olympia/addons/buttons.py:183
 msgid "Continue to Download&nbsp;&rarr;"
 msgstr ""
 
-#: src/olympia/addons/buttons.py:202 src/olympia/addons/helpers.py:35 src/olympia/addons/views.py:319 src/olympia/addons/templates/addons/impala/details.html:114
+#: src/olympia/addons/buttons.py:199 src/olympia/addons/helpers.py:35 src/olympia/addons/views.py:333 src/olympia/addons/templates/addons/impala/details.html:111
 #: src/olympia/addons/templates/addons/impala/listing/items.html:17 src/olympia/addons/templates/addons/mobile/home.html:40 src/olympia/amo/templates/amo/side_nav.html:6
-#: src/olympia/amo/templates/amo/side_nav.html:10 src/olympia/amo/templates/amo/site_nav.html:2 src/olympia/amo/templates/amo/site_nav.html:55 src/olympia/bandwagon/views.py:95
-#: src/olympia/browse/views.py:54 src/olympia/browse/views.py:68 src/olympia/browse/views.py:235 src/olympia/browse/templates/browse/impala/category_landing.html:22
+#: src/olympia/amo/templates/amo/side_nav.html:10 src/olympia/amo/templates/amo/site_nav.html:2 src/olympia/amo/templates/amo/site_nav.html:53 src/olympia/bandwagon/views.py:95
+#: src/olympia/browse/views.py:54 src/olympia/browse/views.py:68 src/olympia/browse/views.py:202 src/olympia/browse/templates/browse/impala/category_landing.html:22
 #: src/olympia/browse/templates/browse/personas/mobile/category_landing.html:26
 msgid "Featured"
 msgstr ""
 
-#: src/olympia/addons/buttons.py:221
+#: src/olympia/addons/buttons.py:218
 msgid "Add to {0}"
 msgstr ""
 
@@ -113,39 +114,39 @@ msgid_plural "All tags must be at least {0} characters."
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/olympia/addons/forms.py:234
+#: src/olympia/addons/forms.py:238
 msgid "Categories cannot be changed while your add-on is featured for this application."
 msgstr ""
 
 #. L10n: {0} is the number of categories.
-#: src/olympia/addons/forms.py:238
+#: src/olympia/addons/forms.py:242
 msgid "You can have only {0} category."
 msgid_plural "You can have only {0} categories."
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/olympia/addons/forms.py:246
+#: src/olympia/addons/forms.py:250
 msgid "The miscellaneous category cannot be combined with additional categories."
 msgstr ""
 
-#: src/olympia/addons/forms.py:369
+#: src/olympia/addons/forms.py:374
 #, python-format
 msgid "Before changing your default locale you must have a name, summary, and description in that locale. You are missing %s."
 msgstr ""
 
-#: src/olympia/addons/forms.py:484 src/olympia/addons/forms.py:575
+#: src/olympia/addons/forms.py:455 src/olympia/addons/forms.py:546
 msgid "A license must be selected."
 msgstr ""
 
-#: src/olympia/addons/forms.py:556
+#: src/olympia/addons/forms.py:527
 msgid "Give Your Theme a Name."
 msgstr ""
 
-#: src/olympia/addons/forms.py:562 src/olympia/devhub/templates/devhub/personas/submit.html:53
+#: src/olympia/addons/forms.py:533 src/olympia/devhub/templates/devhub/personas/submit.html:53
 msgid "Describe your Theme."
 msgstr ""
 
-#: src/olympia/addons/forms.py:704
+#: src/olympia/addons/forms.py:675
 msgid "Enter a new author's email address"
 msgstr ""
 
@@ -153,37 +154,37 @@ msgstr ""
 msgid "Not Reviewed"
 msgstr ""
 
-#: src/olympia/addons/models.py:301
+#: src/olympia/addons/models.py:298
 msgid "Users have the option of contributing more or less than this amount."
 msgstr ""
 
-#: src/olympia/addons/models.py:309
-msgid "Users will always be asked in the Add-ons Manager (Firefox 4 and above)"
+#: src/olympia/addons/models.py:306
+msgid "Users will always be asked in the Add-ons Manager (Firefox 4 and above). Only applies to desktop."
 msgstr ""
 
-#: src/olympia/addons/models.py:1804 src/olympia/addons/templates/addons/details_box.html:55 src/olympia/devhub/templates/devhub/index.html:92
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:102
+#: src/olympia/addons/models.py:1802 src/olympia/addons/templates/addons/details_box.html:55 src/olympia/devhub/templates/devhub/index.html:92
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:89
 msgid "Listed"
 msgstr ""
 
-#: src/olympia/addons/views.py:320 src/olympia/browse/templates/browse/personas/mobile/category_landing.html:27
+#: src/olympia/addons/views.py:334 src/olympia/browse/templates/browse/personas/mobile/category_landing.html:27
 msgid "Popular"
 msgstr ""
 
-#: src/olympia/addons/views.py:321 src/olympia/browse/views.py:238 src/olympia/browse/views.py:280 src/olympia/browse/views.py:482
+#: src/olympia/addons/views.py:335 src/olympia/browse/views.py:205 src/olympia/browse/views.py:247 src/olympia/browse/views.py:449
 msgid "Recently Added"
 msgstr ""
 
-#: src/olympia/addons/views.py:322 src/olympia/bandwagon/views.py:99 src/olympia/browse/views.py:60 src/olympia/browse/views.py:71 src/olympia/search/forms.py:16 src/olympia/search/forms.py:91
+#: src/olympia/addons/views.py:336 src/olympia/bandwagon/views.py:99 src/olympia/browse/views.py:60 src/olympia/browse/views.py:71 src/olympia/search/forms.py:16 src/olympia/search/forms.py:91
 msgid "Recently Updated"
 msgstr ""
 
 #. l10n: {0} is the addon name
-#: src/olympia/addons/views.py:520
+#: src/olympia/addons/views.py:534
 msgid "Contribution for {0}"
 msgstr ""
 
-#: src/olympia/addons/views.py:613
+#: src/olympia/addons/views.py:627
 msgid "Abuse reported."
 msgstr ""
 
@@ -250,9 +251,9 @@ msgstr ""
 #: src/olympia/devhub/templates/devhub/addons/ajax_compat_update.html:36 src/olympia/devhub/templates/devhub/addons/profile.html:44 src/olympia/devhub/templates/devhub/addons/edit/admin.html:101
 #: src/olympia/devhub/templates/devhub/addons/edit/basic.html:152 src/olympia/devhub/templates/devhub/addons/edit/details.html:85 src/olympia/devhub/templates/devhub/addons/edit/support.html:67
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:166 src/olympia/devhub/templates/devhub/addons/forms_shared/media.html:149
-#: src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:44 src/olympia/devhub/templates/devhub/versions/add_file_modal.html:78 src/olympia/devhub/templates/devhub/versions/edit.html:139
-#: src/olympia/devhub/templates/devhub/versions/list.html:242 src/olympia/devhub/templates/devhub/versions/list.html:276 src/olympia/devhub/templates/devhub/versions/list.html:317
-#: src/olympia/devhub/templates/devhub/versions/list.html:351 src/olympia/reviews/templates/reviews/edit_review.html:16 src/olympia/translations/templates/translations/trans-menu.html:50
+#: src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:43 src/olympia/devhub/templates/devhub/versions/add_file_modal.html:58 src/olympia/devhub/templates/devhub/versions/edit.html:139
+#: src/olympia/devhub/templates/devhub/versions/list.html:239 src/olympia/devhub/templates/devhub/versions/list.html:281 src/olympia/devhub/templates/devhub/versions/list.html:315
+#: src/olympia/devhub/templates/devhub/versions/list.html:349 src/olympia/reviews/templates/reviews/edit_review.html:16 src/olympia/translations/templates/translations/trans-menu.html:50
 #: src/olympia/translations/templates/translations/trans-menu.html:62
 msgid "or"
 msgstr ""
@@ -363,7 +364,7 @@ msgid "Add-on Information for {0}"
 msgstr ""
 
 #: src/olympia/addons/templates/addons/details_box.html:30 src/olympia/addons/templates/addons/persona_detail_table.html:3 src/olympia/addons/templates/addons/mobile/details.html:63
-#: src/olympia/addons/templates/addons/mobile/persona_detail_table.html:7 src/olympia/browse/views.py:459 src/olympia/devhub/views.py:75
+#: src/olympia/addons/templates/addons/mobile/persona_detail_table.html:7 src/olympia/browse/views.py:426 src/olympia/devhub/views.py:73
 msgid "Updated"
 msgstr ""
 
@@ -382,11 +383,11 @@ msgstr ""
 msgid "Visibility"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/details_box.html:57 src/olympia/devhub/templates/devhub/index.html:94 src/olympia/devhub/templates/devhub/includes/addon_details.html:104
+#: src/olympia/addons/templates/addons/details_box.html:57 src/olympia/devhub/templates/devhub/index.html:94 src/olympia/devhub/templates/devhub/includes/addon_details.html:91
 msgid "Hidden"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/details_box.html:59 src/olympia/devhub/templates/devhub/index.html:96 src/olympia/devhub/templates/devhub/includes/addon_details.html:106
+#: src/olympia/addons/templates/addons/details_box.html:59 src/olympia/devhub/templates/devhub/index.html:96 src/olympia/devhub/templates/devhub/includes/addon_details.html:93
 msgid "Unlisted"
 msgstr ""
 
@@ -394,13 +395,13 @@ msgstr ""
 msgid "Required Add-ons"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/details_box.html:81 src/olympia/addons/templates/addons/persona_detail_table.html:15 src/olympia/browse/views.py:462 src/olympia/devhub/views.py:78
-#: src/olympia/devhub/views.py:85 src/olympia/discovery/templates/discovery/addons/detail.html:57 src/olympia/reviews/forms.py:62 src/olympia/reviews/templates/reviews/add.html:57
+#: src/olympia/addons/templates/addons/details_box.html:81 src/olympia/addons/templates/addons/persona_detail_table.html:15 src/olympia/browse/views.py:429 src/olympia/devhub/views.py:76
+#: src/olympia/devhub/views.py:83 src/olympia/discovery/templates/discovery/addons/detail.html:57 src/olympia/reviews/forms.py:62 src/olympia/reviews/templates/reviews/add.html:57
 #: src/olympia/reviews/templates/reviews/mobile/review_list.html:18
 msgid "Rating"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/details_box.html:85 src/olympia/browse/views.py:461 src/olympia/devhub/views.py:77 src/olympia/devhub/views.py:84
+#: src/olympia/addons/templates/addons/details_box.html:85 src/olympia/browse/views.py:428 src/olympia/devhub/views.py:75 src/olympia/devhub/views.py:82
 #: src/olympia/stats/templates/stats/addon_report_menu.html:8 src/olympia/stats/templates/stats/collection_report_menu.html:18
 msgid "Downloads"
 msgstr ""
@@ -420,7 +421,7 @@ msgstr ""
 
 #. The Privacy Policy for this add-on.
 #: src/olympia/addons/templates/addons/details_box.html:121 src/olympia/addons/templates/addons/privacy.html:19 src/olympia/addons/templates/addons/privacy.html:23
-#: src/olympia/addons/templates/addons/impala/button.html:43 src/olympia/addons/templates/addons/impala/details.html:307 src/olympia/devhub/templates/devhub/includes/policy_form.html:20
+#: src/olympia/addons/templates/addons/impala/button.html:43 src/olympia/addons/templates/addons/impala/details.html:312 src/olympia/devhub/templates/devhub/includes/policy_form.html:23
 #: src/olympia/templates/mobile/base_addons.html:87
 msgid "Privacy Policy"
 msgstr ""
@@ -445,7 +446,7 @@ msgstr ""
 msgid "Developer Comments"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/details_box.html:199 src/olympia/addons/templates/addons/impala/details.html:259
+#: src/olympia/addons/templates/addons/details_box.html:199 src/olympia/addons/templates/addons/impala/details.html:264
 msgid "Development Channel"
 msgstr ""
 
@@ -465,7 +466,7 @@ msgid ""
 "developer. To stop receiving development updates, reinstall the default version from the link above."
 msgstr ""
 
-#: src/olympia/addons/templates/addons/details_box.html:220 src/olympia/addons/templates/addons/impala/details.html:278
+#: src/olympia/addons/templates/addons/details_box.html:220 src/olympia/addons/templates/addons/impala/details.html:283
 msgid "Version {0}:"
 msgstr ""
 
@@ -484,7 +485,7 @@ msgid "End-User License Agreement for {0}"
 msgstr ""
 
 #: src/olympia/addons/templates/addons/eula.html:17 src/olympia/addons/templates/addons/eula.html:21 src/olympia/addons/templates/addons/impala/button.html:48
-#: src/olympia/addons/templates/addons/impala/details.html:316 src/olympia/devhub/templates/devhub/includes/policy_form.html:3 src/olympia/discovery/templates/discovery/addons/eula.html:11
+#: src/olympia/addons/templates/addons/impala/details.html:321 src/olympia/devhub/templates/devhub/includes/policy_form.html:3 src/olympia/discovery/templates/discovery/addons/eula.html:11
 msgid "End-User License Agreement"
 msgstr ""
 
@@ -501,7 +502,7 @@ msgstr ""
 msgid "Add-ons for {0}"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/home.html:10 src/olympia/addons/templates/addons/home.html:51 src/olympia/browse/templates/browse/impala/base_listing.html:11
+#: src/olympia/addons/templates/addons/home.html:10 src/olympia/addons/templates/addons/home.html:53 src/olympia/browse/templates/browse/impala/base_listing.html:11
 msgid "Featured Extensions"
 msgstr ""
 
@@ -509,29 +510,29 @@ msgstr ""
 msgid "Popular Extensions"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/home.html:42 src/olympia/amo/templates/amo/side_nav.html:3 src/olympia/amo/templates/amo/side_nav.html:11 src/olympia/amo/templates/amo/site_nav.html:3
-#: src/olympia/amo/templates/amo/site_nav.html:25 src/olympia/browse/views.py:236 src/olympia/browse/views.py:281 src/olympia/browse/views.py:481
+#: src/olympia/addons/templates/addons/home.html:44 src/olympia/amo/templates/amo/side_nav.html:3 src/olympia/amo/templates/amo/side_nav.html:11 src/olympia/amo/templates/amo/site_nav.html:3
+#: src/olympia/amo/templates/amo/site_nav.html:25 src/olympia/browse/views.py:203 src/olympia/browse/views.py:248 src/olympia/browse/views.py:448
 msgid "Most Popular"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/home.html:43
+#: src/olympia/addons/templates/addons/home.html:45
 msgid "All »"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/home.html:52 src/olympia/addons/templates/addons/home.html:61 src/olympia/addons/templates/addons/home.html:70 src/olympia/addons/templates/addons/home.html:78
+#: src/olympia/addons/templates/addons/home.html:54 src/olympia/addons/templates/addons/home.html:63 src/olympia/addons/templates/addons/home.html:72 src/olympia/addons/templates/addons/home.html:80
 #: src/olympia/browse/templates/browse/impala/category_landing.html:36
 msgid "See all »"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/home.html:60
+#: src/olympia/addons/templates/addons/home.html:62
 msgid "Up &amp; Coming Extensions"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/home.html:69 src/olympia/browse/templates/browse/personas/category_landing.html:61 src/olympia/discovery/templates/discovery/pane.html:74
+#: src/olympia/addons/templates/addons/home.html:71 src/olympia/browse/templates/browse/personas/category_landing.html:61 src/olympia/discovery/templates/discovery/pane.html:74
 msgid "Featured Themes"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/home.html:77 src/olympia/bandwagon/templates/bandwagon/impala/collection_listing.html:5
+#: src/olympia/addons/templates/addons/home.html:79 src/olympia/bandwagon/templates/bandwagon/impala/collection_listing.html:5
 msgid "Featured Collections"
 msgstr ""
 
@@ -549,7 +550,7 @@ msgid "Updated {0}"
 msgstr ""
 
 #. {0} is a date.
-#: src/olympia/addons/templates/addons/macros.html:10 src/olympia/addons/templates/addons/macros.html:69 src/olympia/addons/templates/addons/persona_preview.html:21
+#: src/olympia/addons/templates/addons/macros.html:10 src/olympia/addons/templates/addons/macros.html:69 src/olympia/addons/templates/addons/persona_preview.html:22
 #: src/olympia/addons/templates/addons/listing/items_mobile.html:44 src/olympia/addons/templates/addons/listing/macros.html:39
 #: src/olympia/bandwagon/templates/bandwagon/collection_listing_items.html:37 src/olympia/bandwagon/templates/bandwagon/impala/collection_listing_items.html:37
 msgid "Added {0}"
@@ -570,15 +571,14 @@ msgstr[0] ""
 msgstr[1] ""
 
 #. {0} is the number of downloads.
-#: src/olympia/addons/templates/addons/macros.html:53 src/olympia/addons/templates/addons/impala/details.html:61
+#: src/olympia/addons/templates/addons/macros.html:53 src/olympia/addons/templates/addons/impala/details.html:59
 msgid "{0} weekly download"
 msgid_plural "{0} weekly downloads"
 msgstr[0] ""
 msgstr[1] ""
 
 #. {0} is the number of users.
-#: src/olympia/addons/templates/addons/macros.html:61 src/olympia/addons/templates/addons/impala/details.html:54 src/olympia/compat/templates/compat/index.html:71
-#: src/olympia/zadmin/templates/zadmin/compat.html:67
+#: src/olympia/addons/templates/addons/macros.html:61 src/olympia/addons/templates/addons/impala/details.html:52 src/olympia/zadmin/templates/zadmin/compat.html:67
 msgid "{0} user"
 msgid_plural "{0} users"
 msgstr[0] ""
@@ -596,7 +596,7 @@ msgstr ""
 msgid "Return to the addon."
 msgstr ""
 
-#: src/olympia/addons/templates/addons/persona_detail.html:17 src/olympia/addons/templates/addons/impala/details.html:106 src/olympia/addons/templates/addons/mobile/details.html:23
+#: src/olympia/addons/templates/addons/persona_detail.html:17 src/olympia/addons/templates/addons/impala/details.html:103 src/olympia/addons/templates/addons/mobile/details.html:23
 #: src/olympia/addons/templates/addons/mobile/persona_detail.html:21 src/olympia/discovery/templates/discovery/addons/base.html:27 src/olympia/editors/templates/editors/review.html:31
 msgid "by"
 msgstr ""
@@ -640,34 +640,35 @@ msgstr ""
 msgid "License"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/persona_preview.html:12 src/olympia/constants/base.py:48
+#: src/olympia/addons/templates/addons/persona_preview.html:13 src/olympia/constants/base.py:48
 msgid "Awaiting Review"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/persona_preview.html:14 src/olympia/amo/log.py:180 src/olympia/constants/base.py:42 src/olympia/editors/helpers.py:62
+#: src/olympia/addons/templates/addons/persona_preview.html:15 src/olympia/amo/log.py:180 src/olympia/constants/base.py:42 src/olympia/editors/helpers.py:62
 msgid "Rejected"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/persona_preview.html:16 src/olympia/amo/log.py:159
+#: src/olympia/addons/templates/addons/persona_preview.html:17 src/olympia/amo/log.py:159
 msgid "Approved"
 msgstr ""
 
 #. {0} is the number of users.
-#: src/olympia/addons/templates/addons/persona_preview.html:26 src/olympia/addons/templates/addons/listing/items_mobile.html:36 src/olympia/addons/templates/addons/listing/macros.html:31
+#: src/olympia/addons/templates/addons/persona_preview.html:27 src/olympia/addons/templates/addons/listing/items_mobile.html:36 src/olympia/addons/templates/addons/listing/macros.html:31
 msgid "<strong>{0}</strong> user"
 msgid_plural "<strong>{0}</strong> users"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/olympia/addons/templates/addons/persona_preview.html:40
+#: src/olympia/addons/templates/addons/persona_preview.html:41
 msgid "Hover to Preview"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/persona_preview.html:46 src/olympia/addons/templates/addons/persona_preview.html:48 src/olympia/reviews/templates/reviews/add.html:15
+#: src/olympia/addons/templates/addons/persona_preview.html:47 src/olympia/addons/templates/addons/persona_preview.html:49 src/olympia/addons/templates/addons/persona_preview.html:97
+#: src/olympia/reviews/templates/reviews/add.html:15
 msgid "Add"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/persona_preview.html:57 src/olympia/bandwagon/templates/bandwagon/ajax_new.html:16 src/olympia/bandwagon/templates/bandwagon/edit.html:19
+#: src/olympia/addons/templates/addons/persona_preview.html:58 src/olympia/bandwagon/templates/bandwagon/ajax_new.html:16 src/olympia/bandwagon/templates/bandwagon/edit.html:19
 #: src/olympia/bandwagon/templates/bandwagon/includes/addedit.html:19 src/olympia/devhub/templates/devhub/addons/edit/admin.html:13 src/olympia/devhub/templates/devhub/addons/edit/basic.html:10
 #: src/olympia/devhub/templates/devhub/addons/edit/details.html:8 src/olympia/devhub/templates/devhub/addons/edit/media.html:6 src/olympia/devhub/templates/devhub/addons/edit/support.html:8
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:9 src/olympia/devhub/templates/devhub/addons/submit/describe.html:29 src/olympia/editors/templates/editors/review.html:257
@@ -676,21 +677,21 @@ msgstr ""
 
 #. For datetime formatting, see the table on
 #. http://docs.python.org/library/datetime.html#strftime-and-strptime-behavior
-#: src/olympia/addons/templates/addons/persona_preview.html:66
+#: src/olympia/addons/templates/addons/persona_preview.html:67
 #, python-format
 msgid "%%Y-%%m-%%d"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/persona_preview.html:67
+#: src/olympia/addons/templates/addons/persona_preview.html:68
 msgid "by {0} on {1}"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/persona_preview.html:75 src/olympia/reviews/helpers.py:17 src/olympia/reviews/templates/reviews/review_list.html:63
+#: src/olympia/addons/templates/addons/persona_preview.html:76 src/olympia/reviews/helpers.py:17 src/olympia/reviews/templates/reviews/review_list.html:63
 #: src/olympia/reviews/templates/reviews/reviews_link.html:21 src/olympia/reviews/templates/reviews/impala/reviews_link.html:16
 msgid "Not yet rated"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/persona_preview.html:78
+#: src/olympia/addons/templates/addons/persona_preview.html:79
 msgid "<b>{0}</b> users"
 msgstr ""
 
@@ -703,7 +704,7 @@ msgid "Learn more about Firefox"
 msgstr ""
 
 #: src/olympia/addons/templates/addons/popups.html:22
-msgid "or <b><a class=\"installer\" href=\"{url}\">download anyway</a></b>"
+msgid "or <b><a class=\"button installer\" href=\"{url}\">download anyway</a></b>"
 msgstr ""
 
 #: src/olympia/addons/templates/addons/popups.html:26
@@ -802,7 +803,7 @@ msgid ""
 msgstr ""
 
 #: src/olympia/addons/templates/addons/report_abuse.html:6 src/olympia/addons/templates/addons/report_abuse_full.html:10 src/olympia/addons/templates/addons/impala/details-more.html:23
-#: src/olympia/addons/templates/addons/impala/details.html:328
+#: src/olympia/addons/templates/addons/impala/details.html:333
 msgid "Report Abuse"
 msgstr ""
 
@@ -821,9 +822,9 @@ msgstr ""
 #: src/olympia/devhub/templates/devhub/addons/ajax_compat_update.html:36 src/olympia/devhub/templates/devhub/addons/profile.html:44 src/olympia/devhub/templates/devhub/addons/edit/admin.html:104
 #: src/olympia/devhub/templates/devhub/addons/edit/basic.html:155 src/olympia/devhub/templates/devhub/addons/edit/details.html:88 src/olympia/devhub/templates/devhub/addons/edit/support.html:70
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:169 src/olympia/devhub/templates/devhub/addons/forms_shared/media.html:152
-#: src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:44 src/olympia/devhub/templates/devhub/personas/edit.html:222 src/olympia/devhub/templates/devhub/versions/add_file_modal.html:79
-#: src/olympia/devhub/templates/devhub/versions/edit.html:140 src/olympia/devhub/templates/devhub/versions/list.html:208 src/olympia/devhub/templates/devhub/versions/list.html:242
-#: src/olympia/devhub/templates/devhub/versions/list.html:276 src/olympia/devhub/templates/devhub/versions/list.html:317 src/olympia/reviews/templates/reviews/edit_review.html:16
+#: src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:43 src/olympia/devhub/templates/devhub/personas/edit.html:222 src/olympia/devhub/templates/devhub/versions/add_file_modal.html:59
+#: src/olympia/devhub/templates/devhub/versions/edit.html:140 src/olympia/devhub/templates/devhub/versions/list.html:208 src/olympia/devhub/templates/devhub/versions/list.html:239
+#: src/olympia/devhub/templates/devhub/versions/list.html:281 src/olympia/devhub/templates/devhub/versions/list.html:315 src/olympia/reviews/templates/reviews/edit_review.html:16
 #: src/olympia/translations/templates/translations/trans-menu.html:50 src/olympia/translations/templates/translations/trans-menu.html:62 src/olympia/zadmin/templates/zadmin/validation.html:105
 msgid "Cancel"
 msgstr ""
@@ -868,7 +869,7 @@ msgstr ""
 msgid "Review Guidelines"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/review_list_box.html:5 src/olympia/addons/templates/addons/impala/details-more.html:27 src/olympia/editors/helpers.py:921
+#: src/olympia/addons/templates/addons/review_list_box.html:5 src/olympia/addons/templates/addons/impala/details-more.html:27 src/olympia/editors/helpers.py:1001
 #: src/olympia/reviews/templates/reviews/add.html:14 src/olympia/reviews/templates/reviews/reply.html:14 src/olympia/reviews/templates/reviews/review_list.html:19
 #: src/olympia/reviews/templates/reviews/mobile/review_list.html:26
 msgid "Reviews"
@@ -959,119 +960,119 @@ msgid_plural "Other add-ons by these authors"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/olympia/addons/templates/addons/impala/details.html:41
+#: src/olympia/addons/templates/addons/impala/details.html:39
 #, python-format
 msgid "<span itemprop=\"ratingCount\">%(num)s</span> user review"
 msgid_plural "<span itemprop=\"ratingCount\">%(num)s</span> user reviews"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/olympia/addons/templates/addons/impala/details.html:69
+#: src/olympia/addons/templates/addons/impala/details.html:66
 msgid "View statistics"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/impala/details.html:84
+#: src/olympia/addons/templates/addons/impala/details.html:81
 msgid "Manage"
 msgstr ""
 
 #. {0} is an add-on name.
-#: src/olympia/addons/templates/addons/impala/details.html:96
+#: src/olympia/addons/templates/addons/impala/details.html:93
 msgid "Icon of {0}"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/impala/details.html:103 src/olympia/addons/templates/addons/impala/listing/items.html:14
+#: src/olympia/addons/templates/addons/impala/details.html:100 src/olympia/addons/templates/addons/impala/listing/items.html:14
 msgid "No Restart"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/impala/details.html:127
+#: src/olympia/addons/templates/addons/impala/details.html:124
 #, python-format
 msgid "Meet the Developer: <a href=\"%(url)s\">%(name)s</a>"
 msgid_plural "<a href=\"%(url)s\">Meet the Developers</a>"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/olympia/addons/templates/addons/impala/details.html:137
+#: src/olympia/addons/templates/addons/impala/details.html:134
 msgid "Learn why {0} was created and find out what's next for this add-on."
 msgstr ""
 
 #. {0} is an index.
-#: src/olympia/addons/templates/addons/impala/details.html:156
+#: src/olympia/addons/templates/addons/impala/details.html:161
 msgid "Add-on screenshot #{0}"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/impala/details.html:182
+#: src/olympia/addons/templates/addons/impala/details.html:187
 msgid "Add-on home page"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/impala/details.html:185
+#: src/olympia/addons/templates/addons/impala/details.html:190
 msgid "Support site"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/impala/details.html:189
+#: src/olympia/addons/templates/addons/impala/details.html:194
 msgid "Support E-mail"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/impala/details.html:194 src/olympia/devhub/models.py:378 src/olympia/devhub/templates/devhub/versions/list.html:12
+#: src/olympia/addons/templates/addons/impala/details.html:199 src/olympia/devhub/models.py:378 src/olympia/devhub/templates/devhub/versions/list.html:12
 #: src/olympia/versions/templates/versions/version.html:6 src/olympia/versions/templates/versions/mobile/version.html:6
 msgid "Version {0}"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/impala/details.html:194
+#: src/olympia/addons/templates/addons/impala/details.html:199
 msgid "Info"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/impala/details.html:195 src/olympia/devhub/templates/devhub/includes/addon_details.html:129
+#: src/olympia/addons/templates/addons/impala/details.html:200 src/olympia/devhub/templates/devhub/includes/addon_details.html:116
 msgid "Last Updated:"
-msgstr ""
-
-#: src/olympia/addons/templates/addons/impala/details.html:200
-#, python-format
-msgid "Released under <a target=\"_blank\" href=\"%(url)s\">%(name)s</a>"
-msgstr ""
-
-#: src/olympia/addons/templates/addons/impala/details.html:201 src/olympia/addons/templates/addons/impala/details.html:206 src/olympia/amo/helpers.py:398 src/olympia/devhub/forms.py:142
-#: src/olympia/devhub/forms.py:173 src/olympia/versions/templates/versions/version.html:40 src/olympia/versions/templates/versions/version.html:45
-msgid "Custom License"
 msgstr ""
 
 #: src/olympia/addons/templates/addons/impala/details.html:205
 #, python-format
+msgid "Released under <a target=\"_blank\" href=\"%(url)s\">%(name)s</a>"
+msgstr ""
+
+#: src/olympia/addons/templates/addons/impala/details.html:206 src/olympia/addons/templates/addons/impala/details.html:211 src/olympia/amo/helpers.py:398 src/olympia/devhub/forms.py:142
+#: src/olympia/devhub/forms.py:173 src/olympia/versions/templates/versions/version.html:40 src/olympia/versions/templates/versions/version.html:45
+msgid "Custom License"
+msgstr ""
+
+#: src/olympia/addons/templates/addons/impala/details.html:210
+#, python-format
 msgid "Released under <a href=\"%(url)s\">%(name)s</a>"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/impala/details.html:217
+#: src/olympia/addons/templates/addons/impala/details.html:222
 msgid "About this Add-on"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/impala/details.html:233
+#: src/olympia/addons/templates/addons/impala/details.html:238
 msgid "Developer’s Comments"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/impala/details.html:243
+#: src/olympia/addons/templates/addons/impala/details.html:248
 msgid "Version Information"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/impala/details.html:250
+#: src/olympia/addons/templates/addons/impala/details.html:255
 msgid "See complete version history"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/impala/details.html:262
+#: src/olympia/addons/templates/addons/impala/details.html:267
 msgid ""
 "The Development Channel lets you test an experimental new version of this add-on before it's released to the general public. Once you install the development version, you will continue to get "
 "updates from this channel. To stop receiving development updates, reinstall the default version from the link above."
 msgstr ""
 
-#: src/olympia/addons/templates/addons/impala/details.html:272
+#: src/olympia/addons/templates/addons/impala/details.html:277
 msgid "<strong>Caution:</strong> Development versions of this add-on have not been reviewed by Mozilla."
 msgstr ""
 
-#: src/olympia/addons/templates/addons/impala/details.html:287
+#: src/olympia/addons/templates/addons/impala/details.html:292
 msgid "See complete development channel history"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/impala/details.html:306 src/olympia/addons/templates/addons/impala/details.html:315 src/olympia/addons/templates/addons/impala/details.html:327
+#: src/olympia/addons/templates/addons/impala/details.html:311 src/olympia/addons/templates/addons/impala/details.html:320 src/olympia/addons/templates/addons/impala/details.html:332
 #: src/olympia/addons/templates/addons/impala/review_add_box.html:4 src/olympia/stats/templates/stats/popup.html:2 src/olympia/stats/templates/stats/popup.html:8
-#: src/olympia/stats/templates/stats/stats.html:202 src/olympia/users/templates/users/profile.html:119
+#: src/olympia/stats/templates/stats/stats.html:204 src/olympia/users/templates/users/profile.html:119
 msgid "close"
 msgstr ""
 
@@ -1127,15 +1128,11 @@ msgstr ""
 msgid "Source Code License"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/impala/persona_grid.html:16 src/olympia/addons/templates/addons/impala/toplist.html:6
-msgid "{0} users"
-msgstr ""
-
 #: src/olympia/addons/templates/addons/impala/review_list_box.html:19 src/olympia/reviews/templates/reviews/review.html:40
 msgid "permalink"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/impala/review_list_box.html:23 src/olympia/editors/templates/editors/queue.html:98 src/olympia/reviews/templates/reviews/review.html:44
+#: src/olympia/addons/templates/addons/impala/review_list_box.html:23 src/olympia/editors/templates/editors/queue.html:104 src/olympia/reviews/templates/reviews/review.html:44
 msgid "translate"
 msgstr ""
 
@@ -1154,6 +1151,10 @@ msgstr ""
 msgid "Be the first!"
 msgstr ""
 
+#: src/olympia/addons/templates/addons/impala/toplist.html:6
+msgid "{0} users"
+msgstr ""
+
 #: src/olympia/addons/templates/addons/impala/listing/sorter.html:14 src/olympia/devhub/templates/devhub/addons/listing/item_actions.html:49
 msgid "More"
 msgstr ""
@@ -1166,7 +1167,7 @@ msgstr ""
 msgid "My Add-ons"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/includes/dashboard_tabs.html:6 src/olympia/amo/context_processors.py:51
+#: src/olympia/addons/templates/addons/includes/dashboard_tabs.html:6 src/olympia/amo/context_processors.py:50
 msgid "My Themes"
 msgstr ""
 
@@ -1221,7 +1222,7 @@ msgstr ""
 msgid "Weekly Downloads"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/mobile/details.html:99 src/olympia/compat/templates/compat/reporter_detail.html:46 src/olympia/devhub/forms.py:787
+#: src/olympia/addons/templates/addons/mobile/details.html:99 src/olympia/compat/templates/compat/reporter_detail.html:46 src/olympia/devhub/forms.py:788
 #: src/olympia/devhub/templates/devhub/versions/list.html:163
 msgid "Version"
 msgstr ""
@@ -1305,7 +1306,7 @@ msgstr ""
 #: src/olympia/browse/templates/browse/personas/category_landing.html:21 src/olympia/browse/templates/browse/personas/category_landing.html:23
 #: src/olympia/browse/templates/browse/personas/category_landing.html:38 src/olympia/browse/templates/browse/personas/grid.html:7 src/olympia/browse/templates/browse/personas/grid.html:11
 #: src/olympia/browse/templates/browse/personas/mobile/base.html:7 src/olympia/browse/templates/browse/personas/mobile/category_landing.html:19 src/olympia/constants/base.py:180
-#: src/olympia/devhub/templates/devhub/personas/submit.html:13 src/olympia/editors/helpers.py:105 src/olympia/editors/templates/editors/base.html:26
+#: src/olympia/devhub/templates/devhub/personas/submit.html:13 src/olympia/editors/helpers.py:107 src/olympia/editors/templates/editors/base.html:26
 #: src/olympia/editors/templates/editors/performance.html:73 src/olympia/search/templates/search/personas.html:39 src/olympia/templates/menu_links.html:9
 msgid "Themes"
 msgstr ""
@@ -1326,7 +1327,7 @@ msgstr ""
 msgid "Highest Rated"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/mobile/home.html:74 src/olympia/amo/templates/amo/side_nav.html:5 src/olympia/amo/templates/amo/site_nav.html:27 src/olympia/amo/templates/amo/site_nav.html:57
+#: src/olympia/addons/templates/addons/mobile/home.html:74 src/olympia/amo/templates/amo/side_nav.html:5 src/olympia/amo/templates/amo/site_nav.html:27 src/olympia/amo/templates/amo/site_nav.html:55
 #: src/olympia/bandwagon/views.py:97 src/olympia/browse/views.py:57 src/olympia/browse/views.py:67 src/olympia/browse/templates/browse/personas/mobile/category_landing.html:65
 #: src/olympia/search/forms.py:15 src/olympia/search/forms.py:87
 msgid "Newest"
@@ -1340,90 +1341,90 @@ msgstr ""
 msgid "Theme Info &raquo;"
 msgstr ""
 
-#: src/olympia/amo/context_processors.py:39 src/olympia/devhub/templates/devhub/nav.html:43
+#: src/olympia/amo/context_processors.py:37 src/olympia/devhub/templates/devhub/nav.html:43
 msgid "Tools"
 msgstr ""
 
-#: src/olympia/amo/context_processors.py:48 src/olympia/discovery/templates/discovery/pane_account.html:8 src/olympia/users/templates/users/includes/navigation.html:2
+#: src/olympia/amo/context_processors.py:47 src/olympia/discovery/templates/discovery/pane_account.html:8 src/olympia/users/templates/users/includes/navigation.html:2
 msgid "My Profile"
 msgstr ""
 
-#: src/olympia/amo/context_processors.py:54 src/olympia/users/templates/users/edit.html:5 src/olympia/users/templates/users/includes/navigation.html:3
+#: src/olympia/amo/context_processors.py:53 src/olympia/users/templates/users/edit.html:5 src/olympia/users/templates/users/includes/navigation.html:3
 msgid "Account Settings"
 msgstr ""
 
-#: src/olympia/amo/context_processors.py:57 src/olympia/discovery/templates/discovery/pane_account.html:11 src/olympia/users/templates/users/profile.html:83
+#: src/olympia/amo/context_processors.py:56 src/olympia/discovery/templates/discovery/pane_account.html:11 src/olympia/users/templates/users/profile.html:83
 #: src/olympia/users/templates/users/includes/navigation.html:4
 msgid "My Collections"
 msgstr ""
 
-#: src/olympia/amo/context_processors.py:62 src/olympia/discovery/templates/discovery/pane_account.html:10 src/olympia/users/templates/users/includes/navigation.html:7
+#: src/olympia/amo/context_processors.py:61 src/olympia/discovery/templates/discovery/pane_account.html:10 src/olympia/users/templates/users/includes/navigation.html:7
 msgid "My Favorites"
 msgstr ""
 
-#: src/olympia/amo/context_processors.py:67 src/olympia/discovery/templates/discovery/pane_account.html:13 src/olympia/templates/impala/user_login.html:14
+#: src/olympia/amo/context_processors.py:66 src/olympia/discovery/templates/discovery/pane_account.html:13 src/olympia/templates/impala/user_login.html:14
 #: src/olympia/templates/mobile/header_auth.html:5
 msgid "Log out"
 msgstr ""
 
-#: src/olympia/amo/context_processors.py:72 src/olympia/devhub/templates/devhub/addons/dashboard.html:4
+#: src/olympia/amo/context_processors.py:71 src/olympia/devhub/templates/devhub/addons/dashboard.html:4
 msgid "Manage My Submissions"
 msgstr ""
 
-#: src/olympia/amo/context_processors.py:75 src/olympia/devhub/templates/devhub/nav.html:27 src/olympia/devhub/templates/devhub/addons/dashboard.html:25
+#: src/olympia/amo/context_processors.py:74 src/olympia/devhub/templates/devhub/nav.html:27 src/olympia/devhub/templates/devhub/addons/dashboard.html:25
 #: src/olympia/devhub/templates/devhub/addons/submit/base.html:4
 msgid "Submit a New Add-on"
 msgstr ""
 
-#: src/olympia/amo/context_processors.py:77 src/olympia/browse/templates/browse/personas/base.html:50 src/olympia/devhub/templates/devhub/index.html:24
+#: src/olympia/amo/context_processors.py:76 src/olympia/browse/templates/browse/personas/base.html:50 src/olympia/devhub/templates/devhub/index.html:24
 #: src/olympia/devhub/templates/devhub/addons/dashboard.html:29
 msgid "Submit a New Theme"
 msgstr ""
 
-#: src/olympia/amo/context_processors.py:79 src/olympia/amo/templates/amo/site_nav.html:87 src/olympia/devhub/helpers.py:36 src/olympia/devhub/helpers.py:68 src/olympia/devhub/helpers.py:102
+#: src/olympia/amo/context_processors.py:78 src/olympia/amo/templates/amo/site_nav.html:85 src/olympia/devhub/helpers.py:36 src/olympia/devhub/helpers.py:68 src/olympia/devhub/helpers.py:102
 #: src/olympia/templates/footer.html:6 src/olympia/templates/menu_links.html:14
 msgid "Developer Hub"
 msgstr ""
 
-#: src/olympia/amo/context_processors.py:83 src/olympia/devhub/views.py:1792
+#: src/olympia/amo/context_processors.py:81 src/olympia/devhub/views.py:1796
 msgid "Manage API Keys"
 msgstr ""
 
-#: src/olympia/amo/context_processors.py:88 src/olympia/editors/helpers.py:82 src/olympia/editors/helpers.py:102 src/olympia/editors/templates/editors/base.html:10
+#: src/olympia/amo/context_processors.py:86 src/olympia/editors/helpers.py:84 src/olympia/editors/helpers.py:104 src/olympia/editors/templates/editors/base.html:10
 msgid "Editor Tools"
 msgstr ""
 
-#: src/olympia/amo/context_processors.py:92
+#: src/olympia/amo/context_processors.py:90
 msgid "Admin Tools"
 msgstr ""
 
-#: src/olympia/amo/fields.py:15
+#: src/olympia/amo/fields.py:20
 msgid "Incorrect, please try again."
 msgstr ""
 
-#: src/olympia/amo/fields.py:16
+#: src/olympia/amo/fields.py:21
 msgid "Error verifying input, please try again."
 msgstr ""
 
-#: src/olympia/amo/fields.py:32
+#: src/olympia/amo/fields.py:37
 msgid "This must be a valid hex color code, such as #000000."
 msgstr ""
 
-#: src/olympia/amo/fields.py:58
+#: src/olympia/amo/fields.py:63
 msgid "Enter at least one value."
 msgstr ""
 
-#: src/olympia/amo/helpers.py:162 src/olympia/amo/templates/amo/site_nav.html:61 src/olympia/bandwagon/templates/bandwagon/add.html:9
+#: src/olympia/amo/helpers.py:162 src/olympia/amo/templates/amo/site_nav.html:59 src/olympia/bandwagon/templates/bandwagon/add.html:9
 #: src/olympia/bandwagon/templates/bandwagon/collection_detail.html:15 src/olympia/bandwagon/templates/bandwagon/delete.html:9 src/olympia/bandwagon/templates/bandwagon/edit.html:15
 #: src/olympia/bandwagon/templates/bandwagon/user_listing.html:18 src/olympia/bandwagon/templates/bandwagon/user_listing.html:21
 #: src/olympia/bandwagon/templates/bandwagon/impala/collection_listing.html:12 src/olympia/bandwagon/templates/bandwagon/impala/collection_listing.html:20
 #: src/olympia/bandwagon/templates/bandwagon/impala/collection_listing.html:24 src/olympia/bandwagon/templates/bandwagon/impala/collection_sidebar.html:3
 #: src/olympia/bandwagon/templates/bandwagon/includes/collection_sidebar.html:2 src/olympia/bandwagon/templates/bandwagon/mobile/collection_listing.html:3
-#: src/olympia/stats/templates/stats/stats.html:77 src/olympia/templates/menu_links.html:12
+#: src/olympia/stats/templates/stats/stats.html:33 src/olympia/templates/menu_links.html:12
 msgid "Collections"
 msgstr ""
 
-#: src/olympia/amo/helpers.py:171 src/olympia/amo/templates/amo/site_nav.html:85 src/olympia/browse/templates/browse/language_tools.html:3
+#: src/olympia/amo/helpers.py:171 src/olympia/amo/templates/amo/site_nav.html:83 src/olympia/browse/templates/browse/language_tools.html:3
 msgid "Dictionaries & Language Packs"
 msgstr ""
 
@@ -1575,8 +1576,8 @@ msgstr ""
 msgid "Comment on {addon} {version}."
 msgstr ""
 
-#: src/olympia/amo/log.py:236 src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:19 src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:47
-#: src/olympia/editors/helpers.py:511 src/olympia/editors/templates/editors/themes/history_table.html:11
+#: src/olympia/amo/log.py:236 src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:17 src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:45
+#: src/olympia/editors/helpers.py:584 src/olympia/editors/templates/editors/themes/history_table.html:11
 msgid "Comment"
 msgstr ""
 
@@ -1899,7 +1900,7 @@ msgstr ""
 #: src/olympia/amo/templates/amo/mobile/paginator.html:14 src/olympia/amo/templates/amo/mobile/paginator.html:16 src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:51
 #: src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:65 src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:78
 #: src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:91 src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:104
-#: src/olympia/discovery/templates/discovery/pane.html:45 src/olympia/discovery/templates/discovery/addons/detail.html:39 src/olympia/stats/templates/stats/stats.html:167
+#: src/olympia/discovery/templates/discovery/pane.html:45 src/olympia/discovery/templates/discovery/addons/detail.html:39 src/olympia/stats/templates/stats/stats.html:169
 msgid "Next"
 msgstr ""
 
@@ -1931,7 +1932,7 @@ msgid ""
 msgstr ""
 
 #: src/olympia/amo/templates/amo/side_nav.html:4 src/olympia/amo/templates/amo/side_nav.html:12 src/olympia/amo/templates/amo/site_nav.html:4 src/olympia/amo/templates/amo/site_nav.html:26
-#: src/olympia/browse/views.py:56 src/olympia/browse/views.py:66 src/olympia/browse/views.py:237 src/olympia/browse/views.py:282 src/olympia/search/forms.py:86
+#: src/olympia/browse/views.py:56 src/olympia/browse/views.py:66 src/olympia/browse/views.py:204 src/olympia/browse/views.py:249 src/olympia/search/forms.py:86
 msgid "Top Rated"
 msgstr ""
 
@@ -1945,38 +1946,38 @@ msgstr ""
 msgid "Extensions"
 msgstr ""
 
-#: src/olympia/amo/templates/amo/site_nav.html:45
+#: src/olympia/amo/templates/amo/site_nav.html:44
 msgid "Want more customization? Try <b>Complete Themes</b>"
 msgstr ""
 
-#: src/olympia/amo/templates/amo/site_nav.html:56 src/olympia/bandwagon/views.py:96
+#: src/olympia/amo/templates/amo/site_nav.html:54 src/olympia/bandwagon/views.py:96
 msgid "Most Followers"
 msgstr ""
 
-#: src/olympia/amo/templates/amo/site_nav.html:68 src/olympia/bandwagon/templates/bandwagon/impala/collection_sidebar.html:16
+#: src/olympia/amo/templates/amo/site_nav.html:66 src/olympia/bandwagon/templates/bandwagon/impala/collection_sidebar.html:16
 #: src/olympia/bandwagon/templates/bandwagon/includes/collection_sidebar.html:18
 msgid "Collections I've Made"
 msgstr ""
 
-#: src/olympia/amo/templates/amo/site_nav.html:70 src/olympia/bandwagon/templates/bandwagon/user_listing.html:4 src/olympia/bandwagon/templates/bandwagon/impala/collection_sidebar.html:13
+#: src/olympia/amo/templates/amo/site_nav.html:68 src/olympia/bandwagon/templates/bandwagon/user_listing.html:4 src/olympia/bandwagon/templates/bandwagon/impala/collection_sidebar.html:13
 #: src/olympia/bandwagon/templates/bandwagon/includes/collection_sidebar.html:15
 msgid "Collections I'm Following"
 msgstr ""
 
-#: src/olympia/amo/templates/amo/site_nav.html:73 src/olympia/bandwagon/templates/bandwagon/impala/collection_sidebar.html:18
-#: src/olympia/bandwagon/templates/bandwagon/includes/collection_sidebar.html:20 src/olympia/users/models.py:512
+#: src/olympia/amo/templates/amo/site_nav.html:71 src/olympia/bandwagon/templates/bandwagon/impala/collection_sidebar.html:18
+#: src/olympia/bandwagon/templates/bandwagon/includes/collection_sidebar.html:20 src/olympia/users/models.py:521
 msgid "My Favorite Add-ons"
 msgstr ""
 
-#: src/olympia/amo/templates/amo/site_nav.html:78
+#: src/olympia/amo/templates/amo/site_nav.html:76
 msgid "More&hellip;"
 msgstr ""
 
-#: src/olympia/amo/templates/amo/site_nav.html:82
+#: src/olympia/amo/templates/amo/site_nav.html:80
 msgid "Add-ons for Mobile"
 msgstr ""
 
-#: src/olympia/amo/templates/amo/site_nav.html:86 src/olympia/browse/feeds.py:207 src/olympia/browse/templates/browse/search_tools.html:3 src/olympia/constants/base.py:176
+#: src/olympia/amo/templates/amo/site_nav.html:84 src/olympia/browse/feeds.py:207 src/olympia/browse/templates/browse/search_tools.html:3 src/olympia/constants/base.py:176
 #: src/olympia/templates/menu_links.html:10
 msgid "Search Tools"
 msgstr ""
@@ -1992,7 +1993,7 @@ msgid "Jump to first page"
 msgstr ""
 
 #: src/olympia/amo/templates/amo/impala/paginator.html:22 src/olympia/amo/templates/amo/mobile/impala_paginator.html:12 src/olympia/discovery/templates/discovery/pane.html:44
-#: src/olympia/discovery/templates/discovery/addons/detail.html:38 src/olympia/stats/templates/stats/stats.html:164
+#: src/olympia/discovery/templates/discovery/addons/detail.html:38 src/olympia/stats/templates/stats/stats.html:166
 msgid "Previous"
 msgstr ""
 
@@ -2015,30 +2016,49 @@ msgid_plural "Page {n}"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/olympia/amo/templates/services/install.html:38
-#, python-format
-msgid "If you are not prompted to install %(addon_name)s in a moment, please <a href=\"%(addon_xpi)s\">click here</a>."
-msgstr ""
-
-#: src/olympia/amo/tests/test_messages.py:57 src/olympia/amo/tests/test_messages.py:58 src/olympia/reviews/forms.py:25 src/olympia/reviews/forms.py:50 src/olympia/reviews/templates/reviews/add.html:56
+#: src/olympia/amo/tests/test_messages.py:56 src/olympia/amo/tests/test_messages.py:57 src/olympia/reviews/forms.py:25 src/olympia/reviews/forms.py:50 src/olympia/reviews/templates/reviews/add.html:56
 #: src/olympia/reviews/templates/reviews/reply.html:30
 msgid "Title"
 msgstr ""
 
-#: src/olympia/amo/tests/test_messages.py:57 src/olympia/amo/tests/test_messages.py:58
+#: src/olympia/amo/tests/test_messages.py:56 src/olympia/amo/tests/test_messages.py:57
 msgid "Body"
 msgstr ""
 
-#: src/olympia/amo/tests/test_messages.py:59
+#: src/olympia/amo/tests/test_messages.py:58
 msgid "Another Title"
 msgstr ""
 
-#: src/olympia/amo/tests/test_messages.py:59
+#: src/olympia/amo/tests/test_messages.py:58
 msgid "Another Body"
 msgstr ""
 
-#: src/olympia/api/views.py:255
-msgid "Not implemented yet."
+#: src/olympia/api/authentication.py:76
+msgid "Signature has expired."
+msgstr ""
+
+#: src/olympia/api/authentication.py:79
+msgid "Error decoding signature."
+msgstr ""
+
+#: src/olympia/api/authentication.py:82
+msgid "Invalid JWT Token."
+msgstr ""
+
+#: src/olympia/api/authentication.py:130
+msgid "Invalid Authorization header. No credentials provided."
+msgstr ""
+
+#: src/olympia/api/authentication.py:133
+msgid "Invalid Authorization header. Credentials string should not contain spaces."
+msgstr ""
+
+#: src/olympia/api/fields.py:29
+msgid "The field must have a length of at least {num} characters."
+msgstr ""
+
+#: src/olympia/api/fields.py:31
+msgid "The language code {lang_code} is invalid."
 msgstr ""
 
 #: src/olympia/applications/views.py:39 src/olympia/applications/templates/applications/appversions.html:3
@@ -2057,7 +2077,7 @@ msgstr ""
 msgid "Add-ons submitted to Mozilla Add-ons must have a manifest file with at least one of the below applications supported. Only the versions listed below are allowed for these applications."
 msgstr ""
 
-#: src/olympia/applications/templates/applications/appversions.html:25
+#: src/olympia/applications/templates/applications/appversions.html:25 src/olympia/editors/helpers.py:361
 msgid "GUID"
 msgstr ""
 
@@ -2171,8 +2191,8 @@ msgstr ""
 msgid "Remove from favorites"
 msgstr ""
 
-#: src/olympia/bandwagon/views.py:98 src/olympia/bandwagon/views.py:191 src/olympia/browse/views.py:58 src/olympia/browse/views.py:69 src/olympia/browse/views.py:458 src/olympia/devhub/views.py:74
-#: src/olympia/devhub/views.py:82 src/olympia/devhub/templates/devhub/addons/edit/basic.html:20 src/olympia/editors/templates/editors/leaderboard.html:24
+#: src/olympia/bandwagon/views.py:98 src/olympia/bandwagon/views.py:191 src/olympia/browse/views.py:58 src/olympia/browse/views.py:69 src/olympia/browse/views.py:425 src/olympia/devhub/views.py:72
+#: src/olympia/devhub/views.py:80 src/olympia/devhub/templates/devhub/addons/edit/basic.html:20 src/olympia/editors/templates/editors/leaderboard.html:24
 #: src/olympia/editors/templates/editors/themes/queue_list.html:48 src/olympia/search/forms.py:17 src/olympia/search/forms.py:89 src/olympia/users/templates/users/vcard.html:5
 msgid "Name"
 msgstr ""
@@ -2181,7 +2201,7 @@ msgstr ""
 msgid "Recently Popular"
 msgstr ""
 
-#: src/olympia/bandwagon/views.py:189 src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:18
+#: src/olympia/bandwagon/views.py:189 src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:16
 msgid "Added"
 msgstr ""
 
@@ -2195,7 +2215,7 @@ msgstr ""
 
 #: src/olympia/bandwagon/views.py:316
 #, python-format
-msgid "Your new collection is shown below. You can <ahref=\"%(url)s\">edit additional settings</a> if you'dlike."
+msgid "Your new collection is shown below. You can <a href=\"%(url)s\">edit additional settings</a> if you'd like."
 msgstr ""
 
 #: src/olympia/bandwagon/views.py:322
@@ -2323,8 +2343,8 @@ msgid_plural "%(num)s Add-ons in this Collection"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/olympia/bandwagon/templates/bandwagon/collection_detail.html:125 src/olympia/compat/templates/compat/index.html:25 src/olympia/compat/templates/compat/reporter_detail.html:29
-#: src/olympia/files/templates/files/viewer.html:29 src/olympia/templates/amo_footer.html:17 src/olympia/templates/includes/lang_switcher.html:10
+#: src/olympia/bandwagon/templates/bandwagon/collection_detail.html:125 src/olympia/compat/templates/compat/reporter_detail.html:29 src/olympia/files/templates/files/viewer.html:29
+#: src/olympia/templates/amo_footer.html:17 src/olympia/templates/includes/lang_switcher.html:10
 msgid "Go"
 msgstr ""
 
@@ -2491,7 +2511,7 @@ msgid "Remove this user as a contributor"
 msgstr ""
 
 #: src/olympia/bandwagon/templates/bandwagon/edit_contributors.html:18 src/olympia/bandwagon/templates/bandwagon/edit_contributors.html:43
-#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:20 src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:48
+#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:18 src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:46
 #: src/olympia/devhub/templates/devhub/addons/ajax_compat_update.html:19
 msgid "Remove"
 msgstr ""
@@ -2539,7 +2559,7 @@ msgid "<b>Warning:</b> By changing the owner of this collection, you will no lon
 msgstr ""
 
 #: src/olympia/bandwagon/templates/bandwagon/edit_contributors.html:83 src/olympia/devhub/templates/devhub/addons/forms_shared/media.html:157
-#: src/olympia/devhub/templates/devhub/addons/submit/describe.html:69 src/olympia/devhub/templates/devhub/addons/submit/license.html:60 src/olympia/devhub/templates/devhub/addons/submit/upload.html:78
+#: src/olympia/devhub/templates/devhub/addons/submit/describe.html:69 src/olympia/devhub/templates/devhub/addons/submit/license.html:60 src/olympia/devhub/templates/devhub/addons/submit/upload.html:70
 #: src/olympia/devhub/templates/devhub/payments/tier.html:17 src/olympia/editors/templates/editors/themes/themes.html:111 src/olympia/editors/templates/editors/themes/themes.html:128
 #: src/olympia/editors/templates/editors/themes/themes.html:134 src/olympia/editors/templates/editors/themes/themes.html:141 src/olympia/users/templates/users/fxa_migration_prompt_content.html:10
 #: src/olympia/users/templates/users/login_form.html:42 src/olympia/users/templates/users/mobile/login.html:57
@@ -2622,31 +2642,31 @@ msgid "Add-ons in Your Collection"
 msgstr ""
 
 #: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:4
-msgid ""
-"To include an add-on in this collection, enter its name in the box below and hit enter.  You can also use the <strong>Add to Collection</strong> links throughout the site to include add-ons later."
+msgid "To include an add-on in this collection, enter its name in the box below and hit enter."
 msgstr ""
 
-#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:17 src/olympia/constants/base.py:400 src/olympia/devhub/templates/devhub/addons/activity.html:62
+#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:15 src/olympia/constants/base.py:400 src/olympia/devhub/templates/devhub/addons/activity.html:62
+#: src/olympia/editors/helpers.py:273 src/olympia/editors/helpers.py:360
 msgid "Add-on"
 msgstr ""
 
-#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:26
+#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:24
 msgid "Enter the name of the add-on to include"
 msgstr ""
 
-#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:28
+#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:26
 msgid "Add to Collection"
 msgstr ""
 
-#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:45 src/olympia/editors/helpers.py:936 src/olympia/editors/helpers.py:956
+#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:43 src/olympia/editors/helpers.py:1016 src/olympia/editors/helpers.py:1036
 msgid "Pending"
 msgstr ""
 
-#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:47
+#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:45
 msgid "Add a comment"
 msgstr ""
 
-#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:48
+#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:46
 msgid "Remove this add-on from the collection"
 msgstr ""
 
@@ -2753,12 +2773,12 @@ msgstr ""
 msgid "Most Users"
 msgstr ""
 
-#: src/olympia/browse/views.py:61 src/olympia/browse/views.py:72 src/olympia/browse/views.py:279 src/olympia/browse/templates/browse/personas/mobile/category_landing.html:63
+#: src/olympia/browse/views.py:61 src/olympia/browse/views.py:72 src/olympia/browse/views.py:246 src/olympia/browse/templates/browse/personas/mobile/category_landing.html:63
 #: src/olympia/discovery/templates/discovery/pane.html:67 src/olympia/search/forms.py:92
 msgid "Up & Coming"
 msgstr ""
 
-#: src/olympia/browse/views.py:460 src/olympia/devhub/views.py:76 src/olympia/devhub/views.py:83 src/olympia/discovery/templates/discovery/addons/detail.html:66
+#: src/olympia/browse/views.py:427 src/olympia/devhub/views.py:74 src/olympia/devhub/views.py:81 src/olympia/discovery/templates/discovery/addons/detail.html:66
 msgid "Created"
 msgstr ""
 
@@ -2946,8 +2966,8 @@ msgid_plural "See all %(cnt)s extensions in %(name)s &raquo;"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/olympia/browse/templates/browse/mobile/extensions.html:13 src/olympia/compat/templates/compat/index.html:82 src/olympia/devhub/templates/devhub/devhub_search.html:24
-#: src/olympia/devhub/templates/devhub/addons/activity.html:47 src/olympia/search/templates/search/no_results.html:4 src/olympia/search/templates/search/mobile/results.html:36
+#: src/olympia/browse/templates/browse/mobile/extensions.html:13 src/olympia/devhub/templates/devhub/devhub_search.html:24 src/olympia/devhub/templates/devhub/addons/activity.html:47
+#: src/olympia/search/templates/search/no_results.html:4 src/olympia/search/templates/search/mobile/results.html:36
 msgid "No results found."
 msgstr ""
 
@@ -3032,7 +3052,7 @@ msgstr ""
 msgid "All"
 msgstr ""
 
-#: src/olympia/compat/forms.py:22 src/olympia/search/views.py:525
+#: src/olympia/compat/forms.py:22 src/olympia/editors/templates/editors/base.html:69 src/olympia/search/views.py:518
 msgid "All Add-ons"
 msgstr ""
 
@@ -3042,53 +3062,6 @@ msgstr ""
 
 #: src/olympia/compat/forms.py:24
 msgid "Non-binary"
-msgstr ""
-
-#. Review points sources other than add-ons and themes.
-#: src/olympia/compat/views.py:87 src/olympia/constants/base.py:388 src/olympia/devhub/forms.py:162 src/olympia/editors/templates/editors/performance.html:75
-msgid "Other"
-msgstr ""
-
-#: src/olympia/compat/templates/compat/index.html:4
-msgid "Add-on Compatibility Report for {app} {version}"
-msgstr ""
-
-#: src/olympia/compat/templates/compat/index.html:11
-msgid "{app} {version} Compatibility"
-msgstr ""
-
-#: src/olympia/compat/templates/compat/index.html:17
-#, python-format
-msgid "Top 95%% compatible with previous version"
-msgstr ""
-
-#: src/olympia/compat/templates/compat/index.html:18
-#, python-format
-msgid "Top 95%% of all add-ons"
-msgstr ""
-
-#: src/olympia/compat/templates/compat/index.html:19
-msgid "All active add-ons"
-msgstr ""
-
-#: src/olympia/compat/templates/compat/index.html:23 src/olympia/constants/base.py:401
-msgid "App"
-msgstr ""
-
-#: src/olympia/compat/templates/compat/index.html:55
-msgid "Details for add-ons compatible with previous version:"
-msgstr ""
-
-#: src/olympia/compat/templates/compat/index.html:57
-msgid "Show all versions"
-msgstr ""
-
-#: src/olympia/compat/templates/compat/index.html:59
-msgid "Details for add-ons compatible with all versions:"
-msgstr ""
-
-#: src/olympia/compat/templates/compat/index.html:61
-msgid "Show previous version only"
 msgstr ""
 
 #: src/olympia/compat/templates/compat/reporter.html:3
@@ -3142,8 +3115,8 @@ msgstr ""
 msgid "Report Type"
 msgstr ""
 
-#: src/olympia/compat/templates/compat/reporter_detail.html:47 src/olympia/devhub/forms.py:784 src/olympia/devhub/templates/devhub/addons/ajax_compat_update.html:17 src/olympia/editors/forms.py:108
-#: src/olympia/zadmin/forms.py:45
+#: src/olympia/compat/templates/compat/reporter_detail.html:47 src/olympia/devhub/forms.py:785 src/olympia/devhub/templates/devhub/addons/ajax_compat_update.html:17 src/olympia/editors/forms.py:108
+#: src/olympia/editors/forms.py:248 src/olympia/zadmin/forms.py:45
 msgid "Application"
 msgstr ""
 
@@ -3231,7 +3204,8 @@ msgstr ""
 msgid "Preliminarily Reviewed and Awaiting Full Review"
 msgstr ""
 
-#: src/olympia/constants/base.py:33 src/olympia/editors/helpers.py:924 src/olympia/editors/templates/editors/themes/history_table.html:34
+#: src/olympia/constants/base.py:33 src/olympia/editors/forms.py:258 src/olympia/editors/helpers.py:73 src/olympia/editors/helpers.py:1004
+#: src/olympia/editors/templates/editors/themes/history_table.html:34
 msgid "Deleted"
 msgstr ""
 
@@ -3328,6 +3302,11 @@ msgstr ""
 msgid "Ask before users can download this add-on"
 msgstr ""
 
+#. Review points sources other than add-ons and themes.
+#: src/olympia/constants/base.py:388 src/olympia/devhub/forms.py:162 src/olympia/editors/templates/editors/performance.html:75
+msgid "Other"
+msgstr ""
+
 #: src/olympia/constants/base.py:389
 msgid "Exception"
 msgstr ""
@@ -3338,6 +3317,10 @@ msgstr ""
 
 #: src/olympia/constants/base.py:391
 msgid "Change"
+msgstr ""
+
+#: src/olympia/constants/base.py:401
+msgid "App"
 msgstr ""
 
 #: src/olympia/constants/base.py:402
@@ -3488,7 +3471,7 @@ msgstr ""
 msgid "Duplicate"
 msgstr ""
 
-#: src/olympia/constants/editors.py:17 src/olympia/editors/helpers.py:502 src/olympia/editors/templates/editors/themes/queue.html:71 src/olympia/editors/templates/editors/themes/themes.html:94
+#: src/olympia/constants/editors.py:17 src/olympia/editors/helpers.py:575 src/olympia/editors/templates/editors/themes/queue.html:71 src/olympia/editors/templates/editors/themes/themes.html:94
 msgid "Reject"
 msgstr ""
 
@@ -3588,7 +3571,7 @@ msgstr ""
 msgid "Android"
 msgstr ""
 
-#: src/olympia/core/apps.py:19
+#: src/olympia/core/apps.py:21
 msgid "Core"
 msgstr ""
 
@@ -3722,7 +3705,7 @@ msgid "Submit my add-on for manual review."
 msgstr ""
 
 #: src/olympia/devhub/forms.py:537
-msgid "Do not list my add-on on this site (beta)"
+msgid "Do not list my add-on on this site"
 msgstr ""
 
 #: src/olympia/devhub/forms.py:538
@@ -3755,46 +3738,46 @@ msgstr ""
 
 #: src/olympia/devhub/forms.py:592
 #, python-format
-msgid "Version %s already exists"
+msgid "Version %s already exists, or was uploaded before."
 msgstr ""
 
-#: src/olympia/devhub/forms.py:604
+#: src/olympia/devhub/forms.py:605
 msgid "Select a valid choice. That choice is not one of the available choices."
 msgstr ""
 
-#: src/olympia/devhub/forms.py:610
+#: src/olympia/devhub/forms.py:611
 msgid "A file with a version ending with a|alpha|b|beta and an optional number is detected as beta."
 msgstr ""
 
-#: src/olympia/devhub/forms.py:633
+#: src/olympia/devhub/forms.py:634
 msgid "You cannot upload any more files for this version."
 msgstr ""
 
-#: src/olympia/devhub/forms.py:639
+#: src/olympia/devhub/forms.py:640
 msgid "Version doesn't match"
 msgstr ""
 
-#: src/olympia/devhub/forms.py:668
+#: src/olympia/devhub/forms.py:669
 msgid "You cannot delete a file once the review process has started.  You must delete the whole version."
 msgstr ""
 
-#: src/olympia/devhub/forms.py:688
+#: src/olympia/devhub/forms.py:689
 msgid "The platform All cannot be combined with specific platforms."
 msgstr ""
 
-#: src/olympia/devhub/forms.py:693
+#: src/olympia/devhub/forms.py:694
 msgid "A platform can only be chosen once."
 msgstr ""
 
-#: src/olympia/devhub/forms.py:706
+#: src/olympia/devhub/forms.py:707
 msgid "A review type must be selected."
 msgstr ""
 
-#: src/olympia/devhub/forms.py:788 src/olympia/editors/forms.py:114 src/olympia/zadmin/forms.py:49 src/olympia/zadmin/forms.py:52
+#: src/olympia/devhub/forms.py:789 src/olympia/editors/forms.py:114 src/olympia/editors/forms.py:254 src/olympia/zadmin/forms.py:49 src/olympia/zadmin/forms.py:52
 msgid "Select an application first"
 msgstr ""
 
-#: src/olympia/devhub/forms.py:840
+#: src/olympia/devhub/forms.py:841
 msgid "There cannot be more than 3 required add-ons."
 msgstr ""
 
@@ -3828,76 +3811,76 @@ msgstr[1] ""
 msgid "Review"
 msgstr ""
 
-#: src/olympia/devhub/tasks.py:551
+#: src/olympia/devhub/tasks.py:583
 #, python-format
 msgid "%s responded with %s (%s)."
 msgstr ""
 
-#: src/olympia/devhub/tasks.py:555
+#: src/olympia/devhub/tasks.py:587
 #, python-format
 msgid "Connection to \"%s\" timed out."
 msgstr ""
 
-#: src/olympia/devhub/tasks.py:557
+#: src/olympia/devhub/tasks.py:589
 #, python-format
 msgid "Could not contact host at \"%s\"."
 msgstr ""
 
-#: src/olympia/devhub/utils.py:104
+#: src/olympia/devhub/utils.py:105
 #, python-format
 msgid "Validation generated too many errors/warnings so %s messages were truncated. After addressing the visible messages, you'll be able to see the others."
 msgstr ""
 
-#: src/olympia/devhub/views.py:183
+#: src/olympia/devhub/views.py:181
 msgid "All My Add-ons"
 msgstr ""
 
-#: src/olympia/devhub/views.py:210
+#: src/olympia/devhub/views.py:208
 msgid "All Activity"
 msgstr ""
 
-#: src/olympia/devhub/views.py:211
+#: src/olympia/devhub/views.py:209
 msgid "Add-on Updates"
 msgstr ""
 
-#: src/olympia/devhub/views.py:212
+#: src/olympia/devhub/views.py:210
 msgid "Add-on Status"
 msgstr ""
 
-#: src/olympia/devhub/views.py:213
+#: src/olympia/devhub/views.py:211
 msgid "User Collections"
 msgstr ""
 
-#: src/olympia/devhub/views.py:214 src/olympia/devhub/templates/devhub/docs/policies-maintenance.html:68 src/olympia/pages/templates/pages/dev_faq.html:38
+#: src/olympia/devhub/views.py:212 src/olympia/devhub/templates/devhub/docs/policies-maintenance.html:68 src/olympia/pages/templates/pages/dev_faq.html:38
 #: src/olympia/pages/templates/pages/dev_faq.html:484
 msgid "User Reviews"
 msgstr ""
 
-#: src/olympia/devhub/views.py:327 src/olympia/devhub/views.py:331 src/olympia/devhub/views.py:484 src/olympia/devhub/views.py:513 src/olympia/devhub/views.py:564 src/olympia/devhub/views.py:1150
+#: src/olympia/devhub/views.py:325 src/olympia/devhub/views.py:329 src/olympia/devhub/views.py:484 src/olympia/devhub/views.py:513 src/olympia/devhub/views.py:564 src/olympia/devhub/views.py:1156
 msgid "Changes successfully saved."
 msgstr ""
 
-#: src/olympia/devhub/views.py:334 src/olympia/devhub/views.py:1631
+#: src/olympia/devhub/views.py:332 src/olympia/devhub/views.py:1637
 msgid "Please check the form for errors."
 msgstr ""
 
-#: src/olympia/devhub/views.py:346
+#: src/olympia/devhub/views.py:344
 msgid "Add-on cannot be deleted. Disable this add-on instead."
 msgstr ""
 
-#: src/olympia/devhub/views.py:356
+#: src/olympia/devhub/views.py:354
 msgid "Theme deleted."
 msgstr ""
 
-#: src/olympia/devhub/views.py:356
+#: src/olympia/devhub/views.py:354
 msgid "Add-on deleted."
 msgstr ""
 
-#: src/olympia/devhub/views.py:362
+#: src/olympia/devhub/views.py:360
 msgid "URL name was incorrect. Theme was not deleted."
 msgstr ""
 
-#: src/olympia/devhub/views.py:367
+#: src/olympia/devhub/views.py:365
 msgid "URL name was incorrect. Add-on was not deleted."
 msgstr ""
 
@@ -3925,7 +3908,7 @@ msgstr ""
 msgid "Check Add-on Compatibility"
 msgstr ""
 
-#: src/olympia/devhub/views.py:808 src/olympia/signing/views.py:90
+#: src/olympia/devhub/views.py:808 src/olympia/signing/views.py:95
 msgid "You cannot submit this type of add-on"
 msgstr ""
 
@@ -3955,33 +3938,33 @@ msgstr ""
 msgid "There was an error uploading your preview."
 msgstr ""
 
-#: src/olympia/devhub/views.py:1189
+#: src/olympia/devhub/views.py:1195
 #, python-format
 msgid "Version %s disabled."
 msgstr ""
 
-#: src/olympia/devhub/views.py:1193
+#: src/olympia/devhub/views.py:1199
 #, python-format
 msgid "Version %s deleted."
 msgstr ""
 
-#: src/olympia/devhub/views.py:1203
+#: src/olympia/devhub/views.py:1209
 msgid "This upload has failed validation, and may lack complete validation results. Please take due care when reviewing it."
 msgstr ""
 
-#: src/olympia/devhub/views.py:1677
+#: src/olympia/devhub/views.py:1683
 msgid "Preliminary Review Requested."
 msgstr ""
 
-#: src/olympia/devhub/views.py:1678
+#: src/olympia/devhub/views.py:1684
 msgid "Full Review Requested."
 msgstr ""
 
-#: src/olympia/devhub/views.py:1779
+#: src/olympia/devhub/views.py:1783
 msgid "Your old credentials were revoked and are no longer valid. Be sure to update all API clients with the new credentials."
 msgstr ""
 
-#: src/olympia/devhub/views.py:1797
+#: src/olympia/devhub/views.py:1801
 msgid "New API key created"
 msgstr ""
 
@@ -4011,7 +3994,7 @@ msgstr ""
 msgid "{0} :: Search"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/devhub_search.html:6 src/olympia/devhub/templates/devhub/search.html:8 src/olympia/editors/forms.py:435 src/olympia/editors/forms.py:437
+#: src/olympia/devhub/templates/devhub/devhub_search.html:6 src/olympia/devhub/templates/devhub/search.html:8 src/olympia/editors/forms.py:534 src/olympia/editors/forms.py:536
 #: src/olympia/editors/templates/editors/queue.html:27 src/olympia/editors/templates/editors/themes/queue_list.html:14 src/olympia/search/templates/search/collections.html:17
 #: src/olympia/search/templates/search/personas.html:18 src/olympia/search/templates/search/results.html:18 src/olympia/search/templates/search/mobile/results.html:8
 #: src/olympia/templates/search.html:14 src/olympia/templates/impala/search.html:18
@@ -4071,12 +4054,12 @@ msgstr ""
 msgid "Start Making Add-ons"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/index.html:86 src/olympia/devhub/templates/devhub/addons/listing/items.html:25 src/olympia/devhub/templates/devhub/includes/addon_details.html:15
+#: src/olympia/devhub/templates/devhub/index.html:86 src/olympia/devhub/templates/devhub/addons/listing/items.html:25 src/olympia/devhub/templates/devhub/includes/addon_details.html:20
 #: src/olympia/devhub/templates/devhub/personas/edit.html:43
 msgid "Status:"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/index.html:90 src/olympia/devhub/templates/devhub/includes/addon_details.html:100
+#: src/olympia/devhub/templates/devhub/index.html:90 src/olympia/devhub/templates/devhub/includes/addon_details.html:87
 msgid "Visibility:"
 msgstr ""
 
@@ -4084,11 +4067,11 @@ msgstr ""
 msgid "Latest Version:"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/index.html:109 src/olympia/devhub/templates/devhub/includes/addon_details.html:145 src/olympia/devhub/templates/devhub/personas/edit.html:49
+#: src/olympia/devhub/templates/devhub/index.html:109 src/olympia/devhub/templates/devhub/includes/addon_details.html:131 src/olympia/devhub/templates/devhub/personas/edit.html:49
 msgid "Queue Position:"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/index.html:110 src/olympia/devhub/templates/devhub/includes/addon_details.html:146 src/olympia/devhub/templates/devhub/personas/edit.html:50
+#: src/olympia/devhub/templates/devhub/index.html:110 src/olympia/devhub/templates/devhub/includes/addon_details.html:132 src/olympia/devhub/templates/devhub/personas/edit.html:50
 #, python-format
 msgid "%(position)s of %(total)s"
 msgstr ""
@@ -4190,16 +4173,6 @@ msgstr ""
 msgid "Do you want your add-on to be distributed on this site?"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/validate_addon.html:49 src/olympia/devhub/templates/devhub/addons/submit/upload.html:30 src/olympia/devhub/templates/devhub/versions/add_file_modal.html:14
-#: src/olympia/devhub/templates/devhub/versions/add_file_modal.html:53 src/olympia/devhub/templates/devhub/versions/list.html:298
-msgid "Warning:"
-msgstr ""
-
-#: src/olympia/devhub/templates/devhub/validate_addon.html:50 src/olympia/devhub/templates/devhub/addons/submit/upload.html:31
-#, python-format
-msgid "Submission of unlisted add-ons for signing is currently in an open beta. Please <a href=\"%(url)s\" target=\"_blank\">report any bugs</a> that you encounter."
-msgstr ""
-
 #. first parameter is a filename like lorem-ipsum-1.0.2.xpi
 #: src/olympia/devhub/templates/devhub/validation.html:5
 msgid "Validation Results for {0}"
@@ -4274,7 +4247,7 @@ msgstr ""
 msgid "Update Compatibility"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/addons/ajax_compat_update.html:4
+#: src/olympia/devhub/templates/devhub/addons/ajax_compat_update.html:4 src/olympia/devhub/templates/devhub/versions/edit.html:45
 msgid "Adjusting application information here will allow users to install your add-on even if the install manifest in the package indicates that the add-on is incompatible."
 msgstr ""
 
@@ -4286,9 +4259,9 @@ msgstr ""
 msgid "Add Another Application&hellip;"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/addons/ajax_compat_update.html:38 src/olympia/devhub/templates/devhub/addons/owner.html:86 src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:46
-#: src/olympia/devhub/templates/devhub/versions/list.html:351 src/olympia/devhub/templates/devhub/versions/list.html:353 src/olympia/templates/impala/base.html:132
-#: src/olympia/templates/impala/base.html:143 src/olympia/templates/impala/base.html:161 src/olympia/templates/impala/base.html:171
+#: src/olympia/devhub/templates/devhub/addons/ajax_compat_update.html:38 src/olympia/devhub/templates/devhub/addons/owner.html:86 src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:45
+#: src/olympia/devhub/templates/devhub/versions/list.html:349 src/olympia/devhub/templates/devhub/versions/list.html:351 src/olympia/templates/impala/base.html:129
+#: src/olympia/templates/impala/base.html:140 src/olympia/templates/impala/base.html:158 src/olympia/templates/impala/base.html:168
 msgid "Close"
 msgstr ""
 
@@ -4322,7 +4295,7 @@ msgstr ""
 msgid "Manage Authors & License"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/addons/owner.html:29 src/olympia/editors/templates/editors/review.html:270
+#: src/olympia/devhub/templates/devhub/addons/owner.html:29 src/olympia/editors/helpers.py:362 src/olympia/editors/templates/editors/review.html:270
 msgid "Authors"
 msgstr ""
 
@@ -4391,17 +4364,11 @@ msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/basic.html:52
 msgid ""
-"A short explanation of your add-on's basic\n"
-"                          functionality that is displayed in search and browse\n"
-"                          listings, as well as at the top of your add-on's\n"
-"                          details page. It is only relevant for listed add-ons."
+"A short explanation of your add-on's basic functionality that is displayed in search and browse listings, as well as at the top of your add-on's details page. It is only relevant for listed add-ons."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/basic.html:73
-msgid ""
-"Categories are the primary way users browse through add-ons.\n"
-"                        Choose any that fit your add-on's functionality for the most\n"
-"                        exposure. It is only relevant for listed add-ons."
+msgid "Categories are the primary way users browse through add-ons. Choose any that fit your add-on's functionality for the most exposure. It is only relevant for listed add-ons."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/basic.html:90
@@ -4411,11 +4378,7 @@ msgid ""
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/basic.html:119
-msgid ""
-"Tags help users find your add-on and should be short\n"
-"                        descriptors such as tabs, toolbar, or twitter.  You\n"
-"                        may have a maximum of {0} tags. It is only relevant\n"
-"                        for listed add-ons."
+msgid "Tags help users find your add-on and should be short descriptors such as tabs, toolbar, or twitter. You may have a maximum of {0} tags. It is only relevant for listed add-ons."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/basic.html:129 src/olympia/devhub/templates/devhub/personas/edit.html:97 src/olympia/devhub/templates/devhub/personas/submit.html:46
@@ -4443,11 +4406,7 @@ msgid "Add-on Details for {0}"
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/details.html:22
-msgid ""
-"A longer explanation of features,\n"
-"                          functionality, and other relevant information. This\n"
-"                          field is only displayed on the add-on's details\n"
-"                          page. It is only relevant for listed add-ons."
+msgid "A longer explanation of features, functionality, and other relevant information. This field is only displayed on the add-on's details page. It is only relevant for listed add-ons."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/details.html:44 src/olympia/translations/templates/translations/trans-menu.html:13
@@ -4455,10 +4414,7 @@ msgid "Default Locale"
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/details.html:45
-msgid ""
-"Information about your add-on is displayed in this locale\n"
-"                        unless you override it with a locale-specific translation.\n"
-"                        It is only relevant for listed add-ons."
+msgid "Information about your add-on is displayed in this locale unless you override it with a locale-specific translation. It is only relevant for listed add-ons."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/details.html:61 src/olympia/users/forms.py:311 src/olympia/users/templates/users/edit.html:122 src/olympia/users/templates/users/register.html:57
@@ -4468,10 +4424,8 @@ msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/details.html:63
 msgid ""
-"If your add-on has another homepage, enter its\n"
-"                          address here. If your website is localized into other\n"
-"                          languages multiple translations of this field can be\n"
-"                          added. It is only relevant for listed add-ons."
+"If your add-on has another homepage, enter its address here. If your website is localized into other languages multiple translations of this field can be added. It is only relevant for listed add-"
+"ons."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/media.html:3
@@ -4489,19 +4443,14 @@ msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/support.html:22
 msgid ""
-"If you wish to display an e-mail address for support\n"
-"                          inquiries, enter it here. If you have different\n"
-"                          addresses for each language multiple translations of\n"
-"                          this field can be added. It is only relevant for\n"
-"                          listed add-ons."
+"If you wish to display an e-mail address for support inquiries, enter it here. If you have different addresses for each language multiple translations of this field can be added. It is only "
+"relevant for listed add-ons."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/support.html:45
 msgid ""
-"If your add-on has a support website or forum, enter\n"
-"                          its address here. If your website is localized into\n"
-"                          other languages, multiple translations of this field can\n"
-"                          be added. It is only relevant for listed add-ons."
+"If your add-on has a support website or forum, enter its address here. If your website is localized into other languages, multiple translations of this field can be added. It is only relevant for "
+"listed add-ons."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:6
@@ -4515,11 +4464,8 @@ msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:23
 msgid ""
-"Any information end users may want to know that isn't\n"
-"                          necessarily applicable to the add-on summary or description.\n"
-"                          Common uses include listing known major bugs, information on\n"
-"                          how to report bugs, anticipated release date of a new version,\n"
-"                          etc. It is only relevant for listed add-ons."
+"Any information end users may want to know that isn't necessarily applicable to the add-on summary or description. Common uses include listing known major bugs, information on how to report bugs, "
+"anticipated release date of a new version, etc. It is only relevant for listed add-ons."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:46
@@ -4531,9 +4477,7 @@ msgid "Add-on Flags"
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:69
-msgid ""
-"These flags are used to classify add-ons. It is only\n"
-"                        relevant for listed add-ons."
+msgid "These flags are used to classify add-ons. It is only relevant for listed add-ons."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:74
@@ -4549,9 +4493,7 @@ msgid "View Source?"
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:90
-msgid ""
-"Whether the source of your add-on can be displayed in our\n"
-"                        online viewer. It is only relevant for listed add-ons."
+msgid "Whether the source of your add-on can be displayed in our online viewer. It is only relevant for listed add-ons."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:94
@@ -4567,10 +4509,7 @@ msgid "Public Stats?"
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:102
-msgid ""
-"Whether the download and usage stats of your add-on can\n"
-"                        be displayed in our online viewer.\n"
-"                        It is only relevant for listed add-ons."
+msgid "Whether the download and usage stats of your add-on can be displayed in our online viewer. It is only relevant for listed add-ons."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:107
@@ -4586,10 +4525,7 @@ msgid "Upgrade SDK?"
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:116
-msgid ""
-"If selected, we will try to automatically upgrade your\n"
-"                        add-on when a new version of the SDK is released.\n"
-"                        It is only relevant for listed add-ons."
+msgid "If selected, we will try to automatically upgrade your add-on when a new version of the SDK is released. It is only relevant for listed add-ons."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:121
@@ -4640,10 +4576,8 @@ msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/forms_shared/media.html:16
 msgid ""
-"Upload an icon for your add-on or choose from one of ours. The\n"
-"                      icon is displayed nearly everywhere your add-on is. Uploaded images\n"
-"                      must be one of the following image types: .png, .jpg.\n"
-"                      It is only relevant for listed add-ons."
+"Upload an icon for your add-on or choose from one of ours. The icon is displayed nearly everywhere your add-on is. Uploaded images must be one of the following image types: .png, .jpg. It is only "
+"relevant for listed add-ons."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/forms_shared/media.html:25
@@ -4656,9 +4590,7 @@ msgid "32x32px"
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/forms_shared/media.html:39
-msgid ""
-"Used in listings of add-ons, like search results\n"
-"                            and featured add-ons."
+msgid "Used in listings of add-ons, like search results and featured add-ons."
 msgstr ""
 
 #. The size of the icon
@@ -4753,16 +4685,14 @@ msgid "Deleting your add-on will permanently remove it from the site and prevent
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:24
-msgid ""
-"Enter the following text confirm your decision:\n"
-"           {slug}"
+msgid "Enter the following text confirm your decision: {slug}"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:34
+#: src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:33
 msgid "Please tell us why you are deleting your theme:"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:36
+#: src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:35
 msgid "Please tell us why you are deleting your add-on:"
 msgstr ""
 
@@ -4799,8 +4729,8 @@ msgstr ""
 msgid "Daily statistics on downloads and users."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/addons/listing/item_actions.html:45 src/olympia/stats/templates/stats/stats.html:75 src/olympia/stats/templates/stats/stats.html:79
-#: src/olympia/stats/templates/stats/stats.html:81
+#: src/olympia/devhub/templates/devhub/addons/listing/item_actions.html:45 src/olympia/stats/templates/stats/stats.html:31 src/olympia/stats/templates/stats/stats.html:35
+#: src/olympia/stats/templates/stats/stats.html:37
 msgid "Statistics"
 msgstr ""
 
@@ -4919,10 +4849,7 @@ msgid "Your add-on has been submitted to the Full Review queue."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/submit/done.html:18
-msgid ""
-"You'll receive an email once it has been reviewed by an editor. In\n"
-"          the meantime, you and your friends can install it directly from its\n"
-"          details page:"
+msgid "You'll receive an email once it has been reviewed by an editor. In the meantime, you and your friends can install it directly from its details page:"
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/submit/done.html:27 src/olympia/devhub/templates/devhub/addons/submit/done.html:77 src/olympia/devhub/templates/devhub/personas/submit_done.html:16
@@ -5128,11 +5055,11 @@ msgstr ""
 msgid "Use the fields below to upload your add-on package and select any platform restrictions. After upload, a series of automated validation tests will be run on your file."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/addons/submit/upload.html:59 src/olympia/devhub/templates/devhub/versions/add_file_modal.html:39
+#: src/olympia/devhub/templates/devhub/addons/submit/upload.html:51 src/olympia/devhub/templates/devhub/versions/add_file_modal.html:28
 msgid "Which platforms is this file compatible with?"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/addons/submit/upload.html:67 src/olympia/devhub/templates/devhub/versions/add_file_modal.html:65
+#: src/olympia/devhub/templates/devhub/addons/submit/upload.html:59 src/olympia/devhub/templates/devhub/versions/add_file_modal.html:45
 msgid "Administrative overrides"
 msgstr ""
 
@@ -5242,8 +5169,8 @@ msgstr ""
 
 #: src/olympia/devhub/templates/devhub/docs/policies-contact.html:44
 msgid ""
-"If you've found a problem with the site, we'd love to fix it. Please <a href=\"https://github.com/mozilla/olympia/issues\">file a bug report</a> in GitHub, including the location of the problem and "
-"how you encountered it."
+"If you've found a problem with the site, we'd love to fix it. Please <a href=\"https://github.com/mozilla/addons/issues/new\">file a bug report</a> in GitHub, including the location of the problem "
+"and how you encountered it."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/docs/policies-maintenance.html:3 src/olympia/devhub/templates/devhub/docs/policies-maintenance.html:7
@@ -5810,7 +5737,7 @@ msgstr ""
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:282
 msgid ""
-"Add-ons that store or otherwise handle browsing data must support <a href=\"https://developer.mozilla.org/En/Supporting_private_browsing_mode\">Private Browsing Mode</a>.  During a Private Browsing "
+"Add-ons that store or otherwise handle browsing data must support <a href=\"https://developer.mozilla.org/En/Supporting_private_browsing_mode\">Private Browsing Mode</a>. During a Private Browsing "
 "session, no browsing data can be written to disk, and all of this data must be cleared when Firefox quits or the Private Browsing session ends."
 msgstr ""
 
@@ -5975,129 +5902,95 @@ msgstr ""
 msgid "How to get in touch with us regarding these policies or your add-on."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:6
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:10
 msgid "You have disabled this add-on"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:20
-msgid ""
-"Your add-on's listing is disabled and is not showing\n"
-"                             anywhere in our gallery or update service."
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:24
+msgid "Your add-on's listing is disabled and is not showing anywhere in our gallery or update service."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:25
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:27
 msgid "Please complete your add-on."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:29
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:30
 msgid "You will receive an email when the review is complete."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:34
-msgid ""
-"You will receive an email when the review is complete. Until\n"
-"                             then, your add-on is not listed in our gallery but can be\n"
-"                             accessed directly from its details page."
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:33
+msgid "You will receive an email when the review is complete. Until then, your add-on is not listed in our gallery but can be accessed directly from its details page."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:38 src/olympia/devhub/templates/devhub/includes/addon_details.html:48
-msgid ""
-"You will receive an email when the review is\n"
-"                             complete and your add-on is signed."
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:37 src/olympia/devhub/templates/devhub/includes/addon_details.html:45
+msgid "You will receive an email when the review is complete and your add-on is signed."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:44
-msgid ""
-"You will receive an email when the review is complete. Until\n"
-"                             then, your add-on is not listed in our gallery but can be\n"
-"                             accessed directly from its details page. "
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:41
+msgid "You will receive an email when the review is complete. Until then, your add-on is not listed in our gallery but can be accessed directly from its details page. "
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:54
-msgid ""
-"Your add-on is displayed in our gallery and users are\n"
-"                             receiving automatic updates."
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:49
+msgid "Your add-on is displayed in our gallery and users are receiving automatic updates."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:57
-msgid ""
-"Your add-on has been signed and can be bundled with an\n"
-"                             application installer."
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:52
+msgid "Your add-on has been signed and can be bundled with an application installer."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:63
-msgid ""
-"Your add-on was disabled by a site administrator and is no\n"
-"                             longer shown in our gallery. If you have any questions,\n"
-"                             please email amo-admins@mozilla.org."
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:56
+msgid "Your add-on was disabled by a site administrator and is no longer shown in our gallery. If you have any questions, please email amo-admins@mozilla.org."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:70
-msgid ""
-"Your add-on is displayed in our gallery as experimental\n"
-"                             and users are receiving automatic updates. Some features\n"
-"                             are unavailable to your add-on."
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:62
+msgid "Your add-on is displayed in our gallery as experimental and users are receiving automatic updates. Some features are unavailable to your add-on."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:74
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:66
 msgid "Your add-on has been signed."
 msgstr ""
 
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:69
+msgid ""
+"You will receive an email when the full review is complete. Until then, your add-on is displayed in our gallery as experimental and users are receiving automatic updates. Some features are "
+"unavailable to your add-on."
+msgstr ""
+
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:74
+msgid "You will receive an email when the full review is complete, making you able to bundle your add-on with an application installer."
+msgstr ""
+
 #: src/olympia/devhub/templates/devhub/includes/addon_details.html:79
-msgid ""
-"You will receive an email when the full review is complete.\n"
-"                             Until then, your add-on is displayed in our gallery as\n"
-"                             experimental and users are receiving automatic updates.\n"
-"                             Some features are unavailable to your add-on."
+msgid "All add-ons hosted in our gallery must now be reviewed by an editor. If you wish to continue hosting your add-on, please click to select a review process."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:84
-msgid ""
-"You will receive an email when the full review is\n"
-"                             complete, making you able to bundle your add-on with an\n"
-"                             application installer."
-msgstr ""
-
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:91
-msgid ""
-"All add-ons hosted in our gallery must now be reviewed by an\n"
-"                             editor. If you wish to continue hosting your add-on, please\n"
-"                             click to select a review process."
-msgstr ""
-
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:113
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:100
 msgid "Current Version:"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:115
-msgid ""
-"This is the version of your add-on that will\n"
-"                                           be installed if someone clicks the Install\n"
-"                                           button on addons.mozilla.org. It is only\n"
-"                                           relevant for listed add-ons."
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:102
+msgid "This is the version of your add-on that will be installed if someone clicks the Install button on addons.mozilla.org. It is only relevant for listed add-ons."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:123
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:110
 msgid "Created:"
 msgstr ""
 
 #. {0} is a date. dennis-ignore: E201
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:125 src/olympia/devhub/templates/devhub/includes/addon_details.html:131
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:112 src/olympia/devhub/templates/devhub/includes/addon_details.html:118
 #, python-format
 msgid "%%b %%e, %%Y"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:136
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:123
 msgid "Next Version:"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:138
-msgid ""
-"This is the newest uploaded version, however\n"
-"                                           it isn’t live on the site yet."
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:125
+msgid "This is the newest uploaded version, however it isn’t live on the site yet."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:144 src/olympia/devhub/templates/devhub/versions/list.html:30
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:130 src/olympia/devhub/templates/devhub/versions/list.html:30
 msgid "Queues are not reviewed strictly in order"
 msgstr ""
 
@@ -6165,9 +6058,7 @@ msgid "View the blog &#9658;"
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/includes/license_form.html:6
-msgid ""
-"Please choose a license appropriate for the rights you grant on your source code.\n"
-"                  It is only relevant for listed add-ons."
+msgid "Please choose a license appropriate for the rights you grant on your source code. It is only relevant for listed add-ons."
 msgstr ""
 
 #. {0} is a list of HTML tags.
@@ -6194,14 +6085,11 @@ msgstr[1] ""
 #: src/olympia/devhub/templates/devhub/includes/policy_form.html:4
 msgid ""
 "Users will be required to accept the following End-User License Agreement (EULA) prior to installing your add-on. The presence of a EULA significantly affects the number of downloads an add-on "
-"receives. Please note that a EULA is not the same as a code license, such as the GPL or MPL.\n"
-"                It is only relevant for listed add-ons."
+"receives. Please note that a EULA is not the same as a code license, such as the GPL or MPL.It is only relevant for listed add-ons."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/policy_form.html:21
-msgid ""
-"If your add-on transmits any data from the user's computer, a privacy policy is required that explains what data is sent and how it is used.\n"
-"                It is only relevant for listed add-ons."
+#: src/olympia/devhub/templates/devhub/includes/policy_form.html:24
+msgid "If your add-on transmits any data from the user's computer, a privacy policy is required that explains what data is sent and how it is used. It is only relevant for listed add-ons."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/includes/source_form_field.html:2
@@ -6369,12 +6257,8 @@ msgstr ""
 msgid "Add some tags to describe your Theme."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/personas/edit.html:106
-msgid ""
-"A short explanation of your theme's\n"
-"                                basic functionality that is displayed in\n"
-"                                search and browse listings, as well as at\n"
-"                                the top of your theme's details page."
+#: src/olympia/devhub/templates/devhub/personas/edit.html:106 src/olympia/devhub/templates/devhub/personas/submit.html:54
+msgid "A short explanation of your theme's basic functionality that is displayed in search and browse listings, as well as at the top of your theme's details page."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/personas/edit.html:122 src/olympia/devhub/templates/devhub/personas/submit.html:68
@@ -6444,7 +6328,7 @@ msgid "Upon upload and form submission, the AMO Team will review your updated de
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/personas/edit.html:241
-msgid "Your previously resubmitted design,  which is under pending review."
+msgid "Your previously resubmitted design, which is under pending review."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/personas/edit.html:245
@@ -6511,14 +6395,6 @@ msgstr ""
 
 #: src/olympia/devhub/templates/devhub/personas/submit.html:33
 msgid "Give your Theme a name."
-msgstr ""
-
-#: src/olympia/devhub/templates/devhub/personas/submit.html:54
-msgid ""
-"A short explanation of your theme's\n"
-"                                      basic functionality that is displayed in\n"
-"                                      search and browse listings, as well as at\n"
-"                                      the top of your theme's details page."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/personas/submit.html:198
@@ -6595,30 +6471,16 @@ msgstr ""
 msgid "Files added to reviewed versions must be reviewed before they will be available for download."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/add_file_modal.html:15
-#, python-format
-msgid ""
-"Submission of updates to unlisted add-ons for signing is currently in an open beta. Manual review may still be required for a large number of add-ons. Please <a href=\"%(url)s\" target=\"_blank"
-"\">report any bugs</a> that you encounter."
-msgstr ""
-
-#: src/olympia/devhub/templates/devhub/versions/add_file_modal.html:35
+#: src/olympia/devhub/templates/devhub/versions/add_file_modal.html:24
 msgid "Select the target platform for this file."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/add_file_modal.html:46
+#: src/olympia/devhub/templates/devhub/versions/add_file_modal.html:35
 msgid "Which review type would you like to nominate for?"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/add_file_modal.html:51
+#: src/olympia/devhub/templates/devhub/versions/add_file_modal.html:40
 msgid "Only publish this version to my beta channel."
-msgstr ""
-
-#: src/olympia/devhub/templates/devhub/versions/add_file_modal.html:54
-#, python-format
-msgid ""
-"The behavior of the beta channel has changed to accommodate <a href=\"%(addon_signing_url)s\" target=\"_blank\">mandatory add-on signing</a>. The new process is currently in an open beta, and may "
-"change significantly in the near future. Please <a href=\"%(issues_url)s\" target=\"_blank\">report any bugs</a> that you encounter."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/versions/edit.html:5
@@ -6642,19 +6504,10 @@ msgstr ""
 msgid "Upload Another File"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/edit.html:45
-msgid ""
-"Adjusting application information here will allow users to install your\n"
-"                          add-on even if the install manifest in the package indicates that the\n"
-"                          add-on is incompatible."
-msgstr ""
-
 #: src/olympia/devhub/templates/devhub/versions/edit.html:74
 msgid ""
-"Information about changes in this release, new features,\n"
-"                              known bugs, and other useful information specific to this\n"
-"                              release/version. This information is also shown in the\n"
-"                              Add-ons Manager when updating."
+"Information about changes in this release, new features, known bugs, and other useful information specific to this release/version. This information is also shown in the Add-ons Manager when "
+"updating."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/versions/edit.html:99
@@ -6666,10 +6519,7 @@ msgid "Notes for Reviewers"
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/versions/edit.html:114
-msgid ""
-"Optionally, enter any information that may be useful\n"
-"                              to the Editor reviewing this add-on, such as test\n"
-"                              account information."
+msgid "Optionally, enter any information that may be useful to the Editor reviewing this add-on, such as test account information."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/versions/edit.html:127
@@ -6747,7 +6597,7 @@ msgstr ""
 msgid "Request Preliminary Review"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:80 src/olympia/devhub/templates/devhub/versions/list.html:327 src/olympia/devhub/templates/devhub/versions/list.html:350
+#: src/olympia/devhub/templates/devhub/versions/list.html:80 src/olympia/devhub/templates/devhub/versions/list.html:325 src/olympia/devhub/templates/devhub/versions/list.html:348
 msgid "Cancel Review Request"
 msgstr ""
 
@@ -6776,7 +6626,7 @@ msgid "Unlisted:"
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/versions/list.html:114
-msgid "Not distributed on {0}. Developers will upload new versions for signing and distribute the add-ons on their own. (beta)"
+msgid "Not distributed on {0}. Developers will upload new versions for signing and distribute the add-ons on their own."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/versions/list.html:122
@@ -6839,81 +6689,73 @@ msgid "<strong>Important:</strong> Once a version has been deleted, you may not 
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/versions/list.html:230
-msgid ""
-"Deleting a version which has already been reviewed\n"
-"               may also cause a significant delay in the review of\n"
-"               your next update."
-msgstr ""
-
-#: src/olympia/devhub/templates/devhub/versions/list.html:233
 msgid "Are you sure you wish to delete this version?"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:238
+#: src/olympia/devhub/templates/devhub/versions/list.html:235
 msgid "Delete Version"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:240
+#: src/olympia/devhub/templates/devhub/versions/list.html:237
 msgid "Disable Version"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:247
+#: src/olympia/devhub/templates/devhub/versions/list.html:244
 msgid "Add a new Version"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:249
+#: src/olympia/devhub/templates/devhub/versions/list.html:246
 msgid "Add Version"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:256 src/olympia/devhub/templates/devhub/versions/list.html:274
+#: src/olympia/devhub/templates/devhub/versions/list.html:253 src/olympia/devhub/templates/devhub/versions/list.html:279
 msgid "Hide Add-on"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:259
+#: src/olympia/devhub/templates/devhub/versions/list.html:256
 msgid "Hiding your add-on will prevent it from appearing anywhere in our gallery and will stop users from receiving automatic updates."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:265
+#: src/olympia/devhub/templates/devhub/versions/list.html:263
+msgid "The files awaiting review will be disabled and you will need to upload new versions."
+msgstr ""
+
+#: src/olympia/devhub/templates/devhub/versions/list.html:270
 msgid "Are you sure you wish to hide your add-on?"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:286 src/olympia/devhub/templates/devhub/versions/list.html:315
+#: src/olympia/devhub/templates/devhub/versions/list.html:291 src/olympia/devhub/templates/devhub/versions/list.html:313
 msgid "Unlist Add-on"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:289
+#: src/olympia/devhub/templates/devhub/versions/list.html:294
 #, python-format
 msgid ""
 "Unlisting your add-on will make it (and each of its versions/files) invisible on this website. It won't show up in searches, won't have a public facing page, and won't be updated automatically for "
-"current users.  It is recommended for unlisted add-ons to provide a custom <a href=\"%(update_url)s\" target=\"_blank\">updateURL</a> in their manifest file for automatic updates."
+"current users. It is recommended for unlisted add-ons to provide a custom <a href=\"%(update_url)s\" target=\"_blank\">updateURL</a> in their manifest file for automatic updates."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:299
-#, python-format
-msgid "Switching add-ons to unlisted is currently in an open beta. Please <a href=\"%(url)s\" target=\"_blank\">report any bugs</a> that you encounter."
-msgstr ""
-
-#: src/olympia/devhub/templates/devhub/versions/list.html:305
+#: src/olympia/devhub/templates/devhub/versions/list.html:303
 msgid "Unlisting an add-on is irreversible!"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:305
+#: src/olympia/devhub/templates/devhub/versions/list.html:303
 msgid "An unlisted add-on cannot be switched to be listed."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:307
+#: src/olympia/devhub/templates/devhub/versions/list.html:305
 msgid "Are you sure you wish to unlist your add-on?"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:330
+#: src/olympia/devhub/templates/devhub/versions/list.html:328
 msgid "Canceling your review request will leave your add-on as preliminarily reviewed."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:335
+#: src/olympia/devhub/templates/devhub/versions/list.html:333
 msgid "Canceling your review request will mark your add-on incomplete. If you do not complete your add-on after several days by re-requesting review, it will be deleted."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:343
+#: src/olympia/devhub/templates/devhub/versions/list.html:341
 msgid "Are you sure you wish to cancel your review request?"
 msgstr ""
 
@@ -7252,19 +7094,19 @@ msgstr ""
 msgid "Search by add-on name / author email"
 msgstr ""
 
-#: src/olympia/editors/forms.py:103
+#: src/olympia/editors/forms.py:103 src/olympia/editors/forms.py:244 src/olympia/editors/forms.py:257
 msgid "yes"
 msgstr ""
 
-#: src/olympia/editors/forms.py:104
+#: src/olympia/editors/forms.py:104 src/olympia/editors/forms.py:244 src/olympia/editors/forms.py:257
 msgid "no"
 msgstr ""
 
-#: src/olympia/editors/forms.py:105
+#: src/olympia/editors/forms.py:105 src/olympia/editors/forms.py:245
 msgid "Admin Flag"
 msgstr ""
 
-#: src/olympia/editors/forms.py:113
+#: src/olympia/editors/forms.py:113 src/olympia/editors/forms.py:253
 msgid "Max. Version"
 msgstr ""
 
@@ -7276,55 +7118,59 @@ msgstr ""
 msgid "Add-on Types"
 msgstr ""
 
-#: src/olympia/editors/forms.py:126 src/olympia/editors/helpers.py:267
+#: src/olympia/editors/forms.py:126 src/olympia/editors/helpers.py:279
 msgid "Platforms"
 msgstr ""
 
+#: src/olympia/editors/forms.py:237
+msgid "Search by add-on name / author email / guid"
+msgstr ""
+
 #. L10n: 0 = platform, 1 = filename, 2 = status message
-#: src/olympia/editors/forms.py:238
+#: src/olympia/editors/forms.py:342
 #, python-format
 msgid "<strong>%s</strong> &middot; %s &middot; %s"
 msgstr ""
 
-#: src/olympia/editors/forms.py:252
+#: src/olympia/editors/forms.py:356
 msgid "Comments:"
 msgstr ""
 
-#: src/olympia/editors/forms.py:256
+#: src/olympia/editors/forms.py:360
 msgid "Operating systems:"
 msgstr ""
 
-#: src/olympia/editors/forms.py:258
+#: src/olympia/editors/forms.py:362
 msgid "Applications:"
 msgstr ""
 
-#: src/olympia/editors/forms.py:260
+#: src/olympia/editors/forms.py:364
 msgid "Notify me the next time this add-on is updated. (Subsequent updates will not generate an email)"
 msgstr ""
 
-#: src/olympia/editors/forms.py:265
+#: src/olympia/editors/forms.py:369
 msgid "Clear Admin Review Flag"
 msgstr ""
 
-#: src/olympia/editors/forms.py:267
+#: src/olympia/editors/forms.py:371
 msgid "Clear more info requested flag"
 msgstr ""
 
-#: src/olympia/editors/forms.py:281
+#: src/olympia/editors/forms.py:385
 msgid "Choose a canned response..."
 msgstr ""
 
 #. L10n: Description of what can be searched for.
-#: src/olympia/editors/forms.py:324
+#: src/olympia/editors/forms.py:423
 msgid "theme name"
 msgstr ""
 
-#: src/olympia/editors/forms.py:350
+#: src/olympia/editors/forms.py:449
 msgid "Someone else is reviewing this theme."
 msgstr ""
 
 #. L10n: Description of what can be searched for.
-#: src/olympia/editors/forms.py:447
+#: src/olympia/editors/forms.py:546
 msgid "app, reviewer, or comment"
 msgstr ""
 
@@ -7340,246 +7186,264 @@ msgstr ""
 msgid "Rejected or Unreviewed"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:123 src/olympia/editors/helpers.py:136
+#: src/olympia/editors/helpers.py:125 src/olympia/editors/helpers.py:138
 msgid "Queue"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:124 src/olympia/editors/templates/editors/base.html:50 src/olympia/editors/templates/editors/base.html:65
+#: src/olympia/editors/helpers.py:126 src/olympia/editors/templates/editors/base.html:50 src/olympia/editors/templates/editors/base.html:65
 msgid "Pending Updates"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:125 src/olympia/editors/templates/editors/base.html:48 src/olympia/editors/templates/editors/base.html:63
+#: src/olympia/editors/helpers.py:127 src/olympia/editors/templates/editors/base.html:48 src/olympia/editors/templates/editors/base.html:63
 msgid "Full Reviews"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:126 src/olympia/editors/templates/editors/base.html:52 src/olympia/editors/templates/editors/base.html:67
+#: src/olympia/editors/helpers.py:128 src/olympia/editors/templates/editors/base.html:52 src/olympia/editors/templates/editors/base.html:67
 msgid "Preliminary Reviews"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:127 src/olympia/editors/templates/editors/base.html:54
+#: src/olympia/editors/helpers.py:129 src/olympia/editors/templates/editors/base.html:54
 msgid "Moderated Reviews"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:128 src/olympia/editors/templates/editors/base.html:46
+#: src/olympia/editors/helpers.py:130 src/olympia/editors/templates/editors/base.html:46
 msgid "Fast Track"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:130
+#: src/olympia/editors/helpers.py:132
 msgid "Pending Themes"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:131 src/olympia/editors/templates/editors/themes/queue.html:4
+#: src/olympia/editors/helpers.py:133 src/olympia/editors/templates/editors/themes/queue.html:4
 msgid "Flagged Themes"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:132
+#: src/olympia/editors/helpers.py:134
 msgid "Update Themes"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:137
+#: src/olympia/editors/helpers.py:139
 msgid "Unlisted Pending Updates"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:138
+#: src/olympia/editors/helpers.py:140
 msgid "Unlisted Full Reviews"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:139
+#: src/olympia/editors/helpers.py:141
 msgid "Unlisted Preliminary Reviews"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:170
+#: src/olympia/editors/helpers.py:142
+msgid "Unlisted All Add-ons"
+msgstr ""
+
+#: src/olympia/editors/helpers.py:173
 msgid "Fast Track ({0})"
 msgid_plural "Fast Track ({0})"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/olympia/editors/helpers.py:175
+#: src/olympia/editors/helpers.py:178
 msgid "Full Review ({0})"
 msgid_plural "Full Reviews ({0})"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/olympia/editors/helpers.py:180
+#: src/olympia/editors/helpers.py:183
 msgid "Pending Update ({0})"
 msgid_plural "Pending Updates ({0})"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/olympia/editors/helpers.py:185
+#: src/olympia/editors/helpers.py:188
 msgid "Preliminary Review ({0})"
 msgid_plural "Preliminary Reviews ({0})"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/olympia/editors/helpers.py:190
+#: src/olympia/editors/helpers.py:193
 msgid "Moderated Review ({0})"
 msgid_plural "Moderated Reviews ({0})"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/olympia/editors/helpers.py:196
+#: src/olympia/editors/helpers.py:199
 msgid "Unlisted Full Review ({0})"
 msgid_plural "Unlisted Full Reviews ({0})"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/olympia/editors/helpers.py:201
+#: src/olympia/editors/helpers.py:204
 msgid "Unlisted Pending Update ({0})"
 msgid_plural "Unlisted Pending Updates ({0})"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/olympia/editors/helpers.py:206
+#: src/olympia/editors/helpers.py:209
 msgid "Unlisted Preliminary Review ({0})"
 msgid_plural "Unlisted Preliminary Reviews ({0})"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/olympia/editors/helpers.py:261
-msgid "Addon"
-msgstr ""
+#: src/olympia/editors/helpers.py:214
+msgid "Unlisted All Add-ons ({0})"
+msgid_plural "Unlisted All Add-ons ({0})"
+msgstr[0] ""
+msgstr[1] ""
 
-#: src/olympia/editors/helpers.py:262
+#: src/olympia/editors/helpers.py:274
 msgid "Type"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:263
+#: src/olympia/editors/helpers.py:275
 msgid "Waiting Time"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:264 src/olympia/editors/templates/editors/review.html:285
+#: src/olympia/editors/helpers.py:276 src/olympia/editors/templates/editors/review.html:285
 msgid "Flags"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:265
+#: src/olympia/editors/helpers.py:277
 msgid "Applications"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:270
+#: src/olympia/editors/helpers.py:282
 msgid "Additional"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:285
+#: src/olympia/editors/helpers.py:302
 msgid "Site Specific"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:287
+#: src/olympia/editors/helpers.py:304
 msgid "Requires External Software"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:289
+#: src/olympia/editors/helpers.py:306
 msgid "Binary Components"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:313
+#: src/olympia/editors/helpers.py:339
 msgid "moments ago"
 msgstr ""
 
 #. L10n: first argument is number of minutes
-#: src/olympia/editors/helpers.py:316
+#: src/olympia/editors/helpers.py:342
 msgid "{0} minute"
 msgid_plural "{0} minutes"
 msgstr[0] ""
 msgstr[1] ""
 
 #. L10n: first argument is number of hours
-#: src/olympia/editors/helpers.py:320
+#: src/olympia/editors/helpers.py:346
 msgid "{0} hour"
 msgid_plural "{0} hours"
 msgstr[0] ""
 msgstr[1] ""
 
 #. L10n: first argument is number of days
-#: src/olympia/editors/helpers.py:324
+#: src/olympia/editors/helpers.py:350
 msgid "{0} day"
 msgid_plural "{0} days"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/olympia/editors/helpers.py:488
+#: src/olympia/editors/helpers.py:364
+msgid "Last Review"
+msgstr ""
+
+#: src/olympia/editors/helpers.py:366
+msgid "Last Update"
+msgstr ""
+
+#: src/olympia/editors/helpers.py:387
+msgid "No Reviews"
+msgstr ""
+
+#: src/olympia/editors/helpers.py:561
 msgid "Push to public"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:490
+#: src/olympia/editors/helpers.py:563
 msgid "Grant full review"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:505
+#: src/olympia/editors/helpers.py:578
 msgid "Request more information"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:508
+#: src/olympia/editors/helpers.py:581
 msgid "Request super-review"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:519
+#: src/olympia/editors/helpers.py:592
 msgid "Grant preliminary review"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:520
+#: src/olympia/editors/helpers.py:593
 msgid "This will mark the files as preliminarily reviewed."
 msgstr ""
 
-#: src/olympia/editors/helpers.py:522
+#: src/olympia/editors/helpers.py:595
 msgid "Use this form to request more information from the author. They will receive an email and be able to answer here. You will be notified by email when they reply."
 msgstr ""
 
-#: src/olympia/editors/helpers.py:526
+#: src/olympia/editors/helpers.py:599
 msgid ""
 "If you have concerns about this add-on's security, copyright issues, or other concerns that an administrator should look into, enter your comments in the area below. They will be sent to "
 "administrators, not the author."
 msgstr ""
 
-#: src/olympia/editors/helpers.py:532
+#: src/olympia/editors/helpers.py:605
 msgid "This will reject the add-on and remove it from the review queue."
 msgstr ""
 
-#: src/olympia/editors/helpers.py:534
-msgid "Make a comment on this version.  The author won't be able to see this."
+#: src/olympia/editors/helpers.py:607
+msgid "Make a comment on this version. The author won't be able to see this."
 msgstr ""
 
-#: src/olympia/editors/helpers.py:538
+#: src/olympia/editors/helpers.py:611
 msgid "This will reject the files and remove them from the review queue."
 msgstr ""
 
-#: src/olympia/editors/helpers.py:542
+#: src/olympia/editors/helpers.py:615
 msgid "This will mark the add-on as preliminarily reviewed. Future versions will undergo preliminary review."
 msgstr ""
 
-#: src/olympia/editors/helpers.py:547
+#: src/olympia/editors/helpers.py:620
 msgid "This will mark the files as preliminarily reviewed. Future versions will undergo preliminary review."
 msgstr ""
 
-#: src/olympia/editors/helpers.py:552
+#: src/olympia/editors/helpers.py:625
 msgid "Retain preliminary review"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:553
+#: src/olympia/editors/helpers.py:626
 msgid "This will retain the add-on as preliminarily reviewed. Future versions will undergo preliminary review."
 msgstr ""
 
-#: src/olympia/editors/helpers.py:558
+#: src/olympia/editors/helpers.py:631
 msgid "This will approve a sandboxed version of a public add-on to appear on the public side."
 msgstr ""
 
-#: src/olympia/editors/helpers.py:561
+#: src/olympia/editors/helpers.py:634
 msgid "This will reject a version of a public add-on and remove it from the queue."
 msgstr ""
 
-#: src/olympia/editors/helpers.py:564
+#: src/olympia/editors/helpers.py:637
 msgid "This will mark the add-on and its most recent version and files as public. Future versions will go into the sandbox until they are reviewed by an editor."
 msgstr ""
 
-#: src/olympia/editors/helpers.py:637
+#: src/olympia/editors/helpers.py:714
 msgid "add-on"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:940 src/olympia/editors/helpers.py:960
+#: src/olympia/editors/helpers.py:1020 src/olympia/editors/helpers.py:1040
 msgid "Flagged"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:944 src/olympia/editors/helpers.py:963
+#: src/olympia/editors/helpers.py:1024 src/olympia/editors/helpers.py:1043
 msgid "Updates"
 msgstr ""
 
@@ -7631,56 +7495,56 @@ msgstr ""
 msgid "A question about your Theme submission"
 msgstr ""
 
-#: src/olympia/editors/views.py:144
+#: src/olympia/editors/views.py:146
 msgid "New Add-ons (Under 5 days)"
 msgstr ""
 
-#: src/olympia/editors/views.py:145
+#: src/olympia/editors/views.py:147
 msgid "Passable (5 to 10 days)"
 msgstr ""
 
-#: src/olympia/editors/views.py:146
+#: src/olympia/editors/views.py:148
 msgid "Overdue (Over 10 days)"
 msgstr ""
 
-#: src/olympia/editors/views.py:532
+#: src/olympia/editors/views.py:539
 msgid "An unknown error occurred"
 msgstr ""
 
-#: src/olympia/editors/views.py:587
+#: src/olympia/editors/views.py:592
 msgid "Self-reviews are not allowed."
 msgstr ""
 
-#: src/olympia/editors/views.py:609
+#: src/olympia/editors/views.py:613
 msgid "Review successfully processed."
 msgstr ""
 
-#: src/olympia/editors/views.py:807
+#: src/olympia/editors/views.py:812
 msgid "was approved"
 msgstr ""
 
-#: src/olympia/editors/views.py:808
+#: src/olympia/editors/views.py:813
 msgid "given preliminary review"
 msgstr ""
 
-#: src/olympia/editors/views.py:809
+#: src/olympia/editors/views.py:814
 msgid "rejected"
 msgstr ""
 
-#: src/olympia/editors/views.py:810
+#: src/olympia/editors/views.py:815
 msgctxt "editors_review_history_nominated_adminreview"
 msgid "escalated"
 msgstr ""
 
-#: src/olympia/editors/views.py:812
+#: src/olympia/editors/views.py:817
 msgid "needs more information"
 msgstr ""
 
-#: src/olympia/editors/views.py:813
+#: src/olympia/editors/views.py:818
 msgid "needs super review"
 msgstr ""
 
-#: src/olympia/editors/views.py:814
+#: src/olympia/editors/views.py:819
 msgid "commented"
 msgstr ""
 
@@ -7725,28 +7589,28 @@ msgstr ""
 msgid "Unlisted Queues"
 msgstr ""
 
-#: src/olympia/editors/templates/editors/base.html:72 src/olympia/editors/templates/editors/performance.html:6
+#: src/olympia/editors/templates/editors/base.html:74 src/olympia/editors/templates/editors/performance.html:6
 msgid "Performance"
 msgstr ""
 
-#: src/olympia/editors/templates/editors/base.html:75 src/olympia/editors/templates/editors/themes/base.html:19 src/olympia/editors/templates/editors/themes/base.html:38
+#: src/olympia/editors/templates/editors/base.html:77 src/olympia/editors/templates/editors/themes/base.html:19 src/olympia/editors/templates/editors/themes/base.html:38
 msgid "Logs"
 msgstr ""
 
-#: src/olympia/editors/templates/editors/base.html:78 src/olympia/editors/templates/editors/reviewlog.html:4 src/olympia/editors/templates/editors/reviewlog.html:27
+#: src/olympia/editors/templates/editors/base.html:80 src/olympia/editors/templates/editors/reviewlog.html:4 src/olympia/editors/templates/editors/reviewlog.html:27
 msgid "Add-on Review Log"
 msgstr ""
 
-#: src/olympia/editors/templates/editors/base.html:80 src/olympia/editors/templates/editors/eventlog.html:4 src/olympia/editors/templates/editors/eventlog.html:8
+#: src/olympia/editors/templates/editors/base.html:82 src/olympia/editors/templates/editors/eventlog.html:4 src/olympia/editors/templates/editors/eventlog.html:8
 #: src/olympia/editors/templates/editors/eventlog_detail.html:4
 msgid "Moderated Review Log"
 msgstr ""
 
-#: src/olympia/editors/templates/editors/base.html:82 src/olympia/editors/templates/editors/beta_signed_log.html:4 src/olympia/editors/templates/editors/beta_signed_log.html:8
+#: src/olympia/editors/templates/editors/base.html:84 src/olympia/editors/templates/editors/beta_signed_log.html:4 src/olympia/editors/templates/editors/beta_signed_log.html:8
 msgid "Signed Beta Files Log"
 msgstr ""
 
-#: src/olympia/editors/templates/editors/base.html:87 src/olympia/editors/templates/editors/includes/daily-message.html:4
+#: src/olympia/editors/templates/editors/base.html:89 src/olympia/editors/templates/editors/includes/daily-message.html:4
 msgid "Announcement"
 msgstr ""
 
@@ -7967,45 +7831,45 @@ msgstr ""
 msgid "clear search"
 msgstr ""
 
-#: src/olympia/editors/templates/editors/queue.html:72 src/olympia/editors/templates/editors/queue.html:122
+#: src/olympia/editors/templates/editors/queue.html:78 src/olympia/editors/templates/editors/queue.html:128
 msgid "Process Reviews"
 msgstr ""
 
-#: src/olympia/editors/templates/editors/queue.html:80
+#: src/olympia/editors/templates/editors/queue.html:86
 msgid "Moderation actions:"
 msgstr ""
 
-#: src/olympia/editors/templates/editors/queue.html:90
+#: src/olympia/editors/templates/editors/queue.html:96
 #, python-format
 msgid "by %(user)s on %(date)s %(stars)s (%(locale)s)"
 msgstr ""
 
-#: src/olympia/editors/templates/editors/queue.html:106
+#: src/olympia/editors/templates/editors/queue.html:112
 #, python-format
 msgid "<strong>%(reason)s</strong> <span class=\"light\">Flagged by %(user)s on %(date)s</span>"
 msgstr ""
 
-#: src/olympia/editors/templates/editors/queue.html:119
-msgid "All reviews have been moderated.  Good work!"
+#: src/olympia/editors/templates/editors/queue.html:125
+msgid "All reviews have been moderated. Good work!"
 msgstr ""
 
-#: src/olympia/editors/templates/editors/queue.html:161
+#: src/olympia/editors/templates/editors/queue.html:167
 msgid "Version Notes / Notes for Reviewer"
 msgstr ""
 
-#: src/olympia/editors/templates/editors/queue.html:169
+#: src/olympia/editors/templates/editors/queue.html:175
 msgid "There are currently no add-ons of this type to review."
 msgstr ""
 
-#: src/olympia/editors/templates/editors/queue.html:181 src/olympia/editors/templates/editors/themes/queue_list.html:85
+#: src/olympia/editors/templates/editors/queue.html:187 src/olympia/editors/templates/editors/themes/queue_list.html:85
 msgid "Helpful Links:"
 msgstr ""
 
-#: src/olympia/editors/templates/editors/queue.html:182
+#: src/olympia/editors/templates/editors/queue.html:188
 msgid "Add-on Policy"
 msgstr ""
 
-#: src/olympia/editors/templates/editors/queue.html:184
+#: src/olympia/editors/templates/editors/queue.html:190
 msgid "Editors' Guide"
 msgstr ""
 
@@ -8068,10 +7932,7 @@ msgid "<strong>Warning!</strong> Another user was viewing this page before you."
 msgstr ""
 
 #: src/olympia/editors/templates/editors/review.html:237
-msgid ""
-"The whiteboard is the place to exchange information relevant to\n"
-"               this addon (whatever the version), between the developer and the\n"
-"               editor. This is visible and editable by both."
+msgid "The whiteboard is the place to exchange information relevant to this addon (whatever the version), between the developer and the editor. This is visible and editable by both."
 msgstr ""
 
 #: src/olympia/editors/templates/editors/review.html:241
@@ -8345,7 +8206,7 @@ msgstr ""
 msgid "Describe your reason for flagging"
 msgstr ""
 
-#: src/olympia/files/forms.py:88
+#: src/olympia/files/forms.py:90
 msgid "Cannot diff a version against itself"
 msgstr ""
 
@@ -8380,51 +8241,51 @@ msgstr ""
 msgid "There was an error accessing file %s."
 msgstr ""
 
-#: src/olympia/files/utils.py:343
+#: src/olympia/files/utils.py:340
 msgid "Could not parse uploaded file."
 msgstr ""
 
-#: src/olympia/files/utils.py:380
+#: src/olympia/files/utils.py:377
 msgid "Invalid file name in archive: {0}"
 msgstr ""
 
-#: src/olympia/files/utils.py:388
+#: src/olympia/files/utils.py:385
 msgid "File exceeding size limit in archive: {0}"
 msgstr ""
 
-#: src/olympia/files/utils.py:439
+#: src/olympia/files/utils.py:436
 msgid "Invalid archive."
 msgstr ""
 
-#: src/olympia/files/utils.py:529 src/olympia/files/utils.py:532
+#: src/olympia/files/utils.py:526 src/olympia/files/utils.py:529
 msgid "Could not parse the manifest file."
 msgstr ""
 
-#: src/olympia/files/utils.py:551
+#: src/olympia/files/utils.py:548
 msgid "Could not find an add-on ID."
 msgstr ""
 
-#: src/olympia/files/utils.py:554
+#: src/olympia/files/utils.py:551
 msgid "Add-on ID must be 64 characters or less."
 msgstr ""
 
-#: src/olympia/files/utils.py:556
+#: src/olympia/files/utils.py:553
 msgid "Add-on ID doesn't match add-on."
 msgstr ""
 
-#: src/olympia/files/utils.py:564
+#: src/olympia/files/utils.py:561
 msgid "Duplicate add-on ID found."
 msgstr ""
 
-#: src/olympia/files/utils.py:567
+#: src/olympia/files/utils.py:564
 msgid "Version numbers should have fewer than 32 characters."
 msgstr ""
 
-#: src/olympia/files/utils.py:570
+#: src/olympia/files/utils.py:567
 msgid "Version numbers should only contain letters, numbers, and these punctuation characters: +*.-_."
 msgstr ""
 
-#: src/olympia/files/utils.py:587
+#: src/olympia/files/utils.py:584
 msgid "<em:type> doesn't match add-on"
 msgstr ""
 
@@ -8523,6 +8384,10 @@ msgstr ""
 
 #: src/olympia/files/templates/files/viewer.html:134
 msgid "Fetching file."
+msgstr ""
+
+#: src/olympia/legacy_api/views.py:255
+msgid "Not implemented yet."
 msgstr ""
 
 #: src/olympia/lib/constants.py:6
@@ -9181,10 +9046,6 @@ msgstr ""
 msgid "Zimbabwe Dollar"
 msgstr ""
 
-#: src/olympia/lib/video/ffmpeg.py:112 src/olympia/lib/video/totem.py:81
-msgid "Videos must be in WebM."
-msgstr ""
-
 #: src/olympia/pages/templates/pages/about.lhtml:3 src/olympia/pages/templates/pages/about.lhtml:10
 msgid "About Mozilla Add-ons"
 msgstr ""
@@ -9196,7 +9057,7 @@ msgstr ""
 #: src/olympia/pages/templates/pages/about.lhtml:13
 msgid ""
 "addons.mozilla.org, commonly known as \"AMO\", is Mozilla's official site for add-ons to Mozilla software, such as Firefox, Thunderbird, and SeaMonkey. Add-ons let you add new features and change "
-"the way your browser or application works.  Take a look around and explore the thousands of ways to customize the way you do things online."
+"the way your browser or application works. Take a look around and explore the thousands of ways to customize the way you do things online."
 msgstr ""
 
 #: src/olympia/pages/templates/pages/about.lhtml:19
@@ -9541,7 +9402,7 @@ msgstr ""
 msgid ""
 "Yes. It's possible, but some of the functionality provided by these libraries are available through XPCOM, XUL, and JavaScript. In addition, authors should take care if libraries modify primitive "
 "object prototypes (String.prototype, Date.prototype, etc.) and/or define global functions (eg. the $ function). These are prone to cause conflict with other add-ons, in particular if different add-"
-"ons use different versions of libraries and so on. Developers need to be very, very careful with using them.  Mozilla does not offer documentation on using them to build add-ons."
+"ons use different versions of libraries and so on. Developers need to be very, very careful with using them. Mozilla does not offer documentation on using them to build add-ons."
 msgstr ""
 
 #: src/olympia/pages/templates/pages/dev_faq.html:165
@@ -9655,8 +9516,8 @@ msgstr ""
 #, python-format
 msgid ""
 "Yes. Many developers choose to host their own add-ons. Choosing to host your add-on on <a href=\"%(amo_url)s\">Mozilla's add-on site</a>, though, allows for much greater exposure to your add-on due "
-"to the large volume of visitors to the site.  <a href=\"%(md_url)s\">mozdev.org</a> offers free project hosting for Mozilla applications and extensions providing developers with tools to help "
-"manage source code, version control, bug tracking and documentation."
+"to the large volume of visitors to the site. <a href=\"%(md_url)s\">mozdev.org</a> offers free project hosting for Mozilla applications and extensions providing developers with tools to help manage "
+"source code, version control, bug tracking and documentation."
 msgstr ""
 
 #: src/olympia/pages/templates/pages/dev_faq.html:277
@@ -9704,7 +9565,7 @@ msgstr ""
 #: src/olympia/pages/templates/pages/dev_faq.html:314
 #, python-format
 msgid ""
-"Yes. Mozilla's <a href=\"%(p_url)s\">Add-on Policy</a> describes what is an acceptable submission. This policy is subject to change without notice.  In addition, the AMO editorial team uses the <a "
+"Yes. Mozilla's <a href=\"%(p_url)s\">Add-on Policy</a> describes what is an acceptable submission. This policy is subject to change without notice. In addition, the AMO editorial team uses the <a "
 "href=\"%(g_url)s\">Editors Reviewing Guide</a> to ensure that your add-on meets specific guidelines for functionality and security."
 msgstr ""
 
@@ -9821,7 +9682,7 @@ msgstr ""
 #: src/olympia/pages/templates/pages/dev_faq.html:434
 #, python-format
 msgid ""
-"This is why it's very important to read the <a href=\"%(g_url)s\">Editors Reviewing Guide</a> to ensure that your add-on is setup as expected.  It's also a good idea to read the blog post, <a href="
+"This is why it's very important to read the <a href=\"%(g_url)s\">Editors Reviewing Guide</a> to ensure that your add-on is setup as expected. It's also a good idea to read the blog post, <a href="
 "\"%(blog_url)s\">Successfully Getting your Add-on Reviewed</a> which provides excellent insight into ensuring a smooth review of your add-on."
 msgstr ""
 
@@ -9928,7 +9789,7 @@ msgstr ""
 
 #: src/olympia/pages/templates/pages/dev_faq.html:572
 msgid ""
-"Free Software Foundation provides short summaries of the key open source licenses, including whether the license qualifies as a free software license or a copyleft license.  Also includes a "
+"Free Software Foundation provides short summaries of the key open source licenses, including whether the license qualifies as a free software license or a copyleft license. Also includes a "
 "discussion of what constitutes a free software license or a copyleft license (e.g., a Copyleft license is a general method for making a program or other work free, and requiring all modified and "
 "extended versions of the program to be free as well.)"
 msgstr ""
@@ -10106,19 +9967,13 @@ msgid "Add-on Gallery"
 msgstr ""
 
 #: src/olympia/pages/templates/pages/faq.html:171
-msgid ""
-"How do I choose between add-ons that seem to do the same\n"
-"    thing?"
+msgid "How do I choose between add-ons that seem to do the same thing?"
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:173
+#: src/olympia/pages/templates/pages/faq.html:172
 msgid ""
-"There are often several add-ons that have similar features. To\n"
-"    figure out which is right for you, read the entire description of the\n"
-"    add-on and view its screenshots. If there are still several in the running,\n"
-"    read through the add-on's ratings, user reviews, and statistics to see\n"
-"    which is most liked by other users. Remember that you can also just try\n"
-"    out both and see which you like better."
+"There are often several add-ons that have similar features. To figure out which is right for you, read the entire description of the add-on and view its screenshots. If there are still several in "
+"the running, read through the add-on's ratings, user reviews, and statistics to see which is most liked by other users. Remember that you can also just try out both and see which you like better."
 msgstr ""
 
 #: src/olympia/pages/templates/pages/faq.html:180
@@ -10159,80 +10014,67 @@ msgid "How much do add-ons cost to purchase?"
 msgstr ""
 
 #: src/olympia/pages/templates/pages/faq.html:207
-msgid ""
-"Add-ons hosted in our gallery are free unless clearly marked\n"
-"    otherwise."
+msgid "Add-ons hosted in our gallery are free unless clearly marked otherwise."
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:210
+#: src/olympia/pages/templates/pages/faq.html:209
 msgid "What does it mean when an add-on asks for contributions?"
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:211
+#: src/olympia/pages/templates/pages/faq.html:210
 msgid ""
-"Some add-on authors request users who enjoy an add-on to\n"
-"        contribute to its development by making a monetary contribution. These\n"
-"        contributions go directly to the developer unless a third party is\n"
-"        indicated, such as the non-profit Mozilla Foundation."
+"Some add-on authors request users who enjoy an add-on to contribute to its development by making a monetary contribution. These contributions go directly to the developer unless a third party is "
+"indicated, such as the non-profit Mozilla Foundation."
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:216
+#: src/olympia/pages/templates/pages/faq.html:215
 msgid "What are beta add-ons?"
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:218
+#: src/olympia/pages/templates/pages/faq.html:217
 msgid ""
-"Beta add-ons are unreviewed versions which represent the\n"
-"        latest work of an add-on author. While different authors have different\n"
-"        standards for beta code quality, you should assume that these add-ons\n"
-"        are less stable than the general add-on releases."
+"Beta add-ons are unreviewed versions which represent the latest work of an add-on author. While different authors have different standards for beta code quality, you should assume that these add-"
+"ons are less stable than the general add-on releases."
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:222
+#: src/olympia/pages/templates/pages/faq.html:221
 msgid ""
 "Please note that when you install an add-on from the \"Beta Version\" section of an add-on's listing, you will continue to receive updates for that add-on as they become available. Like the initial "
 "version you installed, all beta releases are unreviewed by Mozilla and may harm your computer."
 msgstr ""
 
+#: src/olympia/pages/templates/pages/faq.html:228
+msgid "What does it mean when an add-on is flagged as slow?"
+msgstr ""
+
 #: src/olympia/pages/templates/pages/faq.html:229
-msgid ""
-"What does it mean when an add-on is flagged as\n"
-"    slow?"
+msgid "Most add-ons load code and resources at the same time Firefox is starting up. In most cases the impact in start-up time is minimal, but some add-ons can cause a noticeable slowdown."
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:231
-msgid ""
-"Most add-ons load code and resources at the same time Firefox\n"
-"        is starting up. In most cases the impact in start-up time is minimal,\n"
-"        but some add-ons can cause a noticeable slowdown."
-msgstr ""
-
-#: src/olympia/pages/templates/pages/faq.html:236
+#: src/olympia/pages/templates/pages/faq.html:234
 msgid "How do I report an inappropriate or spam user review?"
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:237
+#: src/olympia/pages/templates/pages/faq.html:235
 msgid ""
-"To report a user review of an add-on, log in with your account\n"
-"    and visit the add-on's reviews page. Find the review you wish to report,\n"
-"    click \"Report this review\" and select a reason. Our editorial team will\n"
-"    investigate the review and take appropriate action."
+"To report a user review of an add-on, log in with your account and visit the add-on's reviews page. Find the review you wish to report, click \"Report this review\" and select a reason. Our "
+"editorial team will investigate the review and take appropriate action."
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:242
+#: src/olympia/pages/templates/pages/faq.html:240
 msgid "How do I report a bug or contact the Mozilla Add-ons team?"
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:243
+#: src/olympia/pages/templates/pages/faq.html:241
 #, python-format
 msgid "Please visit our <a href=\"%(contact_url)s\">Contact page</a>."
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:246
+#: src/olympia/pages/templates/pages/faq.html:244
 msgid "What is a Source Code License?"
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:247
+#: src/olympia/pages/templates/pages/faq.html:245
 #, python-format
 msgid ""
 "The source code used to create an add-on is an exclusive copyright of the add-on author, unless otherwise declared in a source code license. Many add-ons on this site have <a href=\"%(url)s\" lang="
@@ -10240,60 +10082,60 @@ msgid ""
 "the GPL or BSD licenses instead of making up their own."
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:256
+#: src/olympia/pages/templates/pages/faq.html:254
 #, python-format
 msgid "Firefox and other Mozilla software are <a href=\"%(url)s\">open source</a>."
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:264
+#: src/olympia/pages/templates/pages/faq.html:262
 msgid "Collections and Favorites"
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:267
+#: src/olympia/pages/templates/pages/faq.html:265
 msgid "What is a collection?"
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:268
+#: src/olympia/pages/templates/pages/faq.html:266
 msgid "Collections are groups of related add-ons created by users to share."
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:270
+#: src/olympia/pages/templates/pages/faq.html:268
 msgid "What is the My Favorites collection?"
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:271
+#: src/olympia/pages/templates/pages/faq.html:269
 msgid "Favorite add-ons are add-ons that you have bookmarked to easily get back to later. You can add an add-on to your favorites collection by clicking \"Add to favorites\" on its details page."
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:275 src/olympia/templates/menu_links.html:13 src/olympia/templates/impala/header_title.html:17
+#: src/olympia/pages/templates/pages/faq.html:273 src/olympia/templates/menu_links.html:13 src/olympia/templates/impala/header_title.html:17
 msgid "Mobile Add-ons"
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:278
+#: src/olympia/pages/templates/pages/faq.html:276
 msgid "What are mobile add-ons?"
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:279
+#: src/olympia/pages/templates/pages/faq.html:277
 #, python-format
 msgid ""
 "Mobile add-ons work with <a href=\"%(mobile_url)s\">Firefox for Mobile</a> and add or modify functionality just like desktop add-ons. You can find add-ons that work with Firefox for Mobile in our "
 "<a href=\"%(gallery_url)s\">gallery</a>."
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:288
+#: src/olympia/pages/templates/pages/faq.html:286
 msgid "Developer Topics"
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:289
+#: src/olympia/pages/templates/pages/faq.html:287
 #, python-format
 msgid "Please see our <a href=\"%(faq_url)s\">Developer FAQ</a> and <a href=\"%(hub_url)s\">Developer Hub</a> for answers to add-on developer-related questions."
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:294
+#: src/olympia/pages/templates/pages/faq.html:292
 msgid "Still have questions?"
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:295
+#: src/olympia/pages/templates/pages/faq.html:293
 #, python-format
 msgid "For general Firefox support, visit our <a href=\"%(sumo_url)s\">support website</a>. For general add-on and website questions, visit our <a href=\"%(forum_url)s\">forum</a>."
 msgstr ""
@@ -10431,7 +10273,7 @@ msgstr ""
 
 #: src/olympia/pages/templates/pages/sunbird.html:29
 msgid ""
-"Development on the Sunbird project has halted and its final release was on March 30, 2010.  We've been proud to host Sunbird add-ons on this site but as the project is no longer maintained we have "
+"Development on the Sunbird project has halted and its final release was on March 30, 2010. We've been proud to host Sunbird add-ons on this site but as the project is no longer maintained we have "
 "disabled our support for the add-ons."
 msgstr ""
 
@@ -10509,7 +10351,7 @@ msgstr ""
 #, python-format
 msgid ""
 "<h2>Keep these tips in mind:</h2> <ul> <li> Write like you're telling a friend about your experience with the add-on. Give specifics and helpful details, such as what features you liked and/or "
-"disliked, how easy to use it is, and any disadvantages it has.  Avoid generic language such as calling it \"Great\" or \"Bad\" unless you can give reasons why you believe this is so. </li> <li> "
+"disliked, how easy to use it is, and any disadvantages it has. Avoid generic language such as calling it \"Great\" or \"Bad\" unless you can give reasons why you believe this is so. </li> <li> "
 "Please do not post bug reports in reviews. We do not make your email address available to add-on developers and they may need to contact you to help resolve your issue. See the <a href=\"%(support)s"
 "\">support section</a> to find out where to get assistance for this add-on. </li> <li>Please keep reviews clean, avoid the use of improper language and do not post any personal information. </li> </"
 "ul> <p>Please read the <a href=\"%(guide)s\" target=\"_blank\">Review Guidelines</a> for more detail about user add-on reviews.</p>"
@@ -10745,16 +10587,16 @@ msgstr ""
 
 #. L10n: {0} is an application, such as Firefox. This means "any version of
 #. Firefox."
-#: src/olympia/search/views.py:554
+#: src/olympia/search/views.py:547
 msgid "Any {0}"
 msgstr ""
 
 #. L10n: "All Systems" means show everything regardless of platform.
-#: src/olympia/search/views.py:589
+#: src/olympia/search/views.py:582
 msgid "All Systems"
 msgstr ""
 
-#: src/olympia/search/views.py:600
+#: src/olympia/search/views.py:593
 msgid "All Tags"
 msgstr ""
 
@@ -10928,31 +10770,31 @@ msgstr ""
 msgid "Share this Collection"
 msgstr ""
 
-#: src/olympia/signing/views.py:30 src/olympia/templates/base.html:75 src/olympia/templates/impala/base.html:115
+#: src/olympia/signing/views.py:33 src/olympia/templates/base.html:71 src/olympia/templates/impala/base.html:112
 msgid "Some features are temporarily disabled while we perform website maintenance. We'll be back to full capacity shortly."
 msgstr ""
 
-#: src/olympia/signing/views.py:53
+#: src/olympia/signing/views.py:56
 msgid "Could not find add-on with id \"{}\"."
 msgstr ""
 
-#: src/olympia/signing/views.py:67
+#: src/olympia/signing/views.py:70
 msgid "You do not own this addon."
 msgstr ""
 
-#: src/olympia/signing/views.py:82
+#: src/olympia/signing/views.py:87
 msgid "Missing \"upload\" key in multipart file data."
 msgstr ""
 
-#: src/olympia/signing/views.py:96
+#: src/olympia/signing/views.py:101
 msgid "Version does not match the manifest file."
 msgstr ""
 
-#: src/olympia/signing/views.py:100
+#: src/olympia/signing/views.py:105
 msgid "Version already exists."
 msgstr ""
 
-#: src/olympia/signing/views.py:136
+#: src/olympia/signing/views.py:141
 msgid "No uploaded file for that addon and version."
 msgstr ""
 
@@ -11065,89 +10907,89 @@ msgstr ""
 msgid "Statistics Dashboard :: Add-ons for {0}"
 msgstr ""
 
-#: src/olympia/stats/templates/stats/stats.html:30
-msgid "Controls:"
-msgstr ""
-
-#: src/olympia/stats/templates/stats/stats.html:33
-msgid "reset zoom"
-msgstr ""
-
-#: src/olympia/stats/templates/stats/stats.html:40
-msgid "Group by:"
-msgstr ""
-
-#: src/olympia/stats/templates/stats/stats.html:42
-msgid "day"
-msgstr ""
-
-#: src/olympia/stats/templates/stats/stats.html:45
-msgid "week"
-msgstr ""
-
-#: src/olympia/stats/templates/stats/stats.html:48
-msgid "month"
-msgstr ""
-
-#: src/olympia/stats/templates/stats/stats.html:54
-msgid "For last:"
-msgstr ""
-
-#: src/olympia/stats/templates/stats/stats.html:57
-msgid "7 days"
-msgstr ""
-
-#: src/olympia/stats/templates/stats/stats.html:60
-msgid "30 days"
-msgstr ""
-
-#: src/olympia/stats/templates/stats/stats.html:63
-msgid "90 days"
-msgstr ""
-
-#: src/olympia/stats/templates/stats/stats.html:66
-msgid "365 days"
-msgstr ""
-
-#: src/olympia/stats/templates/stats/stats.html:69
-msgid "Custom..."
-msgstr ""
-
 #. {0} is an add-on name
-#: src/olympia/stats/templates/stats/stats.html:88 src/olympia/stats/templates/stats/stats.html:91
+#: src/olympia/stats/templates/stats/stats.html:44 src/olympia/stats/templates/stats/stats.html:47
 msgid "Statistics for {0}"
 msgstr ""
 
-#: src/olympia/stats/templates/stats/stats.html:94
+#: src/olympia/stats/templates/stats/stats.html:50
 msgid "Statistics Dashboard"
 msgstr ""
 
-#: src/olympia/stats/templates/stats/stats.html:104
+#: src/olympia/stats/templates/stats/stats.html:57
+msgid "Controls:"
+msgstr ""
+
+#: src/olympia/stats/templates/stats/stats.html:60
+msgid "reset zoom"
+msgstr ""
+
+#: src/olympia/stats/templates/stats/stats.html:67
+msgid "Group by:"
+msgstr ""
+
+#: src/olympia/stats/templates/stats/stats.html:69
+msgid "day"
+msgstr ""
+
+#: src/olympia/stats/templates/stats/stats.html:72
+msgid "week"
+msgstr ""
+
+#: src/olympia/stats/templates/stats/stats.html:75
+msgid "month"
+msgstr ""
+
+#: src/olympia/stats/templates/stats/stats.html:81
+msgid "For last:"
+msgstr ""
+
+#: src/olympia/stats/templates/stats/stats.html:84
+msgid "7 days"
+msgstr ""
+
+#: src/olympia/stats/templates/stats/stats.html:87
+msgid "30 days"
+msgstr ""
+
+#: src/olympia/stats/templates/stats/stats.html:90
+msgid "90 days"
+msgstr ""
+
+#: src/olympia/stats/templates/stats/stats.html:93
+msgid "365 days"
+msgstr ""
+
+#: src/olympia/stats/templates/stats/stats.html:96
+msgid "Custom..."
+msgstr ""
+
+#: src/olympia/stats/templates/stats/stats.html:106
 msgid "Statistics processing is currently disabled, so recent data is unavailable. The statistics are still being collected and this page will be updated soon with the missing data."
 msgstr ""
 
-#: src/olympia/stats/templates/stats/stats.html:110
+#: src/olympia/stats/templates/stats/stats.html:112
 msgid "Loading the latest data&hellip;"
 msgstr ""
 
-#: src/olympia/stats/templates/stats/stats.html:142 src/olympia/stats/templates/stats/reports/overview.html:25 src/olympia/stats/templates/stats/reports/overview.html:37
+#: src/olympia/stats/templates/stats/stats.html:144 src/olympia/stats/templates/stats/reports/overview.html:25 src/olympia/stats/templates/stats/reports/overview.html:37
 #: src/olympia/stats/templates/stats/reports/overview.html:49
 msgid "No data available."
 msgstr ""
 
-#: src/olympia/stats/templates/stats/stats.html:177
+#: src/olympia/stats/templates/stats/stats.html:179
 msgid "This dashboard is currently <b>public</b>."
 msgstr ""
 
-#: src/olympia/stats/templates/stats/stats.html:179
+#: src/olympia/stats/templates/stats/stats.html:181
 msgid "Contribution stats are currently <b>private</b>."
 msgstr ""
 
-#: src/olympia/stats/templates/stats/stats.html:182
+#: src/olympia/stats/templates/stats/stats.html:184
 msgid "This dashboard is currently <b>private</b>."
 msgstr ""
 
-#: src/olympia/stats/templates/stats/stats.html:185
+#: src/olympia/stats/templates/stats/stats.html:187
 msgid "Change settings."
 msgstr ""
 
@@ -11299,15 +11141,6 @@ msgstr ""
 msgid "Application versions by Date"
 msgstr ""
 
-#: src/olympia/tags/templates/tags/top_cloud.html:4
-msgid "Top {0} Tags"
-msgstr ""
-
-#. {0} is the current application name
-#: src/olympia/tags/templates/tags/top_cloud.html:14
-msgid "{0} Top Tags"
-msgstr ""
-
 #: src/olympia/templates/amo_footer.html:6 src/olympia/templates/includes/lang_switcher.html:2
 msgid "Other languages"
 msgstr ""
@@ -11316,11 +11149,11 @@ msgstr ""
 msgid "Mozilla Add-ons"
 msgstr ""
 
-#: src/olympia/templates/base.html:91 src/olympia/templates/impala/base.html:81
+#: src/olympia/templates/base.html:89 src/olympia/templates/impala/base.html:78
 msgid "Find add-ons for other applications"
 msgstr ""
 
-#: src/olympia/templates/base.html:92 src/olympia/templates/impala/base.html:81
+#: src/olympia/templates/base.html:90 src/olympia/templates/impala/base.html:78
 msgid "Other Applications"
 msgstr ""
 
@@ -11345,7 +11178,7 @@ msgid "View Mobile Site"
 msgstr ""
 
 #: src/olympia/templates/copyright.html:7
-msgid "Site Status "
+msgid "Site Status"
 msgstr ""
 
 #: src/olympia/templates/footer.html:3
@@ -11445,35 +11278,35 @@ msgstr ""
 msgid "<a href=\"%(reg)s\">Register</a> or <a href=\"%(login)s\">Log in</a>"
 msgstr ""
 
-#: src/olympia/templates/impala/base.html:126
+#: src/olympia/templates/impala/base.html:123
 #, python-format
 msgid "To try the thousands of add-ons available here, download <a href=\"%(url)s\">Mozilla Firefox</a>, a fast, free way to surf the Web!"
 msgstr ""
 
-#: src/olympia/templates/impala/base.html:138
+#: src/olympia/templates/impala/base.html:135
 #, python-format
 msgid "Add-ons is switching to Firefox Accounts for login. <a href=\"%(url)s\" class=\"fxa-login\">Sign in now to transfer your account.</a>"
 msgstr ""
 
 #. {0} is an application, such as Firefox.
-#: src/olympia/templates/impala/base.html:148
+#: src/olympia/templates/impala/base.html:145
 msgid "Welcome to {0} Add-ons."
 msgstr ""
 
-#: src/olympia/templates/impala/base.html:151
+#: src/olympia/templates/impala/base.html:148
 msgid "Choose from thousands of extra features and styles to make Firefox your own."
 msgstr ""
 
-#: src/olympia/templates/impala/base.html:156
+#: src/olympia/templates/impala/base.html:153
 #, python-format
 msgid "Add extra features and styles to make %(app)s your own."
 msgstr ""
 
-#: src/olympia/templates/impala/base.html:164
+#: src/olympia/templates/impala/base.html:161
 msgid "On the go?"
 msgstr ""
 
-#: src/olympia/templates/impala/base.html:166
+#: src/olympia/templates/impala/base.html:163
 msgid "Check out our <a class=\"mobile-link\" href=\"#\">Mobile Add-ons site</a>."
 msgstr ""
 
@@ -11697,19 +11530,19 @@ msgstr ""
 
 #. L10n: {id} will be something like "13ad6a", just a random number
 #. to differentiate this user from other anonymous users.
-#: src/olympia/users/models.py:353
+#: src/olympia/users/models.py:362
 msgid "Anonymous user {id}"
 msgstr ""
 
-#: src/olympia/users/models.py:410
+#: src/olympia/users/models.py:419
 msgid "Your account has been restricted"
 msgstr ""
 
-#: src/olympia/users/models.py:480
+#: src/olympia/users/models.py:489
 msgid "Please confirm your email address"
 msgstr ""
 
-#: src/olympia/users/models.py:506
+#: src/olympia/users/models.py:515
 msgid "My Mobile Add-ons"
 msgstr ""
 
@@ -11986,7 +11819,7 @@ msgstr ""
 
 #: src/olympia/users/templates/users/edit.html:70
 #, python-format
-msgid "Change your password.  If you forgot your password, you can <a href=\"%(reset_url)s\">use the reset form</a>."
+msgid "Change your password. If you forgot your password, you can <a href=\"%(reset_url)s\">use the reset form</a>."
 msgstr ""
 
 #: src/olympia/users/templates/users/edit.html:76
@@ -12006,7 +11839,7 @@ msgid "Profile"
 msgstr ""
 
 #: src/olympia/users/templates/users/edit.html:100
-msgid "Give us a bit more information about yourself.  All these fields are optional, but they'll help other users get to know you better."
+msgid "Give us a bit more information about yourself. All these fields are optional, but they'll help other users get to know you better."
 msgstr ""
 
 #: src/olympia/users/templates/users/edit.html:124
@@ -12222,7 +12055,7 @@ msgid "Confirm password"
 msgstr ""
 
 #: src/olympia/users/templates/users/pwreset_confirm.html:47
-msgid "The password reset link was invalid, possibly because it has already been used.  Please request a new password reset."
+msgid "The password reset link was invalid, possibly because it has already been used. Please request a new password reset."
 msgstr ""
 
 #: src/olympia/users/templates/users/pwreset_request.html:15
@@ -12408,7 +12241,7 @@ msgstr ""
 
 #: src/olympia/users/templates/users/unsubscribe.html:30
 #, python-format
-msgid "Unfortunately, we weren't able to unsubscribe you.  The link you clicked is invalid. However, you can unsubscribe still unsubscribe on your <a href=\"%(edit_url)s\">edit profile page</a>."
+msgid "Unfortunately, we weren't able to unsubscribe you. The link you clicked is invalid. However, you can unsubscribe still unsubscribe on your <a href=\"%(edit_url)s\">edit profile page</a>."
 msgstr ""
 
 #: src/olympia/users/templates/users/vcard.html:2
@@ -12462,15 +12295,15 @@ msgstr ""
 msgid "Version History with Changelogs"
 msgstr ""
 
-#: src/olympia/versions/models.py:314
+#: src/olympia/versions/models.py:313
 msgid "Add-on uses binary components."
 msgstr ""
 
-#: src/olympia/versions/models.py:317
+#: src/olympia/versions/models.py:316
 msgid "Add-on has opted into strict compatibility checking."
 msgstr ""
 
-#: src/olympia/versions/models.py:715
+#: src/olympia/versions/models.py:711
 msgid "{app} {min} and later"
 msgstr ""
 
@@ -12545,4 +12378,8 @@ msgstr ""
 
 #: src/olympia/zadmin/forms.py:105
 msgid "Log emails instead of sending"
+msgstr ""
+
+#: src/olympia/zadmin/forms.py:215
+msgid "Deleted versions can`t be changed."
 msgstr ""

--- a/locale/hi_IN/LC_MESSAGES/djangojs.po
+++ b/locale/hi_IN/LC_MESSAGES/djangojs.po
@@ -1,1216 +1,1236 @@
-
 #, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2016-02-24 21:23+0000\n"
+"POT-Creation-Date: 2016-04-18 15:47+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
+"Language: \n"
 "MIME-Version: 1.0\n"
-"Content-Type: text/plain; charset=utf-8\n"
+"Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Generated-By: Babel 2.2.0\n"
 
-#: static/js/common/ratingwidget.js:31
+#: static/js/common-all.js:1426 static/js/impala-all.js:1511 static/js/zamboni/discovery-all.js:12598 static/js/zamboni/init.js:28 static/js/zamboni/mobile-all.js:14945
+msgid "This feature is temporarily disabled while we perform website maintenance. Please check back a little later."
+msgstr ""
+
+#. L10n: {0} is an app name like Firefox.
+#: static/js/common-all.js:1837 static/js/impala-all.js:1922 static/js/zamboni/buttons.js:73 static/js/zamboni/discovery-all.js:13108
+msgid "Accept and Install"
+msgstr ""
+
+#: static/js/common-all.js:1837 static/js/impala-all.js:1922 static/js/zamboni/buttons.js:73 static/js/zamboni/discovery-all.js:13108
+msgid "Add to {0}"
+msgstr ""
+
+#: static/js/common-all.js:1842 static/js/impala-all.js:1927 static/js/zamboni/buttons.js:78 static/js/zamboni/discovery-all.js:13113
+msgid "Download Now"
+msgstr ""
+
+#: static/js/common-all.js:1883 static/js/impala-all.js:1968 static/js/zamboni/buttons.js:119 static/js/zamboni/discovery-all.js:13154
+msgid "Add-on has not been updated to support default-to-compatible."
+msgstr ""
+
+#: static/js/common-all.js:1888 static/js/impala-all.js:1973 static/js/zamboni/buttons.js:124 static/js/zamboni/discovery-all.js:13159
+msgid "You need to be using Firefox 10.0 or higher."
+msgstr ""
+
+#: static/js/common-all.js:1900 static/js/impala-all.js:1985 static/js/zamboni/buttons.js:136 static/js/zamboni/discovery-all.js:13171
+msgid "Mozilla has marked this version as incompatible with your Firefox version."
+msgstr ""
+
+#. L10n: {0} is an platform like Windows or Linux.
+#: static/js/common-all.js:1981 static/js/impala-all.js:2066 static/js/zamboni/buttons.js:217 static/js/zamboni/discovery-all.js:13252
+msgid "Install for {0} anyway"
+msgstr ""
+
+#: static/js/common-all.js:1981 static/js/impala-all.js:2066 static/js/zamboni/buttons.js:217 static/js/zamboni/discovery-all.js:13252
+msgid "Download for {0} anyway"
+msgstr ""
+
+#: static/js/common-all.js:2038 static/js/impala-all.js:2123 static/js/zamboni/buttons.js:274 static/js/zamboni/discovery-all.js:13309
+msgid "Not available for your platform"
+msgstr ""
+
+#. L10n: {0} is an app name, {1} is the app version.
+#: static/js/common-all.js:2049 static/js/common-all.js:2086 static/js/impala-all.js:2134 static/js/impala-all.js:2171 static/js/zamboni/buttons.js:286 static/js/zamboni/buttons.js:324
+#: static/js/zamboni/discovery-all.js:13320 static/js/zamboni/discovery-all.js:13357
+msgid "Not available for {0} {1}"
+msgstr ""
+
+#: static/js/common-all.js:2112 static/js/impala-all.js:2197 static/js/zamboni/buttons.js:351 static/js/zamboni/discovery-all.js:13383
+msgid "Works with {app} {min} - {max}"
+msgstr ""
+
+#: static/js/common-all.js:2114 static/js/impala-all.js:2199 static/js/zamboni/buttons.js:353 static/js/zamboni/discovery-all.js:13385
+msgid "View other versions"
+msgstr ""
+
+#: static/js/common-all.js:2162 static/js/impala-all.js:2247 static/js/zamboni/buttons.js:401 static/js/zamboni/discovery-all.js:13433
+msgid "Only with Firefox — Get Firefox Now!"
+msgstr ""
+
+#: static/js/common-all.js:2278 static/js/impala-all.js:2363 static/js/zamboni/buttons.js:517 static/js/zamboni/discovery-all.js:13549 static/js/zamboni/mobile-all.js:15177
+#: static/js/zamboni/mobile/buttons.js:43
+msgid "Sorry, you need a Mozilla-based browser (such as Firefox) to install a search plugin."
+msgstr ""
+
+#: static/js/common-all.js:9088 static/js/impala-all.js:9649 static/js/zamboni/global.js:410
+msgid "Loading..."
+msgstr ""
+
+#. L10n: {0} is the number of characters left.
+#: static/js/common-all.js:9152 static/js/impala-all.js:9713 static/js/zamboni/global.js:474
+msgid "<b>{0}</b> character left."
+msgid_plural "<b>{0}</b> characters left."
+msgstr[0] ""
+msgstr[1] ""
+
+#: static/js/common-all.js:9589 static/js/common-min.js:6 static/js/impala-all.js:10052 static/js/impala-min.js:6 static/js/common/ratingwidget.js:31 static/js/zamboni/mobile-all.js:16123
+#: static/js/zamboni/mobile-min.js:6
 msgid "{0} star"
 msgid_plural "{0} stars"
 msgstr[0] ""
 msgstr[1] ""
 
-#: static/js/common/upload-addon.js:41 static/js/common/upload-image.js:128
+#: static/js/common-all.js:9676 static/js/common-min.js:6 static/js/impala-all.js:10139 static/js/impala-min.js:6 static/js/zamboni/l10n.js:45
+msgid "Remove this localization"
+msgstr ""
+
+#: static/js/common-all.js:10193 static/js/common-min.js:6 static/js/impala-all.js:10674 static/js/impala-min.js:6 static/js/zamboni/discovery-all.js:13678
+msgid "close"
+msgstr ""
+
+#: static/js/common-all.js:10860 static/js/common-min.js:6 static/js/impala-all.js:11481 static/js/impala-min.js:6 static/js/impala/reviews.js:23 static/js/zamboni/reviews.js:18
+msgid "Flagged for review"
+msgstr ""
+
+#: static/js/common-all.js:10876 static/js/common-min.js:6 static/js/impala-all.js:11498 static/js/impala-min.js:6 static/js/impala/reviews.js:40 static/js/zamboni/reviews.js:34
+msgid "Your input is required"
+msgstr ""
+
+#: static/js/common-all.js:10945 static/js/common-min.js:6 static/js/impala-all.js:11610 static/js/impala-min.js:7 static/js/impala/reviews.js:152 static/js/zamboni/reviews.js:103
+msgid "Marked for deletion"
+msgstr ""
+
+#: static/js/common-all.js:11573 static/js/common-min.js:7 static/js/impala-all.js:13809 static/js/impala-min.js:8 static/js/zamboni/collections.js:229
+msgid "Adding to Favorites&hellip;"
+msgstr ""
+
+#: static/js/common-all.js:11576 static/js/common-min.js:7 static/js/impala-all.js:13812 static/js/impala-min.js:8 static/js/zamboni/collections.js:232
+msgid "Removing Favorite&hellip;"
+msgstr ""
+
+#: static/js/common-all.js:11579 static/js/common-min.js:7 static/js/impala-all.js:13815 static/js/impala-min.js:8 static/js/zamboni/collections.js:235
+msgid "Add to Favorites"
+msgstr ""
+
+#: static/js/common-all.js:11582 static/js/common-min.js:7 static/js/impala-all.js:13818 static/js/impala-min.js:8 static/js/zamboni/collections.js:238
+msgid "Remove from Favorites"
+msgstr ""
+
+#: static/js/common-all.js:11647 static/js/common-min.js:7 static/js/impala-all.js:13883 static/js/impala-min.js:8 static/js/zamboni/collections.js:303
+msgid "Pending"
+msgstr ""
+
+#: static/js/common-all.js:11648 static/js/common-min.js:7 static/js/impala-all.js:13884 static/js/impala-min.js:8 static/js/zamboni/collections.js:304
+msgid "Add a comment"
+msgstr ""
+
+#: static/js/common-all.js:11648 static/js/common-min.js:7 static/js/impala-all.js:13884 static/js/impala-min.js:8 static/js/zamboni/collections.js:304
+msgid "Comment"
+msgstr ""
+
+#: static/js/common-all.js:11649 static/js/common-min.js:7 static/js/impala-all.js:13885 static/js/impala-min.js:8 static/js/zamboni/collections.js:305
+msgid "Remove this add-on from the collection"
+msgstr ""
+
+#: static/js/common-all.js:11649 static/js/common-all.js:11678 static/js/common-min.js:7 static/js/impala-all.js:13885 static/js/impala-all.js:13914 static/js/impala-min.js:8
+#: static/js/zamboni/collections.js:305 static/js/zamboni/collections.js:334
+msgid "Remove"
+msgstr ""
+
+#: static/js/common-all.js:11678 static/js/common-min.js:7 static/js/impala-all.js:13914 static/js/impala-min.js:8 static/js/zamboni/collections.js:334
+msgid "Remove this user as a contributor"
+msgstr ""
+
+#: static/js/common-all.js:11690 static/js/common-min.js:7 static/js/impala-all.js:13926 static/js/impala-min.js:8 static/js/zamboni/collections.js:346
+msgid "An email address is required."
+msgstr ""
+
+#: static/js/common-all.js:11708 static/js/common-min.js:7 static/js/impala-all.js:13944 static/js/impala-min.js:8 static/js/zamboni/collections.js:364
+msgid "You cannot add yourself as a contributor."
+msgstr ""
+
+#: static/js/common-all.js:11710 static/js/common-min.js:7 static/js/impala-all.js:13946 static/js/impala-min.js:8 static/js/zamboni/collections.js:366
+msgid "You have already added that user."
+msgstr ""
+
+#: static/js/common-all.js:11917 static/js/common-min.js:7 static/js/impala-all.js:14153 static/js/impala-min.js:8 static/js/zamboni/collections.js:573
+msgid "Add to favorites"
+msgstr ""
+
+#: static/js/common-all.js:11921 static/js/common-min.js:7 static/js/impala-all.js:14157 static/js/impala-min.js:8 static/js/zamboni/collections.js:577
+msgid "Remove from favorites"
+msgstr ""
+
+#: static/js/common-all.js:11939 static/js/common-min.js:7 static/js/impala-all.js:14175 static/js/impala-all.js:14233 static/js/impala-min.js:8 static/js/impala/collections.js:10
+#: static/js/zamboni/collections.js:595
+msgid "Follow this Collection"
+msgstr ""
+
+#: static/js/common-all.js:11948 static/js/common-min.js:7 static/js/impala-all.js:14184 static/js/impala-min.js:8 static/js/zamboni/collections.js:604
+msgid "Stop following"
+msgstr ""
+
+#: static/js/common-all.js:12096 static/js/common-min.js:7 static/js/zamboni/password-strength.js:20
+msgid "Password strength:"
+msgstr ""
+
+#: static/js/common-all.js:12102 static/js/common-min.js:7 static/js/zamboni/password-strength.js:26
+msgid "At least {0} character left."
+msgid_plural "At least {0} characters left."
+msgstr[0] ""
+msgstr[1] ""
+
+#: static/js/common-all.js:12286 static/js/common-min.js:7 static/js/impala-all.js:14632 static/js/impala-min.js:8 static/js/impala/suggestions.js:39
+msgid "Search themes for <b>{0}</b>"
+msgstr ""
+
+#: static/js/common-all.js:12288 static/js/common-min.js:7 static/js/impala-all.js:14634 static/js/impala-min.js:8 static/js/impala/suggestions.js:41
+msgid "Search apps for <b>{0}</b>"
+msgstr ""
+
+#: static/js/common-all.js:12290 static/js/common-min.js:7 static/js/impala-all.js:14636 static/js/impala-min.js:8 static/js/impala/suggestions.js:43
+msgid "Search add-ons for <b>{0}</b>"
+msgstr ""
+
+#: static/js/common-all.js:12521 static/js/common-min.js:7 static/js/impala-all.js:14867 static/js/impala-min.js:8 static/js/impala/site_suggestions.js:46
+msgid "Category"
+msgstr ""
+
+#. L10n: {0} is an app name.
+#: static/js/impala-all.js:11632 static/js/impala-min.js:7 static/js/impala/listing.js:11 static/js/zamboni/themes.js:13
+msgid "This theme is incompatible with your version of {0}"
+msgstr ""
+
+#: static/js/impala-all.js:12146 static/js/impala-all.js:14331 static/js/impala-min.js:7 static/js/impala-min.js:8 static/js/common/upload-image.js:97 static/js/impala/users.js:51
+#: static/js/zamboni/devhub-all.js:894 static/js/zamboni/devhub-min.js:1
+msgid "Images must be either PNG or JPG."
+msgstr ""
+
+#: static/js/impala-all.js:12150 static/js/impala-min.js:7 static/js/common/upload-image.js:101 static/js/zamboni/devhub-all.js:898 static/js/zamboni/devhub-min.js:1
+msgid "Videos must be in WebM."
+msgstr ""
+
+#: static/js/impala-all.js:12177 static/js/impala-min.js:7 static/js/common/upload-addon.js:41 static/js/common/upload-image.js:128 static/js/zamboni/devhub-all.js:272
+#: static/js/zamboni/devhub-all.js:925 static/js/zamboni/devhub-min.js:1
 msgid "There was a problem contacting the server."
 msgstr ""
 
-#: static/js/common/upload-addon.js:69
+#: static/js/impala-all.js:13298 static/js/impala-min.js:7 static/js/impala/persona_creation.js:60
+msgid "All Rights Reserved"
+msgstr ""
+
+#: static/js/impala-all.js:13302 static/js/impala-min.js:7 static/js/impala/persona_creation.js:64
+msgid "Creative Commons Attribution 3.0"
+msgstr ""
+
+#: static/js/impala-all.js:13307 static/js/impala-min.js:7 static/js/impala/persona_creation.js:69
+msgid "Creative Commons Attribution-NonCommercial 3.0"
+msgstr ""
+
+#: static/js/impala-all.js:13312 static/js/impala-min.js:7 static/js/impala/persona_creation.js:74
+msgid "Creative Commons Attribution-NonCommercial-NoDerivs 3.0"
+msgstr ""
+
+#: static/js/impala-all.js:13317 static/js/impala-min.js:7 static/js/impala/persona_creation.js:79
+msgid "Creative Commons Attribution-NonCommercial-Share Alike 3.0"
+msgstr ""
+
+#: static/js/impala-all.js:13322 static/js/impala-min.js:7 static/js/impala/persona_creation.js:84
+msgid "Creative Commons Attribution-NoDerivs 3.0"
+msgstr ""
+
+#: static/js/impala-all.js:13327 static/js/impala-min.js:7 static/js/impala/persona_creation.js:89
+msgid "Creative Commons Attribution-ShareAlike 3.0"
+msgstr ""
+
+#: static/js/impala-all.js:13530 static/js/impala-min.js:7 static/js/impala/persona_creation.js:292
+msgid "Your Theme's Name"
+msgstr ""
+
+#: static/js/impala-all.js:14242 static/js/impala-min.js:8 static/js/impala/collections.js:19
+msgid "Stop Following"
+msgstr ""
+
+#: static/js/impala-all.js:14243 static/js/impala-min.js:8 static/js/impala/collections.js:20
+msgid "Following"
+msgstr ""
+
+#: static/js/impala-all.js:14313 static/js/impala-min.js:8 static/js/impala/users.js:33
+msgid "use original"
+msgstr ""
+
+#: static/js/impala-all.js:14523 static/js/impala-min.js:8 static/js/impala/search.js:114
+msgid "Updating results&hellip;"
+msgstr ""
+
+#: static/js/common/upload-addon.js:69 static/js/zamboni/devhub-all.js:300 static/js/zamboni/devhub-min.js:1
 msgid "Select a file..."
 msgstr ""
 
-#: static/js/common/upload-addon.js:70
+#: static/js/common/upload-addon.js:70 static/js/zamboni/devhub-all.js:301 static/js/zamboni/devhub-min.js:1
 msgid "Your add-on should end with .xpi, .jar or .xml"
 msgstr ""
 
 #. L10n: {0} is the percent of the file that has been uploaded.
-#: static/js/common/upload-addon.js:104
+#: static/js/common/upload-addon.js:104 static/js/zamboni/devhub-all.js:335 static/js/zamboni/devhub-min.js:1
 #, python-format
 msgid "{0}% complete"
 msgstr ""
 
 #. L10n: "{bytes uploaded} of {total filesize}".
-#: static/js/common/upload-addon.js:107
+#: static/js/common/upload-addon.js:107 static/js/zamboni/devhub-all.js:338 static/js/zamboni/devhub-min.js:1
 msgid "{0} of {1}"
 msgstr ""
 
-#: static/js/common/upload-addon.js:140
+#: static/js/common/upload-addon.js:140 static/js/zamboni/devhub-all.js:371 static/js/zamboni/devhub-min.js:1
 msgid "Cancel"
 msgstr ""
 
-#: static/js/common/upload-addon.js:162
+#: static/js/common/upload-addon.js:162 static/js/zamboni/devhub-all.js:393 static/js/zamboni/devhub-min.js:1
 msgid "Uploading {0}"
 msgstr ""
 
-#: static/js/common/upload-addon.js:189
+#: static/js/common/upload-addon.js:189 static/js/zamboni/devhub-all.js:420 static/js/zamboni/devhub-min.js:1
 msgid "Error with {0}"
 msgstr ""
 
-#: static/js/common/upload-addon.js:194
+#: static/js/common/upload-addon.js:194 static/js/zamboni/devhub-all.js:425 static/js/zamboni/devhub-min.js:1
 msgid "Your add-on failed validation with {0} error."
 msgid_plural "Your add-on failed validation with {0} errors."
 msgstr[0] ""
 msgstr[1] ""
 
-#: static/js/common/upload-addon.js:208
+#: static/js/common/upload-addon.js:208 static/js/zamboni/devhub-all.js:439 static/js/zamboni/devhub-min.js:1
 msgid "&hellip;and {0} more"
 msgid_plural "&hellip;and {0} more"
 msgstr[0] ""
 msgstr[1] ""
 
-#: static/js/common/upload-addon.js:222 static/js/common/upload-addon.js:512
+#: static/js/common/upload-addon.js:222 static/js/common/upload-addon.js:497 static/js/zamboni/devhub-all.js:453 static/js/zamboni/devhub-all.js:743 static/js/zamboni/devhub-min.js:1
 msgid "See full validation report"
 msgstr ""
 
-#: static/js/common/upload-addon.js:234
+#: static/js/common/upload-addon.js:234 static/js/zamboni/devhub-all.js:465 static/js/zamboni/devhub-min.js:1
 msgid "Validating {0}"
 msgstr ""
 
 #. L10n: first argument is an HTTP status code
-#: static/js/common/upload-addon.js:273
+#: static/js/common/upload-addon.js:273 static/js/zamboni/devhub-all.js:504 static/js/zamboni/devhub-min.js:1
 msgid "Received an empty response from the server; status: {0}"
 msgstr ""
 
-#: static/js/common/upload-addon.js:373
+#: static/js/common/upload-addon.js:370 static/js/zamboni/devhub-all.js:604 static/js/zamboni/devhub-min.js:1
 msgid "Unexpected server error while validating."
 msgstr ""
 
-#: static/js/common/upload-addon.js:412
+#: static/js/common/upload-addon.js:409 static/js/zamboni/devhub-all.js:643 static/js/zamboni/devhub-min.js:1
 msgid "Finished validating {0}"
 msgstr ""
 
-#: static/js/common/upload-addon.js:418
+#: static/js/common/upload-addon.js:415 static/js/zamboni/devhub-all.js:649 static/js/zamboni/devhub-min.js:1
 msgid "Your add-on validation timed out, it will be manually reviewed."
 msgstr ""
 
-#: static/js/common/upload-addon.js:421
+#: static/js/common/upload-addon.js:418 static/js/zamboni/devhub-all.js:652 static/js/zamboni/devhub-min.js:1
 msgid "Your add-on was validated with no errors and {0} warning."
 msgid_plural "Your add-on was validated with no errors and {0} warnings."
 msgstr[0] ""
 msgstr[1] ""
 
-#: static/js/common/upload-addon.js:426
+#: static/js/common/upload-addon.js:423 static/js/zamboni/devhub-all.js:657 static/js/zamboni/devhub-min.js:1
 msgid "Your add-on was validated with no errors and {0} message."
 msgid_plural "Your add-on was validated with no errors and {0} messages."
 msgstr[0] ""
 msgstr[1] ""
 
-#: static/js/common/upload-addon.js:431
+#: static/js/common/upload-addon.js:428 static/js/zamboni/devhub-all.js:662 static/js/zamboni/devhub-min.js:1
 msgid "Your add-on was validated with no errors or warnings."
 msgstr ""
 
-#: static/js/common/upload-addon.js:446
+#: static/js/common/upload-addon.js:443 static/js/zamboni/devhub-all.js:677 static/js/zamboni/devhub-min.js:1
 msgid "Your submission will be automatically signed."
 msgstr ""
 
-#: static/js/common/upload-addon.js:465
+#: static/js/common/upload-addon.js:450 static/js/zamboni/devhub-all.js:696 static/js/zamboni/devhub-min.js:1
 msgid "Include detailed version notes (this can be done in the next step)."
 msgstr ""
 
-#: static/js/common/upload-addon.js:466
+#: static/js/common/upload-addon.js:451 static/js/zamboni/devhub-all.js:697 static/js/zamboni/devhub-min.js:1
 msgid "If your add-on requires an account to a website in order to be fully tested, include a test username and password in the Notes to Reviewer (this can be done in the next step)."
 msgstr ""
 
-#: static/js/common/upload-addon.js:467
+#: static/js/common/upload-addon.js:452 static/js/zamboni/devhub-all.js:698 static/js/zamboni/devhub-min.js:1
 msgid "If your add-on is intended for a limited audience you should choose Preliminary Review instead of Full Review."
 msgstr ""
 
-#: static/js/common/upload-addon.js:480
+#: static/js/common/upload-addon.js:465 static/js/zamboni/devhub-all.js:711 static/js/zamboni/devhub-min.js:1
 msgid "Add-on submission checklist"
 msgstr ""
 
-#: static/js/common/upload-addon.js:481
+#: static/js/common/upload-addon.js:466 static/js/zamboni/devhub-all.js:712 static/js/zamboni/devhub-min.js:1
 msgid "Please verify the following points before finalizing your submission. This will minimize delays or misunderstanding during the review process:"
 msgstr ""
 
-#: static/js/common/upload-addon.js:483
+#: static/js/common/upload-addon.js:468 static/js/zamboni/devhub-all.js:714 static/js/zamboni/devhub-min.js:1
 msgid ""
 "Compiled binaries, as well as minified or obfuscated scripts (excluding known libraries) need to have their sources submitted separately for review. Make sure that you use the source code upload "
 "field to avoid having your submission rejected."
 msgstr ""
 
-#: static/js/common/upload-addon.js:501
+#: static/js/common/upload-addon.js:486 static/js/zamboni/devhub-all.js:732 static/js/zamboni/devhub-min.js:1
 msgid "The validation process found these issues that can lead to rejections:"
 msgstr ""
 
-#: static/js/common/upload-addon.js:518
+#: static/js/common/upload-addon.js:503 static/js/zamboni/devhub-all.js:749 static/js/zamboni/devhub-min.js:1
 msgid "If you are unfamiliar with the add-ons review process, you can read about it here."
 msgstr ""
 
-#: static/js/common/upload-addon.js:555
+#: static/js/common/upload-addon.js:540 static/js/zamboni/devhub-all.js:786 static/js/zamboni/devhub-min.js:1
 msgid "Sorry, no supported platform has been found."
 msgstr ""
 
-#: static/js/common/upload-base.js:57
+#: static/js/common/upload-base.js:57 static/js/zamboni/devhub-all.js:187 static/js/zamboni/devhub-min.js:1
 msgid "The filetype you uploaded isn't recognized."
 msgstr ""
 
-#: static/js/common/upload-base.js:79
+#: static/js/common/upload-base.js:79 static/js/zamboni/devhub-all.js:209 static/js/zamboni/devhub-min.js:1
 msgid "You cancelled the upload."
 msgstr ""
 
-#: static/js/common/upload-image.js:97 static/js/impala/users.js:51
-msgid "Images must be either PNG or JPG."
-msgstr ""
-
-#: static/js/common/upload-image.js:101
-msgid "Videos must be in WebM."
-msgstr ""
-
-#: static/js/impala/collections.js:10 static/js/zamboni/collections.js:595
-msgid "Follow this Collection"
-msgstr ""
-
-#: static/js/impala/collections.js:19
-msgid "Stop Following"
-msgstr ""
-
-#: static/js/impala/collections.js:20
-msgid "Following"
-msgstr ""
-
-#. L10n: {0} is an app name.
-#: static/js/impala/listing.js:11 static/js/zamboni/themes.js:13
-msgid "This theme is incompatible with your version of {0}"
-msgstr ""
-
-#: static/js/impala/persona_creation.js:60
-msgid "All Rights Reserved"
-msgstr ""
-
-#: static/js/impala/persona_creation.js:64
-msgid "Creative Commons Attribution 3.0"
-msgstr ""
-
-#: static/js/impala/persona_creation.js:69
-msgid "Creative Commons Attribution-NonCommercial 3.0"
-msgstr ""
-
-#: static/js/impala/persona_creation.js:74
-msgid "Creative Commons Attribution-NonCommercial-NoDerivs 3.0"
-msgstr ""
-
-#: static/js/impala/persona_creation.js:79
-msgid "Creative Commons Attribution-NonCommercial-Share Alike 3.0"
-msgstr ""
-
-#: static/js/impala/persona_creation.js:84
-msgid "Creative Commons Attribution-NoDerivs 3.0"
-msgstr ""
-
-#: static/js/impala/persona_creation.js:89
-msgid "Creative Commons Attribution-ShareAlike 3.0"
-msgstr ""
-
-#: static/js/impala/persona_creation.js:292
-msgid "Your Theme's Name"
-msgstr ""
-
-#: static/js/impala/reviews.js:23 static/js/zamboni/reviews.js:18
-msgid "Flagged for review"
-msgstr ""
-
-#: static/js/impala/reviews.js:40 static/js/zamboni/reviews.js:34
-msgid "Your input is required"
-msgstr ""
-
-#: static/js/impala/reviews.js:152 static/js/zamboni/reviews.js:103
-msgid "Marked for deletion"
-msgstr ""
-
-#: static/js/impala/search.js:114
-msgid "Updating results&hellip;"
-msgstr ""
-
-#: static/js/impala/site_suggestions.js:46
-msgid "Category"
-msgstr ""
-
-#: static/js/impala/suggestions.js:39
-msgid "Search themes for <b>{0}</b>"
-msgstr ""
-
-#: static/js/impala/suggestions.js:41
-msgid "Search apps for <b>{0}</b>"
-msgstr ""
-
-#: static/js/impala/suggestions.js:43
-msgid "Search add-ons for <b>{0}</b>"
-msgstr ""
-
-#: static/js/impala/users.js:33
-msgid "use original"
-msgstr ""
-
-#: static/js/impala/stats/chart.js:267
+#: static/js/impala/stats/chart.js:267 static/js/zamboni/stats-all.js:16898 static/js/zamboni/stats-min.js:5
 msgid "Week of {0}"
 msgstr ""
 
-#: static/js/impala/stats/chart.js:269
+#: static/js/impala/stats/chart.js:269 static/js/zamboni/stats-all.js:16900 static/js/zamboni/stats-min.js:5
 msgid " downloads"
 msgstr ""
 
-#: static/js/impala/stats/chart.js:270
+#: static/js/impala/stats/chart.js:270 static/js/zamboni/stats-all.js:16901 static/js/zamboni/stats-min.js:5
 msgid "{0} users"
 msgstr ""
 
-#: static/js/impala/stats/chart.js:271
+#: static/js/impala/stats/chart.js:271 static/js/zamboni/stats-all.js:16902 static/js/zamboni/stats-min.js:5
 msgid "{0} add-ons"
 msgstr ""
 
-#: static/js/impala/stats/chart.js:272
+#: static/js/impala/stats/chart.js:272 static/js/zamboni/stats-all.js:16903 static/js/zamboni/stats-min.js:5
 msgid "{0} collections"
 msgstr ""
 
-#: static/js/impala/stats/chart.js:273
+#: static/js/impala/stats/chart.js:273 static/js/zamboni/stats-all.js:16904 static/js/zamboni/stats-min.js:5
 msgid "{0} reviews"
 msgstr ""
 
-#: static/js/impala/stats/chart.js:275
+#: static/js/impala/stats/chart.js:275 static/js/zamboni/stats-all.js:16906 static/js/zamboni/stats-min.js:5
 msgid "{0} sales"
 msgstr ""
 
-#: static/js/impala/stats/chart.js:276
+#: static/js/impala/stats/chart.js:276 static/js/zamboni/stats-all.js:16907 static/js/zamboni/stats-min.js:5
 msgid "{0} refunds"
 msgstr ""
 
-#: static/js/impala/stats/chart.js:277
+#: static/js/impala/stats/chart.js:277 static/js/zamboni/stats-all.js:16908 static/js/zamboni/stats-min.js:5
 msgid "{0} installs"
 msgstr ""
 
-#: static/js/impala/stats/chart.js:369 static/js/impala/stats/csv_keys.js:3 static/js/impala/stats/csv_keys.js:109
+#: static/js/impala/stats/chart.js:369 static/js/impala/stats/csv_keys.js:3 static/js/impala/stats/csv_keys.js:109 static/js/zamboni/stats-all.js:15284 static/js/zamboni/stats-all.js:15390
+#: static/js/zamboni/stats-all.js:17000 static/js/zamboni/stats-min.js:4 static/js/zamboni/stats-min.js:5
 msgid "Downloads"
 msgstr ""
 
-#: static/js/impala/stats/chart.js:379 static/js/impala/stats/csv_keys.js:6 static/js/impala/stats/csv_keys.js:110
+#: static/js/impala/stats/chart.js:379 static/js/impala/stats/csv_keys.js:6 static/js/impala/stats/csv_keys.js:110 static/js/zamboni/stats-all.js:15287 static/js/zamboni/stats-all.js:15391
+#: static/js/zamboni/stats-all.js:17010 static/js/zamboni/stats-min.js:4 static/js/zamboni/stats-min.js:5
 msgid "Daily Users"
 msgstr ""
 
-#: static/js/impala/stats/chart.js:410
+#: static/js/impala/stats/chart.js:410 static/js/zamboni/stats-all.js:17041 static/js/zamboni/stats-min.js:5
 msgid "Amount, in USD"
 msgstr ""
 
-#: static/js/impala/stats/chart.js:421 static/js/impala/stats/csv_keys.js:104
+#: static/js/impala/stats/chart.js:421 static/js/impala/stats/csv_keys.js:104 static/js/zamboni/stats-all.js:15385 static/js/zamboni/stats-all.js:17052 static/js/zamboni/stats-min.js:5
 msgid "Number of Contributions"
 msgstr ""
 
-#: static/js/impala/stats/chart.js:447
+#: static/js/impala/stats/chart.js:447 static/js/zamboni/stats-all.js:17078 static/js/zamboni/stats-min.js:5
 msgid "More Info..."
 msgstr ""
 
 #. L10n: {0} is an ISO-formatted date.
-#: static/js/impala/stats/chart.js:451
+#: static/js/impala/stats/chart.js:451 static/js/zamboni/stats-all.js:17082 static/js/zamboni/stats-min.js:5
 msgid "Details for {0}"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:9
+#: static/js/impala/stats/csv_keys.js:9 static/js/zamboni/stats-all.js:15290 static/js/zamboni/stats-min.js:4
 msgid "Collections Created"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:12
+#: static/js/impala/stats/csv_keys.js:12 static/js/zamboni/stats-all.js:15293 static/js/zamboni/stats-min.js:4
 msgid "Add-ons in Use"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:15
+#: static/js/impala/stats/csv_keys.js:15 static/js/zamboni/stats-all.js:15296 static/js/zamboni/stats-min.js:4
 msgid "Add-ons Created"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:18
+#: static/js/impala/stats/csv_keys.js:18 static/js/zamboni/stats-all.js:15299 static/js/zamboni/stats-min.js:4
 msgid "Add-ons Downloaded"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:21
+#: static/js/impala/stats/csv_keys.js:21 static/js/zamboni/stats-all.js:15302 static/js/zamboni/stats-min.js:4
 msgid "Add-ons Updated"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:24
+#: static/js/impala/stats/csv_keys.js:24 static/js/zamboni/stats-all.js:15305 static/js/zamboni/stats-min.js:4
 msgid "Reviews Written"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:27
+#: static/js/impala/stats/csv_keys.js:27 static/js/zamboni/stats-all.js:15308 static/js/zamboni/stats-min.js:4
 msgid "User Signups"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:30
+#: static/js/impala/stats/csv_keys.js:30 static/js/zamboni/stats-all.js:15311 static/js/zamboni/stats-min.js:4
 msgid "Subscribers"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:33
+#: static/js/impala/stats/csv_keys.js:33 static/js/zamboni/stats-all.js:15314 static/js/zamboni/stats-min.js:4
 msgid "Ratings"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:36 static/js/impala/stats/csv_keys.js:114
+#: static/js/impala/stats/csv_keys.js:36 static/js/impala/stats/csv_keys.js:114 static/js/zamboni/stats-all.js:15317 static/js/zamboni/stats-all.js:15395 static/js/zamboni/stats-min.js:4
+#: static/js/zamboni/stats-min.js:5
 msgid "Sales"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:39 static/js/impala/stats/csv_keys.js:113
+#: static/js/impala/stats/csv_keys.js:39 static/js/impala/stats/csv_keys.js:113 static/js/zamboni/stats-all.js:15320 static/js/zamboni/stats-all.js:15394 static/js/zamboni/stats-min.js:4
+#: static/js/zamboni/stats-min.js:5
 msgid "Installs"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:42
+#: static/js/impala/stats/csv_keys.js:42 static/js/zamboni/stats-all.js:15323 static/js/zamboni/stats-min.js:4
 msgid "Unknown"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:43
+#: static/js/impala/stats/csv_keys.js:43 static/js/zamboni/stats-all.js:15324 static/js/zamboni/stats-min.js:4
 msgid "Add-ons Manager"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:44
+#: static/js/impala/stats/csv_keys.js:44 static/js/zamboni/stats-all.js:15325 static/js/zamboni/stats-min.js:4
 msgid "Add-ons Manager Promo"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:45
+#: static/js/impala/stats/csv_keys.js:45 static/js/zamboni/stats-all.js:15326 static/js/zamboni/stats-min.js:4
 msgid "Add-ons Manager Featured"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:46
+#: static/js/impala/stats/csv_keys.js:46 static/js/zamboni/stats-all.js:15327 static/js/zamboni/stats-min.js:4
 msgid "Add-ons Manager Learn More"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:47
+#: static/js/impala/stats/csv_keys.js:47 static/js/zamboni/stats-all.js:15328 static/js/zamboni/stats-min.js:4
 msgid "Search Suggestions"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:48
+#: static/js/impala/stats/csv_keys.js:48 static/js/zamboni/stats-all.js:15329 static/js/zamboni/stats-min.js:4
 msgid "Search Results"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:49 static/js/impala/stats/csv_keys.js:50 static/js/impala/stats/csv_keys.js:51
+#: static/js/impala/stats/csv_keys.js:49 static/js/impala/stats/csv_keys.js:50 static/js/impala/stats/csv_keys.js:51 static/js/zamboni/stats-all.js:15330 static/js/zamboni/stats-all.js:15331
+#: static/js/zamboni/stats-all.js:15332 static/js/zamboni/stats-min.js:4
 msgid "Homepage Promo"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:52 static/js/impala/stats/csv_keys.js:53
+#: static/js/impala/stats/csv_keys.js:52 static/js/impala/stats/csv_keys.js:53 static/js/zamboni/stats-all.js:15333 static/js/zamboni/stats-all.js:15334 static/js/zamboni/stats-min.js:4
 msgid "Homepage Featured"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:54 static/js/impala/stats/csv_keys.js:55
+#: static/js/impala/stats/csv_keys.js:54 static/js/impala/stats/csv_keys.js:55 static/js/zamboni/stats-all.js:15335 static/js/zamboni/stats-all.js:15336 static/js/zamboni/stats-min.js:4
 msgid "Homepage Up and Coming"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:56
+#: static/js/impala/stats/csv_keys.js:56 static/js/zamboni/stats-all.js:15337 static/js/zamboni/stats-min.js:4
 msgid "Homepage Most Popular"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:57 static/js/impala/stats/csv_keys.js:59
+#: static/js/impala/stats/csv_keys.js:57 static/js/impala/stats/csv_keys.js:59 static/js/zamboni/stats-all.js:15338 static/js/zamboni/stats-all.js:15340 static/js/zamboni/stats-min.js:4
 msgid "Detail Page"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:58 static/js/impala/stats/csv_keys.js:60
+#: static/js/impala/stats/csv_keys.js:58 static/js/impala/stats/csv_keys.js:60 static/js/zamboni/stats-all.js:15339 static/js/zamboni/stats-all.js:15341 static/js/zamboni/stats-min.js:4
 msgid "Detail Page (bottom)"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:61
+#: static/js/impala/stats/csv_keys.js:61 static/js/zamboni/stats-all.js:15342 static/js/zamboni/stats-min.js:4
 msgid "Detail Page (Development Channel)"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:62 static/js/impala/stats/csv_keys.js:63 static/js/impala/stats/csv_keys.js:64
+#: static/js/impala/stats/csv_keys.js:62 static/js/impala/stats/csv_keys.js:63 static/js/impala/stats/csv_keys.js:64 static/js/zamboni/stats-all.js:15343 static/js/zamboni/stats-all.js:15344
+#: static/js/zamboni/stats-all.js:15345 static/js/zamboni/stats-min.js:4
 msgid "Often Used With"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:65 static/js/impala/stats/csv_keys.js:66
+#: static/js/impala/stats/csv_keys.js:65 static/js/impala/stats/csv_keys.js:66 static/js/zamboni/stats-all.js:15346 static/js/zamboni/stats-all.js:15347 static/js/zamboni/stats-min.js:4
 msgid "Others By Author"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:67 static/js/impala/stats/csv_keys.js:68
+#: static/js/impala/stats/csv_keys.js:67 static/js/impala/stats/csv_keys.js:68 static/js/zamboni/stats-all.js:15348 static/js/zamboni/stats-all.js:15349 static/js/zamboni/stats-min.js:4
 msgid "Dependencies"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:69 static/js/impala/stats/csv_keys.js:70
+#: static/js/impala/stats/csv_keys.js:69 static/js/impala/stats/csv_keys.js:70 static/js/zamboni/stats-all.js:15350 static/js/zamboni/stats-all.js:15351 static/js/zamboni/stats-min.js:4
 msgid "Upsell"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:71
+#: static/js/impala/stats/csv_keys.js:71 static/js/zamboni/stats-all.js:15352 static/js/zamboni/stats-min.js:4
 msgid "Meet the Developer"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:72
+#: static/js/impala/stats/csv_keys.js:72 static/js/zamboni/stats-all.js:15353 static/js/zamboni/stats-min.js:4
 msgid "User Profile"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:73
+#: static/js/impala/stats/csv_keys.js:73 static/js/zamboni/stats-all.js:15354 static/js/zamboni/stats-min.js:4
 msgid "Version History"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:75
+#: static/js/impala/stats/csv_keys.js:75 static/js/zamboni/stats-all.js:15356 static/js/zamboni/stats-min.js:4
 msgid "Sharing"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:76
+#: static/js/impala/stats/csv_keys.js:76 static/js/zamboni/stats-all.js:15357 static/js/zamboni/stats-min.js:4
 msgid "Category Pages"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:77
+#: static/js/impala/stats/csv_keys.js:77 static/js/zamboni/stats-all.js:15358 static/js/zamboni/stats-min.js:4
 msgid "Collections"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:78 static/js/impala/stats/csv_keys.js:79
+#: static/js/impala/stats/csv_keys.js:78 static/js/impala/stats/csv_keys.js:79 static/js/zamboni/stats-all.js:15359 static/js/zamboni/stats-all.js:15360 static/js/zamboni/stats-min.js:4
 msgid "Category Landing Featured Carousel"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:80 static/js/impala/stats/csv_keys.js:81
+#: static/js/impala/stats/csv_keys.js:80 static/js/impala/stats/csv_keys.js:81 static/js/zamboni/stats-all.js:15361 static/js/zamboni/stats-all.js:15362 static/js/zamboni/stats-min.js:4
 msgid "Category Landing Top Rated"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:82 static/js/impala/stats/csv_keys.js:83
+#: static/js/impala/stats/csv_keys.js:82 static/js/impala/stats/csv_keys.js:83 static/js/zamboni/stats-all.js:15363 static/js/zamboni/stats-all.js:15364 static/js/zamboni/stats-min.js:5
 msgid "Category Landing Most Popular"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:84 static/js/impala/stats/csv_keys.js:85
+#: static/js/impala/stats/csv_keys.js:84 static/js/impala/stats/csv_keys.js:85 static/js/zamboni/stats-all.js:15365 static/js/zamboni/stats-all.js:15366 static/js/zamboni/stats-min.js:5
 msgid "Category Landing Recently Added"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:86 static/js/impala/stats/csv_keys.js:87
+#: static/js/impala/stats/csv_keys.js:86 static/js/impala/stats/csv_keys.js:87 static/js/zamboni/stats-all.js:15367 static/js/zamboni/stats-all.js:15368 static/js/zamboni/stats-min.js:5
 msgid "Browse Listing Featured Sort"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:88 static/js/impala/stats/csv_keys.js:89
+#: static/js/impala/stats/csv_keys.js:88 static/js/impala/stats/csv_keys.js:89 static/js/zamboni/stats-all.js:15369 static/js/zamboni/stats-all.js:15370 static/js/zamboni/stats-min.js:5
 msgid "Browse Listing Users Sort"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:90 static/js/impala/stats/csv_keys.js:91
+#: static/js/impala/stats/csv_keys.js:90 static/js/impala/stats/csv_keys.js:91 static/js/zamboni/stats-all.js:15371 static/js/zamboni/stats-all.js:15372 static/js/zamboni/stats-min.js:5
 msgid "Browse Listing Rating Sort"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:92 static/js/impala/stats/csv_keys.js:93
+#: static/js/impala/stats/csv_keys.js:92 static/js/impala/stats/csv_keys.js:93 static/js/zamboni/stats-all.js:15373 static/js/zamboni/stats-all.js:15374 static/js/zamboni/stats-min.js:5
 msgid "Browse Listing Created Sort"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:94 static/js/impala/stats/csv_keys.js:95
+#: static/js/impala/stats/csv_keys.js:94 static/js/impala/stats/csv_keys.js:95 static/js/zamboni/stats-all.js:15375 static/js/zamboni/stats-all.js:15376 static/js/zamboni/stats-min.js:5
 msgid "Browse Listing Name Sort"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:96 static/js/impala/stats/csv_keys.js:97
+#: static/js/impala/stats/csv_keys.js:96 static/js/impala/stats/csv_keys.js:97 static/js/zamboni/stats-all.js:15377 static/js/zamboni/stats-all.js:15378 static/js/zamboni/stats-min.js:5
 msgid "Browse Listing Popular Sort"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:98 static/js/impala/stats/csv_keys.js:99
+#: static/js/impala/stats/csv_keys.js:98 static/js/impala/stats/csv_keys.js:99 static/js/zamboni/stats-all.js:15379 static/js/zamboni/stats-all.js:15380 static/js/zamboni/stats-min.js:5
 msgid "Browse Listing Updated Sort"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:100 static/js/impala/stats/csv_keys.js:101
+#: static/js/impala/stats/csv_keys.js:100 static/js/impala/stats/csv_keys.js:101 static/js/zamboni/stats-all.js:15381 static/js/zamboni/stats-all.js:15382 static/js/zamboni/stats-min.js:5
 msgid "Browse Listing Up and Coming Sort"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:105
+#: static/js/impala/stats/csv_keys.js:105 static/js/zamboni/stats-all.js:15386 static/js/zamboni/stats-min.js:5
 msgid "Total Amount Contributed"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:106
+#: static/js/impala/stats/csv_keys.js:106 static/js/zamboni/stats-all.js:15387 static/js/zamboni/stats-min.js:5
 msgid "Average Contribution"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:115
+#: static/js/impala/stats/csv_keys.js:115 static/js/zamboni/stats-all.js:15396 static/js/zamboni/stats-min.js:5
 msgid "Usage"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:118
+#: static/js/impala/stats/csv_keys.js:118 static/js/zamboni/stats-all.js:15399 static/js/zamboni/stats-min.js:5
 msgid "Firefox"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:119
+#: static/js/impala/stats/csv_keys.js:119 static/js/zamboni/stats-all.js:15400 static/js/zamboni/stats-min.js:5
 msgid "Mozilla"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:120
+#: static/js/impala/stats/csv_keys.js:120 static/js/zamboni/stats-all.js:15401 static/js/zamboni/stats-min.js:5
 msgid "Thunderbird"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:121
+#: static/js/impala/stats/csv_keys.js:121 static/js/zamboni/stats-all.js:15402 static/js/zamboni/stats-min.js:5
 msgid "Sunbird"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:122
+#: static/js/impala/stats/csv_keys.js:122 static/js/zamboni/stats-all.js:15403 static/js/zamboni/stats-min.js:5
 msgid "SeaMonkey"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:123
+#: static/js/impala/stats/csv_keys.js:123 static/js/zamboni/stats-all.js:15404 static/js/zamboni/stats-min.js:5
 msgid "Fennec"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:124
+#: static/js/impala/stats/csv_keys.js:124 static/js/zamboni/stats-all.js:15405 static/js/zamboni/stats-min.js:5
 msgid "Android"
 msgstr ""
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:129
+#: static/js/impala/stats/csv_keys.js:129 static/js/zamboni/stats-all.js:15410 static/js/zamboni/stats-min.js:5
 msgid "Downloads and Daily Users, last {0} days"
 msgstr ""
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:131
+#: static/js/impala/stats/csv_keys.js:131 static/js/zamboni/stats-all.js:15412 static/js/zamboni/stats-min.js:5
 msgid "Downloads and Daily Users from {0} to {1}"
 msgstr ""
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:135
+#: static/js/impala/stats/csv_keys.js:135 static/js/zamboni/stats-all.js:15416 static/js/zamboni/stats-min.js:5
 msgid "Installs and Daily Users, last {0} days"
 msgstr ""
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:137
+#: static/js/impala/stats/csv_keys.js:137 static/js/zamboni/stats-all.js:15418 static/js/zamboni/stats-min.js:5
 msgid "Installs and Daily Users from {0} to {1}"
 msgstr ""
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:141
+#: static/js/impala/stats/csv_keys.js:141 static/js/zamboni/stats-all.js:15422 static/js/zamboni/stats-min.js:5
 msgid "Downloads, last {0} days"
 msgstr ""
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:143
+#: static/js/impala/stats/csv_keys.js:143 static/js/zamboni/stats-all.js:15424 static/js/zamboni/stats-min.js:5
 msgid "Downloads from {0} to {1}"
 msgstr ""
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:147
+#: static/js/impala/stats/csv_keys.js:147 static/js/zamboni/stats-all.js:15428 static/js/zamboni/stats-min.js:5
 msgid "Daily Users, last {0} days"
 msgstr ""
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:149
+#: static/js/impala/stats/csv_keys.js:149 static/js/zamboni/stats-all.js:15430 static/js/zamboni/stats-min.js:5
 msgid "Daily Users from {0} to {1}"
 msgstr ""
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:153
+#: static/js/impala/stats/csv_keys.js:153 static/js/zamboni/stats-all.js:15434 static/js/zamboni/stats-min.js:5
 msgid "Applications, last {0} days"
 msgstr ""
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:155
+#: static/js/impala/stats/csv_keys.js:155 static/js/zamboni/stats-all.js:15436 static/js/zamboni/stats-min.js:5
 msgid "Applications from {0} to {1}"
 msgstr ""
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:159
+#: static/js/impala/stats/csv_keys.js:159 static/js/zamboni/stats-all.js:15440 static/js/zamboni/stats-min.js:5
 msgid "Platforms, last {0} days"
 msgstr ""
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:161
+#: static/js/impala/stats/csv_keys.js:161 static/js/zamboni/stats-all.js:15442 static/js/zamboni/stats-min.js:5
 msgid "Platforms from {0} to {1}"
 msgstr ""
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:165
+#: static/js/impala/stats/csv_keys.js:165 static/js/zamboni/stats-all.js:15446 static/js/zamboni/stats-min.js:5
 msgid "Languages, last {0} days"
 msgstr ""
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:167
+#: static/js/impala/stats/csv_keys.js:167 static/js/zamboni/stats-all.js:15448 static/js/zamboni/stats-min.js:5
 msgid "Languages from {0} to {1}"
 msgstr ""
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:171
+#: static/js/impala/stats/csv_keys.js:171 static/js/zamboni/stats-all.js:15452 static/js/zamboni/stats-min.js:5
 msgid "Add-on Versions, last {0} days"
 msgstr ""
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:173
+#: static/js/impala/stats/csv_keys.js:173 static/js/zamboni/stats-all.js:15454 static/js/zamboni/stats-min.js:5
 msgid "Add-on Versions from {0} to {1}"
 msgstr ""
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:177
+#: static/js/impala/stats/csv_keys.js:177 static/js/zamboni/stats-all.js:15458 static/js/zamboni/stats-min.js:5
 msgid "Add-on Status, last {0} days"
 msgstr ""
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:179
+#: static/js/impala/stats/csv_keys.js:179 static/js/zamboni/stats-all.js:15460 static/js/zamboni/stats-min.js:5
 msgid "Add-on Status from {0} to {1}"
 msgstr ""
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:183
+#: static/js/impala/stats/csv_keys.js:183 static/js/zamboni/stats-all.js:15464 static/js/zamboni/stats-min.js:5
 msgid "Download Sources, last {0} days"
 msgstr ""
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:185
+#: static/js/impala/stats/csv_keys.js:185 static/js/zamboni/stats-all.js:15466 static/js/zamboni/stats-min.js:5
 msgid "Download Sources from {0} to {1}"
 msgstr ""
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:189
+#: static/js/impala/stats/csv_keys.js:189 static/js/zamboni/stats-all.js:15470 static/js/zamboni/stats-min.js:5
 msgid "Contributions, last {0} days"
 msgstr ""
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:191
+#: static/js/impala/stats/csv_keys.js:191 static/js/zamboni/stats-all.js:15472 static/js/zamboni/stats-min.js:5
 msgid "Contributions from {0} to {1}"
 msgstr ""
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:195
+#: static/js/impala/stats/csv_keys.js:195 static/js/zamboni/stats-all.js:15476 static/js/zamboni/stats-min.js:5
 msgid "Site Metrics, last {0} days"
 msgstr ""
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:197
+#: static/js/impala/stats/csv_keys.js:197 static/js/zamboni/stats-all.js:15478 static/js/zamboni/stats-min.js:5
 msgid "Site Metrics from {0} to {1}"
 msgstr ""
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:201
+#: static/js/impala/stats/csv_keys.js:201 static/js/zamboni/stats-all.js:15482 static/js/zamboni/stats-min.js:5
 msgid "Add-ons in Use, last {0} days"
 msgstr ""
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:203
+#: static/js/impala/stats/csv_keys.js:203 static/js/zamboni/stats-all.js:15484 static/js/zamboni/stats-min.js:5
 msgid "Add-ons in Use from {0} to {1}"
 msgstr ""
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:207
+#: static/js/impala/stats/csv_keys.js:207 static/js/zamboni/stats-all.js:15488 static/js/zamboni/stats-min.js:5
 msgid "Add-ons Downloaded, last {0} days"
 msgstr ""
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:209
+#: static/js/impala/stats/csv_keys.js:209 static/js/zamboni/stats-all.js:15490 static/js/zamboni/stats-min.js:5
 msgid "Add-ons Downloaded from {0} to {1}"
 msgstr ""
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:213
+#: static/js/impala/stats/csv_keys.js:213 static/js/zamboni/stats-all.js:15494 static/js/zamboni/stats-min.js:5
 msgid "Add-ons Created, last {0} days"
 msgstr ""
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:215
+#: static/js/impala/stats/csv_keys.js:215 static/js/zamboni/stats-all.js:15496 static/js/zamboni/stats-min.js:5
 msgid "Add-ons Created from {0} to {1}"
 msgstr ""
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:219
+#: static/js/impala/stats/csv_keys.js:219 static/js/zamboni/stats-all.js:15500 static/js/zamboni/stats-min.js:5
 msgid "Add-ons Updated, last {0} days"
 msgstr ""
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:221
+#: static/js/impala/stats/csv_keys.js:221 static/js/zamboni/stats-all.js:15502 static/js/zamboni/stats-min.js:5
 msgid "Add-ons Updated from {0} to {1}"
 msgstr ""
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:225
+#: static/js/impala/stats/csv_keys.js:225 static/js/zamboni/stats-all.js:15506 static/js/zamboni/stats-min.js:5
 msgid "Reviews Written, last {0} days"
 msgstr ""
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:227
+#: static/js/impala/stats/csv_keys.js:227 static/js/zamboni/stats-all.js:15508 static/js/zamboni/stats-min.js:5
 msgid "Reviews Written from {0} to {1}"
 msgstr ""
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:231
+#: static/js/impala/stats/csv_keys.js:231 static/js/zamboni/stats-all.js:15512 static/js/zamboni/stats-min.js:5
 msgid "User Signups, last {0} days"
 msgstr ""
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:233
+#: static/js/impala/stats/csv_keys.js:233 static/js/zamboni/stats-all.js:15514 static/js/zamboni/stats-min.js:5
 msgid "User Signups from {0} to {1}"
 msgstr ""
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:237
+#: static/js/impala/stats/csv_keys.js:237 static/js/zamboni/stats-all.js:15518 static/js/zamboni/stats-min.js:5
 msgid "Collections Created, last {0} days"
 msgstr ""
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:239
+#: static/js/impala/stats/csv_keys.js:239 static/js/zamboni/stats-all.js:15520 static/js/zamboni/stats-min.js:5
 msgid "Collections Created from {0} to {1}"
 msgstr ""
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:243
+#: static/js/impala/stats/csv_keys.js:243 static/js/zamboni/stats-all.js:15524 static/js/zamboni/stats-min.js:5
 msgid "Subscribers, last {0} days"
 msgstr ""
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:245
+#: static/js/impala/stats/csv_keys.js:245 static/js/zamboni/stats-all.js:15526 static/js/zamboni/stats-min.js:5
 msgid "Subscribers from {0} to {1}"
 msgstr ""
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:249
+#: static/js/impala/stats/csv_keys.js:249 static/js/zamboni/stats-all.js:15530 static/js/zamboni/stats-min.js:5
 msgid "Ratings, last {0} days"
 msgstr ""
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:251
+#: static/js/impala/stats/csv_keys.js:251 static/js/zamboni/stats-all.js:15532 static/js/zamboni/stats-min.js:5
 msgid "Ratings from {0} to {1}"
 msgstr ""
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:255
+#: static/js/impala/stats/csv_keys.js:255 static/js/zamboni/stats-all.js:15536 static/js/zamboni/stats-min.js:5
 msgid "Sales, last {0} days"
 msgstr ""
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:257
+#: static/js/impala/stats/csv_keys.js:257 static/js/zamboni/stats-all.js:15538 static/js/zamboni/stats-min.js:5
 msgid "Sales from {0} to {1}"
 msgstr ""
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:261
+#: static/js/impala/stats/csv_keys.js:261 static/js/zamboni/stats-all.js:15542 static/js/zamboni/stats-min.js:5
 msgid "Installs, last {0} days"
 msgstr ""
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:263
+#: static/js/impala/stats/csv_keys.js:263 static/js/zamboni/stats-all.js:15544 static/js/zamboni/stats-min.js:5
 msgid "Installs from {0} to {1}"
 msgstr ""
 
 #. L10n: {0} and {1} are integers.
-#: static/js/impala/stats/csv_keys.js:269
+#: static/js/impala/stats/csv_keys.js:269 static/js/zamboni/stats-all.js:15550 static/js/zamboni/stats-min.js:5
 msgid "<b>{0}</b> in last {1} days"
 msgstr ""
 
 #. L10n: {0} is an integer and {1} and {2} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:271 static/js/impala/stats/csv_keys.js:277
+#: static/js/impala/stats/csv_keys.js:271 static/js/impala/stats/csv_keys.js:277 static/js/zamboni/stats-all.js:15552 static/js/zamboni/stats-all.js:15558 static/js/zamboni/stats-min.js:5
 msgid "<b>{0}</b> from {1} to {2}"
 msgstr ""
 
 #. L10n: {0} and {1} are integers.
-#: static/js/impala/stats/csv_keys.js:275
+#: static/js/impala/stats/csv_keys.js:275 static/js/zamboni/stats-all.js:15556 static/js/zamboni/stats-min.js:5
 msgid "<b>{0}</b> average in last {1} days"
 msgstr ""
 
-#: static/js/impala/stats/overview.js:19
+#: static/js/impala/stats/overview.js:19 static/js/zamboni/stats-all.js:16469 static/js/zamboni/stats-min.js:5
 msgid "No data available."
 msgstr ""
 
-#: static/js/impala/stats/table.js:74
+#: static/js/impala/stats/table.js:74 static/js/zamboni/stats-all.js:17209 static/js/zamboni/stats-min.js:5
 msgid "Date"
 msgstr ""
 
-#: static/js/impala/stats/topchart.js:96
+#: static/js/impala/stats/topchart.js:96 static/js/zamboni/stats-all.js:16600 static/js/zamboni/stats-min.js:5
 msgid "Other"
 msgstr ""
 
-#: static/js/zamboni/admin_validation.js:24 static/js/zamboni/devhub.js:1229 static/js/zamboni/editors.js:295
+#: static/js/zamboni/admin-all.js:180 static/js/zamboni/admin-min.js:1 static/js/zamboni/admin_validation.js:24 static/js/zamboni/devhub-all.js:2408 static/js/zamboni/devhub-min.js:2
+#: static/js/zamboni/devhub.js:1229 static/js/zamboni/editors-all.js:15576 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:295
 msgid "Select an application first"
 msgstr ""
 
-#: static/js/zamboni/admin_validation.js:51
+#: static/js/zamboni/admin-all.js:207 static/js/zamboni/admin-min.js:1 static/js/zamboni/admin_validation.js:51
 msgid "Set {0} add-on to a max version of {1} and email the author."
 msgid_plural "Set {0} add-ons to a max version of {1} and email the authors."
 msgstr[0] ""
 msgstr[1] ""
 
-#: static/js/zamboni/admin_validation.js:54
+#: static/js/zamboni/admin-all.js:210 static/js/zamboni/admin-min.js:1 static/js/zamboni/admin_validation.js:54
 msgid "Email author of {2} add-on which failed validation."
 msgid_plural "Email authors of {2} add-ons which failed validation."
 msgstr[0] ""
 msgstr[1] ""
 
-#. L10n: {0} is an app name like Firefox.
-#: static/js/zamboni/buttons.js:66
-msgid "Accept and Install"
-msgstr ""
-
-#: static/js/zamboni/buttons.js:66
-msgid "Add to {0}"
-msgstr ""
-
-#: static/js/zamboni/buttons.js:71
-msgid "Download Now"
-msgstr ""
-
-#: static/js/zamboni/buttons.js:112
-msgid "Add-on has not been updated to support default-to-compatible."
-msgstr ""
-
-#: static/js/zamboni/buttons.js:117
-msgid "You need to be using Firefox 10.0 or higher."
-msgstr ""
-
-#: static/js/zamboni/buttons.js:129
-msgid "Mozilla has marked this version as incompatible with your Firefox version."
-msgstr ""
-
-#. L10n: {0} is an platform like Windows or Linux.
-#: static/js/zamboni/buttons.js:210
-msgid "Install for {0} anyway"
-msgstr ""
-
-#: static/js/zamboni/buttons.js:210
-msgid "Download for {0} anyway"
-msgstr ""
-
-#: static/js/zamboni/buttons.js:267
-msgid "Not available for your platform"
-msgstr ""
-
-#. L10n: {0} is an app name, {1} is the app version.
-#: static/js/zamboni/buttons.js:278 static/js/zamboni/buttons.js:315
-msgid "Not available for {0} {1}"
-msgstr ""
-
-#: static/js/zamboni/buttons.js:341
-msgid "Works with {app} {min} - {max}"
-msgstr ""
-
-#: static/js/zamboni/buttons.js:343
-msgid "View other versions"
-msgstr ""
-
-#: static/js/zamboni/buttons.js:391
-msgid "Only with Firefox — Get Firefox Now!"
-msgstr ""
-
-#: static/js/zamboni/buttons.js:507 static/js/zamboni/mobile/buttons.js:43
-msgid "Sorry, you need a Mozilla-based browser (such as Firefox) to install a search plugin."
-msgstr ""
-
-#: static/js/zamboni/collections.js:229
-msgid "Adding to Favorites&hellip;"
-msgstr ""
-
-#: static/js/zamboni/collections.js:232
-msgid "Removing Favorite&hellip;"
-msgstr ""
-
-#: static/js/zamboni/collections.js:235
-msgid "Add to Favorites"
-msgstr ""
-
-#: static/js/zamboni/collections.js:238
-msgid "Remove from Favorites"
-msgstr ""
-
-#: static/js/zamboni/collections.js:303
-msgid "Pending"
-msgstr ""
-
-#: static/js/zamboni/collections.js:304
-msgid "Add a comment"
-msgstr ""
-
-#: static/js/zamboni/collections.js:304
-msgid "Comment"
-msgstr ""
-
-#: static/js/zamboni/collections.js:305
-msgid "Remove this add-on from the collection"
-msgstr ""
-
-#: static/js/zamboni/collections.js:305 static/js/zamboni/collections.js:334
-msgid "Remove"
-msgstr ""
-
-#: static/js/zamboni/collections.js:334
-msgid "Remove this user as a contributor"
-msgstr ""
-
-#: static/js/zamboni/collections.js:346
-msgid "An email address is required."
-msgstr ""
-
-#: static/js/zamboni/collections.js:364
-msgid "You cannot add yourself as a contributor."
-msgstr ""
-
-#: static/js/zamboni/collections.js:366
-msgid "You have already added that user."
-msgstr ""
-
-#: static/js/zamboni/collections.js:573
-msgid "Add to favorites"
-msgstr ""
-
-#: static/js/zamboni/collections.js:577
-msgid "Remove from favorites"
-msgstr ""
-
-#: static/js/zamboni/collections.js:604
-msgid "Stop following"
-msgstr ""
-
-#: static/js/zamboni/devhub.js:110
+#: static/js/zamboni/devhub-all.js:1289 static/js/zamboni/devhub-min.js:1 static/js/zamboni/devhub.js:110
 msgid "Your browser does not support the video tag"
 msgstr ""
 
-#: static/js/zamboni/devhub.js:371
+#: static/js/zamboni/devhub-all.js:1550 static/js/zamboni/devhub-min.js:1 static/js/zamboni/devhub.js:371
 msgid "Changes Saved"
 msgstr ""
 
-#: static/js/zamboni/devhub.js:387
+#: static/js/zamboni/devhub-all.js:1566 static/js/zamboni/devhub-min.js:1 static/js/zamboni/devhub.js:387
 msgid "Enter a new author's email address"
 msgstr ""
 
-#: static/js/zamboni/devhub.js:536
+#: static/js/zamboni/devhub-all.js:1715 static/js/zamboni/devhub-min.js:1 static/js/zamboni/devhub.js:536
 msgid "There was an error uploading your file."
 msgstr ""
 
-#: static/js/zamboni/devhub.js:681
+#: static/js/zamboni/devhub-all.js:1860 static/js/zamboni/devhub-min.js:1 static/js/zamboni/devhub.js:681
 msgid "{files} file"
 msgid_plural "{files} files"
 msgstr[0] ""
 msgstr[1] ""
 
-#: static/js/zamboni/devhub.js:684
+#: static/js/zamboni/devhub-all.js:1863 static/js/zamboni/devhub-min.js:1 static/js/zamboni/devhub.js:684
 msgid "{reviews} user review"
 msgid_plural "{reviews} user reviews"
 msgstr[0] ""
 msgstr[1] ""
 
-#: static/js/zamboni/devhub.js:796
+#: static/js/zamboni/devhub-all.js:1975 static/js/zamboni/devhub-min.js:2 static/js/zamboni/devhub.js:796
 msgid "Learn more"
 msgstr ""
 
-#: static/js/zamboni/devhub.js:800
+#: static/js/zamboni/devhub-all.js:1979 static/js/zamboni/devhub-min.js:2 static/js/zamboni/devhub.js:800
 msgid "Example"
 msgstr ""
 
-#: static/js/zamboni/devhub.js:1130
+#: static/js/zamboni/devhub-all.js:2309 static/js/zamboni/devhub-min.js:2 static/js/zamboni/devhub.js:1130
 msgid "Image changes being processed"
 msgstr ""
 
-#: static/js/zamboni/devhub.js:1280
+#: static/js/zamboni/devhub-all.js:2459 static/js/zamboni/devhub-min.js:2 static/js/zamboni/devhub.js:1280
 msgid "Must be a valid e-mail address."
+msgstr ""
+
+#: static/js/zamboni/devhub-all.js:2613 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:80
+msgid "All tests passed successfully."
+msgstr ""
+
+#: static/js/zamboni/devhub-all.js:2616 static/js/zamboni/devhub-all.js:3011 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:83 static/js/zamboni/validator.js:478
+msgid "These tests were not run."
+msgstr ""
+
+#: static/js/zamboni/devhub-all.js:2664 static/js/zamboni/devhub-all.js:2677 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:131 static/js/zamboni/validator.js:144
+msgid "Tests"
+msgstr ""
+
+#: static/js/zamboni/devhub-all.js:2779 static/js/zamboni/devhub-all.js:3108 static/js/zamboni/devhub-all.js:3127 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:246
+#: static/js/zamboni/validator.js:575 static/js/zamboni/validator.js:594
+msgid "Error"
+msgstr ""
+
+#: static/js/zamboni/devhub-all.js:2780 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:247
+msgid "Warning"
+msgstr ""
+
+#: static/js/zamboni/devhub-all.js:2794 static/js/zamboni/devhub-min.js:2 static/js/zamboni/files-all.js:5657 static/js/zamboni/files-min.js:3 static/js/zamboni/files.js:411
+#: static/js/zamboni/validator.js:261
+msgid "Ignore this message in future updates"
+msgstr ""
+
+#: static/js/zamboni/devhub-all.js:2817 static/js/zamboni/devhub-min.js:2 static/js/zamboni/files-all.js:5663 static/js/zamboni/files-min.js:3 static/js/zamboni/files.js:417
+#: static/js/zamboni/validator.js:284
+msgid "Severity for automated signing:"
+msgstr ""
+
+#: static/js/zamboni/devhub-all.js:2832 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:299
+msgid "Suggestions for passing automated signing:"
+msgstr ""
+
+#: static/js/zamboni/devhub-all.js:2920 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:387
+msgid "Compatibility Tests"
+msgstr ""
+
+#: static/js/zamboni/devhub-all.js:2999 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:466
+msgid "Add-on failed validation."
+msgstr ""
+
+#: static/js/zamboni/devhub-all.js:3001 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:468
+msgid "Add-on passed validation."
+msgstr ""
+
+#: static/js/zamboni/devhub-all.js:3014 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:481
+msgid "{0} error"
+msgid_plural "{0} errors"
+msgstr[0] ""
+msgstr[1] ""
+
+#: static/js/zamboni/devhub-all.js:3016 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:483
+msgid "{0} warning"
+msgid_plural "{0} warnings"
+msgstr[0] ""
+msgstr[1] ""
+
+#: static/js/zamboni/devhub-all.js:3018 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:485
+msgid "{0} notice"
+msgid_plural "{0} notices"
+msgstr[0] ""
+msgstr[1] ""
+
+#: static/js/zamboni/devhub-all.js:3110 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:577
+msgid "Validation task could not complete or completed with errors"
+msgstr ""
+
+#: static/js/zamboni/devhub-all.js:3128 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:595
+msgid "Internal server error"
 msgstr ""
 
 #: static/js/zamboni/devhub_search.js:8
 msgid "No results found."
 msgstr ""
 
-#: static/js/zamboni/editors.js:121
+#: static/js/zamboni/editors-all.js:15402 static/js/zamboni/editors-min.js:4 static/js/zamboni/editors.js:121
 msgid "{name} was viewing this page first."
 msgstr ""
 
-#: static/js/zamboni/editors.js:171
+#: static/js/zamboni/editors-all.js:15452 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:171
 msgid "Receipt checked by app."
 msgstr ""
 
-#: static/js/zamboni/editors.js:173
+#: static/js/zamboni/editors-all.js:15454 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:173
 msgid "Receipt was not checked by app."
 msgstr ""
 
-#: static/js/zamboni/editors.js:244
+#: static/js/zamboni/editors-all.js:15525 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:244
 msgid "{name} was viewing this add-on first."
 msgstr ""
 
-#: static/js/zamboni/editors.js:255
+#: static/js/zamboni/editors-all.js:15536 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:255
 msgid "Loading&hellip;"
 msgstr ""
 
-#: static/js/zamboni/editors.js:260
+#: static/js/zamboni/editors-all.js:15541 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:260
 msgid "Version Notes"
 msgstr ""
 
-#: static/js/zamboni/editors.js:265
+#: static/js/zamboni/editors-all.js:15546 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:265
 msgid "Notes for Reviewers"
 msgstr ""
 
-#: static/js/zamboni/editors.js:270
+#: static/js/zamboni/editors-all.js:15551 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:270
 msgid "No version notes found"
 msgstr ""
 
-#: static/js/zamboni/editors.js:330
+#: static/js/zamboni/editors-all.js:15611 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:330
 msgid "Average Reviews"
 msgstr ""
 
-#: static/js/zamboni/editors.js:386
+#: static/js/zamboni/editors-all.js:15667 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:386
 msgid "Number of Reviews"
 msgstr ""
 
-#: static/js/zamboni/editors.js:445
+#: static/js/zamboni/editors-all.js:15726 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:445
 msgid "Error loading translation"
 msgstr ""
 
-#: static/js/zamboni/files.js:411 static/js/zamboni/validator.js:261
-msgid "Ignore this message in future updates"
-msgstr ""
-
-#: static/js/zamboni/files.js:417 static/js/zamboni/validator.js:284
-msgid "Severity for automated signing:"
-msgstr ""
-
-#: static/js/zamboni/global.js:410
-msgid "Loading..."
-msgstr ""
-
-#. L10n: {0} is the number of characters left.
-#: static/js/zamboni/global.js:474
-msgid "<b>{0}</b> character left."
-msgid_plural "<b>{0}</b> characters left."
-msgstr[0] ""
-msgstr[1] ""
-
-#: static/js/zamboni/init.js:28
-msgid "This feature is temporarily disabled while we perform website maintenance. Please check back a little later."
-msgstr ""
-
-#: static/js/zamboni/l10n.js:45
-msgid "Remove this localization"
-msgstr ""
-
-#: static/js/zamboni/password-strength.js:20
-msgid "Password strength:"
-msgstr ""
-
-#: static/js/zamboni/password-strength.js:26
-msgid "At least {0} character left."
-msgid_plural "At least {0} characters left."
-msgstr[0] ""
-msgstr[1] ""
-
-#: static/js/zamboni/themes_review.js:176
-msgid "Requested Info"
-msgstr ""
-
-#: static/js/zamboni/themes_review.js:177
-msgid "Flagged"
-msgstr ""
-
-#: static/js/zamboni/themes_review.js:178
-msgid "Duplicate"
-msgstr ""
-
-#: static/js/zamboni/themes_review.js:179
-msgid "Rejected"
-msgstr ""
-
-#: static/js/zamboni/themes_review.js:180
-msgid "Approved"
-msgstr ""
-
-#: static/js/zamboni/themes_review.js:424
-msgid "No results found"
-msgstr ""
-
-#: static/js/zamboni/themes_review_templates.js:31
+#: static/js/zamboni/editors-all.js:15975 static/js/zamboni/editors-min.js:5 static/js/zamboni/themes_review_templates.js:31
 msgid "Theme"
 msgstr ""
 
-#: static/js/zamboni/themes_review_templates.js:33
+#: static/js/zamboni/editors-all.js:15977 static/js/zamboni/editors-min.js:5 static/js/zamboni/themes_review_templates.js:33
 msgid "Reviewer"
 msgstr ""
 
-#: static/js/zamboni/themes_review_templates.js:35
+#: static/js/zamboni/editors-all.js:15979 static/js/zamboni/editors-min.js:5 static/js/zamboni/themes_review_templates.js:35
 msgid "Status"
 msgstr ""
 
-#: static/js/zamboni/validator.js:80
-msgid "All tests passed successfully."
+#: static/js/zamboni/editors-all.js:16196 static/js/zamboni/editors-min.js:5 static/js/zamboni/themes_review.js:176
+msgid "Requested Info"
 msgstr ""
 
-#: static/js/zamboni/validator.js:83 static/js/zamboni/validator.js:478
-msgid "These tests were not run."
+#: static/js/zamboni/editors-all.js:16197 static/js/zamboni/editors-min.js:5 static/js/zamboni/themes_review.js:177
+msgid "Flagged"
 msgstr ""
 
-#: static/js/zamboni/validator.js:131 static/js/zamboni/validator.js:144
-msgid "Tests"
+#: static/js/zamboni/editors-all.js:16198 static/js/zamboni/editors-min.js:5 static/js/zamboni/themes_review.js:178
+msgid "Duplicate"
 msgstr ""
 
-#: static/js/zamboni/validator.js:246 static/js/zamboni/validator.js:575 static/js/zamboni/validator.js:594
-msgid "Error"
+#: static/js/zamboni/editors-all.js:16199 static/js/zamboni/editors-min.js:5 static/js/zamboni/themes_review.js:179
+msgid "Rejected"
 msgstr ""
 
-#: static/js/zamboni/validator.js:247
-msgid "Warning"
+#: static/js/zamboni/editors-all.js:16200 static/js/zamboni/editors-min.js:5 static/js/zamboni/themes_review.js:180
+msgid "Approved"
 msgstr ""
 
-#: static/js/zamboni/validator.js:299
-msgid "Suggestions for passing automated signing:"
+#: static/js/zamboni/editors-all.js:16444 static/js/zamboni/editors-min.js:5 static/js/zamboni/themes_review.js:424
+msgid "No results found"
 msgstr ""
 
-#: static/js/zamboni/validator.js:387
-msgid "Compatibility Tests"
-msgstr ""
-
-#: static/js/zamboni/validator.js:466
-msgid "Add-on failed validation."
-msgstr ""
-
-#: static/js/zamboni/validator.js:468
-msgid "Add-on passed validation."
-msgstr ""
-
-#: static/js/zamboni/validator.js:481
-msgid "{0} error"
-msgid_plural "{0} errors"
-msgstr[0] ""
-msgstr[1] ""
-
-#: static/js/zamboni/validator.js:483
-msgid "{0} warning"
-msgid_plural "{0} warnings"
-msgstr[0] ""
-msgstr[1] ""
-
-#: static/js/zamboni/validator.js:485
-msgid "{0} notice"
-msgid_plural "{0} notices"
-msgstr[0] ""
-msgstr[1] ""
-
-#: static/js/zamboni/validator.js:577
-msgid "Validation task could not complete or completed with errors"
-msgstr ""
-
-#: static/js/zamboni/validator.js:595
-msgid "Internal server error"
-msgstr ""
-
-#: static/js/zamboni/mobile/buttons.js:52
+#: static/js/zamboni/mobile-all.js:15186 static/js/zamboni/mobile/buttons.js:52
 msgid "Not Updated for {0} {1}"
 msgstr ""
 
-#: static/js/zamboni/mobile/buttons.js:53
+#: static/js/zamboni/mobile-all.js:15187 static/js/zamboni/mobile/buttons.js:53
 msgid "Requires Newer Version of {0}"
 msgstr ""
 
-#: static/js/zamboni/mobile/buttons.js:54
+#: static/js/zamboni/mobile-all.js:15188 static/js/zamboni/mobile/buttons.js:54
 msgid "Unreviewed"
 msgstr ""
 
-#: static/js/zamboni/mobile/buttons.js:55
+#: static/js/zamboni/mobile-all.js:15189 static/js/zamboni/mobile/buttons.js:55
 msgid "Experimental <span>(Learn More)</span>"
 msgstr ""
 
-#: static/js/zamboni/mobile/buttons.js:56 static/js/zamboni/mobile/buttons.js:57
+#: static/js/zamboni/mobile-all.js:15190 static/js/zamboni/mobile-all.js:15191 static/js/zamboni/mobile/buttons.js:56 static/js/zamboni/mobile/buttons.js:57
 msgid "Not Available for {0}"
 msgstr ""
 
-#: static/js/zamboni/mobile/buttons.js:58
+#: static/js/zamboni/mobile-all.js:15192 static/js/zamboni/mobile/buttons.js:58
 msgid "Experimental"
 msgstr ""
 
-#: static/js/zamboni/mobile/buttons.js:59
+#: static/js/zamboni/mobile-all.js:15193 static/js/zamboni/mobile/buttons.js:59
 msgid "Themes Require Newer Version of {0}"
 msgstr ""
 
-#: static/js/zamboni/mobile/buttons.js:60
+#: static/js/zamboni/mobile-all.js:15194 static/js/zamboni/mobile/buttons.js:60
 msgid "Themes Require {0}"
 msgstr ""
 
-#: static/js/zamboni/mobile/buttons.js:105
+#: static/js/zamboni/mobile-all.js:15239 static/js/zamboni/mobile/buttons.js:105
 msgid "Installing..."
 msgstr ""
 
-#: static/js/zamboni/mobile/buttons.js:125
+#: static/js/zamboni/mobile-all.js:15259 static/js/zamboni/mobile/buttons.js:125
 msgid "This add-on has been preliminarily reviewed by Mozilla."
 msgstr ""
 
-#: static/js/zamboni/mobile/buttons.js:250
+#: static/js/zamboni/mobile-all.js:15384 static/js/zamboni/mobile/buttons.js:250
 msgid "Keep it"
 msgstr ""
 
-#: static/js/zamboni/mobile/general.js:344
+#: static/js/zamboni/mobile-all.js:16049 static/js/zamboni/mobile-min.js:6 static/js/zamboni/mobile/general.js:344
 msgid "You're trying it on!"
 msgstr ""
 
-#: static/js/zamboni/mobile/general.js:356
+#: static/js/zamboni/mobile-all.js:16061 static/js/zamboni/mobile-min.js:6 static/js/zamboni/mobile/general.js:356
 msgid "Added to Firefox"
 msgstr ""
-

--- a/locale/hr/LC_MESSAGES/django.po
+++ b/locale/hr/LC_MESSAGES/django.po
@@ -6,69 +6,70 @@ msgid ""
 msgstr ""
 "Project-Id-Version: addons VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2016-02-24 21:23+0000\n"
+"POT-Creation-Date: 2016-04-18 15:47+0000\n"
 "PO-Revision-Date: 2013-03-09 16:37+0000\n"
 "Last-Translator: Vedran <vedran.kovacevic@mozilla-hr.org>\n"
 "Language-Team: Croatian\n"
+"Language: \n"
 "MIME-Version: 1.0\n"
-"Content-Type: text/plain; charset=utf-8\n"
+"Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Generated-By: Babel 2.2.0\n"
 
-#: src/olympia/accounts/views.py:52
+#: src/olympia/accounts/views.py:54
 msgid "Your log in attempt could not be parsed. Please try again."
 msgstr ""
 
-#: src/olympia/accounts/views.py:54
+#: src/olympia/accounts/views.py:56
 msgid "Your Firefox Account could not be found. Please try again."
 msgstr ""
 
-#: src/olympia/accounts/views.py:55
+#: src/olympia/accounts/views.py:57
 msgid "You could not be logged in. Please try again."
 msgstr ""
 
-#: src/olympia/accounts/views.py:57
+#: src/olympia/accounts/views.py:59
 msgid "Your account has already been migrated to Firefox Accounts."
 msgstr ""
 
-#: src/olympia/accounts/views.py:59
+#: src/olympia/accounts/views.py:61
 msgid "Your Firefox Account already exists on this site."
 msgstr ""
 
-#: src/olympia/accounts/views.py:108
+#: src/olympia/accounts/views.py:110
 msgid "Great job!"
 msgstr ""
 
-#: src/olympia/accounts/views.py:109
+#: src/olympia/accounts/views.py:111
 msgid "You can now log in to Add-ons with your Firefox Account."
 msgstr ""
 
-#: src/olympia/accounts/views.py:121
+#: src/olympia/accounts/views.py:123
 msgid "Need help?"
 msgstr ""
 
-#: src/olympia/addons/buttons.py:180
+#: src/olympia/addons/buttons.py:177
 msgid "Download Now"
 msgstr "Preuzmite sada"
 
-#: src/olympia/addons/buttons.py:182
+#: src/olympia/addons/buttons.py:179
 msgid "Download"
 msgstr "Preuzimanje"
 
 #. L10n: please keep &nbsp; in the string so &rarr; does not wrap.
-#: src/olympia/addons/buttons.py:186
+#: src/olympia/addons/buttons.py:183
 msgid "Continue to Download&nbsp;&rarr;"
 msgstr "Nastavi na Preuzimanje&nbsp;&rarr;"
 
-#: src/olympia/addons/buttons.py:202 src/olympia/addons/helpers.py:35 src/olympia/addons/views.py:319 src/olympia/addons/templates/addons/impala/details.html:114
+#: src/olympia/addons/buttons.py:199 src/olympia/addons/helpers.py:35 src/olympia/addons/views.py:333 src/olympia/addons/templates/addons/impala/details.html:111
 #: src/olympia/addons/templates/addons/impala/listing/items.html:17 src/olympia/addons/templates/addons/mobile/home.html:40 src/olympia/amo/templates/amo/side_nav.html:6
-#: src/olympia/amo/templates/amo/side_nav.html:10 src/olympia/amo/templates/amo/site_nav.html:2 src/olympia/amo/templates/amo/site_nav.html:55 src/olympia/bandwagon/views.py:95
-#: src/olympia/browse/views.py:54 src/olympia/browse/views.py:68 src/olympia/browse/views.py:235 src/olympia/browse/templates/browse/impala/category_landing.html:22
+#: src/olympia/amo/templates/amo/side_nav.html:10 src/olympia/amo/templates/amo/site_nav.html:2 src/olympia/amo/templates/amo/site_nav.html:53 src/olympia/bandwagon/views.py:95
+#: src/olympia/browse/views.py:54 src/olympia/browse/views.py:68 src/olympia/browse/views.py:202 src/olympia/browse/templates/browse/impala/category_landing.html:22
 #: src/olympia/browse/templates/browse/personas/mobile/category_landing.html:26
 msgid "Featured"
 msgstr "Istaknuto"
 
-#: src/olympia/addons/buttons.py:221
+#: src/olympia/addons/buttons.py:218
 msgid "Add to {0}"
 msgstr "Dodaj u {0}"
 
@@ -91,7 +92,6 @@ msgid "Invalid tag: {0}"
 msgid_plural "Invalid tags: {0}"
 msgstr[0] ""
 msgstr[1] ""
-msgstr[2] ""
 
 #. L10n: {0} is a single tag or a comma-separated list of tags.
 #: src/olympia/addons/forms.py:103
@@ -99,14 +99,12 @@ msgid "\"{0}\" is a reserved tag and cannot be used."
 msgid_plural "\"{0}\" are reserved tags and cannot be used."
 msgstr[0] ""
 msgstr[1] ""
-msgstr[2] ""
 
 #: src/olympia/addons/forms.py:111
 msgid "You have {0} too many tags."
 msgid_plural "You have {0} too many tags."
 msgstr[0] ""
 msgstr[1] ""
-msgstr[2] ""
 
 #: src/olympia/addons/forms.py:117
 #, python-format
@@ -118,42 +116,40 @@ msgid "All tags must be at least {0} character."
 msgid_plural "All tags must be at least {0} characters."
 msgstr[0] ""
 msgstr[1] ""
-msgstr[2] ""
 
-#: src/olympia/addons/forms.py:234
+#: src/olympia/addons/forms.py:238
 msgid "Categories cannot be changed while your add-on is featured for this application."
 msgstr ""
 
 #. L10n: {0} is the number of categories.
-#: src/olympia/addons/forms.py:238
+#: src/olympia/addons/forms.py:242
 msgid "You can have only {0} category."
 msgid_plural "You can have only {0} categories."
 msgstr[0] ""
 msgstr[1] ""
-msgstr[2] ""
 
-#: src/olympia/addons/forms.py:246
+#: src/olympia/addons/forms.py:250
 msgid "The miscellaneous category cannot be combined with additional categories."
 msgstr ""
 
-#: src/olympia/addons/forms.py:369
+#: src/olympia/addons/forms.py:374
 #, python-format
 msgid "Before changing your default locale you must have a name, summary, and description in that locale. You are missing %s."
 msgstr "Prije nego što promijenite zadani jezik trebate imati ime, sažetak i opis na tom jeziku. Nedostaje vam %s."
 
-#: src/olympia/addons/forms.py:484 src/olympia/addons/forms.py:575
+#: src/olympia/addons/forms.py:455 src/olympia/addons/forms.py:546
 msgid "A license must be selected."
 msgstr ""
 
-#: src/olympia/addons/forms.py:556
+#: src/olympia/addons/forms.py:527
 msgid "Give Your Theme a Name."
 msgstr ""
 
-#: src/olympia/addons/forms.py:562 src/olympia/devhub/templates/devhub/personas/submit.html:53
+#: src/olympia/addons/forms.py:533 src/olympia/devhub/templates/devhub/personas/submit.html:53
 msgid "Describe your Theme."
 msgstr ""
 
-#: src/olympia/addons/forms.py:704
+#: src/olympia/addons/forms.py:675
 msgid "Enter a new author's email address"
 msgstr ""
 
@@ -161,37 +157,37 @@ msgstr ""
 msgid "Not Reviewed"
 msgstr "Nije pregledano"
 
-#: src/olympia/addons/models.py:301
+#: src/olympia/addons/models.py:298
 msgid "Users have the option of contributing more or less than this amount."
 msgstr "Korisnici imaju mogućnost doniranja većeg ili manjeg iznosa od ovoga."
 
-#: src/olympia/addons/models.py:309
-msgid "Users will always be asked in the Add-ons Manager (Firefox 4 and above)"
-msgstr "Korisnici će uvijek biti pitani u upravitelju dodacima (Firefox 4 i noviji)"
+#: src/olympia/addons/models.py:306
+msgid "Users will always be asked in the Add-ons Manager (Firefox 4 and above). Only applies to desktop."
+msgstr ""
 
-#: src/olympia/addons/models.py:1804 src/olympia/addons/templates/addons/details_box.html:55 src/olympia/devhub/templates/devhub/index.html:92
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:102
+#: src/olympia/addons/models.py:1802 src/olympia/addons/templates/addons/details_box.html:55 src/olympia/devhub/templates/devhub/index.html:92
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:89
 msgid "Listed"
 msgstr ""
 
-#: src/olympia/addons/views.py:320 src/olympia/browse/templates/browse/personas/mobile/category_landing.html:27
+#: src/olympia/addons/views.py:334 src/olympia/browse/templates/browse/personas/mobile/category_landing.html:27
 msgid "Popular"
 msgstr "Popularno"
 
-#: src/olympia/addons/views.py:321 src/olympia/browse/views.py:238 src/olympia/browse/views.py:280 src/olympia/browse/views.py:482
+#: src/olympia/addons/views.py:335 src/olympia/browse/views.py:205 src/olympia/browse/views.py:247 src/olympia/browse/views.py:449
 msgid "Recently Added"
 msgstr "Nedavno dodano"
 
-#: src/olympia/addons/views.py:322 src/olympia/bandwagon/views.py:99 src/olympia/browse/views.py:60 src/olympia/browse/views.py:71 src/olympia/search/forms.py:16 src/olympia/search/forms.py:91
+#: src/olympia/addons/views.py:336 src/olympia/bandwagon/views.py:99 src/olympia/browse/views.py:60 src/olympia/browse/views.py:71 src/olympia/search/forms.py:16 src/olympia/search/forms.py:91
 msgid "Recently Updated"
 msgstr "Nedavno ažurirano"
 
 #. l10n: {0} is the addon name
-#: src/olympia/addons/views.py:520
+#: src/olympia/addons/views.py:534
 msgid "Contribution for {0}"
 msgstr "Doprinos za {0}"
 
-#: src/olympia/addons/views.py:613
+#: src/olympia/addons/views.py:627
 msgid "Abuse reported."
 msgstr "Zloupotreba prijavljena."
 
@@ -258,9 +254,9 @@ msgstr "Donacije"
 #: src/olympia/devhub/templates/devhub/addons/ajax_compat_update.html:36 src/olympia/devhub/templates/devhub/addons/profile.html:44 src/olympia/devhub/templates/devhub/addons/edit/admin.html:101
 #: src/olympia/devhub/templates/devhub/addons/edit/basic.html:152 src/olympia/devhub/templates/devhub/addons/edit/details.html:85 src/olympia/devhub/templates/devhub/addons/edit/support.html:67
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:166 src/olympia/devhub/templates/devhub/addons/forms_shared/media.html:149
-#: src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:44 src/olympia/devhub/templates/devhub/versions/add_file_modal.html:78 src/olympia/devhub/templates/devhub/versions/edit.html:139
-#: src/olympia/devhub/templates/devhub/versions/list.html:242 src/olympia/devhub/templates/devhub/versions/list.html:276 src/olympia/devhub/templates/devhub/versions/list.html:317
-#: src/olympia/devhub/templates/devhub/versions/list.html:351 src/olympia/reviews/templates/reviews/edit_review.html:16 src/olympia/translations/templates/translations/trans-menu.html:50
+#: src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:43 src/olympia/devhub/templates/devhub/versions/add_file_modal.html:58 src/olympia/devhub/templates/devhub/versions/edit.html:139
+#: src/olympia/devhub/templates/devhub/versions/list.html:239 src/olympia/devhub/templates/devhub/versions/list.html:281 src/olympia/devhub/templates/devhub/versions/list.html:315
+#: src/olympia/devhub/templates/devhub/versions/list.html:349 src/olympia/reviews/templates/reviews/edit_review.html:16 src/olympia/translations/templates/translations/trans-menu.html:50
 #: src/olympia/translations/templates/translations/trans-menu.html:62
 msgid "or"
 msgstr "ili"
@@ -373,7 +369,7 @@ msgid "Add-on Information for {0}"
 msgstr "Informacija dodatka za {0}"
 
 #: src/olympia/addons/templates/addons/details_box.html:30 src/olympia/addons/templates/addons/persona_detail_table.html:3 src/olympia/addons/templates/addons/mobile/details.html:63
-#: src/olympia/addons/templates/addons/mobile/persona_detail_table.html:7 src/olympia/browse/views.py:459 src/olympia/devhub/views.py:75
+#: src/olympia/addons/templates/addons/mobile/persona_detail_table.html:7 src/olympia/browse/views.py:426 src/olympia/devhub/views.py:73
 msgid "Updated"
 msgstr "Ažurirano"
 
@@ -392,11 +388,11 @@ msgstr "Kompatibilan sa"
 msgid "Visibility"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/details_box.html:57 src/olympia/devhub/templates/devhub/index.html:94 src/olympia/devhub/templates/devhub/includes/addon_details.html:104
+#: src/olympia/addons/templates/addons/details_box.html:57 src/olympia/devhub/templates/devhub/index.html:94 src/olympia/devhub/templates/devhub/includes/addon_details.html:91
 msgid "Hidden"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/details_box.html:59 src/olympia/devhub/templates/devhub/index.html:96 src/olympia/devhub/templates/devhub/includes/addon_details.html:106
+#: src/olympia/addons/templates/addons/details_box.html:59 src/olympia/devhub/templates/devhub/index.html:96 src/olympia/devhub/templates/devhub/includes/addon_details.html:93
 msgid "Unlisted"
 msgstr ""
 
@@ -405,13 +401,13 @@ msgid "Required Add-ons"
 msgstr ""
 
 # 100%
-#: src/olympia/addons/templates/addons/details_box.html:81 src/olympia/addons/templates/addons/persona_detail_table.html:15 src/olympia/browse/views.py:462 src/olympia/devhub/views.py:78
-#: src/olympia/devhub/views.py:85 src/olympia/discovery/templates/discovery/addons/detail.html:57 src/olympia/reviews/forms.py:62 src/olympia/reviews/templates/reviews/add.html:57
+#: src/olympia/addons/templates/addons/details_box.html:81 src/olympia/addons/templates/addons/persona_detail_table.html:15 src/olympia/browse/views.py:429 src/olympia/devhub/views.py:76
+#: src/olympia/devhub/views.py:83 src/olympia/discovery/templates/discovery/addons/detail.html:57 src/olympia/reviews/forms.py:62 src/olympia/reviews/templates/reviews/add.html:57
 #: src/olympia/reviews/templates/reviews/mobile/review_list.html:18
 msgid "Rating"
 msgstr "Ocjena"
 
-#: src/olympia/addons/templates/addons/details_box.html:85 src/olympia/browse/views.py:461 src/olympia/devhub/views.py:77 src/olympia/devhub/views.py:84
+#: src/olympia/addons/templates/addons/details_box.html:85 src/olympia/browse/views.py:428 src/olympia/devhub/views.py:75 src/olympia/devhub/views.py:82
 #: src/olympia/stats/templates/stats/addon_report_menu.html:8 src/olympia/stats/templates/stats/collection_report_menu.html:18
 msgid "Downloads"
 msgstr "Preuzimanja"
@@ -431,7 +427,7 @@ msgstr ""
 
 #. The Privacy Policy for this add-on.
 #: src/olympia/addons/templates/addons/details_box.html:121 src/olympia/addons/templates/addons/privacy.html:19 src/olympia/addons/templates/addons/privacy.html:23
-#: src/olympia/addons/templates/addons/impala/button.html:43 src/olympia/addons/templates/addons/impala/details.html:307 src/olympia/devhub/templates/devhub/includes/policy_form.html:20
+#: src/olympia/addons/templates/addons/impala/button.html:43 src/olympia/addons/templates/addons/impala/details.html:312 src/olympia/devhub/templates/devhub/includes/policy_form.html:23
 #: src/olympia/templates/mobile/base_addons.html:87
 msgid "Privacy Policy"
 msgstr "Zaštita Privatnosti"
@@ -457,7 +453,7 @@ msgstr "Galerija slika"
 msgid "Developer Comments"
 msgstr "Komentari programera"
 
-#: src/olympia/addons/templates/addons/details_box.html:199 src/olympia/addons/templates/addons/impala/details.html:259
+#: src/olympia/addons/templates/addons/details_box.html:199 src/olympia/addons/templates/addons/impala/details.html:264
 msgid "Development Channel"
 msgstr ""
 
@@ -479,7 +475,7 @@ msgstr ""
 "<strong>Oprez:</strong> Razvojne inačice ovog dodatka još nisu pregledane od strane Mozille. Nakon što ste instalirali razvojnu inačicu nastavit ćete primati razvojna programerska ažuriranja. Da "
 "biste prestali primati razvojna ažuriranja, ponovno instalirajte standardnu inačicu s gore navedenog linka."
 
-#: src/olympia/addons/templates/addons/details_box.html:220 src/olympia/addons/templates/addons/impala/details.html:278
+#: src/olympia/addons/templates/addons/details_box.html:220 src/olympia/addons/templates/addons/impala/details.html:283
 msgid "Version {0}:"
 msgstr "Verzija {0}:"
 
@@ -498,7 +494,7 @@ msgid "End-User License Agreement for {0}"
 msgstr "End_User Ugovor o licenci za {0}"
 
 #: src/olympia/addons/templates/addons/eula.html:17 src/olympia/addons/templates/addons/eula.html:21 src/olympia/addons/templates/addons/impala/button.html:48
-#: src/olympia/addons/templates/addons/impala/details.html:316 src/olympia/devhub/templates/devhub/includes/policy_form.html:3 src/olympia/discovery/templates/discovery/addons/eula.html:11
+#: src/olympia/addons/templates/addons/impala/details.html:321 src/olympia/devhub/templates/devhub/includes/policy_form.html:3 src/olympia/discovery/templates/discovery/addons/eula.html:11
 msgid "End-User License Agreement"
 msgstr "End_User Ugovor o licenci"
 
@@ -515,7 +511,7 @@ msgstr ""
 msgid "Add-ons for {0}"
 msgstr "Dodaci za {0}"
 
-#: src/olympia/addons/templates/addons/home.html:10 src/olympia/addons/templates/addons/home.html:51 src/olympia/browse/templates/browse/impala/base_listing.html:11
+#: src/olympia/addons/templates/addons/home.html:10 src/olympia/addons/templates/addons/home.html:53 src/olympia/browse/templates/browse/impala/base_listing.html:11
 msgid "Featured Extensions"
 msgstr "Preporučene ekstenzije"
 
@@ -523,30 +519,30 @@ msgstr "Preporučene ekstenzije"
 msgid "Popular Extensions"
 msgstr "Popularne ekstenzije"
 
-#: src/olympia/addons/templates/addons/home.html:42 src/olympia/amo/templates/amo/side_nav.html:3 src/olympia/amo/templates/amo/side_nav.html:11 src/olympia/amo/templates/amo/site_nav.html:3
-#: src/olympia/amo/templates/amo/site_nav.html:25 src/olympia/browse/views.py:236 src/olympia/browse/views.py:281 src/olympia/browse/views.py:481
+#: src/olympia/addons/templates/addons/home.html:44 src/olympia/amo/templates/amo/side_nav.html:3 src/olympia/amo/templates/amo/side_nav.html:11 src/olympia/amo/templates/amo/site_nav.html:3
+#: src/olympia/amo/templates/amo/site_nav.html:25 src/olympia/browse/views.py:203 src/olympia/browse/views.py:248 src/olympia/browse/views.py:448
 msgid "Most Popular"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/home.html:43
+#: src/olympia/addons/templates/addons/home.html:45
 msgid "All »"
 msgstr ""
 
 # 77%
-#: src/olympia/addons/templates/addons/home.html:52 src/olympia/addons/templates/addons/home.html:61 src/olympia/addons/templates/addons/home.html:70 src/olympia/addons/templates/addons/home.html:78
+#: src/olympia/addons/templates/addons/home.html:54 src/olympia/addons/templates/addons/home.html:63 src/olympia/addons/templates/addons/home.html:72 src/olympia/addons/templates/addons/home.html:80
 #: src/olympia/browse/templates/browse/impala/category_landing.html:36
 msgid "See all »"
 msgstr "Vidi sve »"
 
-#: src/olympia/addons/templates/addons/home.html:60
+#: src/olympia/addons/templates/addons/home.html:62
 msgid "Up &amp; Coming Extensions"
 msgstr "Up &amp; Ekstenzije koje dolaze"
 
-#: src/olympia/addons/templates/addons/home.html:69 src/olympia/browse/templates/browse/personas/category_landing.html:61 src/olympia/discovery/templates/discovery/pane.html:74
+#: src/olympia/addons/templates/addons/home.html:71 src/olympia/browse/templates/browse/personas/category_landing.html:61 src/olympia/discovery/templates/discovery/pane.html:74
 msgid "Featured Themes"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/home.html:77 src/olympia/bandwagon/templates/bandwagon/impala/collection_listing.html:5
+#: src/olympia/addons/templates/addons/home.html:79 src/olympia/bandwagon/templates/bandwagon/impala/collection_listing.html:5
 msgid "Featured Collections"
 msgstr "Istaknute zbirke"
 
@@ -564,7 +560,7 @@ msgid "Updated {0}"
 msgstr ""
 
 #. {0} is a date.
-#: src/olympia/addons/templates/addons/macros.html:10 src/olympia/addons/templates/addons/macros.html:69 src/olympia/addons/templates/addons/persona_preview.html:21
+#: src/olympia/addons/templates/addons/macros.html:10 src/olympia/addons/templates/addons/macros.html:69 src/olympia/addons/templates/addons/persona_preview.html:22
 #: src/olympia/addons/templates/addons/listing/items_mobile.html:44 src/olympia/addons/templates/addons/listing/macros.html:39
 #: src/olympia/bandwagon/templates/bandwagon/collection_listing_items.html:37 src/olympia/bandwagon/templates/bandwagon/impala/collection_listing_items.html:37
 msgid "Added {0}"
@@ -576,7 +572,6 @@ msgid "%(num)s weekly download"
 msgid_plural "%(num)s weekly downloads"
 msgstr[0] ""
 msgstr[1] ""
-msgstr[2] ""
 
 #: src/olympia/addons/templates/addons/macros.html:28
 #, python-format
@@ -584,24 +579,20 @@ msgid "%(num)s user"
 msgid_plural "%(num)s users"
 msgstr[0] ""
 msgstr[1] ""
-msgstr[2] ""
 
 #. {0} is the number of downloads.
-#: src/olympia/addons/templates/addons/macros.html:53 src/olympia/addons/templates/addons/impala/details.html:61
+#: src/olympia/addons/templates/addons/macros.html:53 src/olympia/addons/templates/addons/impala/details.html:59
 msgid "{0} weekly download"
 msgid_plural "{0} weekly downloads"
 msgstr[0] "{0} tjedno preuzimanje"
 msgstr[1] "{0} tjedno preuzimanja"
-msgstr[2] "{0} tjedno preuzimanja"
 
 #. {0} is the number of users.
-#: src/olympia/addons/templates/addons/macros.html:61 src/olympia/addons/templates/addons/impala/details.html:54 src/olympia/compat/templates/compat/index.html:71
-#: src/olympia/zadmin/templates/zadmin/compat.html:67
+#: src/olympia/addons/templates/addons/macros.html:61 src/olympia/addons/templates/addons/impala/details.html:52 src/olympia/zadmin/templates/zadmin/compat.html:67
 msgid "{0} user"
 msgid_plural "{0} users"
 msgstr[0] ""
 msgstr[1] ""
-msgstr[2] ""
 
 #: src/olympia/addons/templates/addons/paypal_result.html:12
 msgid "Payment cancelled"
@@ -615,7 +606,7 @@ msgstr "Uplata završena"
 msgid "Return to the addon."
 msgstr ""
 
-#: src/olympia/addons/templates/addons/persona_detail.html:17 src/olympia/addons/templates/addons/impala/details.html:106 src/olympia/addons/templates/addons/mobile/details.html:23
+#: src/olympia/addons/templates/addons/persona_detail.html:17 src/olympia/addons/templates/addons/impala/details.html:103 src/olympia/addons/templates/addons/mobile/details.html:23
 #: src/olympia/addons/templates/addons/mobile/persona_detail.html:21 src/olympia/discovery/templates/discovery/addons/base.html:27 src/olympia/editors/templates/editors/review.html:31
 msgid "by"
 msgstr "od"
@@ -659,36 +650,36 @@ msgstr "Dnevni korisnici"
 msgid "License"
 msgstr "Licenca"
 
-#: src/olympia/addons/templates/addons/persona_preview.html:12 src/olympia/constants/base.py:48
+#: src/olympia/addons/templates/addons/persona_preview.html:13 src/olympia/constants/base.py:48
 msgid "Awaiting Review"
 msgstr ""
 
 # 87%
-#: src/olympia/addons/templates/addons/persona_preview.html:14 src/olympia/amo/log.py:180 src/olympia/constants/base.py:42 src/olympia/editors/helpers.py:62
+#: src/olympia/addons/templates/addons/persona_preview.html:15 src/olympia/amo/log.py:180 src/olympia/constants/base.py:42 src/olympia/editors/helpers.py:62
 msgid "Rejected"
 msgstr "Odbijeno"
 
-#: src/olympia/addons/templates/addons/persona_preview.html:16 src/olympia/amo/log.py:159
+#: src/olympia/addons/templates/addons/persona_preview.html:17 src/olympia/amo/log.py:159
 msgid "Approved"
 msgstr ""
 
 #. {0} is the number of users.
-#: src/olympia/addons/templates/addons/persona_preview.html:26 src/olympia/addons/templates/addons/listing/items_mobile.html:36 src/olympia/addons/templates/addons/listing/macros.html:31
+#: src/olympia/addons/templates/addons/persona_preview.html:27 src/olympia/addons/templates/addons/listing/items_mobile.html:36 src/olympia/addons/templates/addons/listing/macros.html:31
 msgid "<strong>{0}</strong> user"
 msgid_plural "<strong>{0}</strong> users"
 msgstr[0] ""
 msgstr[1] ""
-msgstr[2] ""
 
-#: src/olympia/addons/templates/addons/persona_preview.html:40
+#: src/olympia/addons/templates/addons/persona_preview.html:41
 msgid "Hover to Preview"
 msgstr "Pređite preko izgleda"
 
-#: src/olympia/addons/templates/addons/persona_preview.html:46 src/olympia/addons/templates/addons/persona_preview.html:48 src/olympia/reviews/templates/reviews/add.html:15
+#: src/olympia/addons/templates/addons/persona_preview.html:47 src/olympia/addons/templates/addons/persona_preview.html:49 src/olympia/addons/templates/addons/persona_preview.html:97
+#: src/olympia/reviews/templates/reviews/add.html:15
 msgid "Add"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/persona_preview.html:57 src/olympia/bandwagon/templates/bandwagon/ajax_new.html:16 src/olympia/bandwagon/templates/bandwagon/edit.html:19
+#: src/olympia/addons/templates/addons/persona_preview.html:58 src/olympia/bandwagon/templates/bandwagon/ajax_new.html:16 src/olympia/bandwagon/templates/bandwagon/edit.html:19
 #: src/olympia/bandwagon/templates/bandwagon/includes/addedit.html:19 src/olympia/devhub/templates/devhub/addons/edit/admin.html:13 src/olympia/devhub/templates/devhub/addons/edit/basic.html:10
 #: src/olympia/devhub/templates/devhub/addons/edit/details.html:8 src/olympia/devhub/templates/devhub/addons/edit/media.html:6 src/olympia/devhub/templates/devhub/addons/edit/support.html:8
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:9 src/olympia/devhub/templates/devhub/addons/submit/describe.html:29 src/olympia/editors/templates/editors/review.html:257
@@ -697,21 +688,21 @@ msgstr ""
 
 #. For datetime formatting, see the table on
 #. http://docs.python.org/library/datetime.html#strftime-and-strptime-behavior
-#: src/olympia/addons/templates/addons/persona_preview.html:66
+#: src/olympia/addons/templates/addons/persona_preview.html:67
 #, python-format
 msgid "%%Y-%%m-%%d"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/persona_preview.html:67
+#: src/olympia/addons/templates/addons/persona_preview.html:68
 msgid "by {0} on {1}"
 msgstr "od {0} na {1}"
 
-#: src/olympia/addons/templates/addons/persona_preview.html:75 src/olympia/reviews/helpers.py:17 src/olympia/reviews/templates/reviews/review_list.html:63
+#: src/olympia/addons/templates/addons/persona_preview.html:76 src/olympia/reviews/helpers.py:17 src/olympia/reviews/templates/reviews/review_list.html:63
 #: src/olympia/reviews/templates/reviews/reviews_link.html:21 src/olympia/reviews/templates/reviews/impala/reviews_link.html:16
 msgid "Not yet rated"
 msgstr "Još nije ocijenjeno"
 
-#: src/olympia/addons/templates/addons/persona_preview.html:78
+#: src/olympia/addons/templates/addons/persona_preview.html:79
 msgid "<b>{0}</b> users"
 msgstr "<b>{0}</b> korisnika"
 
@@ -724,8 +715,8 @@ msgid "Learn more about Firefox"
 msgstr ""
 
 #: src/olympia/addons/templates/addons/popups.html:22
-msgid "or <b><a class=\"installer\" href=\"{url}\">download anyway</a></b>"
-msgstr "ili <b><a class=\"installer\" href=\"{url}\">svejedno preuzmi</a></b>"
+msgid "or <b><a class=\"button installer\" href=\"{url}\">download anyway</a></b>"
+msgstr ""
 
 #: src/olympia/addons/templates/addons/popups.html:26
 msgid ""
@@ -823,7 +814,7 @@ msgid ""
 msgstr ""
 
 #: src/olympia/addons/templates/addons/report_abuse.html:6 src/olympia/addons/templates/addons/report_abuse_full.html:10 src/olympia/addons/templates/addons/impala/details-more.html:23
-#: src/olympia/addons/templates/addons/impala/details.html:328
+#: src/olympia/addons/templates/addons/impala/details.html:333
 msgid "Report Abuse"
 msgstr ""
 
@@ -842,9 +833,9 @@ msgstr "Pošalji prijavu"
 #: src/olympia/devhub/templates/devhub/addons/ajax_compat_update.html:36 src/olympia/devhub/templates/devhub/addons/profile.html:44 src/olympia/devhub/templates/devhub/addons/edit/admin.html:104
 #: src/olympia/devhub/templates/devhub/addons/edit/basic.html:155 src/olympia/devhub/templates/devhub/addons/edit/details.html:88 src/olympia/devhub/templates/devhub/addons/edit/support.html:70
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:169 src/olympia/devhub/templates/devhub/addons/forms_shared/media.html:152
-#: src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:44 src/olympia/devhub/templates/devhub/personas/edit.html:222 src/olympia/devhub/templates/devhub/versions/add_file_modal.html:79
-#: src/olympia/devhub/templates/devhub/versions/edit.html:140 src/olympia/devhub/templates/devhub/versions/list.html:208 src/olympia/devhub/templates/devhub/versions/list.html:242
-#: src/olympia/devhub/templates/devhub/versions/list.html:276 src/olympia/devhub/templates/devhub/versions/list.html:317 src/olympia/reviews/templates/reviews/edit_review.html:16
+#: src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:43 src/olympia/devhub/templates/devhub/personas/edit.html:222 src/olympia/devhub/templates/devhub/versions/add_file_modal.html:59
+#: src/olympia/devhub/templates/devhub/versions/edit.html:140 src/olympia/devhub/templates/devhub/versions/list.html:208 src/olympia/devhub/templates/devhub/versions/list.html:239
+#: src/olympia/devhub/templates/devhub/versions/list.html:281 src/olympia/devhub/templates/devhub/versions/list.html:315 src/olympia/reviews/templates/reviews/edit_review.html:16
 #: src/olympia/translations/templates/translations/trans-menu.html:50 src/olympia/translations/templates/translations/trans-menu.html:62 src/olympia/zadmin/templates/zadmin/validation.html:105
 msgid "Cancel"
 msgstr ""
@@ -890,7 +881,7 @@ msgstr ""
 msgid "Review Guidelines"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/review_list_box.html:5 src/olympia/addons/templates/addons/impala/details-more.html:27 src/olympia/editors/helpers.py:921
+#: src/olympia/addons/templates/addons/review_list_box.html:5 src/olympia/addons/templates/addons/impala/details-more.html:27 src/olympia/editors/helpers.py:1001
 #: src/olympia/reviews/templates/reviews/add.html:14 src/olympia/reviews/templates/reviews/reply.html:14 src/olympia/reviews/templates/reviews/review_list.html:19
 #: src/olympia/reviews/templates/reviews/mobile/review_list.html:26
 msgid "Reviews"
@@ -911,7 +902,6 @@ msgid "See all reviews of this add-on"
 msgid_plural "See all %(cnt)s reviews of this add-on"
 msgstr[0] "Vidi sve revizije ovog dodatka"
 msgstr[1] "Vidi sve %(cnt)s revizije ovih dodataka"
-msgstr[2] "Vidi sve %(cnt)s revizije ovih dodataka"
 
 #: src/olympia/addons/templates/addons/tags_box.html:3 src/olympia/devhub/templates/devhub/addons/edit/basic.html:118
 msgid "Tags"
@@ -981,124 +971,121 @@ msgid "Other add-ons by %(author)s"
 msgid_plural "Other add-ons by these authors"
 msgstr[0] ""
 msgstr[1] ""
-msgstr[2] ""
 
-#: src/olympia/addons/templates/addons/impala/details.html:41
+#: src/olympia/addons/templates/addons/impala/details.html:39
 #, python-format
 msgid "<span itemprop=\"ratingCount\">%(num)s</span> user review"
 msgid_plural "<span itemprop=\"ratingCount\">%(num)s</span> user reviews"
 msgstr[0] ""
 msgstr[1] ""
-msgstr[2] ""
 
-#: src/olympia/addons/templates/addons/impala/details.html:69
+#: src/olympia/addons/templates/addons/impala/details.html:66
 msgid "View statistics"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/impala/details.html:84
+#: src/olympia/addons/templates/addons/impala/details.html:81
 msgid "Manage"
 msgstr ""
 
 #. {0} is an add-on name.
-#: src/olympia/addons/templates/addons/impala/details.html:96
+#: src/olympia/addons/templates/addons/impala/details.html:93
 msgid "Icon of {0}"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/impala/details.html:103 src/olympia/addons/templates/addons/impala/listing/items.html:14
+#: src/olympia/addons/templates/addons/impala/details.html:100 src/olympia/addons/templates/addons/impala/listing/items.html:14
 msgid "No Restart"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/impala/details.html:127
+#: src/olympia/addons/templates/addons/impala/details.html:124
 #, python-format
 msgid "Meet the Developer: <a href=\"%(url)s\">%(name)s</a>"
 msgid_plural "<a href=\"%(url)s\">Meet the Developers</a>"
 msgstr[0] ""
 msgstr[1] ""
-msgstr[2] ""
 
-#: src/olympia/addons/templates/addons/impala/details.html:137
+#: src/olympia/addons/templates/addons/impala/details.html:134
 msgid "Learn why {0} was created and find out what's next for this add-on."
 msgstr "Saznajte zašto je kreiran {0} i što je sljedeće za ovaj dodatak."
 
 #. {0} is an index.
-#: src/olympia/addons/templates/addons/impala/details.html:156
+#: src/olympia/addons/templates/addons/impala/details.html:161
 msgid "Add-on screenshot #{0}"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/impala/details.html:182
+#: src/olympia/addons/templates/addons/impala/details.html:187
 msgid "Add-on home page"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/impala/details.html:185
+#: src/olympia/addons/templates/addons/impala/details.html:190
 msgid "Support site"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/impala/details.html:189
+#: src/olympia/addons/templates/addons/impala/details.html:194
 msgid "Support E-mail"
 msgstr ""
 
 # 91%
-#: src/olympia/addons/templates/addons/impala/details.html:194 src/olympia/devhub/models.py:378 src/olympia/devhub/templates/devhub/versions/list.html:12
+#: src/olympia/addons/templates/addons/impala/details.html:199 src/olympia/devhub/models.py:378 src/olympia/devhub/templates/devhub/versions/list.html:12
 #: src/olympia/versions/templates/versions/version.html:6 src/olympia/versions/templates/versions/mobile/version.html:6
 msgid "Version {0}"
 msgstr "Inačica {0}"
 
-#: src/olympia/addons/templates/addons/impala/details.html:194
+#: src/olympia/addons/templates/addons/impala/details.html:199
 msgid "Info"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/impala/details.html:195 src/olympia/devhub/templates/devhub/includes/addon_details.html:129
+#: src/olympia/addons/templates/addons/impala/details.html:200 src/olympia/devhub/templates/devhub/includes/addon_details.html:116
 msgid "Last Updated:"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/impala/details.html:200
+#: src/olympia/addons/templates/addons/impala/details.html:205
 #, python-format
 msgid "Released under <a target=\"_blank\" href=\"%(url)s\">%(name)s</a>"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/impala/details.html:201 src/olympia/addons/templates/addons/impala/details.html:206 src/olympia/amo/helpers.py:398 src/olympia/devhub/forms.py:142
+#: src/olympia/addons/templates/addons/impala/details.html:206 src/olympia/addons/templates/addons/impala/details.html:211 src/olympia/amo/helpers.py:398 src/olympia/devhub/forms.py:142
 #: src/olympia/devhub/forms.py:173 src/olympia/versions/templates/versions/version.html:40 src/olympia/versions/templates/versions/version.html:45
 msgid "Custom License"
 msgstr "Korisnička licenca"
 
-#: src/olympia/addons/templates/addons/impala/details.html:205
+#: src/olympia/addons/templates/addons/impala/details.html:210
 #, python-format
 msgid "Released under <a href=\"%(url)s\">%(name)s</a>"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/impala/details.html:217
+#: src/olympia/addons/templates/addons/impala/details.html:222
 msgid "About this Add-on"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/impala/details.html:233
+#: src/olympia/addons/templates/addons/impala/details.html:238
 msgid "Developer’s Comments"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/impala/details.html:243
+#: src/olympia/addons/templates/addons/impala/details.html:248
 msgid "Version Information"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/impala/details.html:250
+#: src/olympia/addons/templates/addons/impala/details.html:255
 msgid "See complete version history"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/impala/details.html:262
+#: src/olympia/addons/templates/addons/impala/details.html:267
 msgid ""
 "The Development Channel lets you test an experimental new version of this add-on before it's released to the general public. Once you install the development version, you will continue to get "
 "updates from this channel. To stop receiving development updates, reinstall the default version from the link above."
 msgstr ""
 
-#: src/olympia/addons/templates/addons/impala/details.html:272
+#: src/olympia/addons/templates/addons/impala/details.html:277
 msgid "<strong>Caution:</strong> Development versions of this add-on have not been reviewed by Mozilla."
 msgstr ""
 
-#: src/olympia/addons/templates/addons/impala/details.html:287
+#: src/olympia/addons/templates/addons/impala/details.html:292
 msgid "See complete development channel history"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/impala/details.html:306 src/olympia/addons/templates/addons/impala/details.html:315 src/olympia/addons/templates/addons/impala/details.html:327
+#: src/olympia/addons/templates/addons/impala/details.html:311 src/olympia/addons/templates/addons/impala/details.html:320 src/olympia/addons/templates/addons/impala/details.html:332
 #: src/olympia/addons/templates/addons/impala/review_add_box.html:4 src/olympia/stats/templates/stats/popup.html:2 src/olympia/stats/templates/stats/popup.html:8
-#: src/olympia/stats/templates/stats/stats.html:202 src/olympia/users/templates/users/profile.html:119
+#: src/olympia/stats/templates/stats/stats.html:204 src/olympia/users/templates/users/profile.html:119
 msgid "close"
 msgstr ""
 
@@ -1129,7 +1116,6 @@ msgid "About the Developer"
 msgid_plural "About the Developers"
 msgstr[0] ""
 msgstr[1] ""
-msgstr[2] ""
 
 #: src/olympia/addons/templates/addons/impala/developers.html:96 src/olympia/users/templates/users/edit.html:130 src/olympia/users/templates/users/profile.html:26
 msgid "No Photo"
@@ -1155,15 +1141,11 @@ msgstr "Licenca izvornog koda za {addon}"
 msgid "Source Code License"
 msgstr "Licenca izvornog koda"
 
-#: src/olympia/addons/templates/addons/impala/persona_grid.html:16 src/olympia/addons/templates/addons/impala/toplist.html:6
-msgid "{0} users"
-msgstr ""
-
 #: src/olympia/addons/templates/addons/impala/review_list_box.html:19 src/olympia/reviews/templates/reviews/review.html:40
 msgid "permalink"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/impala/review_list_box.html:23 src/olympia/editors/templates/editors/queue.html:98 src/olympia/reviews/templates/reviews/review.html:44
+#: src/olympia/addons/templates/addons/impala/review_list_box.html:23 src/olympia/editors/templates/editors/queue.html:104 src/olympia/reviews/templates/reviews/review.html:44
 msgid "translate"
 msgstr ""
 
@@ -1173,7 +1155,6 @@ msgid "See all user reviews"
 msgid_plural "See all %(cnt)s user reviews"
 msgstr[0] ""
 msgstr[1] ""
-msgstr[2] ""
 
 #: src/olympia/addons/templates/addons/impala/review_list_box.html:47 src/olympia/reviews/templates/reviews/review_list.html:84
 msgid "This add-on has not yet been reviewed."
@@ -1181,6 +1162,10 @@ msgstr ""
 
 #: src/olympia/addons/templates/addons/impala/review_list_box.html:50
 msgid "Be the first!"
+msgstr ""
+
+#: src/olympia/addons/templates/addons/impala/toplist.html:6
+msgid "{0} users"
 msgstr ""
 
 #: src/olympia/addons/templates/addons/impala/listing/sorter.html:14 src/olympia/devhub/templates/devhub/addons/listing/item_actions.html:49
@@ -1196,7 +1181,7 @@ msgstr "Dodaj u zbirku"
 msgid "My Add-ons"
 msgstr "Moji Add-ons"
 
-#: src/olympia/addons/templates/addons/includes/dashboard_tabs.html:6 src/olympia/amo/context_processors.py:51
+#: src/olympia/addons/templates/addons/includes/dashboard_tabs.html:6 src/olympia/amo/context_processors.py:50
 msgid "My Themes"
 msgstr ""
 
@@ -1238,7 +1223,6 @@ msgid "<strong>{0}</strong> weekly download"
 msgid_plural "<strong>{0}</strong> weekly downloads"
 msgstr[0] ""
 msgstr[1] ""
-msgstr[2] ""
 
 #: src/olympia/addons/templates/addons/mobile/details.html:32
 msgid "Read More"
@@ -1252,7 +1236,7 @@ msgstr ""
 msgid "Weekly Downloads"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/mobile/details.html:99 src/olympia/compat/templates/compat/reporter_detail.html:46 src/olympia/devhub/forms.py:787
+#: src/olympia/addons/templates/addons/mobile/details.html:99 src/olympia/compat/templates/compat/reporter_detail.html:46 src/olympia/devhub/forms.py:788
 #: src/olympia/devhub/templates/devhub/versions/list.html:163
 msgid "Version"
 msgstr "Inačica"
@@ -1336,7 +1320,7 @@ msgstr ""
 #: src/olympia/browse/templates/browse/personas/category_landing.html:21 src/olympia/browse/templates/browse/personas/category_landing.html:23
 #: src/olympia/browse/templates/browse/personas/category_landing.html:38 src/olympia/browse/templates/browse/personas/grid.html:7 src/olympia/browse/templates/browse/personas/grid.html:11
 #: src/olympia/browse/templates/browse/personas/mobile/base.html:7 src/olympia/browse/templates/browse/personas/mobile/category_landing.html:19 src/olympia/constants/base.py:180
-#: src/olympia/devhub/templates/devhub/personas/submit.html:13 src/olympia/editors/helpers.py:105 src/olympia/editors/templates/editors/base.html:26
+#: src/olympia/devhub/templates/devhub/personas/submit.html:13 src/olympia/editors/helpers.py:107 src/olympia/editors/templates/editors/base.html:26
 #: src/olympia/editors/templates/editors/performance.html:73 src/olympia/search/templates/search/personas.html:39 src/olympia/templates/menu_links.html:9
 msgid "Themes"
 msgstr "Teme"
@@ -1357,7 +1341,7 @@ msgstr ""
 msgid "Highest Rated"
 msgstr "Najviše rangirani"
 
-#: src/olympia/addons/templates/addons/mobile/home.html:74 src/olympia/amo/templates/amo/side_nav.html:5 src/olympia/amo/templates/amo/site_nav.html:27 src/olympia/amo/templates/amo/site_nav.html:57
+#: src/olympia/addons/templates/addons/mobile/home.html:74 src/olympia/amo/templates/amo/side_nav.html:5 src/olympia/amo/templates/amo/site_nav.html:27 src/olympia/amo/templates/amo/site_nav.html:55
 #: src/olympia/bandwagon/views.py:97 src/olympia/browse/views.py:57 src/olympia/browse/views.py:67 src/olympia/browse/templates/browse/personas/mobile/category_landing.html:65
 #: src/olympia/search/forms.py:15 src/olympia/search/forms.py:87
 msgid "Newest"
@@ -1371,90 +1355,90 @@ msgstr ""
 msgid "Theme Info &raquo;"
 msgstr ""
 
-#: src/olympia/amo/context_processors.py:39 src/olympia/devhub/templates/devhub/nav.html:43
+#: src/olympia/amo/context_processors.py:37 src/olympia/devhub/templates/devhub/nav.html:43
 msgid "Tools"
 msgstr ""
 
-#: src/olympia/amo/context_processors.py:48 src/olympia/discovery/templates/discovery/pane_account.html:8 src/olympia/users/templates/users/includes/navigation.html:2
+#: src/olympia/amo/context_processors.py:47 src/olympia/discovery/templates/discovery/pane_account.html:8 src/olympia/users/templates/users/includes/navigation.html:2
 msgid "My Profile"
 msgstr ""
 
-#: src/olympia/amo/context_processors.py:54 src/olympia/users/templates/users/edit.html:5 src/olympia/users/templates/users/includes/navigation.html:3
+#: src/olympia/amo/context_processors.py:53 src/olympia/users/templates/users/edit.html:5 src/olympia/users/templates/users/includes/navigation.html:3
 msgid "Account Settings"
 msgstr "Postavke računa"
 
-#: src/olympia/amo/context_processors.py:57 src/olympia/discovery/templates/discovery/pane_account.html:11 src/olympia/users/templates/users/profile.html:83
+#: src/olympia/amo/context_processors.py:56 src/olympia/discovery/templates/discovery/pane_account.html:11 src/olympia/users/templates/users/profile.html:83
 #: src/olympia/users/templates/users/includes/navigation.html:4
 msgid "My Collections"
 msgstr ""
 
-#: src/olympia/amo/context_processors.py:62 src/olympia/discovery/templates/discovery/pane_account.html:10 src/olympia/users/templates/users/includes/navigation.html:7
+#: src/olympia/amo/context_processors.py:61 src/olympia/discovery/templates/discovery/pane_account.html:10 src/olympia/users/templates/users/includes/navigation.html:7
 msgid "My Favorites"
 msgstr ""
 
-#: src/olympia/amo/context_processors.py:67 src/olympia/discovery/templates/discovery/pane_account.html:13 src/olympia/templates/impala/user_login.html:14
+#: src/olympia/amo/context_processors.py:66 src/olympia/discovery/templates/discovery/pane_account.html:13 src/olympia/templates/impala/user_login.html:14
 #: src/olympia/templates/mobile/header_auth.html:5
 msgid "Log out"
 msgstr ""
 
-#: src/olympia/amo/context_processors.py:72 src/olympia/devhub/templates/devhub/addons/dashboard.html:4
+#: src/olympia/amo/context_processors.py:71 src/olympia/devhub/templates/devhub/addons/dashboard.html:4
 msgid "Manage My Submissions"
 msgstr ""
 
-#: src/olympia/amo/context_processors.py:75 src/olympia/devhub/templates/devhub/nav.html:27 src/olympia/devhub/templates/devhub/addons/dashboard.html:25
+#: src/olympia/amo/context_processors.py:74 src/olympia/devhub/templates/devhub/nav.html:27 src/olympia/devhub/templates/devhub/addons/dashboard.html:25
 #: src/olympia/devhub/templates/devhub/addons/submit/base.html:4
 msgid "Submit a New Add-on"
 msgstr ""
 
-#: src/olympia/amo/context_processors.py:77 src/olympia/browse/templates/browse/personas/base.html:50 src/olympia/devhub/templates/devhub/index.html:24
+#: src/olympia/amo/context_processors.py:76 src/olympia/browse/templates/browse/personas/base.html:50 src/olympia/devhub/templates/devhub/index.html:24
 #: src/olympia/devhub/templates/devhub/addons/dashboard.html:29
 msgid "Submit a New Theme"
 msgstr ""
 
-#: src/olympia/amo/context_processors.py:79 src/olympia/amo/templates/amo/site_nav.html:87 src/olympia/devhub/helpers.py:36 src/olympia/devhub/helpers.py:68 src/olympia/devhub/helpers.py:102
+#: src/olympia/amo/context_processors.py:78 src/olympia/amo/templates/amo/site_nav.html:85 src/olympia/devhub/helpers.py:36 src/olympia/devhub/helpers.py:68 src/olympia/devhub/helpers.py:102
 #: src/olympia/templates/footer.html:6 src/olympia/templates/menu_links.html:14
 msgid "Developer Hub"
 msgstr ""
 
-#: src/olympia/amo/context_processors.py:83 src/olympia/devhub/views.py:1792
+#: src/olympia/amo/context_processors.py:81 src/olympia/devhub/views.py:1796
 msgid "Manage API Keys"
 msgstr ""
 
-#: src/olympia/amo/context_processors.py:88 src/olympia/editors/helpers.py:82 src/olympia/editors/helpers.py:102 src/olympia/editors/templates/editors/base.html:10
+#: src/olympia/amo/context_processors.py:86 src/olympia/editors/helpers.py:84 src/olympia/editors/helpers.py:104 src/olympia/editors/templates/editors/base.html:10
 msgid "Editor Tools"
 msgstr "Alati uređivača"
 
-#: src/olympia/amo/context_processors.py:92
+#: src/olympia/amo/context_processors.py:90
 msgid "Admin Tools"
 msgstr ""
 
-#: src/olympia/amo/fields.py:15
+#: src/olympia/amo/fields.py:20
 msgid "Incorrect, please try again."
 msgstr ""
 
-#: src/olympia/amo/fields.py:16
+#: src/olympia/amo/fields.py:21
 msgid "Error verifying input, please try again."
 msgstr ""
 
-#: src/olympia/amo/fields.py:32
+#: src/olympia/amo/fields.py:37
 msgid "This must be a valid hex color code, such as #000000."
 msgstr ""
 
-#: src/olympia/amo/fields.py:58
+#: src/olympia/amo/fields.py:63
 msgid "Enter at least one value."
 msgstr ""
 
-#: src/olympia/amo/helpers.py:162 src/olympia/amo/templates/amo/site_nav.html:61 src/olympia/bandwagon/templates/bandwagon/add.html:9
+#: src/olympia/amo/helpers.py:162 src/olympia/amo/templates/amo/site_nav.html:59 src/olympia/bandwagon/templates/bandwagon/add.html:9
 #: src/olympia/bandwagon/templates/bandwagon/collection_detail.html:15 src/olympia/bandwagon/templates/bandwagon/delete.html:9 src/olympia/bandwagon/templates/bandwagon/edit.html:15
 #: src/olympia/bandwagon/templates/bandwagon/user_listing.html:18 src/olympia/bandwagon/templates/bandwagon/user_listing.html:21
 #: src/olympia/bandwagon/templates/bandwagon/impala/collection_listing.html:12 src/olympia/bandwagon/templates/bandwagon/impala/collection_listing.html:20
 #: src/olympia/bandwagon/templates/bandwagon/impala/collection_listing.html:24 src/olympia/bandwagon/templates/bandwagon/impala/collection_sidebar.html:3
 #: src/olympia/bandwagon/templates/bandwagon/includes/collection_sidebar.html:2 src/olympia/bandwagon/templates/bandwagon/mobile/collection_listing.html:3
-#: src/olympia/stats/templates/stats/stats.html:77 src/olympia/templates/menu_links.html:12
+#: src/olympia/stats/templates/stats/stats.html:33 src/olympia/templates/menu_links.html:12
 msgid "Collections"
 msgstr ""
 
-#: src/olympia/amo/helpers.py:171 src/olympia/amo/templates/amo/site_nav.html:85 src/olympia/browse/templates/browse/language_tools.html:3
+#: src/olympia/amo/helpers.py:171 src/olympia/amo/templates/amo/site_nav.html:83 src/olympia/browse/templates/browse/language_tools.html:3
 msgid "Dictionaries & Language Packs"
 msgstr ""
 
@@ -1607,8 +1591,8 @@ msgstr ""
 msgid "Comment on {addon} {version}."
 msgstr ""
 
-#: src/olympia/amo/log.py:236 src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:19 src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:47
-#: src/olympia/editors/helpers.py:511 src/olympia/editors/templates/editors/themes/history_table.html:11
+#: src/olympia/amo/log.py:236 src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:17 src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:45
+#: src/olympia/editors/helpers.py:584 src/olympia/editors/templates/editors/themes/history_table.html:11
 msgid "Comment"
 msgstr "Komentar"
 
@@ -1914,9 +1898,8 @@ msgstr "Ups"
 
 #: src/olympia/amo/templates/amo/500.html:6
 #, python-format
-msgid "<h1>Oops! We had an error.</h1> <p>We'll get to fixing that soon.</p> <p> You can try refreshing the page, or head back to the <a href=\"%(home)s\">Add-ons homepage</a>. </p>"
+msgid "<h1>Oops!  We had an error.</h1> <p>We'll get to fixing that soon.</p> <p> You can try refreshing the page, or head back to the <a href=\"%(home)s\">Add-ons homepage</a>. </p>"
 msgstr ""
-"<h1>Ups! Dogodila se pogreška.</h1> <p>Popraviti ćemo to uskoro.</p> <p> Možete pokušati ponovno učitati stranicu ili vratiti se natrag na <a href=\"%(home)s\">početnu stranicu dodataka</a>. </p>"
 
 #: src/olympia/amo/templates/amo/license_link.html:10
 msgid "Some rights reserved"
@@ -1938,7 +1921,7 @@ msgstr ""
 #: src/olympia/amo/templates/amo/mobile/paginator.html:14 src/olympia/amo/templates/amo/mobile/paginator.html:16 src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:51
 #: src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:65 src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:78
 #: src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:91 src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:104
-#: src/olympia/discovery/templates/discovery/pane.html:45 src/olympia/discovery/templates/discovery/addons/detail.html:39 src/olympia/stats/templates/stats/stats.html:167
+#: src/olympia/discovery/templates/discovery/pane.html:45 src/olympia/discovery/templates/discovery/addons/detail.html:39 src/olympia/stats/templates/stats/stats.html:169
 msgid "Next"
 msgstr ""
 
@@ -1970,7 +1953,7 @@ msgid ""
 msgstr ""
 
 #: src/olympia/amo/templates/amo/side_nav.html:4 src/olympia/amo/templates/amo/side_nav.html:12 src/olympia/amo/templates/amo/site_nav.html:4 src/olympia/amo/templates/amo/site_nav.html:26
-#: src/olympia/browse/views.py:56 src/olympia/browse/views.py:66 src/olympia/browse/views.py:237 src/olympia/browse/views.py:282 src/olympia/search/forms.py:86
+#: src/olympia/browse/views.py:56 src/olympia/browse/views.py:66 src/olympia/browse/views.py:204 src/olympia/browse/views.py:249 src/olympia/search/forms.py:86
 msgid "Top Rated"
 msgstr ""
 
@@ -1984,38 +1967,38 @@ msgstr "Istraži"
 msgid "Extensions"
 msgstr ""
 
-#: src/olympia/amo/templates/amo/site_nav.html:45
+#: src/olympia/amo/templates/amo/site_nav.html:44
 msgid "Want more customization? Try <b>Complete Themes</b>"
 msgstr ""
 
-#: src/olympia/amo/templates/amo/site_nav.html:56 src/olympia/bandwagon/views.py:96
+#: src/olympia/amo/templates/amo/site_nav.html:54 src/olympia/bandwagon/views.py:96
 msgid "Most Followers"
 msgstr ""
 
-#: src/olympia/amo/templates/amo/site_nav.html:68 src/olympia/bandwagon/templates/bandwagon/impala/collection_sidebar.html:16
+#: src/olympia/amo/templates/amo/site_nav.html:66 src/olympia/bandwagon/templates/bandwagon/impala/collection_sidebar.html:16
 #: src/olympia/bandwagon/templates/bandwagon/includes/collection_sidebar.html:18
 msgid "Collections I've Made"
 msgstr ""
 
-#: src/olympia/amo/templates/amo/site_nav.html:70 src/olympia/bandwagon/templates/bandwagon/user_listing.html:4 src/olympia/bandwagon/templates/bandwagon/impala/collection_sidebar.html:13
+#: src/olympia/amo/templates/amo/site_nav.html:68 src/olympia/bandwagon/templates/bandwagon/user_listing.html:4 src/olympia/bandwagon/templates/bandwagon/impala/collection_sidebar.html:13
 #: src/olympia/bandwagon/templates/bandwagon/includes/collection_sidebar.html:15
 msgid "Collections I'm Following"
 msgstr ""
 
-#: src/olympia/amo/templates/amo/site_nav.html:73 src/olympia/bandwagon/templates/bandwagon/impala/collection_sidebar.html:18
-#: src/olympia/bandwagon/templates/bandwagon/includes/collection_sidebar.html:20 src/olympia/users/models.py:512
+#: src/olympia/amo/templates/amo/site_nav.html:71 src/olympia/bandwagon/templates/bandwagon/impala/collection_sidebar.html:18
+#: src/olympia/bandwagon/templates/bandwagon/includes/collection_sidebar.html:20 src/olympia/users/models.py:521
 msgid "My Favorite Add-ons"
 msgstr "Moji omiljeni dodaci"
 
-#: src/olympia/amo/templates/amo/site_nav.html:78
+#: src/olympia/amo/templates/amo/site_nav.html:76
 msgid "More&hellip;"
 msgstr "Više&hellip;"
 
-#: src/olympia/amo/templates/amo/site_nav.html:82
+#: src/olympia/amo/templates/amo/site_nav.html:80
 msgid "Add-ons for Mobile"
 msgstr ""
 
-#: src/olympia/amo/templates/amo/site_nav.html:86 src/olympia/browse/feeds.py:207 src/olympia/browse/templates/browse/search_tools.html:3 src/olympia/constants/base.py:176
+#: src/olympia/amo/templates/amo/site_nav.html:84 src/olympia/browse/feeds.py:207 src/olympia/browse/templates/browse/search_tools.html:3 src/olympia/constants/base.py:176
 #: src/olympia/templates/menu_links.html:10
 msgid "Search Tools"
 msgstr ""
@@ -2031,7 +2014,7 @@ msgid "Jump to first page"
 msgstr ""
 
 #: src/olympia/amo/templates/amo/impala/paginator.html:22 src/olympia/amo/templates/amo/mobile/impala_paginator.html:12 src/olympia/discovery/templates/discovery/pane.html:44
-#: src/olympia/discovery/templates/discovery/addons/detail.html:38 src/olympia/stats/templates/stats/stats.html:164
+#: src/olympia/discovery/templates/discovery/addons/detail.html:38 src/olympia/stats/templates/stats/stats.html:166
 msgid "Previous"
 msgstr ""
 
@@ -2053,32 +2036,50 @@ msgid "Page {n}"
 msgid_plural "Page {n}"
 msgstr[0] ""
 msgstr[1] ""
-msgstr[2] ""
 
-#: src/olympia/amo/templates/services/install.html:38
-#, python-format
-msgid "If you are not prompted to install %(addon_name)s in a moment, please <a href=\"%(addon_xpi)s\">click here</a>."
-msgstr ""
-
-#: src/olympia/amo/tests/test_messages.py:57 src/olympia/amo/tests/test_messages.py:58 src/olympia/reviews/forms.py:25 src/olympia/reviews/forms.py:50 src/olympia/reviews/templates/reviews/add.html:56
+#: src/olympia/amo/tests/test_messages.py:56 src/olympia/amo/tests/test_messages.py:57 src/olympia/reviews/forms.py:25 src/olympia/reviews/forms.py:50 src/olympia/reviews/templates/reviews/add.html:56
 #: src/olympia/reviews/templates/reviews/reply.html:30
 msgid "Title"
 msgstr ""
 
-#: src/olympia/amo/tests/test_messages.py:57 src/olympia/amo/tests/test_messages.py:58
+#: src/olympia/amo/tests/test_messages.py:56 src/olympia/amo/tests/test_messages.py:57
 msgid "Body"
 msgstr ""
 
-#: src/olympia/amo/tests/test_messages.py:59
+#: src/olympia/amo/tests/test_messages.py:58
 msgid "Another Title"
 msgstr ""
 
-#: src/olympia/amo/tests/test_messages.py:59
+#: src/olympia/amo/tests/test_messages.py:58
 msgid "Another Body"
 msgstr ""
 
-#: src/olympia/api/views.py:255
-msgid "Not implemented yet."
+#: src/olympia/api/authentication.py:76
+msgid "Signature has expired."
+msgstr ""
+
+#: src/olympia/api/authentication.py:79
+msgid "Error decoding signature."
+msgstr ""
+
+#: src/olympia/api/authentication.py:82
+msgid "Invalid JWT Token."
+msgstr ""
+
+#: src/olympia/api/authentication.py:130
+msgid "Invalid Authorization header. No credentials provided."
+msgstr ""
+
+#: src/olympia/api/authentication.py:133
+msgid "Invalid Authorization header. Credentials string should not contain spaces."
+msgstr ""
+
+#: src/olympia/api/fields.py:29
+msgid "The field must have a length of at least {num} characters."
+msgstr ""
+
+#: src/olympia/api/fields.py:31
+msgid "The language code {lang_code} is invalid."
 msgstr ""
 
 #: src/olympia/applications/views.py:39 src/olympia/applications/templates/applications/appversions.html:3
@@ -2097,7 +2098,7 @@ msgstr ""
 msgid "Add-ons submitted to Mozilla Add-ons must have a manifest file with at least one of the below applications supported. Only the versions listed below are allowed for these applications."
 msgstr ""
 
-#: src/olympia/applications/templates/applications/appversions.html:25
+#: src/olympia/applications/templates/applications/appversions.html:25 src/olympia/editors/helpers.py:361
 msgid "GUID"
 msgstr "GUID"
 
@@ -2211,8 +2212,8 @@ msgstr ""
 msgid "Remove from favorites"
 msgstr "Ukloni iz favorita"
 
-#: src/olympia/bandwagon/views.py:98 src/olympia/bandwagon/views.py:191 src/olympia/browse/views.py:58 src/olympia/browse/views.py:69 src/olympia/browse/views.py:458 src/olympia/devhub/views.py:74
-#: src/olympia/devhub/views.py:82 src/olympia/devhub/templates/devhub/addons/edit/basic.html:20 src/olympia/editors/templates/editors/leaderboard.html:24
+#: src/olympia/bandwagon/views.py:98 src/olympia/bandwagon/views.py:191 src/olympia/browse/views.py:58 src/olympia/browse/views.py:69 src/olympia/browse/views.py:425 src/olympia/devhub/views.py:72
+#: src/olympia/devhub/views.py:80 src/olympia/devhub/templates/devhub/addons/edit/basic.html:20 src/olympia/editors/templates/editors/leaderboard.html:24
 #: src/olympia/editors/templates/editors/themes/queue_list.html:48 src/olympia/search/forms.py:17 src/olympia/search/forms.py:89 src/olympia/users/templates/users/vcard.html:5
 msgid "Name"
 msgstr "Ime"
@@ -2221,7 +2222,7 @@ msgstr "Ime"
 msgid "Recently Popular"
 msgstr ""
 
-#: src/olympia/bandwagon/views.py:189 src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:18
+#: src/olympia/bandwagon/views.py:189 src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:16
 msgid "Added"
 msgstr "Dodano"
 
@@ -2235,7 +2236,7 @@ msgstr ""
 
 #: src/olympia/bandwagon/views.py:316
 #, python-format
-msgid "Your new collection is shown below. You can <ahref=\"%(url)s\">edit additional settings</a> if you'dlike."
+msgid "Your new collection is shown below. You can <a href=\"%(url)s\">edit additional settings</a> if you'd like."
 msgstr ""
 
 #: src/olympia/bandwagon/views.py:322
@@ -2322,7 +2323,6 @@ msgid "<span>%(num)s</span> follower"
 msgid_plural "<span>%(num)s</span> followers"
 msgstr[0] "<span>%(num)s</span> pratitelj"
 msgstr[1] "<span>%(num)s</span> pratitelji"
-msgstr[2] "<span>%(num)s</span> pratitelja"
 
 #: src/olympia/bandwagon/templates/bandwagon/collection_detail.html:54
 msgid "About this Collection"
@@ -2362,7 +2362,6 @@ msgid "%(num)s Theme in this Collection"
 msgid_plural "%(num)s Themes in this Collection"
 msgstr[0] ""
 msgstr[1] ""
-msgstr[2] ""
 
 #: src/olympia/bandwagon/templates/bandwagon/collection_detail.html:111
 #, python-format
@@ -2370,10 +2369,9 @@ msgid "%(num)s Add-on in this Collection"
 msgid_plural "%(num)s Add-ons in this Collection"
 msgstr[0] ""
 msgstr[1] ""
-msgstr[2] ""
 
-#: src/olympia/bandwagon/templates/bandwagon/collection_detail.html:125 src/olympia/compat/templates/compat/index.html:25 src/olympia/compat/templates/compat/reporter_detail.html:29
-#: src/olympia/files/templates/files/viewer.html:29 src/olympia/templates/amo_footer.html:17 src/olympia/templates/includes/lang_switcher.html:10
+#: src/olympia/bandwagon/templates/bandwagon/collection_detail.html:125 src/olympia/compat/templates/compat/reporter_detail.html:29 src/olympia/files/templates/files/viewer.html:29
+#: src/olympia/templates/amo_footer.html:17 src/olympia/templates/includes/lang_switcher.html:10
 msgid "Go"
 msgstr "Idi"
 
@@ -2407,11 +2405,9 @@ msgstr ""
 
 #: src/olympia/bandwagon/templates/bandwagon/collection_detail.html:186
 msgid ""
-"Add-ons that you mark as favorites using the <b>Add to Favorites</b> feature appear below. This collection is currently <b>private</b>, which means only you can see it. If you would like everyone "
+"Add-ons that you mark as favorites using the <b>Add to Favorites</b> feature appear below. This collection is currently <b>private</b>, which means only you can see it.  If you would like everyone "
 "to be able to see your favorites, click the button below to make it public."
 msgstr ""
-"Dodaci koje označite kao favorite koristeći <b>Dodaj u favorite</b> značajku pojavljuju se ispod. Ova zbirka je trenutno <b>privatna</b>, što znači da je samo vi možete vidjeti. Ako želite da svi "
-"mogu vidjeti Vaše favorite, pritisnite tipku ispod da je učinite javnom."
 
 #: src/olympia/bandwagon/templates/bandwagon/collection_detail.html:196
 msgid "My favorite add-ons"
@@ -2423,7 +2419,6 @@ msgid "<span>%(addons)s</span> add-on"
 msgid_plural "<span>%(addons)s</span> add-ons"
 msgstr[0] ""
 msgstr[1] ""
-msgstr[2] ""
 
 #: src/olympia/bandwagon/templates/bandwagon/collection_grid.html:32
 #, python-format
@@ -2431,7 +2426,6 @@ msgid "<span>%(followers)s</span> follower"
 msgid_plural "<span>%(followers)s</span> followers"
 msgstr[0] ""
 msgstr[1] ""
-msgstr[2] ""
 
 #. People "follow" collections to get notified of updates.                    Like
 #. Twitter followers.
@@ -2443,7 +2437,6 @@ msgid "%(num)s weekly follower"
 msgid_plural "%(num)s weekly followers"
 msgstr[0] ""
 msgstr[1] ""
-msgstr[2] ""
 
 #. People "follow" collections to get notified of updates.                    Like
 #. Twitter followers.
@@ -2453,7 +2446,6 @@ msgid "%(num)s monthly follower"
 msgid_plural "%(num)s monthly followers"
 msgstr[0] ""
 msgstr[1] ""
-msgstr[2] ""
 
 #. People "follow" collections to get notified of updates.                    Like
 #. Twitter followers.
@@ -2465,7 +2457,6 @@ msgid "%(num)s follower"
 msgid_plural "%(num)s followers"
 msgstr[0] ""
 msgstr[1] ""
-msgstr[2] ""
 
 #: src/olympia/bandwagon/templates/bandwagon/collection_listing_items.html:56 src/olympia/bandwagon/templates/bandwagon/impala/collection_listing_items.html:9
 #: src/olympia/devhub/templates/devhub/personas/edit.html:27
@@ -2549,7 +2540,7 @@ msgid "Remove this user as a contributor"
 msgstr ""
 
 #: src/olympia/bandwagon/templates/bandwagon/edit_contributors.html:18 src/olympia/bandwagon/templates/bandwagon/edit_contributors.html:43
-#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:20 src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:48
+#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:18 src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:46
 #: src/olympia/devhub/templates/devhub/addons/ajax_compat_update.html:19
 msgid "Remove"
 msgstr ""
@@ -2560,11 +2551,9 @@ msgstr ""
 
 #: src/olympia/bandwagon/templates/bandwagon/edit_contributors.html:26
 msgid ""
-"You can add multiple contributors to this collection. A contributor can add and remove add-ons from this collection, but cannot change its name or description. To add a contributor, enter their "
+"You can add multiple contributors to this collection.  A contributor can add and remove add-ons from this collection, but cannot change its name or description.  To add a contributor, enter their "
 "email in the box below. Contributors must have a Mozilla Add-ons account."
 msgstr ""
-"Možete dodati više doprinositelja u ovu zbirku. Doprinositelj može dodati i ukloniti dodatke iz ove zbirke, ali ne može promijeniti ime ili opis. Da bi dodali doprinositelja, unesite njihov email u "
-"polje ispod. Doprinositelji moraju imati Mozilla Add-ons račun."
 
 #: src/olympia/bandwagon/templates/bandwagon/edit_contributors.html:40
 msgid "User"
@@ -2599,7 +2588,7 @@ msgid "<b>Warning:</b> By changing the owner of this collection, you will no lon
 msgstr ""
 
 #: src/olympia/bandwagon/templates/bandwagon/edit_contributors.html:83 src/olympia/devhub/templates/devhub/addons/forms_shared/media.html:157
-#: src/olympia/devhub/templates/devhub/addons/submit/describe.html:69 src/olympia/devhub/templates/devhub/addons/submit/license.html:60 src/olympia/devhub/templates/devhub/addons/submit/upload.html:78
+#: src/olympia/devhub/templates/devhub/addons/submit/describe.html:69 src/olympia/devhub/templates/devhub/addons/submit/license.html:60 src/olympia/devhub/templates/devhub/addons/submit/upload.html:70
 #: src/olympia/devhub/templates/devhub/payments/tier.html:17 src/olympia/editors/templates/editors/themes/themes.html:111 src/olympia/editors/templates/editors/themes/themes.html:128
 #: src/olympia/editors/templates/editors/themes/themes.html:134 src/olympia/editors/templates/editors/themes/themes.html:141 src/olympia/users/templates/users/fxa_migration_prompt_content.html:10
 #: src/olympia/users/templates/users/login_form.html:42 src/olympia/users/templates/users/mobile/login.html:57
@@ -2671,43 +2660,43 @@ msgid "Reset"
 msgstr "Resetiraj"
 
 #: src/olympia/bandwagon/templates/bandwagon/includes/addedit.html:53
-msgid "PNG and JPG supported. Image will be resized to 32x32."
-msgstr "PNG i JPG podržani. Slici će se promijeniti veličina na 32x32."
+msgid "PNG and JPG supported.  Image will be resized to 32x32."
+msgstr ""
 
 #: src/olympia/bandwagon/templates/bandwagon/includes/addedit_errors.html:3
-msgid "There are errors in this form. Please correct them below."
-msgstr "Postoje pogreške u ovom obrascu. Molimo Vas da ih ispravite u nastavku."
+msgid "There are errors in this form.  Please correct them below."
+msgstr ""
 
 #: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:2
 msgid "Add-ons in Your Collection"
 msgstr "Dodaci u Vašoj zbirci"
 
 #: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:4
-msgid ""
-"To include an add-on in this collection, enter its name in the box below and hit enter.  You can also use the <strong>Add to Collection</strong> links throughout the site to include add-ons later."
+msgid "To include an add-on in this collection, enter its name in the box below and hit enter."
 msgstr ""
 
-#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:17 src/olympia/constants/base.py:400 src/olympia/devhub/templates/devhub/addons/activity.html:62
+#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:15 src/olympia/constants/base.py:400 src/olympia/devhub/templates/devhub/addons/activity.html:62
+#: src/olympia/editors/helpers.py:273 src/olympia/editors/helpers.py:360
 msgid "Add-on"
 msgstr ""
 
-#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:26
+#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:24
 msgid "Enter the name of the add-on to include"
 msgstr ""
 
-#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:28
+#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:26
 msgid "Add to Collection"
 msgstr "Dodaj u zbirku"
 
-#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:45 src/olympia/editors/helpers.py:936 src/olympia/editors/helpers.py:956
+#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:43 src/olympia/editors/helpers.py:1016 src/olympia/editors/helpers.py:1036
 msgid "Pending"
 msgstr ""
 
-#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:47
+#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:45
 msgid "Add a comment"
 msgstr ""
 
-#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:48
+#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:46
 msgid "Remove this add-on from the collection"
 msgstr ""
 
@@ -2814,12 +2803,12 @@ msgstr "Alati za pretraživanje"
 msgid "Most Users"
 msgstr ""
 
-#: src/olympia/browse/views.py:61 src/olympia/browse/views.py:72 src/olympia/browse/views.py:279 src/olympia/browse/templates/browse/personas/mobile/category_landing.html:63
+#: src/olympia/browse/views.py:61 src/olympia/browse/views.py:72 src/olympia/browse/views.py:246 src/olympia/browse/templates/browse/personas/mobile/category_landing.html:63
 #: src/olympia/discovery/templates/discovery/pane.html:67 src/olympia/search/forms.py:92
 msgid "Up & Coming"
 msgstr "Aktualni & dolazeći"
 
-#: src/olympia/browse/views.py:460 src/olympia/devhub/views.py:76 src/olympia/devhub/views.py:83 src/olympia/discovery/templates/discovery/addons/detail.html:66
+#: src/olympia/browse/views.py:427 src/olympia/devhub/views.py:74 src/olympia/devhub/views.py:81 src/olympia/discovery/templates/discovery/addons/detail.html:66
 msgid "Created"
 msgstr ""
 
@@ -2901,7 +2890,6 @@ msgid "<b>{0}</b> add-on"
 msgid_plural "<b>{0}</b> add-ons"
 msgstr[0] ""
 msgstr[1] ""
-msgstr[2] ""
 
 #: src/olympia/browse/templates/browse/search_tools.html:61
 msgid "Search Extensions"
@@ -3008,10 +2996,9 @@ msgid "See the %(cnt)s extension in %(name)s &raquo;"
 msgid_plural "See all %(cnt)s extensions in %(name)s &raquo;"
 msgstr[0] ""
 msgstr[1] ""
-msgstr[2] ""
 
-#: src/olympia/browse/templates/browse/mobile/extensions.html:13 src/olympia/compat/templates/compat/index.html:82 src/olympia/devhub/templates/devhub/devhub_search.html:24
-#: src/olympia/devhub/templates/devhub/addons/activity.html:47 src/olympia/search/templates/search/no_results.html:4 src/olympia/search/templates/search/mobile/results.html:36
+#: src/olympia/browse/templates/browse/mobile/extensions.html:13 src/olympia/devhub/templates/devhub/devhub_search.html:24 src/olympia/devhub/templates/devhub/addons/activity.html:47
+#: src/olympia/search/templates/search/no_results.html:4 src/olympia/search/templates/search/mobile/results.html:36
 msgid "No results found."
 msgstr ""
 
@@ -3096,7 +3083,7 @@ msgstr ""
 msgid "All"
 msgstr "Svi"
 
-#: src/olympia/compat/forms.py:22 src/olympia/search/views.py:525
+#: src/olympia/compat/forms.py:22 src/olympia/editors/templates/editors/base.html:69 src/olympia/search/views.py:518
 msgid "All Add-ons"
 msgstr ""
 
@@ -3106,53 +3093,6 @@ msgstr ""
 
 #: src/olympia/compat/forms.py:24
 msgid "Non-binary"
-msgstr ""
-
-#. Review points sources other than add-ons and themes.
-#: src/olympia/compat/views.py:87 src/olympia/constants/base.py:388 src/olympia/devhub/forms.py:162 src/olympia/editors/templates/editors/performance.html:75
-msgid "Other"
-msgstr ""
-
-#: src/olympia/compat/templates/compat/index.html:4
-msgid "Add-on Compatibility Report for {app} {version}"
-msgstr ""
-
-#: src/olympia/compat/templates/compat/index.html:11
-msgid "{app} {version} Compatibility"
-msgstr ""
-
-#: src/olympia/compat/templates/compat/index.html:17
-#, python-format
-msgid "Top 95%% compatible with previous version"
-msgstr ""
-
-#: src/olympia/compat/templates/compat/index.html:18
-#, python-format
-msgid "Top 95%% of all add-ons"
-msgstr ""
-
-#: src/olympia/compat/templates/compat/index.html:19
-msgid "All active add-ons"
-msgstr ""
-
-#: src/olympia/compat/templates/compat/index.html:23 src/olympia/constants/base.py:401
-msgid "App"
-msgstr ""
-
-#: src/olympia/compat/templates/compat/index.html:55
-msgid "Details for add-ons compatible with previous version:"
-msgstr ""
-
-#: src/olympia/compat/templates/compat/index.html:57
-msgid "Show all versions"
-msgstr ""
-
-#: src/olympia/compat/templates/compat/index.html:59
-msgid "Details for add-ons compatible with all versions:"
-msgstr ""
-
-#: src/olympia/compat/templates/compat/index.html:61
-msgid "Show previous version only"
 msgstr ""
 
 #: src/olympia/compat/templates/compat/reporter.html:3
@@ -3188,14 +3128,12 @@ msgid "{0} success report"
 msgid_plural "{0} success reports"
 msgstr[0] ""
 msgstr[1] ""
-msgstr[2] ""
 
 #: src/olympia/compat/templates/compat/reporter_detail.html:17
 msgid "{0} problem report"
 msgid_plural "{0} problem reports"
 msgstr[0] ""
 msgstr[1] ""
-msgstr[2] ""
 
 #: src/olympia/compat/templates/compat/reporter_detail.html:21 src/olympia/users/templates/users/profile.html:70
 msgid "View all"
@@ -3209,8 +3147,8 @@ msgstr ""
 msgid "Report Type"
 msgstr ""
 
-#: src/olympia/compat/templates/compat/reporter_detail.html:47 src/olympia/devhub/forms.py:784 src/olympia/devhub/templates/devhub/addons/ajax_compat_update.html:17 src/olympia/editors/forms.py:108
-#: src/olympia/zadmin/forms.py:45
+#: src/olympia/compat/templates/compat/reporter_detail.html:47 src/olympia/devhub/forms.py:785 src/olympia/devhub/templates/devhub/addons/ajax_compat_update.html:17 src/olympia/editors/forms.py:108
+#: src/olympia/editors/forms.py:248 src/olympia/zadmin/forms.py:45
 msgid "Application"
 msgstr "Aplikacija"
 
@@ -3298,7 +3236,8 @@ msgstr "Preliminarna revizija"
 msgid "Preliminarily Reviewed and Awaiting Full Review"
 msgstr ""
 
-#: src/olympia/constants/base.py:33 src/olympia/editors/helpers.py:924 src/olympia/editors/templates/editors/themes/history_table.html:34
+#: src/olympia/constants/base.py:33 src/olympia/editors/forms.py:258 src/olympia/editors/helpers.py:73 src/olympia/editors/helpers.py:1004
+#: src/olympia/editors/templates/editors/themes/history_table.html:34
 msgid "Deleted"
 msgstr ""
 
@@ -3395,6 +3334,11 @@ msgstr ""
 msgid "Ask before users can download this add-on"
 msgstr ""
 
+#. Review points sources other than add-ons and themes.
+#: src/olympia/constants/base.py:388 src/olympia/devhub/forms.py:162 src/olympia/editors/templates/editors/performance.html:75
+msgid "Other"
+msgstr ""
+
 #: src/olympia/constants/base.py:389
 msgid "Exception"
 msgstr ""
@@ -3405,6 +3349,10 @@ msgstr ""
 
 #: src/olympia/constants/base.py:391
 msgid "Change"
+msgstr ""
+
+#: src/olympia/constants/base.py:401
+msgid "App"
 msgstr ""
 
 #: src/olympia/constants/base.py:402
@@ -3555,7 +3503,7 @@ msgstr ""
 msgid "Duplicate"
 msgstr ""
 
-#: src/olympia/constants/editors.py:17 src/olympia/editors/helpers.py:502 src/olympia/editors/templates/editors/themes/queue.html:71 src/olympia/editors/templates/editors/themes/themes.html:94
+#: src/olympia/constants/editors.py:17 src/olympia/editors/helpers.py:575 src/olympia/editors/templates/editors/themes/queue.html:71 src/olympia/editors/templates/editors/themes/themes.html:94
 msgid "Reject"
 msgstr ""
 
@@ -3655,7 +3603,7 @@ msgstr ""
 msgid "Android"
 msgstr "Android"
 
-#: src/olympia/core/apps.py:19
+#: src/olympia/core/apps.py:21
 msgid "Core"
 msgstr ""
 
@@ -3789,7 +3737,7 @@ msgid "Submit my add-on for manual review."
 msgstr ""
 
 #: src/olympia/devhub/forms.py:537
-msgid "Do not list my add-on on this site (beta)"
+msgid "Do not list my add-on on this site"
 msgstr ""
 
 #: src/olympia/devhub/forms.py:538
@@ -3822,46 +3770,46 @@ msgstr ""
 
 #: src/olympia/devhub/forms.py:592
 #, python-format
-msgid "Version %s already exists"
-msgstr "Inačica %s već postoji"
+msgid "Version %s already exists, or was uploaded before."
+msgstr ""
 
-#: src/olympia/devhub/forms.py:604
+#: src/olympia/devhub/forms.py:605
 msgid "Select a valid choice. That choice is not one of the available choices."
 msgstr ""
 
-#: src/olympia/devhub/forms.py:610
+#: src/olympia/devhub/forms.py:611
 msgid "A file with a version ending with a|alpha|b|beta and an optional number is detected as beta."
 msgstr ""
 
-#: src/olympia/devhub/forms.py:633
+#: src/olympia/devhub/forms.py:634
 msgid "You cannot upload any more files for this version."
 msgstr ""
 
-#: src/olympia/devhub/forms.py:639
+#: src/olympia/devhub/forms.py:640
 msgid "Version doesn't match"
 msgstr "Inačica se ne podudara"
 
-#: src/olympia/devhub/forms.py:668
-msgid "You cannot delete a file once the review process has started. You must delete the whole version."
-msgstr "Ne možete obrisati datoteku jednom kad je proces revizije započet. Morate obrisati cijelu inačicu."
+#: src/olympia/devhub/forms.py:669
+msgid "You cannot delete a file once the review process has started.  You must delete the whole version."
+msgstr ""
 
-#: src/olympia/devhub/forms.py:688
+#: src/olympia/devhub/forms.py:689
 msgid "The platform All cannot be combined with specific platforms."
 msgstr "Platforma Sve ne može se kombinirati s određenim platformama."
 
-#: src/olympia/devhub/forms.py:693
+#: src/olympia/devhub/forms.py:694
 msgid "A platform can only be chosen once."
 msgstr ""
 
-#: src/olympia/devhub/forms.py:706
+#: src/olympia/devhub/forms.py:707
 msgid "A review type must be selected."
 msgstr ""
 
-#: src/olympia/devhub/forms.py:788 src/olympia/editors/forms.py:114 src/olympia/zadmin/forms.py:49 src/olympia/zadmin/forms.py:52
+#: src/olympia/devhub/forms.py:789 src/olympia/editors/forms.py:114 src/olympia/editors/forms.py:254 src/olympia/zadmin/forms.py:49 src/olympia/zadmin/forms.py:52
 msgid "Select an application first"
 msgstr ""
 
-#: src/olympia/devhub/forms.py:840
+#: src/olympia/devhub/forms.py:841
 msgid "There cannot be more than 3 required add-ons."
 msgstr ""
 
@@ -3883,7 +3831,6 @@ msgid "{0} error"
 msgid_plural "{0} errors"
 msgstr[0] "{0} pogreška"
 msgstr[1] "{0} pogreške"
-msgstr[2] "{0} pogrešaka"
 
 #. L10n: first parameter is the number of warnings
 #: src/olympia/devhub/helpers.py:203
@@ -3891,83 +3838,82 @@ msgid "{0} warning"
 msgid_plural "{0} warnings"
 msgstr[0] ""
 msgstr[1] ""
-msgstr[2] ""
 
 # 85%
 #: src/olympia/devhub/models.py:375 src/olympia/reviews/templates/reviews/add.html:58
 msgid "Review"
 msgstr "Revizija"
 
-#: src/olympia/devhub/tasks.py:551
+#: src/olympia/devhub/tasks.py:583
 #, python-format
 msgid "%s responded with %s (%s)."
 msgstr ""
 
-#: src/olympia/devhub/tasks.py:555
+#: src/olympia/devhub/tasks.py:587
 #, python-format
 msgid "Connection to \"%s\" timed out."
 msgstr ""
 
-#: src/olympia/devhub/tasks.py:557
+#: src/olympia/devhub/tasks.py:589
 #, python-format
 msgid "Could not contact host at \"%s\"."
 msgstr ""
 
-#: src/olympia/devhub/utils.py:104
+#: src/olympia/devhub/utils.py:105
 #, python-format
 msgid "Validation generated too many errors/warnings so %s messages were truncated. After addressing the visible messages, you'll be able to see the others."
 msgstr ""
 
-#: src/olympia/devhub/views.py:183
+#: src/olympia/devhub/views.py:181
 msgid "All My Add-ons"
 msgstr ""
 
-#: src/olympia/devhub/views.py:210
+#: src/olympia/devhub/views.py:208
 msgid "All Activity"
 msgstr "Sve aktivnosti"
 
-#: src/olympia/devhub/views.py:211
+#: src/olympia/devhub/views.py:209
 msgid "Add-on Updates"
 msgstr "Ažuriranja dodataka"
 
-#: src/olympia/devhub/views.py:212
+#: src/olympia/devhub/views.py:210
 msgid "Add-on Status"
 msgstr "Status dodataka"
 
-#: src/olympia/devhub/views.py:213
+#: src/olympia/devhub/views.py:211
 msgid "User Collections"
 msgstr ""
 
-#: src/olympia/devhub/views.py:214 src/olympia/devhub/templates/devhub/docs/policies-maintenance.html:68 src/olympia/pages/templates/pages/dev_faq.html:38
+#: src/olympia/devhub/views.py:212 src/olympia/devhub/templates/devhub/docs/policies-maintenance.html:68 src/olympia/pages/templates/pages/dev_faq.html:38
 #: src/olympia/pages/templates/pages/dev_faq.html:484
 msgid "User Reviews"
 msgstr ""
 
-#: src/olympia/devhub/views.py:327 src/olympia/devhub/views.py:331 src/olympia/devhub/views.py:484 src/olympia/devhub/views.py:513 src/olympia/devhub/views.py:564 src/olympia/devhub/views.py:1150
+#: src/olympia/devhub/views.py:325 src/olympia/devhub/views.py:329 src/olympia/devhub/views.py:484 src/olympia/devhub/views.py:513 src/olympia/devhub/views.py:564 src/olympia/devhub/views.py:1156
 msgid "Changes successfully saved."
 msgstr "Promjene uspješno spremljene."
 
-#: src/olympia/devhub/views.py:334 src/olympia/devhub/views.py:1631
+#: src/olympia/devhub/views.py:332 src/olympia/devhub/views.py:1637
 msgid "Please check the form for errors."
 msgstr ""
 
-#: src/olympia/devhub/views.py:346
+#: src/olympia/devhub/views.py:344
 msgid "Add-on cannot be deleted. Disable this add-on instead."
 msgstr ""
 
-#: src/olympia/devhub/views.py:356
+#: src/olympia/devhub/views.py:354
 msgid "Theme deleted."
 msgstr ""
 
-#: src/olympia/devhub/views.py:356
+#: src/olympia/devhub/views.py:354
 msgid "Add-on deleted."
 msgstr ""
 
-#: src/olympia/devhub/views.py:362
+#: src/olympia/devhub/views.py:360
 msgid "URL name was incorrect. Theme was not deleted."
 msgstr ""
 
-#: src/olympia/devhub/views.py:367
+#: src/olympia/devhub/views.py:365
 msgid "URL name was incorrect. Add-on was not deleted."
 msgstr ""
 
@@ -3995,7 +3941,7 @@ msgstr ""
 msgid "Check Add-on Compatibility"
 msgstr ""
 
-#: src/olympia/devhub/views.py:808 src/olympia/signing/views.py:90
+#: src/olympia/devhub/views.py:808 src/olympia/signing/views.py:95
 msgid "You cannot submit this type of add-on"
 msgstr ""
 
@@ -4027,33 +3973,33 @@ msgstr ""
 msgid "There was an error uploading your preview."
 msgstr "Došlo je do pogreške prilikom učitavanja Vašeg pregleda."
 
-#: src/olympia/devhub/views.py:1189
+#: src/olympia/devhub/views.py:1195
 #, python-format
 msgid "Version %s disabled."
 msgstr ""
 
-#: src/olympia/devhub/views.py:1193
+#: src/olympia/devhub/views.py:1199
 #, python-format
 msgid "Version %s deleted."
 msgstr "Inačica %s izbrisana."
 
-#: src/olympia/devhub/views.py:1203
+#: src/olympia/devhub/views.py:1209
 msgid "This upload has failed validation, and may lack complete validation results. Please take due care when reviewing it."
 msgstr ""
 
-#: src/olympia/devhub/views.py:1677
+#: src/olympia/devhub/views.py:1683
 msgid "Preliminary Review Requested."
 msgstr "Preliminarna revizija zatražena."
 
-#: src/olympia/devhub/views.py:1678
+#: src/olympia/devhub/views.py:1684
 msgid "Full Review Requested."
 msgstr ""
 
-#: src/olympia/devhub/views.py:1779
+#: src/olympia/devhub/views.py:1783
 msgid "Your old credentials were revoked and are no longer valid. Be sure to update all API clients with the new credentials."
 msgstr ""
 
-#: src/olympia/devhub/views.py:1797
+#: src/olympia/devhub/views.py:1801
 msgid "New API key created"
 msgstr ""
 
@@ -4083,7 +4029,7 @@ msgstr "Povratak na dodatke"
 msgid "{0} :: Search"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/devhub_search.html:6 src/olympia/devhub/templates/devhub/search.html:8 src/olympia/editors/forms.py:435 src/olympia/editors/forms.py:437
+#: src/olympia/devhub/templates/devhub/devhub_search.html:6 src/olympia/devhub/templates/devhub/search.html:8 src/olympia/editors/forms.py:534 src/olympia/editors/forms.py:536
 #: src/olympia/editors/templates/editors/queue.html:27 src/olympia/editors/templates/editors/themes/queue_list.html:14 src/olympia/search/templates/search/collections.html:17
 #: src/olympia/search/templates/search/personas.html:18 src/olympia/search/templates/search/results.html:18 src/olympia/search/templates/search/mobile/results.html:8
 #: src/olympia/templates/search.html:14 src/olympia/templates/impala/search.html:18
@@ -4143,12 +4089,12 @@ msgstr ""
 msgid "Start Making Add-ons"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/index.html:86 src/olympia/devhub/templates/devhub/addons/listing/items.html:25 src/olympia/devhub/templates/devhub/includes/addon_details.html:15
+#: src/olympia/devhub/templates/devhub/index.html:86 src/olympia/devhub/templates/devhub/addons/listing/items.html:25 src/olympia/devhub/templates/devhub/includes/addon_details.html:20
 #: src/olympia/devhub/templates/devhub/personas/edit.html:43
 msgid "Status:"
 msgstr "Status:"
 
-#: src/olympia/devhub/templates/devhub/index.html:90 src/olympia/devhub/templates/devhub/includes/addon_details.html:100
+#: src/olympia/devhub/templates/devhub/index.html:90 src/olympia/devhub/templates/devhub/includes/addon_details.html:87
 msgid "Visibility:"
 msgstr ""
 
@@ -4156,11 +4102,11 @@ msgstr ""
 msgid "Latest Version:"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/index.html:109 src/olympia/devhub/templates/devhub/includes/addon_details.html:145 src/olympia/devhub/templates/devhub/personas/edit.html:49
+#: src/olympia/devhub/templates/devhub/index.html:109 src/olympia/devhub/templates/devhub/includes/addon_details.html:131 src/olympia/devhub/templates/devhub/personas/edit.html:49
 msgid "Queue Position:"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/index.html:110 src/olympia/devhub/templates/devhub/includes/addon_details.html:146 src/olympia/devhub/templates/devhub/personas/edit.html:50
+#: src/olympia/devhub/templates/devhub/index.html:110 src/olympia/devhub/templates/devhub/includes/addon_details.html:132 src/olympia/devhub/templates/devhub/personas/edit.html:50
 #, python-format
 msgid "%(position)s of %(total)s"
 msgstr ""
@@ -4262,16 +4208,6 @@ msgstr ""
 msgid "Do you want your add-on to be distributed on this site?"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/validate_addon.html:49 src/olympia/devhub/templates/devhub/addons/submit/upload.html:30 src/olympia/devhub/templates/devhub/versions/add_file_modal.html:14
-#: src/olympia/devhub/templates/devhub/versions/add_file_modal.html:53 src/olympia/devhub/templates/devhub/versions/list.html:298
-msgid "Warning:"
-msgstr ""
-
-#: src/olympia/devhub/templates/devhub/validate_addon.html:50 src/olympia/devhub/templates/devhub/addons/submit/upload.html:31
-#, python-format
-msgid "Submission of unlisted add-ons for signing is currently in an open beta. Please <a href=\"%(url)s\" target=\"_blank\">report any bugs</a> that you encounter."
-msgstr ""
-
 #. first parameter is a filename like lorem-ipsum-1.0.2.xpi
 #: src/olympia/devhub/templates/devhub/validation.html:5
 msgid "Validation Results for {0}"
@@ -4348,7 +4284,7 @@ msgstr "Kompatibilnost"
 msgid "Update Compatibility"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/addons/ajax_compat_update.html:4
+#: src/olympia/devhub/templates/devhub/addons/ajax_compat_update.html:4 src/olympia/devhub/templates/devhub/versions/edit.html:45
 msgid "Adjusting application information here will allow users to install your add-on even if the install manifest in the package indicates that the add-on is incompatible."
 msgstr ""
 
@@ -4360,9 +4296,9 @@ msgstr "Podržane inačice"
 msgid "Add Another Application&hellip;"
 msgstr "Dodaj drugu Inačicu&hellip;"
 
-#: src/olympia/devhub/templates/devhub/addons/ajax_compat_update.html:38 src/olympia/devhub/templates/devhub/addons/owner.html:86 src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:46
-#: src/olympia/devhub/templates/devhub/versions/list.html:351 src/olympia/devhub/templates/devhub/versions/list.html:353 src/olympia/templates/impala/base.html:132
-#: src/olympia/templates/impala/base.html:143 src/olympia/templates/impala/base.html:161 src/olympia/templates/impala/base.html:171
+#: src/olympia/devhub/templates/devhub/addons/ajax_compat_update.html:38 src/olympia/devhub/templates/devhub/addons/owner.html:86 src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:45
+#: src/olympia/devhub/templates/devhub/versions/list.html:349 src/olympia/devhub/templates/devhub/versions/list.html:351 src/olympia/templates/impala/base.html:129
+#: src/olympia/templates/impala/base.html:140 src/olympia/templates/impala/base.html:158 src/olympia/templates/impala/base.html:168
 msgid "Close"
 msgstr ""
 
@@ -4381,7 +4317,6 @@ msgid "<b>{0}</b> theme"
 msgid_plural "<b>{0}</b> themes"
 msgstr[0] ""
 msgstr[1] ""
-msgstr[2] ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit.html:3 src/olympia/devhub/templates/devhub/addons/listing/item_actions.html:25
 #: src/olympia/devhub/templates/devhub/addons/listing/item_actions_theme.html:7 src/olympia/devhub/templates/devhub/includes/addons_edit_nav.html:2
@@ -4397,7 +4332,7 @@ msgstr ""
 msgid "Manage Authors & License"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/addons/owner.html:29 src/olympia/editors/templates/editors/review.html:270
+#: src/olympia/devhub/templates/devhub/addons/owner.html:29 src/olympia/editors/helpers.py:362 src/olympia/editors/templates/editors/review.html:270
 msgid "Authors"
 msgstr "Autori"
 
@@ -4466,17 +4401,11 @@ msgstr "Sažetak"
 
 #: src/olympia/devhub/templates/devhub/addons/edit/basic.html:52
 msgid ""
-"A short explanation of your add-on's basic\n"
-"                          functionality that is displayed in search and browse\n"
-"                          listings, as well as at the top of your add-on's\n"
-"                          details page. It is only relevant for listed add-ons."
+"A short explanation of your add-on's basic functionality that is displayed in search and browse listings, as well as at the top of your add-on's details page. It is only relevant for listed add-ons."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/basic.html:73
-msgid ""
-"Categories are the primary way users browse through add-ons.\n"
-"                        Choose any that fit your add-on's functionality for the most\n"
-"                        exposure. It is only relevant for listed add-ons."
+msgid "Categories are the primary way users browse through add-ons. Choose any that fit your add-on's functionality for the most exposure. It is only relevant for listed add-ons."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/basic.html:90
@@ -4486,11 +4415,7 @@ msgid ""
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/basic.html:119
-msgid ""
-"Tags help users find your add-on and should be short\n"
-"                        descriptors such as tabs, toolbar, or twitter.  You\n"
-"                        may have a maximum of {0} tags. It is only relevant\n"
-"                        for listed add-ons."
+msgid "Tags help users find your add-on and should be short descriptors such as tabs, toolbar, or twitter. You may have a maximum of {0} tags. It is only relevant for listed add-ons."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/basic.html:129 src/olympia/devhub/templates/devhub/personas/edit.html:97 src/olympia/devhub/templates/devhub/personas/submit.html:46
@@ -4498,7 +4423,6 @@ msgid "Comma-separated, minimum of {0} character."
 msgid_plural "Comma-separated, minimum of {0} characters."
 msgstr[0] ""
 msgstr[1] ""
-msgstr[2] ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/basic.html:132 src/olympia/devhub/templates/devhub/personas/edit.html:100 src/olympia/devhub/templates/devhub/personas/submit.html:49
 msgid "Example: dark, cinema, noir. Limit 20."
@@ -4509,7 +4433,6 @@ msgid "Reserved tag:"
 msgid_plural "Reserved tags:"
 msgstr[0] "Rezervirana oznaka:"
 msgstr[1] "Rezervirane oznake:"
-msgstr[2] "Rezervirano oznaka:"
 
 #: src/olympia/devhub/templates/devhub/addons/edit/details.html:5
 msgid "Add-on Details"
@@ -4520,11 +4443,7 @@ msgid "Add-on Details for {0}"
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/details.html:22
-msgid ""
-"A longer explanation of features,\n"
-"                          functionality, and other relevant information. This\n"
-"                          field is only displayed on the add-on's details\n"
-"                          page. It is only relevant for listed add-ons."
+msgid "A longer explanation of features, functionality, and other relevant information. This field is only displayed on the add-on's details page. It is only relevant for listed add-ons."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/details.html:44 src/olympia/translations/templates/translations/trans-menu.html:13
@@ -4532,10 +4451,7 @@ msgid "Default Locale"
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/details.html:45
-msgid ""
-"Information about your add-on is displayed in this locale\n"
-"                        unless you override it with a locale-specific translation.\n"
-"                        It is only relevant for listed add-ons."
+msgid "Information about your add-on is displayed in this locale unless you override it with a locale-specific translation. It is only relevant for listed add-ons."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/details.html:61 src/olympia/users/forms.py:311 src/olympia/users/templates/users/edit.html:122 src/olympia/users/templates/users/register.html:57
@@ -4545,10 +4461,8 @@ msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/details.html:63
 msgid ""
-"If your add-on has another homepage, enter its\n"
-"                          address here. If your website is localized into other\n"
-"                          languages multiple translations of this field can be\n"
-"                          added. It is only relevant for listed add-ons."
+"If your add-on has another homepage, enter its address here. If your website is localized into other languages multiple translations of this field can be added. It is only relevant for listed add-"
+"ons."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/media.html:3
@@ -4566,19 +4480,14 @@ msgstr "Informacije podrške za {0}"
 
 #: src/olympia/devhub/templates/devhub/addons/edit/support.html:22
 msgid ""
-"If you wish to display an e-mail address for support\n"
-"                          inquiries, enter it here. If you have different\n"
-"                          addresses for each language multiple translations of\n"
-"                          this field can be added. It is only relevant for\n"
-"                          listed add-ons."
+"If you wish to display an e-mail address for support inquiries, enter it here. If you have different addresses for each language multiple translations of this field can be added. It is only "
+"relevant for listed add-ons."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/support.html:45
 msgid ""
-"If your add-on has a support website or forum, enter\n"
-"                          its address here. If your website is localized into\n"
-"                          other languages, multiple translations of this field can\n"
-"                          be added. It is only relevant for listed add-ons."
+"If your add-on has a support website or forum, enter its address here. If your website is localized into other languages, multiple translations of this field can be added. It is only relevant for "
+"listed add-ons."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:6
@@ -4592,11 +4501,8 @@ msgstr "Tehnički detalji za {0}"
 
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:23
 msgid ""
-"Any information end users may want to know that isn't\n"
-"                          necessarily applicable to the add-on summary or description.\n"
-"                          Common uses include listing known major bugs, information on\n"
-"                          how to report bugs, anticipated release date of a new version,\n"
-"                          etc. It is only relevant for listed add-ons."
+"Any information end users may want to know that isn't necessarily applicable to the add-on summary or description. Common uses include listing known major bugs, information on how to report bugs, "
+"anticipated release date of a new version, etc. It is only relevant for listed add-ons."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:46
@@ -4608,9 +4514,7 @@ msgid "Add-on Flags"
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:69
-msgid ""
-"These flags are used to classify add-ons. It is only\n"
-"                        relevant for listed add-ons."
+msgid "These flags are used to classify add-ons. It is only relevant for listed add-ons."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:74
@@ -4626,9 +4530,7 @@ msgid "View Source?"
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:90
-msgid ""
-"Whether the source of your add-on can be displayed in our\n"
-"                        online viewer. It is only relevant for listed add-ons."
+msgid "Whether the source of your add-on can be displayed in our online viewer. It is only relevant for listed add-ons."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:94
@@ -4644,10 +4546,7 @@ msgid "Public Stats?"
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:102
-msgid ""
-"Whether the download and usage stats of your add-on can\n"
-"                        be displayed in our online viewer.\n"
-"                        It is only relevant for listed add-ons."
+msgid "Whether the download and usage stats of your add-on can be displayed in our online viewer. It is only relevant for listed add-ons."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:107
@@ -4663,10 +4562,7 @@ msgid "Upgrade SDK?"
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:116
-msgid ""
-"If selected, we will try to automatically upgrade your\n"
-"                        add-on when a new version of the SDK is released.\n"
-"                        It is only relevant for listed add-ons."
+msgid "If selected, we will try to automatically upgrade your add-on when a new version of the SDK is released. It is only relevant for listed add-ons."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:121
@@ -4718,10 +4614,8 @@ msgstr "Ikona dodatka"
 
 #: src/olympia/devhub/templates/devhub/addons/forms_shared/media.html:16
 msgid ""
-"Upload an icon for your add-on or choose from one of ours. The\n"
-"                      icon is displayed nearly everywhere your add-on is. Uploaded images\n"
-"                      must be one of the following image types: .png, .jpg.\n"
-"                      It is only relevant for listed add-ons."
+"Upload an icon for your add-on or choose from one of ours. The icon is displayed nearly everywhere your add-on is. Uploaded images must be one of the following image types: .png, .jpg. It is only "
+"relevant for listed add-ons."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/forms_shared/media.html:25
@@ -4829,16 +4723,14 @@ msgid "Deleting your add-on will permanently remove it from the site and prevent
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:24
-msgid ""
-"Enter the following text confirm your decision:\n"
-"           {slug}"
+msgid "Enter the following text confirm your decision: {slug}"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:34
+#: src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:33
 msgid "Please tell us why you are deleting your theme:"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:36
+#: src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:35
 msgid "Please tell us why you are deleting your add-on:"
 msgstr ""
 
@@ -4875,8 +4767,8 @@ msgstr ""
 msgid "Daily statistics on downloads and users."
 msgstr "Dnevna statistika o preuzimanjima i korisnicima."
 
-#: src/olympia/devhub/templates/devhub/addons/listing/item_actions.html:45 src/olympia/stats/templates/stats/stats.html:75 src/olympia/stats/templates/stats/stats.html:79
-#: src/olympia/stats/templates/stats/stats.html:81
+#: src/olympia/devhub/templates/devhub/addons/listing/item_actions.html:45 src/olympia/stats/templates/stats/stats.html:31 src/olympia/stats/templates/stats/stats.html:35
+#: src/olympia/stats/templates/stats/stats.html:37
 msgid "Statistics"
 msgstr ""
 
@@ -4937,7 +4829,6 @@ msgid "<strong>{0}</strong> active user"
 msgid_plural "<strong>{0}</strong> active users"
 msgstr[0] "<strong>{0}</strong> aktivni korisnik"
 msgstr[1] "<strong>{0}</strong> aktivni korisnici"
-msgstr[2] "<strong>{0}</strong> aktivnih korisnika"
 
 #: src/olympia/devhub/templates/devhub/addons/submit/base.html:11
 msgid "Submit Add-on"
@@ -4996,10 +4887,7 @@ msgid "Your add-on has been submitted to the Full Review queue."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/submit/done.html:18
-msgid ""
-"You'll receive an email once it has been reviewed by an editor. In\n"
-"          the meantime, you and your friends can install it directly from its\n"
-"          details page:"
+msgid "You'll receive an email once it has been reviewed by an editor. In the meantime, you and your friends can install it directly from its details page:"
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/submit/done.html:27 src/olympia/devhub/templates/devhub/addons/submit/done.html:77 src/olympia/devhub/templates/devhub/personas/submit_done.html:16
@@ -5207,11 +5095,11 @@ msgstr "Korak 2. Dodavanje Vašeg dodatka"
 msgid "Use the fields below to upload your add-on package and select any platform restrictions. After upload, a series of automated validation tests will be run on your file."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/addons/submit/upload.html:59 src/olympia/devhub/templates/devhub/versions/add_file_modal.html:39
+#: src/olympia/devhub/templates/devhub/addons/submit/upload.html:51 src/olympia/devhub/templates/devhub/versions/add_file_modal.html:28
 msgid "Which platforms is this file compatible with?"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/addons/submit/upload.html:67 src/olympia/devhub/templates/devhub/versions/add_file_modal.html:65
+#: src/olympia/devhub/templates/devhub/addons/submit/upload.html:59 src/olympia/devhub/templates/devhub/versions/add_file_modal.html:45
 msgid "Administrative overrides"
 msgstr ""
 
@@ -5321,8 +5209,8 @@ msgstr ""
 
 #: src/olympia/devhub/templates/devhub/docs/policies-contact.html:44
 msgid ""
-"If you've found a problem with the site, we'd love to fix it. Please <a href=\"https://github.com/mozilla/olympia/issues\">file a bug report</a> in GitHub, including the location of the problem and "
-"how you encountered it."
+"If you've found a problem with the site, we'd love to fix it. Please <a href=\"https://github.com/mozilla/addons/issues/new\">file a bug report</a> in GitHub, including the location of the problem "
+"and how you encountered it."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/docs/policies-maintenance.html:3 src/olympia/devhub/templates/devhub/docs/policies-maintenance.html:7
@@ -5889,7 +5777,7 @@ msgstr ""
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:282
 msgid ""
-"Add-ons that store or otherwise handle browsing data must support <a href=\"https://developer.mozilla.org/En/Supporting_private_browsing_mode\">Private Browsing Mode</a>.  During a Private Browsing "
+"Add-ons that store or otherwise handle browsing data must support <a href=\"https://developer.mozilla.org/En/Supporting_private_browsing_mode\">Private Browsing Mode</a>. During a Private Browsing "
 "session, no browsing data can be written to disk, and all of this data must be cleared when Firefox quits or the Private Browsing session ends."
 msgstr ""
 
@@ -6054,127 +5942,95 @@ msgstr ""
 msgid "How to get in touch with us regarding these policies or your add-on."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:6
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:10
 msgid "You have disabled this add-on"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:20
-msgid ""
-"Your add-on's listing is disabled and is not showing\n"
-"                             anywhere in our gallery or update service."
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:24
+msgid "Your add-on's listing is disabled and is not showing anywhere in our gallery or update service."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:25
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:27
 msgid "Please complete your add-on."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:29
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:30
 msgid "You will receive an email when the review is complete."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:34
-msgid ""
-"You will receive an email when the review is complete. Until\n"
-"                             then, your add-on is not listed in our gallery but can be\n"
-"                             accessed directly from its details page."
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:33
+msgid "You will receive an email when the review is complete. Until then, your add-on is not listed in our gallery but can be accessed directly from its details page."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:38 src/olympia/devhub/templates/devhub/includes/addon_details.html:48
-msgid ""
-"You will receive an email when the review is\n"
-"                             complete and your add-on is signed."
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:37 src/olympia/devhub/templates/devhub/includes/addon_details.html:45
+msgid "You will receive an email when the review is complete and your add-on is signed."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:44
-msgid ""
-"You will receive an email when the review is complete. Until\n"
-"                             then, your add-on is not listed in our gallery but can be\n"
-"                             accessed directly from its details page. "
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:41
+msgid "You will receive an email when the review is complete. Until then, your add-on is not listed in our gallery but can be accessed directly from its details page. "
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:54
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:49
 msgid "Your add-on is displayed in our gallery and users are receiving automatic updates."
 msgstr "Vaš dodatak je prikazan u našoj galeriji, a korisnici dobivaju automatska ažuriranja."
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:57
-msgid ""
-"Your add-on has been signed and can be bundled with an\n"
-"                             application installer."
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:52
+msgid "Your add-on has been signed and can be bundled with an application installer."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:63
-msgid ""
-"Your add-on was disabled by a site administrator and is no\n"
-"                             longer shown in our gallery. If you have any questions,\n"
-"                             please email amo-admins@mozilla.org."
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:56
+msgid "Your add-on was disabled by a site administrator and is no longer shown in our gallery. If you have any questions, please email amo-admins@mozilla.org."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:70
-msgid ""
-"Your add-on is displayed in our gallery as experimental\n"
-"                             and users are receiving automatic updates. Some features\n"
-"                             are unavailable to your add-on."
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:62
+msgid "Your add-on is displayed in our gallery as experimental and users are receiving automatic updates. Some features are unavailable to your add-on."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:74
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:66
 msgid "Your add-on has been signed."
 msgstr ""
 
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:69
+msgid ""
+"You will receive an email when the full review is complete. Until then, your add-on is displayed in our gallery as experimental and users are receiving automatic updates. Some features are "
+"unavailable to your add-on."
+msgstr ""
+
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:74
+msgid "You will receive an email when the full review is complete, making you able to bundle your add-on with an application installer."
+msgstr ""
+
 #: src/olympia/devhub/templates/devhub/includes/addon_details.html:79
-msgid ""
-"You will receive an email when the full review is complete.\n"
-"                             Until then, your add-on is displayed in our gallery as\n"
-"                             experimental and users are receiving automatic updates.\n"
-"                             Some features are unavailable to your add-on."
+msgid "All add-ons hosted in our gallery must now be reviewed by an editor. If you wish to continue hosting your add-on, please click to select a review process."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:84
-msgid ""
-"You will receive an email when the full review is\n"
-"                             complete, making you able to bundle your add-on with an\n"
-"                             application installer."
-msgstr ""
-
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:91
-msgid ""
-"All add-ons hosted in our gallery must now be reviewed by an\n"
-"                             editor. If you wish to continue hosting your add-on, please\n"
-"                             click to select a review process."
-msgstr ""
-
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:113
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:100
 msgid "Current Version:"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:115
-msgid ""
-"This is the version of your add-on that will\n"
-"                                           be installed if someone clicks the Install\n"
-"                                           button on addons.mozilla.org. It is only\n"
-"                                           relevant for listed add-ons."
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:102
+msgid "This is the version of your add-on that will be installed if someone clicks the Install button on addons.mozilla.org. It is only relevant for listed add-ons."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:123
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:110
 msgid "Created:"
 msgstr ""
 
 #. {0} is a date. dennis-ignore: E201
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:125 src/olympia/devhub/templates/devhub/includes/addon_details.html:131
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:112 src/olympia/devhub/templates/devhub/includes/addon_details.html:118
 #, python-format
 msgid "%%b %%e, %%Y"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:136
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:123
 msgid "Next Version:"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:138
-msgid ""
-"This is the newest uploaded version, however\n"
-"                                           it isn’t live on the site yet."
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:125
+msgid "This is the newest uploaded version, however it isn’t live on the site yet."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:144 src/olympia/devhub/templates/devhub/versions/list.html:30
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:130 src/olympia/devhub/templates/devhub/versions/list.html:30
 msgid "Queues are not reviewed strictly in order"
 msgstr ""
 
@@ -6242,9 +6098,7 @@ msgid "View the blog &#9658;"
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/includes/license_form.html:6
-msgid ""
-"Please choose a license appropriate for the rights you grant on your source code.\n"
-"                  It is only relevant for listed add-ons."
+msgid "Please choose a license appropriate for the rights you grant on your source code. It is only relevant for listed add-ons."
 msgstr ""
 
 #. {0} is a list of HTML tags.
@@ -6267,19 +6121,15 @@ msgid "Select <b>up to {0}</b> {1} category for this add-on:"
 msgid_plural "Select <b>up to {0}</b> {1} categories for this add-on:"
 msgstr[0] ""
 msgstr[1] ""
-msgstr[2] ""
 
 #: src/olympia/devhub/templates/devhub/includes/policy_form.html:4
 msgid ""
 "Users will be required to accept the following End-User License Agreement (EULA) prior to installing your add-on. The presence of a EULA significantly affects the number of downloads an add-on "
-"receives. Please note that a EULA is not the same as a code license, such as the GPL or MPL.\n"
-"                It is only relevant for listed add-ons."
+"receives. Please note that a EULA is not the same as a code license, such as the GPL or MPL.It is only relevant for listed add-ons."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/policy_form.html:21
-msgid ""
-"If your add-on transmits any data from the user's computer, a privacy policy is required that explains what data is sent and how it is used.\n"
-"                It is only relevant for listed add-ons."
+#: src/olympia/devhub/templates/devhub/includes/policy_form.html:24
+msgid "If your add-on transmits any data from the user's computer, a privacy policy is required that explains what data is sent and how it is used. It is only relevant for listed add-ons."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/includes/source_form_field.html:2
@@ -6451,12 +6301,8 @@ msgstr ""
 msgid "Add some tags to describe your Theme."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/personas/edit.html:106
-msgid ""
-"A short explanation of your theme's\n"
-"                                basic functionality that is displayed in\n"
-"                                search and browse listings, as well as at\n"
-"                                the top of your theme's details page."
+#: src/olympia/devhub/templates/devhub/personas/edit.html:106 src/olympia/devhub/templates/devhub/personas/submit.html:54
+msgid "A short explanation of your theme's basic functionality that is displayed in search and browse listings, as well as at the top of your theme's details page."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/personas/edit.html:122 src/olympia/devhub/templates/devhub/personas/submit.html:68
@@ -6526,7 +6372,7 @@ msgid "Upon upload and form submission, the AMO Team will review your updated de
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/personas/edit.html:241
-msgid "Your previously resubmitted design,  which is under pending review."
+msgid "Your previously resubmitted design, which is under pending review."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/personas/edit.html:245
@@ -6593,14 +6439,6 @@ msgstr ""
 
 #: src/olympia/devhub/templates/devhub/personas/submit.html:33
 msgid "Give your Theme a name."
-msgstr ""
-
-#: src/olympia/devhub/templates/devhub/personas/submit.html:54
-msgid ""
-"A short explanation of your theme's\n"
-"                                      basic functionality that is displayed in\n"
-"                                      search and browse listings, as well as at\n"
-"                                      the top of your theme's details page."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/personas/submit.html:198
@@ -6677,30 +6515,16 @@ msgstr ""
 msgid "Files added to reviewed versions must be reviewed before they will be available for download."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/add_file_modal.html:15
-#, python-format
-msgid ""
-"Submission of updates to unlisted add-ons for signing is currently in an open beta. Manual review may still be required for a large number of add-ons. Please <a href=\"%(url)s\" target=\"_blank"
-"\">report any bugs</a> that you encounter."
-msgstr ""
-
-#: src/olympia/devhub/templates/devhub/versions/add_file_modal.html:35
+#: src/olympia/devhub/templates/devhub/versions/add_file_modal.html:24
 msgid "Select the target platform for this file."
 msgstr "Odaberite ciljanu platformu za ovu datoteku."
 
-#: src/olympia/devhub/templates/devhub/versions/add_file_modal.html:46
+#: src/olympia/devhub/templates/devhub/versions/add_file_modal.html:35
 msgid "Which review type would you like to nominate for?"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/add_file_modal.html:51
+#: src/olympia/devhub/templates/devhub/versions/add_file_modal.html:40
 msgid "Only publish this version to my beta channel."
-msgstr ""
-
-#: src/olympia/devhub/templates/devhub/versions/add_file_modal.html:54
-#, python-format
-msgid ""
-"The behavior of the beta channel has changed to accommodate <a href=\"%(addon_signing_url)s\" target=\"_blank\">mandatory add-on signing</a>. The new process is currently in an open beta, and may "
-"change significantly in the near future. Please <a href=\"%(issues_url)s\" target=\"_blank\">report any bugs</a> that you encounter."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/versions/edit.html:5
@@ -6724,19 +6548,10 @@ msgstr ""
 msgid "Upload Another File"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/edit.html:45
-msgid ""
-"Adjusting application information here will allow users to install your\n"
-"                          add-on even if the install manifest in the package indicates that the\n"
-"                          add-on is incompatible."
-msgstr ""
-
 #: src/olympia/devhub/templates/devhub/versions/edit.html:74
 msgid ""
-"Information about changes in this release, new features,\n"
-"                              known bugs, and other useful information specific to this\n"
-"                              release/version. This information is also shown in the\n"
-"                              Add-ons Manager when updating."
+"Information about changes in this release, new features, known bugs, and other useful information specific to this release/version. This information is also shown in the Add-ons Manager when "
+"updating."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/versions/edit.html:99
@@ -6748,10 +6563,7 @@ msgid "Notes for Reviewers"
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/versions/edit.html:114
-msgid ""
-"Optionally, enter any information that may be useful\n"
-"                              to the Editor reviewing this add-on, such as test\n"
-"                              account information."
+msgid "Optionally, enter any information that may be useful to the Editor reviewing this add-on, such as test account information."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/versions/edit.html:127
@@ -6804,7 +6616,6 @@ msgid "{0} file"
 msgid_plural "{0} files"
 msgstr[0] ""
 msgstr[1] ""
-msgstr[2] ""
 
 #: src/olympia/devhub/templates/devhub/versions/list.html:25
 msgid "0 files"
@@ -6831,7 +6642,7 @@ msgstr ""
 msgid "Request Preliminary Review"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:80 src/olympia/devhub/templates/devhub/versions/list.html:327 src/olympia/devhub/templates/devhub/versions/list.html:350
+#: src/olympia/devhub/templates/devhub/versions/list.html:80 src/olympia/devhub/templates/devhub/versions/list.html:325 src/olympia/devhub/templates/devhub/versions/list.html:348
 msgid "Cancel Review Request"
 msgstr "Otkaži zahtjev za revizijom"
 
@@ -6860,7 +6671,7 @@ msgid "Unlisted:"
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/versions/list.html:114
-msgid "Not distributed on {0}. Developers will upload new versions for signing and distribute the add-ons on their own. (beta)"
+msgid "Not distributed on {0}. Developers will upload new versions for signing and distribute the add-ons on their own."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/versions/list.html:122
@@ -6923,81 +6734,73 @@ msgid "<strong>Important:</strong> Once a version has been deleted, you may not 
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/versions/list.html:230
-msgid ""
-"Deleting a version which has already been reviewed\n"
-"               may also cause a significant delay in the review of\n"
-"               your next update."
-msgstr ""
-
-#: src/olympia/devhub/templates/devhub/versions/list.html:233
 msgid "Are you sure you wish to delete this version?"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:238
+#: src/olympia/devhub/templates/devhub/versions/list.html:235
 msgid "Delete Version"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:240
+#: src/olympia/devhub/templates/devhub/versions/list.html:237
 msgid "Disable Version"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:247
+#: src/olympia/devhub/templates/devhub/versions/list.html:244
 msgid "Add a new Version"
 msgstr "Dodaj novu inačicu"
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:249
+#: src/olympia/devhub/templates/devhub/versions/list.html:246
 msgid "Add Version"
 msgstr "Dodaj inačicu"
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:256 src/olympia/devhub/templates/devhub/versions/list.html:274
+#: src/olympia/devhub/templates/devhub/versions/list.html:253 src/olympia/devhub/templates/devhub/versions/list.html:279
 msgid "Hide Add-on"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:259
+#: src/olympia/devhub/templates/devhub/versions/list.html:256
 msgid "Hiding your add-on will prevent it from appearing anywhere in our gallery and will stop users from receiving automatic updates."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:265
+#: src/olympia/devhub/templates/devhub/versions/list.html:263
+msgid "The files awaiting review will be disabled and you will need to upload new versions."
+msgstr ""
+
+#: src/olympia/devhub/templates/devhub/versions/list.html:270
 msgid "Are you sure you wish to hide your add-on?"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:286 src/olympia/devhub/templates/devhub/versions/list.html:315
+#: src/olympia/devhub/templates/devhub/versions/list.html:291 src/olympia/devhub/templates/devhub/versions/list.html:313
 msgid "Unlist Add-on"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:289
+#: src/olympia/devhub/templates/devhub/versions/list.html:294
 #, python-format
 msgid ""
 "Unlisting your add-on will make it (and each of its versions/files) invisible on this website. It won't show up in searches, won't have a public facing page, and won't be updated automatically for "
-"current users.  It is recommended for unlisted add-ons to provide a custom <a href=\"%(update_url)s\" target=\"_blank\">updateURL</a> in their manifest file for automatic updates."
+"current users. It is recommended for unlisted add-ons to provide a custom <a href=\"%(update_url)s\" target=\"_blank\">updateURL</a> in their manifest file for automatic updates."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:299
-#, python-format
-msgid "Switching add-ons to unlisted is currently in an open beta. Please <a href=\"%(url)s\" target=\"_blank\">report any bugs</a> that you encounter."
-msgstr ""
-
-#: src/olympia/devhub/templates/devhub/versions/list.html:305
+#: src/olympia/devhub/templates/devhub/versions/list.html:303
 msgid "Unlisting an add-on is irreversible!"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:305
+#: src/olympia/devhub/templates/devhub/versions/list.html:303
 msgid "An unlisted add-on cannot be switched to be listed."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:307
+#: src/olympia/devhub/templates/devhub/versions/list.html:305
 msgid "Are you sure you wish to unlist your add-on?"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:330
+#: src/olympia/devhub/templates/devhub/versions/list.html:328
 msgid "Canceling your review request will leave your add-on as preliminarily reviewed."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:335
+#: src/olympia/devhub/templates/devhub/versions/list.html:333
 msgid "Canceling your review request will mark your add-on incomplete. If you do not complete your add-on after several days by re-requesting review, it will be deleted."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:343
+#: src/olympia/devhub/templates/devhub/versions/list.html:341
 msgid "Are you sure you wish to cancel your review request?"
 msgstr ""
 
@@ -7338,19 +7141,19 @@ msgstr ""
 msgid "Search by add-on name / author email"
 msgstr ""
 
-#: src/olympia/editors/forms.py:103
+#: src/olympia/editors/forms.py:103 src/olympia/editors/forms.py:244 src/olympia/editors/forms.py:257
 msgid "yes"
 msgstr "da"
 
-#: src/olympia/editors/forms.py:104
+#: src/olympia/editors/forms.py:104 src/olympia/editors/forms.py:244 src/olympia/editors/forms.py:257
 msgid "no"
 msgstr "ne"
 
-#: src/olympia/editors/forms.py:105
+#: src/olympia/editors/forms.py:105 src/olympia/editors/forms.py:245
 msgid "Admin Flag"
 msgstr "Zastava administratora"
 
-#: src/olympia/editors/forms.py:113
+#: src/olympia/editors/forms.py:113 src/olympia/editors/forms.py:253
 msgid "Max. Version"
 msgstr "Maks. inačica"
 
@@ -7362,57 +7165,61 @@ msgstr "Dana od podnošenja"
 msgid "Add-on Types"
 msgstr ""
 
-#: src/olympia/editors/forms.py:126 src/olympia/editors/helpers.py:267
+#: src/olympia/editors/forms.py:126 src/olympia/editors/helpers.py:279
 msgid "Platforms"
 msgstr ""
 
+#: src/olympia/editors/forms.py:237
+msgid "Search by add-on name / author email / guid"
+msgstr ""
+
 #. L10n: 0 = platform, 1 = filename, 2 = status message
-#: src/olympia/editors/forms.py:238
+#: src/olympia/editors/forms.py:342
 #, python-format
 msgid "<strong>%s</strong> &middot; %s &middot; %s"
 msgstr ""
 
 # 77%
-#: src/olympia/editors/forms.py:252
+#: src/olympia/editors/forms.py:356
 msgid "Comments:"
 msgstr "Komentari:"
 
-#: src/olympia/editors/forms.py:256
+#: src/olympia/editors/forms.py:360
 msgid "Operating systems:"
 msgstr "Operativni sustavi:"
 
 # 84%
-#: src/olympia/editors/forms.py:258
+#: src/olympia/editors/forms.py:362
 msgid "Applications:"
 msgstr "Aplikacije:"
 
-#: src/olympia/editors/forms.py:260
+#: src/olympia/editors/forms.py:364
 msgid "Notify me the next time this add-on is updated. (Subsequent updates will not generate an email)"
 msgstr "OBavijestime kada se dodatak slijedeći put ažurira. (Slijedeća ažuriranja neće generirati email)"
 
-#: src/olympia/editors/forms.py:265
+#: src/olympia/editors/forms.py:369
 msgid "Clear Admin Review Flag"
 msgstr ""
 
-#: src/olympia/editors/forms.py:267
+#: src/olympia/editors/forms.py:371
 msgid "Clear more info requested flag"
 msgstr ""
 
-#: src/olympia/editors/forms.py:281
+#: src/olympia/editors/forms.py:385
 msgid "Choose a canned response..."
 msgstr ""
 
 #. L10n: Description of what can be searched for.
-#: src/olympia/editors/forms.py:324
+#: src/olympia/editors/forms.py:423
 msgid "theme name"
 msgstr ""
 
-#: src/olympia/editors/forms.py:350
+#: src/olympia/editors/forms.py:449
 msgid "Someone else is reviewing this theme."
 msgstr ""
 
 #. L10n: Description of what can be searched for.
-#: src/olympia/editors/forms.py:447
+#: src/olympia/editors/forms.py:546
 msgid "app, reviewer, or comment"
 msgstr ""
 
@@ -7428,257 +7235,264 @@ msgstr ""
 msgid "Rejected or Unreviewed"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:123 src/olympia/editors/helpers.py:136
+#: src/olympia/editors/helpers.py:125 src/olympia/editors/helpers.py:138
 msgid "Queue"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:124 src/olympia/editors/templates/editors/base.html:50 src/olympia/editors/templates/editors/base.html:65
+#: src/olympia/editors/helpers.py:126 src/olympia/editors/templates/editors/base.html:50 src/olympia/editors/templates/editors/base.html:65
 msgid "Pending Updates"
 msgstr "Ažuriranja na čekanju"
 
-#: src/olympia/editors/helpers.py:125 src/olympia/editors/templates/editors/base.html:48 src/olympia/editors/templates/editors/base.html:63
+#: src/olympia/editors/helpers.py:127 src/olympia/editors/templates/editors/base.html:48 src/olympia/editors/templates/editors/base.html:63
 msgid "Full Reviews"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:126 src/olympia/editors/templates/editors/base.html:52 src/olympia/editors/templates/editors/base.html:67
+#: src/olympia/editors/helpers.py:128 src/olympia/editors/templates/editors/base.html:52 src/olympia/editors/templates/editors/base.html:67
 msgid "Preliminary Reviews"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:127 src/olympia/editors/templates/editors/base.html:54
+#: src/olympia/editors/helpers.py:129 src/olympia/editors/templates/editors/base.html:54
 msgid "Moderated Reviews"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:128 src/olympia/editors/templates/editors/base.html:46
+#: src/olympia/editors/helpers.py:130 src/olympia/editors/templates/editors/base.html:46
 msgid "Fast Track"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:130
+#: src/olympia/editors/helpers.py:132
 msgid "Pending Themes"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:131 src/olympia/editors/templates/editors/themes/queue.html:4
+#: src/olympia/editors/helpers.py:133 src/olympia/editors/templates/editors/themes/queue.html:4
 msgid "Flagged Themes"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:132
+#: src/olympia/editors/helpers.py:134
 msgid "Update Themes"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:137
+#: src/olympia/editors/helpers.py:139
 msgid "Unlisted Pending Updates"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:138
+#: src/olympia/editors/helpers.py:140
 msgid "Unlisted Full Reviews"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:139
+#: src/olympia/editors/helpers.py:141
 msgid "Unlisted Preliminary Reviews"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:170
+#: src/olympia/editors/helpers.py:142
+msgid "Unlisted All Add-ons"
+msgstr ""
+
+#: src/olympia/editors/helpers.py:173
 msgid "Fast Track ({0})"
 msgid_plural "Fast Track ({0})"
 msgstr[0] ""
 msgstr[1] ""
-msgstr[2] ""
 
-#: src/olympia/editors/helpers.py:175
+#: src/olympia/editors/helpers.py:178
 msgid "Full Review ({0})"
 msgid_plural "Full Reviews ({0})"
 msgstr[0] ""
 msgstr[1] ""
-msgstr[2] ""
 
-#: src/olympia/editors/helpers.py:180
+#: src/olympia/editors/helpers.py:183
 msgid "Pending Update ({0})"
 msgid_plural "Pending Updates ({0})"
 msgstr[0] "Čeka na ažuriranje ({0})"
 msgstr[1] "Čekaju na ažuriranje ({0})"
-msgstr[2] "Čeka na ažuriranje ({0})"
 
-#: src/olympia/editors/helpers.py:185
+#: src/olympia/editors/helpers.py:188
 msgid "Preliminary Review ({0})"
 msgid_plural "Preliminary Reviews ({0})"
 msgstr[0] "Preliminarna revizija ({0})"
 msgstr[1] "Preliminarne revizije ({0})"
-msgstr[2] "Preliminarnih revizija ({0})"
 
-#: src/olympia/editors/helpers.py:190
+#: src/olympia/editors/helpers.py:193
 msgid "Moderated Review ({0})"
 msgid_plural "Moderated Reviews ({0})"
 msgstr[0] "Moderirana revizija ({0})"
 msgstr[1] "Moderirane revizije ({0})"
-msgstr[2] "Moderiranih revizija ({0})"
 
-#: src/olympia/editors/helpers.py:196
+#: src/olympia/editors/helpers.py:199
 msgid "Unlisted Full Review ({0})"
 msgid_plural "Unlisted Full Reviews ({0})"
 msgstr[0] ""
 msgstr[1] ""
-msgstr[2] ""
 
-#: src/olympia/editors/helpers.py:201
+#: src/olympia/editors/helpers.py:204
 msgid "Unlisted Pending Update ({0})"
 msgid_plural "Unlisted Pending Updates ({0})"
 msgstr[0] ""
 msgstr[1] ""
-msgstr[2] ""
 
-#: src/olympia/editors/helpers.py:206
+#: src/olympia/editors/helpers.py:209
 msgid "Unlisted Preliminary Review ({0})"
 msgid_plural "Unlisted Preliminary Reviews ({0})"
 msgstr[0] ""
 msgstr[1] ""
-msgstr[2] ""
 
-#: src/olympia/editors/helpers.py:261
-msgid "Addon"
-msgstr ""
+#: src/olympia/editors/helpers.py:214
+msgid "Unlisted All Add-ons ({0})"
+msgid_plural "Unlisted All Add-ons ({0})"
+msgstr[0] ""
+msgstr[1] ""
 
-#: src/olympia/editors/helpers.py:262
+#: src/olympia/editors/helpers.py:274
 msgid "Type"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:263
+#: src/olympia/editors/helpers.py:275
 msgid "Waiting Time"
 msgstr "Vrijeme čekanja"
 
-#: src/olympia/editors/helpers.py:264 src/olympia/editors/templates/editors/review.html:285
+#: src/olympia/editors/helpers.py:276 src/olympia/editors/templates/editors/review.html:285
 msgid "Flags"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:265
+#: src/olympia/editors/helpers.py:277
 msgid "Applications"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:270
+#: src/olympia/editors/helpers.py:282
 msgid "Additional"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:285
+#: src/olympia/editors/helpers.py:302
 msgid "Site Specific"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:287
+#: src/olympia/editors/helpers.py:304
 msgid "Requires External Software"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:289
+#: src/olympia/editors/helpers.py:306
 msgid "Binary Components"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:313
+#: src/olympia/editors/helpers.py:339
 msgid "moments ago"
 msgstr ""
 
 #. L10n: first argument is number of minutes
-#: src/olympia/editors/helpers.py:316
+#: src/olympia/editors/helpers.py:342
 msgid "{0} minute"
 msgid_plural "{0} minutes"
 msgstr[0] ""
 msgstr[1] ""
-msgstr[2] ""
 
 #. L10n: first argument is number of hours
-#: src/olympia/editors/helpers.py:320
+#: src/olympia/editors/helpers.py:346
 msgid "{0} hour"
 msgid_plural "{0} hours"
 msgstr[0] ""
 msgstr[1] ""
-msgstr[2] ""
 
 #. L10n: first argument is number of days
-#: src/olympia/editors/helpers.py:324
+#: src/olympia/editors/helpers.py:350
 msgid "{0} day"
 msgid_plural "{0} days"
 msgstr[0] ""
 msgstr[1] ""
-msgstr[2] ""
 
-#: src/olympia/editors/helpers.py:488
+#: src/olympia/editors/helpers.py:364
+msgid "Last Review"
+msgstr ""
+
+#: src/olympia/editors/helpers.py:366
+msgid "Last Update"
+msgstr ""
+
+#: src/olympia/editors/helpers.py:387
+msgid "No Reviews"
+msgstr ""
+
+#: src/olympia/editors/helpers.py:561
 msgid "Push to public"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:490
+#: src/olympia/editors/helpers.py:563
 msgid "Grant full review"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:505
+#: src/olympia/editors/helpers.py:578
 msgid "Request more information"
 msgstr "Zatraži više informacija"
 
-#: src/olympia/editors/helpers.py:508
+#: src/olympia/editors/helpers.py:581
 msgid "Request super-review"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:519
+#: src/olympia/editors/helpers.py:592
 msgid "Grant preliminary review"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:520
+#: src/olympia/editors/helpers.py:593
 msgid "This will mark the files as preliminarily reviewed."
 msgstr ""
 
-#: src/olympia/editors/helpers.py:522
+#: src/olympia/editors/helpers.py:595
 msgid "Use this form to request more information from the author. They will receive an email and be able to answer here. You will be notified by email when they reply."
 msgstr ""
 
-#: src/olympia/editors/helpers.py:526
+#: src/olympia/editors/helpers.py:599
 msgid ""
 "If you have concerns about this add-on's security, copyright issues, or other concerns that an administrator should look into, enter your comments in the area below. They will be sent to "
 "administrators, not the author."
 msgstr ""
 
-#: src/olympia/editors/helpers.py:532
+#: src/olympia/editors/helpers.py:605
 msgid "This will reject the add-on and remove it from the review queue."
 msgstr ""
 
-#: src/olympia/editors/helpers.py:534
-msgid "Make a comment on this version.  The author won't be able to see this."
+#: src/olympia/editors/helpers.py:607
+msgid "Make a comment on this version. The author won't be able to see this."
 msgstr ""
 
-#: src/olympia/editors/helpers.py:538
+#: src/olympia/editors/helpers.py:611
 msgid "This will reject the files and remove them from the review queue."
 msgstr ""
 
-#: src/olympia/editors/helpers.py:542
+#: src/olympia/editors/helpers.py:615
 msgid "This will mark the add-on as preliminarily reviewed. Future versions will undergo preliminary review."
 msgstr ""
 
-#: src/olympia/editors/helpers.py:547
+#: src/olympia/editors/helpers.py:620
 msgid "This will mark the files as preliminarily reviewed. Future versions will undergo preliminary review."
 msgstr "Ovo će označiti datoteke kao preliminarno pregledane. Buduće inačice bit će podvrgnute preliminarnoj reviziji."
 
-#: src/olympia/editors/helpers.py:552
+#: src/olympia/editors/helpers.py:625
 msgid "Retain preliminary review"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:553
+#: src/olympia/editors/helpers.py:626
 msgid "This will retain the add-on as preliminarily reviewed. Future versions will undergo preliminary review."
 msgstr "Ovo će zadržati dodatak preliminarno pregledanim. Buduće inačice bit će podvrgnute preliminarnoj reviziji."
 
-#: src/olympia/editors/helpers.py:558
+#: src/olympia/editors/helpers.py:631
 msgid "This will approve a sandboxed version of a public add-on to appear on the public side."
 msgstr ""
 
-#: src/olympia/editors/helpers.py:561
+#: src/olympia/editors/helpers.py:634
 msgid "This will reject a version of a public add-on and remove it from the queue."
 msgstr ""
 
-#: src/olympia/editors/helpers.py:564
+#: src/olympia/editors/helpers.py:637
 msgid "This will mark the add-on and its most recent version and files as public. Future versions will go into the sandbox until they are reviewed by an editor."
 msgstr ""
 
-#: src/olympia/editors/helpers.py:637
+#: src/olympia/editors/helpers.py:714
 msgid "add-on"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:940 src/olympia/editors/helpers.py:960
+#: src/olympia/editors/helpers.py:1020 src/olympia/editors/helpers.py:1040
 msgid "Flagged"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:944 src/olympia/editors/helpers.py:963
+#: src/olympia/editors/helpers.py:1024 src/olympia/editors/helpers.py:1043
 msgid "Updates"
 msgstr ""
 
@@ -7730,57 +7544,57 @@ msgstr ""
 msgid "A question about your Theme submission"
 msgstr ""
 
-#: src/olympia/editors/views.py:144
+#: src/olympia/editors/views.py:146
 msgid "New Add-ons (Under 5 days)"
 msgstr "Novi dodaci (ispod 5 dana)"
 
-#: src/olympia/editors/views.py:145
+#: src/olympia/editors/views.py:147
 msgid "Passable (5 to 10 days)"
 msgstr "Prolazni (5 do 10 dana)"
 
-#: src/olympia/editors/views.py:146
+#: src/olympia/editors/views.py:148
 msgid "Overdue (Over 10 days)"
 msgstr "Prošao rok (više od 10 dana)"
 
-#: src/olympia/editors/views.py:532
+#: src/olympia/editors/views.py:539
 msgid "An unknown error occurred"
 msgstr ""
 
-#: src/olympia/editors/views.py:587
+#: src/olympia/editors/views.py:592
 msgid "Self-reviews are not allowed."
 msgstr ""
 
-#: src/olympia/editors/views.py:609
+#: src/olympia/editors/views.py:613
 msgid "Review successfully processed."
 msgstr ""
 
-#: src/olympia/editors/views.py:807
+#: src/olympia/editors/views.py:812
 msgid "was approved"
 msgstr ""
 
-#: src/olympia/editors/views.py:808
+#: src/olympia/editors/views.py:813
 msgid "given preliminary review"
 msgstr ""
 
-#: src/olympia/editors/views.py:809
+#: src/olympia/editors/views.py:814
 msgid "rejected"
 msgstr "odbijen"
 
-#: src/olympia/editors/views.py:810
+#: src/olympia/editors/views.py:815
 msgctxt "editors_review_history_nominated_adminreview"
 msgid "escalated"
 msgstr ""
 
 # 79%
-#: src/olympia/editors/views.py:812
+#: src/olympia/editors/views.py:817
 msgid "needs more information"
 msgstr "treba više informacija"
 
-#: src/olympia/editors/views.py:813
+#: src/olympia/editors/views.py:818
 msgid "needs super review"
 msgstr "treba prvorazrednu reviziju"
 
-#: src/olympia/editors/views.py:814
+#: src/olympia/editors/views.py:819
 msgid "commented"
 msgstr ""
 
@@ -7789,7 +7603,6 @@ msgid "{0} theme review successfully processed (+{1} points, {2} total)."
 msgid_plural "{0} theme reviews successfully processed (+{1} points, {2} total)."
 msgstr[0] ""
 msgstr[1] ""
-msgstr[2] ""
 
 #: src/olympia/editors/views_themes.py:341
 msgid "Your theme locks have successfully been released. Other reviewers may now review those released themes. You may have to refresh the page to see the changes reflected in the table below."
@@ -7826,28 +7639,28 @@ msgstr ""
 msgid "Unlisted Queues"
 msgstr ""
 
-#: src/olympia/editors/templates/editors/base.html:72 src/olympia/editors/templates/editors/performance.html:6
+#: src/olympia/editors/templates/editors/base.html:74 src/olympia/editors/templates/editors/performance.html:6
 msgid "Performance"
 msgstr ""
 
-#: src/olympia/editors/templates/editors/base.html:75 src/olympia/editors/templates/editors/themes/base.html:19 src/olympia/editors/templates/editors/themes/base.html:38
+#: src/olympia/editors/templates/editors/base.html:77 src/olympia/editors/templates/editors/themes/base.html:19 src/olympia/editors/templates/editors/themes/base.html:38
 msgid "Logs"
 msgstr "Evidencije"
 
-#: src/olympia/editors/templates/editors/base.html:78 src/olympia/editors/templates/editors/reviewlog.html:4 src/olympia/editors/templates/editors/reviewlog.html:27
+#: src/olympia/editors/templates/editors/base.html:80 src/olympia/editors/templates/editors/reviewlog.html:4 src/olympia/editors/templates/editors/reviewlog.html:27
 msgid "Add-on Review Log"
 msgstr "Revizijski zapis dodatka"
 
-#: src/olympia/editors/templates/editors/base.html:80 src/olympia/editors/templates/editors/eventlog.html:4 src/olympia/editors/templates/editors/eventlog.html:8
+#: src/olympia/editors/templates/editors/base.html:82 src/olympia/editors/templates/editors/eventlog.html:4 src/olympia/editors/templates/editors/eventlog.html:8
 #: src/olympia/editors/templates/editors/eventlog_detail.html:4
 msgid "Moderated Review Log"
 msgstr "Moderirani revizijski zapis"
 
-#: src/olympia/editors/templates/editors/base.html:82 src/olympia/editors/templates/editors/beta_signed_log.html:4 src/olympia/editors/templates/editors/beta_signed_log.html:8
+#: src/olympia/editors/templates/editors/base.html:84 src/olympia/editors/templates/editors/beta_signed_log.html:4 src/olympia/editors/templates/editors/beta_signed_log.html:8
 msgid "Signed Beta Files Log"
 msgstr ""
 
-#: src/olympia/editors/templates/editors/base.html:87 src/olympia/editors/templates/editors/includes/daily-message.html:4
+#: src/olympia/editors/templates/editors/base.html:89 src/olympia/editors/templates/editors/includes/daily-message.html:4
 msgid "Announcement"
 msgstr ""
 
@@ -7907,21 +7720,18 @@ msgid "Full Review ({num})"
 msgid_plural "Full Reviews ({num})"
 msgstr[0] ""
 msgstr[1] ""
-msgstr[2] ""
 
 #: src/olympia/editors/templates/editors/home.html:18
 msgid "Pending Update ({num})"
 msgid_plural "Pending Updates ({num})"
 msgstr[0] ""
 msgstr[1] ""
-msgstr[2] ""
 
 #: src/olympia/editors/templates/editors/home.html:25
 msgid "Preliminary Review ({num})"
 msgid_plural "Preliminary Reviews ({num})"
 msgstr[0] ""
 msgstr[1] ""
-msgstr[2] ""
 
 #: src/olympia/editors/templates/editors/home.html:36 src/olympia/editors/templates/editors/home.html:86
 msgid "Current waiting times:"
@@ -7932,7 +7742,6 @@ msgid "{0} add-on"
 msgid_plural "{0} add-ons"
 msgstr[0] ""
 msgstr[1] ""
-msgstr[2] ""
 
 #: src/olympia/editors/templates/editors/home.html:45 src/olympia/editors/templates/editors/home.html:95
 #, python-format
@@ -7944,21 +7753,18 @@ msgid "Unlisted Full Review ({num})"
 msgid_plural "Unlisted Full Reviews ({num})"
 msgstr[0] ""
 msgstr[1] ""
-msgstr[2] ""
 
 #: src/olympia/editors/templates/editors/home.html:68
 msgid "Unlisted Pending Update ({num})"
 msgid_plural "Unlisted Pending Updates ({num})"
 msgstr[0] ""
 msgstr[1] ""
-msgstr[2] ""
 
 #: src/olympia/editors/templates/editors/home.html:75
 msgid "Unlisted Preliminary Review ({num})"
 msgid_plural "Unlisted Preliminary Reviews ({num})"
 msgstr[0] ""
 msgstr[1] ""
-msgstr[2] ""
 
 #: src/olympia/editors/templates/editors/home.html:109 src/olympia/editors/templates/editors/performance.html:37 src/olympia/editors/templates/editors/themes/home.html:54
 msgid "Total Reviews"
@@ -7982,7 +7788,6 @@ msgid "Moderated Review ({num})"
 msgid_plural "Moderated Reviews ({num})"
 msgstr[0] ""
 msgstr[1] ""
-msgstr[2] ""
 
 #: src/olympia/editors/templates/editors/leaderboard.html:3 src/olympia/editors/templates/editors/includes/reviewers_score_bar.html:56
 msgid "Reviewer Leaderboard"
@@ -8076,45 +7881,45 @@ msgstr ""
 msgid "clear search"
 msgstr "očisti pretraživanje"
 
-#: src/olympia/editors/templates/editors/queue.html:72 src/olympia/editors/templates/editors/queue.html:122
+#: src/olympia/editors/templates/editors/queue.html:78 src/olympia/editors/templates/editors/queue.html:128
 msgid "Process Reviews"
 msgstr ""
 
-#: src/olympia/editors/templates/editors/queue.html:80
+#: src/olympia/editors/templates/editors/queue.html:86
 msgid "Moderation actions:"
 msgstr ""
 
-#: src/olympia/editors/templates/editors/queue.html:90
+#: src/olympia/editors/templates/editors/queue.html:96
 #, python-format
 msgid "by %(user)s on %(date)s %(stars)s (%(locale)s)"
 msgstr "od strane %(user)s %(date)s %(stars)s (%(locale)s)"
 
-#: src/olympia/editors/templates/editors/queue.html:106
+#: src/olympia/editors/templates/editors/queue.html:112
 #, python-format
 msgid "<strong>%(reason)s</strong> <span class=\"light\">Flagged by %(user)s on %(date)s</span>"
 msgstr ""
 
-#: src/olympia/editors/templates/editors/queue.html:119
-msgid "All reviews have been moderated.  Good work!"
+#: src/olympia/editors/templates/editors/queue.html:125
+msgid "All reviews have been moderated. Good work!"
 msgstr ""
 
-#: src/olympia/editors/templates/editors/queue.html:161
+#: src/olympia/editors/templates/editors/queue.html:167
 msgid "Version Notes / Notes for Reviewer"
 msgstr ""
 
-#: src/olympia/editors/templates/editors/queue.html:169
+#: src/olympia/editors/templates/editors/queue.html:175
 msgid "There are currently no add-ons of this type to review."
 msgstr ""
 
-#: src/olympia/editors/templates/editors/queue.html:181 src/olympia/editors/templates/editors/themes/queue_list.html:85
+#: src/olympia/editors/templates/editors/queue.html:187 src/olympia/editors/templates/editors/themes/queue_list.html:85
 msgid "Helpful Links:"
 msgstr "Korisni linkovi:"
 
-#: src/olympia/editors/templates/editors/queue.html:182
+#: src/olympia/editors/templates/editors/queue.html:188
 msgid "Add-on Policy"
 msgstr "Polica dodatka"
 
-#: src/olympia/editors/templates/editors/queue.html:184
+#: src/olympia/editors/templates/editors/queue.html:190
 msgid "Editors' Guide"
 msgstr ""
 
@@ -8178,10 +7983,7 @@ msgid "<strong>Warning!</strong> Another user was viewing this page before you."
 msgstr ""
 
 #: src/olympia/editors/templates/editors/review.html:237
-msgid ""
-"The whiteboard is the place to exchange information relevant to\n"
-"               this addon (whatever the version), between the developer and the\n"
-"               editor. This is visible and editable by both."
+msgid "The whiteboard is the place to exchange information relevant to this addon (whatever the version), between the developer and the editor. This is visible and editable by both."
 msgstr ""
 
 #: src/olympia/editors/templates/editors/review.html:241
@@ -8326,21 +8128,18 @@ msgid "{num} Pending Theme Review"
 msgid_plural "{num} Pending Theme Reviews"
 msgstr[0] ""
 msgstr[1] ""
-msgstr[2] ""
 
 #: src/olympia/editors/templates/editors/themes/home.html:27
 msgid "{num} Flagged Review"
 msgid_plural "{num} Flagged Reviews"
 msgstr[0] ""
 msgstr[1] ""
-msgstr[2] ""
 
 #: src/olympia/editors/templates/editors/themes/home.html:34
 msgid "{num} Update"
 msgid_plural "{num} Updates"
 msgstr[0] ""
 msgstr[1] ""
-msgstr[2] ""
 
 #: src/olympia/editors/templates/editors/themes/logs.html:4
 msgid "Theme Review Log"
@@ -8459,7 +8258,7 @@ msgstr ""
 msgid "Describe your reason for flagging"
 msgstr ""
 
-#: src/olympia/files/forms.py:88
+#: src/olympia/files/forms.py:90
 msgid "Cannot diff a version against itself"
 msgstr ""
 
@@ -8495,51 +8294,51 @@ msgstr "Došlo je do pogreške prilikom pristupa datoteci %s. %s."
 msgid "There was an error accessing file %s."
 msgstr "Došlo je do pogreške prilikom pristupa datoteci %s."
 
-#: src/olympia/files/utils.py:343
+#: src/olympia/files/utils.py:340
 msgid "Could not parse uploaded file."
 msgstr ""
 
-#: src/olympia/files/utils.py:380
+#: src/olympia/files/utils.py:377
 msgid "Invalid file name in archive: {0}"
 msgstr ""
 
-#: src/olympia/files/utils.py:388
+#: src/olympia/files/utils.py:385
 msgid "File exceeding size limit in archive: {0}"
 msgstr ""
 
-#: src/olympia/files/utils.py:439
+#: src/olympia/files/utils.py:436
 msgid "Invalid archive."
 msgstr ""
 
-#: src/olympia/files/utils.py:529 src/olympia/files/utils.py:532
+#: src/olympia/files/utils.py:526 src/olympia/files/utils.py:529
 msgid "Could not parse the manifest file."
 msgstr ""
 
-#: src/olympia/files/utils.py:551
+#: src/olympia/files/utils.py:548
 msgid "Could not find an add-on ID."
 msgstr ""
 
-#: src/olympia/files/utils.py:554
+#: src/olympia/files/utils.py:551
 msgid "Add-on ID must be 64 characters or less."
 msgstr ""
 
-#: src/olympia/files/utils.py:556
+#: src/olympia/files/utils.py:553
 msgid "Add-on ID doesn't match add-on."
 msgstr ""
 
-#: src/olympia/files/utils.py:564
+#: src/olympia/files/utils.py:561
 msgid "Duplicate add-on ID found."
 msgstr ""
 
-#: src/olympia/files/utils.py:567
+#: src/olympia/files/utils.py:564
 msgid "Version numbers should have fewer than 32 characters."
 msgstr ""
 
-#: src/olympia/files/utils.py:570
+#: src/olympia/files/utils.py:567
 msgid "Version numbers should only contain letters, numbers, and these punctuation characters: +*.-_."
 msgstr ""
 
-#: src/olympia/files/utils.py:587
+#: src/olympia/files/utils.py:584
 msgid "<em:type> doesn't match add-on"
 msgstr "<em:type> ne odgovara dodatku"
 
@@ -8640,6 +8439,10 @@ msgstr "Nema datoteka u učitanoj datoteci."
 #: src/olympia/files/templates/files/viewer.html:134
 msgid "Fetching file."
 msgstr "Dohvat datoteke."
+
+#: src/olympia/legacy_api/views.py:255
+msgid "Not implemented yet."
+msgstr ""
 
 #: src/olympia/lib/constants.py:6
 msgid "United Arab Emirates Dirham"
@@ -9297,10 +9100,6 @@ msgstr ""
 msgid "Zimbabwe Dollar"
 msgstr ""
 
-#: src/olympia/lib/video/ffmpeg.py:112 src/olympia/lib/video/totem.py:81
-msgid "Videos must be in WebM."
-msgstr ""
-
 #: src/olympia/pages/templates/pages/about.lhtml:3 src/olympia/pages/templates/pages/about.lhtml:10
 msgid "About Mozilla Add-ons"
 msgstr ""
@@ -9312,7 +9111,7 @@ msgstr ""
 #: src/olympia/pages/templates/pages/about.lhtml:13
 msgid ""
 "addons.mozilla.org, commonly known as \"AMO\", is Mozilla's official site for add-ons to Mozilla software, such as Firefox, Thunderbird, and SeaMonkey. Add-ons let you add new features and change "
-"the way your browser or application works.  Take a look around and explore the thousands of ways to customize the way you do things online."
+"the way your browser or application works. Take a look around and explore the thousands of ways to customize the way you do things online."
 msgstr ""
 
 #: src/olympia/pages/templates/pages/about.lhtml:19
@@ -9658,7 +9457,7 @@ msgstr ""
 msgid ""
 "Yes. It's possible, but some of the functionality provided by these libraries are available through XPCOM, XUL, and JavaScript. In addition, authors should take care if libraries modify primitive "
 "object prototypes (String.prototype, Date.prototype, etc.) and/or define global functions (eg. the $ function). These are prone to cause conflict with other add-ons, in particular if different add-"
-"ons use different versions of libraries and so on. Developers need to be very, very careful with using them.  Mozilla does not offer documentation on using them to build add-ons."
+"ons use different versions of libraries and so on. Developers need to be very, very careful with using them. Mozilla does not offer documentation on using them to build add-ons."
 msgstr ""
 
 #: src/olympia/pages/templates/pages/dev_faq.html:165
@@ -9772,8 +9571,8 @@ msgstr ""
 #, python-format
 msgid ""
 "Yes. Many developers choose to host their own add-ons. Choosing to host your add-on on <a href=\"%(amo_url)s\">Mozilla's add-on site</a>, though, allows for much greater exposure to your add-on due "
-"to the large volume of visitors to the site.  <a href=\"%(md_url)s\">mozdev.org</a> offers free project hosting for Mozilla applications and extensions providing developers with tools to help "
-"manage source code, version control, bug tracking and documentation."
+"to the large volume of visitors to the site. <a href=\"%(md_url)s\">mozdev.org</a> offers free project hosting for Mozilla applications and extensions providing developers with tools to help manage "
+"source code, version control, bug tracking and documentation."
 msgstr ""
 
 #: src/olympia/pages/templates/pages/dev_faq.html:277
@@ -9821,7 +9620,7 @@ msgstr ""
 #: src/olympia/pages/templates/pages/dev_faq.html:314
 #, python-format
 msgid ""
-"Yes. Mozilla's <a href=\"%(p_url)s\">Add-on Policy</a> describes what is an acceptable submission. This policy is subject to change without notice.  In addition, the AMO editorial team uses the <a "
+"Yes. Mozilla's <a href=\"%(p_url)s\">Add-on Policy</a> describes what is an acceptable submission. This policy is subject to change without notice. In addition, the AMO editorial team uses the <a "
 "href=\"%(g_url)s\">Editors Reviewing Guide</a> to ensure that your add-on meets specific guidelines for functionality and security."
 msgstr ""
 
@@ -9938,7 +9737,7 @@ msgstr ""
 #: src/olympia/pages/templates/pages/dev_faq.html:434
 #, python-format
 msgid ""
-"This is why it's very important to read the <a href=\"%(g_url)s\">Editors Reviewing Guide</a> to ensure that your add-on is setup as expected.  It's also a good idea to read the blog post, <a href="
+"This is why it's very important to read the <a href=\"%(g_url)s\">Editors Reviewing Guide</a> to ensure that your add-on is setup as expected. It's also a good idea to read the blog post, <a href="
 "\"%(blog_url)s\">Successfully Getting your Add-on Reviewed</a> which provides excellent insight into ensuring a smooth review of your add-on."
 msgstr ""
 
@@ -10045,7 +9844,7 @@ msgstr ""
 
 #: src/olympia/pages/templates/pages/dev_faq.html:572
 msgid ""
-"Free Software Foundation provides short summaries of the key open source licenses, including whether the license qualifies as a free software license or a copyleft license.  Also includes a "
+"Free Software Foundation provides short summaries of the key open source licenses, including whether the license qualifies as a free software license or a copyleft license. Also includes a "
 "discussion of what constitutes a free software license or a copyleft license (e.g., a Copyleft license is a general method for making a program or other work free, and requiring all modified and "
 "extended versions of the program to be free as well.)"
 msgstr ""
@@ -10235,14 +10034,10 @@ msgstr ""
 msgid "How do I choose between add-ons that seem to do the same thing?"
 msgstr "Kako izabrati između dodataka za koje se čini da rade istu stvar?"
 
-#: src/olympia/pages/templates/pages/faq.html:173
+#: src/olympia/pages/templates/pages/faq.html:172
 msgid ""
-"There are often several add-ons that have similar features. To\n"
-"    figure out which is right for you, read the entire description of the\n"
-"    add-on and view its screenshots. If there are still several in the running,\n"
-"    read through the add-on's ratings, user reviews, and statistics to see\n"
-"    which is most liked by other users. Remember that you can also just try\n"
-"    out both and see which you like better."
+"There are often several add-ons that have similar features. To figure out which is right for you, read the entire description of the add-on and view its screenshots. If there are still several in "
+"the running, read through the add-on's ratings, user reviews, and statistics to see which is most liked by other users. Remember that you can also just try out both and see which you like better."
 msgstr ""
 
 #: src/olympia/pages/templates/pages/faq.html:180
@@ -10283,36 +10078,30 @@ msgid "How much do add-ons cost to purchase?"
 msgstr ""
 
 #: src/olympia/pages/templates/pages/faq.html:207
-msgid ""
-"Add-ons hosted in our gallery are free unless clearly marked\n"
-"    otherwise."
+msgid "Add-ons hosted in our gallery are free unless clearly marked otherwise."
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:210
+#: src/olympia/pages/templates/pages/faq.html:209
 msgid "What does it mean when an add-on asks for contributions?"
 msgstr "Što znači kada dodatak pita za doprinose?"
 
-#: src/olympia/pages/templates/pages/faq.html:211
+#: src/olympia/pages/templates/pages/faq.html:210
 msgid ""
-"Some add-on authors request users who enjoy an add-on to\n"
-"        contribute to its development by making a monetary contribution. These\n"
-"        contributions go directly to the developer unless a third party is\n"
-"        indicated, such as the non-profit Mozilla Foundation."
+"Some add-on authors request users who enjoy an add-on to contribute to its development by making a monetary contribution. These contributions go directly to the developer unless a third party is "
+"indicated, such as the non-profit Mozilla Foundation."
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:216
+#: src/olympia/pages/templates/pages/faq.html:215
 msgid "What are beta add-ons?"
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:218
+#: src/olympia/pages/templates/pages/faq.html:217
 msgid ""
-"Beta add-ons are unreviewed versions which represent the\n"
-"        latest work of an add-on author. While different authors have different\n"
-"        standards for beta code quality, you should assume that these add-ons\n"
-"        are less stable than the general add-on releases."
+"Beta add-ons are unreviewed versions which represent the latest work of an add-on author. While different authors have different standards for beta code quality, you should assume that these add-"
+"ons are less stable than the general add-on releases."
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:222
+#: src/olympia/pages/templates/pages/faq.html:221
 msgid ""
 "Please note that when you install an add-on from the \"Beta Version\" section of an add-on's listing, you will continue to receive updates for that add-on as they become available. Like the initial "
 "version you installed, all beta releases are unreviewed by Mozilla and may harm your computer."
@@ -10320,24 +10109,19 @@ msgstr ""
 "Imajte na umu da prilikom instaliranja dodatka iz \"Beta inačica\" dijela popisa dodatka, i dalje ćete primati ažuriranja za taj dodatak čim ona postanu dostupna. Kao i početna inačica koji ste "
 "instalirali, sva beta izdanja nisu pregledana od strane Mozille i mogu naštetiti Vašem računalu."
 
+#: src/olympia/pages/templates/pages/faq.html:228
+msgid "What does it mean when an add-on is flagged as slow?"
+msgstr ""
+
 #: src/olympia/pages/templates/pages/faq.html:229
-msgid ""
-"What does it mean when an add-on is flagged as\n"
-"    slow?"
+msgid "Most add-ons load code and resources at the same time Firefox is starting up. In most cases the impact in start-up time is minimal, but some add-ons can cause a noticeable slowdown."
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:231
-msgid ""
-"Most add-ons load code and resources at the same time Firefox\n"
-"        is starting up. In most cases the impact in start-up time is minimal,\n"
-"        but some add-ons can cause a noticeable slowdown."
-msgstr ""
-
-#: src/olympia/pages/templates/pages/faq.html:236
+#: src/olympia/pages/templates/pages/faq.html:234
 msgid "How do I report an inappropriate or spam user review?"
 msgstr "Kako mogu prijaviti neprikladnu ili neželjenu korisničku reviziju?"
 
-#: src/olympia/pages/templates/pages/faq.html:237
+#: src/olympia/pages/templates/pages/faq.html:235
 msgid ""
 "To report a user review of an add-on, log in with your account and visit the add-on's reviews page. Find the review you wish to report, click \"Report this review\" and select a reason. Our "
 "editorial team will investigate the review and take appropriate action."
@@ -10345,20 +10129,20 @@ msgstr ""
 "Da biste prijavili korisničku reviziju dodatka, prijavite se sa svojim računom i posjetite revizijsku stranicu dodatka. Pronađite reviziju koji želite prijaviti, kliknite \"Prijavi ovu reviziju\" i "
 "odaberite razlog. Naš uređivački tim će istražiti reviziju i poduzeti odgovarajuće mjere."
 
-#: src/olympia/pages/templates/pages/faq.html:242
+#: src/olympia/pages/templates/pages/faq.html:240
 msgid "How do I report a bug or contact the Mozilla Add-ons team?"
 msgstr "Kako da prijavim grešku ili kontaktiram Mozilla tim za Dodatke?"
 
-#: src/olympia/pages/templates/pages/faq.html:243
+#: src/olympia/pages/templates/pages/faq.html:241
 #, python-format
 msgid "Please visit our <a href=\"%(contact_url)s\">Contact page</a>."
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:246
+#: src/olympia/pages/templates/pages/faq.html:244
 msgid "What is a Source Code License?"
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:247
+#: src/olympia/pages/templates/pages/faq.html:245
 #, python-format
 msgid ""
 "The source code used to create an add-on is an exclusive copyright of the add-on author, unless otherwise declared in a source code license. Many add-ons on this site have <a href=\"%(url)s\" lang="
@@ -10366,60 +10150,60 @@ msgid ""
 "the GPL or BSD licenses instead of making up their own."
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:256
+#: src/olympia/pages/templates/pages/faq.html:254
 #, python-format
 msgid "Firefox and other Mozilla software are <a href=\"%(url)s\">open source</a>."
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:264
+#: src/olympia/pages/templates/pages/faq.html:262
 msgid "Collections and Favorites"
 msgstr "Zbirke i favoriti"
 
-#: src/olympia/pages/templates/pages/faq.html:267
+#: src/olympia/pages/templates/pages/faq.html:265
 msgid "What is a collection?"
 msgstr "Što je zbirka?"
 
-#: src/olympia/pages/templates/pages/faq.html:268
+#: src/olympia/pages/templates/pages/faq.html:266
 msgid "Collections are groups of related add-ons created by users to share."
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:270
+#: src/olympia/pages/templates/pages/faq.html:268
 msgid "What is the My Favorites collection?"
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:271
+#: src/olympia/pages/templates/pages/faq.html:269
 msgid "Favorite add-ons are add-ons that you have bookmarked to easily get back to later. You can add an add-on to your favorites collection by clicking \"Add to favorites\" on its details page."
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:275 src/olympia/templates/menu_links.html:13 src/olympia/templates/impala/header_title.html:17
+#: src/olympia/pages/templates/pages/faq.html:273 src/olympia/templates/menu_links.html:13 src/olympia/templates/impala/header_title.html:17
 msgid "Mobile Add-ons"
 msgstr "Mobilni dodaci"
 
-#: src/olympia/pages/templates/pages/faq.html:278
+#: src/olympia/pages/templates/pages/faq.html:276
 msgid "What are mobile add-ons?"
 msgstr "Što su mobilni dodaci?"
 
-#: src/olympia/pages/templates/pages/faq.html:279
+#: src/olympia/pages/templates/pages/faq.html:277
 #, python-format
 msgid ""
 "Mobile add-ons work with <a href=\"%(mobile_url)s\">Firefox for Mobile</a> and add or modify functionality just like desktop add-ons. You can find add-ons that work with Firefox for Mobile in our "
 "<a href=\"%(gallery_url)s\">gallery</a>."
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:288
+#: src/olympia/pages/templates/pages/faq.html:286
 msgid "Developer Topics"
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:289
+#: src/olympia/pages/templates/pages/faq.html:287
 #, python-format
 msgid "Please see our <a href=\"%(faq_url)s\">Developer FAQ</a> and <a href=\"%(hub_url)s\">Developer Hub</a> for answers to add-on developer-related questions."
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:294
+#: src/olympia/pages/templates/pages/faq.html:292
 msgid "Still have questions?"
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:295
+#: src/olympia/pages/templates/pages/faq.html:293
 #, python-format
 msgid "For general Firefox support, visit our <a href=\"%(sumo_url)s\">support website</a>. For general add-on and website questions, visit our <a href=\"%(forum_url)s\">forum</a>."
 msgstr ""
@@ -10557,7 +10341,7 @@ msgstr ""
 
 #: src/olympia/pages/templates/pages/sunbird.html:29
 msgid ""
-"Development on the Sunbird project has halted and its final release was on March 30, 2010.  We've been proud to host Sunbird add-ons on this site but as the project is no longer maintained we have "
+"Development on the Sunbird project has halted and its final release was on March 30, 2010. We've been proud to host Sunbird add-ons on this site but as the project is no longer maintained we have "
 "disabled our support for the add-ons."
 msgstr ""
 
@@ -10635,7 +10419,7 @@ msgstr "Dodaj reviziju za {0}"
 #, python-format
 msgid ""
 "<h2>Keep these tips in mind:</h2> <ul> <li> Write like you're telling a friend about your experience with the add-on. Give specifics and helpful details, such as what features you liked and/or "
-"disliked, how easy to use it is, and any disadvantages it has.  Avoid generic language such as calling it \"Great\" or \"Bad\" unless you can give reasons why you believe this is so. </li> <li> "
+"disliked, how easy to use it is, and any disadvantages it has. Avoid generic language such as calling it \"Great\" or \"Bad\" unless you can give reasons why you believe this is so. </li> <li> "
 "Please do not post bug reports in reviews. We do not make your email address available to add-on developers and they may need to contact you to help resolve your issue. See the <a href=\"%(support)s"
 "\">support section</a> to find out where to get assistance for this add-on. </li> <li>Please keep reviews clean, avoid the use of improper language and do not post any personal information. </li> </"
 "ul> <p>Please read the <a href=\"%(guide)s\" target=\"_blank\">Review Guidelines</a> for more detail about user add-on reviews.</p>"
@@ -10683,7 +10467,6 @@ msgid "This user has a <a href=\"%(user_review_url)s\">previous review</a> of th
 msgid_plural "This user has <a href=\"%(user_review_url)s\">%(cnt)s previous reviews</a> of this add-on."
 msgstr[0] ""
 msgstr[1] ""
-msgstr[2] ""
 
 #: src/olympia/reviews/templates/reviews/review.html:62
 #, python-format
@@ -10731,7 +10514,6 @@ msgid "<b>{0}</b> review for this add-on"
 msgid_plural "<b>{0}</b> reviews for this add-on"
 msgstr[0] ""
 msgstr[1] ""
-msgstr[2] ""
 
 #. {0} is a developer's name.
 #: src/olympia/reviews/templates/reviews/review_list.html:33
@@ -10744,7 +10526,6 @@ msgid "Review for %(addon)s by %(user)s"
 msgid_plural "Reviews for %(addon)s by %(user)s"
 msgstr[0] ""
 msgstr[1] ""
-msgstr[2] ""
 
 #: src/olympia/reviews/templates/reviews/review_list.html:42
 msgid "No reviews found."
@@ -10768,7 +10549,6 @@ msgid "{num} review"
 msgid_plural "{num} reviews"
 msgstr[0] "{num} pregled"
 msgstr[1] "{num} pregleda"
-msgstr[2] "{num} pregleda"
 
 #: src/olympia/reviews/templates/reviews/impala/reviews_rating.html:1
 msgid "Rated {0} out of 5 stars"
@@ -10796,7 +10576,6 @@ msgid "Average from {0} Rating"
 msgid_plural "Average from {0} Ratings"
 msgstr[0] ""
 msgstr[1] ""
-msgstr[2] ""
 
 # 91%
 #: src/olympia/reviews/templates/reviews/mobile/review_list.html:34
@@ -10814,7 +10593,6 @@ msgid "See All Reviews"
 msgid_plural "See All %(cnt)s Reviews"
 msgstr[0] ""
 msgstr[1] ""
-msgstr[2] ""
 
 #: src/olympia/search/forms.py:11
 msgid "Most popular this week"
@@ -10880,16 +10658,16 @@ msgstr ""
 
 #. L10n: {0} is an application, such as Firefox. This means "any version of
 #. Firefox."
-#: src/olympia/search/views.py:554
+#: src/olympia/search/views.py:547
 msgid "Any {0}"
 msgstr ""
 
 #. L10n: "All Systems" means show everything regardless of platform.
-#: src/olympia/search/views.py:589
+#: src/olympia/search/views.py:582
 msgid "All Systems"
 msgstr ""
 
-#: src/olympia/search/views.py:600
+#: src/olympia/search/views.py:593
 msgid "All Tags"
 msgstr ""
 
@@ -10934,7 +10712,6 @@ msgid "<b>{0}</b> matching result"
 msgid_plural "<b>{0}</b> matching results"
 msgstr[0] ""
 msgstr[1] ""
-msgstr[2] ""
 
 #: src/olympia/search/templates/search/results.html:67
 msgid "Filter Results"
@@ -10957,7 +10734,6 @@ msgid "{0} post"
 msgid_plural "{0} posts"
 msgstr[0] ""
 msgstr[1] ""
-msgstr[2] ""
 
 #: src/olympia/sharing/__init__.py:20
 msgid "Post to Facebook"
@@ -10968,7 +10744,6 @@ msgid "{0} Like"
 msgid_plural "{0} Likes"
 msgstr[0] ""
 msgstr[1] ""
-msgstr[2] ""
 
 #: src/olympia/sharing/__init__.py:30
 msgid "Tweet on Twitter"
@@ -10979,7 +10754,6 @@ msgid "{0} tweet"
 msgid_plural "{0} tweets"
 msgstr[0] ""
 msgstr[1] ""
-msgstr[2] ""
 
 #: src/olympia/sharing/__init__.py:40
 msgid "Share on g+"
@@ -11014,7 +10788,6 @@ msgid "{0} post on localservice1"
 msgid_plural "{0} posts on localservice1"
 msgstr[0] ""
 msgstr[1] ""
-msgstr[2] ""
 
 #. L10n: Only change if you have reason! wiki.mozilla.org/AMO:Localizers
 #: src/olympia/sharing/__init__.py:76
@@ -11037,7 +10810,6 @@ msgid "{0} post on localservice2"
 msgid_plural "{0} posts on localservice2"
 msgstr[0] ""
 msgstr[1] ""
-msgstr[2] ""
 
 #. L10n: Only change if you have reason! wiki.mozilla.org/AMO:Localizers
 #: src/olympia/sharing/__init__.py:91
@@ -11060,7 +10832,6 @@ msgid "{0} post on localservice3"
 msgid_plural "{0} posts on localservice3"
 msgstr[0] ""
 msgstr[1] ""
-msgstr[2] ""
 
 #: src/olympia/sharing/templates/sharing/sharing_widget.html:2
 msgid "Share this Add-on"
@@ -11070,31 +10841,31 @@ msgstr ""
 msgid "Share this Collection"
 msgstr ""
 
-#: src/olympia/signing/views.py:30 src/olympia/templates/base.html:75 src/olympia/templates/impala/base.html:115
+#: src/olympia/signing/views.py:33 src/olympia/templates/base.html:71 src/olympia/templates/impala/base.html:112
 msgid "Some features are temporarily disabled while we perform website maintenance. We'll be back to full capacity shortly."
 msgstr ""
 
-#: src/olympia/signing/views.py:53
+#: src/olympia/signing/views.py:56
 msgid "Could not find add-on with id \"{}\"."
 msgstr ""
 
-#: src/olympia/signing/views.py:67
+#: src/olympia/signing/views.py:70
 msgid "You do not own this addon."
 msgstr ""
 
-#: src/olympia/signing/views.py:82
+#: src/olympia/signing/views.py:87
 msgid "Missing \"upload\" key in multipart file data."
 msgstr ""
 
-#: src/olympia/signing/views.py:96
+#: src/olympia/signing/views.py:101
 msgid "Version does not match the manifest file."
 msgstr ""
 
-#: src/olympia/signing/views.py:100
+#: src/olympia/signing/views.py:105
 msgid "Version already exists."
 msgstr ""
 
-#: src/olympia/signing/views.py:136
+#: src/olympia/signing/views.py:141
 msgid "No uploaded file for that addon and version."
 msgstr ""
 
@@ -11212,89 +10983,89 @@ msgstr "{0} :: Nadzorna ploča statistike"
 msgid "Statistics Dashboard :: Add-ons for {0}"
 msgstr ""
 
-#: src/olympia/stats/templates/stats/stats.html:30
-msgid "Controls:"
-msgstr ""
-
-#: src/olympia/stats/templates/stats/stats.html:33
-msgid "reset zoom"
-msgstr ""
-
-#: src/olympia/stats/templates/stats/stats.html:40
-msgid "Group by:"
-msgstr ""
-
-#: src/olympia/stats/templates/stats/stats.html:42
-msgid "day"
-msgstr ""
-
-#: src/olympia/stats/templates/stats/stats.html:45
-msgid "week"
-msgstr ""
-
-#: src/olympia/stats/templates/stats/stats.html:48
-msgid "month"
-msgstr ""
-
-#: src/olympia/stats/templates/stats/stats.html:54
-msgid "For last:"
-msgstr ""
-
-#: src/olympia/stats/templates/stats/stats.html:57
-msgid "7 days"
-msgstr ""
-
-#: src/olympia/stats/templates/stats/stats.html:60
-msgid "30 days"
-msgstr ""
-
-#: src/olympia/stats/templates/stats/stats.html:63
-msgid "90 days"
-msgstr ""
-
-#: src/olympia/stats/templates/stats/stats.html:66
-msgid "365 days"
-msgstr ""
-
-#: src/olympia/stats/templates/stats/stats.html:69
-msgid "Custom..."
-msgstr ""
-
 #. {0} is an add-on name
-#: src/olympia/stats/templates/stats/stats.html:88 src/olympia/stats/templates/stats/stats.html:91
+#: src/olympia/stats/templates/stats/stats.html:44 src/olympia/stats/templates/stats/stats.html:47
 msgid "Statistics for {0}"
 msgstr ""
 
-#: src/olympia/stats/templates/stats/stats.html:94
+#: src/olympia/stats/templates/stats/stats.html:50
 msgid "Statistics Dashboard"
 msgstr ""
 
-#: src/olympia/stats/templates/stats/stats.html:104
+#: src/olympia/stats/templates/stats/stats.html:57
+msgid "Controls:"
+msgstr ""
+
+#: src/olympia/stats/templates/stats/stats.html:60
+msgid "reset zoom"
+msgstr ""
+
+#: src/olympia/stats/templates/stats/stats.html:67
+msgid "Group by:"
+msgstr ""
+
+#: src/olympia/stats/templates/stats/stats.html:69
+msgid "day"
+msgstr ""
+
+#: src/olympia/stats/templates/stats/stats.html:72
+msgid "week"
+msgstr ""
+
+#: src/olympia/stats/templates/stats/stats.html:75
+msgid "month"
+msgstr ""
+
+#: src/olympia/stats/templates/stats/stats.html:81
+msgid "For last:"
+msgstr ""
+
+#: src/olympia/stats/templates/stats/stats.html:84
+msgid "7 days"
+msgstr ""
+
+#: src/olympia/stats/templates/stats/stats.html:87
+msgid "30 days"
+msgstr ""
+
+#: src/olympia/stats/templates/stats/stats.html:90
+msgid "90 days"
+msgstr ""
+
+#: src/olympia/stats/templates/stats/stats.html:93
+msgid "365 days"
+msgstr ""
+
+#: src/olympia/stats/templates/stats/stats.html:96
+msgid "Custom..."
+msgstr ""
+
+#: src/olympia/stats/templates/stats/stats.html:106
 msgid "Statistics processing is currently disabled, so recent data is unavailable. The statistics are still being collected and this page will be updated soon with the missing data."
 msgstr ""
 
-#: src/olympia/stats/templates/stats/stats.html:110
+#: src/olympia/stats/templates/stats/stats.html:112
 msgid "Loading the latest data&hellip;"
 msgstr ""
 
-#: src/olympia/stats/templates/stats/stats.html:142 src/olympia/stats/templates/stats/reports/overview.html:25 src/olympia/stats/templates/stats/reports/overview.html:37
+#: src/olympia/stats/templates/stats/stats.html:144 src/olympia/stats/templates/stats/reports/overview.html:25 src/olympia/stats/templates/stats/reports/overview.html:37
 #: src/olympia/stats/templates/stats/reports/overview.html:49
 msgid "No data available."
 msgstr ""
 
-#: src/olympia/stats/templates/stats/stats.html:177
+#: src/olympia/stats/templates/stats/stats.html:179
 msgid "This dashboard is currently <b>public</b>."
 msgstr ""
 
-#: src/olympia/stats/templates/stats/stats.html:179
+#: src/olympia/stats/templates/stats/stats.html:181
 msgid "Contribution stats are currently <b>private</b>."
 msgstr ""
 
-#: src/olympia/stats/templates/stats/stats.html:182
+#: src/olympia/stats/templates/stats/stats.html:184
 msgid "This dashboard is currently <b>private</b>."
 msgstr ""
 
-#: src/olympia/stats/templates/stats/stats.html:185
+#: src/olympia/stats/templates/stats/stats.html:187
 msgid "Change settings."
 msgstr ""
 
@@ -11446,15 +11217,6 @@ msgstr ""
 msgid "Application versions by Date"
 msgstr ""
 
-#: src/olympia/tags/templates/tags/top_cloud.html:4
-msgid "Top {0} Tags"
-msgstr ""
-
-#. {0} is the current application name
-#: src/olympia/tags/templates/tags/top_cloud.html:14
-msgid "{0} Top Tags"
-msgstr ""
-
 #: src/olympia/templates/amo_footer.html:6 src/olympia/templates/includes/lang_switcher.html:2
 msgid "Other languages"
 msgstr ""
@@ -11463,11 +11225,11 @@ msgstr ""
 msgid "Mozilla Add-ons"
 msgstr ""
 
-#: src/olympia/templates/base.html:91 src/olympia/templates/impala/base.html:81
+#: src/olympia/templates/base.html:89 src/olympia/templates/impala/base.html:78
 msgid "Find add-ons for other applications"
 msgstr ""
 
-#: src/olympia/templates/base.html:92 src/olympia/templates/impala/base.html:81
+#: src/olympia/templates/base.html:90 src/olympia/templates/impala/base.html:78
 msgid "Other Applications"
 msgstr ""
 
@@ -11492,7 +11254,7 @@ msgid "View Mobile Site"
 msgstr "Pregled stranice za mobitele"
 
 #: src/olympia/templates/copyright.html:7
-msgid "Site Status "
+msgid "Site Status"
 msgstr ""
 
 #: src/olympia/templates/footer.html:3
@@ -11592,35 +11354,35 @@ msgstr ""
 msgid "<a href=\"%(reg)s\">Register</a> or <a href=\"%(login)s\">Log in</a>"
 msgstr "<a href=\"%(reg)s\">Registrirajte se</a> ili <a href=\"%(login)s\">Prijavite se</a>"
 
-#: src/olympia/templates/impala/base.html:126
+#: src/olympia/templates/impala/base.html:123
 #, python-format
 msgid "To try the thousands of add-ons available here, download <a href=\"%(url)s\">Mozilla Firefox</a>, a fast, free way to surf the Web!"
 msgstr ""
 
-#: src/olympia/templates/impala/base.html:138
+#: src/olympia/templates/impala/base.html:135
 #, python-format
 msgid "Add-ons is switching to Firefox Accounts for login. <a href=\"%(url)s\" class=\"fxa-login\">Sign in now to transfer your account.</a>"
 msgstr ""
 
 #. {0} is an application, such as Firefox.
-#: src/olympia/templates/impala/base.html:148
+#: src/olympia/templates/impala/base.html:145
 msgid "Welcome to {0} Add-ons."
 msgstr ""
 
-#: src/olympia/templates/impala/base.html:151
+#: src/olympia/templates/impala/base.html:148
 msgid "Choose from thousands of extra features and styles to make Firefox your own."
 msgstr ""
 
-#: src/olympia/templates/impala/base.html:156
+#: src/olympia/templates/impala/base.html:153
 #, python-format
 msgid "Add extra features and styles to make %(app)s your own."
 msgstr ""
 
-#: src/olympia/templates/impala/base.html:164
+#: src/olympia/templates/impala/base.html:161
 msgid "On the go?"
 msgstr ""
 
-#: src/olympia/templates/impala/base.html:166
+#: src/olympia/templates/impala/base.html:163
 msgid "Check out our <a class=\"mobile-link\" href=\"#\">Mobile Add-ons site</a>."
 msgstr ""
 
@@ -11844,19 +11606,19 @@ msgstr ""
 
 #. L10n: {id} will be something like "13ad6a", just a random number
 #. to differentiate this user from other anonymous users.
-#: src/olympia/users/models.py:353
+#: src/olympia/users/models.py:362
 msgid "Anonymous user {id}"
 msgstr ""
 
-#: src/olympia/users/models.py:410
+#: src/olympia/users/models.py:419
 msgid "Your account has been restricted"
 msgstr ""
 
-#: src/olympia/users/models.py:480
+#: src/olympia/users/models.py:489
 msgid "Please confirm your email address"
 msgstr ""
 
-#: src/olympia/users/models.py:506
+#: src/olympia/users/models.py:515
 msgid "My Mobile Add-ons"
 msgstr ""
 
@@ -12133,7 +11895,7 @@ msgstr ""
 
 #: src/olympia/users/templates/users/edit.html:70
 #, python-format
-msgid "Change your password.  If you forgot your password, you can <a href=\"%(reset_url)s\">use the reset form</a>."
+msgid "Change your password. If you forgot your password, you can <a href=\"%(reset_url)s\">use the reset form</a>."
 msgstr ""
 
 #: src/olympia/users/templates/users/edit.html:76
@@ -12153,7 +11915,7 @@ msgid "Profile"
 msgstr ""
 
 #: src/olympia/users/templates/users/edit.html:100
-msgid "Give us a bit more information about yourself.  All these fields are optional, but they'll help other users get to know you better."
+msgid "Give us a bit more information about yourself. All these fields are optional, but they'll help other users get to know you better."
 msgstr ""
 
 #: src/olympia/users/templates/users/edit.html:124
@@ -12369,7 +12131,7 @@ msgid "Confirm password"
 msgstr ""
 
 #: src/olympia/users/templates/users/pwreset_confirm.html:47
-msgid "The password reset link was invalid, possibly because it has already been used.  Please request a new password reset."
+msgid "The password reset link was invalid, possibly because it has already been used. Please request a new password reset."
 msgstr ""
 
 #: src/olympia/users/templates/users/pwreset_request.html:15
@@ -12555,7 +12317,7 @@ msgstr ""
 
 #: src/olympia/users/templates/users/unsubscribe.html:30
 #, python-format
-msgid "Unfortunately, we weren't able to unsubscribe you.  The link you clicked is invalid. However, you can unsubscribe still unsubscribe on your <a href=\"%(edit_url)s\">edit profile page</a>."
+msgid "Unfortunately, we weren't able to unsubscribe you. The link you clicked is invalid. However, you can unsubscribe still unsubscribe on your <a href=\"%(edit_url)s\">edit profile page</a>."
 msgstr ""
 
 #: src/olympia/users/templates/users/vcard.html:2
@@ -12588,7 +12350,6 @@ msgid "%(num)s theme"
 msgid_plural "%(num)s themes"
 msgstr[0] ""
 msgstr[1] ""
-msgstr[2] ""
 
 #: src/olympia/users/templates/users/vcard.html:62
 #, python-format
@@ -12596,7 +12357,6 @@ msgid "%(num)s add-on"
 msgid_plural "%(num)s add-ons"
 msgstr[0] ""
 msgstr[1] ""
-msgstr[2] ""
 
 #: src/olympia/users/templates/users/vcard.html:75
 msgid "Average rating of developer's add-ons"
@@ -12611,15 +12371,15 @@ msgstr ""
 msgid "Version History with Changelogs"
 msgstr ""
 
-#: src/olympia/versions/models.py:314
+#: src/olympia/versions/models.py:313
 msgid "Add-on uses binary components."
 msgstr ""
 
-#: src/olympia/versions/models.py:317
+#: src/olympia/versions/models.py:316
 msgid "Add-on has opted into strict compatibility checking."
 msgstr ""
 
-#: src/olympia/versions/models.py:715
+#: src/olympia/versions/models.py:711
 msgid "{app} {min} and later"
 msgstr ""
 
@@ -12657,7 +12417,6 @@ msgid "<b>{0}</b> version"
 msgid_plural "<b>{0}</b> versions"
 msgstr[0] ""
 msgstr[1] ""
-msgstr[2] ""
 
 #: src/olympia/versions/templates/versions/version_list.html:35 src/olympia/versions/templates/versions/mobile/version_list.html:14
 msgid "Be careful with old versions!"
@@ -12696,4 +12455,8 @@ msgstr ""
 
 #: src/olympia/zadmin/forms.py:105
 msgid "Log emails instead of sending"
+msgstr ""
+
+#: src/olympia/zadmin/forms.py:215
+msgid "Deleted versions can`t be changed."
 msgstr ""

--- a/locale/hr/LC_MESSAGES/djangojs.po
+++ b/locale/hr/LC_MESSAGES/djangojs.po
@@ -6,1229 +6,1236 @@ msgid ""
 msgstr ""
 "Project-Id-Version: addons VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2016-02-24 21:23+0000\n"
+"POT-Creation-Date: 2016-04-18 15:47+0000\n"
 "PO-Revision-Date: 2013-03-09 16:37+0000\n"
 "Last-Translator: Vedran <vedran.kovacevic@mozilla-hr.org>\n"
 "Language-Team: Croatian\n"
+"Language: \n"
 "MIME-Version: 1.0\n"
-"Content-Type: text/plain; charset=utf-8\n"
+"Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Generated-By: Babel 2.2.0\n"
 
-#: static/js/common/ratingwidget.js:31
+#: static/js/common-all.js:1426 static/js/impala-all.js:1511 static/js/zamboni/discovery-all.js:12598 static/js/zamboni/init.js:28 static/js/zamboni/mobile-all.js:14945
+msgid "This feature is temporarily disabled while we perform website maintenance. Please check back a little later."
+msgstr "Usluga je privremeno onemogućena tijekom radova na održavanju stranice. Molimo pokušajte kasnije."
+
+#. L10n: {0} is an app name like Firefox.
+#: static/js/common-all.js:1837 static/js/impala-all.js:1922 static/js/zamboni/buttons.js:73 static/js/zamboni/discovery-all.js:13108
+msgid "Accept and Install"
+msgstr "Prihvati i instaliraj"
+
+#: static/js/common-all.js:1837 static/js/impala-all.js:1922 static/js/zamboni/buttons.js:73 static/js/zamboni/discovery-all.js:13108
+msgid "Add to {0}"
+msgstr "Dodaj u {0}"
+
+#: static/js/common-all.js:1842 static/js/impala-all.js:1927 static/js/zamboni/buttons.js:78 static/js/zamboni/discovery-all.js:13113
+msgid "Download Now"
+msgstr "Preuzmi sada"
+
+#: static/js/common-all.js:1883 static/js/impala-all.js:1968 static/js/zamboni/buttons.js:119 static/js/zamboni/discovery-all.js:13154
+msgid "Add-on has not been updated to support default-to-compatible."
+msgstr ""
+
+#: static/js/common-all.js:1888 static/js/impala-all.js:1973 static/js/zamboni/buttons.js:124 static/js/zamboni/discovery-all.js:13159
+msgid "You need to be using Firefox 10.0 or higher."
+msgstr ""
+
+#: static/js/common-all.js:1900 static/js/impala-all.js:1985 static/js/zamboni/buttons.js:136 static/js/zamboni/discovery-all.js:13171
+msgid "Mozilla has marked this version as incompatible with your Firefox version."
+msgstr ""
+
+#. L10n: {0} is an platform like Windows or Linux.
+#: static/js/common-all.js:1981 static/js/impala-all.js:2066 static/js/zamboni/buttons.js:217 static/js/zamboni/discovery-all.js:13252
+msgid "Install for {0} anyway"
+msgstr "Instaliraj na {0} svejedno"
+
+#: static/js/common-all.js:1981 static/js/impala-all.js:2066 static/js/zamboni/buttons.js:217 static/js/zamboni/discovery-all.js:13252
+msgid "Download for {0} anyway"
+msgstr "Preuzmi za {0} svejedno"
+
+#: static/js/common-all.js:2038 static/js/impala-all.js:2123 static/js/zamboni/buttons.js:274 static/js/zamboni/discovery-all.js:13309
+msgid "Not available for your platform"
+msgstr "Nije dostupno za vašu platformu"
+
+#. L10n: {0} is an app name, {1} is the app version.
+#: static/js/common-all.js:2049 static/js/common-all.js:2086 static/js/impala-all.js:2134 static/js/impala-all.js:2171 static/js/zamboni/buttons.js:286 static/js/zamboni/buttons.js:324
+#: static/js/zamboni/discovery-all.js:13320 static/js/zamboni/discovery-all.js:13357
+msgid "Not available for {0} {1}"
+msgstr "Nije dostupno za {0} {1}"
+
+#: static/js/common-all.js:2112 static/js/impala-all.js:2197 static/js/zamboni/buttons.js:351 static/js/zamboni/discovery-all.js:13383
+msgid "Works with {app} {min} - {max}"
+msgstr ""
+
+#: static/js/common-all.js:2114 static/js/impala-all.js:2199 static/js/zamboni/buttons.js:353 static/js/zamboni/discovery-all.js:13385
+msgid "View other versions"
+msgstr ""
+
+#: static/js/common-all.js:2162 static/js/impala-all.js:2247 static/js/zamboni/buttons.js:401 static/js/zamboni/discovery-all.js:13433
+msgid "Only with Firefox — Get Firefox Now!"
+msgstr ""
+
+#: static/js/common-all.js:2278 static/js/impala-all.js:2363 static/js/zamboni/buttons.js:517 static/js/zamboni/discovery-all.js:13549 static/js/zamboni/mobile-all.js:15177
+#: static/js/zamboni/mobile/buttons.js:43
+msgid "Sorry, you need a Mozilla-based browser (such as Firefox) to install a search plugin."
+msgstr "Žao nam je, potreban vam je Mozillin preglednik (kao što je Firefox) da biste instalirali priključak za tražilicu."
+
+#: static/js/common-all.js:9088 static/js/impala-all.js:9649 static/js/zamboni/global.js:410
+msgid "Loading..."
+msgstr ""
+
+#. L10n: {0} is the number of characters left.
+#: static/js/common-all.js:9152 static/js/impala-all.js:9713 static/js/zamboni/global.js:474
+msgid "<b>{0}</b> character left."
+msgid_plural "<b>{0}</b> characters left."
+msgstr[0] "preostalo <b>{0}</b> slovo."
+msgstr[1] "preostalo <b>{0}</b> slova."
+
+#: static/js/common-all.js:9589 static/js/common-min.js:6 static/js/impala-all.js:10052 static/js/impala-min.js:6 static/js/common/ratingwidget.js:31 static/js/zamboni/mobile-all.js:16123
+#: static/js/zamboni/mobile-min.js:6
 msgid "{0} star"
 msgid_plural "{0} stars"
 msgstr[0] "{0} zvjezdica"
 msgstr[1] "{0} zvjezdice"
-msgstr[2] "{0} zvjezdica"
 
-#: static/js/common/upload-addon.js:41 static/js/common/upload-image.js:128
+#: static/js/common-all.js:9676 static/js/common-min.js:6 static/js/impala-all.js:10139 static/js/impala-min.js:6 static/js/zamboni/l10n.js:45
+msgid "Remove this localization"
+msgstr "Ukloni ovaj prijevod"
+
+#: static/js/common-all.js:10193 static/js/common-min.js:6 static/js/impala-all.js:10674 static/js/impala-min.js:6 static/js/zamboni/discovery-all.js:13678
+msgid "close"
+msgstr ""
+
+#: static/js/common-all.js:10860 static/js/common-min.js:6 static/js/impala-all.js:11481 static/js/impala-min.js:6 static/js/impala/reviews.js:23 static/js/zamboni/reviews.js:18
+msgid "Flagged for review"
+msgstr "Označeno za pregled"
+
+#: static/js/common-all.js:10876 static/js/common-min.js:6 static/js/impala-all.js:11498 static/js/impala-min.js:6 static/js/impala/reviews.js:40 static/js/zamboni/reviews.js:34
+msgid "Your input is required"
+msgstr "Unos je potreban"
+
+#: static/js/common-all.js:10945 static/js/common-min.js:6 static/js/impala-all.js:11610 static/js/impala-min.js:7 static/js/impala/reviews.js:152 static/js/zamboni/reviews.js:103
+msgid "Marked for deletion"
+msgstr "Označeno za brisanje"
+
+#: static/js/common-all.js:11573 static/js/common-min.js:7 static/js/impala-all.js:13809 static/js/impala-min.js:8 static/js/zamboni/collections.js:229
+msgid "Adding to Favorites&hellip;"
+msgstr "Dodavanje u favorite&hellip;"
+
+#: static/js/common-all.js:11576 static/js/common-min.js:7 static/js/impala-all.js:13812 static/js/impala-min.js:8 static/js/zamboni/collections.js:232
+msgid "Removing Favorite&hellip;"
+msgstr "Uklanjanje favorita&hellip;"
+
+#: static/js/common-all.js:11579 static/js/common-min.js:7 static/js/impala-all.js:13815 static/js/impala-min.js:8 static/js/zamboni/collections.js:235
+msgid "Add to Favorites"
+msgstr "Dodaj u favorite"
+
+#: static/js/common-all.js:11582 static/js/common-min.js:7 static/js/impala-all.js:13818 static/js/impala-min.js:8 static/js/zamboni/collections.js:238
+msgid "Remove from Favorites"
+msgstr "Ukloni iz favorita"
+
+#: static/js/common-all.js:11647 static/js/common-min.js:7 static/js/impala-all.js:13883 static/js/impala-min.js:8 static/js/zamboni/collections.js:303
+msgid "Pending"
+msgstr "Na čekanju"
+
+#: static/js/common-all.js:11648 static/js/common-min.js:7 static/js/impala-all.js:13884 static/js/impala-min.js:8 static/js/zamboni/collections.js:304
+msgid "Add a comment"
+msgstr "Dodaj komentar"
+
+#: static/js/common-all.js:11648 static/js/common-min.js:7 static/js/impala-all.js:13884 static/js/impala-min.js:8 static/js/zamboni/collections.js:304
+msgid "Comment"
+msgstr "Komentar"
+
+#: static/js/common-all.js:11649 static/js/common-min.js:7 static/js/impala-all.js:13885 static/js/impala-min.js:8 static/js/zamboni/collections.js:305
+msgid "Remove this add-on from the collection"
+msgstr "Ukloni ovaj dodatak iz zbirke"
+
+#: static/js/common-all.js:11649 static/js/common-all.js:11678 static/js/common-min.js:7 static/js/impala-all.js:13885 static/js/impala-all.js:13914 static/js/impala-min.js:8
+#: static/js/zamboni/collections.js:305 static/js/zamboni/collections.js:334
+msgid "Remove"
+msgstr "Ukloni"
+
+#: static/js/common-all.js:11678 static/js/common-min.js:7 static/js/impala-all.js:13914 static/js/impala-min.js:8 static/js/zamboni/collections.js:334
+msgid "Remove this user as a contributor"
+msgstr "Ukloni korisnika kao suradnika"
+
+#: static/js/common-all.js:11690 static/js/common-min.js:7 static/js/impala-all.js:13926 static/js/impala-min.js:8 static/js/zamboni/collections.js:346
+msgid "An email address is required."
+msgstr ""
+
+#: static/js/common-all.js:11708 static/js/common-min.js:7 static/js/impala-all.js:13944 static/js/impala-min.js:8 static/js/zamboni/collections.js:364
+msgid "You cannot add yourself as a contributor."
+msgstr ""
+
+#: static/js/common-all.js:11710 static/js/common-min.js:7 static/js/impala-all.js:13946 static/js/impala-min.js:8 static/js/zamboni/collections.js:366
+msgid "You have already added that user."
+msgstr ""
+
+#: static/js/common-all.js:11917 static/js/common-min.js:7 static/js/impala-all.js:14153 static/js/impala-min.js:8 static/js/zamboni/collections.js:573
+msgid "Add to favorites"
+msgstr "Dodaj u favorite"
+
+#: static/js/common-all.js:11921 static/js/common-min.js:7 static/js/impala-all.js:14157 static/js/impala-min.js:8 static/js/zamboni/collections.js:577
+msgid "Remove from favorites"
+msgstr "Ukloni iz favorita"
+
+#: static/js/common-all.js:11939 static/js/common-min.js:7 static/js/impala-all.js:14175 static/js/impala-all.js:14233 static/js/impala-min.js:8 static/js/impala/collections.js:10
+#: static/js/zamboni/collections.js:595
+msgid "Follow this Collection"
+msgstr "Slijedi zbirku"
+
+#: static/js/common-all.js:11948 static/js/common-min.js:7 static/js/impala-all.js:14184 static/js/impala-min.js:8 static/js/zamboni/collections.js:604
+msgid "Stop following"
+msgstr "Prestani slijediti"
+
+#: static/js/common-all.js:12096 static/js/common-min.js:7 static/js/zamboni/password-strength.js:20
+msgid "Password strength:"
+msgstr ""
+
+#: static/js/common-all.js:12102 static/js/common-min.js:7 static/js/zamboni/password-strength.js:26
+msgid "At least {0} character left."
+msgid_plural "At least {0} characters left."
+msgstr[0] ""
+msgstr[1] ""
+
+#: static/js/common-all.js:12286 static/js/common-min.js:7 static/js/impala-all.js:14632 static/js/impala-min.js:8 static/js/impala/suggestions.js:39
+msgid "Search themes for <b>{0}</b>"
+msgstr ""
+
+#: static/js/common-all.js:12288 static/js/common-min.js:7 static/js/impala-all.js:14634 static/js/impala-min.js:8 static/js/impala/suggestions.js:41
+msgid "Search apps for <b>{0}</b>"
+msgstr ""
+
+#: static/js/common-all.js:12290 static/js/common-min.js:7 static/js/impala-all.js:14636 static/js/impala-min.js:8 static/js/impala/suggestions.js:43
+msgid "Search add-ons for <b>{0}</b>"
+msgstr ""
+
+#: static/js/common-all.js:12521 static/js/common-min.js:7 static/js/impala-all.js:14867 static/js/impala-min.js:8 static/js/impala/site_suggestions.js:46
+msgid "Category"
+msgstr ""
+
+#. L10n: {0} is an app name.
+#: static/js/impala-all.js:11632 static/js/impala-min.js:7 static/js/impala/listing.js:11 static/js/zamboni/themes.js:13
+msgid "This theme is incompatible with your version of {0}"
+msgstr "Tema nije kompatibilna sa vašom verzijom {0}"
+
+#: static/js/impala-all.js:12146 static/js/impala-all.js:14331 static/js/impala-min.js:7 static/js/impala-min.js:8 static/js/common/upload-image.js:97 static/js/impala/users.js:51
+#: static/js/zamboni/devhub-all.js:894 static/js/zamboni/devhub-min.js:1
+msgid "Images must be either PNG or JPG."
+msgstr ""
+
+#: static/js/impala-all.js:12150 static/js/impala-min.js:7 static/js/common/upload-image.js:101 static/js/zamboni/devhub-all.js:898 static/js/zamboni/devhub-min.js:1
+msgid "Videos must be in WebM."
+msgstr ""
+
+#: static/js/impala-all.js:12177 static/js/impala-min.js:7 static/js/common/upload-addon.js:41 static/js/common/upload-image.js:128 static/js/zamboni/devhub-all.js:272
+#: static/js/zamboni/devhub-all.js:925 static/js/zamboni/devhub-min.js:1
 msgid "There was a problem contacting the server."
 msgstr "Dogodio se problem u povezivanju na poslužitelja."
 
-#: static/js/common/upload-addon.js:69
+#: static/js/impala-all.js:13298 static/js/impala-min.js:7 static/js/impala/persona_creation.js:60
+msgid "All Rights Reserved"
+msgstr ""
+
+#: static/js/impala-all.js:13302 static/js/impala-min.js:7 static/js/impala/persona_creation.js:64
+msgid "Creative Commons Attribution 3.0"
+msgstr ""
+
+#: static/js/impala-all.js:13307 static/js/impala-min.js:7 static/js/impala/persona_creation.js:69
+msgid "Creative Commons Attribution-NonCommercial 3.0"
+msgstr ""
+
+#: static/js/impala-all.js:13312 static/js/impala-min.js:7 static/js/impala/persona_creation.js:74
+msgid "Creative Commons Attribution-NonCommercial-NoDerivs 3.0"
+msgstr ""
+
+#: static/js/impala-all.js:13317 static/js/impala-min.js:7 static/js/impala/persona_creation.js:79
+msgid "Creative Commons Attribution-NonCommercial-Share Alike 3.0"
+msgstr ""
+
+#: static/js/impala-all.js:13322 static/js/impala-min.js:7 static/js/impala/persona_creation.js:84
+msgid "Creative Commons Attribution-NoDerivs 3.0"
+msgstr ""
+
+#: static/js/impala-all.js:13327 static/js/impala-min.js:7 static/js/impala/persona_creation.js:89
+msgid "Creative Commons Attribution-ShareAlike 3.0"
+msgstr ""
+
+#: static/js/impala-all.js:13530 static/js/impala-min.js:7 static/js/impala/persona_creation.js:292
+msgid "Your Theme's Name"
+msgstr ""
+
+#: static/js/impala-all.js:14242 static/js/impala-min.js:8 static/js/impala/collections.js:19
+msgid "Stop Following"
+msgstr ""
+
+#: static/js/impala-all.js:14243 static/js/impala-min.js:8 static/js/impala/collections.js:20
+msgid "Following"
+msgstr ""
+
+#: static/js/impala-all.js:14313 static/js/impala-min.js:8 static/js/impala/users.js:33
+msgid "use original"
+msgstr ""
+
+#: static/js/impala-all.js:14523 static/js/impala-min.js:8 static/js/impala/search.js:114
+msgid "Updating results&hellip;"
+msgstr ""
+
+#: static/js/common/upload-addon.js:69 static/js/zamboni/devhub-all.js:300 static/js/zamboni/devhub-min.js:1
 msgid "Select a file..."
 msgstr "Odaberite datoteku..."
 
-#: static/js/common/upload-addon.js:70
+#: static/js/common/upload-addon.js:70 static/js/zamboni/devhub-all.js:301 static/js/zamboni/devhub-min.js:1
 msgid "Your add-on should end with .xpi, .jar or .xml"
 msgstr ""
 
 #. L10n: {0} is the percent of the file that has been uploaded.
-#: static/js/common/upload-addon.js:104
+#: static/js/common/upload-addon.js:104 static/js/zamboni/devhub-all.js:335 static/js/zamboni/devhub-min.js:1
 #, fuzzy, python-format
 msgid "{0}% complete"
 msgstr "{0}% završeno"
 
 #. L10n: "{bytes uploaded} of {total filesize}".
-#: static/js/common/upload-addon.js:107
+#: static/js/common/upload-addon.js:107 static/js/zamboni/devhub-all.js:338 static/js/zamboni/devhub-min.js:1
 msgid "{0} of {1}"
 msgstr "{0} od {1}"
 
-#: static/js/common/upload-addon.js:140
+#: static/js/common/upload-addon.js:140 static/js/zamboni/devhub-all.js:371 static/js/zamboni/devhub-min.js:1
 msgid "Cancel"
 msgstr "Odustani"
 
-#: static/js/common/upload-addon.js:162
+#: static/js/common/upload-addon.js:162 static/js/zamboni/devhub-all.js:393 static/js/zamboni/devhub-min.js:1
 msgid "Uploading {0}"
 msgstr "Učitavanje {0}"
 
-#: static/js/common/upload-addon.js:189
+#: static/js/common/upload-addon.js:189 static/js/zamboni/devhub-all.js:420 static/js/zamboni/devhub-min.js:1
 msgid "Error with {0}"
 msgstr "Greška u {0}"
 
-#: static/js/common/upload-addon.js:194
+#: static/js/common/upload-addon.js:194 static/js/zamboni/devhub-all.js:425 static/js/zamboni/devhub-min.js:1
 msgid "Your add-on failed validation with {0} error."
 msgid_plural "Your add-on failed validation with {0} errors."
 msgstr[0] "Vaš dodatak nije prošao ovjeru sa {0} pogreškom."
 msgstr[1] "Vaš dodatak nije prošao ovjeru sa {0} pogreške."
-msgstr[2] "Vaš dodatak nije prošao ovjeru sa {0} pogreški."
 
-#: static/js/common/upload-addon.js:208
+#: static/js/common/upload-addon.js:208 static/js/zamboni/devhub-all.js:439 static/js/zamboni/devhub-min.js:1
 msgid "&hellip;and {0} more"
 msgid_plural "&hellip;and {0} more"
 msgstr[0] "&hellip;i {0} više"
 msgstr[1] "&hellip;i {0} više"
-msgstr[2] "&hellip;i {0} više"
 
-#: static/js/common/upload-addon.js:222 static/js/common/upload-addon.js:512
+#: static/js/common/upload-addon.js:222 static/js/common/upload-addon.js:497 static/js/zamboni/devhub-all.js:453 static/js/zamboni/devhub-all.js:743 static/js/zamboni/devhub-min.js:1
 msgid "See full validation report"
 msgstr "Pogledajte cijelo izvješće ovjere"
 
-#: static/js/common/upload-addon.js:234
+#: static/js/common/upload-addon.js:234 static/js/zamboni/devhub-all.js:465 static/js/zamboni/devhub-min.js:1
 msgid "Validating {0}"
 msgstr "Ovjera {0}"
 
 #. L10n: first argument is an HTTP status code
-#: static/js/common/upload-addon.js:273
+#: static/js/common/upload-addon.js:273 static/js/zamboni/devhub-all.js:504 static/js/zamboni/devhub-min.js:1
 msgid "Received an empty response from the server; status: {0}"
 msgstr ""
 
-#: static/js/common/upload-addon.js:373
+#: static/js/common/upload-addon.js:370 static/js/zamboni/devhub-all.js:604 static/js/zamboni/devhub-min.js:1
 msgid "Unexpected server error while validating."
 msgstr "Neočekivana pogreška poslužitelja tijekom ovjere."
 
-#: static/js/common/upload-addon.js:412
+#: static/js/common/upload-addon.js:409 static/js/zamboni/devhub-all.js:643 static/js/zamboni/devhub-min.js:1
 msgid "Finished validating {0}"
 msgstr "Završavanje provjere {0}"
 
-#: static/js/common/upload-addon.js:418
+#: static/js/common/upload-addon.js:415 static/js/zamboni/devhub-all.js:649 static/js/zamboni/devhub-min.js:1
 msgid "Your add-on validation timed out, it will be manually reviewed."
 msgstr ""
 
-#: static/js/common/upload-addon.js:421
+#: static/js/common/upload-addon.js:418 static/js/zamboni/devhub-all.js:652 static/js/zamboni/devhub-min.js:1
 msgid "Your add-on was validated with no errors and {0} warning."
 msgid_plural "Your add-on was validated with no errors and {0} warnings."
 msgstr[0] ""
 msgstr[1] ""
-msgstr[2] ""
 
-#: static/js/common/upload-addon.js:426
+#: static/js/common/upload-addon.js:423 static/js/zamboni/devhub-all.js:657 static/js/zamboni/devhub-min.js:1
 msgid "Your add-on was validated with no errors and {0} message."
 msgid_plural "Your add-on was validated with no errors and {0} messages."
 msgstr[0] ""
 msgstr[1] ""
-msgstr[2] ""
 
-#: static/js/common/upload-addon.js:431
+#: static/js/common/upload-addon.js:428 static/js/zamboni/devhub-all.js:662 static/js/zamboni/devhub-min.js:1
 msgid "Your add-on was validated with no errors or warnings."
 msgstr ""
 
-#: static/js/common/upload-addon.js:446
+#: static/js/common/upload-addon.js:443 static/js/zamboni/devhub-all.js:677 static/js/zamboni/devhub-min.js:1
 msgid "Your submission will be automatically signed."
 msgstr ""
 
-#: static/js/common/upload-addon.js:465
+#: static/js/common/upload-addon.js:450 static/js/zamboni/devhub-all.js:696 static/js/zamboni/devhub-min.js:1
 msgid "Include detailed version notes (this can be done in the next step)."
 msgstr ""
 
-#: static/js/common/upload-addon.js:466
+#: static/js/common/upload-addon.js:451 static/js/zamboni/devhub-all.js:697 static/js/zamboni/devhub-min.js:1
 msgid "If your add-on requires an account to a website in order to be fully tested, include a test username and password in the Notes to Reviewer (this can be done in the next step)."
 msgstr ""
 
-#: static/js/common/upload-addon.js:467
+#: static/js/common/upload-addon.js:452 static/js/zamboni/devhub-all.js:698 static/js/zamboni/devhub-min.js:1
 msgid "If your add-on is intended for a limited audience you should choose Preliminary Review instead of Full Review."
 msgstr ""
 
-#: static/js/common/upload-addon.js:480
+#: static/js/common/upload-addon.js:465 static/js/zamboni/devhub-all.js:711 static/js/zamboni/devhub-min.js:1
 msgid "Add-on submission checklist"
 msgstr ""
 
-#: static/js/common/upload-addon.js:481
+#: static/js/common/upload-addon.js:466 static/js/zamboni/devhub-all.js:712 static/js/zamboni/devhub-min.js:1
 msgid "Please verify the following points before finalizing your submission. This will minimize delays or misunderstanding during the review process:"
 msgstr ""
 
-#: static/js/common/upload-addon.js:483
+#: static/js/common/upload-addon.js:468 static/js/zamboni/devhub-all.js:714 static/js/zamboni/devhub-min.js:1
 msgid ""
 "Compiled binaries, as well as minified or obfuscated scripts (excluding known libraries) need to have their sources submitted separately for review. Make sure that you use the source code upload "
 "field to avoid having your submission rejected."
 msgstr ""
 
-#: static/js/common/upload-addon.js:501
+#: static/js/common/upload-addon.js:486 static/js/zamboni/devhub-all.js:732 static/js/zamboni/devhub-min.js:1
 msgid "The validation process found these issues that can lead to rejections:"
 msgstr ""
 
-#: static/js/common/upload-addon.js:518
+#: static/js/common/upload-addon.js:503 static/js/zamboni/devhub-all.js:749 static/js/zamboni/devhub-min.js:1
 msgid "If you are unfamiliar with the add-ons review process, you can read about it here."
 msgstr ""
 
-#: static/js/common/upload-addon.js:555
+#: static/js/common/upload-addon.js:540 static/js/zamboni/devhub-all.js:786 static/js/zamboni/devhub-min.js:1
 msgid "Sorry, no supported platform has been found."
 msgstr ""
 
-#: static/js/common/upload-base.js:57
+#: static/js/common/upload-base.js:57 static/js/zamboni/devhub-all.js:187 static/js/zamboni/devhub-min.js:1
 msgid "The filetype you uploaded isn't recognized."
 msgstr "Tip datoteke koji ste učitali nije prepoznat."
 
-#: static/js/common/upload-base.js:79
+#: static/js/common/upload-base.js:79 static/js/zamboni/devhub-all.js:209 static/js/zamboni/devhub-min.js:1
 msgid "You cancelled the upload."
 msgstr "Prekinuli ste učitavanje."
 
-#: static/js/common/upload-image.js:97 static/js/impala/users.js:51
-msgid "Images must be either PNG or JPG."
-msgstr ""
-
-#: static/js/common/upload-image.js:101
-msgid "Videos must be in WebM."
-msgstr ""
-
-#: static/js/impala/collections.js:10 static/js/zamboni/collections.js:595
-msgid "Follow this Collection"
-msgstr "Slijedi zbirku"
-
-#: static/js/impala/collections.js:19
-msgid "Stop Following"
-msgstr ""
-
-#: static/js/impala/collections.js:20
-msgid "Following"
-msgstr ""
-
-#. L10n: {0} is an app name.
-#: static/js/impala/listing.js:11 static/js/zamboni/themes.js:13
-msgid "This theme is incompatible with your version of {0}"
-msgstr "Tema nije kompatibilna sa vašom verzijom {0}"
-
-#: static/js/impala/persona_creation.js:60
-msgid "All Rights Reserved"
-msgstr ""
-
-#: static/js/impala/persona_creation.js:64
-msgid "Creative Commons Attribution 3.0"
-msgstr ""
-
-#: static/js/impala/persona_creation.js:69
-msgid "Creative Commons Attribution-NonCommercial 3.0"
-msgstr ""
-
-#: static/js/impala/persona_creation.js:74
-msgid "Creative Commons Attribution-NonCommercial-NoDerivs 3.0"
-msgstr ""
-
-#: static/js/impala/persona_creation.js:79
-msgid "Creative Commons Attribution-NonCommercial-Share Alike 3.0"
-msgstr ""
-
-#: static/js/impala/persona_creation.js:84
-msgid "Creative Commons Attribution-NoDerivs 3.0"
-msgstr ""
-
-#: static/js/impala/persona_creation.js:89
-msgid "Creative Commons Attribution-ShareAlike 3.0"
-msgstr ""
-
-#: static/js/impala/persona_creation.js:292
-msgid "Your Theme's Name"
-msgstr ""
-
-#: static/js/impala/reviews.js:23 static/js/zamboni/reviews.js:18
-msgid "Flagged for review"
-msgstr "Označeno za pregled"
-
-#: static/js/impala/reviews.js:40 static/js/zamboni/reviews.js:34
-msgid "Your input is required"
-msgstr "Unos je potreban"
-
-#: static/js/impala/reviews.js:152 static/js/zamboni/reviews.js:103
-msgid "Marked for deletion"
-msgstr "Označeno za brisanje"
-
-#: static/js/impala/search.js:114
-msgid "Updating results&hellip;"
-msgstr ""
-
-#: static/js/impala/site_suggestions.js:46
-msgid "Category"
-msgstr ""
-
-#: static/js/impala/suggestions.js:39
-msgid "Search themes for <b>{0}</b>"
-msgstr ""
-
-#: static/js/impala/suggestions.js:41
-msgid "Search apps for <b>{0}</b>"
-msgstr ""
-
-#: static/js/impala/suggestions.js:43
-msgid "Search add-ons for <b>{0}</b>"
-msgstr ""
-
-#: static/js/impala/users.js:33
-msgid "use original"
-msgstr ""
-
-#: static/js/impala/stats/chart.js:267
+#: static/js/impala/stats/chart.js:267 static/js/zamboni/stats-all.js:16898 static/js/zamboni/stats-min.js:5
 msgid "Week of {0}"
 msgstr ""
 
-#: static/js/impala/stats/chart.js:269
+#: static/js/impala/stats/chart.js:269 static/js/zamboni/stats-all.js:16900 static/js/zamboni/stats-min.js:5
 msgid " downloads"
 msgstr ""
 
-#: static/js/impala/stats/chart.js:270
+#: static/js/impala/stats/chart.js:270 static/js/zamboni/stats-all.js:16901 static/js/zamboni/stats-min.js:5
 msgid "{0} users"
 msgstr ""
 
-#: static/js/impala/stats/chart.js:271
+#: static/js/impala/stats/chart.js:271 static/js/zamboni/stats-all.js:16902 static/js/zamboni/stats-min.js:5
 msgid "{0} add-ons"
 msgstr ""
 
-#: static/js/impala/stats/chart.js:272
+#: static/js/impala/stats/chart.js:272 static/js/zamboni/stats-all.js:16903 static/js/zamboni/stats-min.js:5
 msgid "{0} collections"
 msgstr ""
 
-#: static/js/impala/stats/chart.js:273
+#: static/js/impala/stats/chart.js:273 static/js/zamboni/stats-all.js:16904 static/js/zamboni/stats-min.js:5
 msgid "{0} reviews"
 msgstr ""
 
-#: static/js/impala/stats/chart.js:275
+#: static/js/impala/stats/chart.js:275 static/js/zamboni/stats-all.js:16906 static/js/zamboni/stats-min.js:5
 msgid "{0} sales"
 msgstr ""
 
-#: static/js/impala/stats/chart.js:276
+#: static/js/impala/stats/chart.js:276 static/js/zamboni/stats-all.js:16907 static/js/zamboni/stats-min.js:5
 msgid "{0} refunds"
 msgstr ""
 
-#: static/js/impala/stats/chart.js:277
+#: static/js/impala/stats/chart.js:277 static/js/zamboni/stats-all.js:16908 static/js/zamboni/stats-min.js:5
 msgid "{0} installs"
 msgstr ""
 
-#: static/js/impala/stats/chart.js:369 static/js/impala/stats/csv_keys.js:3 static/js/impala/stats/csv_keys.js:109
+#: static/js/impala/stats/chart.js:369 static/js/impala/stats/csv_keys.js:3 static/js/impala/stats/csv_keys.js:109 static/js/zamboni/stats-all.js:15284 static/js/zamboni/stats-all.js:15390
+#: static/js/zamboni/stats-all.js:17000 static/js/zamboni/stats-min.js:4 static/js/zamboni/stats-min.js:5
 msgid "Downloads"
 msgstr ""
 
-#: static/js/impala/stats/chart.js:379 static/js/impala/stats/csv_keys.js:6 static/js/impala/stats/csv_keys.js:110
+#: static/js/impala/stats/chart.js:379 static/js/impala/stats/csv_keys.js:6 static/js/impala/stats/csv_keys.js:110 static/js/zamboni/stats-all.js:15287 static/js/zamboni/stats-all.js:15391
+#: static/js/zamboni/stats-all.js:17010 static/js/zamboni/stats-min.js:4 static/js/zamboni/stats-min.js:5
 msgid "Daily Users"
 msgstr ""
 
-#: static/js/impala/stats/chart.js:410
+#: static/js/impala/stats/chart.js:410 static/js/zamboni/stats-all.js:17041 static/js/zamboni/stats-min.js:5
 msgid "Amount, in USD"
 msgstr ""
 
-#: static/js/impala/stats/chart.js:421 static/js/impala/stats/csv_keys.js:104
+#: static/js/impala/stats/chart.js:421 static/js/impala/stats/csv_keys.js:104 static/js/zamboni/stats-all.js:15385 static/js/zamboni/stats-all.js:17052 static/js/zamboni/stats-min.js:5
 msgid "Number of Contributions"
 msgstr ""
 
-#: static/js/impala/stats/chart.js:447
+#: static/js/impala/stats/chart.js:447 static/js/zamboni/stats-all.js:17078 static/js/zamboni/stats-min.js:5
 msgid "More Info..."
 msgstr ""
 
 #. L10n: {0} is an ISO-formatted date.
-#: static/js/impala/stats/chart.js:451
+#: static/js/impala/stats/chart.js:451 static/js/zamboni/stats-all.js:17082 static/js/zamboni/stats-min.js:5
 msgid "Details for {0}"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:9
+#: static/js/impala/stats/csv_keys.js:9 static/js/zamboni/stats-all.js:15290 static/js/zamboni/stats-min.js:4
 msgid "Collections Created"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:12
+#: static/js/impala/stats/csv_keys.js:12 static/js/zamboni/stats-all.js:15293 static/js/zamboni/stats-min.js:4
 msgid "Add-ons in Use"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:15
+#: static/js/impala/stats/csv_keys.js:15 static/js/zamboni/stats-all.js:15296 static/js/zamboni/stats-min.js:4
 msgid "Add-ons Created"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:18
+#: static/js/impala/stats/csv_keys.js:18 static/js/zamboni/stats-all.js:15299 static/js/zamboni/stats-min.js:4
 msgid "Add-ons Downloaded"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:21
+#: static/js/impala/stats/csv_keys.js:21 static/js/zamboni/stats-all.js:15302 static/js/zamboni/stats-min.js:4
 msgid "Add-ons Updated"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:24
+#: static/js/impala/stats/csv_keys.js:24 static/js/zamboni/stats-all.js:15305 static/js/zamboni/stats-min.js:4
 msgid "Reviews Written"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:27
+#: static/js/impala/stats/csv_keys.js:27 static/js/zamboni/stats-all.js:15308 static/js/zamboni/stats-min.js:4
 msgid "User Signups"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:30
+#: static/js/impala/stats/csv_keys.js:30 static/js/zamboni/stats-all.js:15311 static/js/zamboni/stats-min.js:4
 msgid "Subscribers"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:33
+#: static/js/impala/stats/csv_keys.js:33 static/js/zamboni/stats-all.js:15314 static/js/zamboni/stats-min.js:4
 msgid "Ratings"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:36 static/js/impala/stats/csv_keys.js:114
+#: static/js/impala/stats/csv_keys.js:36 static/js/impala/stats/csv_keys.js:114 static/js/zamboni/stats-all.js:15317 static/js/zamboni/stats-all.js:15395 static/js/zamboni/stats-min.js:4
+#: static/js/zamboni/stats-min.js:5
 msgid "Sales"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:39 static/js/impala/stats/csv_keys.js:113
+#: static/js/impala/stats/csv_keys.js:39 static/js/impala/stats/csv_keys.js:113 static/js/zamboni/stats-all.js:15320 static/js/zamboni/stats-all.js:15394 static/js/zamboni/stats-min.js:4
+#: static/js/zamboni/stats-min.js:5
 msgid "Installs"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:42
+#: static/js/impala/stats/csv_keys.js:42 static/js/zamboni/stats-all.js:15323 static/js/zamboni/stats-min.js:4
 msgid "Unknown"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:43
+#: static/js/impala/stats/csv_keys.js:43 static/js/zamboni/stats-all.js:15324 static/js/zamboni/stats-min.js:4
 msgid "Add-ons Manager"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:44
+#: static/js/impala/stats/csv_keys.js:44 static/js/zamboni/stats-all.js:15325 static/js/zamboni/stats-min.js:4
 msgid "Add-ons Manager Promo"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:45
+#: static/js/impala/stats/csv_keys.js:45 static/js/zamboni/stats-all.js:15326 static/js/zamboni/stats-min.js:4
 msgid "Add-ons Manager Featured"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:46
+#: static/js/impala/stats/csv_keys.js:46 static/js/zamboni/stats-all.js:15327 static/js/zamboni/stats-min.js:4
 msgid "Add-ons Manager Learn More"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:47
+#: static/js/impala/stats/csv_keys.js:47 static/js/zamboni/stats-all.js:15328 static/js/zamboni/stats-min.js:4
 msgid "Search Suggestions"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:48
+#: static/js/impala/stats/csv_keys.js:48 static/js/zamboni/stats-all.js:15329 static/js/zamboni/stats-min.js:4
 msgid "Search Results"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:49 static/js/impala/stats/csv_keys.js:50 static/js/impala/stats/csv_keys.js:51
+#: static/js/impala/stats/csv_keys.js:49 static/js/impala/stats/csv_keys.js:50 static/js/impala/stats/csv_keys.js:51 static/js/zamboni/stats-all.js:15330 static/js/zamboni/stats-all.js:15331
+#: static/js/zamboni/stats-all.js:15332 static/js/zamboni/stats-min.js:4
 msgid "Homepage Promo"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:52 static/js/impala/stats/csv_keys.js:53
+#: static/js/impala/stats/csv_keys.js:52 static/js/impala/stats/csv_keys.js:53 static/js/zamboni/stats-all.js:15333 static/js/zamboni/stats-all.js:15334 static/js/zamboni/stats-min.js:4
 msgid "Homepage Featured"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:54 static/js/impala/stats/csv_keys.js:55
+#: static/js/impala/stats/csv_keys.js:54 static/js/impala/stats/csv_keys.js:55 static/js/zamboni/stats-all.js:15335 static/js/zamboni/stats-all.js:15336 static/js/zamboni/stats-min.js:4
 msgid "Homepage Up and Coming"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:56
+#: static/js/impala/stats/csv_keys.js:56 static/js/zamboni/stats-all.js:15337 static/js/zamboni/stats-min.js:4
 msgid "Homepage Most Popular"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:57 static/js/impala/stats/csv_keys.js:59
+#: static/js/impala/stats/csv_keys.js:57 static/js/impala/stats/csv_keys.js:59 static/js/zamboni/stats-all.js:15338 static/js/zamboni/stats-all.js:15340 static/js/zamboni/stats-min.js:4
 msgid "Detail Page"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:58 static/js/impala/stats/csv_keys.js:60
+#: static/js/impala/stats/csv_keys.js:58 static/js/impala/stats/csv_keys.js:60 static/js/zamboni/stats-all.js:15339 static/js/zamboni/stats-all.js:15341 static/js/zamboni/stats-min.js:4
 msgid "Detail Page (bottom)"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:61
+#: static/js/impala/stats/csv_keys.js:61 static/js/zamboni/stats-all.js:15342 static/js/zamboni/stats-min.js:4
 msgid "Detail Page (Development Channel)"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:62 static/js/impala/stats/csv_keys.js:63 static/js/impala/stats/csv_keys.js:64
+#: static/js/impala/stats/csv_keys.js:62 static/js/impala/stats/csv_keys.js:63 static/js/impala/stats/csv_keys.js:64 static/js/zamboni/stats-all.js:15343 static/js/zamboni/stats-all.js:15344
+#: static/js/zamboni/stats-all.js:15345 static/js/zamboni/stats-min.js:4
 msgid "Often Used With"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:65 static/js/impala/stats/csv_keys.js:66
+#: static/js/impala/stats/csv_keys.js:65 static/js/impala/stats/csv_keys.js:66 static/js/zamboni/stats-all.js:15346 static/js/zamboni/stats-all.js:15347 static/js/zamboni/stats-min.js:4
 msgid "Others By Author"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:67 static/js/impala/stats/csv_keys.js:68
+#: static/js/impala/stats/csv_keys.js:67 static/js/impala/stats/csv_keys.js:68 static/js/zamboni/stats-all.js:15348 static/js/zamboni/stats-all.js:15349 static/js/zamboni/stats-min.js:4
 msgid "Dependencies"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:69 static/js/impala/stats/csv_keys.js:70
+#: static/js/impala/stats/csv_keys.js:69 static/js/impala/stats/csv_keys.js:70 static/js/zamboni/stats-all.js:15350 static/js/zamboni/stats-all.js:15351 static/js/zamboni/stats-min.js:4
 msgid "Upsell"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:71
+#: static/js/impala/stats/csv_keys.js:71 static/js/zamboni/stats-all.js:15352 static/js/zamboni/stats-min.js:4
 msgid "Meet the Developer"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:72
+#: static/js/impala/stats/csv_keys.js:72 static/js/zamboni/stats-all.js:15353 static/js/zamboni/stats-min.js:4
 msgid "User Profile"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:73
+#: static/js/impala/stats/csv_keys.js:73 static/js/zamboni/stats-all.js:15354 static/js/zamboni/stats-min.js:4
 msgid "Version History"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:75
+#: static/js/impala/stats/csv_keys.js:75 static/js/zamboni/stats-all.js:15356 static/js/zamboni/stats-min.js:4
 msgid "Sharing"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:76
+#: static/js/impala/stats/csv_keys.js:76 static/js/zamboni/stats-all.js:15357 static/js/zamboni/stats-min.js:4
 msgid "Category Pages"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:77
+#: static/js/impala/stats/csv_keys.js:77 static/js/zamboni/stats-all.js:15358 static/js/zamboni/stats-min.js:4
 msgid "Collections"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:78 static/js/impala/stats/csv_keys.js:79
+#: static/js/impala/stats/csv_keys.js:78 static/js/impala/stats/csv_keys.js:79 static/js/zamboni/stats-all.js:15359 static/js/zamboni/stats-all.js:15360 static/js/zamboni/stats-min.js:4
 msgid "Category Landing Featured Carousel"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:80 static/js/impala/stats/csv_keys.js:81
+#: static/js/impala/stats/csv_keys.js:80 static/js/impala/stats/csv_keys.js:81 static/js/zamboni/stats-all.js:15361 static/js/zamboni/stats-all.js:15362 static/js/zamboni/stats-min.js:4
 msgid "Category Landing Top Rated"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:82 static/js/impala/stats/csv_keys.js:83
+#: static/js/impala/stats/csv_keys.js:82 static/js/impala/stats/csv_keys.js:83 static/js/zamboni/stats-all.js:15363 static/js/zamboni/stats-all.js:15364 static/js/zamboni/stats-min.js:5
 msgid "Category Landing Most Popular"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:84 static/js/impala/stats/csv_keys.js:85
+#: static/js/impala/stats/csv_keys.js:84 static/js/impala/stats/csv_keys.js:85 static/js/zamboni/stats-all.js:15365 static/js/zamboni/stats-all.js:15366 static/js/zamboni/stats-min.js:5
 msgid "Category Landing Recently Added"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:86 static/js/impala/stats/csv_keys.js:87
+#: static/js/impala/stats/csv_keys.js:86 static/js/impala/stats/csv_keys.js:87 static/js/zamboni/stats-all.js:15367 static/js/zamboni/stats-all.js:15368 static/js/zamboni/stats-min.js:5
 msgid "Browse Listing Featured Sort"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:88 static/js/impala/stats/csv_keys.js:89
+#: static/js/impala/stats/csv_keys.js:88 static/js/impala/stats/csv_keys.js:89 static/js/zamboni/stats-all.js:15369 static/js/zamboni/stats-all.js:15370 static/js/zamboni/stats-min.js:5
 msgid "Browse Listing Users Sort"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:90 static/js/impala/stats/csv_keys.js:91
+#: static/js/impala/stats/csv_keys.js:90 static/js/impala/stats/csv_keys.js:91 static/js/zamboni/stats-all.js:15371 static/js/zamboni/stats-all.js:15372 static/js/zamboni/stats-min.js:5
 msgid "Browse Listing Rating Sort"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:92 static/js/impala/stats/csv_keys.js:93
+#: static/js/impala/stats/csv_keys.js:92 static/js/impala/stats/csv_keys.js:93 static/js/zamboni/stats-all.js:15373 static/js/zamboni/stats-all.js:15374 static/js/zamboni/stats-min.js:5
 msgid "Browse Listing Created Sort"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:94 static/js/impala/stats/csv_keys.js:95
+#: static/js/impala/stats/csv_keys.js:94 static/js/impala/stats/csv_keys.js:95 static/js/zamboni/stats-all.js:15375 static/js/zamboni/stats-all.js:15376 static/js/zamboni/stats-min.js:5
 msgid "Browse Listing Name Sort"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:96 static/js/impala/stats/csv_keys.js:97
+#: static/js/impala/stats/csv_keys.js:96 static/js/impala/stats/csv_keys.js:97 static/js/zamboni/stats-all.js:15377 static/js/zamboni/stats-all.js:15378 static/js/zamboni/stats-min.js:5
 msgid "Browse Listing Popular Sort"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:98 static/js/impala/stats/csv_keys.js:99
+#: static/js/impala/stats/csv_keys.js:98 static/js/impala/stats/csv_keys.js:99 static/js/zamboni/stats-all.js:15379 static/js/zamboni/stats-all.js:15380 static/js/zamboni/stats-min.js:5
 msgid "Browse Listing Updated Sort"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:100 static/js/impala/stats/csv_keys.js:101
+#: static/js/impala/stats/csv_keys.js:100 static/js/impala/stats/csv_keys.js:101 static/js/zamboni/stats-all.js:15381 static/js/zamboni/stats-all.js:15382 static/js/zamboni/stats-min.js:5
 msgid "Browse Listing Up and Coming Sort"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:105
+#: static/js/impala/stats/csv_keys.js:105 static/js/zamboni/stats-all.js:15386 static/js/zamboni/stats-min.js:5
 msgid "Total Amount Contributed"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:106
+#: static/js/impala/stats/csv_keys.js:106 static/js/zamboni/stats-all.js:15387 static/js/zamboni/stats-min.js:5
 msgid "Average Contribution"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:115
+#: static/js/impala/stats/csv_keys.js:115 static/js/zamboni/stats-all.js:15396 static/js/zamboni/stats-min.js:5
 msgid "Usage"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:118
+#: static/js/impala/stats/csv_keys.js:118 static/js/zamboni/stats-all.js:15399 static/js/zamboni/stats-min.js:5
 msgid "Firefox"
 msgstr "Firefox"
 
-#: static/js/impala/stats/csv_keys.js:119
+#: static/js/impala/stats/csv_keys.js:119 static/js/zamboni/stats-all.js:15400 static/js/zamboni/stats-min.js:5
 msgid "Mozilla"
 msgstr "Mozilla"
 
-#: static/js/impala/stats/csv_keys.js:120
+#: static/js/impala/stats/csv_keys.js:120 static/js/zamboni/stats-all.js:15401 static/js/zamboni/stats-min.js:5
 msgid "Thunderbird"
 msgstr "Thunderbird"
 
-#: static/js/impala/stats/csv_keys.js:121
+#: static/js/impala/stats/csv_keys.js:121 static/js/zamboni/stats-all.js:15402 static/js/zamboni/stats-min.js:5
 msgid "Sunbird"
 msgstr "Sunbird"
 
-#: static/js/impala/stats/csv_keys.js:122
+#: static/js/impala/stats/csv_keys.js:122 static/js/zamboni/stats-all.js:15403 static/js/zamboni/stats-min.js:5
 msgid "SeaMonkey"
 msgstr "SeaMonkey"
 
-#: static/js/impala/stats/csv_keys.js:123
+#: static/js/impala/stats/csv_keys.js:123 static/js/zamboni/stats-all.js:15404 static/js/zamboni/stats-min.js:5
 msgid "Fennec"
 msgstr "Fennec"
 
-#: static/js/impala/stats/csv_keys.js:124
+#: static/js/impala/stats/csv_keys.js:124 static/js/zamboni/stats-all.js:15405 static/js/zamboni/stats-min.js:5
 msgid "Android"
 msgstr ""
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:129
+#: static/js/impala/stats/csv_keys.js:129 static/js/zamboni/stats-all.js:15410 static/js/zamboni/stats-min.js:5
 msgid "Downloads and Daily Users, last {0} days"
 msgstr ""
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:131
+#: static/js/impala/stats/csv_keys.js:131 static/js/zamboni/stats-all.js:15412 static/js/zamboni/stats-min.js:5
 msgid "Downloads and Daily Users from {0} to {1}"
 msgstr ""
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:135
+#: static/js/impala/stats/csv_keys.js:135 static/js/zamboni/stats-all.js:15416 static/js/zamboni/stats-min.js:5
 msgid "Installs and Daily Users, last {0} days"
 msgstr ""
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:137
+#: static/js/impala/stats/csv_keys.js:137 static/js/zamboni/stats-all.js:15418 static/js/zamboni/stats-min.js:5
 msgid "Installs and Daily Users from {0} to {1}"
 msgstr ""
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:141
+#: static/js/impala/stats/csv_keys.js:141 static/js/zamboni/stats-all.js:15422 static/js/zamboni/stats-min.js:5
 msgid "Downloads, last {0} days"
 msgstr ""
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:143
+#: static/js/impala/stats/csv_keys.js:143 static/js/zamboni/stats-all.js:15424 static/js/zamboni/stats-min.js:5
 msgid "Downloads from {0} to {1}"
 msgstr ""
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:147
+#: static/js/impala/stats/csv_keys.js:147 static/js/zamboni/stats-all.js:15428 static/js/zamboni/stats-min.js:5
 msgid "Daily Users, last {0} days"
 msgstr ""
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:149
+#: static/js/impala/stats/csv_keys.js:149 static/js/zamboni/stats-all.js:15430 static/js/zamboni/stats-min.js:5
 msgid "Daily Users from {0} to {1}"
 msgstr ""
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:153
+#: static/js/impala/stats/csv_keys.js:153 static/js/zamboni/stats-all.js:15434 static/js/zamboni/stats-min.js:5
 msgid "Applications, last {0} days"
 msgstr ""
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:155
+#: static/js/impala/stats/csv_keys.js:155 static/js/zamboni/stats-all.js:15436 static/js/zamboni/stats-min.js:5
 msgid "Applications from {0} to {1}"
 msgstr ""
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:159
+#: static/js/impala/stats/csv_keys.js:159 static/js/zamboni/stats-all.js:15440 static/js/zamboni/stats-min.js:5
 msgid "Platforms, last {0} days"
 msgstr ""
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:161
+#: static/js/impala/stats/csv_keys.js:161 static/js/zamboni/stats-all.js:15442 static/js/zamboni/stats-min.js:5
 msgid "Platforms from {0} to {1}"
 msgstr ""
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:165
+#: static/js/impala/stats/csv_keys.js:165 static/js/zamboni/stats-all.js:15446 static/js/zamboni/stats-min.js:5
 msgid "Languages, last {0} days"
 msgstr ""
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:167
+#: static/js/impala/stats/csv_keys.js:167 static/js/zamboni/stats-all.js:15448 static/js/zamboni/stats-min.js:5
 msgid "Languages from {0} to {1}"
 msgstr ""
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:171
+#: static/js/impala/stats/csv_keys.js:171 static/js/zamboni/stats-all.js:15452 static/js/zamboni/stats-min.js:5
 msgid "Add-on Versions, last {0} days"
 msgstr ""
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:173
+#: static/js/impala/stats/csv_keys.js:173 static/js/zamboni/stats-all.js:15454 static/js/zamboni/stats-min.js:5
 msgid "Add-on Versions from {0} to {1}"
 msgstr ""
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:177
+#: static/js/impala/stats/csv_keys.js:177 static/js/zamboni/stats-all.js:15458 static/js/zamboni/stats-min.js:5
 msgid "Add-on Status, last {0} days"
 msgstr ""
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:179
+#: static/js/impala/stats/csv_keys.js:179 static/js/zamboni/stats-all.js:15460 static/js/zamboni/stats-min.js:5
 msgid "Add-on Status from {0} to {1}"
 msgstr ""
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:183
+#: static/js/impala/stats/csv_keys.js:183 static/js/zamboni/stats-all.js:15464 static/js/zamboni/stats-min.js:5
 msgid "Download Sources, last {0} days"
 msgstr ""
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:185
+#: static/js/impala/stats/csv_keys.js:185 static/js/zamboni/stats-all.js:15466 static/js/zamboni/stats-min.js:5
 msgid "Download Sources from {0} to {1}"
 msgstr ""
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:189
+#: static/js/impala/stats/csv_keys.js:189 static/js/zamboni/stats-all.js:15470 static/js/zamboni/stats-min.js:5
 msgid "Contributions, last {0} days"
 msgstr ""
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:191
+#: static/js/impala/stats/csv_keys.js:191 static/js/zamboni/stats-all.js:15472 static/js/zamboni/stats-min.js:5
 msgid "Contributions from {0} to {1}"
 msgstr ""
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:195
+#: static/js/impala/stats/csv_keys.js:195 static/js/zamboni/stats-all.js:15476 static/js/zamboni/stats-min.js:5
 msgid "Site Metrics, last {0} days"
 msgstr ""
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:197
+#: static/js/impala/stats/csv_keys.js:197 static/js/zamboni/stats-all.js:15478 static/js/zamboni/stats-min.js:5
 msgid "Site Metrics from {0} to {1}"
 msgstr ""
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:201
+#: static/js/impala/stats/csv_keys.js:201 static/js/zamboni/stats-all.js:15482 static/js/zamboni/stats-min.js:5
 msgid "Add-ons in Use, last {0} days"
 msgstr ""
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:203
+#: static/js/impala/stats/csv_keys.js:203 static/js/zamboni/stats-all.js:15484 static/js/zamboni/stats-min.js:5
 msgid "Add-ons in Use from {0} to {1}"
 msgstr ""
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:207
+#: static/js/impala/stats/csv_keys.js:207 static/js/zamboni/stats-all.js:15488 static/js/zamboni/stats-min.js:5
 msgid "Add-ons Downloaded, last {0} days"
 msgstr ""
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:209
+#: static/js/impala/stats/csv_keys.js:209 static/js/zamboni/stats-all.js:15490 static/js/zamboni/stats-min.js:5
 msgid "Add-ons Downloaded from {0} to {1}"
 msgstr ""
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:213
+#: static/js/impala/stats/csv_keys.js:213 static/js/zamboni/stats-all.js:15494 static/js/zamboni/stats-min.js:5
 msgid "Add-ons Created, last {0} days"
 msgstr ""
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:215
+#: static/js/impala/stats/csv_keys.js:215 static/js/zamboni/stats-all.js:15496 static/js/zamboni/stats-min.js:5
 msgid "Add-ons Created from {0} to {1}"
 msgstr ""
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:219
+#: static/js/impala/stats/csv_keys.js:219 static/js/zamboni/stats-all.js:15500 static/js/zamboni/stats-min.js:5
 msgid "Add-ons Updated, last {0} days"
 msgstr ""
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:221
+#: static/js/impala/stats/csv_keys.js:221 static/js/zamboni/stats-all.js:15502 static/js/zamboni/stats-min.js:5
 msgid "Add-ons Updated from {0} to {1}"
 msgstr ""
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:225
+#: static/js/impala/stats/csv_keys.js:225 static/js/zamboni/stats-all.js:15506 static/js/zamboni/stats-min.js:5
 msgid "Reviews Written, last {0} days"
 msgstr ""
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:227
+#: static/js/impala/stats/csv_keys.js:227 static/js/zamboni/stats-all.js:15508 static/js/zamboni/stats-min.js:5
 msgid "Reviews Written from {0} to {1}"
 msgstr ""
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:231
+#: static/js/impala/stats/csv_keys.js:231 static/js/zamboni/stats-all.js:15512 static/js/zamboni/stats-min.js:5
 msgid "User Signups, last {0} days"
 msgstr ""
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:233
+#: static/js/impala/stats/csv_keys.js:233 static/js/zamboni/stats-all.js:15514 static/js/zamboni/stats-min.js:5
 msgid "User Signups from {0} to {1}"
 msgstr ""
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:237
+#: static/js/impala/stats/csv_keys.js:237 static/js/zamboni/stats-all.js:15518 static/js/zamboni/stats-min.js:5
 msgid "Collections Created, last {0} days"
 msgstr ""
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:239
+#: static/js/impala/stats/csv_keys.js:239 static/js/zamboni/stats-all.js:15520 static/js/zamboni/stats-min.js:5
 msgid "Collections Created from {0} to {1}"
 msgstr ""
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:243
+#: static/js/impala/stats/csv_keys.js:243 static/js/zamboni/stats-all.js:15524 static/js/zamboni/stats-min.js:5
 msgid "Subscribers, last {0} days"
 msgstr ""
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:245
+#: static/js/impala/stats/csv_keys.js:245 static/js/zamboni/stats-all.js:15526 static/js/zamboni/stats-min.js:5
 msgid "Subscribers from {0} to {1}"
 msgstr ""
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:249
+#: static/js/impala/stats/csv_keys.js:249 static/js/zamboni/stats-all.js:15530 static/js/zamboni/stats-min.js:5
 msgid "Ratings, last {0} days"
 msgstr ""
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:251
+#: static/js/impala/stats/csv_keys.js:251 static/js/zamboni/stats-all.js:15532 static/js/zamboni/stats-min.js:5
 msgid "Ratings from {0} to {1}"
 msgstr ""
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:255
+#: static/js/impala/stats/csv_keys.js:255 static/js/zamboni/stats-all.js:15536 static/js/zamboni/stats-min.js:5
 msgid "Sales, last {0} days"
 msgstr ""
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:257
+#: static/js/impala/stats/csv_keys.js:257 static/js/zamboni/stats-all.js:15538 static/js/zamboni/stats-min.js:5
 msgid "Sales from {0} to {1}"
 msgstr ""
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:261
+#: static/js/impala/stats/csv_keys.js:261 static/js/zamboni/stats-all.js:15542 static/js/zamboni/stats-min.js:5
 msgid "Installs, last {0} days"
 msgstr ""
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:263
+#: static/js/impala/stats/csv_keys.js:263 static/js/zamboni/stats-all.js:15544 static/js/zamboni/stats-min.js:5
 msgid "Installs from {0} to {1}"
 msgstr ""
 
 #. L10n: {0} and {1} are integers.
-#: static/js/impala/stats/csv_keys.js:269
+#: static/js/impala/stats/csv_keys.js:269 static/js/zamboni/stats-all.js:15550 static/js/zamboni/stats-min.js:5
 msgid "<b>{0}</b> in last {1} days"
 msgstr ""
 
 #. L10n: {0} is an integer and {1} and {2} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:271 static/js/impala/stats/csv_keys.js:277
+#: static/js/impala/stats/csv_keys.js:271 static/js/impala/stats/csv_keys.js:277 static/js/zamboni/stats-all.js:15552 static/js/zamboni/stats-all.js:15558 static/js/zamboni/stats-min.js:5
 msgid "<b>{0}</b> from {1} to {2}"
 msgstr ""
 
 #. L10n: {0} and {1} are integers.
-#: static/js/impala/stats/csv_keys.js:275
+#: static/js/impala/stats/csv_keys.js:275 static/js/zamboni/stats-all.js:15556 static/js/zamboni/stats-min.js:5
 msgid "<b>{0}</b> average in last {1} days"
 msgstr ""
 
-#: static/js/impala/stats/overview.js:19
+#: static/js/impala/stats/overview.js:19 static/js/zamboni/stats-all.js:16469 static/js/zamboni/stats-min.js:5
 msgid "No data available."
 msgstr ""
 
-#: static/js/impala/stats/table.js:74
+#: static/js/impala/stats/table.js:74 static/js/zamboni/stats-all.js:17209 static/js/zamboni/stats-min.js:5
 msgid "Date"
 msgstr ""
 
-#: static/js/impala/stats/topchart.js:96
+#: static/js/impala/stats/topchart.js:96 static/js/zamboni/stats-all.js:16600 static/js/zamboni/stats-min.js:5
 msgid "Other"
 msgstr "Ostali"
 
-#: static/js/zamboni/admin_validation.js:24 static/js/zamboni/devhub.js:1229 static/js/zamboni/editors.js:295
+#: static/js/zamboni/admin-all.js:180 static/js/zamboni/admin-min.js:1 static/js/zamboni/admin_validation.js:24 static/js/zamboni/devhub-all.js:2408 static/js/zamboni/devhub-min.js:2
+#: static/js/zamboni/devhub.js:1229 static/js/zamboni/editors-all.js:15576 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:295
 msgid "Select an application first"
 msgstr "Najprije odaberite aplikaciju"
 
-#: static/js/zamboni/admin_validation.js:51
+#: static/js/zamboni/admin-all.js:207 static/js/zamboni/admin-min.js:1 static/js/zamboni/admin_validation.js:51
 msgid "Set {0} add-on to a max version of {1} and email the author."
 msgid_plural "Set {0} add-ons to a max version of {1} and email the authors."
 msgstr[0] ""
 msgstr[1] ""
-msgstr[2] ""
 
-#: static/js/zamboni/admin_validation.js:54
+#: static/js/zamboni/admin-all.js:210 static/js/zamboni/admin-min.js:1 static/js/zamboni/admin_validation.js:54
 msgid "Email author of {2} add-on which failed validation."
 msgid_plural "Email authors of {2} add-ons which failed validation."
 msgstr[0] ""
 msgstr[1] ""
-msgstr[2] ""
 
-#. L10n: {0} is an app name like Firefox.
-#: static/js/zamboni/buttons.js:66
-msgid "Accept and Install"
-msgstr "Prihvati i instaliraj"
-
-#: static/js/zamboni/buttons.js:66
-msgid "Add to {0}"
-msgstr "Dodaj u {0}"
-
-#: static/js/zamboni/buttons.js:71
-msgid "Download Now"
-msgstr "Preuzmi sada"
-
-#: static/js/zamboni/buttons.js:112
-msgid "Add-on has not been updated to support default-to-compatible."
-msgstr ""
-
-#: static/js/zamboni/buttons.js:117
-msgid "You need to be using Firefox 10.0 or higher."
-msgstr ""
-
-#: static/js/zamboni/buttons.js:129
-msgid "Mozilla has marked this version as incompatible with your Firefox version."
-msgstr ""
-
-#. L10n: {0} is an platform like Windows or Linux.
-#: static/js/zamboni/buttons.js:210
-msgid "Install for {0} anyway"
-msgstr "Instaliraj na {0} svejedno"
-
-#: static/js/zamboni/buttons.js:210
-msgid "Download for {0} anyway"
-msgstr "Preuzmi za {0} svejedno"
-
-#: static/js/zamboni/buttons.js:267
-msgid "Not available for your platform"
-msgstr "Nije dostupno za vašu platformu"
-
-#. L10n: {0} is an app name, {1} is the app version.
-#: static/js/zamboni/buttons.js:278 static/js/zamboni/buttons.js:315
-msgid "Not available for {0} {1}"
-msgstr "Nije dostupno za {0} {1}"
-
-#: static/js/zamboni/buttons.js:341
-msgid "Works with {app} {min} - {max}"
-msgstr ""
-
-#: static/js/zamboni/buttons.js:343
-msgid "View other versions"
-msgstr ""
-
-#: static/js/zamboni/buttons.js:391
-msgid "Only with Firefox — Get Firefox Now!"
-msgstr ""
-
-#: static/js/zamboni/buttons.js:507 static/js/zamboni/mobile/buttons.js:43
-msgid "Sorry, you need a Mozilla-based browser (such as Firefox) to install a search plugin."
-msgstr "Žao nam je, potreban vam je Mozillin preglednik (kao što je Firefox) da biste instalirali priključak za tražilicu."
-
-#: static/js/zamboni/collections.js:229
-msgid "Adding to Favorites&hellip;"
-msgstr "Dodavanje u favorite&hellip;"
-
-#: static/js/zamboni/collections.js:232
-msgid "Removing Favorite&hellip;"
-msgstr "Uklanjanje favorita&hellip;"
-
-#: static/js/zamboni/collections.js:235
-msgid "Add to Favorites"
-msgstr "Dodaj u favorite"
-
-#: static/js/zamboni/collections.js:238
-msgid "Remove from Favorites"
-msgstr "Ukloni iz favorita"
-
-#: static/js/zamboni/collections.js:303
-msgid "Pending"
-msgstr "Na čekanju"
-
-#: static/js/zamboni/collections.js:304
-msgid "Add a comment"
-msgstr "Dodaj komentar"
-
-#: static/js/zamboni/collections.js:304
-msgid "Comment"
-msgstr "Komentar"
-
-#: static/js/zamboni/collections.js:305
-msgid "Remove this add-on from the collection"
-msgstr "Ukloni ovaj dodatak iz zbirke"
-
-#: static/js/zamboni/collections.js:305 static/js/zamboni/collections.js:334
-msgid "Remove"
-msgstr "Ukloni"
-
-#: static/js/zamboni/collections.js:334
-msgid "Remove this user as a contributor"
-msgstr "Ukloni korisnika kao suradnika"
-
-#: static/js/zamboni/collections.js:346
-msgid "An email address is required."
-msgstr ""
-
-#: static/js/zamboni/collections.js:364
-msgid "You cannot add yourself as a contributor."
-msgstr ""
-
-#: static/js/zamboni/collections.js:366
-msgid "You have already added that user."
-msgstr ""
-
-#: static/js/zamboni/collections.js:573
-msgid "Add to favorites"
-msgstr "Dodaj u favorite"
-
-#: static/js/zamboni/collections.js:577
-msgid "Remove from favorites"
-msgstr "Ukloni iz favorita"
-
-#: static/js/zamboni/collections.js:604
-msgid "Stop following"
-msgstr "Prestani slijediti"
-
-#: static/js/zamboni/devhub.js:110
+#: static/js/zamboni/devhub-all.js:1289 static/js/zamboni/devhub-min.js:1 static/js/zamboni/devhub.js:110
 msgid "Your browser does not support the video tag"
 msgstr ""
 
-#: static/js/zamboni/devhub.js:371
+#: static/js/zamboni/devhub-all.js:1550 static/js/zamboni/devhub-min.js:1 static/js/zamboni/devhub.js:371
 msgid "Changes Saved"
 msgstr "Izmjene spremljene"
 
-#: static/js/zamboni/devhub.js:387
+#: static/js/zamboni/devhub-all.js:1566 static/js/zamboni/devhub-min.js:1 static/js/zamboni/devhub.js:387
 msgid "Enter a new author's email address"
 msgstr "Unesite novu email adresu autora"
 
-#: static/js/zamboni/devhub.js:536
+#: static/js/zamboni/devhub-all.js:1715 static/js/zamboni/devhub-min.js:1 static/js/zamboni/devhub.js:536
 msgid "There was an error uploading your file."
 msgstr "Dogodila se pogreška tijekom učitavanja vaše datoteke."
 
-#: static/js/zamboni/devhub.js:681
+#: static/js/zamboni/devhub-all.js:1860 static/js/zamboni/devhub-min.js:1 static/js/zamboni/devhub.js:681
 msgid "{files} file"
 msgid_plural "{files} files"
 msgstr[0] "{files} datoteka"
 msgstr[1] "{files} datoteke"
-msgstr[2] "{files} datoteka"
 
-#: static/js/zamboni/devhub.js:684
+#: static/js/zamboni/devhub-all.js:1863 static/js/zamboni/devhub-min.js:1 static/js/zamboni/devhub.js:684
 msgid "{reviews} user review"
 msgid_plural "{reviews} user reviews"
 msgstr[0] ""
 msgstr[1] ""
-msgstr[2] ""
 
-#: static/js/zamboni/devhub.js:796
+#: static/js/zamboni/devhub-all.js:1975 static/js/zamboni/devhub-min.js:2 static/js/zamboni/devhub.js:796
 msgid "Learn more"
 msgstr "Saznajte više"
 
-#: static/js/zamboni/devhub.js:800
+#: static/js/zamboni/devhub-all.js:1979 static/js/zamboni/devhub-min.js:2 static/js/zamboni/devhub.js:800
 msgid "Example"
 msgstr "Primjer"
 
-#: static/js/zamboni/devhub.js:1130
+#: static/js/zamboni/devhub-all.js:2309 static/js/zamboni/devhub-min.js:2 static/js/zamboni/devhub.js:1130
 msgid "Image changes being processed"
 msgstr "Obrađuju se izmjene na slici"
 
-#: static/js/zamboni/devhub.js:1280
+#: static/js/zamboni/devhub-all.js:2459 static/js/zamboni/devhub-min.js:2 static/js/zamboni/devhub.js:1280
 msgid "Must be a valid e-mail address."
 msgstr ""
+
+#: static/js/zamboni/devhub-all.js:2613 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:80
+msgid "All tests passed successfully."
+msgstr "Svi testovi su uspješno obavljeni."
+
+#: static/js/zamboni/devhub-all.js:2616 static/js/zamboni/devhub-all.js:3011 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:83 static/js/zamboni/validator.js:478
+msgid "These tests were not run."
+msgstr "Ovi testovi su obavljeni."
+
+#: static/js/zamboni/devhub-all.js:2664 static/js/zamboni/devhub-all.js:2677 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:131 static/js/zamboni/validator.js:144
+msgid "Tests"
+msgstr ""
+
+#: static/js/zamboni/devhub-all.js:2779 static/js/zamboni/devhub-all.js:3108 static/js/zamboni/devhub-all.js:3127 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:246
+#: static/js/zamboni/validator.js:575 static/js/zamboni/validator.js:594
+msgid "Error"
+msgstr "Pogreška"
+
+#: static/js/zamboni/devhub-all.js:2780 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:247
+msgid "Warning"
+msgstr "Upozorenje"
+
+#: static/js/zamboni/devhub-all.js:2794 static/js/zamboni/devhub-min.js:2 static/js/zamboni/files-all.js:5657 static/js/zamboni/files-min.js:3 static/js/zamboni/files.js:411
+#: static/js/zamboni/validator.js:261
+msgid "Ignore this message in future updates"
+msgstr ""
+
+#: static/js/zamboni/devhub-all.js:2817 static/js/zamboni/devhub-min.js:2 static/js/zamboni/files-all.js:5663 static/js/zamboni/files-min.js:3 static/js/zamboni/files.js:417
+#: static/js/zamboni/validator.js:284
+msgid "Severity for automated signing:"
+msgstr ""
+
+#: static/js/zamboni/devhub-all.js:2832 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:299
+msgid "Suggestions for passing automated signing:"
+msgstr ""
+
+#: static/js/zamboni/devhub-all.js:2920 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:387
+msgid "Compatibility Tests"
+msgstr ""
+
+#: static/js/zamboni/devhub-all.js:2999 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:466
+msgid "Add-on failed validation."
+msgstr "Dodatak nije prošao ovjeru."
+
+#: static/js/zamboni/devhub-all.js:3001 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:468
+msgid "Add-on passed validation."
+msgstr "Dodatak je prošao ovjeru."
+
+#: static/js/zamboni/devhub-all.js:3014 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:481
+msgid "{0} error"
+msgid_plural "{0} errors"
+msgstr[0] "{0} pogreška"
+msgstr[1] "{0} pogreške"
+
+#: static/js/zamboni/devhub-all.js:3016 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:483
+msgid "{0} warning"
+msgid_plural "{0} warnings"
+msgstr[0] "{0} upozorenje"
+msgstr[1] "{0} upozorenja"
+
+#: static/js/zamboni/devhub-all.js:3018 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:485
+msgid "{0} notice"
+msgid_plural "{0} notices"
+msgstr[0] ""
+msgstr[1] ""
+
+#: static/js/zamboni/devhub-all.js:3110 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:577
+msgid "Validation task could not complete or completed with errors"
+msgstr "Zadatak ovjere se nije mogao dovršiti ili je završen sa pogreškama"
+
+#: static/js/zamboni/devhub-all.js:3128 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:595
+msgid "Internal server error"
+msgstr "Interna pogreška poslužitelja"
 
 #: static/js/zamboni/devhub_search.js:8
 msgid "No results found."
 msgstr ""
 
-#: static/js/zamboni/editors.js:121
+#: static/js/zamboni/editors-all.js:15402 static/js/zamboni/editors-min.js:4 static/js/zamboni/editors.js:121
 msgid "{name} was viewing this page first."
 msgstr "{name} je prvi pregledao stranicu."
 
-#: static/js/zamboni/editors.js:171
+#: static/js/zamboni/editors-all.js:15452 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:171
 msgid "Receipt checked by app."
 msgstr ""
 
-#: static/js/zamboni/editors.js:173
+#: static/js/zamboni/editors-all.js:15454 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:173
 msgid "Receipt was not checked by app."
 msgstr ""
 
-#: static/js/zamboni/editors.js:244
+#: static/js/zamboni/editors-all.js:15525 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:244
 msgid "{name} was viewing this add-on first."
 msgstr ""
 
-#: static/js/zamboni/editors.js:255
+#: static/js/zamboni/editors-all.js:15536 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:255
 msgid "Loading&hellip;"
 msgstr "Učitavam&hellip;"
 
-#: static/js/zamboni/editors.js:260
+#: static/js/zamboni/editors-all.js:15541 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:260
 msgid "Version Notes"
 msgstr ""
 
-#: static/js/zamboni/editors.js:265
+#: static/js/zamboni/editors-all.js:15546 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:265
 msgid "Notes for Reviewers"
 msgstr ""
 
-#: static/js/zamboni/editors.js:270
+#: static/js/zamboni/editors-all.js:15551 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:270
 msgid "No version notes found"
 msgstr ""
 
-#: static/js/zamboni/editors.js:330
+#: static/js/zamboni/editors-all.js:15611 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:330
 msgid "Average Reviews"
 msgstr ""
 
-#: static/js/zamboni/editors.js:386
+#: static/js/zamboni/editors-all.js:15667 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:386
 msgid "Number of Reviews"
 msgstr ""
 
-#: static/js/zamboni/editors.js:445
+#: static/js/zamboni/editors-all.js:15726 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:445
 msgid "Error loading translation"
 msgstr ""
 
-#: static/js/zamboni/files.js:411 static/js/zamboni/validator.js:261
-msgid "Ignore this message in future updates"
-msgstr ""
-
-#: static/js/zamboni/files.js:417 static/js/zamboni/validator.js:284
-msgid "Severity for automated signing:"
-msgstr ""
-
-#: static/js/zamboni/global.js:410
-msgid "Loading..."
-msgstr ""
-
-#. L10n: {0} is the number of characters left.
-#: static/js/zamboni/global.js:474
-msgid "<b>{0}</b> character left."
-msgid_plural "<b>{0}</b> characters left."
-msgstr[0] "preostalo <b>{0}</b> slovo."
-msgstr[1] "preostalo <b>{0}</b> slova."
-msgstr[2] "preostalo <b>{0}</b> slova."
-
-#: static/js/zamboni/init.js:28
-msgid "This feature is temporarily disabled while we perform website maintenance. Please check back a little later."
-msgstr "Usluga je privremeno onemogućena tijekom radova na održavanju stranice. Molimo pokušajte kasnije."
-
-#: static/js/zamboni/l10n.js:45
-msgid "Remove this localization"
-msgstr "Ukloni ovaj prijevod"
-
-#: static/js/zamboni/password-strength.js:20
-msgid "Password strength:"
-msgstr ""
-
-#: static/js/zamboni/password-strength.js:26
-msgid "At least {0} character left."
-msgid_plural "At least {0} characters left."
-msgstr[0] ""
-msgstr[1] ""
-msgstr[2] ""
-
-#: static/js/zamboni/themes_review.js:176
-msgid "Requested Info"
-msgstr ""
-
-#: static/js/zamboni/themes_review.js:177
-msgid "Flagged"
-msgstr ""
-
-#: static/js/zamboni/themes_review.js:178
-msgid "Duplicate"
-msgstr ""
-
-#: static/js/zamboni/themes_review.js:179
-msgid "Rejected"
-msgstr ""
-
-#: static/js/zamboni/themes_review.js:180
-msgid "Approved"
-msgstr ""
-
-#: static/js/zamboni/themes_review.js:424
-msgid "No results found"
-msgstr ""
-
-#: static/js/zamboni/themes_review_templates.js:31
+#: static/js/zamboni/editors-all.js:15975 static/js/zamboni/editors-min.js:5 static/js/zamboni/themes_review_templates.js:31
 msgid "Theme"
 msgstr ""
 
-#: static/js/zamboni/themes_review_templates.js:33
+#: static/js/zamboni/editors-all.js:15977 static/js/zamboni/editors-min.js:5 static/js/zamboni/themes_review_templates.js:33
 msgid "Reviewer"
 msgstr ""
 
-#: static/js/zamboni/themes_review_templates.js:35
+#: static/js/zamboni/editors-all.js:15979 static/js/zamboni/editors-min.js:5 static/js/zamboni/themes_review_templates.js:35
 msgid "Status"
 msgstr ""
 
-#: static/js/zamboni/validator.js:80
-msgid "All tests passed successfully."
-msgstr "Svi testovi su uspješno obavljeni."
-
-#: static/js/zamboni/validator.js:83 static/js/zamboni/validator.js:478
-msgid "These tests were not run."
-msgstr "Ovi testovi su obavljeni."
-
-#: static/js/zamboni/validator.js:131 static/js/zamboni/validator.js:144
-msgid "Tests"
+#: static/js/zamboni/editors-all.js:16196 static/js/zamboni/editors-min.js:5 static/js/zamboni/themes_review.js:176
+msgid "Requested Info"
 msgstr ""
 
-#: static/js/zamboni/validator.js:246 static/js/zamboni/validator.js:575 static/js/zamboni/validator.js:594
-msgid "Error"
-msgstr "Pogreška"
-
-#: static/js/zamboni/validator.js:247
-msgid "Warning"
-msgstr "Upozorenje"
-
-#: static/js/zamboni/validator.js:299
-msgid "Suggestions for passing automated signing:"
+#: static/js/zamboni/editors-all.js:16197 static/js/zamboni/editors-min.js:5 static/js/zamboni/themes_review.js:177
+msgid "Flagged"
 msgstr ""
 
-#: static/js/zamboni/validator.js:387
-msgid "Compatibility Tests"
+#: static/js/zamboni/editors-all.js:16198 static/js/zamboni/editors-min.js:5 static/js/zamboni/themes_review.js:178
+msgid "Duplicate"
 msgstr ""
 
-#: static/js/zamboni/validator.js:466
-msgid "Add-on failed validation."
-msgstr "Dodatak nije prošao ovjeru."
+#: static/js/zamboni/editors-all.js:16199 static/js/zamboni/editors-min.js:5 static/js/zamboni/themes_review.js:179
+msgid "Rejected"
+msgstr ""
 
-#: static/js/zamboni/validator.js:468
-msgid "Add-on passed validation."
-msgstr "Dodatak je prošao ovjeru."
+#: static/js/zamboni/editors-all.js:16200 static/js/zamboni/editors-min.js:5 static/js/zamboni/themes_review.js:180
+msgid "Approved"
+msgstr ""
 
-#: static/js/zamboni/validator.js:481
-msgid "{0} error"
-msgid_plural "{0} errors"
-msgstr[0] "{0} pogreška"
-msgstr[1] "{0} pogreške"
-msgstr[2] "{0} pogreški"
+#: static/js/zamboni/editors-all.js:16444 static/js/zamboni/editors-min.js:5 static/js/zamboni/themes_review.js:424
+msgid "No results found"
+msgstr ""
 
-#: static/js/zamboni/validator.js:483
-msgid "{0} warning"
-msgid_plural "{0} warnings"
-msgstr[0] "{0} upozorenje"
-msgstr[1] "{0} upozorenja"
-msgstr[2] "{0} upozorenja"
-
-#: static/js/zamboni/validator.js:485
-msgid "{0} notice"
-msgid_plural "{0} notices"
-msgstr[0] ""
-msgstr[1] ""
-msgstr[2] ""
-
-#: static/js/zamboni/validator.js:577
-msgid "Validation task could not complete or completed with errors"
-msgstr "Zadatak ovjere se nije mogao dovršiti ili je završen sa pogreškama"
-
-#: static/js/zamboni/validator.js:595
-msgid "Internal server error"
-msgstr "Interna pogreška poslužitelja"
-
-#: static/js/zamboni/mobile/buttons.js:52
+#: static/js/zamboni/mobile-all.js:15186 static/js/zamboni/mobile/buttons.js:52
 msgid "Not Updated for {0} {1}"
 msgstr "Nije ažurirano već {0} {1}"
 
-#: static/js/zamboni/mobile/buttons.js:53
+#: static/js/zamboni/mobile-all.js:15187 static/js/zamboni/mobile/buttons.js:53
 msgid "Requires Newer Version of {0}"
 msgstr "Zahtijeva noviju verziju {0}"
 
-#: static/js/zamboni/mobile/buttons.js:54
+#: static/js/zamboni/mobile-all.js:15188 static/js/zamboni/mobile/buttons.js:54
 msgid "Unreviewed"
 msgstr "Nepregledano"
 
-#: static/js/zamboni/mobile/buttons.js:55
+#: static/js/zamboni/mobile-all.js:15189 static/js/zamboni/mobile/buttons.js:55
 msgid "Experimental <span>(Learn More)</span>"
 msgstr "Eksperimentalni<span>(Saznaj više)</span>"
 
 # 80%
 # 100%
-#: static/js/zamboni/mobile/buttons.js:56 static/js/zamboni/mobile/buttons.js:57
+#: static/js/zamboni/mobile-all.js:15190 static/js/zamboni/mobile-all.js:15191 static/js/zamboni/mobile/buttons.js:56 static/js/zamboni/mobile/buttons.js:57
 msgid "Not Available for {0}"
 msgstr "Nije dostupno za {0}"
 
-#: static/js/zamboni/mobile/buttons.js:58
+#: static/js/zamboni/mobile-all.js:15192 static/js/zamboni/mobile/buttons.js:58
 msgid "Experimental"
 msgstr "Eksperimentalni"
 
-#: static/js/zamboni/mobile/buttons.js:59
+#: static/js/zamboni/mobile-all.js:15193 static/js/zamboni/mobile/buttons.js:59
 msgid "Themes Require Newer Version of {0}"
 msgstr ""
 
-#: static/js/zamboni/mobile/buttons.js:60
+#: static/js/zamboni/mobile-all.js:15194 static/js/zamboni/mobile/buttons.js:60
 msgid "Themes Require {0}"
 msgstr ""
 
-#: static/js/zamboni/mobile/buttons.js:105
+#: static/js/zamboni/mobile-all.js:15239 static/js/zamboni/mobile/buttons.js:105
 msgid "Installing..."
 msgstr ""
 
-#: static/js/zamboni/mobile/buttons.js:125
+#: static/js/zamboni/mobile-all.js:15259 static/js/zamboni/mobile/buttons.js:125
 msgid "This add-on has been preliminarily reviewed by Mozilla."
 msgstr "Ovaj dodatak je preliminarno revidiran od strane Mozille."
 
-#: static/js/zamboni/mobile/buttons.js:250
+#: static/js/zamboni/mobile-all.js:15384 static/js/zamboni/mobile/buttons.js:250
 msgid "Keep it"
 msgstr ""
 
-#: static/js/zamboni/mobile/general.js:344
+#: static/js/zamboni/mobile-all.js:16049 static/js/zamboni/mobile-min.js:6 static/js/zamboni/mobile/general.js:344
 msgid "You're trying it on!"
 msgstr ""
 
-#: static/js/zamboni/mobile/general.js:356
+#: static/js/zamboni/mobile-all.js:16061 static/js/zamboni/mobile-min.js:6 static/js/zamboni/mobile/general.js:356
 msgid "Added to Firefox"
 msgstr ""
-

--- a/locale/hsb/LC_MESSAGES/django.po
+++ b/locale/hsb/LC_MESSAGES/django.po
@@ -1,16 +1,16 @@
-# 
+#
 #, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT 1.0\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2016-04-11 14:21+0000\n"
-"PO-Revision-Date: 2016-04-18 21:57+0000\n"
+"POT-Creation-Date: 2016-04-18 15:47+0000\n"
+"PO-Revision-Date: 2016-04-17 20:50+0000\n"
 "Last-Translator: Michael Wolf <milupo@sorbzilla.de>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
 "Language: hsb\n"
 "MIME-Version: 1.0\n"
-"Content-Type: text/plain; charset=utf-8\n"
+"Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=4; plural=(n%100==1 ? 0 : n%100==2 ? 1 : n%100==3 || n%100==4 ? 2 : 3);\n"
 "Generated-By: Babel 2.2.0\n"
@@ -18,8 +18,7 @@ msgstr ""
 
 #: src/olympia/accounts/views.py:54
 msgid "Your log in attempt could not be parsed. Please try again."
-msgstr ""
-"Waš přizjewjenski posypt njeda so analyzować. Prošu spytajće hišće raz."
+msgstr "Waš přizjewjenski posypt njeda so analyzować. Prošu spytajće hišće raz."
 
 #: src/olympia/accounts/views.py:56
 msgid "Your Firefox Account could not be found. Please try again."
@@ -43,43 +42,34 @@ msgstr "Dobre dźěło!"
 
 #: src/olympia/accounts/views.py:111
 msgid "You can now log in to Add-ons with your Firefox Account."
-msgstr ""
-"Móžeće so nětko ze swojim kontom Firefox na websydle přidatkow přizjewić."
+msgstr "Móžeće so nětko ze swojim kontom Firefox na websydle přidatkow přizjewić."
 
 #: src/olympia/accounts/views.py:123
 msgid "Need help?"
 msgstr "Trjebaće pomoc?"
 
-#: src/olympia/addons/buttons.py:180
+#: src/olympia/addons/buttons.py:177
 msgid "Download Now"
 msgstr "Nětko sćahnyć"
 
-#: src/olympia/addons/buttons.py:182
+#: src/olympia/addons/buttons.py:179
 msgid "Download"
 msgstr "Sćahnyć"
 
 #. L10n: please keep &nbsp; in the string so &rarr; does not wrap.
-#: src/olympia/addons/buttons.py:186
+#: src/olympia/addons/buttons.py:183
 msgid "Continue to Download&nbsp;&rarr;"
 msgstr "Dale sćahnyć&nbsp;&rarr;"
 
-#: src/olympia/addons/buttons.py:202 src/olympia/addons/helpers.py:35
-#: src/olympia/addons/views.py:332
-#: src/olympia/addons/templates/addons/impala/details.html:111
-#: src/olympia/addons/templates/addons/impala/listing/items.html:17
-#: src/olympia/addons/templates/addons/mobile/home.html:40
-#: src/olympia/amo/templates/amo/side_nav.html:6
-#: src/olympia/amo/templates/amo/side_nav.html:10
-#: src/olympia/amo/templates/amo/site_nav.html:2
-#: src/olympia/amo/templates/amo/site_nav.html:53
-#: src/olympia/bandwagon/views.py:95 src/olympia/browse/views.py:54
-#: src/olympia/browse/views.py:68 src/olympia/browse/views.py:235
-#: src/olympia/browse/templates/browse/impala/category_landing.html:22
+#: src/olympia/addons/buttons.py:199 src/olympia/addons/helpers.py:35 src/olympia/addons/views.py:333 src/olympia/addons/templates/addons/impala/details.html:111
+#: src/olympia/addons/templates/addons/impala/listing/items.html:17 src/olympia/addons/templates/addons/mobile/home.html:40 src/olympia/amo/templates/amo/side_nav.html:6
+#: src/olympia/amo/templates/amo/side_nav.html:10 src/olympia/amo/templates/amo/site_nav.html:2 src/olympia/amo/templates/amo/site_nav.html:53 src/olympia/bandwagon/views.py:95
+#: src/olympia/browse/views.py:54 src/olympia/browse/views.py:68 src/olympia/browse/views.py:202 src/olympia/browse/templates/browse/impala/category_landing.html:22
 #: src/olympia/browse/templates/browse/personas/mobile/category_landing.html:26
 msgid "Featured"
 msgstr "Předstajene"
 
-#: src/olympia/addons/buttons.py:221
+#: src/olympia/addons/buttons.py:218
 msgid "Add to {0}"
 msgstr "K {0} přidać"
 
@@ -124,11 +114,8 @@ msgstr[3] "Sće {0} značkow přewjele."
 
 #: src/olympia/addons/forms.py:117
 #, python-format
-msgid ""
-"All tags must be %s characters or less after invalid characters are removed."
-msgstr ""
-"Wšě znački dyrbja %s znamješkow abo mjenje měć, po tym zo so njepłaćiwe "
-"znamješka wotstronili."
+msgid "All tags must be %s characters or less after invalid characters are removed."
+msgstr "Wšě znački dyrbja %s znamješkow abo mjenje měć, po tym zo so njepłaćiwe znamješka wotstronili."
 
 #: src/olympia/addons/forms.py:121
 msgid "All tags must be at least {0} character."
@@ -139,12 +126,8 @@ msgstr[2] "Wšě znački dyrbja znajmjeńša {0} znamješka měć."
 msgstr[3] "Wšě znački dyrbja znajmjeńša {0} znamješkow měć."
 
 #: src/olympia/addons/forms.py:238
-msgid ""
-"Categories cannot be changed while your add-on is featured for this "
-"application."
-msgstr ""
-"Kategorije njedadźa so změnić, mjeztym so waš přidatk za tute nałoženje "
-"předstaja."
+msgid "Categories cannot be changed while your add-on is featured for this application."
+msgstr "Kategorije njedadźa so změnić, mjeztym so waš přidatk za tute nałoženje předstaja."
 
 #. L10n: {0} is the number of categories.
 #: src/olympia/addons/forms.py:242
@@ -156,18 +139,13 @@ msgstr[2] "Móžeš jenož {0} kategorije měć."
 msgstr[3] "Móžeš jenož {0} kategorijow měć."
 
 #: src/olympia/addons/forms.py:250
-msgid ""
-"The miscellaneous category cannot be combined with additional categories."
+msgid "The miscellaneous category cannot be combined with additional categories."
 msgstr "Kategorija „Wšelake“ njeda so z druhimi kategorijemi kombinować."
 
 #: src/olympia/addons/forms.py:374
 #, python-format
-msgid ""
-"Before changing your default locale you must have a name, summary, and "
-"description in that locale. You are missing %s."
-msgstr ""
-"Prjedy hač swoju standardnu rěč změniće, dyrbiće mjeno, zjeće a wopisanje w "
-"tutej rěči měć. %s hišće faluje."
+msgid "Before changing your default locale you must have a name, summary, and description in that locale. You are missing %s."
+msgstr "Prjedy hač swoju standardnu rěč změniće, dyrbiće mjeno, zjeće a wopisanje w tutej rěči měć. %s hišće faluje."
 
 #: src/olympia/addons/forms.py:455 src/olympia/addons/forms.py:546
 msgid "A license must be selected."
@@ -177,8 +155,7 @@ msgstr "Dyrbiće licencu wubrać."
 msgid "Give Your Theme a Name."
 msgstr "Podajće swoju drastu a swoje mjeno."
 
-#: src/olympia/addons/forms.py:533
-#: src/olympia/devhub/templates/devhub/personas/submit.html:53
+#: src/olympia/addons/forms.py:533 src/olympia/devhub/templates/devhub/personas/submit.html:53
 msgid "Describe your Theme."
 msgstr "Wopisaj swoju drastu."
 
@@ -195,42 +172,32 @@ msgid "Users have the option of contributing more or less than this amount."
 msgstr "Wužiwarjo móža wjace abo mjenje hač tuteje sumy darić."
 
 #: src/olympia/addons/models.py:306
-msgid ""
-"Users will always be asked in the Add-ons Manager (Firefox 4 and above). "
-"Only applies to desktop."
-msgstr ""
-"Prašeja so wužiwarjow přeco w zrjadowaku přidatkow (Firefox 4 a nowši). "
-"Płaći jenož za desktop."
+msgid "Users will always be asked in the Add-ons Manager (Firefox 4 and above). Only applies to desktop."
+msgstr "Prašeja so wužiwarjow přeco w zrjadowaku přidatkow (Firefox 4 a nowši). Płaći jenož za desktop."
 
-#: src/olympia/addons/models.py:1800
-#: src/olympia/addons/templates/addons/details_box.html:55
-#: src/olympia/devhub/templates/devhub/index.html:92
+#: src/olympia/addons/models.py:1802 src/olympia/addons/templates/addons/details_box.html:55 src/olympia/devhub/templates/devhub/index.html:92
 #: src/olympia/devhub/templates/devhub/includes/addon_details.html:89
 msgid "Listed"
 msgstr "Nalistowane"
 
-#: src/olympia/addons/views.py:333
-#: src/olympia/browse/templates/browse/personas/mobile/category_landing.html:27
+#: src/olympia/addons/views.py:334 src/olympia/browse/templates/browse/personas/mobile/category_landing.html:27
 msgid "Popular"
 msgstr "Woblubowane"
 
-#: src/olympia/addons/views.py:334 src/olympia/browse/views.py:238
-#: src/olympia/browse/views.py:280 src/olympia/browse/views.py:482
+#: src/olympia/addons/views.py:335 src/olympia/browse/views.py:205 src/olympia/browse/views.py:247 src/olympia/browse/views.py:449
 msgid "Recently Added"
 msgstr "Njedawno přidate"
 
-#: src/olympia/addons/views.py:335 src/olympia/bandwagon/views.py:99
-#: src/olympia/browse/views.py:60 src/olympia/browse/views.py:71
-#: src/olympia/search/forms.py:16 src/olympia/search/forms.py:91
+#: src/olympia/addons/views.py:336 src/olympia/bandwagon/views.py:99 src/olympia/browse/views.py:60 src/olympia/browse/views.py:71 src/olympia/search/forms.py:16 src/olympia/search/forms.py:91
 msgid "Recently Updated"
 msgstr "Njedawno zaktualizowane"
 
 #. l10n: {0} is the addon name
-#: src/olympia/addons/views.py:533
+#: src/olympia/addons/views.py:534
 msgid "Contribution for {0}"
 msgstr "Přinošk za {0}"
 
-#: src/olympia/addons/views.py:626
+#: src/olympia/addons/views.py:627
 msgid "Abuse reported."
 msgstr "Znjewužiwanje zdźělene."
 
@@ -238,114 +205,68 @@ msgstr "Znjewužiwanje zdźělene."
 msgid "My add-on doesn't fit into any of the categories"
 msgstr "Mój přidatk njehodźi so do žaneje kategorije"
 
-#: src/olympia/addons/templates/addons/button.html:27
-#: src/olympia/addons/templates/addons/impala/button.html:11
-#: src/olympia/addons/templates/addons/mobile/button.html:11
+#: src/olympia/addons/templates/addons/button.html:27 src/olympia/addons/templates/addons/impala/button.html:11 src/olympia/addons/templates/addons/mobile/button.html:11
 msgid "No compatible versions"
 msgstr "Žane kompatibelne wersije"
 
-#: src/olympia/addons/templates/addons/button.html:35
-#: src/olympia/addons/templates/addons/impala/button.html:19
+#: src/olympia/addons/templates/addons/button.html:35 src/olympia/addons/templates/addons/impala/button.html:19
 msgid "Added to Mobile"
 msgstr "Mobilnemu gratej přidate"
 
-#: src/olympia/addons/templates/addons/button.html:37
-#: src/olympia/addons/templates/addons/impala/button.html:21
+#: src/olympia/addons/templates/addons/button.html:37 src/olympia/addons/templates/addons/impala/button.html:21
 msgid "Add to Mobile"
 msgstr "Mobilnemu gratej přidać"
 
 #. {0} is a platform name like Windows or Mac OS X.
-#: src/olympia/addons/templates/addons/button.html:66
-#: src/olympia/addons/templates/addons/includes/install_button.html:19
+#: src/olympia/addons/templates/addons/button.html:66 src/olympia/addons/templates/addons/includes/install_button.html:19
 msgid "for {0}"
 msgstr "za {0}"
 
-#: src/olympia/addons/templates/addons/button.html:82
-#: src/olympia/addons/templates/addons/mobile/button.html:23
+#: src/olympia/addons/templates/addons/button.html:82 src/olympia/addons/templates/addons/mobile/button.html:23
 msgid "View privacy policy"
 msgstr "Prawidła priwatnosće pokazać"
 
-#: src/olympia/addons/templates/addons/button.html:87
-#: src/olympia/addons/templates/addons/details_box.html:133
-#: src/olympia/addons/templates/addons/mobile/button.html:28
+#: src/olympia/addons/templates/addons/button.html:87 src/olympia/addons/templates/addons/details_box.html:133 src/olympia/addons/templates/addons/mobile/button.html:28
 #: src/olympia/discovery/templates/discovery/addons/detail.html:28
 msgid "View End-User License Agreement"
 msgstr "Licencne dojednanje za kóncnych wužiwarjow (EULA) pokazać"
 
-#: src/olympia/addons/templates/addons/button.html:92
-#: src/olympia/addons/templates/addons/impala/button.html:54
+#: src/olympia/addons/templates/addons/button.html:92 src/olympia/addons/templates/addons/impala/button.html:54
 #, python-format
-msgid ""
-"This add-on has not been reviewed by Mozilla. <a href=\"%(url)s\">Learn "
-"more</a>"
-msgstr ""
-"Tutón přidatk njeje so wot Mozilla přepruwował. <a href=\"%(url)s\">Dalše "
-"informacije</a>"
+msgid "This add-on has not been reviewed by Mozilla. <a href=\"%(url)s\">Learn more</a>"
+msgstr "Tutón přidatk njeje so wot Mozilla přepruwował. <a href=\"%(url)s\">Dalše informacije</a>"
 
-#: src/olympia/addons/templates/addons/button.html:97
-#: src/olympia/addons/templates/addons/impala/button.html:60
+#: src/olympia/addons/templates/addons/button.html:97 src/olympia/addons/templates/addons/impala/button.html:60
 #, python-format
-msgid ""
-"This add-on has been preliminarily reviewed by Mozilla. <a "
-"href=\"%(url)s\">Learn more</a>"
-msgstr ""
-"Tutón přidatk je so nachwilu wot Mozilla přepruwował. <a "
-"href=\"%(url)s\">Dalše informacije</a>"
+msgid "This add-on has been preliminarily reviewed by Mozilla. <a href=\"%(url)s\">Learn more</a>"
+msgstr "Tutón přidatk je so nachwilu wot Mozilla přepruwował. <a href=\"%(url)s\">Dalše informacije</a>"
 
-#: src/olympia/addons/templates/addons/contribution.html:11
-#: src/olympia/addons/templates/addons/impala/developers.html:44
-msgid ""
-"The developer of this add-on asks that you help support its continued "
-"development by making a small contribution."
-msgstr ""
-"Wuwiwar tutoho přidatka was prosy, zo byšće jeho dalše wuwiwanje přez mały "
-"přinošk podpěrujeće."
+#: src/olympia/addons/templates/addons/contribution.html:11 src/olympia/addons/templates/addons/impala/developers.html:44
+msgid "The developer of this add-on asks that you help support its continued development by making a small contribution."
+msgstr "Wuwiwar tutoho přidatka was prosy, zo byšće jeho dalše wuwiwanje přez mały přinošk podpěrujeće."
 
 #: src/olympia/addons/templates/addons/contribution.html:14
 #, python-format
-msgid ""
-"The developer of this add-on asks that you show your support by making a "
-"donation to the <a href=\"%(charity_url)s\">%(charity_name)s</a>."
-msgstr ""
-"Wuwiwar tutoho přidatka was prosy, zo byšće swoju podpěru přez dar za <a "
-"href=\"%(charity_url)s\">%(charity_name)s</a> pokazał."
+msgid "The developer of this add-on asks that you show your support by making a donation to the <a href=\"%(charity_url)s\">%(charity_name)s</a>."
+msgstr "Wuwiwar tutoho přidatka was prosy, zo byšće swoju podpěru přez dar za <a href=\"%(charity_url)s\">%(charity_name)s</a> pokazał."
 
 #: src/olympia/addons/templates/addons/contribution.html:19
 #, python-format
-msgid ""
-"The developer of this add-on asks that you show your support by making a "
-"small contribution to <a href=\"%(charity_url)s\">%(charity_name)s</a>."
-msgstr ""
-"Wuwiwar tutoho přidatka was prosy, zo byšće swoju podpěru přez mały přinošk "
-"za <a href=\"%(charity_url)s\">%(charity_name)s</a> pokazał."
+msgid "The developer of this add-on asks that you show your support by making a small contribution to <a href=\"%(charity_url)s\">%(charity_name)s</a>."
+msgstr "Wuwiwar tutoho přidatka was prosy, zo byšće swoju podpěru přez mały přinošk za <a href=\"%(charity_url)s\">%(charity_name)s</a> pokazał."
 
-#: src/olympia/addons/templates/addons/contribution.html:30
-#: src/olympia/addons/templates/addons/impala/contribution.html:18
-#: src/olympia/templates/menu_links.html:25
+#: src/olympia/addons/templates/addons/contribution.html:30 src/olympia/addons/templates/addons/impala/contribution.html:18 src/olympia/templates/menu_links.html:25
 msgid "Contribute"
 msgstr "Darić"
 
 #. Click Contribute button OR Install button
-#: src/olympia/addons/templates/addons/contribution.html:34
-#: src/olympia/addons/templates/addons/report_abuse.html:26
-#: src/olympia/addons/templates/addons/impala/contribution.html:32
-#: src/olympia/devhub/templates/devhub/addons/ajax_compat_update.html:36
-#: src/olympia/devhub/templates/devhub/addons/profile.html:44
-#: src/olympia/devhub/templates/devhub/addons/edit/admin.html:101
-#: src/olympia/devhub/templates/devhub/addons/edit/basic.html:152
-#: src/olympia/devhub/templates/devhub/addons/edit/details.html:85
-#: src/olympia/devhub/templates/devhub/addons/edit/support.html:67
-#: src/olympia/devhub/templates/devhub/addons/edit/technical.html:166
-#: src/olympia/devhub/templates/devhub/addons/forms_shared/media.html:149
-#: src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:43
-#: src/olympia/devhub/templates/devhub/versions/add_file_modal.html:57
-#: src/olympia/devhub/templates/devhub/versions/edit.html:139
-#: src/olympia/devhub/templates/devhub/versions/list.html:239
-#: src/olympia/devhub/templates/devhub/versions/list.html:281
-#: src/olympia/devhub/templates/devhub/versions/list.html:315
-#: src/olympia/devhub/templates/devhub/versions/list.html:349
-#: src/olympia/reviews/templates/reviews/edit_review.html:16
-#: src/olympia/translations/templates/translations/trans-menu.html:50
+#: src/olympia/addons/templates/addons/contribution.html:34 src/olympia/addons/templates/addons/report_abuse.html:26 src/olympia/addons/templates/addons/impala/contribution.html:32
+#: src/olympia/devhub/templates/devhub/addons/ajax_compat_update.html:36 src/olympia/devhub/templates/devhub/addons/profile.html:44 src/olympia/devhub/templates/devhub/addons/edit/admin.html:101
+#: src/olympia/devhub/templates/devhub/addons/edit/basic.html:152 src/olympia/devhub/templates/devhub/addons/edit/details.html:85 src/olympia/devhub/templates/devhub/addons/edit/support.html:67
+#: src/olympia/devhub/templates/devhub/addons/edit/technical.html:166 src/olympia/devhub/templates/devhub/addons/forms_shared/media.html:149
+#: src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:43 src/olympia/devhub/templates/devhub/versions/add_file_modal.html:58 src/olympia/devhub/templates/devhub/versions/edit.html:139
+#: src/olympia/devhub/templates/devhub/versions/list.html:239 src/olympia/devhub/templates/devhub/versions/list.html:281 src/olympia/devhub/templates/devhub/versions/list.html:315
+#: src/olympia/devhub/templates/devhub/versions/list.html:349 src/olympia/reviews/templates/reviews/edit_review.html:16 src/olympia/translations/templates/translations/trans-menu.html:50
 #: src/olympia/translations/templates/translations/trans-menu.html:62
 msgid "or"
 msgstr "abo"
@@ -354,41 +275,23 @@ msgstr "abo"
 msgid "Suggested Contribution: {0}"
 msgstr "Namjetowany přinošk: {0}"
 
-#: src/olympia/addons/templates/addons/contribution.html:48
-#: src/olympia/amo/templates/amo/recaptcha.html:5
-#: src/olympia/versions/templates/versions/version.html:52
+#: src/olympia/addons/templates/addons/contribution.html:48 src/olympia/amo/templates/amo/recaptcha.html:5 src/olympia/versions/templates/versions/version.html:52
 msgid "What's this?"
 msgstr "Što to je?"
 
 #: src/olympia/addons/templates/addons/contribution.html:63
 #, python-format
-msgid ""
-"The developer of this add-on would like you to consider making a donation to"
-" the <a href=\"%(charity_url)s\">%(charity_name)s</a> if you enjoy using it."
-msgstr ""
-"Wuwiwar tutoho přidatka was prosy, zo byšće dar za <a "
-"href=\"%(charity_url)s\">%(charity_name)s</a> rozwažił, jeli jón rady "
-"wužiwaće."
+msgid "The developer of this add-on would like you to consider making a donation to the <a href=\"%(charity_url)s\">%(charity_name)s</a> if you enjoy using it."
+msgstr "Wuwiwar tutoho přidatka was prosy, zo byšće dar za <a href=\"%(charity_url)s\">%(charity_name)s</a> rozwažił, jeli jón rady wužiwaće."
 
 #: src/olympia/addons/templates/addons/contribution.html:69
 #, python-format
-msgid ""
-"The developer of this add-on would like you to consider making a small "
-"contribution to <a href=\"%(charity_url)s\">%(charity_name)s</a> if you "
-"enjoy using it."
-msgstr ""
-"Wuwiwar tutoho přidatka was prosy, zo byšće mały přinošk za <a "
-"href=\"%(charity_url)s\">%(charity_name)s</a> rozwažił, jeli jón rady "
-"wužiwaće."
+msgid "The developer of this add-on would like you to consider making a small contribution to <a href=\"%(charity_url)s\">%(charity_name)s</a> if you enjoy using it."
+msgstr "Wuwiwar tutoho přidatka was prosy, zo byšće mały přinošk za <a href=\"%(charity_url)s\">%(charity_name)s</a> rozwažił, jeli jón rady wužiwaće."
 
 #: src/olympia/addons/templates/addons/contribution.html:76
-msgid ""
-"Mozilla is committed to supporting a vibrant and healthy developer "
-"ecosystem. Your optional contribution helps sustain further development of "
-"this add-on."
-msgstr ""
-"Mozilla je zawjazany, žiwy a strowy wuwiwarski ekosystem podpěrować. Waš "
-"dobrowólny přinošk pomha, dalše wuwiwanje tutoho přidatka zachować."
+msgid "Mozilla is committed to supporting a vibrant and healthy developer ecosystem. Your optional contribution helps sustain further development of this add-on."
+msgstr "Mozilla je zawjazany, žiwy a strowy wuwiwarski ekosystem podpěrować. Waš dobrowólny přinošk pomha, dalše wuwiwanje tutoho přidatka zachować."
 
 #: src/olympia/addons/templates/addons/contributions_lightbox.html:5
 msgid "Make a Contribution"
@@ -396,35 +299,22 @@ msgstr "Darić"
 
 #: src/olympia/addons/templates/addons/contributions_lightbox.html:9
 #, python-format
-msgid ""
-"Help support the continued development of <strong>%(addon_name)s</strong> by"
-" making a small contribution through <a href=\"%(paypal_url)s\">PayPal</a>."
-msgstr ""
-"Pomhajće, dalše wuwiwanje <strong>%(addon_name)s</strong> přez mały přinošk "
-"přez <a href=\"%(paypal_url)s\">PayPal</a> podpěrać."
+msgid "Help support the continued development of <strong>%(addon_name)s</strong> by making a small contribution through <a href=\"%(paypal_url)s\">PayPal</a>."
+msgstr "Pomhajće, dalše wuwiwanje <strong>%(addon_name)s</strong> přez mały přinošk přez <a href=\"%(paypal_url)s\">PayPal</a> podpěrać."
 
 #: src/olympia/addons/templates/addons/contributions_lightbox.html:15
 #, python-format
 msgid ""
-"To show your support for <b>%(addon_name)s</b>, the developer asks that you "
-"make a donation to the <a href=\"%(charity_url)s\">%(charity_name)s</a> "
-"through <a href=\"%(paypal_url)s\">PayPal</a>."
-msgstr ""
-"Zo byšće swoju podpěru za <b>%(addon_name)s</b> pokazał, wuwiwar was prosy, "
-"zo byšće <a href=\"%(charity_url)s\">%(charity_name)s</a> přez <a "
-"href=\"%(paypal_url)s\">PayPal</a> darił."
+"To show your support for <b>%(addon_name)s</b>, the developer asks that you make a donation to the <a href=\"%(charity_url)s\">%(charity_name)s</a> through <a href=\"%(paypal_url)s\">PayPal</a>."
+msgstr "Zo byšće swoju podpěru za <b>%(addon_name)s</b> pokazał, wuwiwar was prosy, zo byšće <a href=\"%(charity_url)s\">%(charity_name)s</a> přez <a href=\"%(paypal_url)s\">PayPal</a> darił."
 
 #: src/olympia/addons/templates/addons/contributions_lightbox.html:21
 #, python-format
 msgid ""
-"To show your support for <b>%(addon_name)s</b>, the developer asks that you "
-"make a small contribution to <a "
-"href=\"%(charity_url)s\">%(charity_name)s</a> through <a "
-"href=\"%(paypal_url)s\">PayPal</a>."
+"To show your support for <b>%(addon_name)s</b>, the developer asks that you make a small contribution to <a href=\"%(charity_url)s\">%(charity_name)s</a> through <a href=\"%(paypal_url)s\">PayPal</"
+"a>."
 msgstr ""
-"Zo byšće swoju podpěru za <b>%(addon_name)s</b> pokazał, wuwiwar was prosy, "
-"zo byšće mały přinošk <a href=\"%(charity_url)s\">%(charity_name)s</a> přez "
-"<a href=\"%(paypal_url)s\">PayPal</a> dał."
+"Zo byšće swoju podpěru za <b>%(addon_name)s</b> pokazał, wuwiwar was prosy, zo byšće mały přinošk <a href=\"%(charity_url)s\">%(charity_name)s</a> přez <a href=\"%(paypal_url)s\">PayPal</a> dał."
 
 #: src/olympia/addons/templates/addons/contributions_lightbox.html:30
 msgid "How much would you like to contribute?"
@@ -447,8 +337,7 @@ msgstr "Darjenska suma dyrbi ličba być."
 msgid "A one-time suggested contribution of {0}"
 msgstr "Jónkróćny namjetowany dar {0}"
 
-#. {0} is a currency symbol (e.g., $),                    {1} is an amount
-#. input
+#. {0} is a currency symbol (e.g., $),                    {1} is an amount input
 #. field
 #: src/olympia/addons/templates/addons/contributions_lightbox.html:64
 msgid "A one-time contribution of {0} {1}"
@@ -458,11 +347,8 @@ msgstr "Jónkróćny přinošk {0} {1}"
 msgid "Leave a comment or request with your contribution."
 msgstr "Zawostajće komentar abo naprašowanje ze swojim darom."
 
-#: src/olympia/addons/templates/addons/contributions_lightbox.html:74
-#: src/olympia/bandwagon/templates/bandwagon/ajax_new.html:20
-#: src/olympia/bandwagon/templates/bandwagon/includes/addedit.html:37
-#: src/olympia/reviews/templates/reviews/mobile/add_form.html:13
-#: src/olympia/templates/includes/forms.html:10
+#: src/olympia/addons/templates/addons/contributions_lightbox.html:74 src/olympia/bandwagon/templates/bandwagon/ajax_new.html:20 src/olympia/bandwagon/templates/bandwagon/includes/addedit.html:37
+#: src/olympia/reviews/templates/reviews/mobile/add_form.html:13 src/olympia/templates/includes/forms.html:10
 msgid "(optional)"
 msgstr "(opcionalny)"
 
@@ -482,36 +368,27 @@ msgstr "Ně, dźakuju so"
 msgid "Contribution made, thank you."
 msgstr "Přinošk je so darił, wulki dźak."
 
-#: src/olympia/addons/templates/addons/details_box.html:10
-#: src/olympia/discovery/templates/discovery/addons/detail.html:19
+#: src/olympia/addons/templates/addons/details_box.html:10 src/olympia/discovery/templates/discovery/addons/detail.html:19
 msgid "No restart required"
 msgstr "Žane znowastartowanje trěbne"
 
 #. This is a caption for a table. {0} is an add-on name.
-#: src/olympia/addons/templates/addons/details_box.html:26
-#: src/olympia/addons/templates/addons/includes/persona.html:9
+#: src/olympia/addons/templates/addons/details_box.html:26 src/olympia/addons/templates/addons/includes/persona.html:9
 msgid "Add-on Information for {0}"
 msgstr "Přidatkowe informacije za {0}"
 
-#: src/olympia/addons/templates/addons/details_box.html:30
-#: src/olympia/addons/templates/addons/persona_detail_table.html:3
-#: src/olympia/addons/templates/addons/mobile/details.html:63
-#: src/olympia/addons/templates/addons/mobile/persona_detail_table.html:7
-#: src/olympia/browse/views.py:459 src/olympia/devhub/views.py:75
+#: src/olympia/addons/templates/addons/details_box.html:30 src/olympia/addons/templates/addons/persona_detail_table.html:3 src/olympia/addons/templates/addons/mobile/details.html:63
+#: src/olympia/addons/templates/addons/mobile/persona_detail_table.html:7 src/olympia/browse/views.py:426 src/olympia/devhub/views.py:73
 msgid "Updated"
 msgstr "Zaktualizowany"
 
-#: src/olympia/addons/templates/addons/details_box.html:38
-#: src/olympia/addons/templates/addons/mobile/details.html:71
-#: src/olympia/devhub/templates/devhub/addons/edit/support.html:43
+#: src/olympia/addons/templates/addons/details_box.html:38 src/olympia/addons/templates/addons/mobile/details.html:71 src/olympia/devhub/templates/devhub/addons/edit/support.html:43
 #: src/olympia/discovery/templates/discovery/addons/detail.html:77
 msgid "Website"
 msgstr "Websydło"
 
 #. This refers to this version's compatible applications, such as Firefox 8.0
-#: src/olympia/addons/templates/addons/details_box.html:47
-#: src/olympia/addons/templates/addons/mobile/details.html:80
-#: src/olympia/search/templates/search/results.html:72
+#: src/olympia/addons/templates/addons/details_box.html:47 src/olympia/addons/templates/addons/mobile/details.html:80 src/olympia/search/templates/search/results.html:72
 #: src/olympia/versions/templates/versions/version.html:21
 msgid "Works with"
 msgstr "Funguje z"
@@ -520,45 +397,30 @@ msgstr "Funguje z"
 msgid "Visibility"
 msgstr "Widźomnosć"
 
-#: src/olympia/addons/templates/addons/details_box.html:57
-#: src/olympia/devhub/templates/devhub/index.html:94
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:91
+#: src/olympia/addons/templates/addons/details_box.html:57 src/olympia/devhub/templates/devhub/index.html:94 src/olympia/devhub/templates/devhub/includes/addon_details.html:91
 msgid "Hidden"
 msgstr "Schowane"
 
-#: src/olympia/addons/templates/addons/details_box.html:59
-#: src/olympia/devhub/templates/devhub/index.html:96
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:93
+#: src/olympia/addons/templates/addons/details_box.html:59 src/olympia/devhub/templates/devhub/index.html:96 src/olympia/devhub/templates/devhub/includes/addon_details.html:93
 msgid "Unlisted"
 msgstr "W lisćinje njepodate"
 
-#: src/olympia/addons/templates/addons/details_box.html:67
-#: src/olympia/devhub/templates/devhub/addons/edit/technical.html:44
+#: src/olympia/addons/templates/addons/details_box.html:67 src/olympia/devhub/templates/devhub/addons/edit/technical.html:44
 msgid "Required Add-ons"
 msgstr "Trěbne přidatki"
 
-#: src/olympia/addons/templates/addons/details_box.html:81
-#: src/olympia/addons/templates/addons/persona_detail_table.html:15
-#: src/olympia/browse/views.py:462 src/olympia/devhub/views.py:78
-#: src/olympia/devhub/views.py:85
-#: src/olympia/discovery/templates/discovery/addons/detail.html:57
-#: src/olympia/reviews/forms.py:62
-#: src/olympia/reviews/templates/reviews/add.html:57
+#: src/olympia/addons/templates/addons/details_box.html:81 src/olympia/addons/templates/addons/persona_detail_table.html:15 src/olympia/browse/views.py:429 src/olympia/devhub/views.py:76
+#: src/olympia/devhub/views.py:83 src/olympia/discovery/templates/discovery/addons/detail.html:57 src/olympia/reviews/forms.py:62 src/olympia/reviews/templates/reviews/add.html:57
 #: src/olympia/reviews/templates/reviews/mobile/review_list.html:18
 msgid "Rating"
 msgstr "Pohódnoćenje"
 
-#: src/olympia/addons/templates/addons/details_box.html:85
-#: src/olympia/browse/views.py:461 src/olympia/devhub/views.py:77
-#: src/olympia/devhub/views.py:84
-#: src/olympia/stats/templates/stats/addon_report_menu.html:8
-#: src/olympia/stats/templates/stats/collection_report_menu.html:18
+#: src/olympia/addons/templates/addons/details_box.html:85 src/olympia/browse/views.py:428 src/olympia/devhub/views.py:75 src/olympia/devhub/views.py:82
+#: src/olympia/stats/templates/stats/addon_report_menu.html:8 src/olympia/stats/templates/stats/collection_report_menu.html:18
 msgid "Downloads"
 msgstr "Sćehnjenja"
 
-#: src/olympia/addons/templates/addons/details_box.html:91
-#: src/olympia/addons/templates/addons/details_box.html:103
-#: src/olympia/devhub/templates/devhub/addons/listing/item_actions_theme.html:17
+#: src/olympia/addons/templates/addons/details_box.html:91 src/olympia/addons/templates/addons/details_box.html:103 src/olympia/devhub/templates/devhub/addons/listing/item_actions_theme.html:17
 #: src/olympia/devhub/templates/devhub/personas/edit.html:60
 msgid "View Statistics"
 msgstr "Statistiku pokazać"
@@ -572,18 +434,13 @@ msgid "Abuse Reports"
 msgstr "Rozprawy wo znjewužiwanju"
 
 #. The Privacy Policy for this add-on.
-#: src/olympia/addons/templates/addons/details_box.html:121
-#: src/olympia/addons/templates/addons/privacy.html:19
-#: src/olympia/addons/templates/addons/privacy.html:23
-#: src/olympia/addons/templates/addons/impala/button.html:43
-#: src/olympia/addons/templates/addons/impala/details.html:312
-#: src/olympia/devhub/templates/devhub/includes/policy_form.html:23
+#: src/olympia/addons/templates/addons/details_box.html:121 src/olympia/addons/templates/addons/privacy.html:19 src/olympia/addons/templates/addons/privacy.html:23
+#: src/olympia/addons/templates/addons/impala/button.html:43 src/olympia/addons/templates/addons/impala/details.html:312 src/olympia/devhub/templates/devhub/includes/policy_form.html:23
 #: src/olympia/templates/mobile/base_addons.html:87
 msgid "Privacy Policy"
 msgstr "Prawidła priwatnosće"
 
-#: src/olympia/addons/templates/addons/details_box.html:124
-#: src/olympia/discovery/templates/discovery/addons/detail.html:24
+#: src/olympia/addons/templates/addons/details_box.html:124 src/olympia/discovery/templates/discovery/addons/detail.html:24
 msgid "View Privacy Policy"
 msgstr "Prawidła priwatnosće pokazać"
 
@@ -591,8 +448,7 @@ msgstr "Prawidła priwatnosće pokazać"
 msgid "EULA"
 msgstr "EULA"
 
-#: src/olympia/addons/templates/addons/details_box.html:171
-#: src/olympia/addons/templates/addons/details_box.html:231
+#: src/olympia/addons/templates/addons/details_box.html:171 src/olympia/addons/templates/addons/details_box.html:231
 msgid "More about this add-on"
 msgstr "Wjace wo tutym přidatku"
 
@@ -600,26 +456,21 @@ msgstr "Wjace wo tutym přidatku"
 msgid "Image Gallery"
 msgstr "Wobrazowa galerija"
 
-#: src/olympia/addons/templates/addons/details_box.html:190
-#: src/olympia/devhub/templates/devhub/addons/edit/technical.html:21
+#: src/olympia/addons/templates/addons/details_box.html:190 src/olympia/devhub/templates/devhub/addons/edit/technical.html:21
 msgid "Developer Comments"
 msgstr "Wuwiwarske komentary"
 
-#: src/olympia/addons/templates/addons/details_box.html:199
-#: src/olympia/addons/templates/addons/impala/details.html:264
+#: src/olympia/addons/templates/addons/details_box.html:199 src/olympia/addons/templates/addons/impala/details.html:264
 msgid "Development Channel"
 msgstr "Wuwiwarski kanal"
 
-#: src/olympia/addons/templates/addons/details_box.html:202
-#: src/olympia/addons/templates/addons/mobile/details.html:124
+#: src/olympia/addons/templates/addons/details_box.html:202 src/olympia/addons/templates/addons/mobile/details.html:124
 msgid ""
-"The Development Channel lets you test an experimental new version of this "
-"add-on before it's released to the general public. Once you install the "
-"development version, you will continue to get updates from this channel."
+"The Development Channel lets you test an experimental new version of this add-on before it's released to the general public. Once you install the development version, you will continue to get "
+"updates from this channel."
 msgstr ""
-"Wuwiwarski kanal wam zmóžnja, nowu eksperimentalnu wersiju tutoho přidatka "
-"testować, prjedy hač so powšitkownej zjawnosći přewostaji. Hdyž wuwiwarsku "
-"wersiju instalujeće, budźeće dale aktualizacije z tutoho kanala dóstawać."
+"Wuwiwarski kanal wam zmóžnja, nowu eksperimentalnu wersiju tutoho přidatka testować, prjedy hač so powšitkownej zjawnosći přewostaji. Hdyž wuwiwarsku wersiju instalujeće, budźeće dale aktualizacije "
+"z tutoho kanala dóstawać."
 
 #: src/olympia/addons/templates/addons/details_box.html:207
 msgid "Install development version"
@@ -627,20 +478,13 @@ msgstr "Wuwiwarsku wersiju instalować"
 
 #: src/olympia/addons/templates/addons/details_box.html:211
 msgid ""
-"<strong>Caution:</strong> Development versions of this add-on have not been "
-"reviewed by Mozilla. Once you install a development version you will "
-"continue to receive development updates from this developer. To stop "
-"receiving development updates, reinstall the default version from the link "
-"above."
+"<strong>Caution:</strong> Development versions of this add-on have not been reviewed by Mozilla. Once you install a development version you will continue to receive development updates from this "
+"developer. To stop receiving development updates, reinstall the default version from the link above."
 msgstr ""
-"<strong>Kedźbu:</strong> Wuwiwarske wersije tutoho přidatka njejsu "
-"přepruwowane wot Mozilla. Hdyž wuwiwarsku wersiju instalujeće, budźeće dale "
-"wuwiwarske aktualizacije wot tutoho wuwiwarja dóstawać. Zo njebyšće hižo "
-"žane wuwiwarske aktualizacije dóstawał, instalujće standardnu wersiju wot "
-"wotkaza horjeka."
+"<strong>Kedźbu:</strong> Wuwiwarske wersije tutoho přidatka njejsu přepruwowane wot Mozilla. Hdyž wuwiwarsku wersiju instalujeće, budźeće dale wuwiwarske aktualizacije wot tutoho wuwiwarja "
+"dóstawać. Zo njebyšće hižo žane wuwiwarske aktualizacije dóstawał, instalujće standardnu wersiju wot wotkaza horjeka."
 
-#: src/olympia/addons/templates/addons/details_box.html:220
-#: src/olympia/addons/templates/addons/impala/details.html:283
+#: src/olympia/addons/templates/addons/details_box.html:220 src/olympia/addons/templates/addons/impala/details.html:283
 msgid "Version {0}:"
 msgstr "Wersija {0}:"
 
@@ -648,52 +492,35 @@ msgstr "Wersija {0}:"
 msgid "Nothing to see here!  The developer did not include any details."
 msgstr "Tu njeje ničo widźeć! Wuwiwar njeje žane podrobnosće integrował."
 
-#: src/olympia/addons/templates/addons/details_box.html:251
-#: src/olympia/devhub/templates/devhub/versions/edit.html:73
-#: src/olympia/editors/templates/editors/review.html:98
+#: src/olympia/addons/templates/addons/details_box.html:251 src/olympia/devhub/templates/devhub/versions/edit.html:73 src/olympia/editors/templates/editors/review.html:98
 msgid "Version Notes"
 msgstr "Wersijowe pokazy"
 
 #. {0} is the name of the add-on.
 #. {0} is the name of the add-on
-#: src/olympia/addons/templates/addons/eula.html:6
-#: src/olympia/discovery/templates/discovery/addons/eula.html:5
+#: src/olympia/addons/templates/addons/eula.html:6 src/olympia/discovery/templates/discovery/addons/eula.html:5
 msgid "End-User License Agreement for {0}"
 msgstr "Licencne dojednanje za kóncnych wužiwarjow (EULA) za {0}"
 
-#: src/olympia/addons/templates/addons/eula.html:17
-#: src/olympia/addons/templates/addons/eula.html:21
-#: src/olympia/addons/templates/addons/impala/button.html:48
-#: src/olympia/addons/templates/addons/impala/details.html:321
-#: src/olympia/devhub/templates/devhub/includes/policy_form.html:3
-#: src/olympia/discovery/templates/discovery/addons/eula.html:11
+#: src/olympia/addons/templates/addons/eula.html:17 src/olympia/addons/templates/addons/eula.html:21 src/olympia/addons/templates/addons/impala/button.html:48
+#: src/olympia/addons/templates/addons/impala/details.html:321 src/olympia/devhub/templates/devhub/includes/policy_form.html:3 src/olympia/discovery/templates/discovery/addons/eula.html:11
 msgid "End-User License Agreement"
 msgstr "Licencne dojednanje z kónčnym wužiwarjom (EULA)"
 
-#: src/olympia/addons/templates/addons/eula.html:23
-#: src/olympia/discovery/templates/discovery/addons/eula.html:13
+#: src/olympia/addons/templates/addons/eula.html:23 src/olympia/discovery/templates/discovery/addons/eula.html:13
 #, python-format
-msgid ""
-"%(addon_name)s requires that you accept the following End-User License "
-"Agreement before installation can proceed:"
-msgstr ""
-"%(addon_name)s sej wužaduje, zo slědowace licencne dojednanje za kónčnych "
-"wužiwarjow (EULA) akceptujeće, prjedy hač z instalowanjom pokročujeće:"
+msgid "%(addon_name)s requires that you accept the following End-User License Agreement before installation can proceed:"
+msgstr "%(addon_name)s sej wužaduje, zo slědowace licencne dojednanje za kónčnych wužiwarjow (EULA) akceptujeće, prjedy hač z instalowanjom pokročujeće:"
 
-#: src/olympia/addons/templates/addons/eula.html:34
-#: src/olympia/addons/templates/addons/privacy.html:26
+#: src/olympia/addons/templates/addons/eula.html:34 src/olympia/addons/templates/addons/privacy.html:26
 msgid "Back to {0}…"
 msgstr "Wróćo k {0}…"
 
-#: src/olympia/addons/templates/addons/home.html:3
-#: src/olympia/addons/templates/addons/mobile/home.html:3
-#: src/olympia/amo/helpers.py:235
+#: src/olympia/addons/templates/addons/home.html:3 src/olympia/addons/templates/addons/mobile/home.html:3 src/olympia/amo/helpers.py:235
 msgid "Add-ons for {0}"
 msgstr "Přidatki za {0}"
 
-#: src/olympia/addons/templates/addons/home.html:10
-#: src/olympia/addons/templates/addons/home.html:53
-#: src/olympia/browse/templates/browse/impala/base_listing.html:11
+#: src/olympia/addons/templates/addons/home.html:10 src/olympia/addons/templates/addons/home.html:53 src/olympia/browse/templates/browse/impala/base_listing.html:11
 msgid "Featured Extensions"
 msgstr "Předstajene rozšěrjenja"
 
@@ -701,13 +528,8 @@ msgstr "Předstajene rozšěrjenja"
 msgid "Popular Extensions"
 msgstr "Woblubowane rozšěrjenja"
 
-#: src/olympia/addons/templates/addons/home.html:44
-#: src/olympia/amo/templates/amo/side_nav.html:3
-#: src/olympia/amo/templates/amo/side_nav.html:11
-#: src/olympia/amo/templates/amo/site_nav.html:3
-#: src/olympia/amo/templates/amo/site_nav.html:25
-#: src/olympia/browse/views.py:236 src/olympia/browse/views.py:281
-#: src/olympia/browse/views.py:481
+#: src/olympia/addons/templates/addons/home.html:44 src/olympia/amo/templates/amo/side_nav.html:3 src/olympia/amo/templates/amo/side_nav.html:11 src/olympia/amo/templates/amo/site_nav.html:3
+#: src/olympia/amo/templates/amo/site_nav.html:25 src/olympia/browse/views.py:203 src/olympia/browse/views.py:248 src/olympia/browse/views.py:448
 msgid "Most Popular"
 msgstr "Najbóle woblubowane"
 
@@ -715,10 +537,7 @@ msgstr "Najbóle woblubowane"
 msgid "All »"
 msgstr "Wšě »"
 
-#: src/olympia/addons/templates/addons/home.html:54
-#: src/olympia/addons/templates/addons/home.html:63
-#: src/olympia/addons/templates/addons/home.html:72
-#: src/olympia/addons/templates/addons/home.html:80
+#: src/olympia/addons/templates/addons/home.html:54 src/olympia/addons/templates/addons/home.html:63 src/olympia/addons/templates/addons/home.html:72 src/olympia/addons/templates/addons/home.html:80
 #: src/olympia/browse/templates/browse/impala/category_landing.html:36
 msgid "See all »"
 msgstr "Wšě pokazać »"
@@ -727,44 +546,31 @@ msgstr "Wšě pokazać »"
 msgid "Up &amp; Coming Extensions"
 msgstr "Nastawace rozšěrjenja"
 
-#: src/olympia/addons/templates/addons/home.html:71
-#: src/olympia/browse/templates/browse/personas/category_landing.html:61
-#: src/olympia/discovery/templates/discovery/pane.html:74
+#: src/olympia/addons/templates/addons/home.html:71 src/olympia/browse/templates/browse/personas/category_landing.html:61 src/olympia/discovery/templates/discovery/pane.html:74
 msgid "Featured Themes"
 msgstr "Předstajene drasty"
 
-#: src/olympia/addons/templates/addons/home.html:79
-#: src/olympia/bandwagon/templates/bandwagon/impala/collection_listing.html:5
+#: src/olympia/addons/templates/addons/home.html:79 src/olympia/bandwagon/templates/bandwagon/impala/collection_listing.html:5
 msgid "Featured Collections"
 msgstr "Předstajene zběrki"
 
-#: src/olympia/addons/templates/addons/listing_header.html:3
-#: src/olympia/addons/templates/addons/impala/listing/sorter.html:2
-#: src/olympia/amo/templates/amo/mobile/sort_by.html:2
+#: src/olympia/addons/templates/addons/listing_header.html:3 src/olympia/addons/templates/addons/impala/listing/sorter.html:2 src/olympia/amo/templates/amo/mobile/sort_by.html:2
 #: src/olympia/bandwagon/templates/bandwagon/collection_detail.html:118
 msgid "Sort by:"
 msgstr "Sortěrować po:"
 
 #. {0} is a date.
 #. {0} is a date
-#: src/olympia/addons/templates/addons/macros.html:7
-#: src/olympia/addons/templates/addons/macros.html:72
-#: src/olympia/addons/templates/addons/listing/items_mobile.html:48
-#: src/olympia/addons/templates/addons/listing/macros.html:42
-#: src/olympia/bandwagon/templates/bandwagon/collection_detail.html:50
-#: src/olympia/bandwagon/templates/bandwagon/collection_listing_items.html:40
-#: src/olympia/bandwagon/templates/bandwagon/impala/collection_listing_items.html:40
+#: src/olympia/addons/templates/addons/macros.html:7 src/olympia/addons/templates/addons/macros.html:72 src/olympia/addons/templates/addons/listing/items_mobile.html:48
+#: src/olympia/addons/templates/addons/listing/macros.html:42 src/olympia/bandwagon/templates/bandwagon/collection_detail.html:50
+#: src/olympia/bandwagon/templates/bandwagon/collection_listing_items.html:40 src/olympia/bandwagon/templates/bandwagon/impala/collection_listing_items.html:40
 msgid "Updated {0}"
 msgstr "Aktualizowany: {0}"
 
 #. {0} is a date.
-#: src/olympia/addons/templates/addons/macros.html:10
-#: src/olympia/addons/templates/addons/macros.html:69
-#: src/olympia/addons/templates/addons/persona_preview.html:22
-#: src/olympia/addons/templates/addons/listing/items_mobile.html:44
-#: src/olympia/addons/templates/addons/listing/macros.html:39
-#: src/olympia/bandwagon/templates/bandwagon/collection_listing_items.html:37
-#: src/olympia/bandwagon/templates/bandwagon/impala/collection_listing_items.html:37
+#: src/olympia/addons/templates/addons/macros.html:10 src/olympia/addons/templates/addons/macros.html:69 src/olympia/addons/templates/addons/persona_preview.html:22
+#: src/olympia/addons/templates/addons/listing/items_mobile.html:44 src/olympia/addons/templates/addons/listing/macros.html:39
+#: src/olympia/bandwagon/templates/bandwagon/collection_listing_items.html:37 src/olympia/bandwagon/templates/bandwagon/impala/collection_listing_items.html:37
 msgid "Added {0}"
 msgstr "Přidaty: {0}"
 
@@ -787,8 +593,7 @@ msgstr[2] "%(num)s wužiwarjo"
 msgstr[3] "%(num)s wužiwarjow"
 
 #. {0} is the number of downloads.
-#: src/olympia/addons/templates/addons/macros.html:53
-#: src/olympia/addons/templates/addons/impala/details.html:59
+#: src/olympia/addons/templates/addons/macros.html:53 src/olympia/addons/templates/addons/impala/details.html:59
 msgid "{0} weekly download"
 msgid_plural "{0} weekly downloads"
 msgstr[0] "{0} tydźenske sćehnjenje"
@@ -797,9 +602,7 @@ msgstr[2] "{0} tydźenske sćehnjenja"
 msgstr[3] "{0} tydźenskich sćehnjenjow"
 
 #. {0} is the number of users.
-#: src/olympia/addons/templates/addons/macros.html:61
-#: src/olympia/addons/templates/addons/impala/details.html:52
-#: src/olympia/zadmin/templates/zadmin/compat.html:67
+#: src/olympia/addons/templates/addons/macros.html:61 src/olympia/addons/templates/addons/impala/details.html:52 src/olympia/zadmin/templates/zadmin/compat.html:67
 msgid "{0} user"
 msgid_plural "{0} users"
 msgstr[0] "{0} wužiwar"
@@ -819,12 +622,8 @@ msgstr "Płaćenje dokónčene"
 msgid "Return to the addon."
 msgstr "Wróćo k přidatkej."
 
-#: src/olympia/addons/templates/addons/persona_detail.html:17
-#: src/olympia/addons/templates/addons/impala/details.html:103
-#: src/olympia/addons/templates/addons/mobile/details.html:23
-#: src/olympia/addons/templates/addons/mobile/persona_detail.html:21
-#: src/olympia/discovery/templates/discovery/addons/base.html:27
-#: src/olympia/editors/templates/editors/review.html:31
+#: src/olympia/addons/templates/addons/persona_detail.html:17 src/olympia/addons/templates/addons/impala/details.html:103 src/olympia/addons/templates/addons/mobile/details.html:23
+#: src/olympia/addons/templates/addons/mobile/persona_detail.html:21 src/olympia/discovery/templates/discovery/addons/base.html:27 src/olympia/editors/templates/editors/review.html:31
 msgid "by"
 msgstr "wot"
 
@@ -834,8 +633,7 @@ msgid "More {0} Themes"
 msgstr "Dalše drasty kategorije {0}"
 
 #. {0} is a category name, such as Nature
-#: src/olympia/addons/templates/addons/persona_detail.html:39
-#: src/olympia/addons/templates/addons/mobile/persona_detail.html:66
+#: src/olympia/addons/templates/addons/persona_detail.html:39 src/olympia/addons/templates/addons/mobile/persona_detail.html:66
 msgid "See all {0} Themes"
 msgstr "Wšě drasty kategorije {0} pokazać"
 
@@ -843,65 +641,45 @@ msgstr "Wšě drasty kategorije {0} pokazać"
 msgid "More by this Artist"
 msgstr "Dalše wot tutoho wuměłca"
 
-#: src/olympia/addons/templates/addons/persona_detail.html:52
-#: src/olympia/addons/templates/addons/mobile/persona_detail.html:49
+#: src/olympia/addons/templates/addons/persona_detail.html:52 src/olympia/addons/templates/addons/mobile/persona_detail.html:49
 msgid "See all Themes by this Artist"
 msgstr "Wšě drasty wot tutoho wuměłca pokazać"
 
-#: src/olympia/addons/templates/addons/persona_detail.html:71
-#: src/olympia/addons/templates/addons/mobile/home.html:42
-#: src/olympia/amo/templates/amo/side_nav.html:22
-#: src/olympia/browse/templates/browse/personas/mobile/category_landing.html:28
-#: src/olympia/devhub/templates/devhub/addons/edit/basic.html:72
-#: src/olympia/editors/templates/editors/review.html:277
-#: src/olympia/editors/templates/editors/themes/themes.html:34
-#: src/olympia/templates/categories.html:7
+#: src/olympia/addons/templates/addons/persona_detail.html:71 src/olympia/addons/templates/addons/mobile/home.html:42 src/olympia/amo/templates/amo/side_nav.html:22
+#: src/olympia/browse/templates/browse/personas/mobile/category_landing.html:28 src/olympia/devhub/templates/devhub/addons/edit/basic.html:72 src/olympia/editors/templates/editors/review.html:277
+#: src/olympia/editors/templates/editors/themes/themes.html:34 src/olympia/templates/categories.html:7
 msgid "Categories"
 msgstr "Kategorije"
 
-#: src/olympia/addons/templates/addons/persona_detail_table.html:10
-#: src/olympia/addons/templates/addons/mobile/persona_detail_table.html:3
-#: src/olympia/editors/templates/editors/themes/deleted.html:19
+#: src/olympia/addons/templates/addons/persona_detail_table.html:10 src/olympia/addons/templates/addons/mobile/persona_detail_table.html:3 src/olympia/editors/templates/editors/themes/deleted.html:19
 #: src/olympia/editors/templates/editors/themes/themes.html:25
 msgid "Artist"
 msgstr "Wuměłc"
 
-#: src/olympia/addons/templates/addons/persona_detail_table.html:19
-#: src/olympia/addons/templates/addons/mobile/persona_detail_table.html:14
-#: src/olympia/stats/templates/stats/addon_report_menu.html:17
+#: src/olympia/addons/templates/addons/persona_detail_table.html:19 src/olympia/addons/templates/addons/mobile/persona_detail_table.html:14 src/olympia/stats/templates/stats/addon_report_menu.html:17
 msgid "Daily Users"
 msgstr "Wšědni wužiwarjo"
 
 #. The License for this add-on.
-#: src/olympia/addons/templates/addons/persona_detail_table.html:26
-#: src/olympia/addons/templates/addons/impala/license.html:17
-#: src/olympia/addons/templates/addons/mobile/persona_detail_table.html:21
-#: src/olympia/devhub/templates/devhub/includes/license_form.html:5
-#: src/olympia/devhub/templates/devhub/versions/edit.html:89
-#: src/olympia/editors/templates/editors/themes/themes.html:41
+#: src/olympia/addons/templates/addons/persona_detail_table.html:26 src/olympia/addons/templates/addons/impala/license.html:17 src/olympia/addons/templates/addons/mobile/persona_detail_table.html:21
+#: src/olympia/devhub/templates/devhub/includes/license_form.html:5 src/olympia/devhub/templates/devhub/versions/edit.html:89 src/olympia/editors/templates/editors/themes/themes.html:41
 msgid "License"
 msgstr "Licenca"
 
-#: src/olympia/addons/templates/addons/persona_preview.html:13
-#: src/olympia/constants/base.py:48
+#: src/olympia/addons/templates/addons/persona_preview.html:13 src/olympia/constants/base.py:48
 msgid "Awaiting Review"
 msgstr "Čaka na přepruwowanje"
 
-#: src/olympia/addons/templates/addons/persona_preview.html:15
-#: src/olympia/amo/log.py:180 src/olympia/constants/base.py:42
-#: src/olympia/editors/helpers.py:62
+#: src/olympia/addons/templates/addons/persona_preview.html:15 src/olympia/amo/log.py:180 src/olympia/constants/base.py:42 src/olympia/editors/helpers.py:62
 msgid "Rejected"
 msgstr "Wotpokazany"
 
-#: src/olympia/addons/templates/addons/persona_preview.html:17
-#: src/olympia/amo/log.py:159
+#: src/olympia/addons/templates/addons/persona_preview.html:17 src/olympia/amo/log.py:159
 msgid "Approved"
 msgstr "Schwaleny"
 
 #. {0} is the number of users.
-#: src/olympia/addons/templates/addons/persona_preview.html:27
-#: src/olympia/addons/templates/addons/listing/items_mobile.html:36
-#: src/olympia/addons/templates/addons/listing/macros.html:31
+#: src/olympia/addons/templates/addons/persona_preview.html:27 src/olympia/addons/templates/addons/listing/items_mobile.html:36 src/olympia/addons/templates/addons/listing/macros.html:31
 msgid "<strong>{0}</strong> user"
 msgid_plural "<strong>{0}</strong> users"
 msgstr[0] "<strong>{0}</strong> wužiwar"
@@ -913,24 +691,15 @@ msgstr[3] "<strong>{0}</strong> wužiwarjow"
 msgid "Hover to Preview"
 msgstr "Za přehlad pokazowak myški nad tym dźeržeć"
 
-#: src/olympia/addons/templates/addons/persona_preview.html:47
-#: src/olympia/addons/templates/addons/persona_preview.html:49
+#: src/olympia/addons/templates/addons/persona_preview.html:47 src/olympia/addons/templates/addons/persona_preview.html:49 src/olympia/addons/templates/addons/persona_preview.html:97
 #: src/olympia/reviews/templates/reviews/add.html:15
 msgid "Add"
 msgstr "Přidać"
 
-#: src/olympia/addons/templates/addons/persona_preview.html:58
-#: src/olympia/bandwagon/templates/bandwagon/ajax_new.html:16
-#: src/olympia/bandwagon/templates/bandwagon/edit.html:19
-#: src/olympia/bandwagon/templates/bandwagon/includes/addedit.html:19
-#: src/olympia/devhub/templates/devhub/addons/edit/admin.html:13
-#: src/olympia/devhub/templates/devhub/addons/edit/basic.html:10
-#: src/olympia/devhub/templates/devhub/addons/edit/details.html:8
-#: src/olympia/devhub/templates/devhub/addons/edit/media.html:6
-#: src/olympia/devhub/templates/devhub/addons/edit/support.html:8
-#: src/olympia/devhub/templates/devhub/addons/edit/technical.html:9
-#: src/olympia/devhub/templates/devhub/addons/submit/describe.html:29
-#: src/olympia/editors/templates/editors/review.html:257
+#: src/olympia/addons/templates/addons/persona_preview.html:58 src/olympia/bandwagon/templates/bandwagon/ajax_new.html:16 src/olympia/bandwagon/templates/bandwagon/edit.html:19
+#: src/olympia/bandwagon/templates/bandwagon/includes/addedit.html:19 src/olympia/devhub/templates/devhub/addons/edit/admin.html:13 src/olympia/devhub/templates/devhub/addons/edit/basic.html:10
+#: src/olympia/devhub/templates/devhub/addons/edit/details.html:8 src/olympia/devhub/templates/devhub/addons/edit/media.html:6 src/olympia/devhub/templates/devhub/addons/edit/support.html:8
+#: src/olympia/devhub/templates/devhub/addons/edit/technical.html:9 src/olympia/devhub/templates/devhub/addons/submit/describe.html:29 src/olympia/editors/templates/editors/review.html:257
 msgid "Edit"
 msgstr "Wobdźěłać"
 
@@ -945,11 +714,8 @@ msgstr "%%d. %%m. %%Y"
 msgid "by {0} on {1}"
 msgstr "wot {0} dnja {1}"
 
-#: src/olympia/addons/templates/addons/persona_preview.html:76
-#: src/olympia/reviews/helpers.py:17
-#: src/olympia/reviews/templates/reviews/review_list.html:63
-#: src/olympia/reviews/templates/reviews/reviews_link.html:21
-#: src/olympia/reviews/templates/reviews/impala/reviews_link.html:16
+#: src/olympia/addons/templates/addons/persona_preview.html:76 src/olympia/reviews/helpers.py:17 src/olympia/reviews/templates/reviews/review_list.html:63
+#: src/olympia/reviews/templates/reviews/reviews_link.html:21 src/olympia/reviews/templates/reviews/impala/reviews_link.html:16
 msgid "Not yet rated"
 msgstr "Hišće njepohódnoćeny"
 
@@ -958,73 +724,48 @@ msgid "<b>{0}</b> users"
 msgstr "<b>{0}</b> wužiwarjow"
 
 #: src/olympia/addons/templates/addons/popups.html:17
-msgid ""
-"To install this add-on and thousands more, <b>get Firefox</b>, a free and "
-"open web browser from Mozilla."
-msgstr ""
-"Zo byšće tutón přidatk a tysace dalše instalował, <b>wobstarajće sej "
-"Firefox</b>, darmotny a wotewrjeny webwobhladowak wot Mozilla."
+msgid "To install this add-on and thousands more, <b>get Firefox</b>, a free and open web browser from Mozilla."
+msgstr "Zo byšće tutón přidatk a tysace dalše instalował, <b>wobstarajće sej Firefox</b>, darmotny a wotewrjeny webwobhladowak wot Mozilla."
 
-#: src/olympia/addons/templates/addons/popups.html:21
-#: src/olympia/addons/templates/addons/popups.html:52
+#: src/olympia/addons/templates/addons/popups.html:21 src/olympia/addons/templates/addons/popups.html:52
 msgid "Learn more about Firefox"
 msgstr "Dalše informacije wo Firefox"
 
 #: src/olympia/addons/templates/addons/popups.html:22
-msgid "or <b><a class=\"installer\" href=\"{url}\">download anyway</a></b>"
-msgstr "abo <b><a class=\"installer\" href=\"{url}\">najebać toho instalować</a></b>"
+msgid "or <b><a class=\"button installer\" href=\"{url}\">download anyway</a></b>"
+msgstr ""
 
 #: src/olympia/addons/templates/addons/popups.html:26
 msgid ""
-"<strong>How to Install in Thunderbird</strong> <ol> <li>Download and save "
-"the file to your hard disk.</li> <li>In Mozilla Thunderbird, open Add-ons "
-"from the Tools menu.</li> <li>From the options button next to the add-on "
-"search field, select \"Install Add-on From File...\" and locate the "
-"downloaded add-on.</li> </ol>"
+"<strong>How to Install in Thunderbird</strong> <ol> <li>Download and save the file to your hard disk.</li> <li>In Mozilla Thunderbird, open Add-ons from the Tools menu.</li> <li>From the options "
+"button next to the add-on search field, select \"Install Add-on From File...\" and locate the downloaded add-on.</li> </ol>"
 msgstr ""
-"<strong>Instalacija w Thunderbird</strong> <ol> <li>Sćehńće a składujće "
-"dataju na swojej krutej tačeli. </li> <li>Wočińće zrjadowak přidatkow přez "
-"meni „Nastroje“ w Mozilla Thunderbird.</li> <li>Wubjerće z tłóčatkom ze "
-"zubatym koleskom pódla pytanskeho pola přidatka zapisk „Přidatk z dataje "
-"instalować...“ a wubjerće sćehnjeny přidatk.</li> </ol>"
+"<strong>Instalacija w Thunderbird</strong> <ol> <li>Sćehńće a składujće dataju na swojej krutej tačeli. </li> <li>Wočińće zrjadowak přidatkow přez meni „Nastroje“ w Mozilla Thunderbird.</li> "
+"<li>Wubjerće z tłóčatkom ze zubatym koleskom pódla pytanskeho pola přidatka zapisk „Přidatk z dataje instalować...“ a wubjerće sćehnjeny přidatk.</li> </ol>"
 
 #: src/olympia/addons/templates/addons/popups.html:41
-msgid ""
-"To install this Theme, <b>get Thunderbird</b>, a free and open source email "
-"client from Mozilla Messaging and install the Personas Plus add-on."
-msgstr ""
-"Zo byšće tutu drastu instalował, <b>wobstarajće sej Thunderbird</b>, "
-"darmotny e-mejlowy programy wotewrjeneho žórła wot Mozilla Messaging a "
-"instalujće přidatk Personas Plus."
+msgid "To install this Theme, <b>get Thunderbird</b>, a free and open source email client from Mozilla Messaging and install the Personas Plus add-on."
+msgstr "Zo byšće tutu drastu instalował, <b>wobstarajće sej Thunderbird</b>, darmotny e-mejlowy programy wotewrjeneho žórła wot Mozilla Messaging a instalujće přidatk Personas Plus."
 
 #: src/olympia/addons/templates/addons/popups.html:46
 msgid "Learn more about Thunderbird"
 msgstr "Dalše informacije wo Thunderbird"
 
 #: src/olympia/addons/templates/addons/popups.html:48
-msgid ""
-"To install this Theme and thousands more, <b>get Firefox</b>, a free and "
-"open web browser from Mozilla."
-msgstr ""
-"Zo byšće tutu drastu a tysace dalše instalował, <b>wobstarajće sej "
-"Firefox</b>, darmotny a wotewrjeny webwobhladowak wot Mozilla."
+msgid "To install this Theme and thousands more, <b>get Firefox</b>, a free and open web browser from Mozilla."
+msgstr "Zo byšće tutu drastu a tysace dalše instalował, <b>wobstarajće sej Firefox</b>, darmotny a wotewrjeny webwobhladowak wot Mozilla."
 
 #: src/olympia/addons/templates/addons/popups.html:60
 #, python-format
 msgid "This add-on has not been updated to work with your version of %(app)s."
-msgstr ""
-"Tutón přidatk njeje so hišće zaktualizował, zo by z wašej wersiju %(app)s "
-"fungował."
+msgstr "Tutón přidatk njeje so hišće zaktualizował, zo by z wašej wersiju %(app)s fungował."
 
-#: src/olympia/addons/templates/addons/popups.html:63
-#: src/olympia/addons/templates/addons/popups.html:140
-#: src/olympia/addons/templates/addons/popups.html:150
+#: src/olympia/addons/templates/addons/popups.html:63 src/olympia/addons/templates/addons/popups.html:140 src/olympia/addons/templates/addons/popups.html:150
 msgid "Install Anyway"
 msgstr "Najebać toho instalować"
 
 #: src/olympia/addons/templates/addons/popups.html:71
-msgid ""
-"This add-on requires a version of Firefox that has not been released yet."
+msgid "This add-on requires a version of Firefox that has not been released yet."
 msgstr "Tutón přidatk sej wersiju Firefox wužaduje, kotrež hišće njeje wušła."
 
 #: src/olympia/addons/templates/addons/popups.html:74
@@ -1033,16 +774,11 @@ msgstr "Pomhajće, nowe wersije Firefox testować"
 
 #: src/olympia/addons/templates/addons/popups.html:77
 #, python-format
-msgid ""
-"This add-on requires %(app)s {new_version}. You are currently using %(app)s "
-"{old_version}."
-msgstr ""
-"Tutón přidatk sej %(app)s {new_version} wužaduje. Wužiwaće tuchwilu %(app)s "
-"{old_version}."
+msgid "This add-on requires %(app)s {new_version}. You are currently using %(app)s {old_version}."
+msgstr "Tutón přidatk sej %(app)s {new_version} wužaduje. Wužiwaće tuchwilu %(app)s {old_version}."
 
 #. {0} is an app name, like Firefox.
-#: src/olympia/addons/templates/addons/popups.html:82
-#: src/olympia/addons/templates/addons/popups.html:101
+#: src/olympia/addons/templates/addons/popups.html:82 src/olympia/addons/templates/addons/popups.html:101
 msgid "Upgrade {0}"
 msgstr "{0} aktualizować"
 
@@ -1053,44 +789,27 @@ msgstr "abo <a href=\"%(href)s\">starše wersije tutoho přidatka</a> pokazać."
 
 #: src/olympia/addons/templates/addons/popups.html:96
 #, python-format
-msgid ""
-"This Persona requires %(app)s %(new_version)s. You are currently using "
-"%(app)s {old_version}."
-msgstr ""
-"Tutón Persona sej %(app)s %(new_version)s wužaduje. Wužiwaće tuchwilu "
-"%(app)s {old_version}."
+msgid "This Persona requires %(app)s %(new_version)s. You are currently using %(app)s {old_version}."
+msgstr "Tutón Persona sej %(app)s %(new_version)s wužaduje. Wužiwaće tuchwilu %(app)s {old_version}."
 
 #: src/olympia/addons/templates/addons/popups.html:108
 msgid ""
-"<strong>Caution:</strong> This add-on has not been reviewed by Mozilla and "
-"can't be installed on release versions of Firefox 43 and above.  Be careful "
-"when installing third-party software that might harm your computer."
+"<strong>Caution:</strong> This add-on has not been reviewed by Mozilla and can't be installed on release versions of Firefox 43 and above.  Be careful when installing third-party software that "
+"might harm your computer."
 msgstr ""
-"<strong>Kedźbu:</strong> Tutón přidatk njeje přepruwowany wot Mozilla a "
-"njeda so do wersije Firefox 43 a nowšych instalować. Budźće kedźbliwy, hdyž "
-"programy třećich poskićowarjow instalujeće, kotrež móhli wašemu ličakej "
-"škodu činić."
+"<strong>Kedźbu:</strong> Tutón přidatk njeje přepruwowany wot Mozilla a njeda so do wersije Firefox 43 a nowšych instalować. Budźće kedźbliwy, hdyž programy třećich poskićowarjow instalujeće, "
+"kotrež móhli wašemu ličakej škodu činić."
 
 #: src/olympia/addons/templates/addons/popups.html:120
-msgid ""
-"<strong>Please note:</strong> This add-on is not compatible with your "
-"operating system."
-msgstr ""
-"<strong>Kedźbu:</strong> Tutón přidatk z wašim dźěłowym systemom "
-"kompatibelny njeje."
+msgid "<strong>Please note:</strong> This add-on is not compatible with your operating system."
+msgstr "<strong>Kedźbu:</strong> Tutón přidatk z wašim dźěłowym systemom kompatibelny njeje."
 
-#: src/olympia/addons/templates/addons/popups.html:136
-#: src/olympia/addons/templates/addons/impala/button.html:70
+#: src/olympia/addons/templates/addons/popups.html:136 src/olympia/addons/templates/addons/impala/button.html:70
 #, python-format
-msgid ""
-"This add-on is not compatible with your version of %(app)s because of the "
-"following:"
-msgstr ""
-"Tutón přidatk je ze slědowaceje přičiny z wašej wersiju %(app)s kompatibelny"
-" njeje:"
+msgid "This add-on is not compatible with your version of %(app)s because of the following:"
+msgstr "Tutón přidatk je ze slědowaceje přičiny z wašej wersiju %(app)s kompatibelny njeje:"
 
-#: src/olympia/addons/templates/addons/popups.html:141
-#: src/olympia/addons/templates/addons/popups.html:151
+#: src/olympia/addons/templates/addons/popups.html:141 src/olympia/addons/templates/addons/popups.html:151
 msgid "View other versions"
 msgstr "Druhe wersije pokazać"
 
@@ -1114,13 +833,9 @@ msgid ""
 "  to your phone.  (You'll need a QR reader.  Search your phone's marketplace if\n"
 "  don't have one.)"
 msgstr ""
-"Chceće {0} na swojim mobilnym Firefox? Skenujće tutón QR-kod, zo byšće jón "
-"direktnje na swojim telefonje instalował. (Trjebaće QR-čitak. Přepytajće "
-"torhošćo swojeho telefona, jeli tajki nimaće.)"
+"Chceće {0} na swojim mobilnym Firefox? Skenujće tutón QR-kod, zo byšće jón direktnje na swojim telefonje instalował. (Trjebaće QR-čitak. Přepytajće torhošćo swojeho telefona, jeli tajki nimaće.)"
 
-#: src/olympia/addons/templates/addons/report_abuse.html:6
-#: src/olympia/addons/templates/addons/report_abuse_full.html:10
-#: src/olympia/addons/templates/addons/impala/details-more.html:23
+#: src/olympia/addons/templates/addons/report_abuse.html:6 src/olympia/addons/templates/addons/report_abuse_full.html:10 src/olympia/addons/templates/addons/impala/details-more.html:23
 #: src/olympia/addons/templates/addons/impala/details.html:333
 msgid "Report Abuse"
 msgstr "Znjewužiwanje zdźělić"
@@ -1128,131 +843,81 @@ msgstr "Znjewužiwanje zdźělić"
 #: src/olympia/addons/templates/addons/report_abuse.html:10
 #, python-format
 msgid ""
-"If you suspect this add-on violates <a href=\"%(url)s\">our policies</a> or "
-"has security or privacy issues, please use the form below to describe your "
-"concerns. Please do not use this form for any other reason."
+"If you suspect this add-on violates <a href=\"%(url)s\">our policies</a> or has security or privacy issues, please use the form below to describe your concerns. Please do not use this form for any "
+"other reason."
 msgstr ""
-"Jeli sej mysliće, zo so tutón přidatk přećiwo <a href=\"%(url)s\">našim "
-"prawidłam</a> přeńdźe abo ma problemy wěstoty a priwatnosće, wužiwajće prošu"
-" slědowacy formular, zo byšće swoje wobmyslenja wopisał. Prošu njewužiwaj "
-"tutón formilar z druheje přičiny."
+"Jeli sej mysliće, zo so tutón přidatk přećiwo <a href=\"%(url)s\">našim prawidłam</a> přeńdźe abo ma problemy wěstoty a priwatnosće, wužiwajće prošu slědowacy formular, zo byšće swoje wobmyslenja "
+"wopisał. Prošu njewužiwaj tutón formilar z druheje přičiny."
 
-#: src/olympia/addons/templates/addons/report_abuse.html:24
-#: src/olympia/users/templates/users/report_abuse.html:19
+#: src/olympia/addons/templates/addons/report_abuse.html:24 src/olympia/users/templates/users/report_abuse.html:19
 msgid "Send Report"
 msgstr "Rozprawu pósłać"
 
-#: src/olympia/addons/templates/addons/report_abuse.html:26
-#: src/olympia/addons/templates/addons/mobile/eula.html:16
-#: src/olympia/addons/templates/addons/mobile/persona_confirm.html:7
-#: src/olympia/devhub/templates/devhub/addons/ajax_compat_update.html:36
-#: src/olympia/devhub/templates/devhub/addons/profile.html:44
-#: src/olympia/devhub/templates/devhub/addons/edit/admin.html:104
-#: src/olympia/devhub/templates/devhub/addons/edit/basic.html:155
-#: src/olympia/devhub/templates/devhub/addons/edit/details.html:88
-#: src/olympia/devhub/templates/devhub/addons/edit/support.html:70
-#: src/olympia/devhub/templates/devhub/addons/edit/technical.html:169
-#: src/olympia/devhub/templates/devhub/addons/forms_shared/media.html:152
-#: src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:43
-#: src/olympia/devhub/templates/devhub/personas/edit.html:222
-#: src/olympia/devhub/templates/devhub/versions/add_file_modal.html:58
-#: src/olympia/devhub/templates/devhub/versions/edit.html:140
-#: src/olympia/devhub/templates/devhub/versions/list.html:208
-#: src/olympia/devhub/templates/devhub/versions/list.html:239
-#: src/olympia/devhub/templates/devhub/versions/list.html:281
-#: src/olympia/devhub/templates/devhub/versions/list.html:315
-#: src/olympia/reviews/templates/reviews/edit_review.html:16
-#: src/olympia/translations/templates/translations/trans-menu.html:50
-#: src/olympia/translations/templates/translations/trans-menu.html:62
-#: src/olympia/zadmin/templates/zadmin/validation.html:105
+#: src/olympia/addons/templates/addons/report_abuse.html:26 src/olympia/addons/templates/addons/mobile/eula.html:16 src/olympia/addons/templates/addons/mobile/persona_confirm.html:7
+#: src/olympia/devhub/templates/devhub/addons/ajax_compat_update.html:36 src/olympia/devhub/templates/devhub/addons/profile.html:44 src/olympia/devhub/templates/devhub/addons/edit/admin.html:104
+#: src/olympia/devhub/templates/devhub/addons/edit/basic.html:155 src/olympia/devhub/templates/devhub/addons/edit/details.html:88 src/olympia/devhub/templates/devhub/addons/edit/support.html:70
+#: src/olympia/devhub/templates/devhub/addons/edit/technical.html:169 src/olympia/devhub/templates/devhub/addons/forms_shared/media.html:152
+#: src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:43 src/olympia/devhub/templates/devhub/personas/edit.html:222 src/olympia/devhub/templates/devhub/versions/add_file_modal.html:59
+#: src/olympia/devhub/templates/devhub/versions/edit.html:140 src/olympia/devhub/templates/devhub/versions/list.html:208 src/olympia/devhub/templates/devhub/versions/list.html:239
+#: src/olympia/devhub/templates/devhub/versions/list.html:281 src/olympia/devhub/templates/devhub/versions/list.html:315 src/olympia/reviews/templates/reviews/edit_review.html:16
+#: src/olympia/translations/templates/translations/trans-menu.html:50 src/olympia/translations/templates/translations/trans-menu.html:62 src/olympia/zadmin/templates/zadmin/validation.html:105
 msgid "Cancel"
 msgstr "Přetorhnyć"
 
-#: src/olympia/addons/templates/addons/review_add_box.html:3
-#: src/olympia/addons/templates/addons/impala/review_add_box.html:5
+#: src/olympia/addons/templates/addons/review_add_box.html:3 src/olympia/addons/templates/addons/impala/review_add_box.html:5
 msgid "What do you think?"
 msgstr "Što mysliće?"
 
-#: src/olympia/addons/templates/addons/review_add_box.html:7
-#: src/olympia/addons/templates/addons/impala/review_add_box.html:9
+#: src/olympia/addons/templates/addons/review_add_box.html:7 src/olympia/addons/templates/addons/impala/review_add_box.html:9
 #, python-format
 msgid "Please <a href=\"%(login)s\">log in</a> to submit a review"
-msgstr ""
-"Prošu <a href=\"%(login)s\">přizjewće so</a>, zo byšće pohódnoćenje zapodał"
+msgstr "Prošu <a href=\"%(login)s\">přizjewće so</a>, zo byšće pohódnoćenje zapodał"
 
-#: src/olympia/addons/templates/addons/review_add_box.html:16
-#: src/olympia/addons/templates/addons/impala/review_add_box.html:18
-#: src/olympia/reviews/templates/reviews/mobile/add_form.html:13
+#: src/olympia/addons/templates/addons/review_add_box.html:16 src/olympia/addons/templates/addons/impala/review_add_box.html:18 src/olympia/reviews/templates/reviews/mobile/add_form.html:13
 msgid "Title:"
 msgstr "Titul:"
 
-#: src/olympia/addons/templates/addons/review_add_box.html:17
-#: src/olympia/addons/templates/addons/impala/review_add_box.html:19
-#: src/olympia/reviews/templates/reviews/mobile/add_form.html:17
+#: src/olympia/addons/templates/addons/review_add_box.html:17 src/olympia/addons/templates/addons/impala/review_add_box.html:19 src/olympia/reviews/templates/reviews/mobile/add_form.html:17
 msgid "Review:"
 msgstr "Pohódnoćenje:"
 
-#: src/olympia/addons/templates/addons/review_add_box.html:18
-#: src/olympia/addons/templates/addons/impala/review_add_box.html:20
-#: src/olympia/reviews/templates/reviews/mobile/add_form.html:16
+#: src/olympia/addons/templates/addons/review_add_box.html:18 src/olympia/addons/templates/addons/impala/review_add_box.html:20 src/olympia/reviews/templates/reviews/mobile/add_form.html:16
 msgid "Rating:"
 msgstr "Pohódnoćenje:"
 
-#: src/olympia/addons/templates/addons/review_add_box.html:19
-#: src/olympia/addons/templates/addons/impala/review_add_box.html:21
-#: src/olympia/reviews/templates/reviews/add.html:63
-#: src/olympia/reviews/templates/reviews/edit_review.html:15
-#: src/olympia/reviews/templates/reviews/mobile/add_form.html:18
+#: src/olympia/addons/templates/addons/review_add_box.html:19 src/olympia/addons/templates/addons/impala/review_add_box.html:21 src/olympia/reviews/templates/reviews/add.html:63
+#: src/olympia/reviews/templates/reviews/edit_review.html:15 src/olympia/reviews/templates/reviews/mobile/add_form.html:18
 msgid "Submit review"
 msgstr "Pohódnoćenje wotpósłać"
 
-#: src/olympia/addons/templates/addons/review_add_box.html:24
-#: src/olympia/addons/templates/addons/impala/review_add_box.html:26
-msgid ""
-"Please do not post bug reports in reviews. We do not make your email address"
-" available to add-on developers and they may need to contact you to help "
-"resolve your issue."
+#: src/olympia/addons/templates/addons/review_add_box.html:24 src/olympia/addons/templates/addons/impala/review_add_box.html:26
+msgid "Please do not post bug reports in reviews. We do not make your email address available to add-on developers and they may need to contact you to help resolve your issue."
 msgstr ""
-"Prošu njesćelće rozprawy wo zmylkach w pohódnoćenjach. Njestajamy "
-"přidatkowym wuwiwarjam wašu e-mejlowu adresu k dispoziciji a njemóža tohodla"
-" z wami do zwiska stupić, zo bychu waš problem rozrisali."
+"Prošu njesćelće rozprawy wo zmylkach w pohódnoćenjach. Njestajamy přidatkowym wuwiwarjam wašu e-mejlowu adresu k dispoziciji a njemóža tohodla z wami do zwiska stupić, zo bychu waš problem "
+"rozrisali."
 
-#: src/olympia/addons/templates/addons/review_add_box.html:32
-#: src/olympia/addons/templates/addons/impala/review_add_box.html:35
+#: src/olympia/addons/templates/addons/review_add_box.html:32 src/olympia/addons/templates/addons/impala/review_add_box.html:35
 #, python-format
-msgid ""
-"See the <a href=\"%(support)s\">support section</a> to find out where to get"
-" assistance for this add-on."
-msgstr ""
-"Hlejće <a href=\"%(support)s\">wotrězk Pomoc</a>, zo byšće pomoc wo tutym "
-"přidatku dóstał."
+msgid "See the <a href=\"%(support)s\">support section</a> to find out where to get assistance for this add-on."
+msgstr "Hlejće <a href=\"%(support)s\">wotrězk Pomoc</a>, zo byšće pomoc wo tutym přidatku dóstał."
 
-#: src/olympia/addons/templates/addons/review_add_box.html:38
-#: src/olympia/addons/templates/addons/impala/review_add_box.html:42
-#: src/olympia/pages/templates/pages/review_guide.html:3
+#: src/olympia/addons/templates/addons/review_add_box.html:38 src/olympia/addons/templates/addons/impala/review_add_box.html:42 src/olympia/pages/templates/pages/review_guide.html:3
 #: src/olympia/pages/templates/pages/review_guide.html:44
 msgid "Review Guidelines"
 msgstr "Pohódnoćenske směrnicy"
 
-#: src/olympia/addons/templates/addons/review_list_box.html:5
-#: src/olympia/addons/templates/addons/impala/details-more.html:27
-#: src/olympia/editors/helpers.py:997
-#: src/olympia/reviews/templates/reviews/add.html:14
-#: src/olympia/reviews/templates/reviews/reply.html:14
-#: src/olympia/reviews/templates/reviews/review_list.html:19
+#: src/olympia/addons/templates/addons/review_list_box.html:5 src/olympia/addons/templates/addons/impala/details-more.html:27 src/olympia/editors/helpers.py:1001
+#: src/olympia/reviews/templates/reviews/add.html:14 src/olympia/reviews/templates/reviews/reply.html:14 src/olympia/reviews/templates/reviews/review_list.html:19
 #: src/olympia/reviews/templates/reviews/mobile/review_list.html:26
 msgid "Reviews"
 msgstr "Pohódnoćenja"
 
-#: src/olympia/addons/templates/addons/review_list_box.html:14
-#: src/olympia/addons/templates/addons/impala/review_list_box.html:14
-#: src/olympia/reviews/templates/reviews/review.html:30
+#: src/olympia/addons/templates/addons/review_list_box.html:14 src/olympia/addons/templates/addons/impala/review_list_box.html:14 src/olympia/reviews/templates/reviews/review.html:30
 #, python-format
 msgid "by %(user)s on %(date)s"
 msgstr "wot %(user)s dnja %(date)s"
 
-#: src/olympia/addons/templates/addons/review_list_box.html:19
-#: src/olympia/addons/templates/addons/impala/review_list_box.html:29
+#: src/olympia/addons/templates/addons/review_list_box.html:19 src/olympia/addons/templates/addons/impala/review_list_box.html:29
 msgid "Show the developer's reply to this review"
 msgstr "Wotmołwu wuwiwarja na tute pohódnoćenje pokazać"
 
@@ -1265,21 +930,16 @@ msgstr[1] "%(cnt)s pohódnoćeni tutoho přidatka pokazać"
 msgstr[2] "Wšě %(cnt)s pohódnoćenja tutoho přidatka pokazać"
 msgstr[3] "Wšě %(cnt)s pohódnoćenjow tutoho přidatka pokazać"
 
-#: src/olympia/addons/templates/addons/tags_box.html:3
-#: src/olympia/devhub/templates/devhub/addons/edit/basic.html:118
+#: src/olympia/addons/templates/addons/tags_box.html:3 src/olympia/devhub/templates/devhub/addons/edit/basic.html:118
 msgid "Tags"
 msgstr "Znački"
 
-#: src/olympia/addons/templates/addons/impala/addon_hovercard.html:7
-#: src/olympia/addons/templates/addons/impala/addon_hovercard.html:9
+#: src/olympia/addons/templates/addons/impala/addon_hovercard.html:7 src/olympia/addons/templates/addons/impala/addon_hovercard.html:9
 msgid "Icon for {0}"
 msgstr "Symbol za {0}"
 
-#: src/olympia/addons/templates/addons/impala/addon_hovercard.html:34
-#: src/olympia/addons/templates/addons/impala/featured_grid.html:26
-#: src/olympia/addons/templates/addons/impala/theme_grid.html:22
-#: src/olympia/bandwagon/templates/bandwagon/collection_detail.html:31
-#: src/olympia/users/templates/users/helpers/addon_users_list.html:7
+#: src/olympia/addons/templates/addons/impala/addon_hovercard.html:34 src/olympia/addons/templates/addons/impala/featured_grid.html:26 src/olympia/addons/templates/addons/impala/theme_grid.html:22
+#: src/olympia/bandwagon/templates/bandwagon/collection_detail.html:31 src/olympia/users/templates/users/helpers/addon_users_list.html:7
 #, python-format
 msgid "by %(users)s"
 msgstr "wot %(users)s"
@@ -1299,39 +959,22 @@ msgstr "Spodoba so wam tutón přidatk?"
 
 #: src/olympia/addons/templates/addons/impala/contribution.html:43
 #, python-format
-msgid ""
-"The <a href=\"%(meet_url)s\">developer of this add-on</a> asks that you help"
-" support its continued development by making a small contribution."
-msgstr ""
-"<a href=\"%(meet_url)s\">Wuwiwar tutoho přidatka</a> was prosy, zo byšće "
-"jeho dalše wuwiwanje přez mały přinošk podpěrujeće."
+msgid "The <a href=\"%(meet_url)s\">developer of this add-on</a> asks that you help support its continued development by making a small contribution."
+msgstr "<a href=\"%(meet_url)s\">Wuwiwar tutoho přidatka</a> was prosy, zo byšće jeho dalše wuwiwanje přez mały přinošk podpěrujeće."
 
 #: src/olympia/addons/templates/addons/impala/contribution.html:48
 #, python-format
-msgid ""
-"The <a href=\"%(meet_url)s\">developer of this add-on</a> asks that you show"
-" your support by making a donation to the <a "
-"href=\"%(charity_url)s\">%(charity_name)s</a>."
-msgstr ""
-"<a href=\"%(meet_url)s\">Wuwiwar tutoho přidatka</a> was prosy, zo byšće "
-"swoju podpěru přez dar za <a href=\"%(charity_url)s\">%(charity_name)s</a> "
-"pokazał."
+msgid "The <a href=\"%(meet_url)s\">developer of this add-on</a> asks that you show your support by making a donation to the <a href=\"%(charity_url)s\">%(charity_name)s</a>."
+msgstr "<a href=\"%(meet_url)s\">Wuwiwar tutoho přidatka</a> was prosy, zo byšće swoju podpěru přez dar za <a href=\"%(charity_url)s\">%(charity_name)s</a> pokazał."
 
 #: src/olympia/addons/templates/addons/impala/contribution.html:53
 #, python-format
-msgid ""
-"The <a href=\"%(meet_url)s\">developer of this add-on</a> asks that you show"
-" your support by making a small contribution to <a "
-"href=\"%(charity_url)s\">%(charity_name)s</a>."
-msgstr ""
-"<a href=\"%(meet_url)s\">Wuwiwar tutoho přidatka</a> was prosy, zo byšće "
-"swoju podpěru přez mały přinošk za <a "
-"href=\"%(charity_url)s\">%(charity_name)s</a> pokazał."
+msgid "The <a href=\"%(meet_url)s\">developer of this add-on</a> asks that you show your support by making a small contribution to <a href=\"%(charity_url)s\">%(charity_name)s</a>."
+msgstr "<a href=\"%(meet_url)s\">Wuwiwar tutoho přidatka</a> was prosy, zo byšće swoju podpěru přez mały přinošk za <a href=\"%(charity_url)s\">%(charity_name)s</a> pokazał."
 
 #: src/olympia/addons/templates/addons/impala/dependencies_note.html:4
 msgid "This add-on requires the following add-ons to work properly:"
-msgstr ""
-"Tutón přidatk sej slědowace přidatki wužaduje, zo by korektnje fungował:"
+msgstr "Tutón přidatk sej slědowace přidatki wužaduje, zo by korektnje fungował:"
 
 #: src/olympia/addons/templates/addons/impala/details-more.html:13
 msgid "Average"
@@ -1365,8 +1008,7 @@ msgid_plural "<span itemprop=\"ratingCount\">%(num)s</span> user reviews"
 msgstr[0] "<span itemprop=\"ratingCount\">%(num)s</span> wužiwarske pohódnoćenje"
 msgstr[1] "<span itemprop=\"ratingCount\">%(num)s</span> wužiwarskej pohódnoćeni"
 msgstr[2] "<span itemprop=\"ratingCount\">%(num)s</span> wužiwarske pohódnoćenja"
-msgstr[3] ""
-"<span itemprop=\"ratingCount\">%(num)s</span> wužiwarskich pohódnoćenjow"
+msgstr[3] "<span itemprop=\"ratingCount\">%(num)s</span> wužiwarskich pohódnoćenjow"
 
 #: src/olympia/addons/templates/addons/impala/details.html:66
 msgid "View statistics"
@@ -1381,8 +1023,7 @@ msgstr "Rjadować"
 msgid "Icon of {0}"
 msgstr "Symbol {0}"
 
-#: src/olympia/addons/templates/addons/impala/details.html:100
-#: src/olympia/addons/templates/addons/impala/listing/items.html:14
+#: src/olympia/addons/templates/addons/impala/details.html:100 src/olympia/addons/templates/addons/impala/listing/items.html:14
 msgid "No Restart"
 msgstr "Žane znowastartowanje"
 
@@ -1416,11 +1057,8 @@ msgstr "Sydło pomocy"
 msgid "Support E-mail"
 msgstr "E-mejlowa adresa pomocy"
 
-#: src/olympia/addons/templates/addons/impala/details.html:199
-#: src/olympia/devhub/models.py:378
-#: src/olympia/devhub/templates/devhub/versions/list.html:12
-#: src/olympia/versions/templates/versions/version.html:6
-#: src/olympia/versions/templates/versions/mobile/version.html:6
+#: src/olympia/addons/templates/addons/impala/details.html:199 src/olympia/devhub/models.py:378 src/olympia/devhub/templates/devhub/versions/list.html:12
+#: src/olympia/versions/templates/versions/version.html:6 src/olympia/versions/templates/versions/mobile/version.html:6
 msgid "Version {0}"
 msgstr "Wersija {0}"
 
@@ -1428,8 +1066,7 @@ msgstr "Wersija {0}"
 msgid "Info"
 msgstr "Informacije"
 
-#: src/olympia/addons/templates/addons/impala/details.html:200
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:116
+#: src/olympia/addons/templates/addons/impala/details.html:200 src/olympia/devhub/templates/devhub/includes/addon_details.html:116
 msgid "Last Updated:"
 msgstr "Poslednja aktualizacija:"
 
@@ -1438,12 +1075,8 @@ msgstr "Poslednja aktualizacija:"
 msgid "Released under <a target=\"_blank\" href=\"%(url)s\">%(name)s</a>"
 msgstr "Wozjewjeny pod <a target=\"_blank\" href=\"%(url)s\">%(name)s</a>"
 
-#: src/olympia/addons/templates/addons/impala/details.html:206
-#: src/olympia/addons/templates/addons/impala/details.html:211
-#: src/olympia/amo/helpers.py:398 src/olympia/devhub/forms.py:142
-#: src/olympia/devhub/forms.py:173
-#: src/olympia/versions/templates/versions/version.html:40
-#: src/olympia/versions/templates/versions/version.html:45
+#: src/olympia/addons/templates/addons/impala/details.html:206 src/olympia/addons/templates/addons/impala/details.html:211 src/olympia/amo/helpers.py:398 src/olympia/devhub/forms.py:142
+#: src/olympia/devhub/forms.py:173 src/olympia/versions/templates/versions/version.html:40 src/olympia/versions/templates/versions/version.html:45
 msgid "Custom License"
 msgstr "Swójska licenca"
 
@@ -1470,38 +1103,23 @@ msgstr "Dospołnu wersijowu historiju pokazać"
 
 #: src/olympia/addons/templates/addons/impala/details.html:267
 msgid ""
-"The Development Channel lets you test an experimental new version of this "
-"add-on before it's released to the general public. Once you install the "
-"development version, you will continue to get updates from this channel. To "
-"stop receiving development updates, reinstall the default version from the "
-"link above."
+"The Development Channel lets you test an experimental new version of this add-on before it's released to the general public. Once you install the development version, you will continue to get "
+"updates from this channel. To stop receiving development updates, reinstall the default version from the link above."
 msgstr ""
-"Wuwiwarski kanal wam zmóžnja, nowu eksperimentalnu wersiju tutoho přidatka "
-"testować, prjedy hač so powšitkownej zjawnosći přewostaji. Hdyž wuwiwarsku "
-"wersiju instalujeće, budźeće dale aktualizacije z tutoho kanala dóstawać. Zo"
-" njebyšće hižo žane wuwiwarske aktualizacije dóstał, instalujće strandardnu "
-"wersiju z wotkaza horjeka."
+"Wuwiwarski kanal wam zmóžnja, nowu eksperimentalnu wersiju tutoho přidatka testować, prjedy hač so powšitkownej zjawnosći přewostaji. Hdyž wuwiwarsku wersiju instalujeće, budźeće dale aktualizacije "
+"z tutoho kanala dóstawać. Zo njebyšće hižo žane wuwiwarske aktualizacije dóstał, instalujće strandardnu wersiju z wotkaza horjeka."
 
 #: src/olympia/addons/templates/addons/impala/details.html:277
-msgid ""
-"<strong>Caution:</strong> Development versions of this add-on have not been "
-"reviewed by Mozilla."
-msgstr ""
-"<strong>Kedźbu:</strong> Wuwiwarske wersije tutoho přidatka njebuchu "
-"přepruwowane wot Mozilla."
+msgid "<strong>Caution:</strong> Development versions of this add-on have not been reviewed by Mozilla."
+msgstr "<strong>Kedźbu:</strong> Wuwiwarske wersije tutoho přidatka njebuchu přepruwowane wot Mozilla."
 
 #: src/olympia/addons/templates/addons/impala/details.html:292
 msgid "See complete development channel history"
 msgstr "Dospołnu historiju wuwiwarskeho kanala pokazać"
 
-#: src/olympia/addons/templates/addons/impala/details.html:311
-#: src/olympia/addons/templates/addons/impala/details.html:320
-#: src/olympia/addons/templates/addons/impala/details.html:332
-#: src/olympia/addons/templates/addons/impala/review_add_box.html:4
-#: src/olympia/stats/templates/stats/popup.html:2
-#: src/olympia/stats/templates/stats/popup.html:8
-#: src/olympia/stats/templates/stats/stats.html:202
-#: src/olympia/users/templates/users/profile.html:119
+#: src/olympia/addons/templates/addons/impala/details.html:311 src/olympia/addons/templates/addons/impala/details.html:320 src/olympia/addons/templates/addons/impala/details.html:332
+#: src/olympia/addons/templates/addons/impala/review_add_box.html:4 src/olympia/stats/templates/stats/popup.html:2 src/olympia/stats/templates/stats/popup.html:8
+#: src/olympia/stats/templates/stats/stats.html:204 src/olympia/users/templates/users/profile.html:119
 msgid "close"
 msgstr "začinić"
 
@@ -1516,12 +1134,8 @@ msgid "Meet the {0} Developer"
 msgstr "Zeznajće so z wuwiwarjom přidatka {0}"
 
 #: src/olympia/addons/templates/addons/impala/developers.html:41
-msgid ""
-"Before downloading this add-on, please consider supporting the development "
-"of this add-on by making a small contribution."
-msgstr ""
-"Prjedy hač tutón přidatk sćehnjeće, přemyslujće nad tym, hač chceće "
-"wuwiwanje tutoho přidatka přez mały přinošk podpěrać."
+msgid "Before downloading this add-on, please consider supporting the development of this add-on by making a small contribution."
+msgstr "Prjedy hač tutón přidatk sćehnjeće, přemyslujće nad tym, hač chceće wuwiwanje tutoho přidatka přez mały přinošk podpěrać."
 
 #: src/olympia/addons/templates/addons/impala/developers.html:80
 msgid "Why was {0} created?"
@@ -1539,9 +1153,7 @@ msgstr[1] "Wo wuwiwarjomaj"
 msgstr[2] "Wo wuwiwarjach"
 msgstr[3] "Wo wuwiwarjach"
 
-#: src/olympia/addons/templates/addons/impala/developers.html:96
-#: src/olympia/users/templates/users/edit.html:130
-#: src/olympia/users/templates/users/profile.html:26
+#: src/olympia/addons/templates/addons/impala/developers.html:96 src/olympia/users/templates/users/edit.html:130 src/olympia/users/templates/users/profile.html:26
 msgid "No Photo"
 msgstr "Žane foto"
 
@@ -1561,19 +1173,15 @@ msgstr "Tutón přidatk je so wot administratora znjemóžnił."
 msgid "Source Code License for {addon}"
 msgstr "Licenca žórłoweho koda za {addon}"
 
-#: src/olympia/addons/templates/addons/impala/license.html:21
-#: src/olympia/versions/templates/versions/mobile/version.html:18
+#: src/olympia/addons/templates/addons/impala/license.html:21 src/olympia/versions/templates/versions/mobile/version.html:18
 msgid "Source Code License"
 msgstr "Licenca žórłoweho koda"
 
-#: src/olympia/addons/templates/addons/impala/review_list_box.html:19
-#: src/olympia/reviews/templates/reviews/review.html:40
+#: src/olympia/addons/templates/addons/impala/review_list_box.html:19 src/olympia/reviews/templates/reviews/review.html:40
 msgid "permalink"
 msgstr "trajny wotkaz"
 
-#: src/olympia/addons/templates/addons/impala/review_list_box.html:23
-#: src/olympia/editors/templates/editors/queue.html:98
-#: src/olympia/reviews/templates/reviews/review.html:44
+#: src/olympia/addons/templates/addons/impala/review_list_box.html:23 src/olympia/editors/templates/editors/queue.html:104 src/olympia/reviews/templates/reviews/review.html:44
 msgid "translate"
 msgstr "přełožować"
 
@@ -1586,8 +1194,7 @@ msgstr[1] "%(cnt)s wužiwarskej pohódnoćeni pokazać"
 msgstr[2] "Wšitke %(cnt)s wužiwarske pohódnoćenja pokazać"
 msgstr[3] "Wšitkich %(cnt)s wužiwarskich pohódnoćenjow pokazać"
 
-#: src/olympia/addons/templates/addons/impala/review_list_box.html:47
-#: src/olympia/reviews/templates/reviews/review_list.html:84
+#: src/olympia/addons/templates/addons/impala/review_list_box.html:47 src/olympia/reviews/templates/reviews/review_list.html:84
 msgid "This add-on has not yet been reviewed."
 msgstr "Tutón přidatk njeje so hišće pohódnoćił."
 
@@ -1599,24 +1206,19 @@ msgstr "Budźće prěni!"
 msgid "{0} users"
 msgstr "{0} wužiwarjow"
 
-#: src/olympia/addons/templates/addons/impala/listing/sorter.html:14
-#: src/olympia/devhub/templates/devhub/addons/listing/item_actions.html:49
+#: src/olympia/addons/templates/addons/impala/listing/sorter.html:14 src/olympia/devhub/templates/devhub/addons/listing/item_actions.html:49
 msgid "More"
 msgstr "Wjace"
 
-#: src/olympia/addons/templates/addons/includes/collection_add_widget.html:7
-#: src/olympia/addons/templates/addons/includes/collection_add_widget.html:10
+#: src/olympia/addons/templates/addons/includes/collection_add_widget.html:7 src/olympia/addons/templates/addons/includes/collection_add_widget.html:10
 msgid "Add to collection"
 msgstr "Zběrce přidać"
 
-#: src/olympia/addons/templates/addons/includes/dashboard_tabs.html:4
-#: src/olympia/devhub/templates/devhub/index.html:73
-#: src/olympia/devhub/templates/devhub/nav.html:14
+#: src/olympia/addons/templates/addons/includes/dashboard_tabs.html:4 src/olympia/devhub/templates/devhub/index.html:73 src/olympia/devhub/templates/devhub/nav.html:14
 msgid "My Add-ons"
 msgstr "Moje přidatki"
 
-#: src/olympia/addons/templates/addons/includes/dashboard_tabs.html:6
-#: src/olympia/amo/context_processors.py:52
+#: src/olympia/addons/templates/addons/includes/dashboard_tabs.html:6 src/olympia/amo/context_processors.py:50
 msgid "My Themes"
 msgstr "Moje drasty"
 
@@ -1632,21 +1234,17 @@ msgstr "Drastu wobdźěłać"
 msgid "Approve / Reject"
 msgstr "Schwalić / Wotpokazać"
 
-#: src/olympia/addons/templates/addons/includes/persona.html:25
-#: src/olympia/editors/templates/editors/themes/single.html:43
+#: src/olympia/addons/templates/addons/includes/persona.html:25 src/olympia/editors/templates/editors/themes/single.html:43
 msgid "Review History"
 msgstr "Historija pohódnoćenjow"
 
 #: src/olympia/addons/templates/addons/includes/persona_pending_notice.html:3
 msgid "Sorry, this theme is pending. Please come back later."
-msgstr ""
-"Bohužel tuta drasta hišće na schwalenje čaka. Prošu přińdźće pozdźišo hišće "
-"raz."
+msgstr "Bohužel tuta drasta hišće na schwalenje čaka. Prošu přińdźće pozdźišo hišće raz."
 
 #: src/olympia/addons/templates/addons/includes/persona_pending_notice.html:8
 msgid "This theme is pending. It is invisible to everyone but you."
-msgstr ""
-"Tuta drasta hišće na schwalenje čaka. Je za wšěch nimo tebje njewidźomna."
+msgstr "Tuta drasta hišće na schwalenje čaka. Je za wšěch nimo tebje njewidźomna."
 
 #: src/olympia/addons/templates/addons/listing/items.html:29
 msgid "Collector's Note"
@@ -1657,9 +1255,7 @@ msgid "Not Yet Rated"
 msgstr "Hišće njepohódnoćeny"
 
 #. {0} is the number of downloads.
-#: src/olympia/addons/templates/addons/listing/items_mobile.html:27
-#: src/olympia/addons/templates/addons/listing/macros.html:24
-#: src/olympia/devhub/templates/devhub/addons/listing/macros.html:15
+#: src/olympia/addons/templates/addons/listing/items_mobile.html:27 src/olympia/addons/templates/addons/listing/macros.html:24 src/olympia/devhub/templates/devhub/addons/listing/macros.html:15
 msgid "<strong>{0}</strong> weekly download"
 msgid_plural "<strong>{0}</strong> weekly downloads"
 msgstr[0] "<strong>{0}</strong> tydźenske sćehnjenje"
@@ -1675,15 +1271,11 @@ msgstr "Dalše informacije"
 msgid "Users"
 msgstr "Wužiwarjo"
 
-#: src/olympia/addons/templates/addons/mobile/details.html:92
-#: src/olympia/browse/views.py:59 src/olympia/browse/views.py:70
-#: src/olympia/search/forms.py:90
+#: src/olympia/addons/templates/addons/mobile/details.html:92 src/olympia/browse/views.py:59 src/olympia/browse/views.py:70 src/olympia/search/forms.py:90
 msgid "Weekly Downloads"
 msgstr "Tydźenske sćehnjenja"
 
-#: src/olympia/addons/templates/addons/mobile/details.html:99
-#: src/olympia/compat/templates/compat/reporter_detail.html:46
-#: src/olympia/devhub/forms.py:779
+#: src/olympia/addons/templates/addons/mobile/details.html:99 src/olympia/compat/templates/compat/reporter_detail.html:46 src/olympia/devhub/forms.py:788
 #: src/olympia/devhub/templates/devhub/versions/list.html:163
 msgid "Version"
 msgstr "Wersija"
@@ -1719,49 +1311,29 @@ msgstr "Licencne dojednanje"
 
 #: src/olympia/addons/templates/addons/mobile/eula.html:5
 #, python-format
-msgid ""
-"%(name)s requires that you accept the following End-User License Agreement "
-"before installation can proceed:"
-msgstr ""
-"%(name)s sej žada, zo slědowace licencne dojednanje za kónčnych wužiwarjow "
-"(EULA) akceptujeće, prjedy hač z instalaciju pokročujeće:"
+msgid "%(name)s requires that you accept the following End-User License Agreement before installation can proceed:"
+msgstr "%(name)s sej žada, zo slědowace licencne dojednanje za kónčnych wužiwarjow (EULA) akceptujeće, prjedy hač z instalaciju pokročujeće:"
 
 #: src/olympia/addons/templates/addons/mobile/eula.html:15
 msgid "Accept"
 msgstr "Akceptować"
 
-#: src/olympia/addons/templates/addons/mobile/home.html:10
-#: src/olympia/templates/mobile/base_addons.html:53
+#: src/olympia/addons/templates/addons/mobile/home.html:10 src/olympia/templates/mobile/base_addons.html:53
 msgid "Add-ons are not currently available on Firefox for iOS."
 msgstr "Přidatki tuchwilu za Firefox za iOS k dispoziciji njejsu."
 
-#: src/olympia/addons/templates/addons/mobile/home.html:12
-#: src/olympia/templates/mobile/base_addons.html:55
-msgid ""
-"You need Firefox to install add-ons. <a "
-"href=\"http://mozilla.com/mobile\">Learn More&nbsp;&raquo;</a>"
-msgstr ""
-"Trjebaće Firefox, zo byšće přidatki instalował. <a "
-"href=\"http://mozilla.com/mobile\">Dalše informacije&nbsp;&raquo;</a>"
+#: src/olympia/addons/templates/addons/mobile/home.html:12 src/olympia/templates/mobile/base_addons.html:55
+msgid "You need Firefox to install add-ons. <a href=\"http://mozilla.com/mobile\">Learn More&nbsp;&raquo;</a>"
+msgstr "Trjebaće Firefox, zo byšće přidatki instalował. <a href=\"http://mozilla.com/mobile\">Dalše informacije&nbsp;&raquo;</a>"
 
-#: src/olympia/addons/templates/addons/mobile/home.html:19
-#: src/olympia/templates/header_title.html:4
-#: src/olympia/templates/impala/header_title.html:3
+#: src/olympia/addons/templates/addons/mobile/home.html:19 src/olympia/templates/header_title.html:4 src/olympia/templates/impala/header_title.html:3
 msgid "Return to the {0} Add-ons homepage"
 msgstr "Wróćo k startowej stronje přidatka {0}"
 
-#: src/olympia/addons/templates/addons/mobile/home.html:21
-#: src/olympia/amo/helpers.py:237
-#: src/olympia/bandwagon/templates/bandwagon/edit.html:34
-#: src/olympia/discovery/templates/discovery/pane.html:92
-#: src/olympia/editors/templates/editors/base.html:21
-#: src/olympia/editors/templates/editors/performance.html:72
-#: src/olympia/templates/menu_links.html:4
-#: src/olympia/templates/impala/header_title.html:13
-#: src/olympia/templates/impala/header_title.html:15
-#: src/olympia/templates/impala/header_title.html:19
-#: src/olympia/templates/impala/header_title.html:23
-#: src/olympia/templates/mobile/base_addons.html:47
+#: src/olympia/addons/templates/addons/mobile/home.html:21 src/olympia/amo/helpers.py:237 src/olympia/bandwagon/templates/bandwagon/edit.html:34 src/olympia/discovery/templates/discovery/pane.html:92
+#: src/olympia/editors/templates/editors/base.html:21 src/olympia/editors/templates/editors/performance.html:72 src/olympia/templates/menu_links.html:4
+#: src/olympia/templates/impala/header_title.html:13 src/olympia/templates/impala/header_title.html:15 src/olympia/templates/impala/header_title.html:19
+#: src/olympia/templates/impala/header_title.html:23 src/olympia/templates/mobile/base_addons.html:47
 msgid "Add-ons"
 msgstr "Přidatki"
 
@@ -1769,20 +1341,15 @@ msgstr "Přidatki"
 msgid "Easy ways to personalize."
 msgstr "Lochke přiměrjenje."
 
-#: src/olympia/addons/templates/addons/mobile/home.html:24
-#: src/olympia/devhub/templates/devhub/addons/submit/done.html:47
-#: src/olympia/discovery/templates/discovery/pane.html:34
-#: src/olympia/discovery/templates/discovery/addons/detail.html:16
-#: src/olympia/discovery/templates/discovery/modules/featured.html:21
-#: src/olympia/discovery/templates/discovery/modules/monthly.html:22
+#: src/olympia/addons/templates/addons/mobile/home.html:24 src/olympia/devhub/templates/devhub/addons/submit/done.html:47 src/olympia/discovery/templates/discovery/pane.html:34
+#: src/olympia/discovery/templates/discovery/addons/detail.html:16 src/olympia/discovery/templates/discovery/modules/featured.html:21 src/olympia/discovery/templates/discovery/modules/monthly.html:22
 msgid "Learn More"
 msgstr "Dalše informacije"
 
 #: src/olympia/addons/templates/addons/mobile/home.html:26
 msgid ""
-"Add-ons are applications that let you personalize Firefox with extra "
-"functionality and style. Whether you mistype the name of a website or can't "
-"read a busy page, there's an add-on to improve your on-the-go browsing."
+"Add-ons are applications that let you personalize Firefox with extra functionality and style. Whether you mistype the name of a website or can't read a busy page, there's an add-on to improve your "
+"on-the-go browsing."
 msgstr ""
 "Přidatki su nałoženja, kotrež wam zmóžnjeja, Firefox z přidatnej "
 "funkcionalnosću a přidatnym stilom přiměrić. Hač mjeno websydła wopak pisaće"
@@ -1791,26 +1358,13 @@ msgstr ""
 
 #. {0} is a category name. Ex: "Sports"
 #. {0} is a category name, such as Nature.
-#: src/olympia/addons/templates/addons/mobile/home.html:43
-#: src/olympia/amo/templates/amo/site_nav.html:32
-#: src/olympia/browse/feeds.py:107
-#: src/olympia/browse/templates/browse/impala/base_listing.html:38
-#: src/olympia/browse/templates/browse/personas/base.html:6
-#: src/olympia/browse/templates/browse/personas/base.html:42
-#: src/olympia/browse/templates/browse/personas/category_landing.html:21
-#: src/olympia/browse/templates/browse/personas/category_landing.html:23
-#: src/olympia/browse/templates/browse/personas/category_landing.html:38
-#: src/olympia/browse/templates/browse/personas/grid.html:7
-#: src/olympia/browse/templates/browse/personas/grid.html:11
-#: src/olympia/browse/templates/browse/personas/mobile/base.html:7
-#: src/olympia/browse/templates/browse/personas/mobile/category_landing.html:19
-#: src/olympia/constants/base.py:180
-#: src/olympia/devhub/templates/devhub/personas/submit.html:13
-#: src/olympia/editors/helpers.py:107
-#: src/olympia/editors/templates/editors/base.html:26
-#: src/olympia/editors/templates/editors/performance.html:73
-#: src/olympia/search/templates/search/personas.html:39
-#: src/olympia/templates/menu_links.html:9
+#: src/olympia/addons/templates/addons/mobile/home.html:43 src/olympia/amo/templates/amo/site_nav.html:32 src/olympia/browse/feeds.py:107
+#: src/olympia/browse/templates/browse/impala/base_listing.html:38 src/olympia/browse/templates/browse/personas/base.html:6 src/olympia/browse/templates/browse/personas/base.html:42
+#: src/olympia/browse/templates/browse/personas/category_landing.html:21 src/olympia/browse/templates/browse/personas/category_landing.html:23
+#: src/olympia/browse/templates/browse/personas/category_landing.html:38 src/olympia/browse/templates/browse/personas/grid.html:7 src/olympia/browse/templates/browse/personas/grid.html:11
+#: src/olympia/browse/templates/browse/personas/mobile/base.html:7 src/olympia/browse/templates/browse/personas/mobile/category_landing.html:19 src/olympia/constants/base.py:180
+#: src/olympia/devhub/templates/devhub/personas/submit.html:13 src/olympia/editors/helpers.py:107 src/olympia/editors/templates/editors/base.html:26
+#: src/olympia/editors/templates/editors/performance.html:73 src/olympia/search/templates/search/personas.html:39 src/olympia/templates/menu_links.html:9
 msgid "Themes"
 msgstr "Drasty"
 
@@ -1826,19 +1380,12 @@ msgstr "Wšě woblubowane přidatki pokazać"
 msgid "More Add-ons"
 msgstr "Dalše přidatki"
 
-#: src/olympia/addons/templates/addons/mobile/home.html:72
-#: src/olympia/browse/templates/browse/personas/mobile/category_landing.html:64
-#: src/olympia/search/forms.py:14
+#: src/olympia/addons/templates/addons/mobile/home.html:72 src/olympia/browse/templates/browse/personas/mobile/category_landing.html:64 src/olympia/search/forms.py:14
 msgid "Highest Rated"
 msgstr "Najwyše pohódnoćene"
 
-#: src/olympia/addons/templates/addons/mobile/home.html:74
-#: src/olympia/amo/templates/amo/side_nav.html:5
-#: src/olympia/amo/templates/amo/site_nav.html:27
-#: src/olympia/amo/templates/amo/site_nav.html:55
-#: src/olympia/bandwagon/views.py:97 src/olympia/browse/views.py:57
-#: src/olympia/browse/views.py:67
-#: src/olympia/browse/templates/browse/personas/mobile/category_landing.html:65
+#: src/olympia/addons/templates/addons/mobile/home.html:74 src/olympia/amo/templates/amo/side_nav.html:5 src/olympia/amo/templates/amo/site_nav.html:27 src/olympia/amo/templates/amo/site_nav.html:55
+#: src/olympia/bandwagon/views.py:97 src/olympia/browse/views.py:57 src/olympia/browse/views.py:67 src/olympia/browse/templates/browse/personas/mobile/category_landing.html:65
 #: src/olympia/search/forms.py:15 src/olympia/search/forms.py:87
 msgid "Newest"
 msgstr "Najnowše"
@@ -1851,81 +1398,60 @@ msgstr "Wupruwujće jón!"
 msgid "Theme Info &raquo;"
 msgstr "Informacije wo drasće &raquo;"
 
-#: src/olympia/amo/context_processors.py:39
-#: src/olympia/devhub/templates/devhub/nav.html:43
+#: src/olympia/amo/context_processors.py:37 src/olympia/devhub/templates/devhub/nav.html:43
 msgid "Tools"
 msgstr "Nastroje"
 
-#: src/olympia/amo/context_processors.py:49
-#: src/olympia/discovery/templates/discovery/pane_account.html:8
-#: src/olympia/users/templates/users/includes/navigation.html:2
+#: src/olympia/amo/context_processors.py:47 src/olympia/discovery/templates/discovery/pane_account.html:8 src/olympia/users/templates/users/includes/navigation.html:2
 msgid "My Profile"
 msgstr "Mój profil"
 
-#: src/olympia/amo/context_processors.py:55
-#: src/olympia/users/templates/users/edit.html:5
-#: src/olympia/users/templates/users/includes/navigation.html:3
+#: src/olympia/amo/context_processors.py:53 src/olympia/users/templates/users/edit.html:5 src/olympia/users/templates/users/includes/navigation.html:3
 msgid "Account Settings"
 msgstr "Kontowe nastajenja"
 
-#: src/olympia/amo/context_processors.py:58
-#: src/olympia/discovery/templates/discovery/pane_account.html:11
-#: src/olympia/users/templates/users/profile.html:83
+#: src/olympia/amo/context_processors.py:56 src/olympia/discovery/templates/discovery/pane_account.html:11 src/olympia/users/templates/users/profile.html:83
 #: src/olympia/users/templates/users/includes/navigation.html:4
 msgid "My Collections"
 msgstr "Moje zběrki"
 
-#: src/olympia/amo/context_processors.py:63
-#: src/olympia/discovery/templates/discovery/pane_account.html:10
-#: src/olympia/users/templates/users/includes/navigation.html:7
+#: src/olympia/amo/context_processors.py:61 src/olympia/discovery/templates/discovery/pane_account.html:10 src/olympia/users/templates/users/includes/navigation.html:7
 msgid "My Favorites"
 msgstr "Moje fawority"
 
-#: src/olympia/amo/context_processors.py:68
-#: src/olympia/discovery/templates/discovery/pane_account.html:13
-#: src/olympia/templates/impala/user_login.html:14
+#: src/olympia/amo/context_processors.py:66 src/olympia/discovery/templates/discovery/pane_account.html:13 src/olympia/templates/impala/user_login.html:14
 #: src/olympia/templates/mobile/header_auth.html:5
 msgid "Log out"
 msgstr "Wotzjewić"
 
-#: src/olympia/amo/context_processors.py:73
-#: src/olympia/devhub/templates/devhub/addons/dashboard.html:4
+#: src/olympia/amo/context_processors.py:71 src/olympia/devhub/templates/devhub/addons/dashboard.html:4
 msgid "Manage My Submissions"
 msgstr "Moje zapodaća rjadować"
 
-#: src/olympia/amo/context_processors.py:76
-#: src/olympia/devhub/templates/devhub/nav.html:27
-#: src/olympia/devhub/templates/devhub/addons/dashboard.html:25
+#: src/olympia/amo/context_processors.py:74 src/olympia/devhub/templates/devhub/nav.html:27 src/olympia/devhub/templates/devhub/addons/dashboard.html:25
 #: src/olympia/devhub/templates/devhub/addons/submit/base.html:4
 msgid "Submit a New Add-on"
 msgstr "Nowy přidatk zapodać"
 
-#: src/olympia/amo/context_processors.py:78
-#: src/olympia/browse/templates/browse/personas/base.html:50
-#: src/olympia/devhub/templates/devhub/index.html:24
+#: src/olympia/amo/context_processors.py:76 src/olympia/browse/templates/browse/personas/base.html:50 src/olympia/devhub/templates/devhub/index.html:24
 #: src/olympia/devhub/templates/devhub/addons/dashboard.html:29
 msgid "Submit a New Theme"
 msgstr "Nowu drastu zapodać"
 
-#: src/olympia/amo/context_processors.py:80
-#: src/olympia/amo/templates/amo/site_nav.html:85
-#: src/olympia/devhub/helpers.py:36 src/olympia/devhub/helpers.py:68
-#: src/olympia/devhub/helpers.py:102 src/olympia/templates/footer.html:6
-#: src/olympia/templates/menu_links.html:14
+#: src/olympia/amo/context_processors.py:78 src/olympia/amo/templates/amo/site_nav.html:85 src/olympia/devhub/helpers.py:36 src/olympia/devhub/helpers.py:68 src/olympia/devhub/helpers.py:102
+#: src/olympia/templates/footer.html:6 src/olympia/templates/menu_links.html:14
 msgid "Developer Hub"
 msgstr "Wuwiwarski róžk"
 
-#: src/olympia/amo/context_processors.py:84 src/olympia/devhub/views.py:1795
+#: src/olympia/amo/context_processors.py:81 src/olympia/devhub/views.py:1796
 msgid "Manage API Keys"
 msgstr "API-kluče rjadować"
 
-#: src/olympia/amo/context_processors.py:89 src/olympia/editors/helpers.py:84
-#: src/olympia/editors/helpers.py:104
-#: src/olympia/editors/templates/editors/base.html:10
+#: src/olympia/amo/context_processors.py:86 src/olympia/editors/helpers.py:84 src/olympia/editors/helpers.py:104 src/olympia/editors/templates/editors/base.html:10
 msgid "Editor Tools"
 msgstr "Nastroje redaktora"
 
-#: src/olympia/amo/context_processors.py:93
+#: src/olympia/amo/context_processors.py:90
 msgid "Admin Tools"
 msgstr "Administratorowe nastroje"
 
@@ -1945,28 +1471,17 @@ msgstr "To dyrbi płaćiwy heksadecimalny barbowy kod być, na přikład #000000
 msgid "Enter at least one value."
 msgstr "Zapodajće znajmjeńša jednu hódnotu."
 
-#: src/olympia/amo/helpers.py:162
-#: src/olympia/amo/templates/amo/site_nav.html:59
-#: src/olympia/bandwagon/templates/bandwagon/add.html:9
-#: src/olympia/bandwagon/templates/bandwagon/collection_detail.html:15
-#: src/olympia/bandwagon/templates/bandwagon/delete.html:9
-#: src/olympia/bandwagon/templates/bandwagon/edit.html:15
-#: src/olympia/bandwagon/templates/bandwagon/user_listing.html:18
-#: src/olympia/bandwagon/templates/bandwagon/user_listing.html:21
-#: src/olympia/bandwagon/templates/bandwagon/impala/collection_listing.html:12
-#: src/olympia/bandwagon/templates/bandwagon/impala/collection_listing.html:20
-#: src/olympia/bandwagon/templates/bandwagon/impala/collection_listing.html:24
-#: src/olympia/bandwagon/templates/bandwagon/impala/collection_sidebar.html:3
-#: src/olympia/bandwagon/templates/bandwagon/includes/collection_sidebar.html:2
-#: src/olympia/bandwagon/templates/bandwagon/mobile/collection_listing.html:3
-#: src/olympia/stats/templates/stats/stats.html:77
-#: src/olympia/templates/menu_links.html:12
+#: src/olympia/amo/helpers.py:162 src/olympia/amo/templates/amo/site_nav.html:59 src/olympia/bandwagon/templates/bandwagon/add.html:9
+#: src/olympia/bandwagon/templates/bandwagon/collection_detail.html:15 src/olympia/bandwagon/templates/bandwagon/delete.html:9 src/olympia/bandwagon/templates/bandwagon/edit.html:15
+#: src/olympia/bandwagon/templates/bandwagon/user_listing.html:18 src/olympia/bandwagon/templates/bandwagon/user_listing.html:21
+#: src/olympia/bandwagon/templates/bandwagon/impala/collection_listing.html:12 src/olympia/bandwagon/templates/bandwagon/impala/collection_listing.html:20
+#: src/olympia/bandwagon/templates/bandwagon/impala/collection_listing.html:24 src/olympia/bandwagon/templates/bandwagon/impala/collection_sidebar.html:3
+#: src/olympia/bandwagon/templates/bandwagon/includes/collection_sidebar.html:2 src/olympia/bandwagon/templates/bandwagon/mobile/collection_listing.html:3
+#: src/olympia/stats/templates/stats/stats.html:33 src/olympia/templates/menu_links.html:12
 msgid "Collections"
 msgstr "Zběrki"
 
-#: src/olympia/amo/helpers.py:171
-#: src/olympia/amo/templates/amo/site_nav.html:83
-#: src/olympia/browse/templates/browse/language_tools.html:3
+#: src/olympia/amo/helpers.py:171 src/olympia/amo/templates/amo/site_nav.html:83 src/olympia/browse/templates/browse/language_tools.html:3
 msgid "Dictionaries & Language Packs"
 msgstr "Słowniki a rěčne pakćiki"
 
@@ -2118,11 +1633,8 @@ msgstr "Superpřepruwowanje je požadane"
 msgid "Comment on {addon} {version}."
 msgstr "Komentar k přidatkej {addon} {version}."
 
-#: src/olympia/amo/log.py:236
-#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:19
-#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:47
-#: src/olympia/editors/helpers.py:580
-#: src/olympia/editors/templates/editors/themes/history_table.html:11
+#: src/olympia/amo/log.py:236 src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:17 src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:45
+#: src/olympia/editors/helpers.py:584 src/olympia/editors/templates/editors/themes/history_table.html:11
 msgid "Comment"
 msgstr "Komentar"
 
@@ -2381,10 +1893,7 @@ msgstr ""
 msgid "{addon} unlisted."
 msgstr ""
 
-#: src/olympia/amo/log.py:592 src/olympia/amo/log.py:598
-#: src/olympia/amo/log.py:612 src/olympia/amo/log.py:618
-#: src/olympia/amo/log.py:624 src/olympia/amo/log.py:630
-#: src/olympia/amo/log.py:636
+#: src/olympia/amo/log.py:592 src/olympia/amo/log.py:598 src/olympia/amo/log.py:612 src/olympia/amo/log.py:618 src/olympia/amo/log.py:624 src/olympia/amo/log.py:630 src/olympia/amo/log.py:636
 msgid "{file} was signed."
 msgstr ""
 
@@ -2398,15 +1907,11 @@ msgid "Not allowed"
 msgstr ""
 
 #: src/olympia/amo/templates/amo/403.html:7
-msgid ""
-"<h1>Oops! Not allowed.</h1> <p>You tried to do something that you weren't "
-"allowed to.</p>"
+msgid "<h1>Oops! Not allowed.</h1> <p>You tried to do something that you weren't allowed to.</p>"
 msgstr ""
 
 #: src/olympia/amo/templates/amo/403.html:12
-msgid ""
-"<p>Try going back to the previous page, refreshing and then trying "
-"again.</p>"
+msgid "<p>Try going back to the previous page, refreshing and then trying again.</p>"
 msgstr ""
 
 #: src/olympia/amo/templates/amo/404.html:3
@@ -2416,20 +1921,12 @@ msgstr ""
 #: src/olympia/amo/templates/amo/404.html:6
 #, python-format
 msgid ""
-"<h1>We're sorry, but we can't find what you're looking for.</h1> <p> The "
-"page or file you requested wasn't found on our site. It's possible that you "
-"clicked a link that's out of date, or typed in the address incorrectly. </p>"
-" <ul> <li>If you typed in the address, please double check the "
-"spelling.</li> <li> If you followed a link from somewhere, please let us "
-"know at <a href=\"mailto:webmaster@mozilla.com\">webmaster@mozilla.com</a>. "
-"Tell us where you came from and what you were looking for, and we'll do our "
-"best to fix it. </li> </ul> <p>Or you can just jump over to some of the "
-"popular pages on our website.</p> <ul> <li>Are you interested in a <a "
-"href=\"%(rec)s\">list of featured add-ons</a>?</li> <li> Do you want to <a "
-"href=\"%(search)s\">search for add-ons</a>? You may go to the <a "
-"href=\"%(search)s\">search page</a> or just use the search field above. "
-"</li> <li> If you prefer to start over, just go to the <a href=\"%(home)s"
-"\">add-ons front page</a>. </li> </ul>"
+"<h1>We're sorry, but we can't find what you're looking for.</h1> <p> The page or file you requested wasn't found on our site. It's possible that you clicked a link that's out of date, or typed in "
+"the address incorrectly. </p> <ul> <li>If you typed in the address, please double check the spelling.</li> <li> If you followed a link from somewhere, please let us know at <a href=\"mailto:"
+"webmaster@mozilla.com\">webmaster@mozilla.com</a>. Tell us where you came from and what you were looking for, and we'll do our best to fix it. </li> </ul> <p>Or you can just jump over to some of "
+"the popular pages on our website.</p> <ul> <li>Are you interested in a <a href=\"%(rec)s\">list of featured add-ons</a>?</li> <li> Do you want to <a href=\"%(search)s\">search for add-ons</a>? You "
+"may go to the <a href=\"%(search)s\">search page</a> or just use the search field above. </li> <li> If you prefer to start over, just go to the <a href=\"%(home)s\">add-ons front page</a>. </li> </"
+"ul>"
 msgstr ""
 
 #: src/olympia/amo/templates/amo/500.html:3
@@ -2438,72 +1935,48 @@ msgstr ""
 
 #: src/olympia/amo/templates/amo/500.html:6
 #, python-format
-msgid ""
-"<h1>Oops!  We had an error.</h1> <p>We'll get to fixing that soon.</p> <p> "
-"You can try refreshing the page, or head back to the <a href=\"%(home)s"
-"\">Add-ons homepage</a>. </p>"
+msgid "<h1>Oops!  We had an error.</h1> <p>We'll get to fixing that soon.</p> <p> You can try refreshing the page, or head back to the <a href=\"%(home)s\">Add-ons homepage</a>. </p>"
 msgstr ""
 
 #: src/olympia/amo/templates/amo/license_link.html:10
 msgid "Some rights reserved"
 msgstr ""
 
-#: src/olympia/amo/templates/amo/no_results.html:1
-#: src/olympia/editors/templates/editors/includes/search_results_themes.html:26
+#: src/olympia/amo/templates/amo/no_results.html:1 src/olympia/editors/templates/editors/includes/search_results_themes.html:26
 msgid "No results found"
 msgstr ""
 
 #. abbreviation of 'previous'
-#: src/olympia/amo/templates/amo/paginator.html:6
-#: src/olympia/amo/templates/amo/mobile/paginator.html:4
-#: src/olympia/amo/templates/amo/mobile/paginator.html:6
-#: src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:49
-#: src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:63
-#: src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:76
-#: src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:89
+#: src/olympia/amo/templates/amo/paginator.html:6 src/olympia/amo/templates/amo/mobile/paginator.html:4 src/olympia/amo/templates/amo/mobile/paginator.html:6
+#: src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:49 src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:63
+#: src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:76 src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:89
 #: src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:102
 msgid "Prev"
 msgstr ""
 
-#: src/olympia/amo/templates/amo/paginator.html:26
-#: src/olympia/amo/templates/amo/impala/paginator.html:26
-#: src/olympia/amo/templates/amo/mobile/impala_paginator.html:16
-#: src/olympia/amo/templates/amo/mobile/paginator.html:14
-#: src/olympia/amo/templates/amo/mobile/paginator.html:16
-#: src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:51
-#: src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:65
-#: src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:78
-#: src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:91
-#: src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:104
-#: src/olympia/discovery/templates/discovery/pane.html:45
-#: src/olympia/discovery/templates/discovery/addons/detail.html:39
-#: src/olympia/stats/templates/stats/stats.html:167
+#: src/olympia/amo/templates/amo/paginator.html:26 src/olympia/amo/templates/amo/impala/paginator.html:26 src/olympia/amo/templates/amo/mobile/impala_paginator.html:16
+#: src/olympia/amo/templates/amo/mobile/paginator.html:14 src/olympia/amo/templates/amo/mobile/paginator.html:16 src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:51
+#: src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:65 src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:78
+#: src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:91 src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:104
+#: src/olympia/discovery/templates/discovery/pane.html:45 src/olympia/discovery/templates/discovery/addons/detail.html:39 src/olympia/stats/templates/stats/stats.html:169
 msgid "Next"
 msgstr ""
 
-#: src/olympia/amo/templates/amo/paginator.html:32
-#: src/olympia/editors/templates/editors/includes/paginator_history.html:11
+#: src/olympia/amo/templates/amo/paginator.html:32 src/olympia/editors/templates/editors/includes/paginator_history.html:11
 #, python-format
-msgid ""
-"Results <strong>%(begin)s</strong>&ndash;<strong>%(end)s</strong> of "
-"<strong>%(count)s</strong>"
+msgid "Results <strong>%(begin)s</strong>&ndash;<strong>%(end)s</strong> of <strong>%(count)s</strong>"
 msgstr ""
 
-#: src/olympia/amo/templates/amo/read-only.html:3
-#: src/olympia/amo/templates/amo/read-only.html:7
+#: src/olympia/amo/templates/amo/read-only.html:3 src/olympia/amo/templates/amo/read-only.html:7
 msgid "Maintenance in progress"
 msgstr ""
 
 #: src/olympia/amo/templates/amo/read-only.html:9
-msgid ""
-"This feature is temporarily disabled while we perform website maintenance. "
-"Please use your browser's Back button and try again a little later."
+msgid "This feature is temporarily disabled while we perform website maintenance. Please use your browser's Back button and try again a little later."
 msgstr ""
 
 #: src/olympia/amo/templates/amo/read-only.html:14
-msgid ""
-"Some features on this page are temporarily disabled while we perform website"
-" maintenance. Please try again a little later."
+msgid "Some features on this page are temporarily disabled while we perform website maintenance. Please try again a little later."
 msgstr ""
 
 #: src/olympia/amo/templates/amo/recaptcha.html:4
@@ -2512,20 +1985,12 @@ msgstr ""
 
 #: src/olympia/amo/templates/amo/recaptcha.html:8
 msgid ""
-"<p> Please enter <strong>all the words</strong> below, <strong>separated by "
-"a space if necessary</strong>. </p> <p> If this is hard to read, you can <a "
-"href=\"#\" id=\"recaptcha_different\">try different words</a> or <a "
-"href=\"#\" id=\"recaptcha_audio\">try a different type of challenge</a> "
-"instead. </p>"
+"<p> Please enter <strong>all the words</strong> below, <strong>separated by a space if necessary</strong>. </p> <p> If this is hard to read, you can <a href=\"#\" id=\"recaptcha_different\">try "
+"different words</a> or <a href=\"#\" id=\"recaptcha_audio\">try a different type of challenge</a> instead. </p>"
 msgstr ""
 
-#: src/olympia/amo/templates/amo/side_nav.html:4
-#: src/olympia/amo/templates/amo/side_nav.html:12
-#: src/olympia/amo/templates/amo/site_nav.html:4
-#: src/olympia/amo/templates/amo/site_nav.html:26
-#: src/olympia/browse/views.py:56 src/olympia/browse/views.py:66
-#: src/olympia/browse/views.py:237 src/olympia/browse/views.py:282
-#: src/olympia/search/forms.py:86
+#: src/olympia/amo/templates/amo/side_nav.html:4 src/olympia/amo/templates/amo/side_nav.html:12 src/olympia/amo/templates/amo/site_nav.html:4 src/olympia/amo/templates/amo/site_nav.html:26
+#: src/olympia/browse/views.py:56 src/olympia/browse/views.py:66 src/olympia/browse/views.py:204 src/olympia/browse/views.py:249 src/olympia/search/forms.py:86
 msgid "Top Rated"
 msgstr ""
 
@@ -2533,12 +1998,8 @@ msgstr ""
 msgid "Explore"
 msgstr ""
 
-#: src/olympia/amo/templates/amo/site_nav.html:23
-#: src/olympia/browse/feeds.py:65 src/olympia/browse/feeds.py:78
-#: src/olympia/browse/feeds.py:92 src/olympia/browse/feeds.py:100
-#: src/olympia/browse/templates/browse/base_listing.html:7
-#: src/olympia/browse/templates/browse/creatured.html:10
-#: src/olympia/browse/templates/browse/impala/base_listing.html:37
+#: src/olympia/amo/templates/amo/site_nav.html:23 src/olympia/browse/feeds.py:65 src/olympia/browse/feeds.py:78 src/olympia/browse/feeds.py:92 src/olympia/browse/feeds.py:100
+#: src/olympia/browse/templates/browse/base_listing.html:7 src/olympia/browse/templates/browse/creatured.html:10 src/olympia/browse/templates/browse/impala/base_listing.html:37
 #: src/olympia/constants/base.py:173 src/olympia/templates/menu_links.html:8
 msgid "Extensions"
 msgstr ""
@@ -2547,28 +2008,22 @@ msgstr ""
 msgid "Want more customization? Try <b>Complete Themes</b>"
 msgstr ""
 
-#: src/olympia/amo/templates/amo/site_nav.html:54
-#: src/olympia/bandwagon/views.py:96
+#: src/olympia/amo/templates/amo/site_nav.html:54 src/olympia/bandwagon/views.py:96
 msgid "Most Followers"
 msgstr ""
 
-#: src/olympia/amo/templates/amo/site_nav.html:66
-#: src/olympia/bandwagon/templates/bandwagon/impala/collection_sidebar.html:16
+#: src/olympia/amo/templates/amo/site_nav.html:66 src/olympia/bandwagon/templates/bandwagon/impala/collection_sidebar.html:16
 #: src/olympia/bandwagon/templates/bandwagon/includes/collection_sidebar.html:18
 msgid "Collections I've Made"
 msgstr ""
 
-#: src/olympia/amo/templates/amo/site_nav.html:68
-#: src/olympia/bandwagon/templates/bandwagon/user_listing.html:4
-#: src/olympia/bandwagon/templates/bandwagon/impala/collection_sidebar.html:13
+#: src/olympia/amo/templates/amo/site_nav.html:68 src/olympia/bandwagon/templates/bandwagon/user_listing.html:4 src/olympia/bandwagon/templates/bandwagon/impala/collection_sidebar.html:13
 #: src/olympia/bandwagon/templates/bandwagon/includes/collection_sidebar.html:15
 msgid "Collections I'm Following"
 msgstr ""
 
-#: src/olympia/amo/templates/amo/site_nav.html:71
-#: src/olympia/bandwagon/templates/bandwagon/impala/collection_sidebar.html:18
-#: src/olympia/bandwagon/templates/bandwagon/includes/collection_sidebar.html:20
-#: src/olympia/users/models.py:521
+#: src/olympia/amo/templates/amo/site_nav.html:71 src/olympia/bandwagon/templates/bandwagon/impala/collection_sidebar.html:18
+#: src/olympia/bandwagon/templates/bandwagon/includes/collection_sidebar.html:20 src/olympia/users/models.py:521
 msgid "My Favorite Add-ons"
 msgstr ""
 
@@ -2580,32 +2035,23 @@ msgstr ""
 msgid "Add-ons for Mobile"
 msgstr ""
 
-#: src/olympia/amo/templates/amo/site_nav.html:84
-#: src/olympia/browse/feeds.py:207
-#: src/olympia/browse/templates/browse/search_tools.html:3
-#: src/olympia/constants/base.py:176 src/olympia/templates/menu_links.html:10
+#: src/olympia/amo/templates/amo/site_nav.html:84 src/olympia/browse/feeds.py:207 src/olympia/browse/templates/browse/search_tools.html:3 src/olympia/constants/base.py:176
+#: src/olympia/templates/menu_links.html:10
 msgid "Search Tools"
 msgstr ""
 
 #. This is a page range (e.g., Page 1 of 50).
-#: src/olympia/amo/templates/amo/impala/paginator.html:5
-#: src/olympia/amo/templates/amo/mobile/impala_paginator.html:26
+#: src/olympia/amo/templates/amo/impala/paginator.html:5 src/olympia/amo/templates/amo/mobile/impala_paginator.html:26
 #, python-format
-msgid ""
-"Page <a href=\"%(current_pg_url)s\">%(current_pg)s</a> of <a "
-"href=\"%(last_pg_url)s\">%(last_pg)s</a>"
+msgid "Page <a href=\"%(current_pg_url)s\">%(current_pg)s</a> of <a href=\"%(last_pg_url)s\">%(last_pg)s</a>"
 msgstr ""
 
-#: src/olympia/amo/templates/amo/impala/paginator.html:16
-#: src/olympia/amo/templates/amo/mobile/impala_paginator.html:6
+#: src/olympia/amo/templates/amo/impala/paginator.html:16 src/olympia/amo/templates/amo/mobile/impala_paginator.html:6
 msgid "Jump to first page"
 msgstr ""
 
-#: src/olympia/amo/templates/amo/impala/paginator.html:22
-#: src/olympia/amo/templates/amo/mobile/impala_paginator.html:12
-#: src/olympia/discovery/templates/discovery/pane.html:44
-#: src/olympia/discovery/templates/discovery/addons/detail.html:38
-#: src/olympia/stats/templates/stats/stats.html:164
+#: src/olympia/amo/templates/amo/impala/paginator.html:22 src/olympia/amo/templates/amo/mobile/impala_paginator.html:12 src/olympia/discovery/templates/discovery/pane.html:44
+#: src/olympia/discovery/templates/discovery/addons/detail.html:38 src/olympia/stats/templates/stats/stats.html:166
 msgid "Previous"
 msgstr ""
 
@@ -2615,11 +2061,9 @@ msgstr ""
 
 #. First and second arguments are the result range (e.g., 1-20);
 #. third argument is the number of total results (e.g., 1,000).
-#. First and second arguments are the result range (e.g., 1-20);
-#. third
+#. First and second arguments are the result range (e.g., 1-20);              third
 #. argument is the number of total results (e.g., 1,000).
-#: src/olympia/amo/templates/amo/impala/paginator.html:36
-#: src/olympia/amo/templates/amo/mobile/impala_paginator.html:38
+#: src/olympia/amo/templates/amo/impala/paginator.html:36 src/olympia/amo/templates/amo/mobile/impala_paginator.html:38
 #, python-format
 msgid "Showing <b>%(begin)s</b>&ndash;<b>%(end)s</b> of <b>%(count)s</b>"
 msgstr ""
@@ -2632,16 +2076,12 @@ msgstr[1] ""
 msgstr[2] ""
 msgstr[3] ""
 
-#: src/olympia/amo/tests/test_messages.py:56
-#: src/olympia/amo/tests/test_messages.py:57 src/olympia/reviews/forms.py:25
-#: src/olympia/reviews/forms.py:50
-#: src/olympia/reviews/templates/reviews/add.html:56
+#: src/olympia/amo/tests/test_messages.py:56 src/olympia/amo/tests/test_messages.py:57 src/olympia/reviews/forms.py:25 src/olympia/reviews/forms.py:50 src/olympia/reviews/templates/reviews/add.html:56
 #: src/olympia/reviews/templates/reviews/reply.html:30
 msgid "Title"
 msgstr ""
 
-#: src/olympia/amo/tests/test_messages.py:56
-#: src/olympia/amo/tests/test_messages.py:57
+#: src/olympia/amo/tests/test_messages.py:56 src/olympia/amo/tests/test_messages.py:57
 msgid "Body"
 msgstr ""
 
@@ -2670,8 +2110,7 @@ msgid "Invalid Authorization header. No credentials provided."
 msgstr ""
 
 #: src/olympia/api/authentication.py:133
-msgid ""
-"Invalid Authorization header. Credentials string should not contain spaces."
+msgid "Invalid Authorization header. Credentials string should not contain spaces."
 msgstr ""
 
 #: src/olympia/api/fields.py:29
@@ -2682,8 +2121,7 @@ msgstr ""
 msgid "The language code {lang_code} is invalid."
 msgstr ""
 
-#: src/olympia/applications/views.py:39
-#: src/olympia/applications/templates/applications/appversions.html:3
+#: src/olympia/applications/views.py:39 src/olympia/applications/templates/applications/appversions.html:3
 msgid "Application Versions"
 msgstr ""
 
@@ -2696,20 +2134,15 @@ msgid "Valid Application Versions"
 msgstr ""
 
 #: src/olympia/applications/templates/applications/appversions.html:12
-msgid ""
-"Add-ons submitted to Mozilla Add-ons must have a manifest file with at least"
-" one of the below applications supported. Only the versions listed below are"
-" allowed for these applications."
+msgid "Add-ons submitted to Mozilla Add-ons must have a manifest file with at least one of the below applications supported. Only the versions listed below are allowed for these applications."
 msgstr ""
 
-#: src/olympia/applications/templates/applications/appversions.html:25
-#: src/olympia/editors/helpers.py:361
+#: src/olympia/applications/templates/applications/appversions.html:25 src/olympia/editors/helpers.py:361
 msgid "GUID"
 msgstr ""
 
 #. {0} is an add-on name.
-#: src/olympia/applications/templates/applications/appversions.html:26
-#: src/olympia/versions/templates/versions/version_list.html:23
+#: src/olympia/applications/templates/applications/appversions.html:26 src/olympia/versions/templates/versions/version_list.html:23
 msgid "Versions"
 msgstr ""
 
@@ -2719,10 +2152,7 @@ msgstr ""
 
 #: src/olympia/applications/templates/applications/appversions.html:31
 #, python-format
-msgid ""
-"If your supported application does not require a manifest file, you still "
-"must include one with the required properties as specified <a "
-"href=\"%(url)s\">here</a>."
+msgid "If your supported application does not require a manifest file, you still must include one with the required properties as specified <a href=\"%(url)s\">here</a>."
 msgstr ""
 
 #. L10n: {0} is 'Add-ons for <app>'.
@@ -2731,10 +2161,8 @@ msgstr ""
 msgid "Collections :: %s"
 msgstr ""
 
-#: src/olympia/bandwagon/feeds.py:50
-#: src/olympia/bandwagon/templates/bandwagon/collection_detail.html:137
-msgid ""
-"Collections are groups of related add-ons that anyone can create and share."
+#: src/olympia/bandwagon/feeds.py:50 src/olympia/bandwagon/templates/bandwagon/collection_detail.html:137
+msgid "Collections are groups of related add-ons that anyone can create and share."
 msgstr ""
 
 #. L10n: {0} is a collection name, {1} is 'Add-ons for <app>'.
@@ -2786,12 +2214,11 @@ msgstr ""
 msgid "This url is already in use by another collection"
 msgstr ""
 
-#: src/olympia/bandwagon/forms.py:197 src/olympia/devhub/views.py:1053
+#: src/olympia/bandwagon/forms.py:197 src/olympia/devhub/views.py:1049
 msgid "Icons must be either PNG or JPG."
 msgstr ""
 
-#: src/olympia/bandwagon/forms.py:202 src/olympia/devhub/views.py:1071
-#: src/olympia/users/forms.py:476
+#: src/olympia/bandwagon/forms.py:202 src/olympia/devhub/views.py:1067 src/olympia/users/forms.py:476
 #, python-format
 msgid "Please use images smaller than %dMB."
 msgstr ""
@@ -2812,8 +2239,7 @@ msgstr ""
 msgid "Log in to vote for this collection"
 msgstr ""
 
-#: src/olympia/bandwagon/helpers.py:123
-#: src/olympia/bandwagon/templates/bandwagon/favorites_widget.html:2
+#: src/olympia/bandwagon/helpers.py:123 src/olympia/bandwagon/templates/bandwagon/favorites_widget.html:2
 msgid "Add to favorites"
 msgstr ""
 
@@ -2821,20 +2247,13 @@ msgstr ""
 msgid "Favorite"
 msgstr ""
 
-#: src/olympia/bandwagon/helpers.py:124
-#: src/olympia/bandwagon/templates/bandwagon/favorites_widget.html:2
+#: src/olympia/bandwagon/helpers.py:124 src/olympia/bandwagon/templates/bandwagon/favorites_widget.html:2
 msgid "Remove from favorites"
 msgstr ""
 
-#: src/olympia/bandwagon/views.py:98 src/olympia/bandwagon/views.py:191
-#: src/olympia/browse/views.py:58 src/olympia/browse/views.py:69
-#: src/olympia/browse/views.py:458 src/olympia/devhub/views.py:74
-#: src/olympia/devhub/views.py:82
-#: src/olympia/devhub/templates/devhub/addons/edit/basic.html:20
-#: src/olympia/editors/templates/editors/leaderboard.html:24
-#: src/olympia/editors/templates/editors/themes/queue_list.html:48
-#: src/olympia/search/forms.py:17 src/olympia/search/forms.py:89
-#: src/olympia/users/templates/users/vcard.html:5
+#: src/olympia/bandwagon/views.py:98 src/olympia/bandwagon/views.py:191 src/olympia/browse/views.py:58 src/olympia/browse/views.py:69 src/olympia/browse/views.py:425 src/olympia/devhub/views.py:72
+#: src/olympia/devhub/views.py:80 src/olympia/devhub/templates/devhub/addons/edit/basic.html:20 src/olympia/editors/templates/editors/leaderboard.html:24
+#: src/olympia/editors/templates/editors/themes/queue_list.html:48 src/olympia/search/forms.py:17 src/olympia/search/forms.py:89 src/olympia/users/templates/users/vcard.html:5
 msgid "Name"
 msgstr ""
 
@@ -2842,8 +2261,7 @@ msgstr ""
 msgid "Recently Popular"
 msgstr ""
 
-#: src/olympia/bandwagon/views.py:189
-#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:18
+#: src/olympia/bandwagon/views.py:189 src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:16
 msgid "Added"
 msgstr ""
 
@@ -2857,9 +2275,7 @@ msgstr ""
 
 #: src/olympia/bandwagon/views.py:316
 #, python-format
-msgid ""
-"Your new collection is shown below. You can <a href=\"%(url)s\">edit "
-"additional settings</a> if you'd like."
+msgid "Your new collection is shown below. You can <a href=\"%(url)s\">edit additional settings</a> if you'd like."
 msgstr ""
 
 #: src/olympia/bandwagon/views.py:322
@@ -2875,28 +2291,20 @@ msgstr ""
 msgid "Icon Deleted"
 msgstr ""
 
-#: src/olympia/bandwagon/templates/bandwagon/add.html:3
-#: src/olympia/bandwagon/templates/bandwagon/add.html:11
-#: src/olympia/bandwagon/templates/bandwagon/includes/collection_sidebar.html:26
+#: src/olympia/bandwagon/templates/bandwagon/add.html:3 src/olympia/bandwagon/templates/bandwagon/add.html:11 src/olympia/bandwagon/templates/bandwagon/includes/collection_sidebar.html:26
 msgid "Create a New Collection"
 msgstr ""
 
-#: src/olympia/bandwagon/templates/bandwagon/add.html:9
-#: src/olympia/devhub/templates/devhub/personas/submit.html:14
+#: src/olympia/bandwagon/templates/bandwagon/add.html:9 src/olympia/devhub/templates/devhub/personas/submit.html:14
 msgid "Create"
 msgstr ""
 
-#: src/olympia/bandwagon/templates/bandwagon/add.html:24
-#: src/olympia/bandwagon/templates/bandwagon/ajax_new.html:28
+#: src/olympia/bandwagon/templates/bandwagon/add.html:24 src/olympia/bandwagon/templates/bandwagon/ajax_new.html:28
 #, python-format
-msgid ""
-"As noted in our <a href=\"%(legal)s\">Legal Notices</a>, individual "
-"collection arrangements are governed by the Creative Commons Attribution "
-"Share-Alike License"
+msgid "As noted in our <a href=\"%(legal)s\">Legal Notices</a>, individual collection arrangements are governed by the Creative Commons Attribution Share-Alike License"
 msgstr ""
 
-#: src/olympia/bandwagon/templates/bandwagon/add.html:33
-#: src/olympia/bandwagon/templates/bandwagon/ajax_new.html:38
+#: src/olympia/bandwagon/templates/bandwagon/add.html:33 src/olympia/bandwagon/templates/bandwagon/ajax_new.html:38
 msgid "Create Collection"
 msgstr ""
 
@@ -2912,8 +2320,7 @@ msgstr ""
 msgid "Start a New Collection"
 msgstr ""
 
-#: src/olympia/bandwagon/templates/bandwagon/ajax_new.html:6
-#: src/olympia/bandwagon/templates/bandwagon/includes/addedit.html:7
+#: src/olympia/bandwagon/templates/bandwagon/ajax_new.html:6 src/olympia/bandwagon/templates/bandwagon/includes/addedit.html:7
 msgid "Name:"
 msgstr ""
 
@@ -2926,15 +2333,11 @@ msgstr ""
 msgid "To rate collections, you must have an add-ons account."
 msgstr ""
 
-#: src/olympia/bandwagon/templates/bandwagon/barometer.html:18
-#: src/olympia/templates/base.html:145
-#: src/olympia/templates/impala/base.html:198
+#: src/olympia/bandwagon/templates/bandwagon/barometer.html:18 src/olympia/templates/base.html:145 src/olympia/templates/impala/base.html:198
 msgid "Create an Add-ons Account"
 msgstr ""
 
-#: src/olympia/bandwagon/templates/bandwagon/barometer.html:21
-#: src/olympia/templates/base.html:148
-#: src/olympia/templates/impala/base.html:201
+#: src/olympia/bandwagon/templates/bandwagon/barometer.html:21 src/olympia/templates/base.html:148 src/olympia/templates/impala/base.html:201
 #, python-format
 msgid "or <a href=\"%(login)s\">log in to your current account</a>"
 msgstr ""
@@ -2947,8 +2350,7 @@ msgstr ""
 msgid "private"
 msgstr ""
 
-#: src/olympia/bandwagon/templates/bandwagon/collection_detail.html:45
-#: src/olympia/bandwagon/templates/bandwagon/mobile/listing_items.html:9
+#: src/olympia/bandwagon/templates/bandwagon/collection_detail.html:45 src/olympia/bandwagon/templates/bandwagon/mobile/listing_items.html:9
 #, python-format
 msgid "<span>%(num)s</span> follower"
 msgid_plural "<span>%(num)s</span> followers"
@@ -2985,8 +2387,7 @@ msgstr ""
 msgid "Edit Collection"
 msgstr ""
 
-#: src/olympia/bandwagon/templates/bandwagon/collection_detail.html:88
-#: src/olympia/bandwagon/templates/bandwagon/includes/delete.html:3
+#: src/olympia/bandwagon/templates/bandwagon/collection_detail.html:88 src/olympia/bandwagon/templates/bandwagon/includes/delete.html:3
 msgid "Delete Collection"
 msgstr ""
 
@@ -3008,11 +2409,8 @@ msgstr[1] ""
 msgstr[2] ""
 msgstr[3] ""
 
-#: src/olympia/bandwagon/templates/bandwagon/collection_detail.html:125
-#: src/olympia/compat/templates/compat/reporter_detail.html:29
-#: src/olympia/files/templates/files/viewer.html:29
-#: src/olympia/templates/amo_footer.html:17
-#: src/olympia/templates/includes/lang_switcher.html:10
+#: src/olympia/bandwagon/templates/bandwagon/collection_detail.html:125 src/olympia/compat/templates/compat/reporter_detail.html:29 src/olympia/files/templates/files/viewer.html:29
+#: src/olympia/templates/amo_footer.html:17 src/olympia/templates/includes/lang_switcher.html:10
 msgid "Go"
 msgstr ""
 
@@ -3038,18 +2436,14 @@ msgstr ""
 
 #: src/olympia/bandwagon/templates/bandwagon/collection_detail.html:179
 msgid ""
-"Add-ons that you mark as favorites using the <b>Add to Favorites</b> feature"
-" appear below. This collection is currently <b>public</b>, which means "
-"everyone can see it. If you would like to hide it from public view, click "
-"the button below to make it private."
+"Add-ons that you mark as favorites using the <b>Add to Favorites</b> feature appear below. This collection is currently <b>public</b>, which means everyone can see it. If you would like to hide it "
+"from public view, click the button below to make it private."
 msgstr ""
 
 #: src/olympia/bandwagon/templates/bandwagon/collection_detail.html:186
 msgid ""
-"Add-ons that you mark as favorites using the <b>Add to Favorites</b> feature"
-" appear below. This collection is currently <b>private</b>, which means only"
-" you can see it.  If you would like everyone to be able to see your "
-"favorites, click the button below to make it public."
+"Add-ons that you mark as favorites using the <b>Add to Favorites</b> feature appear below. This collection is currently <b>private</b>, which means only you can see it.  If you would like everyone "
+"to be able to see your favorites, click the button below to make it public."
 msgstr ""
 
 #: src/olympia/bandwagon/templates/bandwagon/collection_detail.html:196
@@ -3074,13 +2468,11 @@ msgstr[1] ""
 msgstr[2] ""
 msgstr[3] ""
 
-#. People "follow" collections to get notified of updates.
-#. Like
+#. People "follow" collections to get notified of updates.                    Like
 #. Twitter followers.
 #. People "follow" collections to get notified of updates.
 #. Like Twitter followers.
-#: src/olympia/bandwagon/templates/bandwagon/collection_listing_items.html:10
-#: src/olympia/bandwagon/templates/bandwagon/impala/collection_listing_items.html:18
+#: src/olympia/bandwagon/templates/bandwagon/collection_listing_items.html:10 src/olympia/bandwagon/templates/bandwagon/impala/collection_listing_items.html:18
 #, python-format
 msgid "%(num)s weekly follower"
 msgid_plural "%(num)s weekly followers"
@@ -3089,8 +2481,7 @@ msgstr[1] ""
 msgstr[2] ""
 msgstr[3] ""
 
-#. People "follow" collections to get notified of updates.
-#. Like
+#. People "follow" collections to get notified of updates.                    Like
 #. Twitter followers.
 #: src/olympia/bandwagon/templates/bandwagon/collection_listing_items.html:18
 #, python-format
@@ -3101,13 +2492,11 @@ msgstr[1] ""
 msgstr[2] ""
 msgstr[3] ""
 
-#. People "follow" collections to get notified of updates.
-#. Like
+#. People "follow" collections to get notified of updates.                    Like
 #. Twitter followers.
 #. People "follow" collections to get notified of updates.
 #. Like Twitter followers.
-#: src/olympia/bandwagon/templates/bandwagon/collection_listing_items.html:26
-#: src/olympia/bandwagon/templates/bandwagon/impala/collection_listing_items.html:26
+#: src/olympia/bandwagon/templates/bandwagon/collection_listing_items.html:26 src/olympia/bandwagon/templates/bandwagon/impala/collection_listing_items.html:26
 #, python-format
 msgid "%(num)s follower"
 msgid_plural "%(num)s followers"
@@ -3116,20 +2505,17 @@ msgstr[1] ""
 msgstr[2] ""
 msgstr[3] ""
 
-#: src/olympia/bandwagon/templates/bandwagon/collection_listing_items.html:56
-#: src/olympia/bandwagon/templates/bandwagon/impala/collection_listing_items.html:9
+#: src/olympia/bandwagon/templates/bandwagon/collection_listing_items.html:56 src/olympia/bandwagon/templates/bandwagon/impala/collection_listing_items.html:9
 #: src/olympia/devhub/templates/devhub/personas/edit.html:27
 msgid "by {0}"
 msgstr ""
 
-#: src/olympia/bandwagon/templates/bandwagon/collection_widgets.html:5
-#: src/olympia/bandwagon/templates/bandwagon/collection_widgets.html:7
+#: src/olympia/bandwagon/templates/bandwagon/collection_widgets.html:5 src/olympia/bandwagon/templates/bandwagon/collection_widgets.html:7
 #: src/olympia/bandwagon/templates/bandwagon/impala/collection_listing_items.html:53
 msgid "Stop Following"
 msgstr ""
 
-#: src/olympia/bandwagon/templates/bandwagon/collection_widgets.html:6
-#: src/olympia/bandwagon/templates/bandwagon/collection_widgets.html:7
+#: src/olympia/bandwagon/templates/bandwagon/collection_widgets.html:6 src/olympia/bandwagon/templates/bandwagon/collection_widgets.html:7
 #: src/olympia/bandwagon/templates/bandwagon/impala/collection_listing_items.html:53
 msgid "Follow this Collection"
 msgstr ""
@@ -3139,16 +2525,12 @@ msgid "Edit this Collection"
 msgstr ""
 
 #. %s is the name of the collection.
-#: src/olympia/bandwagon/templates/bandwagon/delete.html:4
-#: src/olympia/bandwagon/templates/bandwagon/delete.html:15
+#: src/olympia/bandwagon/templates/bandwagon/delete.html:4 src/olympia/bandwagon/templates/bandwagon/delete.html:15
 msgid "Delete {0}"
 msgstr ""
 
-#: src/olympia/bandwagon/templates/bandwagon/delete.html:13
-#: src/olympia/devhub/templates/devhub/addons/listing/item_actions.html:14
-#: src/olympia/devhub/templates/devhub/addons/listing/item_actions_theme.html:28
-#: src/olympia/devhub/templates/devhub/versions/list.html:131
-#: src/olympia/devhub/templates/devhub/versions/list.html:149
+#: src/olympia/bandwagon/templates/bandwagon/delete.html:13 src/olympia/devhub/templates/devhub/addons/listing/item_actions.html:14
+#: src/olympia/devhub/templates/devhub/addons/listing/item_actions_theme.html:28 src/olympia/devhub/templates/devhub/versions/list.html:131 src/olympia/devhub/templates/devhub/versions/list.html:149
 #: src/olympia/devhub/templates/devhub/versions/list.html:166
 msgid "Delete"
 msgstr ""
@@ -3157,35 +2539,24 @@ msgstr ""
 msgid "Are you sure?"
 msgstr ""
 
-#: src/olympia/bandwagon/templates/bandwagon/delete.html:21
-#: src/olympia/devhub/templates/devhub/personas/edit.html:131
-#: src/olympia/devhub/templates/devhub/personas/edit.html:152
-#: src/olympia/devhub/templates/devhub/personas/edit.html:173
-#: src/olympia/devhub/templates/devhub/personas/submit.html:77
-#: src/olympia/devhub/templates/devhub/personas/submit.html:98
+#: src/olympia/bandwagon/templates/bandwagon/delete.html:21 src/olympia/devhub/templates/devhub/personas/edit.html:131 src/olympia/devhub/templates/devhub/personas/edit.html:152
+#: src/olympia/devhub/templates/devhub/personas/edit.html:173 src/olympia/devhub/templates/devhub/personas/submit.html:77 src/olympia/devhub/templates/devhub/personas/submit.html:98
 #: src/olympia/devhub/templates/devhub/personas/submit.html:119
 msgid "Yes"
 msgstr ""
 
-#: src/olympia/bandwagon/templates/bandwagon/delete.html:22
-#: src/olympia/devhub/templates/devhub/personas/edit.html:140
-#: src/olympia/devhub/templates/devhub/personas/edit.html:161
-#: src/olympia/devhub/templates/devhub/personas/edit.html:191
-#: src/olympia/devhub/templates/devhub/personas/submit.html:86
-#: src/olympia/devhub/templates/devhub/personas/submit.html:107
+#: src/olympia/bandwagon/templates/bandwagon/delete.html:22 src/olympia/devhub/templates/devhub/personas/edit.html:140 src/olympia/devhub/templates/devhub/personas/edit.html:161
+#: src/olympia/devhub/templates/devhub/personas/edit.html:191 src/olympia/devhub/templates/devhub/personas/submit.html:86 src/olympia/devhub/templates/devhub/personas/submit.html:107
 #: src/olympia/devhub/templates/devhub/personas/submit.html:137
 msgid "No"
 msgstr ""
 
 #. {0} is the name of the collection.
-#: src/olympia/bandwagon/templates/bandwagon/edit.html:5
-#: src/olympia/bandwagon/templates/bandwagon/edit.html:21
+#: src/olympia/bandwagon/templates/bandwagon/edit.html:5 src/olympia/bandwagon/templates/bandwagon/edit.html:21
 msgid "Edit {0}"
 msgstr ""
 
-#: src/olympia/bandwagon/templates/bandwagon/edit.html:29
-#: src/olympia/devhub/templates/devhub/addons/edit/details.html:20
-#: src/olympia/editors/templates/editors/themes/themes.html:62
+#: src/olympia/bandwagon/templates/bandwagon/edit.html:29 src/olympia/devhub/templates/devhub/addons/edit/details.html:20 src/olympia/editors/templates/editors/themes/themes.html:62
 msgid "Description"
 msgstr ""
 
@@ -3193,31 +2564,17 @@ msgstr ""
 msgid "Contributors & More"
 msgstr ""
 
-#: src/olympia/bandwagon/templates/bandwagon/edit.html:54
-#: src/olympia/bandwagon/templates/bandwagon/edit.html:67
-#: src/olympia/bandwagon/templates/bandwagon/edit.html:82
-#: src/olympia/devhub/templates/devhub/addons/ajax_compat_update.html:35
-#: src/olympia/devhub/templates/devhub/addons/owner.html:59
-#: src/olympia/devhub/templates/devhub/addons/profile.html:42
-#: src/olympia/devhub/templates/devhub/addons/edit/admin.html:101
-#: src/olympia/devhub/templates/devhub/addons/edit/basic.html:152
-#: src/olympia/devhub/templates/devhub/addons/edit/details.html:85
-#: src/olympia/devhub/templates/devhub/addons/edit/support.html:67
-#: src/olympia/devhub/templates/devhub/addons/edit/technical.html:166
-#: src/olympia/devhub/templates/devhub/addons/forms_shared/media.html:149
-#: src/olympia/devhub/templates/devhub/payments/voluntary.html:64
-#: src/olympia/devhub/templates/devhub/personas/edit.html:35
-#: src/olympia/devhub/templates/devhub/personas/edit.html:304
-#: src/olympia/devhub/templates/devhub/versions/edit.html:139
-#: src/olympia/translations/templates/translations/trans-menu.html:48
+#: src/olympia/bandwagon/templates/bandwagon/edit.html:54 src/olympia/bandwagon/templates/bandwagon/edit.html:67 src/olympia/bandwagon/templates/bandwagon/edit.html:82
+#: src/olympia/devhub/templates/devhub/addons/ajax_compat_update.html:35 src/olympia/devhub/templates/devhub/addons/owner.html:59 src/olympia/devhub/templates/devhub/addons/profile.html:42
+#: src/olympia/devhub/templates/devhub/addons/edit/admin.html:101 src/olympia/devhub/templates/devhub/addons/edit/basic.html:152 src/olympia/devhub/templates/devhub/addons/edit/details.html:85
+#: src/olympia/devhub/templates/devhub/addons/edit/support.html:67 src/olympia/devhub/templates/devhub/addons/edit/technical.html:166
+#: src/olympia/devhub/templates/devhub/addons/forms_shared/media.html:149 src/olympia/devhub/templates/devhub/payments/voluntary.html:64 src/olympia/devhub/templates/devhub/personas/edit.html:35
+#: src/olympia/devhub/templates/devhub/personas/edit.html:304 src/olympia/devhub/templates/devhub/versions/edit.html:139 src/olympia/translations/templates/translations/trans-menu.html:48
 msgid "Save Changes"
 msgstr ""
 
-#: src/olympia/bandwagon/templates/bandwagon/edit_contributors.html:9
-#: src/olympia/bandwagon/templates/bandwagon/edit_contributors.html:12
-#: src/olympia/bandwagon/templates/bandwagon/edit_contributors.html:17
-#: src/olympia/bandwagon/templates/bandwagon/edit_contributors.html:58
-#: src/olympia/constants/base.py:134
+#: src/olympia/bandwagon/templates/bandwagon/edit_contributors.html:9 src/olympia/bandwagon/templates/bandwagon/edit_contributors.html:12
+#: src/olympia/bandwagon/templates/bandwagon/edit_contributors.html:17 src/olympia/bandwagon/templates/bandwagon/edit_contributors.html:58 src/olympia/constants/base.py:134
 msgid "Owner"
 msgstr ""
 
@@ -3229,10 +2586,8 @@ msgstr ""
 msgid "Remove this user as a contributor"
 msgstr ""
 
-#: src/olympia/bandwagon/templates/bandwagon/edit_contributors.html:18
-#: src/olympia/bandwagon/templates/bandwagon/edit_contributors.html:43
-#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:20
-#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:48
+#: src/olympia/bandwagon/templates/bandwagon/edit_contributors.html:18 src/olympia/bandwagon/templates/bandwagon/edit_contributors.html:43
+#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:18 src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:46
 #: src/olympia/devhub/templates/devhub/addons/ajax_compat_update.html:19
 msgid "Remove"
 msgstr ""
@@ -3243,19 +2598,15 @@ msgstr ""
 
 #: src/olympia/bandwagon/templates/bandwagon/edit_contributors.html:26
 msgid ""
-"You can add multiple contributors to this collection.  A contributor can add"
-" and remove add-ons from this collection, but cannot change its name or "
-"description.  To add a contributor, enter their email in the box below. "
-"Contributors must have a Mozilla Add-ons account."
+"You can add multiple contributors to this collection.  A contributor can add and remove add-ons from this collection, but cannot change its name or description.  To add a contributor, enter their "
+"email in the box below. Contributors must have a Mozilla Add-ons account."
 msgstr ""
 
 #: src/olympia/bandwagon/templates/bandwagon/edit_contributors.html:40
 msgid "User"
 msgstr ""
 
-#: src/olympia/bandwagon/templates/bandwagon/edit_contributors.html:41
-#: src/olympia/devhub/templates/devhub/addons/edit/support.html:20
-#: src/olympia/users/templates/users/delete.html:49
+#: src/olympia/bandwagon/templates/bandwagon/edit_contributors.html:41 src/olympia/devhub/templates/devhub/addons/edit/support.html:20 src/olympia/users/templates/users/delete.html:49
 msgid "Email"
 msgstr ""
 
@@ -3280,25 +2631,14 @@ msgid "Admin Settings"
 msgstr ""
 
 #: src/olympia/bandwagon/templates/bandwagon/edit_contributors.html:76
-msgid ""
-"<b>Warning:</b> By changing the owner of this collection, you will no longer"
-" be able to edit it. You will only be able to add and remove add-ons from "
-"it."
+msgid "<b>Warning:</b> By changing the owner of this collection, you will no longer be able to edit it. You will only be able to add and remove add-ons from it."
 msgstr ""
 
-#: src/olympia/bandwagon/templates/bandwagon/edit_contributors.html:83
-#: src/olympia/devhub/templates/devhub/addons/forms_shared/media.html:157
-#: src/olympia/devhub/templates/devhub/addons/submit/describe.html:69
-#: src/olympia/devhub/templates/devhub/addons/submit/license.html:60
-#: src/olympia/devhub/templates/devhub/addons/submit/upload.html:64
-#: src/olympia/devhub/templates/devhub/payments/tier.html:17
-#: src/olympia/editors/templates/editors/themes/themes.html:111
-#: src/olympia/editors/templates/editors/themes/themes.html:128
-#: src/olympia/editors/templates/editors/themes/themes.html:134
-#: src/olympia/editors/templates/editors/themes/themes.html:141
-#: src/olympia/users/templates/users/fxa_migration_prompt_content.html:10
-#: src/olympia/users/templates/users/login_form.html:42
-#: src/olympia/users/templates/users/mobile/login.html:57
+#: src/olympia/bandwagon/templates/bandwagon/edit_contributors.html:83 src/olympia/devhub/templates/devhub/addons/forms_shared/media.html:157
+#: src/olympia/devhub/templates/devhub/addons/submit/describe.html:69 src/olympia/devhub/templates/devhub/addons/submit/license.html:60 src/olympia/devhub/templates/devhub/addons/submit/upload.html:70
+#: src/olympia/devhub/templates/devhub/payments/tier.html:17 src/olympia/editors/templates/editors/themes/themes.html:111 src/olympia/editors/templates/editors/themes/themes.html:128
+#: src/olympia/editors/templates/editors/themes/themes.html:134 src/olympia/editors/templates/editors/themes/themes.html:141 src/olympia/users/templates/users/fxa_migration_prompt_content.html:10
+#: src/olympia/users/templates/users/login_form.html:42 src/olympia/users/templates/users/mobile/login.html:57
 msgid "Continue"
 msgstr ""
 
@@ -3337,15 +2677,10 @@ msgstr ""
 
 #: src/olympia/bandwagon/templates/bandwagon/impala/collection_listing.html:28
 #, python-format
-msgid ""
-"Collections are groups of related add-ons that anyone can create and share. "
-"Explore collections created by other users or <a href=\"%(url)s\">create "
-"your own</a>."
+msgid "Collections are groups of related add-ons that anyone can create and share. Explore collections created by other users or <a href=\"%(url)s\">create your own</a>."
 msgstr ""
 
-#: src/olympia/bandwagon/templates/bandwagon/impala/collection_listing.html:37
-#: src/olympia/browse/templates/browse/extensions.html:13
-#: src/olympia/browse/templates/browse/themes.html:14
+#: src/olympia/bandwagon/templates/bandwagon/impala/collection_listing.html:37 src/olympia/browse/templates/browse/extensions.html:13 src/olympia/browse/templates/browse/themes.html:14
 msgid "Subscribe"
 msgstr ""
 
@@ -3353,17 +2688,13 @@ msgstr ""
 msgid "Following"
 msgstr ""
 
-#: src/olympia/bandwagon/templates/bandwagon/impala/collection_sidebar.html:22
-#: src/olympia/bandwagon/templates/bandwagon/impala/collection_sidebar.html:28
+#: src/olympia/bandwagon/templates/bandwagon/impala/collection_sidebar.html:22 src/olympia/bandwagon/templates/bandwagon/impala/collection_sidebar.html:28
 #: src/olympia/bandwagon/templates/bandwagon/includes/collection_sidebar.html:32
 msgid "Create a Collection"
 msgstr ""
 
-#: src/olympia/bandwagon/templates/bandwagon/impala/collection_sidebar.html:23
-#: src/olympia/bandwagon/templates/bandwagon/includes/collection_sidebar.html:27
-msgid ""
-"Collections make it easy to keep track of favorite add-ons and share your "
-"perfectly customized browser with others."
+#: src/olympia/bandwagon/templates/bandwagon/impala/collection_sidebar.html:23 src/olympia/bandwagon/templates/bandwagon/includes/collection_sidebar.html:27
+msgid "Collections make it easy to keep track of favorite add-ons and share your perfectly customized browser with others."
 msgstr ""
 
 #: src/olympia/bandwagon/templates/bandwagon/includes/addedit.html:42
@@ -3387,37 +2718,31 @@ msgid "Add-ons in Your Collection"
 msgstr ""
 
 #: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:4
-msgid ""
-"To include an add-on in this collection, enter its name in the box below and"
-" hit enter.  You can also use the <strong>Add to Collection</strong> links "
-"throughout the site to include add-ons later."
+msgid "To include an add-on in this collection, enter its name in the box below and hit enter."
 msgstr ""
 
-#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:17
-#: src/olympia/constants/base.py:400
-#: src/olympia/devhub/templates/devhub/addons/activity.html:62
+#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:15 src/olympia/constants/base.py:400 src/olympia/devhub/templates/devhub/addons/activity.html:62
 #: src/olympia/editors/helpers.py:273 src/olympia/editors/helpers.py:360
 msgid "Add-on"
 msgstr ""
 
-#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:26
+#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:24
 msgid "Enter the name of the add-on to include"
 msgstr ""
 
-#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:28
+#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:26
 msgid "Add to Collection"
 msgstr ""
 
-#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:45
-#: src/olympia/editors/helpers.py:1012 src/olympia/editors/helpers.py:1032
+#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:43 src/olympia/editors/helpers.py:1016 src/olympia/editors/helpers.py:1036
 msgid "Pending"
 msgstr ""
 
-#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:47
+#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:45
 msgid "Add a comment"
 msgstr ""
 
-#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:48
+#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:46
 msgid "Remove this add-on from the collection"
 msgstr ""
 
@@ -3429,14 +2754,11 @@ msgstr ""
 msgid "Groups of related add-ons that anyone can create."
 msgstr ""
 
-#: src/olympia/blocklist/templates/blocklist/blocked_detail.html:3
-#: src/olympia/blocklist/templates/blocklist/blocked_list.html:3
-#: src/olympia/blocklist/templates/blocklist/blocked_list.html:10
+#: src/olympia/blocklist/templates/blocklist/blocked_detail.html:3 src/olympia/blocklist/templates/blocklist/blocked_list.html:3 src/olympia/blocklist/templates/blocklist/blocked_list.html:10
 msgid "Blocked Add-ons"
 msgstr ""
 
-#: src/olympia/blocklist/templates/blocklist/blocked_detail.html:8
-#: src/olympia/blocklist/templates/blocklist/blocked_list.html:6
+#: src/olympia/blocklist/templates/blocklist/blocked_detail.html:8 src/olympia/blocklist/templates/blocklist/blocked_list.html:6
 msgid "Blocklist"
 msgstr ""
 
@@ -3458,25 +2780,18 @@ msgid "What does this mean?"
 msgstr ""
 
 #: src/olympia/blocklist/templates/blocklist/blocked_detail.html:22
-msgid ""
-"Users are strongly encouraged to disable the problematic add-on or plugin, "
-"but may choose to continue using it if they accept the risks described."
+msgid "Users are strongly encouraged to disable the problematic add-on or plugin, but may choose to continue using it if they accept the risks described."
 msgstr ""
 
 #: src/olympia/blocklist/templates/blocklist/blocked_detail.html:27
-msgid ""
-"The problematic add-on or plugin will be automatically disabled and no "
-"longer usable."
+msgid "The problematic add-on or plugin will be automatically disabled and no longer usable."
 msgstr ""
 
 #: src/olympia/blocklist/templates/blocklist/blocked_detail.html:33
 #, python-format
 msgid ""
-"When Mozilla becomes aware of add-ons, plugins, or other third-party "
-"software that seriously compromises %(app)s security, stability, or "
-"performance and meets <a href=\"%(criteria)s\">certain criteria</a>, the "
-"software may be blocked from general use.  For more information, please read"
-" <a href=\"%(support)s\">this support article</a>."
+"When Mozilla becomes aware of add-ons, plugins, or other third-party software that seriously compromises %(app)s security, stability, or performance and meets <a href=\"%(criteria)s\">certain "
+"criteria</a>, the software may be blocked from general use.  For more information, please read <a href=\"%(support)s\">this support article</a>."
 msgstr ""
 
 #: src/olympia/blocklist/templates/blocklist/blocked_detail.html:44
@@ -3490,9 +2805,7 @@ msgid "Blocked on %(date)s."
 msgstr ""
 
 #: src/olympia/blocklist/templates/blocklist/blocked_list.html:11
-msgid ""
-"The following software is known to cause serious security, stability, or "
-"performance issues with {app}."
+msgid "The following software is known to cause serious security, stability, or performance issues with {app}."
 msgstr ""
 
 #. L10n: %s is a category name.
@@ -3515,8 +2828,7 @@ msgstr ""
 #. L10n: %s is an app name.
 #: src/olympia/browse/feeds.py:138
 #, python-format
-msgid ""
-"Here's a few of our favorite add-ons to help you get started customizing %s."
+msgid "Here's a few of our favorite add-ons to help you get started customizing %s."
 msgstr ""
 
 #. L10n: %s is a category name.
@@ -3533,43 +2845,28 @@ msgstr ""
 msgid "Search tools"
 msgstr ""
 
-#: src/olympia/browse/views.py:55 src/olympia/browse/views.py:65
-#: src/olympia/search/forms.py:85
+#: src/olympia/browse/views.py:55 src/olympia/browse/views.py:65 src/olympia/search/forms.py:85
 msgid "Most Users"
 msgstr ""
 
-#: src/olympia/browse/views.py:61 src/olympia/browse/views.py:72
-#: src/olympia/browse/views.py:279
-#: src/olympia/browse/templates/browse/personas/mobile/category_landing.html:63
-#: src/olympia/discovery/templates/discovery/pane.html:67
-#: src/olympia/search/forms.py:92
+#: src/olympia/browse/views.py:61 src/olympia/browse/views.py:72 src/olympia/browse/views.py:246 src/olympia/browse/templates/browse/personas/mobile/category_landing.html:63
+#: src/olympia/discovery/templates/discovery/pane.html:67 src/olympia/search/forms.py:92
 msgid "Up & Coming"
 msgstr ""
 
-#: src/olympia/browse/views.py:460 src/olympia/devhub/views.py:76
-#: src/olympia/devhub/views.py:83
-#: src/olympia/discovery/templates/discovery/addons/detail.html:66
+#: src/olympia/browse/views.py:427 src/olympia/devhub/views.py:74 src/olympia/devhub/views.py:81 src/olympia/discovery/templates/discovery/addons/detail.html:66
 msgid "Created"
 msgstr ""
 
 #. {0} is the category name. Ex: Sports
-#: src/olympia/browse/templates/browse/creatured.html:5
-#: src/olympia/browse/templates/browse/creatured.html:13
+#: src/olympia/browse/templates/browse/creatured.html:5 src/olympia/browse/templates/browse/creatured.html:13
 msgid "{0}: Featured Add-ons"
 msgstr ""
 
-#: src/olympia/browse/templates/browse/creatured.html:12
-#: src/olympia/browse/templates/browse/featured.html:4
-#: src/olympia/browse/templates/browse/featured.html:12
-#: src/olympia/browse/templates/browse/featured.html:13
-#: src/olympia/devhub/templates/devhub/docs/policies-recommended.html:3
-#: src/olympia/devhub/templates/devhub/docs/policies-recommended.html:7
-#: src/olympia/devhub/templates/devhub/docs/policies-recommended.html:9
-#: src/olympia/devhub/templates/devhub/docs/policies.html:21
-#: src/olympia/devhub/templates/devhub/docs/policies.html:90
-#: src/olympia/discovery/modules.py:341
-#: src/olympia/discovery/templates/discovery/pane.html:52
-#: src/olympia/templates/menu_links.html:7
+#: src/olympia/browse/templates/browse/creatured.html:12 src/olympia/browse/templates/browse/featured.html:4 src/olympia/browse/templates/browse/featured.html:12
+#: src/olympia/browse/templates/browse/featured.html:13 src/olympia/devhub/templates/devhub/docs/policies-recommended.html:3 src/olympia/devhub/templates/devhub/docs/policies-recommended.html:7
+#: src/olympia/devhub/templates/devhub/docs/policies-recommended.html:9 src/olympia/devhub/templates/devhub/docs/policies.html:21 src/olympia/devhub/templates/devhub/docs/policies.html:90
+#: src/olympia/discovery/modules.py:341 src/olympia/discovery/templates/discovery/pane.html:52 src/olympia/templates/menu_links.html:7
 msgid "Featured Add-ons"
 msgstr ""
 
@@ -3580,9 +2877,7 @@ msgstr ""
 
 #: src/olympia/browse/templates/browse/featured.html:15
 #, python-format
-msgid ""
-"Here's a few of our favorite add-ons to help you get started customizing "
-"%(app)s."
+msgid "Here's a few of our favorite add-ons to help you get started customizing %(app)s."
 msgstr ""
 
 #: src/olympia/browse/templates/browse/language_tools.html:9
@@ -3609,19 +2904,15 @@ msgstr ""
 msgid "List of language packs and dictionaries available in your locale."
 msgstr ""
 
-#: src/olympia/browse/templates/browse/language_tools.html:41
-#: src/olympia/browse/templates/browse/language_tools.html:63
+#: src/olympia/browse/templates/browse/language_tools.html:41 src/olympia/browse/templates/browse/language_tools.html:63
 msgid "Language"
 msgstr ""
 
-#: src/olympia/browse/templates/browse/language_tools.html:42
-#: src/olympia/browse/templates/browse/language_tools.html:64
-#: src/olympia/constants/base.py:162
+#: src/olympia/browse/templates/browse/language_tools.html:42 src/olympia/browse/templates/browse/language_tools.html:64 src/olympia/constants/base.py:162
 msgid "Dictionary"
 msgstr ""
 
-#: src/olympia/browse/templates/browse/language_tools.html:43
-#: src/olympia/browse/templates/browse/language_tools.html:65
+#: src/olympia/browse/templates/browse/language_tools.html:43 src/olympia/browse/templates/browse/language_tools.html:65
 msgid "Language Pack"
 msgstr ""
 
@@ -3639,8 +2930,7 @@ msgid "{0} :: Search Tools"
 msgstr ""
 
 #. {0} is an integer.
-#: src/olympia/browse/templates/browse/search_tools.html:39
-#: src/olympia/devhub/templates/devhub/addons/dashboard.html:17
+#: src/olympia/browse/templates/browse/search_tools.html:39 src/olympia/devhub/templates/devhub/addons/dashboard.html:17
 msgid "<b>{0}</b> add-on"
 msgid_plural "<b>{0}</b> add-ons"
 msgstr[0] ""
@@ -3670,27 +2960,18 @@ msgstr ""
 
 #. {0} is an app name, like Firefox.
 #: src/olympia/browse/templates/browse/search_tools.html:93
-msgid ""
-"Learn more about the <a "
-"href=\"http://support.mozilla.com/kb/Search+bar\">search bar</a> in {0}"
+msgid "Learn more about the <a href=\"http://support.mozilla.com/kb/Search+bar\">search bar</a> in {0}"
 msgstr ""
 
 #: src/olympia/browse/templates/browse/search_tools.html:94
-msgid ""
-"Browse through even more search providers at <a "
-"href=\"http://mycroft.mozdev.org/\">mycroft.mozdev.org</a>"
+msgid "Browse through even more search providers at <a href=\"http://mycroft.mozdev.org/\">mycroft.mozdev.org</a>"
 msgstr ""
 
 #: src/olympia/browse/templates/browse/search_tools.html:95
-msgid ""
-"<a "
-"href=\"https://developer.mozilla.org/en/Creating_OpenSearch_plugins_for_Firefox\">Make"
-" your own</a> search tool"
+msgid "<a href=\"https://developer.mozilla.org/en/Creating_OpenSearch_plugins_for_Firefox\">Make your own</a> search tool"
 msgstr ""
 
-#: src/olympia/browse/templates/browse/themes.html:6
-#: src/olympia/browse/templates/browse/themes.html:9
-#: src/olympia/constants/base.py:174
+#: src/olympia/browse/templates/browse/themes.html:6 src/olympia/browse/templates/browse/themes.html:9 src/olympia/constants/base.py:174
 msgid "Complete Themes"
 msgstr ""
 
@@ -3765,23 +3046,17 @@ msgstr[1] ""
 msgstr[2] ""
 msgstr[3] ""
 
-#: src/olympia/browse/templates/browse/mobile/extensions.html:13
-#: src/olympia/devhub/templates/devhub/devhub_search.html:24
-#: src/olympia/devhub/templates/devhub/addons/activity.html:47
-#: src/olympia/search/templates/search/no_results.html:4
-#: src/olympia/search/templates/search/mobile/results.html:36
+#: src/olympia/browse/templates/browse/mobile/extensions.html:13 src/olympia/devhub/templates/devhub/devhub_search.html:24 src/olympia/devhub/templates/devhub/addons/activity.html:47
+#: src/olympia/search/templates/search/no_results.html:4 src/olympia/search/templates/search/mobile/results.html:36
 msgid "No results found."
 msgstr ""
 
-#: src/olympia/browse/templates/browse/personas/base.html:6
-#: src/olympia/browse/templates/browse/personas/mobile/base.html:7
+#: src/olympia/browse/templates/browse/personas/base.html:6 src/olympia/browse/templates/browse/personas/mobile/base.html:7
 msgid "{0} Themes"
 msgstr ""
 
 #. {0} is a user's name.
-#: src/olympia/browse/templates/browse/personas/base.html:15
-#: src/olympia/browse/templates/browse/personas/base.html:40
-#: src/olympia/browse/templates/browse/personas/grid.html:8
+#: src/olympia/browse/templates/browse/personas/base.html:15 src/olympia/browse/templates/browse/personas/base.html:40 src/olympia/browse/templates/browse/personas/grid.html:8
 msgid "{0}'s Themes"
 msgstr ""
 
@@ -3801,27 +3076,21 @@ msgstr ""
 msgid "Learn more"
 msgstr ""
 
-#: src/olympia/browse/templates/browse/personas/category_landing.html:6
-#: src/olympia/browse/templates/browse/personas/mobile/category_landing.html:5
+#: src/olympia/browse/templates/browse/personas/category_landing.html:6 src/olympia/browse/templates/browse/personas/mobile/category_landing.html:5
 msgid "View All Recently Added"
 msgstr ""
 
-#: src/olympia/browse/templates/browse/personas/category_landing.html:7
-#: src/olympia/browse/templates/browse/personas/mobile/category_landing.html:6
+#: src/olympia/browse/templates/browse/personas/category_landing.html:7 src/olympia/browse/templates/browse/personas/mobile/category_landing.html:6
 msgid "View All Most Popular"
 msgstr ""
 
-#: src/olympia/browse/templates/browse/personas/category_landing.html:8
-#: src/olympia/browse/templates/browse/personas/mobile/category_landing.html:7
+#: src/olympia/browse/templates/browse/personas/category_landing.html:8 src/olympia/browse/templates/browse/personas/mobile/category_landing.html:7
 msgid "View All Top Rated"
 msgstr ""
 
 #: src/olympia/browse/templates/browse/personas/category_landing.html:40
 #, python-format
-msgid ""
-"Over 300,000 designs to personalize your browser! Move your mouse over a "
-"Background Theme to try it on. <a href=\"%(url)s\" class=\"more-info\">Start"
-" exploring</a>"
+msgid "Over 300,000 designs to personalize your browser! Move your mouse over a Background Theme to try it on. <a href=\"%(url)s\" class=\"more-info\">Start exploring</a>"
 msgstr ""
 
 #: src/olympia/browse/templates/browse/personas/category_landing.html:47
@@ -3832,10 +3101,7 @@ msgstr ""
 #. theme.
 #: src/olympia/browse/templates/browse/personas/category_landing.html:50
 #, python-format
-msgid ""
-"Complete Themes transform the look of your browser with styles for the "
-"window frame, address bar, buttons, tabs, and menus. <a href=\"%(url)s\" "
-"class=\"more-info\">Start exploring</a>"
+msgid "Complete Themes transform the look of your browser with styles for the window frame, address bar, buttons, tabs, and menus. <a href=\"%(url)s\" class=\"more-info\">Start exploring</a>"
 msgstr ""
 
 #: src/olympia/browse/templates/browse/personas/category_landing.html:76
@@ -3866,9 +3132,7 @@ msgstr ""
 msgid "All"
 msgstr ""
 
-#: src/olympia/compat/forms.py:22
-#: src/olympia/editors/templates/editors/base.html:69
-#: src/olympia/search/views.py:518
+#: src/olympia/compat/forms.py:22 src/olympia/editors/templates/editors/base.html:69 src/olympia/search/views.py:518
 msgid "All Add-ons"
 msgstr ""
 
@@ -3884,22 +3148,18 @@ msgstr ""
 msgid "Add-on Compatibility Reports"
 msgstr ""
 
-#: src/olympia/compat/templates/compat/reporter.html:11
-#: src/olympia/compat/templates/compat/reporter_detail.html:35
+#: src/olympia/compat/templates/compat/reporter.html:11 src/olympia/compat/templates/compat/reporter_detail.html:35
 #, python-format
 msgid ""
-"<p> Reports submitted to us through the <a href=\"%(url_)s\">Add-on "
-"Compatibility Reporter</a> are collected here for developers to view. These "
-"reports help us determine which add-ons will need help supporting an "
-"upcoming Firefox version. </p>"
+"<p> Reports submitted to us through the <a href=\"%(url_)s\">Add-on Compatibility Reporter</a> are collected here for developers to view. These reports help us determine which add-ons will need "
+"help supporting an upcoming Firefox version. </p>"
 msgstr ""
 
 #: src/olympia/compat/templates/compat/reporter.html:18
 msgid "Reports for your Add-ons"
 msgstr ""
 
-#: src/olympia/compat/templates/compat/reporter.html:30
-#: src/olympia/compat/templates/compat/reporter_detail.html:9
+#: src/olympia/compat/templates/compat/reporter.html:30 src/olympia/compat/templates/compat/reporter_detail.html:9
 msgid "Add-on Compatibility Center"
 msgstr ""
 
@@ -3907,9 +3167,7 @@ msgstr ""
 msgid "Enter the GUID of an add-on below to view any reports we've received."
 msgstr ""
 
-#: src/olympia/compat/templates/compat/reporter_detail.html:3
-#: src/olympia/compat/templates/compat/reporter_detail.html:10
-#: src/olympia/compat/templates/compat/reporter_detail.html:25
+#: src/olympia/compat/templates/compat/reporter_detail.html:3 src/olympia/compat/templates/compat/reporter_detail.html:10 src/olympia/compat/templates/compat/reporter_detail.html:25
 msgid "{addon} Compatibility Reports"
 msgstr ""
 
@@ -3929,8 +3187,7 @@ msgstr[1] ""
 msgstr[2] ""
 msgstr[3] ""
 
-#: src/olympia/compat/templates/compat/reporter_detail.html:21
-#: src/olympia/users/templates/users/profile.html:70
+#: src/olympia/compat/templates/compat/reporter_detail.html:21 src/olympia/users/templates/users/profile.html:70
 msgid "View all"
 msgstr ""
 
@@ -3942,10 +3199,8 @@ msgstr ""
 msgid "Report Type"
 msgstr ""
 
-#: src/olympia/compat/templates/compat/reporter_detail.html:47
-#: src/olympia/devhub/forms.py:776
-#: src/olympia/devhub/templates/devhub/addons/ajax_compat_update.html:17
-#: src/olympia/editors/forms.py:108 src/olympia/zadmin/forms.py:45
+#: src/olympia/compat/templates/compat/reporter_detail.html:47 src/olympia/devhub/forms.py:785 src/olympia/devhub/templates/devhub/addons/ajax_compat_update.html:17 src/olympia/editors/forms.py:108
+#: src/olympia/editors/forms.py:248 src/olympia/zadmin/forms.py:45
 msgid "Application"
 msgstr ""
 
@@ -3957,8 +3212,7 @@ msgstr ""
 msgid "Platform"
 msgstr ""
 
-#: src/olympia/compat/templates/compat/reporter_detail.html:50
-#: src/olympia/editors/templates/editors/themes/themes.html:40
+#: src/olympia/compat/templates/compat/reporter_detail.html:50 src/olympia/editors/templates/editors/themes/themes.html:40
 msgid "Submitted"
 msgstr ""
 
@@ -3986,8 +3240,7 @@ msgstr ""
 msgid "SeaMonkey"
 msgstr ""
 
-#: src/olympia/constants/applications.py:75
-#: src/olympia/pages/templates/pages/sunbird.html:4
+#: src/olympia/constants/applications.py:75 src/olympia/pages/templates/pages/sunbird.html:4
 msgid "Sunbird"
 msgstr ""
 
@@ -4035,8 +3288,7 @@ msgstr ""
 msgid "Preliminarily Reviewed and Awaiting Full Review"
 msgstr ""
 
-#: src/olympia/constants/base.py:33 src/olympia/editors/helpers.py:73
-#: src/olympia/editors/helpers.py:1000
+#: src/olympia/constants/base.py:33 src/olympia/editors/forms.py:258 src/olympia/editors/helpers.py:73 src/olympia/editors/helpers.py:1004
 #: src/olympia/editors/templates/editors/themes/history_table.html:34
 msgid "Deleted"
 msgstr ""
@@ -4069,13 +3321,11 @@ msgstr ""
 msgid "Viewer"
 msgstr ""
 
-#: src/olympia/constants/base.py:137
-#: src/olympia/templates/mobile/header.html:7
+#: src/olympia/constants/base.py:137 src/olympia/templates/mobile/header.html:7
 msgid "Support"
 msgstr ""
 
-#: src/olympia/constants/base.py:159 src/olympia/constants/base.py:172
-#: src/olympia/constants/platforms.py:10
+#: src/olympia/constants/base.py:159 src/olympia/constants/base.py:172 src/olympia/constants/platforms.py:10
 msgid "Any"
 msgstr ""
 
@@ -4103,11 +3353,8 @@ msgstr ""
 msgid "Plugin"
 msgstr ""
 
-#: src/olympia/constants/base.py:167
-#: src/olympia/editors/templates/editors/includes/search_results_themes.html:5
-#: src/olympia/editors/templates/editors/themes/deleted.html:18
-#: src/olympia/editors/templates/editors/themes/history_table.html:8
-#: src/olympia/editors/templates/editors/themes/logs.html:17
+#: src/olympia/constants/base.py:167 src/olympia/editors/templates/editors/includes/search_results_themes.html:5 src/olympia/editors/templates/editors/themes/deleted.html:18
+#: src/olympia/editors/templates/editors/themes/history_table.html:8 src/olympia/editors/templates/editors/themes/logs.html:17
 msgid "Theme"
 msgstr ""
 
@@ -4140,8 +3387,7 @@ msgid "Ask before users can download this add-on"
 msgstr ""
 
 #. Review points sources other than add-ons and themes.
-#: src/olympia/constants/base.py:388 src/olympia/devhub/forms.py:162
-#: src/olympia/editors/templates/editors/performance.html:75
+#: src/olympia/constants/base.py:388 src/olympia/devhub/forms.py:162 src/olympia/editors/templates/editors/performance.html:75
 msgid "Other"
 msgstr ""
 
@@ -4297,32 +3543,23 @@ msgstr ""
 msgid "Signed of a preliminary review"
 msgstr ""
 
-#: src/olympia/constants/editors.py:14
-#: src/olympia/editors/templates/editors/themes/queue.html:76
-#: src/olympia/editors/templates/editors/themes/themes.html:87
+#: src/olympia/constants/editors.py:14 src/olympia/editors/templates/editors/themes/queue.html:76 src/olympia/editors/templates/editors/themes/themes.html:87
 msgid "Request More Info"
 msgstr ""
 
-#: src/olympia/constants/editors.py:15
-#: src/olympia/editors/templates/editors/themes/queue.html:74
-#: src/olympia/editors/templates/editors/themes/themes.html:91
+#: src/olympia/constants/editors.py:15 src/olympia/editors/templates/editors/themes/queue.html:74 src/olympia/editors/templates/editors/themes/themes.html:91
 msgid "Flag"
 msgstr ""
 
-#: src/olympia/constants/editors.py:16
-#: src/olympia/editors/templates/editors/themes/queue.html:72
-#: src/olympia/editors/templates/editors/themes/themes.html:93
+#: src/olympia/constants/editors.py:16 src/olympia/editors/templates/editors/themes/queue.html:72 src/olympia/editors/templates/editors/themes/themes.html:93
 msgid "Duplicate"
 msgstr ""
 
-#: src/olympia/constants/editors.py:17 src/olympia/editors/helpers.py:571
-#: src/olympia/editors/templates/editors/themes/queue.html:71
-#: src/olympia/editors/templates/editors/themes/themes.html:94
+#: src/olympia/constants/editors.py:17 src/olympia/editors/helpers.py:575 src/olympia/editors/templates/editors/themes/queue.html:71 src/olympia/editors/templates/editors/themes/themes.html:94
 msgid "Reject"
 msgstr ""
 
-#: src/olympia/constants/editors.py:18
-#: src/olympia/editors/templates/editors/themes/queue.html:70
+#: src/olympia/constants/editors.py:18 src/olympia/editors/templates/editors/themes/queue.html:70
 msgid "Approve"
 msgstr ""
 
@@ -4455,9 +3692,7 @@ msgstr ""
 msgid "Message not eligible for annotation"
 msgstr ""
 
-#: src/olympia/devhub/forms.py:124
-#: src/olympia/devhub/templates/devhub/versions/edit.html:94
-#: src/olympia/users/templates/users/edit.html:150
+#: src/olympia/devhub/forms.py:124 src/olympia/devhub/templates/devhub/versions/edit.html:94 src/olympia/users/templates/users/edit.html:150
 msgid "Details"
 msgstr ""
 
@@ -4558,81 +3793,75 @@ msgid "Do not list my add-on on this site"
 msgstr ""
 
 #: src/olympia/devhub/forms.py:538
-msgid ""
-"Check this option if you intend to distribute your add-on on your own and "
-"only need it to be signed by Mozilla."
+msgid "Check this option if you intend to distribute your add-on on your own and only need it to be signed by Mozilla."
 msgstr ""
 
-#: src/olympia/devhub/forms.py:556
-#: src/olympia/devhub/templates/devhub/addons/submit/select-review.html:24
-#: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:42
+#: src/olympia/devhub/forms.py:544
+msgid "This add-on will be bundled with an application installer."
+msgstr ""
+
+#: src/olympia/devhub/forms.py:546
+msgid "Add-ons that are bundled with application installers will be code reviewed by Mozilla before they are signed and are held to a higher quality standard."
+msgstr ""
+
+#: src/olympia/devhub/forms.py:565 src/olympia/devhub/templates/devhub/addons/submit/select-review.html:24 src/olympia/devhub/templates/devhub/docs/policies-reviews.html:42
 msgid "Full Review"
 msgstr ""
 
-#: src/olympia/devhub/forms.py:557
-#: src/olympia/devhub/templates/devhub/addons/submit/select-review.html:47
-#: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:153
+#: src/olympia/devhub/forms.py:566 src/olympia/devhub/templates/devhub/addons/submit/select-review.html:47 src/olympia/devhub/templates/devhub/docs/policies-reviews.html:153
 msgid "Preliminary Review"
 msgstr ""
 
-#: src/olympia/devhub/forms.py:561
+#: src/olympia/devhub/forms.py:570
 msgid "Please choose a review nomination type"
 msgstr ""
 
-#: src/olympia/devhub/forms.py:565
-msgid ""
-"A file with a version ending with a|alpha|b|beta|pre|rc and an optional "
-"number is detected as beta."
+#: src/olympia/devhub/forms.py:574
+msgid "A file with a version ending with a|alpha|b|beta|pre|rc and an optional number is detected as beta."
 msgstr ""
 
-#: src/olympia/devhub/forms.py:583
+#: src/olympia/devhub/forms.py:592
 #, python-format
 msgid "Version %s already exists, or was uploaded before."
 msgstr ""
 
-#: src/olympia/devhub/forms.py:596
-msgid ""
-"Select a valid choice. That choice is not one of the available choices."
+#: src/olympia/devhub/forms.py:605
+msgid "Select a valid choice. That choice is not one of the available choices."
 msgstr ""
 
-#: src/olympia/devhub/forms.py:602
-msgid ""
-"A file with a version ending with a|alpha|b|beta and an optional number is "
-"detected as beta."
+#: src/olympia/devhub/forms.py:611
+msgid "A file with a version ending with a|alpha|b|beta and an optional number is detected as beta."
 msgstr ""
 
-#: src/olympia/devhub/forms.py:625
+#: src/olympia/devhub/forms.py:634
 msgid "You cannot upload any more files for this version."
 msgstr ""
 
-#: src/olympia/devhub/forms.py:631
+#: src/olympia/devhub/forms.py:640
 msgid "Version doesn't match"
 msgstr ""
 
-#: src/olympia/devhub/forms.py:660
-msgid ""
-"You cannot delete a file once the review process has started.  You must "
-"delete the whole version."
+#: src/olympia/devhub/forms.py:669
+msgid "You cannot delete a file once the review process has started.  You must delete the whole version."
 msgstr ""
 
-#: src/olympia/devhub/forms.py:680
+#: src/olympia/devhub/forms.py:689
 msgid "The platform All cannot be combined with specific platforms."
 msgstr ""
 
-#: src/olympia/devhub/forms.py:685
+#: src/olympia/devhub/forms.py:694
 msgid "A platform can only be chosen once."
 msgstr ""
 
-#: src/olympia/devhub/forms.py:698
+#: src/olympia/devhub/forms.py:707
 msgid "A review type must be selected."
 msgstr ""
 
-#: src/olympia/devhub/forms.py:780 src/olympia/editors/forms.py:114
-#: src/olympia/zadmin/forms.py:49 src/olympia/zadmin/forms.py:52
+#: src/olympia/devhub/forms.py:789 src/olympia/editors/forms.py:114 src/olympia/editors/forms.py:254 src/olympia/zadmin/forms.py:49 src/olympia/zadmin/forms.py:52
 msgid "Select an application first"
 msgstr ""
 
-#: src/olympia/devhub/forms.py:832
+#: src/olympia/devhub/forms.py:841
 msgid "There cannot be more than 3 required add-ons."
 msgstr ""
 
@@ -4666,183 +3895,169 @@ msgstr[1] ""
 msgstr[2] ""
 msgstr[3] ""
 
-#: src/olympia/devhub/models.py:375
-#: src/olympia/reviews/templates/reviews/add.html:58
+#: src/olympia/devhub/models.py:375 src/olympia/reviews/templates/reviews/add.html:58
 msgid "Review"
 msgstr ""
 
-#: src/olympia/devhub/tasks.py:590
+#: src/olympia/devhub/tasks.py:583
 #, python-format
 msgid "%s responded with %s (%s)."
 msgstr ""
 
-#: src/olympia/devhub/tasks.py:594
+#: src/olympia/devhub/tasks.py:587
 #, python-format
 msgid "Connection to \"%s\" timed out."
 msgstr ""
 
-#: src/olympia/devhub/tasks.py:596
+#: src/olympia/devhub/tasks.py:589
 #, python-format
 msgid "Could not contact host at \"%s\"."
 msgstr ""
 
 #: src/olympia/devhub/utils.py:105
 #, python-format
-msgid ""
-"Validation generated too many errors/warnings so %s messages were truncated."
-" After addressing the visible messages, you'll be able to see the others."
+msgid "Validation generated too many errors/warnings so %s messages were truncated. After addressing the visible messages, you'll be able to see the others."
 msgstr ""
 
-#: src/olympia/devhub/views.py:183
+#: src/olympia/devhub/views.py:181
 msgid "All My Add-ons"
 msgstr ""
 
-#: src/olympia/devhub/views.py:210
+#: src/olympia/devhub/views.py:208
 msgid "All Activity"
 msgstr ""
 
-#: src/olympia/devhub/views.py:211
+#: src/olympia/devhub/views.py:209
 msgid "Add-on Updates"
 msgstr ""
 
-#: src/olympia/devhub/views.py:212
+#: src/olympia/devhub/views.py:210
 msgid "Add-on Status"
 msgstr ""
 
-#: src/olympia/devhub/views.py:213
+#: src/olympia/devhub/views.py:211
 msgid "User Collections"
 msgstr ""
 
-#: src/olympia/devhub/views.py:214
-#: src/olympia/devhub/templates/devhub/docs/policies-maintenance.html:68
-#: src/olympia/pages/templates/pages/dev_faq.html:38
+#: src/olympia/devhub/views.py:212 src/olympia/devhub/templates/devhub/docs/policies-maintenance.html:68 src/olympia/pages/templates/pages/dev_faq.html:38
 #: src/olympia/pages/templates/pages/dev_faq.html:484
 msgid "User Reviews"
 msgstr ""
 
-#: src/olympia/devhub/views.py:327 src/olympia/devhub/views.py:331
-#: src/olympia/devhub/views.py:487 src/olympia/devhub/views.py:516
-#: src/olympia/devhub/views.py:567 src/olympia/devhub/views.py:1160
+#: src/olympia/devhub/views.py:325 src/olympia/devhub/views.py:329 src/olympia/devhub/views.py:484 src/olympia/devhub/views.py:513 src/olympia/devhub/views.py:564 src/olympia/devhub/views.py:1156
 msgid "Changes successfully saved."
 msgstr ""
 
-#: src/olympia/devhub/views.py:334 src/olympia/devhub/views.py:1634
+#: src/olympia/devhub/views.py:332 src/olympia/devhub/views.py:1637
 msgid "Please check the form for errors."
 msgstr ""
 
-#: src/olympia/devhub/views.py:346
+#: src/olympia/devhub/views.py:344
 msgid "Add-on cannot be deleted. Disable this add-on instead."
 msgstr ""
 
-#: src/olympia/devhub/views.py:356
+#: src/olympia/devhub/views.py:354
 msgid "Theme deleted."
 msgstr ""
 
-#: src/olympia/devhub/views.py:356
+#: src/olympia/devhub/views.py:354
 msgid "Add-on deleted."
 msgstr ""
 
-#: src/olympia/devhub/views.py:362
+#: src/olympia/devhub/views.py:360
 msgid "URL name was incorrect. Theme was not deleted."
 msgstr ""
 
-#: src/olympia/devhub/views.py:367
+#: src/olympia/devhub/views.py:365
 msgid "URL name was incorrect. Add-on was not deleted."
 msgstr ""
 
-#: src/olympia/devhub/views.py:452
+#: src/olympia/devhub/views.py:449
 msgid "An author has been added to your add-on"
 msgstr ""
 
-#: src/olympia/devhub/views.py:459
+#: src/olympia/devhub/views.py:456
 msgid "An author has a role changed on your add-on"
 msgstr ""
 
-#: src/olympia/devhub/views.py:479
+#: src/olympia/devhub/views.py:476
 msgid "An author has been removed from your add-on"
 msgstr ""
 
-#: src/olympia/devhub/views.py:522
+#: src/olympia/devhub/views.py:519
 msgid "There were errors in your submission."
 msgstr ""
 
-#: src/olympia/devhub/views.py:586
+#: src/olympia/devhub/views.py:583
 msgid "Validate Add-on"
 msgstr ""
 
-#: src/olympia/devhub/views.py:597
+#: src/olympia/devhub/views.py:594
 msgid "Check Add-on Compatibility"
 msgstr ""
 
-#: src/olympia/devhub/views.py:812 src/olympia/signing/views.py:95
+#: src/olympia/devhub/views.py:808 src/olympia/signing/views.py:95
 msgid "You cannot submit this type of add-on"
 msgstr ""
 
-#: src/olympia/devhub/views.py:1055 src/olympia/users/forms.py:471
+#: src/olympia/devhub/views.py:1051 src/olympia/users/forms.py:471
 msgid "Images must be either PNG or JPG."
 msgstr ""
 
-#: src/olympia/devhub/views.py:1059
+#: src/olympia/devhub/views.py:1055
 msgid "Icons cannot be animated."
 msgstr ""
 
-#: src/olympia/devhub/views.py:1061
+#: src/olympia/devhub/views.py:1057
 msgid "Images cannot be animated."
 msgstr ""
 
-#: src/olympia/devhub/views.py:1074
+#: src/olympia/devhub/views.py:1070
 #, python-format
 msgid "Images cannot be larger than %dKB."
 msgstr ""
 
 #. L10n: {0} is an image width (in pixels), {1} is a height.
-#: src/olympia/devhub/views.py:1084
+#: src/olympia/devhub/views.py:1080
 msgid "Image must be exactly {0} pixels wide and {1} pixels tall."
 msgstr ""
 
-#: src/olympia/devhub/views.py:1091
+#: src/olympia/devhub/views.py:1087
 msgid "There was an error uploading your preview."
 msgstr ""
 
-#: src/olympia/devhub/views.py:1199
+#: src/olympia/devhub/views.py:1195
 #, python-format
 msgid "Version %s disabled."
 msgstr ""
 
-#: src/olympia/devhub/views.py:1203
+#: src/olympia/devhub/views.py:1199
 #, python-format
 msgid "Version %s deleted."
 msgstr ""
 
-#: src/olympia/devhub/views.py:1213
-msgid ""
-"This upload has failed validation, and may lack complete validation results."
-" Please take due care when reviewing it."
+#: src/olympia/devhub/views.py:1209
+msgid "This upload has failed validation, and may lack complete validation results. Please take due care when reviewing it."
 msgstr ""
 
-#: src/olympia/devhub/views.py:1680
+#: src/olympia/devhub/views.py:1683
 msgid "Preliminary Review Requested."
 msgstr ""
 
-#: src/olympia/devhub/views.py:1681
+#: src/olympia/devhub/views.py:1684
 msgid "Full Review Requested."
 msgstr ""
 
-#: src/olympia/devhub/views.py:1782
-msgid ""
-"Your old credentials were revoked and are no longer valid. Be sure to update"
-" all API clients with the new credentials."
+#: src/olympia/devhub/views.py:1783
+msgid "Your old credentials were revoked and are no longer valid. Be sure to update all API clients with the new credentials."
 msgstr ""
 
-#: src/olympia/devhub/views.py:1800
+#: src/olympia/devhub/views.py:1801
 msgid "New API key created"
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/agreement.html:2
-msgid ""
-"Before starting, please read and accept our Firefox Add-on Distribution "
-"Agreement. It also links to our Privacy Notice which explains how we handle "
-"your information."
+msgid "Before starting, please read and accept our Firefox Add-on Distribution Agreement. It also links to our Privacy Notice which explains how we handle your information."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/agreement.html:13
@@ -4857,44 +4072,30 @@ msgstr ""
 msgid "or <a href=\"{0}\">Cancel</a>"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/base.html:23
-#: src/olympia/devhub/templates/devhub/base_impala.html:20
-#: src/olympia/discovery/templates/discovery/addons/base.html:17
+#: src/olympia/devhub/templates/devhub/base.html:23 src/olympia/devhub/templates/devhub/base_impala.html:20 src/olympia/discovery/templates/discovery/addons/base.html:17
 msgid "Back to Add-ons"
 msgstr ""
 
 #. {0} is a search term, such as Firebug.
 #. {0} is a search query.
-#: src/olympia/devhub/templates/devhub/devhub_search.html:4
-#: src/olympia/search/templates/search/results.html:9
-#: src/olympia/search/templates/search/mobile/results.html:6
+#: src/olympia/devhub/templates/devhub/devhub_search.html:4 src/olympia/search/templates/search/results.html:9 src/olympia/search/templates/search/mobile/results.html:6
 msgid "{0} :: Search"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/devhub_search.html:6
-#: src/olympia/devhub/templates/devhub/search.html:8
-#: src/olympia/editors/forms.py:430 src/olympia/editors/forms.py:432
-#: src/olympia/editors/templates/editors/queue.html:27
-#: src/olympia/editors/templates/editors/themes/queue_list.html:14
-#: src/olympia/search/templates/search/collections.html:17
-#: src/olympia/search/templates/search/personas.html:18
-#: src/olympia/search/templates/search/results.html:18
-#: src/olympia/search/templates/search/mobile/results.html:8
-#: src/olympia/templates/search.html:14
-#: src/olympia/templates/impala/search.html:18
+#: src/olympia/devhub/templates/devhub/devhub_search.html:6 src/olympia/devhub/templates/devhub/search.html:8 src/olympia/editors/forms.py:534 src/olympia/editors/forms.py:536
+#: src/olympia/editors/templates/editors/queue.html:27 src/olympia/editors/templates/editors/themes/queue_list.html:14 src/olympia/search/templates/search/collections.html:17
+#: src/olympia/search/templates/search/personas.html:18 src/olympia/search/templates/search/results.html:18 src/olympia/search/templates/search/mobile/results.html:8
+#: src/olympia/templates/search.html:14 src/olympia/templates/impala/search.html:18
 msgid "Search"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/devhub_search.html:11
-#: src/olympia/devhub/templates/devhub/devhub_search.html:15
-#: src/olympia/search/templates/search/collections.html:18
+#: src/olympia/devhub/templates/devhub/devhub_search.html:11 src/olympia/devhub/templates/devhub/devhub_search.html:15 src/olympia/search/templates/search/collections.html:18
 #: src/olympia/search/templates/search/personas.html:20
 msgid "Search Results"
 msgstr ""
 
 #. {0} is a search term, such as Firebug.
-#: src/olympia/devhub/templates/devhub/devhub_search.html:13
-#: src/olympia/search/templates/search/results.html:11
+#: src/olympia/devhub/templates/devhub/devhub_search.html:13 src/olympia/search/templates/search/results.html:11
 msgid "Search Results for \"{0}\""
 msgstr ""
 
@@ -4915,9 +4116,7 @@ msgid "AMO Reviewers"
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/index.html:29
-msgid ""
-"Get ahead! Become an AMO Reviewer today and get your add-ons reviewed "
-"faster."
+msgid "Get ahead! Become an AMO Reviewer today and get your add-ons reviewed faster."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/index.html:32
@@ -4930,33 +4129,25 @@ msgstr ""
 
 #: src/olympia/devhub/templates/devhub/index.html:41
 msgid ""
-"Add-ons let millions of Firefox users enhance and customize their browsing "
-"experience. If you're a Web developer and know <a "
-"href=\"https://developer.mozilla.org/docs/Web/HTML\">HTML</a>, <a "
-"href=\"https://developer.mozilla.org/docs/Web/JavaScript\">JavaScript</a>, "
-"and <a href=\"https://developer.mozilla.org/docs/Web/CSS\">CSS</a>, you "
-"already have all the necessary skills to make a great add-on."
+"Add-ons let millions of Firefox users enhance and customize their browsing experience. If you're a Web developer and know <a href=\"https://developer.mozilla.org/docs/Web/HTML\">HTML</a>, <a href="
+"\"https://developer.mozilla.org/docs/Web/JavaScript\">JavaScript</a>, and <a href=\"https://developer.mozilla.org/docs/Web/CSS\">CSS</a>, you already have all the necessary skills to make a great "
+"add-on."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/index.html:51
-msgid ""
-"Head over to the <a href=\"https://developer.mozilla.org/Add-ons\">Mozilla "
-"Developer Network</a> to learn everything you need to know to get started."
+msgid "Head over to the <a href=\"https://developer.mozilla.org/Add-ons\">Mozilla Developer Network</a> to learn everything you need to know to get started."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/index.html:58
 msgid "Start Making Add-ons"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/index.html:86
-#: src/olympia/devhub/templates/devhub/addons/listing/items.html:25
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:20
+#: src/olympia/devhub/templates/devhub/index.html:86 src/olympia/devhub/templates/devhub/addons/listing/items.html:25 src/olympia/devhub/templates/devhub/includes/addon_details.html:20
 #: src/olympia/devhub/templates/devhub/personas/edit.html:43
 msgid "Status:"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/index.html:90
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:87
+#: src/olympia/devhub/templates/devhub/index.html:90 src/olympia/devhub/templates/devhub/includes/addon_details.html:87
 msgid "Visibility:"
 msgstr ""
 
@@ -4964,21 +4155,16 @@ msgstr ""
 msgid "Latest Version:"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/index.html:109
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:131
-#: src/olympia/devhub/templates/devhub/personas/edit.html:49
+#: src/olympia/devhub/templates/devhub/index.html:109 src/olympia/devhub/templates/devhub/includes/addon_details.html:131 src/olympia/devhub/templates/devhub/personas/edit.html:49
 msgid "Queue Position:"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/index.html:110
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:132
-#: src/olympia/devhub/templates/devhub/personas/edit.html:50
+#: src/olympia/devhub/templates/devhub/index.html:110 src/olympia/devhub/templates/devhub/includes/addon_details.html:132 src/olympia/devhub/templates/devhub/personas/edit.html:50
 #, python-format
 msgid "%(position)s of %(total)s"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/index.html:120
-#: src/olympia/devhub/templates/devhub/includes/addons_edit_nav.html:19
+#: src/olympia/devhub/templates/devhub/index.html:120 src/olympia/devhub/templates/devhub/includes/addons_edit_nav.html:19
 msgid "Upload New Version"
 msgstr ""
 
@@ -4992,9 +4178,7 @@ msgstr ""
 
 #: src/olympia/devhub/templates/devhub/index.html:136
 #, python-format
-msgid ""
-"Upload an <a href=\"%(addon_url)s\">add-on</a> or <a "
-"href=\"%(theme_url)s\">theme</a> to get started!"
+msgid "Upload an <a href=\"%(addon_url)s\">add-on</a> or <a href=\"%(theme_url)s\">theme</a> to get started!"
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/nav.html:2
@@ -5022,17 +4206,10 @@ msgstr ""
 msgid "Lightweight Themes"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/nav.html:39
-#: src/olympia/devhub/templates/devhub/docs/policies-agreement.html:6
-#: src/olympia/devhub/templates/devhub/docs/policies-contact.html:6
-#: src/olympia/devhub/templates/devhub/docs/policies-maintenance.html:6
-#: src/olympia/devhub/templates/devhub/docs/policies-recommended.html:6
-#: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:6
-#: src/olympia/devhub/templates/devhub/docs/policies-submission.html:6
-#: src/olympia/devhub/templates/devhub/docs/policies.html:3
-#: src/olympia/devhub/templates/devhub/docs/policies.html:9
-#: src/olympia/devhub/templates/devhub/docs/policies.html:38
-#: src/olympia/devhub/templates/devhub/docs/policies.html:39
+#: src/olympia/devhub/templates/devhub/nav.html:39 src/olympia/devhub/templates/devhub/docs/policies-agreement.html:6 src/olympia/devhub/templates/devhub/docs/policies-contact.html:6
+#: src/olympia/devhub/templates/devhub/docs/policies-maintenance.html:6 src/olympia/devhub/templates/devhub/docs/policies-recommended.html:6
+#: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:6 src/olympia/devhub/templates/devhub/docs/policies-submission.html:6 src/olympia/devhub/templates/devhub/docs/policies.html:3
+#: src/olympia/devhub/templates/devhub/docs/policies.html:9 src/olympia/devhub/templates/devhub/docs/policies.html:38 src/olympia/devhub/templates/devhub/docs/policies.html:39
 msgid "Add-on Policies"
 msgstr ""
 
@@ -5073,19 +4250,14 @@ msgid "Use the field below to upload your add-on package."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/validate_addon.html:19
-msgid ""
-"After upload, a series of automated validation tests will run to check "
-"compatibility with the following application version:"
+msgid "After upload, a series of automated validation tests will run to check compatibility with the following application version:"
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/validate_addon.html:34
-msgid ""
-"After upload, a series of automated validation tests will be run on your "
-"file."
+msgid "After upload, a series of automated validation tests will be run on your file."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/validate_addon.html:42
-#: src/olympia/devhub/templates/devhub/addons/submit/upload.html:23
+#: src/olympia/devhub/templates/devhub/validate_addon.html:42 src/olympia/devhub/templates/devhub/addons/submit/upload.html:23
 msgid "Do you want your add-on to be distributed on this site?"
 msgstr ""
 
@@ -5106,14 +4278,11 @@ msgstr ""
 msgid "Tested for compatibility against:"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/addons/activity.html:4
-#: src/olympia/devhub/templates/devhub/addons/activity.html:20
+#: src/olympia/devhub/templates/devhub/addons/activity.html:4 src/olympia/devhub/templates/devhub/addons/activity.html:20
 msgid "Recent Activity for My Add-ons"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/addons/activity.html:14
-#: src/olympia/devhub/templates/devhub/addons/activity.html:19
-#: src/olympia/devhub/templates/devhub/addons/dashboard.html:33
+#: src/olympia/devhub/templates/devhub/addons/activity.html:14 src/olympia/devhub/templates/devhub/addons/activity.html:19 src/olympia/devhub/templates/devhub/addons/dashboard.html:33
 msgid "Recent Activity"
 msgstr ""
 
@@ -5135,37 +4304,30 @@ msgstr ""
 msgid "Activity"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/addons/activity.html:83
-#: src/olympia/devhub/templates/devhub/addons/dashboard.html:34
-#: src/olympia/devhub/templates/devhub/addons/dashboard.html:35
-#: src/olympia/devhub/templates/devhub/includes/blog_posts.html:4
-#: src/olympia/devhub/templates/devhub/includes/blog_posts.html:6
+#: src/olympia/devhub/templates/devhub/addons/activity.html:83 src/olympia/devhub/templates/devhub/addons/dashboard.html:34 src/olympia/devhub/templates/devhub/addons/dashboard.html:35
+#: src/olympia/devhub/templates/devhub/includes/blog_posts.html:4 src/olympia/devhub/templates/devhub/includes/blog_posts.html:6
 msgid "Subscribe to this feed"
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/ajax_compat_error.html:7
 #, python-format
 msgid ""
-"This add-on is incompatible with <b>%(app_name)s %(app_version)s</b>, the "
-"latest release of %(app_name)s. Please consider updating your add-on's "
-"compatibility info, or uploading a newer version of this add-on."
+"This add-on is incompatible with <b>%(app_name)s %(app_version)s</b>, the latest release of %(app_name)s. Please consider updating your add-on's compatibility info, or uploading a newer version of "
+"this add-on."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/ajax_compat_error.html:15
 #, python-format
 msgid ""
-"<a href=\"#\" class=\"button compat-update\" data-"
-"updateurl=\"%(update_url)s\">Update Compatibility</a> <a "
-"href=\"%(version_url)s\" class=\"button\">Upload New Version</a> or <a "
-"href=\"#\" class=\"close\">Ignore</a>"
+"<a href=\"#\" class=\"button compat-update\" data-updateurl=\"%(update_url)s\">Update Compatibility</a> <a href=\"%(version_url)s\" class=\"button\">Upload New Version</a> or <a href=\"#\" class="
+"\"close\">Ignore</a>"
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/ajax_compat_status.html:5
 msgid "View and update application compatibility ranges."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/addons/ajax_compat_status.html:6
-#: src/olympia/devhub/templates/devhub/versions/edit.html:44
+#: src/olympia/devhub/templates/devhub/addons/ajax_compat_status.html:6 src/olympia/devhub/templates/devhub/versions/edit.html:44
 msgid "Compatibility"
 msgstr ""
 
@@ -5173,37 +4335,25 @@ msgstr ""
 msgid "Update Compatibility"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/addons/ajax_compat_update.html:4
-#: src/olympia/devhub/templates/devhub/versions/edit.html:45
-msgid ""
-"Adjusting application information here will allow users to install your add-"
-"on even if the install manifest in the package indicates that the add-on is "
-"incompatible."
+#: src/olympia/devhub/templates/devhub/addons/ajax_compat_update.html:4 src/olympia/devhub/templates/devhub/versions/edit.html:45
+msgid "Adjusting application information here will allow users to install your add-on even if the install manifest in the package indicates that the add-on is incompatible."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/ajax_compat_update.html:18
 msgid "Supported Versions"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/addons/ajax_compat_update.html:31
-#: src/olympia/devhub/templates/devhub/versions/edit.html:63
+#: src/olympia/devhub/templates/devhub/addons/ajax_compat_update.html:31 src/olympia/devhub/templates/devhub/versions/edit.html:63
 msgid "Add Another Application&hellip;"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/addons/ajax_compat_update.html:38
-#: src/olympia/devhub/templates/devhub/addons/owner.html:86
-#: src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:45
-#: src/olympia/devhub/templates/devhub/versions/list.html:349
-#: src/olympia/devhub/templates/devhub/versions/list.html:351
-#: src/olympia/templates/impala/base.html:129
-#: src/olympia/templates/impala/base.html:140
-#: src/olympia/templates/impala/base.html:158
-#: src/olympia/templates/impala/base.html:168
+#: src/olympia/devhub/templates/devhub/addons/ajax_compat_update.html:38 src/olympia/devhub/templates/devhub/addons/owner.html:86 src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:45
+#: src/olympia/devhub/templates/devhub/versions/list.html:349 src/olympia/devhub/templates/devhub/versions/list.html:351 src/olympia/templates/impala/base.html:129
+#: src/olympia/templates/impala/base.html:140 src/olympia/templates/impala/base.html:158 src/olympia/templates/impala/base.html:168
 msgid "Close"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/addons/dashboard.html:43
-#: src/olympia/zadmin/templates/zadmin/index.html:22
+#: src/olympia/devhub/templates/devhub/addons/dashboard.html:43 src/olympia/zadmin/templates/zadmin/index.html:22
 #, python-format
 msgid "%(ago)s by %(user)s"
 msgstr ""
@@ -5221,30 +4371,21 @@ msgstr[1] ""
 msgstr[2] ""
 msgstr[3] ""
 
-#: src/olympia/devhub/templates/devhub/addons/edit.html:3
-#: src/olympia/devhub/templates/devhub/addons/listing/item_actions.html:25
-#: src/olympia/devhub/templates/devhub/addons/listing/item_actions_theme.html:7
-#: src/olympia/devhub/templates/devhub/includes/addons_edit_nav.html:2
-#: src/olympia/devhub/templates/devhub/personas/edit.html:6
-#: src/olympia/editors/templates/editors/themes/single.html:37
+#: src/olympia/devhub/templates/devhub/addons/edit.html:3 src/olympia/devhub/templates/devhub/addons/listing/item_actions.html:25
+#: src/olympia/devhub/templates/devhub/addons/listing/item_actions_theme.html:7 src/olympia/devhub/templates/devhub/includes/addons_edit_nav.html:2
+#: src/olympia/devhub/templates/devhub/personas/edit.html:6 src/olympia/editors/templates/editors/themes/single.html:37
 msgid "Edit Listing"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/addons/edit.html:13
-#: src/olympia/devhub/templates/devhub/includes/macros.html:18
-#: src/olympia/translations/templates/translations/all-locales.html:6
+#: src/olympia/devhub/templates/devhub/addons/edit.html:13 src/olympia/devhub/templates/devhub/includes/macros.html:18 src/olympia/translations/templates/translations/all-locales.html:6
 msgid "None"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/addons/owner.html:4
-#: src/olympia/devhub/templates/devhub/addons/listing/item_actions.html:52
-#: src/olympia/devhub/templates/devhub/includes/addons_edit_nav.html:3
+#: src/olympia/devhub/templates/devhub/addons/owner.html:4 src/olympia/devhub/templates/devhub/addons/listing/item_actions.html:52 src/olympia/devhub/templates/devhub/includes/addons_edit_nav.html:3
 msgid "Manage Authors & License"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/addons/owner.html:29
-#: src/olympia/editors/helpers.py:362
-#: src/olympia/editors/templates/editors/review.html:270
+#: src/olympia/devhub/templates/devhub/addons/owner.html:29 src/olympia/editors/helpers.py:362 src/olympia/editors/templates/editors/review.html:270
 msgid "Authors"
 msgstr ""
 
@@ -5254,25 +4395,18 @@ msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/owner.html:78
 msgid ""
-"<p>Add-ons can have any number of authors with 3 possible roles:</p> <ul> "
-"<li><b>Owner:</b> Can manage all aspects of the add-on's listing, including "
-"adding and removing other authors</li> <li><b>Developer:</b> Can manage all "
-"aspects of the add-on's listing, except for adding and removing other "
-"authors and managing payments</li> <li><b>Viewer:</b> Can view the add-on's "
-"settings and statistics, but cannot make any changes</li> </ul>"
+"<p>Add-ons can have any number of authors with 3 possible roles:</p> <ul> <li><b>Owner:</b> Can manage all aspects of the add-on's listing, including adding and removing other authors</li> "
+"<li><b>Developer:</b> Can manage all aspects of the add-on's listing, except for adding and removing other authors and managing payments</li> <li><b>Viewer:</b> Can view the add-on's settings and "
+"statistics, but cannot make any changes</li> </ul>"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/addons/profile.html:3
-#: src/olympia/devhub/templates/devhub/addons/listing/item_actions.html:53
-#: src/olympia/devhub/templates/devhub/includes/addons_edit_nav.html:4
+#: src/olympia/devhub/templates/devhub/addons/profile.html:3 src/olympia/devhub/templates/devhub/addons/listing/item_actions.html:53 src/olympia/devhub/templates/devhub/includes/addons_edit_nav.html:4
 msgid "Manage Developer Profile"
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/profile.html:16
 #, python-format
-msgid ""
-"Your <a href=\"%(url)s\">developer profile</a> is currently "
-"<strong>public</strong> and <strong>required</strong> for contributions."
+msgid "Your <a href=\"%(url)s\">developer profile</a> is currently <strong>public</strong> and <strong>required</strong> for contributions."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/profile.html:22
@@ -5281,9 +4415,7 @@ msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/profile.html:27
 #, python-format
-msgid ""
-"Your <a href=\"%(url)s\">developer profile</a> is currently "
-"<strong>public</strong>."
+msgid "Your <a href=\"%(url)s\">developer profile</a> is currently <strong>public</strong>."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/profile.html:33
@@ -5311,11 +4443,8 @@ msgstr ""
 msgid "Choose a short, unique URL slug for your add-on."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/addons/edit/basic.html:43
-#: src/olympia/devhub/templates/devhub/includes/addons_edit_nav.html:35
-#: src/olympia/devhub/templates/devhub/personas/edit.html:56
-#: src/olympia/editors/templates/editors/review.html:255
-#: src/olympia/editors/templates/editors/themes/single.html:33
+#: src/olympia/devhub/templates/devhub/addons/edit/basic.html:43 src/olympia/devhub/templates/devhub/includes/addons_edit_nav.html:35 src/olympia/devhub/templates/devhub/personas/edit.html:56
+#: src/olympia/editors/templates/editors/review.html:255 src/olympia/editors/templates/editors/themes/single.html:33
 msgid "View Listing"
 msgstr ""
 
@@ -5325,36 +4454,24 @@ msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/basic.html:52
 msgid ""
-"A short explanation of your add-on's basic functionality that is displayed "
-"in search and browse listings, as well as at the top of your add-on's "
-"details page. It is only relevant for listed add-ons."
+"A short explanation of your add-on's basic functionality that is displayed in search and browse listings, as well as at the top of your add-on's details page. It is only relevant for listed add-ons."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/basic.html:73
-msgid ""
-"Categories are the primary way users browse through add-ons. Choose any that"
-" fit your add-on's functionality for the most exposure. It is only relevant "
-"for listed add-ons."
+msgid "Categories are the primary way users browse through add-ons. Choose any that fit your add-on's functionality for the most exposure. It is only relevant for listed add-ons."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/basic.html:90
 #, python-format
 msgid ""
-"Categories cannot be changed while your add-on is featured for this "
-"application. Please email <a href=\"mailto:%(email)s\">%(email)s</a> if "
-"there is a reason you need to modify your categories."
+"Categories cannot be changed while your add-on is featured for this application. Please email <a href=\"mailto:%(email)s\">%(email)s</a> if there is a reason you need to modify your categories."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/basic.html:119
-msgid ""
-"Tags help users find your add-on and should be short descriptors such as "
-"tabs, toolbar, or twitter. You may have a maximum of {0} tags. It is only "
-"relevant for listed add-ons."
+msgid "Tags help users find your add-on and should be short descriptors such as tabs, toolbar, or twitter. You may have a maximum of {0} tags. It is only relevant for listed add-ons."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/addons/edit/basic.html:129
-#: src/olympia/devhub/templates/devhub/personas/edit.html:97
-#: src/olympia/devhub/templates/devhub/personas/submit.html:46
+#: src/olympia/devhub/templates/devhub/addons/edit/basic.html:129 src/olympia/devhub/templates/devhub/personas/edit.html:97 src/olympia/devhub/templates/devhub/personas/submit.html:46
 msgid "Comma-separated, minimum of {0} character."
 msgid_plural "Comma-separated, minimum of {0} characters."
 msgstr[0] ""
@@ -5362,9 +4479,7 @@ msgstr[1] ""
 msgstr[2] ""
 msgstr[3] ""
 
-#: src/olympia/devhub/templates/devhub/addons/edit/basic.html:132
-#: src/olympia/devhub/templates/devhub/personas/edit.html:100
-#: src/olympia/devhub/templates/devhub/personas/submit.html:49
+#: src/olympia/devhub/templates/devhub/addons/edit/basic.html:132 src/olympia/devhub/templates/devhub/personas/edit.html:100 src/olympia/devhub/templates/devhub/personas/submit.html:49
 msgid "Example: dark, cinema, noir. Limit 20."
 msgstr ""
 
@@ -5385,37 +4500,26 @@ msgid "Add-on Details for {0}"
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/details.html:22
-msgid ""
-"A longer explanation of features, functionality, and other relevant "
-"information. This field is only displayed on the add-on's details page. It "
-"is only relevant for listed add-ons."
+msgid "A longer explanation of features, functionality, and other relevant information. This field is only displayed on the add-on's details page. It is only relevant for listed add-ons."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/addons/edit/details.html:44
-#: src/olympia/translations/templates/translations/trans-menu.html:13
+#: src/olympia/devhub/templates/devhub/addons/edit/details.html:44 src/olympia/translations/templates/translations/trans-menu.html:13
 msgid "Default Locale"
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/details.html:45
-msgid ""
-"Information about your add-on is displayed in this locale unless you "
-"override it with a locale-specific translation. It is only relevant for "
-"listed add-ons."
+msgid "Information about your add-on is displayed in this locale unless you override it with a locale-specific translation. It is only relevant for listed add-ons."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/addons/edit/details.html:61
-#: src/olympia/users/forms.py:311
-#: src/olympia/users/templates/users/edit.html:122
-#: src/olympia/users/templates/users/register.html:57
+#: src/olympia/devhub/templates/devhub/addons/edit/details.html:61 src/olympia/users/forms.py:311 src/olympia/users/templates/users/edit.html:122 src/olympia/users/templates/users/register.html:57
 #: src/olympia/users/templates/users/vcard.html:22
 msgid "Homepage"
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/details.html:63
 msgid ""
-"If your add-on has another homepage, enter its address here. If your website"
-" is localized into other languages multiple translations of this field can "
-"be added. It is only relevant for listed add-ons."
+"If your add-on has another homepage, enter its address here. If your website is localized into other languages multiple translations of this field can be added. It is only relevant for listed add-"
+"ons."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/media.html:3
@@ -5433,17 +4537,14 @@ msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/support.html:22
 msgid ""
-"If you wish to display an e-mail address for support inquiries, enter it "
-"here. If you have different addresses for each language multiple "
-"translations of this field can be added. It is only relevant for listed add-"
-"ons."
+"If you wish to display an e-mail address for support inquiries, enter it here. If you have different addresses for each language multiple translations of this field can be added. It is only "
+"relevant for listed add-ons."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/support.html:45
 msgid ""
-"If your add-on has a support website or forum, enter its address here. If "
-"your website is localized into other languages, multiple translations of "
-"this field can be added. It is only relevant for listed add-ons."
+"If your add-on has a support website or forum, enter its address here. If your website is localized into other languages, multiple translations of this field can be added. It is only relevant for "
+"listed add-ons."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:6
@@ -5457,10 +4558,8 @@ msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:23
 msgid ""
-"Any information end users may want to know that isn't necessarily applicable"
-" to the add-on summary or description. Common uses include listing known "
-"major bugs, information on how to report bugs, anticipated release date of a"
-" new version, etc. It is only relevant for listed add-ons."
+"Any information end users may want to know that isn't necessarily applicable to the add-on summary or description. Common uses include listing known major bugs, information on how to report bugs, "
+"anticipated release date of a new version, etc. It is only relevant for listed add-ons."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:46
@@ -5472,9 +4571,7 @@ msgid "Add-on Flags"
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:69
-msgid ""
-"These flags are used to classify add-ons. It is only relevant for listed "
-"add-ons."
+msgid "These flags are used to classify add-ons. It is only relevant for listed add-ons."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:74
@@ -5490,9 +4587,7 @@ msgid "View Source?"
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:90
-msgid ""
-"Whether the source of your add-on can be displayed in our online viewer. It "
-"is only relevant for listed add-ons."
+msgid "Whether the source of your add-on can be displayed in our online viewer. It is only relevant for listed add-ons."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:94
@@ -5508,9 +4603,7 @@ msgid "Public Stats?"
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:102
-msgid ""
-"Whether the download and usage stats of your add-on can be displayed in our "
-"online viewer. It is only relevant for listed add-ons."
+msgid "Whether the download and usage stats of your add-on can be displayed in our online viewer. It is only relevant for listed add-ons."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:107
@@ -5526,15 +4619,11 @@ msgid "Upgrade SDK?"
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:116
-msgid ""
-"If selected, we will try to automatically upgrade your add-on when a new "
-"version of the SDK is released. It is only relevant for listed add-ons."
+msgid "If selected, we will try to automatically upgrade your add-on when a new version of the SDK is released. It is only relevant for listed add-ons."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:121
-msgid ""
-"This add-on will be automatically upgraded to new versions of the Add-on "
-"SDK."
+msgid "This add-on will be automatically upgraded to new versions of the Add-on SDK."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:123
@@ -5550,22 +4639,17 @@ msgid "UUID"
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:132
-msgid ""
-"The UUID of your add-on is specified in its install manifest and uniquely "
-"identifies it. You cannot change your UUID once it has been submitted."
+msgid "The UUID of your add-on is specified in its install manifest and uniquely identifies it. You cannot change your UUID once it has been submitted."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/addons/edit/technical.html:143
-#: src/olympia/devhub/templates/devhub/addons/edit/technical.html:144
+#: src/olympia/devhub/templates/devhub/addons/edit/technical.html:143 src/olympia/devhub/templates/devhub/addons/edit/technical.html:144
 msgid "Whiteboard"
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:146
 msgid ""
-"The whiteboard is the place to provide information relevant to your addon, "
-"whatever the version, to the editor. Use it to provide ways to test the "
-"addon, and any additional information that may help. This whiteboard is also"
-" editable by editors."
+"The whiteboard is the place to provide information relevant to your addon, whatever the version, to the editor. Use it to provide ways to test the addon, and any additional information that may "
+"help. This whiteboard is also editable by editors."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/technical_dependencies.html:9
@@ -5586,10 +4670,8 @@ msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/forms_shared/media.html:16
 msgid ""
-"Upload an icon for your add-on or choose from one of ours. The icon is "
-"displayed nearly everywhere your add-on is. Uploaded images must be one of "
-"the following image types: .png, .jpg. It is only relevant for listed add-"
-"ons."
+"Upload an icon for your add-on or choose from one of ours. The icon is displayed nearly everywhere your add-on is. Uploaded images must be one of the following image types: .png, .jpg. It is only "
+"relevant for listed add-ons."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/forms_shared/media.html:25
@@ -5642,60 +4724,49 @@ msgstr ""
 msgid "Tests"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/addons/includes/validation_compat_test_results.html:25
-#: src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:5
+#: src/olympia/devhub/templates/devhub/addons/includes/validation_compat_test_results.html:25 src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:5
 #: src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:53
 msgid "General Tests"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/addons/includes/validation_compat_test_results.html:32
-#: src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:9
+#: src/olympia/devhub/templates/devhub/addons/includes/validation_compat_test_results.html:32 src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:9
 #: src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:67
 msgid "Security Tests"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/addons/includes/validation_compat_test_results.html:39
-#: src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:13
+#: src/olympia/devhub/templates/devhub/addons/includes/validation_compat_test_results.html:39 src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:13
 #: src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:80
 msgid "Extension Tests"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/addons/includes/validation_compat_test_results.html:46
-#: src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:17
+#: src/olympia/devhub/templates/devhub/addons/includes/validation_compat_test_results.html:46 src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:17
 #: src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:93
 msgid "Localization Tests"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:21
-#: src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:106
+#: src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:21 src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:106
 msgid "Compatibility Tests"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:29
-#: src/olympia/files/templates/files/viewer.html:142
+#: src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:29 src/olympia/files/templates/files/viewer.html:142
 msgid "Hide messages not required for automated signing"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:35
-#: src/olympia/files/templates/files/viewer.html:150
+#: src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:35 src/olympia/files/templates/files/viewer.html:150
 msgid "Hide messages present in previous version and ignored"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:50
-#: src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:64
-#: src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:77
-#: src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:90
+#: src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:50 src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:64
+#: src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:77 src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:90
 #: src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:103
 msgid "Top"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:2
-#: src/olympia/devhub/templates/devhub/personas/edit.html:63
+#: src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:2 src/olympia/devhub/templates/devhub/personas/edit.html:63
 msgid "Delete Theme"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:2
-#: src/olympia/devhub/templates/devhub/versions/list.html:117
+#: src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:2 src/olympia/devhub/templates/devhub/versions/list.html:117
 msgid "Delete Add-on"
 msgstr ""
 
@@ -5704,9 +4775,7 @@ msgid "Deleting your theme will permanently remove it from the site."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:14
-msgid ""
-"Deleting your add-on will permanently remove it from the site and prevent "
-"its GUID from being submitted again by others."
+msgid "Deleting your add-on will permanently remove it from the site and prevent its GUID from being submitted again by others."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:24
@@ -5721,8 +4790,7 @@ msgstr ""
 msgid "Please tell us why you are deleting your add-on:"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/addons/listing/item_actions.html:1
-#: src/olympia/devhub/templates/devhub/addons/listing/item_actions_theme.html:1
+#: src/olympia/devhub/templates/devhub/addons/listing/item_actions.html:1 src/olympia/devhub/templates/devhub/addons/listing/item_actions_theme.html:1
 #: src/olympia/editors/templates/editors/review.html:253
 msgid "Actions"
 msgstr ""
@@ -5755,22 +4823,17 @@ msgstr ""
 msgid "Daily statistics on downloads and users."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/addons/listing/item_actions.html:45
-#: src/olympia/stats/templates/stats/stats.html:75
-#: src/olympia/stats/templates/stats/stats.html:79
-#: src/olympia/stats/templates/stats/stats.html:81
+#: src/olympia/devhub/templates/devhub/addons/listing/item_actions.html:45 src/olympia/stats/templates/stats/stats.html:31 src/olympia/stats/templates/stats/stats.html:35
+#: src/olympia/stats/templates/stats/stats.html:37
 msgid "Statistics"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/addons/listing/item_actions.html:54
-#: src/olympia/devhub/templates/devhub/includes/addons_edit_nav.html:5
-#: src/olympia/devhub/templates/devhub/payments/payments.html:3
-#: src/olympia/devhub/templates/devhub/payments/tier.html:4
+#: src/olympia/devhub/templates/devhub/addons/listing/item_actions.html:54 src/olympia/devhub/templates/devhub/includes/addons_edit_nav.html:5
+#: src/olympia/devhub/templates/devhub/payments/payments.html:3 src/olympia/devhub/templates/devhub/payments/tier.html:4
 msgid "Manage Payments"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/addons/listing/item_actions.html:55
-#: src/olympia/devhub/templates/devhub/includes/addons_edit_nav.html:6
+#: src/olympia/devhub/templates/devhub/addons/listing/item_actions.html:55 src/olympia/devhub/templates/devhub/includes/addons_edit_nav.html:6
 msgid "Manage Status & Versions"
 msgstr ""
 
@@ -5778,10 +4841,8 @@ msgstr ""
 msgid "View Add-on Listing"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/addons/listing/item_actions.html:64
-#: src/olympia/devhub/templates/devhub/addons/listing/item_actions_theme.html:12
-#: src/olympia/devhub/templates/devhub/includes/addons_edit_nav.html:37
-#: src/olympia/devhub/templates/devhub/personas/edit.html:58
+#: src/olympia/devhub/templates/devhub/addons/listing/item_actions.html:64 src/olympia/devhub/templates/devhub/addons/listing/item_actions_theme.html:12
+#: src/olympia/devhub/templates/devhub/includes/addons_edit_nav.html:37 src/olympia/devhub/templates/devhub/personas/edit.html:58
 msgid "View Recent Changes"
 msgstr ""
 
@@ -5806,9 +4867,7 @@ msgid "Delete this theme."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/listing/items.html:10
-msgid ""
-"This add-on will be deleted automatically after a few days if the submission"
-" process is not completed."
+msgid "This add-on will be deleted automatically after a few days if the submission process is not completed."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/listing/items.html:27
@@ -5849,9 +4908,7 @@ msgstr ""
 msgid "The detail page will be:"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/addons/submit/describe.html:24
-#: src/olympia/devhub/templates/devhub/personas/edit.html:89
-#: src/olympia/devhub/templates/devhub/personas/submit.html:38
+#: src/olympia/devhub/templates/devhub/addons/submit/describe.html:24 src/olympia/devhub/templates/devhub/personas/edit.html:89 src/olympia/devhub/templates/devhub/personas/submit.html:38
 msgid "Please use only letters, numbers, underscores, and dashes in your URL."
 msgstr ""
 
@@ -5871,14 +4928,11 @@ msgstr ""
 msgid "The description will appear on the detail page."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/addons/submit/done.html:4
-#: src/olympia/devhub/templates/devhub/personas/submit_done.html:4
+#: src/olympia/devhub/templates/devhub/addons/submit/done.html:4 src/olympia/devhub/templates/devhub/personas/submit_done.html:4
 msgid "Submission Complete"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/addons/submit/done.html:8
-#: src/olympia/devhub/templates/devhub/addons/submit/sidebar.html:13
-#: src/olympia/devhub/templates/devhub/personas/submit_done.html:8
+#: src/olympia/devhub/templates/devhub/addons/submit/done.html:8 src/olympia/devhub/templates/devhub/addons/submit/sidebar.html:13 src/olympia/devhub/templates/devhub/personas/submit_done.html:8
 msgid "You're done!"
 msgstr ""
 
@@ -5891,20 +4945,14 @@ msgid "Your add-on has been submitted to the Full Review queue."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/submit/done.html:18
-msgid ""
-"You'll receive an email once it has been reviewed by an editor. In the "
-"meantime, you and your friends can install it directly from its details "
-"page:"
+msgid "You'll receive an email once it has been reviewed by an editor. In the meantime, you and your friends can install it directly from its details page:"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/addons/submit/done.html:27
-#: src/olympia/devhub/templates/devhub/addons/submit/done.html:77
-#: src/olympia/devhub/templates/devhub/personas/submit_done.html:16
+#: src/olympia/devhub/templates/devhub/addons/submit/done.html:27 src/olympia/devhub/templates/devhub/addons/submit/done.html:77 src/olympia/devhub/templates/devhub/personas/submit_done.html:16
 msgid "Next steps:"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/addons/submit/done.html:32
-#: src/olympia/devhub/templates/devhub/addons/submit/done.html:82
+#: src/olympia/devhub/templates/devhub/addons/submit/done.html:32 src/olympia/devhub/templates/devhub/addons/submit/done.html:82
 msgid "<a href=\"{0}\">Upload</a> another platform-specific file to this version."
 msgstr ""
 
@@ -5913,19 +4961,14 @@ msgid "Provide more details by <a href=\"{0}\">editing its listing</a>."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/submit/done.html:35
-msgid ""
-"Tell your users why you created this in your <a href=\"{0}\">Developer "
-"Profile</a>."
+msgid "Tell your users why you created this in your <a href=\"{0}\">Developer Profile</a>."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/submit/done.html:36
-msgid ""
-"View and subscribe to your add-on's <a href=\"{0}\">activity feed</a> to "
-"stay updated on reviews, collections, and more."
+msgid "View and subscribe to your add-on's <a href=\"{0}\">activity feed</a> to stay updated on reviews, collections, and more."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/addons/submit/done.html:37
-#: src/olympia/devhub/templates/devhub/addons/submit/done.html:86
+#: src/olympia/devhub/templates/devhub/addons/submit/done.html:37 src/olympia/devhub/templates/devhub/addons/submit/done.html:86
 msgid "View approximate review queue <a href=\"{0}\">wait times</a>."
 msgstr ""
 
@@ -5938,13 +4981,11 @@ msgid "Become an AMO Reviewer today and get your add-ons reviewed faster."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/submit/done.html:54
-msgid ""
-"Your add-on has been signed and it's ready to use. You can download it here:"
+msgid "Your add-on has been signed and it's ready to use. You can download it here:"
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/submit/done.html:64
-msgid ""
-"Your add-on has been submitted to the Unlisted Preliminary Review queue."
+msgid "Your add-on has been submitted to the Unlisted Preliminary Review queue."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/submit/done.html:66
@@ -5952,8 +4993,7 @@ msgid "Your add-on has been submitted to the Unlisted Full Review queue."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/submit/done.html:70
-msgid ""
-"You'll receive an email once it has been reviewed by an editor and signed."
+msgid "You'll receive an email once it has been reviewed by an editor and signed."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/submit/done.html:74
@@ -5961,9 +5001,7 @@ msgid "Your add-on will not be publicly available on this website."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/submit/done.html:84
-msgid ""
-"You can upload new versions of your add-on in the <a href=\"{0}\">add-on's "
-"developer page</a>."
+msgid "You can upload new versions of your add-on in the <a href=\"{0}\">add-on's developer page</a>."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/submit/license.html:4
@@ -5975,10 +5013,7 @@ msgid "Step 5. Select a License"
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/submit/license.html:9
-msgid ""
-"We require all add-ons to indicate the terms under which their source code "
-"is licensed. Please select a license from the list below or enter a custom "
-"license."
+msgid "We require all add-ons to indicate the terms under which their source code is licensed. Please select a license from the list below or enter a custom license."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/submit/license.html:18
@@ -5995,9 +5030,8 @@ msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/submit/media.html:9
 msgid ""
-"Custom icons and screenshots draw attention and help users understand what "
-"it does. We strongly recommend uploading a custom icon, as in some areas of "
-"the website, only the icon and name will appear."
+"Custom icons and screenshots draw attention and help users understand what it does. We strongly recommend uploading a custom icon, as in some areas of the website, only the icon and name will "
+"appear."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/submit/select-review.html:5
@@ -6010,17 +5044,13 @@ msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/submit/select-review.html:10
 msgid ""
-"All add-ons hosted in our gallery must be reviewed by an editor before they "
-"appear in categories or search results. While waiting for review, your add-"
-"on can still be accessed through its direct URL. Please choose the review "
-"process below that best fits your add-on."
+"All add-ons hosted in our gallery must be reviewed by an editor before they appear in categories or search results. While waiting for review, your add-on can still be accessed through its direct "
+"URL. Please choose the review process below that best fits your add-on."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/submit/select-review.html:26
 #, python-format
-msgid ""
-"A complete review of your add-on's source and functionality. <a "
-"href=\"%(url)s\">Learn more&hellip;</a>"
+msgid "A complete review of your add-on's source and functionality. <a href=\"%(url)s\">Learn more&hellip;</a>"
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/submit/select-review.html:32
@@ -6049,9 +5079,7 @@ msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/submit/select-review.html:49
 #, python-format
-msgid ""
-"A faster review of your add-on's source for any major problems. <a "
-"href=\"%(url)s\">Learn more&hellip;</a>"
+msgid "A faster review of your add-on's source for any major problems. <a href=\"%(url)s\">Learn more&hellip;</a>"
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/submit/select-review.html:55
@@ -6098,10 +5126,8 @@ msgstr ""
 msgid "Select a review process"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/addons/submit/sidebar.html:18
-#: src/olympia/devhub/templates/devhub/docs/policies-submission.html:3
-#: src/olympia/devhub/templates/devhub/docs/policies-submission.html:7
-#: src/olympia/devhub/templates/devhub/docs/policies-submission.html:9
+#: src/olympia/devhub/templates/devhub/addons/submit/sidebar.html:18 src/olympia/devhub/templates/devhub/docs/policies-submission.html:3
+#: src/olympia/devhub/templates/devhub/docs/policies-submission.html:7 src/olympia/devhub/templates/devhub/docs/policies-submission.html:9
 msgid "Submission Process"
 msgstr ""
 
@@ -6122,24 +5148,18 @@ msgid "Step 2. Upload Your Add-on"
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/submit/upload.html:11
-msgid ""
-"Use the fields below to upload your add-on package and select any platform "
-"restrictions. After upload, a series of automated validation tests will be "
-"run on your file."
+msgid "Use the fields below to upload your add-on package and select any platform restrictions. After upload, a series of automated validation tests will be run on your file."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/addons/submit/upload.html:45
-#: src/olympia/devhub/templates/devhub/versions/add_file_modal.html:27
+#: src/olympia/devhub/templates/devhub/addons/submit/upload.html:51 src/olympia/devhub/templates/devhub/versions/add_file_modal.html:28
 msgid "Which platforms is this file compatible with?"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/addons/submit/upload.html:53
-#: src/olympia/devhub/templates/devhub/versions/add_file_modal.html:44
+#: src/olympia/devhub/templates/devhub/addons/submit/upload.html:59 src/olympia/devhub/templates/devhub/versions/add_file_modal.html:45
 msgid "Administrative overrides"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/api/agreement.html:3
-#: src/olympia/devhub/templates/devhub/api/agreement.html:11
+#: src/olympia/devhub/templates/devhub/api/agreement.html:3 src/olympia/devhub/templates/devhub/api/agreement.html:11
 msgid "Firefox Add-on Distribution Agreement"
 msgstr ""
 
@@ -6149,9 +5169,7 @@ msgstr ""
 
 #: src/olympia/devhub/templates/devhub/api/key.html:20
 #, python-format
-msgid ""
-"For detailed instructions, consult the <a href=\"%(docs_url)s\">API "
-"documentation</a>."
+msgid "For detailed instructions, consult the <a href=\"%(docs_url)s\">API documentation</a>."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/api/key.html:28
@@ -6165,10 +5183,8 @@ msgstr ""
 #: src/olympia/devhub/templates/devhub/api/key.html:37
 #, python-format
 msgid ""
-"To make API requests, send a <a href=\"%(jwt_url)s\">JSON Web Token "
-"(JWT)</a> as the authorization header. You'll need to generate a JWT for "
-"every request as explained in the <a href=\"%(docs_url)s\">API "
-"documentation</a>."
+"To make API requests, send a <a href=\"%(jwt_url)s\">JSON Web Token (JWT)</a> as the authorization header. You'll need to generate a JWT for every request as explained in the <a href=\"%(docs_url)s"
+"\">API documentation</a>."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/api/key.html:47
@@ -6177,9 +5193,7 @@ msgstr ""
 
 #: src/olympia/devhub/templates/devhub/api/key.html:53
 #, python-format
-msgid ""
-"This feature is under active development. If you find a problem please <a "
-"target=\"_blank\" href=\"%(bug_link)s\">report a bug</a>."
+msgid "This feature is under active development. If you find a problem please <a target=\"_blank\" href=\"%(bug_link)s\">report a bug</a>."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/api/key.html:61
@@ -6190,26 +5204,18 @@ msgstr ""
 msgid "Generate new credentials"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/docs/policies-agreement.html:3
-#: src/olympia/devhub/templates/devhub/docs/policies-agreement.html:7
-#: src/olympia/devhub/templates/devhub/docs/policies-agreement.html:9
-#: src/olympia/devhub/templates/devhub/docs/policies.html:24
-#: src/olympia/devhub/templates/devhub/docs/policies.html:103
+#: src/olympia/devhub/templates/devhub/docs/policies-agreement.html:3 src/olympia/devhub/templates/devhub/docs/policies-agreement.html:7
+#: src/olympia/devhub/templates/devhub/docs/policies-agreement.html:9 src/olympia/devhub/templates/devhub/docs/policies.html:24 src/olympia/devhub/templates/devhub/docs/policies.html:103
 msgid "Developer Agreement"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/docs/policies-contact.html:3
-#: src/olympia/devhub/templates/devhub/docs/policies-contact.html:7
-#: src/olympia/devhub/templates/devhub/docs/policies-contact.html:9
-#: src/olympia/devhub/templates/devhub/docs/policies.html:27
-#: src/olympia/devhub/templates/devhub/docs/policies.html:115
+#: src/olympia/devhub/templates/devhub/docs/policies-contact.html:3 src/olympia/devhub/templates/devhub/docs/policies-contact.html:7 src/olympia/devhub/templates/devhub/docs/policies-contact.html:9
+#: src/olympia/devhub/templates/devhub/docs/policies.html:27 src/olympia/devhub/templates/devhub/docs/policies.html:115
 msgid "Contacting Us"
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/docs/policies-contact.html:12
-msgid ""
-"Thanks for your interest in contacting the Mozilla Add-ons team. Please read"
-" this page carefully to ensure your request goes to the right place."
+msgid "Thanks for your interest in contacting the Mozilla Add-ons team. Please read this page carefully to ensure your request goes to the right place."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/docs/policies-contact.html:17
@@ -6218,10 +5224,8 @@ msgstr ""
 
 #: src/olympia/devhub/templates/devhub/docs/policies-contact.html:19
 msgid ""
-"If you have a support question about a particular add-on, such as \"how do I"
-" use this add-on?\" or \"why doesn't this work properly?\", please contact "
-"that add-on's author through the support channels listed on the add-on's "
-"listing page."
+"If you have a support question about a particular add-on, such as \"how do I use this add-on?\" or \"why doesn't this work properly?\", please contact that add-on's author through the support "
+"channels listed on the add-on's listing page."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/docs/policies-contact.html:24
@@ -6235,11 +5239,8 @@ msgstr ""
 #: src/olympia/devhub/templates/devhub/docs/policies-contact.html:26
 #, python-format
 msgid ""
-"If you have a question about an Editor's review of an add-on or want to "
-"report a policy violation, please email %(mail_editors)s. <strong>Almost all"
-" add-on reports fall under this category.</strong> Please be sure to include"
-" a link to the add-on in question and a detailed description of your "
-"question or comment."
+"If you have a question about an Editor's review of an add-on or want to report a policy violation, please email %(mail_editors)s. <strong>Almost all add-on reports fall under this category.</"
+"strong> Please be sure to include a link to the add-on in question and a detailed description of your question or comment."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/docs/policies-contact.html:31
@@ -6253,13 +5254,9 @@ msgstr ""
 #: src/olympia/devhub/templates/devhub/docs/policies-contact.html:36
 #, python-format
 msgid ""
-"If you have discovered a security vulnerability in an add-on, even if it is "
-"not hosted here, Mozilla is very interested in your discovery and will work "
-"with the add-on developer to correct the issue as soon as possible. Add-on "
-"security issues can be reported <a "
-"href=\"http://www.mozilla.org/projects/security/security-bugs-"
-"policy.html\">confidentially</a> in <a "
-"href=\"%(link_bugzilla)s\">Bugzilla</a> or by emailing %(mail_admins)s."
+"If you have discovered a security vulnerability in an add-on, even if it is not hosted here, Mozilla is very interested in your discovery and will work with the add-on developer to correct the "
+"issue as soon as possible. Add-on security issues can be reported <a href=\"http://www.mozilla.org/projects/security/security-bugs-policy.html\">confidentially</a> in <a href=\"%(link_bugzilla)s"
+"\">Bugzilla</a> or by emailing %(mail_admins)s."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/docs/policies-contact.html:42
@@ -6268,13 +5265,11 @@ msgstr ""
 
 #: src/olympia/devhub/templates/devhub/docs/policies-contact.html:44
 msgid ""
-"If you've found a problem with the site, we'd love to fix it. Please <a "
-"href=\"https://github.com/mozilla/addons/issues/new\">file a bug report</a> "
-"in GitHub, including the location of the problem and how you encountered it."
+"If you've found a problem with the site, we'd love to fix it. Please <a href=\"https://github.com/mozilla/addons/issues/new\">file a bug report</a> in GitHub, including the location of the problem "
+"and how you encountered it."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/docs/policies-maintenance.html:3
-#: src/olympia/devhub/templates/devhub/docs/policies-maintenance.html:7
+#: src/olympia/devhub/templates/devhub/docs/policies-maintenance.html:3 src/olympia/devhub/templates/devhub/docs/policies-maintenance.html:7
 #: src/olympia/devhub/templates/devhub/docs/policies-maintenance.html:8
 msgid "Maintaining Your Add-ons"
 msgstr ""
@@ -6285,20 +5280,13 @@ msgstr ""
 
 #: src/olympia/devhub/templates/devhub/docs/policies-maintenance.html:12
 msgid ""
-"Developers are encouraged to submit updates to their add-ons to fix bugs, "
-"add features, and otherwise improve their product. New versions of an add-on"
-" must have a <a "
-"href=\"https://developer.mozilla.org/en/Toolkit_version_format\">higher "
-"version number</a> and can be submitted through the Developer Tools "
-"provided. There is no limit to the number of versions that can be submitted,"
-" but please remember that versions must be reviewed by an editor."
+"Developers are encouraged to submit updates to their add-ons to fix bugs, add features, and otherwise improve their product. New versions of an add-on must have a <a href=\"https://developer."
+"mozilla.org/en/Toolkit_version_format\">higher version number</a> and can be submitted through the Developer Tools provided. There is no limit to the number of versions that can be submitted, but "
+"please remember that versions must be reviewed by an editor."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/docs/policies-maintenance.html:18
-msgid ""
-"New versions will be added to a pending review queue, and any additional "
-"versions submitted before the review is completed will move that version to "
-"the end of the queue."
+msgid "New versions will be added to a pending review queue, and any additional versions submitted before the review is completed will move that version to the end of the queue."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/docs/policies-maintenance.html:23
@@ -6311,31 +5299,22 @@ msgstr ""
 
 #: src/olympia/devhub/templates/devhub/docs/policies-maintenance.html:31
 msgid ""
-"To create a beta channel, upload a file with a unique version string that "
-"contains any of the following strings: <code>a,b,alpha,beta,pre,rc</code>, "
-"with an optional number at the end. This text must come at the end of the "
-"version string. If you understand regex format, here's what we look for in "
-"the version number: <code>\"(a|alpha|b|beta|pre|rc)\\d*$\"</code>."
+"To create a beta channel, upload a file with a unique version string that contains any of the following strings: <code>a,b,alpha,beta,pre,rc</code>, with an optional number at the end. This text "
+"must come at the end of the version string. If you understand regex format, here's what we look for in the version number: <code>\"(a|alpha|b|beta|pre|rc)\\d*$\"</code>."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/docs/policies-maintenance.html:37
 msgid ""
-"Once a file meeting this criteria is uploaded to AMO, it will automatically "
-"be marked as a beta version. Users of add-ons with these unique version "
-"numbers will automatically be served the newest beta updates."
+"Once a file meeting this criteria is uploaded to AMO, it will automatically be marked as a beta version. Users of add-ons with these unique version numbers will automatically be served the newest "
+"beta updates."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/docs/policies-maintenance.html:43
 msgid ""
-"While we call these \"Beta versions\", you can use this channel for "
-"nightlies, or alphas, or prerelease versions as you wish. Please note that "
-"there is only one channel for this purpose and all of your users on this "
-"channel will receive the latest add-ons submitted. For instance, if you "
-"upload <code>1.0beta1</code> to the release channel and then upload "
-"<code>1.1alpha1</code>, all users of <code>1.0beta1</code> will be offered "
-"an upgrade to <code>1.1alpha1</code>. Updates are pushed by submission date "
-"and not version number, so users will always get the most recent channel "
-"update regardless of any kind of alphabetical sorting."
+"While we call these \"Beta versions\", you can use this channel for nightlies, or alphas, or prerelease versions as you wish. Please note that there is only one channel for this purpose and all of "
+"your users on this channel will receive the latest add-ons submitted. For instance, if you upload <code>1.0beta1</code> to the release channel and then upload <code>1.1alpha1</code>, all users of "
+"<code>1.0beta1</code> will be offered an upgrade to <code>1.1alpha1</code>. Updates are pushed by submission date and not version number, so users will always get the most recent channel update "
+"regardless of any kind of alphabetical sorting."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/docs/policies-maintenance.html:48
@@ -6344,13 +5323,9 @@ msgstr ""
 
 #: src/olympia/devhub/templates/devhub/docs/policies-maintenance.html:50
 msgid ""
-"Certain situations may arise in which Mozilla requests that an add-on "
-"developer update their add-on within a given time period to address a major "
-"security issue or policy violation. We work with developers to reasonably "
-"accommodate their own schedules, but if the issue is of a serious enough "
-"nature, add-ons that cannot issue an update with the requested fix may be "
-"demoted from fully-reviewed status, disabled, or permanently removed from "
-"the site."
+"Certain situations may arise in which Mozilla requests that an add-on developer update their add-on within a given time period to address a major security issue or policy violation. We work with "
+"developers to reasonably accommodate their own schedules, but if the issue is of a serious enough nature, add-ons that cannot issue an update with the requested fix may be demoted from fully-"
+"reviewed status, disabled, or permanently removed from the site."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/docs/policies-maintenance.html:55
@@ -6359,43 +5334,32 @@ msgstr ""
 
 #: src/olympia/devhub/templates/devhub/docs/policies-maintenance.html:57
 msgid ""
-"Add-ons can have multiple users with permission to update and manage the "
-"listing. Existing authors of an add-on can transfer ownership and add "
-"additional developers to an add-on's listing through the Developer Tools "
-"provided. No interaction with Mozilla representatives is necessary for a "
-"transfer of ownership."
+"Add-ons can have multiple users with permission to update and manage the listing. Existing authors of an add-on can transfer ownership and add additional developers to an add-on's listing through "
+"the Developer Tools provided. No interaction with Mozilla representatives is necessary for a transfer of ownership."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/docs/policies-maintenance.html:63
 #, python-format
-msgid ""
-"Mozilla can assist with granting additional permissions of an add-on's "
-"listing if <a href=\"%(link_contact)s\">contacted</a> by the add-on's "
-"current owner."
+msgid "Mozilla can assist with granting additional permissions of an add-on's listing if <a href=\"%(link_contact)s\">contacted</a> by the add-on's current owner."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/docs/policies-maintenance.html:70
 msgid ""
-"Mozilla encourages its users to offer feedback on their experiences when "
-"using an add-on. This allows other users to determine if the add-on is "
-"stable and useful. It also provides valuable feedback to developers, "
-"allowing them to continuously improve their add-on to meet user needs."
+"Mozilla encourages its users to offer feedback on their experiences when using an add-on. This allows other users to determine if the add-on is stable and useful. It also provides valuable feedback "
+"to developers, allowing them to continuously improve their add-on to meet user needs."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/docs/policies-maintenance.html:76
 #, python-format
 msgid ""
-"Reviews must follow the <a href=\"%(link_guidelines)s\">review "
-"guidelines</a>. Reviews that do not meet these guidelines may be flagged for"
-" moderation, but negative reviews will not be removed unless they provide "
-"false information."
+"Reviews must follow the <a href=\"%(link_guidelines)s\">review guidelines</a>. Reviews that do not meet these guidelines may be flagged for moderation, but negative reviews will not be removed "
+"unless they provide false information."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/docs/policies-maintenance.html:82
 msgid ""
-"Many developers provide a support mechanism, such as a forum, discussion "
-"group, or email address. It is recommended that support questions be posted "
-"via those mediums instead of in an add-on's review section."
+"Many developers provide a support mechanism, such as a forum, discussion group, or email address. It is recommended that support questions be posted via those mediums instead of in an add-on's "
+"review section."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/docs/policies-maintenance.html:87
@@ -6404,31 +5368,21 @@ msgstr ""
 
 #: src/olympia/devhub/templates/devhub/docs/policies-maintenance.html:90
 msgid ""
-"Many add-ons allow their source code to be openly viewed. This does not mean"
-" that the source code is open source or available for use in another add-on."
-" The original author of an add-on retains copyright of their work unless "
-"otherwise noted in the add-on's license."
+"Many add-ons allow their source code to be openly viewed. This does not mean that the source code is open source or available for use in another add-on. The original author of an add-on retains "
+"copyright of their work unless otherwise noted in the add-on's license."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/docs/policies-maintenance.html:96
 msgid ""
-"In the event that we're notified of a copyright or license infringement, we "
-"will take steps to review the situation and determine if an actual "
-"infringement has occurred. If we determine that there is an infringement, we"
-" will remove the offending add-on and contact the author. New add-on "
-"submissions (including updates) containing infringing code will be denied "
-"approval for public status."
+"In the event that we're notified of a copyright or license infringement, we will take steps to review the situation and determine if an actual infringement has occurred. If we determine that there "
+"is an infringement, we will remove the offending add-on and contact the author. New add-on submissions (including updates) containing infringing code will be denied approval for public status."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/docs/policies-maintenance.html:102
-msgid ""
-"If you are unsure of the current copyright status of an add-on's source "
-"code, you must contact the original author and receive explicit permission "
-"before using the source code."
+msgid "If you are unsure of the current copyright status of an add-on's source code, you must contact the original author and receive explicit permission before using the source code."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/docs/policies-maintenance.html:107
-#: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:306
+#: src/olympia/devhub/templates/devhub/docs/policies-maintenance.html:107 src/olympia/devhub/templates/devhub/docs/policies-reviews.html:306
 #: src/olympia/devhub/templates/devhub/docs/policies-submission.html:97
 msgid "Last updated: January 13, 2011"
 msgstr ""
@@ -6436,25 +5390,18 @@ msgstr ""
 #: src/olympia/devhub/templates/devhub/docs/policies-recommended.html:13
 #, python-format
 msgid ""
-"Featured add-ons are top-quality extensions and themes highlighted on <a "
-"href=\"%(link_gallery)s\">AMO</a>, Firefox's Add-ons Manager, and across "
-"other Mozilla websites. These add-ons showcase the power of Firefox "
-"customization and are useful to a wide audience."
+"Featured add-ons are top-quality extensions and themes highlighted on <a href=\"%(link_gallery)s\">AMO</a>, Firefox's Add-ons Manager, and across other Mozilla websites. These add-ons showcase the "
+"power of Firefox customization and are useful to a wide audience."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/docs/policies-recommended.html:19
 msgid ""
-"Featured add-ons are chosen by the Featured Add-ons Advisory Board, a small "
-"group of add-on developers and fans from the Mozilla community who have "
-"volunteered to review and vote on nominations."
+"Featured add-ons are chosen by the Featured Add-ons Advisory Board, a small group of add-on developers and fans from the Mozilla community who have volunteered to review and vote on nominations."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/docs/policies-recommended.html:25
 #, python-format
-msgid ""
-"<a href=\"%(link_featured)s\">Featured extensions</a> are chosen every "
-"month, and <a href=\"%(link_themes)s\">featured complete themes</a> are "
-"chosen every quarter."
+msgid "<a href=\"%(link_featured)s\">Featured extensions</a> are chosen every month, and <a href=\"%(link_themes)s\">featured complete themes</a> are chosen every quarter."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/docs/policies-recommended.html:30
@@ -6462,14 +5409,11 @@ msgid "Criteria for Featured Add-ons"
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/docs/policies-recommended.html:33
-msgid ""
-"Before nominating an add-on to be featured, please ensure it meets the "
-"following criteria:"
+msgid "Before nominating an add-on to be featured, please ensure it meets the following criteria:"
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/docs/policies-recommended.html:39
-msgid ""
-"The add-on must have a complete and informative listing on AMO. This means:"
+msgid "The add-on must have a complete and informative listing on AMO. This means:"
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/docs/policies-recommended.html:41
@@ -6493,14 +5437,11 @@ msgid "updated screenshots of the add-on's functionality"
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/docs/policies-recommended.html:46
-msgid ""
-"must be fully approved by AMO editors (no preliminarily reviewed entries)"
+msgid "must be fully approved by AMO editors (no preliminarily reviewed entries)"
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/docs/policies-recommended.html:48
-msgid ""
-"The add-on must have excellent user reviews and any problems or support "
-"requests must be promptly addressed by the developer."
+msgid "The add-on must have excellent user reviews and any problems or support requests must be promptly addressed by the developer."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/docs/policies-recommended.html:49
@@ -6508,17 +5449,13 @@ msgid "The add-on must have a minimum of 2,000 users."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/docs/policies-recommended.html:50
-msgid ""
-"The add-on must be compatible with the latest release of Firefox and must be"
-" compatible with beta versions 4 weeks before their final release."
+msgid "The add-on must be compatible with the latest release of Firefox and must be compatible with beta versions 4 weeks before their final release."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/docs/policies-recommended.html:51
 msgid ""
-"<strong>Most importantly</strong>, the add-on must have wide consumer appeal"
-" to Firefox's users and be outstanding in nearly every way: user experience,"
-" performance, security, and usefulness or entertainment value. Featured "
-"complete themes must also be visually appealing."
+"<strong>Most importantly</strong>, the add-on must have wide consumer appeal to Firefox's users and be outstanding in nearly every way: user experience, performance, security, and usefulness or "
+"entertainment value. Featured complete themes must also be visually appealing."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/docs/policies-recommended.html:54
@@ -6531,9 +5468,7 @@ msgstr ""
 
 #: src/olympia/devhub/templates/devhub/docs/policies-recommended.html:57
 #, python-format
-msgid ""
-"If you wish to nominate an add-on to be featured and it meets the criteria "
-"above, send an email to %(mail_featured)s with:"
+msgid "If you wish to nominate an add-on to be featured and it meets the criteria above, send an email to %(mail_featured)s with:"
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/docs/policies-recommended.html:62
@@ -6541,22 +5476,17 @@ msgid "the add-on name, URL, and whether you are its developer"
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/docs/policies-recommended.html:63
-msgid ""
-"a short explanation of why the add-on has wide appeal and should be featured"
+msgid "a short explanation of why the add-on has wide appeal and should be featured"
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/docs/policies-recommended.html:64
-msgid ""
-"optionally, links to any external reviews or articles mentioning the add-on"
+msgid "optionally, links to any external reviews or articles mentioning the add-on"
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/docs/policies-recommended.html:68
 msgid ""
-"Add-on nominations are reviewed by the Advisory Board once a month (once "
-"every 3 months for complete theme nominations). Common reasons for rejection"
-" include lacking wide appeal to consumers, a suboptimal user experience, "
-"quality or security issues, incompatibility, and similarity to another "
-"featured add-on. Rejected add-ons cannot be re-nominated within 3 months."
+"Add-on nominations are reviewed by the Advisory Board once a month (once every 3 months for complete theme nominations). Common reasons for rejection include lacking wide appeal to consumers, a "
+"suboptimal user experience, quality or security issues, incompatibility, and similarity to another featured add-on. Rejected add-ons cannot be re-nominated within 3 months."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/docs/policies-recommended.html:73
@@ -6564,32 +5494,23 @@ msgid "Rotating Featured Add-ons"
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/docs/policies-recommended.html:76
-msgid ""
-"Mozilla and the Featured Add-ons Advisory Board regularly evaluate and "
-"rotate out featured add-ons. Some of the most common reasons for add-ons "
-"being removed from the featured list are:"
+msgid "Mozilla and the Featured Add-ons Advisory Board regularly evaluate and rotate out featured add-ons. Some of the most common reasons for add-ons being removed from the featured list are:"
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/docs/policies-recommended.html:83
 msgid ""
-"Lack of growth &mdash; Add-ons that are featured typically experience a "
-"substantial gain in both downloads and active users. If an add-on is not "
-"demonstrating growth in any substantial way, that's a good indicator the "
-"add-on may not be very useful to our users."
+"Lack of growth &mdash; Add-ons that are featured typically experience a substantial gain in both downloads and active users. If an add-on is not demonstrating growth in any substantial way, that's "
+"a good indicator the add-on may not be very useful to our users."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/docs/policies-recommended.html:88
-msgid ""
-"Negative reviews &mdash; Featured add-ons should have a great experience and"
-" very few bugs, so add-ons with many negative reviews may be reconsidered."
+msgid "Negative reviews &mdash; Featured add-ons should have a great experience and very few bugs, so add-ons with many negative reviews may be reconsidered."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/docs/policies-recommended.html:93
 msgid ""
-"Incompatibility with upcoming Firefox versions &mdash; Featured add-ons are "
-"expected to be compatible with stable and beta versions of Firefox. Add-ons "
-"not yet compatible with a Beta version of Firefox four weeks before its "
-"expected release will lose their featured status."
+"Incompatibility with upcoming Firefox versions &mdash; Featured add-ons are expected to be compatible with stable and beta versions of Firefox. Add-ons not yet compatible with a Beta version of "
+"Firefox four weeks before its expected release will lose their featured status."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/docs/policies-recommended.html:99
@@ -6597,121 +5518,87 @@ msgid "Joining the Featured Add-ons Advisory Board"
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/docs/policies-recommended.html:102
-msgid ""
-"Every six months a new Advisory Board is chosen based on applications from "
-"the add-ons community. Members must:"
+msgid "Every six months a new Advisory Board is chosen based on applications from the add-ons community. Members must:"
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/docs/policies-recommended.html:108
-msgid ""
-"be active members of the add-ons community, whether as a developer, "
-"evangelist, or fan"
+msgid "be active members of the add-ons community, whether as a developer, evangelist, or fan"
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/docs/policies-recommended.html:109
-msgid ""
-"commit to trying all the nominations submitted, giving their feedback, and "
-"casting their votes every month"
+msgid "commit to trying all the nominations submitted, giving their feedback, and casting their votes every month"
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/docs/policies-recommended.html:110
-msgid ""
-"abstain from voting on add-ons that they have any business or personal "
-"affiliations with, as well as direct competitors of any such add-ons"
+msgid "abstain from voting on add-ons that they have any business or personal affiliations with, as well as direct competitors of any such add-ons"
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/docs/policies-recommended.html:114
 msgid ""
-"Members of the Mozilla Add-ons team may veto any add-on's selection because "
-"of security, privacy, compatibility, or any other reason, but in general it "
-"is up to the Board to select add-ons to feature."
+"Members of the Mozilla Add-ons team may veto any add-on's selection because of security, privacy, compatibility, or any other reason, but in general it is up to the Board to select add-ons to "
+"feature."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/docs/policies-recommended.html:120
 msgid ""
-"This featured policy only applies to the addons.mozilla.org global list of "
-"featured add-ons. Add-ons featured in other locations are often pulled from "
-"this list, but Mozilla may feature any add-on in other locations without the"
-" Board's consent. Additionally, locale-specific features override the global"
-" defaults, so if a locale has opted to select its own features, some or all "
-"of the global features may not appear in that locale."
+"This featured policy only applies to the addons.mozilla.org global list of featured add-ons. Add-ons featured in other locations are often pulled from this list, but Mozilla may feature any add-on "
+"in other locations without the Board's consent. Additionally, locale-specific features override the global defaults, so if a locale has opted to select its own features, some or all of the global "
+"features may not appear in that locale."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/docs/policies-recommended.html:126
 #, python-format
-msgid ""
-"Follow the <a href=\"%(link_blog)s\">Add-ons Blog</a> or <a "
-"href=\"%(link_twitter)s\">@mozamo</a> on Twitter to learn when the next "
-"application period opens."
+msgid "Follow the <a href=\"%(link_blog)s\">Add-ons Blog</a> or <a href=\"%(link_twitter)s\">@mozamo</a> on Twitter to learn when the next application period opens."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/docs/policies-recommended.html:131
 msgid "Last updated: January 31, 2013"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:3
-#: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:7
-#: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:8
-#: src/olympia/devhub/templates/devhub/docs/policies.html:15
-#: src/olympia/devhub/templates/devhub/docs/policies.html:64
+#: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:3 src/olympia/devhub/templates/devhub/docs/policies-reviews.html:7 src/olympia/devhub/templates/devhub/docs/policies-reviews.html:8
+#: src/olympia/devhub/templates/devhub/docs/policies.html:15 src/olympia/devhub/templates/devhub/docs/policies.html:64
 msgid "Review Process"
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:12
 msgid ""
-"In order to ensure all add-ons hosted in our gallery are safe for users to "
-"install, Mozilla will begin requiring all hosted add-ons to undergo review. "
-"We offer two types of review and developers are free to choose the best fit "
-"for their add-on."
+"In order to ensure all add-ons hosted in our gallery are safe for users to install, Mozilla will begin requiring all hosted add-ons to undergo review. We offer two types of review and developers "
+"are free to choose the best fit for their add-on."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:19
 msgid ""
-"<strong><a href=\"#full\">Full Review</a></strong> &mdash; a thorough "
-"functional and code review of the add-on, appropriate for add-ons ready for "
-"distribution to the masses. All site features are available to these add-"
-"ons."
+"<strong><a href=\"#full\">Full Review</a></strong> &mdash; a thorough functional and code review of the add-on, appropriate for add-ons ready for distribution to the masses. All site features are "
+"available to these add-ons."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:24
 msgid ""
-"<strong><a href=\"#preliminary\">Preliminary Review</a></strong> &mdash; a "
-"faster review intended for experimental add-ons. Preliminary reviews do not "
-"check for functionality or full policy compliance, but the reviewed add-ons "
-"have install button cautions and some feature limitations."
+"<strong><a href=\"#preliminary\">Preliminary Review</a></strong> &mdash; a faster review intended for experimental add-ons. Preliminary reviews do not check for functionality or full policy "
+"compliance, but the reviewed add-ons have install button cautions and some feature limitations."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:31
 msgid ""
-"Detailed descriptions of each option are below. After selecting a review "
-"process at submission, the add-on will be placed in the queue. Add-ons are "
-"reviewed by the <a href=\"https://wiki.mozilla.org/AMO:Editors\">AMO "
-"Editors</a>, a group of talented developers that volunteer to help the "
-"Mozilla project by reviewing add-ons to ensure a stable and safe experience "
-"for users. Developers will receive an email with any updates throughout the "
-"review process."
+"Detailed descriptions of each option are below. After selecting a review process at submission, the add-on will be placed in the queue. Add-ons are reviewed by the <a href=\"https://wiki.mozilla."
+"org/AMO:Editors\">AMO Editors</a>, a group of talented developers that volunteer to help the Mozilla project by reviewing add-ons to ensure a stable and safe experience for users. Developers will "
+"receive an email with any updates throughout the review process."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:37
 msgid ""
-"While waiting for review, add-ons will not appear anywhere in the gallery "
-"publicly, but direct links to the add-on's details page will work. This "
-"allows the author to blog or share the link with friends, inviting them to "
-"try it out, even when not yet reviewed."
+"While waiting for review, add-ons will not appear anywhere in the gallery publicly, but direct links to the add-on's details page will work. This allows the author to blog or share the link with "
+"friends, inviting them to try it out, even when not yet reviewed."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:44
 msgid ""
-"Full reviews are appropriate for add-ons that are well-tested, stable, fast,"
-" and have wide appeal to our users. If you aren't confident that your add-on"
-" meets that criteria, please consider working out the kinks while in "
-"preliminary review and accumulating user feedback first."
+"Full reviews are appropriate for add-ons that are well-tested, stable, fast, and have wide appeal to our users. If you aren't confident that your add-on meets that criteria, please consider working "
+"out the kinks while in preliminary review and accumulating user feedback first."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:50
-msgid ""
-"We aim to perform full reviews in under 10 days, though most add-ons are "
-"reviewed in much less time."
+msgid "We aim to perform full reviews in under 10 days, though most add-ons are reviewed in much less time."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:55
@@ -6723,15 +5610,11 @@ msgid "When performing a full review, editors will:"
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:64
-msgid ""
-"install the add-on, making sure it functions as described and is free of "
-"major defects"
+msgid "install the add-on, making sure it functions as described and is free of major defects"
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:69
-msgid ""
-"perform a source code review, looking for performance and security best "
-"practices"
+msgid "perform a source code review, looking for performance and security best practices"
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:74
@@ -6739,28 +5622,21 @@ msgid "ensure the add-on's privacy policy is in line with its functionality"
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:79
-msgid ""
-"look for compliance with all of Mozilla's policies, detailed in these "
-"documents"
+msgid "look for compliance with all of Mozilla's policies, detailed in these documents"
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:86
-msgid ""
-"Some of the most common issues we see when performing these reviews are:"
+msgid "Some of the most common issues we see when performing these reviews are:"
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:93
 msgid ""
-"<strong>JavaScript namespace pollution</strong> &mdash; the most common "
-"violation. Be sure to <a "
-"href=\"https://developer.mozilla.org/en/XUL_School/JavaScript_Object_Management\">wrap"
-" your loose variables</a>"
+"<strong>JavaScript namespace pollution</strong> &mdash; the most common violation. Be sure to <a href=\"https://developer.mozilla.org/en/XUL_School/JavaScript_Object_Management\">wrap your loose "
+"variables</a>"
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:99
-msgid ""
-"proper preference naming - all preference names should begin with "
-"\"extensions.\", followed by the add-on name or some other unique identifier"
+msgid "proper preference naming - all preference names should begin with \"extensions.\", followed by the add-on name or some other unique identifier"
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:103
@@ -6806,67 +5682,49 @@ msgstr ""
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:117
 #, python-format
 msgid ""
-"For information on how to avoid these problems, please see our <a "
-"href=\"%(link_howto)s\">How-to Library</a>. Some of these practices, such as"
-" binary or obfuscated code, are allowed under certain conditions outlined "
-"below."
+"For information on how to avoid these problems, please see our <a href=\"%(link_howto)s\">How-to Library</a>. Some of these practices, such as binary or obfuscated code, are allowed under certain "
+"conditions outlined below."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:123
 #, python-format
 msgid ""
-"Many of the above restrictions are tested automatically by an extension "
-"scanner that will flag suspicious add-ons for editor review. You can read "
-"more about this scanner in the <a href=\"%(link_validation)s\">Validation "
-"Help</a> document."
+"Many of the above restrictions are tested automatically by an extension scanner that will flag suspicious add-ons for editor review. You can read more about this scanner in the <a href="
+"\"%(link_validation)s\">Validation Help</a> document."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:129
 msgid ""
-"If the add-on is site-specific, it is recommended that a test account is "
-"provided for use during the review process. Additionally, including detailed"
-" testing instructions will allow an editor to better understand how the add-"
-"on functions and expedite the testing process. This information can be "
-"placed in the Notes to Reviewer field when editing a version in the "
-"Developer Hub."
+"If the add-on is site-specific, it is recommended that a test account is provided for use during the review process. Additionally, including detailed testing instructions will allow an editor to "
+"better understand how the add-on functions and expedite the testing process. This information can be placed in the Notes to Reviewer field when editing a version in the Developer Hub."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:134
-#: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:168
+#: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:134 src/olympia/devhub/templates/devhub/docs/policies-reviews.html:168
 msgid "After the Review"
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:136
 msgid ""
-"Once an add-on is granted full review, it will immediately be available in "
-"the gallery, showing in browse and search results with a warning-free "
-"install button. All features, including voluntary contributions and beta "
-"channels will be available."
+"Once an add-on is granted full review, it will immediately be available in the gallery, showing in browse and search results with a warning-free install button. All features, including voluntary "
+"contributions and beta channels will be available."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:142
 msgid ""
-"Subsequent versions of the add-on will automatically be placed in the full "
-"review queue. Until the review is completed, the new version will only be "
-"displayed on the Version History page of the add-on. Once reviewed, the "
-"version will be updated across the site and deployed through the automatic "
-"update service."
+"Subsequent versions of the add-on will automatically be placed in the full review queue. Until the review is completed, the new version will only be displayed on the Version History page of the add-"
+"on. Once reviewed, the version will be updated across the site and deployed through the automatic update service."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:148
 msgid ""
-"If a version does not meet the criteria for full review, it can either be "
-"granted preliminary review or disabled if there is a security concern. The "
-"author will receive an email explaining the action taken and how to fix it. "
-"In most cases, the developer can simply fix the problem and re-submit for "
-"full review."
+"If a version does not meet the criteria for full review, it can either be granted preliminary review or disabled if there is a security concern. The author will receive an email explaining the "
+"action taken and how to fix it. In most cases, the developer can simply fix the problem and re-submit for full review."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:155
 msgid ""
-"Preliminary reviews are appropriate for experimental add-ons and provide a "
-"way to get user testing and feedback without going through the longer, more "
-"thorough review process. We aim to complete these reviews in under 3 days."
+"Preliminary reviews are appropriate for experimental add-ons and provide a way to get user testing and feedback without going through the longer, more thorough review process. We aim to complete "
+"these reviews in under 3 days."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:160
@@ -6875,36 +5733,25 @@ msgstr ""
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:162
 msgid ""
-"When performing a preliminary review, editors will review the source code "
-"for security issues and major policy violations, but will not install the "
-"add-on to test functionality in most cases. Preliminary review will be "
-"granted unless a security vulnerability or major policy violation is "
-"discovered."
+"When performing a preliminary review, editors will review the source code for security issues and major policy violations, but will not install the add-on to test functionality in most cases. "
+"Preliminary review will be granted unless a security vulnerability or major policy violation is discovered."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:171
 msgid ""
-"Once preliminary review is granted, the add-on will be immediately available"
-" in the gallery, showing in browse and search results but ranked lower than "
-"fully-reviewed add-ons. Install buttons will have caution stripes and a "
-"notice that the add-on is experimental and not fully reviewed by Mozilla, "
-"though no click-through is required. Additionally, these add-ons cannot use "
-"the voluntary contributions and beta channel features."
+"Once preliminary review is granted, the add-on will be immediately available in the gallery, showing in browse and search results but ranked lower than fully-reviewed add-ons. Install buttons will "
+"have caution stripes and a notice that the add-on is experimental and not fully reviewed by Mozilla, though no click-through is required. Additionally, these add-ons cannot use the voluntary "
+"contributions and beta channel features."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:177
-msgid ""
-"After being granted preliminary review, Mozilla may later revoke the review "
-"if other serious problems are reported to us by users."
+msgid "After being granted preliminary review, Mozilla may later revoke the review if other serious problems are reported to us by users."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:183
 msgid ""
-"Subsequent versions of the add-on will automatically be placed in the "
-"preliminary review queue. Until the review is completed, the new version "
-"will only be displayed on the Version History page of the add-on. Once "
-"reviewed, the version will be updated across the site and deployed through "
-"the automatic update service."
+"Subsequent versions of the add-on will automatically be placed in the preliminary review queue. Until the review is completed, the new version will only be displayed on the Version History page of "
+"the add-on. Once reviewed, the version will be updated across the site and deployed through the automatic update service."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:188
@@ -6920,41 +5767,29 @@ msgid "The following add-ons are not permitted in any form:"
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:194
-msgid ""
-"Add-ons that embed known <a "
-"href=\"http://en.wikipedia.org/wiki/Spyware\">spyware</a> or <a "
-"href=\"http://en.wikipedia.org/wiki/Malware\">malware</a>"
+msgid "Add-ons that embed known <a href=\"http://en.wikipedia.org/wiki/Spyware\">spyware</a> or <a href=\"http://en.wikipedia.org/wiki/Malware\">malware</a>"
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:199
 msgid ""
-"Illegal and criminal add-ons, such as <a "
-"href=\"http://en.wikipedia.org/wiki/Click_fraud\">click fraud</a> "
-"generators, <a href=\"http://en.wikipedia.org/wiki/Warez\">warez</a> "
-"download and directory assistants, child pornography finders, etc."
+"Illegal and criminal add-ons, such as <a href=\"http://en.wikipedia.org/wiki/Click_fraud\">click fraud</a> generators, <a href=\"http://en.wikipedia.org/wiki/Warez\">warez</a> download and "
+"directory assistants, child pornography finders, etc."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:204
-msgid ""
-"Add-ons whose main purpose is to facilitate access to pornographic material,"
-" or include references to this material in their descriptions"
+msgid "Add-ons whose main purpose is to facilitate access to pornographic material, or include references to this material in their descriptions"
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:210
-msgid ""
-"Add-ons that, upon installation, auto-install or launch installers of non-"
-"Firefox software"
+msgid "Add-ons that, upon installation, auto-install or launch installers of non-Firefox software"
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:215
-msgid ""
-"Add-ons that provide their own update mechanism for code or search engines"
+msgid "Add-ons that provide their own update mechanism for code or search engines"
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:220
-msgid ""
-"Add-ons that make changes to web content in ways that are non-obvious or "
-"difficult to trace by their users"
+msgid "Add-ons that make changes to web content in ways that are non-obvious or difficult to trace by their users"
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:225
@@ -6971,41 +5806,25 @@ msgstr ""
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:238
 msgid ""
-"Surprises can be appropriate in many situations, but they are not welcome "
-"when user security, privacy, and control are at stake. It is extremely "
-"important to be as transparent as possible when submitting an add-on for "
-"hosting on this site. A Mozilla user should be able to easily discern what "
-"the functionality of an add-on is and not be presented with unexpected "
-"experiences post-install."
+"Surprises can be appropriate in many situations, but they are not welcome when user security, privacy, and control are at stake. It is extremely important to be as transparent as possible when "
+"submitting an add-on for hosting on this site. A Mozilla user should be able to easily discern what the functionality of an add-on is and not be presented with unexpected experiences post-install."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:243
 msgid ""
-"<p> Whenever an add-on includes any unexpected* feature that </p> <ul> "
-"<li>compromises user privacy or security (like sending data to third "
-"parties),</li> <li>changes default settings like the homepage or search "
-"engine, or</li> <li>changes settings or features in other add-ons or "
-"deactivates them altogether</li> </ul> <p>the features must adhere to the "
-"following requirements:</p> <ul> <li>The add-on description must clearly "
-"state what changes the add-on makes.</li> <li>All changes must be opt-in, "
-"meaning the user must take non-default action to enact the change.</li> "
-"<li>The opt-in dialog must clearly state the name of the add-on requesting "
-"the change.</li> <li>Uninstalling the add-on restores the user's original "
-"settings if they were changed.</li> </ul> <p>*Unexpected features are those "
-"that are unrelated to the add-on's primary function.</p>"
+"<p> Whenever an add-on includes any unexpected* feature that </p> <ul> <li>compromises user privacy or security (like sending data to third parties),</li> <li>changes default settings like the "
+"homepage or search engine, or</li> <li>changes settings or features in other add-ons or deactivates them altogether</li> </ul> <p>the features must adhere to the following requirements:</p> <ul> "
+"<li>The add-on description must clearly state what changes the add-on makes.</li> <li>All changes must be opt-in, meaning the user must take non-default action to enact the change.</li> <li>The opt-"
+"in dialog must clearly state the name of the add-on requesting the change.</li> <li>Uninstalling the add-on restores the user's original settings if they were changed.</li> </ul> <p>*Unexpected "
+"features are those that are unrelated to the add-on's primary function.</p>"
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:268
-msgid ""
-"These features cannot be introduced into an update of a fully-reviewed add-"
-"on; the opt-in change process must be part of the initial review."
+msgid "These features cannot be introduced into an update of a fully-reviewed add-on; the opt-in change process must be part of the initial review."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:274
-msgid ""
-"These are minimum requirements and not a guarantee that the add-on will be "
-"approved. This section applies to all add-ons hosted on the site, including "
-"preliminarily reviewed add-ons."
+msgid "These are minimum requirements and not a guarantee that the add-on will be approved. This section applies to all add-ons hosted on the site, including preliminarily reviewed add-ons."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:279
@@ -7014,11 +5833,8 @@ msgstr ""
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:282
 msgid ""
-"Add-ons that store or otherwise handle browsing data must support <a "
-"href=\"https://developer.mozilla.org/En/Supporting_private_browsing_mode\">Private"
-" Browsing Mode</a>. During a Private Browsing session, no browsing data can "
-"be written to disk, and all of this data must be cleared when Firefox quits "
-"or the Private Browsing session ends."
+"Add-ons that store or otherwise handle browsing data must support <a href=\"https://developer.mozilla.org/En/Supporting_private_browsing_mode\">Private Browsing Mode</a>. During a Private Browsing "
+"session, no browsing data can be written to disk, and all of this data must be cleared when Firefox quits or the Private Browsing session ends."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:287
@@ -7027,27 +5843,19 @@ msgstr ""
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:289
 msgid ""
-"Add-ons may contain binary, obfuscated and minified source code, but Mozilla"
-" must be allowed to review a copy of the human-readable source code of each "
-"version of an add-on submitted for review. These add-ons are ineligible for "
-"preliminary review and must choose the full review process."
+"Add-ons may contain binary, obfuscated and minified source code, but Mozilla must be allowed to review a copy of the human-readable source code of each version of an add-on submitted for review. "
+"These add-ons are ineligible for preliminary review and must choose the full review process."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:295
 msgid ""
-"If an add-on contains binary or obfuscated source code, the author will "
-"receive a message when the add-on is reviewed indicating whom to contact at "
-"Mozilla to coordinate review of the source code. This code will be reviewed "
-"by an administrator and will not be shared or redistributed in any way. The "
-"code will only be used for the purpose of reviewing the add-on."
+"If an add-on contains binary or obfuscated source code, the author will receive a message when the add-on is reviewed indicating whom to contact at Mozilla to coordinate review of the source code. "
+"This code will be reviewed by an administrator and will not be shared or redistributed in any way. The code will only be used for the purpose of reviewing the add-on."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:301
 #, python-format
-msgid ""
-"If your add-on contains binary or obfuscated code that you don't own or "
-"can't get the source code for, you may <a href=\"%(link_contact)s\">contact "
-"us</a> for information on how to proceed."
+msgid "If your add-on contains binary or obfuscated code that you don't own or can't get the source code for, you may <a href=\"%(link_contact)s\">contact us</a> for information on how to proceed."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/docs/policies-submission.html:11
@@ -7056,138 +5864,86 @@ msgstr ""
 
 #: src/olympia/devhub/templates/devhub/docs/policies-submission.html:13
 msgid ""
-"Add-ons hosted on Mozilla Add-ons should be of high quality and give users "
-"an improved web experience. We look for the following things when deciding "
-"whether an add-on is appropriate to be public and unrestricted:"
+"Add-ons hosted on Mozilla Add-ons should be of high quality and give users an improved web experience. We look for the following things when deciding whether an add-on is appropriate to be public "
+"and unrestricted:"
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/docs/policies-submission.html:19
 msgid ""
-"<strong>Are you responsive?</strong> We expect that an author who is "
-"promoting their add-on to our applications' many users is responsive to "
-"problem reports, maintains their contact information, and updates their add-"
-"on promptly to keep current with Firefox releases and changes in our "
-"policies. This doesn't mean that you have to reply to every question that "
-"someone posts in the discussions, or that you even need to fix every bug, "
-"but we do expect that you will respond to issues in a manner that's "
-"appropriate to the severity of the issue in question."
+"<strong>Are you responsive?</strong> We expect that an author who is promoting their add-on to our applications' many users is responsive to problem reports, maintains their contact information, "
+"and updates their add-on promptly to keep current with Firefox releases and changes in our policies. This doesn't mean that you have to reply to every question that someone posts in the "
+"discussions, or that you even need to fix every bug, but we do expect that you will respond to issues in a manner that's appropriate to the severity of the issue in question."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/docs/policies-submission.html:25
 msgid ""
-"<strong>Is the add-on clearly and accurately described?</strong> It's of the"
-" utmost importance to us that users get what they expect when they try a new"
-" add-on. Your add-on name should be clear and concise, and you should "
-"refrain from using special characters or numbers to get higher search "
-"rankings or for decorative purposes. Your description should provide details"
-" about what the add-on does, how a user should take advantage of it, and "
-"what the user should expect when they install it. Links to external "
-"documents for detailed instructions are fine, but the description itself "
-"should cover the basics and leave users confident that they know what "
-"they'll get. Also, it is important that you maintain version notes "
-"appropriately as you improve and change your add-on. Users should be able to"
-" see what's new in an add-on they may have tried previously, and should be "
-"made aware of changes that might affect their current use of the add-on when"
-" they update."
+"<strong>Is the add-on clearly and accurately described?</strong> It's of the utmost importance to us that users get what they expect when they try a new add-on. Your add-on name should be clear and "
+"concise, and you should refrain from using special characters or numbers to get higher search rankings or for decorative purposes. Your description should provide details about what the add-on "
+"does, how a user should take advantage of it, and what the user should expect when they install it. Links to external documents for detailed instructions are fine, but the description itself should "
+"cover the basics and leave users confident that they know what they'll get. Also, it is important that you maintain version notes appropriately as you improve and change your add-on. Users should "
+"be able to see what's new in an add-on they may have tried previously, and should be made aware of changes that might affect their current use of the add-on when they update."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/docs/policies-submission.html:31
 msgid ""
-"<strong>Are all privacy and security concerns clearly spelled out?</strong> "
-"This is an aspect of a clear and accurate description, but such an important"
-" one that we feel it deserves specific mention. Many very useful and well-"
-"written add-ons manipulate some form of user data, or can present security "
-"hazards if misused; they are welcome on the site, but they must make it very"
-" clear to users what risks they might encounter, and what they can do to "
-"protect themselves."
+"<strong>Are all privacy and security concerns clearly spelled out?</strong> This is an aspect of a clear and accurate description, but such an important one that we feel it deserves specific "
+"mention. Many very useful and well-written add-ons manipulate some form of user data, or can present security hazards if misused; they are welcome on the site, but they must make it very clear to "
+"users what risks they might encounter, and what they can do to protect themselves."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/docs/policies-submission.html:37
 msgid ""
-"<strong>Has the add-on been well-tested, and is it free of obvious or "
-"serious defects?</strong> One important thing that we look for when "
-"considering an add-on is whether its user reviews indicate that it has "
-"received thorough testing, and that it doesn't have serious problems or "
-"negative impacts on the browser. If reviewers report problems such as major "
-"performance issues, crashes, frequent problems using the functions of the "
-"add-on, or spamming of messages to the error console, you should take those "
-"reports to heart, and re-submit your add-on after you've addressed them as "
-"best you can. We don't expect you to perfectly optimize or have zero bugs "
-"&mdash; Firefox itself undergoes constant improvement in these areas &mdash;"
-" but we do want you to take reasonable efforts to minimize downsides, and to"
-" clearly call out cases where users may be surprised by those that remain."
+"<strong>Has the add-on been well-tested, and is it free of obvious or serious defects?</strong> One important thing that we look for when considering an add-on is whether its user reviews indicate "
+"that it has received thorough testing, and that it doesn't have serious problems or negative impacts on the browser. If reviewers report problems such as major performance issues, crashes, frequent "
+"problems using the functions of the add-on, or spamming of messages to the error console, you should take those reports to heart, and re-submit your add-on after you've addressed them as best you "
+"can. We don't expect you to perfectly optimize or have zero bugs &mdash; Firefox itself undergoes constant improvement in these areas &mdash; but we do want you to take reasonable efforts to "
+"minimize downsides, and to clearly call out cases where users may be surprised by those that remain."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/docs/policies-submission.html:43
 msgid ""
-"<strong>Do the add-on and add-on author both treat the user "
-"respectfully?</strong> Your software should not intrude on the user "
-"unnecessarily, try to trick the user, or conceal any of its activities from "
-"the user. Users (or even non-users) are sometimes rude in their comments, "
-"and while we will do our best to filter out inaccurate reviews as they're "
-"reported to us, we do expect that authors will avoid retaliating with "
-"rudeness of their own."
+"<strong>Do the add-on and add-on author both treat the user respectfully?</strong> Your software should not intrude on the user unnecessarily, try to trick the user, or conceal any of its "
+"activities from the user. Users (or even non-users) are sometimes rude in their comments, and while we will do our best to filter out inaccurate reviews as they're reported to us, we do expect that "
+"authors will avoid retaliating with rudeness of their own."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/docs/policies-submission.html:49
 msgid ""
-"<strong>Is the add-on useful to an appropriately wide portion of Firefox's "
-"users?</strong> Your add-on doesn't need to be the next Greasemonkey or "
-"Firebug, but if it is only useful to people at your company or who are part "
-"of a small web community, we may feel that it's not yet appropriate to put "
-"it in front of all of our users."
+"<strong>Is the add-on useful to an appropriately wide portion of Firefox's users?</strong> Your add-on doesn't need to be the next Greasemonkey or Firebug, but if it is only useful to people at "
+"your company or who are part of a small web community, we may feel that it's not yet appropriate to put it in front of all of our users."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/docs/policies-submission.html:55
 msgid ""
-"We are constantly looking at ways to improve the organization of the site to"
-" better accommodate add-ons that are exemplary in other ways, but are aimed "
-"at only a small community of potential users. Correctly categorizing and "
-"maintaining the metadata of your add-on will help us figure out how we can "
-"surface more of those sorts of add-ons to people who are most likely to "
-"benefit from them."
+"We are constantly looking at ways to improve the organization of the site to better accommodate add-ons that are exemplary in other ways, but are aimed at only a small community of potential users. "
+"Correctly categorizing and maintaining the metadata of your add-on will help us figure out how we can surface more of those sorts of add-ons to people who are most likely to benefit from them."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/docs/policies-submission.html:61
 msgid ""
-"If your add-on just provides bookmarks or other simple access points to your"
-" site, it's probably not appropriate for the gallery. Like the rest of the "
-"Mozilla project, we love web applications and new web services, but Firefox "
-"add-ons should provide an improved browsing experience for the user and not "
-"just be a way to promote a new site or service through a Mozilla Add-ons "
-"listing."
+"If your add-on just provides bookmarks or other simple access points to your site, it's probably not appropriate for the gallery. Like the rest of the Mozilla project, we love web applications and "
+"new web services, but Firefox add-ons should provide an improved browsing experience for the user and not just be a way to promote a new site or service through a Mozilla Add-ons listing."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/docs/policies-submission.html:67
 msgid ""
-"<strong>Is the add-on free of unlicensed trademarks and copyrights?</strong>"
-" Though you may mean no harm to the holder of a trademark, or the owner of a"
-" copyrighted work, we can't host add-ons that infringe on trademarks or "
-"copyrights. If you don't have permission to use a trademarked name or image,"
-" please do not submit your add-on to us. If your add-on includes code that "
-"is copyrighted by someone else, and is not licensed to you to use in your "
-"add-on, please do not submit your add-on to us."
+"<strong>Is the add-on free of unlicensed trademarks and copyrights?</strong> Though you may mean no harm to the holder of a trademark, or the owner of a copyrighted work, we can't host add-ons that "
+"infringe on trademarks or copyrights. If you don't have permission to use a trademarked name or image, please do not submit your add-on to us. If your add-on includes code that is copyrighted by "
+"someone else, and is not licensed to you to use in your add-on, please do not submit your add-on to us."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/docs/policies-submission.html:73
 msgid ""
-"In terms of reuse of source code from other add-ons, if the author has not "
-"clearly stated that you are permitted to use his or her code in your own "
-"work &mdash; such as by placing it under an open source license &mdash; then"
-" you should assume that you do not have the right to do so. You can contact "
-"the author to seek such permission, but we can't provide you with any "
-"special rights to it just because it's listed on the site, or because the "
-"author isn't responding to your request."
+"In terms of reuse of source code from other add-ons, if the author has not clearly stated that you are permitted to use his or her code in your own work &mdash; such as by placing it under an open "
+"source license &mdash; then you should assume that you do not have the right to do so. You can contact the author to seek such permission, but we can't provide you with any special rights to it "
+"just because it's listed on the site, or because the author isn't responding to your request."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/docs/policies-submission.html:79
 msgid ""
-"This applies to the Mozilla Foundation's trademarks as well, including "
-"\"Mozilla\", \"Firefox\", and \"Thunderbird\". The Mozilla policy on "
-"trademark use is designed to protect against confusion, and prevent the "
-"trademarks from being overturned due to lack of protection; please respect "
-"the need for such protection, and help us preserve some of the most valuable"
-" assets of the Mozilla Foundation."
+"This applies to the Mozilla Foundation's trademarks as well, including \"Mozilla\", \"Firefox\", and \"Thunderbird\". The Mozilla policy on trademark use is designed to protect against confusion, "
+"and prevent the trademarks from being overturned due to lack of protection; please respect the need for such protection, and help us preserve some of the most valuable assets of the Mozilla "
+"Foundation."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/docs/policies-submission.html:84
@@ -7196,65 +5952,46 @@ msgstr ""
 
 #: src/olympia/devhub/templates/devhub/docs/policies-submission.html:86
 msgid ""
-"Selecting an appropriate license for your add-on is a very important step in"
-" the submission process. A license specifies the rights you grant on your "
-"source code and is important in protecting your intellectual property."
+"Selecting an appropriate license for your add-on is a very important step in the submission process. A license specifies the rights you grant on your source code and is important in protecting your "
+"intellectual property."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/docs/policies-submission.html:92
 msgid ""
-"During the add-on submission process, you will be presented with a list of "
-"popular licenses to choose from, as well as the ability to specify your own "
-"license. It is best to consult with a legal professional about which license"
-" option is best for you. Choosing the right license for your source code "
-"will help to prevent confusion and code conflicts in the future."
+"During the add-on submission process, you will be presented with a list of popular licenses to choose from, as well as the ability to specify your own license. It is best to consult with a legal "
+"professional about which license option is best for you. Choosing the right license for your source code will help to prevent confusion and code conflicts in the future."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/docs/policies.html:12
-#: src/olympia/devhub/templates/devhub/docs/policies.html:52
+#: src/olympia/devhub/templates/devhub/docs/policies.html:12 src/olympia/devhub/templates/devhub/docs/policies.html:52
 msgid "Add-on Submission"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/docs/policies.html:18
-#: src/olympia/devhub/templates/devhub/docs/policies.html:78
+#: src/olympia/devhub/templates/devhub/docs/policies.html:18 src/olympia/devhub/templates/devhub/docs/policies.html:78
 msgid "Maintaining Your Add-on"
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/docs/policies.html:43
-msgid ""
-"Mozilla is committed to ensuring a great add-ons experience for our users "
-"and developers. Please review the policies below before submitting your add-"
-"on."
+msgid "Mozilla is committed to ensuring a great add-ons experience for our users and developers. Please review the policies below before submitting your add-on."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/docs/policies.html:55
-msgid ""
-"Find out what is expected of add-ons we host and our policies on specific "
-"add-on practices."
+msgid "Find out what is expected of add-ons we host and our policies on specific add-on practices."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/docs/policies.html:67
-msgid ""
-"What happens after your add-on is submitted? Learn about how our Editors "
-"review submissions."
+msgid "What happens after your add-on is submitted? Learn about how our Editors review submissions."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/docs/policies.html:81
-msgid ""
-"Add-on updates, transferring ownership, user reviews, and what to expect "
-"once your add-on is approved."
+msgid "Add-on updates, transferring ownership, user reviews, and what to expect once your add-on is approved."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/docs/policies.html:93
-msgid ""
-"How up-and-coming add-ons become featured and what&#039;s involved in the "
-"process."
+msgid "How up-and-coming add-ons become featured and what&#039;s involved in the process."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/docs/policies.html:106
-msgid ""
-"Terms of Service for submitting your work to our site. Developers are "
-"required to accept this agreement before submission."
+msgid "Terms of Service for submitting your work to our site. Developers are required to accept this agreement before submission."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/docs/policies.html:118
@@ -7266,9 +6003,7 @@ msgid "You have disabled this add-on"
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/includes/addon_details.html:24
-msgid ""
-"Your add-on's listing is disabled and is not showing anywhere in our gallery"
-" or update service."
+msgid "Your add-on's listing is disabled and is not showing anywhere in our gallery or update service."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/includes/addon_details.html:27
@@ -7280,48 +6015,31 @@ msgid "You will receive an email when the review is complete."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/includes/addon_details.html:33
-msgid ""
-"You will receive an email when the review is complete. Until then, your add-"
-"on is not listed in our gallery but can be accessed directly from its "
-"details page."
+msgid "You will receive an email when the review is complete. Until then, your add-on is not listed in our gallery but can be accessed directly from its details page."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:37
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:45
-msgid ""
-"You will receive an email when the review is complete and your add-on is "
-"signed."
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:37 src/olympia/devhub/templates/devhub/includes/addon_details.html:45
+msgid "You will receive an email when the review is complete and your add-on is signed."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/includes/addon_details.html:41
-msgid ""
-"You will receive an email when the review is complete. Until then, your add-"
-"on is not listed in our gallery but can be accessed directly from its "
-"details page. "
+msgid "You will receive an email when the review is complete. Until then, your add-on is not listed in our gallery but can be accessed directly from its details page. "
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/includes/addon_details.html:49
-msgid ""
-"Your add-on is displayed in our gallery and users are receiving automatic "
-"updates."
+msgid "Your add-on is displayed in our gallery and users are receiving automatic updates."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/includes/addon_details.html:52
-msgid ""
-"Your add-on has been signed and can be bundled with an application "
-"installer."
+msgid "Your add-on has been signed and can be bundled with an application installer."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/includes/addon_details.html:56
-msgid ""
-"Your add-on was disabled by a site administrator and is no longer shown in "
-"our gallery. If you have any questions, please email amo-admins@mozilla.org."
+msgid "Your add-on was disabled by a site administrator and is no longer shown in our gallery. If you have any questions, please email amo-admins@mozilla.org."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/includes/addon_details.html:62
-msgid ""
-"Your add-on is displayed in our gallery as experimental and users are "
-"receiving automatic updates. Some features are unavailable to your add-on."
+msgid "Your add-on is displayed in our gallery as experimental and users are receiving automatic updates. Some features are unavailable to your add-on."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/includes/addon_details.html:66
@@ -7330,22 +6048,16 @@ msgstr ""
 
 #: src/olympia/devhub/templates/devhub/includes/addon_details.html:69
 msgid ""
-"You will receive an email when the full review is complete. Until then, your"
-" add-on is displayed in our gallery as experimental and users are receiving "
-"automatic updates. Some features are unavailable to your add-on."
+"You will receive an email when the full review is complete. Until then, your add-on is displayed in our gallery as experimental and users are receiving automatic updates. Some features are "
+"unavailable to your add-on."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/includes/addon_details.html:74
-msgid ""
-"You will receive an email when the full review is complete, making you able "
-"to bundle your add-on with an application installer."
+msgid "You will receive an email when the full review is complete, making you able to bundle your add-on with an application installer."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/includes/addon_details.html:79
-msgid ""
-"All add-ons hosted in our gallery must now be reviewed by an editor. If you "
-"wish to continue hosting your add-on, please click to select a review "
-"process."
+msgid "All add-ons hosted in our gallery must now be reviewed by an editor. If you wish to continue hosting your add-on, please click to select a review process."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/includes/addon_details.html:100
@@ -7353,10 +6065,7 @@ msgid "Current Version:"
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/includes/addon_details.html:102
-msgid ""
-"This is the version of your add-on that will be installed if someone clicks "
-"the Install button on addons.mozilla.org. It is only relevant for listed "
-"add-ons."
+msgid "This is the version of your add-on that will be installed if someone clicks the Install button on addons.mozilla.org. It is only relevant for listed add-ons."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/includes/addon_details.html:110
@@ -7364,8 +6073,7 @@ msgid "Created:"
 msgstr ""
 
 #. {0} is a date. dennis-ignore: E201
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:112
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:118
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:112 src/olympia/devhub/templates/devhub/includes/addon_details.html:118
 #, python-format
 msgid "%%b %%e, %%Y"
 msgstr ""
@@ -7375,12 +6083,10 @@ msgid "Next Version:"
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/includes/addon_details.html:125
-msgid ""
-"This is the newest uploaded version, however it isn’t live on the site yet."
+msgid "This is the newest uploaded version, however it isn’t live on the site yet."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:130
-#: src/olympia/devhub/templates/devhub/versions/list.html:30
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:130 src/olympia/devhub/templates/devhub/versions/list.html:30
 msgid "Queues are not reviewed strictly in order"
 msgstr ""
 
@@ -7398,10 +6104,8 @@ msgstr ""
 
 #: src/olympia/devhub/templates/devhub/includes/addons_create_profile.html:24
 msgid ""
-"Your developer profile will tell users about you, why you made this add-on, "
-"and what's next for the add-on. This profile is required for add-ons "
-"requesting contributions, but can be useful for any developer interested in "
-"connecting with users."
+"Your developer profile will tell users about you, why you made this add-on, and what's next for the add-on. This profile is required for add-ons requesting contributions, but can be useful for any "
+"developer interested in connecting with users."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/includes/addons_create_profile.html:32
@@ -7414,15 +6118,11 @@ msgid "<a href=\"%(url)s\"><strong>Update your user profile.</strong></a>"
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/includes/addons_create_profile.html:45
-msgid ""
-"Whether it was an idea while in line at the grocery store or the solution to"
-" one of life's great problems, share your story."
+msgid "Whether it was an idea while in line at the grocery store or the solution to one of life's great problems, share your story."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/includes/addons_create_profile.html:61
-msgid ""
-"Telling your users what's coming soon will give them something to look "
-"forward to."
+msgid "Telling your users what's coming soon will give them something to look forward to."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/includes/addons_edit_nav.html:23
@@ -7454,9 +6154,7 @@ msgid "View the blog &#9658;"
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/includes/license_form.html:6
-msgid ""
-"Please choose a license appropriate for the rights you grant on your source "
-"code. It is only relevant for listed add-ons."
+msgid "Please choose a license appropriate for the rights you grant on your source code. It is only relevant for listed add-ons."
 msgstr ""
 
 #. {0} is a list of HTML tags.
@@ -7472,8 +6170,7 @@ msgstr ""
 msgid "Remove this application"
 msgstr ""
 
-#. {0} is the maximum number of add-on categories allowed.                {1}
-#. is
+#. {0} is the maximum number of add-on categories allowed.                {1} is
 #. the application name.
 #: src/olympia/devhub/templates/devhub/includes/macros.html:70
 msgid "Select <b>up to {0}</b> {1} category for this add-on:"
@@ -7485,24 +6182,16 @@ msgstr[3] ""
 
 #: src/olympia/devhub/templates/devhub/includes/policy_form.html:4
 msgid ""
-"Users will be required to accept the following End-User License Agreement "
-"(EULA) prior to installing your add-on. The presence of a EULA significantly"
-" affects the number of downloads an add-on receives. Please note that a EULA"
-" is not the same as a code license, such as the GPL or MPL.It is only "
-"relevant for listed add-ons."
+"Users will be required to accept the following End-User License Agreement (EULA) prior to installing your add-on. The presence of a EULA significantly affects the number of downloads an add-on "
+"receives. Please note that a EULA is not the same as a code license, such as the GPL or MPL.It is only relevant for listed add-ons."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/includes/policy_form.html:24
-msgid ""
-"If your add-on transmits any data from the user's computer, a privacy policy"
-" is required that explains what data is sent and how it is used. It is only "
-"relevant for listed add-ons."
+msgid "If your add-on transmits any data from the user's computer, a privacy policy is required that explains what data is sent and how it is used. It is only relevant for listed add-ons."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/includes/source_form_field.html:2
-msgid ""
-"If your add-on contains binary or obfuscated code other than known "
-"libraries, upload its sources for review."
+msgid "If your add-on contains binary or obfuscated code other than known libraries, upload its sources for review."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/includes/source_form_field.html:3
@@ -7510,9 +6199,7 @@ msgid "Read more about the source code review policy."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/includes/version_file.html:20
-msgid ""
-"You cannot remove an individual file after the review process has begun. You"
-" must delete the entire version."
+msgid "You cannot remove an individual file after the review process has begun. You must delete the entire version."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/includes/version_file.html:36
@@ -7541,9 +6228,7 @@ msgid "Voluntary Contributions"
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/payments/payments.html:38
-msgid ""
-"Add-ons enrolled in our contributions program can request voluntary "
-"financial support from users."
+msgid "Add-ons enrolled in our contributions program can request voluntary financial support from users."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/payments/payments.html:40
@@ -7555,9 +6240,7 @@ msgid "Choose when and how users are asked to contribute"
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/payments/payments.html:42
-msgid ""
-"Receive contributions in your PayPal account or send them to an organization"
-" of your choice"
+msgid "Receive contributions in your PayPal account or send them to an organization of your choice"
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/payments/payments.html:46
@@ -7566,17 +6249,14 @@ msgstr ""
 
 #: src/olympia/devhub/templates/devhub/payments/payments.html:53
 #, python-format
-msgid ""
-"Contributions are only available for add-ons with a <a "
-"href=\"%(url)s\">completed developer profile</a>."
+msgid "Contributions are only available for add-ons with a <a href=\"%(url)s\">completed developer profile</a>."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/payments/payments.html:59
 msgid "Contributions are only available for fully reviewed add-ons."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/payments/payments.html:65
-#: src/olympia/devhub/templates/devhub/payments/voluntary.html:2
+#: src/olympia/devhub/templates/devhub/payments/payments.html:65 src/olympia/devhub/templates/devhub/payments/voluntary.html:2
 msgid "Set up Contributions"
 msgstr ""
 
@@ -7589,15 +6269,12 @@ msgstr ""
 msgid "or <a href=\"%(cancel)s\">Cancel</a>"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/payments/voluntary.html:2
-#: src/olympia/stats/templates/stats/addon_report_menu.html:39
+#: src/olympia/devhub/templates/devhub/payments/voluntary.html:2 src/olympia/stats/templates/stats/addon_report_menu.html:39
 msgid "Contributions"
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/payments/voluntary.html:3
-msgid ""
-"Fill in the fields below to begin asking for voluntary contributions from "
-"users."
+msgid "Fill in the fields below to begin asking for voluntary contributions from users."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/payments/voluntary.html:11
@@ -7641,16 +6318,13 @@ msgid "Send a thank-you note?"
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/payments/voluntary.html:47
-msgid ""
-"We'll automatically email users who contribute to your add-on with this "
-"message."
+msgid "We'll automatically email users who contribute to your add-on with this message."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/payments/voluntary.html:49
 msgid ""
-"We recommend thanking the user and telling them how much you appreciate "
-"their support. You might also want to tell them about what's next for your "
-"add-on and about any other add-ons you've made for them to try."
+"We recommend thanking the user and telling them how much you appreciate their support. You might also want to tell them about what's next for your add-on and about any other add-ons you've made for "
+"them to try."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/payments/voluntary.html:64
@@ -7665,128 +6339,90 @@ msgstr ""
 msgid "Transfer ownership"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/personas/edit.html:77
-#: src/olympia/devhub/templates/devhub/personas/submit.html:31
+#: src/olympia/devhub/templates/devhub/personas/edit.html:77 src/olympia/devhub/templates/devhub/personas/submit.html:31
 msgid "Theme Details"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/personas/edit.html:87
-#: src/olympia/devhub/templates/devhub/personas/submit.html:36
+#: src/olympia/devhub/templates/devhub/personas/edit.html:87 src/olympia/devhub/templates/devhub/personas/submit.html:36
 msgid "Supply a pretty URL for your detail page."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/personas/edit.html:92
-#: src/olympia/devhub/templates/devhub/personas/submit.html:41
+#: src/olympia/devhub/templates/devhub/personas/edit.html:92 src/olympia/devhub/templates/devhub/personas/submit.html:41
 msgid "Select the category that best describes your Theme."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/personas/edit.html:95
-#: src/olympia/devhub/templates/devhub/personas/submit.html:44
+#: src/olympia/devhub/templates/devhub/personas/edit.html:95 src/olympia/devhub/templates/devhub/personas/submit.html:44
 msgid "Add some tags to describe your Theme."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/personas/edit.html:106
-#: src/olympia/devhub/templates/devhub/personas/submit.html:54
-msgid ""
-"A short explanation of your theme's basic functionality that is displayed in"
-" search and browse listings, as well as at the top of your theme's details "
-"page."
+#: src/olympia/devhub/templates/devhub/personas/edit.html:106 src/olympia/devhub/templates/devhub/personas/submit.html:54
+msgid "A short explanation of your theme's basic functionality that is displayed in search and browse listings, as well as at the top of your theme's details page."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/personas/edit.html:122
-#: src/olympia/devhub/templates/devhub/personas/submit.html:68
+#: src/olympia/devhub/templates/devhub/personas/edit.html:122 src/olympia/devhub/templates/devhub/personas/submit.html:68
 msgid "Theme License"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/personas/edit.html:126
-#: src/olympia/devhub/templates/devhub/personas/submit.html:72
+#: src/olympia/devhub/templates/devhub/personas/edit.html:126 src/olympia/devhub/templates/devhub/personas/submit.html:72
 msgid "Can others share your Theme, as long as you're given credit?"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/personas/edit.html:132
-#: src/olympia/devhub/templates/devhub/personas/edit.html:153
-#: src/olympia/devhub/templates/devhub/personas/submit.html:78
+#: src/olympia/devhub/templates/devhub/personas/edit.html:132 src/olympia/devhub/templates/devhub/personas/edit.html:153 src/olympia/devhub/templates/devhub/personas/submit.html:78
 #: src/olympia/devhub/templates/devhub/personas/submit.html:99
-msgid ""
-"The licensor permits others to copy, distribute, display, and perform the "
-"work, including for commercial purposes."
+msgid "The licensor permits others to copy, distribute, display, and perform the work, including for commercial purposes."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/personas/edit.html:141
-#: src/olympia/devhub/templates/devhub/personas/edit.html:162
-#: src/olympia/devhub/templates/devhub/personas/submit.html:87
+#: src/olympia/devhub/templates/devhub/personas/edit.html:141 src/olympia/devhub/templates/devhub/personas/edit.html:162 src/olympia/devhub/templates/devhub/personas/submit.html:87
 #: src/olympia/devhub/templates/devhub/personas/submit.html:108
-msgid ""
-"The licensor permits others to copy, distribute, display, and perform the "
-"work for non-commercial purposes only."
+msgid "The licensor permits others to copy, distribute, display, and perform the work for non-commercial purposes only."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/personas/edit.html:147
-#: src/olympia/devhub/templates/devhub/personas/submit.html:93
+#: src/olympia/devhub/templates/devhub/personas/edit.html:147 src/olympia/devhub/templates/devhub/personas/submit.html:93
 msgid "Can others make commercial use of your Theme?"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/personas/edit.html:168
-#: src/olympia/devhub/templates/devhub/personas/submit.html:114
+#: src/olympia/devhub/templates/devhub/personas/edit.html:168 src/olympia/devhub/templates/devhub/personas/submit.html:114
 msgid "Can others create derivative works from your Theme?"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/personas/edit.html:174
-#: src/olympia/devhub/templates/devhub/personas/submit.html:120
-msgid ""
-"The licensor permits others to copy, distribute, display and perform the "
-"work, as well as make derivative works based on it."
+#: src/olympia/devhub/templates/devhub/personas/edit.html:174 src/olympia/devhub/templates/devhub/personas/submit.html:120
+msgid "The licensor permits others to copy, distribute, display and perform the work, as well as make derivative works based on it."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/personas/edit.html:182
-#: src/olympia/devhub/templates/devhub/personas/submit.html:128
+#: src/olympia/devhub/templates/devhub/personas/edit.html:182 src/olympia/devhub/templates/devhub/personas/submit.html:128
 msgid "Yes, as long as they share alike"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/personas/edit.html:183
-#: src/olympia/devhub/templates/devhub/personas/submit.html:129
-msgid ""
-"The licensor permits others to distribute derivativeworks only under the "
-"same license or one compatible with the one that governs the licensor's "
-"work."
+#: src/olympia/devhub/templates/devhub/personas/edit.html:183 src/olympia/devhub/templates/devhub/personas/submit.html:129
+msgid "The licensor permits others to distribute derivativeworks only under the same license or one compatible with the one that governs the licensor's work."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/personas/edit.html:192
-#: src/olympia/devhub/templates/devhub/personas/submit.html:138
-msgid ""
-"The licensor permits others to copy, distribute and transmit only unaltered "
-"copies of the work — not derivative works based on it."
+#: src/olympia/devhub/templates/devhub/personas/edit.html:192 src/olympia/devhub/templates/devhub/personas/submit.html:138
+msgid "The licensor permits others to copy, distribute and transmit only unaltered copies of the work — not derivative works based on it."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/personas/edit.html:199
-#: src/olympia/devhub/templates/devhub/personas/submit.html:145
+#: src/olympia/devhub/templates/devhub/personas/edit.html:199 src/olympia/devhub/templates/devhub/personas/submit.html:145
 msgid "Your Theme will be released under the following license:"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/personas/edit.html:202
-#: src/olympia/devhub/templates/devhub/personas/submit.html:148
+#: src/olympia/devhub/templates/devhub/personas/edit.html:202 src/olympia/devhub/templates/devhub/personas/submit.html:148
 msgid "Select a different license."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/personas/edit.html:207
-#: src/olympia/devhub/templates/devhub/personas/submit.html:153
+#: src/olympia/devhub/templates/devhub/personas/edit.html:207 src/olympia/devhub/templates/devhub/personas/submit.html:153
 msgid "Select a license for your Theme."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/personas/edit.html:217
-#: src/olympia/devhub/templates/devhub/personas/submit.html:163
+#: src/olympia/devhub/templates/devhub/personas/edit.html:217 src/olympia/devhub/templates/devhub/personas/submit.html:163
 msgid "Theme Design"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/personas/edit.html:221
-#: src/olympia/devhub/templates/devhub/personas/edit.html:224
+#: src/olympia/devhub/templates/devhub/personas/edit.html:221 src/olympia/devhub/templates/devhub/personas/edit.html:224
 msgid "Upload New Design"
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/personas/edit.html:226
-msgid ""
-"Upon upload and form submission, the AMO Team will review your updated "
-"design. Your current design will still be public in the meantime."
+msgid "Upon upload and form submission, the AMO Team will review your updated design. Your current design will still be public in the meantime."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/personas/edit.html:241
@@ -7813,43 +6449,35 @@ msgstr ""
 msgid "Footer"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/personas/edit.html:274
-#: src/olympia/devhub/templates/devhub/personas/submit.html:167
+#: src/olympia/devhub/templates/devhub/personas/edit.html:274 src/olympia/devhub/templates/devhub/personas/submit.html:167
 msgid "Select colors for your Theme."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/personas/edit.html:276
-#: src/olympia/devhub/templates/devhub/personas/submit.html:169
+#: src/olympia/devhub/templates/devhub/personas/edit.html:276 src/olympia/devhub/templates/devhub/personas/submit.html:169
 msgid "Foreground Text"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/personas/edit.html:277
-#: src/olympia/devhub/templates/devhub/personas/submit.html:170
+#: src/olympia/devhub/templates/devhub/personas/edit.html:277 src/olympia/devhub/templates/devhub/personas/submit.html:170
 msgid "This is the color of the tab text."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/personas/edit.html:279
-#: src/olympia/devhub/templates/devhub/personas/submit.html:172
+#: src/olympia/devhub/templates/devhub/personas/edit.html:279 src/olympia/devhub/templates/devhub/personas/submit.html:172
 msgid "Background"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/personas/edit.html:280
-#: src/olympia/devhub/templates/devhub/personas/submit.html:173
+#: src/olympia/devhub/templates/devhub/personas/edit.html:280 src/olympia/devhub/templates/devhub/personas/submit.html:173
 msgid "This is the color of the tabs."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/personas/edit.html:285
-#: src/olympia/devhub/templates/devhub/personas/submit.html:178
+#: src/olympia/devhub/templates/devhub/personas/edit.html:285 src/olympia/devhub/templates/devhub/personas/submit.html:178
 msgid "Preview"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/personas/edit.html:291
-#: src/olympia/devhub/templates/devhub/personas/submit.html:183
+#: src/olympia/devhub/templates/devhub/personas/edit.html:291 src/olympia/devhub/templates/devhub/personas/submit.html:183
 msgid "Your Theme's Name"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/personas/edit.html:294
-#: src/olympia/devhub/templates/devhub/personas/submit.html:186
+#: src/olympia/devhub/templates/devhub/personas/edit.html:294 src/olympia/devhub/templates/devhub/personas/submit.html:186
 #, python-format
 msgid "by <a href=\"%(profile_url)s\" target=\"_blank\">%(user)s</a>"
 msgstr ""
@@ -7860,10 +6488,7 @@ msgstr ""
 
 #: src/olympia/devhub/templates/devhub/personas/submit.html:18
 #, python-format
-msgid ""
-"Background themes let you easily personalize the look of your Firefox. "
-"Submit your own design below, or <a href=\"%(submit_url)s\">learn how to "
-"create one</a>!"
+msgid "Background themes let you easily personalize the look of your Firefox. Submit your own design below, or <a href=\"%(submit_url)s\">learn how to create one</a>!"
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/personas/submit.html:33
@@ -7873,9 +6498,7 @@ msgstr ""
 #: src/olympia/devhub/templates/devhub/personas/submit.html:198
 #, python-format
 msgid ""
-"I agree to the <a href=\"%(agreement_url)s\" target=\"_blank\">Firefox Add-"
-"on Distribution Agreement</a> and to my information being handled as "
-"described in the <a href=\"%(privacy_notice_url)s\" "
+"I agree to the <a href=\"%(agreement_url)s\" target=\"_blank\">Firefox Add-on Distribution Agreement</a> and to my information being handled as described in the <a href=\"%(privacy_notice_url)s\" "
 "target=\"_blank\">Websites, Communications and Cookies Privacy Notice</a>."
 msgstr ""
 
@@ -7884,23 +6507,17 @@ msgid "Submit Theme"
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/personas/submit_done.html:11
-msgid ""
-"Your theme has been submitted to the Review Queue. You'll receive an email "
-"once it has been reviewed, typically within 24 hours."
+msgid "Your theme has been submitted to the Review Queue. You'll receive an email once it has been reviewed, typically within 24 hours."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/personas/submit_done.html:19
 #, python-format
-msgid ""
-"Provide more details about your theme by <a href=\"%(edit_url)s\">editing "
-"its listing</a>."
+msgid "Provide more details about your theme by <a href=\"%(edit_url)s\">editing its listing</a>."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/personas/submit_done.html:25
 #, python-format
-msgid ""
-"View and subscribe to your theme's <a href=\"%(feed_url)s\">activity "
-"feed</a> to stay updated on reviews, collections, and more."
+msgid "View and subscribe to your theme's <a href=\"%(feed_url)s\">activity feed</a> to stay updated on reviews, collections, and more."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/personas/submit_done.html:32
@@ -7916,13 +6533,11 @@ msgstr ""
 msgid "3000 &times; 200 pixels"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/personas/includes/theme_design.html:9
-#: src/olympia/devhub/templates/devhub/personas/includes/theme_design.html:25
+#: src/olympia/devhub/templates/devhub/personas/includes/theme_design.html:9 src/olympia/devhub/templates/devhub/personas/includes/theme_design.html:25
 msgid "300 KB max"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/personas/includes/theme_design.html:10
-#: src/olympia/devhub/templates/devhub/personas/includes/theme_design.html:26
+#: src/olympia/devhub/templates/devhub/personas/includes/theme_design.html:10 src/olympia/devhub/templates/devhub/personas/includes/theme_design.html:26
 msgid "PNG or JPG"
 msgstr ""
 
@@ -7950,21 +6565,19 @@ msgstr ""
 msgid "Select a different footer image"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/add_file_modal.html:7
-msgid ""
-"Files added to reviewed versions must be reviewed before they will be "
-"available for download."
+#: src/olympia/devhub/templates/devhub/versions/add_file_modal.html:8
+msgid "Files added to reviewed versions must be reviewed before they will be available for download."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/add_file_modal.html:23
+#: src/olympia/devhub/templates/devhub/versions/add_file_modal.html:24
 msgid "Select the target platform for this file."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/add_file_modal.html:34
+#: src/olympia/devhub/templates/devhub/versions/add_file_modal.html:35
 msgid "Which review type would you like to nominate for?"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/add_file_modal.html:39
+#: src/olympia/devhub/templates/devhub/versions/add_file_modal.html:40
 msgid "Only publish this version to my beta channel."
 msgstr ""
 
@@ -7972,8 +6585,7 @@ msgstr ""
 msgid "Manage Version {0}"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/edit.html:12
-#: src/olympia/devhub/templates/devhub/versions/list.html:3
+#: src/olympia/devhub/templates/devhub/versions/edit.html:12 src/olympia/devhub/templates/devhub/versions/list.html:3
 msgid "Status & Versions"
 msgstr ""
 
@@ -7992,24 +6604,20 @@ msgstr ""
 
 #: src/olympia/devhub/templates/devhub/versions/edit.html:74
 msgid ""
-"Information about changes in this release, new features, known bugs, and "
-"other useful information specific to this release/version. This information "
-"is also shown in the Add-ons Manager when updating."
+"Information about changes in this release, new features, known bugs, and other useful information specific to this release/version. This information is also shown in the Add-ons Manager when "
+"updating."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/versions/edit.html:99
 msgid "Approval Status"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/edit.html:113
-#: src/olympia/editors/templates/editors/review.html:108
+#: src/olympia/devhub/templates/devhub/versions/edit.html:113 src/olympia/editors/templates/editors/review.html:108
 msgid "Notes for Reviewers"
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/versions/edit.html:114
-msgid ""
-"Optionally, enter any information that may be useful to the Editor reviewing"
-" this add-on, such as test account information."
+msgid "Optionally, enter any information that may be useful to the Editor reviewing this add-on, such as test account information."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/versions/edit.html:127
@@ -8017,13 +6625,10 @@ msgid "Source code"
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/versions/edit.html:128
-msgid ""
-"If your add-on contain binary or obfuscated code, make the source available "
-"here for reviewers."
+msgid "If your add-on contain binary or obfuscated code, make the source available here for reviewers."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/edit.html:145
-#: src/olympia/devhub/templates/devhub/versions/edit.html:149
+#: src/olympia/devhub/templates/devhub/versions/edit.html:145 src/olympia/devhub/templates/devhub/versions/edit.html:149
 msgid "Upload a new file"
 msgstr ""
 
@@ -8092,9 +6697,7 @@ msgstr ""
 msgid "Request Preliminary Review"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:80
-#: src/olympia/devhub/templates/devhub/versions/list.html:325
-#: src/olympia/devhub/templates/devhub/versions/list.html:348
+#: src/olympia/devhub/templates/devhub/versions/list.html:80 src/olympia/devhub/templates/devhub/versions/list.html:325 src/olympia/devhub/templates/devhub/versions/list.html:348
 msgid "Cancel Review Request"
 msgstr ""
 
@@ -8107,8 +6710,7 @@ msgid "Listed:"
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/versions/list.html:102
-msgid ""
-"Visible to everyone on {0} and included in search results and listing pages"
+msgid "Visible to everyone on {0} and included in search results and listing pages"
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/versions/list.html:108
@@ -8116,9 +6718,7 @@ msgid "Hidden:"
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/versions/list.html:108
-msgid ""
-"Hosted on {0}, but hidden to anyone but authors. Used to temporarily hide "
-"listings or discontinue them."
+msgid "Hosted on {0}, but hidden to anyone but authors. Used to temporarily hide listings or discontinue them."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/versions/list.html:114
@@ -8126,9 +6726,7 @@ msgid "Unlisted:"
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/versions/list.html:114
-msgid ""
-"Not distributed on {0}. Developers will upload new versions for signing and "
-"distribute the add-ons on their own."
+msgid "Not distributed on {0}. Developers will upload new versions for signing and distribute the add-ons on their own."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/versions/list.html:122
@@ -8139,17 +6737,12 @@ msgstr ""
 msgid "Currently on AMO"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:129
-#: src/olympia/devhub/templates/devhub/versions/list.html:147
-#: src/olympia/devhub/templates/devhub/versions/list.html:164
-#: src/olympia/editors/templates/editors/includes/search_results_themes.html:7
-#: src/olympia/editors/templates/editors/themes/queue_list.html:50
+#: src/olympia/devhub/templates/devhub/versions/list.html:129 src/olympia/devhub/templates/devhub/versions/list.html:147 src/olympia/devhub/templates/devhub/versions/list.html:164
+#: src/olympia/editors/templates/editors/includes/search_results_themes.html:7 src/olympia/editors/templates/editors/themes/queue_list.html:50
 msgid "Status"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:130
-#: src/olympia/devhub/templates/devhub/versions/list.html:148
-#: src/olympia/devhub/templates/devhub/versions/list.html:165
+#: src/olympia/devhub/templates/devhub/versions/list.html:130 src/olympia/devhub/templates/devhub/versions/list.html:148 src/olympia/devhub/templates/devhub/versions/list.html:165
 #: src/olympia/editors/templates/editors/includes/files_view.html:11
 msgid "Validation"
 msgstr ""
@@ -8171,10 +6764,7 @@ msgid "Full review may not be required"
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/versions/list.html:201
-msgid ""
-"Unlisted add-ons don't need Full Review unless they are distributed as part "
-"of an application installer. Read <a href=\"{link}\" target=\"_blank\">this "
-"documentation</a> for more information."
+msgid "Unlisted add-ons don't need Full Review unless they are distributed as part of an application installer. Read <a href=\"{link}\" target=\"_blank\">this documentation</a> for more information."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/versions/list.html:209
@@ -8187,9 +6777,7 @@ msgstr ""
 
 #: src/olympia/devhub/templates/devhub/versions/list.html:218
 msgid ""
-"You are about to delete the current version of your add-on. This may cause "
-"your add-on status to change, or your listing to lose public visibility, if "
-"this is the only public version of your add-on."
+"You are about to delete the current version of your add-on. This may cause your add-on status to change, or your listing to lose public visibility, if this is the only public version of your add-on."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/versions/list.html:219
@@ -8197,9 +6785,7 @@ msgid "Deleting this version will permanently delete:"
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/versions/list.html:225
-msgid ""
-"<strong>Important:</strong> Once a version has been deleted, you may not "
-"upload a new version with the same version number."
+msgid "<strong>Important:</strong> Once a version has been deleted, you may not upload a new version with the same version number."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/versions/list.html:230
@@ -8222,41 +6808,31 @@ msgstr ""
 msgid "Add Version"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:253
-#: src/olympia/devhub/templates/devhub/versions/list.html:279
+#: src/olympia/devhub/templates/devhub/versions/list.html:253 src/olympia/devhub/templates/devhub/versions/list.html:279
 msgid "Hide Add-on"
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/versions/list.html:256
-msgid ""
-"Hiding your add-on will prevent it from appearing anywhere in our gallery "
-"and will stop users from receiving automatic updates."
+msgid "Hiding your add-on will prevent it from appearing anywhere in our gallery and will stop users from receiving automatic updates."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/versions/list.html:263
-msgid ""
-"The files awaiting review will be disabled and you will need to upload new "
-"versions."
+msgid "The files awaiting review will be disabled and you will need to upload new versions."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/versions/list.html:270
 msgid "Are you sure you wish to hide your add-on?"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:291
-#: src/olympia/devhub/templates/devhub/versions/list.html:313
+#: src/olympia/devhub/templates/devhub/versions/list.html:291 src/olympia/devhub/templates/devhub/versions/list.html:313
 msgid "Unlist Add-on"
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/versions/list.html:294
 #, python-format
 msgid ""
-"Unlisting your add-on will make it (and each of its versions/files) "
-"invisible on this website. It won't show up in searches, won't have a public"
-" facing page, and won't be updated automatically for current users. It is "
-"recommended for unlisted add-ons to provide a custom <a "
-"href=\"%(update_url)s\" target=\"_blank\">updateURL</a> in their manifest "
-"file for automatic updates."
+"Unlisting your add-on will make it (and each of its versions/files) invisible on this website. It won't show up in searches, won't have a public facing page, and won't be updated automatically for "
+"current users. It is recommended for unlisted add-ons to provide a custom <a href=\"%(update_url)s\" target=\"_blank\">updateURL</a> in their manifest file for automatic updates."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/versions/list.html:303
@@ -8272,16 +6848,11 @@ msgid "Are you sure you wish to unlist your add-on?"
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/versions/list.html:328
-msgid ""
-"Canceling your review request will leave your add-on as preliminarily "
-"reviewed."
+msgid "Canceling your review request will leave your add-on as preliminarily reviewed."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/versions/list.html:333
-msgid ""
-"Canceling your review request will mark your add-on incomplete. If you do "
-"not complete your add-on after several days by re-requesting review, it will"
-" be deleted."
+msgid "Canceling your review request will mark your add-on incomplete. If you do not complete your add-on after several days by re-requesting review, it will be deleted."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/versions/list.html:341
@@ -8317,14 +6888,11 @@ msgid "Translate content on the web from and into over 40 languages."
 msgstr ""
 
 #: src/olympia/discovery/modules.py:171
-msgid ""
-"Easily connect to your social networks, and share or comment on the page "
-"you're visiting."
+msgid "Easily connect to your social networks, and share or comment on the page you're visiting."
 msgstr ""
 
 #: src/olympia/discovery/modules.py:173
-msgid ""
-"A quick view to compare prices when you shop online or search for flights."
+msgid "A quick view to compare prices when you shop online or search for flights."
 msgstr ""
 
 #: src/olympia/discovery/modules.py:183
@@ -8368,9 +6936,7 @@ msgid "Add-ons that help you on your travels!"
 msgstr ""
 
 #: src/olympia/discovery/modules.py:226
-msgid ""
-"Displays a country flag depicting the location of the current website's "
-"server and more."
+msgid "Displays a country flag depicting the location of the current website's server and more."
 msgstr ""
 
 #: src/olympia/discovery/modules.py:228
@@ -8378,9 +6944,7 @@ msgid "FoxClocks let you keep an eye on the time around the world."
 msgstr ""
 
 #: src/olympia/discovery/modules.py:230
-msgid ""
-"Automatically get the lowest price when you shop online or search for "
-"flights."
+msgid "Automatically get the lowest price when you shop online or search for flights."
 msgstr ""
 
 #: src/olympia/discovery/modules.py:240
@@ -8420,9 +6984,7 @@ msgid "Put a Theme on It!"
 msgstr ""
 
 #: src/olympia/discovery/modules.py:281
-msgid ""
-"Visit addons.mozilla.org from Firefox for Android and dress up your mobile "
-"browser to match your style, mood, or the season."
+msgid "Visit addons.mozilla.org from Firefox for Android and dress up your mobile browser to match your style, mood, or the season."
 msgstr ""
 
 #: src/olympia/discovery/modules.py:290
@@ -8450,9 +7012,7 @@ msgid "Protect your privacy online with the add-ons in this collection."
 msgstr ""
 
 #: src/olympia/discovery/modules.py:342
-msgid ""
-"Great add-ons for work, fun, privacy, productivity&hellip; just about "
-"anything!"
+msgid "Great add-ons for work, fun, privacy, productivity&hellip; just about anything!"
 msgstr ""
 
 #: src/olympia/discovery/modules.py:350
@@ -8473,18 +7033,14 @@ msgstr ""
 
 #: src/olympia/discovery/templates/discovery/pane.html:28
 #, python-format
-msgid ""
-"Add-ons are applications that let you personalize %(app)s with extra "
-"functionality or style. Try a time-saving sidebar, a weather notifier, or a "
-"themed look to make %(app)s your own."
+msgid "Add-ons are applications that let you personalize %(app)s with extra functionality or style. Try a time-saving sidebar, a weather notifier, or a themed look to make %(app)s your own."
 msgstr ""
 
 #: src/olympia/discovery/templates/discovery/pane.html:62
 msgid "Learn More About Add-ons"
 msgstr ""
 
-#: src/olympia/discovery/templates/discovery/pane.html:66
-#: src/olympia/discovery/templates/discovery/pane.html:73
+#: src/olympia/discovery/templates/discovery/pane.html:66 src/olympia/discovery/templates/discovery/pane.html:73
 msgid "See all"
 msgstr ""
 
@@ -8515,9 +7071,7 @@ msgstr ""
 
 #: src/olympia/discovery/templates/discovery/pane_account.html:17
 #, python-format
-msgid ""
-"Thanks for using %(app)s and supporting <a href=\"%(url)s\">Mozilla's "
-"mission</a>!"
+msgid "Thanks for using %(app)s and supporting <a href=\"%(url)s\">Mozilla's mission</a>!"
 msgstr ""
 
 #: src/olympia/discovery/templates/discovery/pane_account.html:23
@@ -8542,10 +7096,7 @@ msgstr ""
 
 #: src/olympia/discovery/templates/discovery/modules/go-mobile.html:8
 #, python-format
-msgid ""
-"Visit <a href=\"%(url)s\">firefox.com/m</a> to get Firefox on your phone and"
-" personalize your browser anytime, anywhere. Easily discover and install "
-"add-ons from the mobile Add-ons Manager."
+msgid "Visit <a href=\"%(url)s\">firefox.com/m</a> to get Firefox on your phone and personalize your browser anytime, anywhere. Easily discover and install add-ons from the mobile Add-ons Manager."
 msgstr ""
 
 #: src/olympia/discovery/templates/discovery/modules/go-mobile.html:13
@@ -8561,15 +7112,11 @@ msgid "Find great add-ons to help you with all your holiday shopping needs."
 msgstr ""
 
 #: src/olympia/discovery/templates/discovery/modules/holiday.html:13
-msgid ""
-"Install the Amazon Browser Apps and receive special Amazon features right at"
-" your fingertips."
+msgid "Install the Amazon Browser Apps and receive special Amazon features right at your fingertips."
 msgstr ""
 
 #: src/olympia/discovery/templates/discovery/modules/holiday.html:22
-msgid ""
-"Keep an eye on your eBay activity wherever you are on the web when you "
-"install the eBay Sidebar for Firefox."
+msgid "Keep an eye on your eBay activity wherever you are on the web when you install the eBay Sidebar for Firefox."
 msgstr ""
 
 #: src/olympia/discovery/templates/discovery/modules/holiday.html:31
@@ -8647,19 +7194,19 @@ msgstr ""
 msgid "Search by add-on name / author email"
 msgstr ""
 
-#: src/olympia/editors/forms.py:103
+#: src/olympia/editors/forms.py:103 src/olympia/editors/forms.py:244 src/olympia/editors/forms.py:257
 msgid "yes"
 msgstr ""
 
-#: src/olympia/editors/forms.py:104
+#: src/olympia/editors/forms.py:104 src/olympia/editors/forms.py:244 src/olympia/editors/forms.py:257
 msgid "no"
 msgstr ""
 
-#: src/olympia/editors/forms.py:105
+#: src/olympia/editors/forms.py:105 src/olympia/editors/forms.py:245
 msgid "Admin Flag"
 msgstr ""
 
-#: src/olympia/editors/forms.py:113
+#: src/olympia/editors/forms.py:113 src/olympia/editors/forms.py:253
 msgid "Max. Version"
 msgstr ""
 
@@ -8675,53 +7222,55 @@ msgstr ""
 msgid "Platforms"
 msgstr ""
 
+#: src/olympia/editors/forms.py:237
+msgid "Search by add-on name / author email / guid"
+msgstr ""
+
 #. L10n: 0 = platform, 1 = filename, 2 = status message
-#: src/olympia/editors/forms.py:238
+#: src/olympia/editors/forms.py:342
 #, python-format
 msgid "<strong>%s</strong> &middot; %s &middot; %s"
 msgstr ""
 
-#: src/olympia/editors/forms.py:252
+#: src/olympia/editors/forms.py:356
 msgid "Comments:"
 msgstr ""
 
-#: src/olympia/editors/forms.py:256
+#: src/olympia/editors/forms.py:360
 msgid "Operating systems:"
 msgstr ""
 
-#: src/olympia/editors/forms.py:258
+#: src/olympia/editors/forms.py:362
 msgid "Applications:"
 msgstr ""
 
-#: src/olympia/editors/forms.py:260
-msgid ""
-"Notify me the next time this add-on is updated. (Subsequent updates will not"
-" generate an email)"
+#: src/olympia/editors/forms.py:364
+msgid "Notify me the next time this add-on is updated. (Subsequent updates will not generate an email)"
 msgstr ""
 
-#: src/olympia/editors/forms.py:265
+#: src/olympia/editors/forms.py:369
 msgid "Clear Admin Review Flag"
 msgstr ""
 
-#: src/olympia/editors/forms.py:267
+#: src/olympia/editors/forms.py:371
 msgid "Clear more info requested flag"
 msgstr ""
 
-#: src/olympia/editors/forms.py:281
+#: src/olympia/editors/forms.py:385
 msgid "Choose a canned response..."
 msgstr ""
 
 #. L10n: Description of what can be searched for.
-#: src/olympia/editors/forms.py:319
+#: src/olympia/editors/forms.py:423
 msgid "theme name"
 msgstr ""
 
-#: src/olympia/editors/forms.py:345
+#: src/olympia/editors/forms.py:449
 msgid "Someone else is reviewing this theme."
 msgstr ""
 
 #. L10n: Description of what can be searched for.
-#: src/olympia/editors/forms.py:442
+#: src/olympia/editors/forms.py:546
 msgid "app, reviewer, or comment"
 msgstr ""
 
@@ -8741,31 +7290,23 @@ msgstr ""
 msgid "Queue"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:126
-#: src/olympia/editors/templates/editors/base.html:50
-#: src/olympia/editors/templates/editors/base.html:65
+#: src/olympia/editors/helpers.py:126 src/olympia/editors/templates/editors/base.html:50 src/olympia/editors/templates/editors/base.html:65
 msgid "Pending Updates"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:127
-#: src/olympia/editors/templates/editors/base.html:48
-#: src/olympia/editors/templates/editors/base.html:63
+#: src/olympia/editors/helpers.py:127 src/olympia/editors/templates/editors/base.html:48 src/olympia/editors/templates/editors/base.html:63
 msgid "Full Reviews"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:128
-#: src/olympia/editors/templates/editors/base.html:52
-#: src/olympia/editors/templates/editors/base.html:67
+#: src/olympia/editors/helpers.py:128 src/olympia/editors/templates/editors/base.html:52 src/olympia/editors/templates/editors/base.html:67
 msgid "Preliminary Reviews"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:129
-#: src/olympia/editors/templates/editors/base.html:54
+#: src/olympia/editors/helpers.py:129 src/olympia/editors/templates/editors/base.html:54
 msgid "Moderated Reviews"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:130
-#: src/olympia/editors/templates/editors/base.html:46
+#: src/olympia/editors/helpers.py:130 src/olympia/editors/templates/editors/base.html:46
 msgid "Fast Track"
 msgstr ""
 
@@ -8773,8 +7314,7 @@ msgstr ""
 msgid "Pending Themes"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:133
-#: src/olympia/editors/templates/editors/themes/queue.html:4
+#: src/olympia/editors/helpers.py:133 src/olympia/editors/templates/editors/themes/queue.html:4
 msgid "Flagged Themes"
 msgstr ""
 
@@ -8878,8 +7418,7 @@ msgstr ""
 msgid "Waiting Time"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:276
-#: src/olympia/editors/templates/editors/review.html:285
+#: src/olympia/editors/helpers.py:276 src/olympia/editors/templates/editors/review.html:285
 msgid "Flags"
 msgstr ""
 
@@ -8942,105 +7481,93 @@ msgstr ""
 msgid "Last Update"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:559
-msgid "Push to public"
+#: src/olympia/editors/helpers.py:387
+msgid "No Reviews"
 msgstr ""
 
 #: src/olympia/editors/helpers.py:561
+msgid "Push to public"
+msgstr ""
+
+#: src/olympia/editors/helpers.py:563
 msgid "Grant full review"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:574
+#: src/olympia/editors/helpers.py:578
 msgid "Request more information"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:577
+#: src/olympia/editors/helpers.py:581
 msgid "Request super-review"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:588
+#: src/olympia/editors/helpers.py:592
 msgid "Grant preliminary review"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:589
+#: src/olympia/editors/helpers.py:593
 msgid "This will mark the files as preliminarily reviewed."
 msgstr ""
 
-#: src/olympia/editors/helpers.py:591
-msgid ""
-"Use this form to request more information from the author. They will receive"
-" an email and be able to answer here. You will be notified by email when "
-"they reply."
-msgstr ""
-
 #: src/olympia/editors/helpers.py:595
-msgid ""
-"If you have concerns about this add-on's security, copyright issues, or "
-"other concerns that an administrator should look into, enter your comments "
-"in the area below. They will be sent to administrators, not the author."
+msgid "Use this form to request more information from the author. They will receive an email and be able to answer here. You will be notified by email when they reply."
 msgstr ""
 
-#: src/olympia/editors/helpers.py:601
+#: src/olympia/editors/helpers.py:599
+msgid ""
+"If you have concerns about this add-on's security, copyright issues, or other concerns that an administrator should look into, enter your comments in the area below. They will be sent to "
+"administrators, not the author."
+msgstr ""
+
+#: src/olympia/editors/helpers.py:605
 msgid "This will reject the add-on and remove it from the review queue."
 msgstr ""
 
-#: src/olympia/editors/helpers.py:603
+#: src/olympia/editors/helpers.py:607
 msgid "Make a comment on this version. The author won't be able to see this."
 msgstr ""
 
-#: src/olympia/editors/helpers.py:607
+#: src/olympia/editors/helpers.py:611
 msgid "This will reject the files and remove them from the review queue."
 msgstr ""
 
-#: src/olympia/editors/helpers.py:611
-msgid ""
-"This will mark the add-on as preliminarily reviewed. Future versions will "
-"undergo preliminary review."
+#: src/olympia/editors/helpers.py:615
+msgid "This will mark the add-on as preliminarily reviewed. Future versions will undergo preliminary review."
 msgstr ""
 
-#: src/olympia/editors/helpers.py:616
-msgid ""
-"This will mark the files as preliminarily reviewed. Future versions will "
-"undergo preliminary review."
+#: src/olympia/editors/helpers.py:620
+msgid "This will mark the files as preliminarily reviewed. Future versions will undergo preliminary review."
 msgstr ""
 
-#: src/olympia/editors/helpers.py:621
+#: src/olympia/editors/helpers.py:625
 msgid "Retain preliminary review"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:622
-msgid ""
-"This will retain the add-on as preliminarily reviewed. Future versions will "
-"undergo preliminary review."
+#: src/olympia/editors/helpers.py:626
+msgid "This will retain the add-on as preliminarily reviewed. Future versions will undergo preliminary review."
 msgstr ""
 
-#: src/olympia/editors/helpers.py:627
-msgid ""
-"This will approve a sandboxed version of a public add-on to appear on the "
-"public side."
+#: src/olympia/editors/helpers.py:631
+msgid "This will approve a sandboxed version of a public add-on to appear on the public side."
 msgstr ""
 
-#: src/olympia/editors/helpers.py:630
-msgid ""
-"This will reject a version of a public add-on and remove it from the queue."
+#: src/olympia/editors/helpers.py:634
+msgid "This will reject a version of a public add-on and remove it from the queue."
 msgstr ""
 
-#: src/olympia/editors/helpers.py:633
-msgid ""
-"This will mark the add-on and its most recent version and files as public. "
-"Future versions will go into the sandbox until they are reviewed by an "
-"editor."
+#: src/olympia/editors/helpers.py:637
+msgid "This will mark the add-on and its most recent version and files as public. Future versions will go into the sandbox until they are reviewed by an editor."
 msgstr ""
 
-#: src/olympia/editors/helpers.py:710
+#: src/olympia/editors/helpers.py:714
 msgid "add-on"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:1016 src/olympia/editors/helpers.py:1036
+#: src/olympia/editors/helpers.py:1020 src/olympia/editors/helpers.py:1040
 msgid "Flagged"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:1020 src/olympia/editors/helpers.py:1039
+#: src/olympia/editors/helpers.py:1024 src/olympia/editors/helpers.py:1043
 msgid "Updates"
 msgstr ""
 
@@ -9104,61 +7631,57 @@ msgstr ""
 msgid "Overdue (Over 10 days)"
 msgstr ""
 
-#: src/olympia/editors/views.py:538
+#: src/olympia/editors/views.py:539
 msgid "An unknown error occurred"
 msgstr ""
 
-#: src/olympia/editors/views.py:591
+#: src/olympia/editors/views.py:592
 msgid "Self-reviews are not allowed."
 msgstr ""
 
-#: src/olympia/editors/views.py:612
+#: src/olympia/editors/views.py:613
 msgid "Review successfully processed."
 msgstr ""
 
-#: src/olympia/editors/views.py:811
+#: src/olympia/editors/views.py:812
 msgid "was approved"
 msgstr ""
 
-#: src/olympia/editors/views.py:812
+#: src/olympia/editors/views.py:813
 msgid "given preliminary review"
 msgstr ""
 
-#: src/olympia/editors/views.py:813
+#: src/olympia/editors/views.py:814
 msgid "rejected"
 msgstr ""
 
-#: src/olympia/editors/views.py:814
+#: src/olympia/editors/views.py:815
 msgctxt "editors_review_history_nominated_adminreview"
 msgid "escalated"
 msgstr ""
 
-#: src/olympia/editors/views.py:816
+#: src/olympia/editors/views.py:817
 msgid "needs more information"
 msgstr ""
 
-#: src/olympia/editors/views.py:817
+#: src/olympia/editors/views.py:818
 msgid "needs super review"
 msgstr ""
 
-#: src/olympia/editors/views.py:818
+#: src/olympia/editors/views.py:819
 msgid "commented"
 msgstr ""
 
 #: src/olympia/editors/views_themes.py:326
 msgid "{0} theme review successfully processed (+{1} points, {2} total)."
-msgid_plural ""
-"{0} theme reviews successfully processed (+{1} points, {2} total)."
+msgid_plural "{0} theme reviews successfully processed (+{1} points, {2} total)."
 msgstr[0] ""
 msgstr[1] ""
 msgstr[2] ""
 msgstr[3] ""
 
 #: src/olympia/editors/views_themes.py:341
-msgid ""
-"Your theme locks have successfully been released. Other reviewers may now "
-"review those released themes. You may have to refresh the page to see the "
-"changes reflected in the table below."
+msgid "Your theme locks have successfully been released. Other reviewers may now review those released themes. You may have to refresh the page to see the changes reflected in the table below."
 msgstr ""
 
 #: src/olympia/editors/templates/editors/abuse_reports.html:4
@@ -9183,9 +7706,7 @@ msgstr ""
 msgid "Return to the Editor Tools homepage"
 msgstr ""
 
-#: src/olympia/editors/templates/editors/base.html:43
-#: src/olympia/editors/templates/editors/themes/base.html:14
-#: src/olympia/editors/templates/editors/themes/base.html:28
+#: src/olympia/editors/templates/editors/base.html:43 src/olympia/editors/templates/editors/themes/base.html:14 src/olympia/editors/templates/editors/themes/base.html:28
 #: src/olympia/editors/templates/editors/themes/queue.html:25
 msgid "Queues"
 msgstr ""
@@ -9194,71 +7715,51 @@ msgstr ""
 msgid "Unlisted Queues"
 msgstr ""
 
-#: src/olympia/editors/templates/editors/base.html:74
-#: src/olympia/editors/templates/editors/performance.html:6
+#: src/olympia/editors/templates/editors/base.html:74 src/olympia/editors/templates/editors/performance.html:6
 msgid "Performance"
 msgstr ""
 
-#: src/olympia/editors/templates/editors/base.html:77
-#: src/olympia/editors/templates/editors/themes/base.html:19
-#: src/olympia/editors/templates/editors/themes/base.html:38
+#: src/olympia/editors/templates/editors/base.html:77 src/olympia/editors/templates/editors/themes/base.html:19 src/olympia/editors/templates/editors/themes/base.html:38
 msgid "Logs"
 msgstr ""
 
-#: src/olympia/editors/templates/editors/base.html:80
-#: src/olympia/editors/templates/editors/reviewlog.html:4
-#: src/olympia/editors/templates/editors/reviewlog.html:27
+#: src/olympia/editors/templates/editors/base.html:80 src/olympia/editors/templates/editors/reviewlog.html:4 src/olympia/editors/templates/editors/reviewlog.html:27
 msgid "Add-on Review Log"
 msgstr ""
 
-#: src/olympia/editors/templates/editors/base.html:82
-#: src/olympia/editors/templates/editors/eventlog.html:4
-#: src/olympia/editors/templates/editors/eventlog.html:8
+#: src/olympia/editors/templates/editors/base.html:82 src/olympia/editors/templates/editors/eventlog.html:4 src/olympia/editors/templates/editors/eventlog.html:8
 #: src/olympia/editors/templates/editors/eventlog_detail.html:4
 msgid "Moderated Review Log"
 msgstr ""
 
-#: src/olympia/editors/templates/editors/base.html:84
-#: src/olympia/editors/templates/editors/beta_signed_log.html:4
-#: src/olympia/editors/templates/editors/beta_signed_log.html:8
+#: src/olympia/editors/templates/editors/base.html:84 src/olympia/editors/templates/editors/beta_signed_log.html:4 src/olympia/editors/templates/editors/beta_signed_log.html:8
 msgid "Signed Beta Files Log"
 msgstr ""
 
-#: src/olympia/editors/templates/editors/base.html:89
-#: src/olympia/editors/templates/editors/includes/daily-message.html:4
+#: src/olympia/editors/templates/editors/base.html:89 src/olympia/editors/templates/editors/includes/daily-message.html:4
 msgid "Announcement"
 msgstr ""
 
 #. "Filter" is a button label (verb)
-#: src/olympia/editors/templates/editors/beta_signed_log.html:17
-#: src/olympia/editors/templates/editors/eventlog.html:24
-#: src/olympia/editors/templates/editors/reviewlog.html:21
-#: src/olympia/editors/templates/editors/themes/macros.html:45
-#: src/olympia/editors/templates/editors/themes/includes/logs_filter_deleted.html:12
+#: src/olympia/editors/templates/editors/beta_signed_log.html:17 src/olympia/editors/templates/editors/eventlog.html:24 src/olympia/editors/templates/editors/reviewlog.html:21
+#: src/olympia/editors/templates/editors/themes/macros.html:45 src/olympia/editors/templates/editors/themes/includes/logs_filter_deleted.html:12
 msgid "Filter"
 msgstr ""
 
-#: src/olympia/editors/templates/editors/beta_signed_log.html:23
-#: src/olympia/editors/templates/editors/eventlog.html:30
-#: src/olympia/editors/templates/editors/reviewlog.html:34
+#: src/olympia/editors/templates/editors/beta_signed_log.html:23 src/olympia/editors/templates/editors/eventlog.html:30 src/olympia/editors/templates/editors/reviewlog.html:34
 #: src/olympia/editors/templates/editors/themes/logs.html:16
 msgid "Date"
 msgstr ""
 
-#: src/olympia/editors/templates/editors/beta_signed_log.html:24
-#: src/olympia/editors/templates/editors/eventlog.html:31
-#: src/olympia/editors/templates/editors/reviewlog.html:35
+#: src/olympia/editors/templates/editors/beta_signed_log.html:24 src/olympia/editors/templates/editors/eventlog.html:31 src/olympia/editors/templates/editors/reviewlog.html:35
 msgid "Event"
 msgstr ""
 
-#: src/olympia/editors/templates/editors/beta_signed_log.html:37
-#: src/olympia/editors/templates/editors/eventlog.html:44
-#: src/olympia/editors/templates/editors/home.html:180
+#: src/olympia/editors/templates/editors/beta_signed_log.html:37 src/olympia/editors/templates/editors/eventlog.html:44 src/olympia/editors/templates/editors/home.html:180
 msgid "More details."
 msgstr ""
 
-#: src/olympia/editors/templates/editors/beta_signed_log.html:46
-#: src/olympia/editors/templates/editors/eventlog.html:53
+#: src/olympia/editors/templates/editors/beta_signed_log.html:46 src/olympia/editors/templates/editors/eventlog.html:53
 msgid "No events found for this period."
 msgstr ""
 
@@ -9314,13 +7815,11 @@ msgstr[1] ""
 msgstr[2] ""
 msgstr[3] ""
 
-#: src/olympia/editors/templates/editors/home.html:36
-#: src/olympia/editors/templates/editors/home.html:86
+#: src/olympia/editors/templates/editors/home.html:36 src/olympia/editors/templates/editors/home.html:86
 msgid "Current waiting times:"
 msgstr ""
 
-#: src/olympia/editors/templates/editors/home.html:44
-#: src/olympia/editors/templates/editors/home.html:94
+#: src/olympia/editors/templates/editors/home.html:44 src/olympia/editors/templates/editors/home.html:94
 msgid "{0} add-on"
 msgid_plural "{0} add-ons"
 msgstr[0] ""
@@ -9328,8 +7827,7 @@ msgstr[1] ""
 msgstr[2] ""
 msgstr[3] ""
 
-#: src/olympia/editors/templates/editors/home.html:45
-#: src/olympia/editors/templates/editors/home.html:95
+#: src/olympia/editors/templates/editors/home.html:45 src/olympia/editors/templates/editors/home.html:95
 #, python-format
 msgid "{0}%%"
 msgstr ""
@@ -9358,14 +7856,11 @@ msgstr[1] ""
 msgstr[2] ""
 msgstr[3] ""
 
-#: src/olympia/editors/templates/editors/home.html:109
-#: src/olympia/editors/templates/editors/performance.html:37
-#: src/olympia/editors/templates/editors/themes/home.html:54
+#: src/olympia/editors/templates/editors/home.html:109 src/olympia/editors/templates/editors/performance.html:37 src/olympia/editors/templates/editors/themes/home.html:54
 msgid "Total Reviews"
 msgstr ""
 
-#: src/olympia/editors/templates/editors/home.html:110
-#: src/olympia/editors/templates/editors/themes/home.html:55
+#: src/olympia/editors/templates/editors/home.html:110 src/olympia/editors/templates/editors/themes/home.html:55
 msgid "Reviews This Month"
 msgstr ""
 
@@ -9373,8 +7868,7 @@ msgstr ""
 msgid "New Editors"
 msgstr ""
 
-#: src/olympia/editors/templates/editors/home.html:126
-#: src/olympia/editors/templates/editors/home.html:141
+#: src/olympia/editors/templates/editors/home.html:126 src/olympia/editors/templates/editors/home.html:141
 msgid "You're #{0} with {1} reviews"
 msgstr ""
 
@@ -9387,13 +7881,11 @@ msgstr[1] ""
 msgstr[2] ""
 msgstr[3] ""
 
-#: src/olympia/editors/templates/editors/leaderboard.html:3
-#: src/olympia/editors/templates/editors/includes/reviewers_score_bar.html:56
+#: src/olympia/editors/templates/editors/leaderboard.html:3 src/olympia/editors/templates/editors/includes/reviewers_score_bar.html:56
 msgid "Reviewer Leaderboard"
 msgstr ""
 
-#: src/olympia/editors/templates/editors/leaderboard.html:18
-#: src/olympia/editors/templates/editors/performance.html:65
+#: src/olympia/editors/templates/editors/leaderboard.html:18 src/olympia/editors/templates/editors/performance.html:65
 msgid "No review points awarded yet."
 msgstr ""
 
@@ -9413,8 +7905,7 @@ msgstr ""
 msgid "Update message of the day"
 msgstr ""
 
-#: src/olympia/editors/templates/editors/motd.html:15
-#: src/olympia/editors/templates/editors/review.html:224
+#: src/olympia/editors/templates/editors/motd.html:15 src/olympia/editors/templates/editors/review.html:224
 msgid "Save"
 msgstr ""
 
@@ -9482,49 +7973,45 @@ msgstr ""
 msgid "clear search"
 msgstr ""
 
-#: src/olympia/editors/templates/editors/queue.html:72
-#: src/olympia/editors/templates/editors/queue.html:122
+#: src/olympia/editors/templates/editors/queue.html:78 src/olympia/editors/templates/editors/queue.html:128
 msgid "Process Reviews"
 msgstr ""
 
-#: src/olympia/editors/templates/editors/queue.html:80
+#: src/olympia/editors/templates/editors/queue.html:86
 msgid "Moderation actions:"
 msgstr ""
 
-#: src/olympia/editors/templates/editors/queue.html:90
+#: src/olympia/editors/templates/editors/queue.html:96
 #, python-format
 msgid "by %(user)s on %(date)s %(stars)s (%(locale)s)"
 msgstr ""
 
-#: src/olympia/editors/templates/editors/queue.html:106
+#: src/olympia/editors/templates/editors/queue.html:112
 #, python-format
-msgid ""
-"<strong>%(reason)s</strong> <span class=\"light\">Flagged by %(user)s on "
-"%(date)s</span>"
+msgid "<strong>%(reason)s</strong> <span class=\"light\">Flagged by %(user)s on %(date)s</span>"
 msgstr ""
 
-#: src/olympia/editors/templates/editors/queue.html:119
+#: src/olympia/editors/templates/editors/queue.html:125
 msgid "All reviews have been moderated. Good work!"
 msgstr ""
 
-#: src/olympia/editors/templates/editors/queue.html:161
+#: src/olympia/editors/templates/editors/queue.html:167
 msgid "Version Notes / Notes for Reviewer"
 msgstr ""
 
-#: src/olympia/editors/templates/editors/queue.html:169
+#: src/olympia/editors/templates/editors/queue.html:175
 msgid "There are currently no add-ons of this type to review."
 msgstr ""
 
-#: src/olympia/editors/templates/editors/queue.html:181
-#: src/olympia/editors/templates/editors/themes/queue_list.html:85
+#: src/olympia/editors/templates/editors/queue.html:187 src/olympia/editors/templates/editors/themes/queue_list.html:85
 msgid "Helpful Links:"
 msgstr ""
 
-#: src/olympia/editors/templates/editors/queue.html:182
+#: src/olympia/editors/templates/editors/queue.html:188
 msgid "Add-on Policy"
 msgstr ""
 
-#: src/olympia/editors/templates/editors/queue.html:184
+#: src/olympia/editors/templates/editors/queue.html:190
 msgid "Editors' Guide"
 msgstr ""
 
@@ -9537,16 +8024,13 @@ msgstr ""
 msgid "Add-on user change history"
 msgstr ""
 
-#: src/olympia/editors/templates/editors/review.html:52
-#: src/olympia/editors/templates/editors/review.html:266
+#: src/olympia/editors/templates/editors/review.html:52 src/olympia/editors/templates/editors/review.html:266
 msgid "Add-on History"
 msgstr ""
 
 #: src/olympia/editors/templates/editors/review.html:64
 #, python-format
-msgid ""
-"Version %(version)s &middot; %(created)s <span class=\"light\">&middot; "
-"%(version_status)s</span>"
+msgid "Version %(version)s &middot; %(created)s <span class=\"light\">&middot; %(version_status)s</span>"
 msgstr ""
 
 #: src/olympia/editors/templates/editors/review.html:73
@@ -9570,17 +8054,14 @@ msgid "This version has not been reviewed."
 msgstr ""
 
 #: src/olympia/editors/templates/editors/review.html:154
-msgid ""
-"You can still submit this form, however only do so if you know it won't "
-"conflict."
+msgid "You can still submit this form, however only do so if you know it won't conflict."
 msgstr ""
 
 #: src/olympia/editors/templates/editors/review.html:161
 msgid "Insert canned response..."
 msgstr ""
 
-#: src/olympia/editors/templates/editors/review.html:167
-#: src/olympia/files/templates/files/viewer.html:54
+#: src/olympia/editors/templates/editors/review.html:167 src/olympia/files/templates/files/viewer.html:54
 msgid "Files:"
 msgstr ""
 
@@ -9589,23 +8070,18 @@ msgid "Tested on:"
 msgstr ""
 
 #: src/olympia/editors/templates/editors/review.html:220
-msgid ""
-"<strong>Warning!</strong> Another user was viewing this page before you."
+msgid "<strong>Warning!</strong> Another user was viewing this page before you."
 msgstr ""
 
 #: src/olympia/editors/templates/editors/review.html:237
-msgid ""
-"The whiteboard is the place to exchange information relevant to this addon "
-"(whatever the version), between the developer and the editor. This is "
-"visible and editable by both."
+msgid "The whiteboard is the place to exchange information relevant to this addon (whatever the version), between the developer and the editor. This is visible and editable by both."
 msgstr ""
 
 #: src/olympia/editors/templates/editors/review.html:241
 msgid "Update the whiteboard"
 msgstr ""
 
-#: src/olympia/editors/templates/editors/review.html:257
-#: src/olympia/editors/templates/editors/review.html:258
+#: src/olympia/editors/templates/editors/review.html:257 src/olympia/editors/templates/editors/review.html:258
 msgid "(admin)"
 msgstr ""
 
@@ -9633,18 +8109,15 @@ msgstr ""
 msgid "Add-on has been deleted."
 msgstr ""
 
-#: src/olympia/editors/templates/editors/reviewlog.html:59
-#: src/olympia/editors/templates/editors/themes/logs.html:36
+#: src/olympia/editors/templates/editors/reviewlog.html:59 src/olympia/editors/templates/editors/themes/logs.html:36
 msgid "Show Comments"
 msgstr ""
 
-#: src/olympia/editors/templates/editors/reviewlog.html:60
-#: src/olympia/editors/templates/editors/themes/logs.html:37
+#: src/olympia/editors/templates/editors/reviewlog.html:60 src/olympia/editors/templates/editors/themes/logs.html:37
 msgid "Hide Comments"
 msgstr ""
 
-#: src/olympia/editors/templates/editors/reviewlog.html:72
-#: src/olympia/editors/templates/editors/themes/logs.html:54
+#: src/olympia/editors/templates/editors/reviewlog.html:72 src/olympia/editors/templates/editors/themes/logs.html:54
 msgid "No reviews found for this period."
 msgstr ""
 
@@ -9702,11 +8175,8 @@ msgstr ""
 msgid "You have <span>{0}</span> points."
 msgstr ""
 
-#: src/olympia/editors/templates/editors/includes/search_results_themes.html:6
-#: src/olympia/editors/templates/editors/themes/history_table.html:7
-#: src/olympia/editors/templates/editors/themes/logs.html:19
-#: src/olympia/editors/templates/editors/themes/queue_list.html:49
-#: src/olympia/editors/templates/editors/themes/single.html:26
+#: src/olympia/editors/templates/editors/includes/search_results_themes.html:6 src/olympia/editors/templates/editors/themes/history_table.html:7
+#: src/olympia/editors/templates/editors/themes/logs.html:19 src/olympia/editors/templates/editors/themes/queue_list.html:49 src/olympia/editors/templates/editors/themes/single.html:26
 #: src/olympia/editors/templates/editors/themes/themes.html:45
 msgid "Reviewer"
 msgstr ""
@@ -9731,8 +8201,7 @@ msgstr ""
 msgid "Review Date"
 msgstr ""
 
-#: src/olympia/editors/templates/editors/themes/history_table.html:9
-#: src/olympia/editors/templates/editors/themes/logs.html:18
+#: src/olympia/editors/templates/editors/themes/history_table.html:9 src/olympia/editors/templates/editors/themes/logs.html:18
 msgid "Action"
 msgstr ""
 
@@ -9903,9 +8372,7 @@ msgid "Problems decoding {0}."
 msgstr ""
 
 #: src/olympia/files/helpers.py:186
-msgid ""
-"This file is not viewable online. Please download the file to view the "
-"contents."
+msgid "This file is not viewable online. Please download the file to view the contents."
 msgstr ""
 
 #: src/olympia/files/helpers.py:194
@@ -9963,9 +8430,7 @@ msgid "Version numbers should have fewer than 32 characters."
 msgstr ""
 
 #: src/olympia/files/utils.py:567
-msgid ""
-"Version numbers should only contain letters, numbers, and these punctuation "
-"characters: +*.-_."
+msgid "Version numbers should only contain letters, numbers, and these punctuation characters: +*.-_."
 msgstr ""
 
 #: src/olympia/files/utils.py:584
@@ -9986,9 +8451,7 @@ msgstr ""
 
 #: src/olympia/files/templates/files/file.html:4
 #, python-format
-msgid ""
-"Version: %(version)s &bull; Size: %(size)s &bull; MD5 hash: %(md5)s &bull; "
-"Mimetype: %(mimetype)s"
+msgid "Version: %(version)s &bull; Size: %(size)s &bull; MD5 hash: %(md5)s &bull; Mimetype: %(mimetype)s"
 msgstr ""
 
 #: src/olympia/files/templates/files/viewer.html:4
@@ -10027,48 +8490,39 @@ msgstr ""
 msgid "Tab stops:"
 msgstr ""
 
-#: src/olympia/files/templates/files/viewer.html:79
-#: src/olympia/files/templates/files/viewer.html:80
+#: src/olympia/files/templates/files/viewer.html:79 src/olympia/files/templates/files/viewer.html:80
 msgid "Up file"
 msgstr ""
 
-#: src/olympia/files/templates/files/viewer.html:84
-#: src/olympia/files/templates/files/viewer.html:85
+#: src/olympia/files/templates/files/viewer.html:84 src/olympia/files/templates/files/viewer.html:85
 msgid "Down file"
 msgstr ""
 
-#: src/olympia/files/templates/files/viewer.html:90
-#: src/olympia/files/templates/files/viewer.html:91
+#: src/olympia/files/templates/files/viewer.html:90 src/olympia/files/templates/files/viewer.html:91
 msgid "Previous diff"
 msgstr ""
 
-#: src/olympia/files/templates/files/viewer.html:93
-#: src/olympia/files/templates/files/viewer.html:94
+#: src/olympia/files/templates/files/viewer.html:93 src/olympia/files/templates/files/viewer.html:94
 msgid "Previous note"
 msgstr ""
 
-#: src/olympia/files/templates/files/viewer.html:100
-#: src/olympia/files/templates/files/viewer.html:101
+#: src/olympia/files/templates/files/viewer.html:100 src/olympia/files/templates/files/viewer.html:101
 msgid "Next diff"
 msgstr ""
 
-#: src/olympia/files/templates/files/viewer.html:103
-#: src/olympia/files/templates/files/viewer.html:104
+#: src/olympia/files/templates/files/viewer.html:103 src/olympia/files/templates/files/viewer.html:104
 msgid "Next note"
 msgstr ""
 
-#: src/olympia/files/templates/files/viewer.html:109
-#: src/olympia/files/templates/files/viewer.html:110
+#: src/olympia/files/templates/files/viewer.html:109 src/olympia/files/templates/files/viewer.html:110
 msgid "Expand all"
 msgstr ""
 
-#: src/olympia/files/templates/files/viewer.html:114
-#: src/olympia/files/templates/files/viewer.html:115
+#: src/olympia/files/templates/files/viewer.html:114 src/olympia/files/templates/files/viewer.html:115
 msgid "Hide or unhide tree"
 msgstr ""
 
-#: src/olympia/files/templates/files/viewer.html:119
-#: src/olympia/files/templates/files/viewer.html:120
+#: src/olympia/files/templates/files/viewer.html:119 src/olympia/files/templates/files/viewer.html:120
 msgid "Wrap or unwrap text"
 msgstr ""
 
@@ -10740,12 +9194,7 @@ msgstr ""
 msgid "Zimbabwe Dollar"
 msgstr ""
 
-#: src/olympia/lib/video/ffmpeg.py:112 src/olympia/lib/video/totem.py:81
-msgid "Videos must be in WebM."
-msgstr ""
-
-#: src/olympia/pages/templates/pages/about.lhtml:3
-#: src/olympia/pages/templates/pages/about.lhtml:10
+#: src/olympia/pages/templates/pages/about.lhtml:3 src/olympia/pages/templates/pages/about.lhtml:10
 msgid "About Mozilla Add-ons"
 msgstr ""
 
@@ -10755,11 +9204,8 @@ msgstr ""
 
 #: src/olympia/pages/templates/pages/about.lhtml:13
 msgid ""
-"addons.mozilla.org, commonly known as \"AMO\", is Mozilla's official site "
-"for add-ons to Mozilla software, such as Firefox, Thunderbird, and "
-"SeaMonkey. Add-ons let you add new features and change the way your browser "
-"or application works. Take a look around and explore the thousands of ways "
-"to customize the way you do things online."
+"addons.mozilla.org, commonly known as \"AMO\", is Mozilla's official site for add-ons to Mozilla software, such as Firefox, Thunderbird, and SeaMonkey. Add-ons let you add new features and change "
+"the way your browser or application works. Take a look around and explore the thousands of ways to customize the way you do things online."
 msgstr ""
 
 #: src/olympia/pages/templates/pages/about.lhtml:19
@@ -10768,11 +9214,8 @@ msgstr ""
 
 #: src/olympia/pages/templates/pages/about.lhtml:20
 msgid ""
-"The add-ons listed here have been created by thousands of developers from "
-"our community, ranging from individual hobbyists to large corporations. All "
-"publicly listed add-ons are reviewed by a team of editors before being "
-"released. Add-ons marked as Experimental have not been reviewed and should "
-"only be installed with caution."
+"The add-ons listed here have been created by thousands of developers from our community, ranging from individual hobbyists to large corporations. All publicly listed add-ons are reviewed by a team "
+"of editors before being released. Add-ons marked as Experimental have not been reviewed and should only be installed with caution."
 msgstr ""
 
 #: src/olympia/pages/templates/pages/about.lhtml:26
@@ -10780,30 +9223,22 @@ msgid "How do I keep up with what's happening at AMO?"
 msgstr ""
 
 #: src/olympia/pages/templates/pages/about.lhtml:27
-msgid ""
-"There are several ways to find out the latest news from the world of add-"
-"ons:"
+msgid "There are several ways to find out the latest news from the world of add-ons:"
 msgstr ""
 
 #: src/olympia/pages/templates/pages/about.lhtml:29
 #, python-format
-msgid ""
-"Our <a href=\"%(url)s\">Add-ons Blog</a> is regularly updated with "
-"information for both add-on enthusiasts and developers."
+msgid "Our <a href=\"%(url)s\">Add-ons Blog</a> is regularly updated with information for both add-on enthusiasts and developers."
 msgstr ""
 
 #: src/olympia/pages/templates/pages/about.lhtml:32
 #, python-format
-msgid ""
-"We often post news, tips, and tricks to our Twitter account, <a "
-"href=\"%(url)s\">mozamo</a>"
+msgid "We often post news, tips, and tricks to our Twitter account, <a href=\"%(url)s\">mozamo</a>"
 msgstr ""
 
 #: src/olympia/pages/templates/pages/about.lhtml:34
 #, python-format
-msgid ""
-"Our <a href=\"%(url)s\">forums</a> are a good place to interact with the "
-"add-ons community and discuss upcoming changes to AMO."
+msgid "Our <a href=\"%(url)s\">forums</a> are a good place to interact with the add-ons community and discuss upcoming changes to AMO."
 msgstr ""
 
 #: src/olympia/pages/templates/pages/about.lhtml:39
@@ -10811,37 +9246,27 @@ msgid "This sounds great! How can I get involved?"
 msgstr ""
 
 #: src/olympia/pages/templates/pages/about.lhtml:40
-msgid ""
-"There are plenty of ways to get involved. If you're on the technical side:"
+msgid "There are plenty of ways to get involved. If you're on the technical side:"
 msgstr ""
 
 #: src/olympia/pages/templates/pages/about.lhtml:42
 #, python-format
-msgid ""
-"<a href=\"%(url)s\">Make your own add-on</a>. We provide free hosting and "
-"update services and can help you reach a large audience of users."
+msgid "<a href=\"%(url)s\">Make your own add-on</a>. We provide free hosting and update services and can help you reach a large audience of users."
 msgstr ""
 
 #: src/olympia/pages/templates/pages/about.lhtml:45
 #, python-format
-msgid ""
-"If you have add-on development experience, <a href=\"%(url)s\"> become an "
-"editor</a>! Our editors are add-on fans with a technical background who "
-"review add-ons for code quality and stability."
+msgid "If you have add-on development experience, <a href=\"%(url)s\"> become an editor</a>! Our editors are add-on fans with a technical background who review add-ons for code quality and stability."
 msgstr ""
 
 #: src/olympia/pages/templates/pages/about.lhtml:49
 #, python-format
 msgid ""
-"Help improve this website. It's open source, and you can file bugs and "
-"submit patches. <a href=\"%(url)s\"> GitHub</a> contains all of our current "
-"bugs, legacy bugs can still be found in Bugzilla."
+"Help improve this website. It's open source, and you can file bugs and submit patches. <a href=\"%(url)s\"> GitHub</a> contains all of our current bugs, legacy bugs can still be found in Bugzilla."
 msgstr ""
 
 #: src/olympia/pages/templates/pages/about.lhtml:55
-msgid ""
-"If you're interested in add-ons but not quite as technical, there are still "
-"ways to help:"
+msgid "If you're interested in add-ons but not quite as technical, there are still ways to help:"
 msgstr ""
 
 #: src/olympia/pages/templates/pages/about.lhtml:58
@@ -10854,9 +9279,7 @@ msgid "Participate in our <a href=\"%(url)s\">forums</a>."
 msgstr ""
 
 #: src/olympia/pages/templates/pages/about.lhtml:61
-msgid ""
-"Review add-ons on the site. Add-on authors are more likely to improve their "
-"add-ons and write new ones when they know people appreciate their work."
+msgid "Review add-ons on the site. Add-on authors are more likely to improve their add-ons and write new ones when they know people appreciate their work."
 msgstr ""
 
 #: src/olympia/pages/templates/pages/about.lhtml:66
@@ -10866,16 +9289,13 @@ msgstr ""
 #: src/olympia/pages/templates/pages/about.lhtml:67
 #, python-format
 msgid ""
-"A good place to start is our <a href=\"%(faq_url)s\"><abbr "
-"title=\"Frequently Asked Questions\">FAQ</abbr></a>. If you don't find an "
-"answer there, you can <a href=\"%(forum_url)s\"> ask on our forums</a>."
+"A good place to start is our <a href=\"%(faq_url)s\"><abbr title=\"Frequently Asked Questions\">FAQ</abbr></a>. If you don't find an answer there, you can <a href=\"%(forum_url)s\"> ask on our "
+"forums</a>."
 msgstr ""
 
 #: src/olympia/pages/templates/pages/about.lhtml:72
 #, python-format
-msgid ""
-"If you really need to contact someone from the Mozilla team, please see our "
-"<a href=\"%(url)s\"> contact information</a> page."
+msgid "If you really need to contact someone from the Mozilla team, please see our <a href=\"%(url)s\"> contact information</a> page."
 msgstr ""
 
 #: src/olympia/pages/templates/pages/about.lhtml:76
@@ -10885,10 +9305,8 @@ msgstr ""
 #: src/olympia/pages/templates/pages/about.lhtml:77
 #, python-format
 msgid ""
-"Over the years, many people have contributed to this website, including both"
-" volunteers from the community and a dedicated AMO team. A list of "
-"significant contributors can be found on our <a href=\"%(url)s\"> Site "
-"Credits</a> page."
+"Over the years, many people have contributed to this website, including both volunteers from the community and a dedicated AMO team. A list of significant contributors can be found on our <a href="
+"\"%(url)s\"> Site Credits</a> page."
 msgstr ""
 
 #: src/olympia/pages/templates/pages/acr_firstrun.html:4
@@ -10900,9 +9318,7 @@ msgid "Add-on Compatibility Reporter has been installed"
 msgstr ""
 
 #: src/olympia/pages/templates/pages/acr_firstrun.html:28
-msgid ""
-"It’s easy to help us make sure add-ons are updated in time for the release "
-"of the next version of Firefox."
+msgid "It’s easy to help us make sure add-ons are updated in time for the release of the next version of Firefox."
 msgstr ""
 
 #: src/olympia/pages/templates/pages/acr_firstrun.html:35
@@ -10911,35 +9327,27 @@ msgstr ""
 
 #: src/olympia/pages/templates/pages/acr_firstrun.html:40
 msgid ""
-"As you start browsing and using your add-ons, take careful note of anything "
-"that seems different from when you last used the extension. This might be a "
-"display glitch, such as a menu item missing, or something more serious, like"
-" the add-on not working at all or showing errors."
+"As you start browsing and using your add-ons, take careful note of anything that seems different from when you last used the extension. This might be a display glitch, such as a menu item missing, "
+"or something more serious, like the add-on not working at all or showing errors."
 msgstr ""
 
 #: src/olympia/pages/templates/pages/acr_firstrun.html:49
 msgid ""
-"Once you know whether a particular add-on works properly or has problems, "
-"open the Add-ons Manager and click Compatibility next to the add-on to let "
-"Mozilla know what you found in your testing. Submitting a report will help "
-"us tell the add-on developer whether their add-on is working properly in "
-"this version or might need some fixes."
+"Once you know whether a particular add-on works properly or has problems, open the Add-ons Manager and click Compatibility next to the add-on to let Mozilla know what you found in your testing. "
+"Submitting a report will help us tell the add-on developer whether their add-on is working properly in this version or might need some fixes."
 msgstr ""
 
 #: src/olympia/pages/templates/pages/acr_firstrun.html:61
 #, python-format
 msgid ""
-"If you upgrade to a new version of Firefox or update your add-ons, your "
-"reports for the old versions will be hidden to allow you to test the new "
-"version. If you have any questions, please ask in <a href=\"%(url)s\">our "
-"forums</a>."
+"If you upgrade to a new version of Firefox or update your add-ons, your reports for the old versions will be hidden to allow you to test the new version. If you have any questions, please ask in <a "
+"href=\"%(url)s\">our forums</a>."
 msgstr ""
 
 #: src/olympia/pages/templates/pages/acr_firstrun.html:69
 msgid ""
-"Thousands of add-ons are made by our community every year, and your "
-"assistance with compatibility testing helps us make sure these add-ons stay "
-"useful as we strive to provide a great user experience."
+"Thousands of add-ons are made by our community every year, and your assistance with compatibility testing helps us make sure these add-ons stay useful as we strive to provide a great user "
+"experience."
 msgstr ""
 
 #: src/olympia/pages/templates/pages/acr_firstrun.html:75
@@ -10951,9 +9359,7 @@ msgid "Site Credits"
 msgstr ""
 
 #: src/olympia/pages/templates/pages/credits.html:12
-msgid ""
-"Mozilla would like to thank the following people for their contributions to "
-"the addons.mozilla.org project over the years:"
+msgid "Mozilla would like to thank the following people for their contributions to the addons.mozilla.org project over the years:"
 msgstr ""
 
 #: src/olympia/pages/templates/pages/credits.html:18
@@ -10987,73 +9393,57 @@ msgstr ""
 
 #: src/olympia/pages/templates/pages/credits.html:59
 msgid ""
-"Some icons used are from the <a "
-"href=\"http://www.famfamfam.com/lab/icons/silk/\">famfamfam Silk Icon "
-"Set</a>, licensed under a <a "
-"href=\"http://creativecommons.org/licenses/by/2.5/\">Creative Commons "
-"Attribution 2.5 License</a>."
+"Some icons used are from the <a href=\"http://www.famfamfam.com/lab/icons/silk/\">famfamfam Silk Icon Set</a>, licensed under a <a href=\"http://creativecommons.org/licenses/by/2.5/\">Creative "
+"Commons Attribution 2.5 License</a>."
 msgstr ""
 
 #: src/olympia/pages/templates/pages/credits.html:60
 msgid ""
-"Some icons used are from the <a href=\"http://www.fatcow.com/free-"
-"icons/\">FatCow Farm-Fresh Web Icons Set</a>, licensed under a <a "
-"href=\"http://creativecommons.org/licenses/by/3.0/us/\">Creative Commons "
-"Attribution 3.0 License</a>."
+"Some icons used are from the <a href=\"http://www.fatcow.com/free-icons/\">FatCow Farm-Fresh Web Icons Set</a>, licensed under a <a href=\"http://creativecommons.org/licenses/by/3.0/us/\">Creative "
+"Commons Attribution 3.0 License</a>."
 msgstr ""
 
 #: src/olympia/pages/templates/pages/credits.html:61
 msgid ""
-"Some pages use elements of <a "
-"href=\"http://shop.highsoft.com/highcharts.html\">Highcharts</a> (non-"
-"commercial), licensed under a <a href=\"http://creativecommons.org/licenses"
-"/by-nc/3.0/\">Creative Commons Attribution-NonCommercial 3.0 License</a>."
+"Some pages use elements of <a href=\"http://shop.highsoft.com/highcharts.html\">Highcharts</a> (non-commercial), licensed under a <a href=\"http://creativecommons.org/licenses/by-nc/3.0/\">Creative "
+"Commons Attribution-NonCommercial 3.0 License</a>."
 msgstr ""
 
 #: src/olympia/pages/templates/pages/credits.html:65
 #, python-format
-msgid ""
-"For information on contributing, please see our <a href=\"%(url)s\">wiki "
-"page</a>."
+msgid "For information on contributing, please see our <a href=\"%(url)s\">wiki page</a>."
 msgstr ""
 
 #: src/olympia/pages/templates/pages/dev_faq.html:4
 msgid "Developer FAQ"
 msgstr ""
 
-#: src/olympia/pages/templates/pages/dev_faq.html:31
-#: src/olympia/pages/templates/pages/review_guide.html:33
+#: src/olympia/pages/templates/pages/dev_faq.html:31 src/olympia/pages/templates/pages/review_guide.html:33
 msgid "Sections"
 msgstr ""
 
-#: src/olympia/pages/templates/pages/dev_faq.html:33
-#: src/olympia/pages/templates/pages/dev_faq.html:45
+#: src/olympia/pages/templates/pages/dev_faq.html:33 src/olympia/pages/templates/pages/dev_faq.html:45
 msgid "Developing an Add-on"
 msgstr ""
 
 #. Heading for a list of resources for developers
-#: src/olympia/pages/templates/pages/dev_faq.html:34
-#: src/olympia/pages/templates/pages/dev_faq.html:208
+#: src/olympia/pages/templates/pages/dev_faq.html:34 src/olympia/pages/templates/pages/dev_faq.html:208
 msgid "Support Resources"
 msgstr ""
 
-#: src/olympia/pages/templates/pages/dev_faq.html:35
-#: src/olympia/pages/templates/pages/dev_faq.html:261
+#: src/olympia/pages/templates/pages/dev_faq.html:35 src/olympia/pages/templates/pages/dev_faq.html:261
 msgid "Contributing your Add-on"
 msgstr ""
 
-#: src/olympia/pages/templates/pages/dev_faq.html:36
-#: src/olympia/pages/templates/pages/dev_faq.html:381
+#: src/olympia/pages/templates/pages/dev_faq.html:36 src/olympia/pages/templates/pages/dev_faq.html:381
 msgid "Add-on Review Process"
 msgstr ""
 
-#: src/olympia/pages/templates/pages/dev_faq.html:37
-#: src/olympia/pages/templates/pages/dev_faq.html:444
+#: src/olympia/pages/templates/pages/dev_faq.html:37 src/olympia/pages/templates/pages/dev_faq.html:444
 msgid "Managing Your Add-on"
 msgstr ""
 
-#: src/olympia/pages/templates/pages/dev_faq.html:39
-#: src/olympia/pages/templates/pages/dev_faq.html:528
+#: src/olympia/pages/templates/pages/dev_faq.html:39 src/olympia/pages/templates/pages/dev_faq.html:528
 msgid "References for Open Source Licenses"
 msgstr ""
 
@@ -11063,10 +9453,7 @@ msgstr ""
 
 #: src/olympia/pages/templates/pages/dev_faq.html:47
 #, python-format
-msgid ""
-"<h3>How do I build an Add-on?</h3> <p> Mozilla provides documentation on how"
-" to build an add-on via the <a href=\"%(url)s\">Mozilla Developer "
-"Network</a>. </p>"
+msgid "<h3>How do I build an Add-on?</h3> <p> Mozilla provides documentation on how to build an add-on via the <a href=\"%(url)s\">Mozilla Developer Network</a>. </p>"
 msgstr ""
 
 #: src/olympia/pages/templates/pages/dev_faq.html:55
@@ -11087,9 +9474,8 @@ msgstr ""
 
 #: src/olympia/pages/templates/pages/dev_faq.html:68
 msgid ""
-"You will need to have a version of the Mozilla software that you're building"
-" the add-on for and a code editor of your choice. Add-ons can be built for "
-"almost all Mozilla software but are primarily targeted for:"
+"You will need to have a version of the Mozilla software that you're building the add-on for and a code editor of your choice. Add-ons can be built for almost all Mozilla software but are primarily "
+"targeted for:"
 msgstr ""
 
 #: src/olympia/pages/templates/pages/dev_faq.html:82
@@ -11099,18 +9485,13 @@ msgstr ""
 #. This is a list of popular code editors.  Feel free to adjust as you like.
 #: src/olympia/pages/templates/pages/dev_faq.html:85
 msgid ""
-"<li><a href=\"http://komodoide.com/komodo-edit/\">Komodo Edit</a></li> "
-"<li><a href=\"http://macromates.com/\">TextMate</a></li> <li><a href=\"http"
-"://notepad-plus-plus.org/\">Notepad++</a></li> <li><a "
-"href=\"http://www.eclipse.org/\">Eclipse IDE</a></li>"
+"<li><a href=\"http://komodoide.com/komodo-edit/\">Komodo Edit</a></li> <li><a href=\"http://macromates.com/\">TextMate</a></li> <li><a href=\"http://notepad-plus-plus.org/\">Notepad++</a></li> "
+"<li><a href=\"http://www.eclipse.org/\">Eclipse IDE</a></li>"
 msgstr ""
 
 #: src/olympia/pages/templates/pages/dev_faq.html:94
 #, python-format
-msgid ""
-"You can also learn more about setting up your development environment via "
-"the MDN article <a href=\"%(url)s\">Setting up extension development "
-"environment</a>"
+msgid "You can also learn more about setting up your development environment via the MDN article <a href=\"%(url)s\">Setting up extension development environment</a>"
 msgstr ""
 
 #: src/olympia/pages/templates/pages/dev_faq.html:100
@@ -11118,9 +9499,7 @@ msgid "What is a \".xpi\" file?"
 msgstr ""
 
 #: src/olympia/pages/templates/pages/dev_faq.html:102
-msgid ""
-"Extensions are packaged and distributed in ZIP files or Bundles, with the "
-"XPI (pronounced \"zippy\") file extension."
+msgid "Extensions are packaged and distributed in ZIP files or Bundles, with the XPI (pronounced \"zippy\") file extension."
 msgstr ""
 
 #: src/olympia/pages/templates/pages/dev_faq.html:108
@@ -11129,10 +9508,8 @@ msgstr ""
 
 #: src/olympia/pages/templates/pages/dev_faq.html:110
 msgid ""
-"XUL (XML User Interface Language) is Mozilla's XML-based language that lets "
-"you build feature-rich cross platform applications. It provides user "
-"interface widgets like buttons, menus, toolbars, trees, etc that can be used"
-" to enhance add-ons by modifying parts of the browser UI."
+"XUL (XML User Interface Language) is Mozilla's XML-based language that lets you build feature-rich cross platform applications. It provides user interface widgets like buttons, menus, toolbars, "
+"trees, etc that can be used to enhance add-ons by modifying parts of the browser UI."
 msgstr ""
 
 #: src/olympia/pages/templates/pages/dev_faq.html:119
@@ -11142,13 +9519,9 @@ msgstr ""
 #: src/olympia/pages/templates/pages/dev_faq.html:121
 #, python-format
 msgid ""
-"This file, called an <a href=\"%(url)s\">Install Manifest</a>, is used by "
-"Add-on Manager-enabled XUL applications to determine information about an "
-"add-on as it is being installed. It contains metadata identifying the add-"
-"on, providing information about who created it, where more information can "
-"be found about it, which versions of what applications it is compatible "
-"with, how it should be updated, and so on. The format of the Install "
-"Manifest is RDF/XML."
+"This file, called an <a href=\"%(url)s\">Install Manifest</a>, is used by Add-on Manager-enabled XUL applications to determine information about an add-on as it is being installed. It contains "
+"metadata identifying the add-on, providing information about who created it, where more information can be found about it, which versions of what applications it is compatible with, how it should "
+"be updated, and so on. The format of the Install Manifest is RDF/XML."
 msgstr ""
 
 #: src/olympia/pages/templates/pages/dev_faq.html:132
@@ -11156,10 +9529,7 @@ msgid "What does \"maxVersion\" mean?"
 msgstr ""
 
 #: src/olympia/pages/templates/pages/dev_faq.html:134
-msgid ""
-"This determines the maximum version of Firefox you're saying this extension "
-"will work with. Set this to be no newer than the newest currently available "
-"version!"
+msgid "This determines the maximum version of Firefox you're saying this extension will work with. Set this to be no newer than the newest currently available version!"
 msgstr ""
 
 #: src/olympia/pages/templates/pages/dev_faq.html:141
@@ -11169,27 +9539,18 @@ msgstr ""
 #: src/olympia/pages/templates/pages/dev_faq.html:143
 #, python-format
 msgid ""
-"Yes. You can use Mozilla's <a href=\"%(url)s\">XPCOM component object "
-"model</a> to enhance your add-ons. XPCOM components be used and implemented "
-"in JavaScript, Java, and Python in addition to C++."
+"Yes. You can use Mozilla's <a href=\"%(url)s\">XPCOM component object model</a> to enhance your add-ons. XPCOM components be used and implemented in JavaScript, Java, and Python in addition to C++."
 msgstr ""
 
 #: src/olympia/pages/templates/pages/dev_faq.html:150
-msgid ""
-"Can I use a JavaScript library like jQuery, MooTools or Prototype to build "
-"my add-on?"
+msgid "Can I use a JavaScript library like jQuery, MooTools or Prototype to build my add-on?"
 msgstr ""
 
 #: src/olympia/pages/templates/pages/dev_faq.html:152
 msgid ""
-"Yes. It's possible, but some of the functionality provided by these "
-"libraries are available through XPCOM, XUL, and JavaScript. In addition, "
-"authors should take care if libraries modify primitive object prototypes "
-"(String.prototype, Date.prototype, etc.) and/or define global functions (eg."
-" the $ function). These are prone to cause conflict with other add-ons, in "
-"particular if different add-ons use different versions of libraries and so "
-"on. Developers need to be very, very careful with using them. Mozilla does "
-"not offer documentation on using them to build add-ons."
+"Yes. It's possible, but some of the functionality provided by these libraries are available through XPCOM, XUL, and JavaScript. In addition, authors should take care if libraries modify primitive "
+"object prototypes (String.prototype, Date.prototype, etc.) and/or define global functions (eg. the $ function). These are prone to cause conflict with other add-ons, in particular if different add-"
+"ons use different versions of libraries and so on. Developers need to be very, very careful with using them. Mozilla does not offer documentation on using them to build add-ons."
 msgstr ""
 
 #: src/olympia/pages/templates/pages/dev_faq.html:165
@@ -11202,20 +9563,14 @@ msgid "You can use the <a href=\"%(url)s\">Add-on Debugger</a>."
 msgstr ""
 
 #: src/olympia/pages/templates/pages/dev_faq.html:172
-msgid ""
-"How do I test for compatibility with the latest version of Mozilla software?"
+msgid "How do I test for compatibility with the latest version of Mozilla software?"
 msgstr ""
 
 #: src/olympia/pages/templates/pages/dev_faq.html:174
 msgid ""
-"To ensure compatibility with the latest Mozilla software, it's important to "
-"download updates as they become available and test your add-on to ensure "
-"that it is still functioning as expected. In many cases, the latest version "
-"of Mozilla software may be a beta release. Since these releases at times "
-"introduce architectural changes that may impact the functionality of your "
-"add-on, it's important to be actively involved in the beta process to ensure"
-" that your add-on users are not negatively impacted upon final release of "
-"Mozilla software."
+"To ensure compatibility with the latest Mozilla software, it's important to download updates as they become available and test your add-on to ensure that it is still functioning as expected. In "
+"many cases, the latest version of Mozilla software may be a beta release. Since these releases at times introduce architectural changes that may impact the functionality of your add-on, it's "
+"important to be actively involved in the beta process to ensure that your add-on users are not negatively impacted upon final release of Mozilla software."
 msgstr ""
 
 #: src/olympia/pages/templates/pages/dev_faq.html:185
@@ -11225,11 +9580,8 @@ msgstr ""
 #: src/olympia/pages/templates/pages/dev_faq.html:187
 #, python-format
 msgid ""
-"Poorly written extensions can have a severe impact on the browsing "
-"experience, including on the overall performance of Firefox itself. The "
-"following page contains many good <a href=\"%(url)s\">guides</a> that help "
-"you improve performance, whether you're developing core Mozilla code or an "
-"add-on."
+"Poorly written extensions can have a severe impact on the browsing experience, including on the overall performance of Firefox itself. The following page contains many good <a href=\"%(url)s"
+"\">guides</a> that help you improve performance, whether you're developing core Mozilla code or an add-on."
 msgstr ""
 
 #: src/olympia/pages/templates/pages/dev_faq.html:195
@@ -11239,10 +9591,8 @@ msgstr ""
 #: src/olympia/pages/templates/pages/dev_faq.html:197
 #, python-format
 msgid ""
-"Yes. Details on localizing your add-on can be found in the the <a "
-"href=\"%(l10n_url)s\">Mozilla Developer Network Localization page</a>. <a "
-"href=\"%(bz_url)s\">The BabelZilla project</a> is also a great resource for "
-"learning about localization and volunteering to help translate add-ons."
+"Yes. Details on localizing your add-on can be found in the the <a href=\"%(l10n_url)s\">Mozilla Developer Network Localization page</a>. <a href=\"%(bz_url)s\">The BabelZilla project</a> is also a "
+"great resource for learning about localization and volunteering to help translate add-ons."
 msgstr ""
 
 #: src/olympia/pages/templates/pages/dev_faq.html:210
@@ -11261,9 +9611,7 @@ msgstr ""
 
 #. #jetpack is the name of the IRC channel.  do not change.
 #: src/olympia/pages/templates/pages/dev_faq.html:220
-msgid ""
-"#jetpack (for discussions about the Add-ons SDK and cfx/jpm - formerly known"
-" as Jetpack)"
+msgid "#jetpack (for discussions about the Add-ons SDK and cfx/jpm - formerly known as Jetpack)"
 msgstr ""
 
 #. Label for a link to the extension developers mailing list
@@ -11304,11 +9652,8 @@ msgstr ""
 #: src/olympia/pages/templates/pages/dev_faq.html:248
 #, python-format
 msgid ""
-"Yes. You may find 3rd party developers via the <a href=\"%(forum_url)s"
-"\">Add-ons forum</a>, <a href=\"%(list_url)s\">mozilla.jobs list</a>, <a "
-"href=\"%(mz_url)s\">mozillaZine forums</a> or <a href=\"%(wiki_url)s\">the "
-"Mozilla Wiki</a>. Please note that Mozilla does not offer developer "
-"recommendations."
+"Yes. You may find 3rd party developers via the <a href=\"%(forum_url)s\">Add-ons forum</a>, <a href=\"%(list_url)s\">mozilla.jobs list</a>, <a href=\"%(mz_url)s\">mozillaZine forums</a> or <a href="
+"\"%(wiki_url)s\">the Mozilla Wiki</a>. Please note that Mozilla does not offer developer recommendations."
 msgstr ""
 
 #: src/olympia/pages/templates/pages/dev_faq.html:263
@@ -11318,13 +9663,9 @@ msgstr ""
 #: src/olympia/pages/templates/pages/dev_faq.html:265
 #, python-format
 msgid ""
-"Yes. Many developers choose to host their own add-ons. Choosing to host your"
-" add-on on <a href=\"%(amo_url)s\">Mozilla's add-on site</a>, though, allows"
-" for much greater exposure to your add-on due to the large volume of "
-"visitors to the site. <a href=\"%(md_url)s\">mozdev.org</a> offers free "
-"project hosting for Mozilla applications and extensions providing developers"
-" with tools to help manage source code, version control, bug tracking and "
-"documentation."
+"Yes. Many developers choose to host their own add-ons. Choosing to host your add-on on <a href=\"%(amo_url)s\">Mozilla's add-on site</a>, though, allows for much greater exposure to your add-on due "
+"to the large volume of visitors to the site. <a href=\"%(md_url)s\">mozdev.org</a> offers free project hosting for Mozilla applications and extensions providing developers with tools to help manage "
+"source code, version control, bug tracking and documentation."
 msgstr ""
 
 #: src/olympia/pages/templates/pages/dev_faq.html:277
@@ -11333,9 +9674,7 @@ msgstr ""
 
 #: src/olympia/pages/templates/pages/dev_faq.html:279
 #, python-format
-msgid ""
-"Yes. You can host your add-on on <a href=\"%(url)s\">Mozilla's add-on "
-"website</a>."
+msgid "Yes. You can host your add-on on <a href=\"%(url)s\">Mozilla's add-on website</a>."
 msgstr ""
 
 #: src/olympia/pages/templates/pages/dev_faq.html:284
@@ -11344,12 +9683,8 @@ msgstr ""
 
 #: src/olympia/pages/templates/pages/dev_faq.html:286
 msgid ""
-"Mozilla's AMO (<a "
-"href=\"https://addons.mozilla.org\">https://addons.mozilla.org</a>) is the "
-"incubator that helps developers build, distribute, and support fantastic "
-"consumer products powered by Mozilla. It provides you the tools and "
-"infrastructure necessary to manage, host and expose your add-on to a massive"
-" base of Mozilla users."
+"Mozilla's AMO (<a href=\"https://addons.mozilla.org\">https://addons.mozilla.org</a>) is the incubator that helps developers build, distribute, and support fantastic consumer products powered by "
+"Mozilla. It provides you the tools and infrastructure necessary to manage, host and expose your add-on to a massive base of Mozilla users."
 msgstr ""
 
 #: src/olympia/pages/templates/pages/dev_faq.html:295
@@ -11358,9 +9693,7 @@ msgstr ""
 
 #: src/olympia/pages/templates/pages/dev_faq.html:297
 #, python-format
-msgid ""
-"Yes. Our <a href=\"%(url)s\">Privacy Policy</a> describes how your "
-"information is managed by Mozilla."
+msgid "Yes. Our <a href=\"%(url)s\">Privacy Policy</a> describes how your information is managed by Mozilla."
 msgstr ""
 
 #: src/olympia/pages/templates/pages/dev_faq.html:302
@@ -11369,25 +9702,19 @@ msgstr ""
 
 #: src/olympia/pages/templates/pages/dev_faq.html:304
 msgid ""
-"The \"Developer Tools\" dashboard is the area that provides you the tools to"
-" successfully manage your add-ons. It provides the functionality necessary "
-"to submit your add-ons to AMO, manage add-on information, and review "
-"statistics."
+"The \"Developer Tools\" dashboard is the area that provides you the tools to successfully manage your add-ons. It provides the functionality necessary to submit your add-ons to AMO, manage add-on "
+"information, and review statistics."
 msgstr ""
 
 #: src/olympia/pages/templates/pages/dev_faq.html:312
-msgid ""
-"Does Mozilla have a policy in place as to what is an acceptable submission?"
+msgid "Does Mozilla have a policy in place as to what is an acceptable submission?"
 msgstr ""
 
 #: src/olympia/pages/templates/pages/dev_faq.html:314
 #, python-format
 msgid ""
-"Yes. Mozilla's <a href=\"%(p_url)s\">Add-on Policy</a> describes what is an "
-"acceptable submission. This policy is subject to change without notice. In "
-"addition, the AMO editorial team uses the <a href=\"%(g_url)s\">Editors "
-"Reviewing Guide</a> to ensure that your add-on meets specific guidelines for"
-" functionality and security."
+"Yes. Mozilla's <a href=\"%(p_url)s\">Add-on Policy</a> describes what is an acceptable submission. This policy is subject to change without notice. In addition, the AMO editorial team uses the <a "
+"href=\"%(g_url)s\">Editors Reviewing Guide</a> to ensure that your add-on meets specific guidelines for functionality and security."
 msgstr ""
 
 #: src/olympia/pages/templates/pages/dev_faq.html:324
@@ -11397,11 +9724,8 @@ msgstr ""
 #: src/olympia/pages/templates/pages/dev_faq.html:326
 #, python-format
 msgid ""
-"The Developer Tools dashboard will allow you to upload and submit add-ons to"
-" AMO. You must be a registered AMO users before you can submit an add-on. "
-"Before submitting your add-on be sure to you have read the AMO <a "
-"href=\"%(url)s\">Editors Reviewing Guide</a> to ensure that your add-on has "
-"met the guidelines used by editors to review add-ons."
+"The Developer Tools dashboard will allow you to upload and submit add-ons to AMO. You must be a registered AMO users before you can submit an add-on. Before submitting your add-on be sure to you "
+"have read the AMO <a href=\"%(url)s\">Editors Reviewing Guide</a> to ensure that your add-on has met the guidelines used by editors to review add-ons."
 msgstr ""
 
 #: src/olympia/pages/templates/pages/dev_faq.html:336
@@ -11409,9 +9733,7 @@ msgid "What operating system do I choose for my add-on?"
 msgstr ""
 
 #: src/olympia/pages/templates/pages/dev_faq.html:338
-msgid ""
-"You must choose the operating systems on which your add-on will successfully"
-" function."
+msgid "You must choose the operating systems on which your add-on will successfully function."
 msgstr ""
 
 #: src/olympia/pages/templates/pages/dev_faq.html:344
@@ -11420,11 +9742,8 @@ msgstr ""
 
 #: src/olympia/pages/templates/pages/dev_faq.html:346
 msgid ""
-"The choice of category is dependent on what type of audience you are "
-"targeting and the functionality of your add-on. If you're unsure of which "
-"category your add-on falls into, please choose \"Other\". The AMO team may "
-"re-categorize your add-on if it's determined that it's better suited in a "
-"different category."
+"The choice of category is dependent on what type of audience you are targeting and the functionality of your add-on. If you're unsure of which category your add-on falls into, please choose \"Other"
+"\". The AMO team may re-categorize your add-on if it's determined that it's better suited in a different category."
 msgstr ""
 
 #: src/olympia/pages/templates/pages/dev_faq.html:355
@@ -11432,9 +9751,7 @@ msgid "What does \"nominating\" my add-on mean?"
 msgstr ""
 
 #: src/olympia/pages/templates/pages/dev_faq.html:357
-msgid ""
-"Nominated add-ons are new add-ons that the author has nominated to become "
-"public via the Developer Tools."
+msgid "Nominated add-ons are new add-ons that the author has nominated to become public via the Developer Tools."
 msgstr ""
 
 #: src/olympia/pages/templates/pages/dev_faq.html:363
@@ -11442,10 +9759,7 @@ msgid "Can I specify a license agreement for using my add-on?"
 msgstr ""
 
 #: src/olympia/pages/templates/pages/dev_faq.html:365
-msgid ""
-"Yes. You can specify a license agreement when submitting your add-on. You "
-"can also add or update a license agreement via the Developer Tools dashboard"
-" after your add-on has been submitted."
+msgid "Yes. You can specify a license agreement when submitting your add-on. You can also add or update a license agreement via the Developer Tools dashboard after your add-on has been submitted."
 msgstr ""
 
 #: src/olympia/pages/templates/pages/dev_faq.html:372
@@ -11453,10 +9767,7 @@ msgid "Can I include a privacy policy for my add-on?"
 msgstr ""
 
 #: src/olympia/pages/templates/pages/dev_faq.html:374
-msgid ""
-"Yes. You can specify a privacy policy when submitting your add-on. You can "
-"also add or update a privacy policy via the Developer Tools dashboard after "
-"your add-on has been submitted."
+msgid "Yes. You can specify a privacy policy when submitting your add-on. You can also add or update a privacy policy via the Developer Tools dashboard after your add-on has been submitted."
 msgstr ""
 
 #: src/olympia/pages/templates/pages/dev_faq.html:383
@@ -11466,10 +9777,8 @@ msgstr ""
 #: src/olympia/pages/templates/pages/dev_faq.html:385
 #, python-format
 msgid ""
-"All add-ons submitted, whether new or updated, are reviewed to ensure that "
-"Mozilla users have a stable and safe experience. All add-ons submissions are"
-" reviewed using the guidelines outlined in the <a href=\"%(url)s\">Editors "
-"Reviewing Guide</a>."
+"All add-ons submitted, whether new or updated, are reviewed to ensure that Mozilla users have a stable and safe experience. All add-ons submissions are reviewed using the guidelines outlined in the "
+"<a href=\"%(url)s\">Editors Reviewing Guide</a>."
 msgstr ""
 
 #: src/olympia/pages/templates/pages/dev_faq.html:393
@@ -11479,12 +9788,9 @@ msgstr ""
 #: src/olympia/pages/templates/pages/dev_faq.html:395
 #, python-format
 msgid ""
-"Add-ons are reviewed by the AMO Editors, a group of talented developers that"
-" volunteer to help the Mozilla project by reviewing add-ons to ensure a "
-"stable and safe experience for Mozilla users. When communicating with "
-"editors, please be courteous, patient and respectful as they are working "
-"hard to ensure that your add-on is set up correctly and follows the "
-"guidelines outlined in the <a href=\"%(url)s\">Editors Reviewing Guide</a>."
+"Add-ons are reviewed by the AMO Editors, a group of talented developers that volunteer to help the Mozilla project by reviewing add-ons to ensure a stable and safe experience for Mozilla users. "
+"When communicating with editors, please be courteous, patient and respectful as they are working hard to ensure that your add-on is set up correctly and follows the guidelines outlined in the <a "
+"href=\"%(url)s\">Editors Reviewing Guide</a>."
 msgstr ""
 
 #: src/olympia/pages/templates/pages/dev_faq.html:406
@@ -11494,11 +9800,8 @@ msgstr ""
 #: src/olympia/pages/templates/pages/dev_faq.html:408
 #, python-format
 msgid ""
-"The Mozilla editorial team follows the <a href=\"%(url)s\">Editors Reviewing"
-" Guide</a> when testing an add-on for acceptance onto AMO. It is important "
-"that add-on developers review this guide to ensure that common problem areas"
-" are addressed prior to submitting their add-on for review. This will "
-"greatly assist in expediting the review process."
+"The Mozilla editorial team follows the <a href=\"%(url)s\">Editors Reviewing Guide</a> when testing an add-on for acceptance onto AMO. It is important that add-on developers review this guide to "
+"ensure that common problem areas are addressed prior to submitting their add-on for review. This will greatly assist in expediting the review process."
 msgstr ""
 
 #: src/olympia/pages/templates/pages/dev_faq.html:418
@@ -11506,9 +9809,7 @@ msgid "How long will it take for my add-on to be reviewed?"
 msgstr ""
 
 #: src/olympia/pages/templates/pages/dev_faq.html:420
-msgid ""
-"We cannot give a time estimate as to how long it will take before an add-on "
-"is reviewed. Many factors affect the time including the:"
+msgid "We cannot give a time estimate as to how long it will take before an add-on is reviewed. Many factors affect the time including the:"
 msgstr ""
 
 #. part of a list (<li>)
@@ -11529,11 +9830,8 @@ msgstr ""
 #: src/olympia/pages/templates/pages/dev_faq.html:434
 #, python-format
 msgid ""
-"This is why it's very important to read the <a href=\"%(g_url)s\">Editors "
-"Reviewing Guide</a> to ensure that your add-on is setup as expected. It's "
-"also a good idea to read the blog post, <a "
-"href=\"%(blog_url)s\">Successfully Getting your Add-on Reviewed</a> which "
-"provides excellent insight into ensuring a smooth review of your add-on."
+"This is why it's very important to read the <a href=\"%(g_url)s\">Editors Reviewing Guide</a> to ensure that your add-on is setup as expected. It's also a good idea to read the blog post, <a href="
+"\"%(blog_url)s\">Successfully Getting your Add-on Reviewed</a> which provides excellent insight into ensuring a smooth review of your add-on."
 msgstr ""
 
 #: src/olympia/pages/templates/pages/dev_faq.html:446
@@ -11541,10 +9839,7 @@ msgid "How can I see how many times my add-on has been downloaded?"
 msgstr ""
 
 #: src/olympia/pages/templates/pages/dev_faq.html:448
-msgid ""
-"The Statistics Dashboard found in the Developer Tools dashboard provides "
-"information that can help you determine your add-on downloads since you've "
-"submitted it to AMO."
+msgid "The Statistics Dashboard found in the Developer Tools dashboard provides information that can help you determine your add-on downloads since you've submitted it to AMO."
 msgstr ""
 
 #: src/olympia/pages/templates/pages/dev_faq.html:455
@@ -11553,9 +9848,7 @@ msgstr ""
 
 #: src/olympia/pages/templates/pages/dev_faq.html:457
 msgid ""
-"The Statistics Dashboard found in the Developer Tools dashboard provides "
-"information that can help you determine how many users have been actively "
-"using your add-on since you've submitted it to AMO."
+"The Statistics Dashboard found in the Developer Tools dashboard provides information that can help you determine how many users have been actively using your add-on since you've submitted it to AMO."
 msgstr ""
 
 #: src/olympia/pages/templates/pages/dev_faq.html:464
@@ -11563,10 +9856,7 @@ msgid "How do I submit an update for my add-on?"
 msgstr ""
 
 #: src/olympia/pages/templates/pages/dev_faq.html:466
-msgid ""
-"You can submit an update for your add-on via the Developer Tools dashboard "
-"by choosing the option \"Upload a new version\" and uploading a new .xpi "
-"file for your add-on."
+msgid "You can submit an update for your add-on via the Developer Tools dashboard by choosing the option \"Upload a new version\" and uploading a new .xpi file for your add-on."
 msgstr ""
 
 #: src/olympia/pages/templates/pages/dev_faq.html:473
@@ -11575,39 +9865,30 @@ msgstr ""
 
 #: src/olympia/pages/templates/pages/dev_faq.html:475
 msgid ""
-"That depends. If you are simply changing a description of your add-on or "
-"updating a \"maxVersion\" to ensure compatibility with a new Mozilla "
-"software update, then your add-on does not need to be reviewed again. If, "
-"however, you submit a new updated file, then your add-on update will need to"
-" be reviewed by an editor."
+"That depends. If you are simply changing a description of your add-on or updating a \"maxVersion\" to ensure compatibility with a new Mozilla software update, then your add-on does not need to be "
+"reviewed again. If, however, you submit a new updated file, then your add-on update will need to be reviewed by an editor."
 msgstr ""
 
 #: src/olympia/pages/templates/pages/dev_faq.html:486
-msgid ""
-"How do I reply to a user who has posted a negative review of my add-on?"
+msgid "How do I reply to a user who has posted a negative review of my add-on?"
 msgstr ""
 
 #: src/olympia/pages/templates/pages/dev_faq.html:488
-msgid ""
-"A developer may reply to any review posted to their add-on as long as they "
-"are logged into AMO. In addition, any user can flag a review as:"
+msgid "A developer may reply to any review posted to their add-on as long as they are logged into AMO. In addition, any user can flag a review as:"
 msgstr ""
 
 #. part of a list (<li>)
-#: src/olympia/pages/templates/pages/dev_faq.html:495
-#: src/olympia/reviews/models.py:159
+#: src/olympia/pages/templates/pages/dev_faq.html:495 src/olympia/reviews/models.py:159
 msgid "Spam or otherwise non-review content"
 msgstr ""
 
 #. part of a list (<li>)
-#: src/olympia/pages/templates/pages/dev_faq.html:497
-#: src/olympia/reviews/models.py:160
+#: src/olympia/pages/templates/pages/dev_faq.html:497 src/olympia/reviews/models.py:160
 msgid "Inappropriate language/dialog"
 msgstr ""
 
 #. part of a list (<li>)
-#: src/olympia/pages/templates/pages/dev_faq.html:499
-#: src/olympia/reviews/models.py:161
+#: src/olympia/pages/templates/pages/dev_faq.html:499 src/olympia/reviews/models.py:161
 msgid "Misplaced bug report or support request"
 msgstr ""
 
@@ -11617,10 +9898,7 @@ msgid "Other (provides a pop-up prompt for information)"
 msgstr ""
 
 #: src/olympia/pages/templates/pages/dev_faq.html:504
-msgid ""
-"Currently, AMO does not provide a mechanism to directly communicate with a "
-"reviewer but this feature is being investigated and considered for a future "
-"update."
+msgid "Currently, AMO does not provide a mechanism to directly communicate with a reviewer but this feature is being investigated and considered for a future update."
 msgstr ""
 
 #: src/olympia/pages/templates/pages/dev_faq.html:511
@@ -11628,9 +9906,7 @@ msgid "Can I request that a review be removed if the review is negative?"
 msgstr ""
 
 #: src/olympia/pages/templates/pages/dev_faq.html:513
-msgid ""
-"No. We do not remove negative reviews from add-ons unless they are found to "
-"be false."
+msgid "No. We do not remove negative reviews from add-ons unless they are found to be false."
 msgstr ""
 
 #: src/olympia/pages/templates/pages/dev_faq.html:519
@@ -11638,55 +9914,36 @@ msgid "Can I request that a review be removed if the review is inaccurate?"
 msgstr ""
 
 #: src/olympia/pages/templates/pages/dev_faq.html:521
-msgid ""
-"If an author contacts us and asks for a review containing false or "
-"inaccurate information to be removed, we will review the post and consider "
-"removing it."
+msgid "If an author contacts us and asks for a review containing false or inaccurate information to be removed, we will review the post and consider removing it."
 msgstr ""
 
 #: src/olympia/pages/templates/pages/dev_faq.html:530
 msgid ""
-"Do you need more information about the various open source licenses? Are you"
-" confused as to which license you should select? What rights does a specific"
-" license grant? While nothing replaces reading the full terms of a license, "
-"below are some sites that contain information about some of the key open "
-"source licenses that may help you sort out the differences between them. "
-"These sites are being provided solely for your convenience and as a "
-"reference for your personal use. These resources do not constitute legal "
-"advice nor should they be used in lieu of such advice. Mozilla neither "
-"guarantees nor is responsible for the content of these sites or your "
-"reliance on such content."
+"Do you need more information about the various open source licenses? Are you confused as to which license you should select? What rights does a specific license grant? While nothing replaces "
+"reading the full terms of a license, below are some sites that contain information about some of the key open source licenses that may help you sort out the differences between them. These sites "
+"are being provided solely for your convenience and as a reference for your personal use. These resources do not constitute legal advice nor should they be used in lieu of such advice. Mozilla "
+"neither guarantees nor is responsible for the content of these sites or your reliance on such content."
 msgstr ""
 
 #: src/olympia/pages/templates/pages/dev_faq.html:545
 msgid ""
-"In addition to the full text of the Mozilla Public License(\"MPL\"), this "
-"also provides an annotated version of the MPL and an <abbr "
-"title=\"Frequently Asked Questions\">FAQ</abbr> to help you if you want to "
-"use or distribute code licensed under it."
+"In addition to the full text of the Mozilla Public License(\"MPL\"), this also provides an annotated version of the MPL and an <abbr title=\"Frequently Asked Questions\">FAQ</abbr> to help you if "
+"you want to use or distribute code licensed under it."
 msgstr ""
 
 #: src/olympia/pages/templates/pages/dev_faq.html:559
-msgid ""
-"A table summarizing and comparing how some of the key open source licenses "
-"treat distributions, proprietary software linking, and redistribution of "
-"code with changes."
+msgid "A table summarizing and comparing how some of the key open source licenses treat distributions, proprietary software linking, and redistribution of code with changes."
 msgstr ""
 
 #: src/olympia/pages/templates/pages/dev_faq.html:572
 msgid ""
-"Free Software Foundation provides short summaries of the key open source "
-"licenses, including whether the license qualifies as a free software license"
-" or a copyleft license. Also includes a discussion of what constitutes a "
-"free software license or a copyleft license (e.g., a Copyleft license is a "
-"general method for making a program or other work free, and requiring all "
-"modified and extended versions of the program to be free as well.)"
+"Free Software Foundation provides short summaries of the key open source licenses, including whether the license qualifies as a free software license or a copyleft license. Also includes a "
+"discussion of what constitutes a free software license or a copyleft license (e.g., a Copyleft license is a general method for making a program or other work free, and requiring all modified and "
+"extended versions of the program to be free as well.)"
 msgstr ""
 
 #: src/olympia/pages/templates/pages/dev_faq.html:589
-msgid ""
-"Open Source Initiative provides the terms of some of the key open source "
-"licenses."
+msgid "Open Source Initiative provides the terms of some of the key open source licenses."
 msgstr ""
 
 #: src/olympia/pages/templates/pages/dev_faq.html:599
@@ -11694,14 +9951,10 @@ msgid "A comparison of known open source licenses on Wikipedia."
 msgstr ""
 
 #: src/olympia/pages/templates/pages/dev_faq.html:605
-msgid ""
-"A site to provide non-judgmental guidance on choosing a license for your "
-"open source project."
+msgid "A site to provide non-judgmental guidance on choosing a license for your open source project."
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:3
-#: src/olympia/pages/templates/pages/faq.html:9
-#: src/olympia/pages/templates/pages/faq.html:10
+#: src/olympia/pages/templates/pages/faq.html:3 src/olympia/pages/templates/pages/faq.html:9 src/olympia/pages/templates/pages/faq.html:10
 msgid "Frequently Asked Questions"
 msgstr ""
 
@@ -11716,12 +9969,8 @@ msgstr ""
 #: src/olympia/pages/templates/pages/faq.html:16
 #, python-format
 msgid ""
-"Add-ons are small pieces of software that add new features or functionality "
-"to your installation of %(app_name)s. Add-ons can augment %(app_name)s with "
-"new features, foreign language dictionaries, or change its visual "
-"appearance. Through add-ons, you can customize %(app_name)s to meet your "
-"needs and tastes. <a href=\"%(learnmore_url)s\">Learn more about "
-"customization</a>"
+"Add-ons are small pieces of software that add new features or functionality to your installation of %(app_name)s. Add-ons can augment %(app_name)s with new features, foreign language dictionaries, "
+"or change its visual appearance. Through add-ons, you can customize %(app_name)s to meet your needs and tastes. <a href=\"%(learnmore_url)s\">Learn more about customization</a>"
 msgstr ""
 
 #: src/olympia/pages/templates/pages/faq.html:26
@@ -11731,15 +9980,9 @@ msgstr ""
 #: src/olympia/pages/templates/pages/faq.html:27
 #, python-format
 msgid ""
-"Add-ons listed in this gallery only work with Mozilla-based applications, "
-"such as <a href=\"%(getfirefox_url)s\">Firefox</a>, <a "
-"href=\"%(getmobile_url)s\">Firefox Mobile</a>, <a "
-"href=\"%(getseamonkey_url)s\">SeaMonkey</a>, and <a "
-"href=\"%(getthunderbird_url)s\">Thunderbird</a>. However, not all add-ons "
-"work with each of those applications or every version of those applications."
-" Each add-on specifies which applications and versions it works with, such "
-"as Firefox 2.0 - 3.6.*. For Firefox add-ons, the install buttons will "
-"indicate whether the add-on is compatible or not."
+"Add-ons listed in this gallery only work with Mozilla-based applications, such as <a href=\"%(getfirefox_url)s\">Firefox</a>, <a href=\"%(getmobile_url)s\">Firefox Mobile</a>, <a href="
+"\"%(getseamonkey_url)s\">SeaMonkey</a>, and <a href=\"%(getthunderbird_url)s\">Thunderbird</a>. However, not all add-ons work with each of those applications or every version of those applications. "
+"Each add-on specifies which applications and versions it works with, such as Firefox 2.0 - 3.6.*. For Firefox add-ons, the install buttons will indicate whether the add-on is compatible or not."
 msgstr ""
 
 #: src/olympia/pages/templates/pages/faq.html:42
@@ -11748,57 +9991,39 @@ msgstr ""
 
 #: src/olympia/pages/templates/pages/faq.html:43
 #, python-format
-msgid ""
-"There are several kinds of add-ons that customize %(app_name)s in different "
-"ways:"
+msgid "There are several kinds of add-ons that customize %(app_name)s in different ways:"
 msgstr ""
 
 #: src/olympia/pages/templates/pages/faq.html:47
 #, python-format
 msgid ""
-"<strong><a href=\"%(browse_url)s\">Extensions</a></strong> add new features "
-"to %(app_name)s or modify existing functionality. There are extensions that "
-"allow you to block advertisements, download videos from websites, integrate "
-"more closely with social websites, and add features you see in other "
-"applications."
+"<strong><a href=\"%(browse_url)s\">Extensions</a></strong> add new features to %(app_name)s or modify existing functionality. There are extensions that allow you to block advertisements, download "
+"videos from websites, integrate more closely with social websites, and add features you see in other applications."
 msgstr ""
 
 #: src/olympia/pages/templates/pages/faq.html:55
 #, python-format
-msgid ""
-"<strong><a href=\"%(browse_url)s\">Complete Themes</a></strong> change the "
-"entire appearance of %(app_name)s, usually including icons, colors, dialogs,"
-" and other visual styles."
+msgid "<strong><a href=\"%(browse_url)s\">Complete Themes</a></strong> change the entire appearance of %(app_name)s, usually including icons, colors, dialogs, and other visual styles."
 msgstr ""
 
 #: src/olympia/pages/templates/pages/faq.html:61
 #, python-format
-msgid ""
-"<strong><a href=\"%(browse_url)s\">Themes</a></strong> are lightweight "
-"themes that use background images to customize your %(app_name)s toolbars."
+msgid "<strong><a href=\"%(browse_url)s\">Themes</a></strong> are lightweight themes that use background images to customize your %(app_name)s toolbars."
 msgstr ""
 
 #: src/olympia/pages/templates/pages/faq.html:66
 #, python-format
-msgid ""
-"<strong><a href=\"%(browse_url)s\">Search Providers</a> </strong> add "
-"additional choices to the search box dropdown. These providers allow you to "
-"quickly search any website."
+msgid "<strong><a href=\"%(browse_url)s\">Search Providers</a> </strong> add additional choices to the search box dropdown. These providers allow you to quickly search any website."
 msgstr ""
 
 #: src/olympia/pages/templates/pages/faq.html:72
 #, python-format
-msgid ""
-"<strong><a href=\"%(browse_url)s\">Dictionaries & Language "
-"Packs</a></strong> add support for additional languages to %(app_name)s."
+msgid "<strong><a href=\"%(browse_url)s\">Dictionaries & Language Packs</a></strong> add support for additional languages to %(app_name)s."
 msgstr ""
 
 #: src/olympia/pages/templates/pages/faq.html:77
 #, python-format
-msgid ""
-"<strong><a href=\"%(browse_url)s\">Plugins</a></strong> help %(app_name)s "
-"display or understand different types of media, such as Adobe Flash or Apple"
-" Quicktime."
+msgid "<strong><a href=\"%(browse_url)s\">Plugins</a></strong> help %(app_name)s display or understand different types of media, such as Adobe Flash or Apple Quicktime."
 msgstr ""
 
 #: src/olympia/pages/templates/pages/faq.html:85
@@ -11808,13 +10033,9 @@ msgstr ""
 #: src/olympia/pages/templates/pages/faq.html:86
 #, python-format
 msgid ""
-"In most cases, add-ons can be installed by simply clicking the install "
-"button provided. Add-ons can be managed, disabled, or uninstalled from the "
-"Add-ons Manager in %(app_name)s. For more detailed instructions, read <a "
-"href=\"%(extension_url)s\">this article on extensions</a> or <a "
-"href=\"%(theme_url)s\">this one for Themes and Complete Themes</a>. If you "
-"have difficulty installing add-ons, see <a "
-"href=\"%(troubleshooting_url)s\">Troubleshooting Extensions and Themes</a>."
+"In most cases, add-ons can be installed by simply clicking the install button provided. Add-ons can be managed, disabled, or uninstalled from the Add-ons Manager in %(app_name)s. For more detailed "
+"instructions, read <a href=\"%(extension_url)s\">this article on extensions</a> or <a href=\"%(theme_url)s\">this one for Themes and Complete Themes</a>. If you have difficulty installing add-ons, "
+"see <a href=\"%(troubleshooting_url)s\">Troubleshooting Extensions and Themes</a>."
 msgstr ""
 
 #: src/olympia/pages/templates/pages/faq.html:100
@@ -11824,11 +10045,8 @@ msgstr ""
 #: src/olympia/pages/templates/pages/faq.html:101
 #, python-format
 msgid ""
-"In Firefox, add-ons marked with \"No restart required\" can be installed "
-"without restarting. These add-ons have been created using the <a "
-"href=\"%(sdk_url)s\">Add-on SDK</a> or <a "
-"href=\"%(bootstrap_url)s\">bootstrapping</a>. Other add-ons will still "
-"require a restart before you can use them."
+"In Firefox, add-ons marked with \"No restart required\" can be installed without restarting. These add-ons have been created using the <a href=\"%(sdk_url)s\">Add-on SDK</a> or <a href="
+"\"%(bootstrap_url)s\">bootstrapping</a>. Other add-ons will still require a restart before you can use them."
 msgstr ""
 
 #: src/olympia/pages/templates/pages/faq.html:110
@@ -11838,13 +10056,9 @@ msgstr ""
 #: src/olympia/pages/templates/pages/faq.html:111
 #, python-format
 msgid ""
-"Add-ons, unlike plugins, are automatically checked for updates once every "
-"day. In Firefox, updates are automatically installed by default. Versions of"
-" Firefox prior to 4 (and other applications) will alert you that updates to "
-"your add-ons are available. <a href=\"%(plugin_url)s\">Plugins</a> are not "
-"currently automatically checked for updates, so be sure to regularly visit "
-"the <a href=\"%(plugincheck_url)s\">Plugin Check</a> page to stay up-to-"
-"date."
+"Add-ons, unlike plugins, are automatically checked for updates once every day. In Firefox, updates are automatically installed by default. Versions of Firefox prior to 4 (and other applications) "
+"will alert you that updates to your add-ons are available. <a href=\"%(plugin_url)s\">Plugins</a> are not currently automatically checked for updates, so be sure to regularly visit the <a href="
+"\"%(plugincheck_url)s\">Plugin Check</a> page to stay up-to-date."
 msgstr ""
 
 #: src/olympia/pages/templates/pages/faq.html:122
@@ -11854,12 +10068,9 @@ msgstr ""
 #: src/olympia/pages/templates/pages/faq.html:123
 #, python-format
 msgid ""
-"Unless clearly marked otherwise, add-ons available from this gallery have "
-"been checked and approved by Mozilla's team of editors and are safe to "
-"install. We recommend that you only install approved add-ons. If you wish to"
-" install unapproved add-ons or add-ons from third-party websites, use "
-"caution as these add-ons may harm your computer or violate your privacy. <a "
-"href=\"%(learnmore_url)s\">Learn more about our approval process</a>"
+"Unless clearly marked otherwise, add-ons available from this gallery have been checked and approved by Mozilla's team of editors and are safe to install. We recommend that you only install approved "
+"add-ons. If you wish to install unapproved add-ons or add-ons from third-party websites, use caution as these add-ons may harm your computer or violate your privacy. <a href=\"%(learnmore_url)s"
+"\">Learn more about our approval process</a>"
 msgstr ""
 
 #: src/olympia/pages/templates/pages/faq.html:133
@@ -11870,30 +10081,21 @@ msgstr ""
 #: src/olympia/pages/templates/pages/faq.html:135
 #, python-format
 msgid ""
-"Most add-ons do not cause a perceivable performance decrease in "
-"%(app_name)s, though installing an excessive number may have adverse "
-"effects. If you suspect an add-on is causing %(app_name)s to be slow, try "
-"disabling it."
+"Most add-ons do not cause a perceivable performance decrease in %(app_name)s, though installing an excessive number may have adverse effects. If you suspect an add-on is causing %(app_name)s to be "
+"slow, try disabling it."
 msgstr ""
 
 #: src/olympia/pages/templates/pages/faq.html:141
 #, python-format
-msgid ""
-"%(app_name)s told me an add-on isn't compatible. Is there a way I can still "
-"use it?"
+msgid "%(app_name)s told me an add-on isn't compatible. Is there a way I can still use it?"
 msgstr ""
 
 #: src/olympia/pages/templates/pages/faq.html:144
 #, python-format
 msgid ""
-"If an add-on isn't compatible with your version of %(app_name)s, it is "
-"usually either because your version of %(app_name)s is outdated or the add-"
-"on author has not yet updated the add-on to be compatible with a newer "
-"version you are using. Mozilla does not recommend trying to circumvent these"
-" compatibility checks, as they can lead to browser instability or in some "
-"cases loss of data. For users who are testing out alpha or beta versions of "
-"Firefox, we offer the <a href=\"%(acr_url)s\">Add-on Compatibility "
-"Reporter</a> to help add-on developers update their compatibility."
+"If an add-on isn't compatible with your version of %(app_name)s, it is usually either because your version of %(app_name)s is outdated or the add-on author has not yet updated the add-on to be "
+"compatible with a newer version you are using. Mozilla does not recommend trying to circumvent these compatibility checks, as they can lead to browser instability or in some cases loss of data. For "
+"users who are testing out alpha or beta versions of Firefox, we offer the <a href=\"%(acr_url)s\">Add-on Compatibility Reporter</a> to help add-on developers update their compatibility."
 msgstr ""
 
 #: src/olympia/pages/templates/pages/faq.html:156
@@ -11903,12 +10105,9 @@ msgstr ""
 #: src/olympia/pages/templates/pages/faq.html:157
 #, python-format
 msgid ""
-"Add-ons are usually created by third-party developers from around the world,"
-" so the best way to get help with an add-on is to look for support links on "
-"the add-on's homepage or contact the developer. If you are having issues "
-"with %(app_name)s that you suspect are related to add-ons you have "
-"installed, <a href=\"%(troubleshooting_url)s\">visit this support "
-"article</a> for troubleshooting tips."
+"Add-ons are usually created by third-party developers from around the world, so the best way to get help with an add-on is to look for support links on the add-on's homepage or contact the "
+"developer. If you are having issues with %(app_name)s that you suspect are related to add-ons you have installed, <a href=\"%(troubleshooting_url)s\">visit this support article</a> for "
+"troubleshooting tips."
 msgstr ""
 
 #: src/olympia/pages/templates/pages/faq.html:169
@@ -11921,12 +10120,8 @@ msgstr ""
 
 #: src/olympia/pages/templates/pages/faq.html:172
 msgid ""
-"There are often several add-ons that have similar features. To figure out "
-"which is right for you, read the entire description of the add-on and view "
-"its screenshots. If there are still several in the running, read through the"
-" add-on's ratings, user reviews, and statistics to see which is most liked "
-"by other users. Remember that you can also just try out both and see which "
-"you like better."
+"There are often several add-ons that have similar features. To figure out which is right for you, read the entire description of the add-on and view its screenshots. If there are still several in "
+"the running, read through the add-on's ratings, user reviews, and statistics to see which is most liked by other users. Remember that you can also just try out both and see which you like better."
 msgstr ""
 
 #: src/olympia/pages/templates/pages/faq.html:180
@@ -11936,26 +10131,19 @@ msgstr ""
 #: src/olympia/pages/templates/pages/faq.html:181
 #, python-format
 msgid ""
-"With thousands of add-ons available, there's something for everyone. But if "
-"you're looking for a particular add-on and can't find it, you might try "
-"searching on other sites or posting about it in our <a href=\"%(forum_url)s"
-"\">Add-ons </a>forum."
+"With thousands of add-ons available, there's something for everyone. But if you're looking for a particular add-on and can't find it, you might try searching on other sites or posting about it in "
+"our <a href=\"%(forum_url)s\">Add-ons </a>forum."
 msgstr ""
 
 #: src/olympia/pages/templates/pages/faq.html:187
-msgid ""
-"What does it mean if an add-on is \"experimental\" or \"preliminarily "
-"reviewed\"?"
+msgid "What does it mean if an add-on is \"experimental\" or \"preliminarily reviewed\"?"
 msgstr ""
 
 #: src/olympia/pages/templates/pages/faq.html:188
 #, python-format
 msgid ""
-"Experimental add-ons have been checked by our editors to make sure they "
-"don't have security problems, but they may still have bugs or not work "
-"properly. Use caution when installing experimental add-ons and uninstall the"
-" add-on immediately if you notice problems. <a href=\"%(url)s\">Learn more "
-"about our review process</a></dd>"
+"Experimental add-ons have been checked by our editors to make sure they don't have security problems, but they may still have bugs or not work properly. Use caution when installing experimental add-"
+"ons and uninstall the add-on immediately if you notice problems. <a href=\"%(url)s\">Learn more about our review process</a></dd>"
 msgstr ""
 
 #: src/olympia/pages/templates/pages/faq.html:196
@@ -11965,12 +10153,8 @@ msgstr ""
 #: src/olympia/pages/templates/pages/faq.html:197
 #, python-format
 msgid ""
-"While all add-ons publicly available in our gallery are reviewed by an "
-"editor, you may receive a direct link to an add-on that hasn't yet been "
-"reviewed. Use caution when installing these add-ons, as they could harm your"
-" computer or violate your privacy. We recommend that you only install "
-"reviewed add-ons. <a href=\"%(url)s\">Learn more about our review "
-"process</a></dd>"
+"While all add-ons publicly available in our gallery are reviewed by an editor, you may receive a direct link to an add-on that hasn't yet been reviewed. Use caution when installing these add-ons, "
+"as they could harm your computer or violate your privacy. We recommend that you only install reviewed add-ons. <a href=\"%(url)s\">Learn more about our review process</a></dd>"
 msgstr ""
 
 #: src/olympia/pages/templates/pages/faq.html:206
@@ -11978,8 +10162,7 @@ msgid "How much do add-ons cost to purchase?"
 msgstr ""
 
 #: src/olympia/pages/templates/pages/faq.html:207
-msgid ""
-"Add-ons hosted in our gallery are free unless clearly marked otherwise."
+msgid "Add-ons hosted in our gallery are free unless clearly marked otherwise."
 msgstr ""
 
 #: src/olympia/pages/templates/pages/faq.html:209
@@ -11988,10 +10171,8 @@ msgstr ""
 
 #: src/olympia/pages/templates/pages/faq.html:210
 msgid ""
-"Some add-on authors request users who enjoy an add-on to contribute to its "
-"development by making a monetary contribution. These contributions go "
-"directly to the developer unless a third party is indicated, such as the "
-"non-profit Mozilla Foundation."
+"Some add-on authors request users who enjoy an add-on to contribute to its development by making a monetary contribution. These contributions go directly to the developer unless a third party is "
+"indicated, such as the non-profit Mozilla Foundation."
 msgstr ""
 
 #: src/olympia/pages/templates/pages/faq.html:215
@@ -12000,19 +10181,14 @@ msgstr ""
 
 #: src/olympia/pages/templates/pages/faq.html:217
 msgid ""
-"Beta add-ons are unreviewed versions which represent the latest work of an "
-"add-on author. While different authors have different standards for beta "
-"code quality, you should assume that these add-ons are less stable than the "
-"general add-on releases."
+"Beta add-ons are unreviewed versions which represent the latest work of an add-on author. While different authors have different standards for beta code quality, you should assume that these add-"
+"ons are less stable than the general add-on releases."
 msgstr ""
 
 #: src/olympia/pages/templates/pages/faq.html:221
 msgid ""
-"Please note that when you install an add-on from the \"Beta Version\" "
-"section of an add-on's listing, you will continue to receive updates for "
-"that add-on as they become available. Like the initial version you "
-"installed, all beta releases are unreviewed by Mozilla and may harm your "
-"computer."
+"Please note that when you install an add-on from the \"Beta Version\" section of an add-on's listing, you will continue to receive updates for that add-on as they become available. Like the initial "
+"version you installed, all beta releases are unreviewed by Mozilla and may harm your computer."
 msgstr ""
 
 #: src/olympia/pages/templates/pages/faq.html:228
@@ -12020,10 +10196,7 @@ msgid "What does it mean when an add-on is flagged as slow?"
 msgstr ""
 
 #: src/olympia/pages/templates/pages/faq.html:229
-msgid ""
-"Most add-ons load code and resources at the same time Firefox is starting "
-"up. In most cases the impact in start-up time is minimal, but some add-ons "
-"can cause a noticeable slowdown."
+msgid "Most add-ons load code and resources at the same time Firefox is starting up. In most cases the impact in start-up time is minimal, but some add-ons can cause a noticeable slowdown."
 msgstr ""
 
 #: src/olympia/pages/templates/pages/faq.html:234
@@ -12032,10 +10205,8 @@ msgstr ""
 
 #: src/olympia/pages/templates/pages/faq.html:235
 msgid ""
-"To report a user review of an add-on, log in with your account and visit the"
-" add-on's reviews page. Find the review you wish to report, click \"Report "
-"this review\" and select a reason. Our editorial team will investigate the "
-"review and take appropriate action."
+"To report a user review of an add-on, log in with your account and visit the add-on's reviews page. Find the review you wish to report, click \"Report this review\" and select a reason. Our "
+"editorial team will investigate the review and take appropriate action."
 msgstr ""
 
 #: src/olympia/pages/templates/pages/faq.html:240
@@ -12054,19 +10225,14 @@ msgstr ""
 #: src/olympia/pages/templates/pages/faq.html:245
 #, python-format
 msgid ""
-"The source code used to create an add-on is an exclusive copyright of the "
-"add-on author, unless otherwise declared in a source code license. Many add-"
-"ons on this site have <a href=\"%(url)s\" lang=\"en\">open source "
-"licenses</a> that make the source code publicly available for copy and reuse"
-" under conditions determined by the author. Most authors choose widely known"
-" open source licenses like the GPL or BSD licenses instead of making up "
-"their own."
+"The source code used to create an add-on is an exclusive copyright of the add-on author, unless otherwise declared in a source code license. Many add-ons on this site have <a href=\"%(url)s\" lang="
+"\"en\">open source licenses</a> that make the source code publicly available for copy and reuse under conditions determined by the author. Most authors choose widely known open source licenses like "
+"the GPL or BSD licenses instead of making up their own."
 msgstr ""
 
 #: src/olympia/pages/templates/pages/faq.html:254
 #, python-format
-msgid ""
-"Firefox and other Mozilla software are <a href=\"%(url)s\">open source</a>."
+msgid "Firefox and other Mozilla software are <a href=\"%(url)s\">open source</a>."
 msgstr ""
 
 #: src/olympia/pages/templates/pages/faq.html:262
@@ -12086,15 +10252,10 @@ msgid "What is the My Favorites collection?"
 msgstr ""
 
 #: src/olympia/pages/templates/pages/faq.html:269
-msgid ""
-"Favorite add-ons are add-ons that you have bookmarked to easily get back to "
-"later. You can add an add-on to your favorites collection by clicking \"Add "
-"to favorites\" on its details page."
+msgid "Favorite add-ons are add-ons that you have bookmarked to easily get back to later. You can add an add-on to your favorites collection by clicking \"Add to favorites\" on its details page."
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:273
-#: src/olympia/templates/menu_links.html:13
-#: src/olympia/templates/impala/header_title.html:17
+#: src/olympia/pages/templates/pages/faq.html:273 src/olympia/templates/menu_links.html:13 src/olympia/templates/impala/header_title.html:17
 msgid "Mobile Add-ons"
 msgstr ""
 
@@ -12105,10 +10266,8 @@ msgstr ""
 #: src/olympia/pages/templates/pages/faq.html:277
 #, python-format
 msgid ""
-"Mobile add-ons work with <a href=\"%(mobile_url)s\">Firefox for Mobile</a> "
-"and add or modify functionality just like desktop add-ons. You can find add-"
-"ons that work with Firefox for Mobile in our <a "
-"href=\"%(gallery_url)s\">gallery</a>."
+"Mobile add-ons work with <a href=\"%(mobile_url)s\">Firefox for Mobile</a> and add or modify functionality just like desktop add-ons. You can find add-ons that work with Firefox for Mobile in our "
+"<a href=\"%(gallery_url)s\">gallery</a>."
 msgstr ""
 
 #: src/olympia/pages/templates/pages/faq.html:286
@@ -12117,10 +10276,7 @@ msgstr ""
 
 #: src/olympia/pages/templates/pages/faq.html:287
 #, python-format
-msgid ""
-"Please see our <a href=\"%(faq_url)s\">Developer FAQ</a> and <a "
-"href=\"%(hub_url)s\">Developer Hub</a> for answers to add-on developer-"
-"related questions."
+msgid "Please see our <a href=\"%(faq_url)s\">Developer FAQ</a> and <a href=\"%(hub_url)s\">Developer Hub</a> for answers to add-on developer-related questions."
 msgstr ""
 
 #: src/olympia/pages/templates/pages/faq.html:292
@@ -12129,27 +10285,21 @@ msgstr ""
 
 #: src/olympia/pages/templates/pages/faq.html:293
 #, python-format
-msgid ""
-"For general Firefox support, visit our <a href=\"%(sumo_url)s\">support "
-"website</a>. For general add-on and website questions, visit our <a "
-"href=\"%(forum_url)s\">forum</a>."
+msgid "For general Firefox support, visit our <a href=\"%(sumo_url)s\">support website</a>. For general add-on and website questions, visit our <a href=\"%(forum_url)s\">forum</a>."
 msgstr ""
 
-#: src/olympia/pages/templates/pages/review_guide.html:36
-#: src/olympia/pages/templates/pages/review_guide.html:51
+#: src/olympia/pages/templates/pages/review_guide.html:36 src/olympia/pages/templates/pages/review_guide.html:51
 msgid "Some tips for writing a great review"
 msgstr ""
 
-#: src/olympia/pages/templates/pages/review_guide.html:39
-#: src/olympia/pages/templates/pages/review_guide.html:131
+#: src/olympia/pages/templates/pages/review_guide.html:39 src/olympia/pages/templates/pages/review_guide.html:131
 msgid "Frequently Asked Questions about Reviews"
 msgstr ""
 
 #: src/olympia/pages/templates/pages/review_guide.html:46
 msgid ""
-"Add-on reviews are a way for you to share your opinions about the add-ons "
-"you’ve installed and used. Our review moderation team reserves the right to "
-"refuse or remove any review that does not comply with these guidelines."
+"Add-on reviews are a way for you to share your opinions about the add-ons you’ve installed and used. Our review moderation team reserves the right to refuse or remove any review that does not "
+"comply with these guidelines."
 msgstr ""
 
 #: src/olympia/pages/templates/pages/review_guide.html:53
@@ -12157,8 +10307,7 @@ msgid "Do:"
 msgstr ""
 
 #: src/olympia/pages/templates/pages/review_guide.html:56
-msgid ""
-"Write like you are telling a friend about your experience with the add-on."
+msgid "Write like you are telling a friend about your experience with the add-on."
 msgstr ""
 
 #: src/olympia/pages/templates/pages/review_guide.html:61
@@ -12190,8 +10339,7 @@ msgid "Will you continue to use this add-on?"
 msgstr ""
 
 #: src/olympia/pages/templates/pages/review_guide.html:73
-msgid ""
-"Take a moment to read your review before submitting it to minimize typos."
+msgid "Take a moment to read your review before submitting it to minimize typos."
 msgstr ""
 
 #: src/olympia/pages/templates/pages/review_guide.html:79
@@ -12204,9 +10352,8 @@ msgstr ""
 
 #: src/olympia/pages/templates/pages/review_guide.html:87
 msgid ""
-"Post technical issues, support requests, or feature suggestions. Use the "
-"available support options for each add-on, if available. You can find them "
-"in the side column next to the About this Add-on section."
+"Post technical issues, support requests, or feature suggestions. Use the available support options for each add-on, if available. You can find them in the side column next to the About this Add-on "
+"section."
 msgstr ""
 
 #: src/olympia/pages/templates/pages/review_guide.html:92
@@ -12214,38 +10361,29 @@ msgid "Write reviews for add-ons which you have not personally used."
 msgstr ""
 
 #: src/olympia/pages/templates/pages/review_guide.html:97
-msgid ""
-"Use profanity, sexual language or language that can be construed as hateful."
+msgid "Use profanity, sexual language or language that can be construed as hateful."
 msgstr ""
 
 #: src/olympia/pages/templates/pages/review_guide.html:103
-msgid ""
-"Include HTML, links, source code or code snippets. Reviews are meant to be "
-"text only."
+msgid "Include HTML, links, source code or code snippets. Reviews are meant to be text only."
 msgstr ""
 
 #: src/olympia/pages/templates/pages/review_guide.html:108
-msgid ""
-"Make false statements, disparage add-on authors or personally insult them."
+msgid "Make false statements, disparage add-on authors or personally insult them."
 msgstr ""
 
 #: src/olympia/pages/templates/pages/review_guide.html:114
-msgid ""
-"Include your own or anyone else’s email, phone number, or other personal "
-"details."
+msgid "Include your own or anyone else’s email, phone number, or other personal details."
 msgstr ""
 
 #: src/olympia/pages/templates/pages/review_guide.html:119
-msgid ""
-"Post reviews for an add-on you or your organization wrote or represent."
+msgid "Post reviews for an add-on you or your organization wrote or represent."
 msgstr ""
 
 #: src/olympia/pages/templates/pages/review_guide.html:125
 msgid ""
-"Criticize an add-on for something it’s intended to do. For example, leaving "
-"a negative review of an add-on for displaying ads or requiring data "
-"gathering, when that is the intended purpose of the add-on, or the add-on "
-"requires gathering data to function."
+"Criticize an add-on for something it’s intended to do. For example, leaving a negative review of an add-on for displaying ads or requiring data gathering, when that is the intended purpose of the "
+"add-on, or the add-on requires gathering data to function."
 msgstr ""
 
 #: src/olympia/pages/templates/pages/review_guide.html:133
@@ -12254,10 +10392,8 @@ msgstr ""
 
 #: src/olympia/pages/templates/pages/review_guide.html:135
 msgid ""
-"Please report or flag any questionable reviews by clicking the \"Report this"
-" review\" and it will be submitted to the site for moderation. Our "
-"moderation team will use the Review Guidelines to evaluate whether or not to"
-" delete the review or restore it back to the site."
+"Please report or flag any questionable reviews by clicking the \"Report this review\" and it will be submitted to the site for moderation. Our moderation team will use the Review Guidelines to "
+"evaluate whether or not to delete the review or restore it back to the site."
 msgstr ""
 
 #: src/olympia/pages/templates/pages/review_guide.html:140
@@ -12266,10 +10402,7 @@ msgstr ""
 
 #: src/olympia/pages/templates/pages/review_guide.html:142
 #, python-format
-msgid ""
-"Yes, add-on authors can provide a single response to a review. You can set "
-"up a discussion topic in our <a href=\"%(forum_url)s\">forum</a> to engage "
-"in additional discussion or follow-up."
+msgid "Yes, add-on authors can provide a single response to a review. You can set up a discussion topic in our <a href=\"%(forum_url)s\">forum</a> to engage in additional discussion or follow-up."
 msgstr ""
 
 #: src/olympia/pages/templates/pages/review_guide.html:149
@@ -12278,11 +10411,8 @@ msgstr ""
 
 #: src/olympia/pages/templates/pages/review_guide.html:151
 msgid ""
-"In general, no. But if the review did not meet the review guidelines "
-"outlined above, you can click \"Report this review\" and have it moderated. "
-"If a review included a complaint that is no longer valid due to a new "
-"release of your add-on, we may consider deleting the review. Submit your "
-"detailed request to amo-editors@mozilla.org."
+"In general, no. But if the review did not meet the review guidelines outlined above, you can click \"Report this review\" and have it moderated. If a review included a complaint that is no longer "
+"valid due to a new release of your add-on, we may consider deleting the review. Submit your detailed request to amo-editors@mozilla.org."
 msgstr ""
 
 #: src/olympia/pages/templates/pages/sunbird.html:26
@@ -12291,17 +10421,13 @@ msgstr ""
 
 #: src/olympia/pages/templates/pages/sunbird.html:29
 msgid ""
-"Development on the Sunbird project has halted and its final release was on "
-"March 30, 2010. We've been proud to host Sunbird add-ons on this site but as"
-" the project is no longer maintained we have disabled our support for the "
-"add-ons."
+"Development on the Sunbird project has halted and its final release was on March 30, 2010. We've been proud to host Sunbird add-ons on this site but as the project is no longer maintained we have "
+"disabled our support for the add-ons."
 msgstr ""
 
 #: src/olympia/pages/templates/pages/sunbird.html:38
 #, python-format
-msgid ""
-"We recommend upgrading to <a href=\"%(tb_url)s\">Thunderbird</a> and <a "
-"href=\"%(lightning_url)s\">Lightning</a>."
+msgid "We recommend upgrading to <a href=\"%(tb_url)s\">Thunderbird</a> and <a href=\"%(lightning_url)s\">Lightning</a>."
 msgstr ""
 
 #: src/olympia/pages/templates/pages/sunbird.html:45
@@ -12353,8 +10479,7 @@ msgstr ""
 msgid "Skip for now"
 msgstr ""
 
-#: src/olympia/reviews/forms.py:151
-#: src/olympia/reviews/templates/reviews/review.html:107
+#: src/olympia/reviews/forms.py:151 src/olympia/reviews/templates/reviews/review.html:107
 msgid "Delete review"
 msgstr ""
 
@@ -12373,27 +10498,18 @@ msgstr ""
 #: src/olympia/reviews/templates/reviews/add.html:26
 #, python-format
 msgid ""
-"<h2>Keep these tips in mind:</h2> <ul> <li> Write like you're telling a "
-"friend about your experience with the add-on. Give specifics and helpful "
-"details, such as what features you liked and/or disliked, how easy to use it"
-" is, and any disadvantages it has. Avoid generic language such as calling it"
-" \"Great\" or \"Bad\" unless you can give reasons why you believe this is "
-"so. </li> <li> Please do not post bug reports in reviews. We do not make "
-"your email address available to add-on developers and they may need to "
-"contact you to help resolve your issue. See the <a "
-"href=\"%(support)s\">support section</a> to find out where to get assistance"
-" for this add-on. </li> <li>Please keep reviews clean, avoid the use of "
-"improper language and do not post any personal information. </li> </ul> "
-"<p>Please read the <a href=\"%(guide)s\" target=\"_blank\">Review "
-"Guidelines</a> for more detail about user add-on reviews.</p>"
+"<h2>Keep these tips in mind:</h2> <ul> <li> Write like you're telling a friend about your experience with the add-on. Give specifics and helpful details, such as what features you liked and/or "
+"disliked, how easy to use it is, and any disadvantages it has. Avoid generic language such as calling it \"Great\" or \"Bad\" unless you can give reasons why you believe this is so. </li> <li> "
+"Please do not post bug reports in reviews. We do not make your email address available to add-on developers and they may need to contact you to help resolve your issue. See the <a href=\"%(support)s"
+"\">support section</a> to find out where to get assistance for this add-on. </li> <li>Please keep reviews clean, avoid the use of improper language and do not post any personal information. </li> </"
+"ul> <p>Please read the <a href=\"%(guide)s\" target=\"_blank\">Review Guidelines</a> for more detail about user add-on reviews.</p>"
 msgstr ""
 
 #: src/olympia/reviews/templates/reviews/reply.html:4
 msgid "Reply to review by {0}"
 msgstr ""
 
-#: src/olympia/reviews/templates/reviews/reply.html:15
-#: src/olympia/reviews/templates/reviews/reply.html:31
+#: src/olympia/reviews/templates/reviews/reply.html:15 src/olympia/reviews/templates/reviews/reply.html:31
 msgid "Reply"
 msgstr ""
 
@@ -12401,8 +10517,7 @@ msgstr ""
 msgid "Write a Reply"
 msgstr ""
 
-#: src/olympia/reviews/templates/reviews/reply.html:36
-#: src/olympia/reviews/templates/reviews/report_review.html:12
+#: src/olympia/reviews/templates/reviews/reply.html:36 src/olympia/reviews/templates/reviews/report_review.html:12
 msgid "Submit"
 msgstr ""
 
@@ -12422,19 +10537,14 @@ msgid "by %(user)s <b>(Developer)</b> on %(date)s"
 msgstr ""
 
 #. {0} is a version number (like 1.01)
-#: src/olympia/reviews/templates/reviews/review.html:50
-#: src/olympia/reviews/templates/reviews/mobile/review_list.html:41
+#: src/olympia/reviews/templates/reviews/review.html:50 src/olympia/reviews/templates/reviews/mobile/review_list.html:41
 msgid "This review is for a previous version of the add-on ({0})."
 msgstr ""
 
 #: src/olympia/reviews/templates/reviews/review.html:56
 #, python-format
-msgid ""
-"This user has a <a href=\"%(user_review_url)s\">previous review</a> of this "
-"add-on."
-msgid_plural ""
-"This user has <a href=\"%(user_review_url)s\">%(cnt)s previous reviews</a> "
-"of this add-on."
+msgid "This user has a <a href=\"%(user_review_url)s\">previous review</a> of this add-on."
+msgid_plural "This user has <a href=\"%(user_review_url)s\">%(cnt)s previous reviews</a> of this add-on."
 msgstr[0] ""
 msgstr[1] ""
 msgstr[2] ""
@@ -12442,9 +10552,7 @@ msgstr[3] ""
 
 #: src/olympia/reviews/templates/reviews/review.html:62
 #, python-format
-msgid ""
-"This user has <a href=\"%(user_review_url)s\">other reviews</a> of this add-"
-"on."
+msgid "This user has <a href=\"%(user_review_url)s\">other reviews</a> of this add-on."
 msgstr ""
 
 #: src/olympia/reviews/templates/reviews/review.html:72
@@ -12477,9 +10585,7 @@ msgid "{0} :: Reviews"
 msgstr ""
 
 #. {0} is an addon name.
-#: src/olympia/reviews/templates/reviews/review_list.html:24
-#: src/olympia/reviews/templates/reviews/mobile/add.html:4
-#: src/olympia/reviews/templates/reviews/mobile/review_list.html:4
+#: src/olympia/reviews/templates/reviews/review_list.html:24 src/olympia/reviews/templates/reviews/mobile/add.html:4 src/olympia/reviews/templates/reviews/mobile/review_list.html:4
 msgid "Reviews for {0}"
 msgstr ""
 
@@ -12519,8 +10625,7 @@ msgstr ""
 msgid "Write a New Review"
 msgstr ""
 
-#: src/olympia/reviews/templates/reviews/review_list.html:81
-#: src/olympia/reviews/templates/reviews/mobile/reviews_link.html:15
+#: src/olympia/reviews/templates/reviews/review_list.html:81 src/olympia/reviews/templates/reviews/mobile/reviews_link.html:15
 msgid "Be the first to write a review."
 msgstr ""
 
@@ -12541,8 +10646,7 @@ msgstr ""
 msgid "Rated %(rating)s out of 5 stars"
 msgstr ""
 
-#: src/olympia/reviews/templates/reviews/mobile/add_form.html:3
-#: src/olympia/reviews/templates/reviews/mobile/add_form.html:8
+#: src/olympia/reviews/templates/reviews/mobile/add_form.html:3 src/olympia/reviews/templates/reviews/mobile/add_form.html:8
 msgid "Add a Review"
 msgstr ""
 
@@ -12617,14 +10721,11 @@ msgid "Relevance"
 msgstr ""
 
 #: src/olympia/search/helpers.py:24
-msgid ""
-"Results <strong>{0}</strong>-<strong>{1}</strong> of <strong>{2}</strong>"
+msgid "Results <strong>{0}</strong>-<strong>{1}</strong> of <strong>{2}</strong>"
 msgstr ""
 
 #: src/olympia/search/helpers.py:44
-msgid ""
-"Showing {0} - {1} of {2} results for <strong>{3}</strong> tagged with "
-"<strong>{4}</strong>"
+msgid "Showing {0} - {1} of {2} results for <strong>{3}</strong> tagged with <strong>{4}</strong>"
 msgstr ""
 
 #: src/olympia/search/helpers.py:49
@@ -12640,9 +10741,7 @@ msgid "Showing {0} - {1} of {2} results"
 msgstr ""
 
 #. {0} is an application, like Firefox.
-#: src/olympia/search/views.py:264 src/olympia/templates/base.html:17
-#: src/olympia/templates/impala/base.html:17
-#: src/olympia/templates/mobile/base_addons.html:17
+#: src/olympia/search/views.py:264 src/olympia/templates/base.html:17 src/olympia/templates/impala/base.html:17 src/olympia/templates/mobile/base_addons.html:17
 msgid "{0} Add-ons"
 msgstr ""
 
@@ -12845,11 +10944,8 @@ msgstr ""
 msgid "Share this Collection"
 msgstr ""
 
-#: src/olympia/signing/views.py:33 src/olympia/templates/base.html:71
-#: src/olympia/templates/impala/base.html:112
-msgid ""
-"Some features are temporarily disabled while we perform website maintenance."
-" We'll be back to full capacity shortly."
+#: src/olympia/signing/views.py:33 src/olympia/templates/base.html:71 src/olympia/templates/impala/base.html:112
+msgid "Some features are temporarily disabled while we perform website maintenance. We'll be back to full capacity shortly."
 msgstr ""
 
 #: src/olympia/signing/views.py:56
@@ -12964,8 +11060,7 @@ msgstr ""
 msgid "To"
 msgstr ""
 
-#: src/olympia/stats/templates/stats/popup.html:27
-#: src/olympia/users/templates/users/pwreset_confirm.html:38
+#: src/olympia/stats/templates/stats/popup.html:27 src/olympia/users/templates/users/pwreset_confirm.html:38
 msgid "Update"
 msgstr ""
 
@@ -12986,95 +11081,89 @@ msgstr ""
 msgid "Statistics Dashboard :: Add-ons for {0}"
 msgstr ""
 
-#: src/olympia/stats/templates/stats/stats.html:30
-msgid "Controls:"
-msgstr ""
-
-#: src/olympia/stats/templates/stats/stats.html:33
-msgid "reset zoom"
-msgstr ""
-
-#: src/olympia/stats/templates/stats/stats.html:40
-msgid "Group by:"
-msgstr ""
-
-#: src/olympia/stats/templates/stats/stats.html:42
-msgid "day"
-msgstr ""
-
-#: src/olympia/stats/templates/stats/stats.html:45
-msgid "week"
-msgstr ""
-
-#: src/olympia/stats/templates/stats/stats.html:48
-msgid "month"
-msgstr ""
-
-#: src/olympia/stats/templates/stats/stats.html:54
-msgid "For last:"
-msgstr ""
-
-#: src/olympia/stats/templates/stats/stats.html:57
-msgid "7 days"
-msgstr ""
-
-#: src/olympia/stats/templates/stats/stats.html:60
-msgid "30 days"
-msgstr ""
-
-#: src/olympia/stats/templates/stats/stats.html:63
-msgid "90 days"
-msgstr ""
-
-#: src/olympia/stats/templates/stats/stats.html:66
-msgid "365 days"
-msgstr ""
-
-#: src/olympia/stats/templates/stats/stats.html:69
-msgid "Custom..."
-msgstr ""
-
 #. {0} is an add-on name
-#: src/olympia/stats/templates/stats/stats.html:88
-#: src/olympia/stats/templates/stats/stats.html:91
+#: src/olympia/stats/templates/stats/stats.html:44 src/olympia/stats/templates/stats/stats.html:47
 msgid "Statistics for {0}"
 msgstr ""
 
-#: src/olympia/stats/templates/stats/stats.html:94
+#: src/olympia/stats/templates/stats/stats.html:50
 msgid "Statistics Dashboard"
 msgstr ""
 
-#: src/olympia/stats/templates/stats/stats.html:104
-msgid ""
-"Statistics processing is currently disabled, so recent data is unavailable. "
-"The statistics are still being collected and this page will be updated soon "
-"with the missing data."
+#: src/olympia/stats/templates/stats/stats.html:57
+msgid "Controls:"
 msgstr ""
 
-#: src/olympia/stats/templates/stats/stats.html:110
+#: src/olympia/stats/templates/stats/stats.html:60
+msgid "reset zoom"
+msgstr ""
+
+#: src/olympia/stats/templates/stats/stats.html:67
+msgid "Group by:"
+msgstr ""
+
+#: src/olympia/stats/templates/stats/stats.html:69
+msgid "day"
+msgstr ""
+
+#: src/olympia/stats/templates/stats/stats.html:72
+msgid "week"
+msgstr ""
+
+#: src/olympia/stats/templates/stats/stats.html:75
+msgid "month"
+msgstr ""
+
+#: src/olympia/stats/templates/stats/stats.html:81
+msgid "For last:"
+msgstr ""
+
+#: src/olympia/stats/templates/stats/stats.html:84
+msgid "7 days"
+msgstr ""
+
+#: src/olympia/stats/templates/stats/stats.html:87
+msgid "30 days"
+msgstr ""
+
+#: src/olympia/stats/templates/stats/stats.html:90
+msgid "90 days"
+msgstr ""
+
+#: src/olympia/stats/templates/stats/stats.html:93
+msgid "365 days"
+msgstr ""
+
+#: src/olympia/stats/templates/stats/stats.html:96
+msgid "Custom..."
+msgstr ""
+
+#: src/olympia/stats/templates/stats/stats.html:106
+msgid "Statistics processing is currently disabled, so recent data is unavailable. The statistics are still being collected and this page will be updated soon with the missing data."
+msgstr ""
+
+#: src/olympia/stats/templates/stats/stats.html:112
 msgid "Loading the latest data&hellip;"
 msgstr ""
 
-#: src/olympia/stats/templates/stats/stats.html:142
-#: src/olympia/stats/templates/stats/reports/overview.html:25
-#: src/olympia/stats/templates/stats/reports/overview.html:37
+#: src/olympia/stats/templates/stats/stats.html:144 src/olympia/stats/templates/stats/reports/overview.html:25 src/olympia/stats/templates/stats/reports/overview.html:37
 #: src/olympia/stats/templates/stats/reports/overview.html:49
 msgid "No data available."
 msgstr ""
 
-#: src/olympia/stats/templates/stats/stats.html:177
+#: src/olympia/stats/templates/stats/stats.html:179
 msgid "This dashboard is currently <b>public</b>."
 msgstr ""
 
-#: src/olympia/stats/templates/stats/stats.html:179
+#: src/olympia/stats/templates/stats/stats.html:181
 msgid "Contribution stats are currently <b>private</b>."
 msgstr ""
 
-#: src/olympia/stats/templates/stats/stats.html:182
+#: src/olympia/stats/templates/stats/stats.html:184
 msgid "This dashboard is currently <b>private</b>."
 msgstr ""
 
-#: src/olympia/stats/templates/stats/stats.html:185
+#: src/olympia/stats/templates/stats/stats.html:187
 msgid "Change settings."
 msgstr ""
 
@@ -13116,9 +11205,8 @@ msgstr ""
 
 #: src/olympia/stats/templates/stats/reports/downloads.html:10
 msgid ""
-"<h2>How are downloads counted?</h2> <p> Download counts are updated every "
-"evening and only include original add-on downloads, not updates. Downloads "
-"can be broken down by the specific source referring the download. </p>"
+"<h2>How are downloads counted?</h2> <p> Download counts are updated every evening and only include original add-on downloads, not updates. Downloads can be broken down by the specific source "
+"referring the download. </p>"
 msgstr ""
 
 #: src/olympia/stats/templates/stats/reports/locales.html:3
@@ -13133,8 +11221,7 @@ msgstr ""
 msgid "<b>{0}</b> Downloads"
 msgstr ""
 
-#: src/olympia/stats/templates/stats/reports/overview.html:9
-#: src/olympia/stats/templates/stats/reports/overview.html:13
+#: src/olympia/stats/templates/stats/reports/overview.html:9 src/olympia/stats/templates/stats/reports/overview.html:13
 msgid "Loading..."
 msgstr ""
 
@@ -13185,19 +11272,11 @@ msgstr ""
 #: src/olympia/stats/templates/stats/reports/sources.html:10
 #, python-format
 msgid ""
-"<h2>Tracking external sources</h2> <p> If you link to your add-on's details "
-"page or directly to its file from an external site, such as your blog or "
-"website, you can append a parameter to be tracked as an additional download "
-"source on this page. For example, the following links would appear as "
-"sourced by your blog: <dl> <dt>Add-on Details Page</dt> "
-"<dd>https://addons.mozilla.org/addon/%(slug)s?src=<b>external-blog</b></dd> "
-"<dt>Direct File Link</dt> "
-"<dd>https://addons.mozilla.org/downloads/latest/%(id)s/addon-%(id)s-latest.xpi?src=<b"
-">external-blog</b></dd> </dl> <p> Only src parameters that begin with "
-"\"external-\" will be tracked, up to 61 additional characters. Any text "
-"after \"external-\" can be used to describe the source, such as \"external-"
-"blog\", \"external-sidebar\", \"external-campaign225\", etc. The following "
-"URL-safe characters are allowed: <code>a-z A-Z - . _ ~ %% +</code>"
+"<h2>Tracking external sources</h2> <p> If you link to your add-on's details page or directly to its file from an external site, such as your blog or website, you can append a parameter to be "
+"tracked as an additional download source on this page. For example, the following links would appear as sourced by your blog: <dl> <dt>Add-on Details Page</dt> <dd>https://addons.mozilla.org/addon/"
+"%(slug)s?src=<b>external-blog</b></dd> <dt>Direct File Link</dt> <dd>https://addons.mozilla.org/downloads/latest/%(id)s/addon-%(id)s-latest.xpi?src=<b>external-blog</b></dd> </dl> <p> Only src "
+"parameters that begin with \"external-\" will be tracked, up to 61 additional characters. Any text after \"external-\" can be used to describe the source, such as \"external-blog\", \"external-"
+"sidebar\", \"external-campaign225\", etc. The following URL-safe characters are allowed: <code>a-z A-Z - . _ ~ %% +</code>"
 msgstr ""
 
 #: src/olympia/stats/templates/stats/reports/statuses.html:3
@@ -13218,18 +11297,14 @@ msgstr ""
 
 #: src/olympia/stats/templates/stats/reports/usage.html:11
 msgid ""
-"<h2>What are daily users?</h2> <p> Themes installed from this site check for"
-" updates once per day. The total number of these update pings is known as "
-"Active Daily Users, or the total number of people using your theme by day. "
-"</p>"
+"<h2>What are daily users?</h2> <p> Themes installed from this site check for updates once per day. The total number of these update pings is known as Active Daily Users, or the total number of "
+"people using your theme by day. </p>"
 msgstr ""
 
 #: src/olympia/stats/templates/stats/reports/usage.html:20
 msgid ""
-"<h2>What are daily users?</h2> <p> Add-ons downloaded from this site check "
-"for updates once per day. The total number of these update pings is known as"
-" Active Daily Users. Daily users can be broken down by add-on version, "
-"operating system, add-on status, application, and locale. </p>"
+"<h2>What are daily users?</h2> <p> Add-ons downloaded from this site check for updates once per day. The total number of these update pings is known as Active Daily Users. Daily users can be broken "
+"down by add-on version, operating system, add-on status, application, and locale. </p>"
 msgstr ""
 
 #: src/olympia/stats/templates/stats/reports/users_created.html:3
@@ -13240,34 +11315,27 @@ msgstr ""
 msgid "Application versions by Date"
 msgstr ""
 
-#: src/olympia/templates/amo_footer.html:6
-#: src/olympia/templates/includes/lang_switcher.html:2
+#: src/olympia/templates/amo_footer.html:6 src/olympia/templates/includes/lang_switcher.html:2
 msgid "Other languages"
 msgstr ""
 
-#: src/olympia/templates/base.html:9 src/olympia/templates/impala/base.html:9
-#: src/olympia/templates/mobile/base_addons.html:9
+#: src/olympia/templates/base.html:9 src/olympia/templates/impala/base.html:9 src/olympia/templates/mobile/base_addons.html:9
 msgid "Mozilla Add-ons"
 msgstr ""
 
-#: src/olympia/templates/base.html:89
-#: src/olympia/templates/impala/base.html:78
+#: src/olympia/templates/base.html:89 src/olympia/templates/impala/base.html:78
 msgid "Find add-ons for other applications"
 msgstr ""
 
-#: src/olympia/templates/base.html:90
-#: src/olympia/templates/impala/base.html:78
+#: src/olympia/templates/base.html:90 src/olympia/templates/impala/base.html:78
 msgid "Other Applications"
 msgstr ""
 
-#: src/olympia/templates/base.html:141
-#: src/olympia/templates/impala/base.html:194
-msgid ""
-"To create your own collections, you must have a Mozilla Add-ons account."
+#: src/olympia/templates/base.html:141 src/olympia/templates/impala/base.html:194
+msgid "To create your own collections, you must have a Mozilla Add-ons account."
 msgstr ""
 
-#: src/olympia/templates/base.html:168
-#: src/olympia/templates/impala/base.html:215
+#: src/olympia/templates/base.html:168 src/olympia/templates/impala/base.html:215
 msgid "Footer logo"
 msgstr ""
 
@@ -13291,13 +11359,11 @@ msgstr ""
 msgid "get to know <b>add-ons</b>"
 msgstr ""
 
-#: src/olympia/templates/footer.html:4
-#: src/olympia/templates/menu_links.html:20
+#: src/olympia/templates/footer.html:4 src/olympia/templates/menu_links.html:20
 msgid "About"
 msgstr ""
 
-#: src/olympia/templates/footer.html:5
-#: src/olympia/templates/menu_links.html:32
+#: src/olympia/templates/footer.html:5 src/olympia/templates/menu_links.html:32
 msgid "Blog"
 msgstr ""
 
@@ -13373,9 +11439,7 @@ msgstr ""
 msgid "Contact Us"
 msgstr ""
 
-#: src/olympia/templates/user_login.html:22
-#: src/olympia/users/templates/users/edit.html:31
-#: src/olympia/users/templates/users/includes/navigation.html:12
+#: src/olympia/templates/user_login.html:22 src/olympia/users/templates/users/edit.html:31 src/olympia/users/templates/users/includes/navigation.html:12
 msgid "My Account"
 msgstr ""
 
@@ -13383,24 +11447,19 @@ msgstr ""
 msgid "Welcome, {0}"
 msgstr ""
 
-#: src/olympia/templates/user_login.html:41
-#: src/olympia/templates/impala/user_login.html:20
+#: src/olympia/templates/user_login.html:41 src/olympia/templates/impala/user_login.html:20
 #, python-format
 msgid "<a href=\"%(reg)s\">Register</a> or <a href=\"%(login)s\">Log in</a>"
 msgstr ""
 
 #: src/olympia/templates/impala/base.html:123
 #, python-format
-msgid ""
-"To try the thousands of add-ons available here, download <a "
-"href=\"%(url)s\">Mozilla Firefox</a>, a fast, free way to surf the Web!"
+msgid "To try the thousands of add-ons available here, download <a href=\"%(url)s\">Mozilla Firefox</a>, a fast, free way to surf the Web!"
 msgstr ""
 
 #: src/olympia/templates/impala/base.html:135
 #, python-format
-msgid ""
-"Add-ons is switching to Firefox Accounts for login. <a href=\"%(url)s\" "
-"class=\"fxa-login\">Sign in now to transfer your account.</a>"
+msgid "Add-ons is switching to Firefox Accounts for login. <a href=\"%(url)s\" class=\"fxa-login\">Sign in now to transfer your account.</a>"
 msgstr ""
 
 #. {0} is an application, such as Firefox.
@@ -13409,8 +11468,7 @@ msgid "Welcome to {0} Add-ons."
 msgstr ""
 
 #: src/olympia/templates/impala/base.html:148
-msgid ""
-"Choose from thousands of extra features and styles to make Firefox your own."
+msgid "Choose from thousands of extra features and styles to make Firefox your own."
 msgstr ""
 
 #: src/olympia/templates/impala/base.html:153
@@ -13430,8 +11488,7 @@ msgstr ""
 msgid "Android Add-ons"
 msgstr ""
 
-#: src/olympia/templates/includes/forms.html:2
-#: src/olympia/templates/includes/forms.html:6
+#: src/olympia/templates/includes/forms.html:2 src/olympia/templates/includes/forms.html:6
 msgid "required"
 msgstr ""
 
@@ -13476,15 +11533,11 @@ msgstr ""
 msgid "menu"
 msgstr ""
 
-#: src/olympia/templates/mobile/header_auth.html:7
-#: src/olympia/users/templates/users/register.html:41
-#: src/olympia/users/templates/users/register.html:89
+#: src/olympia/templates/mobile/header_auth.html:7 src/olympia/users/templates/users/register.html:41 src/olympia/users/templates/users/register.html:89
 msgid "Register"
 msgstr ""
 
-#: src/olympia/templates/mobile/header_auth.html:8
-#: src/olympia/users/templates/users/login_form.html:41
-#: src/olympia/users/templates/users/pwreset_complete.html:15
+#: src/olympia/templates/mobile/header_auth.html:8 src/olympia/users/templates/users/login_form.html:41 src/olympia/users/templates/users/pwreset_complete.html:15
 #: src/olympia/users/templates/users/mobile/login.html:56
 msgid "Log in"
 msgstr ""
@@ -13495,8 +11548,7 @@ msgstr ""
 msgid "Localize for: <a id=\"change-locale\" href=\"#\">%(dl)s</a>"
 msgstr ""
 
-#: src/olympia/translations/templates/translations/trans-menu.html:16
-#: src/olympia/translations/templates/translations/trans-menu.html:29
+#: src/olympia/translations/templates/translations/trans-menu.html:16 src/olympia/translations/templates/translations/trans-menu.html:29
 #, python-format
 msgid "%(title)s <em>&middot; %(lang)s</em>"
 msgstr ""
@@ -13511,9 +11563,7 @@ msgstr ""
 
 #. {0} is a language name, like 'French'
 #: src/olympia/translations/templates/translations/trans-menu.html:42
-msgid ""
-"You have unsaved changes in the <b>{0}</b> locale. Would you like to save "
-"your changes before switching locales?"
+msgid "You have unsaved changes in the <b>{0}</b> locale. Would you like to save your changes before switching locales?"
 msgstr ""
 
 #: src/olympia/translations/templates/translations/trans-menu.html:49
@@ -13522,9 +11572,7 @@ msgstr ""
 
 #. {0} is a language name, like 'French'
 #: src/olympia/translations/templates/translations/trans-menu.html:56
-msgid ""
-"Are you sure you want to remove all <b>{0}</b> translations? This cannot be "
-"undone."
+msgid "Are you sure you want to remove all <b>{0}</b> translations? This cannot be undone."
 msgstr ""
 
 #: src/olympia/translations/templates/translations/trans-menu.html:61
@@ -13546,20 +11594,14 @@ msgstr ""
 
 #: src/olympia/users/forms.py:90
 #, python-format
-msgid ""
-"As part of our new password policy, your password must be %s characters or "
-"more. Please update your password by <a href=\"%s\">issuing a password "
-"reset</a>."
+msgid "As part of our new password policy, your password must be %s characters or more. Please update your password by <a href=\"%s\">issuing a password reset</a>."
 msgstr ""
 
 #: src/olympia/users/forms.py:115
-msgid ""
-"You must recover your password through Firefox Accounts. Try logging in "
-"instead."
+msgid "You must recover your password through Firefox Accounts. Try logging in instead."
 msgstr ""
 
-#: src/olympia/users/forms.py:206
-#: src/olympia/users/templates/users/pwreset_confirm.html:24
+#: src/olympia/users/forms.py:206 src/olympia/users/templates/users/pwreset_confirm.html:24
 msgid "New password"
 msgstr ""
 
@@ -13572,9 +11614,7 @@ msgid "Usernames cannot contain only digits."
 msgstr ""
 
 #: src/olympia/users/forms.py:274
-msgid ""
-"Enter a valid username consisting of letters, numbers, underscores or "
-"hyphens."
+msgid "Enter a valid username consisting of letters, numbers, underscores or hyphens."
 msgstr ""
 
 #: src/olympia/users/forms.py:277
@@ -13585,33 +11625,24 @@ msgstr ""
 msgid "This username is already in use."
 msgstr ""
 
-#: src/olympia/users/forms.py:296
-#: src/olympia/users/templates/users/edit.html:107
+#: src/olympia/users/forms.py:296 src/olympia/users/templates/users/edit.html:107
 msgid "Display Name"
 msgstr ""
 
-#: src/olympia/users/forms.py:298
-#: src/olympia/users/templates/users/edit.html:112
-#: src/olympia/users/templates/users/vcard.html:10
+#: src/olympia/users/forms.py:298 src/olympia/users/templates/users/edit.html:112 src/olympia/users/templates/users/vcard.html:10
 msgid "Location"
 msgstr ""
 
-#: src/olympia/users/forms.py:300
-#: src/olympia/users/templates/users/edit.html:117
-#: src/olympia/users/templates/users/vcard.html:16
+#: src/olympia/users/forms.py:300 src/olympia/users/templates/users/edit.html:117 src/olympia/users/templates/users/vcard.html:16
 msgid "Occupation"
 msgstr ""
 
 #: src/olympia/users/forms.py:329
-msgid ""
-"This URL has an invalid format. Valid URLs look like "
-"http://example.com/my_page."
+msgid "This URL has an invalid format. Valid URLs look like http://example.com/my_page."
 msgstr ""
 
 #: src/olympia/users/forms.py:337
-msgid ""
-"Please use an email address from a different provider to complete your "
-"registration."
+msgid "Please use an email address from a different provider to complete your registration."
 msgstr ""
 
 #: src/olympia/users/forms.py:345
@@ -13622,13 +11653,11 @@ msgstr ""
 msgid "The passwords did not match."
 msgstr ""
 
-#: src/olympia/users/forms.py:377
-#: src/olympia/users/templates/users/edit.html:128
+#: src/olympia/users/forms.py:377 src/olympia/users/templates/users/edit.html:128
 msgid "Profile Photo"
 msgstr ""
 
-#: src/olympia/users/forms.py:385
-#: src/olympia/users/templates/users/edit.html:142
+#: src/olympia/users/forms.py:385 src/olympia/users/templates/users/edit.html:142
 msgid "Default locale"
 msgstr ""
 
@@ -13645,9 +11674,7 @@ msgid "Email cannot be changed."
 msgstr ""
 
 #: src/olympia/users/forms.py:541
-msgid ""
-"To anonymize, enter a reason for the change but do not change any other "
-"field."
+msgid "To anonymize, enter a reason for the change but do not change any other field."
 msgstr ""
 
 #: src/olympia/users/forms.py:587
@@ -13754,8 +11781,7 @@ msgid "Mozilla needs to contact me about my individual app"
 msgstr ""
 
 #: src/olympia/users/notifications.py:139
-msgid ""
-"Mozilla wants to contact me about relevant App Developer news and surveys"
+msgid "Mozilla wants to contact me about relevant App Developer news and surveys"
 msgstr ""
 
 #: src/olympia/users/notifications.py:150
@@ -13783,10 +11809,7 @@ msgid "Successfully verified!"
 msgstr ""
 
 #: src/olympia/users/views.py:132
-msgid ""
-"An email has been sent to your address to confirm your account. Before you "
-"can log in, you have to activate your account by clicking on the link "
-"provided in this email."
+msgid "An email has been sent to your address to confirm your account. Before you can log in, you have to activate your account by clicking on the link provided in this email."
 msgstr ""
 
 #: src/olympia/users/views.py:136 src/olympia/users/views.py:619
@@ -13811,9 +11834,8 @@ msgstr ""
 
 #: src/olympia/users/views.py:197
 msgid ""
-"An email has been sent to {0} to confirm your new email address. For the "
-"change to take effect, you need to click on the link provided in this email."
-" Until then, you can keep logging in with your current email address."
+"An email has been sent to {0} to confirm your new email address. For the change to take effect, you need to click on the link provided in this email. Until then, you can keep logging in with your "
+"current email address."
 msgstr ""
 
 #: src/olympia/users/views.py:210
@@ -13826,13 +11848,11 @@ msgid "Errors Found"
 msgstr ""
 
 #: src/olympia/users/views.py:225
-msgid ""
-"There were errors in the changes you made. Please correct them and resubmit."
+msgid "There were errors in the changes you made. Please correct them and resubmit."
 msgstr ""
 
 #: src/olympia/users/views.py:273
-msgid ""
-"We're sorry, but you are not eligible to request a t-shirt at this time."
+msgid "We're sorry, but you are not eligible to request a t-shirt at this time."
 msgstr ""
 
 #: src/olympia/users/views.py:329
@@ -13848,18 +11868,14 @@ msgid "Wrong email address or password!"
 msgstr ""
 
 #: src/olympia/users/views.py:434
-msgid ""
-"A link to activate your user account was sent by email to your address {0}. "
-"You have to click it before you can log in."
+msgid "A link to activate your user account was sent by email to your address {0}. You have to click it before you can log in."
 msgstr ""
 
 #: src/olympia/users/views.py:439
 #, python-format
 msgid ""
-"If you did not receive the confirmation email, make sure your email service "
-"did not mark it as \"junk mail\" or \"spam\". If you need to, you can have "
-"us <a href=\"%s\">resend the confirmation message</a> to your email address "
-"mentioned above."
+"If you did not receive the confirmation email, make sure your email service did not mark it as \"junk mail\" or \"spam\". If you need to, you can have us <a href=\"%s\">resend the confirmation "
+"message</a> to your email address mentioned above."
 msgstr ""
 
 #: src/olympia/users/views.py:444
@@ -13879,10 +11895,7 @@ msgid "Congratulations! Your user account was successfully created."
 msgstr ""
 
 #: src/olympia/users/views.py:615
-msgid ""
-"An email has been sent to your address {0} to confirm your account. Before "
-"you can log in, you have to activate your account by clicking on the link "
-"provided in this email."
+msgid "An email has been sent to your address {0} to confirm your account. Before you can log in, you have to activate your account by clicking on the link provided in this email."
 msgstr ""
 
 #: src/olympia/users/views.py:639
@@ -13901,24 +11914,19 @@ msgstr ""
 msgid "new"
 msgstr ""
 
-#: src/olympia/users/templates/users/delete.html:4
-#: src/olympia/users/templates/users/delete.html:10
+#: src/olympia/users/templates/users/delete.html:4 src/olympia/users/templates/users/delete.html:10
 msgid "Delete User Account"
 msgstr ""
 
 #: src/olympia/users/templates/users/delete.html:14
 #, python-format
 msgid ""
-"You cannot delete your account if you are listed as an <a href=\"%(link)s\">"
-" author of any add-ons</a>. To delete your account, please have another "
-"person in your development group delete you from the list of authors for "
-"your add-ons. Afterwards you will be able to delete your account here."
+"You cannot delete your account if you are listed as an <a href=\"%(link)s\"> author of any add-ons</a>. To delete your account, please have another person in your development group delete you from "
+"the list of authors for your add-ons. Afterwards you will be able to delete your account here."
 msgstr ""
 
 #: src/olympia/users/templates/users/delete.html:29
-msgid ""
-"By clicking \"delete\" your account is going to be <strong>permanently "
-"removed</strong>. That means:"
+msgid "By clicking \"delete\" your account is going to be <strong>permanently removed</strong>. That means:"
 msgstr ""
 
 #: src/olympia/users/templates/users/delete.html:35
@@ -13927,9 +11935,7 @@ msgid "You will not be able to log into %(site)s anymore."
 msgstr ""
 
 #: src/olympia/users/templates/users/delete.html:40
-msgid ""
-"Your reviews and ratings will not be deleted, but they will no longer be "
-"associated with you."
+msgid "Your reviews and ratings will not be deleted, but they will no longer be associated with you."
 msgstr ""
 
 #: src/olympia/users/templates/users/delete.html:46
@@ -13944,8 +11950,7 @@ msgstr ""
 msgid "Delete my user account now"
 msgstr ""
 
-#: src/olympia/users/templates/users/delete_photo.html:3
-#: src/olympia/users/templates/users/delete_photo.html:9
+#: src/olympia/users/templates/users/delete_photo.html:3 src/olympia/users/templates/users/delete_photo.html:9
 msgid "Delete User Photo"
 msgstr ""
 
@@ -13958,23 +11963,18 @@ msgid "Please set your display name"
 msgstr ""
 
 #: src/olympia/users/templates/users/edit.html:21
-msgid ""
-"Please set your display name or username to complete the registration "
-"process."
+msgid "Please set your display name or username to complete the registration process."
 msgstr ""
 
 #: src/olympia/users/templates/users/edit.html:33
 msgid "Manage basic account information, such as username and email address."
 msgstr ""
 
-#: src/olympia/users/templates/users/edit.html:39
-#: src/olympia/users/templates/users/register.html:47
+#: src/olympia/users/templates/users/edit.html:39 src/olympia/users/templates/users/register.html:47
 msgid "Username"
 msgstr ""
 
-#: src/olympia/users/templates/users/edit.html:45
-#: src/olympia/users/templates/users/pwreset_request.html:21
-#: src/olympia/users/templates/users/register.html:62
+#: src/olympia/users/templates/users/edit.html:45 src/olympia/users/templates/users/pwreset_request.html:21 src/olympia/users/templates/users/register.html:62
 msgid "Email Address"
 msgstr ""
 
@@ -13986,18 +11986,14 @@ msgstr ""
 msgid "Change Password"
 msgstr ""
 
-#: src/olympia/users/templates/users/edit.html:68
-#: src/olympia/users/templates/users/login_form.html:22
-#: src/olympia/users/templates/users/register.html:67
+#: src/olympia/users/templates/users/edit.html:68 src/olympia/users/templates/users/login_form.html:22 src/olympia/users/templates/users/register.html:67
 #: src/olympia/users/templates/users/mobile/login.html:37
 msgid "Password"
 msgstr ""
 
 #: src/olympia/users/templates/users/edit.html:70
 #, python-format
-msgid ""
-"Change your password. If you forgot your password, you can <a "
-"href=\"%(reset_url)s\">use the reset form</a>."
+msgid "Change your password. If you forgot your password, you can <a href=\"%(reset_url)s\">use the reset form</a>."
 msgstr ""
 
 #: src/olympia/users/templates/users/edit.html:76
@@ -14017,9 +12013,7 @@ msgid "Profile"
 msgstr ""
 
 #: src/olympia/users/templates/users/edit.html:100
-msgid ""
-"Give us a bit more information about yourself. All these fields are "
-"optional, but they'll help other users get to know you better."
+msgid "Give us a bit more information about yourself. All these fields are optional, but they'll help other users get to know you better."
 msgstr ""
 
 #: src/olympia/users/templates/users/edit.html:124
@@ -14035,15 +12029,11 @@ msgid "Delete current photo"
 msgstr ""
 
 #: src/olympia/users/templates/users/edit.html:144
-msgid ""
-"This is the default locale used to display information about you (like your "
-"description)."
+msgid "This is the default locale used to display information about you (like your description)."
 msgstr ""
 
 #: src/olympia/users/templates/users/edit.html:152
-msgid ""
-"Introduce yourself to the community, if you like! This text will appear "
-"publicly on your user info page."
+msgid "Introduce yourself to the community, if you like! This text will appear publicly on your user info page."
 msgstr ""
 
 #: src/olympia/users/templates/users/edit.html:161
@@ -14071,15 +12061,11 @@ msgid "Notifications"
 msgstr ""
 
 #: src/olympia/users/templates/users/edit.html:195
-msgid ""
-"From time to time, Mozilla may send you email about upcoming releases and "
-"add-on events. Please select the topics you are interested in."
+msgid "From time to time, Mozilla may send you email about upcoming releases and add-on events. Please select the topics you are interested in."
 msgstr ""
 
 #: src/olympia/users/templates/users/edit.html:205
-msgid ""
-"Mozilla reserves the right to contact you individually about specific "
-"concerns with your hosted add-ons."
+msgid "Mozilla reserves the right to contact you individually about specific concerns with your hosted add-ons."
 msgstr ""
 
 #: src/olympia/users/templates/users/edit.html:215
@@ -14102,60 +12088,48 @@ msgstr ""
 msgid "all"
 msgstr ""
 
-#: src/olympia/users/templates/users/fxa_migration.html:3
-#: src/olympia/users/templates/users/fxa_migration.html:11
-#: src/olympia/users/templates/users/mobile/fxa_migration.html:3
+#: src/olympia/users/templates/users/fxa_migration.html:3 src/olympia/users/templates/users/fxa_migration.html:11 src/olympia/users/templates/users/mobile/fxa_migration.html:3
 #: src/olympia/users/templates/users/mobile/fxa_migration.html:8
 msgid "Migrate to Firefox Accounts"
 msgstr ""
 
 #: src/olympia/users/templates/users/fxa_migration_prompt_content.html:3
-msgid ""
-"Mozilla Add-ons has transitioned to Firefox Accounts for login. Continue to "
-"complete the simple upgrade process."
+msgid "Mozilla Add-ons has transitioned to Firefox Accounts for login. Continue to complete the simple upgrade process."
 msgstr ""
 
 #: src/olympia/users/templates/users/fxa_migration_prompt_content.html:14
 msgid "Skip"
 msgstr ""
 
-#: src/olympia/users/templates/users/login.html:3
-#: src/olympia/users/templates/users/mobile/login.html:3
+#: src/olympia/users/templates/users/login.html:3 src/olympia/users/templates/users/mobile/login.html:3
 msgid "User Login"
 msgstr ""
 
-#: src/olympia/users/templates/users/login.html:13
-#: src/olympia/users/templates/users/mobile/login.html:21
+#: src/olympia/users/templates/users/login.html:13 src/olympia/users/templates/users/mobile/login.html:21
 msgid "Enter your email"
 msgstr ""
 
-#: src/olympia/users/templates/users/login.html:15
-#: src/olympia/users/templates/users/mobile/login.html:23
+#: src/olympia/users/templates/users/login.html:15 src/olympia/users/templates/users/mobile/login.html:23
 msgid "Log In"
 msgstr ""
 
-#: src/olympia/users/templates/users/login_form.html:17
-#: src/olympia/users/templates/users/mobile/login.html:32
+#: src/olympia/users/templates/users/login_form.html:17 src/olympia/users/templates/users/mobile/login.html:32
 msgid "Email address"
 msgstr ""
 
-#: src/olympia/users/templates/users/login_form.html:30
-#: src/olympia/users/templates/users/mobile/login.html:44
+#: src/olympia/users/templates/users/login_form.html:30 src/olympia/users/templates/users/mobile/login.html:44
 msgid "Remember me on this device"
 msgstr ""
 
-#: src/olympia/users/templates/users/login_help.html:3
-#: src/olympia/users/templates/users/mobile/login.html:63
+#: src/olympia/users/templates/users/login_help.html:3 src/olympia/users/templates/users/mobile/login.html:63
 msgid "Login Problems?"
 msgstr ""
 
-#: src/olympia/users/templates/users/login_help.html:5
-#: src/olympia/users/templates/users/mobile/login.html:65
+#: src/olympia/users/templates/users/login_help.html:5 src/olympia/users/templates/users/mobile/login.html:65
 msgid "I don't have an account."
 msgstr ""
 
-#: src/olympia/users/templates/users/login_help.html:6
-#: src/olympia/users/templates/users/mobile/login.html:66
+#: src/olympia/users/templates/users/login_help.html:6 src/olympia/users/templates/users/mobile/login.html:66
 msgid "I forgot my password."
 msgstr ""
 
@@ -14164,15 +12138,9 @@ msgstr ""
 msgid "You are now logged in as <strong>%(user_email)s</strong>!"
 msgstr ""
 
-#: src/olympia/users/templates/users/newpw_sent.html:3
-#: src/olympia/users/templates/users/newpw_sent.html:8
-#: src/olympia/users/templates/users/pwreset_complete.html:3
-#: src/olympia/users/templates/users/pwreset_confirm.html:4
-#: src/olympia/users/templates/users/pwreset_confirm.html:18
-#: src/olympia/users/templates/users/pwreset_request.html:4
-#: src/olympia/users/templates/users/pwreset_request.html:10
-#: src/olympia/users/templates/users/pwreset_sent.html:3
-#: src/olympia/users/templates/users/pwreset_sent.html:8
+#: src/olympia/users/templates/users/newpw_sent.html:3 src/olympia/users/templates/users/newpw_sent.html:8 src/olympia/users/templates/users/pwreset_complete.html:3
+#: src/olympia/users/templates/users/pwreset_confirm.html:4 src/olympia/users/templates/users/pwreset_confirm.html:18 src/olympia/users/templates/users/pwreset_request.html:4
+#: src/olympia/users/templates/users/pwreset_request.html:10 src/olympia/users/templates/users/pwreset_sent.html:3 src/olympia/users/templates/users/pwreset_sent.html:8
 msgid "Password Reset"
 msgstr ""
 
@@ -14188,8 +12156,7 @@ msgstr ""
 msgid "Manage user"
 msgstr ""
 
-#: src/olympia/users/templates/users/profile.html:18
-#: src/olympia/users/templates/users/report_abuse_full.html:9
+#: src/olympia/users/templates/users/profile.html:18 src/olympia/users/templates/users/report_abuse_full.html:9
 msgid "Report user"
 msgstr ""
 
@@ -14249,32 +12216,24 @@ msgstr ""
 msgid "Password successfully reset."
 msgstr ""
 
-#: src/olympia/users/templates/users/pwreset_confirm.html:13
-#: src/olympia/users/templates/users/pwreset_confirm.html:46
+#: src/olympia/users/templates/users/pwreset_confirm.html:13 src/olympia/users/templates/users/pwreset_confirm.html:46
 msgid "Password reset unsuccessful"
 msgstr ""
 
 #: src/olympia/users/templates/users/pwreset_confirm.html:14
-msgid ""
-"You have migrated to Firefox Accounts. You can no longer change your "
-"password here."
+msgid "You have migrated to Firefox Accounts. You can no longer change your password here."
 msgstr ""
 
-#: src/olympia/users/templates/users/pwreset_confirm.html:31
-#: src/olympia/users/templates/users/register.html:72
+#: src/olympia/users/templates/users/pwreset_confirm.html:31 src/olympia/users/templates/users/register.html:72
 msgid "Confirm password"
 msgstr ""
 
 #: src/olympia/users/templates/users/pwreset_confirm.html:47
-msgid ""
-"The password reset link was invalid, possibly because it has already been "
-"used. Please request a new password reset."
+msgid "The password reset link was invalid, possibly because it has already been used. Please request a new password reset."
 msgstr ""
 
 #: src/olympia/users/templates/users/pwreset_request.html:15
-msgid ""
-"Forgotten your password? Enter your e-mail address below, and we'll e-mail "
-"instructions for setting a new one."
+msgid "Forgotten your password? Enter your e-mail address below, and we'll e-mail instructions for setting a new one."
 msgstr ""
 
 #: src/olympia/users/templates/users/pwreset_request.html:25
@@ -14283,9 +12242,7 @@ msgstr ""
 
 #: src/olympia/users/templates/users/pwreset_sent.html:10
 msgid ""
-"An email has been sent to the requested account with further information. If"
-" you do not receive an email then please confirm you have entered the same "
-"email address used during account registration."
+"An email has been sent to the requested account with further information. If you do not receive an email then please confirm you have entered the same email address used during account registration."
 msgstr ""
 
 #: src/olympia/users/templates/users/register.html:4
@@ -14297,9 +12254,7 @@ msgid "Why register?"
 msgstr ""
 
 #: src/olympia/users/templates/users/register.html:14
-msgid ""
-"Registration on AMO is <strong>not required</strong> if you simply want to "
-"download and install public add-ons."
+msgid "Registration on AMO is <strong>not required</strong> if you simply want to download and install public add-ons."
 msgstr ""
 
 #: src/olympia/users/templates/users/register.html:16
@@ -14311,30 +12266,20 @@ msgid "You want to submit reviews for add-ons"
 msgstr ""
 
 #: src/olympia/users/templates/users/register.html:19
-msgid ""
-"You want to keep track of your favorite add-on collections or create one "
-"yourself"
+msgid "You want to keep track of your favorite add-on collections or create one yourself"
 msgstr ""
 
 #: src/olympia/users/templates/users/register.html:20
-msgid ""
-"You are an add-on developer and want to upload your add-on for hosting on "
-"AMO"
+msgid "You are an add-on developer and want to upload your add-on for hosting on AMO"
 msgstr ""
 
 #: src/olympia/users/templates/users/register.html:23
-msgid ""
-"Upon successful registration, you will be sent a confirmation email to the "
-"address you provided. Please follow the instructions there to confirm your "
-"account."
+msgid "Upon successful registration, you will be sent a confirmation email to the address you provided. Please follow the instructions there to confirm your account."
 msgstr ""
 
 #: src/olympia/users/templates/users/register.html:30
 #, python-format
-msgid ""
-"If you like, you can read our <a href=\"%(legal)s\" title=\"Legal "
-"Notices\">Legal Notices</a> and <a href=\"%(privacy)s\" title=\"Privacy "
-"Policy\">Privacy Policy</a>."
+msgid "If you like, you can read our <a href=\"%(legal)s\" title=\"Legal Notices\">Legal Notices</a> and <a href=\"%(privacy)s\" title=\"Privacy Policy\">Privacy Policy</a>."
 msgstr ""
 
 #: src/olympia/users/templates/users/register.html:52
@@ -14342,9 +12287,7 @@ msgid "Display name"
 msgstr ""
 
 #: src/olympia/users/templates/users/report_abuse.html:7
-msgid ""
-"Please describe why you are reporting this user, such as for spam or an "
-"inappropriate picture."
+msgid "Please describe why you are reporting this user, such as for spam or an inappropriate picture."
 msgstr ""
 
 #: src/olympia/users/templates/users/report_abuse_full.html:3
@@ -14359,32 +12302,24 @@ msgstr ""
 msgid "Special Edition Add-on Creator T-shirt"
 msgstr ""
 
-#: src/olympia/users/templates/users/t-shirt.html:14
-#: src/olympia/users/templates/users/t-shirt.html:120
+#: src/olympia/users/templates/users/t-shirt.html:14 src/olympia/users/templates/users/t-shirt.html:120
 msgid "Note:"
 msgstr ""
 
 #: src/olympia/users/templates/users/t-shirt.html:15
-msgid ""
-"You have already submitted a request for a t-shirt. You may re-submit this "
-"form to update your information, but you will only receive one shirt."
+msgid "You have already submitted a request for a t-shirt. You may re-submit this form to update your information, but you will only receive one shirt."
 msgstr ""
 
 #: src/olympia/users/templates/users/t-shirt.html:26
-msgid ""
-"Thank you for helping to make Firefox the most extensible browser available!"
+msgid "Thank you for helping to make Firefox the most extensible browser available!"
 msgstr ""
 
 #: src/olympia/users/templates/users/t-shirt.html:33
-msgid ""
-"As a thank you gift, we'd like to send you a special-edition, community-"
-"designed t-shirt. To receive your shirt, please fill out the form below."
+msgid "As a thank you gift, we'd like to send you a special-edition, community-designed t-shirt. To receive your shirt, please fill out the form below."
 msgstr ""
 
 #: src/olympia/users/templates/users/t-shirt.html:41
-msgid ""
-"Your contact information will only be used by Mozilla to ship this special "
-"edition t-shirt."
+msgid "Your contact information will only be used by Mozilla to ship this special edition t-shirt."
 msgstr ""
 
 #: src/olympia/users/templates/users/t-shirt.html:60
@@ -14441,16 +12376,12 @@ msgstr ""
 
 #: src/olympia/users/templates/users/t-shirt.html:137
 msgid ""
-"We're sorry, but in order to qualify for our special edition t-shirt, you "
-"must be an add-on developer with at least one listed add-on, one unlisted "
-"but signed add-on, or any number of background themes with a combined total "
-"of 10,000 average daily users."
+"We're sorry, but in order to qualify for our special edition t-shirt, you must be an add-on developer with at least one listed add-on, one unlisted but signed add-on, or any number of background "
+"themes with a combined total of 10,000 average daily users."
 msgstr ""
 
 #: src/olympia/users/templates/users/tougher_password.html:2
-msgid ""
-"For your account a password must contain at least 8 characters including "
-"letters and numbers."
+msgid "For your account a password must contain at least 8 characters including letters and numbers."
 msgstr ""
 
 #: src/olympia/users/templates/users/unsubscribe.html:2
@@ -14463,9 +12394,7 @@ msgstr ""
 
 #: src/olympia/users/templates/users/unsubscribe.html:10
 #, python-format
-msgid ""
-"The email address <strong>%(email)s</strong> will no longer get messages "
-"when:"
+msgid "The email address <strong>%(email)s</strong> will no longer get messages when:"
 msgstr ""
 
 #: src/olympia/users/templates/users/unsubscribe.html:20
@@ -14486,10 +12415,7 @@ msgstr ""
 
 #: src/olympia/users/templates/users/unsubscribe.html:30
 #, python-format
-msgid ""
-"Unfortunately, we weren't able to unsubscribe you. The link you clicked is "
-"invalid. However, you can unsubscribe still unsubscribe on your <a "
-"href=\"%(edit_url)s\">edit profile page</a>."
+msgid "Unfortunately, we weren't able to unsubscribe you. The link you clicked is invalid. However, you can unsubscribe still unsubscribe on your <a href=\"%(edit_url)s\">edit profile page</a>."
 msgstr ""
 
 #: src/olympia/users/templates/users/vcard.html:2
@@ -14596,17 +12522,13 @@ msgstr[1] ""
 msgstr[2] ""
 msgstr[3] ""
 
-#: src/olympia/versions/templates/versions/version_list.html:35
-#: src/olympia/versions/templates/versions/mobile/version_list.html:14
+#: src/olympia/versions/templates/versions/version_list.html:35 src/olympia/versions/templates/versions/mobile/version_list.html:14
 msgid "Be careful with old versions!"
 msgstr ""
 
-#: src/olympia/versions/templates/versions/version_list.html:36
-#: src/olympia/versions/templates/versions/mobile/version_list.html:15
+#: src/olympia/versions/templates/versions/version_list.html:36 src/olympia/versions/templates/versions/mobile/version_list.html:15
 #, python-format
-msgid ""
-"These versions are displayed for reference and testing purposes. You should "
-"always use the <a href=\"%(url)s\">latest version</a> of an add-on."
+msgid "These versions are displayed for reference and testing purposes. You should always use the <a href=\"%(url)s\">latest version</a> of an add-on."
 msgstr ""
 
 #: src/olympia/versions/templates/versions/mobile/version.html:4
@@ -14636,4 +12558,8 @@ msgstr ""
 
 #: src/olympia/zadmin/forms.py:105
 msgid "Log emails instead of sending"
+msgstr ""
+
+#: src/olympia/zadmin/forms.py:215
+msgid "Deleted versions can`t be changed."
 msgstr ""

--- a/locale/hsb/LC_MESSAGES/djangojs.po
+++ b/locale/hsb/LC_MESSAGES/djangojs.po
@@ -1,125 +1,92 @@
-# 
+#
 #, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT 1.0\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2016-04-11 14:21+0000\n"
+"POT-Creation-Date: 2016-04-18 15:40+0000\n"
 "PO-Revision-Date: 2016-04-16 19:38+0000\n"
 "Last-Translator: Michael Wolf <milupo@sorbzilla.de>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
 "Language: hsb\n"
 "MIME-Version: 1.0\n"
-"Content-Type: text/plain; charset=utf-8\n"
+"Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=4; plural=(n%100==1 ? 0 : n%100==2 ? 1 : n%100==3 || n%100==4 ? 2 : 3);\n"
 "Generated-By: Babel 2.2.0\n"
 "X-Generator: Pontoon\n"
 
-#: static/js/common-all.js:1426 static/js/impala-all.js:1511
-#: static/js/zamboni/discovery-all.js:12598 static/js/zamboni/init.js:28
-#: static/js/zamboni/mobile-all.js:14945
-msgid ""
-"This feature is temporarily disabled while we perform website maintenance. "
-"Please check back a little later."
-msgstr ""
-"Tuta funkcija je so nachwilu znjemóžnjena, mjeztym zo wothladowanske dźěła "
-"na websydle přewjedźemy. Prošu spytajće tróšku pozdźišo hišće raz."
+#: static/js/common-all.js:1426 static/js/impala-all.js:1511 static/js/zamboni/discovery-all.js:12598 static/js/zamboni/init.js:28 static/js/zamboni/mobile-all.js:14945
+msgid "This feature is temporarily disabled while we perform website maintenance. Please check back a little later."
+msgstr "Tuta funkcija je so nachwilu znjemóžnjena, mjeztym zo wothladowanske dźěła na websydle přewjedźemy. Prošu spytajće tróšku pozdźišo hišće raz."
 
 #. L10n: {0} is an app name like Firefox.
-#: static/js/common-all.js:1837 static/js/impala-all.js:1922
-#: static/js/zamboni/buttons.js:73 static/js/zamboni/discovery-all.js:13108
+#: static/js/common-all.js:1837 static/js/impala-all.js:1922 static/js/zamboni/buttons.js:73 static/js/zamboni/discovery-all.js:13108
 msgid "Accept and Install"
 msgstr "Akceptować a instalować"
 
-#: static/js/common-all.js:1837 static/js/impala-all.js:1922
-#: static/js/zamboni/buttons.js:73 static/js/zamboni/discovery-all.js:13108
+#: static/js/common-all.js:1837 static/js/impala-all.js:1922 static/js/zamboni/buttons.js:73 static/js/zamboni/discovery-all.js:13108
 msgid "Add to {0}"
 msgstr "K {0} přidać"
 
-#: static/js/common-all.js:1842 static/js/impala-all.js:1927
-#: static/js/zamboni/buttons.js:78 static/js/zamboni/discovery-all.js:13113
+#: static/js/common-all.js:1842 static/js/impala-all.js:1927 static/js/zamboni/buttons.js:78 static/js/zamboni/discovery-all.js:13113
 msgid "Download Now"
 msgstr "Nětko sćahnyć"
 
-#: static/js/common-all.js:1883 static/js/impala-all.js:1968
-#: static/js/zamboni/buttons.js:119 static/js/zamboni/discovery-all.js:13154
+#: static/js/common-all.js:1883 static/js/impala-all.js:1968 static/js/zamboni/buttons.js:119 static/js/zamboni/discovery-all.js:13154
 msgid "Add-on has not been updated to support default-to-compatible."
-msgstr ""
-"Přidatk njeje so zaktualizował, zo byšće standardnu kompatibelnosć podpěrał."
+msgstr "Přidatk njeje so zaktualizował, zo byšće standardnu kompatibelnosć podpěrał."
 
-#: static/js/common-all.js:1888 static/js/impala-all.js:1973
-#: static/js/zamboni/buttons.js:124 static/js/zamboni/discovery-all.js:13159
+#: static/js/common-all.js:1888 static/js/impala-all.js:1973 static/js/zamboni/buttons.js:124 static/js/zamboni/discovery-all.js:13159
 msgid "You need to be using Firefox 10.0 or higher."
 msgstr "Dyrbiće Firefox 10.0 abo nowši wužiwać."
 
-#: static/js/common-all.js:1900 static/js/impala-all.js:1985
-#: static/js/zamboni/buttons.js:136 static/js/zamboni/discovery-all.js:13171
-msgid ""
-"Mozilla has marked this version as incompatible with your Firefox version."
-msgstr ""
-"Mozilla je tutu wersiju jako z wašej wersiju Firefox kompatibelnu "
-"markěrował."
+#: static/js/common-all.js:1900 static/js/impala-all.js:1985 static/js/zamboni/buttons.js:136 static/js/zamboni/discovery-all.js:13171
+msgid "Mozilla has marked this version as incompatible with your Firefox version."
+msgstr "Mozilla je tutu wersiju jako z wašej wersiju Firefox kompatibelnu markěrował."
 
 #. L10n: {0} is an platform like Windows or Linux.
-#: static/js/common-all.js:1981 static/js/impala-all.js:2066
-#: static/js/zamboni/buttons.js:217 static/js/zamboni/discovery-all.js:13252
+#: static/js/common-all.js:1981 static/js/impala-all.js:2066 static/js/zamboni/buttons.js:217 static/js/zamboni/discovery-all.js:13252
 msgid "Install for {0} anyway"
 msgstr "Najebać toho za {0} instalować"
 
-#: static/js/common-all.js:1981 static/js/impala-all.js:2066
-#: static/js/zamboni/buttons.js:217 static/js/zamboni/discovery-all.js:13252
+#: static/js/common-all.js:1981 static/js/impala-all.js:2066 static/js/zamboni/buttons.js:217 static/js/zamboni/discovery-all.js:13252
 msgid "Download for {0} anyway"
 msgstr "Najebać toho za {0} sćahnyć"
 
-#: static/js/common-all.js:2038 static/js/impala-all.js:2123
-#: static/js/zamboni/buttons.js:274 static/js/zamboni/discovery-all.js:13309
+#: static/js/common-all.js:2038 static/js/impala-all.js:2123 static/js/zamboni/buttons.js:274 static/js/zamboni/discovery-all.js:13309
 msgid "Not available for your platform"
 msgstr "Njeje za wašu platformu k dispoziciji"
 
 #. L10n: {0} is an app name, {1} is the app version.
-#: static/js/common-all.js:2049 static/js/common-all.js:2086
-#: static/js/impala-all.js:2134 static/js/impala-all.js:2171
-#: static/js/zamboni/buttons.js:285 static/js/zamboni/buttons.js:322
-#: static/js/zamboni/discovery-all.js:13320
-#: static/js/zamboni/discovery-all.js:13357
+#: static/js/common-all.js:2049 static/js/common-all.js:2086 static/js/impala-all.js:2134 static/js/impala-all.js:2171 static/js/zamboni/buttons.js:286 static/js/zamboni/buttons.js:324
+#: static/js/zamboni/discovery-all.js:13320 static/js/zamboni/discovery-all.js:13357
 msgid "Not available for {0} {1}"
 msgstr "Njeje za {0} {1} k dispoziciji"
 
-#: static/js/common-all.js:2112 static/js/impala-all.js:2197
-#: static/js/zamboni/buttons.js:348 static/js/zamboni/discovery-all.js:13383
+#: static/js/common-all.js:2112 static/js/impala-all.js:2197 static/js/zamboni/buttons.js:351 static/js/zamboni/discovery-all.js:13383
 msgid "Works with {app} {min} - {max}"
 msgstr "Funguje z {app} {min} - {max}"
 
-#: static/js/common-all.js:2114 static/js/impala-all.js:2199
-#: static/js/zamboni/buttons.js:350 static/js/zamboni/discovery-all.js:13385
+#: static/js/common-all.js:2114 static/js/impala-all.js:2199 static/js/zamboni/buttons.js:353 static/js/zamboni/discovery-all.js:13385
 msgid "View other versions"
 msgstr "Druhe wersije pokazać"
 
-#: static/js/common-all.js:2162 static/js/impala-all.js:2247
-#: static/js/zamboni/buttons.js:398 static/js/zamboni/discovery-all.js:13433
+#: static/js/common-all.js:2162 static/js/impala-all.js:2247 static/js/zamboni/buttons.js:401 static/js/zamboni/discovery-all.js:13433
 msgid "Only with Firefox — Get Firefox Now!"
 msgstr "Jenož z Firefox – Wobstarajće sej nětko Firefox!"
 
-#: static/js/common-all.js:2278 static/js/impala-all.js:2363
-#: static/js/zamboni/buttons.js:514 static/js/zamboni/discovery-all.js:13549
-#: static/js/zamboni/mobile-all.js:15177
+#: static/js/common-all.js:2278 static/js/impala-all.js:2363 static/js/zamboni/buttons.js:517 static/js/zamboni/discovery-all.js:13549 static/js/zamboni/mobile-all.js:15177
 #: static/js/zamboni/mobile/buttons.js:43
-msgid ""
-"Sorry, you need a Mozilla-based browser (such as Firefox) to install a "
-"search plugin."
-msgstr ""
-"Bohužel trjebaće wobhladowak Mozilla (na přikład Firefox), zo byšće pytanski"
-" tykač instalował."
+msgid "Sorry, you need a Mozilla-based browser (such as Firefox) to install a search plugin."
+msgstr "Bohužel trjebaće wobhladowak Mozilla (na přikład Firefox), zo byšće pytanski tykač instalował."
 
-#: static/js/common-all.js:9088 static/js/impala-all.js:9649
-#: static/js/zamboni/global.js:410
+#: static/js/common-all.js:9088 static/js/impala-all.js:9649 static/js/zamboni/global.js:410
 msgid "Loading..."
 msgstr "Začituje so..."
 
 #. L10n: {0} is the number of characters left.
-#: static/js/common-all.js:9152 static/js/impala-all.js:9713
-#: static/js/zamboni/global.js:474
+#: static/js/common-all.js:9152 static/js/impala-all.js:9713 static/js/zamboni/global.js:474
 msgid "<b>{0}</b> character left."
 msgid_plural "<b>{0}</b> characters left."
 msgstr[0] "<b>{0}</b> znamješko wyše."
@@ -127,9 +94,7 @@ msgstr[1] "<b>{0}</b> znamješce wyše."
 msgstr[2] "<b>{0}</b> znamješka wyše."
 msgstr[3] "<b>{0}</b> znamješkow wyše."
 
-#: static/js/common-all.js:9589 static/js/common-min.js:6
-#: static/js/impala-all.js:10052 static/js/impala-min.js:6
-#: static/js/common/ratingwidget.js:31 static/js/zamboni/mobile-all.js:16123
+#: static/js/common-all.js:9589 static/js/common-min.js:6 static/js/impala-all.js:10052 static/js/impala-min.js:6 static/js/common/ratingwidget.js:31 static/js/zamboni/mobile-all.js:16123
 #: static/js/zamboni/mobile-min.js:6
 msgid "{0} star"
 msgid_plural "{0} stars"
@@ -138,147 +103,101 @@ msgstr[1] "{0} hwěžce"
 msgstr[2] "{0} hwěžki"
 msgstr[3] "{0} hwěžkow"
 
-#: static/js/common-all.js:9676 static/js/common-min.js:6
-#: static/js/impala-all.js:10139 static/js/impala-min.js:6
-#: static/js/zamboni/l10n.js:45
+#: static/js/common-all.js:9676 static/js/common-min.js:6 static/js/impala-all.js:10139 static/js/impala-min.js:6 static/js/zamboni/l10n.js:45
 msgid "Remove this localization"
 msgstr "Tutón přełožk wotstronić"
 
-#: static/js/common-all.js:10193 static/js/common-min.js:6
-#: static/js/impala-all.js:10674 static/js/impala-min.js:6
-#: static/js/zamboni/discovery-all.js:13678
+#: static/js/common-all.js:10193 static/js/common-min.js:6 static/js/impala-all.js:10674 static/js/impala-min.js:6 static/js/zamboni/discovery-all.js:13678
 msgid "close"
 msgstr "začinić"
 
-#: static/js/common-all.js:10860 static/js/common-min.js:6
-#: static/js/impala-all.js:11481 static/js/impala-min.js:6
-#: static/js/impala/reviews.js:23 static/js/zamboni/reviews.js:18
+#: static/js/common-all.js:10860 static/js/common-min.js:6 static/js/impala-all.js:11481 static/js/impala-min.js:6 static/js/impala/reviews.js:23 static/js/zamboni/reviews.js:18
 msgid "Flagged for review"
 msgstr "Za přepruwowanje woznamjenjeny"
 
-#: static/js/common-all.js:10876 static/js/common-min.js:6
-#: static/js/impala-all.js:11498 static/js/impala-min.js:6
-#: static/js/impala/reviews.js:40 static/js/zamboni/reviews.js:34
+#: static/js/common-all.js:10876 static/js/common-min.js:6 static/js/impala-all.js:11498 static/js/impala-min.js:6 static/js/impala/reviews.js:40 static/js/zamboni/reviews.js:34
 msgid "Your input is required"
 msgstr "Waše zapodaće je trěbne"
 
-#: static/js/common-all.js:10945 static/js/common-min.js:6
-#: static/js/impala-all.js:11610 static/js/impala-min.js:7
-#: static/js/impala/reviews.js:152 static/js/zamboni/reviews.js:103
+#: static/js/common-all.js:10945 static/js/common-min.js:6 static/js/impala-all.js:11610 static/js/impala-min.js:7 static/js/impala/reviews.js:152 static/js/zamboni/reviews.js:103
 msgid "Marked for deletion"
 msgstr "Za zhašenje markěrowany"
 
-#: static/js/common-all.js:11573 static/js/common-min.js:7
-#: static/js/impala-all.js:13809 static/js/impala-min.js:8
-#: static/js/zamboni/collections.js:229
+#: static/js/common-all.js:11573 static/js/common-min.js:7 static/js/impala-all.js:13809 static/js/impala-min.js:8 static/js/zamboni/collections.js:229
 msgid "Adding to Favorites&hellip;"
 msgstr "Přidawa so faworitam&hellip;"
 
-#: static/js/common-all.js:11576 static/js/common-min.js:7
-#: static/js/impala-all.js:13812 static/js/impala-min.js:8
-#: static/js/zamboni/collections.js:232
+#: static/js/common-all.js:11576 static/js/common-min.js:7 static/js/impala-all.js:13812 static/js/impala-min.js:8 static/js/zamboni/collections.js:232
 msgid "Removing Favorite&hellip;"
 msgstr "Faworit so wotstronja&hellip;"
 
-#: static/js/common-all.js:11579 static/js/common-min.js:7
-#: static/js/impala-all.js:13815 static/js/impala-min.js:8
-#: static/js/zamboni/collections.js:235
+#: static/js/common-all.js:11579 static/js/common-min.js:7 static/js/impala-all.js:13815 static/js/impala-min.js:8 static/js/zamboni/collections.js:235
 msgid "Add to Favorites"
 msgstr "Faworitam přidać"
 
-#: static/js/common-all.js:11582 static/js/common-min.js:7
-#: static/js/impala-all.js:13818 static/js/impala-min.js:8
-#: static/js/zamboni/collections.js:238
+#: static/js/common-all.js:11582 static/js/common-min.js:7 static/js/impala-all.js:13818 static/js/impala-min.js:8 static/js/zamboni/collections.js:238
 msgid "Remove from Favorites"
 msgstr "Z faworitow wotstronić"
 
-#: static/js/common-all.js:11647 static/js/common-min.js:7
-#: static/js/impala-all.js:13883 static/js/impala-min.js:8
-#: static/js/zamboni/collections.js:303
+#: static/js/common-all.js:11647 static/js/common-min.js:7 static/js/impala-all.js:13883 static/js/impala-min.js:8 static/js/zamboni/collections.js:303
 msgid "Pending"
 msgstr "Wustejacy"
 
-#: static/js/common-all.js:11648 static/js/common-min.js:7
-#: static/js/impala-all.js:13884 static/js/impala-min.js:8
-#: static/js/zamboni/collections.js:304
+#: static/js/common-all.js:11648 static/js/common-min.js:7 static/js/impala-all.js:13884 static/js/impala-min.js:8 static/js/zamboni/collections.js:304
 msgid "Add a comment"
 msgstr "Komentar přidać"
 
-#: static/js/common-all.js:11648 static/js/common-min.js:7
-#: static/js/impala-all.js:13884 static/js/impala-min.js:8
-#: static/js/zamboni/collections.js:304
+#: static/js/common-all.js:11648 static/js/common-min.js:7 static/js/impala-all.js:13884 static/js/impala-min.js:8 static/js/zamboni/collections.js:304
 msgid "Comment"
 msgstr "Komentar"
 
-#: static/js/common-all.js:11649 static/js/common-min.js:7
-#: static/js/impala-all.js:13885 static/js/impala-min.js:8
-#: static/js/zamboni/collections.js:305
+#: static/js/common-all.js:11649 static/js/common-min.js:7 static/js/impala-all.js:13885 static/js/impala-min.js:8 static/js/zamboni/collections.js:305
 msgid "Remove this add-on from the collection"
 msgstr "Tutón přidatk ze zběrki wotstronić"
 
-#: static/js/common-all.js:11649 static/js/common-all.js:11678
-#: static/js/common-min.js:7 static/js/impala-all.js:13885
-#: static/js/impala-all.js:13914 static/js/impala-min.js:8
+#: static/js/common-all.js:11649 static/js/common-all.js:11678 static/js/common-min.js:7 static/js/impala-all.js:13885 static/js/impala-all.js:13914 static/js/impala-min.js:8
 #: static/js/zamboni/collections.js:305 static/js/zamboni/collections.js:334
 msgid "Remove"
 msgstr "Wotstronić"
 
-#: static/js/common-all.js:11678 static/js/common-min.js:7
-#: static/js/impala-all.js:13914 static/js/impala-min.js:8
-#: static/js/zamboni/collections.js:334
+#: static/js/common-all.js:11678 static/js/common-min.js:7 static/js/impala-all.js:13914 static/js/impala-min.js:8 static/js/zamboni/collections.js:334
 msgid "Remove this user as a contributor"
 msgstr "Wužiwarja jako sobuskutkowarja wotstronić"
 
-#: static/js/common-all.js:11690 static/js/common-min.js:7
-#: static/js/impala-all.js:13926 static/js/impala-min.js:8
-#: static/js/zamboni/collections.js:346
+#: static/js/common-all.js:11690 static/js/common-min.js:7 static/js/impala-all.js:13926 static/js/impala-min.js:8 static/js/zamboni/collections.js:346
 msgid "An email address is required."
 msgstr "E-mejlowa adresa je trěbna."
 
-#: static/js/common-all.js:11708 static/js/common-min.js:7
-#: static/js/impala-all.js:13944 static/js/impala-min.js:8
-#: static/js/zamboni/collections.js:364
+#: static/js/common-all.js:11708 static/js/common-min.js:7 static/js/impala-all.js:13944 static/js/impala-min.js:8 static/js/zamboni/collections.js:364
 msgid "You cannot add yourself as a contributor."
 msgstr "Njemóžeće sebje jako sobuskutkowaceho přidać."
 
-#: static/js/common-all.js:11710 static/js/common-min.js:7
-#: static/js/impala-all.js:13946 static/js/impala-min.js:8
-#: static/js/zamboni/collections.js:366
+#: static/js/common-all.js:11710 static/js/common-min.js:7 static/js/impala-all.js:13946 static/js/impala-min.js:8 static/js/zamboni/collections.js:366
 msgid "You have already added that user."
 msgstr "Sće hižo toho wužiwarja přidał."
 
-#: static/js/common-all.js:11917 static/js/common-min.js:7
-#: static/js/impala-all.js:14153 static/js/impala-min.js:8
-#: static/js/zamboni/collections.js:573
+#: static/js/common-all.js:11917 static/js/common-min.js:7 static/js/impala-all.js:14153 static/js/impala-min.js:8 static/js/zamboni/collections.js:573
 msgid "Add to favorites"
 msgstr "Faworitam přidać"
 
-#: static/js/common-all.js:11921 static/js/common-min.js:7
-#: static/js/impala-all.js:14157 static/js/impala-min.js:8
-#: static/js/zamboni/collections.js:577
+#: static/js/common-all.js:11921 static/js/common-min.js:7 static/js/impala-all.js:14157 static/js/impala-min.js:8 static/js/zamboni/collections.js:577
 msgid "Remove from favorites"
 msgstr "Z faworitow wotstronić"
 
-#: static/js/common-all.js:11939 static/js/common-min.js:7
-#: static/js/impala-all.js:14175 static/js/impala-all.js:14233
-#: static/js/impala-min.js:8 static/js/impala/collections.js:10
+#: static/js/common-all.js:11939 static/js/common-min.js:7 static/js/impala-all.js:14175 static/js/impala-all.js:14233 static/js/impala-min.js:8 static/js/impala/collections.js:10
 #: static/js/zamboni/collections.js:595
 msgid "Follow this Collection"
 msgstr "Tutej zběrce slědować"
 
-#: static/js/common-all.js:11948 static/js/common-min.js:7
-#: static/js/impala-all.js:14184 static/js/impala-min.js:8
-#: static/js/zamboni/collections.js:604
+#: static/js/common-all.js:11948 static/js/common-min.js:7 static/js/impala-all.js:14184 static/js/impala-min.js:8 static/js/zamboni/collections.js:604
 msgid "Stop following"
 msgstr "Hižo njeslědować"
 
-#: static/js/common-all.js:12096 static/js/common-min.js:7
-#: static/js/zamboni/password-strength.js:20
+#: static/js/common-all.js:12096 static/js/common-min.js:7 static/js/zamboni/password-strength.js:20
 msgid "Password strength:"
 msgstr "Hesłowa móc:"
 
-#: static/js/common-all.js:12102 static/js/common-min.js:7
-#: static/js/zamboni/password-strength.js:26
+#: static/js/common-all.js:12102 static/js/common-min.js:7 static/js/zamboni/password-strength.js:26
 msgid "At least {0} character left."
 msgid_plural "At least {0} characters left."
 msgstr[0] "Znajmjeńša {0} znamješko wyše."
@@ -286,156 +205,121 @@ msgstr[1] "Znajmjeńša {0} znamješce wyše."
 msgstr[2] "Znajmjeńša {0} znamješka wyše."
 msgstr[3] "Znajmjeńša {0} znamješkow wyše."
 
-#: static/js/common-all.js:12286 static/js/common-min.js:7
-#: static/js/impala-all.js:14632 static/js/impala-min.js:8
-#: static/js/impala/suggestions.js:39
+#: static/js/common-all.js:12286 static/js/common-min.js:7 static/js/impala-all.js:14632 static/js/impala-min.js:8 static/js/impala/suggestions.js:39
 msgid "Search themes for <b>{0}</b>"
 msgstr "Drasty za <b>{0}</b> pytać"
 
-#: static/js/common-all.js:12288 static/js/common-min.js:7
-#: static/js/impala-all.js:14634 static/js/impala-min.js:8
-#: static/js/impala/suggestions.js:41
+#: static/js/common-all.js:12288 static/js/common-min.js:7 static/js/impala-all.js:14634 static/js/impala-min.js:8 static/js/impala/suggestions.js:41
 msgid "Search apps for <b>{0}</b>"
 msgstr "Nałoženja za <b>{0}</b> pytać"
 
-#: static/js/common-all.js:12290 static/js/common-min.js:7
-#: static/js/impala-all.js:14636 static/js/impala-min.js:8
-#: static/js/impala/suggestions.js:43
+#: static/js/common-all.js:12290 static/js/common-min.js:7 static/js/impala-all.js:14636 static/js/impala-min.js:8 static/js/impala/suggestions.js:43
 msgid "Search add-ons for <b>{0}</b>"
 msgstr "Přidatki za <b>{0}</b> pytać"
 
-#: static/js/common-all.js:12521 static/js/common-min.js:7
-#: static/js/impala-all.js:14867 static/js/impala-min.js:8
-#: static/js/impala/site_suggestions.js:46
+#: static/js/common-all.js:12521 static/js/common-min.js:7 static/js/impala-all.js:14867 static/js/impala-min.js:8 static/js/impala/site_suggestions.js:46
 msgid "Category"
 msgstr "Kategorija"
 
 #. L10n: {0} is an app name.
-#: static/js/impala-all.js:11632 static/js/impala-min.js:7
-#: static/js/impala/listing.js:11 static/js/zamboni/themes.js:13
+#: static/js/impala-all.js:11632 static/js/impala-min.js:7 static/js/impala/listing.js:11 static/js/zamboni/themes.js:13
 msgid "This theme is incompatible with your version of {0}"
 msgstr "Tuta drasta z wašej wersiju {0} kompatibelna njeje"
 
-#: static/js/impala-all.js:12146 static/js/impala-all.js:14331
-#: static/js/impala-min.js:7 static/js/impala-min.js:8
-#: static/js/common/upload-image.js:97 static/js/impala/users.js:51
+#: static/js/impala-all.js:12146 static/js/impala-all.js:14331 static/js/impala-min.js:7 static/js/impala-min.js:8 static/js/common/upload-image.js:97 static/js/impala/users.js:51
 #: static/js/zamboni/devhub-all.js:894 static/js/zamboni/devhub-min.js:1
 msgid "Images must be either PNG or JPG."
 msgstr "Wobrazy dyrbja pak PNG pak JPG być."
 
-#: static/js/impala-all.js:12150 static/js/impala-min.js:7
-#: static/js/common/upload-image.js:101 static/js/zamboni/devhub-all.js:898
-#: static/js/zamboni/devhub-min.js:1
+#: static/js/impala-all.js:12150 static/js/impala-min.js:7 static/js/common/upload-image.js:101 static/js/zamboni/devhub-all.js:898 static/js/zamboni/devhub-min.js:1
 msgid "Videos must be in WebM."
 msgstr "Wideja dyrbja we formaće WebM być."
 
-#: static/js/impala-all.js:12177 static/js/impala-min.js:7
-#: static/js/common/upload-addon.js:41 static/js/common/upload-image.js:128
-#: static/js/zamboni/devhub-all.js:272 static/js/zamboni/devhub-all.js:925
-#: static/js/zamboni/devhub-min.js:1
+#: static/js/impala-all.js:12177 static/js/impala-min.js:7 static/js/common/upload-addon.js:41 static/js/common/upload-image.js:128 static/js/zamboni/devhub-all.js:272
+#: static/js/zamboni/devhub-all.js:925 static/js/zamboni/devhub-min.js:1
 msgid "There was a problem contacting the server."
 msgstr "Při kontaktowanju serwera je problem wustupił."
 
-#: static/js/impala-all.js:13298 static/js/impala-min.js:7
-#: static/js/impala/persona_creation.js:60
+#: static/js/impala-all.js:13298 static/js/impala-min.js:7 static/js/impala/persona_creation.js:60
 msgid "All Rights Reserved"
 msgstr "Wšě prawa wuměnjene"
 
-#: static/js/impala-all.js:13302 static/js/impala-min.js:7
-#: static/js/impala/persona_creation.js:64
+#: static/js/impala-all.js:13302 static/js/impala-min.js:7 static/js/impala/persona_creation.js:64
 msgid "Creative Commons Attribution 3.0"
 msgstr "Creative Commons Attribution 3.0"
 
-#: static/js/impala-all.js:13307 static/js/impala-min.js:7
-#: static/js/impala/persona_creation.js:69
+#: static/js/impala-all.js:13307 static/js/impala-min.js:7 static/js/impala/persona_creation.js:69
 msgid "Creative Commons Attribution-NonCommercial 3.0"
 msgstr "Creative Commons Attribution-NonCommercial 3.0"
 
-#: static/js/impala-all.js:13312 static/js/impala-min.js:7
-#: static/js/impala/persona_creation.js:74
+#: static/js/impala-all.js:13312 static/js/impala-min.js:7 static/js/impala/persona_creation.js:74
 msgid "Creative Commons Attribution-NonCommercial-NoDerivs 3.0"
 msgstr "Creative Commons Attribution-NonCommercial-NoDerivs 3.0"
 
-#: static/js/impala-all.js:13317 static/js/impala-min.js:7
-#: static/js/impala/persona_creation.js:79
+#: static/js/impala-all.js:13317 static/js/impala-min.js:7 static/js/impala/persona_creation.js:79
 msgid "Creative Commons Attribution-NonCommercial-Share Alike 3.0"
 msgstr "Creative Commons Attribution-NonCommercial-Share Alike 3.0"
 
-#: static/js/impala-all.js:13322 static/js/impala-min.js:7
-#: static/js/impala/persona_creation.js:84
+#: static/js/impala-all.js:13322 static/js/impala-min.js:7 static/js/impala/persona_creation.js:84
 msgid "Creative Commons Attribution-NoDerivs 3.0"
 msgstr "Creative Commons Attribution-NoDerivs 3.0"
 
-#: static/js/impala-all.js:13327 static/js/impala-min.js:7
-#: static/js/impala/persona_creation.js:89
+#: static/js/impala-all.js:13327 static/js/impala-min.js:7 static/js/impala/persona_creation.js:89
 msgid "Creative Commons Attribution-ShareAlike 3.0"
 msgstr "Creative Commons Attribution-ShareAlike 3.0"
 
-#: static/js/impala-all.js:13530 static/js/impala-min.js:7
-#: static/js/impala/persona_creation.js:292
+#: static/js/impala-all.js:13530 static/js/impala-min.js:7 static/js/impala/persona_creation.js:292
 msgid "Your Theme's Name"
 msgstr "Mjeno wašeje drasty"
 
-#: static/js/impala-all.js:14242 static/js/impala-min.js:8
-#: static/js/impala/collections.js:19
+#: static/js/impala-all.js:14242 static/js/impala-min.js:8 static/js/impala/collections.js:19
 msgid "Stop Following"
 msgstr "Hižo njeslědować"
 
-#: static/js/impala-all.js:14243 static/js/impala-min.js:8
-#: static/js/impala/collections.js:20
+#: static/js/impala-all.js:14243 static/js/impala-min.js:8 static/js/impala/collections.js:20
 msgid "Following"
 msgstr "Slědować"
 
-#: static/js/impala-all.js:14313 static/js/impala-min.js:8
-#: static/js/impala/users.js:33
+#: static/js/impala-all.js:14313 static/js/impala-min.js:8 static/js/impala/users.js:33
 msgid "use original"
 msgstr "original wužiwać"
 
-#: static/js/impala-all.js:14523 static/js/impala-min.js:8
-#: static/js/impala/search.js:114
+#: static/js/impala-all.js:14523 static/js/impala-min.js:8 static/js/impala/search.js:114
 msgid "Updating results&hellip;"
 msgstr "Wuslědki so aktualizuja&hellip;"
 
-#: static/js/common/upload-addon.js:69 static/js/zamboni/devhub-all.js:300
-#: static/js/zamboni/devhub-min.js:1
+#: static/js/common/upload-addon.js:69 static/js/zamboni/devhub-all.js:300 static/js/zamboni/devhub-min.js:1
 msgid "Select a file..."
 msgstr "Wubjerće dataju..."
 
-#: static/js/common/upload-addon.js:70 static/js/zamboni/devhub-all.js:301
-#: static/js/zamboni/devhub-min.js:1
+#: static/js/common/upload-addon.js:70 static/js/zamboni/devhub-all.js:301 static/js/zamboni/devhub-min.js:1
 msgid "Your add-on should end with .xpi, .jar or .xml"
 msgstr "Waš přidatk dyrbjał kóncowku .xpi, .jar abo .xml měć"
 
 #. L10n: {0} is the percent of the file that has been uploaded.
-#: static/js/common/upload-addon.js:104 static/js/zamboni/devhub-all.js:335
-#: static/js/zamboni/devhub-min.js:1
+#: static/js/common/upload-addon.js:104 static/js/zamboni/devhub-all.js:335 static/js/zamboni/devhub-min.js:1
 #, python-format
 msgid "{0}% complete"
 msgstr "{0}% dokónčene"
 
 #. L10n: "{bytes uploaded} of {total filesize}".
-#: static/js/common/upload-addon.js:107 static/js/zamboni/devhub-all.js:338
-#: static/js/zamboni/devhub-min.js:1
+#: static/js/common/upload-addon.js:107 static/js/zamboni/devhub-all.js:338 static/js/zamboni/devhub-min.js:1
 msgid "{0} of {1}"
 msgstr "{0} z {1}"
 
-#: static/js/common/upload-addon.js:140 static/js/zamboni/devhub-all.js:371
-#: static/js/zamboni/devhub-min.js:1
+#: static/js/common/upload-addon.js:140 static/js/zamboni/devhub-all.js:371 static/js/zamboni/devhub-min.js:1
 msgid "Cancel"
 msgstr "Přetorhnyć"
 
-#: static/js/common/upload-addon.js:162 static/js/zamboni/devhub-all.js:393
-#: static/js/zamboni/devhub-min.js:1
+#: static/js/common/upload-addon.js:162 static/js/zamboni/devhub-all.js:393 static/js/zamboni/devhub-min.js:1
 msgid "Uploading {0}"
 msgstr "{0} so nahrawa"
 
-#: static/js/common/upload-addon.js:189 static/js/zamboni/devhub-all.js:420
-#: static/js/zamboni/devhub-min.js:1
+#: static/js/common/upload-addon.js:189 static/js/zamboni/devhub-all.js:420 static/js/zamboni/devhub-min.js:1
 msgid "Error with {0}"
 msgstr "Zmylk z {0}"
 
-#: static/js/common/upload-addon.js:194 static/js/zamboni/devhub-all.js:425
-#: static/js/zamboni/devhub-min.js:1
+#: static/js/common/upload-addon.js:194 static/js/zamboni/devhub-all.js:425 static/js/zamboni/devhub-min.js:1
 msgid "Your add-on failed validation with {0} error."
 msgid_plural "Your add-on failed validation with {0} errors."
 msgstr[0] "Waš přidatk je při přepruwowanju z {0} zmylkom přepadnył."
@@ -443,8 +327,7 @@ msgstr[1] "Waš přidatk je při přepruwowanju z {0} zmylkomaj přepadnył."
 msgstr[2] "Waš přidatk je při přepruwowanju z {0} zmylkami přepadnył."
 msgstr[3] "Waš přidatk je při přepruwowanju z {0} zmylkami přepadnył."
 
-#: static/js/common/upload-addon.js:208 static/js/zamboni/devhub-all.js:439
-#: static/js/zamboni/devhub-min.js:1
+#: static/js/common/upload-addon.js:208 static/js/zamboni/devhub-all.js:439 static/js/zamboni/devhub-min.js:1
 msgid "&hellip;and {0} more"
 msgid_plural "&hellip;and {0} more"
 msgstr[0] "&hellip;a {0} dalši"
@@ -452,925 +335,693 @@ msgstr[1] "&hellip;a {0} dalšej"
 msgstr[2] "&hellip;a {0} dalše"
 msgstr[3] "&hellip;a {0} dalšich"
 
-#: static/js/common/upload-addon.js:222 static/js/common/upload-addon.js:478
-#: static/js/zamboni/devhub-all.js:453 static/js/zamboni/devhub-all.js:743
-#: static/js/zamboni/devhub-min.js:1
+#: static/js/common/upload-addon.js:222 static/js/common/upload-addon.js:497 static/js/zamboni/devhub-all.js:453 static/js/zamboni/devhub-all.js:743 static/js/zamboni/devhub-min.js:1
 msgid "See full validation report"
 msgstr "Dospołnu přepruwowansku rozprawu čitać"
 
-#: static/js/common/upload-addon.js:234 static/js/zamboni/devhub-all.js:465
-#: static/js/zamboni/devhub-min.js:1
+#: static/js/common/upload-addon.js:234 static/js/zamboni/devhub-all.js:465 static/js/zamboni/devhub-min.js:1
 msgid "Validating {0}"
 msgstr "{0} so přepruwuje"
 
 #. L10n: first argument is an HTTP status code
-#: static/js/common/upload-addon.js:273 static/js/zamboni/devhub-all.js:504
-#: static/js/zamboni/devhub-min.js:1
+#: static/js/common/upload-addon.js:273 static/js/zamboni/devhub-all.js:504 static/js/zamboni/devhub-min.js:1
 msgid "Received an empty response from the server; status: {0}"
 msgstr "Prózdna wotmołwa je so wot serwera dóstała; status: {0}"
 
-#: static/js/common/upload-addon.js:352 static/js/zamboni/devhub-all.js:604
-#: static/js/zamboni/devhub-min.js:1
+#: static/js/common/upload-addon.js:370 static/js/zamboni/devhub-all.js:604 static/js/zamboni/devhub-min.js:1
 msgid "Unexpected server error while validating."
 msgstr "Njewočakowany serwerowy zmylk při přepruwowanju."
 
-#: static/js/common/upload-addon.js:391 static/js/zamboni/devhub-all.js:643
-#: static/js/zamboni/devhub-min.js:1
+#: static/js/common/upload-addon.js:409 static/js/zamboni/devhub-all.js:643 static/js/zamboni/devhub-min.js:1
 msgid "Finished validating {0}"
 msgstr "Přepruwowanje {0} dokónčene"
 
-#: static/js/common/upload-addon.js:397 static/js/zamboni/devhub-all.js:649
-#: static/js/zamboni/devhub-min.js:1
+#: static/js/common/upload-addon.js:415 static/js/zamboni/devhub-all.js:649 static/js/zamboni/devhub-min.js:1
 msgid "Your add-on validation timed out, it will be manually reviewed."
-msgstr ""
-"Waše přepruwowanje přidatka je čas překročiło, budźe so tohodla manuelnje "
-"přewjesć."
+msgstr "Waše přepruwowanje přidatka je čas překročiło, budźe so tohodla manuelnje přewjesć."
 
-#: static/js/common/upload-addon.js:400 static/js/zamboni/devhub-all.js:652
-#: static/js/zamboni/devhub-min.js:1
+#: static/js/common/upload-addon.js:418 static/js/zamboni/devhub-all.js:652 static/js/zamboni/devhub-min.js:1
 msgid "Your add-on was validated with no errors and {0} warning."
 msgid_plural "Your add-on was validated with no errors and {0} warnings."
-msgstr[0] ""
-"Waš přidatk je přepruwowanje bjeze zmylkow a z {0} warnowanjom wobstał."
-msgstr[1] ""
-"Waš přidatk je přepruwowanje bjeze zmylkow a z {0} warnowanjomaj wobstał."
-msgstr[2] ""
-"Waš přidatk je přepruwowanje bjeze zmylkow a z {0} warnowanjemi wobstał."
-msgstr[3] ""
-"Waš přidatk je přepruwowanje bjeze zmylkow a z {0} warnowanjemi wobstał."
+msgstr[0] "Waš přidatk je přepruwowanje bjeze zmylkow a z {0} warnowanjom wobstał."
+msgstr[1] "Waš přidatk je přepruwowanje bjeze zmylkow a z {0} warnowanjomaj wobstał."
+msgstr[2] "Waš přidatk je přepruwowanje bjeze zmylkow a z {0} warnowanjemi wobstał."
+msgstr[3] "Waš přidatk je přepruwowanje bjeze zmylkow a z {0} warnowanjemi wobstał."
 
-#: static/js/common/upload-addon.js:405 static/js/zamboni/devhub-all.js:657
-#: static/js/zamboni/devhub-min.js:1
+#: static/js/common/upload-addon.js:423 static/js/zamboni/devhub-all.js:657 static/js/zamboni/devhub-min.js:1
 msgid "Your add-on was validated with no errors and {0} message."
 msgid_plural "Your add-on was validated with no errors and {0} messages."
-msgstr[0] ""
-"Waš přidatk je přepruwowanje bjeze zmylkow a z {0} zdźělenku wobstał."
-msgstr[1] ""
-"Waš přidatk je přepruwowanje bjeze zmylkow a z {0} zdźělenkomaj wobstał."
-msgstr[2] ""
-"Waš přidatk je přepruwowanje bjeze zmylkow a z {0} zdźělenkami wobstał."
-msgstr[3] ""
-"Waš přidatk je přepruwowanje bjeze zmylkow a z {0} zdźělenkami wobstał."
+msgstr[0] "Waš přidatk je přepruwowanje bjeze zmylkow a z {0} zdźělenku wobstał."
+msgstr[1] "Waš přidatk je přepruwowanje bjeze zmylkow a z {0} zdźělenkomaj wobstał."
+msgstr[2] "Waš přidatk je přepruwowanje bjeze zmylkow a z {0} zdźělenkami wobstał."
+msgstr[3] "Waš přidatk je přepruwowanje bjeze zmylkow a z {0} zdźělenkami wobstał."
 
-#: static/js/common/upload-addon.js:410 static/js/zamboni/devhub-all.js:662
-#: static/js/zamboni/devhub-min.js:1
+#: static/js/common/upload-addon.js:428 static/js/zamboni/devhub-all.js:662 static/js/zamboni/devhub-min.js:1
 msgid "Your add-on was validated with no errors or warnings."
-msgstr ""
-"Waš přidatk je přepruwowanje bjeze zmylkow a bjez warnowanjow wobstał."
+msgstr "Waš přidatk je přepruwowanje bjeze zmylkow a bjez warnowanjow wobstał."
 
-#: static/js/common/upload-addon.js:424 static/js/zamboni/devhub-all.js:677
-#: static/js/zamboni/devhub-min.js:1
+#: static/js/common/upload-addon.js:443 static/js/zamboni/devhub-all.js:677 static/js/zamboni/devhub-min.js:1
 msgid "Your submission will be automatically signed."
 msgstr "Waše zapodaće budźe so awtomatisce signować."
 
-#: static/js/common/upload-addon.js:431 static/js/zamboni/devhub-all.js:696
-#: static/js/zamboni/devhub-min.js:1
+#: static/js/common/upload-addon.js:450 static/js/zamboni/devhub-all.js:696 static/js/zamboni/devhub-min.js:1
 msgid "Include detailed version notes (this can be done in the next step)."
-msgstr ""
-"Nadrobne wersijowe informacije zapřijeć (to hodźi so w přichodnym kroku "
-"činić)."
+msgstr "Nadrobne wersijowe informacije zapřijeć (to hodźi so w přichodnym kroku činić)."
 
-#: static/js/common/upload-addon.js:432 static/js/zamboni/devhub-all.js:697
-#: static/js/zamboni/devhub-min.js:1
-msgid ""
-"If your add-on requires an account to a website in order to be fully tested,"
-" include a test username and password in the Notes to Reviewer (this can be "
-"done in the next step)."
-msgstr ""
-"Jeli sej waš přidatk konto z websydłom wužaduje, zo by so dospołnje "
-"testował, podajće w zdźělenjach na přepruwowarja testowe wužiwarske mjeno a "
-"hesło (to hodźi so w přichodnym kroku činić)."
+#: static/js/common/upload-addon.js:451 static/js/zamboni/devhub-all.js:697 static/js/zamboni/devhub-min.js:1
+msgid "If your add-on requires an account to a website in order to be fully tested, include a test username and password in the Notes to Reviewer (this can be done in the next step)."
+msgstr "Jeli sej waš přidatk konto z websydłom wužaduje, zo by so dospołnje testował, podajće w zdźělenjach na přepruwowarja testowe wužiwarske mjeno a hesło (to hodźi so w přichodnym kroku činić)."
 
-#: static/js/common/upload-addon.js:433 static/js/zamboni/devhub-all.js:698
-#: static/js/zamboni/devhub-min.js:1
-msgid ""
-"If your add-on is intended for a limited audience you should choose "
-"Preliminary Review instead of Full Review."
-msgstr ""
-"Jeli waš přidatk je za wobmjezowany wužiwarski kruh mysleny, wy měł "
-"„Nachwilne přepruwowanje“ město „Dospołneho přepruwowanja“ wubrać."
+#: static/js/common/upload-addon.js:452 static/js/zamboni/devhub-all.js:698 static/js/zamboni/devhub-min.js:1
+msgid "If your add-on is intended for a limited audience you should choose Preliminary Review instead of Full Review."
+msgstr "Jeli waš přidatk je za wobmjezowany wužiwarski kruh mysleny, wy měł „Nachwilne přepruwowanje“ město „Dospołneho přepruwowanja“ wubrać."
 
-#: static/js/common/upload-addon.js:446 static/js/zamboni/devhub-all.js:711
-#: static/js/zamboni/devhub-min.js:1
+#: static/js/common/upload-addon.js:465 static/js/zamboni/devhub-all.js:711 static/js/zamboni/devhub-min.js:1
 msgid "Add-on submission checklist"
 msgstr "Kontrolna lisćina za zapodaća přidatkow"
 
-#: static/js/common/upload-addon.js:447 static/js/zamboni/devhub-all.js:712
-#: static/js/zamboni/devhub-min.js:1
-msgid ""
-"Please verify the following points before finalizing your submission. This "
-"will minimize delays or misunderstanding during the review process:"
-msgstr ""
-"Prošu wobkrućće slědowace dypki, prjedy hač swoje zapodaće dokónčiće. To "
-"komdźenja abo njedorozumjenja za přepruwowanski proces pomjeńši:"
+#: static/js/common/upload-addon.js:466 static/js/zamboni/devhub-all.js:712 static/js/zamboni/devhub-min.js:1
+msgid "Please verify the following points before finalizing your submission. This will minimize delays or misunderstanding during the review process:"
+msgstr "Prošu wobkrućće slědowace dypki, prjedy hač swoje zapodaće dokónčiće. To komdźenja abo njedorozumjenja za přepruwowanski proces pomjeńši:"
 
-#: static/js/common/upload-addon.js:449 static/js/zamboni/devhub-all.js:714
-#: static/js/zamboni/devhub-min.js:1
+#: static/js/common/upload-addon.js:468 static/js/zamboni/devhub-all.js:714 static/js/zamboni/devhub-min.js:1
 msgid ""
-"Compiled binaries, as well as minified or obfuscated scripts (excluding "
-"known libraries) need to have their sources submitted separately for review."
-" Make sure that you use the source code upload field to avoid having your "
-"submission rejected."
+"Compiled binaries, as well as minified or obfuscated scripts (excluding known libraries) need to have their sources submitted separately for review. Make sure that you use the source code upload "
+"field to avoid having your submission rejected."
 msgstr ""
-"Kompilowane binarne dataje kaž tež skrótšene abo skomolene skripty (nimo "
-"znatych bibliotekow) dyrbja so separatnje za přepruwowanje zapodać. "
-"Wužiwajće na kóždy pad polo za nahrawanje žórłoweho koda, zo njeby so waše "
-"zapodaće wotpokazało."
+"Kompilowane binarne dataje kaž tež skrótšene abo skomolene skripty (nimo znatych bibliotekow) dyrbja so separatnje za přepruwowanje zapodać. Wužiwajće na kóždy pad polo za nahrawanje žórłoweho "
+"koda, zo njeby so waše zapodaće wotpokazało."
 
-#: static/js/common/upload-addon.js:467 static/js/zamboni/devhub-all.js:732
-#: static/js/zamboni/devhub-min.js:1
+#: static/js/common/upload-addon.js:486 static/js/zamboni/devhub-all.js:732 static/js/zamboni/devhub-min.js:1
 msgid "The validation process found these issues that can lead to rejections:"
-msgstr ""
-"Přepruwowanski proces je slědowace problemy namakał, kotrež móhli k "
-"wotpokazanjam wjesć:"
+msgstr "Přepruwowanski proces je slědowace problemy namakał, kotrež móhli k wotpokazanjam wjesć:"
 
-#: static/js/common/upload-addon.js:484 static/js/zamboni/devhub-all.js:749
-#: static/js/zamboni/devhub-min.js:1
-msgid ""
-"If you are unfamiliar with the add-ons review process, you can read about it"
-" here."
-msgstr ""
-"Jeli přepruwowanski proces za přidatki njeznajeće, móžeće so tu wo tym "
-"informować."
+#: static/js/common/upload-addon.js:503 static/js/zamboni/devhub-all.js:749 static/js/zamboni/devhub-min.js:1
+msgid "If you are unfamiliar with the add-ons review process, you can read about it here."
+msgstr "Jeli přepruwowanski proces za přidatki njeznajeće, móžeće so tu wo tym informować."
 
-#: static/js/common/upload-addon.js:521 static/js/zamboni/devhub-all.js:786
-#: static/js/zamboni/devhub-min.js:1
+#: static/js/common/upload-addon.js:540 static/js/zamboni/devhub-all.js:786 static/js/zamboni/devhub-min.js:1
 msgid "Sorry, no supported platform has been found."
 msgstr "Bohužel njeje so podpěrana platforma namakała."
 
-#: static/js/common/upload-base.js:57 static/js/zamboni/devhub-all.js:187
-#: static/js/zamboni/devhub-min.js:1
+#: static/js/common/upload-base.js:57 static/js/zamboni/devhub-all.js:187 static/js/zamboni/devhub-min.js:1
 msgid "The filetype you uploaded isn't recognized."
 msgstr "Datajowy typ, kotryž sć nahrał, so njespóznawa."
 
-#: static/js/common/upload-base.js:79 static/js/zamboni/devhub-all.js:209
-#: static/js/zamboni/devhub-min.js:1
+#: static/js/common/upload-base.js:79 static/js/zamboni/devhub-all.js:209 static/js/zamboni/devhub-min.js:1
 msgid "You cancelled the upload."
 msgstr "Sće nahraće přetorhnył."
 
-#: static/js/impala/stats/chart.js:267 static/js/zamboni/stats-all.js:16898
-#: static/js/zamboni/stats-min.js:5
+#: static/js/impala/stats/chart.js:267 static/js/zamboni/stats-all.js:16898 static/js/zamboni/stats-min.js:5
 msgid "Week of {0}"
 msgstr "Tydźeń {0}"
 
-#: static/js/impala/stats/chart.js:269 static/js/zamboni/stats-all.js:16900
-#: static/js/zamboni/stats-min.js:5
+#: static/js/impala/stats/chart.js:269 static/js/zamboni/stats-all.js:16900 static/js/zamboni/stats-min.js:5
 msgid " downloads"
 msgstr " sćehnjenjow"
 
-#: static/js/impala/stats/chart.js:270 static/js/zamboni/stats-all.js:16901
-#: static/js/zamboni/stats-min.js:5
+#: static/js/impala/stats/chart.js:270 static/js/zamboni/stats-all.js:16901 static/js/zamboni/stats-min.js:5
 msgid "{0} users"
 msgstr "{0} wužiwarjow"
 
-#: static/js/impala/stats/chart.js:271 static/js/zamboni/stats-all.js:16902
-#: static/js/zamboni/stats-min.js:5
+#: static/js/impala/stats/chart.js:271 static/js/zamboni/stats-all.js:16902 static/js/zamboni/stats-min.js:5
 msgid "{0} add-ons"
 msgstr "{0} přidatkow"
 
-#: static/js/impala/stats/chart.js:272 static/js/zamboni/stats-all.js:16903
-#: static/js/zamboni/stats-min.js:5
+#: static/js/impala/stats/chart.js:272 static/js/zamboni/stats-all.js:16903 static/js/zamboni/stats-min.js:5
 msgid "{0} collections"
 msgstr "{0} zběrkow"
 
-#: static/js/impala/stats/chart.js:273 static/js/zamboni/stats-all.js:16904
-#: static/js/zamboni/stats-min.js:5
+#: static/js/impala/stats/chart.js:273 static/js/zamboni/stats-all.js:16904 static/js/zamboni/stats-min.js:5
 msgid "{0} reviews"
 msgstr "{0} pohódnocénjow"
 
-#: static/js/impala/stats/chart.js:275 static/js/zamboni/stats-all.js:16906
-#: static/js/zamboni/stats-min.js:5
+#: static/js/impala/stats/chart.js:275 static/js/zamboni/stats-all.js:16906 static/js/zamboni/stats-min.js:5
 msgid "{0} sales"
 msgstr "{0} předanjow"
 
-#: static/js/impala/stats/chart.js:276 static/js/zamboni/stats-all.js:16907
-#: static/js/zamboni/stats-min.js:5
+#: static/js/impala/stats/chart.js:276 static/js/zamboni/stats-all.js:16907 static/js/zamboni/stats-min.js:5
 msgid "{0} refunds"
 msgstr "{0} zarunanjow"
 
-#: static/js/impala/stats/chart.js:277 static/js/zamboni/stats-all.js:16908
-#: static/js/zamboni/stats-min.js:5
+#: static/js/impala/stats/chart.js:277 static/js/zamboni/stats-all.js:16908 static/js/zamboni/stats-min.js:5
 msgid "{0} installs"
 msgstr "{0} instalacijow"
 
-#: static/js/impala/stats/chart.js:369 static/js/impala/stats/csv_keys.js:3
-#: static/js/impala/stats/csv_keys.js:109 static/js/zamboni/stats-all.js:15284
-#: static/js/zamboni/stats-all.js:15390 static/js/zamboni/stats-all.js:17000
-#: static/js/zamboni/stats-min.js:4 static/js/zamboni/stats-min.js:5
+#: static/js/impala/stats/chart.js:369 static/js/impala/stats/csv_keys.js:3 static/js/impala/stats/csv_keys.js:109 static/js/zamboni/stats-all.js:15284 static/js/zamboni/stats-all.js:15390
+#: static/js/zamboni/stats-all.js:17000 static/js/zamboni/stats-min.js:4 static/js/zamboni/stats-min.js:5
 msgid "Downloads"
 msgstr "Sćehnjenja"
 
-#: static/js/impala/stats/chart.js:379 static/js/impala/stats/csv_keys.js:6
-#: static/js/impala/stats/csv_keys.js:110 static/js/zamboni/stats-all.js:15287
-#: static/js/zamboni/stats-all.js:15391 static/js/zamboni/stats-all.js:17010
-#: static/js/zamboni/stats-min.js:4 static/js/zamboni/stats-min.js:5
+#: static/js/impala/stats/chart.js:379 static/js/impala/stats/csv_keys.js:6 static/js/impala/stats/csv_keys.js:110 static/js/zamboni/stats-all.js:15287 static/js/zamboni/stats-all.js:15391
+#: static/js/zamboni/stats-all.js:17010 static/js/zamboni/stats-min.js:4 static/js/zamboni/stats-min.js:5
 msgid "Daily Users"
 msgstr "Wšědni wužiwarjo"
 
-#: static/js/impala/stats/chart.js:410 static/js/zamboni/stats-all.js:17041
-#: static/js/zamboni/stats-min.js:5
+#: static/js/impala/stats/chart.js:410 static/js/zamboni/stats-all.js:17041 static/js/zamboni/stats-min.js:5
 msgid "Amount, in USD"
 msgstr "Suma, w USD"
 
-#: static/js/impala/stats/chart.js:421 static/js/impala/stats/csv_keys.js:104
-#: static/js/zamboni/stats-all.js:15385 static/js/zamboni/stats-all.js:17052
-#: static/js/zamboni/stats-min.js:5
+#: static/js/impala/stats/chart.js:421 static/js/impala/stats/csv_keys.js:104 static/js/zamboni/stats-all.js:15385 static/js/zamboni/stats-all.js:17052 static/js/zamboni/stats-min.js:5
 msgid "Number of Contributions"
 msgstr "Ličba přinoškow"
 
-#: static/js/impala/stats/chart.js:447 static/js/zamboni/stats-all.js:17078
-#: static/js/zamboni/stats-min.js:5
+#: static/js/impala/stats/chart.js:447 static/js/zamboni/stats-all.js:17078 static/js/zamboni/stats-min.js:5
 msgid "More Info..."
 msgstr "Dalše informacije..."
 
 #. L10n: {0} is an ISO-formatted date.
-#: static/js/impala/stats/chart.js:451 static/js/zamboni/stats-all.js:17082
-#: static/js/zamboni/stats-min.js:5
+#: static/js/impala/stats/chart.js:451 static/js/zamboni/stats-all.js:17082 static/js/zamboni/stats-min.js:5
 msgid "Details for {0}"
 msgstr "Podrobnosće za {0}"
 
-#: static/js/impala/stats/csv_keys.js:9 static/js/zamboni/stats-all.js:15290
-#: static/js/zamboni/stats-min.js:4
+#: static/js/impala/stats/csv_keys.js:9 static/js/zamboni/stats-all.js:15290 static/js/zamboni/stats-min.js:4
 msgid "Collections Created"
 msgstr "Wutworjene zběrki"
 
-#: static/js/impala/stats/csv_keys.js:12 static/js/zamboni/stats-all.js:15293
-#: static/js/zamboni/stats-min.js:4
+#: static/js/impala/stats/csv_keys.js:12 static/js/zamboni/stats-all.js:15293 static/js/zamboni/stats-min.js:4
 msgid "Add-ons in Use"
 msgstr "Wužiwane přidatki"
 
-#: static/js/impala/stats/csv_keys.js:15 static/js/zamboni/stats-all.js:15296
-#: static/js/zamboni/stats-min.js:4
+#: static/js/impala/stats/csv_keys.js:15 static/js/zamboni/stats-all.js:15296 static/js/zamboni/stats-min.js:4
 msgid "Add-ons Created"
 msgstr "Wutworjene přidatki"
 
-#: static/js/impala/stats/csv_keys.js:18 static/js/zamboni/stats-all.js:15299
-#: static/js/zamboni/stats-min.js:4
+#: static/js/impala/stats/csv_keys.js:18 static/js/zamboni/stats-all.js:15299 static/js/zamboni/stats-min.js:4
 msgid "Add-ons Downloaded"
 msgstr "Sćehnjene přidatki"
 
-#: static/js/impala/stats/csv_keys.js:21 static/js/zamboni/stats-all.js:15302
-#: static/js/zamboni/stats-min.js:4
+#: static/js/impala/stats/csv_keys.js:21 static/js/zamboni/stats-all.js:15302 static/js/zamboni/stats-min.js:4
 msgid "Add-ons Updated"
 msgstr "Zaktualizowane přidatki"
 
-#: static/js/impala/stats/csv_keys.js:24 static/js/zamboni/stats-all.js:15305
-#: static/js/zamboni/stats-min.js:4
+#: static/js/impala/stats/csv_keys.js:24 static/js/zamboni/stats-all.js:15305 static/js/zamboni/stats-min.js:4
 msgid "Reviews Written"
 msgstr "Napisane pohódnoćenja"
 
-#: static/js/impala/stats/csv_keys.js:27 static/js/zamboni/stats-all.js:15308
-#: static/js/zamboni/stats-min.js:4
+#: static/js/impala/stats/csv_keys.js:27 static/js/zamboni/stats-all.js:15308 static/js/zamboni/stats-min.js:4
 msgid "User Signups"
 msgstr "Wužiwarske registrowanja"
 
-#: static/js/impala/stats/csv_keys.js:30 static/js/zamboni/stats-all.js:15311
-#: static/js/zamboni/stats-min.js:4
+#: static/js/impala/stats/csv_keys.js:30 static/js/zamboni/stats-all.js:15311 static/js/zamboni/stats-min.js:4
 msgid "Subscribers"
 msgstr "Abonenća"
 
-#: static/js/impala/stats/csv_keys.js:33 static/js/zamboni/stats-all.js:15314
-#: static/js/zamboni/stats-min.js:4
+#: static/js/impala/stats/csv_keys.js:33 static/js/zamboni/stats-all.js:15314 static/js/zamboni/stats-min.js:4
 msgid "Ratings"
 msgstr "Pohódnoćenja"
 
-#: static/js/impala/stats/csv_keys.js:36
-#: static/js/impala/stats/csv_keys.js:114 static/js/zamboni/stats-all.js:15317
-#: static/js/zamboni/stats-all.js:15395 static/js/zamboni/stats-min.js:4
+#: static/js/impala/stats/csv_keys.js:36 static/js/impala/stats/csv_keys.js:114 static/js/zamboni/stats-all.js:15317 static/js/zamboni/stats-all.js:15395 static/js/zamboni/stats-min.js:4
 #: static/js/zamboni/stats-min.js:5
 msgid "Sales"
 msgstr "Předanje"
 
-#: static/js/impala/stats/csv_keys.js:39
-#: static/js/impala/stats/csv_keys.js:113 static/js/zamboni/stats-all.js:15320
-#: static/js/zamboni/stats-all.js:15394 static/js/zamboni/stats-min.js:4
+#: static/js/impala/stats/csv_keys.js:39 static/js/impala/stats/csv_keys.js:113 static/js/zamboni/stats-all.js:15320 static/js/zamboni/stats-all.js:15394 static/js/zamboni/stats-min.js:4
 #: static/js/zamboni/stats-min.js:5
 msgid "Installs"
 msgstr "Instalacije"
 
-#: static/js/impala/stats/csv_keys.js:42 static/js/zamboni/stats-all.js:15323
-#: static/js/zamboni/stats-min.js:4
+#: static/js/impala/stats/csv_keys.js:42 static/js/zamboni/stats-all.js:15323 static/js/zamboni/stats-min.js:4
 msgid "Unknown"
 msgstr "Njeznate"
 
-#: static/js/impala/stats/csv_keys.js:43 static/js/zamboni/stats-all.js:15324
-#: static/js/zamboni/stats-min.js:4
+#: static/js/impala/stats/csv_keys.js:43 static/js/zamboni/stats-all.js:15324 static/js/zamboni/stats-min.js:4
 msgid "Add-ons Manager"
 msgstr "Zrjadowak přidatkow"
 
-#: static/js/impala/stats/csv_keys.js:44 static/js/zamboni/stats-all.js:15325
-#: static/js/zamboni/stats-min.js:4
+#: static/js/impala/stats/csv_keys.js:44 static/js/zamboni/stats-all.js:15325 static/js/zamboni/stats-min.js:4
 msgid "Add-ons Manager Promo"
 msgstr "Zrjadowak přidatkow „Promo“"
 
-#: static/js/impala/stats/csv_keys.js:45 static/js/zamboni/stats-all.js:15326
-#: static/js/zamboni/stats-min.js:4
+#: static/js/impala/stats/csv_keys.js:45 static/js/zamboni/stats-all.js:15326 static/js/zamboni/stats-min.js:4
 msgid "Add-ons Manager Featured"
 msgstr "W zrjadowaku přidatkow předstajene"
 
-#: static/js/impala/stats/csv_keys.js:46 static/js/zamboni/stats-all.js:15327
-#: static/js/zamboni/stats-min.js:4
+#: static/js/impala/stats/csv_keys.js:46 static/js/zamboni/stats-all.js:15327 static/js/zamboni/stats-min.js:4
 msgid "Add-ons Manager Learn More"
 msgstr "Zrjadowak přidatkow „Dalše informacije“"
 
-#: static/js/impala/stats/csv_keys.js:47 static/js/zamboni/stats-all.js:15328
-#: static/js/zamboni/stats-min.js:4
+#: static/js/impala/stats/csv_keys.js:47 static/js/zamboni/stats-all.js:15328 static/js/zamboni/stats-min.js:4
 msgid "Search Suggestions"
 msgstr "Pytanske namjety"
 
-#: static/js/impala/stats/csv_keys.js:48 static/js/zamboni/stats-all.js:15329
-#: static/js/zamboni/stats-min.js:4
+#: static/js/impala/stats/csv_keys.js:48 static/js/zamboni/stats-all.js:15329 static/js/zamboni/stats-min.js:4
 msgid "Search Results"
 msgstr "Pytanske wuslědki"
 
-#: static/js/impala/stats/csv_keys.js:49 static/js/impala/stats/csv_keys.js:50
-#: static/js/impala/stats/csv_keys.js:51 static/js/zamboni/stats-all.js:15330
-#: static/js/zamboni/stats-all.js:15331 static/js/zamboni/stats-all.js:15332
-#: static/js/zamboni/stats-min.js:4
+#: static/js/impala/stats/csv_keys.js:49 static/js/impala/stats/csv_keys.js:50 static/js/impala/stats/csv_keys.js:51 static/js/zamboni/stats-all.js:15330 static/js/zamboni/stats-all.js:15331
+#: static/js/zamboni/stats-all.js:15332 static/js/zamboni/stats-min.js:4
 msgid "Homepage Promo"
 msgstr "Startowa strona „Promo“"
 
-#: static/js/impala/stats/csv_keys.js:52 static/js/impala/stats/csv_keys.js:53
-#: static/js/zamboni/stats-all.js:15333 static/js/zamboni/stats-all.js:15334
-#: static/js/zamboni/stats-min.js:4
+#: static/js/impala/stats/csv_keys.js:52 static/js/impala/stats/csv_keys.js:53 static/js/zamboni/stats-all.js:15333 static/js/zamboni/stats-all.js:15334 static/js/zamboni/stats-min.js:4
 msgid "Homepage Featured"
 msgstr "Startowa strona „Předstajene“"
 
-#: static/js/impala/stats/csv_keys.js:54 static/js/impala/stats/csv_keys.js:55
-#: static/js/zamboni/stats-all.js:15335 static/js/zamboni/stats-all.js:15336
-#: static/js/zamboni/stats-min.js:4
+#: static/js/impala/stats/csv_keys.js:54 static/js/impala/stats/csv_keys.js:55 static/js/zamboni/stats-all.js:15335 static/js/zamboni/stats-all.js:15336 static/js/zamboni/stats-min.js:4
 msgid "Homepage Up and Coming"
 msgstr "Startowa strona „Nastawace“"
 
-#: static/js/impala/stats/csv_keys.js:56 static/js/zamboni/stats-all.js:15337
-#: static/js/zamboni/stats-min.js:4
+#: static/js/impala/stats/csv_keys.js:56 static/js/zamboni/stats-all.js:15337 static/js/zamboni/stats-min.js:4
 msgid "Homepage Most Popular"
 msgstr "Startowa strona „Najbóle woblubowane“"
 
-#: static/js/impala/stats/csv_keys.js:57 static/js/impala/stats/csv_keys.js:59
-#: static/js/zamboni/stats-all.js:15338 static/js/zamboni/stats-all.js:15340
-#: static/js/zamboni/stats-min.js:4
+#: static/js/impala/stats/csv_keys.js:57 static/js/impala/stats/csv_keys.js:59 static/js/zamboni/stats-all.js:15338 static/js/zamboni/stats-all.js:15340 static/js/zamboni/stats-min.js:4
 msgid "Detail Page"
 msgstr "Strona podrobnosćow"
 
-#: static/js/impala/stats/csv_keys.js:58 static/js/impala/stats/csv_keys.js:60
-#: static/js/zamboni/stats-all.js:15339 static/js/zamboni/stats-all.js:15341
-#: static/js/zamboni/stats-min.js:4
+#: static/js/impala/stats/csv_keys.js:58 static/js/impala/stats/csv_keys.js:60 static/js/zamboni/stats-all.js:15339 static/js/zamboni/stats-all.js:15341 static/js/zamboni/stats-min.js:4
 msgid "Detail Page (bottom)"
 msgstr "Strona podrobnosćow (deleka)"
 
-#: static/js/impala/stats/csv_keys.js:61 static/js/zamboni/stats-all.js:15342
-#: static/js/zamboni/stats-min.js:4
+#: static/js/impala/stats/csv_keys.js:61 static/js/zamboni/stats-all.js:15342 static/js/zamboni/stats-min.js:4
 msgid "Detail Page (Development Channel)"
 msgstr "Strona podrobnosćow (wuwiwarski kanal)"
 
-#: static/js/impala/stats/csv_keys.js:62 static/js/impala/stats/csv_keys.js:63
-#: static/js/impala/stats/csv_keys.js:64 static/js/zamboni/stats-all.js:15343
-#: static/js/zamboni/stats-all.js:15344 static/js/zamboni/stats-all.js:15345
-#: static/js/zamboni/stats-min.js:4
+#: static/js/impala/stats/csv_keys.js:62 static/js/impala/stats/csv_keys.js:63 static/js/impala/stats/csv_keys.js:64 static/js/zamboni/stats-all.js:15343 static/js/zamboni/stats-all.js:15344
+#: static/js/zamboni/stats-all.js:15345 static/js/zamboni/stats-min.js:4
 msgid "Often Used With"
 msgstr "Husto wužiwany z"
 
-#: static/js/impala/stats/csv_keys.js:65 static/js/impala/stats/csv_keys.js:66
-#: static/js/zamboni/stats-all.js:15346 static/js/zamboni/stats-all.js:15347
-#: static/js/zamboni/stats-min.js:4
+#: static/js/impala/stats/csv_keys.js:65 static/js/impala/stats/csv_keys.js:66 static/js/zamboni/stats-all.js:15346 static/js/zamboni/stats-all.js:15347 static/js/zamboni/stats-min.js:4
 msgid "Others By Author"
 msgstr "Druhe po awtorje"
 
-#: static/js/impala/stats/csv_keys.js:67 static/js/impala/stats/csv_keys.js:68
-#: static/js/zamboni/stats-all.js:15348 static/js/zamboni/stats-all.js:15349
-#: static/js/zamboni/stats-min.js:4
+#: static/js/impala/stats/csv_keys.js:67 static/js/impala/stats/csv_keys.js:68 static/js/zamboni/stats-all.js:15348 static/js/zamboni/stats-all.js:15349 static/js/zamboni/stats-min.js:4
 msgid "Dependencies"
 msgstr "Wotwisnosće"
 
-#: static/js/impala/stats/csv_keys.js:69 static/js/impala/stats/csv_keys.js:70
-#: static/js/zamboni/stats-all.js:15350 static/js/zamboni/stats-all.js:15351
-#: static/js/zamboni/stats-min.js:4
+#: static/js/impala/stats/csv_keys.js:69 static/js/impala/stats/csv_keys.js:70 static/js/zamboni/stats-all.js:15350 static/js/zamboni/stats-all.js:15351 static/js/zamboni/stats-min.js:4
 msgid "Upsell"
 msgstr "Přidatne předanje"
 
-#: static/js/impala/stats/csv_keys.js:71 static/js/zamboni/stats-all.js:15352
-#: static/js/zamboni/stats-min.js:4
+#: static/js/impala/stats/csv_keys.js:71 static/js/zamboni/stats-all.js:15352 static/js/zamboni/stats-min.js:4
 msgid "Meet the Developer"
 msgstr "Zeznajće z wuwiwarjom"
 
-#: static/js/impala/stats/csv_keys.js:72 static/js/zamboni/stats-all.js:15353
-#: static/js/zamboni/stats-min.js:4
+#: static/js/impala/stats/csv_keys.js:72 static/js/zamboni/stats-all.js:15353 static/js/zamboni/stats-min.js:4
 msgid "User Profile"
 msgstr "Wužiwarski profil"
 
-#: static/js/impala/stats/csv_keys.js:73 static/js/zamboni/stats-all.js:15354
-#: static/js/zamboni/stats-min.js:4
+#: static/js/impala/stats/csv_keys.js:73 static/js/zamboni/stats-all.js:15354 static/js/zamboni/stats-min.js:4
 msgid "Version History"
 msgstr "Wersijowa historija"
 
-#: static/js/impala/stats/csv_keys.js:75 static/js/zamboni/stats-all.js:15356
-#: static/js/zamboni/stats-min.js:4
+#: static/js/impala/stats/csv_keys.js:75 static/js/zamboni/stats-all.js:15356 static/js/zamboni/stats-min.js:4
 msgid "Sharing"
 msgstr "Dźělić"
 
-#: static/js/impala/stats/csv_keys.js:76 static/js/zamboni/stats-all.js:15357
-#: static/js/zamboni/stats-min.js:4
+#: static/js/impala/stats/csv_keys.js:76 static/js/zamboni/stats-all.js:15357 static/js/zamboni/stats-min.js:4
 msgid "Category Pages"
 msgstr "Kategorijowe strony"
 
-#: static/js/impala/stats/csv_keys.js:77 static/js/zamboni/stats-all.js:15358
-#: static/js/zamboni/stats-min.js:4
+#: static/js/impala/stats/csv_keys.js:77 static/js/zamboni/stats-all.js:15358 static/js/zamboni/stats-min.js:4
 msgid "Collections"
 msgstr "Zběrki"
 
-#: static/js/impala/stats/csv_keys.js:78 static/js/impala/stats/csv_keys.js:79
-#: static/js/zamboni/stats-all.js:15359 static/js/zamboni/stats-all.js:15360
-#: static/js/zamboni/stats-min.js:4
+#: static/js/impala/stats/csv_keys.js:78 static/js/impala/stats/csv_keys.js:79 static/js/zamboni/stats-all.js:15359 static/js/zamboni/stats-all.js:15360 static/js/zamboni/stats-min.js:4
 msgid "Category Landing Featured Carousel"
 msgstr "Kategorijowy přehlad „Karusel předstajenych“"
 
-#: static/js/impala/stats/csv_keys.js:80 static/js/impala/stats/csv_keys.js:81
-#: static/js/zamboni/stats-all.js:15361 static/js/zamboni/stats-all.js:15362
-#: static/js/zamboni/stats-min.js:4
+#: static/js/impala/stats/csv_keys.js:80 static/js/impala/stats/csv_keys.js:81 static/js/zamboni/stats-all.js:15361 static/js/zamboni/stats-all.js:15362 static/js/zamboni/stats-min.js:4
 msgid "Category Landing Top Rated"
 msgstr "Kategorijowy přehlad „Najwyše pohódnoćenje“"
 
-#: static/js/impala/stats/csv_keys.js:82 static/js/impala/stats/csv_keys.js:83
-#: static/js/zamboni/stats-all.js:15363 static/js/zamboni/stats-all.js:15364
-#: static/js/zamboni/stats-min.js:5
+#: static/js/impala/stats/csv_keys.js:82 static/js/impala/stats/csv_keys.js:83 static/js/zamboni/stats-all.js:15363 static/js/zamboni/stats-all.js:15364 static/js/zamboni/stats-min.js:5
 msgid "Category Landing Most Popular"
 msgstr "Kategorjowy přehlad „Najbóle woblubowane“"
 
-#: static/js/impala/stats/csv_keys.js:84 static/js/impala/stats/csv_keys.js:85
-#: static/js/zamboni/stats-all.js:15365 static/js/zamboni/stats-all.js:15366
-#: static/js/zamboni/stats-min.js:5
+#: static/js/impala/stats/csv_keys.js:84 static/js/impala/stats/csv_keys.js:85 static/js/zamboni/stats-all.js:15365 static/js/zamboni/stats-all.js:15366 static/js/zamboni/stats-min.js:5
 msgid "Category Landing Recently Added"
 msgstr "Kategorijowy přehlad „Njedawno přidate“"
 
-#: static/js/impala/stats/csv_keys.js:86 static/js/impala/stats/csv_keys.js:87
-#: static/js/zamboni/stats-all.js:15367 static/js/zamboni/stats-all.js:15368
-#: static/js/zamboni/stats-min.js:5
+#: static/js/impala/stats/csv_keys.js:86 static/js/impala/stats/csv_keys.js:87 static/js/zamboni/stats-all.js:15367 static/js/zamboni/stats-all.js:15368 static/js/zamboni/stats-min.js:5
 msgid "Browse Listing Featured Sort"
 msgstr "Lisćinu přepytować „Sortěrowane po předstajenych“"
 
-#: static/js/impala/stats/csv_keys.js:88 static/js/impala/stats/csv_keys.js:89
-#: static/js/zamboni/stats-all.js:15369 static/js/zamboni/stats-all.js:15370
-#: static/js/zamboni/stats-min.js:5
+#: static/js/impala/stats/csv_keys.js:88 static/js/impala/stats/csv_keys.js:89 static/js/zamboni/stats-all.js:15369 static/js/zamboni/stats-all.js:15370 static/js/zamboni/stats-min.js:5
 msgid "Browse Listing Users Sort"
 msgstr "Lisćinu přepytować „Sortěrowane po wužiwarjach“"
 
-#: static/js/impala/stats/csv_keys.js:90 static/js/impala/stats/csv_keys.js:91
-#: static/js/zamboni/stats-all.js:15371 static/js/zamboni/stats-all.js:15372
-#: static/js/zamboni/stats-min.js:5
+#: static/js/impala/stats/csv_keys.js:90 static/js/impala/stats/csv_keys.js:91 static/js/zamboni/stats-all.js:15371 static/js/zamboni/stats-all.js:15372 static/js/zamboni/stats-min.js:5
 msgid "Browse Listing Rating Sort"
 msgstr "Lisćinu přepytować „Sortěrowane po pohódnoćenju“"
 
-#: static/js/impala/stats/csv_keys.js:92 static/js/impala/stats/csv_keys.js:93
-#: static/js/zamboni/stats-all.js:15373 static/js/zamboni/stats-all.js:15374
-#: static/js/zamboni/stats-min.js:5
+#: static/js/impala/stats/csv_keys.js:92 static/js/impala/stats/csv_keys.js:93 static/js/zamboni/stats-all.js:15373 static/js/zamboni/stats-all.js:15374 static/js/zamboni/stats-min.js:5
 msgid "Browse Listing Created Sort"
 msgstr "Lisćinu přepytować „Sortěrowane po wutworjenju“"
 
-#: static/js/impala/stats/csv_keys.js:94 static/js/impala/stats/csv_keys.js:95
-#: static/js/zamboni/stats-all.js:15375 static/js/zamboni/stats-all.js:15376
-#: static/js/zamboni/stats-min.js:5
+#: static/js/impala/stats/csv_keys.js:94 static/js/impala/stats/csv_keys.js:95 static/js/zamboni/stats-all.js:15375 static/js/zamboni/stats-all.js:15376 static/js/zamboni/stats-min.js:5
 msgid "Browse Listing Name Sort"
 msgstr "Lisćinu přepytować „Sortěrowane po mjenje“"
 
-#: static/js/impala/stats/csv_keys.js:96 static/js/impala/stats/csv_keys.js:97
-#: static/js/zamboni/stats-all.js:15377 static/js/zamboni/stats-all.js:15378
-#: static/js/zamboni/stats-min.js:5
+#: static/js/impala/stats/csv_keys.js:96 static/js/impala/stats/csv_keys.js:97 static/js/zamboni/stats-all.js:15377 static/js/zamboni/stats-all.js:15378 static/js/zamboni/stats-min.js:5
 msgid "Browse Listing Popular Sort"
 msgstr "Lisćinu přepytować „Sortěrowane po woblubowanych“"
 
-#: static/js/impala/stats/csv_keys.js:98 static/js/impala/stats/csv_keys.js:99
-#: static/js/zamboni/stats-all.js:15379 static/js/zamboni/stats-all.js:15380
-#: static/js/zamboni/stats-min.js:5
+#: static/js/impala/stats/csv_keys.js:98 static/js/impala/stats/csv_keys.js:99 static/js/zamboni/stats-all.js:15379 static/js/zamboni/stats-all.js:15380 static/js/zamboni/stats-min.js:5
 msgid "Browse Listing Updated Sort"
 msgstr "Lisćinu přepytować „Sortěrowane po zaktualizowanych“"
 
-#: static/js/impala/stats/csv_keys.js:100
-#: static/js/impala/stats/csv_keys.js:101 static/js/zamboni/stats-all.js:15381
-#: static/js/zamboni/stats-all.js:15382 static/js/zamboni/stats-min.js:5
+#: static/js/impala/stats/csv_keys.js:100 static/js/impala/stats/csv_keys.js:101 static/js/zamboni/stats-all.js:15381 static/js/zamboni/stats-all.js:15382 static/js/zamboni/stats-min.js:5
 msgid "Browse Listing Up and Coming Sort"
 msgstr "Lisćinu přepytować „Sortěrowane po nastawacych“"
 
-#: static/js/impala/stats/csv_keys.js:105 static/js/zamboni/stats-all.js:15386
-#: static/js/zamboni/stats-min.js:5
+#: static/js/impala/stats/csv_keys.js:105 static/js/zamboni/stats-all.js:15386 static/js/zamboni/stats-min.js:5
 msgid "Total Amount Contributed"
 msgstr "Darjena suma dohromady"
 
-#: static/js/impala/stats/csv_keys.js:106 static/js/zamboni/stats-all.js:15387
-#: static/js/zamboni/stats-min.js:5
+#: static/js/impala/stats/csv_keys.js:106 static/js/zamboni/stats-all.js:15387 static/js/zamboni/stats-min.js:5
 msgid "Average Contribution"
 msgstr "Přerěznje darjena suma"
 
-#: static/js/impala/stats/csv_keys.js:115 static/js/zamboni/stats-all.js:15396
-#: static/js/zamboni/stats-min.js:5
+#: static/js/impala/stats/csv_keys.js:115 static/js/zamboni/stats-all.js:15396 static/js/zamboni/stats-min.js:5
 msgid "Usage"
 msgstr "Wužiwanje"
 
-#: static/js/impala/stats/csv_keys.js:118 static/js/zamboni/stats-all.js:15399
-#: static/js/zamboni/stats-min.js:5
+#: static/js/impala/stats/csv_keys.js:118 static/js/zamboni/stats-all.js:15399 static/js/zamboni/stats-min.js:5
 msgid "Firefox"
 msgstr "Firefox"
 
-#: static/js/impala/stats/csv_keys.js:119 static/js/zamboni/stats-all.js:15400
-#: static/js/zamboni/stats-min.js:5
+#: static/js/impala/stats/csv_keys.js:119 static/js/zamboni/stats-all.js:15400 static/js/zamboni/stats-min.js:5
 msgid "Mozilla"
 msgstr "Mozilla"
 
-#: static/js/impala/stats/csv_keys.js:120 static/js/zamboni/stats-all.js:15401
-#: static/js/zamboni/stats-min.js:5
+#: static/js/impala/stats/csv_keys.js:120 static/js/zamboni/stats-all.js:15401 static/js/zamboni/stats-min.js:5
 msgid "Thunderbird"
 msgstr "Thunderbird"
 
-#: static/js/impala/stats/csv_keys.js:121 static/js/zamboni/stats-all.js:15402
-#: static/js/zamboni/stats-min.js:5
+#: static/js/impala/stats/csv_keys.js:121 static/js/zamboni/stats-all.js:15402 static/js/zamboni/stats-min.js:5
 msgid "Sunbird"
 msgstr "Sunbird"
 
-#: static/js/impala/stats/csv_keys.js:122 static/js/zamboni/stats-all.js:15403
-#: static/js/zamboni/stats-min.js:5
+#: static/js/impala/stats/csv_keys.js:122 static/js/zamboni/stats-all.js:15403 static/js/zamboni/stats-min.js:5
 msgid "SeaMonkey"
 msgstr "SeaMonkey"
 
-#: static/js/impala/stats/csv_keys.js:123 static/js/zamboni/stats-all.js:15404
-#: static/js/zamboni/stats-min.js:5
+#: static/js/impala/stats/csv_keys.js:123 static/js/zamboni/stats-all.js:15404 static/js/zamboni/stats-min.js:5
 msgid "Fennec"
 msgstr "Fennec"
 
-#: static/js/impala/stats/csv_keys.js:124 static/js/zamboni/stats-all.js:15405
-#: static/js/zamboni/stats-min.js:5
+#: static/js/impala/stats/csv_keys.js:124 static/js/zamboni/stats-all.js:15405 static/js/zamboni/stats-min.js:5
 msgid "Android"
 msgstr "Android"
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:129 static/js/zamboni/stats-all.js:15410
-#: static/js/zamboni/stats-min.js:5
+#: static/js/impala/stats/csv_keys.js:129 static/js/zamboni/stats-all.js:15410 static/js/zamboni/stats-min.js:5
 msgid "Downloads and Daily Users, last {0} days"
 msgstr "Sćehnjenja a wšědni wužiwarjo, zańdźene {0} dnjow"
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:131 static/js/zamboni/stats-all.js:15412
-#: static/js/zamboni/stats-min.js:5
+#: static/js/impala/stats/csv_keys.js:131 static/js/zamboni/stats-all.js:15412 static/js/zamboni/stats-min.js:5
 msgid "Downloads and Daily Users from {0} to {1}"
 msgstr "Sćehnjenja a wšědni wužiwarjo wot {0} hač do {1}"
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:135 static/js/zamboni/stats-all.js:15416
-#: static/js/zamboni/stats-min.js:5
+#: static/js/impala/stats/csv_keys.js:135 static/js/zamboni/stats-all.js:15416 static/js/zamboni/stats-min.js:5
 msgid "Installs and Daily Users, last {0} days"
 msgstr "Instalacije a wšědni wužiwarjo, zańdźene {0} dnjow"
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:137 static/js/zamboni/stats-all.js:15418
-#: static/js/zamboni/stats-min.js:5
+#: static/js/impala/stats/csv_keys.js:137 static/js/zamboni/stats-all.js:15418 static/js/zamboni/stats-min.js:5
 msgid "Installs and Daily Users from {0} to {1}"
 msgstr "Instalacije a wšědni wužiwarjo wot {0} hač do {1}"
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:141 static/js/zamboni/stats-all.js:15422
-#: static/js/zamboni/stats-min.js:5
+#: static/js/impala/stats/csv_keys.js:141 static/js/zamboni/stats-all.js:15422 static/js/zamboni/stats-min.js:5
 msgid "Downloads, last {0} days"
 msgstr "Sćehnjenja, zańdźene {0} dnjow"
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:143 static/js/zamboni/stats-all.js:15424
-#: static/js/zamboni/stats-min.js:5
+#: static/js/impala/stats/csv_keys.js:143 static/js/zamboni/stats-all.js:15424 static/js/zamboni/stats-min.js:5
 msgid "Downloads from {0} to {1}"
 msgstr "Sćehnjenja wot {0} hač do {1}"
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:147 static/js/zamboni/stats-all.js:15428
-#: static/js/zamboni/stats-min.js:5
+#: static/js/impala/stats/csv_keys.js:147 static/js/zamboni/stats-all.js:15428 static/js/zamboni/stats-min.js:5
 msgid "Daily Users, last {0} days"
 msgstr "Wšědni wužiwarjo, zańdźene {0} dnjow"
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:149 static/js/zamboni/stats-all.js:15430
-#: static/js/zamboni/stats-min.js:5
+#: static/js/impala/stats/csv_keys.js:149 static/js/zamboni/stats-all.js:15430 static/js/zamboni/stats-min.js:5
 msgid "Daily Users from {0} to {1}"
 msgstr "Wšědni wužiwarjo wot {0} hač do {1}"
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:153 static/js/zamboni/stats-all.js:15434
-#: static/js/zamboni/stats-min.js:5
+#: static/js/impala/stats/csv_keys.js:153 static/js/zamboni/stats-all.js:15434 static/js/zamboni/stats-min.js:5
 msgid "Applications, last {0} days"
 msgstr "Nałoženja, zańdźene {0} dnjow"
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:155 static/js/zamboni/stats-all.js:15436
-#: static/js/zamboni/stats-min.js:5
+#: static/js/impala/stats/csv_keys.js:155 static/js/zamboni/stats-all.js:15436 static/js/zamboni/stats-min.js:5
 msgid "Applications from {0} to {1}"
 msgstr "Nałoženja wot {0} hač do {1}"
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:159 static/js/zamboni/stats-all.js:15440
-#: static/js/zamboni/stats-min.js:5
+#: static/js/impala/stats/csv_keys.js:159 static/js/zamboni/stats-all.js:15440 static/js/zamboni/stats-min.js:5
 msgid "Platforms, last {0} days"
 msgstr "Platformy, zańdźene {0} dnjow"
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:161 static/js/zamboni/stats-all.js:15442
-#: static/js/zamboni/stats-min.js:5
+#: static/js/impala/stats/csv_keys.js:161 static/js/zamboni/stats-all.js:15442 static/js/zamboni/stats-min.js:5
 msgid "Platforms from {0} to {1}"
 msgstr "Platformy wot {0} hač do {1}"
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:165 static/js/zamboni/stats-all.js:15446
-#: static/js/zamboni/stats-min.js:5
+#: static/js/impala/stats/csv_keys.js:165 static/js/zamboni/stats-all.js:15446 static/js/zamboni/stats-min.js:5
 msgid "Languages, last {0} days"
 msgstr "Rěče, zańdźene {0} dnjow"
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:167 static/js/zamboni/stats-all.js:15448
-#: static/js/zamboni/stats-min.js:5
+#: static/js/impala/stats/csv_keys.js:167 static/js/zamboni/stats-all.js:15448 static/js/zamboni/stats-min.js:5
 msgid "Languages from {0} to {1}"
 msgstr "Rěče wot {0} hač do {1}"
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:171 static/js/zamboni/stats-all.js:15452
-#: static/js/zamboni/stats-min.js:5
+#: static/js/impala/stats/csv_keys.js:171 static/js/zamboni/stats-all.js:15452 static/js/zamboni/stats-min.js:5
 msgid "Add-on Versions, last {0} days"
 msgstr "Přidatkowe wersije, zańdźene {0} dnjow"
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:173 static/js/zamboni/stats-all.js:15454
-#: static/js/zamboni/stats-min.js:5
+#: static/js/impala/stats/csv_keys.js:173 static/js/zamboni/stats-all.js:15454 static/js/zamboni/stats-min.js:5
 msgid "Add-on Versions from {0} to {1}"
 msgstr "Přidatkowe wersije wot {0} hač do {1}"
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:177 static/js/zamboni/stats-all.js:15458
-#: static/js/zamboni/stats-min.js:5
+#: static/js/impala/stats/csv_keys.js:177 static/js/zamboni/stats-all.js:15458 static/js/zamboni/stats-min.js:5
 msgid "Add-on Status, last {0} days"
 msgstr "Přidatkowy status, zańdźene {0} dnjow"
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:179 static/js/zamboni/stats-all.js:15460
-#: static/js/zamboni/stats-min.js:5
+#: static/js/impala/stats/csv_keys.js:179 static/js/zamboni/stats-all.js:15460 static/js/zamboni/stats-min.js:5
 msgid "Add-on Status from {0} to {1}"
 msgstr "Přidatkowy status wot {0} hač do {1}"
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:183 static/js/zamboni/stats-all.js:15464
-#: static/js/zamboni/stats-min.js:5
+#: static/js/impala/stats/csv_keys.js:183 static/js/zamboni/stats-all.js:15464 static/js/zamboni/stats-min.js:5
 msgid "Download Sources, last {0} days"
 msgstr "Sćehnjenske žórła, zańdźene {0} dnjow"
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:185 static/js/zamboni/stats-all.js:15466
-#: static/js/zamboni/stats-min.js:5
+#: static/js/impala/stats/csv_keys.js:185 static/js/zamboni/stats-all.js:15466 static/js/zamboni/stats-min.js:5
 msgid "Download Sources from {0} to {1}"
 msgstr "Sćehnjenske žórła wot {0} hač do {1}"
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:189 static/js/zamboni/stats-all.js:15470
-#: static/js/zamboni/stats-min.js:5
+#: static/js/impala/stats/csv_keys.js:189 static/js/zamboni/stats-all.js:15470 static/js/zamboni/stats-min.js:5
 msgid "Contributions, last {0} days"
 msgstr "Přinoški, zańdźene {0} dnjow"
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:191 static/js/zamboni/stats-all.js:15472
-#: static/js/zamboni/stats-min.js:5
+#: static/js/impala/stats/csv_keys.js:191 static/js/zamboni/stats-all.js:15472 static/js/zamboni/stats-min.js:5
 msgid "Contributions from {0} to {1}"
 msgstr "Přinoški wot {0} hač do {1}"
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:195 static/js/zamboni/stats-all.js:15476
-#: static/js/zamboni/stats-min.js:5
+#: static/js/impala/stats/csv_keys.js:195 static/js/zamboni/stats-all.js:15476 static/js/zamboni/stats-min.js:5
 msgid "Site Metrics, last {0} days"
 msgstr "Sydłowa statistika, zańdźene {0} dnjow"
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:197 static/js/zamboni/stats-all.js:15478
-#: static/js/zamboni/stats-min.js:5
+#: static/js/impala/stats/csv_keys.js:197 static/js/zamboni/stats-all.js:15478 static/js/zamboni/stats-min.js:5
 msgid "Site Metrics from {0} to {1}"
 msgstr "Sydłowa statistika wot {0} hač do {1}"
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:201 static/js/zamboni/stats-all.js:15482
-#: static/js/zamboni/stats-min.js:5
+#: static/js/impala/stats/csv_keys.js:201 static/js/zamboni/stats-all.js:15482 static/js/zamboni/stats-min.js:5
 msgid "Add-ons in Use, last {0} days"
 msgstr "Wužiwane přidatki, zańdźene {0} dnjow"
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:203 static/js/zamboni/stats-all.js:15484
-#: static/js/zamboni/stats-min.js:5
+#: static/js/impala/stats/csv_keys.js:203 static/js/zamboni/stats-all.js:15484 static/js/zamboni/stats-min.js:5
 msgid "Add-ons in Use from {0} to {1}"
 msgstr "Wužiwane přidatki wot {0} hač do {1}"
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:207 static/js/zamboni/stats-all.js:15488
-#: static/js/zamboni/stats-min.js:5
+#: static/js/impala/stats/csv_keys.js:207 static/js/zamboni/stats-all.js:15488 static/js/zamboni/stats-min.js:5
 msgid "Add-ons Downloaded, last {0} days"
 msgstr "Sćehnjene přidatki, zańdźene {0} dnjow"
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:209 static/js/zamboni/stats-all.js:15490
-#: static/js/zamboni/stats-min.js:5
+#: static/js/impala/stats/csv_keys.js:209 static/js/zamboni/stats-all.js:15490 static/js/zamboni/stats-min.js:5
 msgid "Add-ons Downloaded from {0} to {1}"
 msgstr "Sćehnjene přidatki wot {0} hač do {1}"
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:213 static/js/zamboni/stats-all.js:15494
-#: static/js/zamboni/stats-min.js:5
+#: static/js/impala/stats/csv_keys.js:213 static/js/zamboni/stats-all.js:15494 static/js/zamboni/stats-min.js:5
 msgid "Add-ons Created, last {0} days"
 msgstr "Wutworjene přidatki, zańdźene {0} dnjow"
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:215 static/js/zamboni/stats-all.js:15496
-#: static/js/zamboni/stats-min.js:5
+#: static/js/impala/stats/csv_keys.js:215 static/js/zamboni/stats-all.js:15496 static/js/zamboni/stats-min.js:5
 msgid "Add-ons Created from {0} to {1}"
 msgstr "Wutworjene přidatki wot {0} hač do {1}"
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:219 static/js/zamboni/stats-all.js:15500
-#: static/js/zamboni/stats-min.js:5
+#: static/js/impala/stats/csv_keys.js:219 static/js/zamboni/stats-all.js:15500 static/js/zamboni/stats-min.js:5
 msgid "Add-ons Updated, last {0} days"
 msgstr "Zaktualizowane přidatki, zańdźene {0} dnjow"
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:221 static/js/zamboni/stats-all.js:15502
-#: static/js/zamboni/stats-min.js:5
+#: static/js/impala/stats/csv_keys.js:221 static/js/zamboni/stats-all.js:15502 static/js/zamboni/stats-min.js:5
 msgid "Add-ons Updated from {0} to {1}"
 msgstr "Zaktualizowane přidatki wot {0} hač do {1}"
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:225 static/js/zamboni/stats-all.js:15506
-#: static/js/zamboni/stats-min.js:5
+#: static/js/impala/stats/csv_keys.js:225 static/js/zamboni/stats-all.js:15506 static/js/zamboni/stats-min.js:5
 msgid "Reviews Written, last {0} days"
 msgstr "Napisane pohódnoćenja, zańdźene {0} dnjow"
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:227 static/js/zamboni/stats-all.js:15508
-#: static/js/zamboni/stats-min.js:5
+#: static/js/impala/stats/csv_keys.js:227 static/js/zamboni/stats-all.js:15508 static/js/zamboni/stats-min.js:5
 msgid "Reviews Written from {0} to {1}"
 msgstr "Napisane pohódnoćenja wot {0} hač do {1}"
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:231 static/js/zamboni/stats-all.js:15512
-#: static/js/zamboni/stats-min.js:5
+#: static/js/impala/stats/csv_keys.js:231 static/js/zamboni/stats-all.js:15512 static/js/zamboni/stats-min.js:5
 msgid "User Signups, last {0} days"
 msgstr "Wužiwarske registrowanja, zańdźene {0} dnjow"
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:233 static/js/zamboni/stats-all.js:15514
-#: static/js/zamboni/stats-min.js:5
+#: static/js/impala/stats/csv_keys.js:233 static/js/zamboni/stats-all.js:15514 static/js/zamboni/stats-min.js:5
 msgid "User Signups from {0} to {1}"
 msgstr "Wužiwarske registrowanja wot {0} hač do {1}"
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:237 static/js/zamboni/stats-all.js:15518
-#: static/js/zamboni/stats-min.js:5
+#: static/js/impala/stats/csv_keys.js:237 static/js/zamboni/stats-all.js:15518 static/js/zamboni/stats-min.js:5
 msgid "Collections Created, last {0} days"
 msgstr "Wutworjene zběrki, zańdźene {0} dnjow"
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:239 static/js/zamboni/stats-all.js:15520
-#: static/js/zamboni/stats-min.js:5
+#: static/js/impala/stats/csv_keys.js:239 static/js/zamboni/stats-all.js:15520 static/js/zamboni/stats-min.js:5
 msgid "Collections Created from {0} to {1}"
 msgstr "Wutworjene zběrki wot {0} hač do {1}"
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:243 static/js/zamboni/stats-all.js:15524
-#: static/js/zamboni/stats-min.js:5
+#: static/js/impala/stats/csv_keys.js:243 static/js/zamboni/stats-all.js:15524 static/js/zamboni/stats-min.js:5
 msgid "Subscribers, last {0} days"
 msgstr "Abonenća, zańdźene {0} dnjow"
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:245 static/js/zamboni/stats-all.js:15526
-#: static/js/zamboni/stats-min.js:5
+#: static/js/impala/stats/csv_keys.js:245 static/js/zamboni/stats-all.js:15526 static/js/zamboni/stats-min.js:5
 msgid "Subscribers from {0} to {1}"
 msgstr "Abonenća wot {0} hač do {1}"
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:249 static/js/zamboni/stats-all.js:15530
-#: static/js/zamboni/stats-min.js:5
+#: static/js/impala/stats/csv_keys.js:249 static/js/zamboni/stats-all.js:15530 static/js/zamboni/stats-min.js:5
 msgid "Ratings, last {0} days"
 msgstr "Pohódnoćenja, zańdźene {0} dnjow"
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:251 static/js/zamboni/stats-all.js:15532
-#: static/js/zamboni/stats-min.js:5
+#: static/js/impala/stats/csv_keys.js:251 static/js/zamboni/stats-all.js:15532 static/js/zamboni/stats-min.js:5
 msgid "Ratings from {0} to {1}"
 msgstr "Pohódnoćenja wot {0} hač do {1}"
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:255 static/js/zamboni/stats-all.js:15536
-#: static/js/zamboni/stats-min.js:5
+#: static/js/impala/stats/csv_keys.js:255 static/js/zamboni/stats-all.js:15536 static/js/zamboni/stats-min.js:5
 msgid "Sales, last {0} days"
 msgstr "Předanje, zańdźene {0} dnjow"
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:257 static/js/zamboni/stats-all.js:15538
-#: static/js/zamboni/stats-min.js:5
+#: static/js/impala/stats/csv_keys.js:257 static/js/zamboni/stats-all.js:15538 static/js/zamboni/stats-min.js:5
 msgid "Sales from {0} to {1}"
 msgstr "Předanje wot {0} hač do {1}"
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:261 static/js/zamboni/stats-all.js:15542
-#: static/js/zamboni/stats-min.js:5
+#: static/js/impala/stats/csv_keys.js:261 static/js/zamboni/stats-all.js:15542 static/js/zamboni/stats-min.js:5
 msgid "Installs, last {0} days"
 msgstr "Instalacije, zańdźene {0} dnjow"
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:263 static/js/zamboni/stats-all.js:15544
-#: static/js/zamboni/stats-min.js:5
+#: static/js/impala/stats/csv_keys.js:263 static/js/zamboni/stats-all.js:15544 static/js/zamboni/stats-min.js:5
 msgid "Installs from {0} to {1}"
 msgstr "Instalacije wot {0} hač do {1}"
 
 #. L10n: {0} and {1} are integers.
-#: static/js/impala/stats/csv_keys.js:269 static/js/zamboni/stats-all.js:15550
-#: static/js/zamboni/stats-min.js:5
+#: static/js/impala/stats/csv_keys.js:269 static/js/zamboni/stats-all.js:15550 static/js/zamboni/stats-min.js:5
 msgid "<b>{0}</b> in last {1} days"
 msgstr "<b>{0}</b> w zańdźenych {1} dnjach"
 
 #. L10n: {0} is an integer and {1} and {2} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:271
-#: static/js/impala/stats/csv_keys.js:277 static/js/zamboni/stats-all.js:15552
-#: static/js/zamboni/stats-all.js:15558 static/js/zamboni/stats-min.js:5
+#: static/js/impala/stats/csv_keys.js:271 static/js/impala/stats/csv_keys.js:277 static/js/zamboni/stats-all.js:15552 static/js/zamboni/stats-all.js:15558 static/js/zamboni/stats-min.js:5
 msgid "<b>{0}</b> from {1} to {2}"
 msgstr "<b>{0}</b> wot {1} hač do {2}"
 
 #. L10n: {0} and {1} are integers.
-#: static/js/impala/stats/csv_keys.js:275 static/js/zamboni/stats-all.js:15556
-#: static/js/zamboni/stats-min.js:5
+#: static/js/impala/stats/csv_keys.js:275 static/js/zamboni/stats-all.js:15556 static/js/zamboni/stats-min.js:5
 msgid "<b>{0}</b> average in last {1} days"
 msgstr "Přerěznje <b>{0}</b> w zańdźenych {1} dnjach"
 
-#: static/js/impala/stats/overview.js:19 static/js/zamboni/stats-all.js:16469
-#: static/js/zamboni/stats-min.js:5
+#: static/js/impala/stats/overview.js:19 static/js/zamboni/stats-all.js:16469 static/js/zamboni/stats-min.js:5
 msgid "No data available."
 msgstr "Žane daty k dispoziciji."
 
-#: static/js/impala/stats/table.js:74 static/js/zamboni/stats-all.js:17209
-#: static/js/zamboni/stats-min.js:5
+#: static/js/impala/stats/table.js:74 static/js/zamboni/stats-all.js:17209 static/js/zamboni/stats-min.js:5
 msgid "Date"
 msgstr "Datum"
 
-#: static/js/impala/stats/topchart.js:96 static/js/zamboni/stats-all.js:16600
-#: static/js/zamboni/stats-min.js:5
+#: static/js/impala/stats/topchart.js:96 static/js/zamboni/stats-all.js:16600 static/js/zamboni/stats-min.js:5
 msgid "Other"
 msgstr "Druhe"
 
-#: static/js/zamboni/admin-all.js:180 static/js/zamboni/admin-min.js:1
-#: static/js/zamboni/admin_validation.js:24
-#: static/js/zamboni/devhub-all.js:2408 static/js/zamboni/devhub-min.js:2
-#: static/js/zamboni/devhub.js:1229 static/js/zamboni/editors-all.js:15576
-#: static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:295
+#: static/js/zamboni/admin-all.js:180 static/js/zamboni/admin-min.js:1 static/js/zamboni/admin_validation.js:24 static/js/zamboni/devhub-all.js:2408 static/js/zamboni/devhub-min.js:2
+#: static/js/zamboni/devhub.js:1229 static/js/zamboni/editors-all.js:15576 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:295
 msgid "Select an application first"
 msgstr "Wubjerće najprjedy nałoženje"
 
-#: static/js/zamboni/admin-all.js:207 static/js/zamboni/admin-min.js:1
-#: static/js/zamboni/admin_validation.js:51
+#: static/js/zamboni/admin-all.js:207 static/js/zamboni/admin-min.js:1 static/js/zamboni/admin_validation.js:51
 msgid "Set {0} add-on to a max version of {1} and email the author."
 msgid_plural "Set {0} add-ons to a max version of {1} and email the authors."
-msgstr[0] ""
-"{0} přidatk na maksimalnu wersiju {1} stajić a awtorej e-mejlku pósłać"
-msgstr[1] ""
-"{0} přidatkaj na maksimalnu wersiju {1} stajić a awtorej e-mejlku pósłać"
-msgstr[2] ""
-"{0} přidatki na maksimalnu wersiju {1} stajić a awtorej e-mejlku pósłać"
-msgstr[3] ""
-"{0} přidatkow na maksimalnu wersiju {1} stajić a awtorej e-mejlku pósłać"
+msgstr[0] "{0} přidatk na maksimalnu wersiju {1} stajić a awtorej e-mejlku pósłać"
+msgstr[1] "{0} přidatkaj na maksimalnu wersiju {1} stajić a awtorej e-mejlku pósłać"
+msgstr[2] "{0} přidatki na maksimalnu wersiju {1} stajić a awtorej e-mejlku pósłać"
+msgstr[3] "{0} přidatkow na maksimalnu wersiju {1} stajić a awtorej e-mejlku pósłać"
 
-#: static/js/zamboni/admin-all.js:210 static/js/zamboni/admin-min.js:1
-#: static/js/zamboni/admin_validation.js:54
+#: static/js/zamboni/admin-all.js:210 static/js/zamboni/admin-min.js:1 static/js/zamboni/admin_validation.js:54
 msgid "Email author of {2} add-on which failed validation."
 msgid_plural "Email authors of {2} add-ons which failed validation."
-msgstr[0] ""
-"Awtorej {2} přidatka e-mejlku pósłać, kotrehož přepruwowanje je so "
-"nimokuliło."
-msgstr[1] ""
-"Awtorej {2} přidatkow e-mejlku pósłać, kotrejuž přepruwowanje je so "
-"nimokuliło."
-msgstr[2] ""
-"Awtorej {2} přidatkow e-mejlku pósłać, kotrychž přepruwowanje je so "
-"nimokuliło."
-msgstr[3] ""
-"Awtorej {2} přidatkow e-mejlku pósłać, kotrychž přepruwowanje je so "
-"nimokuliło."
+msgstr[0] "Awtorej {2} přidatka e-mejlku pósłać, kotrehož přepruwowanje je so nimokuliło."
+msgstr[1] "Awtorej {2} přidatkow e-mejlku pósłać, kotrejuž přepruwowanje je so nimokuliło."
+msgstr[2] "Awtorej {2} přidatkow e-mejlku pósłać, kotrychž přepruwowanje je so nimokuliło."
+msgstr[3] "Awtorej {2} přidatkow e-mejlku pósłać, kotrychž přepruwowanje je so nimokuliło."
 
-#: static/js/zamboni/devhub-all.js:1289 static/js/zamboni/devhub-min.js:1
-#: static/js/zamboni/devhub.js:110
+#: static/js/zamboni/devhub-all.js:1289 static/js/zamboni/devhub-min.js:1 static/js/zamboni/devhub.js:110
 msgid "Your browser does not support the video tag"
 msgstr "Waš wobhladowak značku video njepodpěruje"
 
-#: static/js/zamboni/devhub-all.js:1550 static/js/zamboni/devhub-min.js:1
-#: static/js/zamboni/devhub.js:371
+#: static/js/zamboni/devhub-all.js:1550 static/js/zamboni/devhub-min.js:1 static/js/zamboni/devhub.js:371
 msgid "Changes Saved"
 msgstr "Změny su so składowali"
 
-#: static/js/zamboni/devhub-all.js:1566 static/js/zamboni/devhub-min.js:1
-#: static/js/zamboni/devhub.js:387
+#: static/js/zamboni/devhub-all.js:1566 static/js/zamboni/devhub-min.js:1 static/js/zamboni/devhub.js:387
 msgid "Enter a new author's email address"
 msgstr "E-mejlowu adresu noweho awtora zapodać"
 
-#: static/js/zamboni/devhub-all.js:1715 static/js/zamboni/devhub-min.js:1
-#: static/js/zamboni/devhub.js:536
+#: static/js/zamboni/devhub-all.js:1715 static/js/zamboni/devhub-min.js:1 static/js/zamboni/devhub.js:536
 msgid "There was an error uploading your file."
 msgstr "Při nahrawanju wašeje dataje je zmylk wustupił."
 
-#: static/js/zamboni/devhub-all.js:1860 static/js/zamboni/devhub-min.js:1
-#: static/js/zamboni/devhub.js:681
+#: static/js/zamboni/devhub-all.js:1860 static/js/zamboni/devhub-min.js:1 static/js/zamboni/devhub.js:681
 msgid "{files} file"
 msgid_plural "{files} files"
 msgstr[0] "{files} dataja"
@@ -1378,8 +1029,7 @@ msgstr[1] "{files} dataji"
 msgstr[2] "{files} dataje"
 msgstr[3] "{files} datajow"
 
-#: static/js/zamboni/devhub-all.js:1863 static/js/zamboni/devhub-min.js:1
-#: static/js/zamboni/devhub.js:684
+#: static/js/zamboni/devhub-all.js:1863 static/js/zamboni/devhub-min.js:1 static/js/zamboni/devhub.js:684
 msgid "{reviews} user review"
 msgid_plural "{reviews} user reviews"
 msgstr[0] "{reviews} wužiwarske pohódnoćenje"
@@ -1387,89 +1037,70 @@ msgstr[1] "{reviews} wužiwarskej pohódnoćeni"
 msgstr[2] "{reviews} wužiwarske pohódnoćenja"
 msgstr[3] "{reviews} wužiwarskich pohódnoćenjow"
 
-#: static/js/zamboni/devhub-all.js:1975 static/js/zamboni/devhub-min.js:2
-#: static/js/zamboni/devhub.js:796
+#: static/js/zamboni/devhub-all.js:1975 static/js/zamboni/devhub-min.js:2 static/js/zamboni/devhub.js:796
 msgid "Learn more"
 msgstr "Dalše informacije"
 
-#: static/js/zamboni/devhub-all.js:1979 static/js/zamboni/devhub-min.js:2
-#: static/js/zamboni/devhub.js:800
+#: static/js/zamboni/devhub-all.js:1979 static/js/zamboni/devhub-min.js:2 static/js/zamboni/devhub.js:800
 msgid "Example"
 msgstr "Přikład"
 
-#: static/js/zamboni/devhub-all.js:2309 static/js/zamboni/devhub-min.js:2
-#: static/js/zamboni/devhub.js:1130
+#: static/js/zamboni/devhub-all.js:2309 static/js/zamboni/devhub-min.js:2 static/js/zamboni/devhub.js:1130
 msgid "Image changes being processed"
 msgstr "Wobrazowe změny so předźěłuja"
 
-#: static/js/zamboni/devhub-all.js:2459 static/js/zamboni/devhub-min.js:2
-#: static/js/zamboni/devhub.js:1280
+#: static/js/zamboni/devhub-all.js:2459 static/js/zamboni/devhub-min.js:2 static/js/zamboni/devhub.js:1280
 msgid "Must be a valid e-mail address."
 msgstr "To dyrbi płaćiwa e-mejlowa adresa być."
 
-#: static/js/zamboni/devhub-all.js:2613 static/js/zamboni/devhub-min.js:2
-#: static/js/zamboni/validator.js:80
+#: static/js/zamboni/devhub-all.js:2613 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:80
 msgid "All tests passed successfully."
 msgstr "Wšě testy wuspěšnje zakónčene."
 
-#: static/js/zamboni/devhub-all.js:2616 static/js/zamboni/devhub-all.js:3011
-#: static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:83
-#: static/js/zamboni/validator.js:478
+#: static/js/zamboni/devhub-all.js:2616 static/js/zamboni/devhub-all.js:3011 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:83 static/js/zamboni/validator.js:478
 msgid "These tests were not run."
 msgstr "Tute testy njejsu so přewjedli."
 
-#: static/js/zamboni/devhub-all.js:2664 static/js/zamboni/devhub-all.js:2677
-#: static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:131
-#: static/js/zamboni/validator.js:144
+#: static/js/zamboni/devhub-all.js:2664 static/js/zamboni/devhub-all.js:2677 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:131 static/js/zamboni/validator.js:144
 msgid "Tests"
 msgstr "Testy"
 
-#: static/js/zamboni/devhub-all.js:2779 static/js/zamboni/devhub-all.js:3108
-#: static/js/zamboni/devhub-all.js:3127 static/js/zamboni/devhub-min.js:2
-#: static/js/zamboni/validator.js:246 static/js/zamboni/validator.js:575
-#: static/js/zamboni/validator.js:594
+#: static/js/zamboni/devhub-all.js:2779 static/js/zamboni/devhub-all.js:3108 static/js/zamboni/devhub-all.js:3127 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:246
+#: static/js/zamboni/validator.js:575 static/js/zamboni/validator.js:594
 msgid "Error"
 msgstr "Zmylk"
 
-#: static/js/zamboni/devhub-all.js:2780 static/js/zamboni/devhub-min.js:2
-#: static/js/zamboni/validator.js:247
+#: static/js/zamboni/devhub-all.js:2780 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:247
 msgid "Warning"
 msgstr "Warnowanje"
 
-#: static/js/zamboni/devhub-all.js:2794 static/js/zamboni/devhub-min.js:2
-#: static/js/zamboni/files-all.js:5657 static/js/zamboni/files-min.js:3
-#: static/js/zamboni/files.js:411 static/js/zamboni/validator.js:261
+#: static/js/zamboni/devhub-all.js:2794 static/js/zamboni/devhub-min.js:2 static/js/zamboni/files-all.js:5657 static/js/zamboni/files-min.js:3 static/js/zamboni/files.js:411
+#: static/js/zamboni/validator.js:261
 msgid "Ignore this message in future updates"
 msgstr "Tutu zdźělenku w přichodnych aktualizacijach ignorować"
 
-#: static/js/zamboni/devhub-all.js:2817 static/js/zamboni/devhub-min.js:2
-#: static/js/zamboni/files-all.js:5663 static/js/zamboni/files-min.js:3
-#: static/js/zamboni/files.js:417 static/js/zamboni/validator.js:284
+#: static/js/zamboni/devhub-all.js:2817 static/js/zamboni/devhub-min.js:2 static/js/zamboni/files-all.js:5663 static/js/zamboni/files-min.js:3 static/js/zamboni/files.js:417
+#: static/js/zamboni/validator.js:284
 msgid "Severity for automated signing:"
 msgstr "Nuznosć za awtomatiske signowanje:"
 
-#: static/js/zamboni/devhub-all.js:2832 static/js/zamboni/devhub-min.js:2
-#: static/js/zamboni/validator.js:299
+#: static/js/zamboni/devhub-all.js:2832 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:299
 msgid "Suggestions for passing automated signing:"
 msgstr "Namjety za wobstaće awtomatiskeho signowanja:"
 
-#: static/js/zamboni/devhub-all.js:2920 static/js/zamboni/devhub-min.js:2
-#: static/js/zamboni/validator.js:387
+#: static/js/zamboni/devhub-all.js:2920 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:387
 msgid "Compatibility Tests"
 msgstr "Testy kompatibelnosće"
 
-#: static/js/zamboni/devhub-all.js:2999 static/js/zamboni/devhub-min.js:2
-#: static/js/zamboni/validator.js:466
+#: static/js/zamboni/devhub-all.js:2999 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:466
 msgid "Add-on failed validation."
 msgstr "Přidatk je při přepruwowanju přepadnył."
 
-#: static/js/zamboni/devhub-all.js:3001 static/js/zamboni/devhub-min.js:2
-#: static/js/zamboni/validator.js:468
+#: static/js/zamboni/devhub-all.js:3001 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:468
 msgid "Add-on passed validation."
 msgstr "Přidatk je přepruwowanje wobstał."
 
-#: static/js/zamboni/devhub-all.js:3014 static/js/zamboni/devhub-min.js:2
-#: static/js/zamboni/validator.js:481
+#: static/js/zamboni/devhub-all.js:3014 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:481
 msgid "{0} error"
 msgid_plural "{0} errors"
 msgstr[0] "{0} zmylk"
@@ -1477,8 +1108,7 @@ msgstr[1] "{0} zmylkaj"
 msgstr[2] "{0} zmylki"
 msgstr[3] "{0} zmylkow"
 
-#: static/js/zamboni/devhub-all.js:3016 static/js/zamboni/devhub-min.js:2
-#: static/js/zamboni/validator.js:483
+#: static/js/zamboni/devhub-all.js:3016 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:483
 msgid "{0} warning"
 msgid_plural "{0} warnings"
 msgstr[0] "{0} warnowanje"
@@ -1486,8 +1116,7 @@ msgstr[1] "{0} warnowani"
 msgstr[2] "{0} warnowanja"
 msgstr[3] "{0} warnowanjow"
 
-#: static/js/zamboni/devhub-all.js:3018 static/js/zamboni/devhub-min.js:2
-#: static/js/zamboni/validator.js:485
+#: static/js/zamboni/devhub-all.js:3018 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:485
 msgid "{0} notice"
 msgid_plural "{0} notices"
 msgstr[0] "{0} powěsć"
@@ -1495,13 +1124,11 @@ msgstr[1] "{0} powěsći"
 msgstr[2] "{0} powěsće"
 msgstr[3] "{0} powěsćow"
 
-#: static/js/zamboni/devhub-all.js:3110 static/js/zamboni/devhub-min.js:2
-#: static/js/zamboni/validator.js:577
+#: static/js/zamboni/devhub-all.js:3110 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:577
 msgid "Validation task could not complete or completed with errors"
 msgstr "Přepruwowanje njeda so dokónčić abo je so ze zmylkami dokónčiło"
 
-#: static/js/zamboni/devhub-all.js:3128 static/js/zamboni/devhub-min.js:2
-#: static/js/zamboni/validator.js:595
+#: static/js/zamboni/devhub-all.js:3128 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:595
 msgid "Internal server error"
 msgstr "Nutřkowny serwerowy zmylk"
 
@@ -1509,168 +1136,134 @@ msgstr "Nutřkowny serwerowy zmylk"
 msgid "No results found."
 msgstr "Žane wusědki namakane."
 
-#: static/js/zamboni/editors-all.js:15402 static/js/zamboni/editors-min.js:4
-#: static/js/zamboni/editors.js:121
+#: static/js/zamboni/editors-all.js:15402 static/js/zamboni/editors-min.js:4 static/js/zamboni/editors.js:121
 msgid "{name} was viewing this page first."
 msgstr "{name} je sej tutu stronu jako prěni wobhladał."
 
-#: static/js/zamboni/editors-all.js:15452 static/js/zamboni/editors-min.js:5
-#: static/js/zamboni/editors.js:171
+#: static/js/zamboni/editors-all.js:15452 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:171
 msgid "Receipt checked by app."
 msgstr "Kwitowanka je so přez nałoženje přepruwowała."
 
-#: static/js/zamboni/editors-all.js:15454 static/js/zamboni/editors-min.js:5
-#: static/js/zamboni/editors.js:173
+#: static/js/zamboni/editors-all.js:15454 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:173
 msgid "Receipt was not checked by app."
 msgstr "Kwitowanka njeje so přez nałoženje přepruwowała."
 
-#: static/js/zamboni/editors-all.js:15525 static/js/zamboni/editors-min.js:5
-#: static/js/zamboni/editors.js:244
+#: static/js/zamboni/editors-all.js:15525 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:244
 msgid "{name} was viewing this add-on first."
 msgstr "{name} je sej tutón přidatk jako prěni wobhladał."
 
-#: static/js/zamboni/editors-all.js:15536 static/js/zamboni/editors-min.js:5
-#: static/js/zamboni/editors.js:255
+#: static/js/zamboni/editors-all.js:15536 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:255
 msgid "Loading&hellip;"
 msgstr "Začituje so&hellip;"
 
-#: static/js/zamboni/editors-all.js:15541 static/js/zamboni/editors-min.js:5
-#: static/js/zamboni/editors.js:260
+#: static/js/zamboni/editors-all.js:15541 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:260
 msgid "Version Notes"
 msgstr "Wersijowe pokazy"
 
-#: static/js/zamboni/editors-all.js:15546 static/js/zamboni/editors-min.js:5
-#: static/js/zamboni/editors.js:265
+#: static/js/zamboni/editors-all.js:15546 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:265
 msgid "Notes for Reviewers"
 msgstr "Pokazy za přepruwowarjow"
 
-#: static/js/zamboni/editors-all.js:15551 static/js/zamboni/editors-min.js:5
-#: static/js/zamboni/editors.js:270
+#: static/js/zamboni/editors-all.js:15551 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:270
 msgid "No version notes found"
 msgstr "Žane wersijowe pokazy namakane"
 
-#: static/js/zamboni/editors-all.js:15611 static/js/zamboni/editors-min.js:5
-#: static/js/zamboni/editors.js:330
+#: static/js/zamboni/editors-all.js:15611 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:330
 msgid "Average Reviews"
 msgstr "Přerězne pohódnoćenja"
 
-#: static/js/zamboni/editors-all.js:15667 static/js/zamboni/editors-min.js:5
-#: static/js/zamboni/editors.js:386
+#: static/js/zamboni/editors-all.js:15667 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:386
 msgid "Number of Reviews"
 msgstr "Ličba pohódnoćenjow"
 
-#: static/js/zamboni/editors-all.js:15726 static/js/zamboni/editors-min.js:5
-#: static/js/zamboni/editors.js:445
+#: static/js/zamboni/editors-all.js:15726 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:445
 msgid "Error loading translation"
 msgstr "Zmylk při začitowanju přełožka"
 
-#: static/js/zamboni/editors-all.js:15975 static/js/zamboni/editors-min.js:5
-#: static/js/zamboni/themes_review_templates.js:31
+#: static/js/zamboni/editors-all.js:15975 static/js/zamboni/editors-min.js:5 static/js/zamboni/themes_review_templates.js:31
 msgid "Theme"
 msgstr "Drasta"
 
-#: static/js/zamboni/editors-all.js:15977 static/js/zamboni/editors-min.js:5
-#: static/js/zamboni/themes_review_templates.js:33
+#: static/js/zamboni/editors-all.js:15977 static/js/zamboni/editors-min.js:5 static/js/zamboni/themes_review_templates.js:33
 msgid "Reviewer"
 msgstr "Přepruwowar"
 
-#: static/js/zamboni/editors-all.js:15979 static/js/zamboni/editors-min.js:5
-#: static/js/zamboni/themes_review_templates.js:35
+#: static/js/zamboni/editors-all.js:15979 static/js/zamboni/editors-min.js:5 static/js/zamboni/themes_review_templates.js:35
 msgid "Status"
 msgstr "Status"
 
-#: static/js/zamboni/editors-all.js:16196 static/js/zamboni/editors-min.js:5
-#: static/js/zamboni/themes_review.js:176
+#: static/js/zamboni/editors-all.js:16196 static/js/zamboni/editors-min.js:5 static/js/zamboni/themes_review.js:176
 msgid "Requested Info"
 msgstr "Informacije požadane"
 
-#: static/js/zamboni/editors-all.js:16197 static/js/zamboni/editors-min.js:5
-#: static/js/zamboni/themes_review.js:177
+#: static/js/zamboni/editors-all.js:16197 static/js/zamboni/editors-min.js:5 static/js/zamboni/themes_review.js:177
 msgid "Flagged"
 msgstr "Woznamjenjene"
 
-#: static/js/zamboni/editors-all.js:16198 static/js/zamboni/editors-min.js:5
-#: static/js/zamboni/themes_review.js:178
+#: static/js/zamboni/editors-all.js:16198 static/js/zamboni/editors-min.js:5 static/js/zamboni/themes_review.js:178
 msgid "Duplicate"
 msgstr "Duplikat"
 
-#: static/js/zamboni/editors-all.js:16199 static/js/zamboni/editors-min.js:5
-#: static/js/zamboni/themes_review.js:179
+#: static/js/zamboni/editors-all.js:16199 static/js/zamboni/editors-min.js:5 static/js/zamboni/themes_review.js:179
 msgid "Rejected"
 msgstr "Wotpokazane"
 
-#: static/js/zamboni/editors-all.js:16200 static/js/zamboni/editors-min.js:5
-#: static/js/zamboni/themes_review.js:180
+#: static/js/zamboni/editors-all.js:16200 static/js/zamboni/editors-min.js:5 static/js/zamboni/themes_review.js:180
 msgid "Approved"
 msgstr "Schwalene"
 
-#: static/js/zamboni/editors-all.js:16444 static/js/zamboni/editors-min.js:5
-#: static/js/zamboni/themes_review.js:424
+#: static/js/zamboni/editors-all.js:16444 static/js/zamboni/editors-min.js:5 static/js/zamboni/themes_review.js:424
 msgid "No results found"
 msgstr "Žane wuslědki namakane"
 
-#: static/js/zamboni/mobile-all.js:15186
-#: static/js/zamboni/mobile/buttons.js:52
+#: static/js/zamboni/mobile-all.js:15186 static/js/zamboni/mobile/buttons.js:52
 msgid "Not Updated for {0} {1}"
 msgstr "Za {0} {1} njeaktualizowany"
 
-#: static/js/zamboni/mobile-all.js:15187
-#: static/js/zamboni/mobile/buttons.js:53
+#: static/js/zamboni/mobile-all.js:15187 static/js/zamboni/mobile/buttons.js:53
 msgid "Requires Newer Version of {0}"
 msgstr "Wužaduje sej nowšu wersiju {0}"
 
-#: static/js/zamboni/mobile-all.js:15188
-#: static/js/zamboni/mobile/buttons.js:54
+#: static/js/zamboni/mobile-all.js:15188 static/js/zamboni/mobile/buttons.js:54
 msgid "Unreviewed"
 msgstr "Njepřepruwowany"
 
-#: static/js/zamboni/mobile-all.js:15189
-#: static/js/zamboni/mobile/buttons.js:55
+#: static/js/zamboni/mobile-all.js:15189 static/js/zamboni/mobile/buttons.js:55
 msgid "Experimental <span>(Learn More)</span>"
 msgstr "Eksperimentelny <span>(Dalše informacije)</span>"
 
-#: static/js/zamboni/mobile-all.js:15190 static/js/zamboni/mobile-all.js:15191
-#: static/js/zamboni/mobile/buttons.js:56
-#: static/js/zamboni/mobile/buttons.js:57
+#: static/js/zamboni/mobile-all.js:15190 static/js/zamboni/mobile-all.js:15191 static/js/zamboni/mobile/buttons.js:56 static/js/zamboni/mobile/buttons.js:57
 msgid "Not Available for {0}"
 msgstr "Njeje za {0} k dispoziciji"
 
-#: static/js/zamboni/mobile-all.js:15192
-#: static/js/zamboni/mobile/buttons.js:58
+#: static/js/zamboni/mobile-all.js:15192 static/js/zamboni/mobile/buttons.js:58
 msgid "Experimental"
 msgstr "Eksperimentelny"
 
-#: static/js/zamboni/mobile-all.js:15193
-#: static/js/zamboni/mobile/buttons.js:59
+#: static/js/zamboni/mobile-all.js:15193 static/js/zamboni/mobile/buttons.js:59
 msgid "Themes Require Newer Version of {0}"
 msgstr "Drasty sej nowšu wersiju {0} wužaduja"
 
-#: static/js/zamboni/mobile-all.js:15194
-#: static/js/zamboni/mobile/buttons.js:60
+#: static/js/zamboni/mobile-all.js:15194 static/js/zamboni/mobile/buttons.js:60
 msgid "Themes Require {0}"
 msgstr "Drasty sej {0} wužaduja"
 
-#: static/js/zamboni/mobile-all.js:15239
-#: static/js/zamboni/mobile/buttons.js:105
+#: static/js/zamboni/mobile-all.js:15239 static/js/zamboni/mobile/buttons.js:105
 msgid "Installing..."
 msgstr "Instaluje so..."
 
-#: static/js/zamboni/mobile-all.js:15259
-#: static/js/zamboni/mobile/buttons.js:125
+#: static/js/zamboni/mobile-all.js:15259 static/js/zamboni/mobile/buttons.js:125
 msgid "This add-on has been preliminarily reviewed by Mozilla."
 msgstr "Tutón přidatk je so nachwilu wot Mozilla přepruwował."
 
-#: static/js/zamboni/mobile-all.js:15384
-#: static/js/zamboni/mobile/buttons.js:250
+#: static/js/zamboni/mobile-all.js:15384 static/js/zamboni/mobile/buttons.js:250
 msgid "Keep it"
 msgstr "Wobchować"
 
-#: static/js/zamboni/mobile-all.js:16049 static/js/zamboni/mobile-min.js:6
-#: static/js/zamboni/mobile/general.js:344
+#: static/js/zamboni/mobile-all.js:16049 static/js/zamboni/mobile-min.js:6 static/js/zamboni/mobile/general.js:344
 msgid "You're trying it on!"
 msgstr "Wupruwujeće jón!"
 
-#: static/js/zamboni/mobile-all.js:16061 static/js/zamboni/mobile-min.js:6
-#: static/js/zamboni/mobile/general.js:356
+#: static/js/zamboni/mobile-all.js:16061 static/js/zamboni/mobile-min.js:6 static/js/zamboni/mobile/general.js:356
 msgid "Added to Firefox"
 msgstr "K Firefox přidaty"

--- a/locale/ht/LC_MESSAGES/django.po
+++ b/locale/ht/LC_MESSAGES/django.po
@@ -3,69 +3,70 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2016-02-24 21:23+0000\n"
+"POT-Creation-Date: 2016-04-18 15:47+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
+"Language: \n"
 "MIME-Version: 1.0\n"
-"Content-Type: text/plain; charset=utf-8\n"
+"Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Generated-By: Babel 2.2.0\n"
 
-#: src/olympia/accounts/views.py:52
+#: src/olympia/accounts/views.py:54
 msgid "Your log in attempt could not be parsed. Please try again."
 msgstr ""
 
-#: src/olympia/accounts/views.py:54
+#: src/olympia/accounts/views.py:56
 msgid "Your Firefox Account could not be found. Please try again."
 msgstr ""
 
-#: src/olympia/accounts/views.py:55
+#: src/olympia/accounts/views.py:57
 msgid "You could not be logged in. Please try again."
 msgstr ""
 
-#: src/olympia/accounts/views.py:57
+#: src/olympia/accounts/views.py:59
 msgid "Your account has already been migrated to Firefox Accounts."
 msgstr ""
 
-#: src/olympia/accounts/views.py:59
+#: src/olympia/accounts/views.py:61
 msgid "Your Firefox Account already exists on this site."
 msgstr ""
 
-#: src/olympia/accounts/views.py:108
+#: src/olympia/accounts/views.py:110
 msgid "Great job!"
 msgstr ""
 
-#: src/olympia/accounts/views.py:109
+#: src/olympia/accounts/views.py:111
 msgid "You can now log in to Add-ons with your Firefox Account."
 msgstr ""
 
-#: src/olympia/accounts/views.py:121
+#: src/olympia/accounts/views.py:123
 msgid "Need help?"
 msgstr ""
 
-#: src/olympia/addons/buttons.py:180
+#: src/olympia/addons/buttons.py:177
 msgid "Download Now"
 msgstr ""
 
-#: src/olympia/addons/buttons.py:182
+#: src/olympia/addons/buttons.py:179
 msgid "Download"
 msgstr ""
 
 #. L10n: please keep &nbsp; in the string so &rarr; does not wrap.
-#: src/olympia/addons/buttons.py:186
+#: src/olympia/addons/buttons.py:183
 msgid "Continue to Download&nbsp;&rarr;"
 msgstr ""
 
-#: src/olympia/addons/buttons.py:202 src/olympia/addons/helpers.py:35 src/olympia/addons/views.py:319 src/olympia/addons/templates/addons/impala/details.html:114
+#: src/olympia/addons/buttons.py:199 src/olympia/addons/helpers.py:35 src/olympia/addons/views.py:333 src/olympia/addons/templates/addons/impala/details.html:111
 #: src/olympia/addons/templates/addons/impala/listing/items.html:17 src/olympia/addons/templates/addons/mobile/home.html:40 src/olympia/amo/templates/amo/side_nav.html:6
-#: src/olympia/amo/templates/amo/side_nav.html:10 src/olympia/amo/templates/amo/site_nav.html:2 src/olympia/amo/templates/amo/site_nav.html:55 src/olympia/bandwagon/views.py:95
-#: src/olympia/browse/views.py:54 src/olympia/browse/views.py:68 src/olympia/browse/views.py:235 src/olympia/browse/templates/browse/impala/category_landing.html:22
+#: src/olympia/amo/templates/amo/side_nav.html:10 src/olympia/amo/templates/amo/site_nav.html:2 src/olympia/amo/templates/amo/site_nav.html:53 src/olympia/bandwagon/views.py:95
+#: src/olympia/browse/views.py:54 src/olympia/browse/views.py:68 src/olympia/browse/views.py:202 src/olympia/browse/templates/browse/impala/category_landing.html:22
 #: src/olympia/browse/templates/browse/personas/mobile/category_landing.html:26
 msgid "Featured"
 msgstr ""
 
-#: src/olympia/addons/buttons.py:221
+#: src/olympia/addons/buttons.py:218
 msgid "Add to {0}"
 msgstr ""
 
@@ -113,39 +114,39 @@ msgid_plural "All tags must be at least {0} characters."
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/olympia/addons/forms.py:234
+#: src/olympia/addons/forms.py:238
 msgid "Categories cannot be changed while your add-on is featured for this application."
 msgstr ""
 
 #. L10n: {0} is the number of categories.
-#: src/olympia/addons/forms.py:238
+#: src/olympia/addons/forms.py:242
 msgid "You can have only {0} category."
 msgid_plural "You can have only {0} categories."
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/olympia/addons/forms.py:246
+#: src/olympia/addons/forms.py:250
 msgid "The miscellaneous category cannot be combined with additional categories."
 msgstr ""
 
-#: src/olympia/addons/forms.py:369
+#: src/olympia/addons/forms.py:374
 #, python-format
 msgid "Before changing your default locale you must have a name, summary, and description in that locale. You are missing %s."
 msgstr ""
 
-#: src/olympia/addons/forms.py:484 src/olympia/addons/forms.py:575
+#: src/olympia/addons/forms.py:455 src/olympia/addons/forms.py:546
 msgid "A license must be selected."
 msgstr ""
 
-#: src/olympia/addons/forms.py:556
+#: src/olympia/addons/forms.py:527
 msgid "Give Your Theme a Name."
 msgstr ""
 
-#: src/olympia/addons/forms.py:562 src/olympia/devhub/templates/devhub/personas/submit.html:53
+#: src/olympia/addons/forms.py:533 src/olympia/devhub/templates/devhub/personas/submit.html:53
 msgid "Describe your Theme."
 msgstr ""
 
-#: src/olympia/addons/forms.py:704
+#: src/olympia/addons/forms.py:675
 msgid "Enter a new author's email address"
 msgstr ""
 
@@ -153,37 +154,37 @@ msgstr ""
 msgid "Not Reviewed"
 msgstr ""
 
-#: src/olympia/addons/models.py:301
+#: src/olympia/addons/models.py:298
 msgid "Users have the option of contributing more or less than this amount."
 msgstr ""
 
-#: src/olympia/addons/models.py:309
-msgid "Users will always be asked in the Add-ons Manager (Firefox 4 and above)"
+#: src/olympia/addons/models.py:306
+msgid "Users will always be asked in the Add-ons Manager (Firefox 4 and above). Only applies to desktop."
 msgstr ""
 
-#: src/olympia/addons/models.py:1804 src/olympia/addons/templates/addons/details_box.html:55 src/olympia/devhub/templates/devhub/index.html:92
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:102
+#: src/olympia/addons/models.py:1802 src/olympia/addons/templates/addons/details_box.html:55 src/olympia/devhub/templates/devhub/index.html:92
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:89
 msgid "Listed"
 msgstr ""
 
-#: src/olympia/addons/views.py:320 src/olympia/browse/templates/browse/personas/mobile/category_landing.html:27
+#: src/olympia/addons/views.py:334 src/olympia/browse/templates/browse/personas/mobile/category_landing.html:27
 msgid "Popular"
 msgstr ""
 
-#: src/olympia/addons/views.py:321 src/olympia/browse/views.py:238 src/olympia/browse/views.py:280 src/olympia/browse/views.py:482
+#: src/olympia/addons/views.py:335 src/olympia/browse/views.py:205 src/olympia/browse/views.py:247 src/olympia/browse/views.py:449
 msgid "Recently Added"
 msgstr ""
 
-#: src/olympia/addons/views.py:322 src/olympia/bandwagon/views.py:99 src/olympia/browse/views.py:60 src/olympia/browse/views.py:71 src/olympia/search/forms.py:16 src/olympia/search/forms.py:91
+#: src/olympia/addons/views.py:336 src/olympia/bandwagon/views.py:99 src/olympia/browse/views.py:60 src/olympia/browse/views.py:71 src/olympia/search/forms.py:16 src/olympia/search/forms.py:91
 msgid "Recently Updated"
 msgstr ""
 
 #. l10n: {0} is the addon name
-#: src/olympia/addons/views.py:520
+#: src/olympia/addons/views.py:534
 msgid "Contribution for {0}"
 msgstr ""
 
-#: src/olympia/addons/views.py:613
+#: src/olympia/addons/views.py:627
 msgid "Abuse reported."
 msgstr ""
 
@@ -250,9 +251,9 @@ msgstr ""
 #: src/olympia/devhub/templates/devhub/addons/ajax_compat_update.html:36 src/olympia/devhub/templates/devhub/addons/profile.html:44 src/olympia/devhub/templates/devhub/addons/edit/admin.html:101
 #: src/olympia/devhub/templates/devhub/addons/edit/basic.html:152 src/olympia/devhub/templates/devhub/addons/edit/details.html:85 src/olympia/devhub/templates/devhub/addons/edit/support.html:67
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:166 src/olympia/devhub/templates/devhub/addons/forms_shared/media.html:149
-#: src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:44 src/olympia/devhub/templates/devhub/versions/add_file_modal.html:78 src/olympia/devhub/templates/devhub/versions/edit.html:139
-#: src/olympia/devhub/templates/devhub/versions/list.html:242 src/olympia/devhub/templates/devhub/versions/list.html:276 src/olympia/devhub/templates/devhub/versions/list.html:317
-#: src/olympia/devhub/templates/devhub/versions/list.html:351 src/olympia/reviews/templates/reviews/edit_review.html:16 src/olympia/translations/templates/translations/trans-menu.html:50
+#: src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:43 src/olympia/devhub/templates/devhub/versions/add_file_modal.html:58 src/olympia/devhub/templates/devhub/versions/edit.html:139
+#: src/olympia/devhub/templates/devhub/versions/list.html:239 src/olympia/devhub/templates/devhub/versions/list.html:281 src/olympia/devhub/templates/devhub/versions/list.html:315
+#: src/olympia/devhub/templates/devhub/versions/list.html:349 src/olympia/reviews/templates/reviews/edit_review.html:16 src/olympia/translations/templates/translations/trans-menu.html:50
 #: src/olympia/translations/templates/translations/trans-menu.html:62
 msgid "or"
 msgstr ""
@@ -363,7 +364,7 @@ msgid "Add-on Information for {0}"
 msgstr ""
 
 #: src/olympia/addons/templates/addons/details_box.html:30 src/olympia/addons/templates/addons/persona_detail_table.html:3 src/olympia/addons/templates/addons/mobile/details.html:63
-#: src/olympia/addons/templates/addons/mobile/persona_detail_table.html:7 src/olympia/browse/views.py:459 src/olympia/devhub/views.py:75
+#: src/olympia/addons/templates/addons/mobile/persona_detail_table.html:7 src/olympia/browse/views.py:426 src/olympia/devhub/views.py:73
 msgid "Updated"
 msgstr ""
 
@@ -382,11 +383,11 @@ msgstr ""
 msgid "Visibility"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/details_box.html:57 src/olympia/devhub/templates/devhub/index.html:94 src/olympia/devhub/templates/devhub/includes/addon_details.html:104
+#: src/olympia/addons/templates/addons/details_box.html:57 src/olympia/devhub/templates/devhub/index.html:94 src/olympia/devhub/templates/devhub/includes/addon_details.html:91
 msgid "Hidden"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/details_box.html:59 src/olympia/devhub/templates/devhub/index.html:96 src/olympia/devhub/templates/devhub/includes/addon_details.html:106
+#: src/olympia/addons/templates/addons/details_box.html:59 src/olympia/devhub/templates/devhub/index.html:96 src/olympia/devhub/templates/devhub/includes/addon_details.html:93
 msgid "Unlisted"
 msgstr ""
 
@@ -394,13 +395,13 @@ msgstr ""
 msgid "Required Add-ons"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/details_box.html:81 src/olympia/addons/templates/addons/persona_detail_table.html:15 src/olympia/browse/views.py:462 src/olympia/devhub/views.py:78
-#: src/olympia/devhub/views.py:85 src/olympia/discovery/templates/discovery/addons/detail.html:57 src/olympia/reviews/forms.py:62 src/olympia/reviews/templates/reviews/add.html:57
+#: src/olympia/addons/templates/addons/details_box.html:81 src/olympia/addons/templates/addons/persona_detail_table.html:15 src/olympia/browse/views.py:429 src/olympia/devhub/views.py:76
+#: src/olympia/devhub/views.py:83 src/olympia/discovery/templates/discovery/addons/detail.html:57 src/olympia/reviews/forms.py:62 src/olympia/reviews/templates/reviews/add.html:57
 #: src/olympia/reviews/templates/reviews/mobile/review_list.html:18
 msgid "Rating"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/details_box.html:85 src/olympia/browse/views.py:461 src/olympia/devhub/views.py:77 src/olympia/devhub/views.py:84
+#: src/olympia/addons/templates/addons/details_box.html:85 src/olympia/browse/views.py:428 src/olympia/devhub/views.py:75 src/olympia/devhub/views.py:82
 #: src/olympia/stats/templates/stats/addon_report_menu.html:8 src/olympia/stats/templates/stats/collection_report_menu.html:18
 msgid "Downloads"
 msgstr ""
@@ -420,7 +421,7 @@ msgstr ""
 
 #. The Privacy Policy for this add-on.
 #: src/olympia/addons/templates/addons/details_box.html:121 src/olympia/addons/templates/addons/privacy.html:19 src/olympia/addons/templates/addons/privacy.html:23
-#: src/olympia/addons/templates/addons/impala/button.html:43 src/olympia/addons/templates/addons/impala/details.html:307 src/olympia/devhub/templates/devhub/includes/policy_form.html:20
+#: src/olympia/addons/templates/addons/impala/button.html:43 src/olympia/addons/templates/addons/impala/details.html:312 src/olympia/devhub/templates/devhub/includes/policy_form.html:23
 #: src/olympia/templates/mobile/base_addons.html:87
 msgid "Privacy Policy"
 msgstr ""
@@ -445,7 +446,7 @@ msgstr ""
 msgid "Developer Comments"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/details_box.html:199 src/olympia/addons/templates/addons/impala/details.html:259
+#: src/olympia/addons/templates/addons/details_box.html:199 src/olympia/addons/templates/addons/impala/details.html:264
 msgid "Development Channel"
 msgstr ""
 
@@ -465,7 +466,7 @@ msgid ""
 "developer. To stop receiving development updates, reinstall the default version from the link above."
 msgstr ""
 
-#: src/olympia/addons/templates/addons/details_box.html:220 src/olympia/addons/templates/addons/impala/details.html:278
+#: src/olympia/addons/templates/addons/details_box.html:220 src/olympia/addons/templates/addons/impala/details.html:283
 msgid "Version {0}:"
 msgstr ""
 
@@ -484,7 +485,7 @@ msgid "End-User License Agreement for {0}"
 msgstr ""
 
 #: src/olympia/addons/templates/addons/eula.html:17 src/olympia/addons/templates/addons/eula.html:21 src/olympia/addons/templates/addons/impala/button.html:48
-#: src/olympia/addons/templates/addons/impala/details.html:316 src/olympia/devhub/templates/devhub/includes/policy_form.html:3 src/olympia/discovery/templates/discovery/addons/eula.html:11
+#: src/olympia/addons/templates/addons/impala/details.html:321 src/olympia/devhub/templates/devhub/includes/policy_form.html:3 src/olympia/discovery/templates/discovery/addons/eula.html:11
 msgid "End-User License Agreement"
 msgstr ""
 
@@ -501,7 +502,7 @@ msgstr ""
 msgid "Add-ons for {0}"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/home.html:10 src/olympia/addons/templates/addons/home.html:51 src/olympia/browse/templates/browse/impala/base_listing.html:11
+#: src/olympia/addons/templates/addons/home.html:10 src/olympia/addons/templates/addons/home.html:53 src/olympia/browse/templates/browse/impala/base_listing.html:11
 msgid "Featured Extensions"
 msgstr ""
 
@@ -509,29 +510,29 @@ msgstr ""
 msgid "Popular Extensions"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/home.html:42 src/olympia/amo/templates/amo/side_nav.html:3 src/olympia/amo/templates/amo/side_nav.html:11 src/olympia/amo/templates/amo/site_nav.html:3
-#: src/olympia/amo/templates/amo/site_nav.html:25 src/olympia/browse/views.py:236 src/olympia/browse/views.py:281 src/olympia/browse/views.py:481
+#: src/olympia/addons/templates/addons/home.html:44 src/olympia/amo/templates/amo/side_nav.html:3 src/olympia/amo/templates/amo/side_nav.html:11 src/olympia/amo/templates/amo/site_nav.html:3
+#: src/olympia/amo/templates/amo/site_nav.html:25 src/olympia/browse/views.py:203 src/olympia/browse/views.py:248 src/olympia/browse/views.py:448
 msgid "Most Popular"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/home.html:43
+#: src/olympia/addons/templates/addons/home.html:45
 msgid "All »"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/home.html:52 src/olympia/addons/templates/addons/home.html:61 src/olympia/addons/templates/addons/home.html:70 src/olympia/addons/templates/addons/home.html:78
+#: src/olympia/addons/templates/addons/home.html:54 src/olympia/addons/templates/addons/home.html:63 src/olympia/addons/templates/addons/home.html:72 src/olympia/addons/templates/addons/home.html:80
 #: src/olympia/browse/templates/browse/impala/category_landing.html:36
 msgid "See all »"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/home.html:60
+#: src/olympia/addons/templates/addons/home.html:62
 msgid "Up &amp; Coming Extensions"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/home.html:69 src/olympia/browse/templates/browse/personas/category_landing.html:61 src/olympia/discovery/templates/discovery/pane.html:74
+#: src/olympia/addons/templates/addons/home.html:71 src/olympia/browse/templates/browse/personas/category_landing.html:61 src/olympia/discovery/templates/discovery/pane.html:74
 msgid "Featured Themes"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/home.html:77 src/olympia/bandwagon/templates/bandwagon/impala/collection_listing.html:5
+#: src/olympia/addons/templates/addons/home.html:79 src/olympia/bandwagon/templates/bandwagon/impala/collection_listing.html:5
 msgid "Featured Collections"
 msgstr ""
 
@@ -549,7 +550,7 @@ msgid "Updated {0}"
 msgstr ""
 
 #. {0} is a date.
-#: src/olympia/addons/templates/addons/macros.html:10 src/olympia/addons/templates/addons/macros.html:69 src/olympia/addons/templates/addons/persona_preview.html:21
+#: src/olympia/addons/templates/addons/macros.html:10 src/olympia/addons/templates/addons/macros.html:69 src/olympia/addons/templates/addons/persona_preview.html:22
 #: src/olympia/addons/templates/addons/listing/items_mobile.html:44 src/olympia/addons/templates/addons/listing/macros.html:39
 #: src/olympia/bandwagon/templates/bandwagon/collection_listing_items.html:37 src/olympia/bandwagon/templates/bandwagon/impala/collection_listing_items.html:37
 msgid "Added {0}"
@@ -570,15 +571,14 @@ msgstr[0] ""
 msgstr[1] ""
 
 #. {0} is the number of downloads.
-#: src/olympia/addons/templates/addons/macros.html:53 src/olympia/addons/templates/addons/impala/details.html:61
+#: src/olympia/addons/templates/addons/macros.html:53 src/olympia/addons/templates/addons/impala/details.html:59
 msgid "{0} weekly download"
 msgid_plural "{0} weekly downloads"
 msgstr[0] ""
 msgstr[1] ""
 
 #. {0} is the number of users.
-#: src/olympia/addons/templates/addons/macros.html:61 src/olympia/addons/templates/addons/impala/details.html:54 src/olympia/compat/templates/compat/index.html:71
-#: src/olympia/zadmin/templates/zadmin/compat.html:67
+#: src/olympia/addons/templates/addons/macros.html:61 src/olympia/addons/templates/addons/impala/details.html:52 src/olympia/zadmin/templates/zadmin/compat.html:67
 msgid "{0} user"
 msgid_plural "{0} users"
 msgstr[0] ""
@@ -596,7 +596,7 @@ msgstr ""
 msgid "Return to the addon."
 msgstr ""
 
-#: src/olympia/addons/templates/addons/persona_detail.html:17 src/olympia/addons/templates/addons/impala/details.html:106 src/olympia/addons/templates/addons/mobile/details.html:23
+#: src/olympia/addons/templates/addons/persona_detail.html:17 src/olympia/addons/templates/addons/impala/details.html:103 src/olympia/addons/templates/addons/mobile/details.html:23
 #: src/olympia/addons/templates/addons/mobile/persona_detail.html:21 src/olympia/discovery/templates/discovery/addons/base.html:27 src/olympia/editors/templates/editors/review.html:31
 msgid "by"
 msgstr ""
@@ -640,34 +640,35 @@ msgstr ""
 msgid "License"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/persona_preview.html:12 src/olympia/constants/base.py:48
+#: src/olympia/addons/templates/addons/persona_preview.html:13 src/olympia/constants/base.py:48
 msgid "Awaiting Review"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/persona_preview.html:14 src/olympia/amo/log.py:180 src/olympia/constants/base.py:42 src/olympia/editors/helpers.py:62
+#: src/olympia/addons/templates/addons/persona_preview.html:15 src/olympia/amo/log.py:180 src/olympia/constants/base.py:42 src/olympia/editors/helpers.py:62
 msgid "Rejected"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/persona_preview.html:16 src/olympia/amo/log.py:159
+#: src/olympia/addons/templates/addons/persona_preview.html:17 src/olympia/amo/log.py:159
 msgid "Approved"
 msgstr ""
 
 #. {0} is the number of users.
-#: src/olympia/addons/templates/addons/persona_preview.html:26 src/olympia/addons/templates/addons/listing/items_mobile.html:36 src/olympia/addons/templates/addons/listing/macros.html:31
+#: src/olympia/addons/templates/addons/persona_preview.html:27 src/olympia/addons/templates/addons/listing/items_mobile.html:36 src/olympia/addons/templates/addons/listing/macros.html:31
 msgid "<strong>{0}</strong> user"
 msgid_plural "<strong>{0}</strong> users"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/olympia/addons/templates/addons/persona_preview.html:40
+#: src/olympia/addons/templates/addons/persona_preview.html:41
 msgid "Hover to Preview"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/persona_preview.html:46 src/olympia/addons/templates/addons/persona_preview.html:48 src/olympia/reviews/templates/reviews/add.html:15
+#: src/olympia/addons/templates/addons/persona_preview.html:47 src/olympia/addons/templates/addons/persona_preview.html:49 src/olympia/addons/templates/addons/persona_preview.html:97
+#: src/olympia/reviews/templates/reviews/add.html:15
 msgid "Add"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/persona_preview.html:57 src/olympia/bandwagon/templates/bandwagon/ajax_new.html:16 src/olympia/bandwagon/templates/bandwagon/edit.html:19
+#: src/olympia/addons/templates/addons/persona_preview.html:58 src/olympia/bandwagon/templates/bandwagon/ajax_new.html:16 src/olympia/bandwagon/templates/bandwagon/edit.html:19
 #: src/olympia/bandwagon/templates/bandwagon/includes/addedit.html:19 src/olympia/devhub/templates/devhub/addons/edit/admin.html:13 src/olympia/devhub/templates/devhub/addons/edit/basic.html:10
 #: src/olympia/devhub/templates/devhub/addons/edit/details.html:8 src/olympia/devhub/templates/devhub/addons/edit/media.html:6 src/olympia/devhub/templates/devhub/addons/edit/support.html:8
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:9 src/olympia/devhub/templates/devhub/addons/submit/describe.html:29 src/olympia/editors/templates/editors/review.html:257
@@ -676,21 +677,21 @@ msgstr ""
 
 #. For datetime formatting, see the table on
 #. http://docs.python.org/library/datetime.html#strftime-and-strptime-behavior
-#: src/olympia/addons/templates/addons/persona_preview.html:66
+#: src/olympia/addons/templates/addons/persona_preview.html:67
 #, python-format
 msgid "%%Y-%%m-%%d"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/persona_preview.html:67
+#: src/olympia/addons/templates/addons/persona_preview.html:68
 msgid "by {0} on {1}"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/persona_preview.html:75 src/olympia/reviews/helpers.py:17 src/olympia/reviews/templates/reviews/review_list.html:63
+#: src/olympia/addons/templates/addons/persona_preview.html:76 src/olympia/reviews/helpers.py:17 src/olympia/reviews/templates/reviews/review_list.html:63
 #: src/olympia/reviews/templates/reviews/reviews_link.html:21 src/olympia/reviews/templates/reviews/impala/reviews_link.html:16
 msgid "Not yet rated"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/persona_preview.html:78
+#: src/olympia/addons/templates/addons/persona_preview.html:79
 msgid "<b>{0}</b> users"
 msgstr ""
 
@@ -703,7 +704,7 @@ msgid "Learn more about Firefox"
 msgstr ""
 
 #: src/olympia/addons/templates/addons/popups.html:22
-msgid "or <b><a class=\"installer\" href=\"{url}\">download anyway</a></b>"
+msgid "or <b><a class=\"button installer\" href=\"{url}\">download anyway</a></b>"
 msgstr ""
 
 #: src/olympia/addons/templates/addons/popups.html:26
@@ -802,7 +803,7 @@ msgid ""
 msgstr ""
 
 #: src/olympia/addons/templates/addons/report_abuse.html:6 src/olympia/addons/templates/addons/report_abuse_full.html:10 src/olympia/addons/templates/addons/impala/details-more.html:23
-#: src/olympia/addons/templates/addons/impala/details.html:328
+#: src/olympia/addons/templates/addons/impala/details.html:333
 msgid "Report Abuse"
 msgstr ""
 
@@ -821,9 +822,9 @@ msgstr ""
 #: src/olympia/devhub/templates/devhub/addons/ajax_compat_update.html:36 src/olympia/devhub/templates/devhub/addons/profile.html:44 src/olympia/devhub/templates/devhub/addons/edit/admin.html:104
 #: src/olympia/devhub/templates/devhub/addons/edit/basic.html:155 src/olympia/devhub/templates/devhub/addons/edit/details.html:88 src/olympia/devhub/templates/devhub/addons/edit/support.html:70
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:169 src/olympia/devhub/templates/devhub/addons/forms_shared/media.html:152
-#: src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:44 src/olympia/devhub/templates/devhub/personas/edit.html:222 src/olympia/devhub/templates/devhub/versions/add_file_modal.html:79
-#: src/olympia/devhub/templates/devhub/versions/edit.html:140 src/olympia/devhub/templates/devhub/versions/list.html:208 src/olympia/devhub/templates/devhub/versions/list.html:242
-#: src/olympia/devhub/templates/devhub/versions/list.html:276 src/olympia/devhub/templates/devhub/versions/list.html:317 src/olympia/reviews/templates/reviews/edit_review.html:16
+#: src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:43 src/olympia/devhub/templates/devhub/personas/edit.html:222 src/olympia/devhub/templates/devhub/versions/add_file_modal.html:59
+#: src/olympia/devhub/templates/devhub/versions/edit.html:140 src/olympia/devhub/templates/devhub/versions/list.html:208 src/olympia/devhub/templates/devhub/versions/list.html:239
+#: src/olympia/devhub/templates/devhub/versions/list.html:281 src/olympia/devhub/templates/devhub/versions/list.html:315 src/olympia/reviews/templates/reviews/edit_review.html:16
 #: src/olympia/translations/templates/translations/trans-menu.html:50 src/olympia/translations/templates/translations/trans-menu.html:62 src/olympia/zadmin/templates/zadmin/validation.html:105
 msgid "Cancel"
 msgstr ""
@@ -868,7 +869,7 @@ msgstr ""
 msgid "Review Guidelines"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/review_list_box.html:5 src/olympia/addons/templates/addons/impala/details-more.html:27 src/olympia/editors/helpers.py:921
+#: src/olympia/addons/templates/addons/review_list_box.html:5 src/olympia/addons/templates/addons/impala/details-more.html:27 src/olympia/editors/helpers.py:1001
 #: src/olympia/reviews/templates/reviews/add.html:14 src/olympia/reviews/templates/reviews/reply.html:14 src/olympia/reviews/templates/reviews/review_list.html:19
 #: src/olympia/reviews/templates/reviews/mobile/review_list.html:26
 msgid "Reviews"
@@ -959,119 +960,119 @@ msgid_plural "Other add-ons by these authors"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/olympia/addons/templates/addons/impala/details.html:41
+#: src/olympia/addons/templates/addons/impala/details.html:39
 #, python-format
 msgid "<span itemprop=\"ratingCount\">%(num)s</span> user review"
 msgid_plural "<span itemprop=\"ratingCount\">%(num)s</span> user reviews"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/olympia/addons/templates/addons/impala/details.html:69
+#: src/olympia/addons/templates/addons/impala/details.html:66
 msgid "View statistics"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/impala/details.html:84
+#: src/olympia/addons/templates/addons/impala/details.html:81
 msgid "Manage"
 msgstr ""
 
 #. {0} is an add-on name.
-#: src/olympia/addons/templates/addons/impala/details.html:96
+#: src/olympia/addons/templates/addons/impala/details.html:93
 msgid "Icon of {0}"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/impala/details.html:103 src/olympia/addons/templates/addons/impala/listing/items.html:14
+#: src/olympia/addons/templates/addons/impala/details.html:100 src/olympia/addons/templates/addons/impala/listing/items.html:14
 msgid "No Restart"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/impala/details.html:127
+#: src/olympia/addons/templates/addons/impala/details.html:124
 #, python-format
 msgid "Meet the Developer: <a href=\"%(url)s\">%(name)s</a>"
 msgid_plural "<a href=\"%(url)s\">Meet the Developers</a>"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/olympia/addons/templates/addons/impala/details.html:137
+#: src/olympia/addons/templates/addons/impala/details.html:134
 msgid "Learn why {0} was created and find out what's next for this add-on."
 msgstr ""
 
 #. {0} is an index.
-#: src/olympia/addons/templates/addons/impala/details.html:156
+#: src/olympia/addons/templates/addons/impala/details.html:161
 msgid "Add-on screenshot #{0}"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/impala/details.html:182
+#: src/olympia/addons/templates/addons/impala/details.html:187
 msgid "Add-on home page"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/impala/details.html:185
+#: src/olympia/addons/templates/addons/impala/details.html:190
 msgid "Support site"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/impala/details.html:189
+#: src/olympia/addons/templates/addons/impala/details.html:194
 msgid "Support E-mail"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/impala/details.html:194 src/olympia/devhub/models.py:378 src/olympia/devhub/templates/devhub/versions/list.html:12
+#: src/olympia/addons/templates/addons/impala/details.html:199 src/olympia/devhub/models.py:378 src/olympia/devhub/templates/devhub/versions/list.html:12
 #: src/olympia/versions/templates/versions/version.html:6 src/olympia/versions/templates/versions/mobile/version.html:6
 msgid "Version {0}"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/impala/details.html:194
+#: src/olympia/addons/templates/addons/impala/details.html:199
 msgid "Info"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/impala/details.html:195 src/olympia/devhub/templates/devhub/includes/addon_details.html:129
+#: src/olympia/addons/templates/addons/impala/details.html:200 src/olympia/devhub/templates/devhub/includes/addon_details.html:116
 msgid "Last Updated:"
-msgstr ""
-
-#: src/olympia/addons/templates/addons/impala/details.html:200
-#, python-format
-msgid "Released under <a target=\"_blank\" href=\"%(url)s\">%(name)s</a>"
-msgstr ""
-
-#: src/olympia/addons/templates/addons/impala/details.html:201 src/olympia/addons/templates/addons/impala/details.html:206 src/olympia/amo/helpers.py:398 src/olympia/devhub/forms.py:142
-#: src/olympia/devhub/forms.py:173 src/olympia/versions/templates/versions/version.html:40 src/olympia/versions/templates/versions/version.html:45
-msgid "Custom License"
 msgstr ""
 
 #: src/olympia/addons/templates/addons/impala/details.html:205
 #, python-format
+msgid "Released under <a target=\"_blank\" href=\"%(url)s\">%(name)s</a>"
+msgstr ""
+
+#: src/olympia/addons/templates/addons/impala/details.html:206 src/olympia/addons/templates/addons/impala/details.html:211 src/olympia/amo/helpers.py:398 src/olympia/devhub/forms.py:142
+#: src/olympia/devhub/forms.py:173 src/olympia/versions/templates/versions/version.html:40 src/olympia/versions/templates/versions/version.html:45
+msgid "Custom License"
+msgstr ""
+
+#: src/olympia/addons/templates/addons/impala/details.html:210
+#, python-format
 msgid "Released under <a href=\"%(url)s\">%(name)s</a>"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/impala/details.html:217
+#: src/olympia/addons/templates/addons/impala/details.html:222
 msgid "About this Add-on"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/impala/details.html:233
+#: src/olympia/addons/templates/addons/impala/details.html:238
 msgid "Developer’s Comments"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/impala/details.html:243
+#: src/olympia/addons/templates/addons/impala/details.html:248
 msgid "Version Information"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/impala/details.html:250
+#: src/olympia/addons/templates/addons/impala/details.html:255
 msgid "See complete version history"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/impala/details.html:262
+#: src/olympia/addons/templates/addons/impala/details.html:267
 msgid ""
 "The Development Channel lets you test an experimental new version of this add-on before it's released to the general public. Once you install the development version, you will continue to get "
 "updates from this channel. To stop receiving development updates, reinstall the default version from the link above."
 msgstr ""
 
-#: src/olympia/addons/templates/addons/impala/details.html:272
+#: src/olympia/addons/templates/addons/impala/details.html:277
 msgid "<strong>Caution:</strong> Development versions of this add-on have not been reviewed by Mozilla."
 msgstr ""
 
-#: src/olympia/addons/templates/addons/impala/details.html:287
+#: src/olympia/addons/templates/addons/impala/details.html:292
 msgid "See complete development channel history"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/impala/details.html:306 src/olympia/addons/templates/addons/impala/details.html:315 src/olympia/addons/templates/addons/impala/details.html:327
+#: src/olympia/addons/templates/addons/impala/details.html:311 src/olympia/addons/templates/addons/impala/details.html:320 src/olympia/addons/templates/addons/impala/details.html:332
 #: src/olympia/addons/templates/addons/impala/review_add_box.html:4 src/olympia/stats/templates/stats/popup.html:2 src/olympia/stats/templates/stats/popup.html:8
-#: src/olympia/stats/templates/stats/stats.html:202 src/olympia/users/templates/users/profile.html:119
+#: src/olympia/stats/templates/stats/stats.html:204 src/olympia/users/templates/users/profile.html:119
 msgid "close"
 msgstr ""
 
@@ -1127,15 +1128,11 @@ msgstr ""
 msgid "Source Code License"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/impala/persona_grid.html:16 src/olympia/addons/templates/addons/impala/toplist.html:6
-msgid "{0} users"
-msgstr ""
-
 #: src/olympia/addons/templates/addons/impala/review_list_box.html:19 src/olympia/reviews/templates/reviews/review.html:40
 msgid "permalink"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/impala/review_list_box.html:23 src/olympia/editors/templates/editors/queue.html:98 src/olympia/reviews/templates/reviews/review.html:44
+#: src/olympia/addons/templates/addons/impala/review_list_box.html:23 src/olympia/editors/templates/editors/queue.html:104 src/olympia/reviews/templates/reviews/review.html:44
 msgid "translate"
 msgstr ""
 
@@ -1154,6 +1151,10 @@ msgstr ""
 msgid "Be the first!"
 msgstr ""
 
+#: src/olympia/addons/templates/addons/impala/toplist.html:6
+msgid "{0} users"
+msgstr ""
+
 #: src/olympia/addons/templates/addons/impala/listing/sorter.html:14 src/olympia/devhub/templates/devhub/addons/listing/item_actions.html:49
 msgid "More"
 msgstr ""
@@ -1166,7 +1167,7 @@ msgstr ""
 msgid "My Add-ons"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/includes/dashboard_tabs.html:6 src/olympia/amo/context_processors.py:51
+#: src/olympia/addons/templates/addons/includes/dashboard_tabs.html:6 src/olympia/amo/context_processors.py:50
 msgid "My Themes"
 msgstr ""
 
@@ -1221,7 +1222,7 @@ msgstr ""
 msgid "Weekly Downloads"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/mobile/details.html:99 src/olympia/compat/templates/compat/reporter_detail.html:46 src/olympia/devhub/forms.py:787
+#: src/olympia/addons/templates/addons/mobile/details.html:99 src/olympia/compat/templates/compat/reporter_detail.html:46 src/olympia/devhub/forms.py:788
 #: src/olympia/devhub/templates/devhub/versions/list.html:163
 msgid "Version"
 msgstr ""
@@ -1305,7 +1306,7 @@ msgstr ""
 #: src/olympia/browse/templates/browse/personas/category_landing.html:21 src/olympia/browse/templates/browse/personas/category_landing.html:23
 #: src/olympia/browse/templates/browse/personas/category_landing.html:38 src/olympia/browse/templates/browse/personas/grid.html:7 src/olympia/browse/templates/browse/personas/grid.html:11
 #: src/olympia/browse/templates/browse/personas/mobile/base.html:7 src/olympia/browse/templates/browse/personas/mobile/category_landing.html:19 src/olympia/constants/base.py:180
-#: src/olympia/devhub/templates/devhub/personas/submit.html:13 src/olympia/editors/helpers.py:105 src/olympia/editors/templates/editors/base.html:26
+#: src/olympia/devhub/templates/devhub/personas/submit.html:13 src/olympia/editors/helpers.py:107 src/olympia/editors/templates/editors/base.html:26
 #: src/olympia/editors/templates/editors/performance.html:73 src/olympia/search/templates/search/personas.html:39 src/olympia/templates/menu_links.html:9
 msgid "Themes"
 msgstr ""
@@ -1326,7 +1327,7 @@ msgstr ""
 msgid "Highest Rated"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/mobile/home.html:74 src/olympia/amo/templates/amo/side_nav.html:5 src/olympia/amo/templates/amo/site_nav.html:27 src/olympia/amo/templates/amo/site_nav.html:57
+#: src/olympia/addons/templates/addons/mobile/home.html:74 src/olympia/amo/templates/amo/side_nav.html:5 src/olympia/amo/templates/amo/site_nav.html:27 src/olympia/amo/templates/amo/site_nav.html:55
 #: src/olympia/bandwagon/views.py:97 src/olympia/browse/views.py:57 src/olympia/browse/views.py:67 src/olympia/browse/templates/browse/personas/mobile/category_landing.html:65
 #: src/olympia/search/forms.py:15 src/olympia/search/forms.py:87
 msgid "Newest"
@@ -1340,90 +1341,90 @@ msgstr ""
 msgid "Theme Info &raquo;"
 msgstr ""
 
-#: src/olympia/amo/context_processors.py:39 src/olympia/devhub/templates/devhub/nav.html:43
+#: src/olympia/amo/context_processors.py:37 src/olympia/devhub/templates/devhub/nav.html:43
 msgid "Tools"
 msgstr ""
 
-#: src/olympia/amo/context_processors.py:48 src/olympia/discovery/templates/discovery/pane_account.html:8 src/olympia/users/templates/users/includes/navigation.html:2
+#: src/olympia/amo/context_processors.py:47 src/olympia/discovery/templates/discovery/pane_account.html:8 src/olympia/users/templates/users/includes/navigation.html:2
 msgid "My Profile"
 msgstr ""
 
-#: src/olympia/amo/context_processors.py:54 src/olympia/users/templates/users/edit.html:5 src/olympia/users/templates/users/includes/navigation.html:3
+#: src/olympia/amo/context_processors.py:53 src/olympia/users/templates/users/edit.html:5 src/olympia/users/templates/users/includes/navigation.html:3
 msgid "Account Settings"
 msgstr ""
 
-#: src/olympia/amo/context_processors.py:57 src/olympia/discovery/templates/discovery/pane_account.html:11 src/olympia/users/templates/users/profile.html:83
+#: src/olympia/amo/context_processors.py:56 src/olympia/discovery/templates/discovery/pane_account.html:11 src/olympia/users/templates/users/profile.html:83
 #: src/olympia/users/templates/users/includes/navigation.html:4
 msgid "My Collections"
 msgstr ""
 
-#: src/olympia/amo/context_processors.py:62 src/olympia/discovery/templates/discovery/pane_account.html:10 src/olympia/users/templates/users/includes/navigation.html:7
+#: src/olympia/amo/context_processors.py:61 src/olympia/discovery/templates/discovery/pane_account.html:10 src/olympia/users/templates/users/includes/navigation.html:7
 msgid "My Favorites"
 msgstr ""
 
-#: src/olympia/amo/context_processors.py:67 src/olympia/discovery/templates/discovery/pane_account.html:13 src/olympia/templates/impala/user_login.html:14
+#: src/olympia/amo/context_processors.py:66 src/olympia/discovery/templates/discovery/pane_account.html:13 src/olympia/templates/impala/user_login.html:14
 #: src/olympia/templates/mobile/header_auth.html:5
 msgid "Log out"
 msgstr ""
 
-#: src/olympia/amo/context_processors.py:72 src/olympia/devhub/templates/devhub/addons/dashboard.html:4
+#: src/olympia/amo/context_processors.py:71 src/olympia/devhub/templates/devhub/addons/dashboard.html:4
 msgid "Manage My Submissions"
 msgstr ""
 
-#: src/olympia/amo/context_processors.py:75 src/olympia/devhub/templates/devhub/nav.html:27 src/olympia/devhub/templates/devhub/addons/dashboard.html:25
+#: src/olympia/amo/context_processors.py:74 src/olympia/devhub/templates/devhub/nav.html:27 src/olympia/devhub/templates/devhub/addons/dashboard.html:25
 #: src/olympia/devhub/templates/devhub/addons/submit/base.html:4
 msgid "Submit a New Add-on"
 msgstr ""
 
-#: src/olympia/amo/context_processors.py:77 src/olympia/browse/templates/browse/personas/base.html:50 src/olympia/devhub/templates/devhub/index.html:24
+#: src/olympia/amo/context_processors.py:76 src/olympia/browse/templates/browse/personas/base.html:50 src/olympia/devhub/templates/devhub/index.html:24
 #: src/olympia/devhub/templates/devhub/addons/dashboard.html:29
 msgid "Submit a New Theme"
 msgstr ""
 
-#: src/olympia/amo/context_processors.py:79 src/olympia/amo/templates/amo/site_nav.html:87 src/olympia/devhub/helpers.py:36 src/olympia/devhub/helpers.py:68 src/olympia/devhub/helpers.py:102
+#: src/olympia/amo/context_processors.py:78 src/olympia/amo/templates/amo/site_nav.html:85 src/olympia/devhub/helpers.py:36 src/olympia/devhub/helpers.py:68 src/olympia/devhub/helpers.py:102
 #: src/olympia/templates/footer.html:6 src/olympia/templates/menu_links.html:14
 msgid "Developer Hub"
 msgstr ""
 
-#: src/olympia/amo/context_processors.py:83 src/olympia/devhub/views.py:1792
+#: src/olympia/amo/context_processors.py:81 src/olympia/devhub/views.py:1796
 msgid "Manage API Keys"
 msgstr ""
 
-#: src/olympia/amo/context_processors.py:88 src/olympia/editors/helpers.py:82 src/olympia/editors/helpers.py:102 src/olympia/editors/templates/editors/base.html:10
+#: src/olympia/amo/context_processors.py:86 src/olympia/editors/helpers.py:84 src/olympia/editors/helpers.py:104 src/olympia/editors/templates/editors/base.html:10
 msgid "Editor Tools"
 msgstr ""
 
-#: src/olympia/amo/context_processors.py:92
+#: src/olympia/amo/context_processors.py:90
 msgid "Admin Tools"
 msgstr ""
 
-#: src/olympia/amo/fields.py:15
+#: src/olympia/amo/fields.py:20
 msgid "Incorrect, please try again."
 msgstr ""
 
-#: src/olympia/amo/fields.py:16
+#: src/olympia/amo/fields.py:21
 msgid "Error verifying input, please try again."
 msgstr ""
 
-#: src/olympia/amo/fields.py:32
+#: src/olympia/amo/fields.py:37
 msgid "This must be a valid hex color code, such as #000000."
 msgstr ""
 
-#: src/olympia/amo/fields.py:58
+#: src/olympia/amo/fields.py:63
 msgid "Enter at least one value."
 msgstr ""
 
-#: src/olympia/amo/helpers.py:162 src/olympia/amo/templates/amo/site_nav.html:61 src/olympia/bandwagon/templates/bandwagon/add.html:9
+#: src/olympia/amo/helpers.py:162 src/olympia/amo/templates/amo/site_nav.html:59 src/olympia/bandwagon/templates/bandwagon/add.html:9
 #: src/olympia/bandwagon/templates/bandwagon/collection_detail.html:15 src/olympia/bandwagon/templates/bandwagon/delete.html:9 src/olympia/bandwagon/templates/bandwagon/edit.html:15
 #: src/olympia/bandwagon/templates/bandwagon/user_listing.html:18 src/olympia/bandwagon/templates/bandwagon/user_listing.html:21
 #: src/olympia/bandwagon/templates/bandwagon/impala/collection_listing.html:12 src/olympia/bandwagon/templates/bandwagon/impala/collection_listing.html:20
 #: src/olympia/bandwagon/templates/bandwagon/impala/collection_listing.html:24 src/olympia/bandwagon/templates/bandwagon/impala/collection_sidebar.html:3
 #: src/olympia/bandwagon/templates/bandwagon/includes/collection_sidebar.html:2 src/olympia/bandwagon/templates/bandwagon/mobile/collection_listing.html:3
-#: src/olympia/stats/templates/stats/stats.html:77 src/olympia/templates/menu_links.html:12
+#: src/olympia/stats/templates/stats/stats.html:33 src/olympia/templates/menu_links.html:12
 msgid "Collections"
 msgstr ""
 
-#: src/olympia/amo/helpers.py:171 src/olympia/amo/templates/amo/site_nav.html:85 src/olympia/browse/templates/browse/language_tools.html:3
+#: src/olympia/amo/helpers.py:171 src/olympia/amo/templates/amo/site_nav.html:83 src/olympia/browse/templates/browse/language_tools.html:3
 msgid "Dictionaries & Language Packs"
 msgstr ""
 
@@ -1575,8 +1576,8 @@ msgstr ""
 msgid "Comment on {addon} {version}."
 msgstr ""
 
-#: src/olympia/amo/log.py:236 src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:19 src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:47
-#: src/olympia/editors/helpers.py:511 src/olympia/editors/templates/editors/themes/history_table.html:11
+#: src/olympia/amo/log.py:236 src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:17 src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:45
+#: src/olympia/editors/helpers.py:584 src/olympia/editors/templates/editors/themes/history_table.html:11
 msgid "Comment"
 msgstr ""
 
@@ -1899,7 +1900,7 @@ msgstr ""
 #: src/olympia/amo/templates/amo/mobile/paginator.html:14 src/olympia/amo/templates/amo/mobile/paginator.html:16 src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:51
 #: src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:65 src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:78
 #: src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:91 src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:104
-#: src/olympia/discovery/templates/discovery/pane.html:45 src/olympia/discovery/templates/discovery/addons/detail.html:39 src/olympia/stats/templates/stats/stats.html:167
+#: src/olympia/discovery/templates/discovery/pane.html:45 src/olympia/discovery/templates/discovery/addons/detail.html:39 src/olympia/stats/templates/stats/stats.html:169
 msgid "Next"
 msgstr ""
 
@@ -1931,7 +1932,7 @@ msgid ""
 msgstr ""
 
 #: src/olympia/amo/templates/amo/side_nav.html:4 src/olympia/amo/templates/amo/side_nav.html:12 src/olympia/amo/templates/amo/site_nav.html:4 src/olympia/amo/templates/amo/site_nav.html:26
-#: src/olympia/browse/views.py:56 src/olympia/browse/views.py:66 src/olympia/browse/views.py:237 src/olympia/browse/views.py:282 src/olympia/search/forms.py:86
+#: src/olympia/browse/views.py:56 src/olympia/browse/views.py:66 src/olympia/browse/views.py:204 src/olympia/browse/views.py:249 src/olympia/search/forms.py:86
 msgid "Top Rated"
 msgstr ""
 
@@ -1945,38 +1946,38 @@ msgstr ""
 msgid "Extensions"
 msgstr ""
 
-#: src/olympia/amo/templates/amo/site_nav.html:45
+#: src/olympia/amo/templates/amo/site_nav.html:44
 msgid "Want more customization? Try <b>Complete Themes</b>"
 msgstr ""
 
-#: src/olympia/amo/templates/amo/site_nav.html:56 src/olympia/bandwagon/views.py:96
+#: src/olympia/amo/templates/amo/site_nav.html:54 src/olympia/bandwagon/views.py:96
 msgid "Most Followers"
 msgstr ""
 
-#: src/olympia/amo/templates/amo/site_nav.html:68 src/olympia/bandwagon/templates/bandwagon/impala/collection_sidebar.html:16
+#: src/olympia/amo/templates/amo/site_nav.html:66 src/olympia/bandwagon/templates/bandwagon/impala/collection_sidebar.html:16
 #: src/olympia/bandwagon/templates/bandwagon/includes/collection_sidebar.html:18
 msgid "Collections I've Made"
 msgstr ""
 
-#: src/olympia/amo/templates/amo/site_nav.html:70 src/olympia/bandwagon/templates/bandwagon/user_listing.html:4 src/olympia/bandwagon/templates/bandwagon/impala/collection_sidebar.html:13
+#: src/olympia/amo/templates/amo/site_nav.html:68 src/olympia/bandwagon/templates/bandwagon/user_listing.html:4 src/olympia/bandwagon/templates/bandwagon/impala/collection_sidebar.html:13
 #: src/olympia/bandwagon/templates/bandwagon/includes/collection_sidebar.html:15
 msgid "Collections I'm Following"
 msgstr ""
 
-#: src/olympia/amo/templates/amo/site_nav.html:73 src/olympia/bandwagon/templates/bandwagon/impala/collection_sidebar.html:18
-#: src/olympia/bandwagon/templates/bandwagon/includes/collection_sidebar.html:20 src/olympia/users/models.py:512
+#: src/olympia/amo/templates/amo/site_nav.html:71 src/olympia/bandwagon/templates/bandwagon/impala/collection_sidebar.html:18
+#: src/olympia/bandwagon/templates/bandwagon/includes/collection_sidebar.html:20 src/olympia/users/models.py:521
 msgid "My Favorite Add-ons"
 msgstr ""
 
-#: src/olympia/amo/templates/amo/site_nav.html:78
+#: src/olympia/amo/templates/amo/site_nav.html:76
 msgid "More&hellip;"
 msgstr ""
 
-#: src/olympia/amo/templates/amo/site_nav.html:82
+#: src/olympia/amo/templates/amo/site_nav.html:80
 msgid "Add-ons for Mobile"
 msgstr ""
 
-#: src/olympia/amo/templates/amo/site_nav.html:86 src/olympia/browse/feeds.py:207 src/olympia/browse/templates/browse/search_tools.html:3 src/olympia/constants/base.py:176
+#: src/olympia/amo/templates/amo/site_nav.html:84 src/olympia/browse/feeds.py:207 src/olympia/browse/templates/browse/search_tools.html:3 src/olympia/constants/base.py:176
 #: src/olympia/templates/menu_links.html:10
 msgid "Search Tools"
 msgstr ""
@@ -1992,7 +1993,7 @@ msgid "Jump to first page"
 msgstr ""
 
 #: src/olympia/amo/templates/amo/impala/paginator.html:22 src/olympia/amo/templates/amo/mobile/impala_paginator.html:12 src/olympia/discovery/templates/discovery/pane.html:44
-#: src/olympia/discovery/templates/discovery/addons/detail.html:38 src/olympia/stats/templates/stats/stats.html:164
+#: src/olympia/discovery/templates/discovery/addons/detail.html:38 src/olympia/stats/templates/stats/stats.html:166
 msgid "Previous"
 msgstr ""
 
@@ -2015,30 +2016,49 @@ msgid_plural "Page {n}"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/olympia/amo/templates/services/install.html:38
-#, python-format
-msgid "If you are not prompted to install %(addon_name)s in a moment, please <a href=\"%(addon_xpi)s\">click here</a>."
-msgstr ""
-
-#: src/olympia/amo/tests/test_messages.py:57 src/olympia/amo/tests/test_messages.py:58 src/olympia/reviews/forms.py:25 src/olympia/reviews/forms.py:50 src/olympia/reviews/templates/reviews/add.html:56
+#: src/olympia/amo/tests/test_messages.py:56 src/olympia/amo/tests/test_messages.py:57 src/olympia/reviews/forms.py:25 src/olympia/reviews/forms.py:50 src/olympia/reviews/templates/reviews/add.html:56
 #: src/olympia/reviews/templates/reviews/reply.html:30
 msgid "Title"
 msgstr ""
 
-#: src/olympia/amo/tests/test_messages.py:57 src/olympia/amo/tests/test_messages.py:58
+#: src/olympia/amo/tests/test_messages.py:56 src/olympia/amo/tests/test_messages.py:57
 msgid "Body"
 msgstr ""
 
-#: src/olympia/amo/tests/test_messages.py:59
+#: src/olympia/amo/tests/test_messages.py:58
 msgid "Another Title"
 msgstr ""
 
-#: src/olympia/amo/tests/test_messages.py:59
+#: src/olympia/amo/tests/test_messages.py:58
 msgid "Another Body"
 msgstr ""
 
-#: src/olympia/api/views.py:255
-msgid "Not implemented yet."
+#: src/olympia/api/authentication.py:76
+msgid "Signature has expired."
+msgstr ""
+
+#: src/olympia/api/authentication.py:79
+msgid "Error decoding signature."
+msgstr ""
+
+#: src/olympia/api/authentication.py:82
+msgid "Invalid JWT Token."
+msgstr ""
+
+#: src/olympia/api/authentication.py:130
+msgid "Invalid Authorization header. No credentials provided."
+msgstr ""
+
+#: src/olympia/api/authentication.py:133
+msgid "Invalid Authorization header. Credentials string should not contain spaces."
+msgstr ""
+
+#: src/olympia/api/fields.py:29
+msgid "The field must have a length of at least {num} characters."
+msgstr ""
+
+#: src/olympia/api/fields.py:31
+msgid "The language code {lang_code} is invalid."
 msgstr ""
 
 #: src/olympia/applications/views.py:39 src/olympia/applications/templates/applications/appversions.html:3
@@ -2057,7 +2077,7 @@ msgstr ""
 msgid "Add-ons submitted to Mozilla Add-ons must have a manifest file with at least one of the below applications supported. Only the versions listed below are allowed for these applications."
 msgstr ""
 
-#: src/olympia/applications/templates/applications/appversions.html:25
+#: src/olympia/applications/templates/applications/appversions.html:25 src/olympia/editors/helpers.py:361
 msgid "GUID"
 msgstr ""
 
@@ -2171,8 +2191,8 @@ msgstr ""
 msgid "Remove from favorites"
 msgstr ""
 
-#: src/olympia/bandwagon/views.py:98 src/olympia/bandwagon/views.py:191 src/olympia/browse/views.py:58 src/olympia/browse/views.py:69 src/olympia/browse/views.py:458 src/olympia/devhub/views.py:74
-#: src/olympia/devhub/views.py:82 src/olympia/devhub/templates/devhub/addons/edit/basic.html:20 src/olympia/editors/templates/editors/leaderboard.html:24
+#: src/olympia/bandwagon/views.py:98 src/olympia/bandwagon/views.py:191 src/olympia/browse/views.py:58 src/olympia/browse/views.py:69 src/olympia/browse/views.py:425 src/olympia/devhub/views.py:72
+#: src/olympia/devhub/views.py:80 src/olympia/devhub/templates/devhub/addons/edit/basic.html:20 src/olympia/editors/templates/editors/leaderboard.html:24
 #: src/olympia/editors/templates/editors/themes/queue_list.html:48 src/olympia/search/forms.py:17 src/olympia/search/forms.py:89 src/olympia/users/templates/users/vcard.html:5
 msgid "Name"
 msgstr ""
@@ -2181,7 +2201,7 @@ msgstr ""
 msgid "Recently Popular"
 msgstr ""
 
-#: src/olympia/bandwagon/views.py:189 src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:18
+#: src/olympia/bandwagon/views.py:189 src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:16
 msgid "Added"
 msgstr ""
 
@@ -2195,7 +2215,7 @@ msgstr ""
 
 #: src/olympia/bandwagon/views.py:316
 #, python-format
-msgid "Your new collection is shown below. You can <ahref=\"%(url)s\">edit additional settings</a> if you'dlike."
+msgid "Your new collection is shown below. You can <a href=\"%(url)s\">edit additional settings</a> if you'd like."
 msgstr ""
 
 #: src/olympia/bandwagon/views.py:322
@@ -2323,8 +2343,8 @@ msgid_plural "%(num)s Add-ons in this Collection"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/olympia/bandwagon/templates/bandwagon/collection_detail.html:125 src/olympia/compat/templates/compat/index.html:25 src/olympia/compat/templates/compat/reporter_detail.html:29
-#: src/olympia/files/templates/files/viewer.html:29 src/olympia/templates/amo_footer.html:17 src/olympia/templates/includes/lang_switcher.html:10
+#: src/olympia/bandwagon/templates/bandwagon/collection_detail.html:125 src/olympia/compat/templates/compat/reporter_detail.html:29 src/olympia/files/templates/files/viewer.html:29
+#: src/olympia/templates/amo_footer.html:17 src/olympia/templates/includes/lang_switcher.html:10
 msgid "Go"
 msgstr ""
 
@@ -2491,7 +2511,7 @@ msgid "Remove this user as a contributor"
 msgstr ""
 
 #: src/olympia/bandwagon/templates/bandwagon/edit_contributors.html:18 src/olympia/bandwagon/templates/bandwagon/edit_contributors.html:43
-#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:20 src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:48
+#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:18 src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:46
 #: src/olympia/devhub/templates/devhub/addons/ajax_compat_update.html:19
 msgid "Remove"
 msgstr ""
@@ -2539,7 +2559,7 @@ msgid "<b>Warning:</b> By changing the owner of this collection, you will no lon
 msgstr ""
 
 #: src/olympia/bandwagon/templates/bandwagon/edit_contributors.html:83 src/olympia/devhub/templates/devhub/addons/forms_shared/media.html:157
-#: src/olympia/devhub/templates/devhub/addons/submit/describe.html:69 src/olympia/devhub/templates/devhub/addons/submit/license.html:60 src/olympia/devhub/templates/devhub/addons/submit/upload.html:78
+#: src/olympia/devhub/templates/devhub/addons/submit/describe.html:69 src/olympia/devhub/templates/devhub/addons/submit/license.html:60 src/olympia/devhub/templates/devhub/addons/submit/upload.html:70
 #: src/olympia/devhub/templates/devhub/payments/tier.html:17 src/olympia/editors/templates/editors/themes/themes.html:111 src/olympia/editors/templates/editors/themes/themes.html:128
 #: src/olympia/editors/templates/editors/themes/themes.html:134 src/olympia/editors/templates/editors/themes/themes.html:141 src/olympia/users/templates/users/fxa_migration_prompt_content.html:10
 #: src/olympia/users/templates/users/login_form.html:42 src/olympia/users/templates/users/mobile/login.html:57
@@ -2622,31 +2642,31 @@ msgid "Add-ons in Your Collection"
 msgstr ""
 
 #: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:4
-msgid ""
-"To include an add-on in this collection, enter its name in the box below and hit enter.  You can also use the <strong>Add to Collection</strong> links throughout the site to include add-ons later."
+msgid "To include an add-on in this collection, enter its name in the box below and hit enter."
 msgstr ""
 
-#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:17 src/olympia/constants/base.py:400 src/olympia/devhub/templates/devhub/addons/activity.html:62
+#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:15 src/olympia/constants/base.py:400 src/olympia/devhub/templates/devhub/addons/activity.html:62
+#: src/olympia/editors/helpers.py:273 src/olympia/editors/helpers.py:360
 msgid "Add-on"
 msgstr ""
 
-#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:26
+#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:24
 msgid "Enter the name of the add-on to include"
 msgstr ""
 
-#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:28
+#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:26
 msgid "Add to Collection"
 msgstr ""
 
-#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:45 src/olympia/editors/helpers.py:936 src/olympia/editors/helpers.py:956
+#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:43 src/olympia/editors/helpers.py:1016 src/olympia/editors/helpers.py:1036
 msgid "Pending"
 msgstr ""
 
-#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:47
+#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:45
 msgid "Add a comment"
 msgstr ""
 
-#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:48
+#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:46
 msgid "Remove this add-on from the collection"
 msgstr ""
 
@@ -2753,12 +2773,12 @@ msgstr ""
 msgid "Most Users"
 msgstr ""
 
-#: src/olympia/browse/views.py:61 src/olympia/browse/views.py:72 src/olympia/browse/views.py:279 src/olympia/browse/templates/browse/personas/mobile/category_landing.html:63
+#: src/olympia/browse/views.py:61 src/olympia/browse/views.py:72 src/olympia/browse/views.py:246 src/olympia/browse/templates/browse/personas/mobile/category_landing.html:63
 #: src/olympia/discovery/templates/discovery/pane.html:67 src/olympia/search/forms.py:92
 msgid "Up & Coming"
 msgstr ""
 
-#: src/olympia/browse/views.py:460 src/olympia/devhub/views.py:76 src/olympia/devhub/views.py:83 src/olympia/discovery/templates/discovery/addons/detail.html:66
+#: src/olympia/browse/views.py:427 src/olympia/devhub/views.py:74 src/olympia/devhub/views.py:81 src/olympia/discovery/templates/discovery/addons/detail.html:66
 msgid "Created"
 msgstr ""
 
@@ -2946,8 +2966,8 @@ msgid_plural "See all %(cnt)s extensions in %(name)s &raquo;"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/olympia/browse/templates/browse/mobile/extensions.html:13 src/olympia/compat/templates/compat/index.html:82 src/olympia/devhub/templates/devhub/devhub_search.html:24
-#: src/olympia/devhub/templates/devhub/addons/activity.html:47 src/olympia/search/templates/search/no_results.html:4 src/olympia/search/templates/search/mobile/results.html:36
+#: src/olympia/browse/templates/browse/mobile/extensions.html:13 src/olympia/devhub/templates/devhub/devhub_search.html:24 src/olympia/devhub/templates/devhub/addons/activity.html:47
+#: src/olympia/search/templates/search/no_results.html:4 src/olympia/search/templates/search/mobile/results.html:36
 msgid "No results found."
 msgstr ""
 
@@ -3032,7 +3052,7 @@ msgstr ""
 msgid "All"
 msgstr ""
 
-#: src/olympia/compat/forms.py:22 src/olympia/search/views.py:525
+#: src/olympia/compat/forms.py:22 src/olympia/editors/templates/editors/base.html:69 src/olympia/search/views.py:518
 msgid "All Add-ons"
 msgstr ""
 
@@ -3042,53 +3062,6 @@ msgstr ""
 
 #: src/olympia/compat/forms.py:24
 msgid "Non-binary"
-msgstr ""
-
-#. Review points sources other than add-ons and themes.
-#: src/olympia/compat/views.py:87 src/olympia/constants/base.py:388 src/olympia/devhub/forms.py:162 src/olympia/editors/templates/editors/performance.html:75
-msgid "Other"
-msgstr ""
-
-#: src/olympia/compat/templates/compat/index.html:4
-msgid "Add-on Compatibility Report for {app} {version}"
-msgstr ""
-
-#: src/olympia/compat/templates/compat/index.html:11
-msgid "{app} {version} Compatibility"
-msgstr ""
-
-#: src/olympia/compat/templates/compat/index.html:17
-#, python-format
-msgid "Top 95%% compatible with previous version"
-msgstr ""
-
-#: src/olympia/compat/templates/compat/index.html:18
-#, python-format
-msgid "Top 95%% of all add-ons"
-msgstr ""
-
-#: src/olympia/compat/templates/compat/index.html:19
-msgid "All active add-ons"
-msgstr ""
-
-#: src/olympia/compat/templates/compat/index.html:23 src/olympia/constants/base.py:401
-msgid "App"
-msgstr ""
-
-#: src/olympia/compat/templates/compat/index.html:55
-msgid "Details for add-ons compatible with previous version:"
-msgstr ""
-
-#: src/olympia/compat/templates/compat/index.html:57
-msgid "Show all versions"
-msgstr ""
-
-#: src/olympia/compat/templates/compat/index.html:59
-msgid "Details for add-ons compatible with all versions:"
-msgstr ""
-
-#: src/olympia/compat/templates/compat/index.html:61
-msgid "Show previous version only"
 msgstr ""
 
 #: src/olympia/compat/templates/compat/reporter.html:3
@@ -3142,8 +3115,8 @@ msgstr ""
 msgid "Report Type"
 msgstr ""
 
-#: src/olympia/compat/templates/compat/reporter_detail.html:47 src/olympia/devhub/forms.py:784 src/olympia/devhub/templates/devhub/addons/ajax_compat_update.html:17 src/olympia/editors/forms.py:108
-#: src/olympia/zadmin/forms.py:45
+#: src/olympia/compat/templates/compat/reporter_detail.html:47 src/olympia/devhub/forms.py:785 src/olympia/devhub/templates/devhub/addons/ajax_compat_update.html:17 src/olympia/editors/forms.py:108
+#: src/olympia/editors/forms.py:248 src/olympia/zadmin/forms.py:45
 msgid "Application"
 msgstr ""
 
@@ -3231,7 +3204,8 @@ msgstr ""
 msgid "Preliminarily Reviewed and Awaiting Full Review"
 msgstr ""
 
-#: src/olympia/constants/base.py:33 src/olympia/editors/helpers.py:924 src/olympia/editors/templates/editors/themes/history_table.html:34
+#: src/olympia/constants/base.py:33 src/olympia/editors/forms.py:258 src/olympia/editors/helpers.py:73 src/olympia/editors/helpers.py:1004
+#: src/olympia/editors/templates/editors/themes/history_table.html:34
 msgid "Deleted"
 msgstr ""
 
@@ -3328,6 +3302,11 @@ msgstr ""
 msgid "Ask before users can download this add-on"
 msgstr ""
 
+#. Review points sources other than add-ons and themes.
+#: src/olympia/constants/base.py:388 src/olympia/devhub/forms.py:162 src/olympia/editors/templates/editors/performance.html:75
+msgid "Other"
+msgstr ""
+
 #: src/olympia/constants/base.py:389
 msgid "Exception"
 msgstr ""
@@ -3338,6 +3317,10 @@ msgstr ""
 
 #: src/olympia/constants/base.py:391
 msgid "Change"
+msgstr ""
+
+#: src/olympia/constants/base.py:401
+msgid "App"
 msgstr ""
 
 #: src/olympia/constants/base.py:402
@@ -3488,7 +3471,7 @@ msgstr ""
 msgid "Duplicate"
 msgstr ""
 
-#: src/olympia/constants/editors.py:17 src/olympia/editors/helpers.py:502 src/olympia/editors/templates/editors/themes/queue.html:71 src/olympia/editors/templates/editors/themes/themes.html:94
+#: src/olympia/constants/editors.py:17 src/olympia/editors/helpers.py:575 src/olympia/editors/templates/editors/themes/queue.html:71 src/olympia/editors/templates/editors/themes/themes.html:94
 msgid "Reject"
 msgstr ""
 
@@ -3588,7 +3571,7 @@ msgstr ""
 msgid "Android"
 msgstr ""
 
-#: src/olympia/core/apps.py:19
+#: src/olympia/core/apps.py:21
 msgid "Core"
 msgstr ""
 
@@ -3722,7 +3705,7 @@ msgid "Submit my add-on for manual review."
 msgstr ""
 
 #: src/olympia/devhub/forms.py:537
-msgid "Do not list my add-on on this site (beta)"
+msgid "Do not list my add-on on this site"
 msgstr ""
 
 #: src/olympia/devhub/forms.py:538
@@ -3755,46 +3738,46 @@ msgstr ""
 
 #: src/olympia/devhub/forms.py:592
 #, python-format
-msgid "Version %s already exists"
+msgid "Version %s already exists, or was uploaded before."
 msgstr ""
 
-#: src/olympia/devhub/forms.py:604
+#: src/olympia/devhub/forms.py:605
 msgid "Select a valid choice. That choice is not one of the available choices."
 msgstr ""
 
-#: src/olympia/devhub/forms.py:610
+#: src/olympia/devhub/forms.py:611
 msgid "A file with a version ending with a|alpha|b|beta and an optional number is detected as beta."
 msgstr ""
 
-#: src/olympia/devhub/forms.py:633
+#: src/olympia/devhub/forms.py:634
 msgid "You cannot upload any more files for this version."
 msgstr ""
 
-#: src/olympia/devhub/forms.py:639
+#: src/olympia/devhub/forms.py:640
 msgid "Version doesn't match"
 msgstr ""
 
-#: src/olympia/devhub/forms.py:668
+#: src/olympia/devhub/forms.py:669
 msgid "You cannot delete a file once the review process has started.  You must delete the whole version."
 msgstr ""
 
-#: src/olympia/devhub/forms.py:688
+#: src/olympia/devhub/forms.py:689
 msgid "The platform All cannot be combined with specific platforms."
 msgstr ""
 
-#: src/olympia/devhub/forms.py:693
+#: src/olympia/devhub/forms.py:694
 msgid "A platform can only be chosen once."
 msgstr ""
 
-#: src/olympia/devhub/forms.py:706
+#: src/olympia/devhub/forms.py:707
 msgid "A review type must be selected."
 msgstr ""
 
-#: src/olympia/devhub/forms.py:788 src/olympia/editors/forms.py:114 src/olympia/zadmin/forms.py:49 src/olympia/zadmin/forms.py:52
+#: src/olympia/devhub/forms.py:789 src/olympia/editors/forms.py:114 src/olympia/editors/forms.py:254 src/olympia/zadmin/forms.py:49 src/olympia/zadmin/forms.py:52
 msgid "Select an application first"
 msgstr ""
 
-#: src/olympia/devhub/forms.py:840
+#: src/olympia/devhub/forms.py:841
 msgid "There cannot be more than 3 required add-ons."
 msgstr ""
 
@@ -3828,76 +3811,76 @@ msgstr[1] ""
 msgid "Review"
 msgstr ""
 
-#: src/olympia/devhub/tasks.py:551
+#: src/olympia/devhub/tasks.py:583
 #, python-format
 msgid "%s responded with %s (%s)."
 msgstr ""
 
-#: src/olympia/devhub/tasks.py:555
+#: src/olympia/devhub/tasks.py:587
 #, python-format
 msgid "Connection to \"%s\" timed out."
 msgstr ""
 
-#: src/olympia/devhub/tasks.py:557
+#: src/olympia/devhub/tasks.py:589
 #, python-format
 msgid "Could not contact host at \"%s\"."
 msgstr ""
 
-#: src/olympia/devhub/utils.py:104
+#: src/olympia/devhub/utils.py:105
 #, python-format
 msgid "Validation generated too many errors/warnings so %s messages were truncated. After addressing the visible messages, you'll be able to see the others."
 msgstr ""
 
-#: src/olympia/devhub/views.py:183
+#: src/olympia/devhub/views.py:181
 msgid "All My Add-ons"
 msgstr ""
 
-#: src/olympia/devhub/views.py:210
+#: src/olympia/devhub/views.py:208
 msgid "All Activity"
 msgstr ""
 
-#: src/olympia/devhub/views.py:211
+#: src/olympia/devhub/views.py:209
 msgid "Add-on Updates"
 msgstr ""
 
-#: src/olympia/devhub/views.py:212
+#: src/olympia/devhub/views.py:210
 msgid "Add-on Status"
 msgstr ""
 
-#: src/olympia/devhub/views.py:213
+#: src/olympia/devhub/views.py:211
 msgid "User Collections"
 msgstr ""
 
-#: src/olympia/devhub/views.py:214 src/olympia/devhub/templates/devhub/docs/policies-maintenance.html:68 src/olympia/pages/templates/pages/dev_faq.html:38
+#: src/olympia/devhub/views.py:212 src/olympia/devhub/templates/devhub/docs/policies-maintenance.html:68 src/olympia/pages/templates/pages/dev_faq.html:38
 #: src/olympia/pages/templates/pages/dev_faq.html:484
 msgid "User Reviews"
 msgstr ""
 
-#: src/olympia/devhub/views.py:327 src/olympia/devhub/views.py:331 src/olympia/devhub/views.py:484 src/olympia/devhub/views.py:513 src/olympia/devhub/views.py:564 src/olympia/devhub/views.py:1150
+#: src/olympia/devhub/views.py:325 src/olympia/devhub/views.py:329 src/olympia/devhub/views.py:484 src/olympia/devhub/views.py:513 src/olympia/devhub/views.py:564 src/olympia/devhub/views.py:1156
 msgid "Changes successfully saved."
 msgstr ""
 
-#: src/olympia/devhub/views.py:334 src/olympia/devhub/views.py:1631
+#: src/olympia/devhub/views.py:332 src/olympia/devhub/views.py:1637
 msgid "Please check the form for errors."
 msgstr ""
 
-#: src/olympia/devhub/views.py:346
+#: src/olympia/devhub/views.py:344
 msgid "Add-on cannot be deleted. Disable this add-on instead."
 msgstr ""
 
-#: src/olympia/devhub/views.py:356
+#: src/olympia/devhub/views.py:354
 msgid "Theme deleted."
 msgstr ""
 
-#: src/olympia/devhub/views.py:356
+#: src/olympia/devhub/views.py:354
 msgid "Add-on deleted."
 msgstr ""
 
-#: src/olympia/devhub/views.py:362
+#: src/olympia/devhub/views.py:360
 msgid "URL name was incorrect. Theme was not deleted."
 msgstr ""
 
-#: src/olympia/devhub/views.py:367
+#: src/olympia/devhub/views.py:365
 msgid "URL name was incorrect. Add-on was not deleted."
 msgstr ""
 
@@ -3925,7 +3908,7 @@ msgstr ""
 msgid "Check Add-on Compatibility"
 msgstr ""
 
-#: src/olympia/devhub/views.py:808 src/olympia/signing/views.py:90
+#: src/olympia/devhub/views.py:808 src/olympia/signing/views.py:95
 msgid "You cannot submit this type of add-on"
 msgstr ""
 
@@ -3955,33 +3938,33 @@ msgstr ""
 msgid "There was an error uploading your preview."
 msgstr ""
 
-#: src/olympia/devhub/views.py:1189
+#: src/olympia/devhub/views.py:1195
 #, python-format
 msgid "Version %s disabled."
 msgstr ""
 
-#: src/olympia/devhub/views.py:1193
+#: src/olympia/devhub/views.py:1199
 #, python-format
 msgid "Version %s deleted."
 msgstr ""
 
-#: src/olympia/devhub/views.py:1203
+#: src/olympia/devhub/views.py:1209
 msgid "This upload has failed validation, and may lack complete validation results. Please take due care when reviewing it."
 msgstr ""
 
-#: src/olympia/devhub/views.py:1677
+#: src/olympia/devhub/views.py:1683
 msgid "Preliminary Review Requested."
 msgstr ""
 
-#: src/olympia/devhub/views.py:1678
+#: src/olympia/devhub/views.py:1684
 msgid "Full Review Requested."
 msgstr ""
 
-#: src/olympia/devhub/views.py:1779
+#: src/olympia/devhub/views.py:1783
 msgid "Your old credentials were revoked and are no longer valid. Be sure to update all API clients with the new credentials."
 msgstr ""
 
-#: src/olympia/devhub/views.py:1797
+#: src/olympia/devhub/views.py:1801
 msgid "New API key created"
 msgstr ""
 
@@ -4011,7 +3994,7 @@ msgstr ""
 msgid "{0} :: Search"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/devhub_search.html:6 src/olympia/devhub/templates/devhub/search.html:8 src/olympia/editors/forms.py:435 src/olympia/editors/forms.py:437
+#: src/olympia/devhub/templates/devhub/devhub_search.html:6 src/olympia/devhub/templates/devhub/search.html:8 src/olympia/editors/forms.py:534 src/olympia/editors/forms.py:536
 #: src/olympia/editors/templates/editors/queue.html:27 src/olympia/editors/templates/editors/themes/queue_list.html:14 src/olympia/search/templates/search/collections.html:17
 #: src/olympia/search/templates/search/personas.html:18 src/olympia/search/templates/search/results.html:18 src/olympia/search/templates/search/mobile/results.html:8
 #: src/olympia/templates/search.html:14 src/olympia/templates/impala/search.html:18
@@ -4071,12 +4054,12 @@ msgstr ""
 msgid "Start Making Add-ons"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/index.html:86 src/olympia/devhub/templates/devhub/addons/listing/items.html:25 src/olympia/devhub/templates/devhub/includes/addon_details.html:15
+#: src/olympia/devhub/templates/devhub/index.html:86 src/olympia/devhub/templates/devhub/addons/listing/items.html:25 src/olympia/devhub/templates/devhub/includes/addon_details.html:20
 #: src/olympia/devhub/templates/devhub/personas/edit.html:43
 msgid "Status:"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/index.html:90 src/olympia/devhub/templates/devhub/includes/addon_details.html:100
+#: src/olympia/devhub/templates/devhub/index.html:90 src/olympia/devhub/templates/devhub/includes/addon_details.html:87
 msgid "Visibility:"
 msgstr ""
 
@@ -4084,11 +4067,11 @@ msgstr ""
 msgid "Latest Version:"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/index.html:109 src/olympia/devhub/templates/devhub/includes/addon_details.html:145 src/olympia/devhub/templates/devhub/personas/edit.html:49
+#: src/olympia/devhub/templates/devhub/index.html:109 src/olympia/devhub/templates/devhub/includes/addon_details.html:131 src/olympia/devhub/templates/devhub/personas/edit.html:49
 msgid "Queue Position:"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/index.html:110 src/olympia/devhub/templates/devhub/includes/addon_details.html:146 src/olympia/devhub/templates/devhub/personas/edit.html:50
+#: src/olympia/devhub/templates/devhub/index.html:110 src/olympia/devhub/templates/devhub/includes/addon_details.html:132 src/olympia/devhub/templates/devhub/personas/edit.html:50
 #, python-format
 msgid "%(position)s of %(total)s"
 msgstr ""
@@ -4190,16 +4173,6 @@ msgstr ""
 msgid "Do you want your add-on to be distributed on this site?"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/validate_addon.html:49 src/olympia/devhub/templates/devhub/addons/submit/upload.html:30 src/olympia/devhub/templates/devhub/versions/add_file_modal.html:14
-#: src/olympia/devhub/templates/devhub/versions/add_file_modal.html:53 src/olympia/devhub/templates/devhub/versions/list.html:298
-msgid "Warning:"
-msgstr ""
-
-#: src/olympia/devhub/templates/devhub/validate_addon.html:50 src/olympia/devhub/templates/devhub/addons/submit/upload.html:31
-#, python-format
-msgid "Submission of unlisted add-ons for signing is currently in an open beta. Please <a href=\"%(url)s\" target=\"_blank\">report any bugs</a> that you encounter."
-msgstr ""
-
 #. first parameter is a filename like lorem-ipsum-1.0.2.xpi
 #: src/olympia/devhub/templates/devhub/validation.html:5
 msgid "Validation Results for {0}"
@@ -4274,7 +4247,7 @@ msgstr ""
 msgid "Update Compatibility"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/addons/ajax_compat_update.html:4
+#: src/olympia/devhub/templates/devhub/addons/ajax_compat_update.html:4 src/olympia/devhub/templates/devhub/versions/edit.html:45
 msgid "Adjusting application information here will allow users to install your add-on even if the install manifest in the package indicates that the add-on is incompatible."
 msgstr ""
 
@@ -4286,9 +4259,9 @@ msgstr ""
 msgid "Add Another Application&hellip;"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/addons/ajax_compat_update.html:38 src/olympia/devhub/templates/devhub/addons/owner.html:86 src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:46
-#: src/olympia/devhub/templates/devhub/versions/list.html:351 src/olympia/devhub/templates/devhub/versions/list.html:353 src/olympia/templates/impala/base.html:132
-#: src/olympia/templates/impala/base.html:143 src/olympia/templates/impala/base.html:161 src/olympia/templates/impala/base.html:171
+#: src/olympia/devhub/templates/devhub/addons/ajax_compat_update.html:38 src/olympia/devhub/templates/devhub/addons/owner.html:86 src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:45
+#: src/olympia/devhub/templates/devhub/versions/list.html:349 src/olympia/devhub/templates/devhub/versions/list.html:351 src/olympia/templates/impala/base.html:129
+#: src/olympia/templates/impala/base.html:140 src/olympia/templates/impala/base.html:158 src/olympia/templates/impala/base.html:168
 msgid "Close"
 msgstr ""
 
@@ -4322,7 +4295,7 @@ msgstr ""
 msgid "Manage Authors & License"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/addons/owner.html:29 src/olympia/editors/templates/editors/review.html:270
+#: src/olympia/devhub/templates/devhub/addons/owner.html:29 src/olympia/editors/helpers.py:362 src/olympia/editors/templates/editors/review.html:270
 msgid "Authors"
 msgstr ""
 
@@ -4391,17 +4364,11 @@ msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/basic.html:52
 msgid ""
-"A short explanation of your add-on's basic\n"
-"                          functionality that is displayed in search and browse\n"
-"                          listings, as well as at the top of your add-on's\n"
-"                          details page. It is only relevant for listed add-ons."
+"A short explanation of your add-on's basic functionality that is displayed in search and browse listings, as well as at the top of your add-on's details page. It is only relevant for listed add-ons."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/basic.html:73
-msgid ""
-"Categories are the primary way users browse through add-ons.\n"
-"                        Choose any that fit your add-on's functionality for the most\n"
-"                        exposure. It is only relevant for listed add-ons."
+msgid "Categories are the primary way users browse through add-ons. Choose any that fit your add-on's functionality for the most exposure. It is only relevant for listed add-ons."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/basic.html:90
@@ -4411,11 +4378,7 @@ msgid ""
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/basic.html:119
-msgid ""
-"Tags help users find your add-on and should be short\n"
-"                        descriptors such as tabs, toolbar, or twitter.  You\n"
-"                        may have a maximum of {0} tags. It is only relevant\n"
-"                        for listed add-ons."
+msgid "Tags help users find your add-on and should be short descriptors such as tabs, toolbar, or twitter. You may have a maximum of {0} tags. It is only relevant for listed add-ons."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/basic.html:129 src/olympia/devhub/templates/devhub/personas/edit.html:97 src/olympia/devhub/templates/devhub/personas/submit.html:46
@@ -4443,11 +4406,7 @@ msgid "Add-on Details for {0}"
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/details.html:22
-msgid ""
-"A longer explanation of features,\n"
-"                          functionality, and other relevant information. This\n"
-"                          field is only displayed on the add-on's details\n"
-"                          page. It is only relevant for listed add-ons."
+msgid "A longer explanation of features, functionality, and other relevant information. This field is only displayed on the add-on's details page. It is only relevant for listed add-ons."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/details.html:44 src/olympia/translations/templates/translations/trans-menu.html:13
@@ -4455,10 +4414,7 @@ msgid "Default Locale"
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/details.html:45
-msgid ""
-"Information about your add-on is displayed in this locale\n"
-"                        unless you override it with a locale-specific translation.\n"
-"                        It is only relevant for listed add-ons."
+msgid "Information about your add-on is displayed in this locale unless you override it with a locale-specific translation. It is only relevant for listed add-ons."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/details.html:61 src/olympia/users/forms.py:311 src/olympia/users/templates/users/edit.html:122 src/olympia/users/templates/users/register.html:57
@@ -4468,10 +4424,8 @@ msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/details.html:63
 msgid ""
-"If your add-on has another homepage, enter its\n"
-"                          address here. If your website is localized into other\n"
-"                          languages multiple translations of this field can be\n"
-"                          added. It is only relevant for listed add-ons."
+"If your add-on has another homepage, enter its address here. If your website is localized into other languages multiple translations of this field can be added. It is only relevant for listed add-"
+"ons."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/media.html:3
@@ -4489,19 +4443,14 @@ msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/support.html:22
 msgid ""
-"If you wish to display an e-mail address for support\n"
-"                          inquiries, enter it here. If you have different\n"
-"                          addresses for each language multiple translations of\n"
-"                          this field can be added. It is only relevant for\n"
-"                          listed add-ons."
+"If you wish to display an e-mail address for support inquiries, enter it here. If you have different addresses for each language multiple translations of this field can be added. It is only "
+"relevant for listed add-ons."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/support.html:45
 msgid ""
-"If your add-on has a support website or forum, enter\n"
-"                          its address here. If your website is localized into\n"
-"                          other languages, multiple translations of this field can\n"
-"                          be added. It is only relevant for listed add-ons."
+"If your add-on has a support website or forum, enter its address here. If your website is localized into other languages, multiple translations of this field can be added. It is only relevant for "
+"listed add-ons."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:6
@@ -4515,11 +4464,8 @@ msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:23
 msgid ""
-"Any information end users may want to know that isn't\n"
-"                          necessarily applicable to the add-on summary or description.\n"
-"                          Common uses include listing known major bugs, information on\n"
-"                          how to report bugs, anticipated release date of a new version,\n"
-"                          etc. It is only relevant for listed add-ons."
+"Any information end users may want to know that isn't necessarily applicable to the add-on summary or description. Common uses include listing known major bugs, information on how to report bugs, "
+"anticipated release date of a new version, etc. It is only relevant for listed add-ons."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:46
@@ -4531,9 +4477,7 @@ msgid "Add-on Flags"
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:69
-msgid ""
-"These flags are used to classify add-ons. It is only\n"
-"                        relevant for listed add-ons."
+msgid "These flags are used to classify add-ons. It is only relevant for listed add-ons."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:74
@@ -4549,9 +4493,7 @@ msgid "View Source?"
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:90
-msgid ""
-"Whether the source of your add-on can be displayed in our\n"
-"                        online viewer. It is only relevant for listed add-ons."
+msgid "Whether the source of your add-on can be displayed in our online viewer. It is only relevant for listed add-ons."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:94
@@ -4567,10 +4509,7 @@ msgid "Public Stats?"
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:102
-msgid ""
-"Whether the download and usage stats of your add-on can\n"
-"                        be displayed in our online viewer.\n"
-"                        It is only relevant for listed add-ons."
+msgid "Whether the download and usage stats of your add-on can be displayed in our online viewer. It is only relevant for listed add-ons."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:107
@@ -4586,10 +4525,7 @@ msgid "Upgrade SDK?"
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:116
-msgid ""
-"If selected, we will try to automatically upgrade your\n"
-"                        add-on when a new version of the SDK is released.\n"
-"                        It is only relevant for listed add-ons."
+msgid "If selected, we will try to automatically upgrade your add-on when a new version of the SDK is released. It is only relevant for listed add-ons."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:121
@@ -4640,10 +4576,8 @@ msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/forms_shared/media.html:16
 msgid ""
-"Upload an icon for your add-on or choose from one of ours. The\n"
-"                      icon is displayed nearly everywhere your add-on is. Uploaded images\n"
-"                      must be one of the following image types: .png, .jpg.\n"
-"                      It is only relevant for listed add-ons."
+"Upload an icon for your add-on or choose from one of ours. The icon is displayed nearly everywhere your add-on is. Uploaded images must be one of the following image types: .png, .jpg. It is only "
+"relevant for listed add-ons."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/forms_shared/media.html:25
@@ -4656,9 +4590,7 @@ msgid "32x32px"
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/forms_shared/media.html:39
-msgid ""
-"Used in listings of add-ons, like search results\n"
-"                            and featured add-ons."
+msgid "Used in listings of add-ons, like search results and featured add-ons."
 msgstr ""
 
 #. The size of the icon
@@ -4753,16 +4685,14 @@ msgid "Deleting your add-on will permanently remove it from the site and prevent
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:24
-msgid ""
-"Enter the following text confirm your decision:\n"
-"           {slug}"
+msgid "Enter the following text confirm your decision: {slug}"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:34
+#: src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:33
 msgid "Please tell us why you are deleting your theme:"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:36
+#: src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:35
 msgid "Please tell us why you are deleting your add-on:"
 msgstr ""
 
@@ -4799,8 +4729,8 @@ msgstr ""
 msgid "Daily statistics on downloads and users."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/addons/listing/item_actions.html:45 src/olympia/stats/templates/stats/stats.html:75 src/olympia/stats/templates/stats/stats.html:79
-#: src/olympia/stats/templates/stats/stats.html:81
+#: src/olympia/devhub/templates/devhub/addons/listing/item_actions.html:45 src/olympia/stats/templates/stats/stats.html:31 src/olympia/stats/templates/stats/stats.html:35
+#: src/olympia/stats/templates/stats/stats.html:37
 msgid "Statistics"
 msgstr ""
 
@@ -4919,10 +4849,7 @@ msgid "Your add-on has been submitted to the Full Review queue."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/submit/done.html:18
-msgid ""
-"You'll receive an email once it has been reviewed by an editor. In\n"
-"          the meantime, you and your friends can install it directly from its\n"
-"          details page:"
+msgid "You'll receive an email once it has been reviewed by an editor. In the meantime, you and your friends can install it directly from its details page:"
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/submit/done.html:27 src/olympia/devhub/templates/devhub/addons/submit/done.html:77 src/olympia/devhub/templates/devhub/personas/submit_done.html:16
@@ -5128,11 +5055,11 @@ msgstr ""
 msgid "Use the fields below to upload your add-on package and select any platform restrictions. After upload, a series of automated validation tests will be run on your file."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/addons/submit/upload.html:59 src/olympia/devhub/templates/devhub/versions/add_file_modal.html:39
+#: src/olympia/devhub/templates/devhub/addons/submit/upload.html:51 src/olympia/devhub/templates/devhub/versions/add_file_modal.html:28
 msgid "Which platforms is this file compatible with?"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/addons/submit/upload.html:67 src/olympia/devhub/templates/devhub/versions/add_file_modal.html:65
+#: src/olympia/devhub/templates/devhub/addons/submit/upload.html:59 src/olympia/devhub/templates/devhub/versions/add_file_modal.html:45
 msgid "Administrative overrides"
 msgstr ""
 
@@ -5242,8 +5169,8 @@ msgstr ""
 
 #: src/olympia/devhub/templates/devhub/docs/policies-contact.html:44
 msgid ""
-"If you've found a problem with the site, we'd love to fix it. Please <a href=\"https://github.com/mozilla/olympia/issues\">file a bug report</a> in GitHub, including the location of the problem and "
-"how you encountered it."
+"If you've found a problem with the site, we'd love to fix it. Please <a href=\"https://github.com/mozilla/addons/issues/new\">file a bug report</a> in GitHub, including the location of the problem "
+"and how you encountered it."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/docs/policies-maintenance.html:3 src/olympia/devhub/templates/devhub/docs/policies-maintenance.html:7
@@ -5810,7 +5737,7 @@ msgstr ""
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:282
 msgid ""
-"Add-ons that store or otherwise handle browsing data must support <a href=\"https://developer.mozilla.org/En/Supporting_private_browsing_mode\">Private Browsing Mode</a>.  During a Private Browsing "
+"Add-ons that store or otherwise handle browsing data must support <a href=\"https://developer.mozilla.org/En/Supporting_private_browsing_mode\">Private Browsing Mode</a>. During a Private Browsing "
 "session, no browsing data can be written to disk, and all of this data must be cleared when Firefox quits or the Private Browsing session ends."
 msgstr ""
 
@@ -5975,129 +5902,95 @@ msgstr ""
 msgid "How to get in touch with us regarding these policies or your add-on."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:6
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:10
 msgid "You have disabled this add-on"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:20
-msgid ""
-"Your add-on's listing is disabled and is not showing\n"
-"                             anywhere in our gallery or update service."
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:24
+msgid "Your add-on's listing is disabled and is not showing anywhere in our gallery or update service."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:25
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:27
 msgid "Please complete your add-on."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:29
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:30
 msgid "You will receive an email when the review is complete."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:34
-msgid ""
-"You will receive an email when the review is complete. Until\n"
-"                             then, your add-on is not listed in our gallery but can be\n"
-"                             accessed directly from its details page."
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:33
+msgid "You will receive an email when the review is complete. Until then, your add-on is not listed in our gallery but can be accessed directly from its details page."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:38 src/olympia/devhub/templates/devhub/includes/addon_details.html:48
-msgid ""
-"You will receive an email when the review is\n"
-"                             complete and your add-on is signed."
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:37 src/olympia/devhub/templates/devhub/includes/addon_details.html:45
+msgid "You will receive an email when the review is complete and your add-on is signed."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:44
-msgid ""
-"You will receive an email when the review is complete. Until\n"
-"                             then, your add-on is not listed in our gallery but can be\n"
-"                             accessed directly from its details page. "
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:41
+msgid "You will receive an email when the review is complete. Until then, your add-on is not listed in our gallery but can be accessed directly from its details page. "
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:54
-msgid ""
-"Your add-on is displayed in our gallery and users are\n"
-"                             receiving automatic updates."
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:49
+msgid "Your add-on is displayed in our gallery and users are receiving automatic updates."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:57
-msgid ""
-"Your add-on has been signed and can be bundled with an\n"
-"                             application installer."
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:52
+msgid "Your add-on has been signed and can be bundled with an application installer."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:63
-msgid ""
-"Your add-on was disabled by a site administrator and is no\n"
-"                             longer shown in our gallery. If you have any questions,\n"
-"                             please email amo-admins@mozilla.org."
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:56
+msgid "Your add-on was disabled by a site administrator and is no longer shown in our gallery. If you have any questions, please email amo-admins@mozilla.org."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:70
-msgid ""
-"Your add-on is displayed in our gallery as experimental\n"
-"                             and users are receiving automatic updates. Some features\n"
-"                             are unavailable to your add-on."
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:62
+msgid "Your add-on is displayed in our gallery as experimental and users are receiving automatic updates. Some features are unavailable to your add-on."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:74
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:66
 msgid "Your add-on has been signed."
 msgstr ""
 
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:69
+msgid ""
+"You will receive an email when the full review is complete. Until then, your add-on is displayed in our gallery as experimental and users are receiving automatic updates. Some features are "
+"unavailable to your add-on."
+msgstr ""
+
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:74
+msgid "You will receive an email when the full review is complete, making you able to bundle your add-on with an application installer."
+msgstr ""
+
 #: src/olympia/devhub/templates/devhub/includes/addon_details.html:79
-msgid ""
-"You will receive an email when the full review is complete.\n"
-"                             Until then, your add-on is displayed in our gallery as\n"
-"                             experimental and users are receiving automatic updates.\n"
-"                             Some features are unavailable to your add-on."
+msgid "All add-ons hosted in our gallery must now be reviewed by an editor. If you wish to continue hosting your add-on, please click to select a review process."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:84
-msgid ""
-"You will receive an email when the full review is\n"
-"                             complete, making you able to bundle your add-on with an\n"
-"                             application installer."
-msgstr ""
-
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:91
-msgid ""
-"All add-ons hosted in our gallery must now be reviewed by an\n"
-"                             editor. If you wish to continue hosting your add-on, please\n"
-"                             click to select a review process."
-msgstr ""
-
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:113
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:100
 msgid "Current Version:"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:115
-msgid ""
-"This is the version of your add-on that will\n"
-"                                           be installed if someone clicks the Install\n"
-"                                           button on addons.mozilla.org. It is only\n"
-"                                           relevant for listed add-ons."
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:102
+msgid "This is the version of your add-on that will be installed if someone clicks the Install button on addons.mozilla.org. It is only relevant for listed add-ons."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:123
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:110
 msgid "Created:"
 msgstr ""
 
 #. {0} is a date. dennis-ignore: E201
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:125 src/olympia/devhub/templates/devhub/includes/addon_details.html:131
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:112 src/olympia/devhub/templates/devhub/includes/addon_details.html:118
 #, python-format
 msgid "%%b %%e, %%Y"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:136
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:123
 msgid "Next Version:"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:138
-msgid ""
-"This is the newest uploaded version, however\n"
-"                                           it isn’t live on the site yet."
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:125
+msgid "This is the newest uploaded version, however it isn’t live on the site yet."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:144 src/olympia/devhub/templates/devhub/versions/list.html:30
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:130 src/olympia/devhub/templates/devhub/versions/list.html:30
 msgid "Queues are not reviewed strictly in order"
 msgstr ""
 
@@ -6165,9 +6058,7 @@ msgid "View the blog &#9658;"
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/includes/license_form.html:6
-msgid ""
-"Please choose a license appropriate for the rights you grant on your source code.\n"
-"                  It is only relevant for listed add-ons."
+msgid "Please choose a license appropriate for the rights you grant on your source code. It is only relevant for listed add-ons."
 msgstr ""
 
 #. {0} is a list of HTML tags.
@@ -6194,14 +6085,11 @@ msgstr[1] ""
 #: src/olympia/devhub/templates/devhub/includes/policy_form.html:4
 msgid ""
 "Users will be required to accept the following End-User License Agreement (EULA) prior to installing your add-on. The presence of a EULA significantly affects the number of downloads an add-on "
-"receives. Please note that a EULA is not the same as a code license, such as the GPL or MPL.\n"
-"                It is only relevant for listed add-ons."
+"receives. Please note that a EULA is not the same as a code license, such as the GPL or MPL.It is only relevant for listed add-ons."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/policy_form.html:21
-msgid ""
-"If your add-on transmits any data from the user's computer, a privacy policy is required that explains what data is sent and how it is used.\n"
-"                It is only relevant for listed add-ons."
+#: src/olympia/devhub/templates/devhub/includes/policy_form.html:24
+msgid "If your add-on transmits any data from the user's computer, a privacy policy is required that explains what data is sent and how it is used. It is only relevant for listed add-ons."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/includes/source_form_field.html:2
@@ -6369,12 +6257,8 @@ msgstr ""
 msgid "Add some tags to describe your Theme."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/personas/edit.html:106
-msgid ""
-"A short explanation of your theme's\n"
-"                                basic functionality that is displayed in\n"
-"                                search and browse listings, as well as at\n"
-"                                the top of your theme's details page."
+#: src/olympia/devhub/templates/devhub/personas/edit.html:106 src/olympia/devhub/templates/devhub/personas/submit.html:54
+msgid "A short explanation of your theme's basic functionality that is displayed in search and browse listings, as well as at the top of your theme's details page."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/personas/edit.html:122 src/olympia/devhub/templates/devhub/personas/submit.html:68
@@ -6444,7 +6328,7 @@ msgid "Upon upload and form submission, the AMO Team will review your updated de
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/personas/edit.html:241
-msgid "Your previously resubmitted design,  which is under pending review."
+msgid "Your previously resubmitted design, which is under pending review."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/personas/edit.html:245
@@ -6511,14 +6395,6 @@ msgstr ""
 
 #: src/olympia/devhub/templates/devhub/personas/submit.html:33
 msgid "Give your Theme a name."
-msgstr ""
-
-#: src/olympia/devhub/templates/devhub/personas/submit.html:54
-msgid ""
-"A short explanation of your theme's\n"
-"                                      basic functionality that is displayed in\n"
-"                                      search and browse listings, as well as at\n"
-"                                      the top of your theme's details page."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/personas/submit.html:198
@@ -6595,30 +6471,16 @@ msgstr ""
 msgid "Files added to reviewed versions must be reviewed before they will be available for download."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/add_file_modal.html:15
-#, python-format
-msgid ""
-"Submission of updates to unlisted add-ons for signing is currently in an open beta. Manual review may still be required for a large number of add-ons. Please <a href=\"%(url)s\" target=\"_blank"
-"\">report any bugs</a> that you encounter."
-msgstr ""
-
-#: src/olympia/devhub/templates/devhub/versions/add_file_modal.html:35
+#: src/olympia/devhub/templates/devhub/versions/add_file_modal.html:24
 msgid "Select the target platform for this file."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/add_file_modal.html:46
+#: src/olympia/devhub/templates/devhub/versions/add_file_modal.html:35
 msgid "Which review type would you like to nominate for?"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/add_file_modal.html:51
+#: src/olympia/devhub/templates/devhub/versions/add_file_modal.html:40
 msgid "Only publish this version to my beta channel."
-msgstr ""
-
-#: src/olympia/devhub/templates/devhub/versions/add_file_modal.html:54
-#, python-format
-msgid ""
-"The behavior of the beta channel has changed to accommodate <a href=\"%(addon_signing_url)s\" target=\"_blank\">mandatory add-on signing</a>. The new process is currently in an open beta, and may "
-"change significantly in the near future. Please <a href=\"%(issues_url)s\" target=\"_blank\">report any bugs</a> that you encounter."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/versions/edit.html:5
@@ -6642,19 +6504,10 @@ msgstr ""
 msgid "Upload Another File"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/edit.html:45
-msgid ""
-"Adjusting application information here will allow users to install your\n"
-"                          add-on even if the install manifest in the package indicates that the\n"
-"                          add-on is incompatible."
-msgstr ""
-
 #: src/olympia/devhub/templates/devhub/versions/edit.html:74
 msgid ""
-"Information about changes in this release, new features,\n"
-"                              known bugs, and other useful information specific to this\n"
-"                              release/version. This information is also shown in the\n"
-"                              Add-ons Manager when updating."
+"Information about changes in this release, new features, known bugs, and other useful information specific to this release/version. This information is also shown in the Add-ons Manager when "
+"updating."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/versions/edit.html:99
@@ -6666,10 +6519,7 @@ msgid "Notes for Reviewers"
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/versions/edit.html:114
-msgid ""
-"Optionally, enter any information that may be useful\n"
-"                              to the Editor reviewing this add-on, such as test\n"
-"                              account information."
+msgid "Optionally, enter any information that may be useful to the Editor reviewing this add-on, such as test account information."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/versions/edit.html:127
@@ -6747,7 +6597,7 @@ msgstr ""
 msgid "Request Preliminary Review"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:80 src/olympia/devhub/templates/devhub/versions/list.html:327 src/olympia/devhub/templates/devhub/versions/list.html:350
+#: src/olympia/devhub/templates/devhub/versions/list.html:80 src/olympia/devhub/templates/devhub/versions/list.html:325 src/olympia/devhub/templates/devhub/versions/list.html:348
 msgid "Cancel Review Request"
 msgstr ""
 
@@ -6776,7 +6626,7 @@ msgid "Unlisted:"
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/versions/list.html:114
-msgid "Not distributed on {0}. Developers will upload new versions for signing and distribute the add-ons on their own. (beta)"
+msgid "Not distributed on {0}. Developers will upload new versions for signing and distribute the add-ons on their own."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/versions/list.html:122
@@ -6839,81 +6689,73 @@ msgid "<strong>Important:</strong> Once a version has been deleted, you may not 
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/versions/list.html:230
-msgid ""
-"Deleting a version which has already been reviewed\n"
-"               may also cause a significant delay in the review of\n"
-"               your next update."
-msgstr ""
-
-#: src/olympia/devhub/templates/devhub/versions/list.html:233
 msgid "Are you sure you wish to delete this version?"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:238
+#: src/olympia/devhub/templates/devhub/versions/list.html:235
 msgid "Delete Version"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:240
+#: src/olympia/devhub/templates/devhub/versions/list.html:237
 msgid "Disable Version"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:247
+#: src/olympia/devhub/templates/devhub/versions/list.html:244
 msgid "Add a new Version"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:249
+#: src/olympia/devhub/templates/devhub/versions/list.html:246
 msgid "Add Version"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:256 src/olympia/devhub/templates/devhub/versions/list.html:274
+#: src/olympia/devhub/templates/devhub/versions/list.html:253 src/olympia/devhub/templates/devhub/versions/list.html:279
 msgid "Hide Add-on"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:259
+#: src/olympia/devhub/templates/devhub/versions/list.html:256
 msgid "Hiding your add-on will prevent it from appearing anywhere in our gallery and will stop users from receiving automatic updates."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:265
+#: src/olympia/devhub/templates/devhub/versions/list.html:263
+msgid "The files awaiting review will be disabled and you will need to upload new versions."
+msgstr ""
+
+#: src/olympia/devhub/templates/devhub/versions/list.html:270
 msgid "Are you sure you wish to hide your add-on?"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:286 src/olympia/devhub/templates/devhub/versions/list.html:315
+#: src/olympia/devhub/templates/devhub/versions/list.html:291 src/olympia/devhub/templates/devhub/versions/list.html:313
 msgid "Unlist Add-on"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:289
+#: src/olympia/devhub/templates/devhub/versions/list.html:294
 #, python-format
 msgid ""
 "Unlisting your add-on will make it (and each of its versions/files) invisible on this website. It won't show up in searches, won't have a public facing page, and won't be updated automatically for "
-"current users.  It is recommended for unlisted add-ons to provide a custom <a href=\"%(update_url)s\" target=\"_blank\">updateURL</a> in their manifest file for automatic updates."
+"current users. It is recommended for unlisted add-ons to provide a custom <a href=\"%(update_url)s\" target=\"_blank\">updateURL</a> in their manifest file for automatic updates."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:299
-#, python-format
-msgid "Switching add-ons to unlisted is currently in an open beta. Please <a href=\"%(url)s\" target=\"_blank\">report any bugs</a> that you encounter."
-msgstr ""
-
-#: src/olympia/devhub/templates/devhub/versions/list.html:305
+#: src/olympia/devhub/templates/devhub/versions/list.html:303
 msgid "Unlisting an add-on is irreversible!"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:305
+#: src/olympia/devhub/templates/devhub/versions/list.html:303
 msgid "An unlisted add-on cannot be switched to be listed."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:307
+#: src/olympia/devhub/templates/devhub/versions/list.html:305
 msgid "Are you sure you wish to unlist your add-on?"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:330
+#: src/olympia/devhub/templates/devhub/versions/list.html:328
 msgid "Canceling your review request will leave your add-on as preliminarily reviewed."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:335
+#: src/olympia/devhub/templates/devhub/versions/list.html:333
 msgid "Canceling your review request will mark your add-on incomplete. If you do not complete your add-on after several days by re-requesting review, it will be deleted."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:343
+#: src/olympia/devhub/templates/devhub/versions/list.html:341
 msgid "Are you sure you wish to cancel your review request?"
 msgstr ""
 
@@ -7252,19 +7094,19 @@ msgstr ""
 msgid "Search by add-on name / author email"
 msgstr ""
 
-#: src/olympia/editors/forms.py:103
+#: src/olympia/editors/forms.py:103 src/olympia/editors/forms.py:244 src/olympia/editors/forms.py:257
 msgid "yes"
 msgstr ""
 
-#: src/olympia/editors/forms.py:104
+#: src/olympia/editors/forms.py:104 src/olympia/editors/forms.py:244 src/olympia/editors/forms.py:257
 msgid "no"
 msgstr ""
 
-#: src/olympia/editors/forms.py:105
+#: src/olympia/editors/forms.py:105 src/olympia/editors/forms.py:245
 msgid "Admin Flag"
 msgstr ""
 
-#: src/olympia/editors/forms.py:113
+#: src/olympia/editors/forms.py:113 src/olympia/editors/forms.py:253
 msgid "Max. Version"
 msgstr ""
 
@@ -7276,55 +7118,59 @@ msgstr ""
 msgid "Add-on Types"
 msgstr ""
 
-#: src/olympia/editors/forms.py:126 src/olympia/editors/helpers.py:267
+#: src/olympia/editors/forms.py:126 src/olympia/editors/helpers.py:279
 msgid "Platforms"
 msgstr ""
 
+#: src/olympia/editors/forms.py:237
+msgid "Search by add-on name / author email / guid"
+msgstr ""
+
 #. L10n: 0 = platform, 1 = filename, 2 = status message
-#: src/olympia/editors/forms.py:238
+#: src/olympia/editors/forms.py:342
 #, python-format
 msgid "<strong>%s</strong> &middot; %s &middot; %s"
 msgstr ""
 
-#: src/olympia/editors/forms.py:252
+#: src/olympia/editors/forms.py:356
 msgid "Comments:"
 msgstr ""
 
-#: src/olympia/editors/forms.py:256
+#: src/olympia/editors/forms.py:360
 msgid "Operating systems:"
 msgstr ""
 
-#: src/olympia/editors/forms.py:258
+#: src/olympia/editors/forms.py:362
 msgid "Applications:"
 msgstr ""
 
-#: src/olympia/editors/forms.py:260
+#: src/olympia/editors/forms.py:364
 msgid "Notify me the next time this add-on is updated. (Subsequent updates will not generate an email)"
 msgstr ""
 
-#: src/olympia/editors/forms.py:265
+#: src/olympia/editors/forms.py:369
 msgid "Clear Admin Review Flag"
 msgstr ""
 
-#: src/olympia/editors/forms.py:267
+#: src/olympia/editors/forms.py:371
 msgid "Clear more info requested flag"
 msgstr ""
 
-#: src/olympia/editors/forms.py:281
+#: src/olympia/editors/forms.py:385
 msgid "Choose a canned response..."
 msgstr ""
 
 #. L10n: Description of what can be searched for.
-#: src/olympia/editors/forms.py:324
+#: src/olympia/editors/forms.py:423
 msgid "theme name"
 msgstr ""
 
-#: src/olympia/editors/forms.py:350
+#: src/olympia/editors/forms.py:449
 msgid "Someone else is reviewing this theme."
 msgstr ""
 
 #. L10n: Description of what can be searched for.
-#: src/olympia/editors/forms.py:447
+#: src/olympia/editors/forms.py:546
 msgid "app, reviewer, or comment"
 msgstr ""
 
@@ -7340,246 +7186,264 @@ msgstr ""
 msgid "Rejected or Unreviewed"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:123 src/olympia/editors/helpers.py:136
+#: src/olympia/editors/helpers.py:125 src/olympia/editors/helpers.py:138
 msgid "Queue"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:124 src/olympia/editors/templates/editors/base.html:50 src/olympia/editors/templates/editors/base.html:65
+#: src/olympia/editors/helpers.py:126 src/olympia/editors/templates/editors/base.html:50 src/olympia/editors/templates/editors/base.html:65
 msgid "Pending Updates"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:125 src/olympia/editors/templates/editors/base.html:48 src/olympia/editors/templates/editors/base.html:63
+#: src/olympia/editors/helpers.py:127 src/olympia/editors/templates/editors/base.html:48 src/olympia/editors/templates/editors/base.html:63
 msgid "Full Reviews"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:126 src/olympia/editors/templates/editors/base.html:52 src/olympia/editors/templates/editors/base.html:67
+#: src/olympia/editors/helpers.py:128 src/olympia/editors/templates/editors/base.html:52 src/olympia/editors/templates/editors/base.html:67
 msgid "Preliminary Reviews"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:127 src/olympia/editors/templates/editors/base.html:54
+#: src/olympia/editors/helpers.py:129 src/olympia/editors/templates/editors/base.html:54
 msgid "Moderated Reviews"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:128 src/olympia/editors/templates/editors/base.html:46
+#: src/olympia/editors/helpers.py:130 src/olympia/editors/templates/editors/base.html:46
 msgid "Fast Track"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:130
+#: src/olympia/editors/helpers.py:132
 msgid "Pending Themes"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:131 src/olympia/editors/templates/editors/themes/queue.html:4
+#: src/olympia/editors/helpers.py:133 src/olympia/editors/templates/editors/themes/queue.html:4
 msgid "Flagged Themes"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:132
+#: src/olympia/editors/helpers.py:134
 msgid "Update Themes"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:137
+#: src/olympia/editors/helpers.py:139
 msgid "Unlisted Pending Updates"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:138
+#: src/olympia/editors/helpers.py:140
 msgid "Unlisted Full Reviews"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:139
+#: src/olympia/editors/helpers.py:141
 msgid "Unlisted Preliminary Reviews"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:170
+#: src/olympia/editors/helpers.py:142
+msgid "Unlisted All Add-ons"
+msgstr ""
+
+#: src/olympia/editors/helpers.py:173
 msgid "Fast Track ({0})"
 msgid_plural "Fast Track ({0})"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/olympia/editors/helpers.py:175
+#: src/olympia/editors/helpers.py:178
 msgid "Full Review ({0})"
 msgid_plural "Full Reviews ({0})"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/olympia/editors/helpers.py:180
+#: src/olympia/editors/helpers.py:183
 msgid "Pending Update ({0})"
 msgid_plural "Pending Updates ({0})"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/olympia/editors/helpers.py:185
+#: src/olympia/editors/helpers.py:188
 msgid "Preliminary Review ({0})"
 msgid_plural "Preliminary Reviews ({0})"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/olympia/editors/helpers.py:190
+#: src/olympia/editors/helpers.py:193
 msgid "Moderated Review ({0})"
 msgid_plural "Moderated Reviews ({0})"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/olympia/editors/helpers.py:196
+#: src/olympia/editors/helpers.py:199
 msgid "Unlisted Full Review ({0})"
 msgid_plural "Unlisted Full Reviews ({0})"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/olympia/editors/helpers.py:201
+#: src/olympia/editors/helpers.py:204
 msgid "Unlisted Pending Update ({0})"
 msgid_plural "Unlisted Pending Updates ({0})"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/olympia/editors/helpers.py:206
+#: src/olympia/editors/helpers.py:209
 msgid "Unlisted Preliminary Review ({0})"
 msgid_plural "Unlisted Preliminary Reviews ({0})"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/olympia/editors/helpers.py:261
-msgid "Addon"
-msgstr ""
+#: src/olympia/editors/helpers.py:214
+msgid "Unlisted All Add-ons ({0})"
+msgid_plural "Unlisted All Add-ons ({0})"
+msgstr[0] ""
+msgstr[1] ""
 
-#: src/olympia/editors/helpers.py:262
+#: src/olympia/editors/helpers.py:274
 msgid "Type"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:263
+#: src/olympia/editors/helpers.py:275
 msgid "Waiting Time"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:264 src/olympia/editors/templates/editors/review.html:285
+#: src/olympia/editors/helpers.py:276 src/olympia/editors/templates/editors/review.html:285
 msgid "Flags"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:265
+#: src/olympia/editors/helpers.py:277
 msgid "Applications"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:270
+#: src/olympia/editors/helpers.py:282
 msgid "Additional"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:285
+#: src/olympia/editors/helpers.py:302
 msgid "Site Specific"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:287
+#: src/olympia/editors/helpers.py:304
 msgid "Requires External Software"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:289
+#: src/olympia/editors/helpers.py:306
 msgid "Binary Components"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:313
+#: src/olympia/editors/helpers.py:339
 msgid "moments ago"
 msgstr ""
 
 #. L10n: first argument is number of minutes
-#: src/olympia/editors/helpers.py:316
+#: src/olympia/editors/helpers.py:342
 msgid "{0} minute"
 msgid_plural "{0} minutes"
 msgstr[0] ""
 msgstr[1] ""
 
 #. L10n: first argument is number of hours
-#: src/olympia/editors/helpers.py:320
+#: src/olympia/editors/helpers.py:346
 msgid "{0} hour"
 msgid_plural "{0} hours"
 msgstr[0] ""
 msgstr[1] ""
 
 #. L10n: first argument is number of days
-#: src/olympia/editors/helpers.py:324
+#: src/olympia/editors/helpers.py:350
 msgid "{0} day"
 msgid_plural "{0} days"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/olympia/editors/helpers.py:488
+#: src/olympia/editors/helpers.py:364
+msgid "Last Review"
+msgstr ""
+
+#: src/olympia/editors/helpers.py:366
+msgid "Last Update"
+msgstr ""
+
+#: src/olympia/editors/helpers.py:387
+msgid "No Reviews"
+msgstr ""
+
+#: src/olympia/editors/helpers.py:561
 msgid "Push to public"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:490
+#: src/olympia/editors/helpers.py:563
 msgid "Grant full review"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:505
+#: src/olympia/editors/helpers.py:578
 msgid "Request more information"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:508
+#: src/olympia/editors/helpers.py:581
 msgid "Request super-review"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:519
+#: src/olympia/editors/helpers.py:592
 msgid "Grant preliminary review"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:520
+#: src/olympia/editors/helpers.py:593
 msgid "This will mark the files as preliminarily reviewed."
 msgstr ""
 
-#: src/olympia/editors/helpers.py:522
+#: src/olympia/editors/helpers.py:595
 msgid "Use this form to request more information from the author. They will receive an email and be able to answer here. You will be notified by email when they reply."
 msgstr ""
 
-#: src/olympia/editors/helpers.py:526
+#: src/olympia/editors/helpers.py:599
 msgid ""
 "If you have concerns about this add-on's security, copyright issues, or other concerns that an administrator should look into, enter your comments in the area below. They will be sent to "
 "administrators, not the author."
 msgstr ""
 
-#: src/olympia/editors/helpers.py:532
+#: src/olympia/editors/helpers.py:605
 msgid "This will reject the add-on and remove it from the review queue."
 msgstr ""
 
-#: src/olympia/editors/helpers.py:534
-msgid "Make a comment on this version.  The author won't be able to see this."
+#: src/olympia/editors/helpers.py:607
+msgid "Make a comment on this version. The author won't be able to see this."
 msgstr ""
 
-#: src/olympia/editors/helpers.py:538
+#: src/olympia/editors/helpers.py:611
 msgid "This will reject the files and remove them from the review queue."
 msgstr ""
 
-#: src/olympia/editors/helpers.py:542
+#: src/olympia/editors/helpers.py:615
 msgid "This will mark the add-on as preliminarily reviewed. Future versions will undergo preliminary review."
 msgstr ""
 
-#: src/olympia/editors/helpers.py:547
+#: src/olympia/editors/helpers.py:620
 msgid "This will mark the files as preliminarily reviewed. Future versions will undergo preliminary review."
 msgstr ""
 
-#: src/olympia/editors/helpers.py:552
+#: src/olympia/editors/helpers.py:625
 msgid "Retain preliminary review"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:553
+#: src/olympia/editors/helpers.py:626
 msgid "This will retain the add-on as preliminarily reviewed. Future versions will undergo preliminary review."
 msgstr ""
 
-#: src/olympia/editors/helpers.py:558
+#: src/olympia/editors/helpers.py:631
 msgid "This will approve a sandboxed version of a public add-on to appear on the public side."
 msgstr ""
 
-#: src/olympia/editors/helpers.py:561
+#: src/olympia/editors/helpers.py:634
 msgid "This will reject a version of a public add-on and remove it from the queue."
 msgstr ""
 
-#: src/olympia/editors/helpers.py:564
+#: src/olympia/editors/helpers.py:637
 msgid "This will mark the add-on and its most recent version and files as public. Future versions will go into the sandbox until they are reviewed by an editor."
 msgstr ""
 
-#: src/olympia/editors/helpers.py:637
+#: src/olympia/editors/helpers.py:714
 msgid "add-on"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:940 src/olympia/editors/helpers.py:960
+#: src/olympia/editors/helpers.py:1020 src/olympia/editors/helpers.py:1040
 msgid "Flagged"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:944 src/olympia/editors/helpers.py:963
+#: src/olympia/editors/helpers.py:1024 src/olympia/editors/helpers.py:1043
 msgid "Updates"
 msgstr ""
 
@@ -7631,56 +7495,56 @@ msgstr ""
 msgid "A question about your Theme submission"
 msgstr ""
 
-#: src/olympia/editors/views.py:144
+#: src/olympia/editors/views.py:146
 msgid "New Add-ons (Under 5 days)"
 msgstr ""
 
-#: src/olympia/editors/views.py:145
+#: src/olympia/editors/views.py:147
 msgid "Passable (5 to 10 days)"
 msgstr ""
 
-#: src/olympia/editors/views.py:146
+#: src/olympia/editors/views.py:148
 msgid "Overdue (Over 10 days)"
 msgstr ""
 
-#: src/olympia/editors/views.py:532
+#: src/olympia/editors/views.py:539
 msgid "An unknown error occurred"
 msgstr ""
 
-#: src/olympia/editors/views.py:587
+#: src/olympia/editors/views.py:592
 msgid "Self-reviews are not allowed."
 msgstr ""
 
-#: src/olympia/editors/views.py:609
+#: src/olympia/editors/views.py:613
 msgid "Review successfully processed."
 msgstr ""
 
-#: src/olympia/editors/views.py:807
+#: src/olympia/editors/views.py:812
 msgid "was approved"
 msgstr ""
 
-#: src/olympia/editors/views.py:808
+#: src/olympia/editors/views.py:813
 msgid "given preliminary review"
 msgstr ""
 
-#: src/olympia/editors/views.py:809
+#: src/olympia/editors/views.py:814
 msgid "rejected"
 msgstr ""
 
-#: src/olympia/editors/views.py:810
+#: src/olympia/editors/views.py:815
 msgctxt "editors_review_history_nominated_adminreview"
 msgid "escalated"
 msgstr ""
 
-#: src/olympia/editors/views.py:812
+#: src/olympia/editors/views.py:817
 msgid "needs more information"
 msgstr ""
 
-#: src/olympia/editors/views.py:813
+#: src/olympia/editors/views.py:818
 msgid "needs super review"
 msgstr ""
 
-#: src/olympia/editors/views.py:814
+#: src/olympia/editors/views.py:819
 msgid "commented"
 msgstr ""
 
@@ -7725,28 +7589,28 @@ msgstr ""
 msgid "Unlisted Queues"
 msgstr ""
 
-#: src/olympia/editors/templates/editors/base.html:72 src/olympia/editors/templates/editors/performance.html:6
+#: src/olympia/editors/templates/editors/base.html:74 src/olympia/editors/templates/editors/performance.html:6
 msgid "Performance"
 msgstr ""
 
-#: src/olympia/editors/templates/editors/base.html:75 src/olympia/editors/templates/editors/themes/base.html:19 src/olympia/editors/templates/editors/themes/base.html:38
+#: src/olympia/editors/templates/editors/base.html:77 src/olympia/editors/templates/editors/themes/base.html:19 src/olympia/editors/templates/editors/themes/base.html:38
 msgid "Logs"
 msgstr ""
 
-#: src/olympia/editors/templates/editors/base.html:78 src/olympia/editors/templates/editors/reviewlog.html:4 src/olympia/editors/templates/editors/reviewlog.html:27
+#: src/olympia/editors/templates/editors/base.html:80 src/olympia/editors/templates/editors/reviewlog.html:4 src/olympia/editors/templates/editors/reviewlog.html:27
 msgid "Add-on Review Log"
 msgstr ""
 
-#: src/olympia/editors/templates/editors/base.html:80 src/olympia/editors/templates/editors/eventlog.html:4 src/olympia/editors/templates/editors/eventlog.html:8
+#: src/olympia/editors/templates/editors/base.html:82 src/olympia/editors/templates/editors/eventlog.html:4 src/olympia/editors/templates/editors/eventlog.html:8
 #: src/olympia/editors/templates/editors/eventlog_detail.html:4
 msgid "Moderated Review Log"
 msgstr ""
 
-#: src/olympia/editors/templates/editors/base.html:82 src/olympia/editors/templates/editors/beta_signed_log.html:4 src/olympia/editors/templates/editors/beta_signed_log.html:8
+#: src/olympia/editors/templates/editors/base.html:84 src/olympia/editors/templates/editors/beta_signed_log.html:4 src/olympia/editors/templates/editors/beta_signed_log.html:8
 msgid "Signed Beta Files Log"
 msgstr ""
 
-#: src/olympia/editors/templates/editors/base.html:87 src/olympia/editors/templates/editors/includes/daily-message.html:4
+#: src/olympia/editors/templates/editors/base.html:89 src/olympia/editors/templates/editors/includes/daily-message.html:4
 msgid "Announcement"
 msgstr ""
 
@@ -7967,45 +7831,45 @@ msgstr ""
 msgid "clear search"
 msgstr ""
 
-#: src/olympia/editors/templates/editors/queue.html:72 src/olympia/editors/templates/editors/queue.html:122
+#: src/olympia/editors/templates/editors/queue.html:78 src/olympia/editors/templates/editors/queue.html:128
 msgid "Process Reviews"
 msgstr ""
 
-#: src/olympia/editors/templates/editors/queue.html:80
+#: src/olympia/editors/templates/editors/queue.html:86
 msgid "Moderation actions:"
 msgstr ""
 
-#: src/olympia/editors/templates/editors/queue.html:90
+#: src/olympia/editors/templates/editors/queue.html:96
 #, python-format
 msgid "by %(user)s on %(date)s %(stars)s (%(locale)s)"
 msgstr ""
 
-#: src/olympia/editors/templates/editors/queue.html:106
+#: src/olympia/editors/templates/editors/queue.html:112
 #, python-format
 msgid "<strong>%(reason)s</strong> <span class=\"light\">Flagged by %(user)s on %(date)s</span>"
 msgstr ""
 
-#: src/olympia/editors/templates/editors/queue.html:119
-msgid "All reviews have been moderated.  Good work!"
+#: src/olympia/editors/templates/editors/queue.html:125
+msgid "All reviews have been moderated. Good work!"
 msgstr ""
 
-#: src/olympia/editors/templates/editors/queue.html:161
+#: src/olympia/editors/templates/editors/queue.html:167
 msgid "Version Notes / Notes for Reviewer"
 msgstr ""
 
-#: src/olympia/editors/templates/editors/queue.html:169
+#: src/olympia/editors/templates/editors/queue.html:175
 msgid "There are currently no add-ons of this type to review."
 msgstr ""
 
-#: src/olympia/editors/templates/editors/queue.html:181 src/olympia/editors/templates/editors/themes/queue_list.html:85
+#: src/olympia/editors/templates/editors/queue.html:187 src/olympia/editors/templates/editors/themes/queue_list.html:85
 msgid "Helpful Links:"
 msgstr ""
 
-#: src/olympia/editors/templates/editors/queue.html:182
+#: src/olympia/editors/templates/editors/queue.html:188
 msgid "Add-on Policy"
 msgstr ""
 
-#: src/olympia/editors/templates/editors/queue.html:184
+#: src/olympia/editors/templates/editors/queue.html:190
 msgid "Editors' Guide"
 msgstr ""
 
@@ -8068,10 +7932,7 @@ msgid "<strong>Warning!</strong> Another user was viewing this page before you."
 msgstr ""
 
 #: src/olympia/editors/templates/editors/review.html:237
-msgid ""
-"The whiteboard is the place to exchange information relevant to\n"
-"               this addon (whatever the version), between the developer and the\n"
-"               editor. This is visible and editable by both."
+msgid "The whiteboard is the place to exchange information relevant to this addon (whatever the version), between the developer and the editor. This is visible and editable by both."
 msgstr ""
 
 #: src/olympia/editors/templates/editors/review.html:241
@@ -8345,7 +8206,7 @@ msgstr ""
 msgid "Describe your reason for flagging"
 msgstr ""
 
-#: src/olympia/files/forms.py:88
+#: src/olympia/files/forms.py:90
 msgid "Cannot diff a version against itself"
 msgstr ""
 
@@ -8380,51 +8241,51 @@ msgstr ""
 msgid "There was an error accessing file %s."
 msgstr ""
 
-#: src/olympia/files/utils.py:343
+#: src/olympia/files/utils.py:340
 msgid "Could not parse uploaded file."
 msgstr ""
 
-#: src/olympia/files/utils.py:380
+#: src/olympia/files/utils.py:377
 msgid "Invalid file name in archive: {0}"
 msgstr ""
 
-#: src/olympia/files/utils.py:388
+#: src/olympia/files/utils.py:385
 msgid "File exceeding size limit in archive: {0}"
 msgstr ""
 
-#: src/olympia/files/utils.py:439
+#: src/olympia/files/utils.py:436
 msgid "Invalid archive."
 msgstr ""
 
-#: src/olympia/files/utils.py:529 src/olympia/files/utils.py:532
+#: src/olympia/files/utils.py:526 src/olympia/files/utils.py:529
 msgid "Could not parse the manifest file."
 msgstr ""
 
-#: src/olympia/files/utils.py:551
+#: src/olympia/files/utils.py:548
 msgid "Could not find an add-on ID."
 msgstr ""
 
-#: src/olympia/files/utils.py:554
+#: src/olympia/files/utils.py:551
 msgid "Add-on ID must be 64 characters or less."
 msgstr ""
 
-#: src/olympia/files/utils.py:556
+#: src/olympia/files/utils.py:553
 msgid "Add-on ID doesn't match add-on."
 msgstr ""
 
-#: src/olympia/files/utils.py:564
+#: src/olympia/files/utils.py:561
 msgid "Duplicate add-on ID found."
 msgstr ""
 
-#: src/olympia/files/utils.py:567
+#: src/olympia/files/utils.py:564
 msgid "Version numbers should have fewer than 32 characters."
 msgstr ""
 
-#: src/olympia/files/utils.py:570
+#: src/olympia/files/utils.py:567
 msgid "Version numbers should only contain letters, numbers, and these punctuation characters: +*.-_."
 msgstr ""
 
-#: src/olympia/files/utils.py:587
+#: src/olympia/files/utils.py:584
 msgid "<em:type> doesn't match add-on"
 msgstr ""
 
@@ -8523,6 +8384,10 @@ msgstr ""
 
 #: src/olympia/files/templates/files/viewer.html:134
 msgid "Fetching file."
+msgstr ""
+
+#: src/olympia/legacy_api/views.py:255
+msgid "Not implemented yet."
 msgstr ""
 
 #: src/olympia/lib/constants.py:6
@@ -9181,10 +9046,6 @@ msgstr ""
 msgid "Zimbabwe Dollar"
 msgstr ""
 
-#: src/olympia/lib/video/ffmpeg.py:112 src/olympia/lib/video/totem.py:81
-msgid "Videos must be in WebM."
-msgstr ""
-
 #: src/olympia/pages/templates/pages/about.lhtml:3 src/olympia/pages/templates/pages/about.lhtml:10
 msgid "About Mozilla Add-ons"
 msgstr ""
@@ -9196,7 +9057,7 @@ msgstr ""
 #: src/olympia/pages/templates/pages/about.lhtml:13
 msgid ""
 "addons.mozilla.org, commonly known as \"AMO\", is Mozilla's official site for add-ons to Mozilla software, such as Firefox, Thunderbird, and SeaMonkey. Add-ons let you add new features and change "
-"the way your browser or application works.  Take a look around and explore the thousands of ways to customize the way you do things online."
+"the way your browser or application works. Take a look around and explore the thousands of ways to customize the way you do things online."
 msgstr ""
 
 #: src/olympia/pages/templates/pages/about.lhtml:19
@@ -9541,7 +9402,7 @@ msgstr ""
 msgid ""
 "Yes. It's possible, but some of the functionality provided by these libraries are available through XPCOM, XUL, and JavaScript. In addition, authors should take care if libraries modify primitive "
 "object prototypes (String.prototype, Date.prototype, etc.) and/or define global functions (eg. the $ function). These are prone to cause conflict with other add-ons, in particular if different add-"
-"ons use different versions of libraries and so on. Developers need to be very, very careful with using them.  Mozilla does not offer documentation on using them to build add-ons."
+"ons use different versions of libraries and so on. Developers need to be very, very careful with using them. Mozilla does not offer documentation on using them to build add-ons."
 msgstr ""
 
 #: src/olympia/pages/templates/pages/dev_faq.html:165
@@ -9655,8 +9516,8 @@ msgstr ""
 #, python-format
 msgid ""
 "Yes. Many developers choose to host their own add-ons. Choosing to host your add-on on <a href=\"%(amo_url)s\">Mozilla's add-on site</a>, though, allows for much greater exposure to your add-on due "
-"to the large volume of visitors to the site.  <a href=\"%(md_url)s\">mozdev.org</a> offers free project hosting for Mozilla applications and extensions providing developers with tools to help "
-"manage source code, version control, bug tracking and documentation."
+"to the large volume of visitors to the site. <a href=\"%(md_url)s\">mozdev.org</a> offers free project hosting for Mozilla applications and extensions providing developers with tools to help manage "
+"source code, version control, bug tracking and documentation."
 msgstr ""
 
 #: src/olympia/pages/templates/pages/dev_faq.html:277
@@ -9704,7 +9565,7 @@ msgstr ""
 #: src/olympia/pages/templates/pages/dev_faq.html:314
 #, python-format
 msgid ""
-"Yes. Mozilla's <a href=\"%(p_url)s\">Add-on Policy</a> describes what is an acceptable submission. This policy is subject to change without notice.  In addition, the AMO editorial team uses the <a "
+"Yes. Mozilla's <a href=\"%(p_url)s\">Add-on Policy</a> describes what is an acceptable submission. This policy is subject to change without notice. In addition, the AMO editorial team uses the <a "
 "href=\"%(g_url)s\">Editors Reviewing Guide</a> to ensure that your add-on meets specific guidelines for functionality and security."
 msgstr ""
 
@@ -9821,7 +9682,7 @@ msgstr ""
 #: src/olympia/pages/templates/pages/dev_faq.html:434
 #, python-format
 msgid ""
-"This is why it's very important to read the <a href=\"%(g_url)s\">Editors Reviewing Guide</a> to ensure that your add-on is setup as expected.  It's also a good idea to read the blog post, <a href="
+"This is why it's very important to read the <a href=\"%(g_url)s\">Editors Reviewing Guide</a> to ensure that your add-on is setup as expected. It's also a good idea to read the blog post, <a href="
 "\"%(blog_url)s\">Successfully Getting your Add-on Reviewed</a> which provides excellent insight into ensuring a smooth review of your add-on."
 msgstr ""
 
@@ -9928,7 +9789,7 @@ msgstr ""
 
 #: src/olympia/pages/templates/pages/dev_faq.html:572
 msgid ""
-"Free Software Foundation provides short summaries of the key open source licenses, including whether the license qualifies as a free software license or a copyleft license.  Also includes a "
+"Free Software Foundation provides short summaries of the key open source licenses, including whether the license qualifies as a free software license or a copyleft license. Also includes a "
 "discussion of what constitutes a free software license or a copyleft license (e.g., a Copyleft license is a general method for making a program or other work free, and requiring all modified and "
 "extended versions of the program to be free as well.)"
 msgstr ""
@@ -10106,19 +9967,13 @@ msgid "Add-on Gallery"
 msgstr ""
 
 #: src/olympia/pages/templates/pages/faq.html:171
-msgid ""
-"How do I choose between add-ons that seem to do the same\n"
-"    thing?"
+msgid "How do I choose between add-ons that seem to do the same thing?"
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:173
+#: src/olympia/pages/templates/pages/faq.html:172
 msgid ""
-"There are often several add-ons that have similar features. To\n"
-"    figure out which is right for you, read the entire description of the\n"
-"    add-on and view its screenshots. If there are still several in the running,\n"
-"    read through the add-on's ratings, user reviews, and statistics to see\n"
-"    which is most liked by other users. Remember that you can also just try\n"
-"    out both and see which you like better."
+"There are often several add-ons that have similar features. To figure out which is right for you, read the entire description of the add-on and view its screenshots. If there are still several in "
+"the running, read through the add-on's ratings, user reviews, and statistics to see which is most liked by other users. Remember that you can also just try out both and see which you like better."
 msgstr ""
 
 #: src/olympia/pages/templates/pages/faq.html:180
@@ -10159,80 +10014,67 @@ msgid "How much do add-ons cost to purchase?"
 msgstr ""
 
 #: src/olympia/pages/templates/pages/faq.html:207
-msgid ""
-"Add-ons hosted in our gallery are free unless clearly marked\n"
-"    otherwise."
+msgid "Add-ons hosted in our gallery are free unless clearly marked otherwise."
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:210
+#: src/olympia/pages/templates/pages/faq.html:209
 msgid "What does it mean when an add-on asks for contributions?"
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:211
+#: src/olympia/pages/templates/pages/faq.html:210
 msgid ""
-"Some add-on authors request users who enjoy an add-on to\n"
-"        contribute to its development by making a monetary contribution. These\n"
-"        contributions go directly to the developer unless a third party is\n"
-"        indicated, such as the non-profit Mozilla Foundation."
+"Some add-on authors request users who enjoy an add-on to contribute to its development by making a monetary contribution. These contributions go directly to the developer unless a third party is "
+"indicated, such as the non-profit Mozilla Foundation."
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:216
+#: src/olympia/pages/templates/pages/faq.html:215
 msgid "What are beta add-ons?"
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:218
+#: src/olympia/pages/templates/pages/faq.html:217
 msgid ""
-"Beta add-ons are unreviewed versions which represent the\n"
-"        latest work of an add-on author. While different authors have different\n"
-"        standards for beta code quality, you should assume that these add-ons\n"
-"        are less stable than the general add-on releases."
+"Beta add-ons are unreviewed versions which represent the latest work of an add-on author. While different authors have different standards for beta code quality, you should assume that these add-"
+"ons are less stable than the general add-on releases."
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:222
+#: src/olympia/pages/templates/pages/faq.html:221
 msgid ""
 "Please note that when you install an add-on from the \"Beta Version\" section of an add-on's listing, you will continue to receive updates for that add-on as they become available. Like the initial "
 "version you installed, all beta releases are unreviewed by Mozilla and may harm your computer."
 msgstr ""
 
+#: src/olympia/pages/templates/pages/faq.html:228
+msgid "What does it mean when an add-on is flagged as slow?"
+msgstr ""
+
 #: src/olympia/pages/templates/pages/faq.html:229
-msgid ""
-"What does it mean when an add-on is flagged as\n"
-"    slow?"
+msgid "Most add-ons load code and resources at the same time Firefox is starting up. In most cases the impact in start-up time is minimal, but some add-ons can cause a noticeable slowdown."
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:231
-msgid ""
-"Most add-ons load code and resources at the same time Firefox\n"
-"        is starting up. In most cases the impact in start-up time is minimal,\n"
-"        but some add-ons can cause a noticeable slowdown."
-msgstr ""
-
-#: src/olympia/pages/templates/pages/faq.html:236
+#: src/olympia/pages/templates/pages/faq.html:234
 msgid "How do I report an inappropriate or spam user review?"
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:237
+#: src/olympia/pages/templates/pages/faq.html:235
 msgid ""
-"To report a user review of an add-on, log in with your account\n"
-"    and visit the add-on's reviews page. Find the review you wish to report,\n"
-"    click \"Report this review\" and select a reason. Our editorial team will\n"
-"    investigate the review and take appropriate action."
+"To report a user review of an add-on, log in with your account and visit the add-on's reviews page. Find the review you wish to report, click \"Report this review\" and select a reason. Our "
+"editorial team will investigate the review and take appropriate action."
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:242
+#: src/olympia/pages/templates/pages/faq.html:240
 msgid "How do I report a bug or contact the Mozilla Add-ons team?"
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:243
+#: src/olympia/pages/templates/pages/faq.html:241
 #, python-format
 msgid "Please visit our <a href=\"%(contact_url)s\">Contact page</a>."
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:246
+#: src/olympia/pages/templates/pages/faq.html:244
 msgid "What is a Source Code License?"
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:247
+#: src/olympia/pages/templates/pages/faq.html:245
 #, python-format
 msgid ""
 "The source code used to create an add-on is an exclusive copyright of the add-on author, unless otherwise declared in a source code license. Many add-ons on this site have <a href=\"%(url)s\" lang="
@@ -10240,60 +10082,60 @@ msgid ""
 "the GPL or BSD licenses instead of making up their own."
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:256
+#: src/olympia/pages/templates/pages/faq.html:254
 #, python-format
 msgid "Firefox and other Mozilla software are <a href=\"%(url)s\">open source</a>."
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:264
+#: src/olympia/pages/templates/pages/faq.html:262
 msgid "Collections and Favorites"
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:267
+#: src/olympia/pages/templates/pages/faq.html:265
 msgid "What is a collection?"
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:268
+#: src/olympia/pages/templates/pages/faq.html:266
 msgid "Collections are groups of related add-ons created by users to share."
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:270
+#: src/olympia/pages/templates/pages/faq.html:268
 msgid "What is the My Favorites collection?"
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:271
+#: src/olympia/pages/templates/pages/faq.html:269
 msgid "Favorite add-ons are add-ons that you have bookmarked to easily get back to later. You can add an add-on to your favorites collection by clicking \"Add to favorites\" on its details page."
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:275 src/olympia/templates/menu_links.html:13 src/olympia/templates/impala/header_title.html:17
+#: src/olympia/pages/templates/pages/faq.html:273 src/olympia/templates/menu_links.html:13 src/olympia/templates/impala/header_title.html:17
 msgid "Mobile Add-ons"
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:278
+#: src/olympia/pages/templates/pages/faq.html:276
 msgid "What are mobile add-ons?"
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:279
+#: src/olympia/pages/templates/pages/faq.html:277
 #, python-format
 msgid ""
 "Mobile add-ons work with <a href=\"%(mobile_url)s\">Firefox for Mobile</a> and add or modify functionality just like desktop add-ons. You can find add-ons that work with Firefox for Mobile in our "
 "<a href=\"%(gallery_url)s\">gallery</a>."
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:288
+#: src/olympia/pages/templates/pages/faq.html:286
 msgid "Developer Topics"
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:289
+#: src/olympia/pages/templates/pages/faq.html:287
 #, python-format
 msgid "Please see our <a href=\"%(faq_url)s\">Developer FAQ</a> and <a href=\"%(hub_url)s\">Developer Hub</a> for answers to add-on developer-related questions."
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:294
+#: src/olympia/pages/templates/pages/faq.html:292
 msgid "Still have questions?"
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:295
+#: src/olympia/pages/templates/pages/faq.html:293
 #, python-format
 msgid "For general Firefox support, visit our <a href=\"%(sumo_url)s\">support website</a>. For general add-on and website questions, visit our <a href=\"%(forum_url)s\">forum</a>."
 msgstr ""
@@ -10431,7 +10273,7 @@ msgstr ""
 
 #: src/olympia/pages/templates/pages/sunbird.html:29
 msgid ""
-"Development on the Sunbird project has halted and its final release was on March 30, 2010.  We've been proud to host Sunbird add-ons on this site but as the project is no longer maintained we have "
+"Development on the Sunbird project has halted and its final release was on March 30, 2010. We've been proud to host Sunbird add-ons on this site but as the project is no longer maintained we have "
 "disabled our support for the add-ons."
 msgstr ""
 
@@ -10509,7 +10351,7 @@ msgstr ""
 #, python-format
 msgid ""
 "<h2>Keep these tips in mind:</h2> <ul> <li> Write like you're telling a friend about your experience with the add-on. Give specifics and helpful details, such as what features you liked and/or "
-"disliked, how easy to use it is, and any disadvantages it has.  Avoid generic language such as calling it \"Great\" or \"Bad\" unless you can give reasons why you believe this is so. </li> <li> "
+"disliked, how easy to use it is, and any disadvantages it has. Avoid generic language such as calling it \"Great\" or \"Bad\" unless you can give reasons why you believe this is so. </li> <li> "
 "Please do not post bug reports in reviews. We do not make your email address available to add-on developers and they may need to contact you to help resolve your issue. See the <a href=\"%(support)s"
 "\">support section</a> to find out where to get assistance for this add-on. </li> <li>Please keep reviews clean, avoid the use of improper language and do not post any personal information. </li> </"
 "ul> <p>Please read the <a href=\"%(guide)s\" target=\"_blank\">Review Guidelines</a> for more detail about user add-on reviews.</p>"
@@ -10745,16 +10587,16 @@ msgstr ""
 
 #. L10n: {0} is an application, such as Firefox. This means "any version of
 #. Firefox."
-#: src/olympia/search/views.py:554
+#: src/olympia/search/views.py:547
 msgid "Any {0}"
 msgstr ""
 
 #. L10n: "All Systems" means show everything regardless of platform.
-#: src/olympia/search/views.py:589
+#: src/olympia/search/views.py:582
 msgid "All Systems"
 msgstr ""
 
-#: src/olympia/search/views.py:600
+#: src/olympia/search/views.py:593
 msgid "All Tags"
 msgstr ""
 
@@ -10928,31 +10770,31 @@ msgstr ""
 msgid "Share this Collection"
 msgstr ""
 
-#: src/olympia/signing/views.py:30 src/olympia/templates/base.html:75 src/olympia/templates/impala/base.html:115
+#: src/olympia/signing/views.py:33 src/olympia/templates/base.html:71 src/olympia/templates/impala/base.html:112
 msgid "Some features are temporarily disabled while we perform website maintenance. We'll be back to full capacity shortly."
 msgstr ""
 
-#: src/olympia/signing/views.py:53
+#: src/olympia/signing/views.py:56
 msgid "Could not find add-on with id \"{}\"."
 msgstr ""
 
-#: src/olympia/signing/views.py:67
+#: src/olympia/signing/views.py:70
 msgid "You do not own this addon."
 msgstr ""
 
-#: src/olympia/signing/views.py:82
+#: src/olympia/signing/views.py:87
 msgid "Missing \"upload\" key in multipart file data."
 msgstr ""
 
-#: src/olympia/signing/views.py:96
+#: src/olympia/signing/views.py:101
 msgid "Version does not match the manifest file."
 msgstr ""
 
-#: src/olympia/signing/views.py:100
+#: src/olympia/signing/views.py:105
 msgid "Version already exists."
 msgstr ""
 
-#: src/olympia/signing/views.py:136
+#: src/olympia/signing/views.py:141
 msgid "No uploaded file for that addon and version."
 msgstr ""
 
@@ -11065,89 +10907,89 @@ msgstr ""
 msgid "Statistics Dashboard :: Add-ons for {0}"
 msgstr ""
 
-#: src/olympia/stats/templates/stats/stats.html:30
-msgid "Controls:"
-msgstr ""
-
-#: src/olympia/stats/templates/stats/stats.html:33
-msgid "reset zoom"
-msgstr ""
-
-#: src/olympia/stats/templates/stats/stats.html:40
-msgid "Group by:"
-msgstr ""
-
-#: src/olympia/stats/templates/stats/stats.html:42
-msgid "day"
-msgstr ""
-
-#: src/olympia/stats/templates/stats/stats.html:45
-msgid "week"
-msgstr ""
-
-#: src/olympia/stats/templates/stats/stats.html:48
-msgid "month"
-msgstr ""
-
-#: src/olympia/stats/templates/stats/stats.html:54
-msgid "For last:"
-msgstr ""
-
-#: src/olympia/stats/templates/stats/stats.html:57
-msgid "7 days"
-msgstr ""
-
-#: src/olympia/stats/templates/stats/stats.html:60
-msgid "30 days"
-msgstr ""
-
-#: src/olympia/stats/templates/stats/stats.html:63
-msgid "90 days"
-msgstr ""
-
-#: src/olympia/stats/templates/stats/stats.html:66
-msgid "365 days"
-msgstr ""
-
-#: src/olympia/stats/templates/stats/stats.html:69
-msgid "Custom..."
-msgstr ""
-
 #. {0} is an add-on name
-#: src/olympia/stats/templates/stats/stats.html:88 src/olympia/stats/templates/stats/stats.html:91
+#: src/olympia/stats/templates/stats/stats.html:44 src/olympia/stats/templates/stats/stats.html:47
 msgid "Statistics for {0}"
 msgstr ""
 
-#: src/olympia/stats/templates/stats/stats.html:94
+#: src/olympia/stats/templates/stats/stats.html:50
 msgid "Statistics Dashboard"
 msgstr ""
 
-#: src/olympia/stats/templates/stats/stats.html:104
+#: src/olympia/stats/templates/stats/stats.html:57
+msgid "Controls:"
+msgstr ""
+
+#: src/olympia/stats/templates/stats/stats.html:60
+msgid "reset zoom"
+msgstr ""
+
+#: src/olympia/stats/templates/stats/stats.html:67
+msgid "Group by:"
+msgstr ""
+
+#: src/olympia/stats/templates/stats/stats.html:69
+msgid "day"
+msgstr ""
+
+#: src/olympia/stats/templates/stats/stats.html:72
+msgid "week"
+msgstr ""
+
+#: src/olympia/stats/templates/stats/stats.html:75
+msgid "month"
+msgstr ""
+
+#: src/olympia/stats/templates/stats/stats.html:81
+msgid "For last:"
+msgstr ""
+
+#: src/olympia/stats/templates/stats/stats.html:84
+msgid "7 days"
+msgstr ""
+
+#: src/olympia/stats/templates/stats/stats.html:87
+msgid "30 days"
+msgstr ""
+
+#: src/olympia/stats/templates/stats/stats.html:90
+msgid "90 days"
+msgstr ""
+
+#: src/olympia/stats/templates/stats/stats.html:93
+msgid "365 days"
+msgstr ""
+
+#: src/olympia/stats/templates/stats/stats.html:96
+msgid "Custom..."
+msgstr ""
+
+#: src/olympia/stats/templates/stats/stats.html:106
 msgid "Statistics processing is currently disabled, so recent data is unavailable. The statistics are still being collected and this page will be updated soon with the missing data."
 msgstr ""
 
-#: src/olympia/stats/templates/stats/stats.html:110
+#: src/olympia/stats/templates/stats/stats.html:112
 msgid "Loading the latest data&hellip;"
 msgstr ""
 
-#: src/olympia/stats/templates/stats/stats.html:142 src/olympia/stats/templates/stats/reports/overview.html:25 src/olympia/stats/templates/stats/reports/overview.html:37
+#: src/olympia/stats/templates/stats/stats.html:144 src/olympia/stats/templates/stats/reports/overview.html:25 src/olympia/stats/templates/stats/reports/overview.html:37
 #: src/olympia/stats/templates/stats/reports/overview.html:49
 msgid "No data available."
 msgstr ""
 
-#: src/olympia/stats/templates/stats/stats.html:177
+#: src/olympia/stats/templates/stats/stats.html:179
 msgid "This dashboard is currently <b>public</b>."
 msgstr ""
 
-#: src/olympia/stats/templates/stats/stats.html:179
+#: src/olympia/stats/templates/stats/stats.html:181
 msgid "Contribution stats are currently <b>private</b>."
 msgstr ""
 
-#: src/olympia/stats/templates/stats/stats.html:182
+#: src/olympia/stats/templates/stats/stats.html:184
 msgid "This dashboard is currently <b>private</b>."
 msgstr ""
 
-#: src/olympia/stats/templates/stats/stats.html:185
+#: src/olympia/stats/templates/stats/stats.html:187
 msgid "Change settings."
 msgstr ""
 
@@ -11299,15 +11141,6 @@ msgstr ""
 msgid "Application versions by Date"
 msgstr ""
 
-#: src/olympia/tags/templates/tags/top_cloud.html:4
-msgid "Top {0} Tags"
-msgstr ""
-
-#. {0} is the current application name
-#: src/olympia/tags/templates/tags/top_cloud.html:14
-msgid "{0} Top Tags"
-msgstr ""
-
 #: src/olympia/templates/amo_footer.html:6 src/olympia/templates/includes/lang_switcher.html:2
 msgid "Other languages"
 msgstr ""
@@ -11316,11 +11149,11 @@ msgstr ""
 msgid "Mozilla Add-ons"
 msgstr ""
 
-#: src/olympia/templates/base.html:91 src/olympia/templates/impala/base.html:81
+#: src/olympia/templates/base.html:89 src/olympia/templates/impala/base.html:78
 msgid "Find add-ons for other applications"
 msgstr ""
 
-#: src/olympia/templates/base.html:92 src/olympia/templates/impala/base.html:81
+#: src/olympia/templates/base.html:90 src/olympia/templates/impala/base.html:78
 msgid "Other Applications"
 msgstr ""
 
@@ -11345,7 +11178,7 @@ msgid "View Mobile Site"
 msgstr ""
 
 #: src/olympia/templates/copyright.html:7
-msgid "Site Status "
+msgid "Site Status"
 msgstr ""
 
 #: src/olympia/templates/footer.html:3
@@ -11445,35 +11278,35 @@ msgstr ""
 msgid "<a href=\"%(reg)s\">Register</a> or <a href=\"%(login)s\">Log in</a>"
 msgstr ""
 
-#: src/olympia/templates/impala/base.html:126
+#: src/olympia/templates/impala/base.html:123
 #, python-format
 msgid "To try the thousands of add-ons available here, download <a href=\"%(url)s\">Mozilla Firefox</a>, a fast, free way to surf the Web!"
 msgstr ""
 
-#: src/olympia/templates/impala/base.html:138
+#: src/olympia/templates/impala/base.html:135
 #, python-format
 msgid "Add-ons is switching to Firefox Accounts for login. <a href=\"%(url)s\" class=\"fxa-login\">Sign in now to transfer your account.</a>"
 msgstr ""
 
 #. {0} is an application, such as Firefox.
-#: src/olympia/templates/impala/base.html:148
+#: src/olympia/templates/impala/base.html:145
 msgid "Welcome to {0} Add-ons."
 msgstr ""
 
-#: src/olympia/templates/impala/base.html:151
+#: src/olympia/templates/impala/base.html:148
 msgid "Choose from thousands of extra features and styles to make Firefox your own."
 msgstr ""
 
-#: src/olympia/templates/impala/base.html:156
+#: src/olympia/templates/impala/base.html:153
 #, python-format
 msgid "Add extra features and styles to make %(app)s your own."
 msgstr ""
 
-#: src/olympia/templates/impala/base.html:164
+#: src/olympia/templates/impala/base.html:161
 msgid "On the go?"
 msgstr ""
 
-#: src/olympia/templates/impala/base.html:166
+#: src/olympia/templates/impala/base.html:163
 msgid "Check out our <a class=\"mobile-link\" href=\"#\">Mobile Add-ons site</a>."
 msgstr ""
 
@@ -11697,19 +11530,19 @@ msgstr ""
 
 #. L10n: {id} will be something like "13ad6a", just a random number
 #. to differentiate this user from other anonymous users.
-#: src/olympia/users/models.py:353
+#: src/olympia/users/models.py:362
 msgid "Anonymous user {id}"
 msgstr ""
 
-#: src/olympia/users/models.py:410
+#: src/olympia/users/models.py:419
 msgid "Your account has been restricted"
 msgstr ""
 
-#: src/olympia/users/models.py:480
+#: src/olympia/users/models.py:489
 msgid "Please confirm your email address"
 msgstr ""
 
-#: src/olympia/users/models.py:506
+#: src/olympia/users/models.py:515
 msgid "My Mobile Add-ons"
 msgstr ""
 
@@ -11986,7 +11819,7 @@ msgstr ""
 
 #: src/olympia/users/templates/users/edit.html:70
 #, python-format
-msgid "Change your password.  If you forgot your password, you can <a href=\"%(reset_url)s\">use the reset form</a>."
+msgid "Change your password. If you forgot your password, you can <a href=\"%(reset_url)s\">use the reset form</a>."
 msgstr ""
 
 #: src/olympia/users/templates/users/edit.html:76
@@ -12006,7 +11839,7 @@ msgid "Profile"
 msgstr ""
 
 #: src/olympia/users/templates/users/edit.html:100
-msgid "Give us a bit more information about yourself.  All these fields are optional, but they'll help other users get to know you better."
+msgid "Give us a bit more information about yourself. All these fields are optional, but they'll help other users get to know you better."
 msgstr ""
 
 #: src/olympia/users/templates/users/edit.html:124
@@ -12222,7 +12055,7 @@ msgid "Confirm password"
 msgstr ""
 
 #: src/olympia/users/templates/users/pwreset_confirm.html:47
-msgid "The password reset link was invalid, possibly because it has already been used.  Please request a new password reset."
+msgid "The password reset link was invalid, possibly because it has already been used. Please request a new password reset."
 msgstr ""
 
 #: src/olympia/users/templates/users/pwreset_request.html:15
@@ -12408,7 +12241,7 @@ msgstr ""
 
 #: src/olympia/users/templates/users/unsubscribe.html:30
 #, python-format
-msgid "Unfortunately, we weren't able to unsubscribe you.  The link you clicked is invalid. However, you can unsubscribe still unsubscribe on your <a href=\"%(edit_url)s\">edit profile page</a>."
+msgid "Unfortunately, we weren't able to unsubscribe you. The link you clicked is invalid. However, you can unsubscribe still unsubscribe on your <a href=\"%(edit_url)s\">edit profile page</a>."
 msgstr ""
 
 #: src/olympia/users/templates/users/vcard.html:2
@@ -12462,15 +12295,15 @@ msgstr ""
 msgid "Version History with Changelogs"
 msgstr ""
 
-#: src/olympia/versions/models.py:314
+#: src/olympia/versions/models.py:313
 msgid "Add-on uses binary components."
 msgstr ""
 
-#: src/olympia/versions/models.py:317
+#: src/olympia/versions/models.py:316
 msgid "Add-on has opted into strict compatibility checking."
 msgstr ""
 
-#: src/olympia/versions/models.py:715
+#: src/olympia/versions/models.py:711
 msgid "{app} {min} and later"
 msgstr ""
 
@@ -12545,4 +12378,8 @@ msgstr ""
 
 #: src/olympia/zadmin/forms.py:105
 msgid "Log emails instead of sending"
+msgstr ""
+
+#: src/olympia/zadmin/forms.py:215
+msgid "Deleted versions can`t be changed."
 msgstr ""

--- a/locale/ht/LC_MESSAGES/djangojs.po
+++ b/locale/ht/LC_MESSAGES/djangojs.po
@@ -1,1216 +1,1236 @@
-
 #, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2016-02-24 21:23+0000\n"
+"POT-Creation-Date: 2016-04-18 15:47+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
+"Language: \n"
 "MIME-Version: 1.0\n"
-"Content-Type: text/plain; charset=utf-8\n"
+"Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Generated-By: Babel 2.2.0\n"
 
-#: static/js/common/ratingwidget.js:31
+#: static/js/common-all.js:1426 static/js/impala-all.js:1511 static/js/zamboni/discovery-all.js:12598 static/js/zamboni/init.js:28 static/js/zamboni/mobile-all.js:14945
+msgid "This feature is temporarily disabled while we perform website maintenance. Please check back a little later."
+msgstr ""
+
+#. L10n: {0} is an app name like Firefox.
+#: static/js/common-all.js:1837 static/js/impala-all.js:1922 static/js/zamboni/buttons.js:73 static/js/zamboni/discovery-all.js:13108
+msgid "Accept and Install"
+msgstr ""
+
+#: static/js/common-all.js:1837 static/js/impala-all.js:1922 static/js/zamboni/buttons.js:73 static/js/zamboni/discovery-all.js:13108
+msgid "Add to {0}"
+msgstr ""
+
+#: static/js/common-all.js:1842 static/js/impala-all.js:1927 static/js/zamboni/buttons.js:78 static/js/zamboni/discovery-all.js:13113
+msgid "Download Now"
+msgstr ""
+
+#: static/js/common-all.js:1883 static/js/impala-all.js:1968 static/js/zamboni/buttons.js:119 static/js/zamboni/discovery-all.js:13154
+msgid "Add-on has not been updated to support default-to-compatible."
+msgstr ""
+
+#: static/js/common-all.js:1888 static/js/impala-all.js:1973 static/js/zamboni/buttons.js:124 static/js/zamboni/discovery-all.js:13159
+msgid "You need to be using Firefox 10.0 or higher."
+msgstr ""
+
+#: static/js/common-all.js:1900 static/js/impala-all.js:1985 static/js/zamboni/buttons.js:136 static/js/zamboni/discovery-all.js:13171
+msgid "Mozilla has marked this version as incompatible with your Firefox version."
+msgstr ""
+
+#. L10n: {0} is an platform like Windows or Linux.
+#: static/js/common-all.js:1981 static/js/impala-all.js:2066 static/js/zamboni/buttons.js:217 static/js/zamboni/discovery-all.js:13252
+msgid "Install for {0} anyway"
+msgstr ""
+
+#: static/js/common-all.js:1981 static/js/impala-all.js:2066 static/js/zamboni/buttons.js:217 static/js/zamboni/discovery-all.js:13252
+msgid "Download for {0} anyway"
+msgstr ""
+
+#: static/js/common-all.js:2038 static/js/impala-all.js:2123 static/js/zamboni/buttons.js:274 static/js/zamboni/discovery-all.js:13309
+msgid "Not available for your platform"
+msgstr ""
+
+#. L10n: {0} is an app name, {1} is the app version.
+#: static/js/common-all.js:2049 static/js/common-all.js:2086 static/js/impala-all.js:2134 static/js/impala-all.js:2171 static/js/zamboni/buttons.js:286 static/js/zamboni/buttons.js:324
+#: static/js/zamboni/discovery-all.js:13320 static/js/zamboni/discovery-all.js:13357
+msgid "Not available for {0} {1}"
+msgstr ""
+
+#: static/js/common-all.js:2112 static/js/impala-all.js:2197 static/js/zamboni/buttons.js:351 static/js/zamboni/discovery-all.js:13383
+msgid "Works with {app} {min} - {max}"
+msgstr ""
+
+#: static/js/common-all.js:2114 static/js/impala-all.js:2199 static/js/zamboni/buttons.js:353 static/js/zamboni/discovery-all.js:13385
+msgid "View other versions"
+msgstr ""
+
+#: static/js/common-all.js:2162 static/js/impala-all.js:2247 static/js/zamboni/buttons.js:401 static/js/zamboni/discovery-all.js:13433
+msgid "Only with Firefox — Get Firefox Now!"
+msgstr ""
+
+#: static/js/common-all.js:2278 static/js/impala-all.js:2363 static/js/zamboni/buttons.js:517 static/js/zamboni/discovery-all.js:13549 static/js/zamboni/mobile-all.js:15177
+#: static/js/zamboni/mobile/buttons.js:43
+msgid "Sorry, you need a Mozilla-based browser (such as Firefox) to install a search plugin."
+msgstr ""
+
+#: static/js/common-all.js:9088 static/js/impala-all.js:9649 static/js/zamboni/global.js:410
+msgid "Loading..."
+msgstr ""
+
+#. L10n: {0} is the number of characters left.
+#: static/js/common-all.js:9152 static/js/impala-all.js:9713 static/js/zamboni/global.js:474
+msgid "<b>{0}</b> character left."
+msgid_plural "<b>{0}</b> characters left."
+msgstr[0] ""
+msgstr[1] ""
+
+#: static/js/common-all.js:9589 static/js/common-min.js:6 static/js/impala-all.js:10052 static/js/impala-min.js:6 static/js/common/ratingwidget.js:31 static/js/zamboni/mobile-all.js:16123
+#: static/js/zamboni/mobile-min.js:6
 msgid "{0} star"
 msgid_plural "{0} stars"
 msgstr[0] ""
 msgstr[1] ""
 
-#: static/js/common/upload-addon.js:41 static/js/common/upload-image.js:128
+#: static/js/common-all.js:9676 static/js/common-min.js:6 static/js/impala-all.js:10139 static/js/impala-min.js:6 static/js/zamboni/l10n.js:45
+msgid "Remove this localization"
+msgstr ""
+
+#: static/js/common-all.js:10193 static/js/common-min.js:6 static/js/impala-all.js:10674 static/js/impala-min.js:6 static/js/zamboni/discovery-all.js:13678
+msgid "close"
+msgstr ""
+
+#: static/js/common-all.js:10860 static/js/common-min.js:6 static/js/impala-all.js:11481 static/js/impala-min.js:6 static/js/impala/reviews.js:23 static/js/zamboni/reviews.js:18
+msgid "Flagged for review"
+msgstr ""
+
+#: static/js/common-all.js:10876 static/js/common-min.js:6 static/js/impala-all.js:11498 static/js/impala-min.js:6 static/js/impala/reviews.js:40 static/js/zamboni/reviews.js:34
+msgid "Your input is required"
+msgstr ""
+
+#: static/js/common-all.js:10945 static/js/common-min.js:6 static/js/impala-all.js:11610 static/js/impala-min.js:7 static/js/impala/reviews.js:152 static/js/zamboni/reviews.js:103
+msgid "Marked for deletion"
+msgstr ""
+
+#: static/js/common-all.js:11573 static/js/common-min.js:7 static/js/impala-all.js:13809 static/js/impala-min.js:8 static/js/zamboni/collections.js:229
+msgid "Adding to Favorites&hellip;"
+msgstr ""
+
+#: static/js/common-all.js:11576 static/js/common-min.js:7 static/js/impala-all.js:13812 static/js/impala-min.js:8 static/js/zamboni/collections.js:232
+msgid "Removing Favorite&hellip;"
+msgstr ""
+
+#: static/js/common-all.js:11579 static/js/common-min.js:7 static/js/impala-all.js:13815 static/js/impala-min.js:8 static/js/zamboni/collections.js:235
+msgid "Add to Favorites"
+msgstr ""
+
+#: static/js/common-all.js:11582 static/js/common-min.js:7 static/js/impala-all.js:13818 static/js/impala-min.js:8 static/js/zamboni/collections.js:238
+msgid "Remove from Favorites"
+msgstr ""
+
+#: static/js/common-all.js:11647 static/js/common-min.js:7 static/js/impala-all.js:13883 static/js/impala-min.js:8 static/js/zamboni/collections.js:303
+msgid "Pending"
+msgstr ""
+
+#: static/js/common-all.js:11648 static/js/common-min.js:7 static/js/impala-all.js:13884 static/js/impala-min.js:8 static/js/zamboni/collections.js:304
+msgid "Add a comment"
+msgstr ""
+
+#: static/js/common-all.js:11648 static/js/common-min.js:7 static/js/impala-all.js:13884 static/js/impala-min.js:8 static/js/zamboni/collections.js:304
+msgid "Comment"
+msgstr ""
+
+#: static/js/common-all.js:11649 static/js/common-min.js:7 static/js/impala-all.js:13885 static/js/impala-min.js:8 static/js/zamboni/collections.js:305
+msgid "Remove this add-on from the collection"
+msgstr ""
+
+#: static/js/common-all.js:11649 static/js/common-all.js:11678 static/js/common-min.js:7 static/js/impala-all.js:13885 static/js/impala-all.js:13914 static/js/impala-min.js:8
+#: static/js/zamboni/collections.js:305 static/js/zamboni/collections.js:334
+msgid "Remove"
+msgstr ""
+
+#: static/js/common-all.js:11678 static/js/common-min.js:7 static/js/impala-all.js:13914 static/js/impala-min.js:8 static/js/zamboni/collections.js:334
+msgid "Remove this user as a contributor"
+msgstr ""
+
+#: static/js/common-all.js:11690 static/js/common-min.js:7 static/js/impala-all.js:13926 static/js/impala-min.js:8 static/js/zamboni/collections.js:346
+msgid "An email address is required."
+msgstr ""
+
+#: static/js/common-all.js:11708 static/js/common-min.js:7 static/js/impala-all.js:13944 static/js/impala-min.js:8 static/js/zamboni/collections.js:364
+msgid "You cannot add yourself as a contributor."
+msgstr ""
+
+#: static/js/common-all.js:11710 static/js/common-min.js:7 static/js/impala-all.js:13946 static/js/impala-min.js:8 static/js/zamboni/collections.js:366
+msgid "You have already added that user."
+msgstr ""
+
+#: static/js/common-all.js:11917 static/js/common-min.js:7 static/js/impala-all.js:14153 static/js/impala-min.js:8 static/js/zamboni/collections.js:573
+msgid "Add to favorites"
+msgstr ""
+
+#: static/js/common-all.js:11921 static/js/common-min.js:7 static/js/impala-all.js:14157 static/js/impala-min.js:8 static/js/zamboni/collections.js:577
+msgid "Remove from favorites"
+msgstr ""
+
+#: static/js/common-all.js:11939 static/js/common-min.js:7 static/js/impala-all.js:14175 static/js/impala-all.js:14233 static/js/impala-min.js:8 static/js/impala/collections.js:10
+#: static/js/zamboni/collections.js:595
+msgid "Follow this Collection"
+msgstr ""
+
+#: static/js/common-all.js:11948 static/js/common-min.js:7 static/js/impala-all.js:14184 static/js/impala-min.js:8 static/js/zamboni/collections.js:604
+msgid "Stop following"
+msgstr ""
+
+#: static/js/common-all.js:12096 static/js/common-min.js:7 static/js/zamboni/password-strength.js:20
+msgid "Password strength:"
+msgstr ""
+
+#: static/js/common-all.js:12102 static/js/common-min.js:7 static/js/zamboni/password-strength.js:26
+msgid "At least {0} character left."
+msgid_plural "At least {0} characters left."
+msgstr[0] ""
+msgstr[1] ""
+
+#: static/js/common-all.js:12286 static/js/common-min.js:7 static/js/impala-all.js:14632 static/js/impala-min.js:8 static/js/impala/suggestions.js:39
+msgid "Search themes for <b>{0}</b>"
+msgstr ""
+
+#: static/js/common-all.js:12288 static/js/common-min.js:7 static/js/impala-all.js:14634 static/js/impala-min.js:8 static/js/impala/suggestions.js:41
+msgid "Search apps for <b>{0}</b>"
+msgstr ""
+
+#: static/js/common-all.js:12290 static/js/common-min.js:7 static/js/impala-all.js:14636 static/js/impala-min.js:8 static/js/impala/suggestions.js:43
+msgid "Search add-ons for <b>{0}</b>"
+msgstr ""
+
+#: static/js/common-all.js:12521 static/js/common-min.js:7 static/js/impala-all.js:14867 static/js/impala-min.js:8 static/js/impala/site_suggestions.js:46
+msgid "Category"
+msgstr ""
+
+#. L10n: {0} is an app name.
+#: static/js/impala-all.js:11632 static/js/impala-min.js:7 static/js/impala/listing.js:11 static/js/zamboni/themes.js:13
+msgid "This theme is incompatible with your version of {0}"
+msgstr ""
+
+#: static/js/impala-all.js:12146 static/js/impala-all.js:14331 static/js/impala-min.js:7 static/js/impala-min.js:8 static/js/common/upload-image.js:97 static/js/impala/users.js:51
+#: static/js/zamboni/devhub-all.js:894 static/js/zamboni/devhub-min.js:1
+msgid "Images must be either PNG or JPG."
+msgstr ""
+
+#: static/js/impala-all.js:12150 static/js/impala-min.js:7 static/js/common/upload-image.js:101 static/js/zamboni/devhub-all.js:898 static/js/zamboni/devhub-min.js:1
+msgid "Videos must be in WebM."
+msgstr ""
+
+#: static/js/impala-all.js:12177 static/js/impala-min.js:7 static/js/common/upload-addon.js:41 static/js/common/upload-image.js:128 static/js/zamboni/devhub-all.js:272
+#: static/js/zamboni/devhub-all.js:925 static/js/zamboni/devhub-min.js:1
 msgid "There was a problem contacting the server."
 msgstr ""
 
-#: static/js/common/upload-addon.js:69
+#: static/js/impala-all.js:13298 static/js/impala-min.js:7 static/js/impala/persona_creation.js:60
+msgid "All Rights Reserved"
+msgstr ""
+
+#: static/js/impala-all.js:13302 static/js/impala-min.js:7 static/js/impala/persona_creation.js:64
+msgid "Creative Commons Attribution 3.0"
+msgstr ""
+
+#: static/js/impala-all.js:13307 static/js/impala-min.js:7 static/js/impala/persona_creation.js:69
+msgid "Creative Commons Attribution-NonCommercial 3.0"
+msgstr ""
+
+#: static/js/impala-all.js:13312 static/js/impala-min.js:7 static/js/impala/persona_creation.js:74
+msgid "Creative Commons Attribution-NonCommercial-NoDerivs 3.0"
+msgstr ""
+
+#: static/js/impala-all.js:13317 static/js/impala-min.js:7 static/js/impala/persona_creation.js:79
+msgid "Creative Commons Attribution-NonCommercial-Share Alike 3.0"
+msgstr ""
+
+#: static/js/impala-all.js:13322 static/js/impala-min.js:7 static/js/impala/persona_creation.js:84
+msgid "Creative Commons Attribution-NoDerivs 3.0"
+msgstr ""
+
+#: static/js/impala-all.js:13327 static/js/impala-min.js:7 static/js/impala/persona_creation.js:89
+msgid "Creative Commons Attribution-ShareAlike 3.0"
+msgstr ""
+
+#: static/js/impala-all.js:13530 static/js/impala-min.js:7 static/js/impala/persona_creation.js:292
+msgid "Your Theme's Name"
+msgstr ""
+
+#: static/js/impala-all.js:14242 static/js/impala-min.js:8 static/js/impala/collections.js:19
+msgid "Stop Following"
+msgstr ""
+
+#: static/js/impala-all.js:14243 static/js/impala-min.js:8 static/js/impala/collections.js:20
+msgid "Following"
+msgstr ""
+
+#: static/js/impala-all.js:14313 static/js/impala-min.js:8 static/js/impala/users.js:33
+msgid "use original"
+msgstr ""
+
+#: static/js/impala-all.js:14523 static/js/impala-min.js:8 static/js/impala/search.js:114
+msgid "Updating results&hellip;"
+msgstr ""
+
+#: static/js/common/upload-addon.js:69 static/js/zamboni/devhub-all.js:300 static/js/zamboni/devhub-min.js:1
 msgid "Select a file..."
 msgstr ""
 
-#: static/js/common/upload-addon.js:70
+#: static/js/common/upload-addon.js:70 static/js/zamboni/devhub-all.js:301 static/js/zamboni/devhub-min.js:1
 msgid "Your add-on should end with .xpi, .jar or .xml"
 msgstr ""
 
 #. L10n: {0} is the percent of the file that has been uploaded.
-#: static/js/common/upload-addon.js:104
+#: static/js/common/upload-addon.js:104 static/js/zamboni/devhub-all.js:335 static/js/zamboni/devhub-min.js:1
 #, python-format
 msgid "{0}% complete"
 msgstr ""
 
 #. L10n: "{bytes uploaded} of {total filesize}".
-#: static/js/common/upload-addon.js:107
+#: static/js/common/upload-addon.js:107 static/js/zamboni/devhub-all.js:338 static/js/zamboni/devhub-min.js:1
 msgid "{0} of {1}"
 msgstr ""
 
-#: static/js/common/upload-addon.js:140
+#: static/js/common/upload-addon.js:140 static/js/zamboni/devhub-all.js:371 static/js/zamboni/devhub-min.js:1
 msgid "Cancel"
 msgstr ""
 
-#: static/js/common/upload-addon.js:162
+#: static/js/common/upload-addon.js:162 static/js/zamboni/devhub-all.js:393 static/js/zamboni/devhub-min.js:1
 msgid "Uploading {0}"
 msgstr ""
 
-#: static/js/common/upload-addon.js:189
+#: static/js/common/upload-addon.js:189 static/js/zamboni/devhub-all.js:420 static/js/zamboni/devhub-min.js:1
 msgid "Error with {0}"
 msgstr ""
 
-#: static/js/common/upload-addon.js:194
+#: static/js/common/upload-addon.js:194 static/js/zamboni/devhub-all.js:425 static/js/zamboni/devhub-min.js:1
 msgid "Your add-on failed validation with {0} error."
 msgid_plural "Your add-on failed validation with {0} errors."
 msgstr[0] ""
 msgstr[1] ""
 
-#: static/js/common/upload-addon.js:208
+#: static/js/common/upload-addon.js:208 static/js/zamboni/devhub-all.js:439 static/js/zamboni/devhub-min.js:1
 msgid "&hellip;and {0} more"
 msgid_plural "&hellip;and {0} more"
 msgstr[0] ""
 msgstr[1] ""
 
-#: static/js/common/upload-addon.js:222 static/js/common/upload-addon.js:512
+#: static/js/common/upload-addon.js:222 static/js/common/upload-addon.js:497 static/js/zamboni/devhub-all.js:453 static/js/zamboni/devhub-all.js:743 static/js/zamboni/devhub-min.js:1
 msgid "See full validation report"
 msgstr ""
 
-#: static/js/common/upload-addon.js:234
+#: static/js/common/upload-addon.js:234 static/js/zamboni/devhub-all.js:465 static/js/zamboni/devhub-min.js:1
 msgid "Validating {0}"
 msgstr ""
 
 #. L10n: first argument is an HTTP status code
-#: static/js/common/upload-addon.js:273
+#: static/js/common/upload-addon.js:273 static/js/zamboni/devhub-all.js:504 static/js/zamboni/devhub-min.js:1
 msgid "Received an empty response from the server; status: {0}"
 msgstr ""
 
-#: static/js/common/upload-addon.js:373
+#: static/js/common/upload-addon.js:370 static/js/zamboni/devhub-all.js:604 static/js/zamboni/devhub-min.js:1
 msgid "Unexpected server error while validating."
 msgstr ""
 
-#: static/js/common/upload-addon.js:412
+#: static/js/common/upload-addon.js:409 static/js/zamboni/devhub-all.js:643 static/js/zamboni/devhub-min.js:1
 msgid "Finished validating {0}"
 msgstr ""
 
-#: static/js/common/upload-addon.js:418
+#: static/js/common/upload-addon.js:415 static/js/zamboni/devhub-all.js:649 static/js/zamboni/devhub-min.js:1
 msgid "Your add-on validation timed out, it will be manually reviewed."
 msgstr ""
 
-#: static/js/common/upload-addon.js:421
+#: static/js/common/upload-addon.js:418 static/js/zamboni/devhub-all.js:652 static/js/zamboni/devhub-min.js:1
 msgid "Your add-on was validated with no errors and {0} warning."
 msgid_plural "Your add-on was validated with no errors and {0} warnings."
 msgstr[0] ""
 msgstr[1] ""
 
-#: static/js/common/upload-addon.js:426
+#: static/js/common/upload-addon.js:423 static/js/zamboni/devhub-all.js:657 static/js/zamboni/devhub-min.js:1
 msgid "Your add-on was validated with no errors and {0} message."
 msgid_plural "Your add-on was validated with no errors and {0} messages."
 msgstr[0] ""
 msgstr[1] ""
 
-#: static/js/common/upload-addon.js:431
+#: static/js/common/upload-addon.js:428 static/js/zamboni/devhub-all.js:662 static/js/zamboni/devhub-min.js:1
 msgid "Your add-on was validated with no errors or warnings."
 msgstr ""
 
-#: static/js/common/upload-addon.js:446
+#: static/js/common/upload-addon.js:443 static/js/zamboni/devhub-all.js:677 static/js/zamboni/devhub-min.js:1
 msgid "Your submission will be automatically signed."
 msgstr ""
 
-#: static/js/common/upload-addon.js:465
+#: static/js/common/upload-addon.js:450 static/js/zamboni/devhub-all.js:696 static/js/zamboni/devhub-min.js:1
 msgid "Include detailed version notes (this can be done in the next step)."
 msgstr ""
 
-#: static/js/common/upload-addon.js:466
+#: static/js/common/upload-addon.js:451 static/js/zamboni/devhub-all.js:697 static/js/zamboni/devhub-min.js:1
 msgid "If your add-on requires an account to a website in order to be fully tested, include a test username and password in the Notes to Reviewer (this can be done in the next step)."
 msgstr ""
 
-#: static/js/common/upload-addon.js:467
+#: static/js/common/upload-addon.js:452 static/js/zamboni/devhub-all.js:698 static/js/zamboni/devhub-min.js:1
 msgid "If your add-on is intended for a limited audience you should choose Preliminary Review instead of Full Review."
 msgstr ""
 
-#: static/js/common/upload-addon.js:480
+#: static/js/common/upload-addon.js:465 static/js/zamboni/devhub-all.js:711 static/js/zamboni/devhub-min.js:1
 msgid "Add-on submission checklist"
 msgstr ""
 
-#: static/js/common/upload-addon.js:481
+#: static/js/common/upload-addon.js:466 static/js/zamboni/devhub-all.js:712 static/js/zamboni/devhub-min.js:1
 msgid "Please verify the following points before finalizing your submission. This will minimize delays or misunderstanding during the review process:"
 msgstr ""
 
-#: static/js/common/upload-addon.js:483
+#: static/js/common/upload-addon.js:468 static/js/zamboni/devhub-all.js:714 static/js/zamboni/devhub-min.js:1
 msgid ""
 "Compiled binaries, as well as minified or obfuscated scripts (excluding known libraries) need to have their sources submitted separately for review. Make sure that you use the source code upload "
 "field to avoid having your submission rejected."
 msgstr ""
 
-#: static/js/common/upload-addon.js:501
+#: static/js/common/upload-addon.js:486 static/js/zamboni/devhub-all.js:732 static/js/zamboni/devhub-min.js:1
 msgid "The validation process found these issues that can lead to rejections:"
 msgstr ""
 
-#: static/js/common/upload-addon.js:518
+#: static/js/common/upload-addon.js:503 static/js/zamboni/devhub-all.js:749 static/js/zamboni/devhub-min.js:1
 msgid "If you are unfamiliar with the add-ons review process, you can read about it here."
 msgstr ""
 
-#: static/js/common/upload-addon.js:555
+#: static/js/common/upload-addon.js:540 static/js/zamboni/devhub-all.js:786 static/js/zamboni/devhub-min.js:1
 msgid "Sorry, no supported platform has been found."
 msgstr ""
 
-#: static/js/common/upload-base.js:57
+#: static/js/common/upload-base.js:57 static/js/zamboni/devhub-all.js:187 static/js/zamboni/devhub-min.js:1
 msgid "The filetype you uploaded isn't recognized."
 msgstr ""
 
-#: static/js/common/upload-base.js:79
+#: static/js/common/upload-base.js:79 static/js/zamboni/devhub-all.js:209 static/js/zamboni/devhub-min.js:1
 msgid "You cancelled the upload."
 msgstr ""
 
-#: static/js/common/upload-image.js:97 static/js/impala/users.js:51
-msgid "Images must be either PNG or JPG."
-msgstr ""
-
-#: static/js/common/upload-image.js:101
-msgid "Videos must be in WebM."
-msgstr ""
-
-#: static/js/impala/collections.js:10 static/js/zamboni/collections.js:595
-msgid "Follow this Collection"
-msgstr ""
-
-#: static/js/impala/collections.js:19
-msgid "Stop Following"
-msgstr ""
-
-#: static/js/impala/collections.js:20
-msgid "Following"
-msgstr ""
-
-#. L10n: {0} is an app name.
-#: static/js/impala/listing.js:11 static/js/zamboni/themes.js:13
-msgid "This theme is incompatible with your version of {0}"
-msgstr ""
-
-#: static/js/impala/persona_creation.js:60
-msgid "All Rights Reserved"
-msgstr ""
-
-#: static/js/impala/persona_creation.js:64
-msgid "Creative Commons Attribution 3.0"
-msgstr ""
-
-#: static/js/impala/persona_creation.js:69
-msgid "Creative Commons Attribution-NonCommercial 3.0"
-msgstr ""
-
-#: static/js/impala/persona_creation.js:74
-msgid "Creative Commons Attribution-NonCommercial-NoDerivs 3.0"
-msgstr ""
-
-#: static/js/impala/persona_creation.js:79
-msgid "Creative Commons Attribution-NonCommercial-Share Alike 3.0"
-msgstr ""
-
-#: static/js/impala/persona_creation.js:84
-msgid "Creative Commons Attribution-NoDerivs 3.0"
-msgstr ""
-
-#: static/js/impala/persona_creation.js:89
-msgid "Creative Commons Attribution-ShareAlike 3.0"
-msgstr ""
-
-#: static/js/impala/persona_creation.js:292
-msgid "Your Theme's Name"
-msgstr ""
-
-#: static/js/impala/reviews.js:23 static/js/zamboni/reviews.js:18
-msgid "Flagged for review"
-msgstr ""
-
-#: static/js/impala/reviews.js:40 static/js/zamboni/reviews.js:34
-msgid "Your input is required"
-msgstr ""
-
-#: static/js/impala/reviews.js:152 static/js/zamboni/reviews.js:103
-msgid "Marked for deletion"
-msgstr ""
-
-#: static/js/impala/search.js:114
-msgid "Updating results&hellip;"
-msgstr ""
-
-#: static/js/impala/site_suggestions.js:46
-msgid "Category"
-msgstr ""
-
-#: static/js/impala/suggestions.js:39
-msgid "Search themes for <b>{0}</b>"
-msgstr ""
-
-#: static/js/impala/suggestions.js:41
-msgid "Search apps for <b>{0}</b>"
-msgstr ""
-
-#: static/js/impala/suggestions.js:43
-msgid "Search add-ons for <b>{0}</b>"
-msgstr ""
-
-#: static/js/impala/users.js:33
-msgid "use original"
-msgstr ""
-
-#: static/js/impala/stats/chart.js:267
+#: static/js/impala/stats/chart.js:267 static/js/zamboni/stats-all.js:16898 static/js/zamboni/stats-min.js:5
 msgid "Week of {0}"
 msgstr ""
 
-#: static/js/impala/stats/chart.js:269
+#: static/js/impala/stats/chart.js:269 static/js/zamboni/stats-all.js:16900 static/js/zamboni/stats-min.js:5
 msgid " downloads"
 msgstr ""
 
-#: static/js/impala/stats/chart.js:270
+#: static/js/impala/stats/chart.js:270 static/js/zamboni/stats-all.js:16901 static/js/zamboni/stats-min.js:5
 msgid "{0} users"
 msgstr ""
 
-#: static/js/impala/stats/chart.js:271
+#: static/js/impala/stats/chart.js:271 static/js/zamboni/stats-all.js:16902 static/js/zamboni/stats-min.js:5
 msgid "{0} add-ons"
 msgstr ""
 
-#: static/js/impala/stats/chart.js:272
+#: static/js/impala/stats/chart.js:272 static/js/zamboni/stats-all.js:16903 static/js/zamboni/stats-min.js:5
 msgid "{0} collections"
 msgstr ""
 
-#: static/js/impala/stats/chart.js:273
+#: static/js/impala/stats/chart.js:273 static/js/zamboni/stats-all.js:16904 static/js/zamboni/stats-min.js:5
 msgid "{0} reviews"
 msgstr ""
 
-#: static/js/impala/stats/chart.js:275
+#: static/js/impala/stats/chart.js:275 static/js/zamboni/stats-all.js:16906 static/js/zamboni/stats-min.js:5
 msgid "{0} sales"
 msgstr ""
 
-#: static/js/impala/stats/chart.js:276
+#: static/js/impala/stats/chart.js:276 static/js/zamboni/stats-all.js:16907 static/js/zamboni/stats-min.js:5
 msgid "{0} refunds"
 msgstr ""
 
-#: static/js/impala/stats/chart.js:277
+#: static/js/impala/stats/chart.js:277 static/js/zamboni/stats-all.js:16908 static/js/zamboni/stats-min.js:5
 msgid "{0} installs"
 msgstr ""
 
-#: static/js/impala/stats/chart.js:369 static/js/impala/stats/csv_keys.js:3 static/js/impala/stats/csv_keys.js:109
+#: static/js/impala/stats/chart.js:369 static/js/impala/stats/csv_keys.js:3 static/js/impala/stats/csv_keys.js:109 static/js/zamboni/stats-all.js:15284 static/js/zamboni/stats-all.js:15390
+#: static/js/zamboni/stats-all.js:17000 static/js/zamboni/stats-min.js:4 static/js/zamboni/stats-min.js:5
 msgid "Downloads"
 msgstr ""
 
-#: static/js/impala/stats/chart.js:379 static/js/impala/stats/csv_keys.js:6 static/js/impala/stats/csv_keys.js:110
+#: static/js/impala/stats/chart.js:379 static/js/impala/stats/csv_keys.js:6 static/js/impala/stats/csv_keys.js:110 static/js/zamboni/stats-all.js:15287 static/js/zamboni/stats-all.js:15391
+#: static/js/zamboni/stats-all.js:17010 static/js/zamboni/stats-min.js:4 static/js/zamboni/stats-min.js:5
 msgid "Daily Users"
 msgstr ""
 
-#: static/js/impala/stats/chart.js:410
+#: static/js/impala/stats/chart.js:410 static/js/zamboni/stats-all.js:17041 static/js/zamboni/stats-min.js:5
 msgid "Amount, in USD"
 msgstr ""
 
-#: static/js/impala/stats/chart.js:421 static/js/impala/stats/csv_keys.js:104
+#: static/js/impala/stats/chart.js:421 static/js/impala/stats/csv_keys.js:104 static/js/zamboni/stats-all.js:15385 static/js/zamboni/stats-all.js:17052 static/js/zamboni/stats-min.js:5
 msgid "Number of Contributions"
 msgstr ""
 
-#: static/js/impala/stats/chart.js:447
+#: static/js/impala/stats/chart.js:447 static/js/zamboni/stats-all.js:17078 static/js/zamboni/stats-min.js:5
 msgid "More Info..."
 msgstr ""
 
 #. L10n: {0} is an ISO-formatted date.
-#: static/js/impala/stats/chart.js:451
+#: static/js/impala/stats/chart.js:451 static/js/zamboni/stats-all.js:17082 static/js/zamboni/stats-min.js:5
 msgid "Details for {0}"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:9
+#: static/js/impala/stats/csv_keys.js:9 static/js/zamboni/stats-all.js:15290 static/js/zamboni/stats-min.js:4
 msgid "Collections Created"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:12
+#: static/js/impala/stats/csv_keys.js:12 static/js/zamboni/stats-all.js:15293 static/js/zamboni/stats-min.js:4
 msgid "Add-ons in Use"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:15
+#: static/js/impala/stats/csv_keys.js:15 static/js/zamboni/stats-all.js:15296 static/js/zamboni/stats-min.js:4
 msgid "Add-ons Created"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:18
+#: static/js/impala/stats/csv_keys.js:18 static/js/zamboni/stats-all.js:15299 static/js/zamboni/stats-min.js:4
 msgid "Add-ons Downloaded"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:21
+#: static/js/impala/stats/csv_keys.js:21 static/js/zamboni/stats-all.js:15302 static/js/zamboni/stats-min.js:4
 msgid "Add-ons Updated"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:24
+#: static/js/impala/stats/csv_keys.js:24 static/js/zamboni/stats-all.js:15305 static/js/zamboni/stats-min.js:4
 msgid "Reviews Written"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:27
+#: static/js/impala/stats/csv_keys.js:27 static/js/zamboni/stats-all.js:15308 static/js/zamboni/stats-min.js:4
 msgid "User Signups"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:30
+#: static/js/impala/stats/csv_keys.js:30 static/js/zamboni/stats-all.js:15311 static/js/zamboni/stats-min.js:4
 msgid "Subscribers"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:33
+#: static/js/impala/stats/csv_keys.js:33 static/js/zamboni/stats-all.js:15314 static/js/zamboni/stats-min.js:4
 msgid "Ratings"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:36 static/js/impala/stats/csv_keys.js:114
+#: static/js/impala/stats/csv_keys.js:36 static/js/impala/stats/csv_keys.js:114 static/js/zamboni/stats-all.js:15317 static/js/zamboni/stats-all.js:15395 static/js/zamboni/stats-min.js:4
+#: static/js/zamboni/stats-min.js:5
 msgid "Sales"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:39 static/js/impala/stats/csv_keys.js:113
+#: static/js/impala/stats/csv_keys.js:39 static/js/impala/stats/csv_keys.js:113 static/js/zamboni/stats-all.js:15320 static/js/zamboni/stats-all.js:15394 static/js/zamboni/stats-min.js:4
+#: static/js/zamboni/stats-min.js:5
 msgid "Installs"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:42
+#: static/js/impala/stats/csv_keys.js:42 static/js/zamboni/stats-all.js:15323 static/js/zamboni/stats-min.js:4
 msgid "Unknown"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:43
+#: static/js/impala/stats/csv_keys.js:43 static/js/zamboni/stats-all.js:15324 static/js/zamboni/stats-min.js:4
 msgid "Add-ons Manager"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:44
+#: static/js/impala/stats/csv_keys.js:44 static/js/zamboni/stats-all.js:15325 static/js/zamboni/stats-min.js:4
 msgid "Add-ons Manager Promo"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:45
+#: static/js/impala/stats/csv_keys.js:45 static/js/zamboni/stats-all.js:15326 static/js/zamboni/stats-min.js:4
 msgid "Add-ons Manager Featured"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:46
+#: static/js/impala/stats/csv_keys.js:46 static/js/zamboni/stats-all.js:15327 static/js/zamboni/stats-min.js:4
 msgid "Add-ons Manager Learn More"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:47
+#: static/js/impala/stats/csv_keys.js:47 static/js/zamboni/stats-all.js:15328 static/js/zamboni/stats-min.js:4
 msgid "Search Suggestions"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:48
+#: static/js/impala/stats/csv_keys.js:48 static/js/zamboni/stats-all.js:15329 static/js/zamboni/stats-min.js:4
 msgid "Search Results"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:49 static/js/impala/stats/csv_keys.js:50 static/js/impala/stats/csv_keys.js:51
+#: static/js/impala/stats/csv_keys.js:49 static/js/impala/stats/csv_keys.js:50 static/js/impala/stats/csv_keys.js:51 static/js/zamboni/stats-all.js:15330 static/js/zamboni/stats-all.js:15331
+#: static/js/zamboni/stats-all.js:15332 static/js/zamboni/stats-min.js:4
 msgid "Homepage Promo"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:52 static/js/impala/stats/csv_keys.js:53
+#: static/js/impala/stats/csv_keys.js:52 static/js/impala/stats/csv_keys.js:53 static/js/zamboni/stats-all.js:15333 static/js/zamboni/stats-all.js:15334 static/js/zamboni/stats-min.js:4
 msgid "Homepage Featured"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:54 static/js/impala/stats/csv_keys.js:55
+#: static/js/impala/stats/csv_keys.js:54 static/js/impala/stats/csv_keys.js:55 static/js/zamboni/stats-all.js:15335 static/js/zamboni/stats-all.js:15336 static/js/zamboni/stats-min.js:4
 msgid "Homepage Up and Coming"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:56
+#: static/js/impala/stats/csv_keys.js:56 static/js/zamboni/stats-all.js:15337 static/js/zamboni/stats-min.js:4
 msgid "Homepage Most Popular"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:57 static/js/impala/stats/csv_keys.js:59
+#: static/js/impala/stats/csv_keys.js:57 static/js/impala/stats/csv_keys.js:59 static/js/zamboni/stats-all.js:15338 static/js/zamboni/stats-all.js:15340 static/js/zamboni/stats-min.js:4
 msgid "Detail Page"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:58 static/js/impala/stats/csv_keys.js:60
+#: static/js/impala/stats/csv_keys.js:58 static/js/impala/stats/csv_keys.js:60 static/js/zamboni/stats-all.js:15339 static/js/zamboni/stats-all.js:15341 static/js/zamboni/stats-min.js:4
 msgid "Detail Page (bottom)"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:61
+#: static/js/impala/stats/csv_keys.js:61 static/js/zamboni/stats-all.js:15342 static/js/zamboni/stats-min.js:4
 msgid "Detail Page (Development Channel)"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:62 static/js/impala/stats/csv_keys.js:63 static/js/impala/stats/csv_keys.js:64
+#: static/js/impala/stats/csv_keys.js:62 static/js/impala/stats/csv_keys.js:63 static/js/impala/stats/csv_keys.js:64 static/js/zamboni/stats-all.js:15343 static/js/zamboni/stats-all.js:15344
+#: static/js/zamboni/stats-all.js:15345 static/js/zamboni/stats-min.js:4
 msgid "Often Used With"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:65 static/js/impala/stats/csv_keys.js:66
+#: static/js/impala/stats/csv_keys.js:65 static/js/impala/stats/csv_keys.js:66 static/js/zamboni/stats-all.js:15346 static/js/zamboni/stats-all.js:15347 static/js/zamboni/stats-min.js:4
 msgid "Others By Author"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:67 static/js/impala/stats/csv_keys.js:68
+#: static/js/impala/stats/csv_keys.js:67 static/js/impala/stats/csv_keys.js:68 static/js/zamboni/stats-all.js:15348 static/js/zamboni/stats-all.js:15349 static/js/zamboni/stats-min.js:4
 msgid "Dependencies"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:69 static/js/impala/stats/csv_keys.js:70
+#: static/js/impala/stats/csv_keys.js:69 static/js/impala/stats/csv_keys.js:70 static/js/zamboni/stats-all.js:15350 static/js/zamboni/stats-all.js:15351 static/js/zamboni/stats-min.js:4
 msgid "Upsell"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:71
+#: static/js/impala/stats/csv_keys.js:71 static/js/zamboni/stats-all.js:15352 static/js/zamboni/stats-min.js:4
 msgid "Meet the Developer"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:72
+#: static/js/impala/stats/csv_keys.js:72 static/js/zamboni/stats-all.js:15353 static/js/zamboni/stats-min.js:4
 msgid "User Profile"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:73
+#: static/js/impala/stats/csv_keys.js:73 static/js/zamboni/stats-all.js:15354 static/js/zamboni/stats-min.js:4
 msgid "Version History"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:75
+#: static/js/impala/stats/csv_keys.js:75 static/js/zamboni/stats-all.js:15356 static/js/zamboni/stats-min.js:4
 msgid "Sharing"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:76
+#: static/js/impala/stats/csv_keys.js:76 static/js/zamboni/stats-all.js:15357 static/js/zamboni/stats-min.js:4
 msgid "Category Pages"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:77
+#: static/js/impala/stats/csv_keys.js:77 static/js/zamboni/stats-all.js:15358 static/js/zamboni/stats-min.js:4
 msgid "Collections"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:78 static/js/impala/stats/csv_keys.js:79
+#: static/js/impala/stats/csv_keys.js:78 static/js/impala/stats/csv_keys.js:79 static/js/zamboni/stats-all.js:15359 static/js/zamboni/stats-all.js:15360 static/js/zamboni/stats-min.js:4
 msgid "Category Landing Featured Carousel"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:80 static/js/impala/stats/csv_keys.js:81
+#: static/js/impala/stats/csv_keys.js:80 static/js/impala/stats/csv_keys.js:81 static/js/zamboni/stats-all.js:15361 static/js/zamboni/stats-all.js:15362 static/js/zamboni/stats-min.js:4
 msgid "Category Landing Top Rated"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:82 static/js/impala/stats/csv_keys.js:83
+#: static/js/impala/stats/csv_keys.js:82 static/js/impala/stats/csv_keys.js:83 static/js/zamboni/stats-all.js:15363 static/js/zamboni/stats-all.js:15364 static/js/zamboni/stats-min.js:5
 msgid "Category Landing Most Popular"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:84 static/js/impala/stats/csv_keys.js:85
+#: static/js/impala/stats/csv_keys.js:84 static/js/impala/stats/csv_keys.js:85 static/js/zamboni/stats-all.js:15365 static/js/zamboni/stats-all.js:15366 static/js/zamboni/stats-min.js:5
 msgid "Category Landing Recently Added"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:86 static/js/impala/stats/csv_keys.js:87
+#: static/js/impala/stats/csv_keys.js:86 static/js/impala/stats/csv_keys.js:87 static/js/zamboni/stats-all.js:15367 static/js/zamboni/stats-all.js:15368 static/js/zamboni/stats-min.js:5
 msgid "Browse Listing Featured Sort"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:88 static/js/impala/stats/csv_keys.js:89
+#: static/js/impala/stats/csv_keys.js:88 static/js/impala/stats/csv_keys.js:89 static/js/zamboni/stats-all.js:15369 static/js/zamboni/stats-all.js:15370 static/js/zamboni/stats-min.js:5
 msgid "Browse Listing Users Sort"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:90 static/js/impala/stats/csv_keys.js:91
+#: static/js/impala/stats/csv_keys.js:90 static/js/impala/stats/csv_keys.js:91 static/js/zamboni/stats-all.js:15371 static/js/zamboni/stats-all.js:15372 static/js/zamboni/stats-min.js:5
 msgid "Browse Listing Rating Sort"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:92 static/js/impala/stats/csv_keys.js:93
+#: static/js/impala/stats/csv_keys.js:92 static/js/impala/stats/csv_keys.js:93 static/js/zamboni/stats-all.js:15373 static/js/zamboni/stats-all.js:15374 static/js/zamboni/stats-min.js:5
 msgid "Browse Listing Created Sort"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:94 static/js/impala/stats/csv_keys.js:95
+#: static/js/impala/stats/csv_keys.js:94 static/js/impala/stats/csv_keys.js:95 static/js/zamboni/stats-all.js:15375 static/js/zamboni/stats-all.js:15376 static/js/zamboni/stats-min.js:5
 msgid "Browse Listing Name Sort"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:96 static/js/impala/stats/csv_keys.js:97
+#: static/js/impala/stats/csv_keys.js:96 static/js/impala/stats/csv_keys.js:97 static/js/zamboni/stats-all.js:15377 static/js/zamboni/stats-all.js:15378 static/js/zamboni/stats-min.js:5
 msgid "Browse Listing Popular Sort"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:98 static/js/impala/stats/csv_keys.js:99
+#: static/js/impala/stats/csv_keys.js:98 static/js/impala/stats/csv_keys.js:99 static/js/zamboni/stats-all.js:15379 static/js/zamboni/stats-all.js:15380 static/js/zamboni/stats-min.js:5
 msgid "Browse Listing Updated Sort"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:100 static/js/impala/stats/csv_keys.js:101
+#: static/js/impala/stats/csv_keys.js:100 static/js/impala/stats/csv_keys.js:101 static/js/zamboni/stats-all.js:15381 static/js/zamboni/stats-all.js:15382 static/js/zamboni/stats-min.js:5
 msgid "Browse Listing Up and Coming Sort"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:105
+#: static/js/impala/stats/csv_keys.js:105 static/js/zamboni/stats-all.js:15386 static/js/zamboni/stats-min.js:5
 msgid "Total Amount Contributed"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:106
+#: static/js/impala/stats/csv_keys.js:106 static/js/zamboni/stats-all.js:15387 static/js/zamboni/stats-min.js:5
 msgid "Average Contribution"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:115
+#: static/js/impala/stats/csv_keys.js:115 static/js/zamboni/stats-all.js:15396 static/js/zamboni/stats-min.js:5
 msgid "Usage"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:118
+#: static/js/impala/stats/csv_keys.js:118 static/js/zamboni/stats-all.js:15399 static/js/zamboni/stats-min.js:5
 msgid "Firefox"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:119
+#: static/js/impala/stats/csv_keys.js:119 static/js/zamboni/stats-all.js:15400 static/js/zamboni/stats-min.js:5
 msgid "Mozilla"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:120
+#: static/js/impala/stats/csv_keys.js:120 static/js/zamboni/stats-all.js:15401 static/js/zamboni/stats-min.js:5
 msgid "Thunderbird"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:121
+#: static/js/impala/stats/csv_keys.js:121 static/js/zamboni/stats-all.js:15402 static/js/zamboni/stats-min.js:5
 msgid "Sunbird"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:122
+#: static/js/impala/stats/csv_keys.js:122 static/js/zamboni/stats-all.js:15403 static/js/zamboni/stats-min.js:5
 msgid "SeaMonkey"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:123
+#: static/js/impala/stats/csv_keys.js:123 static/js/zamboni/stats-all.js:15404 static/js/zamboni/stats-min.js:5
 msgid "Fennec"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:124
+#: static/js/impala/stats/csv_keys.js:124 static/js/zamboni/stats-all.js:15405 static/js/zamboni/stats-min.js:5
 msgid "Android"
 msgstr ""
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:129
+#: static/js/impala/stats/csv_keys.js:129 static/js/zamboni/stats-all.js:15410 static/js/zamboni/stats-min.js:5
 msgid "Downloads and Daily Users, last {0} days"
 msgstr ""
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:131
+#: static/js/impala/stats/csv_keys.js:131 static/js/zamboni/stats-all.js:15412 static/js/zamboni/stats-min.js:5
 msgid "Downloads and Daily Users from {0} to {1}"
 msgstr ""
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:135
+#: static/js/impala/stats/csv_keys.js:135 static/js/zamboni/stats-all.js:15416 static/js/zamboni/stats-min.js:5
 msgid "Installs and Daily Users, last {0} days"
 msgstr ""
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:137
+#: static/js/impala/stats/csv_keys.js:137 static/js/zamboni/stats-all.js:15418 static/js/zamboni/stats-min.js:5
 msgid "Installs and Daily Users from {0} to {1}"
 msgstr ""
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:141
+#: static/js/impala/stats/csv_keys.js:141 static/js/zamboni/stats-all.js:15422 static/js/zamboni/stats-min.js:5
 msgid "Downloads, last {0} days"
 msgstr ""
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:143
+#: static/js/impala/stats/csv_keys.js:143 static/js/zamboni/stats-all.js:15424 static/js/zamboni/stats-min.js:5
 msgid "Downloads from {0} to {1}"
 msgstr ""
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:147
+#: static/js/impala/stats/csv_keys.js:147 static/js/zamboni/stats-all.js:15428 static/js/zamboni/stats-min.js:5
 msgid "Daily Users, last {0} days"
 msgstr ""
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:149
+#: static/js/impala/stats/csv_keys.js:149 static/js/zamboni/stats-all.js:15430 static/js/zamboni/stats-min.js:5
 msgid "Daily Users from {0} to {1}"
 msgstr ""
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:153
+#: static/js/impala/stats/csv_keys.js:153 static/js/zamboni/stats-all.js:15434 static/js/zamboni/stats-min.js:5
 msgid "Applications, last {0} days"
 msgstr ""
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:155
+#: static/js/impala/stats/csv_keys.js:155 static/js/zamboni/stats-all.js:15436 static/js/zamboni/stats-min.js:5
 msgid "Applications from {0} to {1}"
 msgstr ""
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:159
+#: static/js/impala/stats/csv_keys.js:159 static/js/zamboni/stats-all.js:15440 static/js/zamboni/stats-min.js:5
 msgid "Platforms, last {0} days"
 msgstr ""
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:161
+#: static/js/impala/stats/csv_keys.js:161 static/js/zamboni/stats-all.js:15442 static/js/zamboni/stats-min.js:5
 msgid "Platforms from {0} to {1}"
 msgstr ""
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:165
+#: static/js/impala/stats/csv_keys.js:165 static/js/zamboni/stats-all.js:15446 static/js/zamboni/stats-min.js:5
 msgid "Languages, last {0} days"
 msgstr ""
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:167
+#: static/js/impala/stats/csv_keys.js:167 static/js/zamboni/stats-all.js:15448 static/js/zamboni/stats-min.js:5
 msgid "Languages from {0} to {1}"
 msgstr ""
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:171
+#: static/js/impala/stats/csv_keys.js:171 static/js/zamboni/stats-all.js:15452 static/js/zamboni/stats-min.js:5
 msgid "Add-on Versions, last {0} days"
 msgstr ""
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:173
+#: static/js/impala/stats/csv_keys.js:173 static/js/zamboni/stats-all.js:15454 static/js/zamboni/stats-min.js:5
 msgid "Add-on Versions from {0} to {1}"
 msgstr ""
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:177
+#: static/js/impala/stats/csv_keys.js:177 static/js/zamboni/stats-all.js:15458 static/js/zamboni/stats-min.js:5
 msgid "Add-on Status, last {0} days"
 msgstr ""
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:179
+#: static/js/impala/stats/csv_keys.js:179 static/js/zamboni/stats-all.js:15460 static/js/zamboni/stats-min.js:5
 msgid "Add-on Status from {0} to {1}"
 msgstr ""
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:183
+#: static/js/impala/stats/csv_keys.js:183 static/js/zamboni/stats-all.js:15464 static/js/zamboni/stats-min.js:5
 msgid "Download Sources, last {0} days"
 msgstr ""
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:185
+#: static/js/impala/stats/csv_keys.js:185 static/js/zamboni/stats-all.js:15466 static/js/zamboni/stats-min.js:5
 msgid "Download Sources from {0} to {1}"
 msgstr ""
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:189
+#: static/js/impala/stats/csv_keys.js:189 static/js/zamboni/stats-all.js:15470 static/js/zamboni/stats-min.js:5
 msgid "Contributions, last {0} days"
 msgstr ""
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:191
+#: static/js/impala/stats/csv_keys.js:191 static/js/zamboni/stats-all.js:15472 static/js/zamboni/stats-min.js:5
 msgid "Contributions from {0} to {1}"
 msgstr ""
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:195
+#: static/js/impala/stats/csv_keys.js:195 static/js/zamboni/stats-all.js:15476 static/js/zamboni/stats-min.js:5
 msgid "Site Metrics, last {0} days"
 msgstr ""
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:197
+#: static/js/impala/stats/csv_keys.js:197 static/js/zamboni/stats-all.js:15478 static/js/zamboni/stats-min.js:5
 msgid "Site Metrics from {0} to {1}"
 msgstr ""
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:201
+#: static/js/impala/stats/csv_keys.js:201 static/js/zamboni/stats-all.js:15482 static/js/zamboni/stats-min.js:5
 msgid "Add-ons in Use, last {0} days"
 msgstr ""
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:203
+#: static/js/impala/stats/csv_keys.js:203 static/js/zamboni/stats-all.js:15484 static/js/zamboni/stats-min.js:5
 msgid "Add-ons in Use from {0} to {1}"
 msgstr ""
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:207
+#: static/js/impala/stats/csv_keys.js:207 static/js/zamboni/stats-all.js:15488 static/js/zamboni/stats-min.js:5
 msgid "Add-ons Downloaded, last {0} days"
 msgstr ""
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:209
+#: static/js/impala/stats/csv_keys.js:209 static/js/zamboni/stats-all.js:15490 static/js/zamboni/stats-min.js:5
 msgid "Add-ons Downloaded from {0} to {1}"
 msgstr ""
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:213
+#: static/js/impala/stats/csv_keys.js:213 static/js/zamboni/stats-all.js:15494 static/js/zamboni/stats-min.js:5
 msgid "Add-ons Created, last {0} days"
 msgstr ""
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:215
+#: static/js/impala/stats/csv_keys.js:215 static/js/zamboni/stats-all.js:15496 static/js/zamboni/stats-min.js:5
 msgid "Add-ons Created from {0} to {1}"
 msgstr ""
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:219
+#: static/js/impala/stats/csv_keys.js:219 static/js/zamboni/stats-all.js:15500 static/js/zamboni/stats-min.js:5
 msgid "Add-ons Updated, last {0} days"
 msgstr ""
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:221
+#: static/js/impala/stats/csv_keys.js:221 static/js/zamboni/stats-all.js:15502 static/js/zamboni/stats-min.js:5
 msgid "Add-ons Updated from {0} to {1}"
 msgstr ""
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:225
+#: static/js/impala/stats/csv_keys.js:225 static/js/zamboni/stats-all.js:15506 static/js/zamboni/stats-min.js:5
 msgid "Reviews Written, last {0} days"
 msgstr ""
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:227
+#: static/js/impala/stats/csv_keys.js:227 static/js/zamboni/stats-all.js:15508 static/js/zamboni/stats-min.js:5
 msgid "Reviews Written from {0} to {1}"
 msgstr ""
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:231
+#: static/js/impala/stats/csv_keys.js:231 static/js/zamboni/stats-all.js:15512 static/js/zamboni/stats-min.js:5
 msgid "User Signups, last {0} days"
 msgstr ""
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:233
+#: static/js/impala/stats/csv_keys.js:233 static/js/zamboni/stats-all.js:15514 static/js/zamboni/stats-min.js:5
 msgid "User Signups from {0} to {1}"
 msgstr ""
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:237
+#: static/js/impala/stats/csv_keys.js:237 static/js/zamboni/stats-all.js:15518 static/js/zamboni/stats-min.js:5
 msgid "Collections Created, last {0} days"
 msgstr ""
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:239
+#: static/js/impala/stats/csv_keys.js:239 static/js/zamboni/stats-all.js:15520 static/js/zamboni/stats-min.js:5
 msgid "Collections Created from {0} to {1}"
 msgstr ""
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:243
+#: static/js/impala/stats/csv_keys.js:243 static/js/zamboni/stats-all.js:15524 static/js/zamboni/stats-min.js:5
 msgid "Subscribers, last {0} days"
 msgstr ""
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:245
+#: static/js/impala/stats/csv_keys.js:245 static/js/zamboni/stats-all.js:15526 static/js/zamboni/stats-min.js:5
 msgid "Subscribers from {0} to {1}"
 msgstr ""
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:249
+#: static/js/impala/stats/csv_keys.js:249 static/js/zamboni/stats-all.js:15530 static/js/zamboni/stats-min.js:5
 msgid "Ratings, last {0} days"
 msgstr ""
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:251
+#: static/js/impala/stats/csv_keys.js:251 static/js/zamboni/stats-all.js:15532 static/js/zamboni/stats-min.js:5
 msgid "Ratings from {0} to {1}"
 msgstr ""
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:255
+#: static/js/impala/stats/csv_keys.js:255 static/js/zamboni/stats-all.js:15536 static/js/zamboni/stats-min.js:5
 msgid "Sales, last {0} days"
 msgstr ""
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:257
+#: static/js/impala/stats/csv_keys.js:257 static/js/zamboni/stats-all.js:15538 static/js/zamboni/stats-min.js:5
 msgid "Sales from {0} to {1}"
 msgstr ""
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:261
+#: static/js/impala/stats/csv_keys.js:261 static/js/zamboni/stats-all.js:15542 static/js/zamboni/stats-min.js:5
 msgid "Installs, last {0} days"
 msgstr ""
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:263
+#: static/js/impala/stats/csv_keys.js:263 static/js/zamboni/stats-all.js:15544 static/js/zamboni/stats-min.js:5
 msgid "Installs from {0} to {1}"
 msgstr ""
 
 #. L10n: {0} and {1} are integers.
-#: static/js/impala/stats/csv_keys.js:269
+#: static/js/impala/stats/csv_keys.js:269 static/js/zamboni/stats-all.js:15550 static/js/zamboni/stats-min.js:5
 msgid "<b>{0}</b> in last {1} days"
 msgstr ""
 
 #. L10n: {0} is an integer and {1} and {2} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:271 static/js/impala/stats/csv_keys.js:277
+#: static/js/impala/stats/csv_keys.js:271 static/js/impala/stats/csv_keys.js:277 static/js/zamboni/stats-all.js:15552 static/js/zamboni/stats-all.js:15558 static/js/zamboni/stats-min.js:5
 msgid "<b>{0}</b> from {1} to {2}"
 msgstr ""
 
 #. L10n: {0} and {1} are integers.
-#: static/js/impala/stats/csv_keys.js:275
+#: static/js/impala/stats/csv_keys.js:275 static/js/zamboni/stats-all.js:15556 static/js/zamboni/stats-min.js:5
 msgid "<b>{0}</b> average in last {1} days"
 msgstr ""
 
-#: static/js/impala/stats/overview.js:19
+#: static/js/impala/stats/overview.js:19 static/js/zamboni/stats-all.js:16469 static/js/zamboni/stats-min.js:5
 msgid "No data available."
 msgstr ""
 
-#: static/js/impala/stats/table.js:74
+#: static/js/impala/stats/table.js:74 static/js/zamboni/stats-all.js:17209 static/js/zamboni/stats-min.js:5
 msgid "Date"
 msgstr ""
 
-#: static/js/impala/stats/topchart.js:96
+#: static/js/impala/stats/topchart.js:96 static/js/zamboni/stats-all.js:16600 static/js/zamboni/stats-min.js:5
 msgid "Other"
 msgstr ""
 
-#: static/js/zamboni/admin_validation.js:24 static/js/zamboni/devhub.js:1229 static/js/zamboni/editors.js:295
+#: static/js/zamboni/admin-all.js:180 static/js/zamboni/admin-min.js:1 static/js/zamboni/admin_validation.js:24 static/js/zamboni/devhub-all.js:2408 static/js/zamboni/devhub-min.js:2
+#: static/js/zamboni/devhub.js:1229 static/js/zamboni/editors-all.js:15576 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:295
 msgid "Select an application first"
 msgstr ""
 
-#: static/js/zamboni/admin_validation.js:51
+#: static/js/zamboni/admin-all.js:207 static/js/zamboni/admin-min.js:1 static/js/zamboni/admin_validation.js:51
 msgid "Set {0} add-on to a max version of {1} and email the author."
 msgid_plural "Set {0} add-ons to a max version of {1} and email the authors."
 msgstr[0] ""
 msgstr[1] ""
 
-#: static/js/zamboni/admin_validation.js:54
+#: static/js/zamboni/admin-all.js:210 static/js/zamboni/admin-min.js:1 static/js/zamboni/admin_validation.js:54
 msgid "Email author of {2} add-on which failed validation."
 msgid_plural "Email authors of {2} add-ons which failed validation."
 msgstr[0] ""
 msgstr[1] ""
 
-#. L10n: {0} is an app name like Firefox.
-#: static/js/zamboni/buttons.js:66
-msgid "Accept and Install"
-msgstr ""
-
-#: static/js/zamboni/buttons.js:66
-msgid "Add to {0}"
-msgstr ""
-
-#: static/js/zamboni/buttons.js:71
-msgid "Download Now"
-msgstr ""
-
-#: static/js/zamboni/buttons.js:112
-msgid "Add-on has not been updated to support default-to-compatible."
-msgstr ""
-
-#: static/js/zamboni/buttons.js:117
-msgid "You need to be using Firefox 10.0 or higher."
-msgstr ""
-
-#: static/js/zamboni/buttons.js:129
-msgid "Mozilla has marked this version as incompatible with your Firefox version."
-msgstr ""
-
-#. L10n: {0} is an platform like Windows or Linux.
-#: static/js/zamboni/buttons.js:210
-msgid "Install for {0} anyway"
-msgstr ""
-
-#: static/js/zamboni/buttons.js:210
-msgid "Download for {0} anyway"
-msgstr ""
-
-#: static/js/zamboni/buttons.js:267
-msgid "Not available for your platform"
-msgstr ""
-
-#. L10n: {0} is an app name, {1} is the app version.
-#: static/js/zamboni/buttons.js:278 static/js/zamboni/buttons.js:315
-msgid "Not available for {0} {1}"
-msgstr ""
-
-#: static/js/zamboni/buttons.js:341
-msgid "Works with {app} {min} - {max}"
-msgstr ""
-
-#: static/js/zamboni/buttons.js:343
-msgid "View other versions"
-msgstr ""
-
-#: static/js/zamboni/buttons.js:391
-msgid "Only with Firefox — Get Firefox Now!"
-msgstr ""
-
-#: static/js/zamboni/buttons.js:507 static/js/zamboni/mobile/buttons.js:43
-msgid "Sorry, you need a Mozilla-based browser (such as Firefox) to install a search plugin."
-msgstr ""
-
-#: static/js/zamboni/collections.js:229
-msgid "Adding to Favorites&hellip;"
-msgstr ""
-
-#: static/js/zamboni/collections.js:232
-msgid "Removing Favorite&hellip;"
-msgstr ""
-
-#: static/js/zamboni/collections.js:235
-msgid "Add to Favorites"
-msgstr ""
-
-#: static/js/zamboni/collections.js:238
-msgid "Remove from Favorites"
-msgstr ""
-
-#: static/js/zamboni/collections.js:303
-msgid "Pending"
-msgstr ""
-
-#: static/js/zamboni/collections.js:304
-msgid "Add a comment"
-msgstr ""
-
-#: static/js/zamboni/collections.js:304
-msgid "Comment"
-msgstr ""
-
-#: static/js/zamboni/collections.js:305
-msgid "Remove this add-on from the collection"
-msgstr ""
-
-#: static/js/zamboni/collections.js:305 static/js/zamboni/collections.js:334
-msgid "Remove"
-msgstr ""
-
-#: static/js/zamboni/collections.js:334
-msgid "Remove this user as a contributor"
-msgstr ""
-
-#: static/js/zamboni/collections.js:346
-msgid "An email address is required."
-msgstr ""
-
-#: static/js/zamboni/collections.js:364
-msgid "You cannot add yourself as a contributor."
-msgstr ""
-
-#: static/js/zamboni/collections.js:366
-msgid "You have already added that user."
-msgstr ""
-
-#: static/js/zamboni/collections.js:573
-msgid "Add to favorites"
-msgstr ""
-
-#: static/js/zamboni/collections.js:577
-msgid "Remove from favorites"
-msgstr ""
-
-#: static/js/zamboni/collections.js:604
-msgid "Stop following"
-msgstr ""
-
-#: static/js/zamboni/devhub.js:110
+#: static/js/zamboni/devhub-all.js:1289 static/js/zamboni/devhub-min.js:1 static/js/zamboni/devhub.js:110
 msgid "Your browser does not support the video tag"
 msgstr ""
 
-#: static/js/zamboni/devhub.js:371
+#: static/js/zamboni/devhub-all.js:1550 static/js/zamboni/devhub-min.js:1 static/js/zamboni/devhub.js:371
 msgid "Changes Saved"
 msgstr ""
 
-#: static/js/zamboni/devhub.js:387
+#: static/js/zamboni/devhub-all.js:1566 static/js/zamboni/devhub-min.js:1 static/js/zamboni/devhub.js:387
 msgid "Enter a new author's email address"
 msgstr ""
 
-#: static/js/zamboni/devhub.js:536
+#: static/js/zamboni/devhub-all.js:1715 static/js/zamboni/devhub-min.js:1 static/js/zamboni/devhub.js:536
 msgid "There was an error uploading your file."
 msgstr ""
 
-#: static/js/zamboni/devhub.js:681
+#: static/js/zamboni/devhub-all.js:1860 static/js/zamboni/devhub-min.js:1 static/js/zamboni/devhub.js:681
 msgid "{files} file"
 msgid_plural "{files} files"
 msgstr[0] ""
 msgstr[1] ""
 
-#: static/js/zamboni/devhub.js:684
+#: static/js/zamboni/devhub-all.js:1863 static/js/zamboni/devhub-min.js:1 static/js/zamboni/devhub.js:684
 msgid "{reviews} user review"
 msgid_plural "{reviews} user reviews"
 msgstr[0] ""
 msgstr[1] ""
 
-#: static/js/zamboni/devhub.js:796
+#: static/js/zamboni/devhub-all.js:1975 static/js/zamboni/devhub-min.js:2 static/js/zamboni/devhub.js:796
 msgid "Learn more"
 msgstr ""
 
-#: static/js/zamboni/devhub.js:800
+#: static/js/zamboni/devhub-all.js:1979 static/js/zamboni/devhub-min.js:2 static/js/zamboni/devhub.js:800
 msgid "Example"
 msgstr ""
 
-#: static/js/zamboni/devhub.js:1130
+#: static/js/zamboni/devhub-all.js:2309 static/js/zamboni/devhub-min.js:2 static/js/zamboni/devhub.js:1130
 msgid "Image changes being processed"
 msgstr ""
 
-#: static/js/zamboni/devhub.js:1280
+#: static/js/zamboni/devhub-all.js:2459 static/js/zamboni/devhub-min.js:2 static/js/zamboni/devhub.js:1280
 msgid "Must be a valid e-mail address."
+msgstr ""
+
+#: static/js/zamboni/devhub-all.js:2613 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:80
+msgid "All tests passed successfully."
+msgstr ""
+
+#: static/js/zamboni/devhub-all.js:2616 static/js/zamboni/devhub-all.js:3011 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:83 static/js/zamboni/validator.js:478
+msgid "These tests were not run."
+msgstr ""
+
+#: static/js/zamboni/devhub-all.js:2664 static/js/zamboni/devhub-all.js:2677 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:131 static/js/zamboni/validator.js:144
+msgid "Tests"
+msgstr ""
+
+#: static/js/zamboni/devhub-all.js:2779 static/js/zamboni/devhub-all.js:3108 static/js/zamboni/devhub-all.js:3127 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:246
+#: static/js/zamboni/validator.js:575 static/js/zamboni/validator.js:594
+msgid "Error"
+msgstr ""
+
+#: static/js/zamboni/devhub-all.js:2780 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:247
+msgid "Warning"
+msgstr ""
+
+#: static/js/zamboni/devhub-all.js:2794 static/js/zamboni/devhub-min.js:2 static/js/zamboni/files-all.js:5657 static/js/zamboni/files-min.js:3 static/js/zamboni/files.js:411
+#: static/js/zamboni/validator.js:261
+msgid "Ignore this message in future updates"
+msgstr ""
+
+#: static/js/zamboni/devhub-all.js:2817 static/js/zamboni/devhub-min.js:2 static/js/zamboni/files-all.js:5663 static/js/zamboni/files-min.js:3 static/js/zamboni/files.js:417
+#: static/js/zamboni/validator.js:284
+msgid "Severity for automated signing:"
+msgstr ""
+
+#: static/js/zamboni/devhub-all.js:2832 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:299
+msgid "Suggestions for passing automated signing:"
+msgstr ""
+
+#: static/js/zamboni/devhub-all.js:2920 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:387
+msgid "Compatibility Tests"
+msgstr ""
+
+#: static/js/zamboni/devhub-all.js:2999 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:466
+msgid "Add-on failed validation."
+msgstr ""
+
+#: static/js/zamboni/devhub-all.js:3001 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:468
+msgid "Add-on passed validation."
+msgstr ""
+
+#: static/js/zamboni/devhub-all.js:3014 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:481
+msgid "{0} error"
+msgid_plural "{0} errors"
+msgstr[0] ""
+msgstr[1] ""
+
+#: static/js/zamboni/devhub-all.js:3016 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:483
+msgid "{0} warning"
+msgid_plural "{0} warnings"
+msgstr[0] ""
+msgstr[1] ""
+
+#: static/js/zamboni/devhub-all.js:3018 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:485
+msgid "{0} notice"
+msgid_plural "{0} notices"
+msgstr[0] ""
+msgstr[1] ""
+
+#: static/js/zamboni/devhub-all.js:3110 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:577
+msgid "Validation task could not complete or completed with errors"
+msgstr ""
+
+#: static/js/zamboni/devhub-all.js:3128 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:595
+msgid "Internal server error"
 msgstr ""
 
 #: static/js/zamboni/devhub_search.js:8
 msgid "No results found."
 msgstr ""
 
-#: static/js/zamboni/editors.js:121
+#: static/js/zamboni/editors-all.js:15402 static/js/zamboni/editors-min.js:4 static/js/zamboni/editors.js:121
 msgid "{name} was viewing this page first."
 msgstr ""
 
-#: static/js/zamboni/editors.js:171
+#: static/js/zamboni/editors-all.js:15452 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:171
 msgid "Receipt checked by app."
 msgstr ""
 
-#: static/js/zamboni/editors.js:173
+#: static/js/zamboni/editors-all.js:15454 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:173
 msgid "Receipt was not checked by app."
 msgstr ""
 
-#: static/js/zamboni/editors.js:244
+#: static/js/zamboni/editors-all.js:15525 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:244
 msgid "{name} was viewing this add-on first."
 msgstr ""
 
-#: static/js/zamboni/editors.js:255
+#: static/js/zamboni/editors-all.js:15536 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:255
 msgid "Loading&hellip;"
 msgstr ""
 
-#: static/js/zamboni/editors.js:260
+#: static/js/zamboni/editors-all.js:15541 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:260
 msgid "Version Notes"
 msgstr ""
 
-#: static/js/zamboni/editors.js:265
+#: static/js/zamboni/editors-all.js:15546 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:265
 msgid "Notes for Reviewers"
 msgstr ""
 
-#: static/js/zamboni/editors.js:270
+#: static/js/zamboni/editors-all.js:15551 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:270
 msgid "No version notes found"
 msgstr ""
 
-#: static/js/zamboni/editors.js:330
+#: static/js/zamboni/editors-all.js:15611 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:330
 msgid "Average Reviews"
 msgstr ""
 
-#: static/js/zamboni/editors.js:386
+#: static/js/zamboni/editors-all.js:15667 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:386
 msgid "Number of Reviews"
 msgstr ""
 
-#: static/js/zamboni/editors.js:445
+#: static/js/zamboni/editors-all.js:15726 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:445
 msgid "Error loading translation"
 msgstr ""
 
-#: static/js/zamboni/files.js:411 static/js/zamboni/validator.js:261
-msgid "Ignore this message in future updates"
-msgstr ""
-
-#: static/js/zamboni/files.js:417 static/js/zamboni/validator.js:284
-msgid "Severity for automated signing:"
-msgstr ""
-
-#: static/js/zamboni/global.js:410
-msgid "Loading..."
-msgstr ""
-
-#. L10n: {0} is the number of characters left.
-#: static/js/zamboni/global.js:474
-msgid "<b>{0}</b> character left."
-msgid_plural "<b>{0}</b> characters left."
-msgstr[0] ""
-msgstr[1] ""
-
-#: static/js/zamboni/init.js:28
-msgid "This feature is temporarily disabled while we perform website maintenance. Please check back a little later."
-msgstr ""
-
-#: static/js/zamboni/l10n.js:45
-msgid "Remove this localization"
-msgstr ""
-
-#: static/js/zamboni/password-strength.js:20
-msgid "Password strength:"
-msgstr ""
-
-#: static/js/zamboni/password-strength.js:26
-msgid "At least {0} character left."
-msgid_plural "At least {0} characters left."
-msgstr[0] ""
-msgstr[1] ""
-
-#: static/js/zamboni/themes_review.js:176
-msgid "Requested Info"
-msgstr ""
-
-#: static/js/zamboni/themes_review.js:177
-msgid "Flagged"
-msgstr ""
-
-#: static/js/zamboni/themes_review.js:178
-msgid "Duplicate"
-msgstr ""
-
-#: static/js/zamboni/themes_review.js:179
-msgid "Rejected"
-msgstr ""
-
-#: static/js/zamboni/themes_review.js:180
-msgid "Approved"
-msgstr ""
-
-#: static/js/zamboni/themes_review.js:424
-msgid "No results found"
-msgstr ""
-
-#: static/js/zamboni/themes_review_templates.js:31
+#: static/js/zamboni/editors-all.js:15975 static/js/zamboni/editors-min.js:5 static/js/zamboni/themes_review_templates.js:31
 msgid "Theme"
 msgstr ""
 
-#: static/js/zamboni/themes_review_templates.js:33
+#: static/js/zamboni/editors-all.js:15977 static/js/zamboni/editors-min.js:5 static/js/zamboni/themes_review_templates.js:33
 msgid "Reviewer"
 msgstr ""
 
-#: static/js/zamboni/themes_review_templates.js:35
+#: static/js/zamboni/editors-all.js:15979 static/js/zamboni/editors-min.js:5 static/js/zamboni/themes_review_templates.js:35
 msgid "Status"
 msgstr ""
 
-#: static/js/zamboni/validator.js:80
-msgid "All tests passed successfully."
+#: static/js/zamboni/editors-all.js:16196 static/js/zamboni/editors-min.js:5 static/js/zamboni/themes_review.js:176
+msgid "Requested Info"
 msgstr ""
 
-#: static/js/zamboni/validator.js:83 static/js/zamboni/validator.js:478
-msgid "These tests were not run."
+#: static/js/zamboni/editors-all.js:16197 static/js/zamboni/editors-min.js:5 static/js/zamboni/themes_review.js:177
+msgid "Flagged"
 msgstr ""
 
-#: static/js/zamboni/validator.js:131 static/js/zamboni/validator.js:144
-msgid "Tests"
+#: static/js/zamboni/editors-all.js:16198 static/js/zamboni/editors-min.js:5 static/js/zamboni/themes_review.js:178
+msgid "Duplicate"
 msgstr ""
 
-#: static/js/zamboni/validator.js:246 static/js/zamboni/validator.js:575 static/js/zamboni/validator.js:594
-msgid "Error"
+#: static/js/zamboni/editors-all.js:16199 static/js/zamboni/editors-min.js:5 static/js/zamboni/themes_review.js:179
+msgid "Rejected"
 msgstr ""
 
-#: static/js/zamboni/validator.js:247
-msgid "Warning"
+#: static/js/zamboni/editors-all.js:16200 static/js/zamboni/editors-min.js:5 static/js/zamboni/themes_review.js:180
+msgid "Approved"
 msgstr ""
 
-#: static/js/zamboni/validator.js:299
-msgid "Suggestions for passing automated signing:"
+#: static/js/zamboni/editors-all.js:16444 static/js/zamboni/editors-min.js:5 static/js/zamboni/themes_review.js:424
+msgid "No results found"
 msgstr ""
 
-#: static/js/zamboni/validator.js:387
-msgid "Compatibility Tests"
-msgstr ""
-
-#: static/js/zamboni/validator.js:466
-msgid "Add-on failed validation."
-msgstr ""
-
-#: static/js/zamboni/validator.js:468
-msgid "Add-on passed validation."
-msgstr ""
-
-#: static/js/zamboni/validator.js:481
-msgid "{0} error"
-msgid_plural "{0} errors"
-msgstr[0] ""
-msgstr[1] ""
-
-#: static/js/zamboni/validator.js:483
-msgid "{0} warning"
-msgid_plural "{0} warnings"
-msgstr[0] ""
-msgstr[1] ""
-
-#: static/js/zamboni/validator.js:485
-msgid "{0} notice"
-msgid_plural "{0} notices"
-msgstr[0] ""
-msgstr[1] ""
-
-#: static/js/zamboni/validator.js:577
-msgid "Validation task could not complete or completed with errors"
-msgstr ""
-
-#: static/js/zamboni/validator.js:595
-msgid "Internal server error"
-msgstr ""
-
-#: static/js/zamboni/mobile/buttons.js:52
+#: static/js/zamboni/mobile-all.js:15186 static/js/zamboni/mobile/buttons.js:52
 msgid "Not Updated for {0} {1}"
 msgstr ""
 
-#: static/js/zamboni/mobile/buttons.js:53
+#: static/js/zamboni/mobile-all.js:15187 static/js/zamboni/mobile/buttons.js:53
 msgid "Requires Newer Version of {0}"
 msgstr ""
 
-#: static/js/zamboni/mobile/buttons.js:54
+#: static/js/zamboni/mobile-all.js:15188 static/js/zamboni/mobile/buttons.js:54
 msgid "Unreviewed"
 msgstr ""
 
-#: static/js/zamboni/mobile/buttons.js:55
+#: static/js/zamboni/mobile-all.js:15189 static/js/zamboni/mobile/buttons.js:55
 msgid "Experimental <span>(Learn More)</span>"
 msgstr ""
 
-#: static/js/zamboni/mobile/buttons.js:56 static/js/zamboni/mobile/buttons.js:57
+#: static/js/zamboni/mobile-all.js:15190 static/js/zamboni/mobile-all.js:15191 static/js/zamboni/mobile/buttons.js:56 static/js/zamboni/mobile/buttons.js:57
 msgid "Not Available for {0}"
 msgstr ""
 
-#: static/js/zamboni/mobile/buttons.js:58
+#: static/js/zamboni/mobile-all.js:15192 static/js/zamboni/mobile/buttons.js:58
 msgid "Experimental"
 msgstr ""
 
-#: static/js/zamboni/mobile/buttons.js:59
+#: static/js/zamboni/mobile-all.js:15193 static/js/zamboni/mobile/buttons.js:59
 msgid "Themes Require Newer Version of {0}"
 msgstr ""
 
-#: static/js/zamboni/mobile/buttons.js:60
+#: static/js/zamboni/mobile-all.js:15194 static/js/zamboni/mobile/buttons.js:60
 msgid "Themes Require {0}"
 msgstr ""
 
-#: static/js/zamboni/mobile/buttons.js:105
+#: static/js/zamboni/mobile-all.js:15239 static/js/zamboni/mobile/buttons.js:105
 msgid "Installing..."
 msgstr ""
 
-#: static/js/zamboni/mobile/buttons.js:125
+#: static/js/zamboni/mobile-all.js:15259 static/js/zamboni/mobile/buttons.js:125
 msgid "This add-on has been preliminarily reviewed by Mozilla."
 msgstr ""
 
-#: static/js/zamboni/mobile/buttons.js:250
+#: static/js/zamboni/mobile-all.js:15384 static/js/zamboni/mobile/buttons.js:250
 msgid "Keep it"
 msgstr ""
 
-#: static/js/zamboni/mobile/general.js:344
+#: static/js/zamboni/mobile-all.js:16049 static/js/zamboni/mobile-min.js:6 static/js/zamboni/mobile/general.js:344
 msgid "You're trying it on!"
 msgstr ""
 
-#: static/js/zamboni/mobile/general.js:356
+#: static/js/zamboni/mobile-all.js:16061 static/js/zamboni/mobile-min.js:6 static/js/zamboni/mobile/general.js:356
 msgid "Added to Firefox"
 msgstr ""
-

--- a/locale/hu/LC_MESSAGES/django.po
+++ b/locale/hu/LC_MESSAGES/django.po
@@ -9,82 +9,72 @@
 # Kalman Kemenczy <kkemenczy@opensuse.org>, 2011, 2012, 2013.
 msgid ""
 msgstr ""
-"Project-Id-Version: addons\n"
+"Project-Id-Version:  addons\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2016-02-24 21:23+0000\n"
+"POT-Creation-Date: 2016-04-18 15:40+0000\n"
 "PO-Revision-Date: 2016-04-15 07:25+0000\n"
 "Last-Translator: Balázs Meskó <meskobalazs@gmail.com>\n"
 "Language-Team: Hungarian <kde-l10n-hu@kde.org>\n"
-"Language: hu\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 "Generated-By: Babel 2.2.0\n"
-"X-Generator: Pontoon\n"
 
-#: src/olympia/accounts/views.py:52
+#: src/olympia/accounts/views.py:54
 msgid "Your log in attempt could not be parsed. Please try again."
 msgstr "Belépési kísérlete nem értelmezhető. Kérjük, próbálja meg újra."
 
-#: src/olympia/accounts/views.py:54
+#: src/olympia/accounts/views.py:56
 msgid "Your Firefox Account could not be found. Please try again."
 msgstr "Firefox-fiókja nem található. Kérjük, próbálja meg újra."
 
-#: src/olympia/accounts/views.py:55
+#: src/olympia/accounts/views.py:57
 msgid "You could not be logged in. Please try again."
 msgstr "Bejelentkezése sikertelen volt. Kérjük, próbálja meg újra."
 
-#: src/olympia/accounts/views.py:57
+#: src/olympia/accounts/views.py:59
 msgid "Your account has already been migrated to Firefox Accounts."
 msgstr "Fiókja már migrálva lett a Firefox Fiókok szolgáltatásba."
 
-#: src/olympia/accounts/views.py:59
+#: src/olympia/accounts/views.py:61
 msgid "Your Firefox Account already exists on this site."
 msgstr "Már létezik Firefox-fiókja ezen az oldalon."
 
-#: src/olympia/accounts/views.py:108
+#: src/olympia/accounts/views.py:110
 msgid "Great job!"
 msgstr "Kitűnő!"
 
-#: src/olympia/accounts/views.py:109
+#: src/olympia/accounts/views.py:111
 msgid "You can now log in to Add-ons with your Firefox Account."
 msgstr "Most már Firefox-fiókjával bejelentkezhet a Kiegészítők oldalra."
 
-#: src/olympia/accounts/views.py:121
+#: src/olympia/accounts/views.py:123
 msgid "Need help?"
 msgstr "Segítségre van szüksége?"
 
-#: src/olympia/addons/buttons.py:180
+#: src/olympia/addons/buttons.py:177
 msgid "Download Now"
 msgstr "Letöltés most"
 
-#: src/olympia/addons/buttons.py:182
+#: src/olympia/addons/buttons.py:179
 msgid "Download"
 msgstr "Letöltés"
 
 #. L10n: please keep &nbsp; in the string so &rarr; does not wrap.
-#: src/olympia/addons/buttons.py:186
+#: src/olympia/addons/buttons.py:183
 msgid "Continue to Download&nbsp;&rarr;"
 msgstr "Tovább a letöltéshez&nbsp;&rarr;"
 
-#: src/olympia/addons/buttons.py:202 src/olympia/addons/helpers.py:35
-#: src/olympia/addons/views.py:319
-#: src/olympia/addons/templates/addons/impala/details.html:114
-#: src/olympia/addons/templates/addons/impala/listing/items.html:17
-#: src/olympia/addons/templates/addons/mobile/home.html:40
-#: src/olympia/amo/templates/amo/side_nav.html:6
-#: src/olympia/amo/templates/amo/side_nav.html:10
-#: src/olympia/amo/templates/amo/site_nav.html:2
-#: src/olympia/amo/templates/amo/site_nav.html:55
-#: src/olympia/bandwagon/views.py:95 src/olympia/browse/views.py:54
-#: src/olympia/browse/views.py:68 src/olympia/browse/views.py:235
-#: src/olympia/browse/templates/browse/impala/category_landing.html:22
+#: src/olympia/addons/buttons.py:199 src/olympia/addons/helpers.py:35 src/olympia/addons/views.py:333 src/olympia/addons/templates/addons/impala/details.html:111
+#: src/olympia/addons/templates/addons/impala/listing/items.html:17 src/olympia/addons/templates/addons/mobile/home.html:40 src/olympia/amo/templates/amo/side_nav.html:6
+#: src/olympia/amo/templates/amo/side_nav.html:10 src/olympia/amo/templates/amo/site_nav.html:2 src/olympia/amo/templates/amo/site_nav.html:53 src/olympia/bandwagon/views.py:95
+#: src/olympia/browse/views.py:54 src/olympia/browse/views.py:68 src/olympia/browse/views.py:202 src/olympia/browse/templates/browse/impala/category_landing.html:22
 #: src/olympia/browse/templates/browse/personas/mobile/category_landing.html:26
 msgid "Featured"
 msgstr "Kiemelt"
 
-#: src/olympia/addons/buttons.py:221
+#: src/olympia/addons/buttons.py:218
 msgid "Add to {0}"
 msgstr "Hozzáadás: {0}"
 
@@ -123,11 +113,8 @@ msgstr[1] "{0} címkével több az engedélyezettnél."
 
 #: src/olympia/addons/forms.py:117
 #, python-format
-msgid ""
-"All tags must be %s characters or less after invalid characters are removed."
-msgstr ""
-"A címkék hossza az eltávolított érvénytelen karaktereket követően maximum %s"
-" karakter lehet."
+msgid "All tags must be %s characters or less after invalid characters are removed."
+msgstr "A címkék hossza az eltávolított érvénytelen karaktereket követően maximum %s karakter lehet."
 
 #: src/olympia/addons/forms.py:121
 msgid "All tags must be at least {0} character."
@@ -135,47 +122,39 @@ msgid_plural "All tags must be at least {0} characters."
 msgstr[0] "A címkéknek legalább {0} karakterből kell állnia."
 msgstr[1] "A címkéknek legalább {0} karakterből kell állnia."
 
-#: src/olympia/addons/forms.py:234
-msgid ""
-"Categories cannot be changed while your add-on is featured for this "
-"application."
+#: src/olympia/addons/forms.py:238
+msgid "Categories cannot be changed while your add-on is featured for this application."
 msgstr "Láthatóság"
 
 #. L10n: {0} is the number of categories.
-#: src/olympia/addons/forms.py:238
+#: src/olympia/addons/forms.py:242
 msgid "You can have only {0} category."
 msgid_plural "You can have only {0} categories."
 msgstr[0] "Csak {0} kategóriája van."
 msgstr[1] "Csak {0} kategóriája van."
 
-#: src/olympia/addons/forms.py:246
-msgid ""
-"The miscellaneous category cannot be combined with additional categories."
+#: src/olympia/addons/forms.py:250
+msgid "The miscellaneous category cannot be combined with additional categories."
 msgstr "Az egyéb kategória nem vonható össze más kategóriákkal."
 
-#: src/olympia/addons/forms.py:369
+#: src/olympia/addons/forms.py:374
 #, python-format
-msgid ""
-"Before changing your default locale you must have a name, summary, and "
-"description in that locale. You are missing %s."
-msgstr ""
-"Az alapértelmezett nyelv módosítása előtt meg kell adnia a bevét, "
-"összefoglalóját és a leírást az adott nyelven. A következőt hagyta ki: %s."
+msgid "Before changing your default locale you must have a name, summary, and description in that locale. You are missing %s."
+msgstr "Az alapértelmezett nyelv módosítása előtt meg kell adnia a bevét, összefoglalóját és a leírást az adott nyelven. A következőt hagyta ki: %s."
 
-#: src/olympia/addons/forms.py:484 src/olympia/addons/forms.py:575
+#: src/olympia/addons/forms.py:455 src/olympia/addons/forms.py:546
 msgid "A license must be selected."
 msgstr "Ki kell választani a licencet."
 
-#: src/olympia/addons/forms.py:556
+#: src/olympia/addons/forms.py:527
 msgid "Give Your Theme a Name."
 msgstr "Adjon egy nevet a témának."
 
-#: src/olympia/addons/forms.py:562
-#: src/olympia/devhub/templates/devhub/personas/submit.html:53
+#: src/olympia/addons/forms.py:533 src/olympia/devhub/templates/devhub/personas/submit.html:53
 msgid "Describe your Theme."
 msgstr "Írja le a témát."
 
-#: src/olympia/addons/forms.py:704
+#: src/olympia/addons/forms.py:675
 msgid "Enter a new author's email address"
 msgstr "Írjon be egy új szerzői e-mail címet"
 
@@ -183,48 +162,39 @@ msgstr "Írjon be egy új szerzői e-mail címet"
 msgid "Not Reviewed"
 msgstr "Nem értékelt"
 
-#: src/olympia/addons/models.py:301
+#: src/olympia/addons/models.py:298
 msgid "Users have the option of contributing more or less than this amount."
 msgstr "A felhasználóknak lehetőségük van ennél többet vagy kevesebbet adni."
 
-#: src/olympia/addons/models.py:309
-msgid ""
-"Users will always be asked in the Add-ons Manager (Firefox 4 and above)"
+#: src/olympia/addons/models.py:306
+msgid "Users will always be asked in the Add-ons Manager (Firefox 4 and above). Only applies to desktop."
 msgstr ""
-"A Kiegészítőkezelőben a felhasználókat mindig megkérdezzük (a Firefox 4 "
-"verziótól kezdődően)"
 
 # Column name in a table.
-#: src/olympia/addons/models.py:1804
-#: src/olympia/addons/templates/addons/details_box.html:55
-#: src/olympia/devhub/templates/devhub/index.html:92
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:102
+#: src/olympia/addons/models.py:1802 src/olympia/addons/templates/addons/details_box.html:55 src/olympia/devhub/templates/devhub/index.html:92
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:89
 msgid "Listed"
 msgstr "Felsorolva"
 
-#: src/olympia/addons/views.py:320
-#: src/olympia/browse/templates/browse/personas/mobile/category_landing.html:27
+#: src/olympia/addons/views.py:334 src/olympia/browse/templates/browse/personas/mobile/category_landing.html:27
 msgid "Popular"
 msgstr "Népszerű"
 
-#: src/olympia/addons/views.py:321 src/olympia/browse/views.py:238
-#: src/olympia/browse/views.py:280 src/olympia/browse/views.py:482
+#: src/olympia/addons/views.py:335 src/olympia/browse/views.py:205 src/olympia/browse/views.py:247 src/olympia/browse/views.py:449
 msgid "Recently Added"
 msgstr "Nemrég hozzáadott"
 
-#: src/olympia/addons/views.py:322 src/olympia/bandwagon/views.py:99
-#: src/olympia/browse/views.py:60 src/olympia/browse/views.py:71
-#: src/olympia/search/forms.py:16 src/olympia/search/forms.py:91
+#: src/olympia/addons/views.py:336 src/olympia/bandwagon/views.py:99 src/olympia/browse/views.py:60 src/olympia/browse/views.py:71 src/olympia/search/forms.py:16 src/olympia/search/forms.py:91
 msgid "Recently Updated"
 msgstr "Legutóbb frissítve"
 
-#. l10n: {0} is the addon name
 # %1 is an add-on name.
-#: src/olympia/addons/views.py:520
+#. l10n: {0} is the addon name
+#: src/olympia/addons/views.py:534
 msgid "Contribution for {0}"
 msgstr "Adomány ennek: {0}"
 
-#: src/olympia/addons/views.py:613
+#: src/olympia/addons/views.py:627
 msgid "Abuse reported."
 msgstr "Visszaélést jelentettek."
 
@@ -232,114 +202,70 @@ msgstr "Visszaélést jelentettek."
 msgid "My add-on doesn't fit into any of the categories"
 msgstr "A kiegészítő nem illik egyik kategóriába sem"
 
-#: src/olympia/addons/templates/addons/button.html:27
-#: src/olympia/addons/templates/addons/impala/button.html:11
-#: src/olympia/addons/templates/addons/mobile/button.html:11
+#: src/olympia/addons/templates/addons/button.html:27 src/olympia/addons/templates/addons/impala/button.html:11 src/olympia/addons/templates/addons/mobile/button.html:11
 msgid "No compatible versions"
 msgstr "Nincs kompatibilis verzió"
 
-#: src/olympia/addons/templates/addons/button.html:35
-#: src/olympia/addons/templates/addons/impala/button.html:19
+#: src/olympia/addons/templates/addons/button.html:35 src/olympia/addons/templates/addons/impala/button.html:19
 msgid "Added to Mobile"
 msgstr "Hozzáadva Mobile-hoz"
 
-#: src/olympia/addons/templates/addons/button.html:37
-#: src/olympia/addons/templates/addons/impala/button.html:21
+#: src/olympia/addons/templates/addons/button.html:37 src/olympia/addons/templates/addons/impala/button.html:21
 msgid "Add to Mobile"
 msgstr "Hozzáadás Mobile-hoz"
 
 #. {0} is a platform name like Windows or Mac OS X.
-#: src/olympia/addons/templates/addons/button.html:66
-#: src/olympia/addons/templates/addons/includes/install_button.html:19
+#: src/olympia/addons/templates/addons/button.html:66 src/olympia/addons/templates/addons/includes/install_button.html:19
 msgid "for {0}"
 msgstr "{0} operációs rendszerhez"
 
-#: src/olympia/addons/templates/addons/button.html:82
-#: src/olympia/addons/templates/addons/mobile/button.html:23
+#: src/olympia/addons/templates/addons/button.html:82 src/olympia/addons/templates/addons/mobile/button.html:23
 msgid "View privacy policy"
 msgstr "Adatvédelmi nyilatkozat megtekintése"
 
-#: src/olympia/addons/templates/addons/button.html:87
-#: src/olympia/addons/templates/addons/details_box.html:133
-#: src/olympia/addons/templates/addons/mobile/button.html:28
+#: src/olympia/addons/templates/addons/button.html:87 src/olympia/addons/templates/addons/details_box.html:133 src/olympia/addons/templates/addons/mobile/button.html:28
 #: src/olympia/discovery/templates/discovery/addons/detail.html:28
 msgid "View End-User License Agreement"
 msgstr "Végfelhasználói licencszerződés megjelenítése"
 
-#: src/olympia/addons/templates/addons/button.html:92
-#: src/olympia/addons/templates/addons/impala/button.html:54
+#: src/olympia/addons/templates/addons/button.html:92 src/olympia/addons/templates/addons/impala/button.html:54
 #, python-format
-msgid ""
-"This add-on has not been reviewed by Mozilla. <a href=\"%(url)s\">Learn "
-"more</a>"
-msgstr ""
-"Ezt a kiegészítőt nem értékelte a Mozilla. <a href=\"%(url)s\">Tudjon meg "
-"többet</a>"
+msgid "This add-on has not been reviewed by Mozilla. <a href=\"%(url)s\">Learn more</a>"
+msgstr "Ezt a kiegészítőt nem értékelte a Mozilla. <a href=\"%(url)s\">Tudjon meg többet</a>"
 
-#: src/olympia/addons/templates/addons/button.html:97
-#: src/olympia/addons/templates/addons/impala/button.html:60
+#: src/olympia/addons/templates/addons/button.html:97 src/olympia/addons/templates/addons/impala/button.html:60
 #, python-format
-msgid ""
-"This add-on has been preliminarily reviewed by Mozilla. <a "
-"href=\"%(url)s\">Learn more</a>"
-msgstr ""
-"Ezt a kiegészítőt előzetesen értékelte a Mozilla. <a href=\"%(url)s\">Tudjon"
-" meg többet</a>"
+msgid "This add-on has been preliminarily reviewed by Mozilla. <a href=\"%(url)s\">Learn more</a>"
+msgstr "Ezt a kiegészítőt előzetesen értékelte a Mozilla. <a href=\"%(url)s\">Tudjon meg többet</a>"
 
-#: src/olympia/addons/templates/addons/contribution.html:11
-#: src/olympia/addons/templates/addons/impala/developers.html:44
-msgid ""
-"The developer of this add-on asks that you help support its continued "
-"development by making a small contribution."
+#: src/olympia/addons/templates/addons/contribution.html:11 src/olympia/addons/templates/addons/impala/developers.html:44
+msgid "The developer of this add-on asks that you help support its continued development by making a small contribution."
 msgstr "A kiegészítő készítője a támogatását kéri a fejlesztés folytatásához."
 
 #: src/olympia/addons/templates/addons/contribution.html:14
 #, python-format
-msgid ""
-"The developer of this add-on asks that you show your support by making a "
-"donation to the <a href=\"%(charity_url)s\">%(charity_name)s</a>."
-msgstr ""
-"A kiegészítő fejlesztője kéri, hogy adománnyal támogassa a(z) <a "
-"href=\"%(charity_url)s\">%(charity_name)s</a> munkáját."
+msgid "The developer of this add-on asks that you show your support by making a donation to the <a href=\"%(charity_url)s\">%(charity_name)s</a>."
+msgstr "A kiegészítő fejlesztője kéri, hogy adománnyal támogassa a(z) <a href=\"%(charity_url)s\">%(charity_name)s</a> munkáját."
 
 #: src/olympia/addons/templates/addons/contribution.html:19
 #, python-format
-msgid ""
-"The developer of this add-on asks that you show your support by making a "
-"small contribution to <a href=\"%(charity_url)s\">%(charity_name)s</a>."
-msgstr ""
-"A kiegészítő fejlesztője adományt kér a(z) <a "
-"href=\"%(charity_url)s\">%(charity_name)s</a> munkájának támogatásához."
+msgid "The developer of this add-on asks that you show your support by making a small contribution to <a href=\"%(charity_url)s\">%(charity_name)s</a>."
+msgstr "A kiegészítő fejlesztője adományt kér a(z) <a href=\"%(charity_url)s\">%(charity_name)s</a> munkájának támogatásához."
 
-#: src/olympia/addons/templates/addons/contribution.html:30
-#: src/olympia/addons/templates/addons/impala/contribution.html:18
-#: src/olympia/templates/menu_links.html:25
+#: src/olympia/addons/templates/addons/contribution.html:30 src/olympia/addons/templates/addons/impala/contribution.html:18 src/olympia/templates/menu_links.html:25
 msgid "Contribute"
 msgstr "Adományozás"
 
-#. Click Contribute button OR Install button
 # This is a separator between the graphical [contribute] button and the
 # graphical [download now] button
-#: src/olympia/addons/templates/addons/contribution.html:34
-#: src/olympia/addons/templates/addons/report_abuse.html:26
-#: src/olympia/addons/templates/addons/impala/contribution.html:32
-#: src/olympia/devhub/templates/devhub/addons/ajax_compat_update.html:36
-#: src/olympia/devhub/templates/devhub/addons/profile.html:44
-#: src/olympia/devhub/templates/devhub/addons/edit/admin.html:101
-#: src/olympia/devhub/templates/devhub/addons/edit/basic.html:152
-#: src/olympia/devhub/templates/devhub/addons/edit/details.html:85
-#: src/olympia/devhub/templates/devhub/addons/edit/support.html:67
-#: src/olympia/devhub/templates/devhub/addons/edit/technical.html:166
-#: src/olympia/devhub/templates/devhub/addons/forms_shared/media.html:149
-#: src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:44
-#: src/olympia/devhub/templates/devhub/versions/add_file_modal.html:78
-#: src/olympia/devhub/templates/devhub/versions/edit.html:139
-#: src/olympia/devhub/templates/devhub/versions/list.html:242
-#: src/olympia/devhub/templates/devhub/versions/list.html:276
-#: src/olympia/devhub/templates/devhub/versions/list.html:317
-#: src/olympia/devhub/templates/devhub/versions/list.html:351
-#: src/olympia/reviews/templates/reviews/edit_review.html:16
-#: src/olympia/translations/templates/translations/trans-menu.html:50
+#. Click Contribute button OR Install button
+#: src/olympia/addons/templates/addons/contribution.html:34 src/olympia/addons/templates/addons/report_abuse.html:26 src/olympia/addons/templates/addons/impala/contribution.html:32
+#: src/olympia/devhub/templates/devhub/addons/ajax_compat_update.html:36 src/olympia/devhub/templates/devhub/addons/profile.html:44 src/olympia/devhub/templates/devhub/addons/edit/admin.html:101
+#: src/olympia/devhub/templates/devhub/addons/edit/basic.html:152 src/olympia/devhub/templates/devhub/addons/edit/details.html:85 src/olympia/devhub/templates/devhub/addons/edit/support.html:67
+#: src/olympia/devhub/templates/devhub/addons/edit/technical.html:166 src/olympia/devhub/templates/devhub/addons/forms_shared/media.html:149
+#: src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:43 src/olympia/devhub/templates/devhub/versions/add_file_modal.html:58 src/olympia/devhub/templates/devhub/versions/edit.html:139
+#: src/olympia/devhub/templates/devhub/versions/list.html:239 src/olympia/devhub/templates/devhub/versions/list.html:281 src/olympia/devhub/templates/devhub/versions/list.html:315
+#: src/olympia/devhub/templates/devhub/versions/list.html:349 src/olympia/reviews/templates/reviews/edit_review.html:16 src/olympia/translations/templates/translations/trans-menu.html:50
 #: src/olympia/translations/templates/translations/trans-menu.html:62
 msgid "or"
 msgstr "vagy"
@@ -348,41 +274,23 @@ msgstr "vagy"
 msgid "Suggested Contribution: {0}"
 msgstr "Javasolt támogatás: {0}"
 
-#: src/olympia/addons/templates/addons/contribution.html:48
-#: src/olympia/amo/templates/amo/recaptcha.html:5
-#: src/olympia/versions/templates/versions/version.html:52
+#: src/olympia/addons/templates/addons/contribution.html:48 src/olympia/amo/templates/amo/recaptcha.html:5 src/olympia/versions/templates/versions/version.html:52
 msgid "What's this?"
 msgstr "Mi ez?"
 
 #: src/olympia/addons/templates/addons/contribution.html:63
 #, python-format
-msgid ""
-"The developer of this add-on would like you to consider making a donation to"
-" the <a href=\"%(charity_url)s\">%(charity_name)s</a> if you enjoy using it."
-msgstr ""
-"A kiegészítő fejlesztője kéri, hogy amennyiben elégedett munkájával, "
-"támogassa a(z) <a href=\"%(charity_url)s\">%(charity_name)s</a> szervezet "
-"munkáját."
+msgid "The developer of this add-on would like you to consider making a donation to the <a href=\"%(charity_url)s\">%(charity_name)s</a> if you enjoy using it."
+msgstr "A kiegészítő fejlesztője kéri, hogy amennyiben elégedett munkájával, támogassa a(z) <a href=\"%(charity_url)s\">%(charity_name)s</a> szervezet munkáját."
 
 #: src/olympia/addons/templates/addons/contribution.html:69
 #, python-format
-msgid ""
-"The developer of this add-on would like you to consider making a small "
-"contribution to <a href=\"%(charity_url)s\">%(charity_name)s</a> if you "
-"enjoy using it."
-msgstr ""
-"A kiegészítő fejlesztője kéri, hogy amennyiben elégedett munkájával, "
-"támogassa azt: <a href=\"%(charity_url)s\">%(charity_name)s</a>."
+msgid "The developer of this add-on would like you to consider making a small contribution to <a href=\"%(charity_url)s\">%(charity_name)s</a> if you enjoy using it."
+msgstr "A kiegészítő fejlesztője kéri, hogy amennyiben elégedett munkájával, támogassa azt: <a href=\"%(charity_url)s\">%(charity_name)s</a>."
 
 #: src/olympia/addons/templates/addons/contribution.html:76
-msgid ""
-"Mozilla is committed to supporting a vibrant and healthy developer "
-"ecosystem. Your optional contribution helps sustain further development of "
-"this add-on."
-msgstr ""
-"A Mozilla elkötelezett a pezsgő és egészséges fejlesztői ökoszisztéma "
-"támogatása iránt. Az önkéntes adománya segít folytatni a kiegészítő "
-"fejlesztését."
+msgid "Mozilla is committed to supporting a vibrant and healthy developer ecosystem. Your optional contribution helps sustain further development of this add-on."
+msgstr "A Mozilla elkötelezett a pezsgő és egészséges fejlesztői ökoszisztéma támogatása iránt. Az önkéntes adománya segít folytatni a kiegészítő fejlesztését."
 
 #: src/olympia/addons/templates/addons/contributions_lightbox.html:5
 msgid "Make a Contribution"
@@ -390,36 +298,24 @@ msgstr "Közreműködés"
 
 #: src/olympia/addons/templates/addons/contributions_lightbox.html:9
 #, python-format
-msgid ""
-"Help support the continued development of <strong>%(addon_name)s</strong> by"
-" making a small contribution through <a href=\"%(paypal_url)s\">PayPal</a>."
-msgstr ""
-"Támogassa a(z) <strong>%(addon_name)s</strong> kiegészítő folyamatos "
-"fejlesztését <a href=\"%(paypal_url)s\">Paypal</a>on keresztüli "
-"hozzájárulással."
+msgid "Help support the continued development of <strong>%(addon_name)s</strong> by making a small contribution through <a href=\"%(paypal_url)s\">PayPal</a>."
+msgstr "Támogassa a(z) <strong>%(addon_name)s</strong> kiegészítő folyamatos fejlesztését <a href=\"%(paypal_url)s\">Paypal</a>on keresztüli hozzájárulással."
 
 #: src/olympia/addons/templates/addons/contributions_lightbox.html:15
 #, python-format
-msgid ""
-"To show your support for <b>%(addon_name)s</b>, the developer asks that you "
-"make a donation to the <a href=\"%(charity_url)s\">%(charity_name)s</a> "
-"through <a href=\"%(paypal_url)s\">PayPal</a>."
+msgid "To show your support for <b>%(addon_name)s</b>, the developer asks that you make a donation to the <a href=\"%(charity_url)s\">%(charity_name)s</a> through <a href=\"%(paypal_url)s\">PayPal</a>."
 msgstr ""
-"A fejlesztő adományt kér a(z) <b>%(addon_name)s</b> kiegészítő "
-"fejlesztéséért, <a href=\"%(paypal_url)s\">Paypalon</a> keresztül a(z) <a "
-"href=\"%(charity_url)s\">%(charity_name)s</a> szervezet számára."
+"A fejlesztő adományt kér a(z) <b>%(addon_name)s</b> kiegészítő fejlesztéséért, <a href=\"%(paypal_url)s\">Paypalon</a> keresztül a(z) <a href=\"%(charity_url)s\">%(charity_name)s</a> szervezet "
+"számára."
 
 #: src/olympia/addons/templates/addons/contributions_lightbox.html:21
 #, python-format
 msgid ""
-"To show your support for <b>%(addon_name)s</b>, the developer asks that you "
-"make a small contribution to <a "
-"href=\"%(charity_url)s\">%(charity_name)s</a> through <a "
+"To show your support for <b>%(addon_name)s</b>, the developer asks that you make a small contribution to <a href=\"%(charity_url)s\">%(charity_name)s</a> through <a "
 "href=\"%(paypal_url)s\">PayPal</a>."
 msgstr ""
-"A fejlesztő adományt kér a(z) <b>%(addon_name)s</b> kiegészítő "
-"fejlesztéséért, <a href=\"%(paypal_url)s\">Paypalon</a> keresztül a(z) <a "
-"href=\"%(charity_url)s\">%(charity_name)s</a> szervezet számára."
+"A fejlesztő adományt kér a(z) <b>%(addon_name)s</b> kiegészítő fejlesztéséért, <a href=\"%(paypal_url)s\">Paypalon</a> keresztül a(z) <a href=\"%(charity_url)s\">%(charity_name)s</a> szervezet "
+"számára."
 
 #: src/olympia/addons/templates/addons/contributions_lightbox.html:30
 msgid "How much would you like to contribute?"
@@ -442,8 +338,7 @@ msgstr "A támogatás mértéke szám legyen."
 msgid "A one-time suggested contribution of {0}"
 msgstr "Egyszeri javasolt támogatás: {0}"
 
-#. {0} is a currency symbol (e.g., $),                    {1} is an amount
-#. input
+#. {0} is a currency symbol (e.g., $),                    {1} is an amount input
 #. field
 #: src/olympia/addons/templates/addons/contributions_lightbox.html:64
 msgid "A one-time contribution of {0} {1}"
@@ -453,11 +348,8 @@ msgstr "Egyszeri támogatás: {0} {1}"
 msgid "Leave a comment or request with your contribution."
 msgstr "Írjon üzenetet vagy kérést a támogatásával kapcsolatban."
 
-#: src/olympia/addons/templates/addons/contributions_lightbox.html:74
-#: src/olympia/bandwagon/templates/bandwagon/ajax_new.html:20
-#: src/olympia/bandwagon/templates/bandwagon/includes/addedit.html:37
-#: src/olympia/reviews/templates/reviews/mobile/add_form.html:13
-#: src/olympia/templates/includes/forms.html:10
+#: src/olympia/addons/templates/addons/contributions_lightbox.html:74 src/olympia/bandwagon/templates/bandwagon/ajax_new.html:20 src/olympia/bandwagon/templates/bandwagon/includes/addedit.html:37
+#: src/olympia/reviews/templates/reviews/mobile/add_form.html:13 src/olympia/templates/includes/forms.html:10
 msgid "(optional)"
 msgstr "(opcionális)"
 
@@ -477,36 +369,27 @@ msgstr "Köszönöm, nem"
 msgid "Contribution made, thank you."
 msgstr "Adomány elküldve, köszönjük."
 
-#: src/olympia/addons/templates/addons/details_box.html:10
-#: src/olympia/discovery/templates/discovery/addons/detail.html:19
+#: src/olympia/addons/templates/addons/details_box.html:10 src/olympia/discovery/templates/discovery/addons/detail.html:19
 msgid "No restart required"
 msgstr "Nem szükséges újraindítás"
 
 #. This is a caption for a table. {0} is an add-on name.
-#: src/olympia/addons/templates/addons/details_box.html:26
-#: src/olympia/addons/templates/addons/includes/persona.html:9
+#: src/olympia/addons/templates/addons/details_box.html:26 src/olympia/addons/templates/addons/includes/persona.html:9
 msgid "Add-on Information for {0}"
 msgstr "{0} kiegészítő információ"
 
-#: src/olympia/addons/templates/addons/details_box.html:30
-#: src/olympia/addons/templates/addons/persona_detail_table.html:3
-#: src/olympia/addons/templates/addons/mobile/details.html:63
-#: src/olympia/addons/templates/addons/mobile/persona_detail_table.html:7
-#: src/olympia/browse/views.py:459 src/olympia/devhub/views.py:75
+#: src/olympia/addons/templates/addons/details_box.html:30 src/olympia/addons/templates/addons/persona_detail_table.html:3 src/olympia/addons/templates/addons/mobile/details.html:63
+#: src/olympia/addons/templates/addons/mobile/persona_detail_table.html:7 src/olympia/browse/views.py:426 src/olympia/devhub/views.py:74
 msgid "Updated"
 msgstr "Frissítve"
 
-#: src/olympia/addons/templates/addons/details_box.html:38
-#: src/olympia/addons/templates/addons/mobile/details.html:71
-#: src/olympia/devhub/templates/devhub/addons/edit/support.html:43
+#: src/olympia/addons/templates/addons/details_box.html:38 src/olympia/addons/templates/addons/mobile/details.html:71 src/olympia/devhub/templates/devhub/addons/edit/support.html:43
 #: src/olympia/discovery/templates/discovery/addons/detail.html:77
 msgid "Website"
 msgstr "Weboldal"
 
 #. This refers to this version's compatible applications, such as Firefox 8.0
-#: src/olympia/addons/templates/addons/details_box.html:47
-#: src/olympia/addons/templates/addons/mobile/details.html:80
-#: src/olympia/search/templates/search/results.html:72
+#: src/olympia/addons/templates/addons/details_box.html:47 src/olympia/addons/templates/addons/mobile/details.html:80 src/olympia/search/templates/search/results.html:72
 #: src/olympia/versions/templates/versions/version.html:21
 msgid "Works with"
 msgstr "Működik"
@@ -515,45 +398,30 @@ msgstr "Működik"
 msgid "Visibility"
 msgstr "Láthatóság"
 
-#: src/olympia/addons/templates/addons/details_box.html:57
-#: src/olympia/devhub/templates/devhub/index.html:94
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:104
+#: src/olympia/addons/templates/addons/details_box.html:57 src/olympia/devhub/templates/devhub/index.html:94 src/olympia/devhub/templates/devhub/includes/addon_details.html:91
 msgid "Hidden"
 msgstr "Rejtett"
 
-#: src/olympia/addons/templates/addons/details_box.html:59
-#: src/olympia/devhub/templates/devhub/index.html:96
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:106
+#: src/olympia/addons/templates/addons/details_box.html:59 src/olympia/devhub/templates/devhub/index.html:96 src/olympia/devhub/templates/devhub/includes/addon_details.html:93
 msgid "Unlisted"
 msgstr "Titkos"
 
-#: src/olympia/addons/templates/addons/details_box.html:67
-#: src/olympia/devhub/templates/devhub/addons/edit/technical.html:44
+#: src/olympia/addons/templates/addons/details_box.html:67 src/olympia/devhub/templates/devhub/addons/edit/technical.html:44
 msgid "Required Add-ons"
 msgstr "Szükséges kiegészítők"
 
-#: src/olympia/addons/templates/addons/details_box.html:81
-#: src/olympia/addons/templates/addons/persona_detail_table.html:15
-#: src/olympia/browse/views.py:462 src/olympia/devhub/views.py:78
-#: src/olympia/devhub/views.py:85
-#: src/olympia/discovery/templates/discovery/addons/detail.html:57
-#: src/olympia/reviews/forms.py:62
-#: src/olympia/reviews/templates/reviews/add.html:57
+#: src/olympia/addons/templates/addons/details_box.html:81 src/olympia/addons/templates/addons/persona_detail_table.html:15 src/olympia/browse/views.py:429 src/olympia/devhub/views.py:77
+#: src/olympia/devhub/views.py:84 src/olympia/discovery/templates/discovery/addons/detail.html:57 src/olympia/reviews/forms.py:62 src/olympia/reviews/templates/reviews/add.html:57
 #: src/olympia/reviews/templates/reviews/mobile/review_list.html:18
 msgid "Rating"
 msgstr "Osztályzat"
 
-#: src/olympia/addons/templates/addons/details_box.html:85
-#: src/olympia/browse/views.py:461 src/olympia/devhub/views.py:77
-#: src/olympia/devhub/views.py:84
-#: src/olympia/stats/templates/stats/addon_report_menu.html:8
-#: src/olympia/stats/templates/stats/collection_report_menu.html:18
+#: src/olympia/addons/templates/addons/details_box.html:85 src/olympia/browse/views.py:428 src/olympia/devhub/views.py:76 src/olympia/devhub/views.py:83
+#: src/olympia/stats/templates/stats/addon_report_menu.html:8 src/olympia/stats/templates/stats/collection_report_menu.html:18
 msgid "Downloads"
 msgstr "Letöltések"
 
-#: src/olympia/addons/templates/addons/details_box.html:91
-#: src/olympia/addons/templates/addons/details_box.html:103
-#: src/olympia/devhub/templates/devhub/addons/listing/item_actions_theme.html:17
+#: src/olympia/addons/templates/addons/details_box.html:91 src/olympia/addons/templates/addons/details_box.html:103 src/olympia/devhub/templates/devhub/addons/listing/item_actions_theme.html:17
 #: src/olympia/devhub/templates/devhub/personas/edit.html:60
 msgid "View Statistics"
 msgstr "Statisztika megtekintése"
@@ -567,18 +435,13 @@ msgid "Abuse Reports"
 msgstr "Visszaélés-jelentések"
 
 #. The Privacy Policy for this add-on.
-#: src/olympia/addons/templates/addons/details_box.html:121
-#: src/olympia/addons/templates/addons/privacy.html:19
-#: src/olympia/addons/templates/addons/privacy.html:23
-#: src/olympia/addons/templates/addons/impala/button.html:43
-#: src/olympia/addons/templates/addons/impala/details.html:307
-#: src/olympia/devhub/templates/devhub/includes/policy_form.html:20
+#: src/olympia/addons/templates/addons/details_box.html:121 src/olympia/addons/templates/addons/privacy.html:19 src/olympia/addons/templates/addons/privacy.html:23
+#: src/olympia/addons/templates/addons/impala/button.html:43 src/olympia/addons/templates/addons/impala/details.html:312 src/olympia/devhub/templates/devhub/includes/policy_form.html:23
 #: src/olympia/templates/mobile/base_addons.html:87
 msgid "Privacy Policy"
 msgstr "Adatvédelmi irányelvek"
 
-#: src/olympia/addons/templates/addons/details_box.html:124
-#: src/olympia/discovery/templates/discovery/addons/detail.html:24
+#: src/olympia/addons/templates/addons/details_box.html:124 src/olympia/discovery/templates/discovery/addons/detail.html:24
 msgid "View Privacy Policy"
 msgstr "Adatvédelmi irányelvek megtekintése"
 
@@ -586,8 +449,7 @@ msgstr "Adatvédelmi irányelvek megtekintése"
 msgid "EULA"
 msgstr "EULA"
 
-#: src/olympia/addons/templates/addons/details_box.html:171
-#: src/olympia/addons/templates/addons/details_box.html:231
+#: src/olympia/addons/templates/addons/details_box.html:171 src/olympia/addons/templates/addons/details_box.html:231
 msgid "More about this add-on"
 msgstr "További tudnivalók a kiegészítőről"
 
@@ -595,27 +457,21 @@ msgstr "További tudnivalók a kiegészítőről"
 msgid "Image Gallery"
 msgstr "Képgaléria"
 
-#: src/olympia/addons/templates/addons/details_box.html:190
-#: src/olympia/devhub/templates/devhub/addons/edit/technical.html:21
+#: src/olympia/addons/templates/addons/details_box.html:190 src/olympia/devhub/templates/devhub/addons/edit/technical.html:21
 msgid "Developer Comments"
 msgstr "Fejlesztő megjegyzései"
 
-#: src/olympia/addons/templates/addons/details_box.html:199
-#: src/olympia/addons/templates/addons/impala/details.html:259
+#: src/olympia/addons/templates/addons/details_box.html:199 src/olympia/addons/templates/addons/impala/details.html:264
 msgid "Development Channel"
 msgstr "Fejlesztői csatorna"
 
-#: src/olympia/addons/templates/addons/details_box.html:202
-#: src/olympia/addons/templates/addons/mobile/details.html:124
+#: src/olympia/addons/templates/addons/details_box.html:202 src/olympia/addons/templates/addons/mobile/details.html:124
 msgid ""
-"The Development Channel lets you test an experimental new version of this "
-"add-on before it's released to the general public. Once you install the "
-"development version, you will continue to get updates from this channel."
+"The Development Channel lets you test an experimental new version of this add-on before it's released to the general public. Once you install the development version, you will continue to get "
+"updates from this channel."
 msgstr ""
-"A Fejlesztői csatorna segítségével a hivatalos megjelenés előtt "
-"kipróbálhatja a kiegészítő legfrissebb verzióját. A fejlesztői verzió "
-"telepítését követően folyamatosan érkeznek a frissítések erről a "
-"csatornáról."
+"A Fejlesztői csatorna segítségével a hivatalos megjelenés előtt kipróbálhatja a kiegészítő legfrissebb verzióját. A fejlesztői verzió telepítését követően folyamatosan érkeznek a frissítések erről "
+"a csatornáról."
 
 #: src/olympia/addons/templates/addons/details_box.html:207
 msgid "Install development version"
@@ -623,75 +479,52 @@ msgstr "Fejlesztői verzió telepítése"
 
 #: src/olympia/addons/templates/addons/details_box.html:211
 msgid ""
-"<strong>Caution:</strong> Development versions of this add-on have not been "
-"reviewed by Mozilla. Once you install a development version you will "
-"continue to receive development updates from this developer. To stop "
-"receiving development updates, reinstall the default version from the link "
-"above."
+"<strong>Caution:</strong> Development versions of this add-on have not been reviewed by Mozilla. Once you install a development version you will continue to receive development updates from this "
+"developer. To stop receiving development updates, reinstall the default version from the link above."
 msgstr ""
-"<strong>Figyelem:</strong> A Fejlesztői verziót még nem értékelte a Mozilla."
-" A Fejlesztői verzió telepítését követően közvetlenül a fejlesztőtől fogja "
-"kapni a frissítéseket. A frissítések leállításához a fenti hivatkozás "
-"használatával telepítse újra az alapértelmezett verziót."
+"<strong>Figyelem:</strong> A Fejlesztői verziót még nem értékelte a Mozilla. A Fejlesztői verzió telepítését követően közvetlenül a fejlesztőtől fogja kapni a frissítéseket. A frissítések "
+"leállításához a fenti hivatkozás használatával telepítse újra az alapértelmezett verziót."
 
-#: src/olympia/addons/templates/addons/details_box.html:220
-#: src/olympia/addons/templates/addons/impala/details.html:278
+#: src/olympia/addons/templates/addons/details_box.html:220 src/olympia/addons/templates/addons/impala/details.html:283
 msgid "Version {0}:"
 msgstr "{0} verzió:"
 
 #: src/olympia/addons/templates/addons/details_box.html:234
-msgid "Nothing to see here!  The developer did not include any details."
-msgstr "Nincs itt semmi látnivaló!  A fejlesztő nem adott hozzá részleteket."
+msgid "Nothing to see here! The developer did not include any details."
+msgstr "Itt nincs mit látni. A fejlesztő nem adott meg részleteket."
 
-#: src/olympia/addons/templates/addons/details_box.html:251
-#: src/olympia/devhub/templates/devhub/versions/edit.html:73
-#: src/olympia/editors/templates/editors/review.html:98
+#: src/olympia/addons/templates/addons/details_box.html:251 src/olympia/devhub/templates/devhub/versions/edit.html:73 src/olympia/editors/templates/editors/review.html:98
 msgid "Version Notes"
 msgstr "Megjegyzések a verzióhoz"
 
 #. {0} is the name of the add-on.
 #. {0} is the name of the add-on
-#: src/olympia/addons/templates/addons/eula.html:6
-#: src/olympia/discovery/templates/discovery/addons/eula.html:5
+#: src/olympia/addons/templates/addons/eula.html:6 src/olympia/discovery/templates/discovery/addons/eula.html:5
 msgid "End-User License Agreement for {0}"
 msgstr "{0} felhasználói licencszerződés"
 
-#: src/olympia/addons/templates/addons/eula.html:17
-#: src/olympia/addons/templates/addons/eula.html:21
-#: src/olympia/addons/templates/addons/impala/button.html:48
-#: src/olympia/addons/templates/addons/impala/details.html:316
-#: src/olympia/devhub/templates/devhub/includes/policy_form.html:3
-#: src/olympia/discovery/templates/discovery/addons/eula.html:11
+#: src/olympia/addons/templates/addons/eula.html:17 src/olympia/addons/templates/addons/eula.html:21 src/olympia/addons/templates/addons/impala/button.html:48
+#: src/olympia/addons/templates/addons/impala/details.html:321 src/olympia/devhub/templates/devhub/includes/policy_form.html:3 src/olympia/discovery/templates/discovery/addons/eula.html:11
 msgid "End-User License Agreement"
 msgstr "Végfelhasználói licencszerződés"
 
-#: src/olympia/addons/templates/addons/eula.html:23
-#: src/olympia/discovery/templates/discovery/addons/eula.html:13
+#: src/olympia/addons/templates/addons/eula.html:23 src/olympia/discovery/templates/discovery/addons/eula.html:13
 #, python-format
-msgid ""
-"%(addon_name)s requires that you accept the following End-User License "
-"Agreement before installation can proceed:"
-msgstr ""
-"A(z) %(addon_name)s telepítése előtt el kell fogadnia a következő "
-"Végfelhasználói licencszerződést:"
+msgid "%(addon_name)s requires that you accept the following End-User License Agreement before installation can proceed:"
+msgstr "A(z) %(addon_name)s telepítése előtt el kell fogadnia a következő Végfelhasználói licencszerződést:"
 
-#: src/olympia/addons/templates/addons/eula.html:34
-#: src/olympia/addons/templates/addons/privacy.html:26
+#: src/olympia/addons/templates/addons/eula.html:34 src/olympia/addons/templates/addons/privacy.html:26
 msgid "Back to {0}…"
 msgstr "Vissza ehhez: {0}…"
 
 # {0} is the application the user is browsing.  Examples:  Thunderbird,
 # Firefox,
 # Sunbird
-#: src/olympia/addons/templates/addons/home.html:3
-#: src/olympia/addons/templates/addons/mobile/home.html:3
-#: src/olympia/amo/helpers.py:235
+#: src/olympia/addons/templates/addons/home.html:3 src/olympia/addons/templates/addons/mobile/home.html:3 src/olympia/amo/helpers.py:235
 msgid "Add-ons for {0}"
 msgstr "{0}-kiegészítők"
 
-#: src/olympia/addons/templates/addons/home.html:10
-#: src/olympia/addons/templates/addons/home.html:51
-#: src/olympia/browse/templates/browse/impala/base_listing.html:11
+#: src/olympia/addons/templates/addons/home.html:10 src/olympia/addons/templates/addons/home.html:53 src/olympia/browse/templates/browse/impala/base_listing.html:11
 msgid "Featured Extensions"
 msgstr "Kiemelt kiterjesztések"
 
@@ -699,69 +532,48 @@ msgstr "Kiemelt kiterjesztések"
 msgid "Popular Extensions"
 msgstr "Népszerű kiterjesztések"
 
-#: src/olympia/addons/templates/addons/home.html:42
-#: src/olympia/amo/templates/amo/side_nav.html:3
-#: src/olympia/amo/templates/amo/side_nav.html:11
-#: src/olympia/amo/templates/amo/site_nav.html:3
-#: src/olympia/amo/templates/amo/site_nav.html:25
-#: src/olympia/browse/views.py:236 src/olympia/browse/views.py:281
-#: src/olympia/browse/views.py:481
+#: src/olympia/addons/templates/addons/home.html:44 src/olympia/amo/templates/amo/side_nav.html:3 src/olympia/amo/templates/amo/side_nav.html:11 src/olympia/amo/templates/amo/site_nav.html:3
+#: src/olympia/amo/templates/amo/site_nav.html:25 src/olympia/browse/views.py:203 src/olympia/browse/views.py:248 src/olympia/browse/views.py:448
 msgid "Most Popular"
 msgstr "Legnépszerűbb"
 
-#: src/olympia/addons/templates/addons/home.html:43
+#: src/olympia/addons/templates/addons/home.html:45
 msgid "All »"
 msgstr "Összes »"
 
-#: src/olympia/addons/templates/addons/home.html:52
-#: src/olympia/addons/templates/addons/home.html:61
-#: src/olympia/addons/templates/addons/home.html:70
-#: src/olympia/addons/templates/addons/home.html:78
+#: src/olympia/addons/templates/addons/home.html:54 src/olympia/addons/templates/addons/home.html:63 src/olympia/addons/templates/addons/home.html:72 src/olympia/addons/templates/addons/home.html:80
 #: src/olympia/browse/templates/browse/impala/category_landing.html:36
 msgid "See all »"
 msgstr "Összes megtekintése »"
 
-#: src/olympia/addons/templates/addons/home.html:60
+#: src/olympia/addons/templates/addons/home.html:62
 msgid "Up &amp; Coming Extensions"
 msgstr "Ígéretes kiegészítők"
 
-#: src/olympia/addons/templates/addons/home.html:69
-#: src/olympia/browse/templates/browse/personas/category_landing.html:61
-#: src/olympia/discovery/templates/discovery/pane.html:74
+#: src/olympia/addons/templates/addons/home.html:71 src/olympia/browse/templates/browse/personas/category_landing.html:61 src/olympia/discovery/templates/discovery/pane.html:74
 msgid "Featured Themes"
 msgstr "Kiemelt témák"
 
-#: src/olympia/addons/templates/addons/home.html:77
-#: src/olympia/bandwagon/templates/bandwagon/impala/collection_listing.html:5
+#: src/olympia/addons/templates/addons/home.html:79 src/olympia/bandwagon/templates/bandwagon/impala/collection_listing.html:5
 msgid "Featured Collections"
 msgstr "Kiemelt gyűjtemények"
 
-#: src/olympia/addons/templates/addons/listing_header.html:3
-#: src/olympia/addons/templates/addons/impala/listing/sorter.html:2
-#: src/olympia/amo/templates/amo/mobile/sort_by.html:2
+#: src/olympia/addons/templates/addons/listing_header.html:3 src/olympia/addons/templates/addons/impala/listing/sorter.html:2 src/olympia/amo/templates/amo/mobile/sort_by.html:2
 #: src/olympia/bandwagon/templates/bandwagon/collection_detail.html:118
 msgid "Sort by:"
 msgstr "Rendezés:"
 
 #. {0} is a date.
 #. {0} is a date
-#: src/olympia/addons/templates/addons/macros.html:7
-#: src/olympia/addons/templates/addons/macros.html:72
-#: src/olympia/addons/templates/addons/listing/items_mobile.html:48
-#: src/olympia/addons/templates/addons/listing/macros.html:42
-#: src/olympia/bandwagon/templates/bandwagon/collection_detail.html:50
-#: src/olympia/bandwagon/templates/bandwagon/collection_listing_items.html:40
-#: src/olympia/bandwagon/templates/bandwagon/impala/collection_listing_items.html:40
+#: src/olympia/addons/templates/addons/macros.html:7 src/olympia/addons/templates/addons/macros.html:72 src/olympia/addons/templates/addons/listing/items_mobile.html:48
+#: src/olympia/addons/templates/addons/listing/macros.html:42 src/olympia/bandwagon/templates/bandwagon/collection_detail.html:50
+#: src/olympia/bandwagon/templates/bandwagon/collection_listing_items.html:40 src/olympia/bandwagon/templates/bandwagon/impala/collection_listing_items.html:40
 msgid "Updated {0}"
 msgstr "{0} frissítve"
 
 #. {0} is a date.
-#: src/olympia/addons/templates/addons/macros.html:10
-#: src/olympia/addons/templates/addons/macros.html:69
-#: src/olympia/addons/templates/addons/persona_preview.html:21
-#: src/olympia/addons/templates/addons/listing/items_mobile.html:44
-#: src/olympia/addons/templates/addons/listing/macros.html:39
-#: src/olympia/bandwagon/templates/bandwagon/collection_listing_items.html:37
+#: src/olympia/addons/templates/addons/macros.html:10 src/olympia/addons/templates/addons/macros.html:69 src/olympia/addons/templates/addons/persona_preview.html:22
+#: src/olympia/addons/templates/addons/listing/items_mobile.html:44 src/olympia/addons/templates/addons/listing/macros.html:39 src/olympia/bandwagon/templates/bandwagon/collection_listing_items.html:37
 #: src/olympia/bandwagon/templates/bandwagon/impala/collection_listing_items.html:37
 msgid "Added {0}"
 msgstr "Hozzáadva: {0}"
@@ -781,18 +593,14 @@ msgstr[0] "%(num)s felhasználó"
 msgstr[1] "%(num)s felhasználó"
 
 #. {0} is the number of downloads.
-#: src/olympia/addons/templates/addons/macros.html:53
-#: src/olympia/addons/templates/addons/impala/details.html:61
+#: src/olympia/addons/templates/addons/macros.html:53 src/olympia/addons/templates/addons/impala/details.html:59
 msgid "{0} weekly download"
 msgid_plural "{0} weekly downloads"
 msgstr[0] "{0} letöltés hetente"
 msgstr[1] "{0} letöltés hetente"
 
 #. {0} is the number of users.
-#: src/olympia/addons/templates/addons/macros.html:61
-#: src/olympia/addons/templates/addons/impala/details.html:54
-#: src/olympia/compat/templates/compat/index.html:71
-#: src/olympia/zadmin/templates/zadmin/compat.html:67
+#: src/olympia/addons/templates/addons/macros.html:61 src/olympia/addons/templates/addons/impala/details.html:52 src/olympia/zadmin/templates/zadmin/compat.html:67
 msgid "{0} user"
 msgid_plural "{0} users"
 msgstr[0] "{0} felhasználó"
@@ -810,12 +618,8 @@ msgstr "Fizetés végrehajtva"
 msgid "Return to the addon."
 msgstr "Vissza a kiegészítőhöz."
 
-#: src/olympia/addons/templates/addons/persona_detail.html:17
-#: src/olympia/addons/templates/addons/impala/details.html:106
-#: src/olympia/addons/templates/addons/mobile/details.html:23
-#: src/olympia/addons/templates/addons/mobile/persona_detail.html:21
-#: src/olympia/discovery/templates/discovery/addons/base.html:27
-#: src/olympia/editors/templates/editors/review.html:31
+#: src/olympia/addons/templates/addons/persona_detail.html:17 src/olympia/addons/templates/addons/impala/details.html:103 src/olympia/addons/templates/addons/mobile/details.html:23
+#: src/olympia/addons/templates/addons/mobile/persona_detail.html:21 src/olympia/discovery/templates/discovery/addons/base.html:27 src/olympia/editors/templates/editors/review.html:31
 msgid "by"
 msgstr ":"
 
@@ -825,8 +629,7 @@ msgid "More {0} Themes"
 msgstr "További {0} téma"
 
 #. {0} is a category name, such as Nature
-#: src/olympia/addons/templates/addons/persona_detail.html:39
-#: src/olympia/addons/templates/addons/mobile/persona_detail.html:66
+#: src/olympia/addons/templates/addons/persona_detail.html:39 src/olympia/addons/templates/addons/mobile/persona_detail.html:66
 msgid "See all {0} Themes"
 msgstr "Összes téma megtekintése: {0}"
 
@@ -834,188 +637,130 @@ msgstr "Összes téma megtekintése: {0}"
 msgid "More by this Artist"
 msgstr "További persona ettől az alkotótól"
 
-#: src/olympia/addons/templates/addons/persona_detail.html:52
-#: src/olympia/addons/templates/addons/mobile/persona_detail.html:49
+#: src/olympia/addons/templates/addons/persona_detail.html:52 src/olympia/addons/templates/addons/mobile/persona_detail.html:49
 msgid "See all Themes by this Artist"
 msgstr "Az alkotó összes témájának megjelenítése"
 
-#: src/olympia/addons/templates/addons/persona_detail.html:71
-#: src/olympia/addons/templates/addons/mobile/home.html:42
-#: src/olympia/amo/templates/amo/side_nav.html:22
-#: src/olympia/browse/templates/browse/personas/mobile/category_landing.html:28
-#: src/olympia/devhub/templates/devhub/addons/edit/basic.html:72
-#: src/olympia/editors/templates/editors/review.html:277
-#: src/olympia/editors/templates/editors/themes/themes.html:34
-#: src/olympia/templates/categories.html:7
+#: src/olympia/addons/templates/addons/persona_detail.html:71 src/olympia/addons/templates/addons/mobile/home.html:42 src/olympia/amo/templates/amo/side_nav.html:22
+#: src/olympia/browse/templates/browse/personas/mobile/category_landing.html:28 src/olympia/devhub/templates/devhub/addons/edit/basic.html:72 src/olympia/editors/templates/editors/review.html:277
+#: src/olympia/editors/templates/editors/themes/themes.html:34 src/olympia/templates/categories.html:7
 msgid "Categories"
 msgstr "Kategóriák"
 
-#: src/olympia/addons/templates/addons/persona_detail_table.html:10
-#: src/olympia/addons/templates/addons/mobile/persona_detail_table.html:3
-#: src/olympia/editors/templates/editors/themes/deleted.html:19
+#: src/olympia/addons/templates/addons/persona_detail_table.html:10 src/olympia/addons/templates/addons/mobile/persona_detail_table.html:3 src/olympia/editors/templates/editors/themes/deleted.html:19
 #: src/olympia/editors/templates/editors/themes/themes.html:25
 msgid "Artist"
 msgstr "Alkotó"
 
-#: src/olympia/addons/templates/addons/persona_detail_table.html:19
-#: src/olympia/addons/templates/addons/mobile/persona_detail_table.html:14
-#: src/olympia/stats/templates/stats/addon_report_menu.html:17
+#: src/olympia/addons/templates/addons/persona_detail_table.html:19 src/olympia/addons/templates/addons/mobile/persona_detail_table.html:14 src/olympia/stats/templates/stats/addon_report_menu.html:17
 msgid "Daily Users"
 msgstr "Napi felhasználók"
 
 #. The License for this add-on.
-#: src/olympia/addons/templates/addons/persona_detail_table.html:26
-#: src/olympia/addons/templates/addons/impala/license.html:17
-#: src/olympia/addons/templates/addons/mobile/persona_detail_table.html:21
-#: src/olympia/devhub/templates/devhub/includes/license_form.html:5
-#: src/olympia/devhub/templates/devhub/versions/edit.html:89
-#: src/olympia/editors/templates/editors/themes/themes.html:41
+#: src/olympia/addons/templates/addons/persona_detail_table.html:26 src/olympia/addons/templates/addons/impala/license.html:17 src/olympia/addons/templates/addons/mobile/persona_detail_table.html:21
+#: src/olympia/devhub/templates/devhub/includes/license_form.html:5 src/olympia/devhub/templates/devhub/versions/edit.html:89 src/olympia/editors/templates/editors/themes/themes.html:41
 msgid "License"
 msgstr "Licenc"
 
-#: src/olympia/addons/templates/addons/persona_preview.html:12
-#: src/olympia/constants/base.py:48
+#: src/olympia/addons/templates/addons/persona_preview.html:13 src/olympia/constants/base.py:48
 msgid "Awaiting Review"
 msgstr "Értékelésre vár"
 
-#: src/olympia/addons/templates/addons/persona_preview.html:14
-#: src/olympia/amo/log.py:180 src/olympia/constants/base.py:42
-#: src/olympia/editors/helpers.py:62
+#: src/olympia/addons/templates/addons/persona_preview.html:15 src/olympia/amo/log.py:180 src/olympia/constants/base.py:42 src/olympia/editors/helpers.py:62
 msgid "Rejected"
 msgstr "Elutasított"
 
-#: src/olympia/addons/templates/addons/persona_preview.html:16
-#: src/olympia/amo/log.py:159
+#: src/olympia/addons/templates/addons/persona_preview.html:17 src/olympia/amo/log.py:159
 msgid "Approved"
 msgstr "Jóváhagyott"
 
 #. {0} is the number of users.
-#: src/olympia/addons/templates/addons/persona_preview.html:26
-#: src/olympia/addons/templates/addons/listing/items_mobile.html:36
-#: src/olympia/addons/templates/addons/listing/macros.html:31
+#: src/olympia/addons/templates/addons/persona_preview.html:27 src/olympia/addons/templates/addons/listing/items_mobile.html:36 src/olympia/addons/templates/addons/listing/macros.html:31
 msgid "<strong>{0}</strong> user"
 msgid_plural "<strong>{0}</strong> users"
 msgstr[0] "<strong>{0}</strong> felhasználó"
 msgstr[1] "<strong>{0}</strong> felhasználó"
 
-#: src/olympia/addons/templates/addons/persona_preview.html:40
+#: src/olympia/addons/templates/addons/persona_preview.html:41
 msgid "Hover to Preview"
 msgstr "Előnézethez húzza fölé az egeret"
 
-#: src/olympia/addons/templates/addons/persona_preview.html:46
-#: src/olympia/addons/templates/addons/persona_preview.html:48
+#: src/olympia/addons/templates/addons/persona_preview.html:47 src/olympia/addons/templates/addons/persona_preview.html:49 src/olympia/addons/templates/addons/persona_preview.html:97
 #: src/olympia/reviews/templates/reviews/add.html:15
 msgid "Add"
 msgstr "Hozzáadás"
 
-#: src/olympia/addons/templates/addons/persona_preview.html:57
-#: src/olympia/bandwagon/templates/bandwagon/ajax_new.html:16
-#: src/olympia/bandwagon/templates/bandwagon/edit.html:19
-#: src/olympia/bandwagon/templates/bandwagon/includes/addedit.html:19
-#: src/olympia/devhub/templates/devhub/addons/edit/admin.html:13
-#: src/olympia/devhub/templates/devhub/addons/edit/basic.html:10
-#: src/olympia/devhub/templates/devhub/addons/edit/details.html:8
-#: src/olympia/devhub/templates/devhub/addons/edit/media.html:6
-#: src/olympia/devhub/templates/devhub/addons/edit/support.html:8
-#: src/olympia/devhub/templates/devhub/addons/edit/technical.html:9
-#: src/olympia/devhub/templates/devhub/addons/submit/describe.html:29
-#: src/olympia/editors/templates/editors/review.html:257
+#: src/olympia/addons/templates/addons/persona_preview.html:58 src/olympia/bandwagon/templates/bandwagon/ajax_new.html:16 src/olympia/bandwagon/templates/bandwagon/edit.html:19
+#: src/olympia/bandwagon/templates/bandwagon/includes/addedit.html:19 src/olympia/devhub/templates/devhub/addons/edit/admin.html:13 src/olympia/devhub/templates/devhub/addons/edit/basic.html:10
+#: src/olympia/devhub/templates/devhub/addons/edit/details.html:8 src/olympia/devhub/templates/devhub/addons/edit/media.html:6 src/olympia/devhub/templates/devhub/addons/edit/support.html:8
+#: src/olympia/devhub/templates/devhub/addons/edit/technical.html:9 src/olympia/devhub/templates/devhub/addons/submit/describe.html:29 src/olympia/editors/templates/editors/review.html:257
 msgid "Edit"
 msgstr "Szerkesztés"
 
 #. For datetime formatting, see the table on
 #. http://docs.python.org/library/datetime.html#strftime-and-strptime-behavior
-#: src/olympia/addons/templates/addons/persona_preview.html:66
+#: src/olympia/addons/templates/addons/persona_preview.html:67
 #, python-format
 msgid "%%Y-%%m-%%d"
 msgstr "%%Y.%%m.%%d."
 
-#: src/olympia/addons/templates/addons/persona_preview.html:67
+#: src/olympia/addons/templates/addons/persona_preview.html:68
 msgid "by {0} on {1}"
 msgstr "értékelte: {0}, dátum: {1}"
 
-#: src/olympia/addons/templates/addons/persona_preview.html:75
-#: src/olympia/reviews/helpers.py:17
-#: src/olympia/reviews/templates/reviews/review_list.html:63
-#: src/olympia/reviews/templates/reviews/reviews_link.html:21
-#: src/olympia/reviews/templates/reviews/impala/reviews_link.html:16
+#: src/olympia/addons/templates/addons/persona_preview.html:76 src/olympia/reviews/helpers.py:17 src/olympia/reviews/templates/reviews/review_list.html:63
+#: src/olympia/reviews/templates/reviews/reviews_link.html:21 src/olympia/reviews/templates/reviews/impala/reviews_link.html:16
 msgid "Not yet rated"
 msgstr "Még nem osztályozott"
 
-#: src/olympia/addons/templates/addons/persona_preview.html:78
+#: src/olympia/addons/templates/addons/persona_preview.html:79
 msgid "<b>{0}</b> users"
 msgstr "<b>{0}</b> felhasználó"
 
 #: src/olympia/addons/templates/addons/popups.html:17
-msgid ""
-"To install this add-on and thousands more, <b>get Firefox</b>, a free and "
-"open web browser from Mozilla."
-msgstr ""
-"A kiegészítő telepítéséhez <b>töltsön le egy Firefox</b>ot, a Mozilla "
-"ingyenes és nyílt böngészőjét."
+msgid "To install this add-on and thousands more, <b>get Firefox</b>, a free and open web browser from Mozilla."
+msgstr "A kiegészítő telepítéséhez <b>töltsön le egy Firefox</b>ot, a Mozilla ingyenes és nyílt böngészőjét."
 
-#: src/olympia/addons/templates/addons/popups.html:21
-#: src/olympia/addons/templates/addons/popups.html:52
+#: src/olympia/addons/templates/addons/popups.html:21 src/olympia/addons/templates/addons/popups.html:52
 msgid "Learn more about Firefox"
 msgstr "Tudjon meg többet a Firefox böngészőről."
 
 #: src/olympia/addons/templates/addons/popups.html:22
-msgid "or <b><a class=\"installer\" href=\"{url}\">download anyway</a></b>"
-msgstr "vagy <b><a class=\"installer\" href=\"{url}\">letöltés mindenképpen</a></b>"
+msgid "or <b><a class=\"button installer\" href=\"{url}\">download anyway</a></b>"
+msgstr ""
 
 #: src/olympia/addons/templates/addons/popups.html:26
 msgid ""
-"<strong>How to Install in Thunderbird</strong> <ol> <li>Download and save "
-"the file to your hard disk.</li> <li>In Mozilla Thunderbird, open Add-ons "
-"from the Tools menu.</li> <li>From the options button next to the add-on "
-"search field, select \"Install Add-on From File...\" and locate the "
-"downloaded add-on.</li> </ol>"
+"<strong>How to Install in Thunderbird</strong> <ol> <li>Download and save the file to your hard disk.</li> <li>In Mozilla Thunderbird, open Add-ons from the Tools menu.</li> <li>From the options "
+"button next to the add-on search field, select \"Install Add-on From File...\" and locate the downloaded add-on.</li> </ol>"
 msgstr ""
-"<strong>Hogyan telepítse Thunderbirdben</strong> <ol> <li>Töltse le és "
-"mentse a fájlt merevlemezére.</li> <li>A Mozilla Thunderbirdben nyissa meg a"
-" Kiegészítők pontot az Eszközök menüből.</li> <li>A kiegészítőkereső mező "
-"melletti beállítások gomb menüjéből válassza a „Kiegészítő telepítése "
-"fájlból” pontot, és keresse meg a letöltött kiegészítőt.</li> </ol>"
+"<strong>Hogyan telepítse Thunderbirdben</strong> <ol> <li>Töltse le és mentse a fájlt merevlemezére.</li> <li>A Mozilla Thunderbirdben nyissa meg a Kiegészítők pontot az Eszközök menüből.</li> "
+"<li>A kiegészítőkereső mező melletti beállítások gomb menüjéből válassza a „Kiegészítő telepítése fájlból” pontot, és keresse meg a letöltött kiegészítőt.</li> </ol>"
 
 #: src/olympia/addons/templates/addons/popups.html:41
-msgid ""
-"To install this Theme, <b>get Thunderbird</b>, a free and open source email "
-"client from Mozilla Messaging and install the Personas Plus add-on."
-msgstr ""
-"A téma telepítéséhez <b>töltse le a Thunderbird</b>öt, a Mozilla ingyenes és"
-" nyílt forrású levelezőprogramját és telepítse a Personas Plus kiegészítőt."
+msgid "To install this Theme, <b>get Thunderbird</b>, a free and open source email client from Mozilla Messaging and install the Personas Plus add-on."
+msgstr "A téma telepítéséhez <b>töltse le a Thunderbird</b>öt, a Mozilla ingyenes és nyílt forrású levelezőprogramját és telepítse a Personas Plus kiegészítőt."
 
 #: src/olympia/addons/templates/addons/popups.html:46
 msgid "Learn more about Thunderbird"
 msgstr "Tudjon meg többet a Thunderbird levelezőprogramról"
 
 #: src/olympia/addons/templates/addons/popups.html:48
-msgid ""
-"To install this Theme and thousands more, <b>get Firefox</b>, a free and "
-"open web browser from Mozilla."
-msgstr ""
-"A téma telepítéséhez <b>töltsön le egy Firefox</b>ot, a Mozilla ingyenes és "
-"nyílt böngészőjét."
+msgid "To install this Theme and thousands more, <b>get Firefox</b>, a free and open web browser from Mozilla."
+msgstr "A téma telepítéséhez <b>töltsön le egy Firefox</b>ot, a Mozilla ingyenes és nyílt böngészőjét."
 
 #: src/olympia/addons/templates/addons/popups.html:60
 #, python-format
 msgid "This add-on has not been updated to work with your version of %(app)s."
-msgstr ""
-"A kiegészítő nem lett frissítve, hogy ezzel a %(app)s verzióval használni "
-"lehessen."
+msgstr "A kiegészítő nem lett frissítve, hogy ezzel a %(app)s verzióval használni lehessen."
 
-#: src/olympia/addons/templates/addons/popups.html:63
-#: src/olympia/addons/templates/addons/popups.html:140
-#: src/olympia/addons/templates/addons/popups.html:150
+#: src/olympia/addons/templates/addons/popups.html:63 src/olympia/addons/templates/addons/popups.html:140 src/olympia/addons/templates/addons/popups.html:150
 msgid "Install Anyway"
 msgstr "Telepítés mindenképpen"
 
 #: src/olympia/addons/templates/addons/popups.html:71
-msgid ""
-"This add-on requires a version of Firefox that has not been released yet."
-msgstr ""
-"Ennek a kiegészítőnek olyan Firefox verzióra van szüksége, amely még nem "
-"jelent meg."
+msgid "This add-on requires a version of Firefox that has not been released yet."
+msgstr "Ennek a kiegészítőnek olyan Firefox verzióra van szüksége, amely még nem jelent meg."
 
 #: src/olympia/addons/templates/addons/popups.html:74
 msgid "Help test new Firefox Versions"
@@ -1023,16 +768,11 @@ msgstr "Segítsen az új Firefox verzió tesztelésében"
 
 #: src/olympia/addons/templates/addons/popups.html:77
 #, python-format
-msgid ""
-"This add-on requires %(app)s {new_version}. You are currently using %(app)s "
-"{old_version}."
-msgstr ""
-"A kiegészítő számára a %(app)s {new_version} verzióra van szükség. Jelenleg "
-"a %(app)s {old_version} verzióját használja."
+msgid "This add-on requires %(app)s {new_version}. You are currently using %(app)s {old_version}."
+msgstr "A kiegészítő számára a %(app)s {new_version} verzióra van szükség. Jelenleg a %(app)s {old_version} verzióját használja."
 
 #. {0} is an app name, like Firefox.
-#: src/olympia/addons/templates/addons/popups.html:82
-#: src/olympia/addons/templates/addons/popups.html:101
+#: src/olympia/addons/templates/addons/popups.html:82 src/olympia/addons/templates/addons/popups.html:101
 msgid "Upgrade {0}"
 msgstr "{0} frissítése"
 
@@ -1043,44 +783,27 @@ msgstr "vagy nézze meg a <a href=\"%(href)s\">kiegészítő régebbi verzióit<
 
 #: src/olympia/addons/templates/addons/popups.html:96
 #, python-format
-msgid ""
-"This Persona requires %(app)s %(new_version)s. You are currently using "
-"%(app)s {old_version}."
-msgstr ""
-"A persona számára a %(app)s %(new_version)s verzióra van szükség. Jelenleg a"
-" %(app)s  {old_version} verzióját használja."
+msgid "This Persona requires %(app)s %(new_version)s. You are currently using %(app)s {old_version}."
+msgstr "A persona számára a %(app)s %(new_version)s verzióra van szükség. Jelenleg a %(app)s  {old_version} verzióját használja."
 
 #: src/olympia/addons/templates/addons/popups.html:108
 msgid ""
-"<strong>Caution:</strong> This add-on has not been reviewed by Mozilla and "
-"can't be installed on release versions of Firefox 43 and above.  Be careful "
-"when installing third-party software that might harm your computer."
+"<strong>Caution:</strong> This add-on has not been reviewed by Mozilla and can't be installed on release versions of Firefox 43 and above. Be careful when installing third-party software that might"
+" harm your computer."
 msgstr ""
-"<strong>Vigyázat:</strong> Ezt a kiegészítőt a Mozilla nem értékelte, és a "
-"Firefox 43 és újabb verziókhoz nem telepíthető.  Legyen elővigyázatos "
-"harmadik féltől származó programok telepítésekor, ezek károsíthatják "
-"számítógépét."
+"<strong>Figyelmeztetés:</strong> Ezt a kiegészítőt a Mozilla nem vizsgálta meg és Firefox 43 és újabb verziókhoz nem telepíthető. Legyen óvatos, mikor harmadik féltől származó szoftvert telepít, "
+"mert ezek kárt okozhatnak számítógépében."
 
 #: src/olympia/addons/templates/addons/popups.html:120
-msgid ""
-"<strong>Please note:</strong> This add-on is not compatible with your "
-"operating system."
-msgstr ""
-"<strong>Megjegyzés:</strong> Ez a kiegészítő nem kompatibilis az operációs "
-"rendszerével."
+msgid "<strong>Please note:</strong> This add-on is not compatible with your operating system."
+msgstr "<strong>Megjegyzés:</strong> Ez a kiegészítő nem kompatibilis az operációs rendszerével."
 
-#: src/olympia/addons/templates/addons/popups.html:136
-#: src/olympia/addons/templates/addons/impala/button.html:70
+#: src/olympia/addons/templates/addons/popups.html:136 src/olympia/addons/templates/addons/impala/button.html:70
 #, python-format
-msgid ""
-"This add-on is not compatible with your version of %(app)s because of the "
-"following:"
-msgstr ""
-"Ez a kiegészítő az alábbi okok miatt nem kompatibilis ezzel a %(app)s "
-"verzióval:"
+msgid "This add-on is not compatible with your version of %(app)s because of the following:"
+msgstr "Ez a kiegészítő az alábbi okok miatt nem kompatibilis ezzel a %(app)s verzióval:"
 
-#: src/olympia/addons/templates/addons/popups.html:141
-#: src/olympia/addons/templates/addons/popups.html:151
+#: src/olympia/addons/templates/addons/popups.html:141 src/olympia/addons/templates/addons/popups.html:151
 msgid "View other versions"
 msgstr "Egyéb verziók megtekintése"
 
@@ -1099,149 +822,92 @@ msgid "QR code for add-on"
 msgstr "QR kód a kiegészítőhöz"
 
 #: src/olympia/addons/templates/addons/qr_code.html:6
-msgid ""
-"Want {0} on your mobile Firefox?  Scan this QR code to install directly\n"
-"  to your phone.  (You'll need a QR reader.  Search your phone's marketplace if\n"
-"  don't have one.)"
+msgid "Want {0} on your mobile Firefox? Scan this QR code to install directly to your phone. (You'll need a QR reader. Search your phone's marketplace if don't have one.)"
 msgstr ""
-"A(z) {0} kiegészítőt a mobilos Firefoxán kívánja használni?  Használja a QR kódot a telepítéshez.\n"
-"  (Ehhez QR olvasó alkalmazásra van szüksége.  Amennyiben nincs ilyen alkalmazása,\n"
-"  keressen a telefonhoz elérhető alkalmazások között.)"
+"A(z) {0} kiegészítőt a Firefox Mobile-on kívánja használni? Használja a QR kódot a telepítéshez. (Ehhez QR olvasó alkalmazásra van szüksége. Amennyiben nincs ilyen alkalmazása, keressen a "
+"telefonhoz elérhető alkalmazások között.)"
 
-#: src/olympia/addons/templates/addons/report_abuse.html:6
-#: src/olympia/addons/templates/addons/report_abuse_full.html:10
-#: src/olympia/addons/templates/addons/impala/details-more.html:23
-#: src/olympia/addons/templates/addons/impala/details.html:328
+#: src/olympia/addons/templates/addons/report_abuse.html:6 src/olympia/addons/templates/addons/report_abuse_full.html:10 src/olympia/addons/templates/addons/impala/details-more.html:23
+#: src/olympia/addons/templates/addons/impala/details.html:333
 msgid "Report Abuse"
 msgstr "Visszaélés jelentése"
 
 #: src/olympia/addons/templates/addons/report_abuse.html:10
 #, python-format
 msgid ""
-"If you suspect this add-on violates <a href=\"%(url)s\">our policies</a> or "
-"has security or privacy issues, please use the form below to describe your "
-"concerns. Please do not use this form for any other reason."
+"If you suspect this add-on violates <a href=\"%(url)s\">our policies</a> or has security or privacy issues, please use the form below to describe your concerns. Please do not use this form for any "
+"other reason."
 msgstr ""
-"Ha úgy gondolja, hogy ez a kiegészítő megsérti az <a "
-"href=\"%(url)s\">irányelveinket</a> vagy biztonsági, adatvédelmi problémák "
-"vannak vele kapcsolatban, akkor írja le az alábbi űrlapon az ezzel "
+"Ha úgy gondolja, hogy ez a kiegészítő megsérti az <a href=\"%(url)s\">irányelveinket</a> vagy biztonsági, adatvédelmi problémák vannak vele kapcsolatban, akkor írja le az alábbi űrlapon az ezzel "
 "kapcsolatos aggodalmait. Ne használja ezt az űrlapot bármely más ok miatt."
 
-#: src/olympia/addons/templates/addons/report_abuse.html:24
-#: src/olympia/users/templates/users/report_abuse.html:19
+#: src/olympia/addons/templates/addons/report_abuse.html:24 src/olympia/users/templates/users/report_abuse.html:19
 msgid "Send Report"
 msgstr "Jelentés küldése"
 
-#: src/olympia/addons/templates/addons/report_abuse.html:26
-#: src/olympia/addons/templates/addons/mobile/eula.html:16
-#: src/olympia/addons/templates/addons/mobile/persona_confirm.html:7
-#: src/olympia/devhub/templates/devhub/addons/ajax_compat_update.html:36
-#: src/olympia/devhub/templates/devhub/addons/profile.html:44
-#: src/olympia/devhub/templates/devhub/addons/edit/admin.html:104
-#: src/olympia/devhub/templates/devhub/addons/edit/basic.html:155
-#: src/olympia/devhub/templates/devhub/addons/edit/details.html:88
-#: src/olympia/devhub/templates/devhub/addons/edit/support.html:70
-#: src/olympia/devhub/templates/devhub/addons/edit/technical.html:169
-#: src/olympia/devhub/templates/devhub/addons/forms_shared/media.html:152
-#: src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:44
-#: src/olympia/devhub/templates/devhub/personas/edit.html:222
-#: src/olympia/devhub/templates/devhub/versions/add_file_modal.html:79
-#: src/olympia/devhub/templates/devhub/versions/edit.html:140
-#: src/olympia/devhub/templates/devhub/versions/list.html:208
-#: src/olympia/devhub/templates/devhub/versions/list.html:242
-#: src/olympia/devhub/templates/devhub/versions/list.html:276
-#: src/olympia/devhub/templates/devhub/versions/list.html:317
-#: src/olympia/reviews/templates/reviews/edit_review.html:16
-#: src/olympia/translations/templates/translations/trans-menu.html:50
-#: src/olympia/translations/templates/translations/trans-menu.html:62
-#: src/olympia/zadmin/templates/zadmin/validation.html:105
+#: src/olympia/addons/templates/addons/report_abuse.html:26 src/olympia/addons/templates/addons/mobile/eula.html:16 src/olympia/addons/templates/addons/mobile/persona_confirm.html:7
+#: src/olympia/devhub/templates/devhub/addons/ajax_compat_update.html:36 src/olympia/devhub/templates/devhub/addons/profile.html:44 src/olympia/devhub/templates/devhub/addons/edit/admin.html:104
+#: src/olympia/devhub/templates/devhub/addons/edit/basic.html:155 src/olympia/devhub/templates/devhub/addons/edit/details.html:88 src/olympia/devhub/templates/devhub/addons/edit/support.html:70
+#: src/olympia/devhub/templates/devhub/addons/edit/technical.html:169 src/olympia/devhub/templates/devhub/addons/forms_shared/media.html:152
+#: src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:43 src/olympia/devhub/templates/devhub/personas/edit.html:222 src/olympia/devhub/templates/devhub/versions/add_file_modal.html:59
+#: src/olympia/devhub/templates/devhub/versions/edit.html:140 src/olympia/devhub/templates/devhub/versions/list.html:208 src/olympia/devhub/templates/devhub/versions/list.html:239
+#: src/olympia/devhub/templates/devhub/versions/list.html:281 src/olympia/devhub/templates/devhub/versions/list.html:315 src/olympia/reviews/templates/reviews/edit_review.html:16
+#: src/olympia/translations/templates/translations/trans-menu.html:50 src/olympia/translations/templates/translations/trans-menu.html:62 src/olympia/zadmin/templates/zadmin/validation.html:105
 msgid "Cancel"
 msgstr "Mégsem"
 
-#: src/olympia/addons/templates/addons/review_add_box.html:3
-#: src/olympia/addons/templates/addons/impala/review_add_box.html:5
+#: src/olympia/addons/templates/addons/review_add_box.html:3 src/olympia/addons/templates/addons/impala/review_add_box.html:5
 msgid "What do you think?"
 msgstr "Mit gondol?"
 
-#: src/olympia/addons/templates/addons/review_add_box.html:7
-#: src/olympia/addons/templates/addons/impala/review_add_box.html:9
+#: src/olympia/addons/templates/addons/review_add_box.html:7 src/olympia/addons/templates/addons/impala/review_add_box.html:9
 #, python-format
 msgid "Please <a href=\"%(login)s\">log in</a> to submit a review"
 msgstr "<a href=\"%(login)s\">Lépjen be</a> az értékelés beküldéséhez"
 
-#: src/olympia/addons/templates/addons/review_add_box.html:16
-#: src/olympia/addons/templates/addons/impala/review_add_box.html:18
-#: src/olympia/reviews/templates/reviews/mobile/add_form.html:13
+#: src/olympia/addons/templates/addons/review_add_box.html:16 src/olympia/addons/templates/addons/impala/review_add_box.html:18 src/olympia/reviews/templates/reviews/mobile/add_form.html:13
 msgid "Title:"
 msgstr "Cím:"
 
-#: src/olympia/addons/templates/addons/review_add_box.html:17
-#: src/olympia/addons/templates/addons/impala/review_add_box.html:19
-#: src/olympia/reviews/templates/reviews/mobile/add_form.html:17
+#: src/olympia/addons/templates/addons/review_add_box.html:17 src/olympia/addons/templates/addons/impala/review_add_box.html:19 src/olympia/reviews/templates/reviews/mobile/add_form.html:17
 msgid "Review:"
 msgstr "Értékelés:"
 
-#: src/olympia/addons/templates/addons/review_add_box.html:18
-#: src/olympia/addons/templates/addons/impala/review_add_box.html:20
-#: src/olympia/reviews/templates/reviews/mobile/add_form.html:16
+#: src/olympia/addons/templates/addons/review_add_box.html:18 src/olympia/addons/templates/addons/impala/review_add_box.html:20 src/olympia/reviews/templates/reviews/mobile/add_form.html:16
 msgid "Rating:"
 msgstr "Osztályzat:"
 
-#: src/olympia/addons/templates/addons/review_add_box.html:19
-#: src/olympia/addons/templates/addons/impala/review_add_box.html:21
-#: src/olympia/reviews/templates/reviews/add.html:63
-#: src/olympia/reviews/templates/reviews/edit_review.html:15
-#: src/olympia/reviews/templates/reviews/mobile/add_form.html:18
+#: src/olympia/addons/templates/addons/review_add_box.html:19 src/olympia/addons/templates/addons/impala/review_add_box.html:21 src/olympia/reviews/templates/reviews/add.html:63
+#: src/olympia/reviews/templates/reviews/edit_review.html:15 src/olympia/reviews/templates/reviews/mobile/add_form.html:18
 msgid "Submit review"
 msgstr "Értékelés beküldése"
 
-#: src/olympia/addons/templates/addons/review_add_box.html:24
-#: src/olympia/addons/templates/addons/impala/review_add_box.html:26
-msgid ""
-"Please do not post bug reports in reviews. We do not make your email address"
-" available to add-on developers and they may need to contact you to help "
-"resolve your issue."
-msgstr ""
-"Kérjük, ne írjon hibajelentést az értékelésbe. Az e-mail címét nem adjuk "
-"tovább a kiegészítők fejlesztőinek, és esetleg szükség lehet a "
-"kapcsolatfelvételre a probléma megoldásához."
+#: src/olympia/addons/templates/addons/review_add_box.html:24 src/olympia/addons/templates/addons/impala/review_add_box.html:26
+msgid "Please do not post bug reports in reviews. We do not make your email address available to add-on developers and they may need to contact you to help resolve your issue."
+msgstr "Kérjük, ne írjon hibajelentést az értékelésbe. Az e-mail címét nem adjuk tovább a kiegészítők fejlesztőinek, és esetleg szükség lehet a kapcsolatfelvételre a probléma megoldásához."
 
-#: src/olympia/addons/templates/addons/review_add_box.html:32
-#: src/olympia/addons/templates/addons/impala/review_add_box.html:35
+#: src/olympia/addons/templates/addons/review_add_box.html:32 src/olympia/addons/templates/addons/impala/review_add_box.html:35
 #, python-format
-msgid ""
-"See the <a href=\"%(support)s\">support section</a> to find out where to get"
-" assistance for this add-on."
-msgstr ""
-"Nézze meg a <a href=\"%(support)s\">támogatói részt</a>, hogy megtudja, "
-"hogyan kérhet segítséget ehhez a kiegészítőhöz."
+msgid "See the <a href=\"%(support)s\">support section</a> to find out where to get assistance for this add-on."
+msgstr "Nézze meg a <a href=\"%(support)s\">támogatói részt</a>, hogy megtudja, hogyan kérhet segítséget ehhez a kiegészítőhöz."
 
-#: src/olympia/addons/templates/addons/review_add_box.html:38
-#: src/olympia/addons/templates/addons/impala/review_add_box.html:42
-#: src/olympia/pages/templates/pages/review_guide.html:3
+#: src/olympia/addons/templates/addons/review_add_box.html:38 src/olympia/addons/templates/addons/impala/review_add_box.html:42 src/olympia/pages/templates/pages/review_guide.html:3
 #: src/olympia/pages/templates/pages/review_guide.html:44
 msgid "Review Guidelines"
 msgstr "Értékelési útmutató"
 
-#: src/olympia/addons/templates/addons/review_list_box.html:5
-#: src/olympia/addons/templates/addons/impala/details-more.html:27
-#: src/olympia/editors/helpers.py:921
-#: src/olympia/reviews/templates/reviews/add.html:14
-#: src/olympia/reviews/templates/reviews/reply.html:14
-#: src/olympia/reviews/templates/reviews/review_list.html:19
+#: src/olympia/addons/templates/addons/review_list_box.html:5 src/olympia/addons/templates/addons/impala/details-more.html:27 src/olympia/editors/helpers.py:1001
+#: src/olympia/reviews/templates/reviews/add.html:14 src/olympia/reviews/templates/reviews/reply.html:14 src/olympia/reviews/templates/reviews/review_list.html:19
 #: src/olympia/reviews/templates/reviews/mobile/review_list.html:26
 msgid "Reviews"
 msgstr "Értékelések"
 
-#: src/olympia/addons/templates/addons/review_list_box.html:14
-#: src/olympia/addons/templates/addons/impala/review_list_box.html:14
-#: src/olympia/reviews/templates/reviews/review.html:30
+#: src/olympia/addons/templates/addons/review_list_box.html:14 src/olympia/addons/templates/addons/impala/review_list_box.html:14 src/olympia/reviews/templates/reviews/review.html:30
 #, python-format
 msgid "by %(user)s on %(date)s"
 msgstr "készítette: %(user)s, %(date)s"
 
-#: src/olympia/addons/templates/addons/review_list_box.html:19
-#: src/olympia/addons/templates/addons/impala/review_list_box.html:29
+#: src/olympia/addons/templates/addons/review_list_box.html:19 src/olympia/addons/templates/addons/impala/review_list_box.html:29
 msgid "Show the developer's reply to this review"
 msgstr "Fejlesztő választásának megjelenítése ehhez az értékeléshez"
 
@@ -1252,21 +918,16 @@ msgid_plural "See all %(cnt)s reviews of this add-on"
 msgstr[0] "Kiegészítő összes értékelésének megtekintése"
 msgstr[1] "Kiegészítő összes (%(cnt)s) értékelésének megtekintése"
 
-#: src/olympia/addons/templates/addons/tags_box.html:3
-#: src/olympia/devhub/templates/devhub/addons/edit/basic.html:118
+#: src/olympia/addons/templates/addons/tags_box.html:3 src/olympia/devhub/templates/devhub/addons/edit/basic.html:118
 msgid "Tags"
 msgstr "Címkék"
 
-#: src/olympia/addons/templates/addons/impala/addon_hovercard.html:7
-#: src/olympia/addons/templates/addons/impala/addon_hovercard.html:9
+#: src/olympia/addons/templates/addons/impala/addon_hovercard.html:7 src/olympia/addons/templates/addons/impala/addon_hovercard.html:9
 msgid "Icon for {0}"
 msgstr "Ikonja: {0}"
 
-#: src/olympia/addons/templates/addons/impala/addon_hovercard.html:34
-#: src/olympia/addons/templates/addons/impala/featured_grid.html:26
-#: src/olympia/addons/templates/addons/impala/theme_grid.html:22
-#: src/olympia/bandwagon/templates/bandwagon/collection_detail.html:31
-#: src/olympia/users/templates/users/helpers/addon_users_list.html:7
+#: src/olympia/addons/templates/addons/impala/addon_hovercard.html:34 src/olympia/addons/templates/addons/impala/featured_grid.html:26 src/olympia/addons/templates/addons/impala/theme_grid.html:22
+#: src/olympia/bandwagon/templates/bandwagon/collection_detail.html:31 src/olympia/users/templates/users/helpers/addon_users_list.html:7
 #, python-format
 msgid "by %(users)s"
 msgstr "írta: %(users)s"
@@ -1286,32 +947,18 @@ msgstr "Tetszett ez a kiegészítő?"
 
 #: src/olympia/addons/templates/addons/impala/contribution.html:43
 #, python-format
-msgid ""
-"The <a href=\"%(meet_url)s\">developer of this add-on</a> asks that you help"
-" support its continued development by making a small contribution."
-msgstr ""
-"A <a href=\"%(meet_url)s\">kiegészítő fejlesztője</a> támogatást kér a "
-"kiegészítő fejlesztésének folytatásához."
+msgid "The <a href=\"%(meet_url)s\">developer of this add-on</a> asks that you help support its continued development by making a small contribution."
+msgstr "A <a href=\"%(meet_url)s\">kiegészítő fejlesztője</a> támogatást kér a kiegészítő fejlesztésének folytatásához."
 
 #: src/olympia/addons/templates/addons/impala/contribution.html:48
 #, python-format
-msgid ""
-"The <a href=\"%(meet_url)s\">developer of this add-on</a> asks that you show"
-" your support by making a donation to the <a "
-"href=\"%(charity_url)s\">%(charity_name)s</a>."
-msgstr ""
-"A <a href=\"%(meet_url)s\">kiegészítő fejlesztője</a> kéri, hogy adománnyal "
-"támogassa munkáját: <a href=\"%(charity_url)s\">%(charity_name)s</a>."
+msgid "The <a href=\"%(meet_url)s\">developer of this add-on</a> asks that you show your support by making a donation to the <a href=\"%(charity_url)s\">%(charity_name)s</a>."
+msgstr "A <a href=\"%(meet_url)s\">kiegészítő fejlesztője</a> kéri, hogy adománnyal támogassa munkáját: <a href=\"%(charity_url)s\">%(charity_name)s</a>."
 
 #: src/olympia/addons/templates/addons/impala/contribution.html:53
 #, python-format
-msgid ""
-"The <a href=\"%(meet_url)s\">developer of this add-on</a> asks that you show"
-" your support by making a small contribution to <a "
-"href=\"%(charity_url)s\">%(charity_name)s</a>."
-msgstr ""
-"A <a href=\"%(meet_url)s\">kiegészítő fejlesztője</a> adományt kér a(z) <a "
-"href=\"%(charity_url)s\">%(charity_name)s</a> munkájának támogatásához."
+msgid "The <a href=\"%(meet_url)s\">developer of this add-on</a> asks that you show your support by making a small contribution to <a href=\"%(charity_url)s\">%(charity_name)s</a>."
+msgstr "A <a href=\"%(meet_url)s\">kiegészítő fejlesztője</a> adományt kér a(z) <a href=\"%(charity_url)s\">%(charity_name)s</a> munkájának támogatásához."
 
 #: src/olympia/addons/templates/addons/impala/dependencies_note.html:4
 msgid "This add-on requires the following add-ons to work properly:"
@@ -1340,32 +987,31 @@ msgid_plural "Other add-ons by these authors"
 msgstr[0] "%(author)s további kiegészítői"
 msgstr[1] "A szerzők további kiegészítői"
 
-#: src/olympia/addons/templates/addons/impala/details.html:41
+#: src/olympia/addons/templates/addons/impala/details.html:39
 #, python-format
 msgid "<span itemprop=\"ratingCount\">%(num)s</span> user review"
 msgid_plural "<span itemprop=\"ratingCount\">%(num)s</span> user reviews"
 msgstr[0] "<span itemprop=\"ratingCount\">%(num)s</span> felhasználói értékelés"
 msgstr[1] "<span itemprop=\"ratingCount\">%(num)s</span> felhasználói értékelés"
 
-#: src/olympia/addons/templates/addons/impala/details.html:69
+#: src/olympia/addons/templates/addons/impala/details.html:66
 msgid "View statistics"
 msgstr "Statisztika megtekintése"
 
-#: src/olympia/addons/templates/addons/impala/details.html:84
+#: src/olympia/addons/templates/addons/impala/details.html:81
 msgid "Manage"
 msgstr "Beállítás"
 
 #. {0} is an add-on name.
-#: src/olympia/addons/templates/addons/impala/details.html:96
+#: src/olympia/addons/templates/addons/impala/details.html:93
 msgid "Icon of {0}"
 msgstr "{0} ikonja"
 
-#: src/olympia/addons/templates/addons/impala/details.html:103
-#: src/olympia/addons/templates/addons/impala/listing/items.html:14
+#: src/olympia/addons/templates/addons/impala/details.html:100 src/olympia/addons/templates/addons/impala/listing/items.html:14
 msgid "No Restart"
 msgstr "Nincs újraindítás"
 
-#: src/olympia/addons/templates/addons/impala/details.html:127
+#: src/olympia/addons/templates/addons/impala/details.html:124
 #, python-format
 msgid "Meet the Developer: <a href=\"%(url)s\">%(name)s</a>"
 msgid_plural "<a href=\"%(url)s\">Meet the Developers</a>"
@@ -1373,115 +1019,90 @@ msgstr[0] "Ismerje meg a fejlesztőt: <a href=\"%(url)s\">%(name)s</a>"
 msgstr[1] "<a href=\"%(url)s\">Ismerje meg a fejlesztőket</a>"
 
 # {0} is an add-on name.
-#: src/olympia/addons/templates/addons/impala/details.html:137
+#: src/olympia/addons/templates/addons/impala/details.html:134
 msgid "Learn why {0} was created and find out what's next for this add-on."
-msgstr ""
-"Ismerje meg a(z) {0} létrejöttének okát, és hogy mi következik a kiegészítő "
-"fejlesztésében."
+msgstr "Ismerje meg a(z) {0} létrejöttének okát, és hogy mi következik a kiegészítő fejlesztésében."
 
 #. {0} is an index.
-#: src/olympia/addons/templates/addons/impala/details.html:156
+#: src/olympia/addons/templates/addons/impala/details.html:161
 msgid "Add-on screenshot #{0}"
 msgstr "Kiegészítő {0}. képernyőképe"
 
-#: src/olympia/addons/templates/addons/impala/details.html:182
+#: src/olympia/addons/templates/addons/impala/details.html:187
 msgid "Add-on home page"
 msgstr "Kiegészítő honlapja"
 
-#: src/olympia/addons/templates/addons/impala/details.html:185
+#: src/olympia/addons/templates/addons/impala/details.html:190
 msgid "Support site"
 msgstr "Támogatói oldal"
 
-#: src/olympia/addons/templates/addons/impala/details.html:189
+#: src/olympia/addons/templates/addons/impala/details.html:194
 msgid "Support E-mail"
 msgstr "Támogatás levélben"
 
-#: src/olympia/addons/templates/addons/impala/details.html:194
-#: src/olympia/devhub/models.py:378
-#: src/olympia/devhub/templates/devhub/versions/list.html:12
-#: src/olympia/versions/templates/versions/version.html:6
-#: src/olympia/versions/templates/versions/mobile/version.html:6
+#: src/olympia/addons/templates/addons/impala/details.html:199 src/olympia/devhub/models.py:378 src/olympia/devhub/templates/devhub/versions/list.html:12
+#: src/olympia/versions/templates/versions/version.html:6 src/olympia/versions/templates/versions/mobile/version.html:6
 msgid "Version {0}"
 msgstr "{0} verzió"
 
-#: src/olympia/addons/templates/addons/impala/details.html:194
+#: src/olympia/addons/templates/addons/impala/details.html:199
 msgid "Info"
 msgstr "Info"
 
-#: src/olympia/addons/templates/addons/impala/details.html:195
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:129
+#: src/olympia/addons/templates/addons/impala/details.html:200 src/olympia/devhub/templates/devhub/includes/addon_details.html:116
 msgid "Last Updated:"
 msgstr "Legutóbbi frissítés:"
 
-#: src/olympia/addons/templates/addons/impala/details.html:200
+#: src/olympia/addons/templates/addons/impala/details.html:205
 #, python-format
 msgid "Released under <a target=\"_blank\" href=\"%(url)s\">%(name)s</a>"
 msgstr "<a target=\"_blank\" href=\"%(url)s\">%(name)s</a> alatt jelenik meg"
 
-#: src/olympia/addons/templates/addons/impala/details.html:201
-#: src/olympia/addons/templates/addons/impala/details.html:206
-#: src/olympia/amo/helpers.py:398 src/olympia/devhub/forms.py:142
-#: src/olympia/devhub/forms.py:173
-#: src/olympia/versions/templates/versions/version.html:40
-#: src/olympia/versions/templates/versions/version.html:45
+#: src/olympia/addons/templates/addons/impala/details.html:206 src/olympia/addons/templates/addons/impala/details.html:211 src/olympia/amo/helpers.py:398 src/olympia/devhub/forms.py:142
+#: src/olympia/devhub/forms.py:173 src/olympia/versions/templates/versions/version.html:40 src/olympia/versions/templates/versions/version.html:45
 msgid "Custom License"
 msgstr "Egyéni licenc"
 
-#: src/olympia/addons/templates/addons/impala/details.html:205
+#: src/olympia/addons/templates/addons/impala/details.html:210
 #, python-format
 msgid "Released under <a href=\"%(url)s\">%(name)s</a>"
 msgstr "<a href=\"%(url)s\">%(name)s</a> alatt jelenik meg"
 
-#: src/olympia/addons/templates/addons/impala/details.html:217
+#: src/olympia/addons/templates/addons/impala/details.html:222
 msgid "About this Add-on"
 msgstr "Kiegészítő névjegye"
 
-#: src/olympia/addons/templates/addons/impala/details.html:233
+#: src/olympia/addons/templates/addons/impala/details.html:238
 msgid "Developer’s Comments"
 msgstr "Fejlesztő megjegyzései"
 
-#: src/olympia/addons/templates/addons/impala/details.html:243
+#: src/olympia/addons/templates/addons/impala/details.html:248
 msgid "Version Information"
 msgstr "Verzióinformációk"
 
-#: src/olympia/addons/templates/addons/impala/details.html:250
+#: src/olympia/addons/templates/addons/impala/details.html:255
 msgid "See complete version history"
 msgstr "Teljes verziótörténet megtekintése"
 
-#: src/olympia/addons/templates/addons/impala/details.html:262
+#: src/olympia/addons/templates/addons/impala/details.html:267
 msgid ""
-"The Development Channel lets you test an experimental new version of this "
-"add-on before it's released to the general public. Once you install the "
-"development version, you will continue to get updates from this channel. To "
-"stop receiving development updates, reinstall the default version from the "
-"link above."
+"The Development Channel lets you test an experimental new version of this add-on before it's released to the general public. Once you install the development version, you will continue to get "
+"updates from this channel. To stop receiving development updates, reinstall the default version from the link above."
 msgstr ""
-"A Fejlesztői csatorna segítségével a hivatalos megjelenés előtt "
-"kipróbálhatja a kiegészítő legfrissebb verzióját. A fejlesztői verzió "
-"telepítését követően folyamatosan érkeznek a frissítések erről a "
-"csatornáról. Amennyiben nem kíván több fejlesztői frissítést kapni, "
-"telepítse újra a hivatalos verziót a fenti hivatkozás segítségével."
+"A Fejlesztői csatorna segítségével a hivatalos megjelenés előtt kipróbálhatja a kiegészítő legfrissebb verzióját. A fejlesztői verzió telepítését követően folyamatosan érkeznek a frissítések erről "
+"a csatornáról. Amennyiben nem kíván több fejlesztői frissítést kapni, telepítse újra a hivatalos verziót a fenti hivatkozás segítségével."
 
-#: src/olympia/addons/templates/addons/impala/details.html:272
-msgid ""
-"<strong>Caution:</strong> Development versions of this add-on have not been "
-"reviewed by Mozilla."
-msgstr ""
-"<strong>Figyelmeztetés:</strong> Ezen kiegészítő fejlesztői verzióit a "
-"Mozilla nem vizsgálta."
+#: src/olympia/addons/templates/addons/impala/details.html:277
+msgid "<strong>Caution:</strong> Development versions of this add-on have not been reviewed by Mozilla."
+msgstr "<strong>Figyelmeztetés:</strong> Ezen kiegészítő fejlesztői verzióit a Mozilla nem vizsgálta."
 
-#: src/olympia/addons/templates/addons/impala/details.html:287
+#: src/olympia/addons/templates/addons/impala/details.html:292
 msgid "See complete development channel history"
 msgstr "Teljes verziótörténet megtekintése"
 
-#: src/olympia/addons/templates/addons/impala/details.html:306
-#: src/olympia/addons/templates/addons/impala/details.html:315
-#: src/olympia/addons/templates/addons/impala/details.html:327
-#: src/olympia/addons/templates/addons/impala/review_add_box.html:4
-#: src/olympia/stats/templates/stats/popup.html:2
-#: src/olympia/stats/templates/stats/popup.html:8
-#: src/olympia/stats/templates/stats/stats.html:202
-#: src/olympia/users/templates/users/profile.html:119
+#: src/olympia/addons/templates/addons/impala/details.html:311 src/olympia/addons/templates/addons/impala/details.html:320 src/olympia/addons/templates/addons/impala/details.html:332
+#: src/olympia/addons/templates/addons/impala/review_add_box.html:4 src/olympia/stats/templates/stats/popup.html:2 src/olympia/stats/templates/stats/popup.html:8
+#: src/olympia/stats/templates/stats/stats.html:204 src/olympia/users/templates/users/profile.html:119
 msgid "close"
 msgstr "bezárás"
 
@@ -1496,12 +1117,8 @@ msgid "Meet the {0} Developer"
 msgstr "Ismerje meg a(z) {0} fejlesztőt"
 
 #: src/olympia/addons/templates/addons/impala/developers.html:41
-msgid ""
-"Before downloading this add-on, please consider supporting the development "
-"of this add-on by making a small contribution."
-msgstr ""
-"A kiegészítő letöltése előtt, kérjük, fontolja meg, hogy egy szerény "
-"adománnyal támogatja a kiegészítő fejlesztését."
+msgid "Before downloading this add-on, please consider supporting the development of this add-on by making a small contribution."
+msgstr "A kiegészítő letöltése előtt, kérjük, fontolja meg, hogy egy szerény adománnyal támogatja a kiegészítő fejlesztését."
 
 # %1 is an add-on name.
 #: src/olympia/addons/templates/addons/impala/developers.html:80
@@ -1519,9 +1136,7 @@ msgid_plural "About the Developers"
 msgstr[0] "A fejlesztőről"
 msgstr[1] "A fejlesztőkről"
 
-#: src/olympia/addons/templates/addons/impala/developers.html:96
-#: src/olympia/users/templates/users/edit.html:130
-#: src/olympia/users/templates/users/profile.html:26
+#: src/olympia/addons/templates/addons/impala/developers.html:96 src/olympia/users/templates/users/edit.html:130 src/olympia/users/templates/users/profile.html:26
 msgid "No Photo"
 msgstr "Nincs fénykép"
 
@@ -1541,24 +1156,15 @@ msgstr "Ezt a kiegészítőt az adminisztrátor letiltotta."
 msgid "Source Code License for {addon}"
 msgstr "{addon} forráskód licence"
 
-#: src/olympia/addons/templates/addons/impala/license.html:21
-#: src/olympia/versions/templates/versions/mobile/version.html:18
+#: src/olympia/addons/templates/addons/impala/license.html:21 src/olympia/versions/templates/versions/mobile/version.html:18
 msgid "Source Code License"
 msgstr "Forráskód licence"
 
-#: src/olympia/addons/templates/addons/impala/persona_grid.html:16
-#: src/olympia/addons/templates/addons/impala/toplist.html:6
-msgid "{0} users"
-msgstr "{0} felhasználó"
-
-#: src/olympia/addons/templates/addons/impala/review_list_box.html:19
-#: src/olympia/reviews/templates/reviews/review.html:40
+#: src/olympia/addons/templates/addons/impala/review_list_box.html:19 src/olympia/reviews/templates/reviews/review.html:40
 msgid "permalink"
 msgstr "közvetlen hivatkozás"
 
-#: src/olympia/addons/templates/addons/impala/review_list_box.html:23
-#: src/olympia/editors/templates/editors/queue.html:98
-#: src/olympia/reviews/templates/reviews/review.html:44
+#: src/olympia/addons/templates/addons/impala/review_list_box.html:23 src/olympia/editors/templates/editors/queue.html:104 src/olympia/reviews/templates/reviews/review.html:44
 msgid "translate"
 msgstr "fordítás"
 
@@ -1569,8 +1175,7 @@ msgid_plural "See all %(cnt)s user reviews"
 msgstr[0] "Összes felhasználói értékelés megtekintése"
 msgstr[1] "Összes felhasználói értékelés (%(cnt)s) megtekintése"
 
-#: src/olympia/addons/templates/addons/impala/review_list_box.html:47
-#: src/olympia/reviews/templates/reviews/review_list.html:84
+#: src/olympia/addons/templates/addons/impala/review_list_box.html:47 src/olympia/reviews/templates/reviews/review_list.html:84
 msgid "This add-on has not yet been reviewed."
 msgstr "Ezt a kiegészítőt még senki sem értékelte."
 
@@ -1578,24 +1183,23 @@ msgstr "Ezt a kiegészítőt még senki sem értékelte."
 msgid "Be the first!"
 msgstr "Legyen az első!"
 
-#: src/olympia/addons/templates/addons/impala/listing/sorter.html:14
-#: src/olympia/devhub/templates/devhub/addons/listing/item_actions.html:49
+#: src/olympia/addons/templates/addons/impala/toplist.html:6
+msgid "{0} users"
+msgstr "{0} felhasználó"
+
+#: src/olympia/addons/templates/addons/impala/listing/sorter.html:14 src/olympia/devhub/templates/devhub/addons/listing/item_actions.html:49
 msgid "More"
 msgstr "Tovább"
 
-#: src/olympia/addons/templates/addons/includes/collection_add_widget.html:7
-#: src/olympia/addons/templates/addons/includes/collection_add_widget.html:10
+#: src/olympia/addons/templates/addons/includes/collection_add_widget.html:7 src/olympia/addons/templates/addons/includes/collection_add_widget.html:10
 msgid "Add to collection"
 msgstr "Hozzáadás gyűjteményhez"
 
-#: src/olympia/addons/templates/addons/includes/dashboard_tabs.html:4
-#: src/olympia/devhub/templates/devhub/index.html:73
-#: src/olympia/devhub/templates/devhub/nav.html:14
+#: src/olympia/addons/templates/addons/includes/dashboard_tabs.html:4 src/olympia/devhub/templates/devhub/index.html:73 src/olympia/devhub/templates/devhub/nav.html:14
 msgid "My Add-ons"
 msgstr "Saját kiegészítők"
 
-#: src/olympia/addons/templates/addons/includes/dashboard_tabs.html:6
-#: src/olympia/amo/context_processors.py:51
+#: src/olympia/addons/templates/addons/includes/dashboard_tabs.html:6 src/olympia/amo/context_processors.py:52
 msgid "My Themes"
 msgstr "Saját témák"
 
@@ -1611,8 +1215,7 @@ msgstr "Téma szerkesztése"
 msgid "Approve / Reject"
 msgstr "Elfogadás / Visszautasítás"
 
-#: src/olympia/addons/templates/addons/includes/persona.html:25
-#: src/olympia/editors/templates/editors/themes/single.html:43
+#: src/olympia/addons/templates/addons/includes/persona.html:25 src/olympia/editors/templates/editors/themes/single.html:43
 msgid "Review History"
 msgstr "Értékelések előzményei"
 
@@ -1633,9 +1236,7 @@ msgid "Not Yet Rated"
 msgstr "Még nem értékelt"
 
 #. {0} is the number of downloads.
-#: src/olympia/addons/templates/addons/listing/items_mobile.html:27
-#: src/olympia/addons/templates/addons/listing/macros.html:24
-#: src/olympia/devhub/templates/devhub/addons/listing/macros.html:15
+#: src/olympia/addons/templates/addons/listing/items_mobile.html:27 src/olympia/addons/templates/addons/listing/macros.html:24 src/olympia/devhub/templates/devhub/addons/listing/macros.html:15
 msgid "<strong>{0}</strong> weekly download"
 msgid_plural "<strong>{0}</strong> weekly downloads"
 msgstr[0] "<strong>{0}</strong> letöltés hetente"
@@ -1649,15 +1250,11 @@ msgstr "Tovább"
 msgid "Users"
 msgstr "Felhasználók"
 
-#: src/olympia/addons/templates/addons/mobile/details.html:92
-#: src/olympia/browse/views.py:59 src/olympia/browse/views.py:70
-#: src/olympia/search/forms.py:90
+#: src/olympia/addons/templates/addons/mobile/details.html:92 src/olympia/browse/views.py:59 src/olympia/browse/views.py:70 src/olympia/search/forms.py:90
 msgid "Weekly Downloads"
 msgstr "Heti letöltések"
 
-#: src/olympia/addons/templates/addons/mobile/details.html:99
-#: src/olympia/compat/templates/compat/reporter_detail.html:46
-#: src/olympia/devhub/forms.py:787
+#: src/olympia/addons/templates/addons/mobile/details.html:99 src/olympia/compat/templates/compat/reporter_detail.html:46 src/olympia/devhub/forms.py:788
 #: src/olympia/devhub/templates/devhub/versions/list.html:163
 msgid "Version"
 msgstr "Verzió"
@@ -1693,50 +1290,29 @@ msgstr "Felhasználói licencszerződés"
 
 #: src/olympia/addons/templates/addons/mobile/eula.html:5
 #, python-format
-msgid ""
-"%(name)s requires that you accept the following End-User License Agreement "
-"before installation can proceed:"
-msgstr ""
-"A(z) %(name)s telepítése előtt el kell fogadnia a következő Végfelhasználói "
-"licencszerződést:"
+msgid "%(name)s requires that you accept the following End-User License Agreement before installation can proceed:"
+msgstr "A(z) %(name)s telepítése előtt el kell fogadnia a következő Végfelhasználói licencszerződést:"
 
 #: src/olympia/addons/templates/addons/mobile/eula.html:15
 msgid "Accept"
 msgstr "Elfogadás"
 
-#: src/olympia/addons/templates/addons/mobile/home.html:10
-#: src/olympia/templates/mobile/base_addons.html:53
+#: src/olympia/addons/templates/addons/mobile/home.html:10 src/olympia/templates/mobile/base_addons.html:53
 msgid "Add-ons are not currently available on Firefox for iOS."
 msgstr "Firefox iOS-en jelenleg nem elérhetők a kiegészítők."
 
-#: src/olympia/addons/templates/addons/mobile/home.html:12
-#: src/olympia/templates/mobile/base_addons.html:55
-msgid ""
-"You need Firefox to install add-ons. <a "
-"href=\"http://mozilla.com/mobile\">Learn More&nbsp;&raquo;</a>"
-msgstr ""
-"A kiegészítők telepítéséhez szüksége van egy Firefox böngészőre <a "
-"href=\"http://mozilla.com/mobile\">Ismerje meg&nbsp;&raquo;</a>"
+#: src/olympia/addons/templates/addons/mobile/home.html:12 src/olympia/templates/mobile/base_addons.html:55
+msgid "You need Firefox to install add-ons. <a href=\"http://mozilla.com/mobile\">Learn More&nbsp;&raquo;</a>"
+msgstr "A kiegészítők telepítéséhez szüksége van egy Firefox böngészőre <a href=\"http://mozilla.com/mobile\">Ismerje meg&nbsp;&raquo;</a>"
 
 # {0} is the application name.  Example:  Firefox
-#: src/olympia/addons/templates/addons/mobile/home.html:19
-#: src/olympia/templates/header_title.html:4
-#: src/olympia/templates/impala/header_title.html:3
+#: src/olympia/addons/templates/addons/mobile/home.html:19 src/olympia/templates/header_title.html:4 src/olympia/templates/impala/header_title.html:3
 msgid "Return to the {0} Add-ons homepage"
 msgstr "Visszatérés a {0}-kiegészítők honlapjára"
 
-#: src/olympia/addons/templates/addons/mobile/home.html:21
-#: src/olympia/amo/helpers.py:237
-#: src/olympia/bandwagon/templates/bandwagon/edit.html:34
-#: src/olympia/discovery/templates/discovery/pane.html:92
-#: src/olympia/editors/templates/editors/base.html:21
-#: src/olympia/editors/templates/editors/performance.html:72
-#: src/olympia/templates/menu_links.html:4
-#: src/olympia/templates/impala/header_title.html:13
-#: src/olympia/templates/impala/header_title.html:15
-#: src/olympia/templates/impala/header_title.html:19
-#: src/olympia/templates/impala/header_title.html:23
-#: src/olympia/templates/mobile/base_addons.html:47
+#: src/olympia/addons/templates/addons/mobile/home.html:21 src/olympia/amo/helpers.py:237 src/olympia/bandwagon/templates/bandwagon/edit.html:34 src/olympia/discovery/templates/discovery/pane.html:92
+#: src/olympia/editors/templates/editors/base.html:21 src/olympia/editors/templates/editors/performance.html:72 src/olympia/templates/menu_links.html:4 src/olympia/templates/impala/header_title.html:13
+#: src/olympia/templates/impala/header_title.html:15 src/olympia/templates/impala/header_title.html:19 src/olympia/templates/impala/header_title.html:23 src/olympia/templates/mobile/base_addons.html:47
 msgid "Add-ons"
 msgstr "Kiegészítők"
 
@@ -1744,48 +1320,27 @@ msgstr "Kiegészítők"
 msgid "Easy ways to personalize."
 msgstr "Testreszabás egyszerű módjai."
 
-#: src/olympia/addons/templates/addons/mobile/home.html:24
-#: src/olympia/devhub/templates/devhub/addons/submit/done.html:47
-#: src/olympia/discovery/templates/discovery/pane.html:34
-#: src/olympia/discovery/templates/discovery/addons/detail.html:16
-#: src/olympia/discovery/templates/discovery/modules/featured.html:21
-#: src/olympia/discovery/templates/discovery/modules/monthly.html:22
+#: src/olympia/addons/templates/addons/mobile/home.html:24 src/olympia/devhub/templates/devhub/addons/submit/done.html:47 src/olympia/discovery/templates/discovery/pane.html:34
+#: src/olympia/discovery/templates/discovery/addons/detail.html:16 src/olympia/discovery/templates/discovery/modules/featured.html:21 src/olympia/discovery/templates/discovery/modules/monthly.html:22
 msgid "Learn More"
 msgstr "További infó"
 
 #: src/olympia/addons/templates/addons/mobile/home.html:26
 msgid ""
-"Add-ons are applications that let you personalize Firefox with extra "
-"functionality and style. Whether you mistype the name of a website or can't "
-"read a busy page, there's an add-on to improve your on-the-go browsing."
+"Add-ons are applications that let you personalize Firefox with extra functionality and style. Whether you mistype the name of a website or can't read a busy page, there's an add-on to improve your "
+"on-the-go browsing."
 msgstr ""
-"A kiegészítők olyan alkalmazások, amelyek segítségével személyre szabható a "
-"Firefox böngésző, így extra funkciókat és megjelenést kaphat. Ha elütötte a "
-"weboldal nevét vagy nem tud elolvasni egy túlzsúfolt weboldalt, biztos talál"
-" egy kiegészítőt, amely segítségére lehet."
+"A kiegészítők olyan alkalmazások, amelyek segítségével személyre szabható a Firefox böngésző, így extra funkciókat és megjelenést kaphat. Ha elütötte a weboldal nevét vagy nem tud elolvasni egy "
+"túlzsúfolt weboldalt, biztos talál egy kiegészítőt, amely segítségére lehet."
 
 #. {0} is a category name. Ex: "Sports"
 #. {0} is a category name, such as Nature.
-#: src/olympia/addons/templates/addons/mobile/home.html:43
-#: src/olympia/amo/templates/amo/site_nav.html:32
-#: src/olympia/browse/feeds.py:107
-#: src/olympia/browse/templates/browse/impala/base_listing.html:38
-#: src/olympia/browse/templates/browse/personas/base.html:6
-#: src/olympia/browse/templates/browse/personas/base.html:42
-#: src/olympia/browse/templates/browse/personas/category_landing.html:21
-#: src/olympia/browse/templates/browse/personas/category_landing.html:23
-#: src/olympia/browse/templates/browse/personas/category_landing.html:38
-#: src/olympia/browse/templates/browse/personas/grid.html:7
-#: src/olympia/browse/templates/browse/personas/grid.html:11
-#: src/olympia/browse/templates/browse/personas/mobile/base.html:7
-#: src/olympia/browse/templates/browse/personas/mobile/category_landing.html:19
-#: src/olympia/constants/base.py:180
-#: src/olympia/devhub/templates/devhub/personas/submit.html:13
-#: src/olympia/editors/helpers.py:105
-#: src/olympia/editors/templates/editors/base.html:26
-#: src/olympia/editors/templates/editors/performance.html:73
-#: src/olympia/search/templates/search/personas.html:39
-#: src/olympia/templates/menu_links.html:9
+#: src/olympia/addons/templates/addons/mobile/home.html:43 src/olympia/amo/templates/amo/site_nav.html:32 src/olympia/browse/feeds.py:107 src/olympia/browse/templates/browse/impala/base_listing.html:38
+#: src/olympia/browse/templates/browse/personas/base.html:6 src/olympia/browse/templates/browse/personas/base.html:42 src/olympia/browse/templates/browse/personas/category_landing.html:21
+#: src/olympia/browse/templates/browse/personas/category_landing.html:23 src/olympia/browse/templates/browse/personas/category_landing.html:38 src/olympia/browse/templates/browse/personas/grid.html:7
+#: src/olympia/browse/templates/browse/personas/grid.html:11 src/olympia/browse/templates/browse/personas/mobile/base.html:7 src/olympia/browse/templates/browse/personas/mobile/category_landing.html:19
+#: src/olympia/constants/base.py:180 src/olympia/devhub/templates/devhub/personas/submit.html:13 src/olympia/editors/helpers.py:107 src/olympia/editors/templates/editors/base.html:26
+#: src/olympia/editors/templates/editors/performance.html:73 src/olympia/search/templates/search/personas.html:39 src/olympia/templates/menu_links.html:9
 msgid "Themes"
 msgstr "Témák"
 
@@ -1801,19 +1356,12 @@ msgstr "Az összes népszerű kiegészítő megtekintése"
 msgid "More Add-ons"
 msgstr "További kiegészítők"
 
-#: src/olympia/addons/templates/addons/mobile/home.html:72
-#: src/olympia/browse/templates/browse/personas/mobile/category_landing.html:64
-#: src/olympia/search/forms.py:14
+#: src/olympia/addons/templates/addons/mobile/home.html:72 src/olympia/browse/templates/browse/personas/mobile/category_landing.html:64 src/olympia/search/forms.py:14
 msgid "Highest Rated"
 msgstr "Legjobb értékelés"
 
-#: src/olympia/addons/templates/addons/mobile/home.html:74
-#: src/olympia/amo/templates/amo/side_nav.html:5
-#: src/olympia/amo/templates/amo/site_nav.html:27
-#: src/olympia/amo/templates/amo/site_nav.html:57
-#: src/olympia/bandwagon/views.py:97 src/olympia/browse/views.py:57
-#: src/olympia/browse/views.py:67
-#: src/olympia/browse/templates/browse/personas/mobile/category_landing.html:65
+#: src/olympia/addons/templates/addons/mobile/home.html:74 src/olympia/amo/templates/amo/side_nav.html:5 src/olympia/amo/templates/amo/site_nav.html:27 src/olympia/amo/templates/amo/site_nav.html:55
+#: src/olympia/bandwagon/views.py:97 src/olympia/browse/views.py:57 src/olympia/browse/views.py:67 src/olympia/browse/templates/browse/personas/mobile/category_landing.html:65
 #: src/olympia/search/forms.py:15 src/olympia/search/forms.py:87
 msgid "Newest"
 msgstr "Legújabb"
@@ -1826,122 +1374,88 @@ msgstr "Próbálja ki!"
 msgid "Theme Info &raquo;"
 msgstr "Téma információ &raquo;"
 
-#: src/olympia/amo/context_processors.py:39
-#: src/olympia/devhub/templates/devhub/nav.html:43
+#: src/olympia/amo/context_processors.py:39 src/olympia/devhub/templates/devhub/nav.html:43
 msgid "Tools"
 msgstr "Eszközök"
 
-#: src/olympia/amo/context_processors.py:48
-#: src/olympia/discovery/templates/discovery/pane_account.html:8
-#: src/olympia/users/templates/users/includes/navigation.html:2
+#: src/olympia/amo/context_processors.py:49 src/olympia/discovery/templates/discovery/pane_account.html:8 src/olympia/users/templates/users/includes/navigation.html:2
 msgid "My Profile"
 msgstr "Saját profil"
 
-#: src/olympia/amo/context_processors.py:54
-#: src/olympia/users/templates/users/edit.html:5
-#: src/olympia/users/templates/users/includes/navigation.html:3
+#: src/olympia/amo/context_processors.py:55 src/olympia/users/templates/users/edit.html:5 src/olympia/users/templates/users/includes/navigation.html:3
 msgid "Account Settings"
 msgstr "Beállítások"
 
-#: src/olympia/amo/context_processors.py:57
-#: src/olympia/discovery/templates/discovery/pane_account.html:11
-#: src/olympia/users/templates/users/profile.html:83
+#: src/olympia/amo/context_processors.py:58 src/olympia/discovery/templates/discovery/pane_account.html:11 src/olympia/users/templates/users/profile.html:83
 #: src/olympia/users/templates/users/includes/navigation.html:4
 msgid "My Collections"
 msgstr "Saját gyűjtemények"
 
-#: src/olympia/amo/context_processors.py:62
-#: src/olympia/discovery/templates/discovery/pane_account.html:10
-#: src/olympia/users/templates/users/includes/navigation.html:7
+#: src/olympia/amo/context_processors.py:63 src/olympia/discovery/templates/discovery/pane_account.html:10 src/olympia/users/templates/users/includes/navigation.html:7
 msgid "My Favorites"
 msgstr "Saját kedvencek"
 
-#: src/olympia/amo/context_processors.py:67
-#: src/olympia/discovery/templates/discovery/pane_account.html:13
-#: src/olympia/templates/impala/user_login.html:14
-#: src/olympia/templates/mobile/header_auth.html:5
+#: src/olympia/amo/context_processors.py:68 src/olympia/discovery/templates/discovery/pane_account.html:13 src/olympia/templates/impala/user_login.html:14 src/olympia/templates/mobile/header_auth.html:5
 msgid "Log out"
 msgstr "Kijelentkezés"
 
-#: src/olympia/amo/context_processors.py:72
-#: src/olympia/devhub/templates/devhub/addons/dashboard.html:4
+#: src/olympia/amo/context_processors.py:73 src/olympia/devhub/templates/devhub/addons/dashboard.html:4
 msgid "Manage My Submissions"
 msgstr "Beküldéseim kezelése"
 
-#: src/olympia/amo/context_processors.py:75
-#: src/olympia/devhub/templates/devhub/nav.html:27
-#: src/olympia/devhub/templates/devhub/addons/dashboard.html:25
+#: src/olympia/amo/context_processors.py:76 src/olympia/devhub/templates/devhub/nav.html:27 src/olympia/devhub/templates/devhub/addons/dashboard.html:25
 #: src/olympia/devhub/templates/devhub/addons/submit/base.html:4
 msgid "Submit a New Add-on"
 msgstr "Új kiegészítő beküldése"
 
-#: src/olympia/amo/context_processors.py:77
-#: src/olympia/browse/templates/browse/personas/base.html:50
-#: src/olympia/devhub/templates/devhub/index.html:24
+#: src/olympia/amo/context_processors.py:78 src/olympia/browse/templates/browse/personas/base.html:50 src/olympia/devhub/templates/devhub/index.html:24
 #: src/olympia/devhub/templates/devhub/addons/dashboard.html:29
 msgid "Submit a New Theme"
 msgstr "Új téma beküldése"
 
-#: src/olympia/amo/context_processors.py:79
-#: src/olympia/amo/templates/amo/site_nav.html:87
-#: src/olympia/devhub/helpers.py:36 src/olympia/devhub/helpers.py:68
-#: src/olympia/devhub/helpers.py:102 src/olympia/templates/footer.html:6
-#: src/olympia/templates/menu_links.html:14
+#: src/olympia/amo/context_processors.py:80 src/olympia/amo/templates/amo/site_nav.html:85 src/olympia/devhub/helpers.py:36 src/olympia/devhub/helpers.py:68 src/olympia/devhub/helpers.py:102
+#: src/olympia/templates/footer.html:6 src/olympia/templates/menu_links.html:14
 msgid "Developer Hub"
 msgstr "Fejlesztőközpont"
 
-#: src/olympia/amo/context_processors.py:83 src/olympia/devhub/views.py:1792
+#: src/olympia/amo/context_processors.py:84 src/olympia/devhub/views.py:1799
 msgid "Manage API Keys"
 msgstr "API kulcsok kezelése"
 
-#: src/olympia/amo/context_processors.py:88 src/olympia/editors/helpers.py:82
-#: src/olympia/editors/helpers.py:102
-#: src/olympia/editors/templates/editors/base.html:10
+#: src/olympia/amo/context_processors.py:89 src/olympia/editors/helpers.py:84 src/olympia/editors/helpers.py:104 src/olympia/editors/templates/editors/base.html:10
 msgid "Editor Tools"
 msgstr "Szerkesztőeszközök"
 
-#: src/olympia/amo/context_processors.py:92
+#: src/olympia/amo/context_processors.py:93
 msgid "Admin Tools"
 msgstr "Admin eszközök"
 
-#: src/olympia/amo/fields.py:15
+#: src/olympia/amo/fields.py:20
 msgid "Incorrect, please try again."
 msgstr "Helytelen, kérjük próbálja meg újra."
 
-#: src/olympia/amo/fields.py:16
+#: src/olympia/amo/fields.py:21
 msgid "Error verifying input, please try again."
 msgstr "Hiba a bemenet ellenőrzésekor, kérjük próbálja meg újra."
 
-#: src/olympia/amo/fields.py:32
+#: src/olympia/amo/fields.py:37
 msgid "This must be a valid hex color code, such as #000000."
 msgstr "Ennek érvényes hexakódnak kell lennie, mint például: #000000."
 
-#: src/olympia/amo/fields.py:58
+#: src/olympia/amo/fields.py:63
 msgid "Enter at least one value."
 msgstr "Legalább egy értéket meg kell adni."
 
-#: src/olympia/amo/helpers.py:162
-#: src/olympia/amo/templates/amo/site_nav.html:61
-#: src/olympia/bandwagon/templates/bandwagon/add.html:9
-#: src/olympia/bandwagon/templates/bandwagon/collection_detail.html:15
-#: src/olympia/bandwagon/templates/bandwagon/delete.html:9
-#: src/olympia/bandwagon/templates/bandwagon/edit.html:15
-#: src/olympia/bandwagon/templates/bandwagon/user_listing.html:18
-#: src/olympia/bandwagon/templates/bandwagon/user_listing.html:21
-#: src/olympia/bandwagon/templates/bandwagon/impala/collection_listing.html:12
-#: src/olympia/bandwagon/templates/bandwagon/impala/collection_listing.html:20
-#: src/olympia/bandwagon/templates/bandwagon/impala/collection_listing.html:24
-#: src/olympia/bandwagon/templates/bandwagon/impala/collection_sidebar.html:3
-#: src/olympia/bandwagon/templates/bandwagon/includes/collection_sidebar.html:2
-#: src/olympia/bandwagon/templates/bandwagon/mobile/collection_listing.html:3
-#: src/olympia/stats/templates/stats/stats.html:77
-#: src/olympia/templates/menu_links.html:12
+#: src/olympia/amo/helpers.py:162 src/olympia/amo/templates/amo/site_nav.html:59 src/olympia/bandwagon/templates/bandwagon/add.html:9 src/olympia/bandwagon/templates/bandwagon/collection_detail.html:15
+#: src/olympia/bandwagon/templates/bandwagon/delete.html:9 src/olympia/bandwagon/templates/bandwagon/edit.html:15 src/olympia/bandwagon/templates/bandwagon/user_listing.html:18
+#: src/olympia/bandwagon/templates/bandwagon/user_listing.html:21 src/olympia/bandwagon/templates/bandwagon/impala/collection_listing.html:12
+#: src/olympia/bandwagon/templates/bandwagon/impala/collection_listing.html:20 src/olympia/bandwagon/templates/bandwagon/impala/collection_listing.html:24
+#: src/olympia/bandwagon/templates/bandwagon/impala/collection_sidebar.html:3 src/olympia/bandwagon/templates/bandwagon/includes/collection_sidebar.html:2
+#: src/olympia/bandwagon/templates/bandwagon/mobile/collection_listing.html:3 src/olympia/stats/templates/stats/stats.html:33 src/olympia/templates/menu_links.html:12
 msgid "Collections"
 msgstr "Gyűjtemények"
 
-#: src/olympia/amo/helpers.py:171
-#: src/olympia/amo/templates/amo/site_nav.html:85
-#: src/olympia/browse/templates/browse/language_tools.html:3
+#: src/olympia/amo/helpers.py:171 src/olympia/amo/templates/amo/site_nav.html:83 src/olympia/browse/templates/browse/language_tools.html:3
 msgid "Dictionaries & Language Packs"
 msgstr "Szótárak és nyelvi csomagok"
 
@@ -2027,8 +1541,7 @@ msgstr "{0} verzió törlése a(z) {addon} kiegészítőtől."
 
 #: src/olympia/amo/log.py:141
 msgid "File {0.name} added to {version} of {addon}."
-msgstr ""
-"{0.name} fájl hozzáadva a(z) {addon} kiegészítő {version} változatához."
+msgstr "{0.name} fájl hozzáadva a(z) {addon} kiegészítő {version} változatához."
 
 #: src/olympia/amo/log.py:152
 msgid "File {0} deleted from {version} of {addon}."
@@ -2094,11 +1607,8 @@ msgstr "Teljes értékelést kér"
 msgid "Comment on {addon} {version}."
 msgstr "Hozzászólás ehhez: {addon} {version}."
 
-#: src/olympia/amo/log.py:236
-#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:19
-#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:47
-#: src/olympia/editors/helpers.py:511
-#: src/olympia/editors/templates/editors/themes/history_table.html:11
+#: src/olympia/amo/log.py:236 src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:17 src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:45
+#: src/olympia/editors/helpers.py:584 src/olympia/editors/templates/editors/themes/history_table.html:11
 msgid "Comment"
 msgstr "Megjegyzés"
 
@@ -2112,14 +1622,11 @@ msgstr "A(z) {tag} címke eltávolításra került a(z) {addon} kiegészítőtő
 
 #: src/olympia/amo/log.py:257
 msgid "{addon} added to {collection}."
-msgstr ""
-"A(z) {addon} kiegészítő hozzáadásra került a(z) {collection} gyűjteményhez."
+msgstr "A(z) {addon} kiegészítő hozzáadásra került a(z) {collection} gyűjteményhez."
 
 #: src/olympia/amo/log.py:263
 msgid "{addon} removed from {collection}."
-msgstr ""
-"A(z) {addon} kiegészítő eltávolításra került a(z) {collection} "
-"gyűjteményből."
+msgstr "A(z) {addon} kiegészítő eltávolításra került a(z) {collection} gyűjteményből."
 
 #: src/olympia/amo/log.py:269
 msgid "{review} for {addon} written."
@@ -2151,9 +1658,7 @@ msgstr "{0} {1} hozzáadva."
 #. L10n: {0} is a user, {1} is their role
 #: src/olympia/amo/log.py:310
 msgid "{0.name} role changed to {1} for {addon}."
-msgstr ""
-"A(z) {0.name} felhasználó szerepe megváltozott erre: {1} a(z) {addon} "
-"kiegészítőhöz."
+msgstr "A(z) {0.name} felhasználó szerepe megváltozott erre: {1} a(z) {addon} kiegészítőhöz."
 
 #: src/olympia/amo/log.py:318
 msgid "{addon} is now licensed under {0.name}."
@@ -2181,9 +1686,7 @@ msgstr "A {addon} kiegészítőhöz tartozó {review} értékelés törlésre ke
 
 #: src/olympia/amo/log.py:347
 msgid "{user} deleted {review} for {addon}."
-msgstr ""
-"{addon} kiegészítőhöz tartozó {review} értékelést {user} felhasználó "
-"törölte."
+msgstr "{addon} kiegészítőhöz tartozó {review} értékelést {user} felhasználó törölte."
 
 #: src/olympia/amo/log.py:354
 msgid "Application max version for {version} updated."
@@ -2258,8 +1761,8 @@ msgid "Reviewer escalation"
 msgstr "Értékelő általi eszkalálás"
 
 #: src/olympia/amo/log.py:442
-msgid "Video removed from {addon} because of a problem with the video. "
-msgstr "A(z) {addon} kiegészítőből a videó eltávolítva a videó hibája miatt. "
+msgid "Video removed from {addon} because of a problem with the video."
+msgstr "A videó a hibája miatt eltávolítva ebből: {addon}."
 
 #: src/olympia/amo/log.py:444
 msgid "Video removed"
@@ -2363,10 +1866,7 @@ msgstr "{addon} tartalom besorolása módosítva."
 msgid "{addon} unlisted."
 msgstr "{addon} titkos."
 
-#: src/olympia/amo/log.py:592 src/olympia/amo/log.py:598
-#: src/olympia/amo/log.py:612 src/olympia/amo/log.py:618
-#: src/olympia/amo/log.py:624 src/olympia/amo/log.py:630
-#: src/olympia/amo/log.py:636
+#: src/olympia/amo/log.py:592 src/olympia/amo/log.py:598 src/olympia/amo/log.py:612 src/olympia/amo/log.py:618 src/olympia/amo/log.py:624 src/olympia/amo/log.py:630 src/olympia/amo/log.py:636
 msgid "{file} was signed."
 msgstr "{file} aláírása megtörtént."
 
@@ -2380,20 +1880,12 @@ msgid "Not allowed"
 msgstr "Nem engedélyezett"
 
 #: src/olympia/amo/templates/amo/403.html:7
-msgid ""
-"<h1>Oops! Not allowed.</h1> <p>You tried to do something that you weren't "
-"allowed to.</p>"
-msgstr ""
-"<h1>Hoppá! Nem engedélyezett.</h1> <p>Olyasmit próbált meg, amely önnek nem "
-"engedélyezett.</p>"
+msgid "<h1>Oops! Not allowed.</h1> <p>You tried to do something that you weren't allowed to.</p>"
+msgstr "<h1>Hoppá! Nem engedélyezett.</h1> <p>Olyasmit próbált meg, amely önnek nem engedélyezett.</p>"
 
 #: src/olympia/amo/templates/amo/403.html:12
-msgid ""
-"<p>Try going back to the previous page, refreshing and then trying "
-"again.</p>"
-msgstr ""
-"<p>Próbáljon meg visszamenni az előző oldalra, frissítsen és próbálja meg "
-"újra.</p>"
+msgid "<p>Try going back to the previous page, refreshing and then trying again.</p>"
+msgstr "<p>Próbáljon meg visszamenni az előző oldalra, frissítsen és próbálja meg újra.</p>"
 
 #: src/olympia/amo/templates/amo/404.html:3
 msgid "Not Found"
@@ -2402,35 +1894,19 @@ msgstr "Nem található"
 #: src/olympia/amo/templates/amo/404.html:6
 #, python-format
 msgid ""
-"<h1>We're sorry, but we can't find what you're looking for.</h1> <p> The "
-"page or file you requested wasn't found on our site. It's possible that you "
-"clicked a link that's out of date, or typed in the address incorrectly. </p>"
-" <ul> <li>If you typed in the address, please double check the "
-"spelling.</li> <li> If you followed a link from somewhere, please let us "
-"know at <a href=\"mailto:webmaster@mozilla.com\">webmaster@mozilla.com</a>. "
-"Tell us where you came from and what you were looking for, and we'll do our "
-"best to fix it. </li> </ul> <p>Or you can just jump over to some of the "
-"popular pages on our website.</p> <ul> <li>Are you interested in a <a "
-"href=\"%(rec)s\">list of featured add-ons</a>?</li> <li> Do you want to <a "
-"href=\"%(search)s\">search for add-ons</a>? You may go to the <a "
-"href=\"%(search)s\">search page</a> or just use the search field above. "
-"</li> <li> If you prefer to start over, just go to the <a href=\"%(home)s"
-"\">add-ons front page</a>. </li> </ul>"
+"<h1>We're sorry, but we can't find what you're looking for.</h1> <p> The page or file you requested wasn't found on our site. It's possible that you clicked a link that's out of date, or typed in "
+"the address incorrectly. </p> <ul> <li>If you typed in the address, please double check the spelling.</li> <li> If you followed a link from somewhere, please let us know at <a "
+"href=\"mailto:webmaster@mozilla.com\">webmaster@mozilla.com</a>. Tell us where you came from and what you were looking for, and we'll do our best to fix it. </li> </ul> <p>Or you can just jump over"
+" to some of the popular pages on our website.</p> <ul> <li>Are you interested in a <a href=\"%(rec)s\">list of featured add-ons</a>?</li> <li> Do you want to <a href=\"%(search)s\">search for add-"
+"ons</a>? You may go to the <a href=\"%(search)s\">search page</a> or just use the search field above. </li> <li> If you prefer to start over, just go to the <a href=\"%(home)s\">add-ons front "
+"page</a>. </li> </ul>"
 msgstr ""
-"<h1>Sajnáljuk, de nem találjuk amit keres.</h1> <p> A keresett oldal vagy "
-"fájl nem található a weboldalunkon. Lehetséges, hogy elavult hivatkozást "
-"használt vagy hibásan gépelte be a megadott címet. </p> <ul> <li>Amennyiben "
-"begépelte a címet, akkor ellenőrizze annak helyességét.</li> <li> Amennyiben"
-" másik oldalról jutott el ide, akkor kérjük írja meg a <a "
-"href=\"mailto:webmaster@mozilla.com\">webmaster@mozilla.com</a> címre, hogy "
-"melyikről és hogy mit keresett. Mindent meg fogunk tenni a hiba kijavítása "
-"érdekében.</li> </ul> <p>Vagy egyszerűen csak ugorjon át valamelyik népszerű"
-" weboldalunkra..</p> <ul> <li>Érdeklik a <a href=\"%(rec)s\">kiemelt "
-"kiterjesztések</a>?</li> <li> <a href=\"%(search)s\">Kiterjesztést szeretne "
-"keresni</a>? Ebben az esetben menjen a <a "
-"href=\"%(search)s\">keresőoldalra</a> vagy használja a keresőmezőt. </li> "
-"<li> Amennyiben az elejéről kívánja kezdeni, akkor ugorjon a <a "
-"href=\"%(home)s\">kiegészítők kezdőlapjára</a>. </li> </ul>"
+"<h1>Sajnáljuk, de nem találjuk amit keres.</h1> <p> A keresett oldal vagy fájl nem található a weboldalunkon. Lehetséges, hogy elavult hivatkozást használt vagy hibásan gépelte be a megadott címet."
+" </p> <ul> <li>Amennyiben begépelte a címet, akkor ellenőrizze annak helyességét.</li> <li> Amennyiben másik oldalról jutott el ide, akkor kérjük írja meg a <a "
+"href=\"mailto:webmaster@mozilla.com\">webmaster@mozilla.com</a> címre, hogy melyikről és hogy mit keresett. Mindent meg fogunk tenni a hiba kijavítása érdekében.</li> </ul> <p>Vagy egyszerűen csak "
+"ugorjon át valamelyik népszerű weboldalunkra..</p> <ul> <li>Érdeklik a <a href=\"%(rec)s\">kiemelt kiterjesztések</a>?</li> <li> <a href=\"%(search)s\">Kiterjesztést szeretne keresni</a>? Ebben az "
+"esetben menjen a <a href=\"%(search)s\">keresőoldalra</a> vagy használja a keresőmezőt. </li> <li> Amennyiben az elejéről kívánja kezdeni, akkor ugorjon a <a href=\"%(home)s\">kiegészítők "
+"kezdőlapjára</a>. </li> </ul>"
 
 #: src/olympia/amo/templates/amo/500.html:3
 msgid "Oops"
@@ -2438,82 +1914,51 @@ msgstr "Hoppá"
 
 #: src/olympia/amo/templates/amo/500.html:6
 #, python-format
-msgid ""
-"<h1>Oops!  We had an error.</h1> <p>We'll get to fixing that soon.</p> <p> "
-"You can try refreshing the page, or head back to the <a href=\"%(home)s"
-"\">Add-ons homepage</a>. </p>"
+msgid "<h1>Oops! We had an error.</h1> <p>We'll get to fixing that soon.</p> <p> You can try refreshing the page, or head back to the <a href=\"%(home)s\">Add-ons homepage</a>. </p>"
 msgstr ""
-"<h1>Hoppá! Valami hiba történt.</h1> <p>Hamarosan javítani fogjuk.</p> <p> "
-"Megpróbálhatja újratölteni az oldalt, visszaléphet az előzőre vagy a <a "
-"href=\"%(home)s\">Kiegészítők kezdőlapjára</a> ugorhat. </p>"
+"<h1>Hoppá! Valami hiba történt.</h1> <p>Hamarosan javítani fogjuk.</p> <p> Megpróbálhatja újratölteni az oldalt, visszaléphet az előzőre vagy a <a href=\"%(home)s\">Kiegészítők kezdőlapjára</a> "
+"ugorhat. </p>"
 
 #: src/olympia/amo/templates/amo/license_link.html:10
 msgid "Some rights reserved"
 msgstr "Néhány jog fenntartva"
 
-#: src/olympia/amo/templates/amo/no_results.html:1
-#: src/olympia/editors/templates/editors/includes/search_results_themes.html:26
+#: src/olympia/amo/templates/amo/no_results.html:1 src/olympia/editors/templates/editors/includes/search_results_themes.html:26
 msgid "No results found"
 msgstr "Nincs találat"
 
 #. abbreviation of 'previous'
-#: src/olympia/amo/templates/amo/paginator.html:6
-#: src/olympia/amo/templates/amo/mobile/paginator.html:4
-#: src/olympia/amo/templates/amo/mobile/paginator.html:6
-#: src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:49
-#: src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:63
-#: src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:76
-#: src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:89
+#: src/olympia/amo/templates/amo/paginator.html:6 src/olympia/amo/templates/amo/mobile/paginator.html:4 src/olympia/amo/templates/amo/mobile/paginator.html:6
+#: src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:49 src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:63
+#: src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:76 src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:89
 #: src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:102
 msgid "Prev"
 msgstr "Vissza"
 
-#: src/olympia/amo/templates/amo/paginator.html:26
-#: src/olympia/amo/templates/amo/impala/paginator.html:26
-#: src/olympia/amo/templates/amo/mobile/impala_paginator.html:16
-#: src/olympia/amo/templates/amo/mobile/paginator.html:14
-#: src/olympia/amo/templates/amo/mobile/paginator.html:16
-#: src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:51
-#: src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:65
-#: src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:78
-#: src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:91
-#: src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:104
-#: src/olympia/discovery/templates/discovery/pane.html:45
-#: src/olympia/discovery/templates/discovery/addons/detail.html:39
-#: src/olympia/stats/templates/stats/stats.html:167
+#: src/olympia/amo/templates/amo/paginator.html:26 src/olympia/amo/templates/amo/impala/paginator.html:26 src/olympia/amo/templates/amo/mobile/impala_paginator.html:16
+#: src/olympia/amo/templates/amo/mobile/paginator.html:14 src/olympia/amo/templates/amo/mobile/paginator.html:16 src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:51
+#: src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:65 src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:78
+#: src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:91 src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:104
+#: src/olympia/discovery/templates/discovery/pane.html:45 src/olympia/discovery/templates/discovery/addons/detail.html:39 src/olympia/stats/templates/stats/stats.html:169
 msgid "Next"
 msgstr "Tovább"
 
-#: src/olympia/amo/templates/amo/paginator.html:32
-#: src/olympia/editors/templates/editors/includes/paginator_history.html:11
+#: src/olympia/amo/templates/amo/paginator.html:32 src/olympia/editors/templates/editors/includes/paginator_history.html:11
 #, python-format
-msgid ""
-"Results <strong>%(begin)s</strong>&ndash;<strong>%(end)s</strong> of "
-"<strong>%(count)s</strong>"
-msgstr ""
-"Találatok: <strong>%(begin)s</strong>&ndash;<strong>%(end)s</strong> / "
-"<strong>%(count)s</strong>"
+msgid "Results <strong>%(begin)s</strong>&ndash;<strong>%(end)s</strong> of <strong>%(count)s</strong>"
+msgstr "Találatok: <strong>%(begin)s</strong>&ndash;<strong>%(end)s</strong> / <strong>%(count)s</strong>"
 
-#: src/olympia/amo/templates/amo/read-only.html:3
-#: src/olympia/amo/templates/amo/read-only.html:7
+#: src/olympia/amo/templates/amo/read-only.html:3 src/olympia/amo/templates/amo/read-only.html:7
 msgid "Maintenance in progress"
 msgstr "Karbantartás folyamatban"
 
 #: src/olympia/amo/templates/amo/read-only.html:9
-msgid ""
-"This feature is temporarily disabled while we perform website maintenance. "
-"Please use your browser's Back button and try again a little later."
-msgstr ""
-"Ez a funkció a karbantartás ideje alatt átmenetileg le van tiltva. Használja"
-" a böngésző Vissza gombját és próbálja meg kicsit később."
+msgid "This feature is temporarily disabled while we perform website maintenance. Please use your browser's Back button and try again a little later."
+msgstr "Ez a funkció a karbantartás ideje alatt átmenetileg le van tiltva. Használja a böngésző Vissza gombját és próbálja meg kicsit később."
 
 #: src/olympia/amo/templates/amo/read-only.html:14
-msgid ""
-"Some features on this page are temporarily disabled while we perform website"
-" maintenance. Please try again a little later."
-msgstr ""
-"Néhány funkció a karbantartás ideje alatt átmenetileg le van tiltva. "
-"Használja a böngésző Vissza gombját és próbálja meg kicsit később."
+msgid "Some features on this page are temporarily disabled while we perform website maintenance. Please try again a little later."
+msgstr "Néhány funkció a karbantartás ideje alatt átmenetileg le van tiltva. Használja a böngésző Vissza gombját és próbálja meg kicsit később."
 
 #: src/olympia/amo/templates/amo/recaptcha.html:4
 msgid "Are you human?"
@@ -2521,25 +1966,14 @@ msgstr "Valóban ember?"
 
 #: src/olympia/amo/templates/amo/recaptcha.html:8
 msgid ""
-"<p> Please enter <strong>all the words</strong> below, <strong>separated by "
-"a space if necessary</strong>. </p> <p> If this is hard to read, you can <a "
-"href=\"#\" id=\"recaptcha_different\">try different words</a> or <a "
-"href=\"#\" id=\"recaptcha_audio\">try a different type of challenge</a> "
-"instead. </p>"
+"<p> Please enter <strong>all the words</strong> below, <strong>separated by a space if necessary</strong>. </p> <p> If this is hard to read, you can <a href=\"#\" id=\"recaptcha_different\">try "
+"different words</a> or <a href=\"#\" id=\"recaptcha_audio\">try a different type of challenge</a> instead. </p>"
 msgstr ""
-"<p> Kérjük, írja be <strong>mind</strong> az alábbi szavakat, szükség esetén"
-" <strong>szóközzel elválasztva</strong>. </p> <p>Ha ezt nehéz elolvasni, "
-"akkor <a href=\"#\" id=\"recaptcha_different\">próbálkozhat más "
-"szavakkal</a> vagy <a href=\"#\" id=\"recaptcha_audio\">próbáljon ki más "
-"típusú ellenőrzést</a> helyette. </p>"
+"<p> Kérjük, írja be <strong>mind</strong> az alábbi szavakat, szükség esetén <strong>szóközzel elválasztva</strong>. </p> <p>Ha ezt nehéz elolvasni, akkor <a href=\"#\" "
+"id=\"recaptcha_different\">próbálkozhat más szavakkal</a> vagy <a href=\"#\" id=\"recaptcha_audio\">próbáljon ki más típusú ellenőrzést</a> helyette. </p>"
 
-#: src/olympia/amo/templates/amo/side_nav.html:4
-#: src/olympia/amo/templates/amo/side_nav.html:12
-#: src/olympia/amo/templates/amo/site_nav.html:4
-#: src/olympia/amo/templates/amo/site_nav.html:26
-#: src/olympia/browse/views.py:56 src/olympia/browse/views.py:66
-#: src/olympia/browse/views.py:237 src/olympia/browse/views.py:282
-#: src/olympia/search/forms.py:86
+#: src/olympia/amo/templates/amo/side_nav.html:4 src/olympia/amo/templates/amo/side_nav.html:12 src/olympia/amo/templates/amo/site_nav.html:4 src/olympia/amo/templates/amo/site_nav.html:26
+#: src/olympia/browse/views.py:56 src/olympia/browse/views.py:66 src/olympia/browse/views.py:204 src/olympia/browse/views.py:249 src/olympia/search/forms.py:86
 msgid "Top Rated"
 msgstr "Legjobbra értékelt"
 
@@ -2548,82 +1982,59 @@ msgid "Explore"
 msgstr "Felfedezés"
 
 # Plural in this context means many of the add-on type
-#: src/olympia/amo/templates/amo/site_nav.html:23
-#: src/olympia/browse/feeds.py:65 src/olympia/browse/feeds.py:78
-#: src/olympia/browse/feeds.py:92 src/olympia/browse/feeds.py:100
-#: src/olympia/browse/templates/browse/base_listing.html:7
-#: src/olympia/browse/templates/browse/creatured.html:10
-#: src/olympia/browse/templates/browse/impala/base_listing.html:37
+#: src/olympia/amo/templates/amo/site_nav.html:23 src/olympia/browse/feeds.py:65 src/olympia/browse/feeds.py:78 src/olympia/browse/feeds.py:92 src/olympia/browse/feeds.py:100
+#: src/olympia/browse/templates/browse/base_listing.html:7 src/olympia/browse/templates/browse/creatured.html:10 src/olympia/browse/templates/browse/impala/base_listing.html:37
 #: src/olympia/constants/base.py:173 src/olympia/templates/menu_links.html:8
 msgid "Extensions"
 msgstr "Bővítmények"
 
-#: src/olympia/amo/templates/amo/site_nav.html:45
+#: src/olympia/amo/templates/amo/site_nav.html:44
 msgid "Want more customization? Try <b>Complete Themes</b>"
-msgstr ""
-"Még több testreszabhatóságot szeretne? Próbálja ki a <b>Teljes témákat</b>"
+msgstr "Még több testreszabhatóságot szeretne? Próbálja ki a <b>Teljes témákat</b>"
 
-#: src/olympia/amo/templates/amo/site_nav.html:56
-#: src/olympia/bandwagon/views.py:96
+#: src/olympia/amo/templates/amo/site_nav.html:54 src/olympia/bandwagon/views.py:96
 msgid "Most Followers"
 msgstr "Legtöbb követő"
 
-#: src/olympia/amo/templates/amo/site_nav.html:68
-#: src/olympia/bandwagon/templates/bandwagon/impala/collection_sidebar.html:16
-#: src/olympia/bandwagon/templates/bandwagon/includes/collection_sidebar.html:18
+#: src/olympia/amo/templates/amo/site_nav.html:66 src/olympia/bandwagon/templates/bandwagon/impala/collection_sidebar.html:16 src/olympia/bandwagon/templates/bandwagon/includes/collection_sidebar.html:18
 msgid "Collections I've Made"
 msgstr "Saját gyűjtemények"
 
-#: src/olympia/amo/templates/amo/site_nav.html:70
-#: src/olympia/bandwagon/templates/bandwagon/user_listing.html:4
-#: src/olympia/bandwagon/templates/bandwagon/impala/collection_sidebar.html:13
+#: src/olympia/amo/templates/amo/site_nav.html:68 src/olympia/bandwagon/templates/bandwagon/user_listing.html:4 src/olympia/bandwagon/templates/bandwagon/impala/collection_sidebar.html:13
 #: src/olympia/bandwagon/templates/bandwagon/includes/collection_sidebar.html:15
 msgid "Collections I'm Following"
 msgstr "Általam követett gyűjtemények"
 
-#: src/olympia/amo/templates/amo/site_nav.html:73
-#: src/olympia/bandwagon/templates/bandwagon/impala/collection_sidebar.html:18
-#: src/olympia/bandwagon/templates/bandwagon/includes/collection_sidebar.html:20
-#: src/olympia/users/models.py:512
+#: src/olympia/amo/templates/amo/site_nav.html:71 src/olympia/bandwagon/templates/bandwagon/impala/collection_sidebar.html:18 src/olympia/bandwagon/templates/bandwagon/includes/collection_sidebar.html:20
+#: src/olympia/users/models.py:521
 msgid "My Favorite Add-ons"
 msgstr "Kedvenc kiegészítőim"
 
-#: src/olympia/amo/templates/amo/site_nav.html:78
+#: src/olympia/amo/templates/amo/site_nav.html:76
 msgid "More&hellip;"
 msgstr "Tovább&hellip;"
 
-#: src/olympia/amo/templates/amo/site_nav.html:82
+#: src/olympia/amo/templates/amo/site_nav.html:80
 msgid "Add-ons for Mobile"
 msgstr "Kiegészítők a Mobile-hoz"
 
-#: src/olympia/amo/templates/amo/site_nav.html:86
-#: src/olympia/browse/feeds.py:207
-#: src/olympia/browse/templates/browse/search_tools.html:3
-#: src/olympia/constants/base.py:176 src/olympia/templates/menu_links.html:10
+#: src/olympia/amo/templates/amo/site_nav.html:84 src/olympia/browse/feeds.py:207 src/olympia/browse/templates/browse/search_tools.html:3 src/olympia/constants/base.py:176
+#: src/olympia/templates/menu_links.html:10
 msgid "Search Tools"
 msgstr "Keresőeszközök"
 
 #. This is a page range (e.g., Page 1 of 50).
-#: src/olympia/amo/templates/amo/impala/paginator.html:5
-#: src/olympia/amo/templates/amo/mobile/impala_paginator.html:26
+#: src/olympia/amo/templates/amo/impala/paginator.html:5 src/olympia/amo/templates/amo/mobile/impala_paginator.html:26
 #, python-format
-msgid ""
-"Page <a href=\"%(current_pg_url)s\">%(current_pg)s</a> of <a "
-"href=\"%(last_pg_url)s\">%(last_pg)s</a>"
-msgstr ""
-"<a href=\"%(current_pg_url)s\">%(current_pg)s</a> / <a "
-"href=\"%(last_pg_url)s\">%(last_pg)s</a> oldal"
+msgid "Page <a href=\"%(current_pg_url)s\">%(current_pg)s</a> of <a href=\"%(last_pg_url)s\">%(last_pg)s</a>"
+msgstr "<a href=\"%(current_pg_url)s\">%(current_pg)s</a> / <a href=\"%(last_pg_url)s\">%(last_pg)s</a> oldal"
 
-#: src/olympia/amo/templates/amo/impala/paginator.html:16
-#: src/olympia/amo/templates/amo/mobile/impala_paginator.html:6
+#: src/olympia/amo/templates/amo/impala/paginator.html:16 src/olympia/amo/templates/amo/mobile/impala_paginator.html:6
 msgid "Jump to first page"
 msgstr "Ugrás az első oldalra"
 
-#: src/olympia/amo/templates/amo/impala/paginator.html:22
-#: src/olympia/amo/templates/amo/mobile/impala_paginator.html:12
-#: src/olympia/discovery/templates/discovery/pane.html:44
-#: src/olympia/discovery/templates/discovery/addons/detail.html:38
-#: src/olympia/stats/templates/stats/stats.html:164
+#: src/olympia/amo/templates/amo/impala/paginator.html:22 src/olympia/amo/templates/amo/mobile/impala_paginator.html:12 src/olympia/discovery/templates/discovery/pane.html:44
+#: src/olympia/discovery/templates/discovery/addons/detail.html:38 src/olympia/stats/templates/stats/stats.html:166
 msgid "Previous"
 msgstr "Előző"
 
@@ -2633,14 +2044,12 @@ msgstr "Ugrás az utolsó oldalra"
 
 #. First and second arguments are the result range (e.g., 1-20);
 #. third argument is the number of total results (e.g., 1,000).
-#. third
+#. First and second arguments are the result range (e.g., 1-20);              third
 #. argument is the number of total results (e.g., 1,000).
-#: src/olympia/amo/templates/amo/impala/paginator.html:36
-#: src/olympia/amo/templates/amo/mobile/impala_paginator.html:38
+#: src/olympia/amo/templates/amo/impala/paginator.html:36 src/olympia/amo/templates/amo/mobile/impala_paginator.html:38
 #, python-format
 msgid "Showing <b>%(begin)s</b>&ndash;<b>%(end)s</b> of <b>%(count)s</b>"
-msgstr ""
-"<b>%(begin)s</b>&ndash;<b>%(end)s</b> / <b>%(count)s</b> megjelenítése"
+msgstr "<b>%(begin)s</b>&ndash;<b>%(end)s</b> / <b>%(count)s</b> megjelenítése"
 
 #: src/olympia/amo/templates/amo/mobile/paginator.html:10
 msgid "Page {n}"
@@ -2648,42 +2057,52 @@ msgid_plural "Page {n}"
 msgstr[0] "{n}. oldal"
 msgstr[1] "{n}. oldal"
 
-#: src/olympia/amo/templates/services/install.html:38
-#, python-format
-msgid ""
-"If you are not prompted to install %(addon_name)s in a moment, please <a "
-"href=\"%(addon_xpi)s\">click here</a>."
-msgstr ""
-"Ha nem kap felszólítást a(z) %(addon_name)s telepítésére egy pillanat múlva,"
-" akkor <a href=\"%(addon_xpi)s\">kattintson ide</a>."
-
-#: src/olympia/amo/tests/test_messages.py:57
-#: src/olympia/amo/tests/test_messages.py:58 src/olympia/reviews/forms.py:25
-#: src/olympia/reviews/forms.py:50
-#: src/olympia/reviews/templates/reviews/add.html:56
+#: src/olympia/amo/tests/test_messages.py:56 src/olympia/amo/tests/test_messages.py:57 src/olympia/reviews/forms.py:25 src/olympia/reviews/forms.py:50 src/olympia/reviews/templates/reviews/add.html:56
 #: src/olympia/reviews/templates/reviews/reply.html:30
 msgid "Title"
 msgstr "Cím"
 
-#: src/olympia/amo/tests/test_messages.py:57
-#: src/olympia/amo/tests/test_messages.py:58
+#: src/olympia/amo/tests/test_messages.py:56 src/olympia/amo/tests/test_messages.py:57
 msgid "Body"
 msgstr "Törzs"
 
-#: src/olympia/amo/tests/test_messages.py:59
+#: src/olympia/amo/tests/test_messages.py:58
 msgid "Another Title"
 msgstr "Másik cím"
 
-#: src/olympia/amo/tests/test_messages.py:59
+#: src/olympia/amo/tests/test_messages.py:58
 msgid "Another Body"
 msgstr "Másik törzs"
 
-#: src/olympia/api/views.py:255
-msgid "Not implemented yet."
-msgstr "Még nem megvalósított."
+#: src/olympia/api/authentication.py:76
+msgid "Signature has expired."
+msgstr ""
 
-#: src/olympia/applications/views.py:39
-#: src/olympia/applications/templates/applications/appversions.html:3
+#: src/olympia/api/authentication.py:79
+msgid "Error decoding signature."
+msgstr ""
+
+#: src/olympia/api/authentication.py:82
+msgid "Invalid JWT Token."
+msgstr ""
+
+#: src/olympia/api/authentication.py:130
+msgid "Invalid Authorization header. No credentials provided."
+msgstr ""
+
+#: src/olympia/api/authentication.py:133
+msgid "Invalid Authorization header. Credentials string should not contain spaces."
+msgstr ""
+
+#: src/olympia/api/fields.py:29
+msgid "The field must have a length of at least {num} characters."
+msgstr ""
+
+#: src/olympia/api/fields.py:31
+msgid "The language code {lang_code} is invalid."
+msgstr ""
+
+#: src/olympia/applications/views.py:39 src/olympia/applications/templates/applications/appversions.html:3
 msgid "Application Versions"
 msgstr "Alkalmazásverziók"
 
@@ -2696,22 +2115,17 @@ msgid "Valid Application Versions"
 msgstr "Érvényes alkalmazásverziók"
 
 #: src/olympia/applications/templates/applications/appversions.html:12
-msgid ""
-"Add-ons submitted to Mozilla Add-ons must have a manifest file with at least"
-" one of the below applications supported. Only the versions listed below are"
-" allowed for these applications."
+msgid "Add-ons submitted to Mozilla Add-ons must have a manifest file with at least one of the below applications supported. Only the versions listed below are allowed for these applications."
 msgstr ""
-"Mozilla Kiegészítők közé benyújtott kiegészítőnek kell legyen egy "
-"jegyzékfájlja, mely legalább egyet támogat az alábbi alkalmazások közül. "
-"Ezeknek az alkalmazásoknak csak az alább felsorolt verziói engedélyezettek."
+"Mozilla Kiegészítők közé benyújtott kiegészítőnek kell legyen egy jegyzékfájlja, mely legalább egyet támogat az alábbi alkalmazások közül. Ezeknek az alkalmazásoknak csak az alább felsorolt verziói"
+" engedélyezettek."
 
-#: src/olympia/applications/templates/applications/appversions.html:25
+#: src/olympia/applications/templates/applications/appversions.html:25 src/olympia/editors/helpers.py:361
 msgid "GUID"
 msgstr "GUID"
 
 #. {0} is an add-on name.
-#: src/olympia/applications/templates/applications/appversions.html:26
-#: src/olympia/versions/templates/versions/version_list.html:23
+#: src/olympia/applications/templates/applications/appversions.html:26 src/olympia/versions/templates/versions/version_list.html:23
 msgid "Versions"
 msgstr "Verziók"
 
@@ -2721,13 +2135,8 @@ msgstr "http://developer.mozilla.org/en/docs/Install_Manifests"
 
 #: src/olympia/applications/templates/applications/appversions.html:31
 #, python-format
-msgid ""
-"If your supported application does not require a manifest file, you still "
-"must include one with the required properties as specified <a "
-"href=\"%(url)s\">here</a>."
-msgstr ""
-"Ha a támogatott alkalmazás nem igényli a jegyzékfájlt, akkor is mellékelni "
-"kell egyet az <a href=\"%(url)s\">itt</a> meghatározott tartalommal."
+msgid "If your supported application does not require a manifest file, you still must include one with the required properties as specified <a href=\"%(url)s\">here</a>."
+msgstr "Ha a támogatott alkalmazás nem igényli a jegyzékfájlt, akkor is mellékelni kell egyet az <a href=\"%(url)s\">itt</a> meghatározott tartalommal."
 
 #. L10n: {0} is 'Add-ons for <app>'.
 #: src/olympia/bandwagon/feeds.py:44
@@ -2735,13 +2144,9 @@ msgstr ""
 msgid "Collections :: %s"
 msgstr "Gyűjtemények :: %s"
 
-#: src/olympia/bandwagon/feeds.py:50
-#: src/olympia/bandwagon/templates/bandwagon/collection_detail.html:137
-msgid ""
-"Collections are groups of related add-ons that anyone can create and share."
-msgstr ""
-"A gyűjtemények bárki által létrehozott és megosztott kiegészítők egy "
-"csoportja."
+#: src/olympia/bandwagon/feeds.py:50 src/olympia/bandwagon/templates/bandwagon/collection_detail.html:137
+msgid "Collections are groups of related add-ons that anyone can create and share."
+msgstr "A gyűjtemények bárki által létrehozott és megosztott kiegészítők egy csoportja."
 
 #. L10n: {0} is a collection name, {1} is 'Add-ons for <app>'.
 #: src/olympia/bandwagon/feeds.py:70
@@ -2792,12 +2197,11 @@ msgstr "Hivatkozások nem engedélyezettek."
 msgid "This url is already in use by another collection"
 msgstr "Ezt az URL-t egy másik gyűjtemény használja"
 
-#: src/olympia/bandwagon/forms.py:197 src/olympia/devhub/views.py:1049
+#: src/olympia/bandwagon/forms.py:197 src/olympia/devhub/views.py:1050
 msgid "Icons must be either PNG or JPG."
 msgstr "Az ikonnak PNG-nek vagy JPG-nek kell lennie."
 
-#: src/olympia/bandwagon/forms.py:202 src/olympia/devhub/views.py:1067
-#: src/olympia/users/forms.py:476
+#: src/olympia/bandwagon/forms.py:202 src/olympia/devhub/views.py:1068 src/olympia/users/forms.py:476
 #, python-format
 msgid "Please use images smaller than %dMB."
 msgstr "Használjon %dMB méretnél kisebb képeket."
@@ -2818,8 +2222,7 @@ msgstr "Szavazatom törlése erről a gyűjteményről"
 msgid "Log in to vote for this collection"
 msgstr "Jelentkezzen be, hogy szavazhasson"
 
-#: src/olympia/bandwagon/helpers.py:123
-#: src/olympia/bandwagon/templates/bandwagon/favorites_widget.html:2
+#: src/olympia/bandwagon/helpers.py:123 src/olympia/bandwagon/templates/bandwagon/favorites_widget.html:2
 msgid "Add to favorites"
 msgstr "Hozzáadás a kedvencekhez"
 
@@ -2827,20 +2230,13 @@ msgstr "Hozzáadás a kedvencekhez"
 msgid "Favorite"
 msgstr "Kedvenc"
 
-#: src/olympia/bandwagon/helpers.py:124
-#: src/olympia/bandwagon/templates/bandwagon/favorites_widget.html:2
+#: src/olympia/bandwagon/helpers.py:124 src/olympia/bandwagon/templates/bandwagon/favorites_widget.html:2
 msgid "Remove from favorites"
 msgstr "Eltávolítás a kedvencek közül"
 
-#: src/olympia/bandwagon/views.py:98 src/olympia/bandwagon/views.py:191
-#: src/olympia/browse/views.py:58 src/olympia/browse/views.py:69
-#: src/olympia/browse/views.py:458 src/olympia/devhub/views.py:74
-#: src/olympia/devhub/views.py:82
-#: src/olympia/devhub/templates/devhub/addons/edit/basic.html:20
-#: src/olympia/editors/templates/editors/leaderboard.html:24
-#: src/olympia/editors/templates/editors/themes/queue_list.html:48
-#: src/olympia/search/forms.py:17 src/olympia/search/forms.py:89
-#: src/olympia/users/templates/users/vcard.html:5
+#: src/olympia/bandwagon/views.py:98 src/olympia/bandwagon/views.py:191 src/olympia/browse/views.py:58 src/olympia/browse/views.py:69 src/olympia/browse/views.py:425 src/olympia/devhub/views.py:73
+#: src/olympia/devhub/views.py:81 src/olympia/devhub/templates/devhub/addons/edit/basic.html:20 src/olympia/editors/templates/editors/leaderboard.html:24
+#: src/olympia/editors/templates/editors/themes/queue_list.html:48 src/olympia/search/forms.py:17 src/olympia/search/forms.py:89 src/olympia/users/templates/users/vcard.html:5
 msgid "Name"
 msgstr "Név"
 
@@ -2848,8 +2244,7 @@ msgstr "Név"
 msgid "Recently Popular"
 msgstr "Jelenleg népszerű"
 
-#: src/olympia/bandwagon/views.py:189
-#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:18
+#: src/olympia/bandwagon/views.py:189 src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:16
 msgid "Added"
 msgstr "Hozzáadva"
 
@@ -2863,12 +2258,8 @@ msgstr "A gyűjtemény elkészült!"
 
 #: src/olympia/bandwagon/views.py:316
 #, python-format
-msgid ""
-"Your new collection is shown below. You can <ahref=\"%(url)s\">edit "
-"additional settings</a> if you'dlike."
-msgstr ""
-"Az új gyűjteménye alább látható. Ha szeretné, további "
-"<ahref=\"%(url)s\">módosításokat végezhet</a> rajta."
+msgid "Your new collection is shown below. You can <a href=\"%(url)s\">edit additional settings</a> if you'd like."
+msgstr "Az új gyűjtemény itt látható. Amennyiben szeretne, további <a href=\"%(url)s\">módosításokat végezhet</a> rajta."
 
 #: src/olympia/bandwagon/views.py:322
 msgid "Collection updated!"
@@ -2877,39 +2268,26 @@ msgstr "A gyűjtemény frissítése megtörtént!"
 #: src/olympia/bandwagon/views.py:323
 #, python-format
 msgid "<a href=\"%(url)s\">View your collection</a> to see the changes."
-msgstr ""
-"<a href=\"%(url)s\">Nézze meg gyűjteményét</a> a változások "
-"megjelenítéséhez."
+msgstr "<a href=\"%(url)s\">Nézze meg gyűjteményét</a> a változások megjelenítéséhez."
 
 #: src/olympia/bandwagon/views.py:579
 msgid "Icon Deleted"
 msgstr "Az ikon törölve"
 
-#: src/olympia/bandwagon/templates/bandwagon/add.html:3
-#: src/olympia/bandwagon/templates/bandwagon/add.html:11
-#: src/olympia/bandwagon/templates/bandwagon/includes/collection_sidebar.html:26
+#: src/olympia/bandwagon/templates/bandwagon/add.html:3 src/olympia/bandwagon/templates/bandwagon/add.html:11 src/olympia/bandwagon/templates/bandwagon/includes/collection_sidebar.html:26
 msgid "Create a New Collection"
 msgstr "Új gyűjtemény létrehozása"
 
-#: src/olympia/bandwagon/templates/bandwagon/add.html:9
-#: src/olympia/devhub/templates/devhub/personas/submit.html:14
+#: src/olympia/bandwagon/templates/bandwagon/add.html:9 src/olympia/devhub/templates/devhub/personas/submit.html:14
 msgid "Create"
 msgstr "Létrehozás"
 
-#: src/olympia/bandwagon/templates/bandwagon/add.html:24
-#: src/olympia/bandwagon/templates/bandwagon/ajax_new.html:28
+#: src/olympia/bandwagon/templates/bandwagon/add.html:24 src/olympia/bandwagon/templates/bandwagon/ajax_new.html:28
 #, python-format
-msgid ""
-"As noted in our <a href=\"%(legal)s\">Legal Notices</a>, individual "
-"collection arrangements are governed by the Creative Commons Attribution "
-"Share-Alike License"
-msgstr ""
-"Ahogy az a <a href=\"%(legal)s\">Jogi közlemények</a> részben olvasható, az "
-"egyéni gyűjteményekre a Creative Commons Attribution Share-Alike License "
-"feltételei vonatkoznak."
+msgid "As noted in our <a href=\"%(legal)s\">Legal Notices</a>, individual collection arrangements are governed by the Creative Commons Attribution Share-Alike License"
+msgstr "Ahogy az a <a href=\"%(legal)s\">Jogi közlemények</a> részben olvasható, az egyéni gyűjteményekre a Creative Commons Attribution Share-Alike License feltételei vonatkoznak."
 
-#: src/olympia/bandwagon/templates/bandwagon/add.html:33
-#: src/olympia/bandwagon/templates/bandwagon/ajax_new.html:38
+#: src/olympia/bandwagon/templates/bandwagon/add.html:33 src/olympia/bandwagon/templates/bandwagon/ajax_new.html:38
 msgid "Create Collection"
 msgstr "Gyűjtemény létrehozása"
 
@@ -2925,8 +2303,7 @@ msgstr "Új gyűjtemény indítása…"
 msgid "Start a New Collection"
 msgstr "Új gyűjtemény indítása"
 
-#: src/olympia/bandwagon/templates/bandwagon/ajax_new.html:6
-#: src/olympia/bandwagon/templates/bandwagon/includes/addedit.html:7
+#: src/olympia/bandwagon/templates/bandwagon/ajax_new.html:6 src/olympia/bandwagon/templates/bandwagon/includes/addedit.html:7
 msgid "Name:"
 msgstr "Név:"
 
@@ -2939,15 +2316,11 @@ msgstr "vagy <a id=\"collections-new-cancel\" href=\"#\">Mégsem</a>"
 msgid "To rate collections, you must have an add-ons account."
 msgstr "A gyűjtemények értékeléséhez felhasználói fiókra van szükség."
 
-#: src/olympia/bandwagon/templates/bandwagon/barometer.html:18
-#: src/olympia/templates/base.html:145
-#: src/olympia/templates/impala/base.html:198
+#: src/olympia/bandwagon/templates/bandwagon/barometer.html:18 src/olympia/templates/base.html:145 src/olympia/templates/impala/base.html:198
 msgid "Create an Add-ons Account"
 msgstr "Felhasználói fiók létrehozása"
 
-#: src/olympia/bandwagon/templates/bandwagon/barometer.html:21
-#: src/olympia/templates/base.html:148
-#: src/olympia/templates/impala/base.html:201
+#: src/olympia/bandwagon/templates/bandwagon/barometer.html:21 src/olympia/templates/base.html:148 src/olympia/templates/impala/base.html:201
 #, python-format
 msgid "or <a href=\"%(login)s\">log in to your current account</a>"
 msgstr "vagy <a href=\"%(login)s\">bejelentkezés meglévő felhasználóval</a>"
@@ -2960,8 +2333,7 @@ msgstr "{0} :: Gyűjtemények"
 msgid "private"
 msgstr "magán"
 
-#: src/olympia/bandwagon/templates/bandwagon/collection_detail.html:45
-#: src/olympia/bandwagon/templates/bandwagon/mobile/listing_items.html:9
+#: src/olympia/bandwagon/templates/bandwagon/collection_detail.html:45 src/olympia/bandwagon/templates/bandwagon/mobile/listing_items.html:9
 #, python-format
 msgid "<span>%(num)s</span> follower"
 msgid_plural "<span>%(num)s</span> followers"
@@ -2996,8 +2368,7 @@ msgstr "További opciók:"
 msgid "Edit Collection"
 msgstr "Gyűjtemény szerkesztése"
 
-#: src/olympia/bandwagon/templates/bandwagon/collection_detail.html:88
-#: src/olympia/bandwagon/templates/bandwagon/includes/delete.html:3
+#: src/olympia/bandwagon/templates/bandwagon/collection_detail.html:88 src/olympia/bandwagon/templates/bandwagon/includes/delete.html:3
 msgid "Delete Collection"
 msgstr "Gyűjtemény törlése"
 
@@ -3015,12 +2386,8 @@ msgid_plural "%(num)s Add-ons in this Collection"
 msgstr[0] "%(num)s Kiegészítő van a Gyűjteményben"
 msgstr[1] "%(num)s Kiegészítő van a Gyűjteményben"
 
-#: src/olympia/bandwagon/templates/bandwagon/collection_detail.html:125
-#: src/olympia/compat/templates/compat/index.html:25
-#: src/olympia/compat/templates/compat/reporter_detail.html:29
-#: src/olympia/files/templates/files/viewer.html:29
-#: src/olympia/templates/amo_footer.html:17
-#: src/olympia/templates/includes/lang_switcher.html:10
+#: src/olympia/bandwagon/templates/bandwagon/collection_detail.html:125 src/olympia/compat/templates/compat/reporter_detail.html:29 src/olympia/files/templates/files/viewer.html:29
+#: src/olympia/templates/amo_footer.html:17 src/olympia/templates/includes/lang_switcher.html:10
 msgid "Go"
 msgstr "Ugrás"
 
@@ -3046,29 +2413,19 @@ msgstr "Összes gyűjtemény ettől a felhasználótól"
 
 #: src/olympia/bandwagon/templates/bandwagon/collection_detail.html:179
 msgid ""
-"Add-ons that you mark as favorites using the <b>Add to Favorites</b> feature"
-" appear below. This collection is currently <b>public</b>, which means "
-"everyone can see it. If you would like to hide it from public view, click "
-"the button below to make it private."
+"Add-ons that you mark as favorites using the <b>Add to Favorites</b> feature appear below. This collection is currently <b>public</b>, which means everyone can see it. If you would like to hide it "
+"from public view, click the button below to make it private."
 msgstr ""
-"Azok a kiegészítők, amelyek a kedvencek közé kerültek a <b>Hozzáadás a "
-"kedvencekhez</b> funkció használatával, azok alul jelennek meg. Ez a "
-"gyűjtemény jelenleg <b>nyilvános</b>, ami azt jelenti, hogy mindenki "
-"láthatja. Amennyiben el akarja rejteni a nyilvánosság elől, akkor az alábbi "
-"gomb megnyomásával priváttá teheti."
+"Azok a kiegészítők, amelyek a kedvencek közé kerültek a <b>Hozzáadás a kedvencekhez</b> funkció használatával, azok alul jelennek meg. Ez a gyűjtemény jelenleg <b>nyilvános</b>, ami azt jelenti, "
+"hogy mindenki láthatja. Amennyiben el akarja rejteni a nyilvánosság elől, akkor az alábbi gomb megnyomásával priváttá teheti."
 
 #: src/olympia/bandwagon/templates/bandwagon/collection_detail.html:186
 msgid ""
-"Add-ons that you mark as favorites using the <b>Add to Favorites</b> feature"
-" appear below. This collection is currently <b>private</b>, which means only"
-" you can see it.  If you would like everyone to be able to see your "
-"favorites, click the button below to make it public."
+"Add-ons that you mark as favorites using the <b>Add to Favorites</b> feature appear below. This collection is currently <b>private</b>, which means only you can see it. If you would like everyone "
+"to be able to see your favorites, click the button below to make it public."
 msgstr ""
-"Azok a kiegészítők, amelyek a kedvencek közé kerültek a <b>Hozzáadás a "
-"kedvencekhez</b> funkció használatával, azok alul jelennek meg. Ez a "
-"gyűjtemény jelenleg <b>privát</b>, ami azt jelenti, hogy csak Ön láthatja. "
-"Ha szeretné, hogy bárki lássa a kedvenceit, kattintson a lenti gombra a "
-"nyilvánossá tételhez."
+"Azok a kiegészítők, amelyek a kedvencek közé kerültek a <b>Hozzáadás a kedvencekhez</b> funkció használatával, azok alul jelennek meg. Ez a gyűjtemény jelenleg <b>privát</b>, ami azt jelenti, hogy "
+"más nem láthatja. Amennyiben mindenki számára láthatóvá kívánja tenni, akkor az alábbi gomb megnyomásával teheti nyilvánossá."
 
 #: src/olympia/bandwagon/templates/bandwagon/collection_detail.html:196
 msgid "My favorite add-ons"
@@ -3088,20 +2445,18 @@ msgid_plural "<span>%(followers)s</span> followers"
 msgstr[0] "<span>%(followers)s</span> követő"
 msgstr[1] "<span>%(followers)s</span> követő"
 
-#. People "follow" collections to get notified of updates.
-#. Like
+#. People "follow" collections to get notified of updates.                    Like
 #. Twitter followers.
+#. People "follow" collections to get notified of updates.
 #. Like Twitter followers.
-#: src/olympia/bandwagon/templates/bandwagon/collection_listing_items.html:10
-#: src/olympia/bandwagon/templates/bandwagon/impala/collection_listing_items.html:18
+#: src/olympia/bandwagon/templates/bandwagon/collection_listing_items.html:10 src/olympia/bandwagon/templates/bandwagon/impala/collection_listing_items.html:18
 #, python-format
 msgid "%(num)s weekly follower"
 msgid_plural "%(num)s weekly followers"
 msgstr[0] "%(num)s követő hetente"
 msgstr[1] "%(num)s követő hetente"
 
-#. People "follow" collections to get notified of updates.
-#. Like
+#. People "follow" collections to get notified of updates.                    Like
 #. Twitter followers.
 #: src/olympia/bandwagon/templates/bandwagon/collection_listing_items.html:18
 #, python-format
@@ -3110,32 +2465,28 @@ msgid_plural "%(num)s monthly followers"
 msgstr[0] "%(num)s havi követő"
 msgstr[1] "%(num)s havi követő"
 
-#. People "follow" collections to get notified of updates.
-#. Like
+#. People "follow" collections to get notified of updates.                    Like
 #. Twitter followers.
+#. People "follow" collections to get notified of updates.
 #. Like Twitter followers.
-#: src/olympia/bandwagon/templates/bandwagon/collection_listing_items.html:26
-#: src/olympia/bandwagon/templates/bandwagon/impala/collection_listing_items.html:26
+#: src/olympia/bandwagon/templates/bandwagon/collection_listing_items.html:26 src/olympia/bandwagon/templates/bandwagon/impala/collection_listing_items.html:26
 #, python-format
 msgid "%(num)s follower"
 msgid_plural "%(num)s followers"
 msgstr[0] "%(num)s követő"
 msgstr[1] "%(num)s követő"
 
-#: src/olympia/bandwagon/templates/bandwagon/collection_listing_items.html:56
-#: src/olympia/bandwagon/templates/bandwagon/impala/collection_listing_items.html:9
+#: src/olympia/bandwagon/templates/bandwagon/collection_listing_items.html:56 src/olympia/bandwagon/templates/bandwagon/impala/collection_listing_items.html:9
 #: src/olympia/devhub/templates/devhub/personas/edit.html:27
 msgid "by {0}"
 msgstr "{0} készítette"
 
-#: src/olympia/bandwagon/templates/bandwagon/collection_widgets.html:5
-#: src/olympia/bandwagon/templates/bandwagon/collection_widgets.html:7
+#: src/olympia/bandwagon/templates/bandwagon/collection_widgets.html:5 src/olympia/bandwagon/templates/bandwagon/collection_widgets.html:7
 #: src/olympia/bandwagon/templates/bandwagon/impala/collection_listing_items.html:53
 msgid "Stop Following"
 msgstr "Követés megállítása"
 
-#: src/olympia/bandwagon/templates/bandwagon/collection_widgets.html:6
-#: src/olympia/bandwagon/templates/bandwagon/collection_widgets.html:7
+#: src/olympia/bandwagon/templates/bandwagon/collection_widgets.html:6 src/olympia/bandwagon/templates/bandwagon/collection_widgets.html:7
 #: src/olympia/bandwagon/templates/bandwagon/impala/collection_listing_items.html:53
 msgid "Follow this Collection"
 msgstr "Gyűjtemény követése"
@@ -3145,16 +2496,12 @@ msgid "Edit this Collection"
 msgstr "Gyűjtemény szerkesztése"
 
 #. %s is the name of the collection.
-#: src/olympia/bandwagon/templates/bandwagon/delete.html:4
-#: src/olympia/bandwagon/templates/bandwagon/delete.html:15
+#: src/olympia/bandwagon/templates/bandwagon/delete.html:4 src/olympia/bandwagon/templates/bandwagon/delete.html:15
 msgid "Delete {0}"
 msgstr "{0} törlése"
 
-#: src/olympia/bandwagon/templates/bandwagon/delete.html:13
-#: src/olympia/devhub/templates/devhub/addons/listing/item_actions.html:14
-#: src/olympia/devhub/templates/devhub/addons/listing/item_actions_theme.html:28
-#: src/olympia/devhub/templates/devhub/versions/list.html:131
-#: src/olympia/devhub/templates/devhub/versions/list.html:149
+#: src/olympia/bandwagon/templates/bandwagon/delete.html:13 src/olympia/devhub/templates/devhub/addons/listing/item_actions.html:14
+#: src/olympia/devhub/templates/devhub/addons/listing/item_actions_theme.html:28 src/olympia/devhub/templates/devhub/versions/list.html:131 src/olympia/devhub/templates/devhub/versions/list.html:149
 #: src/olympia/devhub/templates/devhub/versions/list.html:166
 msgid "Delete"
 msgstr "Törlés"
@@ -3163,35 +2510,24 @@ msgstr "Törlés"
 msgid "Are you sure?"
 msgstr "Biztos benne?"
 
-#: src/olympia/bandwagon/templates/bandwagon/delete.html:21
-#: src/olympia/devhub/templates/devhub/personas/edit.html:131
-#: src/olympia/devhub/templates/devhub/personas/edit.html:152
-#: src/olympia/devhub/templates/devhub/personas/edit.html:173
-#: src/olympia/devhub/templates/devhub/personas/submit.html:77
-#: src/olympia/devhub/templates/devhub/personas/submit.html:98
+#: src/olympia/bandwagon/templates/bandwagon/delete.html:21 src/olympia/devhub/templates/devhub/personas/edit.html:131 src/olympia/devhub/templates/devhub/personas/edit.html:152
+#: src/olympia/devhub/templates/devhub/personas/edit.html:173 src/olympia/devhub/templates/devhub/personas/submit.html:77 src/olympia/devhub/templates/devhub/personas/submit.html:98
 #: src/olympia/devhub/templates/devhub/personas/submit.html:119
 msgid "Yes"
 msgstr "Igen"
 
-#: src/olympia/bandwagon/templates/bandwagon/delete.html:22
-#: src/olympia/devhub/templates/devhub/personas/edit.html:140
-#: src/olympia/devhub/templates/devhub/personas/edit.html:161
-#: src/olympia/devhub/templates/devhub/personas/edit.html:191
-#: src/olympia/devhub/templates/devhub/personas/submit.html:86
-#: src/olympia/devhub/templates/devhub/personas/submit.html:107
+#: src/olympia/bandwagon/templates/bandwagon/delete.html:22 src/olympia/devhub/templates/devhub/personas/edit.html:140 src/olympia/devhub/templates/devhub/personas/edit.html:161
+#: src/olympia/devhub/templates/devhub/personas/edit.html:191 src/olympia/devhub/templates/devhub/personas/submit.html:86 src/olympia/devhub/templates/devhub/personas/submit.html:107
 #: src/olympia/devhub/templates/devhub/personas/submit.html:137
 msgid "No"
 msgstr "Nem"
 
 #. {0} is the name of the collection.
-#: src/olympia/bandwagon/templates/bandwagon/edit.html:5
-#: src/olympia/bandwagon/templates/bandwagon/edit.html:21
+#: src/olympia/bandwagon/templates/bandwagon/edit.html:5 src/olympia/bandwagon/templates/bandwagon/edit.html:21
 msgid "Edit {0}"
 msgstr "{0} szerkesztése"
 
-#: src/olympia/bandwagon/templates/bandwagon/edit.html:29
-#: src/olympia/devhub/templates/devhub/addons/edit/details.html:20
-#: src/olympia/editors/templates/editors/themes/themes.html:62
+#: src/olympia/bandwagon/templates/bandwagon/edit.html:29 src/olympia/devhub/templates/devhub/addons/edit/details.html:20 src/olympia/editors/templates/editors/themes/themes.html:62
 msgid "Description"
 msgstr "Leírás"
 
@@ -3199,32 +2535,18 @@ msgstr "Leírás"
 msgid "Contributors & More"
 msgstr "Közreműködök és egyebek"
 
-#: src/olympia/bandwagon/templates/bandwagon/edit.html:54
-#: src/olympia/bandwagon/templates/bandwagon/edit.html:67
-#: src/olympia/bandwagon/templates/bandwagon/edit.html:82
-#: src/olympia/devhub/templates/devhub/addons/ajax_compat_update.html:35
-#: src/olympia/devhub/templates/devhub/addons/owner.html:59
-#: src/olympia/devhub/templates/devhub/addons/profile.html:42
-#: src/olympia/devhub/templates/devhub/addons/edit/admin.html:101
-#: src/olympia/devhub/templates/devhub/addons/edit/basic.html:152
-#: src/olympia/devhub/templates/devhub/addons/edit/details.html:85
-#: src/olympia/devhub/templates/devhub/addons/edit/support.html:67
-#: src/olympia/devhub/templates/devhub/addons/edit/technical.html:166
-#: src/olympia/devhub/templates/devhub/addons/forms_shared/media.html:149
-#: src/olympia/devhub/templates/devhub/payments/voluntary.html:64
-#: src/olympia/devhub/templates/devhub/personas/edit.html:35
-#: src/olympia/devhub/templates/devhub/personas/edit.html:304
-#: src/olympia/devhub/templates/devhub/versions/edit.html:139
-#: src/olympia/translations/templates/translations/trans-menu.html:48
+#: src/olympia/bandwagon/templates/bandwagon/edit.html:54 src/olympia/bandwagon/templates/bandwagon/edit.html:67 src/olympia/bandwagon/templates/bandwagon/edit.html:82
+#: src/olympia/devhub/templates/devhub/addons/ajax_compat_update.html:35 src/olympia/devhub/templates/devhub/addons/owner.html:59 src/olympia/devhub/templates/devhub/addons/profile.html:42
+#: src/olympia/devhub/templates/devhub/addons/edit/admin.html:101 src/olympia/devhub/templates/devhub/addons/edit/basic.html:152 src/olympia/devhub/templates/devhub/addons/edit/details.html:85
+#: src/olympia/devhub/templates/devhub/addons/edit/support.html:67 src/olympia/devhub/templates/devhub/addons/edit/technical.html:166
+#: src/olympia/devhub/templates/devhub/addons/forms_shared/media.html:149 src/olympia/devhub/templates/devhub/payments/voluntary.html:64 src/olympia/devhub/templates/devhub/personas/edit.html:35
+#: src/olympia/devhub/templates/devhub/personas/edit.html:304 src/olympia/devhub/templates/devhub/versions/edit.html:139 src/olympia/translations/templates/translations/trans-menu.html:48
 msgid "Save Changes"
 msgstr "Változások mentése"
 
 # <option> text in a <select> for Author role in an add-on.
-#: src/olympia/bandwagon/templates/bandwagon/edit_contributors.html:9
-#: src/olympia/bandwagon/templates/bandwagon/edit_contributors.html:12
-#: src/olympia/bandwagon/templates/bandwagon/edit_contributors.html:17
-#: src/olympia/bandwagon/templates/bandwagon/edit_contributors.html:58
-#: src/olympia/constants/base.py:134
+#: src/olympia/bandwagon/templates/bandwagon/edit_contributors.html:9 src/olympia/bandwagon/templates/bandwagon/edit_contributors.html:12
+#: src/olympia/bandwagon/templates/bandwagon/edit_contributors.html:17 src/olympia/bandwagon/templates/bandwagon/edit_contributors.html:58 src/olympia/constants/base.py:134
 msgid "Owner"
 msgstr "Tulajdonos"
 
@@ -3236,10 +2558,8 @@ msgstr "Tulajdonos"
 msgid "Remove this user as a contributor"
 msgstr "Felhasználó eltávolítása a közreműködők közül"
 
-#: src/olympia/bandwagon/templates/bandwagon/edit_contributors.html:18
-#: src/olympia/bandwagon/templates/bandwagon/edit_contributors.html:43
-#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:20
-#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:48
+#: src/olympia/bandwagon/templates/bandwagon/edit_contributors.html:18 src/olympia/bandwagon/templates/bandwagon/edit_contributors.html:43
+#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:18 src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:46
 #: src/olympia/devhub/templates/devhub/addons/ajax_compat_update.html:19
 msgid "Remove"
 msgstr "Eltávolítás"
@@ -3250,23 +2570,17 @@ msgstr "Gyűjtemény közreműködői"
 
 #: src/olympia/bandwagon/templates/bandwagon/edit_contributors.html:26
 msgid ""
-"You can add multiple contributors to this collection. A contributor can add "
-"and remove add-ons from this collection, but cannot change its name or "
-"description. To add a contributor, enter their email in the box below. "
-"Contributors must have a Mozilla Add-ons account."
+"You can add multiple contributors to this collection. A contributor can add and remove add-ons from this collection, but cannot change its name or description. To add a contributor, enter their "
+"email in the box below. Contributors must have a Mozilla Add-ons account."
 msgstr ""
-"Lehetőség van egy gyűjteményhez több közreműködőt is hozzáadni. A "
-"közreműködő kiegészítőket adhat hozzá és távolíthat el a gyűjteményből- A "
-"közreműködő hozzáadásához adja meg az e-mail címét. A közreműködőnek "
-"rendelkeznie kell Mozilla Add-ons felhasználói fiókkal."
+"Lehetőség van egy gyűjteményhez több közreműködőt is hozzáadni. A közreműködő kiegészítőket adhat hozzá és távolíthat el a gyűjteményből- A közreműködő hozzáadásához adja meg az e-mail címét. A "
+"közreműködőnek rendelkeznie kell Mozilla Add-ons felhasználói fiókkal."
 
 #: src/olympia/bandwagon/templates/bandwagon/edit_contributors.html:40
 msgid "User"
 msgstr "Felhasználó"
 
-#: src/olympia/bandwagon/templates/bandwagon/edit_contributors.html:41
-#: src/olympia/devhub/templates/devhub/addons/edit/support.html:20
-#: src/olympia/users/templates/users/delete.html:49
+#: src/olympia/bandwagon/templates/bandwagon/edit_contributors.html:41 src/olympia/devhub/templates/devhub/addons/edit/support.html:20 src/olympia/users/templates/users/delete.html:49
 msgid "Email"
 msgstr "E-mail"
 
@@ -3292,28 +2606,14 @@ msgid "Admin Settings"
 msgstr "Admin beállítások"
 
 #: src/olympia/bandwagon/templates/bandwagon/edit_contributors.html:76
-msgid ""
-"<b>Warning:</b> By changing the owner of this collection, you will no longer"
-" be able to edit it. You will only be able to add and remove add-ons from "
-"it."
-msgstr ""
-"<b>Figyelem!</b> A gyűjtemény tulajdonosának megváltoztatásakor, többet nem "
-"jogosult a gyűjtemény szerkesztéséhez. Ettől kezdve csak kiegészítőket tud "
-"majd eltávolítani és hozzáadni."
+msgid "<b>Warning:</b> By changing the owner of this collection, you will no longer be able to edit it. You will only be able to add and remove add-ons from it."
+msgstr "<b>Figyelem!</b> A gyűjtemény tulajdonosának megváltoztatásakor, többet nem jogosult a gyűjtemény szerkesztéséhez. Ettől kezdve csak kiegészítőket tud majd eltávolítani és hozzáadni."
 
-#: src/olympia/bandwagon/templates/bandwagon/edit_contributors.html:83
-#: src/olympia/devhub/templates/devhub/addons/forms_shared/media.html:157
-#: src/olympia/devhub/templates/devhub/addons/submit/describe.html:69
-#: src/olympia/devhub/templates/devhub/addons/submit/license.html:60
-#: src/olympia/devhub/templates/devhub/addons/submit/upload.html:78
-#: src/olympia/devhub/templates/devhub/payments/tier.html:17
-#: src/olympia/editors/templates/editors/themes/themes.html:111
-#: src/olympia/editors/templates/editors/themes/themes.html:128
-#: src/olympia/editors/templates/editors/themes/themes.html:134
-#: src/olympia/editors/templates/editors/themes/themes.html:141
-#: src/olympia/users/templates/users/fxa_migration_prompt_content.html:10
-#: src/olympia/users/templates/users/login_form.html:42
-#: src/olympia/users/templates/users/mobile/login.html:57
+#: src/olympia/bandwagon/templates/bandwagon/edit_contributors.html:83 src/olympia/devhub/templates/devhub/addons/forms_shared/media.html:157
+#: src/olympia/devhub/templates/devhub/addons/submit/describe.html:69 src/olympia/devhub/templates/devhub/addons/submit/license.html:60 src/olympia/devhub/templates/devhub/addons/submit/upload.html:70
+#: src/olympia/devhub/templates/devhub/payments/tier.html:17 src/olympia/editors/templates/editors/themes/themes.html:111 src/olympia/editors/templates/editors/themes/themes.html:128
+#: src/olympia/editors/templates/editors/themes/themes.html:134 src/olympia/editors/templates/editors/themes/themes.html:141 src/olympia/users/templates/users/fxa_migration_prompt_content.html:10
+#: src/olympia/users/templates/users/login_form.html:42 src/olympia/users/templates/users/mobile/login.html:57
 msgid "Continue"
 msgstr "Folytatás"
 
@@ -3352,18 +2652,12 @@ msgstr "Jelenleg népszerű gyűjtemények"
 
 #: src/olympia/bandwagon/templates/bandwagon/impala/collection_listing.html:28
 #, python-format
-msgid ""
-"Collections are groups of related add-ons that anyone can create and share. "
-"Explore collections created by other users or <a href=\"%(url)s\">create "
-"your own</a>."
+msgid "Collections are groups of related add-ons that anyone can create and share. Explore collections created by other users or <a href=\"%(url)s\">create your own</a>."
 msgstr ""
-"A gyűjtemények valaki által összeállított és megosztott, valamilyen módon "
-"kapcsolatban lévő kiegészítők csoportja. Fedezze fel a mások által készített"
-" gyűjteményeket vagy <a href=\"%(url)s\">készítse el sajátját</a>."
+"A gyűjtemények valaki által összeállított és megosztott, valamilyen módon kapcsolatban lévő kiegészítők csoportja. Fedezze fel a mások által készített gyűjteményeket vagy <a "
+"href=\"%(url)s\">készítse el sajátját</a>."
 
-#: src/olympia/bandwagon/templates/bandwagon/impala/collection_listing.html:37
-#: src/olympia/browse/templates/browse/extensions.html:13
-#: src/olympia/browse/templates/browse/themes.html:14
+#: src/olympia/bandwagon/templates/bandwagon/impala/collection_listing.html:37 src/olympia/browse/templates/browse/extensions.html:13 src/olympia/browse/templates/browse/themes.html:14
 msgid "Subscribe"
 msgstr "Feliratkozás"
 
@@ -3371,20 +2665,14 @@ msgstr "Feliratkozás"
 msgid "Following"
 msgstr "Követés"
 
-#: src/olympia/bandwagon/templates/bandwagon/impala/collection_sidebar.html:22
-#: src/olympia/bandwagon/templates/bandwagon/impala/collection_sidebar.html:28
+#: src/olympia/bandwagon/templates/bandwagon/impala/collection_sidebar.html:22 src/olympia/bandwagon/templates/bandwagon/impala/collection_sidebar.html:28
 #: src/olympia/bandwagon/templates/bandwagon/includes/collection_sidebar.html:32
 msgid "Create a Collection"
 msgstr "Gyűjtemény készítése"
 
-#: src/olympia/bandwagon/templates/bandwagon/impala/collection_sidebar.html:23
-#: src/olympia/bandwagon/templates/bandwagon/includes/collection_sidebar.html:27
-msgid ""
-"Collections make it easy to keep track of favorite add-ons and share your "
-"perfectly customized browser with others."
-msgstr ""
-"A gyűjtemények egyszerűvé teszik a kedvenc kiegészítők figyelemmel kísérését"
-" és másokkal való megosztását."
+#: src/olympia/bandwagon/templates/bandwagon/impala/collection_sidebar.html:23 src/olympia/bandwagon/templates/bandwagon/includes/collection_sidebar.html:27
+msgid "Collections make it easy to keep track of favorite add-ons and share your perfectly customized browser with others."
+msgstr "A gyűjtemények egyszerűvé teszik a kedvenc kiegészítők figyelemmel kísérését és másokkal való megosztását."
 
 #: src/olympia/bandwagon/templates/bandwagon/includes/addedit.html:42
 msgid "Collection Icon"
@@ -3395,53 +2683,43 @@ msgid "Reset"
 msgstr "Visszaállítás"
 
 #: src/olympia/bandwagon/templates/bandwagon/includes/addedit.html:53
-msgid "PNG and JPG supported.  Image will be resized to 32x32."
-msgstr ""
-"PNG és JPG formátum támogatott.  A kép 32×32 méretre lesz átméretezve."
+msgid "PNG and JPG supported. Image will be resized to 32x32."
+msgstr "PNG és JPG formátum támogatott, a kép mérete 32x32 méretre lesz átméretezve."
 
 #: src/olympia/bandwagon/templates/bandwagon/includes/addedit_errors.html:3
-msgid "There are errors in this form.  Please correct them below."
-msgstr "Hibák vannak ezen az űrlapon.  Kérjük, alább javítsa ezeket."
+msgid "There are errors in this form. Please correct them below."
+msgstr "Hibák vannak ezen az űrlapon. Javítsa őket."
 
 #: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:2
 msgid "Add-ons in Your Collection"
 msgstr "Kiegészítők a gyűjteményében"
 
 #: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:4
-msgid ""
-"To include an add-on in this collection, enter its name in the box below and"
-" hit enter. You can also use the <strong>Add to Collection</strong> links "
-"throughout the site to include add-ons later."
+msgid "To include an add-on in this collection, enter its name in the box below and hit enter."
 msgstr ""
-"A kiegészítők gyűjteményhez való hozzáadásához adja meg a kiegészítő nevét "
-"és nyomja meg az Enter billentyűt. Másik lehetőség a kiegészítő oldalakon "
-"található <strong>Hozzáadás gyűjteményhez</strong> hivatkozásokat "
-"használata."
 
-#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:17
-#: src/olympia/constants/base.py:400
-#: src/olympia/devhub/templates/devhub/addons/activity.html:62
+#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:15 src/olympia/constants/base.py:400 src/olympia/devhub/templates/devhub/addons/activity.html:62
+#: src/olympia/editors/helpers.py:273 src/olympia/editors/helpers.py:360
 msgid "Add-on"
 msgstr "Kiegészítő"
 
-#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:26
+#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:24
 msgid "Enter the name of the add-on to include"
 msgstr "Adja meg a hozzáadni kívánt kiegészítő nevét"
 
-#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:28
+#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:26
 msgid "Add to Collection"
 msgstr "Hozzáadás gyűjteményhez"
 
-#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:45
-#: src/olympia/editors/helpers.py:936 src/olympia/editors/helpers.py:956
+#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:43 src/olympia/editors/helpers.py:1016 src/olympia/editors/helpers.py:1036
 msgid "Pending"
 msgstr "Függő"
 
-#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:47
+#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:45
 msgid "Add a comment"
 msgstr "Megjegyzés hozzáadása"
 
-#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:48
+#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:46
 msgid "Remove this add-on from the collection"
 msgstr "Kiegészítő eltávolítása a gyűjteményből"
 
@@ -3453,14 +2731,11 @@ msgstr "Gyűjtemények"
 msgid "Groups of related add-ons that anyone can create."
 msgstr "Bárki által létrehozott kiegészítők egy csoportja."
 
-#: src/olympia/blocklist/templates/blocklist/blocked_detail.html:3
-#: src/olympia/blocklist/templates/blocklist/blocked_list.html:3
-#: src/olympia/blocklist/templates/blocklist/blocked_list.html:10
+#: src/olympia/blocklist/templates/blocklist/blocked_detail.html:3 src/olympia/blocklist/templates/blocklist/blocked_list.html:3 src/olympia/blocklist/templates/blocklist/blocked_list.html:10
 msgid "Blocked Add-ons"
 msgstr "Blokkolt kiegészítők"
 
-#: src/olympia/blocklist/templates/blocklist/blocked_detail.html:8
-#: src/olympia/blocklist/templates/blocklist/blocked_list.html:6
+#: src/olympia/blocklist/templates/blocklist/blocked_detail.html:8 src/olympia/blocklist/templates/blocklist/blocked_list.html:6
 msgid "Blocklist"
 msgstr "Blokklista"
 
@@ -3482,44 +2757,27 @@ msgid "What does this mean?"
 msgstr "Mit jelent ez?"
 
 #: src/olympia/blocklist/templates/blocklist/blocked_detail.html:22
-msgid ""
-"Users are strongly encouraged to disable the problematic add-on or plugin, "
-"but may choose to continue using it if they accept the risks described."
-msgstr ""
-"A felhasználóknak erősen javasolt, hogy tiltsa le a problémás kiegészítőket "
-"vagy bővítményeket, de dönthet úgy is, hogy továbbra is használja ezeket, "
-"amennyiben elfogadja a leírt kockázatok."
+msgid "Users are strongly encouraged to disable the problematic add-on or plugin, but may choose to continue using it if they accept the risks described."
+msgstr "A felhasználóknak erősen javasolt, hogy tiltsa le a problémás kiegészítőket vagy bővítményeket, de dönthet úgy is, hogy továbbra is használja ezeket, amennyiben elfogadja a leírt kockázatok."
 
 #: src/olympia/blocklist/templates/blocklist/blocked_detail.html:27
-msgid ""
-"The problematic add-on or plugin will be automatically disabled and no "
-"longer usable."
-msgstr ""
-"A problémás kiegészítő vagy bővítmény automatikusan letiltásra kerül és nem "
-"lesz használható."
+msgid "The problematic add-on or plugin will be automatically disabled and no longer usable."
+msgstr "A problémás kiegészítő vagy bővítmény automatikusan letiltásra kerül és nem lesz használható."
 
 #: src/olympia/blocklist/templates/blocklist/blocked_detail.html:33
 #, python-format
 msgid ""
-"When Mozilla becomes aware of add-ons, plugins, or other third-party "
-"software that seriously compromises %(app)s security, stability, or "
-"performance and meets <a href=\"%(criteria)s\">certain criteria</a>, the "
-"software may be blocked from general use. For more information, please read "
-"<a href=\"%(support)s\">this support article</a>."
+"When Mozilla becomes aware of add-ons, plugins, or other third-party software that seriously compromises %(app)s security, stability, or performance and meets <a href=\"%(criteria)s\">certain "
+"criteria</a>, the software may be blocked from general use. For more information, please read <a href=\"%(support)s\">this support article</a>."
 msgstr ""
-"Amikor a Mozilla tudomást szerez arról, hogy valamely kiegészítő, bővítmény "
-"vagy más gyártók szoftverkomponense komolyan veszélyezteti a(z) %(app)s "
-"biztonságát, a stabilitását vagy teljesítményét, és megfelel <a "
-"href=\"%(criteria)s\">bizonyos kritériumoknak</a>, a szoftver általános "
-"használatát blokkolhatják. További információkért kérjük, olvassa el <a "
-"href=\"%(support)s\">ezt a leírást</a>."
+"Amikor a Mozilla tudomást szerez arról, hogy valamely kiegészítő, bővítmény vagy más gyártók szoftverkomponense komolyan veszélyezteti a(z) %(app)s biztonságát, a stabilitását vagy teljesítményét, "
+"és megfelel <a href=\"%(criteria)s\">bizonyos kritériumoknak</a>, a szoftver általános használatát blokkolhatják. További információkért kérjük, olvassa el <a href=\"%(support)s\">ezt a "
+"leírást</a>."
 
 #: src/olympia/blocklist/templates/blocklist/blocked_detail.html:44
 #, python-format
 msgid "Blocked on %(date)s. <a href=\"%(link)s\">View block request</a>."
-msgstr ""
-"Blokkolva: %(date)s. <a href=\"%(link)s\">Tekintse meg a blokkolási "
-"kérést</a>."
+msgstr "Blokkolva: %(date)s. <a href=\"%(link)s\">Tekintse meg a blokkolási kérést</a>."
 
 #: src/olympia/blocklist/templates/blocklist/blocked_detail.html:48
 #, python-format
@@ -3527,12 +2785,8 @@ msgid "Blocked on %(date)s."
 msgstr "Blokkolás ideje: %(date)s."
 
 #: src/olympia/blocklist/templates/blocklist/blocked_list.html:11
-msgid ""
-"The following software is known to cause serious security, stability, or "
-"performance issues with {app}."
-msgstr ""
-"Ennek a szoftvernek ismert, súlyos biztonsági-, stabilitási- vagy "
-"teljesítmény problémái vannak a {app} alkalmazással."
+msgid "The following software is known to cause serious security, stability, or performance issues with {app}."
+msgstr "Ennek a szoftvernek ismert, súlyos biztonsági-, stabilitási- vagy teljesítmény problémái vannak a {app} alkalmazással."
 
 #. L10n: %s is a category name.
 #: src/olympia/browse/feeds.py:76 src/olympia/browse/feeds.py:98
@@ -3554,11 +2808,8 @@ msgstr "Kiemelt kiegészítők :: %s"
 #. L10n: %s is an app name.
 #: src/olympia/browse/feeds.py:138
 #, python-format
-msgid ""
-"Here's a few of our favorite add-ons to help you get started customizing %s."
-msgstr ""
-"Itt van néhány népszerű kiegészítő, hogy segítsen testreszabni a %s "
-"alkalmazást."
+msgid "Here's a few of our favorite add-ons to help you get started customizing %s."
+msgstr "Itt van néhány népszerű kiegészítő, hogy segítsen testreszabni a %s alkalmazást."
 
 #. L10n: %s is a category name.
 #: src/olympia/browse/feeds.py:157
@@ -3574,43 +2825,28 @@ msgstr "Keresőeszközök és kereséssel kapcsolatos bővítmények"
 msgid "Search tools"
 msgstr "Keresőeszközök"
 
-#: src/olympia/browse/views.py:55 src/olympia/browse/views.py:65
-#: src/olympia/search/forms.py:85
+#: src/olympia/browse/views.py:55 src/olympia/browse/views.py:65 src/olympia/search/forms.py:85
 msgid "Most Users"
 msgstr "Legtöbb felhasználó"
 
-#: src/olympia/browse/views.py:61 src/olympia/browse/views.py:72
-#: src/olympia/browse/views.py:279
-#: src/olympia/browse/templates/browse/personas/mobile/category_landing.html:63
-#: src/olympia/discovery/templates/discovery/pane.html:67
-#: src/olympia/search/forms.py:92
+#: src/olympia/browse/views.py:61 src/olympia/browse/views.py:72 src/olympia/browse/views.py:246 src/olympia/browse/templates/browse/personas/mobile/category_landing.html:63
+#: src/olympia/discovery/templates/discovery/pane.html:67 src/olympia/search/forms.py:92
 msgid "Up & Coming"
 msgstr "Ígéretes"
 
-#: src/olympia/browse/views.py:460 src/olympia/devhub/views.py:76
-#: src/olympia/devhub/views.py:83
-#: src/olympia/discovery/templates/discovery/addons/detail.html:66
+#: src/olympia/browse/views.py:427 src/olympia/devhub/views.py:75 src/olympia/devhub/views.py:82 src/olympia/discovery/templates/discovery/addons/detail.html:66
 msgid "Created"
 msgstr "Létrehozva"
 
 #. {0} is the category name. Ex: Sports
-#: src/olympia/browse/templates/browse/creatured.html:5
-#: src/olympia/browse/templates/browse/creatured.html:13
+#: src/olympia/browse/templates/browse/creatured.html:5 src/olympia/browse/templates/browse/creatured.html:13
 msgid "{0}: Featured Add-ons"
 msgstr "{0}: Kiemelt kiegészítők"
 
-#: src/olympia/browse/templates/browse/creatured.html:12
-#: src/olympia/browse/templates/browse/featured.html:4
-#: src/olympia/browse/templates/browse/featured.html:12
-#: src/olympia/browse/templates/browse/featured.html:13
-#: src/olympia/devhub/templates/devhub/docs/policies-recommended.html:3
-#: src/olympia/devhub/templates/devhub/docs/policies-recommended.html:7
-#: src/olympia/devhub/templates/devhub/docs/policies-recommended.html:9
-#: src/olympia/devhub/templates/devhub/docs/policies.html:21
-#: src/olympia/devhub/templates/devhub/docs/policies.html:90
-#: src/olympia/discovery/modules.py:341
-#: src/olympia/discovery/templates/discovery/pane.html:52
-#: src/olympia/templates/menu_links.html:7
+#: src/olympia/browse/templates/browse/creatured.html:12 src/olympia/browse/templates/browse/featured.html:4 src/olympia/browse/templates/browse/featured.html:12
+#: src/olympia/browse/templates/browse/featured.html:13 src/olympia/devhub/templates/devhub/docs/policies-recommended.html:3 src/olympia/devhub/templates/devhub/docs/policies-recommended.html:7
+#: src/olympia/devhub/templates/devhub/docs/policies-recommended.html:9 src/olympia/devhub/templates/devhub/docs/policies.html:21 src/olympia/devhub/templates/devhub/docs/policies.html:90
+#: src/olympia/discovery/modules.py:341 src/olympia/discovery/templates/discovery/pane.html:52 src/olympia/templates/menu_links.html:7
 msgid "Featured Add-ons"
 msgstr "Kiemelt kiegészítők"
 
@@ -3621,12 +2857,8 @@ msgstr "Nincs kiemelt kiegészítő a(z) {0} kategóriában."
 
 #: src/olympia/browse/templates/browse/featured.html:15
 #, python-format
-msgid ""
-"Here's a few of our favorite add-ons to help you get started customizing "
-"%(app)s."
-msgstr ""
-"Itt van néhány népszerű kiegészítő, hogy segítsen testreszabni a %(app)s "
-"alkalmazást."
+msgid "Here's a few of our favorite add-ons to help you get started customizing %(app)s."
+msgstr "Itt van néhány népszerű kiegészítő, hogy segítsen testreszabni a %(app)s alkalmazást."
 
 #: src/olympia/browse/templates/browse/language_tools.html:9
 msgid "Install Dictionary"
@@ -3650,23 +2882,17 @@ msgstr "Elérhető ezen a nyelven"
 
 #: src/olympia/browse/templates/browse/language_tools.html:38
 msgid "List of language packs and dictionaries available in your locale."
-msgstr ""
-"Sorolja fel a nyelvi csomagokat és szótárakat, amelyek elérhetők az Ön "
-"nyelvén. "
+msgstr "Sorolja fel a nyelvi csomagokat és szótárakat, amelyek elérhetők az Ön nyelvén. "
 
-#: src/olympia/browse/templates/browse/language_tools.html:41
-#: src/olympia/browse/templates/browse/language_tools.html:63
+#: src/olympia/browse/templates/browse/language_tools.html:41 src/olympia/browse/templates/browse/language_tools.html:63
 msgid "Language"
 msgstr "Nyelv"
 
-#: src/olympia/browse/templates/browse/language_tools.html:42
-#: src/olympia/browse/templates/browse/language_tools.html:64
-#: src/olympia/constants/base.py:162
+#: src/olympia/browse/templates/browse/language_tools.html:42 src/olympia/browse/templates/browse/language_tools.html:64 src/olympia/constants/base.py:162
 msgid "Dictionary"
 msgstr "Szótár"
 
-#: src/olympia/browse/templates/browse/language_tools.html:43
-#: src/olympia/browse/templates/browse/language_tools.html:65
+#: src/olympia/browse/templates/browse/language_tools.html:43 src/olympia/browse/templates/browse/language_tools.html:65
 msgid "Language Pack"
 msgstr "Nyelvi csomag"
 
@@ -3684,8 +2910,7 @@ msgid "{0} :: Search Tools"
 msgstr "{0} :: Keresőeszközök"
 
 #. {0} is an integer.
-#: src/olympia/browse/templates/browse/search_tools.html:39
-#: src/olympia/devhub/templates/devhub/addons/dashboard.html:17
+#: src/olympia/browse/templates/browse/search_tools.html:39 src/olympia/devhub/templates/devhub/addons/dashboard.html:17
 msgid "<b>{0}</b> add-on"
 msgid_plural "<b>{0}</b> add-ons"
 msgstr[0] "<b>{0}</b> kiegészítő"
@@ -3713,34 +2938,18 @@ msgstr "További források"
 
 #. {0} is an app name, like Firefox.
 #: src/olympia/browse/templates/browse/search_tools.html:93
-msgid ""
-"Learn more about the <a "
-"href=\"http://support.mozilla.com/kb/Search+bar\">search bar</a> in {0}"
-msgstr ""
-"Tudjon meg többet a {0} <a "
-"href=\"http://support.mozilla.com/kb/Search+bar\">keresőmezőjéről</a>."
+msgid "Learn more about the <a href=\"http://support.mozilla.com/kb/Search+bar\">search bar</a> in {0}"
+msgstr "Tudjon meg többet a {0} <a href=\"http://support.mozilla.com/kb/Search+bar\">keresőmezőjéről</a>."
 
 #: src/olympia/browse/templates/browse/search_tools.html:94
-msgid ""
-"Browse through even more search providers at <a "
-"href=\"http://mycroft.mozdev.org/\">mycroft.mozdev.org</a>"
-msgstr ""
-"További kereső szolgáltatót találhat a <a "
-"href=\"http://mycroft.mozdev.org/\">mycroft.mozdev.org</a> weboldalon"
+msgid "Browse through even more search providers at <a href=\"http://mycroft.mozdev.org/\">mycroft.mozdev.org</a>"
+msgstr "További kereső szolgáltatót találhat a <a href=\"http://mycroft.mozdev.org/\">mycroft.mozdev.org</a> weboldalon"
 
 #: src/olympia/browse/templates/browse/search_tools.html:95
-msgid ""
-"<a "
-"href=\"https://developer.mozilla.org/en/Creating_OpenSearch_plugins_for_Firefox\">Make"
-" your own</a> search tool"
-msgstr ""
-"<a "
-"href=\"https://developer.mozilla.org/en/Creating_OpenSearch_plugins_for_Firefox\">Készítse"
-" el saját</a> keresőjét"
+msgid "<a href=\"https://developer.mozilla.org/en/Creating_OpenSearch_plugins_for_Firefox\">Make your own</a> search tool"
+msgstr "<a href=\"https://developer.mozilla.org/en/Creating_OpenSearch_plugins_for_Firefox\">Készítse el saját</a> keresőjét"
 
-#: src/olympia/browse/templates/browse/themes.html:6
-#: src/olympia/browse/templates/browse/themes.html:9
-#: src/olympia/constants/base.py:174
+#: src/olympia/browse/templates/browse/themes.html:6 src/olympia/browse/templates/browse/themes.html:9 src/olympia/constants/base.py:174
 msgid "Complete Themes"
 msgstr "Teljes témák"
 
@@ -3811,27 +3020,19 @@ msgstr "Ígéretes teljes témák"
 msgid "See the %(cnt)s extension in %(name)s &raquo;"
 msgid_plural "See all %(cnt)s extensions in %(name)s &raquo;"
 msgstr[0] "Tekintse meg %(cnt)s bővítményt a(z) %(name)s kategóriában &raquo;"
-msgstr[1] ""
-"Tekintsen meg %(cnt)s bővítményt a(z) %(name)s kategóriában &raquo;"
+msgstr[1] "Tekintsen meg %(cnt)s bővítményt a(z) %(name)s kategóriában &raquo;"
 
-#: src/olympia/browse/templates/browse/mobile/extensions.html:13
-#: src/olympia/compat/templates/compat/index.html:82
-#: src/olympia/devhub/templates/devhub/devhub_search.html:24
-#: src/olympia/devhub/templates/devhub/addons/activity.html:47
-#: src/olympia/search/templates/search/no_results.html:4
-#: src/olympia/search/templates/search/mobile/results.html:36
+#: src/olympia/browse/templates/browse/mobile/extensions.html:13 src/olympia/devhub/templates/devhub/devhub_search.html:24 src/olympia/devhub/templates/devhub/addons/activity.html:47
+#: src/olympia/search/templates/search/no_results.html:4 src/olympia/search/templates/search/mobile/results.html:36
 msgid "No results found."
 msgstr "A keresés eredménytelen."
 
-#: src/olympia/browse/templates/browse/personas/base.html:6
-#: src/olympia/browse/templates/browse/personas/mobile/base.html:7
+#: src/olympia/browse/templates/browse/personas/base.html:6 src/olympia/browse/templates/browse/personas/mobile/base.html:7
 msgid "{0} Themes"
 msgstr "{0} téma"
 
 #. {0} is a user's name.
-#: src/olympia/browse/templates/browse/personas/base.html:15
-#: src/olympia/browse/templates/browse/personas/base.html:40
-#: src/olympia/browse/templates/browse/personas/grid.html:8
+#: src/olympia/browse/templates/browse/personas/base.html:15 src/olympia/browse/templates/browse/personas/base.html:40 src/olympia/browse/templates/browse/personas/grid.html:8
 msgid "{0}'s Themes"
 msgstr "{0} témái"
 
@@ -3851,31 +3052,22 @@ msgstr "Az Ön böngészője, az Ön stílusa! Öltöztesse fel saját ízlése 
 msgid "Learn more"
 msgstr "Tudjon meg többet"
 
-#: src/olympia/browse/templates/browse/personas/category_landing.html:6
-#: src/olympia/browse/templates/browse/personas/mobile/category_landing.html:5
+#: src/olympia/browse/templates/browse/personas/category_landing.html:6 src/olympia/browse/templates/browse/personas/mobile/category_landing.html:5
 msgid "View All Recently Added"
 msgstr "Összes nemrég hozzáadott megtekintése"
 
-#: src/olympia/browse/templates/browse/personas/category_landing.html:7
-#: src/olympia/browse/templates/browse/personas/mobile/category_landing.html:6
+#: src/olympia/browse/templates/browse/personas/category_landing.html:7 src/olympia/browse/templates/browse/personas/mobile/category_landing.html:6
 msgid "View All Most Popular"
 msgstr "Összes legnépszerűbb megtekintése"
 
-#: src/olympia/browse/templates/browse/personas/category_landing.html:8
-#: src/olympia/browse/templates/browse/personas/mobile/category_landing.html:7
+#: src/olympia/browse/templates/browse/personas/category_landing.html:8 src/olympia/browse/templates/browse/personas/mobile/category_landing.html:7
 msgid "View All Top Rated"
 msgstr "Összes legtöbbre értékelt megtekintése"
 
 #: src/olympia/browse/templates/browse/personas/category_landing.html:40
 #, python-format
-msgid ""
-"Over 300,000 designs to personalize your browser! Move your mouse over a "
-"Background Theme to try it on. <a href=\"%(url)s\" class=\"more-info\">Start"
-" exploring</a>"
-msgstr ""
-"300 000-nél is több téma a böngészője testreszabásához! Vigye egerét egy "
-"háttértéma fölé a kipróbálásához. <a href=\"%(url)s\" class=\"more-"
-"info\">Kezdje el a felfedezést</a>"
+msgid "Over 300,000 designs to personalize your browser! Move your mouse over a Background Theme to try it on. <a href=\"%(url)s\" class=\"more-info\">Start exploring</a>"
+msgstr "300 000-nél is több téma a böngészője testreszabásához! Vigye egerét egy háttértéma fölé a kipróbálásához. <a href=\"%(url)s\" class=\"more-info\">Kezdje el a felfedezést</a>"
 
 #: src/olympia/browse/templates/browse/personas/category_landing.html:47
 msgid "Want more personalization?"
@@ -3885,14 +3077,8 @@ msgstr "További testreszabást szeretne?"
 #. theme.
 #: src/olympia/browse/templates/browse/personas/category_landing.html:50
 #, python-format
-msgid ""
-"Complete Themes transform the look of your browser with styles for the "
-"window frame, address bar, buttons, tabs, and menus. <a href=\"%(url)s\" "
-"class=\"more-info\">Start exploring</a>"
-msgstr ""
-"A teljes témák átalakítják az egész böngésző megjelenését az ablakkeret, "
-"címsor, gombok, lapok és menük stílusaival. <a href=\"%(url)s\" class"
-"=\"more-info\">Kezdje el a felfedezést</a>"
+msgid "Complete Themes transform the look of your browser with styles for the window frame, address bar, buttons, tabs, and menus. <a href=\"%(url)s\" class=\"more-info\">Start exploring</a>"
+msgstr "A teljes témák átalakítják az egész böngésző megjelenését az ablakkeret, címsor, gombok, lapok és menük stílusaival. <a href=\"%(url)s\" class=\"more-info\">Kezdje el a felfedezést</a>"
 
 #: src/olympia/browse/templates/browse/personas/category_landing.html:76
 msgid "Up & Coming Themes"
@@ -3922,7 +3108,7 @@ msgstr "&laquo; Összes téma"
 msgid "All"
 msgstr "Összes"
 
-#: src/olympia/compat/forms.py:22 src/olympia/search/views.py:525
+#: src/olympia/compat/forms.py:22 src/olympia/editors/templates/editors/base.html:69 src/olympia/search/views.py:518
 msgid "All Add-ons"
 msgstr "Összes kiegészítő"
 
@@ -3934,93 +3120,32 @@ msgstr "Bináris"
 msgid "Non-binary"
 msgstr "Nem bináris"
 
-#. Review points sources other than add-ons and themes.
-#: src/olympia/compat/views.py:87 src/olympia/constants/base.py:388
-#: src/olympia/devhub/forms.py:162
-#: src/olympia/editors/templates/editors/performance.html:75
-msgid "Other"
-msgstr "Egyéb"
-
-#: src/olympia/compat/templates/compat/index.html:4
-msgid "Add-on Compatibility Report for {app} {version}"
-msgstr "{app} {version} kiegészítő kompatibilitása"
-
-#: src/olympia/compat/templates/compat/index.html:11
-msgid "{app} {version} Compatibility"
-msgstr "{app} {version} kompatibilitás"
-
-#: src/olympia/compat/templates/compat/index.html:17
-#, python-format
-msgid "Top 95%% compatible with previous version"
-msgstr "Az előző verzióval kompatibilisek felső 95%%-a"
-
-#: src/olympia/compat/templates/compat/index.html:18
-#, python-format
-msgid "Top 95%% of all add-ons"
-msgstr "A kiegészítők felső 95%%-a"
-
-#: src/olympia/compat/templates/compat/index.html:19
-msgid "All active add-ons"
-msgstr "Összes aktív kiterjesztés"
-
-#: src/olympia/compat/templates/compat/index.html:23
-#: src/olympia/constants/base.py:401
-msgid "App"
-msgstr "App"
-
-#: src/olympia/compat/templates/compat/index.html:55
-msgid "Details for add-ons compatible with previous version:"
-msgstr "Előző verzióval kompatibilis kiegészítők részletei:"
-
-#: src/olympia/compat/templates/compat/index.html:57
-msgid "Show all versions"
-msgstr "Összes verzió megjelenítése"
-
-#: src/olympia/compat/templates/compat/index.html:59
-msgid "Details for add-ons compatible with all versions:"
-msgstr "Minden verzióval kompatibilis kiegészítők részletei:"
-
-#: src/olympia/compat/templates/compat/index.html:61
-msgid "Show previous version only"
-msgstr "Csak a korábbi verziók megjelenítése"
-
 #: src/olympia/compat/templates/compat/reporter.html:3
 msgid "Add-on Compatibility Reports"
 msgstr "Kiegészítők kompatibilitási jelentései"
 
-#: src/olympia/compat/templates/compat/reporter.html:11
-#: src/olympia/compat/templates/compat/reporter_detail.html:35
+#: src/olympia/compat/templates/compat/reporter.html:11 src/olympia/compat/templates/compat/reporter_detail.html:35
 #, python-format
 msgid ""
-"<p> Reports submitted to us through the <a href=\"%(url_)s\">Add-on "
-"Compatibility Reporter</a> are collected here for developers to view. These "
-"reports help us determine which add-ons will need help supporting an "
-"upcoming Firefox version. </p>"
+"<p> Reports submitted to us through the <a href=\"%(url_)s\">Add-on Compatibility Reporter</a> are collected here for developers to view. These reports help us determine which add-ons will need "
+"help supporting an upcoming Firefox version. </p>"
 msgstr ""
-"<p>A <a href=\"%(url_)s\">kiegészítők kompatibilitási jelentésén</a> "
-"keresztül beküldött jelentések itt kerülnek összegyűjtésre a fejlesztők "
-"számára. Ezek a jelentések segítenek nekünk meghatározni, hogy mely "
-"kiegészítők igényelnek majd segítséget egy soron következő Firefox verzió "
-"támogatásához.</p>"
+"<p>A <a href=\"%(url_)s\">kiegészítők kompatibilitási jelentésén</a> keresztül beküldött jelentések itt kerülnek összegyűjtésre a fejlesztők számára. Ezek a jelentések segítenek nekünk "
+"meghatározni, hogy mely kiegészítők igényelnek majd segítséget egy soron következő Firefox verzió támogatásához.</p>"
 
 #: src/olympia/compat/templates/compat/reporter.html:18
 msgid "Reports for your Add-ons"
 msgstr "Kiegészítőinek jelentései"
 
-#: src/olympia/compat/templates/compat/reporter.html:30
-#: src/olympia/compat/templates/compat/reporter_detail.html:9
+#: src/olympia/compat/templates/compat/reporter.html:30 src/olympia/compat/templates/compat/reporter_detail.html:9
 msgid "Add-on Compatibility Center"
 msgstr "Kiegészítő kompatibilitási központ"
 
 #: src/olympia/compat/templates/compat/reporter.html:34
 msgid "Enter the GUID of an add-on below to view any reports we've received."
-msgstr ""
-"Adja meg a kiegészítő GUID-ját, hogy megtekinthessen bármilyen beérkezett "
-"jelentést."
+msgstr "Adja meg a kiegészítő GUID-ját, hogy megtekinthessen bármilyen beérkezett jelentést."
 
-#: src/olympia/compat/templates/compat/reporter_detail.html:3
-#: src/olympia/compat/templates/compat/reporter_detail.html:10
-#: src/olympia/compat/templates/compat/reporter_detail.html:25
+#: src/olympia/compat/templates/compat/reporter_detail.html:3 src/olympia/compat/templates/compat/reporter_detail.html:10 src/olympia/compat/templates/compat/reporter_detail.html:25
 msgid "{addon} Compatibility Reports"
 msgstr "{addon} kompatibilitási jelentései"
 
@@ -4036,8 +3161,7 @@ msgid_plural "{0} problem reports"
 msgstr[0] "{0} hibajelentés"
 msgstr[1] "{0} hibajelentés"
 
-#: src/olympia/compat/templates/compat/reporter_detail.html:21
-#: src/olympia/users/templates/users/profile.html:70
+#: src/olympia/compat/templates/compat/reporter_detail.html:21 src/olympia/users/templates/users/profile.html:70
 msgid "View all"
 msgstr "Összes megjelenítése"
 
@@ -4049,10 +3173,8 @@ msgstr "Szűrés alkalmazás szerint"
 msgid "Report Type"
 msgstr "Jelentés típusa"
 
-#: src/olympia/compat/templates/compat/reporter_detail.html:47
-#: src/olympia/devhub/forms.py:784
-#: src/olympia/devhub/templates/devhub/addons/ajax_compat_update.html:17
-#: src/olympia/editors/forms.py:108 src/olympia/zadmin/forms.py:45
+#: src/olympia/compat/templates/compat/reporter_detail.html:47 src/olympia/devhub/forms.py:785 src/olympia/devhub/templates/devhub/addons/ajax_compat_update.html:17 src/olympia/editors/forms.py:108
+#: src/olympia/editors/forms.py:248 src/olympia/zadmin/forms.py:45
 msgid "Application"
 msgstr "Alkalmazás"
 
@@ -4064,8 +3186,7 @@ msgstr "Alkalmazás build"
 msgid "Platform"
 msgstr "Platform"
 
-#: src/olympia/compat/templates/compat/reporter_detail.html:50
-#: src/olympia/editors/templates/editors/themes/themes.html:40
+#: src/olympia/compat/templates/compat/reporter_detail.html:50 src/olympia/editors/templates/editors/themes/themes.html:40
 msgid "Submitted"
 msgstr "Elküldve"
 
@@ -4093,8 +3214,7 @@ msgstr "Thunderbird"
 msgid "SeaMonkey"
 msgstr "SeaMonkey"
 
-#: src/olympia/constants/applications.py:75
-#: src/olympia/pages/templates/pages/sunbird.html:4
+#: src/olympia/constants/applications.py:75 src/olympia/pages/templates/pages/sunbird.html:4
 msgid "Sunbird"
 msgstr "Sunbird"
 
@@ -4142,7 +3262,7 @@ msgstr "Előzetesen értékelt"
 msgid "Preliminarily Reviewed and Awaiting Full Review"
 msgstr "Előzetesen értékelt és teljes értékelésre vár"
 
-#: src/olympia/constants/base.py:33 src/olympia/editors/helpers.py:924
+#: src/olympia/constants/base.py:33 src/olympia/editors/forms.py:258 src/olympia/editors/helpers.py:73 src/olympia/editors/helpers.py:1004
 #: src/olympia/editors/templates/editors/themes/history_table.html:34
 msgid "Deleted"
 msgstr "Törölt"
@@ -4176,13 +3296,11 @@ msgstr "Fejlesztő"
 msgid "Viewer"
 msgstr "Szemlélő"
 
-#: src/olympia/constants/base.py:137
-#: src/olympia/templates/mobile/header.html:7
+#: src/olympia/constants/base.py:137 src/olympia/templates/mobile/header.html:7
 msgid "Support"
 msgstr "Támogatás"
 
-#: src/olympia/constants/base.py:159 src/olympia/constants/base.py:172
-#: src/olympia/constants/platforms.py:10
+#: src/olympia/constants/base.py:159 src/olympia/constants/base.py:172 src/olympia/constants/platforms.py:10
 msgid "Any"
 msgstr "Bármely"
 
@@ -4210,11 +3328,8 @@ msgstr "Nyelvi csomag (kiegészítő)"
 msgid "Plugin"
 msgstr "Bővítmény"
 
-#: src/olympia/constants/base.py:167
-#: src/olympia/editors/templates/editors/includes/search_results_themes.html:5
-#: src/olympia/editors/templates/editors/themes/deleted.html:18
-#: src/olympia/editors/templates/editors/themes/history_table.html:8
-#: src/olympia/editors/templates/editors/themes/logs.html:17
+#: src/olympia/constants/base.py:167 src/olympia/editors/templates/editors/includes/search_results_themes.html:5 src/olympia/editors/templates/editors/themes/deleted.html:18
+#: src/olympia/editors/templates/editors/themes/history_table.html:8 src/olympia/editors/templates/editors/themes/logs.html:17
 msgid "Theme"
 msgstr "Téma"
 
@@ -4242,13 +3357,16 @@ msgstr "Csak ezen a kiegészítő oldalon és a fejlesztői profilon kérdezzen"
 
 #: src/olympia/constants/base.py:272
 msgid "Ask after users start downloading this add-on"
-msgstr ""
-"Azután kérdezzen, miután a felhasználó elkezdte letölteni a kiegészítőt"
+msgstr "Azután kérdezzen, miután a felhasználó elkezdte letölteni a kiegészítőt"
 
 #: src/olympia/constants/base.py:273
 msgid "Ask before users can download this add-on"
-msgstr ""
-"Azelőtt kérdezzen, mielőtt a felhasználó le tudná tölteni a kiegészítőt"
+msgstr "Azelőtt kérdezzen, mielőtt a felhasználó le tudná tölteni a kiegészítőt"
+
+#. Review points sources other than add-ons and themes.
+#: src/olympia/constants/base.py:388 src/olympia/devhub/forms.py:162 src/olympia/editors/templates/editors/performance.html:75
+msgid "Other"
+msgstr "Egyéb"
 
 #: src/olympia/constants/base.py:389
 msgid "Exception"
@@ -4261,6 +3379,10 @@ msgstr "Kiadás"
 #: src/olympia/constants/base.py:391
 msgid "Change"
 msgstr "Módosítás"
+
+#: src/olympia/constants/base.py:401
+msgid "App"
+msgstr "App"
 
 #: src/olympia/constants/base.py:402
 msgid "Persona"
@@ -4398,32 +3520,23 @@ msgstr "Aláírva, teljes értékelésre kész"
 msgid "Signed of a preliminary review"
 msgstr "Aláírva, előzetes értékelésre kész"
 
-#: src/olympia/constants/editors.py:14
-#: src/olympia/editors/templates/editors/themes/queue.html:76
-#: src/olympia/editors/templates/editors/themes/themes.html:87
+#: src/olympia/constants/editors.py:14 src/olympia/editors/templates/editors/themes/queue.html:76 src/olympia/editors/templates/editors/themes/themes.html:87
 msgid "Request More Info"
 msgstr "További információ kérése"
 
-#: src/olympia/constants/editors.py:15
-#: src/olympia/editors/templates/editors/themes/queue.html:74
-#: src/olympia/editors/templates/editors/themes/themes.html:91
+#: src/olympia/constants/editors.py:15 src/olympia/editors/templates/editors/themes/queue.html:74 src/olympia/editors/templates/editors/themes/themes.html:91
 msgid "Flag"
 msgstr "Megjelölés"
 
-#: src/olympia/constants/editors.py:16
-#: src/olympia/editors/templates/editors/themes/queue.html:72
-#: src/olympia/editors/templates/editors/themes/themes.html:93
+#: src/olympia/constants/editors.py:16 src/olympia/editors/templates/editors/themes/queue.html:72 src/olympia/editors/templates/editors/themes/themes.html:93
 msgid "Duplicate"
 msgstr "Többszörös"
 
-#: src/olympia/constants/editors.py:17 src/olympia/editors/helpers.py:502
-#: src/olympia/editors/templates/editors/themes/queue.html:71
-#: src/olympia/editors/templates/editors/themes/themes.html:94
+#: src/olympia/constants/editors.py:17 src/olympia/editors/helpers.py:575 src/olympia/editors/templates/editors/themes/queue.html:71 src/olympia/editors/templates/editors/themes/themes.html:94
 msgid "Reject"
 msgstr "Visszautasítás"
 
-#: src/olympia/constants/editors.py:18
-#: src/olympia/editors/templates/editors/themes/queue.html:70
+#: src/olympia/constants/editors.py:18 src/olympia/editors/templates/editors/themes/queue.html:70
 msgid "Approve"
 msgstr "Jóváhagyás"
 
@@ -4519,7 +3632,7 @@ msgstr "Solaris"
 msgid "Android"
 msgstr "Android"
 
-#: src/olympia/core/apps.py:19
+#: src/olympia/core/apps.py:21
 msgid "Core"
 msgstr "Mag"
 
@@ -4556,9 +3669,7 @@ msgstr "Érvénytelen JSON objektum"
 msgid "Message not eligible for annotation"
 msgstr "Az üzenethez nem adható magyarázó jegyzet"
 
-#: src/olympia/devhub/forms.py:124
-#: src/olympia/devhub/templates/devhub/versions/edit.html:94
-#: src/olympia/users/templates/users/edit.html:150
+#: src/olympia/devhub/forms.py:124 src/olympia/devhub/templates/devhub/versions/edit.html:94 src/olympia/users/templates/users/edit.html:150
 msgid "Details"
 msgstr "Részletek"
 
@@ -4655,38 +3766,26 @@ msgid "Submit my add-on for manual review."
 msgstr "Kiegészítő kézi értékelésre benyújtása."
 
 #: src/olympia/devhub/forms.py:537
-msgid "Do not list my add-on on this site (beta)"
-msgstr "Ne listázza a kiegészítőt ezen az oldalon (béta)"
+msgid "Do not list my add-on on this site"
+msgstr ""
 
 #: src/olympia/devhub/forms.py:538
-msgid ""
-"Check this option if you intend to distribute your add-on on your own and "
-"only need it to be signed by Mozilla."
-msgstr ""
-"Jelölje be ezt a lehetőséget, ha a kiegészítőt terjeszteni kívánja, és csak "
-"a Mozilla aláírására van szüksége."
+msgid "Check this option if you intend to distribute your add-on on your own and only need it to be signed by Mozilla."
+msgstr "Jelölje be ezt a lehetőséget, ha a kiegészítőt terjeszteni kívánja, és csak a Mozilla aláírására van szüksége."
 
 #: src/olympia/devhub/forms.py:544
 msgid "This add-on will be bundled with an application installer."
 msgstr "Ez a kiegészítő egy alkalmazás-telepítőhöz lesz csatolva."
 
 #: src/olympia/devhub/forms.py:546
-msgid ""
-"Add-ons that are bundled with application installers will be code reviewed "
-"by Mozilla before they are signed and are held to a higher quality standard."
-msgstr ""
-"Az alkalmazás telepítőhöz csatolt kiegészítők kódját aláírás előtt a Mozilla"
-" értékeli és magasabb követelményeknek kell megfelelniük."
+msgid "Add-ons that are bundled with application installers will be code reviewed by Mozilla before they are signed and are held to a higher quality standard."
+msgstr "Az alkalmazás telepítőhöz csatolt kiegészítők kódját aláírás előtt a Mozilla értékeli és magasabb követelményeknek kell megfelelniük."
 
-#: src/olympia/devhub/forms.py:565
-#: src/olympia/devhub/templates/devhub/addons/submit/select-review.html:24
-#: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:42
+#: src/olympia/devhub/forms.py:565 src/olympia/devhub/templates/devhub/addons/submit/select-review.html:24 src/olympia/devhub/templates/devhub/docs/policies-reviews.html:42
 msgid "Full Review"
 msgstr "Teljes értékelés"
 
-#: src/olympia/devhub/forms.py:566
-#: src/olympia/devhub/templates/devhub/addons/submit/select-review.html:47
-#: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:153
+#: src/olympia/devhub/forms.py:566 src/olympia/devhub/templates/devhub/addons/submit/select-review.html:47 src/olympia/devhub/templates/devhub/docs/policies-reviews.html:153
 msgid "Preliminary Review"
 msgstr "Előzetes értékelés"
 
@@ -4695,66 +3794,51 @@ msgid "Please choose a review nomination type"
 msgstr "Válasszon egy értékelésajánlási típust"
 
 #: src/olympia/devhub/forms.py:574
-msgid ""
-"A file with a version ending with a|alpha|b|beta|pre|rc and an optional "
-"number is detected as beta."
-msgstr ""
-"A(z) a|alpha|b|beta|pre|rc és egy elhagyható számmal végződő verziójú fájlok"
-" béta verzióként értelmeződnek."
+msgid "A file with a version ending with a|alpha|b|beta|pre|rc and an optional number is detected as beta."
+msgstr "A(z) a|alpha|b|beta|pre|rc és egy elhagyható számmal végződő verziójú fájlok béta verzióként értelmeződnek."
 
 #: src/olympia/devhub/forms.py:592
 #, python-format
-msgid "Version %s already exists"
-msgstr "Már létezik %s verzió"
-
-#: src/olympia/devhub/forms.py:604
-msgid ""
-"Select a valid choice. That choice is not one of the available choices."
+msgid "Version %s already exists, or was uploaded before."
 msgstr ""
-"Válasszon érvényes lehetőséget. Ez a választás nem az elérhetők egyike."
 
-#: src/olympia/devhub/forms.py:610
-msgid ""
-"A file with a version ending with a|alpha|b|beta and an optional number is "
-"detected as beta."
-msgstr ""
-"A(z) a|alpha|b|beta és egy elhagyható számmal végződő verziójú fájlok béta "
-"verzióként értelmeződnek."
+#: src/olympia/devhub/forms.py:605
+msgid "Select a valid choice. That choice is not one of the available choices."
+msgstr "Válasszon érvényes lehetőséget. Ez a választás nem az elérhetők egyike."
 
-#: src/olympia/devhub/forms.py:633
+#: src/olympia/devhub/forms.py:611
+msgid "A file with a version ending with a|alpha|b|beta and an optional number is detected as beta."
+msgstr "A(z) a|alpha|b|beta és egy elhagyható számmal végződő verziójú fájlok béta verzióként értelmeződnek."
+
+#: src/olympia/devhub/forms.py:634
 msgid "You cannot upload any more files for this version."
 msgstr "Ehhez a verzióhoz több fájl nem tölthető fel."
 
-#: src/olympia/devhub/forms.py:639
+#: src/olympia/devhub/forms.py:640
 msgid "Version doesn't match"
 msgstr "Nem egyeznek a verziók"
 
-#: src/olympia/devhub/forms.py:668
-msgid ""
-"You cannot delete a file once the review process has started.  You must "
-"delete the whole version."
-msgstr ""
-"Az értékelés elkezdését követően nem törölhet fájlt. Ehhez le kell törölnie "
-"a teljes verziót."
+#: src/olympia/devhub/forms.py:669
+msgid "You cannot delete a file once the review process has started. You must delete the whole version."
+msgstr "A vizsgálat elkezdését követően nem törölhet fájlt. Ehhez le kell törölnie a teljes verziót."
 
-#: src/olympia/devhub/forms.py:688
+#: src/olympia/devhub/forms.py:689
 msgid "The platform All cannot be combined with specific platforms."
 msgstr "Az Összes platform nem vonható össze más platformokkal."
 
-#: src/olympia/devhub/forms.py:693
+#: src/olympia/devhub/forms.py:694
 msgid "A platform can only be chosen once."
 msgstr "Egy platform csak egyszer választható ki."
 
-#: src/olympia/devhub/forms.py:706
+#: src/olympia/devhub/forms.py:707
 msgid "A review type must be selected."
 msgstr "Ki kell választani az értékelés típusát."
 
-#: src/olympia/devhub/forms.py:788 src/olympia/editors/forms.py:114
-#: src/olympia/zadmin/forms.py:49 src/olympia/zadmin/forms.py:52
+#: src/olympia/devhub/forms.py:789 src/olympia/editors/forms.py:114 src/olympia/editors/forms.py:254 src/olympia/zadmin/forms.py:49 src/olympia/zadmin/forms.py:52
 msgid "Select an application first"
 msgstr "Először válassza ki az alkalmazást"
 
-#: src/olympia/devhub/forms.py:840
+#: src/olympia/devhub/forms.py:841
 msgid "There cannot be more than 3 required add-ons."
 msgstr "Nem lehet 3-nál több szükséges kiegészítő."
 
@@ -4784,194 +3868,170 @@ msgid_plural "{0} warnings"
 msgstr[0] "{0} figyelmeztetés"
 msgstr[1] "{0} figyelmeztetés"
 
-#: src/olympia/devhub/models.py:375
-#: src/olympia/reviews/templates/reviews/add.html:58
+#: src/olympia/devhub/models.py:375 src/olympia/reviews/templates/reviews/add.html:58
 msgid "Review"
 msgstr "Értékelés"
 
-#: src/olympia/devhub/tasks.py:551
+#: src/olympia/devhub/tasks.py:583
 #, python-format
 msgid "%s responded with %s (%s)."
 msgstr "%s így válaszolt: %s (%s)."
 
-#: src/olympia/devhub/tasks.py:555
+#: src/olympia/devhub/tasks.py:587
 #, python-format
 msgid "Connection to \"%s\" timed out."
 msgstr "Időtúllépés miatt a kapcsolat megszakadt ezzel: „%s”."
 
-#: src/olympia/devhub/tasks.py:557
+#: src/olympia/devhub/tasks.py:589
 #, python-format
 msgid "Could not contact host at \"%s\"."
 msgstr "Nem lehet csatlakozni ehhez a kiszolgálóhoz: \"%s\"."
 
-#: src/olympia/devhub/utils.py:104
+#: src/olympia/devhub/utils.py:105
 #, python-format
-msgid ""
-"Validation generated too many errors/warnings so %s messages were truncated."
-" After addressing the visible messages, you'll be able to see the others."
-msgstr ""
-"Az ellenőrzés túl sok hibát/figyelmeztetést generált, így %s üzenet "
-"csonkítva lett. A látható üzenetek megoldása után láthatja a többit is."
+msgid "Validation generated too many errors/warnings so %s messages were truncated. After addressing the visible messages, you'll be able to see the others."
+msgstr "Az ellenőrzés túl sok hibát/figyelmeztetést generált, így %s üzenet csonkítva lett. A látható üzenetek megoldása után láthatja a többit is."
 
-#: src/olympia/devhub/views.py:183
+#: src/olympia/devhub/views.py:182
 msgid "All My Add-ons"
 msgstr "Összes saját kiterjesztés"
 
-#: src/olympia/devhub/views.py:210
+#: src/olympia/devhub/views.py:209
 msgid "All Activity"
 msgstr "Összes tevékenység"
 
-#: src/olympia/devhub/views.py:211
+#: src/olympia/devhub/views.py:210
 msgid "Add-on Updates"
 msgstr "Kiegészítő frissítései"
 
-#: src/olympia/devhub/views.py:212
+#: src/olympia/devhub/views.py:211
 msgid "Add-on Status"
 msgstr "Kiegészítő állapota"
 
-#: src/olympia/devhub/views.py:213
+#: src/olympia/devhub/views.py:212
 msgid "User Collections"
 msgstr "Felhasználó gyűjteményei"
 
-#: src/olympia/devhub/views.py:214
-#: src/olympia/devhub/templates/devhub/docs/policies-maintenance.html:68
-#: src/olympia/pages/templates/pages/dev_faq.html:38
+#: src/olympia/devhub/views.py:213 src/olympia/devhub/templates/devhub/docs/policies-maintenance.html:68 src/olympia/pages/templates/pages/dev_faq.html:38
 #: src/olympia/pages/templates/pages/dev_faq.html:484
 msgid "User Reviews"
 msgstr "Felhasználói értékelések"
 
-#: src/olympia/devhub/views.py:327 src/olympia/devhub/views.py:331
-#: src/olympia/devhub/views.py:484 src/olympia/devhub/views.py:513
-#: src/olympia/devhub/views.py:564 src/olympia/devhub/views.py:1150
+#: src/olympia/devhub/views.py:326 src/olympia/devhub/views.py:330 src/olympia/devhub/views.py:485 src/olympia/devhub/views.py:514 src/olympia/devhub/views.py:565 src/olympia/devhub/views.py:1157
 msgid "Changes successfully saved."
 msgstr "A változások sikeresen elmentve."
 
-#: src/olympia/devhub/views.py:334 src/olympia/devhub/views.py:1631
+#: src/olympia/devhub/views.py:333 src/olympia/devhub/views.py:1638
 msgid "Please check the form for errors."
 msgstr "Ellenőrizze az űrlap hibáit."
 
-#: src/olympia/devhub/views.py:346
+#: src/olympia/devhub/views.py:345
 msgid "Add-on cannot be deleted. Disable this add-on instead."
 msgstr "A kiegészítő nem törölhető. Inkább tiltsa le azt."
 
-#: src/olympia/devhub/views.py:356
+#: src/olympia/devhub/views.py:355
 msgid "Theme deleted."
 msgstr "A téma törölve."
 
-#: src/olympia/devhub/views.py:356
+#: src/olympia/devhub/views.py:355
 msgid "Add-on deleted."
 msgstr "A kiegészítő letörölve."
 
-#: src/olympia/devhub/views.py:362
+#: src/olympia/devhub/views.py:361
 msgid "URL name was incorrect. Theme was not deleted."
 msgstr "Az URL név helytelen volt. A téma nem törlődött."
 
-#: src/olympia/devhub/views.py:367
+#: src/olympia/devhub/views.py:366
 msgid "URL name was incorrect. Add-on was not deleted."
 msgstr "Az URL név helytelen volt. A kiegészítő nem törlődött."
 
-#: src/olympia/devhub/views.py:449
+#: src/olympia/devhub/views.py:450
 msgid "An author has been added to your add-on"
 msgstr "A kiegészítőhöz egy szerző hozzárendelésre került"
 
-#: src/olympia/devhub/views.py:456
+#: src/olympia/devhub/views.py:457
 msgid "An author has a role changed on your add-on"
 msgstr "A kiegészítő egyik szerzőjének szerepe megváltozott"
 
-#: src/olympia/devhub/views.py:476
+#: src/olympia/devhub/views.py:477
 msgid "An author has been removed from your add-on"
 msgstr "A kiegészítő egy szerzője eltávolításra került"
 
-#: src/olympia/devhub/views.py:519
+#: src/olympia/devhub/views.py:520
 msgid "There were errors in your submission."
 msgstr "Hibák voltak a benyújtáskor."
 
-#: src/olympia/devhub/views.py:583
+#: src/olympia/devhub/views.py:584
 msgid "Validate Add-on"
 msgstr "Kiegészítő ellenőrzése"
 
-#: src/olympia/devhub/views.py:594
+#: src/olympia/devhub/views.py:595
 msgid "Check Add-on Compatibility"
 msgstr "Kiegészítő kompatibilitásának ellenőrzése"
 
-#: src/olympia/devhub/views.py:808 src/olympia/signing/views.py:90
+#: src/olympia/devhub/views.py:809 src/olympia/signing/views.py:95
 msgid "You cannot submit this type of add-on"
 msgstr "Ilyen típusú kiegészítőt nem küldhet be"
 
-#: src/olympia/devhub/views.py:1051 src/olympia/users/forms.py:471
+#: src/olympia/devhub/views.py:1052 src/olympia/users/forms.py:471
 msgid "Images must be either PNG or JPG."
 msgstr "Az ikonnak PNG-nek vagy JPG-nek kell lennie."
 
-#: src/olympia/devhub/views.py:1055
+#: src/olympia/devhub/views.py:1056
 msgid "Icons cannot be animated."
 msgstr "Az ikon nem lehet animált."
 
-#: src/olympia/devhub/views.py:1057
+#: src/olympia/devhub/views.py:1058
 msgid "Images cannot be animated."
 msgstr "A kép nem lehet animált."
 
-#: src/olympia/devhub/views.py:1070
+#: src/olympia/devhub/views.py:1071
 #, python-format
 msgid "Images cannot be larger than %dKB."
 msgstr "A kép nem lehet nagyobb, mint %d KB."
 
 #. L10n: {0} is an image width (in pixels), {1} is a height.
-#: src/olympia/devhub/views.py:1080
+#: src/olympia/devhub/views.py:1081
 msgid "Image must be exactly {0} pixels wide and {1} pixels tall."
-msgstr ""
-"A képnek pontosan {0} képpont szélesnek és {1} képpont magasnak kell lennie."
+msgstr "A képnek pontosan {0} képpont szélesnek és {1} képpont magasnak kell lennie."
 
-#: src/olympia/devhub/views.py:1087
+#: src/olympia/devhub/views.py:1088
 msgid "There was an error uploading your preview."
 msgstr "Hiba történt az előnézet feltöltésekor."
 
-#: src/olympia/devhub/views.py:1189
+#: src/olympia/devhub/views.py:1196
 #, python-format
 msgid "Version %s disabled."
 msgstr "%s verzió letiltva."
 
-#: src/olympia/devhub/views.py:1193
+#: src/olympia/devhub/views.py:1200
 #, python-format
 msgid "Version %s deleted."
 msgstr "%s verzió törölve."
 
-#: src/olympia/devhub/views.py:1203
-msgid ""
-"This upload has failed validation, and may lack complete validation results."
-" Please take due care when reviewing it."
-msgstr ""
-"Ezen feltöltés ellenőrzése sikertelen lett, és hiányozhatnak az értékelés "
-"teljes eredményei. A vizsgálat során legyen különösen figyelmes."
+#: src/olympia/devhub/views.py:1210
+msgid "This upload has failed validation, and may lack complete validation results. Please take due care when reviewing it."
+msgstr "Ezen feltöltés ellenőrzése sikertelen lett, és hiányozhatnak az értékelés teljes eredményei. A vizsgálat során legyen különösen figyelmes."
 
-#: src/olympia/devhub/views.py:1677
+#: src/olympia/devhub/views.py:1684
 msgid "Preliminary Review Requested."
 msgstr "Előzetes értékelés igényelve."
 
-#: src/olympia/devhub/views.py:1678
+#: src/olympia/devhub/views.py:1685
 msgid "Full Review Requested."
 msgstr "Teljes értékelést kérve."
 
-#: src/olympia/devhub/views.py:1779
-msgid ""
-"Your old credentials were revoked and are no longer valid. Be sure to update"
-" all API clients with the new credentials."
-msgstr ""
-"Régi hitelesítő adatait visszavonták és már nem érvényesek. Győződjön meg "
-"minden API ügyfél új hitelesítő adatokkal való frissítéséről."
+#: src/olympia/devhub/views.py:1786
+msgid "Your old credentials were revoked and are no longer valid. Be sure to update all API clients with the new credentials."
+msgstr "Régi hitelesítő adatait visszavonták és már nem érvényesek. Győződjön meg minden API ügyfél új hitelesítő adatokkal való frissítéséről."
 
-#: src/olympia/devhub/views.py:1797
+#: src/olympia/devhub/views.py:1804
 msgid "New API key created"
 msgstr "Új API kulcs létrehozva"
 
 #: src/olympia/devhub/templates/devhub/agreement.html:2
-msgid ""
-"Before starting, please read and accept our Firefox Add-on Distribution "
-"Agreement. It also links to our Privacy Notice which explains how we handle "
-"your information."
-msgstr ""
-"Kezdés előtt kérjük olvassa el és fogadja el a Firefox kiegészítő "
-"terjesztési megállapodásunkat. Ez hivatkozza az adatvédelmi nyilatkozatunkat"
-" is, amely elmagyarázza, hogy adatait hogyan kezeljük."
+msgid "Before starting, please read and accept our Firefox Add-on Distribution Agreement. It also links to our Privacy Notice which explains how we handle your information."
+msgstr "Kezdés előtt kérjük olvassa el és fogadja el a Firefox kiegészítő terjesztési megállapodásunkat. Ez hivatkozza az adatvédelmi nyilatkozatunkat is, amely elmagyarázza, hogy adatait hogyan kezeljük."
 
 #: src/olympia/devhub/templates/devhub/agreement.html:13
 msgid "Printable Version"
@@ -4985,44 +4045,30 @@ msgstr "Elfogadom a megállapodást"
 msgid "or <a href=\"{0}\">Cancel</a>"
 msgstr "vagy <a href=\"{0}\">Mégsem</a>"
 
-#: src/olympia/devhub/templates/devhub/base.html:23
-#: src/olympia/devhub/templates/devhub/base_impala.html:20
-#: src/olympia/discovery/templates/discovery/addons/base.html:17
+#: src/olympia/devhub/templates/devhub/base.html:23 src/olympia/devhub/templates/devhub/base_impala.html:20 src/olympia/discovery/templates/discovery/addons/base.html:17
 msgid "Back to Add-ons"
 msgstr "Vissza a kiegészítőkhöz"
 
 #. {0} is a search term, such as Firebug.
 #. {0} is a search query.
-#: src/olympia/devhub/templates/devhub/devhub_search.html:4
-#: src/olympia/search/templates/search/results.html:9
-#: src/olympia/search/templates/search/mobile/results.html:6
+#: src/olympia/devhub/templates/devhub/devhub_search.html:4 src/olympia/search/templates/search/results.html:9 src/olympia/search/templates/search/mobile/results.html:6
 msgid "{0} :: Search"
 msgstr "{0} :: Keresés"
 
-#: src/olympia/devhub/templates/devhub/devhub_search.html:6
-#: src/olympia/devhub/templates/devhub/search.html:8
-#: src/olympia/editors/forms.py:435 src/olympia/editors/forms.py:437
-#: src/olympia/editors/templates/editors/queue.html:27
-#: src/olympia/editors/templates/editors/themes/queue_list.html:14
-#: src/olympia/search/templates/search/collections.html:17
-#: src/olympia/search/templates/search/personas.html:18
-#: src/olympia/search/templates/search/results.html:18
-#: src/olympia/search/templates/search/mobile/results.html:8
-#: src/olympia/templates/search.html:14
+#: src/olympia/devhub/templates/devhub/devhub_search.html:6 src/olympia/devhub/templates/devhub/search.html:8 src/olympia/editors/forms.py:534 src/olympia/editors/forms.py:536
+#: src/olympia/editors/templates/editors/queue.html:27 src/olympia/editors/templates/editors/themes/queue_list.html:14 src/olympia/search/templates/search/collections.html:17
+#: src/olympia/search/templates/search/personas.html:18 src/olympia/search/templates/search/results.html:18 src/olympia/search/templates/search/mobile/results.html:8 src/olympia/templates/search.html:14
 #: src/olympia/templates/impala/search.html:18
 msgid "Search"
 msgstr "Keresés"
 
-#: src/olympia/devhub/templates/devhub/devhub_search.html:11
-#: src/olympia/devhub/templates/devhub/devhub_search.html:15
-#: src/olympia/search/templates/search/collections.html:18
+#: src/olympia/devhub/templates/devhub/devhub_search.html:11 src/olympia/devhub/templates/devhub/devhub_search.html:15 src/olympia/search/templates/search/collections.html:18
 #: src/olympia/search/templates/search/personas.html:20
 msgid "Search Results"
 msgstr "Találatok"
 
 #. {0} is a search term, such as Firebug.
-#: src/olympia/devhub/templates/devhub/devhub_search.html:13
-#: src/olympia/search/templates/search/results.html:11
+#: src/olympia/devhub/templates/devhub/devhub_search.html:13 src/olympia/search/templates/search/results.html:11
 msgid "Search Results for \"{0}\""
 msgstr "Találatok a következőre: „{0}”"
 
@@ -5043,12 +4089,8 @@ msgid "AMO Reviewers"
 msgstr "AMO értékelők"
 
 #: src/olympia/devhub/templates/devhub/index.html:29
-msgid ""
-"Get ahead! Become an AMO Reviewer today and get your add-ons reviewed "
-"faster."
-msgstr ""
-"Lépjen előre! Legyen AMO értékelő ma, és vizsgáltassa be gyorsabban a "
-"kiegészítőit."
+msgid "Get ahead! Become an AMO Reviewer today and get your add-ons reviewed faster."
+msgstr "Lépjen előre! Legyen AMO értékelő ma, és vizsgáltassa be gyorsabban a kiegészítőit."
 
 #: src/olympia/devhub/templates/devhub/index.html:32
 msgid "Become an AMO Reviewer"
@@ -5060,42 +4102,28 @@ msgstr "Tanuljon meg mindent a kiegészítőkről"
 
 #: src/olympia/devhub/templates/devhub/index.html:41
 msgid ""
-"Add-ons let millions of Firefox users enhance and customize their browsing "
-"experience. If you're a Web developer and know <a "
-"href=\"https://developer.mozilla.org/docs/Web/HTML\">HTML</a>, <a "
-"href=\"https://developer.mozilla.org/docs/Web/JavaScript\">JavaScript</a>, "
-"and <a href=\"https://developer.mozilla.org/docs/Web/CSS\">CSS</a>, you "
-"already have all the necessary skills to make a great add-on."
+"Add-ons let millions of Firefox users enhance and customize their browsing experience. If you're a Web developer and know <a href=\"https://developer.mozilla.org/docs/Web/HTML\">HTML</a>, <a "
+"href=\"https://developer.mozilla.org/docs/Web/JavaScript\">JavaScript</a>, and <a href=\"https://developer.mozilla.org/docs/Web/CSS\">CSS</a>, you already have all the necessary skills to make a "
+"great add-on."
 msgstr ""
-"A kiegészítők Firefox felhasználók millióinak teszik jobbá és személyessé a "
-"böngészési élményt. Ha Ön webfejlesztő, és ismeri a <a "
-"href=\"https://developer.mozilla.org/docs/Web/HTML\">HTML</a>-t, <a "
-"href=\"https://developer.mozilla.org/docs/Web/JavaScript\">JavaScript</a>et,"
-" é s<a href=\"https://developer.mozilla.org/docs/Web/CSS\">CSS</a>-t, máris "
-"minden szükséges képessége megvan egy nagyszerű kiegészítő elkészítéséhez."
+"A kiegészítők Firefox felhasználók millióinak teszik jobbá és személyessé a böngészési élményt. Ha Ön webfejlesztő, és ismeri a <a href=\"https://developer.mozilla.org/docs/Web/HTML\">HTML</a>-t, "
+"<a href=\"https://developer.mozilla.org/docs/Web/JavaScript\">JavaScript</a>et, é s<a href=\"https://developer.mozilla.org/docs/Web/CSS\">CSS</a>-t, máris minden szükséges képessége megvan egy "
+"nagyszerű kiegészítő elkészítéséhez."
 
 #: src/olympia/devhub/templates/devhub/index.html:51
-msgid ""
-"Head over to the <a href=\"https://developer.mozilla.org/Add-ons\">Mozilla "
-"Developer Network</a> to learn everything you need to know to get started."
-msgstr ""
-"Nézzen el a <a href=\"https://developer.mozilla.org/Add-ons\">Mozilla "
-"Developer Network</a> oldalra, ahol mindent megtudhat, ami a kezdéshez "
-"szükséges."
+msgid "Head over to the <a href=\"https://developer.mozilla.org/Add-ons\">Mozilla Developer Network</a> to learn everything you need to know to get started."
+msgstr "Nézzen el a <a href=\"https://developer.mozilla.org/Add-ons\">Mozilla Developer Network</a> oldalra, ahol mindent megtudhat, ami a kezdéshez szükséges."
 
 #: src/olympia/devhub/templates/devhub/index.html:58
 msgid "Start Making Add-ons"
 msgstr "Kezdjen kiegészítőket készíteni"
 
-#: src/olympia/devhub/templates/devhub/index.html:86
-#: src/olympia/devhub/templates/devhub/addons/listing/items.html:25
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:15
+#: src/olympia/devhub/templates/devhub/index.html:86 src/olympia/devhub/templates/devhub/addons/listing/items.html:25 src/olympia/devhub/templates/devhub/includes/addon_details.html:20
 #: src/olympia/devhub/templates/devhub/personas/edit.html:43
 msgid "Status:"
 msgstr "Állapot:"
 
-#: src/olympia/devhub/templates/devhub/index.html:90
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:100
+#: src/olympia/devhub/templates/devhub/index.html:90 src/olympia/devhub/templates/devhub/includes/addon_details.html:87
 msgid "Visibility:"
 msgstr "Láthatóság:"
 
@@ -5103,21 +4131,16 @@ msgstr "Láthatóság:"
 msgid "Latest Version:"
 msgstr "Legújabb verzió:"
 
-#: src/olympia/devhub/templates/devhub/index.html:109
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:145
-#: src/olympia/devhub/templates/devhub/personas/edit.html:49
+#: src/olympia/devhub/templates/devhub/index.html:109 src/olympia/devhub/templates/devhub/includes/addon_details.html:131 src/olympia/devhub/templates/devhub/personas/edit.html:49
 msgid "Queue Position:"
 msgstr "Sorbeli pozíció:"
 
-#: src/olympia/devhub/templates/devhub/index.html:110
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:146
-#: src/olympia/devhub/templates/devhub/personas/edit.html:50
+#: src/olympia/devhub/templates/devhub/index.html:110 src/olympia/devhub/templates/devhub/includes/addon_details.html:132 src/olympia/devhub/templates/devhub/personas/edit.html:50
 #, python-format
 msgid "%(position)s of %(total)s"
 msgstr "%(position)s / %(total)s"
 
-#: src/olympia/devhub/templates/devhub/index.html:120
-#: src/olympia/devhub/templates/devhub/includes/addons_edit_nav.html:19
+#: src/olympia/devhub/templates/devhub/index.html:120 src/olympia/devhub/templates/devhub/includes/addons_edit_nav.html:19
 msgid "Upload New Version"
 msgstr "Új verzió feltöltése"
 
@@ -5131,12 +4154,8 @@ msgstr "Tegye közzé kiegészítőjét!"
 
 #: src/olympia/devhub/templates/devhub/index.html:136
 #, python-format
-msgid ""
-"Upload an <a href=\"%(addon_url)s\">add-on</a> or <a "
-"href=\"%(theme_url)s\">theme</a> to get started!"
-msgstr ""
-"Töltsön fel egy <a href=\"%(addon_url)s\">kiegészítőt</a> vagy<a "
-"href=\"%(theme_url)s\">témát</a> a kezdéshez!"
+msgid "Upload an <a href=\"%(addon_url)s\">add-on</a> or <a href=\"%(theme_url)s\">theme</a> to get started!"
+msgstr "Töltsön fel egy <a href=\"%(addon_url)s\">kiegészítőt</a> vagy<a href=\"%(theme_url)s\">témát</a> a kezdéshez!"
 
 #: src/olympia/devhub/templates/devhub/nav.html:2
 msgid "Return to the DevHub homepage"
@@ -5163,17 +4182,10 @@ msgstr "Bővítményfejlesztés"
 msgid "Lightweight Themes"
 msgstr "Könnyű témák"
 
-#: src/olympia/devhub/templates/devhub/nav.html:39
-#: src/olympia/devhub/templates/devhub/docs/policies-agreement.html:6
-#: src/olympia/devhub/templates/devhub/docs/policies-contact.html:6
-#: src/olympia/devhub/templates/devhub/docs/policies-maintenance.html:6
-#: src/olympia/devhub/templates/devhub/docs/policies-recommended.html:6
-#: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:6
-#: src/olympia/devhub/templates/devhub/docs/policies-submission.html:6
-#: src/olympia/devhub/templates/devhub/docs/policies.html:3
-#: src/olympia/devhub/templates/devhub/docs/policies.html:9
-#: src/olympia/devhub/templates/devhub/docs/policies.html:38
-#: src/olympia/devhub/templates/devhub/docs/policies.html:39
+#: src/olympia/devhub/templates/devhub/nav.html:39 src/olympia/devhub/templates/devhub/docs/policies-agreement.html:6 src/olympia/devhub/templates/devhub/docs/policies-contact.html:6
+#: src/olympia/devhub/templates/devhub/docs/policies-maintenance.html:6 src/olympia/devhub/templates/devhub/docs/policies-recommended.html:6
+#: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:6 src/olympia/devhub/templates/devhub/docs/policies-submission.html:6 src/olympia/devhub/templates/devhub/docs/policies.html:3
+#: src/olympia/devhub/templates/devhub/docs/policies.html:9 src/olympia/devhub/templates/devhub/docs/policies.html:38 src/olympia/devhub/templates/devhub/docs/policies.html:39
 msgid "Add-on Policies"
 msgstr "Kiegészítő-irányelvek"
 
@@ -5214,45 +4226,16 @@ msgid "Use the field below to upload your add-on package."
 msgstr "Használja az alábbi mezőt a kiegészítőcsomag feltöltéséhez."
 
 #: src/olympia/devhub/templates/devhub/validate_addon.html:19
-msgid ""
-"After upload, a series of automated validation tests will run to check "
-"compatibility with the following application version:"
-msgstr ""
-"A feltöltést követően számos automatikus ellenőrzés fut le a kompatibilitás "
-"vizsgálatához az alábbi alkalmazásverzióhoz:"
+msgid "After upload, a series of automated validation tests will run to check compatibility with the following application version:"
+msgstr "A feltöltést követően számos automatikus ellenőrzés fut le a kompatibilitás vizsgálatához az alábbi alkalmazásverzióhoz:"
 
 #: src/olympia/devhub/templates/devhub/validate_addon.html:34
-msgid ""
-"After upload, a series of automated validation tests will be run on your "
-"file."
-msgstr ""
-"A feltöltés után egy sor automatikus ellenőrzési mechanizmus indul el és "
-"vizsgálja meg a fájlt."
+msgid "After upload, a series of automated validation tests will be run on your file."
+msgstr "A feltöltés után egy sor automatikus ellenőrzési mechanizmus indul el és vizsgálja meg a fájlt."
 
-#: src/olympia/devhub/templates/devhub/validate_addon.html:42
-#: src/olympia/devhub/templates/devhub/addons/submit/upload.html:23
+#: src/olympia/devhub/templates/devhub/validate_addon.html:42 src/olympia/devhub/templates/devhub/addons/submit/upload.html:23
 msgid "Do you want your add-on to be distributed on this site?"
 msgstr "Szeretné a kiegészítőt ezen az oldalon terjeszteni?"
-
-#: src/olympia/devhub/templates/devhub/validate_addon.html:49
-#: src/olympia/devhub/templates/devhub/addons/submit/upload.html:30
-#: src/olympia/devhub/templates/devhub/versions/add_file_modal.html:14
-#: src/olympia/devhub/templates/devhub/versions/add_file_modal.html:53
-#: src/olympia/devhub/templates/devhub/versions/list.html:298
-msgid "Warning:"
-msgstr "Figyelmeztetés:"
-
-#: src/olympia/devhub/templates/devhub/validate_addon.html:50
-#: src/olympia/devhub/templates/devhub/addons/submit/upload.html:31
-#, python-format
-msgid ""
-"Submission of unlisted add-ons for signing is currently in an open beta. "
-"Please <a href=\"%(url)s\" target=\"_blank\">report any bugs</a> that you "
-"encounter."
-msgstr ""
-"A nem listázott kiegészítők aláírásra való benyújtása jelenleg nyílt béta "
-"állapotú. Kérjük, <a href=\"%(url)s\" target=\"_blank\"> jelentse, ha "
-"hibával találkozik</a>."
 
 #. first parameter is a filename like lorem-ipsum-1.0.2.xpi
 #: src/olympia/devhub/templates/devhub/validation.html:5
@@ -5271,14 +4254,11 @@ msgstr "Ellenőrzés dátuma:"
 msgid "Tested for compatibility against:"
 msgstr "Kompatibilitás vizsgálata:"
 
-#: src/olympia/devhub/templates/devhub/addons/activity.html:4
-#: src/olympia/devhub/templates/devhub/addons/activity.html:20
+#: src/olympia/devhub/templates/devhub/addons/activity.html:4 src/olympia/devhub/templates/devhub/addons/activity.html:20
 msgid "Recent Activity for My Add-ons"
 msgstr "Friss tevékenységek a saját kiegészítőimen"
 
-#: src/olympia/devhub/templates/devhub/addons/activity.html:14
-#: src/olympia/devhub/templates/devhub/addons/activity.html:19
-#: src/olympia/devhub/templates/devhub/addons/dashboard.html:33
+#: src/olympia/devhub/templates/devhub/addons/activity.html:14 src/olympia/devhub/templates/devhub/addons/activity.html:19 src/olympia/devhub/templates/devhub/addons/dashboard.html:33
 msgid "Recent Activity"
 msgstr "Friss tevékenység"
 
@@ -5300,45 +4280,34 @@ msgstr "Tevékenység pontosítása"
 msgid "Activity"
 msgstr "Tevékenység"
 
-#: src/olympia/devhub/templates/devhub/addons/activity.html:83
-#: src/olympia/devhub/templates/devhub/addons/dashboard.html:34
-#: src/olympia/devhub/templates/devhub/addons/dashboard.html:35
-#: src/olympia/devhub/templates/devhub/includes/blog_posts.html:4
-#: src/olympia/devhub/templates/devhub/includes/blog_posts.html:6
+#: src/olympia/devhub/templates/devhub/addons/activity.html:83 src/olympia/devhub/templates/devhub/addons/dashboard.html:34 src/olympia/devhub/templates/devhub/addons/dashboard.html:35
+#: src/olympia/devhub/templates/devhub/includes/blog_posts.html:4 src/olympia/devhub/templates/devhub/includes/blog_posts.html:6
 msgid "Subscribe to this feed"
 msgstr "Feliratkozás a hírforrásra"
 
 #: src/olympia/devhub/templates/devhub/addons/ajax_compat_error.html:7
 #, python-format
 msgid ""
-"This add-on is incompatible with <b>%(app_name)s %(app_version)s</b>, the "
-"latest release of %(app_name)s. Please consider updating your add-on's "
-"compatibility info, or uploading a newer version of this add-on."
+"This add-on is incompatible with <b>%(app_name)s %(app_version)s</b>, the latest release of %(app_name)s. Please consider updating your add-on's compatibility info, or uploading a newer version of "
+"this add-on."
 msgstr ""
-"Ez a kiegészítő nem kompatibilis a <b>%(app_name)s %(app_version)s</b> "
-"verziójával, ami a %(app_name)s legfrissebb verziója. Frissítse a kiegészítő"
-" kompatibilitása információját, vagy töltse fel a kiegészítő újabb "
-"verzióját."
+"Ez a kiegészítő nem kompatibilis a <b>%(app_name)s %(app_version)s</b> verziójával, ami a %(app_name)s legfrissebb verziója. Frissítse a kiegészítő kompatibilitása információját, vagy töltse fel a "
+"kiegészítő újabb verzióját."
 
 #: src/olympia/devhub/templates/devhub/addons/ajax_compat_error.html:15
 #, python-format
 msgid ""
-"<a href=\"#\" class=\"button compat-update\" data-"
-"updateurl=\"%(update_url)s\">Update Compatibility</a> <a "
-"href=\"%(version_url)s\" class=\"button\">Upload New Version</a> or <a "
-"href=\"#\" class=\"close\">Ignore</a>"
+"<a href=\"#\" class=\"button compat-update\" data-updateurl=\"%(update_url)s\">Update Compatibility</a> <a href=\"%(version_url)s\" class=\"button\">Upload New Version</a> or <a href=\"#\" "
+"class=\"close\">Ignore</a>"
 msgstr ""
-"<a href=\"#\" class=\"button compat-update\" data-"
-"updateurl=\"%(update_url)s\">Kompatibilitás frissítése</a> <a "
-"href=\"%(version_url)s\" class=\"button\">Új verzió feltöltése</a> or <a "
-"href=\"#\" class=\"close\">Kihagyás</a>"
+"<a href=\"#\" class=\"button compat-update\" data-updateurl=\"%(update_url)s\">Kompatibilitás frissítése</a> <a href=\"%(version_url)s\" class=\"button\">Új verzió feltöltése</a> or <a href=\"#\" "
+"class=\"close\">Kihagyás</a>"
 
 #: src/olympia/devhub/templates/devhub/addons/ajax_compat_status.html:5
 msgid "View and update application compatibility ranges."
 msgstr "Alkalmazás kompatibilitási tartományának áttekintése és frissítése."
 
-#: src/olympia/devhub/templates/devhub/addons/ajax_compat_status.html:6
-#: src/olympia/devhub/templates/devhub/versions/edit.html:44
+#: src/olympia/devhub/templates/devhub/addons/ajax_compat_status.html:6 src/olympia/devhub/templates/devhub/versions/edit.html:44
 msgid "Compatibility"
 msgstr "Kompatibilitás"
 
@@ -5346,39 +4315,27 @@ msgstr "Kompatibilitás"
 msgid "Update Compatibility"
 msgstr "Kompatibilitás frissítése"
 
-#: src/olympia/devhub/templates/devhub/addons/ajax_compat_update.html:4
-msgid ""
-"Adjusting application information here will allow users to install your add-"
-"on even if the install manifest in the package indicates that the add-on is "
-"incompatible."
+#: src/olympia/devhub/templates/devhub/addons/ajax_compat_update.html:4 src/olympia/devhub/templates/devhub/versions/edit.html:45
+msgid "Adjusting application information here will allow users to install your add-on even if the install manifest in the package indicates that the add-on is incompatible."
 msgstr ""
-"Az alkalmazás információjának beállításával a felhasználóknak lehetőségük "
-"van a kiegészítők telepítésére, abban az esetben is, ha a telepítéskor a "
-"kiegészítő azt jelzi, hogy nem kompatibilis az adott rendszerrel."
+"Az alkalmazás információjának beállításával a felhasználóknak lehetőségük van a kiegészítők telepítésére, abban az esetben is, ha a telepítéskor a kiegészítő azt jelzi, hogy nem kompatibilis az "
+"adott rendszerrel."
 
 #: src/olympia/devhub/templates/devhub/addons/ajax_compat_update.html:18
 msgid "Supported Versions"
 msgstr "Támogatott verziók"
 
-#: src/olympia/devhub/templates/devhub/addons/ajax_compat_update.html:31
-#: src/olympia/devhub/templates/devhub/versions/edit.html:63
+#: src/olympia/devhub/templates/devhub/addons/ajax_compat_update.html:31 src/olympia/devhub/templates/devhub/versions/edit.html:63
 msgid "Add Another Application&hellip;"
 msgstr "Másik alkalmazás hozzáadása&hellip;"
 
-#: src/olympia/devhub/templates/devhub/addons/ajax_compat_update.html:38
-#: src/olympia/devhub/templates/devhub/addons/owner.html:86
-#: src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:46
-#: src/olympia/devhub/templates/devhub/versions/list.html:351
-#: src/olympia/devhub/templates/devhub/versions/list.html:353
-#: src/olympia/templates/impala/base.html:132
-#: src/olympia/templates/impala/base.html:143
-#: src/olympia/templates/impala/base.html:161
-#: src/olympia/templates/impala/base.html:171
+#: src/olympia/devhub/templates/devhub/addons/ajax_compat_update.html:38 src/olympia/devhub/templates/devhub/addons/owner.html:86 src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:45
+#: src/olympia/devhub/templates/devhub/versions/list.html:349 src/olympia/devhub/templates/devhub/versions/list.html:351 src/olympia/templates/impala/base.html:129
+#: src/olympia/templates/impala/base.html:140 src/olympia/templates/impala/base.html:158 src/olympia/templates/impala/base.html:168
 msgid "Close"
 msgstr "Bezárás"
 
-#: src/olympia/devhub/templates/devhub/addons/dashboard.html:43
-#: src/olympia/zadmin/templates/zadmin/index.html:22
+#: src/olympia/devhub/templates/devhub/addons/dashboard.html:43 src/olympia/zadmin/templates/zadmin/index.html:22
 #, python-format
 msgid "%(ago)s by %(user)s"
 msgstr "%(ago)s, %(user)s szerkesztette"
@@ -5394,29 +4351,21 @@ msgid_plural "<b>{0}</b> themes"
 msgstr[0] "<b>{0}</b> téma"
 msgstr[1] "<b>{0}</b> téma"
 
-#: src/olympia/devhub/templates/devhub/addons/edit.html:3
-#: src/olympia/devhub/templates/devhub/addons/listing/item_actions.html:25
-#: src/olympia/devhub/templates/devhub/addons/listing/item_actions_theme.html:7
-#: src/olympia/devhub/templates/devhub/includes/addons_edit_nav.html:2
-#: src/olympia/devhub/templates/devhub/personas/edit.html:6
-#: src/olympia/editors/templates/editors/themes/single.html:37
+#: src/olympia/devhub/templates/devhub/addons/edit.html:3 src/olympia/devhub/templates/devhub/addons/listing/item_actions.html:25
+#: src/olympia/devhub/templates/devhub/addons/listing/item_actions_theme.html:7 src/olympia/devhub/templates/devhub/includes/addons_edit_nav.html:2
+#: src/olympia/devhub/templates/devhub/personas/edit.html:6 src/olympia/editors/templates/editors/themes/single.html:37
 msgid "Edit Listing"
 msgstr "Megjelenés szerkesztése"
 
-#: src/olympia/devhub/templates/devhub/addons/edit.html:13
-#: src/olympia/devhub/templates/devhub/includes/macros.html:18
-#: src/olympia/translations/templates/translations/all-locales.html:6
+#: src/olympia/devhub/templates/devhub/addons/edit.html:13 src/olympia/devhub/templates/devhub/includes/macros.html:18 src/olympia/translations/templates/translations/all-locales.html:6
 msgid "None"
 msgstr "Nincs"
 
-#: src/olympia/devhub/templates/devhub/addons/owner.html:4
-#: src/olympia/devhub/templates/devhub/addons/listing/item_actions.html:52
-#: src/olympia/devhub/templates/devhub/includes/addons_edit_nav.html:3
+#: src/olympia/devhub/templates/devhub/addons/owner.html:4 src/olympia/devhub/templates/devhub/addons/listing/item_actions.html:52 src/olympia/devhub/templates/devhub/includes/addons_edit_nav.html:3
 msgid "Manage Authors & License"
 msgstr "Szerzők és licencek kezelése"
 
-#: src/olympia/devhub/templates/devhub/addons/owner.html:29
-#: src/olympia/editors/templates/editors/review.html:270
+#: src/olympia/devhub/templates/devhub/addons/owner.html:29 src/olympia/editors/helpers.py:362 src/olympia/editors/templates/editors/review.html:270
 msgid "Authors"
 msgstr "Szerzők"
 
@@ -5426,37 +4375,22 @@ msgstr "Szerző feladatai"
 
 #: src/olympia/devhub/templates/devhub/addons/owner.html:78
 msgid ""
-"<p>Add-ons can have any number of authors with 3 possible roles:</p> <ul> "
-"<li><b>Owner:</b> Can manage all aspects of the add-on's listing, including "
-"adding and removing other authors</li> <li><b>Developer:</b> Can manage all "
-"aspects of the add-on's listing, except for adding and removing other "
-"authors and managing payments</li> <li><b>Viewer:</b> Can view the add-on's "
-"settings and statistics, but cannot make any changes</li> </ul>"
+"<p>Add-ons can have any number of authors with 3 possible roles:</p> <ul> <li><b>Owner:</b> Can manage all aspects of the add-on's listing, including adding and removing other authors</li> "
+"<li><b>Developer:</b> Can manage all aspects of the add-on's listing, except for adding and removing other authors and managing payments</li> <li><b>Viewer:</b> Can view the add-on's settings and "
+"statistics, but cannot make any changes</li> </ul>"
 msgstr ""
-"<p>A kiegészítőknek tetszőleges számú készítője lehet, akik 3 különböző "
-"csoportba sorolhatók:</p> <ul> <li><b>Tulajdonos:</b> kezelheti a kiegészítő"
-" megjelenésének tulajdonságait, beleértve a szerzők hozzáadását és "
-"eltávolítását.</li> <li><b>Fejlesztő:</b> kezelheti a kiegészítő minden "
-"tulajdonságát, kivéve a szerzők hozzáadását és eltávolítását és a "
-"kifizetések kezelését.</li> <li><b>Megtekintő:</b> megtekintheti a "
-"kiegészítő beállításait és statisztikáit, de nem módosíthat semmit.</li> "
-"</ul>"
+"<p>A kiegészítőknek tetszőleges számú készítője lehet, akik 3 különböző csoportba sorolhatók:</p> <ul> <li><b>Tulajdonos:</b> kezelheti a kiegészítő megjelenésének tulajdonságait, beleértve a "
+"szerzők hozzáadását és eltávolítását.</li> <li><b>Fejlesztő:</b> kezelheti a kiegészítő minden tulajdonságát, kivéve a szerzők hozzáadását és eltávolítását és a kifizetések kezelését.</li> "
+"<li><b>Megtekintő:</b> megtekintheti a kiegészítő beállításait és statisztikáit, de nem módosíthat semmit.</li> </ul>"
 
-#: src/olympia/devhub/templates/devhub/addons/profile.html:3
-#: src/olympia/devhub/templates/devhub/addons/listing/item_actions.html:53
-#: src/olympia/devhub/templates/devhub/includes/addons_edit_nav.html:4
+#: src/olympia/devhub/templates/devhub/addons/profile.html:3 src/olympia/devhub/templates/devhub/addons/listing/item_actions.html:53 src/olympia/devhub/templates/devhub/includes/addons_edit_nav.html:4
 msgid "Manage Developer Profile"
 msgstr "Fejlesztői profil kezelése"
 
 #: src/olympia/devhub/templates/devhub/addons/profile.html:16
 #, python-format
-msgid ""
-"Your <a href=\"%(url)s\">developer profile</a> is currently "
-"<strong>public</strong> and <strong>required</strong> for contributions."
-msgstr ""
-"A <a href=\"%(url)s\">fejlesztői profilja</a> jelenleg "
-"<strong>nyilvános</strong> és <strong>szükséges</strong> az "
-"adománygyűjtéshez."
+msgid "Your <a href=\"%(url)s\">developer profile</a> is currently <strong>public</strong> and <strong>required</strong> for contributions."
+msgstr "A <a href=\"%(url)s\">fejlesztői profilja</a> jelenleg <strong>nyilvános</strong> és <strong>szükséges</strong> az adománygyűjtéshez."
 
 #: src/olympia/devhub/templates/devhub/addons/profile.html:22
 msgid "Remove Both"
@@ -5464,12 +4398,8 @@ msgstr "Mindkettő eltávolítása"
 
 #: src/olympia/devhub/templates/devhub/addons/profile.html:27
 #, python-format
-msgid ""
-"Your <a href=\"%(url)s\">developer profile</a> is currently "
-"<strong>public</strong>."
-msgstr ""
-"A <a href=\"%(url)s\">fejlesztői profilja</a> jelenleg "
-"<strong>nyilvános</strong>."
+msgid "Your <a href=\"%(url)s\">developer profile</a> is currently <strong>public</strong>."
+msgstr "A <a href=\"%(url)s\">fejlesztői profilja</a> jelenleg <strong>nyilvános</strong>."
 
 #: src/olympia/devhub/templates/devhub/addons/profile.html:33
 msgid "Remove Profile"
@@ -5496,11 +4426,8 @@ msgstr "Kiegészítő URL-je"
 msgid "Choose a short, unique URL slug for your add-on."
 msgstr "Válasszon rövid, egyedi SEO URL-t a kiegészítőjéhez."
 
-#: src/olympia/devhub/templates/devhub/addons/edit/basic.html:43
-#: src/olympia/devhub/templates/devhub/includes/addons_edit_nav.html:35
-#: src/olympia/devhub/templates/devhub/personas/edit.html:56
-#: src/olympia/editors/templates/editors/review.html:255
-#: src/olympia/editors/templates/editors/themes/single.html:33
+#: src/olympia/devhub/templates/devhub/addons/edit/basic.html:43 src/olympia/devhub/templates/devhub/includes/addons_edit_nav.html:35 src/olympia/devhub/templates/devhub/personas/edit.html:56
+#: src/olympia/editors/templates/editors/review.html:255 src/olympia/editors/templates/editors/themes/single.html:33
 msgid "View Listing"
 msgstr "Megjelenés megtekintése"
 
@@ -5509,59 +4436,35 @@ msgid "Summary"
 msgstr "Összefoglalás"
 
 #: src/olympia/devhub/templates/devhub/addons/edit/basic.html:52
-msgid ""
-"A short explanation of your add-on's basic functionality that is displayed "
-"in search and browse listings, as well as at the top of your add-on's "
-"details page. It is only relevant for listed add-ons."
+msgid "A short explanation of your add-on's basic functionality that is displayed in search and browse listings, as well as at the top of your add-on's details page. It is only relevant for listed add-ons."
 msgstr ""
-"Egy rövid leírás a kiegészítője céljáról, felhasználhatóságáról, ami a "
-"keresési és böngészési találatokban jelenik meg, valamint a kiegészítőjét "
-"leíró oldal tetején. Mindez csak a listázott kiegészítőkre vonatkozik."
+"Egy rövid leírás a kiegészítője céljáról, felhasználhatóságáról, ami a keresési és böngészési találatokban jelenik meg, valamint a kiegészítőjét leíró oldal tetején. Mindez csak a listázott "
+"kiegészítőkre vonatkozik."
 
 #: src/olympia/devhub/templates/devhub/addons/edit/basic.html:73
-msgid ""
-"Categories are the primary way users browse through add-ons. Choose any that"
-" fit your add-on's functionality for the most exposure. It is only relevant "
-"for listed add-ons."
+msgid "Categories are the primary way users browse through add-ons. Choose any that fit your add-on's functionality for the most exposure. It is only relevant for listed add-ons."
 msgstr ""
-"A kategóriák a legfontosabb útja annak, amin keresztül a felhasználók a "
-"kiegészítők között böngésznek. Válassza ki azokat, amik illenek a "
-"kiegészítője funkcióihoz, hogy a lehető legtöbben találhassák meg. Mindez "
-"csak a listázott kiegészítőkre vonatkozik."
+"A kategóriák a legfontosabb útja annak, amin keresztül a felhasználók a kiegészítők között böngésznek. Válassza ki azokat, amik illenek a kiegészítője funkcióihoz, hogy a lehető legtöbben "
+"találhassák meg. Mindez csak a listázott kiegészítőkre vonatkozik."
 
 #: src/olympia/devhub/templates/devhub/addons/edit/basic.html:90
 #, python-format
-msgid ""
-"Categories cannot be changed while your add-on is featured for this "
-"application. Please email <a href=\"mailto:%(email)s\">%(email)s</a> if "
-"there is a reason you need to modify your categories."
-msgstr ""
-"A kategóriák nem módosíthatók amíg az alkalmazás kiemelt kiegészítője. "
-"Küldjön levelet ide: <a href=\"mailto:%(email)s\">%(email)s</a>, amennyiben "
-"valamilyen okból módosítani szeretné a kategóriát."
+msgid "Categories cannot be changed while your add-on is featured for this application. Please email <a href=\"mailto:%(email)s\">%(email)s</a> if there is a reason you need to modify your categories."
+msgstr "A kategóriák nem módosíthatók amíg az alkalmazás kiemelt kiegészítője. Küldjön levelet ide: <a href=\"mailto:%(email)s\">%(email)s</a>, amennyiben valamilyen okból módosítani szeretné a kategóriát."
 
 #: src/olympia/devhub/templates/devhub/addons/edit/basic.html:119
-msgid ""
-"Tags help users find your add-on and should be short descriptors such as "
-"tabs, toolbar, or twitter. You may have a maximum of {0} tags. It is only "
-"relevant for listed add-ons."
+msgid "Tags help users find your add-on and should be short descriptors such as tabs, toolbar, or twitter. You may have a maximum of {0} tags. It is only relevant for listed add-ons."
 msgstr ""
-"A címkék segítenek a felhasználóknak hogy megtalálják a kiegészítőjét és "
-"rövid leírásként is működnek mint pl. „lapok”, az „eszköztár” vagy a "
-"„twitter”. Legfeljebb {0} címkét használhat. Mindez csak a listázott "
-"kiegészítőkre vonatkozik."
+"A címkék segítenek a felhasználóknak hogy megtalálják a kiegészítőjét és rövid leírásként is működnek mint pl. „lapok”, az „eszköztár” vagy a „twitter”. Legfeljebb {0} címkét használhat. Mindez "
+"csak a listázott kiegészítőkre vonatkozik."
 
-#: src/olympia/devhub/templates/devhub/addons/edit/basic.html:129
-#: src/olympia/devhub/templates/devhub/personas/edit.html:97
-#: src/olympia/devhub/templates/devhub/personas/submit.html:46
+#: src/olympia/devhub/templates/devhub/addons/edit/basic.html:129 src/olympia/devhub/templates/devhub/personas/edit.html:97 src/olympia/devhub/templates/devhub/personas/submit.html:46
 msgid "Comma-separated, minimum of {0} character."
 msgid_plural "Comma-separated, minimum of {0} characters."
 msgstr[0] "Vesszővel elválasztott, minimum {0} karakterből álló."
 msgstr[1] "Vesszővel elválasztott, minimum {0} karakterből álló."
 
-#: src/olympia/devhub/templates/devhub/addons/edit/basic.html:132
-#: src/olympia/devhub/templates/devhub/personas/edit.html:100
-#: src/olympia/devhub/templates/devhub/personas/submit.html:49
+#: src/olympia/devhub/templates/devhub/addons/edit/basic.html:132 src/olympia/devhub/templates/devhub/personas/edit.html:100 src/olympia/devhub/templates/devhub/personas/submit.html:49
 msgid "Example: dark, cinema, noir. Limit 20."
 msgstr "Példa: dark, cinema, noir. Korlát: 20."
 
@@ -5580,48 +4483,29 @@ msgid "Add-on Details for {0}"
 msgstr "{0} kiegészítő részletei"
 
 #: src/olympia/devhub/templates/devhub/addons/edit/details.html:22
-msgid ""
-"A longer explanation of features, functionality, and other relevant "
-"information. This field is only displayed on the add-on's details page. It "
-"is only relevant for listed add-ons."
-msgstr ""
-"Egy részletesebb leírás a funkciókról, felhasználhatóságról és más fontos "
-"jellemzőkről. Ez a mező csak a kiegészítőt részletező oldalon jelenik meg. "
-"Mindez csak a listázott kiegészítőkre vonatkozik."
+msgid "A longer explanation of features, functionality, and other relevant information. This field is only displayed on the add-on's details page. It is only relevant for listed add-ons."
+msgstr "Egy részletesebb leírás a funkciókról, felhasználhatóságról és más fontos jellemzőkről. Ez a mező csak a kiegészítőt részletező oldalon jelenik meg. Mindez csak a listázott kiegészítőkre vonatkozik."
 
-#: src/olympia/devhub/templates/devhub/addons/edit/details.html:44
-#: src/olympia/translations/templates/translations/trans-menu.html:13
+#: src/olympia/devhub/templates/devhub/addons/edit/details.html:44 src/olympia/translations/templates/translations/trans-menu.html:13
 msgid "Default Locale"
 msgstr "Alapértelmezett nyelv"
 
 #: src/olympia/devhub/templates/devhub/addons/edit/details.html:45
-msgid ""
-"Information about your add-on is displayed in this locale unless you "
-"override it with a locale-specific translation. It is only relevant for "
-"listed add-ons."
-msgstr ""
-"A kiegészítőről szóló információk csak ezen a nyelvterületen jelennek meg "
-"addig, amíg el nem látja egy másik területhez illő fordítással. Mindez csak "
-"a listázott kiegészítőkre vonatkozik."
+msgid "Information about your add-on is displayed in this locale unless you override it with a locale-specific translation. It is only relevant for listed add-ons."
+msgstr "A kiegészítőről szóló információk csak ezen a nyelvterületen jelennek meg addig, amíg el nem látja egy másik területhez illő fordítással. Mindez csak a listázott kiegészítőkre vonatkozik."
 
-#: src/olympia/devhub/templates/devhub/addons/edit/details.html:61
-#: src/olympia/users/forms.py:311
-#: src/olympia/users/templates/users/edit.html:122
-#: src/olympia/users/templates/users/register.html:57
+#: src/olympia/devhub/templates/devhub/addons/edit/details.html:61 src/olympia/users/forms.py:311 src/olympia/users/templates/users/edit.html:122 src/olympia/users/templates/users/register.html:57
 #: src/olympia/users/templates/users/vcard.html:22
 msgid "Homepage"
 msgstr "Honlap"
 
 #: src/olympia/devhub/templates/devhub/addons/edit/details.html:63
 msgid ""
-"If your add-on has another homepage, enter its address here. If your website"
-" is localized into other languages multiple translations of this field can "
-"be added. It is only relevant for listed add-ons."
+"If your add-on has another homepage, enter its address here. If your website is localized into other languages multiple translations of this field can be added. It is only relevant for listed add-"
+"ons."
 msgstr ""
-"Ha a kiegészítőhöz másik honlap is tartozik, annak a címét itt adja meg. Ha "
-"a weboldala más nyelvekre történt fordításokat is tartalmaz, az egyes nyelvi"
-" verziókat itt adhatja hozzá. Mindez csak a listázott kiegészítőkre "
-"vonatkozik."
+"Ha a kiegészítőhöz másik honlap is tartozik, annak a címét itt adja meg. Ha a weboldala más nyelvekre történt fordításokat is tartalmaz, az egyes nyelvi verziókat itt adhatja hozzá. Mindez csak a "
+"listázott kiegészítőkre vonatkozik."
 
 #: src/olympia/devhub/templates/devhub/addons/edit/media.html:3
 msgid "Images"
@@ -5638,24 +4522,19 @@ msgstr "{0} kiegészítő támogatási információi"
 
 #: src/olympia/devhub/templates/devhub/addons/edit/support.html:22
 msgid ""
-"If you wish to display an e-mail address for support inquiries, enter it "
-"here. If you have different addresses for each language multiple "
-"translations of this field can be added. It is only relevant for listed add-"
-"ons."
+"If you wish to display an e-mail address for support inquiries, enter it here. If you have different addresses for each language multiple translations of this field can be added. It is only "
+"relevant for listed add-ons."
 msgstr ""
-"Ha szeretne megjeleníteni egy e-mail címet a támogatási kérdések fogadására,"
-" azt itt adja meg. Ha különböző címek tartoznak egyes nyelvekhez, ezen mező "
-"többszöri fordítása hozzáadható. Ez csak listázott kiegészítőkre érvényes."
+"Ha szeretne megjeleníteni egy e-mail címet a támogatási kérdések fogadására, azt itt adja meg. Ha különböző címek tartoznak egyes nyelvekhez, ezen mező többszöri fordítása hozzáadható. Ez csak "
+"listázott kiegészítőkre érvényes."
 
 #: src/olympia/devhub/templates/devhub/addons/edit/support.html:45
 msgid ""
-"If your add-on has a support website or forum, enter its address here. If "
-"your website is localized into other languages, multiple translations of "
-"this field can be added. It is only relevant for listed add-ons."
+"If your add-on has a support website or forum, enter its address here. If your website is localized into other languages, multiple translations of this field can be added. It is only relevant for "
+"listed add-ons."
 msgstr ""
-"Ha kiegészítőjének támogatói oldala vagy fóruma van, itt adja meg a címét. "
-"Ha honlapja több nyelven is elérhető, ezen mező többszöri fordítása is "
-"hozzáadható. Ez csak listázott kiegészítőkre érvényes."
+"Ha kiegészítőjének támogatói oldala vagy fóruma van, itt adja meg a címét. Ha honlapja több nyelven is elérhető, ezen mező többszöri fordítása is hozzáadható. Ez csak listázott kiegészítőkre "
+"érvényes."
 
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:6
 msgid "Technical Details"
@@ -5668,16 +4547,11 @@ msgstr "{0} technikai részletei"
 
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:23
 msgid ""
-"Any information end users may want to know that isn't necessarily applicable"
-" to the add-on summary or description. Common uses include listing known "
-"major bugs, information on how to report bugs, anticipated release date of a"
-" new version, etc. It is only relevant for listed add-ons."
+"Any information end users may want to know that isn't necessarily applicable to the add-on summary or description. Common uses include listing known major bugs, information on how to report bugs, "
+"anticipated release date of a new version, etc. It is only relevant for listed add-ons."
 msgstr ""
-"Bármely információ, amit a végfelhasználók tudni akarhatnak, és nem "
-"feltétlenül vonatkozik a kiegészítő összefoglalójához vagy leírásához. "
-"Általában itt a nagyobb hibákat, hibabejelentés lehetőségét, új verziók "
-"lehetséges megjelenési dátumát stb. szokták listázni. Csak listázott "
-"kiegészítőkre vonatkozik."
+"Bármely információ, amit a végfelhasználók tudni akarhatnak, és nem feltétlenül vonatkozik a kiegészítő összefoglalójához vagy leírásához. Általában itt a nagyobb hibákat, hibabejelentés "
+"lehetőségét, új verziók lehetséges megjelenési dátumát stb. szokták listázni. Csak listázott kiegészítőkre vonatkozik."
 
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:46
 msgid "Limit 3"
@@ -5688,12 +4562,8 @@ msgid "Add-on Flags"
 msgstr "Kiegészítő jelzői"
 
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:69
-msgid ""
-"These flags are used to classify add-ons. It is only relevant for listed "
-"add-ons."
-msgstr ""
-"Ezek a jelzők a kiegészítők besorolásához használatosak. Ez csak listázott "
-"kiegészítőkre vonatkozik."
+msgid "These flags are used to classify add-ons. It is only relevant for listed add-ons."
+msgstr "Ezek a jelzők a kiegészítők besorolásához használatosak. Ez csak listázott kiegészítőkre vonatkozik."
 
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:74
 msgid "This is a site-specific add-on."
@@ -5708,12 +4578,8 @@ msgid "View Source?"
 msgstr "Megtekinti a forrást?"
 
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:90
-msgid ""
-"Whether the source of your add-on can be displayed in our online viewer. It "
-"is only relevant for listed add-ons."
-msgstr ""
-"Kiegészítőjének forrása megjeleníthető-e online. Csak listázott "
-"kiegészítőkre vonatkozik."
+msgid "Whether the source of your add-on can be displayed in our online viewer. It is only relevant for listed add-ons."
+msgstr "Kiegészítőjének forrása megjeleníthető-e online. Csak listázott kiegészítőkre vonatkozik."
 
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:94
 msgid "This add-on's source code is publicly viewable."
@@ -5728,12 +4594,8 @@ msgid "Public Stats?"
 msgstr "Nyilvános statisztika?"
 
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:102
-msgid ""
-"Whether the download and usage stats of your add-on can be displayed in our "
-"online viewer. It is only relevant for listed add-ons."
-msgstr ""
-"Kiegészítőjére vonatkozó letöltési és használati statisztika "
-"megjeleníthető-e. Csak listázott kiegészítőkre érvényes."
+msgid "Whether the download and usage stats of your add-on can be displayed in our online viewer. It is only relevant for listed add-ons."
+msgstr "Kiegészítőjére vonatkozó letöltési és használati statisztika megjeleníthető-e. Csak listázott kiegészítőkre érvényes."
 
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:107
 msgid "This add-on's stats are publicly viewable."
@@ -5748,20 +4610,12 @@ msgid "Upgrade SDK?"
 msgstr "Frissíti az SDK-t?"
 
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:116
-msgid ""
-"If selected, we will try to automatically upgrade your add-on when a new "
-"version of the SDK is released. It is only relevant for listed add-ons."
-msgstr ""
-"Ha kiválasztja, megpróbáljuk kiegészítőjét automatikusan frissíteni új SDK "
-"verzió kiadásakor. Csak listázott kiegészítőkre érvényes."
+msgid "If selected, we will try to automatically upgrade your add-on when a new version of the SDK is released. It is only relevant for listed add-ons."
+msgstr "Ha kiválasztja, megpróbáljuk kiegészítőjét automatikusan frissíteni új SDK verzió kiadásakor. Csak listázott kiegészítőkre érvényes."
 
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:121
-msgid ""
-"This add-on will be automatically upgraded to new versions of the Add-on "
-"SDK."
-msgstr ""
-"Ez a kiegészítő automatikusan frissítésre kerül a Kiegészítő SDK új "
-"verziójára."
+msgid "This add-on will be automatically upgraded to new versions of the Add-on SDK."
+msgstr "Ez a kiegészítő automatikusan frissítésre kerül a Kiegészítő SDK új verziójára."
 
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:123
 msgid "No, this add-on will be upgraded manually."
@@ -5776,29 +4630,20 @@ msgid "UUID"
 msgstr "UUID"
 
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:132
-msgid ""
-"The UUID of your add-on is specified in its install manifest and uniquely "
-"identifies it. You cannot change your UUID once it has been submitted."
-msgstr ""
-"A kiegészítő UUID azonosítója a telepítő fájljában van megadva és egyedi "
-"módon azonosítja azt. Az UUID, beküldést követően nem módosítható."
+msgid "The UUID of your add-on is specified in its install manifest and uniquely identifies it. You cannot change your UUID once it has been submitted."
+msgstr "A kiegészítő UUID azonosítója a telepítő fájljában van megadva és egyedi módon azonosítja azt. Az UUID, beküldést követően nem módosítható."
 
-#: src/olympia/devhub/templates/devhub/addons/edit/technical.html:143
-#: src/olympia/devhub/templates/devhub/addons/edit/technical.html:144
+#: src/olympia/devhub/templates/devhub/addons/edit/technical.html:143 src/olympia/devhub/templates/devhub/addons/edit/technical.html:144
 msgid "Whiteboard"
 msgstr "Faliújság"
 
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:146
 msgid ""
-"The whiteboard is the place to provide information relevant to your addon, "
-"whatever the version, to the editor. Use it to provide ways to test the "
-"addon, and any additional information that may help. This whiteboard is also"
-" editable by editors."
+"The whiteboard is the place to provide information relevant to your addon, whatever the version, to the editor. Use it to provide ways to test the addon, and any additional information that may "
+"help. This whiteboard is also editable by editors."
 msgstr ""
-"A faliújság a szerkesztőnek szánt, kiegészítőre vonatkozó információk helye,"
-" verziótól függetlenül. Használja a kiegészítő tesztelhetőségnek leírására "
-"vagy hasznos kiegészítő információk megadására. Ezt a faliújságot a "
-"szerkesztők is alakíthatják."
+"A faliújság a szerkesztőnek szánt, kiegészítőre vonatkozó információk helye, verziótól függetlenül. Használja a kiegészítő tesztelhetőségnek leírására vagy hasznos kiegészítő információk "
+"megadására. Ezt a faliújságot a szerkesztők is alakíthatják."
 
 #: src/olympia/devhub/templates/devhub/addons/edit/technical_dependencies.html:9
 msgid "Remove this dependent add-on"
@@ -5818,15 +4663,11 @@ msgstr "Kiegészítő ikonja"
 
 #: src/olympia/devhub/templates/devhub/addons/forms_shared/media.html:16
 msgid ""
-"Upload an icon for your add-on or choose from one of ours. The icon is "
-"displayed nearly everywhere your add-on is. Uploaded images must be one of "
-"the following image types: .png, .jpg. It is only relevant for listed add-"
-"ons."
+"Upload an icon for your add-on or choose from one of ours. The icon is displayed nearly everywhere your add-on is. Uploaded images must be one of the following image types: .png, .jpg. It is only "
+"relevant for listed add-ons."
 msgstr ""
-"Töltsön fel egy ikont kiegészítőjéhez vagy használjon egyet a mieink közül. "
-"Ez az ikon szinte mindenhol megjelenik a kiegészítő mellett. A feltöltött "
-"kép a következő kiterjesztésű lehet: .png, .jpg. Csak listázott "
-"kiegészítőkre érvényes."
+"Töltsön fel egy ikont kiegészítőjéhez vagy használjon egyet a mieink közül. Ez az ikon szinte mindenhol megjelenik a kiegészítő mellett. A feltöltött kép a következő kiterjesztésű lehet: .png, "
+".jpg. Csak listázott kiegészítőkre érvényes."
 
 #: src/olympia/devhub/templates/devhub/addons/forms_shared/media.html:25
 msgid "Select an icon for your add-on:"
@@ -5839,9 +4680,7 @@ msgstr "32x32px"
 
 #: src/olympia/devhub/templates/devhub/addons/forms_shared/media.html:39
 msgid "Used in listings of add-ons, like search results and featured add-ons."
-msgstr ""
-"Használat a kiegészítő megjelenésekor, mint a találatokban és a kiemelt "
-"kiegészítőknél."
+msgstr "Használat a kiegészítő megjelenésekor, mint a találatokban és a kiemelt kiegészítőknél."
 
 #. The size of the icon
 #: src/olympia/devhub/templates/devhub/addons/forms_shared/media.html:48
@@ -5858,9 +4697,7 @@ msgstr "Egyéni ikon feltöltése…"
 
 #: src/olympia/devhub/templates/devhub/addons/forms_shared/media.html:65
 msgid "PNG and JPG supported. Icons resized to 64x64 pixels if larger."
-msgstr ""
-"PNG és JPG képek támogatottak. Amennyiben az ikon nagyobb, abban esetben "
-"64x64 képpontra lesz átméretezve."
+msgstr "PNG és JPG képek támogatottak. Amennyiben az ikon nagyobb, abban esetben 64x64 képpontra lesz átméretezve."
 
 #: src/olympia/devhub/templates/devhub/addons/forms_shared/media.html:83
 msgid "Screenshots"
@@ -5882,62 +4719,49 @@ msgstr "Képernyőkép hozzáadása…"
 msgid "Tests"
 msgstr "Tesztek"
 
-#: src/olympia/devhub/templates/devhub/addons/includes/validation_compat_test_results.html:25
-#: src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:5
+#: src/olympia/devhub/templates/devhub/addons/includes/validation_compat_test_results.html:25 src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:5
 #: src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:53
 msgid "General Tests"
 msgstr "Általános tesztek"
 
-#: src/olympia/devhub/templates/devhub/addons/includes/validation_compat_test_results.html:32
-#: src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:9
+#: src/olympia/devhub/templates/devhub/addons/includes/validation_compat_test_results.html:32 src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:9
 #: src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:67
 msgid "Security Tests"
 msgstr "Biztonsági tesztek"
 
-#: src/olympia/devhub/templates/devhub/addons/includes/validation_compat_test_results.html:39
-#: src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:13
+#: src/olympia/devhub/templates/devhub/addons/includes/validation_compat_test_results.html:39 src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:13
 #: src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:80
 msgid "Extension Tests"
 msgstr "Bővítményteszt"
 
-#: src/olympia/devhub/templates/devhub/addons/includes/validation_compat_test_results.html:46
-#: src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:17
+#: src/olympia/devhub/templates/devhub/addons/includes/validation_compat_test_results.html:46 src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:17
 #: src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:93
 msgid "Localization Tests"
 msgstr "Lokalizációs tesztek"
 
-#: src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:21
-#: src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:106
+#: src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:21 src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:106
 msgid "Compatibility Tests"
 msgstr "Kompatibilitási tesztek"
 
-#: src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:29
-#: src/olympia/files/templates/files/viewer.html:142
+#: src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:29 src/olympia/files/templates/files/viewer.html:142
 msgid "Hide messages not required for automated signing"
 msgstr "Az automatikus aláíráshoz nem szükséges üzenetek elrejtése"
 
-#: src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:35
-#: src/olympia/files/templates/files/viewer.html:150
+#: src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:35 src/olympia/files/templates/files/viewer.html:150
 msgid "Hide messages present in previous version and ignored"
-msgstr ""
-"A korábbi verzióban megtalálható és figyelmen kívül hagyott üzenetek "
-"elrejtése"
+msgstr "A korábbi verzióban megtalálható és figyelmen kívül hagyott üzenetek elrejtése"
 
-#: src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:50
-#: src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:64
-#: src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:77
-#: src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:90
+#: src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:50 src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:64
+#: src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:77 src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:90
 #: src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:103
 msgid "Top"
 msgstr "Fel"
 
-#: src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:2
-#: src/olympia/devhub/templates/devhub/personas/edit.html:63
+#: src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:2 src/olympia/devhub/templates/devhub/personas/edit.html:63
 msgid "Delete Theme"
 msgstr "Téma törlése"
 
-#: src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:2
-#: src/olympia/devhub/templates/devhub/versions/list.html:117
+#: src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:2 src/olympia/devhub/templates/devhub/versions/list.html:117
 msgid "Delete Add-on"
 msgstr "Kiegészítő törlése"
 
@@ -5946,31 +4770,24 @@ msgid "Deleting your theme will permanently remove it from the site."
 msgstr "A téma törlése véglegesen eltávolítja azt az oldalról."
 
 #: src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:14
-msgid ""
-"Deleting your add-on will permanently remove it from the site and prevent "
-"its GUID from being submitted again by others."
-msgstr ""
-"Kiegészítőjének törlésével véglegesen eltávolítja azt az oldalról, és "
-"megakadályozza, hogy GUID-ját mások ismét benyújtsák."
+msgid "Deleting your add-on will permanently remove it from the site and prevent its GUID from being submitted again by others."
+msgstr "Kiegészítőjének törlésével véglegesen eltávolítja azt az oldalról, és megakadályozza, hogy GUID-ját mások ismét benyújtsák."
 
 #: src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:24
-msgid ""
-"Enter the following text confirm your decision:\n"
-"           {slug}"
+msgid "Enter the following text confirm your decision: {slug}"
 msgstr ""
 "Írja be a következő szöveget, hogy megerősítse a döntését:\n"
 "           {slug}"
 
-#: src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:34
+#: src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:33
 msgid "Please tell us why you are deleting your theme:"
 msgstr "Mondja el, miért törli a témáját:"
 
-#: src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:36
+#: src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:35
 msgid "Please tell us why you are deleting your add-on:"
 msgstr "Mondja el, miért törli a kiegészítőjét:"
 
-#: src/olympia/devhub/templates/devhub/addons/listing/item_actions.html:1
-#: src/olympia/devhub/templates/devhub/addons/listing/item_actions_theme.html:1
+#: src/olympia/devhub/templates/devhub/addons/listing/item_actions.html:1 src/olympia/devhub/templates/devhub/addons/listing/item_actions_theme.html:1
 #: src/olympia/editors/templates/editors/review.html:253
 msgid "Actions"
 msgstr "Műveletek"
@@ -6003,22 +4820,17 @@ msgstr "Új verzió"
 msgid "Daily statistics on downloads and users."
 msgstr "Napi statisztikák a letöltésekről és felhasználókról."
 
-#: src/olympia/devhub/templates/devhub/addons/listing/item_actions.html:45
-#: src/olympia/stats/templates/stats/stats.html:75
-#: src/olympia/stats/templates/stats/stats.html:79
-#: src/olympia/stats/templates/stats/stats.html:81
+#: src/olympia/devhub/templates/devhub/addons/listing/item_actions.html:45 src/olympia/stats/templates/stats/stats.html:31 src/olympia/stats/templates/stats/stats.html:35
+#: src/olympia/stats/templates/stats/stats.html:37
 msgid "Statistics"
 msgstr "Statisztika"
 
-#: src/olympia/devhub/templates/devhub/addons/listing/item_actions.html:54
-#: src/olympia/devhub/templates/devhub/includes/addons_edit_nav.html:5
-#: src/olympia/devhub/templates/devhub/payments/payments.html:3
+#: src/olympia/devhub/templates/devhub/addons/listing/item_actions.html:54 src/olympia/devhub/templates/devhub/includes/addons_edit_nav.html:5 src/olympia/devhub/templates/devhub/payments/payments.html:3
 #: src/olympia/devhub/templates/devhub/payments/tier.html:4
 msgid "Manage Payments"
 msgstr "Kifizetések kezelése"
 
-#: src/olympia/devhub/templates/devhub/addons/listing/item_actions.html:55
-#: src/olympia/devhub/templates/devhub/includes/addons_edit_nav.html:6
+#: src/olympia/devhub/templates/devhub/addons/listing/item_actions.html:55 src/olympia/devhub/templates/devhub/includes/addons_edit_nav.html:6
 msgid "Manage Status & Versions"
 msgstr "Státusz és verziók kezelése"
 
@@ -6026,10 +4838,8 @@ msgstr "Státusz és verziók kezelése"
 msgid "View Add-on Listing"
 msgstr "Kiegészítő megjelenésének megtekintése"
 
-#: src/olympia/devhub/templates/devhub/addons/listing/item_actions.html:64
-#: src/olympia/devhub/templates/devhub/addons/listing/item_actions_theme.html:12
-#: src/olympia/devhub/templates/devhub/includes/addons_edit_nav.html:37
-#: src/olympia/devhub/templates/devhub/personas/edit.html:58
+#: src/olympia/devhub/templates/devhub/addons/listing/item_actions.html:64 src/olympia/devhub/templates/devhub/addons/listing/item_actions_theme.html:12
+#: src/olympia/devhub/templates/devhub/includes/addons_edit_nav.html:37 src/olympia/devhub/templates/devhub/personas/edit.html:58
 msgid "View Recent Changes"
 msgstr "Legutóbbi változtatások megtekintése"
 
@@ -6054,12 +4864,8 @@ msgid "Delete this theme."
 msgstr "Téma törlése."
 
 #: src/olympia/devhub/templates/devhub/addons/listing/items.html:10
-msgid ""
-"This add-on will be deleted automatically after a few days if the submission"
-" process is not completed."
-msgstr ""
-"Ez a kiegészítő automatikusan törlésre kerül pár nap után, ha a beküldési "
-"folyamat nem fejeződik be."
+msgid "This add-on will be deleted automatically after a few days if the submission process is not completed."
+msgstr "Ez a kiegészítő automatikusan törlésre kerül pár nap után, ha a beküldési folyamat nem fejeződik be."
 
 #: src/olympia/devhub/templates/devhub/addons/listing/items.html:27
 msgid "Disabled"
@@ -6097,12 +4903,9 @@ msgstr "Név és verzió:"
 msgid "The detail page will be:"
 msgstr "A részletek oldal:"
 
-#: src/olympia/devhub/templates/devhub/addons/submit/describe.html:24
-#: src/olympia/devhub/templates/devhub/personas/edit.html:89
-#: src/olympia/devhub/templates/devhub/personas/submit.html:38
+#: src/olympia/devhub/templates/devhub/addons/submit/describe.html:24 src/olympia/devhub/templates/devhub/personas/edit.html:89 src/olympia/devhub/templates/devhub/personas/submit.html:38
 msgid "Please use only letters, numbers, underscores, and dashes in your URL."
-msgstr ""
-"Csak betűket, számokat, aláhúzásokat és kötőjeleket használjon az URL-ben."
+msgstr "Csak betűket, számokat, aláhúzásokat és kötőjeleket használjon az URL-ben."
 
 #: src/olympia/devhub/templates/devhub/addons/submit/describe.html:34
 msgid "Provide a brief summary:"
@@ -6120,14 +4923,11 @@ msgstr "Adjon meg részletesebb leírást:"
 msgid "The description will appear on the detail page."
 msgstr "A leírás a részletek oldalon jelenik meg."
 
-#: src/olympia/devhub/templates/devhub/addons/submit/done.html:4
-#: src/olympia/devhub/templates/devhub/personas/submit_done.html:4
+#: src/olympia/devhub/templates/devhub/addons/submit/done.html:4 src/olympia/devhub/templates/devhub/personas/submit_done.html:4
 msgid "Submission Complete"
 msgstr "A benyújtási folyamat kész"
 
-#: src/olympia/devhub/templates/devhub/addons/submit/done.html:8
-#: src/olympia/devhub/templates/devhub/addons/submit/sidebar.html:13
-#: src/olympia/devhub/templates/devhub/personas/submit_done.html:8
+#: src/olympia/devhub/templates/devhub/addons/submit/done.html:8 src/olympia/devhub/templates/devhub/addons/submit/sidebar.html:13 src/olympia/devhub/templates/devhub/personas/submit_done.html:8
 msgid "You're done!"
 msgstr "Kész is van!"
 
@@ -6140,56 +4940,32 @@ msgid "Your add-on has been submitted to the Full Review queue."
 msgstr "A kiegészítő beküldésre került és teljes értékelésre vár."
 
 #: src/olympia/devhub/templates/devhub/addons/submit/done.html:18
-msgid ""
-"You'll receive an email once it has been reviewed by an editor. In the "
-"meantime, you and your friends can install it directly from its details "
-"page:"
-msgstr ""
-"Miután egy szerkesztő értékelte, kapni fog egy e-mailt. Addig is, Ön és "
-"barátai közvetlenül a részletező oldaláról telepíthetik:"
+msgid "You'll receive an email once it has been reviewed by an editor. In the meantime, you and your friends can install it directly from its details page:"
+msgstr "Miután egy szerkesztő értékelte, kapni fog egy e-mailt. Addig is, Ön és barátai közvetlenül a részletező oldaláról telepíthetik:"
 
-#: src/olympia/devhub/templates/devhub/addons/submit/done.html:27
-#: src/olympia/devhub/templates/devhub/addons/submit/done.html:77
-#: src/olympia/devhub/templates/devhub/personas/submit_done.html:16
+#: src/olympia/devhub/templates/devhub/addons/submit/done.html:27 src/olympia/devhub/templates/devhub/addons/submit/done.html:77 src/olympia/devhub/templates/devhub/personas/submit_done.html:16
 msgid "Next steps:"
 msgstr "Következő lépések:"
 
-#: src/olympia/devhub/templates/devhub/addons/submit/done.html:32
-#: src/olympia/devhub/templates/devhub/addons/submit/done.html:82
+#: src/olympia/devhub/templates/devhub/addons/submit/done.html:32 src/olympia/devhub/templates/devhub/addons/submit/done.html:82
 msgid "<a href=\"{0}\">Upload</a> another platform-specific file to this version."
-msgstr ""
-"Ennek a verziónak egy másik, platformspecifikus fájljának <a "
-"href=\"{0}\">feltöltése</a>."
+msgstr "Ennek a verziónak egy másik, platformspecifikus fájljának <a href=\"{0}\">feltöltése</a>."
 
 #: src/olympia/devhub/templates/devhub/addons/submit/done.html:34
 msgid "Provide more details by <a href=\"{0}\">editing its listing</a>."
-msgstr ""
-"Adjon meg további részleteket a <a href=\"{0}\">megjelenésének "
-"szerkesztésével</a>."
+msgstr "Adjon meg további részleteket a <a href=\"{0}\">megjelenésének szerkesztésével</a>."
 
 #: src/olympia/devhub/templates/devhub/addons/submit/done.html:35
-msgid ""
-"Tell your users why you created this in your <a href=\"{0}\">Developer "
-"Profile</a>."
-msgstr ""
-"A <a href=\"{0}\">fejlesztői profiljában</a> mondja el felhasználóinak, hogy"
-" miért készítette el ezt."
+msgid "Tell your users why you created this in your <a href=\"{0}\">Developer Profile</a>."
+msgstr "A <a href=\"{0}\">fejlesztői profiljában</a> mondja el felhasználóinak, hogy miért készítette el ezt."
 
 #: src/olympia/devhub/templates/devhub/addons/submit/done.html:36
-msgid ""
-"View and subscribe to your add-on's <a href=\"{0}\">activity feed</a> to "
-"stay updated on reviews, collections, and more."
-msgstr ""
-"Nézze meg és iratkozzon fel a kiegészítővel kapcsolatos tevékenységek <a "
-"href=\"{0}\">hírfolyamára</a>, így értesítést kaphat az értékelésekről, "
-"gyűjteményekről és még sok másról."
+msgid "View and subscribe to your add-on's <a href=\"{0}\">activity feed</a> to stay updated on reviews, collections, and more."
+msgstr "Nézze meg és iratkozzon fel a kiegészítővel kapcsolatos tevékenységek <a href=\"{0}\">hírfolyamára</a>, így értesítést kaphat az értékelésekről, gyűjteményekről és még sok másról."
 
-#: src/olympia/devhub/templates/devhub/addons/submit/done.html:37
-#: src/olympia/devhub/templates/devhub/addons/submit/done.html:86
+#: src/olympia/devhub/templates/devhub/addons/submit/done.html:37 src/olympia/devhub/templates/devhub/addons/submit/done.html:86
 msgid "View approximate review queue <a href=\"{0}\">wait times</a>."
-msgstr ""
-"Nézze meg a vizsgálati folyamat várható <a href=\"{0}\">várakozási "
-"idejét</a>."
+msgstr "Nézze meg a vizsgálati folyamat várható <a href=\"{0}\">várakozási idejét</a>."
 
 #: src/olympia/devhub/templates/devhub/addons/submit/done.html:42
 msgid "Get Ahead in the Review Queue!"
@@ -6197,17 +4973,14 @@ msgstr "Kerüljön előre az értékelési sorban!"
 
 #: src/olympia/devhub/templates/devhub/addons/submit/done.html:45
 msgid "Become an AMO Reviewer today and get your add-ons reviewed faster."
-msgstr ""
-"Váljon AMO értékelővé még ma, és gyorsítsa fel kiegészítőinek vizsgálatát."
+msgstr "Váljon AMO értékelővé még ma, és gyorsítsa fel kiegészítőinek vizsgálatát."
 
 #: src/olympia/devhub/templates/devhub/addons/submit/done.html:54
-msgid ""
-"Your add-on has been signed and it's ready to use. You can download it here:"
+msgid "Your add-on has been signed and it's ready to use. You can download it here:"
 msgstr "A kiegészítő aláírva és használatra kész. Itt tudja letölteni:"
 
 #: src/olympia/devhub/templates/devhub/addons/submit/done.html:64
-msgid ""
-"Your add-on has been submitted to the Unlisted Preliminary Review queue."
+msgid "Your add-on has been submitted to the Unlisted Preliminary Review queue."
 msgstr "A kiegészítője benyújtásra került a Titkos előzetes értékelési sorba."
 
 #: src/olympia/devhub/templates/devhub/addons/submit/done.html:66
@@ -6215,8 +4988,7 @@ msgid "Your add-on has been submitted to the Unlisted Full Review queue."
 msgstr "A kiegészítője benyújtásra került a Titkos teljes értékelési sorba."
 
 #: src/olympia/devhub/templates/devhub/addons/submit/done.html:70
-msgid ""
-"You'll receive an email once it has been reviewed by an editor and signed."
+msgid "You'll receive an email once it has been reviewed by an editor and signed."
 msgstr "Egy e-mailt fog kapni, amint egy szerkesztő értékelte és aláírta."
 
 #: src/olympia/devhub/templates/devhub/addons/submit/done.html:74
@@ -6224,12 +4996,8 @@ msgid "Your add-on will not be publicly available on this website."
 msgstr "Kiegészítője nem lesz nyilvánosan elérhető ezen a honlapon."
 
 #: src/olympia/devhub/templates/devhub/addons/submit/done.html:84
-msgid ""
-"You can upload new versions of your add-on in the <a href=\"{0}\">add-on's "
-"developer page</a>."
-msgstr ""
-"Kiegészítője új verzióját a <a href=\"{0}\">kiegészítő fejlesztői "
-"oldalán</a> töltheti fel."
+msgid "You can upload new versions of your add-on in the <a href=\"{0}\">add-on's developer page</a>."
+msgstr "Kiegészítője új verzióját a <a href=\"{0}\">kiegészítő fejlesztői oldalán</a> töltheti fel."
 
 #: src/olympia/devhub/templates/devhub/addons/submit/license.html:4
 msgid "Step 5"
@@ -6240,13 +5008,8 @@ msgid "Step 5. Select a License"
 msgstr "5. lépés: a licenc kiválasztása"
 
 #: src/olympia/devhub/templates/devhub/addons/submit/license.html:9
-msgid ""
-"We require all add-ons to indicate the terms under which their source code "
-"is licensed. Please select a license from the list below or enter a custom "
-"license."
-msgstr ""
-"Minden kiegészítőnél szükség van a forráskód licencelésének megállapítására."
-" Válasszon egy licencet a listából vagy adjon meg egy egyéni licencet."
+msgid "We require all add-ons to indicate the terms under which their source code is licensed. Please select a license from the list below or enter a custom license."
+msgstr "Minden kiegészítőnél szükség van a forráskód licencelésének megállapítására. Válasszon egy licencet a listából vagy adjon meg egy egyéni licencet."
 
 #: src/olympia/devhub/templates/devhub/addons/submit/license.html:18
 msgid "Select a license for your add-on:"
@@ -6262,14 +5025,11 @@ msgstr "4. lépés: képek hozzáadása"
 
 #: src/olympia/devhub/templates/devhub/addons/submit/media.html:9
 msgid ""
-"Custom icons and screenshots draw attention and help users understand what "
-"it does. We strongly recommend uploading a custom icon, as in some areas of "
-"the website, only the icon and name will appear."
+"Custom icons and screenshots draw attention and help users understand what it does. We strongly recommend uploading a custom icon, as in some areas of the website, only the icon and name will "
+"appear."
 msgstr ""
-"Az egyéni ikonok és képernyőképek felhívják a figyelmet, és segítenek a "
-"felhasználóknak megérteni, hogy mit csinál. Határozottan javasoljuk egyéni "
-"ikon feltöltését, mert a weboldal egyes területein csak az ikon és a név "
-"jelenik meg."
+"Az egyéni ikonok és képernyőképek felhívják a figyelmet, és segítenek a felhasználóknak megérteni, hogy mit csinál. Határozottan javasoljuk egyéni ikon feltöltését, mert a weboldal egyes területein"
+" csak az ikon és a név jelenik meg."
 
 #: src/olympia/devhub/templates/devhub/addons/submit/select-review.html:5
 msgid "Step 6"
@@ -6281,24 +5041,16 @@ msgstr "6. lépés: értékelési folyamat kiválasztása"
 
 #: src/olympia/devhub/templates/devhub/addons/submit/select-review.html:10
 msgid ""
-"All add-ons hosted in our gallery must be reviewed by an editor before they "
-"appear in categories or search results. While waiting for review, your add-"
-"on can still be accessed through its direct URL. Please choose the review "
-"process below that best fits your add-on."
+"All add-ons hosted in our gallery must be reviewed by an editor before they appear in categories or search results. While waiting for review, your add-on can still be accessed through its direct "
+"URL. Please choose the review process below that best fits your add-on."
 msgstr ""
-"Minden, a galériában megjelenő kiegészítőt a szerkesztők értékelnek. Az "
-"értékelőre való várakozás alatt a kiegészítő közvetlen URL használatával "
-"elérhető. Válassza ki a kiegészítőjéhez legjobban illő átvizsgálási "
-"eljárást."
+"Minden, a galériában megjelenő kiegészítőt a szerkesztők értékelnek. Az értékelőre való várakozás alatt a kiegészítő közvetlen URL használatával elérhető. Válassza ki a kiegészítőjéhez legjobban "
+"illő átvizsgálási eljárást."
 
 #: src/olympia/devhub/templates/devhub/addons/submit/select-review.html:26
 #, python-format
-msgid ""
-"A complete review of your add-on's source and functionality. <a "
-"href=\"%(url)s\">Learn more&hellip;</a>"
-msgstr ""
-"A kiegészítő forrásának és funkcionalitásának teljes értékelése. <a "
-"href=\"%(url)s\">Tudjon meg többet&hellip;</a>"
+msgid "A complete review of your add-on's source and functionality. <a href=\"%(url)s\">Learn more&hellip;</a>"
+msgstr "A kiegészítő forrásának és funkcionalitásának teljes értékelése. <a href=\"%(url)s\">Tudjon meg többet&hellip;</a>"
 
 #: src/olympia/devhub/templates/devhub/addons/submit/select-review.html:32
 msgid "Appropriate for polished add-ons"
@@ -6326,12 +5078,8 @@ msgstr "Teljes értékelés kiválasztása"
 
 #: src/olympia/devhub/templates/devhub/addons/submit/select-review.html:49
 #, python-format
-msgid ""
-"A faster review of your add-on's source for any major problems. <a "
-"href=\"%(url)s\">Learn more&hellip;</a>"
-msgstr ""
-"A kiegészítő forrásának gyorsabb értékelése a főbb problémák vizsgálata "
-"miatt. <a href=\"%(url)s\">Tudjon meg többet&hellip;</a>"
+msgid "A faster review of your add-on's source for any major problems. <a href=\"%(url)s\">Learn more&hellip;</a>"
+msgstr "A kiegészítő forrásának gyorsabb értékelése a főbb problémák vizsgálata miatt. <a href=\"%(url)s\">Tudjon meg többet&hellip;</a>"
 
 #: src/olympia/devhub/templates/devhub/addons/submit/select-review.html:55
 msgid "Appropriate for experimental add-ons"
@@ -6377,10 +5125,8 @@ msgstr "Válasszon licencet"
 msgid "Select a review process"
 msgstr "Válasszon értékelési folyamatot"
 
-#: src/olympia/devhub/templates/devhub/addons/submit/sidebar.html:18
-#: src/olympia/devhub/templates/devhub/docs/policies-submission.html:3
-#: src/olympia/devhub/templates/devhub/docs/policies-submission.html:7
-#: src/olympia/devhub/templates/devhub/docs/policies-submission.html:9
+#: src/olympia/devhub/templates/devhub/addons/submit/sidebar.html:18 src/olympia/devhub/templates/devhub/docs/policies-submission.html:3
+#: src/olympia/devhub/templates/devhub/docs/policies-submission.html:7 src/olympia/devhub/templates/devhub/docs/policies-submission.html:9
 msgid "Submission Process"
 msgstr "Benyújtási folyamat"
 
@@ -6401,27 +5147,18 @@ msgid "Step 2. Upload Your Add-on"
 msgstr "2. lépés: kiegészítő feltöltése"
 
 #: src/olympia/devhub/templates/devhub/addons/submit/upload.html:11
-msgid ""
-"Use the fields below to upload your add-on package and select any platform "
-"restrictions. After upload, a series of automated validation tests will be "
-"run on your file."
-msgstr ""
-"Használja az alábbi mezőket a kiegészítő feltöltéséhez és állítsa be a "
-"platformkorlátozást. A feltöltés után egy sor automatikus ellenőrzési "
-"mechanizmus indul el és vizsgálja meg a fájlt."
+msgid "Use the fields below to upload your add-on package and select any platform restrictions. After upload, a series of automated validation tests will be run on your file."
+msgstr "Használja az alábbi mezőket a kiegészítő feltöltéséhez és állítsa be a platformkorlátozást. A feltöltés után egy sor automatikus ellenőrzési mechanizmus indul el és vizsgálja meg a fájlt."
 
-#: src/olympia/devhub/templates/devhub/addons/submit/upload.html:59
-#: src/olympia/devhub/templates/devhub/versions/add_file_modal.html:39
+#: src/olympia/devhub/templates/devhub/addons/submit/upload.html:51 src/olympia/devhub/templates/devhub/versions/add_file_modal.html:28
 msgid "Which platforms is this file compatible with?"
 msgstr "Mely platformokkal kompatibilis a fájl?"
 
-#: src/olympia/devhub/templates/devhub/addons/submit/upload.html:67
-#: src/olympia/devhub/templates/devhub/versions/add_file_modal.html:65
+#: src/olympia/devhub/templates/devhub/addons/submit/upload.html:59 src/olympia/devhub/templates/devhub/versions/add_file_modal.html:45
 msgid "Administrative overrides"
 msgstr "Adminisztrációs felülbírálások"
 
-#: src/olympia/devhub/templates/devhub/api/agreement.html:3
-#: src/olympia/devhub/templates/devhub/api/agreement.html:11
+#: src/olympia/devhub/templates/devhub/api/agreement.html:3 src/olympia/devhub/templates/devhub/api/agreement.html:11
 msgid "Firefox Add-on Distribution Agreement"
 msgstr "Firefox kiegészítő terjesztési megállapodás"
 
@@ -6431,12 +5168,8 @@ msgstr "API hitelesítési adatok"
 
 #: src/olympia/devhub/templates/devhub/api/key.html:20
 #, python-format
-msgid ""
-"For detailed instructions, consult the <a href=\"%(docs_url)s\">API "
-"documentation</a>."
-msgstr ""
-"Részletes útmutatásért tanulmányozza a <a href=\"%(docs_url)s\">API "
-"dokumentációt</a>."
+msgid "For detailed instructions, consult the <a href=\"%(docs_url)s\">API documentation</a>."
+msgstr "Részletes útmutatásért tanulmányozza a <a href=\"%(docs_url)s\">API dokumentációt</a>."
 
 #: src/olympia/devhub/templates/devhub/api/key.html:28
 msgid "JWT issuer"
@@ -6449,14 +5182,11 @@ msgstr "JWT titok"
 #: src/olympia/devhub/templates/devhub/api/key.html:37
 #, python-format
 msgid ""
-"To make API requests, send a <a href=\"%(jwt_url)s\">JSON Web Token "
-"(JWT)</a> as the authorization header. You'll need to generate a JWT for "
-"every request as explained in the <a href=\"%(docs_url)s\">API "
-"documentation</a>."
+"To make API requests, send a <a href=\"%(jwt_url)s\">JSON Web Token (JWT)</a> as the authorization header. You'll need to generate a JWT for every request as explained in the <a "
+"href=\"%(docs_url)s\">API documentation</a>."
 msgstr ""
-"API kéréshez küldjön egy <a href=\"%(jwt_url)s\">JSON Web Tokent (JWT),</a> "
-"az autorizációs fejlécben. Egy JWT-t kell generálnia minden egyes kéréshez, "
-"ahogy azt az <a href=\"%(docs_url)s\">API dokumentáció</a> elmagyarázza."
+"API kéréshez küldjön egy <a href=\"%(jwt_url)s\">JSON Web Tokent (JWT),</a> az autorizációs fejlécben. Egy JWT-t kell generálnia minden egyes kéréshez, ahogy azt az <a href=\"%(docs_url)s\">API "
+"dokumentáció</a> elmagyarázza."
 
 #: src/olympia/devhub/templates/devhub/api/key.html:47
 msgid "You don't have any API credentials yet."
@@ -6464,12 +5194,8 @@ msgstr "Még nem rendelkezik API hitelesítő adatokkal."
 
 #: src/olympia/devhub/templates/devhub/api/key.html:53
 #, python-format
-msgid ""
-"This feature is under active development. If you find a problem please <a "
-"target=\"_blank\" href=\"%(bug_link)s\">report a bug</a>."
-msgstr ""
-"Ez a funkció aktív fejlesztés alatt áll. Ha problémát talál, kérjük tegyen "
-"<a target=\"_blank\" href=\"%(bug_link)s\">hibabejelentést</a>."
+msgid "This feature is under active development. If you find a problem please <a target=\"_blank\" href=\"%(bug_link)s\">report a bug</a>."
+msgstr "Ez a funkció aktív fejlesztés alatt áll. Ha problémát talál, kérjük tegyen <a target=\"_blank\" href=\"%(bug_link)s\">hibabejelentést</a>."
 
 #: src/olympia/devhub/templates/devhub/api/key.html:61
 msgid "Revoke and regenerate credentials"
@@ -6479,30 +5205,19 @@ msgstr "Hitelesítő adatok visszavonása és újra létrehozása"
 msgid "Generate new credentials"
 msgstr "Új hitelesítő adatok létrehozása"
 
-#: src/olympia/devhub/templates/devhub/docs/policies-agreement.html:3
-#: src/olympia/devhub/templates/devhub/docs/policies-agreement.html:7
-#: src/olympia/devhub/templates/devhub/docs/policies-agreement.html:9
-#: src/olympia/devhub/templates/devhub/docs/policies.html:24
-#: src/olympia/devhub/templates/devhub/docs/policies.html:103
+#: src/olympia/devhub/templates/devhub/docs/policies-agreement.html:3 src/olympia/devhub/templates/devhub/docs/policies-agreement.html:7 src/olympia/devhub/templates/devhub/docs/policies-agreement.html:9
+#: src/olympia/devhub/templates/devhub/docs/policies.html:24 src/olympia/devhub/templates/devhub/docs/policies.html:103
 msgid "Developer Agreement"
 msgstr "Fejlesztői megállapodás"
 
-#: src/olympia/devhub/templates/devhub/docs/policies-contact.html:3
-#: src/olympia/devhub/templates/devhub/docs/policies-contact.html:7
-#: src/olympia/devhub/templates/devhub/docs/policies-contact.html:9
-#: src/olympia/devhub/templates/devhub/docs/policies.html:27
-#: src/olympia/devhub/templates/devhub/docs/policies.html:115
+#: src/olympia/devhub/templates/devhub/docs/policies-contact.html:3 src/olympia/devhub/templates/devhub/docs/policies-contact.html:7 src/olympia/devhub/templates/devhub/docs/policies-contact.html:9
+#: src/olympia/devhub/templates/devhub/docs/policies.html:27 src/olympia/devhub/templates/devhub/docs/policies.html:115
 msgid "Contacting Us"
 msgstr "Kapcsolatfelvétel módja"
 
 #: src/olympia/devhub/templates/devhub/docs/policies-contact.html:12
-msgid ""
-"Thanks for your interest in contacting the Mozilla Add-ons team. Please read"
-" this page carefully to ensure your request goes to the right place."
-msgstr ""
-"Köszönjük, hogy kapcsolatba lépett a Mozilla Kiegészítők csapatával. Kérjük,"
-" olvassa el ezt az oldalt figyelmesen, hogy biztosítsa kérése megfelelő "
-"helyre irányul."
+msgid "Thanks for your interest in contacting the Mozilla Add-ons team. Please read this page carefully to ensure your request goes to the right place."
+msgstr "Köszönjük, hogy kapcsolatba lépett a Mozilla Kiegészítők csapatával. Kérjük, olvassa el ezt az oldalt figyelmesen, hogy biztosítsa kérése megfelelő helyre irányul."
 
 #: src/olympia/devhub/templates/devhub/docs/policies-contact.html:17
 msgid "Add-on Support"
@@ -6510,15 +5225,11 @@ msgstr "Kiegészítő támogatás"
 
 #: src/olympia/devhub/templates/devhub/docs/policies-contact.html:19
 msgid ""
-"If you have a support question about a particular add-on, such as \"how do I"
-" use this add-on?\" or \"why doesn't this work properly?\", please contact "
-"that add-on's author through the support channels listed on the add-on's "
-"listing page."
+"If you have a support question about a particular add-on, such as \"how do I use this add-on?\" or \"why doesn't this work properly?\", please contact that add-on's author through the support "
+"channels listed on the add-on's listing page."
 msgstr ""
-"Ha olyan támogatási kérdése van egy adott bővítménnyel kapcsolatban, mint a "
-"\"hogyan használhatom ezt a kiegészítőt?\" vagy \"miért nem működik "
-"rendesen?\", kérjük, hogy keresse a kiegészítő szerzőjét a kiegészítő "
-"oldalán megadott támogatási csatornákon keresztül."
+"Ha olyan támogatási kérdése van egy adott bővítménnyel kapcsolatban, mint a \"hogyan használhatom ezt a kiegészítőt?\" vagy \"miért nem működik rendesen?\", kérjük, hogy keresse a kiegészítő "
+"szerzőjét a kiegészítő oldalán megadott támogatási csatornákon keresztül."
 
 #: src/olympia/devhub/templates/devhub/docs/policies-contact.html:24
 msgid "Add-on Editorial Concerns"
@@ -6531,18 +5242,11 @@ msgstr "amo-editors kukac mozilla pont org"
 #: src/olympia/devhub/templates/devhub/docs/policies-contact.html:26
 #, python-format
 msgid ""
-"If you have a question about an Editor's review of an add-on or want to "
-"report a policy violation, please email %(mail_editors)s. <strong>Almost all"
-" add-on reports fall under this category.</strong> Please be sure to include"
-" a link to the add-on in question and a detailed description of your "
-"question or comment."
+"If you have a question about an Editor's review of an add-on or want to report a policy violation, please email %(mail_editors)s. <strong>Almost all add-on reports fall under this "
+"category.</strong> Please be sure to include a link to the add-on in question and a detailed description of your question or comment."
 msgstr ""
-"Ha egy szerkesztői értékeléssel kapcsolatban kérdése van, vagy házirend "
-"megszegését jelentené, küldjön egy emailt ide: %(mail_editors)s. "
-"<strong>Szinte minden kiegészítő-jelentés ebbe a kategóriába "
-"tartozik.</strong> Kérjük, bizonyosodjon meg afelől, hogy kérdése vagy "
-"megjegyzése a részletes leírás mellett tartalmazza a kiegészítő hivatkozását"
-" is."
+"Ha egy szerkesztői értékeléssel kapcsolatban kérdése van, vagy házirend megszegését jelentené, küldjön egy emailt ide: %(mail_editors)s. <strong>Szinte minden kiegészítő-jelentés ebbe a kategóriába"
+" tartozik.</strong> Kérjük, bizonyosodjon meg afelől, hogy kérdése vagy megjegyzése a részletes leírás mellett tartalmazza a kiegészítő hivatkozását is."
 
 #: src/olympia/devhub/templates/devhub/docs/policies-contact.html:31
 msgid "Add-on Security Vulnerabilities"
@@ -6555,20 +5259,12 @@ msgstr "amo-admins kukac mozilla pont org"
 #: src/olympia/devhub/templates/devhub/docs/policies-contact.html:36
 #, python-format
 msgid ""
-"If you have discovered a security vulnerability in an add-on, even if it is "
-"not hosted here, Mozilla is very interested in your discovery and will work "
-"with the add-on developer to correct the issue as soon as possible. Add-on "
-"security issues can be reported <a "
-"href=\"http://www.mozilla.org/projects/security/security-bugs-"
-"policy.html\">confidentially</a> in <a "
+"If you have discovered a security vulnerability in an add-on, even if it is not hosted here, Mozilla is very interested in your discovery and will work with the add-on developer to correct the "
+"issue as soon as possible. Add-on security issues can be reported <a href=\"http://www.mozilla.org/projects/security/security-bugs-policy.html\">confidentially</a> in <a "
 "href=\"%(link_bugzilla)s\">Bugzilla</a> or by emailing %(mail_admins)s."
 msgstr ""
-"Ha biztonsági sebezhetőséget fedez fel egy kiegészítőben, akkor is ha nem "
-"itt tárolják, a Mozillát érdekli az Ön találata és a kiegészítő "
-"fejlesztőjével mihamarabb a hiba javításán fogunk dolgozni. Kiegészítőkkel "
-"kapcsolatos biztonsági problémákat <a "
-"href=\"http://www.mozilla.org/projects/security/security-bugs-"
-"policy.html\">bizalmasan</a> a <a href=\"%(link_bugzilla)s\">Bugzilla</a> "
+"Ha biztonsági sebezhetőséget fedez fel egy kiegészítőben, akkor is ha nem itt tárolják, a Mozillát érdekli az Ön találata és a kiegészítő fejlesztőjével mihamarabb a hiba javításán fogunk dolgozni."
+" Kiegészítőkkel kapcsolatos biztonsági problémákat <a href=\"http://www.mozilla.org/projects/security/security-bugs-policy.html\">bizalmasan</a> a <a href=\"%(link_bugzilla)s\">Bugzilla</a> "
 "oldalon, vagy az %(mail_admins)s e-mailcímen jelenthet."
 
 #: src/olympia/devhub/templates/devhub/docs/policies-contact.html:42
@@ -6577,17 +5273,11 @@ msgstr "Honlap funkcionalitása és fejlesztése"
 
 #: src/olympia/devhub/templates/devhub/docs/policies-contact.html:44
 msgid ""
-"If you've found a problem with the site, we'd love to fix it. Please <a "
-"href=\"https://github.com/mozilla/olympia/issues\">file a bug report</a> in "
-"GitHub, including the location of the problem and how you encountered it."
+"If you've found a problem with the site, we'd love to fix it. Please <a href=\"https://github.com/mozilla/addons/issues/new\">file a bug report</a> in GitHub, including the location of the problem "
+"and how you encountered it."
 msgstr ""
-"Ha hibát talált ezen a honlapon hibát, szeretnénk kijavítani. Kérjük, <a "
-"href=\"https://github.com/mozilla/olympia/issues\">tegyen "
-"hibabejelentést</a> a GitHubon, leírva a probléma helyét, és hogy hogyan "
-"találkozott vele."
 
-#: src/olympia/devhub/templates/devhub/docs/policies-maintenance.html:3
-#: src/olympia/devhub/templates/devhub/docs/policies-maintenance.html:7
+#: src/olympia/devhub/templates/devhub/docs/policies-maintenance.html:3 src/olympia/devhub/templates/devhub/docs/policies-maintenance.html:7
 #: src/olympia/devhub/templates/devhub/docs/policies-maintenance.html:8
 msgid "Maintaining Your Add-ons"
 msgstr "Kiegészítők karbantartása"
@@ -6598,32 +5288,17 @@ msgstr "Kiegészítő új verziójának benyújtása"
 
 #: src/olympia/devhub/templates/devhub/docs/policies-maintenance.html:12
 msgid ""
-"Developers are encouraged to submit updates to their add-ons to fix bugs, "
-"add features, and otherwise improve their product. New versions of an add-on"
-" must have a <a "
-"href=\"https://developer.mozilla.org/en/Toolkit_version_format\">higher "
-"version number</a> and can be submitted through the Developer Tools "
-"provided. There is no limit to the number of versions that can be submitted,"
-" but please remember that versions must be reviewed by an editor."
+"Developers are encouraged to submit updates to their add-ons to fix bugs, add features, and otherwise improve their product. New versions of an add-on must have a <a "
+"href=\"https://developer.mozilla.org/en/Toolkit_version_format\">higher version number</a> and can be submitted through the Developer Tools provided. There is no limit to the number of versions "
+"that can be submitted, but please remember that versions must be reviewed by an editor."
 msgstr ""
-"A fejlesztők számára javasolt, hogy a kiegészítésekhez frissítéseket "
-"küldjenek be, amelyekben hibákat javítanak, új funkciókat biztosítanak és "
-"más módon fejlesztik kiegészítőjüket. Az új verzióknak <a "
-"href=\"https://developer.mozilla.org/en/Toolkit_version_format\">magasabb "
-"verziószámmal</a> kell rendelkeznie, amelyet a fejlesztői eszközökön "
-"keresztül kell beküldeni. Nincs korlátozás a beküldhető verziók számára, "
-"azonban érdemes figyelembe venni, hogy minden verziót a szerkesztők "
-"valamelyikének értékelnie kell."
+"A fejlesztők számára javasolt, hogy a kiegészítésekhez frissítéseket küldjenek be, amelyekben hibákat javítanak, új funkciókat biztosítanak és más módon fejlesztik kiegészítőjüket. Az új verzióknak"
+" <a href=\"https://developer.mozilla.org/en/Toolkit_version_format\">magasabb verziószámmal</a> kell rendelkeznie, amelyet a fejlesztői eszközökön keresztül kell beküldeni. Nincs korlátozás a "
+"beküldhető verziók számára, azonban érdemes figyelembe venni, hogy minden verziót a szerkesztők valamelyikének értékelnie kell."
 
 #: src/olympia/devhub/templates/devhub/docs/policies-maintenance.html:18
-msgid ""
-"New versions will be added to a pending review queue, and any additional "
-"versions submitted before the review is completed will move that version to "
-"the end of the queue."
-msgstr ""
-"Az új verziók a függőben lévő értékelések sorához adódnak. Ha az értékelés "
-"befejezése előtt új verziót nyújt be, akkor az a verzió a sor végére fog "
-"kerülni."
+msgid "New versions will be added to a pending review queue, and any additional versions submitted before the review is completed will move that version to the end of the queue."
+msgstr "Az új verziók a függőben lévő értékelések sorához adódnak. Ha az értékelés befejezése előtt új verziót nyújt be, akkor az a verzió a sor végére fog kerülni."
 
 #: src/olympia/devhub/templates/devhub/docs/policies-maintenance.html:23
 msgid "How do I submit a Beta add-on?"
@@ -6635,52 +5310,31 @@ msgstr "A béta csatorna csak teljesen értékelt kiegészítőkhöz elérhető.
 
 #: src/olympia/devhub/templates/devhub/docs/policies-maintenance.html:31
 msgid ""
-"To create a beta channel, upload a file with a unique version string that "
-"contains any of the following strings: <code>a,b,alpha,beta,pre,rc</code>, "
-"with an optional number at the end. This text must come at the end of the "
-"version string. If you understand regex format, here's what we look for in "
-"the version number: <code>\"(a|alpha|b|beta|pre|rc)\\d*$\"</code>."
+"To create a beta channel, upload a file with a unique version string that contains any of the following strings: <code>a,b,alpha,beta,pre,rc</code>, with an optional number at the end. This text "
+"must come at the end of the version string. If you understand regex format, here's what we look for in the version number: <code>\"(a|alpha|b|beta|pre|rc)\\d*$\"</code>."
 msgstr ""
-"A béta csatorna létrehozásához töltsön fel egy egyedi verziószámmal ellátott"
-" fájlt, amely a következő karakterláncok egyikét tartalmazza: "
-"<code>a,b,alpha,beta,pre,rc</code>, választhatóan egy számmal a végén. Ez a "
-"szöveg a verzió karakterlánc végén kell legyen. Ha ismeri a regex "
-"formátumot, erre keresünk a verziószámban: "
-"<code>\"(a|alpha|beta|pre|rc)\\d*$\"</code>."
+"A béta csatorna létrehozásához töltsön fel egy egyedi verziószámmal ellátott fájlt, amely a következő karakterláncok egyikét tartalmazza: <code>a,b,alpha,beta,pre,rc</code>, választhatóan egy "
+"számmal a végén. Ez a szöveg a verzió karakterlánc végén kell legyen. Ha ismeri a regex formátumot, erre keresünk a verziószámban: <code>\"(a|alpha|beta|pre|rc)\\d*$\"</code>."
 
 #: src/olympia/devhub/templates/devhub/docs/policies-maintenance.html:37
 msgid ""
-"Once a file meeting this criteria is uploaded to AMO, it will automatically "
-"be marked as a beta version. Users of add-ons with these unique version "
-"numbers will automatically be served the newest beta updates."
+"Once a file meeting this criteria is uploaded to AMO, it will automatically be marked as a beta version. Users of add-ons with these unique version numbers will automatically be served the newest "
+"beta updates."
 msgstr ""
-"Amint az ezt a feltételt teljesítő fájl feltöltésre került az AMO-ba, "
-"automatikusan béta verzióként lesz megjelölve. Az ezen egyedi verziószámmal "
-"rendelkező kiegészítők felhasználói automatikusan megkapják a legújabb béta "
-"frissítéseket."
+"Amint az ezt a feltételt teljesítő fájl feltöltésre került az AMO-ba, automatikusan béta verzióként lesz megjelölve. Az ezen egyedi verziószámmal rendelkező kiegészítők felhasználói automatikusan "
+"megkapják a legújabb béta frissítéseket."
 
 #: src/olympia/devhub/templates/devhub/docs/policies-maintenance.html:43
 msgid ""
-"While we call these \"Beta versions\", you can use this channel for "
-"nightlies, or alphas, or prerelease versions as you wish. Please note that "
-"there is only one channel for this purpose and all of your users on this "
-"channel will receive the latest add-ons submitted. For instance, if you "
-"upload <code>1.0beta1</code> to the release channel and then upload "
-"<code>1.1alpha1</code>, all users of <code>1.0beta1</code> will be offered "
-"an upgrade to <code>1.1alpha1</code>. Updates are pushed by submission date "
-"and not version number, so users will always get the most recent channel "
-"update regardless of any kind of alphabetical sorting."
+"While we call these \"Beta versions\", you can use this channel for nightlies, or alphas, or prerelease versions as you wish. Please note that there is only one channel for this purpose and all of "
+"your users on this channel will receive the latest add-ons submitted. For instance, if you upload <code>1.0beta1</code> to the release channel and then upload <code>1.1alpha1</code>, all users of "
+"<code>1.0beta1</code> will be offered an upgrade to <code>1.1alpha1</code>. Updates are pushed by submission date and not version number, so users will always get the most recent channel update "
+"regardless of any kind of alphabetical sorting."
 msgstr ""
-"Ugyan mi ezeket \"béta verzióknak\" nevezzük, használhatja ezt a csatornát "
-"éjszakai kiadásokhoz, alfa vagy előzetes kiadási verziókhoz is. Ne feledje, "
-"hogy csak egy csatorna van erre a célra, és a csatorna minden felhasználója "
-"megkapja a legfrissebb beküldött kiegészítőt. Ha például feltölti az "
-"<code>1.0beta1</code> verziót a kiadási csatornába és feltölti az "
-"<code>1.1alpha1</code> verziót, akkor minden <code>1.0beta1</code> "
-"felhasználónak felajánlja a frissítést az <code>1.1alpha1</code> verzióra. A"
-" frissítésék kiküldése beküldési dátum, és nem verziószám alapján történik, "
-"így a felhasználók mindig a legújabb frissítést kapják meg, bármilyen "
-"ábécésorrendtől függetlenül."
+"Ugyan mi ezeket \"béta verzióknak\" nevezzük, használhatja ezt a csatornát éjszakai kiadásokhoz, alfa vagy előzetes kiadási verziókhoz is. Ne feledje, hogy csak egy csatorna van erre a célra, és a "
+"csatorna minden felhasználója megkapja a legfrissebb beküldött kiegészítőt. Ha például feltölti az <code>1.0beta1</code> verziót a kiadási csatornába és feltölti az <code>1.1alpha1</code> verziót, "
+"akkor minden <code>1.0beta1</code> felhasználónak felajánlja a frissítést az <code>1.1alpha1</code> verzióra. A frissítésék kiküldése beküldési dátum, és nem verziószám alapján történik, így a "
+"felhasználók mindig a legújabb frissítést kapják meg, bármilyen ábécésorrendtől függetlenül."
 
 #: src/olympia/devhub/templates/devhub/docs/policies-maintenance.html:48
 msgid "Required Updates"
@@ -6688,22 +5342,13 @@ msgstr "Szükséges frissítések"
 
 #: src/olympia/devhub/templates/devhub/docs/policies-maintenance.html:50
 msgid ""
-"Certain situations may arise in which Mozilla requests that an add-on "
-"developer update their add-on within a given time period to address a major "
-"security issue or policy violation. We work with developers to reasonably "
-"accommodate their own schedules, but if the issue is of a serious enough "
-"nature, add-ons that cannot issue an update with the requested fix may be "
-"demoted from fully-reviewed status, disabled, or permanently removed from "
-"the site."
+"Certain situations may arise in which Mozilla requests that an add-on developer update their add-on within a given time period to address a major security issue or policy violation. We work with "
+"developers to reasonably accommodate their own schedules, but if the issue is of a serious enough nature, add-ons that cannot issue an update with the requested fix may be demoted from fully-"
+"reviewed status, disabled, or permanently removed from the site."
 msgstr ""
-"Bizonyos helyzetek adódhatnak, amikor a Mozilla azt kérheti, hogy egy "
-"kiegészítő-fejlesztő frissítse a kiegészítőjét, egy adott időszakon belül, "
-"hogy megoldjon egy jelentős biztonsági problémát, vagy házirendsértést. "
-"Együtt dolgozunk a fejlesztőkkel, hogy ésszerűen figyelembe vegyük a saját "
-"időbeosztásukat, de ha a probléma egy elég komoly természetű, akkor azon "
-"kiegészítők, amelyek nem adnak ki egy frissítést a kért javítással, "
-"lefokozásra kerülhetnek a teljesen értékelt állapotból, letiltásra "
-"kerülhetnek, vagy végleges törlésre kerülhetnek az oldalról."
+"Bizonyos helyzetek adódhatnak, amikor a Mozilla azt kérheti, hogy egy kiegészítő-fejlesztő frissítse a kiegészítőjét, egy adott időszakon belül, hogy megoldjon egy jelentős biztonsági problémát, "
+"vagy házirendsértést. Együtt dolgozunk a fejlesztőkkel, hogy ésszerűen figyelembe vegyük a saját időbeosztásukat, de ha a probléma egy elég komoly természetű, akkor azon kiegészítők, amelyek nem "
+"adnak ki egy frissítést a kért javítással, lefokozásra kerülhetnek a teljesen értékelt állapotból, letiltásra kerülhetnek, vagy végleges törlésre kerülhetnek az oldalról."
 
 #: src/olympia/devhub/templates/devhub/docs/policies-maintenance.html:55
 msgid "Transfer of Ownership"
@@ -6711,49 +5356,35 @@ msgstr "Tulajdonjog átruházása"
 
 #: src/olympia/devhub/templates/devhub/docs/policies-maintenance.html:57
 msgid ""
-"Add-ons can have multiple users with permission to update and manage the "
-"listing. Existing authors of an add-on can transfer ownership and add "
-"additional developers to an add-on's listing through the Developer Tools "
-"provided. No interaction with Mozilla representatives is necessary for a "
-"transfer of ownership."
+"Add-ons can have multiple users with permission to update and manage the listing. Existing authors of an add-on can transfer ownership and add additional developers to an add-on's listing through "
+"the Developer Tools provided. No interaction with Mozilla representatives is necessary for a transfer of ownership."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/docs/policies-maintenance.html:63
 #, python-format
-msgid ""
-"Mozilla can assist with granting additional permissions of an add-on's "
-"listing if <a href=\"%(link_contact)s\">contacted</a> by the add-on's "
-"current owner."
+msgid "Mozilla can assist with granting additional permissions of an add-on's listing if <a href=\"%(link_contact)s\">contacted</a> by the add-on's current owner."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/docs/policies-maintenance.html:70
 msgid ""
-"Mozilla encourages its users to offer feedback on their experiences when "
-"using an add-on. This allows other users to determine if the add-on is "
-"stable and useful. It also provides valuable feedback to developers, "
-"allowing them to continuously improve their add-on to meet user needs."
+"Mozilla encourages its users to offer feedback on their experiences when using an add-on. This allows other users to determine if the add-on is stable and useful. It also provides valuable feedback"
+" to developers, allowing them to continuously improve their add-on to meet user needs."
 msgstr ""
-"A Mozilla javasolja felhasználóinak, hogy adjanak a kiegészítő használatával"
-" kapcsolatos visszajelzést. Ez lehetőséget biztosít a többi felhasználó "
-"számára, hogy megtudják, hogy a kiegészítő mennyire hasznos vagy stabil. "
-"Ugyancsak hasznos a visszajelzés a fejlesztők számára, lehetőséget adva, "
-"hogy a felhasználói igényeknek megfelelőn tudják folyamatosan "
-"továbbfejleszteni a kiegészítőket."
+"A Mozilla javasolja felhasználóinak, hogy adjanak a kiegészítő használatával kapcsolatos visszajelzést. Ez lehetőséget biztosít a többi felhasználó számára, hogy megtudják, hogy a kiegészítő "
+"mennyire hasznos vagy stabil. Ugyancsak hasznos a visszajelzés a fejlesztők számára, lehetőséget adva, hogy a felhasználói igényeknek megfelelőn tudják folyamatosan továbbfejleszteni a "
+"kiegészítőket."
 
 #: src/olympia/devhub/templates/devhub/docs/policies-maintenance.html:76
 #, python-format
 msgid ""
-"Reviews must follow the <a href=\"%(link_guidelines)s\">review "
-"guidelines</a>. Reviews that do not meet these guidelines may be flagged for"
-" moderation, but negative reviews will not be removed unless they provide "
-"false information."
+"Reviews must follow the <a href=\"%(link_guidelines)s\">review guidelines</a>. Reviews that do not meet these guidelines may be flagged for moderation, but negative reviews will not be removed "
+"unless they provide false information."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/docs/policies-maintenance.html:82
 msgid ""
-"Many developers provide a support mechanism, such as a forum, discussion "
-"group, or email address. It is recommended that support questions be posted "
-"via those mediums instead of in an add-on's review section."
+"Many developers provide a support mechanism, such as a forum, discussion group, or email address. It is recommended that support questions be posted via those mediums instead of in an add-on's "
+"review section."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/docs/policies-maintenance.html:87
@@ -6762,31 +5393,21 @@ msgstr "Kódviták"
 
 #: src/olympia/devhub/templates/devhub/docs/policies-maintenance.html:90
 msgid ""
-"Many add-ons allow their source code to be openly viewed. This does not mean"
-" that the source code is open source or available for use in another add-on."
-" The original author of an add-on retains copyright of their work unless "
-"otherwise noted in the add-on's license."
+"Many add-ons allow their source code to be openly viewed. This does not mean that the source code is open source or available for use in another add-on. The original author of an add-on retains "
+"copyright of their work unless otherwise noted in the add-on's license."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/docs/policies-maintenance.html:96
 msgid ""
-"In the event that we're notified of a copyright or license infringement, we "
-"will take steps to review the situation and determine if an actual "
-"infringement has occurred. If we determine that there is an infringement, we"
-" will remove the offending add-on and contact the author. New add-on "
-"submissions (including updates) containing infringing code will be denied "
-"approval for public status."
+"In the event that we're notified of a copyright or license infringement, we will take steps to review the situation and determine if an actual infringement has occurred. If we determine that there "
+"is an infringement, we will remove the offending add-on and contact the author. New add-on submissions (including updates) containing infringing code will be denied approval for public status."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/docs/policies-maintenance.html:102
-msgid ""
-"If you are unsure of the current copyright status of an add-on's source "
-"code, you must contact the original author and receive explicit permission "
-"before using the source code."
+msgid "If you are unsure of the current copyright status of an add-on's source code, you must contact the original author and receive explicit permission before using the source code."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/docs/policies-maintenance.html:107
-#: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:306
+#: src/olympia/devhub/templates/devhub/docs/policies-maintenance.html:107 src/olympia/devhub/templates/devhub/docs/policies-reviews.html:306
 #: src/olympia/devhub/templates/devhub/docs/policies-submission.html:97
 msgid "Last updated: January 13, 2011"
 msgstr "Utolsó frissítés: 2011. január 13."
@@ -6794,48 +5415,30 @@ msgstr "Utolsó frissítés: 2011. január 13."
 #: src/olympia/devhub/templates/devhub/docs/policies-recommended.html:13
 #, python-format
 msgid ""
-"Featured add-ons are top-quality extensions and themes highlighted on <a "
-"href=\"%(link_gallery)s\">AMO</a>, Firefox's Add-ons Manager, and across "
-"other Mozilla websites. These add-ons showcase the power of Firefox "
-"customization and are useful to a wide audience."
+"Featured add-ons are top-quality extensions and themes highlighted on <a href=\"%(link_gallery)s\">AMO</a>, Firefox's Add-ons Manager, and across other Mozilla websites. These add-ons showcase the "
+"power of Firefox customization and are useful to a wide audience."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/docs/policies-recommended.html:19
-msgid ""
-"Featured add-ons are chosen by the Featured Add-ons Advisory Board, a small "
-"group of add-on developers and fans from the Mozilla community who have "
-"volunteered to review and vote on nominations."
+msgid "Featured add-ons are chosen by the Featured Add-ons Advisory Board, a small group of add-on developers and fans from the Mozilla community who have volunteered to review and vote on nominations."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/docs/policies-recommended.html:25
 #, python-format
-msgid ""
-"<a href=\"%(link_featured)s\">Featured extensions</a> are chosen every "
-"month, and <a href=\"%(link_themes)s\">featured complete themes</a> are "
-"chosen every quarter."
-msgstr ""
-"A <a href=\"%(link_featured)s\">kiemelt kiegészítők</a> havonta kerülnek "
-"kiválasztásra, a <a href=\"%(link_themes)s\">kiemelt teljes témák</a> pedig "
-"negyedévente."
+msgid "<a href=\"%(link_featured)s\">Featured extensions</a> are chosen every month, and <a href=\"%(link_themes)s\">featured complete themes</a> are chosen every quarter."
+msgstr "A <a href=\"%(link_featured)s\">kiemelt kiegészítők</a> havonta kerülnek kiválasztásra, a <a href=\"%(link_themes)s\">kiemelt teljes témák</a> pedig negyedévente."
 
 #: src/olympia/devhub/templates/devhub/docs/policies-recommended.html:30
 msgid "Criteria for Featured Add-ons"
 msgstr "Kiemelt kiegészítők kritériumai"
 
 #: src/olympia/devhub/templates/devhub/docs/policies-recommended.html:33
-msgid ""
-"Before nominating an add-on to be featured, please ensure it meets the "
-"following criteria:"
-msgstr ""
-"Mielőtt kiemeltnek jelöl egy kiegészítőt, kérjük győződjön meg róla, hogy "
-"teljesíti ezeket a feltételeket:"
+msgid "Before nominating an add-on to be featured, please ensure it meets the following criteria:"
+msgstr "Mielőtt kiemeltnek jelöl egy kiegészítőt, kérjük győződjön meg róla, hogy teljesíti ezeket a feltételeket:"
 
 #: src/olympia/devhub/templates/devhub/docs/policies-recommended.html:39
-msgid ""
-"The add-on must have a complete and informative listing on AMO. This means:"
-msgstr ""
-"A kiegészítőnek teljes és informatív AMO jegyzékkel kell rendelkeznie. Ez "
-"ezeket jelenti:"
+msgid "The add-on must have a complete and informative listing on AMO. This means:"
+msgstr "A kiegészítőnek teljes és informatív AMO jegyzékkel kell rendelkeznie. Ez ezeket jelenti:"
 
 #: src/olympia/devhub/templates/devhub/docs/policies-recommended.html:41
 msgid "a 64-pixel custom icon"
@@ -6858,45 +5461,28 @@ msgid "updated screenshots of the add-on's functionality"
 msgstr "frissített képernyőképek a kiegészítő funkcióiról"
 
 #: src/olympia/devhub/templates/devhub/docs/policies-recommended.html:46
-msgid ""
-"must be fully approved by AMO editors (no preliminarily reviewed entries)"
-msgstr ""
-"az AMO szerkesztőinek teljesen el kell fogadniuk (nem lehet előzetesen "
-"értékelt)"
+msgid "must be fully approved by AMO editors (no preliminarily reviewed entries)"
+msgstr "az AMO szerkesztőinek teljesen el kell fogadniuk (nem lehet előzetesen értékelt)"
 
 #: src/olympia/devhub/templates/devhub/docs/policies-recommended.html:48
-msgid ""
-"The add-on must have excellent user reviews and any problems or support "
-"requests must be promptly addressed by the developer."
-msgstr ""
-"A kiegészítőnek kiváló felhasználói értékelésekkel kell rendelkeznie, és "
-"bármilyen problémát időben kell kezelnie a fejlesztőnek."
+msgid "The add-on must have excellent user reviews and any problems or support requests must be promptly addressed by the developer."
+msgstr "A kiegészítőnek kiváló felhasználói értékelésekkel kell rendelkeznie, és bármilyen problémát időben kell kezelnie a fejlesztőnek."
 
 #: src/olympia/devhub/templates/devhub/docs/policies-recommended.html:49
 msgid "The add-on must have a minimum of 2,000 users."
 msgstr "A kiegészítőnek legalább 2.000 felhasználóval kell rendelkeznie."
 
 #: src/olympia/devhub/templates/devhub/docs/policies-recommended.html:50
-msgid ""
-"The add-on must be compatible with the latest release of Firefox and must be"
-" compatible with beta versions 4 weeks before their final release."
-msgstr ""
-"A kiegészítőnek kompatibilisnek kell lennie a legfrissebb Firefox kiadással,"
-" és kompatibilisnek kell lennie a béta verziókkal 4 héttel a végső "
-"megjelenésük előtt."
+msgid "The add-on must be compatible with the latest release of Firefox and must be compatible with beta versions 4 weeks before their final release."
+msgstr "A kiegészítőnek kompatibilisnek kell lennie a legfrissebb Firefox kiadással, és kompatibilisnek kell lennie a béta verziókkal 4 héttel a végső megjelenésük előtt."
 
 #: src/olympia/devhub/templates/devhub/docs/policies-recommended.html:51
 msgid ""
-"<strong>Most importantly</strong>, the add-on must have wide consumer appeal"
-" to Firefox's users and be outstanding in nearly every way: user experience,"
-" performance, security, and usefulness or entertainment value. Featured "
-"complete themes must also be visually appealing."
+"<strong>Most importantly</strong>, the add-on must have wide consumer appeal to Firefox's users and be outstanding in nearly every way: user experience, performance, security, and usefulness or "
+"entertainment value. Featured complete themes must also be visually appealing."
 msgstr ""
-"<strong>A legfontosabb</strong>, a kiegészítőnek széleskörű fogyasztói "
-"vonzereje legyen a Firefox felhasználóinak, és kiemelkedő legyen szinte "
-"mindenben: felhasználói élmény, teljesítmény, biztonság, valamint hasznosság"
-" vagy szórakoztatási érték. A kiemelt teljes témáknak megjelenésükben is "
-"vonzónak kell lenniük."
+"<strong>A legfontosabb</strong>, a kiegészítőnek széleskörű fogyasztói vonzereje legyen a Firefox felhasználóinak, és kiemelkedő legyen szinte mindenben: felhasználói élmény, teljesítmény, "
+"biztonság, valamint hasznosság vagy szórakoztatási érték. A kiemelt teljes témáknak megjelenésükben is vonzónak kell lenniük."
 
 #: src/olympia/devhub/templates/devhub/docs/policies-recommended.html:54
 msgid "Nominating an Add-on"
@@ -6908,39 +5494,25 @@ msgstr "amo-featured kukac mozilla pont org"
 
 #: src/olympia/devhub/templates/devhub/docs/policies-recommended.html:57
 #, python-format
-msgid ""
-"If you wish to nominate an add-on to be featured and it meets the criteria "
-"above, send an email to %(mail_featured)s with:"
-msgstr ""
-"Ha kiemeltnek szeretne jelölni egy kiegészítőt, és megfelel a fenti "
-"követelményeknek, akkor küldjön egy e-mailt az %(mail_featured)s címre a "
-"következőkkel:"
+msgid "If you wish to nominate an add-on to be featured and it meets the criteria above, send an email to %(mail_featured)s with:"
+msgstr "Ha kiemeltnek szeretne jelölni egy kiegészítőt, és megfelel a fenti követelményeknek, akkor küldjön egy e-mailt az %(mail_featured)s címre a következőkkel:"
 
 #: src/olympia/devhub/templates/devhub/docs/policies-recommended.html:62
 msgid "the add-on name, URL, and whether you are its developer"
 msgstr "a kiegészítő neve, URL-je, és hogy Ön-e a fejlesztője"
 
 #: src/olympia/devhub/templates/devhub/docs/policies-recommended.html:63
-msgid ""
-"a short explanation of why the add-on has wide appeal and should be featured"
-msgstr ""
-"egy rövid magyarázat, hogy miért van széleskörű vonzereje és miért kellene "
-"kiemelni"
+msgid "a short explanation of why the add-on has wide appeal and should be featured"
+msgstr "egy rövid magyarázat, hogy miért van széleskörű vonzereje és miért kellene kiemelni"
 
 #: src/olympia/devhub/templates/devhub/docs/policies-recommended.html:64
-msgid ""
-"optionally, links to any external reviews or articles mentioning the add-on"
-msgstr ""
-"választhatóan, hivatkozások külső értékelésekre és cikkekre, amelyek említik"
-" a kiegészítők"
+msgid "optionally, links to any external reviews or articles mentioning the add-on"
+msgstr "választhatóan, hivatkozások külső értékelésekre és cikkekre, amelyek említik a kiegészítők"
 
 #: src/olympia/devhub/templates/devhub/docs/policies-recommended.html:68
 msgid ""
-"Add-on nominations are reviewed by the Advisory Board once a month (once "
-"every 3 months for complete theme nominations). Common reasons for rejection"
-" include lacking wide appeal to consumers, a suboptimal user experience, "
-"quality or security issues, incompatibility, and similarity to another "
-"featured add-on. Rejected add-ons cannot be re-nominated within 3 months."
+"Add-on nominations are reviewed by the Advisory Board once a month (once every 3 months for complete theme nominations). Common reasons for rejection include lacking wide appeal to consumers, a "
+"suboptimal user experience, quality or security issues, incompatibility, and similarity to another featured add-on. Rejected add-ons cannot be re-nominated within 3 months."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/docs/policies-recommended.html:73
@@ -6948,185 +5520,119 @@ msgid "Rotating Featured Add-ons"
 msgstr "Kiemelt kiegészítők forgatása"
 
 #: src/olympia/devhub/templates/devhub/docs/policies-recommended.html:76
-msgid ""
-"Mozilla and the Featured Add-ons Advisory Board regularly evaluate and "
-"rotate out featured add-ons. Some of the most common reasons for add-ons "
-"being removed from the featured list are:"
-msgstr ""
-"A Mozilla és a Kiemelt Kiegészítők Tanácsadói Testület rendszeresen értékeli"
-" és forgatja a kiemelt kiegészítőket. A leggyakoribb okai a kiegészítők "
-"eltávolításának a kiemeltek közül a következőek:"
+msgid "Mozilla and the Featured Add-ons Advisory Board regularly evaluate and rotate out featured add-ons. Some of the most common reasons for add-ons being removed from the featured list are:"
+msgstr "A Mozilla és a Kiemelt Kiegészítők Tanácsadói Testület rendszeresen értékeli és forgatja a kiemelt kiegészítőket. A leggyakoribb okai a kiegészítők eltávolításának a kiemeltek közül a következőek:"
 
 #: src/olympia/devhub/templates/devhub/docs/policies-recommended.html:83
 msgid ""
-"Lack of growth &mdash; Add-ons that are featured typically experience a "
-"substantial gain in both downloads and active users. If an add-on is not "
-"demonstrating growth in any substantial way, that's a good indicator the "
-"add-on may not be very useful to our users."
+"Lack of growth &mdash; Add-ons that are featured typically experience a substantial gain in both downloads and active users. If an add-on is not demonstrating growth in any substantial way, that's "
+"a good indicator the add-on may not be very useful to our users."
 msgstr ""
-"Növekedés hiánya &mdash; A kiemelt kiegészítők jellemzően jelentősen nőnek "
-"mind letöltésekben, mind aktív felhasználókban. Ha egy kiegészítő nem "
-"növekszik lényeges mértékeben, az egy jó jelzése annak, hogy a kiegészítő "
-"nem nagyon hasznos a felhasználóinknak."
+"Növekedés hiánya &mdash; A kiemelt kiegészítők jellemzően jelentősen nőnek mind letöltésekben, mind aktív felhasználókban. Ha egy kiegészítő nem növekszik lényeges mértékeben, az egy jó jelzése "
+"annak, hogy a kiegészítő nem nagyon hasznos a felhasználóinknak."
 
 #: src/olympia/devhub/templates/devhub/docs/policies-recommended.html:88
-msgid ""
-"Negative reviews &mdash; Featured add-ons should have a great experience and"
-" very few bugs, so add-ons with many negative reviews may be reconsidered."
+msgid "Negative reviews &mdash; Featured add-ons should have a great experience and very few bugs, so add-ons with many negative reviews may be reconsidered."
 msgstr ""
-"Negatív értékelések &mdash; A kiemelt kiegészítőnek nagyszerű felhasználói "
-"élménnyel kell rendelkezniük, és kevés hibával, így a sok negatív "
-"értékeléssel rendelkező kiegészítők esetén megfontolhatjuk az "
-"eltávolításukat."
+"Negatív értékelések &mdash; A kiemelt kiegészítőnek nagyszerű felhasználói élménnyel kell rendelkezniük, és kevés hibával, így a sok negatív értékeléssel rendelkező kiegészítők esetén "
+"megfontolhatjuk az eltávolításukat."
 
 #: src/olympia/devhub/templates/devhub/docs/policies-recommended.html:93
 msgid ""
-"Incompatibility with upcoming Firefox versions &mdash; Featured add-ons are "
-"expected to be compatible with stable and beta versions of Firefox. Add-ons "
-"not yet compatible with a Beta version of Firefox four weeks before its "
-"expected release will lose their featured status."
+"Incompatibility with upcoming Firefox versions &mdash; Featured add-ons are expected to be compatible with stable and beta versions of Firefox. Add-ons not yet compatible with a Beta version of "
+"Firefox four weeks before its expected release will lose their featured status."
 msgstr ""
-"Inkompatibilitás a Firefox következő verzióival &mdash; A kiemelt "
-"kiegészítőktől elvárt a Firefox stabil és béta verzióival való "
-"kompatibilitás. Azok a kiegészítők, melyek nem kompatibilisek a Firefox Béta"
-" verziójával a várt kiadás előtt négy héttel, elveszítik a kiemelt "
-"státuszukat."
+"Inkompatibilitás a Firefox következő verzióival &mdash; A kiemelt kiegészítőktől elvárt a Firefox stabil és béta verzióival való kompatibilitás. Azok a kiegészítők, melyek nem kompatibilisek a "
+"Firefox Béta verziójával a várt kiadás előtt négy héttel, elveszítik a kiemelt státuszukat."
 
 #: src/olympia/devhub/templates/devhub/docs/policies-recommended.html:99
 msgid "Joining the Featured Add-ons Advisory Board"
 msgstr "Csatlakozás a Kiemelt Kiegészítők Tanácsadói Testülethez"
 
 #: src/olympia/devhub/templates/devhub/docs/policies-recommended.html:102
-msgid ""
-"Every six months a new Advisory Board is chosen based on applications from "
-"the add-ons community. Members must:"
-msgstr ""
-"Hat havonta új tanácsadói testület kerül kiválasztásra a közösségéből. A "
-"tagoknak:"
+msgid "Every six months a new Advisory Board is chosen based on applications from the add-ons community. Members must:"
+msgstr "Hat havonta új tanácsadói testület kerül kiválasztásra a közösségéből. A tagoknak:"
 
 #: src/olympia/devhub/templates/devhub/docs/policies-recommended.html:108
-msgid ""
-"be active members of the add-ons community, whether as a developer, "
-"evangelist, or fan"
-msgstr ""
-"aktív tagoknak kell lenniük a közösségben, fejlesztőként, evangelistaként "
-"vagy rajongóként"
+msgid "be active members of the add-ons community, whether as a developer, evangelist, or fan"
+msgstr "aktív tagoknak kell lenniük a közösségben, fejlesztőként, evangelistaként vagy rajongóként"
 
 #: src/olympia/devhub/templates/devhub/docs/policies-recommended.html:109
-msgid ""
-"commit to trying all the nominations submitted, giving their feedback, and "
-"casting their votes every month"
-msgstr ""
-"ki kell próbálniuk minden beküldött jelöltet, visszajelzést adniuk, és "
-"szavazni minden hónapban"
+msgid "commit to trying all the nominations submitted, giving their feedback, and casting their votes every month"
+msgstr "ki kell próbálniuk minden beküldött jelöltet, visszajelzést adniuk, és szavazni minden hónapban"
 
 #: src/olympia/devhub/templates/devhub/docs/policies-recommended.html:110
-msgid ""
-"abstain from voting on add-ons that they have any business or personal "
-"affiliations with, as well as direct competitors of any such add-ons"
-msgstr ""
-"nem szabad szavazniuk olyan kiegészítőkre, melyekkel üzleti vagy személyes "
-"kapcsolódásuk van, valamint közvetlen versenytársakra sem"
+msgid "abstain from voting on add-ons that they have any business or personal affiliations with, as well as direct competitors of any such add-ons"
+msgstr "nem szabad szavazniuk olyan kiegészítőkre, melyekkel üzleti vagy személyes kapcsolódásuk van, valamint közvetlen versenytársakra sem"
 
 #: src/olympia/devhub/templates/devhub/docs/policies-recommended.html:114
 msgid ""
-"Members of the Mozilla Add-ons team may veto any add-on's selection because "
-"of security, privacy, compatibility, or any other reason, but in general it "
-"is up to the Board to select add-ons to feature."
+"Members of the Mozilla Add-ons team may veto any add-on's selection because of security, privacy, compatibility, or any other reason, but in general it is up to the Board to select add-ons to "
+"feature."
 msgstr ""
-"A Mozilla Kiegészítők csapat megvétózhatja bármelyik kiegészítő "
-"kiválasztását, biztonsági, magánszféra, kompatibilitási vagy bármilyen más "
-"okból, de általánosságban a testület választja ki a kiemelendő "
-"kiegészítőket."
+"A Mozilla Kiegészítők csapat megvétózhatja bármelyik kiegészítő kiválasztását, biztonsági, magánszféra, kompatibilitási vagy bármilyen más okból, de általánosságban a testület választja ki a "
+"kiemelendő kiegészítőket."
 
 #: src/olympia/devhub/templates/devhub/docs/policies-recommended.html:120
 msgid ""
-"This featured policy only applies to the addons.mozilla.org global list of "
-"featured add-ons. Add-ons featured in other locations are often pulled from "
-"this list, but Mozilla may feature any add-on in other locations without the"
-" Board's consent. Additionally, locale-specific features override the global"
-" defaults, so if a locale has opted to select its own features, some or all "
-"of the global features may not appear in that locale."
+"This featured policy only applies to the addons.mozilla.org global list of featured add-ons. Add-ons featured in other locations are often pulled from this list, but Mozilla may feature any add-on "
+"in other locations without the Board's consent. Additionally, locale-specific features override the global defaults, so if a locale has opted to select its own features, some or all of the global "
+"features may not appear in that locale."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/docs/policies-recommended.html:126
 #, python-format
-msgid ""
-"Follow the <a href=\"%(link_blog)s\">Add-ons Blog</a> or <a "
-"href=\"%(link_twitter)s\">@mozamo</a> on Twitter to learn when the next "
-"application period opens."
-msgstr ""
-"Kövesse a <a href=\"%(link_blog)s\">Kiegészítők Blogot</a> vagy a <a "
-"href=\"%(link_twitter)s\">@mozamo</a>-t a Twitteren, hogy értesüljön róla, "
-"mikor nyit a következő jelölési időszak."
+msgid "Follow the <a href=\"%(link_blog)s\">Add-ons Blog</a> or <a href=\"%(link_twitter)s\">@mozamo</a> on Twitter to learn when the next application period opens."
+msgstr "Kövesse a <a href=\"%(link_blog)s\">Kiegészítők Blogot</a> vagy a <a href=\"%(link_twitter)s\">@mozamo</a>-t a Twitteren, hogy értesüljön róla, mikor nyit a következő jelölési időszak."
 
 #: src/olympia/devhub/templates/devhub/docs/policies-recommended.html:131
 msgid "Last updated: January 31, 2013"
 msgstr "Utolsó frissítés: 2013. január 31."
 
-#: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:3
-#: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:7
-#: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:8
-#: src/olympia/devhub/templates/devhub/docs/policies.html:15
-#: src/olympia/devhub/templates/devhub/docs/policies.html:64
+#: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:3 src/olympia/devhub/templates/devhub/docs/policies-reviews.html:7 src/olympia/devhub/templates/devhub/docs/policies-reviews.html:8
+#: src/olympia/devhub/templates/devhub/docs/policies.html:15 src/olympia/devhub/templates/devhub/docs/policies.html:64
 msgid "Review Process"
 msgstr "Értékelési folyamat"
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:12
 msgid ""
-"In order to ensure all add-ons hosted in our gallery are safe for users to "
-"install, Mozilla will begin requiring all hosted add-ons to undergo review. "
-"We offer two types of review and developers are free to choose the best fit "
-"for their add-on."
+"In order to ensure all add-ons hosted in our gallery are safe for users to install, Mozilla will begin requiring all hosted add-ons to undergo review. We offer two types of review and developers "
+"are free to choose the best fit for their add-on."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:19
 msgid ""
-"<strong><a href=\"#full\">Full Review</a></strong> &mdash; a thorough "
-"functional and code review of the add-on, appropriate for add-ons ready for "
-"distribution to the masses. All site features are available to these add-"
-"ons."
+"<strong><a href=\"#full\">Full Review</a></strong> &mdash; a thorough functional and code review of the add-on, appropriate for add-ons ready for distribution to the masses. All site features are "
+"available to these add-ons."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:24
 msgid ""
-"<strong><a href=\"#preliminary\">Preliminary Review</a></strong> &mdash; a "
-"faster review intended for experimental add-ons. Preliminary reviews do not "
-"check for functionality or full policy compliance, but the reviewed add-ons "
-"have install button cautions and some feature limitations."
+"<strong><a href=\"#preliminary\">Preliminary Review</a></strong> &mdash; a faster review intended for experimental add-ons. Preliminary reviews do not check for functionality or full policy "
+"compliance, but the reviewed add-ons have install button cautions and some feature limitations."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:31
 msgid ""
-"Detailed descriptions of each option are below. After selecting a review "
-"process at submission, the add-on will be placed in the queue. Add-ons are "
-"reviewed by the <a href=\"https://wiki.mozilla.org/AMO:Editors\">AMO "
-"Editors</a>, a group of talented developers that volunteer to help the "
-"Mozilla project by reviewing add-ons to ensure a stable and safe experience "
-"for users. Developers will receive an email with any updates throughout the "
-"review process."
+"Detailed descriptions of each option are below. After selecting a review process at submission, the add-on will be placed in the queue. Add-ons are reviewed by the <a "
+"href=\"https://wiki.mozilla.org/AMO:Editors\">AMO Editors</a>, a group of talented developers that volunteer to help the Mozilla project by reviewing add-ons to ensure a stable and safe experience "
+"for users. Developers will receive an email with any updates throughout the review process."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:37
 msgid ""
-"While waiting for review, add-ons will not appear anywhere in the gallery "
-"publicly, but direct links to the add-on's details page will work. This "
-"allows the author to blog or share the link with friends, inviting them to "
-"try it out, even when not yet reviewed."
+"While waiting for review, add-ons will not appear anywhere in the gallery publicly, but direct links to the add-on's details page will work. This allows the author to blog or share the link with "
+"friends, inviting them to try it out, even when not yet reviewed."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:44
 msgid ""
-"Full reviews are appropriate for add-ons that are well-tested, stable, fast,"
-" and have wide appeal to our users. If you aren't confident that your add-on"
-" meets that criteria, please consider working out the kinks while in "
-"preliminary review and accumulating user feedback first."
+"Full reviews are appropriate for add-ons that are well-tested, stable, fast, and have wide appeal to our users. If you aren't confident that your add-on meets that criteria, please consider working"
+" out the kinks while in preliminary review and accumulating user feedback first."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:50
-msgid ""
-"We aim to perform full reviews in under 10 days, though most add-ons are "
-"reviewed in much less time."
+msgid "We aim to perform full reviews in under 10 days, though most add-ons are reviewed in much less time."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:55
@@ -7138,58 +5644,36 @@ msgid "When performing a full review, editors will:"
 msgstr "Teljes értékeléskor a szerkesztők a következőket teszik:"
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:64
-msgid ""
-"install the add-on, making sure it functions as described and is free of "
-"major defects"
-msgstr ""
-"feltelepítik a kiegészítőt, meggyőződve arról hogy a leírás szerint működik,"
-" és nagyobb hibáktól mentes"
+msgid "install the add-on, making sure it functions as described and is free of major defects"
+msgstr "feltelepítik a kiegészítőt, meggyőződve arról hogy a leírás szerint működik, és nagyobb hibáktól mentes"
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:69
-msgid ""
-"perform a source code review, looking for performance and security best "
-"practices"
-msgstr ""
-"értékelik a forráskódot, teljesítmény és biztonsági megfontolások alapján"
+msgid "perform a source code review, looking for performance and security best practices"
+msgstr "értékelik a forráskódot, teljesítmény és biztonsági megfontolások alapján"
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:74
 msgid "ensure the add-on's privacy policy is in line with its functionality"
-msgstr ""
-"meggyőződnek arról, hogy a kiegészítő adatvédelmi nyilatkozata összhangban "
-"van a funkcionalitással"
+msgstr "meggyőződnek arról, hogy a kiegészítő adatvédelmi nyilatkozata összhangban van a funkcionalitással"
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:79
-msgid ""
-"look for compliance with all of Mozilla's policies, detailed in these "
-"documents"
-msgstr ""
-"ellenőrzik a megfelelést a Mozilla házirendjeivel, amelyek ezekben a "
-"dokumentumokban vannak részletezve"
+msgid "look for compliance with all of Mozilla's policies, detailed in these documents"
+msgstr "ellenőrzik a megfelelést a Mozilla házirendjeivel, amelyek ezekben a dokumentumokban vannak részletezve"
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:86
-msgid ""
-"Some of the most common issues we see when performing these reviews are:"
+msgid "Some of the most common issues we see when performing these reviews are:"
 msgstr "A néhány leggyakoribb probléma amit ezen értékelések alatt látunk:"
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:93
 msgid ""
-"<strong>JavaScript namespace pollution</strong> &mdash; the most common "
-"violation. Be sure to <a "
-"href=\"https://developer.mozilla.org/en/XUL_School/JavaScript_Object_Management\">wrap"
-" your loose variables</a>"
+"<strong>JavaScript namespace pollution</strong> &mdash; the most common violation. Be sure to <a href=\"https://developer.mozilla.org/en/XUL_School/JavaScript_Object_Management\">wrap your loose "
+"variables</a>"
 msgstr ""
-"<strong>JavaScript névtér szennyezés</strong> &mdash; a leggyakoribb "
-"kihágás. Győződjön meg arról, hogy <a "
-"href=\"https://developer.mozilla.org/en/XUL_School/JavaScript_Object_Management\">becsomagolja"
-" a laza változóit</a>"
+"<strong>JavaScript névtér szennyezés</strong> &mdash; a leggyakoribb kihágás. Győződjön meg arról, hogy <a "
+"href=\"https://developer.mozilla.org/en/XUL_School/JavaScript_Object_Management\">becsomagolja a laza változóit</a>"
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:99
-msgid ""
-"proper preference naming - all preference names should begin with "
-"\"extensions.\", followed by the add-on name or some other unique identifier"
-msgstr ""
-"helyes beállításelnevezés – minden beállításnév „extension.”-tal kell "
-"kezdődjön, a kiegészítő nevével vagy más egyedi azonosítóval követve"
+msgid "proper preference naming - all preference names should begin with \"extensions.\", followed by the add-on name or some other unique identifier"
+msgstr "helyes beállításelnevezés – minden beállításnév „extension.”-tal kell kezdődjön, a kiegészítő nevével vagy más egyedi azonosítóval követve"
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:103
 msgid "remote JavaScript execution or injection"
@@ -7234,73 +5718,51 @@ msgstr "alkalmazás indítási vagy oldalbetöltési teljesítmény csökkenés"
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:117
 #, python-format
 msgid ""
-"For information on how to avoid these problems, please see our <a "
-"href=\"%(link_howto)s\">How-to Library</a>. Some of these practices, such as"
-" binary or obfuscated code, are allowed under certain conditions outlined "
-"below."
+"For information on how to avoid these problems, please see our <a href=\"%(link_howto)s\">How-to Library</a>. Some of these practices, such as binary or obfuscated code, are allowed under certain "
+"conditions outlined below."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:123
 #, python-format
 msgid ""
-"Many of the above restrictions are tested automatically by an extension "
-"scanner that will flag suspicious add-ons for editor review. You can read "
-"more about this scanner in the <a href=\"%(link_validation)s\">Validation "
-"Help</a> document."
+"Many of the above restrictions are tested automatically by an extension scanner that will flag suspicious add-ons for editor review. You can read more about this scanner in the <a "
+"href=\"%(link_validation)s\">Validation Help</a> document."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:129
 msgid ""
-"If the add-on is site-specific, it is recommended that a test account is "
-"provided for use during the review process. Additionally, including detailed"
-" testing instructions will allow an editor to better understand how the add-"
-"on functions and expedite the testing process. This information can be "
-"placed in the Notes to Reviewer field when editing a version in the "
-"Developer Hub."
+"If the add-on is site-specific, it is recommended that a test account is provided for use during the review process. Additionally, including detailed testing instructions will allow an editor to "
+"better understand how the add-on functions and expedite the testing process. This information can be placed in the Notes to Reviewer field when editing a version in the Developer Hub."
 msgstr ""
-"Ha a kiegészítő oldalspecifikus, ajánlott megadni egy tesztfiókot az "
-"értékelési folyamathoz. Továbbá, a megadott részletes tesztelési utasítások "
-"segítenek a szerkesztőnek jobban megértenie, hogy hogyan működik a "
-"kiegészítő, és gyorsítja a tesztelési folyamatot. Ez az információ a "
-"„Megjegyzések az értékelőnek” mezőbe helyezhető, amikor egy verziót "
-"szerkeszt a fejlesztőközpontban."
+"Ha a kiegészítő oldalspecifikus, ajánlott megadni egy tesztfiókot az értékelési folyamathoz. Továbbá, a megadott részletes tesztelési utasítások segítenek a szerkesztőnek jobban megértenie, hogy "
+"hogyan működik a kiegészítő, és gyorsítja a tesztelési folyamatot. Ez az információ a „Megjegyzések az értékelőnek” mezőbe helyezhető, amikor egy verziót szerkeszt a fejlesztőközpontban."
 
-#: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:134
-#: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:168
+#: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:134 src/olympia/devhub/templates/devhub/docs/policies-reviews.html:168
 msgid "After the Review"
 msgstr "Az értékelés után"
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:136
 msgid ""
-"Once an add-on is granted full review, it will immediately be available in "
-"the gallery, showing in browse and search results with a warning-free "
-"install button. All features, including voluntary contributions and beta "
-"channels will be available."
+"Once an add-on is granted full review, it will immediately be available in the gallery, showing in browse and search results with a warning-free install button. All features, including voluntary "
+"contributions and beta channels will be available."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:142
 msgid ""
-"Subsequent versions of the add-on will automatically be placed in the full "
-"review queue. Until the review is completed, the new version will only be "
-"displayed on the Version History page of the add-on. Once reviewed, the "
-"version will be updated across the site and deployed through the automatic "
-"update service."
+"Subsequent versions of the add-on will automatically be placed in the full review queue. Until the review is completed, the new version will only be displayed on the Version History page of the "
+"add-on. Once reviewed, the version will be updated across the site and deployed through the automatic update service."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:148
 msgid ""
-"If a version does not meet the criteria for full review, it can either be "
-"granted preliminary review or disabled if there is a security concern. The "
-"author will receive an email explaining the action taken and how to fix it. "
-"In most cases, the developer can simply fix the problem and re-submit for "
-"full review."
+"If a version does not meet the criteria for full review, it can either be granted preliminary review or disabled if there is a security concern. The author will receive an email explaining the "
+"action taken and how to fix it. In most cases, the developer can simply fix the problem and re-submit for full review."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:155
 msgid ""
-"Preliminary reviews are appropriate for experimental add-ons and provide a "
-"way to get user testing and feedback without going through the longer, more "
-"thorough review process. We aim to complete these reviews in under 3 days."
+"Preliminary reviews are appropriate for experimental add-ons and provide a way to get user testing and feedback without going through the longer, more thorough review process. We aim to complete "
+"these reviews in under 3 days."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:160
@@ -7309,36 +5771,25 @@ msgstr "Tesztelési módszerek"
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:162
 msgid ""
-"When performing a preliminary review, editors will review the source code "
-"for security issues and major policy violations, but will not install the "
-"add-on to test functionality in most cases. Preliminary review will be "
-"granted unless a security vulnerability or major policy violation is "
-"discovered."
+"When performing a preliminary review, editors will review the source code for security issues and major policy violations, but will not install the add-on to test functionality in most cases. "
+"Preliminary review will be granted unless a security vulnerability or major policy violation is discovered."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:171
 msgid ""
-"Once preliminary review is granted, the add-on will be immediately available"
-" in the gallery, showing in browse and search results but ranked lower than "
-"fully-reviewed add-ons. Install buttons will have caution stripes and a "
-"notice that the add-on is experimental and not fully reviewed by Mozilla, "
-"though no click-through is required. Additionally, these add-ons cannot use "
-"the voluntary contributions and beta channel features."
+"Once preliminary review is granted, the add-on will be immediately available in the gallery, showing in browse and search results but ranked lower than fully-reviewed add-ons. Install buttons will "
+"have caution stripes and a notice that the add-on is experimental and not fully reviewed by Mozilla, though no click-through is required. Additionally, these add-ons cannot use the voluntary "
+"contributions and beta channel features."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:177
-msgid ""
-"After being granted preliminary review, Mozilla may later revoke the review "
-"if other serious problems are reported to us by users."
+msgid "After being granted preliminary review, Mozilla may later revoke the review if other serious problems are reported to us by users."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:183
 msgid ""
-"Subsequent versions of the add-on will automatically be placed in the "
-"preliminary review queue. Until the review is completed, the new version "
-"will only be displayed on the Version History page of the add-on. Once "
-"reviewed, the version will be updated across the site and deployed through "
-"the automatic update service."
+"Subsequent versions of the add-on will automatically be placed in the preliminary review queue. Until the review is completed, the new version will only be displayed on the Version History page of "
+"the add-on. Once reviewed, the version will be updated across the site and deployed through the automatic update service."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:188
@@ -7354,64 +5805,36 @@ msgid "The following add-ons are not permitted in any form:"
 msgstr "A következő kiegészítők minden formában tiltottak:"
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:194
-msgid ""
-"Add-ons that embed known <a "
-"href=\"http://en.wikipedia.org/wiki/Spyware\">spyware</a> or <a "
-"href=\"http://en.wikipedia.org/wiki/Malware\">malware</a>"
-msgstr ""
-"Kiegészítők, melyek ismert <a "
-"href=\"http://en.wikipedia.org/wiki/Spyware\">kémprogramokat</a> vagy <a "
-"href=\"http://en.wikipedia.org/wiki/Malware\">ártalmas kódot</a> "
-"tartalmaznak"
+msgid "Add-ons that embed known <a href=\"http://en.wikipedia.org/wiki/Spyware\">spyware</a> or <a href=\"http://en.wikipedia.org/wiki/Malware\">malware</a>"
+msgstr "Kiegészítők, melyek ismert <a href=\"http://en.wikipedia.org/wiki/Spyware\">kémprogramokat</a> vagy <a href=\"http://en.wikipedia.org/wiki/Malware\">ártalmas kódot</a> tartalmaznak"
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:199
 msgid ""
-"Illegal and criminal add-ons, such as <a "
-"href=\"http://en.wikipedia.org/wiki/Click_fraud\">click fraud</a> "
-"generators, <a href=\"http://en.wikipedia.org/wiki/Warez\">warez</a> "
-"download and directory assistants, child pornography finders, etc."
+"Illegal and criminal add-ons, such as <a href=\"http://en.wikipedia.org/wiki/Click_fraud\">click fraud</a> generators, <a href=\"http://en.wikipedia.org/wiki/Warez\">warez</a> download and "
+"directory assistants, child pornography finders, etc."
 msgstr ""
-"Illegális és bűnöző kiegészítők, például <a "
-"href=\"http://en.wikipedia.org/wiki/Click_fraud\">kattintási csalás</a> "
-"generátorok, <a href=\"http://en.wikipedia.org/wiki/Warez\">warez</a> "
-"letöltések és keresők, gyermekpornográfia keresők, stb."
+"Illegális és bűnöző kiegészítők, például <a href=\"http://en.wikipedia.org/wiki/Click_fraud\">kattintási csalás</a> generátorok, <a href=\"http://en.wikipedia.org/wiki/Warez\">warez</a> letöltések "
+"és keresők, gyermekpornográfia keresők, stb."
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:204
-msgid ""
-"Add-ons whose main purpose is to facilitate access to pornographic material,"
-" or include references to this material in their descriptions"
-msgstr ""
-"Kiegészítők, melyek fő célja pornográf tartalomhoz hozzáférés, vagy utalás "
-"ilyen tartalomra a leírásban"
+msgid "Add-ons whose main purpose is to facilitate access to pornographic material, or include references to this material in their descriptions"
+msgstr "Kiegészítők, melyek fő célja pornográf tartalomhoz hozzáférés, vagy utalás ilyen tartalomra a leírásban"
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:210
-msgid ""
-"Add-ons that, upon installation, auto-install or launch installers of non-"
-"Firefox software"
-msgstr ""
-"Kiegészítők, melyek telepítéskor, automatikusan, vagy varázslón keresztül "
-"telepítenek nem-Firefox szoftvert."
+msgid "Add-ons that, upon installation, auto-install or launch installers of non-Firefox software"
+msgstr "Kiegészítők, melyek telepítéskor, automatikusan, vagy varázslón keresztül telepítenek nem-Firefox szoftvert."
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:215
-msgid ""
-"Add-ons that provide their own update mechanism for code or search engines"
-msgstr ""
-"Kiegészítők, melyek saját kód- vagy keresőmotor frissítési mechanizmust "
-"tartalmaznak"
+msgid "Add-ons that provide their own update mechanism for code or search engines"
+msgstr "Kiegészítők, melyek saját kód- vagy keresőmotor frissítési mechanizmust tartalmaznak"
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:220
-msgid ""
-"Add-ons that make changes to web content in ways that are non-obvious or "
-"difficult to trace by their users"
-msgstr ""
-"Kiegészítők, melyek oly módon módosítják a webes tartalmat, amely nem "
-"egyértelmű vagy nehezen követhető a felhasználó által"
+msgid "Add-ons that make changes to web content in ways that are non-obvious or difficult to trace by their users"
+msgstr "Kiegészítők, melyek oly módon módosítják a webes tartalmat, amely nem egyértelmű vagy nehezen követhető a felhasználó által"
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:225
 msgid "Add-ons that snoop on or intercept the network traffic of other users"
-msgstr ""
-"Kiegészítők, melyek követik vagy elfogják más felhasználók hálózati "
-"forgalmát"
+msgstr "Kiegészítők, melyek követik vagy elfogják más felhasználók hálózati forgalmát"
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:230
 msgid "Conduit-based toolbars without explicit pre-approval"
@@ -7423,47 +5846,28 @@ msgstr "Alapértelmezések módosítása vagy váratlan funkciók"
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:238
 msgid ""
-"Surprises can be appropriate in many situations, but they are not welcome "
-"when user security, privacy, and control are at stake. It is extremely "
-"important to be as transparent as possible when submitting an add-on for "
-"hosting on this site. A Mozilla user should be able to easily discern what "
-"the functionality of an add-on is and not be presented with unexpected "
-"experiences post-install."
+"Surprises can be appropriate in many situations, but they are not welcome when user security, privacy, and control are at stake. It is extremely important to be as transparent as possible when "
+"submitting an add-on for hosting on this site. A Mozilla user should be able to easily discern what the functionality of an add-on is and not be presented with unexpected experiences post-install."
 msgstr ""
-"A meglepetések sokszor megfelelőek lehetnek, de nem szívesen látottak, ha "
-"felhasználó biztonsága, magánszférája vagy irányítása forog kockán. "
-"Rendkívül fontos hogy olyan transzparens legyen, amennyire csak lehetséges a"
-" kiegészítő benyújtásakor erre az oldalra. Egy Mozilla felhasználónak "
-"könnyen el kell tudnia döntenie, hogy mi a kiegészítő funkciója, és nem "
-"szabad telepítés után váratlan tapasztalatokkal szembesülnie."
+"A meglepetések sokszor megfelelőek lehetnek, de nem szívesen látottak, ha felhasználó biztonsága, magánszférája vagy irányítása forog kockán. Rendkívül fontos hogy olyan transzparens legyen, "
+"amennyire csak lehetséges a kiegészítő benyújtásakor erre az oldalra. Egy Mozilla felhasználónak könnyen el kell tudnia döntenie, hogy mi a kiegészítő funkciója, és nem szabad telepítés után "
+"váratlan tapasztalatokkal szembesülnie."
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:243
 msgid ""
-"<p> Whenever an add-on includes any unexpected* feature that </p> <ul> "
-"<li>compromises user privacy or security (like sending data to third "
-"parties),</li> <li>changes default settings like the homepage or search "
-"engine, or</li> <li>changes settings or features in other add-ons or "
-"deactivates them altogether</li> </ul> <p>the features must adhere to the "
-"following requirements:</p> <ul> <li>The add-on description must clearly "
-"state what changes the add-on makes.</li> <li>All changes must be opt-in, "
-"meaning the user must take non-default action to enact the change.</li> "
-"<li>The opt-in dialog must clearly state the name of the add-on requesting "
-"the change.</li> <li>Uninstalling the add-on restores the user's original "
-"settings if they were changed.</li> </ul> <p>*Unexpected features are those "
-"that are unrelated to the add-on's primary function.</p>"
+"<p> Whenever an add-on includes any unexpected* feature that </p> <ul> <li>compromises user privacy or security (like sending data to third parties),</li> <li>changes default settings like the "
+"homepage or search engine, or</li> <li>changes settings or features in other add-ons or deactivates them altogether</li> </ul> <p>the features must adhere to the following requirements:</p> <ul> "
+"<li>The add-on description must clearly state what changes the add-on makes.</li> <li>All changes must be opt-in, meaning the user must take non-default action to enact the change.</li> <li>The "
+"opt-in dialog must clearly state the name of the add-on requesting the change.</li> <li>Uninstalling the add-on restores the user's original settings if they were changed.</li> </ul> <p>*Unexpected"
+" features are those that are unrelated to the add-on's primary function.</p>"
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:268
-msgid ""
-"These features cannot be introduced into an update of a fully-reviewed add-"
-"on; the opt-in change process must be part of the initial review."
+msgid "These features cannot be introduced into an update of a fully-reviewed add-on; the opt-in change process must be part of the initial review."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:274
-msgid ""
-"These are minimum requirements and not a guarantee that the add-on will be "
-"approved. This section applies to all add-ons hosted on the site, including "
-"preliminarily reviewed add-ons."
+msgid "These are minimum requirements and not a guarantee that the add-on will be approved. This section applies to all add-ons hosted on the site, including preliminarily reviewed add-ons."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:279
@@ -7472,11 +5876,8 @@ msgstr "Privát böngészés"
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:282
 msgid ""
-"Add-ons that store or otherwise handle browsing data must support <a "
-"href=\"https://developer.mozilla.org/En/Supporting_private_browsing_mode\">Private"
-" Browsing Mode</a>.  During a Private Browsing session, no browsing data can"
-" be written to disk, and all of this data must be cleared when Firefox quits"
-" or the Private Browsing session ends."
+"Add-ons that store or otherwise handle browsing data must support <a href=\"https://developer.mozilla.org/En/Supporting_private_browsing_mode\">Private Browsing Mode</a>. During a Private Browsing "
+"session, no browsing data can be written to disk, and all of this data must be cleared when Firefox quits or the Private Browsing session ends."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:287
@@ -7485,42 +5886,25 @@ msgstr "Bináris összetevők és olvashatatlan kódok"
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:289
 msgid ""
-"Add-ons may contain binary, obfuscated and minified source code, but Mozilla"
-" must be allowed to review a copy of the human-readable source code of each "
-"version of an add-on submitted for review. These add-ons are ineligible for "
-"preliminary review and must choose the full review process."
+"Add-ons may contain binary, obfuscated and minified source code, but Mozilla must be allowed to review a copy of the human-readable source code of each version of an add-on submitted for review. "
+"These add-ons are ineligible for preliminary review and must choose the full review process."
 msgstr ""
-"A kiegészítők tartalmazhatnak bináris, olvashatatlanná tett és minimalizált "
-"forráskódot, de a Mozilla számára engedélyezni kell, hogy megvizsgálja az "
-"értékelésre küldött kiegészítő minden verziójának ember által olvasható "
-"forráskódjából egy másolatot. Ezek a kiegészítők nem fogadhatók el az "
-"előzetes értékelésen, hanem a teljes értékelési folyamatot kell választani."
+"A kiegészítők tartalmazhatnak bináris, olvashatatlanná tett és minimalizált forráskódot, de a Mozilla számára engedélyezni kell, hogy megvizsgálja az értékelésre küldött kiegészítő minden "
+"verziójának ember által olvasható forráskódjából egy másolatot. Ezek a kiegészítők nem fogadhatók el az előzetes értékelésen, hanem a teljes értékelési folyamatot kell választani."
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:295
 msgid ""
-"If an add-on contains binary or obfuscated source code, the author will "
-"receive a message when the add-on is reviewed indicating whom to contact at "
-"Mozilla to coordinate review of the source code. This code will be reviewed "
-"by an administrator and will not be shared or redistributed in any way. The "
-"code will only be used for the purpose of reviewing the add-on."
+"If an add-on contains binary or obfuscated source code, the author will receive a message when the add-on is reviewed indicating whom to contact at Mozilla to coordinate review of the source code. "
+"This code will be reviewed by an administrator and will not be shared or redistributed in any way. The code will only be used for the purpose of reviewing the add-on."
 msgstr ""
-"Ha egy kiegészítő bináris vagy olvashatatlanná tett forráskódot tartalmaz, a"
-" szerző a kiegészítő értékelése után egy üzenetet kap, mely jelzi, hogy a "
-"forráskód értékelésével kapcsolatosan kivel vegye fel a kapcsolatot a "
-"Mozillánál. Ezt a kódot megvizsgálja egy adminisztrátor, de nem lesz "
-"megosztva vagy közzétéve semmilyen módon. A kódot kizárólag a kiegészítő "
-"értékeléséhez használjuk."
+"Ha egy kiegészítő bináris vagy olvashatatlanná tett forráskódot tartalmaz, a szerző a kiegészítő értékelése után egy üzenetet kap, mely jelzi, hogy a forráskód értékelésével kapcsolatosan kivel "
+"vegye fel a kapcsolatot a Mozillánál. Ezt a kódot megvizsgálja egy adminisztrátor, de nem lesz megosztva vagy közzétéve semmilyen módon. A kódot kizárólag a kiegészítő értékeléséhez használjuk."
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:301
 #, python-format
-msgid ""
-"If your add-on contains binary or obfuscated code that you don't own or "
-"can't get the source code for, you may <a href=\"%(link_contact)s\">contact "
-"us</a> for information on how to proceed."
+msgid "If your add-on contains binary or obfuscated code that you don't own or can't get the source code for, you may <a href=\"%(link_contact)s\">contact us</a> for information on how to proceed."
 msgstr ""
-"Ha a kiegészítő olyan bináris vagy olvashatatlanná tett kódot tartalmaz, "
-"melynek nem Ön a tulajdonosa, vagy melynek nem tudja beszerezni a "
-"forráskódját, a folytatással kapcsolatos információért <a "
+"Ha a kiegészítő olyan bináris vagy olvashatatlanná tett kódot tartalmaz, melynek nem Ön a tulajdonosa, vagy melynek nem tudja beszerezni a forráskódját, a folytatással kapcsolatos információért <a "
 "href=\"%(link_contact)s\">lépjen kapcsolatba velünk</a>."
 
 #: src/olympia/devhub/templates/devhub/docs/policies-submission.html:11
@@ -7529,173 +5913,100 @@ msgstr "A beküldés követelményei"
 
 #: src/olympia/devhub/templates/devhub/docs/policies-submission.html:13
 msgid ""
-"Add-ons hosted on Mozilla Add-ons should be of high quality and give users "
-"an improved web experience. We look for the following things when deciding "
-"whether an add-on is appropriate to be public and unrestricted:"
+"Add-ons hosted on Mozilla Add-ons should be of high quality and give users an improved web experience. We look for the following things when deciding whether an add-on is appropriate to be public "
+"and unrestricted:"
 msgstr ""
-"A Mozilla Kiegészítők oldalon megjelenő kiegészítőknek magas minőséget és "
-"továbbfejlesztett webélményt kell nyújtaniuk a felhasználók számára. A "
-"következő dolgokra figyelünk, amikor eldöntjük, hogy egy kiegészítő "
-"alkalmas-e nyilvános és korlátlan használatra:"
+"A Mozilla Kiegészítők oldalon megjelenő kiegészítőknek magas minőséget és továbbfejlesztett webélményt kell nyújtaniuk a felhasználók számára. A következő dolgokra figyelünk, amikor eldöntjük, hogy"
+" egy kiegészítő alkalmas-e nyilvános és korlátlan használatra:"
 
 #: src/olympia/devhub/templates/devhub/docs/policies-submission.html:19
 msgid ""
-"<strong>Are you responsive?</strong> We expect that an author who is "
-"promoting their add-on to our applications' many users is responsive to "
-"problem reports, maintains their contact information, and updates their add-"
-"on promptly to keep current with Firefox releases and changes in our "
-"policies. This doesn't mean that you have to reply to every question that "
-"someone posts in the discussions, or that you even need to fix every bug, "
-"but we do expect that you will respond to issues in a manner that's "
-"appropriate to the severity of the issue in question."
+"<strong>Are you responsive?</strong> We expect that an author who is promoting their add-on to our applications' many users is responsive to problem reports, maintains their contact information, "
+"and updates their add-on promptly to keep current with Firefox releases and changes in our policies. This doesn't mean that you have to reply to every question that someone posts in the "
+"discussions, or that you even need to fix every bug, but we do expect that you will respond to issues in a manner that's appropriate to the severity of the issue in question."
 msgstr ""
-"<strong>Elérhető Ön?</strong> Számítunk rá, hogy az a szerző, aki közzéteszi"
-" kiegészítőjét alkalmazásaink számos felhasználója számára, reagál a "
-"hibajelentésekre, karbantartja a kapcsolattartói információit, és az "
-"aktuális Firefox kiadásokkal és szabályzatainkban történő változásokkal "
-"lépést tartva időben frissíti a kiegészítőt. Ez nem azt jelenti, hogy minden"
-" kérdésre válaszolnia kell, amit valaki közzétesz a vitalapon, vagy akár "
-"minden egyes hibát javítson, de számítunk rá, hogy olyan fokig válaszoljon a"
-" problémákra, hogy az arányos legyen a szóban forgó probléma súlyosságával."
+"<strong>Elérhető Ön?</strong> Számítunk rá, hogy az a szerző, aki közzéteszi kiegészítőjét alkalmazásaink számos felhasználója számára, reagál a hibajelentésekre, karbantartja a kapcsolattartói "
+"információit, és az aktuális Firefox kiadásokkal és szabályzatainkban történő változásokkal lépést tartva időben frissíti a kiegészítőt. Ez nem azt jelenti, hogy minden kérdésre válaszolnia kell, "
+"amit valaki közzétesz a vitalapon, vagy akár minden egyes hibát javítson, de számítunk rá, hogy olyan fokig válaszoljon a problémákra, hogy az arányos legyen a szóban forgó probléma súlyosságával."
 
 #: src/olympia/devhub/templates/devhub/docs/policies-submission.html:25
 msgid ""
-"<strong>Is the add-on clearly and accurately described?</strong> It's of the"
-" utmost importance to us that users get what they expect when they try a new"
-" add-on. Your add-on name should be clear and concise, and you should "
-"refrain from using special characters or numbers to get higher search "
-"rankings or for decorative purposes. Your description should provide details"
-" about what the add-on does, how a user should take advantage of it, and "
-"what the user should expect when they install it. Links to external "
-"documents for detailed instructions are fine, but the description itself "
-"should cover the basics and leave users confident that they know what "
-"they'll get. Also, it is important that you maintain version notes "
-"appropriately as you improve and change your add-on. Users should be able to"
-" see what's new in an add-on they may have tried previously, and should be "
-"made aware of changes that might affect their current use of the add-on when"
-" they update."
+"<strong>Is the add-on clearly and accurately described?</strong> It's of the utmost importance to us that users get what they expect when they try a new add-on. Your add-on name should be clear and"
+" concise, and you should refrain from using special characters or numbers to get higher search rankings or for decorative purposes. Your description should provide details about what the add-on "
+"does, how a user should take advantage of it, and what the user should expect when they install it. Links to external documents for detailed instructions are fine, but the description itself should"
+" cover the basics and leave users confident that they know what they'll get. Also, it is important that you maintain version notes appropriately as you improve and change your add-on. Users should "
+"be able to see what's new in an add-on they may have tried previously, and should be made aware of changes that might affect their current use of the add-on when they update."
 msgstr ""
-"<strong>A bővítmény világosan és pontosan le van írva?</strong> Rendkívül "
-"fontos számunkra, hogy a felhasználók azt kapják, amit elvárnak, amikor "
-"kipróbálnak egy új kiegészítőt. A kiegészítője neve legyen egyértelmű és "
-"tömör, valamint a jobb keresési helyezés és dekoratívabb megjelenés "
-"érdekében tartózkodjon a különleges karakterek és számok használatától. A "
-"leírásnak részletesen tartalmaznia kell, hogy mit csinál a kiegészítő, "
-"hogyan használhatja ki azt a felhasználó, és mire számítson, amikor telepíti"
-" azt. A részletes útmutatókhoz külső dokumentumokra mutató hivatkozások "
-"elfogadhatóak, de a leírásnak önmagában le kell fednie az alapokat, és a "
-"felhasználók számára egyértelműen ki kell derülnie, mit kapnak. Szintén "
-"fontos, hogy megfelelően karbantartsa a verziók megjegyzéseit, ahogyan "
-"javítja és változtatja a kiegészítőt. A felhasználóknak látniuk kell, hogy "
-"milyen újdonságok vannak egy kiegészítőben, amelyet korábban kipróbáltak, és"
-" tudatosítania kell bennük a változásokat, melyek hatással lehetnek a "
-"kiegészítő jelenlegi használatára, amikor frissítenek."
+"<strong>A bővítmény világosan és pontosan le van írva?</strong> Rendkívül fontos számunkra, hogy a felhasználók azt kapják, amit elvárnak, amikor kipróbálnak egy új kiegészítőt. A kiegészítője neve"
+" legyen egyértelmű és tömör, valamint a jobb keresési helyezés és dekoratívabb megjelenés érdekében tartózkodjon a különleges karakterek és számok használatától. A leírásnak részletesen "
+"tartalmaznia kell, hogy mit csinál a kiegészítő, hogyan használhatja ki azt a felhasználó, és mire számítson, amikor telepíti azt. A részletes útmutatókhoz külső dokumentumokra mutató hivatkozások "
+"elfogadhatóak, de a leírásnak önmagában le kell fednie az alapokat, és a felhasználók számára egyértelműen ki kell derülnie, mit kapnak. Szintén fontos, hogy megfelelően karbantartsa a verziók "
+"megjegyzéseit, ahogyan javítja és változtatja a kiegészítőt. A felhasználóknak látniuk kell, hogy milyen újdonságok vannak egy kiegészítőben, amelyet korábban kipróbáltak, és tudatosítania kell "
+"bennük a változásokat, melyek hatással lehetnek a kiegészítő jelenlegi használatára, amikor frissítenek."
 
 #: src/olympia/devhub/templates/devhub/docs/policies-submission.html:31
 msgid ""
-"<strong>Are all privacy and security concerns clearly spelled out?</strong> "
-"This is an aspect of a clear and accurate description, but such an important"
-" one that we feel it deserves specific mention. Many very useful and well-"
-"written add-ons manipulate some form of user data, or can present security "
-"hazards if misused; they are welcome on the site, but they must make it very"
-" clear to users what risks they might encounter, and what they can do to "
-"protect themselves."
+"<strong>Are all privacy and security concerns clearly spelled out?</strong> This is an aspect of a clear and accurate description, but such an important one that we feel it deserves specific "
+"mention. Many very useful and well-written add-ons manipulate some form of user data, or can present security hazards if misused; they are welcome on the site, but they must make it very clear to "
+"users what risks they might encounter, and what they can do to protect themselves."
 msgstr ""
-"<strong>Minden adatvédelmi és biztonsági aggályt érthetően "
-"eloszlatott?</strong> Ez a világos és pontos leírások egyik jellemzője, de "
-"olyannyira fontos, hogy úgy érezzük, külön említést érdemel. Sok nagyon "
-"hasznos és jól megírt kiegészítő dolgozza fel a felhasználói adatok "
-"valamilyen formáját, vagy jelenthet biztonsági veszélyt, ha nem megfelelően "
-"használják; szívesen látjuk ezeket is az oldalon, de világossá kell tenniük "
-"a felhasználók számára, hogy milyen kockázattal számoljanak, és mit "
-"tehetnek, hogy megvédjék magukat."
+"<strong>Minden adatvédelmi és biztonsági aggályt érthetően eloszlatott?</strong> Ez a világos és pontos leírások egyik jellemzője, de olyannyira fontos, hogy úgy érezzük, külön említést érdemel. "
+"Sok nagyon hasznos és jól megírt kiegészítő dolgozza fel a felhasználói adatok valamilyen formáját, vagy jelenthet biztonsági veszélyt, ha nem megfelelően használják; szívesen látjuk ezeket is az "
+"oldalon, de világossá kell tenniük a felhasználók számára, hogy milyen kockázattal számoljanak, és mit tehetnek, hogy megvédjék magukat."
 
 #: src/olympia/devhub/templates/devhub/docs/policies-submission.html:37
 msgid ""
-"<strong>Has the add-on been well-tested, and is it free of obvious or "
-"serious defects?</strong> One important thing that we look for when "
-"considering an add-on is whether its user reviews indicate that it has "
-"received thorough testing, and that it doesn't have serious problems or "
-"negative impacts on the browser. If reviewers report problems such as major "
-"performance issues, crashes, frequent problems using the functions of the "
-"add-on, or spamming of messages to the error console, you should take those "
-"reports to heart, and re-submit your add-on after you've addressed them as "
-"best you can. We don't expect you to perfectly optimize or have zero bugs "
-"&mdash; Firefox itself undergoes constant improvement in these areas &mdash;"
-" but we do want you to take reasonable efforts to minimize downsides, and to"
-" clearly call out cases where users may be surprised by those that remain."
+"<strong>Has the add-on been well-tested, and is it free of obvious or serious defects?</strong> One important thing that we look for when considering an add-on is whether its user reviews indicate "
+"that it has received thorough testing, and that it doesn't have serious problems or negative impacts on the browser. If reviewers report problems such as major performance issues, crashes, frequent"
+" problems using the functions of the add-on, or spamming of messages to the error console, you should take those reports to heart, and re-submit your add-on after you've addressed them as best you "
+"can. We don't expect you to perfectly optimize or have zero bugs &mdash; Firefox itself undergoes constant improvement in these areas &mdash; but we do want you to take reasonable efforts to "
+"minimize downsides, and to clearly call out cases where users may be surprised by those that remain."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/docs/policies-submission.html:43
 msgid ""
-"<strong>Do the add-on and add-on author both treat the user "
-"respectfully?</strong> Your software should not intrude on the user "
-"unnecessarily, try to trick the user, or conceal any of its activities from "
-"the user. Users (or even non-users) are sometimes rude in their comments, "
-"and while we will do our best to filter out inaccurate reviews as they're "
-"reported to us, we do expect that authors will avoid retaliating with "
-"rudeness of their own."
+"<strong>Do the add-on and add-on author both treat the user respectfully?</strong> Your software should not intrude on the user unnecessarily, try to trick the user, or conceal any of its "
+"activities from the user. Users (or even non-users) are sometimes rude in their comments, and while we will do our best to filter out inaccurate reviews as they're reported to us, we do expect that"
+" authors will avoid retaliating with rudeness of their own."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/docs/policies-submission.html:49
 msgid ""
-"<strong>Is the add-on useful to an appropriately wide portion of Firefox's "
-"users?</strong> Your add-on doesn't need to be the next Greasemonkey or "
-"Firebug, but if it is only useful to people at your company or who are part "
-"of a small web community, we may feel that it's not yet appropriate to put "
-"it in front of all of our users."
+"<strong>Is the add-on useful to an appropriately wide portion of Firefox's users?</strong> Your add-on doesn't need to be the next Greasemonkey or Firebug, but if it is only useful to people at "
+"your company or who are part of a small web community, we may feel that it's not yet appropriate to put it in front of all of our users."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/docs/policies-submission.html:55
 msgid ""
-"We are constantly looking at ways to improve the organization of the site to"
-" better accommodate add-ons that are exemplary in other ways, but are aimed "
-"at only a small community of potential users. Correctly categorizing and "
-"maintaining the metadata of your add-on will help us figure out how we can "
-"surface more of those sorts of add-ons to people who are most likely to "
-"benefit from them."
+"We are constantly looking at ways to improve the organization of the site to better accommodate add-ons that are exemplary in other ways, but are aimed at only a small community of potential users."
+" Correctly categorizing and maintaining the metadata of your add-on will help us figure out how we can surface more of those sorts of add-ons to people who are most likely to benefit from them."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/docs/policies-submission.html:61
 msgid ""
-"If your add-on just provides bookmarks or other simple access points to your"
-" site, it's probably not appropriate for the gallery. Like the rest of the "
-"Mozilla project, we love web applications and new web services, but Firefox "
-"add-ons should provide an improved browsing experience for the user and not "
-"just be a way to promote a new site or service through a Mozilla Add-ons "
-"listing."
+"If your add-on just provides bookmarks or other simple access points to your site, it's probably not appropriate for the gallery. Like the rest of the Mozilla project, we love web applications and "
+"new web services, but Firefox add-ons should provide an improved browsing experience for the user and not just be a way to promote a new site or service through a Mozilla Add-ons listing."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/docs/policies-submission.html:67
 msgid ""
-"<strong>Is the add-on free of unlicensed trademarks and copyrights?</strong>"
-" Though you may mean no harm to the holder of a trademark, or the owner of a"
-" copyrighted work, we can't host add-ons that infringe on trademarks or "
-"copyrights. If you don't have permission to use a trademarked name or image,"
-" please do not submit your add-on to us. If your add-on includes code that "
-"is copyrighted by someone else, and is not licensed to you to use in your "
-"add-on, please do not submit your add-on to us."
+"<strong>Is the add-on free of unlicensed trademarks and copyrights?</strong> Though you may mean no harm to the holder of a trademark, or the owner of a copyrighted work, we can't host add-ons that"
+" infringe on trademarks or copyrights. If you don't have permission to use a trademarked name or image, please do not submit your add-on to us. If your add-on includes code that is copyrighted by "
+"someone else, and is not licensed to you to use in your add-on, please do not submit your add-on to us."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/docs/policies-submission.html:73
 msgid ""
-"In terms of reuse of source code from other add-ons, if the author has not "
-"clearly stated that you are permitted to use his or her code in your own "
-"work &mdash; such as by placing it under an open source license &mdash; then"
-" you should assume that you do not have the right to do so. You can contact "
-"the author to seek such permission, but we can't provide you with any "
-"special rights to it just because it's listed on the site, or because the "
-"author isn't responding to your request."
+"In terms of reuse of source code from other add-ons, if the author has not clearly stated that you are permitted to use his or her code in your own work &mdash; such as by placing it under an open "
+"source license &mdash; then you should assume that you do not have the right to do so. You can contact the author to seek such permission, but we can't provide you with any special rights to it "
+"just because it's listed on the site, or because the author isn't responding to your request."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/docs/policies-submission.html:79
 msgid ""
-"This applies to the Mozilla Foundation's trademarks as well, including "
-"\"Mozilla\", \"Firefox\", and \"Thunderbird\". The Mozilla policy on "
-"trademark use is designed to protect against confusion, and prevent the "
-"trademarks from being overturned due to lack of protection; please respect "
-"the need for such protection, and help us preserve some of the most valuable"
-" assets of the Mozilla Foundation."
+"This applies to the Mozilla Foundation's trademarks as well, including \"Mozilla\", \"Firefox\", and \"Thunderbird\". The Mozilla policy on trademark use is designed to protect against confusion, "
+"and prevent the trademarks from being overturned due to lack of protection; please respect the need for such protection, and help us preserve some of the most valuable assets of the Mozilla "
+"Foundation."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/docs/policies-submission.html:84
@@ -7704,209 +6015,143 @@ msgstr "Licencelés"
 
 #: src/olympia/devhub/templates/devhub/docs/policies-submission.html:86
 msgid ""
-"Selecting an appropriate license for your add-on is a very important step in"
-" the submission process. A license specifies the rights you grant on your "
-"source code and is important in protecting your intellectual property."
+"Selecting an appropriate license for your add-on is a very important step in the submission process. A license specifies the rights you grant on your source code and is important in protecting your"
+" intellectual property."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/docs/policies-submission.html:92
 msgid ""
-"During the add-on submission process, you will be presented with a list of "
-"popular licenses to choose from, as well as the ability to specify your own "
-"license. It is best to consult with a legal professional about which license"
-" option is best for you. Choosing the right license for your source code "
-"will help to prevent confusion and code conflicts in the future."
+"During the add-on submission process, you will be presented with a list of popular licenses to choose from, as well as the ability to specify your own license. It is best to consult with a legal "
+"professional about which license option is best for you. Choosing the right license for your source code will help to prevent confusion and code conflicts in the future."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/docs/policies.html:12
-#: src/olympia/devhub/templates/devhub/docs/policies.html:52
+#: src/olympia/devhub/templates/devhub/docs/policies.html:12 src/olympia/devhub/templates/devhub/docs/policies.html:52
 msgid "Add-on Submission"
 msgstr "Kiegészítő beküldés"
 
-#: src/olympia/devhub/templates/devhub/docs/policies.html:18
-#: src/olympia/devhub/templates/devhub/docs/policies.html:78
+#: src/olympia/devhub/templates/devhub/docs/policies.html:18 src/olympia/devhub/templates/devhub/docs/policies.html:78
 msgid "Maintaining Your Add-on"
 msgstr "Kiegészítője karbantartása"
 
 #: src/olympia/devhub/templates/devhub/docs/policies.html:43
-msgid ""
-"Mozilla is committed to ensuring a great add-ons experience for our users "
-"and developers. Please review the policies below before submitting your add-"
-"on."
+msgid "Mozilla is committed to ensuring a great add-ons experience for our users and developers. Please review the policies below before submitting your add-on."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/docs/policies.html:55
-msgid ""
-"Find out what is expected of add-ons we host and our policies on specific "
-"add-on practices."
+msgid "Find out what is expected of add-ons we host and our policies on specific add-on practices."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/docs/policies.html:67
-msgid ""
-"What happens after your add-on is submitted? Learn about how our Editors "
-"review submissions."
+msgid "What happens after your add-on is submitted? Learn about how our Editors review submissions."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/docs/policies.html:81
-msgid ""
-"Add-on updates, transferring ownership, user reviews, and what to expect "
-"once your add-on is approved."
+msgid "Add-on updates, transferring ownership, user reviews, and what to expect once your add-on is approved."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/docs/policies.html:93
-msgid ""
-"How up-and-coming add-ons become featured and what&#039;s involved in the "
-"process."
+msgid "How up-and-coming add-ons become featured and what&#039;s involved in the process."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/docs/policies.html:106
-msgid ""
-"Terms of Service for submitting your work to our site. Developers are "
-"required to accept this agreement before submission."
+msgid "Terms of Service for submitting your work to our site. Developers are required to accept this agreement before submission."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/docs/policies.html:118
 msgid "How to get in touch with us regarding these policies or your add-on."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:6
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:10
 msgid "You have disabled this add-on"
 msgstr "Letiltotta ezt a kiegészítőt."
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:20
-msgid ""
-"Your add-on's listing is disabled and is not showing\n"
-"                             anywhere in our gallery or update service."
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:24
+msgid "Your add-on's listing is disabled and is not showing anywhere in our gallery or update service."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:25
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:27
 msgid "Please complete your add-on."
 msgstr "Egészítse ki a kiegészítőjét."
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:29
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:30
 msgid "You will receive an email when the review is complete."
 msgstr "Az értékelés befejeztével kapni fog egy e-mailt."
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:34
-msgid ""
-"You will receive an email when the review is complete. Until then, your add-"
-"on is not listed in our gallery but can be accessed directly from its "
-"details page."
-msgstr ""
-"Az ellenőrzés befejeztével kapni fog egy e-mailt. Addig a kiegészítő nem "
-"jelenik meg a galériában, de közvetlenül elérhető a kiegészítő részletes "
-"lapján keresztül."
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:33
+msgid "You will receive an email when the review is complete. Until then, your add-on is not listed in our gallery but can be accessed directly from its details page."
+msgstr "Az ellenőrzés befejeztével kapni fog egy e-mailt. Addig a kiegészítő nem jelenik meg a galériában, de közvetlenül elérhető a kiegészítő részletes lapján keresztül."
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:38
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:48
-msgid ""
-"You will receive an email when the review is\n"
-"                             complete and your add-on is signed."
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:37 src/olympia/devhub/templates/devhub/includes/addon_details.html:45
+msgid "You will receive an email when the review is complete and your add-on is signed."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:44
-msgid ""
-"You will receive an email when the review is complete. Until then, your add-"
-"on is not listed in our gallery but can be accessed directly from its "
-"details page."
-msgstr ""
-"Az ellenőrzés befejeztével kapni fog egy e-mailt. Addig a kiegészítő nem "
-"jelenik meg a galériában, de közvetlenül elérhető a kiegészítő részletes "
-"lapján keresztül."
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:41
+msgid "You will receive an email when the review is complete. Until then, your add-on is not listed in our gallery but can be accessed directly from its details page."
+msgstr "Az ellenőrzés befejeztével kapni fog egy e-mailt. Addig a kiegészítő nem jelenik meg a galériában, de közvetlenül elérhető a kiegészítő részletes lapján keresztül."
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:54
-msgid ""
-"Your add-on is displayed in our gallery and users are receiving automatic "
-"updates."
-msgstr ""
-"A kiegészítő megjelenik a galériában és a felhasználók automatikus "
-"frissítést kapnak."
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:49
+msgid "Your add-on is displayed in our gallery and users are receiving automatic updates."
+msgstr "A kiegészítő megjelenik a galériában és a felhasználók automatikus frissítést kapnak."
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:57
-msgid ""
-"Your add-on has been signed and can be bundled with an\n"
-"                             application installer."
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:52
+msgid "Your add-on has been signed and can be bundled with an application installer."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:63
-msgid ""
-"Your add-on was disabled by a site administrator and is no\n"
-"                             longer shown in our gallery. If you have any questions,\n"
-"                             please email amo-admins@mozilla.org."
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:56
+msgid "Your add-on was disabled by a site administrator and is no longer shown in our gallery. If you have any questions, please email amo-admins@mozilla.org."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:70
-msgid ""
-"Your add-on is displayed in our gallery as experimental and users are "
-"receiving automatic updates. Some features are unavailable to your add-on."
-msgstr ""
-"A kiegészítő, kísérleti kiegészítőként jelenik meg a galériában és a "
-"felhasználók automatikus frissítést kapnak. Néhány funkció nem érhető el a "
-"kiegészítőhöz."
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:62
+msgid "Your add-on is displayed in our gallery as experimental and users are receiving automatic updates. Some features are unavailable to your add-on."
+msgstr "A kiegészítő, kísérleti kiegészítőként jelenik meg a galériában és a felhasználók automatikus frissítést kapnak. Néhány funkció nem érhető el a kiegészítőhöz."
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:74
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:66
 msgid "Your add-on has been signed."
 msgstr "A kiegészítője alá lett írva."
 
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:69
+msgid ""
+"You will receive an email when the full review is complete. Until then, your add-on is displayed in our gallery as experimental and users are receiving automatic updates. Some features are "
+"unavailable to your add-on."
+msgstr ""
+"A teljes ellenőrzési folyamat befejezésekor levelet fog kapni. A kiegészítő kísérleti kiegészítőként jelenik meg a galériában és a felhasználók automatikus frissítést kapnak. Néhány funkció nem "
+"érhető el a kiegészítőhöz."
+
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:74
+msgid "You will receive an email when the full review is complete, making you able to bundle your add-on with an application installer."
+msgstr ""
+
 #: src/olympia/devhub/templates/devhub/includes/addon_details.html:79
-msgid ""
-"You will receive an email when the full review is complete. Until then, your"
-" add-on is displayed in our gallery as experimental and users are receiving "
-"automatic updates. Some features are unavailable to your add-on."
-msgstr ""
-"A teljes ellenőrzési folyamat befejezésekor levelet fog kapni. A kiegészítő "
-"kísérleti kiegészítőként jelenik meg a galériában és a felhasználók "
-"automatikus frissítést kapnak. Néhány funkció nem érhető el a kiegészítőhöz."
-
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:84
-msgid ""
-"You will receive an email when the full review is\n"
-"                             complete, making you able to bundle your add-on with an\n"
-"                             application installer."
+msgid "All add-ons hosted in our gallery must now be reviewed by an editor. If you wish to continue hosting your add-on, please click to select a review process."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:91
-msgid ""
-"All add-ons hosted in our gallery must now be reviewed by an\n"
-"                             editor. If you wish to continue hosting your add-on, please\n"
-"                             click to select a review process."
-msgstr ""
-
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:113
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:100
 msgid "Current Version:"
 msgstr "Jelenlegi verzió:"
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:115
-msgid ""
-"This is the version of your add-on that will\n"
-"                                           be installed if someone clicks the Install\n"
-"                                           button on addons.mozilla.org. It is only\n"
-"                                           relevant for listed add-ons."
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:102
+msgid "This is the version of your add-on that will be installed if someone clicks the Install button on addons.mozilla.org. It is only relevant for listed add-ons."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:123
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:110
 msgid "Created:"
 msgstr "Létrehozva:"
 
 #. {0} is a date. dennis-ignore: E201
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:125
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:131
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:112 src/olympia/devhub/templates/devhub/includes/addon_details.html:118
 #, python-format
 msgid "%%b %%e, %%Y"
 msgstr "%%Y. %%b. %%e."
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:136
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:123
 msgid "Next Version:"
 msgstr "Következő verzió:"
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:138
-msgid ""
-"This is the newest uploaded version, however\n"
-"                                           it isn’t live on the site yet."
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:125
+msgid "This is the newest uploaded version, however it isn’t live on the site yet."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:144
-#: src/olympia/devhub/templates/devhub/versions/list.html:30
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:130 src/olympia/devhub/templates/devhub/versions/list.html:30
 msgid "Queues are not reviewed strictly in order"
 msgstr "A sorok nem feltétlen szigorú sorrendben értékeltek"
 
@@ -7924,16 +6169,11 @@ msgstr "Fejlesztői profil létrehozása"
 
 #: src/olympia/devhub/templates/devhub/includes/addons_create_profile.html:24
 msgid ""
-"Your developer profile will tell users about you, why you made this add-on, "
-"and what's next for the add-on. This profile is required for add-ons "
-"requesting contributions, but can be useful for any developer interested in "
-"connecting with users."
+"Your developer profile will tell users about you, why you made this add-on, and what's next for the add-on. This profile is required for add-ons requesting contributions, but can be useful for any "
+"developer interested in connecting with users."
 msgstr ""
-"A fejlesztői profil egy bemutatkozás, hogy miért készítette ezt a "
-"kiegészítőt és mi lesz a következő lépés a fejlesztésében. Azoknál a "
-"kiegészítőknél, ahol a fejlesztő adományokat kér, ott a profil kitöltése "
-"kötelező, de hasznos lehet bármelyik fejlesztő számára, akik kapcsolatba "
-"szeretne lépni a felhasználóival."
+"A fejlesztői profil egy bemutatkozás, hogy miért készítette ezt a kiegészítőt és mi lesz a következő lépés a fejlesztésében. Azoknál a kiegészítőknél, ahol a fejlesztő adományokat kér, ott a profil"
+" kitöltése kötelező, de hasznos lehet bármelyik fejlesztő számára, akik kapcsolatba szeretne lépni a felhasználóival."
 
 #: src/olympia/devhub/templates/devhub/includes/addons_create_profile.html:32
 msgid "Make sure your user profile is up to date."
@@ -7945,17 +6185,11 @@ msgid "<a href=\"%(url)s\"><strong>Update your user profile.</strong></a>"
 msgstr "<a href=\"%(url)s\"><strong>saját profil frissítése.</strong></a>"
 
 #: src/olympia/devhub/templates/devhub/includes/addons_create_profile.html:45
-msgid ""
-"Whether it was an idea while in line at the grocery store or the solution to"
-" one of life's great problems, share your story."
-msgstr ""
-"Akár a boltban sorban állás közben jött az ötlet, akár az élet nagy "
-"problémáinak egyikét sikerült megoldania – ossza meg történetét."
+msgid "Whether it was an idea while in line at the grocery store or the solution to one of life's great problems, share your story."
+msgstr "Akár a boltban sorban állás közben jött az ötlet, akár az élet nagy problémáinak egyikét sikerült megoldania – ossza meg történetét."
 
 #: src/olympia/devhub/templates/devhub/includes/addons_create_profile.html:61
-msgid ""
-"Telling your users what's coming soon will give them something to look "
-"forward to."
+msgid "Telling your users what's coming soon will give them something to look forward to."
 msgstr "Mindig jó ötlet a felhasználóknak elmondani, mire számíthatnak."
 
 #: src/olympia/devhub/templates/devhub/includes/addons_edit_nav.html:23
@@ -7987,9 +6221,7 @@ msgid "View the blog &#9658;"
 msgstr "A blog megtekintése &#9658;"
 
 #: src/olympia/devhub/templates/devhub/includes/license_form.html:6
-msgid ""
-"Please choose a license appropriate for the rights you grant on your source code.\n"
-"                  It is only relevant for listed add-ons."
+msgid "Please choose a license appropriate for the rights you grant on your source code. It is only relevant for listed add-ons."
 msgstr ""
 "Kérjük válasszon egy licencet, amely megfelelő azokhoz a jogokhoz,\n"
 "                  amelyeket engedélyezni kíván a forráskódon.\n"
@@ -8008,8 +6240,7 @@ msgstr "Némi HTML támogatva."
 msgid "Remove this application"
 msgstr "Alkalmazás eltávolítása"
 
-#. {0} is the maximum number of add-on categories allowed.                {1}
-#. is
+#. {0} is the maximum number of add-on categories allowed.                {1} is
 #. the application name.
 #: src/olympia/devhub/templates/devhub/includes/macros.html:70
 msgid "Select <b>up to {0}</b> {1} category for this add-on:"
@@ -8019,20 +6250,16 @@ msgstr[1] "Válasszon <b>legfeljebb {0}</b> {1} kategórát a kiegészítőhöz:
 
 #: src/olympia/devhub/templates/devhub/includes/policy_form.html:4
 msgid ""
-"Users will be required to accept the following End-User License Agreement (EULA) prior to installing your add-on. The presence of a EULA significantly affects the number of downloads an add-on receives. Please note that a EULA is not the same as a code license, such as the GPL or MPL.\n"
-"                It is only relevant for listed add-ons."
+"Users will be required to accept the following End-User License Agreement (EULA) prior to installing your add-on. The presence of a EULA significantly affects the number of downloads an add-on "
+"receives. Please note that a EULA is not the same as a code license, such as the GPL or MPL.It is only relevant for listed add-ons."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/policy_form.html:21
-msgid ""
-"If your add-on transmits any data from the user's computer, a privacy policy is required that explains what data is sent and how it is used.\n"
-"                It is only relevant for listed add-ons."
+#: src/olympia/devhub/templates/devhub/includes/policy_form.html:24
+msgid "If your add-on transmits any data from the user's computer, a privacy policy is required that explains what data is sent and how it is used. It is only relevant for listed add-ons."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/includes/source_form_field.html:2
-msgid ""
-"If your add-on contains binary or obfuscated code other than known "
-"libraries, upload its sources for review."
+msgid "If your add-on contains binary or obfuscated code other than known libraries, upload its sources for review."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/includes/source_form_field.html:3
@@ -8040,12 +6267,8 @@ msgid "Read more about the source code review policy."
 msgstr "Olvasson többet a forráskód-értékelési házirendről."
 
 #: src/olympia/devhub/templates/devhub/includes/version_file.html:20
-msgid ""
-"You cannot remove an individual file after the review process has begun. You"
-" must delete the entire version."
-msgstr ""
-"Nem távolíthat el különálló fájlokat az értékelési folyamat befejezte előtt."
-" Az egész verziót törölnie kell."
+msgid "You cannot remove an individual file after the review process has begun. You must delete the entire version."
+msgstr "Nem távolíthat el különálló fájlokat az értékelési folyamat befejezte előtt. Az egész verziót törölnie kell."
 
 #: src/olympia/devhub/templates/devhub/includes/version_file.html:36
 msgid "This file will be deleted on save."
@@ -8073,30 +6296,20 @@ msgid "Voluntary Contributions"
 msgstr "Önkéntes adományok"
 
 #: src/olympia/devhub/templates/devhub/payments/payments.html:38
-msgid ""
-"Add-ons enrolled in our contributions program can request voluntary "
-"financial support from users."
-msgstr ""
-"Azok a kiegészítők, amelyek jelentkeznek a közreműködői programba, anyagi "
-"támogatást kérhetnek a felhasználóktól"
+msgid "Add-ons enrolled in our contributions program can request voluntary financial support from users."
+msgstr "Azok a kiegészítők, amelyek jelentkeznek a közreműködői programba, anyagi támogatást kérhetnek a felhasználóktól"
 
 #: src/olympia/devhub/templates/devhub/payments/payments.html:40
 msgid "Encourage users to support your add-on through your Developer Profile"
-msgstr ""
-"Javasolni lehet a felhasználóknak, hogy támogassák a kiegészítőket a "
-"Fejlesztői profilon keresztül"
+msgstr "Javasolni lehet a felhasználóknak, hogy támogassák a kiegészítőket a Fejlesztői profilon keresztül"
 
 #: src/olympia/devhub/templates/devhub/payments/payments.html:41
 msgid "Choose when and how users are asked to contribute"
 msgstr "Válassza ki, hogy a felhasználók mikor és hogyan járuljanak hozzá"
 
 #: src/olympia/devhub/templates/devhub/payments/payments.html:42
-msgid ""
-"Receive contributions in your PayPal account or send them to an organization"
-" of your choice"
-msgstr ""
-"Adományokat kaphat a PayPal számlájára, vagy elküldheti egy kiválasztott "
-"szervezetnek."
+msgid "Receive contributions in your PayPal account or send them to an organization of your choice"
+msgstr "Adományokat kaphat a PayPal számlájára, vagy elküldheti egy kiválasztott szervezetnek."
 
 #: src/olympia/devhub/templates/devhub/payments/payments.html:46
 msgid "Contributions are only available for listed add-ons."
@@ -8104,19 +6317,14 @@ msgstr "Az adományozás csak a listázott kiegészítőknél elérhető."
 
 #: src/olympia/devhub/templates/devhub/payments/payments.html:53
 #, python-format
-msgid ""
-"Contributions are only available for add-ons with a <a "
-"href=\"%(url)s\">completed developer profile</a>."
-msgstr ""
-"Az adományozás csak a <a href=\"%(url)s\">teljes fejlesztői profillal</a> "
-"rendelkező kiegészítőknél elérhető."
+msgid "Contributions are only available for add-ons with a <a href=\"%(url)s\">completed developer profile</a>."
+msgstr "Az adományozás csak a <a href=\"%(url)s\">teljes fejlesztői profillal</a> rendelkező kiegészítőknél elérhető."
 
 #: src/olympia/devhub/templates/devhub/payments/payments.html:59
 msgid "Contributions are only available for fully reviewed add-ons."
 msgstr "Az adományozás csak a teljesen értékelt kiegészítőknél elérhető."
 
-#: src/olympia/devhub/templates/devhub/payments/payments.html:65
-#: src/olympia/devhub/templates/devhub/payments/voluntary.html:2
+#: src/olympia/devhub/templates/devhub/payments/payments.html:65 src/olympia/devhub/templates/devhub/payments/voluntary.html:2
 msgid "Set up Contributions"
 msgstr "Adományozás beállítása"
 
@@ -8129,18 +6337,13 @@ msgstr "2. lépés: árazás és elérhetőség"
 msgid "or <a href=\"%(cancel)s\">Cancel</a>"
 msgstr "vagy <a href=\"%(cancel)s\">Mégse</a>"
 
-#: src/olympia/devhub/templates/devhub/payments/voluntary.html:2
-#: src/olympia/stats/templates/stats/addon_report_menu.html:39
+#: src/olympia/devhub/templates/devhub/payments/voluntary.html:2 src/olympia/stats/templates/stats/addon_report_menu.html:39
 msgid "Contributions"
 msgstr "Adományok"
 
 #: src/olympia/devhub/templates/devhub/payments/voluntary.html:3
-msgid ""
-"Fill in the fields below to begin asking for voluntary contributions from "
-"users."
-msgstr ""
-"Töltse ki az alábbi mezőket, ha közösségi hozzájárulást kíván kérni a "
-"felhasználóktól."
+msgid "Fill in the fields below to begin asking for voluntary contributions from users."
+msgstr "Töltse ki az alábbi mezőket, ha közösségi hozzájárulást kíván kérni a felhasználóktól."
 
 #: src/olympia/devhub/templates/devhub/payments/voluntary.html:11
 msgid "Who will receive contributions to this add-on?"
@@ -8183,22 +6386,16 @@ msgid "Send a thank-you note?"
 msgstr "Küld köszönő üzenetet?"
 
 #: src/olympia/devhub/templates/devhub/payments/voluntary.html:47
-msgid ""
-"We'll automatically email users who contribute to your add-on with this "
-"message."
-msgstr ""
-"Automatikusan elküldjük az alábbi üzenetet a felhasználóknak, akik adományt "
-"adtak."
+msgid "We'll automatically email users who contribute to your add-on with this message."
+msgstr "Automatikusan elküldjük az alábbi üzenetet a felhasználóknak, akik adományt adtak."
 
 #: src/olympia/devhub/templates/devhub/payments/voluntary.html:49
 msgid ""
-"We recommend thanking the user and telling them how much you appreciate "
-"their support. You might also want to tell them about what's next for your "
-"add-on and about any other add-ons you've made for them to try."
+"We recommend thanking the user and telling them how much you appreciate their support. You might also want to tell them about what's next for your add-on and about any other add-ons you've made for"
+" them to try."
 msgstr ""
-"Javasoljuk, hogy köszönje meg a támogatás és mondja el, hogy mennyire "
-"értékeli azt. Ugyanakkor elmondhatja, hogy mi a következő lépés a kiegészítő"
-" fejlesztésében és javasolhat kipróbálásra más kiegészítőket."
+"Javasoljuk, hogy köszönje meg a támogatás és mondja el, hogy mennyire értékeli azt. Ugyanakkor elmondhatja, hogy mi a következő lépés a kiegészítő fejlesztésében és javasolhat kipróbálásra más "
+"kiegészítőket."
 
 #: src/olympia/devhub/templates/devhub/payments/voluntary.html:64
 msgid "Activate Contributions"
@@ -8212,147 +6409,94 @@ msgstr "vagy <a id=\"setup-cancel\" href=\"#\">Mégsem</a>"
 msgid "Transfer ownership"
 msgstr "Tulajdonjog átadása"
 
-#: src/olympia/devhub/templates/devhub/personas/edit.html:77
-#: src/olympia/devhub/templates/devhub/personas/submit.html:31
+#: src/olympia/devhub/templates/devhub/personas/edit.html:77 src/olympia/devhub/templates/devhub/personas/submit.html:31
 msgid "Theme Details"
 msgstr "Téma részletei"
 
-#: src/olympia/devhub/templates/devhub/personas/edit.html:87
-#: src/olympia/devhub/templates/devhub/personas/submit.html:36
+#: src/olympia/devhub/templates/devhub/personas/edit.html:87 src/olympia/devhub/templates/devhub/personas/submit.html:36
 msgid "Supply a pretty URL for your detail page."
 msgstr "Adjon meg egy szép URL-t a részletek oldalához."
 
-#: src/olympia/devhub/templates/devhub/personas/edit.html:92
-#: src/olympia/devhub/templates/devhub/personas/submit.html:41
+#: src/olympia/devhub/templates/devhub/personas/edit.html:92 src/olympia/devhub/templates/devhub/personas/submit.html:41
 msgid "Select the category that best describes your Theme."
 msgstr "Válassza ki a kategóriát, amely legjobban jellemzi a témáját."
 
-#: src/olympia/devhub/templates/devhub/personas/edit.html:95
-#: src/olympia/devhub/templates/devhub/personas/submit.html:44
+#: src/olympia/devhub/templates/devhub/personas/edit.html:95 src/olympia/devhub/templates/devhub/personas/submit.html:44
 msgid "Add some tags to describe your Theme."
 msgstr "Adjon meg néhány címkét, amely jellemzi a témáját."
 
-#: src/olympia/devhub/templates/devhub/personas/edit.html:106
-msgid ""
-"A short explanation of your theme's basic functionality that is displayed in"
-" search and browse listings, as well as at the top of your theme's details "
-"page."
-msgstr ""
-"Egy rövid magyarázat a témája alapfunkcionalitásáról, amely megjelenik a "
-"keresésekben és a böngészi listázásokban, valamint a témája részletező "
-"oldalának tetején."
+#: src/olympia/devhub/templates/devhub/personas/edit.html:106 src/olympia/devhub/templates/devhub/personas/submit.html:54
+msgid "A short explanation of your theme's basic functionality that is displayed in search and browse listings, as well as at the top of your theme's details page."
+msgstr "Egy rövid magyarázat a témája alapfunkcionalitásáról, amely megjelenik a keresésekben és a böngészi listázásokban, valamint a témája részletező oldalának tetején."
 
-#: src/olympia/devhub/templates/devhub/personas/edit.html:122
-#: src/olympia/devhub/templates/devhub/personas/submit.html:68
+#: src/olympia/devhub/templates/devhub/personas/edit.html:122 src/olympia/devhub/templates/devhub/personas/submit.html:68
 msgid "Theme License"
 msgstr "Téma licence"
 
-#: src/olympia/devhub/templates/devhub/personas/edit.html:126
-#: src/olympia/devhub/templates/devhub/personas/submit.html:72
+#: src/olympia/devhub/templates/devhub/personas/edit.html:126 src/olympia/devhub/templates/devhub/personas/submit.html:72
 msgid "Can others share your Theme, as long as you're given credit?"
 msgstr "Megoszthatják mások a témáját, ha megjelölik Önt forrásként?"
 
-#: src/olympia/devhub/templates/devhub/personas/edit.html:132
-#: src/olympia/devhub/templates/devhub/personas/edit.html:153
-#: src/olympia/devhub/templates/devhub/personas/submit.html:78
+#: src/olympia/devhub/templates/devhub/personas/edit.html:132 src/olympia/devhub/templates/devhub/personas/edit.html:153 src/olympia/devhub/templates/devhub/personas/submit.html:78
 #: src/olympia/devhub/templates/devhub/personas/submit.html:99
-msgid ""
-"The licensor permits others to copy, distribute, display, and perform the "
-"work, including for commercial purposes."
-msgstr ""
-"A licencadó lehetővé teszi másoknak, hogy lehessen másolni, terjeszteni, "
-"megjeleníteni és felhasználni az adott munkát, akár kereskedelmi célokra is."
+msgid "The licensor permits others to copy, distribute, display, and perform the work, including for commercial purposes."
+msgstr "A licencadó lehetővé teszi másoknak, hogy lehessen másolni, terjeszteni, megjeleníteni és felhasználni az adott munkát, akár kereskedelmi célokra is."
 
-#: src/olympia/devhub/templates/devhub/personas/edit.html:141
-#: src/olympia/devhub/templates/devhub/personas/edit.html:162
-#: src/olympia/devhub/templates/devhub/personas/submit.html:87
+#: src/olympia/devhub/templates/devhub/personas/edit.html:141 src/olympia/devhub/templates/devhub/personas/edit.html:162 src/olympia/devhub/templates/devhub/personas/submit.html:87
 #: src/olympia/devhub/templates/devhub/personas/submit.html:108
-msgid ""
-"The licensor permits others to copy, distribute, display, and perform the "
-"work for non-commercial purposes only."
-msgstr ""
-"A licencadó lehetővé teszi másoknak, hogy lehessen másolni, terjeszteni, "
-"megjeleníteni és felhasználni az adott munkát, de csak akkor ha "
-"felhasználásuk nem kereskedelmi jellegű."
+msgid "The licensor permits others to copy, distribute, display, and perform the work for non-commercial purposes only."
+msgstr "A licencadó lehetővé teszi másoknak, hogy lehessen másolni, terjeszteni, megjeleníteni és felhasználni az adott munkát, de csak akkor ha felhasználásuk nem kereskedelmi jellegű."
 
-#: src/olympia/devhub/templates/devhub/personas/edit.html:147
-#: src/olympia/devhub/templates/devhub/personas/submit.html:93
+#: src/olympia/devhub/templates/devhub/personas/edit.html:147 src/olympia/devhub/templates/devhub/personas/submit.html:93
 msgid "Can others make commercial use of your Theme?"
 msgstr "Használhatják-e mások kereskedelmi célokra a témáját?"
 
-#: src/olympia/devhub/templates/devhub/personas/edit.html:168
-#: src/olympia/devhub/templates/devhub/personas/submit.html:114
+#: src/olympia/devhub/templates/devhub/personas/edit.html:168 src/olympia/devhub/templates/devhub/personas/submit.html:114
 msgid "Can others create derivative works from your Theme?"
 msgstr "Készíthetnek-e a mások származékos munkákat a témájából?"
 
-#: src/olympia/devhub/templates/devhub/personas/edit.html:174
-#: src/olympia/devhub/templates/devhub/personas/submit.html:120
-msgid ""
-"The licensor permits others to copy, distribute, display and perform the "
-"work, as well as make derivative works based on it."
-msgstr ""
-"A licencadó lehetővé teszi másoknak, hogy lehessen másolni, terjeszteni, "
-"megjeleníteni és felhasználni az adott, vagy az ebből származtatott munkát."
+#: src/olympia/devhub/templates/devhub/personas/edit.html:174 src/olympia/devhub/templates/devhub/personas/submit.html:120
+msgid "The licensor permits others to copy, distribute, display and perform the work, as well as make derivative works based on it."
+msgstr "A licencadó lehetővé teszi másoknak, hogy lehessen másolni, terjeszteni, megjeleníteni és felhasználni az adott, vagy az ebből származtatott munkát."
 
-#: src/olympia/devhub/templates/devhub/personas/edit.html:182
-#: src/olympia/devhub/templates/devhub/personas/submit.html:128
+#: src/olympia/devhub/templates/devhub/personas/edit.html:182 src/olympia/devhub/templates/devhub/personas/submit.html:128
 msgid "Yes, as long as they share alike"
 msgstr "Igen, ha ugyanígy osztják meg"
 
-#: src/olympia/devhub/templates/devhub/personas/edit.html:183
-#: src/olympia/devhub/templates/devhub/personas/submit.html:129
-msgid ""
-"The licensor permits others to distribute derivativeworks only under the "
-"same license or one compatible with the one that governs the licensor's "
-"work."
-msgstr ""
-"A licencadó lehetővé teszi másoknak, hogy a származtatott munkát terjesszék,"
-" amennyiben az ugyanazt a licencet használja vagy kompatibilis azzal, amely "
-"a licencadó munkáját szabályozza."
+#: src/olympia/devhub/templates/devhub/personas/edit.html:183 src/olympia/devhub/templates/devhub/personas/submit.html:129
+msgid "The licensor permits others to distribute derivativeworks only under the same license or one compatible with the one that governs the licensor's work."
+msgstr "A licencadó lehetővé teszi másoknak, hogy a származtatott munkát terjesszék, amennyiben az ugyanazt a licencet használja vagy kompatibilis azzal, amely a licencadó munkáját szabályozza."
 
-#: src/olympia/devhub/templates/devhub/personas/edit.html:192
-#: src/olympia/devhub/templates/devhub/personas/submit.html:138
-msgid ""
-"The licensor permits others to copy, distribute and transmit only unaltered "
-"copies of the work — not derivative works based on it."
-msgstr ""
-"A licencadó lehetővé teszi másoknak, hogy lehessen másolni, terjeszteni és "
-"átadni az adott munkát, amíg az változatlan marad — nem engedélyezett ebből "
-"származtatott munka készítése."
+#: src/olympia/devhub/templates/devhub/personas/edit.html:192 src/olympia/devhub/templates/devhub/personas/submit.html:138
+msgid "The licensor permits others to copy, distribute and transmit only unaltered copies of the work — not derivative works based on it."
+msgstr "A licencadó lehetővé teszi másoknak, hogy lehessen másolni, terjeszteni és átadni az adott munkát, amíg az változatlan marad — nem engedélyezett ebből származtatott munka készítése."
 
-#: src/olympia/devhub/templates/devhub/personas/edit.html:199
-#: src/olympia/devhub/templates/devhub/personas/submit.html:145
+#: src/olympia/devhub/templates/devhub/personas/edit.html:199 src/olympia/devhub/templates/devhub/personas/submit.html:145
 msgid "Your Theme will be released under the following license:"
 msgstr "A témája a következő licenc alatt kerül kiadásra:"
 
-#: src/olympia/devhub/templates/devhub/personas/edit.html:202
-#: src/olympia/devhub/templates/devhub/personas/submit.html:148
+#: src/olympia/devhub/templates/devhub/personas/edit.html:202 src/olympia/devhub/templates/devhub/personas/submit.html:148
 msgid "Select a different license."
 msgstr "Másik licenc kiválasztása."
 
-#: src/olympia/devhub/templates/devhub/personas/edit.html:207
-#: src/olympia/devhub/templates/devhub/personas/submit.html:153
+#: src/olympia/devhub/templates/devhub/personas/edit.html:207 src/olympia/devhub/templates/devhub/personas/submit.html:153
 msgid "Select a license for your Theme."
 msgstr "Válasszon licencet a témájához."
 
-#: src/olympia/devhub/templates/devhub/personas/edit.html:217
-#: src/olympia/devhub/templates/devhub/personas/submit.html:163
+#: src/olympia/devhub/templates/devhub/personas/edit.html:217 src/olympia/devhub/templates/devhub/personas/submit.html:163
 msgid "Theme Design"
 msgstr "Téma dizájn"
 
-#: src/olympia/devhub/templates/devhub/personas/edit.html:221
-#: src/olympia/devhub/templates/devhub/personas/edit.html:224
+#: src/olympia/devhub/templates/devhub/personas/edit.html:221 src/olympia/devhub/templates/devhub/personas/edit.html:224
 msgid "Upload New Design"
 msgstr "Új dizájn feltöltése"
 
 #: src/olympia/devhub/templates/devhub/personas/edit.html:226
-msgid ""
-"Upon upload and form submission, the AMO Team will review your updated "
-"design. Your current design will still be public in the meantime."
+msgid "Upon upload and form submission, the AMO Team will review your updated design. Your current design will still be public in the meantime."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/personas/edit.html:241
-msgid "Your previously resubmitted design,  which is under pending review."
+msgid "Your previously resubmitted design, which is under pending review."
 msgstr "Az előzőleg benyújtott dizájnja, amely értékelésre vár."
 
 #: src/olympia/devhub/templates/devhub/personas/edit.html:245
@@ -8375,43 +6519,35 @@ msgstr "Fejléc"
 msgid "Footer"
 msgstr "Lábléc"
 
-#: src/olympia/devhub/templates/devhub/personas/edit.html:274
-#: src/olympia/devhub/templates/devhub/personas/submit.html:167
+#: src/olympia/devhub/templates/devhub/personas/edit.html:274 src/olympia/devhub/templates/devhub/personas/submit.html:167
 msgid "Select colors for your Theme."
 msgstr "Válasszon színeket a témájához."
 
-#: src/olympia/devhub/templates/devhub/personas/edit.html:276
-#: src/olympia/devhub/templates/devhub/personas/submit.html:169
+#: src/olympia/devhub/templates/devhub/personas/edit.html:276 src/olympia/devhub/templates/devhub/personas/submit.html:169
 msgid "Foreground Text"
 msgstr "Előtér felirat"
 
-#: src/olympia/devhub/templates/devhub/personas/edit.html:277
-#: src/olympia/devhub/templates/devhub/personas/submit.html:170
+#: src/olympia/devhub/templates/devhub/personas/edit.html:277 src/olympia/devhub/templates/devhub/personas/submit.html:170
 msgid "This is the color of the tab text."
 msgstr "Ez a lapfelirat színe."
 
-#: src/olympia/devhub/templates/devhub/personas/edit.html:279
-#: src/olympia/devhub/templates/devhub/personas/submit.html:172
+#: src/olympia/devhub/templates/devhub/personas/edit.html:279 src/olympia/devhub/templates/devhub/personas/submit.html:172
 msgid "Background"
 msgstr "Háttér"
 
-#: src/olympia/devhub/templates/devhub/personas/edit.html:280
-#: src/olympia/devhub/templates/devhub/personas/submit.html:173
+#: src/olympia/devhub/templates/devhub/personas/edit.html:280 src/olympia/devhub/templates/devhub/personas/submit.html:173
 msgid "This is the color of the tabs."
 msgstr "Ez a lapok színe."
 
-#: src/olympia/devhub/templates/devhub/personas/edit.html:285
-#: src/olympia/devhub/templates/devhub/personas/submit.html:178
+#: src/olympia/devhub/templates/devhub/personas/edit.html:285 src/olympia/devhub/templates/devhub/personas/submit.html:178
 msgid "Preview"
 msgstr "Előnézet"
 
-#: src/olympia/devhub/templates/devhub/personas/edit.html:291
-#: src/olympia/devhub/templates/devhub/personas/submit.html:183
+#: src/olympia/devhub/templates/devhub/personas/edit.html:291 src/olympia/devhub/templates/devhub/personas/submit.html:183
 msgid "Your Theme's Name"
 msgstr "Téma neve"
 
-#: src/olympia/devhub/templates/devhub/personas/edit.html:294
-#: src/olympia/devhub/templates/devhub/personas/submit.html:186
+#: src/olympia/devhub/templates/devhub/personas/edit.html:294 src/olympia/devhub/templates/devhub/personas/submit.html:186
 #, python-format
 msgid "by <a href=\"%(profile_url)s\" target=\"_blank\">%(user)s</a>"
 msgstr "készítette: <a href=\"%(profile_url)s\" target=\"_blank\">%(user)s</a>"
@@ -8422,32 +6558,17 @@ msgstr "Új téma létrehozása"
 
 #: src/olympia/devhub/templates/devhub/personas/submit.html:18
 #, python-format
-msgid ""
-"Background themes let you easily personalize the look of your Firefox. "
-"Submit your own design below, or <a href=\"%(submit_url)s\">learn how to "
-"create one</a>!"
+msgid "Background themes let you easily personalize the look of your Firefox. Submit your own design below, or <a href=\"%(submit_url)s\">learn how to create one</a>!"
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/personas/submit.html:33
 msgid "Give your Theme a name."
 msgstr "Adjon egy nevet a témának."
 
-#: src/olympia/devhub/templates/devhub/personas/submit.html:54
-msgid ""
-"A short explanation of your theme's basic functionality that is displayed in"
-" search and browse listings, as well as at the top of your theme's details "
-"page."
-msgstr ""
-"Egy rövid magyarázat a témája alapfunkcionalitásáról, amely megjelenik a "
-"keresésekben és a böngészi listázásokban, valamint a témája részletező "
-"oldalának tetején."
-
 #: src/olympia/devhub/templates/devhub/personas/submit.html:198
 #, python-format
 msgid ""
-"I agree to the <a href=\"%(agreement_url)s\" target=\"_blank\">Firefox Add-"
-"on Distribution Agreement</a> and to my information being handled as "
-"described in the <a href=\"%(privacy_notice_url)s\" "
+"I agree to the <a href=\"%(agreement_url)s\" target=\"_blank\">Firefox Add-on Distribution Agreement</a> and to my information being handled as described in the <a href=\"%(privacy_notice_url)s\" "
 "target=\"_blank\">Websites, Communications and Cookies Privacy Notice</a>."
 msgstr ""
 
@@ -8456,23 +6577,17 @@ msgid "Submit Theme"
 msgstr "Téma benyújtása"
 
 #: src/olympia/devhub/templates/devhub/personas/submit_done.html:11
-msgid ""
-"Your theme has been submitted to the Review Queue. You'll receive an email "
-"once it has been reviewed, typically within 24 hours."
+msgid "Your theme has been submitted to the Review Queue. You'll receive an email once it has been reviewed, typically within 24 hours."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/personas/submit_done.html:19
 #, python-format
-msgid ""
-"Provide more details about your theme by <a href=\"%(edit_url)s\">editing "
-"its listing</a>."
+msgid "Provide more details about your theme by <a href=\"%(edit_url)s\">editing its listing</a>."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/personas/submit_done.html:25
 #, python-format
-msgid ""
-"View and subscribe to your theme's <a href=\"%(feed_url)s\">activity "
-"feed</a> to stay updated on reviews, collections, and more."
+msgid "View and subscribe to your theme's <a href=\"%(feed_url)s\">activity feed</a> to stay updated on reviews, collections, and more."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/personas/submit_done.html:32
@@ -8488,13 +6603,11 @@ msgstr "Válasszon fejléc képet a témájához."
 msgid "3000 &times; 200 pixels"
 msgstr "3000 &times; 200 képpont"
 
-#: src/olympia/devhub/templates/devhub/personas/includes/theme_design.html:9
-#: src/olympia/devhub/templates/devhub/personas/includes/theme_design.html:25
+#: src/olympia/devhub/templates/devhub/personas/includes/theme_design.html:9 src/olympia/devhub/templates/devhub/personas/includes/theme_design.html:25
 msgid "300 KB max"
 msgstr "max. 300 KB"
 
-#: src/olympia/devhub/templates/devhub/personas/includes/theme_design.html:10
-#: src/olympia/devhub/templates/devhub/personas/includes/theme_design.html:26
+#: src/olympia/devhub/templates/devhub/personas/includes/theme_design.html:10 src/olympia/devhub/templates/devhub/personas/includes/theme_design.html:26
 msgid "PNG or JPG"
 msgstr "PNG vagy JPG"
 
@@ -8523,55 +6636,31 @@ msgid "Select a different footer image"
 msgstr "Válasszon másik alsó képet"
 
 #: src/olympia/devhub/templates/devhub/versions/add_file_modal.html:8
-msgid ""
-"Files added to reviewed versions must be reviewed before they will be "
-"available for download."
-msgstr ""
-"Az értékelt verziókhoz hozzáadott fájlokat értékelni kell, mielőtt azokat "
-"elérhetők lesznek."
+msgid "Files added to reviewed versions must be reviewed before they will be available for download."
+msgstr "Az értékelt verziókhoz hozzáadott fájlokat értékelni kell, mielőtt azokat elérhetők lesznek."
 
-#: src/olympia/devhub/templates/devhub/versions/add_file_modal.html:15
-#, python-format
-msgid ""
-"Submission of updates to unlisted add-ons for signing is currently in an "
-"open beta. Manual review may still be required for a large number of add-"
-"ons. Please <a href=\"%(url)s\" target=\"_blank\">report any bugs</a> that "
-"you encounter."
-msgstr ""
-
-#: src/olympia/devhub/templates/devhub/versions/add_file_modal.html:35
+#: src/olympia/devhub/templates/devhub/versions/add_file_modal.html:24
 msgid "Select the target platform for this file."
 msgstr "Válassza ki a fájl futtatására alkalmas platformot."
 
-#: src/olympia/devhub/templates/devhub/versions/add_file_modal.html:46
+#: src/olympia/devhub/templates/devhub/versions/add_file_modal.html:35
 msgid "Which review type would you like to nominate for?"
 msgstr "Melyik értékeléstípusra szeretne benevezni?"
 
-#: src/olympia/devhub/templates/devhub/versions/add_file_modal.html:51
+#: src/olympia/devhub/templates/devhub/versions/add_file_modal.html:40
 msgid "Only publish this version to my beta channel."
 msgstr "A verzió közzététele csak a béta csatornán."
-
-#: src/olympia/devhub/templates/devhub/versions/add_file_modal.html:54
-#, python-format
-msgid ""
-"The behavior of the beta channel has changed to accommodate <a "
-"href=\"%(addon_signing_url)s\" target=\"_blank\">mandatory add-on "
-"signing</a>. The new process is currently in an open beta, and may change "
-"significantly in the near future. Please <a href=\"%(issues_url)s\" "
-"target=\"_blank\">report any bugs</a> that you encounter."
-msgstr ""
 
 #: src/olympia/devhub/templates/devhub/versions/edit.html:5
 msgid "Manage Version {0}"
 msgstr "{0} verzió kezelése"
 
-#: src/olympia/devhub/templates/devhub/versions/edit.html:12
-#: src/olympia/devhub/templates/devhub/versions/list.html:3
+#: src/olympia/devhub/templates/devhub/versions/edit.html:12 src/olympia/devhub/templates/devhub/versions/list.html:3
 msgid "Status & Versions"
 msgstr "Állapot és verziók"
 
-#. {0} is an add-on name.
 # {0} is the name of the collection
+#. {0} is an add-on name.
 #: src/olympia/devhub/templates/devhub/versions/edit.html:16
 msgid "Manage {0}"
 msgstr "{0} kezelése"
@@ -8584,57 +6673,35 @@ msgstr "Fájlok"
 msgid "Upload Another File"
 msgstr "Másik fájl feltöltése"
 
-#: src/olympia/devhub/templates/devhub/versions/edit.html:45
-msgid ""
-"Adjusting application information here will allow users to install your add-"
-"on even if the install manifest in the package indicates that the add-on is "
-"incompatible."
-msgstr ""
-"Az alkalmazás információjának beállításával a felhasználóknak lehetőségük "
-"van a kiegészítők telepítésére, abban az esetben is, ha a telepítéskor a "
-"kiegészítő azt jelzi, hogy nem kompatibilis az adott rendszerrel."
-
 #: src/olympia/devhub/templates/devhub/versions/edit.html:74
 msgid ""
-"Information about changes in this release, new features, known bugs, and "
-"other useful information specific to this release/version. This information "
-"is also shown in the Add-ons Manager when updating."
+"Information about changes in this release, new features, known bugs, and other useful information specific to this release/version. This information is also shown in the Add-ons Manager when "
+"updating."
 msgstr ""
-"Információk a kiadás változásairól, új szolgáltatásairól, ismert hibáiról és"
-" a kiadásra/verzióra jellemző más hasznos információk. Ezek az információk "
-"frissítéskor megjelennek a kiegészítőkezelő felületén."
+"Információk a kiadás változásairól, új szolgáltatásairól, ismert hibáiról és a kiadásra/verzióra jellemző más hasznos információk. Ezek az információk frissítéskor megjelennek a kiegészítőkezelő "
+"felületén."
 
 #: src/olympia/devhub/templates/devhub/versions/edit.html:99
 msgid "Approval Status"
 msgstr "Jóváhagyás állapota"
 
-#: src/olympia/devhub/templates/devhub/versions/edit.html:113
-#: src/olympia/editors/templates/editors/review.html:108
+#: src/olympia/devhub/templates/devhub/versions/edit.html:113 src/olympia/editors/templates/editors/review.html:108
 msgid "Notes for Reviewers"
 msgstr "Megjegyzés az értékelőknek"
 
 #: src/olympia/devhub/templates/devhub/versions/edit.html:114
-msgid ""
-"Optionally, enter any information that may be useful to the Editor reviewing"
-" this add-on, such as test account information."
-msgstr ""
-"Tetszés szerint adjon meg minden olyan információt, amely hasznos lehet a "
-"szerkesztő számára (például a tesztfelhasználót)."
+msgid "Optionally, enter any information that may be useful to the Editor reviewing this add-on, such as test account information."
+msgstr "Tetszés szerint adjon meg minden olyan információt, amely hasznos lehet a szerkesztő számára (például a tesztfelhasználót)."
 
 #: src/olympia/devhub/templates/devhub/versions/edit.html:127
 msgid "Source code"
 msgstr "Forráskód"
 
 #: src/olympia/devhub/templates/devhub/versions/edit.html:128
-msgid ""
-"If your add-on contain binary or obfuscated code, make the source available "
-"here for reviewers."
-msgstr ""
-"Ha a kiegészítő bináris vagy olvashatatlanná tett kódot tartalmaz, akkor "
-"tegye elérhetővé itt a forrást az értékelőknek."
+msgid "If your add-on contain binary or obfuscated code, make the source available here for reviewers."
+msgstr "Ha a kiegészítő bináris vagy olvashatatlanná tett kódot tartalmaz, akkor tegye elérhetővé itt a forrást az értékelőknek."
 
-#: src/olympia/devhub/templates/devhub/versions/edit.html:145
-#: src/olympia/devhub/templates/devhub/versions/edit.html:149
+#: src/olympia/devhub/templates/devhub/versions/edit.html:145 src/olympia/devhub/templates/devhub/versions/edit.html:149
 msgid "Upload a new file"
 msgstr "Új fájl feltöltése"
 
@@ -8649,9 +6716,7 @@ msgstr "Fájl {file_id} ({platform})"
 #: src/olympia/devhub/templates/devhub/versions/file_status_message.html:5
 #, python-format
 msgid "Created on %(created)s and changed to %(status)s on %(status_date)s"
-msgstr ""
-"Létrehozva ekkor: %(created)s, módosítva %(status)s állapotra ekkor: "
-"%(status_date)s"
+msgstr "Létrehozva ekkor: %(created)s, módosítva %(status)s állapotra ekkor: %(status_date)s"
 
 #: src/olympia/devhub/templates/devhub/versions/file_status_message.html:9
 #, python-format
@@ -8703,9 +6768,7 @@ msgstr "Teljes értékelés kérése"
 msgid "Request Preliminary Review"
 msgstr "Előzetes értékelés kérése"
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:80
-#: src/olympia/devhub/templates/devhub/versions/list.html:327
-#: src/olympia/devhub/templates/devhub/versions/list.html:350
+#: src/olympia/devhub/templates/devhub/versions/list.html:80 src/olympia/devhub/templates/devhub/versions/list.html:325 src/olympia/devhub/templates/devhub/versions/list.html:348
 msgid "Cancel Review Request"
 msgstr "Értékelés kérésének megszakítása"
 
@@ -8718,35 +6781,24 @@ msgid "Listed:"
 msgstr "Felsorolva:"
 
 #: src/olympia/devhub/templates/devhub/versions/list.html:102
-msgid ""
-"Visible to everyone on {0} and included in search results and listing pages"
-msgstr ""
-"Mindenki számára látható itt: {0}, valamint szerepel a találatok között és a"
-" listázási oldalakon"
+msgid "Visible to everyone on {0} and included in search results and listing pages"
+msgstr "Mindenki számára látható itt: {0}, valamint szerepel a találatok között és a listázási oldalakon"
 
 #: src/olympia/devhub/templates/devhub/versions/list.html:108
 msgid "Hidden:"
 msgstr "Rejtett:"
 
 #: src/olympia/devhub/templates/devhub/versions/list.html:108
-msgid ""
-"Hosted on {0}, but hidden to anyone but authors. Used to temporarily hide "
-"listings or discontinue them."
-msgstr ""
-"Kiszolgálva itt: {0}, de a szerzőkön kívül mindenki számára rejtett. A "
-"listázások ideiglenes elrejtésére vagy megszüntetésére használható."
+msgid "Hosted on {0}, but hidden to anyone but authors. Used to temporarily hide listings or discontinue them."
+msgstr "Kiszolgálva itt: {0}, de a szerzőkön kívül mindenki számára rejtett. A listázások ideiglenes elrejtésére vagy megszüntetésére használható."
 
 #: src/olympia/devhub/templates/devhub/versions/list.html:114
 msgid "Unlisted:"
 msgstr "Titkos:"
 
 #: src/olympia/devhub/templates/devhub/versions/list.html:114
-msgid ""
-"Not distributed on {0}. Developers will upload new versions for signing and "
-"distribute the add-ons on their own. (beta)"
+msgid "Not distributed on {0}. Developers will upload new versions for signing and distribute the add-ons on their own."
 msgstr ""
-"Nem terjesztett itt: {0}. A fejlesztők feltöltik az új verziókat aláírásra, "
-"és maguk terjesztik a kiegészítőt. (béta)"
 
 #: src/olympia/devhub/templates/devhub/versions/list.html:122
 msgid "Current versions"
@@ -8756,18 +6808,13 @@ msgstr "Jelenlegi verziók"
 msgid "Currently on AMO"
 msgstr "Jelenleg az AMO-n"
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:129
-#: src/olympia/devhub/templates/devhub/versions/list.html:147
-#: src/olympia/devhub/templates/devhub/versions/list.html:164
-#: src/olympia/editors/templates/editors/includes/search_results_themes.html:7
-#: src/olympia/editors/templates/editors/themes/queue_list.html:50
+#: src/olympia/devhub/templates/devhub/versions/list.html:129 src/olympia/devhub/templates/devhub/versions/list.html:147 src/olympia/devhub/templates/devhub/versions/list.html:164
+#: src/olympia/editors/templates/editors/includes/search_results_themes.html:7 src/olympia/editors/templates/editors/themes/queue_list.html:50
 msgid "Status"
 msgstr "Állapot"
 
 # Header for a column in a table
-#: src/olympia/devhub/templates/devhub/versions/list.html:130
-#: src/olympia/devhub/templates/devhub/versions/list.html:148
-#: src/olympia/devhub/templates/devhub/versions/list.html:165
+#: src/olympia/devhub/templates/devhub/versions/list.html:130 src/olympia/devhub/templates/devhub/versions/list.html:148 src/olympia/devhub/templates/devhub/versions/list.html:165
 #: src/olympia/editors/templates/editors/includes/files_view.html:11
 msgid "Validation"
 msgstr "Ellenőrzés"
@@ -8789,10 +6836,7 @@ msgid "Full review may not be required"
 msgstr "A teljes értékelés nem biztos hogy szükséges"
 
 #: src/olympia/devhub/templates/devhub/versions/list.html:201
-msgid ""
-"Unlisted add-ons don't need Full Review unless they are distributed as part "
-"of an application installer. Read <a href=\"{link}\" target=\"_blank\">this "
-"documentation</a> for more information."
+msgid "Unlisted add-ons don't need Full Review unless they are distributed as part of an application installer. Read <a href=\"{link}\" target=\"_blank\">this documentation</a> for more information."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/versions/list.html:209
@@ -8804,10 +6848,7 @@ msgid "Delete Version {version}"
 msgstr "{version} verzió törlése"
 
 #: src/olympia/devhub/templates/devhub/versions/list.html:218
-msgid ""
-"You are about to delete the current version of your add-on. This may cause "
-"your add-on status to change, or your listing to lose public visibility, if "
-"this is the only public version of your add-on."
+msgid "You are about to delete the current version of your add-on. This may cause your add-on status to change, or your listing to lose public visibility, if this is the only public version of your add-on."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/versions/list.html:219
@@ -8815,107 +6856,77 @@ msgid "Deleting this version will permanently delete:"
 msgstr "A verzió törlése véglegesen törli:"
 
 #: src/olympia/devhub/templates/devhub/versions/list.html:225
-msgid ""
-"<strong>Important:</strong> Once a version has been deleted, you may not "
-"upload a new version with the same version number."
+msgid "<strong>Important:</strong> Once a version has been deleted, you may not upload a new version with the same version number."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/versions/list.html:230
-msgid ""
-"Deleting a version which has already been reviewed\n"
-"               may also cause a significant delay in the review of\n"
-"               your next update."
-msgstr ""
-
-#: src/olympia/devhub/templates/devhub/versions/list.html:233
 msgid "Are you sure you wish to delete this version?"
 msgstr "Biztos, hogy törölni szeretné ezt az verziót?"
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:238
+#: src/olympia/devhub/templates/devhub/versions/list.html:235
 msgid "Delete Version"
 msgstr "Verzió törlése"
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:240
+#: src/olympia/devhub/templates/devhub/versions/list.html:237
 msgid "Disable Version"
 msgstr "Verzió letiltása"
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:247
+#: src/olympia/devhub/templates/devhub/versions/list.html:244
 msgid "Add a new Version"
 msgstr "Új verzió hozzáadása"
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:249
+#: src/olympia/devhub/templates/devhub/versions/list.html:246
 msgid "Add Version"
 msgstr "Verzió hozzáadása"
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:256
-#: src/olympia/devhub/templates/devhub/versions/list.html:274
+#: src/olympia/devhub/templates/devhub/versions/list.html:253 src/olympia/devhub/templates/devhub/versions/list.html:279
 msgid "Hide Add-on"
 msgstr "Kiegészítő elrejtése"
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:259
-msgid ""
-"Hiding your add-on will prevent it from appearing anywhere in our gallery "
-"and will stop users from receiving automatic updates."
+#: src/olympia/devhub/templates/devhub/versions/list.html:256
+msgid "Hiding your add-on will prevent it from appearing anywhere in our gallery and will stop users from receiving automatic updates."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:265
+#: src/olympia/devhub/templates/devhub/versions/list.html:263
+msgid "The files awaiting review will be disabled and you will need to upload new versions."
+msgstr ""
+
+#: src/olympia/devhub/templates/devhub/versions/list.html:270
 msgid "Are you sure you wish to hide your add-on?"
 msgstr "Biztos, hogy el kívánja rejteni a kiegészítőjét?"
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:286
-#: src/olympia/devhub/templates/devhub/versions/list.html:315
+#: src/olympia/devhub/templates/devhub/versions/list.html:291 src/olympia/devhub/templates/devhub/versions/list.html:313
 msgid "Unlist Add-on"
 msgstr "Kiegészítő listázásának megszüntetése"
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:289
+#: src/olympia/devhub/templates/devhub/versions/list.html:294
 #, python-format
 msgid ""
-"Unlisting your add-on will make it (and each of its versions/files) "
-"invisible on this website. It won't show up in searches, won't have a public"
-" facing page, and won't be updated automatically for current users.  It is "
-"recommended for unlisted add-ons to provide a custom <a "
-"href=\"%(update_url)s\" target=\"_blank\">updateURL</a> in their manifest "
-"file for automatic updates."
+"Unlisting your add-on will make it (and each of its versions/files) invisible on this website. It won't show up in searches, won't have a public facing page, and won't be updated automatically for "
+"current users. It is recommended for unlisted add-ons to provide a custom <a href=\"%(update_url)s\" target=\"_blank\">updateURL</a> in their manifest file for automatic updates."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:299
-#, python-format
-msgid ""
-"Switching add-ons to unlisted is currently in an open beta. Please <a "
-"href=\"%(url)s\" target=\"_blank\">report any bugs</a> that you encounter."
-msgstr ""
-
-#: src/olympia/devhub/templates/devhub/versions/list.html:305
+#: src/olympia/devhub/templates/devhub/versions/list.html:303
 msgid "Unlisting an add-on is irreversible!"
 msgstr "A kiegészítő listázásának visszavonása nem visszafordítható!"
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:305
+#: src/olympia/devhub/templates/devhub/versions/list.html:303
 msgid "An unlisted add-on cannot be switched to be listed."
 msgstr "Egy nem listázott kiegészítő nem kapcsolható vissza listázottá."
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:307
+#: src/olympia/devhub/templates/devhub/versions/list.html:305
 msgid "Are you sure you wish to unlist your add-on?"
 msgstr "Biztos, hogy vissza akarja vonni a kiegészítő listázását?"
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:330
-msgid ""
-"Canceling your review request will leave your add-on as preliminarily "
-"reviewed."
-msgstr ""
-"Az ellenőrzési kérelem megszakításával a kiegészítő előzetesen értékelt "
-"állapotú lesz."
+#: src/olympia/devhub/templates/devhub/versions/list.html:328
+msgid "Canceling your review request will leave your add-on as preliminarily reviewed."
+msgstr "Az ellenőrzési kérelem megszakításával a kiegészítő előzetesen értékelt állapotú lesz."
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:335
-msgid ""
-"Canceling your review request will mark your add-on incomplete. If you do "
-"not complete your add-on after several days by re-requesting review, it will"
-" be deleted."
-msgstr ""
-"Az értékelési kérelem megszakításával a kiegészítő \"nem teljes\" állapotba "
-"kerül. Amennyiben néhány napon belül nem egészíti ki az értékelési kérelmét,"
-" abban az esetben törlésre kerül."
+#: src/olympia/devhub/templates/devhub/versions/list.html:333
+msgid "Canceling your review request will mark your add-on incomplete. If you do not complete your add-on after several days by re-requesting review, it will be deleted."
+msgstr "Az értékelési kérelem megszakításával a kiegészítő \"nem teljes\" állapotba kerül. Amennyiben néhány napon belül nem egészíti ki az értékelési kérelmét, abban az esetben törlésre kerül."
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:343
+#: src/olympia/devhub/templates/devhub/versions/list.html:341
 msgid "Are you sure you wish to cancel your review request?"
 msgstr "Biztosan megszakítja az értékelési kérést?"
 
@@ -8948,19 +6959,12 @@ msgid "Translate content on the web from and into over 40 languages."
 msgstr "Fordítsa a weboldal tartalmát 40 nyelvről vagy 40 nyelvre."
 
 #: src/olympia/discovery/modules.py:171
-msgid ""
-"Easily connect to your social networks, and share or comment on the page "
-"you're visiting."
-msgstr ""
-"Kapcsolódjon egyszerűen a közösségi hálózataihoz és osszon meg oldalakat "
-"vagy adjon megjegyzéseket hozzájuk."
+msgid "Easily connect to your social networks, and share or comment on the page you're visiting."
+msgstr "Kapcsolódjon egyszerűen a közösségi hálózataihoz és osszon meg oldalakat vagy adjon megjegyzéseket hozzájuk."
 
 #: src/olympia/discovery/modules.py:173
-msgid ""
-"A quick view to compare prices when you shop online or search for flights."
-msgstr ""
-"Gyorsan hasonlítsa össze az árakat vásárlás közben vagy keressen egy "
-"repülőjáratot."
+msgid "A quick view to compare prices when you shop online or search for flights."
+msgstr "Gyorsan hasonlítsa össze az árakat vásárlás közben vagy keressen egy repülőjáratot."
 
 #: src/olympia/discovery/modules.py:183
 msgid "Firefox 4 Collection"
@@ -9003,25 +7007,16 @@ msgid "Add-ons that help you on your travels!"
 msgstr "Kiegészítők, melyek segítik az utazásaiban!"
 
 #: src/olympia/discovery/modules.py:226
-msgid ""
-"Displays a country flag depicting the location of the current website's "
-"server and more."
-msgstr ""
-"Megjeleníti az ország zászlóját, ahol a jelenlegi weboldal kiszolgálója "
-"található, és még többet."
+msgid "Displays a country flag depicting the location of the current website's server and more."
+msgstr "Megjeleníti az ország zászlóját, ahol a jelenlegi weboldal kiszolgálója található, és még többet."
 
 #: src/olympia/discovery/modules.py:228
 msgid "FoxClocks let you keep an eye on the time around the world."
-msgstr ""
-"A FoxClocks lehetővé teszi, hogy szemmel tartsa az időt a világ körül."
+msgstr "A FoxClocks lehetővé teszi, hogy szemmel tartsa az időt a világ körül."
 
 #: src/olympia/discovery/modules.py:230
-msgid ""
-"Automatically get the lowest price when you shop online or search for "
-"flights."
-msgstr ""
-"Automatikusan a legalacsonyabb árat kapja, ha az interneten vásárol vagy "
-"repülőjegyet keres."
+msgid "Automatically get the lowest price when you shop online or search for flights."
+msgstr "Automatikusan a legalacsonyabb árat kapja, ha az interneten vásárol vagy repülőjegyet keres."
 
 #: src/olympia/discovery/modules.py:240
 msgid "A+ add-ons for School"
@@ -9060,13 +7055,8 @@ msgid "Put a Theme on It!"
 msgstr "Tegyen rá egy témát!"
 
 #: src/olympia/discovery/modules.py:281
-msgid ""
-"Visit addons.mozilla.org from Firefox for Android and dress up your mobile "
-"browser to match your style, mood, or the season."
-msgstr ""
-"Látogassa meg az addons.mozilla.org oldalt a Firefox for Androidból, és "
-"öltöztesse fel böngészőjét, hogy az illeszkedjen a stílusához, hangulatához "
-"vagy az évszakhoz."
+msgid "Visit addons.mozilla.org from Firefox for Android and dress up your mobile browser to match your style, mood, or the season."
+msgstr "Látogassa meg az addons.mozilla.org oldalt a Firefox for Androidból, és öltöztesse fel böngészőjét, hogy az illeszkedjen a stílusához, hangulatához vagy az évszakhoz."
 
 #: src/olympia/discovery/modules.py:290
 msgid "Get up and move!"
@@ -9074,8 +7064,7 @@ msgstr "Álljon fel és mozogjon!"
 
 #: src/olympia/discovery/modules.py:291
 msgid "Install these fitness add-ons to keep you active and healthy."
-msgstr ""
-"Telepítse ezeket a fitnesz kiegészítőket, hogy aktív és egészséges maradjon."
+msgstr "Telepítse ezeket a fitnesz kiegészítőket, hogy aktív és egészséges maradjon."
 
 #: src/olympia/discovery/modules.py:299
 msgid "New &amp; Now"
@@ -9091,17 +7080,11 @@ msgstr "Aggodalommentes böngészés"
 
 #: src/olympia/discovery/modules.py:333
 msgid "Protect your privacy online with the add-ons in this collection."
-msgstr ""
-"Védje meg az online magánszféráját az ebben a gyűjteményben található "
-"kiegészítőkkel."
+msgstr "Védje meg az online magánszféráját az ebben a gyűjteményben található kiegészítőkkel."
 
 #: src/olympia/discovery/modules.py:342
-msgid ""
-"Great add-ons for work, fun, privacy, productivity&hellip; just about "
-"anything!"
-msgstr ""
-"Nagyszerű kiegészítők munkához, szórakozáshoz, magánszférához, "
-"produktivitáshoz&hellip; majdnem bármihez!"
+msgid "Great add-ons for work, fun, privacy, productivity&hellip; just about anything!"
+msgstr "Nagyszerű kiegészítők munkához, szórakozáshoz, magánszférához, produktivitáshoz&hellip; majdnem bármihez!"
 
 #: src/olympia/discovery/modules.py:350
 msgid "Add-ons for Australis Contest Winners"
@@ -9121,22 +7104,16 @@ msgstr "Mik azok a kiegészítők?"
 
 #: src/olympia/discovery/templates/discovery/pane.html:28
 #, python-format
-msgid ""
-"Add-ons are applications that let you personalize %(app)s with extra "
-"functionality or style. Try a time-saving sidebar, a weather notifier, or a "
-"themed look to make %(app)s your own."
+msgid "Add-ons are applications that let you personalize %(app)s with extra functionality or style. Try a time-saving sidebar, a weather notifier, or a themed look to make %(app)s your own."
 msgstr ""
-"A kiegészítők olyan alkalmazások, amelynek segítségével személyre szabható, "
-"extra szolgáltatások vagy funkciók adhatók a %(app)s alkalmazáshoz. Próbálja"
-" ki az időjárás értesítőt, a hírkeresőt vagy a %(app)s alkalmazáshoz "
-"készített témák valamelyikét."
+"A kiegészítők olyan alkalmazások, amelynek segítségével személyre szabható, extra szolgáltatások vagy funkciók adhatók a %(app)s alkalmazáshoz. Próbálja ki az időjárás értesítőt, a hírkeresőt vagy "
+"a %(app)s alkalmazáshoz készített témák valamelyikét."
 
 #: src/olympia/discovery/templates/discovery/pane.html:62
 msgid "Learn More About Add-ons"
 msgstr "Tudjon meg többet a kiegészítőkről"
 
-#: src/olympia/discovery/templates/discovery/pane.html:66
-#: src/olympia/discovery/templates/discovery/pane.html:73
+#: src/olympia/discovery/templates/discovery/pane.html:66 src/olympia/discovery/templates/discovery/pane.html:73
 msgid "See all"
 msgstr "Összes"
 
@@ -9167,12 +7144,8 @@ msgstr "Üdvözöljük, {0}!"
 
 #: src/olympia/discovery/templates/discovery/pane_account.html:17
 #, python-format
-msgid ""
-"Thanks for using %(app)s and supporting <a href=\"%(url)s\">Mozilla's "
-"mission</a>!"
-msgstr ""
-"Köszönjük, hogy a %(app)s alkalmazást használja és támogatja <a "
-"href=\"%(url)s\">Mozilla küldetését</a>!"
+msgid "Thanks for using %(app)s and supporting <a href=\"%(url)s\">Mozilla's mission</a>!"
+msgstr "Köszönjük, hogy a %(app)s alkalmazást használja és támogatja <a href=\"%(url)s\">Mozilla küldetését</a>!"
 
 #: src/olympia/discovery/templates/discovery/pane_account.html:23
 msgid "Add-ons downloaded:"
@@ -9196,15 +7169,10 @@ msgstr "Töltsön le kiegészítőt az útra"
 
 #: src/olympia/discovery/templates/discovery/modules/go-mobile.html:8
 #, python-format
-msgid ""
-"Visit <a href=\"%(url)s\">firefox.com/m</a> to get Firefox on your phone and"
-" personalize your browser anytime, anywhere. Easily discover and install "
-"add-ons from the mobile Add-ons Manager."
+msgid "Visit <a href=\"%(url)s\">firefox.com/m</a> to get Firefox on your phone and personalize your browser anytime, anywhere. Easily discover and install add-ons from the mobile Add-ons Manager."
 msgstr ""
-"Látogassa meg a <a href=\"%(url)s\">firefox.com/m</a> weboldalt a Firefox "
-"telefonra történő letöltéséhez és bármikor, bárhol testreszabhatja "
-"böngészőjét. Könnyedén találhat és telepíthet kiegészítőket a "
-"kiegészítőkezelő segítségével."
+"Látogassa meg a <a href=\"%(url)s\">firefox.com/m</a> weboldalt a Firefox telefonra történő letöltéséhez és bármikor, bárhol testreszabhatja böngészőjét. Könnyedén találhat és telepíthet "
+"kiegészítőket a kiegészítőkezelő segítségével."
 
 #: src/olympia/discovery/templates/discovery/modules/go-mobile.html:13
 msgid "Get Mobile Add-ons"
@@ -9216,24 +7184,15 @@ msgstr "Vásároljon okosan ebben az ünnepi időszakban"
 
 #: src/olympia/discovery/templates/discovery/modules/holiday.html:5
 msgid "Find great add-ons to help you with all your holiday shopping needs."
-msgstr ""
-"Találjon nagyszerű kiegészítőket, melyek segítenek az ünnepi bevásárlásban."
+msgstr "Találjon nagyszerű kiegészítőket, melyek segítenek az ünnepi bevásárlásban."
 
 #: src/olympia/discovery/templates/discovery/modules/holiday.html:13
-msgid ""
-"Install the Amazon Browser Apps and receive special Amazon features right at"
-" your fingertips."
-msgstr ""
-"Telepítse az Amazon böngésző alkalmazásokat, és különleges Amazon funkciókat"
-" fog kapni, egy karnyújtásnyira."
+msgid "Install the Amazon Browser Apps and receive special Amazon features right at your fingertips."
+msgstr "Telepítse az Amazon böngésző alkalmazásokat, és különleges Amazon funkciókat fog kapni, egy karnyújtásnyira."
 
 #: src/olympia/discovery/templates/discovery/modules/holiday.html:22
-msgid ""
-"Keep an eye on your eBay activity wherever you are on the web when you "
-"install the eBay Sidebar for Firefox."
-msgstr ""
-"Tartsa szemmel a eBay tevékenységét, bárhol az interneten, amint telepíti az"
-" eBay oldalsávot a Firefoxhoz."
+msgid "Keep an eye on your eBay activity wherever you are on the web when you install the eBay Sidebar for Firefox."
+msgstr "Tartsa szemmel a eBay tevékenységét, bárhol az interneten, amint telepíti az eBay oldalsávot a Firefoxhoz."
 
 #: src/olympia/discovery/templates/discovery/modules/holiday.html:31
 msgid "See the entire holiday shopping add-on collection."
@@ -9310,19 +7269,19 @@ msgstr "kiegészítő, szerkesztő vagy megjegyzés"
 msgid "Search by add-on name / author email"
 msgstr "Keresés kiegészítő neve / szerző e-mail címe szerint"
 
-#: src/olympia/editors/forms.py:103
+#: src/olympia/editors/forms.py:103 src/olympia/editors/forms.py:244 src/olympia/editors/forms.py:257
 msgid "yes"
 msgstr "igen"
 
-#: src/olympia/editors/forms.py:104
+#: src/olympia/editors/forms.py:104 src/olympia/editors/forms.py:244 src/olympia/editors/forms.py:257
 msgid "no"
 msgstr "nem"
 
-#: src/olympia/editors/forms.py:105
+#: src/olympia/editors/forms.py:105 src/olympia/editors/forms.py:245
 msgid "Admin Flag"
 msgstr "Admin jel"
 
-#: src/olympia/editors/forms.py:113
+#: src/olympia/editors/forms.py:113 src/olympia/editors/forms.py:253
 msgid "Max. Version"
 msgstr "Max. verzió"
 
@@ -9334,59 +7293,59 @@ msgstr "Benyújtás óta eltelt napok száma"
 msgid "Add-on Types"
 msgstr "Kiegészítőtípusok"
 
-#: src/olympia/editors/forms.py:126 src/olympia/editors/helpers.py:267
+#: src/olympia/editors/forms.py:126 src/olympia/editors/helpers.py:279
 msgid "Platforms"
 msgstr "Platformok"
 
+#: src/olympia/editors/forms.py:237
+msgid "Search by add-on name / author email / guid"
+msgstr ""
+
 #. L10n: 0 = platform, 1 = filename, 2 = status message
-#: src/olympia/editors/forms.py:238
+#: src/olympia/editors/forms.py:342
 #, python-format
 msgid "<strong>%s</strong> &middot; %s &middot; %s"
 msgstr "<strong>%s</strong> &middot; %s &middot; %s"
 
-#: src/olympia/editors/forms.py:252
+#: src/olympia/editors/forms.py:356
 msgid "Comments:"
 msgstr "Hozzászólások:"
 
-#: src/olympia/editors/forms.py:256
+#: src/olympia/editors/forms.py:360
 msgid "Operating systems:"
 msgstr "Operációs rendszerek:"
 
-#: src/olympia/editors/forms.py:258
+#: src/olympia/editors/forms.py:362
 msgid "Applications:"
 msgstr "Alkalmazások:"
 
-#: src/olympia/editors/forms.py:260
-msgid ""
-"Notify me the next time this add-on is updated. (Subsequent updates will not"
-" generate an email)"
-msgstr ""
-"Értesítsen a kiegészítő frissítésekor. (Kisebb frissítésekről nem érkezik "
-"levél)"
+#: src/olympia/editors/forms.py:364
+msgid "Notify me the next time this add-on is updated. (Subsequent updates will not generate an email)"
+msgstr "Értesítsen a kiegészítő frissítésekor. (Kisebb frissítésekről nem érkezik levél)"
 
-#: src/olympia/editors/forms.py:265
+#: src/olympia/editors/forms.py:369
 msgid "Clear Admin Review Flag"
 msgstr "Adminisztrátori értékelés jelző törlése"
 
-#: src/olympia/editors/forms.py:267
+#: src/olympia/editors/forms.py:371
 msgid "Clear more info requested flag"
 msgstr "Több információ kérése jelző törlése"
 
-#: src/olympia/editors/forms.py:281
+#: src/olympia/editors/forms.py:385
 msgid "Choose a canned response..."
 msgstr "Válasszon egy konzervválaszt…"
 
 #. L10n: Description of what can be searched for.
-#: src/olympia/editors/forms.py:324
+#: src/olympia/editors/forms.py:423
 msgid "theme name"
 msgstr "téma neve"
 
-#: src/olympia/editors/forms.py:350
+#: src/olympia/editors/forms.py:449
 msgid "Someone else is reviewing this theme."
 msgstr "Valaki más értékeli ezt a témát."
 
 #. L10n: Description of what can be searched for.
-#: src/olympia/editors/forms.py:447
+#: src/olympia/editors/forms.py:546
 msgid "app, reviewer, or comment"
 msgstr "app, értékelő vagy megjegyzés"
 
@@ -9402,296 +7361,266 @@ msgstr "Előzetes értékelésre vár"
 msgid "Rejected or Unreviewed"
 msgstr "Visszautasított vagy nem értékelt"
 
-#: src/olympia/editors/helpers.py:123 src/olympia/editors/helpers.py:136
+#: src/olympia/editors/helpers.py:125 src/olympia/editors/helpers.py:138
 msgid "Queue"
 msgstr "Várakozási sor"
 
-#: src/olympia/editors/helpers.py:124
-#: src/olympia/editors/templates/editors/base.html:50
-#: src/olympia/editors/templates/editors/base.html:65
+#: src/olympia/editors/helpers.py:126 src/olympia/editors/templates/editors/base.html:50 src/olympia/editors/templates/editors/base.html:65
 msgid "Pending Updates"
 msgstr "Függő frissítések"
 
-#: src/olympia/editors/helpers.py:125
-#: src/olympia/editors/templates/editors/base.html:48
-#: src/olympia/editors/templates/editors/base.html:63
+#: src/olympia/editors/helpers.py:127 src/olympia/editors/templates/editors/base.html:48 src/olympia/editors/templates/editors/base.html:63
 msgid "Full Reviews"
 msgstr "Teljes értékelések"
 
-#: src/olympia/editors/helpers.py:126
-#: src/olympia/editors/templates/editors/base.html:52
-#: src/olympia/editors/templates/editors/base.html:67
+#: src/olympia/editors/helpers.py:128 src/olympia/editors/templates/editors/base.html:52 src/olympia/editors/templates/editors/base.html:67
 msgid "Preliminary Reviews"
 msgstr "Előzetes értékelések"
 
-#: src/olympia/editors/helpers.py:127
-#: src/olympia/editors/templates/editors/base.html:54
+#: src/olympia/editors/helpers.py:129 src/olympia/editors/templates/editors/base.html:54
 msgid "Moderated Reviews"
 msgstr "Moderált értékelések"
 
-#: src/olympia/editors/helpers.py:128
-#: src/olympia/editors/templates/editors/base.html:46
+#: src/olympia/editors/helpers.py:130 src/olympia/editors/templates/editors/base.html:46
 msgid "Fast Track"
 msgstr "Gyorsító sáv"
 
-#: src/olympia/editors/helpers.py:130
+#: src/olympia/editors/helpers.py:132
 msgid "Pending Themes"
 msgstr "Függő témák"
 
-#: src/olympia/editors/helpers.py:131
-#: src/olympia/editors/templates/editors/themes/queue.html:4
+#: src/olympia/editors/helpers.py:133 src/olympia/editors/templates/editors/themes/queue.html:4
 msgid "Flagged Themes"
 msgstr "Megjelölt témák"
 
-#: src/olympia/editors/helpers.py:132
+#: src/olympia/editors/helpers.py:134
 msgid "Update Themes"
 msgstr "Frissített témák"
 
-#: src/olympia/editors/helpers.py:137
+#: src/olympia/editors/helpers.py:139
 msgid "Unlisted Pending Updates"
 msgstr "Titkos függő frissítések"
 
-#: src/olympia/editors/helpers.py:138
+#: src/olympia/editors/helpers.py:140
 msgid "Unlisted Full Reviews"
 msgstr "Titkos teljes értékelések"
 
-#: src/olympia/editors/helpers.py:139
+#: src/olympia/editors/helpers.py:141
 msgid "Unlisted Preliminary Reviews"
 msgstr "Titkos előzetes értékelések"
 
-#: src/olympia/editors/helpers.py:170
+#: src/olympia/editors/helpers.py:142
+msgid "Unlisted All Add-ons"
+msgstr ""
+
+#: src/olympia/editors/helpers.py:173
 msgid "Fast Track ({0})"
 msgid_plural "Fast Track ({0})"
 msgstr[0] "Gyorsító sáv ({0})"
 msgstr[1] "Gyorsító sáv ({0})"
 
-#: src/olympia/editors/helpers.py:175
+#: src/olympia/editors/helpers.py:178
 msgid "Full Review ({0})"
 msgid_plural "Full Reviews ({0})"
 msgstr[0] "Teljes értékelés ({0})"
 msgstr[1] "Teljes értékelések ({0})"
 
-#: src/olympia/editors/helpers.py:180
+#: src/olympia/editors/helpers.py:183
 msgid "Pending Update ({0})"
 msgid_plural "Pending Updates ({0})"
 msgstr[0] "Függő frissítés ({0})"
 msgstr[1] "Függő frissítések ({0})"
 
-#: src/olympia/editors/helpers.py:185
+#: src/olympia/editors/helpers.py:188
 msgid "Preliminary Review ({0})"
 msgid_plural "Preliminary Reviews ({0})"
 msgstr[0] "Előzetes értékelés ({0})"
 msgstr[1] "Előzetes értékelések ({0})"
 
-#: src/olympia/editors/helpers.py:190
+#: src/olympia/editors/helpers.py:193
 msgid "Moderated Review ({0})"
 msgid_plural "Moderated Reviews ({0})"
 msgstr[0] "Moderált értékelés ({0})"
 msgstr[1] "Moderált értékelések ({0})"
 
-#: src/olympia/editors/helpers.py:196
+#: src/olympia/editors/helpers.py:199
 msgid "Unlisted Full Review ({0})"
 msgid_plural "Unlisted Full Reviews ({0})"
 msgstr[0] "Titkos teljes értékelés ({0})"
 msgstr[1] "Titkos teljes értékelések ({0})"
 
-#: src/olympia/editors/helpers.py:201
+#: src/olympia/editors/helpers.py:204
 msgid "Unlisted Pending Update ({0})"
 msgid_plural "Unlisted Pending Updates ({0})"
 msgstr[0] "Titkos függő frissítés ({0})"
 msgstr[1] "Titkos függő frissítések ({0})"
 
-#: src/olympia/editors/helpers.py:206
+#: src/olympia/editors/helpers.py:209
 msgid "Unlisted Preliminary Review ({0})"
 msgid_plural "Unlisted Preliminary Reviews ({0})"
 msgstr[0] "Titkos előzetes értékelés ({0})"
 msgstr[1] "Titkos előzetes értékelések ({0})"
 
-#: src/olympia/editors/helpers.py:261
-msgid "Addon"
-msgstr "Kiegészítő"
+#: src/olympia/editors/helpers.py:214
+msgid "Unlisted All Add-ons ({0})"
+msgid_plural "Unlisted All Add-ons ({0})"
+msgstr[0] ""
+msgstr[1] ""
 
-#: src/olympia/editors/helpers.py:262
+#: src/olympia/editors/helpers.py:274
 msgid "Type"
 msgstr "Típus"
 
-#: src/olympia/editors/helpers.py:263
+#: src/olympia/editors/helpers.py:275
 msgid "Waiting Time"
 msgstr "Várakozási idő"
 
-#: src/olympia/editors/helpers.py:264
-#: src/olympia/editors/templates/editors/review.html:285
+#: src/olympia/editors/helpers.py:276 src/olympia/editors/templates/editors/review.html:285
 msgid "Flags"
 msgstr "Jelzők"
 
-#: src/olympia/editors/helpers.py:265
+#: src/olympia/editors/helpers.py:277
 msgid "Applications"
 msgstr "Alkalmazások"
 
-#: src/olympia/editors/helpers.py:270
+#: src/olympia/editors/helpers.py:282
 msgid "Additional"
 msgstr "További"
 
-#: src/olympia/editors/helpers.py:285
+#: src/olympia/editors/helpers.py:302
 msgid "Site Specific"
 msgstr "Webhelyspecifikus"
 
-#: src/olympia/editors/helpers.py:287
+#: src/olympia/editors/helpers.py:304
 msgid "Requires External Software"
 msgstr "Külső szoftvert igényel"
 
-#: src/olympia/editors/helpers.py:289
+#: src/olympia/editors/helpers.py:306
 msgid "Binary Components"
 msgstr "Bináris komponensek"
 
-#: src/olympia/editors/helpers.py:313
+#: src/olympia/editors/helpers.py:339
 msgid "moments ago"
 msgstr "pár másodperce"
 
 #. L10n: first argument is number of minutes
-#: src/olympia/editors/helpers.py:316
+#: src/olympia/editors/helpers.py:342
 msgid "{0} minute"
 msgid_plural "{0} minutes"
 msgstr[0] "{0} perc"
 msgstr[1] "{0} perc"
 
 #. L10n: first argument is number of hours
-#: src/olympia/editors/helpers.py:320
+#: src/olympia/editors/helpers.py:346
 msgid "{0} hour"
 msgid_plural "{0} hours"
 msgstr[0] "{0} óra"
 msgstr[1] "{0} óra"
 
 #. L10n: first argument is number of days
-#: src/olympia/editors/helpers.py:324
+#: src/olympia/editors/helpers.py:350
 msgid "{0} day"
 msgid_plural "{0} days"
 msgstr[0] "{0} nap"
 msgstr[1] "{0} nap"
 
-#: src/olympia/editors/helpers.py:488
+#: src/olympia/editors/helpers.py:364
+msgid "Last Review"
+msgstr ""
+
+#: src/olympia/editors/helpers.py:366
+msgid "Last Update"
+msgstr ""
+
+#: src/olympia/editors/helpers.py:387
+msgid "No Reviews"
+msgstr ""
+
+#: src/olympia/editors/helpers.py:561
 msgid "Push to public"
 msgstr "Publikálás"
 
-#: src/olympia/editors/helpers.py:490
+#: src/olympia/editors/helpers.py:563
 msgid "Grant full review"
 msgstr "Teljes értékelés engedélyezése"
 
-#: src/olympia/editors/helpers.py:505
+#: src/olympia/editors/helpers.py:578
 msgid "Request more information"
 msgstr "További információ kérése"
 
-#: src/olympia/editors/helpers.py:508
+#: src/olympia/editors/helpers.py:581
 msgid "Request super-review"
 msgstr "Teljes értékelés kérése"
 
-#: src/olympia/editors/helpers.py:519
+#: src/olympia/editors/helpers.py:592
 msgid "Grant preliminary review"
 msgstr "Előzetes értékelés megadása"
 
-#: src/olympia/editors/helpers.py:520
+#: src/olympia/editors/helpers.py:593
 msgid "This will mark the files as preliminarily reviewed."
 msgstr "Ez megjelöli a fájlokat, mint előzetesen értékelt."
 
-#: src/olympia/editors/helpers.py:522
-msgid ""
-"Use this form to request more information from the author. They will receive"
-" an email and be able to answer here. You will be notified by email when "
-"they reply."
-msgstr ""
-"Használja ezt az űrlapot, amennyiben kapcsolatba szeretne kerülni a "
-"készítővel, akit e-mailen értesítünk és lehetősége van itt válaszolni. "
-"Értesítést küldünk, amint megérkezik a válasz."
+#: src/olympia/editors/helpers.py:595
+msgid "Use this form to request more information from the author. They will receive an email and be able to answer here. You will be notified by email when they reply."
+msgstr "Használja ezt az űrlapot, amennyiben kapcsolatba szeretne kerülni a készítővel, akit e-mailen értesítünk és lehetősége van itt válaszolni. Értesítést küldünk, amint megérkezik a válasz."
 
-#: src/olympia/editors/helpers.py:526
+#: src/olympia/editors/helpers.py:599
 msgid ""
-"If you have concerns about this add-on's security, copyright issues, or "
-"other concerns that an administrator should look into, enter your comments "
-"in the area below. They will be sent to administrators, not the author."
+"If you have concerns about this add-on's security, copyright issues, or other concerns that an administrator should look into, enter your comments in the area below. They will be sent to "
+"administrators, not the author."
 msgstr ""
-"Amennyiben aggályai vannak a kiegészítő biztonságával, licencelésével vagy "
-"bármi olyasmivel kapcsolatban, amit egy adminisztrátornak jó lenne "
-"ellenőriznie, akkor azt írja az alábbi részbe. Ezt az adminisztrátorok "
-"fogják megkapni, nem pedig a készítő."
+"Amennyiben aggályai vannak a kiegészítő biztonságával, licencelésével vagy bármi olyasmivel kapcsolatban, amit egy adminisztrátornak jó lenne ellenőriznie, akkor azt írja az alábbi részbe. Ezt az "
+"adminisztrátorok fogják megkapni, nem pedig a készítő."
 
-#: src/olympia/editors/helpers.py:532
+#: src/olympia/editors/helpers.py:605
 msgid "This will reject the add-on and remove it from the review queue."
-msgstr ""
-"Ezzel a kiegészítő elutasításra kerül és az értékelés várakozók listájában "
-"sem fog szerepelni."
+msgstr "Ezzel a kiegészítő elutasításra kerül és az értékelés várakozók listájában sem fog szerepelni."
 
-#: src/olympia/editors/helpers.py:534
+#: src/olympia/editors/helpers.py:607
 msgid "Make a comment on this version. The author won't be able to see this."
-msgstr ""
-"Tegyen egy megjegyzést erről a verzióról. A szerző nem fogja ezt látni."
+msgstr "Tegyen egy megjegyzést erről a verzióról. A szerző nem fogja ezt látni."
 
-#: src/olympia/editors/helpers.py:538
+#: src/olympia/editors/helpers.py:611
 msgid "This will reject the files and remove them from the review queue."
-msgstr ""
-"Ez visszautasítja a fájlokat, és eltávolítja azokat az értékelési sorból."
+msgstr "Ez visszautasítja a fájlokat, és eltávolítja azokat az értékelési sorból."
 
-#: src/olympia/editors/helpers.py:542
-msgid ""
-"This will mark the add-on as preliminarily reviewed. Future versions will "
-"undergo preliminary review."
-msgstr ""
-"Ez a kiegészítőt előzetesen értékeltnek tekinti. A későbbi verzióknak is "
-"előzetes értékelésen kell átesniük."
+#: src/olympia/editors/helpers.py:615
+msgid "This will mark the add-on as preliminarily reviewed. Future versions will undergo preliminary review."
+msgstr "Ez a kiegészítőt előzetesen értékeltnek tekinti. A későbbi verzióknak is előzetes értékelésen kell átesniük."
 
-#: src/olympia/editors/helpers.py:547
-msgid ""
-"This will mark the files as preliminarily reviewed. Future versions will "
-"undergo preliminary review."
-msgstr ""
-"Ez a fájlt előzetesen értékeltnek tekinti. A későbbi verzióknak is előzetes "
-"értékelésen kell átesniük."
+#: src/olympia/editors/helpers.py:620
+msgid "This will mark the files as preliminarily reviewed. Future versions will undergo preliminary review."
+msgstr "Ez a fájlt előzetesen értékeltnek tekinti. A későbbi verzióknak is előzetes értékelésen kell átesniük."
 
-#: src/olympia/editors/helpers.py:552
+#: src/olympia/editors/helpers.py:625
 msgid "Retain preliminary review"
 msgstr "Előzetes értékelés megtartása"
 
-#: src/olympia/editors/helpers.py:553
-msgid ""
-"This will retain the add-on as preliminarily reviewed. Future versions will "
-"undergo preliminary review."
-msgstr ""
-"Ez a kiegészítő előzetesen értékelt marad. A későbbi verzióknak is előzetes "
-"értékelésen kell átesniük."
+#: src/olympia/editors/helpers.py:626
+msgid "This will retain the add-on as preliminarily reviewed. Future versions will undergo preliminary review."
+msgstr "Ez a kiegészítő előzetesen értékelt marad. A későbbi verzióknak is előzetes értékelésen kell átesniük."
 
-#: src/olympia/editors/helpers.py:558
-msgid ""
-"This will approve a sandboxed version of a public add-on to appear on the "
-"public side."
-msgstr ""
-"Ez engedélyezi egy publikus kiegészítő meg nem jelent verzióját és "
-"elérhetővé teszi azt a publikus oldalon."
+#: src/olympia/editors/helpers.py:631
+msgid "This will approve a sandboxed version of a public add-on to appear on the public side."
+msgstr "Ez engedélyezi egy publikus kiegészítő meg nem jelent verzióját és elérhetővé teszi azt a publikus oldalon."
 
-#: src/olympia/editors/helpers.py:561
-msgid ""
-"This will reject a version of a public add-on and remove it from the queue."
-msgstr ""
-"Ez elutasítja a publikus kiegészítő verzióját és eltávolítja a várakozási "
-"sorból."
-
-#: src/olympia/editors/helpers.py:564
-msgid ""
-"This will mark the add-on and its most recent version and files as public. "
-"Future versions will go into the sandbox until they are reviewed by an "
-"editor."
-msgstr ""
-"Ez a kiegészítőt és annak legfrissebb változatát publikusnak tekinti. A "
-"jövőben megjelenő verziók nem jelennek meg addig, amíg egy szerkesztő nem "
-"értékeli."
+#: src/olympia/editors/helpers.py:634
+msgid "This will reject a version of a public add-on and remove it from the queue."
+msgstr "Ez elutasítja a publikus kiegészítő verzióját és eltávolítja a várakozási sorból."
 
 #: src/olympia/editors/helpers.py:637
+msgid "This will mark the add-on and its most recent version and files as public. Future versions will go into the sandbox until they are reviewed by an editor."
+msgstr "Ez a kiegészítőt és annak legfrissebb változatát publikusnak tekinti. A jövőben megjelenő verziók nem jelennek meg addig, amíg egy szerkesztő nem értékeli."
+
+#: src/olympia/editors/helpers.py:714
 msgid "add-on"
 msgstr "kiegészítő"
 
-#: src/olympia/editors/helpers.py:940 src/olympia/editors/helpers.py:960
+#: src/olympia/editors/helpers.py:1020 src/olympia/editors/helpers.py:1040
 msgid "Flagged"
 msgstr "Megjelölve"
 
-#: src/olympia/editors/helpers.py:944 src/olympia/editors/helpers.py:963
+#: src/olympia/editors/helpers.py:1024 src/olympia/editors/helpers.py:1043
 msgid "Updates"
 msgstr "Frissítések"
 
@@ -9743,77 +7672,68 @@ msgstr "Téma beküldés megjelölve értékelésre"
 msgid "A question about your Theme submission"
 msgstr "Kérdés a téma beküldéséhez"
 
-#: src/olympia/editors/views.py:144
+#: src/olympia/editors/views.py:146
 msgid "New Add-ons (Under 5 days)"
 msgstr "Új kiegészítők (5 napnál frissebbek)"
 
-#: src/olympia/editors/views.py:145
+#: src/olympia/editors/views.py:147
 msgid "Passable (5 to 10 days)"
 msgstr "Elfogadható (5-10 nap)"
 
-#: src/olympia/editors/views.py:146
+#: src/olympia/editors/views.py:148
 msgid "Overdue (Over 10 days)"
 msgstr "Késedelmes (több mint 10 nap)"
 
-#: src/olympia/editors/views.py:532
+#: src/olympia/editors/views.py:539
 msgid "An unknown error occurred"
 msgstr "Ismeretlen hiba történt"
 
-#: src/olympia/editors/views.py:587
+#: src/olympia/editors/views.py:592
 msgid "Self-reviews are not allowed."
 msgstr "Az önértékelés nem engedélyezett."
 
-#: src/olympia/editors/views.py:609
+#: src/olympia/editors/views.py:613
 msgid "Review successfully processed."
 msgstr "Az értékelés sikeresen megtörtént."
 
-#: src/olympia/editors/views.py:807
+#: src/olympia/editors/views.py:812
 msgid "was approved"
 msgstr "jóváhagyva"
 
-#: src/olympia/editors/views.py:808
+#: src/olympia/editors/views.py:813
 msgid "given preliminary review"
 msgstr "előzetesen értékelt"
 
-#: src/olympia/editors/views.py:809
+#: src/olympia/editors/views.py:814
 msgid "rejected"
 msgstr "elutasított"
 
-#: src/olympia/editors/views.py:810
+#: src/olympia/editors/views.py:815
 msgctxt "editors_review_history_nominated_adminreview"
 msgid "escalated"
 msgstr "továbbított"
 
-#: src/olympia/editors/views.py:812
+#: src/olympia/editors/views.py:817
 msgid "needs more information"
 msgstr "további információ szükséges"
 
-#: src/olympia/editors/views.py:813
+#: src/olympia/editors/views.py:818
 msgid "needs super review"
 msgstr "teljes értékelés szükséges"
 
-#: src/olympia/editors/views.py:814
+#: src/olympia/editors/views.py:819
 msgid "commented"
 msgstr "hozzászólva"
 
 #: src/olympia/editors/views_themes.py:326
 msgid "{0} theme review successfully processed (+{1} points, {2} total)."
-msgid_plural ""
-"{0} theme reviews successfully processed (+{1} points, {2} total)."
-msgstr[0] ""
-"{0} téma értékelés sikeresen feldolgozva (+{1} pont, összesen {2})."
-msgstr[1] ""
-"{0} téma értékelés sikeresen feldolgozva (+{1} pont, összesen {2})."
+msgid_plural "{0} theme reviews successfully processed (+{1} points, {2} total)."
+msgstr[0] "{0} téma értékelés sikeresen feldolgozva (+{1} pont, összesen {2})."
+msgstr[1] "{0} téma értékelés sikeresen feldolgozva (+{1} pont, összesen {2})."
 
 #: src/olympia/editors/views_themes.py:341
-msgid ""
-"Your theme locks have successfully been released. Other reviewers may now "
-"review those released themes. You may have to refresh the page to see the "
-"changes reflected in the table below."
-msgstr ""
-"A téma zárak sikeresen elengedve. Más értékelők most felülvizsgálhatják a "
-"kiadott témákat. Előfordulhat, hogy frissíteni kell az oldalt, hogy a "
-"változások megjelenjenek az alábbi táblázatban."
+msgid "Your theme locks have successfully been released. Other reviewers may now review those released themes. You may have to refresh the page to see the changes reflected in the table below."
+msgstr "A téma zárak sikeresen elengedve. Más értékelők most felülvizsgálhatják a kiadott témákat. Előfordulhat, hogy frissíteni kell az oldalt, hogy a változások megjelenjenek az alábbi táblázatban."
 
 #: src/olympia/editors/templates/editors/abuse_reports.html:4
 msgid "{addon} :: Abuse Reports"
@@ -9837,9 +7757,7 @@ msgstr "<i>ismeretlen</i> ekkor: %(date)s [%(ip_address)s]"
 msgid "Return to the Editor Tools homepage"
 msgstr "Visszatérés a Szerkesztői eszközök oldalra"
 
-#: src/olympia/editors/templates/editors/base.html:43
-#: src/olympia/editors/templates/editors/themes/base.html:14
-#: src/olympia/editors/templates/editors/themes/base.html:28
+#: src/olympia/editors/templates/editors/base.html:43 src/olympia/editors/templates/editors/themes/base.html:14 src/olympia/editors/templates/editors/themes/base.html:28
 #: src/olympia/editors/templates/editors/themes/queue.html:25
 msgid "Queues"
 msgstr "Várakozási sorok"
@@ -9848,73 +7766,53 @@ msgstr "Várakozási sorok"
 msgid "Unlisted Queues"
 msgstr "Titkos sorok"
 
-#: src/olympia/editors/templates/editors/base.html:72
-#: src/olympia/editors/templates/editors/performance.html:6
+#: src/olympia/editors/templates/editors/base.html:74 src/olympia/editors/templates/editors/performance.html:6
 msgid "Performance"
 msgstr "Teljesítmény"
 
-#: src/olympia/editors/templates/editors/base.html:75
-#: src/olympia/editors/templates/editors/themes/base.html:19
-#: src/olympia/editors/templates/editors/themes/base.html:38
+#: src/olympia/editors/templates/editors/base.html:77 src/olympia/editors/templates/editors/themes/base.html:19 src/olympia/editors/templates/editors/themes/base.html:38
 msgid "Logs"
 msgstr "Naplók"
 
-#: src/olympia/editors/templates/editors/base.html:78
-#: src/olympia/editors/templates/editors/reviewlog.html:4
-#: src/olympia/editors/templates/editors/reviewlog.html:27
+#: src/olympia/editors/templates/editors/base.html:80 src/olympia/editors/templates/editors/reviewlog.html:4 src/olympia/editors/templates/editors/reviewlog.html:27
 msgid "Add-on Review Log"
 msgstr "Kiegészítő értékelési naplója"
 
 # 80%
 # 100%
-#: src/olympia/editors/templates/editors/base.html:80
-#: src/olympia/editors/templates/editors/eventlog.html:4
-#: src/olympia/editors/templates/editors/eventlog.html:8
+#: src/olympia/editors/templates/editors/base.html:82 src/olympia/editors/templates/editors/eventlog.html:4 src/olympia/editors/templates/editors/eventlog.html:8
 #: src/olympia/editors/templates/editors/eventlog_detail.html:4
 msgid "Moderated Review Log"
 msgstr "Moderált értékelések naplója"
 
-#: src/olympia/editors/templates/editors/base.html:82
-#: src/olympia/editors/templates/editors/beta_signed_log.html:4
-#: src/olympia/editors/templates/editors/beta_signed_log.html:8
+#: src/olympia/editors/templates/editors/base.html:84 src/olympia/editors/templates/editors/beta_signed_log.html:4 src/olympia/editors/templates/editors/beta_signed_log.html:8
 msgid "Signed Beta Files Log"
 msgstr "Aláírt béta fájlok naplója"
 
-#: src/olympia/editors/templates/editors/base.html:87
-#: src/olympia/editors/templates/editors/includes/daily-message.html:4
+#: src/olympia/editors/templates/editors/base.html:89 src/olympia/editors/templates/editors/includes/daily-message.html:4
 msgid "Announcement"
 msgstr "Bejelentés"
 
 #. "Filter" is a button label (verb)
-#: src/olympia/editors/templates/editors/beta_signed_log.html:17
-#: src/olympia/editors/templates/editors/eventlog.html:24
-#: src/olympia/editors/templates/editors/reviewlog.html:21
-#: src/olympia/editors/templates/editors/themes/macros.html:45
-#: src/olympia/editors/templates/editors/themes/includes/logs_filter_deleted.html:12
+#: src/olympia/editors/templates/editors/beta_signed_log.html:17 src/olympia/editors/templates/editors/eventlog.html:24 src/olympia/editors/templates/editors/reviewlog.html:21
+#: src/olympia/editors/templates/editors/themes/macros.html:45 src/olympia/editors/templates/editors/themes/includes/logs_filter_deleted.html:12
 msgid "Filter"
 msgstr "Szűrő"
 
-#: src/olympia/editors/templates/editors/beta_signed_log.html:23
-#: src/olympia/editors/templates/editors/eventlog.html:30
-#: src/olympia/editors/templates/editors/reviewlog.html:34
+#: src/olympia/editors/templates/editors/beta_signed_log.html:23 src/olympia/editors/templates/editors/eventlog.html:30 src/olympia/editors/templates/editors/reviewlog.html:34
 #: src/olympia/editors/templates/editors/themes/logs.html:16
 msgid "Date"
 msgstr "Dátum"
 
-#: src/olympia/editors/templates/editors/beta_signed_log.html:24
-#: src/olympia/editors/templates/editors/eventlog.html:31
-#: src/olympia/editors/templates/editors/reviewlog.html:35
+#: src/olympia/editors/templates/editors/beta_signed_log.html:24 src/olympia/editors/templates/editors/eventlog.html:31 src/olympia/editors/templates/editors/reviewlog.html:35
 msgid "Event"
 msgstr "Esemény"
 
-#: src/olympia/editors/templates/editors/beta_signed_log.html:37
-#: src/olympia/editors/templates/editors/eventlog.html:44
-#: src/olympia/editors/templates/editors/home.html:180
+#: src/olympia/editors/templates/editors/beta_signed_log.html:37 src/olympia/editors/templates/editors/eventlog.html:44 src/olympia/editors/templates/editors/home.html:180
 msgid "More details."
 msgstr "További részletek."
 
-#: src/olympia/editors/templates/editors/beta_signed_log.html:46
-#: src/olympia/editors/templates/editors/eventlog.html:53
+#: src/olympia/editors/templates/editors/beta_signed_log.html:46 src/olympia/editors/templates/editors/eventlog.html:53
 msgid "No events found for this period."
 msgstr "A megadott időtartamban nem található esemény."
 
@@ -9970,22 +7868,19 @@ msgid_plural "Preliminary Reviews ({num})"
 msgstr[0] "({num}) előzetes értékelés"
 msgstr[1] "({num}) előzetes értékelés"
 
-#: src/olympia/editors/templates/editors/home.html:36
-#: src/olympia/editors/templates/editors/home.html:86
+#: src/olympia/editors/templates/editors/home.html:36 src/olympia/editors/templates/editors/home.html:86
 msgid "Current waiting times:"
 msgstr "Jelenlegi várakozási idő:"
 
 # 81%
 # 100%
-#: src/olympia/editors/templates/editors/home.html:44
-#: src/olympia/editors/templates/editors/home.html:94
+#: src/olympia/editors/templates/editors/home.html:44 src/olympia/editors/templates/editors/home.html:94
 msgid "{0} add-on"
 msgid_plural "{0} add-ons"
 msgstr[0] "{0} kiegészítők"
 msgstr[1] "{0} kiegészítők"
 
-#: src/olympia/editors/templates/editors/home.html:45
-#: src/olympia/editors/templates/editors/home.html:95
+#: src/olympia/editors/templates/editors/home.html:45 src/olympia/editors/templates/editors/home.html:95
 #, python-format
 msgid "{0}%%"
 msgstr "{0}%%"
@@ -10008,14 +7903,11 @@ msgid_plural "Unlisted Preliminary Reviews ({num})"
 msgstr[0] "Titkos előzetes értékelés ({num})"
 msgstr[1] "Titkos előzetes értékelések ({num})"
 
-#: src/olympia/editors/templates/editors/home.html:109
-#: src/olympia/editors/templates/editors/performance.html:37
-#: src/olympia/editors/templates/editors/themes/home.html:54
+#: src/olympia/editors/templates/editors/home.html:109 src/olympia/editors/templates/editors/performance.html:37 src/olympia/editors/templates/editors/themes/home.html:54
 msgid "Total Reviews"
 msgstr "Összes értékelés"
 
-#: src/olympia/editors/templates/editors/home.html:110
-#: src/olympia/editors/templates/editors/themes/home.html:55
+#: src/olympia/editors/templates/editors/home.html:110 src/olympia/editors/templates/editors/themes/home.html:55
 msgid "Reviews This Month"
 msgstr "A hónap értékelései"
 
@@ -10023,27 +7915,24 @@ msgstr "A hónap értékelései"
 msgid "New Editors"
 msgstr "Új szerkesztők"
 
-#: src/olympia/editors/templates/editors/home.html:126
-#: src/olympia/editors/templates/editors/home.html:141
+#: src/olympia/editors/templates/editors/home.html:126 src/olympia/editors/templates/editors/home.html:141
 msgid "You're #{0} with {1} reviews"
 msgstr "Ön #{0}, {1} értékeléssel"
 
-#. num = number of reviews in the queue
 # 87%
 # 100%
+#. num = number of reviews in the queue
 #: src/olympia/editors/templates/editors/home.html:171
 msgid "Moderated Review ({num})"
 msgid_plural "Moderated Reviews ({num})"
 msgstr[0] "({num}) moderált értékelés"
 msgstr[1] "({num}) moderált értékelés"
 
-#: src/olympia/editors/templates/editors/leaderboard.html:3
-#: src/olympia/editors/templates/editors/includes/reviewers_score_bar.html:56
+#: src/olympia/editors/templates/editors/leaderboard.html:3 src/olympia/editors/templates/editors/includes/reviewers_score_bar.html:56
 msgid "Reviewer Leaderboard"
 msgstr "Értékelő ranglista"
 
-#: src/olympia/editors/templates/editors/leaderboard.html:18
-#: src/olympia/editors/templates/editors/performance.html:65
+#: src/olympia/editors/templates/editors/leaderboard.html:18 src/olympia/editors/templates/editors/performance.html:65
 msgid "No review points awarded yet."
 msgstr "Nincsenek még értékelési pontok."
 
@@ -10063,8 +7952,7 @@ msgstr "A nap üzenete"
 msgid "Update message of the day"
 msgstr "A nap üzenetének frissítése"
 
-#: src/olympia/editors/templates/editors/motd.html:15
-#: src/olympia/editors/templates/editors/review.html:224
+#: src/olympia/editors/templates/editors/motd.html:15 src/olympia/editors/templates/editors/review.html:224
 msgid "Save"
 msgstr "Mentés"
 
@@ -10134,51 +8022,45 @@ msgstr "Speciális keresés"
 msgid "clear search"
 msgstr "keresés törlése"
 
-#: src/olympia/editors/templates/editors/queue.html:72
-#: src/olympia/editors/templates/editors/queue.html:122
+#: src/olympia/editors/templates/editors/queue.html:78 src/olympia/editors/templates/editors/queue.html:128
 msgid "Process Reviews"
 msgstr "Értékelések feldolgozása"
 
-#: src/olympia/editors/templates/editors/queue.html:80
+#: src/olympia/editors/templates/editors/queue.html:86
 msgid "Moderation actions:"
 msgstr "Moderációs műveletek:"
 
-#: src/olympia/editors/templates/editors/queue.html:90
+#: src/olympia/editors/templates/editors/queue.html:96
 #, python-format
 msgid "by %(user)s on %(date)s %(stars)s (%(locale)s)"
 msgstr "készítette: %(user)s, %(date)s %(stars)s (%(locale)s)"
 
-#: src/olympia/editors/templates/editors/queue.html:106
+#: src/olympia/editors/templates/editors/queue.html:112
 #, python-format
-msgid ""
-"<strong>%(reason)s</strong> <span class=\"light\">Flagged by %(user)s on "
-"%(date)s</span>"
-msgstr ""
-"<strong>%(reason)s</strong> <span class=\"light\">%(user)s jelölte meg, "
-"%(date)s</span>"
+msgid "<strong>%(reason)s</strong> <span class=\"light\">Flagged by %(user)s on %(date)s</span>"
+msgstr "<strong>%(reason)s</strong> <span class=\"light\">%(user)s jelölte meg, %(date)s</span>"
 
-#: src/olympia/editors/templates/editors/queue.html:119
-msgid "All reviews have been moderated.  Good work!"
+#: src/olympia/editors/templates/editors/queue.html:125
+msgid "All reviews have been moderated. Good work!"
 msgstr "Minden értékelés moderálva. Szép munka!"
 
-#: src/olympia/editors/templates/editors/queue.html:161
+#: src/olympia/editors/templates/editors/queue.html:167
 msgid "Version Notes / Notes for Reviewer"
 msgstr "Verzió megjegyzések / Megjegyzések az értékelőknek"
 
-#: src/olympia/editors/templates/editors/queue.html:169
+#: src/olympia/editors/templates/editors/queue.html:175
 msgid "There are currently no add-ons of this type to review."
 msgstr "Jelenleg nincsenek értékelendő kiegészítők ebből a típusból."
 
-#: src/olympia/editors/templates/editors/queue.html:181
-#: src/olympia/editors/templates/editors/themes/queue_list.html:85
+#: src/olympia/editors/templates/editors/queue.html:187 src/olympia/editors/templates/editors/themes/queue_list.html:85
 msgid "Helpful Links:"
 msgstr "Hasznos hivatkozások:"
 
-#: src/olympia/editors/templates/editors/queue.html:182
+#: src/olympia/editors/templates/editors/queue.html:188
 msgid "Add-on Policy"
 msgstr "Irányelvek a kiegészítőkhöz"
 
-#: src/olympia/editors/templates/editors/queue.html:184
+#: src/olympia/editors/templates/editors/queue.html:190
 msgid "Editors' Guide"
 msgstr "Útmutató szerkesztőknek"
 
@@ -10191,19 +8073,14 @@ msgstr "{0} értékelése"
 msgid "Add-on user change history"
 msgstr "Kiegészítő felhasználóváltozásának előzményei"
 
-#: src/olympia/editors/templates/editors/review.html:52
-#: src/olympia/editors/templates/editors/review.html:266
+#: src/olympia/editors/templates/editors/review.html:52 src/olympia/editors/templates/editors/review.html:266
 msgid "Add-on History"
 msgstr "Kiegészítő előzményei"
 
 #: src/olympia/editors/templates/editors/review.html:64
 #, python-format
-msgid ""
-"Version %(version)s &middot; %(created)s <span class=\"light\">&middot; "
-"%(version_status)s</span>"
-msgstr ""
-"%(version)s verzió &middot; %(created)s <span class=\"light\">&middot; "
-"%(version_status)s</span>"
+msgid "Version %(version)s &middot; %(created)s <span class=\"light\">&middot; %(version_status)s</span>"
+msgstr "%(version)s verzió &middot; %(created)s <span class=\"light\">&middot; %(version_status)s</span>"
 
 #: src/olympia/editors/templates/editors/review.html:73
 msgid "Compatibility:"
@@ -10226,19 +8103,14 @@ msgid "This version has not been reviewed."
 msgstr "Ezt a verziót még nem értékelte senki."
 
 #: src/olympia/editors/templates/editors/review.html:154
-msgid ""
-"You can still submit this form, however only do so if you know it won't "
-"conflict."
-msgstr ""
-"Beküldheti az űrlap tartalmát, de csak akkor tegye meg, ha tudja, hogy nem "
-"okoz ütközést."
+msgid "You can still submit this form, however only do so if you know it won't conflict."
+msgstr "Beküldheti az űrlap tartalmát, de csak akkor tegye meg, ha tudja, hogy nem okoz ütközést."
 
 #: src/olympia/editors/templates/editors/review.html:161
 msgid "Insert canned response..."
 msgstr "Konzervválasz beszúrása…"
 
-#: src/olympia/editors/templates/editors/review.html:167
-#: src/olympia/files/templates/files/viewer.html:54
+#: src/olympia/editors/templates/editors/review.html:167 src/olympia/files/templates/files/viewer.html:54
 msgid "Files:"
 msgstr "Fájlok:"
 
@@ -10247,28 +8119,18 @@ msgid "Tested on:"
 msgstr "Tesztelve:"
 
 #: src/olympia/editors/templates/editors/review.html:220
-msgid ""
-"<strong>Warning!</strong> Another user was viewing this page before you."
-msgstr ""
-"<strong>Figyelem!</strong> Egy másik felhasználó korábban már megtekintette "
-"ezt az oldalt."
+msgid "<strong>Warning!</strong> Another user was viewing this page before you."
+msgstr "<strong>Figyelem!</strong> Egy másik felhasználó korábban már megtekintette ezt az oldalt."
 
 #: src/olympia/editors/templates/editors/review.html:237
-msgid ""
-"The whiteboard is the place to exchange information relevant to this addon "
-"(whatever the version), between the developer and the editor. This is "
-"visible and editable by both."
-msgstr ""
-"A tábla a kiegészítőhöz kapcsolódó releváns információk, fejlesztő és "
-"szerkesztő közti, megosztásának helye (bármely verzióról is legyen szó). Ezt"
-" mindketten látják és szerkeszthetik."
+msgid "The whiteboard is the place to exchange information relevant to this addon (whatever the version), between the developer and the editor. This is visible and editable by both."
+msgstr "A tábla a kiegészítőhöz kapcsolódó releváns információk, fejlesztő és szerkesztő közti, megosztásának helye (bármely verzióról is legyen szó). Ezt mindketten látják és szerkeszthetik."
 
 #: src/olympia/editors/templates/editors/review.html:241
 msgid "Update the whiteboard"
 msgstr "A tábla frissítése"
 
-#: src/olympia/editors/templates/editors/review.html:257
-#: src/olympia/editors/templates/editors/review.html:258
+#: src/olympia/editors/templates/editors/review.html:257 src/olympia/editors/templates/editors/review.html:258
 msgid "(admin)"
 msgstr "(admin)"
 
@@ -10296,18 +8158,15 @@ msgstr "Szerkesztő"
 msgid "Add-on has been deleted."
 msgstr "A kiegészítő le lett törölve."
 
-#: src/olympia/editors/templates/editors/reviewlog.html:59
-#: src/olympia/editors/templates/editors/themes/logs.html:36
+#: src/olympia/editors/templates/editors/reviewlog.html:59 src/olympia/editors/templates/editors/themes/logs.html:36
 msgid "Show Comments"
 msgstr "Hozzászólások megjelenítése"
 
-#: src/olympia/editors/templates/editors/reviewlog.html:60
-#: src/olympia/editors/templates/editors/themes/logs.html:37
+#: src/olympia/editors/templates/editors/reviewlog.html:60 src/olympia/editors/templates/editors/themes/logs.html:37
 msgid "Hide Comments"
 msgstr "Hozzászólások elrejtése"
 
-#: src/olympia/editors/templates/editors/reviewlog.html:72
-#: src/olympia/editors/templates/editors/themes/logs.html:54
+#: src/olympia/editors/templates/editors/reviewlog.html:72 src/olympia/editors/templates/editors/themes/logs.html:54
 msgid "No reviews found for this period."
 msgstr "Nincsenek értékelések ebben az időszakban."
 
@@ -10365,12 +8224,8 @@ msgstr "Bármikor"
 msgid "You have <span>{0}</span> points."
 msgstr "Önnek <span>{0}</span> pontja van."
 
-#: src/olympia/editors/templates/editors/includes/search_results_themes.html:6
-#: src/olympia/editors/templates/editors/themes/history_table.html:7
-#: src/olympia/editors/templates/editors/themes/logs.html:19
-#: src/olympia/editors/templates/editors/themes/queue_list.html:49
-#: src/olympia/editors/templates/editors/themes/single.html:26
-#: src/olympia/editors/templates/editors/themes/themes.html:45
+#: src/olympia/editors/templates/editors/includes/search_results_themes.html:6 src/olympia/editors/templates/editors/themes/history_table.html:7 src/olympia/editors/templates/editors/themes/logs.html:19
+#: src/olympia/editors/templates/editors/themes/queue_list.html:49 src/olympia/editors/templates/editors/themes/single.html:26 src/olympia/editors/templates/editors/themes/themes.html:45
 msgid "Reviewer"
 msgstr "Értékelő"
 
@@ -10394,8 +8249,7 @@ msgstr "Téma értékelés előzményei ehhez: {0}"
 msgid "Review Date"
 msgstr "Értékelés időpontja"
 
-#: src/olympia/editors/templates/editors/themes/history_table.html:9
-#: src/olympia/editors/templates/editors/themes/logs.html:18
+#: src/olympia/editors/templates/editors/themes/history_table.html:9 src/olympia/editors/templates/editors/themes/logs.html:18
 msgid "Action"
 msgstr "Művelet"
 
@@ -10542,7 +8396,7 @@ msgstr "Kérdés az alkotóhoz"
 msgid "Describe your reason for flagging"
 msgstr "Írja le a megjelölés okát"
 
-#: src/olympia/files/forms.py:88
+#: src/olympia/files/forms.py:90
 msgid "Cannot diff a version against itself"
 msgstr "Nem hasonlítható össze egy verzió saját magával"
 
@@ -10560,12 +8414,8 @@ msgid "Problems decoding {0}."
 msgstr "Problémák a(z) {0} dekódolása során."
 
 #: src/olympia/files/helpers.py:186
-msgid ""
-"This file is not viewable online. Please download the file to view the "
-"contents."
-msgstr ""
-"Ez a fájl nem érhető el online. Töltse le a fájlt, ha meg kívánja tekinteni "
-"a tartalmát."
+msgid "This file is not viewable online. Please download the file to view the contents."
+msgstr "Ez a fájl nem érhető el online. Töltse le a fájlt, ha meg kívánja tekinteni a tartalmát."
 
 #: src/olympia/files/helpers.py:194
 msgid "This file is a directory."
@@ -10581,55 +8431,51 @@ msgstr "Hiba történt a(z) %s fájl elérésekor. %s."
 msgid "There was an error accessing file %s."
 msgstr "Hiba történt a(z) %s fájl elérésekor."
 
-#: src/olympia/files/utils.py:343
+#: src/olympia/files/utils.py:340
 msgid "Could not parse uploaded file."
 msgstr "Nem sikerült feldolgozni a feltöltött fájlt."
 
-#: src/olympia/files/utils.py:380
+#: src/olympia/files/utils.py:377
 msgid "Invalid file name in archive: {0}"
 msgstr "Érvénytelen fájlnév az archívumban: {0}"
 
-#: src/olympia/files/utils.py:388
+#: src/olympia/files/utils.py:385
 msgid "File exceeding size limit in archive: {0}"
 msgstr "A méretkorlátnál nagyobb fájl archívumban: {0}"
 
-#: src/olympia/files/utils.py:439
+#: src/olympia/files/utils.py:436
 msgid "Invalid archive."
 msgstr "Érvénytelen archívum."
 
-#: src/olympia/files/utils.py:529 src/olympia/files/utils.py:532
+#: src/olympia/files/utils.py:526 src/olympia/files/utils.py:529
 msgid "Could not parse the manifest file."
 msgstr "Nem sikerült feldolgozni a jegyzékfájlt."
 
-#: src/olympia/files/utils.py:551
+#: src/olympia/files/utils.py:548
 msgid "Could not find an add-on ID."
 msgstr "Nem található a kiegészítő azonosítója."
 
-#: src/olympia/files/utils.py:554
+#: src/olympia/files/utils.py:551
 msgid "Add-on ID must be 64 characters or less."
 msgstr "A kiegészítő azonosító 64 karakter vagy rövidebb lehet."
 
-#: src/olympia/files/utils.py:556
+#: src/olympia/files/utils.py:553
 msgid "Add-on ID doesn't match add-on."
 msgstr "A kiegészítő azonosító nem egyezik a kiegészítővel."
 
-#: src/olympia/files/utils.py:564
+#: src/olympia/files/utils.py:561
 msgid "Duplicate add-on ID found."
 msgstr "Kettőzött kiegészítő azonosító található."
 
-#: src/olympia/files/utils.py:567
+#: src/olympia/files/utils.py:564
 msgid "Version numbers should have fewer than 32 characters."
 msgstr "A verziószámnak 32 karakternél rövidebbnek kell lennie."
 
-#: src/olympia/files/utils.py:570
-msgid ""
-"Version numbers should only contain letters, numbers, and these punctuation "
-"characters: +*.-_."
-msgstr ""
-"A verziószámok kizárólag betűket, számokat és a következő karaktereket "
-"tartalmazhatja: +*.-_."
+#: src/olympia/files/utils.py:567
+msgid "Version numbers should only contain letters, numbers, and these punctuation characters: +*.-_."
+msgstr "A verziószámok kizárólag betűket, számokat és a következő karaktereket tartalmazhatja: +*.-_."
 
-#: src/olympia/files/utils.py:587
+#: src/olympia/files/utils.py:584
 msgid "<em:type> doesn't match add-on"
 msgstr "<em:type> nem illeszkedik kiegészítőre"
 
@@ -10651,12 +8497,8 @@ msgstr "Letöltés: {0}"
 
 #: src/olympia/files/templates/files/file.html:4
 #, python-format
-msgid ""
-"Version: %(version)s &bull; Size: %(size)s &bull; MD5 hash: %(md5)s &bull; "
-"Mimetype: %(mimetype)s"
-msgstr ""
-"Verzió: %(version)s &bull; Méret: %(size)s &bull; MD5 hash: %(md5)s &bull; "
-"Mimetype: %(mimetype)s"
+msgid "Version: %(version)s &bull; Size: %(size)s &bull; MD5 hash: %(md5)s &bull; Mimetype: %(mimetype)s"
+msgstr "Verzió: %(version)s &bull; Méret: %(size)s &bull; MD5 hash: %(md5)s &bull; Mimetype: %(mimetype)s"
 
 #: src/olympia/files/templates/files/viewer.html:4
 msgid "File Compare :: Editor tools"
@@ -10694,48 +8536,39 @@ msgstr "Kiegészítő SDK verzió:"
 msgid "Tab stops:"
 msgstr "Tabulátorpozíció:"
 
-#: src/olympia/files/templates/files/viewer.html:79
-#: src/olympia/files/templates/files/viewer.html:80
+#: src/olympia/files/templates/files/viewer.html:79 src/olympia/files/templates/files/viewer.html:80
 msgid "Up file"
 msgstr "Felmenő fájl"
 
-#: src/olympia/files/templates/files/viewer.html:84
-#: src/olympia/files/templates/files/viewer.html:85
+#: src/olympia/files/templates/files/viewer.html:84 src/olympia/files/templates/files/viewer.html:85
 msgid "Down file"
 msgstr "Lementő fájl"
 
-#: src/olympia/files/templates/files/viewer.html:90
-#: src/olympia/files/templates/files/viewer.html:91
+#: src/olympia/files/templates/files/viewer.html:90 src/olympia/files/templates/files/viewer.html:91
 msgid "Previous diff"
 msgstr "Előző diff"
 
-#: src/olympia/files/templates/files/viewer.html:93
-#: src/olympia/files/templates/files/viewer.html:94
+#: src/olympia/files/templates/files/viewer.html:93 src/olympia/files/templates/files/viewer.html:94
 msgid "Previous note"
 msgstr "Előző jegyzet"
 
-#: src/olympia/files/templates/files/viewer.html:100
-#: src/olympia/files/templates/files/viewer.html:101
+#: src/olympia/files/templates/files/viewer.html:100 src/olympia/files/templates/files/viewer.html:101
 msgid "Next diff"
 msgstr "Következő diff"
 
-#: src/olympia/files/templates/files/viewer.html:103
-#: src/olympia/files/templates/files/viewer.html:104
+#: src/olympia/files/templates/files/viewer.html:103 src/olympia/files/templates/files/viewer.html:104
 msgid "Next note"
 msgstr "Következő jegyzet"
 
-#: src/olympia/files/templates/files/viewer.html:109
-#: src/olympia/files/templates/files/viewer.html:110
+#: src/olympia/files/templates/files/viewer.html:109 src/olympia/files/templates/files/viewer.html:110
 msgid "Expand all"
 msgstr "Összes kinyitása"
 
-#: src/olympia/files/templates/files/viewer.html:114
-#: src/olympia/files/templates/files/viewer.html:115
+#: src/olympia/files/templates/files/viewer.html:114 src/olympia/files/templates/files/viewer.html:115
 msgid "Hide or unhide tree"
 msgstr "Fa elrejtése vagy megjelenítése"
 
-#: src/olympia/files/templates/files/viewer.html:119
-#: src/olympia/files/templates/files/viewer.html:120
+#: src/olympia/files/templates/files/viewer.html:119 src/olympia/files/templates/files/viewer.html:120
 msgid "Wrap or unwrap text"
 msgstr "Szövegtördelés"
 
@@ -10746,6 +8579,10 @@ msgstr "Nincsenek fájlok a feltöltött fájlban."
 #: src/olympia/files/templates/files/viewer.html:134
 msgid "Fetching file."
 msgstr "Fájl feldolgozása."
+
+#: src/olympia/legacy_api/views.py:255
+msgid "Not implemented yet."
+msgstr "Még nem megvalósított."
 
 #: src/olympia/lib/constants.py:6
 msgid "United Arab Emirates Dirham"
@@ -11403,12 +9240,7 @@ msgstr "zambiai kwacha"
 msgid "Zimbabwe Dollar"
 msgstr "zimbabwei dollár"
 
-#: src/olympia/lib/video/ffmpeg.py:112 src/olympia/lib/video/totem.py:81
-msgid "Videos must be in WebM."
-msgstr "A videónak WebM formátumban kell lennie."
-
-#: src/olympia/pages/templates/pages/about.lhtml:3
-#: src/olympia/pages/templates/pages/about.lhtml:10
+#: src/olympia/pages/templates/pages/about.lhtml:3 src/olympia/pages/templates/pages/about.lhtml:10
 msgid "About Mozilla Add-ons"
 msgstr "Mozilla kiegészítőkről"
 
@@ -11418,11 +9250,8 @@ msgstr "Mi ez a honlap?"
 
 #: src/olympia/pages/templates/pages/about.lhtml:13
 msgid ""
-"addons.mozilla.org, commonly known as \"AMO\", is Mozilla's official site "
-"for add-ons to Mozilla software, such as Firefox, Thunderbird, and "
-"SeaMonkey. Add-ons let you add new features and change the way your browser "
-"or application works.  Take a look around and explore the thousands of ways "
-"to customize the way you do things online."
+"addons.mozilla.org, commonly known as \"AMO\", is Mozilla's official site for add-ons to Mozilla software, such as Firefox, Thunderbird, and SeaMonkey. Add-ons let you add new features and change "
+"the way your browser or application works. Take a look around and explore the thousands of ways to customize the way you do things online."
 msgstr ""
 
 #: src/olympia/pages/templates/pages/about.lhtml:19
@@ -11431,11 +9260,8 @@ msgstr "Ki készíti ezeket a kiegészítőket?"
 
 #: src/olympia/pages/templates/pages/about.lhtml:20
 msgid ""
-"The add-ons listed here have been created by thousands of developers from "
-"our community, ranging from individual hobbyists to large corporations. All "
-"publicly listed add-ons are reviewed by a team of editors before being "
-"released. Add-ons marked as Experimental have not been reviewed and should "
-"only be installed with caution."
+"The add-ons listed here have been created by thousands of developers from our community, ranging from individual hobbyists to large corporations. All publicly listed add-ons are reviewed by a team "
+"of editors before being released. Add-ons marked as Experimental have not been reviewed and should only be installed with caution."
 msgstr ""
 
 #: src/olympia/pages/templates/pages/about.lhtml:26
@@ -11443,30 +9269,22 @@ msgid "How do I keep up with what's happening at AMO?"
 msgstr "Hogyan tudok lépést tartani azzal, hogy mi történik az AMO-n?"
 
 #: src/olympia/pages/templates/pages/about.lhtml:27
-msgid ""
-"There are several ways to find out the latest news from the world of add-"
-"ons:"
+msgid "There are several ways to find out the latest news from the world of add-ons:"
 msgstr ""
 
 #: src/olympia/pages/templates/pages/about.lhtml:29
 #, python-format
-msgid ""
-"Our <a href=\"%(url)s\">Add-ons Blog</a> is regularly updated with "
-"information for both add-on enthusiasts and developers."
+msgid "Our <a href=\"%(url)s\">Add-ons Blog</a> is regularly updated with information for both add-on enthusiasts and developers."
 msgstr ""
 
 #: src/olympia/pages/templates/pages/about.lhtml:32
 #, python-format
-msgid ""
-"We often post news, tips, and tricks to our Twitter account, <a "
-"href=\"%(url)s\">mozamo</a>"
+msgid "We often post news, tips, and tricks to our Twitter account, <a href=\"%(url)s\">mozamo</a>"
 msgstr ""
 
 #: src/olympia/pages/templates/pages/about.lhtml:34
 #, python-format
-msgid ""
-"Our <a href=\"%(url)s\">forums</a> are a good place to interact with the "
-"add-ons community and discuss upcoming changes to AMO."
+msgid "Our <a href=\"%(url)s\">forums</a> are a good place to interact with the add-ons community and discuss upcoming changes to AMO."
 msgstr ""
 
 #: src/olympia/pages/templates/pages/about.lhtml:39
@@ -11474,50 +9292,31 @@ msgid "This sounds great! How can I get involved?"
 msgstr "Ez jól hangzik! Hogyan kapcsolódhatok be?"
 
 #: src/olympia/pages/templates/pages/about.lhtml:40
-msgid ""
-"There are plenty of ways to get involved. If you're on the technical side:"
+msgid "There are plenty of ways to get involved. If you're on the technical side:"
 msgstr "Sok módja van a bekapcsolódásnak. Ha a műszaki oldalon van:"
 
 #: src/olympia/pages/templates/pages/about.lhtml:42
 #, python-format
-msgid ""
-"<a href=\"%(url)s\">Make your own add-on</a>. We provide free hosting and "
-"update services and can help you reach a large audience of users."
-msgstr ""
-"<a href=\"%(url)s\">Készítse el saját kiegészítőjét</a>. Ingyenes tárhely és"
-" frissítési szolgáltatásokat biztosítunk, és segíthetünk felhasználók széles"
-" közönségét elérni."
+msgid "<a href=\"%(url)s\">Make your own add-on</a>. We provide free hosting and update services and can help you reach a large audience of users."
+msgstr "<a href=\"%(url)s\">Készítse el saját kiegészítőjét</a>. Ingyenes tárhely és frissítési szolgáltatásokat biztosítunk, és segíthetünk felhasználók széles közönségét elérni."
 
 #: src/olympia/pages/templates/pages/about.lhtml:45
 #, python-format
-msgid ""
-"If you have add-on development experience, <a href=\"%(url)s\"> become an "
-"editor</a>! Our editors are add-on fans with a technical background who "
-"review add-ons for code quality and stability."
+msgid "If you have add-on development experience, <a href=\"%(url)s\"> become an editor</a>! Our editors are add-on fans with a technical background who review add-ons for code quality and stability."
 msgstr ""
-"Ha van kiegészítő-fejlesztési tapasztalata, <a href=\"%(url)s\">legyen "
-"szerkesztő</a>! A szerkesztőink kiegészítő-rajongók, műszaki háttérrel, akik"
-" értékelik a kiegészítők kódminőségét és stabilitásukat."
+"Ha van kiegészítő-fejlesztési tapasztalata, <a href=\"%(url)s\">legyen szerkesztő</a>! A szerkesztőink kiegészítő-rajongók, műszaki háttérrel, akik értékelik a kiegészítők kódminőségét és "
+"stabilitásukat."
 
 #: src/olympia/pages/templates/pages/about.lhtml:49
 #, python-format
-msgid ""
-"Help improve this website. It's open source, and you can file bugs and "
-"submit patches. <a href=\"%(url)s\"> GitHub</a> contains all of our current "
-"bugs, legacy bugs can still be found in Bugzilla."
+msgid "Help improve this website. It's open source, and you can file bugs and submit patches. <a href=\"%(url)s\"> GitHub</a> contains all of our current bugs, legacy bugs can still be found in Bugzilla."
 msgstr ""
-"Segítsen tökéletesíteni honlapunkat. Nyílt forráskódú, és bejelentheti a "
-"hibákat, valamint javításokat küldhet be. A <a href=\"%(url)s\">GitHub</a> "
-"tartalmazza az összes jelenlegi hibát, a korábbi hibák pedig megtalálható a "
-"Bugzillában."
+"Segítsen tökéletesíteni honlapunkat. Nyílt forráskódú, és bejelentheti a hibákat, valamint javításokat küldhet be. A <a href=\"%(url)s\">GitHub</a> tartalmazza az összes jelenlegi hibát, a korábbi "
+"hibák pedig megtalálható a Bugzillában."
 
 #: src/olympia/pages/templates/pages/about.lhtml:55
-msgid ""
-"If you're interested in add-ons but not quite as technical, there are still "
-"ways to help:"
-msgstr ""
-"Ha érdeklik a kiegészítők, de nem a műszaki oldaluk, akkor is több módon "
-"segíthet:"
+msgid "If you're interested in add-ons but not quite as technical, there are still ways to help:"
+msgstr "Ha érdeklik a kiegészítők, de nem a műszaki oldaluk, akkor is több módon segíthet:"
 
 #: src/olympia/pages/templates/pages/about.lhtml:58
 msgid "Tell your friends! Let people know which add-ons you use."
@@ -11529,13 +9328,8 @@ msgid "Participate in our <a href=\"%(url)s\">forums</a>."
 msgstr "Vegyen részt a <a href=\"%(url)s\">fórumunkon</a>."
 
 #: src/olympia/pages/templates/pages/about.lhtml:61
-msgid ""
-"Review add-ons on the site. Add-on authors are more likely to improve their "
-"add-ons and write new ones when they know people appreciate their work."
-msgstr ""
-"Értékeljen kiegészítőket az oldalon. A kiegészítők szerzői nagyobb eséllyel "
-"fejlesztik a kiegészítőjüket, és írnak újakat, ha tudják, hogy az emberek "
-"értékelik a munkájukat."
+msgid "Review add-ons on the site. Add-on authors are more likely to improve their add-ons and write new ones when they know people appreciate their work."
+msgstr "Értékeljen kiegészítőket az oldalon. A kiegészítők szerzői nagyobb eséllyel fejlesztik a kiegészítőjüket, és írnak újakat, ha tudják, hogy az emberek értékelik a munkájukat."
 
 #: src/olympia/pages/templates/pages/about.lhtml:66
 msgid "I have a question"
@@ -11544,16 +9338,13 @@ msgstr "Kérdésem van"
 #: src/olympia/pages/templates/pages/about.lhtml:67
 #, python-format
 msgid ""
-"A good place to start is our <a href=\"%(faq_url)s\"><abbr "
-"title=\"Frequently Asked Questions\">FAQ</abbr></a>. If you don't find an "
-"answer there, you can <a href=\"%(forum_url)s\"> ask on our forums</a>."
+"A good place to start is our <a href=\"%(faq_url)s\"><abbr title=\"Frequently Asked Questions\">FAQ</abbr></a>. If you don't find an answer there, you can <a href=\"%(forum_url)s\"> ask on our "
+"forums</a>."
 msgstr ""
 
 #: src/olympia/pages/templates/pages/about.lhtml:72
 #, python-format
-msgid ""
-"If you really need to contact someone from the Mozilla team, please see our "
-"<a href=\"%(url)s\"> contact information</a> page."
+msgid "If you really need to contact someone from the Mozilla team, please see our <a href=\"%(url)s\"> contact information</a> page."
 msgstr ""
 
 #: src/olympia/pages/templates/pages/about.lhtml:76
@@ -11563,10 +9354,8 @@ msgstr "Kii dolgozik ezen a honlapon?"
 #: src/olympia/pages/templates/pages/about.lhtml:77
 #, python-format
 msgid ""
-"Over the years, many people have contributed to this website, including both"
-" volunteers from the community and a dedicated AMO team. A list of "
-"significant contributors can be found on our <a href=\"%(url)s\"> Site "
-"Credits</a> page."
+"Over the years, many people have contributed to this website, including both volunteers from the community and a dedicated AMO team. A list of significant contributors can be found on our <a "
+"href=\"%(url)s\"> Site Credits</a> page."
 msgstr ""
 
 #: src/olympia/pages/templates/pages/acr_firstrun.html:4
@@ -11578,9 +9367,7 @@ msgid "Add-on Compatibility Reporter has been installed"
 msgstr "Kiegészítő kompatibilitás jelentő települt"
 
 #: src/olympia/pages/templates/pages/acr_firstrun.html:28
-msgid ""
-"It’s easy to help us make sure add-ons are updated in time for the release "
-"of the next version of Firefox."
+msgid "It’s easy to help us make sure add-ons are updated in time for the release of the next version of Firefox."
 msgstr ""
 
 #: src/olympia/pages/templates/pages/acr_firstrun.html:35
@@ -11589,35 +9376,27 @@ msgstr ""
 
 #: src/olympia/pages/templates/pages/acr_firstrun.html:40
 msgid ""
-"As you start browsing and using your add-ons, take careful note of anything "
-"that seems different from when you last used the extension. This might be a "
-"display glitch, such as a menu item missing, or something more serious, like"
-" the add-on not working at all or showing errors."
+"As you start browsing and using your add-ons, take careful note of anything that seems different from when you last used the extension. This might be a display glitch, such as a menu item missing, "
+"or something more serious, like the add-on not working at all or showing errors."
 msgstr ""
 
 #: src/olympia/pages/templates/pages/acr_firstrun.html:49
 msgid ""
-"Once you know whether a particular add-on works properly or has problems, "
-"open the Add-ons Manager and click Compatibility next to the add-on to let "
-"Mozilla know what you found in your testing. Submitting a report will help "
-"us tell the add-on developer whether their add-on is working properly in "
-"this version or might need some fixes."
+"Once you know whether a particular add-on works properly or has problems, open the Add-ons Manager and click Compatibility next to the add-on to let Mozilla know what you found in your testing. "
+"Submitting a report will help us tell the add-on developer whether their add-on is working properly in this version or might need some fixes."
 msgstr ""
 
 #: src/olympia/pages/templates/pages/acr_firstrun.html:61
 #, python-format
 msgid ""
-"If you upgrade to a new version of Firefox or update your add-ons, your "
-"reports for the old versions will be hidden to allow you to test the new "
-"version. If you have any questions, please ask in <a href=\"%(url)s\">our "
-"forums</a>."
+"If you upgrade to a new version of Firefox or update your add-ons, your reports for the old versions will be hidden to allow you to test the new version. If you have any questions, please ask in <a"
+" href=\"%(url)s\">our forums</a>."
 msgstr ""
 
 #: src/olympia/pages/templates/pages/acr_firstrun.html:69
 msgid ""
-"Thousands of add-ons are made by our community every year, and your "
-"assistance with compatibility testing helps us make sure these add-ons stay "
-"useful as we strive to provide a great user experience."
+"Thousands of add-ons are made by our community every year, and your assistance with compatibility testing helps us make sure these add-ons stay useful as we strive to provide a great user "
+"experience."
 msgstr ""
 
 #: src/olympia/pages/templates/pages/acr_firstrun.html:75
@@ -11629,9 +9408,7 @@ msgid "Site Credits"
 msgstr "Köszönetnyilvánítás"
 
 #: src/olympia/pages/templates/pages/credits.html:12
-msgid ""
-"Mozilla would like to thank the following people for their contributions to "
-"the addons.mozilla.org project over the years:"
+msgid "Mozilla would like to thank the following people for their contributions to the addons.mozilla.org project over the years:"
 msgstr ""
 
 #: src/olympia/pages/templates/pages/credits.html:18
@@ -11665,73 +9442,57 @@ msgstr "Szoftver és képek"
 
 #: src/olympia/pages/templates/pages/credits.html:59
 msgid ""
-"Some icons used are from the <a "
-"href=\"http://www.famfamfam.com/lab/icons/silk/\">famfamfam Silk Icon "
-"Set</a>, licensed under a <a "
-"href=\"http://creativecommons.org/licenses/by/2.5/\">Creative Commons "
-"Attribution 2.5 License</a>."
+"Some icons used are from the <a href=\"http://www.famfamfam.com/lab/icons/silk/\">famfamfam Silk Icon Set</a>, licensed under a <a href=\"http://creativecommons.org/licenses/by/2.5/\">Creative "
+"Commons Attribution 2.5 License</a>."
 msgstr ""
 
 #: src/olympia/pages/templates/pages/credits.html:60
 msgid ""
-"Some icons used are from the <a href=\"http://www.fatcow.com/free-"
-"icons/\">FatCow Farm-Fresh Web Icons Set</a>, licensed under a <a "
-"href=\"http://creativecommons.org/licenses/by/3.0/us/\">Creative Commons "
-"Attribution 3.0 License</a>."
+"Some icons used are from the <a href=\"http://www.fatcow.com/free-icons/\">FatCow Farm-Fresh Web Icons Set</a>, licensed under a <a href=\"http://creativecommons.org/licenses/by/3.0/us/\">Creative "
+"Commons Attribution 3.0 License</a>."
 msgstr ""
 
 #: src/olympia/pages/templates/pages/credits.html:61
 msgid ""
-"Some pages use elements of <a "
-"href=\"http://shop.highsoft.com/highcharts.html\">Highcharts</a> (non-"
-"commercial), licensed under a <a href=\"http://creativecommons.org/licenses"
-"/by-nc/3.0/\">Creative Commons Attribution-NonCommercial 3.0 License</a>."
+"Some pages use elements of <a href=\"http://shop.highsoft.com/highcharts.html\">Highcharts</a> (non-commercial), licensed under a <a href=\"http://creativecommons.org/licenses/by-nc/3.0/\">Creative"
+" Commons Attribution-NonCommercial 3.0 License</a>."
 msgstr ""
 
 #: src/olympia/pages/templates/pages/credits.html:65
 #, python-format
-msgid ""
-"For information on contributing, please see our <a href=\"%(url)s\">wiki "
-"page</a>."
+msgid "For information on contributing, please see our <a href=\"%(url)s\">wiki page</a>."
 msgstr ""
 
 #: src/olympia/pages/templates/pages/dev_faq.html:4
 msgid "Developer FAQ"
 msgstr "Fejlesztői GYIK"
 
-#: src/olympia/pages/templates/pages/dev_faq.html:31
-#: src/olympia/pages/templates/pages/review_guide.html:33
+#: src/olympia/pages/templates/pages/dev_faq.html:31 src/olympia/pages/templates/pages/review_guide.html:33
 msgid "Sections"
 msgstr "Szakaszok"
 
-#: src/olympia/pages/templates/pages/dev_faq.html:33
-#: src/olympia/pages/templates/pages/dev_faq.html:45
+#: src/olympia/pages/templates/pages/dev_faq.html:33 src/olympia/pages/templates/pages/dev_faq.html:45
 msgid "Developing an Add-on"
 msgstr "Kiegészítő fejlesztése"
 
 #. Heading for a list of resources for developers
-#: src/olympia/pages/templates/pages/dev_faq.html:34
-#: src/olympia/pages/templates/pages/dev_faq.html:208
+#: src/olympia/pages/templates/pages/dev_faq.html:34 src/olympia/pages/templates/pages/dev_faq.html:208
 msgid "Support Resources"
 msgstr "Támogatási erőforrások"
 
-#: src/olympia/pages/templates/pages/dev_faq.html:35
-#: src/olympia/pages/templates/pages/dev_faq.html:261
+#: src/olympia/pages/templates/pages/dev_faq.html:35 src/olympia/pages/templates/pages/dev_faq.html:261
 msgid "Contributing your Add-on"
 msgstr "Kiegészítőjének közreadása"
 
-#: src/olympia/pages/templates/pages/dev_faq.html:36
-#: src/olympia/pages/templates/pages/dev_faq.html:381
+#: src/olympia/pages/templates/pages/dev_faq.html:36 src/olympia/pages/templates/pages/dev_faq.html:381
 msgid "Add-on Review Process"
 msgstr "Kiegészítő értékelési folyamata"
 
-#: src/olympia/pages/templates/pages/dev_faq.html:37
-#: src/olympia/pages/templates/pages/dev_faq.html:444
+#: src/olympia/pages/templates/pages/dev_faq.html:37 src/olympia/pages/templates/pages/dev_faq.html:444
 msgid "Managing Your Add-on"
 msgstr "Kiegészítők kezelése"
 
-#: src/olympia/pages/templates/pages/dev_faq.html:39
-#: src/olympia/pages/templates/pages/dev_faq.html:528
+#: src/olympia/pages/templates/pages/dev_faq.html:39 src/olympia/pages/templates/pages/dev_faq.html:528
 msgid "References for Open Source Licenses"
 msgstr "Nyílt forráskódú licencek hivatkozásai"
 
@@ -11741,14 +9502,8 @@ msgstr "Kiegészítő-fejlesztői GYIK"
 
 #: src/olympia/pages/templates/pages/dev_faq.html:47
 #, python-format
-msgid ""
-"<h3>How do I build an Add-on?</h3> <p> Mozilla provides documentation on how"
-" to build an add-on via the <a href=\"%(url)s\">Mozilla Developer "
-"Network</a>. </p>"
-msgstr ""
-"<h3>Hogyan készítek egy kiegészítőt?</h3> <p>A Mozilla a <a "
-"href=\"%(url)s\">Mozilla fejlesztői hálózaton</a> keresztül biztosít "
-"dokumentációt arról, hogy hogyan készítsen el egy kiegészítőt.</p>"
+msgid "<h3>How do I build an Add-on?</h3> <p> Mozilla provides documentation on how to build an add-on via the <a href=\"%(url)s\">Mozilla Developer Network</a>. </p>"
+msgstr "<h3>Hogyan készítek egy kiegészítőt?</h3> <p>A Mozilla a <a href=\"%(url)s\">Mozilla fejlesztői hálózaton</a> keresztül biztosít dokumentációt arról, hogy hogyan készítsen el egy kiegészítőt.</p>"
 
 #: src/olympia/pages/templates/pages/dev_faq.html:55
 msgid "Other resources include:"
@@ -11768,9 +9523,8 @@ msgstr "Milyen eszközökre van szükségem, hogy egy kiegészítőt készítsek
 
 #: src/olympia/pages/templates/pages/dev_faq.html:68
 msgid ""
-"You will need to have a version of the Mozilla software that you're building"
-" the add-on for and a code editor of your choice. Add-ons can be built for "
-"almost all Mozilla software but are primarily targeted for:"
+"You will need to have a version of the Mozilla software that you're building the add-on for and a code editor of your choice. Add-ons can be built for almost all Mozilla software but are primarily "
+"targeted for:"
 msgstr ""
 
 #: src/olympia/pages/templates/pages/dev_faq.html:82
@@ -11780,18 +9534,13 @@ msgstr "Népszerű kódszerkesztők többek között:"
 #. This is a list of popular code editors.  Feel free to adjust as you like.
 #: src/olympia/pages/templates/pages/dev_faq.html:85
 msgid ""
-"<li><a href=\"http://komodoide.com/komodo-edit/\">Komodo Edit</a></li> "
-"<li><a href=\"http://macromates.com/\">TextMate</a></li> <li><a href=\"http"
-"://notepad-plus-plus.org/\">Notepad++</a></li> <li><a "
-"href=\"http://www.eclipse.org/\">Eclipse IDE</a></li>"
+"<li><a href=\"http://komodoide.com/komodo-edit/\">Komodo Edit</a></li> <li><a href=\"http://macromates.com/\">TextMate</a></li> <li><a href=\"http://notepad-plus-plus.org/\">Notepad++</a></li> "
+"<li><a href=\"http://www.eclipse.org/\">Eclipse IDE</a></li>"
 msgstr ""
 
 #: src/olympia/pages/templates/pages/dev_faq.html:94
 #, python-format
-msgid ""
-"You can also learn more about setting up your development environment via "
-"the MDN article <a href=\"%(url)s\">Setting up extension development "
-"environment</a>"
+msgid "You can also learn more about setting up your development environment via the MDN article <a href=\"%(url)s\">Setting up extension development environment</a>"
 msgstr ""
 
 #: src/olympia/pages/templates/pages/dev_faq.html:100
@@ -11799,9 +9548,7 @@ msgid "What is a \".xpi\" file?"
 msgstr "Mi az a „.xpi” fájl?"
 
 #: src/olympia/pages/templates/pages/dev_faq.html:102
-msgid ""
-"Extensions are packaged and distributed in ZIP files or Bundles, with the "
-"XPI (pronounced \"zippy\") file extension."
+msgid "Extensions are packaged and distributed in ZIP files or Bundles, with the XPI (pronounced \"zippy\") file extension."
 msgstr ""
 
 #: src/olympia/pages/templates/pages/dev_faq.html:108
@@ -11810,10 +9557,8 @@ msgstr "Mi az a XUL?"
 
 #: src/olympia/pages/templates/pages/dev_faq.html:110
 msgid ""
-"XUL (XML User Interface Language) is Mozilla's XML-based language that lets "
-"you build feature-rich cross platform applications. It provides user "
-"interface widgets like buttons, menus, toolbars, trees, etc that can be used"
-" to enhance add-ons by modifying parts of the browser UI."
+"XUL (XML User Interface Language) is Mozilla's XML-based language that lets you build feature-rich cross platform applications. It provides user interface widgets like buttons, menus, toolbars, "
+"trees, etc that can be used to enhance add-ons by modifying parts of the browser UI."
 msgstr ""
 
 #: src/olympia/pages/templates/pages/dev_faq.html:119
@@ -11823,13 +9568,9 @@ msgstr "Mire használják az „install.rdf” fájlt?"
 #: src/olympia/pages/templates/pages/dev_faq.html:121
 #, python-format
 msgid ""
-"This file, called an <a href=\"%(url)s\">Install Manifest</a>, is used by "
-"Add-on Manager-enabled XUL applications to determine information about an "
-"add-on as it is being installed. It contains metadata identifying the add-"
-"on, providing information about who created it, where more information can "
-"be found about it, which versions of what applications it is compatible "
-"with, how it should be updated, and so on. The format of the Install "
-"Manifest is RDF/XML."
+"This file, called an <a href=\"%(url)s\">Install Manifest</a>, is used by Add-on Manager-enabled XUL applications to determine information about an add-on as it is being installed. It contains "
+"metadata identifying the add-on, providing information about who created it, where more information can be found about it, which versions of what applications it is compatible with, how it should "
+"be updated, and so on. The format of the Install Manifest is RDF/XML."
 msgstr ""
 
 #: src/olympia/pages/templates/pages/dev_faq.html:132
@@ -11837,10 +9578,7 @@ msgid "What does \"maxVersion\" mean?"
 msgstr "Mit jelent a „maxVersion”?"
 
 #: src/olympia/pages/templates/pages/dev_faq.html:134
-msgid ""
-"This determines the maximum version of Firefox you're saying this extension "
-"will work with. Set this to be no newer than the newest currently available "
-"version!"
+msgid "This determines the maximum version of Firefox you're saying this extension will work with. Set this to be no newer than the newest currently available version!"
 msgstr ""
 
 #: src/olympia/pages/templates/pages/dev_faq.html:141
@@ -11849,30 +9587,18 @@ msgstr "Tartalmazhat a kiegészítőm bináris komponenseket?"
 
 #: src/olympia/pages/templates/pages/dev_faq.html:143
 #, python-format
-msgid ""
-"Yes. You can use Mozilla's <a href=\"%(url)s\">XPCOM component object "
-"model</a> to enhance your add-ons. XPCOM components be used and implemented "
-"in JavaScript, Java, and Python in addition to C++."
+msgid "Yes. You can use Mozilla's <a href=\"%(url)s\">XPCOM component object model</a> to enhance your add-ons. XPCOM components be used and implemented in JavaScript, Java, and Python in addition to C++."
 msgstr ""
 
 #: src/olympia/pages/templates/pages/dev_faq.html:150
-msgid ""
-"Can I use a JavaScript library like jQuery, MooTools or Prototype to build "
-"my add-on?"
-msgstr ""
-"Használhatok JavaScript könyvtárakat, mint a jQuery, MooTools vagy "
-"Prototype, a kiegészítőm elkészítéséhez?"
+msgid "Can I use a JavaScript library like jQuery, MooTools or Prototype to build my add-on?"
+msgstr "Használhatok JavaScript könyvtárakat, mint a jQuery, MooTools vagy Prototype, a kiegészítőm elkészítéséhez?"
 
 #: src/olympia/pages/templates/pages/dev_faq.html:152
 msgid ""
-"Yes. It's possible, but some of the functionality provided by these "
-"libraries are available through XPCOM, XUL, and JavaScript. In addition, "
-"authors should take care if libraries modify primitive object prototypes "
-"(String.prototype, Date.prototype, etc.) and/or define global functions (eg."
-" the $ function). These are prone to cause conflict with other add-ons, in "
-"particular if different add-ons use different versions of libraries and so "
-"on. Developers need to be very, very careful with using them.  Mozilla does "
-"not offer documentation on using them to build add-ons."
+"Yes. It's possible, but some of the functionality provided by these libraries are available through XPCOM, XUL, and JavaScript. In addition, authors should take care if libraries modify primitive "
+"object prototypes (String.prototype, Date.prototype, etc.) and/or define global functions (eg. the $ function). These are prone to cause conflict with other add-ons, in particular if different add-"
+"ons use different versions of libraries and so on. Developers need to be very, very careful with using them. Mozilla does not offer documentation on using them to build add-ons."
 msgstr ""
 
 #: src/olympia/pages/templates/pages/dev_faq.html:165
@@ -11885,21 +9611,14 @@ msgid "You can use the <a href=\"%(url)s\">Add-on Debugger</a>."
 msgstr "Használhatja a <a href=\"%(url)s\">Kiegészítő hibakövetőt</a>."
 
 #: src/olympia/pages/templates/pages/dev_faq.html:172
-msgid ""
-"How do I test for compatibility with the latest version of Mozilla software?"
-msgstr ""
-"Hogyan tesztelheti a kompatibilitást a legfrissebb Mozilla szoftverekkel?"
+msgid "How do I test for compatibility with the latest version of Mozilla software?"
+msgstr "Hogyan tesztelheti a kompatibilitást a legfrissebb Mozilla szoftverekkel?"
 
 #: src/olympia/pages/templates/pages/dev_faq.html:174
 msgid ""
-"To ensure compatibility with the latest Mozilla software, it's important to "
-"download updates as they become available and test your add-on to ensure "
-"that it is still functioning as expected. In many cases, the latest version "
-"of Mozilla software may be a beta release. Since these releases at times "
-"introduce architectural changes that may impact the functionality of your "
-"add-on, it's important to be actively involved in the beta process to ensure"
-" that your add-on users are not negatively impacted upon final release of "
-"Mozilla software."
+"To ensure compatibility with the latest Mozilla software, it's important to download updates as they become available and test your add-on to ensure that it is still functioning as expected. In "
+"many cases, the latest version of Mozilla software may be a beta release. Since these releases at times introduce architectural changes that may impact the functionality of your add-on, it's "
+"important to be actively involved in the beta process to ensure that your add-on users are not negatively impacted upon final release of Mozilla software."
 msgstr ""
 
 #: src/olympia/pages/templates/pages/dev_faq.html:185
@@ -11909,11 +9628,8 @@ msgstr "Hogyan javíthatja a kiegészítője teljesítményét?"
 #: src/olympia/pages/templates/pages/dev_faq.html:187
 #, python-format
 msgid ""
-"Poorly written extensions can have a severe impact on the browsing "
-"experience, including on the overall performance of Firefox itself. The "
-"following page contains many good <a href=\"%(url)s\">guides</a> that help "
-"you improve performance, whether you're developing core Mozilla code or an "
-"add-on."
+"Poorly written extensions can have a severe impact on the browsing experience, including on the overall performance of Firefox itself. The following page contains many good <a "
+"href=\"%(url)s\">guides</a> that help you improve performance, whether you're developing core Mozilla code or an add-on."
 msgstr ""
 
 #: src/olympia/pages/templates/pages/dev_faq.html:195
@@ -11923,17 +9639,13 @@ msgstr "Támogathat a kiegészítő több területi beállítást?"
 #: src/olympia/pages/templates/pages/dev_faq.html:197
 #, python-format
 msgid ""
-"Yes. Details on localizing your add-on can be found in the the <a "
-"href=\"%(l10n_url)s\">Mozilla Developer Network Localization page</a>. <a "
-"href=\"%(bz_url)s\">The BabelZilla project</a> is also a great resource for "
-"learning about localization and volunteering to help translate add-ons."
+"Yes. Details on localizing your add-on can be found in the the <a href=\"%(l10n_url)s\">Mozilla Developer Network Localization page</a>. <a href=\"%(bz_url)s\">The BabelZilla project</a> is also a "
+"great resource for learning about localization and volunteering to help translate add-ons."
 msgstr ""
 
 #: src/olympia/pages/templates/pages/dev_faq.html:210
 msgid "I need some advice building my add-on. Where can I find help?"
-msgstr ""
-"Szükségem van néhány tanácsra a kiegészítőm elkészítéséhez. Hol találok "
-"segítséget?"
+msgstr "Szükségem van néhány tanácsra a kiegészítőm elkészítéséhez. Hol találok segítséget?"
 
 #. #extdev is the name of the IRC channel.  do not change.
 #: src/olympia/pages/templates/pages/dev_faq.html:216
@@ -11947,9 +9659,7 @@ msgstr ""
 
 #. #jetpack is the name of the IRC channel.  do not change.
 #: src/olympia/pages/templates/pages/dev_faq.html:220
-msgid ""
-"#jetpack (for discussions about the Add-ons SDK and cfx/jpm - formerly known"
-" as Jetpack)"
+msgid "#jetpack (for discussions about the Add-ons SDK and cfx/jpm - formerly known as Jetpack)"
 msgstr ""
 
 #. Label for a link to the extension developers mailing list
@@ -11985,24 +9695,16 @@ msgstr "Nem."
 
 #: src/olympia/pages/templates/pages/dev_faq.html:246
 msgid "Are there 3rd party developers that I can hire to build my add-on?"
-msgstr ""
-"Vannak-e harmadik félnek számító fejlesztők, akiket meg lehet bízni "
-"kiegészítő-fejlesztéssel?"
+msgstr "Vannak-e harmadik félnek számító fejlesztők, akiket meg lehet bízni kiegészítő-fejlesztéssel?"
 
 #: src/olympia/pages/templates/pages/dev_faq.html:248
 #, python-format
 msgid ""
-"Yes. You may find 3rd party developers via the <a href=\"%(forum_url)s"
-"\">Add-ons forum</a>, <a href=\"%(list_url)s\">mozilla.jobs list</a>, <a "
-"href=\"%(mz_url)s\">mozillaZine forums</a> or <a href=\"%(wiki_url)s\">the "
-"Mozilla Wiki</a>. Please note that Mozilla does not offer developer "
-"recommendations."
+"Yes. You may find 3rd party developers via the <a href=\"%(forum_url)s\">Add-ons forum</a>, <a href=\"%(list_url)s\">mozilla.jobs list</a>, <a href=\"%(mz_url)s\">mozillaZine forums</a> or <a "
+"href=\"%(wiki_url)s\">the Mozilla Wiki</a>. Please note that Mozilla does not offer developer recommendations."
 msgstr ""
-"Igen, találhat külső fejlesztőket a <a href=\"%(forum_url)s\">Kiegészítők "
-"fórumon</a> keresztül, a <a href=\"%(list_url)s\">mozilla.jobs listán</a>, a"
-" <a href=\"%(mz_url)s\">mozillaZine fórumokon</a> vagy <a "
-"href=\"%(wiki_url)s\">a Mozilla Wikin</a>. Kérjük, vegye figyelembe, hogy a "
-"Mozilla nem nyújt fejlesztő ajánlásokat."
+"Igen, találhat külső fejlesztőket a <a href=\"%(forum_url)s\">Kiegészítők fórumon</a> keresztül, a <a href=\"%(list_url)s\">mozilla.jobs listán</a>, a <a href=\"%(mz_url)s\">mozillaZine "
+"fórumokon</a> vagy <a href=\"%(wiki_url)s\">a Mozilla Wikin</a>. Kérjük, vegye figyelembe, hogy a Mozilla nem nyújt fejlesztő ajánlásokat."
 
 #: src/olympia/pages/templates/pages/dev_faq.html:263
 msgid "Can I host my own add-on?"
@@ -12011,13 +9713,9 @@ msgstr ""
 #: src/olympia/pages/templates/pages/dev_faq.html:265
 #, python-format
 msgid ""
-"Yes. Many developers choose to host their own add-ons. Choosing to host your"
-" add-on on <a href=\"%(amo_url)s\">Mozilla's add-on site</a>, though, allows"
-" for much greater exposure to your add-on due to the large volume of "
-"visitors to the site.  <a href=\"%(md_url)s\">mozdev.org</a> offers free "
-"project hosting for Mozilla applications and extensions providing developers"
-" with tools to help manage source code, version control, bug tracking and "
-"documentation."
+"Yes. Many developers choose to host their own add-ons. Choosing to host your add-on on <a href=\"%(amo_url)s\">Mozilla's add-on site</a>, though, allows for much greater exposure to your add-on due"
+" to the large volume of visitors to the site. <a href=\"%(md_url)s\">mozdev.org</a> offers free project hosting for Mozilla applications and extensions providing developers with tools to help "
+"manage source code, version control, bug tracking and documentation."
 msgstr ""
 
 #: src/olympia/pages/templates/pages/dev_faq.html:277
@@ -12026,9 +9724,7 @@ msgstr ""
 
 #: src/olympia/pages/templates/pages/dev_faq.html:279
 #, python-format
-msgid ""
-"Yes. You can host your add-on on <a href=\"%(url)s\">Mozilla's add-on "
-"website</a>."
+msgid "Yes. You can host your add-on on <a href=\"%(url)s\">Mozilla's add-on website</a>."
 msgstr ""
 
 #: src/olympia/pages/templates/pages/dev_faq.html:284
@@ -12037,12 +9733,8 @@ msgstr "Mi az az AMO?"
 
 #: src/olympia/pages/templates/pages/dev_faq.html:286
 msgid ""
-"Mozilla's AMO (<a "
-"href=\"https://addons.mozilla.org\">https://addons.mozilla.org</a>) is the "
-"incubator that helps developers build, distribute, and support fantastic "
-"consumer products powered by Mozilla. It provides you the tools and "
-"infrastructure necessary to manage, host and expose your add-on to a massive"
-" base of Mozilla users."
+"Mozilla's AMO (<a href=\"https://addons.mozilla.org\">https://addons.mozilla.org</a>) is the incubator that helps developers build, distribute, and support fantastic consumer products powered by "
+"Mozilla. It provides you the tools and infrastructure necessary to manage, host and expose your add-on to a massive base of Mozilla users."
 msgstr ""
 
 #: src/olympia/pages/templates/pages/dev_faq.html:295
@@ -12051,9 +9743,7 @@ msgstr ""
 
 #: src/olympia/pages/templates/pages/dev_faq.html:297
 #, python-format
-msgid ""
-"Yes. Our <a href=\"%(url)s\">Privacy Policy</a> describes how your "
-"information is managed by Mozilla."
+msgid "Yes. Our <a href=\"%(url)s\">Privacy Policy</a> describes how your information is managed by Mozilla."
 msgstr ""
 
 #: src/olympia/pages/templates/pages/dev_faq.html:302
@@ -12062,25 +9752,19 @@ msgstr ""
 
 #: src/olympia/pages/templates/pages/dev_faq.html:304
 msgid ""
-"The \"Developer Tools\" dashboard is the area that provides you the tools to"
-" successfully manage your add-ons. It provides the functionality necessary "
-"to submit your add-ons to AMO, manage add-on information, and review "
-"statistics."
+"The \"Developer Tools\" dashboard is the area that provides you the tools to successfully manage your add-ons. It provides the functionality necessary to submit your add-ons to AMO, manage add-on "
+"information, and review statistics."
 msgstr ""
 
 #: src/olympia/pages/templates/pages/dev_faq.html:312
-msgid ""
-"Does Mozilla have a policy in place as to what is an acceptable submission?"
+msgid "Does Mozilla have a policy in place as to what is an acceptable submission?"
 msgstr ""
 
 #: src/olympia/pages/templates/pages/dev_faq.html:314
 #, python-format
 msgid ""
-"Yes. Mozilla's <a href=\"%(p_url)s\">Add-on Policy</a> describes what is an "
-"acceptable submission. This policy is subject to change without notice.  In "
-"addition, the AMO editorial team uses the <a href=\"%(g_url)s\">Editors "
-"Reviewing Guide</a> to ensure that your add-on meets specific guidelines for"
-" functionality and security."
+"Yes. Mozilla's <a href=\"%(p_url)s\">Add-on Policy</a> describes what is an acceptable submission. This policy is subject to change without notice. In addition, the AMO editorial team uses the <a "
+"href=\"%(g_url)s\">Editors Reviewing Guide</a> to ensure that your add-on meets specific guidelines for functionality and security."
 msgstr ""
 
 #: src/olympia/pages/templates/pages/dev_faq.html:324
@@ -12090,11 +9774,8 @@ msgstr ""
 #: src/olympia/pages/templates/pages/dev_faq.html:326
 #, python-format
 msgid ""
-"The Developer Tools dashboard will allow you to upload and submit add-ons to"
-" AMO. You must be a registered AMO users before you can submit an add-on. "
-"Before submitting your add-on be sure to you have read the AMO <a "
-"href=\"%(url)s\">Editors Reviewing Guide</a> to ensure that your add-on has "
-"met the guidelines used by editors to review add-ons."
+"The Developer Tools dashboard will allow you to upload and submit add-ons to AMO. You must be a registered AMO users before you can submit an add-on. Before submitting your add-on be sure to you "
+"have read the AMO <a href=\"%(url)s\">Editors Reviewing Guide</a> to ensure that your add-on has met the guidelines used by editors to review add-ons."
 msgstr ""
 
 #: src/olympia/pages/templates/pages/dev_faq.html:336
@@ -12102,9 +9783,7 @@ msgid "What operating system do I choose for my add-on?"
 msgstr ""
 
 #: src/olympia/pages/templates/pages/dev_faq.html:338
-msgid ""
-"You must choose the operating systems on which your add-on will successfully"
-" function."
+msgid "You must choose the operating systems on which your add-on will successfully function."
 msgstr ""
 
 #: src/olympia/pages/templates/pages/dev_faq.html:344
@@ -12113,11 +9792,8 @@ msgstr ""
 
 #: src/olympia/pages/templates/pages/dev_faq.html:346
 msgid ""
-"The choice of category is dependent on what type of audience you are "
-"targeting and the functionality of your add-on. If you're unsure of which "
-"category your add-on falls into, please choose \"Other\". The AMO team may "
-"re-categorize your add-on if it's determined that it's better suited in a "
-"different category."
+"The choice of category is dependent on what type of audience you are targeting and the functionality of your add-on. If you're unsure of which category your add-on falls into, please choose "
+"\"Other\". The AMO team may re-categorize your add-on if it's determined that it's better suited in a different category."
 msgstr ""
 
 #: src/olympia/pages/templates/pages/dev_faq.html:355
@@ -12125,9 +9801,7 @@ msgid "What does \"nominating\" my add-on mean?"
 msgstr ""
 
 #: src/olympia/pages/templates/pages/dev_faq.html:357
-msgid ""
-"Nominated add-ons are new add-ons that the author has nominated to become "
-"public via the Developer Tools."
+msgid "Nominated add-ons are new add-ons that the author has nominated to become public via the Developer Tools."
 msgstr ""
 
 #: src/olympia/pages/templates/pages/dev_faq.html:363
@@ -12135,10 +9809,7 @@ msgid "Can I specify a license agreement for using my add-on?"
 msgstr ""
 
 #: src/olympia/pages/templates/pages/dev_faq.html:365
-msgid ""
-"Yes. You can specify a license agreement when submitting your add-on. You "
-"can also add or update a license agreement via the Developer Tools dashboard"
-" after your add-on has been submitted."
+msgid "Yes. You can specify a license agreement when submitting your add-on. You can also add or update a license agreement via the Developer Tools dashboard after your add-on has been submitted."
 msgstr ""
 
 #: src/olympia/pages/templates/pages/dev_faq.html:372
@@ -12146,10 +9817,7 @@ msgid "Can I include a privacy policy for my add-on?"
 msgstr ""
 
 #: src/olympia/pages/templates/pages/dev_faq.html:374
-msgid ""
-"Yes. You can specify a privacy policy when submitting your add-on. You can "
-"also add or update a privacy policy via the Developer Tools dashboard after "
-"your add-on has been submitted."
+msgid "Yes. You can specify a privacy policy when submitting your add-on. You can also add or update a privacy policy via the Developer Tools dashboard after your add-on has been submitted."
 msgstr ""
 
 #: src/olympia/pages/templates/pages/dev_faq.html:383
@@ -12159,10 +9827,8 @@ msgstr "Miért kell a kiegészítőjét értékelni?"
 #: src/olympia/pages/templates/pages/dev_faq.html:385
 #, python-format
 msgid ""
-"All add-ons submitted, whether new or updated, are reviewed to ensure that "
-"Mozilla users have a stable and safe experience. All add-ons submissions are"
-" reviewed using the guidelines outlined in the <a href=\"%(url)s\">Editors "
-"Reviewing Guide</a>."
+"All add-ons submitted, whether new or updated, are reviewed to ensure that Mozilla users have a stable and safe experience. All add-ons submissions are reviewed using the guidelines outlined in the"
+" <a href=\"%(url)s\">Editors Reviewing Guide</a>."
 msgstr ""
 
 #: src/olympia/pages/templates/pages/dev_faq.html:393
@@ -12172,12 +9838,9 @@ msgstr "Ki értékeli a kiegészítőjét?"
 #: src/olympia/pages/templates/pages/dev_faq.html:395
 #, python-format
 msgid ""
-"Add-ons are reviewed by the AMO Editors, a group of talented developers that"
-" volunteer to help the Mozilla project by reviewing add-ons to ensure a "
-"stable and safe experience for Mozilla users. When communicating with "
-"editors, please be courteous, patient and respectful as they are working "
-"hard to ensure that your add-on is set up correctly and follows the "
-"guidelines outlined in the <a href=\"%(url)s\">Editors Reviewing Guide</a>."
+"Add-ons are reviewed by the AMO Editors, a group of talented developers that volunteer to help the Mozilla project by reviewing add-ons to ensure a stable and safe experience for Mozilla users. "
+"When communicating with editors, please be courteous, patient and respectful as they are working hard to ensure that your add-on is set up correctly and follows the guidelines outlined in the <a "
+"href=\"%(url)s\">Editors Reviewing Guide</a>."
 msgstr ""
 
 #: src/olympia/pages/templates/pages/dev_faq.html:406
@@ -12187,11 +9850,8 @@ msgstr ""
 #: src/olympia/pages/templates/pages/dev_faq.html:408
 #, python-format
 msgid ""
-"The Mozilla editorial team follows the <a href=\"%(url)s\">Editors Reviewing"
-" Guide</a> when testing an add-on for acceptance onto AMO. It is important "
-"that add-on developers review this guide to ensure that common problem areas"
-" are addressed prior to submitting their add-on for review. This will "
-"greatly assist in expediting the review process."
+"The Mozilla editorial team follows the <a href=\"%(url)s\">Editors Reviewing Guide</a> when testing an add-on for acceptance onto AMO. It is important that add-on developers review this guide to "
+"ensure that common problem areas are addressed prior to submitting their add-on for review. This will greatly assist in expediting the review process."
 msgstr ""
 
 #: src/olympia/pages/templates/pages/dev_faq.html:418
@@ -12199,9 +9859,7 @@ msgid "How long will it take for my add-on to be reviewed?"
 msgstr ""
 
 #: src/olympia/pages/templates/pages/dev_faq.html:420
-msgid ""
-"We cannot give a time estimate as to how long it will take before an add-on "
-"is reviewed. Many factors affect the time including the:"
+msgid "We cannot give a time estimate as to how long it will take before an add-on is reviewed. Many factors affect the time including the:"
 msgstr ""
 
 #. part of a list (<li>)
@@ -12222,11 +9880,8 @@ msgstr ""
 #: src/olympia/pages/templates/pages/dev_faq.html:434
 #, python-format
 msgid ""
-"This is why it's very important to read the <a href=\"%(g_url)s\">Editors "
-"Reviewing Guide</a> to ensure that your add-on is setup as expected.  It's "
-"also a good idea to read the blog post, <a "
-"href=\"%(blog_url)s\">Successfully Getting your Add-on Reviewed</a> which "
-"provides excellent insight into ensuring a smooth review of your add-on."
+"This is why it's very important to read the <a href=\"%(g_url)s\">Editors Reviewing Guide</a> to ensure that your add-on is setup as expected. It's also a good idea to read the blog post, <a "
+"href=\"%(blog_url)s\">Successfully Getting your Add-on Reviewed</a> which provides excellent insight into ensuring a smooth review of your add-on."
 msgstr ""
 
 #: src/olympia/pages/templates/pages/dev_faq.html:446
@@ -12234,10 +9889,7 @@ msgid "How can I see how many times my add-on has been downloaded?"
 msgstr ""
 
 #: src/olympia/pages/templates/pages/dev_faq.html:448
-msgid ""
-"The Statistics Dashboard found in the Developer Tools dashboard provides "
-"information that can help you determine your add-on downloads since you've "
-"submitted it to AMO."
+msgid "The Statistics Dashboard found in the Developer Tools dashboard provides information that can help you determine your add-on downloads since you've submitted it to AMO."
 msgstr ""
 
 #: src/olympia/pages/templates/pages/dev_faq.html:455
@@ -12245,10 +9897,7 @@ msgid "How can I see how many active users are using my add-on?"
 msgstr ""
 
 #: src/olympia/pages/templates/pages/dev_faq.html:457
-msgid ""
-"The Statistics Dashboard found in the Developer Tools dashboard provides "
-"information that can help you determine how many users have been actively "
-"using your add-on since you've submitted it to AMO."
+msgid "The Statistics Dashboard found in the Developer Tools dashboard provides information that can help you determine how many users have been actively using your add-on since you've submitted it to AMO."
 msgstr ""
 
 #: src/olympia/pages/templates/pages/dev_faq.html:464
@@ -12256,10 +9905,7 @@ msgid "How do I submit an update for my add-on?"
 msgstr ""
 
 #: src/olympia/pages/templates/pages/dev_faq.html:466
-msgid ""
-"You can submit an update for your add-on via the Developer Tools dashboard "
-"by choosing the option \"Upload a new version\" and uploading a new .xpi "
-"file for your add-on."
+msgid "You can submit an update for your add-on via the Developer Tools dashboard by choosing the option \"Upload a new version\" and uploading a new .xpi file for your add-on."
 msgstr ""
 
 #: src/olympia/pages/templates/pages/dev_faq.html:473
@@ -12268,39 +9914,30 @@ msgstr ""
 
 #: src/olympia/pages/templates/pages/dev_faq.html:475
 msgid ""
-"That depends. If you are simply changing a description of your add-on or "
-"updating a \"maxVersion\" to ensure compatibility with a new Mozilla "
-"software update, then your add-on does not need to be reviewed again. If, "
-"however, you submit a new updated file, then your add-on update will need to"
-" be reviewed by an editor."
+"That depends. If you are simply changing a description of your add-on or updating a \"maxVersion\" to ensure compatibility with a new Mozilla software update, then your add-on does not need to be "
+"reviewed again. If, however, you submit a new updated file, then your add-on update will need to be reviewed by an editor."
 msgstr ""
 
 #: src/olympia/pages/templates/pages/dev_faq.html:486
-msgid ""
-"How do I reply to a user who has posted a negative review of my add-on?"
+msgid "How do I reply to a user who has posted a negative review of my add-on?"
 msgstr ""
 
 #: src/olympia/pages/templates/pages/dev_faq.html:488
-msgid ""
-"A developer may reply to any review posted to their add-on as long as they "
-"are logged into AMO. In addition, any user can flag a review as:"
+msgid "A developer may reply to any review posted to their add-on as long as they are logged into AMO. In addition, any user can flag a review as:"
 msgstr ""
 
 #. part of a list (<li>)
-#: src/olympia/pages/templates/pages/dev_faq.html:495
-#: src/olympia/reviews/models.py:159
+#: src/olympia/pages/templates/pages/dev_faq.html:495 src/olympia/reviews/models.py:159
 msgid "Spam or otherwise non-review content"
 msgstr "Hirdetés vagy nem értékeléssel kapcsolatos tartalom"
 
 #. part of a list (<li>)
-#: src/olympia/pages/templates/pages/dev_faq.html:497
-#: src/olympia/reviews/models.py:160
+#: src/olympia/pages/templates/pages/dev_faq.html:497 src/olympia/reviews/models.py:160
 msgid "Inappropriate language/dialog"
 msgstr "Nem ideillő nyelvhasználat/veszekedés"
 
 #. part of a list (<li>)
-#: src/olympia/pages/templates/pages/dev_faq.html:499
-#: src/olympia/reviews/models.py:161
+#: src/olympia/pages/templates/pages/dev_faq.html:499 src/olympia/reviews/models.py:161
 msgid "Misplaced bug report or support request"
 msgstr "Rossz helyre küldött hibajelentés vagy támogatási kérés"
 
@@ -12310,23 +9947,15 @@ msgid "Other (provides a pop-up prompt for information)"
 msgstr ""
 
 #: src/olympia/pages/templates/pages/dev_faq.html:504
-msgid ""
-"Currently, AMO does not provide a mechanism to directly communicate with a "
-"reviewer but this feature is being investigated and considered for a future "
-"update."
-msgstr ""
-"Jelenleg, az AMO nem biztosít módot az értékelővel való közvetlenül "
-"kommunikációra, de vizsgáljuk a funkciót, és megfontoljuk egy jövőbeni "
-"frissítésben."
+msgid "Currently, AMO does not provide a mechanism to directly communicate with a reviewer but this feature is being investigated and considered for a future update."
+msgstr "Jelenleg, az AMO nem biztosít módot az értékelővel való közvetlenül kommunikációra, de vizsgáljuk a funkciót, és megfontoljuk egy jövőbeni frissítésben."
 
 #: src/olympia/pages/templates/pages/dev_faq.html:511
 msgid "Can I request that a review be removed if the review is negative?"
 msgstr ""
 
 #: src/olympia/pages/templates/pages/dev_faq.html:513
-msgid ""
-"No. We do not remove negative reviews from add-ons unless they are found to "
-"be false."
+msgid "No. We do not remove negative reviews from add-ons unless they are found to be false."
 msgstr ""
 
 #: src/olympia/pages/templates/pages/dev_faq.html:519
@@ -12334,55 +9963,36 @@ msgid "Can I request that a review be removed if the review is inaccurate?"
 msgstr ""
 
 #: src/olympia/pages/templates/pages/dev_faq.html:521
-msgid ""
-"If an author contacts us and asks for a review containing false or "
-"inaccurate information to be removed, we will review the post and consider "
-"removing it."
+msgid "If an author contacts us and asks for a review containing false or inaccurate information to be removed, we will review the post and consider removing it."
 msgstr ""
 
 #: src/olympia/pages/templates/pages/dev_faq.html:530
 msgid ""
-"Do you need more information about the various open source licenses? Are you"
-" confused as to which license you should select? What rights does a specific"
-" license grant? While nothing replaces reading the full terms of a license, "
-"below are some sites that contain information about some of the key open "
-"source licenses that may help you sort out the differences between them. "
-"These sites are being provided solely for your convenience and as a "
-"reference for your personal use. These resources do not constitute legal "
-"advice nor should they be used in lieu of such advice. Mozilla neither "
-"guarantees nor is responsible for the content of these sites or your "
-"reliance on such content."
+"Do you need more information about the various open source licenses? Are you confused as to which license you should select? What rights does a specific license grant? While nothing replaces "
+"reading the full terms of a license, below are some sites that contain information about some of the key open source licenses that may help you sort out the differences between them. These sites "
+"are being provided solely for your convenience and as a reference for your personal use. These resources do not constitute legal advice nor should they be used in lieu of such advice. Mozilla "
+"neither guarantees nor is responsible for the content of these sites or your reliance on such content."
 msgstr ""
 
 #: src/olympia/pages/templates/pages/dev_faq.html:545
 msgid ""
-"In addition to the full text of the Mozilla Public License(\"MPL\"), this "
-"also provides an annotated version of the MPL and an <abbr "
-"title=\"Frequently Asked Questions\">FAQ</abbr> to help you if you want to "
-"use or distribute code licensed under it."
+"In addition to the full text of the Mozilla Public License(\"MPL\"), this also provides an annotated version of the MPL and an <abbr title=\"Frequently Asked Questions\">FAQ</abbr> to help you if "
+"you want to use or distribute code licensed under it."
 msgstr ""
 
 #: src/olympia/pages/templates/pages/dev_faq.html:559
-msgid ""
-"A table summarizing and comparing how some of the key open source licenses "
-"treat distributions, proprietary software linking, and redistribution of "
-"code with changes."
+msgid "A table summarizing and comparing how some of the key open source licenses treat distributions, proprietary software linking, and redistribution of code with changes."
 msgstr ""
 
 #: src/olympia/pages/templates/pages/dev_faq.html:572
 msgid ""
-"Free Software Foundation provides short summaries of the key open source "
-"licenses, including whether the license qualifies as a free software license"
-" or a copyleft license.  Also includes a discussion of what constitutes a "
-"free software license or a copyleft license (e.g., a Copyleft license is a "
-"general method for making a program or other work free, and requiring all "
-"modified and extended versions of the program to be free as well.)"
+"Free Software Foundation provides short summaries of the key open source licenses, including whether the license qualifies as a free software license or a copyleft license. Also includes a "
+"discussion of what constitutes a free software license or a copyleft license (e.g., a Copyleft license is a general method for making a program or other work free, and requiring all modified and "
+"extended versions of the program to be free as well.)"
 msgstr ""
 
 #: src/olympia/pages/templates/pages/dev_faq.html:589
-msgid ""
-"Open Source Initiative provides the terms of some of the key open source "
-"licenses."
+msgid "Open Source Initiative provides the terms of some of the key open source licenses."
 msgstr ""
 
 #: src/olympia/pages/templates/pages/dev_faq.html:599
@@ -12390,14 +10000,10 @@ msgid "A comparison of known open source licenses on Wikipedia."
 msgstr ""
 
 #: src/olympia/pages/templates/pages/dev_faq.html:605
-msgid ""
-"A site to provide non-judgmental guidance on choosing a license for your "
-"open source project."
+msgid "A site to provide non-judgmental guidance on choosing a license for your open source project."
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:3
-#: src/olympia/pages/templates/pages/faq.html:9
-#: src/olympia/pages/templates/pages/faq.html:10
+#: src/olympia/pages/templates/pages/faq.html:3 src/olympia/pages/templates/pages/faq.html:9 src/olympia/pages/templates/pages/faq.html:10
 msgid "Frequently Asked Questions"
 msgstr "Gyakran Ismételt Kérdések"
 
@@ -12412,19 +10018,12 @@ msgstr "Mi az a kiegészítő?"
 #: src/olympia/pages/templates/pages/faq.html:16
 #, python-format
 msgid ""
-"Add-ons are small pieces of software that add new features or functionality "
-"to your installation of %(app_name)s. Add-ons can augment %(app_name)s with "
-"new features, foreign language dictionaries, or change its visual "
-"appearance. Through add-ons, you can customize %(app_name)s to meet your "
-"needs and tastes. <a href=\"%(learnmore_url)s\">Learn more about "
-"customization</a>"
+"Add-ons are small pieces of software that add new features or functionality to your installation of %(app_name)s. Add-ons can augment %(app_name)s with new features, foreign language dictionaries, "
+"or change its visual appearance. Through add-ons, you can customize %(app_name)s to meet your needs and tastes. <a href=\"%(learnmore_url)s\">Learn more about customization</a>"
 msgstr ""
-"A kiegészítők olyan kis szoftverkomponensek, amelyek új funkciókat adnak a "
-"%(app_name)s alkalmazáshoz. A kiegészítők olyan funkciókat adhatnak a "
-"%(app_name)s alkalmazáshoz, mint szótárak vagy a megjelenés módosítása. A "
-"kiegészítőkön keresztül testreszabható a %(app_name)s, hogy minél jobban "
-"illeszkedjen az igényekhez és az ízléshez. <a "
-"href=\"%(learnmore_url)s\">Tudjon meg többet a testreszabásról</a>"
+"A kiegészítők olyan kis szoftverkomponensek, amelyek új funkciókat adnak a %(app_name)s alkalmazáshoz. A kiegészítők olyan funkciókat adhatnak a %(app_name)s alkalmazáshoz, mint szótárak vagy a "
+"megjelenés módosítása. A kiegészítőkön keresztül testreszabható a %(app_name)s, hogy minél jobban illeszkedjen az igényekhez és az ízléshez. <a href=\"%(learnmore_url)s\">Tudjon meg többet a "
+"testreszabásról</a>"
 
 #: src/olympia/pages/templates/pages/faq.html:26
 msgid "Will add-ons work with my web browser or application?"
@@ -12433,25 +10032,15 @@ msgstr "A kiegészítők működni fognak a böngészőmmel vagy az alkalmazáso
 #: src/olympia/pages/templates/pages/faq.html:27
 #, python-format
 msgid ""
-"Add-ons listed in this gallery only work with Mozilla-based applications, "
-"such as <a href=\"%(getfirefox_url)s\">Firefox</a>, <a "
-"href=\"%(getmobile_url)s\">Firefox Mobile</a>, <a "
-"href=\"%(getseamonkey_url)s\">SeaMonkey</a>, and <a "
-"href=\"%(getthunderbird_url)s\">Thunderbird</a>. However, not all add-ons "
-"work with each of those applications or every version of those applications."
-" Each add-on specifies which applications and versions it works with, such "
-"as Firefox 2.0 - 3.6.*. For Firefox add-ons, the install buttons will "
-"indicate whether the add-on is compatible or not."
+"Add-ons listed in this gallery only work with Mozilla-based applications, such as <a href=\"%(getfirefox_url)s\">Firefox</a>, <a href=\"%(getmobile_url)s\">Firefox Mobile</a>, <a "
+"href=\"%(getseamonkey_url)s\">SeaMonkey</a>, and <a href=\"%(getthunderbird_url)s\">Thunderbird</a>. However, not all add-ons work with each of those applications or every version of those "
+"applications. Each add-on specifies which applications and versions it works with, such as Firefox 2.0 - 3.6.*. For Firefox add-ons, the install buttons will indicate whether the add-on is "
+"compatible or not."
 msgstr ""
-"A galériában található kiegészítők csak Mozilla-alapú alkalmazásokkal "
-"működnek, mint például a <a href=\"%(getfirefox_url)s\">Firefox</a>, a <a "
-"href=\"%(getmobile_url)s\"> Firefox Mobile </a>, a <a "
-"href=\"%(getseamonkey_url)s\">SeaMonkey</a> és a <a "
-"href=\"%(getthunderbird_url)s\">Thunderbird</a>. Azonban nem minden "
-"kiegészítő működik mindegyik alkalmazással vagy minden verzióval. Minden "
-"kiegészítő meghatározza, hogy mely alkalmazásokkal és változatokkal működik "
-"együtt, mint például Firefox 2.0 - 3.6.*. A Firefox-kiegészítőknél a "
-"telepítés gomb jelzi, hogy a kiegészítő kompatibilis, vagy sem."
+"A galériában található kiegészítők csak Mozilla-alapú alkalmazásokkal működnek, mint például a <a href=\"%(getfirefox_url)s\">Firefox</a>, a <a href=\"%(getmobile_url)s\"> Firefox Mobile </a>, a <a"
+" href=\"%(getseamonkey_url)s\">SeaMonkey</a> és a <a href=\"%(getthunderbird_url)s\">Thunderbird</a>. Azonban nem minden kiegészítő működik mindegyik alkalmazással vagy minden verzióval. Minden "
+"kiegészítő meghatározza, hogy mely alkalmazásokkal és változatokkal működik együtt, mint például Firefox 2.0 - 3.6.*. A Firefox-kiegészítőknél a telepítés gomb jelzi, hogy a kiegészítő "
+"kompatibilis, vagy sem."
 
 #: src/olympia/pages/templates/pages/faq.html:42
 msgid "What are the different types of add-ons?"
@@ -12459,74 +10048,46 @@ msgstr "Milyen különböző típusú kiegészítők vannak?"
 
 #: src/olympia/pages/templates/pages/faq.html:43
 #, python-format
-msgid ""
-"There are several kinds of add-ons that customize %(app_name)s in different "
-"ways:"
-msgstr ""
-"A különböző típusú kiegészítők különböző módon képesek testreszabni a "
-"%(app_name)s alkalmazást:"
+msgid "There are several kinds of add-ons that customize %(app_name)s in different ways:"
+msgstr "A különböző típusú kiegészítők különböző módon képesek testreszabni a %(app_name)s alkalmazást:"
 
 #: src/olympia/pages/templates/pages/faq.html:47
 #, python-format
 msgid ""
-"<strong><a href=\"%(browse_url)s\">Extensions</a></strong> add new features "
-"to %(app_name)s or modify existing functionality. There are extensions that "
-"allow you to block advertisements, download videos from websites, integrate "
-"more closely with social websites, and add features you see in other "
-"applications."
+"<strong><a href=\"%(browse_url)s\">Extensions</a></strong> add new features to %(app_name)s or modify existing functionality. There are extensions that allow you to block advertisements, download "
+"videos from websites, integrate more closely with social websites, and add features you see in other applications."
 msgstr ""
-"A <strong><a href=\"%(browse_url)s\">kiegészítők</a></strong> új funkciókat "
-"adnak vagy módosítják a %(app_name)s funkcionalitását. Vannak olyan "
-"bővítmények, amelyek segítségével letilthatók a reklámok, jobb integrációt "
-"tesznek lehetővé a közösségi oldalakkal és más alkalmazásokban található "
-"funkciókat tesz elérhetővé."
+"A <strong><a href=\"%(browse_url)s\">kiegészítők</a></strong> új funkciókat adnak vagy módosítják a %(app_name)s funkcionalitását. Vannak olyan bővítmények, amelyek segítségével letilthatók a "
+"reklámok, jobb integrációt tesznek lehetővé a közösségi oldalakkal és más alkalmazásokban található funkciókat tesz elérhetővé."
 
 #: src/olympia/pages/templates/pages/faq.html:55
 #, python-format
-msgid ""
-"<strong><a href=\"%(browse_url)s\">Complete Themes</a></strong> change the "
-"entire appearance of %(app_name)s, usually including icons, colors, dialogs,"
-" and other visual styles."
+msgid "<strong><a href=\"%(browse_url)s\">Complete Themes</a></strong> change the entire appearance of %(app_name)s, usually including icons, colors, dialogs, and other visual styles."
 msgstr ""
 
 #: src/olympia/pages/templates/pages/faq.html:61
 #, python-format
-msgid ""
-"<strong><a href=\"%(browse_url)s\">Themes</a></strong> are lightweight "
-"themes that use background images to customize your %(app_name)s toolbars."
+msgid "<strong><a href=\"%(browse_url)s\">Themes</a></strong> are lightweight themes that use background images to customize your %(app_name)s toolbars."
 msgstr ""
 
 #: src/olympia/pages/templates/pages/faq.html:66
 #, python-format
-msgid ""
-"<strong><a href=\"%(browse_url)s\">Search Providers</a> </strong> add "
-"additional choices to the search box dropdown. These providers allow you to "
-"quickly search any website."
+msgid "<strong><a href=\"%(browse_url)s\">Search Providers</a> </strong> add additional choices to the search box dropdown. These providers allow you to quickly search any website."
 msgstr ""
-"A <strong><a href=\"%(browse_url)s\">keresőszolgáltatások</a></strong> "
-"további lehetőségeket adnak a keresőmező legördülő listához. Ezek a "
-"szolgáltatások lehetővé teszik a gyors keresést tetszőleges weboldalon."
+"A <strong><a href=\"%(browse_url)s\">keresőszolgáltatások</a></strong> további lehetőségeket adnak a keresőmező legördülő listához. Ezek a szolgáltatások lehetővé teszik a gyors keresést "
+"tetszőleges weboldalon."
 
 #: src/olympia/pages/templates/pages/faq.html:72
 #, python-format
-msgid ""
-"<strong><a href=\"%(browse_url)s\">Dictionaries & Language "
-"Packs</a></strong> add support for additional languages to %(app_name)s."
-msgstr ""
-"<strong>A <a href=\"%(browse_url)s\">Szótárak és nyelvi "
-"csomagok</a></strong> %(app_name)s alkalmazáshoz adott nyelvi támogatást "
-"biztosítanak."
+msgid "<strong><a href=\"%(browse_url)s\">Dictionaries & Language Packs</a></strong> add support for additional languages to %(app_name)s."
+msgstr "<strong>A <a href=\"%(browse_url)s\">Szótárak és nyelvi csomagok</a></strong> %(app_name)s alkalmazáshoz adott nyelvi támogatást biztosítanak."
 
 #: src/olympia/pages/templates/pages/faq.html:77
 #, python-format
-msgid ""
-"<strong><a href=\"%(browse_url)s\">Plugins</a></strong> help %(app_name)s "
-"display or understand different types of media, such as Adobe Flash or Apple"
-" Quicktime."
+msgid "<strong><a href=\"%(browse_url)s\">Plugins</a></strong> help %(app_name)s display or understand different types of media, such as Adobe Flash or Apple Quicktime."
 msgstr ""
-"<strong>A <a href=\"%(browse_url)s\">Bővítmények</a></strong> segítségével a"
-" %(app_name)s alkalmazás képes különböző típusú médiákat megjeleníteni vagy "
-"feldolgozni, ilyen például az Adobe Flash vagy az Apple Quicktime."
+"<strong>A <a href=\"%(browse_url)s\">Bővítmények</a></strong> segítségével a %(app_name)s alkalmazás képes különböző típusú médiákat megjeleníteni vagy feldolgozni, ilyen például az Adobe Flash "
+"vagy az Apple Quicktime."
 
 #: src/olympia/pages/templates/pages/faq.html:85
 msgid "How do I install, manage, or remove an add-on?"
@@ -12535,28 +10096,20 @@ msgstr "Hogyan lehet telepíteni, kezelni vagy eltávolítani a kiegészítőket
 #: src/olympia/pages/templates/pages/faq.html:86
 #, python-format
 msgid ""
-"In most cases, add-ons can be installed by simply clicking the install "
-"button provided. Add-ons can be managed, disabled, or uninstalled from the "
-"Add-ons Manager in %(app_name)s. For more detailed instructions, read <a "
-"href=\"%(extension_url)s\">this article on extensions</a> or <a "
-"href=\"%(theme_url)s\">this one for Themes and Complete Themes</a>. If you "
-"have difficulty installing add-ons, see <a "
-"href=\"%(troubleshooting_url)s\">Troubleshooting Extensions and Themes</a>."
+"In most cases, add-ons can be installed by simply clicking the install button provided. Add-ons can be managed, disabled, or uninstalled from the Add-ons Manager in %(app_name)s. For more detailed "
+"instructions, read <a href=\"%(extension_url)s\">this article on extensions</a> or <a href=\"%(theme_url)s\">this one for Themes and Complete Themes</a>. If you have difficulty installing add-ons, "
+"see <a href=\"%(troubleshooting_url)s\">Troubleshooting Extensions and Themes</a>."
 msgstr ""
 
 #: src/olympia/pages/templates/pages/faq.html:100
 msgid "How do I install add-ons without restarting Firefox?"
-msgstr ""
-"Hogyan lehet telepíteni a kiegészítőket a Firefox újraindítása nélkül?"
+msgstr "Hogyan lehet telepíteni a kiegészítőket a Firefox újraindítása nélkül?"
 
 #: src/olympia/pages/templates/pages/faq.html:101
 #, python-format
 msgid ""
-"In Firefox, add-ons marked with \"No restart required\" can be installed "
-"without restarting. These add-ons have been created using the <a "
-"href=\"%(sdk_url)s\">Add-on SDK</a> or <a "
-"href=\"%(bootstrap_url)s\">bootstrapping</a>. Other add-ons will still "
-"require a restart before you can use them."
+"In Firefox, add-ons marked with \"No restart required\" can be installed without restarting. These add-ons have been created using the <a href=\"%(sdk_url)s\">Add-on SDK</a> or <a "
+"href=\"%(bootstrap_url)s\">bootstrapping</a>. Other add-ons will still require a restart before you can use them."
 msgstr ""
 
 #: src/olympia/pages/templates/pages/faq.html:110
@@ -12566,13 +10119,9 @@ msgstr "Hogyan lehet a legfrissebb verzión tartani a kiegészítőket?"
 #: src/olympia/pages/templates/pages/faq.html:111
 #, python-format
 msgid ""
-"Add-ons, unlike plugins, are automatically checked for updates once every "
-"day. In Firefox, updates are automatically installed by default. Versions of"
-" Firefox prior to 4 (and other applications) will alert you that updates to "
-"your add-ons are available. <a href=\"%(plugin_url)s\">Plugins</a> are not "
-"currently automatically checked for updates, so be sure to regularly visit "
-"the <a href=\"%(plugincheck_url)s\">Plugin Check</a> page to stay up-to-"
-"date."
+"Add-ons, unlike plugins, are automatically checked for updates once every day. In Firefox, updates are automatically installed by default. Versions of Firefox prior to 4 (and other applications) "
+"will alert you that updates to your add-ons are available. <a href=\"%(plugin_url)s\">Plugins</a> are not currently automatically checked for updates, so be sure to regularly visit the <a "
+"href=\"%(plugincheck_url)s\">Plugin Check</a> page to stay up-to-date."
 msgstr ""
 
 #: src/olympia/pages/templates/pages/faq.html:122
@@ -12582,20 +10131,13 @@ msgstr "Biztonságos telepíteni a kiegészítőket?"
 #: src/olympia/pages/templates/pages/faq.html:123
 #, python-format
 msgid ""
-"Unless clearly marked otherwise, add-ons available from this gallery have "
-"been checked and approved by Mozilla's team of editors and are safe to "
-"install. We recommend that you only install approved add-ons. If you wish to"
-" install unapproved add-ons or add-ons from third-party websites, use "
-"caution as these add-ons may harm your computer or violate your privacy. <a "
+"Unless clearly marked otherwise, add-ons available from this gallery have been checked and approved by Mozilla's team of editors and are safe to install. We recommend that you only install approved"
+" add-ons. If you wish to install unapproved add-ons or add-ons from third-party websites, use caution as these add-ons may harm your computer or violate your privacy. <a "
 "href=\"%(learnmore_url)s\">Learn more about our approval process</a>"
 msgstr ""
-"Hacsak egyértelműen nincs jelölve, a galériában található kiegészítőket a "
-"Mozilla csapat szerkesztői átvizsgálták és jóváhagyták és telepítésük "
-"biztonságos. Javasoljuk, hogy csak jóváhagyott kiegészítőt telepítsen. "
-"Amennyiben olyan kiegészítőt kíván telepíteni, amely nem jóváhagyott vagy "
-"más weboldalon található, legyen óvatos, mivel ezek a kiegészítői árthat "
-"rendszernek vagy nem megfelelően kezelheti személyes adatait. <a "
-"href=\"%(learnmore_url)s\">Tudjon meg többet a jóváhagyási folyamatról.</a>"
+"Hacsak egyértelműen nincs jelölve, a galériában található kiegészítőket a Mozilla csapat szerkesztői átvizsgálták és jóváhagyták és telepítésük biztonságos. Javasoljuk, hogy csak jóváhagyott "
+"kiegészítőt telepítsen. Amennyiben olyan kiegészítőt kíván telepíteni, amely nem jóváhagyott vagy más weboldalon található, legyen óvatos, mivel ezek a kiegészítői árthat rendszernek vagy nem "
+"megfelelően kezelheti személyes adatait. <a href=\"%(learnmore_url)s\">Tudjon meg többet a jóváhagyási folyamatról.</a>"
 
 #: src/olympia/pages/templates/pages/faq.html:133
 #, python-format
@@ -12605,42 +10147,26 @@ msgstr "A kiegészítők lelassíthatják a %(app_name)s működését?"
 #: src/olympia/pages/templates/pages/faq.html:135
 #, python-format
 msgid ""
-"Most add-ons do not cause a perceivable performance decrease in "
-"%(app_name)s, though installing an excessive number may have adverse "
-"effects. If you suspect an add-on is causing %(app_name)s to be slow, try "
-"disabling it."
+"Most add-ons do not cause a perceivable performance decrease in %(app_name)s, though installing an excessive number may have adverse effects. If you suspect an add-on is causing %(app_name)s to be "
+"slow, try disabling it."
 msgstr ""
 
 #: src/olympia/pages/templates/pages/faq.html:141
 #, python-format
-msgid ""
-"%(app_name)s told me an add-on isn't compatible. Is there a way I can still "
-"use it?"
-msgstr ""
-"A(z) %(app_name)s alkalmazás szerint a kiegészítő nem kompatibilis. Van rá "
-"lehetőség, hogy ennek ellenére használjam?"
+msgid "%(app_name)s told me an add-on isn't compatible. Is there a way I can still use it?"
+msgstr "A(z) %(app_name)s alkalmazás szerint a kiegészítő nem kompatibilis. Van rá lehetőség, hogy ennek ellenére használjam?"
 
 #: src/olympia/pages/templates/pages/faq.html:144
 #, python-format
 msgid ""
-"If an add-on isn't compatible with your version of %(app_name)s, it is "
-"usually either because your version of %(app_name)s is outdated or the add-"
-"on author has not yet updated the add-on to be compatible with a newer "
-"version you are using. Mozilla does not recommend trying to circumvent these"
-" compatibility checks, as they can lead to browser instability or in some "
-"cases loss of data. For users who are testing out alpha or beta versions of "
-"Firefox, we offer the <a href=\"%(acr_url)s\">Add-on Compatibility "
-"Reporter</a> to help add-on developers update their compatibility."
+"If an add-on isn't compatible with your version of %(app_name)s, it is usually either because your version of %(app_name)s is outdated or the add-on author has not yet updated the add-on to be "
+"compatible with a newer version you are using. Mozilla does not recommend trying to circumvent these compatibility checks, as they can lead to browser instability or in some cases loss of data. For"
+" users who are testing out alpha or beta versions of Firefox, we offer the <a href=\"%(acr_url)s\">Add-on Compatibility Reporter</a> to help add-on developers update their compatibility."
 msgstr ""
-"Amennyiben egy kiegészítő nem kompatibilis az adott %(app_name)s "
-"alkalmazással, annak oka lehet az is, hogy a %(app_name)s alkalmazásnak egy "
-"régi verzióját használja és a kiegészítő csak a legújabb verzióval "
-"kompatibilis. A Mozilla nem javasolja ezen kompatibilitási ellenőrzések "
-"megkerülését, mivel ez a böngésző instabilitásához, néhány esetben pedig "
-"adatvesztéshez vezethet. Azon felhasználók számára, akik alpha vagy beta "
-"Firefox-verziókat tesztelnek, azok használhatják a <a "
-"href=\"%(acr_url)s\">Kompatibilitásjelentő</a> kiegészítőt, hogy segítsen a "
-"fejlesztőknek a kompatibilitás frissítésében."
+"Amennyiben egy kiegészítő nem kompatibilis az adott %(app_name)s alkalmazással, annak oka lehet az is, hogy a %(app_name)s alkalmazásnak egy régi verzióját használja és a kiegészítő csak a legújabb"
+" verzióval kompatibilis. A Mozilla nem javasolja ezen kompatibilitási ellenőrzések megkerülését, mivel ez a böngésző instabilitásához, néhány esetben pedig adatvesztéshez vezethet. Azon "
+"felhasználók számára, akik alpha vagy beta Firefox-verziókat tesztelnek, azok használhatják a <a href=\"%(acr_url)s\">Kompatibilitásjelentő</a> kiegészítőt, hogy segítsen a fejlesztőknek a "
+"kompatibilitás frissítésében."
 
 #: src/olympia/pages/templates/pages/faq.html:156
 msgid "What if I have problems with an add-on?"
@@ -12649,20 +10175,13 @@ msgstr "Mi történik, ha problémám van valamelyik kiegészítővel?"
 #: src/olympia/pages/templates/pages/faq.html:157
 #, python-format
 msgid ""
-"Add-ons are usually created by third-party developers from around the world,"
-" so the best way to get help with an add-on is to look for support links on "
-"the add-on's homepage or contact the developer. If you are having issues "
-"with %(app_name)s that you suspect are related to add-ons you have "
-"installed, <a href=\"%(troubleshooting_url)s\">visit this support "
-"article</a> for troubleshooting tips."
+"Add-ons are usually created by third-party developers from around the world, so the best way to get help with an add-on is to look for support links on the add-on's homepage or contact the "
+"developer. If you are having issues with %(app_name)s that you suspect are related to add-ons you have installed, <a href=\"%(troubleshooting_url)s\">visit this support article</a> for "
+"troubleshooting tips."
 msgstr ""
-"A kiegészítőket általában külső fejlesztők készítik a világ minden táján, "
-"ezért a legjobb módja a segítségkérésnek, ha a kiegészítő weboldalán veszi "
-"igénybe a támogatást, vagy felveszi a kapcsolatot a fejlesztővel. Amennyiben"
-" valamilyen problémája van a %(app_name)s alkalmazással, amelynek "
-"gyaníthatóan köze van egy telepített kiegészítőhöz, akkor a hibakeresési "
-"ötletekért látogasson el a <a href=\"%(troubleshooting_url)s\">támogatói "
-"weboldalra</a>."
+"A kiegészítőket általában külső fejlesztők készítik a világ minden táján, ezért a legjobb módja a segítségkérésnek, ha a kiegészítő weboldalán veszi igénybe a támogatást, vagy felveszi a "
+"kapcsolatot a fejlesztővel. Amennyiben valamilyen problémája van a %(app_name)s alkalmazással, amelynek gyaníthatóan köze van egy telepített kiegészítőhöz, akkor a hibakeresési ötletekért "
+"látogasson el a <a href=\"%(troubleshooting_url)s\">támogatói weboldalra</a>."
 
 #: src/olympia/pages/templates/pages/faq.html:169
 msgid "Add-on Gallery"
@@ -12670,26 +10189,16 @@ msgstr "Kiegészítő galéria"
 
 #: src/olympia/pages/templates/pages/faq.html:171
 msgid "How do I choose between add-ons that seem to do the same thing?"
-msgstr ""
-"Hogyan válasszak két kiegészítő között, amelyek ugyanazt a funkcionalitást "
-"nyújtják?"
+msgstr "Hogyan válasszak két kiegészítő között, amelyek ugyanazt a funkcionalitást nyújtják?"
 
-#: src/olympia/pages/templates/pages/faq.html:173
+#: src/olympia/pages/templates/pages/faq.html:172
 msgid ""
-"There are often several add-ons that have similar features. To figure out "
-"which is right for you, read the entire description of the add-on and view "
-"its screenshots. If there are still several in the running, read through the"
-" add-on's ratings, user reviews, and statistics to see which is most liked "
-"by other users. Remember that you can also just try out both and see which "
-"you like better."
+"There are often several add-ons that have similar features. To figure out which is right for you, read the entire description of the add-on and view its screenshots. If there are still several in "
+"the running, read through the add-on's ratings, user reviews, and statistics to see which is most liked by other users. Remember that you can also just try out both and see which you like better."
 msgstr ""
-"Gyakran több kiegészítő is hasonló funkcionalitással bír. A megfelelő "
-"kiválasztásához olvassa el a kiegészítő teljes leírását és tekintse meg a "
-"hozzájuk kapcsolódó képernyőképeket. Ha még így sem sikerült döntenie, akkor"
-" olvassa el az értékeléseket, visszajelzéseket és statisztikákat, amelyek "
-"alapján megállapíthatók, hogy melyik kideríthető, hogy melyik népszerűbb a "
-"többi felhasználó körében. Ne feledje, hogy kipróbálhat több kiegészít és a "
-"használat során megalapozott döntést tud hozni."
+"Gyakran több kiegészítő is hasonló funkcionalitással bír. A megfelelő kiválasztásához olvassa el a kiegészítő teljes leírását és tekintse meg a hozzájuk kapcsolódó képernyőképeket. Ha még így sem "
+"sikerült döntenie, akkor olvassa el az értékeléseket, visszajelzéseket és statisztikákat, amelyek alapján megállapíthatók, hogy melyik kideríthető, hogy melyik népszerűbb a többi felhasználó "
+"körében. Ne feledje, hogy kipróbálhat több kiegészít és a használat során megalapozott döntést tud hozni."
 
 #: src/olympia/pages/templates/pages/faq.html:180
 msgid "What if I can't find an add-on I'm looking for?"
@@ -12698,32 +10207,22 @@ msgstr "Mi van, ha nem találok olyan kiegészítőt, amit keresek?"
 #: src/olympia/pages/templates/pages/faq.html:181
 #, python-format
 msgid ""
-"With thousands of add-ons available, there's something for everyone. But if "
-"you're looking for a particular add-on and can't find it, you might try "
-"searching on other sites or posting about it in our <a href=\"%(forum_url)s"
-"\">Add-ons </a>forum."
+"With thousands of add-ons available, there's something for everyone. But if you're looking for a particular add-on and can't find it, you might try searching on other sites or posting about it in "
+"our <a href=\"%(forum_url)s\">Add-ons </a>forum."
 msgstr ""
 
 #: src/olympia/pages/templates/pages/faq.html:187
-msgid ""
-"What does it mean if an add-on is \"experimental\" or \"preliminarily "
-"reviewed\"?"
+msgid "What does it mean if an add-on is \"experimental\" or \"preliminarily reviewed\"?"
 msgstr "Mit jelent, ha egy kiegészítő „kísérleti” vagy „előzetesen értékelt”?"
 
 #: src/olympia/pages/templates/pages/faq.html:188
 #, python-format
 msgid ""
-"Experimental add-ons have been checked by our editors to make sure they "
-"don't have security problems, but they may still have bugs or not work "
-"properly. Use caution when installing experimental add-ons and uninstall the"
-" add-on immediately if you notice problems. <a href=\"%(url)s\">Learn more "
-"about our review process</a></dd>"
+"Experimental add-ons have been checked by our editors to make sure they don't have security problems, but they may still have bugs or not work properly. Use caution when installing experimental "
+"add-ons and uninstall the add-on immediately if you notice problems. <a href=\"%(url)s\">Learn more about our review process</a></dd>"
 msgstr ""
-"A kísérleti kiegészítőket a szerkesztők értékelték biztonsági szempontból, "
-"azonban lehetnek benne hibák vagy a működése lehet, hogy nem megfelelő. "
-"Legyen óvatos a kísérleti kiegészítők telepítésekor és amennyiben bármilyen "
-"problémát észlel azonnal távolítsa el. <a href=\"%(url)s\">Tudjon meg többet"
-" az ellenőrző folyamatról</a></dd>"
+"A kísérleti kiegészítőket a szerkesztők értékelték biztonsági szempontból, azonban lehetnek benne hibák vagy a működése lehet, hogy nem megfelelő. Legyen óvatos a kísérleti kiegészítők "
+"telepítésekor és amennyiben bármilyen problémát észlel azonnal távolítsa el. <a href=\"%(url)s\">Tudjon meg többet az ellenőrző folyamatról</a></dd>"
 
 #: src/olympia/pages/templates/pages/faq.html:196
 msgid "What does it mean if an add-on is \"not reviewed\"?"
@@ -12734,245 +10233,173 @@ msgstr ""
 #: src/olympia/pages/templates/pages/faq.html:197
 #, python-format
 msgid ""
-"While all add-ons publicly available in our gallery are reviewed by an "
-"editor, you may receive a direct link to an add-on that hasn't yet been "
-"reviewed. Use caution when installing these add-ons, as they could harm your"
-" computer or violate your privacy. We recommend that you only install "
-"reviewed add-ons. <a href=\"%(url)s\">Learn more about our review "
-"process</a></dd>"
+"While all add-ons publicly available in our gallery are reviewed by an editor, you may receive a direct link to an add-on that hasn't yet been reviewed. Use caution when installing these add-ons, "
+"as they could harm your computer or violate your privacy. We recommend that you only install reviewed add-ons. <a href=\"%(url)s\">Learn more about our review process</a></dd>"
 msgstr ""
-"Annak ellenére, hogy minden kiegészítő nyilvánosan elérhető a galériában és "
-"a szerkesztők értékelték őket, előfordulhat, hogy olyan közvetlen "
-"hivatkozást kap, amely még nem esett át az értékelésen. Legyen óvatos az "
-"ilyen kiegészítők telepítésekor, mivel azok károsíthatják rendszerét vagy "
-"sérthetik személyes adatait. Javasoljuk, hogy csak értékelt kiegészítőket "
-"telepítsen. <a href=\"%(url)s\">Ismerje meg az értékelési "
-"folyamatot</a></dd>"
+"Annak ellenére, hogy minden kiegészítő nyilvánosan elérhető a galériában és a szerkesztők értékelték őket, előfordulhat, hogy olyan közvetlen hivatkozást kap, amely még nem esett át az értékelésen."
+" Legyen óvatos az ilyen kiegészítők telepítésekor, mivel azok károsíthatják rendszerét vagy sérthetik személyes adatait. Javasoljuk, hogy csak értékelt kiegészítőket telepítsen. <a "
+"href=\"%(url)s\">Ismerje meg az értékelési folyamatot</a></dd>"
 
 #: src/olympia/pages/templates/pages/faq.html:206
 msgid "How much do add-ons cost to purchase?"
 msgstr "Mennyibe kerül a kiegészítő?"
 
 #: src/olympia/pages/templates/pages/faq.html:207
-msgid ""
-"Add-ons hosted in our gallery are free unless clearly marked otherwise."
-msgstr ""
-"A galériában található kiegészítők ingyenesek, ellenkező esetben ezek "
-"egyértelműen jelölve vannak."
+msgid "Add-ons hosted in our gallery are free unless clearly marked otherwise."
+msgstr "A galériában található kiegészítők ingyenesek, ellenkező esetben ezek egyértelműen jelölve vannak."
 
-#: src/olympia/pages/templates/pages/faq.html:210
+#: src/olympia/pages/templates/pages/faq.html:209
 msgid "What does it mean when an add-on asks for contributions?"
 msgstr "Mit jelent, ha egy kiegészítő adományt kér?"
 
-#: src/olympia/pages/templates/pages/faq.html:211
+#: src/olympia/pages/templates/pages/faq.html:210
 msgid ""
-"Some add-on authors request users who enjoy an add-on to contribute to its "
-"development by making a monetary contribution. These contributions go "
-"directly to the developer unless a third party is indicated, such as the "
-"non-profit Mozilla Foundation."
+"Some add-on authors request users who enjoy an add-on to contribute to its development by making a monetary contribution. These contributions go directly to the developer unless a third party is "
+"indicated, such as the non-profit Mozilla Foundation."
 msgstr ""
-"Néhány kiegészítő fejlesztő adományt kér a kiegészítőjének fejlesztésének "
-"támogatásához. Ez az adomány közvetlenül a fejlesztőhöz megy, kivéve, ha azt"
-" a fejlesztő harmadik félnek nem ajánlotta fel, például a Mozilla Foundation"
-" számára."
+"Néhány kiegészítő fejlesztő adományt kér a kiegészítőjének fejlesztésének támogatásához. Ez az adomány közvetlenül a fejlesztőhöz megy, kivéve, ha azt a fejlesztő harmadik félnek nem ajánlotta fel,"
+" például a Mozilla Foundation számára."
 
-#: src/olympia/pages/templates/pages/faq.html:216
+#: src/olympia/pages/templates/pages/faq.html:215
 msgid "What are beta add-ons?"
 msgstr "Mik azok a beta kiegészítők?"
 
-#: src/olympia/pages/templates/pages/faq.html:218
+#: src/olympia/pages/templates/pages/faq.html:217
 msgid ""
-"Beta add-ons are unreviewed versions which represent the latest work of an "
-"add-on author. While different authors have different standards for beta "
-"code quality, you should assume that these add-ons are less stable than the "
-"general add-on releases."
+"Beta add-ons are unreviewed versions which represent the latest work of an add-on author. While different authors have different standards for beta code quality, you should assume that these add-"
+"ons are less stable than the general add-on releases."
 msgstr ""
-"A beta kiegészítők nem ellenőrzött változatok, amelyek a fejlesztők "
-"legfrissebb munkáját tartalmazza. Különböző szerzők, különböző módon "
-"értelmezik a beta kód minőségét, de mindenképpen elmondható, hogy ezek a "
-"kiegészítők kevésbé stabilak, mint általában."
+"A beta kiegészítők nem ellenőrzött változatok, amelyek a fejlesztők legfrissebb munkáját tartalmazza. Különböző szerzők, különböző módon értelmezik a beta kód minőségét, de mindenképpen elmondható,"
+" hogy ezek a kiegészítők kevésbé stabilak, mint általában."
 
-#: src/olympia/pages/templates/pages/faq.html:222
+#: src/olympia/pages/templates/pages/faq.html:221
 msgid ""
-"Please note that when you install an add-on from the \"Beta Version\" "
-"section of an add-on's listing, you will continue to receive updates for "
-"that add-on as they become available. Like the initial version you "
-"installed, all beta releases are unreviewed by Mozilla and may harm your "
-"computer."
+"Please note that when you install an add-on from the \"Beta Version\" section of an add-on's listing, you will continue to receive updates for that add-on as they become available. Like the initial"
+" version you installed, all beta releases are unreviewed by Mozilla and may harm your computer."
 msgstr ""
-"Vegye figyelembe, hogyha egy kiegészítőt a „Béta verzió” részéből telepít, "
-"akkor folyamatosan érkezni fognak a frissítések. Ahogy az első telepített "
-"verziónál, úgy az összes béta kiadást sem értékeli a Mozilla és kárt okozhat"
-" a rendszerében."
+"Vegye figyelembe, hogyha egy kiegészítőt a „Béta verzió” részéből telepít, akkor folyamatosan érkezni fognak a frissítések. Ahogy az első telepített verziónál, úgy az összes béta kiadást sem "
+"értékeli a Mozilla és kárt okozhat a rendszerében."
 
-#: src/olympia/pages/templates/pages/faq.html:229
+#: src/olympia/pages/templates/pages/faq.html:228
 msgid "What does it mean when an add-on is flagged as slow?"
 msgstr "Mit jelent, ha egy kiegészítő lassúnak van jelölve?"
 
-#: src/olympia/pages/templates/pages/faq.html:231
-msgid ""
-"Most add-ons load code and resources at the same time Firefox\n"
-"        is starting up. In most cases the impact in start-up time is minimal,\n"
-"        but some add-ons can cause a noticeable slowdown."
+#: src/olympia/pages/templates/pages/faq.html:229
+msgid "Most add-ons load code and resources at the same time Firefox is starting up. In most cases the impact in start-up time is minimal, but some add-ons can cause a noticeable slowdown."
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:236
+#: src/olympia/pages/templates/pages/faq.html:234
 msgid "How do I report an inappropriate or spam user review?"
 msgstr "Hogyan lehet bejelenti a nem megfelelő tartalmú vagy spam értékelést?"
 
-#: src/olympia/pages/templates/pages/faq.html:237
+#: src/olympia/pages/templates/pages/faq.html:235
 msgid ""
-"To report a user review of an add-on, log in with your account and visit the"
-" add-on's reviews page. Find the review you wish to report, click \"Report "
-"this review\" and select a reason. Our editorial team will investigate the "
-"review and take appropriate action."
+"To report a user review of an add-on, log in with your account and visit the add-on's reviews page. Find the review you wish to report, click \"Report this review\" and select a reason. Our "
+"editorial team will investigate the review and take appropriate action."
 msgstr ""
-"Egy felhasználó értékelés bejelentéséhez jelentkezzen be és látogassa meg a "
-"kiegészítő értékelő lapját. Keresse meg a bejelenteni kívánt értékelést és "
-"kattintson az \"Értékelés bejelentése\" hivatkozásra, majd válassza ki annak"
-" okát. A szerkesztői csapat ki fogja vizsgálni a bejelentést és megteszi a "
-"megfelelő intézkedéseket."
+"Egy felhasználó értékelés bejelentéséhez jelentkezzen be és látogassa meg a kiegészítő értékelő lapját. Keresse meg a bejelenteni kívánt értékelést és kattintson az \"Értékelés bejelentése\" "
+"hivatkozásra, majd válassza ki annak okát. A szerkesztői csapat ki fogja vizsgálni a bejelentést és megteszi a megfelelő intézkedéseket."
 
-#: src/olympia/pages/templates/pages/faq.html:242
+#: src/olympia/pages/templates/pages/faq.html:240
 msgid "How do I report a bug or contact the Mozilla Add-ons team?"
-msgstr ""
-"Hogyan lehet hibát bejelenteni, vagy felvenni a kapcsolatot a Mozilla Add-"
-"ons csapattal?"
+msgstr "Hogyan lehet hibát bejelenteni, vagy felvenni a kapcsolatot a Mozilla Add-ons csapattal?"
 
-#: src/olympia/pages/templates/pages/faq.html:243
+#: src/olympia/pages/templates/pages/faq.html:241
 #, python-format
 msgid "Please visit our <a href=\"%(contact_url)s\">Contact page</a>."
 msgstr "Látogassa meg a <a href=\"%(contact_url)s\">Kapcsolat oldalt</a>."
 
-#: src/olympia/pages/templates/pages/faq.html:246
+#: src/olympia/pages/templates/pages/faq.html:244
 msgid "What is a Source Code License?"
 msgstr "Mi az a forráskód-licenc?"
 
-#: src/olympia/pages/templates/pages/faq.html:247
+#: src/olympia/pages/templates/pages/faq.html:245
 #, python-format
 msgid ""
-"The source code used to create an add-on is an exclusive copyright of the "
-"add-on author, unless otherwise declared in a source code license. Many add-"
-"ons on this site have <a href=\"%(url)s\" lang=\"en\">open source "
-"licenses</a> that make the source code publicly available for copy and reuse"
-" under conditions determined by the author. Most authors choose widely known"
-" open source licenses like the GPL or BSD licenses instead of making up "
-"their own."
+"The source code used to create an add-on is an exclusive copyright of the add-on author, unless otherwise declared in a source code license. Many add-ons on this site have <a href=\"%(url)s\" "
+"lang=\"en\">open source licenses</a> that make the source code publicly available for copy and reuse under conditions determined by the author. Most authors choose widely known open source licenses"
+" like the GPL or BSD licenses instead of making up their own."
 msgstr ""
-"A forráskód, amely alapján a kiegészítő készült, szerzői joga kizárólagosan "
-"annak készítőjéé, kivéve akkor a forráskód deklaráltan valamely licenc alá "
-"esik. Számtalan, a galériában található kiegészítő <a href=\"%(url)s\" "
-"lang=\"en\">nyílt forrású licenccel</a> rendelkezik, így forráskódja "
-"szabadon elérhető, másolható és újra felhasználható a szerző által "
-"meghatározott feltételek mellett. A legtöbb szerző nem a saját maga által "
-"kialakított, hanem a széles körben elterjedt nyílt forráskódú licenceket "
-"használja. Ilyen például a GPL, vagy a BSD."
+"A forráskód, amely alapján a kiegészítő készült, szerzői joga kizárólagosan annak készítőjéé, kivéve akkor a forráskód deklaráltan valamely licenc alá esik. Számtalan, a galériában található "
+"kiegészítő <a href=\"%(url)s\" lang=\"en\">nyílt forrású licenccel</a> rendelkezik, így forráskódja szabadon elérhető, másolható és újra felhasználható a szerző által meghatározott feltételek "
+"mellett. A legtöbb szerző nem a saját maga által kialakított, hanem a széles körben elterjedt nyílt forráskódú licenceket használja. Ilyen például a GPL, vagy a BSD."
 
-#: src/olympia/pages/templates/pages/faq.html:256
+#: src/olympia/pages/templates/pages/faq.html:254
 #, python-format
-msgid ""
-"Firefox and other Mozilla software are <a href=\"%(url)s\">open source</a>."
-msgstr ""
-"A Firefox és a többi Mozilla szoftver <a href=\"%(url)s\">nyílt forrású</a>."
+msgid "Firefox and other Mozilla software are <a href=\"%(url)s\">open source</a>."
+msgstr "A Firefox és a többi Mozilla szoftver <a href=\"%(url)s\">nyílt forrású</a>."
 
-#: src/olympia/pages/templates/pages/faq.html:264
+#: src/olympia/pages/templates/pages/faq.html:262
 msgid "Collections and Favorites"
 msgstr "Gyűjtemények és kedvencek"
 
-#: src/olympia/pages/templates/pages/faq.html:267
+#: src/olympia/pages/templates/pages/faq.html:265
 msgid "What is a collection?"
 msgstr "Mi az a gyűjtemény?"
 
-#: src/olympia/pages/templates/pages/faq.html:268
+#: src/olympia/pages/templates/pages/faq.html:266
 msgid "Collections are groups of related add-ons created by users to share."
-msgstr ""
-"A gyűjtemények a felhasználók által létrehozott és megosztott kiegészítők "
-"egy csoportja."
+msgstr "A gyűjtemények a felhasználók által létrehozott és megosztott kiegészítők egy csoportja."
 
-#: src/olympia/pages/templates/pages/faq.html:270
+#: src/olympia/pages/templates/pages/faq.html:268
 msgid "What is the My Favorites collection?"
 msgstr "Ma az a kedvenc gyűjtemény?"
 
-#: src/olympia/pages/templates/pages/faq.html:271
-msgid ""
-"Favorite add-ons are add-ons that you have bookmarked to easily get back to "
-"later. You can add an add-on to your favorites collection by clicking \"Add "
-"to favorites\" on its details page."
+#: src/olympia/pages/templates/pages/faq.html:269
+msgid "Favorite add-ons are add-ons that you have bookmarked to easily get back to later. You can add an add-on to your favorites collection by clicking \"Add to favorites\" on its details page."
 msgstr ""
-"A kedvenc kiegészítők olyan kiegészítők, amelyek könyvjelzővel vannak "
-"megjelölve, hogy később könnyebben meg lehessen őket találni. A kiegészítőt "
-"a részletes lapon található \"Hozzáadás a kedvencekhez\" hivatkozásra "
-"kattintva lehet a kedvencek közé tenni."
+"A kedvenc kiegészítők olyan kiegészítők, amelyek könyvjelzővel vannak megjelölve, hogy később könnyebben meg lehessen őket találni. A kiegészítőt a részletes lapon található \"Hozzáadás a "
+"kedvencekhez\" hivatkozásra kattintva lehet a kedvencek közé tenni."
 
-#: src/olympia/pages/templates/pages/faq.html:275
-#: src/olympia/templates/menu_links.html:13
-#: src/olympia/templates/impala/header_title.html:17
+#: src/olympia/pages/templates/pages/faq.html:273 src/olympia/templates/menu_links.html:13 src/olympia/templates/impala/header_title.html:17
 msgid "Mobile Add-ons"
 msgstr "Mobile kiegészítők"
 
-#: src/olympia/pages/templates/pages/faq.html:278
+#: src/olympia/pages/templates/pages/faq.html:276
 msgid "What are mobile add-ons?"
 msgstr "Mik azok a Mobile kiegészítők?"
 
-#: src/olympia/pages/templates/pages/faq.html:279
+#: src/olympia/pages/templates/pages/faq.html:277
 #, python-format
 msgid ""
-"Mobile add-ons work with <a href=\"%(mobile_url)s\">Firefox for Mobile</a> "
-"and add or modify functionality just like desktop add-ons. You can find add-"
-"ons that work with Firefox for Mobile in our <a "
-"href=\"%(gallery_url)s\">gallery</a>."
+"Mobile add-ons work with <a href=\"%(mobile_url)s\">Firefox for Mobile</a> and add or modify functionality just like desktop add-ons. You can find add-ons that work with Firefox for Mobile in our "
+"<a href=\"%(gallery_url)s\">gallery</a>."
 msgstr ""
-"A Mobile kiegészítők a <a href=\"%(mobile_url)s\">Firefox for Mobile</a> "
-"alkalmazással működnek és az asztali változathoz hasonlóan új funkciókat ad "
-"az alkalmazáshoz vagy módosítja valamely meglévőt. A Firefox for Mobile "
-"kiegészítők a <a href=\"%(gallery_url)s\">galériában</a> találhatók."
+"A Mobile kiegészítők a <a href=\"%(mobile_url)s\">Firefox for Mobile</a> alkalmazással működnek és az asztali változathoz hasonlóan új funkciókat ad az alkalmazáshoz vagy módosítja valamely "
+"meglévőt. A Firefox for Mobile kiegészítők a <a href=\"%(gallery_url)s\">galériában</a> találhatók."
 
-#: src/olympia/pages/templates/pages/faq.html:288
+#: src/olympia/pages/templates/pages/faq.html:286
 msgid "Developer Topics"
 msgstr "Fejlesztői témák"
 
-#: src/olympia/pages/templates/pages/faq.html:289
+#: src/olympia/pages/templates/pages/faq.html:287
 #, python-format
-msgid ""
-"Please see our <a href=\"%(faq_url)s\">Developer FAQ</a> and <a "
-"href=\"%(hub_url)s\">Developer Hub</a> for answers to add-on developer-"
-"related questions."
-msgstr ""
-"A kiegészítők fejlesztésével kapcsolatos kérdésekre adott válaszok a <a "
-"href=\"%(faq_url)s\">Fejlesztői GYIK-ben</a> és a <a "
-"href=\"%(hub_url)s\">Fejlesztőközpontban</a> találhatóak."
+msgid "Please see our <a href=\"%(faq_url)s\">Developer FAQ</a> and <a href=\"%(hub_url)s\">Developer Hub</a> for answers to add-on developer-related questions."
+msgstr "A kiegészítők fejlesztésével kapcsolatos kérdésekre adott válaszok a <a href=\"%(faq_url)s\">Fejlesztői GYIK-ben</a> és a <a href=\"%(hub_url)s\">Fejlesztőközpontban</a> találhatóak."
 
-#: src/olympia/pages/templates/pages/faq.html:294
+#: src/olympia/pages/templates/pages/faq.html:292
 msgid "Still have questions?"
 msgstr "További kérdése van?"
 
-#: src/olympia/pages/templates/pages/faq.html:295
+#: src/olympia/pages/templates/pages/faq.html:293
 #, python-format
-msgid ""
-"For general Firefox support, visit our <a href=\"%(sumo_url)s\">support "
-"website</a>. For general add-on and website questions, visit our <a "
-"href=\"%(forum_url)s\">forum</a>."
+msgid "For general Firefox support, visit our <a href=\"%(sumo_url)s\">support website</a>. For general add-on and website questions, visit our <a href=\"%(forum_url)s\">forum</a>."
 msgstr ""
-"Az általános Firefox támogatásért látogassa meg a <a "
-"href=\"%(sumo_url)s\">támogatói weboldalt</a>. A kiegészítőkkel és "
-"weboldalakkal kapcsolatos általános kérdésekkel látogasson el a <a "
+"Az általános Firefox támogatásért látogassa meg a <a href=\"%(sumo_url)s\">támogatói weboldalt</a>. A kiegészítőkkel és weboldalakkal kapcsolatos általános kérdésekkel látogasson el a <a "
 "href=\"%(forum_url)s\">fórumunkba</a>."
 
-#: src/olympia/pages/templates/pages/review_guide.html:36
-#: src/olympia/pages/templates/pages/review_guide.html:51
+#: src/olympia/pages/templates/pages/review_guide.html:36 src/olympia/pages/templates/pages/review_guide.html:51
 msgid "Some tips for writing a great review"
 msgstr "Néhány tipp nagyszerű értékelések írásához"
 
-#: src/olympia/pages/templates/pages/review_guide.html:39
-#: src/olympia/pages/templates/pages/review_guide.html:131
+#: src/olympia/pages/templates/pages/review_guide.html:39 src/olympia/pages/templates/pages/review_guide.html:131
 msgid "Frequently Asked Questions about Reviews"
 msgstr "Gyakran ismételt kérdések az értékelésekről"
 
 #: src/olympia/pages/templates/pages/review_guide.html:46
 msgid ""
-"Add-on reviews are a way for you to share your opinions about the add-ons "
-"you’ve installed and used. Our review moderation team reserves the right to "
-"refuse or remove any review that does not comply with these guidelines."
+"Add-on reviews are a way for you to share your opinions about the add-ons you’ve installed and used. Our review moderation team reserves the right to refuse or remove any review that does not "
+"comply with these guidelines."
 msgstr ""
 
 #: src/olympia/pages/templates/pages/review_guide.html:53
@@ -12980,11 +10407,8 @@ msgid "Do:"
 msgstr "Ezt tegye:"
 
 #: src/olympia/pages/templates/pages/review_guide.html:56
-msgid ""
-"Write like you are telling a friend about your experience with the add-on."
-msgstr ""
-"Írjon úgy, mintha egy barátjának mesélne a kiegészítővel szerzett "
-"tapasztalatairól."
+msgid "Write like you are telling a friend about your experience with the add-on."
+msgstr "Írjon úgy, mintha egy barátjának mesélne a kiegészítővel szerzett tapasztalatairól."
 
 #: src/olympia/pages/templates/pages/review_guide.html:61
 msgid "Keep reviews concise and easy to understand."
@@ -13015,11 +10439,8 @@ msgid "Will you continue to use this add-on?"
 msgstr "Használja majd ezután is ezt a kiegészítőt?"
 
 #: src/olympia/pages/templates/pages/review_guide.html:73
-msgid ""
-"Take a moment to read your review before submitting it to minimize typos."
-msgstr ""
-"Szánjon rá egy kis időt értékelésének átolvasására, hogy csökkenjen a "
-"gépelési hibák száma."
+msgid "Take a moment to read your review before submitting it to minimize typos."
+msgstr "Szánjon rá egy kis időt értékelésének átolvasására, hogy csökkenjen a gépelési hibák száma."
 
 #: src/olympia/pages/templates/pages/review_guide.html:79
 msgid "Don’t:"
@@ -13027,66 +10448,44 @@ msgstr "Ne tegye:"
 
 #: src/olympia/pages/templates/pages/review_guide.html:82
 msgid "Submit one-word reviews such as \"Great!\", \"wonderful,\" or \"bad.\""
-msgstr ""
-"Ne küldjön be egyszavas értékeléseket, mint „kiváló!”, „csodálatos”, vagy "
-"„rossz”."
+msgstr "Ne küldjön be egyszavas értékeléseket, mint „kiváló!”, „csodálatos”, vagy „rossz”."
 
 #: src/olympia/pages/templates/pages/review_guide.html:87
 msgid ""
-"Post technical issues, support requests, or feature suggestions. Use the "
-"available support options for each add-on, if available. You can find them "
-"in the side column next to the About this Add-on section."
+"Post technical issues, support requests, or feature suggestions. Use the available support options for each add-on, if available. You can find them in the side column next to the About this Add-on "
+"section."
 msgstr ""
-"Ne töltsön fel technikai kérdéseket, támogatási kérelmeket vagy funkció "
-"javaslatokat. Használja a kiegészítőhöz elérhető támogatási lehetőségeket, "
-"ha rendelkezésre állnak. Megtalálhatja őket az oldalsó hasábban az „Erről a "
-"kiegészítőről” szakasz mellett."
+"Ne töltsön fel technikai kérdéseket, támogatási kérelmeket vagy funkció javaslatokat. Használja a kiegészítőhöz elérhető támogatási lehetőségeket, ha rendelkezésre állnak. Megtalálhatja őket az "
+"oldalsó hasábban az „Erről a kiegészítőről” szakasz mellett."
 
 #: src/olympia/pages/templates/pages/review_guide.html:92
 msgid "Write reviews for add-ons which you have not personally used."
 msgstr "Ne írjon értékelést olyan kiegészítőről, melyet nem használt."
 
 #: src/olympia/pages/templates/pages/review_guide.html:97
-msgid ""
-"Use profanity, sexual language or language that can be construed as hateful."
-msgstr ""
-"Ne káromkodjon, trágárkodjon, kerülje a gyűlölködőként értelmezhető "
-"megfogalmazásokat."
+msgid "Use profanity, sexual language or language that can be construed as hateful."
+msgstr "Ne káromkodjon, trágárkodjon, kerülje a gyűlölködőként értelmezhető megfogalmazásokat."
 
 #: src/olympia/pages/templates/pages/review_guide.html:103
-msgid ""
-"Include HTML, links, source code or code snippets. Reviews are meant to be "
-"text only."
-msgstr ""
-"Ne fűzzön bele HTML kódot, hivatkozásokat, forráskódot vagy kódrészleteket. "
-"Az értékelés csak szöveg kell legyen."
+msgid "Include HTML, links, source code or code snippets. Reviews are meant to be text only."
+msgstr "Ne fűzzön bele HTML kódot, hivatkozásokat, forráskódot vagy kódrészleteket. Az értékelés csak szöveg kell legyen."
 
 #: src/olympia/pages/templates/pages/review_guide.html:108
-msgid ""
-"Make false statements, disparage add-on authors or personally insult them."
-msgstr ""
-"Ne tegyen valótlan kijelentést, ne becsmérelje a kiegészítő szerzőit és ne "
-"sértegesse őket."
+msgid "Make false statements, disparage add-on authors or personally insult them."
+msgstr "Ne tegyen valótlan kijelentést, ne becsmérelje a kiegészítő szerzőit és ne sértegesse őket."
 
 #: src/olympia/pages/templates/pages/review_guide.html:114
-msgid ""
-"Include your own or anyone else’s email, phone number, or other personal "
-"details."
-msgstr ""
-"Ne fűzze hozzá saját vagy más e-mailcímét, telefonszámát vagy más személyes "
-"adatát."
+msgid "Include your own or anyone else’s email, phone number, or other personal details."
+msgstr "Ne fűzze hozzá saját vagy más e-mailcímét, telefonszámát vagy más személyes adatát."
 
 #: src/olympia/pages/templates/pages/review_guide.html:119
-msgid ""
-"Post reviews for an add-on you or your organization wrote or represent."
+msgid "Post reviews for an add-on you or your organization wrote or represent."
 msgstr ""
 
 #: src/olympia/pages/templates/pages/review_guide.html:125
 msgid ""
-"Criticize an add-on for something it’s intended to do. For example, leaving "
-"a negative review of an add-on for displaying ads or requiring data "
-"gathering, when that is the intended purpose of the add-on, or the add-on "
-"requires gathering data to function."
+"Criticize an add-on for something it’s intended to do. For example, leaving a negative review of an add-on for displaying ads or requiring data gathering, when that is the intended purpose of the "
+"add-on, or the add-on requires gathering data to function."
 msgstr ""
 
 #: src/olympia/pages/templates/pages/review_guide.html:133
@@ -13095,10 +10494,8 @@ msgstr ""
 
 #: src/olympia/pages/templates/pages/review_guide.html:135
 msgid ""
-"Please report or flag any questionable reviews by clicking the \"Report this"
-" review\" and it will be submitted to the site for moderation. Our "
-"moderation team will use the Review Guidelines to evaluate whether or not to"
-" delete the review or restore it back to the site."
+"Please report or flag any questionable reviews by clicking the \"Report this review\" and it will be submitted to the site for moderation. Our moderation team will use the Review Guidelines to "
+"evaluate whether or not to delete the review or restore it back to the site."
 msgstr ""
 
 #: src/olympia/pages/templates/pages/review_guide.html:140
@@ -13107,25 +10504,17 @@ msgstr ""
 
 #: src/olympia/pages/templates/pages/review_guide.html:142
 #, python-format
-msgid ""
-"Yes, add-on authors can provide a single response to a review. You can set "
-"up a discussion topic in our <a href=\"%(forum_url)s\">forum</a> to engage "
-"in additional discussion or follow-up."
+msgid "Yes, add-on authors can provide a single response to a review. You can set up a discussion topic in our <a href=\"%(forum_url)s\">forum</a> to engage in additional discussion or follow-up."
 msgstr ""
 
 #: src/olympia/pages/templates/pages/review_guide.html:149
 msgid "I’m an add-on author, can I delete unfavorable reviews or ratings?"
-msgstr ""
-"Én vagyok a kiegészítő szerzője, tudom törölni a kedvezőtlen értékeléseket "
-"vagy minősítéseket?"
+msgstr "Én vagyok a kiegészítő szerzője, tudom törölni a kedvezőtlen értékeléseket vagy minősítéseket?"
 
 #: src/olympia/pages/templates/pages/review_guide.html:151
 msgid ""
-"In general, no. But if the review did not meet the review guidelines "
-"outlined above, you can click \"Report this review\" and have it moderated. "
-"If a review included a complaint that is no longer valid due to a new "
-"release of your add-on, we may consider deleting the review. Submit your "
-"detailed request to amo-editors@mozilla.org."
+"In general, no. But if the review did not meet the review guidelines outlined above, you can click \"Report this review\" and have it moderated. If a review included a complaint that is no longer "
+"valid due to a new release of your add-on, we may consider deleting the review. Submit your detailed request to amo-editors@mozilla.org."
 msgstr ""
 
 #: src/olympia/pages/templates/pages/sunbird.html:26
@@ -13134,24 +10523,16 @@ msgstr "A Sunbird visszavonult"
 
 #: src/olympia/pages/templates/pages/sunbird.html:29
 msgid ""
-"Development on the Sunbird project has halted and its final release was on "
-"March 30, 2010.  We've been proud to host Sunbird add-ons on this site but "
-"as the project is no longer maintained we have disabled our support for the "
-"add-ons."
+"Development on the Sunbird project has halted and its final release was on March 30, 2010. We've been proud to host Sunbird add-ons on this site but as the project is no longer maintained we have "
+"disabled our support for the add-ons."
 msgstr ""
-"A Sunbird projekt fejlesztése leállt, az utolsó kiadás 2010. március 30.-án "
-"volt.  Büszkék vagyunk arra, hogy mi szolgáltattuk a Sunbird kiegészítőket "
-"ezen az oldalon, de mivel a projekt már nem karbantartott, ezért letiltottuk"
-" a kiegészítők támogatását."
+"A Sunbird projekt fejlesztése leállt, az utolsó kiadás 2010. március 30.-án volt.  Büszkék vagyunk arra, hogy mi szolgáltattuk a Sunbird kiegészítőket ezen az oldalon, de mivel a projekt már nem "
+"karbantartott, ezért letiltottuk a kiegészítők támogatását."
 
 #: src/olympia/pages/templates/pages/sunbird.html:38
 #, python-format
-msgid ""
-"We recommend upgrading to <a href=\"%(tb_url)s\">Thunderbird</a> and <a "
-"href=\"%(lightning_url)s\">Lightning</a>."
-msgstr ""
-"Javasoljuk a <a href=\"%(tb_url)s\">Thunderbirdre</a> és a <a "
-"href=\"%(lightning_url)s\">Lightningra</a> frissítést."
+msgid "We recommend upgrading to <a href=\"%(tb_url)s\">Thunderbird</a> and <a href=\"%(lightning_url)s\">Lightning</a>."
+msgstr "Javasoljuk a <a href=\"%(tb_url)s\">Thunderbirdre</a> és a <a href=\"%(lightning_url)s\">Lightningra</a> frissítést."
 
 #: src/olympia/pages/templates/pages/sunbird.html:45
 msgid "Read more about Sunbird"
@@ -13171,8 +10552,7 @@ msgstr "Az összeg túl kicsi a vevő pénznemére alakításhoz."
 
 #: src/olympia/paypal/__init__.py:70
 msgid "The buyer and seller must have different PayPal accounts."
-msgstr ""
-"A vevőnek és az eladónak különböző PayPal számlával kell rendelkeznie."
+msgstr "A vevőnek és az eladónak különböző PayPal számlával kell rendelkeznie."
 
 #. L10n: {0} is the currency.
 #: src/olympia/paypal/__init__.py:73
@@ -13203,8 +10583,7 @@ msgstr "Értékelés megtartása; jelzők eltávolítása"
 msgid "Skip for now"
 msgstr "Kihagyás"
 
-#: src/olympia/reviews/forms.py:151
-#: src/olympia/reviews/templates/reviews/review.html:107
+#: src/olympia/reviews/forms.py:151 src/olympia/reviews/templates/reviews/review.html:107
 msgid "Delete review"
 msgstr "Értékelés törlése"
 
@@ -13223,41 +10602,24 @@ msgstr "Értékelés hozzáadása a(z) {0} kiegészítőhöz"
 #: src/olympia/reviews/templates/reviews/add.html:26
 #, python-format
 msgid ""
-"<h2>Keep these tips in mind:</h2> <ul> <li> Write like you're telling a "
-"friend about your experience with the add-on. Give specifics and helpful "
-"details, such as what features you liked and/or disliked, how easy to use it"
-" is, and any disadvantages it has. Avoid generic language such as calling it"
-" \"Great\" or \"Bad\" unless you can give reasons why you believe this is "
-"so. </li> <li> Please do not post bug reports in reviews. We do not make "
-"your email address available to add-on developers and they may need to "
-"contact you to help resolve your issue. See the <a "
-"href=\"%(support)s\">support section</a> to find out where to get assistance"
-" for this add-on. </li> <li>Please keep reviews clean, avoid the use of "
-"improper language and do not post any personal information. </li> </ul> "
-"<p>Please read the <a href=\"%(guide)s\" target=\"_blank\">Review "
-"Guidelines</a> for more detail about user add-on reviews.</p>"
+"<h2>Keep these tips in mind:</h2> <ul> <li> Write like you're telling a friend about your experience with the add-on. Give specifics and helpful details, such as what features you liked and/or "
+"disliked, how easy to use it is, and any disadvantages it has. Avoid generic language such as calling it \"Great\" or \"Bad\" unless you can give reasons why you believe this is so. </li> <li> "
+"Please do not post bug reports in reviews. We do not make your email address available to add-on developers and they may need to contact you to help resolve your issue. See the <a "
+"href=\"%(support)s\">support section</a> to find out where to get assistance for this add-on. </li> <li>Please keep reviews clean, avoid the use of improper language and do not post any personal "
+"information. </li> </ul> <p>Please read the <a href=\"%(guide)s\" target=\"_blank\">Review Guidelines</a> for more detail about user add-on reviews.</p>"
 msgstr ""
-"<h2>Tartsa észben a következőket:</h2><ul><li>Írjon úgy, mint ha egy "
-"barátjában mesélné el a kiegészítővel szerzett tapasztalatait. Írjon "
-"részletesen, például milyen funkciók tetszettek/nem tetszettek, milyen "
-"könnyű volt a használat, mik a hátrányok. Lehetőleg nem tegyen általános "
-"kijelentéseket, például „Jó” vagy „Rossz”, hacsak nem indokolja meg a "
-"véleményét.</li><li>Nem írjon hibaüzeneteket az értékelésbe. Az e-mail címét"
-" nem adjuk tovább a kiegészítők fejlesztőinek, és esetleg szükség lehet a "
-"kapcsolatfelvételre a probléma megoldásához. Olvassa el a <a "
-"href=\"%(support)s\">támogatási szakaszban</a>, hogy hol kaphat segítséget a"
-" kiegészítő használatához.</li><li>Az értékelés legyen tiszta, kerülje az "
-"ide nem illő nyelvezet használatát, és nem adjon meg személyes "
-"adatokat.</li></ul><p>Olvassa el az <a href=\"%(guide)s\" "
-"target=\"_blank\">Értékelési útmutatót</a> a kiegészítők felhasználói "
-"értékelésével kapcsolatos további tudnivalókért.</p>"
+"<h2>Tartsa észben a következőket:</h2><ul><li>Írjon úgy, mint ha egy barátjában mesélné el a kiegészítővel szerzett tapasztalatait. Írjon részletesen, például milyen funkciók tetszettek/nem "
+"tetszettek, milyen könnyű volt a használat, mik a hátrányok. Lehetőleg nem tegyen általános kijelentéseket, például „Jó” vagy „Rossz”, hacsak nem indokolja meg a véleményét.</li><li>Nem írjon "
+"hibaüzeneteket az értékelésbe. Az e-mail címét nem adjuk tovább a kiegészítők fejlesztőinek, és esetleg szükség lehet a kapcsolatfelvételre a probléma megoldásához. Olvassa el a <a "
+"href=\"%(support)s\">támogatási szakaszban</a>, hogy hol kaphat segítséget a kiegészítő használatához.</li><li>Az értékelés legyen tiszta, kerülje az ide nem illő nyelvezet használatát, és nem "
+"adjon meg személyes adatokat.</li></ul><p>Olvassa el az <a href=\"%(guide)s\" target=\"_blank\">Értékelési útmutatót</a> a kiegészítők felhasználói értékelésével kapcsolatos további "
+"tudnivalókért.</p>"
 
 #: src/olympia/reviews/templates/reviews/reply.html:4
 msgid "Reply to review by {0}"
 msgstr "Válasz {0} értékelésére"
 
-#: src/olympia/reviews/templates/reviews/reply.html:15
-#: src/olympia/reviews/templates/reviews/reply.html:31
+#: src/olympia/reviews/templates/reviews/reply.html:15 src/olympia/reviews/templates/reviews/reply.html:31
 msgid "Reply"
 msgstr "Válasz"
 
@@ -13265,8 +10627,7 @@ msgstr "Válasz"
 msgid "Write a Reply"
 msgstr "Válasz írása"
 
-#: src/olympia/reviews/templates/reviews/reply.html:36
-#: src/olympia/reviews/templates/reviews/report_review.html:12
+#: src/olympia/reviews/templates/reviews/reply.html:36 src/olympia/reviews/templates/reviews/report_review.html:12
 msgid "Submit"
 msgstr "Elküldés"
 
@@ -13286,34 +10647,21 @@ msgid "by %(user)s <b>(Developer)</b> on %(date)s"
 msgstr "%(user)s írta <b>(fejlesztő)</b> ekkor: %(date)s"
 
 #. {0} is a version number (like 1.01)
-#: src/olympia/reviews/templates/reviews/review.html:50
-#: src/olympia/reviews/templates/reviews/mobile/review_list.html:41
+#: src/olympia/reviews/templates/reviews/review.html:50 src/olympia/reviews/templates/reviews/mobile/review_list.html:41
 msgid "This review is for a previous version of the add-on ({0})."
 msgstr "Ez az értékelés a kiegészítő előző verziójához készült ({0})."
 
 #: src/olympia/reviews/templates/reviews/review.html:56
 #, python-format
-msgid ""
-"This user has a <a href=\"%(user_review_url)s\">previous review</a> of this "
-"add-on."
-msgid_plural ""
-"This user has <a href=\"%(user_review_url)s\">%(cnt)s previous reviews</a> "
-"of this add-on."
-msgstr[0] ""
-"A felhasználó már <a href=\"%(user_review_url)s\">korábban értékelte</a> ezt"
-" a kiegészítőt."
-msgstr[1] ""
-"A felhasználó már <a href=\"%(user_review_url)s\">%(cnt)s alkalommal "
-"értékelte</a> ezt a kiegészítőt."
+msgid "This user has a <a href=\"%(user_review_url)s\">previous review</a> of this add-on."
+msgid_plural "This user has <a href=\"%(user_review_url)s\">%(cnt)s previous reviews</a> of this add-on."
+msgstr[0] "A felhasználó már <a href=\"%(user_review_url)s\">korábban értékelte</a> ezt a kiegészítőt."
+msgstr[1] "A felhasználó már <a href=\"%(user_review_url)s\">%(cnt)s alkalommal értékelte</a> ezt a kiegészítőt."
 
 #: src/olympia/reviews/templates/reviews/review.html:62
 #, python-format
-msgid ""
-"This user has <a href=\"%(user_review_url)s\">other reviews</a> of this add-"
-"on."
-msgstr ""
-"A felhasználónak <a href=\"%(user_review_url)s\">további értékelése</a> van "
-"ehhez az adatbázishoz."
+msgid "This user has <a href=\"%(user_review_url)s\">other reviews</a> of this add-on."
+msgstr "A felhasználónak <a href=\"%(user_review_url)s\">további értékelése</a> van ehhez az adatbázishoz."
 
 #: src/olympia/reviews/templates/reviews/review.html:72
 msgid "Flagged for review"
@@ -13345,9 +10693,7 @@ msgid "{0} :: Reviews"
 msgstr "{0} :: Értékelések"
 
 #. {0} is an addon name.
-#: src/olympia/reviews/templates/reviews/review_list.html:24
-#: src/olympia/reviews/templates/reviews/mobile/add.html:4
-#: src/olympia/reviews/templates/reviews/mobile/review_list.html:4
+#: src/olympia/reviews/templates/reviews/review_list.html:24 src/olympia/reviews/templates/reviews/mobile/add.html:4 src/olympia/reviews/templates/reviews/mobile/review_list.html:4
 msgid "Reviews for {0}"
 msgstr "{0} értékelései"
 
@@ -13383,8 +10729,7 @@ msgstr "<strong>Átlagos</strong> (%(total)s)"
 msgid "Write a New Review"
 msgstr "Új értékelés írása"
 
-#: src/olympia/reviews/templates/reviews/review_list.html:81
-#: src/olympia/reviews/templates/reviews/mobile/reviews_link.html:15
+#: src/olympia/reviews/templates/reviews/review_list.html:81 src/olympia/reviews/templates/reviews/mobile/reviews_link.html:15
 msgid "Be the first to write a review."
 msgstr "Legyen az első értékelő."
 
@@ -13403,8 +10748,7 @@ msgstr "{0} csillagra értékelve az 5-ből"
 msgid "Rated %(rating)s out of 5 stars"
 msgstr "%(rating)s csillagra értékelve az 5-ből"
 
-#: src/olympia/reviews/templates/reviews/mobile/add_form.html:3
-#: src/olympia/reviews/templates/reviews/mobile/add_form.html:8
+#: src/olympia/reviews/templates/reviews/mobile/add_form.html:3 src/olympia/reviews/templates/reviews/mobile/add_form.html:8
 msgid "Add a Review"
 msgstr "Értékelés hozzáadása"
 
@@ -13475,10 +10819,8 @@ msgid "Relevance"
 msgstr "Relevancia"
 
 #: src/olympia/search/helpers.py:24
-msgid ""
-"Results <strong>{0}</strong>-<strong>{1}</strong> of <strong>{2}</strong>"
-msgstr ""
-"Találatok <strong>{0}</strong>-<strong>{1}</strong> / <strong>{2}</strong>"
+msgid "Results <strong>{0}</strong>-<strong>{1}</strong> of <strong>{2}</strong>"
+msgstr "Találatok <strong>{0}</strong>-<strong>{1}</strong> / <strong>{2}</strong>"
 
 # {0} is a number
 # {1} is a number
@@ -13486,12 +10828,8 @@ msgstr ""
 # {3} is the word the person is searching for
 # {4} is a word (the add-on is tagged with it)
 #: src/olympia/search/helpers.py:44
-msgid ""
-"Showing {0} - {1} of {2} results for <strong>{3}</strong> tagged with "
-"<strong>{4}</strong>"
-msgstr ""
-"{2} <strong>{4}</strong> címkéjű találat erre: <strong>{3}</strong>, {0} - "
-"{1} megjelenítve"
+msgid "Showing {0} - {1} of {2} results for <strong>{3}</strong> tagged with <strong>{4}</strong>"
+msgstr "{2} <strong>{4}</strong> címkéjű találat erre: <strong>{3}</strong>, {0} - {1} megjelenítve"
 
 # {0} is a number
 # {1} is a number
@@ -13517,24 +10855,22 @@ msgid "Showing {0} - {1} of {2} results"
 msgstr "{2} találat, megjelenítve {0} - {1}"
 
 #. {0} is an application, like Firefox.
-#: src/olympia/search/views.py:264 src/olympia/templates/base.html:17
-#: src/olympia/templates/impala/base.html:17
-#: src/olympia/templates/mobile/base_addons.html:17
+#: src/olympia/search/views.py:264 src/olympia/templates/base.html:17 src/olympia/templates/impala/base.html:17 src/olympia/templates/mobile/base_addons.html:17
 msgid "{0} Add-ons"
 msgstr "{0} kiegészítők"
 
 #. L10n: {0} is an application, such as Firefox. This means "any version of
 #. Firefox."
-#: src/olympia/search/views.py:554
+#: src/olympia/search/views.py:547
 msgid "Any {0}"
 msgstr "Bármely {0}"
 
 #. L10n: "All Systems" means show everything regardless of platform.
-#: src/olympia/search/views.py:589
+#: src/olympia/search/views.py:582
 msgid "All Systems"
 msgstr "Összes rendszer"
 
-#: src/olympia/search/views.py:600
+#: src/olympia/search/views.py:593
 msgid "All Tags"
 msgstr "Össze címke"
 
@@ -13553,9 +10889,7 @@ msgstr "A keresés nem érhető el"
 
 #: src/olympia/search/templates/search/down.html:6
 msgid "Search is temporarily unavailable. Please try again in a few minutes."
-msgstr ""
-"A keresés átmenetileg nem érhető el. Kérjük, próbálja meg pár perccel "
-"később."
+msgstr "A keresés átmenetileg nem érhető el. Kérjük, próbálja meg pár perccel később."
 
 #. {0} is the string the user was searching for
 #: src/olympia/search/templates/search/personas.html:9
@@ -13710,36 +11044,31 @@ msgstr "Kiegészítő megosztása"
 msgid "Share this Collection"
 msgstr "A gyűjtemény megosztása"
 
-#: src/olympia/signing/views.py:30 src/olympia/templates/base.html:75
-#: src/olympia/templates/impala/base.html:115
-msgid ""
-"Some features are temporarily disabled while we perform website maintenance."
-" We'll be back to full capacity shortly."
-msgstr ""
-"Néhány funkció a karbantartás ideje alatt átmenetileg le van tiltva. "
-"Hamarosan újra teljes kapacitással fog működni az oldal."
+#: src/olympia/signing/views.py:33 src/olympia/templates/base.html:71 src/olympia/templates/impala/base.html:112
+msgid "Some features are temporarily disabled while we perform website maintenance. We'll be back to full capacity shortly."
+msgstr "Néhány funkció a karbantartás ideje alatt átmenetileg le van tiltva. Hamarosan újra teljes kapacitással fog működni az oldal."
 
-#: src/olympia/signing/views.py:53
+#: src/olympia/signing/views.py:56
 msgid "Could not find add-on with id \"{}\"."
 msgstr "A(z) „{}” azonosítójú kiegészítő nem található."
 
-#: src/olympia/signing/views.py:67
+#: src/olympia/signing/views.py:70
 msgid "You do not own this addon."
 msgstr "Nem Ön a kiegészítő tulajdonosa."
 
-#: src/olympia/signing/views.py:82
+#: src/olympia/signing/views.py:87
 msgid "Missing \"upload\" key in multipart file data."
 msgstr "Hiányzó „feltöltés” kulcs a többrészes fájl adataiban."
 
-#: src/olympia/signing/views.py:96
+#: src/olympia/signing/views.py:101
 msgid "Version does not match the manifest file."
 msgstr "A verzió nem egyezik meg a jegyzékfájllal."
 
-#: src/olympia/signing/views.py:100
+#: src/olympia/signing/views.py:105
 msgid "Version already exists."
 msgstr "A verzió már létezik."
 
-#: src/olympia/signing/views.py:136
+#: src/olympia/signing/views.py:141
 msgid "No uploaded file for that addon and version."
 msgstr "Nincs feltöltött fájl a kiegészítőhöz és a verzióhoz."
 
@@ -13831,8 +11160,7 @@ msgstr "Kezdet"
 msgid "To"
 msgstr "Vég"
 
-#: src/olympia/stats/templates/stats/popup.html:27
-#: src/olympia/users/templates/users/pwreset_confirm.html:38
+#: src/olympia/stats/templates/stats/popup.html:27 src/olympia/users/templates/users/pwreset_confirm.html:38
 msgid "Update"
 msgstr "Frissítés"
 
@@ -13853,98 +11181,89 @@ msgstr "{0} :: Statisztikai vezérlőpult"
 msgid "Statistics Dashboard :: Add-ons for {0}"
 msgstr "Statisztikai vezérlőpult :: Kiegészítők ehhez: {0}"
 
-#: src/olympia/stats/templates/stats/stats.html:30
-msgid "Controls:"
-msgstr "Vezérlőelemek:"
-
-#: src/olympia/stats/templates/stats/stats.html:33
-msgid "reset zoom"
-msgstr "nagyítás visszaállítása"
-
-#: src/olympia/stats/templates/stats/stats.html:40
-msgid "Group by:"
-msgstr "Csoportosítás:"
-
-#: src/olympia/stats/templates/stats/stats.html:42
-msgid "day"
-msgstr "nap"
-
-#: src/olympia/stats/templates/stats/stats.html:45
-msgid "week"
-msgstr "hét"
-
-#: src/olympia/stats/templates/stats/stats.html:48
-msgid "month"
-msgstr "hónap"
-
-#: src/olympia/stats/templates/stats/stats.html:54
-msgid "For last:"
-msgstr "Legutóbbi:"
-
-#: src/olympia/stats/templates/stats/stats.html:57
-msgid "7 days"
-msgstr "7 nap"
-
-#: src/olympia/stats/templates/stats/stats.html:60
-msgid "30 days"
-msgstr "30 nap"
-
-#: src/olympia/stats/templates/stats/stats.html:63
-msgid "90 days"
-msgstr "90 nap"
-
-#: src/olympia/stats/templates/stats/stats.html:66
-msgid "365 days"
-msgstr "365 nap"
-
-#: src/olympia/stats/templates/stats/stats.html:69
-msgid "Custom..."
-msgstr "Egyéni…"
-
 #. {0} is an add-on name
-#: src/olympia/stats/templates/stats/stats.html:88
-#: src/olympia/stats/templates/stats/stats.html:91
+#: src/olympia/stats/templates/stats/stats.html:44 src/olympia/stats/templates/stats/stats.html:47
 msgid "Statistics for {0}"
 msgstr "{0} statisztikája"
 
-#: src/olympia/stats/templates/stats/stats.html:94
+#: src/olympia/stats/templates/stats/stats.html:50
 msgid "Statistics Dashboard"
 msgstr "Statisztikai vezérlőpult"
 
-#: src/olympia/stats/templates/stats/stats.html:104
-msgid ""
-"Statistics processing is currently disabled, so recent data is unavailable. "
-"The statistics are still being collected and this page will be updated soon "
-"with the missing data."
-msgstr ""
-"A statisztikai feldolgozás le van tiltva, így a legfrissebb adatok nem "
-"érhetőek el. A statisztikák továbbra is gyűlnek, és ez az oldal hamarosan "
-"frissülni fog a hiányzó adatokkal."
+#: src/olympia/stats/templates/stats/stats.html:57
+msgid "Controls:"
+msgstr "Vezérlőelemek:"
 
-#: src/olympia/stats/templates/stats/stats.html:110
+#: src/olympia/stats/templates/stats/stats.html:60
+msgid "reset zoom"
+msgstr "nagyítás visszaállítása"
+
+#: src/olympia/stats/templates/stats/stats.html:67
+msgid "Group by:"
+msgstr "Csoportosítás:"
+
+#: src/olympia/stats/templates/stats/stats.html:69
+msgid "day"
+msgstr "nap"
+
+#: src/olympia/stats/templates/stats/stats.html:72
+msgid "week"
+msgstr "hét"
+
+#: src/olympia/stats/templates/stats/stats.html:75
+msgid "month"
+msgstr "hónap"
+
+#: src/olympia/stats/templates/stats/stats.html:81
+msgid "For last:"
+msgstr "Legutóbbi:"
+
+#: src/olympia/stats/templates/stats/stats.html:84
+msgid "7 days"
+msgstr "7 nap"
+
+#: src/olympia/stats/templates/stats/stats.html:87
+msgid "30 days"
+msgstr "30 nap"
+
+#: src/olympia/stats/templates/stats/stats.html:90
+msgid "90 days"
+msgstr "90 nap"
+
+#: src/olympia/stats/templates/stats/stats.html:93
+msgid "365 days"
+msgstr "365 nap"
+
+#: src/olympia/stats/templates/stats/stats.html:96
+msgid "Custom..."
+msgstr "Egyéni…"
+
+#: src/olympia/stats/templates/stats/stats.html:106
+msgid "Statistics processing is currently disabled, so recent data is unavailable. The statistics are still being collected and this page will be updated soon with the missing data."
+msgstr "A statisztikai feldolgozás le van tiltva, így a legfrissebb adatok nem érhetőek el. A statisztikák továbbra is gyűlnek, és ez az oldal hamarosan frissülni fog a hiányzó adatokkal."
+
+#: src/olympia/stats/templates/stats/stats.html:112
 msgid "Loading the latest data&hellip;"
 msgstr "Legfrissebb adatok betöltése&hellip;"
 
-#: src/olympia/stats/templates/stats/stats.html:142
-#: src/olympia/stats/templates/stats/reports/overview.html:25
-#: src/olympia/stats/templates/stats/reports/overview.html:37
+#: src/olympia/stats/templates/stats/stats.html:144 src/olympia/stats/templates/stats/reports/overview.html:25 src/olympia/stats/templates/stats/reports/overview.html:37
 #: src/olympia/stats/templates/stats/reports/overview.html:49
 msgid "No data available."
 msgstr "Nincs elérhető adat."
 
-#: src/olympia/stats/templates/stats/stats.html:177
+#: src/olympia/stats/templates/stats/stats.html:179
 msgid "This dashboard is currently <b>public</b>."
 msgstr "A vezérlőpult jelenleg <b>nyilvános</b>."
 
-#: src/olympia/stats/templates/stats/stats.html:179
+#: src/olympia/stats/templates/stats/stats.html:181
 msgid "Contribution stats are currently <b>private</b>."
 msgstr "A hozzájárulási statisztika jelenleg <b>privát</b>."
 
-#: src/olympia/stats/templates/stats/stats.html:182
+#: src/olympia/stats/templates/stats/stats.html:184
 msgid "This dashboard is currently <b>private</b>."
 msgstr "Az vezérlőpult jelenleg <b>privát</b>."
 
-#: src/olympia/stats/templates/stats/stats.html:185
+#: src/olympia/stats/templates/stats/stats.html:187
 msgid "Change settings."
 msgstr "Beállítások módosítása."
 
@@ -13986,13 +11305,11 @@ msgstr "Hogyan számolódnak a letöltések?"
 
 #: src/olympia/stats/templates/stats/reports/downloads.html:10
 msgid ""
-"<h2>How are downloads counted?</h2> <p> Download counts are updated every "
-"evening and only include original add-on downloads, not updates. Downloads "
-"can be broken down by the specific source referring the download. </p>"
+"<h2>How are downloads counted?</h2> <p> Download counts are updated every evening and only include original add-on downloads, not updates. Downloads can be broken down by the specific source "
+"referring the download. </p>"
 msgstr ""
-"<h2>Hogy számolódnak a letöltések?</h2> <p>A letöltésszámok minden este "
-"frissítésre kerülnek, és csak az eredeti kiegészítő-letöltések számítanak, a"
-" frissítések nem. A letöltések lebonthatóak konkrét források szerint.</p>"
+"<h2>Hogy számolódnak a letöltések?</h2> <p>A letöltésszámok minden este frissítésre kerülnek, és csak az eredeti kiegészítő-letöltések számítanak, a frissítések nem. A letöltések lebonthatóak "
+"konkrét források szerint.</p>"
 
 #: src/olympia/stats/templates/stats/reports/locales.html:3
 msgid "User languages by Date"
@@ -14006,8 +11323,7 @@ msgstr "Platform-használat dátum szerint"
 msgid "<b>{0}</b> Downloads"
 msgstr "<b>{0}</b> letöltés"
 
-#: src/olympia/stats/templates/stats/reports/overview.html:9
-#: src/olympia/stats/templates/stats/reports/overview.html:13
+#: src/olympia/stats/templates/stats/reports/overview.html:9 src/olympia/stats/templates/stats/reports/overview.html:13
 msgid "Loading..."
 msgstr "Betöltés…"
 
@@ -14058,19 +11374,11 @@ msgstr "A külső források követéséről…"
 #: src/olympia/stats/templates/stats/reports/sources.html:10
 #, python-format
 msgid ""
-"<h2>Tracking external sources</h2> <p> If you link to your add-on's details "
-"page or directly to its file from an external site, such as your blog or "
-"website, you can append a parameter to be tracked as an additional download "
-"source on this page. For example, the following links would appear as "
-"sourced by your blog: <dl> <dt>Add-on Details Page</dt> "
-"<dd>https://addons.mozilla.org/addon/%(slug)s?src=<b>external-blog</b></dd> "
-"<dt>Direct File Link</dt> "
-"<dd>https://addons.mozilla.org/downloads/latest/%(id)s/addon-%(id)s-latest.xpi?src=<b"
-">external-blog</b></dd> </dl> <p> Only src parameters that begin with "
-"\"external-\" will be tracked, up to 61 additional characters. Any text "
-"after \"external-\" can be used to describe the source, such as \"external-"
-"blog\", \"external-sidebar\", \"external-campaign225\", etc. The following "
-"URL-safe characters are allowed: <code>a-z A-Z - . _ ~ %% +</code>"
+"<h2>Tracking external sources</h2> <p> If you link to your add-on's details page or directly to its file from an external site, such as your blog or website, you can append a parameter to be "
+"tracked as an additional download source on this page. For example, the following links would appear as sourced by your blog: <dl> <dt>Add-on Details Page</dt> "
+"<dd>https://addons.mozilla.org/addon/%(slug)s?src=<b>external-blog</b></dd> <dt>Direct File Link</dt> <dd>https://addons.mozilla.org/downloads/latest/%(id)s/addon-%(id)s-latest.xpi?src=<b>external-"
+"blog</b></dd> </dl> <p> Only src parameters that begin with \"external-\" will be tracked, up to 61 additional characters. Any text after \"external-\" can be used to describe the source, such as "
+"\"external-blog\", \"external-sidebar\", \"external-campaign225\", etc. The following URL-safe characters are allowed: <code>a-z A-Z - . _ ~ %% +</code>"
 msgstr ""
 
 #: src/olympia/stats/templates/stats/reports/statuses.html:3
@@ -14091,28 +11399,19 @@ msgstr "Kik a napi felhasználók?"
 
 #: src/olympia/stats/templates/stats/reports/usage.html:11
 msgid ""
-"<h2>What are daily users?</h2> <p> Themes installed from this site check for"
-" updates once per day. The total number of these update pings is known as "
-"Active Daily Users, or the total number of people using your theme by day. "
-"</p>"
+"<h2>What are daily users?</h2> <p> Themes installed from this site check for updates once per day. The total number of these update pings is known as Active Daily Users, or the total number of "
+"people using your theme by day. </p>"
 msgstr ""
-"<h2>Kik a napi felhasználók?</h2><p>Az oldalról telepített témák naponta "
-"egyszer ellenőrzik a frissítéseket. Ezen frissítési ellenőrzések összesített"
-" száma az úgynevezett aktív napi felhasználók, vagy az emberek teljes száma,"
-" akik használják a témát aznap.</p>"
+"<h2>Kik a napi felhasználók?</h2><p>Az oldalról telepített témák naponta egyszer ellenőrzik a frissítéseket. Ezen frissítési ellenőrzések összesített száma az úgynevezett aktív napi felhasználók, "
+"vagy az emberek teljes száma, akik használják a témát aznap.</p>"
 
 #: src/olympia/stats/templates/stats/reports/usage.html:20
 msgid ""
-"<h2>What are daily users?</h2> <p> Add-ons downloaded from this site check "
-"for updates once per day. The total number of these update pings is known as"
-" Active Daily Users. Daily users can be broken down by add-on version, "
-"operating system, add-on status, application, and locale. </p>"
+"<h2>What are daily users?</h2> <p> Add-ons downloaded from this site check for updates once per day. The total number of these update pings is known as Active Daily Users. Daily users can be broken"
+" down by add-on version, operating system, add-on status, application, and locale. </p>"
 msgstr ""
-"<h2>Kik a napi felhasználók?</h2><p>Az oldalról letölthető kiegészítők "
-"naponta egyszer ellenőrzik a frissítéseket. Ezen frissítési ellenőrzések "
-"összesített száma az úgynevezett aktív napi felhasználók. A napi "
-"felhasználók lebonthatóak a kiegészítő verziója, az operációs rendszer, a "
-"kiegészítő állapota, az alkalmazás és a területi beállítások szerint.</p>"
+"<h2>Kik a napi felhasználók?</h2><p>Az oldalról letölthető kiegészítők naponta egyszer ellenőrzik a frissítéseket. Ezen frissítési ellenőrzések összesített száma az úgynevezett aktív napi "
+"felhasználók. A napi felhasználók lebonthatóak a kiegészítő verziója, az operációs rendszer, a kiegészítő állapota, az alkalmazás és a területi beállítások szerint.</p>"
 
 #: src/olympia/stats/templates/stats/reports/users_created.html:3
 msgid "User Signups by Date"
@@ -14122,46 +11421,27 @@ msgstr "Felhasználói regisztrációk dátum szerint"
 msgid "Application versions by Date"
 msgstr "Alkalmazásverziók dátum szerint"
 
-# {0} is a number
-#: src/olympia/tags/templates/tags/top_cloud.html:4
-msgid "Top {0} Tags"
-msgstr "Első {0} címke"
-
-#. {0} is the current application name
-#: src/olympia/tags/templates/tags/top_cloud.html:14
-msgid "{0} Top Tags"
-msgstr "{0} leggyakoribb címke"
-
-#: src/olympia/templates/amo_footer.html:6
-#: src/olympia/templates/includes/lang_switcher.html:2
+#: src/olympia/templates/amo_footer.html:6 src/olympia/templates/includes/lang_switcher.html:2
 msgid "Other languages"
 msgstr "Más nyelvek"
 
-#: src/olympia/templates/base.html:9 src/olympia/templates/impala/base.html:9
-#: src/olympia/templates/mobile/base_addons.html:9
+#: src/olympia/templates/base.html:9 src/olympia/templates/impala/base.html:9 src/olympia/templates/mobile/base_addons.html:9
 msgid "Mozilla Add-ons"
 msgstr "Mozilla kiegészítők"
 
-#: src/olympia/templates/base.html:91
-#: src/olympia/templates/impala/base.html:81
+#: src/olympia/templates/base.html:89 src/olympia/templates/impala/base.html:78
 msgid "Find add-ons for other applications"
 msgstr "Kiegészítők keresése más alkalmazásokhoz"
 
-#: src/olympia/templates/base.html:92
-#: src/olympia/templates/impala/base.html:81
+#: src/olympia/templates/base.html:90 src/olympia/templates/impala/base.html:78
 msgid "Other Applications"
 msgstr "Más alkalmazások"
 
-#: src/olympia/templates/base.html:141
-#: src/olympia/templates/impala/base.html:194
-msgid ""
-"To create your own collections, you must have a Mozilla Add-ons account."
-msgstr ""
-"Saját gyűjteményt szeretne készítéséhez Mozilla Add-ons felhasználói fiókkal"
-" kell rendelkeznie."
+#: src/olympia/templates/base.html:141 src/olympia/templates/impala/base.html:194
+msgid "To create your own collections, you must have a Mozilla Add-ons account."
+msgstr "Saját gyűjteményt szeretne készítéséhez Mozilla Add-ons felhasználói fiókkal kell rendelkeznie."
 
-#: src/olympia/templates/base.html:168
-#: src/olympia/templates/impala/base.html:215
+#: src/olympia/templates/base.html:168 src/olympia/templates/impala/base.html:215
 msgid "Footer logo"
 msgstr "Lábléc logó"
 
@@ -14185,14 +11465,12 @@ msgstr "Oldal állapota"
 msgid "get to know <b>add-ons</b>"
 msgstr "ismerje meg a <b>kiegészítőket</b>"
 
-#: src/olympia/templates/footer.html:4
-#: src/olympia/templates/menu_links.html:20
+#: src/olympia/templates/footer.html:4 src/olympia/templates/menu_links.html:20
 msgid "About"
 msgstr "Névjegy"
 
 # Link text to the AMO blog.
-#: src/olympia/templates/footer.html:5
-#: src/olympia/templates/menu_links.html:32
+#: src/olympia/templates/footer.html:5 src/olympia/templates/menu_links.html:32
 msgid "Blog"
 msgstr "Blog"
 
@@ -14269,9 +11547,7 @@ msgstr "Jogi megjegyzések"
 msgid "Contact Us"
 msgstr "Kapcsolat"
 
-#: src/olympia/templates/user_login.html:22
-#: src/olympia/users/templates/users/edit.html:31
-#: src/olympia/users/templates/users/includes/navigation.html:12
+#: src/olympia/templates/user_login.html:22 src/olympia/users/templates/users/edit.html:31 src/olympia/users/templates/users/includes/navigation.html:12
 msgid "My Account"
 msgstr "Saját fiók"
 
@@ -14279,58 +11555,40 @@ msgstr "Saját fiók"
 msgid "Welcome, {0}"
 msgstr "Üdvözöljük, {0}"
 
-#: src/olympia/templates/user_login.html:41
-#: src/olympia/templates/impala/user_login.html:20
+#: src/olympia/templates/user_login.html:41 src/olympia/templates/impala/user_login.html:20
 #, python-format
 msgid "<a href=\"%(reg)s\">Register</a> or <a href=\"%(login)s\">Log in</a>"
-msgstr ""
-"<a href=\"%(reg)s\">Regisztráció</a> vagy <a "
-"href=\"%(login)s\">Bejelentkezés</a>"
+msgstr "<a href=\"%(reg)s\">Regisztráció</a> vagy <a href=\"%(login)s\">Bejelentkezés</a>"
 
-#: src/olympia/templates/impala/base.html:126
+#: src/olympia/templates/impala/base.html:123
 #, python-format
-msgid ""
-"To try the thousands of add-ons available here, download <a "
-"href=\"%(url)s\">Mozilla Firefox</a>, a fast, free way to surf the Web!"
-msgstr ""
-"A több ezer elérhető kiegészítő kipróbálásához töltse le a <a "
-"href=\"%(url)s\">Mozilla Firefox</a> böngészőt, amelynek segítségével "
-"gyorsan és ingyenesen internetezhet!"
+msgid "To try the thousands of add-ons available here, download <a href=\"%(url)s\">Mozilla Firefox</a>, a fast, free way to surf the Web!"
+msgstr "A több ezer elérhető kiegészítő kipróbálásához töltse le a <a href=\"%(url)s\">Mozilla Firefox</a> böngészőt, amelynek segítségével gyorsan és ingyenesen internetezhet!"
 
-#: src/olympia/templates/impala/base.html:138
+#: src/olympia/templates/impala/base.html:135
 #, python-format
-msgid ""
-"Add-ons is switching to Firefox Accounts for login. <a href=\"%(url)s\" "
-"class=\"fxa-login\">Sign in now to transfer your account.</a>"
-msgstr ""
-"A Kiegészítők Firefox fiókokra váltanak a bejelentkezéshez. <a "
-"href=\"%(url)s\" class=\"fxa-login\">Jelentkezzen be most a fiókja "
-"átviteléhez.</a>"
+msgid "Add-ons is switching to Firefox Accounts for login. <a href=\"%(url)s\" class=\"fxa-login\">Sign in now to transfer your account.</a>"
+msgstr "A Kiegészítők Firefox fiókokra váltanak a bejelentkezéshez. <a href=\"%(url)s\" class=\"fxa-login\">Jelentkezzen be most a fiókja átviteléhez.</a>"
 
 #. {0} is an application, such as Firefox.
-#: src/olympia/templates/impala/base.html:148
+#: src/olympia/templates/impala/base.html:145
 msgid "Welcome to {0} Add-ons."
 msgstr "Üdvözöljük a {0} kiegészítők oldalon."
 
-#: src/olympia/templates/impala/base.html:151
-msgid ""
-"Choose from thousands of extra features and styles to make Firefox your own."
-msgstr ""
-"Válasszon több ezer extra funkció és stílus közül, hogy Firefoxát teljesen "
-"magáénak érezhesse."
+#: src/olympia/templates/impala/base.html:148
+msgid "Choose from thousands of extra features and styles to make Firefox your own."
+msgstr "Válasszon több ezer extra funkció és stílus közül, hogy Firefoxát teljesen magáénak érezhesse."
 
-#: src/olympia/templates/impala/base.html:156
+#: src/olympia/templates/impala/base.html:153
 #, python-format
 msgid "Add extra features and styles to make %(app)s your own."
-msgstr ""
-"Bővítse extra funkciókkal és stílusokkal, hogy a %(app)s csak az Öné "
-"lehessen."
+msgstr "Bővítse extra funkciókkal és stílusokkal, hogy a %(app)s csak az Öné lehessen."
 
-#: src/olympia/templates/impala/base.html:164
+#: src/olympia/templates/impala/base.html:161
 msgid "On the go?"
 msgstr "Úton van?"
 
-#: src/olympia/templates/impala/base.html:166
+#: src/olympia/templates/impala/base.html:163
 msgid "Check out our <a class=\"mobile-link\" href=\"#\">Mobile Add-ons site</a>."
 msgstr "Nézze meg a <a class=\"mobile-link\" href=\"#\">Mobile Add-ons weboldalt</a>."
 
@@ -14338,8 +11596,7 @@ msgstr "Nézze meg a <a class=\"mobile-link\" href=\"#\">Mobile Add-ons weboldal
 msgid "Android Add-ons"
 msgstr "Android kiegészítők"
 
-#: src/olympia/templates/includes/forms.html:2
-#: src/olympia/templates/includes/forms.html:6
+#: src/olympia/templates/includes/forms.html:2 src/olympia/templates/includes/forms.html:6
 msgid "required"
 msgstr "szükséges"
 
@@ -14384,15 +11641,11 @@ msgstr "Mozilla weboldal"
 msgid "menu"
 msgstr "menü"
 
-#: src/olympia/templates/mobile/header_auth.html:7
-#: src/olympia/users/templates/users/register.html:41
-#: src/olympia/users/templates/users/register.html:89
+#: src/olympia/templates/mobile/header_auth.html:7 src/olympia/users/templates/users/register.html:41 src/olympia/users/templates/users/register.html:89
 msgid "Register"
 msgstr "Regisztráció"
 
-#: src/olympia/templates/mobile/header_auth.html:8
-#: src/olympia/users/templates/users/login_form.html:41
-#: src/olympia/users/templates/users/pwreset_complete.html:15
+#: src/olympia/templates/mobile/header_auth.html:8 src/olympia/users/templates/users/login_form.html:41 src/olympia/users/templates/users/pwreset_complete.html:15
 #: src/olympia/users/templates/users/mobile/login.html:56
 msgid "Log in"
 msgstr "Bejelentkezés"
@@ -14403,8 +11656,7 @@ msgstr "Bejelentkezés"
 msgid "Localize for: <a id=\"change-locale\" href=\"#\">%(dl)s</a>"
 msgstr "Lokalizáció <a id=\"change-locale\" href=\"#\">%(dl)s</a> nyelvre"
 
-#: src/olympia/translations/templates/translations/trans-menu.html:16
-#: src/olympia/translations/templates/translations/trans-menu.html:29
+#: src/olympia/translations/templates/translations/trans-menu.html:16 src/olympia/translations/templates/translations/trans-menu.html:29
 #, python-format
 msgid "%(title)s <em>&middot; %(lang)s</em>"
 msgstr "%(title)s <em>&middot; %(lang)s</em>"
@@ -14419,12 +11671,8 @@ msgstr "Új területi beállítások"
 
 #. {0} is a language name, like 'French'
 #: src/olympia/translations/templates/translations/trans-menu.html:42
-msgid ""
-"You have unsaved changes in the <b>{0}</b> locale. Would you like to save "
-"your changes before switching locales?"
-msgstr ""
-"Nem mentette el a változásokat <b>{0}</b> területi beállításhoz. Szeretné "
-"elmenteni a változásokat a területi beállítások váltása előtt?"
+msgid "You have unsaved changes in the <b>{0}</b> locale. Would you like to save your changes before switching locales?"
+msgstr "Nem mentette el a változásokat <b>{0}</b> területi beállításhoz. Szeretné elmenteni a változásokat a területi beállítások váltása előtt?"
 
 #: src/olympia/translations/templates/translations/trans-menu.html:49
 msgid "Discard Changes"
@@ -14432,12 +11680,8 @@ msgstr "Módosítások eldobása"
 
 #. {0} is a language name, like 'French'
 #: src/olympia/translations/templates/translations/trans-menu.html:56
-msgid ""
-"Are you sure you want to remove all <b>{0}</b> translations? This cannot be "
-"undone."
-msgstr ""
-"Biztosan el akarja távolítani az összes <b>{0}</b> fordítást? Az művelet nem"
-" vonható vissza."
+msgid "Are you sure you want to remove all <b>{0}</b> translations? This cannot be undone."
+msgstr "Biztosan el akarja távolítani az összes <b>{0}</b> fordítást? Az művelet nem vonható vissza."
 
 #: src/olympia/translations/templates/translations/trans-menu.html:61
 msgid "Delete Locale"
@@ -14458,25 +11702,14 @@ msgstr "Ez a jelszó nem engedélyezett."
 
 #: src/olympia/users/forms.py:90
 #, python-format
-msgid ""
-"As part of our new password policy, your password must be %s characters or "
-"more. Please update your password by <a href=\"%s\">issuing a password "
-"reset</a>."
-msgstr ""
-"Az új jelszóházirendek részeként, a jelszónak %s vagy több karakternek kell "
-"lennie. Kérjük, frissítse a jelszót, <a href=\"%s\">jelszó helyreállítás "
-"kérésével</a>."
+msgid "As part of our new password policy, your password must be %s characters or more. Please update your password by <a href=\"%s\">issuing a password reset</a>."
+msgstr "Az új jelszóházirendek részeként, a jelszónak %s vagy több karakternek kell lennie. Kérjük, frissítse a jelszót, <a href=\"%s\">jelszó helyreállítás kérésével</a>."
 
 #: src/olympia/users/forms.py:115
-msgid ""
-"You must recover your password through Firefox Accounts. Try logging in "
-"instead."
-msgstr ""
-"A Firefox Fiókokon keresztül kell helyreállítani a jelszavát. Próbáljon meg "
-"ehelyett bejelentkezni."
+msgid "You must recover your password through Firefox Accounts. Try logging in instead."
+msgstr "A Firefox Fiókokon keresztül kell helyreállítani a jelszavát. Próbáljon meg ehelyett bejelentkezni."
 
-#: src/olympia/users/forms.py:206
-#: src/olympia/users/templates/users/pwreset_confirm.html:24
+#: src/olympia/users/forms.py:206 src/olympia/users/templates/users/pwreset_confirm.html:24
 msgid "New password"
 msgstr "Új jelszó"
 
@@ -14489,12 +11722,8 @@ msgid "Usernames cannot contain only digits."
 msgstr "A felhasználónevek nem tartalmazhatnak csak számokat."
 
 #: src/olympia/users/forms.py:274
-msgid ""
-"Enter a valid username consisting of letters, numbers, underscores or "
-"hyphens."
-msgstr ""
-"Adjon meg egy érvényes felhasználónevet, amely betűkből, számokból, "
-"aláhúzásokból vagy kötőjelekből áll."
+msgid "Enter a valid username consisting of letters, numbers, underscores or hyphens."
+msgstr "Adjon meg egy érvényes felhasználónevet, amely betűkből, számokból, aláhúzásokból vagy kötőjelekből áll."
 
 #: src/olympia/users/forms.py:277
 msgid "This username cannot be used."
@@ -14504,37 +11733,25 @@ msgstr "Ez a felhasználónév nem használható."
 msgid "This username is already in use."
 msgstr "Ez a felhasználónév már használatban van."
 
-#: src/olympia/users/forms.py:296
-#: src/olympia/users/templates/users/edit.html:107
+#: src/olympia/users/forms.py:296 src/olympia/users/templates/users/edit.html:107
 msgid "Display Name"
 msgstr "Megjelenő név"
 
-#: src/olympia/users/forms.py:298
-#: src/olympia/users/templates/users/edit.html:112
-#: src/olympia/users/templates/users/vcard.html:10
+#: src/olympia/users/forms.py:298 src/olympia/users/templates/users/edit.html:112 src/olympia/users/templates/users/vcard.html:10
 msgid "Location"
 msgstr "Hely"
 
-#: src/olympia/users/forms.py:300
-#: src/olympia/users/templates/users/edit.html:117
-#: src/olympia/users/templates/users/vcard.html:16
+#: src/olympia/users/forms.py:300 src/olympia/users/templates/users/edit.html:117 src/olympia/users/templates/users/vcard.html:16
 msgid "Occupation"
 msgstr "Foglalkozás"
 
 #: src/olympia/users/forms.py:329
-msgid ""
-"This URL has an invalid format. Valid URLs look like "
-"http://example.com/my_page."
-msgstr ""
-"Ez az URL érvénytelen formátumban van. Az érvényes URL-ek formátuma ehhez "
-"hasonló: http://pelda.hu/sajat_oldal."
+msgid "This URL has an invalid format. Valid URLs look like http://example.com/my_page."
+msgstr "Ez az URL érvénytelen formátumban van. Az érvényes URL-ek formátuma ehhez hasonló: http://pelda.hu/sajat_oldal."
 
 #: src/olympia/users/forms.py:337
-msgid ""
-"Please use an email address from a different provider to complete your "
-"registration."
-msgstr ""
-"A regisztrációhoz használjon más szolgáltató által kibocsátott e-mail címet."
+msgid "Please use an email address from a different provider to complete your registration."
+msgstr "A regisztrációhoz használjon más szolgáltató által kibocsátott e-mail címet."
 
 #: src/olympia/users/forms.py:345
 msgid "This display name cannot be used."
@@ -14544,20 +11761,17 @@ msgstr "Ez a megjelenítendő név nem használható."
 msgid "The passwords did not match."
 msgstr "A jelszavak nem egyeznek."
 
-#: src/olympia/users/forms.py:377
-#: src/olympia/users/templates/users/edit.html:128
+#: src/olympia/users/forms.py:377 src/olympia/users/templates/users/edit.html:128
 msgid "Profile Photo"
 msgstr "Profilkép"
 
-#: src/olympia/users/forms.py:385
-#: src/olympia/users/templates/users/edit.html:142
+#: src/olympia/users/forms.py:385 src/olympia/users/templates/users/edit.html:142
 msgid "Default locale"
 msgstr "Alapértelmezett területi beállítás"
 
 #: src/olympia/users/forms.py:412
 msgid "Firefox Accounts users cannot currently change their email address."
-msgstr ""
-"A Firefox Fiókok felhasználói jelenleg nem módosíthatják az e-mail címüket."
+msgstr "A Firefox Fiókok felhasználói jelenleg nem módosíthatják az e-mail címüket."
 
 #: src/olympia/users/forms.py:446
 msgid "Wrong password entered!"
@@ -14568,12 +11782,8 @@ msgid "Email cannot be changed."
 msgstr "Az e-mail nem módosítható."
 
 #: src/olympia/users/forms.py:541
-msgid ""
-"To anonymize, enter a reason for the change but do not change any other "
-"field."
-msgstr ""
-"Az anonimizáláshoz adja meg a változás okát, de ne változtasson meg más "
-"mezőt."
+msgid "To anonymize, enter a reason for the change but do not change any other field."
+msgstr "Az anonimizáláshoz adja meg a változás okát, de ne változtasson meg más mezőt."
 
 #: src/olympia/users/forms.py:587
 msgid "Please enter at least one name to blacklist."
@@ -14602,19 +11812,19 @@ msgstr "Nincs ilyen felhasználó ilyen e-mail címmel."
 
 #. L10n: {id} will be something like "13ad6a", just a random number
 #. to differentiate this user from other anonymous users.
-#: src/olympia/users/models.py:353
+#: src/olympia/users/models.py:362
 msgid "Anonymous user {id}"
 msgstr "Ismeretlen felhasználó {id}"
 
-#: src/olympia/users/models.py:410
+#: src/olympia/users/models.py:419
 msgid "Your account has been restricted"
 msgstr "A felhasználói fiókja korlátozva lett"
 
-#: src/olympia/users/models.py:480
+#: src/olympia/users/models.py:489
 msgid "Please confirm your email address"
 msgstr "Ellenőrizze az e-mail címét"
 
-#: src/olympia/users/models.py:506
+#: src/olympia/users/models.py:515
 msgid "My Mobile Add-ons"
 msgstr "Saját Mobile kiegészítők"
 
@@ -14679,17 +11889,12 @@ msgid "Mozilla needs to contact me about my individual app"
 msgstr "a Mozillának szükséges kapcsolatba lépnie velem az alkalmazásom miatt"
 
 #: src/olympia/users/notifications.py:139
-msgid ""
-"Mozilla wants to contact me about relevant App Developer news and surveys"
-msgstr ""
-"A Mozilla kapcsolatba akar lépni velem releváns alkalmazás-fejlesztői "
-"hírekkel és felmérésekkel kapcsolatban"
+msgid "Mozilla wants to contact me about relevant App Developer news and surveys"
+msgstr "A Mozilla kapcsolatba akar lépni velem releváns alkalmazás-fejlesztői hírekkel és felmérésekkel kapcsolatban"
 
 #: src/olympia/users/notifications.py:150
 msgid "Mozilla wants to contact me about new regions added to the Marketplace"
-msgstr ""
-"A Mozilla kapcsolatba akar lépni velem a Marketplacebe bekerülő új régiók "
-"miatt"
+msgstr "A Mozilla kapcsolatba akar lépni velem a Marketplacebe bekerülő új régiók miatt"
 
 #: src/olympia/users/notifications.py:158
 msgid "User Notifications"
@@ -14712,14 +11917,8 @@ msgid "Successfully verified!"
 msgstr "Sikeresen ellenőrizve!"
 
 #: src/olympia/users/views.py:132
-msgid ""
-"An email has been sent to your address to confirm your account. Before you "
-"can log in, you have to activate your account by clicking on the link "
-"provided in this email."
-msgstr ""
-"Egy e-mailt küldtünk az Ön címére, hogy megerősítsük a fiókját. Mielőtt be "
-"tudna jelentkezni, aktiválnia kell a fiókját az e-mailben küldött "
-"hivatkozásra kattintással."
+msgid "An email has been sent to your address to confirm your account. Before you can log in, you have to activate your account by clicking on the link provided in this email."
+msgstr "Egy e-mailt küldtünk az Ön címére, hogy megerősítsük a fiókját. Mielőtt be tudna jelentkezni, aktiválnia kell a fiókját az e-mailben küldött hivatkozásra kattintással."
 
 #: src/olympia/users/views.py:136 src/olympia/users/views.py:619
 msgid "Confirmation Email Sent"
@@ -14743,13 +11942,11 @@ msgstr "Megerősítő e-mail elküldve"
 
 #: src/olympia/users/views.py:197
 msgid ""
-"An email has been sent to {0} to confirm your new email address. For the "
-"change to take effect, you need to click on the link provided in this email."
-" Until then, you can keep logging in with your current email address."
+"An email has been sent to {0} to confirm your new email address. For the change to take effect, you need to click on the link provided in this email. Until then, you can keep logging in with your "
+"current email address."
 msgstr ""
-"Egy e-mailt küldtünk a(z) {0} címre, hogy megerősítsük az új e-mail címét. A"
-" változások érvénybe lépéséhez rá kell kattintania az e-mailben kapott "
-"hivatkozásra. Addig még bejelentkezhet a jelenlegi e-mail címével."
+"Egy e-mailt küldtünk a(z) {0} címre, hogy megerősítsük az új e-mail címét. A változások érvénybe lépéséhez rá kell kattintania az e-mailben kapott hivatkozásra. Addig még bejelentkezhet a jelenlegi"
+" e-mail címével."
 
 #: src/olympia/users/views.py:210
 #, python-format
@@ -14761,13 +11958,11 @@ msgid "Errors Found"
 msgstr "Talált hibák"
 
 #: src/olympia/users/views.py:225
-msgid ""
-"There were errors in the changes you made. Please correct them and resubmit."
+msgid "There were errors in the changes you made. Please correct them and resubmit."
 msgstr "Hibák voltak a módosításokban. Javítsa ki őket, és küldje újra."
 
 #: src/olympia/users/views.py:273
-msgid ""
-"We're sorry, but you are not eligible to request a t-shirt at this time."
+msgid "We're sorry, but you are not eligible to request a t-shirt at this time."
 msgstr "Sajnáljuk, de most nem jogosult póló kérésére."
 
 #: src/olympia/users/views.py:329
@@ -14783,25 +11978,17 @@ msgid "Wrong email address or password!"
 msgstr "Rossz e-mail cím vagy jelszó!"
 
 #: src/olympia/users/views.py:434
-msgid ""
-"A link to activate your user account was sent by email to your address {0}. "
-"You have to click it before you can log in."
-msgstr ""
-"A felhasználói fiókját aktiváló hivatkozás el lett küldve a(z) {0} e-mail "
-"címére. Rá kell kattintania mielőtt bejelentkezhetne."
+msgid "A link to activate your user account was sent by email to your address {0}. You have to click it before you can log in."
+msgstr "A felhasználói fiókját aktiváló hivatkozás el lett küldve a(z) {0} e-mail címére. Rá kell kattintania mielőtt bejelentkezhetne."
 
 #: src/olympia/users/views.py:439
 #, python-format
 msgid ""
-"If you did not receive the confirmation email, make sure your email service "
-"did not mark it as \"junk mail\" or \"spam\". If you need to, you can have "
-"us <a href=\"%s\">resend the confirmation message</a> to your email address "
-"mentioned above."
+"If you did not receive the confirmation email, make sure your email service did not mark it as \"junk mail\" or \"spam\". If you need to, you can have us <a href=\"%s\">resend the confirmation "
+"message</a> to your email address mentioned above."
 msgstr ""
-"Ha nem kapott megerősítő e-mail, akkor győződjön meg róla, hogy a levelező "
-"szolgáltatása nem jelölte meg „kéretlen üzenetként” vagy „spamként”. Ha "
-"szükséges, <a href=\"%s\">újra kérheti a megerősítő üzenetet</a> a fent "
-"említett e-mail címére."
+"Ha nem kapott megerősítő e-mail, akkor győződjön meg róla, hogy a levelező szolgáltatása nem jelölte meg „kéretlen üzenetként” vagy „spamként”. Ha szükséges, <a href=\"%s\">újra kérheti a "
+"megerősítő üzenetet</a> a fent említett e-mail címére."
 
 #: src/olympia/users/views.py:444
 msgid "Activation Email Sent"
@@ -14821,14 +12008,8 @@ msgstr "Gratulálunk! A felhasználói fiók sikeresen létrejött."
 
 # %1 is the user's email address
 #: src/olympia/users/views.py:615
-msgid ""
-"An email has been sent to your address {0} to confirm your account. Before "
-"you can log in, you have to activate your account by clicking on the link "
-"provided in this email."
-msgstr ""
-"A felhasználói fiókot aktiváló hivatkozást e-mailben küldtük el a(z) {0} "
-"címre. Az első bejelentkezés előtt aktiválnia kell a fiókját az e-mailben "
-"küldött hivatkozásra való kattintással."
+msgid "An email has been sent to your address {0} to confirm your account. Before you can log in, you have to activate your account by clicking on the link provided in this email."
+msgstr "A felhasználói fiókot aktiváló hivatkozást e-mailben küldtük el a(z) {0} címre. Az első bejelentkezés előtt aktiválnia kell a fiókját az e-mailben küldött hivatkozásra való kattintással."
 
 #: src/olympia/users/views.py:639
 msgid "There are errors in this form"
@@ -14846,31 +12027,22 @@ msgstr "Felhasználó bejelentve."
 msgid "new"
 msgstr "új"
 
-#: src/olympia/users/templates/users/delete.html:4
-#: src/olympia/users/templates/users/delete.html:10
+#: src/olympia/users/templates/users/delete.html:4 src/olympia/users/templates/users/delete.html:10
 msgid "Delete User Account"
 msgstr "Felhasználói fiók törlése"
 
 #: src/olympia/users/templates/users/delete.html:14
 #, python-format
 msgid ""
-"You cannot delete your account if you are listed as an <a href=\"%(link)s\">"
-" author of any add-ons</a>. To delete your account, please have another "
-"person in your development group delete you from the list of authors for "
-"your add-ons. Afterwards you will be able to delete your account here."
+"You cannot delete your account if you are listed as an <a href=\"%(link)s\"> author of any add-ons</a>. To delete your account, please have another person in your development group delete you from "
+"the list of authors for your add-ons. Afterwards you will be able to delete your account here."
 msgstr ""
-"Nem törölheti a fiókját, ha <a href=\"%(link)s\">bármelyik kiegészítő "
-"szerzőjeként szerepel</a>. A fiók törléséhez először kérjen meg valakit a "
-"fejlesztőcsoportjából, hogy törölje a kiegészítőinek szerzői közül. Ezután "
-"tudja törölni itt a fiókját."
+"Nem törölheti a fiókját, ha <a href=\"%(link)s\">bármelyik kiegészítő szerzőjeként szerepel</a>. A fiók törléséhez először kérjen meg valakit a fejlesztőcsoportjából, hogy törölje a kiegészítőinek "
+"szerzői közül. Ezután tudja törölni itt a fiókját."
 
 #: src/olympia/users/templates/users/delete.html:29
-msgid ""
-"By clicking \"delete\" your account is going to be <strong>permanently "
-"removed</strong>. That means:"
-msgstr ""
-"A „törlésre” kattintva a fiókja <strong>véglegesen eltávolításra "
-"kerül</strong>. Tehát:"
+msgid "By clicking \"delete\" your account is going to be <strong>permanently removed</strong>. That means:"
+msgstr "A „törlésre” kattintva a fiókja <strong>véglegesen eltávolításra kerül</strong>. Tehát:"
 
 #: src/olympia/users/templates/users/delete.html:35
 #, python-format
@@ -14878,12 +12050,8 @@ msgid "You will not be able to log into %(site)s anymore."
 msgstr "Többé nem fog tudni bejelentkezni a %(site)s oldalra."
 
 #: src/olympia/users/templates/users/delete.html:40
-msgid ""
-"Your reviews and ratings will not be deleted, but they will no longer be "
-"associated with you."
-msgstr ""
-"Az értékelései és minősítési nem kerülnek törlésre, de többé nem fognak "
-"Önhöz kötődni."
+msgid "Your reviews and ratings will not be deleted, but they will no longer be associated with you."
+msgstr "Az értékelései és minősítési nem kerülnek törlésre, de többé nem fognak Önhöz kötődni."
 
 #: src/olympia/users/templates/users/delete.html:46
 msgid "Confirm account deletion"
@@ -14897,8 +12065,7 @@ msgstr "Megértettem, hogy az a művelet visszafordíthatatlan."
 msgid "Delete my user account now"
 msgstr "Felhasználói fiók törlése"
 
-#: src/olympia/users/templates/users/delete_photo.html:3
-#: src/olympia/users/templates/users/delete_photo.html:9
+#: src/olympia/users/templates/users/delete_photo.html:3 src/olympia/users/templates/users/delete_photo.html:9
 msgid "Delete User Photo"
 msgstr "Felhasználói kép törlése"
 
@@ -14911,27 +12078,18 @@ msgid "Please set your display name"
 msgstr "Kérjük, adja meg a megjelenítendő nevét"
 
 #: src/olympia/users/templates/users/edit.html:21
-msgid ""
-"Please set your display name or username to complete the registration "
-"process."
-msgstr ""
-"Kérjük, állítsa be a megjelenítendő nevet vagy felhasználónevet a "
-"regisztráció befejezéséhez."
+msgid "Please set your display name or username to complete the registration process."
+msgstr "Kérjük, állítsa be a megjelenítendő nevet vagy felhasználónevet a regisztráció befejezéséhez."
 
 #: src/olympia/users/templates/users/edit.html:33
 msgid "Manage basic account information, such as username and email address."
-msgstr ""
-"Kezelje az alapvető fiókinformációt, mint például a felhasználónevét és "
-"e-mail címét."
+msgstr "Kezelje az alapvető fiókinformációt, mint például a felhasználónevét és e-mail címét."
 
-#: src/olympia/users/templates/users/edit.html:39
-#: src/olympia/users/templates/users/register.html:47
+#: src/olympia/users/templates/users/edit.html:39 src/olympia/users/templates/users/register.html:47
 msgid "Username"
 msgstr "Felhasználónév"
 
-#: src/olympia/users/templates/users/edit.html:45
-#: src/olympia/users/templates/users/pwreset_request.html:21
-#: src/olympia/users/templates/users/register.html:62
+#: src/olympia/users/templates/users/edit.html:45 src/olympia/users/templates/users/pwreset_request.html:21 src/olympia/users/templates/users/register.html:62
 msgid "Email Address"
 msgstr "E-mail cím"
 
@@ -14943,21 +12101,15 @@ msgstr "Firefox-fiók kezelése…"
 msgid "Change Password"
 msgstr "Jelszó megváltoztatása"
 
-#: src/olympia/users/templates/users/edit.html:68
-#: src/olympia/users/templates/users/login_form.html:22
-#: src/olympia/users/templates/users/register.html:67
+#: src/olympia/users/templates/users/edit.html:68 src/olympia/users/templates/users/login_form.html:22 src/olympia/users/templates/users/register.html:67
 #: src/olympia/users/templates/users/mobile/login.html:37
 msgid "Password"
 msgstr "Jelszó"
 
 #: src/olympia/users/templates/users/edit.html:70
 #, python-format
-msgid ""
-"Change your password.  If you forgot your password, you can <a "
-"href=\"%(reset_url)s\">use the reset form</a>."
-msgstr ""
-"Jelszó megváltoztatása. Ha elfelejtette jelszavát, akkor használja a <a "
-"href=\"%(reset_url)s\">helyreállítási űrlapot</a>."
+msgid "Change your password. If you forgot your password, you can <a href=\"%(reset_url)s\">use the reset form</a>."
+msgstr "Jelszó megváltoztatása. Ha elfelejtette jelszavát, akkor használja a <a href=\"%(reset_url)s\">helyreállítási űrlapot</a>."
 
 #: src/olympia/users/templates/users/edit.html:76
 msgid "Old Password"
@@ -14976,12 +12128,8 @@ msgid "Profile"
 msgstr "Profil"
 
 #: src/olympia/users/templates/users/edit.html:100
-msgid ""
-"Give us a bit more information about yourself.  All these fields are "
-"optional, but they'll help other users get to know you better."
-msgstr ""
-"Adjon meg némi információt Önről. Ezek a mező nem kötelezőek, de segítenek "
-"más felhasználóknak jobban megismerni Önt."
+msgid "Give us a bit more information about yourself. All these fields are optional, but they'll help other users get to know you better."
+msgstr "Adjon meg némi információt Önről. Ezek a mező nem kötelezőek, de segítenek más felhasználóknak jobban megismerni Önt."
 
 #: src/olympia/users/templates/users/edit.html:124
 msgid "This URL will only be visible if you are a developer."
@@ -14996,20 +12144,12 @@ msgid "Delete current photo"
 msgstr "Jelenlegi fotó törlése"
 
 #: src/olympia/users/templates/users/edit.html:144
-msgid ""
-"This is the default locale used to display information about you (like your "
-"description)."
-msgstr ""
-"Ez a jelenleg használt területi beállítás az Ön információinak "
-"megjelenítéséhez (pl. a leírásánál)."
+msgid "This is the default locale used to display information about you (like your description)."
+msgstr "Ez a jelenleg használt területi beállítás az Ön információinak megjelenítéséhez (pl. a leírásánál)."
 
 #: src/olympia/users/templates/users/edit.html:152
-msgid ""
-"Introduce yourself to the community, if you like! This text will appear "
-"publicly on your user info page."
-msgstr ""
-"Mutatkozzon be a közösségnek! Ez a szöveg meg fog jelenni a nyilvános "
-"adatlapján."
+msgid "Introduce yourself to the community, if you like! This text will appear publicly on your user info page."
+msgstr "Mutatkozzon be a közösségnek! Ez a szöveg meg fog jelenni a nyilvános adatlapján."
 
 #: src/olympia/users/templates/users/edit.html:161
 msgid "Allowed HTML: {0}. Links are forbidden."
@@ -15036,21 +12176,12 @@ msgid "Notifications"
 msgstr "Értesítések"
 
 #: src/olympia/users/templates/users/edit.html:195
-msgid ""
-"From time to time, Mozilla may send you email about upcoming releases and "
-"add-on events. Please select the topics you are interested in."
-msgstr ""
-"Időről időre a Mozilla e-mail üzeneteket küldhet a soron következő "
-"kiadásokról és eseményekről. Kérjük válassza ki azokat a témákat, melyek "
-"érdeklik."
+msgid "From time to time, Mozilla may send you email about upcoming releases and add-on events. Please select the topics you are interested in."
+msgstr "Időről időre a Mozilla e-mail üzeneteket küldhet a soron következő kiadásokról és eseményekről. Kérjük válassza ki azokat a témákat, melyek érdeklik."
 
 #: src/olympia/users/templates/users/edit.html:205
-msgid ""
-"Mozilla reserves the right to contact you individually about specific "
-"concerns with your hosted add-ons."
-msgstr ""
-"A Mozilla fenntartja a jogot, hogy egyénileg felvegye Önnel a kapcsolatot, "
-"ha aggasztónak találja az Ön által beküldött kiegészítőket."
+msgid "Mozilla reserves the right to contact you individually about specific concerns with your hosted add-ons."
+msgstr "A Mozilla fenntartja a jogot, hogy egyénileg felvegye Önnel a kapcsolatot, ha aggasztónak találja az Ön által beküldött kiegészítőket."
 
 #: src/olympia/users/templates/users/edit.html:215
 msgid "Admin"
@@ -15072,63 +12203,49 @@ msgstr "nincs"
 msgid "all"
 msgstr "mind"
 
-#: src/olympia/users/templates/users/fxa_migration.html:3
-#: src/olympia/users/templates/users/fxa_migration.html:11
-#: src/olympia/users/templates/users/mobile/fxa_migration.html:3
+#: src/olympia/users/templates/users/fxa_migration.html:3 src/olympia/users/templates/users/fxa_migration.html:11 src/olympia/users/templates/users/mobile/fxa_migration.html:3
 #: src/olympia/users/templates/users/mobile/fxa_migration.html:8
 msgid "Migrate to Firefox Accounts"
 msgstr "Migrálás Firefox fiókra"
 
 #: src/olympia/users/templates/users/fxa_migration_prompt_content.html:3
-msgid ""
-"Mozilla Add-ons has transitioned to Firefox Accounts for login. Continue to "
-"complete the simple upgrade process."
-msgstr ""
-"A Mozilla Kiegészítők áttért a Firefox fiókokra a bejelentkezéshez. "
-"Folytassa az egyszerű frissítési folyamat befejezéséhez."
+msgid "Mozilla Add-ons has transitioned to Firefox Accounts for login. Continue to complete the simple upgrade process."
+msgstr "A Mozilla Kiegészítők áttért a Firefox fiókokra a bejelentkezéshez. Folytassa az egyszerű frissítési folyamat befejezéséhez."
 
 #: src/olympia/users/templates/users/fxa_migration_prompt_content.html:14
 msgid "Skip"
 msgstr "Kihagyás"
 
-#: src/olympia/users/templates/users/login.html:3
-#: src/olympia/users/templates/users/mobile/login.html:3
+#: src/olympia/users/templates/users/login.html:3 src/olympia/users/templates/users/mobile/login.html:3
 msgid "User Login"
 msgstr "Felhasználónév"
 
-#: src/olympia/users/templates/users/login.html:13
-#: src/olympia/users/templates/users/mobile/login.html:21
+#: src/olympia/users/templates/users/login.html:13 src/olympia/users/templates/users/mobile/login.html:21
 msgid "Enter your email"
 msgstr "Adja meg az e-mail címét"
 
-#: src/olympia/users/templates/users/login.html:15
-#: src/olympia/users/templates/users/mobile/login.html:23
+#: src/olympia/users/templates/users/login.html:15 src/olympia/users/templates/users/mobile/login.html:23
 msgid "Log In"
 msgstr "Bejelentkezés"
 
-#: src/olympia/users/templates/users/login_form.html:17
-#: src/olympia/users/templates/users/mobile/login.html:32
+#: src/olympia/users/templates/users/login_form.html:17 src/olympia/users/templates/users/mobile/login.html:32
 msgid "Email address"
 msgstr "E-mail cím"
 
-#: src/olympia/users/templates/users/login_form.html:30
-#: src/olympia/users/templates/users/mobile/login.html:44
+#: src/olympia/users/templates/users/login_form.html:30 src/olympia/users/templates/users/mobile/login.html:44
 msgid "Remember me on this device"
 msgstr "Jegyezzen meg ezen az eszközön"
 
 # This is a header for additional help options
-#: src/olympia/users/templates/users/login_help.html:3
-#: src/olympia/users/templates/users/mobile/login.html:63
+#: src/olympia/users/templates/users/login_help.html:3 src/olympia/users/templates/users/mobile/login.html:63
 msgid "Login Problems?"
 msgstr "Bejelentkezési problémák?"
 
-#: src/olympia/users/templates/users/login_help.html:5
-#: src/olympia/users/templates/users/mobile/login.html:65
+#: src/olympia/users/templates/users/login_help.html:5 src/olympia/users/templates/users/mobile/login.html:65
 msgid "I don't have an account."
 msgstr "Nincs fiókom."
 
-#: src/olympia/users/templates/users/login_help.html:6
-#: src/olympia/users/templates/users/mobile/login.html:66
+#: src/olympia/users/templates/users/login_help.html:6 src/olympia/users/templates/users/mobile/login.html:66
 msgid "I forgot my password."
 msgstr "Elfelejtettem a jelszavam."
 
@@ -15137,15 +12254,9 @@ msgstr "Elfelejtettem a jelszavam."
 msgid "You are now logged in as <strong>%(user_email)s</strong>!"
 msgstr "Bejelentkezve mint <strong>%(user_email)s</strong>!"
 
-#: src/olympia/users/templates/users/newpw_sent.html:3
-#: src/olympia/users/templates/users/newpw_sent.html:8
-#: src/olympia/users/templates/users/pwreset_complete.html:3
-#: src/olympia/users/templates/users/pwreset_confirm.html:4
-#: src/olympia/users/templates/users/pwreset_confirm.html:18
-#: src/olympia/users/templates/users/pwreset_request.html:4
-#: src/olympia/users/templates/users/pwreset_request.html:10
-#: src/olympia/users/templates/users/pwreset_sent.html:3
-#: src/olympia/users/templates/users/pwreset_sent.html:8
+#: src/olympia/users/templates/users/newpw_sent.html:3 src/olympia/users/templates/users/newpw_sent.html:8 src/olympia/users/templates/users/pwreset_complete.html:3
+#: src/olympia/users/templates/users/pwreset_confirm.html:4 src/olympia/users/templates/users/pwreset_confirm.html:18 src/olympia/users/templates/users/pwreset_request.html:4
+#: src/olympia/users/templates/users/pwreset_request.html:10 src/olympia/users/templates/users/pwreset_sent.html:3 src/olympia/users/templates/users/pwreset_sent.html:8
 msgid "Password Reset"
 msgstr "Jelszó beállítása"
 
@@ -15161,8 +12272,7 @@ msgstr "Profil szerkesztése"
 msgid "Manage user"
 msgstr "Felhasználó kezelése"
 
-#: src/olympia/users/templates/users/profile.html:18
-#: src/olympia/users/templates/users/report_abuse_full.html:9
+#: src/olympia/users/templates/users/profile.html:18 src/olympia/users/templates/users/report_abuse_full.html:9
 msgid "Report user"
 msgstr "Felhasználó bejelentése"
 
@@ -15225,54 +12335,33 @@ msgstr "Sikerült!"
 msgid "Password successfully reset."
 msgstr "A jelszó beállítása sikeresen megtörtént."
 
-#: src/olympia/users/templates/users/pwreset_confirm.html:13
-#: src/olympia/users/templates/users/pwreset_confirm.html:46
+#: src/olympia/users/templates/users/pwreset_confirm.html:13 src/olympia/users/templates/users/pwreset_confirm.html:46
 msgid "Password reset unsuccessful"
 msgstr "Jelszó átállítása sikertelen volt"
 
 #: src/olympia/users/templates/users/pwreset_confirm.html:14
-msgid ""
-"You have migrated to Firefox Accounts. You can no longer change your "
-"password here."
-msgstr ""
-"Áttért a Firefox fiókok használatára, többé már nem változtathatja meg itt a"
-" jelszavát."
+msgid "You have migrated to Firefox Accounts. You can no longer change your password here."
+msgstr "Áttért a Firefox fiókok használatára, többé már nem változtathatja meg itt a jelszavát."
 
-#: src/olympia/users/templates/users/pwreset_confirm.html:31
-#: src/olympia/users/templates/users/register.html:72
+#: src/olympia/users/templates/users/pwreset_confirm.html:31 src/olympia/users/templates/users/register.html:72
 msgid "Confirm password"
 msgstr "Jelszó megerősítése"
 
 #: src/olympia/users/templates/users/pwreset_confirm.html:47
-msgid ""
-"The password reset link was invalid, possibly because it has already been "
-"used. Please request a new password reset."
-msgstr ""
-"A jelszó létrehozására mutató hivatkozás nem megfelelő. Lehet, hogy már "
-"korábban felhasználásra került. Indítsa újra a jelszó létrehozásának "
-"folyamatát."
+msgid "The password reset link was invalid, possibly because it has already been used. Please request a new password reset."
+msgstr "A jelszó létrehozására mutató hivatkozás nem megfelelő. Lehet, hogy már korábban felhasználásra került. Indítsa újra a jelszó létrehozásának folyamatát."
 
 #: src/olympia/users/templates/users/pwreset_request.html:15
-msgid ""
-"Forgotten your password? Enter your e-mail address below, and we'll e-mail "
-"instructions for setting a new one."
-msgstr ""
-"Elfelejtette a jelszavát? Adja meg e-mail címét, és mi elküldjük egy "
-"útmutatót, amellyel beállíthat egy újat."
+msgid "Forgotten your password? Enter your e-mail address below, and we'll e-mail instructions for setting a new one."
+msgstr "Elfelejtette a jelszavát? Adja meg e-mail címét, és mi elküldjük egy útmutatót, amellyel beállíthat egy újat."
 
 #: src/olympia/users/templates/users/pwreset_request.html:25
 msgid "Send password reset link"
 msgstr "Jelszót törlő hivatkozás küldése"
 
 #: src/olympia/users/templates/users/pwreset_sent.html:10
-msgid ""
-"An email has been sent to the requested account with further information. If"
-" you do not receive an email then please confirm you have entered the same "
-"email address used during account registration."
-msgstr ""
-"További információt tartalmazó levelet küldtünk a megadott e-mail címre. "
-"Amennyiben nem kapott levelet, ellenőrizzem hogy ugyanazt az e-mail címet "
-"adta meg, mint regisztrációkor."
+msgid "An email has been sent to the requested account with further information. If you do not receive an email then please confirm you have entered the same email address used during account registration."
+msgstr "További információt tartalmazó levelet küldtünk a megadott e-mail címre. Amennyiben nem kapott levelet, ellenőrizzem hogy ugyanazt az e-mail címet adta meg, mint regisztrációkor."
 
 #: src/olympia/users/templates/users/register.html:4
 msgid "New User Registration"
@@ -15283,12 +12372,8 @@ msgid "Why register?"
 msgstr "Miért regisztráljon?"
 
 #: src/olympia/users/templates/users/register.html:14
-msgid ""
-"Registration on AMO is <strong>not required</strong> if you simply want to "
-"download and install public add-ons."
-msgstr ""
-"Az AMO regisztráció <strong>nem kötelező</strong>, ha csak nyilvános "
-"kiegészítőket szeretne letölteni és telepíteni."
+msgid "Registration on AMO is <strong>not required</strong> if you simply want to download and install public add-ons."
+msgstr "Az AMO regisztráció <strong>nem kötelező</strong>, ha csak nyilvános kiegészítőket szeretne letölteni és telepíteni."
 
 #: src/olympia/users/templates/users/register.html:16
 msgid "You only need to register if:"
@@ -15299,53 +12384,29 @@ msgid "You want to submit reviews for add-ons"
 msgstr "Értékeléseket akar beküldeni kiegészítőkhöz"
 
 #: src/olympia/users/templates/users/register.html:19
-msgid ""
-"You want to keep track of your favorite add-on collections or create one "
-"yourself"
-msgstr ""
-"Szeretné nyomon követni kedvenc kiegészítőgyűjteményeit vagy szeretne egy "
-"sajátot létrehozni"
+msgid "You want to keep track of your favorite add-on collections or create one yourself"
+msgstr "Szeretné nyomon követni kedvenc kiegészítőgyűjteményeit vagy szeretne egy sajátot létrehozni"
 
 #: src/olympia/users/templates/users/register.html:20
-msgid ""
-"You are an add-on developer and want to upload your add-on for hosting on "
-"AMO"
-msgstr ""
-"Ön egy kiegészítőfejlesztő, és szeretné feltölteni a kiegészítőjét, hogy az "
-"AMO szolgáltassa azt "
+msgid "You are an add-on developer and want to upload your add-on for hosting on AMO"
+msgstr "Ön egy kiegészítőfejlesztő, és szeretné feltölteni a kiegészítőjét, hogy az AMO szolgáltassa azt "
 
 #: src/olympia/users/templates/users/register.html:23
-msgid ""
-"Upon successful registration, you will be sent a confirmation email to the "
-"address you provided. Please follow the instructions there to confirm your "
-"account."
-msgstr ""
-"A sikeres regisztráció után egy megerősítő e-mailt fog kapni a megadott "
-"e-mail címre. Kérjük kövesse az abban leírt utasításokat, hogy megerősítse "
-"fiókját."
+msgid "Upon successful registration, you will be sent a confirmation email to the address you provided. Please follow the instructions there to confirm your account."
+msgstr "A sikeres regisztráció után egy megerősítő e-mailt fog kapni a megadott e-mail címre. Kérjük kövesse az abban leírt utasításokat, hogy megerősítse fiókját."
 
 #: src/olympia/users/templates/users/register.html:30
 #, python-format
-msgid ""
-"If you like, you can read our <a href=\"%(legal)s\" title=\"Legal "
-"Notices\">Legal Notices</a> and <a href=\"%(privacy)s\" title=\"Privacy "
-"Policy\">Privacy Policy</a>."
-msgstr ""
-"Ha szeretné,  elolvashatja a <a href=\"%(legal)s\" title=\"Legal "
-"Notices\">Jogi megjegyzéseket</a> és az <a href=\"%(privacy)s\" "
-"title=\"Privacy Policy\">Adatvédelmi nyilatkozatot</a>."
+msgid "If you like, you can read our <a href=\"%(legal)s\" title=\"Legal Notices\">Legal Notices</a> and <a href=\"%(privacy)s\" title=\"Privacy Policy\">Privacy Policy</a>."
+msgstr "Ha szeretné,  elolvashatja a <a href=\"%(legal)s\" title=\"Legal Notices\">Jogi megjegyzéseket</a> és az <a href=\"%(privacy)s\" title=\"Privacy Policy\">Adatvédelmi nyilatkozatot</a>."
 
 #: src/olympia/users/templates/users/register.html:52
 msgid "Display name"
 msgstr "Megjelenő név"
 
 #: src/olympia/users/templates/users/report_abuse.html:7
-msgid ""
-"Please describe why you are reporting this user, such as for spam or an "
-"inappropriate picture."
-msgstr ""
-"Írja le, hogy miért jelentette be ezt a felhasználót (például spam, nem "
-"megfelelő kép)."
+msgid "Please describe why you are reporting this user, such as for spam or an inappropriate picture."
+msgstr "Írja le, hogy miért jelentette be ezt a felhasználót (például spam, nem megfelelő kép)."
 
 #: src/olympia/users/templates/users/report_abuse_full.html:3
 msgid "Report user {0}"
@@ -15359,41 +12420,25 @@ msgstr "Póló rendelése"
 msgid "Special Edition Add-on Creator T-shirt"
 msgstr "Különleges kiadású kiegészítő-fejlesztői póló"
 
-#: src/olympia/users/templates/users/t-shirt.html:14
-#: src/olympia/users/templates/users/t-shirt.html:120
+#: src/olympia/users/templates/users/t-shirt.html:14 src/olympia/users/templates/users/t-shirt.html:120
 msgid "Note:"
 msgstr "Megjegyzés:"
 
 #: src/olympia/users/templates/users/t-shirt.html:15
-msgid ""
-"You have already submitted a request for a t-shirt. You may re-submit this "
-"form to update your information, but you will only receive one shirt."
-msgstr ""
-"Már igényelt pólót. Az adatait frissítve új igénylést adhat le, de így is "
-"csak egy pólót küldhetünk."
+msgid "You have already submitted a request for a t-shirt. You may re-submit this form to update your information, but you will only receive one shirt."
+msgstr "Már igényelt pólót. Az adatait frissítve új igénylést adhat le, de így is csak egy pólót küldhetünk."
 
 #: src/olympia/users/templates/users/t-shirt.html:26
-msgid ""
-"Thank you for helping to make Firefox the most extensible browser available!"
-msgstr ""
-"Köszönjük, hogy segíti a Firefoxot abban, hogy a leginkább bővíthető "
-"böngésző legyen!"
+msgid "Thank you for helping to make Firefox the most extensible browser available!"
+msgstr "Köszönjük, hogy segíti a Firefoxot abban, hogy a leginkább bővíthető böngésző legyen!"
 
 #: src/olympia/users/templates/users/t-shirt.html:33
-msgid ""
-"As a thank you gift, we'd like to send you a special-edition, community-"
-"designed t-shirt. To receive your shirt, please fill out the form below."
-msgstr ""
-"Hálánk jeléül szeretnénk küldeni egy különleges, közösség által tervezett "
-"pólót. A póló igényléséhez kérjük, töltse ki az űrlapot."
+msgid "As a thank you gift, we'd like to send you a special-edition, community-designed t-shirt. To receive your shirt, please fill out the form below."
+msgstr "Hálánk jeléül szeretnénk küldeni egy különleges, közösség által tervezett pólót. A póló igényléséhez kérjük, töltse ki az űrlapot."
 
 #: src/olympia/users/templates/users/t-shirt.html:41
-msgid ""
-"Your contact information will only be used by Mozilla to ship this special "
-"edition t-shirt."
-msgstr ""
-"Megadott adatait a Mozilla kizárólag a póló kézbesítéséhez használja csak "
-"fel."
+msgid "Your contact information will only be used by Mozilla to ship this special edition t-shirt."
+msgstr "Megadott adatait a Mozilla kizárólag a póló kézbesítéséhez használja csak fel."
 
 #: src/olympia/users/templates/users/t-shirt.html:60
 msgid "Mailing Address"
@@ -15449,24 +12494,15 @@ msgstr "Póló kérése"
 
 #: src/olympia/users/templates/users/t-shirt.html:137
 msgid ""
-"We're sorry, but in order to qualify for our special edition t-shirt, you "
-"must be an add-on developer with at least one listed add-on, one unlisted "
-"but signed add-on, or any number of background themes with a combined total "
-"of 10,000 average daily users."
+"We're sorry, but in order to qualify for our special edition t-shirt, you must be an add-on developer with at least one listed add-on, one unlisted but signed add-on, or any number of background "
+"themes with a combined total of 10,000 average daily users."
 msgstr ""
-"Sajnáljuk, de ahhoz hogy jogosult legyen a különleges kiadású pólónkra, "
-"ahhoz kiegészítőfejlesztőnek kell lennie, legalább egy listázott "
-"kiegészítővel, vagy egy nem listázott, de aláírt kiegészítővel, vagy "
-"tetszőleges számú háttértémával, amelyek összesített, átlagos napi "
-"felhasználószáma eléri a 10.000-et."
+"Sajnáljuk, de ahhoz hogy jogosult legyen a különleges kiadású pólónkra, ahhoz kiegészítőfejlesztőnek kell lennie, legalább egy listázott kiegészítővel, vagy egy nem listázott, de aláírt "
+"kiegészítővel, vagy tetszőleges számú háttértémával, amelyek összesített, átlagos napi felhasználószáma eléri a 10.000-et."
 
 #: src/olympia/users/templates/users/tougher_password.html:2
-msgid ""
-"For your account a password must contain at least 8 characters including "
-"letters and numbers."
-msgstr ""
-"A fiókhoz tartozó jelszónak legalább 8 karakter hosszúnak kell lennie, "
-"valamint betűket és számokat is kell tartalmaznia."
+msgid "For your account a password must contain at least 8 characters including letters and numbers."
+msgstr "A fiókhoz tartozó jelszónak legalább 8 karakter hosszúnak kell lennie, valamint betűket és számokat is kell tartalmaznia."
 
 #: src/olympia/users/templates/users/unsubscribe.html:2
 msgid "Unsubscribe"
@@ -15478,12 +12514,8 @@ msgstr "Sikeres leiratkozás!"
 
 #: src/olympia/users/templates/users/unsubscribe.html:10
 #, python-format
-msgid ""
-"The email address <strong>%(email)s</strong> will no longer get messages "
-"when:"
-msgstr ""
-"Nem fog több üzenetet kapni a <strong>%(email)s</strong> e-mail címre ezt "
-"követően:"
+msgid "The email address <strong>%(email)s</strong> will no longer get messages when:"
+msgstr "Nem fog több üzenetet kapni a <strong>%(email)s</strong> e-mail címre ezt követően:"
 
 #: src/olympia/users/templates/users/unsubscribe.html:20
 msgid "More Actions:"
@@ -15503,14 +12535,8 @@ msgstr "Nem sikerült a leiratkozás"
 
 #: src/olympia/users/templates/users/unsubscribe.html:30
 #, python-format
-msgid ""
-"Unfortunately, we weren't able to unsubscribe you. The link you clicked is "
-"invalid. However, you can unsubscribe still unsubscribe on your <a "
-"href=\"%(edit_url)s\">edit profile page</a>."
-msgstr ""
-"Sajnos a leiratkozás sikertelen volt. A hivatkozás, amire kattintott, "
-"érvénytelen. De leiratkozhat a <a href=\"%(edit_url)s\">profil szerkesztése "
-"oldalon is</a>."
+msgid "Unfortunately, we weren't able to unsubscribe you. The link you clicked is invalid. However, you can unsubscribe still unsubscribe on your <a href=\"%(edit_url)s\">edit profile page</a>."
+msgstr "Sajnos a leiratkozás sikertelen volt. A hivatkozás, amire kattintott, érvénytelen. De leiratkozhat a <a href=\"%(edit_url)s\">profil szerkesztése oldalon is</a>."
 
 #: src/olympia/users/templates/users/vcard.html:2
 msgid "Developer Information"
@@ -15563,15 +12589,15 @@ msgstr "%s verziótörténet"
 msgid "Version History with Changelogs"
 msgstr "Verziótörténet a módosítások naplójával"
 
-#: src/olympia/versions/models.py:314
+#: src/olympia/versions/models.py:313
 msgid "Add-on uses binary components."
 msgstr "A kiegészítő bináris komponenseket használ."
 
-#: src/olympia/versions/models.py:317
+#: src/olympia/versions/models.py:316
 msgid "Add-on has opted into strict compatibility checking."
 msgstr "A kiegészítő feliratkozott a szigorú kompatibilitás-ellenőrzésre."
 
-#: src/olympia/versions/models.py:715
+#: src/olympia/versions/models.py:711
 msgid "{app} {min} and later"
 msgstr "{app} {min} és frissebbek"
 
@@ -15598,8 +12624,8 @@ msgstr "A forráskód kiadva <a href=\"%(url)s\">%(name)s</a> alatt"
 msgid "View the source"
 msgstr "Forrás megtekintése"
 
-#. {0} is an add-on name.
 # {0} is the add-on name
+#. {0} is an add-on name.
 #: src/olympia/versions/templates/versions/version_list.html:26
 msgid "{0} Version History"
 msgstr "{0} verziótörténete"
@@ -15611,20 +12637,14 @@ msgid_plural "<b>{0}</b> versions"
 msgstr[0] "<b>{0}</b> verzió"
 msgstr[1] "<b>{0}</b> verzió"
 
-#: src/olympia/versions/templates/versions/version_list.html:35
-#: src/olympia/versions/templates/versions/mobile/version_list.html:14
+#: src/olympia/versions/templates/versions/version_list.html:35 src/olympia/versions/templates/versions/mobile/version_list.html:14
 msgid "Be careful with old versions!"
 msgstr "Legyen óvatos a régi verziókkal!"
 
-#: src/olympia/versions/templates/versions/version_list.html:36
-#: src/olympia/versions/templates/versions/mobile/version_list.html:15
+#: src/olympia/versions/templates/versions/version_list.html:36 src/olympia/versions/templates/versions/mobile/version_list.html:15
 #, python-format
-msgid ""
-"These versions are displayed for reference and testing purposes. You should "
-"always use the <a href=\"%(url)s\">latest version</a> of an add-on."
-msgstr ""
-"Ezek a verziók csak tanulmányozás és tesztelés céljából jelennek meg. Mindig"
-" a kiegészítő <a href=\"%(url)s\">legújabb verzióját</a> használja."
+msgid "These versions are displayed for reference and testing purposes. You should always use the <a href=\"%(url)s\">latest version</a> of an add-on."
+msgstr "Ezek a verziók csak tanulmányozás és tesztelés céljából jelennek meg. Mindig a kiegészítő <a href=\"%(url)s\">legújabb verzióját</a> használja."
 
 #: src/olympia/versions/templates/versions/mobile/version.html:4
 msgid "Beta Version {0}"
@@ -15654,3 +12674,8 @@ msgstr "Küldjön levelet, ha végzett"
 #: src/olympia/zadmin/forms.py:105
 msgid "Log emails instead of sending"
 msgstr "Levelek naplózása, küldés helyett"
+
+#: src/olympia/zadmin/forms.py:215
+msgid "Deleted versions can`t be changed."
+msgstr ""
+

--- a/locale/hu/LC_MESSAGES/djangojs.po
+++ b/locale/hu/LC_MESSAGES/djangojs.po
@@ -4,136 +4,393 @@ msgid ""
 msgstr ""
 "Project-Id-Version:  \n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2016-02-24 21:23+0000\n"
+"POT-Creation-Date: 2016-04-18 15:47+0000\n"
 "PO-Revision-Date: 2016-03-02 22:10+0000\n"
 "Last-Translator: Gabor Kelemen <kelemeng@ubuntu.com>\n"
 "Language-Team: Hungarian <kde-l10n-hu@kde.org>\n"
+"Language: hu\n"
 "MIME-Version: 1.0\n"
-"Content-Type: text/plain; charset=utf-8\n"
+"Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Generated-By: Babel 2.2.0\n"
 
-#: static/js/common/ratingwidget.js:31
+#: static/js/common-all.js:1426 static/js/impala-all.js:1511 static/js/zamboni/discovery-all.js:12598 static/js/zamboni/init.js:28 static/js/zamboni/mobile-all.js:14945
+msgid "This feature is temporarily disabled while we perform website maintenance. Please check back a little later."
+msgstr "Ez a funkció a weboldal karbantartása alatt, átmenetileg nem érhető el. Kérjük, látogasson vissza kicsit később."
+
+#. L10n: {0} is an app name like Firefox.
+#: static/js/common-all.js:1837 static/js/impala-all.js:1922 static/js/zamboni/buttons.js:73 static/js/zamboni/discovery-all.js:13108
+msgid "Accept and Install"
+msgstr "Elfogadás és telepítés"
+
+#: static/js/common-all.js:1837 static/js/impala-all.js:1922 static/js/zamboni/buttons.js:73 static/js/zamboni/discovery-all.js:13108
+msgid "Add to {0}"
+msgstr "Hozzáadás ehhez: {0}"
+
+#: static/js/common-all.js:1842 static/js/impala-all.js:1927 static/js/zamboni/buttons.js:78 static/js/zamboni/discovery-all.js:13113
+msgid "Download Now"
+msgstr "Letöltés most"
+
+#: static/js/common-all.js:1883 static/js/impala-all.js:1968 static/js/zamboni/buttons.js:119 static/js/zamboni/discovery-all.js:13154
+msgid "Add-on has not been updated to support default-to-compatible."
+msgstr "A kiegészítő nem lett frissítve, hogy támogassa az alapértelmezett kompatibilitást."
+
+#: static/js/common-all.js:1888 static/js/impala-all.js:1973 static/js/zamboni/buttons.js:124 static/js/zamboni/discovery-all.js:13159
+msgid "You need to be using Firefox 10.0 or higher."
+msgstr "Firefox 10.0 vagy annál frissebb verziót kell használnia."
+
+#: static/js/common-all.js:1900 static/js/impala-all.js:1985 static/js/zamboni/buttons.js:136 static/js/zamboni/discovery-all.js:13171
+msgid "Mozilla has marked this version as incompatible with your Firefox version."
+msgstr "A Mozilla szerint ez a verzió nem működik a Firefox verziójával."
+
+#. L10n: {0} is an platform like Windows or Linux.
+#: static/js/common-all.js:1981 static/js/impala-all.js:2066 static/js/zamboni/buttons.js:217 static/js/zamboni/discovery-all.js:13252
+msgid "Install for {0} anyway"
+msgstr "Telepítés mindenképpen erre: {0}"
+
+#: static/js/common-all.js:1981 static/js/impala-all.js:2066 static/js/zamboni/buttons.js:217 static/js/zamboni/discovery-all.js:13252
+msgid "Download for {0} anyway"
+msgstr "Letöltés mindenképpen erre: {0}"
+
+#: static/js/common-all.js:2038 static/js/impala-all.js:2123 static/js/zamboni/buttons.js:274 static/js/zamboni/discovery-all.js:13309
+msgid "Not available for your platform"
+msgstr "Nem érhető el ezen a platformon"
+
+#. L10n: {0} is an app name, {1} is the app version.
+#: static/js/common-all.js:2049 static/js/common-all.js:2086 static/js/impala-all.js:2134 static/js/impala-all.js:2171 static/js/zamboni/buttons.js:286 static/js/zamboni/buttons.js:324
+#: static/js/zamboni/discovery-all.js:13320 static/js/zamboni/discovery-all.js:13357
+msgid "Not available for {0} {1}"
+msgstr "Nem érhető el a(z) {0} {1} verzióhoz"
+
+#: static/js/common-all.js:2112 static/js/impala-all.js:2197 static/js/zamboni/buttons.js:351 static/js/zamboni/discovery-all.js:13383
+msgid "Works with {app} {min} - {max}"
+msgstr "Ezzel működik: {app} {min} - {max}"
+
+#: static/js/common-all.js:2114 static/js/impala-all.js:2199 static/js/zamboni/buttons.js:353 static/js/zamboni/discovery-all.js:13385
+msgid "View other versions"
+msgstr "További verziók megtekintése"
+
+#: static/js/common-all.js:2162 static/js/impala-all.js:2247 static/js/zamboni/buttons.js:401 static/js/zamboni/discovery-all.js:13433
+msgid "Only with Firefox — Get Firefox Now!"
+msgstr "Csak a Firefoxszal – szerezze be a Firefoxot most!"
+
+#: static/js/common-all.js:2278 static/js/impala-all.js:2363 static/js/zamboni/buttons.js:517 static/js/zamboni/discovery-all.js:13549 static/js/zamboni/mobile-all.js:15177
+#: static/js/zamboni/mobile/buttons.js:43
+msgid "Sorry, you need a Mozilla-based browser (such as Firefox) to install a search plugin."
+msgstr "A keresőszolgáltatások telepítéséhez szükség van egy Mozilla-alapú böngészőre (pl. Firefox)."
+
+#: static/js/common-all.js:9088 static/js/impala-all.js:9649 static/js/zamboni/global.js:410
+msgid "Loading..."
+msgstr "Betöltés…"
+
+#. L10n: {0} is the number of characters left.
+#: static/js/common-all.js:9152 static/js/impala-all.js:9713 static/js/zamboni/global.js:474
+msgid "<b>{0}</b> character left."
+msgid_plural "<b>{0}</b> characters left."
+msgstr[0] "<b>{0}</b> karakter maradt."
+msgstr[1] "<b>{0}</b> karakter maradt."
+
+#: static/js/common-all.js:9589 static/js/common-min.js:6 static/js/impala-all.js:10052 static/js/impala-min.js:6 static/js/common/ratingwidget.js:31 static/js/zamboni/mobile-all.js:16123
+#: static/js/zamboni/mobile-min.js:6
 msgid "{0} star"
 msgid_plural "{0} stars"
 msgstr[0] "{0} csillag"
 msgstr[1] "{0} csillag"
 
-#: static/js/common/upload-addon.js:41 static/js/common/upload-image.js:128
+#: static/js/common-all.js:9676 static/js/common-min.js:6 static/js/impala-all.js:10139 static/js/impala-min.js:6 static/js/zamboni/l10n.js:45
+msgid "Remove this localization"
+msgstr "Honosítás eltávolítása"
+
+#: static/js/common-all.js:10193 static/js/common-min.js:6 static/js/impala-all.js:10674 static/js/impala-min.js:6 static/js/zamboni/discovery-all.js:13678
+msgid "close"
+msgstr ""
+
+#: static/js/common-all.js:10860 static/js/common-min.js:6 static/js/impala-all.js:11481 static/js/impala-min.js:6 static/js/impala/reviews.js:23 static/js/zamboni/reviews.js:18
+msgid "Flagged for review"
+msgstr "Vizsgálatra jelölve"
+
+#: static/js/common-all.js:10876 static/js/common-min.js:6 static/js/impala-all.js:11498 static/js/impala-min.js:6 static/js/impala/reviews.js:40 static/js/zamboni/reviews.js:34
+msgid "Your input is required"
+msgstr "Az adatok kitöltése kötelező"
+
+#: static/js/common-all.js:10945 static/js/common-min.js:6 static/js/impala-all.js:11610 static/js/impala-min.js:7 static/js/impala/reviews.js:152 static/js/zamboni/reviews.js:103
+msgid "Marked for deletion"
+msgstr "Törlésre jelölve"
+
+#: static/js/common-all.js:11573 static/js/common-min.js:7 static/js/impala-all.js:13809 static/js/impala-min.js:8 static/js/zamboni/collections.js:229
+msgid "Adding to Favorites&hellip;"
+msgstr "Hozzáadás a Kedvencekhez&hellip;"
+
+#: static/js/common-all.js:11576 static/js/common-min.js:7 static/js/impala-all.js:13812 static/js/impala-min.js:8 static/js/zamboni/collections.js:232
+msgid "Removing Favorite&hellip;"
+msgstr "Eltávolítás a Kedvencekből&hellip;"
+
+#: static/js/common-all.js:11579 static/js/common-min.js:7 static/js/impala-all.js:13815 static/js/impala-min.js:8 static/js/zamboni/collections.js:235
+msgid "Add to Favorites"
+msgstr "Hozzáadás a Kedvencekhez"
+
+#: static/js/common-all.js:11582 static/js/common-min.js:7 static/js/impala-all.js:13818 static/js/impala-min.js:8 static/js/zamboni/collections.js:238
+msgid "Remove from Favorites"
+msgstr "Eltávolítás a Kedvencekből"
+
+#: static/js/common-all.js:11647 static/js/common-min.js:7 static/js/impala-all.js:13883 static/js/impala-min.js:8 static/js/zamboni/collections.js:303
+msgid "Pending"
+msgstr "Folyamatban"
+
+#: static/js/common-all.js:11648 static/js/common-min.js:7 static/js/impala-all.js:13884 static/js/impala-min.js:8 static/js/zamboni/collections.js:304
+msgid "Add a comment"
+msgstr "Megjegyzés hozzáadása"
+
+#: static/js/common-all.js:11648 static/js/common-min.js:7 static/js/impala-all.js:13884 static/js/impala-min.js:8 static/js/zamboni/collections.js:304
+msgid "Comment"
+msgstr "Megjegyzés"
+
+#: static/js/common-all.js:11649 static/js/common-min.js:7 static/js/impala-all.js:13885 static/js/impala-min.js:8 static/js/zamboni/collections.js:305
+msgid "Remove this add-on from the collection"
+msgstr "Kiegészítő eltávolítása a gyűjteményből"
+
+#: static/js/common-all.js:11649 static/js/common-all.js:11678 static/js/common-min.js:7 static/js/impala-all.js:13885 static/js/impala-all.js:13914 static/js/impala-min.js:8
+#: static/js/zamboni/collections.js:305 static/js/zamboni/collections.js:334
+msgid "Remove"
+msgstr "Eltávolítás"
+
+#: static/js/common-all.js:11678 static/js/common-min.js:7 static/js/impala-all.js:13914 static/js/impala-min.js:8 static/js/zamboni/collections.js:334
+msgid "Remove this user as a contributor"
+msgstr "Felhasználó eltávolítása a közreműködők közül"
+
+#: static/js/common-all.js:11690 static/js/common-min.js:7 static/js/impala-all.js:13926 static/js/impala-min.js:8 static/js/zamboni/collections.js:346
+msgid "An email address is required."
+msgstr "Az e-mail cím megadása kötelező."
+
+#: static/js/common-all.js:11708 static/js/common-min.js:7 static/js/impala-all.js:13944 static/js/impala-min.js:8 static/js/zamboni/collections.js:364
+msgid "You cannot add yourself as a contributor."
+msgstr "Önmagát nem adhatja hozzá közreműködőnek."
+
+#: static/js/common-all.js:11710 static/js/common-min.js:7 static/js/impala-all.js:13946 static/js/impala-min.js:8 static/js/zamboni/collections.js:366
+msgid "You have already added that user."
+msgstr "Már hozzáadta ezt a felhasználót."
+
+#: static/js/common-all.js:11917 static/js/common-min.js:7 static/js/impala-all.js:14153 static/js/impala-min.js:8 static/js/zamboni/collections.js:573
+msgid "Add to favorites"
+msgstr "Hozzáadás a kedvencekhez"
+
+#: static/js/common-all.js:11921 static/js/common-min.js:7 static/js/impala-all.js:14157 static/js/impala-min.js:8 static/js/zamboni/collections.js:577
+msgid "Remove from favorites"
+msgstr "Eltávolítás a kedvencekből"
+
+#: static/js/common-all.js:11939 static/js/common-min.js:7 static/js/impala-all.js:14175 static/js/impala-all.js:14233 static/js/impala-min.js:8 static/js/impala/collections.js:10
+#: static/js/zamboni/collections.js:595
+msgid "Follow this Collection"
+msgstr "Gyűjtemény követése"
+
+#: static/js/common-all.js:11948 static/js/common-min.js:7 static/js/impala-all.js:14184 static/js/impala-min.js:8 static/js/zamboni/collections.js:604
+msgid "Stop following"
+msgstr "Követés megszüntetése"
+
+#: static/js/common-all.js:12096 static/js/common-min.js:7 static/js/zamboni/password-strength.js:20
+msgid "Password strength:"
+msgstr "Jelszó erőssége:"
+
+#: static/js/common-all.js:12102 static/js/common-min.js:7 static/js/zamboni/password-strength.js:26
+msgid "At least {0} character left."
+msgid_plural "At least {0} characters left."
+msgstr[0] "{0} karakter maradt."
+msgstr[1] "{0} karakter maradt."
+
+#: static/js/common-all.js:12286 static/js/common-min.js:7 static/js/impala-all.js:14632 static/js/impala-min.js:8 static/js/impala/suggestions.js:39
+msgid "Search themes for <b>{0}</b>"
+msgstr "<b>{0}</b> téma keresése"
+
+#: static/js/common-all.js:12288 static/js/common-min.js:7 static/js/impala-all.js:14634 static/js/impala-min.js:8 static/js/impala/suggestions.js:41
+msgid "Search apps for <b>{0}</b>"
+msgstr "<b>{0}</b> appok keresése"
+
+#: static/js/common-all.js:12290 static/js/common-min.js:7 static/js/impala-all.js:14636 static/js/impala-min.js:8 static/js/impala/suggestions.js:43
+msgid "Search add-ons for <b>{0}</b>"
+msgstr "<b>{0}</b> kiegészítő keresése"
+
+#: static/js/common-all.js:12521 static/js/common-min.js:7 static/js/impala-all.js:14867 static/js/impala-min.js:8 static/js/impala/site_suggestions.js:46
+msgid "Category"
+msgstr "Kategória"
+
+#. L10n: {0} is an app name.
+#: static/js/impala-all.js:11632 static/js/impala-min.js:7 static/js/impala/listing.js:11 static/js/zamboni/themes.js:13
+msgid "This theme is incompatible with your version of {0}"
+msgstr "A téma nem kompatibilis ezzel a {0} verzióval"
+
+#: static/js/impala-all.js:12146 static/js/impala-all.js:14331 static/js/impala-min.js:7 static/js/impala-min.js:8 static/js/common/upload-image.js:97 static/js/impala/users.js:51
+#: static/js/zamboni/devhub-all.js:894 static/js/zamboni/devhub-min.js:1
+msgid "Images must be either PNG or JPG."
+msgstr "Az ikonnak PNG-nek vagy JPG-nek kell lennie."
+
+#: static/js/impala-all.js:12150 static/js/impala-min.js:7 static/js/common/upload-image.js:101 static/js/zamboni/devhub-all.js:898 static/js/zamboni/devhub-min.js:1
+msgid "Videos must be in WebM."
+msgstr "A videónak WebM formátumban kell lennie."
+
+#: static/js/impala-all.js:12177 static/js/impala-min.js:7 static/js/common/upload-addon.js:41 static/js/common/upload-image.js:128 static/js/zamboni/devhub-all.js:272
+#: static/js/zamboni/devhub-all.js:925 static/js/zamboni/devhub-min.js:1
 msgid "There was a problem contacting the server."
 msgstr "Probléma történt a kiszolgálóhoz történő csatlakozás közben."
 
-#: static/js/common/upload-addon.js:69
+#: static/js/impala-all.js:13298 static/js/impala-min.js:7 static/js/impala/persona_creation.js:60
+msgid "All Rights Reserved"
+msgstr "Minden jog fenntartva"
+
+#: static/js/impala-all.js:13302 static/js/impala-min.js:7 static/js/impala/persona_creation.js:64
+msgid "Creative Commons Attribution 3.0"
+msgstr "Creative Commons – Nevezd meg! 3.0"
+
+#: static/js/impala-all.js:13307 static/js/impala-min.js:7 static/js/impala/persona_creation.js:69
+msgid "Creative Commons Attribution-NonCommercial 3.0"
+msgstr "Creative Commons – Nevezd meg! – Ne add el! 3.0"
+
+#: static/js/impala-all.js:13312 static/js/impala-min.js:7 static/js/impala/persona_creation.js:74
+msgid "Creative Commons Attribution-NonCommercial-NoDerivs 3.0"
+msgstr "Creative Commons – Nevezd meg! – Ne add el! – Ne változtasd! 3.0"
+
+#: static/js/impala-all.js:13317 static/js/impala-min.js:7 static/js/impala/persona_creation.js:79
+msgid "Creative Commons Attribution-NonCommercial-Share Alike 3.0"
+msgstr "Creative Commons – Nevezd meg! – Ne add el! – Így add tovább! 3.0"
+
+#: static/js/impala-all.js:13322 static/js/impala-min.js:7 static/js/impala/persona_creation.js:84
+msgid "Creative Commons Attribution-NoDerivs 3.0"
+msgstr "Creative Commons – Nevezd meg! – Ne változtasd! 3.0"
+
+#: static/js/impala-all.js:13327 static/js/impala-min.js:7 static/js/impala/persona_creation.js:89
+msgid "Creative Commons Attribution-ShareAlike 3.0"
+msgstr "Creative Commons – Nevezd meg! – Így add tovább! 3.0"
+
+#: static/js/impala-all.js:13530 static/js/impala-min.js:7 static/js/impala/persona_creation.js:292
+msgid "Your Theme's Name"
+msgstr "Téma neve"
+
+#: static/js/impala-all.js:14242 static/js/impala-min.js:8 static/js/impala/collections.js:19
+msgid "Stop Following"
+msgstr "Követés leállítása"
+
+#: static/js/impala-all.js:14243 static/js/impala-min.js:8 static/js/impala/collections.js:20
+msgid "Following"
+msgstr "Követés"
+
+#: static/js/impala-all.js:14313 static/js/impala-min.js:8 static/js/impala/users.js:33
+msgid "use original"
+msgstr "eredeti használata"
+
+#: static/js/impala-all.js:14523 static/js/impala-min.js:8 static/js/impala/search.js:114
+msgid "Updating results&hellip;"
+msgstr "Eredmény frissítése&hellip;"
+
+#: static/js/common/upload-addon.js:69 static/js/zamboni/devhub-all.js:300 static/js/zamboni/devhub-min.js:1
 msgid "Select a file..."
 msgstr "Fájl kiválasztása…"
 
-#: static/js/common/upload-addon.js:70
+#: static/js/common/upload-addon.js:70 static/js/zamboni/devhub-all.js:301 static/js/zamboni/devhub-min.js:1
 msgid "Your add-on should end with .xpi, .jar or .xml"
 msgstr "A kiegészítőnek .xpi, .jar vagy .xml kiterjesztésűnek kell lennie"
 
 #. L10n: {0} is the percent of the file that has been uploaded.
-#: static/js/common/upload-addon.js:104
+#: static/js/common/upload-addon.js:104 static/js/zamboni/devhub-all.js:335 static/js/zamboni/devhub-min.js:1
 #, python-format
 msgid "{0}% complete"
 msgstr "{0}% kész"
 
 #. L10n: "{bytes uploaded} of {total filesize}".
-#: static/js/common/upload-addon.js:107
+#: static/js/common/upload-addon.js:107 static/js/zamboni/devhub-all.js:338 static/js/zamboni/devhub-min.js:1
 msgid "{0} of {1}"
 msgstr "{0} / {1}"
 
-#: static/js/common/upload-addon.js:140
+#: static/js/common/upload-addon.js:140 static/js/zamboni/devhub-all.js:371 static/js/zamboni/devhub-min.js:1
 msgid "Cancel"
 msgstr "Mégsem"
 
-#: static/js/common/upload-addon.js:162
+#: static/js/common/upload-addon.js:162 static/js/zamboni/devhub-all.js:393 static/js/zamboni/devhub-min.js:1
 msgid "Uploading {0}"
 msgstr "{0} feltöltése"
 
-#: static/js/common/upload-addon.js:189
+#: static/js/common/upload-addon.js:189 static/js/zamboni/devhub-all.js:420 static/js/zamboni/devhub-min.js:1
 msgid "Error with {0}"
 msgstr "Hiba ezzel: {0}"
 
-#: static/js/common/upload-addon.js:194
+#: static/js/common/upload-addon.js:194 static/js/zamboni/devhub-all.js:425 static/js/zamboni/devhub-min.js:1
 msgid "Your add-on failed validation with {0} error."
 msgid_plural "Your add-on failed validation with {0} errors."
 msgstr[0] "A kiegészítő az ellenőrzése {0} hiba miatt sikertelen."
 msgstr[1] "A kiegészítő az ellenőrzése {0} hiba miatt sikertelen."
 
-#: static/js/common/upload-addon.js:208
+#: static/js/common/upload-addon.js:208 static/js/zamboni/devhub-all.js:439 static/js/zamboni/devhub-min.js:1
 msgid "&hellip;and {0} more"
 msgid_plural "&hellip;and {0} more"
 msgstr[0] "&hellip; és további {0}"
 msgstr[1] "&hellip; és további {0}"
 
-#: static/js/common/upload-addon.js:222 static/js/common/upload-addon.js:512
+#: static/js/common/upload-addon.js:222 static/js/common/upload-addon.js:497 static/js/zamboni/devhub-all.js:453 static/js/zamboni/devhub-all.js:743 static/js/zamboni/devhub-min.js:1
 msgid "See full validation report"
 msgstr "Teljes ellenőrzési jelentés megjelenítése"
 
-#: static/js/common/upload-addon.js:234
+#: static/js/common/upload-addon.js:234 static/js/zamboni/devhub-all.js:465 static/js/zamboni/devhub-min.js:1
 msgid "Validating {0}"
 msgstr "{0} ellenőrzése"
 
 #. L10n: first argument is an HTTP status code
-#: static/js/common/upload-addon.js:273
+#: static/js/common/upload-addon.js:273 static/js/zamboni/devhub-all.js:504 static/js/zamboni/devhub-min.js:1
 msgid "Received an empty response from the server; status: {0}"
 msgstr "Üres válasz érkezett a kiszolgálótól; állapot: {0}"
 
-#: static/js/common/upload-addon.js:373
+#: static/js/common/upload-addon.js:370 static/js/zamboni/devhub-all.js:604 static/js/zamboni/devhub-min.js:1
 msgid "Unexpected server error while validating."
 msgstr "Az ellenőrzés közben váratlan hiba történt."
 
-#: static/js/common/upload-addon.js:412
+#: static/js/common/upload-addon.js:409 static/js/zamboni/devhub-all.js:643 static/js/zamboni/devhub-min.js:1
 msgid "Finished validating {0}"
 msgstr "{0} ellenőrzése befejeződött"
 
-#: static/js/common/upload-addon.js:418
+#: static/js/common/upload-addon.js:415 static/js/zamboni/devhub-all.js:649 static/js/zamboni/devhub-min.js:1
 msgid "Your add-on validation timed out, it will be manually reviewed."
 msgstr "Időtúllépés történt a kiegészítő érvényesítése közben, kézi felülvizsgálatra kerül."
 
-#: static/js/common/upload-addon.js:421
+#: static/js/common/upload-addon.js:418 static/js/zamboni/devhub-all.js:652 static/js/zamboni/devhub-min.js:1
 msgid "Your add-on was validated with no errors and {0} warning."
 msgid_plural "Your add-on was validated with no errors and {0} warnings."
 msgstr[0] "A kiegészítő hiba nélkül és {0} figyelmeztetéssel átment az ellenőrzésen."
 msgstr[1] "A kiegészítő hiba nélkül és {0} figyelmeztetéssel átment az ellenőrzésen."
 
-#: static/js/common/upload-addon.js:426
+#: static/js/common/upload-addon.js:423 static/js/zamboni/devhub-all.js:657 static/js/zamboni/devhub-min.js:1
 msgid "Your add-on was validated with no errors and {0} message."
 msgid_plural "Your add-on was validated with no errors and {0} messages."
 msgstr[0] "A kiegészítő hiba nélkül és {0} üzenettel átment az ellenőrzésen."
 msgstr[1] "A kiegészítő hiba nélkül és {0} üzenettel átment az ellenőrzésen."
 
-#: static/js/common/upload-addon.js:431
+#: static/js/common/upload-addon.js:428 static/js/zamboni/devhub-all.js:662 static/js/zamboni/devhub-min.js:1
 msgid "Your add-on was validated with no errors or warnings."
 msgstr "A kiegészítő hiba és figyelmeztetés nélkül átment az ellenőrzésen."
 
-#: static/js/common/upload-addon.js:446
+#: static/js/common/upload-addon.js:443 static/js/zamboni/devhub-all.js:677 static/js/zamboni/devhub-min.js:1
 msgid "Your submission will be automatically signed."
 msgstr "A benyújtása aláírására automatikusan sor kerül."
 
-#: static/js/common/upload-addon.js:465
+#: static/js/common/upload-addon.js:450 static/js/zamboni/devhub-all.js:696 static/js/zamboni/devhub-min.js:1
 msgid "Include detailed version notes (this can be done in the next step)."
 msgstr "Adjon meg részletes verzióinformációt (ezt a következő lépésben is megteheti)."
 
-#: static/js/common/upload-addon.js:466
+#: static/js/common/upload-addon.js:451 static/js/zamboni/devhub-all.js:697 static/js/zamboni/devhub-min.js:1
 msgid "If your add-on requires an account to a website in order to be fully tested, include a test username and password in the Notes to Reviewer (this can be done in the next step)."
 msgstr ""
 "Ha a kiegészítőnek egy weboldalhoz tartozó felhasználói fiókra van szüksége a teljes teszteléshez, adjon meg egy teszt felhasználónevet és jelszót a Megjegyzés a vizsgálatot végzőknek résznél (ezt "
 "a következő lépésben is megteheti)."
 
-#: static/js/common/upload-addon.js:467
+#: static/js/common/upload-addon.js:452 static/js/zamboni/devhub-all.js:698 static/js/zamboni/devhub-min.js:1
 msgid "If your add-on is intended for a limited audience you should choose Preliminary Review instead of Full Review."
 msgstr "Ha a kiegészítő korlátozott közönség számára készült, válassza az Előzetes vizsgálatot a Teljes vizsgálat helyett."
 
-#: static/js/common/upload-addon.js:480
+#: static/js/common/upload-addon.js:465 static/js/zamboni/devhub-all.js:711 static/js/zamboni/devhub-min.js:1
 msgid "Add-on submission checklist"
 msgstr "Ellenőrzőlista kiegészítő beküldéséhez"
 
-#: static/js/common/upload-addon.js:481
+#: static/js/common/upload-addon.js:466 static/js/zamboni/devhub-all.js:712 static/js/zamboni/devhub-min.js:1
 msgid "Please verify the following points before finalizing your submission. This will minimize delays or misunderstanding during the review process:"
 msgstr "Kérjük, ellenőrizze a következő pontokat, mielőtt befejezi a beküldést. Ez csökkenti a vizsgálathoz szükséges időt és a félreértéseket:"
 
-#: static/js/common/upload-addon.js:483
+#: static/js/common/upload-addon.js:468 static/js/zamboni/devhub-all.js:714 static/js/zamboni/devhub-min.js:1
 msgid ""
 "Compiled binaries, as well as minified or obfuscated scripts (excluding known libraries) need to have their sources submitted separately for review. Make sure that you use the source code upload "
 "field to avoid having your submission rejected."
@@ -141,1080 +398,844 @@ msgstr ""
 "A lefordított binárisoknak, mint ahogyan a minimalizált vagy olvashatatlanná tett parancsfájloknak is (kivéve az ismert könyvtárakat) külön kell beküldeni a forrását ellenőrzésre. Használja a "
 "forráskódfeltöltés mezőt, hogy elkerülje a beküldés visszautasítását."
 
-#: static/js/common/upload-addon.js:501
+#: static/js/common/upload-addon.js:486 static/js/zamboni/devhub-all.js:732 static/js/zamboni/devhub-min.js:1
 msgid "The validation process found these issues that can lead to rejections:"
 msgstr "Az ellenőrzési folyamat ezeket a problémákat találta, amik elutasításhoz vezethetnek:"
 
-#: static/js/common/upload-addon.js:518
+#: static/js/common/upload-addon.js:503 static/js/zamboni/devhub-all.js:749 static/js/zamboni/devhub-min.js:1
 msgid "If you are unfamiliar with the add-ons review process, you can read about it here."
 msgstr "Ha nem ismeri a bővítmény-ellenőrzési folyamatot, itt olvashat róla."
 
-#: static/js/common/upload-addon.js:555
+#: static/js/common/upload-addon.js:540 static/js/zamboni/devhub-all.js:786 static/js/zamboni/devhub-min.js:1
 msgid "Sorry, no supported platform has been found."
 msgstr "Elnézést, nem található támogatott platform."
 
-#: static/js/common/upload-base.js:57
+#: static/js/common/upload-base.js:57 static/js/zamboni/devhub-all.js:187 static/js/zamboni/devhub-min.js:1
 msgid "The filetype you uploaded isn't recognized."
 msgstr "A feltöltött fájl típusa nem ismerhető fel."
 
-#: static/js/common/upload-base.js:79
+#: static/js/common/upload-base.js:79 static/js/zamboni/devhub-all.js:209 static/js/zamboni/devhub-min.js:1
 msgid "You cancelled the upload."
 msgstr "A feltöltés megszakítva."
 
-#: static/js/common/upload-image.js:97 static/js/impala/users.js:51
-msgid "Images must be either PNG or JPG."
-msgstr "Az ikonnak PNG-nek vagy JPG-nek kell lennie."
-
-#: static/js/common/upload-image.js:101
-msgid "Videos must be in WebM."
-msgstr "A videónak WebM formátumban kell lennie."
-
-#: static/js/impala/collections.js:10 static/js/zamboni/collections.js:595
-msgid "Follow this Collection"
-msgstr "Gyűjtemény követése"
-
-#: static/js/impala/collections.js:19
-msgid "Stop Following"
-msgstr "Követés leállítása"
-
-#: static/js/impala/collections.js:20
-msgid "Following"
-msgstr "Követés"
-
-#. L10n: {0} is an app name.
-#: static/js/impala/listing.js:11 static/js/zamboni/themes.js:13
-msgid "This theme is incompatible with your version of {0}"
-msgstr "A téma nem kompatibilis ezzel a {0} verzióval"
-
-#: static/js/impala/persona_creation.js:60
-msgid "All Rights Reserved"
-msgstr "Minden jog fenntartva"
-
-#: static/js/impala/persona_creation.js:64
-msgid "Creative Commons Attribution 3.0"
-msgstr "Creative Commons – Nevezd meg! 3.0"
-
-#: static/js/impala/persona_creation.js:69
-msgid "Creative Commons Attribution-NonCommercial 3.0"
-msgstr "Creative Commons – Nevezd meg! – Ne add el! 3.0"
-
-#: static/js/impala/persona_creation.js:74
-msgid "Creative Commons Attribution-NonCommercial-NoDerivs 3.0"
-msgstr "Creative Commons – Nevezd meg! – Ne add el! – Ne változtasd! 3.0"
-
-#: static/js/impala/persona_creation.js:79
-msgid "Creative Commons Attribution-NonCommercial-Share Alike 3.0"
-msgstr "Creative Commons – Nevezd meg! – Ne add el! – Így add tovább! 3.0"
-
-#: static/js/impala/persona_creation.js:84
-msgid "Creative Commons Attribution-NoDerivs 3.0"
-msgstr "Creative Commons – Nevezd meg! – Ne változtasd! 3.0"
-
-#: static/js/impala/persona_creation.js:89
-msgid "Creative Commons Attribution-ShareAlike 3.0"
-msgstr "Creative Commons – Nevezd meg! – Így add tovább! 3.0"
-
-#: static/js/impala/persona_creation.js:292
-msgid "Your Theme's Name"
-msgstr "Téma neve"
-
-#: static/js/impala/reviews.js:23 static/js/zamboni/reviews.js:18
-msgid "Flagged for review"
-msgstr "Vizsgálatra jelölve"
-
-#: static/js/impala/reviews.js:40 static/js/zamboni/reviews.js:34
-msgid "Your input is required"
-msgstr "Az adatok kitöltése kötelező"
-
-#: static/js/impala/reviews.js:152 static/js/zamboni/reviews.js:103
-msgid "Marked for deletion"
-msgstr "Törlésre jelölve"
-
-#: static/js/impala/search.js:114
-msgid "Updating results&hellip;"
-msgstr "Eredmény frissítése&hellip;"
-
-#: static/js/impala/site_suggestions.js:46
-msgid "Category"
-msgstr "Kategória"
-
-#: static/js/impala/suggestions.js:39
-msgid "Search themes for <b>{0}</b>"
-msgstr "<b>{0}</b> téma keresése"
-
-#: static/js/impala/suggestions.js:41
-msgid "Search apps for <b>{0}</b>"
-msgstr "<b>{0}</b> appok keresése"
-
-#: static/js/impala/suggestions.js:43
-msgid "Search add-ons for <b>{0}</b>"
-msgstr "<b>{0}</b> kiegészítő keresése"
-
-#: static/js/impala/users.js:33
-msgid "use original"
-msgstr "eredeti használata"
-
-#: static/js/impala/stats/chart.js:267
+#: static/js/impala/stats/chart.js:267 static/js/zamboni/stats-all.js:16898 static/js/zamboni/stats-min.js:5
 msgid "Week of {0}"
 msgstr "{0}. hét"
 
-#: static/js/impala/stats/chart.js:269
+#: static/js/impala/stats/chart.js:269 static/js/zamboni/stats-all.js:16900 static/js/zamboni/stats-min.js:5
 msgid " downloads"
-msgstr " letöltés"
+msgstr ""
 
-#: static/js/impala/stats/chart.js:270
+#: static/js/impala/stats/chart.js:270 static/js/zamboni/stats-all.js:16901 static/js/zamboni/stats-min.js:5
 msgid "{0} users"
 msgstr "{0} felhasználó"
 
-#: static/js/impala/stats/chart.js:271
+#: static/js/impala/stats/chart.js:271 static/js/zamboni/stats-all.js:16902 static/js/zamboni/stats-min.js:5
 msgid "{0} add-ons"
 msgstr "{0} kiegészítő"
 
-#: static/js/impala/stats/chart.js:272
+#: static/js/impala/stats/chart.js:272 static/js/zamboni/stats-all.js:16903 static/js/zamboni/stats-min.js:5
 msgid "{0} collections"
 msgstr "{0} gyűjtemény"
 
-#: static/js/impala/stats/chart.js:273
+#: static/js/impala/stats/chart.js:273 static/js/zamboni/stats-all.js:16904 static/js/zamboni/stats-min.js:5
 msgid "{0} reviews"
 msgstr "{0} értékelés"
 
-#: static/js/impala/stats/chart.js:275
+#: static/js/impala/stats/chart.js:275 static/js/zamboni/stats-all.js:16906 static/js/zamboni/stats-min.js:5
 msgid "{0} sales"
 msgstr "{0} eladás"
 
-#: static/js/impala/stats/chart.js:276
+#: static/js/impala/stats/chart.js:276 static/js/zamboni/stats-all.js:16907 static/js/zamboni/stats-min.js:5
 msgid "{0} refunds"
 msgstr "{0} visszatérítés"
 
-#: static/js/impala/stats/chart.js:277
+#: static/js/impala/stats/chart.js:277 static/js/zamboni/stats-all.js:16908 static/js/zamboni/stats-min.js:5
 msgid "{0} installs"
 msgstr "{0} telepítés"
 
-#: static/js/impala/stats/chart.js:369 static/js/impala/stats/csv_keys.js:3 static/js/impala/stats/csv_keys.js:109
+#: static/js/impala/stats/chart.js:369 static/js/impala/stats/csv_keys.js:3 static/js/impala/stats/csv_keys.js:109 static/js/zamboni/stats-all.js:15284 static/js/zamboni/stats-all.js:15390
+#: static/js/zamboni/stats-all.js:17000 static/js/zamboni/stats-min.js:4 static/js/zamboni/stats-min.js:5
 msgid "Downloads"
 msgstr "Letöltések"
 
-#: static/js/impala/stats/chart.js:379 static/js/impala/stats/csv_keys.js:6 static/js/impala/stats/csv_keys.js:110
+#: static/js/impala/stats/chart.js:379 static/js/impala/stats/csv_keys.js:6 static/js/impala/stats/csv_keys.js:110 static/js/zamboni/stats-all.js:15287 static/js/zamboni/stats-all.js:15391
+#: static/js/zamboni/stats-all.js:17010 static/js/zamboni/stats-min.js:4 static/js/zamboni/stats-min.js:5
 msgid "Daily Users"
 msgstr "Napi felhasználók"
 
-#: static/js/impala/stats/chart.js:410
+#: static/js/impala/stats/chart.js:410 static/js/zamboni/stats-all.js:17041 static/js/zamboni/stats-min.js:5
 msgid "Amount, in USD"
 msgstr "Mennyiség, USD-ben"
 
-#: static/js/impala/stats/chart.js:421 static/js/impala/stats/csv_keys.js:104
+#: static/js/impala/stats/chart.js:421 static/js/impala/stats/csv_keys.js:104 static/js/zamboni/stats-all.js:15385 static/js/zamboni/stats-all.js:17052 static/js/zamboni/stats-min.js:5
 msgid "Number of Contributions"
 msgstr "Hozzájárulások száma"
 
-#: static/js/impala/stats/chart.js:447
+#: static/js/impala/stats/chart.js:447 static/js/zamboni/stats-all.js:17078 static/js/zamboni/stats-min.js:5
 msgid "More Info..."
 msgstr "Tovább…"
 
 #. L10n: {0} is an ISO-formatted date.
-#: static/js/impala/stats/chart.js:451
+#: static/js/impala/stats/chart.js:451 static/js/zamboni/stats-all.js:17082 static/js/zamboni/stats-min.js:5
 msgid "Details for {0}"
 msgstr "{0} részletei"
 
-#: static/js/impala/stats/csv_keys.js:9
+#: static/js/impala/stats/csv_keys.js:9 static/js/zamboni/stats-all.js:15290 static/js/zamboni/stats-min.js:4
 msgid "Collections Created"
 msgstr "Létrehozott gyűjtemények"
 
-#: static/js/impala/stats/csv_keys.js:12
+#: static/js/impala/stats/csv_keys.js:12 static/js/zamboni/stats-all.js:15293 static/js/zamboni/stats-min.js:4
 msgid "Add-ons in Use"
 msgstr "Használt kiegészítők"
 
-#: static/js/impala/stats/csv_keys.js:15
+#: static/js/impala/stats/csv_keys.js:15 static/js/zamboni/stats-all.js:15296 static/js/zamboni/stats-min.js:4
 msgid "Add-ons Created"
 msgstr "Létrehozott kiegészítők"
 
-#: static/js/impala/stats/csv_keys.js:18
+#: static/js/impala/stats/csv_keys.js:18 static/js/zamboni/stats-all.js:15299 static/js/zamboni/stats-min.js:4
 msgid "Add-ons Downloaded"
 msgstr "Letöltött kiegészítők"
 
-#: static/js/impala/stats/csv_keys.js:21
+#: static/js/impala/stats/csv_keys.js:21 static/js/zamboni/stats-all.js:15302 static/js/zamboni/stats-min.js:4
 msgid "Add-ons Updated"
 msgstr "Frissített kiegészítők"
 
-#: static/js/impala/stats/csv_keys.js:24
+#: static/js/impala/stats/csv_keys.js:24 static/js/zamboni/stats-all.js:15305 static/js/zamboni/stats-min.js:4
 msgid "Reviews Written"
 msgstr "Megírt értékelések"
 
-#: static/js/impala/stats/csv_keys.js:27
+#: static/js/impala/stats/csv_keys.js:27 static/js/zamboni/stats-all.js:15308 static/js/zamboni/stats-min.js:4
 msgid "User Signups"
 msgstr "Regisztrációk"
 
-#: static/js/impala/stats/csv_keys.js:30
+#: static/js/impala/stats/csv_keys.js:30 static/js/zamboni/stats-all.js:15311 static/js/zamboni/stats-min.js:4
 msgid "Subscribers"
 msgstr "Feliratkozók"
 
-#: static/js/impala/stats/csv_keys.js:33
+#: static/js/impala/stats/csv_keys.js:33 static/js/zamboni/stats-all.js:15314 static/js/zamboni/stats-min.js:4
 msgid "Ratings"
 msgstr "Értékelések"
 
-#: static/js/impala/stats/csv_keys.js:36 static/js/impala/stats/csv_keys.js:114
+#: static/js/impala/stats/csv_keys.js:36 static/js/impala/stats/csv_keys.js:114 static/js/zamboni/stats-all.js:15317 static/js/zamboni/stats-all.js:15395 static/js/zamboni/stats-min.js:4
+#: static/js/zamboni/stats-min.js:5
 msgid "Sales"
 msgstr "Eladások"
 
-#: static/js/impala/stats/csv_keys.js:39 static/js/impala/stats/csv_keys.js:113
+#: static/js/impala/stats/csv_keys.js:39 static/js/impala/stats/csv_keys.js:113 static/js/zamboni/stats-all.js:15320 static/js/zamboni/stats-all.js:15394 static/js/zamboni/stats-min.js:4
+#: static/js/zamboni/stats-min.js:5
 msgid "Installs"
 msgstr "Telepítések"
 
-#: static/js/impala/stats/csv_keys.js:42
+#: static/js/impala/stats/csv_keys.js:42 static/js/zamboni/stats-all.js:15323 static/js/zamboni/stats-min.js:4
 msgid "Unknown"
 msgstr "Ismeretlen"
 
-#: static/js/impala/stats/csv_keys.js:43
+#: static/js/impala/stats/csv_keys.js:43 static/js/zamboni/stats-all.js:15324 static/js/zamboni/stats-min.js:4
 msgid "Add-ons Manager"
 msgstr "Kiegészítőkezelő"
 
-#: static/js/impala/stats/csv_keys.js:44
+#: static/js/impala/stats/csv_keys.js:44 static/js/zamboni/stats-all.js:15325 static/js/zamboni/stats-min.js:4
 msgid "Add-ons Manager Promo"
 msgstr "Kiegészítőkezelő – bemutató"
 
-#: static/js/impala/stats/csv_keys.js:45
+#: static/js/impala/stats/csv_keys.js:45 static/js/zamboni/stats-all.js:15326 static/js/zamboni/stats-min.js:4
 msgid "Add-ons Manager Featured"
 msgstr "Kiegészítőkezelő – kiemelt kiegészítők"
 
-#: static/js/impala/stats/csv_keys.js:46
+#: static/js/impala/stats/csv_keys.js:46 static/js/zamboni/stats-all.js:15327 static/js/zamboni/stats-min.js:4
 msgid "Add-ons Manager Learn More"
 msgstr "Kiegészítőkezelő – tudjon meg többet"
 
-#: static/js/impala/stats/csv_keys.js:47
+#: static/js/impala/stats/csv_keys.js:47 static/js/zamboni/stats-all.js:15328 static/js/zamboni/stats-min.js:4
 msgid "Search Suggestions"
 msgstr "Keresési javaslatok"
 
-#: static/js/impala/stats/csv_keys.js:48
+#: static/js/impala/stats/csv_keys.js:48 static/js/zamboni/stats-all.js:15329 static/js/zamboni/stats-min.js:4
 msgid "Search Results"
 msgstr "Keresési eredmények"
 
-#: static/js/impala/stats/csv_keys.js:49 static/js/impala/stats/csv_keys.js:50 static/js/impala/stats/csv_keys.js:51
+#: static/js/impala/stats/csv_keys.js:49 static/js/impala/stats/csv_keys.js:50 static/js/impala/stats/csv_keys.js:51 static/js/zamboni/stats-all.js:15330 static/js/zamboni/stats-all.js:15331
+#: static/js/zamboni/stats-all.js:15332 static/js/zamboni/stats-min.js:4
 msgid "Homepage Promo"
 msgstr "Kezdőlap – bemutató"
 
-#: static/js/impala/stats/csv_keys.js:52 static/js/impala/stats/csv_keys.js:53
+#: static/js/impala/stats/csv_keys.js:52 static/js/impala/stats/csv_keys.js:53 static/js/zamboni/stats-all.js:15333 static/js/zamboni/stats-all.js:15334 static/js/zamboni/stats-min.js:4
 msgid "Homepage Featured"
 msgstr "Kiemelt kezdőlap"
 
-#: static/js/impala/stats/csv_keys.js:54 static/js/impala/stats/csv_keys.js:55
+#: static/js/impala/stats/csv_keys.js:54 static/js/impala/stats/csv_keys.js:55 static/js/zamboni/stats-all.js:15335 static/js/zamboni/stats-all.js:15336 static/js/zamboni/stats-min.js:4
 msgid "Homepage Up and Coming"
 msgstr "Ígéretes kezdőlap"
 
-#: static/js/impala/stats/csv_keys.js:56
+#: static/js/impala/stats/csv_keys.js:56 static/js/zamboni/stats-all.js:15337 static/js/zamboni/stats-min.js:4
 msgid "Homepage Most Popular"
 msgstr "Legnépszerűbb kezdőlap"
 
-#: static/js/impala/stats/csv_keys.js:57 static/js/impala/stats/csv_keys.js:59
+#: static/js/impala/stats/csv_keys.js:57 static/js/impala/stats/csv_keys.js:59 static/js/zamboni/stats-all.js:15338 static/js/zamboni/stats-all.js:15340 static/js/zamboni/stats-min.js:4
 msgid "Detail Page"
 msgstr "Részletek oldal"
 
-#: static/js/impala/stats/csv_keys.js:58 static/js/impala/stats/csv_keys.js:60
+#: static/js/impala/stats/csv_keys.js:58 static/js/impala/stats/csv_keys.js:60 static/js/zamboni/stats-all.js:15339 static/js/zamboni/stats-all.js:15341 static/js/zamboni/stats-min.js:4
 msgid "Detail Page (bottom)"
 msgstr "Részletek oldal (alul)"
 
-#: static/js/impala/stats/csv_keys.js:61
+#: static/js/impala/stats/csv_keys.js:61 static/js/zamboni/stats-all.js:15342 static/js/zamboni/stats-min.js:4
 msgid "Detail Page (Development Channel)"
 msgstr "Részletek oldal (Fejlesztői csatorna)"
 
-#: static/js/impala/stats/csv_keys.js:62 static/js/impala/stats/csv_keys.js:63 static/js/impala/stats/csv_keys.js:64
+#: static/js/impala/stats/csv_keys.js:62 static/js/impala/stats/csv_keys.js:63 static/js/impala/stats/csv_keys.js:64 static/js/zamboni/stats-all.js:15343 static/js/zamboni/stats-all.js:15344
+#: static/js/zamboni/stats-all.js:15345 static/js/zamboni/stats-min.js:4
 msgid "Often Used With"
 msgstr "Gyakran használt ezzel:"
 
-#: static/js/impala/stats/csv_keys.js:65 static/js/impala/stats/csv_keys.js:66
+#: static/js/impala/stats/csv_keys.js:65 static/js/impala/stats/csv_keys.js:66 static/js/zamboni/stats-all.js:15346 static/js/zamboni/stats-all.js:15347 static/js/zamboni/stats-min.js:4
 msgid "Others By Author"
 msgstr "A szerző további munkái"
 
-#: static/js/impala/stats/csv_keys.js:67 static/js/impala/stats/csv_keys.js:68
+#: static/js/impala/stats/csv_keys.js:67 static/js/impala/stats/csv_keys.js:68 static/js/zamboni/stats-all.js:15348 static/js/zamboni/stats-all.js:15349 static/js/zamboni/stats-min.js:4
 msgid "Dependencies"
 msgstr "Függőségek"
 
-#: static/js/impala/stats/csv_keys.js:69 static/js/impala/stats/csv_keys.js:70
+#: static/js/impala/stats/csv_keys.js:69 static/js/impala/stats/csv_keys.js:70 static/js/zamboni/stats-all.js:15350 static/js/zamboni/stats-all.js:15351 static/js/zamboni/stats-min.js:4
 msgid "Upsell"
 msgstr "Bővítés"
 
-#: static/js/impala/stats/csv_keys.js:71
+#: static/js/impala/stats/csv_keys.js:71 static/js/zamboni/stats-all.js:15352 static/js/zamboni/stats-min.js:4
 msgid "Meet the Developer"
 msgstr "Ismerje meg a fejlesztőt"
 
-#: static/js/impala/stats/csv_keys.js:72
+#: static/js/impala/stats/csv_keys.js:72 static/js/zamboni/stats-all.js:15353 static/js/zamboni/stats-min.js:4
 msgid "User Profile"
 msgstr "Felhasználói profil"
 
-#: static/js/impala/stats/csv_keys.js:73
+#: static/js/impala/stats/csv_keys.js:73 static/js/zamboni/stats-all.js:15354 static/js/zamboni/stats-min.js:4
 msgid "Version History"
 msgstr "Verziótörténet"
 
-#: static/js/impala/stats/csv_keys.js:75
+#: static/js/impala/stats/csv_keys.js:75 static/js/zamboni/stats-all.js:15356 static/js/zamboni/stats-min.js:4
 msgid "Sharing"
 msgstr "Megosztás"
 
-#: static/js/impala/stats/csv_keys.js:76
+#: static/js/impala/stats/csv_keys.js:76 static/js/zamboni/stats-all.js:15357 static/js/zamboni/stats-min.js:4
 msgid "Category Pages"
 msgstr "Kategória oldalak"
 
-#: static/js/impala/stats/csv_keys.js:77
+#: static/js/impala/stats/csv_keys.js:77 static/js/zamboni/stats-all.js:15358 static/js/zamboni/stats-min.js:4
 msgid "Collections"
 msgstr "Gyűjtemények"
 
-#: static/js/impala/stats/csv_keys.js:78 static/js/impala/stats/csv_keys.js:79
+#: static/js/impala/stats/csv_keys.js:78 static/js/impala/stats/csv_keys.js:79 static/js/zamboni/stats-all.js:15359 static/js/zamboni/stats-all.js:15360 static/js/zamboni/stats-min.js:4
 msgid "Category Landing Featured Carousel"
 msgstr "Kategória nyitólap kiemelt körhinta"
 
-#: static/js/impala/stats/csv_keys.js:80 static/js/impala/stats/csv_keys.js:81
+#: static/js/impala/stats/csv_keys.js:80 static/js/impala/stats/csv_keys.js:81 static/js/zamboni/stats-all.js:15361 static/js/zamboni/stats-all.js:15362 static/js/zamboni/stats-min.js:4
 msgid "Category Landing Top Rated"
 msgstr "Kategória nyitólap legjobb értékelés"
 
-#: static/js/impala/stats/csv_keys.js:82 static/js/impala/stats/csv_keys.js:83
+#: static/js/impala/stats/csv_keys.js:82 static/js/impala/stats/csv_keys.js:83 static/js/zamboni/stats-all.js:15363 static/js/zamboni/stats-all.js:15364 static/js/zamboni/stats-min.js:5
 msgid "Category Landing Most Popular"
 msgstr "Kategória nyitólap legnépszerűbb"
 
-#: static/js/impala/stats/csv_keys.js:84 static/js/impala/stats/csv_keys.js:85
+#: static/js/impala/stats/csv_keys.js:84 static/js/impala/stats/csv_keys.js:85 static/js/zamboni/stats-all.js:15365 static/js/zamboni/stats-all.js:15366 static/js/zamboni/stats-min.js:5
 msgid "Category Landing Recently Added"
 msgstr "Kategória nyitólap nemrég hozzáadott"
 
-#: static/js/impala/stats/csv_keys.js:86 static/js/impala/stats/csv_keys.js:87
+#: static/js/impala/stats/csv_keys.js:86 static/js/impala/stats/csv_keys.js:87 static/js/zamboni/stats-all.js:15367 static/js/zamboni/stats-all.js:15368 static/js/zamboni/stats-min.js:5
 msgid "Browse Listing Featured Sort"
 msgstr "„Kiemelt” böngészési lista rendezése"
 
-#: static/js/impala/stats/csv_keys.js:88 static/js/impala/stats/csv_keys.js:89
+#: static/js/impala/stats/csv_keys.js:88 static/js/impala/stats/csv_keys.js:89 static/js/zamboni/stats-all.js:15369 static/js/zamboni/stats-all.js:15370 static/js/zamboni/stats-min.js:5
 msgid "Browse Listing Users Sort"
 msgstr "„Felhasználók” böngészési lista rendezése"
 
-#: static/js/impala/stats/csv_keys.js:90 static/js/impala/stats/csv_keys.js:91
+#: static/js/impala/stats/csv_keys.js:90 static/js/impala/stats/csv_keys.js:91 static/js/zamboni/stats-all.js:15371 static/js/zamboni/stats-all.js:15372 static/js/zamboni/stats-min.js:5
 msgid "Browse Listing Rating Sort"
 msgstr "„Értékelés” böngészési lista rendezése"
 
-#: static/js/impala/stats/csv_keys.js:92 static/js/impala/stats/csv_keys.js:93
+#: static/js/impala/stats/csv_keys.js:92 static/js/impala/stats/csv_keys.js:93 static/js/zamboni/stats-all.js:15373 static/js/zamboni/stats-all.js:15374 static/js/zamboni/stats-min.js:5
 msgid "Browse Listing Created Sort"
 msgstr "„Létrehozva” böngészési lista rendezése"
 
-#: static/js/impala/stats/csv_keys.js:94 static/js/impala/stats/csv_keys.js:95
+#: static/js/impala/stats/csv_keys.js:94 static/js/impala/stats/csv_keys.js:95 static/js/zamboni/stats-all.js:15375 static/js/zamboni/stats-all.js:15376 static/js/zamboni/stats-min.js:5
 msgid "Browse Listing Name Sort"
 msgstr "„Név” böngészési lista rendezése"
 
-#: static/js/impala/stats/csv_keys.js:96 static/js/impala/stats/csv_keys.js:97
+#: static/js/impala/stats/csv_keys.js:96 static/js/impala/stats/csv_keys.js:97 static/js/zamboni/stats-all.js:15377 static/js/zamboni/stats-all.js:15378 static/js/zamboni/stats-min.js:5
 msgid "Browse Listing Popular Sort"
 msgstr "„Legnépszerűbb” böngészési lista rendezése"
 
-#: static/js/impala/stats/csv_keys.js:98 static/js/impala/stats/csv_keys.js:99
+#: static/js/impala/stats/csv_keys.js:98 static/js/impala/stats/csv_keys.js:99 static/js/zamboni/stats-all.js:15379 static/js/zamboni/stats-all.js:15380 static/js/zamboni/stats-min.js:5
 msgid "Browse Listing Updated Sort"
 msgstr "„Frissítve” böngészési lista rendezése"
 
-#: static/js/impala/stats/csv_keys.js:100 static/js/impala/stats/csv_keys.js:101
+#: static/js/impala/stats/csv_keys.js:100 static/js/impala/stats/csv_keys.js:101 static/js/zamboni/stats-all.js:15381 static/js/zamboni/stats-all.js:15382 static/js/zamboni/stats-min.js:5
 msgid "Browse Listing Up and Coming Sort"
 msgstr "„Ígéretes” böngészési lista rendezése"
 
-#: static/js/impala/stats/csv_keys.js:105
+#: static/js/impala/stats/csv_keys.js:105 static/js/zamboni/stats-all.js:15386 static/js/zamboni/stats-min.js:5
 msgid "Total Amount Contributed"
 msgstr "Teljes adomány"
 
-#: static/js/impala/stats/csv_keys.js:106
+#: static/js/impala/stats/csv_keys.js:106 static/js/zamboni/stats-all.js:15387 static/js/zamboni/stats-min.js:5
 msgid "Average Contribution"
 msgstr "Átlagos adomány"
 
-#: static/js/impala/stats/csv_keys.js:115
+#: static/js/impala/stats/csv_keys.js:115 static/js/zamboni/stats-all.js:15396 static/js/zamboni/stats-min.js:5
 msgid "Usage"
 msgstr "Használat"
 
-#: static/js/impala/stats/csv_keys.js:118
+#: static/js/impala/stats/csv_keys.js:118 static/js/zamboni/stats-all.js:15399 static/js/zamboni/stats-min.js:5
 msgid "Firefox"
 msgstr "Firefox"
 
-#: static/js/impala/stats/csv_keys.js:119
+#: static/js/impala/stats/csv_keys.js:119 static/js/zamboni/stats-all.js:15400 static/js/zamboni/stats-min.js:5
 msgid "Mozilla"
 msgstr "Mozilla"
 
-#: static/js/impala/stats/csv_keys.js:120
+#: static/js/impala/stats/csv_keys.js:120 static/js/zamboni/stats-all.js:15401 static/js/zamboni/stats-min.js:5
 msgid "Thunderbird"
 msgstr "Thunderbird"
 
-#: static/js/impala/stats/csv_keys.js:121
+#: static/js/impala/stats/csv_keys.js:121 static/js/zamboni/stats-all.js:15402 static/js/zamboni/stats-min.js:5
 msgid "Sunbird"
 msgstr "Sunbird"
 
-#: static/js/impala/stats/csv_keys.js:122
+#: static/js/impala/stats/csv_keys.js:122 static/js/zamboni/stats-all.js:15403 static/js/zamboni/stats-min.js:5
 msgid "SeaMonkey"
 msgstr "SeaMonkey"
 
-#: static/js/impala/stats/csv_keys.js:123
+#: static/js/impala/stats/csv_keys.js:123 static/js/zamboni/stats-all.js:15404 static/js/zamboni/stats-min.js:5
 msgid "Fennec"
 msgstr "Fennec"
 
-#: static/js/impala/stats/csv_keys.js:124
+#: static/js/impala/stats/csv_keys.js:124 static/js/zamboni/stats-all.js:15405 static/js/zamboni/stats-min.js:5
 msgid "Android"
 msgstr "Android"
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:129
+#: static/js/impala/stats/csv_keys.js:129 static/js/zamboni/stats-all.js:15410 static/js/zamboni/stats-min.js:5
 msgid "Downloads and Daily Users, last {0} days"
 msgstr "Letöltések és felhasználók az elmúlt {0} napban"
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:131
+#: static/js/impala/stats/csv_keys.js:131 static/js/zamboni/stats-all.js:15412 static/js/zamboni/stats-min.js:5
 msgid "Downloads and Daily Users from {0} to {1}"
 msgstr "Letöltések és felhasználók {0} és {1} között"
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:135
+#: static/js/impala/stats/csv_keys.js:135 static/js/zamboni/stats-all.js:15416 static/js/zamboni/stats-min.js:5
 msgid "Installs and Daily Users, last {0} days"
 msgstr "Telepítések és felhasználók az elmúlt {0} napban"
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:137
+#: static/js/impala/stats/csv_keys.js:137 static/js/zamboni/stats-all.js:15418 static/js/zamboni/stats-min.js:5
 msgid "Installs and Daily Users from {0} to {1}"
 msgstr "Letöltések és felhasználók {0} és {1} között"
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:141
+#: static/js/impala/stats/csv_keys.js:141 static/js/zamboni/stats-all.js:15422 static/js/zamboni/stats-min.js:5
 msgid "Downloads, last {0} days"
 msgstr "Letöltések az elmúlt {0} napban"
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:143
+#: static/js/impala/stats/csv_keys.js:143 static/js/zamboni/stats-all.js:15424 static/js/zamboni/stats-min.js:5
 msgid "Downloads from {0} to {1}"
 msgstr "Letöltések {0} és {1} között"
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:147
+#: static/js/impala/stats/csv_keys.js:147 static/js/zamboni/stats-all.js:15428 static/js/zamboni/stats-min.js:5
 msgid "Daily Users, last {0} days"
 msgstr "Felhasználók az elmúlt {0} napban"
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:149
+#: static/js/impala/stats/csv_keys.js:149 static/js/zamboni/stats-all.js:15430 static/js/zamboni/stats-min.js:5
 msgid "Daily Users from {0} to {1}"
 msgstr "Felhasználók {0} és {1} között"
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:153
+#: static/js/impala/stats/csv_keys.js:153 static/js/zamboni/stats-all.js:15434 static/js/zamboni/stats-min.js:5
 msgid "Applications, last {0} days"
 msgstr "Alkalmazások az elmúlt {0} napban"
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:155
+#: static/js/impala/stats/csv_keys.js:155 static/js/zamboni/stats-all.js:15436 static/js/zamboni/stats-min.js:5
 msgid "Applications from {0} to {1}"
 msgstr "Alkalmazások {0} és {1} között"
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:159
+#: static/js/impala/stats/csv_keys.js:159 static/js/zamboni/stats-all.js:15440 static/js/zamboni/stats-min.js:5
 msgid "Platforms, last {0} days"
 msgstr "Platformok az elmúlt {0} napban"
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:161
+#: static/js/impala/stats/csv_keys.js:161 static/js/zamboni/stats-all.js:15442 static/js/zamboni/stats-min.js:5
 msgid "Platforms from {0} to {1}"
 msgstr "Platformok {0} és {1} között"
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:165
+#: static/js/impala/stats/csv_keys.js:165 static/js/zamboni/stats-all.js:15446 static/js/zamboni/stats-min.js:5
 msgid "Languages, last {0} days"
 msgstr "Nyelvek az elmúlt {0} napban"
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:167
+#: static/js/impala/stats/csv_keys.js:167 static/js/zamboni/stats-all.js:15448 static/js/zamboni/stats-min.js:5
 msgid "Languages from {0} to {1}"
 msgstr "Nyelvek {0} és {1} között"
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:171
+#: static/js/impala/stats/csv_keys.js:171 static/js/zamboni/stats-all.js:15452 static/js/zamboni/stats-min.js:5
 msgid "Add-on Versions, last {0} days"
 msgstr "Kiegészítő verziói az elmúlt {0} napban"
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:173
+#: static/js/impala/stats/csv_keys.js:173 static/js/zamboni/stats-all.js:15454 static/js/zamboni/stats-min.js:5
 msgid "Add-on Versions from {0} to {1}"
 msgstr "Kiegészítő verziói {0} és {1} között"
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:177
+#: static/js/impala/stats/csv_keys.js:177 static/js/zamboni/stats-all.js:15458 static/js/zamboni/stats-min.js:5
 msgid "Add-on Status, last {0} days"
 msgstr "Kiegészítő állapota az elmúlt {0} napban"
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:179
+#: static/js/impala/stats/csv_keys.js:179 static/js/zamboni/stats-all.js:15460 static/js/zamboni/stats-min.js:5
 msgid "Add-on Status from {0} to {1}"
 msgstr "Kiegészítő állapota {0} és {1} között"
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:183
+#: static/js/impala/stats/csv_keys.js:183 static/js/zamboni/stats-all.js:15464 static/js/zamboni/stats-min.js:5
 msgid "Download Sources, last {0} days"
 msgstr "Letöltési források az elmúlt {0} napban"
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:185
+#: static/js/impala/stats/csv_keys.js:185 static/js/zamboni/stats-all.js:15466 static/js/zamboni/stats-min.js:5
 msgid "Download Sources from {0} to {1}"
 msgstr "Letöltési források {0} és {1} között"
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:189
+#: static/js/impala/stats/csv_keys.js:189 static/js/zamboni/stats-all.js:15470 static/js/zamboni/stats-min.js:5
 msgid "Contributions, last {0} days"
 msgstr "Adományok az elmúlt {0} napban"
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:191
+#: static/js/impala/stats/csv_keys.js:191 static/js/zamboni/stats-all.js:15472 static/js/zamboni/stats-min.js:5
 msgid "Contributions from {0} to {1}"
 msgstr "Adományok {0} és {1} között"
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:195
+#: static/js/impala/stats/csv_keys.js:195 static/js/zamboni/stats-all.js:15476 static/js/zamboni/stats-min.js:5
 msgid "Site Metrics, last {0} days"
 msgstr "Oldal metrikái az elmúlt {0} napban"
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:197
+#: static/js/impala/stats/csv_keys.js:197 static/js/zamboni/stats-all.js:15478 static/js/zamboni/stats-min.js:5
 msgid "Site Metrics from {0} to {1}"
 msgstr "Oldal metrikái {0} és {1} között"
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:201
+#: static/js/impala/stats/csv_keys.js:201 static/js/zamboni/stats-all.js:15482 static/js/zamboni/stats-min.js:5
 msgid "Add-ons in Use, last {0} days"
 msgstr "Használt kiegészítők száma az elmúlt {0} napban"
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:203
+#: static/js/impala/stats/csv_keys.js:203 static/js/zamboni/stats-all.js:15484 static/js/zamboni/stats-min.js:5
 msgid "Add-ons in Use from {0} to {1}"
 msgstr "Használt kiegészítők száma {0} és {1} között"
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:207
+#: static/js/impala/stats/csv_keys.js:207 static/js/zamboni/stats-all.js:15488 static/js/zamboni/stats-min.js:5
 msgid "Add-ons Downloaded, last {0} days"
 msgstr "Letöltött kiegészítők száma az elmúlt {0} napban"
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:209
+#: static/js/impala/stats/csv_keys.js:209 static/js/zamboni/stats-all.js:15490 static/js/zamboni/stats-min.js:5
 msgid "Add-ons Downloaded from {0} to {1}"
 msgstr "Letöltött kiegészítők száma {0} és {1} között"
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:213
+#: static/js/impala/stats/csv_keys.js:213 static/js/zamboni/stats-all.js:15494 static/js/zamboni/stats-min.js:5
 msgid "Add-ons Created, last {0} days"
 msgstr "Létrehozott kiegészítők száma az elmúlt {0} napban"
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:215
+#: static/js/impala/stats/csv_keys.js:215 static/js/zamboni/stats-all.js:15496 static/js/zamboni/stats-min.js:5
 msgid "Add-ons Created from {0} to {1}"
 msgstr "Létrehozott kiegészítők száma {0} és {1} között"
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:219
+#: static/js/impala/stats/csv_keys.js:219 static/js/zamboni/stats-all.js:15500 static/js/zamboni/stats-min.js:5
 msgid "Add-ons Updated, last {0} days"
 msgstr "Frissített kiegészítők száma az elmúlt {0} napban"
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:221
+#: static/js/impala/stats/csv_keys.js:221 static/js/zamboni/stats-all.js:15502 static/js/zamboni/stats-min.js:5
 msgid "Add-ons Updated from {0} to {1}"
 msgstr "Frissített kiegészítők száma {0} és {1} között"
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:225
+#: static/js/impala/stats/csv_keys.js:225 static/js/zamboni/stats-all.js:15506 static/js/zamboni/stats-min.js:5
 msgid "Reviews Written, last {0} days"
 msgstr "Megírt értékelések száma az elmúlt {0} napban"
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:227
+#: static/js/impala/stats/csv_keys.js:227 static/js/zamboni/stats-all.js:15508 static/js/zamboni/stats-min.js:5
 msgid "Reviews Written from {0} to {1}"
 msgstr "Megírt értékelések száma {0} és {1} között"
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:231
+#: static/js/impala/stats/csv_keys.js:231 static/js/zamboni/stats-all.js:15512 static/js/zamboni/stats-min.js:5
 msgid "User Signups, last {0} days"
 msgstr "Regisztrációk száma az elmúlt {0} napban"
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:233
+#: static/js/impala/stats/csv_keys.js:233 static/js/zamboni/stats-all.js:15514 static/js/zamboni/stats-min.js:5
 msgid "User Signups from {0} to {1}"
 msgstr "Regisztrációk száma {0} és {1} között"
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:237
+#: static/js/impala/stats/csv_keys.js:237 static/js/zamboni/stats-all.js:15518 static/js/zamboni/stats-min.js:5
 msgid "Collections Created, last {0} days"
 msgstr "Létrehozott gyűjtemények az elmúlt {0} napban"
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:239
+#: static/js/impala/stats/csv_keys.js:239 static/js/zamboni/stats-all.js:15520 static/js/zamboni/stats-min.js:5
 msgid "Collections Created from {0} to {1}"
 msgstr "Létrehozott gyűjtemények {0} és {1} között"
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:243
+#: static/js/impala/stats/csv_keys.js:243 static/js/zamboni/stats-all.js:15524 static/js/zamboni/stats-min.js:5
 msgid "Subscribers, last {0} days"
 msgstr "Feliratkozók az elmúlt {0} napban"
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:245
+#: static/js/impala/stats/csv_keys.js:245 static/js/zamboni/stats-all.js:15526 static/js/zamboni/stats-min.js:5
 msgid "Subscribers from {0} to {1}"
 msgstr "Feliratkozók {0} és {1} között"
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:249
+#: static/js/impala/stats/csv_keys.js:249 static/js/zamboni/stats-all.js:15530 static/js/zamboni/stats-min.js:5
 msgid "Ratings, last {0} days"
 msgstr "Értékelések az elmúlt {0} napban"
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:251
+#: static/js/impala/stats/csv_keys.js:251 static/js/zamboni/stats-all.js:15532 static/js/zamboni/stats-min.js:5
 msgid "Ratings from {0} to {1}"
 msgstr "Értékelések {0} és {1} között"
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:255
+#: static/js/impala/stats/csv_keys.js:255 static/js/zamboni/stats-all.js:15536 static/js/zamboni/stats-min.js:5
 msgid "Sales, last {0} days"
 msgstr "Eladások az elmúlt {0} napban"
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:257
+#: static/js/impala/stats/csv_keys.js:257 static/js/zamboni/stats-all.js:15538 static/js/zamboni/stats-min.js:5
 msgid "Sales from {0} to {1}"
 msgstr "Eladások {0} és {1} között"
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:261
+#: static/js/impala/stats/csv_keys.js:261 static/js/zamboni/stats-all.js:15542 static/js/zamboni/stats-min.js:5
 msgid "Installs, last {0} days"
 msgstr "Telepítések az elmúlt {0} napban"
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:263
+#: static/js/impala/stats/csv_keys.js:263 static/js/zamboni/stats-all.js:15544 static/js/zamboni/stats-min.js:5
 msgid "Installs from {0} to {1}"
 msgstr "Telepítések száma {0} és {1} között"
 
 #. L10n: {0} and {1} are integers.
-#: static/js/impala/stats/csv_keys.js:269
+#: static/js/impala/stats/csv_keys.js:269 static/js/zamboni/stats-all.js:15550 static/js/zamboni/stats-min.js:5
 msgid "<b>{0}</b> in last {1} days"
 msgstr "<b>{0}</b> az utolsó {1} napban"
 
 #. L10n: {0} is an integer and {1} and {2} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:271 static/js/impala/stats/csv_keys.js:277
+#: static/js/impala/stats/csv_keys.js:271 static/js/impala/stats/csv_keys.js:277 static/js/zamboni/stats-all.js:15552 static/js/zamboni/stats-all.js:15558 static/js/zamboni/stats-min.js:5
 msgid "<b>{0}</b> from {1} to {2}"
 msgstr "<b>{0}</b> {1} és {2} között"
 
 #. L10n: {0} and {1} are integers.
-#: static/js/impala/stats/csv_keys.js:275
+#: static/js/impala/stats/csv_keys.js:275 static/js/zamboni/stats-all.js:15556 static/js/zamboni/stats-min.js:5
 msgid "<b>{0}</b> average in last {1} days"
 msgstr "átlagosan <b>{0}</b> az elmúlt {1} napban"
 
-#: static/js/impala/stats/overview.js:19
+#: static/js/impala/stats/overview.js:19 static/js/zamboni/stats-all.js:16469 static/js/zamboni/stats-min.js:5
 msgid "No data available."
 msgstr "Nincs dátum."
 
-#: static/js/impala/stats/table.js:74
+#: static/js/impala/stats/table.js:74 static/js/zamboni/stats-all.js:17209 static/js/zamboni/stats-min.js:5
 msgid "Date"
 msgstr "Dátum"
 
-#: static/js/impala/stats/topchart.js:96
+#: static/js/impala/stats/topchart.js:96 static/js/zamboni/stats-all.js:16600 static/js/zamboni/stats-min.js:5
 msgid "Other"
 msgstr "Egyéb"
 
-#: static/js/zamboni/admin_validation.js:24 static/js/zamboni/devhub.js:1229 static/js/zamboni/editors.js:295
+#: static/js/zamboni/admin-all.js:180 static/js/zamboni/admin-min.js:1 static/js/zamboni/admin_validation.js:24 static/js/zamboni/devhub-all.js:2408 static/js/zamboni/devhub-min.js:2
+#: static/js/zamboni/devhub.js:1229 static/js/zamboni/editors-all.js:15576 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:295
 msgid "Select an application first"
 msgstr "Először válasszon ki alkalmazást"
 
-#: static/js/zamboni/admin_validation.js:51
+#: static/js/zamboni/admin-all.js:207 static/js/zamboni/admin-min.js:1 static/js/zamboni/admin_validation.js:51
 msgid "Set {0} add-on to a max version of {1} and email the author."
 msgid_plural "Set {0} add-ons to a max version of {1} and email the authors."
 msgstr[0] "{0} kiegészítő beállítása {1} legmagasabb verzióra, és levélküldés a szerzőnek."
 msgstr[1] "{0} kiegészítők beállítása {1} legmagasabb verzióra, és levélküldés a szerzőknek."
 
-#: static/js/zamboni/admin_validation.js:54
+#: static/js/zamboni/admin-all.js:210 static/js/zamboni/admin-min.js:1 static/js/zamboni/admin_validation.js:54
 msgid "Email author of {2} add-on which failed validation."
 msgid_plural "Email authors of {2} add-ons which failed validation."
 msgstr[0] "E-mail küldése a(z) {2} kiegészítő szerzőjének, amely nem mentek át az ellenőrzésen."
 msgstr[1] "E-mail küldése a(z) {2} kiegészítők szerzőjének, amelyek nem mentek át az ellenőrzésen."
 
-#. L10n: {0} is an app name like Firefox.
-#: static/js/zamboni/buttons.js:66
-msgid "Accept and Install"
-msgstr "Elfogadás és telepítés"
-
-#: static/js/zamboni/buttons.js:66
-msgid "Add to {0}"
-msgstr "Hozzáadás ehhez: {0}"
-
-#: static/js/zamboni/buttons.js:71
-msgid "Download Now"
-msgstr "Letöltés most"
-
-#: static/js/zamboni/buttons.js:112
-msgid "Add-on has not been updated to support default-to-compatible."
-msgstr "A kiegészítő nem lett frissítve, hogy támogassa az alapértelmezett kompatibilitást."
-
-#: static/js/zamboni/buttons.js:117
-msgid "You need to be using Firefox 10.0 or higher."
-msgstr "Firefox 10.0 vagy annál frissebb verziót kell használnia."
-
-#: static/js/zamboni/buttons.js:129
-msgid "Mozilla has marked this version as incompatible with your Firefox version."
-msgstr "A Mozilla szerint ez a verzió nem működik a Firefox verziójával."
-
-#. L10n: {0} is an platform like Windows or Linux.
-#: static/js/zamboni/buttons.js:210
-msgid "Install for {0} anyway"
-msgstr "Telepítés mindenképpen erre: {0}"
-
-#: static/js/zamboni/buttons.js:210
-msgid "Download for {0} anyway"
-msgstr "Letöltés mindenképpen erre: {0}"
-
-#: static/js/zamboni/buttons.js:267
-msgid "Not available for your platform"
-msgstr "Nem érhető el ezen a platformon"
-
-#. L10n: {0} is an app name, {1} is the app version.
-#: static/js/zamboni/buttons.js:278 static/js/zamboni/buttons.js:315
-msgid "Not available for {0} {1}"
-msgstr "Nem érhető el a(z) {0} {1} verzióhoz"
-
-#: static/js/zamboni/buttons.js:341
-msgid "Works with {app} {min} - {max}"
-msgstr "Ezzel működik: {app} {min} - {max}"
-
-#: static/js/zamboni/buttons.js:343
-msgid "View other versions"
-msgstr "További verziók megtekintése"
-
-#: static/js/zamboni/buttons.js:391
-msgid "Only with Firefox — Get Firefox Now!"
-msgstr "Csak a Firefoxszal – szerezze be a Firefoxot most!"
-
-#: static/js/zamboni/buttons.js:507 static/js/zamboni/mobile/buttons.js:43
-msgid "Sorry, you need a Mozilla-based browser (such as Firefox) to install a search plugin."
-msgstr "A keresőszolgáltatások telepítéséhez szükség van egy Mozilla-alapú böngészőre (pl. Firefox)."
-
-#: static/js/zamboni/collections.js:229
-msgid "Adding to Favorites&hellip;"
-msgstr "Hozzáadás a Kedvencekhez&hellip;"
-
-#: static/js/zamboni/collections.js:232
-msgid "Removing Favorite&hellip;"
-msgstr "Eltávolítás a Kedvencekből&hellip;"
-
-#: static/js/zamboni/collections.js:235
-msgid "Add to Favorites"
-msgstr "Hozzáadás a Kedvencekhez"
-
-#: static/js/zamboni/collections.js:238
-msgid "Remove from Favorites"
-msgstr "Eltávolítás a Kedvencekből"
-
-#: static/js/zamboni/collections.js:303
-msgid "Pending"
-msgstr "Folyamatban"
-
-#: static/js/zamboni/collections.js:304
-msgid "Add a comment"
-msgstr "Megjegyzés hozzáadása"
-
-#: static/js/zamboni/collections.js:304
-msgid "Comment"
-msgstr "Megjegyzés"
-
-#: static/js/zamboni/collections.js:305
-msgid "Remove this add-on from the collection"
-msgstr "Kiegészítő eltávolítása a gyűjteményből"
-
-#: static/js/zamboni/collections.js:305 static/js/zamboni/collections.js:334
-msgid "Remove"
-msgstr "Eltávolítás"
-
-#: static/js/zamboni/collections.js:334
-msgid "Remove this user as a contributor"
-msgstr "Felhasználó eltávolítása a közreműködők közül"
-
-#: static/js/zamboni/collections.js:346
-msgid "An email address is required."
-msgstr "Az e-mail cím megadása kötelező."
-
-#: static/js/zamboni/collections.js:364
-msgid "You cannot add yourself as a contributor."
-msgstr "Önmagát nem adhatja hozzá közreműködőnek."
-
-#: static/js/zamboni/collections.js:366
-msgid "You have already added that user."
-msgstr "Már hozzáadta ezt a felhasználót."
-
-#: static/js/zamboni/collections.js:573
-msgid "Add to favorites"
-msgstr "Hozzáadás a kedvencekhez"
-
-#: static/js/zamboni/collections.js:577
-msgid "Remove from favorites"
-msgstr "Eltávolítás a kedvencekből"
-
-#: static/js/zamboni/collections.js:604
-msgid "Stop following"
-msgstr "Követés megszüntetése"
-
-#: static/js/zamboni/devhub.js:110
+#: static/js/zamboni/devhub-all.js:1289 static/js/zamboni/devhub-min.js:1 static/js/zamboni/devhub.js:110
 msgid "Your browser does not support the video tag"
 msgstr "A böngésző nem támogatja a video elemet"
 
-#: static/js/zamboni/devhub.js:371
+#: static/js/zamboni/devhub-all.js:1550 static/js/zamboni/devhub-min.js:1 static/js/zamboni/devhub.js:371
 msgid "Changes Saved"
 msgstr "Változások lementve"
 
-#: static/js/zamboni/devhub.js:387
+#: static/js/zamboni/devhub-all.js:1566 static/js/zamboni/devhub-min.js:1 static/js/zamboni/devhub.js:387
 msgid "Enter a new author's email address"
 msgstr "Adja meg az új szerző e-mailcímét"
 
-#: static/js/zamboni/devhub.js:536
+#: static/js/zamboni/devhub-all.js:1715 static/js/zamboni/devhub-min.js:1 static/js/zamboni/devhub.js:536
 msgid "There was an error uploading your file."
 msgstr "Hiba történt a fájl feltöltésekor."
 
-#: static/js/zamboni/devhub.js:681
+#: static/js/zamboni/devhub-all.js:1860 static/js/zamboni/devhub-min.js:1 static/js/zamboni/devhub.js:681
 msgid "{files} file"
 msgid_plural "{files} files"
 msgstr[0] "{files} fájl"
 msgstr[1] "{files} fájl"
 
-#: static/js/zamboni/devhub.js:684
+#: static/js/zamboni/devhub-all.js:1863 static/js/zamboni/devhub-min.js:1 static/js/zamboni/devhub.js:684
 msgid "{reviews} user review"
 msgid_plural "{reviews} user reviews"
 msgstr[0] "{reviews} felhasználói értékelés"
 msgstr[1] "{reviews} felhasználói értékelés"
 
-#: static/js/zamboni/devhub.js:796
+#: static/js/zamboni/devhub-all.js:1975 static/js/zamboni/devhub-min.js:2 static/js/zamboni/devhub.js:796
 msgid "Learn more"
 msgstr "Tudjon meg többet"
 
-#: static/js/zamboni/devhub.js:800
+#: static/js/zamboni/devhub-all.js:1979 static/js/zamboni/devhub-min.js:2 static/js/zamboni/devhub.js:800
 msgid "Example"
 msgstr "Példa"
 
-#: static/js/zamboni/devhub.js:1130
+#: static/js/zamboni/devhub-all.js:2309 static/js/zamboni/devhub-min.js:2 static/js/zamboni/devhub.js:1130
 msgid "Image changes being processed"
 msgstr "A kép módosítása folyamatban van"
 
-#: static/js/zamboni/devhub.js:1280
+#: static/js/zamboni/devhub-all.js:2459 static/js/zamboni/devhub-min.js:2 static/js/zamboni/devhub.js:1280
 msgid "Must be a valid e-mail address."
 msgstr "Érvényes e-mail címnek kell lennie."
 
-#: static/js/zamboni/devhub_search.js:8
-msgid "No results found."
-msgstr "Nincs találat."
-
-#: static/js/zamboni/editors.js:121
-msgid "{name} was viewing this page first."
-msgstr "{name} nézte meg először az oldalt."
-
-#: static/js/zamboni/editors.js:171
-msgid "Receipt checked by app."
-msgstr "Az app ellenőrizte a fogadást."
-
-#: static/js/zamboni/editors.js:173
-msgid "Receipt was not checked by app."
-msgstr "Az app nem ellenőrizte a fogadást."
-
-#: static/js/zamboni/editors.js:244
-msgid "{name} was viewing this add-on first."
-msgstr "{name} nézte meg először a kiegészítőt."
-
-#: static/js/zamboni/editors.js:255
-msgid "Loading&hellip;"
-msgstr "Betöltés&hellip;"
-
-#: static/js/zamboni/editors.js:260
-msgid "Version Notes"
-msgstr "Megjegyzések a verzióhoz"
-
-#: static/js/zamboni/editors.js:265
-msgid "Notes for Reviewers"
-msgstr "Megjegyzés a vizsgálatot végzőknek"
-
-#: static/js/zamboni/editors.js:270
-msgid "No version notes found"
-msgstr "Nincsenek megjegyzések a verzióhoz"
-
-#: static/js/zamboni/editors.js:330
-msgid "Average Reviews"
-msgstr "Átlagos értékelések"
-
-#: static/js/zamboni/editors.js:386
-msgid "Number of Reviews"
-msgstr "Értékelések száma"
-
-#: static/js/zamboni/editors.js:445
-msgid "Error loading translation"
-msgstr "Hiba a fordítás betöltésekor"
-
-#: static/js/zamboni/files.js:411 static/js/zamboni/validator.js:261
-msgid "Ignore this message in future updates"
-msgstr "Ezt az üzenetet a jövőbeli frissítéseknél hagyja figyelmen kívül"
-
-#: static/js/zamboni/files.js:417 static/js/zamboni/validator.js:284
-msgid "Severity for automated signing:"
-msgstr "Súlyosság (az automatikus aláíráshoz):"
-
-#: static/js/zamboni/global.js:410
-msgid "Loading..."
-msgstr "Betöltés…"
-
-#. L10n: {0} is the number of characters left.
-#: static/js/zamboni/global.js:474
-msgid "<b>{0}</b> character left."
-msgid_plural "<b>{0}</b> characters left."
-msgstr[0] "<b>{0}</b> karakter maradt."
-msgstr[1] "<b>{0}</b> karakter maradt."
-
-#: static/js/zamboni/init.js:28
-msgid "This feature is temporarily disabled while we perform website maintenance. Please check back a little later."
-msgstr "Ez a funkció a weboldal karbantartása alatt, átmenetileg nem érhető el. Kérjük, látogasson vissza kicsit később."
-
-#: static/js/zamboni/l10n.js:45
-msgid "Remove this localization"
-msgstr "Honosítás eltávolítása"
-
-#: static/js/zamboni/password-strength.js:20
-msgid "Password strength:"
-msgstr "Jelszó erőssége:"
-
-#: static/js/zamboni/password-strength.js:26
-msgid "At least {0} character left."
-msgid_plural "At least {0} characters left."
-msgstr[0] "{0} karakter maradt."
-msgstr[1] "{0} karakter maradt."
-
-#: static/js/zamboni/themes_review.js:176
-msgid "Requested Info"
-msgstr "Kért információ"
-
-#: static/js/zamboni/themes_review.js:177
-msgid "Flagged"
-msgstr "Megjelölt"
-
-#: static/js/zamboni/themes_review.js:178
-msgid "Duplicate"
-msgstr "Másolat"
-
-#: static/js/zamboni/themes_review.js:179
-msgid "Rejected"
-msgstr "Elutasított"
-
-#: static/js/zamboni/themes_review.js:180
-msgid "Approved"
-msgstr "Jóváhagyott"
-
-#: static/js/zamboni/themes_review.js:424
-msgid "No results found"
-msgstr "Nincs találat"
-
-#: static/js/zamboni/themes_review_templates.js:31
-msgid "Theme"
-msgstr "Téma"
-
-#: static/js/zamboni/themes_review_templates.js:33
-msgid "Reviewer"
-msgstr "Véleményező"
-
-#: static/js/zamboni/themes_review_templates.js:35
-msgid "Status"
-msgstr "Állapot"
-
-#: static/js/zamboni/validator.js:80
+#: static/js/zamboni/devhub-all.js:2613 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:80
 msgid "All tests passed successfully."
 msgstr "Az összes teszten sikeresen átment."
 
-#: static/js/zamboni/validator.js:83 static/js/zamboni/validator.js:478
+#: static/js/zamboni/devhub-all.js:2616 static/js/zamboni/devhub-all.js:3011 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:83 static/js/zamboni/validator.js:478
 msgid "These tests were not run."
 msgstr "Ezek a tesztek nem futottak le."
 
-#: static/js/zamboni/validator.js:131 static/js/zamboni/validator.js:144
+#: static/js/zamboni/devhub-all.js:2664 static/js/zamboni/devhub-all.js:2677 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:131 static/js/zamboni/validator.js:144
 msgid "Tests"
 msgstr "Tesztek"
 
-#: static/js/zamboni/validator.js:246 static/js/zamboni/validator.js:575 static/js/zamboni/validator.js:594
+#: static/js/zamboni/devhub-all.js:2779 static/js/zamboni/devhub-all.js:3108 static/js/zamboni/devhub-all.js:3127 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:246
+#: static/js/zamboni/validator.js:575 static/js/zamboni/validator.js:594
 msgid "Error"
 msgstr "Hiba"
 
-#: static/js/zamboni/validator.js:247
+#: static/js/zamboni/devhub-all.js:2780 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:247
 msgid "Warning"
 msgstr "Figyelmeztetés"
 
-#: static/js/zamboni/validator.js:299
+#: static/js/zamboni/devhub-all.js:2794 static/js/zamboni/devhub-min.js:2 static/js/zamboni/files-all.js:5657 static/js/zamboni/files-min.js:3 static/js/zamboni/files.js:411
+#: static/js/zamboni/validator.js:261
+msgid "Ignore this message in future updates"
+msgstr "Ezt az üzenetet a jövőbeli frissítéseknél hagyja figyelmen kívül"
+
+#: static/js/zamboni/devhub-all.js:2817 static/js/zamboni/devhub-min.js:2 static/js/zamboni/files-all.js:5663 static/js/zamboni/files-min.js:3 static/js/zamboni/files.js:417
+#: static/js/zamboni/validator.js:284
+msgid "Severity for automated signing:"
+msgstr "Súlyosság (az automatikus aláíráshoz):"
+
+#: static/js/zamboni/devhub-all.js:2832 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:299
 msgid "Suggestions for passing automated signing:"
 msgstr "Javaslatok az automatizált aláírás teljesítéséhez:"
 
-#: static/js/zamboni/validator.js:387
+#: static/js/zamboni/devhub-all.js:2920 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:387
 msgid "Compatibility Tests"
 msgstr "Kompatibilitás tesztek"
 
-#: static/js/zamboni/validator.js:466
+#: static/js/zamboni/devhub-all.js:2999 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:466
 msgid "Add-on failed validation."
 msgstr "A kiegészítő nem ment át a vizsgálaton."
 
-#: static/js/zamboni/validator.js:468
+#: static/js/zamboni/devhub-all.js:3001 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:468
 msgid "Add-on passed validation."
 msgstr "A kiegészítő átment a vizsgálaton."
 
-#: static/js/zamboni/validator.js:481
+#: static/js/zamboni/devhub-all.js:3014 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:481
 msgid "{0} error"
 msgid_plural "{0} errors"
 msgstr[0] "{0} hiba"
 msgstr[1] "{0} hiba"
 
-#: static/js/zamboni/validator.js:483
+#: static/js/zamboni/devhub-all.js:3016 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:483
 msgid "{0} warning"
 msgid_plural "{0} warnings"
 msgstr[0] "{0} figyelmeztetés"
 msgstr[1] "{0} figyelmeztetés"
 
-#: static/js/zamboni/validator.js:485
+#: static/js/zamboni/devhub-all.js:3018 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:485
 msgid "{0} notice"
 msgid_plural "{0} notices"
 msgstr[0] "{0} értesítés"
 msgstr[1] "{0} értesítés"
 
-#: static/js/zamboni/validator.js:577
+#: static/js/zamboni/devhub-all.js:3110 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:577
 msgid "Validation task could not complete or completed with errors"
 msgstr "Az ellenőrzés nem fejeződött be vagy hibát okozott"
 
-#: static/js/zamboni/validator.js:595
+#: static/js/zamboni/devhub-all.js:3128 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:595
 msgid "Internal server error"
 msgstr "Belső kiszolgálóhiba"
 
-#: static/js/zamboni/mobile/buttons.js:52
+#: static/js/zamboni/devhub_search.js:8
+msgid "No results found."
+msgstr "Nincs találat."
+
+#: static/js/zamboni/editors-all.js:15402 static/js/zamboni/editors-min.js:4 static/js/zamboni/editors.js:121
+msgid "{name} was viewing this page first."
+msgstr "{name} nézte meg először az oldalt."
+
+#: static/js/zamboni/editors-all.js:15452 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:171
+msgid "Receipt checked by app."
+msgstr "Az app ellenőrizte a fogadást."
+
+#: static/js/zamboni/editors-all.js:15454 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:173
+msgid "Receipt was not checked by app."
+msgstr "Az app nem ellenőrizte a fogadást."
+
+#: static/js/zamboni/editors-all.js:15525 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:244
+msgid "{name} was viewing this add-on first."
+msgstr "{name} nézte meg először a kiegészítőt."
+
+#: static/js/zamboni/editors-all.js:15536 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:255
+msgid "Loading&hellip;"
+msgstr "Betöltés&hellip;"
+
+#: static/js/zamboni/editors-all.js:15541 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:260
+msgid "Version Notes"
+msgstr "Megjegyzések a verzióhoz"
+
+#: static/js/zamboni/editors-all.js:15546 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:265
+msgid "Notes for Reviewers"
+msgstr "Megjegyzés a vizsgálatot végzőknek"
+
+#: static/js/zamboni/editors-all.js:15551 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:270
+msgid "No version notes found"
+msgstr "Nincsenek megjegyzések a verzióhoz"
+
+#: static/js/zamboni/editors-all.js:15611 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:330
+msgid "Average Reviews"
+msgstr "Átlagos értékelések"
+
+#: static/js/zamboni/editors-all.js:15667 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:386
+msgid "Number of Reviews"
+msgstr "Értékelések száma"
+
+#: static/js/zamboni/editors-all.js:15726 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:445
+msgid "Error loading translation"
+msgstr "Hiba a fordítás betöltésekor"
+
+#: static/js/zamboni/editors-all.js:15975 static/js/zamboni/editors-min.js:5 static/js/zamboni/themes_review_templates.js:31
+msgid "Theme"
+msgstr "Téma"
+
+#: static/js/zamboni/editors-all.js:15977 static/js/zamboni/editors-min.js:5 static/js/zamboni/themes_review_templates.js:33
+msgid "Reviewer"
+msgstr "Véleményező"
+
+#: static/js/zamboni/editors-all.js:15979 static/js/zamboni/editors-min.js:5 static/js/zamboni/themes_review_templates.js:35
+msgid "Status"
+msgstr "Állapot"
+
+#: static/js/zamboni/editors-all.js:16196 static/js/zamboni/editors-min.js:5 static/js/zamboni/themes_review.js:176
+msgid "Requested Info"
+msgstr "Kért információ"
+
+#: static/js/zamboni/editors-all.js:16197 static/js/zamboni/editors-min.js:5 static/js/zamboni/themes_review.js:177
+msgid "Flagged"
+msgstr "Megjelölt"
+
+#: static/js/zamboni/editors-all.js:16198 static/js/zamboni/editors-min.js:5 static/js/zamboni/themes_review.js:178
+msgid "Duplicate"
+msgstr "Másolat"
+
+#: static/js/zamboni/editors-all.js:16199 static/js/zamboni/editors-min.js:5 static/js/zamboni/themes_review.js:179
+msgid "Rejected"
+msgstr "Elutasított"
+
+#: static/js/zamboni/editors-all.js:16200 static/js/zamboni/editors-min.js:5 static/js/zamboni/themes_review.js:180
+msgid "Approved"
+msgstr "Jóváhagyott"
+
+#: static/js/zamboni/editors-all.js:16444 static/js/zamboni/editors-min.js:5 static/js/zamboni/themes_review.js:424
+msgid "No results found"
+msgstr "Nincs találat"
+
+#: static/js/zamboni/mobile-all.js:15186 static/js/zamboni/mobile/buttons.js:52
 msgid "Not Updated for {0} {1}"
 msgstr "Nincs frissítve a(z) {0} {1} alkalmazáshoz"
 
-#: static/js/zamboni/mobile/buttons.js:53
+#: static/js/zamboni/mobile-all.js:15187 static/js/zamboni/mobile/buttons.js:53
 msgid "Requires Newer Version of {0}"
 msgstr "Újabb {0} verzióra van szüksége"
 
-#: static/js/zamboni/mobile/buttons.js:54
+#: static/js/zamboni/mobile-all.js:15188 static/js/zamboni/mobile/buttons.js:54
 msgid "Unreviewed"
 msgstr "Ellenőrizetlen"
 
-#: static/js/zamboni/mobile/buttons.js:55
+#: static/js/zamboni/mobile-all.js:15189 static/js/zamboni/mobile/buttons.js:55
 msgid "Experimental <span>(Learn More)</span>"
 msgstr "Kísérleti <span>(Tudjon meg többet)</span>"
 
-#: static/js/zamboni/mobile/buttons.js:56 static/js/zamboni/mobile/buttons.js:57
+#: static/js/zamboni/mobile-all.js:15190 static/js/zamboni/mobile-all.js:15191 static/js/zamboni/mobile/buttons.js:56 static/js/zamboni/mobile/buttons.js:57
 msgid "Not Available for {0}"
 msgstr "Nem érhető el a(z) {0} programhoz"
 
-#: static/js/zamboni/mobile/buttons.js:58
+#: static/js/zamboni/mobile-all.js:15192 static/js/zamboni/mobile/buttons.js:58
 msgid "Experimental"
 msgstr "Kísérleti"
 
-#: static/js/zamboni/mobile/buttons.js:59
+#: static/js/zamboni/mobile-all.js:15193 static/js/zamboni/mobile/buttons.js:59
 msgid "Themes Require Newer Version of {0}"
 msgstr "A témák újabb {0} verziót igényelnek"
 
-#: static/js/zamboni/mobile/buttons.js:60
+#: static/js/zamboni/mobile-all.js:15194 static/js/zamboni/mobile/buttons.js:60
 msgid "Themes Require {0}"
 msgstr "A témák ezt igénylik: {0}"
 
-#: static/js/zamboni/mobile/buttons.js:105
+#: static/js/zamboni/mobile-all.js:15239 static/js/zamboni/mobile/buttons.js:105
 msgid "Installing..."
 msgstr "Telepítés..."
 
-#: static/js/zamboni/mobile/buttons.js:125
+#: static/js/zamboni/mobile-all.js:15259 static/js/zamboni/mobile/buttons.js:125
 msgid "This add-on has been preliminarily reviewed by Mozilla."
 msgstr "Ezt a kiegészítőt előzetesen nem vizsgálta meg a Mozilla."
 
-#: static/js/zamboni/mobile/buttons.js:250
+#: static/js/zamboni/mobile-all.js:15384 static/js/zamboni/mobile/buttons.js:250
 msgid "Keep it"
 msgstr "Megtartás"
 
-#: static/js/zamboni/mobile/general.js:344
+#: static/js/zamboni/mobile-all.js:16049 static/js/zamboni/mobile-min.js:6 static/js/zamboni/mobile/general.js:344
 msgid "You're trying it on!"
 msgstr "Próbálja ki!"
 
-#: static/js/zamboni/mobile/general.js:356
+#: static/js/zamboni/mobile-all.js:16061 static/js/zamboni/mobile-min.js:6 static/js/zamboni/mobile/general.js:356
 msgid "Added to Firefox"
 msgstr "Hozzáadás Firefoxhoz"
-

--- a/locale/id/LC_MESSAGES/django.po
+++ b/locale/id/LC_MESSAGES/django.po
@@ -5,82 +5,73 @@
 # Romi Hardiyanto <romihardiyanto@gmail.com>, 2008
 msgid ""
 msgstr ""
-"Project-Id-Version: addons\n"
+"Project-Id-Version:  addons\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2016-02-24 21:23+0000\n"
+"POT-Creation-Date: 2016-04-18 15:47+0000\n"
 "PO-Revision-Date: 2016-04-16 04:28+0000\n"
 "Last-Translator: Romi Hardiyanto <romihardiyanto@gmail.com>\n"
 "Language-Team: Bahasa Indonesia <id@li.org>\n"
-"Language: id\n"
+"Language: \n"
 "MIME-Version: 1.0\n"
-"Content-Type: text/plain; charset=utf-8\n"
+"Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=1; plural=0;\n"
 "Generated-By: Babel 2.2.0\n"
-"X-Generator: Pontoon\n"
 
-#: src/olympia/accounts/views.py:52
+#: src/olympia/accounts/views.py:54
 msgid "Your log in attempt could not be parsed. Please try again."
 msgstr "Upaya masuk Anda tidak bisa diuraikan. Silakan coba lagi."
 
-#: src/olympia/accounts/views.py:54
+#: src/olympia/accounts/views.py:56
 msgid "Your Firefox Account could not be found. Please try again."
 msgstr "Akun Firefox tidak dapat ditemukan. Silakan coba lagi."
 
-#: src/olympia/accounts/views.py:55
+#: src/olympia/accounts/views.py:57
 msgid "You could not be logged in. Please try again."
 msgstr "Anda bisa tidak bisa masuk. Silakan coba lagi."
 
-#: src/olympia/accounts/views.py:57
+#: src/olympia/accounts/views.py:59
 msgid "Your account has already been migrated to Firefox Accounts."
 msgstr "Akun anda telah dipindahkan ke Firefox Accounts."
 
-#: src/olympia/accounts/views.py:59
+#: src/olympia/accounts/views.py:61
 msgid "Your Firefox Account already exists on this site."
 msgstr "Firefox Account anda sudah ada di situs ini."
 
-#: src/olympia/accounts/views.py:108
+#: src/olympia/accounts/views.py:110
 msgid "Great job!"
 msgstr "Kerja yang bagus!"
 
-#: src/olympia/accounts/views.py:109
+#: src/olympia/accounts/views.py:111
 msgid "You can now log in to Add-ons with your Firefox Account."
 msgstr "Anda kini bisa masuk ke Pengaya dengan Firfox Account."
 
-#: src/olympia/accounts/views.py:121
+#: src/olympia/accounts/views.py:123
 msgid "Need help?"
 msgstr "Perlu bantuan?"
 
-#: src/olympia/addons/buttons.py:180
+#: src/olympia/addons/buttons.py:177
 msgid "Download Now"
 msgstr "Unduh Sekarang"
 
-#: src/olympia/addons/buttons.py:182
+#: src/olympia/addons/buttons.py:179
 msgid "Download"
 msgstr "Unduh"
 
 #. L10n: please keep &nbsp; in the string so &rarr; does not wrap.
-#: src/olympia/addons/buttons.py:186
+#: src/olympia/addons/buttons.py:183
 msgid "Continue to Download&nbsp;&rarr;"
 msgstr "Lanjutkan Mengunduh&nbsp;&rarr;"
 
-#: src/olympia/addons/buttons.py:202 src/olympia/addons/helpers.py:35
-#: src/olympia/addons/views.py:319
-#: src/olympia/addons/templates/addons/impala/details.html:114
-#: src/olympia/addons/templates/addons/impala/listing/items.html:17
-#: src/olympia/addons/templates/addons/mobile/home.html:40
-#: src/olympia/amo/templates/amo/side_nav.html:6
-#: src/olympia/amo/templates/amo/side_nav.html:10
-#: src/olympia/amo/templates/amo/site_nav.html:2
-#: src/olympia/amo/templates/amo/site_nav.html:55
-#: src/olympia/bandwagon/views.py:95 src/olympia/browse/views.py:54
-#: src/olympia/browse/views.py:68 src/olympia/browse/views.py:235
-#: src/olympia/browse/templates/browse/impala/category_landing.html:22
+#: src/olympia/addons/buttons.py:199 src/olympia/addons/helpers.py:35 src/olympia/addons/views.py:333 src/olympia/addons/templates/addons/impala/details.html:111
+#: src/olympia/addons/templates/addons/impala/listing/items.html:17 src/olympia/addons/templates/addons/mobile/home.html:40 src/olympia/amo/templates/amo/side_nav.html:6
+#: src/olympia/amo/templates/amo/side_nav.html:10 src/olympia/amo/templates/amo/site_nav.html:2 src/olympia/amo/templates/amo/site_nav.html:53 src/olympia/bandwagon/views.py:95
+#: src/olympia/browse/views.py:54 src/olympia/browse/views.py:68 src/olympia/browse/views.py:202 src/olympia/browse/templates/browse/impala/category_landing.html:22
 #: src/olympia/browse/templates/browse/personas/mobile/category_landing.html:26
 msgid "Featured"
 msgstr "Unggulan"
 
-#: src/olympia/addons/buttons.py:221
+#: src/olympia/addons/buttons.py:218
 msgid "Add to {0}"
 msgstr "Tambahkan ke {0}"
 
@@ -102,72 +93,65 @@ msgstr "Slug ini tidak dapat \"%s\". Silakan pilih yang lain."
 msgid "Invalid tag: {0}"
 msgid_plural "Invalid tags: {0}"
 msgstr[0] "Tag tidak valid: {0}"
+msgstr[1] ""
 
 #. L10n: {0} is a single tag or a comma-separated list of tags.
 #: src/olympia/addons/forms.py:103
 msgid "\"{0}\" is a reserved tag and cannot be used."
 msgid_plural "\"{0}\" are reserved tags and cannot be used."
 msgstr[0] "\"{0}\" adalah tag yang sudah dicadangkan dan tidak bisa digunakan."
+msgstr[1] ""
 
 #: src/olympia/addons/forms.py:111
 msgid "You have {0} too many tags."
 msgid_plural "You have {0} too many tags."
 msgstr[0] "Tagnya terlalu banyak {0} buah."
+msgstr[1] ""
 
 #: src/olympia/addons/forms.py:117
 #, python-format
-msgid ""
-"All tags must be %s characters or less after invalid characters are removed."
-msgstr ""
-"Seluruh tag harus berjumlah %s karakter atau kurang setelah karakter yang "
-"tidak valid dibuang."
+msgid "All tags must be %s characters or less after invalid characters are removed."
+msgstr "Seluruh tag harus berjumlah %s karakter atau kurang setelah karakter yang tidak valid dibuang."
 
 #: src/olympia/addons/forms.py:121
 msgid "All tags must be at least {0} character."
 msgid_plural "All tags must be at least {0} characters."
 msgstr[0] "Semua tag panjangnya paling sedikit harus {0} karakter."
+msgstr[1] ""
 
-#: src/olympia/addons/forms.py:234
-msgid ""
-"Categories cannot be changed while your add-on is featured for this "
-"application."
-msgstr ""
-"Kategori tidak bisa diubah saat pengaya anda ditampilkan untuk aplikasi ini."
+#: src/olympia/addons/forms.py:238
+msgid "Categories cannot be changed while your add-on is featured for this application."
+msgstr "Kategori tidak bisa diubah saat pengaya anda ditampilkan untuk aplikasi ini."
 
 #. L10n: {0} is the number of categories.
-#: src/olympia/addons/forms.py:238
+#: src/olympia/addons/forms.py:242
 msgid "You can have only {0} category."
 msgid_plural "You can have only {0} categories."
 msgstr[0] "Anda hanya diperbolehkan memiliki {0} kategori."
+msgstr[1] ""
 
-#: src/olympia/addons/forms.py:246
-msgid ""
-"The miscellaneous category cannot be combined with additional categories."
+#: src/olympia/addons/forms.py:250
+msgid "The miscellaneous category cannot be combined with additional categories."
 msgstr "Kategori lain-lain tidak dapat digabungkan dengan kategori lainnya."
 
-#: src/olympia/addons/forms.py:369
+#: src/olympia/addons/forms.py:374
 #, python-format
-msgid ""
-"Before changing your default locale you must have a name, summary, and "
-"description in that locale. You are missing %s."
-msgstr ""
-"Sebelum mengubah kode pelokalan baku Anda harus menentukan nama, ringkasan, "
-"dan deskripsi pada kode pelokalan tersebut. Anda masih belum menentukan %s."
+msgid "Before changing your default locale you must have a name, summary, and description in that locale. You are missing %s."
+msgstr "Sebelum mengubah kode pelokalan baku Anda harus menentukan nama, ringkasan, dan deskripsi pada kode pelokalan tersebut. Anda masih belum menentukan %s."
 
-#: src/olympia/addons/forms.py:484 src/olympia/addons/forms.py:575
+#: src/olympia/addons/forms.py:455 src/olympia/addons/forms.py:546
 msgid "A license must be selected."
 msgstr "Sebuah lisensi harus dipilih."
 
-#: src/olympia/addons/forms.py:556
+#: src/olympia/addons/forms.py:527
 msgid "Give Your Theme a Name."
 msgstr "Beri Tema Anda Nama."
 
-#: src/olympia/addons/forms.py:562
-#: src/olympia/devhub/templates/devhub/personas/submit.html:53
+#: src/olympia/addons/forms.py:533 src/olympia/devhub/templates/devhub/personas/submit.html:53
 msgid "Describe your Theme."
 msgstr "Jelaskan Tema anda."
 
-#: src/olympia/addons/forms.py:704
+#: src/olympia/addons/forms.py:675
 msgid "Enter a new author's email address"
 msgstr "Masukkan alamat surel penulis baru"
 
@@ -175,50 +159,39 @@ msgstr "Masukkan alamat surel penulis baru"
 msgid "Not Reviewed"
 msgstr "Belum Ditinjau"
 
-#: src/olympia/addons/models.py:301
+#: src/olympia/addons/models.py:298
 msgid "Users have the option of contributing more or less than this amount."
-msgstr ""
-"Pengguna memiliki pilihan untuk menyumbang sebanyak lebih atau kurang dari "
-"jumlah ini."
+msgstr "Pengguna memiliki pilihan untuk menyumbang sebanyak lebih atau kurang dari jumlah ini."
 
-#: src/olympia/addons/models.py:309
-msgid ""
-"Users will always be asked in the Add-ons Manager (Firefox 4 and above)"
+#: src/olympia/addons/models.py:306
+msgid "Users will always be asked in the Add-ons Manager (Firefox 4 and above). Only applies to desktop."
 msgstr ""
-"Pengguna akan selalu ditanya pada Pengelola Pengaya (Firefox 4 atau lebih "
-"anyar)"
 
 # Column name in a table.
-#: src/olympia/addons/models.py:1804
-#: src/olympia/addons/templates/addons/details_box.html:55
-#: src/olympia/devhub/templates/devhub/index.html:92
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:102
+#: src/olympia/addons/models.py:1802 src/olympia/addons/templates/addons/details_box.html:55 src/olympia/devhub/templates/devhub/index.html:92
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:89
 msgid "Listed"
 msgstr "Terdaftar"
 
-#: src/olympia/addons/views.py:320
-#: src/olympia/browse/templates/browse/personas/mobile/category_landing.html:27
+#: src/olympia/addons/views.py:334 src/olympia/browse/templates/browse/personas/mobile/category_landing.html:27
 msgid "Popular"
 msgstr "Populer"
 
-#: src/olympia/addons/views.py:321 src/olympia/browse/views.py:238
-#: src/olympia/browse/views.py:280 src/olympia/browse/views.py:482
+#: src/olympia/addons/views.py:335 src/olympia/browse/views.py:205 src/olympia/browse/views.py:247 src/olympia/browse/views.py:449
 msgid "Recently Added"
 msgstr "Baru Ditambahkan"
 
-#: src/olympia/addons/views.py:322 src/olympia/bandwagon/views.py:99
-#: src/olympia/browse/views.py:60 src/olympia/browse/views.py:71
-#: src/olympia/search/forms.py:16 src/olympia/search/forms.py:91
+#: src/olympia/addons/views.py:336 src/olympia/bandwagon/views.py:99 src/olympia/browse/views.py:60 src/olympia/browse/views.py:71 src/olympia/search/forms.py:16 src/olympia/search/forms.py:91
 msgid "Recently Updated"
 msgstr "Baru Diperbarui"
 
-#. l10n: {0} is the addon name
 # %1 is an add-on name.
-#: src/olympia/addons/views.py:520
+#. l10n: {0} is the addon name
+#: src/olympia/addons/views.py:534
 msgid "Contribution for {0}"
 msgstr "Sumbangan untuk {0}"
 
-#: src/olympia/addons/views.py:613
+#: src/olympia/addons/views.py:627
 msgid "Abuse reported."
 msgstr "Penyalahgunaan dilaporkan."
 
@@ -226,116 +199,70 @@ msgstr "Penyalahgunaan dilaporkan."
 msgid "My add-on doesn't fit into any of the categories"
 msgstr "Pengaya saya tidak cocok ke kategori apa pun"
 
-#: src/olympia/addons/templates/addons/button.html:27
-#: src/olympia/addons/templates/addons/impala/button.html:11
-#: src/olympia/addons/templates/addons/mobile/button.html:11
+#: src/olympia/addons/templates/addons/button.html:27 src/olympia/addons/templates/addons/impala/button.html:11 src/olympia/addons/templates/addons/mobile/button.html:11
 msgid "No compatible versions"
 msgstr "Tidak ada versi yang kompatibel"
 
-#: src/olympia/addons/templates/addons/button.html:35
-#: src/olympia/addons/templates/addons/impala/button.html:19
+#: src/olympia/addons/templates/addons/button.html:35 src/olympia/addons/templates/addons/impala/button.html:19
 msgid "Added to Mobile"
 msgstr "Ditambahkan ke Seluler"
 
-#: src/olympia/addons/templates/addons/button.html:37
-#: src/olympia/addons/templates/addons/impala/button.html:21
+#: src/olympia/addons/templates/addons/button.html:37 src/olympia/addons/templates/addons/impala/button.html:21
 msgid "Add to Mobile"
 msgstr "Tambahkan ke Seluler"
 
 #. {0} is a platform name like Windows or Mac OS X.
-#: src/olympia/addons/templates/addons/button.html:66
-#: src/olympia/addons/templates/addons/includes/install_button.html:19
+#: src/olympia/addons/templates/addons/button.html:66 src/olympia/addons/templates/addons/includes/install_button.html:19
 msgid "for {0}"
 msgstr "untuk {0}"
 
-#: src/olympia/addons/templates/addons/button.html:82
-#: src/olympia/addons/templates/addons/mobile/button.html:23
+#: src/olympia/addons/templates/addons/button.html:82 src/olympia/addons/templates/addons/mobile/button.html:23
 msgid "View privacy policy"
 msgstr "Tampilkan kebijakan privasi"
 
-#: src/olympia/addons/templates/addons/button.html:87
-#: src/olympia/addons/templates/addons/details_box.html:133
-#: src/olympia/addons/templates/addons/mobile/button.html:28
+#: src/olympia/addons/templates/addons/button.html:87 src/olympia/addons/templates/addons/details_box.html:133 src/olympia/addons/templates/addons/mobile/button.html:28
 #: src/olympia/discovery/templates/discovery/addons/detail.html:28
 msgid "View End-User License Agreement"
 msgstr "Lihat Hak Pengguna Akhir"
 
-#: src/olympia/addons/templates/addons/button.html:92
-#: src/olympia/addons/templates/addons/impala/button.html:54
+#: src/olympia/addons/templates/addons/button.html:92 src/olympia/addons/templates/addons/impala/button.html:54
 #, python-format
-msgid ""
-"This add-on has not been reviewed by Mozilla. <a href=\"%(url)s\">Learn "
-"more</a>"
-msgstr ""
-"Pengaya ini belum ditinjau oleh Mozilla. <a href=\"%(url)s\">Pelajari "
-"selengkapnya</a>"
+msgid "This add-on has not been reviewed by Mozilla. <a href=\"%(url)s\">Learn more</a>"
+msgstr "Pengaya ini belum ditinjau oleh Mozilla. <a href=\"%(url)s\">Pelajari selengkapnya</a>"
 
-#: src/olympia/addons/templates/addons/button.html:97
-#: src/olympia/addons/templates/addons/impala/button.html:60
+#: src/olympia/addons/templates/addons/button.html:97 src/olympia/addons/templates/addons/impala/button.html:60
 #, python-format
-msgid ""
-"This add-on has been preliminarily reviewed by Mozilla. <a "
-"href=\"%(url)s\">Learn more</a>"
-msgstr ""
-"Pengaya ini telah ditinjau oleh Mozilla sebelumnya. <a "
-"href=\"%(url)s\">Pelajari selengkapnya</a>"
+msgid "This add-on has been preliminarily reviewed by Mozilla. <a href=\"%(url)s\">Learn more</a>"
+msgstr "Pengaya ini telah ditinjau oleh Mozilla sebelumnya. <a href=\"%(url)s\">Pelajari selengkapnya</a>"
 
-#: src/olympia/addons/templates/addons/contribution.html:11
-#: src/olympia/addons/templates/addons/impala/developers.html:44
-msgid ""
-"The developer of this add-on asks that you help support its continued "
-"development by making a small contribution."
-msgstr ""
-"Pengembang pengaya ini meminta Anda untuk membantu mendukung perkembangan "
-"lebih lanjut dengan memberi sumbangan."
+#: src/olympia/addons/templates/addons/contribution.html:11 src/olympia/addons/templates/addons/impala/developers.html:44
+msgid "The developer of this add-on asks that you help support its continued development by making a small contribution."
+msgstr "Pengembang pengaya ini meminta Anda untuk membantu mendukung perkembangan lebih lanjut dengan memberi sumbangan."
 
 #: src/olympia/addons/templates/addons/contribution.html:14
 #, python-format
-msgid ""
-"The developer of this add-on asks that you show your support by making a "
-"donation to the <a href=\"%(charity_url)s\">%(charity_name)s</a>."
-msgstr ""
-"Pengembang pengaya ini meminta dukungan Anda dengan memberikan donasi ke <a "
-"href=\"%(charity_url)s\">%(charity_name)s</a>."
+msgid "The developer of this add-on asks that you show your support by making a donation to the <a href=\"%(charity_url)s\">%(charity_name)s</a>."
+msgstr "Pengembang pengaya ini meminta dukungan Anda dengan memberikan donasi ke <a href=\"%(charity_url)s\">%(charity_name)s</a>."
 
 #: src/olympia/addons/templates/addons/contribution.html:19
 #, python-format
-msgid ""
-"The developer of this add-on asks that you show your support by making a "
-"small contribution to <a href=\"%(charity_url)s\">%(charity_name)s</a>."
-msgstr ""
-"Pengembang pengaya ini meminta dukungan Anda untuk memberikan sumbangan "
-"kecil ke <a href=\"%(charity_url)s\">%(charity_name)s</a>."
+msgid "The developer of this add-on asks that you show your support by making a small contribution to <a href=\"%(charity_url)s\">%(charity_name)s</a>."
+msgstr "Pengembang pengaya ini meminta dukungan Anda untuk memberikan sumbangan kecil ke <a href=\"%(charity_url)s\">%(charity_name)s</a>."
 
-#: src/olympia/addons/templates/addons/contribution.html:30
-#: src/olympia/addons/templates/addons/impala/contribution.html:18
-#: src/olympia/templates/menu_links.html:25
+#: src/olympia/addons/templates/addons/contribution.html:30 src/olympia/addons/templates/addons/impala/contribution.html:18 src/olympia/templates/menu_links.html:25
 msgid "Contribute"
 msgstr "Sumbang"
 
-#. Click Contribute button OR Install button
 # This is a separator between the graphical [contribute] button and the
 # graphical [download now] button
-#: src/olympia/addons/templates/addons/contribution.html:34
-#: src/olympia/addons/templates/addons/report_abuse.html:26
-#: src/olympia/addons/templates/addons/impala/contribution.html:32
-#: src/olympia/devhub/templates/devhub/addons/ajax_compat_update.html:36
-#: src/olympia/devhub/templates/devhub/addons/profile.html:44
-#: src/olympia/devhub/templates/devhub/addons/edit/admin.html:101
-#: src/olympia/devhub/templates/devhub/addons/edit/basic.html:152
-#: src/olympia/devhub/templates/devhub/addons/edit/details.html:85
-#: src/olympia/devhub/templates/devhub/addons/edit/support.html:67
-#: src/olympia/devhub/templates/devhub/addons/edit/technical.html:166
-#: src/olympia/devhub/templates/devhub/addons/forms_shared/media.html:149
-#: src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:44
-#: src/olympia/devhub/templates/devhub/versions/add_file_modal.html:78
-#: src/olympia/devhub/templates/devhub/versions/edit.html:139
-#: src/olympia/devhub/templates/devhub/versions/list.html:242
-#: src/olympia/devhub/templates/devhub/versions/list.html:276
-#: src/olympia/devhub/templates/devhub/versions/list.html:317
-#: src/olympia/devhub/templates/devhub/versions/list.html:351
-#: src/olympia/reviews/templates/reviews/edit_review.html:16
-#: src/olympia/translations/templates/translations/trans-menu.html:50
+#. Click Contribute button OR Install button
+#: src/olympia/addons/templates/addons/contribution.html:34 src/olympia/addons/templates/addons/report_abuse.html:26 src/olympia/addons/templates/addons/impala/contribution.html:32
+#: src/olympia/devhub/templates/devhub/addons/ajax_compat_update.html:36 src/olympia/devhub/templates/devhub/addons/profile.html:44 src/olympia/devhub/templates/devhub/addons/edit/admin.html:101
+#: src/olympia/devhub/templates/devhub/addons/edit/basic.html:152 src/olympia/devhub/templates/devhub/addons/edit/details.html:85 src/olympia/devhub/templates/devhub/addons/edit/support.html:67
+#: src/olympia/devhub/templates/devhub/addons/edit/technical.html:166 src/olympia/devhub/templates/devhub/addons/forms_shared/media.html:149
+#: src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:43 src/olympia/devhub/templates/devhub/versions/add_file_modal.html:58 src/olympia/devhub/templates/devhub/versions/edit.html:139
+#: src/olympia/devhub/templates/devhub/versions/list.html:239 src/olympia/devhub/templates/devhub/versions/list.html:281 src/olympia/devhub/templates/devhub/versions/list.html:315
+#: src/olympia/devhub/templates/devhub/versions/list.html:349 src/olympia/reviews/templates/reviews/edit_review.html:16 src/olympia/translations/templates/translations/trans-menu.html:50
 #: src/olympia/translations/templates/translations/trans-menu.html:62
 msgid "or"
 msgstr "atau"
@@ -344,42 +271,23 @@ msgstr "atau"
 msgid "Suggested Contribution: {0}"
 msgstr "Saran Sumbangan: {0}"
 
-#: src/olympia/addons/templates/addons/contribution.html:48
-#: src/olympia/amo/templates/amo/recaptcha.html:5
-#: src/olympia/versions/templates/versions/version.html:52
+#: src/olympia/addons/templates/addons/contribution.html:48 src/olympia/amo/templates/amo/recaptcha.html:5 src/olympia/versions/templates/versions/version.html:52
 msgid "What's this?"
 msgstr "Apa ini?"
 
 #: src/olympia/addons/templates/addons/contribution.html:63
 #, python-format
-msgid ""
-"The developer of this add-on would like you to consider making a donation to"
-" the <a href=\"%(charity_url)s\">%(charity_name)s</a> if you enjoy using it."
-msgstr ""
-"Pengembang pengaya ini menginginkan agar Anda mempertimbangkan untuk "
-"memberikan donasi ke <a href=\"%(charity_url)s\">%(charity_name)s</a> jika "
-"Anda suka menggunakannya."
+msgid "The developer of this add-on would like you to consider making a donation to the <a href=\"%(charity_url)s\">%(charity_name)s</a> if you enjoy using it."
+msgstr "Pengembang pengaya ini menginginkan agar Anda mempertimbangkan untuk memberikan donasi ke <a href=\"%(charity_url)s\">%(charity_name)s</a> jika Anda suka menggunakannya."
 
 #: src/olympia/addons/templates/addons/contribution.html:69
 #, python-format
-msgid ""
-"The developer of this add-on would like you to consider making a small "
-"contribution to <a href=\"%(charity_url)s\">%(charity_name)s</a> if you "
-"enjoy using it."
-msgstr ""
-"Pengembang pengaya ini menginginkan agar Anda mempertimbangkan untuk "
-"memberikan sumbangan kecil ke <a "
-"href=\"%(charity_url)s\">%(charity_name)s</a> jika Anda suka menggunakannya."
+msgid "The developer of this add-on would like you to consider making a small contribution to <a href=\"%(charity_url)s\">%(charity_name)s</a> if you enjoy using it."
+msgstr "Pengembang pengaya ini menginginkan agar Anda mempertimbangkan untuk memberikan sumbangan kecil ke <a href=\"%(charity_url)s\">%(charity_name)s</a> jika Anda suka menggunakannya."
 
 #: src/olympia/addons/templates/addons/contribution.html:76
-msgid ""
-"Mozilla is committed to supporting a vibrant and healthy developer "
-"ecosystem. Your optional contribution helps sustain further development of "
-"this add-on."
-msgstr ""
-"Mozilla berkomitmen untuk mendukung ekosistem pengembang yang sehat dan "
-"luas. Sumbangan Anda yang walau tak wajib akan membantu dalam proses "
-"pengembangan pengaya ini lebih lanjut."
+msgid "Mozilla is committed to supporting a vibrant and healthy developer ecosystem. Your optional contribution helps sustain further development of this add-on."
+msgstr "Mozilla berkomitmen untuk mendukung ekosistem pengembang yang sehat dan luas. Sumbangan Anda yang walau tak wajib akan membantu dalam proses pengembangan pengaya ini lebih lanjut."
 
 #: src/olympia/addons/templates/addons/contributions_lightbox.html:5
 msgid "Make a Contribution"
@@ -387,37 +295,24 @@ msgstr "Beri Sumbangan"
 
 #: src/olympia/addons/templates/addons/contributions_lightbox.html:9
 #, python-format
-msgid ""
-"Help support the continued development of <strong>%(addon_name)s</strong> by"
-" making a small contribution through <a href=\"%(paypal_url)s\">PayPal</a>."
-msgstr ""
-"Bantu dukung pengembangan berlanjut <strong>%(addon_name)s</strong> dengan "
-"berkontribusi sedikit melalui <a href=\"%(paypal_url)s\">PayPal</a>."
+msgid "Help support the continued development of <strong>%(addon_name)s</strong> by making a small contribution through <a href=\"%(paypal_url)s\">PayPal</a>."
+msgstr "Bantu dukung pengembangan berlanjut <strong>%(addon_name)s</strong> dengan berkontribusi sedikit melalui <a href=\"%(paypal_url)s\">PayPal</a>."
 
 #: src/olympia/addons/templates/addons/contributions_lightbox.html:15
 #, python-format
 msgid ""
-"To show your support for <b>%(addon_name)s</b>, the developer asks that you "
-"make a donation to the <a href=\"%(charity_url)s\">%(charity_name)s</a> "
-"through <a href=\"%(paypal_url)s\">PayPal</a>."
+"To show your support for <b>%(addon_name)s</b>, the developer asks that you make a donation to the <a href=\"%(charity_url)s\">%(charity_name)s</a> through <a href=\"%(paypal_url)s\">PayPal</a>."
 msgstr ""
-"Untuk menunjukkan dukungan anda pada <b>%(addon_name)s</b>, pengembang "
-"meminta anda menyumbang pada <a "
-"href=\"%(charity_url)s\">%(charity_name)s</a> melalui <a "
-"href=\"%(paypal_url)s\">PayPal</a>."
+"Untuk menunjukkan dukungan anda pada <b>%(addon_name)s</b>, pengembang meminta anda menyumbang pada <a href=\"%(charity_url)s\">%(charity_name)s</a> melalui <a href=\"%(paypal_url)s\">PayPal</a>."
 
 #: src/olympia/addons/templates/addons/contributions_lightbox.html:21
 #, python-format
 msgid ""
-"To show your support for <b>%(addon_name)s</b>, the developer asks that you "
-"make a small contribution to <a "
-"href=\"%(charity_url)s\">%(charity_name)s</a> through <a "
-"href=\"%(paypal_url)s\">PayPal</a>."
+"To show your support for <b>%(addon_name)s</b>, the developer asks that you make a small contribution to <a href=\"%(charity_url)s\">%(charity_name)s</a> through <a href=\"%(paypal_url)s\">PayPal</"
+"a>."
 msgstr ""
-"Untuk menunjukkan dukungan anda pada <b>%(addon_name)s</b>, pengembang "
-"meminta anda menyumbang dalam jumlah kecil pada <a "
-"href=\"%(charity_url)s\">%(charity_name)s</a> melalui <a "
-"href=\"%(paypal_url)s\">PayPal</a>."
+"Untuk menunjukkan dukungan anda pada <b>%(addon_name)s</b>, pengembang meminta anda menyumbang dalam jumlah kecil pada <a href=\"%(charity_url)s\">%(charity_name)s</a> melalui <a href="
+"\"%(paypal_url)s\">PayPal</a>."
 
 #: src/olympia/addons/templates/addons/contributions_lightbox.html:30
 msgid "How much would you like to contribute?"
@@ -440,8 +335,7 @@ msgstr "Jumlah kontribusi haruslah dalam angka."
 msgid "A one-time suggested contribution of {0}"
 msgstr "Saran sumbangan satu kali sebanyak {0}"
 
-#. {0} is a currency symbol (e.g., $),                    {1} is an amount
-#. input
+#. {0} is a currency symbol (e.g., $),                    {1} is an amount input
 #. field
 #: src/olympia/addons/templates/addons/contributions_lightbox.html:64
 msgid "A one-time contribution of {0} {1}"
@@ -451,11 +345,8 @@ msgstr "Sumbangan satu kali sebanyak {0} {1}"
 msgid "Leave a comment or request with your contribution."
 msgstr "Sertakan komentar atau permintaan bersama dengan sumbangan Anda."
 
-#: src/olympia/addons/templates/addons/contributions_lightbox.html:74
-#: src/olympia/bandwagon/templates/bandwagon/ajax_new.html:20
-#: src/olympia/bandwagon/templates/bandwagon/includes/addedit.html:37
-#: src/olympia/reviews/templates/reviews/mobile/add_form.html:13
-#: src/olympia/templates/includes/forms.html:10
+#: src/olympia/addons/templates/addons/contributions_lightbox.html:74 src/olympia/bandwagon/templates/bandwagon/ajax_new.html:20 src/olympia/bandwagon/templates/bandwagon/includes/addedit.html:37
+#: src/olympia/reviews/templates/reviews/mobile/add_form.html:13 src/olympia/templates/includes/forms.html:10
 msgid "(optional)"
 msgstr "(opsional)"
 
@@ -475,36 +366,27 @@ msgstr "Terima Kasih, Kapan-Kapan"
 msgid "Contribution made, thank you."
 msgstr "Kontribusi telah dibuat, terima kasih."
 
-#: src/olympia/addons/templates/addons/details_box.html:10
-#: src/olympia/discovery/templates/discovery/addons/detail.html:19
+#: src/olympia/addons/templates/addons/details_box.html:10 src/olympia/discovery/templates/discovery/addons/detail.html:19
 msgid "No restart required"
 msgstr "Tidak perlu memulai ulang"
 
 #. This is a caption for a table. {0} is an add-on name.
-#: src/olympia/addons/templates/addons/details_box.html:26
-#: src/olympia/addons/templates/addons/includes/persona.html:9
+#: src/olympia/addons/templates/addons/details_box.html:26 src/olympia/addons/templates/addons/includes/persona.html:9
 msgid "Add-on Information for {0}"
 msgstr "Informasi Pengaya {0}"
 
-#: src/olympia/addons/templates/addons/details_box.html:30
-#: src/olympia/addons/templates/addons/persona_detail_table.html:3
-#: src/olympia/addons/templates/addons/mobile/details.html:63
-#: src/olympia/addons/templates/addons/mobile/persona_detail_table.html:7
-#: src/olympia/browse/views.py:459 src/olympia/devhub/views.py:75
+#: src/olympia/addons/templates/addons/details_box.html:30 src/olympia/addons/templates/addons/persona_detail_table.html:3 src/olympia/addons/templates/addons/mobile/details.html:63
+#: src/olympia/addons/templates/addons/mobile/persona_detail_table.html:7 src/olympia/browse/views.py:426 src/olympia/devhub/views.py:73
 msgid "Updated"
 msgstr "Diperbarui"
 
-#: src/olympia/addons/templates/addons/details_box.html:38
-#: src/olympia/addons/templates/addons/mobile/details.html:71
-#: src/olympia/devhub/templates/devhub/addons/edit/support.html:43
+#: src/olympia/addons/templates/addons/details_box.html:38 src/olympia/addons/templates/addons/mobile/details.html:71 src/olympia/devhub/templates/devhub/addons/edit/support.html:43
 #: src/olympia/discovery/templates/discovery/addons/detail.html:77
 msgid "Website"
 msgstr "Situs Web"
 
 #. This refers to this version's compatible applications, such as Firefox 8.0
-#: src/olympia/addons/templates/addons/details_box.html:47
-#: src/olympia/addons/templates/addons/mobile/details.html:80
-#: src/olympia/search/templates/search/results.html:72
+#: src/olympia/addons/templates/addons/details_box.html:47 src/olympia/addons/templates/addons/mobile/details.html:80 src/olympia/search/templates/search/results.html:72
 #: src/olympia/versions/templates/versions/version.html:21
 msgid "Works with"
 msgstr "Bekerja pada"
@@ -513,45 +395,30 @@ msgstr "Bekerja pada"
 msgid "Visibility"
 msgstr "Visibilitas"
 
-#: src/olympia/addons/templates/addons/details_box.html:57
-#: src/olympia/devhub/templates/devhub/index.html:94
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:104
+#: src/olympia/addons/templates/addons/details_box.html:57 src/olympia/devhub/templates/devhub/index.html:94 src/olympia/devhub/templates/devhub/includes/addon_details.html:91
 msgid "Hidden"
 msgstr "Tersembunyi"
 
-#: src/olympia/addons/templates/addons/details_box.html:59
-#: src/olympia/devhub/templates/devhub/index.html:96
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:106
+#: src/olympia/addons/templates/addons/details_box.html:59 src/olympia/devhub/templates/devhub/index.html:96 src/olympia/devhub/templates/devhub/includes/addon_details.html:93
 msgid "Unlisted"
 msgstr "Tidak terdaftar"
 
-#: src/olympia/addons/templates/addons/details_box.html:67
-#: src/olympia/devhub/templates/devhub/addons/edit/technical.html:44
+#: src/olympia/addons/templates/addons/details_box.html:67 src/olympia/devhub/templates/devhub/addons/edit/technical.html:44
 msgid "Required Add-ons"
 msgstr "Pengaya yang Dibutuhkan"
 
-#: src/olympia/addons/templates/addons/details_box.html:81
-#: src/olympia/addons/templates/addons/persona_detail_table.html:15
-#: src/olympia/browse/views.py:462 src/olympia/devhub/views.py:78
-#: src/olympia/devhub/views.py:85
-#: src/olympia/discovery/templates/discovery/addons/detail.html:57
-#: src/olympia/reviews/forms.py:62
-#: src/olympia/reviews/templates/reviews/add.html:57
+#: src/olympia/addons/templates/addons/details_box.html:81 src/olympia/addons/templates/addons/persona_detail_table.html:15 src/olympia/browse/views.py:429 src/olympia/devhub/views.py:76
+#: src/olympia/devhub/views.py:83 src/olympia/discovery/templates/discovery/addons/detail.html:57 src/olympia/reviews/forms.py:62 src/olympia/reviews/templates/reviews/add.html:57
 #: src/olympia/reviews/templates/reviews/mobile/review_list.html:18
 msgid "Rating"
 msgstr "Peringkat"
 
-#: src/olympia/addons/templates/addons/details_box.html:85
-#: src/olympia/browse/views.py:461 src/olympia/devhub/views.py:77
-#: src/olympia/devhub/views.py:84
-#: src/olympia/stats/templates/stats/addon_report_menu.html:8
-#: src/olympia/stats/templates/stats/collection_report_menu.html:18
+#: src/olympia/addons/templates/addons/details_box.html:85 src/olympia/browse/views.py:428 src/olympia/devhub/views.py:75 src/olympia/devhub/views.py:82
+#: src/olympia/stats/templates/stats/addon_report_menu.html:8 src/olympia/stats/templates/stats/collection_report_menu.html:18
 msgid "Downloads"
 msgstr "Unduhan"
 
-#: src/olympia/addons/templates/addons/details_box.html:91
-#: src/olympia/addons/templates/addons/details_box.html:103
-#: src/olympia/devhub/templates/devhub/addons/listing/item_actions_theme.html:17
+#: src/olympia/addons/templates/addons/details_box.html:91 src/olympia/addons/templates/addons/details_box.html:103 src/olympia/devhub/templates/devhub/addons/listing/item_actions_theme.html:17
 #: src/olympia/devhub/templates/devhub/personas/edit.html:60
 msgid "View Statistics"
 msgstr "Tampilkan Statistik"
@@ -565,18 +432,13 @@ msgid "Abuse Reports"
 msgstr "Laporan Penyalahgunaan"
 
 #. The Privacy Policy for this add-on.
-#: src/olympia/addons/templates/addons/details_box.html:121
-#: src/olympia/addons/templates/addons/privacy.html:19
-#: src/olympia/addons/templates/addons/privacy.html:23
-#: src/olympia/addons/templates/addons/impala/button.html:43
-#: src/olympia/addons/templates/addons/impala/details.html:307
-#: src/olympia/devhub/templates/devhub/includes/policy_form.html:20
+#: src/olympia/addons/templates/addons/details_box.html:121 src/olympia/addons/templates/addons/privacy.html:19 src/olympia/addons/templates/addons/privacy.html:23
+#: src/olympia/addons/templates/addons/impala/button.html:43 src/olympia/addons/templates/addons/impala/details.html:312 src/olympia/devhub/templates/devhub/includes/policy_form.html:23
 #: src/olympia/templates/mobile/base_addons.html:87
 msgid "Privacy Policy"
 msgstr "Kebijakan Privasi"
 
-#: src/olympia/addons/templates/addons/details_box.html:124
-#: src/olympia/discovery/templates/discovery/addons/detail.html:24
+#: src/olympia/addons/templates/addons/details_box.html:124 src/olympia/discovery/templates/discovery/addons/detail.html:24
 msgid "View Privacy Policy"
 msgstr "Tampilkan Kebijakan Privasi"
 
@@ -584,8 +446,7 @@ msgstr "Tampilkan Kebijakan Privasi"
 msgid "EULA"
 msgstr "EULA"
 
-#: src/olympia/addons/templates/addons/details_box.html:171
-#: src/olympia/addons/templates/addons/details_box.html:231
+#: src/olympia/addons/templates/addons/details_box.html:171 src/olympia/addons/templates/addons/details_box.html:231
 msgid "More about this add-on"
 msgstr "Lebih jauh tentang pengaya ini"
 
@@ -593,26 +454,21 @@ msgstr "Lebih jauh tentang pengaya ini"
 msgid "Image Gallery"
 msgstr "Galeri Gambar"
 
-#: src/olympia/addons/templates/addons/details_box.html:190
-#: src/olympia/devhub/templates/devhub/addons/edit/technical.html:21
+#: src/olympia/addons/templates/addons/details_box.html:190 src/olympia/devhub/templates/devhub/addons/edit/technical.html:21
 msgid "Developer Comments"
 msgstr "Komentar Pengembang"
 
-#: src/olympia/addons/templates/addons/details_box.html:199
-#: src/olympia/addons/templates/addons/impala/details.html:259
+#: src/olympia/addons/templates/addons/details_box.html:199 src/olympia/addons/templates/addons/impala/details.html:264
 msgid "Development Channel"
 msgstr "Kanal Pengembangan"
 
-#: src/olympia/addons/templates/addons/details_box.html:202
-#: src/olympia/addons/templates/addons/mobile/details.html:124
+#: src/olympia/addons/templates/addons/details_box.html:202 src/olympia/addons/templates/addons/mobile/details.html:124
 msgid ""
-"The Development Channel lets you test an experimental new version of this "
-"add-on before it's released to the general public. Once you install the "
-"development version, you will continue to get updates from this channel."
+"The Development Channel lets you test an experimental new version of this add-on before it's released to the general public. Once you install the development version, you will continue to get "
+"updates from this channel."
 msgstr ""
-"Saluran Pengembang memungkinkan anda mengetes versi baru yang eksperimental "
-"dari pengaya ini sebelum diluncurkan kepada publik. Sekali anda memasang "
-"versi pengembangan, anda akan terus mendapatkan pembaruan dari saluran ini."
+"Saluran Pengembang memungkinkan anda mengetes versi baru yang eksperimental dari pengaya ini sebelum diluncurkan kepada publik. Sekali anda memasang versi pengembangan, anda akan terus mendapatkan "
+"pembaruan dari saluran ini."
 
 #: src/olympia/addons/templates/addons/details_box.html:207
 msgid "Install development version"
@@ -620,77 +476,52 @@ msgstr "Pasang versi pengembangan"
 
 #: src/olympia/addons/templates/addons/details_box.html:211
 msgid ""
-"<strong>Caution:</strong> Development versions of this add-on have not been "
-"reviewed by Mozilla. Once you install a development version you will "
-"continue to receive development updates from this developer. To stop "
-"receiving development updates, reinstall the default version from the link "
-"above."
+"<strong>Caution:</strong> Development versions of this add-on have not been reviewed by Mozilla. Once you install a development version you will continue to receive development updates from this "
+"developer. To stop receiving development updates, reinstall the default version from the link above."
 msgstr ""
-"<strong>Awas:</strong> Versi pengembangan pengaya ini belum diulas oleh "
-"Mozilla. Sekali anda memasang versi pengembangan anda akan terus menerima "
-"pembaruan pengembangan dari pengembang ini. Untuk berhenti menerimanya, "
-"pasang kembali versi tetap dari tautan di atas."
+"<strong>Awas:</strong> Versi pengembangan pengaya ini belum diulas oleh Mozilla. Sekali anda memasang versi pengembangan anda akan terus menerima pembaruan pengembangan dari pengembang ini. Untuk "
+"berhenti menerimanya, pasang kembali versi tetap dari tautan di atas."
 
-#: src/olympia/addons/templates/addons/details_box.html:220
-#: src/olympia/addons/templates/addons/impala/details.html:278
+#: src/olympia/addons/templates/addons/details_box.html:220 src/olympia/addons/templates/addons/impala/details.html:283
 msgid "Version {0}:"
 msgstr "Versi {0}:"
 
 #: src/olympia/addons/templates/addons/details_box.html:234
 msgid "Nothing to see here!  The developer did not include any details."
 msgstr ""
-"Tidak ada yang bisa dilihat di sini!  Pengembang tidak menyertakan rincian "
-"apapun."
 
-#: src/olympia/addons/templates/addons/details_box.html:251
-#: src/olympia/devhub/templates/devhub/versions/edit.html:73
-#: src/olympia/editors/templates/editors/review.html:98
+#: src/olympia/addons/templates/addons/details_box.html:251 src/olympia/devhub/templates/devhub/versions/edit.html:73 src/olympia/editors/templates/editors/review.html:98
 msgid "Version Notes"
 msgstr "Catatan Versi"
 
 #. {0} is the name of the add-on.
 #. {0} is the name of the add-on
-#: src/olympia/addons/templates/addons/eula.html:6
-#: src/olympia/discovery/templates/discovery/addons/eula.html:5
+#: src/olympia/addons/templates/addons/eula.html:6 src/olympia/discovery/templates/discovery/addons/eula.html:5
 msgid "End-User License Agreement for {0}"
 msgstr "Perjanjian Lisensi Pengguna Akhir untuk {0}"
 
-#: src/olympia/addons/templates/addons/eula.html:17
-#: src/olympia/addons/templates/addons/eula.html:21
-#: src/olympia/addons/templates/addons/impala/button.html:48
-#: src/olympia/addons/templates/addons/impala/details.html:316
-#: src/olympia/devhub/templates/devhub/includes/policy_form.html:3
-#: src/olympia/discovery/templates/discovery/addons/eula.html:11
+#: src/olympia/addons/templates/addons/eula.html:17 src/olympia/addons/templates/addons/eula.html:21 src/olympia/addons/templates/addons/impala/button.html:48
+#: src/olympia/addons/templates/addons/impala/details.html:321 src/olympia/devhub/templates/devhub/includes/policy_form.html:3 src/olympia/discovery/templates/discovery/addons/eula.html:11
 msgid "End-User License Agreement"
 msgstr "Perjanjian Lisensi Pengguna Akhir"
 
-#: src/olympia/addons/templates/addons/eula.html:23
-#: src/olympia/discovery/templates/discovery/addons/eula.html:13
+#: src/olympia/addons/templates/addons/eula.html:23 src/olympia/discovery/templates/discovery/addons/eula.html:13
 #, python-format
-msgid ""
-"%(addon_name)s requires that you accept the following End-User License "
-"Agreement before installation can proceed:"
-msgstr ""
-"%(addon_name)s mewajibkan Anda menyetujui Perjanjian Lisensi Pengguna Akhir "
-"sebelum pemasangan dapat dilanjutkan:"
+msgid "%(addon_name)s requires that you accept the following End-User License Agreement before installation can proceed:"
+msgstr "%(addon_name)s mewajibkan Anda menyetujui Perjanjian Lisensi Pengguna Akhir sebelum pemasangan dapat dilanjutkan:"
 
-#: src/olympia/addons/templates/addons/eula.html:34
-#: src/olympia/addons/templates/addons/privacy.html:26
+#: src/olympia/addons/templates/addons/eula.html:34 src/olympia/addons/templates/addons/privacy.html:26
 msgid "Back to {0}…"
 msgstr "Balik ke {0}…"
 
 # {0} is the application the user is browsing.  Examples:  Thunderbird,
 # Firefox,
 # Sunbird
-#: src/olympia/addons/templates/addons/home.html:3
-#: src/olympia/addons/templates/addons/mobile/home.html:3
-#: src/olympia/amo/helpers.py:235
+#: src/olympia/addons/templates/addons/home.html:3 src/olympia/addons/templates/addons/mobile/home.html:3 src/olympia/amo/helpers.py:235
 msgid "Add-ons for {0}"
 msgstr "Pengaya untuk {0}"
 
-#: src/olympia/addons/templates/addons/home.html:10
-#: src/olympia/addons/templates/addons/home.html:51
-#: src/olympia/browse/templates/browse/impala/base_listing.html:11
+#: src/olympia/addons/templates/addons/home.html:10 src/olympia/addons/templates/addons/home.html:53 src/olympia/browse/templates/browse/impala/base_listing.html:11
 msgid "Featured Extensions"
 msgstr "Ekstensi Unggulan"
 
@@ -698,70 +529,49 @@ msgstr "Ekstensi Unggulan"
 msgid "Popular Extensions"
 msgstr "Ekstensi Populer"
 
-#: src/olympia/addons/templates/addons/home.html:42
-#: src/olympia/amo/templates/amo/side_nav.html:3
-#: src/olympia/amo/templates/amo/side_nav.html:11
-#: src/olympia/amo/templates/amo/site_nav.html:3
-#: src/olympia/amo/templates/amo/site_nav.html:25
-#: src/olympia/browse/views.py:236 src/olympia/browse/views.py:281
-#: src/olympia/browse/views.py:481
+#: src/olympia/addons/templates/addons/home.html:44 src/olympia/amo/templates/amo/side_nav.html:3 src/olympia/amo/templates/amo/side_nav.html:11 src/olympia/amo/templates/amo/site_nav.html:3
+#: src/olympia/amo/templates/amo/site_nav.html:25 src/olympia/browse/views.py:203 src/olympia/browse/views.py:248 src/olympia/browse/views.py:448
 msgid "Most Popular"
 msgstr "Paling Populer"
 
-#: src/olympia/addons/templates/addons/home.html:43
+#: src/olympia/addons/templates/addons/home.html:45
 msgid "All »"
 msgstr "Semua »"
 
-#: src/olympia/addons/templates/addons/home.html:52
-#: src/olympia/addons/templates/addons/home.html:61
-#: src/olympia/addons/templates/addons/home.html:70
-#: src/olympia/addons/templates/addons/home.html:78
+#: src/olympia/addons/templates/addons/home.html:54 src/olympia/addons/templates/addons/home.html:63 src/olympia/addons/templates/addons/home.html:72 src/olympia/addons/templates/addons/home.html:80
 #: src/olympia/browse/templates/browse/impala/category_landing.html:36
 msgid "See all »"
 msgstr "Lihat semua »"
 
-#: src/olympia/addons/templates/addons/home.html:60
+#: src/olympia/addons/templates/addons/home.html:62
 msgid "Up &amp; Coming Extensions"
 msgstr "Ekstensi &amp; yang Akan Datang"
 
-#: src/olympia/addons/templates/addons/home.html:69
-#: src/olympia/browse/templates/browse/personas/category_landing.html:61
-#: src/olympia/discovery/templates/discovery/pane.html:74
+#: src/olympia/addons/templates/addons/home.html:71 src/olympia/browse/templates/browse/personas/category_landing.html:61 src/olympia/discovery/templates/discovery/pane.html:74
 msgid "Featured Themes"
 msgstr "Tema Unggulan"
 
-#: src/olympia/addons/templates/addons/home.html:77
-#: src/olympia/bandwagon/templates/bandwagon/impala/collection_listing.html:5
+#: src/olympia/addons/templates/addons/home.html:79 src/olympia/bandwagon/templates/bandwagon/impala/collection_listing.html:5
 msgid "Featured Collections"
 msgstr "Koleksi Unggulan"
 
-#: src/olympia/addons/templates/addons/listing_header.html:3
-#: src/olympia/addons/templates/addons/impala/listing/sorter.html:2
-#: src/olympia/amo/templates/amo/mobile/sort_by.html:2
+#: src/olympia/addons/templates/addons/listing_header.html:3 src/olympia/addons/templates/addons/impala/listing/sorter.html:2 src/olympia/amo/templates/amo/mobile/sort_by.html:2
 #: src/olympia/bandwagon/templates/bandwagon/collection_detail.html:118
 msgid "Sort by:"
 msgstr "Urut berdasarkan:"
 
 #. {0} is a date.
 #. {0} is a date
-#: src/olympia/addons/templates/addons/macros.html:7
-#: src/olympia/addons/templates/addons/macros.html:72
-#: src/olympia/addons/templates/addons/listing/items_mobile.html:48
-#: src/olympia/addons/templates/addons/listing/macros.html:42
-#: src/olympia/bandwagon/templates/bandwagon/collection_detail.html:50
-#: src/olympia/bandwagon/templates/bandwagon/collection_listing_items.html:40
-#: src/olympia/bandwagon/templates/bandwagon/impala/collection_listing_items.html:40
+#: src/olympia/addons/templates/addons/macros.html:7 src/olympia/addons/templates/addons/macros.html:72 src/olympia/addons/templates/addons/listing/items_mobile.html:48
+#: src/olympia/addons/templates/addons/listing/macros.html:42 src/olympia/bandwagon/templates/bandwagon/collection_detail.html:50
+#: src/olympia/bandwagon/templates/bandwagon/collection_listing_items.html:40 src/olympia/bandwagon/templates/bandwagon/impala/collection_listing_items.html:40
 msgid "Updated {0}"
 msgstr "Diperbarui pada tanggal {0}"
 
 #. {0} is a date.
-#: src/olympia/addons/templates/addons/macros.html:10
-#: src/olympia/addons/templates/addons/macros.html:69
-#: src/olympia/addons/templates/addons/persona_preview.html:21
-#: src/olympia/addons/templates/addons/listing/items_mobile.html:44
-#: src/olympia/addons/templates/addons/listing/macros.html:39
-#: src/olympia/bandwagon/templates/bandwagon/collection_listing_items.html:37
-#: src/olympia/bandwagon/templates/bandwagon/impala/collection_listing_items.html:37
+#: src/olympia/addons/templates/addons/macros.html:10 src/olympia/addons/templates/addons/macros.html:69 src/olympia/addons/templates/addons/persona_preview.html:22
+#: src/olympia/addons/templates/addons/listing/items_mobile.html:44 src/olympia/addons/templates/addons/listing/macros.html:39
+#: src/olympia/bandwagon/templates/bandwagon/collection_listing_items.html:37 src/olympia/bandwagon/templates/bandwagon/impala/collection_listing_items.html:37
 msgid "Added {0}"
 msgstr "Ditambahkan pada tanggal {0}"
 
@@ -770,28 +580,28 @@ msgstr "Ditambahkan pada tanggal {0}"
 msgid "%(num)s weekly download"
 msgid_plural "%(num)s weekly downloads"
 msgstr[0] "%(num)s unduhan mingguan"
+msgstr[1] ""
 
 #: src/olympia/addons/templates/addons/macros.html:28
 #, python-format
 msgid "%(num)s user"
 msgid_plural "%(num)s users"
 msgstr[0] "%(num)s pengguna"
+msgstr[1] ""
 
 #. {0} is the number of downloads.
-#: src/olympia/addons/templates/addons/macros.html:53
-#: src/olympia/addons/templates/addons/impala/details.html:61
+#: src/olympia/addons/templates/addons/macros.html:53 src/olympia/addons/templates/addons/impala/details.html:59
 msgid "{0} weekly download"
 msgid_plural "{0} weekly downloads"
 msgstr[0] "{0} unduhan mingguan"
+msgstr[1] ""
 
 #. {0} is the number of users.
-#: src/olympia/addons/templates/addons/macros.html:61
-#: src/olympia/addons/templates/addons/impala/details.html:54
-#: src/olympia/compat/templates/compat/index.html:71
-#: src/olympia/zadmin/templates/zadmin/compat.html:67
+#: src/olympia/addons/templates/addons/macros.html:61 src/olympia/addons/templates/addons/impala/details.html:52 src/olympia/zadmin/templates/zadmin/compat.html:67
 msgid "{0} user"
 msgid_plural "{0} users"
 msgstr[0] "{0} pengguna"
+msgstr[1] ""
 
 #: src/olympia/addons/templates/addons/paypal_result.html:12
 msgid "Payment cancelled"
@@ -805,12 +615,8 @@ msgstr "Pembayaran selesai"
 msgid "Return to the addon."
 msgstr "Kembali ke pengaya."
 
-#: src/olympia/addons/templates/addons/persona_detail.html:17
-#: src/olympia/addons/templates/addons/impala/details.html:106
-#: src/olympia/addons/templates/addons/mobile/details.html:23
-#: src/olympia/addons/templates/addons/mobile/persona_detail.html:21
-#: src/olympia/discovery/templates/discovery/addons/base.html:27
-#: src/olympia/editors/templates/editors/review.html:31
+#: src/olympia/addons/templates/addons/persona_detail.html:17 src/olympia/addons/templates/addons/impala/details.html:103 src/olympia/addons/templates/addons/mobile/details.html:23
+#: src/olympia/addons/templates/addons/mobile/persona_detail.html:21 src/olympia/discovery/templates/discovery/addons/base.html:27 src/olympia/editors/templates/editors/review.html:31
 msgid "by"
 msgstr "oleh"
 
@@ -820,8 +626,7 @@ msgid "More {0} Themes"
 msgstr "Lebih Banyak Tema {0}"
 
 #. {0} is a category name, such as Nature
-#: src/olympia/addons/templates/addons/persona_detail.html:39
-#: src/olympia/addons/templates/addons/mobile/persona_detail.html:66
+#: src/olympia/addons/templates/addons/persona_detail.html:39 src/olympia/addons/templates/addons/mobile/persona_detail.html:66
 msgid "See all {0} Themes"
 msgstr "Lihat semua Tema {0}"
 
@@ -829,184 +634,129 @@ msgstr "Lihat semua Tema {0}"
 msgid "More by this Artist"
 msgstr "Lainnya dari Seniman ini"
 
-#: src/olympia/addons/templates/addons/persona_detail.html:52
-#: src/olympia/addons/templates/addons/mobile/persona_detail.html:49
+#: src/olympia/addons/templates/addons/persona_detail.html:52 src/olympia/addons/templates/addons/mobile/persona_detail.html:49
 msgid "See all Themes by this Artist"
 msgstr "Lihat seluruh Tema oleh Seniman ini"
 
-#: src/olympia/addons/templates/addons/persona_detail.html:71
-#: src/olympia/addons/templates/addons/mobile/home.html:42
-#: src/olympia/amo/templates/amo/side_nav.html:22
-#: src/olympia/browse/templates/browse/personas/mobile/category_landing.html:28
-#: src/olympia/devhub/templates/devhub/addons/edit/basic.html:72
-#: src/olympia/editors/templates/editors/review.html:277
-#: src/olympia/editors/templates/editors/themes/themes.html:34
-#: src/olympia/templates/categories.html:7
+#: src/olympia/addons/templates/addons/persona_detail.html:71 src/olympia/addons/templates/addons/mobile/home.html:42 src/olympia/amo/templates/amo/side_nav.html:22
+#: src/olympia/browse/templates/browse/personas/mobile/category_landing.html:28 src/olympia/devhub/templates/devhub/addons/edit/basic.html:72 src/olympia/editors/templates/editors/review.html:277
+#: src/olympia/editors/templates/editors/themes/themes.html:34 src/olympia/templates/categories.html:7
 msgid "Categories"
 msgstr "Kategori"
 
-#: src/olympia/addons/templates/addons/persona_detail_table.html:10
-#: src/olympia/addons/templates/addons/mobile/persona_detail_table.html:3
-#: src/olympia/editors/templates/editors/themes/deleted.html:19
+#: src/olympia/addons/templates/addons/persona_detail_table.html:10 src/olympia/addons/templates/addons/mobile/persona_detail_table.html:3 src/olympia/editors/templates/editors/themes/deleted.html:19
 #: src/olympia/editors/templates/editors/themes/themes.html:25
 msgid "Artist"
 msgstr "Seniman"
 
-#: src/olympia/addons/templates/addons/persona_detail_table.html:19
-#: src/olympia/addons/templates/addons/mobile/persona_detail_table.html:14
-#: src/olympia/stats/templates/stats/addon_report_menu.html:17
+#: src/olympia/addons/templates/addons/persona_detail_table.html:19 src/olympia/addons/templates/addons/mobile/persona_detail_table.html:14 src/olympia/stats/templates/stats/addon_report_menu.html:17
 msgid "Daily Users"
 msgstr "Pengguna Harian"
 
 #. The License for this add-on.
-#: src/olympia/addons/templates/addons/persona_detail_table.html:26
-#: src/olympia/addons/templates/addons/impala/license.html:17
-#: src/olympia/addons/templates/addons/mobile/persona_detail_table.html:21
-#: src/olympia/devhub/templates/devhub/includes/license_form.html:5
-#: src/olympia/devhub/templates/devhub/versions/edit.html:89
-#: src/olympia/editors/templates/editors/themes/themes.html:41
+#: src/olympia/addons/templates/addons/persona_detail_table.html:26 src/olympia/addons/templates/addons/impala/license.html:17 src/olympia/addons/templates/addons/mobile/persona_detail_table.html:21
+#: src/olympia/devhub/templates/devhub/includes/license_form.html:5 src/olympia/devhub/templates/devhub/versions/edit.html:89 src/olympia/editors/templates/editors/themes/themes.html:41
 msgid "License"
 msgstr "Lisensi"
 
-#: src/olympia/addons/templates/addons/persona_preview.html:12
-#: src/olympia/constants/base.py:48
+#: src/olympia/addons/templates/addons/persona_preview.html:13 src/olympia/constants/base.py:48
 msgid "Awaiting Review"
 msgstr "Menunggu Ulasan"
 
-#: src/olympia/addons/templates/addons/persona_preview.html:14
-#: src/olympia/amo/log.py:180 src/olympia/constants/base.py:42
-#: src/olympia/editors/helpers.py:62
+#: src/olympia/addons/templates/addons/persona_preview.html:15 src/olympia/amo/log.py:180 src/olympia/constants/base.py:42 src/olympia/editors/helpers.py:62
 msgid "Rejected"
 msgstr "Ditolak"
 
-#: src/olympia/addons/templates/addons/persona_preview.html:16
-#: src/olympia/amo/log.py:159
+#: src/olympia/addons/templates/addons/persona_preview.html:17 src/olympia/amo/log.py:159
 msgid "Approved"
 msgstr "Disetujui"
 
 #. {0} is the number of users.
-#: src/olympia/addons/templates/addons/persona_preview.html:26
-#: src/olympia/addons/templates/addons/listing/items_mobile.html:36
-#: src/olympia/addons/templates/addons/listing/macros.html:31
+#: src/olympia/addons/templates/addons/persona_preview.html:27 src/olympia/addons/templates/addons/listing/items_mobile.html:36 src/olympia/addons/templates/addons/listing/macros.html:31
 msgid "<strong>{0}</strong> user"
 msgid_plural "<strong>{0}</strong> users"
 msgstr[0] "<strong>{0}</strong> pengguna"
+msgstr[1] ""
 
-#: src/olympia/addons/templates/addons/persona_preview.html:40
+#: src/olympia/addons/templates/addons/persona_preview.html:41
 msgid "Hover to Preview"
 msgstr "Layangkan untuk Pratinjau"
 
-#: src/olympia/addons/templates/addons/persona_preview.html:46
-#: src/olympia/addons/templates/addons/persona_preview.html:48
+#: src/olympia/addons/templates/addons/persona_preview.html:47 src/olympia/addons/templates/addons/persona_preview.html:49 src/olympia/addons/templates/addons/persona_preview.html:97
 #: src/olympia/reviews/templates/reviews/add.html:15
 msgid "Add"
 msgstr "Tambah"
 
-#: src/olympia/addons/templates/addons/persona_preview.html:57
-#: src/olympia/bandwagon/templates/bandwagon/ajax_new.html:16
-#: src/olympia/bandwagon/templates/bandwagon/edit.html:19
-#: src/olympia/bandwagon/templates/bandwagon/includes/addedit.html:19
-#: src/olympia/devhub/templates/devhub/addons/edit/admin.html:13
-#: src/olympia/devhub/templates/devhub/addons/edit/basic.html:10
-#: src/olympia/devhub/templates/devhub/addons/edit/details.html:8
-#: src/olympia/devhub/templates/devhub/addons/edit/media.html:6
-#: src/olympia/devhub/templates/devhub/addons/edit/support.html:8
-#: src/olympia/devhub/templates/devhub/addons/edit/technical.html:9
-#: src/olympia/devhub/templates/devhub/addons/submit/describe.html:29
-#: src/olympia/editors/templates/editors/review.html:257
+#: src/olympia/addons/templates/addons/persona_preview.html:58 src/olympia/bandwagon/templates/bandwagon/ajax_new.html:16 src/olympia/bandwagon/templates/bandwagon/edit.html:19
+#: src/olympia/bandwagon/templates/bandwagon/includes/addedit.html:19 src/olympia/devhub/templates/devhub/addons/edit/admin.html:13 src/olympia/devhub/templates/devhub/addons/edit/basic.html:10
+#: src/olympia/devhub/templates/devhub/addons/edit/details.html:8 src/olympia/devhub/templates/devhub/addons/edit/media.html:6 src/olympia/devhub/templates/devhub/addons/edit/support.html:8
+#: src/olympia/devhub/templates/devhub/addons/edit/technical.html:9 src/olympia/devhub/templates/devhub/addons/submit/describe.html:29 src/olympia/editors/templates/editors/review.html:257
 msgid "Edit"
 msgstr "Sunting"
 
 #. For datetime formatting, see the table on
 #. http://docs.python.org/library/datetime.html#strftime-and-strptime-behavior
-#: src/olympia/addons/templates/addons/persona_preview.html:66
+#: src/olympia/addons/templates/addons/persona_preview.html:67
 #, python-format
 msgid "%%Y-%%m-%%d"
 msgstr "%%Y-%%m-%%d"
 
-#: src/olympia/addons/templates/addons/persona_preview.html:67
+#: src/olympia/addons/templates/addons/persona_preview.html:68
 msgid "by {0} on {1}"
 msgstr "oleh {0} pada {1}"
 
-#: src/olympia/addons/templates/addons/persona_preview.html:75
-#: src/olympia/reviews/helpers.py:17
-#: src/olympia/reviews/templates/reviews/review_list.html:63
-#: src/olympia/reviews/templates/reviews/reviews_link.html:21
-#: src/olympia/reviews/templates/reviews/impala/reviews_link.html:16
+#: src/olympia/addons/templates/addons/persona_preview.html:76 src/olympia/reviews/helpers.py:17 src/olympia/reviews/templates/reviews/review_list.html:63
+#: src/olympia/reviews/templates/reviews/reviews_link.html:21 src/olympia/reviews/templates/reviews/impala/reviews_link.html:16
 msgid "Not yet rated"
 msgstr "Belum diperingkat"
 
-#: src/olympia/addons/templates/addons/persona_preview.html:78
+#: src/olympia/addons/templates/addons/persona_preview.html:79
 msgid "<b>{0}</b> users"
 msgstr "<b>{0}</b> pengguna"
 
 #: src/olympia/addons/templates/addons/popups.html:17
-msgid ""
-"To install this add-on and thousands more, <b>get Firefox</b>, a free and "
-"open web browser from Mozilla."
-msgstr ""
-"Untuk memasang pengaya ini dan juga ribuan lainnya, <b>dapatkan Firefox</b>,"
-" peramban web gratis dan terbuka dari Mozilla."
+msgid "To install this add-on and thousands more, <b>get Firefox</b>, a free and open web browser from Mozilla."
+msgstr "Untuk memasang pengaya ini dan juga ribuan lainnya, <b>dapatkan Firefox</b>, peramban web gratis dan terbuka dari Mozilla."
 
-#: src/olympia/addons/templates/addons/popups.html:21
-#: src/olympia/addons/templates/addons/popups.html:52
+#: src/olympia/addons/templates/addons/popups.html:21 src/olympia/addons/templates/addons/popups.html:52
 msgid "Learn more about Firefox"
 msgstr "Pelajari selengkapnya tentang Firefox"
 
 #: src/olympia/addons/templates/addons/popups.html:22
-msgid "or <b><a class=\"installer\" href=\"{url}\">download anyway</a></b>"
-msgstr "atau <b><a class=\"installer\" href=\"{url}\">unduh langsung</a></b>"
+msgid "or <b><a class=\"button installer\" href=\"{url}\">download anyway</a></b>"
+msgstr ""
 
 #: src/olympia/addons/templates/addons/popups.html:26
 msgid ""
-"<strong>How to Install in Thunderbird</strong> <ol> <li>Download and save "
-"the file to your hard disk.</li> <li>In Mozilla Thunderbird, open Add-ons "
-"from the Tools menu.</li> <li>From the options button next to the add-on "
-"search field, select \"Install Add-on From File...\" and locate the "
-"downloaded add-on.</li> </ol>"
+"<strong>How to Install in Thunderbird</strong> <ol> <li>Download and save the file to your hard disk.</li> <li>In Mozilla Thunderbird, open Add-ons from the Tools menu.</li> <li>From the options "
+"button next to the add-on search field, select \"Install Add-on From File...\" and locate the downloaded add-on.</li> </ol>"
 msgstr ""
-"<strong>Bagaimana cara Memasang Thunderbird</strong> <ol> <li>Unduh dan "
-"simpan berkas ke cakram keras anda.</li> <li>Di Mozilla Thunderbird, Pengaya"
-" terbuka dari menu Perangkat.</li> <li>Dari tombol pilihan hingga bidang "
-"pencarian pengaya, pilih \"Pasang Pengaya dari Berkas...\" dan temukan "
-"pengaya yang telah diunduh.</li> </ol>"
+"<strong>Bagaimana cara Memasang Thunderbird</strong> <ol> <li>Unduh dan simpan berkas ke cakram keras anda.</li> <li>Di Mozilla Thunderbird, Pengaya terbuka dari menu Perangkat.</li> <li>Dari "
+"tombol pilihan hingga bidang pencarian pengaya, pilih \"Pasang Pengaya dari Berkas...\" dan temukan pengaya yang telah diunduh.</li> </ol>"
 
 #: src/olympia/addons/templates/addons/popups.html:41
-msgid ""
-"To install this Theme, <b>get Thunderbird</b>, a free and open source email "
-"client from Mozilla Messaging and install the Personas Plus add-on."
-msgstr ""
-"Untuk memasang Tema ini, <b>dapatkan Thunderbird</b>, klien surel yang bebas"
-" dan sumbernya terbuka dari Mozilla Messaging dan pasang Persona Plus "
-"pengaya."
+msgid "To install this Theme, <b>get Thunderbird</b>, a free and open source email client from Mozilla Messaging and install the Personas Plus add-on."
+msgstr "Untuk memasang Tema ini, <b>dapatkan Thunderbird</b>, klien surel yang bebas dan sumbernya terbuka dari Mozilla Messaging dan pasang Persona Plus pengaya."
 
 #: src/olympia/addons/templates/addons/popups.html:46
 msgid "Learn more about Thunderbird"
 msgstr "Pelajari selengkapnya tentang Thunderbird"
 
 #: src/olympia/addons/templates/addons/popups.html:48
-msgid ""
-"To install this Theme and thousands more, <b>get Firefox</b>, a free and "
-"open web browser from Mozilla."
-msgstr ""
-"Untuk memasang tema ini dan yang ribuan lainnya, <b>dapatkan Firefox</b>, "
-"peramban gratis dan terbuka dari Mozilla."
+msgid "To install this Theme and thousands more, <b>get Firefox</b>, a free and open web browser from Mozilla."
+msgstr "Untuk memasang tema ini dan yang ribuan lainnya, <b>dapatkan Firefox</b>, peramban gratis dan terbuka dari Mozilla."
 
 #: src/olympia/addons/templates/addons/popups.html:60
 #, python-format
 msgid "This add-on has not been updated to work with your version of %(app)s."
-msgstr ""
-"Pengaya ini belum diperbarui untuk dapat bekerja dengan versi %(app)s Anda."
+msgstr "Pengaya ini belum diperbarui untuk dapat bekerja dengan versi %(app)s Anda."
 
-#: src/olympia/addons/templates/addons/popups.html:63
-#: src/olympia/addons/templates/addons/popups.html:140
-#: src/olympia/addons/templates/addons/popups.html:150
+#: src/olympia/addons/templates/addons/popups.html:63 src/olympia/addons/templates/addons/popups.html:140 src/olympia/addons/templates/addons/popups.html:150
 msgid "Install Anyway"
 msgstr "Pasang Saja"
 
 #: src/olympia/addons/templates/addons/popups.html:71
-msgid ""
-"This add-on requires a version of Firefox that has not been released yet."
+msgid "This add-on requires a version of Firefox that has not been released yet."
 msgstr "Pengaya ini membutuhkan versi Firefox yang masih belum dirilis."
 
 #: src/olympia/addons/templates/addons/popups.html:74
@@ -1015,16 +765,11 @@ msgstr "Bantu menguji Versi Firefox baru"
 
 #: src/olympia/addons/templates/addons/popups.html:77
 #, python-format
-msgid ""
-"This add-on requires %(app)s {new_version}. You are currently using %(app)s "
-"{old_version}."
-msgstr ""
-"Pengaya ini membutuhkan %(app)s {new_version}. Anda sedang menggunakan "
-"%(app)s {old_version}."
+msgid "This add-on requires %(app)s {new_version}. You are currently using %(app)s {old_version}."
+msgstr "Pengaya ini membutuhkan %(app)s {new_version}. Anda sedang menggunakan %(app)s {old_version}."
 
 #. {0} is an app name, like Firefox.
-#: src/olympia/addons/templates/addons/popups.html:82
-#: src/olympia/addons/templates/addons/popups.html:101
+#: src/olympia/addons/templates/addons/popups.html:82 src/olympia/addons/templates/addons/popups.html:101
 msgid "Upgrade {0}"
 msgstr "Perbarui {0}"
 
@@ -1035,44 +780,25 @@ msgstr "atau lihat <a href=\"%(href)s\">versi lawas pengaya ini</a>."
 
 #: src/olympia/addons/templates/addons/popups.html:96
 #, python-format
-msgid ""
-"This Persona requires %(app)s %(new_version)s. You are currently using "
-"%(app)s {old_version}."
-msgstr ""
-"Persona ini membutuhkan %(app)s %(new_version)s. Anda sedang menggunakan "
-"%(app)s {old_version}."
+msgid "This Persona requires %(app)s %(new_version)s. You are currently using %(app)s {old_version}."
+msgstr "Persona ini membutuhkan %(app)s %(new_version)s. Anda sedang menggunakan %(app)s {old_version}."
 
 #: src/olympia/addons/templates/addons/popups.html:108
 msgid ""
-"<strong>Caution:</strong> This add-on has not been reviewed by Mozilla and "
-"can't be installed on release versions of Firefox 43 and above.  Be careful "
-"when installing third-party software that might harm your computer."
+"<strong>Caution:</strong> This add-on has not been reviewed by Mozilla and can't be installed on release versions of Firefox 43 and above.  Be careful when installing third-party software that "
+"might harm your computer."
 msgstr ""
-"<strong>Awas:</strong> Pengaya ini belum diulas oleh Mozilla dan tidak bisa "
-"dipasang pada Firefox versi rilis 43 dan selanjutnya.  Berhati-hatilah saat "
-"memasang perangkat lunak dari pihak ketiga yang bisa membahayakan komputer "
-"anda."
 
 #: src/olympia/addons/templates/addons/popups.html:120
-msgid ""
-"<strong>Please note:</strong> This add-on is not compatible with your "
-"operating system."
-msgstr ""
-"<strong>Perhatikan:</strong> Pengaya ini tidak kompatibel dengan sistem "
-"operasi Anda."
+msgid "<strong>Please note:</strong> This add-on is not compatible with your operating system."
+msgstr "<strong>Perhatikan:</strong> Pengaya ini tidak kompatibel dengan sistem operasi Anda."
 
-#: src/olympia/addons/templates/addons/popups.html:136
-#: src/olympia/addons/templates/addons/impala/button.html:70
+#: src/olympia/addons/templates/addons/popups.html:136 src/olympia/addons/templates/addons/impala/button.html:70
 #, python-format
-msgid ""
-"This add-on is not compatible with your version of %(app)s because of the "
-"following:"
-msgstr ""
-"Pengaya ini tidak kompatibel dengan versi %(app)s Anda karena hal berikut "
-"ini:"
+msgid "This add-on is not compatible with your version of %(app)s because of the following:"
+msgstr "Pengaya ini tidak kompatibel dengan versi %(app)s Anda karena hal berikut ini:"
 
-#: src/olympia/addons/templates/addons/popups.html:141
-#: src/olympia/addons/templates/addons/popups.html:151
+#: src/olympia/addons/templates/addons/popups.html:141 src/olympia/addons/templates/addons/popups.html:151
 msgid "View other versions"
 msgstr "Lihat versi lain"
 
@@ -1096,144 +822,90 @@ msgid ""
 "  to your phone.  (You'll need a QR reader.  Search your phone's marketplace if\n"
 "  don't have one.)"
 msgstr ""
-"Ingin {0} di Firefox bergerak anda?  Pindai kode QR ini untuk memasang secara langsung \n"
-"  di ponsel anda.  (Anda memerlukan pembaca QR.  Carilah di marketplace ponsel jika anda tidak memilikinya \n"
-"  .)"
 
-#: src/olympia/addons/templates/addons/report_abuse.html:6
-#: src/olympia/addons/templates/addons/report_abuse_full.html:10
-#: src/olympia/addons/templates/addons/impala/details-more.html:23
-#: src/olympia/addons/templates/addons/impala/details.html:328
+#: src/olympia/addons/templates/addons/report_abuse.html:6 src/olympia/addons/templates/addons/report_abuse_full.html:10 src/olympia/addons/templates/addons/impala/details-more.html:23
+#: src/olympia/addons/templates/addons/impala/details.html:333
 msgid "Report Abuse"
 msgstr "Laporkan Penyalahgunaan"
 
 #: src/olympia/addons/templates/addons/report_abuse.html:10
 #, python-format
 msgid ""
-"If you suspect this add-on violates <a href=\"%(url)s\">our policies</a> or "
-"has security or privacy issues, please use the form below to describe your "
-"concerns. Please do not use this form for any other reason."
+"If you suspect this add-on violates <a href=\"%(url)s\">our policies</a> or has security or privacy issues, please use the form below to describe your concerns. Please do not use this form for any "
+"other reason."
 msgstr ""
-"Jika Anda menduga pengaya ini melanggar <a href=\"%(url)s\">kebijakan "
-"kami</a> atau menyebabkan masalah keamanan atau privasi, gunakan formulir di"
-" bawah ini untuk menjelaskan alasan Anda. Jangan gunakan formulir ini untuk "
-"alasan lainnya."
+"Jika Anda menduga pengaya ini melanggar <a href=\"%(url)s\">kebijakan kami</a> atau menyebabkan masalah keamanan atau privasi, gunakan formulir di bawah ini untuk menjelaskan alasan Anda. Jangan "
+"gunakan formulir ini untuk alasan lainnya."
 
-#: src/olympia/addons/templates/addons/report_abuse.html:24
-#: src/olympia/users/templates/users/report_abuse.html:19
+#: src/olympia/addons/templates/addons/report_abuse.html:24 src/olympia/users/templates/users/report_abuse.html:19
 msgid "Send Report"
 msgstr "Kirim Laporan"
 
-#: src/olympia/addons/templates/addons/report_abuse.html:26
-#: src/olympia/addons/templates/addons/mobile/eula.html:16
-#: src/olympia/addons/templates/addons/mobile/persona_confirm.html:7
-#: src/olympia/devhub/templates/devhub/addons/ajax_compat_update.html:36
-#: src/olympia/devhub/templates/devhub/addons/profile.html:44
-#: src/olympia/devhub/templates/devhub/addons/edit/admin.html:104
-#: src/olympia/devhub/templates/devhub/addons/edit/basic.html:155
-#: src/olympia/devhub/templates/devhub/addons/edit/details.html:88
-#: src/olympia/devhub/templates/devhub/addons/edit/support.html:70
-#: src/olympia/devhub/templates/devhub/addons/edit/technical.html:169
-#: src/olympia/devhub/templates/devhub/addons/forms_shared/media.html:152
-#: src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:44
-#: src/olympia/devhub/templates/devhub/personas/edit.html:222
-#: src/olympia/devhub/templates/devhub/versions/add_file_modal.html:79
-#: src/olympia/devhub/templates/devhub/versions/edit.html:140
-#: src/olympia/devhub/templates/devhub/versions/list.html:208
-#: src/olympia/devhub/templates/devhub/versions/list.html:242
-#: src/olympia/devhub/templates/devhub/versions/list.html:276
-#: src/olympia/devhub/templates/devhub/versions/list.html:317
-#: src/olympia/reviews/templates/reviews/edit_review.html:16
-#: src/olympia/translations/templates/translations/trans-menu.html:50
-#: src/olympia/translations/templates/translations/trans-menu.html:62
-#: src/olympia/zadmin/templates/zadmin/validation.html:105
+#: src/olympia/addons/templates/addons/report_abuse.html:26 src/olympia/addons/templates/addons/mobile/eula.html:16 src/olympia/addons/templates/addons/mobile/persona_confirm.html:7
+#: src/olympia/devhub/templates/devhub/addons/ajax_compat_update.html:36 src/olympia/devhub/templates/devhub/addons/profile.html:44 src/olympia/devhub/templates/devhub/addons/edit/admin.html:104
+#: src/olympia/devhub/templates/devhub/addons/edit/basic.html:155 src/olympia/devhub/templates/devhub/addons/edit/details.html:88 src/olympia/devhub/templates/devhub/addons/edit/support.html:70
+#: src/olympia/devhub/templates/devhub/addons/edit/technical.html:169 src/olympia/devhub/templates/devhub/addons/forms_shared/media.html:152
+#: src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:43 src/olympia/devhub/templates/devhub/personas/edit.html:222 src/olympia/devhub/templates/devhub/versions/add_file_modal.html:59
+#: src/olympia/devhub/templates/devhub/versions/edit.html:140 src/olympia/devhub/templates/devhub/versions/list.html:208 src/olympia/devhub/templates/devhub/versions/list.html:239
+#: src/olympia/devhub/templates/devhub/versions/list.html:281 src/olympia/devhub/templates/devhub/versions/list.html:315 src/olympia/reviews/templates/reviews/edit_review.html:16
+#: src/olympia/translations/templates/translations/trans-menu.html:50 src/olympia/translations/templates/translations/trans-menu.html:62 src/olympia/zadmin/templates/zadmin/validation.html:105
 msgid "Cancel"
 msgstr "Batal"
 
-#: src/olympia/addons/templates/addons/review_add_box.html:3
-#: src/olympia/addons/templates/addons/impala/review_add_box.html:5
+#: src/olympia/addons/templates/addons/review_add_box.html:3 src/olympia/addons/templates/addons/impala/review_add_box.html:5
 msgid "What do you think?"
 msgstr "Pendapat Anda?"
 
-#: src/olympia/addons/templates/addons/review_add_box.html:7
-#: src/olympia/addons/templates/addons/impala/review_add_box.html:9
+#: src/olympia/addons/templates/addons/review_add_box.html:7 src/olympia/addons/templates/addons/impala/review_add_box.html:9
 #, python-format
 msgid "Please <a href=\"%(login)s\">log in</a> to submit a review"
 msgstr "Tolong <a href=\"%(login)s\">masuk</a> untuk mengirim ulasan"
 
-#: src/olympia/addons/templates/addons/review_add_box.html:16
-#: src/olympia/addons/templates/addons/impala/review_add_box.html:18
-#: src/olympia/reviews/templates/reviews/mobile/add_form.html:13
+#: src/olympia/addons/templates/addons/review_add_box.html:16 src/olympia/addons/templates/addons/impala/review_add_box.html:18 src/olympia/reviews/templates/reviews/mobile/add_form.html:13
 msgid "Title:"
 msgstr "Judul:"
 
-#: src/olympia/addons/templates/addons/review_add_box.html:17
-#: src/olympia/addons/templates/addons/impala/review_add_box.html:19
-#: src/olympia/reviews/templates/reviews/mobile/add_form.html:17
+#: src/olympia/addons/templates/addons/review_add_box.html:17 src/olympia/addons/templates/addons/impala/review_add_box.html:19 src/olympia/reviews/templates/reviews/mobile/add_form.html:17
 msgid "Review:"
 msgstr "Ulasan:"
 
-#: src/olympia/addons/templates/addons/review_add_box.html:18
-#: src/olympia/addons/templates/addons/impala/review_add_box.html:20
-#: src/olympia/reviews/templates/reviews/mobile/add_form.html:16
+#: src/olympia/addons/templates/addons/review_add_box.html:18 src/olympia/addons/templates/addons/impala/review_add_box.html:20 src/olympia/reviews/templates/reviews/mobile/add_form.html:16
 msgid "Rating:"
 msgstr "Peringkat:"
 
-#: src/olympia/addons/templates/addons/review_add_box.html:19
-#: src/olympia/addons/templates/addons/impala/review_add_box.html:21
-#: src/olympia/reviews/templates/reviews/add.html:63
-#: src/olympia/reviews/templates/reviews/edit_review.html:15
-#: src/olympia/reviews/templates/reviews/mobile/add_form.html:18
+#: src/olympia/addons/templates/addons/review_add_box.html:19 src/olympia/addons/templates/addons/impala/review_add_box.html:21 src/olympia/reviews/templates/reviews/add.html:63
+#: src/olympia/reviews/templates/reviews/edit_review.html:15 src/olympia/reviews/templates/reviews/mobile/add_form.html:18
 msgid "Submit review"
 msgstr "Kirim ulasan"
 
-#: src/olympia/addons/templates/addons/review_add_box.html:24
-#: src/olympia/addons/templates/addons/impala/review_add_box.html:26
-msgid ""
-"Please do not post bug reports in reviews. We do not make your email address"
-" available to add-on developers and they may need to contact you to help "
-"resolve your issue."
+#: src/olympia/addons/templates/addons/review_add_box.html:24 src/olympia/addons/templates/addons/impala/review_add_box.html:26
+msgid "Please do not post bug reports in reviews. We do not make your email address available to add-on developers and they may need to contact you to help resolve your issue."
 msgstr ""
-"Mohon tidak mengirimkan laporan bug pada ulasan ini. Kami tidak "
-"memberitahukan alamat email anda kepada para pengembang yang mungkin mereka "
-"butuhkan untuk menghubungi anda agar masalah anda dapat diselesaikan."
+"Mohon tidak mengirimkan laporan bug pada ulasan ini. Kami tidak memberitahukan alamat email anda kepada para pengembang yang mungkin mereka butuhkan untuk menghubungi anda agar masalah anda dapat "
+"diselesaikan."
 
-#: src/olympia/addons/templates/addons/review_add_box.html:32
-#: src/olympia/addons/templates/addons/impala/review_add_box.html:35
+#: src/olympia/addons/templates/addons/review_add_box.html:32 src/olympia/addons/templates/addons/impala/review_add_box.html:35
 #, python-format
-msgid ""
-"See the <a href=\"%(support)s\">support section</a> to find out where to get"
-" assistance for this add-on."
-msgstr ""
-"Lihat <a href=\"%(support)s\">bagian dukungan</a> untuk mencari tahu kemana "
-"jika butuh bantuan untuk pengaya ini."
+msgid "See the <a href=\"%(support)s\">support section</a> to find out where to get assistance for this add-on."
+msgstr "Lihat <a href=\"%(support)s\">bagian dukungan</a> untuk mencari tahu kemana jika butuh bantuan untuk pengaya ini."
 
-#: src/olympia/addons/templates/addons/review_add_box.html:38
-#: src/olympia/addons/templates/addons/impala/review_add_box.html:42
-#: src/olympia/pages/templates/pages/review_guide.html:3
+#: src/olympia/addons/templates/addons/review_add_box.html:38 src/olympia/addons/templates/addons/impala/review_add_box.html:42 src/olympia/pages/templates/pages/review_guide.html:3
 #: src/olympia/pages/templates/pages/review_guide.html:44
 msgid "Review Guidelines"
 msgstr "Panduan Penulisan Ulasan"
 
-#: src/olympia/addons/templates/addons/review_list_box.html:5
-#: src/olympia/addons/templates/addons/impala/details-more.html:27
-#: src/olympia/editors/helpers.py:921
-#: src/olympia/reviews/templates/reviews/add.html:14
-#: src/olympia/reviews/templates/reviews/reply.html:14
-#: src/olympia/reviews/templates/reviews/review_list.html:19
+#: src/olympia/addons/templates/addons/review_list_box.html:5 src/olympia/addons/templates/addons/impala/details-more.html:27 src/olympia/editors/helpers.py:1001
+#: src/olympia/reviews/templates/reviews/add.html:14 src/olympia/reviews/templates/reviews/reply.html:14 src/olympia/reviews/templates/reviews/review_list.html:19
 #: src/olympia/reviews/templates/reviews/mobile/review_list.html:26
 msgid "Reviews"
 msgstr "Ulasan"
 
-#: src/olympia/addons/templates/addons/review_list_box.html:14
-#: src/olympia/addons/templates/addons/impala/review_list_box.html:14
-#: src/olympia/reviews/templates/reviews/review.html:30
+#: src/olympia/addons/templates/addons/review_list_box.html:14 src/olympia/addons/templates/addons/impala/review_list_box.html:14 src/olympia/reviews/templates/reviews/review.html:30
 #, python-format
 msgid "by %(user)s on %(date)s"
 msgstr "oleh %(user)s pada %(date)s"
 
-#: src/olympia/addons/templates/addons/review_list_box.html:19
-#: src/olympia/addons/templates/addons/impala/review_list_box.html:29
+#: src/olympia/addons/templates/addons/review_list_box.html:19 src/olympia/addons/templates/addons/impala/review_list_box.html:29
 msgid "Show the developer's reply to this review"
 msgstr "Hanya tampilkan balasan pengembang untuk ulasan ini"
 
@@ -1242,22 +914,18 @@ msgstr "Hanya tampilkan balasan pengembang untuk ulasan ini"
 msgid "See all reviews of this add-on"
 msgid_plural "See all %(cnt)s reviews of this add-on"
 msgstr[0] "Lihat semua %(cnt)s ulasan tentang pengaya ini"
+msgstr[1] ""
 
-#: src/olympia/addons/templates/addons/tags_box.html:3
-#: src/olympia/devhub/templates/devhub/addons/edit/basic.html:118
+#: src/olympia/addons/templates/addons/tags_box.html:3 src/olympia/devhub/templates/devhub/addons/edit/basic.html:118
 msgid "Tags"
 msgstr "Tag"
 
-#: src/olympia/addons/templates/addons/impala/addon_hovercard.html:7
-#: src/olympia/addons/templates/addons/impala/addon_hovercard.html:9
+#: src/olympia/addons/templates/addons/impala/addon_hovercard.html:7 src/olympia/addons/templates/addons/impala/addon_hovercard.html:9
 msgid "Icon for {0}"
 msgstr "Ikon untuk {0}"
 
-#: src/olympia/addons/templates/addons/impala/addon_hovercard.html:34
-#: src/olympia/addons/templates/addons/impala/featured_grid.html:26
-#: src/olympia/addons/templates/addons/impala/theme_grid.html:22
-#: src/olympia/bandwagon/templates/bandwagon/collection_detail.html:31
-#: src/olympia/users/templates/users/helpers/addon_users_list.html:7
+#: src/olympia/addons/templates/addons/impala/addon_hovercard.html:34 src/olympia/addons/templates/addons/impala/featured_grid.html:26 src/olympia/addons/templates/addons/impala/theme_grid.html:22
+#: src/olympia/bandwagon/templates/bandwagon/collection_detail.html:31 src/olympia/users/templates/users/helpers/addon_users_list.html:7
 #, python-format
 msgid "by %(users)s"
 msgstr "oleh %(users)s"
@@ -1277,34 +945,18 @@ msgstr "Menyukai pengaya ini?"
 
 #: src/olympia/addons/templates/addons/impala/contribution.html:43
 #, python-format
-msgid ""
-"The <a href=\"%(meet_url)s\">developer of this add-on</a> asks that you help"
-" support its continued development by making a small contribution."
-msgstr ""
-"<a href=\"%(meet_url)s\">Pengembang pengaya ini</a> meminta Anda membantu "
-"mendukung pengembangan berlanjut dengan berkontribusi sedikit."
+msgid "The <a href=\"%(meet_url)s\">developer of this add-on</a> asks that you help support its continued development by making a small contribution."
+msgstr "<a href=\"%(meet_url)s\">Pengembang pengaya ini</a> meminta Anda membantu mendukung pengembangan berlanjut dengan berkontribusi sedikit."
 
 #: src/olympia/addons/templates/addons/impala/contribution.html:48
 #, python-format
-msgid ""
-"The <a href=\"%(meet_url)s\">developer of this add-on</a> asks that you show"
-" your support by making a donation to the <a "
-"href=\"%(charity_url)s\">%(charity_name)s</a>."
-msgstr ""
-"Pengembang <a href=\"%(meet_url)s\">pengaya ini </a> meminta anda "
-"menunjukkan dukungan dengan menyumbang pada <a "
-"href=\"%(charity_url)s\">%(charity_name)s</a>."
+msgid "The <a href=\"%(meet_url)s\">developer of this add-on</a> asks that you show your support by making a donation to the <a href=\"%(charity_url)s\">%(charity_name)s</a>."
+msgstr "Pengembang <a href=\"%(meet_url)s\">pengaya ini </a> meminta anda menunjukkan dukungan dengan menyumbang pada <a href=\"%(charity_url)s\">%(charity_name)s</a>."
 
 #: src/olympia/addons/templates/addons/impala/contribution.html:53
 #, python-format
-msgid ""
-"The <a href=\"%(meet_url)s\">developer of this add-on</a> asks that you show"
-" your support by making a small contribution to <a "
-"href=\"%(charity_url)s\">%(charity_name)s</a>."
-msgstr ""
-"<a href=\"%(meet_url)s\">Pengembang pengaya ini</a> meminta Anda "
-"memperlihatkan dukungan Anda dengan berkontribusi sedikit ke <a "
-"href=\"%(charity_url)s\">%(charity_name)s</a>."
+msgid "The <a href=\"%(meet_url)s\">developer of this add-on</a> asks that you show your support by making a small contribution to <a href=\"%(charity_url)s\">%(charity_name)s</a>."
+msgstr "<a href=\"%(meet_url)s\">Pengembang pengaya ini</a> meminta Anda memperlihatkan dukungan Anda dengan berkontribusi sedikit ke <a href=\"%(charity_url)s\">%(charity_name)s</a>."
 
 #: src/olympia/addons/templates/addons/impala/dependencies_note.html:4
 msgid "This add-on requires the following add-ons to work properly:"
@@ -1331,147 +983,124 @@ msgstr "Bagian dari Koleksi"
 msgid "Other add-ons by %(author)s"
 msgid_plural "Other add-ons by these authors"
 msgstr[0] "Pengaya lain oleh penulis berikut"
+msgstr[1] ""
 
-#: src/olympia/addons/templates/addons/impala/details.html:41
+#: src/olympia/addons/templates/addons/impala/details.html:39
 #, python-format
 msgid "<span itemprop=\"ratingCount\">%(num)s</span> user review"
 msgid_plural "<span itemprop=\"ratingCount\">%(num)s</span> user reviews"
 msgstr[0] "<span itemprop=\"ratingCount\">%(num)s</span> ulasan pengguna"
+msgstr[1] ""
 
-#: src/olympia/addons/templates/addons/impala/details.html:69
+#: src/olympia/addons/templates/addons/impala/details.html:66
 msgid "View statistics"
 msgstr "Tampilkan statistik"
 
-#: src/olympia/addons/templates/addons/impala/details.html:84
+#: src/olympia/addons/templates/addons/impala/details.html:81
 msgid "Manage"
 msgstr "Kelola"
 
 #. {0} is an add-on name.
-#: src/olympia/addons/templates/addons/impala/details.html:96
+#: src/olympia/addons/templates/addons/impala/details.html:93
 msgid "Icon of {0}"
 msgstr "Ikon {0}"
 
-#: src/olympia/addons/templates/addons/impala/details.html:103
-#: src/olympia/addons/templates/addons/impala/listing/items.html:14
+#: src/olympia/addons/templates/addons/impala/details.html:100 src/olympia/addons/templates/addons/impala/listing/items.html:14
 msgid "No Restart"
 msgstr "Tidak bisa Mulai Ulang"
 
-#: src/olympia/addons/templates/addons/impala/details.html:127
+#: src/olympia/addons/templates/addons/impala/details.html:124
 #, python-format
 msgid "Meet the Developer: <a href=\"%(url)s\">%(name)s</a>"
 msgid_plural "<a href=\"%(url)s\">Meet the Developers</a>"
 msgstr[0] "<a href=\"%(url)s\">Bertemu dengan Pengembang</a>"
+msgstr[1] ""
 
 # {0} is an add-on name.
-#: src/olympia/addons/templates/addons/impala/details.html:137
+#: src/olympia/addons/templates/addons/impala/details.html:134
 msgid "Learn why {0} was created and find out what's next for this add-on."
-msgstr ""
-"Pelajari alasan {0} dibuat serta bagaimana pengembangan pengaya ini "
-"selanjutnya."
+msgstr "Pelajari alasan {0} dibuat serta bagaimana pengembangan pengaya ini selanjutnya."
 
 #. {0} is an index.
-#: src/olympia/addons/templates/addons/impala/details.html:156
+#: src/olympia/addons/templates/addons/impala/details.html:161
 msgid "Add-on screenshot #{0}"
 msgstr "Gambar layar pengaya #{0}"
 
-#: src/olympia/addons/templates/addons/impala/details.html:182
+#: src/olympia/addons/templates/addons/impala/details.html:187
 msgid "Add-on home page"
 msgstr "Beranda pengaya"
 
-#: src/olympia/addons/templates/addons/impala/details.html:185
+#: src/olympia/addons/templates/addons/impala/details.html:190
 msgid "Support site"
 msgstr "Situs dukungan"
 
-#: src/olympia/addons/templates/addons/impala/details.html:189
+#: src/olympia/addons/templates/addons/impala/details.html:194
 msgid "Support E-mail"
 msgstr "E-mail dukungan"
 
-#: src/olympia/addons/templates/addons/impala/details.html:194
-#: src/olympia/devhub/models.py:378
-#: src/olympia/devhub/templates/devhub/versions/list.html:12
-#: src/olympia/versions/templates/versions/version.html:6
-#: src/olympia/versions/templates/versions/mobile/version.html:6
+#: src/olympia/addons/templates/addons/impala/details.html:199 src/olympia/devhub/models.py:378 src/olympia/devhub/templates/devhub/versions/list.html:12
+#: src/olympia/versions/templates/versions/version.html:6 src/olympia/versions/templates/versions/mobile/version.html:6
 msgid "Version {0}"
 msgstr "Versi {0}"
 
-#: src/olympia/addons/templates/addons/impala/details.html:194
+#: src/olympia/addons/templates/addons/impala/details.html:199
 msgid "Info"
 msgstr "Info"
 
-#: src/olympia/addons/templates/addons/impala/details.html:195
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:129
+#: src/olympia/addons/templates/addons/impala/details.html:200 src/olympia/devhub/templates/devhub/includes/addon_details.html:116
 msgid "Last Updated:"
 msgstr "Terakhir Diperbarui:"
 
-#: src/olympia/addons/templates/addons/impala/details.html:200
+#: src/olympia/addons/templates/addons/impala/details.html:205
 #, python-format
 msgid "Released under <a target=\"_blank\" href=\"%(url)s\">%(name)s</a>"
 msgstr "Dirilis di bawah <a target=\"_blank\" href=\"%(url)s\">%(name)s</a>"
 
-#: src/olympia/addons/templates/addons/impala/details.html:201
-#: src/olympia/addons/templates/addons/impala/details.html:206
-#: src/olympia/amo/helpers.py:398 src/olympia/devhub/forms.py:142
-#: src/olympia/devhub/forms.py:173
-#: src/olympia/versions/templates/versions/version.html:40
-#: src/olympia/versions/templates/versions/version.html:45
+#: src/olympia/addons/templates/addons/impala/details.html:206 src/olympia/addons/templates/addons/impala/details.html:211 src/olympia/amo/helpers.py:398 src/olympia/devhub/forms.py:142
+#: src/olympia/devhub/forms.py:173 src/olympia/versions/templates/versions/version.html:40 src/olympia/versions/templates/versions/version.html:45
 msgid "Custom License"
 msgstr "Lisensi Khusus"
 
-#: src/olympia/addons/templates/addons/impala/details.html:205
+#: src/olympia/addons/templates/addons/impala/details.html:210
 #, python-format
 msgid "Released under <a href=\"%(url)s\">%(name)s</a>"
 msgstr "Dirilis di bawah <a href=\"%(url)s\">%(name)s</a>"
 
-#: src/olympia/addons/templates/addons/impala/details.html:217
+#: src/olympia/addons/templates/addons/impala/details.html:222
 msgid "About this Add-on"
 msgstr "Tentang Pengaya ini"
 
-#: src/olympia/addons/templates/addons/impala/details.html:233
+#: src/olympia/addons/templates/addons/impala/details.html:238
 msgid "Developer’s Comments"
 msgstr "Komentar Pengembang"
 
-#: src/olympia/addons/templates/addons/impala/details.html:243
+#: src/olympia/addons/templates/addons/impala/details.html:248
 msgid "Version Information"
 msgstr "Informasi Versi"
 
-#: src/olympia/addons/templates/addons/impala/details.html:250
+#: src/olympia/addons/templates/addons/impala/details.html:255
 msgid "See complete version history"
 msgstr "Tampilkan riwayat versi selengkapnya"
 
-#: src/olympia/addons/templates/addons/impala/details.html:262
+#: src/olympia/addons/templates/addons/impala/details.html:267
 msgid ""
-"The Development Channel lets you test an experimental new version of this "
-"add-on before it's released to the general public. Once you install the "
-"development version, you will continue to get updates from this channel. To "
-"stop receiving development updates, reinstall the default version from the "
-"link above."
+"The Development Channel lets you test an experimental new version of this add-on before it's released to the general public. Once you install the development version, you will continue to get "
+"updates from this channel. To stop receiving development updates, reinstall the default version from the link above."
 msgstr ""
-"Saluran Pengembangan memungkinkan anda mengetes versi baru yang "
-"eksperimental dari pengaya ini sebelum dirilis ke publik. Sekali anda "
-"memasang versi pengembangan, anda akan terus mendapatkan pembaruan dari "
-"saluran ini. Untuk berhenti mendapatkan pembaruan tersebut, pasang kembali "
-"versi tetap dari tautan di atas."
+"Saluran Pengembangan memungkinkan anda mengetes versi baru yang eksperimental dari pengaya ini sebelum dirilis ke publik. Sekali anda memasang versi pengembangan, anda akan terus mendapatkan "
+"pembaruan dari saluran ini. Untuk berhenti mendapatkan pembaruan tersebut, pasang kembali versi tetap dari tautan di atas."
 
-#: src/olympia/addons/templates/addons/impala/details.html:272
-msgid ""
-"<strong>Caution:</strong> Development versions of this add-on have not been "
-"reviewed by Mozilla."
-msgstr ""
-"<strong>Awas:</strong> Versi pengembangan dari pengaya ini belum diulas oleh"
-" Mozilla."
+#: src/olympia/addons/templates/addons/impala/details.html:277
+msgid "<strong>Caution:</strong> Development versions of this add-on have not been reviewed by Mozilla."
+msgstr "<strong>Awas:</strong> Versi pengembangan dari pengaya ini belum diulas oleh Mozilla."
 
-#: src/olympia/addons/templates/addons/impala/details.html:287
+#: src/olympia/addons/templates/addons/impala/details.html:292
 msgid "See complete development channel history"
 msgstr "Lihat riwayat lengkap pengembangan kanal"
 
-#: src/olympia/addons/templates/addons/impala/details.html:306
-#: src/olympia/addons/templates/addons/impala/details.html:315
-#: src/olympia/addons/templates/addons/impala/details.html:327
-#: src/olympia/addons/templates/addons/impala/review_add_box.html:4
-#: src/olympia/stats/templates/stats/popup.html:2
-#: src/olympia/stats/templates/stats/popup.html:8
-#: src/olympia/stats/templates/stats/stats.html:202
-#: src/olympia/users/templates/users/profile.html:119
+#: src/olympia/addons/templates/addons/impala/details.html:311 src/olympia/addons/templates/addons/impala/details.html:320 src/olympia/addons/templates/addons/impala/details.html:332
+#: src/olympia/addons/templates/addons/impala/review_add_box.html:4 src/olympia/stats/templates/stats/popup.html:2 src/olympia/stats/templates/stats/popup.html:8
+#: src/olympia/stats/templates/stats/stats.html:204 src/olympia/users/templates/users/profile.html:119
 msgid "close"
 msgstr "tutup"
 
@@ -1480,19 +1109,15 @@ msgstr "tutup"
 msgid "Thank you for installing {0}"
 msgstr "Terima kasih telah memasang {0}"
 
-#. {0} is an add-on name.
 # %1 is an add-on name.
+#. {0} is an add-on name.
 #: src/olympia/addons/templates/addons/impala/developers.html:12
 msgid "Meet the {0} Developer"
 msgstr "Para Pengembang {0}"
 
 #: src/olympia/addons/templates/addons/impala/developers.html:41
-msgid ""
-"Before downloading this add-on, please consider supporting the development "
-"of this add-on by making a small contribution."
-msgstr ""
-"Sebelum mengunduh pengaya ini, mohon pertimbangkan untuk ikut mendukung "
-"pengembangan pengaya ini dengan memberikan sumbangan kecil."
+msgid "Before downloading this add-on, please consider supporting the development of this add-on by making a small contribution."
+msgstr "Sebelum mengunduh pengaya ini, mohon pertimbangkan untuk ikut mendukung pengembangan pengaya ini dengan memberikan sumbangan kecil."
 
 # %1 is an add-on name.
 #: src/olympia/addons/templates/addons/impala/developers.html:80
@@ -1508,10 +1133,9 @@ msgstr "Pengembangan {0} selanjutnya"
 msgid "About the Developer"
 msgid_plural "About the Developers"
 msgstr[0] "Tentang Pengembang"
+msgstr[1] ""
 
-#: src/olympia/addons/templates/addons/impala/developers.html:96
-#: src/olympia/users/templates/users/edit.html:130
-#: src/olympia/users/templates/users/profile.html:26
+#: src/olympia/addons/templates/addons/impala/developers.html:96 src/olympia/users/templates/users/edit.html:130 src/olympia/users/templates/users/profile.html:26
 msgid "No Photo"
 msgstr "Tidak Ada Foto"
 
@@ -1531,24 +1155,15 @@ msgstr "Pengaya ini telah dimatikan oleh administrator."
 msgid "Source Code License for {addon}"
 msgstr "Lisensi Kode Sumber untuk {addon}"
 
-#: src/olympia/addons/templates/addons/impala/license.html:21
-#: src/olympia/versions/templates/versions/mobile/version.html:18
+#: src/olympia/addons/templates/addons/impala/license.html:21 src/olympia/versions/templates/versions/mobile/version.html:18
 msgid "Source Code License"
 msgstr "Lisensi Kode Sumber"
 
-#: src/olympia/addons/templates/addons/impala/persona_grid.html:16
-#: src/olympia/addons/templates/addons/impala/toplist.html:6
-msgid "{0} users"
-msgstr "{0} pengguna"
-
-#: src/olympia/addons/templates/addons/impala/review_list_box.html:19
-#: src/olympia/reviews/templates/reviews/review.html:40
+#: src/olympia/addons/templates/addons/impala/review_list_box.html:19 src/olympia/reviews/templates/reviews/review.html:40
 msgid "permalink"
 msgstr "tautan permanen"
 
-#: src/olympia/addons/templates/addons/impala/review_list_box.html:23
-#: src/olympia/editors/templates/editors/queue.html:98
-#: src/olympia/reviews/templates/reviews/review.html:44
+#: src/olympia/addons/templates/addons/impala/review_list_box.html:23 src/olympia/editors/templates/editors/queue.html:104 src/olympia/reviews/templates/reviews/review.html:44
 msgid "translate"
 msgstr "terjemahkan"
 
@@ -1557,9 +1172,9 @@ msgstr "terjemahkan"
 msgid "See all user reviews"
 msgid_plural "See all %(cnt)s user reviews"
 msgstr[0] "Lihat semua %(cnt)s ulasan pengguna"
+msgstr[1] ""
 
-#: src/olympia/addons/templates/addons/impala/review_list_box.html:47
-#: src/olympia/reviews/templates/reviews/review_list.html:84
+#: src/olympia/addons/templates/addons/impala/review_list_box.html:47 src/olympia/reviews/templates/reviews/review_list.html:84
 msgid "This add-on has not yet been reviewed."
 msgstr "Pengaya ini belum diulas."
 
@@ -1567,24 +1182,23 @@ msgstr "Pengaya ini belum diulas."
 msgid "Be the first!"
 msgstr "Jadilah yang pertama!"
 
-#: src/olympia/addons/templates/addons/impala/listing/sorter.html:14
-#: src/olympia/devhub/templates/devhub/addons/listing/item_actions.html:49
+#: src/olympia/addons/templates/addons/impala/toplist.html:6
+msgid "{0} users"
+msgstr "{0} pengguna"
+
+#: src/olympia/addons/templates/addons/impala/listing/sorter.html:14 src/olympia/devhub/templates/devhub/addons/listing/item_actions.html:49
 msgid "More"
 msgstr "Lebih banyak"
 
-#: src/olympia/addons/templates/addons/includes/collection_add_widget.html:7
-#: src/olympia/addons/templates/addons/includes/collection_add_widget.html:10
+#: src/olympia/addons/templates/addons/includes/collection_add_widget.html:7 src/olympia/addons/templates/addons/includes/collection_add_widget.html:10
 msgid "Add to collection"
 msgstr "Tambahkan ke koleksi"
 
-#: src/olympia/addons/templates/addons/includes/dashboard_tabs.html:4
-#: src/olympia/devhub/templates/devhub/index.html:73
-#: src/olympia/devhub/templates/devhub/nav.html:14
+#: src/olympia/addons/templates/addons/includes/dashboard_tabs.html:4 src/olympia/devhub/templates/devhub/index.html:73 src/olympia/devhub/templates/devhub/nav.html:14
 msgid "My Add-ons"
 msgstr "Pengayaku"
 
-#: src/olympia/addons/templates/addons/includes/dashboard_tabs.html:6
-#: src/olympia/amo/context_processors.py:51
+#: src/olympia/addons/templates/addons/includes/dashboard_tabs.html:6 src/olympia/amo/context_processors.py:50
 msgid "My Themes"
 msgstr "Tema Saya"
 
@@ -1600,8 +1214,7 @@ msgstr "Edit Tema"
 msgid "Approve / Reject"
 msgstr "Setujui / Tolak"
 
-#: src/olympia/addons/templates/addons/includes/persona.html:25
-#: src/olympia/editors/templates/editors/themes/single.html:43
+#: src/olympia/addons/templates/addons/includes/persona.html:25 src/olympia/editors/templates/editors/themes/single.html:43
 msgid "Review History"
 msgstr "Riwayat Ulasan"
 
@@ -1622,12 +1235,11 @@ msgid "Not Yet Rated"
 msgstr "Belum Diperingkat"
 
 #. {0} is the number of downloads.
-#: src/olympia/addons/templates/addons/listing/items_mobile.html:27
-#: src/olympia/addons/templates/addons/listing/macros.html:24
-#: src/olympia/devhub/templates/devhub/addons/listing/macros.html:15
+#: src/olympia/addons/templates/addons/listing/items_mobile.html:27 src/olympia/addons/templates/addons/listing/macros.html:24 src/olympia/devhub/templates/devhub/addons/listing/macros.html:15
 msgid "<strong>{0}</strong> weekly download"
 msgid_plural "<strong>{0}</strong> weekly downloads"
 msgstr[0] "<strong>{0}</strong> unduhan mingguan"
+msgstr[1] ""
 
 #: src/olympia/addons/templates/addons/mobile/details.html:32
 msgid "Read More"
@@ -1637,15 +1249,11 @@ msgstr "Baca Selengkapnya"
 msgid "Users"
 msgstr "Pengguna"
 
-#: src/olympia/addons/templates/addons/mobile/details.html:92
-#: src/olympia/browse/views.py:59 src/olympia/browse/views.py:70
-#: src/olympia/search/forms.py:90
+#: src/olympia/addons/templates/addons/mobile/details.html:92 src/olympia/browse/views.py:59 src/olympia/browse/views.py:70 src/olympia/search/forms.py:90
 msgid "Weekly Downloads"
 msgstr "Unduhan Mingguan"
 
-#: src/olympia/addons/templates/addons/mobile/details.html:99
-#: src/olympia/compat/templates/compat/reporter_detail.html:46
-#: src/olympia/devhub/forms.py:787
+#: src/olympia/addons/templates/addons/mobile/details.html:99 src/olympia/compat/templates/compat/reporter_detail.html:46 src/olympia/devhub/forms.py:788
 #: src/olympia/devhub/templates/devhub/versions/list.html:163
 msgid "Version"
 msgstr "Versi"
@@ -1681,50 +1289,30 @@ msgstr "Kesepakatan Lisensi"
 
 #: src/olympia/addons/templates/addons/mobile/eula.html:5
 #, python-format
-msgid ""
-"%(name)s requires that you accept the following End-User License Agreement "
-"before installation can proceed:"
-msgstr ""
-"%(name)s meminta anda menerima Kesepakatan Lisensi Pengguna sebelum "
-"pemasangan bisa dilanjutkan:"
+msgid "%(name)s requires that you accept the following End-User License Agreement before installation can proceed:"
+msgstr "%(name)s meminta anda menerima Kesepakatan Lisensi Pengguna sebelum pemasangan bisa dilanjutkan:"
 
 #: src/olympia/addons/templates/addons/mobile/eula.html:15
 msgid "Accept"
 msgstr "Terima"
 
-#: src/olympia/addons/templates/addons/mobile/home.html:10
-#: src/olympia/templates/mobile/base_addons.html:53
+#: src/olympia/addons/templates/addons/mobile/home.html:10 src/olympia/templates/mobile/base_addons.html:53
 msgid "Add-ons are not currently available on Firefox for iOS."
 msgstr "Pengaya berikut saat ini belum tersedia di Firefox untuk iOS."
 
-#: src/olympia/addons/templates/addons/mobile/home.html:12
-#: src/olympia/templates/mobile/base_addons.html:55
-msgid ""
-"You need Firefox to install add-ons. <a "
-"href=\"http://mozilla.com/mobile\">Learn More&nbsp;&raquo;</a>"
-msgstr ""
-"Anda perlu Firefox untuk memasang pengaya. <a "
-"href=\"http://mozilla.com/mobile\">Pelajari Lebih Lanjut&nbsp;&raquo;</a>"
+#: src/olympia/addons/templates/addons/mobile/home.html:12 src/olympia/templates/mobile/base_addons.html:55
+msgid "You need Firefox to install add-ons. <a href=\"http://mozilla.com/mobile\">Learn More&nbsp;&raquo;</a>"
+msgstr "Anda perlu Firefox untuk memasang pengaya. <a href=\"http://mozilla.com/mobile\">Pelajari Lebih Lanjut&nbsp;&raquo;</a>"
 
 # {0} is the application name.  Example:  Firefox
-#: src/olympia/addons/templates/addons/mobile/home.html:19
-#: src/olympia/templates/header_title.html:4
-#: src/olympia/templates/impala/header_title.html:3
+#: src/olympia/addons/templates/addons/mobile/home.html:19 src/olympia/templates/header_title.html:4 src/olympia/templates/impala/header_title.html:3
 msgid "Return to the {0} Add-ons homepage"
 msgstr "Kembali ke Beranda Pengaya {0}"
 
-#: src/olympia/addons/templates/addons/mobile/home.html:21
-#: src/olympia/amo/helpers.py:237
-#: src/olympia/bandwagon/templates/bandwagon/edit.html:34
-#: src/olympia/discovery/templates/discovery/pane.html:92
-#: src/olympia/editors/templates/editors/base.html:21
-#: src/olympia/editors/templates/editors/performance.html:72
-#: src/olympia/templates/menu_links.html:4
-#: src/olympia/templates/impala/header_title.html:13
-#: src/olympia/templates/impala/header_title.html:15
-#: src/olympia/templates/impala/header_title.html:19
-#: src/olympia/templates/impala/header_title.html:23
-#: src/olympia/templates/mobile/base_addons.html:47
+#: src/olympia/addons/templates/addons/mobile/home.html:21 src/olympia/amo/helpers.py:237 src/olympia/bandwagon/templates/bandwagon/edit.html:34 src/olympia/discovery/templates/discovery/pane.html:92
+#: src/olympia/editors/templates/editors/base.html:21 src/olympia/editors/templates/editors/performance.html:72 src/olympia/templates/menu_links.html:4
+#: src/olympia/templates/impala/header_title.html:13 src/olympia/templates/impala/header_title.html:15 src/olympia/templates/impala/header_title.html:19
+#: src/olympia/templates/impala/header_title.html:23 src/olympia/templates/mobile/base_addons.html:47
 msgid "Add-ons"
 msgstr "Pengaya"
 
@@ -1732,48 +1320,28 @@ msgstr "Pengaya"
 msgid "Easy ways to personalize."
 msgstr "Cara mudah untuk personalisasi."
 
-#: src/olympia/addons/templates/addons/mobile/home.html:24
-#: src/olympia/devhub/templates/devhub/addons/submit/done.html:47
-#: src/olympia/discovery/templates/discovery/pane.html:34
-#: src/olympia/discovery/templates/discovery/addons/detail.html:16
-#: src/olympia/discovery/templates/discovery/modules/featured.html:21
-#: src/olympia/discovery/templates/discovery/modules/monthly.html:22
+#: src/olympia/addons/templates/addons/mobile/home.html:24 src/olympia/devhub/templates/devhub/addons/submit/done.html:47 src/olympia/discovery/templates/discovery/pane.html:34
+#: src/olympia/discovery/templates/discovery/addons/detail.html:16 src/olympia/discovery/templates/discovery/modules/featured.html:21 src/olympia/discovery/templates/discovery/modules/monthly.html:22
 msgid "Learn More"
 msgstr "Pelajari lebih Lanjut"
 
 #: src/olympia/addons/templates/addons/mobile/home.html:26
 msgid ""
-"Add-ons are applications that let you personalize Firefox with extra "
-"functionality and style. Whether you mistype the name of a website or can't "
-"read a busy page, there's an add-on to improve your on-the-go browsing."
+"Add-ons are applications that let you personalize Firefox with extra functionality and style. Whether you mistype the name of a website or can't read a busy page, there's an add-on to improve your "
+"on-the-go browsing."
 msgstr ""
-"Pengaya adalah aplikasi yang memungkinkan anda mempersonifikasi Firefox "
-"dengan fungsi-fungsi dan gaya ekstra. Apakah anda salah mengetik nama situs "
-"atau tidak bisa membaca laman yang sibuk, tersedia pengaya untuk memperbaiki"
-" penjelajahan anda."
+"Pengaya adalah aplikasi yang memungkinkan anda mempersonifikasi Firefox dengan fungsi-fungsi dan gaya ekstra. Apakah anda salah mengetik nama situs atau tidak bisa membaca laman yang sibuk, "
+"tersedia pengaya untuk memperbaiki penjelajahan anda."
 
 #. {0} is a category name. Ex: "Sports"
 #. {0} is a category name, such as Nature.
-#: src/olympia/addons/templates/addons/mobile/home.html:43
-#: src/olympia/amo/templates/amo/site_nav.html:32
-#: src/olympia/browse/feeds.py:107
-#: src/olympia/browse/templates/browse/impala/base_listing.html:38
-#: src/olympia/browse/templates/browse/personas/base.html:6
-#: src/olympia/browse/templates/browse/personas/base.html:42
-#: src/olympia/browse/templates/browse/personas/category_landing.html:21
-#: src/olympia/browse/templates/browse/personas/category_landing.html:23
-#: src/olympia/browse/templates/browse/personas/category_landing.html:38
-#: src/olympia/browse/templates/browse/personas/grid.html:7
-#: src/olympia/browse/templates/browse/personas/grid.html:11
-#: src/olympia/browse/templates/browse/personas/mobile/base.html:7
-#: src/olympia/browse/templates/browse/personas/mobile/category_landing.html:19
-#: src/olympia/constants/base.py:180
-#: src/olympia/devhub/templates/devhub/personas/submit.html:13
-#: src/olympia/editors/helpers.py:105
-#: src/olympia/editors/templates/editors/base.html:26
-#: src/olympia/editors/templates/editors/performance.html:73
-#: src/olympia/search/templates/search/personas.html:39
-#: src/olympia/templates/menu_links.html:9
+#: src/olympia/addons/templates/addons/mobile/home.html:43 src/olympia/amo/templates/amo/site_nav.html:32 src/olympia/browse/feeds.py:107
+#: src/olympia/browse/templates/browse/impala/base_listing.html:38 src/olympia/browse/templates/browse/personas/base.html:6 src/olympia/browse/templates/browse/personas/base.html:42
+#: src/olympia/browse/templates/browse/personas/category_landing.html:21 src/olympia/browse/templates/browse/personas/category_landing.html:23
+#: src/olympia/browse/templates/browse/personas/category_landing.html:38 src/olympia/browse/templates/browse/personas/grid.html:7 src/olympia/browse/templates/browse/personas/grid.html:11
+#: src/olympia/browse/templates/browse/personas/mobile/base.html:7 src/olympia/browse/templates/browse/personas/mobile/category_landing.html:19 src/olympia/constants/base.py:180
+#: src/olympia/devhub/templates/devhub/personas/submit.html:13 src/olympia/editors/helpers.py:107 src/olympia/editors/templates/editors/base.html:26
+#: src/olympia/editors/templates/editors/performance.html:73 src/olympia/search/templates/search/personas.html:39 src/olympia/templates/menu_links.html:9
 msgid "Themes"
 msgstr "Tema"
 
@@ -1789,19 +1357,12 @@ msgstr "Tampilkan semua pengaya Populer"
 msgid "More Add-ons"
 msgstr "Lebih banyak Pengaya"
 
-#: src/olympia/addons/templates/addons/mobile/home.html:72
-#: src/olympia/browse/templates/browse/personas/mobile/category_landing.html:64
-#: src/olympia/search/forms.py:14
+#: src/olympia/addons/templates/addons/mobile/home.html:72 src/olympia/browse/templates/browse/personas/mobile/category_landing.html:64 src/olympia/search/forms.py:14
 msgid "Highest Rated"
 msgstr "Peringkat Tertinggi"
 
-#: src/olympia/addons/templates/addons/mobile/home.html:74
-#: src/olympia/amo/templates/amo/side_nav.html:5
-#: src/olympia/amo/templates/amo/site_nav.html:27
-#: src/olympia/amo/templates/amo/site_nav.html:57
-#: src/olympia/bandwagon/views.py:97 src/olympia/browse/views.py:57
-#: src/olympia/browse/views.py:67
-#: src/olympia/browse/templates/browse/personas/mobile/category_landing.html:65
+#: src/olympia/addons/templates/addons/mobile/home.html:74 src/olympia/amo/templates/amo/side_nav.html:5 src/olympia/amo/templates/amo/site_nav.html:27 src/olympia/amo/templates/amo/site_nav.html:55
+#: src/olympia/bandwagon/views.py:97 src/olympia/browse/views.py:57 src/olympia/browse/views.py:67 src/olympia/browse/templates/browse/personas/mobile/category_landing.html:65
 #: src/olympia/search/forms.py:15 src/olympia/search/forms.py:87
 msgid "Newest"
 msgstr "Terbaru"
@@ -1814,122 +1375,90 @@ msgstr "Cobalah!"
 msgid "Theme Info &raquo;"
 msgstr "Info Tema &raquo;"
 
-#: src/olympia/amo/context_processors.py:39
-#: src/olympia/devhub/templates/devhub/nav.html:43
+#: src/olympia/amo/context_processors.py:37 src/olympia/devhub/templates/devhub/nav.html:43
 msgid "Tools"
 msgstr "Perangkat"
 
-#: src/olympia/amo/context_processors.py:48
-#: src/olympia/discovery/templates/discovery/pane_account.html:8
-#: src/olympia/users/templates/users/includes/navigation.html:2
+#: src/olympia/amo/context_processors.py:47 src/olympia/discovery/templates/discovery/pane_account.html:8 src/olympia/users/templates/users/includes/navigation.html:2
 msgid "My Profile"
 msgstr "Profil Saya"
 
-#: src/olympia/amo/context_processors.py:54
-#: src/olympia/users/templates/users/edit.html:5
-#: src/olympia/users/templates/users/includes/navigation.html:3
+#: src/olympia/amo/context_processors.py:53 src/olympia/users/templates/users/edit.html:5 src/olympia/users/templates/users/includes/navigation.html:3
 msgid "Account Settings"
 msgstr "Setelan Akun"
 
-#: src/olympia/amo/context_processors.py:57
-#: src/olympia/discovery/templates/discovery/pane_account.html:11
-#: src/olympia/users/templates/users/profile.html:83
+#: src/olympia/amo/context_processors.py:56 src/olympia/discovery/templates/discovery/pane_account.html:11 src/olympia/users/templates/users/profile.html:83
 #: src/olympia/users/templates/users/includes/navigation.html:4
 msgid "My Collections"
 msgstr "Koleksi Saya"
 
-#: src/olympia/amo/context_processors.py:62
-#: src/olympia/discovery/templates/discovery/pane_account.html:10
-#: src/olympia/users/templates/users/includes/navigation.html:7
+#: src/olympia/amo/context_processors.py:61 src/olympia/discovery/templates/discovery/pane_account.html:10 src/olympia/users/templates/users/includes/navigation.html:7
 msgid "My Favorites"
 msgstr "Favorit Saya"
 
-#: src/olympia/amo/context_processors.py:67
-#: src/olympia/discovery/templates/discovery/pane_account.html:13
-#: src/olympia/templates/impala/user_login.html:14
+#: src/olympia/amo/context_processors.py:66 src/olympia/discovery/templates/discovery/pane_account.html:13 src/olympia/templates/impala/user_login.html:14
 #: src/olympia/templates/mobile/header_auth.html:5
 msgid "Log out"
 msgstr "Keluar"
 
-#: src/olympia/amo/context_processors.py:72
-#: src/olympia/devhub/templates/devhub/addons/dashboard.html:4
+#: src/olympia/amo/context_processors.py:71 src/olympia/devhub/templates/devhub/addons/dashboard.html:4
 msgid "Manage My Submissions"
 msgstr "Mengelola Pendaftaran Saya"
 
-#: src/olympia/amo/context_processors.py:75
-#: src/olympia/devhub/templates/devhub/nav.html:27
-#: src/olympia/devhub/templates/devhub/addons/dashboard.html:25
+#: src/olympia/amo/context_processors.py:74 src/olympia/devhub/templates/devhub/nav.html:27 src/olympia/devhub/templates/devhub/addons/dashboard.html:25
 #: src/olympia/devhub/templates/devhub/addons/submit/base.html:4
 msgid "Submit a New Add-on"
 msgstr "Memasukkan Pengaya Baru"
 
-#: src/olympia/amo/context_processors.py:77
-#: src/olympia/browse/templates/browse/personas/base.html:50
-#: src/olympia/devhub/templates/devhub/index.html:24
+#: src/olympia/amo/context_processors.py:76 src/olympia/browse/templates/browse/personas/base.html:50 src/olympia/devhub/templates/devhub/index.html:24
 #: src/olympia/devhub/templates/devhub/addons/dashboard.html:29
 msgid "Submit a New Theme"
 msgstr "Memasukkan Tema Baru"
 
-#: src/olympia/amo/context_processors.py:79
-#: src/olympia/amo/templates/amo/site_nav.html:87
-#: src/olympia/devhub/helpers.py:36 src/olympia/devhub/helpers.py:68
-#: src/olympia/devhub/helpers.py:102 src/olympia/templates/footer.html:6
-#: src/olympia/templates/menu_links.html:14
+#: src/olympia/amo/context_processors.py:78 src/olympia/amo/templates/amo/site_nav.html:85 src/olympia/devhub/helpers.py:36 src/olympia/devhub/helpers.py:68 src/olympia/devhub/helpers.py:102
+#: src/olympia/templates/footer.html:6 src/olympia/templates/menu_links.html:14
 msgid "Developer Hub"
 msgstr "Pusat Pengembang"
 
-#: src/olympia/amo/context_processors.py:83 src/olympia/devhub/views.py:1792
+#: src/olympia/amo/context_processors.py:81 src/olympia/devhub/views.py:1796
 msgid "Manage API Keys"
 msgstr "Mengelola Kunci API"
 
-#: src/olympia/amo/context_processors.py:88 src/olympia/editors/helpers.py:82
-#: src/olympia/editors/helpers.py:102
-#: src/olympia/editors/templates/editors/base.html:10
+#: src/olympia/amo/context_processors.py:86 src/olympia/editors/helpers.py:84 src/olympia/editors/helpers.py:104 src/olympia/editors/templates/editors/base.html:10
 msgid "Editor Tools"
 msgstr "Інструменти редактора"
 
-#: src/olympia/amo/context_processors.py:92
+#: src/olympia/amo/context_processors.py:90
 msgid "Admin Tools"
 msgstr "Адміністративні інструменти"
 
-#: src/olympia/amo/fields.py:15
+#: src/olympia/amo/fields.py:20
 msgid "Incorrect, please try again."
 msgstr "Salah, coba lagi."
 
-#: src/olympia/amo/fields.py:16
+#: src/olympia/amo/fields.py:21
 msgid "Error verifying input, please try again."
 msgstr "Salah memverifikasi pendaftaran, silakan coba lagi."
 
-#: src/olympia/amo/fields.py:32
+#: src/olympia/amo/fields.py:37
 msgid "This must be a valid hex color code, such as #000000."
 msgstr "Ini harus menjadi kode warna hex, seperti #000000."
 
-#: src/olympia/amo/fields.py:58
+#: src/olympia/amo/fields.py:63
 msgid "Enter at least one value."
 msgstr "Masukkan paling sedikit satu nilai."
 
-#: src/olympia/amo/helpers.py:162
-#: src/olympia/amo/templates/amo/site_nav.html:61
-#: src/olympia/bandwagon/templates/bandwagon/add.html:9
-#: src/olympia/bandwagon/templates/bandwagon/collection_detail.html:15
-#: src/olympia/bandwagon/templates/bandwagon/delete.html:9
-#: src/olympia/bandwagon/templates/bandwagon/edit.html:15
-#: src/olympia/bandwagon/templates/bandwagon/user_listing.html:18
-#: src/olympia/bandwagon/templates/bandwagon/user_listing.html:21
-#: src/olympia/bandwagon/templates/bandwagon/impala/collection_listing.html:12
-#: src/olympia/bandwagon/templates/bandwagon/impala/collection_listing.html:20
-#: src/olympia/bandwagon/templates/bandwagon/impala/collection_listing.html:24
-#: src/olympia/bandwagon/templates/bandwagon/impala/collection_sidebar.html:3
-#: src/olympia/bandwagon/templates/bandwagon/includes/collection_sidebar.html:2
-#: src/olympia/bandwagon/templates/bandwagon/mobile/collection_listing.html:3
-#: src/olympia/stats/templates/stats/stats.html:77
-#: src/olympia/templates/menu_links.html:12
+#: src/olympia/amo/helpers.py:162 src/olympia/amo/templates/amo/site_nav.html:59 src/olympia/bandwagon/templates/bandwagon/add.html:9
+#: src/olympia/bandwagon/templates/bandwagon/collection_detail.html:15 src/olympia/bandwagon/templates/bandwagon/delete.html:9 src/olympia/bandwagon/templates/bandwagon/edit.html:15
+#: src/olympia/bandwagon/templates/bandwagon/user_listing.html:18 src/olympia/bandwagon/templates/bandwagon/user_listing.html:21
+#: src/olympia/bandwagon/templates/bandwagon/impala/collection_listing.html:12 src/olympia/bandwagon/templates/bandwagon/impala/collection_listing.html:20
+#: src/olympia/bandwagon/templates/bandwagon/impala/collection_listing.html:24 src/olympia/bandwagon/templates/bandwagon/impala/collection_sidebar.html:3
+#: src/olympia/bandwagon/templates/bandwagon/includes/collection_sidebar.html:2 src/olympia/bandwagon/templates/bandwagon/mobile/collection_listing.html:3
+#: src/olympia/stats/templates/stats/stats.html:33 src/olympia/templates/menu_links.html:12
 msgid "Collections"
 msgstr "Koleksi"
 
-#: src/olympia/amo/helpers.py:171
-#: src/olympia/amo/templates/amo/site_nav.html:85
-#: src/olympia/browse/templates/browse/language_tools.html:3
+#: src/olympia/amo/helpers.py:171 src/olympia/amo/templates/amo/site_nav.html:83 src/olympia/browse/templates/browse/language_tools.html:3
 msgid "Dictionaries & Language Packs"
 msgstr "Kamus & Paket Bahasa"
 
@@ -2081,11 +1610,8 @@ msgstr "Ulasan super dimintakan"
 msgid "Comment on {addon} {version}."
 msgstr "Komentar untuk {addon} {version}."
 
-#: src/olympia/amo/log.py:236
-#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:19
-#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:47
-#: src/olympia/editors/helpers.py:511
-#: src/olympia/editors/templates/editors/themes/history_table.html:11
+#: src/olympia/amo/log.py:236 src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:17 src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:45
+#: src/olympia/editors/helpers.py:584 src/olympia/editors/templates/editors/themes/history_table.html:11
 msgid "Comment"
 msgstr "Komentar"
 
@@ -2239,7 +1765,7 @@ msgstr "Eskalasi pengulas"
 
 #: src/olympia/amo/log.py:442
 msgid "Video removed from {addon} because of a problem with the video. "
-msgstr "Video dihilangkan dari {addon} karena ada masalah dengan video. "
+msgstr ""
 
 #: src/olympia/amo/log.py:444
 msgid "Video removed"
@@ -2343,10 +1869,7 @@ msgstr "{addon} peringkat konten diubah."
 msgid "{addon} unlisted."
 msgstr "{addon} tidak terdaftar."
 
-#: src/olympia/amo/log.py:592 src/olympia/amo/log.py:598
-#: src/olympia/amo/log.py:612 src/olympia/amo/log.py:618
-#: src/olympia/amo/log.py:624 src/olympia/amo/log.py:630
-#: src/olympia/amo/log.py:636
+#: src/olympia/amo/log.py:592 src/olympia/amo/log.py:598 src/olympia/amo/log.py:612 src/olympia/amo/log.py:618 src/olympia/amo/log.py:624 src/olympia/amo/log.py:630 src/olympia/amo/log.py:636
 msgid "{file} was signed."
 msgstr "{file} telah ditandatangani."
 
@@ -2360,19 +1883,12 @@ msgid "Not allowed"
 msgstr "Tidak diizinkan"
 
 #: src/olympia/amo/templates/amo/403.html:7
-msgid ""
-"<h1>Oops! Not allowed.</h1> <p>You tried to do something that you weren't "
-"allowed to.</p>"
-msgstr ""
-"<h1>Ups! Tidak diijinkan.</h1> <p>Anda mencoba melakukan sesuatu yang tidak "
-"diijinkan.</p>"
+msgid "<h1>Oops! Not allowed.</h1> <p>You tried to do something that you weren't allowed to.</p>"
+msgstr "<h1>Ups! Tidak diijinkan.</h1> <p>Anda mencoba melakukan sesuatu yang tidak diijinkan.</p>"
 
 #: src/olympia/amo/templates/amo/403.html:12
-msgid ""
-"<p>Try going back to the previous page, refreshing and then trying "
-"again.</p>"
-msgstr ""
-"<p>Cobalah kembali ke laman sebelumnya, segarkan dan kemudian coba lagi.</p>"
+msgid "<p>Try going back to the previous page, refreshing and then trying again.</p>"
+msgstr "<p>Cobalah kembali ke laman sebelumnya, segarkan dan kemudian coba lagi.</p>"
 
 #: src/olympia/amo/templates/amo/404.html:3
 msgid "Not Found"
@@ -2381,37 +1897,19 @@ msgstr "Tidak Ditemukan"
 #: src/olympia/amo/templates/amo/404.html:6
 #, python-format
 msgid ""
-"<h1>We're sorry, but we can't find what you're looking for.</h1> <p> The "
-"page or file you requested wasn't found on our site. It's possible that you "
-"clicked a link that's out of date, or typed in the address incorrectly. </p>"
-" <ul> <li>If you typed in the address, please double check the "
-"spelling.</li> <li> If you followed a link from somewhere, please let us "
-"know at <a href=\"mailto:webmaster@mozilla.com\">webmaster@mozilla.com</a>. "
-"Tell us where you came from and what you were looking for, and we'll do our "
-"best to fix it. </li> </ul> <p>Or you can just jump over to some of the "
-"popular pages on our website.</p> <ul> <li>Are you interested in a <a "
-"href=\"%(rec)s\">list of featured add-ons</a>?</li> <li> Do you want to <a "
-"href=\"%(search)s\">search for add-ons</a>? You may go to the <a "
-"href=\"%(search)s\">search page</a> or just use the search field above. "
-"</li> <li> If you prefer to start over, just go to the <a href=\"%(home)s"
-"\">add-ons front page</a>. </li> </ul>"
+"<h1>We're sorry, but we can't find what you're looking for.</h1> <p> The page or file you requested wasn't found on our site. It's possible that you clicked a link that's out of date, or typed in "
+"the address incorrectly. </p> <ul> <li>If you typed in the address, please double check the spelling.</li> <li> If you followed a link from somewhere, please let us know at <a href=\"mailto:"
+"webmaster@mozilla.com\">webmaster@mozilla.com</a>. Tell us where you came from and what you were looking for, and we'll do our best to fix it. </li> </ul> <p>Or you can just jump over to some of "
+"the popular pages on our website.</p> <ul> <li>Are you interested in a <a href=\"%(rec)s\">list of featured add-ons</a>?</li> <li> Do you want to <a href=\"%(search)s\">search for add-ons</a>? You "
+"may go to the <a href=\"%(search)s\">search page</a> or just use the search field above. </li> <li> If you prefer to start over, just go to the <a href=\"%(home)s\">add-ons front page</a>. </li> </"
+"ul>"
 msgstr ""
-"<h1>Kami mohon maaf, tetapi kami tidak dapat menemukan yang Anda cari.</h1> "
-"<p> Laman atau berkas yang Anda minta tidak ditemukan pada situs kami. "
-"Mungkin saja Anda mengeklik tautan yang sudah usang atau salah "
-"mengetikkannya. </p> <ul> <li>Jika Anda mengetikkan alamatnya, periksa lagi "
-"apakah sudah benar.</li> <li> Jika Anda menelusuri tautan dari tempat lain, "
-"hubungi kami di <a "
-"href=\"mailto:webmaster@mozilla.com\">webmaster@mozilla.com</a>. Silakan "
-"beri tahu kami lewat mana Anda datang dan apa yang sedang Anda cari, kami "
-"akan berusaha sebaik mungkin menemukannya. </li> </ul> <p>Atau Anda dapat "
-"langsung membuka laman populer pada situs web kami.</p> <ul> <li>Apakah Anda"
-" tertarik untuk melihat <a href=\"%(rec)s\">daftar pengaya "
-"unggulan</a>?</li> <li> Atau ingin <a href=\"%(search)s\">mencari "
-"pengaya</a>? Anda juga dapat langsung menuju ke <a href=\"%(search)s\">laman"
-" pencarian</a> atau gunakan kotak pencarian di atas. </li> <li> Jika Anda "
-"ingin memulai dari awal, buka saja <a href=\"%(home)s\">laman beranda "
-"pengaya</a>. </li> </ul>"
+"<h1>Kami mohon maaf, tetapi kami tidak dapat menemukan yang Anda cari.</h1> <p> Laman atau berkas yang Anda minta tidak ditemukan pada situs kami. Mungkin saja Anda mengeklik tautan yang sudah "
+"usang atau salah mengetikkannya. </p> <ul> <li>Jika Anda mengetikkan alamatnya, periksa lagi apakah sudah benar.</li> <li> Jika Anda menelusuri tautan dari tempat lain, hubungi kami di <a href="
+"\"mailto:webmaster@mozilla.com\">webmaster@mozilla.com</a>. Silakan beri tahu kami lewat mana Anda datang dan apa yang sedang Anda cari, kami akan berusaha sebaik mungkin menemukannya. </li> </ul> "
+"<p>Atau Anda dapat langsung membuka laman populer pada situs web kami.</p> <ul> <li>Apakah Anda tertarik untuk melihat <a href=\"%(rec)s\">daftar pengaya unggulan</a>?</li> <li> Atau ingin <a href="
+"\"%(search)s\">mencari pengaya</a>? Anda juga dapat langsung menuju ke <a href=\"%(search)s\">laman pencarian</a> atau gunakan kotak pencarian di atas. </li> <li> Jika Anda ingin memulai dari awal, "
+"buka saja <a href=\"%(home)s\">laman beranda pengaya</a>. </li> </ul>"
 
 #: src/olympia/amo/templates/amo/500.html:3
 msgid "Oops"
@@ -2419,82 +1917,49 @@ msgstr "Aduh"
 
 #: src/olympia/amo/templates/amo/500.html:6
 #, python-format
-msgid ""
-"<h1>Oops!  We had an error.</h1> <p>We'll get to fixing that soon.</p> <p> "
-"You can try refreshing the page, or head back to the <a href=\"%(home)s"
-"\">Add-ons homepage</a>. </p>"
+msgid "<h1>Oops!  We had an error.</h1> <p>We'll get to fixing that soon.</p> <p> You can try refreshing the page, or head back to the <a href=\"%(home)s\">Add-ons homepage</a>. </p>"
 msgstr ""
-"<h1>Ups!  Terjadi kesalahan.</h1> <p>Kami akan memperbaikinya segera.</p> "
-"<p> Anda bisa mencoba menyegarkan laman, atau kembali ke <a "
-"href=\"%(home)s\">beranda Pengaya</a>. </p>"
 
 #: src/olympia/amo/templates/amo/license_link.html:10
 msgid "Some rights reserved"
 msgstr "Sebagian hak cipta dilindungi"
 
-#: src/olympia/amo/templates/amo/no_results.html:1
-#: src/olympia/editors/templates/editors/includes/search_results_themes.html:26
+#: src/olympia/amo/templates/amo/no_results.html:1 src/olympia/editors/templates/editors/includes/search_results_themes.html:26
 msgid "No results found"
 msgstr "Tak ada hasil yang ditemukan"
 
 #. abbreviation of 'previous'
-#: src/olympia/amo/templates/amo/paginator.html:6
-#: src/olympia/amo/templates/amo/mobile/paginator.html:4
-#: src/olympia/amo/templates/amo/mobile/paginator.html:6
-#: src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:49
-#: src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:63
-#: src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:76
-#: src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:89
+#: src/olympia/amo/templates/amo/paginator.html:6 src/olympia/amo/templates/amo/mobile/paginator.html:4 src/olympia/amo/templates/amo/mobile/paginator.html:6
+#: src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:49 src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:63
+#: src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:76 src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:89
 #: src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:102
 msgid "Prev"
 msgstr "Sebelumnya"
 
-#: src/olympia/amo/templates/amo/paginator.html:26
-#: src/olympia/amo/templates/amo/impala/paginator.html:26
-#: src/olympia/amo/templates/amo/mobile/impala_paginator.html:16
-#: src/olympia/amo/templates/amo/mobile/paginator.html:14
-#: src/olympia/amo/templates/amo/mobile/paginator.html:16
-#: src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:51
-#: src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:65
-#: src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:78
-#: src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:91
-#: src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:104
-#: src/olympia/discovery/templates/discovery/pane.html:45
-#: src/olympia/discovery/templates/discovery/addons/detail.html:39
-#: src/olympia/stats/templates/stats/stats.html:167
+#: src/olympia/amo/templates/amo/paginator.html:26 src/olympia/amo/templates/amo/impala/paginator.html:26 src/olympia/amo/templates/amo/mobile/impala_paginator.html:16
+#: src/olympia/amo/templates/amo/mobile/paginator.html:14 src/olympia/amo/templates/amo/mobile/paginator.html:16 src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:51
+#: src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:65 src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:78
+#: src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:91 src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:104
+#: src/olympia/discovery/templates/discovery/pane.html:45 src/olympia/discovery/templates/discovery/addons/detail.html:39 src/olympia/stats/templates/stats/stats.html:169
 msgid "Next"
 msgstr "Selanjutnya"
 
-#: src/olympia/amo/templates/amo/paginator.html:32
-#: src/olympia/editors/templates/editors/includes/paginator_history.html:11
+#: src/olympia/amo/templates/amo/paginator.html:32 src/olympia/editors/templates/editors/includes/paginator_history.html:11
 #, python-format
-msgid ""
-"Results <strong>%(begin)s</strong>&ndash;<strong>%(end)s</strong> of "
-"<strong>%(count)s</strong>"
-msgstr ""
-"Hasil: <strong>%(begin)s</strong>&ndash;<strong>%(end)s</strong> dari "
-"<strong>%(count)s</strong>"
+msgid "Results <strong>%(begin)s</strong>&ndash;<strong>%(end)s</strong> of <strong>%(count)s</strong>"
+msgstr "Hasil: <strong>%(begin)s</strong>&ndash;<strong>%(end)s</strong> dari <strong>%(count)s</strong>"
 
-#: src/olympia/amo/templates/amo/read-only.html:3
-#: src/olympia/amo/templates/amo/read-only.html:7
+#: src/olympia/amo/templates/amo/read-only.html:3 src/olympia/amo/templates/amo/read-only.html:7
 msgid "Maintenance in progress"
 msgstr "Pemeliharaan sedang berlangsung"
 
 #: src/olympia/amo/templates/amo/read-only.html:9
-msgid ""
-"This feature is temporarily disabled while we perform website maintenance. "
-"Please use your browser's Back button and try again a little later."
-msgstr ""
-"Fitur ini dimatikan sementara kami melakukan pemeliharaan situs. Gunakan "
-"tombol Kembali pada peramban Anda dan coba lagi nanti."
+msgid "This feature is temporarily disabled while we perform website maintenance. Please use your browser's Back button and try again a little later."
+msgstr "Fitur ini dimatikan sementara kami melakukan pemeliharaan situs. Gunakan tombol Kembali pada peramban Anda dan coba lagi nanti."
 
 #: src/olympia/amo/templates/amo/read-only.html:14
-msgid ""
-"Some features on this page are temporarily disabled while we perform website"
-" maintenance. Please try again a little later."
-msgstr ""
-"Sejumlah fitur pada laman ini dimatikan sementara saat kami melakukan "
-"pemeliharaan. Silakan coba lagi nanti."
+msgid "Some features on this page are temporarily disabled while we perform website maintenance. Please try again a little later."
+msgstr "Sejumlah fitur pada laman ini dimatikan sementara saat kami melakukan pemeliharaan. Silakan coba lagi nanti."
 
 #: src/olympia/amo/templates/amo/recaptcha.html:4
 msgid "Are you human?"
@@ -2502,25 +1967,14 @@ msgstr "Benarkah Anda manusia?"
 
 #: src/olympia/amo/templates/amo/recaptcha.html:8
 msgid ""
-"<p> Please enter <strong>all the words</strong> below, <strong>separated by "
-"a space if necessary</strong>. </p> <p> If this is hard to read, you can <a "
-"href=\"#\" id=\"recaptcha_different\">try different words</a> or <a "
-"href=\"#\" id=\"recaptcha_audio\">try a different type of challenge</a> "
-"instead. </p>"
+"<p> Please enter <strong>all the words</strong> below, <strong>separated by a space if necessary</strong>. </p> <p> If this is hard to read, you can <a href=\"#\" id=\"recaptcha_different\">try "
+"different words</a> or <a href=\"#\" id=\"recaptcha_audio\">try a different type of challenge</a> instead. </p>"
 msgstr ""
-"<p> Silakan masukkan <strong>semua kata</strong> di bawah, "
-"<strong>dipisahkan dengan spasi </strong>. </p> <p> Jika ini sulit dibaca, "
-"anda bisa <a href=\"#\" id=\"recaptcha_different\">mencoba kata lain</a> "
-"atau <a href=\"#\" id=\"recaptcha_audio\">dapat pula</a> mencoba tipe "
-"tantangan lain. </p>"
+"<p> Silakan masukkan <strong>semua kata</strong> di bawah, <strong>dipisahkan dengan spasi </strong>. </p> <p> Jika ini sulit dibaca, anda bisa <a href=\"#\" id=\"recaptcha_different\">mencoba kata "
+"lain</a> atau <a href=\"#\" id=\"recaptcha_audio\">dapat pula</a> mencoba tipe tantangan lain. </p>"
 
-#: src/olympia/amo/templates/amo/side_nav.html:4
-#: src/olympia/amo/templates/amo/side_nav.html:12
-#: src/olympia/amo/templates/amo/site_nav.html:4
-#: src/olympia/amo/templates/amo/site_nav.html:26
-#: src/olympia/browse/views.py:56 src/olympia/browse/views.py:66
-#: src/olympia/browse/views.py:237 src/olympia/browse/views.py:282
-#: src/olympia/search/forms.py:86
+#: src/olympia/amo/templates/amo/side_nav.html:4 src/olympia/amo/templates/amo/side_nav.html:12 src/olympia/amo/templates/amo/site_nav.html:4 src/olympia/amo/templates/amo/site_nav.html:26
+#: src/olympia/browse/views.py:56 src/olympia/browse/views.py:66 src/olympia/browse/views.py:204 src/olympia/browse/views.py:249 src/olympia/search/forms.py:86
 msgid "Top Rated"
 msgstr "Peringkat Teratas"
 
@@ -2529,81 +1983,60 @@ msgid "Explore"
 msgstr "Jelajahi"
 
 # Plural in this context means many of the add-on type
-#: src/olympia/amo/templates/amo/site_nav.html:23
-#: src/olympia/browse/feeds.py:65 src/olympia/browse/feeds.py:78
-#: src/olympia/browse/feeds.py:92 src/olympia/browse/feeds.py:100
-#: src/olympia/browse/templates/browse/base_listing.html:7
-#: src/olympia/browse/templates/browse/creatured.html:10
-#: src/olympia/browse/templates/browse/impala/base_listing.html:37
+#: src/olympia/amo/templates/amo/site_nav.html:23 src/olympia/browse/feeds.py:65 src/olympia/browse/feeds.py:78 src/olympia/browse/feeds.py:92 src/olympia/browse/feeds.py:100
+#: src/olympia/browse/templates/browse/base_listing.html:7 src/olympia/browse/templates/browse/creatured.html:10 src/olympia/browse/templates/browse/impala/base_listing.html:37
 #: src/olympia/constants/base.py:173 src/olympia/templates/menu_links.html:8
 msgid "Extensions"
 msgstr "Ekstensi"
 
-#: src/olympia/amo/templates/amo/site_nav.html:45
+#: src/olympia/amo/templates/amo/site_nav.html:44
 msgid "Want more customization? Try <b>Complete Themes</b>"
 msgstr "Ingin lebih banyak penyesuaian? ? Cobalah <b>Tema Komplet</b>"
 
-#: src/olympia/amo/templates/amo/site_nav.html:56
-#: src/olympia/bandwagon/views.py:96
+#: src/olympia/amo/templates/amo/site_nav.html:54 src/olympia/bandwagon/views.py:96
 msgid "Most Followers"
 msgstr "Pengikut Terbanyak"
 
-#: src/olympia/amo/templates/amo/site_nav.html:68
-#: src/olympia/bandwagon/templates/bandwagon/impala/collection_sidebar.html:16
+#: src/olympia/amo/templates/amo/site_nav.html:66 src/olympia/bandwagon/templates/bandwagon/impala/collection_sidebar.html:16
 #: src/olympia/bandwagon/templates/bandwagon/includes/collection_sidebar.html:18
 msgid "Collections I've Made"
 msgstr "Koleksi yang Saya Buat"
 
-#: src/olympia/amo/templates/amo/site_nav.html:70
-#: src/olympia/bandwagon/templates/bandwagon/user_listing.html:4
-#: src/olympia/bandwagon/templates/bandwagon/impala/collection_sidebar.html:13
+#: src/olympia/amo/templates/amo/site_nav.html:68 src/olympia/bandwagon/templates/bandwagon/user_listing.html:4 src/olympia/bandwagon/templates/bandwagon/impala/collection_sidebar.html:13
 #: src/olympia/bandwagon/templates/bandwagon/includes/collection_sidebar.html:15
 msgid "Collections I'm Following"
 msgstr "Koleksi yang Saya Ikuti"
 
-#: src/olympia/amo/templates/amo/site_nav.html:73
-#: src/olympia/bandwagon/templates/bandwagon/impala/collection_sidebar.html:18
-#: src/olympia/bandwagon/templates/bandwagon/includes/collection_sidebar.html:20
-#: src/olympia/users/models.py:512
+#: src/olympia/amo/templates/amo/site_nav.html:71 src/olympia/bandwagon/templates/bandwagon/impala/collection_sidebar.html:18
+#: src/olympia/bandwagon/templates/bandwagon/includes/collection_sidebar.html:20 src/olympia/users/models.py:521
 msgid "My Favorite Add-ons"
 msgstr "Pengaya Fovorit Saya"
 
-#: src/olympia/amo/templates/amo/site_nav.html:78
+#: src/olympia/amo/templates/amo/site_nav.html:76
 msgid "More&hellip;"
 msgstr "Selengkapnya&hellip;"
 
-#: src/olympia/amo/templates/amo/site_nav.html:82
+#: src/olympia/amo/templates/amo/site_nav.html:80
 msgid "Add-ons for Mobile"
 msgstr "Pengaya untuk Seluler"
 
-#: src/olympia/amo/templates/amo/site_nav.html:86
-#: src/olympia/browse/feeds.py:207
-#: src/olympia/browse/templates/browse/search_tools.html:3
-#: src/olympia/constants/base.py:176 src/olympia/templates/menu_links.html:10
+#: src/olympia/amo/templates/amo/site_nav.html:84 src/olympia/browse/feeds.py:207 src/olympia/browse/templates/browse/search_tools.html:3 src/olympia/constants/base.py:176
+#: src/olympia/templates/menu_links.html:10
 msgid "Search Tools"
 msgstr "Perangkat Pencarian"
 
 #. This is a page range (e.g., Page 1 of 50).
-#: src/olympia/amo/templates/amo/impala/paginator.html:5
-#: src/olympia/amo/templates/amo/mobile/impala_paginator.html:26
+#: src/olympia/amo/templates/amo/impala/paginator.html:5 src/olympia/amo/templates/amo/mobile/impala_paginator.html:26
 #, python-format
-msgid ""
-"Page <a href=\"%(current_pg_url)s\">%(current_pg)s</a> of <a "
-"href=\"%(last_pg_url)s\">%(last_pg)s</a>"
-msgstr ""
-"Laman <a href=\"%(current_pg_url)s\">%(current_pg)s</a> dari <a "
-"href=\"%(last_pg_url)s\">%(last_pg)s</a>"
+msgid "Page <a href=\"%(current_pg_url)s\">%(current_pg)s</a> of <a href=\"%(last_pg_url)s\">%(last_pg)s</a>"
+msgstr "Laman <a href=\"%(current_pg_url)s\">%(current_pg)s</a> dari <a href=\"%(last_pg_url)s\">%(last_pg)s</a>"
 
-#: src/olympia/amo/templates/amo/impala/paginator.html:16
-#: src/olympia/amo/templates/amo/mobile/impala_paginator.html:6
+#: src/olympia/amo/templates/amo/impala/paginator.html:16 src/olympia/amo/templates/amo/mobile/impala_paginator.html:6
 msgid "Jump to first page"
 msgstr "Menuju laman pertama"
 
-#: src/olympia/amo/templates/amo/impala/paginator.html:22
-#: src/olympia/amo/templates/amo/mobile/impala_paginator.html:12
-#: src/olympia/discovery/templates/discovery/pane.html:44
-#: src/olympia/discovery/templates/discovery/addons/detail.html:38
-#: src/olympia/stats/templates/stats/stats.html:164
+#: src/olympia/amo/templates/amo/impala/paginator.html:22 src/olympia/amo/templates/amo/mobile/impala_paginator.html:12 src/olympia/discovery/templates/discovery/pane.html:44
+#: src/olympia/discovery/templates/discovery/addons/detail.html:38 src/olympia/stats/templates/stats/stats.html:166
 msgid "Previous"
 msgstr "Sebelumnya"
 
@@ -2613,56 +2046,65 @@ msgstr "Menuju laman terakhir"
 
 #. First and second arguments are the result range (e.g., 1-20);
 #. third argument is the number of total results (e.g., 1,000).
-#. third
+#. First and second arguments are the result range (e.g., 1-20);              third
 #. argument is the number of total results (e.g., 1,000).
-#: src/olympia/amo/templates/amo/impala/paginator.html:36
-#: src/olympia/amo/templates/amo/mobile/impala_paginator.html:38
+#: src/olympia/amo/templates/amo/impala/paginator.html:36 src/olympia/amo/templates/amo/mobile/impala_paginator.html:38
 #, python-format
 msgid "Showing <b>%(begin)s</b>&ndash;<b>%(end)s</b> of <b>%(count)s</b>"
-msgstr ""
-"Menampilkan <b>%(begin)s</b>&ndash;<b>%(end)s</b> dari <b>%(count)s</b>"
+msgstr "Menampilkan <b>%(begin)s</b>&ndash;<b>%(end)s</b> dari <b>%(count)s</b>"
 
 #: src/olympia/amo/templates/amo/mobile/paginator.html:10
 msgid "Page {n}"
 msgid_plural "Page {n}"
 msgstr[0] "Halaman {n}"
+msgstr[1] ""
 
-#: src/olympia/amo/templates/services/install.html:38
-#, python-format
-msgid ""
-"If you are not prompted to install %(addon_name)s in a moment, please <a "
-"href=\"%(addon_xpi)s\">click here</a>."
-msgstr ""
-"Jika anda tidak dianjurkan untuk memasang %(addon_name)s dalam waktu dekat, "
-"silakan <a href=\"%(addon_xpi)s\">klik di sini</a>."
-
-#: src/olympia/amo/tests/test_messages.py:57
-#: src/olympia/amo/tests/test_messages.py:58 src/olympia/reviews/forms.py:25
-#: src/olympia/reviews/forms.py:50
-#: src/olympia/reviews/templates/reviews/add.html:56
+#: src/olympia/amo/tests/test_messages.py:56 src/olympia/amo/tests/test_messages.py:57 src/olympia/reviews/forms.py:25 src/olympia/reviews/forms.py:50 src/olympia/reviews/templates/reviews/add.html:56
 #: src/olympia/reviews/templates/reviews/reply.html:30
 msgid "Title"
 msgstr "Judul"
 
-#: src/olympia/amo/tests/test_messages.py:57
-#: src/olympia/amo/tests/test_messages.py:58
+#: src/olympia/amo/tests/test_messages.py:56 src/olympia/amo/tests/test_messages.py:57
 msgid "Body"
 msgstr "Badan"
 
-#: src/olympia/amo/tests/test_messages.py:59
+#: src/olympia/amo/tests/test_messages.py:58
 msgid "Another Title"
 msgstr "Judul Lain"
 
-#: src/olympia/amo/tests/test_messages.py:59
+#: src/olympia/amo/tests/test_messages.py:58
 msgid "Another Body"
 msgstr "Badan Lain"
 
-#: src/olympia/api/views.py:255
-msgid "Not implemented yet."
-msgstr "Belum diimplementasikan."
+#: src/olympia/api/authentication.py:76
+msgid "Signature has expired."
+msgstr ""
 
-#: src/olympia/applications/views.py:39
-#: src/olympia/applications/templates/applications/appversions.html:3
+#: src/olympia/api/authentication.py:79
+msgid "Error decoding signature."
+msgstr ""
+
+#: src/olympia/api/authentication.py:82
+msgid "Invalid JWT Token."
+msgstr ""
+
+#: src/olympia/api/authentication.py:130
+msgid "Invalid Authorization header. No credentials provided."
+msgstr ""
+
+#: src/olympia/api/authentication.py:133
+msgid "Invalid Authorization header. Credentials string should not contain spaces."
+msgstr ""
+
+#: src/olympia/api/fields.py:29
+msgid "The field must have a length of at least {num} characters."
+msgstr ""
+
+#: src/olympia/api/fields.py:31
+msgid "The language code {lang_code} is invalid."
+msgstr ""
+
+#: src/olympia/applications/views.py:39 src/olympia/applications/templates/applications/appversions.html:3
 msgid "Application Versions"
 msgstr "Versi Aplikasi"
 
@@ -2675,23 +2117,17 @@ msgid "Valid Application Versions"
 msgstr "Versi Aplikasi yang Sah"
 
 #: src/olympia/applications/templates/applications/appversions.html:12
-msgid ""
-"Add-ons submitted to Mozilla Add-ons must have a manifest file with at least"
-" one of the below applications supported. Only the versions listed below are"
-" allowed for these applications."
+msgid "Add-ons submitted to Mozilla Add-ons must have a manifest file with at least one of the below applications supported. Only the versions listed below are allowed for these applications."
 msgstr ""
-"Pengaya yang didaftarkan ke Pengaya Mozilla harus memiliki sebuah berkas "
-"keterangan dengan sekurangnya satu dari aplikasi di bawah ini yang didukung."
-" Hanya versi yang tercantum di bawah ini yang diperkenankan untuk aplikasi "
-"ini."
+"Pengaya yang didaftarkan ke Pengaya Mozilla harus memiliki sebuah berkas keterangan dengan sekurangnya satu dari aplikasi di bawah ini yang didukung. Hanya versi yang tercantum di bawah ini yang "
+"diperkenankan untuk aplikasi ini."
 
-#: src/olympia/applications/templates/applications/appversions.html:25
+#: src/olympia/applications/templates/applications/appversions.html:25 src/olympia/editors/helpers.py:361
 msgid "GUID"
 msgstr "GUID"
 
 #. {0} is an add-on name.
-#: src/olympia/applications/templates/applications/appversions.html:26
-#: src/olympia/versions/templates/versions/version_list.html:23
+#: src/olympia/applications/templates/applications/appversions.html:26 src/olympia/versions/templates/versions/version_list.html:23
 msgid "Versions"
 msgstr "Versi"
 
@@ -2701,14 +2137,8 @@ msgstr "http://developer.mozilla.org/en/docs/Install_Manifests"
 
 #: src/olympia/applications/templates/applications/appversions.html:31
 #, python-format
-msgid ""
-"If your supported application does not require a manifest file, you still "
-"must include one with the required properties as specified <a "
-"href=\"%(url)s\">here</a>."
-msgstr ""
-"Jika aplikasi anda yang didukung tidak memerlukan berkas keterangan, anda "
-"masih harus memasukkan satu dengan properti yang dibutuhkan sebagaimana "
-"dijelaskan <a href=\"%(url)s\">di sini</a>."
+msgid "If your supported application does not require a manifest file, you still must include one with the required properties as specified <a href=\"%(url)s\">here</a>."
+msgstr "Jika aplikasi anda yang didukung tidak memerlukan berkas keterangan, anda masih harus memasukkan satu dengan properti yang dibutuhkan sebagaimana dijelaskan <a href=\"%(url)s\">di sini</a>."
 
 #. L10n: {0} is 'Add-ons for <app>'.
 #: src/olympia/bandwagon/feeds.py:44
@@ -2716,13 +2146,9 @@ msgstr ""
 msgid "Collections :: %s"
 msgstr "Koleksi :: %s"
 
-#: src/olympia/bandwagon/feeds.py:50
-#: src/olympia/bandwagon/templates/bandwagon/collection_detail.html:137
-msgid ""
-"Collections are groups of related add-ons that anyone can create and share."
-msgstr ""
-"Koleksi adalah kelompok pengaya terkait yang dapat dibuat dan dibagi oleh "
-"semua orang."
+#: src/olympia/bandwagon/feeds.py:50 src/olympia/bandwagon/templates/bandwagon/collection_detail.html:137
+msgid "Collections are groups of related add-ons that anyone can create and share."
+msgstr "Koleksi adalah kelompok pengaya terkait yang dapat dibuat dan dibagi oleh semua orang."
 
 #. L10n: {0} is a collection name, {1} is 'Add-ons for <app>'.
 #: src/olympia/bandwagon/feeds.py:70
@@ -2777,8 +2203,7 @@ msgstr "URL ini telah dipakai oleh koleksi lain"
 msgid "Icons must be either PNG or JPG."
 msgstr "Ikon harus dalam PNG atau JPG."
 
-#: src/olympia/bandwagon/forms.py:202 src/olympia/devhub/views.py:1067
-#: src/olympia/users/forms.py:476
+#: src/olympia/bandwagon/forms.py:202 src/olympia/devhub/views.py:1067 src/olympia/users/forms.py:476
 #, python-format
 msgid "Please use images smaller than %dMB."
 msgstr "Gunakan gambar lebih kecil dari %d MB."
@@ -2799,8 +2224,7 @@ msgstr "Hapus suara saya untuk koleksi ini"
 msgid "Log in to vote for this collection"
 msgstr "Masuk untuk memberi suara untuk koleksi ini"
 
-#: src/olympia/bandwagon/helpers.py:123
-#: src/olympia/bandwagon/templates/bandwagon/favorites_widget.html:2
+#: src/olympia/bandwagon/helpers.py:123 src/olympia/bandwagon/templates/bandwagon/favorites_widget.html:2
 msgid "Add to favorites"
 msgstr "Tambahkan ke favorit"
 
@@ -2808,20 +2232,13 @@ msgstr "Tambahkan ke favorit"
 msgid "Favorite"
 msgstr "Favorit"
 
-#: src/olympia/bandwagon/helpers.py:124
-#: src/olympia/bandwagon/templates/bandwagon/favorites_widget.html:2
+#: src/olympia/bandwagon/helpers.py:124 src/olympia/bandwagon/templates/bandwagon/favorites_widget.html:2
 msgid "Remove from favorites"
 msgstr "Hapus dari favorit"
 
-#: src/olympia/bandwagon/views.py:98 src/olympia/bandwagon/views.py:191
-#: src/olympia/browse/views.py:58 src/olympia/browse/views.py:69
-#: src/olympia/browse/views.py:458 src/olympia/devhub/views.py:74
-#: src/olympia/devhub/views.py:82
-#: src/olympia/devhub/templates/devhub/addons/edit/basic.html:20
-#: src/olympia/editors/templates/editors/leaderboard.html:24
-#: src/olympia/editors/templates/editors/themes/queue_list.html:48
-#: src/olympia/search/forms.py:17 src/olympia/search/forms.py:89
-#: src/olympia/users/templates/users/vcard.html:5
+#: src/olympia/bandwagon/views.py:98 src/olympia/bandwagon/views.py:191 src/olympia/browse/views.py:58 src/olympia/browse/views.py:69 src/olympia/browse/views.py:425 src/olympia/devhub/views.py:72
+#: src/olympia/devhub/views.py:80 src/olympia/devhub/templates/devhub/addons/edit/basic.html:20 src/olympia/editors/templates/editors/leaderboard.html:24
+#: src/olympia/editors/templates/editors/themes/queue_list.html:48 src/olympia/search/forms.py:17 src/olympia/search/forms.py:89 src/olympia/users/templates/users/vcard.html:5
 msgid "Name"
 msgstr "Nama"
 
@@ -2829,8 +2246,7 @@ msgstr "Nama"
 msgid "Recently Popular"
 msgstr "Baru-baru ini Populer"
 
-#: src/olympia/bandwagon/views.py:189
-#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:18
+#: src/olympia/bandwagon/views.py:189 src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:16
 msgid "Added"
 msgstr "Ditambahkan"
 
@@ -2844,12 +2260,8 @@ msgstr "Koleksi dibuat!"
 
 #: src/olympia/bandwagon/views.py:316
 #, python-format
-msgid ""
-"Your new collection is shown below. You can <ahref=\"%(url)s\">edit "
-"additional settings</a> if you'dlike."
+msgid "Your new collection is shown below. You can <a href=\"%(url)s\">edit additional settings</a> if you'd like."
 msgstr ""
-"Koleksi baru anda ditampilkan di bawah ini. Anda dapat "
-"<ahref=\"%(url)s\">menyunting pengaturan tambahan</a> jika anda inginkan."
 
 #: src/olympia/bandwagon/views.py:322
 msgid "Collection updated!"
@@ -2864,31 +2276,20 @@ msgstr "<a href=\"%(url)s\">Lihat koleksi Anda</a>untuk melihat pergantian."
 msgid "Icon Deleted"
 msgstr "Ikon Dihapus"
 
-#: src/olympia/bandwagon/templates/bandwagon/add.html:3
-#: src/olympia/bandwagon/templates/bandwagon/add.html:11
-#: src/olympia/bandwagon/templates/bandwagon/includes/collection_sidebar.html:26
+#: src/olympia/bandwagon/templates/bandwagon/add.html:3 src/olympia/bandwagon/templates/bandwagon/add.html:11 src/olympia/bandwagon/templates/bandwagon/includes/collection_sidebar.html:26
 msgid "Create a New Collection"
 msgstr "Buat Koleksi Baru"
 
-#: src/olympia/bandwagon/templates/bandwagon/add.html:9
-#: src/olympia/devhub/templates/devhub/personas/submit.html:14
+#: src/olympia/bandwagon/templates/bandwagon/add.html:9 src/olympia/devhub/templates/devhub/personas/submit.html:14
 msgid "Create"
 msgstr "Buat"
 
-#: src/olympia/bandwagon/templates/bandwagon/add.html:24
-#: src/olympia/bandwagon/templates/bandwagon/ajax_new.html:28
+#: src/olympia/bandwagon/templates/bandwagon/add.html:24 src/olympia/bandwagon/templates/bandwagon/ajax_new.html:28
 #, python-format
-msgid ""
-"As noted in our <a href=\"%(legal)s\">Legal Notices</a>, individual "
-"collection arrangements are governed by the Creative Commons Attribution "
-"Share-Alike License"
-msgstr ""
-"Seperti yang disebutkan dalam <a href=\"%(legal)s\">Pernyataan Hukum</a> "
-"kami, pengaturan koleksi individu diatur oleh Lisensi Atribusi-Berbagi "
-"Serupa Creative Commons"
+msgid "As noted in our <a href=\"%(legal)s\">Legal Notices</a>, individual collection arrangements are governed by the Creative Commons Attribution Share-Alike License"
+msgstr "Seperti yang disebutkan dalam <a href=\"%(legal)s\">Pernyataan Hukum</a> kami, pengaturan koleksi individu diatur oleh Lisensi Atribusi-Berbagi Serupa Creative Commons"
 
-#: src/olympia/bandwagon/templates/bandwagon/add.html:33
-#: src/olympia/bandwagon/templates/bandwagon/ajax_new.html:38
+#: src/olympia/bandwagon/templates/bandwagon/add.html:33 src/olympia/bandwagon/templates/bandwagon/ajax_new.html:38
 msgid "Create Collection"
 msgstr "Buat Koleksi"
 
@@ -2904,8 +2305,7 @@ msgstr "Mulai koleksi baru..."
 msgid "Start a New Collection"
 msgstr "Mulai Koleksi Baru"
 
-#: src/olympia/bandwagon/templates/bandwagon/ajax_new.html:6
-#: src/olympia/bandwagon/templates/bandwagon/includes/addedit.html:7
+#: src/olympia/bandwagon/templates/bandwagon/ajax_new.html:6 src/olympia/bandwagon/templates/bandwagon/includes/addedit.html:7
 msgid "Name:"
 msgstr "Nama:"
 
@@ -2918,15 +2318,11 @@ msgstr "atau <a id=\"collections-new-cancel\" href=\"#\">Batal</a>"
 msgid "To rate collections, you must have an add-ons account."
 msgstr "Untuk memeringkat koleksi, Anda harus memiliki akun pengaya."
 
-#: src/olympia/bandwagon/templates/bandwagon/barometer.html:18
-#: src/olympia/templates/base.html:145
-#: src/olympia/templates/impala/base.html:198
+#: src/olympia/bandwagon/templates/bandwagon/barometer.html:18 src/olympia/templates/base.html:145 src/olympia/templates/impala/base.html:198
 msgid "Create an Add-ons Account"
 msgstr "Buat Akun Pengaya"
 
-#: src/olympia/bandwagon/templates/bandwagon/barometer.html:21
-#: src/olympia/templates/base.html:148
-#: src/olympia/templates/impala/base.html:201
+#: src/olympia/bandwagon/templates/bandwagon/barometer.html:21 src/olympia/templates/base.html:148 src/olympia/templates/impala/base.html:201
 #, python-format
 msgid "or <a href=\"%(login)s\">log in to your current account</a>"
 msgstr "atau <a href=\"%(login)s\">masuk ke akun Anda sekarang</a>"
@@ -2939,12 +2335,12 @@ msgstr "{0} :: Koleksi"
 msgid "private"
 msgstr "pribadi"
 
-#: src/olympia/bandwagon/templates/bandwagon/collection_detail.html:45
-#: src/olympia/bandwagon/templates/bandwagon/mobile/listing_items.html:9
+#: src/olympia/bandwagon/templates/bandwagon/collection_detail.html:45 src/olympia/bandwagon/templates/bandwagon/mobile/listing_items.html:9
 #, python-format
 msgid "<span>%(num)s</span> follower"
 msgid_plural "<span>%(num)s</span> followers"
 msgstr[0] "<span>%(num)s</span> pengikut"
+msgstr[1] ""
 
 #: src/olympia/bandwagon/templates/bandwagon/collection_detail.html:54
 msgid "About this Collection"
@@ -2974,8 +2370,7 @@ msgstr "Opsi Lainnya:"
 msgid "Edit Collection"
 msgstr "Edit Koleksi"
 
-#: src/olympia/bandwagon/templates/bandwagon/collection_detail.html:88
-#: src/olympia/bandwagon/templates/bandwagon/includes/delete.html:3
+#: src/olympia/bandwagon/templates/bandwagon/collection_detail.html:88 src/olympia/bandwagon/templates/bandwagon/includes/delete.html:3
 msgid "Delete Collection"
 msgstr "Hapus Koleksi"
 
@@ -2984,19 +2379,17 @@ msgstr "Hapus Koleksi"
 msgid "%(num)s Theme in this Collection"
 msgid_plural "%(num)s Themes in this Collection"
 msgstr[0] "%(num)s Tema di Koleksi ini"
+msgstr[1] ""
 
 #: src/olympia/bandwagon/templates/bandwagon/collection_detail.html:111
 #, python-format
 msgid "%(num)s Add-on in this Collection"
 msgid_plural "%(num)s Add-ons in this Collection"
 msgstr[0] "%(num)s Pengaya pada Koleksi Ini"
+msgstr[1] ""
 
-#: src/olympia/bandwagon/templates/bandwagon/collection_detail.html:125
-#: src/olympia/compat/templates/compat/index.html:25
-#: src/olympia/compat/templates/compat/reporter_detail.html:29
-#: src/olympia/files/templates/files/viewer.html:29
-#: src/olympia/templates/amo_footer.html:17
-#: src/olympia/templates/includes/lang_switcher.html:10
+#: src/olympia/bandwagon/templates/bandwagon/collection_detail.html:125 src/olympia/compat/templates/compat/reporter_detail.html:29 src/olympia/files/templates/files/viewer.html:29
+#: src/olympia/templates/amo_footer.html:17 src/olympia/templates/includes/lang_switcher.html:10
 msgid "Go"
 msgstr "Buka"
 
@@ -3022,29 +2415,17 @@ msgstr "Lihat semua koleksi dari pengguna ini"
 
 #: src/olympia/bandwagon/templates/bandwagon/collection_detail.html:179
 msgid ""
-"Add-ons that you mark as favorites using the <b>Add to Favorites</b> feature"
-" appear below. This collection is currently <b>public</b>, which means "
-"everyone can see it. If you would like to hide it from public view, click "
-"the button below to make it private."
+"Add-ons that you mark as favorites using the <b>Add to Favorites</b> feature appear below. This collection is currently <b>public</b>, which means everyone can see it. If you would like to hide it "
+"from public view, click the button below to make it private."
 msgstr ""
-"Pengaya yang anda tandai sebagai favorit menggunakan fitur <b>Tambahkan ke "
-"Favorit</b> yang muncul di bawah ini. Koleksi ini saat ini diatur "
-"<b>umum</b>, yang berarti semua bisa melihatnya. Jika anda ingin "
-"menyembunyikannya dari pandangan publik, klik tombol di bawah ini untuk "
-"membuatnya privat."
+"Pengaya yang anda tandai sebagai favorit menggunakan fitur <b>Tambahkan ke Favorit</b> yang muncul di bawah ini. Koleksi ini saat ini diatur <b>umum</b>, yang berarti semua bisa melihatnya. Jika "
+"anda ingin menyembunyikannya dari pandangan publik, klik tombol di bawah ini untuk membuatnya privat."
 
 #: src/olympia/bandwagon/templates/bandwagon/collection_detail.html:186
 msgid ""
-"Add-ons that you mark as favorites using the <b>Add to Favorites</b> feature"
-" appear below. This collection is currently <b>private</b>, which means only"
-" you can see it.  If you would like everyone to be able to see your "
-"favorites, click the button below to make it public."
+"Add-ons that you mark as favorites using the <b>Add to Favorites</b> feature appear below. This collection is currently <b>private</b>, which means only you can see it.  If you would like everyone "
+"to be able to see your favorites, click the button below to make it public."
 msgstr ""
-"Pengaya yang anda tandai sebagai favorit menggunakan fitur <b>Tambahkan ke "
-"Favorit</b> yang muncul di bawah ini. Koleksi ini sedang ditampilkan sebagai"
-" <b>privat</b>, artinya hanya anda yang dapat melihatnya.  Jika anda ingin "
-"semua orang bisa melihat pengaya favorit anda, klik tombol di bawah ini "
-"untuk menjadikannya publik."
 
 #: src/olympia/bandwagon/templates/bandwagon/collection_detail.html:196
 msgid "My favorite add-ons"
@@ -3055,58 +2436,57 @@ msgstr "Pengaya favorit saya"
 msgid "<span>%(addons)s</span> add-on"
 msgid_plural "<span>%(addons)s</span> add-ons"
 msgstr[0] "<span>%(addons)s</span> pengaya"
+msgstr[1] ""
 
 #: src/olympia/bandwagon/templates/bandwagon/collection_grid.html:32
 #, python-format
 msgid "<span>%(followers)s</span> follower"
 msgid_plural "<span>%(followers)s</span> followers"
 msgstr[0] "<span>%(followers)s</span> pengikut"
+msgstr[1] ""
 
-#. People "follow" collections to get notified of updates.
-#. Like
+#. People "follow" collections to get notified of updates.                    Like
 #. Twitter followers.
+#. People "follow" collections to get notified of updates.
 #. Like Twitter followers.
-#: src/olympia/bandwagon/templates/bandwagon/collection_listing_items.html:10
-#: src/olympia/bandwagon/templates/bandwagon/impala/collection_listing_items.html:18
+#: src/olympia/bandwagon/templates/bandwagon/collection_listing_items.html:10 src/olympia/bandwagon/templates/bandwagon/impala/collection_listing_items.html:18
 #, python-format
 msgid "%(num)s weekly follower"
 msgid_plural "%(num)s weekly followers"
 msgstr[0] "%(num)s pengikut mingguan"
+msgstr[1] ""
 
-#. People "follow" collections to get notified of updates.
-#. Like
+#. People "follow" collections to get notified of updates.                    Like
 #. Twitter followers.
 #: src/olympia/bandwagon/templates/bandwagon/collection_listing_items.html:18
 #, python-format
 msgid "%(num)s monthly follower"
 msgid_plural "%(num)s monthly followers"
 msgstr[0] "%(num)s pengikut bulanan"
+msgstr[1] ""
 
-#. People "follow" collections to get notified of updates.
-#. Like
+#. People "follow" collections to get notified of updates.                    Like
 #. Twitter followers.
+#. People "follow" collections to get notified of updates.
 #. Like Twitter followers.
-#: src/olympia/bandwagon/templates/bandwagon/collection_listing_items.html:26
-#: src/olympia/bandwagon/templates/bandwagon/impala/collection_listing_items.html:26
+#: src/olympia/bandwagon/templates/bandwagon/collection_listing_items.html:26 src/olympia/bandwagon/templates/bandwagon/impala/collection_listing_items.html:26
 #, python-format
 msgid "%(num)s follower"
 msgid_plural "%(num)s followers"
 msgstr[0] "%(num)s pengikut"
+msgstr[1] ""
 
-#: src/olympia/bandwagon/templates/bandwagon/collection_listing_items.html:56
-#: src/olympia/bandwagon/templates/bandwagon/impala/collection_listing_items.html:9
+#: src/olympia/bandwagon/templates/bandwagon/collection_listing_items.html:56 src/olympia/bandwagon/templates/bandwagon/impala/collection_listing_items.html:9
 #: src/olympia/devhub/templates/devhub/personas/edit.html:27
 msgid "by {0}"
 msgstr "oleh {0}"
 
-#: src/olympia/bandwagon/templates/bandwagon/collection_widgets.html:5
-#: src/olympia/bandwagon/templates/bandwagon/collection_widgets.html:7
+#: src/olympia/bandwagon/templates/bandwagon/collection_widgets.html:5 src/olympia/bandwagon/templates/bandwagon/collection_widgets.html:7
 #: src/olympia/bandwagon/templates/bandwagon/impala/collection_listing_items.html:53
 msgid "Stop Following"
 msgstr "Berhenti Mengikuti"
 
-#: src/olympia/bandwagon/templates/bandwagon/collection_widgets.html:6
-#: src/olympia/bandwagon/templates/bandwagon/collection_widgets.html:7
+#: src/olympia/bandwagon/templates/bandwagon/collection_widgets.html:6 src/olympia/bandwagon/templates/bandwagon/collection_widgets.html:7
 #: src/olympia/bandwagon/templates/bandwagon/impala/collection_listing_items.html:53
 msgid "Follow this Collection"
 msgstr "Ikuti Koleksi ini"
@@ -3116,16 +2496,12 @@ msgid "Edit this Collection"
 msgstr "Sunting Koleksi ini"
 
 #. %s is the name of the collection.
-#: src/olympia/bandwagon/templates/bandwagon/delete.html:4
-#: src/olympia/bandwagon/templates/bandwagon/delete.html:15
+#: src/olympia/bandwagon/templates/bandwagon/delete.html:4 src/olympia/bandwagon/templates/bandwagon/delete.html:15
 msgid "Delete {0}"
 msgstr "Hapus {0}"
 
-#: src/olympia/bandwagon/templates/bandwagon/delete.html:13
-#: src/olympia/devhub/templates/devhub/addons/listing/item_actions.html:14
-#: src/olympia/devhub/templates/devhub/addons/listing/item_actions_theme.html:28
-#: src/olympia/devhub/templates/devhub/versions/list.html:131
-#: src/olympia/devhub/templates/devhub/versions/list.html:149
+#: src/olympia/bandwagon/templates/bandwagon/delete.html:13 src/olympia/devhub/templates/devhub/addons/listing/item_actions.html:14
+#: src/olympia/devhub/templates/devhub/addons/listing/item_actions_theme.html:28 src/olympia/devhub/templates/devhub/versions/list.html:131 src/olympia/devhub/templates/devhub/versions/list.html:149
 #: src/olympia/devhub/templates/devhub/versions/list.html:166
 msgid "Delete"
 msgstr "Hapus"
@@ -3134,35 +2510,24 @@ msgstr "Hapus"
 msgid "Are you sure?"
 msgstr "Yakin?"
 
-#: src/olympia/bandwagon/templates/bandwagon/delete.html:21
-#: src/olympia/devhub/templates/devhub/personas/edit.html:131
-#: src/olympia/devhub/templates/devhub/personas/edit.html:152
-#: src/olympia/devhub/templates/devhub/personas/edit.html:173
-#: src/olympia/devhub/templates/devhub/personas/submit.html:77
-#: src/olympia/devhub/templates/devhub/personas/submit.html:98
+#: src/olympia/bandwagon/templates/bandwagon/delete.html:21 src/olympia/devhub/templates/devhub/personas/edit.html:131 src/olympia/devhub/templates/devhub/personas/edit.html:152
+#: src/olympia/devhub/templates/devhub/personas/edit.html:173 src/olympia/devhub/templates/devhub/personas/submit.html:77 src/olympia/devhub/templates/devhub/personas/submit.html:98
 #: src/olympia/devhub/templates/devhub/personas/submit.html:119
 msgid "Yes"
 msgstr "Ya"
 
-#: src/olympia/bandwagon/templates/bandwagon/delete.html:22
-#: src/olympia/devhub/templates/devhub/personas/edit.html:140
-#: src/olympia/devhub/templates/devhub/personas/edit.html:161
-#: src/olympia/devhub/templates/devhub/personas/edit.html:191
-#: src/olympia/devhub/templates/devhub/personas/submit.html:86
-#: src/olympia/devhub/templates/devhub/personas/submit.html:107
+#: src/olympia/bandwagon/templates/bandwagon/delete.html:22 src/olympia/devhub/templates/devhub/personas/edit.html:140 src/olympia/devhub/templates/devhub/personas/edit.html:161
+#: src/olympia/devhub/templates/devhub/personas/edit.html:191 src/olympia/devhub/templates/devhub/personas/submit.html:86 src/olympia/devhub/templates/devhub/personas/submit.html:107
 #: src/olympia/devhub/templates/devhub/personas/submit.html:137
 msgid "No"
 msgstr "Tidak"
 
 #. {0} is the name of the collection.
-#: src/olympia/bandwagon/templates/bandwagon/edit.html:5
-#: src/olympia/bandwagon/templates/bandwagon/edit.html:21
+#: src/olympia/bandwagon/templates/bandwagon/edit.html:5 src/olympia/bandwagon/templates/bandwagon/edit.html:21
 msgid "Edit {0}"
 msgstr "Edit {0}"
 
-#: src/olympia/bandwagon/templates/bandwagon/edit.html:29
-#: src/olympia/devhub/templates/devhub/addons/edit/details.html:20
-#: src/olympia/editors/templates/editors/themes/themes.html:62
+#: src/olympia/bandwagon/templates/bandwagon/edit.html:29 src/olympia/devhub/templates/devhub/addons/edit/details.html:20 src/olympia/editors/templates/editors/themes/themes.html:62
 msgid "Description"
 msgstr "Deskripsi"
 
@@ -3170,32 +2535,18 @@ msgstr "Deskripsi"
 msgid "Contributors & More"
 msgstr "Kontributor & Lainnya"
 
-#: src/olympia/bandwagon/templates/bandwagon/edit.html:54
-#: src/olympia/bandwagon/templates/bandwagon/edit.html:67
-#: src/olympia/bandwagon/templates/bandwagon/edit.html:82
-#: src/olympia/devhub/templates/devhub/addons/ajax_compat_update.html:35
-#: src/olympia/devhub/templates/devhub/addons/owner.html:59
-#: src/olympia/devhub/templates/devhub/addons/profile.html:42
-#: src/olympia/devhub/templates/devhub/addons/edit/admin.html:101
-#: src/olympia/devhub/templates/devhub/addons/edit/basic.html:152
-#: src/olympia/devhub/templates/devhub/addons/edit/details.html:85
-#: src/olympia/devhub/templates/devhub/addons/edit/support.html:67
-#: src/olympia/devhub/templates/devhub/addons/edit/technical.html:166
-#: src/olympia/devhub/templates/devhub/addons/forms_shared/media.html:149
-#: src/olympia/devhub/templates/devhub/payments/voluntary.html:64
-#: src/olympia/devhub/templates/devhub/personas/edit.html:35
-#: src/olympia/devhub/templates/devhub/personas/edit.html:304
-#: src/olympia/devhub/templates/devhub/versions/edit.html:139
-#: src/olympia/translations/templates/translations/trans-menu.html:48
+#: src/olympia/bandwagon/templates/bandwagon/edit.html:54 src/olympia/bandwagon/templates/bandwagon/edit.html:67 src/olympia/bandwagon/templates/bandwagon/edit.html:82
+#: src/olympia/devhub/templates/devhub/addons/ajax_compat_update.html:35 src/olympia/devhub/templates/devhub/addons/owner.html:59 src/olympia/devhub/templates/devhub/addons/profile.html:42
+#: src/olympia/devhub/templates/devhub/addons/edit/admin.html:101 src/olympia/devhub/templates/devhub/addons/edit/basic.html:152 src/olympia/devhub/templates/devhub/addons/edit/details.html:85
+#: src/olympia/devhub/templates/devhub/addons/edit/support.html:67 src/olympia/devhub/templates/devhub/addons/edit/technical.html:166
+#: src/olympia/devhub/templates/devhub/addons/forms_shared/media.html:149 src/olympia/devhub/templates/devhub/payments/voluntary.html:64 src/olympia/devhub/templates/devhub/personas/edit.html:35
+#: src/olympia/devhub/templates/devhub/personas/edit.html:304 src/olympia/devhub/templates/devhub/versions/edit.html:139 src/olympia/translations/templates/translations/trans-menu.html:48
 msgid "Save Changes"
 msgstr "Simpan Perubahan"
 
 # <option> text in a <select> for Author role in an add-on.
-#: src/olympia/bandwagon/templates/bandwagon/edit_contributors.html:9
-#: src/olympia/bandwagon/templates/bandwagon/edit_contributors.html:12
-#: src/olympia/bandwagon/templates/bandwagon/edit_contributors.html:17
-#: src/olympia/bandwagon/templates/bandwagon/edit_contributors.html:58
-#: src/olympia/constants/base.py:134
+#: src/olympia/bandwagon/templates/bandwagon/edit_contributors.html:9 src/olympia/bandwagon/templates/bandwagon/edit_contributors.html:12
+#: src/olympia/bandwagon/templates/bandwagon/edit_contributors.html:17 src/olympia/bandwagon/templates/bandwagon/edit_contributors.html:58 src/olympia/constants/base.py:134
 msgid "Owner"
 msgstr "Pemilik"
 
@@ -3207,10 +2558,8 @@ msgstr "Dijadikan Pemilik"
 msgid "Remove this user as a contributor"
 msgstr "Menghapus pengguna ini sebagai kontributor"
 
-#: src/olympia/bandwagon/templates/bandwagon/edit_contributors.html:18
-#: src/olympia/bandwagon/templates/bandwagon/edit_contributors.html:43
-#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:20
-#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:48
+#: src/olympia/bandwagon/templates/bandwagon/edit_contributors.html:18 src/olympia/bandwagon/templates/bandwagon/edit_contributors.html:43
+#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:18 src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:46
 #: src/olympia/devhub/templates/devhub/addons/ajax_compat_update.html:19
 msgid "Remove"
 msgstr "Hapus"
@@ -3221,24 +2570,15 @@ msgstr "Koleksi Kontributor"
 
 #: src/olympia/bandwagon/templates/bandwagon/edit_contributors.html:26
 msgid ""
-"You can add multiple contributors to this collection.  A contributor can add"
-" and remove add-ons from this collection, but cannot change its name or "
-"description.  To add a contributor, enter their email in the box below. "
-"Contributors must have a Mozilla Add-ons account."
+"You can add multiple contributors to this collection.  A contributor can add and remove add-ons from this collection, but cannot change its name or description.  To add a contributor, enter their "
+"email in the box below. Contributors must have a Mozilla Add-ons account."
 msgstr ""
-"Anda bisa menambahkan kontributor di koleksi ini.  Seorang kontributor bisa "
-"menambah dan menghapus pengaya dari koleksi ini, namun tidak dapat mengubah "
-"nama atau deskripsinya.  Untuk menambahkan seorang kontributor, masukkan "
-"alamat surel mereka ke dalam kotak di bawah ini. Kontributor harus memiliki "
-"akun Pengaya Mozilla."
 
 #: src/olympia/bandwagon/templates/bandwagon/edit_contributors.html:40
 msgid "User"
 msgstr "Pengguna"
 
-#: src/olympia/bandwagon/templates/bandwagon/edit_contributors.html:41
-#: src/olympia/devhub/templates/devhub/addons/edit/support.html:20
-#: src/olympia/users/templates/users/delete.html:49
+#: src/olympia/bandwagon/templates/bandwagon/edit_contributors.html:41 src/olympia/devhub/templates/devhub/addons/edit/support.html:20 src/olympia/users/templates/users/delete.html:49
 msgid "Email"
 msgstr "Surel"
 
@@ -3264,28 +2604,14 @@ msgid "Admin Settings"
 msgstr "Pengaturan Admin"
 
 #: src/olympia/bandwagon/templates/bandwagon/edit_contributors.html:76
-msgid ""
-"<b>Warning:</b> By changing the owner of this collection, you will no longer"
-" be able to edit it. You will only be able to add and remove add-ons from "
-"it."
-msgstr ""
-"<b>Awas:</b> dengan mengubah pemilik koleksi ini, anda tidak akan bisa lagi "
-"menyuntingnya. Anda hanya akan bisa menambahkan atau menghapuskan pengaya "
-"dari situ."
+msgid "<b>Warning:</b> By changing the owner of this collection, you will no longer be able to edit it. You will only be able to add and remove add-ons from it."
+msgstr "<b>Awas:</b> dengan mengubah pemilik koleksi ini, anda tidak akan bisa lagi menyuntingnya. Anda hanya akan bisa menambahkan atau menghapuskan pengaya dari situ."
 
-#: src/olympia/bandwagon/templates/bandwagon/edit_contributors.html:83
-#: src/olympia/devhub/templates/devhub/addons/forms_shared/media.html:157
-#: src/olympia/devhub/templates/devhub/addons/submit/describe.html:69
-#: src/olympia/devhub/templates/devhub/addons/submit/license.html:60
-#: src/olympia/devhub/templates/devhub/addons/submit/upload.html:78
-#: src/olympia/devhub/templates/devhub/payments/tier.html:17
-#: src/olympia/editors/templates/editors/themes/themes.html:111
-#: src/olympia/editors/templates/editors/themes/themes.html:128
-#: src/olympia/editors/templates/editors/themes/themes.html:134
-#: src/olympia/editors/templates/editors/themes/themes.html:141
-#: src/olympia/users/templates/users/fxa_migration_prompt_content.html:10
-#: src/olympia/users/templates/users/login_form.html:42
-#: src/olympia/users/templates/users/mobile/login.html:57
+#: src/olympia/bandwagon/templates/bandwagon/edit_contributors.html:83 src/olympia/devhub/templates/devhub/addons/forms_shared/media.html:157
+#: src/olympia/devhub/templates/devhub/addons/submit/describe.html:69 src/olympia/devhub/templates/devhub/addons/submit/license.html:60 src/olympia/devhub/templates/devhub/addons/submit/upload.html:70
+#: src/olympia/devhub/templates/devhub/payments/tier.html:17 src/olympia/editors/templates/editors/themes/themes.html:111 src/olympia/editors/templates/editors/themes/themes.html:128
+#: src/olympia/editors/templates/editors/themes/themes.html:134 src/olympia/editors/templates/editors/themes/themes.html:141 src/olympia/users/templates/users/fxa_migration_prompt_content.html:10
+#: src/olympia/users/templates/users/login_form.html:42 src/olympia/users/templates/users/mobile/login.html:57
 msgid "Continue"
 msgstr "Lanjut"
 
@@ -3324,18 +2650,10 @@ msgstr "Koleksi Populer Baru-baru Ini"
 
 #: src/olympia/bandwagon/templates/bandwagon/impala/collection_listing.html:28
 #, python-format
-msgid ""
-"Collections are groups of related add-ons that anyone can create and share. "
-"Explore collections created by other users or <a href=\"%(url)s\">create "
-"your own</a>."
-msgstr ""
-"Koleksi adalah sekelompok pengaya terkait yang dapat dibuat dan dibagi oleh "
-"setiap orang. Jelajahi koleksi yang dibuat pengguna lain atau <a "
-"href=\"%(url)s\">buat sendiri</a>."
+msgid "Collections are groups of related add-ons that anyone can create and share. Explore collections created by other users or <a href=\"%(url)s\">create your own</a>."
+msgstr "Koleksi adalah sekelompok pengaya terkait yang dapat dibuat dan dibagi oleh setiap orang. Jelajahi koleksi yang dibuat pengguna lain atau <a href=\"%(url)s\">buat sendiri</a>."
 
-#: src/olympia/bandwagon/templates/bandwagon/impala/collection_listing.html:37
-#: src/olympia/browse/templates/browse/extensions.html:13
-#: src/olympia/browse/templates/browse/themes.html:14
+#: src/olympia/bandwagon/templates/bandwagon/impala/collection_listing.html:37 src/olympia/browse/templates/browse/extensions.html:13 src/olympia/browse/templates/browse/themes.html:14
 msgid "Subscribe"
 msgstr "Berlangganan"
 
@@ -3343,20 +2661,14 @@ msgstr "Berlangganan"
 msgid "Following"
 msgstr "Mengikuti"
 
-#: src/olympia/bandwagon/templates/bandwagon/impala/collection_sidebar.html:22
-#: src/olympia/bandwagon/templates/bandwagon/impala/collection_sidebar.html:28
+#: src/olympia/bandwagon/templates/bandwagon/impala/collection_sidebar.html:22 src/olympia/bandwagon/templates/bandwagon/impala/collection_sidebar.html:28
 #: src/olympia/bandwagon/templates/bandwagon/includes/collection_sidebar.html:32
 msgid "Create a Collection"
 msgstr "Membuat Koleksi"
 
-#: src/olympia/bandwagon/templates/bandwagon/impala/collection_sidebar.html:23
-#: src/olympia/bandwagon/templates/bandwagon/includes/collection_sidebar.html:27
-msgid ""
-"Collections make it easy to keep track of favorite add-ons and share your "
-"perfectly customized browser with others."
-msgstr ""
-"Koleksi mempermudah mengikuti perkembangan pengaya favorit dan mempermudah "
-"Anda membagikan ubahsuaian Anda dengan yang lain."
+#: src/olympia/bandwagon/templates/bandwagon/impala/collection_sidebar.html:23 src/olympia/bandwagon/templates/bandwagon/includes/collection_sidebar.html:27
+msgid "Collections make it easy to keep track of favorite add-ons and share your perfectly customized browser with others."
+msgstr "Koleksi mempermudah mengikuti perkembangan pengaya favorit dan mempermudah Anda membagikan ubahsuaian Anda dengan yang lain."
 
 #: src/olympia/bandwagon/templates/bandwagon/includes/addedit.html:42
 msgid "Collection Icon"
@@ -3368,51 +2680,42 @@ msgstr "Setel Ulang"
 
 #: src/olympia/bandwagon/templates/bandwagon/includes/addedit.html:53
 msgid "PNG and JPG supported.  Image will be resized to 32x32."
-msgstr "PNG dan JPG didukung.  Gambar akan diubah ukurannya menjadi 32x32."
+msgstr ""
 
 #: src/olympia/bandwagon/templates/bandwagon/includes/addedit_errors.html:3
 msgid "There are errors in this form.  Please correct them below."
-msgstr "Ada sejumlah kesalahan dalam formulir ini.  Silakan memperbaikinya."
+msgstr ""
 
 #: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:2
 msgid "Add-ons in Your Collection"
 msgstr "Pengaya dalam Koleksi Anda"
 
 #: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:4
-msgid ""
-"To include an add-on in this collection, enter its name in the box below and"
-" hit enter.  You can also use the <strong>Add to Collection</strong> links "
-"throughout the site to include add-ons later."
+msgid "To include an add-on in this collection, enter its name in the box below and hit enter."
 msgstr ""
-"Untuk memasukkan sebuah pengaya dalam koleksi ini, masukkan namanya dalam "
-"kotak di bawah ini dan tekan masuk.  Anda bisa juga menggunakan tautan "
-"<strong>Tambahkan ke Koleksi</strong> di seluruh situs ini untuk memasukkan "
-"pengaya nanti."
 
-#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:17
-#: src/olympia/constants/base.py:400
-#: src/olympia/devhub/templates/devhub/addons/activity.html:62
+#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:15 src/olympia/constants/base.py:400 src/olympia/devhub/templates/devhub/addons/activity.html:62
+#: src/olympia/editors/helpers.py:273 src/olympia/editors/helpers.py:360
 msgid "Add-on"
 msgstr "Pengaya"
 
-#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:26
+#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:24
 msgid "Enter the name of the add-on to include"
 msgstr "Masukkan nama pengaya untuk disertakan"
 
-#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:28
+#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:26
 msgid "Add to Collection"
 msgstr "Tambahkan ke Koleksi"
 
-#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:45
-#: src/olympia/editors/helpers.py:936 src/olympia/editors/helpers.py:956
+#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:43 src/olympia/editors/helpers.py:1016 src/olympia/editors/helpers.py:1036
 msgid "Pending"
 msgstr "Ditunda"
 
-#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:47
+#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:45
 msgid "Add a comment"
 msgstr "Tambahkan komentar"
 
-#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:48
+#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:46
 msgid "Remove this add-on from the collection"
 msgstr "Hapus pengaya ini dari koleksi"
 
@@ -3424,14 +2727,11 @@ msgstr "KOLEKSI"
 msgid "Groups of related add-ons that anyone can create."
 msgstr "Kelompok pengaya yang berkaitan yang bisa dibuat siapa saja."
 
-#: src/olympia/blocklist/templates/blocklist/blocked_detail.html:3
-#: src/olympia/blocklist/templates/blocklist/blocked_list.html:3
-#: src/olympia/blocklist/templates/blocklist/blocked_list.html:10
+#: src/olympia/blocklist/templates/blocklist/blocked_detail.html:3 src/olympia/blocklist/templates/blocklist/blocked_list.html:3 src/olympia/blocklist/templates/blocklist/blocked_list.html:10
 msgid "Blocked Add-ons"
 msgstr "Pengaya yang Diblokir"
 
-#: src/olympia/blocklist/templates/blocklist/blocked_detail.html:8
-#: src/olympia/blocklist/templates/blocklist/blocked_list.html:6
+#: src/olympia/blocklist/templates/blocklist/blocked_detail.html:8 src/olympia/blocklist/templates/blocklist/blocked_list.html:6
 msgid "Blocklist"
 msgstr "Daftar Blokir"
 
@@ -3453,44 +2753,24 @@ msgid "What does this mean?"
 msgstr "Apakah maksudnya?"
 
 #: src/olympia/blocklist/templates/blocklist/blocked_detail.html:22
-msgid ""
-"Users are strongly encouraged to disable the problematic add-on or plugin, "
-"but may choose to continue using it if they accept the risks described."
-msgstr ""
-"Pengguna disarankan untuk mematikan pengaya atau plugin yang bermasalah, "
-"tapi bisa memilih untuk melanjutkan menggunakannya jika mereka menerima "
-"resiko yang dijelaskan."
+msgid "Users are strongly encouraged to disable the problematic add-on or plugin, but may choose to continue using it if they accept the risks described."
+msgstr "Pengguna disarankan untuk mematikan pengaya atau plugin yang bermasalah, tapi bisa memilih untuk melanjutkan menggunakannya jika mereka menerima resiko yang dijelaskan."
 
 #: src/olympia/blocklist/templates/blocklist/blocked_detail.html:27
-msgid ""
-"The problematic add-on or plugin will be automatically disabled and no "
-"longer usable."
-msgstr ""
-"Pengaya atau plugin yang bermasalah akan secara otomatis dimatikan dan tidak"
-" bisa digunakan lagi."
+msgid "The problematic add-on or plugin will be automatically disabled and no longer usable."
+msgstr "Pengaya atau plugin yang bermasalah akan secara otomatis dimatikan dan tidak bisa digunakan lagi."
 
 #: src/olympia/blocklist/templates/blocklist/blocked_detail.html:33
 #, python-format
 msgid ""
-"When Mozilla becomes aware of add-ons, plugins, or other third-party "
-"software that seriously compromises %(app)s security, stability, or "
-"performance and meets <a href=\"%(criteria)s\">certain criteria</a>, the "
-"software may be blocked from general use.  For more information, please read"
-" <a href=\"%(support)s\">this support article</a>."
+"When Mozilla becomes aware of add-ons, plugins, or other third-party software that seriously compromises %(app)s security, stability, or performance and meets <a href=\"%(criteria)s\">certain "
+"criteria</a>, the software may be blocked from general use.  For more information, please read <a href=\"%(support)s\">this support article</a>."
 msgstr ""
-"Saat Mozilla menyadari keberadaan pengaya, plugin atau perangkat lunak pihak"
-" ketiga lainnya yang sungguh-sungguh membahayakan %(app)s keamanan, "
-"stabilitas, atau performa dan memenuhi <a href=\"%(criteria)s\">sejumlah "
-"kriteria</a>, perangkat lunak tersebut akan diblokir dari penggunaan umum.  "
-"Untuk keterangan lebih lanjut, silakan baca <a href=\"%(support)s\">artikel "
-"pendukung ini</a>."
 
 #: src/olympia/blocklist/templates/blocklist/blocked_detail.html:44
 #, python-format
 msgid "Blocked on %(date)s. <a href=\"%(link)s\">View block request</a>."
-msgstr ""
-"Diblokir pada %(date)s. <a href=\"%(link)s\">Tampilkan permintaan "
-"blokir</a>."
+msgstr "Diblokir pada %(date)s. <a href=\"%(link)s\">Tampilkan permintaan blokir</a>."
 
 #: src/olympia/blocklist/templates/blocklist/blocked_detail.html:48
 #, python-format
@@ -3498,12 +2778,8 @@ msgid "Blocked on %(date)s."
 msgstr "Diblokir pada tanggal %(date)s."
 
 #: src/olympia/blocklist/templates/blocklist/blocked_list.html:11
-msgid ""
-"The following software is known to cause serious security, stability, or "
-"performance issues with {app}."
-msgstr ""
-"Perangkat lunak berikut ini diketahui menyebabkan persoalan serius terkait "
-"keamanan, stabilitas dan performa {app}."
+msgid "The following software is known to cause serious security, stability, or performance issues with {app}."
+msgstr "Perangkat lunak berikut ini diketahui menyebabkan persoalan serius terkait keamanan, stabilitas dan performa {app}."
 
 #. L10n: %s is a category name.
 #: src/olympia/browse/feeds.py:76 src/olympia/browse/feeds.py:98
@@ -3525,11 +2801,8 @@ msgstr "Pengaya Unggulan:: %s"
 #. L10n: %s is an app name.
 #: src/olympia/browse/feeds.py:138
 #, python-format
-msgid ""
-"Here's a few of our favorite add-ons to help you get started customizing %s."
-msgstr ""
-"Ini adalah sejumlah pengaya favorit kami untuk membantu anda mulai "
-"menyesuaikan %s."
+msgid "Here's a few of our favorite add-ons to help you get started customizing %s."
+msgstr "Ini adalah sejumlah pengaya favorit kami untuk membantu anda mulai menyesuaikan %s."
 
 #. L10n: %s is a category name.
 #: src/olympia/browse/feeds.py:157
@@ -3545,43 +2818,28 @@ msgstr "Perangkat pencarian dan ekstensi terkait pencarian"
 msgid "Search tools"
 msgstr "Perangkat pencarian"
 
-#: src/olympia/browse/views.py:55 src/olympia/browse/views.py:65
-#: src/olympia/search/forms.py:85
+#: src/olympia/browse/views.py:55 src/olympia/browse/views.py:65 src/olympia/search/forms.py:85
 msgid "Most Users"
 msgstr "Sebagian Besar Pengguna"
 
-#: src/olympia/browse/views.py:61 src/olympia/browse/views.py:72
-#: src/olympia/browse/views.py:279
-#: src/olympia/browse/templates/browse/personas/mobile/category_landing.html:63
-#: src/olympia/discovery/templates/discovery/pane.html:67
-#: src/olympia/search/forms.py:92
+#: src/olympia/browse/views.py:61 src/olympia/browse/views.py:72 src/olympia/browse/views.py:246 src/olympia/browse/templates/browse/personas/mobile/category_landing.html:63
+#: src/olympia/discovery/templates/discovery/pane.html:67 src/olympia/search/forms.py:92
 msgid "Up & Coming"
 msgstr "Yang akan Datang"
 
-#: src/olympia/browse/views.py:460 src/olympia/devhub/views.py:76
-#: src/olympia/devhub/views.py:83
-#: src/olympia/discovery/templates/discovery/addons/detail.html:66
+#: src/olympia/browse/views.py:427 src/olympia/devhub/views.py:74 src/olympia/devhub/views.py:81 src/olympia/discovery/templates/discovery/addons/detail.html:66
 msgid "Created"
 msgstr "Dibuat"
 
 #. {0} is the category name. Ex: Sports
-#: src/olympia/browse/templates/browse/creatured.html:5
-#: src/olympia/browse/templates/browse/creatured.html:13
+#: src/olympia/browse/templates/browse/creatured.html:5 src/olympia/browse/templates/browse/creatured.html:13
 msgid "{0}: Featured Add-ons"
 msgstr "{0}: Pengaya Unggulan"
 
-#: src/olympia/browse/templates/browse/creatured.html:12
-#: src/olympia/browse/templates/browse/featured.html:4
-#: src/olympia/browse/templates/browse/featured.html:12
-#: src/olympia/browse/templates/browse/featured.html:13
-#: src/olympia/devhub/templates/devhub/docs/policies-recommended.html:3
-#: src/olympia/devhub/templates/devhub/docs/policies-recommended.html:7
-#: src/olympia/devhub/templates/devhub/docs/policies-recommended.html:9
-#: src/olympia/devhub/templates/devhub/docs/policies.html:21
-#: src/olympia/devhub/templates/devhub/docs/policies.html:90
-#: src/olympia/discovery/modules.py:341
-#: src/olympia/discovery/templates/discovery/pane.html:52
-#: src/olympia/templates/menu_links.html:7
+#: src/olympia/browse/templates/browse/creatured.html:12 src/olympia/browse/templates/browse/featured.html:4 src/olympia/browse/templates/browse/featured.html:12
+#: src/olympia/browse/templates/browse/featured.html:13 src/olympia/devhub/templates/devhub/docs/policies-recommended.html:3 src/olympia/devhub/templates/devhub/docs/policies-recommended.html:7
+#: src/olympia/devhub/templates/devhub/docs/policies-recommended.html:9 src/olympia/devhub/templates/devhub/docs/policies.html:21 src/olympia/devhub/templates/devhub/docs/policies.html:90
+#: src/olympia/discovery/modules.py:341 src/olympia/discovery/templates/discovery/pane.html:52 src/olympia/templates/menu_links.html:7
 msgid "Featured Add-ons"
 msgstr "Pengaya Unggulan"
 
@@ -3592,12 +2850,8 @@ msgstr "Tidak ada pengaya unggulan pada {0}."
 
 #: src/olympia/browse/templates/browse/featured.html:15
 #, python-format
-msgid ""
-"Here's a few of our favorite add-ons to help you get started customizing "
-"%(app)s."
-msgstr ""
-"Ini adalah sejumlah pengaya favorit kami untuk membantu anda mulai "
-"menyesuaikan %(app)s."
+msgid "Here's a few of our favorite add-ons to help you get started customizing %(app)s."
+msgstr "Ini adalah sejumlah pengaya favorit kami untuk membantu anda mulai menyesuaikan %(app)s."
 
 #: src/olympia/browse/templates/browse/language_tools.html:9
 msgid "Install Dictionary"
@@ -3623,19 +2877,15 @@ msgstr "Tersedia dalam pelokalan Anda"
 msgid "List of language packs and dictionaries available in your locale."
 msgstr "Daftar paket bahasa dan kamus yang tersedia dalam pelokalan Anda."
 
-#: src/olympia/browse/templates/browse/language_tools.html:41
-#: src/olympia/browse/templates/browse/language_tools.html:63
+#: src/olympia/browse/templates/browse/language_tools.html:41 src/olympia/browse/templates/browse/language_tools.html:63
 msgid "Language"
 msgstr "Bahasa"
 
-#: src/olympia/browse/templates/browse/language_tools.html:42
-#: src/olympia/browse/templates/browse/language_tools.html:64
-#: src/olympia/constants/base.py:162
+#: src/olympia/browse/templates/browse/language_tools.html:42 src/olympia/browse/templates/browse/language_tools.html:64 src/olympia/constants/base.py:162
 msgid "Dictionary"
 msgstr "Словник"
 
-#: src/olympia/browse/templates/browse/language_tools.html:43
-#: src/olympia/browse/templates/browse/language_tools.html:65
+#: src/olympia/browse/templates/browse/language_tools.html:43 src/olympia/browse/templates/browse/language_tools.html:65
 msgid "Language Pack"
 msgstr "Paket Bahasa"
 
@@ -3653,11 +2903,11 @@ msgid "{0} :: Search Tools"
 msgstr "{0} :: Perangkat Pencarian"
 
 #. {0} is an integer.
-#: src/olympia/browse/templates/browse/search_tools.html:39
-#: src/olympia/devhub/templates/devhub/addons/dashboard.html:17
+#: src/olympia/browse/templates/browse/search_tools.html:39 src/olympia/devhub/templates/devhub/addons/dashboard.html:17
 msgid "<b>{0}</b> add-on"
 msgid_plural "<b>{0}</b> add-ons"
 msgstr[0] "<b>{0}</b> додаток"
+msgstr[1] ""
 
 #: src/olympia/browse/templates/browse/search_tools.html:61
 msgid "Search Extensions"
@@ -3681,35 +2931,18 @@ msgstr "Sumber Daya Lainnya"
 
 #. {0} is an app name, like Firefox.
 #: src/olympia/browse/templates/browse/search_tools.html:93
-msgid ""
-"Learn more about the <a "
-"href=\"http://support.mozilla.com/kb/Search+bar\">search bar</a> in {0}"
-msgstr ""
-"Pelajari lebih lanjut mengenai <a "
-"href=\"http://support.mozilla.com/kb/Search+bar\">batang pencarian</a> di "
-"{0}"
+msgid "Learn more about the <a href=\"http://support.mozilla.com/kb/Search+bar\">search bar</a> in {0}"
+msgstr "Pelajari lebih lanjut mengenai <a href=\"http://support.mozilla.com/kb/Search+bar\">batang pencarian</a> di {0}"
 
 #: src/olympia/browse/templates/browse/search_tools.html:94
-msgid ""
-"Browse through even more search providers at <a "
-"href=\"http://mycroft.mozdev.org/\">mycroft.mozdev.org</a>"
-msgstr ""
-"Jelajahi lebih banyak penyedia pencarian di <a "
-"href=\"http://mycroft.mozdev.org/\">mycroft.mozdev.org</a>"
+msgid "Browse through even more search providers at <a href=\"http://mycroft.mozdev.org/\">mycroft.mozdev.org</a>"
+msgstr "Jelajahi lebih banyak penyedia pencarian di <a href=\"http://mycroft.mozdev.org/\">mycroft.mozdev.org</a>"
 
 #: src/olympia/browse/templates/browse/search_tools.html:95
-msgid ""
-"<a "
-"href=\"https://developer.mozilla.org/en/Creating_OpenSearch_plugins_for_Firefox\">Make"
-" your own</a> search tool"
-msgstr ""
-"<a "
-"href=\"https://developer.mozilla.org/en/Creating_OpenSearch_plugins_for_Firefox\">Buat"
-" sendiri</a> perangkat pencarian anda"
+msgid "<a href=\"https://developer.mozilla.org/en/Creating_OpenSearch_plugins_for_Firefox\">Make your own</a> search tool"
+msgstr "<a href=\"https://developer.mozilla.org/en/Creating_OpenSearch_plugins_for_Firefox\">Buat sendiri</a> perangkat pencarian anda"
 
-#: src/olympia/browse/templates/browse/themes.html:6
-#: src/olympia/browse/templates/browse/themes.html:9
-#: src/olympia/constants/base.py:174
+#: src/olympia/browse/templates/browse/themes.html:6 src/olympia/browse/templates/browse/themes.html:9 src/olympia/constants/base.py:174
 msgid "Complete Themes"
 msgstr "Tema Komplet"
 
@@ -3780,25 +3013,19 @@ msgstr "Tema Komplet Yang Akan Datang"
 msgid "See the %(cnt)s extension in %(name)s &raquo;"
 msgid_plural "See all %(cnt)s extensions in %(name)s &raquo;"
 msgstr[0] "Lihat seluruh %(cnt)s ekstensi di %(name)s &raquo;"
+msgstr[1] ""
 
-#: src/olympia/browse/templates/browse/mobile/extensions.html:13
-#: src/olympia/compat/templates/compat/index.html:82
-#: src/olympia/devhub/templates/devhub/devhub_search.html:24
-#: src/olympia/devhub/templates/devhub/addons/activity.html:47
-#: src/olympia/search/templates/search/no_results.html:4
-#: src/olympia/search/templates/search/mobile/results.html:36
+#: src/olympia/browse/templates/browse/mobile/extensions.html:13 src/olympia/devhub/templates/devhub/devhub_search.html:24 src/olympia/devhub/templates/devhub/addons/activity.html:47
+#: src/olympia/search/templates/search/no_results.html:4 src/olympia/search/templates/search/mobile/results.html:36
 msgid "No results found."
 msgstr "Tidak ada hasil yang ditemukan."
 
-#: src/olympia/browse/templates/browse/personas/base.html:6
-#: src/olympia/browse/templates/browse/personas/mobile/base.html:7
+#: src/olympia/browse/templates/browse/personas/base.html:6 src/olympia/browse/templates/browse/personas/mobile/base.html:7
 msgid "{0} Themes"
 msgstr "{0} Tema"
 
 #. {0} is a user's name.
-#: src/olympia/browse/templates/browse/personas/base.html:15
-#: src/olympia/browse/templates/browse/personas/base.html:40
-#: src/olympia/browse/templates/browse/personas/grid.html:8
+#: src/olympia/browse/templates/browse/personas/base.html:15 src/olympia/browse/templates/browse/personas/base.html:40 src/olympia/browse/templates/browse/personas/grid.html:8
 msgid "{0}'s Themes"
 msgstr "{0} Tema"
 
@@ -3818,31 +3045,22 @@ msgstr "Peramban anda, gaya anda! Hiaslah dengan desain kreasi anda!"
 msgid "Learn more"
 msgstr "Pelajari lebih lanjut"
 
-#: src/olympia/browse/templates/browse/personas/category_landing.html:6
-#: src/olympia/browse/templates/browse/personas/mobile/category_landing.html:5
+#: src/olympia/browse/templates/browse/personas/category_landing.html:6 src/olympia/browse/templates/browse/personas/mobile/category_landing.html:5
 msgid "View All Recently Added"
 msgstr "Tampilkan Yang Baru Ditambahkan"
 
-#: src/olympia/browse/templates/browse/personas/category_landing.html:7
-#: src/olympia/browse/templates/browse/personas/mobile/category_landing.html:6
+#: src/olympia/browse/templates/browse/personas/category_landing.html:7 src/olympia/browse/templates/browse/personas/mobile/category_landing.html:6
 msgid "View All Most Popular"
 msgstr "Tampilkan Paling Populer"
 
-#: src/olympia/browse/templates/browse/personas/category_landing.html:8
-#: src/olympia/browse/templates/browse/personas/mobile/category_landing.html:7
+#: src/olympia/browse/templates/browse/personas/category_landing.html:8 src/olympia/browse/templates/browse/personas/mobile/category_landing.html:7
 msgid "View All Top Rated"
 msgstr "Tampilkan Peringkat Teratas"
 
 #: src/olympia/browse/templates/browse/personas/category_landing.html:40
 #, python-format
-msgid ""
-"Over 300,000 designs to personalize your browser! Move your mouse over a "
-"Background Theme to try it on. <a href=\"%(url)s\" class=\"more-info\">Start"
-" exploring</a>"
-msgstr ""
-"Lebih dari 300,000 desain untuk membuat peramban anda jadi personal! "
-"Gerakkan tetikus anda di atas Latar Tema untuk mencobanya. <a "
-"href=\"%(url)s\" class=\"more-info\">Mulailah menjelajah</a>"
+msgid "Over 300,000 designs to personalize your browser! Move your mouse over a Background Theme to try it on. <a href=\"%(url)s\" class=\"more-info\">Start exploring</a>"
+msgstr "Lebih dari 300,000 desain untuk membuat peramban anda jadi personal! Gerakkan tetikus anda di atas Latar Tema untuk mencobanya. <a href=\"%(url)s\" class=\"more-info\">Mulailah menjelajah</a>"
 
 #: src/olympia/browse/templates/browse/personas/category_landing.html:47
 msgid "Want more personalization?"
@@ -3852,14 +3070,9 @@ msgstr "Ingin personalisasi lebih?"
 #. theme.
 #: src/olympia/browse/templates/browse/personas/category_landing.html:50
 #, python-format
-msgid ""
-"Complete Themes transform the look of your browser with styles for the "
-"window frame, address bar, buttons, tabs, and menus. <a href=\"%(url)s\" "
-"class=\"more-info\">Start exploring</a>"
+msgid "Complete Themes transform the look of your browser with styles for the window frame, address bar, buttons, tabs, and menus. <a href=\"%(url)s\" class=\"more-info\">Start exploring</a>"
 msgstr ""
-"Tema Komplet mentransformasi tampilan peramban anda dengan berbagai gaya "
-"untuk bingkai jendela, batang alamat, tombol, tab, dan menu. <a "
-"href=\"%(url)s\" class=\"more-info\">Mulailah menjelajah</a>"
+"Tema Komplet mentransformasi tampilan peramban anda dengan berbagai gaya untuk bingkai jendela, batang alamat, tombol, tab, dan menu. <a href=\"%(url)s\" class=\"more-info\">Mulailah menjelajah</a>"
 
 #: src/olympia/browse/templates/browse/personas/category_landing.html:76
 msgid "Up & Coming Themes"
@@ -3889,7 +3102,7 @@ msgstr "&laquo; Seluruh Tema"
 msgid "All"
 msgstr "Всі"
 
-#: src/olympia/compat/forms.py:22 src/olympia/search/views.py:525
+#: src/olympia/compat/forms.py:22 src/olympia/editors/templates/editors/base.html:69 src/olympia/search/views.py:518
 msgid "All Add-ons"
 msgstr "Semua Pengaya"
 
@@ -3901,93 +3114,32 @@ msgstr "Biner"
 msgid "Non-binary"
 msgstr "Non-biner"
 
-#. Review points sources other than add-ons and themes.
-#: src/olympia/compat/views.py:87 src/olympia/constants/base.py:388
-#: src/olympia/devhub/forms.py:162
-#: src/olympia/editors/templates/editors/performance.html:75
-msgid "Other"
-msgstr "Lainnya"
-
-#: src/olympia/compat/templates/compat/index.html:4
-msgid "Add-on Compatibility Report for {app} {version}"
-msgstr "Laporan Kompatibilitas Pengaya untuk {app} {version}"
-
-#: src/olympia/compat/templates/compat/index.html:11
-msgid "{app} {version} Compatibility"
-msgstr "Kompatibilitas {app} {version}"
-
-#: src/olympia/compat/templates/compat/index.html:17
-#, python-format
-msgid "Top 95%% compatible with previous version"
-msgstr "Kompatibilitas tertinggi 95%% dengan versi sebelumnya"
-
-#: src/olympia/compat/templates/compat/index.html:18
-#, python-format
-msgid "Top 95%% of all add-ons"
-msgstr "Sebanyak 95%% dari seluruh pengaya"
-
-#: src/olympia/compat/templates/compat/index.html:19
-msgid "All active add-ons"
-msgstr "Seluruh pengaya yang aktif"
-
-#: src/olympia/compat/templates/compat/index.html:23
-#: src/olympia/constants/base.py:401
-msgid "App"
-msgstr "Aplikasi"
-
-#: src/olympia/compat/templates/compat/index.html:55
-msgid "Details for add-ons compatible with previous version:"
-msgstr "Rincian untuk pengaya yang kompatibel dengan versi sebelumnya:"
-
-#: src/olympia/compat/templates/compat/index.html:57
-msgid "Show all versions"
-msgstr "Tunjukkan semua versi"
-
-#: src/olympia/compat/templates/compat/index.html:59
-msgid "Details for add-ons compatible with all versions:"
-msgstr "Rincian untuk pengaya yang kompatibel dengan seluruh versi:"
-
-#: src/olympia/compat/templates/compat/index.html:61
-msgid "Show previous version only"
-msgstr "Tampilkan versi sebelumnya saja"
-
 #: src/olympia/compat/templates/compat/reporter.html:3
 msgid "Add-on Compatibility Reports"
 msgstr "Laporan Kompatibilitas Pengaya"
 
-#: src/olympia/compat/templates/compat/reporter.html:11
-#: src/olympia/compat/templates/compat/reporter_detail.html:35
+#: src/olympia/compat/templates/compat/reporter.html:11 src/olympia/compat/templates/compat/reporter_detail.html:35
 #, python-format
 msgid ""
-"<p> Reports submitted to us through the <a href=\"%(url_)s\">Add-on "
-"Compatibility Reporter</a> are collected here for developers to view. These "
-"reports help us determine which add-ons will need help supporting an "
-"upcoming Firefox version. </p>"
+"<p> Reports submitted to us through the <a href=\"%(url_)s\">Add-on Compatibility Reporter</a> are collected here for developers to view. These reports help us determine which add-ons will need "
+"help supporting an upcoming Firefox version. </p>"
 msgstr ""
-"<p> Laporan yang dikirimkan pada kami melalui <a href=\"%(url_)s\">Pelapor "
-"Kompatibilitas Pengaya</a> are dikumpulkan di sini oleh para pengembang "
-"untuk dilihat. Laporan-laporan ini membantu kami menentukan pengaya mana "
-"yang akan memerlukan bantuan dalam mendukung versi Firefox yang akan datang."
-" </p>"
+"<p> Laporan yang dikirimkan pada kami melalui <a href=\"%(url_)s\">Pelapor Kompatibilitas Pengaya</a> are dikumpulkan di sini oleh para pengembang untuk dilihat. Laporan-laporan ini membantu kami "
+"menentukan pengaya mana yang akan memerlukan bantuan dalam mendukung versi Firefox yang akan datang. </p>"
 
 #: src/olympia/compat/templates/compat/reporter.html:18
 msgid "Reports for your Add-ons"
 msgstr "Laporan untuk Pengaya anda"
 
-#: src/olympia/compat/templates/compat/reporter.html:30
-#: src/olympia/compat/templates/compat/reporter_detail.html:9
+#: src/olympia/compat/templates/compat/reporter.html:30 src/olympia/compat/templates/compat/reporter_detail.html:9
 msgid "Add-on Compatibility Center"
 msgstr "Pusat Kompatibilitas Pengaya"
 
 #: src/olympia/compat/templates/compat/reporter.html:34
 msgid "Enter the GUID of an add-on below to view any reports we've received."
-msgstr ""
-"Masukkan GUID dari pengaya di bawah ini untuk menampilkan laporan manapun "
-"yang kami terima."
+msgstr "Masukkan GUID dari pengaya di bawah ini untuk menampilkan laporan manapun yang kami terima."
 
-#: src/olympia/compat/templates/compat/reporter_detail.html:3
-#: src/olympia/compat/templates/compat/reporter_detail.html:10
-#: src/olympia/compat/templates/compat/reporter_detail.html:25
+#: src/olympia/compat/templates/compat/reporter_detail.html:3 src/olympia/compat/templates/compat/reporter_detail.html:10 src/olympia/compat/templates/compat/reporter_detail.html:25
 msgid "{addon} Compatibility Reports"
 msgstr "{addon} Laporan Kompatibilitas"
 
@@ -3995,14 +3147,15 @@ msgstr "{addon} Laporan Kompatibilitas"
 msgid "{0} success report"
 msgid_plural "{0} success reports"
 msgstr[0] "{0} laporan keberhasilan"
+msgstr[1] ""
 
 #: src/olympia/compat/templates/compat/reporter_detail.html:17
 msgid "{0} problem report"
 msgid_plural "{0} problem reports"
 msgstr[0] "{0} laporan persoalan"
+msgstr[1] ""
 
-#: src/olympia/compat/templates/compat/reporter_detail.html:21
-#: src/olympia/users/templates/users/profile.html:70
+#: src/olympia/compat/templates/compat/reporter_detail.html:21 src/olympia/users/templates/users/profile.html:70
 msgid "View all"
 msgstr "Tampilkan semua"
 
@@ -4014,10 +3167,8 @@ msgstr "Sortir berdasarkan Aplikasi"
 msgid "Report Type"
 msgstr "Tipe Laporan"
 
-#: src/olympia/compat/templates/compat/reporter_detail.html:47
-#: src/olympia/devhub/forms.py:784
-#: src/olympia/devhub/templates/devhub/addons/ajax_compat_update.html:17
-#: src/olympia/editors/forms.py:108 src/olympia/zadmin/forms.py:45
+#: src/olympia/compat/templates/compat/reporter_detail.html:47 src/olympia/devhub/forms.py:785 src/olympia/devhub/templates/devhub/addons/ajax_compat_update.html:17 src/olympia/editors/forms.py:108
+#: src/olympia/editors/forms.py:248 src/olympia/zadmin/forms.py:45
 msgid "Application"
 msgstr "Програма"
 
@@ -4029,8 +3180,7 @@ msgstr "Membangun Aplikasi"
 msgid "Platform"
 msgstr "Платформа"
 
-#: src/olympia/compat/templates/compat/reporter_detail.html:50
-#: src/olympia/editors/templates/editors/themes/themes.html:40
+#: src/olympia/compat/templates/compat/reporter_detail.html:50 src/olympia/editors/templates/editors/themes/themes.html:40
 msgid "Submitted"
 msgstr "Dikirim"
 
@@ -4058,8 +3208,7 @@ msgstr "Thunderbird"
 msgid "SeaMonkey"
 msgstr "SeaMonkey"
 
-#: src/olympia/constants/applications.py:75
-#: src/olympia/pages/templates/pages/sunbird.html:4
+#: src/olympia/constants/applications.py:75 src/olympia/pages/templates/pages/sunbird.html:4
 msgid "Sunbird"
 msgstr "Sunbird"
 
@@ -4107,7 +3256,7 @@ msgstr "Diulas Sebelumnya"
 msgid "Preliminarily Reviewed and Awaiting Full Review"
 msgstr "Diulas Sebelumnya dan Menunggu Ulasan Lengkap"
 
-#: src/olympia/constants/base.py:33 src/olympia/editors/helpers.py:924
+#: src/olympia/constants/base.py:33 src/olympia/editors/forms.py:258 src/olympia/editors/helpers.py:73 src/olympia/editors/helpers.py:1004
 #: src/olympia/editors/templates/editors/themes/history_table.html:34
 msgid "Deleted"
 msgstr "Dihapus"
@@ -4141,13 +3290,11 @@ msgstr "Pengembang"
 msgid "Viewer"
 msgstr "Pemirsa"
 
-#: src/olympia/constants/base.py:137
-#: src/olympia/templates/mobile/header.html:7
+#: src/olympia/constants/base.py:137 src/olympia/templates/mobile/header.html:7
 msgid "Support"
 msgstr "Dukungan"
 
-#: src/olympia/constants/base.py:159 src/olympia/constants/base.py:172
-#: src/olympia/constants/platforms.py:10
+#: src/olympia/constants/base.py:159 src/olympia/constants/base.py:172 src/olympia/constants/platforms.py:10
 msgid "Any"
 msgstr "Будь-який"
 
@@ -4175,11 +3322,8 @@ msgstr "Paket Bahasa (Pengaya)"
 msgid "Plugin"
 msgstr "Plugin"
 
-#: src/olympia/constants/base.py:167
-#: src/olympia/editors/templates/editors/includes/search_results_themes.html:5
-#: src/olympia/editors/templates/editors/themes/deleted.html:18
-#: src/olympia/editors/templates/editors/themes/history_table.html:8
-#: src/olympia/editors/templates/editors/themes/logs.html:17
+#: src/olympia/constants/base.py:167 src/olympia/editors/templates/editors/includes/search_results_themes.html:5 src/olympia/editors/templates/editors/themes/deleted.html:18
+#: src/olympia/editors/templates/editors/themes/history_table.html:8 src/olympia/editors/templates/editors/themes/logs.html:17
 msgid "Theme"
 msgstr "Тему"
 
@@ -4213,6 +3357,11 @@ msgstr "Tanyakan setelah pengguna mulai mengunduh pengaya ini"
 msgid "Ask before users can download this add-on"
 msgstr "Tanyakan sebelum pengguna mulai mengunduh pengaya ini"
 
+#. Review points sources other than add-ons and themes.
+#: src/olympia/constants/base.py:388 src/olympia/devhub/forms.py:162 src/olympia/editors/templates/editors/performance.html:75
+msgid "Other"
+msgstr "Lainnya"
+
 #: src/olympia/constants/base.py:389
 msgid "Exception"
 msgstr "Pengecualian"
@@ -4224,6 +3373,10 @@ msgstr "Rilis"
 #: src/olympia/constants/base.py:391
 msgid "Change"
 msgstr "Ubah"
+
+#: src/olympia/constants/base.py:401
+msgid "App"
+msgstr "Aplikasi"
 
 #: src/olympia/constants/base.py:402
 msgid "Persona"
@@ -4361,32 +3514,23 @@ msgstr "Ditandatangani untuk ulasan penuh"
 msgid "Signed of a preliminary review"
 msgstr "Ditandatangani untuk ulasan pendahuluan"
 
-#: src/olympia/constants/editors.py:14
-#: src/olympia/editors/templates/editors/themes/queue.html:76
-#: src/olympia/editors/templates/editors/themes/themes.html:87
+#: src/olympia/constants/editors.py:14 src/olympia/editors/templates/editors/themes/queue.html:76 src/olympia/editors/templates/editors/themes/themes.html:87
 msgid "Request More Info"
 msgstr "Meminta Info Tambahan"
 
-#: src/olympia/constants/editors.py:15
-#: src/olympia/editors/templates/editors/themes/queue.html:74
-#: src/olympia/editors/templates/editors/themes/themes.html:91
+#: src/olympia/constants/editors.py:15 src/olympia/editors/templates/editors/themes/queue.html:74 src/olympia/editors/templates/editors/themes/themes.html:91
 msgid "Flag"
 msgstr "Tandai"
 
-#: src/olympia/constants/editors.py:16
-#: src/olympia/editors/templates/editors/themes/queue.html:72
-#: src/olympia/editors/templates/editors/themes/themes.html:93
+#: src/olympia/constants/editors.py:16 src/olympia/editors/templates/editors/themes/queue.html:72 src/olympia/editors/templates/editors/themes/themes.html:93
 msgid "Duplicate"
 msgstr "Duplikat"
 
-#: src/olympia/constants/editors.py:17 src/olympia/editors/helpers.py:502
-#: src/olympia/editors/templates/editors/themes/queue.html:71
-#: src/olympia/editors/templates/editors/themes/themes.html:94
+#: src/olympia/constants/editors.py:17 src/olympia/editors/helpers.py:575 src/olympia/editors/templates/editors/themes/queue.html:71 src/olympia/editors/templates/editors/themes/themes.html:94
 msgid "Reject"
 msgstr "Tolak"
 
-#: src/olympia/constants/editors.py:18
-#: src/olympia/editors/templates/editors/themes/queue.html:70
+#: src/olympia/constants/editors.py:18 src/olympia/editors/templates/editors/themes/queue.html:70
 msgid "Approve"
 msgstr "Setujui"
 
@@ -4482,7 +3626,7 @@ msgstr "Solaris"
 msgid "Android"
 msgstr "Android"
 
-#: src/olympia/core/apps.py:19
+#: src/olympia/core/apps.py:21
 msgid "Core"
 msgstr "Inti"
 
@@ -4519,9 +3663,7 @@ msgstr "Salah objek JSON"
 msgid "Message not eligible for annotation"
 msgstr "Pesan tidak memenuhi syarat untuk anotasi"
 
-#: src/olympia/devhub/forms.py:124
-#: src/olympia/devhub/templates/devhub/versions/edit.html:94
-#: src/olympia/users/templates/users/edit.html:150
+#: src/olympia/devhub/forms.py:124 src/olympia/devhub/templates/devhub/versions/edit.html:94 src/olympia/users/templates/users/edit.html:150
 msgid "Details"
 msgstr "Detail"
 
@@ -4618,39 +3760,26 @@ msgid "Submit my add-on for manual review."
 msgstr "Kirimkan pengaya saya untuk diulas manual."
 
 #: src/olympia/devhub/forms.py:537
-msgid "Do not list my add-on on this site (beta)"
-msgstr "Jangan daftarkan pengaya saya di situs ini (beta)"
+msgid "Do not list my add-on on this site"
+msgstr ""
 
 #: src/olympia/devhub/forms.py:538
-msgid ""
-"Check this option if you intend to distribute your add-on on your own and "
-"only need it to be signed by Mozilla."
-msgstr ""
-"Periksa pilihan ini jika anda bermaksud mendistribusikan pengaya anda "
-"sendiri dan hanya memerlukannya ditandatangani oleh Mozilla."
+msgid "Check this option if you intend to distribute your add-on on your own and only need it to be signed by Mozilla."
+msgstr "Periksa pilihan ini jika anda bermaksud mendistribusikan pengaya anda sendiri dan hanya memerlukannya ditandatangani oleh Mozilla."
 
 #: src/olympia/devhub/forms.py:544
 msgid "This add-on will be bundled with an application installer."
 msgstr "Pengaya ini akan digabungkan dengan instalator aplikasi."
 
 #: src/olympia/devhub/forms.py:546
-msgid ""
-"Add-ons that are bundled with application installers will be code reviewed "
-"by Mozilla before they are signed and are held to a higher quality standard."
-msgstr ""
-"Pengaya yang digabungkan dengan instalator aplikasi akan menjadi kode yang "
-"diulas oleh Mozilla sebelum ditandatangani dan dipercayai memiliki standar "
-"kualitas lebih tinggi."
+msgid "Add-ons that are bundled with application installers will be code reviewed by Mozilla before they are signed and are held to a higher quality standard."
+msgstr "Pengaya yang digabungkan dengan instalator aplikasi akan menjadi kode yang diulas oleh Mozilla sebelum ditandatangani dan dipercayai memiliki standar kualitas lebih tinggi."
 
-#: src/olympia/devhub/forms.py:565
-#: src/olympia/devhub/templates/devhub/addons/submit/select-review.html:24
-#: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:42
+#: src/olympia/devhub/forms.py:565 src/olympia/devhub/templates/devhub/addons/submit/select-review.html:24 src/olympia/devhub/templates/devhub/docs/policies-reviews.html:42
 msgid "Full Review"
 msgstr "Ulasan Penuh"
 
-#: src/olympia/devhub/forms.py:566
-#: src/olympia/devhub/templates/devhub/addons/submit/select-review.html:47
-#: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:153
+#: src/olympia/devhub/forms.py:566 src/olympia/devhub/templates/devhub/addons/submit/select-review.html:47 src/olympia/devhub/templates/devhub/docs/policies-reviews.html:153
 msgid "Preliminary Review"
 msgstr "Ulasan Pendahuluan"
 
@@ -4659,67 +3788,51 @@ msgid "Please choose a review nomination type"
 msgstr "Silakan memilih jenis nominasi ulasan"
 
 #: src/olympia/devhub/forms.py:574
-msgid ""
-"A file with a version ending with a|alpha|b|beta|pre|rc and an optional "
-"number is detected as beta."
-msgstr ""
-"File dengan versi yang diakhiri dengan a|alpha|b|beta|pre|rc dan nomor "
-"opsional dideteksi sebagai beta."
+msgid "A file with a version ending with a|alpha|b|beta|pre|rc and an optional number is detected as beta."
+msgstr "File dengan versi yang diakhiri dengan a|alpha|b|beta|pre|rc dan nomor opsional dideteksi sebagai beta."
 
 #: src/olympia/devhub/forms.py:592
 #, python-format
-msgid "Version %s already exists"
-msgstr "Versi %s sudah ada"
-
-#: src/olympia/devhub/forms.py:604
-msgid ""
-"Select a valid choice. That choice is not one of the available choices."
+msgid "Version %s already exists, or was uploaded before."
 msgstr ""
-"Ambil pilihan yang valid. Pilihan itu bukanlah salah satu dari pilihan yang "
-"tersedia."
 
-#: src/olympia/devhub/forms.py:610
-msgid ""
-"A file with a version ending with a|alpha|b|beta and an optional number is "
-"detected as beta."
-msgstr ""
-"File dengan versi yang diakhiri dengan a|alpha|b|beta|pre|rc dan nomor "
-"opsional dideteksi sebagai beta."
+#: src/olympia/devhub/forms.py:605
+msgid "Select a valid choice. That choice is not one of the available choices."
+msgstr "Ambil pilihan yang valid. Pilihan itu bukanlah salah satu dari pilihan yang tersedia."
 
-#: src/olympia/devhub/forms.py:633
+#: src/olympia/devhub/forms.py:611
+msgid "A file with a version ending with a|alpha|b|beta and an optional number is detected as beta."
+msgstr "File dengan versi yang diakhiri dengan a|alpha|b|beta|pre|rc dan nomor opsional dideteksi sebagai beta."
+
+#: src/olympia/devhub/forms.py:634
 msgid "You cannot upload any more files for this version."
 msgstr "Anda tidak bisa mengunggah lebih banyak file untuk versi ini."
 
-#: src/olympia/devhub/forms.py:639
+#: src/olympia/devhub/forms.py:640
 msgid "Version doesn't match"
 msgstr "Versi tidak cocok"
 
-#: src/olympia/devhub/forms.py:668
-msgid ""
-"You cannot delete a file once the review process has started.  You must "
-"delete the whole version."
+#: src/olympia/devhub/forms.py:669
+msgid "You cannot delete a file once the review process has started.  You must delete the whole version."
 msgstr ""
-"Anda tidak dapat menghapus file setelah proses peninjauan dimulai.   Anda "
-"harus menghapus seluruh versinya."
 
-#: src/olympia/devhub/forms.py:688
+#: src/olympia/devhub/forms.py:689
 msgid "The platform All cannot be combined with specific platforms."
 msgstr "Platform Semua tidak bisa digabungkan dengan platform yang spesifik."
 
-#: src/olympia/devhub/forms.py:693
+#: src/olympia/devhub/forms.py:694
 msgid "A platform can only be chosen once."
 msgstr "Sebuah platform hanya bisa dipilih sekali."
 
-#: src/olympia/devhub/forms.py:706
+#: src/olympia/devhub/forms.py:707
 msgid "A review type must be selected."
 msgstr "Tipe ulasan harus dipilih."
 
-#: src/olympia/devhub/forms.py:788 src/olympia/editors/forms.py:114
-#: src/olympia/zadmin/forms.py:49 src/olympia/zadmin/forms.py:52
+#: src/olympia/devhub/forms.py:789 src/olympia/editors/forms.py:114 src/olympia/editors/forms.py:254 src/olympia/zadmin/forms.py:49 src/olympia/zadmin/forms.py:52
 msgid "Select an application first"
 msgstr "Pilih aplikasi terlebih dahulu"
 
-#: src/olympia/devhub/forms.py:840
+#: src/olympia/devhub/forms.py:841
 msgid "There cannot be more than 3 required add-ons."
 msgstr "Tidak bisa ada lebih dari 3 pengaya yang diminta."
 
@@ -4735,105 +3848,96 @@ msgstr "Pengajuan Saya"
 msgid "Developer Docs"
 msgstr "Dokumen Pengembang"
 
-#. L10n: first parameter is the number of errors
 # {0} is a number
+#. L10n: first parameter is the number of errors
 #: src/olympia/devhub/helpers.py:200
 msgid "{0} error"
 msgid_plural "{0} errors"
 msgstr[0] "{0} galat"
+msgstr[1] ""
 
-#. L10n: first parameter is the number of warnings
 # {0} is a number
+#. L10n: first parameter is the number of warnings
 #: src/olympia/devhub/helpers.py:203
 msgid "{0} warning"
 msgid_plural "{0} warnings"
 msgstr[0] "{0} pesan peringatan"
+msgstr[1] ""
 
-#: src/olympia/devhub/models.py:375
-#: src/olympia/reviews/templates/reviews/add.html:58
+#: src/olympia/devhub/models.py:375 src/olympia/reviews/templates/reviews/add.html:58
 msgid "Review"
 msgstr "Ulasan"
 
-#: src/olympia/devhub/tasks.py:551
+#: src/olympia/devhub/tasks.py:583
 #, python-format
 msgid "%s responded with %s (%s)."
 msgstr "%s dijawab dengan %s (%s)."
 
-#: src/olympia/devhub/tasks.py:555
+#: src/olympia/devhub/tasks.py:587
 #, python-format
 msgid "Connection to \"%s\" timed out."
 msgstr "Koneksi ke \"%s\" habis waktu."
 
-#: src/olympia/devhub/tasks.py:557
+#: src/olympia/devhub/tasks.py:589
 #, python-format
 msgid "Could not contact host at \"%s\"."
 msgstr "Tidak bisa menghubungi host di \"%s\"."
 
-#: src/olympia/devhub/utils.py:104
+#: src/olympia/devhub/utils.py:105
 #, python-format
-msgid ""
-"Validation generated too many errors/warnings so %s messages were truncated."
-" After addressing the visible messages, you'll be able to see the others."
-msgstr ""
-"Validasi menghasilkan terlalu banyak kesalahan/peringatan sehingga %s pesan "
-"terpotong. Setelah menyampaikan pesan yang terlihat, Anda akan bisa melihat "
-"yang lain."
+msgid "Validation generated too many errors/warnings so %s messages were truncated. After addressing the visible messages, you'll be able to see the others."
+msgstr "Validasi menghasilkan terlalu banyak kesalahan/peringatan sehingga %s pesan terpotong. Setelah menyampaikan pesan yang terlihat, Anda akan bisa melihat yang lain."
 
-#: src/olympia/devhub/views.py:183
+#: src/olympia/devhub/views.py:181
 msgid "All My Add-ons"
 msgstr "Semua Pengaya Saya"
 
-#: src/olympia/devhub/views.py:210
+#: src/olympia/devhub/views.py:208
 msgid "All Activity"
 msgstr "Semua Aktivitas"
 
-#: src/olympia/devhub/views.py:211
+#: src/olympia/devhub/views.py:209
 msgid "Add-on Updates"
 msgstr "Pembaruan Pengaya"
 
-#: src/olympia/devhub/views.py:212
+#: src/olympia/devhub/views.py:210
 msgid "Add-on Status"
 msgstr "Status Pengaya"
 
-#: src/olympia/devhub/views.py:213
+#: src/olympia/devhub/views.py:211
 msgid "User Collections"
 msgstr "Koleksi Pengguna"
 
-#: src/olympia/devhub/views.py:214
-#: src/olympia/devhub/templates/devhub/docs/policies-maintenance.html:68
-#: src/olympia/pages/templates/pages/dev_faq.html:38
+#: src/olympia/devhub/views.py:212 src/olympia/devhub/templates/devhub/docs/policies-maintenance.html:68 src/olympia/pages/templates/pages/dev_faq.html:38
 #: src/olympia/pages/templates/pages/dev_faq.html:484
 msgid "User Reviews"
 msgstr "Ulasan Pengguna"
 
-#: src/olympia/devhub/views.py:327 src/olympia/devhub/views.py:331
-#: src/olympia/devhub/views.py:484 src/olympia/devhub/views.py:513
-#: src/olympia/devhub/views.py:564 src/olympia/devhub/views.py:1150
+#: src/olympia/devhub/views.py:325 src/olympia/devhub/views.py:329 src/olympia/devhub/views.py:484 src/olympia/devhub/views.py:513 src/olympia/devhub/views.py:564 src/olympia/devhub/views.py:1156
 msgid "Changes successfully saved."
 msgstr "Perubahan berhasil disimpan."
 
-#: src/olympia/devhub/views.py:334 src/olympia/devhub/views.py:1631
+#: src/olympia/devhub/views.py:332 src/olympia/devhub/views.py:1637
 msgid "Please check the form for errors."
 msgstr "Silahkan lihat formulirnya untuk kesalahan."
 
-#: src/olympia/devhub/views.py:346
+#: src/olympia/devhub/views.py:344
 msgid "Add-on cannot be deleted. Disable this add-on instead."
-msgstr ""
-"Pengaya tidak dapat dihapus. Menonaktifkan pengaya ini sebagai gantinya."
+msgstr "Pengaya tidak dapat dihapus. Menonaktifkan pengaya ini sebagai gantinya."
 
-#: src/olympia/devhub/views.py:356
+#: src/olympia/devhub/views.py:354
 msgid "Theme deleted."
 msgstr "Tema dihapus."
 
-#: src/olympia/devhub/views.py:356
+#: src/olympia/devhub/views.py:354
 msgid "Add-on deleted."
 msgstr "Pengaya dihapus."
 
-#: src/olympia/devhub/views.py:362
+#: src/olympia/devhub/views.py:360
 msgid "URL name was incorrect. Theme was not deleted."
 msgstr "Nama URL salah. Tema tidak dihapus."
 
-#: src/olympia/devhub/views.py:367
+#: src/olympia/devhub/views.py:365
 msgid "URL name was incorrect. Add-on was not deleted."
 msgstr "Nama URL salah. Pengaya tidak dihapus."
 
@@ -4861,7 +3965,7 @@ msgstr "Pengaya Divalidasi"
 msgid "Check Add-on Compatibility"
 msgstr "Memeriksa Kompatibilitas Pengaya"
 
-#: src/olympia/devhub/views.py:808 src/olympia/signing/views.py:90
+#: src/olympia/devhub/views.py:808 src/olympia/signing/views.py:95
 msgid "You cannot submit this type of add-on"
 msgstr "Anda tidak dapat mengirimkan jenis pengaya ini"
 
@@ -4891,53 +3995,41 @@ msgstr "Gambar harus tepat selebar {0} pixel dan tinggi {1} pixel."
 msgid "There was an error uploading your preview."
 msgstr "Terjadi kesalahan menggunggah pratinjau anda."
 
-#: src/olympia/devhub/views.py:1189
+#: src/olympia/devhub/views.py:1195
 #, python-format
 msgid "Version %s disabled."
 msgstr "Versi %s dinonaktifkan."
 
-#: src/olympia/devhub/views.py:1193
+#: src/olympia/devhub/views.py:1199
 #, python-format
 msgid "Version %s deleted."
 msgstr "Versi %s dihapus."
 
-#: src/olympia/devhub/views.py:1203
-msgid ""
-"This upload has failed validation, and may lack complete validation results."
-" Please take due care when reviewing it."
-msgstr ""
-"Unggahan ini telah gagal divalidasi, dan boleh jadi tidak memiliki hasil "
-"validasi yang lengkap. Silakan berhati-hati saat mengulasnya."
+#: src/olympia/devhub/views.py:1209
+msgid "This upload has failed validation, and may lack complete validation results. Please take due care when reviewing it."
+msgstr "Unggahan ini telah gagal divalidasi, dan boleh jadi tidak memiliki hasil validasi yang lengkap. Silakan berhati-hati saat mengulasnya."
 
-#: src/olympia/devhub/views.py:1677
+#: src/olympia/devhub/views.py:1683
 msgid "Preliminary Review Requested."
 msgstr "Ulasan Pendahuluan Dimintakan."
 
-#: src/olympia/devhub/views.py:1678
+#: src/olympia/devhub/views.py:1684
 msgid "Full Review Requested."
 msgstr "Ulasan Penuh Dimintakan."
 
-#: src/olympia/devhub/views.py:1779
-msgid ""
-"Your old credentials were revoked and are no longer valid. Be sure to update"
-" all API clients with the new credentials."
-msgstr ""
-"Keterangan pengenal anda yang lama telah dicabut dan tidak lagi berlaku. "
-"Pastikan memperbarui semua klien API dengan keterangan pengenal yang baru."
+#: src/olympia/devhub/views.py:1783
+msgid "Your old credentials were revoked and are no longer valid. Be sure to update all API clients with the new credentials."
+msgstr "Keterangan pengenal anda yang lama telah dicabut dan tidak lagi berlaku. Pastikan memperbarui semua klien API dengan keterangan pengenal yang baru."
 
-#: src/olympia/devhub/views.py:1797
+#: src/olympia/devhub/views.py:1801
 msgid "New API key created"
 msgstr "Kunci API baru dibuat"
 
 #: src/olympia/devhub/templates/devhub/agreement.html:2
-msgid ""
-"Before starting, please read and accept our Firefox Add-on Distribution "
-"Agreement. It also links to our Privacy Notice which explains how we handle "
-"your information."
+msgid "Before starting, please read and accept our Firefox Add-on Distribution Agreement. It also links to our Privacy Notice which explains how we handle your information."
 msgstr ""
-"Sebelum memulai, harap membaca dan menerima Kesepakatan Distribusi Pengaya "
-"Firefox. Ini juga akan berhubungan dengan Pemberitahuan Privasi kami yang "
-"menerangkan bagaimana kami menangani informasi anda."
+"Sebelum memulai, harap membaca dan menerima Kesepakatan Distribusi Pengaya Firefox. Ini juga akan berhubungan dengan Pemberitahuan Privasi kami yang menerangkan bagaimana kami menangani informasi "
+"anda."
 
 #: src/olympia/devhub/templates/devhub/agreement.html:13
 msgid "Printable Version"
@@ -4951,44 +4043,30 @@ msgstr "Saya menerima Kesepakatan ini"
 msgid "or <a href=\"{0}\">Cancel</a>"
 msgstr "or <a href=\"{0}\">Batal</a>"
 
-#: src/olympia/devhub/templates/devhub/base.html:23
-#: src/olympia/devhub/templates/devhub/base_impala.html:20
-#: src/olympia/discovery/templates/discovery/addons/base.html:17
+#: src/olympia/devhub/templates/devhub/base.html:23 src/olympia/devhub/templates/devhub/base_impala.html:20 src/olympia/discovery/templates/discovery/addons/base.html:17
 msgid "Back to Add-ons"
 msgstr "Kembali ke Pengaya"
 
 #. {0} is a search term, such as Firebug.
 #. {0} is a search query.
-#: src/olympia/devhub/templates/devhub/devhub_search.html:4
-#: src/olympia/search/templates/search/results.html:9
-#: src/olympia/search/templates/search/mobile/results.html:6
+#: src/olympia/devhub/templates/devhub/devhub_search.html:4 src/olympia/search/templates/search/results.html:9 src/olympia/search/templates/search/mobile/results.html:6
 msgid "{0} :: Search"
 msgstr "{0} :: Pencarian"
 
-#: src/olympia/devhub/templates/devhub/devhub_search.html:6
-#: src/olympia/devhub/templates/devhub/search.html:8
-#: src/olympia/editors/forms.py:435 src/olympia/editors/forms.py:437
-#: src/olympia/editors/templates/editors/queue.html:27
-#: src/olympia/editors/templates/editors/themes/queue_list.html:14
-#: src/olympia/search/templates/search/collections.html:17
-#: src/olympia/search/templates/search/personas.html:18
-#: src/olympia/search/templates/search/results.html:18
-#: src/olympia/search/templates/search/mobile/results.html:8
-#: src/olympia/templates/search.html:14
-#: src/olympia/templates/impala/search.html:18
+#: src/olympia/devhub/templates/devhub/devhub_search.html:6 src/olympia/devhub/templates/devhub/search.html:8 src/olympia/editors/forms.py:534 src/olympia/editors/forms.py:536
+#: src/olympia/editors/templates/editors/queue.html:27 src/olympia/editors/templates/editors/themes/queue_list.html:14 src/olympia/search/templates/search/collections.html:17
+#: src/olympia/search/templates/search/personas.html:18 src/olympia/search/templates/search/results.html:18 src/olympia/search/templates/search/mobile/results.html:8
+#: src/olympia/templates/search.html:14 src/olympia/templates/impala/search.html:18
 msgid "Search"
 msgstr "Cari"
 
-#: src/olympia/devhub/templates/devhub/devhub_search.html:11
-#: src/olympia/devhub/templates/devhub/devhub_search.html:15
-#: src/olympia/search/templates/search/collections.html:18
+#: src/olympia/devhub/templates/devhub/devhub_search.html:11 src/olympia/devhub/templates/devhub/devhub_search.html:15 src/olympia/search/templates/search/collections.html:18
 #: src/olympia/search/templates/search/personas.html:20
 msgid "Search Results"
 msgstr "Hasil Pencarian"
 
 #. {0} is a search term, such as Firebug.
-#: src/olympia/devhub/templates/devhub/devhub_search.html:13
-#: src/olympia/search/templates/search/results.html:11
+#: src/olympia/devhub/templates/devhub/devhub_search.html:13 src/olympia/search/templates/search/results.html:11
 msgid "Search Results for \"{0}\""
 msgstr "Hasil Pencarian untuk \"{0}\""
 
@@ -5009,12 +4087,8 @@ msgid "AMO Reviewers"
 msgstr "Pengulas AMO"
 
 #: src/olympia/devhub/templates/devhub/index.html:29
-msgid ""
-"Get ahead! Become an AMO Reviewer today and get your add-ons reviewed "
-"faster."
-msgstr ""
-"Mari! Bergabunglah menjadi Pengulas AMO hari ini agar pengaya anda diulas "
-"lebih cepat."
+msgid "Get ahead! Become an AMO Reviewer today and get your add-ons reviewed faster."
+msgstr "Mari! Bergabunglah menjadi Pengulas AMO hari ini agar pengaya anda diulas lebih cepat."
 
 #: src/olympia/devhub/templates/devhub/index.html:32
 msgid "Become an AMO Reviewer"
@@ -5026,43 +4100,28 @@ msgstr "Pelajari Segala Hal Mengenai Pengaya"
 
 #: src/olympia/devhub/templates/devhub/index.html:41
 msgid ""
-"Add-ons let millions of Firefox users enhance and customize their browsing "
-"experience. If you're a Web developer and know <a "
-"href=\"https://developer.mozilla.org/docs/Web/HTML\">HTML</a>, <a "
-"href=\"https://developer.mozilla.org/docs/Web/JavaScript\">JavaScript</a>, "
-"and <a href=\"https://developer.mozilla.org/docs/Web/CSS\">CSS</a>, you "
-"already have all the necessary skills to make a great add-on."
+"Add-ons let millions of Firefox users enhance and customize their browsing experience. If you're a Web developer and know <a href=\"https://developer.mozilla.org/docs/Web/HTML\">HTML</a>, <a href="
+"\"https://developer.mozilla.org/docs/Web/JavaScript\">JavaScript</a>, and <a href=\"https://developer.mozilla.org/docs/Web/CSS\">CSS</a>, you already have all the necessary skills to make a great "
+"add-on."
 msgstr ""
-"Pengaya memungkinkan jutaan pengguna Firefox meningkatkan dan menyesuaikan "
-"pengalaman penjelajahan mereka. Jika anda seorang pengembang Web dan tahu <a"
-" href=\"https://developer.mozilla.org/docs/Web/HTML\">HTML</a>, <a "
-"href=\"https://developer.mozilla.org/docs/Web/JavaScript\">JavaScript</a>, "
-"dan <a href=\"https://developer.mozilla.org/docs/Web/CSS\">CSS</a>, anda "
-"sudah memiliki semua keterampilan yang diperlukan untuk membuat pengaya yang"
-" hebat."
+"Pengaya memungkinkan jutaan pengguna Firefox meningkatkan dan menyesuaikan pengalaman penjelajahan mereka. Jika anda seorang pengembang Web dan tahu <a href=\"https://developer.mozilla.org/docs/Web/"
+"HTML\">HTML</a>, <a href=\"https://developer.mozilla.org/docs/Web/JavaScript\">JavaScript</a>, dan <a href=\"https://developer.mozilla.org/docs/Web/CSS\">CSS</a>, anda sudah memiliki semua "
+"keterampilan yang diperlukan untuk membuat pengaya yang hebat."
 
 #: src/olympia/devhub/templates/devhub/index.html:51
-msgid ""
-"Head over to the <a href=\"https://developer.mozilla.org/Add-ons\">Mozilla "
-"Developer Network</a> to learn everything you need to know to get started."
-msgstr ""
-"Beralihlah ke <a href=\"https://developer.mozilla.org/Add-ons\">Mozilla "
-"Developer Network</a> untuk mempelajari segala hal yang ingin anda ketahui "
-"untuk memulai."
+msgid "Head over to the <a href=\"https://developer.mozilla.org/Add-ons\">Mozilla Developer Network</a> to learn everything you need to know to get started."
+msgstr "Beralihlah ke <a href=\"https://developer.mozilla.org/Add-ons\">Mozilla Developer Network</a> untuk mempelajari segala hal yang ingin anda ketahui untuk memulai."
 
 #: src/olympia/devhub/templates/devhub/index.html:58
 msgid "Start Making Add-ons"
 msgstr "Mulailah Membuat Pengaya"
 
-#: src/olympia/devhub/templates/devhub/index.html:86
-#: src/olympia/devhub/templates/devhub/addons/listing/items.html:25
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:15
+#: src/olympia/devhub/templates/devhub/index.html:86 src/olympia/devhub/templates/devhub/addons/listing/items.html:25 src/olympia/devhub/templates/devhub/includes/addon_details.html:20
 #: src/olympia/devhub/templates/devhub/personas/edit.html:43
 msgid "Status:"
 msgstr "Status:"
 
-#: src/olympia/devhub/templates/devhub/index.html:90
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:100
+#: src/olympia/devhub/templates/devhub/index.html:90 src/olympia/devhub/templates/devhub/includes/addon_details.html:87
 msgid "Visibility:"
 msgstr "Visibilitas:"
 
@@ -5070,21 +4129,16 @@ msgstr "Visibilitas:"
 msgid "Latest Version:"
 msgstr "Versi Terbaru:"
 
-#: src/olympia/devhub/templates/devhub/index.html:109
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:145
-#: src/olympia/devhub/templates/devhub/personas/edit.html:49
+#: src/olympia/devhub/templates/devhub/index.html:109 src/olympia/devhub/templates/devhub/includes/addon_details.html:131 src/olympia/devhub/templates/devhub/personas/edit.html:49
 msgid "Queue Position:"
 msgstr "Posisi Antrean:"
 
-#: src/olympia/devhub/templates/devhub/index.html:110
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:146
-#: src/olympia/devhub/templates/devhub/personas/edit.html:50
+#: src/olympia/devhub/templates/devhub/index.html:110 src/olympia/devhub/templates/devhub/includes/addon_details.html:132 src/olympia/devhub/templates/devhub/personas/edit.html:50
 #, python-format
 msgid "%(position)s of %(total)s"
 msgstr "%(position)s dari %(total)s"
 
-#: src/olympia/devhub/templates/devhub/index.html:120
-#: src/olympia/devhub/templates/devhub/includes/addons_edit_nav.html:19
+#: src/olympia/devhub/templates/devhub/index.html:120 src/olympia/devhub/templates/devhub/includes/addons_edit_nav.html:19
 msgid "Upload New Version"
 msgstr "Unggah Versi Baru"
 
@@ -5098,12 +4152,8 @@ msgstr "Terbitkan pengaya anda!"
 
 #: src/olympia/devhub/templates/devhub/index.html:136
 #, python-format
-msgid ""
-"Upload an <a href=\"%(addon_url)s\">add-on</a> or <a "
-"href=\"%(theme_url)s\">theme</a> to get started!"
-msgstr ""
-"Unggah sebuah <a href=\"%(addon_url)s\">pengaya</a> atau <a "
-"href=\"%(theme_url)s\">tema</a> untuk memulai!"
+msgid "Upload an <a href=\"%(addon_url)s\">add-on</a> or <a href=\"%(theme_url)s\">theme</a> to get started!"
+msgstr "Unggah sebuah <a href=\"%(addon_url)s\">pengaya</a> atau <a href=\"%(theme_url)s\">tema</a> untuk memulai!"
 
 #: src/olympia/devhub/templates/devhub/nav.html:2
 msgid "Return to the DevHub homepage"
@@ -5130,17 +4180,10 @@ msgstr "Pengembangan Ekstensi"
 msgid "Lightweight Themes"
 msgstr "Tema Ringan"
 
-#: src/olympia/devhub/templates/devhub/nav.html:39
-#: src/olympia/devhub/templates/devhub/docs/policies-agreement.html:6
-#: src/olympia/devhub/templates/devhub/docs/policies-contact.html:6
-#: src/olympia/devhub/templates/devhub/docs/policies-maintenance.html:6
-#: src/olympia/devhub/templates/devhub/docs/policies-recommended.html:6
-#: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:6
-#: src/olympia/devhub/templates/devhub/docs/policies-submission.html:6
-#: src/olympia/devhub/templates/devhub/docs/policies.html:3
-#: src/olympia/devhub/templates/devhub/docs/policies.html:9
-#: src/olympia/devhub/templates/devhub/docs/policies.html:38
-#: src/olympia/devhub/templates/devhub/docs/policies.html:39
+#: src/olympia/devhub/templates/devhub/nav.html:39 src/olympia/devhub/templates/devhub/docs/policies-agreement.html:6 src/olympia/devhub/templates/devhub/docs/policies-contact.html:6
+#: src/olympia/devhub/templates/devhub/docs/policies-maintenance.html:6 src/olympia/devhub/templates/devhub/docs/policies-recommended.html:6
+#: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:6 src/olympia/devhub/templates/devhub/docs/policies-submission.html:6 src/olympia/devhub/templates/devhub/docs/policies.html:3
+#: src/olympia/devhub/templates/devhub/docs/policies.html:9 src/olympia/devhub/templates/devhub/docs/policies.html:38 src/olympia/devhub/templates/devhub/docs/policies.html:39
 msgid "Add-on Policies"
 msgstr "Правила додатків"
 
@@ -5181,45 +4224,16 @@ msgid "Use the field below to upload your add-on package."
 msgstr "Gunakan bidang di bawah ini untuk mengunggah paket pengaya anda."
 
 #: src/olympia/devhub/templates/devhub/validate_addon.html:19
-msgid ""
-"After upload, a series of automated validation tests will run to check "
-"compatibility with the following application version:"
-msgstr ""
-"Setelah mengunggah, serangkaian pengujian validasi otomatis akan berjalan "
-"untuk memeriksa kompatibilitas dengan versi aplikasi di bawah ini:"
+msgid "After upload, a series of automated validation tests will run to check compatibility with the following application version:"
+msgstr "Setelah mengunggah, serangkaian pengujian validasi otomatis akan berjalan untuk memeriksa kompatibilitas dengan versi aplikasi di bawah ini:"
 
 #: src/olympia/devhub/templates/devhub/validate_addon.html:34
-msgid ""
-"After upload, a series of automated validation tests will be run on your "
-"file."
-msgstr ""
-"Setelah mengunggah, serangkaian pengujian validasi otomatis akan dijalankan "
-"pada fiel anda."
+msgid "After upload, a series of automated validation tests will be run on your file."
+msgstr "Setelah mengunggah, serangkaian pengujian validasi otomatis akan dijalankan pada fiel anda."
 
-#: src/olympia/devhub/templates/devhub/validate_addon.html:42
-#: src/olympia/devhub/templates/devhub/addons/submit/upload.html:23
+#: src/olympia/devhub/templates/devhub/validate_addon.html:42 src/olympia/devhub/templates/devhub/addons/submit/upload.html:23
 msgid "Do you want your add-on to be distributed on this site?"
 msgstr "Apakah anda ingin pengaya ini didistribusikan di situs ini?"
-
-#: src/olympia/devhub/templates/devhub/validate_addon.html:49
-#: src/olympia/devhub/templates/devhub/addons/submit/upload.html:30
-#: src/olympia/devhub/templates/devhub/versions/add_file_modal.html:14
-#: src/olympia/devhub/templates/devhub/versions/add_file_modal.html:53
-#: src/olympia/devhub/templates/devhub/versions/list.html:298
-msgid "Warning:"
-msgstr "Peringatan:"
-
-#: src/olympia/devhub/templates/devhub/validate_addon.html:50
-#: src/olympia/devhub/templates/devhub/addons/submit/upload.html:31
-#, python-format
-msgid ""
-"Submission of unlisted add-ons for signing is currently in an open beta. "
-"Please <a href=\"%(url)s\" target=\"_blank\">report any bugs</a> that you "
-"encounter."
-msgstr ""
-"Pengajuan pengaya yang tidak terdaftar untuk penandatanganan saat ini dalam "
-"versi beta terbuka. Harap <a href=\"%(url)s\" target=\"_blank\">melaporkan "
-"bug apapun</a> yang anda temui."
 
 #. first parameter is a filename like lorem-ipsum-1.0.2.xpi
 #: src/olympia/devhub/templates/devhub/validation.html:5
@@ -5238,14 +4252,11 @@ msgstr "Divalidasi di:"
 msgid "Tested for compatibility against:"
 msgstr "Diuji kompatibilitasnya terhadap:"
 
-#: src/olympia/devhub/templates/devhub/addons/activity.html:4
-#: src/olympia/devhub/templates/devhub/addons/activity.html:20
+#: src/olympia/devhub/templates/devhub/addons/activity.html:4 src/olympia/devhub/templates/devhub/addons/activity.html:20
 msgid "Recent Activity for My Add-ons"
 msgstr "Aktivitas Terbaru untuk Pengaya Saya"
 
-#: src/olympia/devhub/templates/devhub/addons/activity.html:14
-#: src/olympia/devhub/templates/devhub/addons/activity.html:19
-#: src/olympia/devhub/templates/devhub/addons/dashboard.html:33
+#: src/olympia/devhub/templates/devhub/addons/activity.html:14 src/olympia/devhub/templates/devhub/addons/activity.html:19 src/olympia/devhub/templates/devhub/addons/dashboard.html:33
 msgid "Recent Activity"
 msgstr "Aktivitas Terkini"
 
@@ -5267,44 +4278,34 @@ msgstr "Aktivitas Diperbaiki"
 msgid "Activity"
 msgstr "Aktivitas"
 
-#: src/olympia/devhub/templates/devhub/addons/activity.html:83
-#: src/olympia/devhub/templates/devhub/addons/dashboard.html:34
-#: src/olympia/devhub/templates/devhub/addons/dashboard.html:35
-#: src/olympia/devhub/templates/devhub/includes/blog_posts.html:4
-#: src/olympia/devhub/templates/devhub/includes/blog_posts.html:6
+#: src/olympia/devhub/templates/devhub/addons/activity.html:83 src/olympia/devhub/templates/devhub/addons/dashboard.html:34 src/olympia/devhub/templates/devhub/addons/dashboard.html:35
+#: src/olympia/devhub/templates/devhub/includes/blog_posts.html:4 src/olympia/devhub/templates/devhub/includes/blog_posts.html:6
 msgid "Subscribe to this feed"
 msgstr "Berlangganan umpan ini"
 
 #: src/olympia/devhub/templates/devhub/addons/ajax_compat_error.html:7
 #, python-format
 msgid ""
-"This add-on is incompatible with <b>%(app_name)s %(app_version)s</b>, the "
-"latest release of %(app_name)s. Please consider updating your add-on's "
-"compatibility info, or uploading a newer version of this add-on."
+"This add-on is incompatible with <b>%(app_name)s %(app_version)s</b>, the latest release of %(app_name)s. Please consider updating your add-on's compatibility info, or uploading a newer version of "
+"this add-on."
 msgstr ""
-"Pengaya ini tidak kompatibel dengan <b>%(app_name)s %(app_version)s</b>, "
-"rilis terakhir dari %(app_name)s. Harap mempertimbangkan untuk memperbarui "
-"info kompatibilitas pengaya anda, atau mengunggah versi terbaru pengaya ini."
+"Pengaya ini tidak kompatibel dengan <b>%(app_name)s %(app_version)s</b>, rilis terakhir dari %(app_name)s. Harap mempertimbangkan untuk memperbarui info kompatibilitas pengaya anda, atau mengunggah "
+"versi terbaru pengaya ini."
 
 #: src/olympia/devhub/templates/devhub/addons/ajax_compat_error.html:15
 #, python-format
 msgid ""
-"<a href=\"#\" class=\"button compat-update\" data-"
-"updateurl=\"%(update_url)s\">Update Compatibility</a> <a "
-"href=\"%(version_url)s\" class=\"button\">Upload New Version</a> or <a "
-"href=\"#\" class=\"close\">Ignore</a>"
+"<a href=\"#\" class=\"button compat-update\" data-updateurl=\"%(update_url)s\">Update Compatibility</a> <a href=\"%(version_url)s\" class=\"button\">Upload New Version</a> or <a href=\"#\" class="
+"\"close\">Ignore</a>"
 msgstr ""
-"<a href=\"#\" class=\"button compat-update\" data-"
-"updateurl=\"%(update_url)s\">Kompatibilitas Diperbarui</a> <a "
-"href=\"%(version_url)s\" class=\"button\">Mengunggah Versi Baru</a> atau <a "
-"href=\"#\" class=\"close\">Abaikan</a>"
+"<a href=\"#\" class=\"button compat-update\" data-updateurl=\"%(update_url)s\">Kompatibilitas Diperbarui</a> <a href=\"%(version_url)s\" class=\"button\">Mengunggah Versi Baru</a> atau <a href=\"#"
+"\" class=\"close\">Abaikan</a>"
 
 #: src/olympia/devhub/templates/devhub/addons/ajax_compat_status.html:5
 msgid "View and update application compatibility ranges."
 msgstr "Lihat dan perbarui rentang kompatibilitas aplikasi."
 
-#: src/olympia/devhub/templates/devhub/addons/ajax_compat_status.html:6
-#: src/olympia/devhub/templates/devhub/versions/edit.html:44
+#: src/olympia/devhub/templates/devhub/addons/ajax_compat_status.html:6 src/olympia/devhub/templates/devhub/versions/edit.html:44
 msgid "Compatibility"
 msgstr "Kompatibilitas"
 
@@ -5312,39 +4313,25 @@ msgstr "Kompatibilitas"
 msgid "Update Compatibility"
 msgstr "Memperbarui Kompatibilitas"
 
-#: src/olympia/devhub/templates/devhub/addons/ajax_compat_update.html:4
-msgid ""
-"Adjusting application information here will allow users to install your add-"
-"on even if the install manifest in the package indicates that the add-on is "
-"incompatible."
-msgstr ""
-"Menyesuaikan informasi aplikasi di sini akan memungkinkan pengguna untuk "
-"memasang pengaya anda bahkan jika manifest pemasangan di paket "
-"mengindikasikan bahwa pengaya ini tidak kompatibel."
+#: src/olympia/devhub/templates/devhub/addons/ajax_compat_update.html:4 src/olympia/devhub/templates/devhub/versions/edit.html:45
+msgid "Adjusting application information here will allow users to install your add-on even if the install manifest in the package indicates that the add-on is incompatible."
+msgstr "Menyesuaikan informasi aplikasi di sini akan memungkinkan pengguna untuk memasang pengaya anda bahkan jika manifest pemasangan di paket mengindikasikan bahwa pengaya ini tidak kompatibel."
 
 #: src/olympia/devhub/templates/devhub/addons/ajax_compat_update.html:18
 msgid "Supported Versions"
 msgstr "Versi yang Didukung"
 
-#: src/olympia/devhub/templates/devhub/addons/ajax_compat_update.html:31
-#: src/olympia/devhub/templates/devhub/versions/edit.html:63
+#: src/olympia/devhub/templates/devhub/addons/ajax_compat_update.html:31 src/olympia/devhub/templates/devhub/versions/edit.html:63
 msgid "Add Another Application&hellip;"
 msgstr "Tambahkan Aplikasi Lain &hellip;"
 
-#: src/olympia/devhub/templates/devhub/addons/ajax_compat_update.html:38
-#: src/olympia/devhub/templates/devhub/addons/owner.html:86
-#: src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:46
-#: src/olympia/devhub/templates/devhub/versions/list.html:351
-#: src/olympia/devhub/templates/devhub/versions/list.html:353
-#: src/olympia/templates/impala/base.html:132
-#: src/olympia/templates/impala/base.html:143
-#: src/olympia/templates/impala/base.html:161
-#: src/olympia/templates/impala/base.html:171
+#: src/olympia/devhub/templates/devhub/addons/ajax_compat_update.html:38 src/olympia/devhub/templates/devhub/addons/owner.html:86 src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:45
+#: src/olympia/devhub/templates/devhub/versions/list.html:349 src/olympia/devhub/templates/devhub/versions/list.html:351 src/olympia/templates/impala/base.html:129
+#: src/olympia/templates/impala/base.html:140 src/olympia/templates/impala/base.html:158 src/olympia/templates/impala/base.html:168
 msgid "Close"
 msgstr "Tutup"
 
-#: src/olympia/devhub/templates/devhub/addons/dashboard.html:43
-#: src/olympia/zadmin/templates/zadmin/index.html:22
+#: src/olympia/devhub/templates/devhub/addons/dashboard.html:43 src/olympia/zadmin/templates/zadmin/index.html:22
 #, python-format
 msgid "%(ago)s by %(user)s"
 msgstr "%(ago)s oleh %(user)s"
@@ -5358,30 +4345,23 @@ msgstr "Aktivitas lebih lama untuk Pengaya Anda"
 msgid "<b>{0}</b> theme"
 msgid_plural "<b>{0}</b> themes"
 msgstr[0] "<b>{0}</b> tema"
+msgstr[1] ""
 
-#: src/olympia/devhub/templates/devhub/addons/edit.html:3
-#: src/olympia/devhub/templates/devhub/addons/listing/item_actions.html:25
-#: src/olympia/devhub/templates/devhub/addons/listing/item_actions_theme.html:7
-#: src/olympia/devhub/templates/devhub/includes/addons_edit_nav.html:2
-#: src/olympia/devhub/templates/devhub/personas/edit.html:6
-#: src/olympia/editors/templates/editors/themes/single.html:37
+#: src/olympia/devhub/templates/devhub/addons/edit.html:3 src/olympia/devhub/templates/devhub/addons/listing/item_actions.html:25
+#: src/olympia/devhub/templates/devhub/addons/listing/item_actions_theme.html:7 src/olympia/devhub/templates/devhub/includes/addons_edit_nav.html:2
+#: src/olympia/devhub/templates/devhub/personas/edit.html:6 src/olympia/editors/templates/editors/themes/single.html:37
 msgid "Edit Listing"
 msgstr "Sunting Daftar"
 
-#: src/olympia/devhub/templates/devhub/addons/edit.html:13
-#: src/olympia/devhub/templates/devhub/includes/macros.html:18
-#: src/olympia/translations/templates/translations/all-locales.html:6
+#: src/olympia/devhub/templates/devhub/addons/edit.html:13 src/olympia/devhub/templates/devhub/includes/macros.html:18 src/olympia/translations/templates/translations/all-locales.html:6
 msgid "None"
 msgstr "Жодного"
 
-#: src/olympia/devhub/templates/devhub/addons/owner.html:4
-#: src/olympia/devhub/templates/devhub/addons/listing/item_actions.html:52
-#: src/olympia/devhub/templates/devhub/includes/addons_edit_nav.html:3
+#: src/olympia/devhub/templates/devhub/addons/owner.html:4 src/olympia/devhub/templates/devhub/addons/listing/item_actions.html:52 src/olympia/devhub/templates/devhub/includes/addons_edit_nav.html:3
 msgid "Manage Authors & License"
 msgstr "Mengelola Penulis dan Lisensi"
 
-#: src/olympia/devhub/templates/devhub/addons/owner.html:29
-#: src/olympia/editors/templates/editors/review.html:270
+#: src/olympia/devhub/templates/devhub/addons/owner.html:29 src/olympia/editors/helpers.py:362 src/olympia/editors/templates/editors/review.html:270
 msgid "Authors"
 msgstr "Penyusun"
 
@@ -5391,35 +4371,22 @@ msgstr "Tentang peran penulis"
 
 #: src/olympia/devhub/templates/devhub/addons/owner.html:78
 msgid ""
-"<p>Add-ons can have any number of authors with 3 possible roles:</p> <ul> "
-"<li><b>Owner:</b> Can manage all aspects of the add-on's listing, including "
-"adding and removing other authors</li> <li><b>Developer:</b> Can manage all "
-"aspects of the add-on's listing, except for adding and removing other "
-"authors and managing payments</li> <li><b>Viewer:</b> Can view the add-on's "
-"settings and statistics, but cannot make any changes</li> </ul>"
+"<p>Add-ons can have any number of authors with 3 possible roles:</p> <ul> <li><b>Owner:</b> Can manage all aspects of the add-on's listing, including adding and removing other authors</li> "
+"<li><b>Developer:</b> Can manage all aspects of the add-on's listing, except for adding and removing other authors and managing payments</li> <li><b>Viewer:</b> Can view the add-on's settings and "
+"statistics, but cannot make any changes</li> </ul>"
 msgstr ""
-"<p>Pengaya bisa memiliki sejumlah penulis dengan 3 peran yang "
-"memungkinkan:</p> <ul> <li><b>Pemilik:</b> Dapat mengelola semua aspek "
-"pendaftaran pengaya, termasuk menambahkan dan menghapus penulis lainnya</li>"
-" <li><b>Pengembang:</b> Dapat mengelola semua aspek pendaftaran pengaya, "
-"kecuali menambahkan dan menghapus penulsi lain dan mengelola pembayaran</li>"
-" <li><b>Pengamat:</b> Dapat melihat pengaturan dan statistik pengaya, tetapi"
-" tidak bisa membuat perubahan apapun </li> </ul>"
+"<p>Pengaya bisa memiliki sejumlah penulis dengan 3 peran yang memungkinkan:</p> <ul> <li><b>Pemilik:</b> Dapat mengelola semua aspek pendaftaran pengaya, termasuk menambahkan dan menghapus penulis "
+"lainnya</li> <li><b>Pengembang:</b> Dapat mengelola semua aspek pendaftaran pengaya, kecuali menambahkan dan menghapus penulsi lain dan mengelola pembayaran</li> <li><b>Pengamat:</b> Dapat melihat "
+"pengaturan dan statistik pengaya, tetapi tidak bisa membuat perubahan apapun </li> </ul>"
 
-#: src/olympia/devhub/templates/devhub/addons/profile.html:3
-#: src/olympia/devhub/templates/devhub/addons/listing/item_actions.html:53
-#: src/olympia/devhub/templates/devhub/includes/addons_edit_nav.html:4
+#: src/olympia/devhub/templates/devhub/addons/profile.html:3 src/olympia/devhub/templates/devhub/addons/listing/item_actions.html:53 src/olympia/devhub/templates/devhub/includes/addons_edit_nav.html:4
 msgid "Manage Developer Profile"
 msgstr "Kelola Profil Pengembang"
 
 #: src/olympia/devhub/templates/devhub/addons/profile.html:16
 #, python-format
-msgid ""
-"Your <a href=\"%(url)s\">developer profile</a> is currently "
-"<strong>public</strong> and <strong>required</strong> for contributions."
-msgstr ""
-"Profil pengembang <a href=\"%(url)s\">anda</a> saat ini "
-"<strong>publi</strong> dan <strong>memerlukan</strong> untuk berkontribusi."
+msgid "Your <a href=\"%(url)s\">developer profile</a> is currently <strong>public</strong> and <strong>required</strong> for contributions."
+msgstr "Profil pengembang <a href=\"%(url)s\">anda</a> saat ini <strong>publi</strong> dan <strong>memerlukan</strong> untuk berkontribusi."
 
 #: src/olympia/devhub/templates/devhub/addons/profile.html:22
 msgid "Remove Both"
@@ -5427,12 +4394,8 @@ msgstr "Hapus Keduanya"
 
 #: src/olympia/devhub/templates/devhub/addons/profile.html:27
 #, python-format
-msgid ""
-"Your <a href=\"%(url)s\">developer profile</a> is currently "
-"<strong>public</strong>."
-msgstr ""
-"Profil <a href=\"%(url)s\">developer anda</a> saat ini "
-"<strong>publik</strong>."
+msgid "Your <a href=\"%(url)s\">developer profile</a> is currently <strong>public</strong>."
+msgstr "Profil <a href=\"%(url)s\">developer anda</a> saat ini <strong>publik</strong>."
 
 #: src/olympia/devhub/templates/devhub/addons/profile.html:33
 msgid "Remove Profile"
@@ -5459,11 +4422,8 @@ msgstr "URL Pengaya"
 msgid "Choose a short, unique URL slug for your add-on."
 msgstr "Pilihlah URL slug yang unik dan pendek untuk pengaya anda."
 
-#: src/olympia/devhub/templates/devhub/addons/edit/basic.html:43
-#: src/olympia/devhub/templates/devhub/includes/addons_edit_nav.html:35
-#: src/olympia/devhub/templates/devhub/personas/edit.html:56
-#: src/olympia/editors/templates/editors/review.html:255
-#: src/olympia/editors/templates/editors/themes/single.html:33
+#: src/olympia/devhub/templates/devhub/addons/edit/basic.html:43 src/olympia/devhub/templates/devhub/includes/addons_edit_nav.html:35 src/olympia/devhub/templates/devhub/personas/edit.html:56
+#: src/olympia/editors/templates/editors/review.html:255 src/olympia/editors/templates/editors/themes/single.html:33
 msgid "View Listing"
 msgstr "Tampilkan pada Daftar"
 
@@ -5473,10 +4433,7 @@ msgstr "Звіт"
 
 #: src/olympia/devhub/templates/devhub/addons/edit/basic.html:52
 msgid ""
-"A short explanation of your add-on's basic\n"
-"                          functionality that is displayed in search and browse\n"
-"                          listings, as well as at the top of your add-on's\n"
-"                          details page. It is only relevant for listed add-ons."
+"A short explanation of your add-on's basic functionality that is displayed in search and browse listings, as well as at the top of your add-on's details page. It is only relevant for listed add-ons."
 msgstr ""
 "Penjelasan pendek untuk fungsi dasar \n"
 "                          pengaya anda yang ditampilkan dalam daftar pencarian \n"
@@ -5484,10 +4441,7 @@ msgstr ""
 "                          pengaya anda. Hanya relevan untuk pengaya terdaftar."
 
 #: src/olympia/devhub/templates/devhub/addons/edit/basic.html:73
-msgid ""
-"Categories are the primary way users browse through add-ons.\n"
-"                        Choose any that fit your add-on's functionality for the most\n"
-"                        exposure. It is only relevant for listed add-ons."
+msgid "Categories are the primary way users browse through add-ons. Choose any that fit your add-on's functionality for the most exposure. It is only relevant for listed add-ons."
 msgstr ""
 "Kategori adalah cara utama pengguna menelusuri pengaya.\n"
 "                        Pilihlah pengaya mana saja yang sesuai dengan fungsinya\n"
@@ -5496,36 +4450,25 @@ msgstr ""
 #: src/olympia/devhub/templates/devhub/addons/edit/basic.html:90
 #, python-format
 msgid ""
-"Categories cannot be changed while your add-on is featured for this "
-"application. Please email <a href=\"mailto:%(email)s\">%(email)s</a> if "
-"there is a reason you need to modify your categories."
+"Categories cannot be changed while your add-on is featured for this application. Please email <a href=\"mailto:%(email)s\">%(email)s</a> if there is a reason you need to modify your categories."
 msgstr ""
-"Kategori tidak dapat diubah saat pengaya anda ditampilkan untuk aplikasi "
-"ini. Harap mengirim surel <a href=\"mailto:%(email)s\">%(email)s</a> jika "
-"ada alasan anda perlu mengubah kategori anda."
+"Kategori tidak dapat diubah saat pengaya anda ditampilkan untuk aplikasi ini. Harap mengirim surel <a href=\"mailto:%(email)s\">%(email)s</a> jika ada alasan anda perlu mengubah kategori anda."
 
 #: src/olympia/devhub/templates/devhub/addons/edit/basic.html:119
-msgid ""
-"Tags help users find your add-on and should be short\n"
-"                        descriptors such as tabs, toolbar, or twitter.  You\n"
-"                        may have a maximum of {0} tags. It is only relevant\n"
-"                        for listed add-ons."
+msgid "Tags help users find your add-on and should be short descriptors such as tabs, toolbar, or twitter. You may have a maximum of {0} tags. It is only relevant for listed add-ons."
 msgstr ""
 "Tag membantu pengguna menemukan pengaya anda dan harus berisi \n"
 "                        gambaran pendek berisi tab, toolbar, atau twitter.  Anda\n"
 "                        bisa memiliki maksimum {0} tag. Ini hanya relevan\n"
 "                        untuk pengaya terdaftar."
 
-#: src/olympia/devhub/templates/devhub/addons/edit/basic.html:129
-#: src/olympia/devhub/templates/devhub/personas/edit.html:97
-#: src/olympia/devhub/templates/devhub/personas/submit.html:46
+#: src/olympia/devhub/templates/devhub/addons/edit/basic.html:129 src/olympia/devhub/templates/devhub/personas/edit.html:97 src/olympia/devhub/templates/devhub/personas/submit.html:46
 msgid "Comma-separated, minimum of {0} character."
 msgid_plural "Comma-separated, minimum of {0} characters."
 msgstr[0] "Dipisahkan koma, minimal {0} karakter."
+msgstr[1] ""
 
-#: src/olympia/devhub/templates/devhub/addons/edit/basic.html:132
-#: src/olympia/devhub/templates/devhub/personas/edit.html:100
-#: src/olympia/devhub/templates/devhub/personas/submit.html:49
+#: src/olympia/devhub/templates/devhub/addons/edit/basic.html:132 src/olympia/devhub/templates/devhub/personas/edit.html:100 src/olympia/devhub/templates/devhub/personas/submit.html:49
 msgid "Example: dark, cinema, noir. Limit 20."
 msgstr "Contoh: gelap, sinema, noir. Batas 20."
 
@@ -5533,6 +4476,7 @@ msgstr "Contoh: gelap, sinema, noir. Batas 20."
 msgid "Reserved tag:"
 msgid_plural "Reserved tags:"
 msgstr[0] "Tag dicadangkan:"
+msgstr[1] ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/details.html:5
 msgid "Add-on Details"
@@ -5543,46 +4487,33 @@ msgid "Add-on Details for {0}"
 msgstr "Rincian Pengaya untuk {0}"
 
 #: src/olympia/devhub/templates/devhub/addons/edit/details.html:22
-msgid ""
-"A longer explanation of features,\n"
-"                          functionality, and other relevant information. This\n"
-"                          field is only displayed on the add-on's details\n"
-"                          page. It is only relevant for listed add-ons."
+msgid "A longer explanation of features, functionality, and other relevant information. This field is only displayed on the add-on's details page. It is only relevant for listed add-ons."
 msgstr ""
 "Penjelasan lebih panjang dari fitur,\n"
 "                          fungsi, dan informasi relevan lainnya. Bidang\n"
 "                          ini hanya ditampilkan pada rincian laman\n"
 "                          pengaya. Hanya relevan untuk pengaya yang terdaftar."
 
-#: src/olympia/devhub/templates/devhub/addons/edit/details.html:44
-#: src/olympia/translations/templates/translations/trans-menu.html:13
+#: src/olympia/devhub/templates/devhub/addons/edit/details.html:44 src/olympia/translations/templates/translations/trans-menu.html:13
 msgid "Default Locale"
 msgstr "Pelokalan Baku"
 
 #: src/olympia/devhub/templates/devhub/addons/edit/details.html:45
-msgid ""
-"Information about your add-on is displayed in this locale\n"
-"                        unless you override it with a locale-specific translation.\n"
-"                        It is only relevant for listed add-ons."
+msgid "Information about your add-on is displayed in this locale unless you override it with a locale-specific translation. It is only relevant for listed add-ons."
 msgstr ""
 "Informasi mengenai pengaya anda ditampilkan dalam logat ini\n"
 "                        terkecuali jika anda membatalkannya dengan penerjemahan spesifik untuk logat tertentu.\n"
 "                        Hanya relevan untuk pengaya yang terdaftar."
 
-#: src/olympia/devhub/templates/devhub/addons/edit/details.html:61
-#: src/olympia/users/forms.py:311
-#: src/olympia/users/templates/users/edit.html:122
-#: src/olympia/users/templates/users/register.html:57
+#: src/olympia/devhub/templates/devhub/addons/edit/details.html:61 src/olympia/users/forms.py:311 src/olympia/users/templates/users/edit.html:122 src/olympia/users/templates/users/register.html:57
 #: src/olympia/users/templates/users/vcard.html:22
 msgid "Homepage"
 msgstr "Situs Web"
 
 #: src/olympia/devhub/templates/devhub/addons/edit/details.html:63
 msgid ""
-"If your add-on has another homepage, enter its\n"
-"                          address here. If your website is localized into other\n"
-"                          languages multiple translations of this field can be\n"
-"                          added. It is only relevant for listed add-ons."
+"If your add-on has another homepage, enter its address here. If your website is localized into other languages multiple translations of this field can be added. It is only relevant for listed add-"
+"ons."
 msgstr ""
 "Jika pengaya anda memiliki beranda yang lain, masukkan\n"
 "                          alamatnya di sini. Jika situs anda dilokalkan ke dalam bahasa\n"
@@ -5604,11 +4535,8 @@ msgstr "Informasi Pendukung untuk {0}"
 
 #: src/olympia/devhub/templates/devhub/addons/edit/support.html:22
 msgid ""
-"If you wish to display an e-mail address for support\n"
-"                          inquiries, enter it here. If you have different\n"
-"                          addresses for each language multiple translations of\n"
-"                          this field can be added. It is only relevant for\n"
-"                          listed add-ons."
+"If you wish to display an e-mail address for support inquiries, enter it here. If you have different addresses for each language multiple translations of this field can be added. It is only "
+"relevant for listed add-ons."
 msgstr ""
 "Jika anda ingin menampilkan alamat surel untuk mendukung \n"
 "                          permintaan, masukkan di sini. Jika anda memiliki alamat\n"
@@ -5618,10 +4546,8 @@ msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/support.html:45
 msgid ""
-"If your add-on has a support website or forum, enter\n"
-"                          its address here. If your website is localized into\n"
-"                          other languages, multiple translations of this field can\n"
-"                          be added. It is only relevant for listed add-ons."
+"If your add-on has a support website or forum, enter its address here. If your website is localized into other languages, multiple translations of this field can be added. It is only relevant for "
+"listed add-ons."
 msgstr ""
 "Jika pengaya anda memiliki situs atau forum pendukung, masukkan\n"
 "                          alamatnya di sini. Jika situs anda dilokalkan ke dalam\n"
@@ -5639,11 +4565,8 @@ msgstr "Rincian Teknis untuk {0}"
 
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:23
 msgid ""
-"Any information end users may want to know that isn't\n"
-"                          necessarily applicable to the add-on summary or description.\n"
-"                          Common uses include listing known major bugs, information on\n"
-"                          how to report bugs, anticipated release date of a new version,\n"
-"                          etc. It is only relevant for listed add-ons."
+"Any information end users may want to know that isn't necessarily applicable to the add-on summary or description. Common uses include listing known major bugs, information on how to report bugs, "
+"anticipated release date of a new version, etc. It is only relevant for listed add-ons."
 msgstr ""
 "Informasi apapun yang ingin diketahui pengguna yang tidak\n"
 "                          sepenuhnya dapat diaplikasikan untuk ringkasan atau keterangan pengaya.\n"
@@ -5660,9 +4583,7 @@ msgid "Add-on Flags"
 msgstr "Bendera Pengaya"
 
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:69
-msgid ""
-"These flags are used to classify add-ons. It is only\n"
-"                        relevant for listed add-ons."
+msgid "These flags are used to classify add-ons. It is only relevant for listed add-ons."
 msgstr ""
 "Bendera ini hanya digunakan untuk mengklasifikasikan pengaya. Hanya\n"
 "                        relevan untuk pengaya yang terdaftar."
@@ -5680,9 +4601,7 @@ msgid "View Source?"
 msgstr "Tampilkan Sumber?"
 
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:90
-msgid ""
-"Whether the source of your add-on can be displayed in our\n"
-"                        online viewer. It is only relevant for listed add-ons."
+msgid "Whether the source of your add-on can be displayed in our online viewer. It is only relevant for listed add-ons."
 msgstr ""
 "Apakah sumber pengaya anda dapat ditampilkan dalam\n"
 "                        penampil daring kami. Hanya berlaku untuk pengaya yang terdaftar."
@@ -5700,10 +4619,7 @@ msgid "Public Stats?"
 msgstr "Statistik Publik?"
 
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:102
-msgid ""
-"Whether the download and usage stats of your add-on can\n"
-"                        be displayed in our online viewer.\n"
-"                        It is only relevant for listed add-ons."
+msgid "Whether the download and usage stats of your add-on can be displayed in our online viewer. It is only relevant for listed add-ons."
 msgstr ""
 "Apakah statistik unduhan dan penggunaan pengaya anda\n"
 "                        dapat ditampilkan dalam penampil daring kami.\n"
@@ -5722,21 +4638,15 @@ msgid "Upgrade SDK?"
 msgstr "Mutakhirkan SDK?"
 
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:116
-msgid ""
-"If selected, we will try to automatically upgrade your\n"
-"                        add-on when a new version of the SDK is released.\n"
-"                        It is only relevant for listed add-ons."
+msgid "If selected, we will try to automatically upgrade your add-on when a new version of the SDK is released. It is only relevant for listed add-ons."
 msgstr ""
 "Jika terpilih, kami akan secara otomatis memutakhirkan pengaya\n"
 "                        anda saat versi baru SDK dirilis.\n"
 "                        Hanya relevan untuk pengaya yang terdaftar."
 
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:121
-msgid ""
-"This add-on will be automatically upgraded to new versions of the Add-on "
-"SDK."
-msgstr ""
-"Pengaya ini akan dimutakhirkan secara otomatis ke versi baru SDK Pengaya."
+msgid "This add-on will be automatically upgraded to new versions of the Add-on SDK."
+msgstr "Pengaya ini akan dimutakhirkan secara otomatis ke versi baru SDK Pengaya."
 
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:123
 msgid "No, this add-on will be upgraded manually."
@@ -5751,30 +4661,20 @@ msgid "UUID"
 msgstr "UUID"
 
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:132
-msgid ""
-"The UUID of your add-on is specified in its install manifest and uniquely "
-"identifies it. You cannot change your UUID once it has been submitted."
-msgstr ""
-"UUID pengaya anda disebutkan secara spesifik dalam manifest pemasangannya "
-"dan secara unik mengidentifikasi hal itu. Anda tidak bisa mengubah UUID "
-"setelah pengaya dikirimkan."
+msgid "The UUID of your add-on is specified in its install manifest and uniquely identifies it. You cannot change your UUID once it has been submitted."
+msgstr "UUID pengaya anda disebutkan secara spesifik dalam manifest pemasangannya dan secara unik mengidentifikasi hal itu. Anda tidak bisa mengubah UUID setelah pengaya dikirimkan."
 
-#: src/olympia/devhub/templates/devhub/addons/edit/technical.html:143
-#: src/olympia/devhub/templates/devhub/addons/edit/technical.html:144
+#: src/olympia/devhub/templates/devhub/addons/edit/technical.html:143 src/olympia/devhub/templates/devhub/addons/edit/technical.html:144
 msgid "Whiteboard"
 msgstr "Papan tulis"
 
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:146
 msgid ""
-"The whiteboard is the place to provide information relevant to your addon, "
-"whatever the version, to the editor. Use it to provide ways to test the "
-"addon, and any additional information that may help. This whiteboard is also"
-" editable by editors."
+"The whiteboard is the place to provide information relevant to your addon, whatever the version, to the editor. Use it to provide ways to test the addon, and any additional information that may "
+"help. This whiteboard is also editable by editors."
 msgstr ""
-"Papan tulis adalah tempat untuk menyediakan informasi yang relevan untuk "
-"pengaya anda, apapun versinya, kepada penyunting. Gunakan untuk menyediakan "
-"cara menguji pengaya, dan tambahan informasi lainnya yang bisa membantu. "
-"Papan tulis ini juga bisa diedit oleh penyunting."
+"Papan tulis adalah tempat untuk menyediakan informasi yang relevan untuk pengaya anda, apapun versinya, kepada penyunting. Gunakan untuk menyediakan cara menguji pengaya, dan tambahan informasi "
+"lainnya yang bisa membantu. Papan tulis ini juga bisa diedit oleh penyunting."
 
 #: src/olympia/devhub/templates/devhub/addons/edit/technical_dependencies.html:9
 msgid "Remove this dependent add-on"
@@ -5794,10 +4694,8 @@ msgstr "Ikon pengaya"
 
 #: src/olympia/devhub/templates/devhub/addons/forms_shared/media.html:16
 msgid ""
-"Upload an icon for your add-on or choose from one of ours. The\n"
-"                      icon is displayed nearly everywhere your add-on is. Uploaded images\n"
-"                      must be one of the following image types: .png, .jpg.\n"
-"                      It is only relevant for listed add-ons."
+"Upload an icon for your add-on or choose from one of ours. The icon is displayed nearly everywhere your add-on is. Uploaded images must be one of the following image types: .png, .jpg. It is only "
+"relevant for listed add-ons."
 msgstr ""
 "Unggah ikon untuk pengaya anda atau pilih dari salah satu milik kami. Ikon\n"
 "                      ditampilkan hampir di manapun pengaya anda berada. Gambar yang diunggah\n"
@@ -5814,9 +4712,7 @@ msgid "32x32px"
 msgstr "32 x 32 px"
 
 #: src/olympia/devhub/templates/devhub/addons/forms_shared/media.html:39
-msgid ""
-"Used in listings of add-ons, like search results\n"
-"                            and featured add-ons."
+msgid "Used in listings of add-ons, like search results and featured add-ons."
 msgstr ""
 "Digunakan di daftar pengaya, seperti hasil pencarian\n"
 "                            dan pengaya yang diunggulkan."
@@ -5836,9 +4732,7 @@ msgstr "Unggah Ikon yang lain..."
 
 #: src/olympia/devhub/templates/devhub/addons/forms_shared/media.html:65
 msgid "PNG and JPG supported. Icons resized to 64x64 pixels if larger."
-msgstr ""
-"PNG dan JPG didukung. Ikon akan diubah ukurannya menjadi 64 x 64 pixel jika "
-"lebih besar."
+msgstr "PNG dan JPG didukung. Ikon akan diubah ukurannya menjadi 64 x 64 pixel jika lebih besar."
 
 #: src/olympia/devhub/templates/devhub/addons/forms_shared/media.html:83
 msgid "Screenshots"
@@ -5860,60 +4754,49 @@ msgstr "Tambahkan Tangkapan layar..."
 msgid "Tests"
 msgstr "Tes"
 
-#: src/olympia/devhub/templates/devhub/addons/includes/validation_compat_test_results.html:25
-#: src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:5
+#: src/olympia/devhub/templates/devhub/addons/includes/validation_compat_test_results.html:25 src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:5
 #: src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:53
 msgid "General Tests"
 msgstr "Tes Umum"
 
-#: src/olympia/devhub/templates/devhub/addons/includes/validation_compat_test_results.html:32
-#: src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:9
+#: src/olympia/devhub/templates/devhub/addons/includes/validation_compat_test_results.html:32 src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:9
 #: src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:67
 msgid "Security Tests"
 msgstr "Tes Keamanan"
 
-#: src/olympia/devhub/templates/devhub/addons/includes/validation_compat_test_results.html:39
-#: src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:13
+#: src/olympia/devhub/templates/devhub/addons/includes/validation_compat_test_results.html:39 src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:13
 #: src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:80
 msgid "Extension Tests"
 msgstr "Tes Ekstensi"
 
-#: src/olympia/devhub/templates/devhub/addons/includes/validation_compat_test_results.html:46
-#: src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:17
+#: src/olympia/devhub/templates/devhub/addons/includes/validation_compat_test_results.html:46 src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:17
 #: src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:93
 msgid "Localization Tests"
 msgstr "Tes Pelokalan"
 
-#: src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:21
-#: src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:106
+#: src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:21 src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:106
 msgid "Compatibility Tests"
 msgstr "Tes Kompatibilitas"
 
-#: src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:29
-#: src/olympia/files/templates/files/viewer.html:142
+#: src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:29 src/olympia/files/templates/files/viewer.html:142
 msgid "Hide messages not required for automated signing"
 msgstr "Pesan tidak perlu disembunyikan untuk penandatanganan otomatis"
 
-#: src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:35
-#: src/olympia/files/templates/files/viewer.html:150
+#: src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:35 src/olympia/files/templates/files/viewer.html:150
 msgid "Hide messages present in previous version and ignored"
 msgstr "Menyembunyikan pesan ada di versi sebelumnya dan tidak diindahkan"
 
-#: src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:50
-#: src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:64
-#: src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:77
-#: src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:90
+#: src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:50 src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:64
+#: src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:77 src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:90
 #: src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:103
 msgid "Top"
 msgstr "Teratas"
 
-#: src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:2
-#: src/olympia/devhub/templates/devhub/personas/edit.html:63
+#: src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:2 src/olympia/devhub/templates/devhub/personas/edit.html:63
 msgid "Delete Theme"
 msgstr "Hapus tema"
 
-#: src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:2
-#: src/olympia/devhub/templates/devhub/versions/list.html:117
+#: src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:2 src/olympia/devhub/templates/devhub/versions/list.html:117
 msgid "Delete Add-on"
 msgstr "Hapus Pengaya"
 
@@ -5922,31 +4805,24 @@ msgid "Deleting your theme will permanently remove it from the site."
 msgstr "Menghapus tema anda akan menghapusnya sama sekali dari situs."
 
 #: src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:14
-msgid ""
-"Deleting your add-on will permanently remove it from the site and prevent "
-"its GUID from being submitted again by others."
-msgstr ""
-"Menghapus pengaya anda akan secara permanen menghapusnya dari situs dan "
-"mencegah GUID tersebut diserahkan kembali oleh orang lain."
+msgid "Deleting your add-on will permanently remove it from the site and prevent its GUID from being submitted again by others."
+msgstr "Menghapus pengaya anda akan secara permanen menghapusnya dari situs dan mencegah GUID tersebut diserahkan kembali oleh orang lain."
 
 #: src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:24
-msgid ""
-"Enter the following text confirm your decision:\n"
-"           {slug}"
+msgid "Enter the following text confirm your decision: {slug}"
 msgstr ""
 "Masukkan teks berikut ini untuk mengkonfirmasi keputusan anda:\n"
 "           {slug}"
 
-#: src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:34
+#: src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:33
 msgid "Please tell us why you are deleting your theme:"
 msgstr "Beritahu kami mengapa Anda menghapus tema Anda:"
 
-#: src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:36
+#: src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:35
 msgid "Please tell us why you are deleting your add-on:"
 msgstr "Beritahu kami mengapa Anda menghapus pengaya Anda:"
 
-#: src/olympia/devhub/templates/devhub/addons/listing/item_actions.html:1
-#: src/olympia/devhub/templates/devhub/addons/listing/item_actions_theme.html:1
+#: src/olympia/devhub/templates/devhub/addons/listing/item_actions.html:1 src/olympia/devhub/templates/devhub/addons/listing/item_actions_theme.html:1
 #: src/olympia/editors/templates/editors/review.html:253
 msgid "Actions"
 msgstr "Aksi"
@@ -5979,22 +4855,17 @@ msgstr "Versi Baru"
 msgid "Daily statistics on downloads and users."
 msgstr "Statistik harian untuk unduhan dan pengguna."
 
-#: src/olympia/devhub/templates/devhub/addons/listing/item_actions.html:45
-#: src/olympia/stats/templates/stats/stats.html:75
-#: src/olympia/stats/templates/stats/stats.html:79
-#: src/olympia/stats/templates/stats/stats.html:81
+#: src/olympia/devhub/templates/devhub/addons/listing/item_actions.html:45 src/olympia/stats/templates/stats/stats.html:31 src/olympia/stats/templates/stats/stats.html:35
+#: src/olympia/stats/templates/stats/stats.html:37
 msgid "Statistics"
 msgstr "Statistik"
 
-#: src/olympia/devhub/templates/devhub/addons/listing/item_actions.html:54
-#: src/olympia/devhub/templates/devhub/includes/addons_edit_nav.html:5
-#: src/olympia/devhub/templates/devhub/payments/payments.html:3
-#: src/olympia/devhub/templates/devhub/payments/tier.html:4
+#: src/olympia/devhub/templates/devhub/addons/listing/item_actions.html:54 src/olympia/devhub/templates/devhub/includes/addons_edit_nav.html:5
+#: src/olympia/devhub/templates/devhub/payments/payments.html:3 src/olympia/devhub/templates/devhub/payments/tier.html:4
 msgid "Manage Payments"
 msgstr "Kelola Pembayaran"
 
-#: src/olympia/devhub/templates/devhub/addons/listing/item_actions.html:55
-#: src/olympia/devhub/templates/devhub/includes/addons_edit_nav.html:6
+#: src/olympia/devhub/templates/devhub/addons/listing/item_actions.html:55 src/olympia/devhub/templates/devhub/includes/addons_edit_nav.html:6
 msgid "Manage Status & Versions"
 msgstr "Kelola Status & Versi"
 
@@ -6002,10 +4873,8 @@ msgstr "Kelola Status & Versi"
 msgid "View Add-on Listing"
 msgstr "Lihat Daftar Pengaya"
 
-#: src/olympia/devhub/templates/devhub/addons/listing/item_actions.html:64
-#: src/olympia/devhub/templates/devhub/addons/listing/item_actions_theme.html:12
-#: src/olympia/devhub/templates/devhub/includes/addons_edit_nav.html:37
-#: src/olympia/devhub/templates/devhub/personas/edit.html:58
+#: src/olympia/devhub/templates/devhub/addons/listing/item_actions.html:64 src/olympia/devhub/templates/devhub/addons/listing/item_actions_theme.html:12
+#: src/olympia/devhub/templates/devhub/includes/addons_edit_nav.html:37 src/olympia/devhub/templates/devhub/personas/edit.html:58
 msgid "View Recent Changes"
 msgstr "Lihat Perubahan Baru-baru ini"
 
@@ -6030,12 +4899,8 @@ msgid "Delete this theme."
 msgstr "Hapus tema ini."
 
 #: src/olympia/devhub/templates/devhub/addons/listing/items.html:10
-msgid ""
-"This add-on will be deleted automatically after a few days if the submission"
-" process is not completed."
-msgstr ""
-"Pengaya ini akan dihapus secara otomatis setelah beberapa hari jika proses "
-"pendaftarannya tidak komplet."
+msgid "This add-on will be deleted automatically after a few days if the submission process is not completed."
+msgstr "Pengaya ini akan dihapus secara otomatis setelah beberapa hari jika proses pendaftarannya tidak komplet."
 
 #: src/olympia/devhub/templates/devhub/addons/listing/items.html:27
 msgid "Disabled"
@@ -6051,6 +4916,7 @@ msgstr "<b>Posisi antrean:</b> %(pos)s dari %(total)s"
 msgid "<strong>{0}</strong> active user"
 msgid_plural "<strong>{0}</strong> active users"
 msgstr[0] "<strong>{0}</strong> pengguna aktif"
+msgstr[1] ""
 
 #: src/olympia/devhub/templates/devhub/addons/submit/base.html:11
 msgid "Submit Add-on"
@@ -6072,13 +4938,9 @@ msgstr "Nama dan versi:"
 msgid "The detail page will be:"
 msgstr "Rindian laman akan:"
 
-#: src/olympia/devhub/templates/devhub/addons/submit/describe.html:24
-#: src/olympia/devhub/templates/devhub/personas/edit.html:89
-#: src/olympia/devhub/templates/devhub/personas/submit.html:38
+#: src/olympia/devhub/templates/devhub/addons/submit/describe.html:24 src/olympia/devhub/templates/devhub/personas/edit.html:89 src/olympia/devhub/templates/devhub/personas/submit.html:38
 msgid "Please use only letters, numbers, underscores, and dashes in your URL."
-msgstr ""
-"Harap hanya menggunakan huruf, angka, garis bawah, dan garis sambung dalam "
-"URL anda."
+msgstr "Harap hanya menggunakan huruf, angka, garis bawah, dan garis sambung dalam URL anda."
 
 #: src/olympia/devhub/templates/devhub/addons/submit/describe.html:34
 msgid "Provide a brief summary:"
@@ -6096,14 +4958,11 @@ msgstr "Sediakan deskripsi yang lebih rinci:"
 msgid "The description will appear on the detail page."
 msgstr "Deksripsi akan muncul dalam laman rincian."
 
-#: src/olympia/devhub/templates/devhub/addons/submit/done.html:4
-#: src/olympia/devhub/templates/devhub/personas/submit_done.html:4
+#: src/olympia/devhub/templates/devhub/addons/submit/done.html:4 src/olympia/devhub/templates/devhub/personas/submit_done.html:4
 msgid "Submission Complete"
 msgstr "Penyerahan Lengkap"
 
-#: src/olympia/devhub/templates/devhub/addons/submit/done.html:8
-#: src/olympia/devhub/templates/devhub/addons/submit/sidebar.html:13
-#: src/olympia/devhub/templates/devhub/personas/submit_done.html:8
+#: src/olympia/devhub/templates/devhub/addons/submit/done.html:8 src/olympia/devhub/templates/devhub/addons/submit/sidebar.html:13 src/olympia/devhub/templates/devhub/personas/submit_done.html:8
 msgid "You're done!"
 msgstr "Selesai!"
 
@@ -6116,52 +4975,33 @@ msgid "Your add-on has been submitted to the Full Review queue."
 msgstr "Pengaya anda telah dimasukkan ke dalam antrean Ulasan Lengkap."
 
 #: src/olympia/devhub/templates/devhub/addons/submit/done.html:18
-msgid ""
-"You'll receive an email once it has been reviewed by an editor. In\n"
-"          the meantime, you and your friends can install it directly from its\n"
-"          details page:"
+msgid "You'll receive an email once it has been reviewed by an editor. In the meantime, you and your friends can install it directly from its details page:"
 msgstr ""
 "Anda akan menerima sebuah surel saat pengaya telah diulas oleh penyunting. \n"
 "          sementara itu, anda dan teman anda dapat memasangnya langsung dari \n"
 "          laman rinciannya:"
 
-#: src/olympia/devhub/templates/devhub/addons/submit/done.html:27
-#: src/olympia/devhub/templates/devhub/addons/submit/done.html:77
-#: src/olympia/devhub/templates/devhub/personas/submit_done.html:16
+#: src/olympia/devhub/templates/devhub/addons/submit/done.html:27 src/olympia/devhub/templates/devhub/addons/submit/done.html:77 src/olympia/devhub/templates/devhub/personas/submit_done.html:16
 msgid "Next steps:"
 msgstr "Langkah berikutnya:"
 
-#: src/olympia/devhub/templates/devhub/addons/submit/done.html:32
-#: src/olympia/devhub/templates/devhub/addons/submit/done.html:82
+#: src/olympia/devhub/templates/devhub/addons/submit/done.html:32 src/olympia/devhub/templates/devhub/addons/submit/done.html:82
 msgid "<a href=\"{0}\">Upload</a> another platform-specific file to this version."
-msgstr ""
-"<a href=\"{0}\">Unggah</a> berkas yang spesifik untuk platform tertentu dari"
-" versi ini."
+msgstr "<a href=\"{0}\">Unggah</a> berkas yang spesifik untuk platform tertentu dari versi ini."
 
 #: src/olympia/devhub/templates/devhub/addons/submit/done.html:34
 msgid "Provide more details by <a href=\"{0}\">editing its listing</a>."
-msgstr ""
-"Berikan rincian lebih lanjut dengan <a href=\"{0}\">menyunting "
-"daftarnya</a>."
+msgstr "Berikan rincian lebih lanjut dengan <a href=\"{0}\">menyunting daftarnya</a>."
 
 #: src/olympia/devhub/templates/devhub/addons/submit/done.html:35
-msgid ""
-"Tell your users why you created this in your <a href=\"{0}\">Developer "
-"Profile</a>."
-msgstr ""
-"Sampaikan pada pengguna mengapa anda membuat pengaya ini dalam <a "
-"href=\"{0}\">Profil Pengembang</a>."
+msgid "Tell your users why you created this in your <a href=\"{0}\">Developer Profile</a>."
+msgstr "Sampaikan pada pengguna mengapa anda membuat pengaya ini dalam <a href=\"{0}\">Profil Pengembang</a>."
 
 #: src/olympia/devhub/templates/devhub/addons/submit/done.html:36
-msgid ""
-"View and subscribe to your add-on's <a href=\"{0}\">activity feed</a> to "
-"stay updated on reviews, collections, and more."
-msgstr ""
-"Lihat dan berlangganan penyedia aktivitas <a href=\"{0}\">pengaya anda</a> "
-"untuk mendapatkan informasi ulasan, koleksi dan lebih banyak lagi."
+msgid "View and subscribe to your add-on's <a href=\"{0}\">activity feed</a> to stay updated on reviews, collections, and more."
+msgstr "Lihat dan berlangganan penyedia aktivitas <a href=\"{0}\">pengaya anda</a> untuk mendapatkan informasi ulasan, koleksi dan lebih banyak lagi."
 
-#: src/olympia/devhub/templates/devhub/addons/submit/done.html:37
-#: src/olympia/devhub/templates/devhub/addons/submit/done.html:86
+#: src/olympia/devhub/templates/devhub/addons/submit/done.html:37 src/olympia/devhub/templates/devhub/addons/submit/done.html:86
 msgid "View approximate review queue <a href=\"{0}\">wait times</a>."
 msgstr "Tampilkan perkiraan waktu tunggu <a href=\"{0}\">antrian ulasan</a>."
 
@@ -6171,44 +5011,31 @@ msgstr "Maju dalam Antrian Ulasan!"
 
 #: src/olympia/devhub/templates/devhub/addons/submit/done.html:45
 msgid "Become an AMO Reviewer today and get your add-ons reviewed faster."
-msgstr ""
-"Jadilah Pengulas AMO hari ini dan pengaya anda akan diulas lebih cepat."
+msgstr "Jadilah Pengulas AMO hari ini dan pengaya anda akan diulas lebih cepat."
 
 #: src/olympia/devhub/templates/devhub/addons/submit/done.html:54
-msgid ""
-"Your add-on has been signed and it's ready to use. You can download it here:"
-msgstr ""
-"Pengaya anda telah diteken dan siap digunakan. Anda bisa mengunduhnya di "
-"sini:"
+msgid "Your add-on has been signed and it's ready to use. You can download it here:"
+msgstr "Pengaya anda telah diteken dan siap digunakan. Anda bisa mengunduhnya di sini:"
 
 #: src/olympia/devhub/templates/devhub/addons/submit/done.html:64
-msgid ""
-"Your add-on has been submitted to the Unlisted Preliminary Review queue."
-msgstr ""
-"Pengaya anda telah didaftarkan ke antrian Ulasan Pendahuluan Tak Terdaftar."
+msgid "Your add-on has been submitted to the Unlisted Preliminary Review queue."
+msgstr "Pengaya anda telah didaftarkan ke antrian Ulasan Pendahuluan Tak Terdaftar."
 
 #: src/olympia/devhub/templates/devhub/addons/submit/done.html:66
 msgid "Your add-on has been submitted to the Unlisted Full Review queue."
 msgstr "Pengaya anda telah didaftarkan ke antrian Ulasan Penuh Tak Terdaftar."
 
 #: src/olympia/devhub/templates/devhub/addons/submit/done.html:70
-msgid ""
-"You'll receive an email once it has been reviewed by an editor and signed."
-msgstr ""
-"Anda akan menerima sebuah surel saat pengaya telah diulas oleh seorang "
-"penyunting dan diteken."
+msgid "You'll receive an email once it has been reviewed by an editor and signed."
+msgstr "Anda akan menerima sebuah surel saat pengaya telah diulas oleh seorang penyunting dan diteken."
 
 #: src/olympia/devhub/templates/devhub/addons/submit/done.html:74
 msgid "Your add-on will not be publicly available on this website."
 msgstr "Pengaya anda tidak akan tersedia untuk publik di situs ini."
 
 #: src/olympia/devhub/templates/devhub/addons/submit/done.html:84
-msgid ""
-"You can upload new versions of your add-on in the <a href=\"{0}\">add-on's "
-"developer page</a>."
-msgstr ""
-"Anda bisa mengunggah versi terbaru pengaya anda di <a href=\"{0}\">laman "
-"pengembang pengaya</a>."
+msgid "You can upload new versions of your add-on in the <a href=\"{0}\">add-on's developer page</a>."
+msgstr "Anda bisa mengunggah versi terbaru pengaya anda di <a href=\"{0}\">laman pengembang pengaya</a>."
 
 #: src/olympia/devhub/templates/devhub/addons/submit/license.html:4
 msgid "Step 5"
@@ -6219,14 +5046,8 @@ msgid "Step 5. Select a License"
 msgstr "Langkah 5. Pilih Lisensi"
 
 #: src/olympia/devhub/templates/devhub/addons/submit/license.html:9
-msgid ""
-"We require all add-ons to indicate the terms under which their source code "
-"is licensed. Please select a license from the list below or enter a custom "
-"license."
-msgstr ""
-"Kami meminta semua pengaya untuk mengindikasikan di bawah ketentuan mana "
-"kode sumber mereka dilisensi. Silakan memilih lisensi dari daftar di bawah "
-"ini atau masukkan lisensi khusus."
+msgid "We require all add-ons to indicate the terms under which their source code is licensed. Please select a license from the list below or enter a custom license."
+msgstr "Kami meminta semua pengaya untuk mengindikasikan di bawah ketentuan mana kode sumber mereka dilisensi. Silakan memilih lisensi dari daftar di bawah ini atau masukkan lisensi khusus."
 
 #: src/olympia/devhub/templates/devhub/addons/submit/license.html:18
 msgid "Select a license for your add-on:"
@@ -6242,14 +5063,11 @@ msgstr "Langkah 4. Menambahkan Gambar"
 
 #: src/olympia/devhub/templates/devhub/addons/submit/media.html:9
 msgid ""
-"Custom icons and screenshots draw attention and help users understand what "
-"it does. We strongly recommend uploading a custom icon, as in some areas of "
-"the website, only the icon and name will appear."
+"Custom icons and screenshots draw attention and help users understand what it does. We strongly recommend uploading a custom icon, as in some areas of the website, only the icon and name will "
+"appear."
 msgstr ""
-"Ikon khusus dan tangkapan layar menarik perhatian dan membantu pengguna "
-"untuk memahami apa yang dilakukannya. Kami sangat merekomendasikan untuk "
-"emngunggah ikon khusus, seperti di sejumlah bagian dalam situs, hanya ikon "
-"dan nama yang akan muncul."
+"Ikon khusus dan tangkapan layar menarik perhatian dan membantu pengguna untuk memahami apa yang dilakukannya. Kami sangat merekomendasikan untuk emngunggah ikon khusus, seperti di sejumlah bagian "
+"dalam situs, hanya ikon dan nama yang akan muncul."
 
 #: src/olympia/devhub/templates/devhub/addons/submit/select-review.html:5
 msgid "Step 6"
@@ -6261,25 +5079,16 @@ msgstr "Langkah 6. Pilih Proses Pengulasan"
 
 #: src/olympia/devhub/templates/devhub/addons/submit/select-review.html:10
 msgid ""
-"All add-ons hosted in our gallery must be reviewed by an editor before they "
-"appear in categories or search results. While waiting for review, your add-"
-"on can still be accessed through its direct URL. Please choose the review "
-"process below that best fits your add-on."
+"All add-ons hosted in our gallery must be reviewed by an editor before they appear in categories or search results. While waiting for review, your add-on can still be accessed through its direct "
+"URL. Please choose the review process below that best fits your add-on."
 msgstr ""
-"Semua pengaya yang diterima dalam galeri kami harus diulas oleh seorang "
-"penyunting sebelum dapat dimunculkan dalam kategori atau hasil pencarian. "
-"Saat menunggu ulasan, pengaya anda masih bisa diakses melalui tautan URL "
-"langsungnya. Harap memilih proses ulasan di bawah ini yang sesuai dengan "
-"pengaya anda."
+"Semua pengaya yang diterima dalam galeri kami harus diulas oleh seorang penyunting sebelum dapat dimunculkan dalam kategori atau hasil pencarian. Saat menunggu ulasan, pengaya anda masih bisa "
+"diakses melalui tautan URL langsungnya. Harap memilih proses ulasan di bawah ini yang sesuai dengan pengaya anda."
 
 #: src/olympia/devhub/templates/devhub/addons/submit/select-review.html:26
 #, python-format
-msgid ""
-"A complete review of your add-on's source and functionality. <a "
-"href=\"%(url)s\">Learn more&hellip;</a>"
-msgstr ""
-"Ulasan komplet sumber pengaya anda dan fungsinya. <a "
-"href=\"%(url)s\">Selengkapnya &hellip;</a>"
+msgid "A complete review of your add-on's source and functionality. <a href=\"%(url)s\">Learn more&hellip;</a>"
+msgstr "Ulasan komplet sumber pengaya anda dan fungsinya. <a href=\"%(url)s\">Selengkapnya &hellip;</a>"
 
 #: src/olympia/devhub/templates/devhub/addons/submit/select-review.html:32
 msgid "Appropriate for polished add-ons"
@@ -6307,12 +5116,8 @@ msgstr "Pilih Ulasan Lengkap"
 
 #: src/olympia/devhub/templates/devhub/addons/submit/select-review.html:49
 #, python-format
-msgid ""
-"A faster review of your add-on's source for any major problems. <a "
-"href=\"%(url)s\">Learn more&hellip;</a>"
-msgstr ""
-"Ulasan yang lebih cepat dari sumber pengaya anda untuk masalah besar apapun."
-" <a href=\"%(url)s\">Selengkapnya&hellip;</a>"
+msgid "A faster review of your add-on's source for any major problems. <a href=\"%(url)s\">Learn more&hellip;</a>"
+msgstr "Ulasan yang lebih cepat dari sumber pengaya anda untuk masalah besar apapun. <a href=\"%(url)s\">Selengkapnya&hellip;</a>"
 
 #: src/olympia/devhub/templates/devhub/addons/submit/select-review.html:55
 msgid "Appropriate for experimental add-ons"
@@ -6358,10 +5163,8 @@ msgstr "Pilih lisensi"
 msgid "Select a review process"
 msgstr "Pilih proses ulasan"
 
-#: src/olympia/devhub/templates/devhub/addons/submit/sidebar.html:18
-#: src/olympia/devhub/templates/devhub/docs/policies-submission.html:3
-#: src/olympia/devhub/templates/devhub/docs/policies-submission.html:7
-#: src/olympia/devhub/templates/devhub/docs/policies-submission.html:9
+#: src/olympia/devhub/templates/devhub/addons/submit/sidebar.html:18 src/olympia/devhub/templates/devhub/docs/policies-submission.html:3
+#: src/olympia/devhub/templates/devhub/docs/policies-submission.html:7 src/olympia/devhub/templates/devhub/docs/policies-submission.html:9
 msgid "Submission Process"
 msgstr "Proses Pendaftaran"
 
@@ -6382,27 +5185,19 @@ msgid "Step 2. Upload Your Add-on"
 msgstr "Langkah 2. Unggah Pengaya Anda"
 
 #: src/olympia/devhub/templates/devhub/addons/submit/upload.html:11
-msgid ""
-"Use the fields below to upload your add-on package and select any platform "
-"restrictions. After upload, a series of automated validation tests will be "
-"run on your file."
+msgid "Use the fields below to upload your add-on package and select any platform restrictions. After upload, a series of automated validation tests will be run on your file."
 msgstr ""
-"Gunakan bidang di bawah ini untuk mengungggah paket pengaya anda dan pilih "
-"pembatasan platform manapun. Setelah menggunggah, serangkaian tes validasi "
-"otomatis akan dijalankan pada berkas anda."
+"Gunakan bidang di bawah ini untuk mengungggah paket pengaya anda dan pilih pembatasan platform manapun. Setelah menggunggah, serangkaian tes validasi otomatis akan dijalankan pada berkas anda."
 
-#: src/olympia/devhub/templates/devhub/addons/submit/upload.html:59
-#: src/olympia/devhub/templates/devhub/versions/add_file_modal.html:39
+#: src/olympia/devhub/templates/devhub/addons/submit/upload.html:51 src/olympia/devhub/templates/devhub/versions/add_file_modal.html:28
 msgid "Which platforms is this file compatible with?"
 msgstr "Platform manakah yang kompatibel dengan berkas ini?"
 
-#: src/olympia/devhub/templates/devhub/addons/submit/upload.html:67
-#: src/olympia/devhub/templates/devhub/versions/add_file_modal.html:65
+#: src/olympia/devhub/templates/devhub/addons/submit/upload.html:59 src/olympia/devhub/templates/devhub/versions/add_file_modal.html:45
 msgid "Administrative overrides"
 msgstr "Mengesampingkan secara administratif"
 
-#: src/olympia/devhub/templates/devhub/api/agreement.html:3
-#: src/olympia/devhub/templates/devhub/api/agreement.html:11
+#: src/olympia/devhub/templates/devhub/api/agreement.html:3 src/olympia/devhub/templates/devhub/api/agreement.html:11
 msgid "Firefox Add-on Distribution Agreement"
 msgstr "Kesepakatan Distribusi Pengaya Firefox"
 
@@ -6412,12 +5207,8 @@ msgstr "Keterangan Pengenal API"
 
 #: src/olympia/devhub/templates/devhub/api/key.html:20
 #, python-format
-msgid ""
-"For detailed instructions, consult the <a href=\"%(docs_url)s\">API "
-"documentation</a>."
-msgstr ""
-"Untuk instruksi yang lebih rinci, lihat <a href=\"%(docs_url)s\">dokumentasi"
-" API</a>."
+msgid "For detailed instructions, consult the <a href=\"%(docs_url)s\">API documentation</a>."
+msgstr "Untuk instruksi yang lebih rinci, lihat <a href=\"%(docs_url)s\">dokumentasi API</a>."
 
 #: src/olympia/devhub/templates/devhub/api/key.html:28
 msgid "JWT issuer"
@@ -6430,15 +5221,11 @@ msgstr "Rahasia JWT"
 #: src/olympia/devhub/templates/devhub/api/key.html:37
 #, python-format
 msgid ""
-"To make API requests, send a <a href=\"%(jwt_url)s\">JSON Web Token "
-"(JWT)</a> as the authorization header. You'll need to generate a JWT for "
-"every request as explained in the <a href=\"%(docs_url)s\">API "
-"documentation</a>."
+"To make API requests, send a <a href=\"%(jwt_url)s\">JSON Web Token (JWT)</a> as the authorization header. You'll need to generate a JWT for every request as explained in the <a href=\"%(docs_url)s"
+"\">API documentation</a>."
 msgstr ""
-"Untuk membuat permintaan API, kirimkan sebuah <a href=\"%(jwt_url)s\">JSON "
-"Web Token (JWT)</a> sebagai bagian awal otorisasi. Anda perlu menghasilkan "
-"JWT untuk setiap permintaan sebagaimana diterangkan dalam <a "
-"href=\"%(docs_url)s\">dokumentasi API</a>."
+"Untuk membuat permintaan API, kirimkan sebuah <a href=\"%(jwt_url)s\">JSON Web Token (JWT)</a> sebagai bagian awal otorisasi. Anda perlu menghasilkan JWT untuk setiap permintaan sebagaimana "
+"diterangkan dalam <a href=\"%(docs_url)s\">dokumentasi API</a>."
 
 #: src/olympia/devhub/templates/devhub/api/key.html:47
 msgid "You don't have any API credentials yet."
@@ -6446,12 +5233,8 @@ msgstr "Anda belum memiliki keterangan pengenal API."
 
 #: src/olympia/devhub/templates/devhub/api/key.html:53
 #, python-format
-msgid ""
-"This feature is under active development. If you find a problem please <a "
-"target=\"_blank\" href=\"%(bug_link)s\">report a bug</a>."
-msgstr ""
-"Fitur ini masih dalam pengembangan aktif. Jika anda menemukan masalah "
-"silakan <a target=\"_blank\" href=\"%(bug_link)s\">laporkan bug</a>."
+msgid "This feature is under active development. If you find a problem please <a target=\"_blank\" href=\"%(bug_link)s\">report a bug</a>."
+msgstr "Fitur ini masih dalam pengembangan aktif. Jika anda menemukan masalah silakan <a target=\"_blank\" href=\"%(bug_link)s\">laporkan bug</a>."
 
 #: src/olympia/devhub/templates/devhub/api/key.html:61
 msgid "Revoke and regenerate credentials"
@@ -6461,30 +5244,19 @@ msgstr "Mencabut dan menghasilkan ulang keterangan pengenal"
 msgid "Generate new credentials"
 msgstr "Menghasilkan keterangan pengenal baru"
 
-#: src/olympia/devhub/templates/devhub/docs/policies-agreement.html:3
-#: src/olympia/devhub/templates/devhub/docs/policies-agreement.html:7
-#: src/olympia/devhub/templates/devhub/docs/policies-agreement.html:9
-#: src/olympia/devhub/templates/devhub/docs/policies.html:24
-#: src/olympia/devhub/templates/devhub/docs/policies.html:103
+#: src/olympia/devhub/templates/devhub/docs/policies-agreement.html:3 src/olympia/devhub/templates/devhub/docs/policies-agreement.html:7
+#: src/olympia/devhub/templates/devhub/docs/policies-agreement.html:9 src/olympia/devhub/templates/devhub/docs/policies.html:24 src/olympia/devhub/templates/devhub/docs/policies.html:103
 msgid "Developer Agreement"
 msgstr "Kesepakatan Pengembang"
 
-#: src/olympia/devhub/templates/devhub/docs/policies-contact.html:3
-#: src/olympia/devhub/templates/devhub/docs/policies-contact.html:7
-#: src/olympia/devhub/templates/devhub/docs/policies-contact.html:9
-#: src/olympia/devhub/templates/devhub/docs/policies.html:27
-#: src/olympia/devhub/templates/devhub/docs/policies.html:115
+#: src/olympia/devhub/templates/devhub/docs/policies-contact.html:3 src/olympia/devhub/templates/devhub/docs/policies-contact.html:7 src/olympia/devhub/templates/devhub/docs/policies-contact.html:9
+#: src/olympia/devhub/templates/devhub/docs/policies.html:27 src/olympia/devhub/templates/devhub/docs/policies.html:115
 msgid "Contacting Us"
 msgstr "Menghubungi Kami"
 
 #: src/olympia/devhub/templates/devhub/docs/policies-contact.html:12
-msgid ""
-"Thanks for your interest in contacting the Mozilla Add-ons team. Please read"
-" this page carefully to ensure your request goes to the right place."
-msgstr ""
-"Terima kasih atas minat anda menghubungi tim Pengaya Mozilla. SIlakan "
-"membaca laman ini secara cermat untuk memastikan permintaan anda menuju ke "
-"tempat yang tepat."
+msgid "Thanks for your interest in contacting the Mozilla Add-ons team. Please read this page carefully to ensure your request goes to the right place."
+msgstr "Terima kasih atas minat anda menghubungi tim Pengaya Mozilla. SIlakan membaca laman ini secara cermat untuk memastikan permintaan anda menuju ke tempat yang tepat."
 
 #: src/olympia/devhub/templates/devhub/docs/policies-contact.html:17
 msgid "Add-on Support"
@@ -6492,15 +5264,11 @@ msgstr "Dukungan Pengaya"
 
 #: src/olympia/devhub/templates/devhub/docs/policies-contact.html:19
 msgid ""
-"If you have a support question about a particular add-on, such as \"how do I"
-" use this add-on?\" or \"why doesn't this work properly?\", please contact "
-"that add-on's author through the support channels listed on the add-on's "
-"listing page."
+"If you have a support question about a particular add-on, such as \"how do I use this add-on?\" or \"why doesn't this work properly?\", please contact that add-on's author through the support "
+"channels listed on the add-on's listing page."
 msgstr ""
-"Jika anda memiliki pertanyaan mengenai dukungan tentang pengaya tertentu, "
-"misalnya \"bagaimana cara menggunakan pengaya ini?\" atau \"mengapa pengaya "
-"ini tidak bekerja dengan baik?\", silakan menghubungi penulis pengaya "
-"tersebut melalui saluran dukungan yang terdaftar dalam laman daftar pengaya."
+"Jika anda memiliki pertanyaan mengenai dukungan tentang pengaya tertentu, misalnya \"bagaimana cara menggunakan pengaya ini?\" atau \"mengapa pengaya ini tidak bekerja dengan baik?\", silakan "
+"menghubungi penulis pengaya tersebut melalui saluran dukungan yang terdaftar dalam laman daftar pengaya."
 
 #: src/olympia/devhub/templates/devhub/docs/policies-contact.html:24
 msgid "Add-on Editorial Concerns"
@@ -6513,17 +5281,11 @@ msgstr "amo-editors at mozilla dot org"
 #: src/olympia/devhub/templates/devhub/docs/policies-contact.html:26
 #, python-format
 msgid ""
-"If you have a question about an Editor's review of an add-on or want to "
-"report a policy violation, please email %(mail_editors)s. <strong>Almost all"
-" add-on reports fall under this category.</strong> Please be sure to include"
-" a link to the add-on in question and a detailed description of your "
-"question or comment."
+"If you have a question about an Editor's review of an add-on or want to report a policy violation, please email %(mail_editors)s. <strong>Almost all add-on reports fall under this category.</"
+"strong> Please be sure to include a link to the add-on in question and a detailed description of your question or comment."
 msgstr ""
-"Jika anda memiliki pertanyaan mengenai ulasan Penyunting atas sebuah pengaya"
-" atau ingin melaporkan pelanggaran kebijakan, silakan mengirim surel "
-"%(mail_editors)s. <strong>Hampir semua laporan pengaya berada dalam kategori"
-" ini.</strong> Harap menyertakan tautan pada pengaya yang dibahasa dan "
-"deskripsi terinci mengenai pertanyaan atau komentar anda."
+"Jika anda memiliki pertanyaan mengenai ulasan Penyunting atas sebuah pengaya atau ingin melaporkan pelanggaran kebijakan, silakan mengirim surel %(mail_editors)s. <strong>Hampir semua laporan "
+"pengaya berada dalam kategori ini.</strong> Harap menyertakan tautan pada pengaya yang dibahasa dan deskripsi terinci mengenai pertanyaan atau komentar anda."
 
 #: src/olympia/devhub/templates/devhub/docs/policies-contact.html:31
 msgid "Add-on Security Vulnerabilities"
@@ -6536,22 +5298,13 @@ msgstr "amo-admins at mozilla dot org"
 #: src/olympia/devhub/templates/devhub/docs/policies-contact.html:36
 #, python-format
 msgid ""
-"If you have discovered a security vulnerability in an add-on, even if it is "
-"not hosted here, Mozilla is very interested in your discovery and will work "
-"with the add-on developer to correct the issue as soon as possible. Add-on "
-"security issues can be reported <a "
-"href=\"http://www.mozilla.org/projects/security/security-bugs-"
-"policy.html\">confidentially</a> in <a "
-"href=\"%(link_bugzilla)s\">Bugzilla</a> or by emailing %(mail_admins)s."
+"If you have discovered a security vulnerability in an add-on, even if it is not hosted here, Mozilla is very interested in your discovery and will work with the add-on developer to correct the "
+"issue as soon as possible. Add-on security issues can be reported <a href=\"http://www.mozilla.org/projects/security/security-bugs-policy.html\">confidentially</a> in <a href=\"%(link_bugzilla)s"
+"\">Bugzilla</a> or by emailing %(mail_admins)s."
 msgstr ""
-"Jika anda menemukan kerentanan keamanan pada sebuah pengaya, bahkan jika "
-"pengaya itu tidak dimuat di sini, Mozilla sangat tertarik pada penemuan anda"
-" dan akan bekerja bersama pengembang untuk memperbaiki masalahnya secepat "
-"mungkin. Isu keamanan pengaya dapat dilaporkan <a "
-"href=\"http://www.mozilla.org/projects/security/security-bugs-"
-"policy.html\">secara rahasia</a> di <a "
-"href=\"%(link_bugzilla)s\">Bugzilla</a> atau dengan mengirim surel "
-"%(mail_admins)s."
+"Jika anda menemukan kerentanan keamanan pada sebuah pengaya, bahkan jika pengaya itu tidak dimuat di sini, Mozilla sangat tertarik pada penemuan anda dan akan bekerja bersama pengembang untuk "
+"memperbaiki masalahnya secepat mungkin. Isu keamanan pengaya dapat dilaporkan <a href=\"http://www.mozilla.org/projects/security/security-bugs-policy.html\">secara rahasia</a> di <a href="
+"\"%(link_bugzilla)s\">Bugzilla</a> atau dengan mengirim surel %(mail_admins)s."
 
 #: src/olympia/devhub/templates/devhub/docs/policies-contact.html:42
 msgid "Website Functionality & Development"
@@ -6559,18 +5312,11 @@ msgstr "Fungsi Situs & Pengembangan"
 
 #: src/olympia/devhub/templates/devhub/docs/policies-contact.html:44
 msgid ""
-"If you've found a problem with the site, we'd love to fix it. Please <a "
-"href=\"https://github.com/mozilla/olympia/issues\">file a bug report</a> in "
-"GitHub, including the location of the problem and how you encountered it."
+"If you've found a problem with the site, we'd love to fix it. Please <a href=\"https://github.com/mozilla/addons/issues/new\">file a bug report</a> in GitHub, including the location of the problem "
+"and how you encountered it."
 msgstr ""
-"Jika anda menemukan masalah dengan situs ini, kami akan dengan senang hati "
-"memperbaikinya. Silakan <a "
-"href=\"https://github.com/mozilla/olympia/issues\">mengirimkan laporan "
-"bug</a> di GitHub, yang mencantumkan letak masalah dan bagaimana anda "
-"menemukannya."
 
-#: src/olympia/devhub/templates/devhub/docs/policies-maintenance.html:3
-#: src/olympia/devhub/templates/devhub/docs/policies-maintenance.html:7
+#: src/olympia/devhub/templates/devhub/docs/policies-maintenance.html:3 src/olympia/devhub/templates/devhub/docs/policies-maintenance.html:7
 #: src/olympia/devhub/templates/devhub/docs/policies-maintenance.html:8
 msgid "Maintaining Your Add-ons"
 msgstr "Menjaga Pengaya Anda"
@@ -6581,31 +5327,17 @@ msgstr "Mengirimkan Versi Baru Pengaya Anda"
 
 #: src/olympia/devhub/templates/devhub/docs/policies-maintenance.html:12
 msgid ""
-"Developers are encouraged to submit updates to their add-ons to fix bugs, "
-"add features, and otherwise improve their product. New versions of an add-on"
-" must have a <a "
-"href=\"https://developer.mozilla.org/en/Toolkit_version_format\">higher "
-"version number</a> and can be submitted through the Developer Tools "
-"provided. There is no limit to the number of versions that can be submitted,"
-" but please remember that versions must be reviewed by an editor."
+"Developers are encouraged to submit updates to their add-ons to fix bugs, add features, and otherwise improve their product. New versions of an add-on must have a <a href=\"https://developer."
+"mozilla.org/en/Toolkit_version_format\">higher version number</a> and can be submitted through the Developer Tools provided. There is no limit to the number of versions that can be submitted, but "
+"please remember that versions must be reviewed by an editor."
 msgstr ""
-"Pengembang didorong untuk mengirimkan pembaruan pengaya mereka untuk "
-"memperbaiki bug, menambah fitur, dan atau memperbaiki produk mereka. Versi "
-"baru pengaya tersebut harus memiliki <a "
-"href=\"https://developer.mozilla.org/en/Toolkit_version_format\">nomor versi"
-" yang lebih tinggi</a> dan bisa dikirimkan melalui Perangkat Pengembang yang"
-" tersedia. Tidak ada batasan untuk jumlah versi yang bisa dikirimkan, namun "
-"harap diingat bahwa versi tersebut harus diulas oleh seorang penyunting."
+"Pengembang didorong untuk mengirimkan pembaruan pengaya mereka untuk memperbaiki bug, menambah fitur, dan atau memperbaiki produk mereka. Versi baru pengaya tersebut harus memiliki <a href="
+"\"https://developer.mozilla.org/en/Toolkit_version_format\">nomor versi yang lebih tinggi</a> dan bisa dikirimkan melalui Perangkat Pengembang yang tersedia. Tidak ada batasan untuk jumlah versi "
+"yang bisa dikirimkan, namun harap diingat bahwa versi tersebut harus diulas oleh seorang penyunting."
 
 #: src/olympia/devhub/templates/devhub/docs/policies-maintenance.html:18
-msgid ""
-"New versions will be added to a pending review queue, and any additional "
-"versions submitted before the review is completed will move that version to "
-"the end of the queue."
-msgstr ""
-"Versi baru ini akan ditambahkan untuk antrean ulasan yang ditunda, dan versi"
-" tambahan lainnya yang dikirimkan sebelum ulasan selesai akan memindahkan "
-"versi tersebut ke ujung antrean."
+msgid "New versions will be added to a pending review queue, and any additional versions submitted before the review is completed will move that version to the end of the queue."
+msgstr "Versi baru ini akan ditambahkan untuk antrean ulasan yang ditunda, dan versi tambahan lainnya yang dikirimkan sebelum ulasan selesai akan memindahkan versi tersebut ke ujung antrean."
 
 #: src/olympia/devhub/templates/devhub/docs/policies-maintenance.html:23
 msgid "How do I submit a Beta add-on?"
@@ -6617,52 +5349,31 @@ msgstr "Saluran beta hanya tersedia bagi pengaya yang diulas secara lengkap."
 
 #: src/olympia/devhub/templates/devhub/docs/policies-maintenance.html:31
 msgid ""
-"To create a beta channel, upload a file with a unique version string that "
-"contains any of the following strings: <code>a,b,alpha,beta,pre,rc</code>, "
-"with an optional number at the end. This text must come at the end of the "
-"version string. If you understand regex format, here's what we look for in "
-"the version number: <code>\"(a|alpha|b|beta|pre|rc)\\d*$\"</code>."
+"To create a beta channel, upload a file with a unique version string that contains any of the following strings: <code>a,b,alpha,beta,pre,rc</code>, with an optional number at the end. This text "
+"must come at the end of the version string. If you understand regex format, here's what we look for in the version number: <code>\"(a|alpha|b|beta|pre|rc)\\d*$\"</code>."
 msgstr ""
-"Untuk membuat saluran beta, unggah berkas dengan rangkaian versi unik yang "
-"mengandung salah satu dari rangkaian berikut: "
-"<code>a,b,alpha,beta,pre,rc</code>, dengan nomor terpilih di bagian "
-"akhirnya. Teks ini harus berada di bagian akhir rangkaian. Jika anda "
-"memahami format regex, inilah yang kami inginkan dalam nomor versi: "
-"<code>\"(a|alpha|b|beta|pre|rc)\\d*$\"</code>."
+"Untuk membuat saluran beta, unggah berkas dengan rangkaian versi unik yang mengandung salah satu dari rangkaian berikut: <code>a,b,alpha,beta,pre,rc</code>, dengan nomor terpilih di bagian "
+"akhirnya. Teks ini harus berada di bagian akhir rangkaian. Jika anda memahami format regex, inilah yang kami inginkan dalam nomor versi: <code>\"(a|alpha|b|beta|pre|rc)\\d*$\"</code>."
 
 #: src/olympia/devhub/templates/devhub/docs/policies-maintenance.html:37
 msgid ""
-"Once a file meeting this criteria is uploaded to AMO, it will automatically "
-"be marked as a beta version. Users of add-ons with these unique version "
-"numbers will automatically be served the newest beta updates."
+"Once a file meeting this criteria is uploaded to AMO, it will automatically be marked as a beta version. Users of add-ons with these unique version numbers will automatically be served the newest "
+"beta updates."
 msgstr ""
-"Sekali sebuah berkas yang memenuhi kriteria ini diunggah ke AMO, berkas "
-"tersebut akan secara otomatis ditandai sebagai versi beta. Pengguna pengaya "
-"dengan versi nomor yang unik ini akan secara otomatis dilayani dengan "
-"pembaruan versi beta terbaru."
+"Sekali sebuah berkas yang memenuhi kriteria ini diunggah ke AMO, berkas tersebut akan secara otomatis ditandai sebagai versi beta. Pengguna pengaya dengan versi nomor yang unik ini akan secara "
+"otomatis dilayani dengan pembaruan versi beta terbaru."
 
 #: src/olympia/devhub/templates/devhub/docs/policies-maintenance.html:43
 msgid ""
-"While we call these \"Beta versions\", you can use this channel for "
-"nightlies, or alphas, or prerelease versions as you wish. Please note that "
-"there is only one channel for this purpose and all of your users on this "
-"channel will receive the latest add-ons submitted. For instance, if you "
-"upload <code>1.0beta1</code> to the release channel and then upload "
-"<code>1.1alpha1</code>, all users of <code>1.0beta1</code> will be offered "
-"an upgrade to <code>1.1alpha1</code>. Updates are pushed by submission date "
-"and not version number, so users will always get the most recent channel "
-"update regardless of any kind of alphabetical sorting."
+"While we call these \"Beta versions\", you can use this channel for nightlies, or alphas, or prerelease versions as you wish. Please note that there is only one channel for this purpose and all of "
+"your users on this channel will receive the latest add-ons submitted. For instance, if you upload <code>1.0beta1</code> to the release channel and then upload <code>1.1alpha1</code>, all users of "
+"<code>1.0beta1</code> will be offered an upgrade to <code>1.1alpha1</code>. Updates are pushed by submission date and not version number, so users will always get the most recent channel update "
+"regardless of any kind of alphabetical sorting."
 msgstr ""
-"Meski kami menyebutnya \"versi Beta\", anda bisa menggunakan saluran ini "
-"untuk nightly, atau alpha, atau versi pra-rilis sesuai keinginan. Harap "
-"dicatat bahwa hanya ada satu saluran untuk tujuan ini dan seluruh pengguna "
-"anda di saluran ini akan menerima pengaya terakhir yang dikirimkan. "
-"Contohnya, jika anda mengunggah <code>1.0beta1</code> ke saluran rilis dan "
-"mengunggah <code>1.1alpha1</code>, seluruh pengguna <code>1.0beta1</code> "
-"akan ditawari pembaruan pula <code>1.1alpha1</code>. Pembaruan didorong oleh"
-" tanggal pengiriman dan bukan nomor versi, jadi pengguna akan selalu "
-"mendapatkan pembaruan saluran terbaru terlepas dari pemisahan alfabetis "
-"apapun."
+"Meski kami menyebutnya \"versi Beta\", anda bisa menggunakan saluran ini untuk nightly, atau alpha, atau versi pra-rilis sesuai keinginan. Harap dicatat bahwa hanya ada satu saluran untuk tujuan "
+"ini dan seluruh pengguna anda di saluran ini akan menerima pengaya terakhir yang dikirimkan. Contohnya, jika anda mengunggah <code>1.0beta1</code> ke saluran rilis dan mengunggah <code>1.1alpha1</"
+"code>, seluruh pengguna <code>1.0beta1</code> akan ditawari pembaruan pula <code>1.1alpha1</code>. Pembaruan didorong oleh tanggal pengiriman dan bukan nomor versi, jadi pengguna akan selalu "
+"mendapatkan pembaruan saluran terbaru terlepas dari pemisahan alfabetis apapun."
 
 #: src/olympia/devhub/templates/devhub/docs/policies-maintenance.html:48
 msgid "Required Updates"
@@ -6670,21 +5381,13 @@ msgstr "Pembaruan yang Dibutuhkan"
 
 #: src/olympia/devhub/templates/devhub/docs/policies-maintenance.html:50
 msgid ""
-"Certain situations may arise in which Mozilla requests that an add-on "
-"developer update their add-on within a given time period to address a major "
-"security issue or policy violation. We work with developers to reasonably "
-"accommodate their own schedules, but if the issue is of a serious enough "
-"nature, add-ons that cannot issue an update with the requested fix may be "
-"demoted from fully-reviewed status, disabled, or permanently removed from "
-"the site."
+"Certain situations may arise in which Mozilla requests that an add-on developer update their add-on within a given time period to address a major security issue or policy violation. We work with "
+"developers to reasonably accommodate their own schedules, but if the issue is of a serious enough nature, add-ons that cannot issue an update with the requested fix may be demoted from fully-"
+"reviewed status, disabled, or permanently removed from the site."
 msgstr ""
-"Situasi tertentu dapat terjadi di mana Mozilla meminta seorang pengembang "
-"pengaya memperbarui pengaya mereka dalam waktu tertentu untuk menangani isu "
-"keamanan yang besar atau pelanggaran kebijakan. Kami bekerja bersama "
-"pengembang untuk secara rasional mengakomodasi jadwal mereka sendiri, namun "
-"jika isu tersebut serius, pengaya yang tidak dapat mengeluarkan pembaruan "
-"dengan perbaikan yang diminta akan dikeluarkan dari status diulas lengkap, "
-"dilumpuhkan atau secara permanen dihapus dari situs."
+"Situasi tertentu dapat terjadi di mana Mozilla meminta seorang pengembang pengaya memperbarui pengaya mereka dalam waktu tertentu untuk menangani isu keamanan yang besar atau pelanggaran kebijakan. "
+"Kami bekerja bersama pengembang untuk secara rasional mengakomodasi jadwal mereka sendiri, namun jika isu tersebut serius, pengaya yang tidak dapat mengeluarkan pembaruan dengan perbaikan yang "
+"diminta akan dikeluarkan dari status diulas lengkap, dilumpuhkan atau secara permanen dihapus dari situs."
 
 #: src/olympia/devhub/templates/devhub/docs/policies-maintenance.html:55
 msgid "Transfer of Ownership"
@@ -6692,64 +5395,41 @@ msgstr "Pemindahan Kepemilikan"
 
 #: src/olympia/devhub/templates/devhub/docs/policies-maintenance.html:57
 msgid ""
-"Add-ons can have multiple users with permission to update and manage the "
-"listing. Existing authors of an add-on can transfer ownership and add "
-"additional developers to an add-on's listing through the Developer Tools "
-"provided. No interaction with Mozilla representatives is necessary for a "
-"transfer of ownership."
+"Add-ons can have multiple users with permission to update and manage the listing. Existing authors of an add-on can transfer ownership and add additional developers to an add-on's listing through "
+"the Developer Tools provided. No interaction with Mozilla representatives is necessary for a transfer of ownership."
 msgstr ""
-"Pengaya dapat memiliki berbagai pengguna dengan izin untuk memperbarui dan "
-"mengelola daftar. Penulis pengaya yang sudah ada dapat mengalihkan "
-"kepemilikan dan menambahkan pengembang dalam daftar pengaya melalui "
-"Perangkat Pengembang yang disediakan. Tidak perlu ada interaksi dengan "
-"representatif Mozilla untuk pengalihan kepemilikan."
+"Pengaya dapat memiliki berbagai pengguna dengan izin untuk memperbarui dan mengelola daftar. Penulis pengaya yang sudah ada dapat mengalihkan kepemilikan dan menambahkan pengembang dalam daftar "
+"pengaya melalui Perangkat Pengembang yang disediakan. Tidak perlu ada interaksi dengan representatif Mozilla untuk pengalihan kepemilikan."
 
 #: src/olympia/devhub/templates/devhub/docs/policies-maintenance.html:63
 #, python-format
-msgid ""
-"Mozilla can assist with granting additional permissions of an add-on's "
-"listing if <a href=\"%(link_contact)s\">contacted</a> by the add-on's "
-"current owner."
-msgstr ""
-"Mozilla dapat membantu dengan memberikan izin tambahan dari daftar pengaya "
-"jika <a href=\"%(link_contact)s\">dihubungi</a> oleh pemilik pengaya saat "
-"ini."
+msgid "Mozilla can assist with granting additional permissions of an add-on's listing if <a href=\"%(link_contact)s\">contacted</a> by the add-on's current owner."
+msgstr "Mozilla dapat membantu dengan memberikan izin tambahan dari daftar pengaya jika <a href=\"%(link_contact)s\">dihubungi</a> oleh pemilik pengaya saat ini."
 
 #: src/olympia/devhub/templates/devhub/docs/policies-maintenance.html:70
 msgid ""
-"Mozilla encourages its users to offer feedback on their experiences when "
-"using an add-on. This allows other users to determine if the add-on is "
-"stable and useful. It also provides valuable feedback to developers, "
-"allowing them to continuously improve their add-on to meet user needs."
+"Mozilla encourages its users to offer feedback on their experiences when using an add-on. This allows other users to determine if the add-on is stable and useful. It also provides valuable feedback "
+"to developers, allowing them to continuously improve their add-on to meet user needs."
 msgstr ""
-"Mozilla mendorong penggunanya untuk memberikan umpan balik atas pengalaman "
-"mereka saat menggunakan pengaya. Hal ini memungkinkan pengguna lain untuk "
-"menentukan apakah pengaya mereka stabil dan berguna. Juga memberikan umpan "
-"balik yang berguna untuk pengembang, agar mereka dapat terus memperbaiki "
-"pengaya sesuai kebutuhan pengguna."
+"Mozilla mendorong penggunanya untuk memberikan umpan balik atas pengalaman mereka saat menggunakan pengaya. Hal ini memungkinkan pengguna lain untuk menentukan apakah pengaya mereka stabil dan "
+"berguna. Juga memberikan umpan balik yang berguna untuk pengembang, agar mereka dapat terus memperbaiki pengaya sesuai kebutuhan pengguna."
 
 #: src/olympia/devhub/templates/devhub/docs/policies-maintenance.html:76
 #, python-format
 msgid ""
-"Reviews must follow the <a href=\"%(link_guidelines)s\">review "
-"guidelines</a>. Reviews that do not meet these guidelines may be flagged for"
-" moderation, but negative reviews will not be removed unless they provide "
-"false information."
+"Reviews must follow the <a href=\"%(link_guidelines)s\">review guidelines</a>. Reviews that do not meet these guidelines may be flagged for moderation, but negative reviews will not be removed "
+"unless they provide false information."
 msgstr ""
-"Ulasan harus mengikuti <a href=\"%(link_guidelines)s\">petunjuk ulasan</a>. "
-"Ulasan yang tidak memenuhi panduan ini akan ditandai untuk moderasi, tapi "
-"ulasan negatif tidak akan dihapus kecuali mereka memberikan informasi palsu."
+"Ulasan harus mengikuti <a href=\"%(link_guidelines)s\">petunjuk ulasan</a>. Ulasan yang tidak memenuhi panduan ini akan ditandai untuk moderasi, tapi ulasan negatif tidak akan dihapus kecuali "
+"mereka memberikan informasi palsu."
 
 #: src/olympia/devhub/templates/devhub/docs/policies-maintenance.html:82
 msgid ""
-"Many developers provide a support mechanism, such as a forum, discussion "
-"group, or email address. It is recommended that support questions be posted "
-"via those mediums instead of in an add-on's review section."
+"Many developers provide a support mechanism, such as a forum, discussion group, or email address. It is recommended that support questions be posted via those mediums instead of in an add-on's "
+"review section."
 msgstr ""
-"Banyak pengembang yang menyediakan mekanisme dukungan, seperti forum, "
-"kelompok diskusi, atau alamat surel. Direkomendasikan agar pertanyaan "
-"dukungan itu dikirimkan melalui medium tersebut alih-alih bagian ulasan "
-"pengaya."
+"Banyak pengembang yang menyediakan mekanisme dukungan, seperti forum, kelompok diskusi, atau alamat surel. Direkomendasikan agar pertanyaan dukungan itu dikirimkan melalui medium tersebut alih-alih "
+"bagian ulasan pengaya."
 
 #: src/olympia/devhub/templates/devhub/docs/policies-maintenance.html:87
 msgid "Code Disputes"
@@ -6757,45 +5437,26 @@ msgstr "Sengketa Kode"
 
 #: src/olympia/devhub/templates/devhub/docs/policies-maintenance.html:90
 msgid ""
-"Many add-ons allow their source code to be openly viewed. This does not mean"
-" that the source code is open source or available for use in another add-on."
-" The original author of an add-on retains copyright of their work unless "
-"otherwise noted in the add-on's license."
+"Many add-ons allow their source code to be openly viewed. This does not mean that the source code is open source or available for use in another add-on. The original author of an add-on retains "
+"copyright of their work unless otherwise noted in the add-on's license."
 msgstr ""
-"Banyak pengaya yang memperbolehkan kode sumber mereka dilihat secara "
-"terbuka. Hal ini tidak berarti bahwa kode sumber itu bersifat open source "
-"atau tersedia untuk digunakan di pengaya lainnya. Penulis asli sebuah "
-"pengaya memiliki hak cipta karya mereka terkecuali dinyatakan dalam lisensi "
-"pengaya."
+"Banyak pengaya yang memperbolehkan kode sumber mereka dilihat secara terbuka. Hal ini tidak berarti bahwa kode sumber itu bersifat open source atau tersedia untuk digunakan di pengaya lainnya. "
+"Penulis asli sebuah pengaya memiliki hak cipta karya mereka terkecuali dinyatakan dalam lisensi pengaya."
 
 #: src/olympia/devhub/templates/devhub/docs/policies-maintenance.html:96
 msgid ""
-"In the event that we're notified of a copyright or license infringement, we "
-"will take steps to review the situation and determine if an actual "
-"infringement has occurred. If we determine that there is an infringement, we"
-" will remove the offending add-on and contact the author. New add-on "
-"submissions (including updates) containing infringing code will be denied "
-"approval for public status."
+"In the event that we're notified of a copyright or license infringement, we will take steps to review the situation and determine if an actual infringement has occurred. If we determine that there "
+"is an infringement, we will remove the offending add-on and contact the author. New add-on submissions (including updates) containing infringing code will be denied approval for public status."
 msgstr ""
-"Pada saat kami diberi tahu tentang pelanggaran hak cipta atau lisensi, kami "
-"akan mengambil langkah-langkah untuk meninjau situasi dan menentukan apakah "
-"pelanggaran yang sebenarnya telah terjadi. Jika kami menentukan bahwa ada "
-"pelanggaran, kami akan menghapus pengaya yang bermasalah dan menghubungi "
-"penulisnya. Pengiriman pengaya baru (termasuk pembaruan) yang mengandung "
-"pelanggaran kode akan ditolak persetujuannya untuk mendapat status publik."
+"Pada saat kami diberi tahu tentang pelanggaran hak cipta atau lisensi, kami akan mengambil langkah-langkah untuk meninjau situasi dan menentukan apakah pelanggaran yang sebenarnya telah terjadi. "
+"Jika kami menentukan bahwa ada pelanggaran, kami akan menghapus pengaya yang bermasalah dan menghubungi penulisnya. Pengiriman pengaya baru (termasuk pembaruan) yang mengandung pelanggaran kode "
+"akan ditolak persetujuannya untuk mendapat status publik."
 
 #: src/olympia/devhub/templates/devhub/docs/policies-maintenance.html:102
-msgid ""
-"If you are unsure of the current copyright status of an add-on's source "
-"code, you must contact the original author and receive explicit permission "
-"before using the source code."
-msgstr ""
-"Jika Anda tidak yakin tentang status hak cipta ssebuah kode sumber pengaya, "
-"Anda harus menghubungi penulis asli dan mendapatkan izin sebelum menggunakan"
-" kode sumber tersebut."
+msgid "If you are unsure of the current copyright status of an add-on's source code, you must contact the original author and receive explicit permission before using the source code."
+msgstr "Jika Anda tidak yakin tentang status hak cipta ssebuah kode sumber pengaya, Anda harus menghubungi penulis asli dan mendapatkan izin sebelum menggunakan kode sumber tersebut."
 
-#: src/olympia/devhub/templates/devhub/docs/policies-maintenance.html:107
-#: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:306
+#: src/olympia/devhub/templates/devhub/docs/policies-maintenance.html:107 src/olympia/devhub/templates/devhub/docs/policies-reviews.html:306
 #: src/olympia/devhub/templates/devhub/docs/policies-submission.html:97
 msgid "Last updated: January 13, 2011"
 msgstr "Terakhir diperbarui: 13 Januari 2011"
@@ -6803,55 +5464,34 @@ msgstr "Terakhir diperbarui: 13 Januari 2011"
 #: src/olympia/devhub/templates/devhub/docs/policies-recommended.html:13
 #, python-format
 msgid ""
-"Featured add-ons are top-quality extensions and themes highlighted on <a "
-"href=\"%(link_gallery)s\">AMO</a>, Firefox's Add-ons Manager, and across "
-"other Mozilla websites. These add-ons showcase the power of Firefox "
-"customization and are useful to a wide audience."
+"Featured add-ons are top-quality extensions and themes highlighted on <a href=\"%(link_gallery)s\">AMO</a>, Firefox's Add-ons Manager, and across other Mozilla websites. These add-ons showcase the "
+"power of Firefox customization and are useful to a wide audience."
 msgstr ""
-"Pengaya unggulan adalah ekstensi berkualitas tinggi dan tema yang disoroti "
-"di <a href=\"%(link_gallery)s\">AMO</a>, Pengelola Pengaya Firefox, dan di "
-"seluruh situs Mozilla lainnya. Pengaya ini menunjukkan kekuatan pengkhususan"
-" Firefox dan berguna untuk audiens yang luas."
+"Pengaya unggulan adalah ekstensi berkualitas tinggi dan tema yang disoroti di <a href=\"%(link_gallery)s\">AMO</a>, Pengelola Pengaya Firefox, dan di seluruh situs Mozilla lainnya. Pengaya ini "
+"menunjukkan kekuatan pengkhususan Firefox dan berguna untuk audiens yang luas."
 
 #: src/olympia/devhub/templates/devhub/docs/policies-recommended.html:19
 msgid ""
-"Featured add-ons are chosen by the Featured Add-ons Advisory Board, a small "
-"group of add-on developers and fans from the Mozilla community who have "
-"volunteered to review and vote on nominations."
+"Featured add-ons are chosen by the Featured Add-ons Advisory Board, a small group of add-on developers and fans from the Mozilla community who have volunteered to review and vote on nominations."
 msgstr ""
-"Pengaya unggulan dipilih oleh Dewan Penasihat Pengaya Unggulan, sekelompok "
-"kecil pengembang dan penggemar dari komunitas Mozilla yang secara sukarela "
-"meninjau dan memilih berdasarkan nominasi."
+"Pengaya unggulan dipilih oleh Dewan Penasihat Pengaya Unggulan, sekelompok kecil pengembang dan penggemar dari komunitas Mozilla yang secara sukarela meninjau dan memilih berdasarkan nominasi."
 
 #: src/olympia/devhub/templates/devhub/docs/policies-recommended.html:25
 #, python-format
-msgid ""
-"<a href=\"%(link_featured)s\">Featured extensions</a> are chosen every "
-"month, and <a href=\"%(link_themes)s\">featured complete themes</a> are "
-"chosen every quarter."
-msgstr ""
-"<a href=\"%(link_featured)s\">Ekstensi unggulan</a> dipilih setiap bulan, "
-"dan <a href=\"%(link_themes)s\">tema lengkap unggulan</a> dipilih setiap "
-"kuartal."
+msgid "<a href=\"%(link_featured)s\">Featured extensions</a> are chosen every month, and <a href=\"%(link_themes)s\">featured complete themes</a> are chosen every quarter."
+msgstr "<a href=\"%(link_featured)s\">Ekstensi unggulan</a> dipilih setiap bulan, dan <a href=\"%(link_themes)s\">tema lengkap unggulan</a> dipilih setiap kuartal."
 
 #: src/olympia/devhub/templates/devhub/docs/policies-recommended.html:30
 msgid "Criteria for Featured Add-ons"
 msgstr "Kriteria untuk Pengaya Unggulan"
 
 #: src/olympia/devhub/templates/devhub/docs/policies-recommended.html:33
-msgid ""
-"Before nominating an add-on to be featured, please ensure it meets the "
-"following criteria:"
-msgstr ""
-"Sebelum menominasikan pengaya untuk diunggulkan, harap memastikan pengaya "
-"tersebut memenuhi kriteria berikut:"
+msgid "Before nominating an add-on to be featured, please ensure it meets the following criteria:"
+msgstr "Sebelum menominasikan pengaya untuk diunggulkan, harap memastikan pengaya tersebut memenuhi kriteria berikut:"
 
 #: src/olympia/devhub/templates/devhub/docs/policies-recommended.html:39
-msgid ""
-"The add-on must have a complete and informative listing on AMO. This means:"
-msgstr ""
-"Pengaya harus memiliki daftar yang lengkap dan informatif di AMO. Ini "
-"berarti:"
+msgid "The add-on must have a complete and informative listing on AMO. This means:"
+msgstr "Pengaya harus memiliki daftar yang lengkap dan informatif di AMO. Ini berarti:"
 
 #: src/olympia/devhub/templates/devhub/docs/policies-recommended.html:41
 msgid "a 64-pixel custom icon"
@@ -6874,44 +5514,28 @@ msgid "updated screenshots of the add-on's functionality"
 msgstr "memperbarui tangkapan layar untuk fungsi pengaya"
 
 #: src/olympia/devhub/templates/devhub/docs/policies-recommended.html:46
-msgid ""
-"must be fully approved by AMO editors (no preliminarily reviewed entries)"
-msgstr ""
-"harus disetujui sepenuhnya oleh penyunting AMO (tidak ada entri yang "
-"ditinjau sebelumnya)"
+msgid "must be fully approved by AMO editors (no preliminarily reviewed entries)"
+msgstr "harus disetujui sepenuhnya oleh penyunting AMO (tidak ada entri yang ditinjau sebelumnya)"
 
 #: src/olympia/devhub/templates/devhub/docs/policies-recommended.html:48
-msgid ""
-"The add-on must have excellent user reviews and any problems or support "
-"requests must be promptly addressed by the developer."
-msgstr ""
-"Pengaya ini pasti memiliki ulasan pengguna yang sempurna dan jika ada "
-"masalah atau permintaan dukungan pasti segera ditindaklanjuti oleh "
-"pengembangnya."
+msgid "The add-on must have excellent user reviews and any problems or support requests must be promptly addressed by the developer."
+msgstr "Pengaya ini pasti memiliki ulasan pengguna yang sempurna dan jika ada masalah atau permintaan dukungan pasti segera ditindaklanjuti oleh pengembangnya."
 
 #: src/olympia/devhub/templates/devhub/docs/policies-recommended.html:49
 msgid "The add-on must have a minimum of 2,000 users."
 msgstr "Pengaya harus memiliki minimal 2000 pengguna."
 
 #: src/olympia/devhub/templates/devhub/docs/policies-recommended.html:50
-msgid ""
-"The add-on must be compatible with the latest release of Firefox and must be"
-" compatible with beta versions 4 weeks before their final release."
-msgstr ""
-"Pengaya harus kompatibel dengan rilis terakhir Firefox dan harus kompatibel "
-"dengan versi beta 4 minggu sebelum rilis finalnya."
+msgid "The add-on must be compatible with the latest release of Firefox and must be compatible with beta versions 4 weeks before their final release."
+msgstr "Pengaya harus kompatibel dengan rilis terakhir Firefox dan harus kompatibel dengan versi beta 4 minggu sebelum rilis finalnya."
 
 #: src/olympia/devhub/templates/devhub/docs/policies-recommended.html:51
 msgid ""
-"<strong>Most importantly</strong>, the add-on must have wide consumer appeal"
-" to Firefox's users and be outstanding in nearly every way: user experience,"
-" performance, security, and usefulness or entertainment value. Featured "
-"complete themes must also be visually appealing."
+"<strong>Most importantly</strong>, the add-on must have wide consumer appeal to Firefox's users and be outstanding in nearly every way: user experience, performance, security, and usefulness or "
+"entertainment value. Featured complete themes must also be visually appealing."
 msgstr ""
-"<strong>Yang terpenting</strong>, pengaya harus memiliki daya tarik luas "
-"bagi pengguna Firefox dan unggul di hampir semua hal: pengalaman pengguna, "
-"performa, keamanan dan nilai ketergunaan atau hiburan. Tema lengkap unggulan"
-" juga harus menarik secara visual."
+"<strong>Yang terpenting</strong>, pengaya harus memiliki daya tarik luas bagi pengguna Firefox dan unggul di hampir semua hal: pengalaman pengguna, performa, keamanan dan nilai ketergunaan atau "
+"hiburan. Tema lengkap unggulan juga harus menarik secara visual."
 
 #: src/olympia/devhub/templates/devhub/docs/policies-recommended.html:54
 msgid "Nominating an Add-on"
@@ -6923,266 +5547,162 @@ msgstr "amo-featured at mozilla dot org"
 
 #: src/olympia/devhub/templates/devhub/docs/policies-recommended.html:57
 #, python-format
-msgid ""
-"If you wish to nominate an add-on to be featured and it meets the criteria "
-"above, send an email to %(mail_featured)s with:"
-msgstr ""
-"Jika anda ingin menominasikan pengaya untuk diunggulkan dan pengaya tersebut"
-" sesuai dengan kriteria di atas, kirimkan surel ke %(mail_featured)s dengan:"
+msgid "If you wish to nominate an add-on to be featured and it meets the criteria above, send an email to %(mail_featured)s with:"
+msgstr "Jika anda ingin menominasikan pengaya untuk diunggulkan dan pengaya tersebut sesuai dengan kriteria di atas, kirimkan surel ke %(mail_featured)s dengan:"
 
 #: src/olympia/devhub/templates/devhub/docs/policies-recommended.html:62
 msgid "the add-on name, URL, and whether you are its developer"
 msgstr "nama pengaya, URLnya, dan apakah anda adalah pengembangnya"
 
 #: src/olympia/devhub/templates/devhub/docs/policies-recommended.html:63
-msgid ""
-"a short explanation of why the add-on has wide appeal and should be featured"
-msgstr ""
-"penjelasan pendek mengenai mengapa pengaya ini memiliki daya tarik yang luas"
-" dan harus diunggulkan"
+msgid "a short explanation of why the add-on has wide appeal and should be featured"
+msgstr "penjelasan pendek mengenai mengapa pengaya ini memiliki daya tarik yang luas dan harus diunggulkan"
 
 #: src/olympia/devhub/templates/devhub/docs/policies-recommended.html:64
-msgid ""
-"optionally, links to any external reviews or articles mentioning the add-on"
-msgstr ""
-"pilihan lainnya, tautkan ke ulasan eksternal atau artikel yang menyebutkan "
-"pengaya ini"
+msgid "optionally, links to any external reviews or articles mentioning the add-on"
+msgstr "pilihan lainnya, tautkan ke ulasan eksternal atau artikel yang menyebutkan pengaya ini"
 
 #: src/olympia/devhub/templates/devhub/docs/policies-recommended.html:68
 msgid ""
-"Add-on nominations are reviewed by the Advisory Board once a month (once "
-"every 3 months for complete theme nominations). Common reasons for rejection"
-" include lacking wide appeal to consumers, a suboptimal user experience, "
-"quality or security issues, incompatibility, and similarity to another "
-"featured add-on. Rejected add-ons cannot be re-nominated within 3 months."
+"Add-on nominations are reviewed by the Advisory Board once a month (once every 3 months for complete theme nominations). Common reasons for rejection include lacking wide appeal to consumers, a "
+"suboptimal user experience, quality or security issues, incompatibility, and similarity to another featured add-on. Rejected add-ons cannot be re-nominated within 3 months."
 msgstr ""
-"Nominasi pengaya ditinjau oleh Dewan Penasihat setiap bulan (sekali dalam 3 "
-"bulan untuk nominasi tema lengkap). Alasan umum penolakan diantaranya kurang"
-" menarik untuk pengguna, pengalaman pengguna yang kurang optimal, masalah "
-"keamanan atau mutu, ketidakcocokan, dan kemiripan dengan pengaya unggulan "
-"lainnya. Pengaya yang ditolak tidak dapat dinominasikan ulang dalam waktu 3 "
-"bulan."
+"Nominasi pengaya ditinjau oleh Dewan Penasihat setiap bulan (sekali dalam 3 bulan untuk nominasi tema lengkap). Alasan umum penolakan diantaranya kurang menarik untuk pengguna, pengalaman pengguna "
+"yang kurang optimal, masalah keamanan atau mutu, ketidakcocokan, dan kemiripan dengan pengaya unggulan lainnya. Pengaya yang ditolak tidak dapat dinominasikan ulang dalam waktu 3 bulan."
 
 #: src/olympia/devhub/templates/devhub/docs/policies-recommended.html:73
 msgid "Rotating Featured Add-ons"
 msgstr "Merotasi Pengaya Unggulan"
 
 #: src/olympia/devhub/templates/devhub/docs/policies-recommended.html:76
-msgid ""
-"Mozilla and the Featured Add-ons Advisory Board regularly evaluate and "
-"rotate out featured add-ons. Some of the most common reasons for add-ons "
-"being removed from the featured list are:"
-msgstr ""
-"Mozilla dan Dewan Penasihat Pengaya Unggulan secara teratur mengevaluasi dan"
-" menggilir pengaya unggulan. Sebagian dari alasan umum sebuah pengaya "
-"dikeluarkan dari daftar unggulan adalah:"
+msgid "Mozilla and the Featured Add-ons Advisory Board regularly evaluate and rotate out featured add-ons. Some of the most common reasons for add-ons being removed from the featured list are:"
+msgstr "Mozilla dan Dewan Penasihat Pengaya Unggulan secara teratur mengevaluasi dan menggilir pengaya unggulan. Sebagian dari alasan umum sebuah pengaya dikeluarkan dari daftar unggulan adalah:"
 
 #: src/olympia/devhub/templates/devhub/docs/policies-recommended.html:83
 msgid ""
-"Lack of growth &mdash; Add-ons that are featured typically experience a "
-"substantial gain in both downloads and active users. If an add-on is not "
-"demonstrating growth in any substantial way, that's a good indicator the "
-"add-on may not be very useful to our users."
+"Lack of growth &mdash; Add-ons that are featured typically experience a substantial gain in both downloads and active users. If an add-on is not demonstrating growth in any substantial way, that's "
+"a good indicator the add-on may not be very useful to our users."
 msgstr ""
-"Kurangnya pertumbuhan &mdash; Pengaya yang diunggulkan biasanya mengalami "
-"pertumbuhan yang substansial dalam pengunduhan dan pengguna aktif. Jika "
-"sebuah pengaya tidak menunjukkan pertumbuhan secara substansial, ini adalah "
-"penanda bahwa pengaya tersebut tidak terlalu bermanfaat bagi pengguna."
+"Kurangnya pertumbuhan &mdash; Pengaya yang diunggulkan biasanya mengalami pertumbuhan yang substansial dalam pengunduhan dan pengguna aktif. Jika sebuah pengaya tidak menunjukkan pertumbuhan secara "
+"substansial, ini adalah penanda bahwa pengaya tersebut tidak terlalu bermanfaat bagi pengguna."
 
 #: src/olympia/devhub/templates/devhub/docs/policies-recommended.html:88
-msgid ""
-"Negative reviews &mdash; Featured add-ons should have a great experience and"
-" very few bugs, so add-ons with many negative reviews may be reconsidered."
-msgstr ""
-"Ulasan negatif &mdash; Pengaya unggulan harus memberikan pengalaman yang "
-"baik dan hanya sedikit bug, jadi pengaya dengan banyak ulasan negatif akan "
-"pertimbangkan ulang."
+msgid "Negative reviews &mdash; Featured add-ons should have a great experience and very few bugs, so add-ons with many negative reviews may be reconsidered."
+msgstr "Ulasan negatif &mdash; Pengaya unggulan harus memberikan pengalaman yang baik dan hanya sedikit bug, jadi pengaya dengan banyak ulasan negatif akan pertimbangkan ulang."
 
 #: src/olympia/devhub/templates/devhub/docs/policies-recommended.html:93
 msgid ""
-"Incompatibility with upcoming Firefox versions &mdash; Featured add-ons are "
-"expected to be compatible with stable and beta versions of Firefox. Add-ons "
-"not yet compatible with a Beta version of Firefox four weeks before its "
-"expected release will lose their featured status."
+"Incompatibility with upcoming Firefox versions &mdash; Featured add-ons are expected to be compatible with stable and beta versions of Firefox. Add-ons not yet compatible with a Beta version of "
+"Firefox four weeks before its expected release will lose their featured status."
 msgstr ""
-"Ketidakcocokan dengan versi Firefox yang akan datang &mdash; Pengaya "
-"unggulan diharapkan cocok dengan versi beta dan stabil Firefox. Pengaya yang"
-" belum cocok dengan versi beta Firefox empat minggu sebelum rilisnya "
-"dijadwalkan akan kehilangan status unggulannya."
+"Ketidakcocokan dengan versi Firefox yang akan datang &mdash; Pengaya unggulan diharapkan cocok dengan versi beta dan stabil Firefox. Pengaya yang belum cocok dengan versi beta Firefox empat minggu "
+"sebelum rilisnya dijadwalkan akan kehilangan status unggulannya."
 
 #: src/olympia/devhub/templates/devhub/docs/policies-recommended.html:99
 msgid "Joining the Featured Add-ons Advisory Board"
 msgstr "Bergabung dengan Badan Penasihat Pengaya Unggulan"
 
 #: src/olympia/devhub/templates/devhub/docs/policies-recommended.html:102
-msgid ""
-"Every six months a new Advisory Board is chosen based on applications from "
-"the add-ons community. Members must:"
-msgstr ""
-"Setiap enam bulan sebuah Badan Penasihat dipilih berdasarkan aplikasi dari "
-"komunitas pengaya. Anggota harus:"
+msgid "Every six months a new Advisory Board is chosen based on applications from the add-ons community. Members must:"
+msgstr "Setiap enam bulan sebuah Badan Penasihat dipilih berdasarkan aplikasi dari komunitas pengaya. Anggota harus:"
 
 #: src/olympia/devhub/templates/devhub/docs/policies-recommended.html:108
-msgid ""
-"be active members of the add-ons community, whether as a developer, "
-"evangelist, or fan"
-msgstr ""
-"jadilah anggota komunitas pengaya yang aktif, baik sebagai pengembang, "
-"penggerak, atau penggemar"
+msgid "be active members of the add-ons community, whether as a developer, evangelist, or fan"
+msgstr "jadilah anggota komunitas pengaya yang aktif, baik sebagai pengembang, penggerak, atau penggemar"
 
 #: src/olympia/devhub/templates/devhub/docs/policies-recommended.html:109
-msgid ""
-"commit to trying all the nominations submitted, giving their feedback, and "
-"casting their votes every month"
-msgstr ""
-"berkomitmen untuk mencoba semua nominasi yang diserahkan, memberikan umpan "
-"balik mereka, dan memberikan suara mereka setiap bulan"
+msgid "commit to trying all the nominations submitted, giving their feedback, and casting their votes every month"
+msgstr "berkomitmen untuk mencoba semua nominasi yang diserahkan, memberikan umpan balik mereka, dan memberikan suara mereka setiap bulan"
 
 #: src/olympia/devhub/templates/devhub/docs/policies-recommended.html:110
-msgid ""
-"abstain from voting on add-ons that they have any business or personal "
-"affiliations with, as well as direct competitors of any such add-ons"
-msgstr ""
-"menjauhkan diri dari pemungutan suara untuk pengaya di mana mereka memiliki "
-"ikatan bisnis atau pribadi, serta pesaing langsung pengaya bersangkutan"
+msgid "abstain from voting on add-ons that they have any business or personal affiliations with, as well as direct competitors of any such add-ons"
+msgstr "menjauhkan diri dari pemungutan suara untuk pengaya di mana mereka memiliki ikatan bisnis atau pribadi, serta pesaing langsung pengaya bersangkutan"
 
 #: src/olympia/devhub/templates/devhub/docs/policies-recommended.html:114
 msgid ""
-"Members of the Mozilla Add-ons team may veto any add-on's selection because "
-"of security, privacy, compatibility, or any other reason, but in general it "
-"is up to the Board to select add-ons to feature."
+"Members of the Mozilla Add-ons team may veto any add-on's selection because of security, privacy, compatibility, or any other reason, but in general it is up to the Board to select add-ons to "
+"feature."
 msgstr ""
-"Anggota tim Pengaya Mozilla dapat memveto pilihan pengaya apapun karena "
-"alasan keamanan, privasi, kecocokan dan lain sebagainya, namun secara umum, "
-"ini adalah keputusan Badan untuk memilih pengaya unggulan."
+"Anggota tim Pengaya Mozilla dapat memveto pilihan pengaya apapun karena alasan keamanan, privasi, kecocokan dan lain sebagainya, namun secara umum, ini adalah keputusan Badan untuk memilih pengaya "
+"unggulan."
 
 #: src/olympia/devhub/templates/devhub/docs/policies-recommended.html:120
 msgid ""
-"This featured policy only applies to the addons.mozilla.org global list of "
-"featured add-ons. Add-ons featured in other locations are often pulled from "
-"this list, but Mozilla may feature any add-on in other locations without the"
-" Board's consent. Additionally, locale-specific features override the global"
-" defaults, so if a locale has opted to select its own features, some or all "
-"of the global features may not appear in that locale."
+"This featured policy only applies to the addons.mozilla.org global list of featured add-ons. Add-ons featured in other locations are often pulled from this list, but Mozilla may feature any add-on "
+"in other locations without the Board's consent. Additionally, locale-specific features override the global defaults, so if a locale has opted to select its own features, some or all of the global "
+"features may not appear in that locale."
 msgstr ""
-"Kebijakan pengaya unggulan ini hanya berlaku untuk pengaya unggulan di "
-"daftar global addons.mozilla.org. Pengaya yang diunggulkan di lokasi lainnya"
-" seringkali diambil dari daftar ini, namun Mozilla dapat mengunggulkan "
-"pengaya apa pun di lokasi lainya tanpa persetujuan Badan. Sebagai tambahan, "
-"pengaya dengan fitur pelokalan tertentu mengesampingkan ketetapan global, "
-"jadi jika sebuah pelokalan telah memilih fitur-fiturnya, sebagian atau "
-"keseluruhan dari fitur global boleh jadi tidak muncul di pelokalan tersebut."
+"Kebijakan pengaya unggulan ini hanya berlaku untuk pengaya unggulan di daftar global addons.mozilla.org. Pengaya yang diunggulkan di lokasi lainnya seringkali diambil dari daftar ini, namun Mozilla "
+"dapat mengunggulkan pengaya apa pun di lokasi lainya tanpa persetujuan Badan. Sebagai tambahan, pengaya dengan fitur pelokalan tertentu mengesampingkan ketetapan global, jadi jika sebuah pelokalan "
+"telah memilih fitur-fiturnya, sebagian atau keseluruhan dari fitur global boleh jadi tidak muncul di pelokalan tersebut."
 
 #: src/olympia/devhub/templates/devhub/docs/policies-recommended.html:126
 #, python-format
-msgid ""
-"Follow the <a href=\"%(link_blog)s\">Add-ons Blog</a> or <a "
-"href=\"%(link_twitter)s\">@mozamo</a> on Twitter to learn when the next "
-"application period opens."
-msgstr ""
-"Ikuti <a href=\"%(link_blog)s\">Blog Pengaya</a> atau <a "
-"href=\"%(link_twitter)s\">@mozamo</a> di Twitter untuk mengetahui kapan "
-"periode aplikasi berikutnya dibuka."
+msgid "Follow the <a href=\"%(link_blog)s\">Add-ons Blog</a> or <a href=\"%(link_twitter)s\">@mozamo</a> on Twitter to learn when the next application period opens."
+msgstr "Ikuti <a href=\"%(link_blog)s\">Blog Pengaya</a> atau <a href=\"%(link_twitter)s\">@mozamo</a> di Twitter untuk mengetahui kapan periode aplikasi berikutnya dibuka."
 
 #: src/olympia/devhub/templates/devhub/docs/policies-recommended.html:131
 msgid "Last updated: January 31, 2013"
 msgstr "Terakhir diperbarui: Januari 31, 2013"
 
-#: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:3
-#: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:7
-#: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:8
-#: src/olympia/devhub/templates/devhub/docs/policies.html:15
-#: src/olympia/devhub/templates/devhub/docs/policies.html:64
+#: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:3 src/olympia/devhub/templates/devhub/docs/policies-reviews.html:7 src/olympia/devhub/templates/devhub/docs/policies-reviews.html:8
+#: src/olympia/devhub/templates/devhub/docs/policies.html:15 src/olympia/devhub/templates/devhub/docs/policies.html:64
 msgid "Review Process"
 msgstr "Proses Pemeriksaan"
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:12
 msgid ""
-"In order to ensure all add-ons hosted in our gallery are safe for users to "
-"install, Mozilla will begin requiring all hosted add-ons to undergo review. "
-"We offer two types of review and developers are free to choose the best fit "
-"for their add-on."
+"In order to ensure all add-ons hosted in our gallery are safe for users to install, Mozilla will begin requiring all hosted add-ons to undergo review. We offer two types of review and developers "
+"are free to choose the best fit for their add-on."
 msgstr ""
-"Dengan maksud untuk memastikan semua pengaya yang dimuat di galeri kami aman"
-" untuk dipasang pengguna, Mozilla akan mulai meminta semua pengaya yang "
-"dimuat untuk melewati peninjauan. Kami menawarkan dua tipe tinjauan dan "
-"pengaya bebas memilih yang paling tepat untuk pengaya mereka."
+"Dengan maksud untuk memastikan semua pengaya yang dimuat di galeri kami aman untuk dipasang pengguna, Mozilla akan mulai meminta semua pengaya yang dimuat untuk melewati peninjauan. Kami menawarkan "
+"dua tipe tinjauan dan pengaya bebas memilih yang paling tepat untuk pengaya mereka."
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:19
 msgid ""
-"<strong><a href=\"#full\">Full Review</a></strong> &mdash; a thorough "
-"functional and code review of the add-on, appropriate for add-ons ready for "
-"distribution to the masses. All site features are available to these add-"
-"ons."
+"<strong><a href=\"#full\">Full Review</a></strong> &mdash; a thorough functional and code review of the add-on, appropriate for add-ons ready for distribution to the masses. All site features are "
+"available to these add-ons."
 msgstr ""
-"<strong><a href=\"#full\">Ulasan Lengkap</a></strong> &mdash; tinjauan "
-"menyeluruh akan kode dan fungsi pengaya, tepat untuk pengaya yang siap "
-"didistribusikan secara luas. Seluruh fitur situs akan tersedia untuk pengaya"
-" ini."
+"<strong><a href=\"#full\">Ulasan Lengkap</a></strong> &mdash; tinjauan menyeluruh akan kode dan fungsi pengaya, tepat untuk pengaya yang siap didistribusikan secara luas. Seluruh fitur situs akan "
+"tersedia untuk pengaya ini."
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:24
 msgid ""
-"<strong><a href=\"#preliminary\">Preliminary Review</a></strong> &mdash; a "
-"faster review intended for experimental add-ons. Preliminary reviews do not "
-"check for functionality or full policy compliance, but the reviewed add-ons "
-"have install button cautions and some feature limitations."
+"<strong><a href=\"#preliminary\">Preliminary Review</a></strong> &mdash; a faster review intended for experimental add-ons. Preliminary reviews do not check for functionality or full policy "
+"compliance, but the reviewed add-ons have install button cautions and some feature limitations."
 msgstr ""
-"<strong><a href=\"#preliminary\">Ulasan Pendahuluan</a></strong> &mdash; "
-"ulasan lebih cepat yang ditujukan untuk pengaya eksperimental. Ulasan "
-"pendahuluan tidak memeriksa fungsi atau penyesuaian kebijakan sepenuhnya, "
-"namun pengaya yang diulas memiliki tombol peringatan untuk pemasangan dan "
-"sejumlah keterbatasan fitur."
+"<strong><a href=\"#preliminary\">Ulasan Pendahuluan</a></strong> &mdash; ulasan lebih cepat yang ditujukan untuk pengaya eksperimental. Ulasan pendahuluan tidak memeriksa fungsi atau penyesuaian "
+"kebijakan sepenuhnya, namun pengaya yang diulas memiliki tombol peringatan untuk pemasangan dan sejumlah keterbatasan fitur."
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:31
 msgid ""
-"Detailed descriptions of each option are below. After selecting a review "
-"process at submission, the add-on will be placed in the queue. Add-ons are "
-"reviewed by the <a href=\"https://wiki.mozilla.org/AMO:Editors\">AMO "
-"Editors</a>, a group of talented developers that volunteer to help the "
-"Mozilla project by reviewing add-ons to ensure a stable and safe experience "
-"for users. Developers will receive an email with any updates throughout the "
-"review process."
+"Detailed descriptions of each option are below. After selecting a review process at submission, the add-on will be placed in the queue. Add-ons are reviewed by the <a href=\"https://wiki.mozilla."
+"org/AMO:Editors\">AMO Editors</a>, a group of talented developers that volunteer to help the Mozilla project by reviewing add-ons to ensure a stable and safe experience for users. Developers will "
+"receive an email with any updates throughout the review process."
 msgstr ""
-"Deksripsi lengkap tiap pilihan ada di bawah ini. Setelah memilih proses "
-"pengulasan saat pendaftaran, pengaya akan ditempatkan dalam antrean. Pengaya"
-" akan diulas oleh <a href=\"https://wiki.mozilla.org/AMO:Editors\">AMO "
-"Editors</a>, sekelompok pengembang berbakat yang dengan sukarela membantu "
-"proyek Mozilla dengan mengulas pengaya untuk memastikan pengalaman yang "
-"stabil dan aman untuk pengguna. Pengembang akan menerima surel dengan "
-"pembaruan apapun selama proses peninjauan."
+"Deksripsi lengkap tiap pilihan ada di bawah ini. Setelah memilih proses pengulasan saat pendaftaran, pengaya akan ditempatkan dalam antrean. Pengaya akan diulas oleh <a href=\"https://wiki.mozilla."
+"org/AMO:Editors\">AMO Editors</a>, sekelompok pengembang berbakat yang dengan sukarela membantu proyek Mozilla dengan mengulas pengaya untuk memastikan pengalaman yang stabil dan aman untuk "
+"pengguna. Pengembang akan menerima surel dengan pembaruan apapun selama proses peninjauan."
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:37
 msgid ""
-"While waiting for review, add-ons will not appear anywhere in the gallery "
-"publicly, but direct links to the add-on's details page will work. This "
-"allows the author to blog or share the link with friends, inviting them to "
-"try it out, even when not yet reviewed."
+"While waiting for review, add-ons will not appear anywhere in the gallery publicly, but direct links to the add-on's details page will work. This allows the author to blog or share the link with "
+"friends, inviting them to try it out, even when not yet reviewed."
 msgstr ""
-"Saat menunggu ulasan, pengaya tidak akan muncul di manapun di galeri secara "
-"publik, namun tautan langsung pada laman rincian pengaya akan bekerja. Ini "
-"memungkinkan penulis untuk memasang di blog atau membagi tautannya dengan "
-"teman, mengundang mereka untuk mencobanya, bahkan saat belum diulas."
+"Saat menunggu ulasan, pengaya tidak akan muncul di manapun di galeri secara publik, namun tautan langsung pada laman rincian pengaya akan bekerja. Ini memungkinkan penulis untuk memasang di blog "
+"atau membagi tautannya dengan teman, mengundang mereka untuk mencobanya, bahkan saat belum diulas."
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:44
 msgid ""
-"Full reviews are appropriate for add-ons that are well-tested, stable, fast,"
-" and have wide appeal to our users. If you aren't confident that your add-on"
-" meets that criteria, please consider working out the kinks while in "
-"preliminary review and accumulating user feedback first."
+"Full reviews are appropriate for add-ons that are well-tested, stable, fast, and have wide appeal to our users. If you aren't confident that your add-on meets that criteria, please consider working "
+"out the kinks while in preliminary review and accumulating user feedback first."
 msgstr ""
-"Ulasan lengkap sesuai untuk pengaya yang teruji, stabil, cepat dan memiliki "
-"daya tarik untuk pengguna kami. Jika anda tidak yakin bahwa pengaya anda "
-"memenuhi kriteria tersebut, harap mempertimbangkan memperbaiki kekusutan "
-"tersebut saat masih berada dalam ulasan pendahuluan dan mengumpulkan umpan "
-"balik pengguna terlebih dahulu."
+"Ulasan lengkap sesuai untuk pengaya yang teruji, stabil, cepat dan memiliki daya tarik untuk pengguna kami. Jika anda tidak yakin bahwa pengaya anda memenuhi kriteria tersebut, harap "
+"mempertimbangkan memperbaiki kekusutan tersebut saat masih berada dalam ulasan pendahuluan dan mengumpulkan umpan balik pengguna terlebih dahulu."
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:50
-msgid ""
-"We aim to perform full reviews in under 10 days, though most add-ons are "
-"reviewed in much less time."
-msgstr ""
-"Kami berupaya untuk melakukan tinjauan penuh kurang dari 10 hari, meskipun "
-"sebagian besar pengaya diulas dalam waktu yang lebih singkat."
+msgid "We aim to perform full reviews in under 10 days, though most add-ons are reviewed in much less time."
+msgstr "Kami berupaya untuk melakukan tinjauan penuh kurang dari 10 hari, meskipun sebagian besar pengaya diulas dalam waktu yang lebih singkat."
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:55
 msgid "Testing Methods &amp; Common Issues"
@@ -7193,59 +5713,36 @@ msgid "When performing a full review, editors will:"
 msgstr "Saat melakukan tinjauan lengkap, penyunting akan:"
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:64
-msgid ""
-"install the add-on, making sure it functions as described and is free of "
-"major defects"
-msgstr ""
-"memasang pengaya, memastikannya berfungsi sebagaimana dijelaskan dan bebas "
-"dari kekurangan yang besar"
+msgid "install the add-on, making sure it functions as described and is free of major defects"
+msgstr "memasang pengaya, memastikannya berfungsi sebagaimana dijelaskan dan bebas dari kekurangan yang besar"
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:69
-msgid ""
-"perform a source code review, looking for performance and security best "
-"practices"
-msgstr ""
-"melakukan peninjauan kode sumber, mencari praktik terbaik performa dan "
-"keamanan"
+msgid "perform a source code review, looking for performance and security best practices"
+msgstr "melakukan peninjauan kode sumber, mencari praktik terbaik performa dan keamanan"
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:74
 msgid "ensure the add-on's privacy policy is in line with its functionality"
 msgstr "memastikan kebijakan privasi pengaya sejalan dengan fungsinya"
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:79
-msgid ""
-"look for compliance with all of Mozilla's policies, detailed in these "
-"documents"
-msgstr ""
-"memastikan kepatuhan terhadap semua kebijakan Mozilla, dirinci dalam dokumen"
-" ini"
+msgid "look for compliance with all of Mozilla's policies, detailed in these documents"
+msgstr "memastikan kepatuhan terhadap semua kebijakan Mozilla, dirinci dalam dokumen ini"
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:86
-msgid ""
-"Some of the most common issues we see when performing these reviews are:"
-msgstr ""
-"Beberapa masalah paling umum kami jumpai saat melakukan tinjauan ini adalah:"
+msgid "Some of the most common issues we see when performing these reviews are:"
+msgstr "Beberapa masalah paling umum kami jumpai saat melakukan tinjauan ini adalah:"
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:93
 msgid ""
-"<strong>JavaScript namespace pollution</strong> &mdash; the most common "
-"violation. Be sure to <a "
-"href=\"https://developer.mozilla.org/en/XUL_School/JavaScript_Object_Management\">wrap"
-" your loose variables</a>"
+"<strong>JavaScript namespace pollution</strong> &mdash; the most common violation. Be sure to <a href=\"https://developer.mozilla.org/en/XUL_School/JavaScript_Object_Management\">wrap your loose "
+"variables</a>"
 msgstr ""
-"<strong>JavaScript polusi nama</strong> &mdash; pelanggaran paling umum. "
-"Pastikan untuk <a "
-"href=\"https://developer.mozilla.org/en/XUL_School/JavaScript_Object_Management\">membungkus"
-" variabel yang longgar</a>"
+"<strong>JavaScript polusi nama</strong> &mdash; pelanggaran paling umum. Pastikan untuk <a href=\"https://developer.mozilla.org/en/XUL_School/JavaScript_Object_Management\">membungkus variabel yang "
+"longgar</a>"
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:99
-msgid ""
-"proper preference naming - all preference names should begin with "
-"\"extensions.\", followed by the add-on name or some other unique identifier"
-msgstr ""
-"penamaan yang tepat - semua nama yang dipilih harus diawali dengan "
-"\"ekstensi.\", dilanjutkan dengan nama pengaya atau beberapa pengenal unik "
-"lainnya"
+msgid "proper preference naming - all preference names should begin with \"extensions.\", followed by the add-on name or some other unique identifier"
+msgstr "penamaan yang tepat - semua nama yang dipilih harus diawali dengan \"ekstensi.\", dilanjutkan dengan nama pengaya atau beberapa pengenal unik lainnya"
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:103
 msgid "remote JavaScript execution or injection"
@@ -7290,100 +5787,65 @@ msgstr "penurunan performa memulai aplikasi atau memuat laman"
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:117
 #, python-format
 msgid ""
-"For information on how to avoid these problems, please see our <a "
-"href=\"%(link_howto)s\">How-to Library</a>. Some of these practices, such as"
-" binary or obfuscated code, are allowed under certain conditions outlined "
-"below."
+"For information on how to avoid these problems, please see our <a href=\"%(link_howto)s\">How-to Library</a>. Some of these practices, such as binary or obfuscated code, are allowed under certain "
+"conditions outlined below."
 msgstr ""
-"Untuk keterangan mengenai bagaimana menghindari masalah ini, silakan lihat "
-"<a href=\"%(link_howto)s\">Pustaka Panduan</a>. Beberapa praktek ini, "
-"misalnya kode atau biner yang dikaburkan, diperkenankan dalam kondisi "
-"tertentu yang diuraikan di bawah ini."
+"Untuk keterangan mengenai bagaimana menghindari masalah ini, silakan lihat <a href=\"%(link_howto)s\">Pustaka Panduan</a>. Beberapa praktek ini, misalnya kode atau biner yang dikaburkan, "
+"diperkenankan dalam kondisi tertentu yang diuraikan di bawah ini."
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:123
 #, python-format
 msgid ""
-"Many of the above restrictions are tested automatically by an extension "
-"scanner that will flag suspicious add-ons for editor review. You can read "
-"more about this scanner in the <a href=\"%(link_validation)s\">Validation "
-"Help</a> document."
+"Many of the above restrictions are tested automatically by an extension scanner that will flag suspicious add-ons for editor review. You can read more about this scanner in the <a href="
+"\"%(link_validation)s\">Validation Help</a> document."
 msgstr ""
-"Sebagian besar dari pembatasan di atas diuji secara otomatis oleh pemindai "
-"ekstensi yang akan menandai pengaya yang mencurigakan untuk diulas "
-"penyunting. Anda bisa membaca mengenai pemindai ini di dokumen <a "
-"href=\"%(link_validation)s\">Bantuan Validasi</a> ."
+"Sebagian besar dari pembatasan di atas diuji secara otomatis oleh pemindai ekstensi yang akan menandai pengaya yang mencurigakan untuk diulas penyunting. Anda bisa membaca mengenai pemindai ini di "
+"dokumen <a href=\"%(link_validation)s\">Bantuan Validasi</a> ."
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:129
 msgid ""
-"If the add-on is site-specific, it is recommended that a test account is "
-"provided for use during the review process. Additionally, including detailed"
-" testing instructions will allow an editor to better understand how the add-"
-"on functions and expedite the testing process. This information can be "
-"placed in the Notes to Reviewer field when editing a version in the "
-"Developer Hub."
+"If the add-on is site-specific, it is recommended that a test account is provided for use during the review process. Additionally, including detailed testing instructions will allow an editor to "
+"better understand how the add-on functions and expedite the testing process. This information can be placed in the Notes to Reviewer field when editing a version in the Developer Hub."
 msgstr ""
-"Jika pengaya ini bersifat spesifik untuk situs, telah direkomendasikan bahwa"
-" akun pengujian disediakan untuk digunakan dalam proses ulasan. Selain itu, "
-"instruksi pengujian yang rinci disertakan dan akan memungkinkan penyunting "
-"untuk memahami lebih baik bagaimana pengaya berfungsi dan mempercepat proses"
-" pengujian. Informasi ini akan ditempatkan dalam Catatan untuk Pengulas saat"
-" sebuah versi disunting dalam Pusat Pengembang."
+"Jika pengaya ini bersifat spesifik untuk situs, telah direkomendasikan bahwa akun pengujian disediakan untuk digunakan dalam proses ulasan. Selain itu, instruksi pengujian yang rinci disertakan dan "
+"akan memungkinkan penyunting untuk memahami lebih baik bagaimana pengaya berfungsi dan mempercepat proses pengujian. Informasi ini akan ditempatkan dalam Catatan untuk Pengulas saat sebuah versi "
+"disunting dalam Pusat Pengembang."
 
-#: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:134
-#: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:168
+#: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:134 src/olympia/devhub/templates/devhub/docs/policies-reviews.html:168
 msgid "After the Review"
 msgstr "Setelah Peninjauan"
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:136
 msgid ""
-"Once an add-on is granted full review, it will immediately be available in "
-"the gallery, showing in browse and search results with a warning-free "
-"install button. All features, including voluntary contributions and beta "
-"channels will be available."
+"Once an add-on is granted full review, it will immediately be available in the gallery, showing in browse and search results with a warning-free install button. All features, including voluntary "
+"contributions and beta channels will be available."
 msgstr ""
-"Setelah sebuah pengaya diberi ulasan lengkap, ia akan segera tersedia di "
-"galeri, ditampilkan dalam hasil pencarian dan penelusuran dengan tombol "
-"pemasangan bebas peringatan. Seluruh fitur, termasuk kontribusi sukarela dan"
-" saluran bera akan tersedia."
+"Setelah sebuah pengaya diberi ulasan lengkap, ia akan segera tersedia di galeri, ditampilkan dalam hasil pencarian dan penelusuran dengan tombol pemasangan bebas peringatan. Seluruh fitur, termasuk "
+"kontribusi sukarela dan saluran bera akan tersedia."
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:142
 msgid ""
-"Subsequent versions of the add-on will automatically be placed in the full "
-"review queue. Until the review is completed, the new version will only be "
-"displayed on the Version History page of the add-on. Once reviewed, the "
-"version will be updated across the site and deployed through the automatic "
-"update service."
+"Subsequent versions of the add-on will automatically be placed in the full review queue. Until the review is completed, the new version will only be displayed on the Version History page of the add-"
+"on. Once reviewed, the version will be updated across the site and deployed through the automatic update service."
 msgstr ""
-"Versi berikutnya pengaya akan ditempatkan secara otomatis dalam antrean "
-"ulasan penuh. Sampai saat peninjauan diselesaikan, versi baru hanya akan "
-"ditampilkan dalam laman Riwayat Versi pengaya. Setelah ditinjau, versi "
-"tersebut akan diperbarui di seluruh situs dan disebarkan melalui layanan "
-"pembaruan otomatis."
+"Versi berikutnya pengaya akan ditempatkan secara otomatis dalam antrean ulasan penuh. Sampai saat peninjauan diselesaikan, versi baru hanya akan ditampilkan dalam laman Riwayat Versi pengaya. "
+"Setelah ditinjau, versi tersebut akan diperbarui di seluruh situs dan disebarkan melalui layanan pembaruan otomatis."
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:148
 msgid ""
-"If a version does not meet the criteria for full review, it can either be "
-"granted preliminary review or disabled if there is a security concern. The "
-"author will receive an email explaining the action taken and how to fix it. "
-"In most cases, the developer can simply fix the problem and re-submit for "
-"full review."
+"If a version does not meet the criteria for full review, it can either be granted preliminary review or disabled if there is a security concern. The author will receive an email explaining the "
+"action taken and how to fix it. In most cases, the developer can simply fix the problem and re-submit for full review."
 msgstr ""
-"Jika sebuah versi tidak memenuhi kriteria untuk ulasan lengkap, dapat "
-"diberikan tinjauan pendahuluan atau dimatikan jika ada kekhawatiran "
-"keamanan. Penulis akan menerima surel yang menjelaskan tindakan yang diambil"
-" dan bagaimana cara memperbaikinya. Dalam kebanyakan kasus, pengembang dapat"
-" memperbaiki masalahnya dan memasukkan kembali untuk diulas lengkap."
+"Jika sebuah versi tidak memenuhi kriteria untuk ulasan lengkap, dapat diberikan tinjauan pendahuluan atau dimatikan jika ada kekhawatiran keamanan. Penulis akan menerima surel yang menjelaskan "
+"tindakan yang diambil dan bagaimana cara memperbaikinya. Dalam kebanyakan kasus, pengembang dapat memperbaiki masalahnya dan memasukkan kembali untuk diulas lengkap."
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:155
 msgid ""
-"Preliminary reviews are appropriate for experimental add-ons and provide a "
-"way to get user testing and feedback without going through the longer, more "
-"thorough review process. We aim to complete these reviews in under 3 days."
+"Preliminary reviews are appropriate for experimental add-ons and provide a way to get user testing and feedback without going through the longer, more thorough review process. We aim to complete "
+"these reviews in under 3 days."
 msgstr ""
-"Peninjauan pendahuluan sesuai untuk pengaya yang lebih eksperimental dan "
-"menyediakan cara bagi pengguna untuk mendapatkan pengujian pengguna dan "
-"umpan balik tanpa melalui proses peninjauan yang panjang dan menyeluruh. "
-"Kami bermaksud untuk melengkapi tinjauan ini dalam waktu kurang dari 3 hari."
+"Peninjauan pendahuluan sesuai untuk pengaya yang lebih eksperimental dan menyediakan cara bagi pengguna untuk mendapatkan pengujian pengguna dan umpan balik tanpa melalui proses peninjauan yang "
+"panjang dan menyeluruh. Kami bermaksud untuk melengkapi tinjauan ini dalam waktu kurang dari 3 hari."
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:160
 msgid "Testing Methods"
@@ -7391,56 +5853,33 @@ msgstr "Metode Pengujian"
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:162
 msgid ""
-"When performing a preliminary review, editors will review the source code "
-"for security issues and major policy violations, but will not install the "
-"add-on to test functionality in most cases. Preliminary review will be "
-"granted unless a security vulnerability or major policy violation is "
-"discovered."
+"When performing a preliminary review, editors will review the source code for security issues and major policy violations, but will not install the add-on to test functionality in most cases. "
+"Preliminary review will be granted unless a security vulnerability or major policy violation is discovered."
 msgstr ""
-"Saat melakukan tinjauan pendahuluan, penyunting akan mengulas koe sumber "
-"untuk isu keamanan dan pelanggaran kebijakan yang besar, tapi tidak akan "
-"memasang pengaya untuk menguji fungsi dalam kebanyakan kasus. Tinjauan "
-"pendahuluan akan diberikan kecuali ada kerentanan keamanan atau pelanggaran "
-"kebijakan besar yang ditemukan."
+"Saat melakukan tinjauan pendahuluan, penyunting akan mengulas koe sumber untuk isu keamanan dan pelanggaran kebijakan yang besar, tapi tidak akan memasang pengaya untuk menguji fungsi dalam "
+"kebanyakan kasus. Tinjauan pendahuluan akan diberikan kecuali ada kerentanan keamanan atau pelanggaran kebijakan besar yang ditemukan."
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:171
 msgid ""
-"Once preliminary review is granted, the add-on will be immediately available"
-" in the gallery, showing in browse and search results but ranked lower than "
-"fully-reviewed add-ons. Install buttons will have caution stripes and a "
-"notice that the add-on is experimental and not fully reviewed by Mozilla, "
-"though no click-through is required. Additionally, these add-ons cannot use "
-"the voluntary contributions and beta channel features."
+"Once preliminary review is granted, the add-on will be immediately available in the gallery, showing in browse and search results but ranked lower than fully-reviewed add-ons. Install buttons will "
+"have caution stripes and a notice that the add-on is experimental and not fully reviewed by Mozilla, though no click-through is required. Additionally, these add-ons cannot use the voluntary "
+"contributions and beta channel features."
 msgstr ""
-"Saat pengulasan awal diberikan, pengaya akan segera tersedia di galeri, "
-"ditampilkan dalam hasil pencarian dan penelusuran tapi memiliki peringkat "
-"lebih rendah daripada pengaya yang diulas lengkap. Tombol pemasangan akan "
-"memiliki garis peringatan dan pemberitahuan bahwa pengaya ini bersifat "
-"eksperimental dan belum diulas sepenuhnya oleh Mozilla, meskipun tidak ada "
-"klik-lalui yang diperlukan. Selain itu, pengaya ini tidak bisa menggunakan "
-"kontribusi sukarela dan fitur saluran beta."
+"Saat pengulasan awal diberikan, pengaya akan segera tersedia di galeri, ditampilkan dalam hasil pencarian dan penelusuran tapi memiliki peringkat lebih rendah daripada pengaya yang diulas lengkap. "
+"Tombol pemasangan akan memiliki garis peringatan dan pemberitahuan bahwa pengaya ini bersifat eksperimental dan belum diulas sepenuhnya oleh Mozilla, meskipun tidak ada klik-lalui yang diperlukan. "
+"Selain itu, pengaya ini tidak bisa menggunakan kontribusi sukarela dan fitur saluran beta."
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:177
-msgid ""
-"After being granted preliminary review, Mozilla may later revoke the review "
-"if other serious problems are reported to us by users."
-msgstr ""
-"Setelah diberikan ulasan pendahuluan, Mozilla dapat mencabut ulasan jika ada"
-" masalah serius lainnya yang dilaporkan pada kami oleh pengguna."
+msgid "After being granted preliminary review, Mozilla may later revoke the review if other serious problems are reported to us by users."
+msgstr "Setelah diberikan ulasan pendahuluan, Mozilla dapat mencabut ulasan jika ada masalah serius lainnya yang dilaporkan pada kami oleh pengguna."
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:183
 msgid ""
-"Subsequent versions of the add-on will automatically be placed in the "
-"preliminary review queue. Until the review is completed, the new version "
-"will only be displayed on the Version History page of the add-on. Once "
-"reviewed, the version will be updated across the site and deployed through "
-"the automatic update service."
+"Subsequent versions of the add-on will automatically be placed in the preliminary review queue. Until the review is completed, the new version will only be displayed on the Version History page of "
+"the add-on. Once reviewed, the version will be updated across the site and deployed through the automatic update service."
 msgstr ""
-"Versi berikutnya dari pengaya akan secara otomatis ditempatkan dalam antrean"
-" ulasan pendahuluan. Sampai peninjauan selesai, versi bari akan ditampilkan "
-"dalam laman Riwayat Versi pengaya. Setelah peninjauan, versi ini akan "
-"diperbarui di seluruh situs dan disebarkan melalui layanan pembaruan "
-"otomatis."
+"Versi berikutnya dari pengaya akan secara otomatis ditempatkan dalam antrean ulasan pendahuluan. Sampai peninjauan selesai, versi bari akan ditampilkan dalam laman Riwayat Versi pengaya. Setelah "
+"peninjauan, versi ini akan diperbarui di seluruh situs dan disebarkan melalui layanan pembaruan otomatis."
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:188
 msgid "Policies on Specific Add-on Practices"
@@ -7455,64 +5894,36 @@ msgid "The following add-ons are not permitted in any form:"
 msgstr "Pengaya berikut ini tidak diijinkan dalam bentuk apapun:"
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:194
-msgid ""
-"Add-ons that embed known <a "
-"href=\"http://en.wikipedia.org/wiki/Spyware\">spyware</a> or <a "
-"href=\"http://en.wikipedia.org/wiki/Malware\">malware</a>"
-msgstr ""
-"Pengaya yang diketahui dilekati <a "
-"href=\"http://en.wikipedia.org/wiki/Spyware\">spyware</a> atau <a "
-"href=\"http://en.wikipedia.org/wiki/Malware\">malware</a>"
+msgid "Add-ons that embed known <a href=\"http://en.wikipedia.org/wiki/Spyware\">spyware</a> or <a href=\"http://en.wikipedia.org/wiki/Malware\">malware</a>"
+msgstr "Pengaya yang diketahui dilekati <a href=\"http://en.wikipedia.org/wiki/Spyware\">spyware</a> atau <a href=\"http://en.wikipedia.org/wiki/Malware\">malware</a>"
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:199
 msgid ""
-"Illegal and criminal add-ons, such as <a "
-"href=\"http://en.wikipedia.org/wiki/Click_fraud\">click fraud</a> "
-"generators, <a href=\"http://en.wikipedia.org/wiki/Warez\">warez</a> "
-"download and directory assistants, child pornography finders, etc."
+"Illegal and criminal add-ons, such as <a href=\"http://en.wikipedia.org/wiki/Click_fraud\">click fraud</a> generators, <a href=\"http://en.wikipedia.org/wiki/Warez\">warez</a> download and "
+"directory assistants, child pornography finders, etc."
 msgstr ""
-"Pengaya yang kriminal dan ilegal, misalnya <a "
-"href=\"http://en.wikipedia.org/wiki/Click_fraud\">klik penipuan</a> "
-"generator, <a href=\"http://en.wikipedia.org/wiki/Warez\">warez</a> "
-"direktori dan asisten pengunduhan, alat menemukan pornografi anak, dll."
+"Pengaya yang kriminal dan ilegal, misalnya <a href=\"http://en.wikipedia.org/wiki/Click_fraud\">klik penipuan</a> generator, <a href=\"http://en.wikipedia.org/wiki/Warez\">warez</a> direktori dan "
+"asisten pengunduhan, alat menemukan pornografi anak, dll."
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:204
-msgid ""
-"Add-ons whose main purpose is to facilitate access to pornographic material,"
-" or include references to this material in their descriptions"
-msgstr ""
-"Pengaya yang tujuan utamanya untuk memfasilitasi akses untuk materi "
-"pornografi, atau menyertakan referensi untuk materi ini dalam penjelasan "
-"mereka"
+msgid "Add-ons whose main purpose is to facilitate access to pornographic material, or include references to this material in their descriptions"
+msgstr "Pengaya yang tujuan utamanya untuk memfasilitasi akses untuk materi pornografi, atau menyertakan referensi untuk materi ini dalam penjelasan mereka"
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:210
-msgid ""
-"Add-ons that, upon installation, auto-install or launch installers of non-"
-"Firefox software"
-msgstr ""
-"Pengaya yang, pada saat dipasang, terpasang otomatis atau meluncurkan "
-"instalator dari perangkat lunak non-Firefox"
+msgid "Add-ons that, upon installation, auto-install or launch installers of non-Firefox software"
+msgstr "Pengaya yang, pada saat dipasang, terpasang otomatis atau meluncurkan instalator dari perangkat lunak non-Firefox"
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:215
-msgid ""
-"Add-ons that provide their own update mechanism for code or search engines"
-msgstr ""
-"Pengaya yang menyediakan mekanisme pembaruan sendiri untuk kode atau mesin "
-"pencarian"
+msgid "Add-ons that provide their own update mechanism for code or search engines"
+msgstr "Pengaya yang menyediakan mekanisme pembaruan sendiri untuk kode atau mesin pencarian"
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:220
-msgid ""
-"Add-ons that make changes to web content in ways that are non-obvious or "
-"difficult to trace by their users"
-msgstr ""
-"Pengaya yang membuat perubahan pada konten web dengan cara yang tidak "
-"langsung atau sulit dilacak oleh pengguna mereka"
+msgid "Add-ons that make changes to web content in ways that are non-obvious or difficult to trace by their users"
+msgstr "Pengaya yang membuat perubahan pada konten web dengan cara yang tidak langsung atau sulit dilacak oleh pengguna mereka"
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:225
 msgid "Add-ons that snoop on or intercept the network traffic of other users"
-msgstr ""
-"Pengaya yang mengintai atau menangkap lalu lintas jaringan atau pengguna "
-"lainnya"
+msgstr "Pengaya yang mengintai atau menangkap lalu lintas jaringan atau pengguna lainnya"
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:230
 msgid "Conduit-based toolbars without explicit pre-approval"
@@ -7524,67 +5935,34 @@ msgstr "Mengubah Fitur yang Tetap dan Tak Terduga"
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:238
 msgid ""
-"Surprises can be appropriate in many situations, but they are not welcome "
-"when user security, privacy, and control are at stake. It is extremely "
-"important to be as transparent as possible when submitting an add-on for "
-"hosting on this site. A Mozilla user should be able to easily discern what "
-"the functionality of an add-on is and not be presented with unexpected "
-"experiences post-install."
+"Surprises can be appropriate in many situations, but they are not welcome when user security, privacy, and control are at stake. It is extremely important to be as transparent as possible when "
+"submitting an add-on for hosting on this site. A Mozilla user should be able to easily discern what the functionality of an add-on is and not be presented with unexpected experiences post-install."
 msgstr ""
-"Kejutan bisa tepat di banyak situasi, tetapi tidak diharapkan jika keamanan "
-"pengguna, privasi dan kendali dipertaruhkan. Sangatlah penting untuk sebisa "
-"mungkin transparan saat mengirimkan sebuah pengaya untuk dimuat dalam situs "
-"ini. Seorang pengguna Mozilla harus bisa dengan mudah membedakan apa fungsi "
-"pengaya itu dan tidak bisa disajikan dengan pengalaman pasca-pemasangan yang"
-" tak teduga."
+"Kejutan bisa tepat di banyak situasi, tetapi tidak diharapkan jika keamanan pengguna, privasi dan kendali dipertaruhkan. Sangatlah penting untuk sebisa mungkin transparan saat mengirimkan sebuah "
+"pengaya untuk dimuat dalam situs ini. Seorang pengguna Mozilla harus bisa dengan mudah membedakan apa fungsi pengaya itu dan tidak bisa disajikan dengan pengalaman pasca-pemasangan yang tak teduga."
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:243
 msgid ""
-"<p> Whenever an add-on includes any unexpected* feature that </p> <ul> "
-"<li>compromises user privacy or security (like sending data to third "
-"parties),</li> <li>changes default settings like the homepage or search "
-"engine, or</li> <li>changes settings or features in other add-ons or "
-"deactivates them altogether</li> </ul> <p>the features must adhere to the "
-"following requirements:</p> <ul> <li>The add-on description must clearly "
-"state what changes the add-on makes.</li> <li>All changes must be opt-in, "
-"meaning the user must take non-default action to enact the change.</li> "
-"<li>The opt-in dialog must clearly state the name of the add-on requesting "
-"the change.</li> <li>Uninstalling the add-on restores the user's original "
-"settings if they were changed.</li> </ul> <p>*Unexpected features are those "
-"that are unrelated to the add-on's primary function.</p>"
+"<p> Whenever an add-on includes any unexpected* feature that </p> <ul> <li>compromises user privacy or security (like sending data to third parties),</li> <li>changes default settings like the "
+"homepage or search engine, or</li> <li>changes settings or features in other add-ons or deactivates them altogether</li> </ul> <p>the features must adhere to the following requirements:</p> <ul> "
+"<li>The add-on description must clearly state what changes the add-on makes.</li> <li>All changes must be opt-in, meaning the user must take non-default action to enact the change.</li> <li>The opt-"
+"in dialog must clearly state the name of the add-on requesting the change.</li> <li>Uninstalling the add-on restores the user's original settings if they were changed.</li> </ul> <p>*Unexpected "
+"features are those that are unrelated to the add-on's primary function.</p>"
 msgstr ""
-"<p> Kapanpun sebuah pengaya memasukkan fitur tak terduga* apapun yang </p> "
-"<ul> <li>dapat mengancam keamanan atau privasi pengguna (seperti mengirimkan"
-" data ke pihak ketiga),</li> <li>mengubah pengaturan tetap seperti beranda "
-"atau mesin pencari</li> <li>mengubah fitur dalam pengaya lain atau "
-"menonaktifkan mereka sama sekali</li> </ul> <p>fitur harus mematuhi "
-"persyaratan berikut:</p> <ul> <li>Deskripsi pengaya harus menjelaskan apa "
-"perubahan apa yang dibuat pengaya.</li> <li>Semua perubahan harus dapat "
-"dipilih, artinya pengguna harus mengambil tindakan tidak tetap untuk "
-"memberlakukan perubahan.</li> <li>Dialog pemilihan harus dengan jelas "
-"menunjukkan nama pengaya yang meminta perubahan.</li> <li>Melepas pengaya "
-"akan mengembalikan pengaturan awal pengguna saat telah diubah.</li> </ul> "
-"<p>*Fitur tak terduga adalah yang tidak berkaitan dengan fungsi utama "
-"pengaya.</p>"
+"<p> Kapanpun sebuah pengaya memasukkan fitur tak terduga* apapun yang </p> <ul> <li>dapat mengancam keamanan atau privasi pengguna (seperti mengirimkan data ke pihak ketiga),</li> <li>mengubah "
+"pengaturan tetap seperti beranda atau mesin pencari</li> <li>mengubah fitur dalam pengaya lain atau menonaktifkan mereka sama sekali</li> </ul> <p>fitur harus mematuhi persyaratan berikut:</p> <ul> "
+"<li>Deskripsi pengaya harus menjelaskan apa perubahan apa yang dibuat pengaya.</li> <li>Semua perubahan harus dapat dipilih, artinya pengguna harus mengambil tindakan tidak tetap untuk "
+"memberlakukan perubahan.</li> <li>Dialog pemilihan harus dengan jelas menunjukkan nama pengaya yang meminta perubahan.</li> <li>Melepas pengaya akan mengembalikan pengaturan awal pengguna saat "
+"telah diubah.</li> </ul> <p>*Fitur tak terduga adalah yang tidak berkaitan dengan fungsi utama pengaya.</p>"
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:268
-msgid ""
-"These features cannot be introduced into an update of a fully-reviewed add-"
-"on; the opt-in change process must be part of the initial review."
-msgstr ""
-"Fitur ini tidak akan bisa dikenalkan pada pembaruan pengaya yang sudah "
-"diulas lengkap; proses perubahan yang dipilih harus merupakan bagian dari "
-"ulasan awal."
+msgid "These features cannot be introduced into an update of a fully-reviewed add-on; the opt-in change process must be part of the initial review."
+msgstr "Fitur ini tidak akan bisa dikenalkan pada pembaruan pengaya yang sudah diulas lengkap; proses perubahan yang dipilih harus merupakan bagian dari ulasan awal."
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:274
-msgid ""
-"These are minimum requirements and not a guarantee that the add-on will be "
-"approved. This section applies to all add-ons hosted on the site, including "
-"preliminarily reviewed add-ons."
+msgid "These are minimum requirements and not a guarantee that the add-on will be approved. This section applies to all add-ons hosted on the site, including preliminarily reviewed add-ons."
 msgstr ""
-"Ada permintaan minimun dan tidak ada jaminan bahwa pengaya akan disetujui. "
-"Bagian ini berlaku untuk semua pengaya yang dimuat di situs, termasuk "
-"pengaya yang sudah mendapat ulasan pendahuluan."
+"Ada permintaan minimun dan tidak ada jaminan bahwa pengaya akan disetujui. Bagian ini berlaku untuk semua pengaya yang dimuat di situs, termasuk pengaya yang sudah mendapat ulasan pendahuluan."
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:279
 msgid "Private Browsing Mode"
@@ -7592,18 +5970,11 @@ msgstr "Mode Penjelajahan Pribadi"
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:282
 msgid ""
-"Add-ons that store or otherwise handle browsing data must support <a "
-"href=\"https://developer.mozilla.org/En/Supporting_private_browsing_mode\">Private"
-" Browsing Mode</a>.  During a Private Browsing session, no browsing data can"
-" be written to disk, and all of this data must be cleared when Firefox quits"
-" or the Private Browsing session ends."
+"Add-ons that store or otherwise handle browsing data must support <a href=\"https://developer.mozilla.org/En/Supporting_private_browsing_mode\">Private Browsing Mode</a>. During a Private Browsing "
+"session, no browsing data can be written to disk, and all of this data must be cleared when Firefox quits or the Private Browsing session ends."
 msgstr ""
-"Pengaya yang menyimpan atau menangani data peramban harus mendukung <a "
-"href=\"https://developer.mozilla.org/En/Supporting_private_browsing_mode\">Mode"
-" Penjelajahan Privat</a>.  Saat sesi Penjelajahan Privat, tak ada data "
-"penelusuran yang bisa disimpan dalam cakram, dan seluruh data ini harus "
-"dibersihkan saat Firefox berhenti atau ketika sesi Penjelajahan Privat "
-"berakhir."
+"Pengaya yang menyimpan atau menangani data peramban harus mendukung <a href=\"https://developer.mozilla.org/En/Supporting_private_browsing_mode\">Mode Penjelajahan Privat</a>.  Saat sesi "
+"Penjelajahan Privat, tak ada data penelusuran yang bisa disimpan dalam cakram, dan seluruh data ini harus dibersihkan saat Firefox berhenti atau ketika sesi Penjelajahan Privat berakhir."
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:287
 msgid "Binary Components & Obfuscated Code"
@@ -7611,43 +5982,27 @@ msgstr "Komponen Biner & Kode yang Dikaburkan"
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:289
 msgid ""
-"Add-ons may contain binary, obfuscated and minified source code, but Mozilla"
-" must be allowed to review a copy of the human-readable source code of each "
-"version of an add-on submitted for review. These add-ons are ineligible for "
-"preliminary review and must choose the full review process."
+"Add-ons may contain binary, obfuscated and minified source code, but Mozilla must be allowed to review a copy of the human-readable source code of each version of an add-on submitted for review. "
+"These add-ons are ineligible for preliminary review and must choose the full review process."
 msgstr ""
-"Pengaya mungkin berisi kode biner, kode sumber yang dikaburkan atau "
-"dikecilkan, tetapi Mozilla harus diperkenankan untuk meninjau salinan kode "
-"sumber yang bisa dibaca manusia dari tiap versi pengaya yang dimasukkan "
-"untuk diulas. Pengaya ini tidak memenuhi syarat untuk ulasan pendahuluan dan"
-" harus memilih proses ulasan lengkap."
+"Pengaya mungkin berisi kode biner, kode sumber yang dikaburkan atau dikecilkan, tetapi Mozilla harus diperkenankan untuk meninjau salinan kode sumber yang bisa dibaca manusia dari tiap versi "
+"pengaya yang dimasukkan untuk diulas. Pengaya ini tidak memenuhi syarat untuk ulasan pendahuluan dan harus memilih proses ulasan lengkap."
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:295
 msgid ""
-"If an add-on contains binary or obfuscated source code, the author will "
-"receive a message when the add-on is reviewed indicating whom to contact at "
-"Mozilla to coordinate review of the source code. This code will be reviewed "
-"by an administrator and will not be shared or redistributed in any way. The "
-"code will only be used for the purpose of reviewing the add-on."
+"If an add-on contains binary or obfuscated source code, the author will receive a message when the add-on is reviewed indicating whom to contact at Mozilla to coordinate review of the source code. "
+"This code will be reviewed by an administrator and will not be shared or redistributed in any way. The code will only be used for the purpose of reviewing the add-on."
 msgstr ""
-"Jika sebuah pengaya mengandung kode biner atau kode sumber yang dikaburkan, "
-"penulis akan menerima pesan saat pengaya diulas yang mengindikasikan siapa "
-"yang perlu dikontak di Mozilla untuk mengkoordinasikan ulasan kode sumber. "
-"Kode ini akan diulas oleh administrator dan tidak akan dibagi atau "
-"didistribusikan ulang dengan cara apapun. Kode hanya akan digunakan untuk "
-"tujuan mengulas pengaya."
+"Jika sebuah pengaya mengandung kode biner atau kode sumber yang dikaburkan, penulis akan menerima pesan saat pengaya diulas yang mengindikasikan siapa yang perlu dikontak di Mozilla untuk "
+"mengkoordinasikan ulasan kode sumber. Kode ini akan diulas oleh administrator dan tidak akan dibagi atau didistribusikan ulang dengan cara apapun. Kode hanya akan digunakan untuk tujuan mengulas "
+"pengaya."
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:301
 #, python-format
-msgid ""
-"If your add-on contains binary or obfuscated code that you don't own or "
-"can't get the source code for, you may <a href=\"%(link_contact)s\">contact "
-"us</a> for information on how to proceed."
+msgid "If your add-on contains binary or obfuscated code that you don't own or can't get the source code for, you may <a href=\"%(link_contact)s\">contact us</a> for information on how to proceed."
 msgstr ""
-"Jika pengaya anda mengandung kode biner atau kode yang dikaburkan yang tidak"
-" anda miliki atau tidak bsia didapatkan kode sumbernya, anda bisa <a "
-"href=\"%(link_contact)s\">menghubungi kami</a> untuk informasi mengenai "
-"bagaimana cara melanjutkan."
+"Jika pengaya anda mengandung kode biner atau kode yang dikaburkan yang tidak anda miliki atau tidak bsia didapatkan kode sumbernya, anda bisa <a href=\"%(link_contact)s\">menghubungi kami</a> untuk "
+"informasi mengenai bagaimana cara melanjutkan."
 
 #: src/olympia/devhub/templates/devhub/docs/policies-submission.html:11
 msgid "Criteria for Submission"
@@ -7655,236 +6010,129 @@ msgstr "Kriteria Pendaftaran"
 
 #: src/olympia/devhub/templates/devhub/docs/policies-submission.html:13
 msgid ""
-"Add-ons hosted on Mozilla Add-ons should be of high quality and give users "
-"an improved web experience. We look for the following things when deciding "
-"whether an add-on is appropriate to be public and unrestricted:"
+"Add-ons hosted on Mozilla Add-ons should be of high quality and give users an improved web experience. We look for the following things when deciding whether an add-on is appropriate to be public "
+"and unrestricted:"
 msgstr ""
-"Pengaya yang dimuat di Pengaya Mozilla harus berkualitas tinggi dan memberi "
-"pengguna pengalaman web yang lebih baik. Kami mencari hal-hal berikut ini "
-"saat memutuskan apakah sebuah pengaya sesuai untuk publik dan tidak "
-"terbatas:"
+"Pengaya yang dimuat di Pengaya Mozilla harus berkualitas tinggi dan memberi pengguna pengalaman web yang lebih baik. Kami mencari hal-hal berikut ini saat memutuskan apakah sebuah pengaya sesuai "
+"untuk publik dan tidak terbatas:"
 
 #: src/olympia/devhub/templates/devhub/docs/policies-submission.html:19
 msgid ""
-"<strong>Are you responsive?</strong> We expect that an author who is "
-"promoting their add-on to our applications' many users is responsive to "
-"problem reports, maintains their contact information, and updates their add-"
-"on promptly to keep current with Firefox releases and changes in our "
-"policies. This doesn't mean that you have to reply to every question that "
-"someone posts in the discussions, or that you even need to fix every bug, "
-"but we do expect that you will respond to issues in a manner that's "
-"appropriate to the severity of the issue in question."
+"<strong>Are you responsive?</strong> We expect that an author who is promoting their add-on to our applications' many users is responsive to problem reports, maintains their contact information, "
+"and updates their add-on promptly to keep current with Firefox releases and changes in our policies. This doesn't mean that you have to reply to every question that someone posts in the "
+"discussions, or that you even need to fix every bug, but we do expect that you will respond to issues in a manner that's appropriate to the severity of the issue in question."
 msgstr ""
-"<strong>Apakah anda responsif?</strong> Kami mengharapkan seorang penulis "
-"yang mempromosikan pengaya mereka pada aplikasi pengguna kami untuk "
-"responsif pada laporan masalah, mengelola kontak informasi mereka, dan "
-"memperbarui pengaya mereka secepatnya untuk jadi tetap terkini sesuai "
-"rilisan Firefox dan perubahan kebijakan kami. Ini tidak berarti anda harus "
-"menjawab setiap pertanyaan yang diajukan seseorang dalam diskusi, atau bahwa"
-" anda perlu memperbaiki setiap bug, tapi kami mengharapkan bahwa anda "
-"membalas masalah dengan cara yang sesuai dengan tingkat keseriusan masalah "
+"<strong>Apakah anda responsif?</strong> Kami mengharapkan seorang penulis yang mempromosikan pengaya mereka pada aplikasi pengguna kami untuk responsif pada laporan masalah, mengelola kontak "
+"informasi mereka, dan memperbarui pengaya mereka secepatnya untuk jadi tetap terkini sesuai rilisan Firefox dan perubahan kebijakan kami. Ini tidak berarti anda harus menjawab setiap pertanyaan "
+"yang diajukan seseorang dalam diskusi, atau bahwa anda perlu memperbaiki setiap bug, tapi kami mengharapkan bahwa anda membalas masalah dengan cara yang sesuai dengan tingkat keseriusan masalah "
 "yang bersangkutan."
 
 #: src/olympia/devhub/templates/devhub/docs/policies-submission.html:25
 msgid ""
-"<strong>Is the add-on clearly and accurately described?</strong> It's of the"
-" utmost importance to us that users get what they expect when they try a new"
-" add-on. Your add-on name should be clear and concise, and you should "
-"refrain from using special characters or numbers to get higher search "
-"rankings or for decorative purposes. Your description should provide details"
-" about what the add-on does, how a user should take advantage of it, and "
-"what the user should expect when they install it. Links to external "
-"documents for detailed instructions are fine, but the description itself "
-"should cover the basics and leave users confident that they know what "
-"they'll get. Also, it is important that you maintain version notes "
-"appropriately as you improve and change your add-on. Users should be able to"
-" see what's new in an add-on they may have tried previously, and should be "
-"made aware of changes that might affect their current use of the add-on when"
-" they update."
+"<strong>Is the add-on clearly and accurately described?</strong> It's of the utmost importance to us that users get what they expect when they try a new add-on. Your add-on name should be clear and "
+"concise, and you should refrain from using special characters or numbers to get higher search rankings or for decorative purposes. Your description should provide details about what the add-on "
+"does, how a user should take advantage of it, and what the user should expect when they install it. Links to external documents for detailed instructions are fine, but the description itself should "
+"cover the basics and leave users confident that they know what they'll get. Also, it is important that you maintain version notes appropriately as you improve and change your add-on. Users should "
+"be able to see what's new in an add-on they may have tried previously, and should be made aware of changes that might affect their current use of the add-on when they update."
 msgstr ""
-"<strong>Apakah pengaya dijelaskan dengan akurat?</strong> Sangatlah penting "
-"bagi kami bahwa pengguna mendapatkan apa yang mereka harapkan saat mereka "
-"mencoba pengaya baru. Nama pengaya anda harus jelas dan ringkas, dan anda "
-"harus menahan diri dari menggunakan karakter khusus atau angka untuk "
-"mendapatkan peringkat pencarian yang lebih tinggi untuk tujuan dekoratif. "
-"Deskripsi anda harus memberikan rincian mengenai apa yang bisa diharapkan "
-"pengguna saat mereka memasangnya. Tautan ke dokumen eksternal untuk "
-"instruksi yang terinci boleh diberikan, namun deskripsinya harus mencakup "
-"hal-hal dasar dan membiarkan pengguna merasa yakin bahwa mereka tahu apa "
-"yang akan mereka dapatkan. Juga, sangatlah penting bahwa anda mempertahankan"
-" versi catatan sepantasnya selama anda memperbaiki dan mengubah pengaya "
-"anda. Pengguna harus bisa melihat apa yang baru dalam sebuah pengaya yang "
-"mungkin telah mereka coba sebelumnya, dan harus bisa disadarkan mengenai "
-"perubahan yang bisa mempengaruhi penggunaan pengaya mereka saat ini jika "
-"diperbarui."
+"<strong>Apakah pengaya dijelaskan dengan akurat?</strong> Sangatlah penting bagi kami bahwa pengguna mendapatkan apa yang mereka harapkan saat mereka mencoba pengaya baru. Nama pengaya anda harus "
+"jelas dan ringkas, dan anda harus menahan diri dari menggunakan karakter khusus atau angka untuk mendapatkan peringkat pencarian yang lebih tinggi untuk tujuan dekoratif. Deskripsi anda harus "
+"memberikan rincian mengenai apa yang bisa diharapkan pengguna saat mereka memasangnya. Tautan ke dokumen eksternal untuk instruksi yang terinci boleh diberikan, namun deskripsinya harus mencakup "
+"hal-hal dasar dan membiarkan pengguna merasa yakin bahwa mereka tahu apa yang akan mereka dapatkan. Juga, sangatlah penting bahwa anda mempertahankan versi catatan sepantasnya selama anda "
+"memperbaiki dan mengubah pengaya anda. Pengguna harus bisa melihat apa yang baru dalam sebuah pengaya yang mungkin telah mereka coba sebelumnya, dan harus bisa disadarkan mengenai perubahan yang "
+"bisa mempengaruhi penggunaan pengaya mereka saat ini jika diperbarui."
 
 #: src/olympia/devhub/templates/devhub/docs/policies-submission.html:31
 msgid ""
-"<strong>Are all privacy and security concerns clearly spelled out?</strong> "
-"This is an aspect of a clear and accurate description, but such an important"
-" one that we feel it deserves specific mention. Many very useful and well-"
-"written add-ons manipulate some form of user data, or can present security "
-"hazards if misused; they are welcome on the site, but they must make it very"
-" clear to users what risks they might encounter, and what they can do to "
-"protect themselves."
+"<strong>Are all privacy and security concerns clearly spelled out?</strong> This is an aspect of a clear and accurate description, but such an important one that we feel it deserves specific "
+"mention. Many very useful and well-written add-ons manipulate some form of user data, or can present security hazards if misused; they are welcome on the site, but they must make it very clear to "
+"users what risks they might encounter, and what they can do to protect themselves."
 msgstr ""
-"<strong>Apakah semua kekhawatiran keamanan dan privasi dijabarkan dengan "
-"jelas?</strong> Ini adalah aspek penjelasan yang jelas dan akurat, namun "
-"merupakan sesuatu yang sangat penting sehingga kami merasa perlu "
-"menyinggungnya secara spesifik. Banyak pengaya yang sangat berguna dan "
-"ditulis dengan baik memanipulasi sebagian formulir data pengguna, atau dapat"
-" menampilkan bahaya keamanan jika disalahgunakan; pengaya semacam itu "
-"diterima dalam situs ini, namun harus ditegaskan dengan jelas untuk pengguna"
-" apa resiko yang mungkin mereka temui, dan apa yang bisa mereka lakukan "
-"untuk melindungi diri sendiri."
+"<strong>Apakah semua kekhawatiran keamanan dan privasi dijabarkan dengan jelas?</strong> Ini adalah aspek penjelasan yang jelas dan akurat, namun merupakan sesuatu yang sangat penting sehingga kami "
+"merasa perlu menyinggungnya secara spesifik. Banyak pengaya yang sangat berguna dan ditulis dengan baik memanipulasi sebagian formulir data pengguna, atau dapat menampilkan bahaya keamanan jika "
+"disalahgunakan; pengaya semacam itu diterima dalam situs ini, namun harus ditegaskan dengan jelas untuk pengguna apa resiko yang mungkin mereka temui, dan apa yang bisa mereka lakukan untuk "
+"melindungi diri sendiri."
 
 #: src/olympia/devhub/templates/devhub/docs/policies-submission.html:37
 msgid ""
-"<strong>Has the add-on been well-tested, and is it free of obvious or "
-"serious defects?</strong> One important thing that we look for when "
-"considering an add-on is whether its user reviews indicate that it has "
-"received thorough testing, and that it doesn't have serious problems or "
-"negative impacts on the browser. If reviewers report problems such as major "
-"performance issues, crashes, frequent problems using the functions of the "
-"add-on, or spamming of messages to the error console, you should take those "
-"reports to heart, and re-submit your add-on after you've addressed them as "
-"best you can. We don't expect you to perfectly optimize or have zero bugs "
-"&mdash; Firefox itself undergoes constant improvement in these areas &mdash;"
-" but we do want you to take reasonable efforts to minimize downsides, and to"
-" clearly call out cases where users may be surprised by those that remain."
+"<strong>Has the add-on been well-tested, and is it free of obvious or serious defects?</strong> One important thing that we look for when considering an add-on is whether its user reviews indicate "
+"that it has received thorough testing, and that it doesn't have serious problems or negative impacts on the browser. If reviewers report problems such as major performance issues, crashes, frequent "
+"problems using the functions of the add-on, or spamming of messages to the error console, you should take those reports to heart, and re-submit your add-on after you've addressed them as best you "
+"can. We don't expect you to perfectly optimize or have zero bugs &mdash; Firefox itself undergoes constant improvement in these areas &mdash; but we do want you to take reasonable efforts to "
+"minimize downsides, and to clearly call out cases where users may be surprised by those that remain."
 msgstr ""
-"<strong>Apakah pengaya telah diuji dengan baik, dan apakah bebas dari "
-"kekurangan serius?</strong> Satu hal penting yang kami cari saat "
-"mempertimbangkan sebuah pengaya adalah apakah ulasan penggunanya "
-"mengindikasikan bahwa ia telah menerima pengujian menyeluruh, dan bahwa "
-"pengaya ini tidak memiliki masalah serius atau dampak negatif pada peramban."
-" Jika pengulas melaporkan masalah seperti persoalan performa yang serius, "
-"gagal, persoalan penggunaan dan fungsi pengaya yang berulang, atau pesan "
-"spam ke konsol kesalahan, anda harus menanggapi serius laporan tersebut, dan"
-" memasukkan ulang pengaya anda setelah anda menyelesaikan persoalannya "
-"sebaik mungkin. Kami tidak mengharapkan anda mengoptimalkan secara sempurna "
-"atau tidak memiliki bug &mdash; Firefox sendiri terus menerus mengalami "
-"perbaikan di bagian ini &mdash; namun kami ingin anda mengambil upaya "
-"rasional untuk meminimalkan kekurangan, dan untuk secara jelas menyebutkan "
-"masalah di mana pengguna bisa heran akan apa yang tersisa."
+"<strong>Apakah pengaya telah diuji dengan baik, dan apakah bebas dari kekurangan serius?</strong> Satu hal penting yang kami cari saat mempertimbangkan sebuah pengaya adalah apakah ulasan "
+"penggunanya mengindikasikan bahwa ia telah menerima pengujian menyeluruh, dan bahwa pengaya ini tidak memiliki masalah serius atau dampak negatif pada peramban. Jika pengulas melaporkan masalah "
+"seperti persoalan performa yang serius, gagal, persoalan penggunaan dan fungsi pengaya yang berulang, atau pesan spam ke konsol kesalahan, anda harus menanggapi serius laporan tersebut, dan "
+"memasukkan ulang pengaya anda setelah anda menyelesaikan persoalannya sebaik mungkin. Kami tidak mengharapkan anda mengoptimalkan secara sempurna atau tidak memiliki bug &mdash; Firefox sendiri "
+"terus menerus mengalami perbaikan di bagian ini &mdash; namun kami ingin anda mengambil upaya rasional untuk meminimalkan kekurangan, dan untuk secara jelas menyebutkan masalah di mana pengguna "
+"bisa heran akan apa yang tersisa."
 
 #: src/olympia/devhub/templates/devhub/docs/policies-submission.html:43
 msgid ""
-"<strong>Do the add-on and add-on author both treat the user "
-"respectfully?</strong> Your software should not intrude on the user "
-"unnecessarily, try to trick the user, or conceal any of its activities from "
-"the user. Users (or even non-users) are sometimes rude in their comments, "
-"and while we will do our best to filter out inaccurate reviews as they're "
-"reported to us, we do expect that authors will avoid retaliating with "
-"rudeness of their own."
+"<strong>Do the add-on and add-on author both treat the user respectfully?</strong> Your software should not intrude on the user unnecessarily, try to trick the user, or conceal any of its "
+"activities from the user. Users (or even non-users) are sometimes rude in their comments, and while we will do our best to filter out inaccurate reviews as they're reported to us, we do expect that "
+"authors will avoid retaliating with rudeness of their own."
 msgstr ""
-"<strong>Apakah pengaya dan penulis pengaya menghormati pengguna?</strong> "
-"Pengaya anda tidak boleh mengganggu pengguna tanpa keperluan, mencoba menipu"
-" pengguna, atau menutupi apapun kegiatannya dari pengguna. Pengguna (atau "
-"bahkan non-pengguna) seringkali berkomentar kasar, dan meskipun kami "
-"berusaha sebaik mungkin menyaring ulasan yang tidak akurat yang dilaporkan "
-"pada kami, kami juga mengharapkan penulis menghindari membalas dendam dengan"
-" kekasaran yang sama."
+"<strong>Apakah pengaya dan penulis pengaya menghormati pengguna?</strong> Pengaya anda tidak boleh mengganggu pengguna tanpa keperluan, mencoba menipu pengguna, atau menutupi apapun kegiatannya "
+"dari pengguna. Pengguna (atau bahkan non-pengguna) seringkali berkomentar kasar, dan meskipun kami berusaha sebaik mungkin menyaring ulasan yang tidak akurat yang dilaporkan pada kami, kami juga "
+"mengharapkan penulis menghindari membalas dendam dengan kekasaran yang sama."
 
 #: src/olympia/devhub/templates/devhub/docs/policies-submission.html:49
 msgid ""
-"<strong>Is the add-on useful to an appropriately wide portion of Firefox's "
-"users?</strong> Your add-on doesn't need to be the next Greasemonkey or "
-"Firebug, but if it is only useful to people at your company or who are part "
-"of a small web community, we may feel that it's not yet appropriate to put "
-"it in front of all of our users."
+"<strong>Is the add-on useful to an appropriately wide portion of Firefox's users?</strong> Your add-on doesn't need to be the next Greasemonkey or Firebug, but if it is only useful to people at "
+"your company or who are part of a small web community, we may feel that it's not yet appropriate to put it in front of all of our users."
 msgstr ""
-"<strong>Apakah pengaya ini bermanfaat untuk sebagian besar pengguna "
-"Firefox?</strong> Pengaya anda tidak perlu menjadi Greasemonkey atau Firebug"
-" berikutnya, namun jika ia hanya berguna untuk karyawan di perusahaan anda "
-"atau bagian dari komunitas web yang kecil, kami merasa bahwa pengaya itu "
-"belum pantas untuk ditampilkan di hadapan semua pengguna kami."
+"<strong>Apakah pengaya ini bermanfaat untuk sebagian besar pengguna Firefox?</strong> Pengaya anda tidak perlu menjadi Greasemonkey atau Firebug berikutnya, namun jika ia hanya berguna untuk "
+"karyawan di perusahaan anda atau bagian dari komunitas web yang kecil, kami merasa bahwa pengaya itu belum pantas untuk ditampilkan di hadapan semua pengguna kami."
 
 #: src/olympia/devhub/templates/devhub/docs/policies-submission.html:55
 msgid ""
-"We are constantly looking at ways to improve the organization of the site to"
-" better accommodate add-ons that are exemplary in other ways, but are aimed "
-"at only a small community of potential users. Correctly categorizing and "
-"maintaining the metadata of your add-on will help us figure out how we can "
-"surface more of those sorts of add-ons to people who are most likely to "
-"benefit from them."
+"We are constantly looking at ways to improve the organization of the site to better accommodate add-ons that are exemplary in other ways, but are aimed at only a small community of potential users. "
+"Correctly categorizing and maintaining the metadata of your add-on will help us figure out how we can surface more of those sorts of add-ons to people who are most likely to benefit from them."
 msgstr ""
-"Kami terus menerus mencari cara untuk memperbaiki organisasi situs untuk "
-"bisa mengakomodasi pengaya dengan lebih baik, yang patut dicontoh dalam hal "
-"lain, namun ditujukan hanya pada komunitas kecil pengguna potensial. "
-"Pengategorian yang tepat dan menjaga metadata pengaya anda akan membantu "
-"kami menentukan bagaimana kami bisa menampilkan lebih banyak pengaya semacam"
-" itu bagi mereka yang boleh jadi mendapat manfaat darinya."
+"Kami terus menerus mencari cara untuk memperbaiki organisasi situs untuk bisa mengakomodasi pengaya dengan lebih baik, yang patut dicontoh dalam hal lain, namun ditujukan hanya pada komunitas kecil "
+"pengguna potensial. Pengategorian yang tepat dan menjaga metadata pengaya anda akan membantu kami menentukan bagaimana kami bisa menampilkan lebih banyak pengaya semacam itu bagi mereka yang boleh "
+"jadi mendapat manfaat darinya."
 
 #: src/olympia/devhub/templates/devhub/docs/policies-submission.html:61
 msgid ""
-"If your add-on just provides bookmarks or other simple access points to your"
-" site, it's probably not appropriate for the gallery. Like the rest of the "
-"Mozilla project, we love web applications and new web services, but Firefox "
-"add-ons should provide an improved browsing experience for the user and not "
-"just be a way to promote a new site or service through a Mozilla Add-ons "
-"listing."
+"If your add-on just provides bookmarks or other simple access points to your site, it's probably not appropriate for the gallery. Like the rest of the Mozilla project, we love web applications and "
+"new web services, but Firefox add-ons should provide an improved browsing experience for the user and not just be a way to promote a new site or service through a Mozilla Add-ons listing."
 msgstr ""
-"Jika pengaya anda menyediakan markah atau titk akses sederhana lainnya ke "
-"situs anda, mungkin tidak tepat untuk galeri. Seperti proyek Mozilla "
-"lainnya, kami menyukai aplikasi web dan layanan web yang baru, namun pengaya"
-" Firefox harus menyediakan pengalaman penjelajahan yang lebih baik untuk "
-"pengguna dan bukan hanya menjadi cara untuk mempromosikan situs baru atau "
-"layanan melalui daftar Pengaya Mozilla."
+"Jika pengaya anda menyediakan markah atau titk akses sederhana lainnya ke situs anda, mungkin tidak tepat untuk galeri. Seperti proyek Mozilla lainnya, kami menyukai aplikasi web dan layanan web "
+"yang baru, namun pengaya Firefox harus menyediakan pengalaman penjelajahan yang lebih baik untuk pengguna dan bukan hanya menjadi cara untuk mempromosikan situs baru atau layanan melalui daftar "
+"Pengaya Mozilla."
 
 #: src/olympia/devhub/templates/devhub/docs/policies-submission.html:67
 msgid ""
-"<strong>Is the add-on free of unlicensed trademarks and copyrights?</strong>"
-" Though you may mean no harm to the holder of a trademark, or the owner of a"
-" copyrighted work, we can't host add-ons that infringe on trademarks or "
-"copyrights. If you don't have permission to use a trademarked name or image,"
-" please do not submit your add-on to us. If your add-on includes code that "
-"is copyrighted by someone else, and is not licensed to you to use in your "
-"add-on, please do not submit your add-on to us."
+"<strong>Is the add-on free of unlicensed trademarks and copyrights?</strong> Though you may mean no harm to the holder of a trademark, or the owner of a copyrighted work, we can't host add-ons that "
+"infringe on trademarks or copyrights. If you don't have permission to use a trademarked name or image, please do not submit your add-on to us. If your add-on includes code that is copyrighted by "
+"someone else, and is not licensed to you to use in your add-on, please do not submit your add-on to us."
 msgstr ""
-"<strong>Apakah pengaya bebas dari merek dagang tanpa lisensi dan hak "
-"cipta?</strong> Meskipun anda mungkin tidak bermaksud jahat pada pemegang "
-"sebuah merek dagang, atau pemilik karya dengan hak cipta, kami tidak bisa "
-"memuat pengaya yang melanggar merek dagang atau hak cipta. Jika anda tidak "
-"memiliki izin untuk menggunakan nama merek dagang atau gambar harap jangan "
-"memasukkan pengaya anda pada kami. Jika pengaya anda memasukkan kode yang "
-"merupakan hak cipta orang lain, dan tidak dilisensikan pada anda untuk "
-"digunakan dalam pengaya anda, mohon jangan daftarkan pengaya anda pada kami."
+"<strong>Apakah pengaya bebas dari merek dagang tanpa lisensi dan hak cipta?</strong> Meskipun anda mungkin tidak bermaksud jahat pada pemegang sebuah merek dagang, atau pemilik karya dengan hak "
+"cipta, kami tidak bisa memuat pengaya yang melanggar merek dagang atau hak cipta. Jika anda tidak memiliki izin untuk menggunakan nama merek dagang atau gambar harap jangan memasukkan pengaya anda "
+"pada kami. Jika pengaya anda memasukkan kode yang merupakan hak cipta orang lain, dan tidak dilisensikan pada anda untuk digunakan dalam pengaya anda, mohon jangan daftarkan pengaya anda pada kami."
 
 #: src/olympia/devhub/templates/devhub/docs/policies-submission.html:73
 msgid ""
-"In terms of reuse of source code from other add-ons, if the author has not "
-"clearly stated that you are permitted to use his or her code in your own "
-"work &mdash; such as by placing it under an open source license &mdash; then"
-" you should assume that you do not have the right to do so. You can contact "
-"the author to seek such permission, but we can't provide you with any "
-"special rights to it just because it's listed on the site, or because the "
-"author isn't responding to your request."
+"In terms of reuse of source code from other add-ons, if the author has not clearly stated that you are permitted to use his or her code in your own work &mdash; such as by placing it under an open "
+"source license &mdash; then you should assume that you do not have the right to do so. You can contact the author to seek such permission, but we can't provide you with any special rights to it "
+"just because it's listed on the site, or because the author isn't responding to your request."
 msgstr ""
-"Dalam hal menggunakan ulang kode sumber dari pengaya lainnya, jika penulis "
-"belum menyatakan secara jelas bahwa anda diizinkan untuk menggunakan kodenya"
-" dalam karya anda sendiri &mdash; misalnya dengan menempatkannya dalam "
-"lisensi sumber terbuka &mdash; maka anda harus menganggap bahwa anda tidak "
-"memiliki hak untuk melakukannya. Anda bisa mengontak penulis untuk mencari "
-"izin, namun kami tidak bisa memberi anda hak khusus untuk hal itu hanya "
-"karena ini terdaftar dalam situs, atau karena penulis tidak merespon "
-"permintaan anda."
+"Dalam hal menggunakan ulang kode sumber dari pengaya lainnya, jika penulis belum menyatakan secara jelas bahwa anda diizinkan untuk menggunakan kodenya dalam karya anda sendiri &mdash; misalnya "
+"dengan menempatkannya dalam lisensi sumber terbuka &mdash; maka anda harus menganggap bahwa anda tidak memiliki hak untuk melakukannya. Anda bisa mengontak penulis untuk mencari izin, namun kami "
+"tidak bisa memberi anda hak khusus untuk hal itu hanya karena ini terdaftar dalam situs, atau karena penulis tidak merespon permintaan anda."
 
 #: src/olympia/devhub/templates/devhub/docs/policies-submission.html:79
 msgid ""
-"This applies to the Mozilla Foundation's trademarks as well, including "
-"\"Mozilla\", \"Firefox\", and \"Thunderbird\". The Mozilla policy on "
-"trademark use is designed to protect against confusion, and prevent the "
-"trademarks from being overturned due to lack of protection; please respect "
-"the need for such protection, and help us preserve some of the most valuable"
-" assets of the Mozilla Foundation."
+"This applies to the Mozilla Foundation's trademarks as well, including \"Mozilla\", \"Firefox\", and \"Thunderbird\". The Mozilla policy on trademark use is designed to protect against confusion, "
+"and prevent the trademarks from being overturned due to lack of protection; please respect the need for such protection, and help us preserve some of the most valuable assets of the Mozilla "
+"Foundation."
 msgstr ""
-"Hal ini berlaku untuk merek dagang Mozilla Foundation juga, termasuk "
-"\"Mozilla\", \"Firefox\", dan \"Tunderbird\". Kebijakan Mozilla tentang "
-"penggunaan merek dagang dirancang untuk melindungi dari kebingungan, dan "
-"mencegah merek dagang diubah karena kurangnya perlindungan; harap "
-"menghormati kebutuhan atas perlindungan semacam ini, dan bantu kami menjaga "
-"sebagian dari aset Mozilla Foundation yang paling berharga."
+"Hal ini berlaku untuk merek dagang Mozilla Foundation juga, termasuk \"Mozilla\", \"Firefox\", dan \"Tunderbird\". Kebijakan Mozilla tentang penggunaan merek dagang dirancang untuk melindungi dari "
+"kebingungan, dan mencegah merek dagang diubah karena kurangnya perlindungan; harap menghormati kebutuhan atas perlindungan semacam ini, dan bantu kami menjaga sebagian dari aset Mozilla Foundation "
+"yang paling berharga."
 
 #: src/olympia/devhub/templates/devhub/docs/policies-submission.html:84
 msgid "Licensing"
@@ -7892,258 +6140,178 @@ msgstr "Melisensi"
 
 #: src/olympia/devhub/templates/devhub/docs/policies-submission.html:86
 msgid ""
-"Selecting an appropriate license for your add-on is a very important step in"
-" the submission process. A license specifies the rights you grant on your "
-"source code and is important in protecting your intellectual property."
+"Selecting an appropriate license for your add-on is a very important step in the submission process. A license specifies the rights you grant on your source code and is important in protecting your "
+"intellectual property."
 msgstr ""
-"Memilih lisensi yang tepat untuk pengaya anda adalah langkah yang sangat "
-"penting dalam proses pendaftaran. Sebuah lisensi merinci hak yang anda "
-"berikan menyangkut kode sumber anda dan ini penting dalam melindungi "
-"properti intelektual."
+"Memilih lisensi yang tepat untuk pengaya anda adalah langkah yang sangat penting dalam proses pendaftaran. Sebuah lisensi merinci hak yang anda berikan menyangkut kode sumber anda dan ini penting "
+"dalam melindungi properti intelektual."
 
 #: src/olympia/devhub/templates/devhub/docs/policies-submission.html:92
 msgid ""
-"During the add-on submission process, you will be presented with a list of "
-"popular licenses to choose from, as well as the ability to specify your own "
-"license. It is best to consult with a legal professional about which license"
-" option is best for you. Choosing the right license for your source code "
-"will help to prevent confusion and code conflicts in the future."
+"During the add-on submission process, you will be presented with a list of popular licenses to choose from, as well as the ability to specify your own license. It is best to consult with a legal "
+"professional about which license option is best for you. Choosing the right license for your source code will help to prevent confusion and code conflicts in the future."
 msgstr ""
-"Saat proses pendaftaran pengaya, anda akan dihadapkan pada daftar lisensi "
-"populer yang bisa dipilih, termasuk kemampuan untuk merinci lisensi anda. "
-"Sebaiknya anda berkonsultasi dengan profesional hukum mengenai pilihan "
-"lisensi yang terbaik untuk anda. Memilih lisensi yang tepat untuk kode "
-"sumber anda akan membantu mencegah kebingungan dan benturan kode di masa "
-"depan."
+"Saat proses pendaftaran pengaya, anda akan dihadapkan pada daftar lisensi populer yang bisa dipilih, termasuk kemampuan untuk merinci lisensi anda. Sebaiknya anda berkonsultasi dengan profesional "
+"hukum mengenai pilihan lisensi yang terbaik untuk anda. Memilih lisensi yang tepat untuk kode sumber anda akan membantu mencegah kebingungan dan benturan kode di masa depan."
 
-#: src/olympia/devhub/templates/devhub/docs/policies.html:12
-#: src/olympia/devhub/templates/devhub/docs/policies.html:52
+#: src/olympia/devhub/templates/devhub/docs/policies.html:12 src/olympia/devhub/templates/devhub/docs/policies.html:52
 msgid "Add-on Submission"
 msgstr "Mendaftarkan Pengaya"
 
-#: src/olympia/devhub/templates/devhub/docs/policies.html:18
-#: src/olympia/devhub/templates/devhub/docs/policies.html:78
+#: src/olympia/devhub/templates/devhub/docs/policies.html:18 src/olympia/devhub/templates/devhub/docs/policies.html:78
 msgid "Maintaining Your Add-on"
 msgstr "Menjaga Pengaya Anda"
 
 #: src/olympia/devhub/templates/devhub/docs/policies.html:43
-msgid ""
-"Mozilla is committed to ensuring a great add-ons experience for our users "
-"and developers. Please review the policies below before submitting your add-"
-"on."
-msgstr ""
-"Mozilla berkomitmen untuk memasrikan pengalaman pengaya yang luar biasa "
-"untuk pengguna dan pengembang. Harap mengulas kebijakan di bawah ini sebelum"
-" mendaftarkan pengaya anda."
+msgid "Mozilla is committed to ensuring a great add-ons experience for our users and developers. Please review the policies below before submitting your add-on."
+msgstr "Mozilla berkomitmen untuk memasrikan pengalaman pengaya yang luar biasa untuk pengguna dan pengembang. Harap mengulas kebijakan di bawah ini sebelum mendaftarkan pengaya anda."
 
 #: src/olympia/devhub/templates/devhub/docs/policies.html:55
-msgid ""
-"Find out what is expected of add-ons we host and our policies on specific "
-"add-on practices."
-msgstr ""
-"Temukan apa yang diharapkan dari pengaya yang kami muat dan kebijakan kami "
-"pada praktek pengaya yang spesifik."
+msgid "Find out what is expected of add-ons we host and our policies on specific add-on practices."
+msgstr "Temukan apa yang diharapkan dari pengaya yang kami muat dan kebijakan kami pada praktek pengaya yang spesifik."
 
 #: src/olympia/devhub/templates/devhub/docs/policies.html:67
-msgid ""
-"What happens after your add-on is submitted? Learn about how our Editors "
-"review submissions."
-msgstr ""
-"Apa yang terjadi setelah pengaya anda dimasukkan? Pelajari bagaimana "
-"Penyunting kami mengulas pendaftaran."
+msgid "What happens after your add-on is submitted? Learn about how our Editors review submissions."
+msgstr "Apa yang terjadi setelah pengaya anda dimasukkan? Pelajari bagaimana Penyunting kami mengulas pendaftaran."
 
 #: src/olympia/devhub/templates/devhub/docs/policies.html:81
-msgid ""
-"Add-on updates, transferring ownership, user reviews, and what to expect "
-"once your add-on is approved."
-msgstr ""
-"Pembaruan pengaya, pengalihan kepemilikan, ulasan pengguna, dan apa yang "
-"dapat diharapkan saat pengaya anda disetujui."
+msgid "Add-on updates, transferring ownership, user reviews, and what to expect once your add-on is approved."
+msgstr "Pembaruan pengaya, pengalihan kepemilikan, ulasan pengguna, dan apa yang dapat diharapkan saat pengaya anda disetujui."
 
 #: src/olympia/devhub/templates/devhub/docs/policies.html:93
-msgid ""
-"How up-and-coming add-ons become featured and what&#039;s involved in the "
-"process."
-msgstr ""
-"Bagaimana pengaya yang sedang naik daun menjadi unggulan dan apa &#039; yang"
-" terjadi dalam proses itu."
+msgid "How up-and-coming add-ons become featured and what&#039;s involved in the process."
+msgstr "Bagaimana pengaya yang sedang naik daun menjadi unggulan dan apa &#039; yang terjadi dalam proses itu."
 
 #: src/olympia/devhub/templates/devhub/docs/policies.html:106
-msgid ""
-"Terms of Service for submitting your work to our site. Developers are "
-"required to accept this agreement before submission."
-msgstr ""
-"Syarat dan Ketentuan untuk memasukkan karya anda ke dalam situs kami. "
-"Pengembang diminta menerima argumen ini sebelum memasukkan."
+msgid "Terms of Service for submitting your work to our site. Developers are required to accept this agreement before submission."
+msgstr "Syarat dan Ketentuan untuk memasukkan karya anda ke dalam situs kami. Pengembang diminta menerima argumen ini sebelum memasukkan."
 
 #: src/olympia/devhub/templates/devhub/docs/policies.html:118
 msgid "How to get in touch with us regarding these policies or your add-on."
-msgstr ""
-"Bagaimana cara berhubungan dengan kami menyangkut kebijakan ini atau pengaya"
-" anda."
+msgstr "Bagaimana cara berhubungan dengan kami menyangkut kebijakan ini atau pengaya anda."
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:6
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:10
 msgid "You have disabled this add-on"
 msgstr "Anda telah melumpuhkan pengaya ini"
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:20
-msgid ""
-"Your add-on's listing is disabled and is not showing\n"
-"                             anywhere in our gallery or update service."
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:24
+msgid "Your add-on's listing is disabled and is not showing anywhere in our gallery or update service."
 msgstr ""
 "Daftar pengaya anda sedang dimatikan dan tidak bisa dilihat\n"
 "                             di manapun di galeri kami atau layanan pembaruan."
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:25
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:27
 msgid "Please complete your add-on."
 msgstr "Silahkan lengkapi pengaya Anda."
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:29
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:30
 msgid "You will receive an email when the review is complete."
 msgstr "Anda akan menerima surel setelah peninjauan selesai."
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:34
-msgid ""
-"You will receive an email when the review is complete. Until\n"
-"                             then, your add-on is not listed in our gallery but can be\n"
-"                             accessed directly from its details page."
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:33
+msgid "You will receive an email when the review is complete. Until then, your add-on is not listed in our gallery but can be accessed directly from its details page."
 msgstr ""
 "Anda akan menerima surel saat ulasan telah lengkap. Hingga\n"
 "                             saat itu, pengaya anda tidak terdaftar di galeri kami tapi bisa \n"
 "                             diakses secara langsung dari laman rinciannya."
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:38
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:48
-msgid ""
-"You will receive an email when the review is\n"
-"                             complete and your add-on is signed."
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:37 src/olympia/devhub/templates/devhub/includes/addon_details.html:45
+msgid "You will receive an email when the review is complete and your add-on is signed."
 msgstr ""
 "Anda akan menerima surel saat ulasan telah\n"
 "                             lengkap dan pengaya anda ditandatangani."
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:44
-msgid ""
-"You will receive an email when the review is complete. Until\n"
-"                             then, your add-on is not listed in our gallery but can be\n"
-"                             accessed directly from its details page. "
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:41
+msgid "You will receive an email when the review is complete. Until then, your add-on is not listed in our gallery but can be accessed directly from its details page. "
 msgstr ""
-"Anda akan menerima surel jika ulasan telah lengkap. Hingga\n"
-"                             saat itu pengaya anda tidak terdaftar dalam galeri kami tapi bisa\n"
-"                             diakses secara langsung dari laman rinciannya. "
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:54
-msgid ""
-"Your add-on is displayed in our gallery and users are\n"
-"                             receiving automatic updates."
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:49
+msgid "Your add-on is displayed in our gallery and users are receiving automatic updates."
 msgstr ""
 "Pengaya ditampilkan di galeri kami dan pengguna bisa\n"
 "                             menerima pembaruan otomatis."
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:57
-msgid ""
-"Your add-on has been signed and can be bundled with an\n"
-"                             application installer."
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:52
+msgid "Your add-on has been signed and can be bundled with an application installer."
 msgstr ""
 "Pengaya anda telah ditandatangani dan bisa dibundel dengan sebuah\n"
 "                             instalator aplikasi."
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:63
-msgid ""
-"Your add-on was disabled by a site administrator and is no\n"
-"                             longer shown in our gallery. If you have any questions,\n"
-"                             please email amo-admins@mozilla.org."
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:56
+msgid "Your add-on was disabled by a site administrator and is no longer shown in our gallery. If you have any questions, please email amo-admins@mozilla.org."
 msgstr ""
 "Pengaya anda dimatikan oleh administrator situs dan tidak\n"
 "                             lagi ditampilkan dalam galeri kami. Jika anda memiliki pertanyaan,\n"
 "                             silakan menghubungi amo-admins@mozilla.org."
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:70
-msgid ""
-"Your add-on is displayed in our gallery as experimental\n"
-"                             and users are receiving automatic updates. Some features\n"
-"                             are unavailable to your add-on."
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:62
+msgid "Your add-on is displayed in our gallery as experimental and users are receiving automatic updates. Some features are unavailable to your add-on."
 msgstr ""
 "Pengaya anda ditampilkan di galeri kami sebagai eksperimental\n"
 "                             dan pengguna menerima pembaruan otomatis. Sejumlah fitur\n"
 "                             tidak tersedia untuk pengaya anda."
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:74
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:66
 msgid "Your add-on has been signed."
 msgstr "Pengaya anda telah ditandai."
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:79
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:69
 msgid ""
-"You will receive an email when the full review is complete.\n"
-"                             Until then, your add-on is displayed in our gallery as\n"
-"                             experimental and users are receiving automatic updates.\n"
-"                             Some features are unavailable to your add-on."
+"You will receive an email when the full review is complete. Until then, your add-on is displayed in our gallery as experimental and users are receiving automatic updates. Some features are "
+"unavailable to your add-on."
 msgstr ""
 "Anda akan menerima surel jika ulasan lengkap sudah selesai.\n"
 "                             Hingga saat itu, pengaya anda ditampilkan dalam galeri kami sebagai\n"
 "                             eksperimental dan pengguna menerima pembaruan otomatis.\n"
 "                             Sejumlah fitur tidak tersedia untuk pengaya anda."
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:84
-msgid ""
-"You will receive an email when the full review is\n"
-"                             complete, making you able to bundle your add-on with an\n"
-"                             application installer."
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:74
+msgid "You will receive an email when the full review is complete, making you able to bundle your add-on with an application installer."
 msgstr ""
 "Anda akan menerima surel saat ulasan lengkap telah\n"
 "                             selesai, membuat anda bisa membundel pengaya anda dengan sebuah\n"
 "                             instalator aplikasi."
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:91
-msgid ""
-"All add-ons hosted in our gallery must now be reviewed by an\n"
-"                             editor. If you wish to continue hosting your add-on, please\n"
-"                             click to select a review process."
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:79
+msgid "All add-ons hosted in our gallery must now be reviewed by an editor. If you wish to continue hosting your add-on, please click to select a review process."
 msgstr ""
 "Semua pengaya yang dimuat di galeri kami kini harus diulas oleh seorang\n"
 "                             penyunting. Jika anda ingin pengaya anda terus dimuat, harap\n"
 "                             klik untuk memilih proses pengulasan."
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:113
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:100
 msgid "Current Version:"
 msgstr "Versi Terkini:"
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:115
-msgid ""
-"This is the version of your add-on that will\n"
-"                                           be installed if someone clicks the Install\n"
-"                                           button on addons.mozilla.org. It is only\n"
-"                                           relevant for listed add-ons."
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:102
+msgid "This is the version of your add-on that will be installed if someone clicks the Install button on addons.mozilla.org. It is only relevant for listed add-ons."
 msgstr ""
 "Ini adalah versi pengaya anda yang akan\n"
 "                                           dipasang jika seseorang mengklik tombol\n"
 "                                           Pasang di addons.mozilla.org. Hanya relevan\n"
 "                                           untuk pengaya yang terdaftar."
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:123
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:110
 msgid "Created:"
 msgstr "Dibuat:"
 
 #. {0} is a date. dennis-ignore: E201
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:125
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:131
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:112 src/olympia/devhub/templates/devhub/includes/addon_details.html:118
 #, python-format
 msgid "%%b %%e, %%Y"
 msgstr "%%b %%e, %%Y"
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:136
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:123
 msgid "Next Version:"
 msgstr "Versi Berikutnya:"
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:138
-msgid ""
-"This is the newest uploaded version, however\n"
-"                                           it isn’t live on the site yet."
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:125
+msgid "This is the newest uploaded version, however it isn’t live on the site yet."
 msgstr ""
 "Ini adalah versi terbaru yang sudah diunggah, namun\n"
 "                                          ini belum ditampilkan di situs."
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:144
-#: src/olympia/devhub/templates/devhub/versions/list.html:30
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:130 src/olympia/devhub/templates/devhub/versions/list.html:30
 msgid "Queues are not reviewed strictly in order"
 msgstr "Antrean tidak ditinjau secara ketat dalam urutan"
 
@@ -8161,15 +6329,11 @@ msgstr "Membuat Profil Pengembang"
 
 #: src/olympia/devhub/templates/devhub/includes/addons_create_profile.html:24
 msgid ""
-"Your developer profile will tell users about you, why you made this add-on, "
-"and what's next for the add-on. This profile is required for add-ons "
-"requesting contributions, but can be useful for any developer interested in "
-"connecting with users."
+"Your developer profile will tell users about you, why you made this add-on, and what's next for the add-on. This profile is required for add-ons requesting contributions, but can be useful for any "
+"developer interested in connecting with users."
 msgstr ""
-"Profil pengembang anda akan mengatakan pada pengguna mengenai anda, mengapa "
-"anda membuat pengaya ini, dan apa yang akan dilakukan berikutnya untuk "
-"pengaya. Profil ini memerlukan permintaan kontribusi pengaya, namun bisa "
-"berguna untuk setiap pengembang yang tertarik berhubungan dengan pengguna."
+"Profil pengembang anda akan mengatakan pada pengguna mengenai anda, mengapa anda membuat pengaya ini, dan apa yang akan dilakukan berikutnya untuk pengaya. Profil ini memerlukan permintaan "
+"kontribusi pengaya, namun bisa berguna untuk setiap pengembang yang tertarik berhubungan dengan pengguna."
 
 #: src/olympia/devhub/templates/devhub/includes/addons_create_profile.html:32
 msgid "Make sure your user profile is up to date."
@@ -8178,24 +6342,15 @@ msgstr "Memastikan profil anda terbarukan."
 #: src/olympia/devhub/templates/devhub/includes/addons_create_profile.html:34
 #, python-format
 msgid "<a href=\"%(url)s\"><strong>Update your user profile.</strong></a>"
-msgstr ""
-"<a href=\"%(url)s\"><strong>Memperbarui profil pengguna anda.</strong></a>"
+msgstr "<a href=\"%(url)s\"><strong>Memperbarui profil pengguna anda.</strong></a>"
 
 #: src/olympia/devhub/templates/devhub/includes/addons_create_profile.html:45
-msgid ""
-"Whether it was an idea while in line at the grocery store or the solution to"
-" one of life's great problems, share your story."
-msgstr ""
-"Apakah itu hanya ide saat mengantre di toko kelontong atau solusi untuk "
-"persoalan besar dalam hidup seseorang, bagikan cerita anda."
+msgid "Whether it was an idea while in line at the grocery store or the solution to one of life's great problems, share your story."
+msgstr "Apakah itu hanya ide saat mengantre di toko kelontong atau solusi untuk persoalan besar dalam hidup seseorang, bagikan cerita anda."
 
 #: src/olympia/devhub/templates/devhub/includes/addons_create_profile.html:61
-msgid ""
-"Telling your users what's coming soon will give them something to look "
-"forward to."
-msgstr ""
-"Menyampaikan pada pengguna apa yang akan muncul dalam waktu dekat akan "
-"memberi mereka sesuatu untuk ditunggu."
+msgid "Telling your users what's coming soon will give them something to look forward to."
+msgstr "Menyampaikan pada pengguna apa yang akan muncul dalam waktu dekat akan memberi mereka sesuatu untuk ditunggu."
 
 #: src/olympia/devhub/templates/devhub/includes/addons_edit_nav.html:23
 msgid "View All"
@@ -8226,9 +6381,7 @@ msgid "View the blog &#9658;"
 msgstr "Lihat blog &#9658;"
 
 #: src/olympia/devhub/templates/devhub/includes/license_form.html:6
-msgid ""
-"Please choose a license appropriate for the rights you grant on your source code.\n"
-"                  It is only relevant for listed add-ons."
+msgid "Please choose a license appropriate for the rights you grant on your source code. It is only relevant for listed add-ons."
 msgstr ""
 "Harap memilih lisensi yang tepat bagi hak yang ingin anda berikan untuk kode sumber anda.\n"
 "                  Hanya relevan untuk pengaya yang terdaftar."
@@ -8246,49 +6399,37 @@ msgstr "Beberapa markah HTML didukung."
 msgid "Remove this application"
 msgstr "Hapus aplikasi ini"
 
-#. {0} is the maximum number of add-on categories allowed.                {1}
-#. is
+#. {0} is the maximum number of add-on categories allowed.                {1} is
 #. the application name.
 #: src/olympia/devhub/templates/devhub/includes/macros.html:70
 msgid "Select <b>up to {0}</b> {1} category for this add-on:"
 msgid_plural "Select <b>up to {0}</b> {1} categories for this add-on:"
 msgstr[0] "Pilih <b>hingga {0}</b> {1} kategori untuk pengaya ini:"
+msgstr[1] ""
 
 #: src/olympia/devhub/templates/devhub/includes/policy_form.html:4
 msgid ""
-"Users will be required to accept the following End-User License Agreement (EULA) prior to installing your add-on. The presence of a EULA significantly affects the number of downloads an add-on receives. Please note that a EULA is not the same as a code license, such as the GPL or MPL.\n"
-"                It is only relevant for listed add-ons."
+"Users will be required to accept the following End-User License Agreement (EULA) prior to installing your add-on. The presence of a EULA significantly affects the number of downloads an add-on "
+"receives. Please note that a EULA is not the same as a code license, such as the GPL or MPL.It is only relevant for listed add-ons."
 msgstr ""
-"Pengguna akan diminta menerima Kesepakatan Lisensi Pengguna (EULA) sebelum memasang pengaya anda. Keberadaan EULA secara signifikan mempengaruhi jumlah unduhan yang diterima pengaya. Harap dicatat bahwa EULA tidak sama dengan kode lisensi, misalnya GPL atau MPL.\n"
-"                Hanya relevan untuk pengaya yang terdaftar."
 
-#: src/olympia/devhub/templates/devhub/includes/policy_form.html:21
-msgid ""
-"If your add-on transmits any data from the user's computer, a privacy policy is required that explains what data is sent and how it is used.\n"
-"                It is only relevant for listed add-ons."
+#: src/olympia/devhub/templates/devhub/includes/policy_form.html:24
+msgid "If your add-on transmits any data from the user's computer, a privacy policy is required that explains what data is sent and how it is used. It is only relevant for listed add-ons."
 msgstr ""
 "Jika pengaya anda memancarkan data apapun dari komputer pengguna, diperlukan sebuah kebijakan privasi yang menjelaskan data apa yang dikirim dan bagaimana itu digunakan.\n"
 "                Hanya relevan untuk pengaya yang terdaftar."
 
 #: src/olympia/devhub/templates/devhub/includes/source_form_field.html:2
-msgid ""
-"If your add-on contains binary or obfuscated code other than known "
-"libraries, upload its sources for review."
-msgstr ""
-"Jika pengaya anda mengandung kode biner atau kode yang dikaburkan selain "
-"pustaka yang diketahui, unggah sumbernya untuk ulasan."
+msgid "If your add-on contains binary or obfuscated code other than known libraries, upload its sources for review."
+msgstr "Jika pengaya anda mengandung kode biner atau kode yang dikaburkan selain pustaka yang diketahui, unggah sumbernya untuk ulasan."
 
 #: src/olympia/devhub/templates/devhub/includes/source_form_field.html:3
 msgid "Read more about the source code review policy."
 msgstr "Baca lebih lanjut mengenai kebijakan mengulas kode sumber."
 
 #: src/olympia/devhub/templates/devhub/includes/version_file.html:20
-msgid ""
-"You cannot remove an individual file after the review process has begun. You"
-" must delete the entire version."
-msgstr ""
-"Anda tidak bisa menghapus berkas individu setelah proses ulasan dimulai. "
-"Anda harus menghapus seluruh versi."
+msgid "You cannot remove an individual file after the review process has begun. You must delete the entire version."
+msgstr "Anda tidak bisa menghapus berkas individu setelah proses ulasan dimulai. Anda harus menghapus seluruh versi."
 
 #: src/olympia/devhub/templates/devhub/includes/version_file.html:36
 msgid "This file will be deleted on save."
@@ -8316,29 +6457,20 @@ msgid "Voluntary Contributions"
 msgstr "Kontribusi Sukarela"
 
 #: src/olympia/devhub/templates/devhub/payments/payments.html:38
-msgid ""
-"Add-ons enrolled in our contributions program can request voluntary "
-"financial support from users."
-msgstr ""
-"Pengaya yang dimasukkan ke dalam program kontribusi bisa meminta dukungan "
-"finansial sukarela dari pengguna."
+msgid "Add-ons enrolled in our contributions program can request voluntary financial support from users."
+msgstr "Pengaya yang dimasukkan ke dalam program kontribusi bisa meminta dukungan finansial sukarela dari pengguna."
 
 #: src/olympia/devhub/templates/devhub/payments/payments.html:40
 msgid "Encourage users to support your add-on through your Developer Profile"
-msgstr ""
-"Mendorong pengguna untuk mendukung pengaya anda melalui Profil Pengembang"
+msgstr "Mendorong pengguna untuk mendukung pengaya anda melalui Profil Pengembang"
 
 #: src/olympia/devhub/templates/devhub/payments/payments.html:41
 msgid "Choose when and how users are asked to contribute"
 msgstr "Pilih kapan dan bagaimana pengguna diminta untuk berkontribusi"
 
 #: src/olympia/devhub/templates/devhub/payments/payments.html:42
-msgid ""
-"Receive contributions in your PayPal account or send them to an organization"
-" of your choice"
-msgstr ""
-"Menerima kontribusi melalui akun PayPal anda atau mengirimkannya ke lembaga "
-"pilihan anda"
+msgid "Receive contributions in your PayPal account or send them to an organization of your choice"
+msgstr "Menerima kontribusi melalui akun PayPal anda atau mengirimkannya ke lembaga pilihan anda"
 
 #: src/olympia/devhub/templates/devhub/payments/payments.html:46
 msgid "Contributions are only available for listed add-ons."
@@ -8346,19 +6478,14 @@ msgstr "Kontribusi hanya tersedia bagi pengaya terdaftar."
 
 #: src/olympia/devhub/templates/devhub/payments/payments.html:53
 #, python-format
-msgid ""
-"Contributions are only available for add-ons with a <a "
-"href=\"%(url)s\">completed developer profile</a>."
-msgstr ""
-"Kontribusi hanya tersedia untuk pengaya dengan <a href=\"%(url)s\">profil "
-"pengembang yang lengkap</a>."
+msgid "Contributions are only available for add-ons with a <a href=\"%(url)s\">completed developer profile</a>."
+msgstr "Kontribusi hanya tersedia untuk pengaya dengan <a href=\"%(url)s\">profil pengembang yang lengkap</a>."
 
 #: src/olympia/devhub/templates/devhub/payments/payments.html:59
 msgid "Contributions are only available for fully reviewed add-ons."
 msgstr "Kontribusi hanya tersedia bagi pengaya yang sudah diulas lengkap."
 
-#: src/olympia/devhub/templates/devhub/payments/payments.html:65
-#: src/olympia/devhub/templates/devhub/payments/voluntary.html:2
+#: src/olympia/devhub/templates/devhub/payments/payments.html:65 src/olympia/devhub/templates/devhub/payments/voluntary.html:2
 msgid "Set up Contributions"
 msgstr "Menetapkan Kontribusi"
 
@@ -8371,18 +6498,13 @@ msgstr "Langkah 2. Harga dan Ketersediaan"
 msgid "or <a href=\"%(cancel)s\">Cancel</a>"
 msgstr "or <a href=\"%(cancel)s\">Batal</a>"
 
-#: src/olympia/devhub/templates/devhub/payments/voluntary.html:2
-#: src/olympia/stats/templates/stats/addon_report_menu.html:39
+#: src/olympia/devhub/templates/devhub/payments/voluntary.html:2 src/olympia/stats/templates/stats/addon_report_menu.html:39
 msgid "Contributions"
 msgstr "Sumbangan"
 
 #: src/olympia/devhub/templates/devhub/payments/voluntary.html:3
-msgid ""
-"Fill in the fields below to begin asking for voluntary contributions from "
-"users."
-msgstr ""
-"Isi kolom di bawah ini untuk mulai meminta kontribusi sukarela dari para "
-"pengguna."
+msgid "Fill in the fields below to begin asking for voluntary contributions from users."
+msgstr "Isi kolom di bawah ini untuk mulai meminta kontribusi sukarela dari para pengguna."
 
 #: src/olympia/devhub/templates/devhub/payments/voluntary.html:11
 msgid "Who will receive contributions to this add-on?"
@@ -8425,23 +6547,16 @@ msgid "Send a thank-you note?"
 msgstr "Sampaikan catatan terima-kasih?"
 
 #: src/olympia/devhub/templates/devhub/payments/voluntary.html:47
-msgid ""
-"We'll automatically email users who contribute to your add-on with this "
-"message."
-msgstr ""
-"Kami akan mengiri surel secara otomatis ke pengguna yang berkontribusi ke "
-"pengaya Anda dengan pesan ini."
+msgid "We'll automatically email users who contribute to your add-on with this message."
+msgstr "Kami akan mengiri surel secara otomatis ke pengguna yang berkontribusi ke pengaya Anda dengan pesan ini."
 
 #: src/olympia/devhub/templates/devhub/payments/voluntary.html:49
 msgid ""
-"We recommend thanking the user and telling them how much you appreciate "
-"their support. You might also want to tell them about what's next for your "
-"add-on and about any other add-ons you've made for them to try."
+"We recommend thanking the user and telling them how much you appreciate their support. You might also want to tell them about what's next for your add-on and about any other add-ons you've made for "
+"them to try."
 msgstr ""
-"Kami merekomendasikan untuk berterima kasih pada pengguna dan mengatakan "
-"pada mereka betapa anda menghargai dukungan mereka. Anda mungkin juga ingin "
-"mengatakan pada mereka apa langkah selanjutnya untuk pengaya anda dan "
-"tentang pengaya lain yang anda minta mereka coba."
+"Kami merekomendasikan untuk berterima kasih pada pengguna dan mengatakan pada mereka betapa anda menghargai dukungan mereka. Anda mungkin juga ingin mengatakan pada mereka apa langkah selanjutnya "
+"untuk pengaya anda dan tentang pengaya lain yang anda minta mereka coba."
 
 #: src/olympia/devhub/templates/devhub/payments/voluntary.html:64
 msgid "Activate Contributions"
@@ -8455,156 +6570,99 @@ msgstr "atau <a id=\"setup-cancel\" href=\"#\">Batal</a>"
 msgid "Transfer ownership"
 msgstr "Pengalihan kepemilikan"
 
-#: src/olympia/devhub/templates/devhub/personas/edit.html:77
-#: src/olympia/devhub/templates/devhub/personas/submit.html:31
+#: src/olympia/devhub/templates/devhub/personas/edit.html:77 src/olympia/devhub/templates/devhub/personas/submit.html:31
 msgid "Theme Details"
 msgstr "Detil Tema"
 
-#: src/olympia/devhub/templates/devhub/personas/edit.html:87
-#: src/olympia/devhub/templates/devhub/personas/submit.html:36
+#: src/olympia/devhub/templates/devhub/personas/edit.html:87 src/olympia/devhub/templates/devhub/personas/submit.html:36
 msgid "Supply a pretty URL for your detail page."
 msgstr "Berikan URL yang cantik untuk laman rincian anda."
 
-#: src/olympia/devhub/templates/devhub/personas/edit.html:92
-#: src/olympia/devhub/templates/devhub/personas/submit.html:41
+#: src/olympia/devhub/templates/devhub/personas/edit.html:92 src/olympia/devhub/templates/devhub/personas/submit.html:41
 msgid "Select the category that best describes your Theme."
 msgstr "Pilih kategori yang paling tepat menggambarkan Tema anda."
 
-#: src/olympia/devhub/templates/devhub/personas/edit.html:95
-#: src/olympia/devhub/templates/devhub/personas/submit.html:44
+#: src/olympia/devhub/templates/devhub/personas/edit.html:95 src/olympia/devhub/templates/devhub/personas/submit.html:44
 msgid "Add some tags to describe your Theme."
 msgstr "Tambahkan beberapa tag untuk mendeskripsikan Tema anda."
 
-#: src/olympia/devhub/templates/devhub/personas/edit.html:106
-msgid ""
-"A short explanation of your theme's\n"
-"                                basic functionality that is displayed in\n"
-"                                search and browse listings, as well as at\n"
-"                                the top of your theme's details page."
+#: src/olympia/devhub/templates/devhub/personas/edit.html:106 src/olympia/devhub/templates/devhub/personas/submit.html:54
+msgid "A short explanation of your theme's basic functionality that is displayed in search and browse listings, as well as at the top of your theme's details page."
 msgstr ""
 "Penjelasan pendek atas tema anda\n"
 "                                fungsi dasar yang ditampilkan di\n"
 "                                daftar pencarian dan penelusuran, termasuk di\n"
 "                                bagian atas laman rincian tema anda."
 
-#: src/olympia/devhub/templates/devhub/personas/edit.html:122
-#: src/olympia/devhub/templates/devhub/personas/submit.html:68
+#: src/olympia/devhub/templates/devhub/personas/edit.html:122 src/olympia/devhub/templates/devhub/personas/submit.html:68
 msgid "Theme License"
 msgstr "Lisensi Tema"
 
-#: src/olympia/devhub/templates/devhub/personas/edit.html:126
-#: src/olympia/devhub/templates/devhub/personas/submit.html:72
+#: src/olympia/devhub/templates/devhub/personas/edit.html:126 src/olympia/devhub/templates/devhub/personas/submit.html:72
 msgid "Can others share your Theme, as long as you're given credit?"
-msgstr ""
-"Dapatkah orang lain membagikan Tema anda, asalkan anda diberi kreditasi?"
+msgstr "Dapatkah orang lain membagikan Tema anda, asalkan anda diberi kreditasi?"
 
-#: src/olympia/devhub/templates/devhub/personas/edit.html:132
-#: src/olympia/devhub/templates/devhub/personas/edit.html:153
-#: src/olympia/devhub/templates/devhub/personas/submit.html:78
+#: src/olympia/devhub/templates/devhub/personas/edit.html:132 src/olympia/devhub/templates/devhub/personas/edit.html:153 src/olympia/devhub/templates/devhub/personas/submit.html:78
 #: src/olympia/devhub/templates/devhub/personas/submit.html:99
-msgid ""
-"The licensor permits others to copy, distribute, display, and perform the "
-"work, including for commercial purposes."
-msgstr ""
-"Pemberi lisensi mengizinkan orang lain untuk menyalin, mendistribusikan, "
-"memajang dan menampilkan karya, termasuk untuk tujuan komersial."
+msgid "The licensor permits others to copy, distribute, display, and perform the work, including for commercial purposes."
+msgstr "Pemberi lisensi mengizinkan orang lain untuk menyalin, mendistribusikan, memajang dan menampilkan karya, termasuk untuk tujuan komersial."
 
-#: src/olympia/devhub/templates/devhub/personas/edit.html:141
-#: src/olympia/devhub/templates/devhub/personas/edit.html:162
-#: src/olympia/devhub/templates/devhub/personas/submit.html:87
+#: src/olympia/devhub/templates/devhub/personas/edit.html:141 src/olympia/devhub/templates/devhub/personas/edit.html:162 src/olympia/devhub/templates/devhub/personas/submit.html:87
 #: src/olympia/devhub/templates/devhub/personas/submit.html:108
-msgid ""
-"The licensor permits others to copy, distribute, display, and perform the "
-"work for non-commercial purposes only."
-msgstr ""
-"Pemberi lisensi mengizinkan orang lain untuk menyalin, mendistribusikan, "
-"memajang dan menampilkan karya untuk tujuan non-komersial saja."
+msgid "The licensor permits others to copy, distribute, display, and perform the work for non-commercial purposes only."
+msgstr "Pemberi lisensi mengizinkan orang lain untuk menyalin, mendistribusikan, memajang dan menampilkan karya untuk tujuan non-komersial saja."
 
-#: src/olympia/devhub/templates/devhub/personas/edit.html:147
-#: src/olympia/devhub/templates/devhub/personas/submit.html:93
+#: src/olympia/devhub/templates/devhub/personas/edit.html:147 src/olympia/devhub/templates/devhub/personas/submit.html:93
 msgid "Can others make commercial use of your Theme?"
 msgstr "Bisakah orang lain menggunakan Tema anda secara komersial?"
 
-#: src/olympia/devhub/templates/devhub/personas/edit.html:168
-#: src/olympia/devhub/templates/devhub/personas/submit.html:114
+#: src/olympia/devhub/templates/devhub/personas/edit.html:168 src/olympia/devhub/templates/devhub/personas/submit.html:114
 msgid "Can others create derivative works from your Theme?"
 msgstr "Dapatkah orang lain membuat karya derivatif dari Tema anda?"
 
-#: src/olympia/devhub/templates/devhub/personas/edit.html:174
-#: src/olympia/devhub/templates/devhub/personas/submit.html:120
-msgid ""
-"The licensor permits others to copy, distribute, display and perform the "
-"work, as well as make derivative works based on it."
-msgstr ""
-"Pemberi lisensi mengizinkan orang lain untuk menyalin, mendistribusikan, "
-"memajang dan menampilkan karya, termasuk membuat karya turunan berdasarkan "
-"itu."
+#: src/olympia/devhub/templates/devhub/personas/edit.html:174 src/olympia/devhub/templates/devhub/personas/submit.html:120
+msgid "The licensor permits others to copy, distribute, display and perform the work, as well as make derivative works based on it."
+msgstr "Pemberi lisensi mengizinkan orang lain untuk menyalin, mendistribusikan, memajang dan menampilkan karya, termasuk membuat karya turunan berdasarkan itu."
 
-#: src/olympia/devhub/templates/devhub/personas/edit.html:182
-#: src/olympia/devhub/templates/devhub/personas/submit.html:128
+#: src/olympia/devhub/templates/devhub/personas/edit.html:182 src/olympia/devhub/templates/devhub/personas/submit.html:128
 msgid "Yes, as long as they share alike"
 msgstr "Iya, sepanjang yang mereka bagi mirip"
 
-#: src/olympia/devhub/templates/devhub/personas/edit.html:183
-#: src/olympia/devhub/templates/devhub/personas/submit.html:129
-msgid ""
-"The licensor permits others to distribute derivativeworks only under the "
-"same license or one compatible with the one that governs the licensor's "
-"work."
-msgstr ""
-"Pemberi lisensi mengizinkan orang lain untuk mendistribusikan karya turunan "
-"hanya di bawah lisensi yang sama atau yang cocok dengan yang mengatur karya "
-"pemberi lisensi."
+#: src/olympia/devhub/templates/devhub/personas/edit.html:183 src/olympia/devhub/templates/devhub/personas/submit.html:129
+msgid "The licensor permits others to distribute derivativeworks only under the same license or one compatible with the one that governs the licensor's work."
+msgstr "Pemberi lisensi mengizinkan orang lain untuk mendistribusikan karya turunan hanya di bawah lisensi yang sama atau yang cocok dengan yang mengatur karya pemberi lisensi."
 
-#: src/olympia/devhub/templates/devhub/personas/edit.html:192
-#: src/olympia/devhub/templates/devhub/personas/submit.html:138
-msgid ""
-"The licensor permits others to copy, distribute and transmit only unaltered "
-"copies of the work — not derivative works based on it."
-msgstr ""
-"Pemberi lisensi mengizinkan orang lain untuk menyalin, mendistribusikan dan "
-"memancarkan hanya salinan yang belum diubah dari karya — bukan karya turunan"
-" berdasarkan itu."
+#: src/olympia/devhub/templates/devhub/personas/edit.html:192 src/olympia/devhub/templates/devhub/personas/submit.html:138
+msgid "The licensor permits others to copy, distribute and transmit only unaltered copies of the work — not derivative works based on it."
+msgstr "Pemberi lisensi mengizinkan orang lain untuk menyalin, mendistribusikan dan memancarkan hanya salinan yang belum diubah dari karya — bukan karya turunan berdasarkan itu."
 
-#: src/olympia/devhub/templates/devhub/personas/edit.html:199
-#: src/olympia/devhub/templates/devhub/personas/submit.html:145
+#: src/olympia/devhub/templates/devhub/personas/edit.html:199 src/olympia/devhub/templates/devhub/personas/submit.html:145
 msgid "Your Theme will be released under the following license:"
 msgstr "Tema anda akan dirilis di bawah lisensi berikut:"
 
-#: src/olympia/devhub/templates/devhub/personas/edit.html:202
-#: src/olympia/devhub/templates/devhub/personas/submit.html:148
+#: src/olympia/devhub/templates/devhub/personas/edit.html:202 src/olympia/devhub/templates/devhub/personas/submit.html:148
 msgid "Select a different license."
 msgstr "Pilih lisensi yang berbeda."
 
-#: src/olympia/devhub/templates/devhub/personas/edit.html:207
-#: src/olympia/devhub/templates/devhub/personas/submit.html:153
+#: src/olympia/devhub/templates/devhub/personas/edit.html:207 src/olympia/devhub/templates/devhub/personas/submit.html:153
 msgid "Select a license for your Theme."
 msgstr "Pilih lisensi untuk Tema anda."
 
-#: src/olympia/devhub/templates/devhub/personas/edit.html:217
-#: src/olympia/devhub/templates/devhub/personas/submit.html:163
+#: src/olympia/devhub/templates/devhub/personas/edit.html:217 src/olympia/devhub/templates/devhub/personas/submit.html:163
 msgid "Theme Design"
 msgstr "Desain Tema"
 
-#: src/olympia/devhub/templates/devhub/personas/edit.html:221
-#: src/olympia/devhub/templates/devhub/personas/edit.html:224
+#: src/olympia/devhub/templates/devhub/personas/edit.html:221 src/olympia/devhub/templates/devhub/personas/edit.html:224
 msgid "Upload New Design"
 msgstr "Unggah Desain Baru"
 
 #: src/olympia/devhub/templates/devhub/personas/edit.html:226
-msgid ""
-"Upon upload and form submission, the AMO Team will review your updated "
-"design. Your current design will still be public in the meantime."
-msgstr ""
-"Setelah mengunggah dan melakukan pendaftaran, tim AMO akan mengulas "
-"rancangan anda yang diperbarui. Rancangan saat ini akan bisa ditampilkan di "
-"publik sementara waktu."
+msgid "Upon upload and form submission, the AMO Team will review your updated design. Your current design will still be public in the meantime."
+msgstr "Setelah mengunggah dan melakukan pendaftaran, tim AMO akan mengulas rancangan anda yang diperbarui. Rancangan saat ini akan bisa ditampilkan di publik sementara waktu."
 
 #: src/olympia/devhub/templates/devhub/personas/edit.html:241
-msgid "Your previously resubmitted design,  which is under pending review."
-msgstr ""
-"Rancangan yang anda masukkan ulang sebelumnya,  yang masih ditunda "
-"ulasannya."
+msgid "Your previously resubmitted design, which is under pending review."
+msgstr "Rancangan yang anda masukkan ulang sebelumnya,  yang masih ditunda ulasannya."
 
 #: src/olympia/devhub/templates/devhub/personas/edit.html:245
 msgid "Pending Header"
@@ -8626,43 +6684,35 @@ msgstr "Judul"
 msgid "Footer"
 msgstr "Catatan Kaki"
 
-#: src/olympia/devhub/templates/devhub/personas/edit.html:274
-#: src/olympia/devhub/templates/devhub/personas/submit.html:167
+#: src/olympia/devhub/templates/devhub/personas/edit.html:274 src/olympia/devhub/templates/devhub/personas/submit.html:167
 msgid "Select colors for your Theme."
 msgstr "Pilih warna untuk Tema anda."
 
-#: src/olympia/devhub/templates/devhub/personas/edit.html:276
-#: src/olympia/devhub/templates/devhub/personas/submit.html:169
+#: src/olympia/devhub/templates/devhub/personas/edit.html:276 src/olympia/devhub/templates/devhub/personas/submit.html:169
 msgid "Foreground Text"
 msgstr "Teks Latar depan"
 
-#: src/olympia/devhub/templates/devhub/personas/edit.html:277
-#: src/olympia/devhub/templates/devhub/personas/submit.html:170
+#: src/olympia/devhub/templates/devhub/personas/edit.html:277 src/olympia/devhub/templates/devhub/personas/submit.html:170
 msgid "This is the color of the tab text."
 msgstr "Ini adalah warna tab teks."
 
-#: src/olympia/devhub/templates/devhub/personas/edit.html:279
-#: src/olympia/devhub/templates/devhub/personas/submit.html:172
+#: src/olympia/devhub/templates/devhub/personas/edit.html:279 src/olympia/devhub/templates/devhub/personas/submit.html:172
 msgid "Background"
 msgstr "Latar Belakang"
 
-#: src/olympia/devhub/templates/devhub/personas/edit.html:280
-#: src/olympia/devhub/templates/devhub/personas/submit.html:173
+#: src/olympia/devhub/templates/devhub/personas/edit.html:280 src/olympia/devhub/templates/devhub/personas/submit.html:173
 msgid "This is the color of the tabs."
 msgstr "Ini adalah warna tab teks."
 
-#: src/olympia/devhub/templates/devhub/personas/edit.html:285
-#: src/olympia/devhub/templates/devhub/personas/submit.html:178
+#: src/olympia/devhub/templates/devhub/personas/edit.html:285 src/olympia/devhub/templates/devhub/personas/submit.html:178
 msgid "Preview"
 msgstr "Pratinjau"
 
-#: src/olympia/devhub/templates/devhub/personas/edit.html:291
-#: src/olympia/devhub/templates/devhub/personas/submit.html:183
+#: src/olympia/devhub/templates/devhub/personas/edit.html:291 src/olympia/devhub/templates/devhub/personas/submit.html:183
 msgid "Your Theme's Name"
 msgstr "Nama Tema Anda"
 
-#: src/olympia/devhub/templates/devhub/personas/edit.html:294
-#: src/olympia/devhub/templates/devhub/personas/submit.html:186
+#: src/olympia/devhub/templates/devhub/personas/edit.html:294 src/olympia/devhub/templates/devhub/personas/submit.html:186
 #, python-format
 msgid "by <a href=\"%(profile_url)s\" target=\"_blank\">%(user)s</a>"
 msgstr "oleh <a href=\"%(profile_url)s\" target=\"_blank\">%(user)s</a>"
@@ -8673,74 +6723,40 @@ msgstr "Membuat Tema Baru"
 
 #: src/olympia/devhub/templates/devhub/personas/submit.html:18
 #, python-format
-msgid ""
-"Background themes let you easily personalize the look of your Firefox. "
-"Submit your own design below, or <a href=\"%(submit_url)s\">learn how to "
-"create one</a>!"
+msgid "Background themes let you easily personalize the look of your Firefox. Submit your own design below, or <a href=\"%(submit_url)s\">learn how to create one</a>!"
 msgstr ""
-"Tema latar memungkinkan anda dengan mudah membuat tampilan Firefox anda "
-"lebih personal. Daftarkan rancangan anda sendiri di bawah ini, or <a "
-"href=\"%(submit_url)s\">pelajari cara membuatnya</a>!"
+"Tema latar memungkinkan anda dengan mudah membuat tampilan Firefox anda lebih personal. Daftarkan rancangan anda sendiri di bawah ini, or <a href=\"%(submit_url)s\">pelajari cara membuatnya</a>!"
 
 #: src/olympia/devhub/templates/devhub/personas/submit.html:33
 msgid "Give your Theme a name."
 msgstr "Beri Tema anda sebuah nama."
 
-#: src/olympia/devhub/templates/devhub/personas/submit.html:54
-msgid ""
-"A short explanation of your theme's\n"
-"                                      basic functionality that is displayed in\n"
-"                                      search and browse listings, as well as at\n"
-"                                      the top of your theme's details page."
-msgstr ""
-"Penjelasan pendek tema anda\n"
-"                                      fungsi dasar yang ditampilkan di\n"
-"                                      daftar pencarian dan penelusuran, termasuk di\n"
-"                                      bagian atas laman rincian tema anda."
-
 #: src/olympia/devhub/templates/devhub/personas/submit.html:198
 #, python-format
 msgid ""
-"I agree to the <a href=\"%(agreement_url)s\" target=\"_blank\">Firefox Add-"
-"on Distribution Agreement</a> and to my information being handled as "
-"described in the <a href=\"%(privacy_notice_url)s\" "
+"I agree to the <a href=\"%(agreement_url)s\" target=\"_blank\">Firefox Add-on Distribution Agreement</a> and to my information being handled as described in the <a href=\"%(privacy_notice_url)s\" "
 "target=\"_blank\">Websites, Communications and Cookies Privacy Notice</a>."
 msgstr ""
-"Saya setuju dengan <a href=\"%(agreement_url)s\" "
-"target=\"_blank\">Kesepakatan Distribusi Pengaya Firefox</a> dan untuk "
-"informasi saya ditangani sebagaimana dijelaskan dalam <a "
-"href=\"%(privacy_notice_url)s\" target=\"_blank\">Catatan Situs, Komunikasi "
-"dan Kuki Privasi</a>."
+"Saya setuju dengan <a href=\"%(agreement_url)s\" target=\"_blank\">Kesepakatan Distribusi Pengaya Firefox</a> dan untuk informasi saya ditangani sebagaimana dijelaskan dalam <a href="
+"\"%(privacy_notice_url)s\" target=\"_blank\">Catatan Situs, Komunikasi dan Kuki Privasi</a>."
 
 #: src/olympia/devhub/templates/devhub/personas/submit.html:205
 msgid "Submit Theme"
 msgstr "Memasukkan Tema"
 
 #: src/olympia/devhub/templates/devhub/personas/submit_done.html:11
-msgid ""
-"Your theme has been submitted to the Review Queue. You'll receive an email "
-"once it has been reviewed, typically within 24 hours."
-msgstr ""
-"Tema anda telah dimasukkan ke Antrean Ulasan. Anda akan menerima surel "
-"setelah tema ini diulas, biasanya dalam waktu 24 jam."
+msgid "Your theme has been submitted to the Review Queue. You'll receive an email once it has been reviewed, typically within 24 hours."
+msgstr "Tema anda telah dimasukkan ke Antrean Ulasan. Anda akan menerima surel setelah tema ini diulas, biasanya dalam waktu 24 jam."
 
 #: src/olympia/devhub/templates/devhub/personas/submit_done.html:19
 #, python-format
-msgid ""
-"Provide more details about your theme by <a href=\"%(edit_url)s\">editing "
-"its listing</a>."
-msgstr ""
-"Berikan rincian tambahan mengenai tema anda dengan <a "
-"href=\"%(edit_url)s\">menyunting daftarnya</a>."
+msgid "Provide more details about your theme by <a href=\"%(edit_url)s\">editing its listing</a>."
+msgstr "Berikan rincian tambahan mengenai tema anda dengan <a href=\"%(edit_url)s\">menyunting daftarnya</a>."
 
 #: src/olympia/devhub/templates/devhub/personas/submit_done.html:25
 #, python-format
-msgid ""
-"View and subscribe to your theme's <a href=\"%(feed_url)s\">activity "
-"feed</a> to stay updated on reviews, collections, and more."
-msgstr ""
-"Lihat dan berlangganan <a href=\"%(feed_url)s\">umpan aktivitas</a> tema "
-"anda untuk tetap mengetahui ulasan, koleksi dan hal lain yang terbaru."
+msgid "View and subscribe to your theme's <a href=\"%(feed_url)s\">activity feed</a> to stay updated on reviews, collections, and more."
+msgstr "Lihat dan berlangganan <a href=\"%(feed_url)s\">umpan aktivitas</a> tema anda untuk tetap mengetahui ulasan, koleksi dan hal lain yang terbaru."
 
 #: src/olympia/devhub/templates/devhub/personas/submit_done.html:32
 #, python-format
@@ -8755,13 +6771,11 @@ msgstr "Pilih gambar judul untuk Tema anda."
 msgid "3000 &times; 200 pixels"
 msgstr "3000 &times; 200 pixel"
 
-#: src/olympia/devhub/templates/devhub/personas/includes/theme_design.html:9
-#: src/olympia/devhub/templates/devhub/personas/includes/theme_design.html:25
+#: src/olympia/devhub/templates/devhub/personas/includes/theme_design.html:9 src/olympia/devhub/templates/devhub/personas/includes/theme_design.html:25
 msgid "300 KB max"
 msgstr "300 KB maks"
 
-#: src/olympia/devhub/templates/devhub/personas/includes/theme_design.html:10
-#: src/olympia/devhub/templates/devhub/personas/includes/theme_design.html:26
+#: src/olympia/devhub/templates/devhub/personas/includes/theme_design.html:10 src/olympia/devhub/templates/devhub/personas/includes/theme_design.html:26
 msgid "PNG or JPG"
 msgstr "PNG atau JPG"
 
@@ -8790,65 +6804,31 @@ msgid "Select a different footer image"
 msgstr "Pilih gambar catatan kaki yang lainnya"
 
 #: src/olympia/devhub/templates/devhub/versions/add_file_modal.html:8
-msgid ""
-"Files added to reviewed versions must be reviewed before they will be "
-"available for download."
-msgstr ""
-"Berkas ditambahkan untuk versi yang diulas harus diulas sebelum tersedia "
-"untuk diunduh."
+msgid "Files added to reviewed versions must be reviewed before they will be available for download."
+msgstr "Berkas ditambahkan untuk versi yang diulas harus diulas sebelum tersedia untuk diunduh."
 
-#: src/olympia/devhub/templates/devhub/versions/add_file_modal.html:15
-#, python-format
-msgid ""
-"Submission of updates to unlisted add-ons for signing is currently in an "
-"open beta. Manual review may still be required for a large number of add-"
-"ons. Please <a href=\"%(url)s\" target=\"_blank\">report any bugs</a> that "
-"you encounter."
-msgstr ""
-"Pendaftaran pembaruan untuk mendaftar pengaya untuk penandatanganan saat ini"
-" adalah versi beta yang terbuka. Ulasan manual masih bisa diminta untuk "
-"sejumlah besar pengaya. Harap <a href=\"%(url)s\" "
-"target=\"_blank\">melaporkan bug apapun</a> yang anda temui."
-
-#: src/olympia/devhub/templates/devhub/versions/add_file_modal.html:35
+#: src/olympia/devhub/templates/devhub/versions/add_file_modal.html:24
 msgid "Select the target platform for this file."
 msgstr "Pilih platform target untuk berkas ini."
 
-#: src/olympia/devhub/templates/devhub/versions/add_file_modal.html:46
+#: src/olympia/devhub/templates/devhub/versions/add_file_modal.html:35
 msgid "Which review type would you like to nominate for?"
 msgstr "Jenis ulasan mana yang Anda inginkan untuk dinominasikan?"
 
-#: src/olympia/devhub/templates/devhub/versions/add_file_modal.html:51
+#: src/olympia/devhub/templates/devhub/versions/add_file_modal.html:40
 msgid "Only publish this version to my beta channel."
 msgstr "Hanya publikasikan versi ini ke saluran beta saya."
-
-#: src/olympia/devhub/templates/devhub/versions/add_file_modal.html:54
-#, python-format
-msgid ""
-"The behavior of the beta channel has changed to accommodate <a "
-"href=\"%(addon_signing_url)s\" target=\"_blank\">mandatory add-on "
-"signing</a>. The new process is currently in an open beta, and may change "
-"significantly in the near future. Please <a href=\"%(issues_url)s\" "
-"target=\"_blank\">report any bugs</a> that you encounter."
-msgstr ""
-"Perilaku saluran beta telah berubah untuk mengakomidasi <a "
-"href=\"%(addon_signing_url)s\" target=\"_blank\">penandatanganan pengaya "
-"yang wajib</a>. Proses baru saat ini adalah versi beta yang terbuka, dan "
-"bisa berubah secara significant dalam waktu dekat. Harap <a "
-"href=\"%(issues_url)s\" target=\"_blank\">melaporkan bug apapun</a> yang "
-"anda temui."
 
 #: src/olympia/devhub/templates/devhub/versions/edit.html:5
 msgid "Manage Version {0}"
 msgstr "Mengelola Versi {0}"
 
-#: src/olympia/devhub/templates/devhub/versions/edit.html:12
-#: src/olympia/devhub/templates/devhub/versions/list.html:3
+#: src/olympia/devhub/templates/devhub/versions/edit.html:12 src/olympia/devhub/templates/devhub/versions/list.html:3
 msgid "Status & Versions"
 msgstr "Status & Versi"
 
-#. {0} is an add-on name.
 # {0} is the name of the collection
+#. {0} is an add-on name.
 #: src/olympia/devhub/templates/devhub/versions/edit.html:16
 msgid "Manage {0}"
 msgstr "Kelola {0}"
@@ -8861,22 +6841,10 @@ msgstr "Berkas"
 msgid "Upload Another File"
 msgstr "Unggah Berkas Lainnya"
 
-#: src/olympia/devhub/templates/devhub/versions/edit.html:45
-msgid ""
-"Adjusting application information here will allow users to install your\n"
-"                          add-on even if the install manifest in the package indicates that the\n"
-"                          add-on is incompatible."
-msgstr ""
-"Menyesuaikan informasi aplikasi di sini akan memungkinkan pengguna untuk memasang\n"
-"                          pengaya anda meskipun manifest pemasangan di paketnya mengindikasikan bahwa\n"
-"                          pengaya ini tidak cocok."
-
 #: src/olympia/devhub/templates/devhub/versions/edit.html:74
 msgid ""
-"Information about changes in this release, new features,\n"
-"                              known bugs, and other useful information specific to this\n"
-"                              release/version. This information is also shown in the\n"
-"                              Add-ons Manager when updating."
+"Information about changes in this release, new features, known bugs, and other useful information specific to this release/version. This information is also shown in the Add-ons Manager when "
+"updating."
 msgstr ""
 "Informasi mengenai perubahan di rilisan ini, fitur baru\n"
 "                              bug yang diketahui, dan informasi berguna lainnya yang spesifik untuk\n"
@@ -8887,16 +6855,12 @@ msgstr ""
 msgid "Approval Status"
 msgstr "Status Persetujuan"
 
-#: src/olympia/devhub/templates/devhub/versions/edit.html:113
-#: src/olympia/editors/templates/editors/review.html:108
+#: src/olympia/devhub/templates/devhub/versions/edit.html:113 src/olympia/editors/templates/editors/review.html:108
 msgid "Notes for Reviewers"
 msgstr "Catatan untuk Pengulas"
 
 #: src/olympia/devhub/templates/devhub/versions/edit.html:114
-msgid ""
-"Optionally, enter any information that may be useful\n"
-"                              to the Editor reviewing this add-on, such as test\n"
-"                              account information."
+msgid "Optionally, enter any information that may be useful to the Editor reviewing this add-on, such as test account information."
 msgstr ""
 "Silakan memilih, masukkan informasi apapun yang bisa berguna\n"
 "                              kepada Penyunting yang mengulas pengaya ini, seperti\n"
@@ -8907,15 +6871,10 @@ msgid "Source code"
 msgstr "Kode sumber"
 
 #: src/olympia/devhub/templates/devhub/versions/edit.html:128
-msgid ""
-"If your add-on contain binary or obfuscated code, make the source available "
-"here for reviewers."
-msgstr ""
-"Jika pengaya anda mengandung kode yang dikaburkan atau biner, sediakan "
-"sumbernya di sini untuk para pengulas."
+msgid "If your add-on contain binary or obfuscated code, make the source available here for reviewers."
+msgstr "Jika pengaya anda mengandung kode yang dikaburkan atau biner, sediakan sumbernya di sini untuk para pengulas."
 
-#: src/olympia/devhub/templates/devhub/versions/edit.html:145
-#: src/olympia/devhub/templates/devhub/versions/edit.html:149
+#: src/olympia/devhub/templates/devhub/versions/edit.html:145 src/olympia/devhub/templates/devhub/versions/edit.html:149
 msgid "Upload a new file"
 msgstr "Unggah berkas baru"
 
@@ -8930,8 +6889,7 @@ msgstr "Berkas {file_id} ({platform})"
 #: src/olympia/devhub/templates/devhub/versions/file_status_message.html:5
 #, python-format
 msgid "Created on %(created)s and changed to %(status)s on %(status_date)s"
-msgstr ""
-"Dibuat di %(created)s dan diubah menjadi %(status)s pada %(status_date)s"
+msgstr "Dibuat di %(created)s dan diubah menjadi %(status)s pada %(status_date)s"
 
 #: src/olympia/devhub/templates/devhub/versions/file_status_message.html:9
 #, python-format
@@ -8956,6 +6914,7 @@ msgstr "Edit versi ini"
 msgid "{0} file"
 msgid_plural "{0} files"
 msgstr[0] "{0} berkas"
+msgstr[1] ""
 
 #: src/olympia/devhub/templates/devhub/versions/list.html:25
 msgid "0 files"
@@ -8982,9 +6941,7 @@ msgstr "Meminta Ulasan Lengkap"
 msgid "Request Preliminary Review"
 msgstr "Meminta Ulasan Pendahuluan"
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:80
-#: src/olympia/devhub/templates/devhub/versions/list.html:327
-#: src/olympia/devhub/templates/devhub/versions/list.html:350
+#: src/olympia/devhub/templates/devhub/versions/list.html:80 src/olympia/devhub/templates/devhub/versions/list.html:325 src/olympia/devhub/templates/devhub/versions/list.html:348
 msgid "Cancel Review Request"
 msgstr "Membatalkan Permintaan Ulasan"
 
@@ -8997,35 +6954,24 @@ msgid "Listed:"
 msgstr "Terdaftar:"
 
 #: src/olympia/devhub/templates/devhub/versions/list.html:102
-msgid ""
-"Visible to everyone on {0} and included in search results and listing pages"
-msgstr ""
-"Dapat dilihat semua orang di {0} dan dimasukkan ke dalam hasil pencarian dan"
-" laman daftar"
+msgid "Visible to everyone on {0} and included in search results and listing pages"
+msgstr "Dapat dilihat semua orang di {0} dan dimasukkan ke dalam hasil pencarian dan laman daftar"
 
 #: src/olympia/devhub/templates/devhub/versions/list.html:108
 msgid "Hidden:"
 msgstr "Tersembunyi:"
 
 #: src/olympia/devhub/templates/devhub/versions/list.html:108
-msgid ""
-"Hosted on {0}, but hidden to anyone but authors. Used to temporarily hide "
-"listings or discontinue them."
-msgstr ""
-"Dimuat di {0}, namun disembunyikan untuk siapapun kecuali penulis. Digunakan"
-" untuk secara temporer menyembunyikan daftar atau menghentikannya."
+msgid "Hosted on {0}, but hidden to anyone but authors. Used to temporarily hide listings or discontinue them."
+msgstr "Dimuat di {0}, namun disembunyikan untuk siapapun kecuali penulis. Digunakan untuk secara temporer menyembunyikan daftar atau menghentikannya."
 
 #: src/olympia/devhub/templates/devhub/versions/list.html:114
 msgid "Unlisted:"
 msgstr "Tidak terdaftar:"
 
 #: src/olympia/devhub/templates/devhub/versions/list.html:114
-msgid ""
-"Not distributed on {0}. Developers will upload new versions for signing and "
-"distribute the add-ons on their own. (beta)"
+msgid "Not distributed on {0}. Developers will upload new versions for signing and distribute the add-ons on their own."
 msgstr ""
-"Tidak didistribusikan di {0}. Pengembang akan mengunggah versi baru untuk "
-"penandatanganan dan distribusi pengaya sendiri. (beta)"
 
 #: src/olympia/devhub/templates/devhub/versions/list.html:122
 msgid "Current versions"
@@ -9035,18 +6981,13 @@ msgstr "Versi terkini"
 msgid "Currently on AMO"
 msgstr "Saat ini di AMO"
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:129
-#: src/olympia/devhub/templates/devhub/versions/list.html:147
-#: src/olympia/devhub/templates/devhub/versions/list.html:164
-#: src/olympia/editors/templates/editors/includes/search_results_themes.html:7
-#: src/olympia/editors/templates/editors/themes/queue_list.html:50
+#: src/olympia/devhub/templates/devhub/versions/list.html:129 src/olympia/devhub/templates/devhub/versions/list.html:147 src/olympia/devhub/templates/devhub/versions/list.html:164
+#: src/olympia/editors/templates/editors/includes/search_results_themes.html:7 src/olympia/editors/templates/editors/themes/queue_list.html:50
 msgid "Status"
 msgstr "Статус"
 
 # Header for a column in a table
-#: src/olympia/devhub/templates/devhub/versions/list.html:130
-#: src/olympia/devhub/templates/devhub/versions/list.html:148
-#: src/olympia/devhub/templates/devhub/versions/list.html:165
+#: src/olympia/devhub/templates/devhub/versions/list.html:130 src/olympia/devhub/templates/devhub/versions/list.html:148 src/olympia/devhub/templates/devhub/versions/list.html:165
 #: src/olympia/editors/templates/editors/includes/files_view.html:11
 msgid "Validation"
 msgstr "Validasi"
@@ -9068,15 +7009,10 @@ msgid "Full review may not be required"
 msgstr "Ulasan lengkap barangkali tidak diperlukan"
 
 #: src/olympia/devhub/templates/devhub/versions/list.html:201
-msgid ""
-"Unlisted add-ons don't need Full Review unless they are distributed as part "
-"of an application installer. Read <a href=\"{link}\" target=\"_blank\">this "
-"documentation</a> for more information."
+msgid "Unlisted add-ons don't need Full Review unless they are distributed as part of an application installer. Read <a href=\"{link}\" target=\"_blank\">this documentation</a> for more information."
 msgstr ""
-"Pengaya yang tidak terdaftar tidak memerlukan Ulasan Lengkap kecuali jika "
-"didistribusikan sebagai bagian dari instalator aplikasi. Baca <a "
-"href=\"{link}\" target=\"_blank\">dokumentasi ini</a> untuk informasi lebih "
-"lanjut."
+"Pengaya yang tidak terdaftar tidak memerlukan Ulasan Lengkap kecuali jika didistribusikan sebagai bagian dari instalator aplikasi. Baca <a href=\"{link}\" target=\"_blank\">dokumentasi ini</a> "
+"untuk informasi lebih lanjut."
 
 #: src/olympia/devhub/templates/devhub/versions/list.html:209
 msgid "Request full review"
@@ -9088,138 +7024,90 @@ msgstr "Hapus Versi {version}"
 
 #: src/olympia/devhub/templates/devhub/versions/list.html:218
 msgid ""
-"You are about to delete the current version of your add-on. This may cause "
-"your add-on status to change, or your listing to lose public visibility, if "
-"this is the only public version of your add-on."
+"You are about to delete the current version of your add-on. This may cause your add-on status to change, or your listing to lose public visibility, if this is the only public version of your add-on."
 msgstr ""
-"Anda akan menghapus versi pengaya anda saat ini. Hal ini bisa menyebabkan "
-"status pengaya anda berubah, atau daftar anda kehilangan pandangan publik, "
-"jika ini adalah satu-satunya versi publik pengaya anda."
+"Anda akan menghapus versi pengaya anda saat ini. Hal ini bisa menyebabkan status pengaya anda berubah, atau daftar anda kehilangan pandangan publik, jika ini adalah satu-satunya versi publik "
+"pengaya anda."
 
 #: src/olympia/devhub/templates/devhub/versions/list.html:219
 msgid "Deleting this version will permanently delete:"
 msgstr "Menghapus versi ini akan secara permanen menghapus:"
 
 #: src/olympia/devhub/templates/devhub/versions/list.html:225
-msgid ""
-"<strong>Important:</strong> Once a version has been deleted, you may not "
-"upload a new version with the same version number."
-msgstr ""
-"<strong>Penting:</strong> Sekali sebuah versi dihapus, anda mungkin tidak "
-"boleh mengunggah versi baru dengan nomor versi yang sama."
+msgid "<strong>Important:</strong> Once a version has been deleted, you may not upload a new version with the same version number."
+msgstr "<strong>Penting:</strong> Sekali sebuah versi dihapus, anda mungkin tidak boleh mengunggah versi baru dengan nomor versi yang sama."
 
 #: src/olympia/devhub/templates/devhub/versions/list.html:230
-msgid ""
-"Deleting a version which has already been reviewed\n"
-"               may also cause a significant delay in the review of\n"
-"               your next update."
-msgstr ""
-"Menghapus sebuah versi yang sudah diulas\n"
-"               dapat menyebabkan penundaan signifikan dari pengulasan\n"
-"              pembaruan anda berikutnya."
-
-#: src/olympia/devhub/templates/devhub/versions/list.html:233
 msgid "Are you sure you wish to delete this version?"
 msgstr "Yakin Anda ingin menghapus versi ini?"
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:238
+#: src/olympia/devhub/templates/devhub/versions/list.html:235
 msgid "Delete Version"
 msgstr "Hapus Versi"
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:240
+#: src/olympia/devhub/templates/devhub/versions/list.html:237
 msgid "Disable Version"
 msgstr "Mematikan Versi"
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:247
+#: src/olympia/devhub/templates/devhub/versions/list.html:244
 msgid "Add a new Version"
 msgstr "Tambah Versi baru"
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:249
+#: src/olympia/devhub/templates/devhub/versions/list.html:246
 msgid "Add Version"
 msgstr "Tambah Versi"
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:256
-#: src/olympia/devhub/templates/devhub/versions/list.html:274
+#: src/olympia/devhub/templates/devhub/versions/list.html:253 src/olympia/devhub/templates/devhub/versions/list.html:279
 msgid "Hide Add-on"
 msgstr "Sembunyikan Pengaya"
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:259
-msgid ""
-"Hiding your add-on will prevent it from appearing anywhere in our gallery "
-"and will stop users from receiving automatic updates."
-msgstr ""
-"Menyembunyikan pengaya akan mencegahnya dari muncul di manapun dalam galeri "
-"kami dan akan menghentikan pengguna menerima pembaruan otomatis."
+#: src/olympia/devhub/templates/devhub/versions/list.html:256
+msgid "Hiding your add-on will prevent it from appearing anywhere in our gallery and will stop users from receiving automatic updates."
+msgstr "Menyembunyikan pengaya akan mencegahnya dari muncul di manapun dalam galeri kami dan akan menghentikan pengguna menerima pembaruan otomatis."
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:265
+#: src/olympia/devhub/templates/devhub/versions/list.html:263
+msgid "The files awaiting review will be disabled and you will need to upload new versions."
+msgstr ""
+
+#: src/olympia/devhub/templates/devhub/versions/list.html:270
 msgid "Are you sure you wish to hide your add-on?"
 msgstr "Anda yakin ingin menyembunyikan pengaya Anda?"
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:286
-#: src/olympia/devhub/templates/devhub/versions/list.html:315
+#: src/olympia/devhub/templates/devhub/versions/list.html:291 src/olympia/devhub/templates/devhub/versions/list.html:313
 msgid "Unlist Add-on"
 msgstr "Keluarkan Pengaya dari Daftar"
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:289
+#: src/olympia/devhub/templates/devhub/versions/list.html:294
 #, python-format
 msgid ""
-"Unlisting your add-on will make it (and each of its versions/files) "
-"invisible on this website. It won't show up in searches, won't have a public"
-" facing page, and won't be updated automatically for current users.  It is "
-"recommended for unlisted add-ons to provide a custom <a "
-"href=\"%(update_url)s\" target=\"_blank\">updateURL</a> in their manifest "
-"file for automatic updates."
+"Unlisting your add-on will make it (and each of its versions/files) invisible on this website. It won't show up in searches, won't have a public facing page, and won't be updated automatically for "
+"current users. It is recommended for unlisted add-ons to provide a custom <a href=\"%(update_url)s\" target=\"_blank\">updateURL</a> in their manifest file for automatic updates."
 msgstr ""
-"Mengeluarkan pengaya anda dari daftar akan membuatnya (dan setiap "
-"versinya/files) tidak terlihat di situs ini. Ia tidak akan terlihat di "
-"pencarian, tidak akan memiliki laman yang menghadap public, dan tidak akan "
-"diperbarui secara otomatis untuk pengguna saat ini.  Direkomendasikan bagi "
-"pengaya yang tidak terdaftar untuk menyediakan <a href=\"%(update_url)s\" "
-"target=\"_blank\">updateURL</a> yang khusus dalam berkas manifes untuk "
-"pembaruan otomatis."
+"Mengeluarkan pengaya anda dari daftar akan membuatnya (dan setiap versinya/files) tidak terlihat di situs ini. Ia tidak akan terlihat di pencarian, tidak akan memiliki laman yang menghadap public, "
+"dan tidak akan diperbarui secara otomatis untuk pengguna saat ini.  Direkomendasikan bagi pengaya yang tidak terdaftar untuk menyediakan <a href=\"%(update_url)s\" target=\"_blank\">updateURL</a> "
+"yang khusus dalam berkas manifes untuk pembaruan otomatis."
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:299
-#, python-format
-msgid ""
-"Switching add-ons to unlisted is currently in an open beta. Please <a "
-"href=\"%(url)s\" target=\"_blank\">report any bugs</a> that you encounter."
-msgstr ""
-"Mengubah pengaya menjadi tidak ada dalam daftar saat ini ada dalam versi "
-"beta terbuka. Harap <a href=\"%(url)s\" target=\"_blank\">melaporkan bug "
-"apapun</a> yang anda temui."
-
-#: src/olympia/devhub/templates/devhub/versions/list.html:305
+#: src/olympia/devhub/templates/devhub/versions/list.html:303
 msgid "Unlisting an add-on is irreversible!"
 msgstr "Menghilangkan pengaya dari daftar tidak bisa diurungkan!"
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:305
+#: src/olympia/devhub/templates/devhub/versions/list.html:303
 msgid "An unlisted add-on cannot be switched to be listed."
-msgstr ""
-"Pengaya yang tidak berada dalam daftar tidak bisa diubah jadi terdaftar."
+msgstr "Pengaya yang tidak berada dalam daftar tidak bisa diubah jadi terdaftar."
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:307
+#: src/olympia/devhub/templates/devhub/versions/list.html:305
 msgid "Are you sure you wish to unlist your add-on?"
 msgstr "Apakah anda yakin ingin mengeluarkan pengaya anda dari daftar?"
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:330
-msgid ""
-"Canceling your review request will leave your add-on as preliminarily "
-"reviewed."
-msgstr ""
-"Membatalkan permintaan ulasan pengaya akan membuat pengaya anda hanya "
-"mendapat ulasan pendahuluan."
+#: src/olympia/devhub/templates/devhub/versions/list.html:328
+msgid "Canceling your review request will leave your add-on as preliminarily reviewed."
+msgstr "Membatalkan permintaan ulasan pengaya akan membuat pengaya anda hanya mendapat ulasan pendahuluan."
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:335
-msgid ""
-"Canceling your review request will mark your add-on incomplete. If you do "
-"not complete your add-on after several days by re-requesting review, it will"
-" be deleted."
-msgstr ""
-"Membatalkan permintaan ulasan anda akan menandai pengaya sebagai tak "
-"lengkap. Jika anda tidak melengkapi pengaya setelah beberapa hari dengan "
-"meminta ulasan ulang, ia akan dihapus."
+#: src/olympia/devhub/templates/devhub/versions/list.html:333
+msgid "Canceling your review request will mark your add-on incomplete. If you do not complete your add-on after several days by re-requesting review, it will be deleted."
+msgstr "Membatalkan permintaan ulasan anda akan menandai pengaya sebagai tak lengkap. Jika anda tidak melengkapi pengaya setelah beberapa hari dengan meminta ulasan ulang, ia akan dihapus."
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:343
+#: src/olympia/devhub/templates/devhub/versions/list.html:341
 msgid "Are you sure you wish to cancel your review request?"
 msgstr "Apakah anda ingin membatalkan permintaan ulasan anda?"
 
@@ -9252,19 +7140,12 @@ msgid "Translate content on the web from and into over 40 languages."
 msgstr "Menerjemahkan konten web dari dan ke lebih 40 bahasa."
 
 #: src/olympia/discovery/modules.py:171
-msgid ""
-"Easily connect to your social networks, and share or comment on the page "
-"you're visiting."
-msgstr ""
-"Hubungkan jejaring sosial anda dengan mudah, dan bagikan atau berkomentar di"
-" laman yang anda kunjungi."
+msgid "Easily connect to your social networks, and share or comment on the page you're visiting."
+msgstr "Hubungkan jejaring sosial anda dengan mudah, dan bagikan atau berkomentar di laman yang anda kunjungi."
 
 #: src/olympia/discovery/modules.py:173
-msgid ""
-"A quick view to compare prices when you shop online or search for flights."
-msgstr ""
-"Lihat sekilas untuk membandingkan harga ketika anda sedang berbelanja daring"
-" atau mencari penerbangan."
+msgid "A quick view to compare prices when you shop online or search for flights."
+msgstr "Lihat sekilas untuk membandingkan harga ketika anda sedang berbelanja daring atau mencari penerbangan."
 
 #: src/olympia/discovery/modules.py:183
 msgid "Firefox 4 Collection"
@@ -9307,24 +7188,16 @@ msgid "Add-ons that help you on your travels!"
 msgstr "Pengaya yang membantu dalam perjalanan anda!"
 
 #: src/olympia/discovery/modules.py:226
-msgid ""
-"Displays a country flag depicting the location of the current website's "
-"server and more."
-msgstr ""
-"Tampilkan bendera negaya yang menunjukkan lokasi di mana server situs ini "
-"kini terpasang dan lain sebagainya."
+msgid "Displays a country flag depicting the location of the current website's server and more."
+msgstr "Tampilkan bendera negaya yang menunjukkan lokasi di mana server situs ini kini terpasang dan lain sebagainya."
 
 #: src/olympia/discovery/modules.py:228
 msgid "FoxClocks let you keep an eye on the time around the world."
 msgstr "FoxClox memungkinkan anda mengetahui waktu di seluruh dunia."
 
 #: src/olympia/discovery/modules.py:230
-msgid ""
-"Automatically get the lowest price when you shop online or search for "
-"flights."
-msgstr ""
-"Secara otomatis mendapatkan harga paling murah saat berbelanja daring atau "
-"mencari penerbangan."
+msgid "Automatically get the lowest price when you shop online or search for flights."
+msgstr "Secara otomatis mendapatkan harga paling murah saat berbelanja daring atau mencari penerbangan."
 
 #: src/olympia/discovery/modules.py:240
 msgid "A+ add-ons for School"
@@ -9363,12 +7236,8 @@ msgid "Put a Theme on It!"
 msgstr "Tambahkan Tema!"
 
 #: src/olympia/discovery/modules.py:281
-msgid ""
-"Visit addons.mozilla.org from Firefox for Android and dress up your mobile "
-"browser to match your style, mood, or the season."
-msgstr ""
-"Kunjungi addons.mozilla.org dari Firefox untuk Android dan dandani peramban "
-"bergerak anda sesuai dengan gaya, suasana hati anda atau berdasarkan musim."
+msgid "Visit addons.mozilla.org from Firefox for Android and dress up your mobile browser to match your style, mood, or the season."
+msgstr "Kunjungi addons.mozilla.org dari Firefox untuk Android dan dandani peramban bergerak anda sesuai dengan gaya, suasana hati anda atau berdasarkan musim."
 
 #: src/olympia/discovery/modules.py:290
 msgid "Get up and move!"
@@ -9395,12 +7264,8 @@ msgid "Protect your privacy online with the add-ons in this collection."
 msgstr "Melindungi privasi anda daring dengan pengaya dalam koleksi ini."
 
 #: src/olympia/discovery/modules.py:342
-msgid ""
-"Great add-ons for work, fun, privacy, productivity&hellip; just about "
-"anything!"
-msgstr ""
-"Pengaya yang hebat untuk bekerja, bersenang-senang, privasi produktivitas "
-"&hellip; apapun!"
+msgid "Great add-ons for work, fun, privacy, productivity&hellip; just about anything!"
+msgstr "Pengaya yang hebat untuk bekerja, bersenang-senang, privasi produktivitas &hellip; apapun!"
 
 #: src/olympia/discovery/modules.py:350
 msgid "Add-ons for Australis Contest Winners"
@@ -9420,22 +7285,16 @@ msgstr "Apa itu Pengaya?"
 
 #: src/olympia/discovery/templates/discovery/pane.html:28
 #, python-format
-msgid ""
-"Add-ons are applications that let you personalize %(app)s with extra "
-"functionality or style. Try a time-saving sidebar, a weather notifier, or a "
-"themed look to make %(app)s your own."
+msgid "Add-ons are applications that let you personalize %(app)s with extra functionality or style. Try a time-saving sidebar, a weather notifier, or a themed look to make %(app)s your own."
 msgstr ""
-"Pengaya adalah aplikasi yang dapat Anda gunakan untuk mengubahsuai %(app)s "
-"dengan tambahan fungsi atau mempercantik gayanya. Coba bilah samping yang "
-"dapat mempercepat cara kerja Anda, pengirim notifikasi cuaca, atau gaya "
-"cantik untuk %(app)s Anda."
+"Pengaya adalah aplikasi yang dapat Anda gunakan untuk mengubahsuai %(app)s dengan tambahan fungsi atau mempercantik gayanya. Coba bilah samping yang dapat mempercepat cara kerja Anda, pengirim "
+"notifikasi cuaca, atau gaya cantik untuk %(app)s Anda."
 
 #: src/olympia/discovery/templates/discovery/pane.html:62
 msgid "Learn More About Add-ons"
 msgstr "Pelajari Lebih Lanjut Tentang Pengaya"
 
-#: src/olympia/discovery/templates/discovery/pane.html:66
-#: src/olympia/discovery/templates/discovery/pane.html:73
+#: src/olympia/discovery/templates/discovery/pane.html:66 src/olympia/discovery/templates/discovery/pane.html:73
 msgid "See all"
 msgstr "Lihat semuanya"
 
@@ -9466,12 +7325,8 @@ msgstr "Hai, {0}"
 
 #: src/olympia/discovery/templates/discovery/pane_account.html:17
 #, python-format
-msgid ""
-"Thanks for using %(app)s and supporting <a href=\"%(url)s\">Mozilla's "
-"mission</a>!"
-msgstr ""
-"Terima kasih karena menggunakan %(app)s dan mendukung <a "
-"href=\"%(url)s\">misi Mozilla</a>!"
+msgid "Thanks for using %(app)s and supporting <a href=\"%(url)s\">Mozilla's mission</a>!"
+msgstr "Terima kasih karena menggunakan %(app)s dan mendukung <a href=\"%(url)s\">misi Mozilla</a>!"
 
 #: src/olympia/discovery/templates/discovery/pane_account.html:23
 msgid "Add-ons downloaded:"
@@ -9495,14 +7350,10 @@ msgstr "Dapatkan Pengaya Di Mana Saja"
 
 #: src/olympia/discovery/templates/discovery/modules/go-mobile.html:8
 #, python-format
-msgid ""
-"Visit <a href=\"%(url)s\">firefox.com/m</a> to get Firefox on your phone and"
-" personalize your browser anytime, anywhere. Easily discover and install "
-"add-ons from the mobile Add-ons Manager."
+msgid "Visit <a href=\"%(url)s\">firefox.com/m</a> to get Firefox on your phone and personalize your browser anytime, anywhere. Easily discover and install add-ons from the mobile Add-ons Manager."
 msgstr ""
-"Kunjungi <a href=\"%(url)s\">firefox.com/m</a> untuk mendapatkan Firefox "
-"dalam ponsel anda dan membuat peramban anda jadi personal kapan saja, di "
-"mana saja. Pengaya yang mudah ditemukan dan dipasang dari Manajer Pengaya."
+"Kunjungi <a href=\"%(url)s\">firefox.com/m</a> untuk mendapatkan Firefox dalam ponsel anda dan membuat peramban anda jadi personal kapan saja, di mana saja. Pengaya yang mudah ditemukan dan "
+"dipasang dari Manajer Pengaya."
 
 #: src/olympia/discovery/templates/discovery/modules/go-mobile.html:13
 msgid "Get Mobile Add-ons"
@@ -9514,25 +7365,15 @@ msgstr "Belanja cerdas musim liburan ini"
 
 #: src/olympia/discovery/templates/discovery/modules/holiday.html:5
 msgid "Find great add-ons to help you with all your holiday shopping needs."
-msgstr ""
-"Temukan pengaya yang hebat untuk membantu anda dengan semua kebutuhan "
-"belanja liburan."
+msgstr "Temukan pengaya yang hebat untuk membantu anda dengan semua kebutuhan belanja liburan."
 
 #: src/olympia/discovery/templates/discovery/modules/holiday.html:13
-msgid ""
-"Install the Amazon Browser Apps and receive special Amazon features right at"
-" your fingertips."
-msgstr ""
-"Pasang Aplikasi Peramban Amazon dan dapatkan fitur Amazon di ujung jari "
-"anda."
+msgid "Install the Amazon Browser Apps and receive special Amazon features right at your fingertips."
+msgstr "Pasang Aplikasi Peramban Amazon dan dapatkan fitur Amazon di ujung jari anda."
 
 #: src/olympia/discovery/templates/discovery/modules/holiday.html:22
-msgid ""
-"Keep an eye on your eBay activity wherever you are on the web when you "
-"install the eBay Sidebar for Firefox."
-msgstr ""
-"Perhatikan pada aktivitas eBay anda di manapun anda berada di web saat anda "
-"memasang sidebar eBay untuk Firefox."
+msgid "Keep an eye on your eBay activity wherever you are on the web when you install the eBay Sidebar for Firefox."
+msgstr "Perhatikan pada aktivitas eBay anda di manapun anda berada di web saat anda memasang sidebar eBay untuk Firefox."
 
 #: src/olympia/discovery/templates/discovery/modules/holiday.html:31
 msgid "See the entire holiday shopping add-on collection."
@@ -9609,19 +7450,19 @@ msgstr "pengaya, penyunting atau komentar"
 msgid "Search by add-on name / author email"
 msgstr "Pencarian berdasarkan nama pengaya / surel penulis"
 
-#: src/olympia/editors/forms.py:103
+#: src/olympia/editors/forms.py:103 src/olympia/editors/forms.py:244 src/olympia/editors/forms.py:257
 msgid "yes"
 msgstr "ya"
 
-#: src/olympia/editors/forms.py:104
+#: src/olympia/editors/forms.py:104 src/olympia/editors/forms.py:244 src/olympia/editors/forms.py:257
 msgid "no"
 msgstr "tidak"
 
-#: src/olympia/editors/forms.py:105
+#: src/olympia/editors/forms.py:105 src/olympia/editors/forms.py:245
 msgid "Admin Flag"
 msgstr "Tandai Admin"
 
-#: src/olympia/editors/forms.py:113
+#: src/olympia/editors/forms.py:113 src/olympia/editors/forms.py:253
 msgid "Max. Version"
 msgstr "Versi Max."
 
@@ -9633,59 +7474,59 @@ msgstr "Hari Sejak Pendaftaran"
 msgid "Add-on Types"
 msgstr "Tipe Pengaya"
 
-#: src/olympia/editors/forms.py:126 src/olympia/editors/helpers.py:267
+#: src/olympia/editors/forms.py:126 src/olympia/editors/helpers.py:279
 msgid "Platforms"
 msgstr "Platform"
 
+#: src/olympia/editors/forms.py:237
+msgid "Search by add-on name / author email / guid"
+msgstr ""
+
 #. L10n: 0 = platform, 1 = filename, 2 = status message
-#: src/olympia/editors/forms.py:238
+#: src/olympia/editors/forms.py:342
 #, python-format
 msgid "<strong>%s</strong> &middot; %s &middot; %s"
 msgstr "<strong>%s</strong> &middot; %s &middot; %s"
 
-#: src/olympia/editors/forms.py:252
+#: src/olympia/editors/forms.py:356
 msgid "Comments:"
 msgstr "Komentar:"
 
-#: src/olympia/editors/forms.py:256
+#: src/olympia/editors/forms.py:360
 msgid "Operating systems:"
 msgstr "Sistem operasi:"
 
-#: src/olympia/editors/forms.py:258
+#: src/olympia/editors/forms.py:362
 msgid "Applications:"
 msgstr "Aplikasi:"
 
-#: src/olympia/editors/forms.py:260
-msgid ""
-"Notify me the next time this add-on is updated. (Subsequent updates will not"
-" generate an email)"
-msgstr ""
-"Beritahu saya jika lain kali pengaya ini diperbarui. (Pembaruan berikutnya "
-"tidak akan menghasilkan surel)"
+#: src/olympia/editors/forms.py:364
+msgid "Notify me the next time this add-on is updated. (Subsequent updates will not generate an email)"
+msgstr "Beritahu saya jika lain kali pengaya ini diperbarui. (Pembaruan berikutnya tidak akan menghasilkan surel)"
 
-#: src/olympia/editors/forms.py:265
+#: src/olympia/editors/forms.py:369
 msgid "Clear Admin Review Flag"
 msgstr "Bersihkan Penandaan Ulasan Admin"
 
-#: src/olympia/editors/forms.py:267
+#: src/olympia/editors/forms.py:371
 msgid "Clear more info requested flag"
 msgstr "Bersihkan tanda permintaan info lebih lanjut"
 
-#: src/olympia/editors/forms.py:281
+#: src/olympia/editors/forms.py:385
 msgid "Choose a canned response..."
 msgstr "Pilih respon yang direkam..."
 
 #. L10n: Description of what can be searched for.
-#: src/olympia/editors/forms.py:324
+#: src/olympia/editors/forms.py:423
 msgid "theme name"
 msgstr "nama tema"
 
-#: src/olympia/editors/forms.py:350
+#: src/olympia/editors/forms.py:449
 msgid "Someone else is reviewing this theme."
 msgstr "Orang lain mengulas tema ini."
 
 #. L10n: Description of what can be searched for.
-#: src/olympia/editors/forms.py:447
+#: src/olympia/editors/forms.py:546
 msgid "app, reviewer, or comment"
 msgstr "aplikasi, pengulas, atau komentar"
 
@@ -9701,282 +7542,266 @@ msgstr "Ulasan Pendahuluan Ditunda"
 msgid "Rejected or Unreviewed"
 msgstr "Ditolak atau Tidak Diulas"
 
-#: src/olympia/editors/helpers.py:123 src/olympia/editors/helpers.py:136
+#: src/olympia/editors/helpers.py:125 src/olympia/editors/helpers.py:138
 msgid "Queue"
 msgstr "Antrean"
 
-#: src/olympia/editors/helpers.py:124
-#: src/olympia/editors/templates/editors/base.html:50
-#: src/olympia/editors/templates/editors/base.html:65
+#: src/olympia/editors/helpers.py:126 src/olympia/editors/templates/editors/base.html:50 src/olympia/editors/templates/editors/base.html:65
 msgid "Pending Updates"
 msgstr "Pembaruan Ditunda"
 
-#: src/olympia/editors/helpers.py:125
-#: src/olympia/editors/templates/editors/base.html:48
-#: src/olympia/editors/templates/editors/base.html:63
+#: src/olympia/editors/helpers.py:127 src/olympia/editors/templates/editors/base.html:48 src/olympia/editors/templates/editors/base.html:63
 msgid "Full Reviews"
 msgstr "Ulasan Lengkap"
 
-#: src/olympia/editors/helpers.py:126
-#: src/olympia/editors/templates/editors/base.html:52
-#: src/olympia/editors/templates/editors/base.html:67
+#: src/olympia/editors/helpers.py:128 src/olympia/editors/templates/editors/base.html:52 src/olympia/editors/templates/editors/base.html:67
 msgid "Preliminary Reviews"
 msgstr "Ulasan Pendahuluan"
 
-#: src/olympia/editors/helpers.py:127
-#: src/olympia/editors/templates/editors/base.html:54
+#: src/olympia/editors/helpers.py:129 src/olympia/editors/templates/editors/base.html:54
 msgid "Moderated Reviews"
 msgstr "Ulasan Dimoderasi"
 
-#: src/olympia/editors/helpers.py:128
-#: src/olympia/editors/templates/editors/base.html:46
+#: src/olympia/editors/helpers.py:130 src/olympia/editors/templates/editors/base.html:46
 msgid "Fast Track"
 msgstr "Jalur Cepat"
 
-#: src/olympia/editors/helpers.py:130
+#: src/olympia/editors/helpers.py:132
 msgid "Pending Themes"
 msgstr "Tema Ditunda"
 
-#: src/olympia/editors/helpers.py:131
-#: src/olympia/editors/templates/editors/themes/queue.html:4
+#: src/olympia/editors/helpers.py:133 src/olympia/editors/templates/editors/themes/queue.html:4
 msgid "Flagged Themes"
 msgstr "Tema Ditandai"
 
-#: src/olympia/editors/helpers.py:132
+#: src/olympia/editors/helpers.py:134
 msgid "Update Themes"
 msgstr "Perbarui Tema"
 
-#: src/olympia/editors/helpers.py:137
+#: src/olympia/editors/helpers.py:139
 msgid "Unlisted Pending Updates"
 msgstr "Pembaruan Ditunda Tidak Terdaftar"
 
-#: src/olympia/editors/helpers.py:138
+#: src/olympia/editors/helpers.py:140
 msgid "Unlisted Full Reviews"
 msgstr "Ulasan Penuh Tidak Terdaftar"
 
-#: src/olympia/editors/helpers.py:139
+#: src/olympia/editors/helpers.py:141
 msgid "Unlisted Preliminary Reviews"
 msgstr "Ulasan Pendahuluan Tidak Terdaftar"
 
-#: src/olympia/editors/helpers.py:170
+#: src/olympia/editors/helpers.py:142
+msgid "Unlisted All Add-ons"
+msgstr ""
+
+#: src/olympia/editors/helpers.py:173
 msgid "Fast Track ({0})"
 msgid_plural "Fast Track ({0})"
 msgstr[0] "Jalur Cepat ({0})"
+msgstr[1] ""
 
-#: src/olympia/editors/helpers.py:175
+#: src/olympia/editors/helpers.py:178
 msgid "Full Review ({0})"
 msgid_plural "Full Reviews ({0})"
 msgstr[0] "Ulasan Lengkap ({0})"
+msgstr[1] ""
 
-#: src/olympia/editors/helpers.py:180
+#: src/olympia/editors/helpers.py:183
 msgid "Pending Update ({0})"
 msgid_plural "Pending Updates ({0})"
 msgstr[0] "Pembaruan Ditunda ({0})"
+msgstr[1] ""
 
-#: src/olympia/editors/helpers.py:185
+#: src/olympia/editors/helpers.py:188
 msgid "Preliminary Review ({0})"
 msgid_plural "Preliminary Reviews ({0})"
 msgstr[0] "Ulasan Pendahuluan ({0})"
+msgstr[1] ""
 
-#: src/olympia/editors/helpers.py:190
+#: src/olympia/editors/helpers.py:193
 msgid "Moderated Review ({0})"
 msgid_plural "Moderated Reviews ({0})"
 msgstr[0] "Ulasan Dimoderasi ({0})"
+msgstr[1] ""
 
-#: src/olympia/editors/helpers.py:196
+#: src/olympia/editors/helpers.py:199
 msgid "Unlisted Full Review ({0})"
 msgid_plural "Unlisted Full Reviews ({0})"
 msgstr[0] "Ulasan Lengkap Tidak Terdaftar ({0})"
+msgstr[1] ""
 
-#: src/olympia/editors/helpers.py:201
+#: src/olympia/editors/helpers.py:204
 msgid "Unlisted Pending Update ({0})"
 msgid_plural "Unlisted Pending Updates ({0})"
 msgstr[0] "Pembaruan Tidak Terdaftar Ditunda ({0})"
+msgstr[1] ""
 
-#: src/olympia/editors/helpers.py:206
+#: src/olympia/editors/helpers.py:209
 msgid "Unlisted Preliminary Review ({0})"
 msgid_plural "Unlisted Preliminary Reviews ({0})"
 msgstr[0] "Ulasan Pendahuluan Tidak Terdaftar ({0})"
+msgstr[1] ""
 
-#: src/olympia/editors/helpers.py:261
-msgid "Addon"
-msgstr "Pengaya"
+#: src/olympia/editors/helpers.py:214
+msgid "Unlisted All Add-ons ({0})"
+msgid_plural "Unlisted All Add-ons ({0})"
+msgstr[0] ""
+msgstr[1] ""
 
-#: src/olympia/editors/helpers.py:262
+#: src/olympia/editors/helpers.py:274
 msgid "Type"
 msgstr "Тип"
 
-#: src/olympia/editors/helpers.py:263
+#: src/olympia/editors/helpers.py:275
 msgid "Waiting Time"
 msgstr "Waktu Tunggu"
 
-#: src/olympia/editors/helpers.py:264
-#: src/olympia/editors/templates/editors/review.html:285
+#: src/olympia/editors/helpers.py:276 src/olympia/editors/templates/editors/review.html:285
 msgid "Flags"
 msgstr "Tanda"
 
-#: src/olympia/editors/helpers.py:265
+#: src/olympia/editors/helpers.py:277
 msgid "Applications"
 msgstr "Aplikasi"
 
-#: src/olympia/editors/helpers.py:270
+#: src/olympia/editors/helpers.py:282
 msgid "Additional"
 msgstr "Tambahan"
 
-#: src/olympia/editors/helpers.py:285
+#: src/olympia/editors/helpers.py:302
 msgid "Site Specific"
 msgstr "Situs Tertentu"
 
-#: src/olympia/editors/helpers.py:287
+#: src/olympia/editors/helpers.py:304
 msgid "Requires External Software"
 msgstr "Perangkat Lunak Luar Diperlukan"
 
-#: src/olympia/editors/helpers.py:289
+#: src/olympia/editors/helpers.py:306
 msgid "Binary Components"
 msgstr "Komponen Biner"
 
-#: src/olympia/editors/helpers.py:313
+#: src/olympia/editors/helpers.py:339
 msgid "moments ago"
 msgstr "saat yang lalu"
 
 #. L10n: first argument is number of minutes
-#: src/olympia/editors/helpers.py:316
+#: src/olympia/editors/helpers.py:342
 msgid "{0} minute"
 msgid_plural "{0} minutes"
 msgstr[0] "{0} menit"
+msgstr[1] ""
 
 #. L10n: first argument is number of hours
-#: src/olympia/editors/helpers.py:320
+#: src/olympia/editors/helpers.py:346
 msgid "{0} hour"
 msgid_plural "{0} hours"
 msgstr[0] "{0} jam"
+msgstr[1] ""
 
 #. L10n: first argument is number of days
-#: src/olympia/editors/helpers.py:324
+#: src/olympia/editors/helpers.py:350
 msgid "{0} day"
 msgid_plural "{0} days"
 msgstr[0] "{0} hari"
+msgstr[1] ""
 
-#: src/olympia/editors/helpers.py:488
+#: src/olympia/editors/helpers.py:364
+msgid "Last Review"
+msgstr ""
+
+#: src/olympia/editors/helpers.py:366
+msgid "Last Update"
+msgstr ""
+
+#: src/olympia/editors/helpers.py:387
+msgid "No Reviews"
+msgstr ""
+
+#: src/olympia/editors/helpers.py:561
 msgid "Push to public"
 msgstr "Dorong ke publik"
 
-#: src/olympia/editors/helpers.py:490
+#: src/olympia/editors/helpers.py:563
 msgid "Grant full review"
 msgstr "Memberi ulasan lengkap"
 
-#: src/olympia/editors/helpers.py:505
+#: src/olympia/editors/helpers.py:578
 msgid "Request more information"
 msgstr "Meminta informasi tambahan"
 
-#: src/olympia/editors/helpers.py:508
+#: src/olympia/editors/helpers.py:581
 msgid "Request super-review"
 msgstr "Meminta ulasan-super"
 
-#: src/olympia/editors/helpers.py:519
+#: src/olympia/editors/helpers.py:592
 msgid "Grant preliminary review"
 msgstr "Memberi ulasan pendahuluan"
 
-#: src/olympia/editors/helpers.py:520
+#: src/olympia/editors/helpers.py:593
 msgid "This will mark the files as preliminarily reviewed."
 msgstr "Ini akan menandai berkas sebagai telah mendapat ulasan pendahuluan."
 
-#: src/olympia/editors/helpers.py:522
-msgid ""
-"Use this form to request more information from the author. They will receive"
-" an email and be able to answer here. You will be notified by email when "
-"they reply."
-msgstr ""
-"Gunakan formulir ini untuk meminta informasi tambahan dari penulis. Mereka "
-"akan menerima surel dan akan bisa menjawab di sini. Anda akan diberi tahu "
-"menggunakan surel saat mereka membalas."
+#: src/olympia/editors/helpers.py:595
+msgid "Use this form to request more information from the author. They will receive an email and be able to answer here. You will be notified by email when they reply."
+msgstr "Gunakan formulir ini untuk meminta informasi tambahan dari penulis. Mereka akan menerima surel dan akan bisa menjawab di sini. Anda akan diberi tahu menggunakan surel saat mereka membalas."
 
-#: src/olympia/editors/helpers.py:526
+#: src/olympia/editors/helpers.py:599
 msgid ""
-"If you have concerns about this add-on's security, copyright issues, or "
-"other concerns that an administrator should look into, enter your comments "
-"in the area below. They will be sent to administrators, not the author."
+"If you have concerns about this add-on's security, copyright issues, or other concerns that an administrator should look into, enter your comments in the area below. They will be sent to "
+"administrators, not the author."
 msgstr ""
-"Jika anda memiliki kekhawatiran mengenai keamanan pengaya ini, masalah hak "
-"cipta, atau kekhawatiran lainnya yang harus diperiksa administrator, "
-"masukkan komentar anda di area di bawah. Semua akan dikirimkan kepada "
-"administrator, bukan penulis."
+"Jika anda memiliki kekhawatiran mengenai keamanan pengaya ini, masalah hak cipta, atau kekhawatiran lainnya yang harus diperiksa administrator, masukkan komentar anda di area di bawah. Semua akan "
+"dikirimkan kepada administrator, bukan penulis."
 
-#: src/olympia/editors/helpers.py:532
+#: src/olympia/editors/helpers.py:605
 msgid "This will reject the add-on and remove it from the review queue."
 msgstr "Ini akan menolak pengaya dan mengeluarkannya dari antrean ulasan."
 
-#: src/olympia/editors/helpers.py:534
-msgid "Make a comment on this version.  The author won't be able to see this."
-msgstr ""
-"Berikan komentar untuk versi ini.  Penulis tidak akan dapat melihatnya."
+#: src/olympia/editors/helpers.py:607
+msgid "Make a comment on this version. The author won't be able to see this."
+msgstr "Berikan komentar untuk versi ini.  Penulis tidak akan dapat melihatnya."
 
-#: src/olympia/editors/helpers.py:538
+#: src/olympia/editors/helpers.py:611
 msgid "This will reject the files and remove them from the review queue."
 msgstr "Ini akan menolak pengaya dan mengeluarkannya dari antrean ulasan."
 
-#: src/olympia/editors/helpers.py:542
-msgid ""
-"This will mark the add-on as preliminarily reviewed. Future versions will "
-"undergo preliminary review."
-msgstr ""
-"Ini akan menandai pengaya sebagai telah mendapat ulasan pendahuluan. Versi "
-"sesudahnya akan melalui ulasan pendahuluan."
+#: src/olympia/editors/helpers.py:615
+msgid "This will mark the add-on as preliminarily reviewed. Future versions will undergo preliminary review."
+msgstr "Ini akan menandai pengaya sebagai telah mendapat ulasan pendahuluan. Versi sesudahnya akan melalui ulasan pendahuluan."
 
-#: src/olympia/editors/helpers.py:547
-msgid ""
-"This will mark the files as preliminarily reviewed. Future versions will "
-"undergo preliminary review."
-msgstr ""
-"Ini akan menandai pengaya sebagai telah mendapat ulasan pendahuluan. Versi "
-"sesudahnya akan melalui ulasan pendahuluan."
+#: src/olympia/editors/helpers.py:620
+msgid "This will mark the files as preliminarily reviewed. Future versions will undergo preliminary review."
+msgstr "Ini akan menandai pengaya sebagai telah mendapat ulasan pendahuluan. Versi sesudahnya akan melalui ulasan pendahuluan."
 
-#: src/olympia/editors/helpers.py:552
+#: src/olympia/editors/helpers.py:625
 msgid "Retain preliminary review"
 msgstr "Meneruskan ulasan pendahuluan"
 
-#: src/olympia/editors/helpers.py:553
-msgid ""
-"This will retain the add-on as preliminarily reviewed. Future versions will "
-"undergo preliminary review."
-msgstr ""
-"Ini akan meneruskan pengaya sebagai telah menerima ulasan pendahuluan. Versi"
-" sesudahnya akan melalui ulasan pendahuluan."
+#: src/olympia/editors/helpers.py:626
+msgid "This will retain the add-on as preliminarily reviewed. Future versions will undergo preliminary review."
+msgstr "Ini akan meneruskan pengaya sebagai telah menerima ulasan pendahuluan. Versi sesudahnya akan melalui ulasan pendahuluan."
 
-#: src/olympia/editors/helpers.py:558
-msgid ""
-"This will approve a sandboxed version of a public add-on to appear on the "
-"public side."
-msgstr ""
-"Ini akan menyetujui versi sandbox dari pengaya publik untuk muncul di sisi "
-"publik."
+#: src/olympia/editors/helpers.py:631
+msgid "This will approve a sandboxed version of a public add-on to appear on the public side."
+msgstr "Ini akan menyetujui versi sandbox dari pengaya publik untuk muncul di sisi publik."
 
-#: src/olympia/editors/helpers.py:561
-msgid ""
-"This will reject a version of a public add-on and remove it from the queue."
-msgstr ""
-"Ini akan menolak sebuah versi dari pengaya publik dan mengeluarkannya dari "
-"antrean."
-
-#: src/olympia/editors/helpers.py:564
-msgid ""
-"This will mark the add-on and its most recent version and files as public. "
-"Future versions will go into the sandbox until they are reviewed by an "
-"editor."
-msgstr ""
-"Ini akan menandai pengaya dan versi terbarunya dan berkasnya sebagai publik."
-" Versi berikutnya juga akan dimasukkan sandbox sampai diulas oleh "
-"penyunting."
+#: src/olympia/editors/helpers.py:634
+msgid "This will reject a version of a public add-on and remove it from the queue."
+msgstr "Ini akan menolak sebuah versi dari pengaya publik dan mengeluarkannya dari antrean."
 
 #: src/olympia/editors/helpers.py:637
+msgid "This will mark the add-on and its most recent version and files as public. Future versions will go into the sandbox until they are reviewed by an editor."
+msgstr "Ini akan menandai pengaya dan versi terbarunya dan berkasnya sebagai publik. Versi berikutnya juga akan dimasukkan sandbox sampai diulas oleh penyunting."
+
+#: src/olympia/editors/helpers.py:714
 msgid "add-on"
 msgstr "pengaya"
 
-#: src/olympia/editors/helpers.py:940 src/olympia/editors/helpers.py:960
+#: src/olympia/editors/helpers.py:1020 src/olympia/editors/helpers.py:1040
 msgid "Flagged"
 msgstr "Ditandai"
 
-#: src/olympia/editors/helpers.py:944 src/olympia/editors/helpers.py:963
+#: src/olympia/editors/helpers.py:1024 src/olympia/editors/helpers.py:1043
 msgid "Updates"
 msgstr "Pembaruan"
 
@@ -10028,74 +7853,70 @@ msgstr "Pendaftaran tema ditandai untuk peninjauan"
 msgid "A question about your Theme submission"
 msgstr "Ada pertanyaan mengenai pendaftaran Tema Anda"
 
-#: src/olympia/editors/views.py:144
+#: src/olympia/editors/views.py:146
 msgid "New Add-ons (Under 5 days)"
 msgstr "Pengaya Baru (Dibawah 5 hari)"
 
-#: src/olympia/editors/views.py:145
+#: src/olympia/editors/views.py:147
 msgid "Passable (5 to 10 days)"
 msgstr "Bisa dilewati (5 hingga 10 hari)"
 
-#: src/olympia/editors/views.py:146
+#: src/olympia/editors/views.py:148
 msgid "Overdue (Over 10 days)"
 msgstr "Terlambat (Lebih dari 10 hari)"
 
-#: src/olympia/editors/views.py:532
+#: src/olympia/editors/views.py:539
 msgid "An unknown error occurred"
 msgstr "Terjadi masalah yang tidak diketahui"
 
-#: src/olympia/editors/views.py:587
+#: src/olympia/editors/views.py:592
 msgid "Self-reviews are not allowed."
 msgstr "Mengulas sendiri tidak diperkenankan."
 
-#: src/olympia/editors/views.py:609
+#: src/olympia/editors/views.py:613
 msgid "Review successfully processed."
 msgstr "Ulasan berhasil diproses."
 
-#: src/olympia/editors/views.py:807
+#: src/olympia/editors/views.py:812
 msgid "was approved"
 msgstr "telah disetujui"
 
-#: src/olympia/editors/views.py:808
+#: src/olympia/editors/views.py:813
 msgid "given preliminary review"
 msgstr "diberi ulasan pendahuluan"
 
-#: src/olympia/editors/views.py:809
+#: src/olympia/editors/views.py:814
 msgid "rejected"
 msgstr "ditolak"
 
-#: src/olympia/editors/views.py:810
+#: src/olympia/editors/views.py:815
 msgctxt "editors_review_history_nominated_adminreview"
 msgid "escalated"
 msgstr "dieskalasi"
 
-#: src/olympia/editors/views.py:812
+#: src/olympia/editors/views.py:817
 msgid "needs more information"
 msgstr "perlu lebih banyak informasi"
 
-#: src/olympia/editors/views.py:813
+#: src/olympia/editors/views.py:818
 msgid "needs super review"
 msgstr "perlu ulasan super"
 
-#: src/olympia/editors/views.py:814
+#: src/olympia/editors/views.py:819
 msgid "commented"
 msgstr "dikomentari"
 
 #: src/olympia/editors/views_themes.py:326
 msgid "{0} theme review successfully processed (+{1} points, {2} total)."
-msgid_plural ""
-"{0} theme reviews successfully processed (+{1} points, {2} total)."
+msgid_plural "{0} theme reviews successfully processed (+{1} points, {2} total)."
 msgstr[0] "{0} ulasan tema berhasil diproses (+{1} poin, {2} total)."
+msgstr[1] ""
 
 #: src/olympia/editors/views_themes.py:341
-msgid ""
-"Your theme locks have successfully been released. Other reviewers may now "
-"review those released themes. You may have to refresh the page to see the "
-"changes reflected in the table below."
+msgid "Your theme locks have successfully been released. Other reviewers may now review those released themes. You may have to refresh the page to see the changes reflected in the table below."
 msgstr ""
-"Kunci tema anda berhasil dilepaskan. Pengulas lainnya sekarang bisa mengulas"
-" tema yang sudah dirilis tersebut. Anda mungkin harus melakukan refresh "
-"laman untuk melihat perubahan yang dimaksud dalam tabel di bawah ini."
+"Kunci tema anda berhasil dilepaskan. Pengulas lainnya sekarang bisa mengulas tema yang sudah dirilis tersebut. Anda mungkin harus melakukan refresh laman untuk melihat perubahan yang dimaksud dalam "
+"tabel di bawah ini."
 
 #: src/olympia/editors/templates/editors/abuse_reports.html:4
 msgid "{addon} :: Abuse Reports"
@@ -10119,9 +7940,7 @@ msgstr "<i>anonim</i> pada tanggal %(date)s [%(ip_address)s]"
 msgid "Return to the Editor Tools homepage"
 msgstr "Kembali ke beranda Perangkat Penyunting"
 
-#: src/olympia/editors/templates/editors/base.html:43
-#: src/olympia/editors/templates/editors/themes/base.html:14
-#: src/olympia/editors/templates/editors/themes/base.html:28
+#: src/olympia/editors/templates/editors/base.html:43 src/olympia/editors/templates/editors/themes/base.html:14 src/olympia/editors/templates/editors/themes/base.html:28
 #: src/olympia/editors/templates/editors/themes/queue.html:25
 msgid "Queues"
 msgstr "Черги"
@@ -10130,71 +7949,51 @@ msgstr "Черги"
 msgid "Unlisted Queues"
 msgstr "Antrean Tidak Terdaftar"
 
-#: src/olympia/editors/templates/editors/base.html:72
-#: src/olympia/editors/templates/editors/performance.html:6
+#: src/olympia/editors/templates/editors/base.html:74 src/olympia/editors/templates/editors/performance.html:6
 msgid "Performance"
 msgstr "Kinerja"
 
-#: src/olympia/editors/templates/editors/base.html:75
-#: src/olympia/editors/templates/editors/themes/base.html:19
-#: src/olympia/editors/templates/editors/themes/base.html:38
+#: src/olympia/editors/templates/editors/base.html:77 src/olympia/editors/templates/editors/themes/base.html:19 src/olympia/editors/templates/editors/themes/base.html:38
 msgid "Logs"
 msgstr "Логи"
 
-#: src/olympia/editors/templates/editors/base.html:78
-#: src/olympia/editors/templates/editors/reviewlog.html:4
-#: src/olympia/editors/templates/editors/reviewlog.html:27
+#: src/olympia/editors/templates/editors/base.html:80 src/olympia/editors/templates/editors/reviewlog.html:4 src/olympia/editors/templates/editors/reviewlog.html:27
 msgid "Add-on Review Log"
 msgstr "Log Ulasan Pengaya"
 
-#: src/olympia/editors/templates/editors/base.html:80
-#: src/olympia/editors/templates/editors/eventlog.html:4
-#: src/olympia/editors/templates/editors/eventlog.html:8
+#: src/olympia/editors/templates/editors/base.html:82 src/olympia/editors/templates/editors/eventlog.html:4 src/olympia/editors/templates/editors/eventlog.html:8
 #: src/olympia/editors/templates/editors/eventlog_detail.html:4
 msgid "Moderated Review Log"
 msgstr "Log Ulasan Dimoderasi"
 
-#: src/olympia/editors/templates/editors/base.html:82
-#: src/olympia/editors/templates/editors/beta_signed_log.html:4
-#: src/olympia/editors/templates/editors/beta_signed_log.html:8
+#: src/olympia/editors/templates/editors/base.html:84 src/olympia/editors/templates/editors/beta_signed_log.html:4 src/olympia/editors/templates/editors/beta_signed_log.html:8
 msgid "Signed Beta Files Log"
 msgstr "Log Berkas Beta Ditandatangani"
 
-#: src/olympia/editors/templates/editors/base.html:87
-#: src/olympia/editors/templates/editors/includes/daily-message.html:4
+#: src/olympia/editors/templates/editors/base.html:89 src/olympia/editors/templates/editors/includes/daily-message.html:4
 msgid "Announcement"
 msgstr "Pengumuman"
 
 #. "Filter" is a button label (verb)
-#: src/olympia/editors/templates/editors/beta_signed_log.html:17
-#: src/olympia/editors/templates/editors/eventlog.html:24
-#: src/olympia/editors/templates/editors/reviewlog.html:21
-#: src/olympia/editors/templates/editors/themes/macros.html:45
-#: src/olympia/editors/templates/editors/themes/includes/logs_filter_deleted.html:12
+#: src/olympia/editors/templates/editors/beta_signed_log.html:17 src/olympia/editors/templates/editors/eventlog.html:24 src/olympia/editors/templates/editors/reviewlog.html:21
+#: src/olympia/editors/templates/editors/themes/macros.html:45 src/olympia/editors/templates/editors/themes/includes/logs_filter_deleted.html:12
 msgid "Filter"
 msgstr "Saringan"
 
-#: src/olympia/editors/templates/editors/beta_signed_log.html:23
-#: src/olympia/editors/templates/editors/eventlog.html:30
-#: src/olympia/editors/templates/editors/reviewlog.html:34
+#: src/olympia/editors/templates/editors/beta_signed_log.html:23 src/olympia/editors/templates/editors/eventlog.html:30 src/olympia/editors/templates/editors/reviewlog.html:34
 #: src/olympia/editors/templates/editors/themes/logs.html:16
 msgid "Date"
 msgstr "Дата"
 
-#: src/olympia/editors/templates/editors/beta_signed_log.html:24
-#: src/olympia/editors/templates/editors/eventlog.html:31
-#: src/olympia/editors/templates/editors/reviewlog.html:35
+#: src/olympia/editors/templates/editors/beta_signed_log.html:24 src/olympia/editors/templates/editors/eventlog.html:31 src/olympia/editors/templates/editors/reviewlog.html:35
 msgid "Event"
 msgstr "Acara"
 
-#: src/olympia/editors/templates/editors/beta_signed_log.html:37
-#: src/olympia/editors/templates/editors/eventlog.html:44
-#: src/olympia/editors/templates/editors/home.html:180
+#: src/olympia/editors/templates/editors/beta_signed_log.html:37 src/olympia/editors/templates/editors/eventlog.html:44 src/olympia/editors/templates/editors/home.html:180
 msgid "More details."
 msgstr "Rincian lainnya."
 
-#: src/olympia/editors/templates/editors/beta_signed_log.html:46
-#: src/olympia/editors/templates/editors/eventlog.html:53
+#: src/olympia/editors/templates/editors/beta_signed_log.html:46 src/olympia/editors/templates/editors/eventlog.html:53
 msgid "No events found for this period."
 msgstr "Tidak ada acara yang ditemukan dalam rentang waktu ini."
 
@@ -10230,30 +8029,31 @@ msgstr "Tidak dihapus"
 msgid "Full Review ({num})"
 msgid_plural "Full Reviews ({num})"
 msgstr[0] "Ulasan Lengkap ({num})"
+msgstr[1] ""
 
 #: src/olympia/editors/templates/editors/home.html:18
 msgid "Pending Update ({num})"
 msgid_plural "Pending Updates ({num})"
 msgstr[0] "Pembaruan Ditunda ({num})"
+msgstr[1] ""
 
 #: src/olympia/editors/templates/editors/home.html:25
 msgid "Preliminary Review ({num})"
 msgid_plural "Preliminary Reviews ({num})"
 msgstr[0] "Ulasan Pendahuluan ({num})"
+msgstr[1] ""
 
-#: src/olympia/editors/templates/editors/home.html:36
-#: src/olympia/editors/templates/editors/home.html:86
+#: src/olympia/editors/templates/editors/home.html:36 src/olympia/editors/templates/editors/home.html:86
 msgid "Current waiting times:"
 msgstr "Waktu tunggu saat ini:"
 
-#: src/olympia/editors/templates/editors/home.html:44
-#: src/olympia/editors/templates/editors/home.html:94
+#: src/olympia/editors/templates/editors/home.html:44 src/olympia/editors/templates/editors/home.html:94
 msgid "{0} add-on"
 msgid_plural "{0} add-ons"
 msgstr[0] "{0} pengaya"
+msgstr[1] ""
 
-#: src/olympia/editors/templates/editors/home.html:45
-#: src/olympia/editors/templates/editors/home.html:95
+#: src/olympia/editors/templates/editors/home.html:45 src/olympia/editors/templates/editors/home.html:95
 #, python-format
 msgid "{0}%%"
 msgstr "{0}%%"
@@ -10262,25 +8062,25 @@ msgstr "{0}%%"
 msgid "Unlisted Full Review ({num})"
 msgid_plural "Unlisted Full Reviews ({num})"
 msgstr[0] "Ulasan Lengkap Tidak Terdaftar ({num})"
+msgstr[1] ""
 
 #: src/olympia/editors/templates/editors/home.html:68
 msgid "Unlisted Pending Update ({num})"
 msgid_plural "Unlisted Pending Updates ({num})"
 msgstr[0] "Pembaruan Ditunda Tidak Terdaftar ({num})"
+msgstr[1] ""
 
 #: src/olympia/editors/templates/editors/home.html:75
 msgid "Unlisted Preliminary Review ({num})"
 msgid_plural "Unlisted Preliminary Reviews ({num})"
 msgstr[0] "Ulasan Pendahuluan Tidak Terdaftar ({num})"
+msgstr[1] ""
 
-#: src/olympia/editors/templates/editors/home.html:109
-#: src/olympia/editors/templates/editors/performance.html:37
-#: src/olympia/editors/templates/editors/themes/home.html:54
+#: src/olympia/editors/templates/editors/home.html:109 src/olympia/editors/templates/editors/performance.html:37 src/olympia/editors/templates/editors/themes/home.html:54
 msgid "Total Reviews"
 msgstr "Ulasan Total"
 
-#: src/olympia/editors/templates/editors/home.html:110
-#: src/olympia/editors/templates/editors/themes/home.html:55
+#: src/olympia/editors/templates/editors/home.html:110 src/olympia/editors/templates/editors/themes/home.html:55
 msgid "Reviews This Month"
 msgstr "Ulasan Bulan Ini"
 
@@ -10288,8 +8088,7 @@ msgstr "Ulasan Bulan Ini"
 msgid "New Editors"
 msgstr "Editor Baru"
 
-#: src/olympia/editors/templates/editors/home.html:126
-#: src/olympia/editors/templates/editors/home.html:141
+#: src/olympia/editors/templates/editors/home.html:126 src/olympia/editors/templates/editors/home.html:141
 msgid "You're #{0} with {1} reviews"
 msgstr "Anda #{0} dengan {1} ulasan"
 
@@ -10298,14 +8097,13 @@ msgstr "Anda #{0} dengan {1} ulasan"
 msgid "Moderated Review ({num})"
 msgid_plural "Moderated Reviews ({num})"
 msgstr[0] "Ulasan Dimoderasi ({num})"
+msgstr[1] ""
 
-#: src/olympia/editors/templates/editors/leaderboard.html:3
-#: src/olympia/editors/templates/editors/includes/reviewers_score_bar.html:56
+#: src/olympia/editors/templates/editors/leaderboard.html:3 src/olympia/editors/templates/editors/includes/reviewers_score_bar.html:56
 msgid "Reviewer Leaderboard"
 msgstr "Papan Pimpinan Pengulas"
 
-#: src/olympia/editors/templates/editors/leaderboard.html:18
-#: src/olympia/editors/templates/editors/performance.html:65
+#: src/olympia/editors/templates/editors/leaderboard.html:18 src/olympia/editors/templates/editors/performance.html:65
 msgid "No review points awarded yet."
 msgstr "Belum ada nilai ulasan yang diberikan."
 
@@ -10325,8 +8123,7 @@ msgstr "Pesan Hari Ini"
 msgid "Update message of the day"
 msgstr "Perbarui pesan hari ini"
 
-#: src/olympia/editors/templates/editors/motd.html:15
-#: src/olympia/editors/templates/editors/review.html:224
+#: src/olympia/editors/templates/editors/motd.html:15 src/olympia/editors/templates/editors/review.html:224
 msgid "Save"
 msgstr "Simpan"
 
@@ -10394,51 +8191,45 @@ msgstr "Pencarian Lanjut"
 msgid "clear search"
 msgstr "hapus pencarian"
 
-#: src/olympia/editors/templates/editors/queue.html:72
-#: src/olympia/editors/templates/editors/queue.html:122
+#: src/olympia/editors/templates/editors/queue.html:78 src/olympia/editors/templates/editors/queue.html:128
 msgid "Process Reviews"
 msgstr "Proses Mengulas"
 
-#: src/olympia/editors/templates/editors/queue.html:80
+#: src/olympia/editors/templates/editors/queue.html:86
 msgid "Moderation actions:"
 msgstr "Aksi moderasi:"
 
-#: src/olympia/editors/templates/editors/queue.html:90
+#: src/olympia/editors/templates/editors/queue.html:96
 #, python-format
 msgid "by %(user)s on %(date)s %(stars)s (%(locale)s)"
 msgstr "oleh %(user)s pada %(date)s %(stars)s (%(locale)s)"
 
-#: src/olympia/editors/templates/editors/queue.html:106
+#: src/olympia/editors/templates/editors/queue.html:112
 #, python-format
-msgid ""
-"<strong>%(reason)s</strong> <span class=\"light\">Flagged by %(user)s on "
-"%(date)s</span>"
-msgstr ""
-"<strong>%(reason)s</strong> <span class=\"light\">Ditandai oleh %(user)s "
-"pada %(date)s</span>"
+msgid "<strong>%(reason)s</strong> <span class=\"light\">Flagged by %(user)s on %(date)s</span>"
+msgstr "<strong>%(reason)s</strong> <span class=\"light\">Ditandai oleh %(user)s pada %(date)s</span>"
 
-#: src/olympia/editors/templates/editors/queue.html:119
-msgid "All reviews have been moderated.  Good work!"
+#: src/olympia/editors/templates/editors/queue.html:125
+msgid "All reviews have been moderated. Good work!"
 msgstr "Seluruh ulasan telah dimoderasi.  Kerja bagus!"
 
-#: src/olympia/editors/templates/editors/queue.html:161
+#: src/olympia/editors/templates/editors/queue.html:167
 msgid "Version Notes / Notes for Reviewer"
 msgstr "Catatan Versi / Catatan untuk Pengulas"
 
-#: src/olympia/editors/templates/editors/queue.html:169
+#: src/olympia/editors/templates/editors/queue.html:175
 msgid "There are currently no add-ons of this type to review."
 msgstr "Saat ini tidak ada pengaya jenis ini untuk diulas."
 
-#: src/olympia/editors/templates/editors/queue.html:181
-#: src/olympia/editors/templates/editors/themes/queue_list.html:85
+#: src/olympia/editors/templates/editors/queue.html:187 src/olympia/editors/templates/editors/themes/queue_list.html:85
 msgid "Helpful Links:"
 msgstr "Tautan yang Berguna:"
 
-#: src/olympia/editors/templates/editors/queue.html:182
+#: src/olympia/editors/templates/editors/queue.html:188
 msgid "Add-on Policy"
 msgstr "Kebijakan Pengaya"
 
-#: src/olympia/editors/templates/editors/queue.html:184
+#: src/olympia/editors/templates/editors/queue.html:190
 msgid "Editors' Guide"
 msgstr "Panduan Editor"
 
@@ -10451,19 +8242,14 @@ msgstr "Ulasan {0}"
 msgid "Add-on user change history"
 msgstr "Riwayat perubahan pengguna pengaya"
 
-#: src/olympia/editors/templates/editors/review.html:52
-#: src/olympia/editors/templates/editors/review.html:266
+#: src/olympia/editors/templates/editors/review.html:52 src/olympia/editors/templates/editors/review.html:266
 msgid "Add-on History"
 msgstr "Riwayat Pengaya"
 
 #: src/olympia/editors/templates/editors/review.html:64
 #, python-format
-msgid ""
-"Version %(version)s &middot; %(created)s <span class=\"light\">&middot; "
-"%(version_status)s</span>"
-msgstr ""
-"Versi %(version)s &middot; %(created)s <span class=\"light\">&middot; "
-"%(version_status)s</span>"
+msgid "Version %(version)s &middot; %(created)s <span class=\"light\">&middot; %(version_status)s</span>"
+msgstr "Versi %(version)s &middot; %(created)s <span class=\"light\">&middot; %(version_status)s</span>"
 
 #: src/olympia/editors/templates/editors/review.html:73
 msgid "Compatibility:"
@@ -10486,19 +8272,14 @@ msgid "This version has not been reviewed."
 msgstr "Versi ini belum diulas."
 
 #: src/olympia/editors/templates/editors/review.html:154
-msgid ""
-"You can still submit this form, however only do so if you know it won't "
-"conflict."
-msgstr ""
-"Anda masih bisa memasukkan formulir ini, bagaimanapun hanya lakukan jika "
-"anda mengetahui ini tidak akan berbenturan."
+msgid "You can still submit this form, however only do so if you know it won't conflict."
+msgstr "Anda masih bisa memasukkan formulir ini, bagaimanapun hanya lakukan jika anda mengetahui ini tidak akan berbenturan."
 
 #: src/olympia/editors/templates/editors/review.html:161
 msgid "Insert canned response..."
 msgstr "Masukkan respons yang dibatasi..."
 
-#: src/olympia/editors/templates/editors/review.html:167
-#: src/olympia/files/templates/files/viewer.html:54
+#: src/olympia/editors/templates/editors/review.html:167 src/olympia/files/templates/files/viewer.html:54
 msgid "Files:"
 msgstr "Berkas:"
 
@@ -10507,17 +8288,11 @@ msgid "Tested on:"
 msgstr "Dites pada:"
 
 #: src/olympia/editors/templates/editors/review.html:220
-msgid ""
-"<strong>Warning!</strong> Another user was viewing this page before you."
-msgstr ""
-"<strong>Perhatian!</strong> Pengguna lain sedang menyaksikan laman ini "
-"sebelum anda."
+msgid "<strong>Warning!</strong> Another user was viewing this page before you."
+msgstr "<strong>Perhatian!</strong> Pengguna lain sedang menyaksikan laman ini sebelum anda."
 
 #: src/olympia/editors/templates/editors/review.html:237
-msgid ""
-"The whiteboard is the place to exchange information relevant to\n"
-"               this addon (whatever the version), between the developer and the\n"
-"               editor. This is visible and editable by both."
+msgid "The whiteboard is the place to exchange information relevant to this addon (whatever the version), between the developer and the editor. This is visible and editable by both."
 msgstr ""
 "Papan tulis adalah tempat bertukar informasi yang relevan untuk \n"
 "               pengaya ini (apapun versinya), antara para pengaya dan\n"
@@ -10527,8 +8302,7 @@ msgstr ""
 msgid "Update the whiteboard"
 msgstr "Perbarui papan tulis"
 
-#: src/olympia/editors/templates/editors/review.html:257
-#: src/olympia/editors/templates/editors/review.html:258
+#: src/olympia/editors/templates/editors/review.html:257 src/olympia/editors/templates/editors/review.html:258
 msgid "(admin)"
 msgstr "(admin)"
 
@@ -10556,18 +8330,15 @@ msgstr "Editor"
 msgid "Add-on has been deleted."
 msgstr "Pengaya telah dihapus."
 
-#: src/olympia/editors/templates/editors/reviewlog.html:59
-#: src/olympia/editors/templates/editors/themes/logs.html:36
+#: src/olympia/editors/templates/editors/reviewlog.html:59 src/olympia/editors/templates/editors/themes/logs.html:36
 msgid "Show Comments"
 msgstr "Tampilkan Komentar"
 
-#: src/olympia/editors/templates/editors/reviewlog.html:60
-#: src/olympia/editors/templates/editors/themes/logs.html:37
+#: src/olympia/editors/templates/editors/reviewlog.html:60 src/olympia/editors/templates/editors/themes/logs.html:37
 msgid "Hide Comments"
 msgstr "Sembunyikan Komentar"
 
-#: src/olympia/editors/templates/editors/reviewlog.html:72
-#: src/olympia/editors/templates/editors/themes/logs.html:54
+#: src/olympia/editors/templates/editors/reviewlog.html:72 src/olympia/editors/templates/editors/themes/logs.html:54
 msgid "No reviews found for this period."
 msgstr "Tidak ada ulasan ditemukan untuk rentang waktu ini."
 
@@ -10625,11 +8396,8 @@ msgstr "Sepanjang Masa"
 msgid "You have <span>{0}</span> points."
 msgstr "Anda memiliki <span>{0}</span> poin."
 
-#: src/olympia/editors/templates/editors/includes/search_results_themes.html:6
-#: src/olympia/editors/templates/editors/themes/history_table.html:7
-#: src/olympia/editors/templates/editors/themes/logs.html:19
-#: src/olympia/editors/templates/editors/themes/queue_list.html:49
-#: src/olympia/editors/templates/editors/themes/single.html:26
+#: src/olympia/editors/templates/editors/includes/search_results_themes.html:6 src/olympia/editors/templates/editors/themes/history_table.html:7
+#: src/olympia/editors/templates/editors/themes/logs.html:19 src/olympia/editors/templates/editors/themes/queue_list.html:49 src/olympia/editors/templates/editors/themes/single.html:26
 #: src/olympia/editors/templates/editors/themes/themes.html:45
 msgid "Reviewer"
 msgstr "Pengulas"
@@ -10654,8 +8422,7 @@ msgstr "Riwayat Ulasan Tema untuk {0}"
 msgid "Review Date"
 msgstr "Tanggal Ulasan"
 
-#: src/olympia/editors/templates/editors/themes/history_table.html:9
-#: src/olympia/editors/templates/editors/themes/logs.html:18
+#: src/olympia/editors/templates/editors/themes/history_table.html:9 src/olympia/editors/templates/editors/themes/logs.html:18
 msgid "Action"
 msgstr "Tindakan"
 
@@ -10671,16 +8438,19 @@ msgstr "Saat ini tidak ada ulasan."
 msgid "{num} Pending Theme Review"
 msgid_plural "{num} Pending Theme Reviews"
 msgstr[0] "{num} Ulasan Tema Ditunda"
+msgstr[1] ""
 
 #: src/olympia/editors/templates/editors/themes/home.html:27
 msgid "{num} Flagged Review"
 msgid_plural "{num} Flagged Reviews"
 msgstr[0] "{num} Ulasan DItandai"
+msgstr[1] ""
 
 #: src/olympia/editors/templates/editors/themes/home.html:34
 msgid "{num} Update"
 msgid_plural "{num} Updates"
 msgstr[0] "{num} Pembaruan"
+msgstr[1] ""
 
 #: src/olympia/editors/templates/editors/themes/logs.html:4
 msgid "Theme Review Log"
@@ -10799,7 +8569,7 @@ msgstr "Ajukan pertanyaan pada seniman"
 msgid "Describe your reason for flagging"
 msgstr "Jelaskan alasan anda menandai"
 
-#: src/olympia/files/forms.py:88
+#: src/olympia/files/forms.py:90
 msgid "Cannot diff a version against itself"
 msgstr "Tidak bisa melakukan diff sebuah versi atas dirinya sendiri"
 
@@ -10817,12 +8587,8 @@ msgid "Problems decoding {0}."
 msgstr "Masalah saat mengurai kode {0}."
 
 #: src/olympia/files/helpers.py:186
-msgid ""
-"This file is not viewable online. Please download the file to view the "
-"contents."
-msgstr ""
-"Berkas ini tidak dapat dilihat secara daring. Harap mengunduh berkas untuk "
-"melihat kontennya."
+msgid "This file is not viewable online. Please download the file to view the contents."
+msgstr "Berkas ini tidak dapat dilihat secara daring. Harap mengunduh berkas untuk melihat kontennya."
 
 #: src/olympia/files/helpers.py:194
 msgid "This file is a directory."
@@ -10838,55 +8604,51 @@ msgstr "Terjadi kesalahan saat mengakses berkas %s. %s."
 msgid "There was an error accessing file %s."
 msgstr "Terjadi kesalahan saat mengakses berkas %s."
 
-#: src/olympia/files/utils.py:343
+#: src/olympia/files/utils.py:340
 msgid "Could not parse uploaded file."
 msgstr "Tidak dapat mengurai berkas yang diunggah."
 
-#: src/olympia/files/utils.py:380
+#: src/olympia/files/utils.py:377
 msgid "Invalid file name in archive: {0}"
 msgstr "Nama berkas dalam arsip tidak benar: {0}"
 
-#: src/olympia/files/utils.py:388
+#: src/olympia/files/utils.py:385
 msgid "File exceeding size limit in archive: {0}"
 msgstr "Berkas melebihi batas ukuran dalam arsip: {0}"
 
-#: src/olympia/files/utils.py:439
+#: src/olympia/files/utils.py:436
 msgid "Invalid archive."
 msgstr "Arsip tidak sah."
 
-#: src/olympia/files/utils.py:529 src/olympia/files/utils.py:532
+#: src/olympia/files/utils.py:526 src/olympia/files/utils.py:529
 msgid "Could not parse the manifest file."
 msgstr "Tidak bisa mengurai berkas manifest."
 
-#: src/olympia/files/utils.py:551
+#: src/olympia/files/utils.py:548
 msgid "Could not find an add-on ID."
 msgstr "Tidak bisa menemukan ID pengaya."
 
-#: src/olympia/files/utils.py:554
+#: src/olympia/files/utils.py:551
 msgid "Add-on ID must be 64 characters or less."
 msgstr "ID pengaya harus terdiri dari 64 karakter atau kurang dari itu."
 
-#: src/olympia/files/utils.py:556
+#: src/olympia/files/utils.py:553
 msgid "Add-on ID doesn't match add-on."
 msgstr "ID pengaya tidak sesuai dengan pengaya."
 
-#: src/olympia/files/utils.py:564
+#: src/olympia/files/utils.py:561
 msgid "Duplicate add-on ID found."
 msgstr "Menduplikasi ID pengaya yang ditemukan."
 
-#: src/olympia/files/utils.py:567
+#: src/olympia/files/utils.py:564
 msgid "Version numbers should have fewer than 32 characters."
 msgstr "Nomor versi harus kurang dari 32 karakter."
 
-#: src/olympia/files/utils.py:570
-msgid ""
-"Version numbers should only contain letters, numbers, and these punctuation "
-"characters: +*.-_."
-msgstr ""
-"Nomor versi hanya bisa terdiri dari huruf, angka, dan karakter tanda baca "
-"ini: +*.-_."
+#: src/olympia/files/utils.py:567
+msgid "Version numbers should only contain letters, numbers, and these punctuation characters: +*.-_."
+msgstr "Nomor versi hanya bisa terdiri dari huruf, angka, dan karakter tanda baca ini: +*.-_."
 
-#: src/olympia/files/utils.py:587
+#: src/olympia/files/utils.py:584
 msgid "<em:type> doesn't match add-on"
 msgstr "<em:type> tidak cocok dengan pengaya"
 
@@ -10904,12 +8666,8 @@ msgstr "Unduh {0}"
 
 #: src/olympia/files/templates/files/file.html:4
 #, python-format
-msgid ""
-"Version: %(version)s &bull; Size: %(size)s &bull; MD5 hash: %(md5)s &bull; "
-"Mimetype: %(mimetype)s"
-msgstr ""
-"Versi: %(version)s &bull; Ukuran: %(size)s &bull; MD5 hash: %(md5)s &bull; "
-"Mimetype: %(mimetype)s"
+msgid "Version: %(version)s &bull; Size: %(size)s &bull; MD5 hash: %(md5)s &bull; Mimetype: %(mimetype)s"
+msgstr "Versi: %(version)s &bull; Ukuran: %(size)s &bull; MD5 hash: %(md5)s &bull; Mimetype: %(mimetype)s"
 
 #: src/olympia/files/templates/files/viewer.html:4
 msgid "File Compare :: Editor tools"
@@ -10947,48 +8705,39 @@ msgstr "Versi pengaya SDK:"
 msgid "Tab stops:"
 msgstr "Hentikan tab:"
 
-#: src/olympia/files/templates/files/viewer.html:79
-#: src/olympia/files/templates/files/viewer.html:80
+#: src/olympia/files/templates/files/viewer.html:79 src/olympia/files/templates/files/viewer.html:80
 msgid "Up file"
 msgstr "Unggah berkas"
 
-#: src/olympia/files/templates/files/viewer.html:84
-#: src/olympia/files/templates/files/viewer.html:85
+#: src/olympia/files/templates/files/viewer.html:84 src/olympia/files/templates/files/viewer.html:85
 msgid "Down file"
 msgstr "Unduh berkas"
 
-#: src/olympia/files/templates/files/viewer.html:90
-#: src/olympia/files/templates/files/viewer.html:91
+#: src/olympia/files/templates/files/viewer.html:90 src/olympia/files/templates/files/viewer.html:91
 msgid "Previous diff"
 msgstr "Diff sebelumnya"
 
-#: src/olympia/files/templates/files/viewer.html:93
-#: src/olympia/files/templates/files/viewer.html:94
+#: src/olympia/files/templates/files/viewer.html:93 src/olympia/files/templates/files/viewer.html:94
 msgid "Previous note"
 msgstr "Catatan sebelumnya"
 
-#: src/olympia/files/templates/files/viewer.html:100
-#: src/olympia/files/templates/files/viewer.html:101
+#: src/olympia/files/templates/files/viewer.html:100 src/olympia/files/templates/files/viewer.html:101
 msgid "Next diff"
 msgstr "Diff berikutnya"
 
-#: src/olympia/files/templates/files/viewer.html:103
-#: src/olympia/files/templates/files/viewer.html:104
+#: src/olympia/files/templates/files/viewer.html:103 src/olympia/files/templates/files/viewer.html:104
 msgid "Next note"
 msgstr "Catatan berikutnya"
 
-#: src/olympia/files/templates/files/viewer.html:109
-#: src/olympia/files/templates/files/viewer.html:110
+#: src/olympia/files/templates/files/viewer.html:109 src/olympia/files/templates/files/viewer.html:110
 msgid "Expand all"
 msgstr "Buka semua"
 
-#: src/olympia/files/templates/files/viewer.html:114
-#: src/olympia/files/templates/files/viewer.html:115
+#: src/olympia/files/templates/files/viewer.html:114 src/olympia/files/templates/files/viewer.html:115
 msgid "Hide or unhide tree"
 msgstr "Sembunyikan atau tampilkan pohon"
 
-#: src/olympia/files/templates/files/viewer.html:119
-#: src/olympia/files/templates/files/viewer.html:120
+#: src/olympia/files/templates/files/viewer.html:119 src/olympia/files/templates/files/viewer.html:120
 msgid "Wrap or unwrap text"
 msgstr "Bungkus atau buka teks"
 
@@ -10999,6 +8748,10 @@ msgstr "Tidak ada berkas dalam berkas yang diunggah."
 #: src/olympia/files/templates/files/viewer.html:134
 msgid "Fetching file."
 msgstr "Mengambil berkas."
+
+#: src/olympia/legacy_api/views.py:255
+msgid "Not implemented yet."
+msgstr "Belum diimplementasikan."
 
 #: src/olympia/lib/constants.py:6
 msgid "United Arab Emirates Dirham"
@@ -11656,12 +9409,7 @@ msgstr "Kwacha Zambia"
 msgid "Zimbabwe Dollar"
 msgstr "Dollar Zimbabwe"
 
-#: src/olympia/lib/video/ffmpeg.py:112 src/olympia/lib/video/totem.py:81
-msgid "Videos must be in WebM."
-msgstr "Video harus berupa WebM."
-
-#: src/olympia/pages/templates/pages/about.lhtml:3
-#: src/olympia/pages/templates/pages/about.lhtml:10
+#: src/olympia/pages/templates/pages/about.lhtml:3 src/olympia/pages/templates/pages/about.lhtml:10
 msgid "About Mozilla Add-ons"
 msgstr "Tentang Pengaya Mozilla"
 
@@ -11671,18 +9419,11 @@ msgstr "Apakah situs ini?"
 
 #: src/olympia/pages/templates/pages/about.lhtml:13
 msgid ""
-"addons.mozilla.org, commonly known as \"AMO\", is Mozilla's official site "
-"for add-ons to Mozilla software, such as Firefox, Thunderbird, and "
-"SeaMonkey. Add-ons let you add new features and change the way your browser "
-"or application works.  Take a look around and explore the thousands of ways "
-"to customize the way you do things online."
+"addons.mozilla.org, commonly known as \"AMO\", is Mozilla's official site for add-ons to Mozilla software, such as Firefox, Thunderbird, and SeaMonkey. Add-ons let you add new features and change "
+"the way your browser or application works. Take a look around and explore the thousands of ways to customize the way you do things online."
 msgstr ""
-"addons.mozilla.org, secara umum dikenal sebagai \"AMO\", adalah situs resmi "
-"Mozilla untuk pengaya bagi perangkat lunak Mozilla. seperti Firefox, "
-"Thunderbird, dan SeaMonkey. Pengaya memungkinkan anda menambah fitur baru "
-"dan mengubah cara peramban atau aplikasi anda bekerja.  Lihatlah sekeliling "
-"dan eksplorasi ribuan cara untuk menyesuaikan cara anda melakukan hal-hal "
-"daring."
+"addons.mozilla.org, secara umum dikenal sebagai \"AMO\", adalah situs resmi Mozilla untuk pengaya bagi perangkat lunak Mozilla. seperti Firefox, Thunderbird, dan SeaMonkey. Pengaya memungkinkan "
+"anda menambah fitur baru dan mengubah cara peramban atau aplikasi anda bekerja.  Lihatlah sekeliling dan eksplorasi ribuan cara untuk menyesuaikan cara anda melakukan hal-hal daring."
 
 #: src/olympia/pages/templates/pages/about.lhtml:19
 msgid "Who creates these add-ons?"
@@ -11690,110 +9431,70 @@ msgstr "Siapakah yang membuat pengaya ini?"
 
 #: src/olympia/pages/templates/pages/about.lhtml:20
 msgid ""
-"The add-ons listed here have been created by thousands of developers from "
-"our community, ranging from individual hobbyists to large corporations. All "
-"publicly listed add-ons are reviewed by a team of editors before being "
-"released. Add-ons marked as Experimental have not been reviewed and should "
-"only be installed with caution."
+"The add-ons listed here have been created by thousands of developers from our community, ranging from individual hobbyists to large corporations. All publicly listed add-ons are reviewed by a team "
+"of editors before being released. Add-ons marked as Experimental have not been reviewed and should only be installed with caution."
 msgstr ""
-"Pengaya yang terdaftar di sini telah dibuat oleh ribuan pengembang dari "
-"negara kami, mulai dari pehobi individu sampai perusahaan besar. Semua "
-"pengaya yang terdaftar secara publik diulas oleh tim penyunting sebelum "
-"dirilis. Pengaya yang ditandai Eksperimental belum diulas dan hanya bisa "
-"dipasang dengan kewaspadaan."
+"Pengaya yang terdaftar di sini telah dibuat oleh ribuan pengembang dari negara kami, mulai dari pehobi individu sampai perusahaan besar. Semua pengaya yang terdaftar secara publik diulas oleh tim "
+"penyunting sebelum dirilis. Pengaya yang ditandai Eksperimental belum diulas dan hanya bisa dipasang dengan kewaspadaan."
 
 #: src/olympia/pages/templates/pages/about.lhtml:26
 msgid "How do I keep up with what's happening at AMO?"
 msgstr "Bagaimana saya bisa tetap mengikuti hal-hal yang terjadi di AMO?"
 
 #: src/olympia/pages/templates/pages/about.lhtml:27
-msgid ""
-"There are several ways to find out the latest news from the world of add-"
-"ons:"
+msgid "There are several ways to find out the latest news from the world of add-ons:"
 msgstr "Ada beberapa cara untuk mengetahui kabar terbaru dari dunia pengaya:"
 
 #: src/olympia/pages/templates/pages/about.lhtml:29
 #, python-format
-msgid ""
-"Our <a href=\"%(url)s\">Add-ons Blog</a> is regularly updated with "
-"information for both add-on enthusiasts and developers."
-msgstr ""
-"<a href=\"%(url)s\">Blog Pengaya</a> kami secara teratur diperbarui dengan "
-"informasi baik bagi penggemar pengaya dan pengembang."
+msgid "Our <a href=\"%(url)s\">Add-ons Blog</a> is regularly updated with information for both add-on enthusiasts and developers."
+msgstr "<a href=\"%(url)s\">Blog Pengaya</a> kami secara teratur diperbarui dengan informasi baik bagi penggemar pengaya dan pengembang."
 
 #: src/olympia/pages/templates/pages/about.lhtml:32
 #, python-format
-msgid ""
-"We often post news, tips, and tricks to our Twitter account, <a "
-"href=\"%(url)s\">mozamo</a>"
-msgstr ""
-"Kami sering mengirimkan berita, kiat dan trik ke akun Twitter, <a "
-"href=\"%(url)s\">mozamo</a>"
+msgid "We often post news, tips, and tricks to our Twitter account, <a href=\"%(url)s\">mozamo</a>"
+msgstr "Kami sering mengirimkan berita, kiat dan trik ke akun Twitter, <a href=\"%(url)s\">mozamo</a>"
 
 #: src/olympia/pages/templates/pages/about.lhtml:34
 #, python-format
-msgid ""
-"Our <a href=\"%(url)s\">forums</a> are a good place to interact with the "
-"add-ons community and discuss upcoming changes to AMO."
-msgstr ""
-"<a href=\"%(url)s\">forum</a> kami adalah tempat yang baik untuk "
-"berinteraksi dengan komunitas pengaya dan mendiskusikan perubahan yang akan "
-"datang di AMO."
+msgid "Our <a href=\"%(url)s\">forums</a> are a good place to interact with the add-ons community and discuss upcoming changes to AMO."
+msgstr "<a href=\"%(url)s\">forum</a> kami adalah tempat yang baik untuk berinteraksi dengan komunitas pengaya dan mendiskusikan perubahan yang akan datang di AMO."
 
 #: src/olympia/pages/templates/pages/about.lhtml:39
 msgid "This sounds great! How can I get involved?"
 msgstr "Ini kedengaran menarik! Bagaimana caranya bergabung?"
 
 #: src/olympia/pages/templates/pages/about.lhtml:40
-msgid ""
-"There are plenty of ways to get involved. If you're on the technical side:"
+msgid "There are plenty of ways to get involved. If you're on the technical side:"
 msgstr "Ada banyak cara untuk bisa bergabung. Jika anda memiliki sisi teknis:"
 
 #: src/olympia/pages/templates/pages/about.lhtml:42
 #, python-format
-msgid ""
-"<a href=\"%(url)s\">Make your own add-on</a>. We provide free hosting and "
-"update services and can help you reach a large audience of users."
-msgstr ""
-"<a href=\"%(url)s\">Buat pengayamu sendiri</a>. Kami menyediakan fasilitas "
-"hosting gratis dan layanan yang diperbarui dan bisa membantu anda menjangkau"
-" pengguna dalam jumlah besar."
+msgid "<a href=\"%(url)s\">Make your own add-on</a>. We provide free hosting and update services and can help you reach a large audience of users."
+msgstr "<a href=\"%(url)s\">Buat pengayamu sendiri</a>. Kami menyediakan fasilitas hosting gratis dan layanan yang diperbarui dan bisa membantu anda menjangkau pengguna dalam jumlah besar."
 
 #: src/olympia/pages/templates/pages/about.lhtml:45
 #, python-format
-msgid ""
-"If you have add-on development experience, <a href=\"%(url)s\"> become an "
-"editor</a>! Our editors are add-on fans with a technical background who "
-"review add-ons for code quality and stability."
+msgid "If you have add-on development experience, <a href=\"%(url)s\"> become an editor</a>! Our editors are add-on fans with a technical background who review add-ons for code quality and stability."
 msgstr ""
-"Jika anda memiliki pengalaman mengembangkan pengaya, <a href=\"%(url)s\"> "
-"jadilah penyunting </a>! Penyunting kami adalah penggemar pengaya dengan "
-"latar belakang teknis yang mengulas pengaya berdasarkan stabilitas dan "
-"kualitas kodenya."
+"Jika anda memiliki pengalaman mengembangkan pengaya, <a href=\"%(url)s\"> jadilah penyunting </a>! Penyunting kami adalah penggemar pengaya dengan latar belakang teknis yang mengulas pengaya "
+"berdasarkan stabilitas dan kualitas kodenya."
 
 #: src/olympia/pages/templates/pages/about.lhtml:49
 #, python-format
 msgid ""
-"Help improve this website. It's open source, and you can file bugs and "
-"submit patches. <a href=\"%(url)s\"> GitHub</a> contains all of our current "
-"bugs, legacy bugs can still be found in Bugzilla."
+"Help improve this website. It's open source, and you can file bugs and submit patches. <a href=\"%(url)s\"> GitHub</a> contains all of our current bugs, legacy bugs can still be found in Bugzilla."
 msgstr ""
-"Bantu perbaiki situs ini. Sumbernya terbuka, dan anda bisa memasukkan bug "
-"dan mengirimkan patch. <a href=\"%(url)s\"> GitHub</a> mengandung semua bug "
-"saat ini, bug tinggalan masih bisa ditemukan di Bugzilla."
+"Bantu perbaiki situs ini. Sumbernya terbuka, dan anda bisa memasukkan bug dan mengirimkan patch. <a href=\"%(url)s\"> GitHub</a> mengandung semua bug saat ini, bug tinggalan masih bisa ditemukan di "
+"Bugzilla."
 
 #: src/olympia/pages/templates/pages/about.lhtml:55
-msgid ""
-"If you're interested in add-ons but not quite as technical, there are still "
-"ways to help:"
-msgstr ""
-"Jika anda tertarik pada pengaya tapi tidak terlalu teknis, ada beberapa cara"
-" untuk membantu:"
+msgid "If you're interested in add-ons but not quite as technical, there are still ways to help:"
+msgstr "Jika anda tertarik pada pengaya tapi tidak terlalu teknis, ada beberapa cara untuk membantu:"
 
 #: src/olympia/pages/templates/pages/about.lhtml:58
 msgid "Tell your friends! Let people know which add-ons you use."
-msgstr ""
-"Katakan pada teman! Biarkan orang tahu pengaya mana yang anda gunakan."
+msgstr "Katakan pada teman! Biarkan orang tahu pengaya mana yang anda gunakan."
 
 #: src/olympia/pages/templates/pages/about.lhtml:59
 #, python-format
@@ -11801,13 +9502,8 @@ msgid "Participate in our <a href=\"%(url)s\">forums</a>."
 msgstr "Berpartisipasi dalam <a href=\"%(url)s\">forum</a>."
 
 #: src/olympia/pages/templates/pages/about.lhtml:61
-msgid ""
-"Review add-ons on the site. Add-on authors are more likely to improve their "
-"add-ons and write new ones when they know people appreciate their work."
-msgstr ""
-"Tinjau pengaya dalam situs. Penulis pengaya akan lebih mungkin memperbaiki "
-"pengaya mereka dan membuat yang baru jika mereka mengetahui orang menghargai"
-" karya mereka."
+msgid "Review add-ons on the site. Add-on authors are more likely to improve their add-ons and write new ones when they know people appreciate their work."
+msgstr "Tinjau pengaya dalam situs. Penulis pengaya akan lebih mungkin memperbaiki pengaya mereka dan membuat yang baru jika mereka mengetahui orang menghargai karya mereka."
 
 #: src/olympia/pages/templates/pages/about.lhtml:66
 msgid "I have a question"
@@ -11816,23 +9512,16 @@ msgstr "Saya punya pertanyaan"
 #: src/olympia/pages/templates/pages/about.lhtml:67
 #, python-format
 msgid ""
-"A good place to start is our <a href=\"%(faq_url)s\"><abbr "
-"title=\"Frequently Asked Questions\">FAQ</abbr></a>. If you don't find an "
-"answer there, you can <a href=\"%(forum_url)s\"> ask on our forums</a>."
+"A good place to start is our <a href=\"%(faq_url)s\"><abbr title=\"Frequently Asked Questions\">FAQ</abbr></a>. If you don't find an answer there, you can <a href=\"%(forum_url)s\"> ask on our "
+"forums</a>."
 msgstr ""
-"Tempat yang baik untuk memulai adalah <a href=\"%(faq_url)s\"><abbr "
-"title=\"Frequently Asked Questions\">FAQ</abbr></a>. Jika anda tidak "
-"menemukan jawaban di sana, anda bisa <a href=\"%(forum_url)s\"> bertanya di "
-"forum kami</a>."
+"Tempat yang baik untuk memulai adalah <a href=\"%(faq_url)s\"><abbr title=\"Frequently Asked Questions\">FAQ</abbr></a>. Jika anda tidak menemukan jawaban di sana, anda bisa <a href=\"%(forum_url)s"
+"\"> bertanya di forum kami</a>."
 
 #: src/olympia/pages/templates/pages/about.lhtml:72
 #, python-format
-msgid ""
-"If you really need to contact someone from the Mozilla team, please see our "
-"<a href=\"%(url)s\"> contact information</a> page."
-msgstr ""
-"Jika anda benar-benar ingin menghubungi seseorang dari tim Mozilla, silakan "
-"lihat laman <a href=\"%(url)s\"> informasi kontak</a> kami."
+msgid "If you really need to contact someone from the Mozilla team, please see our <a href=\"%(url)s\"> contact information</a> page."
+msgstr "Jika anda benar-benar ingin menghubungi seseorang dari tim Mozilla, silakan lihat laman <a href=\"%(url)s\"> informasi kontak</a> kami."
 
 #: src/olympia/pages/templates/pages/about.lhtml:76
 msgid "Who works on this website?"
@@ -11841,15 +9530,11 @@ msgstr "Siapa yang mengerjakan situs ini?"
 #: src/olympia/pages/templates/pages/about.lhtml:77
 #, python-format
 msgid ""
-"Over the years, many people have contributed to this website, including both"
-" volunteers from the community and a dedicated AMO team. A list of "
-"significant contributors can be found on our <a href=\"%(url)s\"> Site "
-"Credits</a> page."
+"Over the years, many people have contributed to this website, including both volunteers from the community and a dedicated AMO team. A list of significant contributors can be found on our <a href="
+"\"%(url)s\"> Site Credits</a> page."
 msgstr ""
-"Selama bertahun-tahun, banyak orang telah berkontribusi untuk situs ini, "
-"termasuk para relawan dari komunitas dan tim tetap AMO. Daftar kontributor "
-"yang signifikan dapat ditemukan di laman<a href=\"%(url)s\"> Site "
-"Credits</a> ."
+"Selama bertahun-tahun, banyak orang telah berkontribusi untuk situs ini, termasuk para relawan dari komunitas dan tim tetap AMO. Daftar kontributor yang signifikan dapat ditemukan di laman<a href="
+"\"%(url)s\"> Site Credits</a> ."
 
 #: src/olympia/pages/templates/pages/acr_firstrun.html:4
 msgid "Add-on Compatibility Reporter"
@@ -11860,12 +9545,8 @@ msgid "Add-on Compatibility Reporter has been installed"
 msgstr "Pelaporan Kompatibilitas Pengaya telah dipasang"
 
 #: src/olympia/pages/templates/pages/acr_firstrun.html:28
-msgid ""
-"It’s easy to help us make sure add-ons are updated in time for the release "
-"of the next version of Firefox."
-msgstr ""
-"Mudah sekali membantu kami memastikan pengaya diperbarui tepat waktu pada "
-"saat rilis versi Firefox berikutnya."
+msgid "It’s easy to help us make sure add-ons are updated in time for the release of the next version of Firefox."
+msgstr "Mudah sekali membantu kami memastikan pengaya diperbarui tepat waktu pada saat rilis versi Firefox berikutnya."
 
 #: src/olympia/pages/templates/pages/acr_firstrun.html:35
 msgid "Here’s how to get started reporting add-on compatibility:"
@@ -11873,54 +9554,36 @@ msgstr "Begini cara memulai melaporkan kecocokan pengaya:"
 
 #: src/olympia/pages/templates/pages/acr_firstrun.html:40
 msgid ""
-"As you start browsing and using your add-ons, take careful note of anything "
-"that seems different from when you last used the extension. This might be a "
-"display glitch, such as a menu item missing, or something more serious, like"
-" the add-on not working at all or showing errors."
+"As you start browsing and using your add-ons, take careful note of anything that seems different from when you last used the extension. This might be a display glitch, such as a menu item missing, "
+"or something more serious, like the add-on not working at all or showing errors."
 msgstr ""
-"Sembari anda mulai menjelajah dan menggunakan pengaya anda, catatlah dengan "
-"hati-hati apa saja yang tampak berbeda sejak terakhir kali anda menggunakan "
-"ekstensi. Ini bisa saja menampilkan kesalahan, misalnya item menu yang "
-"hilang, atau sesuatu yang lebih serius, misalnya pengaya yang tidak bekerja "
-"sama sekali atau menampilkan kesalahan."
+"Sembari anda mulai menjelajah dan menggunakan pengaya anda, catatlah dengan hati-hati apa saja yang tampak berbeda sejak terakhir kali anda menggunakan ekstensi. Ini bisa saja menampilkan "
+"kesalahan, misalnya item menu yang hilang, atau sesuatu yang lebih serius, misalnya pengaya yang tidak bekerja sama sekali atau menampilkan kesalahan."
 
 #: src/olympia/pages/templates/pages/acr_firstrun.html:49
 msgid ""
-"Once you know whether a particular add-on works properly or has problems, "
-"open the Add-ons Manager and click Compatibility next to the add-on to let "
-"Mozilla know what you found in your testing. Submitting a report will help "
-"us tell the add-on developer whether their add-on is working properly in "
-"this version or might need some fixes."
+"Once you know whether a particular add-on works properly or has problems, open the Add-ons Manager and click Compatibility next to the add-on to let Mozilla know what you found in your testing. "
+"Submitting a report will help us tell the add-on developer whether their add-on is working properly in this version or might need some fixes."
 msgstr ""
-"Sekali anda mengetahui apakah pengaya tertentu bekerja dengan baik atau "
-"memiliki masalah, buka Manajer Pengaya dan klik Kecocokan di dekat pengaya "
-"agar Mozilla mengetahui apa yang anda temukan saat pengujian. Memasukkan "
-"laporan akan membantu kami memberi tahu pengembang pengaya apakah pengaya "
-"mereka bekerja dengan baik dalam versi ini atau memerlukan sejumlah "
-"perbaikan."
+"Sekali anda mengetahui apakah pengaya tertentu bekerja dengan baik atau memiliki masalah, buka Manajer Pengaya dan klik Kecocokan di dekat pengaya agar Mozilla mengetahui apa yang anda temukan saat "
+"pengujian. Memasukkan laporan akan membantu kami memberi tahu pengembang pengaya apakah pengaya mereka bekerja dengan baik dalam versi ini atau memerlukan sejumlah perbaikan."
 
 #: src/olympia/pages/templates/pages/acr_firstrun.html:61
 #, python-format
 msgid ""
-"If you upgrade to a new version of Firefox or update your add-ons, your "
-"reports for the old versions will be hidden to allow you to test the new "
-"version. If you have any questions, please ask in <a href=\"%(url)s\">our "
-"forums</a>."
+"If you upgrade to a new version of Firefox or update your add-ons, your reports for the old versions will be hidden to allow you to test the new version. If you have any questions, please ask in <a "
+"href=\"%(url)s\">our forums</a>."
 msgstr ""
-"Jika anda meningkaykan ke versi baru Firefox atau memperbaiki pengaya anda, "
-"laporan anda untuk versi lama akan disembunyikan supaya anda bisa menguji "
-"versi baru. Jika anda memiliki pertanyaan, silakan bertanya di <a "
-"href=\"%(url)s\">forum kami</a>."
+"Jika anda meningkaykan ke versi baru Firefox atau memperbaiki pengaya anda, laporan anda untuk versi lama akan disembunyikan supaya anda bisa menguji versi baru. Jika anda memiliki pertanyaan, "
+"silakan bertanya di <a href=\"%(url)s\">forum kami</a>."
 
 #: src/olympia/pages/templates/pages/acr_firstrun.html:69
 msgid ""
-"Thousands of add-ons are made by our community every year, and your "
-"assistance with compatibility testing helps us make sure these add-ons stay "
-"useful as we strive to provide a great user experience."
+"Thousands of add-ons are made by our community every year, and your assistance with compatibility testing helps us make sure these add-ons stay useful as we strive to provide a great user "
+"experience."
 msgstr ""
-"Ribuan pengaya dibuat oleh komunitas kami setiap tahun, dan bantuan anda "
-"dengan pengujian kecocokan membantu kami memastikan pengaya ini tetap "
-"bermanfaat karena kami ingin memberikan pengalaman pengguna yang luar biasa."
+"Ribuan pengaya dibuat oleh komunitas kami setiap tahun, dan bantuan anda dengan pengujian kecocokan membantu kami memastikan pengaya ini tetap bermanfaat karena kami ingin memberikan pengalaman "
+"pengguna yang luar biasa."
 
 #: src/olympia/pages/templates/pages/acr_firstrun.html:75
 msgid "Thank you!"
@@ -11931,12 +9594,8 @@ msgid "Site Credits"
 msgstr "Kredit Situs"
 
 #: src/olympia/pages/templates/pages/credits.html:12
-msgid ""
-"Mozilla would like to thank the following people for their contributions to "
-"the addons.mozilla.org project over the years:"
-msgstr ""
-"Mozilla ingin berterima kasih pada mereka yang telah berkontribusi di proyek"
-" addons.mozilla.org selama bertahun-tahun:"
+msgid "Mozilla would like to thank the following people for their contributions to the addons.mozilla.org project over the years:"
+msgstr "Mozilla ingin berterima kasih pada mereka yang telah berkontribusi di proyek addons.mozilla.org selama bertahun-tahun:"
 
 #: src/olympia/pages/templates/pages/credits.html:18
 msgid "Developers &amp; Administrators"
@@ -11969,88 +9628,63 @@ msgstr "Perangkat Lunak dan Gambar"
 
 #: src/olympia/pages/templates/pages/credits.html:59
 msgid ""
-"Some icons used are from the <a "
-"href=\"http://www.famfamfam.com/lab/icons/silk/\">famfamfam Silk Icon "
-"Set</a>, licensed under a <a "
-"href=\"http://creativecommons.org/licenses/by/2.5/\">Creative Commons "
-"Attribution 2.5 License</a>."
+"Some icons used are from the <a href=\"http://www.famfamfam.com/lab/icons/silk/\">famfamfam Silk Icon Set</a>, licensed under a <a href=\"http://creativecommons.org/licenses/by/2.5/\">Creative "
+"Commons Attribution 2.5 License</a>."
 msgstr ""
-"Sejumlah ikon diambil dari <a "
-"href=\"http://www.famfamfam.com/lab/icons/silk/\">famfamfam Silk Icon "
-"Set</a>, dibawah lisensi <a "
-"href=\"http://creativecommons.org/licenses/by/2.5/\">Creative Commons "
+"Sejumlah ikon diambil dari <a href=\"http://www.famfamfam.com/lab/icons/silk/\">famfamfam Silk Icon Set</a>, dibawah lisensi <a href=\"http://creativecommons.org/licenses/by/2.5/\">Creative Commons "
 "Attribution 2.5 License</a>."
 
 #: src/olympia/pages/templates/pages/credits.html:60
 msgid ""
-"Some icons used are from the <a href=\"http://www.fatcow.com/free-"
-"icons/\">FatCow Farm-Fresh Web Icons Set</a>, licensed under a <a "
-"href=\"http://creativecommons.org/licenses/by/3.0/us/\">Creative Commons "
-"Attribution 3.0 License</a>."
+"Some icons used are from the <a href=\"http://www.fatcow.com/free-icons/\">FatCow Farm-Fresh Web Icons Set</a>, licensed under a <a href=\"http://creativecommons.org/licenses/by/3.0/us/\">Creative "
+"Commons Attribution 3.0 License</a>."
 msgstr ""
-"Sejumlah ikon diambil dari <a href=\"http://www.fatcow.com/free-"
-"icons/\">FatCow Farm-Fresh Web Icons Set</a>, dibawah lisensi a <a "
-"href=\"http://creativecommons.org/licenses/by/3.0/us/\">Creative Commons "
-"Attribution 3.0 License</a>."
+"Sejumlah ikon diambil dari <a href=\"http://www.fatcow.com/free-icons/\">FatCow Farm-Fresh Web Icons Set</a>, dibawah lisensi a <a href=\"http://creativecommons.org/licenses/by/3.0/us/\">Creative "
+"Commons Attribution 3.0 License</a>."
 
 #: src/olympia/pages/templates/pages/credits.html:61
 msgid ""
-"Some pages use elements of <a "
-"href=\"http://shop.highsoft.com/highcharts.html\">Highcharts</a> (non-"
-"commercial), licensed under a <a href=\"http://creativecommons.org/licenses"
-"/by-nc/3.0/\">Creative Commons Attribution-NonCommercial 3.0 License</a>."
+"Some pages use elements of <a href=\"http://shop.highsoft.com/highcharts.html\">Highcharts</a> (non-commercial), licensed under a <a href=\"http://creativecommons.org/licenses/by-nc/3.0/\">Creative "
+"Commons Attribution-NonCommercial 3.0 License</a>."
 msgstr ""
-"Sejumlah halaman menggunakan elemen dari <a "
-"href=\"http://shop.highsoft.com/highcharts.html\">Highcharts</a> (non-"
-"commercial), di bawah lisensi <a href=\"http://creativecommons.org/licenses"
-"/by-nc/3.0/\">Creative Commons Attribution-NonCommercial 3.0 License</a>."
+"Sejumlah halaman menggunakan elemen dari <a href=\"http://shop.highsoft.com/highcharts.html\">Highcharts</a> (non-commercial), di bawah lisensi <a href=\"http://creativecommons.org/licenses/by-"
+"nc/3.0/\">Creative Commons Attribution-NonCommercial 3.0 License</a>."
 
 #: src/olympia/pages/templates/pages/credits.html:65
 #, python-format
-msgid ""
-"For information on contributing, please see our <a href=\"%(url)s\">wiki "
-"page</a>."
-msgstr ""
-"Untuk informasi mengenai berkontribusi, silakan lihat <a "
-"href=\"%(url)s\">laman wiki</a>."
+msgid "For information on contributing, please see our <a href=\"%(url)s\">wiki page</a>."
+msgstr "Untuk informasi mengenai berkontribusi, silakan lihat <a href=\"%(url)s\">laman wiki</a>."
 
 #: src/olympia/pages/templates/pages/dev_faq.html:4
 msgid "Developer FAQ"
 msgstr "FAQ Pengembang"
 
-#: src/olympia/pages/templates/pages/dev_faq.html:31
-#: src/olympia/pages/templates/pages/review_guide.html:33
+#: src/olympia/pages/templates/pages/dev_faq.html:31 src/olympia/pages/templates/pages/review_guide.html:33
 msgid "Sections"
 msgstr "Bagian"
 
-#: src/olympia/pages/templates/pages/dev_faq.html:33
-#: src/olympia/pages/templates/pages/dev_faq.html:45
+#: src/olympia/pages/templates/pages/dev_faq.html:33 src/olympia/pages/templates/pages/dev_faq.html:45
 msgid "Developing an Add-on"
 msgstr "Mengembangkan sebuah Pengaya"
 
 #. Heading for a list of resources for developers
-#: src/olympia/pages/templates/pages/dev_faq.html:34
-#: src/olympia/pages/templates/pages/dev_faq.html:208
+#: src/olympia/pages/templates/pages/dev_faq.html:34 src/olympia/pages/templates/pages/dev_faq.html:208
 msgid "Support Resources"
 msgstr "Mendukung Sumber Daya"
 
-#: src/olympia/pages/templates/pages/dev_faq.html:35
-#: src/olympia/pages/templates/pages/dev_faq.html:261
+#: src/olympia/pages/templates/pages/dev_faq.html:35 src/olympia/pages/templates/pages/dev_faq.html:261
 msgid "Contributing your Add-on"
 msgstr "Menyumbangkan Pengaya anda"
 
-#: src/olympia/pages/templates/pages/dev_faq.html:36
-#: src/olympia/pages/templates/pages/dev_faq.html:381
+#: src/olympia/pages/templates/pages/dev_faq.html:36 src/olympia/pages/templates/pages/dev_faq.html:381
 msgid "Add-on Review Process"
 msgstr "Proses Mengulas Pengaya"
 
-#: src/olympia/pages/templates/pages/dev_faq.html:37
-#: src/olympia/pages/templates/pages/dev_faq.html:444
+#: src/olympia/pages/templates/pages/dev_faq.html:37 src/olympia/pages/templates/pages/dev_faq.html:444
 msgid "Managing Your Add-on"
 msgstr "Mengelola Pengaya Anda"
 
-#: src/olympia/pages/templates/pages/dev_faq.html:39
-#: src/olympia/pages/templates/pages/dev_faq.html:528
+#: src/olympia/pages/templates/pages/dev_faq.html:39 src/olympia/pages/templates/pages/dev_faq.html:528
 msgid "References for Open Source Licenses"
 msgstr "Referensi untuk Lisensi Sumber Terbuka"
 
@@ -12060,14 +9694,8 @@ msgstr "FAQ Pengembang Pengaya"
 
 #: src/olympia/pages/templates/pages/dev_faq.html:47
 #, python-format
-msgid ""
-"<h3>How do I build an Add-on?</h3> <p> Mozilla provides documentation on how"
-" to build an add-on via the <a href=\"%(url)s\">Mozilla Developer "
-"Network</a>. </p>"
-msgstr ""
-"<h3>Bagaimana cara membangun Pengaya?</h3> <p> Mozilla menyediakan "
-"dokumentasi tentang bagaimana membangun pengaya melalui <a "
-"href=\"%(url)s\">Jejaring Pengembang Mozilla</a>. </p>"
+msgid "<h3>How do I build an Add-on?</h3> <p> Mozilla provides documentation on how to build an add-on via the <a href=\"%(url)s\">Mozilla Developer Network</a>. </p>"
+msgstr "<h3>Bagaimana cara membangun Pengaya?</h3> <p> Mozilla menyediakan dokumentasi tentang bagaimana membangun pengaya melalui <a href=\"%(url)s\">Jejaring Pengembang Mozilla</a>. </p>"
 
 #: src/olympia/pages/templates/pages/dev_faq.html:55
 msgid "Other resources include:"
@@ -12087,13 +9715,11 @@ msgstr "Alat apa yang saya perlukan untuk membangun sebuah Pengaya?"
 
 #: src/olympia/pages/templates/pages/dev_faq.html:68
 msgid ""
-"You will need to have a version of the Mozilla software that you're building"
-" the add-on for and a code editor of your choice. Add-ons can be built for "
-"almost all Mozilla software but are primarily targeted for:"
+"You will need to have a version of the Mozilla software that you're building the add-on for and a code editor of your choice. Add-ons can be built for almost all Mozilla software but are primarily "
+"targeted for:"
 msgstr ""
-"Anda perlu memiliki versi perangkat lunak Mozilla untuk yang mana anda "
-"membuat pengaya dan penyunting kode pilihan anda. Pengaya bisa dibuat untuk "
-"hampir semua perangkat lunak Mozilla namun terutama ditargetkan untuk:"
+"Anda perlu memiliki versi perangkat lunak Mozilla untuk yang mana anda membuat pengaya dan penyunting kode pilihan anda. Pengaya bisa dibuat untuk hampir semua perangkat lunak Mozilla namun "
+"terutama ditargetkan untuk:"
 
 #: src/olympia/pages/templates/pages/dev_faq.html:82
 msgid "Popular code editors include:"
@@ -12102,38 +9728,24 @@ msgstr "Penyunting kode populer meliputi:"
 #. This is a list of popular code editors.  Feel free to adjust as you like.
 #: src/olympia/pages/templates/pages/dev_faq.html:85
 msgid ""
-"<li><a href=\"http://komodoide.com/komodo-edit/\">Komodo Edit</a></li> "
-"<li><a href=\"http://macromates.com/\">TextMate</a></li> <li><a href=\"http"
-"://notepad-plus-plus.org/\">Notepad++</a></li> <li><a "
-"href=\"http://www.eclipse.org/\">Eclipse IDE</a></li>"
+"<li><a href=\"http://komodoide.com/komodo-edit/\">Komodo Edit</a></li> <li><a href=\"http://macromates.com/\">TextMate</a></li> <li><a href=\"http://notepad-plus-plus.org/\">Notepad++</a></li> "
+"<li><a href=\"http://www.eclipse.org/\">Eclipse IDE</a></li>"
 msgstr ""
-"<li><a href=\"http://komodoide.com/komodo-edit/\">Komodo Edit</a></li> "
-"<li><a href=\"http://macromates.com/\">TextMate</a></li> <li><a href=\"http"
-"://notepad-plus-plus.org/\">Notepad++</a></li> <li><a "
-"href=\"http://www.eclipse.org/\">Eclipse IDE</a></li>"
+"<li><a href=\"http://komodoide.com/komodo-edit/\">Komodo Edit</a></li> <li><a href=\"http://macromates.com/\">TextMate</a></li> <li><a href=\"http://notepad-plus-plus.org/\">Notepad++</a></li> "
+"<li><a href=\"http://www.eclipse.org/\">Eclipse IDE</a></li>"
 
 #: src/olympia/pages/templates/pages/dev_faq.html:94
 #, python-format
-msgid ""
-"You can also learn more about setting up your development environment via "
-"the MDN article <a href=\"%(url)s\">Setting up extension development "
-"environment</a>"
-msgstr ""
-"Anda bisa mengetahui lebih lanjut mengenai penyetelan lingkungan "
-"pengembangan melalui artikel MDN <a href=\"%(url)s\">Penyetelan lingkungan "
-"pengembangan ekstensi</a>"
+msgid "You can also learn more about setting up your development environment via the MDN article <a href=\"%(url)s\">Setting up extension development environment</a>"
+msgstr "Anda bisa mengetahui lebih lanjut mengenai penyetelan lingkungan pengembangan melalui artikel MDN <a href=\"%(url)s\">Penyetelan lingkungan pengembangan ekstensi</a>"
 
 #: src/olympia/pages/templates/pages/dev_faq.html:100
 msgid "What is a \".xpi\" file?"
 msgstr "Apakah berkas \".xpi\" itu?"
 
 #: src/olympia/pages/templates/pages/dev_faq.html:102
-msgid ""
-"Extensions are packaged and distributed in ZIP files or Bundles, with the "
-"XPI (pronounced \"zippy\") file extension."
-msgstr ""
-"Ekstensi dikemas dan didistribusikan dalam berkas ZIP atau Bundles, dengan "
-"berkas ekstensi XPI (dibaca \"zippy\")."
+msgid "Extensions are packaged and distributed in ZIP files or Bundles, with the XPI (pronounced \"zippy\") file extension."
+msgstr "Ekstensi dikemas dan didistribusikan dalam berkas ZIP atau Bundles, dengan berkas ekstensi XPI (dibaca \"zippy\")."
 
 #: src/olympia/pages/templates/pages/dev_faq.html:108
 msgid "What is XUL?"
@@ -12141,16 +9753,11 @@ msgstr "Apakah XUL itu?"
 
 #: src/olympia/pages/templates/pages/dev_faq.html:110
 msgid ""
-"XUL (XML User Interface Language) is Mozilla's XML-based language that lets "
-"you build feature-rich cross platform applications. It provides user "
-"interface widgets like buttons, menus, toolbars, trees, etc that can be used"
-" to enhance add-ons by modifying parts of the browser UI."
+"XUL (XML User Interface Language) is Mozilla's XML-based language that lets you build feature-rich cross platform applications. It provides user interface widgets like buttons, menus, toolbars, "
+"trees, etc that can be used to enhance add-ons by modifying parts of the browser UI."
 msgstr ""
-"XUL (XML User Interface Language) adalah basis bahasa XML Mozilla yang "
-"memungkinkan anda membuat fitur yang melintasi platform aplikasi. Hal ini "
-"memberi pengguna dengan widget antarmuka seperti tombol, menu, toolbar, "
-"pohon dll yang bisa digunakan untuk meningkatkan pengaya dengan memodifikasi"
-" bagian UI peramban."
+"XUL (XML User Interface Language) adalah basis bahasa XML Mozilla yang memungkinkan anda membuat fitur yang melintasi platform aplikasi. Hal ini memberi pengguna dengan widget antarmuka seperti "
+"tombol, menu, toolbar, pohon dll yang bisa digunakan untuk meningkatkan pengaya dengan memodifikasi bagian UI peramban."
 
 #: src/olympia/pages/templates/pages/dev_faq.html:119
 msgid "What is the \"install.rdf\" file used for?"
@@ -12159,35 +9766,21 @@ msgstr "Digunakan untuk apa berkas \"install.rdf\" itu?"
 #: src/olympia/pages/templates/pages/dev_faq.html:121
 #, python-format
 msgid ""
-"This file, called an <a href=\"%(url)s\">Install Manifest</a>, is used by "
-"Add-on Manager-enabled XUL applications to determine information about an "
-"add-on as it is being installed. It contains metadata identifying the add-"
-"on, providing information about who created it, where more information can "
-"be found about it, which versions of what applications it is compatible "
-"with, how it should be updated, and so on. The format of the Install "
-"Manifest is RDF/XML."
+"This file, called an <a href=\"%(url)s\">Install Manifest</a>, is used by Add-on Manager-enabled XUL applications to determine information about an add-on as it is being installed. It contains "
+"metadata identifying the add-on, providing information about who created it, where more information can be found about it, which versions of what applications it is compatible with, how it should "
+"be updated, and so on. The format of the Install Manifest is RDF/XML."
 msgstr ""
-"Berkas ini, disebut <a href=\"%(url)s\">Manifest Pemasangan</a>, digunakan "
-"oleh Manajer Pengaya untuk memungkinkan aplikasi XUL untuk menentukan "
-"informasi mengenai pengaya saat dipasang. Ia mengandung metadata yang "
-"mengidentifikasi pengaya, memberikan informasi mengenai siapa yang "
-"membuatnya, di mana informasi yang lebih banyak bisa ditemukan mengenai hal "
-"ini, versi apa dari aplikasi yang cocok dengan itu, bagaimana caranya "
-"diperbarui dan seterusnya. Format Manifest Pemasangan adalah RDF/XML."
+"Berkas ini, disebut <a href=\"%(url)s\">Manifest Pemasangan</a>, digunakan oleh Manajer Pengaya untuk memungkinkan aplikasi XUL untuk menentukan informasi mengenai pengaya saat dipasang. Ia "
+"mengandung metadata yang mengidentifikasi pengaya, memberikan informasi mengenai siapa yang membuatnya, di mana informasi yang lebih banyak bisa ditemukan mengenai hal ini, versi apa dari aplikasi "
+"yang cocok dengan itu, bagaimana caranya diperbarui dan seterusnya. Format Manifest Pemasangan adalah RDF/XML."
 
 #: src/olympia/pages/templates/pages/dev_faq.html:132
 msgid "What does \"maxVersion\" mean?"
 msgstr "Apa yang dimaksud dengan \"maxVersion\"?"
 
 #: src/olympia/pages/templates/pages/dev_faq.html:134
-msgid ""
-"This determines the maximum version of Firefox you're saying this extension "
-"will work with. Set this to be no newer than the newest currently available "
-"version!"
-msgstr ""
-"Ini menentukan versi maksimum Firefox dengan yang mana menurut anda ekstensi"
-" ini bisa bekerja. Atur ini untuk tidak menjadi lebih baru daripada versi "
-"paling baru yang saat ini tersedia!"
+msgid "This determines the maximum version of Firefox you're saying this extension will work with. Set this to be no newer than the newest currently available version!"
+msgstr "Ini menentukan versi maksimum Firefox dengan yang mana menurut anda ekstensi ini bisa bekerja. Atur ini untuk tidak menjadi lebih baru daripada versi paling baru yang saat ini tersedia!"
 
 #: src/olympia/pages/templates/pages/dev_faq.html:141
 msgid "Can my add-on contain binary components?"
@@ -12196,43 +9789,25 @@ msgstr "Bisakah pengaya saya mengandung komponen biner?"
 #: src/olympia/pages/templates/pages/dev_faq.html:143
 #, python-format
 msgid ""
-"Yes. You can use Mozilla's <a href=\"%(url)s\">XPCOM component object "
-"model</a> to enhance your add-ons. XPCOM components be used and implemented "
-"in JavaScript, Java, and Python in addition to C++."
+"Yes. You can use Mozilla's <a href=\"%(url)s\">XPCOM component object model</a> to enhance your add-ons. XPCOM components be used and implemented in JavaScript, Java, and Python in addition to C++."
 msgstr ""
-"Ya. Anda bisa menggunakan <a href=\"%(url)s\">XPCOM model komponen obyek</a>"
-" Mozilla untuk meningkatkan pengaya anda. Komponen XPCOM bisa digunakan dan "
-"diimplementasikan dalam JavaScript, Java, dan Python sebagai tambahan untuk "
-"C++."
+"Ya. Anda bisa menggunakan <a href=\"%(url)s\">XPCOM model komponen obyek</a> Mozilla untuk meningkatkan pengaya anda. Komponen XPCOM bisa digunakan dan diimplementasikan dalam JavaScript, Java, dan "
+"Python sebagai tambahan untuk C++."
 
 #: src/olympia/pages/templates/pages/dev_faq.html:150
-msgid ""
-"Can I use a JavaScript library like jQuery, MooTools or Prototype to build "
-"my add-on?"
-msgstr ""
-"Bisakah saya menggunakan pustaka JavaScript seperti jQuery, MooTools atau "
-"Prototype untuk membuat pengaya?"
+msgid "Can I use a JavaScript library like jQuery, MooTools or Prototype to build my add-on?"
+msgstr "Bisakah saya menggunakan pustaka JavaScript seperti jQuery, MooTools atau Prototype untuk membuat pengaya?"
 
 #: src/olympia/pages/templates/pages/dev_faq.html:152
 msgid ""
-"Yes. It's possible, but some of the functionality provided by these "
-"libraries are available through XPCOM, XUL, and JavaScript. In addition, "
-"authors should take care if libraries modify primitive object prototypes "
-"(String.prototype, Date.prototype, etc.) and/or define global functions (eg."
-" the $ function). These are prone to cause conflict with other add-ons, in "
-"particular if different add-ons use different versions of libraries and so "
-"on. Developers need to be very, very careful with using them.  Mozilla does "
-"not offer documentation on using them to build add-ons."
+"Yes. It's possible, but some of the functionality provided by these libraries are available through XPCOM, XUL, and JavaScript. In addition, authors should take care if libraries modify primitive "
+"object prototypes (String.prototype, Date.prototype, etc.) and/or define global functions (eg. the $ function). These are prone to cause conflict with other add-ons, in particular if different add-"
+"ons use different versions of libraries and so on. Developers need to be very, very careful with using them. Mozilla does not offer documentation on using them to build add-ons."
 msgstr ""
-"Ya. Mungkin, namun beberapa fungsi yang disediakan oleh pustaka ini tersedia"
-" melalui XPCOM, XUL dan JavaScript. In addition, Selain itu, penulis harus "
-"berhati-hati jika pustaka memodifikasi purwarupa obyek primitif "
-"(String.prototype, Date.prototype, etc.) dan/atau mendefinisikan fungsi "
-"global (eg. the $ function). Hal ini cenderung menimbulkan konflik dengan "
-"pengaya lainnya, khususnya jika pengaya berbeda menggunakan versi pustaka "
-"yang berbeda dan seterusnya. Pengembang harus sangat, sangat hati-hati "
-"menggunakannya.  Mozilla tidak menawarkan dokumentasi menggunakan mereka "
-"untuk membangun pengaya."
+"Ya. Mungkin, namun beberapa fungsi yang disediakan oleh pustaka ini tersedia melalui XPCOM, XUL dan JavaScript. In addition, Selain itu, penulis harus berhati-hati jika pustaka memodifikasi "
+"purwarupa obyek primitif (String.prototype, Date.prototype, etc.) dan/atau mendefinisikan fungsi global (eg. the $ function). Hal ini cenderung menimbulkan konflik dengan pengaya lainnya, khususnya "
+"jika pengaya berbeda menggunakan versi pustaka yang berbeda dan seterusnya. Pengembang harus sangat, sangat hati-hati menggunakannya.  Mozilla tidak menawarkan dokumentasi menggunakan mereka untuk "
+"membangun pengaya."
 
 #: src/olympia/pages/templates/pages/dev_faq.html:165
 msgid "How do I debug my add-on?"
@@ -12244,31 +9819,18 @@ msgid "You can use the <a href=\"%(url)s\">Add-on Debugger</a>."
 msgstr "Anda bisa menggunakan <a href=\"%(url)s\">Debugger Pengaya</a>."
 
 #: src/olympia/pages/templates/pages/dev_faq.html:172
-msgid ""
-"How do I test for compatibility with the latest version of Mozilla software?"
-msgstr ""
-"Bagaimana saya menguji kecocokan dengan versi terbaru perangkat lunak "
-"Mozilla?"
+msgid "How do I test for compatibility with the latest version of Mozilla software?"
+msgstr "Bagaimana saya menguji kecocokan dengan versi terbaru perangkat lunak Mozilla?"
 
 #: src/olympia/pages/templates/pages/dev_faq.html:174
 msgid ""
-"To ensure compatibility with the latest Mozilla software, it's important to "
-"download updates as they become available and test your add-on to ensure "
-"that it is still functioning as expected. In many cases, the latest version "
-"of Mozilla software may be a beta release. Since these releases at times "
-"introduce architectural changes that may impact the functionality of your "
-"add-on, it's important to be actively involved in the beta process to ensure"
-" that your add-on users are not negatively impacted upon final release of "
-"Mozilla software."
+"To ensure compatibility with the latest Mozilla software, it's important to download updates as they become available and test your add-on to ensure that it is still functioning as expected. In "
+"many cases, the latest version of Mozilla software may be a beta release. Since these releases at times introduce architectural changes that may impact the functionality of your add-on, it's "
+"important to be actively involved in the beta process to ensure that your add-on users are not negatively impacted upon final release of Mozilla software."
 msgstr ""
-"Untuk memastikan kecocokan dengan perangkat lunak Mozilla terbaru, sangatlah"
-" penting untuk mengunduh pembaruan segera setelah tersedia dan menguji "
-"pengaya anda untuk memastikannya masih bekerja sebagai mana diharapkan. "
-"Dalam kebanyakan kasus, versi terbaru perangkat lunak Mozilla bisa menjadi "
-"rilis beta. Karena rilis ini sering kali memperkenalkan perubahan "
-"arsitektural yang akan mempengaruhi fungsi pengaya anda, sangat penting "
-"untuk terlibat secara aktif dalam proses beta untuk memastikan bahwa "
-"pengguna pengaya anda tidak dipengaruhi secara negatif saat rilis final "
+"Untuk memastikan kecocokan dengan perangkat lunak Mozilla terbaru, sangatlah penting untuk mengunduh pembaruan segera setelah tersedia dan menguji pengaya anda untuk memastikannya masih bekerja "
+"sebagai mana diharapkan. Dalam kebanyakan kasus, versi terbaru perangkat lunak Mozilla bisa menjadi rilis beta. Karena rilis ini sering kali memperkenalkan perubahan arsitektural yang akan "
+"mempengaruhi fungsi pengaya anda, sangat penting untuk terlibat secara aktif dalam proses beta untuk memastikan bahwa pengguna pengaya anda tidak dipengaruhi secara negatif saat rilis final "
 "perangkat lunak Mozilla."
 
 #: src/olympia/pages/templates/pages/dev_faq.html:185
@@ -12278,17 +9840,11 @@ msgstr "Bagaimana cara meningkatkan kinerja pengaya saya?"
 #: src/olympia/pages/templates/pages/dev_faq.html:187
 #, python-format
 msgid ""
-"Poorly written extensions can have a severe impact on the browsing "
-"experience, including on the overall performance of Firefox itself. The "
-"following page contains many good <a href=\"%(url)s\">guides</a> that help "
-"you improve performance, whether you're developing core Mozilla code or an "
-"add-on."
+"Poorly written extensions can have a severe impact on the browsing experience, including on the overall performance of Firefox itself. The following page contains many good <a href=\"%(url)s"
+"\">guides</a> that help you improve performance, whether you're developing core Mozilla code or an add-on."
 msgstr ""
-"Ekstensi yang ditulis sekedarnya bisa memiliki dampak buruk bagi pengalaman "
-"penelusuran, termasuk dalam keseluruhan performa Firefox. Laman berikut ini "
-"mencakup banyak <a href=\"%(url)s\">panduan</a> yang baik yang membantu anda"
-" meningkatkan performa, baik jika anda mengembangkan kode inti Mozilla atau "
-"pengaya."
+"Ekstensi yang ditulis sekedarnya bisa memiliki dampak buruk bagi pengalaman penelusuran, termasuk dalam keseluruhan performa Firefox. Laman berikut ini mencakup banyak <a href=\"%(url)s\">panduan</"
+"a> yang baik yang membantu anda meningkatkan performa, baik jika anda mengembangkan kode inti Mozilla atau pengaya."
 
 #: src/olympia/pages/templates/pages/dev_faq.html:195
 msgid "Can my add-on support multiple locales?"
@@ -12297,22 +9853,15 @@ msgstr "Dapatkah pengaya saya mendukung berbagai kode pelokalan?"
 #: src/olympia/pages/templates/pages/dev_faq.html:197
 #, python-format
 msgid ""
-"Yes. Details on localizing your add-on can be found in the the <a "
-"href=\"%(l10n_url)s\">Mozilla Developer Network Localization page</a>. <a "
-"href=\"%(bz_url)s\">The BabelZilla project</a> is also a great resource for "
-"learning about localization and volunteering to help translate add-ons."
+"Yes. Details on localizing your add-on can be found in the the <a href=\"%(l10n_url)s\">Mozilla Developer Network Localization page</a>. <a href=\"%(bz_url)s\">The BabelZilla project</a> is also a "
+"great resource for learning about localization and volunteering to help translate add-ons."
 msgstr ""
-"Ya. Rincian untuk melokalkan pengaya anda bisa ditemukan dalam <a "
-"href=\"%(l10n_url)s\">laman Pelokalan Mozilla Developer Network </a>. <a "
-"href=\"%(bz_url)s\">Proyek BabelZilla </a> juga merupakan sumber yang baik "
-"untuk belajar tentang pelokalan dan membantu menerjemahkan pengaya secara "
-"sukarela."
+"Ya. Rincian untuk melokalkan pengaya anda bisa ditemukan dalam <a href=\"%(l10n_url)s\">laman Pelokalan Mozilla Developer Network </a>. <a href=\"%(bz_url)s\">Proyek BabelZilla </a> juga merupakan "
+"sumber yang baik untuk belajar tentang pelokalan dan membantu menerjemahkan pengaya secara sukarela."
 
 #: src/olympia/pages/templates/pages/dev_faq.html:210
 msgid "I need some advice building my add-on. Where can I find help?"
-msgstr ""
-"Saya memerlukan saran-saran dalam membangun pengaya. Ke mana saya mencari "
-"bantuan?"
+msgstr "Saya memerlukan saran-saran dalam membangun pengaya. Ke mana saya mencari bantuan?"
 
 #. #extdev is the name of the IRC channel.  do not change.
 #: src/olympia/pages/templates/pages/dev_faq.html:216
@@ -12326,12 +9875,8 @@ msgstr "#amo (untuk dukungan terkait pemuatan pengaya anda di AMO)"
 
 #. #jetpack is the name of the IRC channel.  do not change.
 #: src/olympia/pages/templates/pages/dev_faq.html:220
-msgid ""
-"#jetpack (for discussions about the Add-ons SDK and cfx/jpm - formerly known"
-" as Jetpack)"
-msgstr ""
-"#jetpack (untuk diskusi mengenai SDK Pengaya dan cfx/jpm - sebelumnya "
-"dikenal sebagai Jetpack)"
+msgid "#jetpack (for discussions about the Add-ons SDK and cfx/jpm - formerly known as Jetpack)"
+msgstr "#jetpack (untuk diskusi mengenai SDK Pengaya dan cfx/jpm - sebelumnya dikenal sebagai Jetpack)"
 
 #. Label for a link to the extension developers mailing list
 #: src/olympia/pages/templates/pages/dev_faq.html:225
@@ -12366,24 +9911,16 @@ msgstr "Tidak."
 
 #: src/olympia/pages/templates/pages/dev_faq.html:246
 msgid "Are there 3rd party developers that I can hire to build my add-on?"
-msgstr ""
-"Apakah ada pengembang pihak ke-3 yang bisa saya sewa untuk membangun pengaya"
-" saya?"
+msgstr "Apakah ada pengembang pihak ke-3 yang bisa saya sewa untuk membangun pengaya saya?"
 
 #: src/olympia/pages/templates/pages/dev_faq.html:248
 #, python-format
 msgid ""
-"Yes. You may find 3rd party developers via the <a href=\"%(forum_url)s"
-"\">Add-ons forum</a>, <a href=\"%(list_url)s\">mozilla.jobs list</a>, <a "
-"href=\"%(mz_url)s\">mozillaZine forums</a> or <a href=\"%(wiki_url)s\">the "
-"Mozilla Wiki</a>. Please note that Mozilla does not offer developer "
-"recommendations."
+"Yes. You may find 3rd party developers via the <a href=\"%(forum_url)s\">Add-ons forum</a>, <a href=\"%(list_url)s\">mozilla.jobs list</a>, <a href=\"%(mz_url)s\">mozillaZine forums</a> or <a href="
+"\"%(wiki_url)s\">the Mozilla Wiki</a>. Please note that Mozilla does not offer developer recommendations."
 msgstr ""
-"Iya. Anda bisa menemukan pengembang pihak ke-3 melalui <a "
-"href=\"%(forum_url)s\">forum Pengaya</a>, <a href=\"%(list_url)s\">daftar "
-"mozilla.jobs </a>, <a href=\"%(mz_url)s\">forum mozillaZine </a> atau <a "
-"href=\"%(wiki_url)s\">Mozilla Wiki</a>. Harap dicatat bahwa Mozilla tidak "
-"menawarkan rekomendasi pengaya."
+"Iya. Anda bisa menemukan pengembang pihak ke-3 melalui <a href=\"%(forum_url)s\">forum Pengaya</a>, <a href=\"%(list_url)s\">daftar mozilla.jobs </a>, <a href=\"%(mz_url)s\">forum mozillaZine </a> "
+"atau <a href=\"%(wiki_url)s\">Mozilla Wiki</a>. Harap dicatat bahwa Mozilla tidak menawarkan rekomendasi pengaya."
 
 #: src/olympia/pages/templates/pages/dev_faq.html:263
 msgid "Can I host my own add-on?"
@@ -12392,22 +9929,13 @@ msgstr "Bisakah saya memuat pengaya saya sendiri?"
 #: src/olympia/pages/templates/pages/dev_faq.html:265
 #, python-format
 msgid ""
-"Yes. Many developers choose to host their own add-ons. Choosing to host your"
-" add-on on <a href=\"%(amo_url)s\">Mozilla's add-on site</a>, though, allows"
-" for much greater exposure to your add-on due to the large volume of "
-"visitors to the site.  <a href=\"%(md_url)s\">mozdev.org</a> offers free "
-"project hosting for Mozilla applications and extensions providing developers"
-" with tools to help manage source code, version control, bug tracking and "
-"documentation."
+"Yes. Many developers choose to host their own add-ons. Choosing to host your add-on on <a href=\"%(amo_url)s\">Mozilla's add-on site</a>, though, allows for much greater exposure to your add-on due "
+"to the large volume of visitors to the site. <a href=\"%(md_url)s\">mozdev.org</a> offers free project hosting for Mozilla applications and extensions providing developers with tools to help manage "
+"source code, version control, bug tracking and documentation."
 msgstr ""
-"Ya. Banyak pengembang yang memilih memuat pengaya mereka sendiri. Meski "
-"demikian, memilih untuk memuat pengaya di <a href=\"%(amo_url)s\">situs "
-"pengaya Mozilla</a>, memungkinkan eksposur yang jauh lebih besar pada "
-"pengaya anda karena jumlah pengunjung yang besar ke situs.  <a "
-"href=\"%(md_url)s\">mozdev.org</a> menawarkan pemuatan proyek gratis untuk "
-"aplikasi dan ekstensi Mozilla yang memberi pengembang perangkat untuk "
-"membantu mengelola kode sumber, versi kendali, pelacakan bug dan "
-"dokumentasi."
+"Ya. Banyak pengembang yang memilih memuat pengaya mereka sendiri. Meski demikian, memilih untuk memuat pengaya di <a href=\"%(amo_url)s\">situs pengaya Mozilla</a>, memungkinkan eksposur yang jauh "
+"lebih besar pada pengaya anda karena jumlah pengunjung yang besar ke situs.  <a href=\"%(md_url)s\">mozdev.org</a> menawarkan pemuatan proyek gratis untuk aplikasi dan ekstensi Mozilla yang memberi "
+"pengembang perangkat untuk membantu mengelola kode sumber, versi kendali, pelacakan bug dan dokumentasi."
 
 #: src/olympia/pages/templates/pages/dev_faq.html:277
 msgid "Can Mozilla host my add-on?"
@@ -12415,12 +9943,8 @@ msgstr "Bisakah Mozilla memuat pengaya saya?"
 
 #: src/olympia/pages/templates/pages/dev_faq.html:279
 #, python-format
-msgid ""
-"Yes. You can host your add-on on <a href=\"%(url)s\">Mozilla's add-on "
-"website</a>."
-msgstr ""
-"Ya. Anda bisa memuat pengaya anda di <a href=\"%(url)s\">situs pengaya "
-"Mozilla</a>."
+msgid "Yes. You can host your add-on on <a href=\"%(url)s\">Mozilla's add-on website</a>."
+msgstr "Ya. Anda bisa memuat pengaya anda di <a href=\"%(url)s\">situs pengaya Mozilla</a>."
 
 #: src/olympia/pages/templates/pages/dev_faq.html:284
 msgid "What is AMO?"
@@ -12428,19 +9952,11 @@ msgstr "Apakah AMO itu?"
 
 #: src/olympia/pages/templates/pages/dev_faq.html:286
 msgid ""
-"Mozilla's AMO (<a "
-"href=\"https://addons.mozilla.org\">https://addons.mozilla.org</a>) is the "
-"incubator that helps developers build, distribute, and support fantastic "
-"consumer products powered by Mozilla. It provides you the tools and "
-"infrastructure necessary to manage, host and expose your add-on to a massive"
-" base of Mozilla users."
+"Mozilla's AMO (<a href=\"https://addons.mozilla.org\">https://addons.mozilla.org</a>) is the incubator that helps developers build, distribute, and support fantastic consumer products powered by "
+"Mozilla. It provides you the tools and infrastructure necessary to manage, host and expose your add-on to a massive base of Mozilla users."
 msgstr ""
-"AMO Mozilla (<a "
-"href=\"https://addons.mozilla.org\">https://addons.mozilla.org</a>) adalah "
-"inkubator yang membantu pengembang membuat, mendistribusikan, dan mendukung "
-"produk konsumen yang luar biasa, dengan dukungan Mozilla. Menyediakan "
-"perangkat dan infrastruktur yang diperlukan untuk mengelola, memuat dan "
-"menampilkan pengaya anda kepada pengguna Mozilla secara masif."
+"AMO Mozilla (<a href=\"https://addons.mozilla.org\">https://addons.mozilla.org</a>) adalah inkubator yang membantu pengembang membuat, mendistribusikan, dan mendukung produk konsumen yang luar "
+"biasa, dengan dukungan Mozilla. Menyediakan perangkat dan infrastruktur yang diperlukan untuk mengelola, memuat dan menampilkan pengaya anda kepada pengguna Mozilla secara masif."
 
 #: src/olympia/pages/templates/pages/dev_faq.html:295
 msgid "Does Mozilla keep my account information private?"
@@ -12448,12 +9964,8 @@ msgstr "Apakah Mozilla menjaga informasi akun saya tetap privat?"
 
 #: src/olympia/pages/templates/pages/dev_faq.html:297
 #, python-format
-msgid ""
-"Yes. Our <a href=\"%(url)s\">Privacy Policy</a> describes how your "
-"information is managed by Mozilla."
-msgstr ""
-"Ya. Kami memiliki <a href=\"%(url)s\">Kebijakan Privasi</a> yang menjelaskan"
-" bagaimana informasi anda dikelola Mozilla."
+msgid "Yes. Our <a href=\"%(url)s\">Privacy Policy</a> describes how your information is managed by Mozilla."
+msgstr "Ya. Kami memiliki <a href=\"%(url)s\">Kebijakan Privasi</a> yang menjelaskan bagaimana informasi anda dikelola Mozilla."
 
 #: src/olympia/pages/templates/pages/dev_faq.html:302
 msgid "What are the \"developer tools\" listed on AMO?"
@@ -12461,37 +9973,24 @@ msgstr "Apa sajakah \"perangkat pengembang\" yang didaftar dalam AMO?"
 
 #: src/olympia/pages/templates/pages/dev_faq.html:304
 msgid ""
-"The \"Developer Tools\" dashboard is the area that provides you the tools to"
-" successfully manage your add-ons. It provides the functionality necessary "
-"to submit your add-ons to AMO, manage add-on information, and review "
-"statistics."
+"The \"Developer Tools\" dashboard is the area that provides you the tools to successfully manage your add-ons. It provides the functionality necessary to submit your add-ons to AMO, manage add-on "
+"information, and review statistics."
 msgstr ""
-"Papan \"Perangkat Pengaya\" adalah area yang memberikan alat untuk mengelola"
-" pengaya anda secara berhasil. Ia menyediakan fungsi yang diperlukan untuk "
-"memasukkan pengaya anda ke AMO, mengelola informasi pengaya dan mengulas "
-"statistiknya."
+"Papan \"Perangkat Pengaya\" adalah area yang memberikan alat untuk mengelola pengaya anda secara berhasil. Ia menyediakan fungsi yang diperlukan untuk memasukkan pengaya anda ke AMO, mengelola "
+"informasi pengaya dan mengulas statistiknya."
 
 #: src/olympia/pages/templates/pages/dev_faq.html:312
-msgid ""
-"Does Mozilla have a policy in place as to what is an acceptable submission?"
-msgstr ""
-"Apakah Mozilla memiliki kebijakan yang ditetapkan mengenai penyampaian "
-"apakah yang dapat diterima?"
+msgid "Does Mozilla have a policy in place as to what is an acceptable submission?"
+msgstr "Apakah Mozilla memiliki kebijakan yang ditetapkan mengenai penyampaian apakah yang dapat diterima?"
 
 #: src/olympia/pages/templates/pages/dev_faq.html:314
 #, python-format
 msgid ""
-"Yes. Mozilla's <a href=\"%(p_url)s\">Add-on Policy</a> describes what is an "
-"acceptable submission. This policy is subject to change without notice.  In "
-"addition, the AMO editorial team uses the <a href=\"%(g_url)s\">Editors "
-"Reviewing Guide</a> to ensure that your add-on meets specific guidelines for"
-" functionality and security."
+"Yes. Mozilla's <a href=\"%(p_url)s\">Add-on Policy</a> describes what is an acceptable submission. This policy is subject to change without notice. In addition, the AMO editorial team uses the <a "
+"href=\"%(g_url)s\">Editors Reviewing Guide</a> to ensure that your add-on meets specific guidelines for functionality and security."
 msgstr ""
-"Ya.  <a href=\"%(p_url)s\">Kebijakan Pengaya</a> Mozilla menjelaskan apa "
-"yang dianggap penyampaian yang dapat diterima. Kebijakan ini dapat diubah "
-"tanpa pemberitahuan sebelumnya. Selain itu, tim editorial AMO menggunakan <a"
-" href=\"%(g_url)s\">Panduan Tinjauan Editor</a> untuk memastikan bahwa "
-"pengaya anda memenuhi panduan spesifik tertentu untuk fungsi dan keamanan."
+"Ya.  <a href=\"%(p_url)s\">Kebijakan Pengaya</a> Mozilla menjelaskan apa yang dianggap penyampaian yang dapat diterima. Kebijakan ini dapat diubah tanpa pemberitahuan sebelumnya. Selain itu, tim "
+"editorial AMO menggunakan <a href=\"%(g_url)s\">Panduan Tinjauan Editor</a> untuk memastikan bahwa pengaya anda memenuhi panduan spesifik tertentu untuk fungsi dan keamanan."
 
 #: src/olympia/pages/templates/pages/dev_faq.html:324
 msgid "How do I submit my add-on for review?"
@@ -12500,30 +9999,19 @@ msgstr "Bagaimana saya memasukkan pengaya untuk diulas?"
 #: src/olympia/pages/templates/pages/dev_faq.html:326
 #, python-format
 msgid ""
-"The Developer Tools dashboard will allow you to upload and submit add-ons to"
-" AMO. You must be a registered AMO users before you can submit an add-on. "
-"Before submitting your add-on be sure to you have read the AMO <a "
-"href=\"%(url)s\">Editors Reviewing Guide</a> to ensure that your add-on has "
-"met the guidelines used by editors to review add-ons."
+"The Developer Tools dashboard will allow you to upload and submit add-ons to AMO. You must be a registered AMO users before you can submit an add-on. Before submitting your add-on be sure to you "
+"have read the AMO <a href=\"%(url)s\">Editors Reviewing Guide</a> to ensure that your add-on has met the guidelines used by editors to review add-ons."
 msgstr ""
-"Papan Perangkat Pengembang akan memungkinkan anda memuat dan memasukkan "
-"pengaya ke AMO. Anda harus menjadi pengguna AMO yang terdaftar sebelum bisa "
-"memasukkan pengaya. Sebelum memasukkan pengaya anda, pastikan untuk telah "
-"membaca <a href=\"%(url)s\">Panduan Ulasan Editor</a> AMO untuk memastikan "
-"pengaya anda telah memenuhi panduan yang digunakan editor untuk mengulas "
-"pengaya."
+"Papan Perangkat Pengembang akan memungkinkan anda memuat dan memasukkan pengaya ke AMO. Anda harus menjadi pengguna AMO yang terdaftar sebelum bisa memasukkan pengaya. Sebelum memasukkan pengaya "
+"anda, pastikan untuk telah membaca <a href=\"%(url)s\">Panduan Ulasan Editor</a> AMO untuk memastikan pengaya anda telah memenuhi panduan yang digunakan editor untuk mengulas pengaya."
 
 #: src/olympia/pages/templates/pages/dev_faq.html:336
 msgid "What operating system do I choose for my add-on?"
 msgstr "Sistem operasi apa yang saya pilih untuk pengaya saya?"
 
 #: src/olympia/pages/templates/pages/dev_faq.html:338
-msgid ""
-"You must choose the operating systems on which your add-on will successfully"
-" function."
-msgstr ""
-"Anda harus memilih sistem operasi yang memungkinkan pengaya anda berhasil "
-"berfungsi."
+msgid "You must choose the operating systems on which your add-on will successfully function."
+msgstr "Anda harus memilih sistem operasi yang memungkinkan pengaya anda berhasil berfungsi."
 
 #: src/olympia/pages/templates/pages/dev_faq.html:344
 msgid "What category do I choose for my add-on?"
@@ -12531,58 +10019,38 @@ msgstr "Kategori apa yang saya pilih untuk pengaya saya?"
 
 #: src/olympia/pages/templates/pages/dev_faq.html:346
 msgid ""
-"The choice of category is dependent on what type of audience you are "
-"targeting and the functionality of your add-on. If you're unsure of which "
-"category your add-on falls into, please choose \"Other\". The AMO team may "
-"re-categorize your add-on if it's determined that it's better suited in a "
-"different category."
+"The choice of category is dependent on what type of audience you are targeting and the functionality of your add-on. If you're unsure of which category your add-on falls into, please choose \"Other"
+"\". The AMO team may re-categorize your add-on if it's determined that it's better suited in a different category."
 msgstr ""
-"Pilihan kategori tergantung pada apa tipe audiens yang anda tergetkan dan "
-"fungsi pengaya anda. Jika anda tidak yakin pengaya anda termasuk dalam "
-"kategori mana, harap memilih \"Lainnya\". Tim AMO bisa mengkategori ulang "
-"pengaya anda jika telah ditentukan bahwa pengaya ini lebih cocok dalam "
-"kategori yang berbeda."
+"Pilihan kategori tergantung pada apa tipe audiens yang anda tergetkan dan fungsi pengaya anda. Jika anda tidak yakin pengaya anda termasuk dalam kategori mana, harap memilih \"Lainnya\". Tim AMO "
+"bisa mengkategori ulang pengaya anda jika telah ditentukan bahwa pengaya ini lebih cocok dalam kategori yang berbeda."
 
 #: src/olympia/pages/templates/pages/dev_faq.html:355
 msgid "What does \"nominating\" my add-on mean?"
 msgstr "Apakah artinya \"menominasikan\" pengaya saya?"
 
 #: src/olympia/pages/templates/pages/dev_faq.html:357
-msgid ""
-"Nominated add-ons are new add-ons that the author has nominated to become "
-"public via the Developer Tools."
-msgstr ""
-"Pengaya yang dinominasikan adalah pengaya baru yang penulisnya telah "
-"dinominasikan untuk menjadi publik melalui Perangkat Pengembang."
+msgid "Nominated add-ons are new add-ons that the author has nominated to become public via the Developer Tools."
+msgstr "Pengaya yang dinominasikan adalah pengaya baru yang penulisnya telah dinominasikan untuk menjadi publik melalui Perangkat Pengembang."
 
 #: src/olympia/pages/templates/pages/dev_faq.html:363
 msgid "Can I specify a license agreement for using my add-on?"
-msgstr ""
-"Bisakah saya merinci kesepakatan lisensi untuk menggunakan pengaya saya?"
+msgstr "Bisakah saya merinci kesepakatan lisensi untuk menggunakan pengaya saya?"
 
 #: src/olympia/pages/templates/pages/dev_faq.html:365
-msgid ""
-"Yes. You can specify a license agreement when submitting your add-on. You "
-"can also add or update a license agreement via the Developer Tools dashboard"
-" after your add-on has been submitted."
+msgid "Yes. You can specify a license agreement when submitting your add-on. You can also add or update a license agreement via the Developer Tools dashboard after your add-on has been submitted."
 msgstr ""
-"Bisa. Anda bisa merinci kesepakatan lisensi saat memasukkan pengaya. Anda "
-"juga bisa menambahkan atau memperbarui kesepakatan pengaya lewat papan "
-"Perangkat Pengembang setelah pengaya anda didaftarkan."
+"Bisa. Anda bisa merinci kesepakatan lisensi saat memasukkan pengaya. Anda juga bisa menambahkan atau memperbarui kesepakatan pengaya lewat papan Perangkat Pengembang setelah pengaya anda "
+"didaftarkan."
 
 #: src/olympia/pages/templates/pages/dev_faq.html:372
 msgid "Can I include a privacy policy for my add-on?"
 msgstr "Bisakah saya memasukkan kebijakan privasi untuk pengaya saya?"
 
 #: src/olympia/pages/templates/pages/dev_faq.html:374
-msgid ""
-"Yes. You can specify a privacy policy when submitting your add-on. You can "
-"also add or update a privacy policy via the Developer Tools dashboard after "
-"your add-on has been submitted."
+msgid "Yes. You can specify a privacy policy when submitting your add-on. You can also add or update a privacy policy via the Developer Tools dashboard after your add-on has been submitted."
 msgstr ""
-"Bisa. Anda bisa merinci kebijakan privasi saat memasukkan pengaya. Anda juga"
-" bisa menambah atau memperbarui kebijakan privasi melalui papan Perangkat "
-"Pengembang setelah pengaya anda didaftarkan."
+"Bisa. Anda bisa merinci kebijakan privasi saat memasukkan pengaya. Anda juga bisa menambah atau memperbarui kebijakan privasi melalui papan Perangkat Pengembang setelah pengaya anda didaftarkan."
 
 #: src/olympia/pages/templates/pages/dev_faq.html:383
 msgid "Why must my add-on be reviewed?"
@@ -12591,15 +10059,11 @@ msgstr "Mengapa pengaya saya harus diulas?"
 #: src/olympia/pages/templates/pages/dev_faq.html:385
 #, python-format
 msgid ""
-"All add-ons submitted, whether new or updated, are reviewed to ensure that "
-"Mozilla users have a stable and safe experience. All add-ons submissions are"
-" reviewed using the guidelines outlined in the <a href=\"%(url)s\">Editors "
-"Reviewing Guide</a>."
+"All add-ons submitted, whether new or updated, are reviewed to ensure that Mozilla users have a stable and safe experience. All add-ons submissions are reviewed using the guidelines outlined in the "
+"<a href=\"%(url)s\">Editors Reviewing Guide</a>."
 msgstr ""
-"Semua pengaya yang didaftarkan, baik baru atau dieprbarui, harus diulas "
-"untuk memastikan bahwa pengguna Mozilla mendapatkan pengalaman yang stabil "
-"dan aman. Seluruh pendaftaran pengaya diulas menggunakan panduan yang "
-"ditulis dalam <a href=\"%(url)s\">Panduan Pengulasan Penyunting</a>."
+"Semua pengaya yang didaftarkan, baik baru atau dieprbarui, harus diulas untuk memastikan bahwa pengguna Mozilla mendapatkan pengalaman yang stabil dan aman. Seluruh pendaftaran pengaya diulas "
+"menggunakan panduan yang ditulis dalam <a href=\"%(url)s\">Panduan Pengulasan Penyunting</a>."
 
 #: src/olympia/pages/templates/pages/dev_faq.html:393
 msgid "Who reviews my add-on?"
@@ -12608,20 +10072,13 @@ msgstr "Siapa yang mengulas pengaya saya?"
 #: src/olympia/pages/templates/pages/dev_faq.html:395
 #, python-format
 msgid ""
-"Add-ons are reviewed by the AMO Editors, a group of talented developers that"
-" volunteer to help the Mozilla project by reviewing add-ons to ensure a "
-"stable and safe experience for Mozilla users. When communicating with "
-"editors, please be courteous, patient and respectful as they are working "
-"hard to ensure that your add-on is set up correctly and follows the "
-"guidelines outlined in the <a href=\"%(url)s\">Editors Reviewing Guide</a>."
+"Add-ons are reviewed by the AMO Editors, a group of talented developers that volunteer to help the Mozilla project by reviewing add-ons to ensure a stable and safe experience for Mozilla users. "
+"When communicating with editors, please be courteous, patient and respectful as they are working hard to ensure that your add-on is set up correctly and follows the guidelines outlined in the <a "
+"href=\"%(url)s\">Editors Reviewing Guide</a>."
 msgstr ""
-"Semua pengaya diulas oleh Penyunting AMO, sekelompok pengembang berbakat "
-"yang secara sukarela membantu proyek Mozilla dengan mengulas pengaya untuk "
-"memastikan pengalaman yang stabil dan aman untuk pengguna Mozilla. Saat "
-"berkomunikasi dengan penyunting, harap sopan, sabar dan menghormati karena "
-"mereka bekerja keras untuk memastikan pengaya anda dipasang dengan benar dan"
-" mengikuri panduan yang digariskan di <a href=\"%(url)s\">Panduan Ulasan "
-"Penyunting</a>."
+"Semua pengaya diulas oleh Penyunting AMO, sekelompok pengembang berbakat yang secara sukarela membantu proyek Mozilla dengan mengulas pengaya untuk memastikan pengalaman yang stabil dan aman untuk "
+"pengguna Mozilla. Saat berkomunikasi dengan penyunting, harap sopan, sabar dan menghormati karena mereka bekerja keras untuk memastikan pengaya anda dipasang dengan benar dan mengikuri panduan yang "
+"digariskan di <a href=\"%(url)s\">Panduan Ulasan Penyunting</a>."
 
 #: src/olympia/pages/templates/pages/dev_faq.html:406
 msgid "What are the guidelines used to review my add-on?"
@@ -12630,29 +10087,19 @@ msgstr "Apakah panduan yang digunakan untuk mengulas pengaya saya?"
 #: src/olympia/pages/templates/pages/dev_faq.html:408
 #, python-format
 msgid ""
-"The Mozilla editorial team follows the <a href=\"%(url)s\">Editors Reviewing"
-" Guide</a> when testing an add-on for acceptance onto AMO. It is important "
-"that add-on developers review this guide to ensure that common problem areas"
-" are addressed prior to submitting their add-on for review. This will "
-"greatly assist in expediting the review process."
+"The Mozilla editorial team follows the <a href=\"%(url)s\">Editors Reviewing Guide</a> when testing an add-on for acceptance onto AMO. It is important that add-on developers review this guide to "
+"ensure that common problem areas are addressed prior to submitting their add-on for review. This will greatly assist in expediting the review process."
 msgstr ""
-"Tim penyunting Mozilla mengikuti <a href=\"%(url)s\">Panduan Ulasan "
-"Penyunting</a> saat menguji pengaya untuk diterima di AMO. Sangat penting "
-"bagi pengembang pengaya meninjau panduan ini untuk memastikan bahwa bagian "
-"masalah umum telah ditangani sebelum memasukkan pengaya mereka untuk diulas."
-" Ini akan sangat membantu mempercepat proses pengulasan."
+"Tim penyunting Mozilla mengikuti <a href=\"%(url)s\">Panduan Ulasan Penyunting</a> saat menguji pengaya untuk diterima di AMO. Sangat penting bagi pengembang pengaya meninjau panduan ini untuk "
+"memastikan bahwa bagian masalah umum telah ditangani sebelum memasukkan pengaya mereka untuk diulas. Ini akan sangat membantu mempercepat proses pengulasan."
 
 #: src/olympia/pages/templates/pages/dev_faq.html:418
 msgid "How long will it take for my add-on to be reviewed?"
 msgstr "Berapa lama waktu yang diperlukan pengaya saya untuk diulas?"
 
 #: src/olympia/pages/templates/pages/dev_faq.html:420
-msgid ""
-"We cannot give a time estimate as to how long it will take before an add-on "
-"is reviewed. Many factors affect the time including the:"
-msgstr ""
-"Kami tidak dapat memberikan perkiraan waktu berapa lama sebelum pengaya "
-"diulas. Beberapa faktor yang mempengaruhi jangka waktu tercakup dalam:"
+msgid "We cannot give a time estimate as to how long it will take before an add-on is reviewed. Many factors affect the time including the:"
+msgstr "Kami tidak dapat memberikan perkiraan waktu berapa lama sebelum pengaya diulas. Beberapa faktor yang mempengaruhi jangka waktu tercakup dalam:"
 
 #. part of a list (<li>)
 #: src/olympia/pages/templates/pages/dev_faq.html:427
@@ -12672,60 +10119,36 @@ msgstr "jumlah masalah yang dicakup"
 #: src/olympia/pages/templates/pages/dev_faq.html:434
 #, python-format
 msgid ""
-"This is why it's very important to read the <a href=\"%(g_url)s\">Editors "
-"Reviewing Guide</a> to ensure that your add-on is setup as expected.  It's "
-"also a good idea to read the blog post, <a "
-"href=\"%(blog_url)s\">Successfully Getting your Add-on Reviewed</a> which "
-"provides excellent insight into ensuring a smooth review of your add-on."
+"This is why it's very important to read the <a href=\"%(g_url)s\">Editors Reviewing Guide</a> to ensure that your add-on is setup as expected. It's also a good idea to read the blog post, <a href="
+"\"%(blog_url)s\">Successfully Getting your Add-on Reviewed</a> which provides excellent insight into ensuring a smooth review of your add-on."
 msgstr ""
-"Inilah pentingnya membaca <a href=\"%(g_url)s\">Panduan Ulasan "
-"Penyunting</a> untuk memastikan bahwa pengaya anda ditetapkan sebagaimana "
-"diharapkan.  Juga merupakan ide bagus untuk membaca tulisan di blog, <a "
-"href=\"%(blog_url)s\">Agar Pengaya Anda Berhasil Diulas</a> yang memberikan "
-"wawasan untuk memastikan ulasan yang lancar untuk pengaya anda."
+"Inilah pentingnya membaca <a href=\"%(g_url)s\">Panduan Ulasan Penyunting</a> untuk memastikan bahwa pengaya anda ditetapkan sebagaimana diharapkan.  Juga merupakan ide bagus untuk membaca tulisan "
+"di blog, <a href=\"%(blog_url)s\">Agar Pengaya Anda Berhasil Diulas</a> yang memberikan wawasan untuk memastikan ulasan yang lancar untuk pengaya anda."
 
 #: src/olympia/pages/templates/pages/dev_faq.html:446
 msgid "How can I see how many times my add-on has been downloaded?"
 msgstr "Bagaimana saya bisa melihat berapa kali pengaya saya diunduh?"
 
 #: src/olympia/pages/templates/pages/dev_faq.html:448
-msgid ""
-"The Statistics Dashboard found in the Developer Tools dashboard provides "
-"information that can help you determine your add-on downloads since you've "
-"submitted it to AMO."
-msgstr ""
-"Papan Statistik yang ditemukan dalam papan Perangkat Pengembang menyediakan "
-"informasi yang bisa membantu anda menentukan berapa kali pengaya anda "
-"diunduh sejak dimasukkan ke AMO."
+msgid "The Statistics Dashboard found in the Developer Tools dashboard provides information that can help you determine your add-on downloads since you've submitted it to AMO."
+msgstr "Papan Statistik yang ditemukan dalam papan Perangkat Pengembang menyediakan informasi yang bisa membantu anda menentukan berapa kali pengaya anda diunduh sejak dimasukkan ke AMO."
 
 #: src/olympia/pages/templates/pages/dev_faq.html:455
 msgid "How can I see how many active users are using my add-on?"
-msgstr ""
-"Bagaimana saya bisa melihat berapa banyak pengguna aktif pengaya saya?"
+msgstr "Bagaimana saya bisa melihat berapa banyak pengguna aktif pengaya saya?"
 
 #: src/olympia/pages/templates/pages/dev_faq.html:457
 msgid ""
-"The Statistics Dashboard found in the Developer Tools dashboard provides "
-"information that can help you determine how many users have been actively "
-"using your add-on since you've submitted it to AMO."
-msgstr ""
-"Papan Statistik yang ditemukan dalam papan Perangkat Pengembang menyediakan "
-"informasi yang bisa membantu anda menentukan berapa jumlah pengguna aktif "
-"pengaya anda sejak dimasukkan ke AMO."
+"The Statistics Dashboard found in the Developer Tools dashboard provides information that can help you determine how many users have been actively using your add-on since you've submitted it to AMO."
+msgstr "Papan Statistik yang ditemukan dalam papan Perangkat Pengembang menyediakan informasi yang bisa membantu anda menentukan berapa jumlah pengguna aktif pengaya anda sejak dimasukkan ke AMO."
 
 #: src/olympia/pages/templates/pages/dev_faq.html:464
 msgid "How do I submit an update for my add-on?"
 msgstr "Bagaimana saya memasukkan pembaruan pengaya saya?"
 
 #: src/olympia/pages/templates/pages/dev_faq.html:466
-msgid ""
-"You can submit an update for your add-on via the Developer Tools dashboard "
-"by choosing the option \"Upload a new version\" and uploading a new .xpi "
-"file for your add-on."
-msgstr ""
-"Anda bisa memasukkan pembaruan pengaya melalui papan Perangkat Pengembang "
-"dengan memilih \"Unggah versi baru\" dan mengunggah berkas .xpi baru untuk "
-"pengaya anda."
+msgid "You can submit an update for your add-on via the Developer Tools dashboard by choosing the option \"Upload a new version\" and uploading a new .xpi file for your add-on."
+msgstr "Anda bisa memasukkan pembaruan pengaya melalui papan Perangkat Pengembang dengan memilih \"Unggah versi baru\" dan mengunggah berkas .xpi baru untuk pengaya anda."
 
 #: src/olympia/pages/templates/pages/dev_faq.html:473
 msgid "Does my update need to be reviewed by editors?"
@@ -12733,185 +10156,107 @@ msgstr "Apakah pembaruan yang saya buat perlu diulas oleh penyunting?"
 
 #: src/olympia/pages/templates/pages/dev_faq.html:475
 msgid ""
-"That depends. If you are simply changing a description of your add-on or "
-"updating a \"maxVersion\" to ensure compatibility with a new Mozilla "
-"software update, then your add-on does not need to be reviewed again. If, "
-"however, you submit a new updated file, then your add-on update will need to"
-" be reviewed by an editor."
+"That depends. If you are simply changing a description of your add-on or updating a \"maxVersion\" to ensure compatibility with a new Mozilla software update, then your add-on does not need to be "
+"reviewed again. If, however, you submit a new updated file, then your add-on update will need to be reviewed by an editor."
 msgstr ""
-"Tergantung. Jika anda hanya mengubah deskripsi pengaya atau memperbarui "
-"\"maxVersion\" untuk memastikan kecocokan dengan pembaruan perangkat lunak "
-"Mozilla, maka pengaya anda tidak perlu diulas kembali. Namun, jika anda "
-"memasukkan berkas pembaruan, maka pengaya anda akan perlu diulas kembali "
-"oleh penyunting."
+"Tergantung. Jika anda hanya mengubah deskripsi pengaya atau memperbarui \"maxVersion\" untuk memastikan kecocokan dengan pembaruan perangkat lunak Mozilla, maka pengaya anda tidak perlu diulas "
+"kembali. Namun, jika anda memasukkan berkas pembaruan, maka pengaya anda akan perlu diulas kembali oleh penyunting."
 
 #: src/olympia/pages/templates/pages/dev_faq.html:486
-msgid ""
-"How do I reply to a user who has posted a negative review of my add-on?"
-msgstr ""
-"Bagaimana saya menjawab pengguna yang mengirimkan ulasan negatif untuk "
-"pengaya saya?"
+msgid "How do I reply to a user who has posted a negative review of my add-on?"
+msgstr "Bagaimana saya menjawab pengguna yang mengirimkan ulasan negatif untuk pengaya saya?"
 
 #: src/olympia/pages/templates/pages/dev_faq.html:488
-msgid ""
-"A developer may reply to any review posted to their add-on as long as they "
-"are logged into AMO. In addition, any user can flag a review as:"
-msgstr ""
-"Pengembang bisa membalas ulasan apapun untuk pengaya mereka asalkan mereka "
-"masuk dalam AMO. Sebagai tambahan, setiap pengguna bisa menandai ulasan "
-"sebagai:"
+msgid "A developer may reply to any review posted to their add-on as long as they are logged into AMO. In addition, any user can flag a review as:"
+msgstr "Pengembang bisa membalas ulasan apapun untuk pengaya mereka asalkan mereka masuk dalam AMO. Sebagai tambahan, setiap pengguna bisa menandai ulasan sebagai:"
 
 #. part of a list (<li>)
-#: src/olympia/pages/templates/pages/dev_faq.html:495
-#: src/olympia/reviews/models.py:159
+#: src/olympia/pages/templates/pages/dev_faq.html:495 src/olympia/reviews/models.py:159
 msgid "Spam or otherwise non-review content"
 msgstr "Spam atau tidak berisi ulasan"
 
 #. part of a list (<li>)
-#: src/olympia/pages/templates/pages/dev_faq.html:497
-#: src/olympia/reviews/models.py:160
+#: src/olympia/pages/templates/pages/dev_faq.html:497 src/olympia/reviews/models.py:160
 msgid "Inappropriate language/dialog"
 msgstr "Bahasa yang tidak pantas"
 
 #. part of a list (<li>)
-#: src/olympia/pages/templates/pages/dev_faq.html:499
-#: src/olympia/reviews/models.py:161
+#: src/olympia/pages/templates/pages/dev_faq.html:499 src/olympia/reviews/models.py:161
 msgid "Misplaced bug report or support request"
 msgstr "Laporan bug atau permintaan dukungan yang tidak pada tempatnya"
 
 #. part of a list (<li>)
 #: src/olympia/pages/templates/pages/dev_faq.html:501
 msgid "Other (provides a pop-up prompt for information)"
-msgstr ""
-"Lainnya (memberi bagian yang muncul dengan cepat untuk memberi informasi)"
+msgstr "Lainnya (memberi bagian yang muncul dengan cepat untuk memberi informasi)"
 
 #: src/olympia/pages/templates/pages/dev_faq.html:504
-msgid ""
-"Currently, AMO does not provide a mechanism to directly communicate with a "
-"reviewer but this feature is being investigated and considered for a future "
-"update."
-msgstr ""
-"Saat ini, AMO tidak menyediakan mekanisme untuk berkomunikasi secara "
-"langsung dengan pengulas namun fitur ini sedang diselidiki dan "
-"dipertimbangkan untuk pembaruan di masa depan."
+msgid "Currently, AMO does not provide a mechanism to directly communicate with a reviewer but this feature is being investigated and considered for a future update."
+msgstr "Saat ini, AMO tidak menyediakan mekanisme untuk berkomunikasi secara langsung dengan pengulas namun fitur ini sedang diselidiki dan dipertimbangkan untuk pembaruan di masa depan."
 
 #: src/olympia/pages/templates/pages/dev_faq.html:511
 msgid "Can I request that a review be removed if the review is negative?"
-msgstr ""
-"Bisakah saya meminta sebuah ulasan dihapus jika ulasan tersebut negatif?"
+msgstr "Bisakah saya meminta sebuah ulasan dihapus jika ulasan tersebut negatif?"
 
 #: src/olympia/pages/templates/pages/dev_faq.html:513
-msgid ""
-"No. We do not remove negative reviews from add-ons unless they are found to "
-"be false."
-msgstr ""
-"Tidak. Kami tidak menghapus ulasan negatif dari pengaya kecuali jika ulasan "
-"itu diketahui salah."
+msgid "No. We do not remove negative reviews from add-ons unless they are found to be false."
+msgstr "Tidak. Kami tidak menghapus ulasan negatif dari pengaya kecuali jika ulasan itu diketahui salah."
 
 #: src/olympia/pages/templates/pages/dev_faq.html:519
 msgid "Can I request that a review be removed if the review is inaccurate?"
-msgstr ""
-"Bisakah saya meminta sebuah ulasan dihapus jika ulasan tersebut tidak "
-"akurat?"
+msgstr "Bisakah saya meminta sebuah ulasan dihapus jika ulasan tersebut tidak akurat?"
 
 #: src/olympia/pages/templates/pages/dev_faq.html:521
-msgid ""
-"If an author contacts us and asks for a review containing false or "
-"inaccurate information to be removed, we will review the post and consider "
-"removing it."
-msgstr ""
-"Jika penulis mengontak kami dan meminta supaya ulasan yang mengandung "
-"kesalahan informasi atau tidak akurat dihapus, kami akan meninjau kiriman "
-"tersebut dan menghapusnya."
+msgid "If an author contacts us and asks for a review containing false or inaccurate information to be removed, we will review the post and consider removing it."
+msgstr "Jika penulis mengontak kami dan meminta supaya ulasan yang mengandung kesalahan informasi atau tidak akurat dihapus, kami akan meninjau kiriman tersebut dan menghapusnya."
 
 #: src/olympia/pages/templates/pages/dev_faq.html:530
 msgid ""
-"Do you need more information about the various open source licenses? Are you"
-" confused as to which license you should select? What rights does a specific"
-" license grant? While nothing replaces reading the full terms of a license, "
-"below are some sites that contain information about some of the key open "
-"source licenses that may help you sort out the differences between them. "
-"These sites are being provided solely for your convenience and as a "
-"reference for your personal use. These resources do not constitute legal "
-"advice nor should they be used in lieu of such advice. Mozilla neither "
-"guarantees nor is responsible for the content of these sites or your "
-"reliance on such content."
+"Do you need more information about the various open source licenses? Are you confused as to which license you should select? What rights does a specific license grant? While nothing replaces "
+"reading the full terms of a license, below are some sites that contain information about some of the key open source licenses that may help you sort out the differences between them. These sites "
+"are being provided solely for your convenience and as a reference for your personal use. These resources do not constitute legal advice nor should they be used in lieu of such advice. Mozilla "
+"neither guarantees nor is responsible for the content of these sites or your reliance on such content."
 msgstr ""
-"Apakah anda perlu tambahan informasi mengenai berbagai lisensi sumber "
-"terbuka? Apakah anda kebingungan mengenai lisensi mana yang harus anda "
-"pilih? Hak apakah yang memberi lisensi secara spesifik? Tidak ada yang "
-"menggantikan membaca ketentuan lengkap sebuah lisensi, di bawah ini ada "
-"sejumlah situs yang mengandung informasi mengenai beberapa kunci lisensi "
-"sumber terbuka yang bisa membantu anda menyortir perbedaan di antaranya. "
-"Situs ini disediakan hanya untuk kenyamanan anda dan sebagai referensi untuk"
-" penggunaan pribadi. Sumber ini tidak dianggap saran hukum dan tidak "
-"sebaiknya digunakan untuk memberi saran terkait hal tersebut. Mozilla tidak "
-"menjamin dan tidak bertanggung jawab atas konten situs ini jika anda "
-"bergantung padanya."
+"Apakah anda perlu tambahan informasi mengenai berbagai lisensi sumber terbuka? Apakah anda kebingungan mengenai lisensi mana yang harus anda pilih? Hak apakah yang memberi lisensi secara spesifik? "
+"Tidak ada yang menggantikan membaca ketentuan lengkap sebuah lisensi, di bawah ini ada sejumlah situs yang mengandung informasi mengenai beberapa kunci lisensi sumber terbuka yang bisa membantu "
+"anda menyortir perbedaan di antaranya. Situs ini disediakan hanya untuk kenyamanan anda dan sebagai referensi untuk penggunaan pribadi. Sumber ini tidak dianggap saran hukum dan tidak sebaiknya "
+"digunakan untuk memberi saran terkait hal tersebut. Mozilla tidak menjamin dan tidak bertanggung jawab atas konten situs ini jika anda bergantung padanya."
 
 #: src/olympia/pages/templates/pages/dev_faq.html:545
 msgid ""
-"In addition to the full text of the Mozilla Public License(\"MPL\"), this "
-"also provides an annotated version of the MPL and an <abbr "
-"title=\"Frequently Asked Questions\">FAQ</abbr> to help you if you want to "
-"use or distribute code licensed under it."
+"In addition to the full text of the Mozilla Public License(\"MPL\"), this also provides an annotated version of the MPL and an <abbr title=\"Frequently Asked Questions\">FAQ</abbr> to help you if "
+"you want to use or distribute code licensed under it."
 msgstr ""
-"Sebagai tambahan untuk teks lengkap Lisensi Publik Mozilla(\"MPL\"), ini "
-"juga menyediakan versi beranotasi dari MPL dan <abbr title=\"Frequently "
-"Asked Questions\">FAQ</abbr> untuk membantu anda jika anda ingin menggunakan"
-" atau mendistribusikan kode di bawahnya."
+"Sebagai tambahan untuk teks lengkap Lisensi Publik Mozilla(\"MPL\"), ini juga menyediakan versi beranotasi dari MPL dan <abbr title=\"Frequently Asked Questions\">FAQ</abbr> untuk membantu anda "
+"jika anda ingin menggunakan atau mendistribusikan kode di bawahnya."
 
 #: src/olympia/pages/templates/pages/dev_faq.html:559
-msgid ""
-"A table summarizing and comparing how some of the key open source licenses "
-"treat distributions, proprietary software linking, and redistribution of "
-"code with changes."
-msgstr ""
-"Tabel yang meringkas dan membandingkan bagaimana sebagian dari kunci lisensi"
-" kode terbuka memperlakukan distribusi, kaitan perangkat lunak asal, dan "
-"distribusi ulang kode dengan perubahan."
+msgid "A table summarizing and comparing how some of the key open source licenses treat distributions, proprietary software linking, and redistribution of code with changes."
+msgstr "Tabel yang meringkas dan membandingkan bagaimana sebagian dari kunci lisensi kode terbuka memperlakukan distribusi, kaitan perangkat lunak asal, dan distribusi ulang kode dengan perubahan."
 
 #: src/olympia/pages/templates/pages/dev_faq.html:572
 msgid ""
-"Free Software Foundation provides short summaries of the key open source "
-"licenses, including whether the license qualifies as a free software license"
-" or a copyleft license.  Also includes a discussion of what constitutes a "
-"free software license or a copyleft license (e.g., a Copyleft license is a "
-"general method for making a program or other work free, and requiring all "
-"modified and extended versions of the program to be free as well.)"
+"Free Software Foundation provides short summaries of the key open source licenses, including whether the license qualifies as a free software license or a copyleft license. Also includes a "
+"discussion of what constitutes a free software license or a copyleft license (e.g., a Copyleft license is a general method for making a program or other work free, and requiring all modified and "
+"extended versions of the program to be free as well.)"
 msgstr ""
-"Yayasan Perangkat Lunak Bebas menyediakan ringkasan pendek dari kunci "
-"lisensi sumber terbuka, termasuk apakah lisensi ini dapat dikategorikan "
-"sebagai lisensi perangkat lunak bebas atau lisensi copyleft.  Juga "
-"menyertakan diskusi akan apa yang dimaksud lisensi perangkat lunak bebas "
-"atau lisensi copyleft (mis. lisensi COpyleft adalah metode umum untuk "
-"membuat program atau karya lainnya bebas, dan meminta semua versi yang "
-"dimodifikasi dan diperpanjang untuk menjadi bebas juga.)"
+"Yayasan Perangkat Lunak Bebas menyediakan ringkasan pendek dari kunci lisensi sumber terbuka, termasuk apakah lisensi ini dapat dikategorikan sebagai lisensi perangkat lunak bebas atau lisensi "
+"copyleft.  Juga menyertakan diskusi akan apa yang dimaksud lisensi perangkat lunak bebas atau lisensi copyleft (mis. lisensi COpyleft adalah metode umum untuk membuat program atau karya lainnya "
+"bebas, dan meminta semua versi yang dimodifikasi dan diperpanjang untuk menjadi bebas juga.)"
 
 #: src/olympia/pages/templates/pages/dev_faq.html:589
-msgid ""
-"Open Source Initiative provides the terms of some of the key open source "
-"licenses."
-msgstr ""
-"Inisiatif Sumber Terbuka menyediakan ketentuan untuk sejumlah kunci lisensi "
-"sumber terbuka."
+msgid "Open Source Initiative provides the terms of some of the key open source licenses."
+msgstr "Inisiatif Sumber Terbuka menyediakan ketentuan untuk sejumlah kunci lisensi sumber terbuka."
 
 #: src/olympia/pages/templates/pages/dev_faq.html:599
 msgid "A comparison of known open source licenses on Wikipedia."
-msgstr ""
-"Perbandingan untuk lisensi sumber terbuka yang sudah dikenal di Wikipedia."
+msgstr "Perbandingan untuk lisensi sumber terbuka yang sudah dikenal di Wikipedia."
 
 #: src/olympia/pages/templates/pages/dev_faq.html:605
-msgid ""
-"A site to provide non-judgmental guidance on choosing a license for your "
-"open source project."
-msgstr ""
-"Sebuah situs yang menediakan panduan yang tidak menghakimi dalam memilih "
-"lisensi untuk proyek sumber terbuka anda."
+msgid "A site to provide non-judgmental guidance on choosing a license for your open source project."
+msgstr "Sebuah situs yang menediakan panduan yang tidak menghakimi dalam memilih lisensi untuk proyek sumber terbuka anda."
 
-#: src/olympia/pages/templates/pages/faq.html:3
-#: src/olympia/pages/templates/pages/faq.html:9
-#: src/olympia/pages/templates/pages/faq.html:10
+#: src/olympia/pages/templates/pages/faq.html:3 src/olympia/pages/templates/pages/faq.html:9 src/olympia/pages/templates/pages/faq.html:10
 msgid "Frequently Asked Questions"
 msgstr "Часті питання"
 
@@ -12926,19 +10271,11 @@ msgstr "Apakah pengaya itu?"
 #: src/olympia/pages/templates/pages/faq.html:16
 #, python-format
 msgid ""
-"Add-ons are small pieces of software that add new features or functionality "
-"to your installation of %(app_name)s. Add-ons can augment %(app_name)s with "
-"new features, foreign language dictionaries, or change its visual "
-"appearance. Through add-ons, you can customize %(app_name)s to meet your "
-"needs and tastes. <a href=\"%(learnmore_url)s\">Learn more about "
-"customization</a>"
+"Add-ons are small pieces of software that add new features or functionality to your installation of %(app_name)s. Add-ons can augment %(app_name)s with new features, foreign language dictionaries, "
+"or change its visual appearance. Through add-ons, you can customize %(app_name)s to meet your needs and tastes. <a href=\"%(learnmore_url)s\">Learn more about customization</a>"
 msgstr ""
-"Pengaya adalah bagian kecil perangkat lunak yang menambah fitur atau fungsi "
-"untuk pemasangan %(app_name)s. Pengaya bisa menambah %(app_name)s dengan "
-"fitur baru, kamus bahasa asing, atau mengubah tampilan visualnya. Melalui "
-"pengaya, anda bisa menyesuaikan %(app_name)s sesuai dengan kebutuhan dan "
-"selera anda. <a href=\"%(learnmore_url)s\">Pelajari lebih lanjut tentang "
-"penyesuaian</a>"
+"Pengaya adalah bagian kecil perangkat lunak yang menambah fitur atau fungsi untuk pemasangan %(app_name)s. Pengaya bisa menambah %(app_name)s dengan fitur baru, kamus bahasa asing, atau mengubah "
+"tampilan visualnya. Melalui pengaya, anda bisa menyesuaikan %(app_name)s sesuai dengan kebutuhan dan selera anda. <a href=\"%(learnmore_url)s\">Pelajari lebih lanjut tentang penyesuaian</a>"
 
 #: src/olympia/pages/templates/pages/faq.html:26
 msgid "Will add-ons work with my web browser or application?"
@@ -12947,25 +10284,14 @@ msgstr "Akankah pengaya bekerja dengan peramban atau aplikasi saya?"
 #: src/olympia/pages/templates/pages/faq.html:27
 #, python-format
 msgid ""
-"Add-ons listed in this gallery only work with Mozilla-based applications, "
-"such as <a href=\"%(getfirefox_url)s\">Firefox</a>, <a "
-"href=\"%(getmobile_url)s\">Firefox Mobile</a>, <a "
-"href=\"%(getseamonkey_url)s\">SeaMonkey</a>, and <a "
-"href=\"%(getthunderbird_url)s\">Thunderbird</a>. However, not all add-ons "
-"work with each of those applications or every version of those applications."
-" Each add-on specifies which applications and versions it works with, such "
-"as Firefox 2.0 - 3.6.*. For Firefox add-ons, the install buttons will "
-"indicate whether the add-on is compatible or not."
+"Add-ons listed in this gallery only work with Mozilla-based applications, such as <a href=\"%(getfirefox_url)s\">Firefox</a>, <a href=\"%(getmobile_url)s\">Firefox Mobile</a>, <a href="
+"\"%(getseamonkey_url)s\">SeaMonkey</a>, and <a href=\"%(getthunderbird_url)s\">Thunderbird</a>. However, not all add-ons work with each of those applications or every version of those applications. "
+"Each add-on specifies which applications and versions it works with, such as Firefox 2.0 - 3.6.*. For Firefox add-ons, the install buttons will indicate whether the add-on is compatible or not."
 msgstr ""
-"Pengaya yang terdaftar dalam galeri ini hanya bekerja dengan aplikasi "
-"berbasis Mozilla, misalnya <a href=\"%(getfirefox_url)s\">Firefox</a>, <a "
-"href=\"%(getmobile_url)s\">Firefox Mobile</a>, <a "
-"href=\"%(getseamonkey_url)s\">SeaMonkey</a>, dan <a "
-"href=\"%(getthunderbird_url)s\">Thunderbird</a>. Namun demikian tidak semua "
-"pengaya bekerja dengan tiap aplikasi itu atau setiap versi dari aplikasi "
-"tersebut. Tiap pengaya merinci aplikasi mana dan di version mana pengaya itu"
-" bisa bekerja, misalnya Firefox 2.0 - 3.6.*. Untuk pengaya Firefox, tombol "
-"pemasangan akan mengindikasikan apakah pengaya ini cocok atau tidak."
+"Pengaya yang terdaftar dalam galeri ini hanya bekerja dengan aplikasi berbasis Mozilla, misalnya <a href=\"%(getfirefox_url)s\">Firefox</a>, <a href=\"%(getmobile_url)s\">Firefox Mobile</a>, <a "
+"href=\"%(getseamonkey_url)s\">SeaMonkey</a>, dan <a href=\"%(getthunderbird_url)s\">Thunderbird</a>. Namun demikian tidak semua pengaya bekerja dengan tiap aplikasi itu atau setiap versi dari "
+"aplikasi tersebut. Tiap pengaya merinci aplikasi mana dan di version mana pengaya itu bisa bekerja, misalnya Firefox 2.0 - 3.6.*. Untuk pengaya Firefox, tombol pemasangan akan mengindikasikan "
+"apakah pengaya ini cocok atau tidak."
 
 #: src/olympia/pages/templates/pages/faq.html:42
 msgid "What are the different types of add-ons?"
@@ -12973,78 +10299,44 @@ msgstr "Apa sajakah tipe pengaya yang berbeda?"
 
 #: src/olympia/pages/templates/pages/faq.html:43
 #, python-format
-msgid ""
-"There are several kinds of add-ons that customize %(app_name)s in different "
-"ways:"
-msgstr ""
-"Ada beberapa jenis pengaya yang disesuaikan dengan %(app_name)s dalam "
-"berbagai cara:"
+msgid "There are several kinds of add-ons that customize %(app_name)s in different ways:"
+msgstr "Ada beberapa jenis pengaya yang disesuaikan dengan %(app_name)s dalam berbagai cara:"
 
 #: src/olympia/pages/templates/pages/faq.html:47
 #, python-format
 msgid ""
-"<strong><a href=\"%(browse_url)s\">Extensions</a></strong> add new features "
-"to %(app_name)s or modify existing functionality. There are extensions that "
-"allow you to block advertisements, download videos from websites, integrate "
-"more closely with social websites, and add features you see in other "
-"applications."
+"<strong><a href=\"%(browse_url)s\">Extensions</a></strong> add new features to %(app_name)s or modify existing functionality. There are extensions that allow you to block advertisements, download "
+"videos from websites, integrate more closely with social websites, and add features you see in other applications."
 msgstr ""
-"<strong><a href=\"%(browse_url)s\">Ekstensi</a></strong> tambahkan fitur "
-"baru ke %(app_name)s atau mengubah fungsi yang sudah ada. Terdapat sejumlah "
-"ekstensi yang memungkinkan anda untuk menghentikan iklan, mengunduh video "
-"dari situs, berintegrasi lebih erat dengan situs sosial, dan menambah fitur "
-"yang anda lihat dalam aplikasi lainnya."
+"<strong><a href=\"%(browse_url)s\">Ekstensi</a></strong> tambahkan fitur baru ke %(app_name)s atau mengubah fungsi yang sudah ada. Terdapat sejumlah ekstensi yang memungkinkan anda untuk "
+"menghentikan iklan, mengunduh video dari situs, berintegrasi lebih erat dengan situs sosial, dan menambah fitur yang anda lihat dalam aplikasi lainnya."
 
 #: src/olympia/pages/templates/pages/faq.html:55
 #, python-format
-msgid ""
-"<strong><a href=\"%(browse_url)s\">Complete Themes</a></strong> change the "
-"entire appearance of %(app_name)s, usually including icons, colors, dialogs,"
-" and other visual styles."
-msgstr ""
-"<strong><a href=\"%(browse_url)s\">Tema Lengkap</a></strong> mengubah "
-"tampilan seluruh %(app_name)s, biasanya termasuk ikon, warna, dialog dan "
-"gaya visual lainnya."
+msgid "<strong><a href=\"%(browse_url)s\">Complete Themes</a></strong> change the entire appearance of %(app_name)s, usually including icons, colors, dialogs, and other visual styles."
+msgstr "<strong><a href=\"%(browse_url)s\">Tema Lengkap</a></strong> mengubah tampilan seluruh %(app_name)s, biasanya termasuk ikon, warna, dialog dan gaya visual lainnya."
 
 #: src/olympia/pages/templates/pages/faq.html:61
 #, python-format
-msgid ""
-"<strong><a href=\"%(browse_url)s\">Themes</a></strong> are lightweight "
-"themes that use background images to customize your %(app_name)s toolbars."
-msgstr ""
-"<strong><a href=\"%(browse_url)s\">Tema</a></strong> adalah tema ringan yang"
-" menggunakan gambar latar untuk menyesuaikan toolbar %(app_name)s anda."
+msgid "<strong><a href=\"%(browse_url)s\">Themes</a></strong> are lightweight themes that use background images to customize your %(app_name)s toolbars."
+msgstr "<strong><a href=\"%(browse_url)s\">Tema</a></strong> adalah tema ringan yang menggunakan gambar latar untuk menyesuaikan toolbar %(app_name)s anda."
 
 #: src/olympia/pages/templates/pages/faq.html:66
 #, python-format
-msgid ""
-"<strong><a href=\"%(browse_url)s\">Search Providers</a> </strong> add "
-"additional choices to the search box dropdown. These providers allow you to "
-"quickly search any website."
+msgid "<strong><a href=\"%(browse_url)s\">Search Providers</a> </strong> add additional choices to the search box dropdown. These providers allow you to quickly search any website."
 msgstr ""
-"<strong><a href=\"%(browse_url)s\">Penyedia Pencarian</a> </strong> menambah"
-" pilihan lainnya untuk kotak pencarian yang muncul ke bawah. Penyedia ini "
-"memungkinkan anda untuk mencari situs apa saja dengan cepat."
+"<strong><a href=\"%(browse_url)s\">Penyedia Pencarian</a> </strong> menambah pilihan lainnya untuk kotak pencarian yang muncul ke bawah. Penyedia ini memungkinkan anda untuk mencari situs apa saja "
+"dengan cepat."
 
 #: src/olympia/pages/templates/pages/faq.html:72
 #, python-format
-msgid ""
-"<strong><a href=\"%(browse_url)s\">Dictionaries & Language "
-"Packs</a></strong> add support for additional languages to %(app_name)s."
-msgstr ""
-"<strong><a href=\"%(browse_url)s\">Kamus & Paket Bahasa</a></strong> "
-"menambahkan dukungan bahasa lain untuk %(app_name)s."
+msgid "<strong><a href=\"%(browse_url)s\">Dictionaries & Language Packs</a></strong> add support for additional languages to %(app_name)s."
+msgstr "<strong><a href=\"%(browse_url)s\">Kamus & Paket Bahasa</a></strong> menambahkan dukungan bahasa lain untuk %(app_name)s."
 
 #: src/olympia/pages/templates/pages/faq.html:77
 #, python-format
-msgid ""
-"<strong><a href=\"%(browse_url)s\">Plugins</a></strong> help %(app_name)s "
-"display or understand different types of media, such as Adobe Flash or Apple"
-" Quicktime."
-msgstr ""
-"<strong><a href=\"%(browse_url)s\">Plugin</a></strong> bantuan %(app_name)s "
-"menampilkan atau memahami tipe media yang berbeda, misalnya Adobe Flash atau"
-" Apple Quicktime."
+msgid "<strong><a href=\"%(browse_url)s\">Plugins</a></strong> help %(app_name)s display or understand different types of media, such as Adobe Flash or Apple Quicktime."
+msgstr "<strong><a href=\"%(browse_url)s\">Plugin</a></strong> bantuan %(app_name)s menampilkan atau memahami tipe media yang berbeda, misalnya Adobe Flash atau Apple Quicktime."
 
 #: src/olympia/pages/templates/pages/faq.html:85
 msgid "How do I install, manage, or remove an add-on?"
@@ -13053,21 +10345,13 @@ msgstr "Bagaimana cara saya memasang, mengelola atau menghapus pengaya?"
 #: src/olympia/pages/templates/pages/faq.html:86
 #, python-format
 msgid ""
-"In most cases, add-ons can be installed by simply clicking the install "
-"button provided. Add-ons can be managed, disabled, or uninstalled from the "
-"Add-ons Manager in %(app_name)s. For more detailed instructions, read <a "
-"href=\"%(extension_url)s\">this article on extensions</a> or <a "
-"href=\"%(theme_url)s\">this one for Themes and Complete Themes</a>. If you "
-"have difficulty installing add-ons, see <a "
-"href=\"%(troubleshooting_url)s\">Troubleshooting Extensions and Themes</a>."
+"In most cases, add-ons can be installed by simply clicking the install button provided. Add-ons can be managed, disabled, or uninstalled from the Add-ons Manager in %(app_name)s. For more detailed "
+"instructions, read <a href=\"%(extension_url)s\">this article on extensions</a> or <a href=\"%(theme_url)s\">this one for Themes and Complete Themes</a>. If you have difficulty installing add-ons, "
+"see <a href=\"%(troubleshooting_url)s\">Troubleshooting Extensions and Themes</a>."
 msgstr ""
-"Dalam banyak kasus, pengaya bisa dipasang dengan hanya mengklik tombol "
-"pemasangan yang tersedia. Pengaya bisa dikelola, dimatikan, atau dilepaskan "
-"dari Manajer Pengaya dalam %(app_name)s. Untuk instruksi yang lebih terinci,"
-" baca <a href=\"%(extension_url)s\">artikel ini mengenai ekstensi</a> or <a "
-"href=\"%(theme_url)s\">yang satu ini untuk Tema dan Tema Lengkap</a>. Jika "
-"anda memiliki kesulitan dalam memasang pengaya, lihat <a "
-"href=\"%(troubleshooting_url)s\">Ekstensi Pemecahan Masalah dan Tema</a>."
+"Dalam banyak kasus, pengaya bisa dipasang dengan hanya mengklik tombol pemasangan yang tersedia. Pengaya bisa dikelola, dimatikan, atau dilepaskan dari Manajer Pengaya dalam %(app_name)s. Untuk "
+"instruksi yang lebih terinci, baca <a href=\"%(extension_url)s\">artikel ini mengenai ekstensi</a> or <a href=\"%(theme_url)s\">yang satu ini untuk Tema dan Tema Lengkap</a>. Jika anda memiliki "
+"kesulitan dalam memasang pengaya, lihat <a href=\"%(troubleshooting_url)s\">Ekstensi Pemecahan Masalah dan Tema</a>."
 
 #: src/olympia/pages/templates/pages/faq.html:100
 msgid "How do I install add-ons without restarting Firefox?"
@@ -13076,17 +10360,11 @@ msgstr "Bagaimana cara saya memasang pengaya tanpa melakukan restart Firefox?"
 #: src/olympia/pages/templates/pages/faq.html:101
 #, python-format
 msgid ""
-"In Firefox, add-ons marked with \"No restart required\" can be installed "
-"without restarting. These add-ons have been created using the <a "
-"href=\"%(sdk_url)s\">Add-on SDK</a> or <a "
-"href=\"%(bootstrap_url)s\">bootstrapping</a>. Other add-ons will still "
-"require a restart before you can use them."
+"In Firefox, add-ons marked with \"No restart required\" can be installed without restarting. These add-ons have been created using the <a href=\"%(sdk_url)s\">Add-on SDK</a> or <a href="
+"\"%(bootstrap_url)s\">bootstrapping</a>. Other add-ons will still require a restart before you can use them."
 msgstr ""
-"Dalam Firefox, pengaya yang ditandai dengan \"Tidak diperlukan restart\" "
-"bisa dipasang tanpa melakukan restart. Pengaya ini telah dibuat menggunakan "
-"<a href=\"%(sdk_url)s\">Pengaya SDK</a> atau <a "
-"href=\"%(bootstrap_url)s\">bootstrapping</a>. Pengaya lainnya akan tetap "
-"memerlukan restart sebelum anda bisa menggunakannya."
+"Dalam Firefox, pengaya yang ditandai dengan \"Tidak diperlukan restart\" bisa dipasang tanpa melakukan restart. Pengaya ini telah dibuat menggunakan <a href=\"%(sdk_url)s\">Pengaya SDK</a> atau <a "
+"href=\"%(bootstrap_url)s\">bootstrapping</a>. Pengaya lainnya akan tetap memerlukan restart sebelum anda bisa menggunakannya."
 
 #: src/olympia/pages/templates/pages/faq.html:110
 msgid "How do I keep add-ons up-to-date?"
@@ -13095,21 +10373,13 @@ msgstr "Bagaimana cara menjaga pengaya tetap mutakhir?"
 #: src/olympia/pages/templates/pages/faq.html:111
 #, python-format
 msgid ""
-"Add-ons, unlike plugins, are automatically checked for updates once every "
-"day. In Firefox, updates are automatically installed by default. Versions of"
-" Firefox prior to 4 (and other applications) will alert you that updates to "
-"your add-ons are available. <a href=\"%(plugin_url)s\">Plugins</a> are not "
-"currently automatically checked for updates, so be sure to regularly visit "
-"the <a href=\"%(plugincheck_url)s\">Plugin Check</a> page to stay up-to-"
-"date."
+"Add-ons, unlike plugins, are automatically checked for updates once every day. In Firefox, updates are automatically installed by default. Versions of Firefox prior to 4 (and other applications) "
+"will alert you that updates to your add-ons are available. <a href=\"%(plugin_url)s\">Plugins</a> are not currently automatically checked for updates, so be sure to regularly visit the <a href="
+"\"%(plugincheck_url)s\">Plugin Check</a> page to stay up-to-date."
 msgstr ""
-"Pengaya, berbeda dengan plugin, secara otomatis untuk mengecek pembaruan "
-"sekali setiap hari. Di Firefox, pembaruan dipasang secara otomatis. Versi "
-"Firefox sebelum nomor 4 (dan aplikasi lainnya) akan mengingatkan anda bahwa "
-"pembaruan pengaya anda telah tersedia. <a href=\"%(plugin_url)s\">Plugin</a>"
-" saat ini tidak secara otomatis mengecek pembaruan, jadi pastikan untuk "
-"secara teratur mengunjungi <a href=\"%(plugincheck_url)s\">Pengecekan "
-"Plugin</a> untuk selalu mendapat kabar terbaru."
+"Pengaya, berbeda dengan plugin, secara otomatis untuk mengecek pembaruan sekali setiap hari. Di Firefox, pembaruan dipasang secara otomatis. Versi Firefox sebelum nomor 4 (dan aplikasi lainnya) "
+"akan mengingatkan anda bahwa pembaruan pengaya anda telah tersedia. <a href=\"%(plugin_url)s\">Plugin</a> saat ini tidak secara otomatis mengecek pembaruan, jadi pastikan untuk secara teratur "
+"mengunjungi <a href=\"%(plugincheck_url)s\">Pengecekan Plugin</a> untuk selalu mendapat kabar terbaru."
 
 #: src/olympia/pages/templates/pages/faq.html:122
 msgid "Are add-ons safe to install?"
@@ -13118,20 +10388,13 @@ msgstr "Apakah pengaya aman untuk dipasang?"
 #: src/olympia/pages/templates/pages/faq.html:123
 #, python-format
 msgid ""
-"Unless clearly marked otherwise, add-ons available from this gallery have "
-"been checked and approved by Mozilla's team of editors and are safe to "
-"install. We recommend that you only install approved add-ons. If you wish to"
-" install unapproved add-ons or add-ons from third-party websites, use "
-"caution as these add-ons may harm your computer or violate your privacy. <a "
-"href=\"%(learnmore_url)s\">Learn more about our approval process</a>"
+"Unless clearly marked otherwise, add-ons available from this gallery have been checked and approved by Mozilla's team of editors and are safe to install. We recommend that you only install approved "
+"add-ons. If you wish to install unapproved add-ons or add-ons from third-party websites, use caution as these add-ons may harm your computer or violate your privacy. <a href=\"%(learnmore_url)s"
+"\">Learn more about our approval process</a>"
 msgstr ""
-"Terkecuali ditandai sebaliknya, pengaya yang tersedia dari galeri ini telah "
-"ditandai dan disetujui oleh tim penyunting Mozilla dan aman untuk dipasang. "
-"Kami merekomendasikan anda hanya memasang pengaya yang sudah disetuji. Jika "
-"anda ingin memasang pengaya yang belum disetujui atau pengaya dari situs "
-"pihak ketiga, berhati-hatilah karena pengaya ini bisa membahayakan komputer "
-"anda atau melanggar privasi anda. <a href=\"%(learnmore_url)s\">Pelajari "
-"lebih lanjut tentang proses persetujuan kami</a>"
+"Terkecuali ditandai sebaliknya, pengaya yang tersedia dari galeri ini telah ditandai dan disetujui oleh tim penyunting Mozilla dan aman untuk dipasang. Kami merekomendasikan anda hanya memasang "
+"pengaya yang sudah disetuji. Jika anda ingin memasang pengaya yang belum disetujui atau pengaya dari situs pihak ketiga, berhati-hatilah karena pengaya ini bisa membahayakan komputer anda atau "
+"melanggar privasi anda. <a href=\"%(learnmore_url)s\">Pelajari lebih lanjut tentang proses persetujuan kami</a>"
 
 #: src/olympia/pages/templates/pages/faq.html:133
 #, python-format
@@ -13141,46 +10404,28 @@ msgstr "Bisakah pengaya membuat %(app_name)s lebih lambat?"
 #: src/olympia/pages/templates/pages/faq.html:135
 #, python-format
 msgid ""
-"Most add-ons do not cause a perceivable performance decrease in "
-"%(app_name)s, though installing an excessive number may have adverse "
-"effects. If you suspect an add-on is causing %(app_name)s to be slow, try "
-"disabling it."
+"Most add-ons do not cause a perceivable performance decrease in %(app_name)s, though installing an excessive number may have adverse effects. If you suspect an add-on is causing %(app_name)s to be "
+"slow, try disabling it."
 msgstr ""
-"Sebagian besar pengaya tidak menyebabkan penurunan performa yang dapat "
-"dilihat dengan jelas %(app_name)s, meskipun pemasangan dalam jumlah yang "
-"terlalu bear bisa memberikan dampak yang merugikan. Jika anda mencurigai "
-"sebuah pengaya menyebabkan %(app_name)s melambat, cobalah mematikannya."
+"Sebagian besar pengaya tidak menyebabkan penurunan performa yang dapat dilihat dengan jelas %(app_name)s, meskipun pemasangan dalam jumlah yang terlalu bear bisa memberikan dampak yang merugikan. "
+"Jika anda mencurigai sebuah pengaya menyebabkan %(app_name)s melambat, cobalah mematikannya."
 
 #: src/olympia/pages/templates/pages/faq.html:141
 #, python-format
-msgid ""
-"%(app_name)s told me an add-on isn't compatible. Is there a way I can still "
-"use it?"
-msgstr ""
-"%(app_name)s memberitahukan bahwa pengaya belum kompatibel. Adakah cara agar"
-" saya dapat tetap menggunakannya?"
+msgid "%(app_name)s told me an add-on isn't compatible. Is there a way I can still use it?"
+msgstr "%(app_name)s memberitahukan bahwa pengaya belum kompatibel. Adakah cara agar saya dapat tetap menggunakannya?"
 
 #: src/olympia/pages/templates/pages/faq.html:144
 #, python-format
 msgid ""
-"If an add-on isn't compatible with your version of %(app_name)s, it is "
-"usually either because your version of %(app_name)s is outdated or the add-"
-"on author has not yet updated the add-on to be compatible with a newer "
-"version you are using. Mozilla does not recommend trying to circumvent these"
-" compatibility checks, as they can lead to browser instability or in some "
-"cases loss of data. For users who are testing out alpha or beta versions of "
-"Firefox, we offer the <a href=\"%(acr_url)s\">Add-on Compatibility "
-"Reporter</a> to help add-on developers update their compatibility."
+"If an add-on isn't compatible with your version of %(app_name)s, it is usually either because your version of %(app_name)s is outdated or the add-on author has not yet updated the add-on to be "
+"compatible with a newer version you are using. Mozilla does not recommend trying to circumvent these compatibility checks, as they can lead to browser instability or in some cases loss of data. For "
+"users who are testing out alpha or beta versions of Firefox, we offer the <a href=\"%(acr_url)s\">Add-on Compatibility Reporter</a> to help add-on developers update their compatibility."
 msgstr ""
-"Jika sebuah pengaya tidak cocok dengan versi %(app_name)s anda, biasanya ini"
-" baik karena versi %(app_name)s anda sudah usang atau penulis pengaya belum "
-"memperbarui pengaya untuk jadi lebih cocok dengan versi baru yang anda "
-"gunakan. Mozilla tidak merekomendasikan untuk mencoba mengelakkan pengecekan"
-" kecocokan ini, karena mereka bisa menyebabkan ketidakstabilan peramban atau"
-" dalam banyak kasus kehilangan data. Untuk pengguna yang mengecek Firefox "
-"versi beta atau alpha, kami menawarkan <a href=\"%(acr_url)s\">Pelaporan "
-"Kecocokan Pengaya</a> untuk meminta pengembang pengaya memperbarui kecocokan"
-" mereka."
+"Jika sebuah pengaya tidak cocok dengan versi %(app_name)s anda, biasanya ini baik karena versi %(app_name)s anda sudah usang atau penulis pengaya belum memperbarui pengaya untuk jadi lebih cocok "
+"dengan versi baru yang anda gunakan. Mozilla tidak merekomendasikan untuk mencoba mengelakkan pengecekan kecocokan ini, karena mereka bisa menyebabkan ketidakstabilan peramban atau dalam banyak "
+"kasus kehilangan data. Untuk pengguna yang mengecek Firefox versi beta atau alpha, kami menawarkan <a href=\"%(acr_url)s\">Pelaporan Kecocokan Pengaya</a> untuk meminta pengembang pengaya "
+"memperbarui kecocokan mereka."
 
 #: src/olympia/pages/templates/pages/faq.html:156
 msgid "What if I have problems with an add-on?"
@@ -13189,41 +10434,28 @@ msgstr "Bagaimana jika kita mengalami masalah dengan pengaya?"
 #: src/olympia/pages/templates/pages/faq.html:157
 #, python-format
 msgid ""
-"Add-ons are usually created by third-party developers from around the world,"
-" so the best way to get help with an add-on is to look for support links on "
-"the add-on's homepage or contact the developer. If you are having issues "
-"with %(app_name)s that you suspect are related to add-ons you have "
-"installed, <a href=\"%(troubleshooting_url)s\">visit this support "
-"article</a> for troubleshooting tips."
+"Add-ons are usually created by third-party developers from around the world, so the best way to get help with an add-on is to look for support links on the add-on's homepage or contact the "
+"developer. If you are having issues with %(app_name)s that you suspect are related to add-ons you have installed, <a href=\"%(troubleshooting_url)s\">visit this support article</a> for "
+"troubleshooting tips."
 msgstr ""
-"Pengaya biasanya dibuat oleh pengembang pihak ketiga dari seluruh dunia, "
-"jadi cara terbaik untuk mendapatkan bantuan dengan sebuah pengaya adalah "
-"mencari tautan dukungan di beranda pengaya atau mengontak pengembang. Jika "
-"anda memiliki masalah dengan %(app_name)s yang anda curigai berhubungan "
-"dengan pengaya yang telah anda pasang, <a "
-"href=\"%(troubleshooting_url)s\">lihat artikel dukungan ini</a> untuk kiat "
-"penyelesaian masalah."
+"Pengaya biasanya dibuat oleh pengembang pihak ketiga dari seluruh dunia, jadi cara terbaik untuk mendapatkan bantuan dengan sebuah pengaya adalah mencari tautan dukungan di beranda pengaya atau "
+"mengontak pengembang. Jika anda memiliki masalah dengan %(app_name)s yang anda curigai berhubungan dengan pengaya yang telah anda pasang, <a href=\"%(troubleshooting_url)s\">lihat artikel dukungan "
+"ini</a> untuk kiat penyelesaian masalah."
 
 #: src/olympia/pages/templates/pages/faq.html:169
 msgid "Add-on Gallery"
 msgstr "Galeri Pengaya"
 
 #: src/olympia/pages/templates/pages/faq.html:171
-msgid ""
-"How do I choose between add-ons that seem to do the same\n"
-"    thing?"
+msgid "How do I choose between add-ons that seem to do the same thing?"
 msgstr ""
 "Bagaimana saya bisa memilih pengaya apa yang sepertinya melakukan hal\n"
 "    yang sama?"
 
-#: src/olympia/pages/templates/pages/faq.html:173
+#: src/olympia/pages/templates/pages/faq.html:172
 msgid ""
-"There are often several add-ons that have similar features. To\n"
-"    figure out which is right for you, read the entire description of the\n"
-"    add-on and view its screenshots. If there are still several in the running,\n"
-"    read through the add-on's ratings, user reviews, and statistics to see\n"
-"    which is most liked by other users. Remember that you can also just try\n"
-"    out both and see which you like better."
+"There are often several add-ons that have similar features. To figure out which is right for you, read the entire description of the add-on and view its screenshots. If there are still several in "
+"the running, read through the add-on's ratings, user reviews, and statistics to see which is most liked by other users. Remember that you can also just try out both and see which you like better."
 msgstr ""
 "Seringkali ada beberapa pengaya yang memiliki fitur serupa. Untuk\n"
 "    mencari tahu mana yang tepat untuk anda, baca seluruh deskripsi\n"
@@ -13234,45 +10466,29 @@ msgstr ""
 
 #: src/olympia/pages/templates/pages/faq.html:180
 msgid "What if I can't find an add-on I'm looking for?"
-msgstr ""
-"Bagaimana seandainya saya tidak bisa menemukan pengaya yang saya cari?"
+msgstr "Bagaimana seandainya saya tidak bisa menemukan pengaya yang saya cari?"
 
 #: src/olympia/pages/templates/pages/faq.html:181
 #, python-format
 msgid ""
-"With thousands of add-ons available, there's something for everyone. But if "
-"you're looking for a particular add-on and can't find it, you might try "
-"searching on other sites or posting about it in our <a href=\"%(forum_url)s"
-"\">Add-ons </a>forum."
+"With thousands of add-ons available, there's something for everyone. But if you're looking for a particular add-on and can't find it, you might try searching on other sites or posting about it in "
+"our <a href=\"%(forum_url)s\">Add-ons </a>forum."
 msgstr ""
-"Dengan ribuan pengaya yang tersedia, ada sesuatu untuk tiap orang. Namun "
-"jika anda mencari pengaya tertentu dan tak dapat menemukannya, anda bisa "
-"mencoba mencari di situs lain atau menulis tentang itu dalam <a "
-"href=\"%(forum_url)s\">forum Pengaya </a>."
+"Dengan ribuan pengaya yang tersedia, ada sesuatu untuk tiap orang. Namun jika anda mencari pengaya tertentu dan tak dapat menemukannya, anda bisa mencoba mencari di situs lain atau menulis tentang "
+"itu dalam <a href=\"%(forum_url)s\">forum Pengaya </a>."
 
 #: src/olympia/pages/templates/pages/faq.html:187
-msgid ""
-"What does it mean if an add-on is \"experimental\" or \"preliminarily "
-"reviewed\"?"
-msgstr ""
-"Apakah artinya jika sebuah pengaya disebut \"eksperimental\" atau \"diberi "
-"ulasan pendahuluan\"?"
+msgid "What does it mean if an add-on is \"experimental\" or \"preliminarily reviewed\"?"
+msgstr "Apakah artinya jika sebuah pengaya disebut \"eksperimental\" atau \"diberi ulasan pendahuluan\"?"
 
 #: src/olympia/pages/templates/pages/faq.html:188
 #, python-format
 msgid ""
-"Experimental add-ons have been checked by our editors to make sure they "
-"don't have security problems, but they may still have bugs or not work "
-"properly. Use caution when installing experimental add-ons and uninstall the"
-" add-on immediately if you notice problems. <a href=\"%(url)s\">Learn more "
-"about our review process</a></dd>"
+"Experimental add-ons have been checked by our editors to make sure they don't have security problems, but they may still have bugs or not work properly. Use caution when installing experimental add-"
+"ons and uninstall the add-on immediately if you notice problems. <a href=\"%(url)s\">Learn more about our review process</a></dd>"
 msgstr ""
-"Pengaya eksperimental telah dicek oleh penyunting kami untuk memastikan "
-"mereka tidak memiliki persoalan keamanan, namun pengaya tersebut mungkin "
-"masih mengandung bug atau tidak bekerja selayaknya. Berhati-hatilah saat "
-"memasang pengaya eksperimental dan melepas pengaya secepatnya jika anda "
-"menemui masalah. <a href=\"%(url)s\">Pelajari lebih lanjut tentang proses "
-"ulasan kami</a></dd>"
+"Pengaya eksperimental telah dicek oleh penyunting kami untuk memastikan mereka tidak memiliki persoalan keamanan, namun pengaya tersebut mungkin masih mengandung bug atau tidak bekerja selayaknya. "
+"Berhati-hatilah saat memasang pengaya eksperimental dan melepas pengaya secepatnya jika anda menemui masalah. <a href=\"%(url)s\">Pelajari lebih lanjut tentang proses ulasan kami</a></dd>"
 
 #: src/olympia/pages/templates/pages/faq.html:196
 msgid "What does it mean if an add-on is \"not reviewed\"?"
@@ -13281,265 +10497,195 @@ msgstr "Apakah artinya jika sebuah pengaya \"belum diulas\"?"
 #: src/olympia/pages/templates/pages/faq.html:197
 #, python-format
 msgid ""
-"While all add-ons publicly available in our gallery are reviewed by an "
-"editor, you may receive a direct link to an add-on that hasn't yet been "
-"reviewed. Use caution when installing these add-ons, as they could harm your"
-" computer or violate your privacy. We recommend that you only install "
-"reviewed add-ons. <a href=\"%(url)s\">Learn more about our review "
-"process</a></dd>"
+"While all add-ons publicly available in our gallery are reviewed by an editor, you may receive a direct link to an add-on that hasn't yet been reviewed. Use caution when installing these add-ons, "
+"as they could harm your computer or violate your privacy. We recommend that you only install reviewed add-ons. <a href=\"%(url)s\">Learn more about our review process</a></dd>"
 msgstr ""
-"Meskipun semua pengaya yang tersedia secara publik di galeri kami diulas "
-"oleh penyunting, boleh jadi anda menerima tautan langsung ke sebuah pengaya "
-"yang belum diulas. Berhati-hatilah saat memasang pengaya ini, karena mereka "
-"bisa membahayakan komputer anda atau melanggar privasi anda. Kami "
-"merekomendasikan anda untuk hanya memasang pengaya yang sudah diulas. <a "
-"href=\"%(url)s\">Pelajari lebih lanjut mengenai proses ulasan kami</a></dd>"
+"Meskipun semua pengaya yang tersedia secara publik di galeri kami diulas oleh penyunting, boleh jadi anda menerima tautan langsung ke sebuah pengaya yang belum diulas. Berhati-hatilah saat memasang "
+"pengaya ini, karena mereka bisa membahayakan komputer anda atau melanggar privasi anda. Kami merekomendasikan anda untuk hanya memasang pengaya yang sudah diulas. <a href=\"%(url)s\">Pelajari lebih "
+"lanjut mengenai proses ulasan kami</a></dd>"
 
 #: src/olympia/pages/templates/pages/faq.html:206
 msgid "How much do add-ons cost to purchase?"
 msgstr "Berapakah harga pengaya?"
 
 #: src/olympia/pages/templates/pages/faq.html:207
-msgid ""
-"Add-ons hosted in our gallery are free unless clearly marked\n"
-"    otherwise."
+msgid "Add-ons hosted in our gallery are free unless clearly marked otherwise."
 msgstr ""
 "Pengaya yang dimuat di galeri kami semua gratis kecuali ditandai\n"
 "    sebaliknya."
 
-#: src/olympia/pages/templates/pages/faq.html:210
+#: src/olympia/pages/templates/pages/faq.html:209
 msgid "What does it mean when an add-on asks for contributions?"
 msgstr "Apakah artinya jika sebuah pengaya meminta kontribusi?"
 
-#: src/olympia/pages/templates/pages/faq.html:211
+#: src/olympia/pages/templates/pages/faq.html:210
 msgid ""
-"Some add-on authors request users who enjoy an add-on to\n"
-"        contribute to its development by making a monetary contribution. These\n"
-"        contributions go directly to the developer unless a third party is\n"
-"        indicated, such as the non-profit Mozilla Foundation."
+"Some add-on authors request users who enjoy an add-on to contribute to its development by making a monetary contribution. These contributions go directly to the developer unless a third party is "
+"indicated, such as the non-profit Mozilla Foundation."
 msgstr ""
 "Sejumlah penulis pengaya meminta pengguna yang menikmati pengaya untuk \n"
 "        berkontribusi pada pengembangannya dengan memberikan kontribusi uang. \n"
 "        Kontribusi semacam ini ditujukan langsung kepada pengembang kecuali ada indikasi\n"
 "        pihak ketiga, misalnya Mozilla Foundation yang bersifat nirlaba."
 
-#: src/olympia/pages/templates/pages/faq.html:216
+#: src/olympia/pages/templates/pages/faq.html:215
 msgid "What are beta add-ons?"
 msgstr "Apakah pengaya versi beta itu?"
 
-#: src/olympia/pages/templates/pages/faq.html:218
+#: src/olympia/pages/templates/pages/faq.html:217
 msgid ""
-"Beta add-ons are unreviewed versions which represent the\n"
-"        latest work of an add-on author. While different authors have different\n"
-"        standards for beta code quality, you should assume that these add-ons\n"
-"        are less stable than the general add-on releases."
+"Beta add-ons are unreviewed versions which represent the latest work of an add-on author. While different authors have different standards for beta code quality, you should assume that these add-"
+"ons are less stable than the general add-on releases."
 msgstr ""
 "Pengaya beta adalah versi yang belum diulas yang mewakili\n"
 "        karya terbaru penulis pengaya. Meski penulis yang berbeda memiliki standar\n"
 "        berlainan untuk kualitas kode beta, anda harus berasumsi bahwa pengaya tersebut\n"
 "        kurang stabil dibandingkan rilis pengaya yang umum."
 
-#: src/olympia/pages/templates/pages/faq.html:222
+#: src/olympia/pages/templates/pages/faq.html:221
 msgid ""
-"Please note that when you install an add-on from the \"Beta Version\" "
-"section of an add-on's listing, you will continue to receive updates for "
-"that add-on as they become available. Like the initial version you "
-"installed, all beta releases are unreviewed by Mozilla and may harm your "
-"computer."
+"Please note that when you install an add-on from the \"Beta Version\" section of an add-on's listing, you will continue to receive updates for that add-on as they become available. Like the initial "
+"version you installed, all beta releases are unreviewed by Mozilla and may harm your computer."
 msgstr ""
-"Harap dicatat bahwa ketika anda memasang pengaya dari bagian \"Versi Beta\" "
-"di daftar pengaya, anda akan terus menerima pembaruan untuk pengaya tersebut"
-" saat pengaya itu tersedia. Seperti versi awal yang anda pasang, seluruh "
-"rilisan beta tidak diulas oleh Mozilla dan mungkin berbahaya bagi komputer "
-"anda."
+"Harap dicatat bahwa ketika anda memasang pengaya dari bagian \"Versi Beta\" di daftar pengaya, anda akan terus menerima pembaruan untuk pengaya tersebut saat pengaya itu tersedia. Seperti versi "
+"awal yang anda pasang, seluruh rilisan beta tidak diulas oleh Mozilla dan mungkin berbahaya bagi komputer anda."
 
-#: src/olympia/pages/templates/pages/faq.html:229
-msgid ""
-"What does it mean when an add-on is flagged as\n"
-"    slow?"
+#: src/olympia/pages/templates/pages/faq.html:228
+msgid "What does it mean when an add-on is flagged as slow?"
 msgstr ""
 "Apakah artinya jika pengaya ditandai\n"
 "    lambat?"
 
-#: src/olympia/pages/templates/pages/faq.html:231
-msgid ""
-"Most add-ons load code and resources at the same time Firefox\n"
-"        is starting up. In most cases the impact in start-up time is minimal,\n"
-"        but some add-ons can cause a noticeable slowdown."
+#: src/olympia/pages/templates/pages/faq.html:229
+msgid "Most add-ons load code and resources at the same time Firefox is starting up. In most cases the impact in start-up time is minimal, but some add-ons can cause a noticeable slowdown."
 msgstr ""
 "Sebagian besar pengaya memuat kode dan sumber bersamaan dengan saat Firefox\n"
 "        dimulai. Kadang ini berakibat waktu memulai sangat singkat,\n"
 "        tapi kadang dapat juga menyebabkan pelambatan yang terlihat jelas."
 
-#: src/olympia/pages/templates/pages/faq.html:236
+#: src/olympia/pages/templates/pages/faq.html:234
 msgid "How do I report an inappropriate or spam user review?"
-msgstr ""
-"Bagaimana saya bisa melaporkan ulasan pengguna yang tidak pantas atau spam?"
+msgstr "Bagaimana saya bisa melaporkan ulasan pengguna yang tidak pantas atau spam?"
 
-#: src/olympia/pages/templates/pages/faq.html:237
+#: src/olympia/pages/templates/pages/faq.html:235
 msgid ""
-"To report a user review of an add-on, log in with your account\n"
-"    and visit the add-on's reviews page. Find the review you wish to report,\n"
-"    click \"Report this review\" and select a reason. Our editorial team will\n"
-"    investigate the review and take appropriate action."
+"To report a user review of an add-on, log in with your account and visit the add-on's reviews page. Find the review you wish to report, click \"Report this review\" and select a reason. Our "
+"editorial team will investigate the review and take appropriate action."
 msgstr ""
 "Untuk melaporkan ulasan pengguna atas sebuah pengaya, masuk log dengan akun anda\n"
 "    dan kunjungi laman ulasan pengaya. Temukan ulasan yang ingin anda laporkan,\n"
 "    klik \"Laporkan ulasan ini\" dan pilih satu alasan. Tim penyunting kami akan\n"
 "    menyelidiki ulasan tersebut dan mengambil tindakan yang seharusnya."
 
-#: src/olympia/pages/templates/pages/faq.html:242
+#: src/olympia/pages/templates/pages/faq.html:240
 msgid "How do I report a bug or contact the Mozilla Add-ons team?"
-msgstr ""
-"Bagaimana saya bisa melaporkan bug atau menghubungi tim Pengaya Mozilla?"
+msgstr "Bagaimana saya bisa melaporkan bug atau menghubungi tim Pengaya Mozilla?"
 
-#: src/olympia/pages/templates/pages/faq.html:243
+#: src/olympia/pages/templates/pages/faq.html:241
 #, python-format
 msgid "Please visit our <a href=\"%(contact_url)s\">Contact page</a>."
 msgstr "Silakan kunjungi <a href=\"%(contact_url)s\">laman Kontak</a> kami."
 
-#: src/olympia/pages/templates/pages/faq.html:246
+#: src/olympia/pages/templates/pages/faq.html:244
 msgid "What is a Source Code License?"
 msgstr "Apakah Lisensi Kode Sumber itu?"
 
-#: src/olympia/pages/templates/pages/faq.html:247
+#: src/olympia/pages/templates/pages/faq.html:245
 #, python-format
 msgid ""
-"The source code used to create an add-on is an exclusive copyright of the "
-"add-on author, unless otherwise declared in a source code license. Many add-"
-"ons on this site have <a href=\"%(url)s\" lang=\"en\">open source "
-"licenses</a> that make the source code publicly available for copy and reuse"
-" under conditions determined by the author. Most authors choose widely known"
-" open source licenses like the GPL or BSD licenses instead of making up "
-"their own."
+"The source code used to create an add-on is an exclusive copyright of the add-on author, unless otherwise declared in a source code license. Many add-ons on this site have <a href=\"%(url)s\" lang="
+"\"en\">open source licenses</a> that make the source code publicly available for copy and reuse under conditions determined by the author. Most authors choose widely known open source licenses like "
+"the GPL or BSD licenses instead of making up their own."
 msgstr ""
-"Kode sumber yang digunakan untuk membuat pengaya adalah hak cipta eksklusif "
-"dari penulis pengaya, terkecuali dinyatakan sebaliknya dalam lisensi kode "
-"sumber. Banyak pengaya dalam situs ini memiliki <a href=\"%(url)s\" "
-"lang=\"en\">lisensi sumber terbuka</a> yang membuat code sumbernya tersedia "
-"secara publik untuk disalin dan digunakan ulang dengan syarat yang "
-"ditentukan oelh penulisnya. Sebagian penulis memilih sumber terbuka yang "
-"sudah dikenal luas seperti GPL atau BSD alih-alih membuat sendiri."
+"Kode sumber yang digunakan untuk membuat pengaya adalah hak cipta eksklusif dari penulis pengaya, terkecuali dinyatakan sebaliknya dalam lisensi kode sumber. Banyak pengaya dalam situs ini memiliki "
+"<a href=\"%(url)s\" lang=\"en\">lisensi sumber terbuka</a> yang membuat code sumbernya tersedia secara publik untuk disalin dan digunakan ulang dengan syarat yang ditentukan oelh penulisnya. "
+"Sebagian penulis memilih sumber terbuka yang sudah dikenal luas seperti GPL atau BSD alih-alih membuat sendiri."
 
-#: src/olympia/pages/templates/pages/faq.html:256
+#: src/olympia/pages/templates/pages/faq.html:254
 #, python-format
-msgid ""
-"Firefox and other Mozilla software are <a href=\"%(url)s\">open source</a>."
-msgstr ""
-"Firefox perangkat lunak Mozilla lainnya berbasis <a href=\"%(url)s\">sumber "
-"terbuka</a>."
+msgid "Firefox and other Mozilla software are <a href=\"%(url)s\">open source</a>."
+msgstr "Firefox perangkat lunak Mozilla lainnya berbasis <a href=\"%(url)s\">sumber terbuka</a>."
 
-#: src/olympia/pages/templates/pages/faq.html:264
+#: src/olympia/pages/templates/pages/faq.html:262
 msgid "Collections and Favorites"
 msgstr "Koleksi dan Kesukaan"
 
-#: src/olympia/pages/templates/pages/faq.html:267
+#: src/olympia/pages/templates/pages/faq.html:265
 msgid "What is a collection?"
 msgstr "Apa itu koleksi?"
 
-#: src/olympia/pages/templates/pages/faq.html:268
+#: src/olympia/pages/templates/pages/faq.html:266
 msgid "Collections are groups of related add-ons created by users to share."
-msgstr ""
-"Koleksi adalah kumpulan pengaya yang berkaitan yang digunakan pengguna untuk"
-" berbagi."
+msgstr "Koleksi adalah kumpulan pengaya yang berkaitan yang digunakan pengguna untuk berbagi."
 
-#: src/olympia/pages/templates/pages/faq.html:270
+#: src/olympia/pages/templates/pages/faq.html:268
 msgid "What is the My Favorites collection?"
 msgstr "Apakah koleksi Kesukaan Saya itu?"
 
-#: src/olympia/pages/templates/pages/faq.html:271
-msgid ""
-"Favorite add-ons are add-ons that you have bookmarked to easily get back to "
-"later. You can add an add-on to your favorites collection by clicking \"Add "
-"to favorites\" on its details page."
+#: src/olympia/pages/templates/pages/faq.html:269
+msgid "Favorite add-ons are add-ons that you have bookmarked to easily get back to later. You can add an add-on to your favorites collection by clicking \"Add to favorites\" on its details page."
 msgstr ""
-"Pengaya favorit adalah pengaya yang sudah anda tandai agar mudah ditemukan "
-"kembali nanti. Anda bisa menambah sebuah pengaya pada koleksi favorit anda "
-"dengan mengklik \"Tambahkan ke kesukaan\" di laman rinciannya."
+"Pengaya favorit adalah pengaya yang sudah anda tandai agar mudah ditemukan kembali nanti. Anda bisa menambah sebuah pengaya pada koleksi favorit anda dengan mengklik \"Tambahkan ke kesukaan\" di "
+"laman rinciannya."
 
-#: src/olympia/pages/templates/pages/faq.html:275
-#: src/olympia/templates/menu_links.html:13
-#: src/olympia/templates/impala/header_title.html:17
+#: src/olympia/pages/templates/pages/faq.html:273 src/olympia/templates/menu_links.html:13 src/olympia/templates/impala/header_title.html:17
 msgid "Mobile Add-ons"
 msgstr "Pengaya Seluler"
 
-#: src/olympia/pages/templates/pages/faq.html:278
+#: src/olympia/pages/templates/pages/faq.html:276
 msgid "What are mobile add-ons?"
 msgstr "Apakah pengaya bergerak itu?"
 
-#: src/olympia/pages/templates/pages/faq.html:279
+#: src/olympia/pages/templates/pages/faq.html:277
 #, python-format
 msgid ""
-"Mobile add-ons work with <a href=\"%(mobile_url)s\">Firefox for Mobile</a> "
-"and add or modify functionality just like desktop add-ons. You can find add-"
-"ons that work with Firefox for Mobile in our <a "
-"href=\"%(gallery_url)s\">gallery</a>."
+"Mobile add-ons work with <a href=\"%(mobile_url)s\">Firefox for Mobile</a> and add or modify functionality just like desktop add-ons. You can find add-ons that work with Firefox for Mobile in our "
+"<a href=\"%(gallery_url)s\">gallery</a>."
 msgstr ""
-"Pengaya Mozilla bekerja dengan <a href=\"%(mobile_url)s\">Firefox untuk "
-"Ponsel</a> dan menambah atau mengubah fungsi seperti pada pengaya di "
-"desktop. Anda bisa menemukan pengaya yang bekerja dengan Firefox untuk "
-"Ponsel dalam <a href=\"%(gallery_url)s\">galeri</a>."
+"Pengaya Mozilla bekerja dengan <a href=\"%(mobile_url)s\">Firefox untuk Ponsel</a> dan menambah atau mengubah fungsi seperti pada pengaya di desktop. Anda bisa menemukan pengaya yang bekerja dengan "
+"Firefox untuk Ponsel dalam <a href=\"%(gallery_url)s\">galeri</a>."
 
-#: src/olympia/pages/templates/pages/faq.html:288
+#: src/olympia/pages/templates/pages/faq.html:286
 msgid "Developer Topics"
 msgstr "Topik Pengembang"
 
-#: src/olympia/pages/templates/pages/faq.html:289
+#: src/olympia/pages/templates/pages/faq.html:287
 #, python-format
-msgid ""
-"Please see our <a href=\"%(faq_url)s\">Developer FAQ</a> and <a "
-"href=\"%(hub_url)s\">Developer Hub</a> for answers to add-on developer-"
-"related questions."
-msgstr ""
-"Silakan melihat <a href=\"%(faq_url)s\">FAQ Pengembang</a> dan <a "
-"href=\"%(hub_url)s\">Pusat Pengembang</a> untuk jawaban bagi pertanyaan "
-"terkait pengembang pengaya."
+msgid "Please see our <a href=\"%(faq_url)s\">Developer FAQ</a> and <a href=\"%(hub_url)s\">Developer Hub</a> for answers to add-on developer-related questions."
+msgstr "Silakan melihat <a href=\"%(faq_url)s\">FAQ Pengembang</a> dan <a href=\"%(hub_url)s\">Pusat Pengembang</a> untuk jawaban bagi pertanyaan terkait pengembang pengaya."
 
-#: src/olympia/pages/templates/pages/faq.html:294
+#: src/olympia/pages/templates/pages/faq.html:292
 msgid "Still have questions?"
 msgstr "Masih punya pertanyaan?"
 
-#: src/olympia/pages/templates/pages/faq.html:295
+#: src/olympia/pages/templates/pages/faq.html:293
 #, python-format
-msgid ""
-"For general Firefox support, visit our <a href=\"%(sumo_url)s\">support "
-"website</a>. For general add-on and website questions, visit our <a "
-"href=\"%(forum_url)s\">forum</a>."
-msgstr ""
-"Untuk dukungan Firefox secara umum, kunjungi <a href=\"%(sumo_url)s\">situs "
-"dukungan</a>. Untuk pengaya umun dan pertanyaan situs, kunjungi <a "
-"href=\"%(forum_url)s\">forum</a>."
+msgid "For general Firefox support, visit our <a href=\"%(sumo_url)s\">support website</a>. For general add-on and website questions, visit our <a href=\"%(forum_url)s\">forum</a>."
+msgstr "Untuk dukungan Firefox secara umum, kunjungi <a href=\"%(sumo_url)s\">situs dukungan</a>. Untuk pengaya umun dan pertanyaan situs, kunjungi <a href=\"%(forum_url)s\">forum</a>."
 
-#: src/olympia/pages/templates/pages/review_guide.html:36
-#: src/olympia/pages/templates/pages/review_guide.html:51
+#: src/olympia/pages/templates/pages/review_guide.html:36 src/olympia/pages/templates/pages/review_guide.html:51
 msgid "Some tips for writing a great review"
 msgstr "Sejumlah kiat untuk menulis ulasan yang bagus"
 
-#: src/olympia/pages/templates/pages/review_guide.html:39
-#: src/olympia/pages/templates/pages/review_guide.html:131
+#: src/olympia/pages/templates/pages/review_guide.html:39 src/olympia/pages/templates/pages/review_guide.html:131
 msgid "Frequently Asked Questions about Reviews"
 msgstr "Pertanyaan yang Sering Ditanyakan mengenai Ulasan"
 
 #: src/olympia/pages/templates/pages/review_guide.html:46
 msgid ""
-"Add-on reviews are a way for you to share your opinions about the add-ons "
-"you’ve installed and used. Our review moderation team reserves the right to "
-"refuse or remove any review that does not comply with these guidelines."
+"Add-on reviews are a way for you to share your opinions about the add-ons you’ve installed and used. Our review moderation team reserves the right to refuse or remove any review that does not "
+"comply with these guidelines."
 msgstr ""
-"Ulasan pengaya adalah cara anda untuk berbagai pendapat mengenai pengaya "
-"yang anda pasang dan gunakan. Tim moderasi ulasan kami memiliki hak untuk "
-"menolak atau menghapus ulasan apapun yang tidak sesuai dengan panduan ini."
+"Ulasan pengaya adalah cara anda untuk berbagai pendapat mengenai pengaya yang anda pasang dan gunakan. Tim moderasi ulasan kami memiliki hak untuk menolak atau menghapus ulasan apapun yang tidak "
+"sesuai dengan panduan ini."
 
 #: src/olympia/pages/templates/pages/review_guide.html:53
 msgid "Do:"
 msgstr "Lakukan:"
 
 #: src/olympia/pages/templates/pages/review_guide.html:56
-msgid ""
-"Write like you are telling a friend about your experience with the add-on."
-msgstr ""
-"Menulislah seperti sedang menyampaikan pada teman mengenai pengalaman dengan"
-" pengaya."
+msgid "Write like you are telling a friend about your experience with the add-on."
+msgstr "Menulislah seperti sedang menyampaikan pada teman mengenai pengalaman dengan pengaya."
 
 #: src/olympia/pages/templates/pages/review_guide.html:61
 msgid "Keep reviews concise and easy to understand."
@@ -13570,11 +10716,8 @@ msgid "Will you continue to use this add-on?"
 msgstr "Apakah anda akan terus menggunakan pengaya ini?"
 
 #: src/olympia/pages/templates/pages/review_guide.html:73
-msgid ""
-"Take a moment to read your review before submitting it to minimize typos."
-msgstr ""
-"Luangkan waktu untuk membaca ulasan anda sebelum memasukkannya untuk "
-"meminimalkan kesalahan ketik."
+msgid "Take a moment to read your review before submitting it to minimize typos."
+msgstr "Luangkan waktu untuk membaca ulasan anda sebelum memasukkannya untuk meminimalkan kesalahan ketik."
 
 #: src/olympia/pages/templates/pages/review_guide.html:79
 msgid "Don’t:"
@@ -13586,66 +10729,43 @@ msgstr "Mengirim ulasan satu kata seperti \"Hebat!\", \"luar biasa,\" atau \"jel
 
 #: src/olympia/pages/templates/pages/review_guide.html:87
 msgid ""
-"Post technical issues, support requests, or feature suggestions. Use the "
-"available support options for each add-on, if available. You can find them "
-"in the side column next to the About this Add-on section."
+"Post technical issues, support requests, or feature suggestions. Use the available support options for each add-on, if available. You can find them in the side column next to the About this Add-on "
+"section."
 msgstr ""
-"Kirimkan isu teknis, permintaan dukungan, atau saran fitur. Gunakan pilihan "
-"dukungan yang tersedia untuk tiap pengaya, jika tersedia. Anda bisa "
-"menemukannya di bagian samping kolom di sebelah bagian Tentang Pengaya ini."
+"Kirimkan isu teknis, permintaan dukungan, atau saran fitur. Gunakan pilihan dukungan yang tersedia untuk tiap pengaya, jika tersedia. Anda bisa menemukannya di bagian samping kolom di sebelah "
+"bagian Tentang Pengaya ini."
 
 #: src/olympia/pages/templates/pages/review_guide.html:92
 msgid "Write reviews for add-ons which you have not personally used."
 msgstr "Tulis ulasan untuk pengaya yang belum pernah anda gunakan sendiri."
 
 #: src/olympia/pages/templates/pages/review_guide.html:97
-msgid ""
-"Use profanity, sexual language or language that can be construed as hateful."
-msgstr ""
-"Menggunakan bahasa kasar, seksual atau bahasa yang bisa ditafsirkan sebagai "
-"kebencian."
+msgid "Use profanity, sexual language or language that can be construed as hateful."
+msgstr "Menggunakan bahasa kasar, seksual atau bahasa yang bisa ditafsirkan sebagai kebencian."
 
 #: src/olympia/pages/templates/pages/review_guide.html:103
-msgid ""
-"Include HTML, links, source code or code snippets. Reviews are meant to be "
-"text only."
-msgstr ""
-"Memasukkan HTML, tautan, kode sumber atau potongan kode. Ulasan dimaksudkan "
-"berupa teks saja."
+msgid "Include HTML, links, source code or code snippets. Reviews are meant to be text only."
+msgstr "Memasukkan HTML, tautan, kode sumber atau potongan kode. Ulasan dimaksudkan berupa teks saja."
 
 #: src/olympia/pages/templates/pages/review_guide.html:108
-msgid ""
-"Make false statements, disparage add-on authors or personally insult them."
-msgstr ""
-"Membuat pernyataan yang salah, meremehkan penulis pengaya atau secara "
-"pribadi menghina mereka."
+msgid "Make false statements, disparage add-on authors or personally insult them."
+msgstr "Membuat pernyataan yang salah, meremehkan penulis pengaya atau secara pribadi menghina mereka."
 
 #: src/olympia/pages/templates/pages/review_guide.html:114
-msgid ""
-"Include your own or anyone else’s email, phone number, or other personal "
-"details."
-msgstr ""
-"Masukkan alamat surel anda atau orang lain, nomor telepon, atau rincian "
-"pribadi lainnya."
+msgid "Include your own or anyone else’s email, phone number, or other personal details."
+msgstr "Masukkan alamat surel anda atau orang lain, nomor telepon, atau rincian pribadi lainnya."
 
 #: src/olympia/pages/templates/pages/review_guide.html:119
-msgid ""
-"Post reviews for an add-on you or your organization wrote or represent."
-msgstr ""
-"Kirimkan ulasan untuk pengaya milik anda atau organisasi yang anda tulis "
-"atau wakili."
+msgid "Post reviews for an add-on you or your organization wrote or represent."
+msgstr "Kirimkan ulasan untuk pengaya milik anda atau organisasi yang anda tulis atau wakili."
 
 #: src/olympia/pages/templates/pages/review_guide.html:125
 msgid ""
-"Criticize an add-on for something it’s intended to do. For example, leaving "
-"a negative review of an add-on for displaying ads or requiring data "
-"gathering, when that is the intended purpose of the add-on, or the add-on "
-"requires gathering data to function."
+"Criticize an add-on for something it’s intended to do. For example, leaving a negative review of an add-on for displaying ads or requiring data gathering, when that is the intended purpose of the "
+"add-on, or the add-on requires gathering data to function."
 msgstr ""
-"Beri masukan pada pengaya sesuai dengan apa yang dilakukannya. Sebagai "
-"contoh, meninggalkan ulasan negatif untuk sebuah pengaya karena menampilkan "
-"iklan atau meminta pengumpulan data, sementara itu adalah tujuan keberadaan "
-"pengaya itu, atau pengaya meminta pengumpulan data agar bisa berfungsi."
+"Beri masukan pada pengaya sesuai dengan apa yang dilakukannya. Sebagai contoh, meninggalkan ulasan negatif untuk sebuah pengaya karena menampilkan iklan atau meminta pengumpulan data, sementara itu "
+"adalah tujuan keberadaan pengaya itu, atau pengaya meminta pengumpulan data agar bisa berfungsi."
 
 #: src/olympia/pages/templates/pages/review_guide.html:133
 msgid "How can I report a problematic review?"
@@ -13653,16 +10773,11 @@ msgstr "Bagaimana saya bisa melaporkan ulasan yang problematis?"
 
 #: src/olympia/pages/templates/pages/review_guide.html:135
 msgid ""
-"Please report or flag any questionable reviews by clicking the \"Report this"
-" review\" and it will be submitted to the site for moderation. Our "
-"moderation team will use the Review Guidelines to evaluate whether or not to"
-" delete the review or restore it back to the site."
+"Please report or flag any questionable reviews by clicking the \"Report this review\" and it will be submitted to the site for moderation. Our moderation team will use the Review Guidelines to "
+"evaluate whether or not to delete the review or restore it back to the site."
 msgstr ""
-"Harap melaporkan atau menandai ulasan apa saja yang patut dipertanyakan "
-"dengan mengklik \"Laporkan ulasan ini\" dan akan dikirimkan kembali ke situs"
-" untuk dimoderasi. Tim moderasi kami akan menggunakan Panduan Ulasan untuk "
-"mengevaluasi apakah perlu menghapus atau tidak ulasan itu atau "
-"mengembalikannya ke situs."
+"Harap melaporkan atau menandai ulasan apa saja yang patut dipertanyakan dengan mengklik \"Laporkan ulasan ini\" dan akan dikirimkan kembali ke situs untuk dimoderasi. Tim moderasi kami akan "
+"menggunakan Panduan Ulasan untuk mengevaluasi apakah perlu menghapus atau tidak ulasan itu atau mengembalikannya ke situs."
 
 #: src/olympia/pages/templates/pages/review_guide.html:140
 msgid "I’m an add-on author, can I respond to reviews?"
@@ -13670,34 +10785,22 @@ msgstr "Saya adalah penulis pengaya, bisakah saya merespon ulasan?"
 
 #: src/olympia/pages/templates/pages/review_guide.html:142
 #, python-format
-msgid ""
-"Yes, add-on authors can provide a single response to a review. You can set "
-"up a discussion topic in our <a href=\"%(forum_url)s\">forum</a> to engage "
-"in additional discussion or follow-up."
+msgid "Yes, add-on authors can provide a single response to a review. You can set up a discussion topic in our <a href=\"%(forum_url)s\">forum</a> to engage in additional discussion or follow-up."
 msgstr ""
-"Ya, penulis pengaya bisa menyediakan satu respon untuk ulasan anda. Anda "
-"bisa menyetel topik diskusi dalam <a href=\"%(forum_url)s\">forum</a> anda "
-"untuk berhubungan dengan diskusi tambahan atau tindak lanjut."
+"Ya, penulis pengaya bisa menyediakan satu respon untuk ulasan anda. Anda bisa menyetel topik diskusi dalam <a href=\"%(forum_url)s\">forum</a> anda untuk berhubungan dengan diskusi tambahan atau "
+"tindak lanjut."
 
 #: src/olympia/pages/templates/pages/review_guide.html:149
 msgid "I’m an add-on author, can I delete unfavorable reviews or ratings?"
-msgstr ""
-"Saya adalah penulis pengaya, bisakah saya menghapus ulasan atau peringkat "
-"yang kurang bagus?"
+msgstr "Saya adalah penulis pengaya, bisakah saya menghapus ulasan atau peringkat yang kurang bagus?"
 
 #: src/olympia/pages/templates/pages/review_guide.html:151
 msgid ""
-"In general, no. But if the review did not meet the review guidelines "
-"outlined above, you can click \"Report this review\" and have it moderated. "
-"If a review included a complaint that is no longer valid due to a new "
-"release of your add-on, we may consider deleting the review. Submit your "
-"detailed request to amo-editors@mozilla.org."
+"In general, no. But if the review did not meet the review guidelines outlined above, you can click \"Report this review\" and have it moderated. If a review included a complaint that is no longer "
+"valid due to a new release of your add-on, we may consider deleting the review. Submit your detailed request to amo-editors@mozilla.org."
 msgstr ""
-"Secara umum, tidak. Namun jika ulasan tidak memenuhi panduan di atas, anda "
-"bisa mengklik \"Melaporkan ulasan ini\" agar ulasan tersebut dimoderasi. "
-"Jika sebuah ulasan menyertakan keluhan yang tidak lagi benar disebabkan "
-"rilisan baru pengaya anda, kami akan mempertimbangkan untuk menghapus "
-"ulasan. Kirimkan permintaan terinci anda ke amo-editors@mozilla.org."
+"Secara umum, tidak. Namun jika ulasan tidak memenuhi panduan di atas, anda bisa mengklik \"Melaporkan ulasan ini\" agar ulasan tersebut dimoderasi. Jika sebuah ulasan menyertakan keluhan yang tidak "
+"lagi benar disebabkan rilisan baru pengaya anda, kami akan mempertimbangkan untuk menghapus ulasan. Kirimkan permintaan terinci anda ke amo-editors@mozilla.org."
 
 #: src/olympia/pages/templates/pages/sunbird.html:26
 msgid "Sunbird has retired"
@@ -13705,24 +10808,16 @@ msgstr "Sunbird telah dipensiunkan"
 
 #: src/olympia/pages/templates/pages/sunbird.html:29
 msgid ""
-"Development on the Sunbird project has halted and its final release was on "
-"March 30, 2010.  We've been proud to host Sunbird add-ons on this site but "
-"as the project is no longer maintained we have disabled our support for the "
-"add-ons."
+"Development on the Sunbird project has halted and its final release was on March 30, 2010. We've been proud to host Sunbird add-ons on this site but as the project is no longer maintained we have "
+"disabled our support for the add-ons."
 msgstr ""
-"Pengembangan proyek Sunbird telah dihentikan dan rilisan terakhirnya adalah "
-"tanggal 30 Maret 2010.  Kami bangga telah memuat pengaya Sunbird di situs "
-"ini namun sebagai proyek kami tidak lagi memeliharanya, kami telah "
-"menghentikan dukungan kami untuk pengaya tersebut."
+"Pengembangan proyek Sunbird telah dihentikan dan rilisan terakhirnya adalah tanggal 30 Maret 2010.  Kami bangga telah memuat pengaya Sunbird di situs ini namun sebagai proyek kami tidak lagi "
+"memeliharanya, kami telah menghentikan dukungan kami untuk pengaya tersebut."
 
 #: src/olympia/pages/templates/pages/sunbird.html:38
 #, python-format
-msgid ""
-"We recommend upgrading to <a href=\"%(tb_url)s\">Thunderbird</a> and <a "
-"href=\"%(lightning_url)s\">Lightning</a>."
-msgstr ""
-"Kami merekomendasikan meningkatkan ke <a href=\"%(tb_url)s\">Thunderbird</a>"
-" dan <a href=\"%(lightning_url)s\">Lightning</a>."
+msgid "We recommend upgrading to <a href=\"%(tb_url)s\">Thunderbird</a> and <a href=\"%(lightning_url)s\">Lightning</a>."
+msgstr "Kami merekomendasikan meningkatkan ke <a href=\"%(tb_url)s\">Thunderbird</a> dan <a href=\"%(lightning_url)s\">Lightning</a>."
 
 #: src/olympia/pages/templates/pages/sunbird.html:45
 msgid "Read more about Sunbird"
@@ -13730,9 +10825,7 @@ msgstr "Baca lebih lanjut tentang Sunbird"
 
 #: src/olympia/paypal/__init__.py:25
 msgid "There was an error communicating with PayPal. Please try again later."
-msgstr ""
-"Terjadi masalah komunikasi dengan PayPal. Silakan mencoba kembali lagi "
-"nanti."
+msgstr "Terjadi masalah komunikasi dengan PayPal. Silakan mencoba kembali lagi nanti."
 
 #: src/olympia/paypal/__init__.py:50
 msgid "There was an error with this currency."
@@ -13775,8 +10868,7 @@ msgstr "Terus mengulas; hilangkan penanda"
 msgid "Skip for now"
 msgstr "Lewatkan untuk sekarang"
 
-#: src/olympia/reviews/forms.py:151
-#: src/olympia/reviews/templates/reviews/review.html:107
+#: src/olympia/reviews/forms.py:151 src/olympia/reviews/templates/reviews/review.html:107
 msgid "Delete review"
 msgstr "Hapus ulasan"
 
@@ -13795,41 +10887,24 @@ msgstr "Tambahkan ulasan untuk {0}"
 #: src/olympia/reviews/templates/reviews/add.html:26
 #, python-format
 msgid ""
-"<h2>Keep these tips in mind:</h2> <ul> <li> Write like you're telling a "
-"friend about your experience with the add-on. Give specifics and helpful "
-"details, such as what features you liked and/or disliked, how easy to use it"
-" is, and any disadvantages it has.  Avoid generic language such as calling "
-"it \"Great\" or \"Bad\" unless you can give reasons why you believe this is "
-"so. </li> <li> Please do not post bug reports in reviews. We do not make "
-"your email address available to add-on developers and they may need to "
-"contact you to help resolve your issue. See the <a "
-"href=\"%(support)s\">support section</a> to find out where to get assistance"
-" for this add-on. </li> <li>Please keep reviews clean, avoid the use of "
-"improper language and do not post any personal information. </li> </ul> "
-"<p>Please read the <a href=\"%(guide)s\" target=\"_blank\">Review "
-"Guidelines</a> for more detail about user add-on reviews.</p>"
+"<h2>Keep these tips in mind:</h2> <ul> <li> Write like you're telling a friend about your experience with the add-on. Give specifics and helpful details, such as what features you liked and/or "
+"disliked, how easy to use it is, and any disadvantages it has. Avoid generic language such as calling it \"Great\" or \"Bad\" unless you can give reasons why you believe this is so. </li> <li> "
+"Please do not post bug reports in reviews. We do not make your email address available to add-on developers and they may need to contact you to help resolve your issue. See the <a href=\"%(support)s"
+"\">support section</a> to find out where to get assistance for this add-on. </li> <li>Please keep reviews clean, avoid the use of improper language and do not post any personal information. </li> </"
+"ul> <p>Please read the <a href=\"%(guide)s\" target=\"_blank\">Review Guidelines</a> for more detail about user add-on reviews.</p>"
 msgstr ""
-"<h2>Ingatlah:</h2> <ul> <li> Menulis seperti anda menyampaikan pada teman "
-"mengenai pengalaman dengan pengaya. Berikan rincian yang spesifik dan "
-"membantu, misalnya fitur apa yang anda suka/atau tidak suka, apakah mudah "
-"menggunakannya, dan kekurangan yang dimilikinya.  Hindari penggunaan bahasa "
-"yang umum seperti penyebutan \"Hebat\" atau \"Buruk\" terkecuali jika anda "
-"bisa memberi alasan. </li> <li> Harap jangan mengirimkan laporan bug dalam "
-"ulasan. Kami tidak memberikan alamat surel anda pada pengembang pengaya dan "
-"mereka mungkin perlu menghubungi anda untuk membantu masalah anda. Lihat <a "
-"href=\"%(support)s\">bagian dukungan</a> untuk menemukan di mana bisa "
-"mendapatkan bantuan untuk pengaya ini. </li> <li>Harap jaga ulasan tetap "
-"bersih, hindari penggunaan bahasa yang tidak pantas dan jangan memasang "
-"informasi pribadi apapun. </li> </ul> <p>Bacalah <a href=\"%(guide)s\" "
-"target=\"_blank\">Panduan Ulasan</a> untuk informasi lebih rinci mengenai "
-"ulasan pengguna pengaya.</p>"
+"<h2>Ingatlah:</h2> <ul> <li> Menulis seperti anda menyampaikan pada teman mengenai pengalaman dengan pengaya. Berikan rincian yang spesifik dan membantu, misalnya fitur apa yang anda suka/atau "
+"tidak suka, apakah mudah menggunakannya, dan kekurangan yang dimilikinya.  Hindari penggunaan bahasa yang umum seperti penyebutan \"Hebat\" atau \"Buruk\" terkecuali jika anda bisa memberi alasan. "
+"</li> <li> Harap jangan mengirimkan laporan bug dalam ulasan. Kami tidak memberikan alamat surel anda pada pengembang pengaya dan mereka mungkin perlu menghubungi anda untuk membantu masalah anda. "
+"Lihat <a href=\"%(support)s\">bagian dukungan</a> untuk menemukan di mana bisa mendapatkan bantuan untuk pengaya ini. </li> <li>Harap jaga ulasan tetap bersih, hindari penggunaan bahasa yang tidak "
+"pantas dan jangan memasang informasi pribadi apapun. </li> </ul> <p>Bacalah <a href=\"%(guide)s\" target=\"_blank\">Panduan Ulasan</a> untuk informasi lebih rinci mengenai ulasan pengguna pengaya.</"
+"p>"
 
 #: src/olympia/reviews/templates/reviews/reply.html:4
 msgid "Reply to review by {0}"
 msgstr "Membalas ulasan oleh {0}"
 
-#: src/olympia/reviews/templates/reviews/reply.html:15
-#: src/olympia/reviews/templates/reviews/reply.html:31
+#: src/olympia/reviews/templates/reviews/reply.html:15 src/olympia/reviews/templates/reviews/reply.html:31
 msgid "Reply"
 msgstr "Balas"
 
@@ -13837,8 +10912,7 @@ msgstr "Balas"
 msgid "Write a Reply"
 msgstr "Menulis Balasan"
 
-#: src/olympia/reviews/templates/reviews/reply.html:36
-#: src/olympia/reviews/templates/reviews/report_review.html:12
+#: src/olympia/reviews/templates/reviews/reply.html:36 src/olympia/reviews/templates/reviews/report_review.html:12
 msgid "Submit"
 msgstr "Затвердити"
 
@@ -13858,31 +10932,21 @@ msgid "by %(user)s <b>(Developer)</b> on %(date)s"
 msgstr "oleh %(user)s <b>(Pengembang)</b> pada %(date)s"
 
 #. {0} is a version number (like 1.01)
-#: src/olympia/reviews/templates/reviews/review.html:50
-#: src/olympia/reviews/templates/reviews/mobile/review_list.html:41
+#: src/olympia/reviews/templates/reviews/review.html:50 src/olympia/reviews/templates/reviews/mobile/review_list.html:41
 msgid "This review is for a previous version of the add-on ({0})."
 msgstr "Ulasan ini dibuat untuk versi pengaya ({0}) sebelumnya."
 
 #: src/olympia/reviews/templates/reviews/review.html:56
 #, python-format
-msgid ""
-"This user has a <a href=\"%(user_review_url)s\">previous review</a> of this "
-"add-on."
-msgid_plural ""
-"This user has <a href=\"%(user_review_url)s\">%(cnt)s previous reviews</a> "
-"of this add-on."
-msgstr[0] ""
-"Pengguna ini memiliki <a href=\"%(user_review_url)s\">%(cnt)s ulasan "
-"terdahulu</a> untuk pengaya ini."
+msgid "This user has a <a href=\"%(user_review_url)s\">previous review</a> of this add-on."
+msgid_plural "This user has <a href=\"%(user_review_url)s\">%(cnt)s previous reviews</a> of this add-on."
+msgstr[0] "Pengguna ini memiliki <a href=\"%(user_review_url)s\">%(cnt)s ulasan terdahulu</a> untuk pengaya ini."
+msgstr[1] ""
 
 #: src/olympia/reviews/templates/reviews/review.html:62
 #, python-format
-msgid ""
-"This user has <a href=\"%(user_review_url)s\">other reviews</a> of this add-"
-"on."
-msgstr ""
-"Pengguna ini memiliki <a href=\"%(user_review_url)s\">ulasan lainnya</a> "
-"untuk pengaya ini."
+msgid "This user has <a href=\"%(user_review_url)s\">other reviews</a> of this add-on."
+msgstr "Pengguna ini memiliki <a href=\"%(user_review_url)s\">ulasan lainnya</a> untuk pengaya ini."
 
 #: src/olympia/reviews/templates/reviews/review.html:72
 msgid "Flagged for review"
@@ -13914,9 +10978,7 @@ msgid "{0} :: Reviews"
 msgstr "{0} :: Ulasan"
 
 #. {0} is an addon name.
-#: src/olympia/reviews/templates/reviews/review_list.html:24
-#: src/olympia/reviews/templates/reviews/mobile/add.html:4
-#: src/olympia/reviews/templates/reviews/mobile/review_list.html:4
+#: src/olympia/reviews/templates/reviews/review_list.html:24 src/olympia/reviews/templates/reviews/mobile/add.html:4 src/olympia/reviews/templates/reviews/mobile/review_list.html:4
 msgid "Reviews for {0}"
 msgstr "Ulasan untuk {0}"
 
@@ -13925,6 +10987,7 @@ msgstr "Ulasan untuk {0}"
 msgid "<b>{0}</b> review for this add-on"
 msgid_plural "<b>{0}</b> reviews for this add-on"
 msgstr[0] "<b>{0}</b> ulasan untuk pengaya ini"
+msgstr[1] ""
 
 #. {0} is a developer's name.
 #: src/olympia/reviews/templates/reviews/review_list.html:33
@@ -13936,6 +10999,7 @@ msgstr "Balasan pengembang oleh {0}"
 msgid "Review for %(addon)s by %(user)s"
 msgid_plural "Reviews for %(addon)s by %(user)s"
 msgstr[0] "Ulasan untuk %(addon)s boleh %(user)s"
+msgstr[1] ""
 
 #: src/olympia/reviews/templates/reviews/review_list.html:42
 msgid "No reviews found."
@@ -13950,8 +11014,7 @@ msgstr "<strong>Rata-rata</strong> (%(total)s)"
 msgid "Write a New Review"
 msgstr "Tulis Ulasan Baru"
 
-#: src/olympia/reviews/templates/reviews/review_list.html:81
-#: src/olympia/reviews/templates/reviews/mobile/reviews_link.html:15
+#: src/olympia/reviews/templates/reviews/review_list.html:81 src/olympia/reviews/templates/reviews/mobile/reviews_link.html:15
 msgid "Be the first to write a review."
 msgstr "Kirim ulasan pertamax!"
 
@@ -13959,6 +11022,7 @@ msgstr "Kirim ulasan pertamax!"
 msgid "{num} review"
 msgid_plural "{num} reviews"
 msgstr[0] "{num} ulasan"
+msgstr[1] ""
 
 #: src/olympia/reviews/templates/reviews/impala/reviews_rating.html:1
 msgid "Rated {0} out of 5 stars"
@@ -13969,8 +11033,7 @@ msgstr "Peringkat {0} dari 5 bintang"
 msgid "Rated %(rating)s out of 5 stars"
 msgstr "Peringkat %(rating)s dari 5 bintang"
 
-#: src/olympia/reviews/templates/reviews/mobile/add_form.html:3
-#: src/olympia/reviews/templates/reviews/mobile/add_form.html:8
+#: src/olympia/reviews/templates/reviews/mobile/add_form.html:3 src/olympia/reviews/templates/reviews/mobile/add_form.html:8
 msgid "Add a Review"
 msgstr "Tambahkan Ulasan"
 
@@ -13986,6 +11049,7 @@ msgstr "Belum diperingkat."
 msgid "Average from {0} Rating"
 msgid_plural "Average from {0} Ratings"
 msgstr[0] "Dirata-rata dari {0} Peringkat"
+msgstr[1] ""
 
 #: src/olympia/reviews/templates/reviews/mobile/review_list.html:34
 #, python-format
@@ -14001,6 +11065,7 @@ msgstr "Lebih Lanjut&nbsp;&raquo;"
 msgid "See All Reviews"
 msgid_plural "See All %(cnt)s Reviews"
 msgstr[0] "Lihat Semua %(cnt)s Ulasan"
+msgstr[1] ""
 
 #: src/olympia/search/forms.py:11
 msgid "Most popular this week"
@@ -14039,10 +11104,8 @@ msgid "Relevance"
 msgstr "Relevansi"
 
 #: src/olympia/search/helpers.py:24
-msgid ""
-"Results <strong>{0}</strong>-<strong>{1}</strong> of <strong>{2}</strong>"
-msgstr ""
-"Hasil <strong>{0}</strong>-<strong>{1}</strong> dari <strong>{2}</strong>"
+msgid "Results <strong>{0}</strong>-<strong>{1}</strong> of <strong>{2}</strong>"
+msgstr "Hasil <strong>{0}</strong>-<strong>{1}</strong> dari <strong>{2}</strong>"
 
 # {0} is a number
 # {1} is a number
@@ -14050,12 +11113,8 @@ msgstr ""
 # {3} is the word the person is searching for
 # {4} is a word (the add-on is tagged with it)
 #: src/olympia/search/helpers.py:44
-msgid ""
-"Showing {0} - {1} of {2} results for <strong>{3}</strong> tagged with "
-"<strong>{4}</strong>"
-msgstr ""
-"Menampilkan hasil ke {0} - {1} dari {2} untuk <strong>{3}</strong> dengan "
-"tag <strong>{4}</strong>"
+msgid "Showing {0} - {1} of {2} results for <strong>{3}</strong> tagged with <strong>{4}</strong>"
+msgstr "Menampilkan hasil ke {0} - {1} dari {2} untuk <strong>{3}</strong> dengan tag <strong>{4}</strong>"
 
 # {0} is a number
 # {1} is a number
@@ -14071,8 +11130,7 @@ msgstr "Menampilkan hasil ke {0} - {1} dari {2} untuk <strong>{3}</strong>"
 # {3} is a word (the add-on is tagged with it)
 #: src/olympia/search/helpers.py:52
 msgid "Showing {0} - {1} of {2} results tagged with <strong>{3}</strong>"
-msgstr ""
-"Menampilkan hasil ke {0} - {1} dari {2} dengan tag <strong>{3}</strong>"
+msgstr "Menampilkan hasil ke {0} - {1} dari {2} dengan tag <strong>{3}</strong>"
 
 # {0} is a number
 # {1} is a number
@@ -14082,24 +11140,22 @@ msgid "Showing {0} - {1} of {2} results"
 msgstr "Menampilkan hasil ke {0} - {1} dari {2}"
 
 #. {0} is an application, like Firefox.
-#: src/olympia/search/views.py:264 src/olympia/templates/base.html:17
-#: src/olympia/templates/impala/base.html:17
-#: src/olympia/templates/mobile/base_addons.html:17
+#: src/olympia/search/views.py:264 src/olympia/templates/base.html:17 src/olympia/templates/impala/base.html:17 src/olympia/templates/mobile/base_addons.html:17
 msgid "{0} Add-ons"
 msgstr "Pengaya {0}"
 
 #. L10n: {0} is an application, such as Firefox. This means "any version of
 #. Firefox."
-#: src/olympia/search/views.py:554
+#: src/olympia/search/views.py:547
 msgid "Any {0}"
 msgstr "Berapapun {0}"
 
 #. L10n: "All Systems" means show everything regardless of platform.
-#: src/olympia/search/views.py:589
+#: src/olympia/search/views.py:582
 msgid "All Systems"
 msgstr "Semua Sistem"
 
-#: src/olympia/search/views.py:600
+#: src/olympia/search/views.py:593
 msgid "All Tags"
 msgstr "Seluruh Tag"
 
@@ -14118,8 +11174,7 @@ msgstr "Pencarian Tidak Tersedia"
 
 #: src/olympia/search/templates/search/down.html:6
 msgid "Search is temporarily unavailable. Please try again in a few minutes."
-msgstr ""
-"Pencarian saat ini tidak tersedia. Silakan coba lagi dalam beberapa menit."
+msgstr "Pencarian saat ini tidak tersedia. Silakan coba lagi dalam beberapa menit."
 
 #. {0} is the string the user was searching for
 #: src/olympia/search/templates/search/personas.html:9
@@ -14144,6 +11199,7 @@ msgstr "Hasil Pencarian untuk tag \"{0}\""
 msgid "<b>{0}</b> matching result"
 msgid_plural "<b>{0}</b> matching results"
 msgstr[0] "<b>{0}</b> hasil yang cocok"
+msgstr[1] ""
 
 #: src/olympia/search/templates/search/results.html:67
 msgid "Filter Results"
@@ -14165,6 +11221,7 @@ msgstr "Hasil Pencarian <i>({num})</i>"
 msgid "{0} post"
 msgid_plural "{0} posts"
 msgstr[0] "{0} kiriman"
+msgstr[1] ""
 
 #: src/olympia/sharing/__init__.py:20
 msgid "Post to Facebook"
@@ -14174,6 +11231,7 @@ msgstr "Kirim ke Facebook"
 msgid "{0} Like"
 msgid_plural "{0} Likes"
 msgstr[0] "{0} Menyukai"
+msgstr[1] ""
 
 #: src/olympia/sharing/__init__.py:30
 msgid "Tweet on Twitter"
@@ -14183,6 +11241,7 @@ msgstr "Tweet di Twitter"
 msgid "{0} tweet"
 msgid_plural "{0} tweets"
 msgstr[0] "{0} tweet"
+msgstr[1] ""
 
 #: src/olympia/sharing/__init__.py:40
 msgid "Share on g+"
@@ -14216,6 +11275,7 @@ msgstr "http://localservice1/?url={url}&judul={title}"
 msgid "{0} post on localservice1"
 msgid_plural "{0} posts on localservice1"
 msgstr[0] "{0} kiriman di localservice1"
+msgstr[1] ""
 
 #. L10n: Only change if you have reason! wiki.mozilla.org/AMO:Localizers
 #: src/olympia/sharing/__init__.py:76
@@ -14237,6 +11297,7 @@ msgstr "http://localservice2/?url={url}&judul={title}"
 msgid "{0} post on localservice2"
 msgid_plural "{0} posts on localservice2"
 msgstr[0] "{0} kiriman di localservice2"
+msgstr[1] ""
 
 #. L10n: Only change if you have reason! wiki.mozilla.org/AMO:Localizers
 #: src/olympia/sharing/__init__.py:91
@@ -14258,6 +11319,7 @@ msgstr "http://localservice3/?url={url}&judul={title}"
 msgid "{0} post on localservice3"
 msgid_plural "{0} posts on localservice3"
 msgstr[0] "{0} kiriman di localservice3"
+msgstr[1] ""
 
 #: src/olympia/sharing/templates/sharing/sharing_widget.html:2
 msgid "Share this Add-on"
@@ -14267,38 +11329,31 @@ msgstr "Berbagi Pengaya Ini"
 msgid "Share this Collection"
 msgstr "Berbagi Koleksi Ini"
 
-#: src/olympia/signing/views.py:30 src/olympia/templates/base.html:75
-#: src/olympia/templates/impala/base.html:115
-msgid ""
-"Some features are temporarily disabled while we perform website maintenance."
-" We'll be back to full capacity shortly."
-msgstr ""
-"Beberapa fitur sedang dimatikan sementara karena kami sedang melakukan "
-"pemeliharaan situs web. Beberapa saat lagi kami akan kembali."
+#: src/olympia/signing/views.py:33 src/olympia/templates/base.html:71 src/olympia/templates/impala/base.html:112
+msgid "Some features are temporarily disabled while we perform website maintenance. We'll be back to full capacity shortly."
+msgstr "Beberapa fitur sedang dimatikan sementara karena kami sedang melakukan pemeliharaan situs web. Beberapa saat lagi kami akan kembali."
 
-#: src/olympia/signing/views.py:53
+#: src/olympia/signing/views.py:56
 msgid "Could not find add-on with id \"{}\"."
 msgstr "Tidak bisa menemukan pengaya dengan id \"{}\"."
 
-#: src/olympia/signing/views.py:67
+#: src/olympia/signing/views.py:70
 msgid "You do not own this addon."
 msgstr "Anda tidak memiliki pengaya ini."
 
-#: src/olympia/signing/views.py:82
+#: src/olympia/signing/views.py:87
 msgid "Missing \"upload\" key in multipart file data."
-msgstr ""
-"Kehilangan kunci \"unggah\" dalam berkas data yang terdiri dari beberapa "
-"bagian."
+msgstr "Kehilangan kunci \"unggah\" dalam berkas data yang terdiri dari beberapa bagian."
 
-#: src/olympia/signing/views.py:96
+#: src/olympia/signing/views.py:101
 msgid "Version does not match the manifest file."
 msgstr "Versi ini tidak cocok dengan berkas manifest."
 
-#: src/olympia/signing/views.py:100
+#: src/olympia/signing/views.py:105
 msgid "Version already exists."
 msgstr "Versi yang sudah ada."
 
-#: src/olympia/signing/views.py:136
+#: src/olympia/signing/views.py:141
 msgid "No uploaded file for that addon and version."
 msgstr "Tidak ada berkas yang diunggah untuk pengaya dan versi tadi."
 
@@ -14390,8 +11445,7 @@ msgstr "Dari"
 msgid "To"
 msgstr "Untuk"
 
-#: src/olympia/stats/templates/stats/popup.html:27
-#: src/olympia/users/templates/users/pwreset_confirm.html:38
+#: src/olympia/stats/templates/stats/popup.html:27 src/olympia/users/templates/users/pwreset_confirm.html:38
 msgid "Update"
 msgstr "Perbarui"
 
@@ -14412,98 +11466,89 @@ msgstr "{0} :: Papan Statistik"
 msgid "Statistics Dashboard :: Add-ons for {0}"
 msgstr "Papan Statistik :: Pengaya untuk {0}"
 
-#: src/olympia/stats/templates/stats/stats.html:30
-msgid "Controls:"
-msgstr "Kendali:"
-
-#: src/olympia/stats/templates/stats/stats.html:33
-msgid "reset zoom"
-msgstr "menyetel ulang zoom"
-
-#: src/olympia/stats/templates/stats/stats.html:40
-msgid "Group by:"
-msgstr "Dikelompokkan berdasarkan:"
-
-#: src/olympia/stats/templates/stats/stats.html:42
-msgid "day"
-msgstr "hari"
-
-#: src/olympia/stats/templates/stats/stats.html:45
-msgid "week"
-msgstr "pekan"
-
-#: src/olympia/stats/templates/stats/stats.html:48
-msgid "month"
-msgstr "bulan"
-
-#: src/olympia/stats/templates/stats/stats.html:54
-msgid "For last:"
-msgstr "Untuk terakhir:"
-
-#: src/olympia/stats/templates/stats/stats.html:57
-msgid "7 days"
-msgstr "7 hari"
-
-#: src/olympia/stats/templates/stats/stats.html:60
-msgid "30 days"
-msgstr "30 hari"
-
-#: src/olympia/stats/templates/stats/stats.html:63
-msgid "90 days"
-msgstr "90 hari"
-
-#: src/olympia/stats/templates/stats/stats.html:66
-msgid "365 days"
-msgstr "365 hari"
-
-#: src/olympia/stats/templates/stats/stats.html:69
-msgid "Custom..."
-msgstr "Khusus..."
-
 #. {0} is an add-on name
-#: src/olympia/stats/templates/stats/stats.html:88
-#: src/olympia/stats/templates/stats/stats.html:91
+#: src/olympia/stats/templates/stats/stats.html:44 src/olympia/stats/templates/stats/stats.html:47
 msgid "Statistics for {0}"
 msgstr "Statistik untuk {0}"
 
-#: src/olympia/stats/templates/stats/stats.html:94
+#: src/olympia/stats/templates/stats/stats.html:50
 msgid "Statistics Dashboard"
 msgstr "Papan Statistik"
 
-#: src/olympia/stats/templates/stats/stats.html:104
-msgid ""
-"Statistics processing is currently disabled, so recent data is unavailable. "
-"The statistics are still being collected and this page will be updated soon "
-"with the missing data."
-msgstr ""
-"Pemrosesan statistik saat ini dimatikan, sehingga data baru tidak tersedia. "
-"Statistik masih tetap dikumpulkan dan laman ini akan diperbarui segera "
-"dengan data yang hilang."
+#: src/olympia/stats/templates/stats/stats.html:57
+msgid "Controls:"
+msgstr "Kendali:"
 
-#: src/olympia/stats/templates/stats/stats.html:110
+#: src/olympia/stats/templates/stats/stats.html:60
+msgid "reset zoom"
+msgstr "menyetel ulang zoom"
+
+#: src/olympia/stats/templates/stats/stats.html:67
+msgid "Group by:"
+msgstr "Dikelompokkan berdasarkan:"
+
+#: src/olympia/stats/templates/stats/stats.html:69
+msgid "day"
+msgstr "hari"
+
+#: src/olympia/stats/templates/stats/stats.html:72
+msgid "week"
+msgstr "pekan"
+
+#: src/olympia/stats/templates/stats/stats.html:75
+msgid "month"
+msgstr "bulan"
+
+#: src/olympia/stats/templates/stats/stats.html:81
+msgid "For last:"
+msgstr "Untuk terakhir:"
+
+#: src/olympia/stats/templates/stats/stats.html:84
+msgid "7 days"
+msgstr "7 hari"
+
+#: src/olympia/stats/templates/stats/stats.html:87
+msgid "30 days"
+msgstr "30 hari"
+
+#: src/olympia/stats/templates/stats/stats.html:90
+msgid "90 days"
+msgstr "90 hari"
+
+#: src/olympia/stats/templates/stats/stats.html:93
+msgid "365 days"
+msgstr "365 hari"
+
+#: src/olympia/stats/templates/stats/stats.html:96
+msgid "Custom..."
+msgstr "Khusus..."
+
+#: src/olympia/stats/templates/stats/stats.html:106
+msgid "Statistics processing is currently disabled, so recent data is unavailable. The statistics are still being collected and this page will be updated soon with the missing data."
+msgstr "Pemrosesan statistik saat ini dimatikan, sehingga data baru tidak tersedia. Statistik masih tetap dikumpulkan dan laman ini akan diperbarui segera dengan data yang hilang."
+
+#: src/olympia/stats/templates/stats/stats.html:112
 msgid "Loading the latest data&hellip;"
 msgstr "Memuat data terbaru&hellip;"
 
-#: src/olympia/stats/templates/stats/stats.html:142
-#: src/olympia/stats/templates/stats/reports/overview.html:25
-#: src/olympia/stats/templates/stats/reports/overview.html:37
+#: src/olympia/stats/templates/stats/stats.html:144 src/olympia/stats/templates/stats/reports/overview.html:25 src/olympia/stats/templates/stats/reports/overview.html:37
 #: src/olympia/stats/templates/stats/reports/overview.html:49
 msgid "No data available."
 msgstr "Tidak ada data tersedia."
 
-#: src/olympia/stats/templates/stats/stats.html:177
+#: src/olympia/stats/templates/stats/stats.html:179
 msgid "This dashboard is currently <b>public</b>."
 msgstr "Papan saat ini dalam keadaan <b>publik</b>."
 
-#: src/olympia/stats/templates/stats/stats.html:179
+#: src/olympia/stats/templates/stats/stats.html:181
 msgid "Contribution stats are currently <b>private</b>."
 msgstr "Statistik kontribusi saat ini dalam keadaaan <b>privat</b>."
 
-#: src/olympia/stats/templates/stats/stats.html:182
+#: src/olympia/stats/templates/stats/stats.html:184
 msgid "This dashboard is currently <b>private</b>."
 msgstr "Papan saat ini dalam keadaan <b>privat</b>."
 
-#: src/olympia/stats/templates/stats/stats.html:185
+#: src/olympia/stats/templates/stats/stats.html:187
 msgid "Change settings."
 msgstr "Ubah pengaturan."
 
@@ -14545,14 +11590,11 @@ msgstr "Bagaimana unduhan dihitung?"
 
 #: src/olympia/stats/templates/stats/reports/downloads.html:10
 msgid ""
-"<h2>How are downloads counted?</h2> <p> Download counts are updated every "
-"evening and only include original add-on downloads, not updates. Downloads "
-"can be broken down by the specific source referring the download. </p>"
+"<h2>How are downloads counted?</h2> <p> Download counts are updated every evening and only include original add-on downloads, not updates. Downloads can be broken down by the specific source "
+"referring the download. </p>"
 msgstr ""
-"<h2>Bagaimana unduhan dihitung?</h2> <p> Penghitungan unduhan diperbarui "
-"tiap malam dan hanya memasukkan pengunduhan pengaya pertama kalinya, bukan "
-"pembaruan. Unduhan bisa dibagi-bagi berdasarkan sumber spesifik yang merujuk"
-" pada unduhan. </p>"
+"<h2>Bagaimana unduhan dihitung?</h2> <p> Penghitungan unduhan diperbarui tiap malam dan hanya memasukkan pengunduhan pengaya pertama kalinya, bukan pembaruan. Unduhan bisa dibagi-bagi berdasarkan "
+"sumber spesifik yang merujuk pada unduhan. </p>"
 
 #: src/olympia/stats/templates/stats/reports/locales.html:3
 msgid "User languages by Date"
@@ -14566,8 +11608,7 @@ msgstr "Penggunaan Platform berdasarkan Tanggal"
 msgid "<b>{0}</b> Downloads"
 msgstr "<b>{0}</b> Unduhan"
 
-#: src/olympia/stats/templates/stats/reports/overview.html:9
-#: src/olympia/stats/templates/stats/reports/overview.html:13
+#: src/olympia/stats/templates/stats/reports/overview.html:9 src/olympia/stats/templates/stats/reports/overview.html:13
 msgid "Loading..."
 msgstr "Memuat..."
 
@@ -14618,34 +11659,17 @@ msgstr "Mengenai melacak sumber eksternal..."
 #: src/olympia/stats/templates/stats/reports/sources.html:10
 #, python-format
 msgid ""
-"<h2>Tracking external sources</h2> <p> If you link to your add-on's details "
-"page or directly to its file from an external site, such as your blog or "
-"website, you can append a parameter to be tracked as an additional download "
-"source on this page. For example, the following links would appear as "
-"sourced by your blog: <dl> <dt>Add-on Details Page</dt> "
-"<dd>https://addons.mozilla.org/addon/%(slug)s?src=<b>external-blog</b></dd> "
-"<dt>Direct File Link</dt> "
-"<dd>https://addons.mozilla.org/downloads/latest/%(id)s/addon-%(id)s-latest.xpi?src=<b"
-">external-blog</b></dd> </dl> <p> Only src parameters that begin with "
-"\"external-\" will be tracked, up to 61 additional characters. Any text "
-"after \"external-\" can be used to describe the source, such as \"external-"
-"blog\", \"external-sidebar\", \"external-campaign225\", etc. The following "
-"URL-safe characters are allowed: <code>a-z A-Z - . _ ~ %% +</code>"
+"<h2>Tracking external sources</h2> <p> If you link to your add-on's details page or directly to its file from an external site, such as your blog or website, you can append a parameter to be "
+"tracked as an additional download source on this page. For example, the following links would appear as sourced by your blog: <dl> <dt>Add-on Details Page</dt> <dd>https://addons.mozilla.org/addon/"
+"%(slug)s?src=<b>external-blog</b></dd> <dt>Direct File Link</dt> <dd>https://addons.mozilla.org/downloads/latest/%(id)s/addon-%(id)s-latest.xpi?src=<b>external-blog</b></dd> </dl> <p> Only src "
+"parameters that begin with \"external-\" will be tracked, up to 61 additional characters. Any text after \"external-\" can be used to describe the source, such as \"external-blog\", \"external-"
+"sidebar\", \"external-campaign225\", etc. The following URL-safe characters are allowed: <code>a-z A-Z - . _ ~ %% +</code>"
 msgstr ""
-"<h2>Melacak sumber eksternal</h2> <p> Jika anda menautkan laman rincian "
-"pengaya anda atau langsung pada berkasnya dari situs eksternal, misalnya "
-"blog anda atau situs, anda bisa menambahkan parameter untuk dilacak sebagai "
-"tambahan sumber pengunduhan di halaman ini. Misalnya, tautan berikut akan "
-"muncul sebagai bersumber dari blog anda: <dl> <dt>Laman Rincian Pengaya</dt>"
-" <dd>https://addons.mozilla.org/addon/%(slug)s?src=<b>blog "
-"eksternal</b></dd> <dt>Tautan Berkas Langsung</dt> "
-"<dd>https://addons.mozilla.org/downloads/latest/%(id)s/addon-%(id)s-latest.xpi?src=<b"
-">external-blog</b></dd> </dl> <p> Hanya parameter src yang dimulai dengan "
-"\"eksternal-\" akan dilacak, hingga 61 karakter tambahan. Teks apapun "
-"setelah \"eksternal-\" bisa digunakan untuk menjelaskan sumbernya, misalnya "
-"\"blog eksternal\", \"sidebar eksternal\", \"kampanye 225 eksternal\", dll. "
-"Beberapa karakter aman URL ini diperkenankan: <code>a-z A-Z - . _ ~ %% "
-"+</code>"
+"<h2>Melacak sumber eksternal</h2> <p> Jika anda menautkan laman rincian pengaya anda atau langsung pada berkasnya dari situs eksternal, misalnya blog anda atau situs, anda bisa menambahkan "
+"parameter untuk dilacak sebagai tambahan sumber pengunduhan di halaman ini. Misalnya, tautan berikut akan muncul sebagai bersumber dari blog anda: <dl> <dt>Laman Rincian Pengaya</dt> <dd>https://"
+"addons.mozilla.org/addon/%(slug)s?src=<b>blog eksternal</b></dd> <dt>Tautan Berkas Langsung</dt> <dd>https://addons.mozilla.org/downloads/latest/%(id)s/addon-%(id)s-latest.xpi?src=<b>external-blog</"
+"b></dd> </dl> <p> Hanya parameter src yang dimulai dengan \"eksternal-\" akan dilacak, hingga 61 karakter tambahan. Teks apapun setelah \"eksternal-\" bisa digunakan untuk menjelaskan sumbernya, "
+"misalnya \"blog eksternal\", \"sidebar eksternal\", \"kampanye 225 eksternal\", dll. Beberapa karakter aman URL ini diperkenankan: <code>a-z A-Z - . _ ~ %% +</code>"
 
 #: src/olympia/stats/templates/stats/reports/statuses.html:3
 msgid "Add-on Status by Date"
@@ -14665,28 +11689,19 @@ msgstr "Apakah pengguna harian itu?"
 
 #: src/olympia/stats/templates/stats/reports/usage.html:11
 msgid ""
-"<h2>What are daily users?</h2> <p> Themes installed from this site check for"
-" updates once per day. The total number of these update pings is known as "
-"Active Daily Users, or the total number of people using your theme by day. "
-"</p>"
+"<h2>What are daily users?</h2> <p> Themes installed from this site check for updates once per day. The total number of these update pings is known as Active Daily Users, or the total number of "
+"people using your theme by day. </p>"
 msgstr ""
-"<h2>Apakah pengguna harian itu?</h2> <p> Tema yang dipasang dari situs ini "
-"diperiksa pembaruannya sekali setiap hari. Jumlah total ping pembaruan ini "
-"disebut sebagai Pengguna Aktif Harian, atau jumlah total orang yang "
-"menggunakan tema anda berdasarkan hari. </p>"
+"<h2>Apakah pengguna harian itu?</h2> <p> Tema yang dipasang dari situs ini diperiksa pembaruannya sekali setiap hari. Jumlah total ping pembaruan ini disebut sebagai Pengguna Aktif Harian, atau "
+"jumlah total orang yang menggunakan tema anda berdasarkan hari. </p>"
 
 #: src/olympia/stats/templates/stats/reports/usage.html:20
 msgid ""
-"<h2>What are daily users?</h2> <p> Add-ons downloaded from this site check "
-"for updates once per day. The total number of these update pings is known as"
-" Active Daily Users. Daily users can be broken down by add-on version, "
-"operating system, add-on status, application, and locale. </p>"
+"<h2>What are daily users?</h2> <p> Add-ons downloaded from this site check for updates once per day. The total number of these update pings is known as Active Daily Users. Daily users can be broken "
+"down by add-on version, operating system, add-on status, application, and locale. </p>"
 msgstr ""
-"<h2>Apakah pengguna harian itu?</h2> <p> Pengaya yang diunduh dari situs ini"
-" dicek pembaruannya sekali setiap hari. Jumlah total pembaruan pin ini "
-"diketahui sebagai Pengguna Aktif Harian. Pengguna harian bisa dijabarkan "
-"berdasarkan versi pengaya, sistem operasi, status pengaya, aplikasi dan kode"
-" pelokalan. </p>"
+"<h2>Apakah pengguna harian itu?</h2> <p> Pengaya yang diunduh dari situs ini dicek pembaruannya sekali setiap hari. Jumlah total pembaruan pin ini diketahui sebagai Pengguna Aktif Harian. Pengguna "
+"harian bisa dijabarkan berdasarkan versi pengaya, sistem operasi, status pengaya, aplikasi dan kode pelokalan. </p>"
 
 #: src/olympia/stats/templates/stats/reports/users_created.html:3
 msgid "User Signups by Date"
@@ -14696,46 +11711,27 @@ msgstr "Pendaftaran Pengguna berdasarkan Tanggal"
 msgid "Application versions by Date"
 msgstr "Versi aplikasi berdasarkan Tanggal"
 
-# {0} is a number
-#: src/olympia/tags/templates/tags/top_cloud.html:4
-msgid "Top {0} Tags"
-msgstr "Tag {0} Teratas"
-
-#. {0} is the current application name
-#: src/olympia/tags/templates/tags/top_cloud.html:14
-msgid "{0} Top Tags"
-msgstr "Найпопулярніші мітки {0}"
-
-#: src/olympia/templates/amo_footer.html:6
-#: src/olympia/templates/includes/lang_switcher.html:2
+#: src/olympia/templates/amo_footer.html:6 src/olympia/templates/includes/lang_switcher.html:2
 msgid "Other languages"
 msgstr "Bahasa lainnya"
 
-#: src/olympia/templates/base.html:9 src/olympia/templates/impala/base.html:9
-#: src/olympia/templates/mobile/base_addons.html:9
+#: src/olympia/templates/base.html:9 src/olympia/templates/impala/base.html:9 src/olympia/templates/mobile/base_addons.html:9
 msgid "Mozilla Add-ons"
 msgstr "Pengaya Mozilla"
 
-#: src/olympia/templates/base.html:91
-#: src/olympia/templates/impala/base.html:81
+#: src/olympia/templates/base.html:89 src/olympia/templates/impala/base.html:78
 msgid "Find add-ons for other applications"
 msgstr "Temukan pengaya untuk aplikasi lainnya"
 
-#: src/olympia/templates/base.html:92
-#: src/olympia/templates/impala/base.html:81
+#: src/olympia/templates/base.html:90 src/olympia/templates/impala/base.html:78
 msgid "Other Applications"
 msgstr "Aplikasi Lainnya"
 
-#: src/olympia/templates/base.html:141
-#: src/olympia/templates/impala/base.html:194
-msgid ""
-"To create your own collections, you must have a Mozilla Add-ons account."
-msgstr ""
-"Untuk membuat koleksi Anda sendiri, Anda harus memiliki akun Pengaya "
-"Mozilla."
+#: src/olympia/templates/base.html:141 src/olympia/templates/impala/base.html:194
+msgid "To create your own collections, you must have a Mozilla Add-ons account."
+msgstr "Untuk membuat koleksi Anda sendiri, Anda harus memiliki akun Pengaya Mozilla."
 
-#: src/olympia/templates/base.html:168
-#: src/olympia/templates/impala/base.html:215
+#: src/olympia/templates/base.html:168 src/olympia/templates/impala/base.html:215
 msgid "Footer logo"
 msgstr "Logo catatan kaki"
 
@@ -14752,21 +11748,19 @@ msgid "View Mobile Site"
 msgstr "Tampilkan Situs Seluler"
 
 #: src/olympia/templates/copyright.html:7
-msgid "Site Status "
+msgid "Site Status"
 msgstr "Status Situs "
 
 #: src/olympia/templates/footer.html:3
 msgid "get to know <b>add-ons</b>"
 msgstr "mengenal <b>pengaya</b>"
 
-#: src/olympia/templates/footer.html:4
-#: src/olympia/templates/menu_links.html:20
+#: src/olympia/templates/footer.html:4 src/olympia/templates/menu_links.html:20
 msgid "About"
 msgstr "Tentang"
 
 # Link text to the AMO blog.
-#: src/olympia/templates/footer.html:5
-#: src/olympia/templates/menu_links.html:32
+#: src/olympia/templates/footer.html:5 src/olympia/templates/menu_links.html:32
 msgid "Blog"
 msgstr "Blog"
 
@@ -14843,9 +11837,7 @@ msgstr "Legal"
 msgid "Contact Us"
 msgstr "Hubungi Kami"
 
-#: src/olympia/templates/user_login.html:22
-#: src/olympia/users/templates/users/edit.html:31
-#: src/olympia/users/templates/users/includes/navigation.html:12
+#: src/olympia/templates/user_login.html:22 src/olympia/users/templates/users/edit.html:31 src/olympia/users/templates/users/includes/navigation.html:12
 msgid "My Account"
 msgstr "Akun Saya"
 
@@ -14853,53 +11845,40 @@ msgstr "Akun Saya"
 msgid "Welcome, {0}"
 msgstr "Selamat Datang {0}"
 
-#: src/olympia/templates/user_login.html:41
-#: src/olympia/templates/impala/user_login.html:20
+#: src/olympia/templates/user_login.html:41 src/olympia/templates/impala/user_login.html:20
 #, python-format
 msgid "<a href=\"%(reg)s\">Register</a> or <a href=\"%(login)s\">Log in</a>"
 msgstr "<a href=\"%(reg)s\">Daftar</a> atau <a href=\"%(login)s\">Masuk</a>"
 
-#: src/olympia/templates/impala/base.html:126
+#: src/olympia/templates/impala/base.html:123
 #, python-format
-msgid ""
-"To try the thousands of add-ons available here, download <a "
-"href=\"%(url)s\">Mozilla Firefox</a>, a fast, free way to surf the Web!"
-msgstr ""
-"Cobalah ribuan pengaya yang tersedia di sini, unduh <a "
-"href=\"%(url)s\">Mozilla Firefox</a>, cara cepat dan bebas untuk menjelajahi"
-" Web!"
+msgid "To try the thousands of add-ons available here, download <a href=\"%(url)s\">Mozilla Firefox</a>, a fast, free way to surf the Web!"
+msgstr "Cobalah ribuan pengaya yang tersedia di sini, unduh <a href=\"%(url)s\">Mozilla Firefox</a>, cara cepat dan bebas untuk menjelajahi Web!"
 
-#: src/olympia/templates/impala/base.html:138
+#: src/olympia/templates/impala/base.html:135
 #, python-format
-msgid ""
-"Add-ons is switching to Firefox Accounts for login. <a href=\"%(url)s\" "
-"class=\"fxa-login\">Sign in now to transfer your account.</a>"
-msgstr ""
-"Pengaya beralih ke Firefox Accounts untuk masuk log. <a href=\"%(url)s\" "
-"class=\"fxa-login\">Masuklah sekarang untuk mentransfer akun anda.</a>"
+msgid "Add-ons is switching to Firefox Accounts for login. <a href=\"%(url)s\" class=\"fxa-login\">Sign in now to transfer your account.</a>"
+msgstr "Pengaya beralih ke Firefox Accounts untuk masuk log. <a href=\"%(url)s\" class=\"fxa-login\">Masuklah sekarang untuk mentransfer akun anda.</a>"
 
 #. {0} is an application, such as Firefox.
-#: src/olympia/templates/impala/base.html:148
+#: src/olympia/templates/impala/base.html:145
 msgid "Welcome to {0} Add-ons."
 msgstr "Selamat datang ke Pengaya {0}."
 
-#: src/olympia/templates/impala/base.html:151
-msgid ""
-"Choose from thousands of extra features and styles to make Firefox your own."
-msgstr ""
-"Pilih dari ribuan fitur tambahan dan gayakan untuk membuat Firefox jadi "
-"milik anda."
+#: src/olympia/templates/impala/base.html:148
+msgid "Choose from thousands of extra features and styles to make Firefox your own."
+msgstr "Pilih dari ribuan fitur tambahan dan gayakan untuk membuat Firefox jadi milik anda."
 
-#: src/olympia/templates/impala/base.html:156
+#: src/olympia/templates/impala/base.html:153
 #, python-format
 msgid "Add extra features and styles to make %(app)s your own."
 msgstr "Tambahkan fitur ekstra dan gaya untuk membuat %(app)s milik anda."
 
-#: src/olympia/templates/impala/base.html:164
+#: src/olympia/templates/impala/base.html:161
 msgid "On the go?"
 msgstr "Dalam perjalanan?"
 
-#: src/olympia/templates/impala/base.html:166
+#: src/olympia/templates/impala/base.html:163
 msgid "Check out our <a class=\"mobile-link\" href=\"#\">Mobile Add-ons site</a>."
 msgstr "Periksa <a class=\"mobile-link\" href=\"#\">situs Pengaya Bergerak</a>."
 
@@ -14907,8 +11886,7 @@ msgstr "Periksa <a class=\"mobile-link\" href=\"#\">situs Pengaya Bergerak</a>."
 msgid "Android Add-ons"
 msgstr "Pengaya Android"
 
-#: src/olympia/templates/includes/forms.html:2
-#: src/olympia/templates/includes/forms.html:6
+#: src/olympia/templates/includes/forms.html:2 src/olympia/templates/includes/forms.html:6
 msgid "required"
 msgstr "wajib diisi"
 
@@ -14953,15 +11931,11 @@ msgstr "Kunjungi Mozilla"
 msgid "menu"
 msgstr "menu"
 
-#: src/olympia/templates/mobile/header_auth.html:7
-#: src/olympia/users/templates/users/register.html:41
-#: src/olympia/users/templates/users/register.html:89
+#: src/olympia/templates/mobile/header_auth.html:7 src/olympia/users/templates/users/register.html:41 src/olympia/users/templates/users/register.html:89
 msgid "Register"
 msgstr "Daftar"
 
-#: src/olympia/templates/mobile/header_auth.html:8
-#: src/olympia/users/templates/users/login_form.html:41
-#: src/olympia/users/templates/users/pwreset_complete.html:15
+#: src/olympia/templates/mobile/header_auth.html:8 src/olympia/users/templates/users/login_form.html:41 src/olympia/users/templates/users/pwreset_complete.html:15
 #: src/olympia/users/templates/users/mobile/login.html:56
 msgid "Log in"
 msgstr "Masuk"
@@ -14972,8 +11946,7 @@ msgstr "Masuk"
 msgid "Localize for: <a id=\"change-locale\" href=\"#\">%(dl)s</a>"
 msgstr "Pelokalan untuk <a id=\"change-locale\" href=\"#\">%(dl)s</a>"
 
-#: src/olympia/translations/templates/translations/trans-menu.html:16
-#: src/olympia/translations/templates/translations/trans-menu.html:29
+#: src/olympia/translations/templates/translations/trans-menu.html:16 src/olympia/translations/templates/translations/trans-menu.html:29
 #, python-format
 msgid "%(title)s <em>&middot; %(lang)s</em>"
 msgstr "%(title)s <em>&middot; %(lang)s</em>"
@@ -14988,12 +11961,8 @@ msgstr "Pelokalan Baru"
 
 #. {0} is a language name, like 'French'
 #: src/olympia/translations/templates/translations/trans-menu.html:42
-msgid ""
-"You have unsaved changes in the <b>{0}</b> locale. Would you like to save "
-"your changes before switching locales?"
-msgstr ""
-"Anda memiliki perubahan yang belum disimpan di <b>{0}</b> pelokalan ini. "
-"Apakah anda ingin menyimpan perubahan sebelum berganti pelokalan?"
+msgid "You have unsaved changes in the <b>{0}</b> locale. Would you like to save your changes before switching locales?"
+msgstr "Anda memiliki perubahan yang belum disimpan di <b>{0}</b> pelokalan ini. Apakah anda ingin menyimpan perubahan sebelum berganti pelokalan?"
 
 #: src/olympia/translations/templates/translations/trans-menu.html:49
 msgid "Discard Changes"
@@ -15001,12 +11970,8 @@ msgstr "Hapus Perubahan"
 
 #. {0} is a language name, like 'French'
 #: src/olympia/translations/templates/translations/trans-menu.html:56
-msgid ""
-"Are you sure you want to remove all <b>{0}</b> translations? This cannot be "
-"undone."
-msgstr ""
-"Yakin anda ingin menghapus semua <b>{0}</b> terjemahan? Ini tidak bisa "
-"diurungkan."
+msgid "Are you sure you want to remove all <b>{0}</b> translations? This cannot be undone."
+msgstr "Yakin anda ingin menghapus semua <b>{0}</b> terjemahan? Ini tidak bisa diurungkan."
 
 #: src/olympia/translations/templates/translations/trans-menu.html:61
 msgid "Delete Locale"
@@ -15027,25 +11992,15 @@ msgstr "Kata sandi ini tidak diperbolehkan."
 
 #: src/olympia/users/forms.py:90
 #, python-format
-msgid ""
-"As part of our new password policy, your password must be %s characters or "
-"more. Please update your password by <a href=\"%s\">issuing a password "
-"reset</a>."
+msgid "As part of our new password policy, your password must be %s characters or more. Please update your password by <a href=\"%s\">issuing a password reset</a>."
 msgstr ""
-"Sebagai bagian dari kebijakan sandi baru kami, sandi anda harus terdiri dari"
-" %s karaktor atau lebih. Harap memperbarui sandi anda dengan <a "
-"href=\"%s\">mengeluarkan penyetelan ulang sandi</a>."
+"Sebagai bagian dari kebijakan sandi baru kami, sandi anda harus terdiri dari %s karaktor atau lebih. Harap memperbarui sandi anda dengan <a href=\"%s\">mengeluarkan penyetelan ulang sandi</a>."
 
 #: src/olympia/users/forms.py:115
-msgid ""
-"You must recover your password through Firefox Accounts. Try logging in "
-"instead."
-msgstr ""
-"Anda harus memulihkan sandi anda melalui Firefox Accounts. Cobalah masuk "
-"sebagai gantinya."
+msgid "You must recover your password through Firefox Accounts. Try logging in instead."
+msgstr "Anda harus memulihkan sandi anda melalui Firefox Accounts. Cobalah masuk sebagai gantinya."
 
-#: src/olympia/users/forms.py:206
-#: src/olympia/users/templates/users/pwreset_confirm.html:24
+#: src/olympia/users/forms.py:206 src/olympia/users/templates/users/pwreset_confirm.html:24
 msgid "New password"
 msgstr "Sandi baru"
 
@@ -15058,12 +12013,8 @@ msgid "Usernames cannot contain only digits."
 msgstr "Nama pengguna tidak bisa hanya berisi digit."
 
 #: src/olympia/users/forms.py:274
-msgid ""
-"Enter a valid username consisting of letters, numbers, underscores or "
-"hyphens."
-msgstr ""
-"Masukkan nama pengguna yang benar, terdiri dari huruf, angka, garis bawah "
-"atau tanda hubung."
+msgid "Enter a valid username consisting of letters, numbers, underscores or hyphens."
+msgstr "Masukkan nama pengguna yang benar, terdiri dari huruf, angka, garis bawah atau tanda hubung."
 
 #: src/olympia/users/forms.py:277
 msgid "This username cannot be used."
@@ -15073,38 +12024,25 @@ msgstr "Nama pengguna ini tidak dapat digunakan."
 msgid "This username is already in use."
 msgstr "Nama pengguna ini sudah digunakan."
 
-#: src/olympia/users/forms.py:296
-#: src/olympia/users/templates/users/edit.html:107
+#: src/olympia/users/forms.py:296 src/olympia/users/templates/users/edit.html:107
 msgid "Display Name"
 msgstr "Nama Tampilan"
 
-#: src/olympia/users/forms.py:298
-#: src/olympia/users/templates/users/edit.html:112
-#: src/olympia/users/templates/users/vcard.html:10
+#: src/olympia/users/forms.py:298 src/olympia/users/templates/users/edit.html:112 src/olympia/users/templates/users/vcard.html:10
 msgid "Location"
 msgstr "Lokasi"
 
-#: src/olympia/users/forms.py:300
-#: src/olympia/users/templates/users/edit.html:117
-#: src/olympia/users/templates/users/vcard.html:16
+#: src/olympia/users/forms.py:300 src/olympia/users/templates/users/edit.html:117 src/olympia/users/templates/users/vcard.html:16
 msgid "Occupation"
 msgstr "Pekerjaan"
 
 #: src/olympia/users/forms.py:329
-msgid ""
-"This URL has an invalid format. Valid URLs look like "
-"http://example.com/my_page."
-msgstr ""
-"URL ini formatnya tidak valid. Contoh URL yang valid adalah "
-"http://example.com/namahalaman."
+msgid "This URL has an invalid format. Valid URLs look like http://example.com/my_page."
+msgstr "URL ini formatnya tidak valid. Contoh URL yang valid adalah http://example.com/namahalaman."
 
 #: src/olympia/users/forms.py:337
-msgid ""
-"Please use an email address from a different provider to complete your "
-"registration."
-msgstr ""
-"Harap gunakan alamat surel dari penyedia lainnya untuk melengkapi "
-"pendaftaran."
+msgid "Please use an email address from a different provider to complete your registration."
+msgstr "Harap gunakan alamat surel dari penyedia lainnya untuk melengkapi pendaftaran."
 
 #: src/olympia/users/forms.py:345
 msgid "This display name cannot be used."
@@ -15114,20 +12052,17 @@ msgstr "Nama tampilan ini tidak dapat digunakan."
 msgid "The passwords did not match."
 msgstr "Kata sandi tidak sama."
 
-#: src/olympia/users/forms.py:377
-#: src/olympia/users/templates/users/edit.html:128
+#: src/olympia/users/forms.py:377 src/olympia/users/templates/users/edit.html:128
 msgid "Profile Photo"
 msgstr "Foto Profil"
 
-#: src/olympia/users/forms.py:385
-#: src/olympia/users/templates/users/edit.html:142
+#: src/olympia/users/forms.py:385 src/olympia/users/templates/users/edit.html:142
 msgid "Default locale"
 msgstr "Pelokalan baku"
 
 #: src/olympia/users/forms.py:412
 msgid "Firefox Accounts users cannot currently change their email address."
-msgstr ""
-"Pengguna Firefox Accounts saat ini tidak dapat mengubah alamat sirel mereka."
+msgstr "Pengguna Firefox Accounts saat ini tidak dapat mengubah alamat sirel mereka."
 
 #: src/olympia/users/forms.py:446
 msgid "Wrong password entered!"
@@ -15138,12 +12073,8 @@ msgid "Email cannot be changed."
 msgstr "Surel tidak bisa diubah."
 
 #: src/olympia/users/forms.py:541
-msgid ""
-"To anonymize, enter a reason for the change but do not change any other "
-"field."
-msgstr ""
-"Untuk menjadi anonim, masukkan alasan perubahan, tapi jangan mengubah bagian"
-" lainnya."
+msgid "To anonymize, enter a reason for the change but do not change any other field."
+msgstr "Untuk menjadi anonim, masukkan alasan perubahan, tapi jangan mengubah bagian lainnya."
 
 #: src/olympia/users/forms.py:587
 msgid "Please enter at least one name to blacklist."
@@ -15172,19 +12103,19 @@ msgstr "Tidak ada pengguna dengan email tersebut."
 
 #. L10n: {id} will be something like "13ad6a", just a random number
 #. to differentiate this user from other anonymous users.
-#: src/olympia/users/models.py:353
+#: src/olympia/users/models.py:362
 msgid "Anonymous user {id}"
 msgstr "Pengguna anonim {id}"
 
-#: src/olympia/users/models.py:410
+#: src/olympia/users/models.py:419
 msgid "Your account has been restricted"
 msgstr "Akun anda telah dibatasi"
 
-#: src/olympia/users/models.py:480
+#: src/olympia/users/models.py:489
 msgid "Please confirm your email address"
 msgstr "Будь ласка підтвердіть вашу ел.адресу"
 
-#: src/olympia/users/models.py:506
+#: src/olympia/users/models.py:515
 msgid "My Mobile Add-ons"
 msgstr "Pengaya Bergerak Saya"
 
@@ -15249,16 +12180,12 @@ msgid "Mozilla needs to contact me about my individual app"
 msgstr "Mozilla perlu menghubungi saya mengenai aplikasi individual saya"
 
 #: src/olympia/users/notifications.py:139
-msgid ""
-"Mozilla wants to contact me about relevant App Developer news and surveys"
-msgstr ""
-"Mozilla ingin menghubungi saya mengenai kabar dan survei Pengembang Aplikasi"
+msgid "Mozilla wants to contact me about relevant App Developer news and surveys"
+msgstr "Mozilla ingin menghubungi saya mengenai kabar dan survei Pengembang Aplikasi"
 
 #: src/olympia/users/notifications.py:150
 msgid "Mozilla wants to contact me about new regions added to the Marketplace"
-msgstr ""
-"Mozilla ingin menghubungi saya mengenai region baru yang ditambahkan ke "
-"Marketplace"
+msgstr "Mozilla ingin menghubungi saya mengenai region baru yang ditambahkan ke Marketplace"
 
 #: src/olympia/users/notifications.py:158
 msgid "User Notifications"
@@ -15281,14 +12208,8 @@ msgid "Successfully verified!"
 msgstr "Sukses Diverifikasi!"
 
 #: src/olympia/users/views.py:132
-msgid ""
-"An email has been sent to your address to confirm your account. Before you "
-"can log in, you have to activate your account by clicking on the link "
-"provided in this email."
-msgstr ""
-"Sebuah surel telah dikirimkan ke alamat anda untuk mengkonfirmasi akun anda."
-" Sebelum anda bisa masuk, anda harus mengaktifkan akun anda dengan mengklik "
-"di tautan yang ada dalam surel ini."
+msgid "An email has been sent to your address to confirm your account. Before you can log in, you have to activate your account by clicking on the link provided in this email."
+msgstr "Sebuah surel telah dikirimkan ke alamat anda untuk mengkonfirmasi akun anda. Sebelum anda bisa masuk, anda harus mengaktifkan akun anda dengan mengklik di tautan yang ada dalam surel ini."
 
 #: src/olympia/users/views.py:136 src/olympia/users/views.py:619
 msgid "Confirmation Email Sent"
@@ -15312,14 +12233,11 @@ msgstr "Surel Konfirmasi Dikirimkan"
 
 #: src/olympia/users/views.py:197
 msgid ""
-"An email has been sent to {0} to confirm your new email address. For the "
-"change to take effect, you need to click on the link provided in this email."
-" Until then, you can keep logging in with your current email address."
+"An email has been sent to {0} to confirm your new email address. For the change to take effect, you need to click on the link provided in this email. Until then, you can keep logging in with your "
+"current email address."
 msgstr ""
-"Sebuah surel telah dikirim ke {0} untuk mengkonfirmasi alamat surel baru "
-"anda. Agar perubahan ini berdampak, anda perlu mengklik tautan yang ada "
-"dalam surel ini. Hingga saat itu, anda bisa terus masuk dengan alamat email "
-"saat ini."
+"Sebuah surel telah dikirim ke {0} untuk mengkonfirmasi alamat surel baru anda. Agar perubahan ini berdampak, anda perlu mengklik tautan yang ada dalam surel ini. Hingga saat itu, anda bisa terus "
+"masuk dengan alamat email saat ini."
 
 #: src/olympia/users/views.py:210
 #, python-format
@@ -15331,15 +12249,11 @@ msgid "Errors Found"
 msgstr "Masalah Ditemukan"
 
 #: src/olympia/users/views.py:225
-msgid ""
-"There were errors in the changes you made. Please correct them and resubmit."
-msgstr ""
-"Terjadi galat pada perubahan yang telah Anda lakukan. Silakan diperbaiki dan"
-" kirimkan ulang."
+msgid "There were errors in the changes you made. Please correct them and resubmit."
+msgstr "Terjadi galat pada perubahan yang telah Anda lakukan. Silakan diperbaiki dan kirimkan ulang."
 
 #: src/olympia/users/views.py:273
-msgid ""
-"We're sorry, but you are not eligible to request a t-shirt at this time."
+msgid "We're sorry, but you are not eligible to request a t-shirt at this time."
 msgstr "Mohon maaf, tapi anda tidak dapat meminta kaus saat ini."
 
 #: src/olympia/users/views.py:329
@@ -15355,25 +12269,17 @@ msgid "Wrong email address or password!"
 msgstr "Alamat email atau sandinya salah!"
 
 #: src/olympia/users/views.py:434
-msgid ""
-"A link to activate your user account was sent by email to your address {0}. "
-"You have to click it before you can log in."
-msgstr ""
-"Sebuah tautan untuk mengaktifkan akun pengguna anda telah dikirim melalui "
-"surel {0}. Anda harus mengkliknya sebelum bisa masuk."
+msgid "A link to activate your user account was sent by email to your address {0}. You have to click it before you can log in."
+msgstr "Sebuah tautan untuk mengaktifkan akun pengguna anda telah dikirim melalui surel {0}. Anda harus mengkliknya sebelum bisa masuk."
 
 #: src/olympia/users/views.py:439
 #, python-format
 msgid ""
-"If you did not receive the confirmation email, make sure your email service "
-"did not mark it as \"junk mail\" or \"spam\". If you need to, you can have "
-"us <a href=\"%s\">resend the confirmation message</a> to your email address "
-"mentioned above."
+"If you did not receive the confirmation email, make sure your email service did not mark it as \"junk mail\" or \"spam\". If you need to, you can have us <a href=\"%s\">resend the confirmation "
+"message</a> to your email address mentioned above."
 msgstr ""
-"Jika anda tidak menerima surel konfirmasi, pastikan layanan surel anda tidak"
-" menandainya sebagai \"surel sampan\" atau \"spam\". Jika diperlukan, anda "
-"dapat <a href=\"%s\">mengirim ulang pesan konfirmasi</a> ke alamat surel "
-"anda tersebut di atas."
+"Jika anda tidak menerima surel konfirmasi, pastikan layanan surel anda tidak menandainya sebagai \"surel sampan\" atau \"spam\". Jika diperlukan, anda dapat <a href=\"%s\">mengirim ulang pesan "
+"konfirmasi</a> ke alamat surel anda tersebut di atas."
 
 #: src/olympia/users/views.py:444
 msgid "Activation Email Sent"
@@ -15393,14 +12299,10 @@ msgstr "Selamat! Akun pengguna Anda sukses dibuat."
 
 # %1 is the user's email address
 #: src/olympia/users/views.py:615
-msgid ""
-"An email has been sent to your address {0} to confirm your account. Before "
-"you can log in, you have to activate your account by clicking on the link "
-"provided in this email."
+msgid "An email has been sent to your address {0} to confirm your account. Before you can log in, you have to activate your account by clicking on the link provided in this email."
 msgstr ""
-"Sebuah email telah dikirim ke alamat Anda di {0} untuk mengkonfirmasi akun "
-"Anda. Sebelum Anda dapat masuk, Anda harus mengaktifkan akun Anda dengan "
-"mengklik tautan yang dikirimkan pada email tersebut."
+"Sebuah email telah dikirim ke alamat Anda di {0} untuk mengkonfirmasi akun Anda. Sebelum Anda dapat masuk, Anda harus mengaktifkan akun Anda dengan mengklik tautan yang dikirimkan pada email "
+"tersebut."
 
 #: src/olympia/users/views.py:639
 msgid "There are errors in this form"
@@ -15418,31 +12320,22 @@ msgstr "Pengguna dilaporkan."
 msgid "new"
 msgstr "baru"
 
-#: src/olympia/users/templates/users/delete.html:4
-#: src/olympia/users/templates/users/delete.html:10
+#: src/olympia/users/templates/users/delete.html:4 src/olympia/users/templates/users/delete.html:10
 msgid "Delete User Account"
 msgstr "Hapus Akun Pengguna"
 
 #: src/olympia/users/templates/users/delete.html:14
 #, python-format
 msgid ""
-"You cannot delete your account if you are listed as an <a href=\"%(link)s\">"
-" author of any add-ons</a>. To delete your account, please have another "
-"person in your development group delete you from the list of authors for "
-"your add-ons. Afterwards you will be able to delete your account here."
+"You cannot delete your account if you are listed as an <a href=\"%(link)s\"> author of any add-ons</a>. To delete your account, please have another person in your development group delete you from "
+"the list of authors for your add-ons. Afterwards you will be able to delete your account here."
 msgstr ""
-"Anda tidak bisa menghapus akun jika terdaftar sebagai <a href=\"%(link)s\"> "
-"penulis pengaya apapun</a>. Untuk menghapus akun anda, harap ada orang lain "
-"dalam grup pengembangan anda yang menghapus anda dari daftar penulis pengaya"
-" anda. Setelah ini anda akan bisa menghapus akun di sini."
+"Anda tidak bisa menghapus akun jika terdaftar sebagai <a href=\"%(link)s\"> penulis pengaya apapun</a>. Untuk menghapus akun anda, harap ada orang lain dalam grup pengembangan anda yang menghapus "
+"anda dari daftar penulis pengaya anda. Setelah ini anda akan bisa menghapus akun di sini."
 
 #: src/olympia/users/templates/users/delete.html:29
-msgid ""
-"By clicking \"delete\" your account is going to be <strong>permanently "
-"removed</strong>. That means:"
-msgstr ""
-"Dengan mengklik \"hapus\" akun anda akan <strong>dihapus secara "
-"permanen</strong>. Artinya:"
+msgid "By clicking \"delete\" your account is going to be <strong>permanently removed</strong>. That means:"
+msgstr "Dengan mengklik \"hapus\" akun anda akan <strong>dihapus secara permanen</strong>. Artinya:"
 
 #: src/olympia/users/templates/users/delete.html:35
 #, python-format
@@ -15450,12 +12343,8 @@ msgid "You will not be able to log into %(site)s anymore."
 msgstr "Anda tidak akan dapat masuk ke %(site)s lagi."
 
 #: src/olympia/users/templates/users/delete.html:40
-msgid ""
-"Your reviews and ratings will not be deleted, but they will no longer be "
-"associated with you."
-msgstr ""
-"Ulasan dan peringkat anda tidak akan dihapus, tapi semuanya tidak akan "
-"diasosiasikan dengan anda lagi."
+msgid "Your reviews and ratings will not be deleted, but they will no longer be associated with you."
+msgstr "Ulasan dan peringkat anda tidak akan dihapus, tapi semuanya tidak akan diasosiasikan dengan anda lagi."
 
 #: src/olympia/users/templates/users/delete.html:46
 msgid "Confirm account deletion"
@@ -15469,8 +12358,7 @@ msgstr "Я розумію, що цей крок не може бути неви�
 msgid "Delete my user account now"
 msgstr "Hapus akun pengguna saya sekarang juga"
 
-#: src/olympia/users/templates/users/delete_photo.html:3
-#: src/olympia/users/templates/users/delete_photo.html:9
+#: src/olympia/users/templates/users/delete_photo.html:3 src/olympia/users/templates/users/delete_photo.html:9
 msgid "Delete User Photo"
 msgstr "Hapus Foto Pengguna"
 
@@ -15483,26 +12371,18 @@ msgid "Please set your display name"
 msgstr "Harap menetapkan nama yang ditampilkan"
 
 #: src/olympia/users/templates/users/edit.html:21
-msgid ""
-"Please set your display name or username to complete the registration "
-"process."
-msgstr ""
-"Silakan menetapkan nama yang ditampilkan atau nama pengguna untuk melengkapi"
-" proses registrasi."
+msgid "Please set your display name or username to complete the registration process."
+msgstr "Silakan menetapkan nama yang ditampilkan atau nama pengguna untuk melengkapi proses registrasi."
 
 #: src/olympia/users/templates/users/edit.html:33
 msgid "Manage basic account information, such as username and email address."
-msgstr ""
-"Mengelola informasi akun dasar, misalnya nama pengguna dan alamat surel."
+msgstr "Mengelola informasi akun dasar, misalnya nama pengguna dan alamat surel."
 
-#: src/olympia/users/templates/users/edit.html:39
-#: src/olympia/users/templates/users/register.html:47
+#: src/olympia/users/templates/users/edit.html:39 src/olympia/users/templates/users/register.html:47
 msgid "Username"
 msgstr "Nama pengguna"
 
-#: src/olympia/users/templates/users/edit.html:45
-#: src/olympia/users/templates/users/pwreset_request.html:21
-#: src/olympia/users/templates/users/register.html:62
+#: src/olympia/users/templates/users/edit.html:45 src/olympia/users/templates/users/pwreset_request.html:21 src/olympia/users/templates/users/register.html:62
 msgid "Email Address"
 msgstr "Alamat Email"
 
@@ -15514,21 +12394,15 @@ msgstr "Kelola Akun Firefox..."
 msgid "Change Password"
 msgstr "Ganti Kata Sandi"
 
-#: src/olympia/users/templates/users/edit.html:68
-#: src/olympia/users/templates/users/login_form.html:22
-#: src/olympia/users/templates/users/register.html:67
+#: src/olympia/users/templates/users/edit.html:68 src/olympia/users/templates/users/login_form.html:22 src/olympia/users/templates/users/register.html:67
 #: src/olympia/users/templates/users/mobile/login.html:37
 msgid "Password"
 msgstr "Sandi"
 
 #: src/olympia/users/templates/users/edit.html:70
 #, python-format
-msgid ""
-"Change your password.  If you forgot your password, you can <a "
-"href=\"%(reset_url)s\">use the reset form</a>."
-msgstr ""
-"Ubah sandi anda.  Jika anda melupakan sandi, anda bisa <a "
-"href=\"%(reset_url)s\">menggunakan formulir reset</a>."
+msgid "Change your password. If you forgot your password, you can <a href=\"%(reset_url)s\">use the reset form</a>."
+msgstr "Ubah sandi anda.  Jika anda melupakan sandi, anda bisa <a href=\"%(reset_url)s\">menggunakan formulir reset</a>."
 
 #: src/olympia/users/templates/users/edit.html:76
 msgid "Old Password"
@@ -15547,13 +12421,8 @@ msgid "Profile"
 msgstr "Profil"
 
 #: src/olympia/users/templates/users/edit.html:100
-msgid ""
-"Give us a bit more information about yourself.  All these fields are "
-"optional, but they'll help other users get to know you better."
-msgstr ""
-"Beri kami lebih banyak informasi tentang anda.  Seluruh berkas ini bisa "
-"dipilih, namun semua ini bisa membantu pengguna untuk mengenal anda lebih "
-"baik."
+msgid "Give us a bit more information about yourself. All these fields are optional, but they'll help other users get to know you better."
+msgstr "Beri kami lebih banyak informasi tentang anda.  Seluruh berkas ini bisa dipilih, namun semua ini bisa membantu pengguna untuk mengenal anda lebih baik."
 
 #: src/olympia/users/templates/users/edit.html:124
 msgid "This URL will only be visible if you are a developer."
@@ -15568,20 +12437,12 @@ msgid "Delete current photo"
 msgstr "Hapus foto sekarang ini"
 
 #: src/olympia/users/templates/users/edit.html:144
-msgid ""
-"This is the default locale used to display information about you (like your "
-"description)."
-msgstr ""
-"Ini adalah pelokalan baku yang digunakan untuk menampilkan informasi "
-"mengenai Anda (misalnya deskripsi Anda)."
+msgid "This is the default locale used to display information about you (like your description)."
+msgstr "Ini adalah pelokalan baku yang digunakan untuk menampilkan informasi mengenai Anda (misalnya deskripsi Anda)."
 
 #: src/olympia/users/templates/users/edit.html:152
-msgid ""
-"Introduce yourself to the community, if you like! This text will appear "
-"publicly on your user info page."
-msgstr ""
-"Jika suka, perkenalkan diri Anda ke komunitas. Teks ini akan tampil pada "
-"laman info pengguna Anda untuk umum."
+msgid "Introduce yourself to the community, if you like! This text will appear publicly on your user info page."
+msgstr "Jika suka, perkenalkan diri Anda ke komunitas. Teks ini akan tampil pada laman info pengguna Anda untuk umum."
 
 #: src/olympia/users/templates/users/edit.html:161
 msgid "Allowed HTML: {0}. Links are forbidden."
@@ -15608,20 +12469,12 @@ msgid "Notifications"
 msgstr "Notifikasi"
 
 #: src/olympia/users/templates/users/edit.html:195
-msgid ""
-"From time to time, Mozilla may send you email about upcoming releases and "
-"add-on events. Please select the topics you are interested in."
-msgstr ""
-"Sewaktu-waktu, Mozilla akan mengirimi anda surel mengenai rilis yang akan "
-"datang dan acara pengaya. Silakan memilih topik yang anda minati."
+msgid "From time to time, Mozilla may send you email about upcoming releases and add-on events. Please select the topics you are interested in."
+msgstr "Sewaktu-waktu, Mozilla akan mengirimi anda surel mengenai rilis yang akan datang dan acara pengaya. Silakan memilih topik yang anda minati."
 
 #: src/olympia/users/templates/users/edit.html:205
-msgid ""
-"Mozilla reserves the right to contact you individually about specific "
-"concerns with your hosted add-ons."
-msgstr ""
-"Mozilla memiliki hak untuk menghubungi Anda secara langsung tentang "
-"pertimbangan tertentu untuk pengaya yang diinangi di sini."
+msgid "Mozilla reserves the right to contact you individually about specific concerns with your hosted add-ons."
+msgstr "Mozilla memiliki hak untuk menghubungi Anda secara langsung tentang pertimbangan tertentu untuk pengaya yang diinangi di sini."
 
 #: src/olympia/users/templates/users/edit.html:215
 msgid "Admin"
@@ -15643,63 +12496,49 @@ msgstr "tidak ada"
 msgid "all"
 msgstr "semua"
 
-#: src/olympia/users/templates/users/fxa_migration.html:3
-#: src/olympia/users/templates/users/fxa_migration.html:11
-#: src/olympia/users/templates/users/mobile/fxa_migration.html:3
+#: src/olympia/users/templates/users/fxa_migration.html:3 src/olympia/users/templates/users/fxa_migration.html:11 src/olympia/users/templates/users/mobile/fxa_migration.html:3
 #: src/olympia/users/templates/users/mobile/fxa_migration.html:8
 msgid "Migrate to Firefox Accounts"
 msgstr "Beralihlah ke Firefox Accounts"
 
 #: src/olympia/users/templates/users/fxa_migration_prompt_content.html:3
-msgid ""
-"Mozilla Add-ons has transitioned to Firefox Accounts for login. Continue to "
-"complete the simple upgrade process."
-msgstr ""
-"Pengaya Mozilla telah dipindahkan ke Firefox Accounts untuk masuk. Lanjutkan"
-" untuk menyelesaikan proses peningkatan sederhana."
+msgid "Mozilla Add-ons has transitioned to Firefox Accounts for login. Continue to complete the simple upgrade process."
+msgstr "Pengaya Mozilla telah dipindahkan ke Firefox Accounts untuk masuk. Lanjutkan untuk menyelesaikan proses peningkatan sederhana."
 
 #: src/olympia/users/templates/users/fxa_migration_prompt_content.html:14
 msgid "Skip"
 msgstr "Lewati"
 
-#: src/olympia/users/templates/users/login.html:3
-#: src/olympia/users/templates/users/mobile/login.html:3
+#: src/olympia/users/templates/users/login.html:3 src/olympia/users/templates/users/mobile/login.html:3
 msgid "User Login"
 msgstr "Masuk"
 
-#: src/olympia/users/templates/users/login.html:13
-#: src/olympia/users/templates/users/mobile/login.html:21
+#: src/olympia/users/templates/users/login.html:13 src/olympia/users/templates/users/mobile/login.html:21
 msgid "Enter your email"
 msgstr "Masukkan surel Anda"
 
-#: src/olympia/users/templates/users/login.html:15
-#: src/olympia/users/templates/users/mobile/login.html:23
+#: src/olympia/users/templates/users/login.html:15 src/olympia/users/templates/users/mobile/login.html:23
 msgid "Log In"
 msgstr "Masuk"
 
-#: src/olympia/users/templates/users/login_form.html:17
-#: src/olympia/users/templates/users/mobile/login.html:32
+#: src/olympia/users/templates/users/login_form.html:17 src/olympia/users/templates/users/mobile/login.html:32
 msgid "Email address"
 msgstr "Alamat email"
 
-#: src/olympia/users/templates/users/login_form.html:30
-#: src/olympia/users/templates/users/mobile/login.html:44
+#: src/olympia/users/templates/users/login_form.html:30 src/olympia/users/templates/users/mobile/login.html:44
 msgid "Remember me on this device"
 msgstr "Ingat saya untuk perangkat ini"
 
 # This is a header for additional help options
-#: src/olympia/users/templates/users/login_help.html:3
-#: src/olympia/users/templates/users/mobile/login.html:63
+#: src/olympia/users/templates/users/login_help.html:3 src/olympia/users/templates/users/mobile/login.html:63
 msgid "Login Problems?"
 msgstr "Punya Masalah untuk Masuk?"
 
-#: src/olympia/users/templates/users/login_help.html:5
-#: src/olympia/users/templates/users/mobile/login.html:65
+#: src/olympia/users/templates/users/login_help.html:5 src/olympia/users/templates/users/mobile/login.html:65
 msgid "I don't have an account."
 msgstr "Belum punya akun."
 
-#: src/olympia/users/templates/users/login_help.html:6
-#: src/olympia/users/templates/users/mobile/login.html:66
+#: src/olympia/users/templates/users/login_help.html:6 src/olympia/users/templates/users/mobile/login.html:66
 msgid "I forgot my password."
 msgstr "Lupa sandi."
 
@@ -15708,15 +12547,9 @@ msgstr "Lupa sandi."
 msgid "You are now logged in as <strong>%(user_email)s</strong>!"
 msgstr "Anda sekarang masuk sebagai <strong>%(user_email)s</strong>!"
 
-#: src/olympia/users/templates/users/newpw_sent.html:3
-#: src/olympia/users/templates/users/newpw_sent.html:8
-#: src/olympia/users/templates/users/pwreset_complete.html:3
-#: src/olympia/users/templates/users/pwreset_confirm.html:4
-#: src/olympia/users/templates/users/pwreset_confirm.html:18
-#: src/olympia/users/templates/users/pwreset_request.html:4
-#: src/olympia/users/templates/users/pwreset_request.html:10
-#: src/olympia/users/templates/users/pwreset_sent.html:3
-#: src/olympia/users/templates/users/pwreset_sent.html:8
+#: src/olympia/users/templates/users/newpw_sent.html:3 src/olympia/users/templates/users/newpw_sent.html:8 src/olympia/users/templates/users/pwreset_complete.html:3
+#: src/olympia/users/templates/users/pwreset_confirm.html:4 src/olympia/users/templates/users/pwreset_confirm.html:18 src/olympia/users/templates/users/pwreset_request.html:4
+#: src/olympia/users/templates/users/pwreset_request.html:10 src/olympia/users/templates/users/pwreset_sent.html:3 src/olympia/users/templates/users/pwreset_sent.html:8
 msgid "Password Reset"
 msgstr "Setel Ulang Sandi"
 
@@ -15732,8 +12565,7 @@ msgstr "Edit profil"
 msgid "Manage user"
 msgstr "Kelola pengguna"
 
-#: src/olympia/users/templates/users/profile.html:18
-#: src/olympia/users/templates/users/report_abuse_full.html:9
+#: src/olympia/users/templates/users/profile.html:18 src/olympia/users/templates/users/report_abuse_full.html:9
 msgid "Report user"
 msgstr "Laporkan penguna"
 
@@ -15796,39 +12628,25 @@ msgstr "Sukses!"
 msgid "Password successfully reset."
 msgstr "Sandi sukses disetel ulang."
 
-#: src/olympia/users/templates/users/pwreset_confirm.html:13
-#: src/olympia/users/templates/users/pwreset_confirm.html:46
+#: src/olympia/users/templates/users/pwreset_confirm.html:13 src/olympia/users/templates/users/pwreset_confirm.html:46
 msgid "Password reset unsuccessful"
 msgstr "Скидання пароля не вдалося"
 
 #: src/olympia/users/templates/users/pwreset_confirm.html:14
-msgid ""
-"You have migrated to Firefox Accounts. You can no longer change your "
-"password here."
-msgstr ""
-"Anda telah bermigrasi ke Firefox Accounts. Anda tidak bisa lagi mengubah "
-"kata sandi di sini."
+msgid "You have migrated to Firefox Accounts. You can no longer change your password here."
+msgstr "Anda telah bermigrasi ke Firefox Accounts. Anda tidak bisa lagi mengubah kata sandi di sini."
 
-#: src/olympia/users/templates/users/pwreset_confirm.html:31
-#: src/olympia/users/templates/users/register.html:72
+#: src/olympia/users/templates/users/pwreset_confirm.html:31 src/olympia/users/templates/users/register.html:72
 msgid "Confirm password"
 msgstr "Konfirmasi sandi"
 
 #: src/olympia/users/templates/users/pwreset_confirm.html:47
-msgid ""
-"The password reset link was invalid, possibly because it has already been "
-"used.  Please request a new password reset."
-msgstr ""
-"Tautan penyetelan ulang sandi tidak valid, mungkin sudah pernah digunakan.  "
-"Silakan ajukan permintaan penyetelan ulang sandi yang baru."
+msgid "The password reset link was invalid, possibly because it has already been used. Please request a new password reset."
+msgstr "Tautan penyetelan ulang sandi tidak valid, mungkin sudah pernah digunakan.  Silakan ajukan permintaan penyetelan ulang sandi yang baru."
 
 #: src/olympia/users/templates/users/pwreset_request.html:15
-msgid ""
-"Forgotten your password? Enter your e-mail address below, and we'll e-mail "
-"instructions for setting a new one."
-msgstr ""
-"Lupa sandi anda? Masukkan alamat surel di bawah ini, dan kami akan "
-"mengirimkan surel berisi instruksi untuk membuat yang baru."
+msgid "Forgotten your password? Enter your e-mail address below, and we'll e-mail instructions for setting a new one."
+msgstr "Lupa sandi anda? Masukkan alamat surel di bawah ini, dan kami akan mengirimkan surel berisi instruksi untuk membuat yang baru."
 
 #: src/olympia/users/templates/users/pwreset_request.html:25
 msgid "Send password reset link"
@@ -15836,14 +12654,10 @@ msgstr "Kirim tautan untuk menyetel ulang sandi"
 
 #: src/olympia/users/templates/users/pwreset_sent.html:10
 msgid ""
-"An email has been sent to the requested account with further information. If"
-" you do not receive an email then please confirm you have entered the same "
-"email address used during account registration."
+"An email has been sent to the requested account with further information. If you do not receive an email then please confirm you have entered the same email address used during account registration."
 msgstr ""
-"Surel telah dikirimkan ke akun yang meminta dengan informasi lebih lengkap. "
-"Jika anda tidak menerima surel saat itu, silakan mengkonfirmasi bahwa anda "
-"telah mengirimkan alamat surel yang sama yang digunakan saat pendaftaran "
-"akun."
+"Surel telah dikirimkan ke akun yang meminta dengan informasi lebih lengkap. Jika anda tidak menerima surel saat itu, silakan mengkonfirmasi bahwa anda telah mengirimkan alamat surel yang sama yang "
+"digunakan saat pendaftaran akun."
 
 #: src/olympia/users/templates/users/register.html:4
 msgid "New User Registration"
@@ -15854,12 +12668,8 @@ msgid "Why register?"
 msgstr "Untuk apa pendaftaran diperlukan?"
 
 #: src/olympia/users/templates/users/register.html:14
-msgid ""
-"Registration on AMO is <strong>not required</strong> if you simply want to "
-"download and install public add-ons."
-msgstr ""
-"Registrasi di AMO <strong>tidak diperlukan</strong> jika anda hanya ingin "
-"mengunduh dan memasang pengaya publik."
+msgid "Registration on AMO is <strong>not required</strong> if you simply want to download and install public add-ons."
+msgstr "Registrasi di AMO <strong>tidak diperlukan</strong> jika anda hanya ingin mengunduh dan memasang pengaya publik."
 
 #: src/olympia/users/templates/users/register.html:16
 msgid "You only need to register if:"
@@ -15870,52 +12680,29 @@ msgid "You want to submit reviews for add-ons"
 msgstr "Anda ingin mengirim ulasan untuk pengaya"
 
 #: src/olympia/users/templates/users/register.html:19
-msgid ""
-"You want to keep track of your favorite add-on collections or create one "
-"yourself"
-msgstr ""
-"Anda ingin melacak pengaya favorit atau membuat pengaya yang anda inginkan"
+msgid "You want to keep track of your favorite add-on collections or create one yourself"
+msgstr "Anda ingin melacak pengaya favorit atau membuat pengaya yang anda inginkan"
 
 #: src/olympia/users/templates/users/register.html:20
-msgid ""
-"You are an add-on developer and want to upload your add-on for hosting on "
-"AMO"
-msgstr ""
-"Anda adalah pengembang pengaya dan ingin mengunggah pengaya anda untuk "
-"dimuat di AMO"
+msgid "You are an add-on developer and want to upload your add-on for hosting on AMO"
+msgstr "Anda adalah pengembang pengaya dan ingin mengunggah pengaya anda untuk dimuat di AMO"
 
 #: src/olympia/users/templates/users/register.html:23
-msgid ""
-"Upon successful registration, you will be sent a confirmation email to the "
-"address you provided. Please follow the instructions there to confirm your "
-"account."
-msgstr ""
-"Setelah pendaftaran berhasil dilakukan, anda akan dikirimi surel konfirmasi "
-"ke alamat surel yang anda sediakan. Silakan ikuti instruksi di sini untuk "
-"mengkonfirmasi akun anda."
+msgid "Upon successful registration, you will be sent a confirmation email to the address you provided. Please follow the instructions there to confirm your account."
+msgstr "Setelah pendaftaran berhasil dilakukan, anda akan dikirimi surel konfirmasi ke alamat surel yang anda sediakan. Silakan ikuti instruksi di sini untuk mengkonfirmasi akun anda."
 
 #: src/olympia/users/templates/users/register.html:30
 #, python-format
-msgid ""
-"If you like, you can read our <a href=\"%(legal)s\" title=\"Legal "
-"Notices\">Legal Notices</a> and <a href=\"%(privacy)s\" title=\"Privacy "
-"Policy\">Privacy Policy</a>."
-msgstr ""
-"Jika anda inginkan, anda bisa membaca <a href=\"%(legal)s\" title=\"Legal "
-"Notices\">Peringatan Legal</a> dan <a href=\"%(privacy)s\" title=\"Privacy "
-"Policy\">Kebijakan Privasi</a>kami."
+msgid "If you like, you can read our <a href=\"%(legal)s\" title=\"Legal Notices\">Legal Notices</a> and <a href=\"%(privacy)s\" title=\"Privacy Policy\">Privacy Policy</a>."
+msgstr "Jika anda inginkan, anda bisa membaca <a href=\"%(legal)s\" title=\"Legal Notices\">Peringatan Legal</a> dan <a href=\"%(privacy)s\" title=\"Privacy Policy\">Kebijakan Privasi</a>kami."
 
 #: src/olympia/users/templates/users/register.html:52
 msgid "Display name"
 msgstr "Nama tampilan"
 
 #: src/olympia/users/templates/users/report_abuse.html:7
-msgid ""
-"Please describe why you are reporting this user, such as for spam or an "
-"inappropriate picture."
-msgstr ""
-"Jelaskan mengapa Anda melaporkan pengguna ini, misalnya spam atau gambar "
-"yang tidak pantas."
+msgid "Please describe why you are reporting this user, such as for spam or an inappropriate picture."
+msgstr "Jelaskan mengapa Anda melaporkan pengguna ini, misalnya spam atau gambar yang tidak pantas."
 
 #: src/olympia/users/templates/users/report_abuse_full.html:3
 msgid "Report user {0}"
@@ -15929,43 +12716,25 @@ msgstr "Pemesanan T-Shirt"
 msgid "Special Edition Add-on Creator T-shirt"
 msgstr "Kaus Edisi Khusus Kreator Pengaya"
 
-#: src/olympia/users/templates/users/t-shirt.html:14
-#: src/olympia/users/templates/users/t-shirt.html:120
+#: src/olympia/users/templates/users/t-shirt.html:14 src/olympia/users/templates/users/t-shirt.html:120
 msgid "Note:"
 msgstr "Catatan:"
 
 #: src/olympia/users/templates/users/t-shirt.html:15
-msgid ""
-"You have already submitted a request for a t-shirt. You may re-submit this "
-"form to update your information, but you will only receive one shirt."
-msgstr ""
-"Anda telah memasukkan permintaan untuk mendapatkan kaus. Anda dapat "
-"mengirimkan kembali formulir ini untuk memperbarui informasi, tapi anda "
-"hanya akan menerima satu kaus."
+msgid "You have already submitted a request for a t-shirt. You may re-submit this form to update your information, but you will only receive one shirt."
+msgstr "Anda telah memasukkan permintaan untuk mendapatkan kaus. Anda dapat mengirimkan kembali formulir ini untuk memperbarui informasi, tapi anda hanya akan menerima satu kaus."
 
 #: src/olympia/users/templates/users/t-shirt.html:26
-msgid ""
-"Thank you for helping to make Firefox the most extensible browser available!"
-msgstr ""
-"Terima kasih karena membantu menjadikan Mozilla peramban paling bisa "
-"dikembangkan!"
+msgid "Thank you for helping to make Firefox the most extensible browser available!"
+msgstr "Terima kasih karena membantu menjadikan Mozilla peramban paling bisa dikembangkan!"
 
 #: src/olympia/users/templates/users/t-shirt.html:33
-msgid ""
-"As a thank you gift, we'd like to send you a special-edition, community-"
-"designed t-shirt. To receive your shirt, please fill out the form below."
-msgstr ""
-"Sebagai tanda terima kasih, kami ingin mengirimkan kaus edisi khusus, yang "
-"dirancang komunitas. Untuk menerima kaus anda, silakan mengisi formulir di "
-"bawah ini."
+msgid "As a thank you gift, we'd like to send you a special-edition, community-designed t-shirt. To receive your shirt, please fill out the form below."
+msgstr "Sebagai tanda terima kasih, kami ingin mengirimkan kaus edisi khusus, yang dirancang komunitas. Untuk menerima kaus anda, silakan mengisi formulir di bawah ini."
 
 #: src/olympia/users/templates/users/t-shirt.html:41
-msgid ""
-"Your contact information will only be used by Mozilla to ship this special "
-"edition t-shirt."
-msgstr ""
-"Informasi kontak anda hanya akan digunakan Mozila untuk mengirimkan kaus "
-"edisi khusus ini."
+msgid "Your contact information will only be used by Mozilla to ship this special edition t-shirt."
+msgstr "Informasi kontak anda hanya akan digunakan Mozila untuk mengirimkan kaus edisi khusus ini."
 
 #: src/olympia/users/templates/users/t-shirt.html:60
 msgid "Mailing Address"
@@ -16021,23 +12790,15 @@ msgstr "Meminta Kaus"
 
 #: src/olympia/users/templates/users/t-shirt.html:137
 msgid ""
-"We're sorry, but in order to qualify for our special edition t-shirt, you "
-"must be an add-on developer with at least one listed add-on, one unlisted "
-"but signed add-on, or any number of background themes with a combined total "
-"of 10,000 average daily users."
+"We're sorry, but in order to qualify for our special edition t-shirt, you must be an add-on developer with at least one listed add-on, one unlisted but signed add-on, or any number of background "
+"themes with a combined total of 10,000 average daily users."
 msgstr ""
-"Kami mohon maaf, namun untuk bisa mendapatkan kaus khusus edisi terbatas "
-"kami, anda haruslah seorang pengembang dengan sekurangnya satu pengaya "
-"terdaftar, satu pengaya tidak terdaftar namun ditandatangani, atau berapapun"
-" tema latar dengan jumlah total pengguna rata-rata 10.000 per hari."
+"Kami mohon maaf, namun untuk bisa mendapatkan kaus khusus edisi terbatas kami, anda haruslah seorang pengembang dengan sekurangnya satu pengaya terdaftar, satu pengaya tidak terdaftar namun "
+"ditandatangani, atau berapapun tema latar dengan jumlah total pengguna rata-rata 10.000 per hari."
 
 #: src/olympia/users/templates/users/tougher_password.html:2
-msgid ""
-"For your account a password must contain at least 8 characters including "
-"letters and numbers."
-msgstr ""
-"Untuk akun anda, sebuah sandi harus terdiri dari sekurangnya 8 karakter "
-"termasuk huruf dan angka."
+msgid "For your account a password must contain at least 8 characters including letters and numbers."
+msgstr "Untuk akun anda, sebuah sandi harus terdiri dari sekurangnya 8 karakter termasuk huruf dan angka."
 
 #: src/olympia/users/templates/users/unsubscribe.html:2
 msgid "Unsubscribe"
@@ -16049,12 +12810,8 @@ msgstr "Anda sukses berhenti berlangganan!"
 
 #: src/olympia/users/templates/users/unsubscribe.html:10
 #, python-format
-msgid ""
-"The email address <strong>%(email)s</strong> will no longer get messages "
-"when:"
-msgstr ""
-"Alamat surel <strong>%(email)s</strong> tidak akan mendapatkan pesan lagi "
-"saat:"
+msgid "The email address <strong>%(email)s</strong> will no longer get messages when:"
+msgstr "Alamat surel <strong>%(email)s</strong> tidak akan mendapatkan pesan lagi saat:"
 
 #: src/olympia/users/templates/users/unsubscribe.html:20
 msgid "More Actions:"
@@ -16074,14 +12831,10 @@ msgstr "Anda tidak akan menghentikan langganan anda"
 
 #: src/olympia/users/templates/users/unsubscribe.html:30
 #, python-format
-msgid ""
-"Unfortunately, we weren't able to unsubscribe you.  The link you clicked is "
-"invalid. However, you can unsubscribe still unsubscribe on your <a "
-"href=\"%(edit_url)s\">edit profile page</a>."
+msgid "Unfortunately, we weren't able to unsubscribe you. The link you clicked is invalid. However, you can unsubscribe still unsubscribe on your <a href=\"%(edit_url)s\">edit profile page</a>."
 msgstr ""
-"Sayang sekali, kami tidak bisa menghentikan langganan anda.  Tautan yang "
-"anda klik sudah tidak berlaku. Namun demikian, anda bisa berhenti "
-"berlangganan di <a href=\"%(edit_url)s\">laman edit profil</a>."
+"Sayang sekali, kami tidak bisa menghentikan langganan anda.  Tautan yang anda klik sudah tidak berlaku. Namun demikian, anda bisa berhenti berlangganan di <a href=\"%(edit_url)s\">laman edit "
+"profil</a>."
 
 #: src/olympia/users/templates/users/vcard.html:2
 msgid "Developer Information"
@@ -16112,12 +12865,14 @@ msgstr "{0} pengaya"
 msgid "%(num)s theme"
 msgid_plural "%(num)s themes"
 msgstr[0] "%(num)s tema"
+msgstr[1] ""
 
 #: src/olympia/users/templates/users/vcard.html:62
 #, python-format
 msgid "%(num)s add-on"
 msgid_plural "%(num)s add-ons"
 msgstr[0] "%(num)s pengaya"
+msgstr[1] ""
 
 #: src/olympia/users/templates/users/vcard.html:75
 msgid "Average rating of developer's add-ons"
@@ -16132,15 +12887,15 @@ msgstr "%s Riwayat Versi"
 msgid "Version History with Changelogs"
 msgstr "Riwayat Versi dengan Log Perubahan"
 
-#: src/olympia/versions/models.py:314
+#: src/olympia/versions/models.py:313
 msgid "Add-on uses binary components."
 msgstr "Pengaya menggunakan komponen biner."
 
-#: src/olympia/versions/models.py:317
+#: src/olympia/versions/models.py:316
 msgid "Add-on has opted into strict compatibility checking."
 msgstr "Pengaya telah dimasukkan ke dalam pengecekan kecocokan yang ketat."
 
-#: src/olympia/versions/models.py:715
+#: src/olympia/versions/models.py:711
 msgid "{app} {min} and later"
 msgstr "{app} {min} dan kemudian"
 
@@ -16156,9 +12911,7 @@ msgstr "Dirilis {0}"
 #: src/olympia/versions/templates/versions/version.html:39
 #, python-format
 msgid "Source code released under <a target=\"_blank\" href=\"%(url)s\">%(name)s</a>"
-msgstr ""
-"Kode sumber dirilis di bawah <a target=\"_blank\" "
-"href=\"%(url)s\">%(name)s</a>"
+msgstr "Kode sumber dirilis di bawah <a target=\"_blank\" href=\"%(url)s\">%(name)s</a>"
 
 #: src/olympia/versions/templates/versions/version.html:44
 #, python-format
@@ -16169,8 +12922,8 @@ msgstr "Kode sumber dirilis di bawah <a href=\"%(url)s\">%(name)s</a>"
 msgid "View the source"
 msgstr "Tampilkan kode sumber"
 
-#. {0} is an add-on name.
 # {0} is the add-on name
+#. {0} is an add-on name.
 #: src/olympia/versions/templates/versions/version_list.html:26
 msgid "{0} Version History"
 msgstr "Riwayat Versi {0}"
@@ -16180,22 +12933,16 @@ msgstr "Riwayat Versi {0}"
 msgid "<b>{0}</b> version"
 msgid_plural "<b>{0}</b> versions"
 msgstr[0] "<b>{0}</b> versi"
+msgstr[1] ""
 
-#: src/olympia/versions/templates/versions/version_list.html:35
-#: src/olympia/versions/templates/versions/mobile/version_list.html:14
+#: src/olympia/versions/templates/versions/version_list.html:35 src/olympia/versions/templates/versions/mobile/version_list.html:14
 msgid "Be careful with old versions!"
 msgstr "Hati-hati dengan versi lawas!"
 
-#: src/olympia/versions/templates/versions/version_list.html:36
-#: src/olympia/versions/templates/versions/mobile/version_list.html:15
+#: src/olympia/versions/templates/versions/version_list.html:36 src/olympia/versions/templates/versions/mobile/version_list.html:15
 #, python-format
-msgid ""
-"These versions are displayed for reference and testing purposes. You should "
-"always use the <a href=\"%(url)s\">latest version</a> of an add-on."
-msgstr ""
-"Versi berikut ditampilkan sebagai referensi atau untuk keperluan pengujian. "
-"Anda sebaiknya selalu menggunakan <a href=\"%(url)s\">versi terbaru</a> "
-"pengaya."
+msgid "These versions are displayed for reference and testing purposes. You should always use the <a href=\"%(url)s\">latest version</a> of an add-on."
+msgstr "Versi berikut ditampilkan sebagai referensi atau untuk keperluan pengujian. Anda sebaiknya selalu menggunakan <a href=\"%(url)s\">versi terbaru</a> pengaya."
 
 #: src/olympia/versions/templates/versions/mobile/version.html:4
 msgid "Beta Version {0}"
@@ -16225,3 +12972,7 @@ msgstr "Mengirim surel ketika selesai"
 #: src/olympia/zadmin/forms.py:105
 msgid "Log emails instead of sending"
 msgstr "Mencatat surel alih-alih mengirim"
+
+#: src/olympia/zadmin/forms.py:215
+msgid "Deleted versions can`t be changed."
+msgstr ""

--- a/locale/id/LC_MESSAGES/djangojs.po
+++ b/locale/id/LC_MESSAGES/djangojs.po
@@ -3,129 +3,392 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2016-02-24 21:23+0000\n"
+"POT-Creation-Date: 2016-04-18 15:47+0000\n"
 "PO-Revision-Date: 2016-02-18 08:03+0000\n"
 "Last-Translator: alamanda <dian.ina@gmail.com>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
+"Language: \n"
 "MIME-Version: 1.0\n"
-"Content-Type: text/plain; charset=utf-8\n"
+"Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Generated-By: Babel 2.2.0\n"
 
-#: static/js/common/ratingwidget.js:31
+#: static/js/common-all.js:1426 static/js/impala-all.js:1511 static/js/zamboni/discovery-all.js:12598 static/js/zamboni/init.js:28 static/js/zamboni/mobile-all.js:14945
+msgid "This feature is temporarily disabled while we perform website maintenance. Please check back a little later."
+msgstr "Fitur ini sementara dinonaktifkan saat kita melakukan pemeliharaan situs. Periksa kembali nanti."
+
+#. L10n: {0} is an app name like Firefox.
+#: static/js/common-all.js:1837 static/js/impala-all.js:1922 static/js/zamboni/buttons.js:73 static/js/zamboni/discovery-all.js:13108
+msgid "Accept and Install"
+msgstr "Terima dan Pasang"
+
+#: static/js/common-all.js:1837 static/js/impala-all.js:1922 static/js/zamboni/buttons.js:73 static/js/zamboni/discovery-all.js:13108
+msgid "Add to {0}"
+msgstr "Tambahkan ke {0}"
+
+#: static/js/common-all.js:1842 static/js/impala-all.js:1927 static/js/zamboni/buttons.js:78 static/js/zamboni/discovery-all.js:13113
+msgid "Download Now"
+msgstr "Unduh Sekarang"
+
+#: static/js/common-all.js:1883 static/js/impala-all.js:1968 static/js/zamboni/buttons.js:119 static/js/zamboni/discovery-all.js:13154
+msgid "Add-on has not been updated to support default-to-compatible."
+msgstr "Pengaya belum diperbarui untuk mendukung kompatibel bawaan."
+
+#: static/js/common-all.js:1888 static/js/impala-all.js:1973 static/js/zamboni/buttons.js:124 static/js/zamboni/discovery-all.js:13159
+msgid "You need to be using Firefox 10.0 or higher."
+msgstr "Anda harus menggunakan Firefox 10.0 atau lebih baru."
+
+#: static/js/common-all.js:1900 static/js/impala-all.js:1985 static/js/zamboni/buttons.js:136 static/js/zamboni/discovery-all.js:13171
+msgid "Mozilla has marked this version as incompatible with your Firefox version."
+msgstr "Mozilla telah menandai versi ini tidak kompatibel dengan versi Firefox anda."
+
+#. L10n: {0} is an platform like Windows or Linux.
+#: static/js/common-all.js:1981 static/js/impala-all.js:2066 static/js/zamboni/buttons.js:217 static/js/zamboni/discovery-all.js:13252
+msgid "Install for {0} anyway"
+msgstr "Pasang {0} saja"
+
+#: static/js/common-all.js:1981 static/js/impala-all.js:2066 static/js/zamboni/buttons.js:217 static/js/zamboni/discovery-all.js:13252
+msgid "Download for {0} anyway"
+msgstr "Unduh {0} saja"
+
+#: static/js/common-all.js:2038 static/js/impala-all.js:2123 static/js/zamboni/buttons.js:274 static/js/zamboni/discovery-all.js:13309
+msgid "Not available for your platform"
+msgstr "Tidak tersedia untuk platform Anda"
+
+#. L10n: {0} is an app name, {1} is the app version.
+#: static/js/common-all.js:2049 static/js/common-all.js:2086 static/js/impala-all.js:2134 static/js/impala-all.js:2171 static/js/zamboni/buttons.js:286 static/js/zamboni/buttons.js:324
+#: static/js/zamboni/discovery-all.js:13320 static/js/zamboni/discovery-all.js:13357
+msgid "Not available for {0} {1}"
+msgstr "{0} {1} tidak tersedia"
+
+#: static/js/common-all.js:2112 static/js/impala-all.js:2197 static/js/zamboni/buttons.js:351 static/js/zamboni/discovery-all.js:13383
+msgid "Works with {app} {min} - {max}"
+msgstr "Bekerja dengan {app} {min} - {max}"
+
+#: static/js/common-all.js:2114 static/js/impala-all.js:2199 static/js/zamboni/buttons.js:353 static/js/zamboni/discovery-all.js:13385
+msgid "View other versions"
+msgstr "Lihat versi lainnya"
+
+#: static/js/common-all.js:2162 static/js/impala-all.js:2247 static/js/zamboni/buttons.js:401 static/js/zamboni/discovery-all.js:13433
+msgid "Only with Firefox — Get Firefox Now!"
+msgstr "Hanya dengan Firefox — Dapatkan Firefox Sekarang!"
+
+#: static/js/common-all.js:2278 static/js/impala-all.js:2363 static/js/zamboni/buttons.js:517 static/js/zamboni/discovery-all.js:13549 static/js/zamboni/mobile-all.js:15177
+#: static/js/zamboni/mobile/buttons.js:43
+msgid "Sorry, you need a Mozilla-based browser (such as Firefox) to install a search plugin."
+msgstr "Maaf, Anda membutuhkan peramban berbasis Mozilla (seperti Firefox) untuk memasang plugin pencari."
+
+#: static/js/common-all.js:9088 static/js/impala-all.js:9649 static/js/zamboni/global.js:410
+msgid "Loading..."
+msgstr "Memuat..."
+
+#. L10n: {0} is the number of characters left.
+#: static/js/common-all.js:9152 static/js/impala-all.js:9713 static/js/zamboni/global.js:474
+msgid "<b>{0}</b> character left."
+msgid_plural "<b>{0}</b> characters left."
+msgstr[0] "Sisa <b>{0}</b> karakter."
+msgstr[1] ""
+
+#: static/js/common-all.js:9589 static/js/common-min.js:6 static/js/impala-all.js:10052 static/js/impala-min.js:6 static/js/common/ratingwidget.js:31 static/js/zamboni/mobile-all.js:16123
+#: static/js/zamboni/mobile-min.js:6
 msgid "{0} star"
 msgid_plural "{0} stars"
 msgstr[0] "{0} bintang"
+msgstr[1] ""
 
-#: static/js/common/upload-addon.js:41 static/js/common/upload-image.js:128
+#: static/js/common-all.js:9676 static/js/common-min.js:6 static/js/impala-all.js:10139 static/js/impala-min.js:6 static/js/zamboni/l10n.js:45
+msgid "Remove this localization"
+msgstr "Hapus lokalisasi ini"
+
+#: static/js/common-all.js:10193 static/js/common-min.js:6 static/js/impala-all.js:10674 static/js/impala-min.js:6 static/js/zamboni/discovery-all.js:13678
+msgid "close"
+msgstr ""
+
+#: static/js/common-all.js:10860 static/js/common-min.js:6 static/js/impala-all.js:11481 static/js/impala-min.js:6 static/js/impala/reviews.js:23 static/js/zamboni/reviews.js:18
+msgid "Flagged for review"
+msgstr "Ditandai untuk ulasan"
+
+#: static/js/common-all.js:10876 static/js/common-min.js:6 static/js/impala-all.js:11498 static/js/impala-min.js:6 static/js/impala/reviews.js:40 static/js/zamboni/reviews.js:34
+msgid "Your input is required"
+msgstr "Dibutuhkan masukan Anda"
+
+#: static/js/common-all.js:10945 static/js/common-min.js:6 static/js/impala-all.js:11610 static/js/impala-min.js:7 static/js/impala/reviews.js:152 static/js/zamboni/reviews.js:103
+msgid "Marked for deletion"
+msgstr "Ditandai untuk dihapus"
+
+#: static/js/common-all.js:11573 static/js/common-min.js:7 static/js/impala-all.js:13809 static/js/impala-min.js:8 static/js/zamboni/collections.js:229
+msgid "Adding to Favorites&hellip;"
+msgstr "Tambahkan ke Favorit&hellip;"
+
+#: static/js/common-all.js:11576 static/js/common-min.js:7 static/js/impala-all.js:13812 static/js/impala-min.js:8 static/js/zamboni/collections.js:232
+msgid "Removing Favorite&hellip;"
+msgstr "Hapus Favorit&hellip;"
+
+#: static/js/common-all.js:11579 static/js/common-min.js:7 static/js/impala-all.js:13815 static/js/impala-min.js:8 static/js/zamboni/collections.js:235
+msgid "Add to Favorites"
+msgstr "Tambah ke Favorit"
+
+#: static/js/common-all.js:11582 static/js/common-min.js:7 static/js/impala-all.js:13818 static/js/impala-min.js:8 static/js/zamboni/collections.js:238
+msgid "Remove from Favorites"
+msgstr "Hapus dari Favorit"
+
+#: static/js/common-all.js:11647 static/js/common-min.js:7 static/js/impala-all.js:13883 static/js/impala-min.js:8 static/js/zamboni/collections.js:303
+msgid "Pending"
+msgstr "Tertunda"
+
+#: static/js/common-all.js:11648 static/js/common-min.js:7 static/js/impala-all.js:13884 static/js/impala-min.js:8 static/js/zamboni/collections.js:304
+msgid "Add a comment"
+msgstr "Tambahkan komentar"
+
+#: static/js/common-all.js:11648 static/js/common-min.js:7 static/js/impala-all.js:13884 static/js/impala-min.js:8 static/js/zamboni/collections.js:304
+msgid "Comment"
+msgstr "Komentar"
+
+#: static/js/common-all.js:11649 static/js/common-min.js:7 static/js/impala-all.js:13885 static/js/impala-min.js:8 static/js/zamboni/collections.js:305
+msgid "Remove this add-on from the collection"
+msgstr "Hapus pengaya ini dari koleksi"
+
+#: static/js/common-all.js:11649 static/js/common-all.js:11678 static/js/common-min.js:7 static/js/impala-all.js:13885 static/js/impala-all.js:13914 static/js/impala-min.js:8
+#: static/js/zamboni/collections.js:305 static/js/zamboni/collections.js:334
+msgid "Remove"
+msgstr "Hapus"
+
+#: static/js/common-all.js:11678 static/js/common-min.js:7 static/js/impala-all.js:13914 static/js/impala-min.js:8 static/js/zamboni/collections.js:334
+msgid "Remove this user as a contributor"
+msgstr "Hapus pengguna ini sebagai kontributor"
+
+#: static/js/common-all.js:11690 static/js/common-min.js:7 static/js/impala-all.js:13926 static/js/impala-min.js:8 static/js/zamboni/collections.js:346
+msgid "An email address is required."
+msgstr "Dibutuhkan alamat email."
+
+#: static/js/common-all.js:11708 static/js/common-min.js:7 static/js/impala-all.js:13944 static/js/impala-min.js:8 static/js/zamboni/collections.js:364
+msgid "You cannot add yourself as a contributor."
+msgstr "Anda tidak dapat menambahkan diri sendiri sebagai kontributor."
+
+#: static/js/common-all.js:11710 static/js/common-min.js:7 static/js/impala-all.js:13946 static/js/impala-min.js:8 static/js/zamboni/collections.js:366
+msgid "You have already added that user."
+msgstr "Anda telah menambahkan pengguna tersebut."
+
+#: static/js/common-all.js:11917 static/js/common-min.js:7 static/js/impala-all.js:14153 static/js/impala-min.js:8 static/js/zamboni/collections.js:573
+msgid "Add to favorites"
+msgstr "Tambah ke favorit"
+
+#: static/js/common-all.js:11921 static/js/common-min.js:7 static/js/impala-all.js:14157 static/js/impala-min.js:8 static/js/zamboni/collections.js:577
+msgid "Remove from favorites"
+msgstr "Hapus dari favorit"
+
+#: static/js/common-all.js:11939 static/js/common-min.js:7 static/js/impala-all.js:14175 static/js/impala-all.js:14233 static/js/impala-min.js:8 static/js/impala/collections.js:10
+#: static/js/zamboni/collections.js:595
+msgid "Follow this Collection"
+msgstr "Ikuti Koleksi"
+
+#: static/js/common-all.js:11948 static/js/common-min.js:7 static/js/impala-all.js:14184 static/js/impala-min.js:8 static/js/zamboni/collections.js:604
+msgid "Stop following"
+msgstr "Berhenti mengikuti"
+
+#: static/js/common-all.js:12096 static/js/common-min.js:7 static/js/zamboni/password-strength.js:20
+msgid "Password strength:"
+msgstr "Kekuatan kata sandi:"
+
+#: static/js/common-all.js:12102 static/js/common-min.js:7 static/js/zamboni/password-strength.js:26
+msgid "At least {0} character left."
+msgid_plural "At least {0} characters left."
+msgstr[0] "Paling sedikit sisa {0} karakter."
+msgstr[1] ""
+
+#: static/js/common-all.js:12286 static/js/common-min.js:7 static/js/impala-all.js:14632 static/js/impala-min.js:8 static/js/impala/suggestions.js:39
+msgid "Search themes for <b>{0}</b>"
+msgstr "Cari tema untuk <b>{0}</b>"
+
+#: static/js/common-all.js:12288 static/js/common-min.js:7 static/js/impala-all.js:14634 static/js/impala-min.js:8 static/js/impala/suggestions.js:41
+msgid "Search apps for <b>{0}</b>"
+msgstr "Cari aplikasi untuk <b>{0}</b>"
+
+#: static/js/common-all.js:12290 static/js/common-min.js:7 static/js/impala-all.js:14636 static/js/impala-min.js:8 static/js/impala/suggestions.js:43
+msgid "Search add-ons for <b>{0}</b>"
+msgstr "Cari pengaya untuk <b>{0}</b>"
+
+#: static/js/common-all.js:12521 static/js/common-min.js:7 static/js/impala-all.js:14867 static/js/impala-min.js:8 static/js/impala/site_suggestions.js:46
+msgid "Category"
+msgstr "Kategori"
+
+#. L10n: {0} is an app name.
+#: static/js/impala-all.js:11632 static/js/impala-min.js:7 static/js/impala/listing.js:11 static/js/zamboni/themes.js:13
+msgid "This theme is incompatible with your version of {0}"
+msgstr "Tema ini tidak kompatibel dengan versi {0} Anda"
+
+#: static/js/impala-all.js:12146 static/js/impala-all.js:14331 static/js/impala-min.js:7 static/js/impala-min.js:8 static/js/common/upload-image.js:97 static/js/impala/users.js:51
+#: static/js/zamboni/devhub-all.js:894 static/js/zamboni/devhub-min.js:1
+msgid "Images must be either PNG or JPG."
+msgstr "Gambar harus dalam PNG atau JPG."
+
+#: static/js/impala-all.js:12150 static/js/impala-min.js:7 static/js/common/upload-image.js:101 static/js/zamboni/devhub-all.js:898 static/js/zamboni/devhub-min.js:1
+msgid "Videos must be in WebM."
+msgstr "Video harus dalam WebM."
+
+#: static/js/impala-all.js:12177 static/js/impala-min.js:7 static/js/common/upload-addon.js:41 static/js/common/upload-image.js:128 static/js/zamboni/devhub-all.js:272
+#: static/js/zamboni/devhub-all.js:925 static/js/zamboni/devhub-min.js:1
 msgid "There was a problem contacting the server."
 msgstr "Ada masalah menghubungi server."
 
-#: static/js/common/upload-addon.js:69
+#: static/js/impala-all.js:13298 static/js/impala-min.js:7 static/js/impala/persona_creation.js:60
+msgid "All Rights Reserved"
+msgstr "Dilindungi Hak Cipta"
+
+#: static/js/impala-all.js:13302 static/js/impala-min.js:7 static/js/impala/persona_creation.js:64
+msgid "Creative Commons Attribution 3.0"
+msgstr "Creative Commons Attribution 3.0"
+
+#: static/js/impala-all.js:13307 static/js/impala-min.js:7 static/js/impala/persona_creation.js:69
+msgid "Creative Commons Attribution-NonCommercial 3.0"
+msgstr "Creative Commons Attribution-NonCommercial 3.0"
+
+#: static/js/impala-all.js:13312 static/js/impala-min.js:7 static/js/impala/persona_creation.js:74
+msgid "Creative Commons Attribution-NonCommercial-NoDerivs 3.0"
+msgstr "Creative Commons Attribution-NonCommercial-NoDerivs 3.0"
+
+#: static/js/impala-all.js:13317 static/js/impala-min.js:7 static/js/impala/persona_creation.js:79
+msgid "Creative Commons Attribution-NonCommercial-Share Alike 3.0"
+msgstr "Creative Commons Attribution-NonCommercial-Share Alike 3.0"
+
+#: static/js/impala-all.js:13322 static/js/impala-min.js:7 static/js/impala/persona_creation.js:84
+msgid "Creative Commons Attribution-NoDerivs 3.0"
+msgstr "Creative Commons Attribution-NoDerivs 3.0"
+
+#: static/js/impala-all.js:13327 static/js/impala-min.js:7 static/js/impala/persona_creation.js:89
+msgid "Creative Commons Attribution-ShareAlike 3.0"
+msgstr "Creative Commons Attribution-ShareAlike 3.0"
+
+#: static/js/impala-all.js:13530 static/js/impala-min.js:7 static/js/impala/persona_creation.js:292
+msgid "Your Theme's Name"
+msgstr "Nama tema Anda"
+
+#: static/js/impala-all.js:14242 static/js/impala-min.js:8 static/js/impala/collections.js:19
+msgid "Stop Following"
+msgstr "Berhenti mengikuti"
+
+#: static/js/impala-all.js:14243 static/js/impala-min.js:8 static/js/impala/collections.js:20
+msgid "Following"
+msgstr "Mengikuti"
+
+#: static/js/impala-all.js:14313 static/js/impala-min.js:8 static/js/impala/users.js:33
+msgid "use original"
+msgstr "gunakan yang asli"
+
+#: static/js/impala-all.js:14523 static/js/impala-min.js:8 static/js/impala/search.js:114
+msgid "Updating results&hellip;"
+msgstr "Memperbarui hasil &hellip;"
+
+#: static/js/common/upload-addon.js:69 static/js/zamboni/devhub-all.js:300 static/js/zamboni/devhub-min.js:1
 msgid "Select a file..."
 msgstr "Pilih berkas..."
 
-#: static/js/common/upload-addon.js:70
+#: static/js/common/upload-addon.js:70 static/js/zamboni/devhub-all.js:301 static/js/zamboni/devhub-min.js:1
 msgid "Your add-on should end with .xpi, .jar or .xml"
 msgstr "Pengaya Anda harus berakhir dengan .xpi, .jar atau .xml"
 
 #. L10n: {0} is the percent of the file that has been uploaded.
-#: static/js/common/upload-addon.js:104
+#: static/js/common/upload-addon.js:104 static/js/zamboni/devhub-all.js:335 static/js/zamboni/devhub-min.js:1
 #, python-format
 msgid "{0}% complete"
 msgstr "{0}% komplet"
 
 #. L10n: "{bytes uploaded} of {total filesize}".
-#: static/js/common/upload-addon.js:107
+#: static/js/common/upload-addon.js:107 static/js/zamboni/devhub-all.js:338 static/js/zamboni/devhub-min.js:1
 msgid "{0} of {1}"
 msgstr "{0} dari {1}"
 
-#: static/js/common/upload-addon.js:140
+#: static/js/common/upload-addon.js:140 static/js/zamboni/devhub-all.js:371 static/js/zamboni/devhub-min.js:1
 msgid "Cancel"
 msgstr "Batal"
 
-#: static/js/common/upload-addon.js:162
+#: static/js/common/upload-addon.js:162 static/js/zamboni/devhub-all.js:393 static/js/zamboni/devhub-min.js:1
 msgid "Uploading {0}"
 msgstr "Mengunggah {0}"
 
-#: static/js/common/upload-addon.js:189
+#: static/js/common/upload-addon.js:189 static/js/zamboni/devhub-all.js:420 static/js/zamboni/devhub-min.js:1
 msgid "Error with {0}"
 msgstr "Kesalahan dengan {0}"
 
-#: static/js/common/upload-addon.js:194
+#: static/js/common/upload-addon.js:194 static/js/zamboni/devhub-all.js:425 static/js/zamboni/devhub-min.js:1
 msgid "Your add-on failed validation with {0} error."
 msgid_plural "Your add-on failed validation with {0} errors."
 msgstr[0] "Pengaya Anda gagal validasi dengan {0} kesalahan."
+msgstr[1] ""
 
-#: static/js/common/upload-addon.js:208
+#: static/js/common/upload-addon.js:208 static/js/zamboni/devhub-all.js:439 static/js/zamboni/devhub-min.js:1
 msgid "&hellip;and {0} more"
 msgid_plural "&hellip;and {0} more"
 msgstr[0] "&hellip;dan {0} lagi"
+msgstr[1] ""
 
-#: static/js/common/upload-addon.js:222 static/js/common/upload-addon.js:512
+#: static/js/common/upload-addon.js:222 static/js/common/upload-addon.js:497 static/js/zamboni/devhub-all.js:453 static/js/zamboni/devhub-all.js:743 static/js/zamboni/devhub-min.js:1
 msgid "See full validation report"
 msgstr "Lihat laporan validasi lengkap"
 
-#: static/js/common/upload-addon.js:234
+#: static/js/common/upload-addon.js:234 static/js/zamboni/devhub-all.js:465 static/js/zamboni/devhub-min.js:1
 msgid "Validating {0}"
 msgstr "Mengvalidasi {0}"
 
 #. L10n: first argument is an HTTP status code
-#: static/js/common/upload-addon.js:273
+#: static/js/common/upload-addon.js:273 static/js/zamboni/devhub-all.js:504 static/js/zamboni/devhub-min.js:1
 msgid "Received an empty response from the server; status: {0}"
 msgstr "Menerima balasan kosong dari server; status: {0}"
 
-#: static/js/common/upload-addon.js:373
+#: static/js/common/upload-addon.js:370 static/js/zamboni/devhub-all.js:604 static/js/zamboni/devhub-min.js:1
 msgid "Unexpected server error while validating."
 msgstr "Kesalahan server tidak terduga saat mengesahkan."
 
-#: static/js/common/upload-addon.js:412
+#: static/js/common/upload-addon.js:409 static/js/zamboni/devhub-all.js:643 static/js/zamboni/devhub-min.js:1
 msgid "Finished validating {0}"
 msgstr "Selesai validasi {0}"
 
-#: static/js/common/upload-addon.js:418
+#: static/js/common/upload-addon.js:415 static/js/zamboni/devhub-all.js:649 static/js/zamboni/devhub-min.js:1
 msgid "Your add-on validation timed out, it will be manually reviewed."
 msgstr "Waktu validasi pengaya Anda habis, akan ditinjau secara manual."
 
-#: static/js/common/upload-addon.js:421
+#: static/js/common/upload-addon.js:418 static/js/zamboni/devhub-all.js:652 static/js/zamboni/devhub-min.js:1
 msgid "Your add-on was validated with no errors and {0} warning."
 msgid_plural "Your add-on was validated with no errors and {0} warnings."
 msgstr[0] "Pengaya Anda telah divalidasi dengan tanpa kesalahan dan {0} peringatan."
+msgstr[1] ""
 
-#: static/js/common/upload-addon.js:426
+#: static/js/common/upload-addon.js:423 static/js/zamboni/devhub-all.js:657 static/js/zamboni/devhub-min.js:1
 msgid "Your add-on was validated with no errors and {0} message."
 msgid_plural "Your add-on was validated with no errors and {0} messages."
 msgstr[0] "Pengaya Anda telah divalidasi dengan tanpa kesalahan dan {0} pesan."
+msgstr[1] ""
 
-#: static/js/common/upload-addon.js:431
+#: static/js/common/upload-addon.js:428 static/js/zamboni/devhub-all.js:662 static/js/zamboni/devhub-min.js:1
 msgid "Your add-on was validated with no errors or warnings."
 msgstr "Pengaya Anda telah divalidasi dengan tanpa kesalahan ataupun peringatan."
 
-#: static/js/common/upload-addon.js:446
+#: static/js/common/upload-addon.js:443 static/js/zamboni/devhub-all.js:677 static/js/zamboni/devhub-min.js:1
 msgid "Your submission will be automatically signed."
 msgstr "Pengiriman Anda akan ditandatangani secara otomatis."
 
-#: static/js/common/upload-addon.js:465
+#: static/js/common/upload-addon.js:450 static/js/zamboni/devhub-all.js:696 static/js/zamboni/devhub-min.js:1
 msgid "Include detailed version notes (this can be done in the next step)."
 msgstr "Masukkan catatan versi yang rinci (dapat dilakukan di step berikutnya)."
 
-#: static/js/common/upload-addon.js:466
+#: static/js/common/upload-addon.js:451 static/js/zamboni/devhub-all.js:697 static/js/zamboni/devhub-min.js:1
 msgid "If your add-on requires an account to a website in order to be fully tested, include a test username and password in the Notes to Reviewer (this can be done in the next step)."
-msgstr "Jika pengaya Anda membutuhkan akun untuk situs web untuk diuji secara penuh, masukkan nama pengguna dan kata sandi cobaan di dalam Catatan untuk Pengulas (dapat dilakukan di langkah berikutnya)."
+msgstr ""
+"Jika pengaya Anda membutuhkan akun untuk situs web untuk diuji secara penuh, masukkan nama pengguna dan kata sandi cobaan di dalam Catatan untuk Pengulas (dapat dilakukan di langkah berikutnya)."
 
-#: static/js/common/upload-addon.js:467
+#: static/js/common/upload-addon.js:452 static/js/zamboni/devhub-all.js:698 static/js/zamboni/devhub-min.js:1
 msgid "If your add-on is intended for a limited audience you should choose Preliminary Review instead of Full Review."
 msgstr "Jika pengaya Anda ditujukan untuk khalayak terbatas Anda seharusnya memilih Ulasan Lebih Dulu bukan Ulasan Penuh."
 
-#: static/js/common/upload-addon.js:480
+#: static/js/common/upload-addon.js:465 static/js/zamboni/devhub-all.js:711 static/js/zamboni/devhub-min.js:1
 msgid "Add-on submission checklist"
 msgstr "Daftar cek pendaftaran pengaya"
 
-#: static/js/common/upload-addon.js:481
+#: static/js/common/upload-addon.js:466 static/js/zamboni/devhub-all.js:712 static/js/zamboni/devhub-min.js:1
 msgid "Please verify the following points before finalizing your submission. This will minimize delays or misunderstanding during the review process:"
 msgstr "Tolong verifikasi poin berikut sebelum benar-benar mengirimkan. Ini mengurangi penundaan atau salah pengertian dalam proses ulasan:"
 
-#: static/js/common/upload-addon.js:483
+#: static/js/common/upload-addon.js:468 static/js/zamboni/devhub-all.js:714 static/js/zamboni/devhub-min.js:1
 msgid ""
 "Compiled binaries, as well as minified or obfuscated scripts (excluding known libraries) need to have their sources submitted separately for review. Make sure that you use the source code upload "
 "field to avoid having your submission rejected."
@@ -133,1071 +396,844 @@ msgstr ""
 "File Biner Hasil Kompilasi, dan juga skrip yang dikecilkan atau dikaburkan (tidak termasuk pustaka dikenal) , sumbernya harus dikirim terpisah untuk diulas. Pastikan anda menggunakan bidang "
 "pengunggah kode sumber untuk menghindari penolakan pengiriman Anda."
 
-#: static/js/common/upload-addon.js:501
+#: static/js/common/upload-addon.js:486 static/js/zamboni/devhub-all.js:732 static/js/zamboni/devhub-min.js:1
 msgid "The validation process found these issues that can lead to rejections:"
 msgstr "Proses pengsahan menemukan masalah yang dapat mengakibatkan penolakan:"
 
-#: static/js/common/upload-addon.js:518
+#: static/js/common/upload-addon.js:503 static/js/zamboni/devhub-all.js:749 static/js/zamboni/devhub-min.js:1
 msgid "If you are unfamiliar with the add-ons review process, you can read about it here."
 msgstr "Jika Anda tidak familiar dengan proses ulasan pengaya, Anda dapat membacanya disini."
 
-#: static/js/common/upload-addon.js:555
+#: static/js/common/upload-addon.js:540 static/js/zamboni/devhub-all.js:786 static/js/zamboni/devhub-min.js:1
 msgid "Sorry, no supported platform has been found."
 msgstr "Maaf, tidak ditemukan platform yang didukung."
 
-#: static/js/common/upload-base.js:57
+#: static/js/common/upload-base.js:57 static/js/zamboni/devhub-all.js:187 static/js/zamboni/devhub-min.js:1
 msgid "The filetype you uploaded isn't recognized."
 msgstr "Tipe berkas yang Anda unggah tidak dikenal."
 
-#: static/js/common/upload-base.js:79
+#: static/js/common/upload-base.js:79 static/js/zamboni/devhub-all.js:209 static/js/zamboni/devhub-min.js:1
 msgid "You cancelled the upload."
 msgstr "Anda membatalkan unggah."
 
-#: static/js/common/upload-image.js:97 static/js/impala/users.js:51
-msgid "Images must be either PNG or JPG."
-msgstr "Gambar harus dalam PNG atau JPG."
-
-#: static/js/common/upload-image.js:101
-msgid "Videos must be in WebM."
-msgstr "Video harus dalam WebM."
-
-#: static/js/impala/collections.js:10 static/js/zamboni/collections.js:595
-msgid "Follow this Collection"
-msgstr "Ikuti Koleksi"
-
-#: static/js/impala/collections.js:19
-msgid "Stop Following"
-msgstr "Berhenti mengikuti"
-
-#: static/js/impala/collections.js:20
-msgid "Following"
-msgstr "Mengikuti"
-
-#. L10n: {0} is an app name.
-#: static/js/impala/listing.js:11 static/js/zamboni/themes.js:13
-msgid "This theme is incompatible with your version of {0}"
-msgstr "Tema ini tidak kompatibel dengan versi {0} Anda"
-
-#: static/js/impala/persona_creation.js:60
-msgid "All Rights Reserved"
-msgstr "Dilindungi Hak Cipta"
-
-#: static/js/impala/persona_creation.js:64
-msgid "Creative Commons Attribution 3.0"
-msgstr "Creative Commons Attribution 3.0"
-
-#: static/js/impala/persona_creation.js:69
-msgid "Creative Commons Attribution-NonCommercial 3.0"
-msgstr "Creative Commons Attribution-NonCommercial 3.0"
-
-#: static/js/impala/persona_creation.js:74
-msgid "Creative Commons Attribution-NonCommercial-NoDerivs 3.0"
-msgstr "Creative Commons Attribution-NonCommercial-NoDerivs 3.0"
-
-#: static/js/impala/persona_creation.js:79
-msgid "Creative Commons Attribution-NonCommercial-Share Alike 3.0"
-msgstr "Creative Commons Attribution-NonCommercial-Share Alike 3.0"
-
-#: static/js/impala/persona_creation.js:84
-msgid "Creative Commons Attribution-NoDerivs 3.0"
-msgstr "Creative Commons Attribution-NoDerivs 3.0"
-
-#: static/js/impala/persona_creation.js:89
-msgid "Creative Commons Attribution-ShareAlike 3.0"
-msgstr "Creative Commons Attribution-ShareAlike 3.0"
-
-#: static/js/impala/persona_creation.js:292
-msgid "Your Theme's Name"
-msgstr "Nama tema Anda"
-
-#: static/js/impala/reviews.js:23 static/js/zamboni/reviews.js:18
-msgid "Flagged for review"
-msgstr "Ditandai untuk ulasan"
-
-#: static/js/impala/reviews.js:40 static/js/zamboni/reviews.js:34
-msgid "Your input is required"
-msgstr "Dibutuhkan masukan Anda"
-
-#: static/js/impala/reviews.js:152 static/js/zamboni/reviews.js:103
-msgid "Marked for deletion"
-msgstr "Ditandai untuk dihapus"
-
-#: static/js/impala/search.js:114
-msgid "Updating results&hellip;"
-msgstr "Memperbarui hasil &hellip;"
-
-#: static/js/impala/site_suggestions.js:46
-msgid "Category"
-msgstr "Kategori"
-
-#: static/js/impala/suggestions.js:39
-msgid "Search themes for <b>{0}</b>"
-msgstr "Cari tema untuk <b>{0}</b>"
-
-#: static/js/impala/suggestions.js:41
-msgid "Search apps for <b>{0}</b>"
-msgstr "Cari aplikasi untuk <b>{0}</b>"
-
-#: static/js/impala/suggestions.js:43
-msgid "Search add-ons for <b>{0}</b>"
-msgstr "Cari pengaya untuk <b>{0}</b>"
-
-#: static/js/impala/users.js:33
-msgid "use original"
-msgstr "gunakan yang asli"
-
-#: static/js/impala/stats/chart.js:267
+#: static/js/impala/stats/chart.js:267 static/js/zamboni/stats-all.js:16898 static/js/zamboni/stats-min.js:5
 msgid "Week of {0}"
 msgstr "Minggu ke {0}"
 
-#: static/js/impala/stats/chart.js:269
+#: static/js/impala/stats/chart.js:269 static/js/zamboni/stats-all.js:16900 static/js/zamboni/stats-min.js:5
 msgid " downloads"
-msgstr "  unduhan"
+msgstr ""
 
-#: static/js/impala/stats/chart.js:270
+#: static/js/impala/stats/chart.js:270 static/js/zamboni/stats-all.js:16901 static/js/zamboni/stats-min.js:5
 msgid "{0} users"
 msgstr "{0} pengguna"
 
-#: static/js/impala/stats/chart.js:271
+#: static/js/impala/stats/chart.js:271 static/js/zamboni/stats-all.js:16902 static/js/zamboni/stats-min.js:5
 msgid "{0} add-ons"
 msgstr "{0} pengaya"
 
-#: static/js/impala/stats/chart.js:272
+#: static/js/impala/stats/chart.js:272 static/js/zamboni/stats-all.js:16903 static/js/zamboni/stats-min.js:5
 msgid "{0} collections"
 msgstr "{0} koleksi"
 
-#: static/js/impala/stats/chart.js:273
+#: static/js/impala/stats/chart.js:273 static/js/zamboni/stats-all.js:16904 static/js/zamboni/stats-min.js:5
 msgid "{0} reviews"
 msgstr "{0} ulasan"
 
-#: static/js/impala/stats/chart.js:275
+#: static/js/impala/stats/chart.js:275 static/js/zamboni/stats-all.js:16906 static/js/zamboni/stats-min.js:5
 msgid "{0} sales"
 msgstr "{0} penjualan"
 
-#: static/js/impala/stats/chart.js:276
+#: static/js/impala/stats/chart.js:276 static/js/zamboni/stats-all.js:16907 static/js/zamboni/stats-min.js:5
 msgid "{0} refunds"
 msgstr "{0} pembayaran kembali"
 
-#: static/js/impala/stats/chart.js:277
+#: static/js/impala/stats/chart.js:277 static/js/zamboni/stats-all.js:16908 static/js/zamboni/stats-min.js:5
 msgid "{0} installs"
 msgstr "{0} pemasangan"
 
-#: static/js/impala/stats/chart.js:369 static/js/impala/stats/csv_keys.js:3 static/js/impala/stats/csv_keys.js:109
+#: static/js/impala/stats/chart.js:369 static/js/impala/stats/csv_keys.js:3 static/js/impala/stats/csv_keys.js:109 static/js/zamboni/stats-all.js:15284 static/js/zamboni/stats-all.js:15390
+#: static/js/zamboni/stats-all.js:17000 static/js/zamboni/stats-min.js:4 static/js/zamboni/stats-min.js:5
 msgid "Downloads"
 msgstr "Unggahan"
 
-#: static/js/impala/stats/chart.js:379 static/js/impala/stats/csv_keys.js:6 static/js/impala/stats/csv_keys.js:110
+#: static/js/impala/stats/chart.js:379 static/js/impala/stats/csv_keys.js:6 static/js/impala/stats/csv_keys.js:110 static/js/zamboni/stats-all.js:15287 static/js/zamboni/stats-all.js:15391
+#: static/js/zamboni/stats-all.js:17010 static/js/zamboni/stats-min.js:4 static/js/zamboni/stats-min.js:5
 msgid "Daily Users"
 msgstr "Pengguna harian"
 
-#: static/js/impala/stats/chart.js:410
+#: static/js/impala/stats/chart.js:410 static/js/zamboni/stats-all.js:17041 static/js/zamboni/stats-min.js:5
 msgid "Amount, in USD"
 msgstr "Nilai, dalam USD"
 
-#: static/js/impala/stats/chart.js:421 static/js/impala/stats/csv_keys.js:104
+#: static/js/impala/stats/chart.js:421 static/js/impala/stats/csv_keys.js:104 static/js/zamboni/stats-all.js:15385 static/js/zamboni/stats-all.js:17052 static/js/zamboni/stats-min.js:5
 msgid "Number of Contributions"
 msgstr "Jumlah Kontribusi"
 
-#: static/js/impala/stats/chart.js:447
+#: static/js/impala/stats/chart.js:447 static/js/zamboni/stats-all.js:17078 static/js/zamboni/stats-min.js:5
 msgid "More Info..."
 msgstr "Info Lebih Lanjut..."
 
 #. L10n: {0} is an ISO-formatted date.
-#: static/js/impala/stats/chart.js:451
+#: static/js/impala/stats/chart.js:451 static/js/zamboni/stats-all.js:17082 static/js/zamboni/stats-min.js:5
 msgid "Details for {0}"
 msgstr "Detail untuk {0}"
 
-#: static/js/impala/stats/csv_keys.js:9
+#: static/js/impala/stats/csv_keys.js:9 static/js/zamboni/stats-all.js:15290 static/js/zamboni/stats-min.js:4
 msgid "Collections Created"
 msgstr "Koleksi Dibuat"
 
-#: static/js/impala/stats/csv_keys.js:12
+#: static/js/impala/stats/csv_keys.js:12 static/js/zamboni/stats-all.js:15293 static/js/zamboni/stats-min.js:4
 msgid "Add-ons in Use"
 msgstr "Pengaya yang Dipakai"
 
-#: static/js/impala/stats/csv_keys.js:15
+#: static/js/impala/stats/csv_keys.js:15 static/js/zamboni/stats-all.js:15296 static/js/zamboni/stats-min.js:4
 msgid "Add-ons Created"
 msgstr "Pengaya yang Dibuat"
 
-#: static/js/impala/stats/csv_keys.js:18
+#: static/js/impala/stats/csv_keys.js:18 static/js/zamboni/stats-all.js:15299 static/js/zamboni/stats-min.js:4
 msgid "Add-ons Downloaded"
 msgstr "Pengaya yang Diunduh"
 
-#: static/js/impala/stats/csv_keys.js:21
+#: static/js/impala/stats/csv_keys.js:21 static/js/zamboni/stats-all.js:15302 static/js/zamboni/stats-min.js:4
 msgid "Add-ons Updated"
 msgstr "Pengaya yang Diperbarui"
 
-#: static/js/impala/stats/csv_keys.js:24
+#: static/js/impala/stats/csv_keys.js:24 static/js/zamboni/stats-all.js:15305 static/js/zamboni/stats-min.js:4
 msgid "Reviews Written"
 msgstr "Ulasan yang Ditulis"
 
-#: static/js/impala/stats/csv_keys.js:27
+#: static/js/impala/stats/csv_keys.js:27 static/js/zamboni/stats-all.js:15308 static/js/zamboni/stats-min.js:4
 msgid "User Signups"
 msgstr "Pendaftaran Pengguna"
 
-#: static/js/impala/stats/csv_keys.js:30
+#: static/js/impala/stats/csv_keys.js:30 static/js/zamboni/stats-all.js:15311 static/js/zamboni/stats-min.js:4
 msgid "Subscribers"
 msgstr "Pelanggan"
 
-#: static/js/impala/stats/csv_keys.js:33
+#: static/js/impala/stats/csv_keys.js:33 static/js/zamboni/stats-all.js:15314 static/js/zamboni/stats-min.js:4
 msgid "Ratings"
 msgstr "Peringkat"
 
-#: static/js/impala/stats/csv_keys.js:36 static/js/impala/stats/csv_keys.js:114
+#: static/js/impala/stats/csv_keys.js:36 static/js/impala/stats/csv_keys.js:114 static/js/zamboni/stats-all.js:15317 static/js/zamboni/stats-all.js:15395 static/js/zamboni/stats-min.js:4
+#: static/js/zamboni/stats-min.js:5
 msgid "Sales"
 msgstr "Penjualan"
 
-#: static/js/impala/stats/csv_keys.js:39 static/js/impala/stats/csv_keys.js:113
+#: static/js/impala/stats/csv_keys.js:39 static/js/impala/stats/csv_keys.js:113 static/js/zamboni/stats-all.js:15320 static/js/zamboni/stats-all.js:15394 static/js/zamboni/stats-min.js:4
+#: static/js/zamboni/stats-min.js:5
 msgid "Installs"
 msgstr "Pemasangan"
 
-#: static/js/impala/stats/csv_keys.js:42
+#: static/js/impala/stats/csv_keys.js:42 static/js/zamboni/stats-all.js:15323 static/js/zamboni/stats-min.js:4
 msgid "Unknown"
 msgstr "Tidak diketahui"
 
-#: static/js/impala/stats/csv_keys.js:43
+#: static/js/impala/stats/csv_keys.js:43 static/js/zamboni/stats-all.js:15324 static/js/zamboni/stats-min.js:4
 msgid "Add-ons Manager"
 msgstr "Pengelola Pengaya"
 
-#: static/js/impala/stats/csv_keys.js:44
+#: static/js/impala/stats/csv_keys.js:44 static/js/zamboni/stats-all.js:15325 static/js/zamboni/stats-min.js:4
 msgid "Add-ons Manager Promo"
 msgstr "Promo Pengelola Pengaya"
 
-#: static/js/impala/stats/csv_keys.js:45
+#: static/js/impala/stats/csv_keys.js:45 static/js/zamboni/stats-all.js:15326 static/js/zamboni/stats-min.js:4
 msgid "Add-ons Manager Featured"
 msgstr "Pengelola Pengaya yang Diutamakan"
 
-#: static/js/impala/stats/csv_keys.js:46
+#: static/js/impala/stats/csv_keys.js:46 static/js/zamboni/stats-all.js:15327 static/js/zamboni/stats-min.js:4
 msgid "Add-ons Manager Learn More"
 msgstr "Pengelola Pengaya Pelajari Lebih Lanjut"
 
-#: static/js/impala/stats/csv_keys.js:47
+#: static/js/impala/stats/csv_keys.js:47 static/js/zamboni/stats-all.js:15328 static/js/zamboni/stats-min.js:4
 msgid "Search Suggestions"
 msgstr "Saran Pencarian"
 
-#: static/js/impala/stats/csv_keys.js:48
+#: static/js/impala/stats/csv_keys.js:48 static/js/zamboni/stats-all.js:15329 static/js/zamboni/stats-min.js:4
 msgid "Search Results"
 msgstr "Hasil Pencarian"
 
-#: static/js/impala/stats/csv_keys.js:49 static/js/impala/stats/csv_keys.js:50 static/js/impala/stats/csv_keys.js:51
+#: static/js/impala/stats/csv_keys.js:49 static/js/impala/stats/csv_keys.js:50 static/js/impala/stats/csv_keys.js:51 static/js/zamboni/stats-all.js:15330 static/js/zamboni/stats-all.js:15331
+#: static/js/zamboni/stats-all.js:15332 static/js/zamboni/stats-min.js:4
 msgid "Homepage Promo"
 msgstr "Promo Beranda"
 
-#: static/js/impala/stats/csv_keys.js:52 static/js/impala/stats/csv_keys.js:53
+#: static/js/impala/stats/csv_keys.js:52 static/js/impala/stats/csv_keys.js:53 static/js/zamboni/stats-all.js:15333 static/js/zamboni/stats-all.js:15334 static/js/zamboni/stats-min.js:4
 msgid "Homepage Featured"
 msgstr "Laman yang Diutamakan"
 
-#: static/js/impala/stats/csv_keys.js:54 static/js/impala/stats/csv_keys.js:55
+#: static/js/impala/stats/csv_keys.js:54 static/js/impala/stats/csv_keys.js:55 static/js/zamboni/stats-all.js:15335 static/js/zamboni/stats-all.js:15336 static/js/zamboni/stats-min.js:4
 msgid "Homepage Up and Coming"
 msgstr "Laman yang Akan Datang"
 
-#: static/js/impala/stats/csv_keys.js:56
+#: static/js/impala/stats/csv_keys.js:56 static/js/zamboni/stats-all.js:15337 static/js/zamboni/stats-min.js:4
 msgid "Homepage Most Popular"
 msgstr "Laman Paling Populer"
 
-#: static/js/impala/stats/csv_keys.js:57 static/js/impala/stats/csv_keys.js:59
+#: static/js/impala/stats/csv_keys.js:57 static/js/impala/stats/csv_keys.js:59 static/js/zamboni/stats-all.js:15338 static/js/zamboni/stats-all.js:15340 static/js/zamboni/stats-min.js:4
 msgid "Detail Page"
 msgstr "Detail Laman"
 
-#: static/js/impala/stats/csv_keys.js:58 static/js/impala/stats/csv_keys.js:60
+#: static/js/impala/stats/csv_keys.js:58 static/js/impala/stats/csv_keys.js:60 static/js/zamboni/stats-all.js:15339 static/js/zamboni/stats-all.js:15341 static/js/zamboni/stats-min.js:4
 msgid "Detail Page (bottom)"
 msgstr "Detail Laman (bawah)"
 
-#: static/js/impala/stats/csv_keys.js:61
+#: static/js/impala/stats/csv_keys.js:61 static/js/zamboni/stats-all.js:15342 static/js/zamboni/stats-min.js:4
 msgid "Detail Page (Development Channel)"
 msgstr "Detail Laman (Kanal Pengembangan)"
 
-#: static/js/impala/stats/csv_keys.js:62 static/js/impala/stats/csv_keys.js:63 static/js/impala/stats/csv_keys.js:64
+#: static/js/impala/stats/csv_keys.js:62 static/js/impala/stats/csv_keys.js:63 static/js/impala/stats/csv_keys.js:64 static/js/zamboni/stats-all.js:15343 static/js/zamboni/stats-all.js:15344
+#: static/js/zamboni/stats-all.js:15345 static/js/zamboni/stats-min.js:4
 msgid "Often Used With"
 msgstr "Sering Digunakan Dengan"
 
-#: static/js/impala/stats/csv_keys.js:65 static/js/impala/stats/csv_keys.js:66
+#: static/js/impala/stats/csv_keys.js:65 static/js/impala/stats/csv_keys.js:66 static/js/zamboni/stats-all.js:15346 static/js/zamboni/stats-all.js:15347 static/js/zamboni/stats-min.js:4
 msgid "Others By Author"
 msgstr "Yang Lain Oleh Penyusun"
 
-#: static/js/impala/stats/csv_keys.js:67 static/js/impala/stats/csv_keys.js:68
+#: static/js/impala/stats/csv_keys.js:67 static/js/impala/stats/csv_keys.js:68 static/js/zamboni/stats-all.js:15348 static/js/zamboni/stats-all.js:15349 static/js/zamboni/stats-min.js:4
 msgid "Dependencies"
 msgstr "Ketergantungan"
 
-#: static/js/impala/stats/csv_keys.js:69 static/js/impala/stats/csv_keys.js:70
+#: static/js/impala/stats/csv_keys.js:69 static/js/impala/stats/csv_keys.js:70 static/js/zamboni/stats-all.js:15350 static/js/zamboni/stats-all.js:15351 static/js/zamboni/stats-min.js:4
 msgid "Upsell"
 msgstr "Upsell"
 
-#: static/js/impala/stats/csv_keys.js:71
+#: static/js/impala/stats/csv_keys.js:71 static/js/zamboni/stats-all.js:15352 static/js/zamboni/stats-min.js:4
 msgid "Meet the Developer"
 msgstr "Temui Pengembang"
 
-#: static/js/impala/stats/csv_keys.js:72
+#: static/js/impala/stats/csv_keys.js:72 static/js/zamboni/stats-all.js:15353 static/js/zamboni/stats-min.js:4
 msgid "User Profile"
 msgstr "Profil Pengguna"
 
-#: static/js/impala/stats/csv_keys.js:73
+#: static/js/impala/stats/csv_keys.js:73 static/js/zamboni/stats-all.js:15354 static/js/zamboni/stats-min.js:4
 msgid "Version History"
 msgstr "Riwayat Versi"
 
-#: static/js/impala/stats/csv_keys.js:75
+#: static/js/impala/stats/csv_keys.js:75 static/js/zamboni/stats-all.js:15356 static/js/zamboni/stats-min.js:4
 msgid "Sharing"
 msgstr "Berbagi"
 
-#: static/js/impala/stats/csv_keys.js:76
+#: static/js/impala/stats/csv_keys.js:76 static/js/zamboni/stats-all.js:15357 static/js/zamboni/stats-min.js:4
 msgid "Category Pages"
 msgstr "Laman Kategori"
 
-#: static/js/impala/stats/csv_keys.js:77
+#: static/js/impala/stats/csv_keys.js:77 static/js/zamboni/stats-all.js:15358 static/js/zamboni/stats-min.js:4
 msgid "Collections"
 msgstr "Koleksi"
 
-#: static/js/impala/stats/csv_keys.js:78 static/js/impala/stats/csv_keys.js:79
+#: static/js/impala/stats/csv_keys.js:78 static/js/impala/stats/csv_keys.js:79 static/js/zamboni/stats-all.js:15359 static/js/zamboni/stats-all.js:15360 static/js/zamboni/stats-min.js:4
 msgid "Category Landing Featured Carousel"
 msgstr "Kategori Pendaratan Korsel yang Diutamakan"
 
-#: static/js/impala/stats/csv_keys.js:80 static/js/impala/stats/csv_keys.js:81
+#: static/js/impala/stats/csv_keys.js:80 static/js/impala/stats/csv_keys.js:81 static/js/zamboni/stats-all.js:15361 static/js/zamboni/stats-all.js:15362 static/js/zamboni/stats-min.js:4
 msgid "Category Landing Top Rated"
 msgstr "Kategori Pendaratan Peringkat Tertinggi"
 
-#: static/js/impala/stats/csv_keys.js:82 static/js/impala/stats/csv_keys.js:83
+#: static/js/impala/stats/csv_keys.js:82 static/js/impala/stats/csv_keys.js:83 static/js/zamboni/stats-all.js:15363 static/js/zamboni/stats-all.js:15364 static/js/zamboni/stats-min.js:5
 msgid "Category Landing Most Popular"
 msgstr "Kategori Pendaratan Paling Populer"
 
-#: static/js/impala/stats/csv_keys.js:84 static/js/impala/stats/csv_keys.js:85
+#: static/js/impala/stats/csv_keys.js:84 static/js/impala/stats/csv_keys.js:85 static/js/zamboni/stats-all.js:15365 static/js/zamboni/stats-all.js:15366 static/js/zamboni/stats-min.js:5
 msgid "Category Landing Recently Added"
 msgstr "Kategori Pendaratan Barusaja Ditambahkan"
 
-#: static/js/impala/stats/csv_keys.js:86 static/js/impala/stats/csv_keys.js:87
+#: static/js/impala/stats/csv_keys.js:86 static/js/impala/stats/csv_keys.js:87 static/js/zamboni/stats-all.js:15367 static/js/zamboni/stats-all.js:15368 static/js/zamboni/stats-min.js:5
 msgid "Browse Listing Featured Sort"
 msgstr "Mengurutkan Daftar Penjelajahan yang Diutamakan"
 
-#: static/js/impala/stats/csv_keys.js:88 static/js/impala/stats/csv_keys.js:89
+#: static/js/impala/stats/csv_keys.js:88 static/js/impala/stats/csv_keys.js:89 static/js/zamboni/stats-all.js:15369 static/js/zamboni/stats-all.js:15370 static/js/zamboni/stats-min.js:5
 msgid "Browse Listing Users Sort"
 msgstr "Mengurutkan Daftar Penjelajahan Pengguna"
 
-#: static/js/impala/stats/csv_keys.js:90 static/js/impala/stats/csv_keys.js:91
+#: static/js/impala/stats/csv_keys.js:90 static/js/impala/stats/csv_keys.js:91 static/js/zamboni/stats-all.js:15371 static/js/zamboni/stats-all.js:15372 static/js/zamboni/stats-min.js:5
 msgid "Browse Listing Rating Sort"
 msgstr "Mengurutkan Peringkat Daftar Penjelajahan"
 
-#: static/js/impala/stats/csv_keys.js:92 static/js/impala/stats/csv_keys.js:93
+#: static/js/impala/stats/csv_keys.js:92 static/js/impala/stats/csv_keys.js:93 static/js/zamboni/stats-all.js:15373 static/js/zamboni/stats-all.js:15374 static/js/zamboni/stats-min.js:5
 msgid "Browse Listing Created Sort"
 msgstr "Mengurutkan Daftar Penjelajahan yang Dibuat"
 
-#: static/js/impala/stats/csv_keys.js:94 static/js/impala/stats/csv_keys.js:95
+#: static/js/impala/stats/csv_keys.js:94 static/js/impala/stats/csv_keys.js:95 static/js/zamboni/stats-all.js:15375 static/js/zamboni/stats-all.js:15376 static/js/zamboni/stats-min.js:5
 msgid "Browse Listing Name Sort"
 msgstr "Mengurutkan Daftar Penjelajahan Nama"
 
-#: static/js/impala/stats/csv_keys.js:96 static/js/impala/stats/csv_keys.js:97
+#: static/js/impala/stats/csv_keys.js:96 static/js/impala/stats/csv_keys.js:97 static/js/zamboni/stats-all.js:15377 static/js/zamboni/stats-all.js:15378 static/js/zamboni/stats-min.js:5
 msgid "Browse Listing Popular Sort"
 msgstr "Mengurutkan Daftar Penjelajahan Populer"
 
-#: static/js/impala/stats/csv_keys.js:98 static/js/impala/stats/csv_keys.js:99
+#: static/js/impala/stats/csv_keys.js:98 static/js/impala/stats/csv_keys.js:99 static/js/zamboni/stats-all.js:15379 static/js/zamboni/stats-all.js:15380 static/js/zamboni/stats-min.js:5
 msgid "Browse Listing Updated Sort"
 msgstr "Mengurutkan Daftar Penjelajahan Terbaru"
 
-#: static/js/impala/stats/csv_keys.js:100 static/js/impala/stats/csv_keys.js:101
+#: static/js/impala/stats/csv_keys.js:100 static/js/impala/stats/csv_keys.js:101 static/js/zamboni/stats-all.js:15381 static/js/zamboni/stats-all.js:15382 static/js/zamboni/stats-min.js:5
 msgid "Browse Listing Up and Coming Sort"
 msgstr "Mengurutkan Daftar Datang dan Pergi"
 
-#: static/js/impala/stats/csv_keys.js:105
+#: static/js/impala/stats/csv_keys.js:105 static/js/zamboni/stats-all.js:15386 static/js/zamboni/stats-min.js:5
 msgid "Total Amount Contributed"
 msgstr "Jumlah Total yang Dikontribusikan"
 
-#: static/js/impala/stats/csv_keys.js:106
+#: static/js/impala/stats/csv_keys.js:106 static/js/zamboni/stats-all.js:15387 static/js/zamboni/stats-min.js:5
 msgid "Average Contribution"
 msgstr "Kontribusi Rata-rata"
 
-#: static/js/impala/stats/csv_keys.js:115
+#: static/js/impala/stats/csv_keys.js:115 static/js/zamboni/stats-all.js:15396 static/js/zamboni/stats-min.js:5
 msgid "Usage"
 msgstr "Penggunaan"
 
-#: static/js/impala/stats/csv_keys.js:118
+#: static/js/impala/stats/csv_keys.js:118 static/js/zamboni/stats-all.js:15399 static/js/zamboni/stats-min.js:5
 msgid "Firefox"
 msgstr "Firefox"
 
-#: static/js/impala/stats/csv_keys.js:119
+#: static/js/impala/stats/csv_keys.js:119 static/js/zamboni/stats-all.js:15400 static/js/zamboni/stats-min.js:5
 msgid "Mozilla"
 msgstr "Mozilla"
 
-#: static/js/impala/stats/csv_keys.js:120
+#: static/js/impala/stats/csv_keys.js:120 static/js/zamboni/stats-all.js:15401 static/js/zamboni/stats-min.js:5
 msgid "Thunderbird"
 msgstr "Thunderbird"
 
-#: static/js/impala/stats/csv_keys.js:121
+#: static/js/impala/stats/csv_keys.js:121 static/js/zamboni/stats-all.js:15402 static/js/zamboni/stats-min.js:5
 msgid "Sunbird"
 msgstr "Sunbird"
 
-#: static/js/impala/stats/csv_keys.js:122
+#: static/js/impala/stats/csv_keys.js:122 static/js/zamboni/stats-all.js:15403 static/js/zamboni/stats-min.js:5
 msgid "SeaMonkey"
 msgstr "SeaMonkey"
 
-#: static/js/impala/stats/csv_keys.js:123
+#: static/js/impala/stats/csv_keys.js:123 static/js/zamboni/stats-all.js:15404 static/js/zamboni/stats-min.js:5
 msgid "Fennec"
 msgstr "Fennec"
 
-#: static/js/impala/stats/csv_keys.js:124
+#: static/js/impala/stats/csv_keys.js:124 static/js/zamboni/stats-all.js:15405 static/js/zamboni/stats-min.js:5
 msgid "Android"
 msgstr "Android"
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:129
+#: static/js/impala/stats/csv_keys.js:129 static/js/zamboni/stats-all.js:15410 static/js/zamboni/stats-min.js:5
 msgid "Downloads and Daily Users, last {0} days"
 msgstr "Unduhan dan Pengguna Harian, {0} hari terakhir"
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:131
+#: static/js/impala/stats/csv_keys.js:131 static/js/zamboni/stats-all.js:15412 static/js/zamboni/stats-min.js:5
 msgid "Downloads and Daily Users from {0} to {1}"
 msgstr "Unduhan dan Pengguna Harian dari tanggal {0} hingga tanggal {1}"
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:135
+#: static/js/impala/stats/csv_keys.js:135 static/js/zamboni/stats-all.js:15416 static/js/zamboni/stats-min.js:5
 msgid "Installs and Daily Users, last {0} days"
 msgstr "Pemasangan dan Pengguna Harian, {0} hari terakhir"
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:137
+#: static/js/impala/stats/csv_keys.js:137 static/js/zamboni/stats-all.js:15418 static/js/zamboni/stats-min.js:5
 msgid "Installs and Daily Users from {0} to {1}"
 msgstr "Pemasangan dan Pengguna Harian dari tanggal {0} hingga tanggal {1}"
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:141
+#: static/js/impala/stats/csv_keys.js:141 static/js/zamboni/stats-all.js:15422 static/js/zamboni/stats-min.js:5
 msgid "Downloads, last {0} days"
 msgstr "Unduhan, {0} hari terakhir"
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:143
+#: static/js/impala/stats/csv_keys.js:143 static/js/zamboni/stats-all.js:15424 static/js/zamboni/stats-min.js:5
 msgid "Downloads from {0} to {1}"
 msgstr "Unduhan dari tanggal {0} hingga tanggal {1}"
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:147
+#: static/js/impala/stats/csv_keys.js:147 static/js/zamboni/stats-all.js:15428 static/js/zamboni/stats-min.js:5
 msgid "Daily Users, last {0} days"
 msgstr "Pengguna Harian, {0} hari terakhir"
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:149
+#: static/js/impala/stats/csv_keys.js:149 static/js/zamboni/stats-all.js:15430 static/js/zamboni/stats-min.js:5
 msgid "Daily Users from {0} to {1}"
 msgstr "Pengguna Harian dari tanggal {0} hingga tanggal {1}"
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:153
+#: static/js/impala/stats/csv_keys.js:153 static/js/zamboni/stats-all.js:15434 static/js/zamboni/stats-min.js:5
 msgid "Applications, last {0} days"
 msgstr "Aplikasi, {0} hari terakhir"
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:155
+#: static/js/impala/stats/csv_keys.js:155 static/js/zamboni/stats-all.js:15436 static/js/zamboni/stats-min.js:5
 msgid "Applications from {0} to {1}"
 msgstr "Aplikasi dari tanggal {0} hingga tanggal {1}"
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:159
+#: static/js/impala/stats/csv_keys.js:159 static/js/zamboni/stats-all.js:15440 static/js/zamboni/stats-min.js:5
 msgid "Platforms, last {0} days"
 msgstr "Platform, {0} hari terakhir"
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:161
+#: static/js/impala/stats/csv_keys.js:161 static/js/zamboni/stats-all.js:15442 static/js/zamboni/stats-min.js:5
 msgid "Platforms from {0} to {1}"
 msgstr "Platform dari tanggal {0} hingga tanggal {1}"
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:165
+#: static/js/impala/stats/csv_keys.js:165 static/js/zamboni/stats-all.js:15446 static/js/zamboni/stats-min.js:5
 msgid "Languages, last {0} days"
 msgstr "Bahasa, {0} hari terakhir"
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:167
+#: static/js/impala/stats/csv_keys.js:167 static/js/zamboni/stats-all.js:15448 static/js/zamboni/stats-min.js:5
 msgid "Languages from {0} to {1}"
 msgstr "Bahasa dari tanggal {0} hingga tanggal {1}"
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:171
+#: static/js/impala/stats/csv_keys.js:171 static/js/zamboni/stats-all.js:15452 static/js/zamboni/stats-min.js:5
 msgid "Add-on Versions, last {0} days"
 msgstr "Versi Pengaya, {0} hari terakhir"
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:173
+#: static/js/impala/stats/csv_keys.js:173 static/js/zamboni/stats-all.js:15454 static/js/zamboni/stats-min.js:5
 msgid "Add-on Versions from {0} to {1}"
 msgstr "Versi Pengaya dari tanggal {0} hingga tanggal {1}"
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:177
+#: static/js/impala/stats/csv_keys.js:177 static/js/zamboni/stats-all.js:15458 static/js/zamboni/stats-min.js:5
 msgid "Add-on Status, last {0} days"
 msgstr "Status Pengaya, {0} hari terakhir"
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:179
+#: static/js/impala/stats/csv_keys.js:179 static/js/zamboni/stats-all.js:15460 static/js/zamboni/stats-min.js:5
 msgid "Add-on Status from {0} to {1}"
 msgstr "Status Pengaya dari tanggal {0} hingga tanggal {1}"
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:183
+#: static/js/impala/stats/csv_keys.js:183 static/js/zamboni/stats-all.js:15464 static/js/zamboni/stats-min.js:5
 msgid "Download Sources, last {0} days"
 msgstr "Sumber Unggahan, {0} hari terakhir"
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:185
+#: static/js/impala/stats/csv_keys.js:185 static/js/zamboni/stats-all.js:15466 static/js/zamboni/stats-min.js:5
 msgid "Download Sources from {0} to {1}"
 msgstr "Sumber Unggahan dari tanggal {0} hingga tanggal {1}"
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:189
+#: static/js/impala/stats/csv_keys.js:189 static/js/zamboni/stats-all.js:15470 static/js/zamboni/stats-min.js:5
 msgid "Contributions, last {0} days"
 msgstr "Kontribusi, {0} hari terakhir"
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:191
+#: static/js/impala/stats/csv_keys.js:191 static/js/zamboni/stats-all.js:15472 static/js/zamboni/stats-min.js:5
 msgid "Contributions from {0} to {1}"
 msgstr "Kontribusi dari tanggal {0} hingga tanggal {1}"
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:195
+#: static/js/impala/stats/csv_keys.js:195 static/js/zamboni/stats-all.js:15476 static/js/zamboni/stats-min.js:5
 msgid "Site Metrics, last {0} days"
 msgstr "Metrik Situs, {0} hari terakhir"
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:197
+#: static/js/impala/stats/csv_keys.js:197 static/js/zamboni/stats-all.js:15478 static/js/zamboni/stats-min.js:5
 msgid "Site Metrics from {0} to {1}"
 msgstr "Metrik Situs sejak {0} hingga {1}"
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:201
+#: static/js/impala/stats/csv_keys.js:201 static/js/zamboni/stats-all.js:15482 static/js/zamboni/stats-min.js:5
 msgid "Add-ons in Use, last {0} days"
 msgstr "Pengaya yang dipakai, {0} hari terakhir"
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:203
+#: static/js/impala/stats/csv_keys.js:203 static/js/zamboni/stats-all.js:15484 static/js/zamboni/stats-min.js:5
 msgid "Add-ons in Use from {0} to {1}"
 msgstr "Pengaya yang dipakai dari tanggal {0} hingga tanggal {1}"
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:207
+#: static/js/impala/stats/csv_keys.js:207 static/js/zamboni/stats-all.js:15488 static/js/zamboni/stats-min.js:5
 msgid "Add-ons Downloaded, last {0} days"
 msgstr "Pengaya yang Diunduh, {0} hari terakhir"
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:209
+#: static/js/impala/stats/csv_keys.js:209 static/js/zamboni/stats-all.js:15490 static/js/zamboni/stats-min.js:5
 msgid "Add-ons Downloaded from {0} to {1}"
 msgstr "Pengaya yang Diunduh dari tanggal {0} hingga tanggal {1}"
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:213
+#: static/js/impala/stats/csv_keys.js:213 static/js/zamboni/stats-all.js:15494 static/js/zamboni/stats-min.js:5
 msgid "Add-ons Created, last {0} days"
 msgstr "Pengaya yang Dibuat, {0} hari terakhir"
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:215
+#: static/js/impala/stats/csv_keys.js:215 static/js/zamboni/stats-all.js:15496 static/js/zamboni/stats-min.js:5
 msgid "Add-ons Created from {0} to {1}"
 msgstr "Pengaya yang Dibuat dari tanggal {0} hingga tanggal {1}"
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:219
+#: static/js/impala/stats/csv_keys.js:219 static/js/zamboni/stats-all.js:15500 static/js/zamboni/stats-min.js:5
 msgid "Add-ons Updated, last {0} days"
 msgstr "Pengaya yang Diperbarui, {0} hari terakhir"
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:221
+#: static/js/impala/stats/csv_keys.js:221 static/js/zamboni/stats-all.js:15502 static/js/zamboni/stats-min.js:5
 msgid "Add-ons Updated from {0} to {1}"
 msgstr "Pengaya yang Diperbarui dari tanggal {0} hingga tanggal {1}"
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:225
+#: static/js/impala/stats/csv_keys.js:225 static/js/zamboni/stats-all.js:15506 static/js/zamboni/stats-min.js:5
 msgid "Reviews Written, last {0} days"
 msgstr "Ulasan yang Ditulis, {0} hari terakhir"
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:227
+#: static/js/impala/stats/csv_keys.js:227 static/js/zamboni/stats-all.js:15508 static/js/zamboni/stats-min.js:5
 msgid "Reviews Written from {0} to {1}"
 msgstr "Ulasan yang Ditulis dari tanggal {0} hingga tanggal {1}"
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:231
+#: static/js/impala/stats/csv_keys.js:231 static/js/zamboni/stats-all.js:15512 static/js/zamboni/stats-min.js:5
 msgid "User Signups, last {0} days"
 msgstr "Pendaftaran Pengguna, {0} hari terakhir"
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:233
+#: static/js/impala/stats/csv_keys.js:233 static/js/zamboni/stats-all.js:15514 static/js/zamboni/stats-min.js:5
 msgid "User Signups from {0} to {1}"
 msgstr "Pendaftaran Pengguna dari tanggal {0} hingga tanggal {1}"
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:237
+#: static/js/impala/stats/csv_keys.js:237 static/js/zamboni/stats-all.js:15518 static/js/zamboni/stats-min.js:5
 msgid "Collections Created, last {0} days"
 msgstr "Koleksi yang Dibuat, {0} hari terakhir"
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:239
+#: static/js/impala/stats/csv_keys.js:239 static/js/zamboni/stats-all.js:15520 static/js/zamboni/stats-min.js:5
 msgid "Collections Created from {0} to {1}"
 msgstr "Koleksi yang Dibuat dari tanggal {0} sampai tanggal {1}"
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:243
+#: static/js/impala/stats/csv_keys.js:243 static/js/zamboni/stats-all.js:15524 static/js/zamboni/stats-min.js:5
 msgid "Subscribers, last {0} days"
 msgstr "Pelanggan, {0} hari terakhir"
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:245
+#: static/js/impala/stats/csv_keys.js:245 static/js/zamboni/stats-all.js:15526 static/js/zamboni/stats-min.js:5
 msgid "Subscribers from {0} to {1}"
 msgstr "Pelanggan dari tanggal {0} sampai tanggal {1}"
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:249
+#: static/js/impala/stats/csv_keys.js:249 static/js/zamboni/stats-all.js:15530 static/js/zamboni/stats-min.js:5
 msgid "Ratings, last {0} days"
 msgstr "Peringkat, {0} hari terakhir"
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:251
+#: static/js/impala/stats/csv_keys.js:251 static/js/zamboni/stats-all.js:15532 static/js/zamboni/stats-min.js:5
 msgid "Ratings from {0} to {1}"
 msgstr "Peringkat dari tanggal {0} hingga tanggal {1}"
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:255
+#: static/js/impala/stats/csv_keys.js:255 static/js/zamboni/stats-all.js:15536 static/js/zamboni/stats-min.js:5
 msgid "Sales, last {0} days"
 msgstr "Penjualan, {0} hari terakhir"
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:257
+#: static/js/impala/stats/csv_keys.js:257 static/js/zamboni/stats-all.js:15538 static/js/zamboni/stats-min.js:5
 msgid "Sales from {0} to {1}"
 msgstr "Penjualan dari tanggal {0} hingga tanggal {1}"
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:261
+#: static/js/impala/stats/csv_keys.js:261 static/js/zamboni/stats-all.js:15542 static/js/zamboni/stats-min.js:5
 msgid "Installs, last {0} days"
 msgstr "Pemasangan, {0} hari terakhir"
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:263
+#: static/js/impala/stats/csv_keys.js:263 static/js/zamboni/stats-all.js:15544 static/js/zamboni/stats-min.js:5
 msgid "Installs from {0} to {1}"
 msgstr "Pemasangan dari tanggal {0} hingga tanggal {1}"
 
 #. L10n: {0} and {1} are integers.
-#: static/js/impala/stats/csv_keys.js:269
+#: static/js/impala/stats/csv_keys.js:269 static/js/zamboni/stats-all.js:15550 static/js/zamboni/stats-min.js:5
 msgid "<b>{0}</b> in last {1} days"
 msgstr "<b>{0}</b> dalam {1} hari terakhir"
 
 #. L10n: {0} is an integer and {1} and {2} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:271 static/js/impala/stats/csv_keys.js:277
+#: static/js/impala/stats/csv_keys.js:271 static/js/impala/stats/csv_keys.js:277 static/js/zamboni/stats-all.js:15552 static/js/zamboni/stats-all.js:15558 static/js/zamboni/stats-min.js:5
 msgid "<b>{0}</b> from {1} to {2}"
 msgstr "<b>{0}</b> dari tanggal {1} hingga tanggal {2}"
 
 #. L10n: {0} and {1} are integers.
-#: static/js/impala/stats/csv_keys.js:275
+#: static/js/impala/stats/csv_keys.js:275 static/js/zamboni/stats-all.js:15556 static/js/zamboni/stats-min.js:5
 msgid "<b>{0}</b> average in last {1} days"
 msgstr "Rata-rata <b>{0}</b> dalam {1} hari terakhir"
 
-#: static/js/impala/stats/overview.js:19
+#: static/js/impala/stats/overview.js:19 static/js/zamboni/stats-all.js:16469 static/js/zamboni/stats-min.js:5
 msgid "No data available."
 msgstr "Tidak tersedia tanggal."
 
-#: static/js/impala/stats/table.js:74
+#: static/js/impala/stats/table.js:74 static/js/zamboni/stats-all.js:17209 static/js/zamboni/stats-min.js:5
 msgid "Date"
 msgstr "Tanggal"
 
-#: static/js/impala/stats/topchart.js:96
+#: static/js/impala/stats/topchart.js:96 static/js/zamboni/stats-all.js:16600 static/js/zamboni/stats-min.js:5
 msgid "Other"
 msgstr "Lainnya"
 
-#: static/js/zamboni/admin_validation.js:24 static/js/zamboni/devhub.js:1229 static/js/zamboni/editors.js:295
+#: static/js/zamboni/admin-all.js:180 static/js/zamboni/admin-min.js:1 static/js/zamboni/admin_validation.js:24 static/js/zamboni/devhub-all.js:2408 static/js/zamboni/devhub-min.js:2
+#: static/js/zamboni/devhub.js:1229 static/js/zamboni/editors-all.js:15576 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:295
 msgid "Select an application first"
 msgstr "Pilih aplikasi terlebih dulu"
 
-#: static/js/zamboni/admin_validation.js:51
+#: static/js/zamboni/admin-all.js:207 static/js/zamboni/admin-min.js:1 static/js/zamboni/admin_validation.js:51
 msgid "Set {0} add-on to a max version of {1} and email the author."
 msgid_plural "Set {0} add-ons to a max version of {1} and email the authors."
 msgstr[0] "Jadikan {0} pengaya menjadi versi terbaru {1} dan kirim email ke penyusun."
+msgstr[1] ""
 
-#: static/js/zamboni/admin_validation.js:54
+#: static/js/zamboni/admin-all.js:210 static/js/zamboni/admin-min.js:1 static/js/zamboni/admin_validation.js:54
 msgid "Email author of {2} add-on which failed validation."
 msgid_plural "Email authors of {2} add-ons which failed validation."
 msgstr[0] "Kirim email ke penyusun dari {2} pengaya yang gagal validasi."
+msgstr[1] ""
 
-#. L10n: {0} is an app name like Firefox.
-#: static/js/zamboni/buttons.js:66
-msgid "Accept and Install"
-msgstr "Terima dan Pasang"
-
-#: static/js/zamboni/buttons.js:66
-msgid "Add to {0}"
-msgstr "Tambahkan ke {0}"
-
-#: static/js/zamboni/buttons.js:71
-msgid "Download Now"
-msgstr "Unduh Sekarang"
-
-#: static/js/zamboni/buttons.js:112
-msgid "Add-on has not been updated to support default-to-compatible."
-msgstr "Pengaya belum diperbarui untuk mendukung kompatibel bawaan."
-
-#: static/js/zamboni/buttons.js:117
-msgid "You need to be using Firefox 10.0 or higher."
-msgstr "Anda harus menggunakan Firefox 10.0 atau lebih baru."
-
-#: static/js/zamboni/buttons.js:129
-msgid "Mozilla has marked this version as incompatible with your Firefox version."
-msgstr "Mozilla telah menandai versi ini tidak kompatibel dengan versi Firefox anda."
-
-#. L10n: {0} is an platform like Windows or Linux.
-#: static/js/zamboni/buttons.js:210
-msgid "Install for {0} anyway"
-msgstr "Pasang {0} saja"
-
-#: static/js/zamboni/buttons.js:210
-msgid "Download for {0} anyway"
-msgstr "Unduh {0} saja"
-
-#: static/js/zamboni/buttons.js:267
-msgid "Not available for your platform"
-msgstr "Tidak tersedia untuk platform Anda"
-
-#. L10n: {0} is an app name, {1} is the app version.
-#: static/js/zamboni/buttons.js:278 static/js/zamboni/buttons.js:315
-msgid "Not available for {0} {1}"
-msgstr "{0} {1} tidak tersedia"
-
-#: static/js/zamboni/buttons.js:341
-msgid "Works with {app} {min} - {max}"
-msgstr "Bekerja dengan {app} {min} - {max}"
-
-#: static/js/zamboni/buttons.js:343
-msgid "View other versions"
-msgstr "Lihat versi lainnya"
-
-#: static/js/zamboni/buttons.js:391
-msgid "Only with Firefox — Get Firefox Now!"
-msgstr "Hanya dengan Firefox — Dapatkan Firefox Sekarang!"
-
-#: static/js/zamboni/buttons.js:507 static/js/zamboni/mobile/buttons.js:43
-msgid "Sorry, you need a Mozilla-based browser (such as Firefox) to install a search plugin."
-msgstr "Maaf, Anda membutuhkan peramban berbasis Mozilla (seperti Firefox) untuk memasang plugin pencari."
-
-#: static/js/zamboni/collections.js:229
-msgid "Adding to Favorites&hellip;"
-msgstr "Tambahkan ke Favorit&hellip;"
-
-#: static/js/zamboni/collections.js:232
-msgid "Removing Favorite&hellip;"
-msgstr "Hapus Favorit&hellip;"
-
-#: static/js/zamboni/collections.js:235
-msgid "Add to Favorites"
-msgstr "Tambah ke Favorit"
-
-#: static/js/zamboni/collections.js:238
-msgid "Remove from Favorites"
-msgstr "Hapus dari Favorit"
-
-#: static/js/zamboni/collections.js:303
-msgid "Pending"
-msgstr "Tertunda"
-
-#: static/js/zamboni/collections.js:304
-msgid "Add a comment"
-msgstr "Tambahkan komentar"
-
-#: static/js/zamboni/collections.js:304
-msgid "Comment"
-msgstr "Komentar"
-
-#: static/js/zamboni/collections.js:305
-msgid "Remove this add-on from the collection"
-msgstr "Hapus pengaya ini dari koleksi"
-
-#: static/js/zamboni/collections.js:305 static/js/zamboni/collections.js:334
-msgid "Remove"
-msgstr "Hapus"
-
-#: static/js/zamboni/collections.js:334
-msgid "Remove this user as a contributor"
-msgstr "Hapus pengguna ini sebagai kontributor"
-
-#: static/js/zamboni/collections.js:346
-msgid "An email address is required."
-msgstr "Dibutuhkan alamat email."
-
-#: static/js/zamboni/collections.js:364
-msgid "You cannot add yourself as a contributor."
-msgstr "Anda tidak dapat menambahkan diri sendiri sebagai kontributor."
-
-#: static/js/zamboni/collections.js:366
-msgid "You have already added that user."
-msgstr "Anda telah menambahkan pengguna tersebut."
-
-#: static/js/zamboni/collections.js:573
-msgid "Add to favorites"
-msgstr "Tambah ke favorit"
-
-#: static/js/zamboni/collections.js:577
-msgid "Remove from favorites"
-msgstr "Hapus dari favorit"
-
-#: static/js/zamboni/collections.js:604
-msgid "Stop following"
-msgstr "Berhenti mengikuti"
-
-#: static/js/zamboni/devhub.js:110
+#: static/js/zamboni/devhub-all.js:1289 static/js/zamboni/devhub-min.js:1 static/js/zamboni/devhub.js:110
 msgid "Your browser does not support the video tag"
 msgstr "Peramban Anda tidak mendukung tag video"
 
-#: static/js/zamboni/devhub.js:371
+#: static/js/zamboni/devhub-all.js:1550 static/js/zamboni/devhub-min.js:1 static/js/zamboni/devhub.js:371
 msgid "Changes Saved"
 msgstr "Perubahan Disimpan"
 
-#: static/js/zamboni/devhub.js:387
+#: static/js/zamboni/devhub-all.js:1566 static/js/zamboni/devhub-min.js:1 static/js/zamboni/devhub.js:387
 msgid "Enter a new author's email address"
 msgstr "Ketik alamat email baru penyusun"
 
-#: static/js/zamboni/devhub.js:536
+#: static/js/zamboni/devhub-all.js:1715 static/js/zamboni/devhub-min.js:1 static/js/zamboni/devhub.js:536
 msgid "There was an error uploading your file."
 msgstr "Ada kesalahan mengunggah berkas Anda."
 
-#: static/js/zamboni/devhub.js:681
+#: static/js/zamboni/devhub-all.js:1860 static/js/zamboni/devhub-min.js:1 static/js/zamboni/devhub.js:681
 msgid "{files} file"
 msgid_plural "{files} files"
 msgstr[0] "{files} berkas"
+msgstr[1] ""
 
-#: static/js/zamboni/devhub.js:684
+#: static/js/zamboni/devhub-all.js:1863 static/js/zamboni/devhub-min.js:1 static/js/zamboni/devhub.js:684
 msgid "{reviews} user review"
 msgid_plural "{reviews} user reviews"
 msgstr[0] "{reviews} ulasan pengguna"
+msgstr[1] ""
 
-#: static/js/zamboni/devhub.js:796
+#: static/js/zamboni/devhub-all.js:1975 static/js/zamboni/devhub-min.js:2 static/js/zamboni/devhub.js:796
 msgid "Learn more"
 msgstr "Pelajari selengkapnya"
 
-#: static/js/zamboni/devhub.js:800
+#: static/js/zamboni/devhub-all.js:1979 static/js/zamboni/devhub-min.js:2 static/js/zamboni/devhub.js:800
 msgid "Example"
 msgstr "Contoh"
 
-#: static/js/zamboni/devhub.js:1130
+#: static/js/zamboni/devhub-all.js:2309 static/js/zamboni/devhub-min.js:2 static/js/zamboni/devhub.js:1130
 msgid "Image changes being processed"
 msgstr "Perubahan gambar sedang diproses"
 
-#: static/js/zamboni/devhub.js:1280
+#: static/js/zamboni/devhub-all.js:2459 static/js/zamboni/devhub-min.js:2 static/js/zamboni/devhub.js:1280
 msgid "Must be a valid e-mail address."
 msgstr "Harus alamat e-mail valid."
+
+#: static/js/zamboni/devhub-all.js:2613 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:80
+msgid "All tests passed successfully."
+msgstr "Semua tes lulus dengan sukses."
+
+#: static/js/zamboni/devhub-all.js:2616 static/js/zamboni/devhub-all.js:3011 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:83 static/js/zamboni/validator.js:478
+msgid "These tests were not run."
+msgstr "Tes tersebut tidak dijalankan."
+
+#: static/js/zamboni/devhub-all.js:2664 static/js/zamboni/devhub-all.js:2677 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:131 static/js/zamboni/validator.js:144
+msgid "Tests"
+msgstr "Tes"
+
+#: static/js/zamboni/devhub-all.js:2779 static/js/zamboni/devhub-all.js:3108 static/js/zamboni/devhub-all.js:3127 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:246
+#: static/js/zamboni/validator.js:575 static/js/zamboni/validator.js:594
+msgid "Error"
+msgstr "Masalah"
+
+#: static/js/zamboni/devhub-all.js:2780 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:247
+msgid "Warning"
+msgstr "Peringatan"
+
+#: static/js/zamboni/devhub-all.js:2794 static/js/zamboni/devhub-min.js:2 static/js/zamboni/files-all.js:5657 static/js/zamboni/files-min.js:3 static/js/zamboni/files.js:411
+#: static/js/zamboni/validator.js:261
+msgid "Ignore this message in future updates"
+msgstr "Abaikan pesan ini untuk pembaruan selanjutnya"
+
+#: static/js/zamboni/devhub-all.js:2817 static/js/zamboni/devhub-min.js:2 static/js/zamboni/files-all.js:5663 static/js/zamboni/files-min.js:3 static/js/zamboni/files.js:417
+#: static/js/zamboni/validator.js:284
+msgid "Severity for automated signing:"
+msgstr "Kepelikan untuk menandai otomatis:"
+
+#: static/js/zamboni/devhub-all.js:2832 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:299
+msgid "Suggestions for passing automated signing:"
+msgstr "Saran untuk lulus tanda tangan otomatis:"
+
+#: static/js/zamboni/devhub-all.js:2920 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:387
+msgid "Compatibility Tests"
+msgstr "Tes Kompatibilitas"
+
+#: static/js/zamboni/devhub-all.js:2999 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:466
+msgid "Add-on failed validation."
+msgstr "Pengaya gagal validasi."
+
+#: static/js/zamboni/devhub-all.js:3001 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:468
+msgid "Add-on passed validation."
+msgstr "Pengaya lulus validasi."
+
+#: static/js/zamboni/devhub-all.js:3014 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:481
+msgid "{0} error"
+msgid_plural "{0} errors"
+msgstr[0] "{0} masalah"
+msgstr[1] ""
+
+#: static/js/zamboni/devhub-all.js:3016 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:483
+msgid "{0} warning"
+msgid_plural "{0} warnings"
+msgstr[0] "{0} peringatan"
+msgstr[1] ""
+
+#: static/js/zamboni/devhub-all.js:3018 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:485
+msgid "{0} notice"
+msgid_plural "{0} notices"
+msgstr[0] "{0} pernyataan"
+msgstr[1] ""
+
+#: static/js/zamboni/devhub-all.js:3110 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:577
+msgid "Validation task could not complete or completed with errors"
+msgstr "Tugas validasi tidak selesai atau selesai dengan masalah"
+
+#: static/js/zamboni/devhub-all.js:3128 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:595
+msgid "Internal server error"
+msgstr "Masalah server internal"
 
 #: static/js/zamboni/devhub_search.js:8
 msgid "No results found."
 msgstr "Tidak ditemukan hasil."
 
-#: static/js/zamboni/editors.js:121
+#: static/js/zamboni/editors-all.js:15402 static/js/zamboni/editors-min.js:4 static/js/zamboni/editors.js:121
 msgid "{name} was viewing this page first."
 msgstr "{name} melihat laman ini terlebih dahulu."
 
-#: static/js/zamboni/editors.js:171
+#: static/js/zamboni/editors-all.js:15452 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:171
 msgid "Receipt checked by app."
 msgstr "Tanda konfirmasi diperiksa oleh aplikasi."
 
-#: static/js/zamboni/editors.js:173
+#: static/js/zamboni/editors-all.js:15454 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:173
 msgid "Receipt was not checked by app."
 msgstr "Tanda konfirmasi tidak diperiksa oleh aplikasi."
 
-#: static/js/zamboni/editors.js:244
+#: static/js/zamboni/editors-all.js:15525 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:244
 msgid "{name} was viewing this add-on first."
 msgstr "{name} melihat pengaya ini terlebih dulu."
 
-#: static/js/zamboni/editors.js:255
+#: static/js/zamboni/editors-all.js:15536 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:255
 msgid "Loading&hellip;"
 msgstr "Memuat&hellip;"
 
-#: static/js/zamboni/editors.js:260
+#: static/js/zamboni/editors-all.js:15541 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:260
 msgid "Version Notes"
 msgstr "Catatan Versi"
 
-#: static/js/zamboni/editors.js:265
+#: static/js/zamboni/editors-all.js:15546 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:265
 msgid "Notes for Reviewers"
 msgstr "Catatan untuk Pengulas"
 
-#: static/js/zamboni/editors.js:270
+#: static/js/zamboni/editors-all.js:15551 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:270
 msgid "No version notes found"
 msgstr "Tidak ditemukan catatan versi"
 
-#: static/js/zamboni/editors.js:330
+#: static/js/zamboni/editors-all.js:15611 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:330
 msgid "Average Reviews"
 msgstr "Ulasan Rata-rata"
 
-#: static/js/zamboni/editors.js:386
+#: static/js/zamboni/editors-all.js:15667 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:386
 msgid "Number of Reviews"
 msgstr "Jumlah Ulasan"
 
-#: static/js/zamboni/editors.js:445
+#: static/js/zamboni/editors-all.js:15726 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:445
 msgid "Error loading translation"
 msgstr "Ada masalah memuat terjemahan"
 
-#: static/js/zamboni/files.js:411 static/js/zamboni/validator.js:261
-msgid "Ignore this message in future updates"
-msgstr "Abaikan pesan ini untuk pembaruan selanjutnya"
-
-#: static/js/zamboni/files.js:417 static/js/zamboni/validator.js:284
-msgid "Severity for automated signing:"
-msgstr "Kepelikan untuk menandai otomatis:"
-
-#: static/js/zamboni/global.js:410
-msgid "Loading..."
-msgstr "Memuat..."
-
-#. L10n: {0} is the number of characters left.
-#: static/js/zamboni/global.js:474
-msgid "<b>{0}</b> character left."
-msgid_plural "<b>{0}</b> characters left."
-msgstr[0] "Sisa <b>{0}</b> karakter."
-
-#: static/js/zamboni/init.js:28
-msgid "This feature is temporarily disabled while we perform website maintenance. Please check back a little later."
-msgstr "Fitur ini sementara dinonaktifkan saat kita melakukan pemeliharaan situs. Periksa kembali nanti."
-
-#: static/js/zamboni/l10n.js:45
-msgid "Remove this localization"
-msgstr "Hapus lokalisasi ini"
-
-#: static/js/zamboni/password-strength.js:20
-msgid "Password strength:"
-msgstr "Kekuatan kata sandi:"
-
-#: static/js/zamboni/password-strength.js:26
-msgid "At least {0} character left."
-msgid_plural "At least {0} characters left."
-msgstr[0] "Paling sedikit sisa {0} karakter."
-
-#: static/js/zamboni/themes_review.js:176
-msgid "Requested Info"
-msgstr "Info yang Diminta"
-
-#: static/js/zamboni/themes_review.js:177
-msgid "Flagged"
-msgstr "Ditandai"
-
-#: static/js/zamboni/themes_review.js:178
-msgid "Duplicate"
-msgstr "Duplikat"
-
-#: static/js/zamboni/themes_review.js:179
-msgid "Rejected"
-msgstr "Ditolak"
-
-#: static/js/zamboni/themes_review.js:180
-msgid "Approved"
-msgstr "Disetujui"
-
-#: static/js/zamboni/themes_review.js:424
-msgid "No results found"
-msgstr "Tidak ditemukan hasil"
-
-#: static/js/zamboni/themes_review_templates.js:31
+#: static/js/zamboni/editors-all.js:15975 static/js/zamboni/editors-min.js:5 static/js/zamboni/themes_review_templates.js:31
 msgid "Theme"
 msgstr "Tema"
 
-#: static/js/zamboni/themes_review_templates.js:33
+#: static/js/zamboni/editors-all.js:15977 static/js/zamboni/editors-min.js:5 static/js/zamboni/themes_review_templates.js:33
 msgid "Reviewer"
 msgstr "Pengulas"
 
-#: static/js/zamboni/themes_review_templates.js:35
+#: static/js/zamboni/editors-all.js:15979 static/js/zamboni/editors-min.js:5 static/js/zamboni/themes_review_templates.js:35
 msgid "Status"
 msgstr "Status"
 
-#: static/js/zamboni/validator.js:80
-msgid "All tests passed successfully."
-msgstr "Semua tes lulus dengan sukses."
+#: static/js/zamboni/editors-all.js:16196 static/js/zamboni/editors-min.js:5 static/js/zamboni/themes_review.js:176
+msgid "Requested Info"
+msgstr "Info yang Diminta"
 
-#: static/js/zamboni/validator.js:83 static/js/zamboni/validator.js:478
-msgid "These tests were not run."
-msgstr "Tes tersebut tidak dijalankan."
+#: static/js/zamboni/editors-all.js:16197 static/js/zamboni/editors-min.js:5 static/js/zamboni/themes_review.js:177
+msgid "Flagged"
+msgstr "Ditandai"
 
-#: static/js/zamboni/validator.js:131 static/js/zamboni/validator.js:144
-msgid "Tests"
-msgstr "Tes"
+#: static/js/zamboni/editors-all.js:16198 static/js/zamboni/editors-min.js:5 static/js/zamboni/themes_review.js:178
+msgid "Duplicate"
+msgstr "Duplikat"
 
-#: static/js/zamboni/validator.js:246 static/js/zamboni/validator.js:575 static/js/zamboni/validator.js:594
-msgid "Error"
-msgstr "Masalah"
+#: static/js/zamboni/editors-all.js:16199 static/js/zamboni/editors-min.js:5 static/js/zamboni/themes_review.js:179
+msgid "Rejected"
+msgstr "Ditolak"
 
-#: static/js/zamboni/validator.js:247
-msgid "Warning"
-msgstr "Peringatan"
+#: static/js/zamboni/editors-all.js:16200 static/js/zamboni/editors-min.js:5 static/js/zamboni/themes_review.js:180
+msgid "Approved"
+msgstr "Disetujui"
 
-#: static/js/zamboni/validator.js:299
-msgid "Suggestions for passing automated signing:"
-msgstr "Saran untuk lulus tanda tangan otomatis:"
+#: static/js/zamboni/editors-all.js:16444 static/js/zamboni/editors-min.js:5 static/js/zamboni/themes_review.js:424
+msgid "No results found"
+msgstr "Tidak ditemukan hasil"
 
-#: static/js/zamboni/validator.js:387
-msgid "Compatibility Tests"
-msgstr "Tes Kompatibilitas"
-
-#: static/js/zamboni/validator.js:466
-msgid "Add-on failed validation."
-msgstr "Pengaya gagal validasi."
-
-#: static/js/zamboni/validator.js:468
-msgid "Add-on passed validation."
-msgstr "Pengaya lulus validasi."
-
-#: static/js/zamboni/validator.js:481
-msgid "{0} error"
-msgid_plural "{0} errors"
-msgstr[0] "{0} masalah"
-
-#: static/js/zamboni/validator.js:483
-msgid "{0} warning"
-msgid_plural "{0} warnings"
-msgstr[0] "{0} peringatan"
-
-#: static/js/zamboni/validator.js:485
-msgid "{0} notice"
-msgid_plural "{0} notices"
-msgstr[0] "{0} pernyataan"
-
-#: static/js/zamboni/validator.js:577
-msgid "Validation task could not complete or completed with errors"
-msgstr "Tugas validasi tidak selesai atau selesai dengan masalah"
-
-#: static/js/zamboni/validator.js:595
-msgid "Internal server error"
-msgstr "Masalah server internal"
-
-#: static/js/zamboni/mobile/buttons.js:52
+#: static/js/zamboni/mobile-all.js:15186 static/js/zamboni/mobile/buttons.js:52
 msgid "Not Updated for {0} {1}"
 msgstr "{0}{1} Tidak Diperbarui"
 
-#: static/js/zamboni/mobile/buttons.js:53
+#: static/js/zamboni/mobile-all.js:15187 static/js/zamboni/mobile/buttons.js:53
 msgid "Requires Newer Version of {0}"
 msgstr "Membutuhkan {0} Yang Lebih Baru"
 
-#: static/js/zamboni/mobile/buttons.js:54
+#: static/js/zamboni/mobile-all.js:15188 static/js/zamboni/mobile/buttons.js:54
 msgid "Unreviewed"
 msgstr "Belum diulas"
 
-#: static/js/zamboni/mobile/buttons.js:55
+#: static/js/zamboni/mobile-all.js:15189 static/js/zamboni/mobile/buttons.js:55
 msgid "Experimental <span>(Learn More)</span>"
 msgstr "Eksperimental<span>(Pelajari Lebih Lanjut)</span>"
 
-#: static/js/zamboni/mobile/buttons.js:56 static/js/zamboni/mobile/buttons.js:57
+#: static/js/zamboni/mobile-all.js:15190 static/js/zamboni/mobile-all.js:15191 static/js/zamboni/mobile/buttons.js:56 static/js/zamboni/mobile/buttons.js:57
 msgid "Not Available for {0}"
 msgstr "{0} Tidak Tersedia"
 
-#: static/js/zamboni/mobile/buttons.js:58
+#: static/js/zamboni/mobile-all.js:15192 static/js/zamboni/mobile/buttons.js:58
 msgid "Experimental"
 msgstr "Bersifat experimental"
 
-#: static/js/zamboni/mobile/buttons.js:59
+#: static/js/zamboni/mobile-all.js:15193 static/js/zamboni/mobile/buttons.js:59
 msgid "Themes Require Newer Version of {0}"
 msgstr "Tema Membutuhkan {0} yang Lebih Baru"
 
-#: static/js/zamboni/mobile/buttons.js:60
+#: static/js/zamboni/mobile-all.js:15194 static/js/zamboni/mobile/buttons.js:60
 msgid "Themes Require {0}"
 msgstr "Tema membutuhkan {0}"
 
-#: static/js/zamboni/mobile/buttons.js:105
+#: static/js/zamboni/mobile-all.js:15239 static/js/zamboni/mobile/buttons.js:105
 msgid "Installing..."
 msgstr "Memasang..."
 
-#: static/js/zamboni/mobile/buttons.js:125
+#: static/js/zamboni/mobile-all.js:15259 static/js/zamboni/mobile/buttons.js:125
 msgid "This add-on has been preliminarily reviewed by Mozilla."
 msgstr "Pengaya ini telah diulas lebih dulu oleh Mozilla."
 
-#: static/js/zamboni/mobile/buttons.js:250
+#: static/js/zamboni/mobile-all.js:15384 static/js/zamboni/mobile/buttons.js:250
 msgid "Keep it"
 msgstr "Pertahankan"
 
-#: static/js/zamboni/mobile/general.js:344
+#: static/js/zamboni/mobile-all.js:16049 static/js/zamboni/mobile-min.js:6 static/js/zamboni/mobile/general.js:344
 msgid "You're trying it on!"
 msgstr "Anda mencobanya!"
 
-#: static/js/zamboni/mobile/general.js:356
+#: static/js/zamboni/mobile-all.js:16061 static/js/zamboni/mobile-min.js:6 static/js/zamboni/mobile/general.js:356
 msgid "Added to Firefox"
 msgstr "Ditambahkan ke Firefox"
-

--- a/locale/it/LC_MESSAGES/django.po
+++ b/locale/it/LC_MESSAGES/django.po
@@ -7,69 +7,70 @@ msgid ""
 msgstr ""
 "Project-Id-Version: REMORA 0.1\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2016-02-24 21:23+0000\n"
+"POT-Creation-Date: 2016-04-18 15:47+0000\n"
 "PO-Revision-Date: 2016-03-24 12:23+0000\n"
 "Last-Translator: Sandro Della Giustina <gialloporpora@mozillaitalia.org>\n"
 "Language-Team: Mozilla Italia\n"
+"Language: \n"
 "MIME-Version: 1.0\n"
-"Content-Type: text/plain; charset=utf-8\n"
+"Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Generated-By: Babel 2.2.0\n"
 
-#: src/olympia/accounts/views.py:52
+#: src/olympia/accounts/views.py:54
 msgid "Your log in attempt could not be parsed. Please try again."
 msgstr "Il tentativo di accesso che hai effettuato non può essere analizzato. Riprova."
 
-#: src/olympia/accounts/views.py:54
+#: src/olympia/accounts/views.py:56
 msgid "Your Firefox Account could not be found. Please try again."
 msgstr "Impossibile associare questo utente a un account Firefox. Riprova."
 
-#: src/olympia/accounts/views.py:55
+#: src/olympia/accounts/views.py:57
 msgid "You could not be logged in. Please try again."
 msgstr "Impossibile effettuare l’accesso. Riprova."
 
-#: src/olympia/accounts/views.py:57
+#: src/olympia/accounts/views.py:59
 msgid "Your account has already been migrated to Firefox Accounts."
 msgstr "Questo account è già stato aggiornato per accedere tramite l’account Firefox."
 
-#: src/olympia/accounts/views.py:59
+#: src/olympia/accounts/views.py:61
 msgid "Your Firefox Account already exists on this site."
 msgstr "Questo sito è già stato associato al tuo account Firefox."
 
-#: src/olympia/accounts/views.py:108
+#: src/olympia/accounts/views.py:110
 msgid "Great job!"
 msgstr "Ben fatto."
 
-#: src/olympia/accounts/views.py:109
+#: src/olympia/accounts/views.py:111
 msgid "You can now log in to Add-ons with your Firefox Account."
 msgstr "Adesso puoi effettuare l’accesso a Mozilla Add-ons con l’account Firefox."
 
-#: src/olympia/accounts/views.py:121
+#: src/olympia/accounts/views.py:123
 msgid "Need help?"
 msgstr "Hai bisogno di aiuto?"
 
-#: src/olympia/addons/buttons.py:180
+#: src/olympia/addons/buttons.py:177
 msgid "Download Now"
 msgstr "Scarica ora"
 
-#: src/olympia/addons/buttons.py:182
+#: src/olympia/addons/buttons.py:179
 msgid "Download"
 msgstr "Download"
 
 #. L10n: please keep &nbsp; in the string so &rarr; does not wrap.
-#: src/olympia/addons/buttons.py:186
+#: src/olympia/addons/buttons.py:183
 msgid "Continue to Download&nbsp;&rarr;"
 msgstr "Vai al download&nbsp;&rarr;"
 
-#: src/olympia/addons/buttons.py:202 src/olympia/addons/helpers.py:35 src/olympia/addons/views.py:319 src/olympia/addons/templates/addons/impala/details.html:114
+#: src/olympia/addons/buttons.py:199 src/olympia/addons/helpers.py:35 src/olympia/addons/views.py:333 src/olympia/addons/templates/addons/impala/details.html:111
 #: src/olympia/addons/templates/addons/impala/listing/items.html:17 src/olympia/addons/templates/addons/mobile/home.html:40 src/olympia/amo/templates/amo/side_nav.html:6
-#: src/olympia/amo/templates/amo/side_nav.html:10 src/olympia/amo/templates/amo/site_nav.html:2 src/olympia/amo/templates/amo/site_nav.html:55 src/olympia/bandwagon/views.py:95
-#: src/olympia/browse/views.py:54 src/olympia/browse/views.py:68 src/olympia/browse/views.py:235 src/olympia/browse/templates/browse/impala/category_landing.html:22
+#: src/olympia/amo/templates/amo/side_nav.html:10 src/olympia/amo/templates/amo/site_nav.html:2 src/olympia/amo/templates/amo/site_nav.html:53 src/olympia/bandwagon/views.py:95
+#: src/olympia/browse/views.py:54 src/olympia/browse/views.py:68 src/olympia/browse/views.py:202 src/olympia/browse/templates/browse/impala/category_landing.html:22
 #: src/olympia/browse/templates/browse/personas/mobile/category_landing.html:26
 msgid "Featured"
 msgstr "Consigliati"
 
-#: src/olympia/addons/buttons.py:221
+#: src/olympia/addons/buttons.py:218
 msgid "Add to {0}"
 msgstr "Aggiungi a {0}"
 
@@ -117,39 +118,39 @@ msgid_plural "All tags must be at least {0} characters."
 msgstr[0] "Le etichette devono essere lunghe almeno {0} carattere."
 msgstr[1] "Le etichette devono essere lunghe almeno {0} caratteri."
 
-#: src/olympia/addons/forms.py:234
+#: src/olympia/addons/forms.py:238
 msgid "Categories cannot be changed while your add-on is featured for this application."
 msgstr "Non è possibile cambiare le categorie quando il componente aggiuntivo è consigliato per questa applicazione."
 
 #. L10n: {0} is the number of categories.
-#: src/olympia/addons/forms.py:238
+#: src/olympia/addons/forms.py:242
 msgid "You can have only {0} category."
 msgid_plural "You can have only {0} categories."
 msgstr[0] "È possibile indicare solo {0} categoria."
 msgstr[1] "È possibile indicare solo {0} categorie."
 
-#: src/olympia/addons/forms.py:246
+#: src/olympia/addons/forms.py:250
 msgid "The miscellaneous category cannot be combined with additional categories."
 msgstr "La categoria Varie non può essere utilizzata insieme ad ulteriori categorie."
 
-#: src/olympia/addons/forms.py:369
+#: src/olympia/addons/forms.py:374
 #, python-format
 msgid "Before changing your default locale you must have a name, summary, and description in that locale. You are missing %s."
 msgstr "Per poter modificare il locale predefinito è necessario inserire un nome, un sommario e una descrizione in quel locale. Attualmente mancano %s."
 
-#: src/olympia/addons/forms.py:484 src/olympia/addons/forms.py:575
+#: src/olympia/addons/forms.py:455 src/olympia/addons/forms.py:546
 msgid "A license must be selected."
 msgstr "È necessario selezionare una licenza."
 
-#: src/olympia/addons/forms.py:556
+#: src/olympia/addons/forms.py:527
 msgid "Give Your Theme a Name."
 msgstr "Scegli un nome per il tema."
 
-#: src/olympia/addons/forms.py:562 src/olympia/devhub/templates/devhub/personas/submit.html:53
+#: src/olympia/addons/forms.py:533 src/olympia/devhub/templates/devhub/personas/submit.html:53
 msgid "Describe your Theme."
 msgstr "Descrivi il tuo tema."
 
-#: src/olympia/addons/forms.py:704
+#: src/olympia/addons/forms.py:675
 msgid "Enter a new author's email address"
 msgstr "Inserisci l’indirizzo email di un nuovo autore"
 
@@ -157,39 +158,39 @@ msgstr "Inserisci l’indirizzo email di un nuovo autore"
 msgid "Not Reviewed"
 msgstr "Non verificato"
 
-#: src/olympia/addons/models.py:301
+#: src/olympia/addons/models.py:298
 msgid "Users have the option of contributing more or less than this amount."
 msgstr "Gli utenti possono donare un importo superiore o inferiore a questa cifra."
 
-#: src/olympia/addons/models.py:309
-msgid "Users will always be asked in the Add-ons Manager (Firefox 4 and above)"
-msgstr "Gli utenti riceveranno una richiesta nella schermata di gestione delle estensioni (Firefox 4 e successivi)"
+#: src/olympia/addons/models.py:306
+msgid "Users will always be asked in the Add-ons Manager (Firefox 4 and above). Only applies to desktop."
+msgstr ""
 
 # Column name in a table.
-#: src/olympia/addons/models.py:1804 src/olympia/addons/templates/addons/details_box.html:55 src/olympia/devhub/templates/devhub/index.html:92
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:102
+#: src/olympia/addons/models.py:1802 src/olympia/addons/templates/addons/details_box.html:55 src/olympia/devhub/templates/devhub/index.html:92
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:89
 msgid "Listed"
 msgstr "Visualizzato"
 
-#: src/olympia/addons/views.py:320 src/olympia/browse/templates/browse/personas/mobile/category_landing.html:27
+#: src/olympia/addons/views.py:334 src/olympia/browse/templates/browse/personas/mobile/category_landing.html:27
 msgid "Popular"
 msgstr "Popolari"
 
-#: src/olympia/addons/views.py:321 src/olympia/browse/views.py:238 src/olympia/browse/views.py:280 src/olympia/browse/views.py:482
+#: src/olympia/addons/views.py:335 src/olympia/browse/views.py:205 src/olympia/browse/views.py:247 src/olympia/browse/views.py:449
 msgid "Recently Added"
 msgstr "Più recenti"
 
-#: src/olympia/addons/views.py:322 src/olympia/bandwagon/views.py:99 src/olympia/browse/views.py:60 src/olympia/browse/views.py:71 src/olympia/search/forms.py:16 src/olympia/search/forms.py:91
+#: src/olympia/addons/views.py:336 src/olympia/bandwagon/views.py:99 src/olympia/browse/views.py:60 src/olympia/browse/views.py:71 src/olympia/search/forms.py:16 src/olympia/search/forms.py:91
 msgid "Recently Updated"
 msgstr "Aggiornati di recente"
 
 # %1 is an add-on name.
 #. l10n: {0} is the addon name
-#: src/olympia/addons/views.py:520
+#: src/olympia/addons/views.py:534
 msgid "Contribution for {0}"
 msgstr "Donazioni per {0}"
 
-#: src/olympia/addons/views.py:613
+#: src/olympia/addons/views.py:627
 msgid "Abuse reported."
 msgstr "Abuso segnalato."
 
@@ -258,9 +259,9 @@ msgstr "Fai una donazione"
 #: src/olympia/devhub/templates/devhub/addons/ajax_compat_update.html:36 src/olympia/devhub/templates/devhub/addons/profile.html:44 src/olympia/devhub/templates/devhub/addons/edit/admin.html:101
 #: src/olympia/devhub/templates/devhub/addons/edit/basic.html:152 src/olympia/devhub/templates/devhub/addons/edit/details.html:85 src/olympia/devhub/templates/devhub/addons/edit/support.html:67
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:166 src/olympia/devhub/templates/devhub/addons/forms_shared/media.html:149
-#: src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:44 src/olympia/devhub/templates/devhub/versions/add_file_modal.html:78 src/olympia/devhub/templates/devhub/versions/edit.html:139
-#: src/olympia/devhub/templates/devhub/versions/list.html:242 src/olympia/devhub/templates/devhub/versions/list.html:276 src/olympia/devhub/templates/devhub/versions/list.html:317
-#: src/olympia/devhub/templates/devhub/versions/list.html:351 src/olympia/reviews/templates/reviews/edit_review.html:16 src/olympia/translations/templates/translations/trans-menu.html:50
+#: src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:43 src/olympia/devhub/templates/devhub/versions/add_file_modal.html:58 src/olympia/devhub/templates/devhub/versions/edit.html:139
+#: src/olympia/devhub/templates/devhub/versions/list.html:239 src/olympia/devhub/templates/devhub/versions/list.html:281 src/olympia/devhub/templates/devhub/versions/list.html:315
+#: src/olympia/devhub/templates/devhub/versions/list.html:349 src/olympia/reviews/templates/reviews/edit_review.html:16 src/olympia/translations/templates/translations/trans-menu.html:50
 #: src/olympia/translations/templates/translations/trans-menu.html:62
 msgid "or"
 msgstr "o"
@@ -334,8 +335,7 @@ msgstr "L’importo della donazione deve essere un numero."
 msgid "A one-time suggested contribution of {0}"
 msgstr "Una donazione “una tantum” consigliata di {0}"
 
-#. {0} is a currency symbol (e.g., $),                    {1} is an amount
-#. input
+#. {0} is a currency symbol (e.g., $),                    {1} is an amount input
 #. field
 #: src/olympia/addons/templates/addons/contributions_lightbox.html:64
 msgid "A one-time contribution of {0} {1}"
@@ -376,7 +376,7 @@ msgid "Add-on Information for {0}"
 msgstr "Informazioni componente aggiuntivo per {0}"
 
 #: src/olympia/addons/templates/addons/details_box.html:30 src/olympia/addons/templates/addons/persona_detail_table.html:3 src/olympia/addons/templates/addons/mobile/details.html:63
-#: src/olympia/addons/templates/addons/mobile/persona_detail_table.html:7 src/olympia/browse/views.py:459 src/olympia/devhub/views.py:75
+#: src/olympia/addons/templates/addons/mobile/persona_detail_table.html:7 src/olympia/browse/views.py:426 src/olympia/devhub/views.py:73
 msgid "Updated"
 msgstr "Aggiornato"
 
@@ -395,11 +395,11 @@ msgstr "Compatibile con"
 msgid "Visibility"
 msgstr "Visibilità"
 
-#: src/olympia/addons/templates/addons/details_box.html:57 src/olympia/devhub/templates/devhub/index.html:94 src/olympia/devhub/templates/devhub/includes/addon_details.html:104
+#: src/olympia/addons/templates/addons/details_box.html:57 src/olympia/devhub/templates/devhub/index.html:94 src/olympia/devhub/templates/devhub/includes/addon_details.html:91
 msgid "Hidden"
 msgstr "Nascosto"
 
-#: src/olympia/addons/templates/addons/details_box.html:59 src/olympia/devhub/templates/devhub/index.html:96 src/olympia/devhub/templates/devhub/includes/addon_details.html:106
+#: src/olympia/addons/templates/addons/details_box.html:59 src/olympia/devhub/templates/devhub/index.html:96 src/olympia/devhub/templates/devhub/includes/addon_details.html:93
 msgid "Unlisted"
 msgstr "Esterno"
 
@@ -407,13 +407,13 @@ msgstr "Esterno"
 msgid "Required Add-ons"
 msgstr "Componenti aggiuntivi richiesti"
 
-#: src/olympia/addons/templates/addons/details_box.html:81 src/olympia/addons/templates/addons/persona_detail_table.html:15 src/olympia/browse/views.py:462 src/olympia/devhub/views.py:78
-#: src/olympia/devhub/views.py:85 src/olympia/discovery/templates/discovery/addons/detail.html:57 src/olympia/reviews/forms.py:62 src/olympia/reviews/templates/reviews/add.html:57
+#: src/olympia/addons/templates/addons/details_box.html:81 src/olympia/addons/templates/addons/persona_detail_table.html:15 src/olympia/browse/views.py:429 src/olympia/devhub/views.py:76
+#: src/olympia/devhub/views.py:83 src/olympia/discovery/templates/discovery/addons/detail.html:57 src/olympia/reviews/forms.py:62 src/olympia/reviews/templates/reviews/add.html:57
 #: src/olympia/reviews/templates/reviews/mobile/review_list.html:18
 msgid "Rating"
 msgstr "Voto"
 
-#: src/olympia/addons/templates/addons/details_box.html:85 src/olympia/browse/views.py:461 src/olympia/devhub/views.py:77 src/olympia/devhub/views.py:84
+#: src/olympia/addons/templates/addons/details_box.html:85 src/olympia/browse/views.py:428 src/olympia/devhub/views.py:75 src/olympia/devhub/views.py:82
 #: src/olympia/stats/templates/stats/addon_report_menu.html:8 src/olympia/stats/templates/stats/collection_report_menu.html:18
 msgid "Downloads"
 msgstr "Download"
@@ -433,7 +433,7 @@ msgstr "Segnala abuso"
 
 #. The Privacy Policy for this add-on.
 #: src/olympia/addons/templates/addons/details_box.html:121 src/olympia/addons/templates/addons/privacy.html:19 src/olympia/addons/templates/addons/privacy.html:23
-#: src/olympia/addons/templates/addons/impala/button.html:43 src/olympia/addons/templates/addons/impala/details.html:307 src/olympia/devhub/templates/devhub/includes/policy_form.html:20
+#: src/olympia/addons/templates/addons/impala/button.html:43 src/olympia/addons/templates/addons/impala/details.html:312 src/olympia/devhub/templates/devhub/includes/policy_form.html:23
 #: src/olympia/templates/mobile/base_addons.html:87
 msgid "Privacy Policy"
 msgstr "Informativa sulla privacy"
@@ -458,7 +458,7 @@ msgstr "Galleria delle anteprime"
 msgid "Developer Comments"
 msgstr "Commenti dello sviluppatore"
 
-#: src/olympia/addons/templates/addons/details_box.html:199 src/olympia/addons/templates/addons/impala/details.html:259
+#: src/olympia/addons/templates/addons/details_box.html:199 src/olympia/addons/templates/addons/impala/details.html:264
 msgid "Development Channel"
 msgstr "Canale di sviluppo"
 
@@ -482,13 +482,13 @@ msgstr ""
 "<strong>Attenzione:</strong> le versioni di sviluppo di questo componente aggiuntivo non sono state verificate da Mozilla. Installando una versione di sviluppo continuerai a ricevere tutti gli "
 "aggiornamenti relativi alle versioni sperimentali. Per non ricevere più questo tipo di aggiornamenti, reinstalla la versione ufficiale utilizzando il link fornito."
 
-#: src/olympia/addons/templates/addons/details_box.html:220 src/olympia/addons/templates/addons/impala/details.html:278
+#: src/olympia/addons/templates/addons/details_box.html:220 src/olympia/addons/templates/addons/impala/details.html:283
 msgid "Version {0}:"
 msgstr "Versione {0}:"
 
 #: src/olympia/addons/templates/addons/details_box.html:234
 msgid "Nothing to see here!  The developer did not include any details."
-msgstr "Nessuna informazione disponibile. Lo sviluppatore non ha inserito dati."
+msgstr ""
 
 #: src/olympia/addons/templates/addons/details_box.html:251 src/olympia/devhub/templates/devhub/versions/edit.html:73 src/olympia/editors/templates/editors/review.html:98
 msgid "Version Notes"
@@ -501,7 +501,7 @@ msgid "End-User License Agreement for {0}"
 msgstr "Licenza per l’utente finale (EULA) per {0}"
 
 #: src/olympia/addons/templates/addons/eula.html:17 src/olympia/addons/templates/addons/eula.html:21 src/olympia/addons/templates/addons/impala/button.html:48
-#: src/olympia/addons/templates/addons/impala/details.html:316 src/olympia/devhub/templates/devhub/includes/policy_form.html:3 src/olympia/discovery/templates/discovery/addons/eula.html:11
+#: src/olympia/addons/templates/addons/impala/details.html:321 src/olympia/devhub/templates/devhub/includes/policy_form.html:3 src/olympia/discovery/templates/discovery/addons/eula.html:11
 msgid "End-User License Agreement"
 msgstr "Licenza per l’utente finale"
 
@@ -521,7 +521,7 @@ msgstr "Ritorna a {0}…"
 msgid "Add-ons for {0}"
 msgstr "Componenti aggiuntivi per {0}"
 
-#: src/olympia/addons/templates/addons/home.html:10 src/olympia/addons/templates/addons/home.html:51 src/olympia/browse/templates/browse/impala/base_listing.html:11
+#: src/olympia/addons/templates/addons/home.html:10 src/olympia/addons/templates/addons/home.html:53 src/olympia/browse/templates/browse/impala/base_listing.html:11
 msgid "Featured Extensions"
 msgstr "Estensioni consigliate"
 
@@ -529,29 +529,29 @@ msgstr "Estensioni consigliate"
 msgid "Popular Extensions"
 msgstr "Estensioni popolari"
 
-#: src/olympia/addons/templates/addons/home.html:42 src/olympia/amo/templates/amo/side_nav.html:3 src/olympia/amo/templates/amo/side_nav.html:11 src/olympia/amo/templates/amo/site_nav.html:3
-#: src/olympia/amo/templates/amo/site_nav.html:25 src/olympia/browse/views.py:236 src/olympia/browse/views.py:281 src/olympia/browse/views.py:481
+#: src/olympia/addons/templates/addons/home.html:44 src/olympia/amo/templates/amo/side_nav.html:3 src/olympia/amo/templates/amo/side_nav.html:11 src/olympia/amo/templates/amo/site_nav.html:3
+#: src/olympia/amo/templates/amo/site_nav.html:25 src/olympia/browse/views.py:203 src/olympia/browse/views.py:248 src/olympia/browse/views.py:448
 msgid "Most Popular"
 msgstr "Più popolari"
 
-#: src/olympia/addons/templates/addons/home.html:43
+#: src/olympia/addons/templates/addons/home.html:45
 msgid "All »"
 msgstr "Tutto »"
 
-#: src/olympia/addons/templates/addons/home.html:52 src/olympia/addons/templates/addons/home.html:61 src/olympia/addons/templates/addons/home.html:70 src/olympia/addons/templates/addons/home.html:78
+#: src/olympia/addons/templates/addons/home.html:54 src/olympia/addons/templates/addons/home.html:63 src/olympia/addons/templates/addons/home.html:72 src/olympia/addons/templates/addons/home.html:80
 #: src/olympia/browse/templates/browse/impala/category_landing.html:36
 msgid "See all »"
 msgstr "Vedi tutto »"
 
-#: src/olympia/addons/templates/addons/home.html:60
+#: src/olympia/addons/templates/addons/home.html:62
 msgid "Up &amp; Coming Extensions"
 msgstr "Estensioni emergenti"
 
-#: src/olympia/addons/templates/addons/home.html:69 src/olympia/browse/templates/browse/personas/category_landing.html:61 src/olympia/discovery/templates/discovery/pane.html:74
+#: src/olympia/addons/templates/addons/home.html:71 src/olympia/browse/templates/browse/personas/category_landing.html:61 src/olympia/discovery/templates/discovery/pane.html:74
 msgid "Featured Themes"
 msgstr "Temi consigliati"
 
-#: src/olympia/addons/templates/addons/home.html:77 src/olympia/bandwagon/templates/bandwagon/impala/collection_listing.html:5
+#: src/olympia/addons/templates/addons/home.html:79 src/olympia/bandwagon/templates/bandwagon/impala/collection_listing.html:5
 msgid "Featured Collections"
 msgstr "Raccolte consigliate"
 
@@ -569,7 +569,7 @@ msgid "Updated {0}"
 msgstr "Aggiornato {0}"
 
 #. {0} is a date.
-#: src/olympia/addons/templates/addons/macros.html:10 src/olympia/addons/templates/addons/macros.html:69 src/olympia/addons/templates/addons/persona_preview.html:21
+#: src/olympia/addons/templates/addons/macros.html:10 src/olympia/addons/templates/addons/macros.html:69 src/olympia/addons/templates/addons/persona_preview.html:22
 #: src/olympia/addons/templates/addons/listing/items_mobile.html:44 src/olympia/addons/templates/addons/listing/macros.html:39
 #: src/olympia/bandwagon/templates/bandwagon/collection_listing_items.html:37 src/olympia/bandwagon/templates/bandwagon/impala/collection_listing_items.html:37
 msgid "Added {0}"
@@ -590,15 +590,14 @@ msgstr[0] "%(num)s utente"
 msgstr[1] "%(num)s utenti"
 
 #. {0} is the number of downloads.
-#: src/olympia/addons/templates/addons/macros.html:53 src/olympia/addons/templates/addons/impala/details.html:61
+#: src/olympia/addons/templates/addons/macros.html:53 src/olympia/addons/templates/addons/impala/details.html:59
 msgid "{0} weekly download"
 msgid_plural "{0} weekly downloads"
 msgstr[0] "{0} download settimanali"
 msgstr[1] "{0} download settimanali"
 
 #. {0} is the number of users.
-#: src/olympia/addons/templates/addons/macros.html:61 src/olympia/addons/templates/addons/impala/details.html:54 src/olympia/compat/templates/compat/index.html:71
-#: src/olympia/zadmin/templates/zadmin/compat.html:67
+#: src/olympia/addons/templates/addons/macros.html:61 src/olympia/addons/templates/addons/impala/details.html:52 src/olympia/zadmin/templates/zadmin/compat.html:67
 msgid "{0} user"
 msgid_plural "{0} users"
 msgstr[0] "{0} utente"
@@ -616,7 +615,7 @@ msgstr "Pagamento completato"
 msgid "Return to the addon."
 msgstr "Ritorna al componente aggiuntivo."
 
-#: src/olympia/addons/templates/addons/persona_detail.html:17 src/olympia/addons/templates/addons/impala/details.html:106 src/olympia/addons/templates/addons/mobile/details.html:23
+#: src/olympia/addons/templates/addons/persona_detail.html:17 src/olympia/addons/templates/addons/impala/details.html:103 src/olympia/addons/templates/addons/mobile/details.html:23
 #: src/olympia/addons/templates/addons/mobile/persona_detail.html:21 src/olympia/discovery/templates/discovery/addons/base.html:27 src/olympia/editors/templates/editors/review.html:31
 msgid "by"
 msgstr "di"
@@ -660,34 +659,35 @@ msgstr "Utenti per giorno"
 msgid "License"
 msgstr "Licenza"
 
-#: src/olympia/addons/templates/addons/persona_preview.html:12 src/olympia/constants/base.py:48
+#: src/olympia/addons/templates/addons/persona_preview.html:13 src/olympia/constants/base.py:48
 msgid "Awaiting Review"
 msgstr "In attesa di revisione"
 
-#: src/olympia/addons/templates/addons/persona_preview.html:14 src/olympia/amo/log.py:180 src/olympia/constants/base.py:42 src/olympia/editors/helpers.py:62
+#: src/olympia/addons/templates/addons/persona_preview.html:15 src/olympia/amo/log.py:180 src/olympia/constants/base.py:42 src/olympia/editors/helpers.py:62
 msgid "Rejected"
 msgstr "Respinto"
 
-#: src/olympia/addons/templates/addons/persona_preview.html:16 src/olympia/amo/log.py:159
+#: src/olympia/addons/templates/addons/persona_preview.html:17 src/olympia/amo/log.py:159
 msgid "Approved"
 msgstr "Approvato"
 
 #. {0} is the number of users.
-#: src/olympia/addons/templates/addons/persona_preview.html:26 src/olympia/addons/templates/addons/listing/items_mobile.html:36 src/olympia/addons/templates/addons/listing/macros.html:31
+#: src/olympia/addons/templates/addons/persona_preview.html:27 src/olympia/addons/templates/addons/listing/items_mobile.html:36 src/olympia/addons/templates/addons/listing/macros.html:31
 msgid "<strong>{0}</strong> user"
 msgid_plural "<strong>{0}</strong> users"
 msgstr[0] "<strong>{0}</strong> utente"
 msgstr[1] "<strong>{0}</strong> utenti"
 
-#: src/olympia/addons/templates/addons/persona_preview.html:40
+#: src/olympia/addons/templates/addons/persona_preview.html:41
 msgid "Hover to Preview"
 msgstr "Anteprima al passaggio del mouse"
 
-#: src/olympia/addons/templates/addons/persona_preview.html:46 src/olympia/addons/templates/addons/persona_preview.html:48 src/olympia/reviews/templates/reviews/add.html:15
+#: src/olympia/addons/templates/addons/persona_preview.html:47 src/olympia/addons/templates/addons/persona_preview.html:49 src/olympia/addons/templates/addons/persona_preview.html:97
+#: src/olympia/reviews/templates/reviews/add.html:15
 msgid "Add"
 msgstr "Aggiungi"
 
-#: src/olympia/addons/templates/addons/persona_preview.html:57 src/olympia/bandwagon/templates/bandwagon/ajax_new.html:16 src/olympia/bandwagon/templates/bandwagon/edit.html:19
+#: src/olympia/addons/templates/addons/persona_preview.html:58 src/olympia/bandwagon/templates/bandwagon/ajax_new.html:16 src/olympia/bandwagon/templates/bandwagon/edit.html:19
 #: src/olympia/bandwagon/templates/bandwagon/includes/addedit.html:19 src/olympia/devhub/templates/devhub/addons/edit/admin.html:13 src/olympia/devhub/templates/devhub/addons/edit/basic.html:10
 #: src/olympia/devhub/templates/devhub/addons/edit/details.html:8 src/olympia/devhub/templates/devhub/addons/edit/media.html:6 src/olympia/devhub/templates/devhub/addons/edit/support.html:8
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:9 src/olympia/devhub/templates/devhub/addons/submit/describe.html:29 src/olympia/editors/templates/editors/review.html:257
@@ -696,21 +696,21 @@ msgstr "Modifica"
 
 #. For datetime formatting, see the table on
 #. http://docs.python.org/library/datetime.html#strftime-and-strptime-behavior
-#: src/olympia/addons/templates/addons/persona_preview.html:66
+#: src/olympia/addons/templates/addons/persona_preview.html:67
 #, python-format
 msgid "%%Y-%%m-%%d"
 msgstr "%%d-%%m-%%Y"
 
-#: src/olympia/addons/templates/addons/persona_preview.html:67
+#: src/olympia/addons/templates/addons/persona_preview.html:68
 msgid "by {0} on {1}"
 msgstr "di {0} del {1}"
 
-#: src/olympia/addons/templates/addons/persona_preview.html:75 src/olympia/reviews/helpers.py:17 src/olympia/reviews/templates/reviews/review_list.html:63
+#: src/olympia/addons/templates/addons/persona_preview.html:76 src/olympia/reviews/helpers.py:17 src/olympia/reviews/templates/reviews/review_list.html:63
 #: src/olympia/reviews/templates/reviews/reviews_link.html:21 src/olympia/reviews/templates/reviews/impala/reviews_link.html:16
 msgid "Not yet rated"
 msgstr "Nessun voto"
 
-#: src/olympia/addons/templates/addons/persona_preview.html:78
+#: src/olympia/addons/templates/addons/persona_preview.html:79
 msgid "<b>{0}</b> users"
 msgstr "<b>{0}</b> utenti"
 
@@ -723,8 +723,8 @@ msgid "Learn more about Firefox"
 msgstr "Scopri altre informazioni su Firefox"
 
 #: src/olympia/addons/templates/addons/popups.html:22
-msgid "or <b><a class=\"installer\" href=\"{url}\">download anyway</a></b>"
-msgstr "o <b><a class=\"installer\" href=\"{url}\">scarica comunque</a></b>"
+msgid "or <b><a class=\"button installer\" href=\"{url}\">download anyway</a></b>"
+msgstr ""
 
 #: src/olympia/addons/templates/addons/popups.html:26
 msgid ""
@@ -788,8 +788,6 @@ msgid ""
 "<strong>Caution:</strong> This add-on has not been reviewed by Mozilla and can't be installed on release versions of Firefox 43 and above.  Be careful when installing third-party software that "
 "might harm your computer."
 msgstr ""
-"<strong>Attenzione:</strong> Questo componente aggiuntivo non è stato revisionato da Mozilla e non può essere installato sulle versioni ufficiali di Firefox 43 e superiori. Ti consigliamo di "
-"procedere sempre con cautela quando installi software di terze parti che potrebbe danneggiare il computer."
 
 #: src/olympia/addons/templates/addons/popups.html:120
 msgid "<strong>Please note:</strong> This add-on is not compatible with your operating system."
@@ -824,11 +822,9 @@ msgid ""
 "  to your phone.  (You'll need a QR reader.  Search your phone's marketplace if\n"
 "  don't have one.)"
 msgstr ""
-"Vuoi installare {0} su Firefox per dispositivi portatili? Scannerizza il codice QR per installarlo direttamente sul tuo smartphone. Per eseguire l’operazione è necessario un qualsiasi lettore di "
-"codici QR, che puoi trovare sulla piattaforma di distribuzione app del tuo smartphone."
 
 #: src/olympia/addons/templates/addons/report_abuse.html:6 src/olympia/addons/templates/addons/report_abuse_full.html:10 src/olympia/addons/templates/addons/impala/details-more.html:23
-#: src/olympia/addons/templates/addons/impala/details.html:328
+#: src/olympia/addons/templates/addons/impala/details.html:333
 msgid "Report Abuse"
 msgstr "Segnala abuso"
 
@@ -849,9 +845,9 @@ msgstr "Invia segnalazione"
 #: src/olympia/devhub/templates/devhub/addons/ajax_compat_update.html:36 src/olympia/devhub/templates/devhub/addons/profile.html:44 src/olympia/devhub/templates/devhub/addons/edit/admin.html:104
 #: src/olympia/devhub/templates/devhub/addons/edit/basic.html:155 src/olympia/devhub/templates/devhub/addons/edit/details.html:88 src/olympia/devhub/templates/devhub/addons/edit/support.html:70
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:169 src/olympia/devhub/templates/devhub/addons/forms_shared/media.html:152
-#: src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:44 src/olympia/devhub/templates/devhub/personas/edit.html:222 src/olympia/devhub/templates/devhub/versions/add_file_modal.html:79
-#: src/olympia/devhub/templates/devhub/versions/edit.html:140 src/olympia/devhub/templates/devhub/versions/list.html:208 src/olympia/devhub/templates/devhub/versions/list.html:242
-#: src/olympia/devhub/templates/devhub/versions/list.html:276 src/olympia/devhub/templates/devhub/versions/list.html:317 src/olympia/reviews/templates/reviews/edit_review.html:16
+#: src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:43 src/olympia/devhub/templates/devhub/personas/edit.html:222 src/olympia/devhub/templates/devhub/versions/add_file_modal.html:59
+#: src/olympia/devhub/templates/devhub/versions/edit.html:140 src/olympia/devhub/templates/devhub/versions/list.html:208 src/olympia/devhub/templates/devhub/versions/list.html:239
+#: src/olympia/devhub/templates/devhub/versions/list.html:281 src/olympia/devhub/templates/devhub/versions/list.html:315 src/olympia/reviews/templates/reviews/edit_review.html:16
 #: src/olympia/translations/templates/translations/trans-menu.html:50 src/olympia/translations/templates/translations/trans-menu.html:62 src/olympia/zadmin/templates/zadmin/validation.html:105
 msgid "Cancel"
 msgstr "Annulla"
@@ -896,7 +892,7 @@ msgstr "Consulta la <a href=\"%(support)s\">sezione di supporto</a> per scoprire
 msgid "Review Guidelines"
 msgstr "Linee guida per le recensioni"
 
-#: src/olympia/addons/templates/addons/review_list_box.html:5 src/olympia/addons/templates/addons/impala/details-more.html:27 src/olympia/editors/helpers.py:921
+#: src/olympia/addons/templates/addons/review_list_box.html:5 src/olympia/addons/templates/addons/impala/details-more.html:27 src/olympia/editors/helpers.py:1001
 #: src/olympia/reviews/templates/reviews/add.html:14 src/olympia/reviews/templates/reviews/reply.html:14 src/olympia/reviews/templates/reviews/review_list.html:19
 #: src/olympia/reviews/templates/reviews/mobile/review_list.html:26
 msgid "Reviews"
@@ -989,31 +985,31 @@ msgid_plural "Other add-ons by these authors"
 msgstr[0] "Altri componenti aggiuntivi di %(author)s"
 msgstr[1] "Altri componenti aggiuntivi di questi autori"
 
-#: src/olympia/addons/templates/addons/impala/details.html:41
+#: src/olympia/addons/templates/addons/impala/details.html:39
 #, python-format
 msgid "<span itemprop=\"ratingCount\">%(num)s</span> user review"
 msgid_plural "<span itemprop=\"ratingCount\">%(num)s</span> user reviews"
 msgstr[0] "<span itemprop=\"ratingCount\">%(num)s</span> recensione"
 msgstr[1] "<span itemprop=\"ratingCount\">%(num)s</span> recensioni"
 
-#: src/olympia/addons/templates/addons/impala/details.html:69
+#: src/olympia/addons/templates/addons/impala/details.html:66
 msgid "View statistics"
 msgstr "Visualizza statistiche"
 
-#: src/olympia/addons/templates/addons/impala/details.html:84
+#: src/olympia/addons/templates/addons/impala/details.html:81
 msgid "Manage"
 msgstr "Gestisci"
 
 #. {0} is an add-on name.
-#: src/olympia/addons/templates/addons/impala/details.html:96
+#: src/olympia/addons/templates/addons/impala/details.html:93
 msgid "Icon of {0}"
 msgstr "Icona di {0}"
 
-#: src/olympia/addons/templates/addons/impala/details.html:103 src/olympia/addons/templates/addons/impala/listing/items.html:14
+#: src/olympia/addons/templates/addons/impala/details.html:100 src/olympia/addons/templates/addons/impala/listing/items.html:14
 msgid "No Restart"
 msgstr "Riavvio non richiesto"
 
-#: src/olympia/addons/templates/addons/impala/details.html:127
+#: src/olympia/addons/templates/addons/impala/details.html:124
 #, python-format
 msgid "Meet the Developer: <a href=\"%(url)s\">%(name)s</a>"
 msgid_plural "<a href=\"%(url)s\">Meet the Developers</a>"
@@ -1021,72 +1017,72 @@ msgstr[0] "Incontra lo sviluppatore: <a href=\"%(url)s\">%(name)s</a>"
 msgstr[1] "<a href=\"%(url)s\">Incontra gli sviluppatori</a>"
 
 # {0} is an add-on name.
-#: src/olympia/addons/templates/addons/impala/details.html:137
+#: src/olympia/addons/templates/addons/impala/details.html:134
 msgid "Learn why {0} was created and find out what's next for this add-on."
 msgstr "Scopri perché {0} è stato realizzato e scopri le prospettive di questo componente aggiuntivo."
 
 #. {0} is an index.
-#: src/olympia/addons/templates/addons/impala/details.html:156
+#: src/olympia/addons/templates/addons/impala/details.html:161
 msgid "Add-on screenshot #{0}"
 msgstr "Screenshot n. {0} del componente aggiuntivo"
 
-#: src/olympia/addons/templates/addons/impala/details.html:182
+#: src/olympia/addons/templates/addons/impala/details.html:187
 msgid "Add-on home page"
 msgstr "Sito web del componente aggiuntivo"
 
-#: src/olympia/addons/templates/addons/impala/details.html:185
+#: src/olympia/addons/templates/addons/impala/details.html:190
 msgid "Support site"
 msgstr "Sito di supporto"
 
-#: src/olympia/addons/templates/addons/impala/details.html:189
+#: src/olympia/addons/templates/addons/impala/details.html:194
 msgid "Support E-mail"
 msgstr "Email per il supporto"
 
-#: src/olympia/addons/templates/addons/impala/details.html:194 src/olympia/devhub/models.py:378 src/olympia/devhub/templates/devhub/versions/list.html:12
+#: src/olympia/addons/templates/addons/impala/details.html:199 src/olympia/devhub/models.py:378 src/olympia/devhub/templates/devhub/versions/list.html:12
 #: src/olympia/versions/templates/versions/version.html:6 src/olympia/versions/templates/versions/mobile/version.html:6
 msgid "Version {0}"
 msgstr "Versione {0}"
 
-#: src/olympia/addons/templates/addons/impala/details.html:194
+#: src/olympia/addons/templates/addons/impala/details.html:199
 msgid "Info"
 msgstr "Informazioni"
 
-#: src/olympia/addons/templates/addons/impala/details.html:195 src/olympia/devhub/templates/devhub/includes/addon_details.html:129
+#: src/olympia/addons/templates/addons/impala/details.html:200 src/olympia/devhub/templates/devhub/includes/addon_details.html:116
 msgid "Last Updated:"
 msgstr "Ultimo aggiornamento:"
 
-#: src/olympia/addons/templates/addons/impala/details.html:200
+#: src/olympia/addons/templates/addons/impala/details.html:205
 #, python-format
 msgid "Released under <a target=\"_blank\" href=\"%(url)s\">%(name)s</a>"
 msgstr "Rilasciato sotto <a target=\"_blank\" href=\"%(url)s\">%(name)s</a>"
 
-#: src/olympia/addons/templates/addons/impala/details.html:201 src/olympia/addons/templates/addons/impala/details.html:206 src/olympia/amo/helpers.py:398 src/olympia/devhub/forms.py:142
+#: src/olympia/addons/templates/addons/impala/details.html:206 src/olympia/addons/templates/addons/impala/details.html:211 src/olympia/amo/helpers.py:398 src/olympia/devhub/forms.py:142
 #: src/olympia/devhub/forms.py:173 src/olympia/versions/templates/versions/version.html:40 src/olympia/versions/templates/versions/version.html:45
 msgid "Custom License"
 msgstr "Licenza personalizzata"
 
-#: src/olympia/addons/templates/addons/impala/details.html:205
+#: src/olympia/addons/templates/addons/impala/details.html:210
 #, python-format
 msgid "Released under <a href=\"%(url)s\">%(name)s</a>"
 msgstr "Rilasciato sotto <a href=\"%(url)s\">%(name)s</a>"
 
-#: src/olympia/addons/templates/addons/impala/details.html:217
+#: src/olympia/addons/templates/addons/impala/details.html:222
 msgid "About this Add-on"
 msgstr "Informazioni su questo componente aggiuntivo"
 
-#: src/olympia/addons/templates/addons/impala/details.html:233
+#: src/olympia/addons/templates/addons/impala/details.html:238
 msgid "Developer’s Comments"
 msgstr "Commenti dello sviluppatore"
 
-#: src/olympia/addons/templates/addons/impala/details.html:243
+#: src/olympia/addons/templates/addons/impala/details.html:248
 msgid "Version Information"
 msgstr "Informazioni sulla versione"
 
-#: src/olympia/addons/templates/addons/impala/details.html:250
+#: src/olympia/addons/templates/addons/impala/details.html:255
 msgid "See complete version history"
 msgstr "Visualizza cronologia completa"
 
-#: src/olympia/addons/templates/addons/impala/details.html:262
+#: src/olympia/addons/templates/addons/impala/details.html:267
 msgid ""
 "The Development Channel lets you test an experimental new version of this add-on before it's released to the general public. Once you install the development version, you will continue to get "
 "updates from this channel. To stop receiving development updates, reinstall the default version from the link above."
@@ -1094,17 +1090,17 @@ msgstr ""
 "Il canale di sviluppo ti permette di provare una versione sperimentale di questo componente aggiuntivo prima che venga rilasciata al pubblico. Una volta installata questa versione, continuerai a "
 "ricevere gli aggiornamenti dal canale di sviluppo. Per non ricevere più questo tipo di aggiornamenti, reinstalla la versione normale utilizzando il link precedente."
 
-#: src/olympia/addons/templates/addons/impala/details.html:272
+#: src/olympia/addons/templates/addons/impala/details.html:277
 msgid "<strong>Caution:</strong> Development versions of this add-on have not been reviewed by Mozilla."
 msgstr "<strong>Attenzione:</strong> le versioni di sviluppo di questo componente aggiuntivo non sono state verificate da Mozilla."
 
-#: src/olympia/addons/templates/addons/impala/details.html:287
+#: src/olympia/addons/templates/addons/impala/details.html:292
 msgid "See complete development channel history"
 msgstr "Visualizza la cronologia completa del canale di sviluppo"
 
-#: src/olympia/addons/templates/addons/impala/details.html:306 src/olympia/addons/templates/addons/impala/details.html:315 src/olympia/addons/templates/addons/impala/details.html:327
+#: src/olympia/addons/templates/addons/impala/details.html:311 src/olympia/addons/templates/addons/impala/details.html:320 src/olympia/addons/templates/addons/impala/details.html:332
 #: src/olympia/addons/templates/addons/impala/review_add_box.html:4 src/olympia/stats/templates/stats/popup.html:2 src/olympia/stats/templates/stats/popup.html:8
-#: src/olympia/stats/templates/stats/stats.html:202 src/olympia/users/templates/users/profile.html:119
+#: src/olympia/stats/templates/stats/stats.html:204 src/olympia/users/templates/users/profile.html:119
 msgid "close"
 msgstr "chiudi"
 
@@ -1163,15 +1159,11 @@ msgstr "Licenza del codice sorgente di {addon}"
 msgid "Source Code License"
 msgstr "Licenza del codice sorgente"
 
-#: src/olympia/addons/templates/addons/impala/persona_grid.html:16 src/olympia/addons/templates/addons/impala/toplist.html:6
-msgid "{0} users"
-msgstr "{0} utenti"
-
 #: src/olympia/addons/templates/addons/impala/review_list_box.html:19 src/olympia/reviews/templates/reviews/review.html:40
 msgid "permalink"
 msgstr "link permanente"
 
-#: src/olympia/addons/templates/addons/impala/review_list_box.html:23 src/olympia/editors/templates/editors/queue.html:98 src/olympia/reviews/templates/reviews/review.html:44
+#: src/olympia/addons/templates/addons/impala/review_list_box.html:23 src/olympia/editors/templates/editors/queue.html:104 src/olympia/reviews/templates/reviews/review.html:44
 msgid "translate"
 msgstr "Traduci"
 
@@ -1190,6 +1182,10 @@ msgstr "Questo componente aggiuntivo non ha ancora ricevuto alcuna recensione."
 msgid "Be the first!"
 msgstr "Scrivi tu la prima!"
 
+#: src/olympia/addons/templates/addons/impala/toplist.html:6
+msgid "{0} users"
+msgstr "{0} utenti"
+
 #: src/olympia/addons/templates/addons/impala/listing/sorter.html:14 src/olympia/devhub/templates/devhub/addons/listing/item_actions.html:49
 msgid "More"
 msgstr "Altro"
@@ -1202,7 +1198,7 @@ msgstr "Aggiungi ad una raccolta"
 msgid "My Add-ons"
 msgstr "I miei componenti aggiuntivi"
 
-#: src/olympia/addons/templates/addons/includes/dashboard_tabs.html:6 src/olympia/amo/context_processors.py:51
+#: src/olympia/addons/templates/addons/includes/dashboard_tabs.html:6 src/olympia/amo/context_processors.py:50
 msgid "My Themes"
 msgstr "I miei temi"
 
@@ -1257,7 +1253,7 @@ msgstr "Utenti"
 msgid "Weekly Downloads"
 msgstr "Download per settimana"
 
-#: src/olympia/addons/templates/addons/mobile/details.html:99 src/olympia/compat/templates/compat/reporter_detail.html:46 src/olympia/devhub/forms.py:787
+#: src/olympia/addons/templates/addons/mobile/details.html:99 src/olympia/compat/templates/compat/reporter_detail.html:46 src/olympia/devhub/forms.py:788
 #: src/olympia/devhub/templates/devhub/versions/list.html:163
 msgid "Version"
 msgstr "Versione"
@@ -1344,7 +1340,7 @@ msgstr ""
 #: src/olympia/browse/templates/browse/personas/category_landing.html:21 src/olympia/browse/templates/browse/personas/category_landing.html:23
 #: src/olympia/browse/templates/browse/personas/category_landing.html:38 src/olympia/browse/templates/browse/personas/grid.html:7 src/olympia/browse/templates/browse/personas/grid.html:11
 #: src/olympia/browse/templates/browse/personas/mobile/base.html:7 src/olympia/browse/templates/browse/personas/mobile/category_landing.html:19 src/olympia/constants/base.py:180
-#: src/olympia/devhub/templates/devhub/personas/submit.html:13 src/olympia/editors/helpers.py:105 src/olympia/editors/templates/editors/base.html:26
+#: src/olympia/devhub/templates/devhub/personas/submit.html:13 src/olympia/editors/helpers.py:107 src/olympia/editors/templates/editors/base.html:26
 #: src/olympia/editors/templates/editors/performance.html:73 src/olympia/search/templates/search/personas.html:39 src/olympia/templates/menu_links.html:9
 msgid "Themes"
 msgstr "Temi"
@@ -1365,7 +1361,7 @@ msgstr "Altri componenti aggiuntivi"
 msgid "Highest Rated"
 msgstr "Più votati"
 
-#: src/olympia/addons/templates/addons/mobile/home.html:74 src/olympia/amo/templates/amo/side_nav.html:5 src/olympia/amo/templates/amo/site_nav.html:27 src/olympia/amo/templates/amo/site_nav.html:57
+#: src/olympia/addons/templates/addons/mobile/home.html:74 src/olympia/amo/templates/amo/side_nav.html:5 src/olympia/amo/templates/amo/site_nav.html:27 src/olympia/amo/templates/amo/site_nav.html:55
 #: src/olympia/bandwagon/views.py:97 src/olympia/browse/views.py:57 src/olympia/browse/views.py:67 src/olympia/browse/templates/browse/personas/mobile/category_landing.html:65
 #: src/olympia/search/forms.py:15 src/olympia/search/forms.py:87
 msgid "Newest"
@@ -1379,90 +1375,90 @@ msgstr "Provalo!"
 msgid "Theme Info &raquo;"
 msgstr "Informazioni sul tema &raquo;"
 
-#: src/olympia/amo/context_processors.py:39 src/olympia/devhub/templates/devhub/nav.html:43
+#: src/olympia/amo/context_processors.py:37 src/olympia/devhub/templates/devhub/nav.html:43
 msgid "Tools"
 msgstr "Strumenti"
 
-#: src/olympia/amo/context_processors.py:48 src/olympia/discovery/templates/discovery/pane_account.html:8 src/olympia/users/templates/users/includes/navigation.html:2
+#: src/olympia/amo/context_processors.py:47 src/olympia/discovery/templates/discovery/pane_account.html:8 src/olympia/users/templates/users/includes/navigation.html:2
 msgid "My Profile"
 msgstr "Il mio profilo"
 
-#: src/olympia/amo/context_processors.py:54 src/olympia/users/templates/users/edit.html:5 src/olympia/users/templates/users/includes/navigation.html:3
+#: src/olympia/amo/context_processors.py:53 src/olympia/users/templates/users/edit.html:5 src/olympia/users/templates/users/includes/navigation.html:3
 msgid "Account Settings"
 msgstr "Impostazioni account"
 
-#: src/olympia/amo/context_processors.py:57 src/olympia/discovery/templates/discovery/pane_account.html:11 src/olympia/users/templates/users/profile.html:83
+#: src/olympia/amo/context_processors.py:56 src/olympia/discovery/templates/discovery/pane_account.html:11 src/olympia/users/templates/users/profile.html:83
 #: src/olympia/users/templates/users/includes/navigation.html:4
 msgid "My Collections"
 msgstr "Le mie raccolte"
 
-#: src/olympia/amo/context_processors.py:62 src/olympia/discovery/templates/discovery/pane_account.html:10 src/olympia/users/templates/users/includes/navigation.html:7
+#: src/olympia/amo/context_processors.py:61 src/olympia/discovery/templates/discovery/pane_account.html:10 src/olympia/users/templates/users/includes/navigation.html:7
 msgid "My Favorites"
 msgstr "Mie preferite"
 
-#: src/olympia/amo/context_processors.py:67 src/olympia/discovery/templates/discovery/pane_account.html:13 src/olympia/templates/impala/user_login.html:14
+#: src/olympia/amo/context_processors.py:66 src/olympia/discovery/templates/discovery/pane_account.html:13 src/olympia/templates/impala/user_login.html:14
 #: src/olympia/templates/mobile/header_auth.html:5
 msgid "Log out"
 msgstr "Disconnetti"
 
-#: src/olympia/amo/context_processors.py:72 src/olympia/devhub/templates/devhub/addons/dashboard.html:4
+#: src/olympia/amo/context_processors.py:71 src/olympia/devhub/templates/devhub/addons/dashboard.html:4
 msgid "Manage My Submissions"
 msgstr "Gestione dei progetti"
 
-#: src/olympia/amo/context_processors.py:75 src/olympia/devhub/templates/devhub/nav.html:27 src/olympia/devhub/templates/devhub/addons/dashboard.html:25
+#: src/olympia/amo/context_processors.py:74 src/olympia/devhub/templates/devhub/nav.html:27 src/olympia/devhub/templates/devhub/addons/dashboard.html:25
 #: src/olympia/devhub/templates/devhub/addons/submit/base.html:4
 msgid "Submit a New Add-on"
 msgstr "Carica un nuovo componente aggiuntivo"
 
-#: src/olympia/amo/context_processors.py:77 src/olympia/browse/templates/browse/personas/base.html:50 src/olympia/devhub/templates/devhub/index.html:24
+#: src/olympia/amo/context_processors.py:76 src/olympia/browse/templates/browse/personas/base.html:50 src/olympia/devhub/templates/devhub/index.html:24
 #: src/olympia/devhub/templates/devhub/addons/dashboard.html:29
 msgid "Submit a New Theme"
 msgstr "Carica un nuovo tema"
 
-#: src/olympia/amo/context_processors.py:79 src/olympia/amo/templates/amo/site_nav.html:87 src/olympia/devhub/helpers.py:36 src/olympia/devhub/helpers.py:68 src/olympia/devhub/helpers.py:102
+#: src/olympia/amo/context_processors.py:78 src/olympia/amo/templates/amo/site_nav.html:85 src/olympia/devhub/helpers.py:36 src/olympia/devhub/helpers.py:68 src/olympia/devhub/helpers.py:102
 #: src/olympia/templates/footer.html:6 src/olympia/templates/menu_links.html:14
 msgid "Developer Hub"
 msgstr "Centro di sviluppo"
 
-#: src/olympia/amo/context_processors.py:83 src/olympia/devhub/views.py:1792
+#: src/olympia/amo/context_processors.py:81 src/olympia/devhub/views.py:1796
 msgid "Manage API Keys"
 msgstr "Gestione chiavi API"
 
-#: src/olympia/amo/context_processors.py:88 src/olympia/editors/helpers.py:82 src/olympia/editors/helpers.py:102 src/olympia/editors/templates/editors/base.html:10
+#: src/olympia/amo/context_processors.py:86 src/olympia/editors/helpers.py:84 src/olympia/editors/helpers.py:104 src/olympia/editors/templates/editors/base.html:10
 msgid "Editor Tools"
 msgstr "Strumenti per revisori"
 
-#: src/olympia/amo/context_processors.py:92
+#: src/olympia/amo/context_processors.py:90
 msgid "Admin Tools"
 msgstr "Strumenti di amministrazione"
 
-#: src/olympia/amo/fields.py:15
+#: src/olympia/amo/fields.py:20
 msgid "Incorrect, please try again."
 msgstr "Errore, riprova."
 
-#: src/olympia/amo/fields.py:16
+#: src/olympia/amo/fields.py:21
 msgid "Error verifying input, please try again."
 msgstr "Impossibile verificare i dati inseriti, prova ancora."
 
-#: src/olympia/amo/fields.py:32
+#: src/olympia/amo/fields.py:37
 msgid "This must be a valid hex color code, such as #000000."
 msgstr "Deve essere un codice colore esadecimale valido, come #000000."
 
-#: src/olympia/amo/fields.py:58
+#: src/olympia/amo/fields.py:63
 msgid "Enter at least one value."
 msgstr "Inserire almeno un valore."
 
-#: src/olympia/amo/helpers.py:162 src/olympia/amo/templates/amo/site_nav.html:61 src/olympia/bandwagon/templates/bandwagon/add.html:9
+#: src/olympia/amo/helpers.py:162 src/olympia/amo/templates/amo/site_nav.html:59 src/olympia/bandwagon/templates/bandwagon/add.html:9
 #: src/olympia/bandwagon/templates/bandwagon/collection_detail.html:15 src/olympia/bandwagon/templates/bandwagon/delete.html:9 src/olympia/bandwagon/templates/bandwagon/edit.html:15
 #: src/olympia/bandwagon/templates/bandwagon/user_listing.html:18 src/olympia/bandwagon/templates/bandwagon/user_listing.html:21
 #: src/olympia/bandwagon/templates/bandwagon/impala/collection_listing.html:12 src/olympia/bandwagon/templates/bandwagon/impala/collection_listing.html:20
 #: src/olympia/bandwagon/templates/bandwagon/impala/collection_listing.html:24 src/olympia/bandwagon/templates/bandwagon/impala/collection_sidebar.html:3
 #: src/olympia/bandwagon/templates/bandwagon/includes/collection_sidebar.html:2 src/olympia/bandwagon/templates/bandwagon/mobile/collection_listing.html:3
-#: src/olympia/stats/templates/stats/stats.html:77 src/olympia/templates/menu_links.html:12
+#: src/olympia/stats/templates/stats/stats.html:33 src/olympia/templates/menu_links.html:12
 msgid "Collections"
 msgstr "Raccolte"
 
-#: src/olympia/amo/helpers.py:171 src/olympia/amo/templates/amo/site_nav.html:85 src/olympia/browse/templates/browse/language_tools.html:3
+#: src/olympia/amo/helpers.py:171 src/olympia/amo/templates/amo/site_nav.html:83 src/olympia/browse/templates/browse/language_tools.html:3
 msgid "Dictionaries & Language Packs"
 msgstr "Dizionari e language pack"
 
@@ -1614,8 +1610,8 @@ msgstr "Richiesta super revisione"
 msgid "Comment on {addon} {version}."
 msgstr "Commento su {addon} {version}."
 
-#: src/olympia/amo/log.py:236 src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:19 src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:47
-#: src/olympia/editors/helpers.py:511 src/olympia/editors/templates/editors/themes/history_table.html:11
+#: src/olympia/amo/log.py:236 src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:17 src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:45
+#: src/olympia/editors/helpers.py:584 src/olympia/editors/templates/editors/themes/history_table.html:11
 msgid "Comment"
 msgstr "Commento"
 
@@ -1769,7 +1765,7 @@ msgstr "Escalation revisori"
 
 #: src/olympia/amo/log.py:442
 msgid "Video removed from {addon} because of a problem with the video. "
-msgstr "Il video è stato rimosso da {addon} perché presentava dei problemi."
+msgstr ""
 
 #: src/olympia/amo/log.py:444
 msgid "Video removed"
@@ -1923,8 +1919,6 @@ msgstr "Oops"
 #, python-format
 msgid "<h1>Oops!  We had an error.</h1> <p>We'll get to fixing that soon.</p> <p> You can try refreshing the page, or head back to the <a href=\"%(home)s\">Add-ons homepage</a>. </p>"
 msgstr ""
-"<h1>Oops! Si è verificato un errore.</h1><p>Lo risolveremo quanto prima.</p><p>Nel frattempo, prova a ricaricare la pagina, oppure torna alla <a href=\"%(home)s\">pagina principale di Mozilla Add-"
-"ons</a>.</p>"
 
 #: src/olympia/amo/templates/amo/license_link.html:10
 msgid "Some rights reserved"
@@ -1946,7 +1940,7 @@ msgstr "Precedente"
 #: src/olympia/amo/templates/amo/mobile/paginator.html:14 src/olympia/amo/templates/amo/mobile/paginator.html:16 src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:51
 #: src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:65 src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:78
 #: src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:91 src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:104
-#: src/olympia/discovery/templates/discovery/pane.html:45 src/olympia/discovery/templates/discovery/addons/detail.html:39 src/olympia/stats/templates/stats/stats.html:167
+#: src/olympia/discovery/templates/discovery/pane.html:45 src/olympia/discovery/templates/discovery/addons/detail.html:39 src/olympia/stats/templates/stats/stats.html:169
 msgid "Next"
 msgstr "Successiva"
 
@@ -1980,7 +1974,7 @@ msgstr ""
 "\"recaptcha_different\">ritentare con parole diverse</a> oppure <a href=\"#\" id=\"recaptcha_audio\">provare con un sistema alternativo</a>.</p>"
 
 #: src/olympia/amo/templates/amo/side_nav.html:4 src/olympia/amo/templates/amo/side_nav.html:12 src/olympia/amo/templates/amo/site_nav.html:4 src/olympia/amo/templates/amo/site_nav.html:26
-#: src/olympia/browse/views.py:56 src/olympia/browse/views.py:66 src/olympia/browse/views.py:237 src/olympia/browse/views.py:282 src/olympia/search/forms.py:86
+#: src/olympia/browse/views.py:56 src/olympia/browse/views.py:66 src/olympia/browse/views.py:204 src/olympia/browse/views.py:249 src/olympia/search/forms.py:86
 msgid "Top Rated"
 msgstr "Più votati"
 
@@ -1995,38 +1989,38 @@ msgstr "Esplora"
 msgid "Extensions"
 msgstr "Estensioni"
 
-#: src/olympia/amo/templates/amo/site_nav.html:45
+#: src/olympia/amo/templates/amo/site_nav.html:44
 msgid "Want more customization? Try <b>Complete Themes</b>"
 msgstr "Vuoi ancora più personalizzazione? Prova i <b>temi completi</b>."
 
-#: src/olympia/amo/templates/amo/site_nav.html:56 src/olympia/bandwagon/views.py:96
+#: src/olympia/amo/templates/amo/site_nav.html:54 src/olympia/bandwagon/views.py:96
 msgid "Most Followers"
 msgstr "Più seguiti"
 
-#: src/olympia/amo/templates/amo/site_nav.html:68 src/olympia/bandwagon/templates/bandwagon/impala/collection_sidebar.html:16
+#: src/olympia/amo/templates/amo/site_nav.html:66 src/olympia/bandwagon/templates/bandwagon/impala/collection_sidebar.html:16
 #: src/olympia/bandwagon/templates/bandwagon/includes/collection_sidebar.html:18
 msgid "Collections I've Made"
 msgstr "Raccolte che ho creato"
 
-#: src/olympia/amo/templates/amo/site_nav.html:70 src/olympia/bandwagon/templates/bandwagon/user_listing.html:4 src/olympia/bandwagon/templates/bandwagon/impala/collection_sidebar.html:13
+#: src/olympia/amo/templates/amo/site_nav.html:68 src/olympia/bandwagon/templates/bandwagon/user_listing.html:4 src/olympia/bandwagon/templates/bandwagon/impala/collection_sidebar.html:13
 #: src/olympia/bandwagon/templates/bandwagon/includes/collection_sidebar.html:15
 msgid "Collections I'm Following"
 msgstr "Raccolte che seguo"
 
-#: src/olympia/amo/templates/amo/site_nav.html:73 src/olympia/bandwagon/templates/bandwagon/impala/collection_sidebar.html:18
-#: src/olympia/bandwagon/templates/bandwagon/includes/collection_sidebar.html:20 src/olympia/users/models.py:512
+#: src/olympia/amo/templates/amo/site_nav.html:71 src/olympia/bandwagon/templates/bandwagon/impala/collection_sidebar.html:18
+#: src/olympia/bandwagon/templates/bandwagon/includes/collection_sidebar.html:20 src/olympia/users/models.py:521
 msgid "My Favorite Add-ons"
 msgstr "I miei componenti aggiuntivi preferiti"
 
-#: src/olympia/amo/templates/amo/site_nav.html:78
+#: src/olympia/amo/templates/amo/site_nav.html:76
 msgid "More&hellip;"
 msgstr "Altro&hellip;"
 
-#: src/olympia/amo/templates/amo/site_nav.html:82
+#: src/olympia/amo/templates/amo/site_nav.html:80
 msgid "Add-ons for Mobile"
 msgstr "Componenti aggiuntivi per Mobile"
 
-#: src/olympia/amo/templates/amo/site_nav.html:86 src/olympia/browse/feeds.py:207 src/olympia/browse/templates/browse/search_tools.html:3 src/olympia/constants/base.py:176
+#: src/olympia/amo/templates/amo/site_nav.html:84 src/olympia/browse/feeds.py:207 src/olympia/browse/templates/browse/search_tools.html:3 src/olympia/constants/base.py:176
 #: src/olympia/templates/menu_links.html:10
 msgid "Search Tools"
 msgstr "Strumenti di ricerca"
@@ -2042,7 +2036,7 @@ msgid "Jump to first page"
 msgstr "Vai alla prima pagina"
 
 #: src/olympia/amo/templates/amo/impala/paginator.html:22 src/olympia/amo/templates/amo/mobile/impala_paginator.html:12 src/olympia/discovery/templates/discovery/pane.html:44
-#: src/olympia/discovery/templates/discovery/addons/detail.html:38 src/olympia/stats/templates/stats/stats.html:164
+#: src/olympia/discovery/templates/discovery/addons/detail.html:38 src/olympia/stats/templates/stats/stats.html:166
 msgid "Previous"
 msgstr "Precedente"
 
@@ -2052,7 +2046,7 @@ msgstr "Vai all’ultima pagina"
 
 #. First and second arguments are the result range (e.g., 1-20);
 #. third argument is the number of total results (e.g., 1,000).
-#. third
+#. First and second arguments are the result range (e.g., 1-20);              third
 #. argument is the number of total results (e.g., 1,000).
 #: src/olympia/amo/templates/amo/impala/paginator.html:36 src/olympia/amo/templates/amo/mobile/impala_paginator.html:38
 #, python-format
@@ -2065,31 +2059,50 @@ msgid_plural "Page {n}"
 msgstr[0] "Pagina {n}"
 msgstr[1] "Pagina {n}"
 
-#: src/olympia/amo/templates/services/install.html:38
-#, python-format
-msgid "If you are not prompted to install %(addon_name)s in a moment, please <a href=\"%(addon_xpi)s\">click here</a>."
-msgstr "Se non ti viene chiesto di installare %(addon_name)s entro qualche istante <a href=\"%(addon_xpi)s\">fai clic qui</a>."
-
-#: src/olympia/amo/tests/test_messages.py:57 src/olympia/amo/tests/test_messages.py:58 src/olympia/reviews/forms.py:25 src/olympia/reviews/forms.py:50 src/olympia/reviews/templates/reviews/add.html:56
+#: src/olympia/amo/tests/test_messages.py:56 src/olympia/amo/tests/test_messages.py:57 src/olympia/reviews/forms.py:25 src/olympia/reviews/forms.py:50 src/olympia/reviews/templates/reviews/add.html:56
 #: src/olympia/reviews/templates/reviews/reply.html:30
 msgid "Title"
 msgstr "Titolo"
 
-#: src/olympia/amo/tests/test_messages.py:57 src/olympia/amo/tests/test_messages.py:58
+#: src/olympia/amo/tests/test_messages.py:56 src/olympia/amo/tests/test_messages.py:57
 msgid "Body"
 msgstr "Corpo"
 
-#: src/olympia/amo/tests/test_messages.py:59
+#: src/olympia/amo/tests/test_messages.py:58
 msgid "Another Title"
 msgstr "Altro titolo"
 
-#: src/olympia/amo/tests/test_messages.py:59
+#: src/olympia/amo/tests/test_messages.py:58
 msgid "Another Body"
 msgstr "Altro corpo"
 
-#: src/olympia/api/views.py:255
-msgid "Not implemented yet."
-msgstr "Non ancora implementato."
+#: src/olympia/api/authentication.py:76
+msgid "Signature has expired."
+msgstr ""
+
+#: src/olympia/api/authentication.py:79
+msgid "Error decoding signature."
+msgstr ""
+
+#: src/olympia/api/authentication.py:82
+msgid "Invalid JWT Token."
+msgstr ""
+
+#: src/olympia/api/authentication.py:130
+msgid "Invalid Authorization header. No credentials provided."
+msgstr ""
+
+#: src/olympia/api/authentication.py:133
+msgid "Invalid Authorization header. Credentials string should not contain spaces."
+msgstr ""
+
+#: src/olympia/api/fields.py:29
+msgid "The field must have a length of at least {num} characters."
+msgstr ""
+
+#: src/olympia/api/fields.py:31
+msgid "The language code {lang_code} is invalid."
+msgstr ""
 
 #: src/olympia/applications/views.py:39 src/olympia/applications/templates/applications/appversions.html:3
 msgid "Application Versions"
@@ -2109,7 +2122,7 @@ msgstr ""
 "Nel file manifesto dei componenti aggiuntivi caricati su Mozilla Add-ons deve essere indicata la compatibilità con almeno una delle applicazioni riportate qui di seguito. Non segnalare "
 "compatibilità con versioni diverse da quelle indicate."
 
-#: src/olympia/applications/templates/applications/appversions.html:25
+#: src/olympia/applications/templates/applications/appversions.html:25 src/olympia/editors/helpers.py:361
 msgid "GUID"
 msgstr "GUID"
 
@@ -2225,8 +2238,8 @@ msgstr "Preferito"
 msgid "Remove from favorites"
 msgstr "Rimuovi dai preferiti"
 
-#: src/olympia/bandwagon/views.py:98 src/olympia/bandwagon/views.py:191 src/olympia/browse/views.py:58 src/olympia/browse/views.py:69 src/olympia/browse/views.py:458 src/olympia/devhub/views.py:74
-#: src/olympia/devhub/views.py:82 src/olympia/devhub/templates/devhub/addons/edit/basic.html:20 src/olympia/editors/templates/editors/leaderboard.html:24
+#: src/olympia/bandwagon/views.py:98 src/olympia/bandwagon/views.py:191 src/olympia/browse/views.py:58 src/olympia/browse/views.py:69 src/olympia/browse/views.py:425 src/olympia/devhub/views.py:72
+#: src/olympia/devhub/views.py:80 src/olympia/devhub/templates/devhub/addons/edit/basic.html:20 src/olympia/editors/templates/editors/leaderboard.html:24
 #: src/olympia/editors/templates/editors/themes/queue_list.html:48 src/olympia/search/forms.py:17 src/olympia/search/forms.py:89 src/olympia/users/templates/users/vcard.html:5
 msgid "Name"
 msgstr "Nome"
@@ -2235,7 +2248,7 @@ msgstr "Nome"
 msgid "Recently Popular"
 msgstr "Popolari (recenti)"
 
-#: src/olympia/bandwagon/views.py:189 src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:18
+#: src/olympia/bandwagon/views.py:189 src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:16
 msgid "Added"
 msgstr "Aggiunto"
 
@@ -2249,8 +2262,8 @@ msgstr "Raccolta creata!"
 
 #: src/olympia/bandwagon/views.py:316
 #, python-format
-msgid "Your new collection is shown below. You can <ahref=\"%(url)s\">edit additional settings</a> if you'dlike."
-msgstr "La nuova raccolta è mostrata di seguito. Se lo desideri, è possibile <ahref=\"%(url)s\">modificare le impostazioni aggiuntive</a>."
+msgid "Your new collection is shown below. You can <a href=\"%(url)s\">edit additional settings</a> if you'd like."
+msgstr ""
 
 #: src/olympia/bandwagon/views.py:322
 msgid "Collection updated!"
@@ -2377,8 +2390,8 @@ msgid_plural "%(num)s Add-ons in this Collection"
 msgstr[0] "%(num)s Componente aggiuntivo in questa raccolta"
 msgstr[1] "%(num)s Componenti aggiuntivi in questa raccolta"
 
-#: src/olympia/bandwagon/templates/bandwagon/collection_detail.html:125 src/olympia/compat/templates/compat/index.html:25 src/olympia/compat/templates/compat/reporter_detail.html:29
-#: src/olympia/files/templates/files/viewer.html:29 src/olympia/templates/amo_footer.html:17 src/olympia/templates/includes/lang_switcher.html:10
+#: src/olympia/bandwagon/templates/bandwagon/collection_detail.html:125 src/olympia/compat/templates/compat/reporter_detail.html:29 src/olympia/files/templates/files/viewer.html:29
+#: src/olympia/templates/amo_footer.html:17 src/olympia/templates/includes/lang_switcher.html:10
 msgid "Go"
 msgstr "Vai"
 
@@ -2415,8 +2428,6 @@ msgid ""
 "Add-ons that you mark as favorites using the <b>Add to Favorites</b> feature appear below. This collection is currently <b>private</b>, which means only you can see it.  If you would like everyone "
 "to be able to see your favorites, click the button below to make it public."
 msgstr ""
-"I componenti aggiuntivi che contrassegni come preferiti utilizzando l'opzione <b>Aggiungi ai preferiti</b> vengono mostrati di seguito. Questa raccolta è attualmente <b>privata</b>, cioè visibile "
-"solo da te. Se desideri che gli altri utenti vedano i tuoi componenti preferiti, rendi pubblica la raccolta facendo clic sul pulsante sottostante."
 
 #: src/olympia/bandwagon/templates/bandwagon/collection_detail.html:196
 msgid "My favorite add-ons"
@@ -2436,9 +2447,9 @@ msgid_plural "<span>%(followers)s</span> followers"
 msgstr[0] "<span>%(followers)s</span> iscritto"
 msgstr[1] "<span>%(followers)s</span> iscritti"
 
-#. People "follow" collections to get notified of updates.
-#. Like
+#. People "follow" collections to get notified of updates.                    Like
 #. Twitter followers.
+#. People "follow" collections to get notified of updates.
 #. Like Twitter followers.
 #: src/olympia/bandwagon/templates/bandwagon/collection_listing_items.html:10 src/olympia/bandwagon/templates/bandwagon/impala/collection_listing_items.html:18
 #, python-format
@@ -2447,8 +2458,7 @@ msgid_plural "%(num)s weekly followers"
 msgstr[0] "%(num)s iscritto settimanale"
 msgstr[1] "%(num)s iscritti settimanale"
 
-#. People "follow" collections to get notified of updates.
-#. Like
+#. People "follow" collections to get notified of updates.                    Like
 #. Twitter followers.
 #: src/olympia/bandwagon/templates/bandwagon/collection_listing_items.html:18
 #, python-format
@@ -2457,9 +2467,9 @@ msgid_plural "%(num)s monthly followers"
 msgstr[0] "%(num)s iscritto per mese"
 msgstr[1] "%(num)s iscritti per mese"
 
-#. People "follow" collections to get notified of updates.
-#. Like
+#. People "follow" collections to get notified of updates.                    Like
 #. Twitter followers.
+#. People "follow" collections to get notified of updates.
 #. Like Twitter followers.
 #: src/olympia/bandwagon/templates/bandwagon/collection_listing_items.html:26 src/olympia/bandwagon/templates/bandwagon/impala/collection_listing_items.html:26
 #, python-format
@@ -2551,7 +2561,7 @@ msgid "Remove this user as a contributor"
 msgstr "Rimuovi questo utente dal ruolo di collaboratore"
 
 #: src/olympia/bandwagon/templates/bandwagon/edit_contributors.html:18 src/olympia/bandwagon/templates/bandwagon/edit_contributors.html:43
-#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:20 src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:48
+#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:18 src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:46
 #: src/olympia/devhub/templates/devhub/addons/ajax_compat_update.html:19
 msgid "Remove"
 msgstr "Elimina"
@@ -2565,9 +2575,6 @@ msgid ""
 "You can add multiple contributors to this collection.  A contributor can add and remove add-ons from this collection, but cannot change its name or description.  To add a contributor, enter their "
 "email in the box below. Contributors must have a Mozilla Add-ons account."
 msgstr ""
-"Puoi aggiungere più collaboratori alla raccolta. Un collaboratore possiede i permessi necessari per aggiungere o rimuovere i componenti aggiuntivi dalla raccolta, ma non quelli per modificare il "
-"nome e la descrizione della raccolta stessa. Per aggiungere un collaboratore inserisci la sua email nel campo sottostante. Per poter diventare un collaboratore, è necessario che l’indirizzo email "
-"sia associato a un account registrato su Mozilla Add-ons."
 
 #: src/olympia/bandwagon/templates/bandwagon/edit_contributors.html:40
 msgid "User"
@@ -2603,7 +2610,7 @@ msgid "<b>Warning:</b> By changing the owner of this collection, you will no lon
 msgstr "<b>Attenzione:</b> modificando il proprietario di questa raccolta, non sarai più in grado di modificarla. Avrai solo la possibilità di aggiungere o rimuovere componenti aggiuntivi."
 
 #: src/olympia/bandwagon/templates/bandwagon/edit_contributors.html:83 src/olympia/devhub/templates/devhub/addons/forms_shared/media.html:157
-#: src/olympia/devhub/templates/devhub/addons/submit/describe.html:69 src/olympia/devhub/templates/devhub/addons/submit/license.html:60 src/olympia/devhub/templates/devhub/addons/submit/upload.html:78
+#: src/olympia/devhub/templates/devhub/addons/submit/describe.html:69 src/olympia/devhub/templates/devhub/addons/submit/license.html:60 src/olympia/devhub/templates/devhub/addons/submit/upload.html:70
 #: src/olympia/devhub/templates/devhub/payments/tier.html:17 src/olympia/editors/templates/editors/themes/themes.html:111 src/olympia/editors/templates/editors/themes/themes.html:128
 #: src/olympia/editors/templates/editors/themes/themes.html:134 src/olympia/editors/templates/editors/themes/themes.html:141 src/olympia/users/templates/users/fxa_migration_prompt_content.html:10
 #: src/olympia/users/templates/users/login_form.html:42 src/olympia/users/templates/users/mobile/login.html:57
@@ -2675,44 +2682,42 @@ msgstr "Ripristina"
 
 #: src/olympia/bandwagon/templates/bandwagon/includes/addedit.html:53
 msgid "PNG and JPG supported.  Image will be resized to 32x32."
-msgstr "I formati supportati sono PNG e JPG. L'immagine verrà ridimensionata a 32x32 pixel."
+msgstr ""
 
 #: src/olympia/bandwagon/templates/bandwagon/includes/addedit_errors.html:3
 msgid "There are errors in this form.  Please correct them below."
-msgstr "Il modulo contiene degli errori. Correggi i campi errati qui di seguito."
+msgstr ""
 
 #: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:2
 msgid "Add-ons in Your Collection"
 msgstr "Componenti aggiuntivi inclusi nella raccolta"
 
 #: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:4
-msgid ""
-"To include an add-on in this collection, enter its name in the box below and hit enter.  You can also use the <strong>Add to Collection</strong> links throughout the site to include add-ons later."
+msgid "To include an add-on in this collection, enter its name in the box below and hit enter."
 msgstr ""
-"Per aggiungere un componente aggiuntivo alla raccolta, digita il suo nome nel campo sottostante e premi Invio. In alternativa, puoi aggiungere i componenti aggiuntivi in un secondo momento tramite "
-"l’opzione <strong>Aggiungi a una raccolta</strong> accessibile da varie sezioni del sito."
 
-#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:17 src/olympia/constants/base.py:400 src/olympia/devhub/templates/devhub/addons/activity.html:62
+#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:15 src/olympia/constants/base.py:400 src/olympia/devhub/templates/devhub/addons/activity.html:62
+#: src/olympia/editors/helpers.py:273 src/olympia/editors/helpers.py:360
 msgid "Add-on"
 msgstr "Componente aggiuntivo"
 
-#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:26
+#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:24
 msgid "Enter the name of the add-on to include"
 msgstr "Inserisci il nome del componente aggiuntivo da includere"
 
-#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:28
+#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:26
 msgid "Add to Collection"
 msgstr "Aggiungi ad una raccolta"
 
-#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:45 src/olympia/editors/helpers.py:936 src/olympia/editors/helpers.py:956
+#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:43 src/olympia/editors/helpers.py:1016 src/olympia/editors/helpers.py:1036
 msgid "Pending"
 msgstr "In sospeso"
 
-#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:47
+#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:45
 msgid "Add a comment"
 msgstr "Aggiungi un commento"
 
-#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:48
+#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:46
 msgid "Remove this add-on from the collection"
 msgstr "Rimuovi questo componente aggiuntivo dalla raccolta"
 
@@ -2764,9 +2769,6 @@ msgid ""
 "When Mozilla becomes aware of add-ons, plugins, or other third-party software that seriously compromises %(app)s security, stability, or performance and meets <a href=\"%(criteria)s\">certain "
 "criteria</a>, the software may be blocked from general use.  For more information, please read <a href=\"%(support)s\">this support article</a>."
 msgstr ""
-"Qualora Mozilla riconoscesse che un componente aggiuntivo, un plugin o un altro software di terze parti possa compromettere seriamente la sicurezza, la stabilità o le prestazioni di %(app)s e "
-"risponda a <a href=\"%(criteria)s\">specifici criteri</a>, il software in questione può essere ritirato dall’utilizzo generale. Per ulteriori informazioni fare riferimento al relativo <a href="
-"\"%(support)s\">articolo di supporto</a>."
 
 #: src/olympia/blocklist/templates/blocklist/blocked_detail.html:44
 #, python-format
@@ -2823,12 +2825,12 @@ msgstr "Strumenti di ricerca"
 msgid "Most Users"
 msgstr "Maggior numero di utenti"
 
-#: src/olympia/browse/views.py:61 src/olympia/browse/views.py:72 src/olympia/browse/views.py:279 src/olympia/browse/templates/browse/personas/mobile/category_landing.html:63
+#: src/olympia/browse/views.py:61 src/olympia/browse/views.py:72 src/olympia/browse/views.py:246 src/olympia/browse/templates/browse/personas/mobile/category_landing.html:63
 #: src/olympia/discovery/templates/discovery/pane.html:67 src/olympia/search/forms.py:92
 msgid "Up & Coming"
 msgstr "Emergenti"
 
-#: src/olympia/browse/views.py:460 src/olympia/devhub/views.py:76 src/olympia/devhub/views.py:83 src/olympia/discovery/templates/discovery/addons/detail.html:66
+#: src/olympia/browse/views.py:427 src/olympia/devhub/views.py:74 src/olympia/devhub/views.py:81 src/olympia/discovery/templates/discovery/addons/detail.html:66
 msgid "Created"
 msgstr "Creato"
 
@@ -3016,8 +3018,8 @@ msgid_plural "See all %(cnt)s extensions in %(name)s &raquo;"
 msgstr[0] "Visualizza %(cnt)s estensione in %(name)s &raquo;"
 msgstr[1] "Visualizza le %(cnt)s estensioni in %(name)s &raquo;"
 
-#: src/olympia/browse/templates/browse/mobile/extensions.html:13 src/olympia/compat/templates/compat/index.html:82 src/olympia/devhub/templates/devhub/devhub_search.html:24
-#: src/olympia/devhub/templates/devhub/addons/activity.html:47 src/olympia/search/templates/search/no_results.html:4 src/olympia/search/templates/search/mobile/results.html:36
+#: src/olympia/browse/templates/browse/mobile/extensions.html:13 src/olympia/devhub/templates/devhub/devhub_search.html:24 src/olympia/devhub/templates/devhub/addons/activity.html:47
+#: src/olympia/search/templates/search/no_results.html:4 src/olympia/search/templates/search/mobile/results.html:36
 msgid "No results found."
 msgstr "Nessun risultato."
 
@@ -3106,7 +3108,7 @@ msgstr "&laquo; Tutti i temi"
 msgid "All"
 msgstr "Tutto"
 
-#: src/olympia/compat/forms.py:22 src/olympia/search/views.py:525
+#: src/olympia/compat/forms.py:22 src/olympia/editors/templates/editors/base.html:69 src/olympia/search/views.py:518
 msgid "All Add-ons"
 msgstr "Tutti i componenti aggiuntivi"
 
@@ -3117,53 +3119,6 @@ msgstr "Compilato"
 #: src/olympia/compat/forms.py:24
 msgid "Non-binary"
 msgstr "Non compilato"
-
-#. Review points sources other than add-ons and themes.
-#: src/olympia/compat/views.py:87 src/olympia/constants/base.py:388 src/olympia/devhub/forms.py:162 src/olympia/editors/templates/editors/performance.html:75
-msgid "Other"
-msgstr "Altro"
-
-#: src/olympia/compat/templates/compat/index.html:4
-msgid "Add-on Compatibility Report for {app} {version}"
-msgstr "Rapporto compatibilità per {app} {version}"
-
-#: src/olympia/compat/templates/compat/index.html:11
-msgid "{app} {version} Compatibility"
-msgstr "Compatibilità {app} {version}"
-
-#: src/olympia/compat/templates/compat/index.html:17
-#, python-format
-msgid "Top 95%% compatible with previous version"
-msgstr "I migliori, compatibili al 95%% con la versione precedente"
-
-#: src/olympia/compat/templates/compat/index.html:18
-#, python-format
-msgid "Top 95%% of all add-ons"
-msgstr "Migliori 95%% di tutti i componenti aggiuntivi"
-
-#: src/olympia/compat/templates/compat/index.html:19
-msgid "All active add-ons"
-msgstr "Tutti i componenti aggiuntivi attivi"
-
-#: src/olympia/compat/templates/compat/index.html:23 src/olympia/constants/base.py:401
-msgid "App"
-msgstr "App"
-
-#: src/olympia/compat/templates/compat/index.html:55
-msgid "Details for add-ons compatible with previous version:"
-msgstr "Dettagli sui componenti aggiuntivi compatibili con la versione precedente:"
-
-#: src/olympia/compat/templates/compat/index.html:57
-msgid "Show all versions"
-msgstr "Visualizza tutte le versioni"
-
-#: src/olympia/compat/templates/compat/index.html:59
-msgid "Details for add-ons compatible with all versions:"
-msgstr "Dettagli sui componenti aggiuntivi compatibili con tutte le versioni:"
-
-#: src/olympia/compat/templates/compat/index.html:61
-msgid "Show previous version only"
-msgstr "Mostra solo la versione precedente"
 
 #: src/olympia/compat/templates/compat/reporter.html:3
 msgid "Add-on Compatibility Reports"
@@ -3218,8 +3173,8 @@ msgstr "Filtra per applicazione"
 msgid "Report Type"
 msgstr "Tipo report"
 
-#: src/olympia/compat/templates/compat/reporter_detail.html:47 src/olympia/devhub/forms.py:784 src/olympia/devhub/templates/devhub/addons/ajax_compat_update.html:17 src/olympia/editors/forms.py:108
-#: src/olympia/zadmin/forms.py:45
+#: src/olympia/compat/templates/compat/reporter_detail.html:47 src/olympia/devhub/forms.py:785 src/olympia/devhub/templates/devhub/addons/ajax_compat_update.html:17 src/olympia/editors/forms.py:108
+#: src/olympia/editors/forms.py:248 src/olympia/zadmin/forms.py:45
 msgid "Application"
 msgstr "Applicazione"
 
@@ -3307,7 +3262,8 @@ msgstr "Revisione preliminare effettuata"
 msgid "Preliminarily Reviewed and Awaiting Full Review"
 msgstr "Revisione preliminare effettuata, in attesa di revisione completa"
 
-#: src/olympia/constants/base.py:33 src/olympia/editors/helpers.py:924 src/olympia/editors/templates/editors/themes/history_table.html:34
+#: src/olympia/constants/base.py:33 src/olympia/editors/forms.py:258 src/olympia/editors/helpers.py:73 src/olympia/editors/helpers.py:1004
+#: src/olympia/editors/templates/editors/themes/history_table.html:34
 msgid "Deleted"
 msgstr "Cancellato"
 
@@ -3407,6 +3363,11 @@ msgstr "Chiedi agli utenti dopo aver avviato il download di questo componente ag
 msgid "Ask before users can download this add-on"
 msgstr "Chiedi agli utenti prima di consentire il download di questo componente aggiuntivo"
 
+#. Review points sources other than add-ons and themes.
+#: src/olympia/constants/base.py:388 src/olympia/devhub/forms.py:162 src/olympia/editors/templates/editors/performance.html:75
+msgid "Other"
+msgstr "Altro"
+
 #: src/olympia/constants/base.py:389
 msgid "Exception"
 msgstr "Eccezione"
@@ -3418,6 +3379,10 @@ msgstr "Versione"
 #: src/olympia/constants/base.py:391
 msgid "Change"
 msgstr "Modifica"
+
+#: src/olympia/constants/base.py:401
+msgid "App"
+msgstr "App"
 
 #: src/olympia/constants/base.py:402
 msgid "Persona"
@@ -3567,7 +3532,7 @@ msgstr "Segnala"
 msgid "Duplicate"
 msgstr "Duplica"
 
-#: src/olympia/constants/editors.py:17 src/olympia/editors/helpers.py:502 src/olympia/editors/templates/editors/themes/queue.html:71 src/olympia/editors/templates/editors/themes/themes.html:94
+#: src/olympia/constants/editors.py:17 src/olympia/editors/helpers.py:575 src/olympia/editors/templates/editors/themes/queue.html:71 src/olympia/editors/templates/editors/themes/themes.html:94
 msgid "Reject"
 msgstr "Respingi"
 
@@ -3667,7 +3632,7 @@ msgstr "Solaris"
 msgid "Android"
 msgstr "Android"
 
-#: src/olympia/core/apps.py:19
+#: src/olympia/core/apps.py:21
 msgid "Core"
 msgstr "Base"
 
@@ -3801,8 +3766,8 @@ msgid "Submit my add-on for manual review."
 msgstr "Carica il componente aggiuntivo per sottoporlo a una revisione manuale."
 
 #: src/olympia/devhub/forms.py:537
-msgid "Do not list my add-on on this site (beta)"
-msgstr "Non distribuire il componente su questo sito (beta)"
+msgid "Do not list my add-on on this site"
+msgstr ""
 
 #: src/olympia/devhub/forms.py:538
 msgid "Check this option if you intend to distribute your add-on on your own and only need it to be signed by Mozilla."
@@ -3836,46 +3801,46 @@ msgstr "I file il cui numero di versione termina con a|alpha|b|beta|pre|rc più 
 
 #: src/olympia/devhub/forms.py:592
 #, python-format
-msgid "Version %s already exists"
-msgstr "La versione %s è già presente"
+msgid "Version %s already exists, or was uploaded before."
+msgstr ""
 
-#: src/olympia/devhub/forms.py:604
+#: src/olympia/devhub/forms.py:605
 msgid "Select a valid choice. That choice is not one of the available choices."
 msgstr "Scegli un’opzione valida. L’opzione selezionata non è disponibile."
 
-#: src/olympia/devhub/forms.py:610
+#: src/olympia/devhub/forms.py:611
 msgid "A file with a version ending with a|alpha|b|beta and an optional number is detected as beta."
 msgstr "Ogni nome di file che riporti come identificativo della versione il termine a|alpha|b|beta più un eventuale numero viene rilevato come beta."
 
-#: src/olympia/devhub/forms.py:633
+#: src/olympia/devhub/forms.py:634
 msgid "You cannot upload any more files for this version."
 msgstr "Non è possibile caricare ulteriori file per questa versione."
 
-#: src/olympia/devhub/forms.py:639
+#: src/olympia/devhub/forms.py:640
 msgid "Version doesn't match"
 msgstr "La versione non corrisponde"
 
-#: src/olympia/devhub/forms.py:668
+#: src/olympia/devhub/forms.py:669
 msgid "You cannot delete a file once the review process has started.  You must delete the whole version."
-msgstr "Non è consentito eliminare il singolo file una volta iniziato il processo di revisione. È necessario eliminare l’intera versione."
+msgstr ""
 
-#: src/olympia/devhub/forms.py:688
+#: src/olympia/devhub/forms.py:689
 msgid "The platform All cannot be combined with specific platforms."
 msgstr "Non è possibile selezionare Tutti e contemporaneamente uno specifico sistema operativo."
 
-#: src/olympia/devhub/forms.py:693
+#: src/olympia/devhub/forms.py:694
 msgid "A platform can only be chosen once."
 msgstr "Una piattaforma può essere selezionata una sola volta."
 
-#: src/olympia/devhub/forms.py:706
+#: src/olympia/devhub/forms.py:707
 msgid "A review type must be selected."
 msgstr "Deve essere selezionata una revisione."
 
-#: src/olympia/devhub/forms.py:788 src/olympia/editors/forms.py:114 src/olympia/zadmin/forms.py:49 src/olympia/zadmin/forms.py:52
+#: src/olympia/devhub/forms.py:789 src/olympia/editors/forms.py:114 src/olympia/editors/forms.py:254 src/olympia/zadmin/forms.py:49 src/olympia/zadmin/forms.py:52
 msgid "Select an application first"
 msgstr "Scegli prima un’applicazione"
 
-#: src/olympia/devhub/forms.py:840
+#: src/olympia/devhub/forms.py:841
 msgid "There cannot be more than 3 required add-ons."
 msgstr "Non possono esserci più di 3 componenti aggiuntivi richiesti."
 
@@ -3909,78 +3874,78 @@ msgstr[1] "{0} avvisi"
 msgid "Review"
 msgstr "Recensione"
 
-#: src/olympia/devhub/tasks.py:551
+#: src/olympia/devhub/tasks.py:583
 #, python-format
 msgid "%s responded with %s (%s)."
 msgstr "%s ha risposto con %s (%s)."
 
-#: src/olympia/devhub/tasks.py:555
+#: src/olympia/devhub/tasks.py:587
 #, python-format
 msgid "Connection to \"%s\" timed out."
 msgstr "Tempo per la connessione a \"%s\" esaurito."
 
-#: src/olympia/devhub/tasks.py:557
+#: src/olympia/devhub/tasks.py:589
 #, python-format
 msgid "Could not contact host at \"%s\"."
 msgstr "Impossibile contattare l’host “%s”."
 
-#: src/olympia/devhub/utils.py:104
+#: src/olympia/devhub/utils.py:105
 #, python-format
 msgid "Validation generated too many errors/warnings so %s messages were truncated. After addressing the visible messages, you'll be able to see the others."
 msgstr ""
 "Il processo di convalida per %s ha generato troppi avvisi/messaggi e sono stati perciò troncati. Quando saranno stati risolti i messaggi visualizzati, dovrebbe essere possibile visualizzare il "
 "resto."
 
-#: src/olympia/devhub/views.py:183
+#: src/olympia/devhub/views.py:181
 msgid "All My Add-ons"
 msgstr "Tutti i miei componenti aggiuntivi"
 
-#: src/olympia/devhub/views.py:210
+#: src/olympia/devhub/views.py:208
 msgid "All Activity"
 msgstr "Qualsiasi attività"
 
-#: src/olympia/devhub/views.py:211
+#: src/olympia/devhub/views.py:209
 msgid "Add-on Updates"
 msgstr "Aggiornamenti del componente aggiuntivo"
 
-#: src/olympia/devhub/views.py:212
+#: src/olympia/devhub/views.py:210
 msgid "Add-on Status"
 msgstr "Stato del componente aggiuntivo"
 
-#: src/olympia/devhub/views.py:213
+#: src/olympia/devhub/views.py:211
 msgid "User Collections"
 msgstr "Raccolte dell’utente"
 
-#: src/olympia/devhub/views.py:214 src/olympia/devhub/templates/devhub/docs/policies-maintenance.html:68 src/olympia/pages/templates/pages/dev_faq.html:38
+#: src/olympia/devhub/views.py:212 src/olympia/devhub/templates/devhub/docs/policies-maintenance.html:68 src/olympia/pages/templates/pages/dev_faq.html:38
 #: src/olympia/pages/templates/pages/dev_faq.html:484
 msgid "User Reviews"
 msgstr "Recensioni"
 
-#: src/olympia/devhub/views.py:327 src/olympia/devhub/views.py:331 src/olympia/devhub/views.py:484 src/olympia/devhub/views.py:513 src/olympia/devhub/views.py:564 src/olympia/devhub/views.py:1150
+#: src/olympia/devhub/views.py:325 src/olympia/devhub/views.py:329 src/olympia/devhub/views.py:484 src/olympia/devhub/views.py:513 src/olympia/devhub/views.py:564 src/olympia/devhub/views.py:1156
 msgid "Changes successfully saved."
 msgstr "Modifiche salvate correttamente."
 
-#: src/olympia/devhub/views.py:334 src/olympia/devhub/views.py:1631
+#: src/olympia/devhub/views.py:332 src/olympia/devhub/views.py:1637
 msgid "Please check the form for errors."
 msgstr "Controlla che il modulo non contenga errori."
 
-#: src/olympia/devhub/views.py:346
+#: src/olympia/devhub/views.py:344
 msgid "Add-on cannot be deleted. Disable this add-on instead."
 msgstr "Il componente aggiuntivo non può essere eliminato. Puoi invece disattivare questo componente aggiuntivo."
 
-#: src/olympia/devhub/views.py:356
+#: src/olympia/devhub/views.py:354
 msgid "Theme deleted."
 msgstr "Tema eliminato."
 
-#: src/olympia/devhub/views.py:356
+#: src/olympia/devhub/views.py:354
 msgid "Add-on deleted."
 msgstr "Componente aggiuntivo eliminato."
 
-#: src/olympia/devhub/views.py:362
+#: src/olympia/devhub/views.py:360
 msgid "URL name was incorrect. Theme was not deleted."
 msgstr "Il nome dell’URL non è valido. Il tema non è stato eliminato."
 
-#: src/olympia/devhub/views.py:367
+#: src/olympia/devhub/views.py:365
 msgid "URL name was incorrect. Add-on was not deleted."
 msgstr "Il nome dell’URL non è valido. Il componente aggiuntivo non è stato eliminato."
 
@@ -4008,7 +3973,7 @@ msgstr "Valida componente aggiuntivo"
 msgid "Check Add-on Compatibility"
 msgstr "Verifica compatibilità componente aggiuntivo"
 
-#: src/olympia/devhub/views.py:808 src/olympia/signing/views.py:90
+#: src/olympia/devhub/views.py:808 src/olympia/signing/views.py:95
 msgid "You cannot submit this type of add-on"
 msgstr "Non è possibile caricare questo tipo di componente aggiuntivo."
 
@@ -4038,33 +4003,33 @@ msgstr "L’immagine deve essere larga {0} pixel e alta {1} pixel."
 msgid "There was an error uploading your preview."
 msgstr "Si è verificato un errore durante il caricamento dell’anteprima."
 
-#: src/olympia/devhub/views.py:1189
+#: src/olympia/devhub/views.py:1195
 #, python-format
 msgid "Version %s disabled."
 msgstr "La versione %s è stata disattivata."
 
-#: src/olympia/devhub/views.py:1193
+#: src/olympia/devhub/views.py:1199
 #, python-format
 msgid "Version %s deleted."
 msgstr "Eliminata la versione %s."
 
-#: src/olympia/devhub/views.py:1203
+#: src/olympia/devhub/views.py:1209
 msgid "This upload has failed validation, and may lack complete validation results. Please take due care when reviewing it."
 msgstr "La validazione del file caricato è fallita, pertanto potrebbero mancare i risultati completi della validazione. Tienilo a mente durante il processo di revisione."
 
-#: src/olympia/devhub/views.py:1677
+#: src/olympia/devhub/views.py:1683
 msgid "Preliminary Review Requested."
 msgstr "Richiesta revisione preliminare."
 
-#: src/olympia/devhub/views.py:1678
+#: src/olympia/devhub/views.py:1684
 msgid "Full Review Requested."
 msgstr "Richiesta revisione completa."
 
-#: src/olympia/devhub/views.py:1779
+#: src/olympia/devhub/views.py:1783
 msgid "Your old credentials were revoked and are no longer valid. Be sure to update all API clients with the new credentials."
 msgstr "Le tue vecchie credenziali sono state revocate e non sono più valide. Ricorda di aggiornare tutti i client API che utilizzi con le nuove credenziali."
 
-#: src/olympia/devhub/views.py:1797
+#: src/olympia/devhub/views.py:1801
 msgid "New API key created"
 msgstr "La nuova chiave API è stata creata"
 
@@ -4096,7 +4061,7 @@ msgstr "Ritorna ai componenti aggiuntivi"
 msgid "{0} :: Search"
 msgstr "{0} :: Ricerca"
 
-#: src/olympia/devhub/templates/devhub/devhub_search.html:6 src/olympia/devhub/templates/devhub/search.html:8 src/olympia/editors/forms.py:435 src/olympia/editors/forms.py:437
+#: src/olympia/devhub/templates/devhub/devhub_search.html:6 src/olympia/devhub/templates/devhub/search.html:8 src/olympia/editors/forms.py:534 src/olympia/editors/forms.py:536
 #: src/olympia/editors/templates/editors/queue.html:27 src/olympia/editors/templates/editors/themes/queue_list.html:14 src/olympia/search/templates/search/collections.html:17
 #: src/olympia/search/templates/search/personas.html:18 src/olympia/search/templates/search/results.html:18 src/olympia/search/templates/search/mobile/results.html:8
 #: src/olympia/templates/search.html:14 src/olympia/templates/impala/search.html:18
@@ -4159,12 +4124,12 @@ msgstr "Puoi trovare tutte le informazioni che ti servono per iniziare visitando
 msgid "Start Making Add-ons"
 msgstr "Inizia a realizzare componenti aggiuntivi"
 
-#: src/olympia/devhub/templates/devhub/index.html:86 src/olympia/devhub/templates/devhub/addons/listing/items.html:25 src/olympia/devhub/templates/devhub/includes/addon_details.html:15
+#: src/olympia/devhub/templates/devhub/index.html:86 src/olympia/devhub/templates/devhub/addons/listing/items.html:25 src/olympia/devhub/templates/devhub/includes/addon_details.html:20
 #: src/olympia/devhub/templates/devhub/personas/edit.html:43
 msgid "Status:"
 msgstr "Stato:"
 
-#: src/olympia/devhub/templates/devhub/index.html:90 src/olympia/devhub/templates/devhub/includes/addon_details.html:100
+#: src/olympia/devhub/templates/devhub/index.html:90 src/olympia/devhub/templates/devhub/includes/addon_details.html:87
 msgid "Visibility:"
 msgstr "Visibilità:"
 
@@ -4172,11 +4137,11 @@ msgstr "Visibilità:"
 msgid "Latest Version:"
 msgstr "Ultima versione:"
 
-#: src/olympia/devhub/templates/devhub/index.html:109 src/olympia/devhub/templates/devhub/includes/addon_details.html:145 src/olympia/devhub/templates/devhub/personas/edit.html:49
+#: src/olympia/devhub/templates/devhub/index.html:109 src/olympia/devhub/templates/devhub/includes/addon_details.html:131 src/olympia/devhub/templates/devhub/personas/edit.html:49
 msgid "Queue Position:"
 msgstr "Posizione nella coda:"
 
-#: src/olympia/devhub/templates/devhub/index.html:110 src/olympia/devhub/templates/devhub/includes/addon_details.html:146 src/olympia/devhub/templates/devhub/personas/edit.html:50
+#: src/olympia/devhub/templates/devhub/index.html:110 src/olympia/devhub/templates/devhub/includes/addon_details.html:132 src/olympia/devhub/templates/devhub/personas/edit.html:50
 #, python-format
 msgid "%(position)s of %(total)s"
 msgstr "%(position)s di %(total)s"
@@ -4278,17 +4243,6 @@ msgstr "Una volta terminato il caricamento, verrà eseguita una serie di test au
 msgid "Do you want your add-on to be distributed on this site?"
 msgstr "Desideri che il componente aggiuntivo venga distribuito su questo sito?"
 
-#: src/olympia/devhub/templates/devhub/validate_addon.html:49 src/olympia/devhub/templates/devhub/addons/submit/upload.html:30 src/olympia/devhub/templates/devhub/versions/add_file_modal.html:14
-#: src/olympia/devhub/templates/devhub/versions/add_file_modal.html:53 src/olympia/devhub/templates/devhub/versions/list.html:298
-msgid "Warning:"
-msgstr "Avviso:"
-
-#: src/olympia/devhub/templates/devhub/validate_addon.html:50 src/olympia/devhub/templates/devhub/addons/submit/upload.html:31
-#, python-format
-msgid "Submission of unlisted add-ons for signing is currently in an open beta. Please <a href=\"%(url)s\" target=\"_blank\">report any bugs</a> that you encounter."
-msgstr ""
-"La procedura di firma digitale dei componenti aggiuntivi esterni è attualmente in fase beta. Se riscontri qualsiasi problema <a href=\"%(url)s\" target=\"_blank\">segnalalo aprendo un bug</a>."
-
 #. first parameter is a filename like lorem-ipsum-1.0.2.xpi
 #: src/olympia/devhub/templates/devhub/validation.html:5
 msgid "Validation Results for {0}"
@@ -4367,7 +4321,7 @@ msgstr "Compatibilità"
 msgid "Update Compatibility"
 msgstr "Aggiorna compatibilità"
 
-#: src/olympia/devhub/templates/devhub/addons/ajax_compat_update.html:4
+#: src/olympia/devhub/templates/devhub/addons/ajax_compat_update.html:4 src/olympia/devhub/templates/devhub/versions/edit.html:45
 msgid "Adjusting application information here will allow users to install your add-on even if the install manifest in the package indicates that the add-on is incompatible."
 msgstr ""
 "Modificando le informazioni del componente aggiuntivo in questa sezione gli utenti saranno in grado di completare l’installazione anche se nel file manifesto di installazione presente nel pacchetto "
@@ -4381,9 +4335,9 @@ msgstr "Versioni supportate"
 msgid "Add Another Application&hellip;"
 msgstr "Aggiungi un’altra applicazione&hellip;"
 
-#: src/olympia/devhub/templates/devhub/addons/ajax_compat_update.html:38 src/olympia/devhub/templates/devhub/addons/owner.html:86 src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:46
-#: src/olympia/devhub/templates/devhub/versions/list.html:351 src/olympia/devhub/templates/devhub/versions/list.html:353 src/olympia/templates/impala/base.html:132
-#: src/olympia/templates/impala/base.html:143 src/olympia/templates/impala/base.html:161 src/olympia/templates/impala/base.html:171
+#: src/olympia/devhub/templates/devhub/addons/ajax_compat_update.html:38 src/olympia/devhub/templates/devhub/addons/owner.html:86 src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:45
+#: src/olympia/devhub/templates/devhub/versions/list.html:349 src/olympia/devhub/templates/devhub/versions/list.html:351 src/olympia/templates/impala/base.html:129
+#: src/olympia/templates/impala/base.html:140 src/olympia/templates/impala/base.html:158 src/olympia/templates/impala/base.html:168
 msgid "Close"
 msgstr "Chiudi"
 
@@ -4417,7 +4371,7 @@ msgstr "Nessuno"
 msgid "Manage Authors & License"
 msgstr "Gestisci autori e licenza"
 
-#: src/olympia/devhub/templates/devhub/addons/owner.html:29 src/olympia/editors/templates/editors/review.html:270
+#: src/olympia/devhub/templates/devhub/addons/owner.html:29 src/olympia/editors/helpers.py:362 src/olympia/editors/templates/editors/review.html:270
 msgid "Authors"
 msgstr "Autori"
 
@@ -4489,19 +4443,13 @@ msgstr "Sommario"
 
 #: src/olympia/devhub/templates/devhub/addons/edit/basic.html:52
 msgid ""
-"A short explanation of your add-on's basic\n"
-"                          functionality that is displayed in search and browse\n"
-"                          listings, as well as at the top of your add-on's\n"
-"                          details page. It is only relevant for listed add-ons."
+"A short explanation of your add-on's basic functionality that is displayed in search and browse listings, as well as at the top of your add-on's details page. It is only relevant for listed add-ons."
 msgstr ""
 "Una breve descrizione delle funzioni di base del componente aggiuntivo, viene visualizzata nei risultati di ricerca, negli elenchi e in cima alla pagina principale del componente aggiuntivo. "
 "Rilevante solo per i componenti aggiuntivi pubblici."
 
 #: src/olympia/devhub/templates/devhub/addons/edit/basic.html:73
-msgid ""
-"Categories are the primary way users browse through add-ons.\n"
-"                        Choose any that fit your add-on's functionality for the most\n"
-"                        exposure. It is only relevant for listed add-ons."
+msgid "Categories are the primary way users browse through add-ons. Choose any that fit your add-on's functionality for the most exposure. It is only relevant for listed add-ons."
 msgstr ""
 "Le categorie sono lo strumento principale attraverso cui gli utenti esplorano i componenti aggiuntivi. Per ottenere massima visibilità seleziona la categoria più adatta alle caratteristiche del "
 "componente aggiuntivo. Rilevante solo per i componenti aggiuntivi pubblici."
@@ -4515,11 +4463,7 @@ msgstr ""
 "questa modifica."
 
 #: src/olympia/devhub/templates/devhub/addons/edit/basic.html:119
-msgid ""
-"Tags help users find your add-on and should be short\n"
-"                        descriptors such as tabs, toolbar, or twitter.  You\n"
-"                        may have a maximum of {0} tags. It is only relevant\n"
-"                        for listed add-ons."
+msgid "Tags help users find your add-on and should be short descriptors such as tabs, toolbar, or twitter. You may have a maximum of {0} tags. It is only relevant for listed add-ons."
 msgstr ""
 "Le etichette consentono agli utenti di trovare i componenti aggiuntivi più facilmente. Consistono in descrittori che ne riassumono in breve le funzionalità, come “tabs”, “toolbar” o ”twitter”. Ogni "
 "componente ha a disposizione un massimo di {0} etichette. Rilevante solo per i componenti aggiuntivi pubblici."
@@ -4551,11 +4495,7 @@ msgstr ""
 "componenti aggiuntivi distribuiti su AMO."
 
 #: src/olympia/devhub/templates/devhub/addons/edit/details.html:22
-msgid ""
-"A longer explanation of features,\n"
-"                          functionality, and other relevant information. This\n"
-"                          field is only displayed on the add-on's details\n"
-"                          page. It is only relevant for listed add-ons."
+msgid "A longer explanation of features, functionality, and other relevant information. This field is only displayed on the add-on's details page. It is only relevant for listed add-ons."
 msgstr ""
 "Una descrizione più dettagliata delle caratteristiche, delle funzioni e delle altre informazioni rilevanti sul componente aggiuntivo. Questo campo è visualizzato unicamente sulla pagina dedicata "
 "del componente aggiuntivo. Rilevante solo per i componenti aggiuntivi pubblici."
@@ -4565,10 +4505,7 @@ msgid "Default Locale"
 msgstr "Locale predefinito"
 
 #: src/olympia/devhub/templates/devhub/addons/edit/details.html:45
-msgid ""
-"Information about your add-on is displayed in this locale\n"
-"                        unless you override it with a locale-specific translation.\n"
-"                        It is only relevant for listed add-ons."
+msgid "Information about your add-on is displayed in this locale unless you override it with a locale-specific translation. It is only relevant for listed add-ons."
 msgstr ""
 "Le informazioni sul componente aggiuntivo verranno visualizzate in questa lingua quando non sarà disponibile una versione specifica per la lingua locale del visitatore. Rilevante solo per i "
 "componenti aggiuntivi pubblici.\n"
@@ -4581,10 +4518,8 @@ msgstr "Pagina principale"
 
 #: src/olympia/devhub/templates/devhub/addons/edit/details.html:63
 msgid ""
-"If your add-on has another homepage, enter its\n"
-"                          address here. If your website is localized into other\n"
-"                          languages multiple translations of this field can be\n"
-"                          added. It is only relevant for listed add-ons."
+"If your add-on has another homepage, enter its address here. If your website is localized into other languages multiple translations of this field can be added. It is only relevant for listed add-"
+"ons."
 msgstr ""
 "Se un componente aggiuntivo ha un sito dedicato, inserisci l’indirizzo di seguito. Nel caso il sito sia disponibile in varie lingue, puoi aggiungere più occorrenze di questo campo, una per ogni "
 "lingua in cui il sito è disponibile. Rilevante solo per i componenti aggiuntivi pubblici."
@@ -4604,21 +4539,16 @@ msgstr "Informazioni per il supporto per {0}"
 
 #: src/olympia/devhub/templates/devhub/addons/edit/support.html:22
 msgid ""
-"If you wish to display an e-mail address for support\n"
-"                          inquiries, enter it here. If you have different\n"
-"                          addresses for each language multiple translations of\n"
-"                          this field can be added. It is only relevant for\n"
-"                          listed add-ons."
+"If you wish to display an e-mail address for support inquiries, enter it here. If you have different addresses for each language multiple translations of this field can be added. It is only "
+"relevant for listed add-ons."
 msgstr ""
 "Inserisci nel seguente campo l’indirizzo email dedicato alle richieste di supporto, se presente. Se il supporto viene offerto in più lingue, puoi aggiungere più occorrenze di questo campo, uno per "
 "ogni lingua in cui è reso disponibile. Rilevante solo per i componenti aggiuntivi pubblici."
 
 #: src/olympia/devhub/templates/devhub/addons/edit/support.html:45
 msgid ""
-"If your add-on has a support website or forum, enter\n"
-"                          its address here. If your website is localized into\n"
-"                          other languages, multiple translations of this field can\n"
-"                          be added. It is only relevant for listed add-ons."
+"If your add-on has a support website or forum, enter its address here. If your website is localized into other languages, multiple translations of this field can be added. It is only relevant for "
+"listed add-ons."
 msgstr ""
 "Se il componente aggiuntivo ha un sito o forum di supporto dedicato, inserisci qui l’indirizzo. Nel caso il sito sia disponibile in varie lingue, puoi aggiungere più occorrenze di questo campo, una "
 "per ogni lingua in cui il sito è localizzato. Rilevante solo per i componenti aggiuntivi pubblici."
@@ -4634,11 +4564,8 @@ msgstr "Dettagli tecnici per {0}"
 
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:23
 msgid ""
-"Any information end users may want to know that isn't\n"
-"                          necessarily applicable to the add-on summary or description.\n"
-"                          Common uses include listing known major bugs, information on\n"
-"                          how to report bugs, anticipated release date of a new version,\n"
-"                          etc. It is only relevant for listed add-ons."
+"Any information end users may want to know that isn't necessarily applicable to the add-on summary or description. Common uses include listing known major bugs, information on how to report bugs, "
+"anticipated release date of a new version, etc. It is only relevant for listed add-ons."
 msgstr ""
 "Ulteriori informazioni utili per l’utente finale che non possono essere inserite nei campi sommario e descrizione. Questo campo è solitamente utilizzato per indicare l’elenco dei bug noti più "
 "importanti, le istruzioni per segnalare nuovi bug, date di rilascio previste di versioni future e simili. Rilevante solo per i componenti aggiuntivi pubblici."
@@ -4652,9 +4579,7 @@ msgid "Add-on Flags"
 msgstr "Segnalazioni per questo componente aggiuntivo"
 
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:69
-msgid ""
-"These flags are used to classify add-ons. It is only\n"
-"                        relevant for listed add-ons."
+msgid "These flags are used to classify add-ons. It is only relevant for listed add-ons."
 msgstr "Questo tipo di avvisi vengono utilizzati per classificare i componenti aggiuntivi. Rilevante solo per i componenti aggiuntivi pubblici."
 
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:74
@@ -4670,9 +4595,7 @@ msgid "View Source?"
 msgstr "Mostra il codice sorgente?"
 
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:90
-msgid ""
-"Whether the source of your add-on can be displayed in our\n"
-"                        online viewer. It is only relevant for listed add-ons."
+msgid "Whether the source of your add-on can be displayed in our online viewer. It is only relevant for listed add-ons."
 msgstr "Specifica se il codice sorgente del componente aggiuntivo può essere visualizzato sul sito. Rilevante solo per i componenti aggiuntivi pubblici."
 
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:94
@@ -4688,10 +4611,7 @@ msgid "Public Stats?"
 msgstr "Statistiche pubbliche?"
 
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:102
-msgid ""
-"Whether the download and usage stats of your add-on can\n"
-"                        be displayed in our online viewer.\n"
-"                        It is only relevant for listed add-ons."
+msgid "Whether the download and usage stats of your add-on can be displayed in our online viewer. It is only relevant for listed add-ons."
 msgstr "Specifica se le statistiche di download e di utilizzo del componente aggiuntivo possono essere visualizzate sul sito. Rilevante solo per i componenti aggiuntivi pubblici."
 
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:107
@@ -4707,10 +4627,7 @@ msgid "Upgrade SDK?"
 msgstr "Aggiornamento SDK?"
 
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:116
-msgid ""
-"If selected, we will try to automatically upgrade your\n"
-"                        add-on when a new version of the SDK is released.\n"
-"                        It is only relevant for listed add-ons."
+msgid "If selected, we will try to automatically upgrade your add-on when a new version of the SDK is released. It is only relevant for listed add-ons."
 msgstr ""
 "Selezionando questa opzione, al rilascio di ogni nuova versione di SDK verrà effettuato un tentativo automatico di aggiornamento del componente aggiuntivo. Rilevante solo per i componenti "
 "aggiuntivi pubblici."
@@ -4766,10 +4683,8 @@ msgstr "Icona componente aggiuntivo"
 
 #: src/olympia/devhub/templates/devhub/addons/forms_shared/media.html:16
 msgid ""
-"Upload an icon for your add-on or choose from one of ours. The\n"
-"                      icon is displayed nearly everywhere your add-on is. Uploaded images\n"
-"                      must be one of the following image types: .png, .jpg.\n"
-"                      It is only relevant for listed add-ons."
+"Upload an icon for your add-on or choose from one of ours. The icon is displayed nearly everywhere your add-on is. Uploaded images must be one of the following image types: .png, .jpg. It is only "
+"relevant for listed add-ons."
 msgstr ""
 "Carica un’icona personalizzata per il componente aggiuntivo oppure scegline una tra quelle predefinite. L’icona viene generalmente visualizzata in tutte le pagine dove compare il componente "
 "aggiuntivo. L’icona deve essere caricata in uno dei seguenti formati: .png, .jpg. Rilevante solo per i componenti aggiuntivi pubblici."
@@ -4784,9 +4699,7 @@ msgid "32x32px"
 msgstr "32×32px"
 
 #: src/olympia/devhub/templates/devhub/addons/forms_shared/media.html:39
-msgid ""
-"Used in listings of add-ons, like search results\n"
-"                            and featured add-ons."
+msgid "Used in listings of add-ons, like search results and featured add-ons."
 msgstr "Utilizzato nelle pagine elenco di componenti aggiuntivi, come risultati di ricerca o componenti aggiuntivi consigliati."
 
 #. The size of the icon
@@ -4881,16 +4794,14 @@ msgid "Deleting your add-on will permanently remove it from the site and prevent
 msgstr "Impossibile verificare i dati inseriti, riprova."
 
 #: src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:24
-msgid ""
-"Enter the following text confirm your decision:\n"
-"           {slug}"
+msgid "Enter the following text confirm your decision: {slug}"
 msgstr "Confermare l’operazione digitando il seguente testo: {slug}"
 
-#: src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:34
+#: src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:33
 msgid "Please tell us why you are deleting your theme:"
 msgstr "Il motivo per cui hai deciso di eliminare il tema:"
 
-#: src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:36
+#: src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:35
 msgid "Please tell us why you are deleting your add-on:"
 msgstr "Il motivo per cui hai deciso di eliminare il componente aggiuntivo:"
 
@@ -4927,8 +4838,8 @@ msgstr "Nuova versione"
 msgid "Daily statistics on downloads and users."
 msgstr "Statistiche per giorno di download e utenti."
 
-#: src/olympia/devhub/templates/devhub/addons/listing/item_actions.html:45 src/olympia/stats/templates/stats/stats.html:75 src/olympia/stats/templates/stats/stats.html:79
-#: src/olympia/stats/templates/stats/stats.html:81
+#: src/olympia/devhub/templates/devhub/addons/listing/item_actions.html:45 src/olympia/stats/templates/stats/stats.html:31 src/olympia/stats/templates/stats/stats.html:35
+#: src/olympia/stats/templates/stats/stats.html:37
 msgid "Statistics"
 msgstr "Statistiche"
 
@@ -5047,10 +4958,7 @@ msgid "Your add-on has been submitted to the Full Review queue."
 msgstr "Il tuo componente aggiuntivo è stato inviato alla coda di revisione completa."
 
 #: src/olympia/devhub/templates/devhub/addons/submit/done.html:18
-msgid ""
-"You'll receive an email once it has been reviewed by an editor. In\n"
-"          the meantime, you and your friends can install it directly from its\n"
-"          details page:"
+msgid "You'll receive an email once it has been reviewed by an editor. In the meantime, you and your friends can install it directly from its details page:"
 msgstr "Riceverai una email non appena il componente sarà stato controllato da un revisore. Nel frattempo sarà possibile installarlo direttamente dalla sua pagina su AMO."
 
 #: src/olympia/devhub/templates/devhub/addons/submit/done.html:27 src/olympia/devhub/templates/devhub/addons/submit/done.html:77 src/olympia/devhub/templates/devhub/personas/submit_done.html:16
@@ -5264,11 +5172,11 @@ msgstr ""
 "Utilizza il seguente campo per caricare il pacchetto del tuo componente aggiuntivo e specificare eventuali limitazioni sul sistema operativo. Una volta completato il caricamento verranno eseguiti "
 "dei test automatici sul tuo file."
 
-#: src/olympia/devhub/templates/devhub/addons/submit/upload.html:59 src/olympia/devhub/templates/devhub/versions/add_file_modal.html:39
+#: src/olympia/devhub/templates/devhub/addons/submit/upload.html:51 src/olympia/devhub/templates/devhub/versions/add_file_modal.html:28
 msgid "Which platforms is this file compatible with?"
 msgstr "Con quali piattaforme è compatibile il file?"
 
-#: src/olympia/devhub/templates/devhub/addons/submit/upload.html:67 src/olympia/devhub/templates/devhub/versions/add_file_modal.html:65
+#: src/olympia/devhub/templates/devhub/addons/submit/upload.html:59 src/olympia/devhub/templates/devhub/versions/add_file_modal.html:45
 msgid "Administrative overrides"
 msgstr "Sostituzioni amministrative"
 
@@ -5387,11 +5295,9 @@ msgstr "Funzionalità e sviluppo del sito web"
 
 #: src/olympia/devhub/templates/devhub/docs/policies-contact.html:44
 msgid ""
-"If you've found a problem with the site, we'd love to fix it. Please <a href=\"https://github.com/mozilla/olympia/issues\">file a bug report</a> in GitHub, including the location of the problem and "
-"how you encountered it."
+"If you've found a problem with the site, we'd love to fix it. Please <a href=\"https://github.com/mozilla/addons/issues/new\">file a bug report</a> in GitHub, including the location of the problem "
+"and how you encountered it."
 msgstr ""
-"Se riscontri qualsiasi problema con questo sito, comunicacelo e faremo del nostro meglio per risolverlo. <a href=\"https://github.com/mozilla/olympia/issues\">Apri un bug su GitHub</a>, "
-"ricordandoti di inserire l’indirizzo della pagina e spiegando i passi per riprodurlo."
 
 #: src/olympia/devhub/templates/devhub/docs/policies-maintenance.html:3 src/olympia/devhub/templates/devhub/docs/policies-maintenance.html:7
 #: src/olympia/devhub/templates/devhub/docs/policies-maintenance.html:8
@@ -6058,7 +5964,7 @@ msgstr "Navigazione anonima"
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:282
 msgid ""
-"Add-ons that store or otherwise handle browsing data must support <a href=\"https://developer.mozilla.org/En/Supporting_private_browsing_mode\">Private Browsing Mode</a>.  During a Private Browsing "
+"Add-ons that store or otherwise handle browsing data must support <a href=\"https://developer.mozilla.org/En/Supporting_private_browsing_mode\">Private Browsing Mode</a>. During a Private Browsing "
 "session, no browsing data can be written to disk, and all of this data must be cleared when Firefox quits or the Private Browsing session ends."
 msgstr ""
 "I componenti aggiuntivi che memorizzano o fanno altrimenti uso dei dati di navigazione devono necessariamente essere compatibili con la modalità <a href=\"https://developer.mozilla.org/En/"
@@ -6277,139 +6183,103 @@ msgstr "Termini di servizio per caricare il tuo lavoro sul nostro sito. Gli svil
 msgid "How to get in touch with us regarding these policies or your add-on."
 msgstr "Come contattarci per informazioni su queste norme o sul tuo componente aggiuntivo."
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:6
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:10
 msgid "You have disabled this add-on"
 msgstr "Hai disattivato questo componente aggiuntivo"
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:20
-msgid ""
-"Your add-on's listing is disabled and is not showing\n"
-"                             anywhere in our gallery or update service."
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:24
+msgid "Your add-on's listing is disabled and is not showing anywhere in our gallery or update service."
 msgstr "La visualizzazione del componente aggiuntivo è stata disattivata; il componente aggiuntivo non verrà visualizzato nelle pagine elenco né sarà disponibile per gli aggiornamenti automatici."
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:25
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:27
 msgid "Please complete your add-on."
 msgstr "Completa il tuo componente aggiuntivo."
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:29
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:30
 msgid "You will receive an email when the review is complete."
 msgstr "Riceverai una email quando la revisione sarà completata."
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:34
-msgid ""
-"You will receive an email when the review is complete. Until\n"
-"                             then, your add-on is not listed in our gallery but can be\n"
-"                             accessed directly from its details page."
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:33
+msgid "You will receive an email when the review is complete. Until then, your add-on is not listed in our gallery but can be accessed directly from its details page."
 msgstr ""
 "Quando la revisione sarà conclusa riceverai un’email di notifica. Fino ad allora il componente aggiuntivo non apparirà nelle pagine elenco del sito, ma sarà comunque accessibile dalla sua pagina su "
 "AMO."
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:38 src/olympia/devhub/templates/devhub/includes/addon_details.html:48
-msgid ""
-"You will receive an email when the review is\n"
-"                             complete and your add-on is signed."
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:37 src/olympia/devhub/templates/devhub/includes/addon_details.html:45
+msgid "You will receive an email when the review is complete and your add-on is signed."
 msgstr "Riceverai una notifica via email quando il componente aggiuntivo avrà superato la revisione e sarà stato firmato digitalmente."
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:44
-msgid ""
-"You will receive an email when the review is complete. Until\n"
-"                             then, your add-on is not listed in our gallery but can be\n"
-"                             accessed directly from its details page. "
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:41
+msgid "You will receive an email when the review is complete. Until then, your add-on is not listed in our gallery but can be accessed directly from its details page. "
 msgstr ""
-"Quando la revisione sarà completata riceverai una notifica tramite email. Fino ad allora il componente non comparirà nelle pagine elenco del sito, ma sarà comunque accessibile dalla propria pagina "
-"dedicata."
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:54
-msgid ""
-"Your add-on is displayed in our gallery and users are\n"
-"                             receiving automatic updates."
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:49
+msgid "Your add-on is displayed in our gallery and users are receiving automatic updates."
 msgstr "Il componente aggiuntivo è visualizzato nelle pagine elenco del sito e gli aggiornamenti automatici sono attivi."
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:57
-msgid ""
-"Your add-on has been signed and can be bundled with an\n"
-"                             application installer."
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:52
+msgid "Your add-on has been signed and can be bundled with an application installer."
 msgstr "Il componente aggiuntivo è stato firmato digitalmente da Mozilla e ora può essere distribuito tramite un programma di installazione."
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:63
-msgid ""
-"Your add-on was disabled by a site administrator and is no\n"
-"                             longer shown in our gallery. If you have any questions,\n"
-"                             please email amo-admins@mozilla.org."
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:56
+msgid "Your add-on was disabled by a site administrator and is no longer shown in our gallery. If you have any questions, please email amo-admins@mozilla.org."
 msgstr "Questo componente aggiuntivo è stato disattivato da un amministratore del sito e non viene più visualizzato nelle pagine elenco. Per qualsiasi domanda contatta amo-admins@mozilla.org."
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:70
-msgid ""
-"Your add-on is displayed in our gallery as experimental\n"
-"                             and users are receiving automatic updates. Some features\n"
-"                             are unavailable to your add-on."
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:62
+msgid "Your add-on is displayed in our gallery as experimental and users are receiving automatic updates. Some features are unavailable to your add-on."
 msgstr ""
 "Il componente aggiuntivo è segnalato nelle pagine elenco come componente sperimentale e gli utenti che lo hanno installato ricevono gli aggiornamenti automatici. Alcune funzionalità non sono "
 "disponibili."
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:74
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:66
 msgid "Your add-on has been signed."
 msgstr "Il componente aggiuntivo è stato firmato digitalmente."
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:79
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:69
 msgid ""
-"You will receive an email when the full review is complete.\n"
-"                             Until then, your add-on is displayed in our gallery as\n"
-"                             experimental and users are receiving automatic updates.\n"
-"                             Some features are unavailable to your add-on."
+"You will receive an email when the full review is complete. Until then, your add-on is displayed in our gallery as experimental and users are receiving automatic updates. Some features are "
+"unavailable to your add-on."
 msgstr ""
 "Quando la revisione sarà completata riceverai una notifica tramite email. Fino ad allora il componente aggiuntivo verrà segnalato nelle pagine elenco come componente sperimentale e gli utenti che "
 "lo hanno installato riceveranno gli aggiornamenti automatici. Alcune funzionalità non sono disponibili."
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:84
-msgid ""
-"You will receive an email when the full review is\n"
-"                             complete, making you able to bundle your add-on with an\n"
-"                             application installer."
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:74
+msgid "You will receive an email when the full review is complete, making you able to bundle your add-on with an application installer."
 msgstr "Riceverai un’email di notifica quando la revisione sarà conclusa, a quel punto potrai distribuire il componente aggiuntivo tramite un programma di installazione."
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:91
-msgid ""
-"All add-ons hosted in our gallery must now be reviewed by an\n"
-"                             editor. If you wish to continue hosting your add-on, please\n"
-"                             click to select a review process."
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:79
+msgid "All add-ons hosted in our gallery must now be reviewed by an editor. If you wish to continue hosting your add-on, please click to select a review process."
 msgstr ""
 "Da questo momento tutti i componenti aggiuntivi ospitati sul nostro sito saranno sottoposti a revisione. Se intendi continuare a usufruire di questo servizio, seleziona il processo di revisione "
 "appropriato."
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:113
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:100
 msgid "Current Version:"
 msgstr "Versione attuale:"
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:115
-msgid ""
-"This is the version of your add-on that will\n"
-"                                           be installed if someone clicks the Install\n"
-"                                           button on addons.mozilla.org. It is only\n"
-"                                           relevant for listed add-ons."
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:102
+msgid "This is the version of your add-on that will be installed if someone clicks the Install button on addons.mozilla.org. It is only relevant for listed add-ons."
 msgstr "Questa è la versione del componente aggiuntivo che verrà installata attraverso il pulsante Aggiungi a Firefox sul sito addons.mozilla.org. Rilevante solo per i componenti aggiuntivi pubblici."
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:123
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:110
 msgid "Created:"
 msgstr "Creato:"
 
 #. {0} is a date. dennis-ignore: E201
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:125 src/olympia/devhub/templates/devhub/includes/addon_details.html:131
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:112 src/olympia/devhub/templates/devhub/includes/addon_details.html:118
 #, python-format
 msgid "%%b %%e, %%Y"
 msgstr "%%e %%b %%Y"
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:136
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:123
 msgid "Next Version:"
 msgstr "Prossima versione:"
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:138
-msgid ""
-"This is the newest uploaded version, however\n"
-"                                           it isn’t live on the site yet."
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:125
+msgid "This is the newest uploaded version, however it isn’t live on the site yet."
 msgstr "L’ultima versione caricata, anche se non è quella proposta nella pagina  del componente aggiuntivo."
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:144 src/olympia/devhub/templates/devhub/versions/list.html:30
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:130 src/olympia/devhub/templates/devhub/versions/list.html:30
 msgid "Queues are not reviewed strictly in order"
 msgstr "L’ordine delle code di revisione non è seguito rigidamente"
 
@@ -6479,9 +6349,7 @@ msgid "View the blog &#9658;"
 msgstr "Visualizza il blog &#9658;"
 
 #: src/olympia/devhub/templates/devhub/includes/license_form.html:6
-msgid ""
-"Please choose a license appropriate for the rights you grant on your source code.\n"
-"                  It is only relevant for listed add-ons."
+msgid "Please choose a license appropriate for the rights you grant on your source code. It is only relevant for listed add-ons."
 msgstr "Scegli la licenza appropriata per i diritti che intendi concedere a terzi sul codice sorgente del componente aggiuntivo. Rilevante solo per i componenti aggiuntivi pubblici."
 
 #. {0} is a list of HTML tags.
@@ -6497,8 +6365,7 @@ msgstr "HTML parzialmente consentito."
 msgid "Remove this application"
 msgstr "Rimuovi questa applicazione"
 
-#. {0} is the maximum number of add-on categories allowed.                {1}
-#. is
+#. {0} is the maximum number of add-on categories allowed.                {1} is
 #. the application name.
 #: src/olympia/devhub/templates/devhub/includes/macros.html:70
 msgid "Select <b>up to {0}</b> {1} category for this add-on:"
@@ -6509,17 +6376,11 @@ msgstr[1] "Seleziona <b>al massimo {0}</b> categorie in {1} per questo component
 #: src/olympia/devhub/templates/devhub/includes/policy_form.html:4
 msgid ""
 "Users will be required to accept the following End-User License Agreement (EULA) prior to installing your add-on. The presence of a EULA significantly affects the number of downloads an add-on "
-"receives. Please note that a EULA is not the same as a code license, such as the GPL or MPL.\n"
-"                It is only relevant for listed add-ons."
+"receives. Please note that a EULA is not the same as a code license, such as the GPL or MPL.It is only relevant for listed add-ons."
 msgstr ""
-"Prima di installare il componente aggiuntivo agli utenti verrà richiesto di accettare le condizioni dell’End-User License Agreement (EULA), contratto di licenza per l’utente finale. La presenza di "
-"tale contratto influisce significativamente sul numero di download di un componente aggiuntivo. Nota bene: EULA non equivale a un contratto di licenza del codice quale per esempio GPL o MPL. "
-"Rilevante solo per i componenti aggiuntivi pubblici."
 
-#: src/olympia/devhub/templates/devhub/includes/policy_form.html:21
-msgid ""
-"If your add-on transmits any data from the user's computer, a privacy policy is required that explains what data is sent and how it is used.\n"
-"                It is only relevant for listed add-ons."
+#: src/olympia/devhub/templates/devhub/includes/policy_form.html:24
+msgid "If your add-on transmits any data from the user's computer, a privacy policy is required that explains what data is sent and how it is used. It is only relevant for listed add-ons."
 msgstr ""
 "In tutti i casi in cui il componente aggiuntivo trasmetta e raccolga dati dal computer dell’utente è necessario esplicitare un’informativa sulla privacy che indichi quali dati vengono inviati e "
 "come verranno utilizzati. Rilevante solo per componenti aggiuntivi pubblici."
@@ -6691,12 +6552,8 @@ msgstr "Seleziona la categoria che meglio descrive il tuo tema."
 msgid "Add some tags to describe your Theme."
 msgstr "Aggiungi qualche tag per descrivere il tuo tema."
 
-#: src/olympia/devhub/templates/devhub/personas/edit.html:106
-msgid ""
-"A short explanation of your theme's\n"
-"                                basic functionality that is displayed in\n"
-"                                search and browse listings, as well as at\n"
-"                                the top of your theme's details page."
+#: src/olympia/devhub/templates/devhub/personas/edit.html:106 src/olympia/devhub/templates/devhub/personas/submit.html:54
+msgid "A short explanation of your theme's basic functionality that is displayed in search and browse listings, as well as at the top of your theme's details page."
 msgstr "Una breve presentazione del tema, verrà visualizzata nelle pagine elenco e nei risultati di ricerca oltre che nella pagina del tema su AMO."
 
 #: src/olympia/devhub/templates/devhub/personas/edit.html:122 src/olympia/devhub/templates/devhub/personas/submit.html:68
@@ -6766,7 +6623,7 @@ msgid "Upon upload and form submission, the AMO Team will review your updated de
 msgstr "Una volta caricato il motivo e dopo aver compilato e inviato l’apposito modulo, il team di AMO revisionerà il nuovo motivo. Nel frattempo agli utenti verrà proposto il motivo attuale."
 
 #: src/olympia/devhub/templates/devhub/personas/edit.html:241
-msgid "Your previously resubmitted design,  which is under pending review."
+msgid "Your previously resubmitted design, which is under pending review."
 msgstr "Il design già ricaricato in precedenza e ancora in attesa di revisione."
 
 #: src/olympia/devhub/templates/devhub/personas/edit.html:245
@@ -6836,14 +6693,6 @@ msgstr ""
 #: src/olympia/devhub/templates/devhub/personas/submit.html:33
 msgid "Give your Theme a name."
 msgstr "Scegli un nome per il tuo tema."
-
-#: src/olympia/devhub/templates/devhub/personas/submit.html:54
-msgid ""
-"A short explanation of your theme's\n"
-"                                      basic functionality that is displayed in\n"
-"                                      search and browse listings, as well as at\n"
-"                                      the top of your theme's details page."
-msgstr "Una breve presentazione del tema, verrà visualizzata nelle pagine elenco e nei risultati di ricerca oltre che nella sezione superiore  nella pagina del tema su AMO."
 
 #: src/olympia/devhub/templates/devhub/personas/submit.html:198
 #, python-format
@@ -6921,35 +6770,17 @@ msgstr "Scegli un’altra immagine per il piè di pagina"
 msgid "Files added to reviewed versions must be reviewed before they will be available for download."
 msgstr "I file aggiunti a versioni già verificate devono essere controllati prima di essere disponibili per il download."
 
-#: src/olympia/devhub/templates/devhub/versions/add_file_modal.html:15
-#, python-format
-msgid ""
-"Submission of updates to unlisted add-ons for signing is currently in an open beta. Manual review may still be required for a large number of add-ons. Please <a href=\"%(url)s\" target=\"_blank"
-"\">report any bugs</a> that you encounter."
-msgstr ""
-"La procedura di firma digitale degli aggiornamenti di componenti aggiuntivi esterni è attualmente in fase beta. Per una grande quantità di componenti aggiuntivi sarà ancora necessario procedere con "
-"una revisione manuale. Se riscontri qualsiasi problema <a href=\"%(url)s\" target=\"_blank\">segnalalo aprendo un bug</a>."
-
-#: src/olympia/devhub/templates/devhub/versions/add_file_modal.html:35
+#: src/olympia/devhub/templates/devhub/versions/add_file_modal.html:24
 msgid "Select the target platform for this file."
 msgstr "Seleziona una piattaforma di riferimento per questo file"
 
-#: src/olympia/devhub/templates/devhub/versions/add_file_modal.html:46
+#: src/olympia/devhub/templates/devhub/versions/add_file_modal.html:35
 msgid "Which review type would you like to nominate for?"
 msgstr "Per quale tipo di revisione vuoi candidarti?"
 
-#: src/olympia/devhub/templates/devhub/versions/add_file_modal.html:51
+#: src/olympia/devhub/templates/devhub/versions/add_file_modal.html:40
 msgid "Only publish this version to my beta channel."
 msgstr "Pubblica questa versione unicamente sul mio canale beta."
-
-#: src/olympia/devhub/templates/devhub/versions/add_file_modal.html:54
-#, python-format
-msgid ""
-"The behavior of the beta channel has changed to accommodate <a href=\"%(addon_signing_url)s\" target=\"_blank\">mandatory add-on signing</a>. The new process is currently in an open beta, and may "
-"change significantly in the near future. Please <a href=\"%(issues_url)s\" target=\"_blank\">report any bugs</a> that you encounter."
-msgstr ""
-"Il funzionamento del canale Beta ha subito delle modifiche per gestire <a href=\"%(addon_signing_url)s\" target=\"_blank\">la firma obbligatoria dei componenti aggiuntivi</a>. La procedura è al "
-"momento in una fase sperimentale pubblica e potrebbe subire modifiche sostanziali in un futuro prossimo. <a href=\"%(issues_url)s\" target=\"_blank\">Segnalaci qualunque bug dovessi incontrare</a>."
 
 #: src/olympia/devhub/templates/devhub/versions/edit.html:5
 msgid "Manage Version {0}"
@@ -6973,19 +6804,10 @@ msgstr "File"
 msgid "Upload Another File"
 msgstr "Carica un altro file"
 
-#: src/olympia/devhub/templates/devhub/versions/edit.html:45
-msgid ""
-"Adjusting application information here will allow users to install your\n"
-"                          add-on even if the install manifest in the package indicates that the\n"
-"                          add-on is incompatible."
-msgstr "Modificando da questa pagina le informazioni sul componente aggiuntivo consentirai agli utenti di installarlo anche se nel file manifesto del pacchetto venga dichiarato incompatibile."
-
 #: src/olympia/devhub/templates/devhub/versions/edit.html:74
 msgid ""
-"Information about changes in this release, new features,\n"
-"                              known bugs, and other useful information specific to this\n"
-"                              release/version. This information is also shown in the\n"
-"                              Add-ons Manager when updating."
+"Information about changes in this release, new features, known bugs, and other useful information specific to this release/version. This information is also shown in the Add-ons Manager when "
+"updating."
 msgstr ""
 "Informazioni sulle modifiche presenti in questa versione, nuove funzioni, problemi noti e altre informazioni utili specifiche per questa versione. Questi dati verranno visualizzati durante "
 "l’aggiornamento nella finestra di gestione dei componenti aggiuntivi."
@@ -6999,10 +6821,7 @@ msgid "Notes for Reviewers"
 msgstr "Note per i revisori"
 
 #: src/olympia/devhub/templates/devhub/versions/edit.html:114
-msgid ""
-"Optionally, enter any information that may be useful\n"
-"                              to the Editor reviewing this add-on, such as test\n"
-"                              account information."
+msgid "Optionally, enter any information that may be useful to the Editor reviewing this add-on, such as test account information."
 msgstr "(facoltativo) Inserisci informazioni utili per i revisori che dovranno verificare questa estensione, ad esempio i dati di un account per eseguire test."
 
 #: src/olympia/devhub/templates/devhub/versions/edit.html:127
@@ -7080,7 +6899,7 @@ msgstr "Richiedi revisione completa"
 msgid "Request Preliminary Review"
 msgstr "Richiedi revisione preliminare"
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:80 src/olympia/devhub/templates/devhub/versions/list.html:327 src/olympia/devhub/templates/devhub/versions/list.html:350
+#: src/olympia/devhub/templates/devhub/versions/list.html:80 src/olympia/devhub/templates/devhub/versions/list.html:325 src/olympia/devhub/templates/devhub/versions/list.html:348
 msgid "Cancel Review Request"
 msgstr "Annulla richiesta di revisione"
 
@@ -7110,9 +6929,8 @@ msgid "Unlisted:"
 msgstr "Componenti aggiuntivi esterni:"
 
 #: src/olympia/devhub/templates/devhub/versions/list.html:114
-msgid "Not distributed on {0}. Developers will upload new versions for signing and distribute the add-ons on their own. (beta)"
+msgid "Not distributed on {0}. Developers will upload new versions for signing and distribute the add-ons on their own."
 msgstr ""
-"Non distribuito su {0}. Gli sviluppatori caricheranno le versioni aggiornate per ottenere la firma digitale e distribuiranno in seguito il componente aggiuntivo attraverso canali propri. (beta)"
 
 #: src/olympia/devhub/templates/devhub/versions/list.html:122
 msgid "Current versions"
@@ -7179,87 +6997,78 @@ msgid "<strong>Important:</strong> Once a version has been deleted, you may not 
 msgstr "<strong>Importante:</strong> a seguito dell’eliminazione di una versione non sarà più possibile caricare una copia con lo stesso numero di versione."
 
 #: src/olympia/devhub/templates/devhub/versions/list.html:230
-msgid ""
-"Deleting a version which has already been reviewed\n"
-"               may also cause a significant delay in the review of\n"
-"               your next update."
-msgstr "L’eliminazione di una versione che sia stata già sottoposta a revisione può causare un ritardo significativo nella revisione dell’aggiornamento successivo."
-
-#: src/olympia/devhub/templates/devhub/versions/list.html:233
 msgid "Are you sure you wish to delete this version?"
 msgstr "Eliminare questa versione?"
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:238
+#: src/olympia/devhub/templates/devhub/versions/list.html:235
 msgid "Delete Version"
 msgstr "Elimina versione"
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:240
+#: src/olympia/devhub/templates/devhub/versions/list.html:237
 msgid "Disable Version"
 msgstr "Disattiva versione"
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:247
+#: src/olympia/devhub/templates/devhub/versions/list.html:244
 msgid "Add a new Version"
 msgstr "Aggiungi una nuova versione"
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:249
+#: src/olympia/devhub/templates/devhub/versions/list.html:246
 msgid "Add Version"
 msgstr "Aggiungi versione"
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:256 src/olympia/devhub/templates/devhub/versions/list.html:274
+#: src/olympia/devhub/templates/devhub/versions/list.html:253 src/olympia/devhub/templates/devhub/versions/list.html:279
 msgid "Hide Add-on"
 msgstr "Nascondi il componente aggiuntivo"
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:259
+#: src/olympia/devhub/templates/devhub/versions/list.html:256
 msgid "Hiding your add-on will prevent it from appearing anywhere in our gallery and will stop users from receiving automatic updates."
 msgstr "Se scegli di nascondere il componente aggiuntivo, esso non verrà più visualizzato nelle gallerie di AMO e gli utenti che lo hanno installato non riceveranno più gli aggiornamenti."
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:265
+#: src/olympia/devhub/templates/devhub/versions/list.html:263
+msgid "The files awaiting review will be disabled and you will need to upload new versions."
+msgstr ""
+
+#: src/olympia/devhub/templates/devhub/versions/list.html:270
 msgid "Are you sure you wish to hide your add-on?"
 msgstr "Nascondere il componente aggiuntivo?"
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:286 src/olympia/devhub/templates/devhub/versions/list.html:315
+#: src/olympia/devhub/templates/devhub/versions/list.html:291 src/olympia/devhub/templates/devhub/versions/list.html:313
 msgid "Unlist Add-on"
 msgstr "Imposta il componente aggiuntivo come “esterno”"
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:289
+#: src/olympia/devhub/templates/devhub/versions/list.html:294
 #, python-format
 msgid ""
 "Unlisting your add-on will make it (and each of its versions/files) invisible on this website. It won't show up in searches, won't have a public facing page, and won't be updated automatically for "
-"current users.  It is recommended for unlisted add-ons to provide a custom <a href=\"%(update_url)s\" target=\"_blank\">updateURL</a> in their manifest file for automatic updates."
+"current users. It is recommended for unlisted add-ons to provide a custom <a href=\"%(update_url)s\" target=\"_blank\">updateURL</a> in their manifest file for automatic updates."
 msgstr ""
 "Impostando il tipo di visibilità di un componente aggiuntivo come “esterno” non sarà più possibile visualizzare le sue versioni e i suoi file su AMO. Ciò significa che il componente non verrà più "
 "incluso nei risultati di ricerca né avrà una pagina dedicata, inoltre cesseranno gli aggiornamenti automatici sui dispositivi degli utenti. Quando si ricorre a questa opzione è pertanto "
 "raccomandato includere un <a href=\"%(update_url)s\" target=\"_blank\">updateURL</a> nel file manifesto per rendere possibili gli aggiornamenti automatici."
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:299
-#, python-format
-msgid "Switching add-ons to unlisted is currently in an open beta. Please <a href=\"%(url)s\" target=\"_blank\">report any bugs</a> that you encounter."
-msgstr ""
-"La procedura per rendere un componente aggiuntivo esterno è al momento in una fase sperimentale. Se riscontri qualsiasi problema <a href=\"%(url)s\" target=\"_blank\">segnalalo aprendo un bug</a>."
-
-#: src/olympia/devhub/templates/devhub/versions/list.html:305
+#: src/olympia/devhub/templates/devhub/versions/list.html:303
 msgid "Unlisting an add-on is irreversible!"
 msgstr "Impostare un componente aggiuntivo per la distribuzione esterna è una scelta che non può essere revocata."
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:305
+#: src/olympia/devhub/templates/devhub/versions/list.html:303
 msgid "An unlisted add-on cannot be switched to be listed."
 msgstr "Un componente aggiuntivo distribuito esternamente non potrà più essere ospitato su AMO."
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:307
+#: src/olympia/devhub/templates/devhub/versions/list.html:305
 msgid "Are you sure you wish to unlist your add-on?"
 msgstr "Impostare il componente aggiuntivo come esterno e non visualizzarlo più su AMO?"
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:330
+#: src/olympia/devhub/templates/devhub/versions/list.html:328
 msgid "Canceling your review request will leave your add-on as preliminarily reviewed."
 msgstr "Eliminando la richiesta di revisione il tuo componente aggiuntivo risulterà come parzialmente revisionato."
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:335
+#: src/olympia/devhub/templates/devhub/versions/list.html:333
 msgid "Canceling your review request will mark your add-on incomplete. If you do not complete your add-on after several days by re-requesting review, it will be deleted."
 msgstr ""
 "Eliminando la richiesta di revisione il tuo componente aggiuntivo risulterà incompleto. Se non completi il processo chiedendo una nuova revisione dopo alcuni giorni il componente aggiuntivo verrà "
 "eliminato."
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:343
+#: src/olympia/devhub/templates/devhub/versions/list.html:341
 msgid "Are you sure you wish to cancel your review request?"
 msgstr "Cancellare questa richiesta di revisione?"
 
@@ -7602,19 +7411,19 @@ msgstr "componente aggiuntivo, revisore o commento"
 msgid "Search by add-on name / author email"
 msgstr "Cerca per nome del componente aggiuntivo o email dell’autore"
 
-#: src/olympia/editors/forms.py:103
+#: src/olympia/editors/forms.py:103 src/olympia/editors/forms.py:244 src/olympia/editors/forms.py:257
 msgid "yes"
 msgstr "sì"
 
-#: src/olympia/editors/forms.py:104
+#: src/olympia/editors/forms.py:104 src/olympia/editors/forms.py:244 src/olympia/editors/forms.py:257
 msgid "no"
 msgstr "no"
 
-#: src/olympia/editors/forms.py:105
+#: src/olympia/editors/forms.py:105 src/olympia/editors/forms.py:245
 msgid "Admin Flag"
 msgstr "Flag amministratore"
 
-#: src/olympia/editors/forms.py:113
+#: src/olympia/editors/forms.py:113 src/olympia/editors/forms.py:253
 msgid "Max. Version"
 msgstr "Versione massima"
 
@@ -7626,55 +7435,59 @@ msgstr "Giorni trascorsi dal caricamento"
 msgid "Add-on Types"
 msgstr "Tipi di componente aggiuntivo"
 
-#: src/olympia/editors/forms.py:126 src/olympia/editors/helpers.py:267
+#: src/olympia/editors/forms.py:126 src/olympia/editors/helpers.py:279
 msgid "Platforms"
 msgstr "Piattaforme"
 
+#: src/olympia/editors/forms.py:237
+msgid "Search by add-on name / author email / guid"
+msgstr ""
+
 #. L10n: 0 = platform, 1 = filename, 2 = status message
-#: src/olympia/editors/forms.py:238
+#: src/olympia/editors/forms.py:342
 #, python-format
 msgid "<strong>%s</strong> &middot; %s &middot; %s"
 msgstr "<strong>%s</strong> &middot; %s &middot; %s"
 
-#: src/olympia/editors/forms.py:252
+#: src/olympia/editors/forms.py:356
 msgid "Comments:"
 msgstr "Commenti:"
 
-#: src/olympia/editors/forms.py:256
+#: src/olympia/editors/forms.py:360
 msgid "Operating systems:"
 msgstr "Sistemi operativi:"
 
-#: src/olympia/editors/forms.py:258
+#: src/olympia/editors/forms.py:362
 msgid "Applications:"
 msgstr "Applicazioni:"
 
-#: src/olympia/editors/forms.py:260
+#: src/olympia/editors/forms.py:364
 msgid "Notify me the next time this add-on is updated. (Subsequent updates will not generate an email)"
 msgstr "Invia una notifica al prossimo aggiornamento del componente aggiuntivo (aggiornamenti successivi non genereranno alcuna email)"
 
-#: src/olympia/editors/forms.py:265
+#: src/olympia/editors/forms.py:369
 msgid "Clear Admin Review Flag"
 msgstr "Cancella il flag per la revisione da parte di un amministratore"
 
-#: src/olympia/editors/forms.py:267
+#: src/olympia/editors/forms.py:371
 msgid "Clear more info requested flag"
 msgstr "Cancella flag di richiesta informazioni"
 
-#: src/olympia/editors/forms.py:281
+#: src/olympia/editors/forms.py:385
 msgid "Choose a canned response..."
 msgstr "Scegli una risposta predefinita…"
 
 #. L10n: Description of what can be searched for.
-#: src/olympia/editors/forms.py:324
+#: src/olympia/editors/forms.py:423
 msgid "theme name"
 msgstr "nome del tema"
 
-#: src/olympia/editors/forms.py:350
+#: src/olympia/editors/forms.py:449
 msgid "Someone else is reviewing this theme."
 msgstr "Qualcuno sta già revisionando questo tema."
 
 #. L10n: Description of what can be searched for.
-#: src/olympia/editors/forms.py:447
+#: src/olympia/editors/forms.py:546
 msgid "app, reviewer, or comment"
 msgstr "app, revisore, o commento"
 
@@ -7690,192 +7503,210 @@ msgstr "In attesa di revisione preliminare"
 msgid "Rejected or Unreviewed"
 msgstr "Rifiutato o non revisionato"
 
-#: src/olympia/editors/helpers.py:123 src/olympia/editors/helpers.py:136
+#: src/olympia/editors/helpers.py:125 src/olympia/editors/helpers.py:138
 msgid "Queue"
 msgstr "Coda"
 
-#: src/olympia/editors/helpers.py:124 src/olympia/editors/templates/editors/base.html:50 src/olympia/editors/templates/editors/base.html:65
+#: src/olympia/editors/helpers.py:126 src/olympia/editors/templates/editors/base.html:50 src/olympia/editors/templates/editors/base.html:65
 msgid "Pending Updates"
 msgstr "Aggiornamenti in sospeso"
 
-#: src/olympia/editors/helpers.py:125 src/olympia/editors/templates/editors/base.html:48 src/olympia/editors/templates/editors/base.html:63
+#: src/olympia/editors/helpers.py:127 src/olympia/editors/templates/editors/base.html:48 src/olympia/editors/templates/editors/base.html:63
 msgid "Full Reviews"
 msgstr "Revisioni complete"
 
-#: src/olympia/editors/helpers.py:126 src/olympia/editors/templates/editors/base.html:52 src/olympia/editors/templates/editors/base.html:67
+#: src/olympia/editors/helpers.py:128 src/olympia/editors/templates/editors/base.html:52 src/olympia/editors/templates/editors/base.html:67
 msgid "Preliminary Reviews"
 msgstr "Revisioni preliminari"
 
-#: src/olympia/editors/helpers.py:127 src/olympia/editors/templates/editors/base.html:54
+#: src/olympia/editors/helpers.py:129 src/olympia/editors/templates/editors/base.html:54
 msgid "Moderated Reviews"
 msgstr "Revisioni moderate"
 
-#: src/olympia/editors/helpers.py:128 src/olympia/editors/templates/editors/base.html:46
+#: src/olympia/editors/helpers.py:130 src/olympia/editors/templates/editors/base.html:46
 msgid "Fast Track"
 msgstr "Corsia veloce"
 
-#: src/olympia/editors/helpers.py:130
+#: src/olympia/editors/helpers.py:132
 msgid "Pending Themes"
 msgstr "Temi in sospeso"
 
-#: src/olympia/editors/helpers.py:131 src/olympia/editors/templates/editors/themes/queue.html:4
+#: src/olympia/editors/helpers.py:133 src/olympia/editors/templates/editors/themes/queue.html:4
 msgid "Flagged Themes"
 msgstr "Temi segnalati"
 
-#: src/olympia/editors/helpers.py:132
+#: src/olympia/editors/helpers.py:134
 msgid "Update Themes"
 msgstr "Aggiorna temi"
 
-#: src/olympia/editors/helpers.py:137
+#: src/olympia/editors/helpers.py:139
 msgid "Unlisted Pending Updates"
 msgstr "Aggiornamenti in sospeso per componenti esterni"
 
-#: src/olympia/editors/helpers.py:138
+#: src/olympia/editors/helpers.py:140
 msgid "Unlisted Full Reviews"
 msgstr "Revisioni complete per componenti esterni"
 
-#: src/olympia/editors/helpers.py:139
+#: src/olympia/editors/helpers.py:141
 msgid "Unlisted Preliminary Reviews"
 msgstr "Revisioni preliminari per componenti esterni"
 
-#: src/olympia/editors/helpers.py:170
+#: src/olympia/editors/helpers.py:142
+msgid "Unlisted All Add-ons"
+msgstr ""
+
+#: src/olympia/editors/helpers.py:173
 msgid "Fast Track ({0})"
 msgid_plural "Fast Track ({0})"
 msgstr[0] "Corsia veloce ({0})"
 msgstr[1] "Corsia veloce ({0})"
 
-#: src/olympia/editors/helpers.py:175
+#: src/olympia/editors/helpers.py:178
 msgid "Full Review ({0})"
 msgid_plural "Full Reviews ({0})"
 msgstr[0] "Revisione completa ({0})"
 msgstr[1] "Revisioni complete ({0})"
 
-#: src/olympia/editors/helpers.py:180
+#: src/olympia/editors/helpers.py:183
 msgid "Pending Update ({0})"
 msgid_plural "Pending Updates ({0})"
 msgstr[0] "Aggiornamento in sospeso ({0})"
 msgstr[1] "Aggiornamenti in sospeso ({0})"
 
-#: src/olympia/editors/helpers.py:185
+#: src/olympia/editors/helpers.py:188
 msgid "Preliminary Review ({0})"
 msgid_plural "Preliminary Reviews ({0})"
 msgstr[0] "Revisione preliminare ({0})"
 msgstr[1] "Revisioni preliminari ({0})"
 
-#: src/olympia/editors/helpers.py:190
+#: src/olympia/editors/helpers.py:193
 msgid "Moderated Review ({0})"
 msgid_plural "Moderated Reviews ({0})"
 msgstr[0] "Revisione moderata ({0})"
 msgstr[1] "Revisioni moderate ({0})"
 
-#: src/olympia/editors/helpers.py:196
+#: src/olympia/editors/helpers.py:199
 msgid "Unlisted Full Review ({0})"
 msgid_plural "Unlisted Full Reviews ({0})"
 msgstr[0] "Revisione completa per componente esterno ({0})"
 msgstr[1] "Revisioni complete per componenti esterni ({0})"
 
-#: src/olympia/editors/helpers.py:201
+#: src/olympia/editors/helpers.py:204
 msgid "Unlisted Pending Update ({0})"
 msgid_plural "Unlisted Pending Updates ({0})"
 msgstr[0] "Aggiornamento in sospeso per componente esterno ({0})"
 msgstr[1] "Aggiornamenti in sospeso per componenti esterni ({0})"
 
-#: src/olympia/editors/helpers.py:206
+#: src/olympia/editors/helpers.py:209
 msgid "Unlisted Preliminary Review ({0})"
 msgid_plural "Unlisted Preliminary Reviews ({0})"
 msgstr[0] "Revisione preliminare per componente esterno ({0})"
 msgstr[1] "Revisioni preliminari per componenti esterni ({0})"
 
-#: src/olympia/editors/helpers.py:261
-msgid "Addon"
-msgstr "Componente aggiuntivo"
+#: src/olympia/editors/helpers.py:214
+msgid "Unlisted All Add-ons ({0})"
+msgid_plural "Unlisted All Add-ons ({0})"
+msgstr[0] ""
+msgstr[1] ""
 
-#: src/olympia/editors/helpers.py:262
+#: src/olympia/editors/helpers.py:274
 msgid "Type"
 msgstr "Tipologia"
 
-#: src/olympia/editors/helpers.py:263
+#: src/olympia/editors/helpers.py:275
 msgid "Waiting Time"
 msgstr "Tempo di attesa"
 
-#: src/olympia/editors/helpers.py:264 src/olympia/editors/templates/editors/review.html:285
+#: src/olympia/editors/helpers.py:276 src/olympia/editors/templates/editors/review.html:285
 msgid "Flags"
 msgstr "Flag"
 
-#: src/olympia/editors/helpers.py:265
+#: src/olympia/editors/helpers.py:277
 msgid "Applications"
 msgstr "Applicazioni"
 
-#: src/olympia/editors/helpers.py:270
+#: src/olympia/editors/helpers.py:282
 msgid "Additional"
 msgstr "Aggiuntivo"
 
-#: src/olympia/editors/helpers.py:285
+#: src/olympia/editors/helpers.py:302
 msgid "Site Specific"
 msgstr "Specifico per sito"
 
-#: src/olympia/editors/helpers.py:287
+#: src/olympia/editors/helpers.py:304
 msgid "Requires External Software"
 msgstr "Richiede software aggiuntivo"
 
-#: src/olympia/editors/helpers.py:289
+#: src/olympia/editors/helpers.py:306
 msgid "Binary Components"
 msgstr "Componenti compilati"
 
-#: src/olympia/editors/helpers.py:313
+#: src/olympia/editors/helpers.py:339
 msgid "moments ago"
 msgstr "poco fa"
 
 #. L10n: first argument is number of minutes
-#: src/olympia/editors/helpers.py:316
+#: src/olympia/editors/helpers.py:342
 msgid "{0} minute"
 msgid_plural "{0} minutes"
 msgstr[0] "{0} minuto"
 msgstr[1] "{0} minuti"
 
 #. L10n: first argument is number of hours
-#: src/olympia/editors/helpers.py:320
+#: src/olympia/editors/helpers.py:346
 msgid "{0} hour"
 msgid_plural "{0} hours"
 msgstr[0] "{0} ora"
 msgstr[1] "{0} ore"
 
 #. L10n: first argument is number of days
-#: src/olympia/editors/helpers.py:324
+#: src/olympia/editors/helpers.py:350
 msgid "{0} day"
 msgid_plural "{0} days"
 msgstr[0] "{0} giorno"
 msgstr[1] "{0} giorni"
 
-#: src/olympia/editors/helpers.py:488
+#: src/olympia/editors/helpers.py:364
+msgid "Last Review"
+msgstr ""
+
+#: src/olympia/editors/helpers.py:366
+msgid "Last Update"
+msgstr ""
+
+#: src/olympia/editors/helpers.py:387
+msgid "No Reviews"
+msgstr ""
+
+#: src/olympia/editors/helpers.py:561
 msgid "Push to public"
 msgstr "Pubblica nel Marketplace"
 
-#: src/olympia/editors/helpers.py:490
+#: src/olympia/editors/helpers.py:563
 msgid "Grant full review"
 msgstr "Permetti revisione completa"
 
-#: src/olympia/editors/helpers.py:505
+#: src/olympia/editors/helpers.py:578
 msgid "Request more information"
 msgstr "Richiedi ulteriori informazioni"
 
-#: src/olympia/editors/helpers.py:508
+#: src/olympia/editors/helpers.py:581
 msgid "Request super-review"
 msgstr "Richiedi super-review"
 
-#: src/olympia/editors/helpers.py:519
+#: src/olympia/editors/helpers.py:592
 msgid "Grant preliminary review"
 msgstr "Assegna revisione preliminare"
 
-#: src/olympia/editors/helpers.py:520
+#: src/olympia/editors/helpers.py:593
 msgid "This will mark the files as preliminarily reviewed."
 msgstr "Questo contrassegno indicherà che il file ha ricevuto una revisione preliminare."
 
-#: src/olympia/editors/helpers.py:522
+#: src/olympia/editors/helpers.py:595
 msgid "Use this form to request more information from the author. They will receive an email and be able to answer here. You will be notified by email when they reply."
 msgstr "Utilizza questo modulo per chiedere informazioni all’autore che riceverà una email e potrà risponderti direttamente qui. Riceverai a tua volta una email quando ci sarà una risposta."
 
-#: src/olympia/editors/helpers.py:526
+#: src/olympia/editors/helpers.py:599
 msgid ""
 "If you have concerns about this add-on's security, copyright issues, or other concerns that an administrator should look into, enter your comments in the area below. They will be sent to "
 "administrators, not the author."
@@ -7883,55 +7714,55 @@ msgstr ""
 "Se hai delle preoccupazioni sulla sicurezza di questo componente aggiuntivo, se ci sono problemi di copyright o hai altri dubbi da segnalare agli amministratori del sito, inserisci i commenti in "
 "questo spazio. Il messaggio verrà inviato agli amministratori e non all’autore."
 
-#: src/olympia/editors/helpers.py:532
+#: src/olympia/editors/helpers.py:605
 msgid "This will reject the add-on and remove it from the review queue."
 msgstr "Il componente aggiuntivo verrà respinto e rimosso dalla coda di revisione."
 
-#: src/olympia/editors/helpers.py:534
-msgid "Make a comment on this version.  The author won't be able to see this."
+#: src/olympia/editors/helpers.py:607
+msgid "Make a comment on this version. The author won't be able to see this."
 msgstr "Scrivi un commento su questa versione. L’autore non potrà leggerlo."
 
-#: src/olympia/editors/helpers.py:538
+#: src/olympia/editors/helpers.py:611
 msgid "This will reject the files and remove them from the review queue."
 msgstr "I file verranno respinti e rimossi dalla coda di revisione."
 
-#: src/olympia/editors/helpers.py:542
+#: src/olympia/editors/helpers.py:615
 msgid "This will mark the add-on as preliminarily reviewed. Future versions will undergo preliminary review."
 msgstr "Questo indicherà che il componente aggiuntivo ha ricevuto una revisione preliminare. Le versioni successive riceveranno una revisione preliminare."
 
-#: src/olympia/editors/helpers.py:547
+#: src/olympia/editors/helpers.py:620
 msgid "This will mark the files as preliminarily reviewed. Future versions will undergo preliminary review."
 msgstr "Questo indicherà che i file hanno ricevuto una revisione preliminare. Le versioni successive riceveranno una revisione preliminare."
 
-#: src/olympia/editors/helpers.py:552
+#: src/olympia/editors/helpers.py:625
 msgid "Retain preliminary review"
 msgstr "Mantieni revisione preliminare"
 
-#: src/olympia/editors/helpers.py:553
+#: src/olympia/editors/helpers.py:626
 msgid "This will retain the add-on as preliminarily reviewed. Future versions will undergo preliminary review."
 msgstr "Questo indicherà che il componente aggiuntivo ha ricevuto una revisione preliminare. Le versioni successive riceveranno una revisione preliminare."
 
-#: src/olympia/editors/helpers.py:558
+#: src/olympia/editors/helpers.py:631
 msgid "This will approve a sandboxed version of a public add-on to appear on the public side."
 msgstr "Questo approverà una versione nella sandbox di questo componente aggiuntivo pubblico e la farà apparire nella sezione pubblica."
 
-#: src/olympia/editors/helpers.py:561
+#: src/olympia/editors/helpers.py:634
 msgid "This will reject a version of a public add-on and remove it from the queue."
 msgstr "Questo respinge una versione di un componente aggiuntivo e lo rimuove dalla coda."
 
-#: src/olympia/editors/helpers.py:564
+#: src/olympia/editors/helpers.py:637
 msgid "This will mark the add-on and its most recent version and files as public. Future versions will go into the sandbox until they are reviewed by an editor."
 msgstr "Questo marcherà il componente aggiuntivo, le versioni e i file più recenti come pubblicati. Le versioni successive verranno inserite nella sandbox in attesa del controllo di un revisore."
 
-#: src/olympia/editors/helpers.py:637
+#: src/olympia/editors/helpers.py:714
 msgid "add-on"
 msgstr "componente aggiuntivo"
 
-#: src/olympia/editors/helpers.py:940 src/olympia/editors/helpers.py:960
+#: src/olympia/editors/helpers.py:1020 src/olympia/editors/helpers.py:1040
 msgid "Flagged"
 msgstr "Segnalato"
 
-#: src/olympia/editors/helpers.py:944 src/olympia/editors/helpers.py:963
+#: src/olympia/editors/helpers.py:1024 src/olympia/editors/helpers.py:1043
 msgid "Updates"
 msgstr "Aggiornamenti"
 
@@ -7983,56 +7814,56 @@ msgstr "Il tema caricato è stato segnalato per la revisione"
 msgid "A question about your Theme submission"
 msgstr "Una domanda sul tema caricato"
 
-#: src/olympia/editors/views.py:144
+#: src/olympia/editors/views.py:146
 msgid "New Add-ons (Under 5 days)"
 msgstr "Nuovi componenti aggiuntivi (meno di 5 giorni)"
 
-#: src/olympia/editors/views.py:145
+#: src/olympia/editors/views.py:147
 msgid "Passable (5 to 10 days)"
 msgstr "Accettabile (da 5 a 10 giorni)"
 
-#: src/olympia/editors/views.py:146
+#: src/olympia/editors/views.py:148
 msgid "Overdue (Over 10 days)"
 msgstr "In ritardo (oltre 10 giorni)"
 
-#: src/olympia/editors/views.py:532
+#: src/olympia/editors/views.py:539
 msgid "An unknown error occurred"
 msgstr "Si è verificato un errore sconosciuto"
 
-#: src/olympia/editors/views.py:587
+#: src/olympia/editors/views.py:592
 msgid "Self-reviews are not allowed."
 msgstr "Le auto revisioni non sono consentite."
 
-#: src/olympia/editors/views.py:609
+#: src/olympia/editors/views.py:613
 msgid "Review successfully processed."
 msgstr "Revisione elaborata correttamente."
 
-#: src/olympia/editors/views.py:807
+#: src/olympia/editors/views.py:812
 msgid "was approved"
 msgstr "è stato approvato"
 
-#: src/olympia/editors/views.py:808
+#: src/olympia/editors/views.py:813
 msgid "given preliminary review"
 msgstr "revisione preliminare"
 
-#: src/olympia/editors/views.py:809
+#: src/olympia/editors/views.py:814
 msgid "rejected"
 msgstr "respinto"
 
-#: src/olympia/editors/views.py:810
+#: src/olympia/editors/views.py:815
 msgctxt "editors_review_history_nominated_adminreview"
 msgid "escalated"
 msgstr "inoltrato"
 
-#: src/olympia/editors/views.py:812
+#: src/olympia/editors/views.py:817
 msgid "needs more information"
 msgstr "richieste ulteriori informazioni"
 
-#: src/olympia/editors/views.py:813
+#: src/olympia/editors/views.py:818
 msgid "needs super review"
 msgstr "richiesta super revisione"
 
-#: src/olympia/editors/views.py:814
+#: src/olympia/editors/views.py:819
 msgid "commented"
 msgstr "ha scritto"
 
@@ -8079,28 +7910,28 @@ msgstr "Code"
 msgid "Unlisted Queues"
 msgstr "Code componenti esterni"
 
-#: src/olympia/editors/templates/editors/base.html:72 src/olympia/editors/templates/editors/performance.html:6
+#: src/olympia/editors/templates/editors/base.html:74 src/olympia/editors/templates/editors/performance.html:6
 msgid "Performance"
 msgstr "Prestazioni"
 
-#: src/olympia/editors/templates/editors/base.html:75 src/olympia/editors/templates/editors/themes/base.html:19 src/olympia/editors/templates/editors/themes/base.html:38
+#: src/olympia/editors/templates/editors/base.html:77 src/olympia/editors/templates/editors/themes/base.html:19 src/olympia/editors/templates/editors/themes/base.html:38
 msgid "Logs"
 msgstr "Registri"
 
-#: src/olympia/editors/templates/editors/base.html:78 src/olympia/editors/templates/editors/reviewlog.html:4 src/olympia/editors/templates/editors/reviewlog.html:27
+#: src/olympia/editors/templates/editors/base.html:80 src/olympia/editors/templates/editors/reviewlog.html:4 src/olympia/editors/templates/editors/reviewlog.html:27
 msgid "Add-on Review Log"
 msgstr "Registro revisione componente aggiuntivo"
 
-#: src/olympia/editors/templates/editors/base.html:80 src/olympia/editors/templates/editors/eventlog.html:4 src/olympia/editors/templates/editors/eventlog.html:8
+#: src/olympia/editors/templates/editors/base.html:82 src/olympia/editors/templates/editors/eventlog.html:4 src/olympia/editors/templates/editors/eventlog.html:8
 #: src/olympia/editors/templates/editors/eventlog_detail.html:4
 msgid "Moderated Review Log"
 msgstr "Registro di revisione moderato"
 
-#: src/olympia/editors/templates/editors/base.html:82 src/olympia/editors/templates/editors/beta_signed_log.html:4 src/olympia/editors/templates/editors/beta_signed_log.html:8
+#: src/olympia/editors/templates/editors/base.html:84 src/olympia/editors/templates/editors/beta_signed_log.html:4 src/olympia/editors/templates/editors/beta_signed_log.html:8
 msgid "Signed Beta Files Log"
 msgstr "Log file beta firmati digitalmente"
 
-#: src/olympia/editors/templates/editors/base.html:87 src/olympia/editors/templates/editors/includes/daily-message.html:4
+#: src/olympia/editors/templates/editors/base.html:89 src/olympia/editors/templates/editors/includes/daily-message.html:4
 msgid "Announcement"
 msgstr "Annuncio"
 
@@ -8321,45 +8152,45 @@ msgstr "Ricerca avanzata"
 msgid "clear search"
 msgstr "reimposta ricerca"
 
-#: src/olympia/editors/templates/editors/queue.html:72 src/olympia/editors/templates/editors/queue.html:122
+#: src/olympia/editors/templates/editors/queue.html:78 src/olympia/editors/templates/editors/queue.html:128
 msgid "Process Reviews"
 msgstr "Elabora revisioni"
 
-#: src/olympia/editors/templates/editors/queue.html:80
+#: src/olympia/editors/templates/editors/queue.html:86
 msgid "Moderation actions:"
 msgstr "Azioni di moderazione:"
 
-#: src/olympia/editors/templates/editors/queue.html:90
+#: src/olympia/editors/templates/editors/queue.html:96
 #, python-format
 msgid "by %(user)s on %(date)s %(stars)s (%(locale)s)"
 msgstr "di %(user)s il %(date)s %(stars)s (%(locale)s)"
 
-#: src/olympia/editors/templates/editors/queue.html:106
+#: src/olympia/editors/templates/editors/queue.html:112
 #, python-format
 msgid "<strong>%(reason)s</strong> <span class=\"light\">Flagged by %(user)s on %(date)s</span>"
 msgstr "<strong>%(reason)s</strong> <span class=\"light\">Segnalato da %(user)s il %(date)s</span>"
 
-#: src/olympia/editors/templates/editors/queue.html:119
-msgid "All reviews have been moderated.  Good work!"
+#: src/olympia/editors/templates/editors/queue.html:125
+msgid "All reviews have been moderated. Good work!"
 msgstr "Tutte le recensioni sono state moderate. Ben fatto!"
 
-#: src/olympia/editors/templates/editors/queue.html:161
+#: src/olympia/editors/templates/editors/queue.html:167
 msgid "Version Notes / Notes for Reviewer"
 msgstr "Note di versione/Note per il revisore"
 
-#: src/olympia/editors/templates/editors/queue.html:169
+#: src/olympia/editors/templates/editors/queue.html:175
 msgid "There are currently no add-ons of this type to review."
 msgstr "Non sono presenti componenti aggiuntivi di questo tipo da revisionare."
 
-#: src/olympia/editors/templates/editors/queue.html:181 src/olympia/editors/templates/editors/themes/queue_list.html:85
+#: src/olympia/editors/templates/editors/queue.html:187 src/olympia/editors/templates/editors/themes/queue_list.html:85
 msgid "Helpful Links:"
 msgstr "Link utili:"
 
-#: src/olympia/editors/templates/editors/queue.html:182
+#: src/olympia/editors/templates/editors/queue.html:188
 msgid "Add-on Policy"
 msgstr "Policy componente aggiuntivo"
 
-#: src/olympia/editors/templates/editors/queue.html:184
+#: src/olympia/editors/templates/editors/queue.html:190
 msgid "Editors' Guide"
 msgstr "Guida per revisori"
 
@@ -8422,10 +8253,7 @@ msgid "<strong>Warning!</strong> Another user was viewing this page before you."
 msgstr "<strong>Attenzione!</strong> Un altro utente stava visualizzando questa pagina prima di te."
 
 #: src/olympia/editors/templates/editors/review.html:237
-msgid ""
-"The whiteboard is the place to exchange information relevant to\n"
-"               this addon (whatever the version), between the developer and the\n"
-"               editor. This is visible and editable by both."
+msgid "The whiteboard is the place to exchange information relevant to this addon (whatever the version), between the developer and the editor. This is visible and editable by both."
 msgstr ""
 "La bacheca è un pannello in cui sviluppatore ed editore possono scambiarsi informazioni rilevanti su qualunque versione del componente aggiuntivo. I suoi contenuti possono essere visualizzati e "
 "modificati da entrambi."
@@ -8701,7 +8529,7 @@ msgstr "Poni una domanda all’autore"
 msgid "Describe your reason for flagging"
 msgstr "Descrivi i motivi della segnalazione"
 
-#: src/olympia/files/forms.py:88
+#: src/olympia/files/forms.py:90
 msgid "Cannot diff a version against itself"
 msgstr "Non è possibile comparare una versione con se stessa"
 
@@ -8736,51 +8564,51 @@ msgstr "Si è verificato un errore durante l’accesso al file %s. %s."
 msgid "There was an error accessing file %s."
 msgstr "Si è verificato un errore durante l’accesso al file %s."
 
-#: src/olympia/files/utils.py:343
+#: src/olympia/files/utils.py:340
 msgid "Could not parse uploaded file."
 msgstr "Impossibile analizzare il file caricato."
 
-#: src/olympia/files/utils.py:380
+#: src/olympia/files/utils.py:377
 msgid "Invalid file name in archive: {0}"
 msgstr "Nome di file non valido nell’archivio: {0}"
 
-#: src/olympia/files/utils.py:388
+#: src/olympia/files/utils.py:385
 msgid "File exceeding size limit in archive: {0}"
 msgstr "File che supera la dimensione massima consentita nell’archivio: {0}"
 
-#: src/olympia/files/utils.py:439
+#: src/olympia/files/utils.py:436
 msgid "Invalid archive."
 msgstr "Archivio non valido."
 
-#: src/olympia/files/utils.py:529 src/olympia/files/utils.py:532
+#: src/olympia/files/utils.py:526 src/olympia/files/utils.py:529
 msgid "Could not parse the manifest file."
 msgstr "Impossibile analizzare il file manifesto."
 
-#: src/olympia/files/utils.py:551
+#: src/olympia/files/utils.py:548
 msgid "Could not find an add-on ID."
 msgstr "Impossibile trovare ID del componente aggiuntivo."
 
-#: src/olympia/files/utils.py:554
+#: src/olympia/files/utils.py:551
 msgid "Add-on ID must be 64 characters or less."
 msgstr "L’ID di un componente aggiuntivo non deve superare i 64 caratteri."
 
-#: src/olympia/files/utils.py:556
+#: src/olympia/files/utils.py:553
 msgid "Add-on ID doesn't match add-on."
 msgstr "L’ID specificato non corrisponde al componente aggiuntivo."
 
-#: src/olympia/files/utils.py:564
+#: src/olympia/files/utils.py:561
 msgid "Duplicate add-on ID found."
 msgstr "Rilevato ID duplicato."
 
-#: src/olympia/files/utils.py:567
+#: src/olympia/files/utils.py:564
 msgid "Version numbers should have fewer than 32 characters."
 msgstr "I numeri di versione devono essere lunghi meno di 32 caratteri."
 
-#: src/olympia/files/utils.py:570
+#: src/olympia/files/utils.py:567
 msgid "Version numbers should only contain letters, numbers, and these punctuation characters: +*.-_."
 msgstr "I numeri di versione possono contenere solo lettere, numeri e i seguenti caratteri di punteggiatura: +*.-_."
 
-#: src/olympia/files/utils.py:587
+#: src/olympia/files/utils.py:584
 msgid "<em:type> doesn't match add-on"
 msgstr "<em:type> non corrisponde al componente aggiuntivo"
 
@@ -8880,6 +8708,10 @@ msgstr "Nessun file nell’oggetto caricato."
 #: src/olympia/files/templates/files/viewer.html:134
 msgid "Fetching file."
 msgstr "Recupero file in corso."
+
+#: src/olympia/legacy_api/views.py:255
+msgid "Not implemented yet."
+msgstr "Non ancora implementato."
 
 #: src/olympia/lib/constants.py:6
 msgid "United Arab Emirates Dirham"
@@ -9537,10 +9369,6 @@ msgstr "Kwacha zambiano"
 msgid "Zimbabwe Dollar"
 msgstr "Dollaro dello Zimbabwe"
 
-#: src/olympia/lib/video/ffmpeg.py:112 src/olympia/lib/video/totem.py:81
-msgid "Videos must be in WebM."
-msgstr "I video devono essere in formato WebM."
-
 #: src/olympia/pages/templates/pages/about.lhtml:3 src/olympia/pages/templates/pages/about.lhtml:10
 msgid "About Mozilla Add-ons"
 msgstr "Informazioni su Mozilla Add-ons"
@@ -9552,7 +9380,7 @@ msgstr "Che cosa è questo sito?"
 #: src/olympia/pages/templates/pages/about.lhtml:13
 msgid ""
 "addons.mozilla.org, commonly known as \"AMO\", is Mozilla's official site for add-ons to Mozilla software, such as Firefox, Thunderbird, and SeaMonkey. Add-ons let you add new features and change "
-"the way your browser or application works.  Take a look around and explore the thousands of ways to customize the way you do things online."
+"the way your browser or application works. Take a look around and explore the thousands of ways to customize the way you do things online."
 msgstr ""
 "addons.mozilla.org, noto anche come \"AMO\", è il sito ufficiale che ospita i componenti aggiuntivi per i software Mozilla come Firefox, Thunderbird e SeaMonkey. I componenti aggiuntivi permettono "
 "di arricchire il browser e le altre applicazioni con nuove caratteristiche e modificarne il funzionamento. Esplora il sito e scopri migliaia di modi per personalizzare la tua esperienza online."
@@ -9941,7 +9769,7 @@ msgstr "Posso utilizzare una libreria JavaScript, come jQuery, MooTools o Protot
 msgid ""
 "Yes. It's possible, but some of the functionality provided by these libraries are available through XPCOM, XUL, and JavaScript. In addition, authors should take care if libraries modify primitive "
 "object prototypes (String.prototype, Date.prototype, etc.) and/or define global functions (eg. the $ function). These are prone to cause conflict with other add-ons, in particular if different add-"
-"ons use different versions of libraries and so on. Developers need to be very, very careful with using them.  Mozilla does not offer documentation on using them to build add-ons."
+"ons use different versions of libraries and so on. Developers need to be very, very careful with using them. Mozilla does not offer documentation on using them to build add-ons."
 msgstr ""
 "È possibile, ma considera che diverse funzionalità di queste librerie sono disponibili anche attraverso XPCOM, XUL e JavaScript. Inoltre occorre accertarsi che la libreria non modifichi prototipi "
 "di oggetto primitivi (String.prototype, Date.prototype ecc.) o definisca funzioni globali (es. la funzione $). Tali modifiche tendono a causare conflitti con gli altri componenti aggiuntivi, "
@@ -10069,8 +9897,8 @@ msgstr "Posso caricare il mio componente aggiuntivo in uno spazio web mio?"
 #, python-format
 msgid ""
 "Yes. Many developers choose to host their own add-ons. Choosing to host your add-on on <a href=\"%(amo_url)s\">Mozilla's add-on site</a>, though, allows for much greater exposure to your add-on due "
-"to the large volume of visitors to the site.  <a href=\"%(md_url)s\">mozdev.org</a> offers free project hosting for Mozilla applications and extensions providing developers with tools to help "
-"manage source code, version control, bug tracking and documentation."
+"to the large volume of visitors to the site. <a href=\"%(md_url)s\">mozdev.org</a> offers free project hosting for Mozilla applications and extensions providing developers with tools to help manage "
+"source code, version control, bug tracking and documentation."
 msgstr ""
 "Si. Molti sviluppatori scelgono di caricare i loro componenti aggiuntivi su un proprio spazio web. Tuttavia caricare il componente sul <a href=\"%(amo_url)s\">sito Mozilla dedicato ai componenti "
 "aggiuntivi</a> offre una maggiore visibilità grazie al grande numero di visitatori del sito. <a href=\"%(md_url)s\">mozdev.org</a> mette a disposizione un hosting gratuito ai progetti per "
@@ -10125,7 +9953,7 @@ msgstr "Mozilla ha una politica definita riguardo ai requisiti che un componente
 #: src/olympia/pages/templates/pages/dev_faq.html:314
 #, python-format
 msgid ""
-"Yes. Mozilla's <a href=\"%(p_url)s\">Add-on Policy</a> describes what is an acceptable submission. This policy is subject to change without notice.  In addition, the AMO editorial team uses the <a "
+"Yes. Mozilla's <a href=\"%(p_url)s\">Add-on Policy</a> describes what is an acceptable submission. This policy is subject to change without notice. In addition, the AMO editorial team uses the <a "
 "href=\"%(g_url)s\">Editors Reviewing Guide</a> to ensure that your add-on meets specific guidelines for functionality and security."
 msgstr ""
 "Sì. La <a href=\"%(p_url)s\">politica sui componenti aggiuntivi</a> Mozilla descrive quali caratteristiche deve possedere un componente aggiuntivo per essere considerato accettabile. Questa "
@@ -10260,7 +10088,7 @@ msgstr "il numero di zone problematiche riscontrate"
 #: src/olympia/pages/templates/pages/dev_faq.html:434
 #, python-format
 msgid ""
-"This is why it's very important to read the <a href=\"%(g_url)s\">Editors Reviewing Guide</a> to ensure that your add-on is setup as expected.  It's also a good idea to read the blog post, <a href="
+"This is why it's very important to read the <a href=\"%(g_url)s\">Editors Reviewing Guide</a> to ensure that your add-on is setup as expected. It's also a good idea to read the blog post, <a href="
 "\"%(blog_url)s\">Successfully Getting your Add-on Reviewed</a> which provides excellent insight into ensuring a smooth review of your add-on."
 msgstr ""
 "Per questo è importante leggere la <a href=\"%(g_url)s\">Guida per revisori</a>, in modo da impostare il componente aggiuntivo secondo i criteri indicati. Un’altra lettura utile è l'articolo <a "
@@ -10384,7 +10212,7 @@ msgstr "Una tabella che riassume e confronta come le principali licenze Open Sou
 
 #: src/olympia/pages/templates/pages/dev_faq.html:572
 msgid ""
-"Free Software Foundation provides short summaries of the key open source licenses, including whether the license qualifies as a free software license or a copyleft license.  Also includes a "
+"Free Software Foundation provides short summaries of the key open source licenses, including whether the license qualifies as a free software license or a copyleft license. Also includes a "
 "discussion of what constitutes a free software license or a copyleft license (e.g., a Copyleft license is a general method for making a program or other work free, and requiring all modified and "
 "extended versions of the program to be free as well.)"
 msgstr ""
@@ -10598,19 +10426,13 @@ msgid "Add-on Gallery"
 msgstr "Galleria di componenti aggiuntivi"
 
 #: src/olympia/pages/templates/pages/faq.html:171
-msgid ""
-"How do I choose between add-ons that seem to do the same\n"
-"    thing?"
+msgid "How do I choose between add-ons that seem to do the same thing?"
 msgstr "Come scelgo tra componenti aggiuntivi che fanno la stessa cosa?"
 
-#: src/olympia/pages/templates/pages/faq.html:173
+#: src/olympia/pages/templates/pages/faq.html:172
 msgid ""
-"There are often several add-ons that have similar features. To\n"
-"    figure out which is right for you, read the entire description of the\n"
-"    add-on and view its screenshots. If there are still several in the running,\n"
-"    read through the add-on's ratings, user reviews, and statistics to see\n"
-"    which is most liked by other users. Remember that you can also just try\n"
-"    out both and see which you like better."
+"There are often several add-ons that have similar features. To figure out which is right for you, read the entire description of the add-on and view its screenshots. If there are still several in "
+"the running, read through the add-on's ratings, user reviews, and statistics to see which is most liked by other users. Remember that you can also just try out both and see which you like better."
 msgstr ""
 "Spesso diversi componenti aggiuntivi presentano funzionalità simili. Per decidere quale componente aggiuntivo utilizzare, leggi la descrizione completa e controlla gli screenshot. Se a questo punto "
 "sei ancora indeciso, dai un’occhiata ai voti, alle recensioni degli utenti e alle statistiche per capire qual è il più apprezzato dagli altri utenti. E non dimenticare che puoi sempre installarli "
@@ -10661,40 +10483,34 @@ msgid "How much do add-ons cost to purchase?"
 msgstr "Quanto costa acquistare un componente aggiuntivo?"
 
 #: src/olympia/pages/templates/pages/faq.html:207
-msgid ""
-"Add-ons hosted in our gallery are free unless clearly marked\n"
-"    otherwise."
+msgid "Add-ons hosted in our gallery are free unless clearly marked otherwise."
 msgstr "Tranne dove diversamente indicato, i componenti aggiuntivi presenti nelle pagine elenco di AMO sono da considerarsi gratuiti."
 
-#: src/olympia/pages/templates/pages/faq.html:210
+#: src/olympia/pages/templates/pages/faq.html:209
 msgid "What does it mean when an add-on asks for contributions?"
 msgstr "Che cosa significa quando un componente aggiuntivo richiede delle donazioni?"
 
-#: src/olympia/pages/templates/pages/faq.html:211
+#: src/olympia/pages/templates/pages/faq.html:210
 msgid ""
-"Some add-on authors request users who enjoy an add-on to\n"
-"        contribute to its development by making a monetary contribution. These\n"
-"        contributions go directly to the developer unless a third party is\n"
-"        indicated, such as the non-profit Mozilla Foundation."
+"Some add-on authors request users who enjoy an add-on to contribute to its development by making a monetary contribution. These contributions go directly to the developer unless a third party is "
+"indicated, such as the non-profit Mozilla Foundation."
 msgstr ""
 "Alcuni autori di estensioni richiedono agli utenti di contribuire allo sviluppo dei componenti aggiuntivi con delle donazioni. Questi contributi vanno direttamente allo sviluppatore, a meno che non "
 "sia indicato un altro soggetto (ad esempio l’organizzazione senza fini di lucro Mozilla Foundation)."
 
-#: src/olympia/pages/templates/pages/faq.html:216
+#: src/olympia/pages/templates/pages/faq.html:215
 msgid "What are beta add-ons?"
 msgstr "Che cosa sono i componenti aggiuntivi beta?"
 
-#: src/olympia/pages/templates/pages/faq.html:218
+#: src/olympia/pages/templates/pages/faq.html:217
 msgid ""
-"Beta add-ons are unreviewed versions which represent the\n"
-"        latest work of an add-on author. While different authors have different\n"
-"        standards for beta code quality, you should assume that these add-ons\n"
-"        are less stable than the general add-on releases."
+"Beta add-ons are unreviewed versions which represent the latest work of an add-on author. While different authors have different standards for beta code quality, you should assume that these add-"
+"ons are less stable than the general add-on releases."
 msgstr ""
 "I componenti aggiuntivi \"beta\" sono versioni non verificate e rappresentano il lavoro più aggiornato di uno sviluppatore. Ogni autore utilizza criteri diversi per quanto riguarda la qualità del "
 "codice di una versione beta, in ogni caso è opportuno ipotizzare che queste estensioni siano meno stabili rispetto alle versioni definitive."
 
-#: src/olympia/pages/templates/pages/faq.html:222
+#: src/olympia/pages/templates/pages/faq.html:221
 msgid ""
 "Please note that when you install an add-on from the \"Beta Version\" section of an add-on's listing, you will continue to receive updates for that add-on as they become available. Like the initial "
 "version you installed, all beta releases are unreviewed by Mozilla and may harm your computer."
@@ -10702,49 +10518,42 @@ msgstr ""
 "Attenzione: installando un componente aggiuntivo dalla sezione \"Versioni beta\", continuerai a ricevere aggiornamenti non appena saranno disponibili. Come la versione iniziale che hai installato, "
 "le versioni beta non sono verificate da Mozilla e potrebbero danneggiare il tuo computer."
 
-#: src/olympia/pages/templates/pages/faq.html:229
-msgid ""
-"What does it mean when an add-on is flagged as\n"
-"    slow?"
+#: src/olympia/pages/templates/pages/faq.html:228
+msgid "What does it mean when an add-on is flagged as slow?"
 msgstr "Che cosa significa quando un componente aggiuntivo è segnalato come lento?"
 
-#: src/olympia/pages/templates/pages/faq.html:231
-msgid ""
-"Most add-ons load code and resources at the same time Firefox\n"
-"        is starting up. In most cases the impact in start-up time is minimal,\n"
-"        but some add-ons can cause a noticeable slowdown."
+#: src/olympia/pages/templates/pages/faq.html:229
+msgid "Most add-ons load code and resources at the same time Firefox is starting up. In most cases the impact in start-up time is minimal, but some add-ons can cause a noticeable slowdown."
 msgstr ""
 "La maggior parte dei componenti aggiuntivi carica codice e risorse all’avvio di Firefox. In molti casi l’impatto sui tempi di avvio è minimo, in alcuni casi il rallentamento può essere "
 "significativo."
 
-#: src/olympia/pages/templates/pages/faq.html:236
+#: src/olympia/pages/templates/pages/faq.html:234
 msgid "How do I report an inappropriate or spam user review?"
 msgstr "Come posso segnalare una recensione inappropriata o contenente spam?"
 
-#: src/olympia/pages/templates/pages/faq.html:237
+#: src/olympia/pages/templates/pages/faq.html:235
 msgid ""
-"To report a user review of an add-on, log in with your account\n"
-"    and visit the add-on's reviews page. Find the review you wish to report,\n"
-"    click \"Report this review\" and select a reason. Our editorial team will\n"
-"    investigate the review and take appropriate action."
+"To report a user review of an add-on, log in with your account and visit the add-on's reviews page. Find the review you wish to report, click \"Report this review\" and select a reason. Our "
+"editorial team will investigate the review and take appropriate action."
 msgstr ""
 "Per segnalare la recensione di un utente effettua l’accesso, poi apri la pagina con le recensioni degli utenti, trova la recensione che vuoi segnalare, fai clic su \"Segnala questa recensione\" e "
 "seleziona una motivazione per la segnalazione. I moderatori del sito valuteranno la recensione e prenderanno i necessari provvedimenti."
 
-#: src/olympia/pages/templates/pages/faq.html:242
+#: src/olympia/pages/templates/pages/faq.html:240
 msgid "How do I report a bug or contact the Mozilla Add-ons team?"
 msgstr "Come posso segnalare un bug o contattare il team di Mozilla Add-ons?"
 
-#: src/olympia/pages/templates/pages/faq.html:243
+#: src/olympia/pages/templates/pages/faq.html:241
 #, python-format
 msgid "Please visit our <a href=\"%(contact_url)s\">Contact page</a>."
 msgstr "Consulta la pagina dei <a href=\"%(contact_url)s\">contatti</a>."
 
-#: src/olympia/pages/templates/pages/faq.html:246
+#: src/olympia/pages/templates/pages/faq.html:244
 msgid "What is a Source Code License?"
 msgstr "Che cos’è la licenza per il codice sorgente?"
 
-#: src/olympia/pages/templates/pages/faq.html:247
+#: src/olympia/pages/templates/pages/faq.html:245
 #, python-format
 msgid ""
 "The source code used to create an add-on is an exclusive copyright of the add-on author, unless otherwise declared in a source code license. Many add-ons on this site have <a href=\"%(url)s\" lang="
@@ -10755,42 +10564,42 @@ msgstr ""
 "componenti aggiuntivi utilizzano <a href=\"%(url)s\" lang=\"en\">licenze Open Source</a> che rendono possibile copiare e riutilizzare il codice nelle condizioni indicate dall’autore. Molti autori "
 "utilizzano licenze diffuse e conosciute come GPL o BSD invece di crearne una propria."
 
-#: src/olympia/pages/templates/pages/faq.html:256
+#: src/olympia/pages/templates/pages/faq.html:254
 #, python-format
 msgid "Firefox and other Mozilla software are <a href=\"%(url)s\">open source</a>."
 msgstr "Firefox e gli altri software Mozilla sono <a href=\"%(url)s\">Open Source</a>."
 
-#: src/olympia/pages/templates/pages/faq.html:264
+#: src/olympia/pages/templates/pages/faq.html:262
 msgid "Collections and Favorites"
 msgstr "Raccolte e preferiti"
 
-#: src/olympia/pages/templates/pages/faq.html:267
+#: src/olympia/pages/templates/pages/faq.html:265
 msgid "What is a collection?"
 msgstr "Che cos’è una raccolta?"
 
-#: src/olympia/pages/templates/pages/faq.html:268
+#: src/olympia/pages/templates/pages/faq.html:266
 msgid "Collections are groups of related add-ons created by users to share."
 msgstr "Le raccolte sono gruppi di componenti aggiuntivi realizzate dagli utenti per condividerle con altre persone."
 
-#: src/olympia/pages/templates/pages/faq.html:270
+#: src/olympia/pages/templates/pages/faq.html:268
 msgid "What is the My Favorites collection?"
 msgstr "Che cos’è la raccolta “I miei preferiti”?"
 
-#: src/olympia/pages/templates/pages/faq.html:271
+#: src/olympia/pages/templates/pages/faq.html:269
 msgid "Favorite add-ons are add-ons that you have bookmarked to easily get back to later. You can add an add-on to your favorites collection by clicking \"Add to favorites\" on its details page."
 msgstr ""
 "I componenti aggiuntivi preferiti sono componenti aggiuntivi che hai salvato per poterci tornare facilmente in un secondo tempo. Puoi aggiungere un componente aggiuntivo a questo elenco facendo "
 "clic su \"Aggiungi ai preferiti\" nella pagina con i dettagli dell’estensione."
 
-#: src/olympia/pages/templates/pages/faq.html:275 src/olympia/templates/menu_links.html:13 src/olympia/templates/impala/header_title.html:17
+#: src/olympia/pages/templates/pages/faq.html:273 src/olympia/templates/menu_links.html:13 src/olympia/templates/impala/header_title.html:17
 msgid "Mobile Add-ons"
 msgstr "Comp. agg. Mobile"
 
-#: src/olympia/pages/templates/pages/faq.html:278
+#: src/olympia/pages/templates/pages/faq.html:276
 msgid "What are mobile add-ons?"
 msgstr "Che cosa sono i componenti aggiuntivi per dispositivi portatili?"
 
-#: src/olympia/pages/templates/pages/faq.html:279
+#: src/olympia/pages/templates/pages/faq.html:277
 #, python-format
 msgid ""
 "Mobile add-ons work with <a href=\"%(mobile_url)s\">Firefox for Mobile</a> and add or modify functionality just like desktop add-ons. You can find add-ons that work with Firefox for Mobile in our "
@@ -10799,20 +10608,20 @@ msgstr ""
 "I componenti aggiuntivi per dispositivi portatili funzionano con <a href=\"%(mobile_url)s\">Firefox per dispositivi mobile</a> e aggiungono (o modificano) caratteristiche esattamente come i "
 "componenti aggiuntivi tradizionali. I componenti aggiuntivi compatibili con Firefox per dispositivi portatili sono disponibili nella <a href=\"%(gallery_url)s\">galleria</a>."
 
-#: src/olympia/pages/templates/pages/faq.html:288
+#: src/olympia/pages/templates/pages/faq.html:286
 msgid "Developer Topics"
 msgstr "Discussioni dello sviluppatore"
 
-#: src/olympia/pages/templates/pages/faq.html:289
+#: src/olympia/pages/templates/pages/faq.html:287
 #, python-format
 msgid "Please see our <a href=\"%(faq_url)s\">Developer FAQ</a> and <a href=\"%(hub_url)s\">Developer Hub</a> for answers to add-on developer-related questions."
 msgstr "Consulta le nostre <a href=\"%(faq_url)s\">FAQ per gli sviluppatori</a> e il <a href=\"%(hub_url)s\">Centro di sviluppo</a> per risposte relative allo sviluppo di componenti aggiuntivi."
 
-#: src/olympia/pages/templates/pages/faq.html:294
+#: src/olympia/pages/templates/pages/faq.html:292
 msgid "Still have questions?"
 msgstr "Hai altre domande?"
 
-#: src/olympia/pages/templates/pages/faq.html:295
+#: src/olympia/pages/templates/pages/faq.html:293
 #, python-format
 msgid "For general Firefox support, visit our <a href=\"%(sumo_url)s\">support website</a>. For general add-on and website questions, visit our <a href=\"%(forum_url)s\">forum</a>."
 msgstr ""
@@ -10965,7 +10774,7 @@ msgstr "Sunbird è stato abbandonato"
 
 #: src/olympia/pages/templates/pages/sunbird.html:29
 msgid ""
-"Development on the Sunbird project has halted and its final release was on March 30, 2010.  We've been proud to host Sunbird add-ons on this site but as the project is no longer maintained we have "
+"Development on the Sunbird project has halted and its final release was on March 30, 2010. We've been proud to host Sunbird add-ons on this site but as the project is no longer maintained we have "
 "disabled our support for the add-ons."
 msgstr ""
 "Lo sviluppo del progetto Sunbird è stato sospeso, l’ultima versione è stata rilasciata il 30 marzo 2010. Siamo orgogliosi di aver ospitato i componenti aggiuntivi per Sunbird sul nostro sito, ma "
@@ -11045,7 +10854,7 @@ msgstr "Aggiungi una recensione per {0}"
 #, python-format
 msgid ""
 "<h2>Keep these tips in mind:</h2> <ul> <li> Write like you're telling a friend about your experience with the add-on. Give specifics and helpful details, such as what features you liked and/or "
-"disliked, how easy to use it is, and any disadvantages it has.  Avoid generic language such as calling it \"Great\" or \"Bad\" unless you can give reasons why you believe this is so. </li> <li> "
+"disliked, how easy to use it is, and any disadvantages it has. Avoid generic language such as calling it \"Great\" or \"Bad\" unless you can give reasons why you believe this is so. </li> <li> "
 "Please do not post bug reports in reviews. We do not make your email address available to add-on developers and they may need to contact you to help resolve your issue. See the <a href=\"%(support)s"
 "\">support section</a> to find out where to get assistance for this add-on. </li> <li>Please keep reviews clean, avoid the use of improper language and do not post any personal information. </li> </"
 "ul> <p>Please read the <a href=\"%(guide)s\" target=\"_blank\">Review Guidelines</a> for more detail about user add-on reviews.</p>"
@@ -11303,16 +11112,16 @@ msgstr "Componenti aggiuntivi per {0}"
 
 #. L10n: {0} is an application, such as Firefox. This means "any version of
 #. Firefox."
-#: src/olympia/search/views.py:554
+#: src/olympia/search/views.py:547
 msgid "Any {0}"
 msgstr "Qualsiasi {0}"
 
 #. L10n: "All Systems" means show everything regardless of platform.
-#: src/olympia/search/views.py:589
+#: src/olympia/search/views.py:582
 msgid "All Systems"
 msgstr "Tutti i sistemi"
 
-#: src/olympia/search/views.py:600
+#: src/olympia/search/views.py:593
 msgid "All Tags"
 msgstr "Tutte le etichette"
 
@@ -11486,31 +11295,31 @@ msgstr "Condividi"
 msgid "Share this Collection"
 msgstr "Condividi questa raccolta"
 
-#: src/olympia/signing/views.py:30 src/olympia/templates/base.html:75 src/olympia/templates/impala/base.html:115
+#: src/olympia/signing/views.py:33 src/olympia/templates/base.html:71 src/olympia/templates/impala/base.html:112
 msgid "Some features are temporarily disabled while we perform website maintenance. We'll be back to full capacity shortly."
 msgstr "Alcune funzioni sono momentaneamente disattivate per lavori di manutenzione sul sito. A breve torneremo alla normale funzionalità."
 
-#: src/olympia/signing/views.py:53
+#: src/olympia/signing/views.py:56
 msgid "Could not find add-on with id \"{}\"."
 msgstr "Impossibile trovare un componente aggiuntivo con id “{}”."
 
-#: src/olympia/signing/views.py:67
+#: src/olympia/signing/views.py:70
 msgid "You do not own this addon."
 msgstr "Non sei il proprietario di questo componente aggiuntivo."
 
-#: src/olympia/signing/views.py:82
+#: src/olympia/signing/views.py:87
 msgid "Missing \"upload\" key in multipart file data."
 msgstr "Impossibile trovare la chiave di “upload” tra i dati multipart del file."
 
-#: src/olympia/signing/views.py:96
+#: src/olympia/signing/views.py:101
 msgid "Version does not match the manifest file."
 msgstr "Il numero di versione non corrisponde a quello indicato nel file manifesto."
 
-#: src/olympia/signing/views.py:100
+#: src/olympia/signing/views.py:105
 msgid "Version already exists."
 msgstr "Questa versione esiste già."
 
-#: src/olympia/signing/views.py:136
+#: src/olympia/signing/views.py:141
 msgid "No uploaded file for that addon and version."
 msgstr "Nessun file caricato per il componente aggiuntivo e la versione specificati."
 
@@ -11623,89 +11432,89 @@ msgstr "{0} :Pannello statistiche"
 msgid "Statistics Dashboard :: Add-ons for {0}"
 msgstr "Pannello statistiche :: Componenti aggiuntivi per {0}"
 
-#: src/olympia/stats/templates/stats/stats.html:30
-msgid "Controls:"
-msgstr "Controlli:"
-
-#: src/olympia/stats/templates/stats/stats.html:33
-msgid "reset zoom"
-msgstr "Reimposta zoom"
-
-#: src/olympia/stats/templates/stats/stats.html:40
-msgid "Group by:"
-msgstr "Raggruppa per:"
-
-#: src/olympia/stats/templates/stats/stats.html:42
-msgid "day"
-msgstr "giorno"
-
-#: src/olympia/stats/templates/stats/stats.html:45
-msgid "week"
-msgstr "settimana"
-
-#: src/olympia/stats/templates/stats/stats.html:48
-msgid "month"
-msgstr "mese"
-
-#: src/olympia/stats/templates/stats/stats.html:54
-msgid "For last:"
-msgstr "Negli ultimi:"
-
-#: src/olympia/stats/templates/stats/stats.html:57
-msgid "7 days"
-msgstr "7 giorni"
-
-#: src/olympia/stats/templates/stats/stats.html:60
-msgid "30 days"
-msgstr "30 giorni"
-
-#: src/olympia/stats/templates/stats/stats.html:63
-msgid "90 days"
-msgstr "90 giorni"
-
-#: src/olympia/stats/templates/stats/stats.html:66
-msgid "365 days"
-msgstr "365 giorni"
-
-#: src/olympia/stats/templates/stats/stats.html:69
-msgid "Custom..."
-msgstr "Personalizzato…"
-
 #. {0} is an add-on name
-#: src/olympia/stats/templates/stats/stats.html:88 src/olympia/stats/templates/stats/stats.html:91
+#: src/olympia/stats/templates/stats/stats.html:44 src/olympia/stats/templates/stats/stats.html:47
 msgid "Statistics for {0}"
 msgstr "Statistiche per {0}"
 
-#: src/olympia/stats/templates/stats/stats.html:94
+#: src/olympia/stats/templates/stats/stats.html:50
 msgid "Statistics Dashboard"
 msgstr "Pannello statistiche"
 
-#: src/olympia/stats/templates/stats/stats.html:104
+#: src/olympia/stats/templates/stats/stats.html:57
+msgid "Controls:"
+msgstr "Controlli:"
+
+#: src/olympia/stats/templates/stats/stats.html:60
+msgid "reset zoom"
+msgstr "Reimposta zoom"
+
+#: src/olympia/stats/templates/stats/stats.html:67
+msgid "Group by:"
+msgstr "Raggruppa per:"
+
+#: src/olympia/stats/templates/stats/stats.html:69
+msgid "day"
+msgstr "giorno"
+
+#: src/olympia/stats/templates/stats/stats.html:72
+msgid "week"
+msgstr "settimana"
+
+#: src/olympia/stats/templates/stats/stats.html:75
+msgid "month"
+msgstr "mese"
+
+#: src/olympia/stats/templates/stats/stats.html:81
+msgid "For last:"
+msgstr "Negli ultimi:"
+
+#: src/olympia/stats/templates/stats/stats.html:84
+msgid "7 days"
+msgstr "7 giorni"
+
+#: src/olympia/stats/templates/stats/stats.html:87
+msgid "30 days"
+msgstr "30 giorni"
+
+#: src/olympia/stats/templates/stats/stats.html:90
+msgid "90 days"
+msgstr "90 giorni"
+
+#: src/olympia/stats/templates/stats/stats.html:93
+msgid "365 days"
+msgstr "365 giorni"
+
+#: src/olympia/stats/templates/stats/stats.html:96
+msgid "Custom..."
+msgstr "Personalizzato…"
+
+#: src/olympia/stats/templates/stats/stats.html:106
 msgid "Statistics processing is currently disabled, so recent data is unavailable. The statistics are still being collected and this page will be updated soon with the missing data."
 msgstr "L’analisi dei dati statistici è momentaneamente disattivata. I dati vengono comunque raccolti e questa pagina verrà presto aggiornata con i dati mancanti."
 
-#: src/olympia/stats/templates/stats/stats.html:110
+#: src/olympia/stats/templates/stats/stats.html:112
 msgid "Loading the latest data&hellip;"
 msgstr "Caricamento dei dati più recenti in corso&hellip;"
 
-#: src/olympia/stats/templates/stats/stats.html:142 src/olympia/stats/templates/stats/reports/overview.html:25 src/olympia/stats/templates/stats/reports/overview.html:37
+#: src/olympia/stats/templates/stats/stats.html:144 src/olympia/stats/templates/stats/reports/overview.html:25 src/olympia/stats/templates/stats/reports/overview.html:37
 #: src/olympia/stats/templates/stats/reports/overview.html:49
 msgid "No data available."
 msgstr "Nessun dato disponibile."
 
-#: src/olympia/stats/templates/stats/stats.html:177
+#: src/olympia/stats/templates/stats/stats.html:179
 msgid "This dashboard is currently <b>public</b>."
 msgstr "Al momento questo pannello è <b>pubblico</b>."
 
-#: src/olympia/stats/templates/stats/stats.html:179
+#: src/olympia/stats/templates/stats/stats.html:181
 msgid "Contribution stats are currently <b>private</b>."
 msgstr "Le statistiche sulle donazioni sono attualmente <b>private</b>."
 
-#: src/olympia/stats/templates/stats/stats.html:182
+#: src/olympia/stats/templates/stats/stats.html:184
 msgid "This dashboard is currently <b>private</b>."
 msgstr "Al momento questo pannello è <b>privato</b>."
 
-#: src/olympia/stats/templates/stats/stats.html:185
+#: src/olympia/stats/templates/stats/stats.html:187
 msgid "Change settings."
 msgstr "Cambia impostazioni."
 
@@ -11870,15 +11679,6 @@ msgstr "Utenti registrati per data"
 msgid "Application versions by Date"
 msgstr "Versioni applicazioni per data"
 
-#: src/olympia/tags/templates/tags/top_cloud.html:4
-msgid "Top {0} Tags"
-msgstr "Prime {0} etichette"
-
-#. {0} is the current application name
-#: src/olympia/tags/templates/tags/top_cloud.html:14
-msgid "{0} Top Tags"
-msgstr "Migliori {0} etichette"
-
 #: src/olympia/templates/amo_footer.html:6 src/olympia/templates/includes/lang_switcher.html:2
 msgid "Other languages"
 msgstr "Altre lingue"
@@ -11887,11 +11687,11 @@ msgstr "Altre lingue"
 msgid "Mozilla Add-ons"
 msgstr "Mozilla Add-ons"
 
-#: src/olympia/templates/base.html:91 src/olympia/templates/impala/base.html:81
+#: src/olympia/templates/base.html:89 src/olympia/templates/impala/base.html:78
 msgid "Find add-ons for other applications"
 msgstr "Scopri i componenti aggiuntivi per le altre applicazioni"
 
-#: src/olympia/templates/base.html:92 src/olympia/templates/impala/base.html:81
+#: src/olympia/templates/base.html:90 src/olympia/templates/impala/base.html:78
 msgid "Other Applications"
 msgstr "Altre applicazioni"
 
@@ -11916,7 +11716,7 @@ msgid "View Mobile Site"
 msgstr "Visualizza sito Mobile"
 
 #: src/olympia/templates/copyright.html:7
-msgid "Site Status "
+msgid "Site Status"
 msgstr "Stato del sito"
 
 #: src/olympia/templates/footer.html:3
@@ -12018,35 +11818,35 @@ msgstr "Benvenuto, {0}"
 msgid "<a href=\"%(reg)s\">Register</a> or <a href=\"%(login)s\">Log in</a>"
 msgstr "<a href=\"%(reg)s\">Registrati</a> o <a href=\"%(login)s\">accedi</a>"
 
-#: src/olympia/templates/impala/base.html:126
+#: src/olympia/templates/impala/base.html:123
 #, python-format
 msgid "To try the thousands of add-ons available here, download <a href=\"%(url)s\">Mozilla Firefox</a>, a fast, free way to surf the Web!"
 msgstr "Per provare i componenti aggiuntivi disponibili in questo sito scarica <a href=\"%(url)s\">Mozilla Firefox</a>, un modo veloce e gratuito per navigare sul Web."
 
-#: src/olympia/templates/impala/base.html:138
+#: src/olympia/templates/impala/base.html:135
 #, python-format
 msgid "Add-ons is switching to Firefox Accounts for login. <a href=\"%(url)s\" class=\"fxa-login\">Sign in now to transfer your account.</a>"
 msgstr "Ora è possibile accedere al sito dei componenti aggiuntivi con il proprio account Firefox. <a href=\"%(url)s\" class=\"fxa-login\">Accedi per trasferire il tuo account.</a>"
 
 #. {0} is an application, such as Firefox.
-#: src/olympia/templates/impala/base.html:148
+#: src/olympia/templates/impala/base.html:145
 msgid "Welcome to {0} Add-ons."
 msgstr "Benvenuto in {0} Add-ons."
 
-#: src/olympia/templates/impala/base.html:151
+#: src/olympia/templates/impala/base.html:148
 msgid "Choose from thousands of extra features and styles to make Firefox your own."
 msgstr "Scegli tra migliaia di funzionalità aggiuntive e stili per rendere Firefox veramente tuo."
 
-#: src/olympia/templates/impala/base.html:156
+#: src/olympia/templates/impala/base.html:153
 #, python-format
 msgid "Add extra features and styles to make %(app)s your own."
 msgstr "Aggiungi nuove funzionalità e stili per rendere %(app)s veramente tuo."
 
-#: src/olympia/templates/impala/base.html:164
+#: src/olympia/templates/impala/base.html:161
 msgid "On the go?"
 msgstr "In movimento?"
 
-#: src/olympia/templates/impala/base.html:166
+#: src/olympia/templates/impala/base.html:163
 msgid "Check out our <a class=\"mobile-link\" href=\"#\">Mobile Add-ons site</a>."
 msgstr "Controlla il nostro <a class=\"mobile-link\" href=\"#\">sito Mobile Add-on</a>."
 
@@ -12270,19 +12070,19 @@ msgstr "Nessun utente con questa email."
 
 #. L10n: {id} will be something like "13ad6a", just a random number
 #. to differentiate this user from other anonymous users.
-#: src/olympia/users/models.py:353
+#: src/olympia/users/models.py:362
 msgid "Anonymous user {id}"
 msgstr "Ospite {id}"
 
-#: src/olympia/users/models.py:410
+#: src/olympia/users/models.py:419
 msgid "Your account has been restricted"
 msgstr "Il tuo account è stato limitato"
 
-#: src/olympia/users/models.py:480
+#: src/olympia/users/models.py:489
 msgid "Please confirm your email address"
 msgstr "Conferma il tuo indirizzo email"
 
-#: src/olympia/users/models.py:506
+#: src/olympia/users/models.py:515
 msgid "My Mobile Add-ons"
 msgstr "I miei comp. agg. per dispositivi portatili"
 
@@ -12566,7 +12366,7 @@ msgstr "Password"
 
 #: src/olympia/users/templates/users/edit.html:70
 #, python-format
-msgid "Change your password.  If you forgot your password, you can <a href=\"%(reset_url)s\">use the reset form</a>."
+msgid "Change your password. If you forgot your password, you can <a href=\"%(reset_url)s\">use the reset form</a>."
 msgstr "Modifica la tua password. Se hai dimenticato la password puoi <a href=\"%(reset_url)s\">utilizzare il modulo per reimpostarla</a>."
 
 #: src/olympia/users/templates/users/edit.html:76
@@ -12586,7 +12386,7 @@ msgid "Profile"
 msgstr "Profilo"
 
 #: src/olympia/users/templates/users/edit.html:100
-msgid "Give us a bit more information about yourself.  All these fields are optional, but they'll help other users get to know you better."
+msgid "Give us a bit more information about yourself. All these fields are optional, but they'll help other users get to know you better."
 msgstr "Fornisci qualche informazione in più su di te. Tutti i campi sono facoltativi ma possono aiutare gli altri utenti a conoscerti meglio."
 
 #: src/olympia/users/templates/users/edit.html:124
@@ -12806,7 +12606,7 @@ msgid "Confirm password"
 msgstr "Conferma password"
 
 #: src/olympia/users/templates/users/pwreset_confirm.html:47
-msgid "The password reset link was invalid, possibly because it has already been used.  Please request a new password reset."
+msgid "The password reset link was invalid, possibly because it has already been used. Please request a new password reset."
 msgstr "Il link per la reimpostazione della password non è valido in quanto è già stato utilizzato. Richiedere una nuova reimpostazione della password."
 
 #: src/olympia/users/templates/users/pwreset_request.html:15
@@ -12994,7 +12794,7 @@ msgstr "Non è possibile rimuovere la tua iscrizione"
 
 #: src/olympia/users/templates/users/unsubscribe.html:30
 #, python-format
-msgid "Unfortunately, we weren't able to unsubscribe you.  The link you clicked is invalid. However, you can unsubscribe still unsubscribe on your <a href=\"%(edit_url)s\">edit profile page</a>."
+msgid "Unfortunately, we weren't able to unsubscribe you. The link you clicked is invalid. However, you can unsubscribe still unsubscribe on your <a href=\"%(edit_url)s\">edit profile page</a>."
 msgstr ""
 "Purtroppo non siamo in grado di rimuovere la tua iscrizione. Il link che hai utilizzato non è valido. Puoi comunque rimuovere la tua iscrizione modificando la pagina del tuo <a href=\"%(edit_url)s"
 "\">profilo</a>."
@@ -13050,15 +12850,15 @@ msgstr "Cronologia Versioni %s"
 msgid "Version History with Changelogs"
 msgstr "Cronologia delle versioni con elenco delle modifiche (changelog)"
 
-#: src/olympia/versions/models.py:314
+#: src/olympia/versions/models.py:313
 msgid "Add-on uses binary components."
 msgstr "Questo componente aggiuntivo utilizza componenti compilati."
 
-#: src/olympia/versions/models.py:317
+#: src/olympia/versions/models.py:316
 msgid "Add-on has opted into strict compatibility checking."
 msgstr "Questo componente aggiuntivo ha optato per un rigoroso controllo di compatibilità."
 
-#: src/olympia/versions/models.py:715
+#: src/olympia/versions/models.py:711
 msgid "{app} {min} and later"
 msgstr "{app} {min} e seguenti"
 
@@ -13135,3 +12935,7 @@ msgstr "Invia email al termine"
 #: src/olympia/zadmin/forms.py:105
 msgid "Log emails instead of sending"
 msgstr "Registra email invece di inviarle"
+
+#: src/olympia/zadmin/forms.py:215
+msgid "Deleted versions can`t be changed."
+msgstr ""

--- a/locale/it/LC_MESSAGES/djangojs.po
+++ b/locale/it/LC_MESSAGES/djangojs.po
@@ -3,136 +3,394 @@ msgid ""
 msgstr ""
 "Project-Id-Version: AMO-JS 0.1\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2016-02-24 21:23+0000\n"
+"POT-Creation-Date: 2016-04-18 15:47+0000\n"
 "PO-Revision-Date: 2016-01-21 13:40+0000\n"
 "Last-Translator: Sandro Della Giustina <gialloporpora@mozillaitalia.org>\n"
 "Language-Team: Mozilla Italia\n"
+"Language: \n"
 "MIME-Version: 1.0\n"
-"Content-Type: text/plain; charset=utf-8\n"
+"Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Generated-By: Babel 2.2.0\n"
 
-#: static/js/common/ratingwidget.js:31
+#: static/js/common-all.js:1426 static/js/impala-all.js:1511 static/js/zamboni/discovery-all.js:12598 static/js/zamboni/init.js:28 static/js/zamboni/mobile-all.js:14945
+msgid "This feature is temporarily disabled while we perform website maintenance. Please check back a little later."
+msgstr "Questa funzione è momentaneamente disattivata per dei lavori di manutenzione. Riprovare più tardi."
+
+#. L10n: {0} is an app name like Firefox.
+#: static/js/common-all.js:1837 static/js/impala-all.js:1922 static/js/zamboni/buttons.js:73 static/js/zamboni/discovery-all.js:13108
+msgid "Accept and Install"
+msgstr "Accetta e installa"
+
+#: static/js/common-all.js:1837 static/js/impala-all.js:1922 static/js/zamboni/buttons.js:73 static/js/zamboni/discovery-all.js:13108
+msgid "Add to {0}"
+msgstr "Aggiungi a {0}"
+
+#: static/js/common-all.js:1842 static/js/impala-all.js:1927 static/js/zamboni/buttons.js:78 static/js/zamboni/discovery-all.js:13113
+msgid "Download Now"
+msgstr "Scarica ora"
+
+#: static/js/common-all.js:1883 static/js/impala-all.js:1968 static/js/zamboni/buttons.js:119 static/js/zamboni/discovery-all.js:13154
+msgid "Add-on has not been updated to support default-to-compatible."
+msgstr "Questo componente aggiuntivo non è stato aggiornato per essere sempre compatibile come impostazione predefinita."
+
+#: static/js/common-all.js:1888 static/js/impala-all.js:1973 static/js/zamboni/buttons.js:124 static/js/zamboni/discovery-all.js:13159
+msgid "You need to be using Firefox 10.0 or higher."
+msgstr "È necessario utilizzare Firefox 10 o superiore."
+
+#: static/js/common-all.js:1900 static/js/impala-all.js:1985 static/js/zamboni/buttons.js:136 static/js/zamboni/discovery-all.js:13171
+msgid "Mozilla has marked this version as incompatible with your Firefox version."
+msgstr "Mozilla ha contrassegnato questa versione come non compatibile con la versione di Firefox in uso."
+
+#. L10n: {0} is an platform like Windows or Linux.
+#: static/js/common-all.js:1981 static/js/impala-all.js:2066 static/js/zamboni/buttons.js:217 static/js/zamboni/discovery-all.js:13252
+msgid "Install for {0} anyway"
+msgstr "Installa comunque per {0}"
+
+#: static/js/common-all.js:1981 static/js/impala-all.js:2066 static/js/zamboni/buttons.js:217 static/js/zamboni/discovery-all.js:13252
+msgid "Download for {0} anyway"
+msgstr "Scarica comunque per {0}"
+
+#: static/js/common-all.js:2038 static/js/impala-all.js:2123 static/js/zamboni/buttons.js:274 static/js/zamboni/discovery-all.js:13309
+msgid "Not available for your platform"
+msgstr "Non disponibile per la tua piattaforma"
+
+#. L10n: {0} is an app name, {1} is the app version.
+#: static/js/common-all.js:2049 static/js/common-all.js:2086 static/js/impala-all.js:2134 static/js/impala-all.js:2171 static/js/zamboni/buttons.js:286 static/js/zamboni/buttons.js:324
+#: static/js/zamboni/discovery-all.js:13320 static/js/zamboni/discovery-all.js:13357
+msgid "Not available for {0} {1}"
+msgstr "Non disponibile per {0} {1}"
+
+#: static/js/common-all.js:2112 static/js/impala-all.js:2197 static/js/zamboni/buttons.js:351 static/js/zamboni/discovery-all.js:13383
+msgid "Works with {app} {min} - {max}"
+msgstr "Compatibile con {app} {min} - {max}"
+
+#: static/js/common-all.js:2114 static/js/impala-all.js:2199 static/js/zamboni/buttons.js:353 static/js/zamboni/discovery-all.js:13385
+msgid "View other versions"
+msgstr "Mostra altre versioni"
+
+#: static/js/common-all.js:2162 static/js/impala-all.js:2247 static/js/zamboni/buttons.js:401 static/js/zamboni/discovery-all.js:13433
+msgid "Only with Firefox — Get Firefox Now!"
+msgstr "Solo con Firefox — Scaricalo subito!"
+
+#: static/js/common-all.js:2278 static/js/impala-all.js:2363 static/js/zamboni/buttons.js:517 static/js/zamboni/discovery-all.js:13549 static/js/zamboni/mobile-all.js:15177
+#: static/js/zamboni/mobile/buttons.js:43
+msgid "Sorry, you need a Mozilla-based browser (such as Firefox) to install a search plugin."
+msgstr "Bisogna utilizzare un browser, come Firefox, basato su Mozilla per installare un plugin di ricerca."
+
+#: static/js/common-all.js:9088 static/js/impala-all.js:9649 static/js/zamboni/global.js:410
+msgid "Loading..."
+msgstr "Caricamento…"
+
+#. L10n: {0} is the number of characters left.
+#: static/js/common-all.js:9152 static/js/impala-all.js:9713 static/js/zamboni/global.js:474
+msgid "<b>{0}</b> character left."
+msgid_plural "<b>{0}</b> characters left."
+msgstr[0] "<b>{0}</b> carattere disponibile."
+msgstr[1] "<b>{0}</b> caratteri disponibili."
+
+#: static/js/common-all.js:9589 static/js/common-min.js:6 static/js/impala-all.js:10052 static/js/impala-min.js:6 static/js/common/ratingwidget.js:31 static/js/zamboni/mobile-all.js:16123
+#: static/js/zamboni/mobile-min.js:6
 msgid "{0} star"
 msgid_plural "{0} stars"
 msgstr[0] "{0} stella"
 msgstr[1] "{0} stelle"
 
-#: static/js/common/upload-addon.js:41 static/js/common/upload-image.js:128
+#: static/js/common-all.js:9676 static/js/common-min.js:6 static/js/impala-all.js:10139 static/js/impala-min.js:6 static/js/zamboni/l10n.js:45
+msgid "Remove this localization"
+msgstr "Rimuovi questa localizzazione"
+
+#: static/js/common-all.js:10193 static/js/common-min.js:6 static/js/impala-all.js:10674 static/js/impala-min.js:6 static/js/zamboni/discovery-all.js:13678
+msgid "close"
+msgstr ""
+
+#: static/js/common-all.js:10860 static/js/common-min.js:6 static/js/impala-all.js:11481 static/js/impala-min.js:6 static/js/impala/reviews.js:23 static/js/zamboni/reviews.js:18
+msgid "Flagged for review"
+msgstr "Segnalato per revisione"
+
+#: static/js/common-all.js:10876 static/js/common-min.js:6 static/js/impala-all.js:11498 static/js/impala-min.js:6 static/js/impala/reviews.js:40 static/js/zamboni/reviews.js:34
+msgid "Your input is required"
+msgstr "È richiesto un inserimento"
+
+#: static/js/common-all.js:10945 static/js/common-min.js:6 static/js/impala-all.js:11610 static/js/impala-min.js:7 static/js/impala/reviews.js:152 static/js/zamboni/reviews.js:103
+msgid "Marked for deletion"
+msgstr "Segnalato per eliminazione"
+
+#: static/js/common-all.js:11573 static/js/common-min.js:7 static/js/impala-all.js:13809 static/js/impala-min.js:8 static/js/zamboni/collections.js:229
+msgid "Adding to Favorites&hellip;"
+msgstr "Aggiunta ai Preferiti in corso&hellip;"
+
+#: static/js/common-all.js:11576 static/js/common-min.js:7 static/js/impala-all.js:13812 static/js/impala-min.js:8 static/js/zamboni/collections.js:232
+msgid "Removing Favorite&hellip;"
+msgstr "Eliminazione preferito&hellip;"
+
+#: static/js/common-all.js:11579 static/js/common-min.js:7 static/js/impala-all.js:13815 static/js/impala-min.js:8 static/js/zamboni/collections.js:235
+msgid "Add to Favorites"
+msgstr "Aggiungi a Preferiti"
+
+#: static/js/common-all.js:11582 static/js/common-min.js:7 static/js/impala-all.js:13818 static/js/impala-min.js:8 static/js/zamboni/collections.js:238
+msgid "Remove from Favorites"
+msgstr "Elimina da Preferiti"
+
+#: static/js/common-all.js:11647 static/js/common-min.js:7 static/js/impala-all.js:13883 static/js/impala-min.js:8 static/js/zamboni/collections.js:303
+msgid "Pending"
+msgstr "In attesa"
+
+#: static/js/common-all.js:11648 static/js/common-min.js:7 static/js/impala-all.js:13884 static/js/impala-min.js:8 static/js/zamboni/collections.js:304
+msgid "Add a comment"
+msgstr "Aggiungi un commento"
+
+#: static/js/common-all.js:11648 static/js/common-min.js:7 static/js/impala-all.js:13884 static/js/impala-min.js:8 static/js/zamboni/collections.js:304
+msgid "Comment"
+msgstr "Commento"
+
+#: static/js/common-all.js:11649 static/js/common-min.js:7 static/js/impala-all.js:13885 static/js/impala-min.js:8 static/js/zamboni/collections.js:305
+msgid "Remove this add-on from the collection"
+msgstr "Rimuovi questo componente aggiuntivo dalla raccolta"
+
+#: static/js/common-all.js:11649 static/js/common-all.js:11678 static/js/common-min.js:7 static/js/impala-all.js:13885 static/js/impala-all.js:13914 static/js/impala-min.js:8
+#: static/js/zamboni/collections.js:305 static/js/zamboni/collections.js:334
+msgid "Remove"
+msgstr "Elimina"
+
+#: static/js/common-all.js:11678 static/js/common-min.js:7 static/js/impala-all.js:13914 static/js/impala-min.js:8 static/js/zamboni/collections.js:334
+msgid "Remove this user as a contributor"
+msgstr "Elimina questo utente da collaboratore"
+
+#: static/js/common-all.js:11690 static/js/common-min.js:7 static/js/impala-all.js:13926 static/js/impala-min.js:8 static/js/zamboni/collections.js:346
+msgid "An email address is required."
+msgstr "È necessario un indirizzo email."
+
+#: static/js/common-all.js:11708 static/js/common-min.js:7 static/js/impala-all.js:13944 static/js/impala-min.js:8 static/js/zamboni/collections.js:364
+msgid "You cannot add yourself as a contributor."
+msgstr "Non puoi aggiungere te stesso come collaboratore."
+
+#: static/js/common-all.js:11710 static/js/common-min.js:7 static/js/impala-all.js:13946 static/js/impala-min.js:8 static/js/zamboni/collections.js:366
+msgid "You have already added that user."
+msgstr "Questo utente è stato già aggiunto."
+
+#: static/js/common-all.js:11917 static/js/common-min.js:7 static/js/impala-all.js:14153 static/js/impala-min.js:8 static/js/zamboni/collections.js:573
+msgid "Add to favorites"
+msgstr "Aggiungi ai preferiti"
+
+#: static/js/common-all.js:11921 static/js/common-min.js:7 static/js/impala-all.js:14157 static/js/impala-min.js:8 static/js/zamboni/collections.js:577
+msgid "Remove from favorites"
+msgstr "Elimina dai preferiti"
+
+#: static/js/common-all.js:11939 static/js/common-min.js:7 static/js/impala-all.js:14175 static/js/impala-all.js:14233 static/js/impala-min.js:8 static/js/impala/collections.js:10
+#: static/js/zamboni/collections.js:595
+msgid "Follow this Collection"
+msgstr "Segui questa raccolta"
+
+#: static/js/common-all.js:11948 static/js/common-min.js:7 static/js/impala-all.js:14184 static/js/impala-min.js:8 static/js/zamboni/collections.js:604
+msgid "Stop following"
+msgstr "Non seguire più"
+
+#: static/js/common-all.js:12096 static/js/common-min.js:7 static/js/zamboni/password-strength.js:20
+msgid "Password strength:"
+msgstr "Complessità password:"
+
+#: static/js/common-all.js:12102 static/js/common-min.js:7 static/js/zamboni/password-strength.js:26
+msgid "At least {0} character left."
+msgid_plural "At least {0} characters left."
+msgstr[0] "Almeno {0} carattere ancora disponibile."
+msgstr[1] "Almeno {0} caratteri ancora disponibili."
+
+#: static/js/common-all.js:12286 static/js/common-min.js:7 static/js/impala-all.js:14632 static/js/impala-min.js:8 static/js/impala/suggestions.js:39
+msgid "Search themes for <b>{0}</b>"
+msgstr "Cerca temi per <b>{0}</b>"
+
+#: static/js/common-all.js:12288 static/js/common-min.js:7 static/js/impala-all.js:14634 static/js/impala-min.js:8 static/js/impala/suggestions.js:41
+msgid "Search apps for <b>{0}</b>"
+msgstr "Cerca app per <b>{0}</b>"
+
+#: static/js/common-all.js:12290 static/js/common-min.js:7 static/js/impala-all.js:14636 static/js/impala-min.js:8 static/js/impala/suggestions.js:43
+msgid "Search add-ons for <b>{0}</b>"
+msgstr "Cerca componenti aggiuntivi per <b>{0}</b>"
+
+#: static/js/common-all.js:12521 static/js/common-min.js:7 static/js/impala-all.js:14867 static/js/impala-min.js:8 static/js/impala/site_suggestions.js:46
+msgid "Category"
+msgstr "Categoria"
+
+#. L10n: {0} is an app name.
+#: static/js/impala-all.js:11632 static/js/impala-min.js:7 static/js/impala/listing.js:11 static/js/zamboni/themes.js:13
+msgid "This theme is incompatible with your version of {0}"
+msgstr "Questo tema non è compatibile con la versione di {0} in uso"
+
+#: static/js/impala-all.js:12146 static/js/impala-all.js:14331 static/js/impala-min.js:7 static/js/impala-min.js:8 static/js/common/upload-image.js:97 static/js/impala/users.js:51
+#: static/js/zamboni/devhub-all.js:894 static/js/zamboni/devhub-min.js:1
+msgid "Images must be either PNG or JPG."
+msgstr "Le icone devono essere in formato PNG o JPG."
+
+#: static/js/impala-all.js:12150 static/js/impala-min.js:7 static/js/common/upload-image.js:101 static/js/zamboni/devhub-all.js:898 static/js/zamboni/devhub-min.js:1
+msgid "Videos must be in WebM."
+msgstr "I video devono essere in formato WebM."
+
+#: static/js/impala-all.js:12177 static/js/impala-min.js:7 static/js/common/upload-addon.js:41 static/js/common/upload-image.js:128 static/js/zamboni/devhub-all.js:272
+#: static/js/zamboni/devhub-all.js:925 static/js/zamboni/devhub-min.js:1
 msgid "There was a problem contacting the server."
 msgstr "Si è verificato un problema con la connessione al server."
 
-#: static/js/common/upload-addon.js:69
+#: static/js/impala-all.js:13298 static/js/impala-min.js:7 static/js/impala/persona_creation.js:60
+msgid "All Rights Reserved"
+msgstr "Tutti i diritti riservati"
+
+#: static/js/impala-all.js:13302 static/js/impala-min.js:7 static/js/impala/persona_creation.js:64
+msgid "Creative Commons Attribution 3.0"
+msgstr "Creative Commons Attribuzione 3.0"
+
+#: static/js/impala-all.js:13307 static/js/impala-min.js:7 static/js/impala/persona_creation.js:69
+msgid "Creative Commons Attribution-NonCommercial 3.0"
+msgstr "Creative Commons Attribuzione-Non Commerciale 3.0"
+
+#: static/js/impala-all.js:13312 static/js/impala-min.js:7 static/js/impala/persona_creation.js:74
+msgid "Creative Commons Attribution-NonCommercial-NoDerivs 3.0"
+msgstr "Creative Commons Attribuzione-Non Commerciale-Non opere derivate 3.0"
+
+#: static/js/impala-all.js:13317 static/js/impala-min.js:7 static/js/impala/persona_creation.js:79
+msgid "Creative Commons Attribution-NonCommercial-Share Alike 3.0"
+msgstr "Creative Commons Attribuzione-Non Commerciale-Condividi allo stesso modo 3.0"
+
+#: static/js/impala-all.js:13322 static/js/impala-min.js:7 static/js/impala/persona_creation.js:84
+msgid "Creative Commons Attribution-NoDerivs 3.0"
+msgstr "Creative Commons Attribuzione-Non opere derivate 3.0"
+
+#: static/js/impala-all.js:13327 static/js/impala-min.js:7 static/js/impala/persona_creation.js:89
+msgid "Creative Commons Attribution-ShareAlike 3.0"
+msgstr "Creative Commons Attribuzione-Condividi allo stesso modo 3.0"
+
+#: static/js/impala-all.js:13530 static/js/impala-min.js:7 static/js/impala/persona_creation.js:292
+msgid "Your Theme's Name"
+msgstr "Il nome del tema"
+
+#: static/js/impala-all.js:14242 static/js/impala-min.js:8 static/js/impala/collections.js:19
+msgid "Stop Following"
+msgstr "Non seguire più"
+
+#: static/js/impala-all.js:14243 static/js/impala-min.js:8 static/js/impala/collections.js:20
+msgid "Following"
+msgstr "Seguita"
+
+#: static/js/impala-all.js:14313 static/js/impala-min.js:8 static/js/impala/users.js:33
+msgid "use original"
+msgstr "usa originale"
+
+#: static/js/impala-all.js:14523 static/js/impala-min.js:8 static/js/impala/search.js:114
+msgid "Updating results&hellip;"
+msgstr "Aggiornamento risultati&hellip;"
+
+#: static/js/common/upload-addon.js:69 static/js/zamboni/devhub-all.js:300 static/js/zamboni/devhub-min.js:1
 msgid "Select a file..."
 msgstr "Selezionare un file…"
 
-#: static/js/common/upload-addon.js:70
+#: static/js/common/upload-addon.js:70 static/js/zamboni/devhub-all.js:301 static/js/zamboni/devhub-min.js:1
 msgid "Your add-on should end with .xpi, .jar or .xml"
 msgstr "L’estensione del componente aggiuntivo deve essere .xpi, .jar o .xml"
 
 #. L10n: {0} is the percent of the file that has been uploaded.
-#: static/js/common/upload-addon.js:104
+#: static/js/common/upload-addon.js:104 static/js/zamboni/devhub-all.js:335 static/js/zamboni/devhub-min.js:1
 #, python-format
 msgid "{0}% complete"
 msgstr "{0}% completato"
 
 #. L10n: "{bytes uploaded} of {total filesize}".
-#: static/js/common/upload-addon.js:107
+#: static/js/common/upload-addon.js:107 static/js/zamboni/devhub-all.js:338 static/js/zamboni/devhub-min.js:1
 msgid "{0} of {1}"
 msgstr "{0} di {1}"
 
-#: static/js/common/upload-addon.js:140
+#: static/js/common/upload-addon.js:140 static/js/zamboni/devhub-all.js:371 static/js/zamboni/devhub-min.js:1
 msgid "Cancel"
 msgstr "Annulla"
 
-#: static/js/common/upload-addon.js:162
+#: static/js/common/upload-addon.js:162 static/js/zamboni/devhub-all.js:393 static/js/zamboni/devhub-min.js:1
 msgid "Uploading {0}"
 msgstr "Caricamento in corso di {0}"
 
-#: static/js/common/upload-addon.js:189
+#: static/js/common/upload-addon.js:189 static/js/zamboni/devhub-all.js:420 static/js/zamboni/devhub-min.js:1
 msgid "Error with {0}"
 msgstr "Errore con {0}"
 
-#: static/js/common/upload-addon.js:194
+#: static/js/common/upload-addon.js:194 static/js/zamboni/devhub-all.js:425 static/js/zamboni/devhub-min.js:1
 msgid "Your add-on failed validation with {0} error."
 msgid_plural "Your add-on failed validation with {0} errors."
 msgstr[0] "Il componente aggiuntivo non ha superato la validazione con {0} errore."
 msgstr[1] "Il componente aggiuntivo non ha superato la validazione con {0} errori."
 
-#: static/js/common/upload-addon.js:208
+#: static/js/common/upload-addon.js:208 static/js/zamboni/devhub-all.js:439 static/js/zamboni/devhub-min.js:1
 msgid "&hellip;and {0} more"
 msgid_plural "&hellip;and {0} more"
 msgstr[0] "&hellip;e {0} altro"
 msgstr[1] "&hellip;e altri {0}"
 
-#: static/js/common/upload-addon.js:222 static/js/common/upload-addon.js:512
+#: static/js/common/upload-addon.js:222 static/js/common/upload-addon.js:497 static/js/zamboni/devhub-all.js:453 static/js/zamboni/devhub-all.js:743 static/js/zamboni/devhub-min.js:1
 msgid "See full validation report"
 msgstr "Visualizza il risultato completo della validazione"
 
-#: static/js/common/upload-addon.js:234
+#: static/js/common/upload-addon.js:234 static/js/zamboni/devhub-all.js:465 static/js/zamboni/devhub-min.js:1
 msgid "Validating {0}"
 msgstr "Controllo in corso di {0}"
 
 #. L10n: first argument is an HTTP status code
-#: static/js/common/upload-addon.js:273
+#: static/js/common/upload-addon.js:273 static/js/zamboni/devhub-all.js:504 static/js/zamboni/devhub-min.js:1
 msgid "Received an empty response from the server; status: {0}"
 msgstr "Ricevuta una risposta vuota dal server; status: {0}"
 
-#: static/js/common/upload-addon.js:373
+#: static/js/common/upload-addon.js:370 static/js/zamboni/devhub-all.js:604 static/js/zamboni/devhub-min.js:1
 msgid "Unexpected server error while validating."
 msgstr "Errore inatteso del server durante il controllo."
 
-#: static/js/common/upload-addon.js:412
+#: static/js/common/upload-addon.js:409 static/js/zamboni/devhub-all.js:643 static/js/zamboni/devhub-min.js:1
 msgid "Finished validating {0}"
 msgstr "Validazione di {0} completata"
 
-#: static/js/common/upload-addon.js:418
+#: static/js/common/upload-addon.js:415 static/js/zamboni/devhub-all.js:649 static/js/zamboni/devhub-min.js:1
 msgid "Your add-on validation timed out, it will be manually reviewed."
 msgstr "Il tempo assegnato per la validazione automatica del componente aggiuntivo è scaduto. Verrà effettuata una revisione manuale."
 
-#: static/js/common/upload-addon.js:421
+#: static/js/common/upload-addon.js:418 static/js/zamboni/devhub-all.js:652 static/js/zamboni/devhub-min.js:1
 msgid "Your add-on was validated with no errors and {0} warning."
 msgid_plural "Your add-on was validated with no errors and {0} warnings."
 msgstr[0] "Il componente aggiuntivo ha superato il processo di validazione senza errori e con {0} avviso."
 msgstr[1] "Il componente aggiuntivo ha superato il processo di validazione senza errori e con {0} avvisi."
 
-#: static/js/common/upload-addon.js:426
+#: static/js/common/upload-addon.js:423 static/js/zamboni/devhub-all.js:657 static/js/zamboni/devhub-min.js:1
 msgid "Your add-on was validated with no errors and {0} message."
 msgid_plural "Your add-on was validated with no errors and {0} messages."
 msgstr[0] "Il componente aggiuntivo ha superato il processo di validazione senza errori e con {0} messaggio."
 msgstr[1] "Il componente aggiuntivo ha superato il processo di validazione senza errori e con {0} messaggi."
 
-#: static/js/common/upload-addon.js:431
+#: static/js/common/upload-addon.js:428 static/js/zamboni/devhub-all.js:662 static/js/zamboni/devhub-min.js:1
 msgid "Your add-on was validated with no errors or warnings."
 msgstr "Il componente aggiuntivo ha superato il processo di validazione senza alcun errore o avviso."
 
-#: static/js/common/upload-addon.js:446
+#: static/js/common/upload-addon.js:443 static/js/zamboni/devhub-all.js:677 static/js/zamboni/devhub-min.js:1
 msgid "Your submission will be automatically signed."
 msgstr "Il componente aggiuntivo inviato verrà firmato digitalmente in modo automatico."
 
-#: static/js/common/upload-addon.js:465
+#: static/js/common/upload-addon.js:450 static/js/zamboni/devhub-all.js:696 static/js/zamboni/devhub-min.js:1
 msgid "Include detailed version notes (this can be done in the next step)."
 msgstr "Includi note di versione dettagliate (è possibile inserirle nel prossimo passaggio)."
 
-#: static/js/common/upload-addon.js:466
+#: static/js/common/upload-addon.js:451 static/js/zamboni/devhub-all.js:697 static/js/zamboni/devhub-min.js:1
 msgid "If your add-on requires an account to a website in order to be fully tested, include a test username and password in the Notes to Reviewer (this can be done in the next step)."
 msgstr ""
 "Se per effettuare il test completo del componente aggiuntivo è necessario accedere a un sito web con nome utente e password, inserisci i dati per l’accesso nella nota per i revisori (è possibile "
 "farlo nel prossimo passaggio)."
 
-#: static/js/common/upload-addon.js:467
+#: static/js/common/upload-addon.js:452 static/js/zamboni/devhub-all.js:698 static/js/zamboni/devhub-min.js:1
 msgid "If your add-on is intended for a limited audience you should choose Preliminary Review instead of Full Review."
 msgstr "Nel caso in cui il componente aggiuntivo sia destinato a un’utenza limitata, seleziona Revisione preliminare anziché Revisione completa."
 
-#: static/js/common/upload-addon.js:480
+#: static/js/common/upload-addon.js:465 static/js/zamboni/devhub-all.js:711 static/js/zamboni/devhub-min.js:1
 msgid "Add-on submission checklist"
 msgstr "Promemoria per il caricamento del componente aggiuntivo"
 
-#: static/js/common/upload-addon.js:481
+#: static/js/common/upload-addon.js:466 static/js/zamboni/devhub-all.js:712 static/js/zamboni/devhub-min.js:1
 msgid "Please verify the following points before finalizing your submission. This will minimize delays or misunderstanding during the review process:"
-msgstr "Prima di confermare il caricamento verifica che il componente aggiuntivo soddisfi i seguenti requisiti, in modo da ridurre al minimo eventuali ritardi o equivoci nel corso del processo di revisione:"
+msgstr ""
+"Prima di confermare il caricamento verifica che il componente aggiuntivo soddisfi i seguenti requisiti, in modo da ridurre al minimo eventuali ritardi o equivoci nel corso del processo di revisione:"
 
-#: static/js/common/upload-addon.js:483
+#: static/js/common/upload-addon.js:468 static/js/zamboni/devhub-all.js:714 static/js/zamboni/devhub-min.js:1
 msgid ""
 "Compiled binaries, as well as minified or obfuscated scripts (excluding known libraries) need to have their sources submitted separately for review. Make sure that you use the source code upload "
 "field to avoid having your submission rejected."
@@ -140,1083 +398,847 @@ msgstr ""
 "I sorgenti dei binari compilati, come quelli degli script compressi e offuscati (a eccezione delle librerie note) devono essere caricati separatamente per la revisione. Per evitare che il "
 "componente venga respinto assicurati di inserirle nel campo dedicato appositamente al codice sorgente."
 
-#: static/js/common/upload-addon.js:501
+#: static/js/common/upload-addon.js:486 static/js/zamboni/devhub-all.js:732 static/js/zamboni/devhub-min.js:1
 msgid "The validation process found these issues that can lead to rejections:"
 msgstr "Durante il processo di validazione sono stati rilevati i seguenti problemi, che potrebbero portare al rifiuto del componente aggiuntivo:"
 
-#: static/js/common/upload-addon.js:518
+#: static/js/common/upload-addon.js:503 static/js/zamboni/devhub-all.js:749 static/js/zamboni/devhub-min.js:1
 msgid "If you are unfamiliar with the add-ons review process, you can read about it here."
 msgstr "Se hai poca dimestichezza con il processo di revisione dei componenti aggiuntivi, qui puoi trovare ulteriori informazioni."
 
-#: static/js/common/upload-addon.js:555
+#: static/js/common/upload-addon.js:540 static/js/zamboni/devhub-all.js:786 static/js/zamboni/devhub-min.js:1
 msgid "Sorry, no supported platform has been found."
 msgstr "Spiacenti, non è stato possibile trovare alcuna piattaforma compatibile."
 
-#: static/js/common/upload-base.js:57
+#: static/js/common/upload-base.js:57 static/js/zamboni/devhub-all.js:187 static/js/zamboni/devhub-min.js:1
 msgid "The filetype you uploaded isn't recognized."
 msgstr "Impossibile determinare il tipo di file caricato."
 
-#: static/js/common/upload-base.js:79
+#: static/js/common/upload-base.js:79 static/js/zamboni/devhub-all.js:209 static/js/zamboni/devhub-min.js:1
 msgid "You cancelled the upload."
 msgstr "Caricamento annullato."
 
-#: static/js/common/upload-image.js:97 static/js/impala/users.js:51
-msgid "Images must be either PNG or JPG."
-msgstr "Le icone devono essere in formato PNG o JPG."
-
-#: static/js/common/upload-image.js:101
-msgid "Videos must be in WebM."
-msgstr "I video devono essere in formato WebM."
-
-#: static/js/impala/collections.js:10 static/js/zamboni/collections.js:595
-msgid "Follow this Collection"
-msgstr "Segui questa raccolta"
-
-#: static/js/impala/collections.js:19
-msgid "Stop Following"
-msgstr "Non seguire più"
-
-#: static/js/impala/collections.js:20
-msgid "Following"
-msgstr "Seguita"
-
-#. L10n: {0} is an app name.
-#: static/js/impala/listing.js:11 static/js/zamboni/themes.js:13
-msgid "This theme is incompatible with your version of {0}"
-msgstr "Questo tema non è compatibile con la versione di {0} in uso"
-
-#: static/js/impala/persona_creation.js:60
-msgid "All Rights Reserved"
-msgstr "Tutti i diritti riservati"
-
-#: static/js/impala/persona_creation.js:64
-msgid "Creative Commons Attribution 3.0"
-msgstr "Creative Commons Attribuzione 3.0"
-
-#: static/js/impala/persona_creation.js:69
-msgid "Creative Commons Attribution-NonCommercial 3.0"
-msgstr "Creative Commons Attribuzione-Non Commerciale 3.0"
-
-#: static/js/impala/persona_creation.js:74
-msgid "Creative Commons Attribution-NonCommercial-NoDerivs 3.0"
-msgstr "Creative Commons Attribuzione-Non Commerciale-Non opere derivate 3.0"
-
-#: static/js/impala/persona_creation.js:79
-msgid "Creative Commons Attribution-NonCommercial-Share Alike 3.0"
-msgstr "Creative Commons Attribuzione-Non Commerciale-Condividi allo stesso modo 3.0"
-
-#: static/js/impala/persona_creation.js:84
-msgid "Creative Commons Attribution-NoDerivs 3.0"
-msgstr "Creative Commons Attribuzione-Non opere derivate 3.0"
-
-#: static/js/impala/persona_creation.js:89
-msgid "Creative Commons Attribution-ShareAlike 3.0"
-msgstr "Creative Commons Attribuzione-Condividi allo stesso modo 3.0"
-
-#: static/js/impala/persona_creation.js:292
-msgid "Your Theme's Name"
-msgstr "Il nome del tema"
-
-#: static/js/impala/reviews.js:23 static/js/zamboni/reviews.js:18
-msgid "Flagged for review"
-msgstr "Segnalato per revisione"
-
-#: static/js/impala/reviews.js:40 static/js/zamboni/reviews.js:34
-msgid "Your input is required"
-msgstr "È richiesto un inserimento"
-
-#: static/js/impala/reviews.js:152 static/js/zamboni/reviews.js:103
-msgid "Marked for deletion"
-msgstr "Segnalato per eliminazione"
-
-#: static/js/impala/search.js:114
-msgid "Updating results&hellip;"
-msgstr "Aggiornamento risultati&hellip;"
-
-#: static/js/impala/site_suggestions.js:46
-msgid "Category"
-msgstr "Categoria"
-
-#: static/js/impala/suggestions.js:39
-msgid "Search themes for <b>{0}</b>"
-msgstr "Cerca temi per <b>{0}</b>"
-
-#: static/js/impala/suggestions.js:41
-msgid "Search apps for <b>{0}</b>"
-msgstr "Cerca app per <b>{0}</b>"
-
-#: static/js/impala/suggestions.js:43
-msgid "Search add-ons for <b>{0}</b>"
-msgstr "Cerca componenti aggiuntivi per <b>{0}</b>"
-
-#: static/js/impala/users.js:33
-msgid "use original"
-msgstr "usa originale"
-
-#: static/js/impala/stats/chart.js:267
+#: static/js/impala/stats/chart.js:267 static/js/zamboni/stats-all.js:16898 static/js/zamboni/stats-min.js:5
 msgid "Week of {0}"
 msgstr "Settimana del {0}"
 
-#: static/js/impala/stats/chart.js:269
+#: static/js/impala/stats/chart.js:269 static/js/zamboni/stats-all.js:16900 static/js/zamboni/stats-min.js:5
 msgid " downloads"
-msgstr "download"
+msgstr ""
 
-#: static/js/impala/stats/chart.js:270
+#: static/js/impala/stats/chart.js:270 static/js/zamboni/stats-all.js:16901 static/js/zamboni/stats-min.js:5
 msgid "{0} users"
 msgstr "{0} utenti"
 
-#: static/js/impala/stats/chart.js:271
+#: static/js/impala/stats/chart.js:271 static/js/zamboni/stats-all.js:16902 static/js/zamboni/stats-min.js:5
 msgid "{0} add-ons"
 msgstr "{0} componenti aggiuntivi"
 
-#: static/js/impala/stats/chart.js:272
+#: static/js/impala/stats/chart.js:272 static/js/zamboni/stats-all.js:16903 static/js/zamboni/stats-min.js:5
 msgid "{0} collections"
 msgstr "{0} raccolte"
 
-#: static/js/impala/stats/chart.js:273
+#: static/js/impala/stats/chart.js:273 static/js/zamboni/stats-all.js:16904 static/js/zamboni/stats-min.js:5
 msgid "{0} reviews"
 msgstr "{0} recensioni"
 
-#: static/js/impala/stats/chart.js:275
+#: static/js/impala/stats/chart.js:275 static/js/zamboni/stats-all.js:16906 static/js/zamboni/stats-min.js:5
 msgid "{0} sales"
 msgstr "{0} vendite"
 
-#: static/js/impala/stats/chart.js:276
+#: static/js/impala/stats/chart.js:276 static/js/zamboni/stats-all.js:16907 static/js/zamboni/stats-min.js:5
 msgid "{0} refunds"
 msgstr "{0} rimborsi"
 
-#: static/js/impala/stats/chart.js:277
+#: static/js/impala/stats/chart.js:277 static/js/zamboni/stats-all.js:16908 static/js/zamboni/stats-min.js:5
 msgid "{0} installs"
 msgstr "{0} installazioni"
 
-#: static/js/impala/stats/chart.js:369 static/js/impala/stats/csv_keys.js:3 static/js/impala/stats/csv_keys.js:109
+#: static/js/impala/stats/chart.js:369 static/js/impala/stats/csv_keys.js:3 static/js/impala/stats/csv_keys.js:109 static/js/zamboni/stats-all.js:15284 static/js/zamboni/stats-all.js:15390
+#: static/js/zamboni/stats-all.js:17000 static/js/zamboni/stats-min.js:4 static/js/zamboni/stats-min.js:5
 msgid "Downloads"
 msgstr "Download"
 
-#: static/js/impala/stats/chart.js:379 static/js/impala/stats/csv_keys.js:6 static/js/impala/stats/csv_keys.js:110
+#: static/js/impala/stats/chart.js:379 static/js/impala/stats/csv_keys.js:6 static/js/impala/stats/csv_keys.js:110 static/js/zamboni/stats-all.js:15287 static/js/zamboni/stats-all.js:15391
+#: static/js/zamboni/stats-all.js:17010 static/js/zamboni/stats-min.js:4 static/js/zamboni/stats-min.js:5
 msgid "Daily Users"
 msgstr "Utenti per giorno"
 
-#: static/js/impala/stats/chart.js:410
+#: static/js/impala/stats/chart.js:410 static/js/zamboni/stats-all.js:17041 static/js/zamboni/stats-min.js:5
 msgid "Amount, in USD"
 msgstr "Importo in USD"
 
-#: static/js/impala/stats/chart.js:421 static/js/impala/stats/csv_keys.js:104
+#: static/js/impala/stats/chart.js:421 static/js/impala/stats/csv_keys.js:104 static/js/zamboni/stats-all.js:15385 static/js/zamboni/stats-all.js:17052 static/js/zamboni/stats-min.js:5
 msgid "Number of Contributions"
 msgstr "Numero di donazioni"
 
-#: static/js/impala/stats/chart.js:447
+#: static/js/impala/stats/chart.js:447 static/js/zamboni/stats-all.js:17078 static/js/zamboni/stats-min.js:5
 msgid "More Info..."
 msgstr "Altre informazioni…"
 
 #. L10n: {0} is an ISO-formatted date.
-#: static/js/impala/stats/chart.js:451
+#: static/js/impala/stats/chart.js:451 static/js/zamboni/stats-all.js:17082 static/js/zamboni/stats-min.js:5
 msgid "Details for {0}"
 msgstr "Dettagli del {0}"
 
-#: static/js/impala/stats/csv_keys.js:9
+#: static/js/impala/stats/csv_keys.js:9 static/js/zamboni/stats-all.js:15290 static/js/zamboni/stats-min.js:4
 msgid "Collections Created"
 msgstr "Collezione Creata"
 
-#: static/js/impala/stats/csv_keys.js:12
+#: static/js/impala/stats/csv_keys.js:12 static/js/zamboni/stats-all.js:15293 static/js/zamboni/stats-min.js:4
 msgid "Add-ons in Use"
 msgstr "Add-on in Uso"
 
-#: static/js/impala/stats/csv_keys.js:15
+#: static/js/impala/stats/csv_keys.js:15 static/js/zamboni/stats-all.js:15296 static/js/zamboni/stats-min.js:4
 msgid "Add-ons Created"
 msgstr "Add-on Creati"
 
-#: static/js/impala/stats/csv_keys.js:18
+#: static/js/impala/stats/csv_keys.js:18 static/js/zamboni/stats-all.js:15299 static/js/zamboni/stats-min.js:4
 msgid "Add-ons Downloaded"
 msgstr "Add-on Scaricati"
 
-#: static/js/impala/stats/csv_keys.js:21
+#: static/js/impala/stats/csv_keys.js:21 static/js/zamboni/stats-all.js:15302 static/js/zamboni/stats-min.js:4
 msgid "Add-ons Updated"
 msgstr "Add-on Aggiornati"
 
-#: static/js/impala/stats/csv_keys.js:24
+#: static/js/impala/stats/csv_keys.js:24 static/js/zamboni/stats-all.js:15305 static/js/zamboni/stats-min.js:4
 msgid "Reviews Written"
 msgstr "Recensioni scritte"
 
-#: static/js/impala/stats/csv_keys.js:27
+#: static/js/impala/stats/csv_keys.js:27 static/js/zamboni/stats-all.js:15308 static/js/zamboni/stats-min.js:4
 msgid "User Signups"
 msgstr "Registrazione Utente"
 
-#: static/js/impala/stats/csv_keys.js:30
+#: static/js/impala/stats/csv_keys.js:30 static/js/zamboni/stats-all.js:15311 static/js/zamboni/stats-min.js:4
 msgid "Subscribers"
 msgstr "Iscritti"
 
-#: static/js/impala/stats/csv_keys.js:33
+#: static/js/impala/stats/csv_keys.js:33 static/js/zamboni/stats-all.js:15314 static/js/zamboni/stats-min.js:4
 msgid "Ratings"
 msgstr "Valutazione"
 
 # Io metterei Ac
 # quisti,   rovesciando il punto di vista, da quello di Mozilla a quello
 # dell'utente
-#: static/js/impala/stats/csv_keys.js:36 static/js/impala/stats/csv_keys.js:114
+#: static/js/impala/stats/csv_keys.js:36 static/js/impala/stats/csv_keys.js:114 static/js/zamboni/stats-all.js:15317 static/js/zamboni/stats-all.js:15395 static/js/zamboni/stats-min.js:4
+#: static/js/zamboni/stats-min.js:5
 msgid "Sales"
 msgstr "Vendite"
 
-#: static/js/impala/stats/csv_keys.js:39 static/js/impala/stats/csv_keys.js:113
+#: static/js/impala/stats/csv_keys.js:39 static/js/impala/stats/csv_keys.js:113 static/js/zamboni/stats-all.js:15320 static/js/zamboni/stats-all.js:15394 static/js/zamboni/stats-min.js:4
+#: static/js/zamboni/stats-min.js:5
 msgid "Installs"
 msgstr "Installazioni"
 
-#: static/js/impala/stats/csv_keys.js:42
+#: static/js/impala/stats/csv_keys.js:42 static/js/zamboni/stats-all.js:15323 static/js/zamboni/stats-min.js:4
 msgid "Unknown"
 msgstr "Sconosciuto"
 
-#: static/js/impala/stats/csv_keys.js:43
+#: static/js/impala/stats/csv_keys.js:43 static/js/zamboni/stats-all.js:15324 static/js/zamboni/stats-min.js:4
 msgid "Add-ons Manager"
 msgstr "Gestore componenti aggiuntivi"
 
-#: static/js/impala/stats/csv_keys.js:44
+#: static/js/impala/stats/csv_keys.js:44 static/js/zamboni/stats-all.js:15325 static/js/zamboni/stats-min.js:4
 msgid "Add-ons Manager Promo"
 msgstr "In promozione in Gestione componenti aggiuntivi"
 
-#: static/js/impala/stats/csv_keys.js:45
+#: static/js/impala/stats/csv_keys.js:45 static/js/zamboni/stats-all.js:15326 static/js/zamboni/stats-min.js:4
 msgid "Add-ons Manager Featured"
 msgstr "Consigliati in Gestione componenti aggiuntivi"
 
-#: static/js/impala/stats/csv_keys.js:46
+#: static/js/impala/stats/csv_keys.js:46 static/js/zamboni/stats-all.js:15327 static/js/zamboni/stats-min.js:4
 msgid "Add-ons Manager Learn More"
 msgstr "Sezione Ulteriori informazioni in Gestione componenti aggiuntivi"
 
-#: static/js/impala/stats/csv_keys.js:47
+#: static/js/impala/stats/csv_keys.js:47 static/js/zamboni/stats-all.js:15328 static/js/zamboni/stats-min.js:4
 msgid "Search Suggestions"
 msgstr "Suggerimenti di ricerca"
 
-#: static/js/impala/stats/csv_keys.js:48
+#: static/js/impala/stats/csv_keys.js:48 static/js/zamboni/stats-all.js:15329 static/js/zamboni/stats-min.js:4
 msgid "Search Results"
 msgstr "Cerca tra i risultati"
 
-#: static/js/impala/stats/csv_keys.js:49 static/js/impala/stats/csv_keys.js:50 static/js/impala/stats/csv_keys.js:51
+#: static/js/impala/stats/csv_keys.js:49 static/js/impala/stats/csv_keys.js:50 static/js/impala/stats/csv_keys.js:51 static/js/zamboni/stats-all.js:15330 static/js/zamboni/stats-all.js:15331
+#: static/js/zamboni/stats-all.js:15332 static/js/zamboni/stats-min.js:4
 msgid "Homepage Promo"
 msgstr "Homepage promo"
 
-#: static/js/impala/stats/csv_keys.js:52 static/js/impala/stats/csv_keys.js:53
+#: static/js/impala/stats/csv_keys.js:52 static/js/impala/stats/csv_keys.js:53 static/js/zamboni/stats-all.js:15333 static/js/zamboni/stats-all.js:15334 static/js/zamboni/stats-min.js:4
 msgid "Homepage Featured"
 msgstr "Homepage consigliato"
 
-#: static/js/impala/stats/csv_keys.js:54 static/js/impala/stats/csv_keys.js:55
+#: static/js/impala/stats/csv_keys.js:54 static/js/impala/stats/csv_keys.js:55 static/js/zamboni/stats-all.js:15335 static/js/zamboni/stats-all.js:15336 static/js/zamboni/stats-min.js:4
 msgid "Homepage Up and Coming"
 msgstr "Homepage emergenti"
 
-#: static/js/impala/stats/csv_keys.js:56
+#: static/js/impala/stats/csv_keys.js:56 static/js/zamboni/stats-all.js:15337 static/js/zamboni/stats-min.js:4
 msgid "Homepage Most Popular"
 msgstr "Homepage più popolari"
 
-#: static/js/impala/stats/csv_keys.js:57 static/js/impala/stats/csv_keys.js:59
+#: static/js/impala/stats/csv_keys.js:57 static/js/impala/stats/csv_keys.js:59 static/js/zamboni/stats-all.js:15338 static/js/zamboni/stats-all.js:15340 static/js/zamboni/stats-min.js:4
 msgid "Detail Page"
 msgstr "Scheda completa"
 
-#: static/js/impala/stats/csv_keys.js:58 static/js/impala/stats/csv_keys.js:60
+#: static/js/impala/stats/csv_keys.js:58 static/js/impala/stats/csv_keys.js:60 static/js/zamboni/stats-all.js:15339 static/js/zamboni/stats-all.js:15341 static/js/zamboni/stats-min.js:4
 msgid "Detail Page (bottom)"
 msgstr "Scheda completa (fondo)"
 
-#: static/js/impala/stats/csv_keys.js:61
+#: static/js/impala/stats/csv_keys.js:61 static/js/zamboni/stats-all.js:15342 static/js/zamboni/stats-min.js:4
 msgid "Detail Page (Development Channel)"
 msgstr "Scheda completo (canale sviluppo)"
 
-#: static/js/impala/stats/csv_keys.js:62 static/js/impala/stats/csv_keys.js:63 static/js/impala/stats/csv_keys.js:64
+#: static/js/impala/stats/csv_keys.js:62 static/js/impala/stats/csv_keys.js:63 static/js/impala/stats/csv_keys.js:64 static/js/zamboni/stats-all.js:15343 static/js/zamboni/stats-all.js:15344
+#: static/js/zamboni/stats-all.js:15345 static/js/zamboni/stats-min.js:4
 msgid "Often Used With"
 msgstr "Spesso utilizzato con"
 
-#: static/js/impala/stats/csv_keys.js:65 static/js/impala/stats/csv_keys.js:66
+#: static/js/impala/stats/csv_keys.js:65 static/js/impala/stats/csv_keys.js:66 static/js/zamboni/stats-all.js:15346 static/js/zamboni/stats-all.js:15347 static/js/zamboni/stats-min.js:4
 msgid "Others By Author"
 msgstr "Altro dello stesso autore"
 
-#: static/js/impala/stats/csv_keys.js:67 static/js/impala/stats/csv_keys.js:68
+#: static/js/impala/stats/csv_keys.js:67 static/js/impala/stats/csv_keys.js:68 static/js/zamboni/stats-all.js:15348 static/js/zamboni/stats-all.js:15349 static/js/zamboni/stats-min.js:4
 msgid "Dependencies"
 msgstr "Dipendenze"
 
-#: static/js/impala/stats/csv_keys.js:69 static/js/impala/stats/csv_keys.js:70
+#: static/js/impala/stats/csv_keys.js:69 static/js/impala/stats/csv_keys.js:70 static/js/zamboni/stats-all.js:15350 static/js/zamboni/stats-all.js:15351 static/js/zamboni/stats-min.js:4
 msgid "Upsell"
 msgstr "Upsell"
 
-#: static/js/impala/stats/csv_keys.js:71
+#: static/js/impala/stats/csv_keys.js:71 static/js/zamboni/stats-all.js:15352 static/js/zamboni/stats-min.js:4
 msgid "Meet the Developer"
 msgstr "Incontra lo sviluppatore"
 
-#: static/js/impala/stats/csv_keys.js:72
+#: static/js/impala/stats/csv_keys.js:72 static/js/zamboni/stats-all.js:15353 static/js/zamboni/stats-min.js:4
 msgid "User Profile"
 msgstr "Profilo utente"
 
-#: static/js/impala/stats/csv_keys.js:73
+#: static/js/impala/stats/csv_keys.js:73 static/js/zamboni/stats-all.js:15354 static/js/zamboni/stats-min.js:4
 msgid "Version History"
 msgstr "Cronologia versioni"
 
-#: static/js/impala/stats/csv_keys.js:75
+#: static/js/impala/stats/csv_keys.js:75 static/js/zamboni/stats-all.js:15356 static/js/zamboni/stats-min.js:4
 msgid "Sharing"
 msgstr "Condivisione"
 
-#: static/js/impala/stats/csv_keys.js:76
+#: static/js/impala/stats/csv_keys.js:76 static/js/zamboni/stats-all.js:15357 static/js/zamboni/stats-min.js:4
 msgid "Category Pages"
 msgstr "Pagine categoria"
 
-#: static/js/impala/stats/csv_keys.js:77
+#: static/js/impala/stats/csv_keys.js:77 static/js/zamboni/stats-all.js:15358 static/js/zamboni/stats-min.js:4
 msgid "Collections"
 msgstr "Raccolte"
 
-#: static/js/impala/stats/csv_keys.js:78 static/js/impala/stats/csv_keys.js:79
+#: static/js/impala/stats/csv_keys.js:78 static/js/impala/stats/csv_keys.js:79 static/js/zamboni/stats-all.js:15359 static/js/zamboni/stats-all.js:15360 static/js/zamboni/stats-min.js:4
 msgid "Category Landing Featured Carousel"
 msgstr "Categoria da galleria consigliati"
 
-#: static/js/impala/stats/csv_keys.js:80 static/js/impala/stats/csv_keys.js:81
+#: static/js/impala/stats/csv_keys.js:80 static/js/impala/stats/csv_keys.js:81 static/js/zamboni/stats-all.js:15361 static/js/zamboni/stats-all.js:15362 static/js/zamboni/stats-min.js:4
 msgid "Category Landing Top Rated"
 msgstr "Categoria da più votati"
 
-#: static/js/impala/stats/csv_keys.js:82 static/js/impala/stats/csv_keys.js:83
+#: static/js/impala/stats/csv_keys.js:82 static/js/impala/stats/csv_keys.js:83 static/js/zamboni/stats-all.js:15363 static/js/zamboni/stats-all.js:15364 static/js/zamboni/stats-min.js:5
 msgid "Category Landing Most Popular"
 msgstr "Categoria da più popolari"
 
-#: static/js/impala/stats/csv_keys.js:84 static/js/impala/stats/csv_keys.js:85
+#: static/js/impala/stats/csv_keys.js:84 static/js/impala/stats/csv_keys.js:85 static/js/zamboni/stats-all.js:15365 static/js/zamboni/stats-all.js:15366 static/js/zamboni/stats-min.js:5
 msgid "Category Landing Recently Added"
 msgstr "Categoria da aggiunte di recente"
 
-#: static/js/impala/stats/csv_keys.js:86 static/js/impala/stats/csv_keys.js:87
+#: static/js/impala/stats/csv_keys.js:86 static/js/impala/stats/csv_keys.js:87 static/js/zamboni/stats-all.js:15367 static/js/zamboni/stats-all.js:15368 static/js/zamboni/stats-min.js:5
 msgid "Browse Listing Featured Sort"
 msgstr "Elenchi ordinati per consigliati"
 
-#: static/js/impala/stats/csv_keys.js:88 static/js/impala/stats/csv_keys.js:89
+#: static/js/impala/stats/csv_keys.js:88 static/js/impala/stats/csv_keys.js:89 static/js/zamboni/stats-all.js:15369 static/js/zamboni/stats-all.js:15370 static/js/zamboni/stats-min.js:5
 msgid "Browse Listing Users Sort"
 msgstr "Elenchi ordinati per utenti"
 
-#: static/js/impala/stats/csv_keys.js:90 static/js/impala/stats/csv_keys.js:91
+#: static/js/impala/stats/csv_keys.js:90 static/js/impala/stats/csv_keys.js:91 static/js/zamboni/stats-all.js:15371 static/js/zamboni/stats-all.js:15372 static/js/zamboni/stats-min.js:5
 msgid "Browse Listing Rating Sort"
 msgstr "Elenchi ordinati per voto"
 
-#: static/js/impala/stats/csv_keys.js:92 static/js/impala/stats/csv_keys.js:93
+#: static/js/impala/stats/csv_keys.js:92 static/js/impala/stats/csv_keys.js:93 static/js/zamboni/stats-all.js:15373 static/js/zamboni/stats-all.js:15374 static/js/zamboni/stats-min.js:5
 msgid "Browse Listing Created Sort"
 msgstr "Elenchi ordinati per data creazione"
 
-#: static/js/impala/stats/csv_keys.js:94 static/js/impala/stats/csv_keys.js:95
+#: static/js/impala/stats/csv_keys.js:94 static/js/impala/stats/csv_keys.js:95 static/js/zamboni/stats-all.js:15375 static/js/zamboni/stats-all.js:15376 static/js/zamboni/stats-min.js:5
 msgid "Browse Listing Name Sort"
 msgstr "Elenchi ordinati per nome"
 
-#: static/js/impala/stats/csv_keys.js:96 static/js/impala/stats/csv_keys.js:97
+#: static/js/impala/stats/csv_keys.js:96 static/js/impala/stats/csv_keys.js:97 static/js/zamboni/stats-all.js:15377 static/js/zamboni/stats-all.js:15378 static/js/zamboni/stats-min.js:5
 msgid "Browse Listing Popular Sort"
 msgstr "Elenchi ordinati per popolarità"
 
-#: static/js/impala/stats/csv_keys.js:98 static/js/impala/stats/csv_keys.js:99
+#: static/js/impala/stats/csv_keys.js:98 static/js/impala/stats/csv_keys.js:99 static/js/zamboni/stats-all.js:15379 static/js/zamboni/stats-all.js:15380 static/js/zamboni/stats-min.js:5
 msgid "Browse Listing Updated Sort"
 msgstr "Elenchi ordinati per data aggiornamento"
 
-#: static/js/impala/stats/csv_keys.js:100 static/js/impala/stats/csv_keys.js:101
+#: static/js/impala/stats/csv_keys.js:100 static/js/impala/stats/csv_keys.js:101 static/js/zamboni/stats-all.js:15381 static/js/zamboni/stats-all.js:15382 static/js/zamboni/stats-min.js:5
 msgid "Browse Listing Up and Coming Sort"
 msgstr "Elenchi ordinati per emergenti"
 
-#: static/js/impala/stats/csv_keys.js:105
+#: static/js/impala/stats/csv_keys.js:105 static/js/zamboni/stats-all.js:15386 static/js/zamboni/stats-min.js:5
 msgid "Total Amount Contributed"
 msgstr "Totale donazioni"
 
-#: static/js/impala/stats/csv_keys.js:106
+#: static/js/impala/stats/csv_keys.js:106 static/js/zamboni/stats-all.js:15387 static/js/zamboni/stats-min.js:5
 msgid "Average Contribution"
 msgstr "Donazione media"
 
-#: static/js/impala/stats/csv_keys.js:115
+#: static/js/impala/stats/csv_keys.js:115 static/js/zamboni/stats-all.js:15396 static/js/zamboni/stats-min.js:5
 msgid "Usage"
 msgstr "Uso"
 
-#: static/js/impala/stats/csv_keys.js:118
+#: static/js/impala/stats/csv_keys.js:118 static/js/zamboni/stats-all.js:15399 static/js/zamboni/stats-min.js:5
 msgid "Firefox"
 msgstr "Firefox"
 
-#: static/js/impala/stats/csv_keys.js:119
+#: static/js/impala/stats/csv_keys.js:119 static/js/zamboni/stats-all.js:15400 static/js/zamboni/stats-min.js:5
 msgid "Mozilla"
 msgstr "Mozilla"
 
-#: static/js/impala/stats/csv_keys.js:120
+#: static/js/impala/stats/csv_keys.js:120 static/js/zamboni/stats-all.js:15401 static/js/zamboni/stats-min.js:5
 msgid "Thunderbird"
 msgstr "Thunderbird"
 
-#: static/js/impala/stats/csv_keys.js:121
+#: static/js/impala/stats/csv_keys.js:121 static/js/zamboni/stats-all.js:15402 static/js/zamboni/stats-min.js:5
 msgid "Sunbird"
 msgstr "Sunbird"
 
-#: static/js/impala/stats/csv_keys.js:122
+#: static/js/impala/stats/csv_keys.js:122 static/js/zamboni/stats-all.js:15403 static/js/zamboni/stats-min.js:5
 msgid "SeaMonkey"
 msgstr "SeaMonkey"
 
-#: static/js/impala/stats/csv_keys.js:123
+#: static/js/impala/stats/csv_keys.js:123 static/js/zamboni/stats-all.js:15404 static/js/zamboni/stats-min.js:5
 msgid "Fennec"
 msgstr "Fennec"
 
-#: static/js/impala/stats/csv_keys.js:124
+#: static/js/impala/stats/csv_keys.js:124 static/js/zamboni/stats-all.js:15405 static/js/zamboni/stats-min.js:5
 msgid "Android"
 msgstr "Android"
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:129
+#: static/js/impala/stats/csv_keys.js:129 static/js/zamboni/stats-all.js:15410 static/js/zamboni/stats-min.js:5
 msgid "Downloads and Daily Users, last {0} days"
 msgstr "Download e utenti per giorno, ultimi {0} giorni"
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:131
+#: static/js/impala/stats/csv_keys.js:131 static/js/zamboni/stats-all.js:15412 static/js/zamboni/stats-min.js:5
 msgid "Downloads and Daily Users from {0} to {1}"
 msgstr "Download e utenti per giorno da {0} a {1}"
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:135
+#: static/js/impala/stats/csv_keys.js:135 static/js/zamboni/stats-all.js:15416 static/js/zamboni/stats-min.js:5
 msgid "Installs and Daily Users, last {0} days"
 msgstr "Installazioni e utenti giornalieri, ultimi {0} giorni"
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:137
+#: static/js/impala/stats/csv_keys.js:137 static/js/zamboni/stats-all.js:15418 static/js/zamboni/stats-min.js:5
 msgid "Installs and Daily Users from {0} to {1}"
 msgstr "Installazioni e utenti giornalieri dal {0} al {1}"
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:141
+#: static/js/impala/stats/csv_keys.js:141 static/js/zamboni/stats-all.js:15422 static/js/zamboni/stats-min.js:5
 msgid "Downloads, last {0} days"
 msgstr "Download, ultimi {0} giorni"
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:143
+#: static/js/impala/stats/csv_keys.js:143 static/js/zamboni/stats-all.js:15424 static/js/zamboni/stats-min.js:5
 msgid "Downloads from {0} to {1}"
 msgstr "Download da {0} a {1}"
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:147
+#: static/js/impala/stats/csv_keys.js:147 static/js/zamboni/stats-all.js:15428 static/js/zamboni/stats-min.js:5
 msgid "Daily Users, last {0} days"
 msgstr "Utenti per giorno, ultimi {0} giorni"
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:149
+#: static/js/impala/stats/csv_keys.js:149 static/js/zamboni/stats-all.js:15430 static/js/zamboni/stats-min.js:5
 msgid "Daily Users from {0} to {1}"
 msgstr "Utenti per giorno da {0} a {1}"
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:153
+#: static/js/impala/stats/csv_keys.js:153 static/js/zamboni/stats-all.js:15434 static/js/zamboni/stats-min.js:5
 msgid "Applications, last {0} days"
 msgstr "Applicazioni, ultimi {0} giorni"
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:155
+#: static/js/impala/stats/csv_keys.js:155 static/js/zamboni/stats-all.js:15436 static/js/zamboni/stats-min.js:5
 msgid "Applications from {0} to {1}"
 msgstr "Applicazioni da {0} a {1}"
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:159
+#: static/js/impala/stats/csv_keys.js:159 static/js/zamboni/stats-all.js:15440 static/js/zamboni/stats-min.js:5
 msgid "Platforms, last {0} days"
 msgstr "Piattaforme, ultimi {0} giorni"
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:161
+#: static/js/impala/stats/csv_keys.js:161 static/js/zamboni/stats-all.js:15442 static/js/zamboni/stats-min.js:5
 msgid "Platforms from {0} to {1}"
 msgstr "Piattaforme da {0} a {1}"
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:165
+#: static/js/impala/stats/csv_keys.js:165 static/js/zamboni/stats-all.js:15446 static/js/zamboni/stats-min.js:5
 msgid "Languages, last {0} days"
 msgstr "Lingue, ultimi {0} giorni"
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:167
+#: static/js/impala/stats/csv_keys.js:167 static/js/zamboni/stats-all.js:15448 static/js/zamboni/stats-min.js:5
 msgid "Languages from {0} to {1}"
 msgstr "Lingue da {0} a {1}"
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:171
+#: static/js/impala/stats/csv_keys.js:171 static/js/zamboni/stats-all.js:15452 static/js/zamboni/stats-min.js:5
 msgid "Add-on Versions, last {0} days"
 msgstr "Versioni componenti aggiuntivi, ultimi {0} giorni"
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:173
+#: static/js/impala/stats/csv_keys.js:173 static/js/zamboni/stats-all.js:15454 static/js/zamboni/stats-min.js:5
 msgid "Add-on Versions from {0} to {1}"
 msgstr "Versioni componenti aggiuntivi dal {0} al {1}"
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:177
+#: static/js/impala/stats/csv_keys.js:177 static/js/zamboni/stats-all.js:15458 static/js/zamboni/stats-min.js:5
 msgid "Add-on Status, last {0} days"
 msgstr "Stato componente aggiuntivo, ultimi {0} giorni"
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:179
+#: static/js/impala/stats/csv_keys.js:179 static/js/zamboni/stats-all.js:15460 static/js/zamboni/stats-min.js:5
 msgid "Add-on Status from {0} to {1}"
 msgstr "Stato componente aggiuntivo da {0} a {1}"
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:183
+#: static/js/impala/stats/csv_keys.js:183 static/js/zamboni/stats-all.js:15464 static/js/zamboni/stats-min.js:5
 msgid "Download Sources, last {0} days"
 msgstr "Sorgenti download, ultimi {0} giorni"
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:185
+#: static/js/impala/stats/csv_keys.js:185 static/js/zamboni/stats-all.js:15466 static/js/zamboni/stats-min.js:5
 msgid "Download Sources from {0} to {1}"
 msgstr "Sorgenti download da {0} a {1}"
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:189
+#: static/js/impala/stats/csv_keys.js:189 static/js/zamboni/stats-all.js:15470 static/js/zamboni/stats-min.js:5
 msgid "Contributions, last {0} days"
 msgstr "Donazioni, ultimi {0} giorni"
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:191
+#: static/js/impala/stats/csv_keys.js:191 static/js/zamboni/stats-all.js:15472 static/js/zamboni/stats-min.js:5
 msgid "Contributions from {0} to {1}"
 msgstr "Donazioni da {0} a {1}"
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:195
+#: static/js/impala/stats/csv_keys.js:195 static/js/zamboni/stats-all.js:15476 static/js/zamboni/stats-min.js:5
 msgid "Site Metrics, last {0} days"
 msgstr "Statistiche del sito, ultimi {0} giorni"
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:197
+#: static/js/impala/stats/csv_keys.js:197 static/js/zamboni/stats-all.js:15478 static/js/zamboni/stats-min.js:5
 msgid "Site Metrics from {0} to {1}"
 msgstr "Statistiche del sito dal {0} al {1}"
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:201
+#: static/js/impala/stats/csv_keys.js:201 static/js/zamboni/stats-all.js:15482 static/js/zamboni/stats-min.js:5
 msgid "Add-ons in Use, last {0} days"
 msgstr "Add-on in uso, ultimi {0} giorni"
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:203
+#: static/js/impala/stats/csv_keys.js:203 static/js/zamboni/stats-all.js:15484 static/js/zamboni/stats-min.js:5
 msgid "Add-ons in Use from {0} to {1}"
 msgstr "Componenti aggiuntivi in uso dal {0} al {1}"
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:207
+#: static/js/impala/stats/csv_keys.js:207 static/js/zamboni/stats-all.js:15488 static/js/zamboni/stats-min.js:5
 msgid "Add-ons Downloaded, last {0} days"
 msgstr "Componenti aggiuntivi scaricati, ultimi {0} giorni"
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:209
+#: static/js/impala/stats/csv_keys.js:209 static/js/zamboni/stats-all.js:15490 static/js/zamboni/stats-min.js:5
 msgid "Add-ons Downloaded from {0} to {1}"
 msgstr "Componenti aggiuntivi scaricati dal {0} al {1}"
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:213
+#: static/js/impala/stats/csv_keys.js:213 static/js/zamboni/stats-all.js:15494 static/js/zamboni/stats-min.js:5
 msgid "Add-ons Created, last {0} days"
 msgstr "Componenti aggiuntivi sviluppati, ultimi {0} giorni"
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:215
+#: static/js/impala/stats/csv_keys.js:215 static/js/zamboni/stats-all.js:15496 static/js/zamboni/stats-min.js:5
 msgid "Add-ons Created from {0} to {1}"
 msgstr "Componenti aggiuntivi sviluppati dal {0} al {1}"
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:219
+#: static/js/impala/stats/csv_keys.js:219 static/js/zamboni/stats-all.js:15500 static/js/zamboni/stats-min.js:5
 msgid "Add-ons Updated, last {0} days"
 msgstr "Add-on Aggiornato, ultimi {0} giorni"
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:221
+#: static/js/impala/stats/csv_keys.js:221 static/js/zamboni/stats-all.js:15502 static/js/zamboni/stats-min.js:5
 msgid "Add-ons Updated from {0} to {1}"
 msgstr "Add-on Aggiornati dal {0} al {1}"
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:225
+#: static/js/impala/stats/csv_keys.js:225 static/js/zamboni/stats-all.js:15506 static/js/zamboni/stats-min.js:5
 msgid "Reviews Written, last {0} days"
 msgstr "Recensioni Scritte, da {0} giorni"
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:227
+#: static/js/impala/stats/csv_keys.js:227 static/js/zamboni/stats-all.js:15508 static/js/zamboni/stats-min.js:5
 msgid "Reviews Written from {0} to {1}"
 msgstr "Recensioni Scritte dal {0} al {1}"
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:231
+#: static/js/impala/stats/csv_keys.js:231 static/js/zamboni/stats-all.js:15512 static/js/zamboni/stats-min.js:5
 msgid "User Signups, last {0} days"
 msgstr "Utenti registrati, ultimi {0} giorni"
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:233
+#: static/js/impala/stats/csv_keys.js:233 static/js/zamboni/stats-all.js:15514 static/js/zamboni/stats-min.js:5
 msgid "User Signups from {0} to {1}"
 msgstr "Utenti registrati dal {0} al {1}"
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:237
+#: static/js/impala/stats/csv_keys.js:237 static/js/zamboni/stats-all.js:15518 static/js/zamboni/stats-min.js:5
 msgid "Collections Created, last {0} days"
 msgstr "Collezione Create, ultimi {0} giorni"
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:239
+#: static/js/impala/stats/csv_keys.js:239 static/js/zamboni/stats-all.js:15520 static/js/zamboni/stats-min.js:5
 msgid "Collections Created from {0} to {1}"
 msgstr "Collezioni Create dal {0} al {1}"
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:243
+#: static/js/impala/stats/csv_keys.js:243 static/js/zamboni/stats-all.js:15524 static/js/zamboni/stats-min.js:5
 msgid "Subscribers, last {0} days"
 msgstr "Iscritti, ultimi {0} giorni"
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:245
+#: static/js/impala/stats/csv_keys.js:245 static/js/zamboni/stats-all.js:15526 static/js/zamboni/stats-min.js:5
 msgid "Subscribers from {0} to {1}"
 msgstr "Iscritti dal {0} al {1}"
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:249
+#: static/js/impala/stats/csv_keys.js:249 static/js/zamboni/stats-all.js:15530 static/js/zamboni/stats-min.js:5
 msgid "Ratings, last {0} days"
 msgstr "Votazioni, ultimi {0} giorni"
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:251
+#: static/js/impala/stats/csv_keys.js:251 static/js/zamboni/stats-all.js:15532 static/js/zamboni/stats-min.js:5
 msgid "Ratings from {0} to {1}"
 msgstr "Votazioni dal {0} al {1}"
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:255
+#: static/js/impala/stats/csv_keys.js:255 static/js/zamboni/stats-all.js:15536 static/js/zamboni/stats-min.js:5
 msgid "Sales, last {0} days"
 msgstr "Vendite, ultimi {0} giorni"
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:257
+#: static/js/impala/stats/csv_keys.js:257 static/js/zamboni/stats-all.js:15538 static/js/zamboni/stats-min.js:5
 msgid "Sales from {0} to {1}"
 msgstr "vendite dal {0} al {1}"
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:261
+#: static/js/impala/stats/csv_keys.js:261 static/js/zamboni/stats-all.js:15542 static/js/zamboni/stats-min.js:5
 msgid "Installs, last {0} days"
 msgstr "Installazioni, ultimi {0} giorni"
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:263
+#: static/js/impala/stats/csv_keys.js:263 static/js/zamboni/stats-all.js:15544 static/js/zamboni/stats-min.js:5
 msgid "Installs from {0} to {1}"
 msgstr "Installazioni dal {0} al {1}"
 
 #. L10n: {0} and {1} are integers.
-#: static/js/impala/stats/csv_keys.js:269
+#: static/js/impala/stats/csv_keys.js:269 static/js/zamboni/stats-all.js:15550 static/js/zamboni/stats-min.js:5
 msgid "<b>{0}</b> in last {1} days"
 msgstr "<b>{0}</b> negli ultimi {1} giorni"
 
 #. L10n: {0} is an integer and {1} and {2} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:271 static/js/impala/stats/csv_keys.js:277
+#: static/js/impala/stats/csv_keys.js:271 static/js/impala/stats/csv_keys.js:277 static/js/zamboni/stats-all.js:15552 static/js/zamboni/stats-all.js:15558 static/js/zamboni/stats-min.js:5
 msgid "<b>{0}</b> from {1} to {2}"
 msgstr "<b>{0}</b> da {1} a {2}"
 
 #. L10n: {0} and {1} are integers.
-#: static/js/impala/stats/csv_keys.js:275
+#: static/js/impala/stats/csv_keys.js:275 static/js/zamboni/stats-all.js:15556 static/js/zamboni/stats-min.js:5
 msgid "<b>{0}</b> average in last {1} days"
 msgstr "media di <b>{0}</b> negli ultimi {1} giorni"
 
-#: static/js/impala/stats/overview.js:19
+#: static/js/impala/stats/overview.js:19 static/js/zamboni/stats-all.js:16469 static/js/zamboni/stats-min.js:5
 msgid "No data available."
 msgstr "Nessun dato disponibile."
 
-#: static/js/impala/stats/table.js:74
+#: static/js/impala/stats/table.js:74 static/js/zamboni/stats-all.js:17209 static/js/zamboni/stats-min.js:5
 msgid "Date"
 msgstr "Data"
 
-#: static/js/impala/stats/topchart.js:96
+#: static/js/impala/stats/topchart.js:96 static/js/zamboni/stats-all.js:16600 static/js/zamboni/stats-min.js:5
 msgid "Other"
 msgstr "Altro"
 
-#: static/js/zamboni/admin_validation.js:24 static/js/zamboni/devhub.js:1229 static/js/zamboni/editors.js:295
+#: static/js/zamboni/admin-all.js:180 static/js/zamboni/admin-min.js:1 static/js/zamboni/admin_validation.js:24 static/js/zamboni/devhub-all.js:2408 static/js/zamboni/devhub-min.js:2
+#: static/js/zamboni/devhub.js:1229 static/js/zamboni/editors-all.js:15576 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:295
 msgid "Select an application first"
 msgstr "Selezionare un’applicazione"
 
-#: static/js/zamboni/admin_validation.js:51
+#: static/js/zamboni/admin-all.js:207 static/js/zamboni/admin-min.js:1 static/js/zamboni/admin_validation.js:51
 msgid "Set {0} add-on to a max version of {1} and email the author."
 msgid_plural "Set {0} add-ons to a max version of {1} and email the authors."
 msgstr[0] "Imposta la maxversion del componente aggiuntivo {0} a {1} e invia email all’autore."
 msgstr[1] "Imposta la maxversion dei componenti aggiuntivi {0} a {1} e invia email agli autori."
 
-#: static/js/zamboni/admin_validation.js:54
+#: static/js/zamboni/admin-all.js:210 static/js/zamboni/admin-min.js:1 static/js/zamboni/admin_validation.js:54
 msgid "Email author of {2} add-on which failed validation."
 msgid_plural "Email authors of {2} add-ons which failed validation."
 msgstr[0] "Invia una email all’autore del componente aggiuntivo {2} che non ha superato la validazione."
 msgstr[1] "Invia una email agli autori del componente aggiuntivo {2} che non ha superato la validazione."
 
-#. L10n: {0} is an app name like Firefox.
-#: static/js/zamboni/buttons.js:66
-msgid "Accept and Install"
-msgstr "Accetta e installa"
-
-#: static/js/zamboni/buttons.js:66
-msgid "Add to {0}"
-msgstr "Aggiungi a {0}"
-
-#: static/js/zamboni/buttons.js:71
-msgid "Download Now"
-msgstr "Scarica ora"
-
-#: static/js/zamboni/buttons.js:112
-msgid "Add-on has not been updated to support default-to-compatible."
-msgstr "Questo componente aggiuntivo non è stato aggiornato per essere sempre compatibile come impostazione predefinita."
-
-#: static/js/zamboni/buttons.js:117
-msgid "You need to be using Firefox 10.0 or higher."
-msgstr "È necessario utilizzare Firefox 10 o superiore."
-
-#: static/js/zamboni/buttons.js:129
-msgid "Mozilla has marked this version as incompatible with your Firefox version."
-msgstr "Mozilla ha contrassegnato questa versione come non compatibile con la versione di Firefox in uso."
-
-#. L10n: {0} is an platform like Windows or Linux.
-#: static/js/zamboni/buttons.js:210
-msgid "Install for {0} anyway"
-msgstr "Installa comunque per {0}"
-
-#: static/js/zamboni/buttons.js:210
-msgid "Download for {0} anyway"
-msgstr "Scarica comunque per {0}"
-
-#: static/js/zamboni/buttons.js:267
-msgid "Not available for your platform"
-msgstr "Non disponibile per la tua piattaforma"
-
-#. L10n: {0} is an app name, {1} is the app version.
-#: static/js/zamboni/buttons.js:278 static/js/zamboni/buttons.js:315
-msgid "Not available for {0} {1}"
-msgstr "Non disponibile per {0} {1}"
-
-#: static/js/zamboni/buttons.js:341
-msgid "Works with {app} {min} - {max}"
-msgstr "Compatibile con {app} {min} - {max}"
-
-#: static/js/zamboni/buttons.js:343
-msgid "View other versions"
-msgstr "Mostra altre versioni"
-
-#: static/js/zamboni/buttons.js:391
-msgid "Only with Firefox — Get Firefox Now!"
-msgstr "Solo con Firefox — Scaricalo subito!"
-
-#: static/js/zamboni/buttons.js:507 static/js/zamboni/mobile/buttons.js:43
-msgid "Sorry, you need a Mozilla-based browser (such as Firefox) to install a search plugin."
-msgstr "Bisogna utilizzare un browser, come Firefox, basato su Mozilla per installare un plugin di ricerca."
-
-#: static/js/zamboni/collections.js:229
-msgid "Adding to Favorites&hellip;"
-msgstr "Aggiunta ai Preferiti in corso&hellip;"
-
-#: static/js/zamboni/collections.js:232
-msgid "Removing Favorite&hellip;"
-msgstr "Eliminazione preferito&hellip;"
-
-#: static/js/zamboni/collections.js:235
-msgid "Add to Favorites"
-msgstr "Aggiungi a Preferiti"
-
-#: static/js/zamboni/collections.js:238
-msgid "Remove from Favorites"
-msgstr "Elimina da Preferiti"
-
-#: static/js/zamboni/collections.js:303
-msgid "Pending"
-msgstr "In attesa"
-
-#: static/js/zamboni/collections.js:304
-msgid "Add a comment"
-msgstr "Aggiungi un commento"
-
-#: static/js/zamboni/collections.js:304
-msgid "Comment"
-msgstr "Commento"
-
-#: static/js/zamboni/collections.js:305
-msgid "Remove this add-on from the collection"
-msgstr "Rimuovi questo componente aggiuntivo dalla raccolta"
-
-#: static/js/zamboni/collections.js:305 static/js/zamboni/collections.js:334
-msgid "Remove"
-msgstr "Elimina"
-
-#: static/js/zamboni/collections.js:334
-msgid "Remove this user as a contributor"
-msgstr "Elimina questo utente da collaboratore"
-
-#: static/js/zamboni/collections.js:346
-msgid "An email address is required."
-msgstr "È necessario un indirizzo email."
-
-#: static/js/zamboni/collections.js:364
-msgid "You cannot add yourself as a contributor."
-msgstr "Non puoi aggiungere te stesso come collaboratore."
-
-#: static/js/zamboni/collections.js:366
-msgid "You have already added that user."
-msgstr "Questo utente è stato già aggiunto."
-
-#: static/js/zamboni/collections.js:573
-msgid "Add to favorites"
-msgstr "Aggiungi ai preferiti"
-
-#: static/js/zamboni/collections.js:577
-msgid "Remove from favorites"
-msgstr "Elimina dai preferiti"
-
-#: static/js/zamboni/collections.js:604
-msgid "Stop following"
-msgstr "Non seguire più"
-
-#: static/js/zamboni/devhub.js:110
+#: static/js/zamboni/devhub-all.js:1289 static/js/zamboni/devhub-min.js:1 static/js/zamboni/devhub.js:110
 msgid "Your browser does not support the video tag"
 msgstr "Il browser in uso non supporta il tag video"
 
-#: static/js/zamboni/devhub.js:371
+#: static/js/zamboni/devhub-all.js:1550 static/js/zamboni/devhub-min.js:1 static/js/zamboni/devhub.js:371
 msgid "Changes Saved"
 msgstr "Modifiche salvate"
 
-#: static/js/zamboni/devhub.js:387
+#: static/js/zamboni/devhub-all.js:1566 static/js/zamboni/devhub-min.js:1 static/js/zamboni/devhub.js:387
 msgid "Enter a new author's email address"
 msgstr "Inserire l’indirizzo email di un nuovo autore"
 
-#: static/js/zamboni/devhub.js:536
+#: static/js/zamboni/devhub-all.js:1715 static/js/zamboni/devhub-min.js:1 static/js/zamboni/devhub.js:536
 msgid "There was an error uploading your file."
 msgstr "Si è verificato un errore durante il caricamento del file."
 
-#: static/js/zamboni/devhub.js:681
+#: static/js/zamboni/devhub-all.js:1860 static/js/zamboni/devhub-min.js:1 static/js/zamboni/devhub.js:681
 msgid "{files} file"
 msgid_plural "{files} files"
 msgstr[0] "{files} file"
 msgstr[1] "{files} file"
 
-#: static/js/zamboni/devhub.js:684
+#: static/js/zamboni/devhub-all.js:1863 static/js/zamboni/devhub-min.js:1 static/js/zamboni/devhub.js:684
 msgid "{reviews} user review"
 msgid_plural "{reviews} user reviews"
 msgstr[0] "{reviews} recensione"
 msgstr[1] "{reviews} recensioni"
 
-#: static/js/zamboni/devhub.js:796
+#: static/js/zamboni/devhub-all.js:1975 static/js/zamboni/devhub-min.js:2 static/js/zamboni/devhub.js:796
 msgid "Learn more"
 msgstr "Ulteriori informazioni"
 
-#: static/js/zamboni/devhub.js:800
+#: static/js/zamboni/devhub-all.js:1979 static/js/zamboni/devhub-min.js:2 static/js/zamboni/devhub.js:800
 msgid "Example"
 msgstr "Esempio"
 
-#: static/js/zamboni/devhub.js:1130
+#: static/js/zamboni/devhub-all.js:2309 static/js/zamboni/devhub-min.js:2 static/js/zamboni/devhub.js:1130
 msgid "Image changes being processed"
 msgstr "Elaborazione in corso delle modifiche alle immagini"
 
-#: static/js/zamboni/devhub.js:1280
+#: static/js/zamboni/devhub-all.js:2459 static/js/zamboni/devhub-min.js:2 static/js/zamboni/devhub.js:1280
 msgid "Must be a valid e-mail address."
 msgstr "L’indirizzo email deve essere valido."
 
-#: static/js/zamboni/devhub_search.js:8
-msgid "No results found."
-msgstr "Nessun risultato trovato."
-
-#: static/js/zamboni/editors.js:121
-msgid "{name} was viewing this page first."
-msgstr "{name} stava visualizzando questa pagina per primo."
-
-#: static/js/zamboni/editors.js:171
-msgid "Receipt checked by app."
-msgstr "Ricevuta verificata dalla App."
-
-#: static/js/zamboni/editors.js:173
-msgid "Receipt was not checked by app."
-msgstr "La ricevuta non è stata verificata dalla App."
-
-#: static/js/zamboni/editors.js:244
-msgid "{name} was viewing this add-on first."
-msgstr "{name} stava visualizzando questo componente aggiuntivo per primo."
-
-#: static/js/zamboni/editors.js:255
-msgid "Loading&hellip;"
-msgstr "Caricamento in corso&hellip;"
-
-#: static/js/zamboni/editors.js:260
-msgid "Version Notes"
-msgstr "Note di versione"
-
-#: static/js/zamboni/editors.js:265
-msgid "Notes for Reviewers"
-msgstr "Note per i revisori"
-
-#: static/js/zamboni/editors.js:270
-msgid "No version notes found"
-msgstr "Note di versione non disponibili"
-
-#: static/js/zamboni/editors.js:330
-msgid "Average Reviews"
-msgstr "Media Recensioni"
-
-#: static/js/zamboni/editors.js:386
-msgid "Number of Reviews"
-msgstr "Numero recensioni"
-
-#: static/js/zamboni/editors.js:445
-msgid "Error loading translation"
-msgstr "Si è verificato un errore durante il caricamento della traduzione"
-
-#: static/js/zamboni/files.js:411 static/js/zamboni/validator.js:261
-msgid "Ignore this message in future updates"
-msgstr "Ignorare questo messaggio per gli aggiornamenti futuri"
-
-#: static/js/zamboni/files.js:417 static/js/zamboni/validator.js:284
-msgid "Severity for automated signing:"
-msgstr "Livello di sicurezza della firma digitale automatica:"
-
-#: static/js/zamboni/global.js:410
-msgid "Loading..."
-msgstr "Caricamento…"
-
-#. L10n: {0} is the number of characters left.
-#: static/js/zamboni/global.js:474
-msgid "<b>{0}</b> character left."
-msgid_plural "<b>{0}</b> characters left."
-msgstr[0] "<b>{0}</b> carattere disponibile."
-msgstr[1] "<b>{0}</b> caratteri disponibili."
-
-#: static/js/zamboni/init.js:28
-msgid "This feature is temporarily disabled while we perform website maintenance. Please check back a little later."
-msgstr "Questa funzione è momentaneamente disattivata per dei lavori di manutenzione. Riprovare più tardi."
-
-#: static/js/zamboni/l10n.js:45
-msgid "Remove this localization"
-msgstr "Rimuovi questa localizzazione"
-
-#: static/js/zamboni/password-strength.js:20
-msgid "Password strength:"
-msgstr "Complessità password:"
-
-#: static/js/zamboni/password-strength.js:26
-msgid "At least {0} character left."
-msgid_plural "At least {0} characters left."
-msgstr[0] "Almeno {0} carattere ancora disponibile."
-msgstr[1] "Almeno {0} caratteri ancora disponibili."
-
-#: static/js/zamboni/themes_review.js:176
-msgid "Requested Info"
-msgstr "Informazioni richieste"
-
-#: static/js/zamboni/themes_review.js:177
-msgid "Flagged"
-msgstr "Segnalato"
-
-#: static/js/zamboni/themes_review.js:178
-msgid "Duplicate"
-msgstr "Duplicato"
-
-#: static/js/zamboni/themes_review.js:179
-msgid "Rejected"
-msgstr "Rifiutato"
-
-#: static/js/zamboni/themes_review.js:180
-msgid "Approved"
-msgstr "Approvato"
-
-#: static/js/zamboni/themes_review.js:424
-msgid "No results found"
-msgstr "Nessun risultato trovato"
-
-#: static/js/zamboni/themes_review_templates.js:31
-msgid "Theme"
-msgstr "Tema"
-
-#: static/js/zamboni/themes_review_templates.js:33
-msgid "Reviewer"
-msgstr "Autore recensione"
-
-#: static/js/zamboni/themes_review_templates.js:35
-msgid "Status"
-msgstr "Stato"
-
-#: static/js/zamboni/validator.js:80
+#: static/js/zamboni/devhub-all.js:2613 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:80
 msgid "All tests passed successfully."
 msgstr "Tutti i test superati con successo."
 
-#: static/js/zamboni/validator.js:83 static/js/zamboni/validator.js:478
+#: static/js/zamboni/devhub-all.js:2616 static/js/zamboni/devhub-all.js:3011 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:83 static/js/zamboni/validator.js:478
 msgid "These tests were not run."
 msgstr "Alcuni test non sono stati eseguiti."
 
-#: static/js/zamboni/validator.js:131 static/js/zamboni/validator.js:144
+#: static/js/zamboni/devhub-all.js:2664 static/js/zamboni/devhub-all.js:2677 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:131 static/js/zamboni/validator.js:144
 msgid "Tests"
 msgstr "Test"
 
-#: static/js/zamboni/validator.js:246 static/js/zamboni/validator.js:575 static/js/zamboni/validator.js:594
+#: static/js/zamboni/devhub-all.js:2779 static/js/zamboni/devhub-all.js:3108 static/js/zamboni/devhub-all.js:3127 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:246
+#: static/js/zamboni/validator.js:575 static/js/zamboni/validator.js:594
 msgid "Error"
 msgstr "Errore"
 
-#: static/js/zamboni/validator.js:247
+#: static/js/zamboni/devhub-all.js:2780 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:247
 msgid "Warning"
 msgstr "Avviso"
 
-#: static/js/zamboni/validator.js:299
+#: static/js/zamboni/devhub-all.js:2794 static/js/zamboni/devhub-min.js:2 static/js/zamboni/files-all.js:5657 static/js/zamboni/files-min.js:3 static/js/zamboni/files.js:411
+#: static/js/zamboni/validator.js:261
+msgid "Ignore this message in future updates"
+msgstr "Ignorare questo messaggio per gli aggiornamenti futuri"
+
+#: static/js/zamboni/devhub-all.js:2817 static/js/zamboni/devhub-min.js:2 static/js/zamboni/files-all.js:5663 static/js/zamboni/files-min.js:3 static/js/zamboni/files.js:417
+#: static/js/zamboni/validator.js:284
+msgid "Severity for automated signing:"
+msgstr "Livello di sicurezza della firma digitale automatica:"
+
+#: static/js/zamboni/devhub-all.js:2832 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:299
 msgid "Suggestions for passing automated signing:"
 msgstr "Suggerimenti per superare il processo automatico di firma digitale:"
 
-#: static/js/zamboni/validator.js:387
+#: static/js/zamboni/devhub-all.js:2920 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:387
 msgid "Compatibility Tests"
 msgstr "Test di compatibilità"
 
-#: static/js/zamboni/validator.js:466
+#: static/js/zamboni/devhub-all.js:2999 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:466
 msgid "Add-on failed validation."
 msgstr "Il componente aggiuntivo non ha superato i controlli."
 
-#: static/js/zamboni/validator.js:468
+#: static/js/zamboni/devhub-all.js:3001 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:468
 msgid "Add-on passed validation."
 msgstr "Il componente aggiuntivo ha superato i controlli."
 
-#: static/js/zamboni/validator.js:481
+#: static/js/zamboni/devhub-all.js:3014 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:481
 msgid "{0} error"
 msgid_plural "{0} errors"
 msgstr[0] "{0} errore"
 msgstr[1] "{0} errori"
 
-#: static/js/zamboni/validator.js:483
+#: static/js/zamboni/devhub-all.js:3016 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:483
 msgid "{0} warning"
 msgid_plural "{0} warnings"
 msgstr[0] "{0} avviso"
 msgstr[1] "{0} avvisi"
 
-#: static/js/zamboni/validator.js:485
+#: static/js/zamboni/devhub-all.js:3018 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:485
 msgid "{0} notice"
 msgid_plural "{0} notices"
 msgstr[0] "{0} avviso"
 msgstr[1] "{0} avvisi"
 
-#: static/js/zamboni/validator.js:577
+#: static/js/zamboni/devhub-all.js:3110 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:577
 msgid "Validation task could not complete or completed with errors"
 msgstr "Impossibile completare il controllo o controllo completato con errori"
 
-#: static/js/zamboni/validator.js:595
+#: static/js/zamboni/devhub-all.js:3128 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:595
 msgid "Internal server error"
 msgstr "Errore interno del server"
 
-#: static/js/zamboni/mobile/buttons.js:52
+#: static/js/zamboni/devhub_search.js:8
+msgid "No results found."
+msgstr "Nessun risultato trovato."
+
+#: static/js/zamboni/editors-all.js:15402 static/js/zamboni/editors-min.js:4 static/js/zamboni/editors.js:121
+msgid "{name} was viewing this page first."
+msgstr "{name} stava visualizzando questa pagina per primo."
+
+#: static/js/zamboni/editors-all.js:15452 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:171
+msgid "Receipt checked by app."
+msgstr "Ricevuta verificata dalla App."
+
+#: static/js/zamboni/editors-all.js:15454 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:173
+msgid "Receipt was not checked by app."
+msgstr "La ricevuta non è stata verificata dalla App."
+
+#: static/js/zamboni/editors-all.js:15525 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:244
+msgid "{name} was viewing this add-on first."
+msgstr "{name} stava visualizzando questo componente aggiuntivo per primo."
+
+#: static/js/zamboni/editors-all.js:15536 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:255
+msgid "Loading&hellip;"
+msgstr "Caricamento in corso&hellip;"
+
+#: static/js/zamboni/editors-all.js:15541 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:260
+msgid "Version Notes"
+msgstr "Note di versione"
+
+#: static/js/zamboni/editors-all.js:15546 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:265
+msgid "Notes for Reviewers"
+msgstr "Note per i revisori"
+
+#: static/js/zamboni/editors-all.js:15551 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:270
+msgid "No version notes found"
+msgstr "Note di versione non disponibili"
+
+#: static/js/zamboni/editors-all.js:15611 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:330
+msgid "Average Reviews"
+msgstr "Media Recensioni"
+
+#: static/js/zamboni/editors-all.js:15667 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:386
+msgid "Number of Reviews"
+msgstr "Numero recensioni"
+
+#: static/js/zamboni/editors-all.js:15726 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:445
+msgid "Error loading translation"
+msgstr "Si è verificato un errore durante il caricamento della traduzione"
+
+#: static/js/zamboni/editors-all.js:15975 static/js/zamboni/editors-min.js:5 static/js/zamboni/themes_review_templates.js:31
+msgid "Theme"
+msgstr "Tema"
+
+#: static/js/zamboni/editors-all.js:15977 static/js/zamboni/editors-min.js:5 static/js/zamboni/themes_review_templates.js:33
+msgid "Reviewer"
+msgstr "Autore recensione"
+
+#: static/js/zamboni/editors-all.js:15979 static/js/zamboni/editors-min.js:5 static/js/zamboni/themes_review_templates.js:35
+msgid "Status"
+msgstr "Stato"
+
+#: static/js/zamboni/editors-all.js:16196 static/js/zamboni/editors-min.js:5 static/js/zamboni/themes_review.js:176
+msgid "Requested Info"
+msgstr "Informazioni richieste"
+
+#: static/js/zamboni/editors-all.js:16197 static/js/zamboni/editors-min.js:5 static/js/zamboni/themes_review.js:177
+msgid "Flagged"
+msgstr "Segnalato"
+
+#: static/js/zamboni/editors-all.js:16198 static/js/zamboni/editors-min.js:5 static/js/zamboni/themes_review.js:178
+msgid "Duplicate"
+msgstr "Duplicato"
+
+#: static/js/zamboni/editors-all.js:16199 static/js/zamboni/editors-min.js:5 static/js/zamboni/themes_review.js:179
+msgid "Rejected"
+msgstr "Rifiutato"
+
+#: static/js/zamboni/editors-all.js:16200 static/js/zamboni/editors-min.js:5 static/js/zamboni/themes_review.js:180
+msgid "Approved"
+msgstr "Approvato"
+
+#: static/js/zamboni/editors-all.js:16444 static/js/zamboni/editors-min.js:5 static/js/zamboni/themes_review.js:424
+msgid "No results found"
+msgstr "Nessun risultato trovato"
+
+#: static/js/zamboni/mobile-all.js:15186 static/js/zamboni/mobile/buttons.js:52
 msgid "Not Updated for {0} {1}"
 msgstr "Non aggiornato per {0} {1}"
 
-#: static/js/zamboni/mobile/buttons.js:53
+#: static/js/zamboni/mobile-all.js:15187 static/js/zamboni/mobile/buttons.js:53
 msgid "Requires Newer Version of {0}"
 msgstr "Richiede una versione più recente di {0}"
 
-#: static/js/zamboni/mobile/buttons.js:54
+#: static/js/zamboni/mobile-all.js:15188 static/js/zamboni/mobile/buttons.js:54
 msgid "Unreviewed"
 msgstr "Non revisionato"
 
-#: static/js/zamboni/mobile/buttons.js:55
+#: static/js/zamboni/mobile-all.js:15189 static/js/zamboni/mobile/buttons.js:55
 msgid "Experimental <span>(Learn More)</span>"
 msgstr "Sperimentale <span>(ulteriori informazioni)</span>"
 
-#: static/js/zamboni/mobile/buttons.js:56 static/js/zamboni/mobile/buttons.js:57
+#: static/js/zamboni/mobile-all.js:15190 static/js/zamboni/mobile-all.js:15191 static/js/zamboni/mobile/buttons.js:56 static/js/zamboni/mobile/buttons.js:57
 msgid "Not Available for {0}"
 msgstr "Non disponibile per {0}"
 
-#: static/js/zamboni/mobile/buttons.js:58
+#: static/js/zamboni/mobile-all.js:15192 static/js/zamboni/mobile/buttons.js:58
 msgid "Experimental"
 msgstr "Sperimentale"
 
-#: static/js/zamboni/mobile/buttons.js:59
+#: static/js/zamboni/mobile-all.js:15193 static/js/zamboni/mobile/buttons.js:59
 msgid "Themes Require Newer Version of {0}"
 msgstr "Questi temi richiedono una versione più recente di {0}"
 
-#: static/js/zamboni/mobile/buttons.js:60
+#: static/js/zamboni/mobile-all.js:15194 static/js/zamboni/mobile/buttons.js:60
 msgid "Themes Require {0}"
 msgstr "Questi temi richiedono {0}"
 
-#: static/js/zamboni/mobile/buttons.js:105
+#: static/js/zamboni/mobile-all.js:15239 static/js/zamboni/mobile/buttons.js:105
 msgid "Installing..."
 msgstr "Installazione in corso…"
 
-#: static/js/zamboni/mobile/buttons.js:125
+#: static/js/zamboni/mobile-all.js:15259 static/js/zamboni/mobile/buttons.js:125
 msgid "This add-on has been preliminarily reviewed by Mozilla."
 msgstr "Questo componente aggiuntivo è stato sottoposto a una revisione preliminare da Mozilla."
 
-#: static/js/zamboni/mobile/buttons.js:250
+#: static/js/zamboni/mobile-all.js:15384 static/js/zamboni/mobile/buttons.js:250
 msgid "Keep it"
 msgstr "Mantieni"
 
-#: static/js/zamboni/mobile/general.js:344
+#: static/js/zamboni/mobile-all.js:16049 static/js/zamboni/mobile-min.js:6 static/js/zamboni/mobile/general.js:344
 msgid "You're trying it on!"
 msgstr "La stai già provando!"
 
-#: static/js/zamboni/mobile/general.js:356
+#: static/js/zamboni/mobile-all.js:16061 static/js/zamboni/mobile-min.js:6 static/js/zamboni/mobile/general.js:356
 msgid "Added to Firefox"
 msgstr "Aggiunto a Firefox"
-

--- a/locale/ja/LC_MESSAGES/django.po
+++ b/locale/ja/LC_MESSAGES/django.po
@@ -6,70 +6,71 @@ msgid ""
 msgstr ""
 "Project-Id-Version: REMORA 0.1\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2016-02-24 21:23+0000\n"
+"POT-Creation-Date: 2016-04-18 15:47+0000\n"
 "PO-Revision-Date: 2016-03-19 14:22+0000\n"
 "Last-Translator: Kohei Yoshino <kohei.yoshino@gmail.com>\n"
 "Language-Team: Japanese\n"
+"Language: \n"
 "MIME-Version: 1.0\n"
-"Content-Type: text/plain; charset=utf-8\n"
+"Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Generated-By: Babel 2.2.0\n"
 
-#: src/olympia/accounts/views.py:52
+#: src/olympia/accounts/views.py:54
 msgid "Your log in attempt could not be parsed. Please try again."
 msgstr "あなたのログイン試行は解析されませんでした。再度お試しください。"
 
-#: src/olympia/accounts/views.py:54
+#: src/olympia/accounts/views.py:56
 msgid "Your Firefox Account could not be found. Please try again."
 msgstr "あなたの Firefox アカウントが見つかりませんでした。再度お試しください。"
 
-#: src/olympia/accounts/views.py:55
+#: src/olympia/accounts/views.py:57
 msgid "You could not be logged in. Please try again."
 msgstr "ログインできませんでした。再度お試しください。"
 
-#: src/olympia/accounts/views.py:57
+#: src/olympia/accounts/views.py:59
 msgid "Your account has already been migrated to Firefox Accounts."
 msgstr "あなたのアカウントは既に Firefox アカウントへ統合されています。"
 
-#: src/olympia/accounts/views.py:59
+#: src/olympia/accounts/views.py:61
 msgid "Your Firefox Account already exists on this site."
 msgstr "あなたの Firefox アカウントは既に当サイト上に存在します。"
 
-#: src/olympia/accounts/views.py:108
+#: src/olympia/accounts/views.py:110
 msgid "Great job!"
 msgstr "ログイン完了！"
 
-#: src/olympia/accounts/views.py:109
+#: src/olympia/accounts/views.py:111
 msgid "You can now log in to Add-ons with your Firefox Account."
 msgstr "今後 Firefox アカウントで Add-ons サイトへログインできます。"
 
-#: src/olympia/accounts/views.py:121
+#: src/olympia/accounts/views.py:123
 msgid "Need help?"
 msgstr "サポートが必要ですか？"
 
-#: src/olympia/addons/buttons.py:180
+#: src/olympia/addons/buttons.py:177
 msgid "Download Now"
 msgstr "今すぐダウンロード"
 
-#: src/olympia/addons/buttons.py:182
+#: src/olympia/addons/buttons.py:179
 msgid "Download"
 msgstr "ダウンロード"
 
 #. L10n: please keep &nbsp; in the string so &rarr; does not wrap.
-#: src/olympia/addons/buttons.py:186
+#: src/olympia/addons/buttons.py:183
 msgid "Continue to Download&nbsp;&rarr;"
 msgstr "ダウンロードを続ける&nbsp;&rarr;"
 
 # いろいろな所で使われてるので注意
-#: src/olympia/addons/buttons.py:202 src/olympia/addons/helpers.py:35 src/olympia/addons/views.py:319 src/olympia/addons/templates/addons/impala/details.html:114
+#: src/olympia/addons/buttons.py:199 src/olympia/addons/helpers.py:35 src/olympia/addons/views.py:333 src/olympia/addons/templates/addons/impala/details.html:111
 #: src/olympia/addons/templates/addons/impala/listing/items.html:17 src/olympia/addons/templates/addons/mobile/home.html:40 src/olympia/amo/templates/amo/side_nav.html:6
-#: src/olympia/amo/templates/amo/side_nav.html:10 src/olympia/amo/templates/amo/site_nav.html:2 src/olympia/amo/templates/amo/site_nav.html:55 src/olympia/bandwagon/views.py:95
-#: src/olympia/browse/views.py:54 src/olympia/browse/views.py:68 src/olympia/browse/views.py:235 src/olympia/browse/templates/browse/impala/category_landing.html:22
+#: src/olympia/amo/templates/amo/side_nav.html:10 src/olympia/amo/templates/amo/site_nav.html:2 src/olympia/amo/templates/amo/site_nav.html:53 src/olympia/bandwagon/views.py:95
+#: src/olympia/browse/views.py:54 src/olympia/browse/views.py:68 src/olympia/browse/views.py:202 src/olympia/browse/templates/browse/impala/category_landing.html:22
 #: src/olympia/browse/templates/browse/personas/mobile/category_landing.html:26
 msgid "Featured"
 msgstr "おすすめ"
 
-#: src/olympia/addons/buttons.py:221
+#: src/olympia/addons/buttons.py:218
 msgid "Add to {0}"
 msgstr "{0} へ追加"
 
@@ -91,17 +92,20 @@ msgstr "スラグを「%s」にすることはできません。別のスラグ�
 msgid "Invalid tag: {0}"
 msgid_plural "Invalid tags: {0}"
 msgstr[0] "無効なタグ: {0}"
+msgstr[1] ""
 
 #. L10n: {0} is a single tag or a comma-separated list of tags.
 #: src/olympia/addons/forms.py:103
 msgid "\"{0}\" is a reserved tag and cannot be used."
 msgid_plural "\"{0}\" are reserved tags and cannot be used."
 msgstr[0] "「{0}」は予約されたタグ名なので使用できません。"
+msgstr[1] ""
 
 #: src/olympia/addons/forms.py:111
 msgid "You have {0} too many tags."
 msgid_plural "You have {0} too many tags."
 msgstr[0] "タグの数が上限を {0} 個超えています。"
+msgstr[1] ""
 
 #: src/olympia/addons/forms.py:117
 #, python-format
@@ -112,39 +116,41 @@ msgstr "すべてのタグは無効な文字を除き %s 文字以下でなけ�
 msgid "All tags must be at least {0} character."
 msgid_plural "All tags must be at least {0} characters."
 msgstr[0] "すべてのタグは {0} 文字以上でなければなりません。"
+msgstr[1] ""
 
-#: src/olympia/addons/forms.py:234
+#: src/olympia/addons/forms.py:238
 msgid "Categories cannot be changed while your add-on is featured for this application."
 msgstr "アドオンがこのアプリケーションのおすすめに設定されている間はカテゴリを変更できません。"
 
 #. L10n: {0} is the number of categories.
-#: src/olympia/addons/forms.py:238
+#: src/olympia/addons/forms.py:242
 msgid "You can have only {0} category."
 msgid_plural "You can have only {0} categories."
 msgstr[0] "カテゴリは {0} 個までしか設定できません。"
+msgstr[1] ""
 
-#: src/olympia/addons/forms.py:246
+#: src/olympia/addons/forms.py:250
 msgid "The miscellaneous category cannot be combined with additional categories."
 msgstr "「その他」カテゴリを他のカテゴリと組み合わせることはできません。"
 
-#: src/olympia/addons/forms.py:369
+#: src/olympia/addons/forms.py:374
 #, python-format
 msgid "Before changing your default locale you must have a name, summary, and description in that locale. You are missing %s."
 msgstr "既定のロケールを変更する前に、そのロケールでアドオンの名前、要約、説明を入力する必要があります。%s が不足しています。"
 
-#: src/olympia/addons/forms.py:484 src/olympia/addons/forms.py:575
+#: src/olympia/addons/forms.py:455 src/olympia/addons/forms.py:546
 msgid "A license must be selected."
 msgstr "ライセンスを選択してください。"
 
-#: src/olympia/addons/forms.py:556
+#: src/olympia/addons/forms.py:527
 msgid "Give Your Theme a Name."
 msgstr "テーマに名前を付けてください。"
 
-#: src/olympia/addons/forms.py:562 src/olympia/devhub/templates/devhub/personas/submit.html:53
+#: src/olympia/addons/forms.py:533 src/olympia/devhub/templates/devhub/personas/submit.html:53
 msgid "Describe your Theme."
 msgstr "テーマの説明を記入してください。"
 
-#: src/olympia/addons/forms.py:704
+#: src/olympia/addons/forms.py:675
 msgid "Enter a new author's email address"
 msgstr "新しい作者のメールアドレスを入力してください"
 
@@ -152,39 +158,39 @@ msgstr "新しい作者のメールアドレスを入力してください"
 msgid "Not Reviewed"
 msgstr "未審査"
 
-#: src/olympia/addons/models.py:301
+#: src/olympia/addons/models.py:298
 msgid "Users have the option of contributing more or less than this amount."
 msgstr "ユーザには、この金額にとらわれない額の寄付をする選択肢があります。"
 
-#: src/olympia/addons/models.py:309
-msgid "Users will always be asked in the Add-ons Manager (Firefox 4 and above)"
-msgstr "アドオンマネージャでは常に確認が求められます (Firefox 4 以降)"
+#: src/olympia/addons/models.py:306
+msgid "Users will always be asked in the Add-ons Manager (Firefox 4 and above). Only applies to desktop."
+msgstr ""
 
 # Column name in a table.
-#: src/olympia/addons/models.py:1804 src/olympia/addons/templates/addons/details_box.html:55 src/olympia/devhub/templates/devhub/index.html:92
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:102
+#: src/olympia/addons/models.py:1802 src/olympia/addons/templates/addons/details_box.html:55 src/olympia/devhub/templates/devhub/index.html:92
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:89
 msgid "Listed"
 msgstr "表示"
 
-#: src/olympia/addons/views.py:320 src/olympia/browse/templates/browse/personas/mobile/category_landing.html:27
+#: src/olympia/addons/views.py:334 src/olympia/browse/templates/browse/personas/mobile/category_landing.html:27
 msgid "Popular"
 msgstr "人気"
 
-#: src/olympia/addons/views.py:321 src/olympia/browse/views.py:238 src/olympia/browse/views.py:280 src/olympia/browse/views.py:482
+#: src/olympia/addons/views.py:335 src/olympia/browse/views.py:205 src/olympia/browse/views.py:247 src/olympia/browse/views.py:449
 msgid "Recently Added"
 msgstr "新着"
 
-#: src/olympia/addons/views.py:322 src/olympia/bandwagon/views.py:99 src/olympia/browse/views.py:60 src/olympia/browse/views.py:71 src/olympia/search/forms.py:16 src/olympia/search/forms.py:91
+#: src/olympia/addons/views.py:336 src/olympia/bandwagon/views.py:99 src/olympia/browse/views.py:60 src/olympia/browse/views.py:71 src/olympia/search/forms.py:16 src/olympia/search/forms.py:91
 msgid "Recently Updated"
 msgstr "最近更新"
 
 # {0} is an add-on name.
 #. l10n: {0} is the addon name
-#: src/olympia/addons/views.py:520
+#: src/olympia/addons/views.py:534
 msgid "Contribution for {0}"
 msgstr "{0} への寄付"
 
-#: src/olympia/addons/views.py:613
+#: src/olympia/addons/views.py:627
 msgid "Abuse reported."
 msgstr "不正報告が送信されました。"
 
@@ -254,9 +260,9 @@ msgstr "寄付"
 #: src/olympia/devhub/templates/devhub/addons/ajax_compat_update.html:36 src/olympia/devhub/templates/devhub/addons/profile.html:44 src/olympia/devhub/templates/devhub/addons/edit/admin.html:101
 #: src/olympia/devhub/templates/devhub/addons/edit/basic.html:152 src/olympia/devhub/templates/devhub/addons/edit/details.html:85 src/olympia/devhub/templates/devhub/addons/edit/support.html:67
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:166 src/olympia/devhub/templates/devhub/addons/forms_shared/media.html:149
-#: src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:44 src/olympia/devhub/templates/devhub/versions/add_file_modal.html:78 src/olympia/devhub/templates/devhub/versions/edit.html:139
-#: src/olympia/devhub/templates/devhub/versions/list.html:242 src/olympia/devhub/templates/devhub/versions/list.html:276 src/olympia/devhub/templates/devhub/versions/list.html:317
-#: src/olympia/devhub/templates/devhub/versions/list.html:351 src/olympia/reviews/templates/reviews/edit_review.html:16 src/olympia/translations/templates/translations/trans-menu.html:50
+#: src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:43 src/olympia/devhub/templates/devhub/versions/add_file_modal.html:58 src/olympia/devhub/templates/devhub/versions/edit.html:139
+#: src/olympia/devhub/templates/devhub/versions/list.html:239 src/olympia/devhub/templates/devhub/versions/list.html:281 src/olympia/devhub/templates/devhub/versions/list.html:315
+#: src/olympia/devhub/templates/devhub/versions/list.html:349 src/olympia/reviews/templates/reviews/edit_review.html:16 src/olympia/translations/templates/translations/trans-menu.html:50
 #: src/olympia/translations/templates/translations/trans-menu.html:62
 msgid "or"
 msgstr "または"
@@ -294,15 +300,20 @@ msgstr "<a href=\"%(paypal_url)s\">PayPal</a> を通して少額の寄付をす�
 
 #: src/olympia/addons/templates/addons/contributions_lightbox.html:15
 #, python-format
-msgid "To show your support for <b>%(addon_name)s</b>, the developer asks that you make a donation to the <a href=\"%(charity_url)s\">%(charity_name)s</a> through <a href=\"%(paypal_url)s\">PayPal</a>."
-msgstr "このアドオンの作者は、<a href=\"%(paypal_url)s\">PayPal</a> を通じて <a href=\"%(charity_url)s\">%(charity_name)s</a> へ寄付を行い、<b>%(addon_name)s</b> に対する支援の気持ちを表してもらえるよう、あなたにお願いしています。"
+msgid ""
+"To show your support for <b>%(addon_name)s</b>, the developer asks that you make a donation to the <a href=\"%(charity_url)s\">%(charity_name)s</a> through <a href=\"%(paypal_url)s\">PayPal</a>."
+msgstr ""
+"このアドオンの作者は、<a href=\"%(paypal_url)s\">PayPal</a> を通じて <a href=\"%(charity_url)s\">%(charity_name)s</a> へ寄付を行い、<b>%(addon_name)s</b> に対する支援の気持ちを表してもらえるよう、あ"
+"なたにお願いしています。"
 
 #: src/olympia/addons/templates/addons/contributions_lightbox.html:21
 #, python-format
 msgid ""
-"To show your support for <b>%(addon_name)s</b>, the developer asks that you make a small contribution to <a href=\"%(charity_url)s\">%(charity_name)s</a> through <a "
-"href=\"%(paypal_url)s\">PayPal</a>."
-msgstr "このアドオンの作者は、<a href=\"%(paypal_url)s\">PayPal</a> を通じて <a href=\"%(charity_url)s\">%(charity_name)s</a> へ少額の寄付を行い、<b>%(addon_name)s</b> に対する支援の気持ちを表してもらえるよう、あなたにお願いしています。"
+"To show your support for <b>%(addon_name)s</b>, the developer asks that you make a small contribution to <a href=\"%(charity_url)s\">%(charity_name)s</a> through <a href=\"%(paypal_url)s\">PayPal</"
+"a>."
+msgstr ""
+"このアドオンの作者は、<a href=\"%(paypal_url)s\">PayPal</a> を通じて <a href=\"%(charity_url)s\">%(charity_name)s</a> へ少額の寄付を行い、<b>%(addon_name)s</b> に対する支援の気持ちを表してもらえるよ"
+"う、あなたにお願いしています。"
 
 #: src/olympia/addons/templates/addons/contributions_lightbox.html:30
 msgid "How much would you like to contribute?"
@@ -325,8 +336,7 @@ msgstr "金額は数字で入力してください。"
 msgid "A one-time suggested contribution of {0}"
 msgstr "一度だけの寄付: {0} (推奨額)"
 
-#. {0} is a currency symbol (e.g., $),                    {1} is an amount
-#. input
+#. {0} is a currency symbol (e.g., $),                    {1} is an amount input
 #. field
 #: src/olympia/addons/templates/addons/contributions_lightbox.html:64
 msgid "A one-time contribution of {0} {1}"
@@ -367,7 +377,7 @@ msgid "Add-on Information for {0}"
 msgstr "{0} のアドオン情報"
 
 #: src/olympia/addons/templates/addons/details_box.html:30 src/olympia/addons/templates/addons/persona_detail_table.html:3 src/olympia/addons/templates/addons/mobile/details.html:63
-#: src/olympia/addons/templates/addons/mobile/persona_detail_table.html:7 src/olympia/browse/views.py:459 src/olympia/devhub/views.py:75
+#: src/olympia/addons/templates/addons/mobile/persona_detail_table.html:7 src/olympia/browse/views.py:426 src/olympia/devhub/views.py:73
 msgid "Updated"
 msgstr "更新日"
 
@@ -386,11 +396,11 @@ msgstr "動作環境:"
 msgid "Visibility"
 msgstr "公開状態"
 
-#: src/olympia/addons/templates/addons/details_box.html:57 src/olympia/devhub/templates/devhub/index.html:94 src/olympia/devhub/templates/devhub/includes/addon_details.html:104
+#: src/olympia/addons/templates/addons/details_box.html:57 src/olympia/devhub/templates/devhub/index.html:94 src/olympia/devhub/templates/devhub/includes/addon_details.html:91
 msgid "Hidden"
 msgstr "非掲載"
 
-#: src/olympia/addons/templates/addons/details_box.html:59 src/olympia/devhub/templates/devhub/index.html:96 src/olympia/devhub/templates/devhub/includes/addon_details.html:106
+#: src/olympia/addons/templates/addons/details_box.html:59 src/olympia/devhub/templates/devhub/index.html:96 src/olympia/devhub/templates/devhub/includes/addon_details.html:93
 msgid "Unlisted"
 msgstr "リスト掲載中止"
 
@@ -398,13 +408,13 @@ msgstr "リスト掲載中止"
 msgid "Required Add-ons"
 msgstr "必要なアドオン"
 
-#: src/olympia/addons/templates/addons/details_box.html:81 src/olympia/addons/templates/addons/persona_detail_table.html:15 src/olympia/browse/views.py:462 src/olympia/devhub/views.py:78
-#: src/olympia/devhub/views.py:85 src/olympia/discovery/templates/discovery/addons/detail.html:57 src/olympia/reviews/forms.py:62 src/olympia/reviews/templates/reviews/add.html:57
+#: src/olympia/addons/templates/addons/details_box.html:81 src/olympia/addons/templates/addons/persona_detail_table.html:15 src/olympia/browse/views.py:429 src/olympia/devhub/views.py:76
+#: src/olympia/devhub/views.py:83 src/olympia/discovery/templates/discovery/addons/detail.html:57 src/olympia/reviews/forms.py:62 src/olympia/reviews/templates/reviews/add.html:57
 #: src/olympia/reviews/templates/reviews/mobile/review_list.html:18
 msgid "Rating"
 msgstr "評価"
 
-#: src/olympia/addons/templates/addons/details_box.html:85 src/olympia/browse/views.py:461 src/olympia/devhub/views.py:77 src/olympia/devhub/views.py:84
+#: src/olympia/addons/templates/addons/details_box.html:85 src/olympia/browse/views.py:428 src/olympia/devhub/views.py:75 src/olympia/devhub/views.py:82
 #: src/olympia/stats/templates/stats/addon_report_menu.html:8 src/olympia/stats/templates/stats/collection_report_menu.html:18
 msgid "Downloads"
 msgstr "ダウンロード数"
@@ -424,7 +434,7 @@ msgstr "不正報告"
 
 #. The Privacy Policy for this add-on.
 #: src/olympia/addons/templates/addons/details_box.html:121 src/olympia/addons/templates/addons/privacy.html:19 src/olympia/addons/templates/addons/privacy.html:23
-#: src/olympia/addons/templates/addons/impala/button.html:43 src/olympia/addons/templates/addons/impala/details.html:307 src/olympia/devhub/templates/devhub/includes/policy_form.html:20
+#: src/olympia/addons/templates/addons/impala/button.html:43 src/olympia/addons/templates/addons/impala/details.html:312 src/olympia/devhub/templates/devhub/includes/policy_form.html:23
 #: src/olympia/templates/mobile/base_addons.html:87
 msgid "Privacy Policy"
 msgstr "プライバシーポリシー"
@@ -449,7 +459,7 @@ msgstr "イメージギャラリー"
 msgid "Developer Comments"
 msgstr "開発者のコメント"
 
-#: src/olympia/addons/templates/addons/details_box.html:199 src/olympia/addons/templates/addons/impala/details.html:259
+#: src/olympia/addons/templates/addons/details_box.html:199 src/olympia/addons/templates/addons/impala/details.html:264
 msgid "Development Channel"
 msgstr "開発チャンネル"
 
@@ -467,15 +477,17 @@ msgstr "開発版をインストール"
 msgid ""
 "<strong>Caution:</strong> Development versions of this add-on have not been reviewed by Mozilla. Once you install a development version you will continue to receive development updates from this "
 "developer. To stop receiving development updates, reinstall the default version from the link above."
-msgstr "<strong>注意:</strong> このアドオンの開発版は Mozilla の審査を受けていません。一度開発版をインストールすると、この作者から最新の開発版が継続的に提供されます。開発版の更新を中止するには、上のリンクから通常版を再インストールしてください。"
+msgstr ""
+"<strong>注意:</strong> このアドオンの開発版は Mozilla の審査を受けていません。一度開発版をインストールすると、この作者から最新の開発版が継続的に提供されます。開発版の更新を中止するには、上のリンクか"
+"ら通常版を再インストールしてください。"
 
-#: src/olympia/addons/templates/addons/details_box.html:220 src/olympia/addons/templates/addons/impala/details.html:278
+#: src/olympia/addons/templates/addons/details_box.html:220 src/olympia/addons/templates/addons/impala/details.html:283
 msgid "Version {0}:"
 msgstr "バージョン {0}:"
 
 #: src/olympia/addons/templates/addons/details_box.html:234
 msgid "Nothing to see here!  The developer did not include any details."
-msgstr "表示できる情報が何もありません。開発者が詳細情報を提供していません。"
+msgstr ""
 
 #: src/olympia/addons/templates/addons/details_box.html:251 src/olympia/devhub/templates/devhub/versions/edit.html:73 src/olympia/editors/templates/editors/review.html:98
 msgid "Version Notes"
@@ -488,7 +500,7 @@ msgid "End-User License Agreement for {0}"
 msgstr "{0} のエンドユーザ使用許諾契約書"
 
 #: src/olympia/addons/templates/addons/eula.html:17 src/olympia/addons/templates/addons/eula.html:21 src/olympia/addons/templates/addons/impala/button.html:48
-#: src/olympia/addons/templates/addons/impala/details.html:316 src/olympia/devhub/templates/devhub/includes/policy_form.html:3 src/olympia/discovery/templates/discovery/addons/eula.html:11
+#: src/olympia/addons/templates/addons/impala/details.html:321 src/olympia/devhub/templates/devhub/includes/policy_form.html:3 src/olympia/discovery/templates/discovery/addons/eula.html:11
 msgid "End-User License Agreement"
 msgstr "エンドユーザ使用許諾契約書"
 
@@ -508,7 +520,7 @@ msgstr "{0} のページへ戻る…"
 msgid "Add-ons for {0}"
 msgstr "Add-ons for {0}"
 
-#: src/olympia/addons/templates/addons/home.html:10 src/olympia/addons/templates/addons/home.html:51 src/olympia/browse/templates/browse/impala/base_listing.html:11
+#: src/olympia/addons/templates/addons/home.html:10 src/olympia/addons/templates/addons/home.html:53 src/olympia/browse/templates/browse/impala/base_listing.html:11
 msgid "Featured Extensions"
 msgstr "おすすめの拡張機能"
 
@@ -516,29 +528,29 @@ msgstr "おすすめの拡張機能"
 msgid "Popular Extensions"
 msgstr "人気の拡張機能"
 
-#: src/olympia/addons/templates/addons/home.html:42 src/olympia/amo/templates/amo/side_nav.html:3 src/olympia/amo/templates/amo/side_nav.html:11 src/olympia/amo/templates/amo/site_nav.html:3
-#: src/olympia/amo/templates/amo/site_nav.html:25 src/olympia/browse/views.py:236 src/olympia/browse/views.py:281 src/olympia/browse/views.py:481
+#: src/olympia/addons/templates/addons/home.html:44 src/olympia/amo/templates/amo/side_nav.html:3 src/olympia/amo/templates/amo/side_nav.html:11 src/olympia/amo/templates/amo/site_nav.html:3
+#: src/olympia/amo/templates/amo/site_nav.html:25 src/olympia/browse/views.py:203 src/olympia/browse/views.py:248 src/olympia/browse/views.py:448
 msgid "Most Popular"
 msgstr "最も人気"
 
-#: src/olympia/addons/templates/addons/home.html:43
+#: src/olympia/addons/templates/addons/home.html:45
 msgid "All »"
 msgstr "すべて&nbsp;»"
 
-#: src/olympia/addons/templates/addons/home.html:52 src/olympia/addons/templates/addons/home.html:61 src/olympia/addons/templates/addons/home.html:70 src/olympia/addons/templates/addons/home.html:78
+#: src/olympia/addons/templates/addons/home.html:54 src/olympia/addons/templates/addons/home.html:63 src/olympia/addons/templates/addons/home.html:72 src/olympia/addons/templates/addons/home.html:80
 #: src/olympia/browse/templates/browse/impala/category_landing.html:36
 msgid "See all »"
 msgstr "すべて見る&nbsp;»"
 
-#: src/olympia/addons/templates/addons/home.html:60
+#: src/olympia/addons/templates/addons/home.html:62
 msgid "Up &amp; Coming Extensions"
 msgstr "注目の拡張機能"
 
-#: src/olympia/addons/templates/addons/home.html:69 src/olympia/browse/templates/browse/personas/category_landing.html:61 src/olympia/discovery/templates/discovery/pane.html:74
+#: src/olympia/addons/templates/addons/home.html:71 src/olympia/browse/templates/browse/personas/category_landing.html:61 src/olympia/discovery/templates/discovery/pane.html:74
 msgid "Featured Themes"
 msgstr "おすすめのテーマ"
 
-#: src/olympia/addons/templates/addons/home.html:77 src/olympia/bandwagon/templates/bandwagon/impala/collection_listing.html:5
+#: src/olympia/addons/templates/addons/home.html:79 src/olympia/bandwagon/templates/bandwagon/impala/collection_listing.html:5
 msgid "Featured Collections"
 msgstr "おすすめのコレクション"
 
@@ -556,9 +568,9 @@ msgid "Updated {0}"
 msgstr "更新日: {0}"
 
 #. {0} is a date.
-#: src/olympia/addons/templates/addons/macros.html:10 src/olympia/addons/templates/addons/macros.html:69 src/olympia/addons/templates/addons/persona_preview.html:21
-#: src/olympia/addons/templates/addons/listing/items_mobile.html:44 src/olympia/addons/templates/addons/listing/macros.html:39 src/olympia/bandwagon/templates/bandwagon/collection_listing_items.html:37
-#: src/olympia/bandwagon/templates/bandwagon/impala/collection_listing_items.html:37
+#: src/olympia/addons/templates/addons/macros.html:10 src/olympia/addons/templates/addons/macros.html:69 src/olympia/addons/templates/addons/persona_preview.html:22
+#: src/olympia/addons/templates/addons/listing/items_mobile.html:44 src/olympia/addons/templates/addons/listing/macros.html:39
+#: src/olympia/bandwagon/templates/bandwagon/collection_listing_items.html:37 src/olympia/bandwagon/templates/bandwagon/impala/collection_listing_items.html:37
 msgid "Added {0}"
 msgstr "追加日: {0}"
 
@@ -567,25 +579,28 @@ msgstr "追加日: {0}"
 msgid "%(num)s weekly download"
 msgid_plural "%(num)s weekly downloads"
 msgstr[0] "%(num)s 週間ダウンロード"
+msgstr[1] ""
 
 #: src/olympia/addons/templates/addons/macros.html:28
 #, python-format
 msgid "%(num)s user"
 msgid_plural "%(num)s users"
 msgstr[0] "%(num)s ユーザ"
+msgstr[1] ""
 
 #. {0} is the number of downloads.
-#: src/olympia/addons/templates/addons/macros.html:53 src/olympia/addons/templates/addons/impala/details.html:61
+#: src/olympia/addons/templates/addons/macros.html:53 src/olympia/addons/templates/addons/impala/details.html:59
 msgid "{0} weekly download"
 msgid_plural "{0} weekly downloads"
 msgstr[0] "{0} 週間ダウンロード"
+msgstr[1] ""
 
 #. {0} is the number of users.
-#: src/olympia/addons/templates/addons/macros.html:61 src/olympia/addons/templates/addons/impala/details.html:54 src/olympia/compat/templates/compat/index.html:71
-#: src/olympia/zadmin/templates/zadmin/compat.html:67
+#: src/olympia/addons/templates/addons/macros.html:61 src/olympia/addons/templates/addons/impala/details.html:52 src/olympia/zadmin/templates/zadmin/compat.html:67
 msgid "{0} user"
 msgid_plural "{0} users"
 msgstr[0] "{0} ユーザ"
+msgstr[1] ""
 
 #: src/olympia/addons/templates/addons/paypal_result.html:12
 msgid "Payment cancelled"
@@ -599,7 +614,7 @@ msgstr "購入が完了しました"
 msgid "Return to the addon."
 msgstr "アドオンのページへ戻る"
 
-#: src/olympia/addons/templates/addons/persona_detail.html:17 src/olympia/addons/templates/addons/impala/details.html:106 src/olympia/addons/templates/addons/mobile/details.html:23
+#: src/olympia/addons/templates/addons/persona_detail.html:17 src/olympia/addons/templates/addons/impala/details.html:103 src/olympia/addons/templates/addons/mobile/details.html:23
 #: src/olympia/addons/templates/addons/mobile/persona_detail.html:21 src/olympia/discovery/templates/discovery/addons/base.html:27 src/olympia/editors/templates/editors/review.html:31
 msgid "by"
 msgstr "作者:"
@@ -643,33 +658,35 @@ msgstr "日別ユーザ数"
 msgid "License"
 msgstr "ライセンス"
 
-#: src/olympia/addons/templates/addons/persona_preview.html:12 src/olympia/constants/base.py:48
+#: src/olympia/addons/templates/addons/persona_preview.html:13 src/olympia/constants/base.py:48
 msgid "Awaiting Review"
 msgstr "審査待ち"
 
-#: src/olympia/addons/templates/addons/persona_preview.html:14 src/olympia/amo/log.py:180 src/olympia/constants/base.py:42 src/olympia/editors/helpers.py:62
+#: src/olympia/addons/templates/addons/persona_preview.html:15 src/olympia/amo/log.py:180 src/olympia/constants/base.py:42 src/olympia/editors/helpers.py:62
 msgid "Rejected"
 msgstr "却下済み"
 
-#: src/olympia/addons/templates/addons/persona_preview.html:16 src/olympia/amo/log.py:159
+#: src/olympia/addons/templates/addons/persona_preview.html:17 src/olympia/amo/log.py:159
 msgid "Approved"
 msgstr "承認済み"
 
 #. {0} is the number of users.
-#: src/olympia/addons/templates/addons/persona_preview.html:26 src/olympia/addons/templates/addons/listing/items_mobile.html:36 src/olympia/addons/templates/addons/listing/macros.html:31
+#: src/olympia/addons/templates/addons/persona_preview.html:27 src/olympia/addons/templates/addons/listing/items_mobile.html:36 src/olympia/addons/templates/addons/listing/macros.html:31
 msgid "<strong>{0}</strong> user"
 msgid_plural "<strong>{0}</strong> users"
 msgstr[0] "<strong>{0}</strong> ユーザ"
+msgstr[1] ""
 
-#: src/olympia/addons/templates/addons/persona_preview.html:40
+#: src/olympia/addons/templates/addons/persona_preview.html:41
 msgid "Hover to Preview"
 msgstr "マウスカーソルを合わせるとプレビューできます"
 
-#: src/olympia/addons/templates/addons/persona_preview.html:46 src/olympia/addons/templates/addons/persona_preview.html:48 src/olympia/reviews/templates/reviews/add.html:15
+#: src/olympia/addons/templates/addons/persona_preview.html:47 src/olympia/addons/templates/addons/persona_preview.html:49 src/olympia/addons/templates/addons/persona_preview.html:97
+#: src/olympia/reviews/templates/reviews/add.html:15
 msgid "Add"
 msgstr "追加"
 
-#: src/olympia/addons/templates/addons/persona_preview.html:57 src/olympia/bandwagon/templates/bandwagon/ajax_new.html:16 src/olympia/bandwagon/templates/bandwagon/edit.html:19
+#: src/olympia/addons/templates/addons/persona_preview.html:58 src/olympia/bandwagon/templates/bandwagon/ajax_new.html:16 src/olympia/bandwagon/templates/bandwagon/edit.html:19
 #: src/olympia/bandwagon/templates/bandwagon/includes/addedit.html:19 src/olympia/devhub/templates/devhub/addons/edit/admin.html:13 src/olympia/devhub/templates/devhub/addons/edit/basic.html:10
 #: src/olympia/devhub/templates/devhub/addons/edit/details.html:8 src/olympia/devhub/templates/devhub/addons/edit/media.html:6 src/olympia/devhub/templates/devhub/addons/edit/support.html:8
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:9 src/olympia/devhub/templates/devhub/addons/submit/describe.html:29 src/olympia/editors/templates/editors/review.html:257
@@ -678,21 +695,21 @@ msgstr "編集"
 
 #. For datetime formatting, see the table on
 #. http://docs.python.org/library/datetime.html#strftime-and-strptime-behavior
-#: src/olympia/addons/templates/addons/persona_preview.html:66
+#: src/olympia/addons/templates/addons/persona_preview.html:67
 #, python-format
 msgid "%%Y-%%m-%%d"
 msgstr "%%Y-%%m-%%d"
 
-#: src/olympia/addons/templates/addons/persona_preview.html:67
+#: src/olympia/addons/templates/addons/persona_preview.html:68
 msgid "by {0} on {1}"
 msgstr "投稿者: {0} - 投稿日時: {1}"
 
-#: src/olympia/addons/templates/addons/persona_preview.html:75 src/olympia/reviews/helpers.py:17 src/olympia/reviews/templates/reviews/review_list.html:63
+#: src/olympia/addons/templates/addons/persona_preview.html:76 src/olympia/reviews/helpers.py:17 src/olympia/reviews/templates/reviews/review_list.html:63
 #: src/olympia/reviews/templates/reviews/reviews_link.html:21 src/olympia/reviews/templates/reviews/impala/reviews_link.html:16
 msgid "Not yet rated"
 msgstr "まだ評価されていません"
 
-#: src/olympia/addons/templates/addons/persona_preview.html:78
+#: src/olympia/addons/templates/addons/persona_preview.html:79
 msgid "<b>{0}</b> users"
 msgstr "<b>{0}</b> ユーザ"
 
@@ -705,16 +722,16 @@ msgid "Learn more about Firefox"
 msgstr "Firefox について"
 
 #: src/olympia/addons/templates/addons/popups.html:22
-msgid "or <b><a class=\"installer\" href=\"{url}\">download anyway</a></b>"
-msgstr "または <b><a class=\"installer\" href=\"{url}\">強制ダウンロード</a></b>"
+msgid "or <b><a class=\"button installer\" href=\"{url}\">download anyway</a></b>"
+msgstr ""
 
 #: src/olympia/addons/templates/addons/popups.html:26
 msgid ""
 "<strong>How to Install in Thunderbird</strong> <ol> <li>Download and save the file to your hard disk.</li> <li>In Mozilla Thunderbird, open Add-ons from the Tools menu.</li> <li>From the options "
 "button next to the add-on search field, select \"Install Add-on From File...\" and locate the downloaded add-on.</li> </ol>"
 msgstr ""
-"<strong>Thunderbird へのインストール方法</strong> <ol> <li>まず、ファイルをダウンロードして保存してください。</li> <li>Mozilla Thunderbird の [ツール] メニューから [アドオン] を選択してアドオンタブを開きます。</li> <li>アドオン検索バーの隣にあるオプションボタン (歯車アイコン) をクリックして "
-"[ファイルからアドオンをインストール...] を選択し、先ほど保存したファイルを開いてください。</li> </ol>"
+"<strong>Thunderbird へのインストール方法</strong> <ol> <li>まず、ファイルをダウンロードして保存してください。</li> <li>Mozilla Thunderbird の [ツール] メニューから [アドオン] を選択してアドオンタブ"
+"を開きます。</li> <li>アドオン検索バーの隣にあるオプションボタン (歯車アイコン) をクリックして [ファイルからアドオンをインストール...] を選択し、先ほど保存したファイルを開いてください。</li> </ol>"
 
 #: src/olympia/addons/templates/addons/popups.html:41
 msgid "To install this Theme, <b>get Thunderbird</b>, a free and open source email client from Mozilla Messaging and install the Personas Plus add-on."
@@ -769,7 +786,7 @@ msgstr "このテーマを使うには %(app)s %(new_version)s が必要です�
 msgid ""
 "<strong>Caution:</strong> This add-on has not been reviewed by Mozilla and can't be installed on release versions of Firefox 43 and above.  Be careful when installing third-party software that "
 "might harm your computer."
-msgstr "<strong>警告:</strong> このアドオンは Mozilla による審査を受けておらず、Firefox 43 以降のリリース版にインストールすることはできません。サードパーティ製ソフトウェアはあなたのコンピュータに悪影響を及ぼすこともあるため、インストールには注意が必要です。"
+msgstr ""
 
 #: src/olympia/addons/templates/addons/popups.html:120
 msgid "<strong>Please note:</strong> This add-on is not compatible with your operating system."
@@ -803,10 +820,10 @@ msgid ""
 "Want {0} on your mobile Firefox?  Scan this QR code to install directly\n"
 "  to your phone.  (You'll need a QR reader.  Search your phone's marketplace if\n"
 "  don't have one.)"
-msgstr "Android 版 Firefox で {0} を使いたいですか？ この QR コードを読み取れば、あなたのスマートフォンに直接インストールできます。(QR コードリーダーが必要です。お持ちでなければアプリストアを検索してみてください)"
+msgstr ""
 
 #: src/olympia/addons/templates/addons/report_abuse.html:6 src/olympia/addons/templates/addons/report_abuse_full.html:10 src/olympia/addons/templates/addons/impala/details-more.html:23
-#: src/olympia/addons/templates/addons/impala/details.html:328
+#: src/olympia/addons/templates/addons/impala/details.html:333
 msgid "Report Abuse"
 msgstr "不正報告"
 
@@ -815,7 +832,9 @@ msgstr "不正報告"
 msgid ""
 "If you suspect this add-on violates <a href=\"%(url)s\">our policies</a> or has security or privacy issues, please use the form below to describe your concerns. Please do not use this form for any "
 "other reason."
-msgstr "このアドオンが <a href=\"%(url)s\">ポリシー</a> に違反していたり、セキュリティやプライバシーの問題があると疑われる場合は、以下のフォームに懸念事項を記入し、送信してください。その他の理由でこのフォームを使用しないでください。"
+msgstr ""
+"このアドオンが <a href=\"%(url)s\">ポリシー</a> に違反していたり、セキュリティやプライバシーの問題があると疑われる場合は、以下のフォームに懸念事項を記入し、送信してください。その他の理由でこのフォー"
+"ムを使用しないでください。"
 
 #: src/olympia/addons/templates/addons/report_abuse.html:24 src/olympia/users/templates/users/report_abuse.html:19
 msgid "Send Report"
@@ -825,9 +844,9 @@ msgstr "レポートを送信"
 #: src/olympia/devhub/templates/devhub/addons/ajax_compat_update.html:36 src/olympia/devhub/templates/devhub/addons/profile.html:44 src/olympia/devhub/templates/devhub/addons/edit/admin.html:104
 #: src/olympia/devhub/templates/devhub/addons/edit/basic.html:155 src/olympia/devhub/templates/devhub/addons/edit/details.html:88 src/olympia/devhub/templates/devhub/addons/edit/support.html:70
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:169 src/olympia/devhub/templates/devhub/addons/forms_shared/media.html:152
-#: src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:44 src/olympia/devhub/templates/devhub/personas/edit.html:222 src/olympia/devhub/templates/devhub/versions/add_file_modal.html:79
-#: src/olympia/devhub/templates/devhub/versions/edit.html:140 src/olympia/devhub/templates/devhub/versions/list.html:208 src/olympia/devhub/templates/devhub/versions/list.html:242
-#: src/olympia/devhub/templates/devhub/versions/list.html:276 src/olympia/devhub/templates/devhub/versions/list.html:317 src/olympia/reviews/templates/reviews/edit_review.html:16
+#: src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:43 src/olympia/devhub/templates/devhub/personas/edit.html:222 src/olympia/devhub/templates/devhub/versions/add_file_modal.html:59
+#: src/olympia/devhub/templates/devhub/versions/edit.html:140 src/olympia/devhub/templates/devhub/versions/list.html:208 src/olympia/devhub/templates/devhub/versions/list.html:239
+#: src/olympia/devhub/templates/devhub/versions/list.html:281 src/olympia/devhub/templates/devhub/versions/list.html:315 src/olympia/reviews/templates/reviews/edit_review.html:16
 #: src/olympia/translations/templates/translations/trans-menu.html:50 src/olympia/translations/templates/translations/trans-menu.html:62 src/olympia/zadmin/templates/zadmin/validation.html:105
 msgid "Cancel"
 msgstr "キャンセル"
@@ -872,7 +891,7 @@ msgstr "このアドオンについて何か手助けを必要とされている
 msgid "Review Guidelines"
 msgstr "レビューガイドライン"
 
-#: src/olympia/addons/templates/addons/review_list_box.html:5 src/olympia/addons/templates/addons/impala/details-more.html:27 src/olympia/editors/helpers.py:921
+#: src/olympia/addons/templates/addons/review_list_box.html:5 src/olympia/addons/templates/addons/impala/details-more.html:27 src/olympia/editors/helpers.py:1001
 #: src/olympia/reviews/templates/reviews/add.html:14 src/olympia/reviews/templates/reviews/reply.html:14 src/olympia/reviews/templates/reviews/review_list.html:19
 #: src/olympia/reviews/templates/reviews/mobile/review_list.html:26
 msgid "Reviews"
@@ -892,6 +911,7 @@ msgstr "このレビューに対する作者の返信を表示"
 msgid "See all reviews of this add-on"
 msgid_plural "See all %(cnt)s reviews of this add-on"
 msgstr[0] "このアドオンの %(cnt)s 件のレビューをすべて見る"
+msgstr[1] ""
 
 #: src/olympia/addons/templates/addons/tags_box.html:3 src/olympia/devhub/templates/devhub/addons/edit/basic.html:118
 msgid "Tags"
@@ -960,119 +980,124 @@ msgstr "このアドオンを含むコレクション"
 msgid "Other add-ons by %(author)s"
 msgid_plural "Other add-ons by these authors"
 msgstr[0] "これらの作者が公開している他のアドオン"
+msgstr[1] ""
 
-#: src/olympia/addons/templates/addons/impala/details.html:41
+#: src/olympia/addons/templates/addons/impala/details.html:39
 #, python-format
 msgid "<span itemprop=\"ratingCount\">%(num)s</span> user review"
 msgid_plural "<span itemprop=\"ratingCount\">%(num)s</span> user reviews"
 msgstr[0] "<span itemprop=\"ratingCount\">%(num)s</span> 件のユーザレビュー"
+msgstr[1] ""
 
-#: src/olympia/addons/templates/addons/impala/details.html:69
+#: src/olympia/addons/templates/addons/impala/details.html:66
 msgid "View statistics"
 msgstr "統計情報を表示"
 
-#: src/olympia/addons/templates/addons/impala/details.html:84
+#: src/olympia/addons/templates/addons/impala/details.html:81
 msgid "Manage"
 msgstr "管理"
 
 #. {0} is an add-on name.
-#: src/olympia/addons/templates/addons/impala/details.html:96
+#: src/olympia/addons/templates/addons/impala/details.html:93
 msgid "Icon of {0}"
 msgstr "{0} のアイコン"
 
-#: src/olympia/addons/templates/addons/impala/details.html:103 src/olympia/addons/templates/addons/impala/listing/items.html:14
+#: src/olympia/addons/templates/addons/impala/details.html:100 src/olympia/addons/templates/addons/impala/listing/items.html:14
 msgid "No Restart"
 msgstr "再起動不要"
 
-#: src/olympia/addons/templates/addons/impala/details.html:127
+#: src/olympia/addons/templates/addons/impala/details.html:124
 #, python-format
 msgid "Meet the Developer: <a href=\"%(url)s\">%(name)s</a>"
 msgid_plural "<a href=\"%(url)s\">Meet the Developers</a>"
 msgstr[0] "<a href=\"%(url)s\">作者紹介</a>"
+msgstr[1] ""
 
 # {0} is an add-on name.
-#: src/olympia/addons/templates/addons/impala/details.html:137
+#: src/olympia/addons/templates/addons/impala/details.html:134
 msgid "Learn why {0} was created and find out what's next for this add-on."
 msgstr "{0} が作られた経緯と、このアドオンの今後の開発計画について知りましょう。"
 
 #. {0} is an index.
-#: src/olympia/addons/templates/addons/impala/details.html:156
+#: src/olympia/addons/templates/addons/impala/details.html:161
 msgid "Add-on screenshot #{0}"
 msgstr "アドオンのスクリーンショット #{0}"
 
-#: src/olympia/addons/templates/addons/impala/details.html:182
+#: src/olympia/addons/templates/addons/impala/details.html:187
 msgid "Add-on home page"
 msgstr "アドオンのホームページ"
 
-#: src/olympia/addons/templates/addons/impala/details.html:185
+#: src/olympia/addons/templates/addons/impala/details.html:190
 msgid "Support site"
 msgstr "サポートサイト"
 
-#: src/olympia/addons/templates/addons/impala/details.html:189
+#: src/olympia/addons/templates/addons/impala/details.html:194
 msgid "Support E-mail"
 msgstr "サポートメールアドレス"
 
-#: src/olympia/addons/templates/addons/impala/details.html:194 src/olympia/devhub/models.py:378 src/olympia/devhub/templates/devhub/versions/list.html:12
+#: src/olympia/addons/templates/addons/impala/details.html:199 src/olympia/devhub/models.py:378 src/olympia/devhub/templates/devhub/versions/list.html:12
 #: src/olympia/versions/templates/versions/version.html:6 src/olympia/versions/templates/versions/mobile/version.html:6
 msgid "Version {0}"
 msgstr "バージョン {0}"
 
-#: src/olympia/addons/templates/addons/impala/details.html:194
+#: src/olympia/addons/templates/addons/impala/details.html:199
 msgid "Info"
 msgstr "情報"
 
-#: src/olympia/addons/templates/addons/impala/details.html:195 src/olympia/devhub/templates/devhub/includes/addon_details.html:129
+#: src/olympia/addons/templates/addons/impala/details.html:200 src/olympia/devhub/templates/devhub/includes/addon_details.html:116
 msgid "Last Updated:"
 msgstr "最終更新日:"
 
-#: src/olympia/addons/templates/addons/impala/details.html:200
+#: src/olympia/addons/templates/addons/impala/details.html:205
 #, python-format
 msgid "Released under <a target=\"_blank\" href=\"%(url)s\">%(name)s</a>"
 msgstr "<a target=\"_blank\" href=\"%(url)s\">%(name)s</a> の下で公開されています"
 
-#: src/olympia/addons/templates/addons/impala/details.html:201 src/olympia/addons/templates/addons/impala/details.html:206 src/olympia/amo/helpers.py:398 src/olympia/devhub/forms.py:142
+#: src/olympia/addons/templates/addons/impala/details.html:206 src/olympia/addons/templates/addons/impala/details.html:211 src/olympia/amo/helpers.py:398 src/olympia/devhub/forms.py:142
 #: src/olympia/devhub/forms.py:173 src/olympia/versions/templates/versions/version.html:40 src/olympia/versions/templates/versions/version.html:45
 msgid "Custom License"
 msgstr "独自ライセンス"
 
-#: src/olympia/addons/templates/addons/impala/details.html:205
+#: src/olympia/addons/templates/addons/impala/details.html:210
 #, python-format
 msgid "Released under <a href=\"%(url)s\">%(name)s</a>"
 msgstr "<a href=\"%(url)s\">%(name)s</a> の下で公開されています"
 
-#: src/olympia/addons/templates/addons/impala/details.html:217
+#: src/olympia/addons/templates/addons/impala/details.html:222
 msgid "About this Add-on"
 msgstr "このアドオンについて"
 
-#: src/olympia/addons/templates/addons/impala/details.html:233
+#: src/olympia/addons/templates/addons/impala/details.html:238
 msgid "Developer’s Comments"
 msgstr "作者のコメント"
 
-#: src/olympia/addons/templates/addons/impala/details.html:243
+#: src/olympia/addons/templates/addons/impala/details.html:248
 msgid "Version Information"
 msgstr "バージョン情報"
 
-#: src/olympia/addons/templates/addons/impala/details.html:250
+#: src/olympia/addons/templates/addons/impala/details.html:255
 msgid "See complete version history"
 msgstr "すべてのバージョン履歴を見る"
 
-#: src/olympia/addons/templates/addons/impala/details.html:262
+#: src/olympia/addons/templates/addons/impala/details.html:267
 msgid ""
 "The Development Channel lets you test an experimental new version of this add-on before it's released to the general public. Once you install the development version, you will continue to get "
 "updates from this channel. To stop receiving development updates, reinstall the default version from the link above."
-msgstr "開発チャンネルでは、このアドオンの実験的な新バージョンを一般公開前に試すことができます。一度開発版をインストールすれば、このチャンネルから常に最新版を入手できます。開発版の更新を中止するには、上のリンクから通常版を再インストールしてください。"
+msgstr ""
+"開発チャンネルでは、このアドオンの実験的な新バージョンを一般公開前に試すことができます。一度開発版をインストールすれば、このチャンネルから常に最新版を入手できます。開発版の更新を中止するには、上のリ"
+"ンクから通常版を再インストールしてください。"
 
-#: src/olympia/addons/templates/addons/impala/details.html:272
+#: src/olympia/addons/templates/addons/impala/details.html:277
 msgid "<strong>Caution:</strong> Development versions of this add-on have not been reviewed by Mozilla."
 msgstr "<strong>警告:</strong> このアドオンの開発版は Mozilla による審査を受けていません。"
 
-#: src/olympia/addons/templates/addons/impala/details.html:287
+#: src/olympia/addons/templates/addons/impala/details.html:292
 msgid "See complete development channel history"
 msgstr "開発チャンネルの完全な履歴を見る"
 
-#: src/olympia/addons/templates/addons/impala/details.html:306 src/olympia/addons/templates/addons/impala/details.html:315 src/olympia/addons/templates/addons/impala/details.html:327
+#: src/olympia/addons/templates/addons/impala/details.html:311 src/olympia/addons/templates/addons/impala/details.html:320 src/olympia/addons/templates/addons/impala/details.html:332
 #: src/olympia/addons/templates/addons/impala/review_add_box.html:4 src/olympia/stats/templates/stats/popup.html:2 src/olympia/stats/templates/stats/popup.html:8
-#: src/olympia/stats/templates/stats/stats.html:202 src/olympia/users/templates/users/profile.html:119
+#: src/olympia/stats/templates/stats/stats.html:204 src/olympia/users/templates/users/profile.html:119
 msgid "close"
 msgstr "閉じる"
 
@@ -1105,6 +1130,7 @@ msgstr "{0} の今後の開発計画"
 msgid "About the Developer"
 msgid_plural "About the Developers"
 msgstr[0] "作者について"
+msgstr[1] ""
 
 #: src/olympia/addons/templates/addons/impala/developers.html:96 src/olympia/users/templates/users/edit.html:130 src/olympia/users/templates/users/profile.html:26
 msgid "No Photo"
@@ -1130,15 +1156,11 @@ msgstr "{addon} のソースコードライセンス"
 msgid "Source Code License"
 msgstr "ソースコードライセンス"
 
-#: src/olympia/addons/templates/addons/impala/persona_grid.html:16 src/olympia/addons/templates/addons/impala/toplist.html:6
-msgid "{0} users"
-msgstr "{0} ユーザ"
-
 #: src/olympia/addons/templates/addons/impala/review_list_box.html:19 src/olympia/reviews/templates/reviews/review.html:40
 msgid "permalink"
 msgstr "固定リンク"
 
-#: src/olympia/addons/templates/addons/impala/review_list_box.html:23 src/olympia/editors/templates/editors/queue.html:98 src/olympia/reviews/templates/reviews/review.html:44
+#: src/olympia/addons/templates/addons/impala/review_list_box.html:23 src/olympia/editors/templates/editors/queue.html:104 src/olympia/reviews/templates/reviews/review.html:44
 msgid "translate"
 msgstr "翻訳"
 
@@ -1147,6 +1169,7 @@ msgstr "翻訳"
 msgid "See all user reviews"
 msgid_plural "See all %(cnt)s user reviews"
 msgstr[0] "%(cnt)s 件のユーザレビューをすべて見る"
+msgstr[1] ""
 
 #: src/olympia/addons/templates/addons/impala/review_list_box.html:47 src/olympia/reviews/templates/reviews/review_list.html:84
 msgid "This add-on has not yet been reviewed."
@@ -1155,6 +1178,10 @@ msgstr "このアドオンはまだレビューされていません。"
 #: src/olympia/addons/templates/addons/impala/review_list_box.html:50
 msgid "Be the first!"
 msgstr "最初のレビュアーになりましょう！"
+
+#: src/olympia/addons/templates/addons/impala/toplist.html:6
+msgid "{0} users"
+msgstr "{0} ユーザ"
 
 #: src/olympia/addons/templates/addons/impala/listing/sorter.html:14 src/olympia/devhub/templates/devhub/addons/listing/item_actions.html:49
 msgid "More"
@@ -1168,7 +1195,7 @@ msgstr "コレクションへ追加"
 msgid "My Add-ons"
 msgstr "自分のアドオン"
 
-#: src/olympia/addons/templates/addons/includes/dashboard_tabs.html:6 src/olympia/amo/context_processors.py:51
+#: src/olympia/addons/templates/addons/includes/dashboard_tabs.html:6 src/olympia/amo/context_processors.py:50
 msgid "My Themes"
 msgstr "自分のテーマ"
 
@@ -1209,6 +1236,7 @@ msgstr "まだ評価されていません"
 msgid "<strong>{0}</strong> weekly download"
 msgid_plural "<strong>{0}</strong> weekly downloads"
 msgstr[0] "<strong>{0}</strong> 週間ダウンロード"
+msgstr[1] ""
 
 #: src/olympia/addons/templates/addons/mobile/details.html:32
 msgid "Read More"
@@ -1222,7 +1250,7 @@ msgstr "ユーザ"
 msgid "Weekly Downloads"
 msgstr "週間ダウンロード数"
 
-#: src/olympia/addons/templates/addons/mobile/details.html:99 src/olympia/compat/templates/compat/reporter_detail.html:46 src/olympia/devhub/forms.py:787
+#: src/olympia/addons/templates/addons/mobile/details.html:99 src/olympia/compat/templates/compat/reporter_detail.html:46 src/olympia/devhub/forms.py:788
 #: src/olympia/devhub/templates/devhub/versions/list.html:163
 msgid "Version"
 msgstr "バージョン"
@@ -1279,8 +1307,9 @@ msgid "Return to the {0} Add-ons homepage"
 msgstr "{0} Add-ons のホームページへ戻る"
 
 #: src/olympia/addons/templates/addons/mobile/home.html:21 src/olympia/amo/helpers.py:237 src/olympia/bandwagon/templates/bandwagon/edit.html:34 src/olympia/discovery/templates/discovery/pane.html:92
-#: src/olympia/editors/templates/editors/base.html:21 src/olympia/editors/templates/editors/performance.html:72 src/olympia/templates/menu_links.html:4 src/olympia/templates/impala/header_title.html:13
-#: src/olympia/templates/impala/header_title.html:15 src/olympia/templates/impala/header_title.html:19 src/olympia/templates/impala/header_title.html:23 src/olympia/templates/mobile/base_addons.html:47
+#: src/olympia/editors/templates/editors/base.html:21 src/olympia/editors/templates/editors/performance.html:72 src/olympia/templates/menu_links.html:4
+#: src/olympia/templates/impala/header_title.html:13 src/olympia/templates/impala/header_title.html:15 src/olympia/templates/impala/header_title.html:19
+#: src/olympia/templates/impala/header_title.html:23 src/olympia/templates/mobile/base_addons.html:47
 msgid "Add-ons"
 msgstr "Add-ons"
 
@@ -1297,15 +1326,18 @@ msgstr "詳細"
 msgid ""
 "Add-ons are applications that let you personalize Firefox with extra functionality and style. Whether you mistype the name of a website or can't read a busy page, there's an add-on to improve your "
 "on-the-go browsing."
-msgstr "アドオンとは、Firefox をカスタマイズするために追加の機能やデザインを提供する小さなアプリケーションのことです。例えば、Web サイトの名前を入力ミスしたり、ページがビジー状態で読み込めなかったり、そういったときのためにモバイルブラウジングをより快適にするアドオンがあります。"
+msgstr ""
+"アドオンとは、Firefox をカスタマイズするために追加の機能やデザインを提供する小さなアプリケーションのことです。例えば、Web サイトの名前を入力ミスしたり、ページがビジー状態で読み込めなかったり、そう"
+"いったときのためにモバイルブラウジングをより快適にするアドオンがあります。"
 
 #. {0} is a category name. Ex: "Sports"
 #. {0} is a category name, such as Nature.
-#: src/olympia/addons/templates/addons/mobile/home.html:43 src/olympia/amo/templates/amo/site_nav.html:32 src/olympia/browse/feeds.py:107 src/olympia/browse/templates/browse/impala/base_listing.html:38
-#: src/olympia/browse/templates/browse/personas/base.html:6 src/olympia/browse/templates/browse/personas/base.html:42 src/olympia/browse/templates/browse/personas/category_landing.html:21
-#: src/olympia/browse/templates/browse/personas/category_landing.html:23 src/olympia/browse/templates/browse/personas/category_landing.html:38 src/olympia/browse/templates/browse/personas/grid.html:7
-#: src/olympia/browse/templates/browse/personas/grid.html:11 src/olympia/browse/templates/browse/personas/mobile/base.html:7 src/olympia/browse/templates/browse/personas/mobile/category_landing.html:19
-#: src/olympia/constants/base.py:180 src/olympia/devhub/templates/devhub/personas/submit.html:13 src/olympia/editors/helpers.py:105 src/olympia/editors/templates/editors/base.html:26
+#: src/olympia/addons/templates/addons/mobile/home.html:43 src/olympia/amo/templates/amo/site_nav.html:32 src/olympia/browse/feeds.py:107
+#: src/olympia/browse/templates/browse/impala/base_listing.html:38 src/olympia/browse/templates/browse/personas/base.html:6 src/olympia/browse/templates/browse/personas/base.html:42
+#: src/olympia/browse/templates/browse/personas/category_landing.html:21 src/olympia/browse/templates/browse/personas/category_landing.html:23
+#: src/olympia/browse/templates/browse/personas/category_landing.html:38 src/olympia/browse/templates/browse/personas/grid.html:7 src/olympia/browse/templates/browse/personas/grid.html:11
+#: src/olympia/browse/templates/browse/personas/mobile/base.html:7 src/olympia/browse/templates/browse/personas/mobile/category_landing.html:19 src/olympia/constants/base.py:180
+#: src/olympia/devhub/templates/devhub/personas/submit.html:13 src/olympia/editors/helpers.py:107 src/olympia/editors/templates/editors/base.html:26
 #: src/olympia/editors/templates/editors/performance.html:73 src/olympia/search/templates/search/personas.html:39 src/olympia/templates/menu_links.html:9
 msgid "Themes"
 msgstr "テーマ"
@@ -1326,7 +1358,7 @@ msgstr "すべてのアドオン"
 msgid "Highest Rated"
 msgstr "高評価"
 
-#: src/olympia/addons/templates/addons/mobile/home.html:74 src/olympia/amo/templates/amo/side_nav.html:5 src/olympia/amo/templates/amo/site_nav.html:27 src/olympia/amo/templates/amo/site_nav.html:57
+#: src/olympia/addons/templates/addons/mobile/home.html:74 src/olympia/amo/templates/amo/side_nav.html:5 src/olympia/amo/templates/amo/site_nav.html:27 src/olympia/amo/templates/amo/site_nav.html:55
 #: src/olympia/bandwagon/views.py:97 src/olympia/browse/views.py:57 src/olympia/browse/views.py:67 src/olympia/browse/templates/browse/personas/mobile/category_landing.html:65
 #: src/olympia/search/forms.py:15 src/olympia/search/forms.py:87
 msgid "Newest"
@@ -1340,88 +1372,90 @@ msgstr "プレビュー"
 msgid "Theme Info &raquo;"
 msgstr "テーマの情報 &raquo;"
 
-#: src/olympia/amo/context_processors.py:39 src/olympia/devhub/templates/devhub/nav.html:43
+#: src/olympia/amo/context_processors.py:37 src/olympia/devhub/templates/devhub/nav.html:43
 msgid "Tools"
 msgstr "ツール"
 
-#: src/olympia/amo/context_processors.py:48 src/olympia/discovery/templates/discovery/pane_account.html:8 src/olympia/users/templates/users/includes/navigation.html:2
+#: src/olympia/amo/context_processors.py:47 src/olympia/discovery/templates/discovery/pane_account.html:8 src/olympia/users/templates/users/includes/navigation.html:2
 msgid "My Profile"
 msgstr "自分のプロフィール"
 
-#: src/olympia/amo/context_processors.py:54 src/olympia/users/templates/users/edit.html:5 src/olympia/users/templates/users/includes/navigation.html:3
+#: src/olympia/amo/context_processors.py:53 src/olympia/users/templates/users/edit.html:5 src/olympia/users/templates/users/includes/navigation.html:3
 msgid "Account Settings"
 msgstr "アカウント設定"
 
-#: src/olympia/amo/context_processors.py:57 src/olympia/discovery/templates/discovery/pane_account.html:11 src/olympia/users/templates/users/profile.html:83
+#: src/olympia/amo/context_processors.py:56 src/olympia/discovery/templates/discovery/pane_account.html:11 src/olympia/users/templates/users/profile.html:83
 #: src/olympia/users/templates/users/includes/navigation.html:4
 msgid "My Collections"
 msgstr "自分のコレクション"
 
-#: src/olympia/amo/context_processors.py:62 src/olympia/discovery/templates/discovery/pane_account.html:10 src/olympia/users/templates/users/includes/navigation.html:7
+#: src/olympia/amo/context_processors.py:61 src/olympia/discovery/templates/discovery/pane_account.html:10 src/olympia/users/templates/users/includes/navigation.html:7
 msgid "My Favorites"
 msgstr "自分のお気に入り"
 
-#: src/olympia/amo/context_processors.py:67 src/olympia/discovery/templates/discovery/pane_account.html:13 src/olympia/templates/impala/user_login.html:14 src/olympia/templates/mobile/header_auth.html:5
+#: src/olympia/amo/context_processors.py:66 src/olympia/discovery/templates/discovery/pane_account.html:13 src/olympia/templates/impala/user_login.html:14
+#: src/olympia/templates/mobile/header_auth.html:5
 msgid "Log out"
 msgstr "ログアウト"
 
-#: src/olympia/amo/context_processors.py:72 src/olympia/devhub/templates/devhub/addons/dashboard.html:4
+#: src/olympia/amo/context_processors.py:71 src/olympia/devhub/templates/devhub/addons/dashboard.html:4
 msgid "Manage My Submissions"
 msgstr "自分の登録アイテムを管理"
 
-#: src/olympia/amo/context_processors.py:75 src/olympia/devhub/templates/devhub/nav.html:27 src/olympia/devhub/templates/devhub/addons/dashboard.html:25
+#: src/olympia/amo/context_processors.py:74 src/olympia/devhub/templates/devhub/nav.html:27 src/olympia/devhub/templates/devhub/addons/dashboard.html:25
 #: src/olympia/devhub/templates/devhub/addons/submit/base.html:4
 msgid "Submit a New Add-on"
 msgstr "新しいアドオンを登録"
 
-#: src/olympia/amo/context_processors.py:77 src/olympia/browse/templates/browse/personas/base.html:50 src/olympia/devhub/templates/devhub/index.html:24
+#: src/olympia/amo/context_processors.py:76 src/olympia/browse/templates/browse/personas/base.html:50 src/olympia/devhub/templates/devhub/index.html:24
 #: src/olympia/devhub/templates/devhub/addons/dashboard.html:29
 msgid "Submit a New Theme"
 msgstr "新しいテーマを登録"
 
-#: src/olympia/amo/context_processors.py:79 src/olympia/amo/templates/amo/site_nav.html:87 src/olympia/devhub/helpers.py:36 src/olympia/devhub/helpers.py:68 src/olympia/devhub/helpers.py:102
+#: src/olympia/amo/context_processors.py:78 src/olympia/amo/templates/amo/site_nav.html:85 src/olympia/devhub/helpers.py:36 src/olympia/devhub/helpers.py:68 src/olympia/devhub/helpers.py:102
 #: src/olympia/templates/footer.html:6 src/olympia/templates/menu_links.html:14
 msgid "Developer Hub"
 msgstr "開発者センター"
 
-#: src/olympia/amo/context_processors.py:83 src/olympia/devhub/views.py:1792
+#: src/olympia/amo/context_processors.py:81 src/olympia/devhub/views.py:1796
 msgid "Manage API Keys"
 msgstr "API キーを管理"
 
-#: src/olympia/amo/context_processors.py:88 src/olympia/editors/helpers.py:82 src/olympia/editors/helpers.py:102 src/olympia/editors/templates/editors/base.html:10
+#: src/olympia/amo/context_processors.py:86 src/olympia/editors/helpers.py:84 src/olympia/editors/helpers.py:104 src/olympia/editors/templates/editors/base.html:10
 msgid "Editor Tools"
 msgstr "エディタ用ツール"
 
-#: src/olympia/amo/context_processors.py:92
+#: src/olympia/amo/context_processors.py:90
 msgid "Admin Tools"
 msgstr "管理者用ツール"
 
-#: src/olympia/amo/fields.py:15
+#: src/olympia/amo/fields.py:20
 msgid "Incorrect, please try again."
 msgstr "間違っています。再度お試しください。"
 
-#: src/olympia/amo/fields.py:16
+#: src/olympia/amo/fields.py:21
 msgid "Error verifying input, please try again."
 msgstr "入力内容を検証できませんでした。再度お試しください。"
 
-#: src/olympia/amo/fields.py:32
+#: src/olympia/amo/fields.py:37
 msgid "This must be a valid hex color code, such as #000000."
 msgstr "#000000 のような 16 進数のカラーコードを入力してください。"
 
-#: src/olympia/amo/fields.py:58
+#: src/olympia/amo/fields.py:63
 msgid "Enter at least one value."
 msgstr "少なくともひとつ値を入力してください。"
 
-#: src/olympia/amo/helpers.py:162 src/olympia/amo/templates/amo/site_nav.html:61 src/olympia/bandwagon/templates/bandwagon/add.html:9 src/olympia/bandwagon/templates/bandwagon/collection_detail.html:15
-#: src/olympia/bandwagon/templates/bandwagon/delete.html:9 src/olympia/bandwagon/templates/bandwagon/edit.html:15 src/olympia/bandwagon/templates/bandwagon/user_listing.html:18
-#: src/olympia/bandwagon/templates/bandwagon/user_listing.html:21 src/olympia/bandwagon/templates/bandwagon/impala/collection_listing.html:12
-#: src/olympia/bandwagon/templates/bandwagon/impala/collection_listing.html:20 src/olympia/bandwagon/templates/bandwagon/impala/collection_listing.html:24
-#: src/olympia/bandwagon/templates/bandwagon/impala/collection_sidebar.html:3 src/olympia/bandwagon/templates/bandwagon/includes/collection_sidebar.html:2
-#: src/olympia/bandwagon/templates/bandwagon/mobile/collection_listing.html:3 src/olympia/stats/templates/stats/stats.html:77 src/olympia/templates/menu_links.html:12
+#: src/olympia/amo/helpers.py:162 src/olympia/amo/templates/amo/site_nav.html:59 src/olympia/bandwagon/templates/bandwagon/add.html:9
+#: src/olympia/bandwagon/templates/bandwagon/collection_detail.html:15 src/olympia/bandwagon/templates/bandwagon/delete.html:9 src/olympia/bandwagon/templates/bandwagon/edit.html:15
+#: src/olympia/bandwagon/templates/bandwagon/user_listing.html:18 src/olympia/bandwagon/templates/bandwagon/user_listing.html:21
+#: src/olympia/bandwagon/templates/bandwagon/impala/collection_listing.html:12 src/olympia/bandwagon/templates/bandwagon/impala/collection_listing.html:20
+#: src/olympia/bandwagon/templates/bandwagon/impala/collection_listing.html:24 src/olympia/bandwagon/templates/bandwagon/impala/collection_sidebar.html:3
+#: src/olympia/bandwagon/templates/bandwagon/includes/collection_sidebar.html:2 src/olympia/bandwagon/templates/bandwagon/mobile/collection_listing.html:3
+#: src/olympia/stats/templates/stats/stats.html:33 src/olympia/templates/menu_links.html:12
 msgid "Collections"
 msgstr "コレクション"
 
-#: src/olympia/amo/helpers.py:171 src/olympia/amo/templates/amo/site_nav.html:85 src/olympia/browse/templates/browse/language_tools.html:3
+#: src/olympia/amo/helpers.py:171 src/olympia/amo/templates/amo/site_nav.html:83 src/olympia/browse/templates/browse/language_tools.html:3
 msgid "Dictionaries & Language Packs"
 msgstr "スペルチェック辞書と言語パック"
 
@@ -1573,8 +1607,8 @@ msgstr "上級審査が申請されました"
 msgid "Comment on {addon} {version}."
 msgstr "{addon} {version} についてのコメントが追加されました。"
 
-#: src/olympia/amo/log.py:236 src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:19 src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:47
-#: src/olympia/editors/helpers.py:511 src/olympia/editors/templates/editors/themes/history_table.html:11
+#: src/olympia/amo/log.py:236 src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:17 src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:45
+#: src/olympia/editors/helpers.py:584 src/olympia/editors/templates/editors/themes/history_table.html:11
 msgid "Comment"
 msgstr "コメント"
 
@@ -1728,7 +1762,7 @@ msgstr "審査担当者による上級審査依頼"
 
 #: src/olympia/amo/log.py:442
 msgid "Video removed from {addon} because of a problem with the video. "
-msgstr "動画に問題があったため、{addon} の動画は削除されました。"
+msgstr ""
 
 #: src/olympia/amo/log.py:444
 msgid "Video removed"
@@ -1861,16 +1895,17 @@ msgstr "見つかりませんでした"
 #, python-format
 msgid ""
 "<h1>We're sorry, but we can't find what you're looking for.</h1> <p> The page or file you requested wasn't found on our site. It's possible that you clicked a link that's out of date, or typed in "
-"the address incorrectly. </p> <ul> <li>If you typed in the address, please double check the spelling.</li> <li> If you followed a link from somewhere, please let us know at <a "
-"href=\"mailto:webmaster@mozilla.com\">webmaster@mozilla.com</a>. Tell us where you came from and what you were looking for, and we'll do our best to fix it. </li> </ul> <p>Or you can just jump over"
-" to some of the popular pages on our website.</p> <ul> <li>Are you interested in a <a href=\"%(rec)s\">list of featured add-ons</a>?</li> <li> Do you want to <a href=\"%(search)s\">search for add-"
-"ons</a>? You may go to the <a href=\"%(search)s\">search page</a> or just use the search field above. </li> <li> If you prefer to start over, just go to the <a href=\"%(home)s\">add-ons front "
-"page</a>. </li> </ul>"
+"the address incorrectly. </p> <ul> <li>If you typed in the address, please double check the spelling.</li> <li> If you followed a link from somewhere, please let us know at <a href=\"mailto:"
+"webmaster@mozilla.com\">webmaster@mozilla.com</a>. Tell us where you came from and what you were looking for, and we'll do our best to fix it. </li> </ul> <p>Or you can just jump over to some of "
+"the popular pages on our website.</p> <ul> <li>Are you interested in a <a href=\"%(rec)s\">list of featured add-ons</a>?</li> <li> Do you want to <a href=\"%(search)s\">search for add-ons</a>? You "
+"may go to the <a href=\"%(search)s\">search page</a> or just use the search field above. </li> <li> If you prefer to start over, just go to the <a href=\"%(home)s\">add-ons front page</a>. </li> </"
+"ul>"
 msgstr ""
-"<h1>申し訳ありませんが、お探しのものを見つけることができませんでした。</h1> <p>あなたがお探しのページまたはファイルは当サイト内で見つかりませんでした。古いリンクがクリックされたか間違ったアドレスが入力された可能性があります。</p> <ul> <li>アドレスを直接入力した場合は、スペルに誤りがないか確認してください。</li> "
-"<li>別の場所のリンクから移動してきた場合は、<a href=\"mailto:webmaster@mozilla.com\">webmaster@mozilla.com</a> へメールを送り、どこから来たのか、何を探していたのかをお知らせください。私たちは最善を尽くして問題を修正します。</li> </ul> "
-"<p>あるいは、当サイト内の、いくつかの人気のあるページに移動してください。</p> <ul> <li><a href=\"%(rec)s\">おすすめのアドオンのリスト</a> に興味ありますか？</li> <li><a href=\"%(search)s\">アドオンを検索</a> したいですか？ <a href=\"%(search)s\">検索ページ</a> "
-"へ移動するか、このページの上にある検索バーを使ってください。</li> <li>最初からやり直す場合は、<a href=\"%(home)s\">当サイトのホームページ</a> へ移動してください。</li> </ul>"
+"<h1>申し訳ありませんが、お探しのものを見つけることができませんでした。</h1> <p>あなたがお探しのページまたはファイルは当サイト内で見つかりませんでした。古いリンクがクリックされたか間違ったアドレスが"
+"入力された可能性があります。</p> <ul> <li>アドレスを直接入力した場合は、スペルに誤りがないか確認してください。</li> <li>別の場所のリンクから移動してきた場合は、<a href=\"mailto:webmaster@mozilla.com"
+"\">webmaster@mozilla.com</a> へメールを送り、どこから来たのか、何を探していたのかをお知らせください。私たちは最善を尽くして問題を修正します。</li> </ul> <p>あるいは、当サイト内の、いくつかの人気のあ"
+"るページに移動してください。</p> <ul> <li><a href=\"%(rec)s\">おすすめのアドオンのリスト</a> に興味ありますか？</li> <li><a href=\"%(search)s\">アドオンを検索</a> したいですか？ <a href=\"%(search)s"
+"\">検索ページ</a> へ移動するか、このページの上にある検索バーを使ってください。</li> <li>最初からやり直す場合は、<a href=\"%(home)s\">当サイトのホームページ</a> へ移動してください。</li> </ul>"
 
 #: src/olympia/amo/templates/amo/500.html:3
 msgid "Oops"
@@ -1878,8 +1913,8 @@ msgstr "申し訳ありません"
 
 #: src/olympia/amo/templates/amo/500.html:6
 #, python-format
-msgid "<h1>Oops! We had an error.</h1> <p>We'll get to fixing that soon.</p> <p> You can try refreshing the page, or head back to the <a href=\"%(home)s\">Add-ons homepage</a>. </p>"
-msgstr "<h1>申し訳ありません。エラーが発生しました。</h1> <p>すぐに問題の修正に取り掛かります。</p> <p>ページを再読み込みするか、<a href=\"%(home)s\">当サイトのホームページ</a> へ移動してください。</p>"
+msgid "<h1>Oops!  We had an error.</h1> <p>We'll get to fixing that soon.</p> <p> You can try refreshing the page, or head back to the <a href=\"%(home)s\">Add-ons homepage</a>. </p>"
+msgstr ""
 
 #: src/olympia/amo/templates/amo/license_link.html:10
 msgid "Some rights reserved"
@@ -1901,7 +1936,7 @@ msgstr "前へ"
 #: src/olympia/amo/templates/amo/mobile/paginator.html:14 src/olympia/amo/templates/amo/mobile/paginator.html:16 src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:51
 #: src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:65 src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:78
 #: src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:91 src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:104
-#: src/olympia/discovery/templates/discovery/pane.html:45 src/olympia/discovery/templates/discovery/addons/detail.html:39 src/olympia/stats/templates/stats/stats.html:167
+#: src/olympia/discovery/templates/discovery/pane.html:45 src/olympia/discovery/templates/discovery/addons/detail.html:39 src/olympia/stats/templates/stats/stats.html:169
 msgid "Next"
 msgstr "次へ"
 
@@ -1931,11 +1966,11 @@ msgid ""
 "<p> Please enter <strong>all the words</strong> below, <strong>separated by a space if necessary</strong>. </p> <p> If this is hard to read, you can <a href=\"#\" id=\"recaptcha_different\">try "
 "different words</a> or <a href=\"#\" id=\"recaptcha_audio\">try a different type of challenge</a> instead. </p>"
 msgstr ""
-"<p> 以下に <strong>すべての単語</strong> を <strong>必要に応じ空白で区切って</strong> 入力してください。 </p> <p> もしこれが読みづらければ、<a href=\"#\" id=\"recaptcha_different\">他の単語に変える</a> か、代わりに <a href=\"#\" "
-"id=\"recaptcha_audio\">別の種類の課題を試す</a> こともできます。</p>"
+"<p> 以下に <strong>すべての単語</strong> を <strong>必要に応じ空白で区切って</strong> 入力してください。 </p> <p> もしこれが読みづらければ、<a href=\"#\" id=\"recaptcha_different\">他の単語に変える"
+"</a> か、代わりに <a href=\"#\" id=\"recaptcha_audio\">別の種類の課題を試す</a> こともできます。</p>"
 
 #: src/olympia/amo/templates/amo/side_nav.html:4 src/olympia/amo/templates/amo/side_nav.html:12 src/olympia/amo/templates/amo/site_nav.html:4 src/olympia/amo/templates/amo/site_nav.html:26
-#: src/olympia/browse/views.py:56 src/olympia/browse/views.py:66 src/olympia/browse/views.py:237 src/olympia/browse/views.py:282 src/olympia/search/forms.py:86
+#: src/olympia/browse/views.py:56 src/olympia/browse/views.py:66 src/olympia/browse/views.py:204 src/olympia/browse/views.py:249 src/olympia/search/forms.py:86
 msgid "Top Rated"
 msgstr "高評価"
 
@@ -1950,37 +1985,38 @@ msgstr "アドオンを探す"
 msgid "Extensions"
 msgstr "拡張機能"
 
-#: src/olympia/amo/templates/amo/site_nav.html:45
+#: src/olympia/amo/templates/amo/site_nav.html:44
 msgid "Want more customization? Try <b>Complete Themes</b>"
 msgstr "もっとカスタマイズしたいですか？ <b>完全テーマ</b> を試してください"
 
-#: src/olympia/amo/templates/amo/site_nav.html:56 src/olympia/bandwagon/views.py:96
+#: src/olympia/amo/templates/amo/site_nav.html:54 src/olympia/bandwagon/views.py:96
 msgid "Most Followers"
 msgstr "フォロー数上位"
 
-#: src/olympia/amo/templates/amo/site_nav.html:68 src/olympia/bandwagon/templates/bandwagon/impala/collection_sidebar.html:16 src/olympia/bandwagon/templates/bandwagon/includes/collection_sidebar.html:18
+#: src/olympia/amo/templates/amo/site_nav.html:66 src/olympia/bandwagon/templates/bandwagon/impala/collection_sidebar.html:16
+#: src/olympia/bandwagon/templates/bandwagon/includes/collection_sidebar.html:18
 msgid "Collections I've Made"
 msgstr "自分が作成したコレクション"
 
-#: src/olympia/amo/templates/amo/site_nav.html:70 src/olympia/bandwagon/templates/bandwagon/user_listing.html:4 src/olympia/bandwagon/templates/bandwagon/impala/collection_sidebar.html:13
+#: src/olympia/amo/templates/amo/site_nav.html:68 src/olympia/bandwagon/templates/bandwagon/user_listing.html:4 src/olympia/bandwagon/templates/bandwagon/impala/collection_sidebar.html:13
 #: src/olympia/bandwagon/templates/bandwagon/includes/collection_sidebar.html:15
 msgid "Collections I'm Following"
 msgstr "フォローしているコレクション"
 
-#: src/olympia/amo/templates/amo/site_nav.html:73 src/olympia/bandwagon/templates/bandwagon/impala/collection_sidebar.html:18 src/olympia/bandwagon/templates/bandwagon/includes/collection_sidebar.html:20
-#: src/olympia/users/models.py:512
+#: src/olympia/amo/templates/amo/site_nav.html:71 src/olympia/bandwagon/templates/bandwagon/impala/collection_sidebar.html:18
+#: src/olympia/bandwagon/templates/bandwagon/includes/collection_sidebar.html:20 src/olympia/users/models.py:521
 msgid "My Favorite Add-ons"
 msgstr "お気に入りのアドオン"
 
-#: src/olympia/amo/templates/amo/site_nav.html:78
+#: src/olympia/amo/templates/amo/site_nav.html:76
 msgid "More&hellip;"
 msgstr "その他&hellip;"
 
-#: src/olympia/amo/templates/amo/site_nav.html:82
+#: src/olympia/amo/templates/amo/site_nav.html:80
 msgid "Add-ons for Mobile"
 msgstr "Add-ons for Mobile"
 
-#: src/olympia/amo/templates/amo/site_nav.html:86 src/olympia/browse/feeds.py:207 src/olympia/browse/templates/browse/search_tools.html:3 src/olympia/constants/base.py:176
+#: src/olympia/amo/templates/amo/site_nav.html:84 src/olympia/browse/feeds.py:207 src/olympia/browse/templates/browse/search_tools.html:3 src/olympia/constants/base.py:176
 #: src/olympia/templates/menu_links.html:10
 msgid "Search Tools"
 msgstr "検索ツール"
@@ -1996,7 +2032,7 @@ msgid "Jump to first page"
 msgstr "最初のページへ移動"
 
 #: src/olympia/amo/templates/amo/impala/paginator.html:22 src/olympia/amo/templates/amo/mobile/impala_paginator.html:12 src/olympia/discovery/templates/discovery/pane.html:44
-#: src/olympia/discovery/templates/discovery/addons/detail.html:38 src/olympia/stats/templates/stats/stats.html:164
+#: src/olympia/discovery/templates/discovery/addons/detail.html:38 src/olympia/stats/templates/stats/stats.html:166
 msgid "Previous"
 msgstr "前へ"
 
@@ -2006,7 +2042,7 @@ msgstr "最後のページへ移動"
 
 #. First and second arguments are the result range (e.g., 1-20);
 #. third argument is the number of total results (e.g., 1,000).
-#. third
+#. First and second arguments are the result range (e.g., 1-20);              third
 #. argument is the number of total results (e.g., 1,000).
 #: src/olympia/amo/templates/amo/impala/paginator.html:36 src/olympia/amo/templates/amo/mobile/impala_paginator.html:38
 #, python-format
@@ -2017,32 +2053,52 @@ msgstr "<b>%(count)s</b> 件中 <b>%(begin)s</b> から <b>%(end)s</b> 件目ま
 msgid "Page {n}"
 msgid_plural "Page {n}"
 msgstr[0] "{n} ページ"
+msgstr[1] ""
 
-#: src/olympia/amo/templates/services/install.html:38
-#, python-format
-msgid "If you are not prompted to install %(addon_name)s in a moment, please <a href=\"%(addon_xpi)s\">click here</a>."
-msgstr "しばらく待っても %(addon_name)s のインストール確認が表示されない場合は、<a href=\"%(addon_xpi)s\">ここをクリック</a> してください。"
-
-#: src/olympia/amo/tests/test_messages.py:57 src/olympia/amo/tests/test_messages.py:58 src/olympia/reviews/forms.py:25 src/olympia/reviews/forms.py:50 src/olympia/reviews/templates/reviews/add.html:56
+#: src/olympia/amo/tests/test_messages.py:56 src/olympia/amo/tests/test_messages.py:57 src/olympia/reviews/forms.py:25 src/olympia/reviews/forms.py:50 src/olympia/reviews/templates/reviews/add.html:56
 #: src/olympia/reviews/templates/reviews/reply.html:30
 msgid "Title"
 msgstr "タイトル"
 
-#: src/olympia/amo/tests/test_messages.py:57 src/olympia/amo/tests/test_messages.py:58
+#: src/olympia/amo/tests/test_messages.py:56 src/olympia/amo/tests/test_messages.py:57
 msgid "Body"
 msgstr "本文"
 
-#: src/olympia/amo/tests/test_messages.py:59
+#: src/olympia/amo/tests/test_messages.py:58
 msgid "Another Title"
 msgstr "代替タイトル"
 
-#: src/olympia/amo/tests/test_messages.py:59
+#: src/olympia/amo/tests/test_messages.py:58
 msgid "Another Body"
 msgstr "代替本文"
 
-#: src/olympia/api/views.py:255
-msgid "Not implemented yet."
-msgstr "まだ実装されていません。"
+#: src/olympia/api/authentication.py:76
+msgid "Signature has expired."
+msgstr ""
+
+#: src/olympia/api/authentication.py:79
+msgid "Error decoding signature."
+msgstr ""
+
+#: src/olympia/api/authentication.py:82
+msgid "Invalid JWT Token."
+msgstr ""
+
+#: src/olympia/api/authentication.py:130
+msgid "Invalid Authorization header. No credentials provided."
+msgstr ""
+
+#: src/olympia/api/authentication.py:133
+msgid "Invalid Authorization header. Credentials string should not contain spaces."
+msgstr ""
+
+#: src/olympia/api/fields.py:29
+msgid "The field must have a length of at least {num} characters."
+msgstr ""
+
+#: src/olympia/api/fields.py:31
+msgid "The language code {lang_code} is invalid."
+msgstr ""
 
 #: src/olympia/applications/views.py:39 src/olympia/applications/templates/applications/appversions.html:3
 msgid "Application Versions"
@@ -2060,7 +2116,7 @@ msgstr "アプリケーションの有効バージョン"
 msgid "Add-ons submitted to Mozilla Add-ons must have a manifest file with at least one of the below applications supported. Only the versions listed below are allowed for these applications."
 msgstr ""
 
-#: src/olympia/applications/templates/applications/appversions.html:25
+#: src/olympia/applications/templates/applications/appversions.html:25 src/olympia/editors/helpers.py:361
 msgid "GUID"
 msgstr "GUID"
 
@@ -2174,8 +2230,8 @@ msgstr "お気に入り"
 msgid "Remove from favorites"
 msgstr "お気に入りから削除"
 
-#: src/olympia/bandwagon/views.py:98 src/olympia/bandwagon/views.py:191 src/olympia/browse/views.py:58 src/olympia/browse/views.py:69 src/olympia/browse/views.py:458 src/olympia/devhub/views.py:74
-#: src/olympia/devhub/views.py:82 src/olympia/devhub/templates/devhub/addons/edit/basic.html:20 src/olympia/editors/templates/editors/leaderboard.html:24
+#: src/olympia/bandwagon/views.py:98 src/olympia/bandwagon/views.py:191 src/olympia/browse/views.py:58 src/olympia/browse/views.py:69 src/olympia/browse/views.py:425 src/olympia/devhub/views.py:72
+#: src/olympia/devhub/views.py:80 src/olympia/devhub/templates/devhub/addons/edit/basic.html:20 src/olympia/editors/templates/editors/leaderboard.html:24
 #: src/olympia/editors/templates/editors/themes/queue_list.html:48 src/olympia/search/forms.py:17 src/olympia/search/forms.py:89 src/olympia/users/templates/users/vcard.html:5
 msgid "Name"
 msgstr "タイトル"
@@ -2184,7 +2240,7 @@ msgstr "タイトル"
 msgid "Recently Popular"
 msgstr "最近人気"
 
-#: src/olympia/bandwagon/views.py:189 src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:18
+#: src/olympia/bandwagon/views.py:189 src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:16
 msgid "Added"
 msgstr "追加日"
 
@@ -2198,7 +2254,7 @@ msgstr "コレクションが作成されました！"
 
 #: src/olympia/bandwagon/views.py:316
 #, python-format
-msgid "Your new collection is shown below. You can <ahref=\"%(url)s\">edit additional settings</a> if you'dlike."
+msgid "Your new collection is shown below. You can <a href=\"%(url)s\">edit additional settings</a> if you'd like."
 msgstr ""
 
 #: src/olympia/bandwagon/views.py:322
@@ -2278,6 +2334,7 @@ msgstr "非公開"
 msgid "<span>%(num)s</span> follower"
 msgid_plural "<span>%(num)s</span> followers"
 msgstr[0] "<span>%(num)s</span> 人のフォロワー"
+msgstr[1] ""
 
 #: src/olympia/bandwagon/templates/bandwagon/collection_detail.html:54
 msgid "About this Collection"
@@ -2316,15 +2373,17 @@ msgstr "コレクションを削除"
 msgid "%(num)s Theme in this Collection"
 msgid_plural "%(num)s Themes in this Collection"
 msgstr[0] "このコレクションには %(num)s 個のテーマが含まれています"
+msgstr[1] ""
 
 #: src/olympia/bandwagon/templates/bandwagon/collection_detail.html:111
 #, python-format
 msgid "%(num)s Add-on in this Collection"
 msgid_plural "%(num)s Add-ons in this Collection"
 msgstr[0] "このコレクションには %(num)s 個のアドオンが含まれています"
+msgstr[1] ""
 
-#: src/olympia/bandwagon/templates/bandwagon/collection_detail.html:125 src/olympia/compat/templates/compat/index.html:25 src/olympia/compat/templates/compat/reporter_detail.html:29
-#: src/olympia/files/templates/files/viewer.html:29 src/olympia/templates/amo_footer.html:17 src/olympia/templates/includes/lang_switcher.html:10
+#: src/olympia/bandwagon/templates/bandwagon/collection_detail.html:125 src/olympia/compat/templates/compat/reporter_detail.html:29 src/olympia/files/templates/files/viewer.html:29
+#: src/olympia/templates/amo_footer.html:17 src/olympia/templates/includes/lang_switcher.html:10
 msgid "Go"
 msgstr "移動"
 
@@ -2352,13 +2411,15 @@ msgstr "このユーザのコレクションをすべて見る"
 msgid ""
 "Add-ons that you mark as favorites using the <b>Add to Favorites</b> feature appear below. This collection is currently <b>public</b>, which means everyone can see it. If you would like to hide it "
 "from public view, click the button below to make it private."
-msgstr "<b>お気に入りへ追加</b> 機能でお気に入りへ追加したアドオンが以下に表示されます。このコレクションは現在 <b>公開</b> で、誰でも見ることができます。コレクションの公開を取りやめたい場合は、下のボタンをクリックして非公開に変更してください。"
+msgstr ""
+"<b>お気に入りへ追加</b> 機能でお気に入りへ追加したアドオンが以下に表示されます。このコレクションは現在 <b>公開</b> で、誰でも見ることができます。コレクションの公開を取りやめたい場合は、下のボタンを"
+"クリックして非公開に変更してください。"
 
 #: src/olympia/bandwagon/templates/bandwagon/collection_detail.html:186
 msgid ""
-"Add-ons that you mark as favorites using the <b>Add to Favorites</b> feature appear below. This collection is currently <b>private</b>, which means only you can see it. If you would like everyone "
+"Add-ons that you mark as favorites using the <b>Add to Favorites</b> feature appear below. This collection is currently <b>private</b>, which means only you can see it.  If you would like everyone "
 "to be able to see your favorites, click the button below to make it public."
-msgstr "<b>お気に入りへ追加</b> 機能でお気に入りへ追加したアドオンが以下に表示されます。このコレクションは現在 <b>非公開</b> で、あなただけが見ることができます。誰でも見られるようにしたい場合は、下のボタンをクリックして公開してください。"
+msgstr ""
 
 #: src/olympia/bandwagon/templates/bandwagon/collection_detail.html:196
 msgid "My favorite add-ons"
@@ -2369,41 +2430,45 @@ msgstr "お気に入りのアドオン"
 msgid "<span>%(addons)s</span> add-on"
 msgid_plural "<span>%(addons)s</span> add-ons"
 msgstr[0] "<span>%(addons)s</span> 個のアドオン"
+msgstr[1] ""
 
 #: src/olympia/bandwagon/templates/bandwagon/collection_grid.html:32
 #, python-format
 msgid "<span>%(followers)s</span> follower"
 msgid_plural "<span>%(followers)s</span> followers"
 msgstr[0] "<span>%(followers)s</span> 人のフォロワー"
+msgstr[1] ""
 
-#. People "follow" collections to get notified of updates.
-#. Like
+#. People "follow" collections to get notified of updates.                    Like
 #. Twitter followers.
+#. People "follow" collections to get notified of updates.
 #. Like Twitter followers.
 #: src/olympia/bandwagon/templates/bandwagon/collection_listing_items.html:10 src/olympia/bandwagon/templates/bandwagon/impala/collection_listing_items.html:18
 #, python-format
 msgid "%(num)s weekly follower"
 msgid_plural "%(num)s weekly followers"
 msgstr[0] "%(num)s 人の週間フォロワー"
+msgstr[1] ""
 
-#. People "follow" collections to get notified of updates.
-#. Like
+#. People "follow" collections to get notified of updates.                    Like
 #. Twitter followers.
 #: src/olympia/bandwagon/templates/bandwagon/collection_listing_items.html:18
 #, python-format
 msgid "%(num)s monthly follower"
 msgid_plural "%(num)s monthly followers"
 msgstr[0] "%(num)s 人の月間フォロワー"
+msgstr[1] ""
 
-#. People "follow" collections to get notified of updates.
-#. Like
+#. People "follow" collections to get notified of updates.                    Like
 #. Twitter followers.
+#. People "follow" collections to get notified of updates.
 #. Like Twitter followers.
 #: src/olympia/bandwagon/templates/bandwagon/collection_listing_items.html:26 src/olympia/bandwagon/templates/bandwagon/impala/collection_listing_items.html:26
 #, python-format
 msgid "%(num)s follower"
 msgid_plural "%(num)s followers"
 msgstr[0] "%(num)s 人のフォロワー"
+msgstr[1] ""
 
 #: src/olympia/bandwagon/templates/bandwagon/collection_listing_items.html:56 src/olympia/bandwagon/templates/bandwagon/impala/collection_listing_items.html:9
 #: src/olympia/devhub/templates/devhub/personas/edit.html:27
@@ -2488,7 +2553,7 @@ msgid "Remove this user as a contributor"
 msgstr "このユーザを協力者から削除"
 
 #: src/olympia/bandwagon/templates/bandwagon/edit_contributors.html:18 src/olympia/bandwagon/templates/bandwagon/edit_contributors.html:43
-#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:20 src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:48
+#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:18 src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:46
 #: src/olympia/devhub/templates/devhub/addons/ajax_compat_update.html:19
 msgid "Remove"
 msgstr "削除"
@@ -2501,7 +2566,7 @@ msgstr "コレクションの協力者"
 msgid ""
 "You can add multiple contributors to this collection.  A contributor can add and remove add-ons from this collection, but cannot change its name or description.  To add a contributor, enter their "
 "email in the box below. Contributors must have a Mozilla Add-ons account."
-msgstr "複数の貢献者をこのコレクションに追加できます。  貢献者は、このコレクションにアドオンを追加したり削除したりできますが、その名前や説明を変更することはできません。  貢献者を追加するには、その人のメールアドレスを下のボックスに入力してください。貢献者は Mozilla Add-ons サイトのアカウントが必要です。"
+msgstr ""
 
 #: src/olympia/bandwagon/templates/bandwagon/edit_contributors.html:40
 msgid "User"
@@ -2537,7 +2602,7 @@ msgid "<b>Warning:</b> By changing the owner of this collection, you will no lon
 msgstr "<b>警告:</b> このコレクションのオーナーを変更すると、今後あなたはコレクションを編集できなくなり、コレクションへのアドオンの追加と削除のみが可能となります。"
 
 #: src/olympia/bandwagon/templates/bandwagon/edit_contributors.html:83 src/olympia/devhub/templates/devhub/addons/forms_shared/media.html:157
-#: src/olympia/devhub/templates/devhub/addons/submit/describe.html:69 src/olympia/devhub/templates/devhub/addons/submit/license.html:60 src/olympia/devhub/templates/devhub/addons/submit/upload.html:78
+#: src/olympia/devhub/templates/devhub/addons/submit/describe.html:69 src/olympia/devhub/templates/devhub/addons/submit/license.html:60 src/olympia/devhub/templates/devhub/addons/submit/upload.html:70
 #: src/olympia/devhub/templates/devhub/payments/tier.html:17 src/olympia/editors/templates/editors/themes/themes.html:111 src/olympia/editors/templates/editors/themes/themes.html:128
 #: src/olympia/editors/templates/editors/themes/themes.html:134 src/olympia/editors/templates/editors/themes/themes.html:141 src/olympia/users/templates/users/fxa_migration_prompt_content.html:10
 #: src/olympia/users/templates/users/login_form.html:42 src/olympia/users/templates/users/mobile/login.html:57
@@ -2580,7 +2645,8 @@ msgstr "最近人気のコレクション"
 #: src/olympia/bandwagon/templates/bandwagon/impala/collection_listing.html:28
 #, python-format
 msgid "Collections are groups of related add-ons that anyone can create and share. Explore collections created by other users or <a href=\"%(url)s\">create your own</a>."
-msgstr "コレクションとは、誰もが作成し共有することができる、関連するアドオンのグループのことです。他のユーザが作成したコレクションを探すか、<a href=\"%(url)s\">自分のコレクションを作成</a> してください。"
+msgstr ""
+"コレクションとは、誰もが作成し共有することができる、関連するアドオンのグループのことです。他のユーザが作成したコレクションを探すか、<a href=\"%(url)s\">自分のコレクションを作成</a> してください。"
 
 #: src/olympia/bandwagon/templates/bandwagon/impala/collection_listing.html:37 src/olympia/browse/templates/browse/extensions.html:13 src/olympia/browse/templates/browse/themes.html:14
 msgid "Subscribe"
@@ -2609,41 +2675,42 @@ msgstr "リセット"
 
 #: src/olympia/bandwagon/templates/bandwagon/includes/addedit.html:53
 msgid "PNG and JPG supported.  Image will be resized to 32x32."
-msgstr "PNG 形式と JPG 形式がサポートされています。  画像は 32x32 にサイズ変更されます。"
+msgstr ""
 
 #: src/olympia/bandwagon/templates/bandwagon/includes/addedit_errors.html:3
 msgid "There are errors in this form.  Please correct them below."
-msgstr "このフォームにエラーがあります。  以下を修正してください。"
+msgstr ""
 
 #: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:2
 msgid "Add-ons in Your Collection"
 msgstr "コレクションに入っているアドオン"
 
 #: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:4
-msgid "To include an add-on in this collection, enter its name in the box below and hit enter.  You can also use the <strong>Add to Collection</strong> links throughout the site to include add-ons later."
-msgstr "アドオンをこのコレクションに含めるには、アドオン名を下のボックスに入力して Enter キーを押します。  アドオンのページ上の <strong>コレクションに追加</strong> リンクから後で追加することもできます。"
+msgid "To include an add-on in this collection, enter its name in the box below and hit enter."
+msgstr ""
 
-#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:17 src/olympia/constants/base.py:400 src/olympia/devhub/templates/devhub/addons/activity.html:62
+#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:15 src/olympia/constants/base.py:400 src/olympia/devhub/templates/devhub/addons/activity.html:62
+#: src/olympia/editors/helpers.py:273 src/olympia/editors/helpers.py:360
 msgid "Add-on"
 msgstr "アドオン"
 
-#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:26
+#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:24
 msgid "Enter the name of the add-on to include"
 msgstr "追加するアドオンの名前を入力してください"
 
-#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:28
+#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:26
 msgid "Add to Collection"
 msgstr "コレクションへ追加"
 
-#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:45 src/olympia/editors/helpers.py:936 src/olympia/editors/helpers.py:956
+#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:43 src/olympia/editors/helpers.py:1016 src/olympia/editors/helpers.py:1036
 msgid "Pending"
 msgstr "保留中"
 
-#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:47
+#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:45
 msgid "Add a comment"
 msgstr "コメントを追加"
 
-#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:48
+#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:46
 msgid "Remove this add-on from the collection"
 msgstr "このアドオンをコレクションから削除"
 
@@ -2692,10 +2759,8 @@ msgstr "問題のあるアドオンやプラグインは自動的に無効化さ
 #, python-format
 msgid ""
 "When Mozilla becomes aware of add-ons, plugins, or other third-party software that seriously compromises %(app)s security, stability, or performance and meets <a href=\"%(criteria)s\">certain "
-"criteria</a>, the software may be blocked from general use. For more information, please read <a href=\"%(support)s\">this support article</a>."
+"criteria</a>, the software may be blocked from general use.  For more information, please read <a href=\"%(support)s\">this support article</a>."
 msgstr ""
-"アドオンやプラグイン、その他のサードパーティ製ソフトウェアが、%(app)s の安全性、安定性、あるいはパフォーマンスに深刻な影響を与えることを Mozilla が認識し、それが <a href=\"%(criteria)s\">特定の基準</a> を満たした場合、そのソフトウェアはブロックされ、一般的に使用できなくなる可能性があります。詳しくは、<a "
-"href=\"%(support)s\">このサポート記事</a> をご覧ください。"
 
 #: src/olympia/blocklist/templates/blocklist/blocked_detail.html:44
 #, python-format
@@ -2752,12 +2817,12 @@ msgstr "検索ツール"
 msgid "Most Users"
 msgstr "人気"
 
-#: src/olympia/browse/views.py:61 src/olympia/browse/views.py:72 src/olympia/browse/views.py:279 src/olympia/browse/templates/browse/personas/mobile/category_landing.html:63
+#: src/olympia/browse/views.py:61 src/olympia/browse/views.py:72 src/olympia/browse/views.py:246 src/olympia/browse/templates/browse/personas/mobile/category_landing.html:63
 #: src/olympia/discovery/templates/discovery/pane.html:67 src/olympia/search/forms.py:92
 msgid "Up & Coming"
 msgstr "注目"
 
-#: src/olympia/browse/views.py:460 src/olympia/devhub/views.py:76 src/olympia/devhub/views.py:83 src/olympia/discovery/templates/discovery/addons/detail.html:66
+#: src/olympia/browse/views.py:427 src/olympia/devhub/views.py:74 src/olympia/devhub/views.py:81 src/olympia/discovery/templates/discovery/addons/detail.html:66
 msgid "Created"
 msgstr "新着"
 
@@ -2837,6 +2902,7 @@ msgstr "{0} :: 検索ツール"
 msgid "<b>{0}</b> add-on"
 msgid_plural "<b>{0}</b> add-ons"
 msgstr[0] "<b>{0}</b> 個のアドオン"
+msgstr[1] ""
 
 #: src/olympia/browse/templates/browse/search_tools.html:61
 msgid "Search Extensions"
@@ -2942,9 +3008,10 @@ msgstr "注目の完全テーマ"
 msgid "See the %(cnt)s extension in %(name)s &raquo;"
 msgid_plural "See all %(cnt)s extensions in %(name)s &raquo;"
 msgstr[0] "%(name)s カテゴリの %(cnt)s 個の拡張機能を見る &raquo;"
+msgstr[1] ""
 
-#: src/olympia/browse/templates/browse/mobile/extensions.html:13 src/olympia/compat/templates/compat/index.html:82 src/olympia/devhub/templates/devhub/devhub_search.html:24
-#: src/olympia/devhub/templates/devhub/addons/activity.html:47 src/olympia/search/templates/search/no_results.html:4 src/olympia/search/templates/search/mobile/results.html:36
+#: src/olympia/browse/templates/browse/mobile/extensions.html:13 src/olympia/devhub/templates/devhub/devhub_search.html:24 src/olympia/devhub/templates/devhub/addons/activity.html:47
+#: src/olympia/search/templates/search/no_results.html:4 src/olympia/search/templates/search/mobile/results.html:36
 msgid "No results found."
 msgstr "該当するアドオンはありません。"
 
@@ -2999,7 +3066,9 @@ msgstr "もっとカスタマイズしたい？"
 #: src/olympia/browse/templates/browse/personas/category_landing.html:50
 #, python-format
 msgid "Complete Themes transform the look of your browser with styles for the window frame, address bar, buttons, tabs, and menus. <a href=\"%(url)s\" class=\"more-info\">Start exploring</a>"
-msgstr "完全テーマを使えば、ウィンドウの枠からアドレスバー、ボタン、タブ、メニューに至るまで、ブラウザの見た目を完全に変えることができます。<a href=\"%(url)s\" class=\"more-info\">お気に入りのテーマを探す</a>"
+msgstr ""
+"完全テーマを使えば、ウィンドウの枠からアドレスバー、ボタン、タブ、メニューに至るまで、ブラウザの見た目を完全に変えることができます。<a href=\"%(url)s\" class=\"more-info\">お気に入りのテーマを探す</"
+"a>"
 
 #: src/olympia/browse/templates/browse/personas/category_landing.html:76
 msgid "Up & Coming Themes"
@@ -3029,7 +3098,7 @@ msgstr "&laquo; すべてのテーマ"
 msgid "All"
 msgstr "すべて"
 
-#: src/olympia/compat/forms.py:22 src/olympia/search/views.py:525
+#: src/olympia/compat/forms.py:22 src/olympia/editors/templates/editors/base.html:69 src/olympia/search/views.py:518
 msgid "All Add-ons"
 msgstr "すべてのアドオン"
 
@@ -3041,53 +3110,6 @@ msgstr "バイナリ"
 msgid "Non-binary"
 msgstr "非バイナリ"
 
-#. Review points sources other than add-ons and themes.
-#: src/olympia/compat/views.py:87 src/olympia/constants/base.py:388 src/olympia/devhub/forms.py:162 src/olympia/editors/templates/editors/performance.html:75
-msgid "Other"
-msgstr "その他"
-
-#: src/olympia/compat/templates/compat/index.html:4
-msgid "Add-on Compatibility Report for {app} {version}"
-msgstr "{app} {version} のアドオン互換性報告"
-
-#: src/olympia/compat/templates/compat/index.html:11
-msgid "{app} {version} Compatibility"
-msgstr "{app} {version} の互換性"
-
-#: src/olympia/compat/templates/compat/index.html:17
-#, python-format
-msgid "Top 95%% compatible with previous version"
-msgstr "以前のバージョンと互換性のある上位 95%%"
-
-#: src/olympia/compat/templates/compat/index.html:18
-#, python-format
-msgid "Top 95%% of all add-ons"
-msgstr "すべてのアドオンの上位 95%%"
-
-#: src/olympia/compat/templates/compat/index.html:19
-msgid "All active add-ons"
-msgstr "すべてのアクティブなアドオン"
-
-#: src/olympia/compat/templates/compat/index.html:23 src/olympia/constants/base.py:401
-msgid "App"
-msgstr "アプリ"
-
-#: src/olympia/compat/templates/compat/index.html:55
-msgid "Details for add-ons compatible with previous version:"
-msgstr "以前のバージョンと互換性のあるアドオンの詳細:"
-
-#: src/olympia/compat/templates/compat/index.html:57
-msgid "Show all versions"
-msgstr "すべてのバージョンを表示"
-
-#: src/olympia/compat/templates/compat/index.html:59
-msgid "Details for add-ons compatible with all versions:"
-msgstr "すべてのバージョンと互換性のあるアドオンの詳細:"
-
-#: src/olympia/compat/templates/compat/index.html:61
-msgid "Show previous version only"
-msgstr "以前のバージョンのみを表示"
-
 #: src/olympia/compat/templates/compat/reporter.html:3
 msgid "Add-on Compatibility Reports"
 msgstr "アドオンの互換性レポート"
@@ -3097,7 +3119,9 @@ msgstr "アドオンの互換性レポート"
 msgid ""
 "<p> Reports submitted to us through the <a href=\"%(url_)s\">Add-on Compatibility Reporter</a> are collected here for developers to view. These reports help us determine which add-ons will need "
 "help supporting an upcoming Firefox version. </p>"
-msgstr "<p> <a href=\"%(url_)s\">アドオン互換性レポーター</a> を通じて Mozilla へ送信されたレポートは、ここで収集され、開発者が参照します。これらのレポートは、どのアドオンが Firefox 次期バージョン対応のためにサポートを必要としているか Mozilla が判断するのに役立ちます。</p>"
+msgstr ""
+"<p> <a href=\"%(url_)s\">アドオン互換性レポーター</a> を通じて Mozilla へ送信されたレポートは、ここで収集され、開発者が参照します。これらのレポートは、どのアドオンが Firefox 次期バージョン対応のため"
+"にサポートを必要としているか Mozilla が判断するのに役立ちます。</p>"
 
 #: src/olympia/compat/templates/compat/reporter.html:18
 msgid "Reports for your Add-ons"
@@ -3119,11 +3143,13 @@ msgstr "{addon} の互換性レポート"
 msgid "{0} success report"
 msgid_plural "{0} success reports"
 msgstr[0] "{0} 件の成功報告"
+msgstr[1] ""
 
 #: src/olympia/compat/templates/compat/reporter_detail.html:17
 msgid "{0} problem report"
 msgid_plural "{0} problem reports"
 msgstr[0] "{0} 件の問題報告"
+msgstr[1] ""
 
 #: src/olympia/compat/templates/compat/reporter_detail.html:21 src/olympia/users/templates/users/profile.html:70
 msgid "View all"
@@ -3137,8 +3163,8 @@ msgstr "アプリケーションで絞り込み"
 msgid "Report Type"
 msgstr "レポートの種類"
 
-#: src/olympia/compat/templates/compat/reporter_detail.html:47 src/olympia/devhub/forms.py:784 src/olympia/devhub/templates/devhub/addons/ajax_compat_update.html:17 src/olympia/editors/forms.py:108
-#: src/olympia/zadmin/forms.py:45
+#: src/olympia/compat/templates/compat/reporter_detail.html:47 src/olympia/devhub/forms.py:785 src/olympia/devhub/templates/devhub/addons/ajax_compat_update.html:17 src/olympia/editors/forms.py:108
+#: src/olympia/editors/forms.py:248 src/olympia/zadmin/forms.py:45
 msgid "Application"
 msgstr "アプリケーション"
 
@@ -3226,7 +3252,8 @@ msgstr "事前審査済み"
 msgid "Preliminarily Reviewed and Awaiting Full Review"
 msgstr "事前審査済み、本審査待ち"
 
-#: src/olympia/constants/base.py:33 src/olympia/editors/helpers.py:924 src/olympia/editors/templates/editors/themes/history_table.html:34
+#: src/olympia/constants/base.py:33 src/olympia/editors/forms.py:258 src/olympia/editors/helpers.py:73 src/olympia/editors/helpers.py:1004
+#: src/olympia/editors/templates/editors/themes/history_table.html:34
 msgid "Deleted"
 msgstr "削除済み"
 
@@ -3326,6 +3353,11 @@ msgstr "ユーザがこのアドオンのダウンロードを開始した後に
 msgid "Ask before users can download this add-on"
 msgstr "ユーザがこのアドオンをダウンロードする前に尋ねる"
 
+#. Review points sources other than add-ons and themes.
+#: src/olympia/constants/base.py:388 src/olympia/devhub/forms.py:162 src/olympia/editors/templates/editors/performance.html:75
+msgid "Other"
+msgstr "その他"
+
 #: src/olympia/constants/base.py:389
 msgid "Exception"
 msgstr "例外"
@@ -3337,6 +3369,10 @@ msgstr "リリース"
 #: src/olympia/constants/base.py:391
 msgid "Change"
 msgstr "変更"
+
+#: src/olympia/constants/base.py:401
+msgid "App"
+msgstr "アプリ"
 
 #: src/olympia/constants/base.py:402
 msgid "Persona"
@@ -3486,7 +3522,7 @@ msgstr "フラグ"
 msgid "Duplicate"
 msgstr "重複"
 
-#: src/olympia/constants/editors.py:17 src/olympia/editors/helpers.py:502 src/olympia/editors/templates/editors/themes/queue.html:71 src/olympia/editors/templates/editors/themes/themes.html:94
+#: src/olympia/constants/editors.py:17 src/olympia/editors/helpers.py:575 src/olympia/editors/templates/editors/themes/queue.html:71 src/olympia/editors/templates/editors/themes/themes.html:94
 msgid "Reject"
 msgstr "却下"
 
@@ -3586,7 +3622,7 @@ msgstr "Solaris"
 msgid "Android"
 msgstr "Android"
 
-#: src/olympia/core/apps.py:19
+#: src/olympia/core/apps.py:21
 msgid "Core"
 msgstr "コア"
 
@@ -3720,8 +3756,8 @@ msgid "Submit my add-on for manual review."
 msgstr "このアドオンの手作業による審査を申請します。"
 
 #: src/olympia/devhub/forms.py:537
-msgid "Do not list my add-on on this site (beta)"
-msgstr "このアドオンをサイト上に掲載しない (ベータ)"
+msgid "Do not list my add-on on this site"
+msgstr ""
 
 #: src/olympia/devhub/forms.py:538
 msgid "Check this option if you intend to distribute your add-on on your own and only need it to be signed by Mozilla."
@@ -3753,46 +3789,46 @@ msgstr "a|alpha|b|beta|pre|rc で終わるバージョンや任意の番号を�
 
 #: src/olympia/devhub/forms.py:592
 #, python-format
-msgid "Version %s already exists"
-msgstr "バージョン %s はすでに存在しています"
+msgid "Version %s already exists, or was uploaded before."
+msgstr ""
 
-#: src/olympia/devhub/forms.py:604
+#: src/olympia/devhub/forms.py:605
 msgid "Select a valid choice. That choice is not one of the available choices."
 msgstr "有効な項目を選択してください。それは利用可能な選択肢ではありません。"
 
-#: src/olympia/devhub/forms.py:610
+#: src/olympia/devhub/forms.py:611
 msgid "A file with a version ending with a|alpha|b|beta and an optional number is detected as beta."
 msgstr "バージョンが a、alpha、b、beta のいずれか（または任意でそれに続けて数字）で終わるファイルはベータ版として検出されます。"
 
-#: src/olympia/devhub/forms.py:633
+#: src/olympia/devhub/forms.py:634
 msgid "You cannot upload any more files for this version."
 msgstr "このバージョンにはこれ以上ファイルをアップロードできません。"
 
-#: src/olympia/devhub/forms.py:639
+#: src/olympia/devhub/forms.py:640
 msgid "Version doesn't match"
 msgstr "バージョンが一致しません"
 
-#: src/olympia/devhub/forms.py:668
+#: src/olympia/devhub/forms.py:669
 msgid "You cannot delete a file once the review process has started.  You must delete the whole version."
-msgstr "レビュープロセスが開始されたファイルを削除することはできません。  このバージョン全体を削除する必要があります。"
+msgstr ""
 
-#: src/olympia/devhub/forms.py:688
+#: src/olympia/devhub/forms.py:689
 msgid "The platform All cannot be combined with specific platforms."
 msgstr "「すべて」の OS は、特定の OS と組み合わせることができません。"
 
-#: src/olympia/devhub/forms.py:693
+#: src/olympia/devhub/forms.py:694
 msgid "A platform can only be chosen once."
 msgstr "OS は一度だけ選択することができます。"
 
-#: src/olympia/devhub/forms.py:706
+#: src/olympia/devhub/forms.py:707
 msgid "A review type must be selected."
 msgstr "審査形式を選択してください。"
 
-#: src/olympia/devhub/forms.py:788 src/olympia/editors/forms.py:114 src/olympia/zadmin/forms.py:49 src/olympia/zadmin/forms.py:52
+#: src/olympia/devhub/forms.py:789 src/olympia/editors/forms.py:114 src/olympia/editors/forms.py:254 src/olympia/zadmin/forms.py:49 src/olympia/zadmin/forms.py:52
 msgid "Select an application first"
 msgstr "まずアプリケーションを選択してください"
 
-#: src/olympia/devhub/forms.py:840
+#: src/olympia/devhub/forms.py:841
 msgid "There cannot be more than 3 required add-ons."
 msgstr "依存アドオンを 3 つ以上指定することはできません。"
 
@@ -3814,6 +3850,7 @@ msgstr "開発者向けドキュメント"
 msgid "{0} error"
 msgid_plural "{0} errors"
 msgstr[0] "{0} 個のエラー"
+msgstr[1] ""
 
 # {0} is a number
 #. L10n: first parameter is the number of warnings
@@ -3821,81 +3858,82 @@ msgstr[0] "{0} 個のエラー"
 msgid "{0} warning"
 msgid_plural "{0} warnings"
 msgstr[0] "{0} 個の警告"
+msgstr[1] ""
 
 #: src/olympia/devhub/models.py:375 src/olympia/reviews/templates/reviews/add.html:58
 msgid "Review"
 msgstr "レビュー"
 
-#: src/olympia/devhub/tasks.py:551
+#: src/olympia/devhub/tasks.py:583
 #, python-format
 msgid "%s responded with %s (%s)."
 msgstr "%s が %s (%s) を返しました。"
 
-#: src/olympia/devhub/tasks.py:555
+#: src/olympia/devhub/tasks.py:587
 #, python-format
 msgid "Connection to \"%s\" timed out."
 msgstr "「%s」への接続がタイムアウトしました。"
 
-#: src/olympia/devhub/tasks.py:557
+#: src/olympia/devhub/tasks.py:589
 #, python-format
 msgid "Could not contact host at \"%s\"."
 msgstr "ホスト「%s」へ接続できませんでした。"
 
-#: src/olympia/devhub/utils.py:104
+#: src/olympia/devhub/utils.py:105
 #, python-format
 msgid "Validation generated too many errors/warnings so %s messages were truncated. After addressing the visible messages, you'll be able to see the others."
 msgstr "検証の結果、多数のエラーや警告が見つかったため、%s 個のメッセージが省略されました。表示されているメッセージを解決すると、他のメッセージも表示されます。"
 
-#: src/olympia/devhub/views.py:183
+#: src/olympia/devhub/views.py:181
 msgid "All My Add-ons"
 msgstr "自分のすべてのアドオン"
 
-#: src/olympia/devhub/views.py:210
+#: src/olympia/devhub/views.py:208
 msgid "All Activity"
 msgstr "すべてのアクティビティ"
 
-#: src/olympia/devhub/views.py:211
+#: src/olympia/devhub/views.py:209
 msgid "Add-on Updates"
 msgstr "アドオンの更新"
 
-#: src/olympia/devhub/views.py:212
+#: src/olympia/devhub/views.py:210
 msgid "Add-on Status"
 msgstr "アドオンのステータス"
 
-#: src/olympia/devhub/views.py:213
+#: src/olympia/devhub/views.py:211
 msgid "User Collections"
 msgstr "ユーザコレクション"
 
-#: src/olympia/devhub/views.py:214 src/olympia/devhub/templates/devhub/docs/policies-maintenance.html:68 src/olympia/pages/templates/pages/dev_faq.html:38
+#: src/olympia/devhub/views.py:212 src/olympia/devhub/templates/devhub/docs/policies-maintenance.html:68 src/olympia/pages/templates/pages/dev_faq.html:38
 #: src/olympia/pages/templates/pages/dev_faq.html:484
 msgid "User Reviews"
 msgstr "ユーザレビュー"
 
-#: src/olympia/devhub/views.py:327 src/olympia/devhub/views.py:331 src/olympia/devhub/views.py:484 src/olympia/devhub/views.py:513 src/olympia/devhub/views.py:564 src/olympia/devhub/views.py:1150
+#: src/olympia/devhub/views.py:325 src/olympia/devhub/views.py:329 src/olympia/devhub/views.py:484 src/olympia/devhub/views.py:513 src/olympia/devhub/views.py:564 src/olympia/devhub/views.py:1156
 msgid "Changes successfully saved."
 msgstr "変更は正しく保存されました。"
 
-#: src/olympia/devhub/views.py:334 src/olympia/devhub/views.py:1631
+#: src/olympia/devhub/views.py:332 src/olympia/devhub/views.py:1637
 msgid "Please check the form for errors."
 msgstr "フォームの入力ミスを確認してください。"
 
-#: src/olympia/devhub/views.py:346
+#: src/olympia/devhub/views.py:344
 msgid "Add-on cannot be deleted. Disable this add-on instead."
 msgstr "アドオンを削除できません。代わりに無効化してください。"
 
-#: src/olympia/devhub/views.py:356
+#: src/olympia/devhub/views.py:354
 msgid "Theme deleted."
 msgstr "テーマは削除されました。"
 
-#: src/olympia/devhub/views.py:356
+#: src/olympia/devhub/views.py:354
 msgid "Add-on deleted."
 msgstr "アドオンは削除されました。"
 
-#: src/olympia/devhub/views.py:362
+#: src/olympia/devhub/views.py:360
 msgid "URL name was incorrect. Theme was not deleted."
 msgstr "URL 名が正しくありません。テーマは削除されませんでした。"
 
-#: src/olympia/devhub/views.py:367
+#: src/olympia/devhub/views.py:365
 msgid "URL name was incorrect. Add-on was not deleted."
 msgstr "URL 名が正しくありません。アドオンは削除されませんでした。"
 
@@ -3923,7 +3961,7 @@ msgstr "アドオンの検証"
 msgid "Check Add-on Compatibility"
 msgstr "アドオンの互換性を確認"
 
-#: src/olympia/devhub/views.py:808 src/olympia/signing/views.py:90
+#: src/olympia/devhub/views.py:808 src/olympia/signing/views.py:95
 msgid "You cannot submit this type of add-on"
 msgstr "この種類のアドオンを送信することはできません"
 
@@ -3953,33 +3991,33 @@ msgstr "画像は幅 {0} ピクセル、高さ {1} ピクセルでなければ�
 msgid "There was an error uploading your preview."
 msgstr "プレビューのアップロード中に問題が発生しました。"
 
-#: src/olympia/devhub/views.py:1189
+#: src/olympia/devhub/views.py:1195
 #, python-format
 msgid "Version %s disabled."
 msgstr "バージョン %s は削除されました。"
 
-#: src/olympia/devhub/views.py:1193
+#: src/olympia/devhub/views.py:1199
 #, python-format
 msgid "Version %s deleted."
 msgstr "バージョン %s は削除されました。"
 
-#: src/olympia/devhub/views.py:1203
+#: src/olympia/devhub/views.py:1209
 msgid "This upload has failed validation, and may lack complete validation results. Please take due care when reviewing it."
 msgstr "今回のアップロードは検証に失敗したため、完全な検証結果を表示できない可能性があります。審査の際はその点に注意してください。"
 
-#: src/olympia/devhub/views.py:1677
+#: src/olympia/devhub/views.py:1683
 msgid "Preliminary Review Requested."
 msgstr "事前審査が申請されました。"
 
-#: src/olympia/devhub/views.py:1678
+#: src/olympia/devhub/views.py:1684
 msgid "Full Review Requested."
 msgstr "本審査が申請されました。"
 
-#: src/olympia/devhub/views.py:1779
+#: src/olympia/devhub/views.py:1783
 msgid "Your old credentials were revoked and are no longer valid. Be sure to update all API clients with the new credentials."
 msgstr "あなたの古い認証情報は無効化されたため、使用できなくなりました。新しい認証情報ですべての API クライアントを更新してください。"
 
-#: src/olympia/devhub/views.py:1797
+#: src/olympia/devhub/views.py:1801
 msgid "New API key created"
 msgstr "新しい API キーが作成されました"
 
@@ -4009,10 +4047,10 @@ msgstr "アドオンのページへ戻る"
 msgid "{0} :: Search"
 msgstr "{0} :: 検索"
 
-#: src/olympia/devhub/templates/devhub/devhub_search.html:6 src/olympia/devhub/templates/devhub/search.html:8 src/olympia/editors/forms.py:435 src/olympia/editors/forms.py:437
+#: src/olympia/devhub/templates/devhub/devhub_search.html:6 src/olympia/devhub/templates/devhub/search.html:8 src/olympia/editors/forms.py:534 src/olympia/editors/forms.py:536
 #: src/olympia/editors/templates/editors/queue.html:27 src/olympia/editors/templates/editors/themes/queue_list.html:14 src/olympia/search/templates/search/collections.html:17
-#: src/olympia/search/templates/search/personas.html:18 src/olympia/search/templates/search/results.html:18 src/olympia/search/templates/search/mobile/results.html:8 src/olympia/templates/search.html:14
-#: src/olympia/templates/impala/search.html:18
+#: src/olympia/search/templates/search/personas.html:18 src/olympia/search/templates/search/results.html:18 src/olympia/search/templates/search/mobile/results.html:8
+#: src/olympia/templates/search.html:14 src/olympia/templates/impala/search.html:18
 msgid "Search"
 msgstr "検索"
 
@@ -4057,12 +4095,13 @@ msgstr "アドオンについて詳しく学ぶ"
 
 #: src/olympia/devhub/templates/devhub/index.html:41
 msgid ""
-"Add-ons let millions of Firefox users enhance and customize their browsing experience. If you're a Web developer and know <a href=\"https://developer.mozilla.org/docs/Web/HTML\">HTML</a>, <a "
-"href=\"https://developer.mozilla.org/docs/Web/JavaScript\">JavaScript</a>, and <a href=\"https://developer.mozilla.org/docs/Web/CSS\">CSS</a>, you already have all the necessary skills to make a "
-"great add-on."
+"Add-ons let millions of Firefox users enhance and customize their browsing experience. If you're a Web developer and know <a href=\"https://developer.mozilla.org/docs/Web/HTML\">HTML</a>, <a href="
+"\"https://developer.mozilla.org/docs/Web/JavaScript\">JavaScript</a>, and <a href=\"https://developer.mozilla.org/docs/Web/CSS\">CSS</a>, you already have all the necessary skills to make a great "
+"add-on."
 msgstr ""
-"アドオンを使用すると、数多くの Firefox ユーザがブラウザ機能を拡張したりカスタマイズしたりできます。あなたが Web 開発者で<a href=\"https://developer.mozilla.org/docs/Web/HTML\">HTML</a> や <a "
-"href=\"https://developer.mozilla.org/docs/Web/JavaScript\">JavaScript</a>、<a href=\"https://developer.mozilla.org/docs/Web/CSS\">CSS</a> の知識があれば、すばらしいアドオンを作成するのに必要な技術をすでにお持ちです。"
+"アドオンを使用すると、数多くの Firefox ユーザがブラウザ機能を拡張したりカスタマイズしたりできます。あなたが Web 開発者で<a href=\"https://developer.mozilla.org/docs/Web/HTML\">HTML</a> や <a href="
+"\"https://developer.mozilla.org/docs/Web/JavaScript\">JavaScript</a>、<a href=\"https://developer.mozilla.org/docs/Web/CSS\">CSS</a> の知識があれば、すばらしいアドオンを作成するのに必要な技術をすで"
+"にお持ちです。"
 
 #: src/olympia/devhub/templates/devhub/index.html:51
 msgid "Head over to the <a href=\"https://developer.mozilla.org/Add-ons\">Mozilla Developer Network</a> to learn everything you need to know to get started."
@@ -4072,12 +4111,12 @@ msgstr "はじめに、必要なすべてのことを <a href=\"https://develope
 msgid "Start Making Add-ons"
 msgstr "アドオンを作り始める"
 
-#: src/olympia/devhub/templates/devhub/index.html:86 src/olympia/devhub/templates/devhub/addons/listing/items.html:25 src/olympia/devhub/templates/devhub/includes/addon_details.html:15
+#: src/olympia/devhub/templates/devhub/index.html:86 src/olympia/devhub/templates/devhub/addons/listing/items.html:25 src/olympia/devhub/templates/devhub/includes/addon_details.html:20
 #: src/olympia/devhub/templates/devhub/personas/edit.html:43
 msgid "Status:"
 msgstr "状態:"
 
-#: src/olympia/devhub/templates/devhub/index.html:90 src/olympia/devhub/templates/devhub/includes/addon_details.html:100
+#: src/olympia/devhub/templates/devhub/index.html:90 src/olympia/devhub/templates/devhub/includes/addon_details.html:87
 msgid "Visibility:"
 msgstr "公開状態:"
 
@@ -4085,11 +4124,11 @@ msgstr "公開状態:"
 msgid "Latest Version:"
 msgstr "最新版:"
 
-#: src/olympia/devhub/templates/devhub/index.html:109 src/olympia/devhub/templates/devhub/includes/addon_details.html:145 src/olympia/devhub/templates/devhub/personas/edit.html:49
+#: src/olympia/devhub/templates/devhub/index.html:109 src/olympia/devhub/templates/devhub/includes/addon_details.html:131 src/olympia/devhub/templates/devhub/personas/edit.html:49
 msgid "Queue Position:"
 msgstr "審査待ちの順番:"
 
-#: src/olympia/devhub/templates/devhub/index.html:110 src/olympia/devhub/templates/devhub/includes/addon_details.html:146 src/olympia/devhub/templates/devhub/personas/edit.html:50
+#: src/olympia/devhub/templates/devhub/index.html:110 src/olympia/devhub/templates/devhub/includes/addon_details.html:132 src/olympia/devhub/templates/devhub/personas/edit.html:50
 #, python-format
 msgid "%(position)s of %(total)s"
 msgstr "%(total)s 個中 %(position)s 個目"
@@ -4191,16 +4230,6 @@ msgstr "アップロード完了後、アドオンに含まれるファイルに
 msgid "Do you want your add-on to be distributed on this site?"
 msgstr "このアドオンを当サイトで配布しますか？"
 
-#: src/olympia/devhub/templates/devhub/validate_addon.html:49 src/olympia/devhub/templates/devhub/addons/submit/upload.html:30 src/olympia/devhub/templates/devhub/versions/add_file_modal.html:14
-#: src/olympia/devhub/templates/devhub/versions/add_file_modal.html:53 src/olympia/devhub/templates/devhub/versions/list.html:298
-msgid "Warning:"
-msgstr "警告:"
-
-#: src/olympia/devhub/templates/devhub/validate_addon.html:50 src/olympia/devhub/templates/devhub/addons/submit/upload.html:31
-#, python-format
-msgid "Submission of unlisted add-ons for signing is currently in an open beta. Please <a href=\"%(url)s\" target=\"_blank\">report any bugs</a> that you encounter."
-msgstr "非掲載アドオンの署名用提出は現在オープンベータとなっています。何か問題に遭遇した場合は <a href=\"%(url)s\" target=\"_blank\">バグを報告してください</a>。"
-
 #. first parameter is a filename like lorem-ipsum-1.0.2.xpi
 #: src/olympia/devhub/templates/devhub/validation.html:5
 msgid "Validation Results for {0}"
@@ -4259,9 +4288,11 @@ msgstr "このアドオンは、%(app_name)s の最新版である <b>%(app_name
 #: src/olympia/devhub/templates/devhub/addons/ajax_compat_error.html:15
 #, python-format
 msgid ""
-"<a href=\"#\" class=\"button compat-update\" data-updateurl=\"%(update_url)s\">Update Compatibility</a> <a href=\"%(version_url)s\" class=\"button\">Upload New Version</a> or <a href=\"#\" "
-"class=\"close\">Ignore</a>"
-msgstr "<a href=\"#\" class=\"button compat-update\" data-updateurl=\"%(update_url)s\">互換性情報を更新</a> <a href=\"%(version_url)s\" class=\"button\">新バージョンをアップロード</a> または <a href=\"#\" class=\"close\">無視</a>"
+"<a href=\"#\" class=\"button compat-update\" data-updateurl=\"%(update_url)s\">Update Compatibility</a> <a href=\"%(version_url)s\" class=\"button\">Upload New Version</a> or <a href=\"#\" class="
+"\"close\">Ignore</a>"
+msgstr ""
+"<a href=\"#\" class=\"button compat-update\" data-updateurl=\"%(update_url)s\">互換性情報を更新</a> <a href=\"%(version_url)s\" class=\"button\">新バージョンをアップロード</a> または <a href=\"#\" "
+"class=\"close\">無視</a>"
 
 #: src/olympia/devhub/templates/devhub/addons/ajax_compat_status.html:5
 msgid "View and update application compatibility ranges."
@@ -4275,7 +4306,7 @@ msgstr "互換性"
 msgid "Update Compatibility"
 msgstr "互換性を更新"
 
-#: src/olympia/devhub/templates/devhub/addons/ajax_compat_update.html:4
+#: src/olympia/devhub/templates/devhub/addons/ajax_compat_update.html:4 src/olympia/devhub/templates/devhub/versions/edit.html:45
 msgid "Adjusting application information here will allow users to install your add-on even if the install manifest in the package indicates that the add-on is incompatible."
 msgstr "ここでアプリケーション情報を編集すると、パッケージ内のインストールマニフェストでアドオンの互換性がなくても、ユーザがこのアドオンをインストールできるようになります。"
 
@@ -4287,9 +4318,9 @@ msgstr "対応バージョン"
 msgid "Add Another Application&hellip;"
 msgstr "別のアプリケーションを追加&hellip;"
 
-#: src/olympia/devhub/templates/devhub/addons/ajax_compat_update.html:38 src/olympia/devhub/templates/devhub/addons/owner.html:86 src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:46
-#: src/olympia/devhub/templates/devhub/versions/list.html:351 src/olympia/devhub/templates/devhub/versions/list.html:353 src/olympia/templates/impala/base.html:132
-#: src/olympia/templates/impala/base.html:143 src/olympia/templates/impala/base.html:161 src/olympia/templates/impala/base.html:171
+#: src/olympia/devhub/templates/devhub/addons/ajax_compat_update.html:38 src/olympia/devhub/templates/devhub/addons/owner.html:86 src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:45
+#: src/olympia/devhub/templates/devhub/versions/list.html:349 src/olympia/devhub/templates/devhub/versions/list.html:351 src/olympia/templates/impala/base.html:129
+#: src/olympia/templates/impala/base.html:140 src/olympia/templates/impala/base.html:158 src/olympia/templates/impala/base.html:168
 msgid "Close"
 msgstr "閉じる"
 
@@ -4307,6 +4338,7 @@ msgstr "自分のアドオンの以前のアクティビティ"
 msgid "<b>{0}</b> theme"
 msgid_plural "<b>{0}</b> themes"
 msgstr[0] "<b>{0}</b> 個のテーマ"
+msgstr[1] ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit.html:3 src/olympia/devhub/templates/devhub/addons/listing/item_actions.html:25
 #: src/olympia/devhub/templates/devhub/addons/listing/item_actions_theme.html:7 src/olympia/devhub/templates/devhub/includes/addons_edit_nav.html:2
@@ -4322,7 +4354,7 @@ msgstr "なし"
 msgid "Manage Authors & License"
 msgstr "作者とライセンスを管理"
 
-#: src/olympia/devhub/templates/devhub/addons/owner.html:29 src/olympia/editors/templates/editors/review.html:270
+#: src/olympia/devhub/templates/devhub/addons/owner.html:29 src/olympia/editors/helpers.py:362 src/olympia/editors/templates/editors/review.html:270
 msgid "Authors"
 msgstr "作者"
 
@@ -4336,8 +4368,8 @@ msgid ""
 "<li><b>Developer:</b> Can manage all aspects of the add-on's listing, except for adding and removing other authors and managing payments</li> <li><b>Viewer:</b> Can view the add-on's settings and "
 "statistics, but cannot make any changes</li> </ul>"
 msgstr ""
-"<p>アドオンの作者は何名でも追加でき、次のいずれかの役割を持たせられます:</p> <ul> <li><b>オーナー:</b> 他の作者の追加と削除を含め、アドオンのあらゆる情報を管理できます</li> <li><b>開発者:</b> 他の作者の追加と削除および決済情報の管理を除く、アドオンのあらゆる情報を管理できます</li> <li><b>ビューア:</b> "
-"アドオンの設定と統計情報を見ることができますが、変更は一切できません</li> </ul>"
+"<p>アドオンの作者は何名でも追加でき、次のいずれかの役割を持たせられます:</p> <ul> <li><b>オーナー:</b> 他の作者の追加と削除を含め、アドオンのあらゆる情報を管理できます</li> <li><b>開発者:</b> 他の作"
+"者の追加と削除および決済情報の管理を除く、アドオンのあらゆる情報を管理できます</li> <li><b>ビューア:</b> アドオンの設定と統計情報を見ることができますが、変更は一切できません</li> </ul>"
 
 #: src/olympia/devhub/templates/devhub/addons/profile.html:3 src/olympia/devhub/templates/devhub/addons/listing/item_actions.html:53 src/olympia/devhub/templates/devhub/includes/addons_edit_nav.html:4
 msgid "Manage Developer Profile"
@@ -4392,7 +4424,8 @@ msgid "Summary"
 msgstr "概要"
 
 #: src/olympia/devhub/templates/devhub/addons/edit/basic.html:52
-msgid "A short explanation of your add-on's basic functionality that is displayed in search and browse listings, as well as at the top of your add-on's details page. It is only relevant for listed add-ons."
+msgid ""
+"A short explanation of your add-on's basic functionality that is displayed in search and browse listings, as well as at the top of your add-on's details page. It is only relevant for listed add-ons."
 msgstr "検索結果やカテゴリなどのリスト、そしてアドオンの詳細ページ最上部に表示される、このアドオンの基本機能についての短い説明文。当該アドオンにのみ関係します。"
 
 #: src/olympia/devhub/templates/devhub/addons/edit/basic.html:73
@@ -4401,8 +4434,11 @@ msgstr "カテゴリはユーザがアドオンを探すための主要な手段
 
 #: src/olympia/devhub/templates/devhub/addons/edit/basic.html:90
 #, python-format
-msgid "Categories cannot be changed while your add-on is featured for this application. Please email <a href=\"mailto:%(email)s\">%(email)s</a> if there is a reason you need to modify your categories."
-msgstr "カテゴリは、アドオンがこのアプリケーションのおすすめアドオンに設定されている間は変更できません。カテゴリを変更する必要がある場合は、その理由を <a href=\"mailto:%(email)s\">%(email)s</a> 宛にメールでお知らせください。"
+msgid ""
+"Categories cannot be changed while your add-on is featured for this application. Please email <a href=\"mailto:%(email)s\">%(email)s</a> if there is a reason you need to modify your categories."
+msgstr ""
+"カテゴリは、アドオンがこのアプリケーションのおすすめアドオンに設定されている間は変更できません。カテゴリを変更する必要がある場合は、その理由を <a href=\"mailto:%(email)s\">%(email)s</a> 宛にメールで"
+"お知らせください。"
 
 #: src/olympia/devhub/templates/devhub/addons/edit/basic.html:119
 msgid "Tags help users find your add-on and should be short descriptors such as tabs, toolbar, or twitter. You may have a maximum of {0} tags. It is only relevant for listed add-ons."
@@ -4412,6 +4448,7 @@ msgstr "タグはユーザがアドオンを探すのに役立つ、タブ、ツ
 msgid "Comma-separated, minimum of {0} character."
 msgid_plural "Comma-separated, minimum of {0} characters."
 msgstr[0] "カンマ区切りで最低 {0} 文字。"
+msgstr[1] ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/basic.html:132 src/olympia/devhub/templates/devhub/personas/edit.html:100 src/olympia/devhub/templates/devhub/personas/submit.html:49
 msgid "Example: dark, cinema, noir. Limit 20."
@@ -4421,6 +4458,7 @@ msgstr "例、ダーク、映画、黒。最大 20 個。"
 msgid "Reserved tag:"
 msgid_plural "Reserved tags:"
 msgstr[0] "予約済みのタグ:"
+msgstr[1] ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/details.html:5
 msgid "Add-on Details"
@@ -4451,7 +4489,8 @@ msgstr "ホームページ"
 msgid ""
 "If your add-on has another homepage, enter its address here. If your website is localized into other languages multiple translations of this field can be added. It is only relevant for listed add-"
 "ons."
-msgstr "このアドオンに別のホームページがある場合は、そのアドレスを入力してください。そのサイトが他の言語に翻訳されている場合は、この項目の翻訳を複数追加することもできます。当該アドオンにのみ関係します。"
+msgstr ""
+"このアドオンに別のホームページがある場合は、そのアドレスを入力してください。そのサイトが他の言語に翻訳されている場合は、この項目の翻訳を複数追加することもできます。当該アドオンにのみ関係します。"
 
 #: src/olympia/devhub/templates/devhub/addons/edit/media.html:3
 msgid "Images"
@@ -4470,13 +4509,17 @@ msgstr "{0} のサポート情報"
 msgid ""
 "If you wish to display an e-mail address for support inquiries, enter it here. If you have different addresses for each language multiple translations of this field can be added. It is only "
 "relevant for listed add-ons."
-msgstr "サポートに関する問い合わせのためのメールアドレスを表示したい場合は、そのアドレスを入力してください。言語ごとに異なるアドレスがある場合は、この項目の翻訳を複数追加することもできます。当該アドオンにのみ関係します。"
+msgstr ""
+"サポートに関する問い合わせのためのメールアドレスを表示したい場合は、そのアドレスを入力してください。言語ごとに異なるアドレスがある場合は、この項目の翻訳を複数追加することもできます。当該アドオンにの"
+"み関係します。"
 
 #: src/olympia/devhub/templates/devhub/addons/edit/support.html:45
 msgid ""
 "If your add-on has a support website or forum, enter its address here. If your website is localized into other languages, multiple translations of this field can be added. It is only relevant for "
 "listed add-ons."
-msgstr "このアドオンのサポートに関するサイトやフォーラムがある場合は、そのアドレスを入力してください。サイトが他の言語でも提供されている場合は、この項目の翻訳を複数追加することもできます。当該アドオンにのみ関係します。"
+msgstr ""
+"このアドオンのサポートに関するサイトやフォーラムがある場合は、そのアドレスを入力してください。サイトが他の言語でも提供されている場合は、この項目の翻訳を複数追加することもできます。当該アドオンにのみ"
+"関係します。"
 
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:6
 msgid "Technical Details"
@@ -4491,7 +4534,9 @@ msgstr "{0} の技術的な詳細"
 msgid ""
 "Any information end users may want to know that isn't necessarily applicable to the add-on summary or description. Common uses include listing known major bugs, information on how to report bugs, "
 "anticipated release date of a new version, etc. It is only relevant for listed add-ons."
-msgstr "アドオンの要約や説明には必ずしも当てはまらないものの、エンドユーザが知りたいと思われる何らかの情報。例えば、既知の主要なバグ一覧、バグ報告方法の説明、新バージョンの予定公開日などを記入できます。当該アドオンにのみ関係します。"
+msgstr ""
+"アドオンの要約や説明には必ずしも当てはまらないものの、エンドユーザが知りたいと思われる何らかの情報。例えば、既知の主要なバグ一覧、バグ報告方法の説明、新バージョンの予定公開日などを記入できます。当該"
+"アドオンにのみ関係します。"
 
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:46
 msgid "Limit 3"
@@ -4581,7 +4626,9 @@ msgstr "ホワイトボード"
 msgid ""
 "The whiteboard is the place to provide information relevant to your addon, whatever the version, to the editor. Use it to provide ways to test the addon, and any additional information that may "
 "help. This whiteboard is also editable by editors."
-msgstr "ホワイトボードはあなたのアドオンおよび各バージョンに関連する情報を編集者に提供する場所です。アドオンのテスト方法や、有用な追加情報を提供するために使用してください。このホワイトボードは編集者も編集可能です。"
+msgstr ""
+"ホワイトボードはあなたのアドオンおよび各バージョンに関連する情報を編集者に提供する場所です。アドオンのテスト方法や、有用な追加情報を提供するために使用してください。このホワイトボードは編集者も編集可"
+"能です。"
 
 #: src/olympia/devhub/templates/devhub/addons/edit/technical_dependencies.html:9
 msgid "Remove this dependent add-on"
@@ -4603,7 +4650,9 @@ msgstr "アドオンのアイコン"
 msgid ""
 "Upload an icon for your add-on or choose from one of ours. The icon is displayed nearly everywhere your add-on is. Uploaded images must be one of the following image types: .png, .jpg. It is only "
 "relevant for listed add-ons."
-msgstr "このアドオンのアイコンをアップロードするか、用意されたものの中からひとつ選んでください。アイコンはアドオンが掲載されるほぼすべての場所に表示されます。アップロードする画像は PNG もしくは JPEG 形式でなければなりません。当該アドオンにのみ関係します。"
+msgstr ""
+"このアドオンのアイコンをアップロードするか、用意されたものの中からひとつ選んでください。アイコンはアドオンが掲載されるほぼすべての場所に表示されます。アップロードする画像は PNG もしくは JPEG 形式で"
+"なければなりません。当該アドオンにのみ関係します。"
 
 #: src/olympia/devhub/templates/devhub/addons/forms_shared/media.html:25
 msgid "Select an icon for your add-on:"
@@ -4710,16 +4759,14 @@ msgid "Deleting your add-on will permanently remove it from the site and prevent
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:24
-msgid ""
-"Enter the following text confirm your decision:\n"
-"           {slug}"
+msgid "Enter the following text confirm your decision: {slug}"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:34
+#: src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:33
 msgid "Please tell us why you are deleting your theme:"
 msgstr "このテーマを削除する理由を教えてください:"
 
-#: src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:36
+#: src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:35
 msgid "Please tell us why you are deleting your add-on:"
 msgstr "このアドオンを削除する理由を教えてください:"
 
@@ -4756,13 +4803,13 @@ msgstr "新バージョン"
 msgid "Daily statistics on downloads and users."
 msgstr "ダウンロード数とユーザ数に関する日別統計です。"
 
-#: src/olympia/devhub/templates/devhub/addons/listing/item_actions.html:45 src/olympia/stats/templates/stats/stats.html:75 src/olympia/stats/templates/stats/stats.html:79
-#: src/olympia/stats/templates/stats/stats.html:81
+#: src/olympia/devhub/templates/devhub/addons/listing/item_actions.html:45 src/olympia/stats/templates/stats/stats.html:31 src/olympia/stats/templates/stats/stats.html:35
+#: src/olympia/stats/templates/stats/stats.html:37
 msgid "Statistics"
 msgstr "統計情報"
 
-#: src/olympia/devhub/templates/devhub/addons/listing/item_actions.html:54 src/olympia/devhub/templates/devhub/includes/addons_edit_nav.html:5 src/olympia/devhub/templates/devhub/payments/payments.html:3
-#: src/olympia/devhub/templates/devhub/payments/tier.html:4
+#: src/olympia/devhub/templates/devhub/addons/listing/item_actions.html:54 src/olympia/devhub/templates/devhub/includes/addons_edit_nav.html:5
+#: src/olympia/devhub/templates/devhub/payments/payments.html:3 src/olympia/devhub/templates/devhub/payments/tier.html:4
 msgid "Manage Payments"
 msgstr "決済情報を管理"
 
@@ -4817,6 +4864,7 @@ msgstr "<b>審査待ちの順番:</b> %(total)s 個中 %(pos)s 個目"
 msgid "<strong>{0}</strong> active user"
 msgid_plural "<strong>{0}</strong> active users"
 msgstr[0] "<strong>{0}</strong> 人のアクティブユーザ"
+msgstr[1] ""
 
 #: src/olympia/devhub/templates/devhub/addons/submit/base.html:11
 msgid "Submit Add-on"
@@ -4962,7 +5010,9 @@ msgstr "ステップ 4. 画像を追加"
 msgid ""
 "Custom icons and screenshots draw attention and help users understand what it does. We strongly recommend uploading a custom icon, as in some areas of the website, only the icon and name will "
 "appear."
-msgstr "独自のアイコンとスクリーンショットは、ユーザの注目を集め、それがどのようなものかを理解するのに役立ちます。サイトの一部ではアイコンと名前のみが表示されるため、独自のアイコンをアップロードすることを強く推奨します。"
+msgstr ""
+"独自のアイコンとスクリーンショットは、ユーザの注目を集め、それがどのようなものかを理解するのに役立ちます。サイトの一部ではアイコンと名前のみが表示されるため、独自のアイコンをアップロードすることを強"
+"く推奨します。"
 
 #: src/olympia/devhub/templates/devhub/addons/submit/select-review.html:5
 msgid "Step 6"
@@ -4976,7 +5026,9 @@ msgstr "ステップ 6. 審査方法を選択"
 msgid ""
 "All add-ons hosted in our gallery must be reviewed by an editor before they appear in categories or search results. While waiting for review, your add-on can still be accessed through its direct "
 "URL. Please choose the review process below that best fits your add-on."
-msgstr "このサイトに掲載されるすべてのアドオンは、カテゴリや検索結果に表示される前に、エディタによる審査を受けなければなりません。審査を待っている間も、アドオンのページは URL を直接入力することで表示できます。このアドオンに合った審査方法を以下から選んでください。"
+msgstr ""
+"このサイトに掲載されるすべてのアドオンは、カテゴリや検索結果に表示される前に、エディタによる審査を受けなければなりません。審査を待っている間も、アドオンのページは URL を直接入力することで表示できま"
+"す。このアドオンに合った審査方法を以下から選んでください。"
 
 #: src/olympia/devhub/templates/devhub/addons/submit/select-review.html:26
 #, python-format
@@ -5082,11 +5134,11 @@ msgstr "ステップ 2. アドオンをアップロード"
 msgid "Use the fields below to upload your add-on package and select any platform restrictions. After upload, a series of automated validation tests will be run on your file."
 msgstr "下のフォームを使ってアドオンのパッケージをアップロードし、対応 OS を選択してください。アップロードが完了すると、そのファイルに対して一連の自動検証テストが実施されます。"
 
-#: src/olympia/devhub/templates/devhub/addons/submit/upload.html:59 src/olympia/devhub/templates/devhub/versions/add_file_modal.html:39
+#: src/olympia/devhub/templates/devhub/addons/submit/upload.html:51 src/olympia/devhub/templates/devhub/versions/add_file_modal.html:28
 msgid "Which platforms is this file compatible with?"
 msgstr "このファイルの対応プラットフォーム"
 
-#: src/olympia/devhub/templates/devhub/addons/submit/upload.html:67 src/olympia/devhub/templates/devhub/versions/add_file_modal.html:65
+#: src/olympia/devhub/templates/devhub/addons/submit/upload.html:59 src/olympia/devhub/templates/devhub/versions/add_file_modal.html:45
 msgid "Administrative overrides"
 msgstr "管理者による上書き"
 
@@ -5114,9 +5166,11 @@ msgstr "JWT 秘密鍵"
 #: src/olympia/devhub/templates/devhub/api/key.html:37
 #, python-format
 msgid ""
-"To make API requests, send a <a href=\"%(jwt_url)s\">JSON Web Token (JWT)</a> as the authorization header. You'll need to generate a JWT for every request as explained in the <a "
-"href=\"%(docs_url)s\">API documentation</a>."
-msgstr "API リクエストを行うには、認証ヘッダとして <a href=\"%(jwt_url)s\">JSON Web Token (JWT)</a> を送信します。<a href=\"%(docs_url)s\">API ドキュメント</a> に書かれている通り、リクエストごとに JWT を生成する必要があります。"
+"To make API requests, send a <a href=\"%(jwt_url)s\">JSON Web Token (JWT)</a> as the authorization header. You'll need to generate a JWT for every request as explained in the <a href=\"%(docs_url)s"
+"\">API documentation</a>."
+msgstr ""
+"API リクエストを行うには、認証ヘッダとして <a href=\"%(jwt_url)s\">JSON Web Token (JWT)</a> を送信します。<a href=\"%(docs_url)s\">API ドキュメント</a> に書かれている通り、リクエストごとに JWT を生"
+"成する必要があります。"
 
 #: src/olympia/devhub/templates/devhub/api/key.html:47
 msgid "You don't have any API credentials yet."
@@ -5135,8 +5189,8 @@ msgstr "認証情報を無効化して再生成"
 msgid "Generate new credentials"
 msgstr "新しい認証情報を生成"
 
-#: src/olympia/devhub/templates/devhub/docs/policies-agreement.html:3 src/olympia/devhub/templates/devhub/docs/policies-agreement.html:7 src/olympia/devhub/templates/devhub/docs/policies-agreement.html:9
-#: src/olympia/devhub/templates/devhub/docs/policies.html:24 src/olympia/devhub/templates/devhub/docs/policies.html:103
+#: src/olympia/devhub/templates/devhub/docs/policies-agreement.html:3 src/olympia/devhub/templates/devhub/docs/policies-agreement.html:7
+#: src/olympia/devhub/templates/devhub/docs/policies-agreement.html:9 src/olympia/devhub/templates/devhub/docs/policies.html:24 src/olympia/devhub/templates/devhub/docs/policies.html:103
 msgid "Developer Agreement"
 msgstr "開発者規約"
 
@@ -5157,7 +5211,9 @@ msgstr "アドオンのサポート"
 msgid ""
 "If you have a support question about a particular add-on, such as \"how do I use this add-on?\" or \"why doesn't this work properly?\", please contact that add-on's author through the support "
 "channels listed on the add-on's listing page."
-msgstr "特定のアドオンについて「どうやってこのアドオンを使ったら良いか」「この機能が正しく動作しないのはなぜか」といったサポート関連の質問がある場合は、そのアドオンの紹介ページに記載されているサポートチャンネルを通じてアドオンの作者に問い合わせてください。"
+msgstr ""
+"特定のアドオンについて「どうやってこのアドオンを使ったら良いか」「この機能が正しく動作しないのはなぜか」といったサポート関連の質問がある場合は、そのアドオンの紹介ページに記載されているサポートチャン"
+"ネルを通じてアドオンの作者に問い合わせてください。"
 
 #: src/olympia/devhub/templates/devhub/docs/policies-contact.html:24
 msgid "Add-on Editorial Concerns"
@@ -5170,9 +5226,11 @@ msgstr "amo-editors at mozilla dot org"
 #: src/olympia/devhub/templates/devhub/docs/policies-contact.html:26
 #, python-format
 msgid ""
-"If you have a question about an Editor's review of an add-on or want to report a policy violation, please email %(mail_editors)s. <strong>Almost all add-on reports fall under this "
-"category.</strong> Please be sure to include a link to the add-on in question and a detailed description of your question or comment."
-msgstr "エディタによるアドオンの審査について質問がある場合や、ポリシー違反について報告したい場合は、%(mail_editors)s までメールを送ってください。<strong>アドオンの報告はほぼすべてこのカテゴリに当てはまります</strong>。なお、メール本文には、当該アドオンへのリンクとあなたの質問や意見に関する詳細を必ず含めてください。"
+"If you have a question about an Editor's review of an add-on or want to report a policy violation, please email %(mail_editors)s. <strong>Almost all add-on reports fall under this category.</"
+"strong> Please be sure to include a link to the add-on in question and a detailed description of your question or comment."
+msgstr ""
+"エディタによるアドオンの審査について質問がある場合や、ポリシー違反について報告したい場合は、%(mail_editors)s までメールを送ってください。<strong>アドオンの報告はほぼすべてこのカテゴリに当てはまりま"
+"す</strong>。なお、メール本文には、当該アドオンへのリンクとあなたの質問や意見に関する詳細を必ず含めてください。"
 
 #: src/olympia/devhub/templates/devhub/docs/policies-contact.html:31
 msgid "Add-on Security Vulnerabilities"
@@ -5186,11 +5244,12 @@ msgstr "amo-admins at mozilla dot org"
 #, python-format
 msgid ""
 "If you have discovered a security vulnerability in an add-on, even if it is not hosted here, Mozilla is very interested in your discovery and will work with the add-on developer to correct the "
-"issue as soon as possible. Add-on security issues can be reported <a href=\"http://www.mozilla.org/projects/security/security-bugs-policy.html\">confidentially</a> in <a "
-"href=\"%(link_bugzilla)s\">Bugzilla</a> or by emailing %(mail_admins)s."
+"issue as soon as possible. Add-on security issues can be reported <a href=\"http://www.mozilla.org/projects/security/security-bugs-policy.html\">confidentially</a> in <a href=\"%(link_bugzilla)s"
+"\">Bugzilla</a> or by emailing %(mail_admins)s."
 msgstr ""
-"アドオンにセキュリティ脆弱性を見つけた場合、それが当サイトに掲載されているかどうかに関わらず、Mozilla はあなたの発見に非常に関心があり、アドオン作者と協力してできるだけ早くその問題を修正します。アドオンのセキュリティ問題は <a href=\"%(link_bugzilla)s\">Bugzilla</a> もしくはメール %(mail_admins)s を通じて <a "
-"href=\"http://www.mozilla.org/projects/security/security-bugs-policy.html\">内密に</a> 報告できます。"
+"アドオンにセキュリティ脆弱性を見つけた場合、それが当サイトに掲載されているかどうかに関わらず、Mozilla はあなたの発見に非常に関心があり、アドオン作者と協力してできるだけ早くその問題を修正します。アド"
+"オンのセキュリティ問題は <a href=\"%(link_bugzilla)s\">Bugzilla</a> もしくはメール %(mail_admins)s を通じて <a href=\"http://www.mozilla.org/projects/security/security-bugs-policy.html\">内密に</a> "
+"報告できます。"
 
 #: src/olympia/devhub/templates/devhub/docs/policies-contact.html:42
 msgid "Website Functionality & Development"
@@ -5198,8 +5257,8 @@ msgstr "Web サイトの機能と開発"
 
 #: src/olympia/devhub/templates/devhub/docs/policies-contact.html:44
 msgid ""
-"If you've found a problem with the site, we'd love to fix it. Please <a href=\"https://github.com/mozilla/olympia/issues\">file a bug report</a> in GitHub, including the location of the problem and"
-" how you encountered it."
+"If you've found a problem with the site, we'd love to fix it. Please <a href=\"https://github.com/mozilla/addons/issues/new\">file a bug report</a> in GitHub, including the location of the problem "
+"and how you encountered it."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/docs/policies-maintenance.html:3 src/olympia/devhub/templates/devhub/docs/policies-maintenance.html:7
@@ -5213,12 +5272,13 @@ msgstr "アドオンの新バージョンの登録"
 
 #: src/olympia/devhub/templates/devhub/docs/policies-maintenance.html:12
 msgid ""
-"Developers are encouraged to submit updates to their add-ons to fix bugs, add features, and otherwise improve their product. New versions of an add-on must have a <a "
-"href=\"https://developer.mozilla.org/en/Toolkit_version_format\">higher version number</a> and can be submitted through the Developer Tools provided. There is no limit to the number of versions "
-"that can be submitted, but please remember that versions must be reviewed by an editor."
+"Developers are encouraged to submit updates to their add-ons to fix bugs, add features, and otherwise improve their product. New versions of an add-on must have a <a href=\"https://developer."
+"mozilla.org/en/Toolkit_version_format\">higher version number</a> and can be submitted through the Developer Tools provided. There is no limit to the number of versions that can be submitted, but "
+"please remember that versions must be reviewed by an editor."
 msgstr ""
-"開発者には、バグの修正、機能の追加、その他一般的な改善のためにアドオンの更新を提供するよう推奨します。アドオンの新バージョンには <a href=\"https://developer.mozilla.org/en/Toolkit_version_format\">より大きいバージョン番号</a> "
-"を付けなければならず、当サイト上で提供されている開発者ツールを通じて登録できます。登録可能なバージョンの数に制限はありませんが、各バージョンはエディタによる審査を受ける必要があることを念頭に置いてください。"
+"開発者には、バグの修正、機能の追加、その他一般的な改善のためにアドオンの更新を提供するよう推奨します。アドオンの新バージョンには <a href=\"https://developer.mozilla.org/en/Toolkit_version_format\">"
+"より大きいバージョン番号</a> を付けなければならず、当サイト上で提供されている開発者ツールを通じて登録できます。登録可能なバージョンの数に制限はありませんが、各バージョンはエディタによる審査を受ける"
+"必要があることを念頭に置いてください。"
 
 #: src/olympia/devhub/templates/devhub/docs/policies-maintenance.html:18
 msgid "New versions will be added to a pending review queue, and any additional versions submitted before the review is completed will move that version to the end of the queue."
@@ -5237,8 +5297,8 @@ msgid ""
 "To create a beta channel, upload a file with a unique version string that contains any of the following strings: <code>a,b,alpha,beta,pre,rc</code>, with an optional number at the end. This text "
 "must come at the end of the version string. If you understand regex format, here's what we look for in the version number: <code>\"(a|alpha|b|beta|pre|rc)\\d*$\"</code>."
 msgstr ""
-"ベータチャンネルを作成するには、<code>a,b,alpha,beta,pre,rc</code> のいずれかの文字列を含めた固有のバージョンを付けたファイルをアップロードしてください。末尾には任意で番号も付けられますが、これらの文字列はバージョン文字列の後に足さなければなりません。正規表現で表した場合、バージョン番号は "
-"<code>\"(a|alpha|b|beta|pre|rc)\\d*$\"</code> のようになります。"
+"ベータチャンネルを作成するには、<code>a,b,alpha,beta,pre,rc</code> のいずれかの文字列を含めた固有のバージョンを付けたファイルをアップロードしてください。末尾には任意で番号も付けられますが、これらの"
+"文字列はバージョン文字列の後に足さなければなりません。正規表現で表した場合、バージョン番号は <code>\"(a|alpha|b|beta|pre|rc)\\d*$\"</code> のようになります。"
 
 #: src/olympia/devhub/templates/devhub/docs/policies-maintenance.html:37
 msgid ""
@@ -5253,8 +5313,10 @@ msgid ""
 "<code>1.0beta1</code> will be offered an upgrade to <code>1.1alpha1</code>. Updates are pushed by submission date and not version number, so users will always get the most recent channel update "
 "regardless of any kind of alphabetical sorting."
 msgstr ""
-"私たちはそれらを「ベータ版」と呼んでいますが、あなたは必要に応じてこのチャンネルをナイトリー、アルファ、あるいはプレリリース版として使うこともできます。なお、そうした目的のためのチャンネルは 1 つだけしかなく、登録された最新のアドオンがこのチャンネル上のユーザ全員に配信されます。リリースチャンネルに <code>1.0beta1</code> をアップロードし、その後で "
-"<code>1.1alpha1</code> をアップロードした場合、<code>1.0beta1</code> のユーザ全員に <code>1.1alpha1</code> への更新が提供されます。更新はバージョン番号ではなく登録日に応じて配信されるため、バージョン文字列のアルファベット順に関わらず、ユーザは常に最新の更新を受け取ることになります。"
+"私たちはそれらを「ベータ版」と呼んでいますが、あなたは必要に応じてこのチャンネルをナイトリー、アルファ、あるいはプレリリース版として使うこともできます。なお、そうした目的のためのチャンネルは 1 つだ"
+"けしかなく、登録された最新のアドオンがこのチャンネル上のユーザ全員に配信されます。リリースチャンネルに <code>1.0beta1</code> をアップロードし、その後で <code>1.1alpha1</code> をアップロードした場"
+"合、<code>1.0beta1</code> のユーザ全員に <code>1.1alpha1</code> への更新が提供されます。更新はバージョン番号ではなく登録日に応じて配信されるため、バージョン文字列のアルファベット順に関わらず、ユーザ"
+"は常に最新の更新を受け取ることになります。"
 
 #: src/olympia/devhub/templates/devhub/docs/policies-maintenance.html:48
 msgid "Required Updates"
@@ -5266,8 +5328,8 @@ msgid ""
 "developers to reasonably accommodate their own schedules, but if the issue is of a serious enough nature, add-ons that cannot issue an update with the requested fix may be demoted from fully-"
 "reviewed status, disabled, or permanently removed from the site."
 msgstr ""
-"重要なセキュリティ問題やポリシー違反を解決するため、一定期間内にアドオンを更新するよう Mozilla "
-"から作者に依頼するといった状況がごくまれに発生します。私たちは作者と協力してある程度スケジュールに配慮しますが、その問題が相当深刻であった場合、要請された修正を行った更新を提供できないアドオンは、本審査のステータスを取り消されたり、無効化されたり、当サイトから完全に削除されたりする可能性もあります。"
+"重要なセキュリティ問題やポリシー違反を解決するため、一定期間内にアドオンを更新するよう Mozilla から作者に依頼するといった状況がごくまれに発生します。私たちは作者と協力してある程度スケジュールに配慮"
+"しますが、その問題が相当深刻であった場合、要請された修正を行った更新を提供できないアドオンは、本審査のステータスを取り消されたり、無効化されたり、当サイトから完全に削除されたりする可能性もあります。"
 
 #: src/olympia/devhub/templates/devhub/docs/policies-maintenance.html:55
 msgid "Transfer of Ownership"
@@ -5277,7 +5339,9 @@ msgstr "オーナーの変更"
 msgid ""
 "Add-ons can have multiple users with permission to update and manage the listing. Existing authors of an add-on can transfer ownership and add additional developers to an add-on's listing through "
 "the Developer Tools provided. No interaction with Mozilla representatives is necessary for a transfer of ownership."
-msgstr "アドオンには、更新や紹介ページの管理を行う権限を持ったユーザを複数指定できます。アドオンの既存の作者は、当サイト上の開発者ツールを通じて、アドオンの所有権を委譲したり別の開発者を紹介ページに追加したりすることが可能です。所有権の委譲に関して Mozilla の担当者と相談する必要はありません。"
+msgstr ""
+"アドオンには、更新や紹介ページの管理を行う権限を持ったユーザを複数指定できます。アドオンの既存の作者は、当サイト上の開発者ツールを通じて、アドオンの所有権を委譲したり別の開発者を紹介ページに追加した"
+"りすることが可能です。所有権の委譲に関して Mozilla の担当者と相談する必要はありません。"
 
 #: src/olympia/devhub/templates/devhub/docs/policies-maintenance.html:63
 #, python-format
@@ -5286,22 +5350,28 @@ msgstr "アドオンの現在の所有者から <a href=\"%(link_contact)s\">連
 
 #: src/olympia/devhub/templates/devhub/docs/policies-maintenance.html:70
 msgid ""
-"Mozilla encourages its users to offer feedback on their experiences when using an add-on. This allows other users to determine if the add-on is stable and useful. It also provides valuable feedback"
-" to developers, allowing them to continuously improve their add-on to meet user needs."
-msgstr "Mozilla は各アドオンのユーザに対して、その使用体験に関するフィードバックを送るよう推奨しています。これは、そのアドオンが安定していて便利かどうか、他のユーザが判断できるようにするためです。作者にも有益なフィードバックがもたらされるので、ユーザのニーズに合わせてアドオンを継続的に改善していくことが可能です。"
+"Mozilla encourages its users to offer feedback on their experiences when using an add-on. This allows other users to determine if the add-on is stable and useful. It also provides valuable feedback "
+"to developers, allowing them to continuously improve their add-on to meet user needs."
+msgstr ""
+"Mozilla は各アドオンのユーザに対して、その使用体験に関するフィードバックを送るよう推奨しています。これは、そのアドオンが安定していて便利かどうか、他のユーザが判断できるようにするためです。作者にも有"
+"益なフィードバックがもたらされるので、ユーザのニーズに合わせてアドオンを継続的に改善していくことが可能です。"
 
 #: src/olympia/devhub/templates/devhub/docs/policies-maintenance.html:76
 #, python-format
 msgid ""
 "Reviews must follow the <a href=\"%(link_guidelines)s\">review guidelines</a>. Reviews that do not meet these guidelines may be flagged for moderation, but negative reviews will not be removed "
 "unless they provide false information."
-msgstr "すべてのレビューは <a href=\"%(link_guidelines)s\">レビューガイドライン</a> に従う必要があります。このガイドラインに沿わないレビューは管理者による確認を受ける場合もありますが、ネガティブなレビューは事実に反する情報が含まれていない限り削除されません。"
+msgstr ""
+"すべてのレビューは <a href=\"%(link_guidelines)s\">レビューガイドライン</a> に従う必要があります。このガイドラインに沿わないレビューは管理者による確認を受ける場合もありますが、ネガティブなレビューは"
+"事実に反する情報が含まれていない限り削除されません。"
 
 #: src/olympia/devhub/templates/devhub/docs/policies-maintenance.html:82
 msgid ""
 "Many developers provide a support mechanism, such as a forum, discussion group, or email address. It is recommended that support questions be posted via those mediums instead of in an add-on's "
 "review section."
-msgstr "多くの作者は、フォーラム、ディスカッショングループ、メールアドレスなど、何らかのサポート手段を提供しています。サポートに関する質問はアドオンのレビュー欄ではなくそれらのメディアを通じて投稿するよう推奨します。"
+msgstr ""
+"多くの作者は、フォーラム、ディスカッショングループ、メールアドレスなど、何らかのサポート手段を提供しています。サポートに関する質問はアドオンのレビュー欄ではなくそれらのメディアを通じて投稿するよう推"
+"奨します。"
 
 #: src/olympia/devhub/templates/devhub/docs/policies-maintenance.html:87
 msgid "Code Disputes"
@@ -5311,13 +5381,17 @@ msgstr "コードに関する異議"
 msgid ""
 "Many add-ons allow their source code to be openly viewed. This does not mean that the source code is open source or available for use in another add-on. The original author of an add-on retains "
 "copyright of their work unless otherwise noted in the add-on's license."
-msgstr "多くのアドオンはソースコードの公開を許可しています。これは必ずしも、そのソースコードがオープンソースであり、他のアドオンでも使用できるということではありません。アドオンのライセンスで明記されていない限り、その原作者がコードの著作権を保有しています。"
+msgstr ""
+"多くのアドオンはソースコードの公開を許可しています。これは必ずしも、そのソースコードがオープンソースであり、他のアドオンでも使用できるということではありません。アドオンのライセンスで明記されていない"
+"限り、その原作者がコードの著作権を保有しています。"
 
 #: src/olympia/devhub/templates/devhub/docs/policies-maintenance.html:96
 msgid ""
 "In the event that we're notified of a copyright or license infringement, we will take steps to review the situation and determine if an actual infringement has occurred. If we determine that there "
 "is an infringement, we will remove the offending add-on and contact the author. New add-on submissions (including updates) containing infringing code will be denied approval for public status."
-msgstr "著作権侵害やライセンス違反の報告を受けた場合、私たちはその状況を確認する手続きを取り、実際に違反が起きているかどうかを判断します。違反があると判断された場合、その問題あるアドオンを削除して作者に連絡を取ります。違反コードが含まれた新規登録アドオン (更新を含む) には公開ステータスは与えられません。"
+msgstr ""
+"著作権侵害やライセンス違反の報告を受けた場合、私たちはその状況を確認する手続きを取り、実際に違反が起きているかどうかを判断します。違反があると判断された場合、その問題あるアドオンを削除して作者に連絡"
+"を取ります。違反コードが含まれた新規登録アドオン (更新を含む) には公開ステータスは与えられません。"
 
 #: src/olympia/devhub/templates/devhub/docs/policies-maintenance.html:102
 msgid "If you are unsure of the current copyright status of an add-on's source code, you must contact the original author and receive explicit permission before using the source code."
@@ -5333,11 +5407,16 @@ msgstr "最終更新日: 2011 年 1 月 13 日"
 msgid ""
 "Featured add-ons are top-quality extensions and themes highlighted on <a href=\"%(link_gallery)s\">AMO</a>, Firefox's Add-ons Manager, and across other Mozilla websites. These add-ons showcase the "
 "power of Firefox customization and are useful to a wide audience."
-msgstr "おすすめのアドオンは、<a href=\"%(link_gallery)s\">AMO</a>、Firefox のアドオンマネージャ、その他 Mozilla のサイトで紹介される、高品質な拡張機能とテーマです。これらのアドオンは Firefox の高いカスタマイズ性を示し、幅広いユーザに役立つものです。"
+msgstr ""
+"おすすめのアドオンは、<a href=\"%(link_gallery)s\">AMO</a>、Firefox のアドオンマネージャ、その他 Mozilla のサイトで紹介される、高品質な拡張機能とテーマです。これらのアドオンは Firefox の高いカスタマ"
+"イズ性を示し、幅広いユーザに役立つものです。"
 
 #: src/olympia/devhub/templates/devhub/docs/policies-recommended.html:19
-msgid "Featured add-ons are chosen by the Featured Add-ons Advisory Board, a small group of add-on developers and fans from the Mozilla community who have volunteered to review and vote on nominations."
-msgstr "おすすめのアドオンは Featured Add-ons Advisory Board によって選ばれます。これは、推薦されたアドオンの審査や投票にボランティアとして参加しているアドオン作者や Mozilla コミュニティのファンによって構成される、小規模なグループです。"
+msgid ""
+"Featured add-ons are chosen by the Featured Add-ons Advisory Board, a small group of add-on developers and fans from the Mozilla community who have volunteered to review and vote on nominations."
+msgstr ""
+"おすすめのアドオンは Featured Add-ons Advisory Board によって選ばれます。これは、推薦されたアドオンの審査や投票にボランティアとして参加しているアドオン作者や Mozilla コミュニティのファンによって構成"
+"される、小規模なグループです。"
 
 #: src/olympia/devhub/templates/devhub/docs/policies-recommended.html:25
 #, python-format
@@ -5396,7 +5475,9 @@ msgstr "アドオンは Firefox の最新版に対応している必要があり
 msgid ""
 "<strong>Most importantly</strong>, the add-on must have wide consumer appeal to Firefox's users and be outstanding in nearly every way: user experience, performance, security, and usefulness or "
 "entertainment value. Featured complete themes must also be visually appealing."
-msgstr "<strong>最も重要なことは</strong>、アドオンはあらゆる Firefox ユーザにとって魅力的でなければならず、また、ユーザ体験、パフォーマンス、セキュリティ、利便性あるいは娯楽性といった価値も含め、ほぼあらゆる点で傑出していなければなりません。"
+msgstr ""
+"<strong>最も重要なことは</strong>、アドオンはあらゆる Firefox ユーザにとって魅力的でなければならず、また、ユーザ体験、パフォーマンス、セキュリティ、利便性あるいは娯楽性といった価値も含め、ほぼあらゆ"
+"る点で傑出していなければなりません。"
 
 #: src/olympia/devhub/templates/devhub/docs/policies-recommended.html:54
 msgid "Nominating an Add-on"
@@ -5428,8 +5509,8 @@ msgid ""
 "Add-on nominations are reviewed by the Advisory Board once a month (once every 3 months for complete theme nominations). Common reasons for rejection include lacking wide appeal to consumers, a "
 "suboptimal user experience, quality or security issues, incompatibility, and similarity to another featured add-on. Rejected add-ons cannot be re-nominated within 3 months."
 msgstr ""
-"アドオンの推薦は Advisory Board によって月 1 回 (完全テーマの推薦は 3 か月に 1 回) 審査されます。推薦が却下される場合のよくある理由としては、幅広い層にとって魅力さを欠く、ユーザ体験がいまいちである、品質やセキュリティに問題がある、互換性が十分でない、他のおすすめアドオンと似通っているといった点が挙げられます。却下されたアドオンを 3 "
-"か月以内に再度推薦することはできません。"
+"アドオンの推薦は Advisory Board によって月 1 回 (完全テーマの推薦は 3 か月に 1 回) 審査されます。推薦が却下される場合のよくある理由としては、幅広い層にとって魅力さを欠く、ユーザ体験がいまいちであ"
+"る、品質やセキュリティに問題がある、互換性が十分でない、他のおすすめアドオンと似通っているといった点が挙げられます。却下されたアドオンを 3 か月以内に再度推薦することはできません。"
 
 #: src/olympia/devhub/templates/devhub/docs/policies-recommended.html:73
 msgid "Rotating Featured Add-ons"
@@ -5443,7 +5524,9 @@ msgstr "Mozilla と Featured Add-ons Advisory Board はおすすめのアドオ�
 msgid ""
 "Lack of growth &mdash; Add-ons that are featured typically experience a substantial gain in both downloads and active users. If an add-on is not demonstrating growth in any substantial way, that's "
 "a good indicator the add-on may not be very useful to our users."
-msgstr "成長不足 &mdash; おすすめのリストに追加されたアドオンは一般的に、ダウンロード数とアクティブユーザ数がそれぞれ相当数増加します。アドオンが十分な成長を見せない場合、それがユーザにとってあまり役に立たない可能性を示していると言えるでしょう。"
+msgstr ""
+"成長不足 &mdash; おすすめのリストに追加されたアドオンは一般的に、ダウンロード数とアクティブユーザ数がそれぞれ相当数増加します。アドオンが十分な成長を見せない場合、それがユーザにとってあまり役に立た"
+"ない可能性を示していると言えるでしょう。"
 
 #: src/olympia/devhub/templates/devhub/docs/policies-recommended.html:88
 msgid "Negative reviews &mdash; Featured add-ons should have a great experience and very few bugs, so add-ons with many negative reviews may be reconsidered."
@@ -5453,7 +5536,9 @@ msgstr "ネガティブなレビュー &mdash; おすすめのアドオンは優
 msgid ""
 "Incompatibility with upcoming Firefox versions &mdash; Featured add-ons are expected to be compatible with stable and beta versions of Firefox. Add-ons not yet compatible with a Beta version of "
 "Firefox four weeks before its expected release will lose their featured status."
-msgstr "Firefox 次期バージョンとの非互換 &mdash; おすすめのアドオンは Firefox の安定版とベータ版に対応していることが期待されています。リリース予定日の 4 週間前になってもベータ版と互換性のないアドオンは、おすすめのリストから除かれます。"
+msgstr ""
+"Firefox 次期バージョンとの非互換 &mdash; おすすめのアドオンは Firefox の安定版とベータ版に対応していることが期待されています。リリース予定日の 4 週間前になってもベータ版と互換性のないアドオンは、お"
+"すすめのリストから除かれます。"
 
 #: src/olympia/devhub/templates/devhub/docs/policies-recommended.html:99
 msgid "Joining the Featured Add-ons Advisory Board"
@@ -5487,8 +5572,9 @@ msgid ""
 "in other locations without the Board's consent. Additionally, locale-specific features override the global defaults, so if a locale has opted to select its own features, some or all of the global "
 "features may not appear in that locale."
 msgstr ""
-"このおすすめポリシーは、addons.mozilla.org 上の全世界向けおすすめアドオンリストにのみ適用されます。他の場所で紹介されるアドオンはこのリストから選ばれることもありますが、Mozilla は Advisory Board "
-"の同意なしに他の場所で別のアドオンを紹介することもあります。また、ロケール固有のおすすめアドオンは全世界向けおすすめアドオンより優先されるため、あるロケールで独自のおすすめアドオンが選ばれた場合、一部あるいはすべての全世界向けおすすめアドオンはそのロケールでは表示されません。"
+"このおすすめポリシーは、addons.mozilla.org 上の全世界向けおすすめアドオンリストにのみ適用されます。他の場所で紹介されるアドオンはこのリストから選ばれることもありますが、Mozilla は Advisory Board の"
+"同意なしに他の場所で別のアドオンを紹介することもあります。また、ロケール固有のおすすめアドオンは全世界向けおすすめアドオンより優先されるため、あるロケールで独自のおすすめアドオンが選ばれた場合、一部"
+"あるいはすべての全世界向けおすすめアドオンはそのロケールでは表示されません。"
 
 #: src/olympia/devhub/templates/devhub/docs/policies-recommended.html:126
 #, python-format
@@ -5508,40 +5594,50 @@ msgstr "審査プロセス"
 msgid ""
 "In order to ensure all add-ons hosted in our gallery are safe for users to install, Mozilla will begin requiring all hosted add-ons to undergo review. We offer two types of review and developers "
 "are free to choose the best fit for their add-on."
-msgstr "当サイトのギャラリーに掲載されるすべてのアドオンがインストールしても安全であることを保証するため、Mozilla は今後すべての掲載アドオンに審査を義務付けます。審査には 2 種類あり、開発者はアドオンに最適な方を選択することができます。"
+msgstr ""
+"当サイトのギャラリーに掲載されるすべてのアドオンがインストールしても安全であることを保証するため、Mozilla は今後すべての掲載アドオンに審査を義務付けます。審査には 2 種類あり、開発者はアドオンに最適"
+"な方を選択することができます。"
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:19
 msgid ""
 "<strong><a href=\"#full\">Full Review</a></strong> &mdash; a thorough functional and code review of the add-on, appropriate for add-ons ready for distribution to the masses. All site features are "
 "available to these add-ons."
-msgstr "<strong><a href=\"#full\">完全審査</a></strong> &mdash; これはアドオンの徹底的な機能とコードの審査で、広く一般に配布したいアドオンに適しています。これらのアドオンは同サイトの全機能を使用できます。"
+msgstr ""
+"<strong><a href=\"#full\">完全審査</a></strong> &mdash; これはアドオンの徹底的な機能とコードの審査で、広く一般に配布したいアドオンに適しています。これらのアドオンは同サイトの全機能を使用できます。"
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:24
 msgid ""
 "<strong><a href=\"#preliminary\">Preliminary Review</a></strong> &mdash; a faster review intended for experimental add-ons. Preliminary reviews do not check for functionality or full policy "
 "compliance, but the reviewed add-ons have install button cautions and some feature limitations."
-msgstr "<strong><a href=\"#preliminary\">事前審査</a></strong> &mdash; 実験的なアドオン向けのより素早い審査。事前審査では各機能の動作やポリシーへの完全準拠は確認されませんが、審査済みのアドオンには注意書きの付いたインストールボタンが与えられ、一部機能制限もあります。"
+msgstr ""
+"<strong><a href=\"#preliminary\">事前審査</a></strong> &mdash; 実験的なアドオン向けのより素早い審査。事前審査では各機能の動作やポリシーへの完全準拠は確認されませんが、審査済みのアドオンには注意書き"
+"の付いたインストールボタンが与えられ、一部機能制限もあります。"
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:31
 msgid ""
-"Detailed descriptions of each option are below. After selecting a review process at submission, the add-on will be placed in the queue. Add-ons are reviewed by the <a "
-"href=\"https://wiki.mozilla.org/AMO:Editors\">AMO Editors</a>, a group of talented developers that volunteer to help the Mozilla project by reviewing add-ons to ensure a stable and safe experience "
-"for users. Developers will receive an email with any updates throughout the review process."
+"Detailed descriptions of each option are below. After selecting a review process at submission, the add-on will be placed in the queue. Add-ons are reviewed by the <a href=\"https://wiki.mozilla."
+"org/AMO:Editors\">AMO Editors</a>, a group of talented developers that volunteer to help the Mozilla project by reviewing add-ons to ensure a stable and safe experience for users. Developers will "
+"receive an email with any updates throughout the review process."
 msgstr ""
-"各選択肢の詳しい説明は以下の通りです。提出時に審査の種類を選択すると、アドオンは審査待ちとなります。アドオンは、ユーザにとっての安定性や安全性を確保するためにアドオンを審査することで Mozilla にボランティアとして協力してくれている経験豊富な開発者のグループである <a href=\"https://wiki.mozilla.org/AMO:Editors\">AMO エディタ</a>"
-" によって審査されます。審査の過程でアドオン作者に最新の情報がメールで送られます。"
+"各選択肢の詳しい説明は以下の通りです。提出時に審査の種類を選択すると、アドオンは審査待ちとなります。アドオンは、ユーザにとっての安定性や安全性を確保するためにアドオンを審査することで Mozilla にボラ"
+"ンティアとして協力してくれている経験豊富な開発者のグループである <a href=\"https://wiki.mozilla.org/AMO:Editors\">AMO エディタ</a> によって審査されます。審査の過程でアドオン作者に最新の情報がメール"
+"で送られます。"
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:37
 msgid ""
 "While waiting for review, add-ons will not appear anywhere in the gallery publicly, but direct links to the add-on's details page will work. This allows the author to blog or share the link with "
 "friends, inviting them to try it out, even when not yet reviewed."
-msgstr "審査を待っている間、アドオンはギャラリーのどこにも掲載されませんが、アドオンの詳細ページへの直リンクは有効となります。これにより、審査完了前でも、作者はブログでそのアドオンを紹介したり友人とリンクを共有したりして、そのアドオンを試してもらうことができます。"
+msgstr ""
+"審査を待っている間、アドオンはギャラリーのどこにも掲載されませんが、アドオンの詳細ページへの直リンクは有効となります。これにより、審査完了前でも、作者はブログでそのアドオンを紹介したり友人とリンクを"
+"共有したりして、そのアドオンを試してもらうことができます。"
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:44
 msgid ""
-"Full reviews are appropriate for add-ons that are well-tested, stable, fast, and have wide appeal to our users. If you aren't confident that your add-on meets that criteria, please consider working"
-" out the kinks while in preliminary review and accumulating user feedback first."
-msgstr "完全審査は、よくテストされ、安定し、高速で、ユーザに広く受け入れられるアドオンに適しています。あなたのアドオンがこの条件を満たしているかどうか自信がない場合は、事前審査を申請しつつ問題点を解消し、まずはユーザからのフィードバックを蓄積することを検討してください。"
+"Full reviews are appropriate for add-ons that are well-tested, stable, fast, and have wide appeal to our users. If you aren't confident that your add-on meets that criteria, please consider working "
+"out the kinks while in preliminary review and accumulating user feedback first."
+msgstr ""
+"完全審査は、よくテストされ、安定し、高速で、ユーザに広く受け入れられるアドオンに適しています。あなたのアドオンがこの条件を満たしているかどうか自信がない場合は、事前審査を申請しつつ問題点を解消し、ま"
+"ずはユーザからのフィードバックを蓄積することを検討してください。"
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:50
 msgid "We aim to perform full reviews in under 10 days, though most add-ons are reviewed in much less time."
@@ -5579,7 +5675,9 @@ msgstr "これらの審査中に見られる最も一般的な問題を以下に
 msgid ""
 "<strong>JavaScript namespace pollution</strong> &mdash; the most common violation. Be sure to <a href=\"https://developer.mozilla.org/en/XUL_School/JavaScript_Object_Management\">wrap your loose "
 "variables</a>"
-msgstr "<strong>JavaScript 名前空間汚染</strong> &mdash; 最も良くある違反行為です。<a href=\"https://developer.mozilla.org/ja/docs/XUL/School_tutorial/JavaScript_Object_Management\">変数は独自の名前空間にまとめるようにしましょう</a>"
+msgstr ""
+"<strong>JavaScript 名前空間汚染</strong> &mdash; 最も良くある違反行為です。<a href=\"https://developer.mozilla.org/ja/docs/XUL/School_tutorial/JavaScript_Object_Management\">変数は独自の名前空間にま"
+"とめるようにしましょう</a>"
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:99
 msgid "proper preference naming - all preference names should begin with \"extensions.\", followed by the add-on name or some other unique identifier"
@@ -5635,15 +5733,19 @@ msgstr "これらの問題を防ぐ方法については <a href=\"%(link_howto)
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:123
 #, python-format
 msgid ""
-"Many of the above restrictions are tested automatically by an extension scanner that will flag suspicious add-ons for editor review. You can read more about this scanner in the <a "
-"href=\"%(link_validation)s\">Validation Help</a> document."
-msgstr "上記制限の多くは、拡張機能スキャナによって自動的にテストされ、不審なアドオンはエディタによる審査に回されます。このスキャナに関する詳細は <a href=\"%(link_validation)s\">バリデーターのヘルプ</a> 記事を参照してください。"
+"Many of the above restrictions are tested automatically by an extension scanner that will flag suspicious add-ons for editor review. You can read more about this scanner in the <a href="
+"\"%(link_validation)s\">Validation Help</a> document."
+msgstr ""
+"上記制限の多くは、拡張機能スキャナによって自動的にテストされ、不審なアドオンはエディタによる審査に回されます。このスキャナに関する詳細は <a href=\"%(link_validation)s\">バリデーターのヘルプ</a> 記事"
+"を参照してください。"
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:129
 msgid ""
 "If the add-on is site-specific, it is recommended that a test account is provided for use during the review process. Additionally, including detailed testing instructions will allow an editor to "
 "better understand how the add-on functions and expedite the testing process. This information can be placed in the Notes to Reviewer field when editing a version in the Developer Hub."
-msgstr "あなたのアドオンがサイト固有のものである場合、審査プロセス中に使用できるテスト用アカウントを提供することを推奨します。また、詳細なテスト手順も説明されていれば、アドオンがどのように機能するのかエディタが理解しやすくなり、テスト作業の迅速化につながります。こうした情報は、開発者センター内でバージョンを編集する際「審査担当者へのメモ」欄に入力できます。"
+msgstr ""
+"あなたのアドオンがサイト固有のものである場合、審査プロセス中に使用できるテスト用アカウントを提供することを推奨します。また、詳細なテスト手順も説明されていれば、アドオンがどのように機能するのかエディ"
+"タが理解しやすくなり、テスト作業の迅速化につながります。こうした情報は、開発者センター内でバージョンを編集する際「審査担当者へのメモ」欄に入力できます。"
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:134 src/olympia/devhub/templates/devhub/docs/policies-reviews.html:168
 msgid "After the Review"
@@ -5653,25 +5755,33 @@ msgstr "審査の後"
 msgid ""
 "Once an add-on is granted full review, it will immediately be available in the gallery, showing in browse and search results with a warning-free install button. All features, including voluntary "
 "contributions and beta channels will be available."
-msgstr "アドオンが本審査をパスすると、当サイトのギャラリーで即時公開され、各カテゴリや検索結果に警告なしのインストールボタンと共に表示されるようになります。任意の寄付受付やベータチャンネルといったすべての機能が利用可能となります。"
+msgstr ""
+"アドオンが本審査をパスすると、当サイトのギャラリーで即時公開され、各カテゴリや検索結果に警告なしのインストールボタンと共に表示されるようになります。任意の寄付受付やベータチャンネルといったすべての機"
+"能が利用可能となります。"
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:142
 msgid ""
-"Subsequent versions of the add-on will automatically be placed in the full review queue. Until the review is completed, the new version will only be displayed on the Version History page of the "
-"add-on. Once reviewed, the version will be updated across the site and deployed through the automatic update service."
-msgstr "アドオンの後継バージョンは自動的に本審査待ちリストへ追加されます。審査が完了するまで、その新バージョンはアドオンのバージョン履歴ページにのみ掲載されます。審査が完了したら、サイト全体で新バージョンが表示されるようになり、自動更新サービスを通じた提供も開始されます。"
+"Subsequent versions of the add-on will automatically be placed in the full review queue. Until the review is completed, the new version will only be displayed on the Version History page of the add-"
+"on. Once reviewed, the version will be updated across the site and deployed through the automatic update service."
+msgstr ""
+"アドオンの後継バージョンは自動的に本審査待ちリストへ追加されます。審査が完了するまで、その新バージョンはアドオンのバージョン履歴ページにのみ掲載されます。審査が完了したら、サイト全体で新バージョンが"
+"表示されるようになり、自動更新サービスを通じた提供も開始されます。"
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:148
 msgid ""
 "If a version does not meet the criteria for full review, it can either be granted preliminary review or disabled if there is a security concern. The author will receive an email explaining the "
 "action taken and how to fix it. In most cases, the developer can simply fix the problem and re-submit for full review."
-msgstr "バージョンが本審査の要件を満たしていない場合、事前審査を承認されるか、セキュリティに関する懸念があれば無効化されます。審査結果と問題の修正方法が作者にメールで送られます。たいていの場合、作者は単に指摘された問題を修正し、再度本審査を依頼することができます。"
+msgstr ""
+"バージョンが本審査の要件を満たしていない場合、事前審査を承認されるか、セキュリティに関する懸念があれば無効化されます。審査結果と問題の修正方法が作者にメールで送られます。たいていの場合、作者は単に指"
+"摘された問題を修正し、再度本審査を依頼することができます。"
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:155
 msgid ""
 "Preliminary reviews are appropriate for experimental add-ons and provide a way to get user testing and feedback without going through the longer, more thorough review process. We aim to complete "
 "these reviews in under 3 days."
-msgstr "事前審査は実験的なアドオンに適しており、より時間が掛かり細部にわたる審査プロセスを経ることなく、ユーザにテストへの参加やフィードバックの提供を呼びかけるための方法を提供します。事前審査は 3 日以内に完了することを目指しています。"
+msgstr ""
+"事前審査は実験的なアドオンに適しており、より時間が掛かり細部にわたる審査プロセスを経ることなく、ユーザにテストへの参加やフィードバックの提供を呼びかけるための方法を提供します。事前審査は 3 日以内に"
+"完了することを目指しています。"
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:160
 msgid "Testing Methods"
@@ -5681,7 +5791,9 @@ msgstr "テスト方法"
 msgid ""
 "When performing a preliminary review, editors will review the source code for security issues and major policy violations, but will not install the add-on to test functionality in most cases. "
 "Preliminary review will be granted unless a security vulnerability or major policy violation is discovered."
-msgstr "事前審査を行う際、エディタはセキュリティ問題や重大なポリシー違反がないかどうかソースコードに目を通しますが、アドオンをインストールして動作確認を行うことはほとんどありません。事前審査は、セキュリティ脆弱性や重大なポリシー違反が見つからない限り承認されます。"
+msgstr ""
+"事前審査を行う際、エディタはセキュリティ問題や重大なポリシー違反がないかどうかソースコードに目を通しますが、アドオンをインストールして動作確認を行うことはほとんどありません。事前審査は、セキュリティ"
+"脆弱性や重大なポリシー違反が見つからない限り承認されます。"
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:171
 msgid ""
@@ -5760,9 +5872,9 @@ msgstr ""
 msgid ""
 "<p> Whenever an add-on includes any unexpected* feature that </p> <ul> <li>compromises user privacy or security (like sending data to third parties),</li> <li>changes default settings like the "
 "homepage or search engine, or</li> <li>changes settings or features in other add-ons or deactivates them altogether</li> </ul> <p>the features must adhere to the following requirements:</p> <ul> "
-"<li>The add-on description must clearly state what changes the add-on makes.</li> <li>All changes must be opt-in, meaning the user must take non-default action to enact the change.</li> <li>The "
-"opt-in dialog must clearly state the name of the add-on requesting the change.</li> <li>Uninstalling the add-on restores the user's original settings if they were changed.</li> </ul> <p>*Unexpected"
-" features are those that are unrelated to the add-on's primary function.</p>"
+"<li>The add-on description must clearly state what changes the add-on makes.</li> <li>All changes must be opt-in, meaning the user must take non-default action to enact the change.</li> <li>The opt-"
+"in dialog must clearly state the name of the add-on requesting the change.</li> <li>Uninstalling the add-on restores the user's original settings if they were changed.</li> </ul> <p>*Unexpected "
+"features are those that are unrelated to the add-on's primary function.</p>"
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:268
@@ -5779,8 +5891,8 @@ msgstr "プライベートブラウジングモード"
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:282
 msgid ""
-"Add-ons that store or otherwise handle browsing data must support <a href=\"https://developer.mozilla.org/En/Supporting_private_browsing_mode\">Private Browsing Mode</a>.  During a Private Browsing"
-" session, no browsing data can be written to disk, and all of this data must be cleared when Firefox quits or the Private Browsing session ends."
+"Add-ons that store or otherwise handle browsing data must support <a href=\"https://developer.mozilla.org/En/Supporting_private_browsing_mode\">Private Browsing Mode</a>. During a Private Browsing "
+"session, no browsing data can be written to disk, and all of this data must be cleared when Firefox quits or the Private Browsing session ends."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:287
@@ -5823,10 +5935,10 @@ msgstr ""
 
 #: src/olympia/devhub/templates/devhub/docs/policies-submission.html:25
 msgid ""
-"<strong>Is the add-on clearly and accurately described?</strong> It's of the utmost importance to us that users get what they expect when they try a new add-on. Your add-on name should be clear and"
-" concise, and you should refrain from using special characters or numbers to get higher search rankings or for decorative purposes. Your description should provide details about what the add-on "
-"does, how a user should take advantage of it, and what the user should expect when they install it. Links to external documents for detailed instructions are fine, but the description itself should"
-" cover the basics and leave users confident that they know what they'll get. Also, it is important that you maintain version notes appropriately as you improve and change your add-on. Users should "
+"<strong>Is the add-on clearly and accurately described?</strong> It's of the utmost importance to us that users get what they expect when they try a new add-on. Your add-on name should be clear and "
+"concise, and you should refrain from using special characters or numbers to get higher search rankings or for decorative purposes. Your description should provide details about what the add-on "
+"does, how a user should take advantage of it, and what the user should expect when they install it. Links to external documents for detailed instructions are fine, but the description itself should "
+"cover the basics and leave users confident that they know what they'll get. Also, it is important that you maintain version notes appropriately as you improve and change your add-on. Users should "
 "be able to see what's new in an add-on they may have tried previously, and should be made aware of changes that might affect their current use of the add-on when they update."
 msgstr ""
 
@@ -5840,8 +5952,8 @@ msgstr ""
 #: src/olympia/devhub/templates/devhub/docs/policies-submission.html:37
 msgid ""
 "<strong>Has the add-on been well-tested, and is it free of obvious or serious defects?</strong> One important thing that we look for when considering an add-on is whether its user reviews indicate "
-"that it has received thorough testing, and that it doesn't have serious problems or negative impacts on the browser. If reviewers report problems such as major performance issues, crashes, frequent"
-" problems using the functions of the add-on, or spamming of messages to the error console, you should take those reports to heart, and re-submit your add-on after you've addressed them as best you "
+"that it has received thorough testing, and that it doesn't have serious problems or negative impacts on the browser. If reviewers report problems such as major performance issues, crashes, frequent "
+"problems using the functions of the add-on, or spamming of messages to the error console, you should take those reports to heart, and re-submit your add-on after you've addressed them as best you "
 "can. We don't expect you to perfectly optimize or have zero bugs &mdash; Firefox itself undergoes constant improvement in these areas &mdash; but we do want you to take reasonable efforts to "
 "minimize downsides, and to clearly call out cases where users may be surprised by those that remain."
 msgstr ""
@@ -5849,8 +5961,8 @@ msgstr ""
 #: src/olympia/devhub/templates/devhub/docs/policies-submission.html:43
 msgid ""
 "<strong>Do the add-on and add-on author both treat the user respectfully?</strong> Your software should not intrude on the user unnecessarily, try to trick the user, or conceal any of its "
-"activities from the user. Users (or even non-users) are sometimes rude in their comments, and while we will do our best to filter out inaccurate reviews as they're reported to us, we do expect that"
-" authors will avoid retaliating with rudeness of their own."
+"activities from the user. Users (or even non-users) are sometimes rude in their comments, and while we will do our best to filter out inaccurate reviews as they're reported to us, we do expect that "
+"authors will avoid retaliating with rudeness of their own."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/docs/policies-submission.html:49
@@ -5861,8 +5973,8 @@ msgstr ""
 
 #: src/olympia/devhub/templates/devhub/docs/policies-submission.html:55
 msgid ""
-"We are constantly looking at ways to improve the organization of the site to better accommodate add-ons that are exemplary in other ways, but are aimed at only a small community of potential users."
-" Correctly categorizing and maintaining the metadata of your add-on will help us figure out how we can surface more of those sorts of add-ons to people who are most likely to benefit from them."
+"We are constantly looking at ways to improve the organization of the site to better accommodate add-ons that are exemplary in other ways, but are aimed at only a small community of potential users. "
+"Correctly categorizing and maintaining the metadata of your add-on will help us figure out how we can surface more of those sorts of add-ons to people who are most likely to benefit from them."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/docs/policies-submission.html:61
@@ -5873,8 +5985,8 @@ msgstr ""
 
 #: src/olympia/devhub/templates/devhub/docs/policies-submission.html:67
 msgid ""
-"<strong>Is the add-on free of unlicensed trademarks and copyrights?</strong> Though you may mean no harm to the holder of a trademark, or the owner of a copyrighted work, we can't host add-ons that"
-" infringe on trademarks or copyrights. If you don't have permission to use a trademarked name or image, please do not submit your add-on to us. If your add-on includes code that is copyrighted by "
+"<strong>Is the add-on free of unlicensed trademarks and copyrights?</strong> Though you may mean no harm to the holder of a trademark, or the owner of a copyrighted work, we can't host add-ons that "
+"infringe on trademarks or copyrights. If you don't have permission to use a trademarked name or image, please do not submit your add-on to us. If your add-on includes code that is copyrighted by "
 "someone else, and is not licensed to you to use in your add-on, please do not submit your add-on to us."
 msgstr ""
 
@@ -5898,8 +6010,8 @@ msgstr "ライセンス"
 
 #: src/olympia/devhub/templates/devhub/docs/policies-submission.html:86
 msgid ""
-"Selecting an appropriate license for your add-on is a very important step in the submission process. A license specifies the rights you grant on your source code and is important in protecting your"
-" intellectual property."
+"Selecting an appropriate license for your add-on is a very important step in the submission process. A license specifies the rights you grant on your source code and is important in protecting your "
+"intellectual property."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/docs/policies-submission.html:92
@@ -5944,101 +6056,96 @@ msgstr ""
 msgid "How to get in touch with us regarding these policies or your add-on."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:6
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:10
 msgid "You have disabled this add-on"
 msgstr "あなたはこのアドオンを無効化しています"
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:20
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:24
 msgid "Your add-on's listing is disabled and is not showing anywhere in our gallery or update service."
 msgstr "このアドオンの掲載は無効化されており、当サイトのギャラリーや更新サービスなどには一切表示されません。"
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:25
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:27
 msgid "Please complete your add-on."
 msgstr "このアドオンを完成させてください。"
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:29
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:30
 msgid "You will receive an email when the review is complete."
 msgstr "審査が完了したらメールでお知らせします。"
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:34
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:33
 msgid "You will receive an email when the review is complete. Until then, your add-on is not listed in our gallery but can be accessed directly from its details page."
 msgstr "審査が完了したらメールでお知らせします。それまでの間、このアドオンは当サイトのギャラリーには掲載されませんが、詳細ページから直接アクセスすることは可能です。"
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:38 src/olympia/devhub/templates/devhub/includes/addon_details.html:48
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:37 src/olympia/devhub/templates/devhub/includes/addon_details.html:45
 msgid "You will receive an email when the review is complete and your add-on is signed."
 msgstr "審査が完了し、アドオンが署名されたらメールでお知らせします。"
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:44
-msgid "You will receive an email when the review is complete. Until then, your add-on is not listed in our gallery but can be accessed directly from its details page."
-msgstr "審査が完了したらメールでお知らせします。それまでの間、このアドオンは当サイトのギャラリーには掲載されませんが、詳細ページから直接アクセスすることは可能です。"
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:41
+msgid "You will receive an email when the review is complete. Until then, your add-on is not listed in our gallery but can be accessed directly from its details page. "
+msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:54
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:49
 msgid "Your add-on is displayed in our gallery and users are receiving automatic updates."
 msgstr "このアドオンは当サイトのギャラリーに表示されており、ユーザには自動更新が配信されています。"
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:57
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:52
 msgid "Your add-on has been signed and can be bundled with an application installer."
 msgstr "このアドオンは署名されており、アプリケーションインストーラに同梱できます。"
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:63
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:56
 msgid "Your add-on was disabled by a site administrator and is no longer shown in our gallery. If you have any questions, please email amo-admins@mozilla.org."
 msgstr "このアドオンはサイト管理者によって無効化されており、当サイトのギャラリーには表示されません。質問がある場合は amo-admins@mozilla.org までメールを送ってください。"
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:70
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:62
 msgid "Your add-on is displayed in our gallery as experimental and users are receiving automatic updates. Some features are unavailable to your add-on."
 msgstr "このアドオンは「実験的アドオン」として当サイトのギャラリーに表示されており、ユーザには自動更新が配信されています。なお、一部の機能は利用できません。"
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:74
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:66
 msgid "Your add-on has been signed."
 msgstr "このアドオンは署名されています。"
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:79
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:69
 msgid ""
 "You will receive an email when the full review is complete. Until then, your add-on is displayed in our gallery as experimental and users are receiving automatic updates. Some features are "
 "unavailable to your add-on."
-msgstr "本審査が完了したらメールでお知らせします。それまでの間、このアドオンは当サイトのギャラリーに「実験的アドオン」として表示され、ユーザには自動更新が配信されます。なお、一部の機能は利用できません。"
+msgstr ""
+"本審査が完了したらメールでお知らせします。それまでの間、このアドオンは当サイトのギャラリーに「実験的アドオン」として表示され、ユーザには自動更新が配信されます。なお、一部の機能は利用できません。"
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:84
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:74
 msgid "You will receive an email when the full review is complete, making you able to bundle your add-on with an application installer."
 msgstr "本審査が完了したらメールでお知らせします。それにより、アプリケーションインストーラにこのアドオンを同梱できるようになります。"
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:91
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:79
 msgid "All add-ons hosted in our gallery must now be reviewed by an editor. If you wish to continue hosting your add-on, please click to select a review process."
 msgstr "当サイトのギャラリーに掲載されるアドオンはすべてエディタによる審査を受ける必要があります。今後もこのアドオンの掲載を継続したい場合は、クリックして審査方法を選択してください。"
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:113
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:100
 msgid "Current Version:"
 msgstr "現在のバージョン:"
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:115
-msgid ""
-"This is the version of your add-on that will\n"
-"                                           be installed if someone clicks the Install\n"
-"                                           button on addons.mozilla.org. It is only\n"
-"                                           relevant for listed add-ons."
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:102
+msgid "This is the version of your add-on that will be installed if someone clicks the Install button on addons.mozilla.org. It is only relevant for listed add-ons."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:123
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:110
 msgid "Created:"
 msgstr "作成日:"
 
 #. {0} is a date. dennis-ignore: E201
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:125 src/olympia/devhub/templates/devhub/includes/addon_details.html:131
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:112 src/olympia/devhub/templates/devhub/includes/addon_details.html:118
 #, python-format
 msgid "%%b %%e, %%Y"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:136
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:123
 msgid "Next Version:"
 msgstr "次バージョン:"
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:138
-msgid ""
-"This is the newest uploaded version, however\n"
-"                                           it isn’t live on the site yet."
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:125
+msgid "This is the newest uploaded version, however it isn’t live on the site yet."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:144 src/olympia/devhub/templates/devhub/versions/list.html:30
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:130 src/olympia/devhub/templates/devhub/versions/list.html:30
 msgid "Queues are not reviewed strictly in order"
 msgstr ""
 
@@ -6106,9 +6213,7 @@ msgid "View the blog &#9658;"
 msgstr "ブログを見る &#9658;"
 
 #: src/olympia/devhub/templates/devhub/includes/license_form.html:6
-msgid ""
-"Please choose a license appropriate for the rights you grant on your source code.\n"
-"                  It is only relevant for listed add-ons."
+msgid "Please choose a license appropriate for the rights you grant on your source code. It is only relevant for listed add-ons."
 msgstr ""
 
 #. {0} is a list of HTML tags.
@@ -6124,25 +6229,22 @@ msgstr "いくつかの HTML タグに対応しています。"
 msgid "Remove this application"
 msgstr "このアプリケーションを削除"
 
-#. {0} is the maximum number of add-on categories allowed.                {1}
-#. is
+#. {0} is the maximum number of add-on categories allowed.                {1} is
 #. the application name.
 #: src/olympia/devhub/templates/devhub/includes/macros.html:70
 msgid "Select <b>up to {0}</b> {1} category for this add-on:"
 msgid_plural "Select <b>up to {0}</b> {1} categories for this add-on:"
 msgstr[0] "このアドオンの {1} 用カテゴリを <b>{0} 個まで</b> 選択してください:"
+msgstr[1] ""
 
 #: src/olympia/devhub/templates/devhub/includes/policy_form.html:4
 msgid ""
 "Users will be required to accept the following End-User License Agreement (EULA) prior to installing your add-on. The presence of a EULA significantly affects the number of downloads an add-on "
-"receives. Please note that a EULA is not the same as a code license, such as the GPL or MPL.\n"
-"                It is only relevant for listed add-ons."
+"receives. Please note that a EULA is not the same as a code license, such as the GPL or MPL.It is only relevant for listed add-ons."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/policy_form.html:21
-msgid ""
-"If your add-on transmits any data from the user's computer, a privacy policy is required that explains what data is sent and how it is used.\n"
-"                It is only relevant for listed add-ons."
+#: src/olympia/devhub/templates/devhub/includes/policy_form.html:24
+msgid "If your add-on transmits any data from the user's computer, a privacy policy is required that explains what data is sent and how it is used. It is only relevant for listed add-ons."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/includes/source_form_field.html:2
@@ -6278,8 +6380,8 @@ msgstr ""
 
 #: src/olympia/devhub/templates/devhub/payments/voluntary.html:49
 msgid ""
-"We recommend thanking the user and telling them how much you appreciate their support. You might also want to tell them about what's next for your add-on and about any other add-ons you've made for"
-" them to try."
+"We recommend thanking the user and telling them how much you appreciate their support. You might also want to tell them about what's next for your add-on and about any other add-ons you've made for "
+"them to try."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/payments/voluntary.html:64
@@ -6310,12 +6412,8 @@ msgstr "このテーマが当てはまるカテゴリを選択してください
 msgid "Add some tags to describe your Theme."
 msgstr "このテーマを説明するタグをいくつか追加してください。"
 
-#: src/olympia/devhub/templates/devhub/personas/edit.html:106
-msgid ""
-"A short explanation of your theme's\n"
-"                                basic functionality that is displayed in\n"
-"                                search and browse listings, as well as at\n"
-"                                the top of your theme's details page."
+#: src/olympia/devhub/templates/devhub/personas/edit.html:106 src/olympia/devhub/templates/devhub/personas/submit.html:54
+msgid "A short explanation of your theme's basic functionality that is displayed in search and browse listings, as well as at the top of your theme's details page."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/personas/edit.html:122 src/olympia/devhub/templates/devhub/personas/submit.html:68
@@ -6385,7 +6483,7 @@ msgid "Upon upload and form submission, the AMO Team will review your updated de
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/personas/edit.html:241
-msgid "Your previously resubmitted design,  which is under pending review."
+msgid "Your previously resubmitted design, which is under pending review."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/personas/edit.html:245
@@ -6453,14 +6551,6 @@ msgstr ""
 #: src/olympia/devhub/templates/devhub/personas/submit.html:33
 msgid "Give your Theme a name."
 msgstr "テーマに名前を付けてください。"
-
-#: src/olympia/devhub/templates/devhub/personas/submit.html:54
-msgid ""
-"A short explanation of your theme's\n"
-"                                      basic functionality that is displayed in\n"
-"                                      search and browse listings, as well as at\n"
-"                                      the top of your theme's details page."
-msgstr ""
 
 #: src/olympia/devhub/templates/devhub/personas/submit.html:198
 #, python-format
@@ -6536,30 +6626,16 @@ msgstr "別のフッタ画像を選択"
 msgid "Files added to reviewed versions must be reviewed before they will be available for download."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/add_file_modal.html:15
-#, python-format
-msgid ""
-"Submission of updates to unlisted add-ons for signing is currently in an open beta. Manual review may still be required for a large number of add-ons. Please <a href=\"%(url)s\" "
-"target=\"_blank\">report any bugs</a> that you encounter."
-msgstr "非掲載アドオンの更新版の署名用提出は現在オープンベータとなっています。多くのアドオンについてはまだ手作業による審査が必要となります。何か問題に遭遇した場合は <a href=\"%(url)s\" target=\"_blank\">バグを報告してください</a>。"
-
-#: src/olympia/devhub/templates/devhub/versions/add_file_modal.html:35
+#: src/olympia/devhub/templates/devhub/versions/add_file_modal.html:24
 msgid "Select the target platform for this file."
 msgstr "このファイルの対応 OS を選択します。"
 
-#: src/olympia/devhub/templates/devhub/versions/add_file_modal.html:46
+#: src/olympia/devhub/templates/devhub/versions/add_file_modal.html:35
 msgid "Which review type would you like to nominate for?"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/add_file_modal.html:51
+#: src/olympia/devhub/templates/devhub/versions/add_file_modal.html:40
 msgid "Only publish this version to my beta channel."
-msgstr ""
-
-#: src/olympia/devhub/templates/devhub/versions/add_file_modal.html:54
-#, python-format
-msgid ""
-"The behavior of the beta channel has changed to accommodate <a href=\"%(addon_signing_url)s\" target=\"_blank\">mandatory add-on signing</a>. The new process is currently in an open beta, and may "
-"change significantly in the near future. Please <a href=\"%(issues_url)s\" target=\"_blank\">report any bugs</a> that you encounter."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/versions/edit.html:5
@@ -6584,16 +6660,10 @@ msgstr "ファイル"
 msgid "Upload Another File"
 msgstr "他のファイルをアップロード"
 
-#: src/olympia/devhub/templates/devhub/versions/edit.html:45
-msgid "Adjusting application information here will allow users to install your add-on even if the install manifest in the package indicates that the add-on is incompatible."
-msgstr "ここでアプリケーション情報を編集すると、パッケージ内のインストールマニフェストでアドオンの互換性がなくても、ユーザがこのアドオンをインストールできるようになります。"
-
 #: src/olympia/devhub/templates/devhub/versions/edit.html:74
 msgid ""
-"Information about changes in this release, new features,\n"
-"                              known bugs, and other useful information specific to this\n"
-"                              release/version. This information is also shown in the\n"
-"                              Add-ons Manager when updating."
+"Information about changes in this release, new features, known bugs, and other useful information specific to this release/version. This information is also shown in the Add-ons Manager when "
+"updating."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/versions/edit.html:99
@@ -6605,10 +6675,7 @@ msgid "Notes for Reviewers"
 msgstr "審査担当者へのメモ"
 
 #: src/olympia/devhub/templates/devhub/versions/edit.html:114
-msgid ""
-"Optionally, enter any information that may be useful\n"
-"                              to the Editor reviewing this add-on, such as test\n"
-"                              account information."
+msgid "Optionally, enter any information that may be useful to the Editor reviewing this add-on, such as test account information."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/versions/edit.html:127
@@ -6659,6 +6726,7 @@ msgstr "このバージョンを編集"
 msgid "{0} file"
 msgid_plural "{0} files"
 msgstr[0] ""
+msgstr[1] ""
 
 #: src/olympia/devhub/templates/devhub/versions/list.html:25
 msgid "0 files"
@@ -6685,7 +6753,7 @@ msgstr "本審査を申請"
 msgid "Request Preliminary Review"
 msgstr "事前審査を申請"
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:80 src/olympia/devhub/templates/devhub/versions/list.html:327 src/olympia/devhub/templates/devhub/versions/list.html:350
+#: src/olympia/devhub/templates/devhub/versions/list.html:80 src/olympia/devhub/templates/devhub/versions/list.html:325 src/olympia/devhub/templates/devhub/versions/list.html:348
 msgid "Cancel Review Request"
 msgstr "審査申請をキャンセル"
 
@@ -6714,7 +6782,7 @@ msgid "Unlisted:"
 msgstr "非掲載:"
 
 #: src/olympia/devhub/templates/devhub/versions/list.html:114
-msgid "Not distributed on {0}. Developers will upload new versions for signing and distribute the add-ons on their own. (beta)"
+msgid "Not distributed on {0}. Developers will upload new versions for signing and distribute the add-ons on their own."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/versions/list.html:122
@@ -6765,7 +6833,8 @@ msgid "Delete Version {version}"
 msgstr "バージョン {version} を削除"
 
 #: src/olympia/devhub/templates/devhub/versions/list.html:218
-msgid "You are about to delete the current version of your add-on. This may cause your add-on status to change, or your listing to lose public visibility, if this is the only public version of your add-on."
+msgid ""
+"You are about to delete the current version of your add-on. This may cause your add-on status to change, or your listing to lose public visibility, if this is the only public version of your add-on."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/versions/list.html:219
@@ -6777,81 +6846,73 @@ msgid "<strong>Important:</strong> Once a version has been deleted, you may not 
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/versions/list.html:230
-msgid ""
-"Deleting a version which has already been reviewed\n"
-"               may also cause a significant delay in the review of\n"
-"               your next update."
-msgstr ""
-
-#: src/olympia/devhub/templates/devhub/versions/list.html:233
 msgid "Are you sure you wish to delete this version?"
 msgstr "本当にこのバージョンを削除しますか？"
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:238
+#: src/olympia/devhub/templates/devhub/versions/list.html:235
 msgid "Delete Version"
 msgstr "バージョンを削除"
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:240
+#: src/olympia/devhub/templates/devhub/versions/list.html:237
 msgid "Disable Version"
 msgstr "バージョンを無効化"
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:247
+#: src/olympia/devhub/templates/devhub/versions/list.html:244
 msgid "Add a new Version"
 msgstr "新バージョンを追加"
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:249
+#: src/olympia/devhub/templates/devhub/versions/list.html:246
 msgid "Add Version"
 msgstr "バージョンを追加"
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:256 src/olympia/devhub/templates/devhub/versions/list.html:274
+#: src/olympia/devhub/templates/devhub/versions/list.html:253 src/olympia/devhub/templates/devhub/versions/list.html:279
 msgid "Hide Add-on"
 msgstr "アドオンを非公開にする"
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:259
+#: src/olympia/devhub/templates/devhub/versions/list.html:256
 msgid "Hiding your add-on will prevent it from appearing anywhere in our gallery and will stop users from receiving automatic updates."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:265
+#: src/olympia/devhub/templates/devhub/versions/list.html:263
+msgid "The files awaiting review will be disabled and you will need to upload new versions."
+msgstr ""
+
+#: src/olympia/devhub/templates/devhub/versions/list.html:270
 msgid "Are you sure you wish to hide your add-on?"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:286 src/olympia/devhub/templates/devhub/versions/list.html:315
+#: src/olympia/devhub/templates/devhub/versions/list.html:291 src/olympia/devhub/templates/devhub/versions/list.html:313
 msgid "Unlist Add-on"
 msgstr "アドオンを非掲載にする"
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:289
+#: src/olympia/devhub/templates/devhub/versions/list.html:294
 #, python-format
 msgid ""
 "Unlisting your add-on will make it (and each of its versions/files) invisible on this website. It won't show up in searches, won't have a public facing page, and won't be updated automatically for "
-"current users.  It is recommended for unlisted add-ons to provide a custom <a href=\"%(update_url)s\" target=\"_blank\">updateURL</a> in their manifest file for automatic updates."
+"current users. It is recommended for unlisted add-ons to provide a custom <a href=\"%(update_url)s\" target=\"_blank\">updateURL</a> in their manifest file for automatic updates."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:299
-#, python-format
-msgid "Switching add-ons to unlisted is currently in an open beta. Please <a href=\"%(url)s\" target=\"_blank\">report any bugs</a> that you encounter."
-msgstr "アドオンの非掲載への変更は現在オープンベータとなっています。何か問題に遭遇した場合は <a href=\"%(url)s\" target=\"_blank\">バグを報告してください</a>。"
-
-#: src/olympia/devhub/templates/devhub/versions/list.html:305
+#: src/olympia/devhub/templates/devhub/versions/list.html:303
 msgid "Unlisting an add-on is irreversible!"
 msgstr "アドオンの非掲載化は取り消せません！"
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:305
+#: src/olympia/devhub/templates/devhub/versions/list.html:303
 msgid "An unlisted add-on cannot be switched to be listed."
 msgstr "非掲載アドオンを掲載アドオンに変更することはできません。"
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:307
+#: src/olympia/devhub/templates/devhub/versions/list.html:305
 msgid "Are you sure you wish to unlist your add-on?"
 msgstr "本当にこのアドオンを非掲載にしますか？"
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:330
+#: src/olympia/devhub/templates/devhub/versions/list.html:328
 msgid "Canceling your review request will leave your add-on as preliminarily reviewed."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:335
+#: src/olympia/devhub/templates/devhub/versions/list.html:333
 msgid "Canceling your review request will mark your add-on incomplete. If you do not complete your add-on after several days by re-requesting review, it will be deleted."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:343
+#: src/olympia/devhub/templates/devhub/versions/list.html:341
 msgid "Are you sure you wish to cancel your review request?"
 msgstr ""
 
@@ -7190,19 +7251,19 @@ msgstr "アドオン、エディタ、またはコメント"
 msgid "Search by add-on name / author email"
 msgstr "アドオンの名前、作者のメールアドレスで検索"
 
-#: src/olympia/editors/forms.py:103
+#: src/olympia/editors/forms.py:103 src/olympia/editors/forms.py:244 src/olympia/editors/forms.py:257
 msgid "yes"
 msgstr "はい"
 
-#: src/olympia/editors/forms.py:104
+#: src/olympia/editors/forms.py:104 src/olympia/editors/forms.py:244 src/olympia/editors/forms.py:257
 msgid "no"
 msgstr "いいえ"
 
-#: src/olympia/editors/forms.py:105
+#: src/olympia/editors/forms.py:105 src/olympia/editors/forms.py:245
 msgid "Admin Flag"
 msgstr "管理者フラグ"
 
-#: src/olympia/editors/forms.py:113
+#: src/olympia/editors/forms.py:113 src/olympia/editors/forms.py:253
 msgid "Max. Version"
 msgstr "最大対応バージョン"
 
@@ -7214,55 +7275,59 @@ msgstr "登録からの日数"
 msgid "Add-on Types"
 msgstr "アドオンの種類"
 
-#: src/olympia/editors/forms.py:126 src/olympia/editors/helpers.py:267
+#: src/olympia/editors/forms.py:126 src/olympia/editors/helpers.py:279
 msgid "Platforms"
 msgstr "OS"
 
+#: src/olympia/editors/forms.py:237
+msgid "Search by add-on name / author email / guid"
+msgstr ""
+
 #. L10n: 0 = platform, 1 = filename, 2 = status message
-#: src/olympia/editors/forms.py:238
+#: src/olympia/editors/forms.py:342
 #, python-format
 msgid "<strong>%s</strong> &middot; %s &middot; %s"
 msgstr "<strong>%s</strong> &middot; %s &middot; %s"
 
-#: src/olympia/editors/forms.py:252
+#: src/olympia/editors/forms.py:356
 msgid "Comments:"
 msgstr "コメント:"
 
-#: src/olympia/editors/forms.py:256
+#: src/olympia/editors/forms.py:360
 msgid "Operating systems:"
 msgstr "OS:"
 
-#: src/olympia/editors/forms.py:258
+#: src/olympia/editors/forms.py:362
 msgid "Applications:"
 msgstr "アプリケーション:"
 
-#: src/olympia/editors/forms.py:260
+#: src/olympia/editors/forms.py:364
 msgid "Notify me the next time this add-on is updated. (Subsequent updates will not generate an email)"
 msgstr "次回のアドオンが更新されたときメールで通知を受け取ります。(その後の更新は通知されません)"
 
-#: src/olympia/editors/forms.py:265
+#: src/olympia/editors/forms.py:369
 msgid "Clear Admin Review Flag"
 msgstr "管理者審査フラグをクリア"
 
-#: src/olympia/editors/forms.py:267
+#: src/olympia/editors/forms.py:371
 msgid "Clear more info requested flag"
 msgstr ""
 
-#: src/olympia/editors/forms.py:281
+#: src/olympia/editors/forms.py:385
 msgid "Choose a canned response..."
 msgstr "返信の定型文を選んでください..."
 
 #. L10n: Description of what can be searched for.
-#: src/olympia/editors/forms.py:324
+#: src/olympia/editors/forms.py:423
 msgid "theme name"
 msgstr "テーマの名前"
 
-#: src/olympia/editors/forms.py:350
+#: src/olympia/editors/forms.py:449
 msgid "Someone else is reviewing this theme."
 msgstr "誰か他の担当者がこのテーマを審査しています"
 
 #. L10n: Description of what can be searched for.
-#: src/olympia/editors/forms.py:447
+#: src/olympia/editors/forms.py:546
 msgid "app, reviewer, or comment"
 msgstr "アプリ、審査担当者またはコメント"
 
@@ -7278,235 +7343,264 @@ msgstr "事前審査待ち"
 msgid "Rejected or Unreviewed"
 msgstr "却下もしくは未審査"
 
-#: src/olympia/editors/helpers.py:123 src/olympia/editors/helpers.py:136
+#: src/olympia/editors/helpers.py:125 src/olympia/editors/helpers.py:138
 msgid "Queue"
 msgstr "審査待ち"
 
-#: src/olympia/editors/helpers.py:124 src/olympia/editors/templates/editors/base.html:50 src/olympia/editors/templates/editors/base.html:65
+#: src/olympia/editors/helpers.py:126 src/olympia/editors/templates/editors/base.html:50 src/olympia/editors/templates/editors/base.html:65
 msgid "Pending Updates"
 msgstr "更新審査待ち"
 
-#: src/olympia/editors/helpers.py:125 src/olympia/editors/templates/editors/base.html:48 src/olympia/editors/templates/editors/base.html:63
+#: src/olympia/editors/helpers.py:127 src/olympia/editors/templates/editors/base.html:48 src/olympia/editors/templates/editors/base.html:63
 msgid "Full Reviews"
 msgstr "本審査"
 
-#: src/olympia/editors/helpers.py:126 src/olympia/editors/templates/editors/base.html:52 src/olympia/editors/templates/editors/base.html:67
+#: src/olympia/editors/helpers.py:128 src/olympia/editors/templates/editors/base.html:52 src/olympia/editors/templates/editors/base.html:67
 msgid "Preliminary Reviews"
 msgstr "事前審査"
 
-#: src/olympia/editors/helpers.py:127 src/olympia/editors/templates/editors/base.html:54
+#: src/olympia/editors/helpers.py:129 src/olympia/editors/templates/editors/base.html:54
 msgid "Moderated Reviews"
 msgstr "管理者審査"
 
-#: src/olympia/editors/helpers.py:128 src/olympia/editors/templates/editors/base.html:46
+#: src/olympia/editors/helpers.py:130 src/olympia/editors/templates/editors/base.html:46
 msgid "Fast Track"
 msgstr "優先審査"
 
-#: src/olympia/editors/helpers.py:130
+#: src/olympia/editors/helpers.py:132
 msgid "Pending Themes"
 msgstr "更新待ちのテーマ"
 
-#: src/olympia/editors/helpers.py:131 src/olympia/editors/templates/editors/themes/queue.html:4
+#: src/olympia/editors/helpers.py:133 src/olympia/editors/templates/editors/themes/queue.html:4
 msgid "Flagged Themes"
 msgstr "フラグ付きテーマ"
 
-#: src/olympia/editors/helpers.py:132
+#: src/olympia/editors/helpers.py:134
 msgid "Update Themes"
 msgstr "テーマを更新"
 
-#: src/olympia/editors/helpers.py:137
+#: src/olympia/editors/helpers.py:139
 msgid "Unlisted Pending Updates"
 msgstr "非掲載アドオンの保留更新"
 
-#: src/olympia/editors/helpers.py:138
+#: src/olympia/editors/helpers.py:140
 msgid "Unlisted Full Reviews"
 msgstr "非掲載アドオンの本審査"
 
-#: src/olympia/editors/helpers.py:139
+#: src/olympia/editors/helpers.py:141
 msgid "Unlisted Preliminary Reviews"
 msgstr "非掲載アドオンの事前審査"
 
-#: src/olympia/editors/helpers.py:170
+#: src/olympia/editors/helpers.py:142
+msgid "Unlisted All Add-ons"
+msgstr ""
+
+#: src/olympia/editors/helpers.py:173
 msgid "Fast Track ({0})"
 msgid_plural "Fast Track ({0})"
 msgstr[0] "優先審査 ({0})"
+msgstr[1] ""
 
-#: src/olympia/editors/helpers.py:175
+#: src/olympia/editors/helpers.py:178
 msgid "Full Review ({0})"
 msgid_plural "Full Reviews ({0})"
 msgstr[0] "本審査 ({0})"
+msgstr[1] ""
 
-#: src/olympia/editors/helpers.py:180
+#: src/olympia/editors/helpers.py:183
 msgid "Pending Update ({0})"
 msgid_plural "Pending Updates ({0})"
 msgstr[0] "更新審査待ち ({0})"
+msgstr[1] ""
 
-#: src/olympia/editors/helpers.py:185
+#: src/olympia/editors/helpers.py:188
 msgid "Preliminary Review ({0})"
 msgid_plural "Preliminary Reviews ({0})"
 msgstr[0] "事前審査 ({0})"
+msgstr[1] ""
 
-#: src/olympia/editors/helpers.py:190
+#: src/olympia/editors/helpers.py:193
 msgid "Moderated Review ({0})"
 msgid_plural "Moderated Reviews ({0})"
 msgstr[0] "管理者審査 ({0})"
+msgstr[1] ""
 
-#: src/olympia/editors/helpers.py:196
+#: src/olympia/editors/helpers.py:199
 msgid "Unlisted Full Review ({0})"
 msgid_plural "Unlisted Full Reviews ({0})"
 msgstr[0] "非掲載アドオンの本審査 ({0})"
+msgstr[1] ""
 
-#: src/olympia/editors/helpers.py:201
+#: src/olympia/editors/helpers.py:204
 msgid "Unlisted Pending Update ({0})"
 msgid_plural "Unlisted Pending Updates ({0})"
 msgstr[0] "非掲載アドオンの保留更新 ({0})"
+msgstr[1] ""
 
-#: src/olympia/editors/helpers.py:206
+#: src/olympia/editors/helpers.py:209
 msgid "Unlisted Preliminary Review ({0})"
 msgid_plural "Unlisted Preliminary Reviews ({0})"
 msgstr[0] "非掲載アドオンの事前審査 ({0})"
+msgstr[1] ""
 
-#: src/olympia/editors/helpers.py:261
-msgid "Addon"
-msgstr "アドオン"
+#: src/olympia/editors/helpers.py:214
+msgid "Unlisted All Add-ons ({0})"
+msgid_plural "Unlisted All Add-ons ({0})"
+msgstr[0] ""
+msgstr[1] ""
 
-#: src/olympia/editors/helpers.py:262
+#: src/olympia/editors/helpers.py:274
 msgid "Type"
 msgstr "種類"
 
-#: src/olympia/editors/helpers.py:263
+#: src/olympia/editors/helpers.py:275
 msgid "Waiting Time"
 msgstr "待ち時間"
 
-#: src/olympia/editors/helpers.py:264 src/olympia/editors/templates/editors/review.html:285
+#: src/olympia/editors/helpers.py:276 src/olympia/editors/templates/editors/review.html:285
 msgid "Flags"
 msgstr "フラグ"
 
-#: src/olympia/editors/helpers.py:265
+#: src/olympia/editors/helpers.py:277
 msgid "Applications"
 msgstr "アプリケーション"
 
-#: src/olympia/editors/helpers.py:270
+#: src/olympia/editors/helpers.py:282
 msgid "Additional"
 msgstr "追加"
 
-#: src/olympia/editors/helpers.py:285
+#: src/olympia/editors/helpers.py:302
 msgid "Site Specific"
 msgstr "特定サイト用"
 
-#: src/olympia/editors/helpers.py:287
+#: src/olympia/editors/helpers.py:304
 msgid "Requires External Software"
 msgstr "要外部ソフトウェア"
 
-#: src/olympia/editors/helpers.py:289
+#: src/olympia/editors/helpers.py:306
 msgid "Binary Components"
 msgstr "バイナリコンポーネント"
 
-#: src/olympia/editors/helpers.py:313
+#: src/olympia/editors/helpers.py:339
 msgid "moments ago"
 msgstr "たった今"
 
 #. L10n: first argument is number of minutes
-#: src/olympia/editors/helpers.py:316
+#: src/olympia/editors/helpers.py:342
 msgid "{0} minute"
 msgid_plural "{0} minutes"
 msgstr[0] "{0} 分"
+msgstr[1] ""
 
 #. L10n: first argument is number of hours
-#: src/olympia/editors/helpers.py:320
+#: src/olympia/editors/helpers.py:346
 msgid "{0} hour"
 msgid_plural "{0} hours"
 msgstr[0] "{0} 時間"
+msgstr[1] ""
 
 #. L10n: first argument is number of days
-#: src/olympia/editors/helpers.py:324
+#: src/olympia/editors/helpers.py:350
 msgid "{0} day"
 msgid_plural "{0} days"
 msgstr[0] "{0} 日"
+msgstr[1] ""
 
-#: src/olympia/editors/helpers.py:488
+#: src/olympia/editors/helpers.py:364
+msgid "Last Review"
+msgstr ""
+
+#: src/olympia/editors/helpers.py:366
+msgid "Last Update"
+msgstr ""
+
+#: src/olympia/editors/helpers.py:387
+msgid "No Reviews"
+msgstr ""
+
+#: src/olympia/editors/helpers.py:561
 msgid "Push to public"
 msgstr "公開"
 
-#: src/olympia/editors/helpers.py:490
+#: src/olympia/editors/helpers.py:563
 msgid "Grant full review"
 msgstr "本審査を承認"
 
-#: src/olympia/editors/helpers.py:505
+#: src/olympia/editors/helpers.py:578
 msgid "Request more information"
 msgstr "詳しい情報を求める"
 
-#: src/olympia/editors/helpers.py:508
+#: src/olympia/editors/helpers.py:581
 msgid "Request super-review"
 msgstr "スーパーレビューを求める"
 
-#: src/olympia/editors/helpers.py:519
+#: src/olympia/editors/helpers.py:592
 msgid "Grant preliminary review"
 msgstr "事前審査を承認"
 
-#: src/olympia/editors/helpers.py:520
+#: src/olympia/editors/helpers.py:593
 msgid "This will mark the files as preliminarily reviewed."
 msgstr ""
 
-#: src/olympia/editors/helpers.py:522
+#: src/olympia/editors/helpers.py:595
 msgid "Use this form to request more information from the author. They will receive an email and be able to answer here. You will be notified by email when they reply."
 msgstr ""
 
-#: src/olympia/editors/helpers.py:526
+#: src/olympia/editors/helpers.py:599
 msgid ""
 "If you have concerns about this add-on's security, copyright issues, or other concerns that an administrator should look into, enter your comments in the area below. They will be sent to "
 "administrators, not the author."
 msgstr ""
 
-#: src/olympia/editors/helpers.py:532
+#: src/olympia/editors/helpers.py:605
 msgid "This will reject the add-on and remove it from the review queue."
 msgstr ""
 
-#: src/olympia/editors/helpers.py:534
-msgid "Make a comment on this version.  The author won't be able to see this."
+#: src/olympia/editors/helpers.py:607
+msgid "Make a comment on this version. The author won't be able to see this."
 msgstr ""
 
-#: src/olympia/editors/helpers.py:538
+#: src/olympia/editors/helpers.py:611
 msgid "This will reject the files and remove them from the review queue."
 msgstr ""
 
-#: src/olympia/editors/helpers.py:542
+#: src/olympia/editors/helpers.py:615
 msgid "This will mark the add-on as preliminarily reviewed. Future versions will undergo preliminary review."
 msgstr ""
 
-#: src/olympia/editors/helpers.py:547
+#: src/olympia/editors/helpers.py:620
 msgid "This will mark the files as preliminarily reviewed. Future versions will undergo preliminary review."
 msgstr ""
 
-#: src/olympia/editors/helpers.py:552
+#: src/olympia/editors/helpers.py:625
 msgid "Retain preliminary review"
 msgstr "事前審査に留める"
 
-#: src/olympia/editors/helpers.py:553
+#: src/olympia/editors/helpers.py:626
 msgid "This will retain the add-on as preliminarily reviewed. Future versions will undergo preliminary review."
 msgstr ""
 
-#: src/olympia/editors/helpers.py:558
+#: src/olympia/editors/helpers.py:631
 msgid "This will approve a sandboxed version of a public add-on to appear on the public side."
 msgstr ""
 
-#: src/olympia/editors/helpers.py:561
+#: src/olympia/editors/helpers.py:634
 msgid "This will reject a version of a public add-on and remove it from the queue."
 msgstr ""
 
-#: src/olympia/editors/helpers.py:564
+#: src/olympia/editors/helpers.py:637
 msgid "This will mark the add-on and its most recent version and files as public. Future versions will go into the sandbox until they are reviewed by an editor."
 msgstr ""
 
-#: src/olympia/editors/helpers.py:637
+#: src/olympia/editors/helpers.py:714
 msgid "add-on"
 msgstr "アドオン"
 
-#: src/olympia/editors/helpers.py:940 src/olympia/editors/helpers.py:960
+#: src/olympia/editors/helpers.py:1020 src/olympia/editors/helpers.py:1040
 msgid "Flagged"
 msgstr "フラグ付き"
 
-#: src/olympia/editors/helpers.py:944 src/olympia/editors/helpers.py:963
+#: src/olympia/editors/helpers.py:1024 src/olympia/editors/helpers.py:1043
 msgid "Updates"
 msgstr "更新"
 
@@ -7558,56 +7652,56 @@ msgstr "登録されたテーマは追加審査のためフラグが付けられ
 msgid "A question about your Theme submission"
 msgstr "あなたが登録したテーマに関する質問"
 
-#: src/olympia/editors/views.py:144
+#: src/olympia/editors/views.py:146
 msgid "New Add-ons (Under 5 days)"
 msgstr "新着アドオン (5 日以内)"
 
-#: src/olympia/editors/views.py:145
+#: src/olympia/editors/views.py:147
 msgid "Passable (5 to 10 days)"
 msgstr ""
 
-#: src/olympia/editors/views.py:146
+#: src/olympia/editors/views.py:148
 msgid "Overdue (Over 10 days)"
 msgstr ""
 
-#: src/olympia/editors/views.py:532
+#: src/olympia/editors/views.py:539
 msgid "An unknown error occurred"
 msgstr "不明なエラーが発生しました"
 
-#: src/olympia/editors/views.py:587
+#: src/olympia/editors/views.py:592
 msgid "Self-reviews are not allowed."
 msgstr "自己審査は認められません。"
 
-#: src/olympia/editors/views.py:609
+#: src/olympia/editors/views.py:613
 msgid "Review successfully processed."
 msgstr "審査処理が完了しました。"
 
-#: src/olympia/editors/views.py:807
+#: src/olympia/editors/views.py:812
 msgid "was approved"
 msgstr "は承認されました"
 
-#: src/olympia/editors/views.py:808
+#: src/olympia/editors/views.py:813
 msgid "given preliminary review"
 msgstr "は事前審査を承認されました"
 
-#: src/olympia/editors/views.py:809
+#: src/olympia/editors/views.py:814
 msgid "rejected"
 msgstr "は却下されました"
 
-#: src/olympia/editors/views.py:810
+#: src/olympia/editors/views.py:815
 msgctxt "editors_review_history_nominated_adminreview"
 msgid "escalated"
 msgstr "は上級審査に回されました"
 
-#: src/olympia/editors/views.py:812
+#: src/olympia/editors/views.py:817
 msgid "needs more information"
 msgstr "は詳しい情報を求められました"
 
-#: src/olympia/editors/views.py:813
+#: src/olympia/editors/views.py:818
 msgid "needs super review"
 msgstr "は上級審査が必要です"
 
-#: src/olympia/editors/views.py:814
+#: src/olympia/editors/views.py:819
 msgid "commented"
 msgstr "コメント付き"
 
@@ -7615,6 +7709,7 @@ msgstr "コメント付き"
 msgid "{0} theme review successfully processed (+{1} points, {2} total)."
 msgid_plural "{0} theme reviews successfully processed (+{1} points, {2} total)."
 msgstr[0] "{0} 個のテーマの審査が完了しました (+{1} ポイント、{2} 合計)。"
+msgstr[1] ""
 
 #: src/olympia/editors/views_themes.py:341
 msgid "Your theme locks have successfully been released. Other reviewers may now review those released themes. You may have to refresh the page to see the changes reflected in the table below."
@@ -7651,28 +7746,28 @@ msgstr "審査待ち"
 msgid "Unlisted Queues"
 msgstr "非掲載アドオンの審査待ち"
 
-#: src/olympia/editors/templates/editors/base.html:72 src/olympia/editors/templates/editors/performance.html:6
+#: src/olympia/editors/templates/editors/base.html:74 src/olympia/editors/templates/editors/performance.html:6
 msgid "Performance"
 msgstr "パフォーマンス"
 
-#: src/olympia/editors/templates/editors/base.html:75 src/olympia/editors/templates/editors/themes/base.html:19 src/olympia/editors/templates/editors/themes/base.html:38
+#: src/olympia/editors/templates/editors/base.html:77 src/olympia/editors/templates/editors/themes/base.html:19 src/olympia/editors/templates/editors/themes/base.html:38
 msgid "Logs"
 msgstr "履歴"
 
-#: src/olympia/editors/templates/editors/base.html:78 src/olympia/editors/templates/editors/reviewlog.html:4 src/olympia/editors/templates/editors/reviewlog.html:27
+#: src/olympia/editors/templates/editors/base.html:80 src/olympia/editors/templates/editors/reviewlog.html:4 src/olympia/editors/templates/editors/reviewlog.html:27
 msgid "Add-on Review Log"
 msgstr "アドオンの審査履歴"
 
-#: src/olympia/editors/templates/editors/base.html:80 src/olympia/editors/templates/editors/eventlog.html:4 src/olympia/editors/templates/editors/eventlog.html:8
+#: src/olympia/editors/templates/editors/base.html:82 src/olympia/editors/templates/editors/eventlog.html:4 src/olympia/editors/templates/editors/eventlog.html:8
 #: src/olympia/editors/templates/editors/eventlog_detail.html:4
 msgid "Moderated Review Log"
 msgstr "管理者審査履歴"
 
-#: src/olympia/editors/templates/editors/base.html:82 src/olympia/editors/templates/editors/beta_signed_log.html:4 src/olympia/editors/templates/editors/beta_signed_log.html:8
+#: src/olympia/editors/templates/editors/base.html:84 src/olympia/editors/templates/editors/beta_signed_log.html:4 src/olympia/editors/templates/editors/beta_signed_log.html:8
 msgid "Signed Beta Files Log"
 msgstr ""
 
-#: src/olympia/editors/templates/editors/base.html:87 src/olympia/editors/templates/editors/includes/daily-message.html:4
+#: src/olympia/editors/templates/editors/base.html:89 src/olympia/editors/templates/editors/includes/daily-message.html:4
 msgid "Announcement"
 msgstr "お知らせ"
 
@@ -7731,16 +7826,19 @@ msgstr "削除を取り消し"
 msgid "Full Review ({num})"
 msgid_plural "Full Reviews ({num})"
 msgstr[0] "本審査 ({num})"
+msgstr[1] ""
 
 #: src/olympia/editors/templates/editors/home.html:18
 msgid "Pending Update ({num})"
 msgid_plural "Pending Updates ({num})"
 msgstr[0] "更新審査待ち ({num})"
+msgstr[1] ""
 
 #: src/olympia/editors/templates/editors/home.html:25
 msgid "Preliminary Review ({num})"
 msgid_plural "Preliminary Reviews ({num})"
 msgstr[0] "事前審査 ({num})"
+msgstr[1] ""
 
 #: src/olympia/editors/templates/editors/home.html:36 src/olympia/editors/templates/editors/home.html:86
 msgid "Current waiting times:"
@@ -7750,6 +7848,7 @@ msgstr "現在の待ち時間:"
 msgid "{0} add-on"
 msgid_plural "{0} add-ons"
 msgstr[0] "{0} 個のアドオン"
+msgstr[1] ""
 
 #: src/olympia/editors/templates/editors/home.html:45 src/olympia/editors/templates/editors/home.html:95
 #, python-format
@@ -7760,16 +7859,19 @@ msgstr "{0}%%"
 msgid "Unlisted Full Review ({num})"
 msgid_plural "Unlisted Full Reviews ({num})"
 msgstr[0] "非掲載アドオンの完全審査 ({num})"
+msgstr[1] ""
 
 #: src/olympia/editors/templates/editors/home.html:68
 msgid "Unlisted Pending Update ({num})"
 msgid_plural "Unlisted Pending Updates ({num})"
 msgstr[0] "非掲載アドオンの更新待ち ({num})"
+msgstr[1] ""
 
 #: src/olympia/editors/templates/editors/home.html:75
 msgid "Unlisted Preliminary Review ({num})"
 msgid_plural "Unlisted Preliminary Reviews ({num})"
 msgstr[0] "非掲載アドオンの事前審査 ({num})"
+msgstr[1] ""
 
 #: src/olympia/editors/templates/editors/home.html:109 src/olympia/editors/templates/editors/performance.html:37 src/olympia/editors/templates/editors/themes/home.html:54
 msgid "Total Reviews"
@@ -7792,6 +7894,7 @@ msgstr "あなたの審査回数は {1} 回で {0} 位です"
 msgid "Moderated Review ({num})"
 msgid_plural "Moderated Reviews ({num})"
 msgstr[0] "管理者審査 ({num})"
+msgstr[1] ""
 
 #: src/olympia/editors/templates/editors/leaderboard.html:3 src/olympia/editors/templates/editors/includes/reviewers_score_bar.html:56
 msgid "Reviewer Leaderboard"
@@ -7885,45 +7988,45 @@ msgstr "高度な検索"
 msgid "clear search"
 msgstr "検索をクリア"
 
-#: src/olympia/editors/templates/editors/queue.html:72 src/olympia/editors/templates/editors/queue.html:122
+#: src/olympia/editors/templates/editors/queue.html:78 src/olympia/editors/templates/editors/queue.html:128
 msgid "Process Reviews"
 msgstr "審査を処理"
 
-#: src/olympia/editors/templates/editors/queue.html:80
+#: src/olympia/editors/templates/editors/queue.html:86
 msgid "Moderation actions:"
 msgstr "管理アクション:"
 
-#: src/olympia/editors/templates/editors/queue.html:90
+#: src/olympia/editors/templates/editors/queue.html:96
 #, python-format
 msgid "by %(user)s on %(date)s %(stars)s (%(locale)s)"
 msgstr ""
 
-#: src/olympia/editors/templates/editors/queue.html:106
+#: src/olympia/editors/templates/editors/queue.html:112
 #, python-format
 msgid "<strong>%(reason)s</strong> <span class=\"light\">Flagged by %(user)s on %(date)s</span>"
 msgstr ""
 
-#: src/olympia/editors/templates/editors/queue.html:119
-msgid "All reviews have been moderated.  Good work!"
+#: src/olympia/editors/templates/editors/queue.html:125
+msgid "All reviews have been moderated. Good work!"
 msgstr ""
 
-#: src/olympia/editors/templates/editors/queue.html:161
+#: src/olympia/editors/templates/editors/queue.html:167
 msgid "Version Notes / Notes for Reviewer"
 msgstr "リリースノート / 審査担当者へのメモ"
 
-#: src/olympia/editors/templates/editors/queue.html:169
+#: src/olympia/editors/templates/editors/queue.html:175
 msgid "There are currently no add-ons of this type to review."
 msgstr ""
 
-#: src/olympia/editors/templates/editors/queue.html:181 src/olympia/editors/templates/editors/themes/queue_list.html:85
+#: src/olympia/editors/templates/editors/queue.html:187 src/olympia/editors/templates/editors/themes/queue_list.html:85
 msgid "Helpful Links:"
 msgstr "参考になるリンク:"
 
-#: src/olympia/editors/templates/editors/queue.html:182
+#: src/olympia/editors/templates/editors/queue.html:188
 msgid "Add-on Policy"
 msgstr "アドオンポリシー"
 
-#: src/olympia/editors/templates/editors/queue.html:184
+#: src/olympia/editors/templates/editors/queue.html:190
 msgid "Editors' Guide"
 msgstr "編集者ガイド"
 
@@ -7986,10 +8089,7 @@ msgid "<strong>Warning!</strong> Another user was viewing this page before you."
 msgstr ""
 
 #: src/olympia/editors/templates/editors/review.html:237
-msgid ""
-"The whiteboard is the place to exchange information relevant to\n"
-"               this addon (whatever the version), between the developer and the\n"
-"               editor. This is visible and editable by both."
+msgid "The whiteboard is the place to exchange information relevant to this addon (whatever the version), between the developer and the editor. This is visible and editable by both."
 msgstr ""
 
 #: src/olympia/editors/templates/editors/review.html:241
@@ -8090,8 +8190,9 @@ msgstr "全期間"
 msgid "You have <span>{0}</span> points."
 msgstr "あなたは <span>{0}</span> ポイント獲得しています。"
 
-#: src/olympia/editors/templates/editors/includes/search_results_themes.html:6 src/olympia/editors/templates/editors/themes/history_table.html:7 src/olympia/editors/templates/editors/themes/logs.html:19
-#: src/olympia/editors/templates/editors/themes/queue_list.html:49 src/olympia/editors/templates/editors/themes/single.html:26 src/olympia/editors/templates/editors/themes/themes.html:45
+#: src/olympia/editors/templates/editors/includes/search_results_themes.html:6 src/olympia/editors/templates/editors/themes/history_table.html:7
+#: src/olympia/editors/templates/editors/themes/logs.html:19 src/olympia/editors/templates/editors/themes/queue_list.html:49 src/olympia/editors/templates/editors/themes/single.html:26
+#: src/olympia/editors/templates/editors/themes/themes.html:45
 msgid "Reviewer"
 msgstr "審査担当者"
 
@@ -8131,16 +8232,19 @@ msgstr "現在審査待ちのテーマはありません。"
 msgid "{num} Pending Theme Review"
 msgid_plural "{num} Pending Theme Reviews"
 msgstr[0] "{num} 個の審査待ちテーマ"
+msgstr[1] ""
 
 #: src/olympia/editors/templates/editors/themes/home.html:27
 msgid "{num} Flagged Review"
 msgid_plural "{num} Flagged Reviews"
 msgstr[0] "{num} 個のフラグ付き審査"
+msgstr[1] ""
 
 #: src/olympia/editors/templates/editors/themes/home.html:34
 msgid "{num} Update"
 msgid_plural "{num} Updates"
 msgstr[0] "{num} 個の更新"
+msgstr[1] ""
 
 #: src/olympia/editors/templates/editors/themes/logs.html:4
 msgid "Theme Review Log"
@@ -8259,7 +8363,7 @@ msgstr "作者に質問する"
 msgid "Describe your reason for flagging"
 msgstr "フラグを立てる理由を説明"
 
-#: src/olympia/files/forms.py:88
+#: src/olympia/files/forms.py:90
 msgid "Cannot diff a version against itself"
 msgstr "同じバージョンの差分を取ることはできません"
 
@@ -8294,51 +8398,51 @@ msgstr "ファイル「%s」を開けませんでした。%s"
 msgid "There was an error accessing file %s."
 msgstr "ファイル「%s」を開けませんでした。"
 
-#: src/olympia/files/utils.py:343
+#: src/olympia/files/utils.py:340
 msgid "Could not parse uploaded file."
 msgstr "アップロードされたファイルを解析できませんでした。"
 
-#: src/olympia/files/utils.py:380
+#: src/olympia/files/utils.py:377
 msgid "Invalid file name in archive: {0}"
 msgstr "アーカイブ内のファイル名が不正です: {0}"
 
-#: src/olympia/files/utils.py:388
+#: src/olympia/files/utils.py:385
 msgid "File exceeding size limit in archive: {0}"
 msgstr "アーカイブ内のファイルがサイズ制限を超えています: {0}"
 
-#: src/olympia/files/utils.py:439
+#: src/olympia/files/utils.py:436
 msgid "Invalid archive."
 msgstr "不正なアーカイブです。"
 
-#: src/olympia/files/utils.py:529 src/olympia/files/utils.py:532
+#: src/olympia/files/utils.py:526 src/olympia/files/utils.py:529
 msgid "Could not parse the manifest file."
 msgstr "マニフェストファイルを解析できませんでした。"
 
-#: src/olympia/files/utils.py:551
+#: src/olympia/files/utils.py:548
 msgid "Could not find an add-on ID."
 msgstr "アドオンの ID を見つけられませんでした。"
 
-#: src/olympia/files/utils.py:554
+#: src/olympia/files/utils.py:551
 msgid "Add-on ID must be 64 characters or less."
 msgstr "アドオンの ID は 64 文字以下でなければなりません。"
 
-#: src/olympia/files/utils.py:556
+#: src/olympia/files/utils.py:553
 msgid "Add-on ID doesn't match add-on."
 msgstr "アドオンの ID がアドオンに一致しません。"
 
-#: src/olympia/files/utils.py:564
+#: src/olympia/files/utils.py:561
 msgid "Duplicate add-on ID found."
 msgstr "重複したアドオンの ID が見つかりました。"
 
-#: src/olympia/files/utils.py:567
+#: src/olympia/files/utils.py:564
 msgid "Version numbers should have fewer than 32 characters."
 msgstr "バージョン番号は 32 文字以内でなければなりません。"
 
-#: src/olympia/files/utils.py:570
+#: src/olympia/files/utils.py:567
 msgid "Version numbers should only contain letters, numbers, and these punctuation characters: +*.-_."
 msgstr "バージョン番号に英数字もしくは記号「+*.-_.」以外の文字を含めることはできません。"
 
-#: src/olympia/files/utils.py:587
+#: src/olympia/files/utils.py:584
 msgid "<em:type> doesn't match add-on"
 msgstr "<em:type> がアドオンと一致しません"
 
@@ -8438,6 +8542,10 @@ msgstr "アップロードされたファイルにはファイルが含まれて
 #: src/olympia/files/templates/files/viewer.html:134
 msgid "Fetching file."
 msgstr "ファイルを取得しています。"
+
+#: src/olympia/legacy_api/views.py:255
+msgid "Not implemented yet."
+msgstr "まだ実装されていません。"
 
 #: src/olympia/lib/constants.py:6
 msgid "United Arab Emirates Dirham"
@@ -9095,10 +9203,6 @@ msgstr "ザンビア, クワチャ"
 msgid "Zimbabwe Dollar"
 msgstr "ジンバブエ, ドル"
 
-#: src/olympia/lib/video/ffmpeg.py:112 src/olympia/lib/video/totem.py:81
-msgid "Videos must be in WebM."
-msgstr ""
-
 #: src/olympia/pages/templates/pages/about.lhtml:3 src/olympia/pages/templates/pages/about.lhtml:10
 msgid "About Mozilla Add-ons"
 msgstr "Mozilla Add-ons について"
@@ -9110,7 +9214,7 @@ msgstr "このサイトは何ですか？"
 #: src/olympia/pages/templates/pages/about.lhtml:13
 msgid ""
 "addons.mozilla.org, commonly known as \"AMO\", is Mozilla's official site for add-ons to Mozilla software, such as Firefox, Thunderbird, and SeaMonkey. Add-ons let you add new features and change "
-"the way your browser or application works.  Take a look around and explore the thousands of ways to customize the way you do things online."
+"the way your browser or application works. Take a look around and explore the thousands of ways to customize the way you do things online."
 msgstr ""
 
 #: src/olympia/pages/templates/pages/about.lhtml:19
@@ -9166,7 +9270,8 @@ msgstr ""
 
 #: src/olympia/pages/templates/pages/about.lhtml:49
 #, python-format
-msgid "Help improve this website. It's open source, and you can file bugs and submit patches. <a href=\"%(url)s\"> GitHub</a> contains all of our current bugs, legacy bugs can still be found in Bugzilla."
+msgid ""
+"Help improve this website. It's open source, and you can file bugs and submit patches. <a href=\"%(url)s\"> GitHub</a> contains all of our current bugs, legacy bugs can still be found in Bugzilla."
 msgstr ""
 
 #: src/olympia/pages/templates/pages/about.lhtml:55
@@ -9209,8 +9314,8 @@ msgstr ""
 #: src/olympia/pages/templates/pages/about.lhtml:77
 #, python-format
 msgid ""
-"Over the years, many people have contributed to this website, including both volunteers from the community and a dedicated AMO team. A list of significant contributors can be found on our <a "
-"href=\"%(url)s\"> Site Credits</a> page."
+"Over the years, many people have contributed to this website, including both volunteers from the community and a dedicated AMO team. A list of significant contributors can be found on our <a href="
+"\"%(url)s\"> Site Credits</a> page."
 msgstr ""
 
 #: src/olympia/pages/templates/pages/acr_firstrun.html:4
@@ -9244,8 +9349,8 @@ msgstr ""
 #: src/olympia/pages/templates/pages/acr_firstrun.html:61
 #, python-format
 msgid ""
-"If you upgrade to a new version of Firefox or update your add-ons, your reports for the old versions will be hidden to allow you to test the new version. If you have any questions, please ask in <a"
-" href=\"%(url)s\">our forums</a>."
+"If you upgrade to a new version of Firefox or update your add-ons, your reports for the old versions will be hidden to allow you to test the new version. If you have any questions, please ask in <a "
+"href=\"%(url)s\">our forums</a>."
 msgstr ""
 
 #: src/olympia/pages/templates/pages/acr_firstrun.html:69
@@ -9309,8 +9414,8 @@ msgstr ""
 
 #: src/olympia/pages/templates/pages/credits.html:61
 msgid ""
-"Some pages use elements of <a href=\"http://shop.highsoft.com/highcharts.html\">Highcharts</a> (non-commercial), licensed under a <a href=\"http://creativecommons.org/licenses/by-nc/3.0/\">Creative"
-" Commons Attribution-NonCommercial 3.0 License</a>."
+"Some pages use elements of <a href=\"http://shop.highsoft.com/highcharts.html\">Highcharts</a> (non-commercial), licensed under a <a href=\"http://creativecommons.org/licenses/by-nc/3.0/\">Creative "
+"Commons Attribution-NonCommercial 3.0 License</a>."
 msgstr ""
 
 #: src/olympia/pages/templates/pages/credits.html:65
@@ -9442,7 +9547,8 @@ msgstr ""
 
 #: src/olympia/pages/templates/pages/dev_faq.html:143
 #, python-format
-msgid "Yes. You can use Mozilla's <a href=\"%(url)s\">XPCOM component object model</a> to enhance your add-ons. XPCOM components be used and implemented in JavaScript, Java, and Python in addition to C++."
+msgid ""
+"Yes. You can use Mozilla's <a href=\"%(url)s\">XPCOM component object model</a> to enhance your add-ons. XPCOM components be used and implemented in JavaScript, Java, and Python in addition to C++."
 msgstr ""
 
 #: src/olympia/pages/templates/pages/dev_faq.html:150
@@ -9453,7 +9559,7 @@ msgstr "アドオンを作成するのに、jQuery や MooTools、Prototype.js �
 msgid ""
 "Yes. It's possible, but some of the functionality provided by these libraries are available through XPCOM, XUL, and JavaScript. In addition, authors should take care if libraries modify primitive "
 "object prototypes (String.prototype, Date.prototype, etc.) and/or define global functions (eg. the $ function). These are prone to cause conflict with other add-ons, in particular if different add-"
-"ons use different versions of libraries and so on. Developers need to be very, very careful with using them.  Mozilla does not offer documentation on using them to build add-ons."
+"ons use different versions of libraries and so on. Developers need to be very, very careful with using them. Mozilla does not offer documentation on using them to build add-ons."
 msgstr ""
 
 #: src/olympia/pages/templates/pages/dev_faq.html:165
@@ -9483,8 +9589,8 @@ msgstr ""
 #: src/olympia/pages/templates/pages/dev_faq.html:187
 #, python-format
 msgid ""
-"Poorly written extensions can have a severe impact on the browsing experience, including on the overall performance of Firefox itself. The following page contains many good <a "
-"href=\"%(url)s\">guides</a> that help you improve performance, whether you're developing core Mozilla code or an add-on."
+"Poorly written extensions can have a severe impact on the browsing experience, including on the overall performance of Firefox itself. The following page contains many good <a href=\"%(url)s"
+"\">guides</a> that help you improve performance, whether you're developing core Mozilla code or an add-on."
 msgstr ""
 
 #: src/olympia/pages/templates/pages/dev_faq.html:195
@@ -9555,8 +9661,8 @@ msgstr ""
 #: src/olympia/pages/templates/pages/dev_faq.html:248
 #, python-format
 msgid ""
-"Yes. You may find 3rd party developers via the <a href=\"%(forum_url)s\">Add-ons forum</a>, <a href=\"%(list_url)s\">mozilla.jobs list</a>, <a href=\"%(mz_url)s\">mozillaZine forums</a> or <a "
-"href=\"%(wiki_url)s\">the Mozilla Wiki</a>. Please note that Mozilla does not offer developer recommendations."
+"Yes. You may find 3rd party developers via the <a href=\"%(forum_url)s\">Add-ons forum</a>, <a href=\"%(list_url)s\">mozilla.jobs list</a>, <a href=\"%(mz_url)s\">mozillaZine forums</a> or <a href="
+"\"%(wiki_url)s\">the Mozilla Wiki</a>. Please note that Mozilla does not offer developer recommendations."
 msgstr ""
 
 #: src/olympia/pages/templates/pages/dev_faq.html:263
@@ -9566,9 +9672,9 @@ msgstr ""
 #: src/olympia/pages/templates/pages/dev_faq.html:265
 #, python-format
 msgid ""
-"Yes. Many developers choose to host their own add-ons. Choosing to host your add-on on <a href=\"%(amo_url)s\">Mozilla's add-on site</a>, though, allows for much greater exposure to your add-on due"
-" to the large volume of visitors to the site.  <a href=\"%(md_url)s\">mozdev.org</a> offers free project hosting for Mozilla applications and extensions providing developers with tools to help "
-"manage source code, version control, bug tracking and documentation."
+"Yes. Many developers choose to host their own add-ons. Choosing to host your add-on on <a href=\"%(amo_url)s\">Mozilla's add-on site</a>, though, allows for much greater exposure to your add-on due "
+"to the large volume of visitors to the site. <a href=\"%(md_url)s\">mozdev.org</a> offers free project hosting for Mozilla applications and extensions providing developers with tools to help manage "
+"source code, version control, bug tracking and documentation."
 msgstr ""
 
 #: src/olympia/pages/templates/pages/dev_faq.html:277
@@ -9616,7 +9722,7 @@ msgstr ""
 #: src/olympia/pages/templates/pages/dev_faq.html:314
 #, python-format
 msgid ""
-"Yes. Mozilla's <a href=\"%(p_url)s\">Add-on Policy</a> describes what is an acceptable submission. This policy is subject to change without notice.  In addition, the AMO editorial team uses the <a "
+"Yes. Mozilla's <a href=\"%(p_url)s\">Add-on Policy</a> describes what is an acceptable submission. This policy is subject to change without notice. In addition, the AMO editorial team uses the <a "
 "href=\"%(g_url)s\">Editors Reviewing Guide</a> to ensure that your add-on meets specific guidelines for functionality and security."
 msgstr ""
 
@@ -9645,8 +9751,8 @@ msgstr ""
 
 #: src/olympia/pages/templates/pages/dev_faq.html:346
 msgid ""
-"The choice of category is dependent on what type of audience you are targeting and the functionality of your add-on. If you're unsure of which category your add-on falls into, please choose "
-"\"Other\". The AMO team may re-categorize your add-on if it's determined that it's better suited in a different category."
+"The choice of category is dependent on what type of audience you are targeting and the functionality of your add-on. If you're unsure of which category your add-on falls into, please choose \"Other"
+"\". The AMO team may re-categorize your add-on if it's determined that it's better suited in a different category."
 msgstr ""
 
 #: src/olympia/pages/templates/pages/dev_faq.html:355
@@ -9680,8 +9786,8 @@ msgstr ""
 #: src/olympia/pages/templates/pages/dev_faq.html:385
 #, python-format
 msgid ""
-"All add-ons submitted, whether new or updated, are reviewed to ensure that Mozilla users have a stable and safe experience. All add-ons submissions are reviewed using the guidelines outlined in the"
-" <a href=\"%(url)s\">Editors Reviewing Guide</a>."
+"All add-ons submitted, whether new or updated, are reviewed to ensure that Mozilla users have a stable and safe experience. All add-ons submissions are reviewed using the guidelines outlined in the "
+"<a href=\"%(url)s\">Editors Reviewing Guide</a>."
 msgstr ""
 
 #: src/olympia/pages/templates/pages/dev_faq.html:393
@@ -9733,8 +9839,8 @@ msgstr "発見した問題点の数"
 #: src/olympia/pages/templates/pages/dev_faq.html:434
 #, python-format
 msgid ""
-"This is why it's very important to read the <a href=\"%(g_url)s\">Editors Reviewing Guide</a> to ensure that your add-on is setup as expected.  It's also a good idea to read the blog post, <a "
-"href=\"%(blog_url)s\">Successfully Getting your Add-on Reviewed</a> which provides excellent insight into ensuring a smooth review of your add-on."
+"This is why it's very important to read the <a href=\"%(g_url)s\">Editors Reviewing Guide</a> to ensure that your add-on is setup as expected. It's also a good idea to read the blog post, <a href="
+"\"%(blog_url)s\">Successfully Getting your Add-on Reviewed</a> which provides excellent insight into ensuring a smooth review of your add-on."
 msgstr ""
 
 #: src/olympia/pages/templates/pages/dev_faq.html:446
@@ -9750,7 +9856,8 @@ msgid "How can I see how many active users are using my add-on?"
 msgstr ""
 
 #: src/olympia/pages/templates/pages/dev_faq.html:457
-msgid "The Statistics Dashboard found in the Developer Tools dashboard provides information that can help you determine how many users have been actively using your add-on since you've submitted it to AMO."
+msgid ""
+"The Statistics Dashboard found in the Developer Tools dashboard provides information that can help you determine how many users have been actively using your add-on since you've submitted it to AMO."
 msgstr ""
 
 #: src/olympia/pages/templates/pages/dev_faq.html:464
@@ -9839,7 +9946,7 @@ msgstr ""
 
 #: src/olympia/pages/templates/pages/dev_faq.html:572
 msgid ""
-"Free Software Foundation provides short summaries of the key open source licenses, including whether the license qualifies as a free software license or a copyleft license.  Also includes a "
+"Free Software Foundation provides short summaries of the key open source licenses, including whether the license qualifies as a free software license or a copyleft license. Also includes a "
 "discussion of what constitutes a free software license or a copyleft license (e.g., a Copyleft license is a general method for making a program or other work free, and requiring all modified and "
 "extended versions of the program to be free as well.)"
 msgstr ""
@@ -9874,8 +9981,8 @@ msgid ""
 "Add-ons are small pieces of software that add new features or functionality to your installation of %(app_name)s. Add-ons can augment %(app_name)s with new features, foreign language dictionaries, "
 "or change its visual appearance. Through add-ons, you can customize %(app_name)s to meet your needs and tastes. <a href=\"%(learnmore_url)s\">Learn more about customization</a>"
 msgstr ""
-"アドオンは、あなたの %(app_name)s に新しい特徴や機能を追加する小さなアプリケーションです。アドオンによって、%(app_name)s に新しい機能や外国語の辞書を追加したり、その外観を変更したりすることができます。これにより、%(app_name)s をあなたのニーズや好みに合わせてカスタマイズすることができます。<a "
-"href=\"%(learnmore_url)s\">カスタマイズに関する詳細</a>"
+"アドオンは、あなたの %(app_name)s に新しい特徴や機能を追加する小さなアプリケーションです。アドオンによって、%(app_name)s に新しい機能や外国語の辞書を追加したり、その外観を変更したりすることができま"
+"す。これにより、%(app_name)s をあなたのニーズや好みに合わせてカスタマイズすることができます。<a href=\"%(learnmore_url)s\">カスタマイズに関する詳細</a>"
 
 #: src/olympia/pages/templates/pages/faq.html:26
 msgid "Will add-ons work with my web browser or application?"
@@ -9884,14 +9991,14 @@ msgstr "アドオンは私の Web ブラウザやアプリケーションで動�
 #: src/olympia/pages/templates/pages/faq.html:27
 #, python-format
 msgid ""
-"Add-ons listed in this gallery only work with Mozilla-based applications, such as <a href=\"%(getfirefox_url)s\">Firefox</a>, <a href=\"%(getmobile_url)s\">Firefox Mobile</a>, <a "
-"href=\"%(getseamonkey_url)s\">SeaMonkey</a>, and <a href=\"%(getthunderbird_url)s\">Thunderbird</a>. However, not all add-ons work with each of those applications or every version of those "
-"applications. Each add-on specifies which applications and versions it works with, such as Firefox 2.0 - 3.6.*. For Firefox add-ons, the install buttons will indicate whether the add-on is "
-"compatible or not."
+"Add-ons listed in this gallery only work with Mozilla-based applications, such as <a href=\"%(getfirefox_url)s\">Firefox</a>, <a href=\"%(getmobile_url)s\">Firefox Mobile</a>, <a href="
+"\"%(getseamonkey_url)s\">SeaMonkey</a>, and <a href=\"%(getthunderbird_url)s\">Thunderbird</a>. However, not all add-ons work with each of those applications or every version of those applications. "
+"Each add-on specifies which applications and versions it works with, such as Firefox 2.0 - 3.6.*. For Firefox add-ons, the install buttons will indicate whether the add-on is compatible or not."
 msgstr ""
-"このギャラリーに登録されているアドオンは、 Mozilla の関連製品 （<a href=\"%(getfirefox_url)s\">Firefox</a>, <a href=\"%(getmobile_url)s\">Firefox Mobile</a>, <a href=\"%(getseamonkey_url)s\">SeaMonkey</a>, <a "
-"href=\"%(getthunderbird_url)s\">Thunderbird</a> など） のみで動作します。ただし、すべてのアドオンが、それぞれのアプリケーションとそのすべてのバージョンで動作するわけではありません。それぞれのアドオンには、どのアプリケーションやバージョンで動作するかが明記されています （例えば、 Firefox 2.0 - 3.6.* など）。Firefox "
-"のアドオンに関しては、そのアドオンが動作するかどうかをインストールボタンで判断することができます。"
+"このギャラリーに登録されているアドオンは、 Mozilla の関連製品 （<a href=\"%(getfirefox_url)s\">Firefox</a>, <a href=\"%(getmobile_url)s\">Firefox Mobile</a>, <a href=\"%(getseamonkey_url)s"
+"\">SeaMonkey</a>, <a href=\"%(getthunderbird_url)s\">Thunderbird</a> など） のみで動作します。ただし、すべてのアドオンが、それぞれのアプリケーションとそのすべてのバージョンで動作するわけではありませ"
+"ん。それぞれのアドオンには、どのアプリケーションやバージョンで動作するかが明記されています （例えば、 Firefox 2.0 - 3.6.* など）。Firefox のアドオンに関しては、そのアドオンが動作するかどうかをインス"
+"トールボタンで判断することができます。"
 
 #: src/olympia/pages/templates/pages/faq.html:42
 msgid "What are the different types of add-ons?"
@@ -9908,8 +10015,8 @@ msgid ""
 "<strong><a href=\"%(browse_url)s\">Extensions</a></strong> add new features to %(app_name)s or modify existing functionality. There are extensions that allow you to block advertisements, download "
 "videos from websites, integrate more closely with social websites, and add features you see in other applications."
 msgstr ""
-"<strong><a href=\"%(browse_url)s\">拡張機能</a></strong> は、 %(app_name)s に新しい特徴を追加したり、既存の機能を改良したりすることができます。例えば、広告の表示をブロックしたり、 Web サイトから動画をダウンロードしたり、ソーシャル Web "
-"サイトとの連携をより密接にしたり、他のアプリケーションにある特徴を追加したりといった拡張機能があります。"
+"<strong><a href=\"%(browse_url)s\">拡張機能</a></strong> は、 %(app_name)s に新しい特徴を追加したり、既存の機能を改良したりすることができます。例えば、広告の表示をブロックしたり、 Web サイトから動画"
+"をダウンロードしたり、ソーシャル Web サイトとの連携をより密接にしたり、他のアプリケーションにある特徴を追加したりといった拡張機能があります。"
 
 #: src/olympia/pages/templates/pages/faq.html:55
 #, python-format
@@ -9955,8 +10062,8 @@ msgstr "Firefox を再起動せずにアドオンをインストールするに�
 #: src/olympia/pages/templates/pages/faq.html:101
 #, python-format
 msgid ""
-"In Firefox, add-ons marked with \"No restart required\" can be installed without restarting. These add-ons have been created using the <a href=\"%(sdk_url)s\">Add-on SDK</a> or <a "
-"href=\"%(bootstrap_url)s\">bootstrapping</a>. Other add-ons will still require a restart before you can use them."
+"In Firefox, add-ons marked with \"No restart required\" can be installed without restarting. These add-ons have been created using the <a href=\"%(sdk_url)s\">Add-on SDK</a> or <a href="
+"\"%(bootstrap_url)s\">bootstrapping</a>. Other add-ons will still require a restart before you can use them."
 msgstr ""
 
 #: src/olympia/pages/templates/pages/faq.html:110
@@ -9967,8 +10074,8 @@ msgstr ""
 #, python-format
 msgid ""
 "Add-ons, unlike plugins, are automatically checked for updates once every day. In Firefox, updates are automatically installed by default. Versions of Firefox prior to 4 (and other applications) "
-"will alert you that updates to your add-ons are available. <a href=\"%(plugin_url)s\">Plugins</a> are not currently automatically checked for updates, so be sure to regularly visit the <a "
-"href=\"%(plugincheck_url)s\">Plugin Check</a> page to stay up-to-date."
+"will alert you that updates to your add-ons are available. <a href=\"%(plugin_url)s\">Plugins</a> are not currently automatically checked for updates, so be sure to regularly visit the <a href="
+"\"%(plugincheck_url)s\">Plugin Check</a> page to stay up-to-date."
 msgstr ""
 
 #: src/olympia/pages/templates/pages/faq.html:122
@@ -9978,9 +10085,9 @@ msgstr ""
 #: src/olympia/pages/templates/pages/faq.html:123
 #, python-format
 msgid ""
-"Unless clearly marked otherwise, add-ons available from this gallery have been checked and approved by Mozilla's team of editors and are safe to install. We recommend that you only install approved"
-" add-ons. If you wish to install unapproved add-ons or add-ons from third-party websites, use caution as these add-ons may harm your computer or violate your privacy. <a "
-"href=\"%(learnmore_url)s\">Learn more about our approval process</a>"
+"Unless clearly marked otherwise, add-ons available from this gallery have been checked and approved by Mozilla's team of editors and are safe to install. We recommend that you only install approved "
+"add-ons. If you wish to install unapproved add-ons or add-ons from third-party websites, use caution as these add-ons may harm your computer or violate your privacy. <a href=\"%(learnmore_url)s"
+"\">Learn more about our approval process</a>"
 msgstr ""
 
 #: src/olympia/pages/templates/pages/faq.html:133
@@ -10004,8 +10111,8 @@ msgstr ""
 #, python-format
 msgid ""
 "If an add-on isn't compatible with your version of %(app_name)s, it is usually either because your version of %(app_name)s is outdated or the add-on author has not yet updated the add-on to be "
-"compatible with a newer version you are using. Mozilla does not recommend trying to circumvent these compatibility checks, as they can lead to browser instability or in some cases loss of data. For"
-" users who are testing out alpha or beta versions of Firefox, we offer the <a href=\"%(acr_url)s\">Add-on Compatibility Reporter</a> to help add-on developers update their compatibility."
+"compatible with a newer version you are using. Mozilla does not recommend trying to circumvent these compatibility checks, as they can lead to browser instability or in some cases loss of data. For "
+"users who are testing out alpha or beta versions of Firefox, we offer the <a href=\"%(acr_url)s\">Add-on Compatibility Reporter</a> to help add-on developers update their compatibility."
 msgstr ""
 
 #: src/olympia/pages/templates/pages/faq.html:156
@@ -10025,19 +10132,13 @@ msgid "Add-on Gallery"
 msgstr "アドオンギャラリー"
 
 #: src/olympia/pages/templates/pages/faq.html:171
-msgid ""
-"How do I choose between add-ons that seem to do the same\n"
-"    thing?"
+msgid "How do I choose between add-ons that seem to do the same thing?"
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:173
+#: src/olympia/pages/templates/pages/faq.html:172
 msgid ""
-"There are often several add-ons that have similar features. To\n"
-"    figure out which is right for you, read the entire description of the\n"
-"    add-on and view its screenshots. If there are still several in the running,\n"
-"    read through the add-on's ratings, user reviews, and statistics to see\n"
-"    which is most liked by other users. Remember that you can also just try\n"
-"    out both and see which you like better."
+"There are often several add-ons that have similar features. To figure out which is right for you, read the entire description of the add-on and view its screenshots. If there are still several in "
+"the running, read through the add-on's ratings, user reviews, and statistics to see which is most liked by other users. Remember that you can also just try out both and see which you like better."
 msgstr ""
 
 #: src/olympia/pages/templates/pages/faq.html:180
@@ -10058,8 +10159,8 @@ msgstr ""
 #: src/olympia/pages/templates/pages/faq.html:188
 #, python-format
 msgid ""
-"Experimental add-ons have been checked by our editors to make sure they don't have security problems, but they may still have bugs or not work properly. Use caution when installing experimental "
-"add-ons and uninstall the add-on immediately if you notice problems. <a href=\"%(url)s\">Learn more about our review process</a></dd>"
+"Experimental add-ons have been checked by our editors to make sure they don't have security problems, but they may still have bugs or not work properly. Use caution when installing experimental add-"
+"ons and uninstall the add-on immediately if you notice problems. <a href=\"%(url)s\">Learn more about our review process</a></dd>"
 msgstr ""
 
 #: src/olympia/pages/templates/pages/faq.html:196
@@ -10078,141 +10179,128 @@ msgid "How much do add-ons cost to purchase?"
 msgstr ""
 
 #: src/olympia/pages/templates/pages/faq.html:207
-msgid ""
-"Add-ons hosted in our gallery are free unless clearly marked\n"
-"    otherwise."
+msgid "Add-ons hosted in our gallery are free unless clearly marked otherwise."
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:210
+#: src/olympia/pages/templates/pages/faq.html:209
 msgid "What does it mean when an add-on asks for contributions?"
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:211
+#: src/olympia/pages/templates/pages/faq.html:210
 msgid ""
-"Some add-on authors request users who enjoy an add-on to\n"
-"        contribute to its development by making a monetary contribution. These\n"
-"        contributions go directly to the developer unless a third party is\n"
-"        indicated, such as the non-profit Mozilla Foundation."
+"Some add-on authors request users who enjoy an add-on to contribute to its development by making a monetary contribution. These contributions go directly to the developer unless a third party is "
+"indicated, such as the non-profit Mozilla Foundation."
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:216
+#: src/olympia/pages/templates/pages/faq.html:215
 msgid "What are beta add-ons?"
 msgstr "ベータ版のアドオンとは？"
 
-#: src/olympia/pages/templates/pages/faq.html:218
+#: src/olympia/pages/templates/pages/faq.html:217
 msgid ""
-"Beta add-ons are unreviewed versions which represent the\n"
-"        latest work of an add-on author. While different authors have different\n"
-"        standards for beta code quality, you should assume that these add-ons\n"
-"        are less stable than the general add-on releases."
+"Beta add-ons are unreviewed versions which represent the latest work of an add-on author. While different authors have different standards for beta code quality, you should assume that these add-"
+"ons are less stable than the general add-on releases."
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:222
+#: src/olympia/pages/templates/pages/faq.html:221
 msgid ""
-"Please note that when you install an add-on from the \"Beta Version\" section of an add-on's listing, you will continue to receive updates for that add-on as they become available. Like the initial"
-" version you installed, all beta releases are unreviewed by Mozilla and may harm your computer."
+"Please note that when you install an add-on from the \"Beta Version\" section of an add-on's listing, you will continue to receive updates for that add-on as they become available. Like the initial "
+"version you installed, all beta releases are unreviewed by Mozilla and may harm your computer."
+msgstr ""
+
+#: src/olympia/pages/templates/pages/faq.html:228
+msgid "What does it mean when an add-on is flagged as slow?"
 msgstr ""
 
 #: src/olympia/pages/templates/pages/faq.html:229
-msgid ""
-"What does it mean when an add-on is flagged as\n"
-"    slow?"
+msgid "Most add-ons load code and resources at the same time Firefox is starting up. In most cases the impact in start-up time is minimal, but some add-ons can cause a noticeable slowdown."
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:231
-msgid ""
-"Most add-ons load code and resources at the same time Firefox\n"
-"        is starting up. In most cases the impact in start-up time is minimal,\n"
-"        but some add-ons can cause a noticeable slowdown."
-msgstr ""
-
-#: src/olympia/pages/templates/pages/faq.html:236
+#: src/olympia/pages/templates/pages/faq.html:234
 msgid "How do I report an inappropriate or spam user review?"
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:237
+#: src/olympia/pages/templates/pages/faq.html:235
 msgid ""
-"To report a user review of an add-on, log in with your account\n"
-"    and visit the add-on's reviews page. Find the review you wish to report,\n"
-"    click \"Report this review\" and select a reason. Our editorial team will\n"
-"    investigate the review and take appropriate action."
+"To report a user review of an add-on, log in with your account and visit the add-on's reviews page. Find the review you wish to report, click \"Report this review\" and select a reason. Our "
+"editorial team will investigate the review and take appropriate action."
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:242
+#: src/olympia/pages/templates/pages/faq.html:240
 msgid "How do I report a bug or contact the Mozilla Add-ons team?"
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:243
+#: src/olympia/pages/templates/pages/faq.html:241
 #, python-format
 msgid "Please visit our <a href=\"%(contact_url)s\">Contact page</a>."
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:246
+#: src/olympia/pages/templates/pages/faq.html:244
 msgid "What is a Source Code License?"
 msgstr "ソースコードのライセンスとは？"
 
-#: src/olympia/pages/templates/pages/faq.html:247
+#: src/olympia/pages/templates/pages/faq.html:245
 #, python-format
 msgid ""
-"The source code used to create an add-on is an exclusive copyright of the add-on author, unless otherwise declared in a source code license. Many add-ons on this site have <a href=\"%(url)s\" "
-"lang=\"en\">open source licenses</a> that make the source code publicly available for copy and reuse under conditions determined by the author. Most authors choose widely known open source licenses"
-" like the GPL or BSD licenses instead of making up their own."
+"The source code used to create an add-on is an exclusive copyright of the add-on author, unless otherwise declared in a source code license. Many add-ons on this site have <a href=\"%(url)s\" lang="
+"\"en\">open source licenses</a> that make the source code publicly available for copy and reuse under conditions determined by the author. Most authors choose widely known open source licenses like "
+"the GPL or BSD licenses instead of making up their own."
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:256
+#: src/olympia/pages/templates/pages/faq.html:254
 #, python-format
 msgid "Firefox and other Mozilla software are <a href=\"%(url)s\">open source</a>."
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:264
+#: src/olympia/pages/templates/pages/faq.html:262
 msgid "Collections and Favorites"
 msgstr "コレクションとお気に入り"
 
-#: src/olympia/pages/templates/pages/faq.html:267
+#: src/olympia/pages/templates/pages/faq.html:265
 msgid "What is a collection?"
 msgstr "コレクションとは？"
 
-#: src/olympia/pages/templates/pages/faq.html:268
+#: src/olympia/pages/templates/pages/faq.html:266
 msgid "Collections are groups of related add-ons created by users to share."
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:270
+#: src/olympia/pages/templates/pages/faq.html:268
 msgid "What is the My Favorites collection?"
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:271
+#: src/olympia/pages/templates/pages/faq.html:269
 msgid "Favorite add-ons are add-ons that you have bookmarked to easily get back to later. You can add an add-on to your favorites collection by clicking \"Add to favorites\" on its details page."
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:275 src/olympia/templates/menu_links.html:13 src/olympia/templates/impala/header_title.html:17
+#: src/olympia/pages/templates/pages/faq.html:273 src/olympia/templates/menu_links.html:13 src/olympia/templates/impala/header_title.html:17
 msgid "Mobile Add-ons"
 msgstr "モバイル向けアドオン"
 
-#: src/olympia/pages/templates/pages/faq.html:278
+#: src/olympia/pages/templates/pages/faq.html:276
 msgid "What are mobile add-ons?"
 msgstr "モバイル向けアドオンとは？"
 
-#: src/olympia/pages/templates/pages/faq.html:279
+#: src/olympia/pages/templates/pages/faq.html:277
 #, python-format
 msgid ""
 "Mobile add-ons work with <a href=\"%(mobile_url)s\">Firefox for Mobile</a> and add or modify functionality just like desktop add-ons. You can find add-ons that work with Firefox for Mobile in our "
 "<a href=\"%(gallery_url)s\">gallery</a>."
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:288
+#: src/olympia/pages/templates/pages/faq.html:286
 msgid "Developer Topics"
 msgstr "開発者向けトピックス"
 
-#: src/olympia/pages/templates/pages/faq.html:289
+#: src/olympia/pages/templates/pages/faq.html:287
 #, python-format
 msgid "Please see our <a href=\"%(faq_url)s\">Developer FAQ</a> and <a href=\"%(hub_url)s\">Developer Hub</a> for answers to add-on developer-related questions."
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:294
+#: src/olympia/pages/templates/pages/faq.html:292
 msgid "Still have questions?"
 msgstr "まだ質問がありますか？"
 
-#: src/olympia/pages/templates/pages/faq.html:295
+#: src/olympia/pages/templates/pages/faq.html:293
 #, python-format
 msgid "For general Firefox support, visit our <a href=\"%(sumo_url)s\">support website</a>. For general add-on and website questions, visit our <a href=\"%(forum_url)s\">forum</a>."
 msgstr ""
@@ -10350,7 +10438,7 @@ msgstr "Sunbird は引退しました"
 
 #: src/olympia/pages/templates/pages/sunbird.html:29
 msgid ""
-"Development on the Sunbird project has halted and its final release was on March 30, 2010.  We've been proud to host Sunbird add-ons on this site but as the project is no longer maintained we have "
+"Development on the Sunbird project has halted and its final release was on March 30, 2010. We've been proud to host Sunbird add-ons on this site but as the project is no longer maintained we have "
 "disabled our support for the add-ons."
 msgstr ""
 
@@ -10429,10 +10517,10 @@ msgstr "{0} のレビューを追加"
 #, python-format
 msgid ""
 "<h2>Keep these tips in mind:</h2> <ul> <li> Write like you're telling a friend about your experience with the add-on. Give specifics and helpful details, such as what features you liked and/or "
-"disliked, how easy to use it is, and any disadvantages it has.  Avoid generic language such as calling it \"Great\" or \"Bad\" unless you can give reasons why you believe this is so. </li> <li> "
-"Please do not post bug reports in reviews. We do not make your email address available to add-on developers and they may need to contact you to help resolve your issue. See the <a "
-"href=\"%(support)s\">support section</a> to find out where to get assistance for this add-on. </li> <li>Please keep reviews clean, avoid the use of improper language and do not post any personal "
-"information. </li> </ul> <p>Please read the <a href=\"%(guide)s\" target=\"_blank\">Review Guidelines</a> for more detail about user add-on reviews.</p>"
+"disliked, how easy to use it is, and any disadvantages it has. Avoid generic language such as calling it \"Great\" or \"Bad\" unless you can give reasons why you believe this is so. </li> <li> "
+"Please do not post bug reports in reviews. We do not make your email address available to add-on developers and they may need to contact you to help resolve your issue. See the <a href=\"%(support)s"
+"\">support section</a> to find out where to get assistance for this add-on. </li> <li>Please keep reviews clean, avoid the use of improper language and do not post any personal information. </li> </"
+"ul> <p>Please read the <a href=\"%(guide)s\" target=\"_blank\">Review Guidelines</a> for more detail about user add-on reviews.</p>"
 msgstr ""
 
 #: src/olympia/reviews/templates/reviews/reply.html:4
@@ -10476,6 +10564,7 @@ msgstr "これは以前のバージョン ({0}) についてのレビューで�
 msgid "This user has a <a href=\"%(user_review_url)s\">previous review</a> of this add-on."
 msgid_plural "This user has <a href=\"%(user_review_url)s\">%(cnt)s previous reviews</a> of this add-on."
 msgstr[0] "このユーザはこのアドオンについて <a href=\"%(user_review_url)s\">過去に %(cnt)s 件のレビュー</a> を書いています。"
+msgstr[1] ""
 
 #: src/olympia/reviews/templates/reviews/review.html:62
 #, python-format
@@ -10522,6 +10611,7 @@ msgstr "{0} のレビュー"
 msgid "<b>{0}</b> review for this add-on"
 msgid_plural "<b>{0}</b> reviews for this add-on"
 msgstr[0] "このアドオンには <b>{0}</b> 件のレビューがあります"
+msgstr[1] ""
 
 #. {0} is a developer's name.
 #: src/olympia/reviews/templates/reviews/review_list.html:33
@@ -10533,6 +10623,7 @@ msgstr "開発者 {0} さんからの返信"
 msgid "Review for %(addon)s by %(user)s"
 msgid_plural "Reviews for %(addon)s by %(user)s"
 msgstr[0] "%(user)s さんによる %(addon)s のレビュー"
+msgstr[1] ""
 
 #: src/olympia/reviews/templates/reviews/review_list.html:42
 msgid "No reviews found."
@@ -10555,6 +10646,7 @@ msgstr "ぜひ、最初のレビューを書いてください。"
 msgid "{num} review"
 msgid_plural "{num} reviews"
 msgstr[0] "{num} 件のレビュー"
+msgstr[1] ""
 
 #: src/olympia/reviews/templates/reviews/impala/reviews_rating.html:1
 msgid "Rated {0} out of 5 stars"
@@ -10581,6 +10673,7 @@ msgstr "まだ評価されていません。"
 msgid "Average from {0} Rating"
 msgid_plural "Average from {0} Ratings"
 msgstr[0] ""
+msgstr[1] ""
 
 #: src/olympia/reviews/templates/reviews/mobile/review_list.html:34
 #, python-format
@@ -10596,6 +10689,7 @@ msgstr "全文を表示&nbsp;&raquo;"
 msgid "See All Reviews"
 msgid_plural "See All %(cnt)s Reviews"
 msgstr[0] "レビュー %(cnt)s 件をすべて見る"
+msgstr[1] ""
 
 #: src/olympia/search/forms.py:11
 msgid "Most popular this week"
@@ -10676,16 +10770,16 @@ msgstr "{0} アドオン"
 
 #. L10n: {0} is an application, such as Firefox. This means "any version of
 #. Firefox."
-#: src/olympia/search/views.py:554
+#: src/olympia/search/views.py:547
 msgid "Any {0}"
 msgstr "すべての {0}"
 
 #. L10n: "All Systems" means show everything regardless of platform.
-#: src/olympia/search/views.py:589
+#: src/olympia/search/views.py:582
 msgid "All Systems"
 msgstr "すべてのシステム"
 
-#: src/olympia/search/views.py:600
+#: src/olympia/search/views.py:593
 msgid "All Tags"
 msgstr "すべてのタグ"
 
@@ -10729,6 +10823,7 @@ msgstr "タグ「{0}」の検索結果"
 msgid "<b>{0}</b> matching result"
 msgid_plural "<b>{0}</b> matching results"
 msgstr[0] ""
+msgstr[1] ""
 
 #: src/olympia/search/templates/search/results.html:67
 msgid "Filter Results"
@@ -10750,6 +10845,7 @@ msgstr "検索結果 <i>({num})</i>"
 msgid "{0} post"
 msgid_plural "{0} posts"
 msgstr[0] "{0} 件の投稿"
+msgstr[1] ""
 
 #: src/olympia/sharing/__init__.py:20
 msgid "Post to Facebook"
@@ -10759,6 +10855,7 @@ msgstr "Facebook へ投稿"
 msgid "{0} Like"
 msgid_plural "{0} Likes"
 msgstr[0] "{0} 件のいいね"
+msgstr[1] ""
 
 #: src/olympia/sharing/__init__.py:30
 msgid "Tweet on Twitter"
@@ -10768,6 +10865,7 @@ msgstr "Twitter 上のツイート"
 msgid "{0} tweet"
 msgid_plural "{0} tweets"
 msgstr[0] "{0} 件のツイート"
+msgstr[1] ""
 
 #: src/olympia/sharing/__init__.py:40
 msgid "Share on g+"
@@ -10801,6 +10899,7 @@ msgstr "http://b.hatena.ne.jp/append?{url}"
 msgid "{0} post on localservice1"
 msgid_plural "{0} posts on localservice1"
 msgstr[0] "{0} 件のブックマーク"
+msgstr[1] ""
 
 #. L10n: Only change if you have reason! wiki.mozilla.org/AMO:Localizers
 #: src/olympia/sharing/__init__.py:76
@@ -10822,6 +10921,7 @@ msgstr ""
 msgid "{0} post on localservice2"
 msgid_plural "{0} posts on localservice2"
 msgstr[0] ""
+msgstr[1] ""
 
 #. L10n: Only change if you have reason! wiki.mozilla.org/AMO:Localizers
 #: src/olympia/sharing/__init__.py:91
@@ -10843,6 +10943,7 @@ msgstr ""
 msgid "{0} post on localservice3"
 msgid_plural "{0} posts on localservice3"
 msgstr[0] ""
+msgstr[1] ""
 
 #: src/olympia/sharing/templates/sharing/sharing_widget.html:2
 msgid "Share this Add-on"
@@ -10852,31 +10953,31 @@ msgstr "このアドオンを共有"
 msgid "Share this Collection"
 msgstr "このコレクションを共有"
 
-#: src/olympia/signing/views.py:30 src/olympia/templates/base.html:75 src/olympia/templates/impala/base.html:115
+#: src/olympia/signing/views.py:33 src/olympia/templates/base.html:71 src/olympia/templates/impala/base.html:112
 msgid "Some features are temporarily disabled while we perform website maintenance. We'll be back to full capacity shortly."
 msgstr "サイトメンテナンスの間、いくつかの機能が一時的に無効になっています。まもなく復旧する予定です。"
 
-#: src/olympia/signing/views.py:53
+#: src/olympia/signing/views.py:56
 msgid "Could not find add-on with id \"{}\"."
 msgstr "ID が「{}」のアドオンは見つかりませんでした。"
 
-#: src/olympia/signing/views.py:67
+#: src/olympia/signing/views.py:70
 msgid "You do not own this addon."
 msgstr "このアドオンの所有者ではありません。"
 
-#: src/olympia/signing/views.py:82
+#: src/olympia/signing/views.py:87
 msgid "Missing \"upload\" key in multipart file data."
 msgstr "マルチパートファイルデータに「upload」キーが含まれていません。"
 
-#: src/olympia/signing/views.py:96
+#: src/olympia/signing/views.py:101
 msgid "Version does not match the manifest file."
 msgstr "バージョンがマニフェストファイルと一致しません。"
 
-#: src/olympia/signing/views.py:100
+#: src/olympia/signing/views.py:105
 msgid "Version already exists."
 msgstr "バージョンは既に存在します。"
 
-#: src/olympia/signing/views.py:136
+#: src/olympia/signing/views.py:141
 msgid "No uploaded file for that addon and version."
 msgstr "このアドオンとバージョンのファイルはまだアップロードされていません。"
 
@@ -10989,89 +11090,89 @@ msgstr "{0} :: 統計ダッシュボード"
 msgid "Statistics Dashboard :: Add-ons for {0}"
 msgstr "統計ダッシュボード :: {0} 用アドオン"
 
-#: src/olympia/stats/templates/stats/stats.html:30
-msgid "Controls:"
-msgstr "コントロール:"
-
-#: src/olympia/stats/templates/stats/stats.html:33
-msgid "reset zoom"
-msgstr "ズームをリセット"
-
-#: src/olympia/stats/templates/stats/stats.html:40
-msgid "Group by:"
-msgstr "グループ化:"
-
-#: src/olympia/stats/templates/stats/stats.html:42
-msgid "day"
-msgstr "日"
-
-#: src/olympia/stats/templates/stats/stats.html:45
-msgid "week"
-msgstr "週"
-
-#: src/olympia/stats/templates/stats/stats.html:48
-msgid "month"
-msgstr "月"
-
-#: src/olympia/stats/templates/stats/stats.html:54
-msgid "For last:"
-msgstr "過去:"
-
-#: src/olympia/stats/templates/stats/stats.html:57
-msgid "7 days"
-msgstr "7 日"
-
-#: src/olympia/stats/templates/stats/stats.html:60
-msgid "30 days"
-msgstr "30 日"
-
-#: src/olympia/stats/templates/stats/stats.html:63
-msgid "90 days"
-msgstr "90 日"
-
-#: src/olympia/stats/templates/stats/stats.html:66
-msgid "365 days"
-msgstr "365 日"
-
-#: src/olympia/stats/templates/stats/stats.html:69
-msgid "Custom..."
-msgstr "任意..."
-
 #. {0} is an add-on name
-#: src/olympia/stats/templates/stats/stats.html:88 src/olympia/stats/templates/stats/stats.html:91
+#: src/olympia/stats/templates/stats/stats.html:44 src/olympia/stats/templates/stats/stats.html:47
 msgid "Statistics for {0}"
 msgstr "{0} の統計情報"
 
-#: src/olympia/stats/templates/stats/stats.html:94
+#: src/olympia/stats/templates/stats/stats.html:50
 msgid "Statistics Dashboard"
 msgstr "統計情報ダッシュボード"
 
-#: src/olympia/stats/templates/stats/stats.html:104
+#: src/olympia/stats/templates/stats/stats.html:57
+msgid "Controls:"
+msgstr "コントロール:"
+
+#: src/olympia/stats/templates/stats/stats.html:60
+msgid "reset zoom"
+msgstr "ズームをリセット"
+
+#: src/olympia/stats/templates/stats/stats.html:67
+msgid "Group by:"
+msgstr "グループ化:"
+
+#: src/olympia/stats/templates/stats/stats.html:69
+msgid "day"
+msgstr "日"
+
+#: src/olympia/stats/templates/stats/stats.html:72
+msgid "week"
+msgstr "週"
+
+#: src/olympia/stats/templates/stats/stats.html:75
+msgid "month"
+msgstr "月"
+
+#: src/olympia/stats/templates/stats/stats.html:81
+msgid "For last:"
+msgstr "過去:"
+
+#: src/olympia/stats/templates/stats/stats.html:84
+msgid "7 days"
+msgstr "7 日"
+
+#: src/olympia/stats/templates/stats/stats.html:87
+msgid "30 days"
+msgstr "30 日"
+
+#: src/olympia/stats/templates/stats/stats.html:90
+msgid "90 days"
+msgstr "90 日"
+
+#: src/olympia/stats/templates/stats/stats.html:93
+msgid "365 days"
+msgstr "365 日"
+
+#: src/olympia/stats/templates/stats/stats.html:96
+msgid "Custom..."
+msgstr "任意..."
+
+#: src/olympia/stats/templates/stats/stats.html:106
 msgid "Statistics processing is currently disabled, so recent data is unavailable. The statistics are still being collected and this page will be updated soon with the missing data."
 msgstr ""
 
-#: src/olympia/stats/templates/stats/stats.html:110
+#: src/olympia/stats/templates/stats/stats.html:112
 msgid "Loading the latest data&hellip;"
 msgstr "最新データを読み込み中&hellip;"
 
-#: src/olympia/stats/templates/stats/stats.html:142 src/olympia/stats/templates/stats/reports/overview.html:25 src/olympia/stats/templates/stats/reports/overview.html:37
+#: src/olympia/stats/templates/stats/stats.html:144 src/olympia/stats/templates/stats/reports/overview.html:25 src/olympia/stats/templates/stats/reports/overview.html:37
 #: src/olympia/stats/templates/stats/reports/overview.html:49
 msgid "No data available."
 msgstr "データがありません。"
 
-#: src/olympia/stats/templates/stats/stats.html:177
+#: src/olympia/stats/templates/stats/stats.html:179
 msgid "This dashboard is currently <b>public</b>."
 msgstr "このダッシュボードは現在 <b>公開中</b> です。"
 
-#: src/olympia/stats/templates/stats/stats.html:179
+#: src/olympia/stats/templates/stats/stats.html:181
 msgid "Contribution stats are currently <b>private</b>."
 msgstr "貢献状態は現在 <b>非公開</b> です。"
 
-#: src/olympia/stats/templates/stats/stats.html:182
+#: src/olympia/stats/templates/stats/stats.html:184
 msgid "This dashboard is currently <b>private</b>."
 msgstr "このダッシュボードは現在 <b>非公開</b> です。"
 
-#: src/olympia/stats/templates/stats/stats.html:185
+#: src/olympia/stats/templates/stats/stats.html:187
 msgid "Change settings."
 msgstr "設定を変更"
 
@@ -11181,10 +11282,10 @@ msgstr "外部参照元のトラッキングについて..."
 #, python-format
 msgid ""
 "<h2>Tracking external sources</h2> <p> If you link to your add-on's details page or directly to its file from an external site, such as your blog or website, you can append a parameter to be "
-"tracked as an additional download source on this page. For example, the following links would appear as sourced by your blog: <dl> <dt>Add-on Details Page</dt> "
-"<dd>https://addons.mozilla.org/addon/%(slug)s?src=<b>external-blog</b></dd> <dt>Direct File Link</dt> <dd>https://addons.mozilla.org/downloads/latest/%(id)s/addon-%(id)s-latest.xpi?src=<b>external-"
-"blog</b></dd> </dl> <p> Only src parameters that begin with \"external-\" will be tracked, up to 61 additional characters. Any text after \"external-\" can be used to describe the source, such as "
-"\"external-blog\", \"external-sidebar\", \"external-campaign225\", etc. The following URL-safe characters are allowed: <code>a-z A-Z - . _ ~ %% +</code>"
+"tracked as an additional download source on this page. For example, the following links would appear as sourced by your blog: <dl> <dt>Add-on Details Page</dt> <dd>https://addons.mozilla.org/addon/"
+"%(slug)s?src=<b>external-blog</b></dd> <dt>Direct File Link</dt> <dd>https://addons.mozilla.org/downloads/latest/%(id)s/addon-%(id)s-latest.xpi?src=<b>external-blog</b></dd> </dl> <p> Only src "
+"parameters that begin with \"external-\" will be tracked, up to 61 additional characters. Any text after \"external-\" can be used to describe the source, such as \"external-blog\", \"external-"
+"sidebar\", \"external-campaign225\", etc. The following URL-safe characters are allowed: <code>a-z A-Z - . _ ~ %% +</code>"
 msgstr ""
 
 #: src/olympia/stats/templates/stats/reports/statuses.html:3
@@ -11211,8 +11312,8 @@ msgstr ""
 
 #: src/olympia/stats/templates/stats/reports/usage.html:20
 msgid ""
-"<h2>What are daily users?</h2> <p> Add-ons downloaded from this site check for updates once per day. The total number of these update pings is known as Active Daily Users. Daily users can be broken"
-" down by add-on version, operating system, add-on status, application, and locale. </p>"
+"<h2>What are daily users?</h2> <p> Add-ons downloaded from this site check for updates once per day. The total number of these update pings is known as Active Daily Users. Daily users can be broken "
+"down by add-on version, operating system, add-on status, application, and locale. </p>"
 msgstr ""
 
 #: src/olympia/stats/templates/stats/reports/users_created.html:3
@@ -11223,15 +11324,6 @@ msgstr "日別ユーザ登録者数"
 msgid "Application versions by Date"
 msgstr "日別アプリケーションバージョン"
 
-#: src/olympia/tags/templates/tags/top_cloud.html:4
-msgid "Top {0} Tags"
-msgstr "人気 {0} タグ"
-
-#. {0} is the current application name
-#: src/olympia/tags/templates/tags/top_cloud.html:14
-msgid "{0} Top Tags"
-msgstr "{0} の人気タグ"
-
 #: src/olympia/templates/amo_footer.html:6 src/olympia/templates/includes/lang_switcher.html:2
 msgid "Other languages"
 msgstr "他の言語"
@@ -11240,11 +11332,11 @@ msgstr "他の言語"
 msgid "Mozilla Add-ons"
 msgstr "Mozilla Add-ons"
 
-#: src/olympia/templates/base.html:91 src/olympia/templates/impala/base.html:81
+#: src/olympia/templates/base.html:89 src/olympia/templates/impala/base.html:78
 msgid "Find add-ons for other applications"
 msgstr "他のアプリケーション用のアドオンを探す"
 
-#: src/olympia/templates/base.html:92 src/olympia/templates/impala/base.html:81
+#: src/olympia/templates/base.html:90 src/olympia/templates/impala/base.html:78
 msgid "Other Applications"
 msgstr "他のアプリケーション"
 
@@ -11269,7 +11361,7 @@ msgid "View Mobile Site"
 msgstr "モバイル用サイトを表示"
 
 #: src/olympia/templates/copyright.html:7
-msgid "Site Status "
+msgid "Site Status"
 msgstr "サイトステータス"
 
 # フッタ左端
@@ -11372,35 +11464,35 @@ msgstr "ようこそ {0} さん"
 msgid "<a href=\"%(reg)s\">Register</a> or <a href=\"%(login)s\">Log in</a>"
 msgstr "<a href=\"%(reg)s\">ユーザ登録</a> / <a href=\"%(login)s\">ログイン</a>"
 
-#: src/olympia/templates/impala/base.html:126
+#: src/olympia/templates/impala/base.html:123
 #, python-format
 msgid "To try the thousands of add-ons available here, download <a href=\"%(url)s\">Mozilla Firefox</a>, a fast, free way to surf the Web!"
 msgstr "ここで公開されている数千ものアドオンを試すには、無料の高速 Web ブラウザ <a href=\"%(url)s\">Mozilla Firefox</a> をダウンロードしましょう！"
 
-#: src/olympia/templates/impala/base.html:138
+#: src/olympia/templates/impala/base.html:135
 #, python-format
 msgid "Add-ons is switching to Firefox Accounts for login. <a href=\"%(url)s\" class=\"fxa-login\">Sign in now to transfer your account.</a>"
 msgstr "Add-ons サイトは Firefox アカウントを使ったログイン方式への切り替えを行っています。<a href=\"%(url)s\" class=\"fxa-login\">今すぐログインしてアカウントを移行しましょう</a>。"
 
 #. {0} is an application, such as Firefox.
-#: src/olympia/templates/impala/base.html:148
+#: src/olympia/templates/impala/base.html:145
 msgid "Welcome to {0} Add-ons."
 msgstr "{0} Add-ons へようこそ。"
 
-#: src/olympia/templates/impala/base.html:151
+#: src/olympia/templates/impala/base.html:148
 msgid "Choose from thousands of extra features and styles to make Firefox your own."
 msgstr "数千もの追加機能やデザインから好きなものを選んで、Firefox を自分のものにしましょう。"
 
-#: src/olympia/templates/impala/base.html:156
+#: src/olympia/templates/impala/base.html:153
 #, python-format
 msgid "Add extra features and styles to make %(app)s your own."
 msgstr "機能を追加したりデザインを変えたりして、%(app)s を自分のものにしましょう。"
 
-#: src/olympia/templates/impala/base.html:164
+#: src/olympia/templates/impala/base.html:161
 msgid "On the go?"
 msgstr "外出先ですか？"
 
-#: src/olympia/templates/impala/base.html:166
+#: src/olympia/templates/impala/base.html:163
 msgid "Check out our <a class=\"mobile-link\" href=\"#\">Mobile Add-ons site</a>."
 msgstr "<a class=\"mobile-link\" href=\"#\">Mobile Add-ons サイト</a> を見る"
 
@@ -11624,19 +11716,19 @@ msgstr "このメールアドレスを持つユーザは存在しません。"
 
 #. L10n: {id} will be something like "13ad6a", just a random number
 #. to differentiate this user from other anonymous users.
-#: src/olympia/users/models.py:353
+#: src/olympia/users/models.py:362
 msgid "Anonymous user {id}"
 msgstr "匿名ユーザ {id}"
 
-#: src/olympia/users/models.py:410
+#: src/olympia/users/models.py:419
 msgid "Your account has been restricted"
 msgstr "あなたのアカウントは制限されています"
 
-#: src/olympia/users/models.py:480
+#: src/olympia/users/models.py:489
 msgid "Please confirm your email address"
 msgstr "メールアドレスを確認してください"
 
-#: src/olympia/users/models.py:506
+#: src/olympia/users/models.py:515
 msgid "My Mobile Add-ons"
 msgstr "自分のモバイル向けアドオン"
 
@@ -11756,7 +11848,9 @@ msgstr "確認メールが送信されました"
 msgid ""
 "An email has been sent to {0} to confirm your new email address. For the change to take effect, you need to click on the link provided in this email. Until then, you can keep logging in with your "
 "current email address."
-msgstr "新しいメールアドレスを確認するメールが {0} に送信されました。新しいメールアドレスを有効にするには、送信されたメールに書かれたリンクをクリックする必要があります。それまでは、現在のメールアドレスでログインできます。"
+msgstr ""
+"新しいメールアドレスを確認するメールが {0} に送信されました。新しいメールアドレスを有効にするには、送信されたメールに書かれたリンクをクリックする必要があります。それまでは、現在のメールアドレスでロ"
+"グインできます。"
 
 #: src/olympia/users/views.py:210
 #, python-format
@@ -11796,7 +11890,9 @@ msgstr "あなたのユーザアカウントを有効にするリンクが書か
 msgid ""
 "If you did not receive the confirmation email, make sure your email service did not mark it as \"junk mail\" or \"spam\". If you need to, you can have us <a href=\"%s\">resend the confirmation "
 "message</a> to your email address mentioned above."
-msgstr "確認のメールが届いていない場合は、あなたのメールサービスがこれを「迷惑メール」や「スパムメール」に分類していないか確認してください。必要であれば、上記のメールアドレスに <a href=\"%s\">確認メールを再送信</a> できます。"
+msgstr ""
+"確認のメールが届いていない場合は、あなたのメールサービスがこれを「迷惑メール」や「スパムメール」に分類していないか確認してください。必要であれば、上記のメールアドレスに <a href=\"%s\">確認メールを再"
+"送信</a> できます。"
 
 #: src/olympia/users/views.py:444
 msgid "Activation Email Sent"
@@ -11844,7 +11940,9 @@ msgstr "ユーザアカウントを削除"
 msgid ""
 "You cannot delete your account if you are listed as an <a href=\"%(link)s\"> author of any add-ons</a>. To delete your account, please have another person in your development group delete you from "
 "the list of authors for your add-ons. Afterwards you will be able to delete your account here."
-msgstr "あなたが <a href=\"%(link)s\">アドオンの作者</a> として登録されている場合、アカウントを削除することはできません。アカウントを削除するには、開発グループに参加している他の人に頼んで、あなたをアドオンの作者から外してもらってください。そうすれば、ここでアカウントの削除が可能になります。"
+msgstr ""
+"あなたが <a href=\"%(link)s\">アドオンの作者</a> として登録されている場合、アカウントを削除することはできません。アカウントを削除するには、開発グループに参加している他の人に頼んで、あなたをアドオン"
+"の作者から外してもらってください。そうすれば、ここでアカウントの削除が可能になります。"
 
 #: src/olympia/users/templates/users/delete.html:29
 msgid "By clicking \"delete\" your account is going to be <strong>permanently removed</strong>. That means:"
@@ -12166,7 +12264,8 @@ msgid "Send password reset link"
 msgstr "パスワード変更のためのリンクをメールで送信"
 
 #: src/olympia/users/templates/users/pwreset_sent.html:10
-msgid "An email has been sent to the requested account with further information. If you do not receive an email then please confirm you have entered the same email address used during account registration."
+msgid ""
+"An email has been sent to the requested account with further information. If you do not receive an email then please confirm you have entered the same email address used during account registration."
 msgstr "詳しい情報が記載されたメールがリクエストされたアカウント宛に送信されました。もしメールが届かない場合は、アカウント登録時に使用したのと同じメールアドレスを入力したか再度確認してください。"
 
 #: src/olympia/users/templates/users/register.html:4
@@ -12371,12 +12470,14 @@ msgstr "{0} 個のアドオン"
 msgid "%(num)s theme"
 msgid_plural "%(num)s themes"
 msgstr[0] "%(num)s 個のテーマ"
+msgstr[1] ""
 
 #: src/olympia/users/templates/users/vcard.html:62
 #, python-format
 msgid "%(num)s add-on"
 msgid_plural "%(num)s add-ons"
 msgstr[0] "%(num)s 個のアドオン"
+msgstr[1] ""
 
 #: src/olympia/users/templates/users/vcard.html:75
 msgid "Average rating of developer's add-ons"
@@ -12392,15 +12493,15 @@ msgstr "%s のバージョン履歴"
 msgid "Version History with Changelogs"
 msgstr "バージョン履歴・変更点"
 
-#: src/olympia/versions/models.py:314
+#: src/olympia/versions/models.py:313
 msgid "Add-on uses binary components."
 msgstr "このアドオンはバイナリコンポーネントを含んでいます。"
 
-#: src/olympia/versions/models.py:317
+#: src/olympia/versions/models.py:316
 msgid "Add-on has opted into strict compatibility checking."
 msgstr "このアドオンは厳密な互換性チェックを行うよう設定されています。"
 
-#: src/olympia/versions/models.py:715
+#: src/olympia/versions/models.py:711
 msgid "{app} {min} and later"
 msgstr "{app} {min} 以降"
 
@@ -12438,6 +12539,7 @@ msgstr "{0} のバージョン履歴"
 msgid "<b>{0}</b> version"
 msgid_plural "<b>{0}</b> versions"
 msgstr[0] "<b>{0}</b> 個のバージョンがあります"
+msgstr[1] ""
 
 #: src/olympia/versions/templates/versions/version_list.html:35 src/olympia/versions/templates/versions/mobile/version_list.html:14
 msgid "Be careful with old versions!"
@@ -12478,3 +12580,6 @@ msgstr "完了時にメールを送信する"
 msgid "Log emails instead of sending"
 msgstr "メールを送信する代わりにログで残す"
 
+#: src/olympia/zadmin/forms.py:215
+msgid "Deleted versions can`t be changed."
+msgstr ""

--- a/locale/ja/LC_MESSAGES/djangojs.po
+++ b/locale/ja/LC_MESSAGES/djangojs.po
@@ -3,1199 +3,1236 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2016-02-24 21:23+0000\n"
+"POT-Creation-Date: 2016-04-18 15:47+0000\n"
 "PO-Revision-Date: 2015-11-12 12:14+0000\n"
 "Last-Translator: Kohei Yoshino <kohei.yoshino@gmail.com>\n"
 "Language-Team: Japanese\n"
+"Language: \n"
 "MIME-Version: 1.0\n"
-"Content-Type: text/plain; charset=utf-8\n"
+"Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Generated-By: Babel 2.2.0\n"
 
-#: static/js/common/ratingwidget.js:31
+#: static/js/common-all.js:1426 static/js/impala-all.js:1511 static/js/zamboni/discovery-all.js:12598 static/js/zamboni/init.js:28 static/js/zamboni/mobile-all.js:14945
+msgid "This feature is temporarily disabled while we perform website maintenance. Please check back a little later."
+msgstr "この機能はサイトメンテナンスのため一時的に無効になっています。また後で試してください。"
+
+#. L10n: {0} is an app name like Firefox.
+#: static/js/common-all.js:1837 static/js/impala-all.js:1922 static/js/zamboni/buttons.js:73 static/js/zamboni/discovery-all.js:13108
+msgid "Accept and Install"
+msgstr "同意してインストール"
+
+#: static/js/common-all.js:1837 static/js/impala-all.js:1922 static/js/zamboni/buttons.js:73 static/js/zamboni/discovery-all.js:13108
+msgid "Add to {0}"
+msgstr "{0} へ追加"
+
+#: static/js/common-all.js:1842 static/js/impala-all.js:1927 static/js/zamboni/buttons.js:78 static/js/zamboni/discovery-all.js:13113
+msgid "Download Now"
+msgstr "今すぐダウンロード"
+
+#: static/js/common-all.js:1883 static/js/impala-all.js:1968 static/js/zamboni/buttons.js:119 static/js/zamboni/discovery-all.js:13154
+msgid "Add-on has not been updated to support default-to-compatible."
+msgstr "アドオンが自動的に互換性を保つバージョンへ更新されていません。"
+
+#: static/js/common-all.js:1888 static/js/impala-all.js:1973 static/js/zamboni/buttons.js:124 static/js/zamboni/discovery-all.js:13159
+msgid "You need to be using Firefox 10.0 or higher."
+msgstr "Firefox 10 以上のバージョンを使ってください。"
+
+#: static/js/common-all.js:1900 static/js/impala-all.js:1985 static/js/zamboni/buttons.js:136 static/js/zamboni/discovery-all.js:13171
+msgid "Mozilla has marked this version as incompatible with your Firefox version."
+msgstr "このバージョンは、お使いの Firefox のバージョンと互換性がありません。"
+
+#. L10n: {0} is an platform like Windows or Linux.
+#: static/js/common-all.js:1981 static/js/impala-all.js:2066 static/js/zamboni/buttons.js:217 static/js/zamboni/discovery-all.js:13252
+msgid "Install for {0} anyway"
+msgstr "{0} へ強制インストール"
+
+#: static/js/common-all.js:1981 static/js/impala-all.js:2066 static/js/zamboni/buttons.js:217 static/js/zamboni/discovery-all.js:13252
+msgid "Download for {0} anyway"
+msgstr "{0} へ強制ダウンロード"
+
+#: static/js/common-all.js:2038 static/js/impala-all.js:2123 static/js/zamboni/buttons.js:274 static/js/zamboni/discovery-all.js:13309
+msgid "Not available for your platform"
+msgstr "お使いの OS には対応していません"
+
+#. L10n: {0} is an app name, {1} is the app version.
+#: static/js/common-all.js:2049 static/js/common-all.js:2086 static/js/impala-all.js:2134 static/js/impala-all.js:2171 static/js/zamboni/buttons.js:286 static/js/zamboni/buttons.js:324
+#: static/js/zamboni/discovery-all.js:13320 static/js/zamboni/discovery-all.js:13357
+msgid "Not available for {0} {1}"
+msgstr "{0} {1} には対応していません"
+
+#: static/js/common-all.js:2112 static/js/impala-all.js:2197 static/js/zamboni/buttons.js:351 static/js/zamboni/discovery-all.js:13383
+msgid "Works with {app} {min} - {max}"
+msgstr "動作環境: {app} {min} - {max}"
+
+#: static/js/common-all.js:2114 static/js/impala-all.js:2199 static/js/zamboni/buttons.js:353 static/js/zamboni/discovery-all.js:13385
+msgid "View other versions"
+msgstr "他のバージョンを見る"
+
+#: static/js/common-all.js:2162 static/js/impala-all.js:2247 static/js/zamboni/buttons.js:401 static/js/zamboni/discovery-all.js:13433
+msgid "Only with Firefox — Get Firefox Now!"
+msgstr "Firefox 限定 — 今すぐ Firefox をダウンロード！"
+
+#: static/js/common-all.js:2278 static/js/impala-all.js:2363 static/js/zamboni/buttons.js:517 static/js/zamboni/discovery-all.js:13549 static/js/zamboni/mobile-all.js:15177
+#: static/js/zamboni/mobile/buttons.js:43
+msgid "Sorry, you need a Mozilla-based browser (such as Firefox) to install a search plugin."
+msgstr "申し訳ありませんが、検索プラグインをインストールするには (Firefox など) Mozilla ベースのブラウザが必要です。"
+
+#: static/js/common-all.js:9088 static/js/impala-all.js:9649 static/js/zamboni/global.js:410
+msgid "Loading..."
+msgstr "読み込み中..."
+
+#. L10n: {0} is the number of characters left.
+#: static/js/common-all.js:9152 static/js/impala-all.js:9713 static/js/zamboni/global.js:474
+msgid "<b>{0}</b> character left."
+msgid_plural "<b>{0}</b> characters left."
+msgstr[0] "残り <b>{0}</b> 文字です。"
+msgstr[1] ""
+
+#: static/js/common-all.js:9589 static/js/common-min.js:6 static/js/impala-all.js:10052 static/js/impala-min.js:6 static/js/common/ratingwidget.js:31 static/js/zamboni/mobile-all.js:16123
+#: static/js/zamboni/mobile-min.js:6
 msgid "{0} star"
 msgid_plural "{0} stars"
 msgstr[0] "評価 {0}"
+msgstr[1] ""
 
-#: static/js/common/upload-addon.js:41 static/js/common/upload-image.js:128
+#: static/js/common-all.js:9676 static/js/common-min.js:6 static/js/impala-all.js:10139 static/js/impala-min.js:6 static/js/zamboni/l10n.js:45
+msgid "Remove this localization"
+msgstr "このローカライズを削除"
+
+#: static/js/common-all.js:10193 static/js/common-min.js:6 static/js/impala-all.js:10674 static/js/impala-min.js:6 static/js/zamboni/discovery-all.js:13678
+msgid "close"
+msgstr ""
+
+#: static/js/common-all.js:10860 static/js/common-min.js:6 static/js/impala-all.js:11481 static/js/impala-min.js:6 static/js/impala/reviews.js:23 static/js/zamboni/reviews.js:18
+msgid "Flagged for review"
+msgstr "レビューフラグ付き"
+
+#: static/js/common-all.js:10876 static/js/common-min.js:6 static/js/impala-all.js:11498 static/js/impala-min.js:6 static/js/impala/reviews.js:40 static/js/zamboni/reviews.js:34
+msgid "Your input is required"
+msgstr "入力が必要です"
+
+#: static/js/common-all.js:10945 static/js/common-min.js:6 static/js/impala-all.js:11610 static/js/impala-min.js:7 static/js/impala/reviews.js:152 static/js/zamboni/reviews.js:103
+msgid "Marked for deletion"
+msgstr "削除マーク付き"
+
+#: static/js/common-all.js:11573 static/js/common-min.js:7 static/js/impala-all.js:13809 static/js/impala-min.js:8 static/js/zamboni/collections.js:229
+msgid "Adding to Favorites&hellip;"
+msgstr "お気に入りへ追加..."
+
+#: static/js/common-all.js:11576 static/js/common-min.js:7 static/js/impala-all.js:13812 static/js/impala-min.js:8 static/js/zamboni/collections.js:232
+msgid "Removing Favorite&hellip;"
+msgstr "お気に入りから削除..."
+
+#: static/js/common-all.js:11579 static/js/common-min.js:7 static/js/impala-all.js:13815 static/js/impala-min.js:8 static/js/zamboni/collections.js:235
+msgid "Add to Favorites"
+msgstr "お気に入りへ追加"
+
+#: static/js/common-all.js:11582 static/js/common-min.js:7 static/js/impala-all.js:13818 static/js/impala-min.js:8 static/js/zamboni/collections.js:238
+msgid "Remove from Favorites"
+msgstr "お気に入りから削除"
+
+#: static/js/common-all.js:11647 static/js/common-min.js:7 static/js/impala-all.js:13883 static/js/impala-min.js:8 static/js/zamboni/collections.js:303
+msgid "Pending"
+msgstr "保留中"
+
+#: static/js/common-all.js:11648 static/js/common-min.js:7 static/js/impala-all.js:13884 static/js/impala-min.js:8 static/js/zamboni/collections.js:304
+msgid "Add a comment"
+msgstr "コメントを追加"
+
+#: static/js/common-all.js:11648 static/js/common-min.js:7 static/js/impala-all.js:13884 static/js/impala-min.js:8 static/js/zamboni/collections.js:304
+msgid "Comment"
+msgstr "コメント"
+
+#: static/js/common-all.js:11649 static/js/common-min.js:7 static/js/impala-all.js:13885 static/js/impala-min.js:8 static/js/zamboni/collections.js:305
+msgid "Remove this add-on from the collection"
+msgstr "このアドオンをコレクションから削除"
+
+#: static/js/common-all.js:11649 static/js/common-all.js:11678 static/js/common-min.js:7 static/js/impala-all.js:13885 static/js/impala-all.js:13914 static/js/impala-min.js:8
+#: static/js/zamboni/collections.js:305 static/js/zamboni/collections.js:334
+msgid "Remove"
+msgstr "削除"
+
+#: static/js/common-all.js:11678 static/js/common-min.js:7 static/js/impala-all.js:13914 static/js/impala-min.js:8 static/js/zamboni/collections.js:334
+msgid "Remove this user as a contributor"
+msgstr "このユーザを貢献者から削除"
+
+#: static/js/common-all.js:11690 static/js/common-min.js:7 static/js/impala-all.js:13926 static/js/impala-min.js:8 static/js/zamboni/collections.js:346
+msgid "An email address is required."
+msgstr "メールアドレスを入力してください。"
+
+#: static/js/common-all.js:11708 static/js/common-min.js:7 static/js/impala-all.js:13944 static/js/impala-min.js:8 static/js/zamboni/collections.js:364
+msgid "You cannot add yourself as a contributor."
+msgstr "自分を貢献者として追加することはできません。"
+
+#: static/js/common-all.js:11710 static/js/common-min.js:7 static/js/impala-all.js:13946 static/js/impala-min.js:8 static/js/zamboni/collections.js:366
+msgid "You have already added that user."
+msgstr "このユーザはすでに追加されています。"
+
+#: static/js/common-all.js:11917 static/js/common-min.js:7 static/js/impala-all.js:14153 static/js/impala-min.js:8 static/js/zamboni/collections.js:573
+msgid "Add to favorites"
+msgstr "お気に入りへ追加"
+
+#: static/js/common-all.js:11921 static/js/common-min.js:7 static/js/impala-all.js:14157 static/js/impala-min.js:8 static/js/zamboni/collections.js:577
+msgid "Remove from favorites"
+msgstr "お気に入りから削除"
+
+#: static/js/common-all.js:11939 static/js/common-min.js:7 static/js/impala-all.js:14175 static/js/impala-all.js:14233 static/js/impala-min.js:8 static/js/impala/collections.js:10
+#: static/js/zamboni/collections.js:595
+msgid "Follow this Collection"
+msgstr "このコレクションをフォロー"
+
+#: static/js/common-all.js:11948 static/js/common-min.js:7 static/js/impala-all.js:14184 static/js/impala-min.js:8 static/js/zamboni/collections.js:604
+msgid "Stop following"
+msgstr "フォローをやめる"
+
+#: static/js/common-all.js:12096 static/js/common-min.js:7 static/js/zamboni/password-strength.js:20
+msgid "Password strength:"
+msgstr "パスワードの強度:"
+
+#: static/js/common-all.js:12102 static/js/common-min.js:7 static/js/zamboni/password-strength.js:26
+msgid "At least {0} character left."
+msgid_plural "At least {0} characters left."
+msgstr[0] "あと {0} 文字以上入力してください。"
+msgstr[1] ""
+
+#: static/js/common-all.js:12286 static/js/common-min.js:7 static/js/impala-all.js:14632 static/js/impala-min.js:8 static/js/impala/suggestions.js:39
+msgid "Search themes for <b>{0}</b>"
+msgstr "<b>{0}</b> 用のテーマを検索"
+
+#: static/js/common-all.js:12288 static/js/common-min.js:7 static/js/impala-all.js:14634 static/js/impala-min.js:8 static/js/impala/suggestions.js:41
+msgid "Search apps for <b>{0}</b>"
+msgstr "<b>{0}</b> 用のアプリを検索"
+
+#: static/js/common-all.js:12290 static/js/common-min.js:7 static/js/impala-all.js:14636 static/js/impala-min.js:8 static/js/impala/suggestions.js:43
+msgid "Search add-ons for <b>{0}</b>"
+msgstr "<b>{0}</b> 用のアドオンを検索"
+
+#: static/js/common-all.js:12521 static/js/common-min.js:7 static/js/impala-all.js:14867 static/js/impala-min.js:8 static/js/impala/site_suggestions.js:46
+msgid "Category"
+msgstr "カテゴリ"
+
+#. L10n: {0} is an app name.
+#: static/js/impala-all.js:11632 static/js/impala-min.js:7 static/js/impala/listing.js:11 static/js/zamboni/themes.js:13
+msgid "This theme is incompatible with your version of {0}"
+msgstr "このテーマはお使いの {0} のバージョンと互換性がありません"
+
+#: static/js/impala-all.js:12146 static/js/impala-all.js:14331 static/js/impala-min.js:7 static/js/impala-min.js:8 static/js/common/upload-image.js:97 static/js/impala/users.js:51
+#: static/js/zamboni/devhub-all.js:894 static/js/zamboni/devhub-min.js:1
+msgid "Images must be either PNG or JPG."
+msgstr "画像は PNG か JPEG 形式でなければなりません。"
+
+#: static/js/impala-all.js:12150 static/js/impala-min.js:7 static/js/common/upload-image.js:101 static/js/zamboni/devhub-all.js:898 static/js/zamboni/devhub-min.js:1
+msgid "Videos must be in WebM."
+msgstr "動画は WebM 形式でなければなりません。"
+
+#: static/js/impala-all.js:12177 static/js/impala-min.js:7 static/js/common/upload-addon.js:41 static/js/common/upload-image.js:128 static/js/zamboni/devhub-all.js:272
+#: static/js/zamboni/devhub-all.js:925 static/js/zamboni/devhub-min.js:1
 msgid "There was a problem contacting the server."
 msgstr "サーバへの接続中に問題が発生しました。"
 
-#: static/js/common/upload-addon.js:69
+#: static/js/impala-all.js:13298 static/js/impala-min.js:7 static/js/impala/persona_creation.js:60
+msgid "All Rights Reserved"
+msgstr "All Rights Reserved"
+
+#: static/js/impala-all.js:13302 static/js/impala-min.js:7 static/js/impala/persona_creation.js:64
+msgid "Creative Commons Attribution 3.0"
+msgstr "Creative Commons 表示 3.0"
+
+#: static/js/impala-all.js:13307 static/js/impala-min.js:7 static/js/impala/persona_creation.js:69
+msgid "Creative Commons Attribution-NonCommercial 3.0"
+msgstr "Creative Commons 表示-非営利 3.0"
+
+#: static/js/impala-all.js:13312 static/js/impala-min.js:7 static/js/impala/persona_creation.js:74
+msgid "Creative Commons Attribution-NonCommercial-NoDerivs 3.0"
+msgstr "Creative Commons 表示-非営利-改変禁止 3.0"
+
+#: static/js/impala-all.js:13317 static/js/impala-min.js:7 static/js/impala/persona_creation.js:79
+msgid "Creative Commons Attribution-NonCommercial-Share Alike 3.0"
+msgstr "Creative Commons 表示-非営利-継承 3.0"
+
+#: static/js/impala-all.js:13322 static/js/impala-min.js:7 static/js/impala/persona_creation.js:84
+msgid "Creative Commons Attribution-NoDerivs 3.0"
+msgstr "Creative Commons 表示-改変禁止 3.0"
+
+#: static/js/impala-all.js:13327 static/js/impala-min.js:7 static/js/impala/persona_creation.js:89
+msgid "Creative Commons Attribution-ShareAlike 3.0"
+msgstr "Creative Commons 表示-継承 3.0"
+
+#: static/js/impala-all.js:13530 static/js/impala-min.js:7 static/js/impala/persona_creation.js:292
+msgid "Your Theme's Name"
+msgstr "テーマの名前"
+
+#: static/js/impala-all.js:14242 static/js/impala-min.js:8 static/js/impala/collections.js:19
+msgid "Stop Following"
+msgstr "フォローをやめる"
+
+#: static/js/impala-all.js:14243 static/js/impala-min.js:8 static/js/impala/collections.js:20
+msgid "Following"
+msgstr "フォロー中"
+
+#: static/js/impala-all.js:14313 static/js/impala-min.js:8 static/js/impala/users.js:33
+msgid "use original"
+msgstr "オリジナルを使用"
+
+#: static/js/impala-all.js:14523 static/js/impala-min.js:8 static/js/impala/search.js:114
+msgid "Updating results&hellip;"
+msgstr "結果を更新しています..."
+
+#: static/js/common/upload-addon.js:69 static/js/zamboni/devhub-all.js:300 static/js/zamboni/devhub-min.js:1
 msgid "Select a file..."
 msgstr "ファイルを選択..."
 
-#: static/js/common/upload-addon.js:70
+#: static/js/common/upload-addon.js:70 static/js/zamboni/devhub-all.js:301 static/js/zamboni/devhub-min.js:1
 msgid "Your add-on should end with .xpi, .jar or .xml"
 msgstr "アドオンのファイル拡張子は xpi、jar、xml のいずれかでなければなりません"
 
 #. L10n: {0} is the percent of the file that has been uploaded.
-#: static/js/common/upload-addon.js:104
+#: static/js/common/upload-addon.js:104 static/js/zamboni/devhub-all.js:335 static/js/zamboni/devhub-min.js:1
 #, python-format
 msgid "{0}% complete"
 msgstr "{0}% 完了"
 
 #. L10n: "{bytes uploaded} of {total filesize}".
-#: static/js/common/upload-addon.js:107
+#: static/js/common/upload-addon.js:107 static/js/zamboni/devhub-all.js:338 static/js/zamboni/devhub-min.js:1
 msgid "{0} of {1}"
 msgstr "{0} / {1}"
 
-#: static/js/common/upload-addon.js:140
+#: static/js/common/upload-addon.js:140 static/js/zamboni/devhub-all.js:371 static/js/zamboni/devhub-min.js:1
 msgid "Cancel"
 msgstr "キャンセル"
 
-#: static/js/common/upload-addon.js:162
+#: static/js/common/upload-addon.js:162 static/js/zamboni/devhub-all.js:393 static/js/zamboni/devhub-min.js:1
 msgid "Uploading {0}"
 msgstr "{0} をアップロードしています"
 
-#: static/js/common/upload-addon.js:189
+#: static/js/common/upload-addon.js:189 static/js/zamboni/devhub-all.js:420 static/js/zamboni/devhub-min.js:1
 msgid "Error with {0}"
 msgstr "{0} にエラーがありました"
 
-#: static/js/common/upload-addon.js:194
+#: static/js/common/upload-addon.js:194 static/js/zamboni/devhub-all.js:425 static/js/zamboni/devhub-min.js:1
 msgid "Your add-on failed validation with {0} error."
 msgid_plural "Your add-on failed validation with {0} errors."
 msgstr[0] "アドオンの検証に失敗しました。{0}個のエラーがあります。"
+msgstr[1] ""
 
-#: static/js/common/upload-addon.js:208
+#: static/js/common/upload-addon.js:208 static/js/zamboni/devhub-all.js:439 static/js/zamboni/devhub-min.js:1
 msgid "&hellip;and {0} more"
 msgid_plural "&hellip;and {0} more"
 msgstr[0] "... その他 {0} 個"
+msgstr[1] ""
 
-#: static/js/common/upload-addon.js:222 static/js/common/upload-addon.js:512
+#: static/js/common/upload-addon.js:222 static/js/common/upload-addon.js:497 static/js/zamboni/devhub-all.js:453 static/js/zamboni/devhub-all.js:743 static/js/zamboni/devhub-min.js:1
 msgid "See full validation report"
 msgstr "検証レポートの詳細を見る"
 
-#: static/js/common/upload-addon.js:234
+#: static/js/common/upload-addon.js:234 static/js/zamboni/devhub-all.js:465 static/js/zamboni/devhub-min.js:1
 msgid "Validating {0}"
 msgstr "{0} を検証しています"
 
 #. L10n: first argument is an HTTP status code
-#: static/js/common/upload-addon.js:273
+#: static/js/common/upload-addon.js:273 static/js/zamboni/devhub-all.js:504 static/js/zamboni/devhub-min.js:1
 msgid "Received an empty response from the server; status: {0}"
 msgstr "サーバから空の応答が返りました。ステータス: {0}"
 
-#: static/js/common/upload-addon.js:373
+#: static/js/common/upload-addon.js:370 static/js/zamboni/devhub-all.js:604 static/js/zamboni/devhub-min.js:1
 msgid "Unexpected server error while validating."
 msgstr "検証中に予期せぬサーバエラーが発生しました。"
 
-#: static/js/common/upload-addon.js:412
+#: static/js/common/upload-addon.js:409 static/js/zamboni/devhub-all.js:643 static/js/zamboni/devhub-min.js:1
 msgid "Finished validating {0}"
 msgstr "{0} の検証が完了しました"
 
-#: static/js/common/upload-addon.js:418
+#: static/js/common/upload-addon.js:415 static/js/zamboni/devhub-all.js:649 static/js/zamboni/devhub-min.js:1
 msgid "Your add-on validation timed out, it will be manually reviewed."
 msgstr "このアドオンの検証は時間切れとなったため、手作業で審査されます。"
 
-#: static/js/common/upload-addon.js:421
+#: static/js/common/upload-addon.js:418 static/js/zamboni/devhub-all.js:652 static/js/zamboni/devhub-min.js:1
 msgid "Your add-on was validated with no errors and {0} warning."
 msgid_plural "Your add-on was validated with no errors and {0} warnings."
 msgstr[0] "このアドオンの検証が完了しました。0 件のエラー、{0} 件の警告があります。"
+msgstr[1] ""
 
-#: static/js/common/upload-addon.js:426
+#: static/js/common/upload-addon.js:423 static/js/zamboni/devhub-all.js:657 static/js/zamboni/devhub-min.js:1
 msgid "Your add-on was validated with no errors and {0} message."
 msgid_plural "Your add-on was validated with no errors and {0} messages."
 msgstr[0] "このアドオンの検証が完了しました。0 件のエラー、{0} 件のメッセージがあります。"
+msgstr[1] ""
 
-#: static/js/common/upload-addon.js:431
+#: static/js/common/upload-addon.js:428 static/js/zamboni/devhub-all.js:662 static/js/zamboni/devhub-min.js:1
 msgid "Your add-on was validated with no errors or warnings."
 msgstr "このアドオンの検証が完了しました。エラーも警告もありません。"
 
-#: static/js/common/upload-addon.js:446
+#: static/js/common/upload-addon.js:443 static/js/zamboni/devhub-all.js:677 static/js/zamboni/devhub-min.js:1
 msgid "Your submission will be automatically signed."
 msgstr "あなたのアドオンは自動的に署名されます。"
 
-#: static/js/common/upload-addon.js:465
+#: static/js/common/upload-addon.js:450 static/js/zamboni/devhub-all.js:696 static/js/zamboni/devhub-min.js:1
 msgid "Include detailed version notes (this can be done in the next step)."
 msgstr "詳しいリリースノートを含める (これは次のステップで行えます)。"
 
-#: static/js/common/upload-addon.js:466
+#: static/js/common/upload-addon.js:451 static/js/zamboni/devhub-all.js:697 static/js/zamboni/devhub-min.js:1
 msgid "If your add-on requires an account to a website in order to be fully tested, include a test username and password in the Notes to Reviewer (this can be done in the next step)."
 msgstr "このアドオンを完全にテストするにあたって Web サイトのアカウントが必要となる場合、テスト用のユーザ名とパスワードを審査担当者へのメモに含めてください (これは次のステップで行えます)。"
 
-#: static/js/common/upload-addon.js:467
+#: static/js/common/upload-addon.js:452 static/js/zamboni/devhub-all.js:698 static/js/zamboni/devhub-min.js:1
 msgid "If your add-on is intended for a limited audience you should choose Preliminary Review instead of Full Review."
 msgstr "このアドオンが限られたユーザ向けの場合は、本審査の代わりに事前審査を選択してください。"
 
-#: static/js/common/upload-addon.js:480
+#: static/js/common/upload-addon.js:465 static/js/zamboni/devhub-all.js:711 static/js/zamboni/devhub-min.js:1
 msgid "Add-on submission checklist"
 msgstr "アドオン登録チェックリスト"
 
-#: static/js/common/upload-addon.js:481
+#: static/js/common/upload-addon.js:466 static/js/zamboni/devhub-all.js:712 static/js/zamboni/devhub-min.js:1
 msgid "Please verify the following points before finalizing your submission. This will minimize delays or misunderstanding during the review process:"
 msgstr "登録を完了する前に以下の点について確認してください。これは審査手続き中の遅延や誤解を最小限にするために役立ちます。"
 
-#: static/js/common/upload-addon.js:483
+#: static/js/common/upload-addon.js:468 static/js/zamboni/devhub-all.js:714 static/js/zamboni/devhub-min.js:1
 msgid ""
 "Compiled binaries, as well as minified or obfuscated scripts (excluding known libraries) need to have their sources submitted separately for review. Make sure that you use the source code upload "
 "field to avoid having your submission rejected."
-msgstr "コンパイルされたバイナリや、最小化、難読化されたスクリプト (既知のライブラリを除く) がアドオンに含まれる場合、審査用に別途元のソースを提出する必要があります。そうした場合は必ずソースコードアップロードフォームを使い、審査が即座に却下されないようにしてください。"
+msgstr ""
+"コンパイルされたバイナリや、最小化、難読化されたスクリプト (既知のライブラリを除く) がアドオンに含まれる場合、審査用に別途元のソースを提出する必要があります。そうした場合は必ずソースコードアップロー"
+"ドフォームを使い、審査が即座に却下されないようにしてください。"
 
-#: static/js/common/upload-addon.js:501
+#: static/js/common/upload-addon.js:486 static/js/zamboni/devhub-all.js:732 static/js/zamboni/devhub-min.js:1
 msgid "The validation process found these issues that can lead to rejections:"
 msgstr "アドオンの検証中にこれらの問題が見つかり、審査が却下されました:"
 
-#: static/js/common/upload-addon.js:518
+#: static/js/common/upload-addon.js:503 static/js/zamboni/devhub-all.js:749 static/js/zamboni/devhub-min.js:1
 msgid "If you are unfamiliar with the add-ons review process, you can read about it here."
 msgstr "アドオンの審査手続きについてよくご存じない場合は、こちらをご覧ください。"
 
-#: static/js/common/upload-addon.js:555
+#: static/js/common/upload-addon.js:540 static/js/zamboni/devhub-all.js:786 static/js/zamboni/devhub-min.js:1
 msgid "Sorry, no supported platform has been found."
 msgstr "申し訳ありませんが、対応プラットフォームがひとつも見つかりませんでした。"
 
-#: static/js/common/upload-base.js:57
+#: static/js/common/upload-base.js:57 static/js/zamboni/devhub-all.js:187 static/js/zamboni/devhub-min.js:1
 msgid "The filetype you uploaded isn't recognized."
 msgstr "アップロードされたファイルの種類を認識できません。"
 
-#: static/js/common/upload-base.js:79
+#: static/js/common/upload-base.js:79 static/js/zamboni/devhub-all.js:209 static/js/zamboni/devhub-min.js:1
 msgid "You cancelled the upload."
 msgstr "アップロードがキャンセルされました。"
 
-#: static/js/common/upload-image.js:97 static/js/impala/users.js:51
-msgid "Images must be either PNG or JPG."
-msgstr "画像は PNG か JPEG 形式でなければなりません。"
-
-#: static/js/common/upload-image.js:101
-msgid "Videos must be in WebM."
-msgstr "動画は WebM 形式でなければなりません。"
-
-#: static/js/impala/collections.js:10 static/js/zamboni/collections.js:595
-msgid "Follow this Collection"
-msgstr "このコレクションをフォロー"
-
-#: static/js/impala/collections.js:19
-msgid "Stop Following"
-msgstr "フォローをやめる"
-
-#: static/js/impala/collections.js:20
-msgid "Following"
-msgstr "フォロー中"
-
-#. L10n: {0} is an app name.
-#: static/js/impala/listing.js:11 static/js/zamboni/themes.js:13
-msgid "This theme is incompatible with your version of {0}"
-msgstr "このテーマはお使いの {0} のバージョンと互換性がありません"
-
-#: static/js/impala/persona_creation.js:60
-msgid "All Rights Reserved"
-msgstr "All Rights Reserved"
-
-#: static/js/impala/persona_creation.js:64
-msgid "Creative Commons Attribution 3.0"
-msgstr "Creative Commons 表示 3.0"
-
-#: static/js/impala/persona_creation.js:69
-msgid "Creative Commons Attribution-NonCommercial 3.0"
-msgstr "Creative Commons 表示-非営利 3.0"
-
-#: static/js/impala/persona_creation.js:74
-msgid "Creative Commons Attribution-NonCommercial-NoDerivs 3.0"
-msgstr "Creative Commons 表示-非営利-改変禁止 3.0"
-
-#: static/js/impala/persona_creation.js:79
-msgid "Creative Commons Attribution-NonCommercial-Share Alike 3.0"
-msgstr "Creative Commons 表示-非営利-継承 3.0"
-
-#: static/js/impala/persona_creation.js:84
-msgid "Creative Commons Attribution-NoDerivs 3.0"
-msgstr "Creative Commons 表示-改変禁止 3.0"
-
-#: static/js/impala/persona_creation.js:89
-msgid "Creative Commons Attribution-ShareAlike 3.0"
-msgstr "Creative Commons 表示-継承 3.0"
-
-#: static/js/impala/persona_creation.js:292
-msgid "Your Theme's Name"
-msgstr "テーマの名前"
-
-#: static/js/impala/reviews.js:23 static/js/zamboni/reviews.js:18
-msgid "Flagged for review"
-msgstr "レビューフラグ付き"
-
-#: static/js/impala/reviews.js:40 static/js/zamboni/reviews.js:34
-msgid "Your input is required"
-msgstr "入力が必要です"
-
-#: static/js/impala/reviews.js:152 static/js/zamboni/reviews.js:103
-msgid "Marked for deletion"
-msgstr "削除マーク付き"
-
-#: static/js/impala/search.js:114
-msgid "Updating results&hellip;"
-msgstr "結果を更新しています..."
-
-#: static/js/impala/site_suggestions.js:46
-msgid "Category"
-msgstr "カテゴリ"
-
-#: static/js/impala/suggestions.js:39
-msgid "Search themes for <b>{0}</b>"
-msgstr "<b>{0}</b> 用のテーマを検索"
-
-#: static/js/impala/suggestions.js:41
-msgid "Search apps for <b>{0}</b>"
-msgstr "<b>{0}</b> 用のアプリを検索"
-
-#: static/js/impala/suggestions.js:43
-msgid "Search add-ons for <b>{0}</b>"
-msgstr "<b>{0}</b> 用のアドオンを検索"
-
-#: static/js/impala/users.js:33
-msgid "use original"
-msgstr "オリジナルを使用"
-
-#: static/js/impala/stats/chart.js:267
+#: static/js/impala/stats/chart.js:267 static/js/zamboni/stats-all.js:16898 static/js/zamboni/stats-min.js:5
 msgid "Week of {0}"
 msgstr "{0} の週"
 
-#: static/js/impala/stats/chart.js:269
+#: static/js/impala/stats/chart.js:269 static/js/zamboni/stats-all.js:16900 static/js/zamboni/stats-min.js:5
 msgid " downloads"
-msgstr " 件のダウンロード"
+msgstr ""
 
-#: static/js/impala/stats/chart.js:270
+#: static/js/impala/stats/chart.js:270 static/js/zamboni/stats-all.js:16901 static/js/zamboni/stats-min.js:5
 msgid "{0} users"
 msgstr "{0} 人のユーザ"
 
-#: static/js/impala/stats/chart.js:271
+#: static/js/impala/stats/chart.js:271 static/js/zamboni/stats-all.js:16902 static/js/zamboni/stats-min.js:5
 msgid "{0} add-ons"
 msgstr "{0} 個のアドオン"
 
-#: static/js/impala/stats/chart.js:272
+#: static/js/impala/stats/chart.js:272 static/js/zamboni/stats-all.js:16903 static/js/zamboni/stats-min.js:5
 msgid "{0} collections"
 msgstr "{0} 個のコレクション"
 
-#: static/js/impala/stats/chart.js:273
+#: static/js/impala/stats/chart.js:273 static/js/zamboni/stats-all.js:16904 static/js/zamboni/stats-min.js:5
 msgid "{0} reviews"
 msgstr "{0} 件のレビュー"
 
-#: static/js/impala/stats/chart.js:275
+#: static/js/impala/stats/chart.js:275 static/js/zamboni/stats-all.js:16906 static/js/zamboni/stats-min.js:5
 msgid "{0} sales"
 msgstr "{0} 個の販売"
 
-#: static/js/impala/stats/chart.js:276
+#: static/js/impala/stats/chart.js:276 static/js/zamboni/stats-all.js:16907 static/js/zamboni/stats-min.js:5
 msgid "{0} refunds"
 msgstr "{0} 個の返品"
 
-#: static/js/impala/stats/chart.js:277
+#: static/js/impala/stats/chart.js:277 static/js/zamboni/stats-all.js:16908 static/js/zamboni/stats-min.js:5
 msgid "{0} installs"
 msgstr "{0} 回のインストール"
 
-#: static/js/impala/stats/chart.js:369 static/js/impala/stats/csv_keys.js:3 static/js/impala/stats/csv_keys.js:109
+#: static/js/impala/stats/chart.js:369 static/js/impala/stats/csv_keys.js:3 static/js/impala/stats/csv_keys.js:109 static/js/zamboni/stats-all.js:15284 static/js/zamboni/stats-all.js:15390
+#: static/js/zamboni/stats-all.js:17000 static/js/zamboni/stats-min.js:4 static/js/zamboni/stats-min.js:5
 msgid "Downloads"
 msgstr "ダウンロード"
 
-#: static/js/impala/stats/chart.js:379 static/js/impala/stats/csv_keys.js:6 static/js/impala/stats/csv_keys.js:110
+#: static/js/impala/stats/chart.js:379 static/js/impala/stats/csv_keys.js:6 static/js/impala/stats/csv_keys.js:110 static/js/zamboni/stats-all.js:15287 static/js/zamboni/stats-all.js:15391
+#: static/js/zamboni/stats-all.js:17010 static/js/zamboni/stats-min.js:4 static/js/zamboni/stats-min.js:5
 msgid "Daily Users"
 msgstr "日別ユーザ数"
 
-#: static/js/impala/stats/chart.js:410
+#: static/js/impala/stats/chart.js:410 static/js/zamboni/stats-all.js:17041 static/js/zamboni/stats-min.js:5
 msgid "Amount, in USD"
 msgstr "金額 (米ドル)"
 
-#: static/js/impala/stats/chart.js:421 static/js/impala/stats/csv_keys.js:104
+#: static/js/impala/stats/chart.js:421 static/js/impala/stats/csv_keys.js:104 static/js/zamboni/stats-all.js:15385 static/js/zamboni/stats-all.js:17052 static/js/zamboni/stats-min.js:5
 msgid "Number of Contributions"
 msgstr "寄付回数"
 
-#: static/js/impala/stats/chart.js:447
+#: static/js/impala/stats/chart.js:447 static/js/zamboni/stats-all.js:17078 static/js/zamboni/stats-min.js:5
 msgid "More Info..."
 msgstr "詳細..."
 
 #. L10n: {0} is an ISO-formatted date.
-#: static/js/impala/stats/chart.js:451
+#: static/js/impala/stats/chart.js:451 static/js/zamboni/stats-all.js:17082 static/js/zamboni/stats-min.js:5
 msgid "Details for {0}"
 msgstr "{0} の詳細"
 
-#: static/js/impala/stats/csv_keys.js:9
+#: static/js/impala/stats/csv_keys.js:9 static/js/zamboni/stats-all.js:15290 static/js/zamboni/stats-min.js:4
 msgid "Collections Created"
 msgstr "コレクション作成回数"
 
-#: static/js/impala/stats/csv_keys.js:12
+#: static/js/impala/stats/csv_keys.js:12 static/js/zamboni/stats-all.js:15293 static/js/zamboni/stats-min.js:4
 msgid "Add-ons in Use"
 msgstr "アドオン使用回数"
 
-#: static/js/impala/stats/csv_keys.js:15
+#: static/js/impala/stats/csv_keys.js:15 static/js/zamboni/stats-all.js:15296 static/js/zamboni/stats-min.js:4
 msgid "Add-ons Created"
 msgstr "アドオン作成回数"
 
-#: static/js/impala/stats/csv_keys.js:18
+#: static/js/impala/stats/csv_keys.js:18 static/js/zamboni/stats-all.js:15299 static/js/zamboni/stats-min.js:4
 msgid "Add-ons Downloaded"
 msgstr "アドオンダウンロード回数"
 
-#: static/js/impala/stats/csv_keys.js:21
+#: static/js/impala/stats/csv_keys.js:21 static/js/zamboni/stats-all.js:15302 static/js/zamboni/stats-min.js:4
 msgid "Add-ons Updated"
 msgstr "アドオン更新回数"
 
-#: static/js/impala/stats/csv_keys.js:24
+#: static/js/impala/stats/csv_keys.js:24 static/js/zamboni/stats-all.js:15305 static/js/zamboni/stats-min.js:4
 msgid "Reviews Written"
 msgstr "レビュー投稿数"
 
-#: static/js/impala/stats/csv_keys.js:27
+#: static/js/impala/stats/csv_keys.js:27 static/js/zamboni/stats-all.js:15308 static/js/zamboni/stats-min.js:4
 msgid "User Signups"
 msgstr "ユーザログイン回数"
 
-#: static/js/impala/stats/csv_keys.js:30
+#: static/js/impala/stats/csv_keys.js:30 static/js/zamboni/stats-all.js:15311 static/js/zamboni/stats-min.js:4
 msgid "Subscribers"
 msgstr "購読者数"
 
-#: static/js/impala/stats/csv_keys.js:33
+#: static/js/impala/stats/csv_keys.js:33 static/js/zamboni/stats-all.js:15314 static/js/zamboni/stats-min.js:4
 msgid "Ratings"
 msgstr "評価数"
 
-#: static/js/impala/stats/csv_keys.js:36 static/js/impala/stats/csv_keys.js:114
+#: static/js/impala/stats/csv_keys.js:36 static/js/impala/stats/csv_keys.js:114 static/js/zamboni/stats-all.js:15317 static/js/zamboni/stats-all.js:15395 static/js/zamboni/stats-min.js:4
+#: static/js/zamboni/stats-min.js:5
 msgid "Sales"
 msgstr "販売数"
 
-#: static/js/impala/stats/csv_keys.js:39 static/js/impala/stats/csv_keys.js:113
+#: static/js/impala/stats/csv_keys.js:39 static/js/impala/stats/csv_keys.js:113 static/js/zamboni/stats-all.js:15320 static/js/zamboni/stats-all.js:15394 static/js/zamboni/stats-min.js:4
+#: static/js/zamboni/stats-min.js:5
 msgid "Installs"
 msgstr "インストール回数"
 
-#: static/js/impala/stats/csv_keys.js:42
+#: static/js/impala/stats/csv_keys.js:42 static/js/zamboni/stats-all.js:15323 static/js/zamboni/stats-min.js:4
 msgid "Unknown"
 msgstr "不明"
 
-#: static/js/impala/stats/csv_keys.js:43
+#: static/js/impala/stats/csv_keys.js:43 static/js/zamboni/stats-all.js:15324 static/js/zamboni/stats-min.js:4
 msgid "Add-ons Manager"
 msgstr "アドオンマネージャ"
 
-#: static/js/impala/stats/csv_keys.js:44
+#: static/js/impala/stats/csv_keys.js:44 static/js/zamboni/stats-all.js:15325 static/js/zamboni/stats-min.js:4
 msgid "Add-ons Manager Promo"
 msgstr "アドオンマネージャ内のプロモーション"
 
-#: static/js/impala/stats/csv_keys.js:45
+#: static/js/impala/stats/csv_keys.js:45 static/js/zamboni/stats-all.js:15326 static/js/zamboni/stats-min.js:4
 msgid "Add-ons Manager Featured"
 msgstr "アドオンマネージャ内のおすすめ"
 
-#: static/js/impala/stats/csv_keys.js:46
+#: static/js/impala/stats/csv_keys.js:46 static/js/zamboni/stats-all.js:15327 static/js/zamboni/stats-min.js:4
 msgid "Add-ons Manager Learn More"
 msgstr "アドオンマネージャ内の詳細リンク"
 
-#: static/js/impala/stats/csv_keys.js:47
+#: static/js/impala/stats/csv_keys.js:47 static/js/zamboni/stats-all.js:15328 static/js/zamboni/stats-min.js:4
 msgid "Search Suggestions"
 msgstr "検索サジェスト"
 
-#: static/js/impala/stats/csv_keys.js:48
+#: static/js/impala/stats/csv_keys.js:48 static/js/zamboni/stats-all.js:15329 static/js/zamboni/stats-min.js:4
 msgid "Search Results"
 msgstr "検索結果"
 
-#: static/js/impala/stats/csv_keys.js:49 static/js/impala/stats/csv_keys.js:50 static/js/impala/stats/csv_keys.js:51
+#: static/js/impala/stats/csv_keys.js:49 static/js/impala/stats/csv_keys.js:50 static/js/impala/stats/csv_keys.js:51 static/js/zamboni/stats-all.js:15330 static/js/zamboni/stats-all.js:15331
+#: static/js/zamboni/stats-all.js:15332 static/js/zamboni/stats-min.js:4
 msgid "Homepage Promo"
 msgstr "ホームページの宣伝枠"
 
-#: static/js/impala/stats/csv_keys.js:52 static/js/impala/stats/csv_keys.js:53
+#: static/js/impala/stats/csv_keys.js:52 static/js/impala/stats/csv_keys.js:53 static/js/zamboni/stats-all.js:15333 static/js/zamboni/stats-all.js:15334 static/js/zamboni/stats-min.js:4
 msgid "Homepage Featured"
 msgstr "ホームページのおすすめ枠"
 
-#: static/js/impala/stats/csv_keys.js:54 static/js/impala/stats/csv_keys.js:55
+#: static/js/impala/stats/csv_keys.js:54 static/js/impala/stats/csv_keys.js:55 static/js/zamboni/stats-all.js:15335 static/js/zamboni/stats-all.js:15336 static/js/zamboni/stats-min.js:4
 msgid "Homepage Up and Coming"
 msgstr "ホームページの注目枠"
 
-#: static/js/impala/stats/csv_keys.js:56
+#: static/js/impala/stats/csv_keys.js:56 static/js/zamboni/stats-all.js:15337 static/js/zamboni/stats-min.js:4
 msgid "Homepage Most Popular"
 msgstr "ホームページの人気枠"
 
-#: static/js/impala/stats/csv_keys.js:57 static/js/impala/stats/csv_keys.js:59
+#: static/js/impala/stats/csv_keys.js:57 static/js/impala/stats/csv_keys.js:59 static/js/zamboni/stats-all.js:15338 static/js/zamboni/stats-all.js:15340 static/js/zamboni/stats-min.js:4
 msgid "Detail Page"
 msgstr "詳細ページ"
 
-#: static/js/impala/stats/csv_keys.js:58 static/js/impala/stats/csv_keys.js:60
+#: static/js/impala/stats/csv_keys.js:58 static/js/impala/stats/csv_keys.js:60 static/js/zamboni/stats-all.js:15339 static/js/zamboni/stats-all.js:15341 static/js/zamboni/stats-min.js:4
 msgid "Detail Page (bottom)"
 msgstr "詳細ページ (下部)"
 
-#: static/js/impala/stats/csv_keys.js:61
+#: static/js/impala/stats/csv_keys.js:61 static/js/zamboni/stats-all.js:15342 static/js/zamboni/stats-min.js:4
 msgid "Detail Page (Development Channel)"
 msgstr "詳細ページ (開発チャンネル)"
 
-#: static/js/impala/stats/csv_keys.js:62 static/js/impala/stats/csv_keys.js:63 static/js/impala/stats/csv_keys.js:64
+#: static/js/impala/stats/csv_keys.js:62 static/js/impala/stats/csv_keys.js:63 static/js/impala/stats/csv_keys.js:64 static/js/zamboni/stats-all.js:15343 static/js/zamboni/stats-all.js:15344
+#: static/js/zamboni/stats-all.js:15345 static/js/zamboni/stats-min.js:4
 msgid "Often Used With"
 msgstr "同時使用アドオン"
 
-#: static/js/impala/stats/csv_keys.js:65 static/js/impala/stats/csv_keys.js:66
+#: static/js/impala/stats/csv_keys.js:65 static/js/impala/stats/csv_keys.js:66 static/js/zamboni/stats-all.js:15346 static/js/zamboni/stats-all.js:15347 static/js/zamboni/stats-min.js:4
 msgid "Others By Author"
 msgstr "作者の他のアドオン"
 
-#: static/js/impala/stats/csv_keys.js:67 static/js/impala/stats/csv_keys.js:68
+#: static/js/impala/stats/csv_keys.js:67 static/js/impala/stats/csv_keys.js:68 static/js/zamboni/stats-all.js:15348 static/js/zamboni/stats-all.js:15349 static/js/zamboni/stats-min.js:4
 msgid "Dependencies"
 msgstr "依存関係"
 
-#: static/js/impala/stats/csv_keys.js:69 static/js/impala/stats/csv_keys.js:70
+#: static/js/impala/stats/csv_keys.js:69 static/js/impala/stats/csv_keys.js:70 static/js/zamboni/stats-all.js:15350 static/js/zamboni/stats-all.js:15351 static/js/zamboni/stats-min.js:4
 msgid "Upsell"
 msgstr "有料版"
 
-#: static/js/impala/stats/csv_keys.js:71
+#: static/js/impala/stats/csv_keys.js:71 static/js/zamboni/stats-all.js:15352 static/js/zamboni/stats-min.js:4
 msgid "Meet the Developer"
 msgstr "開発者の紹介"
 
-#: static/js/impala/stats/csv_keys.js:72
+#: static/js/impala/stats/csv_keys.js:72 static/js/zamboni/stats-all.js:15353 static/js/zamboni/stats-min.js:4
 msgid "User Profile"
 msgstr "ユーザプロプロフィール"
 
-#: static/js/impala/stats/csv_keys.js:73
+#: static/js/impala/stats/csv_keys.js:73 static/js/zamboni/stats-all.js:15354 static/js/zamboni/stats-min.js:4
 msgid "Version History"
 msgstr "バージョン履歴"
 
-#: static/js/impala/stats/csv_keys.js:75
+#: static/js/impala/stats/csv_keys.js:75 static/js/zamboni/stats-all.js:15356 static/js/zamboni/stats-min.js:4
 msgid "Sharing"
 msgstr "共有"
 
-#: static/js/impala/stats/csv_keys.js:76
+#: static/js/impala/stats/csv_keys.js:76 static/js/zamboni/stats-all.js:15357 static/js/zamboni/stats-min.js:4
 msgid "Category Pages"
 msgstr "カテゴリページ"
 
-#: static/js/impala/stats/csv_keys.js:77
+#: static/js/impala/stats/csv_keys.js:77 static/js/zamboni/stats-all.js:15358 static/js/zamboni/stats-min.js:4
 msgid "Collections"
 msgstr "コレクション"
 
-#: static/js/impala/stats/csv_keys.js:78 static/js/impala/stats/csv_keys.js:79
+#: static/js/impala/stats/csv_keys.js:78 static/js/impala/stats/csv_keys.js:79 static/js/zamboni/stats-all.js:15359 static/js/zamboni/stats-all.js:15360 static/js/zamboni/stats-min.js:4
 msgid "Category Landing Featured Carousel"
 msgstr "カテゴリトップページのおすすめローテーション"
 
-#: static/js/impala/stats/csv_keys.js:80 static/js/impala/stats/csv_keys.js:81
+#: static/js/impala/stats/csv_keys.js:80 static/js/impala/stats/csv_keys.js:81 static/js/zamboni/stats-all.js:15361 static/js/zamboni/stats-all.js:15362 static/js/zamboni/stats-min.js:4
 msgid "Category Landing Top Rated"
 msgstr "カテゴリトップページの高評価枠"
 
-#: static/js/impala/stats/csv_keys.js:82 static/js/impala/stats/csv_keys.js:83
+#: static/js/impala/stats/csv_keys.js:82 static/js/impala/stats/csv_keys.js:83 static/js/zamboni/stats-all.js:15363 static/js/zamboni/stats-all.js:15364 static/js/zamboni/stats-min.js:5
 msgid "Category Landing Most Popular"
 msgstr "カテゴリトップページの人気枠"
 
-#: static/js/impala/stats/csv_keys.js:84 static/js/impala/stats/csv_keys.js:85
+#: static/js/impala/stats/csv_keys.js:84 static/js/impala/stats/csv_keys.js:85 static/js/zamboni/stats-all.js:15365 static/js/zamboni/stats-all.js:15366 static/js/zamboni/stats-min.js:5
 msgid "Category Landing Recently Added"
 msgstr "カテゴリトップページの新着枠"
 
-#: static/js/impala/stats/csv_keys.js:86 static/js/impala/stats/csv_keys.js:87
+#: static/js/impala/stats/csv_keys.js:86 static/js/impala/stats/csv_keys.js:87 static/js/zamboni/stats-all.js:15367 static/js/zamboni/stats-all.js:15368 static/js/zamboni/stats-min.js:5
 msgid "Browse Listing Featured Sort"
 msgstr "一覧ページのおすすめ順"
 
-#: static/js/impala/stats/csv_keys.js:88 static/js/impala/stats/csv_keys.js:89
+#: static/js/impala/stats/csv_keys.js:88 static/js/impala/stats/csv_keys.js:89 static/js/zamboni/stats-all.js:15369 static/js/zamboni/stats-all.js:15370 static/js/zamboni/stats-min.js:5
 msgid "Browse Listing Users Sort"
 msgstr "一覧ページのユーザ数順"
 
-#: static/js/impala/stats/csv_keys.js:90 static/js/impala/stats/csv_keys.js:91
+#: static/js/impala/stats/csv_keys.js:90 static/js/impala/stats/csv_keys.js:91 static/js/zamboni/stats-all.js:15371 static/js/zamboni/stats-all.js:15372 static/js/zamboni/stats-min.js:5
 msgid "Browse Listing Rating Sort"
 msgstr "一覧ページの評価順"
 
-#: static/js/impala/stats/csv_keys.js:92 static/js/impala/stats/csv_keys.js:93
+#: static/js/impala/stats/csv_keys.js:92 static/js/impala/stats/csv_keys.js:93 static/js/zamboni/stats-all.js:15373 static/js/zamboni/stats-all.js:15374 static/js/zamboni/stats-min.js:5
 msgid "Browse Listing Created Sort"
 msgstr "一覧ページの登録日順"
 
-#: static/js/impala/stats/csv_keys.js:94 static/js/impala/stats/csv_keys.js:95
+#: static/js/impala/stats/csv_keys.js:94 static/js/impala/stats/csv_keys.js:95 static/js/zamboni/stats-all.js:15375 static/js/zamboni/stats-all.js:15376 static/js/zamboni/stats-min.js:5
 msgid "Browse Listing Name Sort"
 msgstr "一覧ページの名前順"
 
-#: static/js/impala/stats/csv_keys.js:96 static/js/impala/stats/csv_keys.js:97
+#: static/js/impala/stats/csv_keys.js:96 static/js/impala/stats/csv_keys.js:97 static/js/zamboni/stats-all.js:15377 static/js/zamboni/stats-all.js:15378 static/js/zamboni/stats-min.js:5
 msgid "Browse Listing Popular Sort"
 msgstr "一覧ページの人気順"
 
-#: static/js/impala/stats/csv_keys.js:98 static/js/impala/stats/csv_keys.js:99
+#: static/js/impala/stats/csv_keys.js:98 static/js/impala/stats/csv_keys.js:99 static/js/zamboni/stats-all.js:15379 static/js/zamboni/stats-all.js:15380 static/js/zamboni/stats-min.js:5
 msgid "Browse Listing Updated Sort"
 msgstr "一覧ページの更新日順"
 
-#: static/js/impala/stats/csv_keys.js:100 static/js/impala/stats/csv_keys.js:101
+#: static/js/impala/stats/csv_keys.js:100 static/js/impala/stats/csv_keys.js:101 static/js/zamboni/stats-all.js:15381 static/js/zamboni/stats-all.js:15382 static/js/zamboni/stats-min.js:5
 msgid "Browse Listing Up and Coming Sort"
 msgstr "一覧ページの注目度順"
 
-#: static/js/impala/stats/csv_keys.js:105
+#: static/js/impala/stats/csv_keys.js:105 static/js/zamboni/stats-all.js:15386 static/js/zamboni/stats-min.js:5
 msgid "Total Amount Contributed"
 msgstr "合計寄付金額"
 
-#: static/js/impala/stats/csv_keys.js:106
+#: static/js/impala/stats/csv_keys.js:106 static/js/zamboni/stats-all.js:15387 static/js/zamboni/stats-min.js:5
 msgid "Average Contribution"
 msgstr "平均寄付金額"
 
-#: static/js/impala/stats/csv_keys.js:115
+#: static/js/impala/stats/csv_keys.js:115 static/js/zamboni/stats-all.js:15396 static/js/zamboni/stats-min.js:5
 msgid "Usage"
 msgstr "使用回数"
 
-#: static/js/impala/stats/csv_keys.js:118
+#: static/js/impala/stats/csv_keys.js:118 static/js/zamboni/stats-all.js:15399 static/js/zamboni/stats-min.js:5
 msgid "Firefox"
 msgstr "Firefox"
 
-#: static/js/impala/stats/csv_keys.js:119
+#: static/js/impala/stats/csv_keys.js:119 static/js/zamboni/stats-all.js:15400 static/js/zamboni/stats-min.js:5
 msgid "Mozilla"
 msgstr "Mozilla"
 
-#: static/js/impala/stats/csv_keys.js:120
+#: static/js/impala/stats/csv_keys.js:120 static/js/zamboni/stats-all.js:15401 static/js/zamboni/stats-min.js:5
 msgid "Thunderbird"
 msgstr "Thunderbird"
 
-#: static/js/impala/stats/csv_keys.js:121
+#: static/js/impala/stats/csv_keys.js:121 static/js/zamboni/stats-all.js:15402 static/js/zamboni/stats-min.js:5
 msgid "Sunbird"
 msgstr "Sunbird"
 
-#: static/js/impala/stats/csv_keys.js:122
+#: static/js/impala/stats/csv_keys.js:122 static/js/zamboni/stats-all.js:15403 static/js/zamboni/stats-min.js:5
 msgid "SeaMonkey"
 msgstr "SeaMonkey"
 
-#: static/js/impala/stats/csv_keys.js:123
+#: static/js/impala/stats/csv_keys.js:123 static/js/zamboni/stats-all.js:15404 static/js/zamboni/stats-min.js:5
 msgid "Fennec"
 msgstr "Fennec"
 
-#: static/js/impala/stats/csv_keys.js:124
+#: static/js/impala/stats/csv_keys.js:124 static/js/zamboni/stats-all.js:15405 static/js/zamboni/stats-min.js:5
 msgid "Android"
 msgstr "Android"
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:129
+#: static/js/impala/stats/csv_keys.js:129 static/js/zamboni/stats-all.js:15410 static/js/zamboni/stats-min.js:5
 msgid "Downloads and Daily Users, last {0} days"
 msgstr "最近 {0} 日間のダウンロード回数とユーザ数"
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:131
+#: static/js/impala/stats/csv_keys.js:131 static/js/zamboni/stats-all.js:15412 static/js/zamboni/stats-min.js:5
 msgid "Downloads and Daily Users from {0} to {1}"
 msgstr "{0} から {1} までのダウンロード回数とユーザ数"
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:135
+#: static/js/impala/stats/csv_keys.js:135 static/js/zamboni/stats-all.js:15416 static/js/zamboni/stats-min.js:5
 msgid "Installs and Daily Users, last {0} days"
 msgstr "最近 {0} 日間のインストール回数とユーザ数"
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:137
+#: static/js/impala/stats/csv_keys.js:137 static/js/zamboni/stats-all.js:15418 static/js/zamboni/stats-min.js:5
 msgid "Installs and Daily Users from {0} to {1}"
 msgstr "{0} から {1} までのインストール回数とユーザ数"
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:141
+#: static/js/impala/stats/csv_keys.js:141 static/js/zamboni/stats-all.js:15422 static/js/zamboni/stats-min.js:5
 msgid "Downloads, last {0} days"
 msgstr "最近 {0} 日間のダウンロード回数"
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:143
+#: static/js/impala/stats/csv_keys.js:143 static/js/zamboni/stats-all.js:15424 static/js/zamboni/stats-min.js:5
 msgid "Downloads from {0} to {1}"
 msgstr "{0} から {1} までのダウンロード回数"
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:147
+#: static/js/impala/stats/csv_keys.js:147 static/js/zamboni/stats-all.js:15428 static/js/zamboni/stats-min.js:5
 msgid "Daily Users, last {0} days"
 msgstr "最近 {0} 日間のユーザ数"
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:149
+#: static/js/impala/stats/csv_keys.js:149 static/js/zamboni/stats-all.js:15430 static/js/zamboni/stats-min.js:5
 msgid "Daily Users from {0} to {1}"
 msgstr "{0} から {1} までのユーザ数"
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:153
+#: static/js/impala/stats/csv_keys.js:153 static/js/zamboni/stats-all.js:15434 static/js/zamboni/stats-min.js:5
 msgid "Applications, last {0} days"
 msgstr "最近 {0} 日間のアプリケーション"
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:155
+#: static/js/impala/stats/csv_keys.js:155 static/js/zamboni/stats-all.js:15436 static/js/zamboni/stats-min.js:5
 msgid "Applications from {0} to {1}"
 msgstr "{0} から {1} までのアプリケーション"
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:159
+#: static/js/impala/stats/csv_keys.js:159 static/js/zamboni/stats-all.js:15440 static/js/zamboni/stats-min.js:5
 msgid "Platforms, last {0} days"
 msgstr "最近 {0} 日間の OS"
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:161
+#: static/js/impala/stats/csv_keys.js:161 static/js/zamboni/stats-all.js:15442 static/js/zamboni/stats-min.js:5
 msgid "Platforms from {0} to {1}"
 msgstr "{0} から {1} までの OS"
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:165
+#: static/js/impala/stats/csv_keys.js:165 static/js/zamboni/stats-all.js:15446 static/js/zamboni/stats-min.js:5
 msgid "Languages, last {0} days"
 msgstr "最近 {0} 日間の言語"
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:167
+#: static/js/impala/stats/csv_keys.js:167 static/js/zamboni/stats-all.js:15448 static/js/zamboni/stats-min.js:5
 msgid "Languages from {0} to {1}"
 msgstr "{0} から {1} までの言語"
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:171
+#: static/js/impala/stats/csv_keys.js:171 static/js/zamboni/stats-all.js:15452 static/js/zamboni/stats-min.js:5
 msgid "Add-on Versions, last {0} days"
 msgstr "最近 {0} 日間のアドオンのバージョン"
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:173
+#: static/js/impala/stats/csv_keys.js:173 static/js/zamboni/stats-all.js:15454 static/js/zamboni/stats-min.js:5
 msgid "Add-on Versions from {0} to {1}"
 msgstr "{0} から {1} までのアドオンのバージョン"
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:177
+#: static/js/impala/stats/csv_keys.js:177 static/js/zamboni/stats-all.js:15458 static/js/zamboni/stats-min.js:5
 msgid "Add-on Status, last {0} days"
 msgstr "最近 {0} 日間のアドオンの状態"
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:179
+#: static/js/impala/stats/csv_keys.js:179 static/js/zamboni/stats-all.js:15460 static/js/zamboni/stats-min.js:5
 msgid "Add-on Status from {0} to {1}"
 msgstr "{0} から {1} までのアドオンの状態"
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:183
+#: static/js/impala/stats/csv_keys.js:183 static/js/zamboni/stats-all.js:15464 static/js/zamboni/stats-min.js:5
 msgid "Download Sources, last {0} days"
 msgstr "最近 {0} 日間のダウンロード参照元"
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:185
+#: static/js/impala/stats/csv_keys.js:185 static/js/zamboni/stats-all.js:15466 static/js/zamboni/stats-min.js:5
 msgid "Download Sources from {0} to {1}"
 msgstr "{0} から {1} までのダウンロード参照元"
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:189
+#: static/js/impala/stats/csv_keys.js:189 static/js/zamboni/stats-all.js:15470 static/js/zamboni/stats-min.js:5
 msgid "Contributions, last {0} days"
 msgstr "最近 {0} 日間の寄付"
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:191
+#: static/js/impala/stats/csv_keys.js:191 static/js/zamboni/stats-all.js:15472 static/js/zamboni/stats-min.js:5
 msgid "Contributions from {0} to {1}"
 msgstr "{0} から {1} までの寄付"
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:195
+#: static/js/impala/stats/csv_keys.js:195 static/js/zamboni/stats-all.js:15476 static/js/zamboni/stats-min.js:5
 msgid "Site Metrics, last {0} days"
 msgstr "最近 {0} 日間のサイト解析"
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:197
+#: static/js/impala/stats/csv_keys.js:197 static/js/zamboni/stats-all.js:15478 static/js/zamboni/stats-min.js:5
 msgid "Site Metrics from {0} to {1}"
 msgstr "{0} から {1} までのサイト解析"
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:201
+#: static/js/impala/stats/csv_keys.js:201 static/js/zamboni/stats-all.js:15482 static/js/zamboni/stats-min.js:5
 msgid "Add-ons in Use, last {0} days"
 msgstr "最近 {0} 日間のアドオン使用回数"
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:203
+#: static/js/impala/stats/csv_keys.js:203 static/js/zamboni/stats-all.js:15484 static/js/zamboni/stats-min.js:5
 msgid "Add-ons in Use from {0} to {1}"
 msgstr "{0} から {1} までのアドオン使用回数"
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:207
+#: static/js/impala/stats/csv_keys.js:207 static/js/zamboni/stats-all.js:15488 static/js/zamboni/stats-min.js:5
 msgid "Add-ons Downloaded, last {0} days"
 msgstr "最近 {0} 日間のアドオンダウンロード回数"
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:209
+#: static/js/impala/stats/csv_keys.js:209 static/js/zamboni/stats-all.js:15490 static/js/zamboni/stats-min.js:5
 msgid "Add-ons Downloaded from {0} to {1}"
 msgstr "{0} から {1} までのアドオンダウンロード回数"
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:213
+#: static/js/impala/stats/csv_keys.js:213 static/js/zamboni/stats-all.js:15494 static/js/zamboni/stats-min.js:5
 msgid "Add-ons Created, last {0} days"
 msgstr "最近 {0} 日間のアドオン作成回数"
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:215
+#: static/js/impala/stats/csv_keys.js:215 static/js/zamboni/stats-all.js:15496 static/js/zamboni/stats-min.js:5
 msgid "Add-ons Created from {0} to {1}"
 msgstr "{0} から {1} までのアドオン作成回数"
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:219
+#: static/js/impala/stats/csv_keys.js:219 static/js/zamboni/stats-all.js:15500 static/js/zamboni/stats-min.js:5
 msgid "Add-ons Updated, last {0} days"
 msgstr "最近 {0} 日間のアドオン更新回数"
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:221
+#: static/js/impala/stats/csv_keys.js:221 static/js/zamboni/stats-all.js:15502 static/js/zamboni/stats-min.js:5
 msgid "Add-ons Updated from {0} to {1}"
 msgstr "{0} から {1} までのアドオン更新回数"
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:225
+#: static/js/impala/stats/csv_keys.js:225 static/js/zamboni/stats-all.js:15506 static/js/zamboni/stats-min.js:5
 msgid "Reviews Written, last {0} days"
 msgstr "最近 {0} 日間のレビュー投稿数"
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:227
+#: static/js/impala/stats/csv_keys.js:227 static/js/zamboni/stats-all.js:15508 static/js/zamboni/stats-min.js:5
 msgid "Reviews Written from {0} to {1}"
 msgstr "{0} から {1} までのレビュー投稿数"
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:231
+#: static/js/impala/stats/csv_keys.js:231 static/js/zamboni/stats-all.js:15512 static/js/zamboni/stats-min.js:5
 msgid "User Signups, last {0} days"
 msgstr "最近 {0} 日間のユーザログイン回数"
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:233
+#: static/js/impala/stats/csv_keys.js:233 static/js/zamboni/stats-all.js:15514 static/js/zamboni/stats-min.js:5
 msgid "User Signups from {0} to {1}"
 msgstr "{0} から {1} までのユーザログイン回数"
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:237
+#: static/js/impala/stats/csv_keys.js:237 static/js/zamboni/stats-all.js:15518 static/js/zamboni/stats-min.js:5
 msgid "Collections Created, last {0} days"
 msgstr "最近 {0} 日間のコレクション作成回数"
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:239
+#: static/js/impala/stats/csv_keys.js:239 static/js/zamboni/stats-all.js:15520 static/js/zamboni/stats-min.js:5
 msgid "Collections Created from {0} to {1}"
 msgstr "{0} から {1} までのコレクション作成回数"
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:243
+#: static/js/impala/stats/csv_keys.js:243 static/js/zamboni/stats-all.js:15524 static/js/zamboni/stats-min.js:5
 msgid "Subscribers, last {0} days"
 msgstr "最近 {0} 日間の購読者数"
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:245
+#: static/js/impala/stats/csv_keys.js:245 static/js/zamboni/stats-all.js:15526 static/js/zamboni/stats-min.js:5
 msgid "Subscribers from {0} to {1}"
 msgstr "{0} から {1} までの購読者数"
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:249
+#: static/js/impala/stats/csv_keys.js:249 static/js/zamboni/stats-all.js:15530 static/js/zamboni/stats-min.js:5
 msgid "Ratings, last {0} days"
 msgstr "最近 {0} 日間の評価数"
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:251
+#: static/js/impala/stats/csv_keys.js:251 static/js/zamboni/stats-all.js:15532 static/js/zamboni/stats-min.js:5
 msgid "Ratings from {0} to {1}"
 msgstr "{0} から {1} までの評価数"
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:255
+#: static/js/impala/stats/csv_keys.js:255 static/js/zamboni/stats-all.js:15536 static/js/zamboni/stats-min.js:5
 msgid "Sales, last {0} days"
 msgstr "最近 {0} 日間の販売数"
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:257
+#: static/js/impala/stats/csv_keys.js:257 static/js/zamboni/stats-all.js:15538 static/js/zamboni/stats-min.js:5
 msgid "Sales from {0} to {1}"
 msgstr "{0} から {1} までの販売数"
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:261
+#: static/js/impala/stats/csv_keys.js:261 static/js/zamboni/stats-all.js:15542 static/js/zamboni/stats-min.js:5
 msgid "Installs, last {0} days"
 msgstr "最近 {0} 日間のインストール回数"
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:263
+#: static/js/impala/stats/csv_keys.js:263 static/js/zamboni/stats-all.js:15544 static/js/zamboni/stats-min.js:5
 msgid "Installs from {0} to {1}"
 msgstr "{0} から {1} までのインストール回数"
 
 #. L10n: {0} and {1} are integers.
-#: static/js/impala/stats/csv_keys.js:269
+#: static/js/impala/stats/csv_keys.js:269 static/js/zamboni/stats-all.js:15550 static/js/zamboni/stats-min.js:5
 msgid "<b>{0}</b> in last {1} days"
 msgstr "最近 {1} 日間の <b>{0}</b>"
 
 #. L10n: {0} is an integer and {1} and {2} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:271 static/js/impala/stats/csv_keys.js:277
+#: static/js/impala/stats/csv_keys.js:271 static/js/impala/stats/csv_keys.js:277 static/js/zamboni/stats-all.js:15552 static/js/zamboni/stats-all.js:15558 static/js/zamboni/stats-min.js:5
 msgid "<b>{0}</b> from {1} to {2}"
 msgstr "{1} から {2} までの <b>{0}</b>"
 
 #. L10n: {0} and {1} are integers.
-#: static/js/impala/stats/csv_keys.js:275
+#: static/js/impala/stats/csv_keys.js:275 static/js/zamboni/stats-all.js:15556 static/js/zamboni/stats-min.js:5
 msgid "<b>{0}</b> average in last {1} days"
 msgstr "最近 {1} 日間の平均 <b>{0}</b>"
 
-#: static/js/impala/stats/overview.js:19
+#: static/js/impala/stats/overview.js:19 static/js/zamboni/stats-all.js:16469 static/js/zamboni/stats-min.js:5
 msgid "No data available."
 msgstr "表示できるデータがありません。"
 
-#: static/js/impala/stats/table.js:74
+#: static/js/impala/stats/table.js:74 static/js/zamboni/stats-all.js:17209 static/js/zamboni/stats-min.js:5
 msgid "Date"
 msgstr "日付"
 
-#: static/js/impala/stats/topchart.js:96
+#: static/js/impala/stats/topchart.js:96 static/js/zamboni/stats-all.js:16600 static/js/zamboni/stats-min.js:5
 msgid "Other"
 msgstr "その他"
 
-#: static/js/zamboni/admin_validation.js:24 static/js/zamboni/devhub.js:1229 static/js/zamboni/editors.js:295
+#: static/js/zamboni/admin-all.js:180 static/js/zamboni/admin-min.js:1 static/js/zamboni/admin_validation.js:24 static/js/zamboni/devhub-all.js:2408 static/js/zamboni/devhub-min.js:2
+#: static/js/zamboni/devhub.js:1229 static/js/zamboni/editors-all.js:15576 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:295
 msgid "Select an application first"
 msgstr "まずアプリケーションを選択してください"
 
-#: static/js/zamboni/admin_validation.js:51
+#: static/js/zamboni/admin-all.js:207 static/js/zamboni/admin-min.js:1 static/js/zamboni/admin_validation.js:51
 msgid "Set {0} add-on to a max version of {1} and email the author."
 msgid_plural "Set {0} add-ons to a max version of {1} and email the authors."
 msgstr[0] "{0} 個のアドオンの最高対応バージョンを {1} へ更新し、作者へメールを送ります。"
+msgstr[1] ""
 
-#: static/js/zamboni/admin_validation.js:54
+#: static/js/zamboni/admin-all.js:210 static/js/zamboni/admin-min.js:1 static/js/zamboni/admin_validation.js:54
 msgid "Email author of {2} add-on which failed validation."
 msgid_plural "Email authors of {2} add-ons which failed validation."
 msgstr[0] "検証をパスしなかった {2} 個のアドオンの作者へメールを送ります。"
+msgstr[1] ""
 
-#. L10n: {0} is an app name like Firefox.
-#: static/js/zamboni/buttons.js:66
-msgid "Accept and Install"
-msgstr "同意してインストール"
-
-#: static/js/zamboni/buttons.js:66
-msgid "Add to {0}"
-msgstr "{0} へ追加"
-
-#: static/js/zamboni/buttons.js:71
-msgid "Download Now"
-msgstr "今すぐダウンロード"
-
-#: static/js/zamboni/buttons.js:112
-msgid "Add-on has not been updated to support default-to-compatible."
-msgstr "アドオンが自動的に互換性を保つバージョンへ更新されていません。"
-
-#: static/js/zamboni/buttons.js:117
-msgid "You need to be using Firefox 10.0 or higher."
-msgstr "Firefox 10 以上のバージョンを使ってください。"
-
-#: static/js/zamboni/buttons.js:129
-msgid "Mozilla has marked this version as incompatible with your Firefox version."
-msgstr "このバージョンは、お使いの Firefox のバージョンと互換性がありません。"
-
-#. L10n: {0} is an platform like Windows or Linux.
-#: static/js/zamboni/buttons.js:210
-msgid "Install for {0} anyway"
-msgstr "{0} へ強制インストール"
-
-#: static/js/zamboni/buttons.js:210
-msgid "Download for {0} anyway"
-msgstr "{0} へ強制ダウンロード"
-
-#: static/js/zamboni/buttons.js:267
-msgid "Not available for your platform"
-msgstr "お使いの OS には対応していません"
-
-#. L10n: {0} is an app name, {1} is the app version.
-#: static/js/zamboni/buttons.js:278 static/js/zamboni/buttons.js:315
-msgid "Not available for {0} {1}"
-msgstr "{0} {1} には対応していません"
-
-#: static/js/zamboni/buttons.js:341
-msgid "Works with {app} {min} - {max}"
-msgstr "動作環境: {app} {min} - {max}"
-
-#: static/js/zamboni/buttons.js:343
-msgid "View other versions"
-msgstr "他のバージョンを見る"
-
-#: static/js/zamboni/buttons.js:391
-msgid "Only with Firefox — Get Firefox Now!"
-msgstr "Firefox 限定 — 今すぐ Firefox をダウンロード！"
-
-#: static/js/zamboni/buttons.js:507 static/js/zamboni/mobile/buttons.js:43
-msgid "Sorry, you need a Mozilla-based browser (such as Firefox) to install a search plugin."
-msgstr "申し訳ありませんが、検索プラグインをインストールするには (Firefox など) Mozilla ベースのブラウザが必要です。"
-
-#: static/js/zamboni/collections.js:229
-msgid "Adding to Favorites&hellip;"
-msgstr "お気に入りへ追加..."
-
-#: static/js/zamboni/collections.js:232
-msgid "Removing Favorite&hellip;"
-msgstr "お気に入りから削除..."
-
-#: static/js/zamboni/collections.js:235
-msgid "Add to Favorites"
-msgstr "お気に入りへ追加"
-
-#: static/js/zamboni/collections.js:238
-msgid "Remove from Favorites"
-msgstr "お気に入りから削除"
-
-#: static/js/zamboni/collections.js:303
-msgid "Pending"
-msgstr "保留中"
-
-#: static/js/zamboni/collections.js:304
-msgid "Add a comment"
-msgstr "コメントを追加"
-
-#: static/js/zamboni/collections.js:304
-msgid "Comment"
-msgstr "コメント"
-
-#: static/js/zamboni/collections.js:305
-msgid "Remove this add-on from the collection"
-msgstr "このアドオンをコレクションから削除"
-
-#: static/js/zamboni/collections.js:305 static/js/zamboni/collections.js:334
-msgid "Remove"
-msgstr "削除"
-
-#: static/js/zamboni/collections.js:334
-msgid "Remove this user as a contributor"
-msgstr "このユーザを貢献者から削除"
-
-#: static/js/zamboni/collections.js:346
-msgid "An email address is required."
-msgstr "メールアドレスを入力してください。"
-
-#: static/js/zamboni/collections.js:364
-msgid "You cannot add yourself as a contributor."
-msgstr "自分を貢献者として追加することはできません。"
-
-#: static/js/zamboni/collections.js:366
-msgid "You have already added that user."
-msgstr "このユーザはすでに追加されています。"
-
-#: static/js/zamboni/collections.js:573
-msgid "Add to favorites"
-msgstr "お気に入りへ追加"
-
-#: static/js/zamboni/collections.js:577
-msgid "Remove from favorites"
-msgstr "お気に入りから削除"
-
-#: static/js/zamboni/collections.js:604
-msgid "Stop following"
-msgstr "フォローをやめる"
-
-#: static/js/zamboni/devhub.js:110
+#: static/js/zamboni/devhub-all.js:1289 static/js/zamboni/devhub-min.js:1 static/js/zamboni/devhub.js:110
 msgid "Your browser does not support the video tag"
 msgstr "お使いのブラウザは video タグに対応していません"
 
-#: static/js/zamboni/devhub.js:371
+#: static/js/zamboni/devhub-all.js:1550 static/js/zamboni/devhub-min.js:1 static/js/zamboni/devhub.js:371
 msgid "Changes Saved"
 msgstr "変更が保存されました"
 
-#: static/js/zamboni/devhub.js:387
+#: static/js/zamboni/devhub-all.js:1566 static/js/zamboni/devhub-min.js:1 static/js/zamboni/devhub.js:387
 msgid "Enter a new author's email address"
 msgstr "新しい作者のメールアドレスを入力してください"
 
-#: static/js/zamboni/devhub.js:536
+#: static/js/zamboni/devhub-all.js:1715 static/js/zamboni/devhub-min.js:1 static/js/zamboni/devhub.js:536
 msgid "There was an error uploading your file."
 msgstr "ファイルのアップロード中にエラーが発生しました。"
 
-#: static/js/zamboni/devhub.js:681
+#: static/js/zamboni/devhub-all.js:1860 static/js/zamboni/devhub-min.js:1 static/js/zamboni/devhub.js:681
 msgid "{files} file"
 msgid_plural "{files} files"
 msgstr[0] "{files} 個のファイル"
+msgstr[1] ""
 
-#: static/js/zamboni/devhub.js:684
+#: static/js/zamboni/devhub-all.js:1863 static/js/zamboni/devhub-min.js:1 static/js/zamboni/devhub.js:684
 msgid "{reviews} user review"
 msgid_plural "{reviews} user reviews"
 msgstr[0] "{reviews} 件のユーザレビュー"
+msgstr[1] ""
 
-#: static/js/zamboni/devhub.js:796
+#: static/js/zamboni/devhub-all.js:1975 static/js/zamboni/devhub-min.js:2 static/js/zamboni/devhub.js:796
 msgid "Learn more"
 msgstr "詳細"
 
-#: static/js/zamboni/devhub.js:800
+#: static/js/zamboni/devhub-all.js:1979 static/js/zamboni/devhub-min.js:2 static/js/zamboni/devhub.js:800
 msgid "Example"
 msgstr "例"
 
-#: static/js/zamboni/devhub.js:1130
+#: static/js/zamboni/devhub-all.js:2309 static/js/zamboni/devhub-min.js:2 static/js/zamboni/devhub.js:1130
 msgid "Image changes being processed"
 msgstr "画像の変換処理を行っています"
 
-#: static/js/zamboni/devhub.js:1280
+#: static/js/zamboni/devhub-all.js:2459 static/js/zamboni/devhub-min.js:2 static/js/zamboni/devhub.js:1280
 msgid "Must be a valid e-mail address."
 msgstr "正しいメールアドレスを入力してください。"
+
+#: static/js/zamboni/devhub-all.js:2613 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:80
+msgid "All tests passed successfully."
+msgstr "すべてのテストに合格しました。"
+
+#: static/js/zamboni/devhub-all.js:2616 static/js/zamboni/devhub-all.js:3011 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:83 static/js/zamboni/validator.js:478
+msgid "These tests were not run."
+msgstr "これらのテストは実行されませんでした。"
+
+#: static/js/zamboni/devhub-all.js:2664 static/js/zamboni/devhub-all.js:2677 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:131 static/js/zamboni/validator.js:144
+msgid "Tests"
+msgstr "テスト"
+
+#: static/js/zamboni/devhub-all.js:2779 static/js/zamboni/devhub-all.js:3108 static/js/zamboni/devhub-all.js:3127 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:246
+#: static/js/zamboni/validator.js:575 static/js/zamboni/validator.js:594
+msgid "Error"
+msgstr "エラー"
+
+#: static/js/zamboni/devhub-all.js:2780 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:247
+msgid "Warning"
+msgstr "警告"
+
+#: static/js/zamboni/devhub-all.js:2794 static/js/zamboni/devhub-min.js:2 static/js/zamboni/files-all.js:5657 static/js/zamboni/files-min.js:3 static/js/zamboni/files.js:411
+#: static/js/zamboni/validator.js:261
+msgid "Ignore this message in future updates"
+msgstr "今後の更新でこのメッセージを無視する"
+
+#: static/js/zamboni/devhub-all.js:2817 static/js/zamboni/devhub-min.js:2 static/js/zamboni/files-all.js:5663 static/js/zamboni/files-min.js:3 static/js/zamboni/files.js:417
+#: static/js/zamboni/validator.js:284
+msgid "Severity for automated signing:"
+msgstr "自動署名の厳格さ:"
+
+#: static/js/zamboni/devhub-all.js:2832 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:299
+msgid "Suggestions for passing automated signing:"
+msgstr "自動署名をパスするための提案:"
+
+#: static/js/zamboni/devhub-all.js:2920 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:387
+msgid "Compatibility Tests"
+msgstr "互換性テスト"
+
+#: static/js/zamboni/devhub-all.js:2999 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:466
+msgid "Add-on failed validation."
+msgstr "アドオンは検証に失敗しました。"
+
+#: static/js/zamboni/devhub-all.js:3001 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:468
+msgid "Add-on passed validation."
+msgstr "アドオンは検証に合格しました。"
+
+#: static/js/zamboni/devhub-all.js:3014 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:481
+msgid "{0} error"
+msgid_plural "{0} errors"
+msgstr[0] "{0} 個のエラー"
+msgstr[1] ""
+
+#: static/js/zamboni/devhub-all.js:3016 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:483
+msgid "{0} warning"
+msgid_plural "{0} warnings"
+msgstr[0] "{0} 個の警告"
+msgstr[1] ""
+
+#: static/js/zamboni/devhub-all.js:3018 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:485
+msgid "{0} notice"
+msgid_plural "{0} notices"
+msgstr[0] "{0} 個の通知"
+msgstr[1] ""
+
+#: static/js/zamboni/devhub-all.js:3110 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:577
+msgid "Validation task could not complete or completed with errors"
+msgstr "検証作業を完了できなかったか、エラーを出力して完了しました"
+
+#: static/js/zamboni/devhub-all.js:3128 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:595
+msgid "Internal server error"
+msgstr "内部サーバエラー"
 
 #: static/js/zamboni/devhub_search.js:8
 msgid "No results found."
 msgstr "結果が見つかりませんでした。"
 
-#: static/js/zamboni/editors.js:121
+#: static/js/zamboni/editors-all.js:15402 static/js/zamboni/editors-min.js:4 static/js/zamboni/editors.js:121
 msgid "{name} was viewing this page first."
 msgstr "{name} が初めてこのページを見ました。"
 
-#: static/js/zamboni/editors.js:171
+#: static/js/zamboni/editors-all.js:15452 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:171
 msgid "Receipt checked by app."
 msgstr "レシートがアプリによって検証されました。"
 
-#: static/js/zamboni/editors.js:173
+#: static/js/zamboni/editors-all.js:15454 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:173
 msgid "Receipt was not checked by app."
 msgstr "レシートがアプリによって検証されませんでした。"
 
-#: static/js/zamboni/editors.js:244
+#: static/js/zamboni/editors-all.js:15525 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:244
 msgid "{name} was viewing this add-on first."
 msgstr "{name} が初めてこのアドオンを見ました。"
 
-#: static/js/zamboni/editors.js:255
+#: static/js/zamboni/editors-all.js:15536 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:255
 msgid "Loading&hellip;"
 msgstr "読み込み中..."
 
-#: static/js/zamboni/editors.js:260
+#: static/js/zamboni/editors-all.js:15541 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:260
 msgid "Version Notes"
 msgstr "リリースノート"
 
-#: static/js/zamboni/editors.js:265
+#: static/js/zamboni/editors-all.js:15546 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:265
 msgid "Notes for Reviewers"
 msgstr "審査担当者へのメモ"
 
-#: static/js/zamboni/editors.js:270
+#: static/js/zamboni/editors-all.js:15551 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:270
 msgid "No version notes found"
 msgstr "リリースノートはありません"
 
-#: static/js/zamboni/editors.js:330
+#: static/js/zamboni/editors-all.js:15611 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:330
 msgid "Average Reviews"
 msgstr "レビュー平均"
 
-#: static/js/zamboni/editors.js:386
+#: static/js/zamboni/editors-all.js:15667 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:386
 msgid "Number of Reviews"
 msgstr "レビュー数"
 
-#: static/js/zamboni/editors.js:445
+#: static/js/zamboni/editors-all.js:15726 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:445
 msgid "Error loading translation"
 msgstr "翻訳読み込みエラー"
 
-#: static/js/zamboni/files.js:411 static/js/zamboni/validator.js:261
-msgid "Ignore this message in future updates"
-msgstr "今後の更新でこのメッセージを無視する"
-
-#: static/js/zamboni/files.js:417 static/js/zamboni/validator.js:284
-msgid "Severity for automated signing:"
-msgstr "自動署名の厳格さ:"
-
-#: static/js/zamboni/global.js:410
-msgid "Loading..."
-msgstr "読み込み中..."
-
-#. L10n: {0} is the number of characters left.
-#: static/js/zamboni/global.js:474
-msgid "<b>{0}</b> character left."
-msgid_plural "<b>{0}</b> characters left."
-msgstr[0] "残り <b>{0}</b> 文字です。"
-
-#: static/js/zamboni/init.js:28
-msgid "This feature is temporarily disabled while we perform website maintenance. Please check back a little later."
-msgstr "この機能はサイトメンテナンスのため一時的に無効になっています。また後で試してください。"
-
-#: static/js/zamboni/l10n.js:45
-msgid "Remove this localization"
-msgstr "このローカライズを削除"
-
-#: static/js/zamboni/password-strength.js:20
-msgid "Password strength:"
-msgstr "パスワードの強度:"
-
-#: static/js/zamboni/password-strength.js:26
-msgid "At least {0} character left."
-msgid_plural "At least {0} characters left."
-msgstr[0] "あと {0} 文字以上入力してください。"
-
-#: static/js/zamboni/themes_review.js:176
-msgid "Requested Info"
-msgstr "求められている情報"
-
-#: static/js/zamboni/themes_review.js:177
-msgid "Flagged"
-msgstr "フラグ付き"
-
-#: static/js/zamboni/themes_review.js:178
-msgid "Duplicate"
-msgstr "重複"
-
-#: static/js/zamboni/themes_review.js:179
-msgid "Rejected"
-msgstr "却下済み"
-
-#: static/js/zamboni/themes_review.js:180
-msgid "Approved"
-msgstr "承認済み"
-
-#: static/js/zamboni/themes_review.js:424
-msgid "No results found"
-msgstr "結果なし"
-
-#: static/js/zamboni/themes_review_templates.js:31
+#: static/js/zamboni/editors-all.js:15975 static/js/zamboni/editors-min.js:5 static/js/zamboni/themes_review_templates.js:31
 msgid "Theme"
 msgstr "テーマ"
 
-#: static/js/zamboni/themes_review_templates.js:33
+#: static/js/zamboni/editors-all.js:15977 static/js/zamboni/editors-min.js:5 static/js/zamboni/themes_review_templates.js:33
 msgid "Reviewer"
 msgstr "レビュー担当者"
 
-#: static/js/zamboni/themes_review_templates.js:35
+#: static/js/zamboni/editors-all.js:15979 static/js/zamboni/editors-min.js:5 static/js/zamboni/themes_review_templates.js:35
 msgid "Status"
 msgstr "ステータス"
 
-#: static/js/zamboni/validator.js:80
-msgid "All tests passed successfully."
-msgstr "すべてのテストに合格しました。"
+#: static/js/zamboni/editors-all.js:16196 static/js/zamboni/editors-min.js:5 static/js/zamboni/themes_review.js:176
+msgid "Requested Info"
+msgstr "求められている情報"
 
-#: static/js/zamboni/validator.js:83 static/js/zamboni/validator.js:478
-msgid "These tests were not run."
-msgstr "これらのテストは実行されませんでした。"
+#: static/js/zamboni/editors-all.js:16197 static/js/zamboni/editors-min.js:5 static/js/zamboni/themes_review.js:177
+msgid "Flagged"
+msgstr "フラグ付き"
 
-#: static/js/zamboni/validator.js:131 static/js/zamboni/validator.js:144
-msgid "Tests"
-msgstr "テスト"
+#: static/js/zamboni/editors-all.js:16198 static/js/zamboni/editors-min.js:5 static/js/zamboni/themes_review.js:178
+msgid "Duplicate"
+msgstr "重複"
 
-#: static/js/zamboni/validator.js:246 static/js/zamboni/validator.js:575 static/js/zamboni/validator.js:594
-msgid "Error"
-msgstr "エラー"
+#: static/js/zamboni/editors-all.js:16199 static/js/zamboni/editors-min.js:5 static/js/zamboni/themes_review.js:179
+msgid "Rejected"
+msgstr "却下済み"
 
-#: static/js/zamboni/validator.js:247
-msgid "Warning"
-msgstr "警告"
+#: static/js/zamboni/editors-all.js:16200 static/js/zamboni/editors-min.js:5 static/js/zamboni/themes_review.js:180
+msgid "Approved"
+msgstr "承認済み"
 
-#: static/js/zamboni/validator.js:299
-msgid "Suggestions for passing automated signing:"
-msgstr "自動署名をパスするための提案:"
+#: static/js/zamboni/editors-all.js:16444 static/js/zamboni/editors-min.js:5 static/js/zamboni/themes_review.js:424
+msgid "No results found"
+msgstr "結果なし"
 
-#: static/js/zamboni/validator.js:387
-msgid "Compatibility Tests"
-msgstr "互換性テスト"
-
-#: static/js/zamboni/validator.js:466
-msgid "Add-on failed validation."
-msgstr "アドオンは検証に失敗しました。"
-
-#: static/js/zamboni/validator.js:468
-msgid "Add-on passed validation."
-msgstr "アドオンは検証に合格しました。"
-
-#: static/js/zamboni/validator.js:481
-msgid "{0} error"
-msgid_plural "{0} errors"
-msgstr[0] "{0} 個のエラー"
-
-#: static/js/zamboni/validator.js:483
-msgid "{0} warning"
-msgid_plural "{0} warnings"
-msgstr[0] "{0} 個の警告"
-
-#: static/js/zamboni/validator.js:485
-msgid "{0} notice"
-msgid_plural "{0} notices"
-msgstr[0] "{0} 個の通知"
-
-#: static/js/zamboni/validator.js:577
-msgid "Validation task could not complete or completed with errors"
-msgstr "検証作業を完了できなかったか、エラーを出力して完了しました"
-
-#: static/js/zamboni/validator.js:595
-msgid "Internal server error"
-msgstr "内部サーバエラー"
-
-#: static/js/zamboni/mobile/buttons.js:52
+#: static/js/zamboni/mobile-all.js:15186 static/js/zamboni/mobile/buttons.js:52
 msgid "Not Updated for {0} {1}"
 msgstr "まだ {0} {1} には対応していません"
 
-#: static/js/zamboni/mobile/buttons.js:53
+#: static/js/zamboni/mobile-all.js:15187 static/js/zamboni/mobile/buttons.js:53
 msgid "Requires Newer Version of {0}"
 msgstr "{0} の新バージョンが必要です"
 
-#: static/js/zamboni/mobile/buttons.js:54
+#: static/js/zamboni/mobile-all.js:15188 static/js/zamboni/mobile/buttons.js:54
 msgid "Unreviewed"
 msgstr "未審査"
 
-#: static/js/zamboni/mobile/buttons.js:55
+#: static/js/zamboni/mobile-all.js:15189 static/js/zamboni/mobile/buttons.js:55
 msgid "Experimental <span>(Learn More)</span>"
 msgstr "実験的 <span>(詳細)</span>"
 
-#: static/js/zamboni/mobile/buttons.js:56 static/js/zamboni/mobile/buttons.js:57
+#: static/js/zamboni/mobile-all.js:15190 static/js/zamboni/mobile-all.js:15191 static/js/zamboni/mobile/buttons.js:56 static/js/zamboni/mobile/buttons.js:57
 msgid "Not Available for {0}"
 msgstr "{0} には対応していません"
 
-#: static/js/zamboni/mobile/buttons.js:58
+#: static/js/zamboni/mobile-all.js:15192 static/js/zamboni/mobile/buttons.js:58
 msgid "Experimental"
 msgstr "実験的"
 
-#: static/js/zamboni/mobile/buttons.js:59
+#: static/js/zamboni/mobile-all.js:15193 static/js/zamboni/mobile/buttons.js:59
 msgid "Themes Require Newer Version of {0}"
 msgstr "このテーマを使うには {0} の新バージョンが必要です"
 
-#: static/js/zamboni/mobile/buttons.js:60
+#: static/js/zamboni/mobile-all.js:15194 static/js/zamboni/mobile/buttons.js:60
 msgid "Themes Require {0}"
 msgstr "このテーマを使うには {0} が必要です"
 
-#: static/js/zamboni/mobile/buttons.js:105
+#: static/js/zamboni/mobile-all.js:15239 static/js/zamboni/mobile/buttons.js:105
 msgid "Installing..."
 msgstr "インストール中..."
 
-#: static/js/zamboni/mobile/buttons.js:125
+#: static/js/zamboni/mobile-all.js:15259 static/js/zamboni/mobile/buttons.js:125
 msgid "This add-on has been preliminarily reviewed by Mozilla."
 msgstr "このアドオンは Mozilla の事前審査を受けています。"
 
-#: static/js/zamboni/mobile/buttons.js:250
+#: static/js/zamboni/mobile-all.js:15384 static/js/zamboni/mobile/buttons.js:250
 msgid "Keep it"
 msgstr "適用"
 
-#: static/js/zamboni/mobile/general.js:344
+#: static/js/zamboni/mobile-all.js:16049 static/js/zamboni/mobile-min.js:6 static/js/zamboni/mobile/general.js:344
 msgid "You're trying it on!"
 msgstr "テーマをプレビューしています"
 
-#: static/js/zamboni/mobile/general.js:356
+#: static/js/zamboni/mobile-all.js:16061 static/js/zamboni/mobile-min.js:6 static/js/zamboni/mobile/general.js:356
 msgid "Added to Firefox"
 msgstr "Firefox へ適用済み"
-

--- a/locale/ka/LC_MESSAGES/django.po
+++ b/locale/ka/LC_MESSAGES/django.po
@@ -1,82 +1,74 @@
-# 
+#
 #, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2016-02-24 21:23+0000\n"
-"PO-Revision-Date: 2016-04-18 22:53+0000\n"
+"POT-Creation-Date: 2016-04-18 15:47+0000\n"
+"PO-Revision-Date: 2016-04-18 12:50+0000\n"
 "Last-Translator: ბექა არაბული <arabulibeqa@yahoo.com>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
-"Language: ka\n"
+"Language: \n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=1; plural=0;\n"
-"X-Generator: Pontoon\n"
+"Generated-By: Babel 2.2.0\n"
 
-#: src/olympia/accounts/views.py:52
+#: src/olympia/accounts/views.py:54
 msgid "Your log in attempt could not be parsed. Please try again."
 msgstr "თქვენი შესვლის მცდელობა ვერ გაანალიზდა. გთხოვთ, ცადეთ ხელახლა."
 
-#: src/olympia/accounts/views.py:54
+#: src/olympia/accounts/views.py:56
 msgid "Your Firefox Account could not be found. Please try again."
 msgstr "თქვენი Firefox ანგარიში ვერ მოიძებნა. გთხოვთ, ცადეთ ხელახლა."
 
-#: src/olympia/accounts/views.py:55
+#: src/olympia/accounts/views.py:57
 msgid "You could not be logged in. Please try again."
 msgstr "შესვლა ვერ მოხერხდა. გთხოვთ, ცადეთ ხელახლა."
 
-#: src/olympia/accounts/views.py:57
+#: src/olympia/accounts/views.py:59
 msgid "Your account has already been migrated to Firefox Accounts."
 msgstr "თქვენი ანგარიში უკვე გადავიდა Firefox ანგარიშებში."
 
-#: src/olympia/accounts/views.py:59
+#: src/olympia/accounts/views.py:61
 msgid "Your Firefox Account already exists on this site."
 msgstr "თქვენი Firefox ანგარიში ამ საიტზე უკვე არსებობს."
 
-#: src/olympia/accounts/views.py:108
+#: src/olympia/accounts/views.py:110
 msgid "Great job!"
 msgstr "ყოჩაღ!"
 
-#: src/olympia/accounts/views.py:109
+#: src/olympia/accounts/views.py:111
 msgid "You can now log in to Add-ons with your Firefox Account."
 msgstr "ახლა დამატებებში შესვლა თქვენი Firefox ანგარიშით შეგიძლიათ."
 
-#: src/olympia/accounts/views.py:121
+#: src/olympia/accounts/views.py:123
 msgid "Need help?"
 msgstr "გესაჭირეობათ დახმარება?"
 
-#: src/olympia/addons/buttons.py:180
+#: src/olympia/addons/buttons.py:177
 msgid "Download Now"
 msgstr "ჩამოტვირთეთ ახლავე"
 
-#: src/olympia/addons/buttons.py:182
+#: src/olympia/addons/buttons.py:179
 msgid "Download"
 msgstr "ჩამოტვირთვა"
 
 #. L10n: please keep &nbsp; in the string so &rarr; does not wrap.
-#: src/olympia/addons/buttons.py:186
+#: src/olympia/addons/buttons.py:183
 msgid "Continue to Download&nbsp;&rarr;"
 msgstr "&nbsp;&rarr;-ის ჩამოტვირთვის გაგრძელება"
 
-#: src/olympia/addons/buttons.py:202 src/olympia/addons/helpers.py:35
-#: src/olympia/addons/views.py:319
-#: src/olympia/addons/templates/addons/impala/details.html:114
-#: src/olympia/addons/templates/addons/impala/listing/items.html:17
-#: src/olympia/addons/templates/addons/mobile/home.html:40
-#: src/olympia/amo/templates/amo/side_nav.html:6
-#: src/olympia/amo/templates/amo/side_nav.html:10
-#: src/olympia/amo/templates/amo/site_nav.html:2
-#: src/olympia/amo/templates/amo/site_nav.html:55
-#: src/olympia/bandwagon/views.py:95 src/olympia/browse/views.py:54
-#: src/olympia/browse/views.py:68 src/olympia/browse/views.py:235
-#: src/olympia/browse/templates/browse/impala/category_landing.html:22
+#: src/olympia/addons/buttons.py:199 src/olympia/addons/helpers.py:35 src/olympia/addons/views.py:333 src/olympia/addons/templates/addons/impala/details.html:111
+#: src/olympia/addons/templates/addons/impala/listing/items.html:17 src/olympia/addons/templates/addons/mobile/home.html:40 src/olympia/amo/templates/amo/side_nav.html:6
+#: src/olympia/amo/templates/amo/side_nav.html:10 src/olympia/amo/templates/amo/site_nav.html:2 src/olympia/amo/templates/amo/site_nav.html:53 src/olympia/bandwagon/views.py:95
+#: src/olympia/browse/views.py:54 src/olympia/browse/views.py:68 src/olympia/browse/views.py:202 src/olympia/browse/templates/browse/impala/category_landing.html:22
 #: src/olympia/browse/templates/browse/personas/mobile/category_landing.html:26
 msgid "Featured"
 msgstr "რეკომენდებული"
 
-#: src/olympia/addons/buttons.py:221
+#: src/olympia/addons/buttons.py:218
 msgid "Add to {0}"
 msgstr "{0}-ში დამატება"
 
@@ -98,73 +90,65 @@ msgstr "იდენტიფიკატორი ვერ იქნება 
 msgid "Invalid tag: {0}"
 msgid_plural "Invalid tags: {0}"
 msgstr[0] "არასწორი იარლიყი: {0}"
+msgstr[1] ""
 
 #. L10n: {0} is a single tag or a comma-separated list of tags.
 #: src/olympia/addons/forms.py:103
 msgid "\"{0}\" is a reserved tag and cannot be used."
 msgid_plural "\"{0}\" are reserved tags and cannot be used."
 msgstr[0] "\"{0}\" დაკავებული იარლიყია და მისი გამოყენება არ შეიძლება."
+msgstr[1] ""
 
 #: src/olympia/addons/forms.py:111
 msgid "You have {0} too many tags."
 msgid_plural "You have {0} too many tags."
 msgstr[0] "თქვენ {0}-ით მეტი იარლიყი გაქვთ."
+msgstr[1] ""
 
 #: src/olympia/addons/forms.py:117
 #, python-format
-msgid ""
-"All tags must be %s characters or less after invalid characters are removed."
-msgstr ""
-"შეუსატყვისი ასოების მოშორების შემდეგ ყველა იარლიყი %s ან ნაკლები ასოსგან "
-"უნდა შედგებოდეს"
+msgid "All tags must be %s characters or less after invalid characters are removed."
+msgstr "შეუსატყვისი ასოების მოშორების შემდეგ ყველა იარლიყი %s ან ნაკლები ასოსგან უნდა შედგებოდეს"
 
 #: src/olympia/addons/forms.py:121
 msgid "All tags must be at least {0} character."
 msgid_plural "All tags must be at least {0} characters."
 msgstr[0] "ყველა იარლიყი მინიმუმ {0} ასოსგან უნდა შედგებოდეს."
+msgstr[1] ""
 
-#: src/olympia/addons/forms.py:234
-msgid ""
-"Categories cannot be changed while your add-on is featured for this "
-"application."
-msgstr ""
-"თქვენი დამატების ამ განაცხადში ყოფნისას კატეგორიის შეცვლა შეუძლებელია."
+#: src/olympia/addons/forms.py:238
+msgid "Categories cannot be changed while your add-on is featured for this application."
+msgstr "თქვენი დამატების ამ განაცხადში ყოფნისას კატეგორიის შეცვლა შეუძლებელია."
 
 #. L10n: {0} is the number of categories.
-#: src/olympia/addons/forms.py:238
+#: src/olympia/addons/forms.py:242
 msgid "You can have only {0} category."
 msgid_plural "You can have only {0} categories."
 msgstr[0] "თქვენ მხოლოდ {0} კატეგორია გაქვთ."
+msgstr[1] ""
 
-#: src/olympia/addons/forms.py:246
-msgid ""
-"The miscellaneous category cannot be combined with additional categories."
-msgstr ""
-"სხვადასხვა კატეგორიის დამატებით კატეგორიებთან გაერთიანება შეუძლებელია."
+#: src/olympia/addons/forms.py:250
+msgid "The miscellaneous category cannot be combined with additional categories."
+msgstr "სხვადასხვა კატეგორიის დამატებით კატეგორიებთან გაერთიანება შეუძლებელია."
 
-#: src/olympia/addons/forms.py:369
+#: src/olympia/addons/forms.py:374
 #, python-format
-msgid ""
-"Before changing your default locale you must have a name, summary, and "
-"description in that locale. You are missing %s."
-msgstr ""
-"ნაგულისხმევი ლოკალის შეცვლამდე, სახელი, შეჯამება და აღწერა ამ ლოკალზე უნდა "
-"გქონდეთ. ახლა გაკლიათ %s."
+msgid "Before changing your default locale you must have a name, summary, and description in that locale. You are missing %s."
+msgstr "ნაგულისხმევი ლოკალის შეცვლამდე, სახელი, შეჯამება და აღწერა ამ ლოკალზე უნდა გქონდეთ. ახლა გაკლიათ %s."
 
-#: src/olympia/addons/forms.py:484 src/olympia/addons/forms.py:575
+#: src/olympia/addons/forms.py:455 src/olympia/addons/forms.py:546
 msgid "A license must be selected."
 msgstr "ლიცენზიის არჩევა აუცილებელია."
 
-#: src/olympia/addons/forms.py:556
+#: src/olympia/addons/forms.py:527
 msgid "Give Your Theme a Name."
 msgstr "დაარქვით თემას სახელი."
 
-#: src/olympia/addons/forms.py:562
-#: src/olympia/devhub/templates/devhub/personas/submit.html:53
+#: src/olympia/addons/forms.py:533 src/olympia/devhub/templates/devhub/personas/submit.html:53
 msgid "Describe your Theme."
 msgstr "აღწერეთ თქვენი თემა."
 
-#: src/olympia/addons/forms.py:704
+#: src/olympia/addons/forms.py:675
 msgid "Enter a new author's email address"
 msgstr "შეიყვანეთ ავტორის ახალი ელ-ფოსტის მისამართი"
 
@@ -172,45 +156,37 @@ msgstr "შეიყვანეთ ავტორის ახალი ელ
 msgid "Not Reviewed"
 msgstr "განუხილველია"
 
-#: src/olympia/addons/models.py:301
+#: src/olympia/addons/models.py:298
 msgid "Users have the option of contributing more or less than this amount."
-msgstr ""
-"მომხმარებლებს შეუძლიათ ამ რაოდენობაზე მეტი ან ნაკლები თანხის შემოწირვა."
+msgstr "მომხმარებლებს შეუძლიათ ამ რაოდენობაზე მეტი ან ნაკლები თანხის შემოწირვა."
 
-#: src/olympia/addons/models.py:309
-msgid ""
-"Users will always be asked in the Add-ons Manager (Firefox 4 and above)"
+#: src/olympia/addons/models.py:306
+msgid "Users will always be asked in the Add-ons Manager (Firefox 4 and above). Only applies to desktop."
 msgstr ""
 
-#: src/olympia/addons/models.py:1804
-#: src/olympia/addons/templates/addons/details_box.html:55
-#: src/olympia/devhub/templates/devhub/index.html:92
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:102
+#: src/olympia/addons/models.py:1802 src/olympia/addons/templates/addons/details_box.html:55 src/olympia/devhub/templates/devhub/index.html:92
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:89
 msgid "Listed"
 msgstr "სიაშია"
 
-#: src/olympia/addons/views.py:320
-#: src/olympia/browse/templates/browse/personas/mobile/category_landing.html:27
+#: src/olympia/addons/views.py:334 src/olympia/browse/templates/browse/personas/mobile/category_landing.html:27
 msgid "Popular"
 msgstr "პოპულარული"
 
-#: src/olympia/addons/views.py:321 src/olympia/browse/views.py:238
-#: src/olympia/browse/views.py:280 src/olympia/browse/views.py:482
+#: src/olympia/addons/views.py:335 src/olympia/browse/views.py:205 src/olympia/browse/views.py:247 src/olympia/browse/views.py:449
 msgid "Recently Added"
 msgstr "ბოლოს დამატებული"
 
-#: src/olympia/addons/views.py:322 src/olympia/bandwagon/views.py:99
-#: src/olympia/browse/views.py:60 src/olympia/browse/views.py:71
-#: src/olympia/search/forms.py:16 src/olympia/search/forms.py:91
+#: src/olympia/addons/views.py:336 src/olympia/bandwagon/views.py:99 src/olympia/browse/views.py:60 src/olympia/browse/views.py:71 src/olympia/search/forms.py:16 src/olympia/search/forms.py:91
 msgid "Recently Updated"
 msgstr "ბოლოს განახლებული"
 
 #. l10n: {0} is the addon name
-#: src/olympia/addons/views.py:520
+#: src/olympia/addons/views.py:534
 msgid "Contribution for {0}"
 msgstr "{0}-სთვის შემომწირველი"
 
-#: src/olympia/addons/views.py:613
+#: src/olympia/addons/views.py:627
 msgid "Abuse reported."
 msgstr "შეტყობინება უკანონოდ გამოყენების შესახებ."
 
@@ -218,116 +194,68 @@ msgstr "შეტყობინება უკანონოდ გამო�
 msgid "My add-on doesn't fit into any of the categories"
 msgstr "ჩემი დამატება არცერთ კატეგორიას არ შეესაბამება"
 
-#: src/olympia/addons/templates/addons/button.html:27
-#: src/olympia/addons/templates/addons/impala/button.html:11
-#: src/olympia/addons/templates/addons/mobile/button.html:11
+#: src/olympia/addons/templates/addons/button.html:27 src/olympia/addons/templates/addons/impala/button.html:11 src/olympia/addons/templates/addons/mobile/button.html:11
 msgid "No compatible versions"
 msgstr "თავსებადი ვერსიები არაა"
 
-#: src/olympia/addons/templates/addons/button.html:35
-#: src/olympia/addons/templates/addons/impala/button.html:19
+#: src/olympia/addons/templates/addons/button.html:35 src/olympia/addons/templates/addons/impala/button.html:19
 msgid "Added to Mobile"
 msgstr "დამატებულია ტელეფონში"
 
-#: src/olympia/addons/templates/addons/button.html:37
-#: src/olympia/addons/templates/addons/impala/button.html:21
+#: src/olympia/addons/templates/addons/button.html:37 src/olympia/addons/templates/addons/impala/button.html:21
 msgid "Add to Mobile"
 msgstr "ტელეფონში დამატება"
 
 #. {0} is a platform name like Windows or Mac OS X.
-#: src/olympia/addons/templates/addons/button.html:66
-#: src/olympia/addons/templates/addons/includes/install_button.html:19
+#: src/olympia/addons/templates/addons/button.html:66 src/olympia/addons/templates/addons/includes/install_button.html:19
 msgid "for {0}"
 msgstr "{0} -სთვის"
 
-#: src/olympia/addons/templates/addons/button.html:82
-#: src/olympia/addons/templates/addons/mobile/button.html:23
+#: src/olympia/addons/templates/addons/button.html:82 src/olympia/addons/templates/addons/mobile/button.html:23
 msgid "View privacy policy"
 msgstr "პრივატულობის პოლიტიკის ნახვა"
 
-#: src/olympia/addons/templates/addons/button.html:87
-#: src/olympia/addons/templates/addons/details_box.html:133
-#: src/olympia/addons/templates/addons/mobile/button.html:28
+#: src/olympia/addons/templates/addons/button.html:87 src/olympia/addons/templates/addons/details_box.html:133 src/olympia/addons/templates/addons/mobile/button.html:28
 #: src/olympia/discovery/templates/discovery/addons/detail.html:28
 msgid "View End-User License Agreement"
 msgstr "მომხმარებლის სალიცენზიო შეთანხმების ნახვა"
 
-#: src/olympia/addons/templates/addons/button.html:92
-#: src/olympia/addons/templates/addons/impala/button.html:54
+#: src/olympia/addons/templates/addons/button.html:92 src/olympia/addons/templates/addons/impala/button.html:54
 #, python-format
-msgid ""
-"This add-on has not been reviewed by Mozilla. <a href=\"%(url)s\">Learn "
-"more</a>"
-msgstr ""
-"ეს დამატება არ არის განხილული Mozilla-ს მიერ. <a "
-"href=\"%(url)s\">დაწვრილებით</a>"
+msgid "This add-on has not been reviewed by Mozilla. <a href=\"%(url)s\">Learn more</a>"
+msgstr "ეს დამატება არ არის განხილული Mozilla-ს მიერ. <a href=\"%(url)s\">დაწვრილებით</a>"
 
-#: src/olympia/addons/templates/addons/button.html:97
-#: src/olympia/addons/templates/addons/impala/button.html:60
+#: src/olympia/addons/templates/addons/button.html:97 src/olympia/addons/templates/addons/impala/button.html:60
 #, python-format
-msgid ""
-"This add-on has been preliminarily reviewed by Mozilla. <a "
-"href=\"%(url)s\">Learn more</a>"
-msgstr ""
-"ამ დამატებამ Mozilla-ს წინასწარი განხილვა გაიარა. <a "
-"href=\"%(url)s\">შეიტყვეთ მეტი</a>"
+msgid "This add-on has been preliminarily reviewed by Mozilla. <a href=\"%(url)s\">Learn more</a>"
+msgstr "ამ დამატებამ Mozilla-ს წინასწარი განხილვა გაიარა. <a href=\"%(url)s\">შეიტყვეთ მეტი</a>"
 
-#: src/olympia/addons/templates/addons/contribution.html:11
-#: src/olympia/addons/templates/addons/impala/developers.html:44
-msgid ""
-"The developer of this add-on asks that you help support its continued "
-"development by making a small contribution."
-msgstr ""
-"ამ დამატების შემქმნელი ნასიამოვნები დარჩება, თუ მისი დეველოპმენტისთვის "
-"მხარის დასაჭერად მცირე წვლილს შეიტანთ."
+#: src/olympia/addons/templates/addons/contribution.html:11 src/olympia/addons/templates/addons/impala/developers.html:44
+msgid "The developer of this add-on asks that you help support its continued development by making a small contribution."
+msgstr "ამ დამატების შემქმნელი ნასიამოვნები დარჩება, თუ მისი დეველოპმენტისთვის მხარის დასაჭერად მცირე წვლილს შეიტანთ."
 
 #: src/olympia/addons/templates/addons/contribution.html:14
 #, python-format
-msgid ""
-"The developer of this add-on asks that you show your support by making a "
-"donation to the <a href=\"%(charity_url)s\">%(charity_name)s</a>."
-msgstr ""
-"ამ დამატების შემქმნელი ნასიამოვნები დარჩება, თუ თქვენს მხარდაჭერას ამ "
-"ორგანიზაციებში მცირე შეწირულობის გაკეთებით გამოხატავთ  <a "
-"href=\"%(charity_url)s\">%(charity_name)s</a>."
+msgid "The developer of this add-on asks that you show your support by making a donation to the <a href=\"%(charity_url)s\">%(charity_name)s</a>."
+msgstr "ამ დამატების შემქმნელი ნასიამოვნები დარჩება, თუ თქვენს მხარდაჭერას ამ ორგანიზაციებში მცირე შეწირულობის გაკეთებით გამოხატავთ  <a href=\"%(charity_url)s\">%(charity_name)s</a>."
 
 #: src/olympia/addons/templates/addons/contribution.html:19
 #, python-format
-msgid ""
-"The developer of this add-on asks that you show your support by making a "
-"small contribution to <a href=\"%(charity_url)s\">%(charity_name)s</a>."
-msgstr ""
-"ამ დამატების შემქმნელი ნასიამოვნები დარჩება, თუ თქვენს მხარდაჭერას ამ "
-"ორგანიზაციებში მცირე წვლილის შეტანით  გამოხატავთ <a "
-"href=\"%(charity_url)s\">%(charity_name)s</a>."
+msgid "The developer of this add-on asks that you show your support by making a small contribution to <a href=\"%(charity_url)s\">%(charity_name)s</a>."
+msgstr "ამ დამატების შემქმნელი ნასიამოვნები დარჩება, თუ თქვენს მხარდაჭერას ამ ორგანიზაციებში მცირე წვლილის შეტანით  გამოხატავთ <a href=\"%(charity_url)s\">%(charity_name)s</a>."
 
-#: src/olympia/addons/templates/addons/contribution.html:30
-#: src/olympia/addons/templates/addons/impala/contribution.html:18
-#: src/olympia/templates/menu_links.html:25
+#: src/olympia/addons/templates/addons/contribution.html:30 src/olympia/addons/templates/addons/impala/contribution.html:18 src/olympia/templates/menu_links.html:25
 msgid "Contribute"
 msgstr "ხელის შეწყობა"
 
 #. Click Contribute button OR Install button
-#: src/olympia/addons/templates/addons/contribution.html:34
-#: src/olympia/addons/templates/addons/report_abuse.html:26
-#: src/olympia/addons/templates/addons/impala/contribution.html:32
-#: src/olympia/devhub/templates/devhub/addons/ajax_compat_update.html:36
-#: src/olympia/devhub/templates/devhub/addons/profile.html:44
-#: src/olympia/devhub/templates/devhub/addons/edit/admin.html:101
-#: src/olympia/devhub/templates/devhub/addons/edit/basic.html:152
-#: src/olympia/devhub/templates/devhub/addons/edit/details.html:85
-#: src/olympia/devhub/templates/devhub/addons/edit/support.html:67
-#: src/olympia/devhub/templates/devhub/addons/edit/technical.html:166
-#: src/olympia/devhub/templates/devhub/addons/forms_shared/media.html:149
-#: src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:44
-#: src/olympia/devhub/templates/devhub/versions/add_file_modal.html:78
-#: src/olympia/devhub/templates/devhub/versions/edit.html:139
-#: src/olympia/devhub/templates/devhub/versions/list.html:242
-#: src/olympia/devhub/templates/devhub/versions/list.html:276
-#: src/olympia/devhub/templates/devhub/versions/list.html:317
-#: src/olympia/devhub/templates/devhub/versions/list.html:351
-#: src/olympia/reviews/templates/reviews/edit_review.html:16
-#: src/olympia/translations/templates/translations/trans-menu.html:50
+#: src/olympia/addons/templates/addons/contribution.html:34 src/olympia/addons/templates/addons/report_abuse.html:26 src/olympia/addons/templates/addons/impala/contribution.html:32
+#: src/olympia/devhub/templates/devhub/addons/ajax_compat_update.html:36 src/olympia/devhub/templates/devhub/addons/profile.html:44 src/olympia/devhub/templates/devhub/addons/edit/admin.html:101
+#: src/olympia/devhub/templates/devhub/addons/edit/basic.html:152 src/olympia/devhub/templates/devhub/addons/edit/details.html:85 src/olympia/devhub/templates/devhub/addons/edit/support.html:67
+#: src/olympia/devhub/templates/devhub/addons/edit/technical.html:166 src/olympia/devhub/templates/devhub/addons/forms_shared/media.html:149
+#: src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:43 src/olympia/devhub/templates/devhub/versions/add_file_modal.html:58 src/olympia/devhub/templates/devhub/versions/edit.html:139
+#: src/olympia/devhub/templates/devhub/versions/list.html:239 src/olympia/devhub/templates/devhub/versions/list.html:281 src/olympia/devhub/templates/devhub/versions/list.html:315
+#: src/olympia/devhub/templates/devhub/versions/list.html:349 src/olympia/reviews/templates/reviews/edit_review.html:16 src/olympia/translations/templates/translations/trans-menu.html:50
 #: src/olympia/translations/templates/translations/trans-menu.html:62
 msgid "or"
 msgstr "ან"
@@ -336,40 +264,23 @@ msgstr "ან"
 msgid "Suggested Contribution: {0}"
 msgstr "შემოთავაზებული შემოწირულობა: %S"
 
-#: src/olympia/addons/templates/addons/contribution.html:48
-#: src/olympia/amo/templates/amo/recaptcha.html:5
-#: src/olympia/versions/templates/versions/version.html:52
+#: src/olympia/addons/templates/addons/contribution.html:48 src/olympia/amo/templates/amo/recaptcha.html:5 src/olympia/versions/templates/versions/version.html:52
 msgid "What's this?"
 msgstr "რა არის ეს?"
 
 #: src/olympia/addons/templates/addons/contribution.html:63
 #, python-format
-msgid ""
-"The developer of this add-on would like you to consider making a donation to"
-" the <a href=\"%(charity_url)s\">%(charity_name)s</a> if you enjoy using it."
-msgstr ""
-"ამ დამატების შემქმნელი ნასიამოვნები დარჩება. თუ ამ ორგანიზაციებში თანხის "
-"შეწირვაზე დაფიქრდებით <a href=\"%(charity_url)s\">%(charity_name)s</a>."
+msgid "The developer of this add-on would like you to consider making a donation to the <a href=\"%(charity_url)s\">%(charity_name)s</a> if you enjoy using it."
+msgstr "ამ დამატების შემქმნელი ნასიამოვნები დარჩება. თუ ამ ორგანიზაციებში თანხის შეწირვაზე დაფიქრდებით <a href=\"%(charity_url)s\">%(charity_name)s</a>."
 
 #: src/olympia/addons/templates/addons/contribution.html:69
 #, python-format
-msgid ""
-"The developer of this add-on would like you to consider making a small "
-"contribution to <a href=\"%(charity_url)s\">%(charity_name)s</a> if you "
-"enjoy using it."
-msgstr ""
-"ამ დამატების შემქმნელი ნასიამოვნები დარჩება. თუ ამ ორგანიზაციებში მცირე "
-"წვლილის შეტანაზე დაფიქრდებით <a "
-"href=\"%(charity_url)s\">%(charity_name)s</a>."
+msgid "The developer of this add-on would like you to consider making a small contribution to <a href=\"%(charity_url)s\">%(charity_name)s</a> if you enjoy using it."
+msgstr "ამ დამატების შემქმნელი ნასიამოვნები დარჩება. თუ ამ ორგანიზაციებში მცირე წვლილის შეტანაზე დაფიქრდებით <a href=\"%(charity_url)s\">%(charity_name)s</a>."
 
 #: src/olympia/addons/templates/addons/contribution.html:76
-msgid ""
-"Mozilla is committed to supporting a vibrant and healthy developer "
-"ecosystem. Your optional contribution helps sustain further development of "
-"this add-on."
-msgstr ""
-"Mozilla ცოცხალი და ჯანმრთელი დეველოპერული ეკოსისტემის მხარდაჭერის ერთგულია. "
-"თქვენი არასავალდებული წვლილი ამ დამატების განვითარებას დიდად დაეხმარება."
+msgid "Mozilla is committed to supporting a vibrant and healthy developer ecosystem. Your optional contribution helps sustain further development of this add-on."
+msgstr "Mozilla ცოცხალი და ჯანმრთელი დეველოპერული ეკოსისტემის მხარდაჭერის ერთგულია. თქვენი არასავალდებული წვლილი ამ დამატების განვითარებას დიდად დაეხმარება."
 
 #: src/olympia/addons/templates/addons/contributions_lightbox.html:5
 msgid "Make a Contribution"
@@ -377,36 +288,24 @@ msgstr "შემოწირულობის გაღება"
 
 #: src/olympia/addons/templates/addons/contributions_lightbox.html:9
 #, python-format
-msgid ""
-"Help support the continued development of <strong>%(addon_name)s</strong> by"
-" making a small contribution through <a href=\"%(paypal_url)s\">PayPal</a>."
-msgstr ""
-"მხარი დაუჭირეთ <strong>%(addon_name)s-ის</strong> განვითარებას და შეიტანეთ "
-"მცირე წვლილი <a href=\"%(paypal_url)s\">PayPal-ის</a> გამოყენებით."
+msgid "Help support the continued development of <strong>%(addon_name)s</strong> by making a small contribution through <a href=\"%(paypal_url)s\">PayPal</a>."
+msgstr "მხარი დაუჭირეთ <strong>%(addon_name)s-ის</strong> განვითარებას და შეიტანეთ მცირე წვლილი <a href=\"%(paypal_url)s\">PayPal-ის</a> გამოყენებით."
 
 #: src/olympia/addons/templates/addons/contributions_lightbox.html:15
 #, python-format
 msgid ""
-"To show your support for <b>%(addon_name)s</b>, the developer asks that you "
-"make a donation to the <a href=\"%(charity_url)s\">%(charity_name)s</a> "
-"through <a href=\"%(paypal_url)s\">PayPal</a>."
+"To show your support for <b>%(addon_name)s</b>, the developer asks that you make a donation to the <a href=\"%(charity_url)s\">%(charity_name)s</a> through <a href=\"%(paypal_url)s\">PayPal</a>."
 msgstr ""
-"<b>%(addon_name)s-ისადმი</b> თქვენი მხარდაჭერის საჩვენებლად, მისი შემქმნელი "
-"ნასიამოვნები დარჩება, თუ <a href=\"%(paypal_url)s\">PayPal-ის</a> "
-"გამოყენებით ამ ორგანიზაციებში გააკეთებთ შეწირულობას <a "
+"<b>%(addon_name)s-ისადმი</b> თქვენი მხარდაჭერის საჩვენებლად, მისი შემქმნელი ნასიამოვნები დარჩება, თუ <a href=\"%(paypal_url)s\">PayPal-ის</a> გამოყენებით ამ ორგანიზაციებში გააკეთებთ შეწირულობას <a "
 "href=\"%(charity_url)s\">%(charity_name)s</a>."
 
 #: src/olympia/addons/templates/addons/contributions_lightbox.html:21
 #, python-format
 msgid ""
-"To show your support for <b>%(addon_name)s</b>, the developer asks that you "
-"make a small contribution to <a "
-"href=\"%(charity_url)s\">%(charity_name)s</a> through <a "
-"href=\"%(paypal_url)s\">PayPal</a>."
+"To show your support for <b>%(addon_name)s</b>, the developer asks that you make a small contribution to <a href=\"%(charity_url)s\">%(charity_name)s</a> through <a href=\"%(paypal_url)s\">PayPal</"
+"a>."
 msgstr ""
-"<b>%(addon_name)s-ისადმი</b> თქვენი მხარდაჭერის საჩვენებლად, მისი შემქმნელი "
-"ნასიამოვნები დარჩება, თუ <a href=\"%(paypal_url)s\">PayPal-ის</a> "
-"გამოყენებით ამ ორგანიზაციებში შეიტანთ მცირე წვლილს <a "
+"<b>%(addon_name)s-ისადმი</b> თქვენი მხარდაჭერის საჩვენებლად, მისი შემქმნელი ნასიამოვნები დარჩება, თუ <a href=\"%(paypal_url)s\">PayPal-ის</a> გამოყენებით ამ ორგანიზაციებში შეიტანთ მცირე წვლილს <a "
 "href=\"%(charity_url)s\">%(charity_name)s</a>."
 
 #: src/olympia/addons/templates/addons/contributions_lightbox.html:30
@@ -430,8 +329,7 @@ msgstr "შეწირულობის ოდენობა უნდა ი
 msgid "A one-time suggested contribution of {0}"
 msgstr "ერთჯერადი შემოთავაზებული შეწირვა რაოდენობით {0}"
 
-#. {0} is a currency symbol (e.g., $),                    {1} is an amount
-#. input
+#. {0} is a currency symbol (e.g., $),                    {1} is an amount input
 #. field
 #: src/olympia/addons/templates/addons/contributions_lightbox.html:64
 msgid "A one-time contribution of {0} {1}"
@@ -441,11 +339,8 @@ msgstr "ერთჯერადი შეწირვა რაოდენო�
 msgid "Leave a comment or request with your contribution."
 msgstr "დატოვეთ კომენტარი ან მოითხოვეთ თქვენი შეწირულობით."
 
-#: src/olympia/addons/templates/addons/contributions_lightbox.html:74
-#: src/olympia/bandwagon/templates/bandwagon/ajax_new.html:20
-#: src/olympia/bandwagon/templates/bandwagon/includes/addedit.html:37
-#: src/olympia/reviews/templates/reviews/mobile/add_form.html:13
-#: src/olympia/templates/includes/forms.html:10
+#: src/olympia/addons/templates/addons/contributions_lightbox.html:74 src/olympia/bandwagon/templates/bandwagon/ajax_new.html:20 src/olympia/bandwagon/templates/bandwagon/includes/addedit.html:37
+#: src/olympia/reviews/templates/reviews/mobile/add_form.html:13 src/olympia/templates/includes/forms.html:10
 msgid "(optional)"
 msgstr "(არასავალდებულო)"
 
@@ -465,36 +360,27 @@ msgstr "არა, გმადლობთ"
 msgid "Contribution made, thank you."
 msgstr "შემოწირულობა მიღებულია, გმადლობთ."
 
-#: src/olympia/addons/templates/addons/details_box.html:10
-#: src/olympia/discovery/templates/discovery/addons/detail.html:19
+#: src/olympia/addons/templates/addons/details_box.html:10 src/olympia/discovery/templates/discovery/addons/detail.html:19
 msgid "No restart required"
 msgstr "გადატვირთვას არ საჭიროებს"
 
 #. This is a caption for a table. {0} is an add-on name.
-#: src/olympia/addons/templates/addons/details_box.html:26
-#: src/olympia/addons/templates/addons/includes/persona.html:9
+#: src/olympia/addons/templates/addons/details_box.html:26 src/olympia/addons/templates/addons/includes/persona.html:9
 msgid "Add-on Information for {0}"
 msgstr "დამატების შესახებ მონაცემები {0}-ისთვის"
 
-#: src/olympia/addons/templates/addons/details_box.html:30
-#: src/olympia/addons/templates/addons/persona_detail_table.html:3
-#: src/olympia/addons/templates/addons/mobile/details.html:63
-#: src/olympia/addons/templates/addons/mobile/persona_detail_table.html:7
-#: src/olympia/browse/views.py:459 src/olympia/devhub/views.py:75
+#: src/olympia/addons/templates/addons/details_box.html:30 src/olympia/addons/templates/addons/persona_detail_table.html:3 src/olympia/addons/templates/addons/mobile/details.html:63
+#: src/olympia/addons/templates/addons/mobile/persona_detail_table.html:7 src/olympia/browse/views.py:426 src/olympia/devhub/views.py:73
 msgid "Updated"
 msgstr "განახლებული"
 
-#: src/olympia/addons/templates/addons/details_box.html:38
-#: src/olympia/addons/templates/addons/mobile/details.html:71
-#: src/olympia/devhub/templates/devhub/addons/edit/support.html:43
+#: src/olympia/addons/templates/addons/details_box.html:38 src/olympia/addons/templates/addons/mobile/details.html:71 src/olympia/devhub/templates/devhub/addons/edit/support.html:43
 #: src/olympia/discovery/templates/discovery/addons/detail.html:77
 msgid "Website"
 msgstr "საიტი"
 
 #. This refers to this version's compatible applications, such as Firefox 8.0
-#: src/olympia/addons/templates/addons/details_box.html:47
-#: src/olympia/addons/templates/addons/mobile/details.html:80
-#: src/olympia/search/templates/search/results.html:72
+#: src/olympia/addons/templates/addons/details_box.html:47 src/olympia/addons/templates/addons/mobile/details.html:80 src/olympia/search/templates/search/results.html:72
 #: src/olympia/versions/templates/versions/version.html:21
 msgid "Works with"
 msgstr "მუშაობს ვერსიასთან"
@@ -503,45 +389,30 @@ msgstr "მუშაობს ვერსიასთან"
 msgid "Visibility"
 msgstr "ხილულობა"
 
-#: src/olympia/addons/templates/addons/details_box.html:57
-#: src/olympia/devhub/templates/devhub/index.html:94
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:104
+#: src/olympia/addons/templates/addons/details_box.html:57 src/olympia/devhub/templates/devhub/index.html:94 src/olympia/devhub/templates/devhub/includes/addon_details.html:91
 msgid "Hidden"
 msgstr "დამალული"
 
-#: src/olympia/addons/templates/addons/details_box.html:59
-#: src/olympia/devhub/templates/devhub/index.html:96
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:106
+#: src/olympia/addons/templates/addons/details_box.html:59 src/olympia/devhub/templates/devhub/index.html:96 src/olympia/devhub/templates/devhub/includes/addon_details.html:93
 msgid "Unlisted"
 msgstr "სიის გარეთ"
 
-#: src/olympia/addons/templates/addons/details_box.html:67
-#: src/olympia/devhub/templates/devhub/addons/edit/technical.html:44
+#: src/olympia/addons/templates/addons/details_box.html:67 src/olympia/devhub/templates/devhub/addons/edit/technical.html:44
 msgid "Required Add-ons"
 msgstr "საჭირო დამატებები"
 
-#: src/olympia/addons/templates/addons/details_box.html:81
-#: src/olympia/addons/templates/addons/persona_detail_table.html:15
-#: src/olympia/browse/views.py:462 src/olympia/devhub/views.py:78
-#: src/olympia/devhub/views.py:85
-#: src/olympia/discovery/templates/discovery/addons/detail.html:57
-#: src/olympia/reviews/forms.py:62
-#: src/olympia/reviews/templates/reviews/add.html:57
+#: src/olympia/addons/templates/addons/details_box.html:81 src/olympia/addons/templates/addons/persona_detail_table.html:15 src/olympia/browse/views.py:429 src/olympia/devhub/views.py:76
+#: src/olympia/devhub/views.py:83 src/olympia/discovery/templates/discovery/addons/detail.html:57 src/olympia/reviews/forms.py:62 src/olympia/reviews/templates/reviews/add.html:57
 #: src/olympia/reviews/templates/reviews/mobile/review_list.html:18
 msgid "Rating"
 msgstr "შეფასება"
 
-#: src/olympia/addons/templates/addons/details_box.html:85
-#: src/olympia/browse/views.py:461 src/olympia/devhub/views.py:77
-#: src/olympia/devhub/views.py:84
-#: src/olympia/stats/templates/stats/addon_report_menu.html:8
-#: src/olympia/stats/templates/stats/collection_report_menu.html:18
+#: src/olympia/addons/templates/addons/details_box.html:85 src/olympia/browse/views.py:428 src/olympia/devhub/views.py:75 src/olympia/devhub/views.py:82
+#: src/olympia/stats/templates/stats/addon_report_menu.html:8 src/olympia/stats/templates/stats/collection_report_menu.html:18
 msgid "Downloads"
 msgstr "ჩამოტვირთვები"
 
-#: src/olympia/addons/templates/addons/details_box.html:91
-#: src/olympia/addons/templates/addons/details_box.html:103
-#: src/olympia/devhub/templates/devhub/addons/listing/item_actions_theme.html:17
+#: src/olympia/addons/templates/addons/details_box.html:91 src/olympia/addons/templates/addons/details_box.html:103 src/olympia/devhub/templates/devhub/addons/listing/item_actions_theme.html:17
 #: src/olympia/devhub/templates/devhub/personas/edit.html:60
 msgid "View Statistics"
 msgstr "სტატისტიკის ნახვა"
@@ -555,18 +426,13 @@ msgid "Abuse Reports"
 msgstr "დარღვევების მოხსენებები"
 
 #. The Privacy Policy for this add-on.
-#: src/olympia/addons/templates/addons/details_box.html:121
-#: src/olympia/addons/templates/addons/privacy.html:19
-#: src/olympia/addons/templates/addons/privacy.html:23
-#: src/olympia/addons/templates/addons/impala/button.html:43
-#: src/olympia/addons/templates/addons/impala/details.html:307
-#: src/olympia/devhub/templates/devhub/includes/policy_form.html:20
+#: src/olympia/addons/templates/addons/details_box.html:121 src/olympia/addons/templates/addons/privacy.html:19 src/olympia/addons/templates/addons/privacy.html:23
+#: src/olympia/addons/templates/addons/impala/button.html:43 src/olympia/addons/templates/addons/impala/details.html:312 src/olympia/devhub/templates/devhub/includes/policy_form.html:23
 #: src/olympia/templates/mobile/base_addons.html:87
 msgid "Privacy Policy"
 msgstr "პრივატულობის პოლიტიკა"
 
-#: src/olympia/addons/templates/addons/details_box.html:124
-#: src/olympia/discovery/templates/discovery/addons/detail.html:24
+#: src/olympia/addons/templates/addons/details_box.html:124 src/olympia/discovery/templates/discovery/addons/detail.html:24
 msgid "View Privacy Policy"
 msgstr "პრივატულობის პოლიტიკა"
 
@@ -574,8 +440,7 @@ msgstr "პრივატულობის პოლიტიკა"
 msgid "EULA"
 msgstr "EULA"
 
-#: src/olympia/addons/templates/addons/details_box.html:171
-#: src/olympia/addons/templates/addons/details_box.html:231
+#: src/olympia/addons/templates/addons/details_box.html:171 src/olympia/addons/templates/addons/details_box.html:231
 msgid "More about this add-on"
 msgstr "მეტი ამ დამატების შესახებ"
 
@@ -583,26 +448,20 @@ msgstr "მეტი ამ დამატების შესახებ"
 msgid "Image Gallery"
 msgstr "სურათების გალერეა"
 
-#: src/olympia/addons/templates/addons/details_box.html:190
-#: src/olympia/devhub/templates/devhub/addons/edit/technical.html:21
+#: src/olympia/addons/templates/addons/details_box.html:190 src/olympia/devhub/templates/devhub/addons/edit/technical.html:21
 msgid "Developer Comments"
 msgstr "შემქმნელის კომენტარები"
 
-#: src/olympia/addons/templates/addons/details_box.html:199
-#: src/olympia/addons/templates/addons/impala/details.html:259
+#: src/olympia/addons/templates/addons/details_box.html:199 src/olympia/addons/templates/addons/impala/details.html:264
 msgid "Development Channel"
 msgstr "განვითარების არხი"
 
-#: src/olympia/addons/templates/addons/details_box.html:202
-#: src/olympia/addons/templates/addons/mobile/details.html:124
+#: src/olympia/addons/templates/addons/details_box.html:202 src/olympia/addons/templates/addons/mobile/details.html:124
 msgid ""
-"The Development Channel lets you test an experimental new version of this "
-"add-on before it's released to the general public. Once you install the "
-"development version, you will continue to get updates from this channel."
+"The Development Channel lets you test an experimental new version of this add-on before it's released to the general public. Once you install the development version, you will continue to get "
+"updates from this channel."
 msgstr ""
-"განვითარების არხი საშუალებას გაძლევთ გასინჯოთ ამ დამატების ახალი "
-"ექსპერიმენტალური ვერსიები მათ საჯაროდ გამოშვებამდე. განვითარების ვერსიის "
-"დაყენების შემდეგ, განახლებებს მიიღებთ პირდაპირ ამ არხიდან."
+"განვითარების არხი საშუალებას გაძლევთ გასინჯოთ ამ დამატების ახალი ექსპერიმენტალური ვერსიები მათ საჯაროდ გამოშვებამდე. განვითარების ვერსიის დაყენების შემდეგ, განახლებებს მიიღებთ პირდაპირ ამ არხიდან."
 
 #: src/olympia/addons/templates/addons/details_box.html:207
 msgid "Install development version"
@@ -610,72 +469,49 @@ msgstr "განვითარების ვერსიის დაყე�
 
 #: src/olympia/addons/templates/addons/details_box.html:211
 msgid ""
-"<strong>Caution:</strong> Development versions of this add-on have not been "
-"reviewed by Mozilla. Once you install a development version you will "
-"continue to receive development updates from this developer. To stop "
-"receiving development updates, reinstall the default version from the link "
-"above."
+"<strong>Caution:</strong> Development versions of this add-on have not been reviewed by Mozilla. Once you install a development version you will continue to receive development updates from this "
+"developer. To stop receiving development updates, reinstall the default version from the link above."
 msgstr ""
-"<strong>ფრთხილად:</strong> ამ დამატების განვითარების ვერსიები Mozilla-ს მიერ"
-" არ განხილულა. განვითარების ვერსიის დაყენების შემდეგ განვითარების ვერსიის "
-"განახლებებს მიიღებთ ამ განმვითარებლისგან. განვითარების განახლებების მიღების "
-"შესაწყვეტად, ხელახლა დააყენეთ ნაგულისხმევი ვერსია ზემოთ მოცემული ბმულით."
+"<strong>ფრთხილად:</strong> ამ დამატების განვითარების ვერსიები Mozilla-ს მიერ არ განხილულა. განვითარების ვერსიის დაყენების შემდეგ განვითარების ვერსიის განახლებებს მიიღებთ ამ განმვითარებლისგან. "
+"განვითარების განახლებების მიღების შესაწყვეტად, ხელახლა დააყენეთ ნაგულისხმევი ვერსია ზემოთ მოცემული ბმულით."
 
-#: src/olympia/addons/templates/addons/details_box.html:220
-#: src/olympia/addons/templates/addons/impala/details.html:278
+#: src/olympia/addons/templates/addons/details_box.html:220 src/olympia/addons/templates/addons/impala/details.html:283
 msgid "Version {0}:"
 msgstr "ვერის {0}:"
 
 #: src/olympia/addons/templates/addons/details_box.html:234
 msgid "Nothing to see here!  The developer did not include any details."
-msgstr "სანახავი არაფერია!   განმვითარებელს დეტალები არ დაუმატებია."
+msgstr ""
 
-#: src/olympia/addons/templates/addons/details_box.html:251
-#: src/olympia/devhub/templates/devhub/versions/edit.html:73
-#: src/olympia/editors/templates/editors/review.html:98
+#: src/olympia/addons/templates/addons/details_box.html:251 src/olympia/devhub/templates/devhub/versions/edit.html:73 src/olympia/editors/templates/editors/review.html:98
 msgid "Version Notes"
 msgstr "ვერსიის შენიშვნები"
 
 #. {0} is the name of the add-on.
 #. {0} is the name of the add-on
-#: src/olympia/addons/templates/addons/eula.html:6
-#: src/olympia/discovery/templates/discovery/addons/eula.html:5
+#: src/olympia/addons/templates/addons/eula.html:6 src/olympia/discovery/templates/discovery/addons/eula.html:5
 msgid "End-User License Agreement for {0}"
 msgstr "მომხმარებლის სალიცენზიო შეთანხმება {0}-სთვის"
 
-#: src/olympia/addons/templates/addons/eula.html:17
-#: src/olympia/addons/templates/addons/eula.html:21
-#: src/olympia/addons/templates/addons/impala/button.html:48
-#: src/olympia/addons/templates/addons/impala/details.html:316
-#: src/olympia/devhub/templates/devhub/includes/policy_form.html:3
-#: src/olympia/discovery/templates/discovery/addons/eula.html:11
+#: src/olympia/addons/templates/addons/eula.html:17 src/olympia/addons/templates/addons/eula.html:21 src/olympia/addons/templates/addons/impala/button.html:48
+#: src/olympia/addons/templates/addons/impala/details.html:321 src/olympia/devhub/templates/devhub/includes/policy_form.html:3 src/olympia/discovery/templates/discovery/addons/eula.html:11
 msgid "End-User License Agreement"
 msgstr "საბოლოო მომხმარებლის სალიცენზიო შეთანხმება"
 
-#: src/olympia/addons/templates/addons/eula.html:23
-#: src/olympia/discovery/templates/discovery/addons/eula.html:13
+#: src/olympia/addons/templates/addons/eula.html:23 src/olympia/discovery/templates/discovery/addons/eula.html:13
 #, python-format
-msgid ""
-"%(addon_name)s requires that you accept the following End-User License "
-"Agreement before installation can proceed:"
-msgstr ""
-"%(addon_name)s ინსტალაციის გაგრძელებამდე მოითხოვს, რომ ამ საბოლოო "
-"მომხმარებლის სალიცენზიო შეთანხმებას დაეთანხმოთ:"
+msgid "%(addon_name)s requires that you accept the following End-User License Agreement before installation can proceed:"
+msgstr "%(addon_name)s ინსტალაციის გაგრძელებამდე მოითხოვს, რომ ამ საბოლოო მომხმარებლის სალიცენზიო შეთანხმებას დაეთანხმოთ:"
 
-#: src/olympia/addons/templates/addons/eula.html:34
-#: src/olympia/addons/templates/addons/privacy.html:26
+#: src/olympia/addons/templates/addons/eula.html:34 src/olympia/addons/templates/addons/privacy.html:26
 msgid "Back to {0}…"
 msgstr "დაბრუნება {0}-ზე…"
 
-#: src/olympia/addons/templates/addons/home.html:3
-#: src/olympia/addons/templates/addons/mobile/home.html:3
-#: src/olympia/amo/helpers.py:235
+#: src/olympia/addons/templates/addons/home.html:3 src/olympia/addons/templates/addons/mobile/home.html:3 src/olympia/amo/helpers.py:235
 msgid "Add-ons for {0}"
 msgstr "დამატებები {0}-სთვის"
 
-#: src/olympia/addons/templates/addons/home.html:10
-#: src/olympia/addons/templates/addons/home.html:51
-#: src/olympia/browse/templates/browse/impala/base_listing.html:11
+#: src/olympia/addons/templates/addons/home.html:10 src/olympia/addons/templates/addons/home.html:53 src/olympia/browse/templates/browse/impala/base_listing.html:11
 msgid "Featured Extensions"
 msgstr "შემოთავაზებული გაფართოებები"
 
@@ -683,70 +519,49 @@ msgstr "შემოთავაზებული გაფართოებ�
 msgid "Popular Extensions"
 msgstr "პოპულარული გაფართოებები"
 
-#: src/olympia/addons/templates/addons/home.html:42
-#: src/olympia/amo/templates/amo/side_nav.html:3
-#: src/olympia/amo/templates/amo/side_nav.html:11
-#: src/olympia/amo/templates/amo/site_nav.html:3
-#: src/olympia/amo/templates/amo/site_nav.html:25
-#: src/olympia/browse/views.py:236 src/olympia/browse/views.py:281
-#: src/olympia/browse/views.py:481
+#: src/olympia/addons/templates/addons/home.html:44 src/olympia/amo/templates/amo/side_nav.html:3 src/olympia/amo/templates/amo/side_nav.html:11 src/olympia/amo/templates/amo/site_nav.html:3
+#: src/olympia/amo/templates/amo/site_nav.html:25 src/olympia/browse/views.py:203 src/olympia/browse/views.py:248 src/olympia/browse/views.py:448
 msgid "Most Popular"
 msgstr "ყველაზე მოთხოვნადი"
 
-#: src/olympia/addons/templates/addons/home.html:43
+#: src/olympia/addons/templates/addons/home.html:45
 msgid "All »"
 msgstr "ყველა »"
 
-#: src/olympia/addons/templates/addons/home.html:52
-#: src/olympia/addons/templates/addons/home.html:61
-#: src/olympia/addons/templates/addons/home.html:70
-#: src/olympia/addons/templates/addons/home.html:78
+#: src/olympia/addons/templates/addons/home.html:54 src/olympia/addons/templates/addons/home.html:63 src/olympia/addons/templates/addons/home.html:72 src/olympia/addons/templates/addons/home.html:80
 #: src/olympia/browse/templates/browse/impala/category_landing.html:36
 msgid "See all »"
 msgstr "ყველას ნახვა »"
 
-#: src/olympia/addons/templates/addons/home.html:60
+#: src/olympia/addons/templates/addons/home.html:62
 msgid "Up &amp; Coming Extensions"
 msgstr "იმედის მომცემი გაფართოებები"
 
-#: src/olympia/addons/templates/addons/home.html:69
-#: src/olympia/browse/templates/browse/personas/category_landing.html:61
-#: src/olympia/discovery/templates/discovery/pane.html:74
+#: src/olympia/addons/templates/addons/home.html:71 src/olympia/browse/templates/browse/personas/category_landing.html:61 src/olympia/discovery/templates/discovery/pane.html:74
 msgid "Featured Themes"
 msgstr "გამორჩეული თემები"
 
-#: src/olympia/addons/templates/addons/home.html:77
-#: src/olympia/bandwagon/templates/bandwagon/impala/collection_listing.html:5
+#: src/olympia/addons/templates/addons/home.html:79 src/olympia/bandwagon/templates/bandwagon/impala/collection_listing.html:5
 msgid "Featured Collections"
 msgstr "რეკლამირებული კოლექციები"
 
-#: src/olympia/addons/templates/addons/listing_header.html:3
-#: src/olympia/addons/templates/addons/impala/listing/sorter.html:2
-#: src/olympia/amo/templates/amo/mobile/sort_by.html:2
+#: src/olympia/addons/templates/addons/listing_header.html:3 src/olympia/addons/templates/addons/impala/listing/sorter.html:2 src/olympia/amo/templates/amo/mobile/sort_by.html:2
 #: src/olympia/bandwagon/templates/bandwagon/collection_detail.html:118
 msgid "Sort by:"
 msgstr "დალაგება:"
 
 #. {0} is a date.
 #. {0} is a date
-#: src/olympia/addons/templates/addons/macros.html:7
-#: src/olympia/addons/templates/addons/macros.html:72
-#: src/olympia/addons/templates/addons/listing/items_mobile.html:48
-#: src/olympia/addons/templates/addons/listing/macros.html:42
-#: src/olympia/bandwagon/templates/bandwagon/collection_detail.html:50
-#: src/olympia/bandwagon/templates/bandwagon/collection_listing_items.html:40
-#: src/olympia/bandwagon/templates/bandwagon/impala/collection_listing_items.html:40
+#: src/olympia/addons/templates/addons/macros.html:7 src/olympia/addons/templates/addons/macros.html:72 src/olympia/addons/templates/addons/listing/items_mobile.html:48
+#: src/olympia/addons/templates/addons/listing/macros.html:42 src/olympia/bandwagon/templates/bandwagon/collection_detail.html:50
+#: src/olympia/bandwagon/templates/bandwagon/collection_listing_items.html:40 src/olympia/bandwagon/templates/bandwagon/impala/collection_listing_items.html:40
 msgid "Updated {0}"
 msgstr "განახლებული {0}"
 
 #. {0} is a date.
-#: src/olympia/addons/templates/addons/macros.html:10
-#: src/olympia/addons/templates/addons/macros.html:69
-#: src/olympia/addons/templates/addons/persona_preview.html:21
-#: src/olympia/addons/templates/addons/listing/items_mobile.html:44
-#: src/olympia/addons/templates/addons/listing/macros.html:39
-#: src/olympia/bandwagon/templates/bandwagon/collection_listing_items.html:37
-#: src/olympia/bandwagon/templates/bandwagon/impala/collection_listing_items.html:37
+#: src/olympia/addons/templates/addons/macros.html:10 src/olympia/addons/templates/addons/macros.html:69 src/olympia/addons/templates/addons/persona_preview.html:22
+#: src/olympia/addons/templates/addons/listing/items_mobile.html:44 src/olympia/addons/templates/addons/listing/macros.html:39
+#: src/olympia/bandwagon/templates/bandwagon/collection_listing_items.html:37 src/olympia/bandwagon/templates/bandwagon/impala/collection_listing_items.html:37
 msgid "Added {0}"
 msgstr "დამატებულია {0}"
 
@@ -755,28 +570,28 @@ msgstr "დამატებულია {0}"
 msgid "%(num)s weekly download"
 msgid_plural "%(num)s weekly downloads"
 msgstr[0] "%(num)s ყოველკვირეული ჩამოტვირთვები"
+msgstr[1] ""
 
 #: src/olympia/addons/templates/addons/macros.html:28
 #, python-format
 msgid "%(num)s user"
 msgid_plural "%(num)s users"
 msgstr[0] "%(num)s მომხმარებელი"
+msgstr[1] ""
 
 #. {0} is the number of downloads.
-#: src/olympia/addons/templates/addons/macros.html:53
-#: src/olympia/addons/templates/addons/impala/details.html:61
+#: src/olympia/addons/templates/addons/macros.html:53 src/olympia/addons/templates/addons/impala/details.html:59
 msgid "{0} weekly download"
 msgid_plural "{0} weekly downloads"
 msgstr[0] "{0} ყოველკვირეული ჩამოტვირთვები"
+msgstr[1] ""
 
 #. {0} is the number of users.
-#: src/olympia/addons/templates/addons/macros.html:61
-#: src/olympia/addons/templates/addons/impala/details.html:54
-#: src/olympia/compat/templates/compat/index.html:71
-#: src/olympia/zadmin/templates/zadmin/compat.html:67
+#: src/olympia/addons/templates/addons/macros.html:61 src/olympia/addons/templates/addons/impala/details.html:52 src/olympia/zadmin/templates/zadmin/compat.html:67
 msgid "{0} user"
 msgid_plural "{0} users"
 msgstr[0] "{0} მომხმარებელი"
+msgstr[1] ""
 
 #: src/olympia/addons/templates/addons/paypal_result.html:12
 msgid "Payment cancelled"
@@ -790,12 +605,8 @@ msgstr "გადახდა შესრულებულია"
 msgid "Return to the addon."
 msgstr "დამატებაზე დაბრუნება."
 
-#: src/olympia/addons/templates/addons/persona_detail.html:17
-#: src/olympia/addons/templates/addons/impala/details.html:106
-#: src/olympia/addons/templates/addons/mobile/details.html:23
-#: src/olympia/addons/templates/addons/mobile/persona_detail.html:21
-#: src/olympia/discovery/templates/discovery/addons/base.html:27
-#: src/olympia/editors/templates/editors/review.html:31
+#: src/olympia/addons/templates/addons/persona_detail.html:17 src/olympia/addons/templates/addons/impala/details.html:103 src/olympia/addons/templates/addons/mobile/details.html:23
+#: src/olympia/addons/templates/addons/mobile/persona_detail.html:21 src/olympia/discovery/templates/discovery/addons/base.html:27 src/olympia/editors/templates/editors/review.html:31
 msgid "by"
 msgstr "ავტორი"
 
@@ -805,8 +616,7 @@ msgid "More {0} Themes"
 msgstr "მეტი {0} თემა"
 
 #. {0} is a category name, such as Nature
-#: src/olympia/addons/templates/addons/persona_detail.html:39
-#: src/olympia/addons/templates/addons/mobile/persona_detail.html:66
+#: src/olympia/addons/templates/addons/persona_detail.html:39 src/olympia/addons/templates/addons/mobile/persona_detail.html:66
 msgid "See all {0} Themes"
 msgstr "ყველა {0} თემის ნახვა"
 
@@ -814,147 +624,106 @@ msgstr "ყველა {0} თემის ნახვა"
 msgid "More by this Artist"
 msgstr "მეტი ამ მხატვრისგან"
 
-#: src/olympia/addons/templates/addons/persona_detail.html:52
-#: src/olympia/addons/templates/addons/mobile/persona_detail.html:49
+#: src/olympia/addons/templates/addons/persona_detail.html:52 src/olympia/addons/templates/addons/mobile/persona_detail.html:49
 msgid "See all Themes by this Artist"
 msgstr "ნახეთ ამ მხატვრის ყველა თემა"
 
-#: src/olympia/addons/templates/addons/persona_detail.html:71
-#: src/olympia/addons/templates/addons/mobile/home.html:42
-#: src/olympia/amo/templates/amo/side_nav.html:22
-#: src/olympia/browse/templates/browse/personas/mobile/category_landing.html:28
-#: src/olympia/devhub/templates/devhub/addons/edit/basic.html:72
-#: src/olympia/editors/templates/editors/review.html:277
-#: src/olympia/editors/templates/editors/themes/themes.html:34
-#: src/olympia/templates/categories.html:7
+#: src/olympia/addons/templates/addons/persona_detail.html:71 src/olympia/addons/templates/addons/mobile/home.html:42 src/olympia/amo/templates/amo/side_nav.html:22
+#: src/olympia/browse/templates/browse/personas/mobile/category_landing.html:28 src/olympia/devhub/templates/devhub/addons/edit/basic.html:72 src/olympia/editors/templates/editors/review.html:277
+#: src/olympia/editors/templates/editors/themes/themes.html:34 src/olympia/templates/categories.html:7
 msgid "Categories"
 msgstr "კატეგორიები"
 
-#: src/olympia/addons/templates/addons/persona_detail_table.html:10
-#: src/olympia/addons/templates/addons/mobile/persona_detail_table.html:3
-#: src/olympia/editors/templates/editors/themes/deleted.html:19
+#: src/olympia/addons/templates/addons/persona_detail_table.html:10 src/olympia/addons/templates/addons/mobile/persona_detail_table.html:3 src/olympia/editors/templates/editors/themes/deleted.html:19
 #: src/olympia/editors/templates/editors/themes/themes.html:25
 msgid "Artist"
 msgstr "მხატვარი"
 
-#: src/olympia/addons/templates/addons/persona_detail_table.html:19
-#: src/olympia/addons/templates/addons/mobile/persona_detail_table.html:14
-#: src/olympia/stats/templates/stats/addon_report_menu.html:17
+#: src/olympia/addons/templates/addons/persona_detail_table.html:19 src/olympia/addons/templates/addons/mobile/persona_detail_table.html:14 src/olympia/stats/templates/stats/addon_report_menu.html:17
 msgid "Daily Users"
 msgstr "დღიური მომხმარებლები"
 
 #. The License for this add-on.
-#: src/olympia/addons/templates/addons/persona_detail_table.html:26
-#: src/olympia/addons/templates/addons/impala/license.html:17
-#: src/olympia/addons/templates/addons/mobile/persona_detail_table.html:21
-#: src/olympia/devhub/templates/devhub/includes/license_form.html:5
-#: src/olympia/devhub/templates/devhub/versions/edit.html:89
-#: src/olympia/editors/templates/editors/themes/themes.html:41
+#: src/olympia/addons/templates/addons/persona_detail_table.html:26 src/olympia/addons/templates/addons/impala/license.html:17 src/olympia/addons/templates/addons/mobile/persona_detail_table.html:21
+#: src/olympia/devhub/templates/devhub/includes/license_form.html:5 src/olympia/devhub/templates/devhub/versions/edit.html:89 src/olympia/editors/templates/editors/themes/themes.html:41
 msgid "License"
 msgstr "ლიცენზია"
 
-#: src/olympia/addons/templates/addons/persona_preview.html:12
-#: src/olympia/constants/base.py:48
+#: src/olympia/addons/templates/addons/persona_preview.html:13 src/olympia/constants/base.py:48
 msgid "Awaiting Review"
 msgstr "ელოდება განხილვას"
 
-#: src/olympia/addons/templates/addons/persona_preview.html:14
-#: src/olympia/amo/log.py:180 src/olympia/constants/base.py:42
-#: src/olympia/editors/helpers.py:62
+#: src/olympia/addons/templates/addons/persona_preview.html:15 src/olympia/amo/log.py:180 src/olympia/constants/base.py:42 src/olympia/editors/helpers.py:62
 msgid "Rejected"
 msgstr "უარყოფილია"
 
-#: src/olympia/addons/templates/addons/persona_preview.html:16
-#: src/olympia/amo/log.py:159
+#: src/olympia/addons/templates/addons/persona_preview.html:17 src/olympia/amo/log.py:159
 msgid "Approved"
 msgstr "მიღებულია"
 
 #. {0} is the number of users.
-#: src/olympia/addons/templates/addons/persona_preview.html:26
-#: src/olympia/addons/templates/addons/listing/items_mobile.html:36
-#: src/olympia/addons/templates/addons/listing/macros.html:31
+#: src/olympia/addons/templates/addons/persona_preview.html:27 src/olympia/addons/templates/addons/listing/items_mobile.html:36 src/olympia/addons/templates/addons/listing/macros.html:31
 msgid "<strong>{0}</strong> user"
 msgid_plural "<strong>{0}</strong> users"
 msgstr[0] "<strong>{0}</strong> მომხმარებელი"
+msgstr[1] ""
 
-#: src/olympia/addons/templates/addons/persona_preview.html:40
+#: src/olympia/addons/templates/addons/persona_preview.html:41
 msgid "Hover to Preview"
 msgstr "გადაულივლივეთ წინასწარ სანახავად"
 
-#: src/olympia/addons/templates/addons/persona_preview.html:46
-#: src/olympia/addons/templates/addons/persona_preview.html:48
+#: src/olympia/addons/templates/addons/persona_preview.html:47 src/olympia/addons/templates/addons/persona_preview.html:49 src/olympia/addons/templates/addons/persona_preview.html:97
 #: src/olympia/reviews/templates/reviews/add.html:15
 msgid "Add"
 msgstr "დამატება"
 
-#: src/olympia/addons/templates/addons/persona_preview.html:57
-#: src/olympia/bandwagon/templates/bandwagon/ajax_new.html:16
-#: src/olympia/bandwagon/templates/bandwagon/edit.html:19
-#: src/olympia/bandwagon/templates/bandwagon/includes/addedit.html:19
-#: src/olympia/devhub/templates/devhub/addons/edit/admin.html:13
-#: src/olympia/devhub/templates/devhub/addons/edit/basic.html:10
-#: src/olympia/devhub/templates/devhub/addons/edit/details.html:8
-#: src/olympia/devhub/templates/devhub/addons/edit/media.html:6
-#: src/olympia/devhub/templates/devhub/addons/edit/support.html:8
-#: src/olympia/devhub/templates/devhub/addons/edit/technical.html:9
-#: src/olympia/devhub/templates/devhub/addons/submit/describe.html:29
-#: src/olympia/editors/templates/editors/review.html:257
+#: src/olympia/addons/templates/addons/persona_preview.html:58 src/olympia/bandwagon/templates/bandwagon/ajax_new.html:16 src/olympia/bandwagon/templates/bandwagon/edit.html:19
+#: src/olympia/bandwagon/templates/bandwagon/includes/addedit.html:19 src/olympia/devhub/templates/devhub/addons/edit/admin.html:13 src/olympia/devhub/templates/devhub/addons/edit/basic.html:10
+#: src/olympia/devhub/templates/devhub/addons/edit/details.html:8 src/olympia/devhub/templates/devhub/addons/edit/media.html:6 src/olympia/devhub/templates/devhub/addons/edit/support.html:8
+#: src/olympia/devhub/templates/devhub/addons/edit/technical.html:9 src/olympia/devhub/templates/devhub/addons/submit/describe.html:29 src/olympia/editors/templates/editors/review.html:257
 msgid "Edit"
 msgstr "ჩასწორება"
 
 #. For datetime formatting, see the table on
 #. http://docs.python.org/library/datetime.html#strftime-and-strptime-behavior
-#: src/olympia/addons/templates/addons/persona_preview.html:66
+#: src/olympia/addons/templates/addons/persona_preview.html:67
 #, python-format
 msgid "%%Y-%%m-%%d"
 msgstr "%%d.%%m.%%Y"
 
-#: src/olympia/addons/templates/addons/persona_preview.html:67
+#: src/olympia/addons/templates/addons/persona_preview.html:68
 msgid "by {0} on {1}"
 msgstr "{0}-სგან {1}-ზე"
 
-#: src/olympia/addons/templates/addons/persona_preview.html:75
-#: src/olympia/reviews/helpers.py:17
-#: src/olympia/reviews/templates/reviews/review_list.html:63
-#: src/olympia/reviews/templates/reviews/reviews_link.html:21
-#: src/olympia/reviews/templates/reviews/impala/reviews_link.html:16
+#: src/olympia/addons/templates/addons/persona_preview.html:76 src/olympia/reviews/helpers.py:17 src/olympia/reviews/templates/reviews/review_list.html:63
+#: src/olympia/reviews/templates/reviews/reviews_link.html:21 src/olympia/reviews/templates/reviews/impala/reviews_link.html:16
 msgid "Not yet rated"
 msgstr "ჯერ არაა შეფასებული"
 
-#: src/olympia/addons/templates/addons/persona_preview.html:78
+#: src/olympia/addons/templates/addons/persona_preview.html:79
 msgid "<b>{0}</b> users"
 msgstr "<b>{0}</b> მომხმარებელი"
 
 #: src/olympia/addons/templates/addons/popups.html:17
-msgid ""
-"To install this add-on and thousands more, <b>get Firefox</b>, a free and "
-"open web browser from Mozilla."
-msgstr ""
-"ამ და სხვა ათასობით დამატების დასაყენებლად, <b>ჩამოტვირთეთ Firefox</b>, "
-"უფასო და ღია ვებ-ბრაუზერი Mozilla-სგან."
+msgid "To install this add-on and thousands more, <b>get Firefox</b>, a free and open web browser from Mozilla."
+msgstr "ამ და სხვა ათასობით დამატების დასაყენებლად, <b>ჩამოტვირთეთ Firefox</b>, უფასო და ღია ვებ-ბრაუზერი Mozilla-სგან."
 
-#: src/olympia/addons/templates/addons/popups.html:21
-#: src/olympia/addons/templates/addons/popups.html:52
+#: src/olympia/addons/templates/addons/popups.html:21 src/olympia/addons/templates/addons/popups.html:52
 msgid "Learn more about Firefox"
 msgstr "გაიგეთ მეტი Firefox-ის შესახებ"
 
 #: src/olympia/addons/templates/addons/popups.html:22
-msgid "or <b><a class=\"installer\" href=\"{url}\">download anyway</a></b>"
-msgstr "or <b><a class=\"installer\" href=\"{url}\">მაინც ჩამოტვირთვა</a></b>"
+msgid "or <b><a class=\"button installer\" href=\"{url}\">download anyway</a></b>"
+msgstr ""
 
 #: src/olympia/addons/templates/addons/popups.html:26
 msgid ""
-"<strong>How to Install in Thunderbird</strong> <ol> <li>Download and save "
-"the file to your hard disk.</li> <li>In Mozilla Thunderbird, open Add-ons "
-"from the Tools menu.</li> <li>From the options button next to the add-on "
-"search field, select \"Install Add-on From File...\" and locate the "
-"downloaded add-on.</li> </ol>"
+"<strong>How to Install in Thunderbird</strong> <ol> <li>Download and save the file to your hard disk.</li> <li>In Mozilla Thunderbird, open Add-ons from the Tools menu.</li> <li>From the options "
+"button next to the add-on search field, select \"Install Add-on From File...\" and locate the downloaded add-on.</li> </ol>"
 msgstr ""
 
 #: src/olympia/addons/templates/addons/popups.html:41
-msgid ""
-"To install this Theme, <b>get Thunderbird</b>, a free and open source email "
-"client from Mozilla Messaging and install the Personas Plus add-on."
+msgid "To install this Theme, <b>get Thunderbird</b>, a free and open source email client from Mozilla Messaging and install the Personas Plus add-on."
 msgstr ""
 
 #: src/olympia/addons/templates/addons/popups.html:46
@@ -962,9 +731,7 @@ msgid "Learn more about Thunderbird"
 msgstr "გაიგეთ მეტი Thunderbird-ის შესახებ"
 
 #: src/olympia/addons/templates/addons/popups.html:48
-msgid ""
-"To install this Theme and thousands more, <b>get Firefox</b>, a free and "
-"open web browser from Mozilla."
+msgid "To install this Theme and thousands more, <b>get Firefox</b>, a free and open web browser from Mozilla."
 msgstr ""
 
 #: src/olympia/addons/templates/addons/popups.html:60
@@ -972,15 +739,12 @@ msgstr ""
 msgid "This add-on has not been updated to work with your version of %(app)s."
 msgstr ""
 
-#: src/olympia/addons/templates/addons/popups.html:63
-#: src/olympia/addons/templates/addons/popups.html:140
-#: src/olympia/addons/templates/addons/popups.html:150
+#: src/olympia/addons/templates/addons/popups.html:63 src/olympia/addons/templates/addons/popups.html:140 src/olympia/addons/templates/addons/popups.html:150
 msgid "Install Anyway"
 msgstr "ჩადგმა ნებისმიერ შემთხვევაში"
 
 #: src/olympia/addons/templates/addons/popups.html:71
-msgid ""
-"This add-on requires a version of Firefox that has not been released yet."
+msgid "This add-on requires a version of Firefox that has not been released yet."
 msgstr "ეს დამატება ითხოვს Firefox-ის იმ ვერსიას, რომელიც ჯერ არ გამოსულა."
 
 #: src/olympia/addons/templates/addons/popups.html:74
@@ -989,14 +753,11 @@ msgstr "დაგვეხმარეთ Firefox-ის ახალი ვე�
 
 #: src/olympia/addons/templates/addons/popups.html:77
 #, python-format
-msgid ""
-"This add-on requires %(app)s {new_version}. You are currently using %(app)s "
-"{old_version}."
+msgid "This add-on requires %(app)s {new_version}. You are currently using %(app)s {old_version}."
 msgstr ""
 
 #. {0} is an app name, like Firefox.
-#: src/olympia/addons/templates/addons/popups.html:82
-#: src/olympia/addons/templates/addons/popups.html:101
+#: src/olympia/addons/templates/addons/popups.html:82 src/olympia/addons/templates/addons/popups.html:101
 msgid "Upgrade {0}"
 msgstr ""
 
@@ -1007,34 +768,25 @@ msgstr ""
 
 #: src/olympia/addons/templates/addons/popups.html:96
 #, python-format
-msgid ""
-"This Persona requires %(app)s %(new_version)s. You are currently using "
-"%(app)s {old_version}."
+msgid "This Persona requires %(app)s %(new_version)s. You are currently using %(app)s {old_version}."
 msgstr ""
 
 #: src/olympia/addons/templates/addons/popups.html:108
 msgid ""
-"<strong>Caution:</strong> This add-on has not been reviewed by Mozilla and "
-"can't be installed on release versions of Firefox 43 and above.  Be careful "
-"when installing third-party software that might harm your computer."
+"<strong>Caution:</strong> This add-on has not been reviewed by Mozilla and can't be installed on release versions of Firefox 43 and above.  Be careful when installing third-party software that "
+"might harm your computer."
 msgstr ""
 
 #: src/olympia/addons/templates/addons/popups.html:120
-msgid ""
-"<strong>Please note:</strong> This add-on is not compatible with your "
-"operating system."
+msgid "<strong>Please note:</strong> This add-on is not compatible with your operating system."
 msgstr ""
 
-#: src/olympia/addons/templates/addons/popups.html:136
-#: src/olympia/addons/templates/addons/impala/button.html:70
+#: src/olympia/addons/templates/addons/popups.html:136 src/olympia/addons/templates/addons/impala/button.html:70
 #, python-format
-msgid ""
-"This add-on is not compatible with your version of %(app)s because of the "
-"following:"
+msgid "This add-on is not compatible with your version of %(app)s because of the following:"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/popups.html:141
-#: src/olympia/addons/templates/addons/popups.html:151
+#: src/olympia/addons/templates/addons/popups.html:141 src/olympia/addons/templates/addons/popups.html:151
 msgid "View other versions"
 msgstr "სხვა ვერსიების ნახვა"
 
@@ -1059,134 +811,85 @@ msgid ""
 "  don't have one.)"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/report_abuse.html:6
-#: src/olympia/addons/templates/addons/report_abuse_full.html:10
-#: src/olympia/addons/templates/addons/impala/details-more.html:23
-#: src/olympia/addons/templates/addons/impala/details.html:328
+#: src/olympia/addons/templates/addons/report_abuse.html:6 src/olympia/addons/templates/addons/report_abuse_full.html:10 src/olympia/addons/templates/addons/impala/details-more.html:23
+#: src/olympia/addons/templates/addons/impala/details.html:333
 msgid "Report Abuse"
 msgstr "შეტყობინება უკანონო გამოყენების შესახებ"
 
 #: src/olympia/addons/templates/addons/report_abuse.html:10
 #, python-format
 msgid ""
-"If you suspect this add-on violates <a href=\"%(url)s\">our policies</a> or "
-"has security or privacy issues, please use the form below to describe your "
-"concerns. Please do not use this form for any other reason."
+"If you suspect this add-on violates <a href=\"%(url)s\">our policies</a> or has security or privacy issues, please use the form below to describe your concerns. Please do not use this form for any "
+"other reason."
 msgstr ""
 
-#: src/olympia/addons/templates/addons/report_abuse.html:24
-#: src/olympia/users/templates/users/report_abuse.html:19
+#: src/olympia/addons/templates/addons/report_abuse.html:24 src/olympia/users/templates/users/report_abuse.html:19
 msgid "Send Report"
 msgstr "შეტყობინების გაგზავნა"
 
-#: src/olympia/addons/templates/addons/report_abuse.html:26
-#: src/olympia/addons/templates/addons/mobile/eula.html:16
-#: src/olympia/addons/templates/addons/mobile/persona_confirm.html:7
-#: src/olympia/devhub/templates/devhub/addons/ajax_compat_update.html:36
-#: src/olympia/devhub/templates/devhub/addons/profile.html:44
-#: src/olympia/devhub/templates/devhub/addons/edit/admin.html:104
-#: src/olympia/devhub/templates/devhub/addons/edit/basic.html:155
-#: src/olympia/devhub/templates/devhub/addons/edit/details.html:88
-#: src/olympia/devhub/templates/devhub/addons/edit/support.html:70
-#: src/olympia/devhub/templates/devhub/addons/edit/technical.html:169
-#: src/olympia/devhub/templates/devhub/addons/forms_shared/media.html:152
-#: src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:44
-#: src/olympia/devhub/templates/devhub/personas/edit.html:222
-#: src/olympia/devhub/templates/devhub/versions/add_file_modal.html:79
-#: src/olympia/devhub/templates/devhub/versions/edit.html:140
-#: src/olympia/devhub/templates/devhub/versions/list.html:208
-#: src/olympia/devhub/templates/devhub/versions/list.html:242
-#: src/olympia/devhub/templates/devhub/versions/list.html:276
-#: src/olympia/devhub/templates/devhub/versions/list.html:317
-#: src/olympia/reviews/templates/reviews/edit_review.html:16
-#: src/olympia/translations/templates/translations/trans-menu.html:50
-#: src/olympia/translations/templates/translations/trans-menu.html:62
-#: src/olympia/zadmin/templates/zadmin/validation.html:105
+#: src/olympia/addons/templates/addons/report_abuse.html:26 src/olympia/addons/templates/addons/mobile/eula.html:16 src/olympia/addons/templates/addons/mobile/persona_confirm.html:7
+#: src/olympia/devhub/templates/devhub/addons/ajax_compat_update.html:36 src/olympia/devhub/templates/devhub/addons/profile.html:44 src/olympia/devhub/templates/devhub/addons/edit/admin.html:104
+#: src/olympia/devhub/templates/devhub/addons/edit/basic.html:155 src/olympia/devhub/templates/devhub/addons/edit/details.html:88 src/olympia/devhub/templates/devhub/addons/edit/support.html:70
+#: src/olympia/devhub/templates/devhub/addons/edit/technical.html:169 src/olympia/devhub/templates/devhub/addons/forms_shared/media.html:152
+#: src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:43 src/olympia/devhub/templates/devhub/personas/edit.html:222 src/olympia/devhub/templates/devhub/versions/add_file_modal.html:59
+#: src/olympia/devhub/templates/devhub/versions/edit.html:140 src/olympia/devhub/templates/devhub/versions/list.html:208 src/olympia/devhub/templates/devhub/versions/list.html:239
+#: src/olympia/devhub/templates/devhub/versions/list.html:281 src/olympia/devhub/templates/devhub/versions/list.html:315 src/olympia/reviews/templates/reviews/edit_review.html:16
+#: src/olympia/translations/templates/translations/trans-menu.html:50 src/olympia/translations/templates/translations/trans-menu.html:62 src/olympia/zadmin/templates/zadmin/validation.html:105
 msgid "Cancel"
 msgstr "გაუქმება"
 
-#: src/olympia/addons/templates/addons/review_add_box.html:3
-#: src/olympia/addons/templates/addons/impala/review_add_box.html:5
+#: src/olympia/addons/templates/addons/review_add_box.html:3 src/olympia/addons/templates/addons/impala/review_add_box.html:5
 msgid "What do you think?"
 msgstr "არ აზრის ხართ?"
 
-#: src/olympia/addons/templates/addons/review_add_box.html:7
-#: src/olympia/addons/templates/addons/impala/review_add_box.html:9
+#: src/olympia/addons/templates/addons/review_add_box.html:7 src/olympia/addons/templates/addons/impala/review_add_box.html:9
 #, python-format
 msgid "Please <a href=\"%(login)s\">log in</a> to submit a review"
 msgstr "მიმოხილვის გასაგზავნათ, გთხოვთ <a href=\"%(login)s\">შედით</a> ანგარიშში"
 
-#: src/olympia/addons/templates/addons/review_add_box.html:16
-#: src/olympia/addons/templates/addons/impala/review_add_box.html:18
-#: src/olympia/reviews/templates/reviews/mobile/add_form.html:13
+#: src/olympia/addons/templates/addons/review_add_box.html:16 src/olympia/addons/templates/addons/impala/review_add_box.html:18 src/olympia/reviews/templates/reviews/mobile/add_form.html:13
 msgid "Title:"
 msgstr "სათაური:"
 
-#: src/olympia/addons/templates/addons/review_add_box.html:17
-#: src/olympia/addons/templates/addons/impala/review_add_box.html:19
-#: src/olympia/reviews/templates/reviews/mobile/add_form.html:17
+#: src/olympia/addons/templates/addons/review_add_box.html:17 src/olympia/addons/templates/addons/impala/review_add_box.html:19 src/olympia/reviews/templates/reviews/mobile/add_form.html:17
 msgid "Review:"
 msgstr "მიმოხილვა:"
 
-#: src/olympia/addons/templates/addons/review_add_box.html:18
-#: src/olympia/addons/templates/addons/impala/review_add_box.html:20
-#: src/olympia/reviews/templates/reviews/mobile/add_form.html:16
+#: src/olympia/addons/templates/addons/review_add_box.html:18 src/olympia/addons/templates/addons/impala/review_add_box.html:20 src/olympia/reviews/templates/reviews/mobile/add_form.html:16
 msgid "Rating:"
 msgstr "შეფასება:"
 
-#: src/olympia/addons/templates/addons/review_add_box.html:19
-#: src/olympia/addons/templates/addons/impala/review_add_box.html:21
-#: src/olympia/reviews/templates/reviews/add.html:63
-#: src/olympia/reviews/templates/reviews/edit_review.html:15
-#: src/olympia/reviews/templates/reviews/mobile/add_form.html:18
+#: src/olympia/addons/templates/addons/review_add_box.html:19 src/olympia/addons/templates/addons/impala/review_add_box.html:21 src/olympia/reviews/templates/reviews/add.html:63
+#: src/olympia/reviews/templates/reviews/edit_review.html:15 src/olympia/reviews/templates/reviews/mobile/add_form.html:18
 msgid "Submit review"
 msgstr "შეფასების გაგზავნა"
 
-#: src/olympia/addons/templates/addons/review_add_box.html:24
-#: src/olympia/addons/templates/addons/impala/review_add_box.html:26
-msgid ""
-"Please do not post bug reports in reviews. We do not make your email address"
-" available to add-on developers and they may need to contact you to help "
-"resolve your issue."
-msgstr ""
-"გთხოვთ, მიმოხილვაში ხარვეზებზე არ ისაუბროთ. შემქმნელისთვის თქვენი ელ-ფოსტის "
-"მისამართი არაა ხელმისაწვდომი, გაუმართაობის აღმოსაფხვრელად კი შეიძლება, "
-"თქვენთან დაკავშირება იყოს საჭირო."
+#: src/olympia/addons/templates/addons/review_add_box.html:24 src/olympia/addons/templates/addons/impala/review_add_box.html:26
+msgid "Please do not post bug reports in reviews. We do not make your email address available to add-on developers and they may need to contact you to help resolve your issue."
+msgstr "გთხოვთ, მიმოხილვაში ხარვეზებზე არ ისაუბროთ. შემქმნელისთვის თქვენი ელ-ფოსტის მისამართი არაა ხელმისაწვდომი, გაუმართაობის აღმოსაფხვრელად კი შეიძლება, თქვენთან დაკავშირება იყოს საჭირო."
 
-#: src/olympia/addons/templates/addons/review_add_box.html:32
-#: src/olympia/addons/templates/addons/impala/review_add_box.html:35
+#: src/olympia/addons/templates/addons/review_add_box.html:32 src/olympia/addons/templates/addons/impala/review_add_box.html:35
 #, python-format
-msgid ""
-"See the <a href=\"%(support)s\">support section</a> to find out where to get"
-" assistance for this add-on."
+msgid "See the <a href=\"%(support)s\">support section</a> to find out where to get assistance for this add-on."
 msgstr ""
 
-#: src/olympia/addons/templates/addons/review_add_box.html:38
-#: src/olympia/addons/templates/addons/impala/review_add_box.html:42
-#: src/olympia/pages/templates/pages/review_guide.html:3
+#: src/olympia/addons/templates/addons/review_add_box.html:38 src/olympia/addons/templates/addons/impala/review_add_box.html:42 src/olympia/pages/templates/pages/review_guide.html:3
 #: src/olympia/pages/templates/pages/review_guide.html:44
 msgid "Review Guidelines"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/review_list_box.html:5
-#: src/olympia/addons/templates/addons/impala/details-more.html:27
-#: src/olympia/editors/helpers.py:921
-#: src/olympia/reviews/templates/reviews/add.html:14
-#: src/olympia/reviews/templates/reviews/reply.html:14
-#: src/olympia/reviews/templates/reviews/review_list.html:19
+#: src/olympia/addons/templates/addons/review_list_box.html:5 src/olympia/addons/templates/addons/impala/details-more.html:27 src/olympia/editors/helpers.py:1001
+#: src/olympia/reviews/templates/reviews/add.html:14 src/olympia/reviews/templates/reviews/reply.html:14 src/olympia/reviews/templates/reviews/review_list.html:19
 #: src/olympia/reviews/templates/reviews/mobile/review_list.html:26
 msgid "Reviews"
 msgstr "მიმოხილვები"
 
-#: src/olympia/addons/templates/addons/review_list_box.html:14
-#: src/olympia/addons/templates/addons/impala/review_list_box.html:14
-#: src/olympia/reviews/templates/reviews/review.html:30
+#: src/olympia/addons/templates/addons/review_list_box.html:14 src/olympia/addons/templates/addons/impala/review_list_box.html:14 src/olympia/reviews/templates/reviews/review.html:30
 #, python-format
 msgid "by %(user)s on %(date)s"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/review_list_box.html:19
-#: src/olympia/addons/templates/addons/impala/review_list_box.html:29
+#: src/olympia/addons/templates/addons/review_list_box.html:19 src/olympia/addons/templates/addons/impala/review_list_box.html:29
 msgid "Show the developer's reply to this review"
 msgstr "შემქმნელის პასუხის ჩვენება, ამ მიმოხილვაზე"
 
@@ -1195,22 +898,18 @@ msgstr "შემქმნელის პასუხის ჩვენებ�
 msgid "See all reviews of this add-on"
 msgid_plural "See all %(cnt)s reviews of this add-on"
 msgstr[0] ""
+msgstr[1] ""
 
-#: src/olympia/addons/templates/addons/tags_box.html:3
-#: src/olympia/devhub/templates/devhub/addons/edit/basic.html:118
+#: src/olympia/addons/templates/addons/tags_box.html:3 src/olympia/devhub/templates/devhub/addons/edit/basic.html:118
 msgid "Tags"
 msgstr "ჭდეები"
 
-#: src/olympia/addons/templates/addons/impala/addon_hovercard.html:7
-#: src/olympia/addons/templates/addons/impala/addon_hovercard.html:9
+#: src/olympia/addons/templates/addons/impala/addon_hovercard.html:7 src/olympia/addons/templates/addons/impala/addon_hovercard.html:9
 msgid "Icon for {0}"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/impala/addon_hovercard.html:34
-#: src/olympia/addons/templates/addons/impala/featured_grid.html:26
-#: src/olympia/addons/templates/addons/impala/theme_grid.html:22
-#: src/olympia/bandwagon/templates/bandwagon/collection_detail.html:31
-#: src/olympia/users/templates/users/helpers/addon_users_list.html:7
+#: src/olympia/addons/templates/addons/impala/addon_hovercard.html:34 src/olympia/addons/templates/addons/impala/featured_grid.html:26 src/olympia/addons/templates/addons/impala/theme_grid.html:22
+#: src/olympia/bandwagon/templates/bandwagon/collection_detail.html:31 src/olympia/users/templates/users/helpers/addon_users_list.html:7
 #, python-format
 msgid "by %(users)s"
 msgstr ""
@@ -1230,25 +929,17 @@ msgstr "მოგწონთ ეს დამატება?"
 
 #: src/olympia/addons/templates/addons/impala/contribution.html:43
 #, python-format
-msgid ""
-"The <a href=\"%(meet_url)s\">developer of this add-on</a> asks that you help"
-" support its continued development by making a small contribution."
+msgid "The <a href=\"%(meet_url)s\">developer of this add-on</a> asks that you help support its continued development by making a small contribution."
 msgstr ""
 
 #: src/olympia/addons/templates/addons/impala/contribution.html:48
 #, python-format
-msgid ""
-"The <a href=\"%(meet_url)s\">developer of this add-on</a> asks that you show"
-" your support by making a donation to the <a "
-"href=\"%(charity_url)s\">%(charity_name)s</a>."
+msgid "The <a href=\"%(meet_url)s\">developer of this add-on</a> asks that you show your support by making a donation to the <a href=\"%(charity_url)s\">%(charity_name)s</a>."
 msgstr ""
 
 #: src/olympia/addons/templates/addons/impala/contribution.html:53
 #, python-format
-msgid ""
-"The <a href=\"%(meet_url)s\">developer of this add-on</a> asks that you show"
-" your support by making a small contribution to <a "
-"href=\"%(charity_url)s\">%(charity_name)s</a>."
+msgid "The <a href=\"%(meet_url)s\">developer of this add-on</a> asks that you show your support by making a small contribution to <a href=\"%(charity_url)s\">%(charity_name)s</a>."
 msgstr ""
 
 #: src/olympia/addons/templates/addons/impala/dependencies_note.html:4
@@ -1276,142 +967,123 @@ msgstr "ამ კრებულების ნაწილი"
 msgid "Other add-ons by %(author)s"
 msgid_plural "Other add-ons by these authors"
 msgstr[0] "ამ ავტორის სხვა დამატებები"
+msgstr[1] ""
 
-#: src/olympia/addons/templates/addons/impala/details.html:41
+#: src/olympia/addons/templates/addons/impala/details.html:39
 #, python-format
 msgid "<span itemprop=\"ratingCount\">%(num)s</span> user review"
 msgid_plural "<span itemprop=\"ratingCount\">%(num)s</span> user reviews"
 msgstr[0] ""
+msgstr[1] ""
 
-#: src/olympia/addons/templates/addons/impala/details.html:69
+#: src/olympia/addons/templates/addons/impala/details.html:66
 msgid "View statistics"
 msgstr "სტატისტიკის ნახვა"
 
-#: src/olympia/addons/templates/addons/impala/details.html:84
+#: src/olympia/addons/templates/addons/impala/details.html:81
 msgid "Manage"
 msgstr "მართვა"
 
 #. {0} is an add-on name.
-#: src/olympia/addons/templates/addons/impala/details.html:96
+#: src/olympia/addons/templates/addons/impala/details.html:93
 msgid "Icon of {0}"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/impala/details.html:103
-#: src/olympia/addons/templates/addons/impala/listing/items.html:14
+#: src/olympia/addons/templates/addons/impala/details.html:100 src/olympia/addons/templates/addons/impala/listing/items.html:14
 msgid "No Restart"
 msgstr "გადაუტვირთავად"
 
-#: src/olympia/addons/templates/addons/impala/details.html:127
+#: src/olympia/addons/templates/addons/impala/details.html:124
 #, python-format
 msgid "Meet the Developer: <a href=\"%(url)s\">%(name)s</a>"
 msgid_plural "<a href=\"%(url)s\">Meet the Developers</a>"
 msgstr[0] ""
+msgstr[1] ""
 
-#: src/olympia/addons/templates/addons/impala/details.html:137
+#: src/olympia/addons/templates/addons/impala/details.html:134
 msgid "Learn why {0} was created and find out what's next for this add-on."
 msgstr ""
 
 #. {0} is an index.
-#: src/olympia/addons/templates/addons/impala/details.html:156
+#: src/olympia/addons/templates/addons/impala/details.html:161
 msgid "Add-on screenshot #{0}"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/impala/details.html:182
+#: src/olympia/addons/templates/addons/impala/details.html:187
 msgid "Add-on home page"
 msgstr "დამატების საშინაო გვერდი"
 
-#: src/olympia/addons/templates/addons/impala/details.html:185
+#: src/olympia/addons/templates/addons/impala/details.html:190
 msgid "Support site"
 msgstr "მხარდაჭერის საიტი"
 
-#: src/olympia/addons/templates/addons/impala/details.html:189
+#: src/olympia/addons/templates/addons/impala/details.html:194
 msgid "Support E-mail"
 msgstr "მხარდაჭერის ელ-ფოსტა"
 
-#: src/olympia/addons/templates/addons/impala/details.html:194
-#: src/olympia/devhub/models.py:378
-#: src/olympia/devhub/templates/devhub/versions/list.html:12
-#: src/olympia/versions/templates/versions/version.html:6
-#: src/olympia/versions/templates/versions/mobile/version.html:6
+#: src/olympia/addons/templates/addons/impala/details.html:199 src/olympia/devhub/models.py:378 src/olympia/devhub/templates/devhub/versions/list.html:12
+#: src/olympia/versions/templates/versions/version.html:6 src/olympia/versions/templates/versions/mobile/version.html:6
 msgid "Version {0}"
 msgstr "ვერსია {0}"
 
-#: src/olympia/addons/templates/addons/impala/details.html:194
+#: src/olympia/addons/templates/addons/impala/details.html:199
 msgid "Info"
 msgstr "ინფორმაცია"
 
-#: src/olympia/addons/templates/addons/impala/details.html:195
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:129
+#: src/olympia/addons/templates/addons/impala/details.html:200 src/olympia/devhub/templates/devhub/includes/addon_details.html:116
 msgid "Last Updated:"
 msgstr "ბოლო განახლება:"
 
-#: src/olympia/addons/templates/addons/impala/details.html:200
+#: src/olympia/addons/templates/addons/impala/details.html:205
 #, python-format
 msgid "Released under <a target=\"_blank\" href=\"%(url)s\">%(name)s</a>"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/impala/details.html:201
-#: src/olympia/addons/templates/addons/impala/details.html:206
-#: src/olympia/amo/helpers.py:398 src/olympia/devhub/forms.py:142
-#: src/olympia/devhub/forms.py:173
-#: src/olympia/versions/templates/versions/version.html:40
-#: src/olympia/versions/templates/versions/version.html:45
+#: src/olympia/addons/templates/addons/impala/details.html:206 src/olympia/addons/templates/addons/impala/details.html:211 src/olympia/amo/helpers.py:398 src/olympia/devhub/forms.py:142
+#: src/olympia/devhub/forms.py:173 src/olympia/versions/templates/versions/version.html:40 src/olympia/versions/templates/versions/version.html:45
 msgid "Custom License"
 msgstr "საკუთარი ლიცენზია"
 
-#: src/olympia/addons/templates/addons/impala/details.html:205
+#: src/olympia/addons/templates/addons/impala/details.html:210
 #, python-format
 msgid "Released under <a href=\"%(url)s\">%(name)s</a>"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/impala/details.html:217
+#: src/olympia/addons/templates/addons/impala/details.html:222
 msgid "About this Add-on"
 msgstr "ამ დამატების შესახებ"
 
-#: src/olympia/addons/templates/addons/impala/details.html:233
+#: src/olympia/addons/templates/addons/impala/details.html:238
 msgid "Developer’s Comments"
 msgstr "განმვითარებლის კომენტარები"
 
-#: src/olympia/addons/templates/addons/impala/details.html:243
+#: src/olympia/addons/templates/addons/impala/details.html:248
 msgid "Version Information"
 msgstr "ვერსიის ინფორმაცია"
 
-#: src/olympia/addons/templates/addons/impala/details.html:250
+#: src/olympia/addons/templates/addons/impala/details.html:255
 msgid "See complete version history"
 msgstr "ვერსიის სრული ისტორია"
 
-#: src/olympia/addons/templates/addons/impala/details.html:262
+#: src/olympia/addons/templates/addons/impala/details.html:267
 msgid ""
-"The Development Channel lets you test an experimental new version of this "
-"add-on before it's released to the general public. Once you install the "
-"development version, you will continue to get updates from this channel. To "
-"stop receiving development updates, reinstall the default version from the "
-"link above."
+"The Development Channel lets you test an experimental new version of this add-on before it's released to the general public. Once you install the development version, you will continue to get "
+"updates from this channel. To stop receiving development updates, reinstall the default version from the link above."
 msgstr ""
-"განვითარების არხი საშუალებას გაძლევთ გასინჯოთ ამ დამატების ახალი "
-"ექსპერიმენტალური ვერსიები მათ საჯაროდ გამოშვებამდე. განვითარების ვერსიის "
-"დაყენების შემდეგ, განახლებებს მიიღებთ პირდაპირ ამ არხიდან. განვითარების "
-"განახლებების მიღების შესაწყვეტად, ხელახლა დააყენეთ ნაგულისხმევი ვერსია ზემოთ"
-" მოცემული ბმულით."
+"განვითარების არხი საშუალებას გაძლევთ გასინჯოთ ამ დამატების ახალი ექსპერიმენტალური ვერსიები მათ საჯაროდ გამოშვებამდე. განვითარების ვერსიის დაყენების შემდეგ, განახლებებს მიიღებთ პირდაპირ ამ არხიდან. "
+"განვითარების განახლებების მიღების შესაწყვეტად, ხელახლა დააყენეთ ნაგულისხმევი ვერსია ზემოთ მოცემული ბმულით."
 
-#: src/olympia/addons/templates/addons/impala/details.html:272
-msgid ""
-"<strong>Caution:</strong> Development versions of this add-on have not been "
-"reviewed by Mozilla."
+#: src/olympia/addons/templates/addons/impala/details.html:277
+msgid "<strong>Caution:</strong> Development versions of this add-on have not been reviewed by Mozilla."
 msgstr ""
 
-#: src/olympia/addons/templates/addons/impala/details.html:287
+#: src/olympia/addons/templates/addons/impala/details.html:292
 msgid "See complete development channel history"
 msgstr "იხილეთ განვითარების არხის სრული ისტორია"
 
-#: src/olympia/addons/templates/addons/impala/details.html:306
-#: src/olympia/addons/templates/addons/impala/details.html:315
-#: src/olympia/addons/templates/addons/impala/details.html:327
-#: src/olympia/addons/templates/addons/impala/review_add_box.html:4
-#: src/olympia/stats/templates/stats/popup.html:2
-#: src/olympia/stats/templates/stats/popup.html:8
-#: src/olympia/stats/templates/stats/stats.html:202
-#: src/olympia/users/templates/users/profile.html:119
+#: src/olympia/addons/templates/addons/impala/details.html:311 src/olympia/addons/templates/addons/impala/details.html:320 src/olympia/addons/templates/addons/impala/details.html:332
+#: src/olympia/addons/templates/addons/impala/review_add_box.html:4 src/olympia/stats/templates/stats/popup.html:2 src/olympia/stats/templates/stats/popup.html:8
+#: src/olympia/stats/templates/stats/stats.html:204 src/olympia/users/templates/users/profile.html:119
 msgid "close"
 msgstr "დახურვა"
 
@@ -1426,9 +1098,7 @@ msgid "Meet the {0} Developer"
 msgstr ""
 
 #: src/olympia/addons/templates/addons/impala/developers.html:41
-msgid ""
-"Before downloading this add-on, please consider supporting the development "
-"of this add-on by making a small contribution."
+msgid "Before downloading this add-on, please consider supporting the development of this add-on by making a small contribution."
 msgstr ""
 
 #: src/olympia/addons/templates/addons/impala/developers.html:80
@@ -1443,10 +1113,9 @@ msgstr ""
 msgid "About the Developer"
 msgid_plural "About the Developers"
 msgstr[0] "შემქმნელების შესახებ"
+msgstr[1] ""
 
-#: src/olympia/addons/templates/addons/impala/developers.html:96
-#: src/olympia/users/templates/users/edit.html:130
-#: src/olympia/users/templates/users/profile.html:26
+#: src/olympia/addons/templates/addons/impala/developers.html:96 src/olympia/users/templates/users/edit.html:130 src/olympia/users/templates/users/profile.html:26
 msgid "No Photo"
 msgstr "ფოტო არაა"
 
@@ -1466,24 +1135,15 @@ msgstr ""
 msgid "Source Code License for {addon}"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/impala/license.html:21
-#: src/olympia/versions/templates/versions/mobile/version.html:18
+#: src/olympia/addons/templates/addons/impala/license.html:21 src/olympia/versions/templates/versions/mobile/version.html:18
 msgid "Source Code License"
 msgstr "წყაროს კოდის ლიცენზია"
 
-#: src/olympia/addons/templates/addons/impala/persona_grid.html:16
-#: src/olympia/addons/templates/addons/impala/toplist.html:6
-msgid "{0} users"
-msgstr "{0} მომხმარებელი"
-
-#: src/olympia/addons/templates/addons/impala/review_list_box.html:19
-#: src/olympia/reviews/templates/reviews/review.html:40
+#: src/olympia/addons/templates/addons/impala/review_list_box.html:19 src/olympia/reviews/templates/reviews/review.html:40
 msgid "permalink"
 msgstr "permalink"
 
-#: src/olympia/addons/templates/addons/impala/review_list_box.html:23
-#: src/olympia/editors/templates/editors/queue.html:98
-#: src/olympia/reviews/templates/reviews/review.html:44
+#: src/olympia/addons/templates/addons/impala/review_list_box.html:23 src/olympia/editors/templates/editors/queue.html:104 src/olympia/reviews/templates/reviews/review.html:44
 msgid "translate"
 msgstr "გადათარგმნა"
 
@@ -1492,9 +1152,9 @@ msgstr "გადათარგმნა"
 msgid "See all user reviews"
 msgid_plural "See all %(cnt)s user reviews"
 msgstr[0] "ყველა %(cnt)s მომხმარებლის მიმოხილვის ნახვა"
+msgstr[1] ""
 
-#: src/olympia/addons/templates/addons/impala/review_list_box.html:47
-#: src/olympia/reviews/templates/reviews/review_list.html:84
+#: src/olympia/addons/templates/addons/impala/review_list_box.html:47 src/olympia/reviews/templates/reviews/review_list.html:84
 msgid "This add-on has not yet been reviewed."
 msgstr "ეს დამატების მიმოხილვა, ჯერ არავის გაუკეთებია."
 
@@ -1502,24 +1162,23 @@ msgstr "ეს დამატების მიმოხილვა, ჯე�
 msgid "Be the first!"
 msgstr "იყავით პირველი!"
 
-#: src/olympia/addons/templates/addons/impala/listing/sorter.html:14
-#: src/olympia/devhub/templates/devhub/addons/listing/item_actions.html:49
+#: src/olympia/addons/templates/addons/impala/toplist.html:6
+msgid "{0} users"
+msgstr "{0} მომხმარებელი"
+
+#: src/olympia/addons/templates/addons/impala/listing/sorter.html:14 src/olympia/devhub/templates/devhub/addons/listing/item_actions.html:49
 msgid "More"
 msgstr "დამატებით"
 
-#: src/olympia/addons/templates/addons/includes/collection_add_widget.html:7
-#: src/olympia/addons/templates/addons/includes/collection_add_widget.html:10
+#: src/olympia/addons/templates/addons/includes/collection_add_widget.html:7 src/olympia/addons/templates/addons/includes/collection_add_widget.html:10
 msgid "Add to collection"
 msgstr "რჩეულ ნაკრებში დამატება"
 
-#: src/olympia/addons/templates/addons/includes/dashboard_tabs.html:4
-#: src/olympia/devhub/templates/devhub/index.html:73
-#: src/olympia/devhub/templates/devhub/nav.html:14
+#: src/olympia/addons/templates/addons/includes/dashboard_tabs.html:4 src/olympia/devhub/templates/devhub/index.html:73 src/olympia/devhub/templates/devhub/nav.html:14
 msgid "My Add-ons"
 msgstr "ჩემი დამატებები"
 
-#: src/olympia/addons/templates/addons/includes/dashboard_tabs.html:6
-#: src/olympia/amo/context_processors.py:51
+#: src/olympia/addons/templates/addons/includes/dashboard_tabs.html:6 src/olympia/amo/context_processors.py:50
 msgid "My Themes"
 msgstr "ჩემი თემები"
 
@@ -1535,8 +1194,7 @@ msgstr "თემის ჩასწორება"
 msgid "Approve / Reject"
 msgstr "მიღება / უარყოფა"
 
-#: src/olympia/addons/templates/addons/includes/persona.html:25
-#: src/olympia/editors/templates/editors/themes/single.html:43
+#: src/olympia/addons/templates/addons/includes/persona.html:25 src/olympia/editors/templates/editors/themes/single.html:43
 msgid "Review History"
 msgstr "მიმოხილვის ისტორია"
 
@@ -1557,12 +1215,11 @@ msgid "Not Yet Rated"
 msgstr "ჯერ არაა შეფასებული"
 
 #. {0} is the number of downloads.
-#: src/olympia/addons/templates/addons/listing/items_mobile.html:27
-#: src/olympia/addons/templates/addons/listing/macros.html:24
-#: src/olympia/devhub/templates/devhub/addons/listing/macros.html:15
+#: src/olympia/addons/templates/addons/listing/items_mobile.html:27 src/olympia/addons/templates/addons/listing/macros.html:24 src/olympia/devhub/templates/devhub/addons/listing/macros.html:15
 msgid "<strong>{0}</strong> weekly download"
 msgid_plural "<strong>{0}</strong> weekly downloads"
 msgstr[0] "<strong>{0}</strong> ყოველკვირეული ჩამოტვირთვა"
+msgstr[1] ""
 
 #: src/olympia/addons/templates/addons/mobile/details.html:32
 msgid "Read More"
@@ -1572,15 +1229,11 @@ msgstr "იხილეთ მეტი"
 msgid "Users"
 msgstr "მომხმარებლები"
 
-#: src/olympia/addons/templates/addons/mobile/details.html:92
-#: src/olympia/browse/views.py:59 src/olympia/browse/views.py:70
-#: src/olympia/search/forms.py:90
+#: src/olympia/addons/templates/addons/mobile/details.html:92 src/olympia/browse/views.py:59 src/olympia/browse/views.py:70 src/olympia/search/forms.py:90
 msgid "Weekly Downloads"
 msgstr "ყოველკვირეული ჩამოტვირთვები"
 
-#: src/olympia/addons/templates/addons/mobile/details.html:99
-#: src/olympia/compat/templates/compat/reporter_detail.html:46
-#: src/olympia/devhub/forms.py:787
+#: src/olympia/addons/templates/addons/mobile/details.html:99 src/olympia/compat/templates/compat/reporter_detail.html:46 src/olympia/devhub/forms.py:788
 #: src/olympia/devhub/templates/devhub/versions/list.html:163
 msgid "Version"
 msgstr "ვერსია"
@@ -1616,47 +1269,29 @@ msgstr "სალიცენზიო შეთანხმება"
 
 #: src/olympia/addons/templates/addons/mobile/eula.html:5
 #, python-format
-msgid ""
-"%(name)s requires that you accept the following End-User License Agreement "
-"before installation can proceed:"
+msgid "%(name)s requires that you accept the following End-User License Agreement before installation can proceed:"
 msgstr ""
 
 #: src/olympia/addons/templates/addons/mobile/eula.html:15
 msgid "Accept"
 msgstr "მიღება"
 
-#: src/olympia/addons/templates/addons/mobile/home.html:10
-#: src/olympia/templates/mobile/base_addons.html:53
+#: src/olympia/addons/templates/addons/mobile/home.html:10 src/olympia/templates/mobile/base_addons.html:53
 msgid "Add-ons are not currently available on Firefox for iOS."
 msgstr "დამატებები ჯერჯერობით არაა ხელმისავსომი Firefox-ის iOS ვერსიაზე."
 
-#: src/olympia/addons/templates/addons/mobile/home.html:12
-#: src/olympia/templates/mobile/base_addons.html:55
-msgid ""
-"You need Firefox to install add-ons. <a "
-"href=\"http://mozilla.com/mobile\">Learn More&nbsp;&raquo;</a>"
-msgstr ""
-"დამატებების დასაყენებლად საჭიროა Firefox. <a "
-"href=\"http://mozilla.com/mobile\">დაწვრილებით&nbsp;&raquo;</a>"
+#: src/olympia/addons/templates/addons/mobile/home.html:12 src/olympia/templates/mobile/base_addons.html:55
+msgid "You need Firefox to install add-ons. <a href=\"http://mozilla.com/mobile\">Learn More&nbsp;&raquo;</a>"
+msgstr "დამატებების დასაყენებლად საჭიროა Firefox. <a href=\"http://mozilla.com/mobile\">დაწვრილებით&nbsp;&raquo;</a>"
 
-#: src/olympia/addons/templates/addons/mobile/home.html:19
-#: src/olympia/templates/header_title.html:4
-#: src/olympia/templates/impala/header_title.html:3
+#: src/olympia/addons/templates/addons/mobile/home.html:19 src/olympia/templates/header_title.html:4 src/olympia/templates/impala/header_title.html:3
 msgid "Return to the {0} Add-ons homepage"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/mobile/home.html:21
-#: src/olympia/amo/helpers.py:237
-#: src/olympia/bandwagon/templates/bandwagon/edit.html:34
-#: src/olympia/discovery/templates/discovery/pane.html:92
-#: src/olympia/editors/templates/editors/base.html:21
-#: src/olympia/editors/templates/editors/performance.html:72
-#: src/olympia/templates/menu_links.html:4
-#: src/olympia/templates/impala/header_title.html:13
-#: src/olympia/templates/impala/header_title.html:15
-#: src/olympia/templates/impala/header_title.html:19
-#: src/olympia/templates/impala/header_title.html:23
-#: src/olympia/templates/mobile/base_addons.html:47
+#: src/olympia/addons/templates/addons/mobile/home.html:21 src/olympia/amo/helpers.py:237 src/olympia/bandwagon/templates/bandwagon/edit.html:34 src/olympia/discovery/templates/discovery/pane.html:92
+#: src/olympia/editors/templates/editors/base.html:21 src/olympia/editors/templates/editors/performance.html:72 src/olympia/templates/menu_links.html:4
+#: src/olympia/templates/impala/header_title.html:13 src/olympia/templates/impala/header_title.html:15 src/olympia/templates/impala/header_title.html:19
+#: src/olympia/templates/impala/header_title.html:23 src/olympia/templates/mobile/base_addons.html:47
 msgid "Add-ons"
 msgstr "დამატებები"
 
@@ -1664,44 +1299,26 @@ msgstr "დამატებები"
 msgid "Easy ways to personalize."
 msgstr ""
 
-#: src/olympia/addons/templates/addons/mobile/home.html:24
-#: src/olympia/devhub/templates/devhub/addons/submit/done.html:47
-#: src/olympia/discovery/templates/discovery/pane.html:34
-#: src/olympia/discovery/templates/discovery/addons/detail.html:16
-#: src/olympia/discovery/templates/discovery/modules/featured.html:21
-#: src/olympia/discovery/templates/discovery/modules/monthly.html:22
+#: src/olympia/addons/templates/addons/mobile/home.html:24 src/olympia/devhub/templates/devhub/addons/submit/done.html:47 src/olympia/discovery/templates/discovery/pane.html:34
+#: src/olympia/discovery/templates/discovery/addons/detail.html:16 src/olympia/discovery/templates/discovery/modules/featured.html:21 src/olympia/discovery/templates/discovery/modules/monthly.html:22
 msgid "Learn More"
 msgstr "გაიგეთ მეტი"
 
 #: src/olympia/addons/templates/addons/mobile/home.html:26
 msgid ""
-"Add-ons are applications that let you personalize Firefox with extra "
-"functionality and style. Whether you mistype the name of a website or can't "
-"read a busy page, there's an add-on to improve your on-the-go browsing."
+"Add-ons are applications that let you personalize Firefox with extra functionality and style. Whether you mistype the name of a website or can't read a busy page, there's an add-on to improve your "
+"on-the-go browsing."
 msgstr ""
 
 #. {0} is a category name. Ex: "Sports"
 #. {0} is a category name, such as Nature.
-#: src/olympia/addons/templates/addons/mobile/home.html:43
-#: src/olympia/amo/templates/amo/site_nav.html:32
-#: src/olympia/browse/feeds.py:107
-#: src/olympia/browse/templates/browse/impala/base_listing.html:38
-#: src/olympia/browse/templates/browse/personas/base.html:6
-#: src/olympia/browse/templates/browse/personas/base.html:42
-#: src/olympia/browse/templates/browse/personas/category_landing.html:21
-#: src/olympia/browse/templates/browse/personas/category_landing.html:23
-#: src/olympia/browse/templates/browse/personas/category_landing.html:38
-#: src/olympia/browse/templates/browse/personas/grid.html:7
-#: src/olympia/browse/templates/browse/personas/grid.html:11
-#: src/olympia/browse/templates/browse/personas/mobile/base.html:7
-#: src/olympia/browse/templates/browse/personas/mobile/category_landing.html:19
-#: src/olympia/constants/base.py:180
-#: src/olympia/devhub/templates/devhub/personas/submit.html:13
-#: src/olympia/editors/helpers.py:105
-#: src/olympia/editors/templates/editors/base.html:26
-#: src/olympia/editors/templates/editors/performance.html:73
-#: src/olympia/search/templates/search/personas.html:39
-#: src/olympia/templates/menu_links.html:9
+#: src/olympia/addons/templates/addons/mobile/home.html:43 src/olympia/amo/templates/amo/site_nav.html:32 src/olympia/browse/feeds.py:107
+#: src/olympia/browse/templates/browse/impala/base_listing.html:38 src/olympia/browse/templates/browse/personas/base.html:6 src/olympia/browse/templates/browse/personas/base.html:42
+#: src/olympia/browse/templates/browse/personas/category_landing.html:21 src/olympia/browse/templates/browse/personas/category_landing.html:23
+#: src/olympia/browse/templates/browse/personas/category_landing.html:38 src/olympia/browse/templates/browse/personas/grid.html:7 src/olympia/browse/templates/browse/personas/grid.html:11
+#: src/olympia/browse/templates/browse/personas/mobile/base.html:7 src/olympia/browse/templates/browse/personas/mobile/category_landing.html:19 src/olympia/constants/base.py:180
+#: src/olympia/devhub/templates/devhub/personas/submit.html:13 src/olympia/editors/helpers.py:107 src/olympia/editors/templates/editors/base.html:26
+#: src/olympia/editors/templates/editors/performance.html:73 src/olympia/search/templates/search/personas.html:39 src/olympia/templates/menu_links.html:9
 msgid "Themes"
 msgstr "თემები"
 
@@ -1717,19 +1334,12 @@ msgstr "ყველა მოთხოვნადი დამატები�
 msgid "More Add-ons"
 msgstr "მეტი დამატებები"
 
-#: src/olympia/addons/templates/addons/mobile/home.html:72
-#: src/olympia/browse/templates/browse/personas/mobile/category_landing.html:64
-#: src/olympia/search/forms.py:14
+#: src/olympia/addons/templates/addons/mobile/home.html:72 src/olympia/browse/templates/browse/personas/mobile/category_landing.html:64 src/olympia/search/forms.py:14
 msgid "Highest Rated"
 msgstr "უმაღლესი შეფასების მქონე"
 
-#: src/olympia/addons/templates/addons/mobile/home.html:74
-#: src/olympia/amo/templates/amo/side_nav.html:5
-#: src/olympia/amo/templates/amo/site_nav.html:27
-#: src/olympia/amo/templates/amo/site_nav.html:57
-#: src/olympia/bandwagon/views.py:97 src/olympia/browse/views.py:57
-#: src/olympia/browse/views.py:67
-#: src/olympia/browse/templates/browse/personas/mobile/category_landing.html:65
+#: src/olympia/addons/templates/addons/mobile/home.html:74 src/olympia/amo/templates/amo/side_nav.html:5 src/olympia/amo/templates/amo/site_nav.html:27 src/olympia/amo/templates/amo/site_nav.html:55
+#: src/olympia/bandwagon/views.py:97 src/olympia/browse/views.py:57 src/olympia/browse/views.py:67 src/olympia/browse/templates/browse/personas/mobile/category_landing.html:65
 #: src/olympia/search/forms.py:15 src/olympia/search/forms.py:87
 msgid "Newest"
 msgstr "უახლესი"
@@ -1742,122 +1352,90 @@ msgstr "გამოცადეთ!"
 msgid "Theme Info &raquo;"
 msgstr ""
 
-#: src/olympia/amo/context_processors.py:39
-#: src/olympia/devhub/templates/devhub/nav.html:43
+#: src/olympia/amo/context_processors.py:37 src/olympia/devhub/templates/devhub/nav.html:43
 msgid "Tools"
 msgstr "ხელსაწყოები"
 
-#: src/olympia/amo/context_processors.py:48
-#: src/olympia/discovery/templates/discovery/pane_account.html:8
-#: src/olympia/users/templates/users/includes/navigation.html:2
+#: src/olympia/amo/context_processors.py:47 src/olympia/discovery/templates/discovery/pane_account.html:8 src/olympia/users/templates/users/includes/navigation.html:2
 msgid "My Profile"
 msgstr "ჩემი პროფილი"
 
-#: src/olympia/amo/context_processors.py:54
-#: src/olympia/users/templates/users/edit.html:5
-#: src/olympia/users/templates/users/includes/navigation.html:3
+#: src/olympia/amo/context_processors.py:53 src/olympia/users/templates/users/edit.html:5 src/olympia/users/templates/users/includes/navigation.html:3
 msgid "Account Settings"
 msgstr "ანგარიშის პარამეტრები"
 
-#: src/olympia/amo/context_processors.py:57
-#: src/olympia/discovery/templates/discovery/pane_account.html:11
-#: src/olympia/users/templates/users/profile.html:83
+#: src/olympia/amo/context_processors.py:56 src/olympia/discovery/templates/discovery/pane_account.html:11 src/olympia/users/templates/users/profile.html:83
 #: src/olympia/users/templates/users/includes/navigation.html:4
 msgid "My Collections"
 msgstr "ჩემი კოლექციები"
 
-#: src/olympia/amo/context_processors.py:62
-#: src/olympia/discovery/templates/discovery/pane_account.html:10
-#: src/olympia/users/templates/users/includes/navigation.html:7
+#: src/olympia/amo/context_processors.py:61 src/olympia/discovery/templates/discovery/pane_account.html:10 src/olympia/users/templates/users/includes/navigation.html:7
 msgid "My Favorites"
 msgstr "ჩემი რჩეულები"
 
-#: src/olympia/amo/context_processors.py:67
-#: src/olympia/discovery/templates/discovery/pane_account.html:13
-#: src/olympia/templates/impala/user_login.html:14
+#: src/olympia/amo/context_processors.py:66 src/olympia/discovery/templates/discovery/pane_account.html:13 src/olympia/templates/impala/user_login.html:14
 #: src/olympia/templates/mobile/header_auth.html:5
 msgid "Log out"
 msgstr "გასვლა"
 
-#: src/olympia/amo/context_processors.py:72
-#: src/olympia/devhub/templates/devhub/addons/dashboard.html:4
+#: src/olympia/amo/context_processors.py:71 src/olympia/devhub/templates/devhub/addons/dashboard.html:4
 msgid "Manage My Submissions"
 msgstr ""
 
-#: src/olympia/amo/context_processors.py:75
-#: src/olympia/devhub/templates/devhub/nav.html:27
-#: src/olympia/devhub/templates/devhub/addons/dashboard.html:25
+#: src/olympia/amo/context_processors.py:74 src/olympia/devhub/templates/devhub/nav.html:27 src/olympia/devhub/templates/devhub/addons/dashboard.html:25
 #: src/olympia/devhub/templates/devhub/addons/submit/base.html:4
 msgid "Submit a New Add-on"
 msgstr "წარადგინეთ ახალი დამატება"
 
-#: src/olympia/amo/context_processors.py:77
-#: src/olympia/browse/templates/browse/personas/base.html:50
-#: src/olympia/devhub/templates/devhub/index.html:24
+#: src/olympia/amo/context_processors.py:76 src/olympia/browse/templates/browse/personas/base.html:50 src/olympia/devhub/templates/devhub/index.html:24
 #: src/olympia/devhub/templates/devhub/addons/dashboard.html:29
 msgid "Submit a New Theme"
 msgstr ""
 
-#: src/olympia/amo/context_processors.py:79
-#: src/olympia/amo/templates/amo/site_nav.html:87
-#: src/olympia/devhub/helpers.py:36 src/olympia/devhub/helpers.py:68
-#: src/olympia/devhub/helpers.py:102 src/olympia/templates/footer.html:6
-#: src/olympia/templates/menu_links.html:14
+#: src/olympia/amo/context_processors.py:78 src/olympia/amo/templates/amo/site_nav.html:85 src/olympia/devhub/helpers.py:36 src/olympia/devhub/helpers.py:68 src/olympia/devhub/helpers.py:102
+#: src/olympia/templates/footer.html:6 src/olympia/templates/menu_links.html:14
 msgid "Developer Hub"
 msgstr ""
 
-#: src/olympia/amo/context_processors.py:83 src/olympia/devhub/views.py:1792
+#: src/olympia/amo/context_processors.py:81 src/olympia/devhub/views.py:1796
 msgid "Manage API Keys"
 msgstr ""
 
-#: src/olympia/amo/context_processors.py:88 src/olympia/editors/helpers.py:82
-#: src/olympia/editors/helpers.py:102
-#: src/olympia/editors/templates/editors/base.html:10
+#: src/olympia/amo/context_processors.py:86 src/olympia/editors/helpers.py:84 src/olympia/editors/helpers.py:104 src/olympia/editors/templates/editors/base.html:10
 msgid "Editor Tools"
 msgstr ""
 
-#: src/olympia/amo/context_processors.py:92
+#: src/olympia/amo/context_processors.py:90
 msgid "Admin Tools"
 msgstr "ადმინის ხელსაწყოები"
 
-#: src/olympia/amo/fields.py:15
+#: src/olympia/amo/fields.py:20
 msgid "Incorrect, please try again."
 msgstr "არასწორი, გთხოვთ, ცადეთ ხელახლა."
 
-#: src/olympia/amo/fields.py:16
+#: src/olympia/amo/fields.py:21
 msgid "Error verifying input, please try again."
 msgstr "შენატანის დამოწმების შეცდომა, გთხოვთ, ცადეთ ხელახლა."
 
-#: src/olympia/amo/fields.py:32
+#: src/olympia/amo/fields.py:37
 msgid "This must be a valid hex color code, such as #000000."
 msgstr ""
 
-#: src/olympia/amo/fields.py:58
+#: src/olympia/amo/fields.py:63
 msgid "Enter at least one value."
 msgstr ""
 
-#: src/olympia/amo/helpers.py:162
-#: src/olympia/amo/templates/amo/site_nav.html:61
-#: src/olympia/bandwagon/templates/bandwagon/add.html:9
-#: src/olympia/bandwagon/templates/bandwagon/collection_detail.html:15
-#: src/olympia/bandwagon/templates/bandwagon/delete.html:9
-#: src/olympia/bandwagon/templates/bandwagon/edit.html:15
-#: src/olympia/bandwagon/templates/bandwagon/user_listing.html:18
-#: src/olympia/bandwagon/templates/bandwagon/user_listing.html:21
-#: src/olympia/bandwagon/templates/bandwagon/impala/collection_listing.html:12
-#: src/olympia/bandwagon/templates/bandwagon/impala/collection_listing.html:20
-#: src/olympia/bandwagon/templates/bandwagon/impala/collection_listing.html:24
-#: src/olympia/bandwagon/templates/bandwagon/impala/collection_sidebar.html:3
-#: src/olympia/bandwagon/templates/bandwagon/includes/collection_sidebar.html:2
-#: src/olympia/bandwagon/templates/bandwagon/mobile/collection_listing.html:3
-#: src/olympia/stats/templates/stats/stats.html:77
-#: src/olympia/templates/menu_links.html:12
+#: src/olympia/amo/helpers.py:162 src/olympia/amo/templates/amo/site_nav.html:59 src/olympia/bandwagon/templates/bandwagon/add.html:9
+#: src/olympia/bandwagon/templates/bandwagon/collection_detail.html:15 src/olympia/bandwagon/templates/bandwagon/delete.html:9 src/olympia/bandwagon/templates/bandwagon/edit.html:15
+#: src/olympia/bandwagon/templates/bandwagon/user_listing.html:18 src/olympia/bandwagon/templates/bandwagon/user_listing.html:21
+#: src/olympia/bandwagon/templates/bandwagon/impala/collection_listing.html:12 src/olympia/bandwagon/templates/bandwagon/impala/collection_listing.html:20
+#: src/olympia/bandwagon/templates/bandwagon/impala/collection_listing.html:24 src/olympia/bandwagon/templates/bandwagon/impala/collection_sidebar.html:3
+#: src/olympia/bandwagon/templates/bandwagon/includes/collection_sidebar.html:2 src/olympia/bandwagon/templates/bandwagon/mobile/collection_listing.html:3
+#: src/olympia/stats/templates/stats/stats.html:33 src/olympia/templates/menu_links.html:12
 msgid "Collections"
 msgstr "კოლექციები"
 
-#: src/olympia/amo/helpers.py:171
-#: src/olympia/amo/templates/amo/site_nav.html:85
-#: src/olympia/browse/templates/browse/language_tools.html:3
+#: src/olympia/amo/helpers.py:171 src/olympia/amo/templates/amo/site_nav.html:83 src/olympia/browse/templates/browse/language_tools.html:3
 msgid "Dictionaries & Language Packs"
 msgstr ""
 
@@ -2009,11 +1587,8 @@ msgstr ""
 msgid "Comment on {addon} {version}."
 msgstr ""
 
-#: src/olympia/amo/log.py:236
-#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:19
-#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:47
-#: src/olympia/editors/helpers.py:511
-#: src/olympia/editors/templates/editors/themes/history_table.html:11
+#: src/olympia/amo/log.py:236 src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:17 src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:45
+#: src/olympia/editors/helpers.py:584 src/olympia/editors/templates/editors/themes/history_table.html:11
 msgid "Comment"
 msgstr "კომენტარი"
 
@@ -2271,10 +1846,7 @@ msgstr ""
 msgid "{addon} unlisted."
 msgstr ""
 
-#: src/olympia/amo/log.py:592 src/olympia/amo/log.py:598
-#: src/olympia/amo/log.py:612 src/olympia/amo/log.py:618
-#: src/olympia/amo/log.py:624 src/olympia/amo/log.py:630
-#: src/olympia/amo/log.py:636
+#: src/olympia/amo/log.py:592 src/olympia/amo/log.py:598 src/olympia/amo/log.py:612 src/olympia/amo/log.py:618 src/olympia/amo/log.py:624 src/olympia/amo/log.py:630 src/olympia/amo/log.py:636
 msgid "{file} was signed."
 msgstr ""
 
@@ -2288,15 +1860,11 @@ msgid "Not allowed"
 msgstr ""
 
 #: src/olympia/amo/templates/amo/403.html:7
-msgid ""
-"<h1>Oops! Not allowed.</h1> <p>You tried to do something that you weren't "
-"allowed to.</p>"
+msgid "<h1>Oops! Not allowed.</h1> <p>You tried to do something that you weren't allowed to.</p>"
 msgstr ""
 
 #: src/olympia/amo/templates/amo/403.html:12
-msgid ""
-"<p>Try going back to the previous page, refreshing and then trying "
-"again.</p>"
+msgid "<p>Try going back to the previous page, refreshing and then trying again.</p>"
 msgstr ""
 
 #: src/olympia/amo/templates/amo/404.html:3
@@ -2306,20 +1874,12 @@ msgstr ""
 #: src/olympia/amo/templates/amo/404.html:6
 #, python-format
 msgid ""
-"<h1>We're sorry, but we can't find what you're looking for.</h1> <p> The "
-"page or file you requested wasn't found on our site. It's possible that you "
-"clicked a link that's out of date, or typed in the address incorrectly. </p>"
-" <ul> <li>If you typed in the address, please double check the "
-"spelling.</li> <li> If you followed a link from somewhere, please let us "
-"know at <a href=\"mailto:webmaster@mozilla.com\">webmaster@mozilla.com</a>. "
-"Tell us where you came from and what you were looking for, and we'll do our "
-"best to fix it. </li> </ul> <p>Or you can just jump over to some of the "
-"popular pages on our website.</p> <ul> <li>Are you interested in a <a "
-"href=\"%(rec)s\">list of featured add-ons</a>?</li> <li> Do you want to <a "
-"href=\"%(search)s\">search for add-ons</a>? You may go to the <a "
-"href=\"%(search)s\">search page</a> or just use the search field above. "
-"</li> <li> If you prefer to start over, just go to the <a href=\"%(home)s"
-"\">add-ons front page</a>. </li> </ul>"
+"<h1>We're sorry, but we can't find what you're looking for.</h1> <p> The page or file you requested wasn't found on our site. It's possible that you clicked a link that's out of date, or typed in "
+"the address incorrectly. </p> <ul> <li>If you typed in the address, please double check the spelling.</li> <li> If you followed a link from somewhere, please let us know at <a href=\"mailto:"
+"webmaster@mozilla.com\">webmaster@mozilla.com</a>. Tell us where you came from and what you were looking for, and we'll do our best to fix it. </li> </ul> <p>Or you can just jump over to some of "
+"the popular pages on our website.</p> <ul> <li>Are you interested in a <a href=\"%(rec)s\">list of featured add-ons</a>?</li> <li> Do you want to <a href=\"%(search)s\">search for add-ons</a>? You "
+"may go to the <a href=\"%(search)s\">search page</a> or just use the search field above. </li> <li> If you prefer to start over, just go to the <a href=\"%(home)s\">add-ons front page</a>. </li> </"
+"ul>"
 msgstr ""
 
 #: src/olympia/amo/templates/amo/500.html:3
@@ -2328,72 +1888,48 @@ msgstr ""
 
 #: src/olympia/amo/templates/amo/500.html:6
 #, python-format
-msgid ""
-"<h1>Oops!  We had an error.</h1> <p>We'll get to fixing that soon.</p> <p> "
-"You can try refreshing the page, or head back to the <a href=\"%(home)s"
-"\">Add-ons homepage</a>. </p>"
+msgid "<h1>Oops!  We had an error.</h1> <p>We'll get to fixing that soon.</p> <p> You can try refreshing the page, or head back to the <a href=\"%(home)s\">Add-ons homepage</a>. </p>"
 msgstr ""
 
 #: src/olympia/amo/templates/amo/license_link.html:10
 msgid "Some rights reserved"
 msgstr ""
 
-#: src/olympia/amo/templates/amo/no_results.html:1
-#: src/olympia/editors/templates/editors/includes/search_results_themes.html:26
+#: src/olympia/amo/templates/amo/no_results.html:1 src/olympia/editors/templates/editors/includes/search_results_themes.html:26
 msgid "No results found"
 msgstr ""
 
 #. abbreviation of 'previous'
-#: src/olympia/amo/templates/amo/paginator.html:6
-#: src/olympia/amo/templates/amo/mobile/paginator.html:4
-#: src/olympia/amo/templates/amo/mobile/paginator.html:6
-#: src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:49
-#: src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:63
-#: src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:76
-#: src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:89
+#: src/olympia/amo/templates/amo/paginator.html:6 src/olympia/amo/templates/amo/mobile/paginator.html:4 src/olympia/amo/templates/amo/mobile/paginator.html:6
+#: src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:49 src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:63
+#: src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:76 src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:89
 #: src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:102
 msgid "Prev"
 msgstr ""
 
-#: src/olympia/amo/templates/amo/paginator.html:26
-#: src/olympia/amo/templates/amo/impala/paginator.html:26
-#: src/olympia/amo/templates/amo/mobile/impala_paginator.html:16
-#: src/olympia/amo/templates/amo/mobile/paginator.html:14
-#: src/olympia/amo/templates/amo/mobile/paginator.html:16
-#: src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:51
-#: src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:65
-#: src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:78
-#: src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:91
-#: src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:104
-#: src/olympia/discovery/templates/discovery/pane.html:45
-#: src/olympia/discovery/templates/discovery/addons/detail.html:39
-#: src/olympia/stats/templates/stats/stats.html:167
+#: src/olympia/amo/templates/amo/paginator.html:26 src/olympia/amo/templates/amo/impala/paginator.html:26 src/olympia/amo/templates/amo/mobile/impala_paginator.html:16
+#: src/olympia/amo/templates/amo/mobile/paginator.html:14 src/olympia/amo/templates/amo/mobile/paginator.html:16 src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:51
+#: src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:65 src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:78
+#: src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:91 src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:104
+#: src/olympia/discovery/templates/discovery/pane.html:45 src/olympia/discovery/templates/discovery/addons/detail.html:39 src/olympia/stats/templates/stats/stats.html:169
 msgid "Next"
 msgstr ""
 
-#: src/olympia/amo/templates/amo/paginator.html:32
-#: src/olympia/editors/templates/editors/includes/paginator_history.html:11
+#: src/olympia/amo/templates/amo/paginator.html:32 src/olympia/editors/templates/editors/includes/paginator_history.html:11
 #, python-format
-msgid ""
-"Results <strong>%(begin)s</strong>&ndash;<strong>%(end)s</strong> of "
-"<strong>%(count)s</strong>"
+msgid "Results <strong>%(begin)s</strong>&ndash;<strong>%(end)s</strong> of <strong>%(count)s</strong>"
 msgstr ""
 
-#: src/olympia/amo/templates/amo/read-only.html:3
-#: src/olympia/amo/templates/amo/read-only.html:7
+#: src/olympia/amo/templates/amo/read-only.html:3 src/olympia/amo/templates/amo/read-only.html:7
 msgid "Maintenance in progress"
 msgstr ""
 
 #: src/olympia/amo/templates/amo/read-only.html:9
-msgid ""
-"This feature is temporarily disabled while we perform website maintenance. "
-"Please use your browser's Back button and try again a little later."
+msgid "This feature is temporarily disabled while we perform website maintenance. Please use your browser's Back button and try again a little later."
 msgstr ""
 
 #: src/olympia/amo/templates/amo/read-only.html:14
-msgid ""
-"Some features on this page are temporarily disabled while we perform website"
-" maintenance. Please try again a little later."
+msgid "Some features on this page are temporarily disabled while we perform website maintenance. Please try again a little later."
 msgstr ""
 
 #: src/olympia/amo/templates/amo/recaptcha.html:4
@@ -2402,20 +1938,12 @@ msgstr ""
 
 #: src/olympia/amo/templates/amo/recaptcha.html:8
 msgid ""
-"<p> Please enter <strong>all the words</strong> below, <strong>separated by "
-"a space if necessary</strong>. </p> <p> If this is hard to read, you can <a "
-"href=\"#\" id=\"recaptcha_different\">try different words</a> or <a "
-"href=\"#\" id=\"recaptcha_audio\">try a different type of challenge</a> "
-"instead. </p>"
+"<p> Please enter <strong>all the words</strong> below, <strong>separated by a space if necessary</strong>. </p> <p> If this is hard to read, you can <a href=\"#\" id=\"recaptcha_different\">try "
+"different words</a> or <a href=\"#\" id=\"recaptcha_audio\">try a different type of challenge</a> instead. </p>"
 msgstr ""
 
-#: src/olympia/amo/templates/amo/side_nav.html:4
-#: src/olympia/amo/templates/amo/side_nav.html:12
-#: src/olympia/amo/templates/amo/site_nav.html:4
-#: src/olympia/amo/templates/amo/site_nav.html:26
-#: src/olympia/browse/views.py:56 src/olympia/browse/views.py:66
-#: src/olympia/browse/views.py:237 src/olympia/browse/views.py:282
-#: src/olympia/search/forms.py:86
+#: src/olympia/amo/templates/amo/side_nav.html:4 src/olympia/amo/templates/amo/side_nav.html:12 src/olympia/amo/templates/amo/site_nav.html:4 src/olympia/amo/templates/amo/site_nav.html:26
+#: src/olympia/browse/views.py:56 src/olympia/browse/views.py:66 src/olympia/browse/views.py:204 src/olympia/browse/views.py:249 src/olympia/search/forms.py:86
 msgid "Top Rated"
 msgstr ""
 
@@ -2423,79 +1951,60 @@ msgstr ""
 msgid "Explore"
 msgstr "დათვალიერება"
 
-#: src/olympia/amo/templates/amo/site_nav.html:23
-#: src/olympia/browse/feeds.py:65 src/olympia/browse/feeds.py:78
-#: src/olympia/browse/feeds.py:92 src/olympia/browse/feeds.py:100
-#: src/olympia/browse/templates/browse/base_listing.html:7
-#: src/olympia/browse/templates/browse/creatured.html:10
-#: src/olympia/browse/templates/browse/impala/base_listing.html:37
+#: src/olympia/amo/templates/amo/site_nav.html:23 src/olympia/browse/feeds.py:65 src/olympia/browse/feeds.py:78 src/olympia/browse/feeds.py:92 src/olympia/browse/feeds.py:100
+#: src/olympia/browse/templates/browse/base_listing.html:7 src/olympia/browse/templates/browse/creatured.html:10 src/olympia/browse/templates/browse/impala/base_listing.html:37
 #: src/olympia/constants/base.py:173 src/olympia/templates/menu_links.html:8
 msgid "Extensions"
 msgstr "გაფართოებები"
 
-#: src/olympia/amo/templates/amo/site_nav.html:45
+#: src/olympia/amo/templates/amo/site_nav.html:44
 msgid "Want more customization? Try <b>Complete Themes</b>"
 msgstr ""
 
-#: src/olympia/amo/templates/amo/site_nav.html:56
-#: src/olympia/bandwagon/views.py:96
+#: src/olympia/amo/templates/amo/site_nav.html:54 src/olympia/bandwagon/views.py:96
 msgid "Most Followers"
 msgstr "ყველაზე მეტი მიმდევარი"
 
-#: src/olympia/amo/templates/amo/site_nav.html:68
-#: src/olympia/bandwagon/templates/bandwagon/impala/collection_sidebar.html:16
+#: src/olympia/amo/templates/amo/site_nav.html:66 src/olympia/bandwagon/templates/bandwagon/impala/collection_sidebar.html:16
 #: src/olympia/bandwagon/templates/bandwagon/includes/collection_sidebar.html:18
 msgid "Collections I've Made"
 msgstr ""
 
-#: src/olympia/amo/templates/amo/site_nav.html:70
-#: src/olympia/bandwagon/templates/bandwagon/user_listing.html:4
-#: src/olympia/bandwagon/templates/bandwagon/impala/collection_sidebar.html:13
+#: src/olympia/amo/templates/amo/site_nav.html:68 src/olympia/bandwagon/templates/bandwagon/user_listing.html:4 src/olympia/bandwagon/templates/bandwagon/impala/collection_sidebar.html:13
 #: src/olympia/bandwagon/templates/bandwagon/includes/collection_sidebar.html:15
 msgid "Collections I'm Following"
 msgstr ""
 
-#: src/olympia/amo/templates/amo/site_nav.html:73
-#: src/olympia/bandwagon/templates/bandwagon/impala/collection_sidebar.html:18
-#: src/olympia/bandwagon/templates/bandwagon/includes/collection_sidebar.html:20
-#: src/olympia/users/models.py:512
+#: src/olympia/amo/templates/amo/site_nav.html:71 src/olympia/bandwagon/templates/bandwagon/impala/collection_sidebar.html:18
+#: src/olympia/bandwagon/templates/bandwagon/includes/collection_sidebar.html:20 src/olympia/users/models.py:521
 msgid "My Favorite Add-ons"
 msgstr ""
 
-#: src/olympia/amo/templates/amo/site_nav.html:78
+#: src/olympia/amo/templates/amo/site_nav.html:76
 msgid "More&hellip;"
 msgstr ""
 
-#: src/olympia/amo/templates/amo/site_nav.html:82
+#: src/olympia/amo/templates/amo/site_nav.html:80
 msgid "Add-ons for Mobile"
 msgstr ""
 
-#: src/olympia/amo/templates/amo/site_nav.html:86
-#: src/olympia/browse/feeds.py:207
-#: src/olympia/browse/templates/browse/search_tools.html:3
-#: src/olympia/constants/base.py:176 src/olympia/templates/menu_links.html:10
+#: src/olympia/amo/templates/amo/site_nav.html:84 src/olympia/browse/feeds.py:207 src/olympia/browse/templates/browse/search_tools.html:3 src/olympia/constants/base.py:176
+#: src/olympia/templates/menu_links.html:10
 msgid "Search Tools"
 msgstr ""
 
 #. This is a page range (e.g., Page 1 of 50).
-#: src/olympia/amo/templates/amo/impala/paginator.html:5
-#: src/olympia/amo/templates/amo/mobile/impala_paginator.html:26
+#: src/olympia/amo/templates/amo/impala/paginator.html:5 src/olympia/amo/templates/amo/mobile/impala_paginator.html:26
 #, python-format
-msgid ""
-"Page <a href=\"%(current_pg_url)s\">%(current_pg)s</a> of <a "
-"href=\"%(last_pg_url)s\">%(last_pg)s</a>"
+msgid "Page <a href=\"%(current_pg_url)s\">%(current_pg)s</a> of <a href=\"%(last_pg_url)s\">%(last_pg)s</a>"
 msgstr ""
 
-#: src/olympia/amo/templates/amo/impala/paginator.html:16
-#: src/olympia/amo/templates/amo/mobile/impala_paginator.html:6
+#: src/olympia/amo/templates/amo/impala/paginator.html:16 src/olympia/amo/templates/amo/mobile/impala_paginator.html:6
 msgid "Jump to first page"
 msgstr ""
 
-#: src/olympia/amo/templates/amo/impala/paginator.html:22
-#: src/olympia/amo/templates/amo/mobile/impala_paginator.html:12
-#: src/olympia/discovery/templates/discovery/pane.html:44
-#: src/olympia/discovery/templates/discovery/addons/detail.html:38
-#: src/olympia/stats/templates/stats/stats.html:164
+#: src/olympia/amo/templates/amo/impala/paginator.html:22 src/olympia/amo/templates/amo/mobile/impala_paginator.html:12 src/olympia/discovery/templates/discovery/pane.html:44
+#: src/olympia/discovery/templates/discovery/addons/detail.html:38 src/olympia/stats/templates/stats/stats.html:166
 msgid "Previous"
 msgstr ""
 
@@ -2505,11 +2014,9 @@ msgstr ""
 
 #. First and second arguments are the result range (e.g., 1-20);
 #. third argument is the number of total results (e.g., 1,000).
-#. First and second arguments are the result range (e.g., 1-20);
-#. third
+#. First and second arguments are the result range (e.g., 1-20);              third
 #. argument is the number of total results (e.g., 1,000).
-#: src/olympia/amo/templates/amo/impala/paginator.html:36
-#: src/olympia/amo/templates/amo/mobile/impala_paginator.html:38
+#: src/olympia/amo/templates/amo/impala/paginator.html:36 src/olympia/amo/templates/amo/mobile/impala_paginator.html:38
 #, python-format
 msgid "Showing <b>%(begin)s</b>&ndash;<b>%(end)s</b> of <b>%(count)s</b>"
 msgstr ""
@@ -2518,41 +2025,54 @@ msgstr ""
 msgid "Page {n}"
 msgid_plural "Page {n}"
 msgstr[0] ""
+msgstr[1] ""
 
-#: src/olympia/amo/templates/services/install.html:38
-#, python-format
-msgid ""
-"If you are not prompted to install %(addon_name)s in a moment, please <a "
-"href=\"%(addon_xpi)s\">click here</a>."
-msgstr ""
-
-#: src/olympia/amo/tests/test_messages.py:57
-#: src/olympia/amo/tests/test_messages.py:58 src/olympia/reviews/forms.py:25
-#: src/olympia/reviews/forms.py:50
-#: src/olympia/reviews/templates/reviews/add.html:56
+#: src/olympia/amo/tests/test_messages.py:56 src/olympia/amo/tests/test_messages.py:57 src/olympia/reviews/forms.py:25 src/olympia/reviews/forms.py:50 src/olympia/reviews/templates/reviews/add.html:56
 #: src/olympia/reviews/templates/reviews/reply.html:30
 msgid "Title"
 msgstr ""
 
-#: src/olympia/amo/tests/test_messages.py:57
-#: src/olympia/amo/tests/test_messages.py:58
+#: src/olympia/amo/tests/test_messages.py:56 src/olympia/amo/tests/test_messages.py:57
 msgid "Body"
 msgstr ""
 
-#: src/olympia/amo/tests/test_messages.py:59
+#: src/olympia/amo/tests/test_messages.py:58
 msgid "Another Title"
 msgstr ""
 
-#: src/olympia/amo/tests/test_messages.py:59
+#: src/olympia/amo/tests/test_messages.py:58
 msgid "Another Body"
 msgstr ""
 
-#: src/olympia/api/views.py:255
-msgid "Not implemented yet."
+#: src/olympia/api/authentication.py:76
+msgid "Signature has expired."
 msgstr ""
 
-#: src/olympia/applications/views.py:39
-#: src/olympia/applications/templates/applications/appversions.html:3
+#: src/olympia/api/authentication.py:79
+msgid "Error decoding signature."
+msgstr ""
+
+#: src/olympia/api/authentication.py:82
+msgid "Invalid JWT Token."
+msgstr ""
+
+#: src/olympia/api/authentication.py:130
+msgid "Invalid Authorization header. No credentials provided."
+msgstr ""
+
+#: src/olympia/api/authentication.py:133
+msgid "Invalid Authorization header. Credentials string should not contain spaces."
+msgstr ""
+
+#: src/olympia/api/fields.py:29
+msgid "The field must have a length of at least {num} characters."
+msgstr ""
+
+#: src/olympia/api/fields.py:31
+msgid "The language code {lang_code} is invalid."
+msgstr ""
+
+#: src/olympia/applications/views.py:39 src/olympia/applications/templates/applications/appversions.html:3
 msgid "Application Versions"
 msgstr ""
 
@@ -2565,19 +2085,15 @@ msgid "Valid Application Versions"
 msgstr ""
 
 #: src/olympia/applications/templates/applications/appversions.html:12
-msgid ""
-"Add-ons submitted to Mozilla Add-ons must have a manifest file with at least"
-" one of the below applications supported. Only the versions listed below are"
-" allowed for these applications."
+msgid "Add-ons submitted to Mozilla Add-ons must have a manifest file with at least one of the below applications supported. Only the versions listed below are allowed for these applications."
 msgstr ""
 
-#: src/olympia/applications/templates/applications/appversions.html:25
+#: src/olympia/applications/templates/applications/appversions.html:25 src/olympia/editors/helpers.py:361
 msgid "GUID"
 msgstr ""
 
 #. {0} is an add-on name.
-#: src/olympia/applications/templates/applications/appversions.html:26
-#: src/olympia/versions/templates/versions/version_list.html:23
+#: src/olympia/applications/templates/applications/appversions.html:26 src/olympia/versions/templates/versions/version_list.html:23
 msgid "Versions"
 msgstr "ვერსიები"
 
@@ -2587,10 +2103,7 @@ msgstr "http://developer.mozilla.org/en/docs/Install_Manifests"
 
 #: src/olympia/applications/templates/applications/appversions.html:31
 #, python-format
-msgid ""
-"If your supported application does not require a manifest file, you still "
-"must include one with the required properties as specified <a "
-"href=\"%(url)s\">here</a>."
+msgid "If your supported application does not require a manifest file, you still must include one with the required properties as specified <a href=\"%(url)s\">here</a>."
 msgstr ""
 
 #. L10n: {0} is 'Add-ons for <app>'.
@@ -2599,10 +2112,8 @@ msgstr ""
 msgid "Collections :: %s"
 msgstr ""
 
-#: src/olympia/bandwagon/feeds.py:50
-#: src/olympia/bandwagon/templates/bandwagon/collection_detail.html:137
-msgid ""
-"Collections are groups of related add-ons that anyone can create and share."
+#: src/olympia/bandwagon/feeds.py:50 src/olympia/bandwagon/templates/bandwagon/collection_detail.html:137
+msgid "Collections are groups of related add-ons that anyone can create and share."
 msgstr ""
 
 #. L10n: {0} is a collection name, {1} is 'Add-ons for <app>'.
@@ -2658,8 +2169,7 @@ msgstr "ამ ბმულს სხვა კრებული უკვე �
 msgid "Icons must be either PNG or JPG."
 msgstr "ხატულები უნდა იყოს PNG ან JPG."
 
-#: src/olympia/bandwagon/forms.py:202 src/olympia/devhub/views.py:1067
-#: src/olympia/users/forms.py:476
+#: src/olympia/bandwagon/forms.py:202 src/olympia/devhub/views.py:1067 src/olympia/users/forms.py:476
 #, python-format
 msgid "Please use images smaller than %dMB."
 msgstr ""
@@ -2680,8 +2190,7 @@ msgstr ""
 msgid "Log in to vote for this collection"
 msgstr ""
 
-#: src/olympia/bandwagon/helpers.py:123
-#: src/olympia/bandwagon/templates/bandwagon/favorites_widget.html:2
+#: src/olympia/bandwagon/helpers.py:123 src/olympia/bandwagon/templates/bandwagon/favorites_widget.html:2
 msgid "Add to favorites"
 msgstr "რჩეულებში დამატება"
 
@@ -2689,20 +2198,13 @@ msgstr "რჩეულებში დამატება"
 msgid "Favorite"
 msgstr "რჩეული"
 
-#: src/olympia/bandwagon/helpers.py:124
-#: src/olympia/bandwagon/templates/bandwagon/favorites_widget.html:2
+#: src/olympia/bandwagon/helpers.py:124 src/olympia/bandwagon/templates/bandwagon/favorites_widget.html:2
 msgid "Remove from favorites"
 msgstr "რჩეულებიდან ამოღება"
 
-#: src/olympia/bandwagon/views.py:98 src/olympia/bandwagon/views.py:191
-#: src/olympia/browse/views.py:58 src/olympia/browse/views.py:69
-#: src/olympia/browse/views.py:458 src/olympia/devhub/views.py:74
-#: src/olympia/devhub/views.py:82
-#: src/olympia/devhub/templates/devhub/addons/edit/basic.html:20
-#: src/olympia/editors/templates/editors/leaderboard.html:24
-#: src/olympia/editors/templates/editors/themes/queue_list.html:48
-#: src/olympia/search/forms.py:17 src/olympia/search/forms.py:89
-#: src/olympia/users/templates/users/vcard.html:5
+#: src/olympia/bandwagon/views.py:98 src/olympia/bandwagon/views.py:191 src/olympia/browse/views.py:58 src/olympia/browse/views.py:69 src/olympia/browse/views.py:425 src/olympia/devhub/views.py:72
+#: src/olympia/devhub/views.py:80 src/olympia/devhub/templates/devhub/addons/edit/basic.html:20 src/olympia/editors/templates/editors/leaderboard.html:24
+#: src/olympia/editors/templates/editors/themes/queue_list.html:48 src/olympia/search/forms.py:17 src/olympia/search/forms.py:89 src/olympia/users/templates/users/vcard.html:5
 msgid "Name"
 msgstr "სახელი"
 
@@ -2710,8 +2212,7 @@ msgstr "სახელი"
 msgid "Recently Popular"
 msgstr "ბოლო დროს პოპულარული"
 
-#: src/olympia/bandwagon/views.py:189
-#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:18
+#: src/olympia/bandwagon/views.py:189 src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:16
 msgid "Added"
 msgstr "დამატებული"
 
@@ -2725,9 +2226,7 @@ msgstr ""
 
 #: src/olympia/bandwagon/views.py:316
 #, python-format
-msgid ""
-"Your new collection is shown below. You can <ahref=\"%(url)s\">edit "
-"additional settings</a> if you'dlike."
+msgid "Your new collection is shown below. You can <a href=\"%(url)s\">edit additional settings</a> if you'd like."
 msgstr ""
 
 #: src/olympia/bandwagon/views.py:322
@@ -2743,28 +2242,20 @@ msgstr ""
 msgid "Icon Deleted"
 msgstr ""
 
-#: src/olympia/bandwagon/templates/bandwagon/add.html:3
-#: src/olympia/bandwagon/templates/bandwagon/add.html:11
-#: src/olympia/bandwagon/templates/bandwagon/includes/collection_sidebar.html:26
+#: src/olympia/bandwagon/templates/bandwagon/add.html:3 src/olympia/bandwagon/templates/bandwagon/add.html:11 src/olympia/bandwagon/templates/bandwagon/includes/collection_sidebar.html:26
 msgid "Create a New Collection"
 msgstr ""
 
-#: src/olympia/bandwagon/templates/bandwagon/add.html:9
-#: src/olympia/devhub/templates/devhub/personas/submit.html:14
+#: src/olympia/bandwagon/templates/bandwagon/add.html:9 src/olympia/devhub/templates/devhub/personas/submit.html:14
 msgid "Create"
 msgstr ""
 
-#: src/olympia/bandwagon/templates/bandwagon/add.html:24
-#: src/olympia/bandwagon/templates/bandwagon/ajax_new.html:28
+#: src/olympia/bandwagon/templates/bandwagon/add.html:24 src/olympia/bandwagon/templates/bandwagon/ajax_new.html:28
 #, python-format
-msgid ""
-"As noted in our <a href=\"%(legal)s\">Legal Notices</a>, individual "
-"collection arrangements are governed by the Creative Commons Attribution "
-"Share-Alike License"
+msgid "As noted in our <a href=\"%(legal)s\">Legal Notices</a>, individual collection arrangements are governed by the Creative Commons Attribution Share-Alike License"
 msgstr ""
 
-#: src/olympia/bandwagon/templates/bandwagon/add.html:33
-#: src/olympia/bandwagon/templates/bandwagon/ajax_new.html:38
+#: src/olympia/bandwagon/templates/bandwagon/add.html:33 src/olympia/bandwagon/templates/bandwagon/ajax_new.html:38
 msgid "Create Collection"
 msgstr ""
 
@@ -2780,8 +2271,7 @@ msgstr ""
 msgid "Start a New Collection"
 msgstr ""
 
-#: src/olympia/bandwagon/templates/bandwagon/ajax_new.html:6
-#: src/olympia/bandwagon/templates/bandwagon/includes/addedit.html:7
+#: src/olympia/bandwagon/templates/bandwagon/ajax_new.html:6 src/olympia/bandwagon/templates/bandwagon/includes/addedit.html:7
 msgid "Name:"
 msgstr ""
 
@@ -2794,15 +2284,11 @@ msgstr ""
 msgid "To rate collections, you must have an add-ons account."
 msgstr ""
 
-#: src/olympia/bandwagon/templates/bandwagon/barometer.html:18
-#: src/olympia/templates/base.html:145
-#: src/olympia/templates/impala/base.html:198
+#: src/olympia/bandwagon/templates/bandwagon/barometer.html:18 src/olympia/templates/base.html:145 src/olympia/templates/impala/base.html:198
 msgid "Create an Add-ons Account"
 msgstr ""
 
-#: src/olympia/bandwagon/templates/bandwagon/barometer.html:21
-#: src/olympia/templates/base.html:148
-#: src/olympia/templates/impala/base.html:201
+#: src/olympia/bandwagon/templates/bandwagon/barometer.html:21 src/olympia/templates/base.html:148 src/olympia/templates/impala/base.html:201
 #, python-format
 msgid "or <a href=\"%(login)s\">log in to your current account</a>"
 msgstr ""
@@ -2815,12 +2301,12 @@ msgstr ""
 msgid "private"
 msgstr ""
 
-#: src/olympia/bandwagon/templates/bandwagon/collection_detail.html:45
-#: src/olympia/bandwagon/templates/bandwagon/mobile/listing_items.html:9
+#: src/olympia/bandwagon/templates/bandwagon/collection_detail.html:45 src/olympia/bandwagon/templates/bandwagon/mobile/listing_items.html:9
 #, python-format
 msgid "<span>%(num)s</span> follower"
 msgid_plural "<span>%(num)s</span> followers"
 msgstr[0] "<span>%(num)s</span> მიმდევარი"
+msgstr[1] ""
 
 #: src/olympia/bandwagon/templates/bandwagon/collection_detail.html:54
 msgid "About this Collection"
@@ -2850,8 +2336,7 @@ msgstr ""
 msgid "Edit Collection"
 msgstr ""
 
-#: src/olympia/bandwagon/templates/bandwagon/collection_detail.html:88
-#: src/olympia/bandwagon/templates/bandwagon/includes/delete.html:3
+#: src/olympia/bandwagon/templates/bandwagon/collection_detail.html:88 src/olympia/bandwagon/templates/bandwagon/includes/delete.html:3
 msgid "Delete Collection"
 msgstr ""
 
@@ -2860,19 +2345,17 @@ msgstr ""
 msgid "%(num)s Theme in this Collection"
 msgid_plural "%(num)s Themes in this Collection"
 msgstr[0] ""
+msgstr[1] ""
 
 #: src/olympia/bandwagon/templates/bandwagon/collection_detail.html:111
 #, python-format
 msgid "%(num)s Add-on in this Collection"
 msgid_plural "%(num)s Add-ons in this Collection"
 msgstr[0] ""
+msgstr[1] ""
 
-#: src/olympia/bandwagon/templates/bandwagon/collection_detail.html:125
-#: src/olympia/compat/templates/compat/index.html:25
-#: src/olympia/compat/templates/compat/reporter_detail.html:29
-#: src/olympia/files/templates/files/viewer.html:29
-#: src/olympia/templates/amo_footer.html:17
-#: src/olympia/templates/includes/lang_switcher.html:10
+#: src/olympia/bandwagon/templates/bandwagon/collection_detail.html:125 src/olympia/compat/templates/compat/reporter_detail.html:29 src/olympia/files/templates/files/viewer.html:29
+#: src/olympia/templates/amo_footer.html:17 src/olympia/templates/includes/lang_switcher.html:10
 msgid "Go"
 msgstr ""
 
@@ -2898,18 +2381,14 @@ msgstr ""
 
 #: src/olympia/bandwagon/templates/bandwagon/collection_detail.html:179
 msgid ""
-"Add-ons that you mark as favorites using the <b>Add to Favorites</b> feature"
-" appear below. This collection is currently <b>public</b>, which means "
-"everyone can see it. If you would like to hide it from public view, click "
-"the button below to make it private."
+"Add-ons that you mark as favorites using the <b>Add to Favorites</b> feature appear below. This collection is currently <b>public</b>, which means everyone can see it. If you would like to hide it "
+"from public view, click the button below to make it private."
 msgstr ""
 
 #: src/olympia/bandwagon/templates/bandwagon/collection_detail.html:186
 msgid ""
-"Add-ons that you mark as favorites using the <b>Add to Favorites</b> feature"
-" appear below. This collection is currently <b>private</b>, which means only"
-" you can see it.  If you would like everyone to be able to see your "
-"favorites, click the button below to make it public."
+"Add-ons that you mark as favorites using the <b>Add to Favorites</b> feature appear below. This collection is currently <b>private</b>, which means only you can see it.  If you would like everyone "
+"to be able to see your favorites, click the button below to make it public."
 msgstr ""
 
 #: src/olympia/bandwagon/templates/bandwagon/collection_detail.html:196
@@ -2921,60 +2400,57 @@ msgstr ""
 msgid "<span>%(addons)s</span> add-on"
 msgid_plural "<span>%(addons)s</span> add-ons"
 msgstr[0] ""
+msgstr[1] ""
 
 #: src/olympia/bandwagon/templates/bandwagon/collection_grid.html:32
 #, python-format
 msgid "<span>%(followers)s</span> follower"
 msgid_plural "<span>%(followers)s</span> followers"
 msgstr[0] "<span>%(followers)s</span> მიმდევარი"
+msgstr[1] ""
 
-#. People "follow" collections to get notified of updates.
-#. Like
+#. People "follow" collections to get notified of updates.                    Like
 #. Twitter followers.
 #. People "follow" collections to get notified of updates.
 #. Like Twitter followers.
-#: src/olympia/bandwagon/templates/bandwagon/collection_listing_items.html:10
-#: src/olympia/bandwagon/templates/bandwagon/impala/collection_listing_items.html:18
+#: src/olympia/bandwagon/templates/bandwagon/collection_listing_items.html:10 src/olympia/bandwagon/templates/bandwagon/impala/collection_listing_items.html:18
 #, python-format
 msgid "%(num)s weekly follower"
 msgid_plural "%(num)s weekly followers"
 msgstr[0] "%(num)s ყოველკვირეული მიმდევარი"
+msgstr[1] ""
 
-#. People "follow" collections to get notified of updates.
-#. Like
+#. People "follow" collections to get notified of updates.                    Like
 #. Twitter followers.
 #: src/olympia/bandwagon/templates/bandwagon/collection_listing_items.html:18
 #, python-format
 msgid "%(num)s monthly follower"
 msgid_plural "%(num)s monthly followers"
 msgstr[0] "%(num)s ყოველთვიური მიმდევარი"
+msgstr[1] ""
 
-#. People "follow" collections to get notified of updates.
-#. Like
+#. People "follow" collections to get notified of updates.                    Like
 #. Twitter followers.
 #. People "follow" collections to get notified of updates.
 #. Like Twitter followers.
-#: src/olympia/bandwagon/templates/bandwagon/collection_listing_items.html:26
-#: src/olympia/bandwagon/templates/bandwagon/impala/collection_listing_items.html:26
+#: src/olympia/bandwagon/templates/bandwagon/collection_listing_items.html:26 src/olympia/bandwagon/templates/bandwagon/impala/collection_listing_items.html:26
 #, python-format
 msgid "%(num)s follower"
 msgid_plural "%(num)s followers"
 msgstr[0] "%(num)s მიმდევარი"
+msgstr[1] ""
 
-#: src/olympia/bandwagon/templates/bandwagon/collection_listing_items.html:56
-#: src/olympia/bandwagon/templates/bandwagon/impala/collection_listing_items.html:9
+#: src/olympia/bandwagon/templates/bandwagon/collection_listing_items.html:56 src/olympia/bandwagon/templates/bandwagon/impala/collection_listing_items.html:9
 #: src/olympia/devhub/templates/devhub/personas/edit.html:27
 msgid "by {0}"
 msgstr ""
 
-#: src/olympia/bandwagon/templates/bandwagon/collection_widgets.html:5
-#: src/olympia/bandwagon/templates/bandwagon/collection_widgets.html:7
+#: src/olympia/bandwagon/templates/bandwagon/collection_widgets.html:5 src/olympia/bandwagon/templates/bandwagon/collection_widgets.html:7
 #: src/olympia/bandwagon/templates/bandwagon/impala/collection_listing_items.html:53
 msgid "Stop Following"
 msgstr ""
 
-#: src/olympia/bandwagon/templates/bandwagon/collection_widgets.html:6
-#: src/olympia/bandwagon/templates/bandwagon/collection_widgets.html:7
+#: src/olympia/bandwagon/templates/bandwagon/collection_widgets.html:6 src/olympia/bandwagon/templates/bandwagon/collection_widgets.html:7
 #: src/olympia/bandwagon/templates/bandwagon/impala/collection_listing_items.html:53
 msgid "Follow this Collection"
 msgstr ""
@@ -2984,16 +2460,12 @@ msgid "Edit this Collection"
 msgstr ""
 
 #. %s is the name of the collection.
-#: src/olympia/bandwagon/templates/bandwagon/delete.html:4
-#: src/olympia/bandwagon/templates/bandwagon/delete.html:15
+#: src/olympia/bandwagon/templates/bandwagon/delete.html:4 src/olympia/bandwagon/templates/bandwagon/delete.html:15
 msgid "Delete {0}"
 msgstr ""
 
-#: src/olympia/bandwagon/templates/bandwagon/delete.html:13
-#: src/olympia/devhub/templates/devhub/addons/listing/item_actions.html:14
-#: src/olympia/devhub/templates/devhub/addons/listing/item_actions_theme.html:28
-#: src/olympia/devhub/templates/devhub/versions/list.html:131
-#: src/olympia/devhub/templates/devhub/versions/list.html:149
+#: src/olympia/bandwagon/templates/bandwagon/delete.html:13 src/olympia/devhub/templates/devhub/addons/listing/item_actions.html:14
+#: src/olympia/devhub/templates/devhub/addons/listing/item_actions_theme.html:28 src/olympia/devhub/templates/devhub/versions/list.html:131 src/olympia/devhub/templates/devhub/versions/list.html:149
 #: src/olympia/devhub/templates/devhub/versions/list.html:166
 msgid "Delete"
 msgstr ""
@@ -3002,35 +2474,24 @@ msgstr ""
 msgid "Are you sure?"
 msgstr ""
 
-#: src/olympia/bandwagon/templates/bandwagon/delete.html:21
-#: src/olympia/devhub/templates/devhub/personas/edit.html:131
-#: src/olympia/devhub/templates/devhub/personas/edit.html:152
-#: src/olympia/devhub/templates/devhub/personas/edit.html:173
-#: src/olympia/devhub/templates/devhub/personas/submit.html:77
-#: src/olympia/devhub/templates/devhub/personas/submit.html:98
+#: src/olympia/bandwagon/templates/bandwagon/delete.html:21 src/olympia/devhub/templates/devhub/personas/edit.html:131 src/olympia/devhub/templates/devhub/personas/edit.html:152
+#: src/olympia/devhub/templates/devhub/personas/edit.html:173 src/olympia/devhub/templates/devhub/personas/submit.html:77 src/olympia/devhub/templates/devhub/personas/submit.html:98
 #: src/olympia/devhub/templates/devhub/personas/submit.html:119
 msgid "Yes"
 msgstr ""
 
-#: src/olympia/bandwagon/templates/bandwagon/delete.html:22
-#: src/olympia/devhub/templates/devhub/personas/edit.html:140
-#: src/olympia/devhub/templates/devhub/personas/edit.html:161
-#: src/olympia/devhub/templates/devhub/personas/edit.html:191
-#: src/olympia/devhub/templates/devhub/personas/submit.html:86
-#: src/olympia/devhub/templates/devhub/personas/submit.html:107
+#: src/olympia/bandwagon/templates/bandwagon/delete.html:22 src/olympia/devhub/templates/devhub/personas/edit.html:140 src/olympia/devhub/templates/devhub/personas/edit.html:161
+#: src/olympia/devhub/templates/devhub/personas/edit.html:191 src/olympia/devhub/templates/devhub/personas/submit.html:86 src/olympia/devhub/templates/devhub/personas/submit.html:107
 #: src/olympia/devhub/templates/devhub/personas/submit.html:137
 msgid "No"
 msgstr ""
 
 #. {0} is the name of the collection.
-#: src/olympia/bandwagon/templates/bandwagon/edit.html:5
-#: src/olympia/bandwagon/templates/bandwagon/edit.html:21
+#: src/olympia/bandwagon/templates/bandwagon/edit.html:5 src/olympia/bandwagon/templates/bandwagon/edit.html:21
 msgid "Edit {0}"
 msgstr ""
 
-#: src/olympia/bandwagon/templates/bandwagon/edit.html:29
-#: src/olympia/devhub/templates/devhub/addons/edit/details.html:20
-#: src/olympia/editors/templates/editors/themes/themes.html:62
+#: src/olympia/bandwagon/templates/bandwagon/edit.html:29 src/olympia/devhub/templates/devhub/addons/edit/details.html:20 src/olympia/editors/templates/editors/themes/themes.html:62
 msgid "Description"
 msgstr ""
 
@@ -3038,31 +2499,17 @@ msgstr ""
 msgid "Contributors & More"
 msgstr ""
 
-#: src/olympia/bandwagon/templates/bandwagon/edit.html:54
-#: src/olympia/bandwagon/templates/bandwagon/edit.html:67
-#: src/olympia/bandwagon/templates/bandwagon/edit.html:82
-#: src/olympia/devhub/templates/devhub/addons/ajax_compat_update.html:35
-#: src/olympia/devhub/templates/devhub/addons/owner.html:59
-#: src/olympia/devhub/templates/devhub/addons/profile.html:42
-#: src/olympia/devhub/templates/devhub/addons/edit/admin.html:101
-#: src/olympia/devhub/templates/devhub/addons/edit/basic.html:152
-#: src/olympia/devhub/templates/devhub/addons/edit/details.html:85
-#: src/olympia/devhub/templates/devhub/addons/edit/support.html:67
-#: src/olympia/devhub/templates/devhub/addons/edit/technical.html:166
-#: src/olympia/devhub/templates/devhub/addons/forms_shared/media.html:149
-#: src/olympia/devhub/templates/devhub/payments/voluntary.html:64
-#: src/olympia/devhub/templates/devhub/personas/edit.html:35
-#: src/olympia/devhub/templates/devhub/personas/edit.html:304
-#: src/olympia/devhub/templates/devhub/versions/edit.html:139
-#: src/olympia/translations/templates/translations/trans-menu.html:48
+#: src/olympia/bandwagon/templates/bandwagon/edit.html:54 src/olympia/bandwagon/templates/bandwagon/edit.html:67 src/olympia/bandwagon/templates/bandwagon/edit.html:82
+#: src/olympia/devhub/templates/devhub/addons/ajax_compat_update.html:35 src/olympia/devhub/templates/devhub/addons/owner.html:59 src/olympia/devhub/templates/devhub/addons/profile.html:42
+#: src/olympia/devhub/templates/devhub/addons/edit/admin.html:101 src/olympia/devhub/templates/devhub/addons/edit/basic.html:152 src/olympia/devhub/templates/devhub/addons/edit/details.html:85
+#: src/olympia/devhub/templates/devhub/addons/edit/support.html:67 src/olympia/devhub/templates/devhub/addons/edit/technical.html:166
+#: src/olympia/devhub/templates/devhub/addons/forms_shared/media.html:149 src/olympia/devhub/templates/devhub/payments/voluntary.html:64 src/olympia/devhub/templates/devhub/personas/edit.html:35
+#: src/olympia/devhub/templates/devhub/personas/edit.html:304 src/olympia/devhub/templates/devhub/versions/edit.html:139 src/olympia/translations/templates/translations/trans-menu.html:48
 msgid "Save Changes"
 msgstr ""
 
-#: src/olympia/bandwagon/templates/bandwagon/edit_contributors.html:9
-#: src/olympia/bandwagon/templates/bandwagon/edit_contributors.html:12
-#: src/olympia/bandwagon/templates/bandwagon/edit_contributors.html:17
-#: src/olympia/bandwagon/templates/bandwagon/edit_contributors.html:58
-#: src/olympia/constants/base.py:134
+#: src/olympia/bandwagon/templates/bandwagon/edit_contributors.html:9 src/olympia/bandwagon/templates/bandwagon/edit_contributors.html:12
+#: src/olympia/bandwagon/templates/bandwagon/edit_contributors.html:17 src/olympia/bandwagon/templates/bandwagon/edit_contributors.html:58 src/olympia/constants/base.py:134
 msgid "Owner"
 msgstr ""
 
@@ -3074,10 +2521,8 @@ msgstr ""
 msgid "Remove this user as a contributor"
 msgstr ""
 
-#: src/olympia/bandwagon/templates/bandwagon/edit_contributors.html:18
-#: src/olympia/bandwagon/templates/bandwagon/edit_contributors.html:43
-#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:20
-#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:48
+#: src/olympia/bandwagon/templates/bandwagon/edit_contributors.html:18 src/olympia/bandwagon/templates/bandwagon/edit_contributors.html:43
+#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:18 src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:46
 #: src/olympia/devhub/templates/devhub/addons/ajax_compat_update.html:19
 msgid "Remove"
 msgstr ""
@@ -3088,19 +2533,15 @@ msgstr ""
 
 #: src/olympia/bandwagon/templates/bandwagon/edit_contributors.html:26
 msgid ""
-"You can add multiple contributors to this collection.  A contributor can add"
-" and remove add-ons from this collection, but cannot change its name or "
-"description.  To add a contributor, enter their email in the box below. "
-"Contributors must have a Mozilla Add-ons account."
+"You can add multiple contributors to this collection.  A contributor can add and remove add-ons from this collection, but cannot change its name or description.  To add a contributor, enter their "
+"email in the box below. Contributors must have a Mozilla Add-ons account."
 msgstr ""
 
 #: src/olympia/bandwagon/templates/bandwagon/edit_contributors.html:40
 msgid "User"
 msgstr ""
 
-#: src/olympia/bandwagon/templates/bandwagon/edit_contributors.html:41
-#: src/olympia/devhub/templates/devhub/addons/edit/support.html:20
-#: src/olympia/users/templates/users/delete.html:49
+#: src/olympia/bandwagon/templates/bandwagon/edit_contributors.html:41 src/olympia/devhub/templates/devhub/addons/edit/support.html:20 src/olympia/users/templates/users/delete.html:49
 msgid "Email"
 msgstr ""
 
@@ -3125,25 +2566,14 @@ msgid "Admin Settings"
 msgstr ""
 
 #: src/olympia/bandwagon/templates/bandwagon/edit_contributors.html:76
-msgid ""
-"<b>Warning:</b> By changing the owner of this collection, you will no longer"
-" be able to edit it. You will only be able to add and remove add-ons from "
-"it."
+msgid "<b>Warning:</b> By changing the owner of this collection, you will no longer be able to edit it. You will only be able to add and remove add-ons from it."
 msgstr ""
 
-#: src/olympia/bandwagon/templates/bandwagon/edit_contributors.html:83
-#: src/olympia/devhub/templates/devhub/addons/forms_shared/media.html:157
-#: src/olympia/devhub/templates/devhub/addons/submit/describe.html:69
-#: src/olympia/devhub/templates/devhub/addons/submit/license.html:60
-#: src/olympia/devhub/templates/devhub/addons/submit/upload.html:78
-#: src/olympia/devhub/templates/devhub/payments/tier.html:17
-#: src/olympia/editors/templates/editors/themes/themes.html:111
-#: src/olympia/editors/templates/editors/themes/themes.html:128
-#: src/olympia/editors/templates/editors/themes/themes.html:134
-#: src/olympia/editors/templates/editors/themes/themes.html:141
-#: src/olympia/users/templates/users/fxa_migration_prompt_content.html:10
-#: src/olympia/users/templates/users/login_form.html:42
-#: src/olympia/users/templates/users/mobile/login.html:57
+#: src/olympia/bandwagon/templates/bandwagon/edit_contributors.html:83 src/olympia/devhub/templates/devhub/addons/forms_shared/media.html:157
+#: src/olympia/devhub/templates/devhub/addons/submit/describe.html:69 src/olympia/devhub/templates/devhub/addons/submit/license.html:60 src/olympia/devhub/templates/devhub/addons/submit/upload.html:70
+#: src/olympia/devhub/templates/devhub/payments/tier.html:17 src/olympia/editors/templates/editors/themes/themes.html:111 src/olympia/editors/templates/editors/themes/themes.html:128
+#: src/olympia/editors/templates/editors/themes/themes.html:134 src/olympia/editors/templates/editors/themes/themes.html:141 src/olympia/users/templates/users/fxa_migration_prompt_content.html:10
+#: src/olympia/users/templates/users/login_form.html:42 src/olympia/users/templates/users/mobile/login.html:57
 msgid "Continue"
 msgstr ""
 
@@ -3182,15 +2612,10 @@ msgstr ""
 
 #: src/olympia/bandwagon/templates/bandwagon/impala/collection_listing.html:28
 #, python-format
-msgid ""
-"Collections are groups of related add-ons that anyone can create and share. "
-"Explore collections created by other users or <a href=\"%(url)s\">create "
-"your own</a>."
+msgid "Collections are groups of related add-ons that anyone can create and share. Explore collections created by other users or <a href=\"%(url)s\">create your own</a>."
 msgstr ""
 
-#: src/olympia/bandwagon/templates/bandwagon/impala/collection_listing.html:37
-#: src/olympia/browse/templates/browse/extensions.html:13
-#: src/olympia/browse/templates/browse/themes.html:14
+#: src/olympia/bandwagon/templates/bandwagon/impala/collection_listing.html:37 src/olympia/browse/templates/browse/extensions.html:13 src/olympia/browse/templates/browse/themes.html:14
 msgid "Subscribe"
 msgstr ""
 
@@ -3198,17 +2623,13 @@ msgstr ""
 msgid "Following"
 msgstr ""
 
-#: src/olympia/bandwagon/templates/bandwagon/impala/collection_sidebar.html:22
-#: src/olympia/bandwagon/templates/bandwagon/impala/collection_sidebar.html:28
+#: src/olympia/bandwagon/templates/bandwagon/impala/collection_sidebar.html:22 src/olympia/bandwagon/templates/bandwagon/impala/collection_sidebar.html:28
 #: src/olympia/bandwagon/templates/bandwagon/includes/collection_sidebar.html:32
 msgid "Create a Collection"
 msgstr "შექმენით კოლექცია"
 
-#: src/olympia/bandwagon/templates/bandwagon/impala/collection_sidebar.html:23
-#: src/olympia/bandwagon/templates/bandwagon/includes/collection_sidebar.html:27
-msgid ""
-"Collections make it easy to keep track of favorite add-ons and share your "
-"perfectly customized browser with others."
+#: src/olympia/bandwagon/templates/bandwagon/impala/collection_sidebar.html:23 src/olympia/bandwagon/templates/bandwagon/includes/collection_sidebar.html:27
+msgid "Collections make it easy to keep track of favorite add-ons and share your perfectly customized browser with others."
 msgstr ""
 
 #: src/olympia/bandwagon/templates/bandwagon/includes/addedit.html:42
@@ -3232,36 +2653,31 @@ msgid "Add-ons in Your Collection"
 msgstr ""
 
 #: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:4
-msgid ""
-"To include an add-on in this collection, enter its name in the box below and"
-" hit enter.  You can also use the <strong>Add to Collection</strong> links "
-"throughout the site to include add-ons later."
+msgid "To include an add-on in this collection, enter its name in the box below and hit enter."
 msgstr ""
 
-#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:17
-#: src/olympia/constants/base.py:400
-#: src/olympia/devhub/templates/devhub/addons/activity.html:62
+#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:15 src/olympia/constants/base.py:400 src/olympia/devhub/templates/devhub/addons/activity.html:62
+#: src/olympia/editors/helpers.py:273 src/olympia/editors/helpers.py:360
 msgid "Add-on"
 msgstr ""
 
-#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:26
+#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:24
 msgid "Enter the name of the add-on to include"
 msgstr ""
 
-#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:28
+#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:26
 msgid "Add to Collection"
 msgstr ""
 
-#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:45
-#: src/olympia/editors/helpers.py:936 src/olympia/editors/helpers.py:956
+#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:43 src/olympia/editors/helpers.py:1016 src/olympia/editors/helpers.py:1036
 msgid "Pending"
 msgstr ""
 
-#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:47
+#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:45
 msgid "Add a comment"
 msgstr ""
 
-#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:48
+#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:46
 msgid "Remove this add-on from the collection"
 msgstr ""
 
@@ -3273,14 +2689,11 @@ msgstr ""
 msgid "Groups of related add-ons that anyone can create."
 msgstr ""
 
-#: src/olympia/blocklist/templates/blocklist/blocked_detail.html:3
-#: src/olympia/blocklist/templates/blocklist/blocked_list.html:3
-#: src/olympia/blocklist/templates/blocklist/blocked_list.html:10
+#: src/olympia/blocklist/templates/blocklist/blocked_detail.html:3 src/olympia/blocklist/templates/blocklist/blocked_list.html:3 src/olympia/blocklist/templates/blocklist/blocked_list.html:10
 msgid "Blocked Add-ons"
 msgstr ""
 
-#: src/olympia/blocklist/templates/blocklist/blocked_detail.html:8
-#: src/olympia/blocklist/templates/blocklist/blocked_list.html:6
+#: src/olympia/blocklist/templates/blocklist/blocked_detail.html:8 src/olympia/blocklist/templates/blocklist/blocked_list.html:6
 msgid "Blocklist"
 msgstr ""
 
@@ -3302,25 +2715,18 @@ msgid "What does this mean?"
 msgstr ""
 
 #: src/olympia/blocklist/templates/blocklist/blocked_detail.html:22
-msgid ""
-"Users are strongly encouraged to disable the problematic add-on or plugin, "
-"but may choose to continue using it if they accept the risks described."
+msgid "Users are strongly encouraged to disable the problematic add-on or plugin, but may choose to continue using it if they accept the risks described."
 msgstr ""
 
 #: src/olympia/blocklist/templates/blocklist/blocked_detail.html:27
-msgid ""
-"The problematic add-on or plugin will be automatically disabled and no "
-"longer usable."
+msgid "The problematic add-on or plugin will be automatically disabled and no longer usable."
 msgstr ""
 
 #: src/olympia/blocklist/templates/blocklist/blocked_detail.html:33
 #, python-format
 msgid ""
-"When Mozilla becomes aware of add-ons, plugins, or other third-party "
-"software that seriously compromises %(app)s security, stability, or "
-"performance and meets <a href=\"%(criteria)s\">certain criteria</a>, the "
-"software may be blocked from general use.  For more information, please read"
-" <a href=\"%(support)s\">this support article</a>."
+"When Mozilla becomes aware of add-ons, plugins, or other third-party software that seriously compromises %(app)s security, stability, or performance and meets <a href=\"%(criteria)s\">certain "
+"criteria</a>, the software may be blocked from general use.  For more information, please read <a href=\"%(support)s\">this support article</a>."
 msgstr ""
 
 #: src/olympia/blocklist/templates/blocklist/blocked_detail.html:44
@@ -3334,9 +2740,7 @@ msgid "Blocked on %(date)s."
 msgstr ""
 
 #: src/olympia/blocklist/templates/blocklist/blocked_list.html:11
-msgid ""
-"The following software is known to cause serious security, stability, or "
-"performance issues with {app}."
+msgid "The following software is known to cause serious security, stability, or performance issues with {app}."
 msgstr ""
 
 #. L10n: %s is a category name.
@@ -3359,8 +2763,7 @@ msgstr ""
 #. L10n: %s is an app name.
 #: src/olympia/browse/feeds.py:138
 #, python-format
-msgid ""
-"Here's a few of our favorite add-ons to help you get started customizing %s."
+msgid "Here's a few of our favorite add-ons to help you get started customizing %s."
 msgstr ""
 
 #. L10n: %s is a category name.
@@ -3377,43 +2780,28 @@ msgstr ""
 msgid "Search tools"
 msgstr ""
 
-#: src/olympia/browse/views.py:55 src/olympia/browse/views.py:65
-#: src/olympia/search/forms.py:85
+#: src/olympia/browse/views.py:55 src/olympia/browse/views.py:65 src/olympia/search/forms.py:85
 msgid "Most Users"
 msgstr ""
 
-#: src/olympia/browse/views.py:61 src/olympia/browse/views.py:72
-#: src/olympia/browse/views.py:279
-#: src/olympia/browse/templates/browse/personas/mobile/category_landing.html:63
-#: src/olympia/discovery/templates/discovery/pane.html:67
-#: src/olympia/search/forms.py:92
+#: src/olympia/browse/views.py:61 src/olympia/browse/views.py:72 src/olympia/browse/views.py:246 src/olympia/browse/templates/browse/personas/mobile/category_landing.html:63
+#: src/olympia/discovery/templates/discovery/pane.html:67 src/olympia/search/forms.py:92
 msgid "Up & Coming"
 msgstr ""
 
-#: src/olympia/browse/views.py:460 src/olympia/devhub/views.py:76
-#: src/olympia/devhub/views.py:83
-#: src/olympia/discovery/templates/discovery/addons/detail.html:66
+#: src/olympia/browse/views.py:427 src/olympia/devhub/views.py:74 src/olympia/devhub/views.py:81 src/olympia/discovery/templates/discovery/addons/detail.html:66
 msgid "Created"
 msgstr ""
 
 #. {0} is the category name. Ex: Sports
-#: src/olympia/browse/templates/browse/creatured.html:5
-#: src/olympia/browse/templates/browse/creatured.html:13
+#: src/olympia/browse/templates/browse/creatured.html:5 src/olympia/browse/templates/browse/creatured.html:13
 msgid "{0}: Featured Add-ons"
 msgstr ""
 
-#: src/olympia/browse/templates/browse/creatured.html:12
-#: src/olympia/browse/templates/browse/featured.html:4
-#: src/olympia/browse/templates/browse/featured.html:12
-#: src/olympia/browse/templates/browse/featured.html:13
-#: src/olympia/devhub/templates/devhub/docs/policies-recommended.html:3
-#: src/olympia/devhub/templates/devhub/docs/policies-recommended.html:7
-#: src/olympia/devhub/templates/devhub/docs/policies-recommended.html:9
-#: src/olympia/devhub/templates/devhub/docs/policies.html:21
-#: src/olympia/devhub/templates/devhub/docs/policies.html:90
-#: src/olympia/discovery/modules.py:341
-#: src/olympia/discovery/templates/discovery/pane.html:52
-#: src/olympia/templates/menu_links.html:7
+#: src/olympia/browse/templates/browse/creatured.html:12 src/olympia/browse/templates/browse/featured.html:4 src/olympia/browse/templates/browse/featured.html:12
+#: src/olympia/browse/templates/browse/featured.html:13 src/olympia/devhub/templates/devhub/docs/policies-recommended.html:3 src/olympia/devhub/templates/devhub/docs/policies-recommended.html:7
+#: src/olympia/devhub/templates/devhub/docs/policies-recommended.html:9 src/olympia/devhub/templates/devhub/docs/policies.html:21 src/olympia/devhub/templates/devhub/docs/policies.html:90
+#: src/olympia/discovery/modules.py:341 src/olympia/discovery/templates/discovery/pane.html:52 src/olympia/templates/menu_links.html:7
 msgid "Featured Add-ons"
 msgstr ""
 
@@ -3424,9 +2812,7 @@ msgstr ""
 
 #: src/olympia/browse/templates/browse/featured.html:15
 #, python-format
-msgid ""
-"Here's a few of our favorite add-ons to help you get started customizing "
-"%(app)s."
+msgid "Here's a few of our favorite add-ons to help you get started customizing %(app)s."
 msgstr ""
 
 #: src/olympia/browse/templates/browse/language_tools.html:9
@@ -3453,19 +2839,15 @@ msgstr ""
 msgid "List of language packs and dictionaries available in your locale."
 msgstr ""
 
-#: src/olympia/browse/templates/browse/language_tools.html:41
-#: src/olympia/browse/templates/browse/language_tools.html:63
+#: src/olympia/browse/templates/browse/language_tools.html:41 src/olympia/browse/templates/browse/language_tools.html:63
 msgid "Language"
 msgstr ""
 
-#: src/olympia/browse/templates/browse/language_tools.html:42
-#: src/olympia/browse/templates/browse/language_tools.html:64
-#: src/olympia/constants/base.py:162
+#: src/olympia/browse/templates/browse/language_tools.html:42 src/olympia/browse/templates/browse/language_tools.html:64 src/olympia/constants/base.py:162
 msgid "Dictionary"
 msgstr ""
 
-#: src/olympia/browse/templates/browse/language_tools.html:43
-#: src/olympia/browse/templates/browse/language_tools.html:65
+#: src/olympia/browse/templates/browse/language_tools.html:43 src/olympia/browse/templates/browse/language_tools.html:65
 msgid "Language Pack"
 msgstr ""
 
@@ -3483,11 +2865,11 @@ msgid "{0} :: Search Tools"
 msgstr ""
 
 #. {0} is an integer.
-#: src/olympia/browse/templates/browse/search_tools.html:39
-#: src/olympia/devhub/templates/devhub/addons/dashboard.html:17
+#: src/olympia/browse/templates/browse/search_tools.html:39 src/olympia/devhub/templates/devhub/addons/dashboard.html:17
 msgid "<b>{0}</b> add-on"
 msgid_plural "<b>{0}</b> add-ons"
 msgstr[0] ""
+msgstr[1] ""
 
 #: src/olympia/browse/templates/browse/search_tools.html:61
 msgid "Search Extensions"
@@ -3511,27 +2893,18 @@ msgstr ""
 
 #. {0} is an app name, like Firefox.
 #: src/olympia/browse/templates/browse/search_tools.html:93
-msgid ""
-"Learn more about the <a "
-"href=\"http://support.mozilla.com/kb/Search+bar\">search bar</a> in {0}"
+msgid "Learn more about the <a href=\"http://support.mozilla.com/kb/Search+bar\">search bar</a> in {0}"
 msgstr ""
 
 #: src/olympia/browse/templates/browse/search_tools.html:94
-msgid ""
-"Browse through even more search providers at <a "
-"href=\"http://mycroft.mozdev.org/\">mycroft.mozdev.org</a>"
+msgid "Browse through even more search providers at <a href=\"http://mycroft.mozdev.org/\">mycroft.mozdev.org</a>"
 msgstr ""
 
 #: src/olympia/browse/templates/browse/search_tools.html:95
-msgid ""
-"<a "
-"href=\"https://developer.mozilla.org/en/Creating_OpenSearch_plugins_for_Firefox\">Make"
-" your own</a> search tool"
+msgid "<a href=\"https://developer.mozilla.org/en/Creating_OpenSearch_plugins_for_Firefox\">Make your own</a> search tool"
 msgstr ""
 
-#: src/olympia/browse/templates/browse/themes.html:6
-#: src/olympia/browse/templates/browse/themes.html:9
-#: src/olympia/constants/base.py:174
+#: src/olympia/browse/templates/browse/themes.html:6 src/olympia/browse/templates/browse/themes.html:9 src/olympia/constants/base.py:174
 msgid "Complete Themes"
 msgstr ""
 
@@ -3602,25 +2975,19 @@ msgstr ""
 msgid "See the %(cnt)s extension in %(name)s &raquo;"
 msgid_plural "See all %(cnt)s extensions in %(name)s &raquo;"
 msgstr[0] ""
+msgstr[1] ""
 
-#: src/olympia/browse/templates/browse/mobile/extensions.html:13
-#: src/olympia/compat/templates/compat/index.html:82
-#: src/olympia/devhub/templates/devhub/devhub_search.html:24
-#: src/olympia/devhub/templates/devhub/addons/activity.html:47
-#: src/olympia/search/templates/search/no_results.html:4
-#: src/olympia/search/templates/search/mobile/results.html:36
+#: src/olympia/browse/templates/browse/mobile/extensions.html:13 src/olympia/devhub/templates/devhub/devhub_search.html:24 src/olympia/devhub/templates/devhub/addons/activity.html:47
+#: src/olympia/search/templates/search/no_results.html:4 src/olympia/search/templates/search/mobile/results.html:36
 msgid "No results found."
 msgstr ""
 
-#: src/olympia/browse/templates/browse/personas/base.html:6
-#: src/olympia/browse/templates/browse/personas/mobile/base.html:7
+#: src/olympia/browse/templates/browse/personas/base.html:6 src/olympia/browse/templates/browse/personas/mobile/base.html:7
 msgid "{0} Themes"
 msgstr ""
 
 #. {0} is a user's name.
-#: src/olympia/browse/templates/browse/personas/base.html:15
-#: src/olympia/browse/templates/browse/personas/base.html:40
-#: src/olympia/browse/templates/browse/personas/grid.html:8
+#: src/olympia/browse/templates/browse/personas/base.html:15 src/olympia/browse/templates/browse/personas/base.html:40 src/olympia/browse/templates/browse/personas/grid.html:8
 msgid "{0}'s Themes"
 msgstr ""
 
@@ -3640,27 +3007,21 @@ msgstr ""
 msgid "Learn more"
 msgstr ""
 
-#: src/olympia/browse/templates/browse/personas/category_landing.html:6
-#: src/olympia/browse/templates/browse/personas/mobile/category_landing.html:5
+#: src/olympia/browse/templates/browse/personas/category_landing.html:6 src/olympia/browse/templates/browse/personas/mobile/category_landing.html:5
 msgid "View All Recently Added"
 msgstr ""
 
-#: src/olympia/browse/templates/browse/personas/category_landing.html:7
-#: src/olympia/browse/templates/browse/personas/mobile/category_landing.html:6
+#: src/olympia/browse/templates/browse/personas/category_landing.html:7 src/olympia/browse/templates/browse/personas/mobile/category_landing.html:6
 msgid "View All Most Popular"
 msgstr ""
 
-#: src/olympia/browse/templates/browse/personas/category_landing.html:8
-#: src/olympia/browse/templates/browse/personas/mobile/category_landing.html:7
+#: src/olympia/browse/templates/browse/personas/category_landing.html:8 src/olympia/browse/templates/browse/personas/mobile/category_landing.html:7
 msgid "View All Top Rated"
 msgstr ""
 
 #: src/olympia/browse/templates/browse/personas/category_landing.html:40
 #, python-format
-msgid ""
-"Over 300,000 designs to personalize your browser! Move your mouse over a "
-"Background Theme to try it on. <a href=\"%(url)s\" class=\"more-info\">Start"
-" exploring</a>"
+msgid "Over 300,000 designs to personalize your browser! Move your mouse over a Background Theme to try it on. <a href=\"%(url)s\" class=\"more-info\">Start exploring</a>"
 msgstr ""
 
 #: src/olympia/browse/templates/browse/personas/category_landing.html:47
@@ -3671,10 +3032,7 @@ msgstr ""
 #. theme.
 #: src/olympia/browse/templates/browse/personas/category_landing.html:50
 #, python-format
-msgid ""
-"Complete Themes transform the look of your browser with styles for the "
-"window frame, address bar, buttons, tabs, and menus. <a href=\"%(url)s\" "
-"class=\"more-info\">Start exploring</a>"
+msgid "Complete Themes transform the look of your browser with styles for the window frame, address bar, buttons, tabs, and menus. <a href=\"%(url)s\" class=\"more-info\">Start exploring</a>"
 msgstr ""
 
 #: src/olympia/browse/templates/browse/personas/category_landing.html:76
@@ -3705,7 +3063,7 @@ msgstr ""
 msgid "All"
 msgstr ""
 
-#: src/olympia/compat/forms.py:22 src/olympia/search/views.py:525
+#: src/olympia/compat/forms.py:22 src/olympia/editors/templates/editors/base.html:69 src/olympia/search/views.py:518
 msgid "All Add-ons"
 msgstr ""
 
@@ -3717,76 +3075,22 @@ msgstr ""
 msgid "Non-binary"
 msgstr ""
 
-#. Review points sources other than add-ons and themes.
-#: src/olympia/compat/views.py:87 src/olympia/constants/base.py:388
-#: src/olympia/devhub/forms.py:162
-#: src/olympia/editors/templates/editors/performance.html:75
-msgid "Other"
-msgstr ""
-
-#: src/olympia/compat/templates/compat/index.html:4
-msgid "Add-on Compatibility Report for {app} {version}"
-msgstr ""
-
-#: src/olympia/compat/templates/compat/index.html:11
-msgid "{app} {version} Compatibility"
-msgstr ""
-
-#: src/olympia/compat/templates/compat/index.html:17
-#, python-format
-msgid "Top 95%% compatible with previous version"
-msgstr ""
-
-#: src/olympia/compat/templates/compat/index.html:18
-#, python-format
-msgid "Top 95%% of all add-ons"
-msgstr ""
-
-#: src/olympia/compat/templates/compat/index.html:19
-msgid "All active add-ons"
-msgstr ""
-
-#: src/olympia/compat/templates/compat/index.html:23
-#: src/olympia/constants/base.py:401
-msgid "App"
-msgstr ""
-
-#: src/olympia/compat/templates/compat/index.html:55
-msgid "Details for add-ons compatible with previous version:"
-msgstr ""
-
-#: src/olympia/compat/templates/compat/index.html:57
-msgid "Show all versions"
-msgstr ""
-
-#: src/olympia/compat/templates/compat/index.html:59
-msgid "Details for add-ons compatible with all versions:"
-msgstr ""
-
-#: src/olympia/compat/templates/compat/index.html:61
-msgid "Show previous version only"
-msgstr ""
-
 #: src/olympia/compat/templates/compat/reporter.html:3
 msgid "Add-on Compatibility Reports"
 msgstr ""
 
-#: src/olympia/compat/templates/compat/reporter.html:11
-#: src/olympia/compat/templates/compat/reporter_detail.html:35
+#: src/olympia/compat/templates/compat/reporter.html:11 src/olympia/compat/templates/compat/reporter_detail.html:35
 #, python-format
 msgid ""
-"<p> Reports submitted to us through the <a href=\"%(url_)s\">Add-on "
-"Compatibility Reporter</a> are collected here for developers to view. These "
-"reports help us determine which add-ons will need help supporting an "
-"upcoming Firefox version. </p>"
+"<p> Reports submitted to us through the <a href=\"%(url_)s\">Add-on Compatibility Reporter</a> are collected here for developers to view. These reports help us determine which add-ons will need "
+"help supporting an upcoming Firefox version. </p>"
 msgstr ""
 
 #: src/olympia/compat/templates/compat/reporter.html:18
 msgid "Reports for your Add-ons"
 msgstr ""
 
-#: src/olympia/compat/templates/compat/reporter.html:30
-#: src/olympia/compat/templates/compat/reporter_detail.html:9
+#: src/olympia/compat/templates/compat/reporter.html:30 src/olympia/compat/templates/compat/reporter_detail.html:9
 msgid "Add-on Compatibility Center"
 msgstr ""
 
@@ -3794,9 +3098,7 @@ msgstr ""
 msgid "Enter the GUID of an add-on below to view any reports we've received."
 msgstr ""
 
-#: src/olympia/compat/templates/compat/reporter_detail.html:3
-#: src/olympia/compat/templates/compat/reporter_detail.html:10
-#: src/olympia/compat/templates/compat/reporter_detail.html:25
+#: src/olympia/compat/templates/compat/reporter_detail.html:3 src/olympia/compat/templates/compat/reporter_detail.html:10 src/olympia/compat/templates/compat/reporter_detail.html:25
 msgid "{addon} Compatibility Reports"
 msgstr ""
 
@@ -3804,14 +3106,15 @@ msgstr ""
 msgid "{0} success report"
 msgid_plural "{0} success reports"
 msgstr[0] ""
+msgstr[1] ""
 
 #: src/olympia/compat/templates/compat/reporter_detail.html:17
 msgid "{0} problem report"
 msgid_plural "{0} problem reports"
 msgstr[0] ""
+msgstr[1] ""
 
-#: src/olympia/compat/templates/compat/reporter_detail.html:21
-#: src/olympia/users/templates/users/profile.html:70
+#: src/olympia/compat/templates/compat/reporter_detail.html:21 src/olympia/users/templates/users/profile.html:70
 msgid "View all"
 msgstr ""
 
@@ -3823,10 +3126,8 @@ msgstr ""
 msgid "Report Type"
 msgstr ""
 
-#: src/olympia/compat/templates/compat/reporter_detail.html:47
-#: src/olympia/devhub/forms.py:784
-#: src/olympia/devhub/templates/devhub/addons/ajax_compat_update.html:17
-#: src/olympia/editors/forms.py:108 src/olympia/zadmin/forms.py:45
+#: src/olympia/compat/templates/compat/reporter_detail.html:47 src/olympia/devhub/forms.py:785 src/olympia/devhub/templates/devhub/addons/ajax_compat_update.html:17 src/olympia/editors/forms.py:108
+#: src/olympia/editors/forms.py:248 src/olympia/zadmin/forms.py:45
 msgid "Application"
 msgstr ""
 
@@ -3838,8 +3139,7 @@ msgstr ""
 msgid "Platform"
 msgstr ""
 
-#: src/olympia/compat/templates/compat/reporter_detail.html:50
-#: src/olympia/editors/templates/editors/themes/themes.html:40
+#: src/olympia/compat/templates/compat/reporter_detail.html:50 src/olympia/editors/templates/editors/themes/themes.html:40
 msgid "Submitted"
 msgstr ""
 
@@ -3867,8 +3167,7 @@ msgstr ""
 msgid "SeaMonkey"
 msgstr ""
 
-#: src/olympia/constants/applications.py:75
-#: src/olympia/pages/templates/pages/sunbird.html:4
+#: src/olympia/constants/applications.py:75 src/olympia/pages/templates/pages/sunbird.html:4
 msgid "Sunbird"
 msgstr ""
 
@@ -3916,7 +3215,7 @@ msgstr ""
 msgid "Preliminarily Reviewed and Awaiting Full Review"
 msgstr ""
 
-#: src/olympia/constants/base.py:33 src/olympia/editors/helpers.py:924
+#: src/olympia/constants/base.py:33 src/olympia/editors/forms.py:258 src/olympia/editors/helpers.py:73 src/olympia/editors/helpers.py:1004
 #: src/olympia/editors/templates/editors/themes/history_table.html:34
 msgid "Deleted"
 msgstr ""
@@ -3949,13 +3248,11 @@ msgstr ""
 msgid "Viewer"
 msgstr ""
 
-#: src/olympia/constants/base.py:137
-#: src/olympia/templates/mobile/header.html:7
+#: src/olympia/constants/base.py:137 src/olympia/templates/mobile/header.html:7
 msgid "Support"
 msgstr ""
 
-#: src/olympia/constants/base.py:159 src/olympia/constants/base.py:172
-#: src/olympia/constants/platforms.py:10
+#: src/olympia/constants/base.py:159 src/olympia/constants/base.py:172 src/olympia/constants/platforms.py:10
 msgid "Any"
 msgstr ""
 
@@ -3983,11 +3280,8 @@ msgstr ""
 msgid "Plugin"
 msgstr ""
 
-#: src/olympia/constants/base.py:167
-#: src/olympia/editors/templates/editors/includes/search_results_themes.html:5
-#: src/olympia/editors/templates/editors/themes/deleted.html:18
-#: src/olympia/editors/templates/editors/themes/history_table.html:8
-#: src/olympia/editors/templates/editors/themes/logs.html:17
+#: src/olympia/constants/base.py:167 src/olympia/editors/templates/editors/includes/search_results_themes.html:5 src/olympia/editors/templates/editors/themes/deleted.html:18
+#: src/olympia/editors/templates/editors/themes/history_table.html:8 src/olympia/editors/templates/editors/themes/logs.html:17
 msgid "Theme"
 msgstr ""
 
@@ -4019,6 +3313,11 @@ msgstr ""
 msgid "Ask before users can download this add-on"
 msgstr ""
 
+#. Review points sources other than add-ons and themes.
+#: src/olympia/constants/base.py:388 src/olympia/devhub/forms.py:162 src/olympia/editors/templates/editors/performance.html:75
+msgid "Other"
+msgstr ""
+
 #: src/olympia/constants/base.py:389
 msgid "Exception"
 msgstr ""
@@ -4029,6 +3328,10 @@ msgstr ""
 
 #: src/olympia/constants/base.py:391
 msgid "Change"
+msgstr ""
+
+#: src/olympia/constants/base.py:401
+msgid "App"
 msgstr ""
 
 #: src/olympia/constants/base.py:402
@@ -4167,32 +3470,23 @@ msgstr ""
 msgid "Signed of a preliminary review"
 msgstr ""
 
-#: src/olympia/constants/editors.py:14
-#: src/olympia/editors/templates/editors/themes/queue.html:76
-#: src/olympia/editors/templates/editors/themes/themes.html:87
+#: src/olympia/constants/editors.py:14 src/olympia/editors/templates/editors/themes/queue.html:76 src/olympia/editors/templates/editors/themes/themes.html:87
 msgid "Request More Info"
 msgstr ""
 
-#: src/olympia/constants/editors.py:15
-#: src/olympia/editors/templates/editors/themes/queue.html:74
-#: src/olympia/editors/templates/editors/themes/themes.html:91
+#: src/olympia/constants/editors.py:15 src/olympia/editors/templates/editors/themes/queue.html:74 src/olympia/editors/templates/editors/themes/themes.html:91
 msgid "Flag"
 msgstr ""
 
-#: src/olympia/constants/editors.py:16
-#: src/olympia/editors/templates/editors/themes/queue.html:72
-#: src/olympia/editors/templates/editors/themes/themes.html:93
+#: src/olympia/constants/editors.py:16 src/olympia/editors/templates/editors/themes/queue.html:72 src/olympia/editors/templates/editors/themes/themes.html:93
 msgid "Duplicate"
 msgstr ""
 
-#: src/olympia/constants/editors.py:17 src/olympia/editors/helpers.py:502
-#: src/olympia/editors/templates/editors/themes/queue.html:71
-#: src/olympia/editors/templates/editors/themes/themes.html:94
+#: src/olympia/constants/editors.py:17 src/olympia/editors/helpers.py:575 src/olympia/editors/templates/editors/themes/queue.html:71 src/olympia/editors/templates/editors/themes/themes.html:94
 msgid "Reject"
 msgstr ""
 
-#: src/olympia/constants/editors.py:18
-#: src/olympia/editors/templates/editors/themes/queue.html:70
+#: src/olympia/constants/editors.py:18 src/olympia/editors/templates/editors/themes/queue.html:70
 msgid "Approve"
 msgstr ""
 
@@ -4288,7 +3582,7 @@ msgstr ""
 msgid "Android"
 msgstr ""
 
-#: src/olympia/core/apps.py:19
+#: src/olympia/core/apps.py:21
 msgid "Core"
 msgstr ""
 
@@ -4325,9 +3619,7 @@ msgstr ""
 msgid "Message not eligible for annotation"
 msgstr ""
 
-#: src/olympia/devhub/forms.py:124
-#: src/olympia/devhub/templates/devhub/versions/edit.html:94
-#: src/olympia/users/templates/users/edit.html:150
+#: src/olympia/devhub/forms.py:124 src/olympia/devhub/templates/devhub/versions/edit.html:94 src/olympia/users/templates/users/edit.html:150
 msgid "Details"
 msgstr ""
 
@@ -4424,13 +3716,11 @@ msgid "Submit my add-on for manual review."
 msgstr ""
 
 #: src/olympia/devhub/forms.py:537
-msgid "Do not list my add-on on this site (beta)"
+msgid "Do not list my add-on on this site"
 msgstr ""
 
 #: src/olympia/devhub/forms.py:538
-msgid ""
-"Check this option if you intend to distribute your add-on on your own and "
-"only need it to be signed by Mozilla."
+msgid "Check this option if you intend to distribute your add-on on your own and only need it to be signed by Mozilla."
 msgstr ""
 
 #: src/olympia/devhub/forms.py:544
@@ -4438,20 +3728,14 @@ msgid "This add-on will be bundled with an application installer."
 msgstr ""
 
 #: src/olympia/devhub/forms.py:546
-msgid ""
-"Add-ons that are bundled with application installers will be code reviewed "
-"by Mozilla before they are signed and are held to a higher quality standard."
+msgid "Add-ons that are bundled with application installers will be code reviewed by Mozilla before they are signed and are held to a higher quality standard."
 msgstr ""
 
-#: src/olympia/devhub/forms.py:565
-#: src/olympia/devhub/templates/devhub/addons/submit/select-review.html:24
-#: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:42
+#: src/olympia/devhub/forms.py:565 src/olympia/devhub/templates/devhub/addons/submit/select-review.html:24 src/olympia/devhub/templates/devhub/docs/policies-reviews.html:42
 msgid "Full Review"
 msgstr ""
 
-#: src/olympia/devhub/forms.py:566
-#: src/olympia/devhub/templates/devhub/addons/submit/select-review.html:47
-#: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:153
+#: src/olympia/devhub/forms.py:566 src/olympia/devhub/templates/devhub/addons/submit/select-review.html:47 src/olympia/devhub/templates/devhub/docs/policies-reviews.html:153
 msgid "Preliminary Review"
 msgstr ""
 
@@ -4460,59 +3744,51 @@ msgid "Please choose a review nomination type"
 msgstr ""
 
 #: src/olympia/devhub/forms.py:574
-msgid ""
-"A file with a version ending with a|alpha|b|beta|pre|rc and an optional "
-"number is detected as beta."
+msgid "A file with a version ending with a|alpha|b|beta|pre|rc and an optional number is detected as beta."
 msgstr ""
 
 #: src/olympia/devhub/forms.py:592
 #, python-format
-msgid "Version %s already exists"
+msgid "Version %s already exists, or was uploaded before."
 msgstr ""
 
-#: src/olympia/devhub/forms.py:604
-msgid ""
-"Select a valid choice. That choice is not one of the available choices."
+#: src/olympia/devhub/forms.py:605
+msgid "Select a valid choice. That choice is not one of the available choices."
 msgstr ""
 
-#: src/olympia/devhub/forms.py:610
-msgid ""
-"A file with a version ending with a|alpha|b|beta and an optional number is "
-"detected as beta."
+#: src/olympia/devhub/forms.py:611
+msgid "A file with a version ending with a|alpha|b|beta and an optional number is detected as beta."
 msgstr ""
 
-#: src/olympia/devhub/forms.py:633
+#: src/olympia/devhub/forms.py:634
 msgid "You cannot upload any more files for this version."
 msgstr ""
 
-#: src/olympia/devhub/forms.py:639
+#: src/olympia/devhub/forms.py:640
 msgid "Version doesn't match"
 msgstr ""
 
-#: src/olympia/devhub/forms.py:668
-msgid ""
-"You cannot delete a file once the review process has started.  You must "
-"delete the whole version."
+#: src/olympia/devhub/forms.py:669
+msgid "You cannot delete a file once the review process has started.  You must delete the whole version."
 msgstr ""
 
-#: src/olympia/devhub/forms.py:688
+#: src/olympia/devhub/forms.py:689
 msgid "The platform All cannot be combined with specific platforms."
 msgstr ""
 
-#: src/olympia/devhub/forms.py:693
+#: src/olympia/devhub/forms.py:694
 msgid "A platform can only be chosen once."
 msgstr ""
 
-#: src/olympia/devhub/forms.py:706
+#: src/olympia/devhub/forms.py:707
 msgid "A review type must be selected."
 msgstr ""
 
-#: src/olympia/devhub/forms.py:788 src/olympia/editors/forms.py:114
-#: src/olympia/zadmin/forms.py:49 src/olympia/zadmin/forms.py:52
+#: src/olympia/devhub/forms.py:789 src/olympia/editors/forms.py:114 src/olympia/editors/forms.py:254 src/olympia/zadmin/forms.py:49 src/olympia/zadmin/forms.py:52
 msgid "Select an application first"
 msgstr ""
 
-#: src/olympia/devhub/forms.py:840
+#: src/olympia/devhub/forms.py:841
 msgid "There cannot be more than 3 required add-ons."
 msgstr ""
 
@@ -4533,94 +3809,89 @@ msgstr ""
 msgid "{0} error"
 msgid_plural "{0} errors"
 msgstr[0] ""
+msgstr[1] ""
 
 #. L10n: first parameter is the number of warnings
 #: src/olympia/devhub/helpers.py:203
 msgid "{0} warning"
 msgid_plural "{0} warnings"
 msgstr[0] ""
+msgstr[1] ""
 
-#: src/olympia/devhub/models.py:375
-#: src/olympia/reviews/templates/reviews/add.html:58
+#: src/olympia/devhub/models.py:375 src/olympia/reviews/templates/reviews/add.html:58
 msgid "Review"
 msgstr ""
 
-#: src/olympia/devhub/tasks.py:551
+#: src/olympia/devhub/tasks.py:583
 #, python-format
 msgid "%s responded with %s (%s)."
 msgstr ""
 
-#: src/olympia/devhub/tasks.py:555
+#: src/olympia/devhub/tasks.py:587
 #, python-format
 msgid "Connection to \"%s\" timed out."
 msgstr ""
 
-#: src/olympia/devhub/tasks.py:557
+#: src/olympia/devhub/tasks.py:589
 #, python-format
 msgid "Could not contact host at \"%s\"."
 msgstr ""
 
-#: src/olympia/devhub/utils.py:104
+#: src/olympia/devhub/utils.py:105
 #, python-format
-msgid ""
-"Validation generated too many errors/warnings so %s messages were truncated."
-" After addressing the visible messages, you'll be able to see the others."
+msgid "Validation generated too many errors/warnings so %s messages were truncated. After addressing the visible messages, you'll be able to see the others."
 msgstr ""
 
-#: src/olympia/devhub/views.py:183
+#: src/olympia/devhub/views.py:181
 msgid "All My Add-ons"
 msgstr ""
 
-#: src/olympia/devhub/views.py:210
+#: src/olympia/devhub/views.py:208
 msgid "All Activity"
 msgstr ""
 
-#: src/olympia/devhub/views.py:211
+#: src/olympia/devhub/views.py:209
 msgid "Add-on Updates"
 msgstr ""
 
-#: src/olympia/devhub/views.py:212
+#: src/olympia/devhub/views.py:210
 msgid "Add-on Status"
 msgstr ""
 
-#: src/olympia/devhub/views.py:213
+#: src/olympia/devhub/views.py:211
 msgid "User Collections"
 msgstr ""
 
-#: src/olympia/devhub/views.py:214
-#: src/olympia/devhub/templates/devhub/docs/policies-maintenance.html:68
-#: src/olympia/pages/templates/pages/dev_faq.html:38
+#: src/olympia/devhub/views.py:212 src/olympia/devhub/templates/devhub/docs/policies-maintenance.html:68 src/olympia/pages/templates/pages/dev_faq.html:38
 #: src/olympia/pages/templates/pages/dev_faq.html:484
 msgid "User Reviews"
 msgstr ""
 
-#: src/olympia/devhub/views.py:327 src/olympia/devhub/views.py:331
-#: src/olympia/devhub/views.py:484 src/olympia/devhub/views.py:513
-#: src/olympia/devhub/views.py:564 src/olympia/devhub/views.py:1150
+#: src/olympia/devhub/views.py:325 src/olympia/devhub/views.py:329 src/olympia/devhub/views.py:484 src/olympia/devhub/views.py:513 src/olympia/devhub/views.py:564 src/olympia/devhub/views.py:1156
 msgid "Changes successfully saved."
 msgstr ""
 
-#: src/olympia/devhub/views.py:334 src/olympia/devhub/views.py:1631
+#: src/olympia/devhub/views.py:332 src/olympia/devhub/views.py:1637
 msgid "Please check the form for errors."
 msgstr ""
 
-#: src/olympia/devhub/views.py:346
+#: src/olympia/devhub/views.py:344
 msgid "Add-on cannot be deleted. Disable this add-on instead."
 msgstr ""
 
-#: src/olympia/devhub/views.py:356
+#: src/olympia/devhub/views.py:354
 msgid "Theme deleted."
 msgstr ""
 
-#: src/olympia/devhub/views.py:356
+#: src/olympia/devhub/views.py:354
 msgid "Add-on deleted."
 msgstr ""
 
-#: src/olympia/devhub/views.py:362
+#: src/olympia/devhub/views.py:360
 msgid "URL name was incorrect. Theme was not deleted."
 msgstr ""
 
-#: src/olympia/devhub/views.py:367
+#: src/olympia/devhub/views.py:365
 msgid "URL name was incorrect. Add-on was not deleted."
 msgstr ""
 
@@ -4648,7 +3919,7 @@ msgstr ""
 msgid "Check Add-on Compatibility"
 msgstr ""
 
-#: src/olympia/devhub/views.py:808 src/olympia/signing/views.py:90
+#: src/olympia/devhub/views.py:808 src/olympia/signing/views.py:95
 msgid "You cannot submit this type of add-on"
 msgstr ""
 
@@ -4678,45 +3949,38 @@ msgstr ""
 msgid "There was an error uploading your preview."
 msgstr ""
 
-#: src/olympia/devhub/views.py:1189
+#: src/olympia/devhub/views.py:1195
 #, python-format
 msgid "Version %s disabled."
 msgstr ""
 
-#: src/olympia/devhub/views.py:1193
+#: src/olympia/devhub/views.py:1199
 #, python-format
 msgid "Version %s deleted."
 msgstr ""
 
-#: src/olympia/devhub/views.py:1203
-msgid ""
-"This upload has failed validation, and may lack complete validation results."
-" Please take due care when reviewing it."
+#: src/olympia/devhub/views.py:1209
+msgid "This upload has failed validation, and may lack complete validation results. Please take due care when reviewing it."
 msgstr ""
 
-#: src/olympia/devhub/views.py:1677
+#: src/olympia/devhub/views.py:1683
 msgid "Preliminary Review Requested."
 msgstr ""
 
-#: src/olympia/devhub/views.py:1678
+#: src/olympia/devhub/views.py:1684
 msgid "Full Review Requested."
 msgstr ""
 
-#: src/olympia/devhub/views.py:1779
-msgid ""
-"Your old credentials were revoked and are no longer valid. Be sure to update"
-" all API clients with the new credentials."
+#: src/olympia/devhub/views.py:1783
+msgid "Your old credentials were revoked and are no longer valid. Be sure to update all API clients with the new credentials."
 msgstr ""
 
-#: src/olympia/devhub/views.py:1797
+#: src/olympia/devhub/views.py:1801
 msgid "New API key created"
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/agreement.html:2
-msgid ""
-"Before starting, please read and accept our Firefox Add-on Distribution "
-"Agreement. It also links to our Privacy Notice which explains how we handle "
-"your information."
+msgid "Before starting, please read and accept our Firefox Add-on Distribution Agreement. It also links to our Privacy Notice which explains how we handle your information."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/agreement.html:13
@@ -4731,44 +3995,30 @@ msgstr ""
 msgid "or <a href=\"{0}\">Cancel</a>"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/base.html:23
-#: src/olympia/devhub/templates/devhub/base_impala.html:20
-#: src/olympia/discovery/templates/discovery/addons/base.html:17
+#: src/olympia/devhub/templates/devhub/base.html:23 src/olympia/devhub/templates/devhub/base_impala.html:20 src/olympia/discovery/templates/discovery/addons/base.html:17
 msgid "Back to Add-ons"
 msgstr ""
 
 #. {0} is a search term, such as Firebug.
 #. {0} is a search query.
-#: src/olympia/devhub/templates/devhub/devhub_search.html:4
-#: src/olympia/search/templates/search/results.html:9
-#: src/olympia/search/templates/search/mobile/results.html:6
+#: src/olympia/devhub/templates/devhub/devhub_search.html:4 src/olympia/search/templates/search/results.html:9 src/olympia/search/templates/search/mobile/results.html:6
 msgid "{0} :: Search"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/devhub_search.html:6
-#: src/olympia/devhub/templates/devhub/search.html:8
-#: src/olympia/editors/forms.py:435 src/olympia/editors/forms.py:437
-#: src/olympia/editors/templates/editors/queue.html:27
-#: src/olympia/editors/templates/editors/themes/queue_list.html:14
-#: src/olympia/search/templates/search/collections.html:17
-#: src/olympia/search/templates/search/personas.html:18
-#: src/olympia/search/templates/search/results.html:18
-#: src/olympia/search/templates/search/mobile/results.html:8
-#: src/olympia/templates/search.html:14
-#: src/olympia/templates/impala/search.html:18
+#: src/olympia/devhub/templates/devhub/devhub_search.html:6 src/olympia/devhub/templates/devhub/search.html:8 src/olympia/editors/forms.py:534 src/olympia/editors/forms.py:536
+#: src/olympia/editors/templates/editors/queue.html:27 src/olympia/editors/templates/editors/themes/queue_list.html:14 src/olympia/search/templates/search/collections.html:17
+#: src/olympia/search/templates/search/personas.html:18 src/olympia/search/templates/search/results.html:18 src/olympia/search/templates/search/mobile/results.html:8
+#: src/olympia/templates/search.html:14 src/olympia/templates/impala/search.html:18
 msgid "Search"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/devhub_search.html:11
-#: src/olympia/devhub/templates/devhub/devhub_search.html:15
-#: src/olympia/search/templates/search/collections.html:18
+#: src/olympia/devhub/templates/devhub/devhub_search.html:11 src/olympia/devhub/templates/devhub/devhub_search.html:15 src/olympia/search/templates/search/collections.html:18
 #: src/olympia/search/templates/search/personas.html:20
 msgid "Search Results"
 msgstr ""
 
 #. {0} is a search term, such as Firebug.
-#: src/olympia/devhub/templates/devhub/devhub_search.html:13
-#: src/olympia/search/templates/search/results.html:11
+#: src/olympia/devhub/templates/devhub/devhub_search.html:13 src/olympia/search/templates/search/results.html:11
 msgid "Search Results for \"{0}\""
 msgstr ""
 
@@ -4789,9 +4039,7 @@ msgid "AMO Reviewers"
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/index.html:29
-msgid ""
-"Get ahead! Become an AMO Reviewer today and get your add-ons reviewed "
-"faster."
+msgid "Get ahead! Become an AMO Reviewer today and get your add-ons reviewed faster."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/index.html:32
@@ -4804,33 +4052,25 @@ msgstr ""
 
 #: src/olympia/devhub/templates/devhub/index.html:41
 msgid ""
-"Add-ons let millions of Firefox users enhance and customize their browsing "
-"experience. If you're a Web developer and know <a "
-"href=\"https://developer.mozilla.org/docs/Web/HTML\">HTML</a>, <a "
-"href=\"https://developer.mozilla.org/docs/Web/JavaScript\">JavaScript</a>, "
-"and <a href=\"https://developer.mozilla.org/docs/Web/CSS\">CSS</a>, you "
-"already have all the necessary skills to make a great add-on."
+"Add-ons let millions of Firefox users enhance and customize their browsing experience. If you're a Web developer and know <a href=\"https://developer.mozilla.org/docs/Web/HTML\">HTML</a>, <a href="
+"\"https://developer.mozilla.org/docs/Web/JavaScript\">JavaScript</a>, and <a href=\"https://developer.mozilla.org/docs/Web/CSS\">CSS</a>, you already have all the necessary skills to make a great "
+"add-on."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/index.html:51
-msgid ""
-"Head over to the <a href=\"https://developer.mozilla.org/Add-ons\">Mozilla "
-"Developer Network</a> to learn everything you need to know to get started."
+msgid "Head over to the <a href=\"https://developer.mozilla.org/Add-ons\">Mozilla Developer Network</a> to learn everything you need to know to get started."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/index.html:58
 msgid "Start Making Add-ons"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/index.html:86
-#: src/olympia/devhub/templates/devhub/addons/listing/items.html:25
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:15
+#: src/olympia/devhub/templates/devhub/index.html:86 src/olympia/devhub/templates/devhub/addons/listing/items.html:25 src/olympia/devhub/templates/devhub/includes/addon_details.html:20
 #: src/olympia/devhub/templates/devhub/personas/edit.html:43
 msgid "Status:"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/index.html:90
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:100
+#: src/olympia/devhub/templates/devhub/index.html:90 src/olympia/devhub/templates/devhub/includes/addon_details.html:87
 msgid "Visibility:"
 msgstr ""
 
@@ -4838,21 +4078,16 @@ msgstr ""
 msgid "Latest Version:"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/index.html:109
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:145
-#: src/olympia/devhub/templates/devhub/personas/edit.html:49
+#: src/olympia/devhub/templates/devhub/index.html:109 src/olympia/devhub/templates/devhub/includes/addon_details.html:131 src/olympia/devhub/templates/devhub/personas/edit.html:49
 msgid "Queue Position:"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/index.html:110
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:146
-#: src/olympia/devhub/templates/devhub/personas/edit.html:50
+#: src/olympia/devhub/templates/devhub/index.html:110 src/olympia/devhub/templates/devhub/includes/addon_details.html:132 src/olympia/devhub/templates/devhub/personas/edit.html:50
 #, python-format
 msgid "%(position)s of %(total)s"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/index.html:120
-#: src/olympia/devhub/templates/devhub/includes/addons_edit_nav.html:19
+#: src/olympia/devhub/templates/devhub/index.html:120 src/olympia/devhub/templates/devhub/includes/addons_edit_nav.html:19
 msgid "Upload New Version"
 msgstr ""
 
@@ -4866,9 +4101,7 @@ msgstr ""
 
 #: src/olympia/devhub/templates/devhub/index.html:136
 #, python-format
-msgid ""
-"Upload an <a href=\"%(addon_url)s\">add-on</a> or <a "
-"href=\"%(theme_url)s\">theme</a> to get started!"
+msgid "Upload an <a href=\"%(addon_url)s\">add-on</a> or <a href=\"%(theme_url)s\">theme</a> to get started!"
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/nav.html:2
@@ -4896,17 +4129,10 @@ msgstr ""
 msgid "Lightweight Themes"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/nav.html:39
-#: src/olympia/devhub/templates/devhub/docs/policies-agreement.html:6
-#: src/olympia/devhub/templates/devhub/docs/policies-contact.html:6
-#: src/olympia/devhub/templates/devhub/docs/policies-maintenance.html:6
-#: src/olympia/devhub/templates/devhub/docs/policies-recommended.html:6
-#: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:6
-#: src/olympia/devhub/templates/devhub/docs/policies-submission.html:6
-#: src/olympia/devhub/templates/devhub/docs/policies.html:3
-#: src/olympia/devhub/templates/devhub/docs/policies.html:9
-#: src/olympia/devhub/templates/devhub/docs/policies.html:38
-#: src/olympia/devhub/templates/devhub/docs/policies.html:39
+#: src/olympia/devhub/templates/devhub/nav.html:39 src/olympia/devhub/templates/devhub/docs/policies-agreement.html:6 src/olympia/devhub/templates/devhub/docs/policies-contact.html:6
+#: src/olympia/devhub/templates/devhub/docs/policies-maintenance.html:6 src/olympia/devhub/templates/devhub/docs/policies-recommended.html:6
+#: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:6 src/olympia/devhub/templates/devhub/docs/policies-submission.html:6 src/olympia/devhub/templates/devhub/docs/policies.html:3
+#: src/olympia/devhub/templates/devhub/docs/policies.html:9 src/olympia/devhub/templates/devhub/docs/policies.html:38 src/olympia/devhub/templates/devhub/docs/policies.html:39
 msgid "Add-on Policies"
 msgstr ""
 
@@ -4947,38 +4173,16 @@ msgid "Use the field below to upload your add-on package."
 msgstr "დამატების პაკეტის ასატვირთად გამოიყენეთ ქვემოთ მოცემული ველი."
 
 #: src/olympia/devhub/templates/devhub/validate_addon.html:19
-msgid ""
-"After upload, a series of automated validation tests will run to check "
-"compatibility with the following application version:"
+msgid "After upload, a series of automated validation tests will run to check compatibility with the following application version:"
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/validate_addon.html:34
-msgid ""
-"After upload, a series of automated validation tests will be run on your "
-"file."
+msgid "After upload, a series of automated validation tests will be run on your file."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/validate_addon.html:42
-#: src/olympia/devhub/templates/devhub/addons/submit/upload.html:23
+#: src/olympia/devhub/templates/devhub/validate_addon.html:42 src/olympia/devhub/templates/devhub/addons/submit/upload.html:23
 msgid "Do you want your add-on to be distributed on this site?"
 msgstr "გსურთ თქვენი დამატების გავრცელება ამ საიტით?"
-
-#: src/olympia/devhub/templates/devhub/validate_addon.html:49
-#: src/olympia/devhub/templates/devhub/addons/submit/upload.html:30
-#: src/olympia/devhub/templates/devhub/versions/add_file_modal.html:14
-#: src/olympia/devhub/templates/devhub/versions/add_file_modal.html:53
-#: src/olympia/devhub/templates/devhub/versions/list.html:298
-msgid "Warning:"
-msgstr ""
-
-#: src/olympia/devhub/templates/devhub/validate_addon.html:50
-#: src/olympia/devhub/templates/devhub/addons/submit/upload.html:31
-#, python-format
-msgid ""
-"Submission of unlisted add-ons for signing is currently in an open beta. "
-"Please <a href=\"%(url)s\" target=\"_blank\">report any bugs</a> that you "
-"encounter."
-msgstr ""
 
 #. first parameter is a filename like lorem-ipsum-1.0.2.xpi
 #: src/olympia/devhub/templates/devhub/validation.html:5
@@ -4997,14 +4201,11 @@ msgstr ""
 msgid "Tested for compatibility against:"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/addons/activity.html:4
-#: src/olympia/devhub/templates/devhub/addons/activity.html:20
+#: src/olympia/devhub/templates/devhub/addons/activity.html:4 src/olympia/devhub/templates/devhub/addons/activity.html:20
 msgid "Recent Activity for My Add-ons"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/addons/activity.html:14
-#: src/olympia/devhub/templates/devhub/addons/activity.html:19
-#: src/olympia/devhub/templates/devhub/addons/dashboard.html:33
+#: src/olympia/devhub/templates/devhub/addons/activity.html:14 src/olympia/devhub/templates/devhub/addons/activity.html:19 src/olympia/devhub/templates/devhub/addons/dashboard.html:33
 msgid "Recent Activity"
 msgstr ""
 
@@ -5026,37 +4227,30 @@ msgstr ""
 msgid "Activity"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/addons/activity.html:83
-#: src/olympia/devhub/templates/devhub/addons/dashboard.html:34
-#: src/olympia/devhub/templates/devhub/addons/dashboard.html:35
-#: src/olympia/devhub/templates/devhub/includes/blog_posts.html:4
-#: src/olympia/devhub/templates/devhub/includes/blog_posts.html:6
+#: src/olympia/devhub/templates/devhub/addons/activity.html:83 src/olympia/devhub/templates/devhub/addons/dashboard.html:34 src/olympia/devhub/templates/devhub/addons/dashboard.html:35
+#: src/olympia/devhub/templates/devhub/includes/blog_posts.html:4 src/olympia/devhub/templates/devhub/includes/blog_posts.html:6
 msgid "Subscribe to this feed"
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/ajax_compat_error.html:7
 #, python-format
 msgid ""
-"This add-on is incompatible with <b>%(app_name)s %(app_version)s</b>, the "
-"latest release of %(app_name)s. Please consider updating your add-on's "
-"compatibility info, or uploading a newer version of this add-on."
+"This add-on is incompatible with <b>%(app_name)s %(app_version)s</b>, the latest release of %(app_name)s. Please consider updating your add-on's compatibility info, or uploading a newer version of "
+"this add-on."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/ajax_compat_error.html:15
 #, python-format
 msgid ""
-"<a href=\"#\" class=\"button compat-update\" data-"
-"updateurl=\"%(update_url)s\">Update Compatibility</a> <a "
-"href=\"%(version_url)s\" class=\"button\">Upload New Version</a> or <a "
-"href=\"#\" class=\"close\">Ignore</a>"
+"<a href=\"#\" class=\"button compat-update\" data-updateurl=\"%(update_url)s\">Update Compatibility</a> <a href=\"%(version_url)s\" class=\"button\">Upload New Version</a> or <a href=\"#\" class="
+"\"close\">Ignore</a>"
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/ajax_compat_status.html:5
 msgid "View and update application compatibility ranges."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/addons/ajax_compat_status.html:6
-#: src/olympia/devhub/templates/devhub/versions/edit.html:44
+#: src/olympia/devhub/templates/devhub/addons/ajax_compat_status.html:6 src/olympia/devhub/templates/devhub/versions/edit.html:44
 msgid "Compatibility"
 msgstr ""
 
@@ -5064,36 +4258,25 @@ msgstr ""
 msgid "Update Compatibility"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/addons/ajax_compat_update.html:4
-msgid ""
-"Adjusting application information here will allow users to install your add-"
-"on even if the install manifest in the package indicates that the add-on is "
-"incompatible."
+#: src/olympia/devhub/templates/devhub/addons/ajax_compat_update.html:4 src/olympia/devhub/templates/devhub/versions/edit.html:45
+msgid "Adjusting application information here will allow users to install your add-on even if the install manifest in the package indicates that the add-on is incompatible."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/ajax_compat_update.html:18
 msgid "Supported Versions"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/addons/ajax_compat_update.html:31
-#: src/olympia/devhub/templates/devhub/versions/edit.html:63
+#: src/olympia/devhub/templates/devhub/addons/ajax_compat_update.html:31 src/olympia/devhub/templates/devhub/versions/edit.html:63
 msgid "Add Another Application&hellip;"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/addons/ajax_compat_update.html:38
-#: src/olympia/devhub/templates/devhub/addons/owner.html:86
-#: src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:46
-#: src/olympia/devhub/templates/devhub/versions/list.html:351
-#: src/olympia/devhub/templates/devhub/versions/list.html:353
-#: src/olympia/templates/impala/base.html:132
-#: src/olympia/templates/impala/base.html:143
-#: src/olympia/templates/impala/base.html:161
-#: src/olympia/templates/impala/base.html:171
+#: src/olympia/devhub/templates/devhub/addons/ajax_compat_update.html:38 src/olympia/devhub/templates/devhub/addons/owner.html:86 src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:45
+#: src/olympia/devhub/templates/devhub/versions/list.html:349 src/olympia/devhub/templates/devhub/versions/list.html:351 src/olympia/templates/impala/base.html:129
+#: src/olympia/templates/impala/base.html:140 src/olympia/templates/impala/base.html:158 src/olympia/templates/impala/base.html:168
 msgid "Close"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/addons/dashboard.html:43
-#: src/olympia/zadmin/templates/zadmin/index.html:22
+#: src/olympia/devhub/templates/devhub/addons/dashboard.html:43 src/olympia/zadmin/templates/zadmin/index.html:22
 #, python-format
 msgid "%(ago)s by %(user)s"
 msgstr ""
@@ -5107,30 +4290,23 @@ msgstr ""
 msgid "<b>{0}</b> theme"
 msgid_plural "<b>{0}</b> themes"
 msgstr[0] ""
+msgstr[1] ""
 
-#: src/olympia/devhub/templates/devhub/addons/edit.html:3
-#: src/olympia/devhub/templates/devhub/addons/listing/item_actions.html:25
-#: src/olympia/devhub/templates/devhub/addons/listing/item_actions_theme.html:7
-#: src/olympia/devhub/templates/devhub/includes/addons_edit_nav.html:2
-#: src/olympia/devhub/templates/devhub/personas/edit.html:6
-#: src/olympia/editors/templates/editors/themes/single.html:37
+#: src/olympia/devhub/templates/devhub/addons/edit.html:3 src/olympia/devhub/templates/devhub/addons/listing/item_actions.html:25
+#: src/olympia/devhub/templates/devhub/addons/listing/item_actions_theme.html:7 src/olympia/devhub/templates/devhub/includes/addons_edit_nav.html:2
+#: src/olympia/devhub/templates/devhub/personas/edit.html:6 src/olympia/editors/templates/editors/themes/single.html:37
 msgid "Edit Listing"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/addons/edit.html:13
-#: src/olympia/devhub/templates/devhub/includes/macros.html:18
-#: src/olympia/translations/templates/translations/all-locales.html:6
+#: src/olympia/devhub/templates/devhub/addons/edit.html:13 src/olympia/devhub/templates/devhub/includes/macros.html:18 src/olympia/translations/templates/translations/all-locales.html:6
 msgid "None"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/addons/owner.html:4
-#: src/olympia/devhub/templates/devhub/addons/listing/item_actions.html:52
-#: src/olympia/devhub/templates/devhub/includes/addons_edit_nav.html:3
+#: src/olympia/devhub/templates/devhub/addons/owner.html:4 src/olympia/devhub/templates/devhub/addons/listing/item_actions.html:52 src/olympia/devhub/templates/devhub/includes/addons_edit_nav.html:3
 msgid "Manage Authors & License"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/addons/owner.html:29
-#: src/olympia/editors/templates/editors/review.html:270
+#: src/olympia/devhub/templates/devhub/addons/owner.html:29 src/olympia/editors/helpers.py:362 src/olympia/editors/templates/editors/review.html:270
 msgid "Authors"
 msgstr ""
 
@@ -5140,25 +4316,18 @@ msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/owner.html:78
 msgid ""
-"<p>Add-ons can have any number of authors with 3 possible roles:</p> <ul> "
-"<li><b>Owner:</b> Can manage all aspects of the add-on's listing, including "
-"adding and removing other authors</li> <li><b>Developer:</b> Can manage all "
-"aspects of the add-on's listing, except for adding and removing other "
-"authors and managing payments</li> <li><b>Viewer:</b> Can view the add-on's "
-"settings and statistics, but cannot make any changes</li> </ul>"
+"<p>Add-ons can have any number of authors with 3 possible roles:</p> <ul> <li><b>Owner:</b> Can manage all aspects of the add-on's listing, including adding and removing other authors</li> "
+"<li><b>Developer:</b> Can manage all aspects of the add-on's listing, except for adding and removing other authors and managing payments</li> <li><b>Viewer:</b> Can view the add-on's settings and "
+"statistics, but cannot make any changes</li> </ul>"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/addons/profile.html:3
-#: src/olympia/devhub/templates/devhub/addons/listing/item_actions.html:53
-#: src/olympia/devhub/templates/devhub/includes/addons_edit_nav.html:4
+#: src/olympia/devhub/templates/devhub/addons/profile.html:3 src/olympia/devhub/templates/devhub/addons/listing/item_actions.html:53 src/olympia/devhub/templates/devhub/includes/addons_edit_nav.html:4
 msgid "Manage Developer Profile"
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/profile.html:16
 #, python-format
-msgid ""
-"Your <a href=\"%(url)s\">developer profile</a> is currently "
-"<strong>public</strong> and <strong>required</strong> for contributions."
+msgid "Your <a href=\"%(url)s\">developer profile</a> is currently <strong>public</strong> and <strong>required</strong> for contributions."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/profile.html:22
@@ -5167,9 +4336,7 @@ msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/profile.html:27
 #, python-format
-msgid ""
-"Your <a href=\"%(url)s\">developer profile</a> is currently "
-"<strong>public</strong>."
+msgid "Your <a href=\"%(url)s\">developer profile</a> is currently <strong>public</strong>."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/profile.html:33
@@ -5197,11 +4364,8 @@ msgstr ""
 msgid "Choose a short, unique URL slug for your add-on."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/addons/edit/basic.html:43
-#: src/olympia/devhub/templates/devhub/includes/addons_edit_nav.html:35
-#: src/olympia/devhub/templates/devhub/personas/edit.html:56
-#: src/olympia/editors/templates/editors/review.html:255
-#: src/olympia/editors/templates/editors/themes/single.html:33
+#: src/olympia/devhub/templates/devhub/addons/edit/basic.html:43 src/olympia/devhub/templates/devhub/includes/addons_edit_nav.html:35 src/olympia/devhub/templates/devhub/personas/edit.html:56
+#: src/olympia/editors/templates/editors/review.html:255 src/olympia/editors/templates/editors/themes/single.html:33
 msgid "View Listing"
 msgstr ""
 
@@ -5211,45 +4375,30 @@ msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/basic.html:52
 msgid ""
-"A short explanation of your add-on's basic\n"
-"                          functionality that is displayed in search and browse\n"
-"                          listings, as well as at the top of your add-on's\n"
-"                          details page. It is only relevant for listed add-ons."
+"A short explanation of your add-on's basic functionality that is displayed in search and browse listings, as well as at the top of your add-on's details page. It is only relevant for listed add-ons."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/basic.html:73
-msgid ""
-"Categories are the primary way users browse through add-ons.\n"
-"                        Choose any that fit your add-on's functionality for the most\n"
-"                        exposure. It is only relevant for listed add-ons."
+msgid "Categories are the primary way users browse through add-ons. Choose any that fit your add-on's functionality for the most exposure. It is only relevant for listed add-ons."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/basic.html:90
 #, python-format
 msgid ""
-"Categories cannot be changed while your add-on is featured for this "
-"application. Please email <a href=\"mailto:%(email)s\">%(email)s</a> if "
-"there is a reason you need to modify your categories."
+"Categories cannot be changed while your add-on is featured for this application. Please email <a href=\"mailto:%(email)s\">%(email)s</a> if there is a reason you need to modify your categories."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/basic.html:119
-msgid ""
-"Tags help users find your add-on and should be short\n"
-"                        descriptors such as tabs, toolbar, or twitter.  You\n"
-"                        may have a maximum of {0} tags. It is only relevant\n"
-"                        for listed add-ons."
+msgid "Tags help users find your add-on and should be short descriptors such as tabs, toolbar, or twitter. You may have a maximum of {0} tags. It is only relevant for listed add-ons."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/addons/edit/basic.html:129
-#: src/olympia/devhub/templates/devhub/personas/edit.html:97
-#: src/olympia/devhub/templates/devhub/personas/submit.html:46
+#: src/olympia/devhub/templates/devhub/addons/edit/basic.html:129 src/olympia/devhub/templates/devhub/personas/edit.html:97 src/olympia/devhub/templates/devhub/personas/submit.html:46
 msgid "Comma-separated, minimum of {0} character."
 msgid_plural "Comma-separated, minimum of {0} characters."
 msgstr[0] ""
+msgstr[1] ""
 
-#: src/olympia/devhub/templates/devhub/addons/edit/basic.html:132
-#: src/olympia/devhub/templates/devhub/personas/edit.html:100
-#: src/olympia/devhub/templates/devhub/personas/submit.html:49
+#: src/olympia/devhub/templates/devhub/addons/edit/basic.html:132 src/olympia/devhub/templates/devhub/personas/edit.html:100 src/olympia/devhub/templates/devhub/personas/submit.html:49
 msgid "Example: dark, cinema, noir. Limit 20."
 msgstr ""
 
@@ -5257,6 +4406,7 @@ msgstr ""
 msgid "Reserved tag:"
 msgid_plural "Reserved tags:"
 msgstr[0] ""
+msgstr[1] ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/details.html:5
 msgid "Add-on Details"
@@ -5267,39 +4417,26 @@ msgid "Add-on Details for {0}"
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/details.html:22
-msgid ""
-"A longer explanation of features,\n"
-"                          functionality, and other relevant information. This\n"
-"                          field is only displayed on the add-on's details\n"
-"                          page. It is only relevant for listed add-ons."
+msgid "A longer explanation of features, functionality, and other relevant information. This field is only displayed on the add-on's details page. It is only relevant for listed add-ons."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/addons/edit/details.html:44
-#: src/olympia/translations/templates/translations/trans-menu.html:13
+#: src/olympia/devhub/templates/devhub/addons/edit/details.html:44 src/olympia/translations/templates/translations/trans-menu.html:13
 msgid "Default Locale"
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/details.html:45
-msgid ""
-"Information about your add-on is displayed in this locale\n"
-"                        unless you override it with a locale-specific translation.\n"
-"                        It is only relevant for listed add-ons."
+msgid "Information about your add-on is displayed in this locale unless you override it with a locale-specific translation. It is only relevant for listed add-ons."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/addons/edit/details.html:61
-#: src/olympia/users/forms.py:311
-#: src/olympia/users/templates/users/edit.html:122
-#: src/olympia/users/templates/users/register.html:57
+#: src/olympia/devhub/templates/devhub/addons/edit/details.html:61 src/olympia/users/forms.py:311 src/olympia/users/templates/users/edit.html:122 src/olympia/users/templates/users/register.html:57
 #: src/olympia/users/templates/users/vcard.html:22
 msgid "Homepage"
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/details.html:63
 msgid ""
-"If your add-on has another homepage, enter its\n"
-"                          address here. If your website is localized into other\n"
-"                          languages multiple translations of this field can be\n"
-"                          added. It is only relevant for listed add-ons."
+"If your add-on has another homepage, enter its address here. If your website is localized into other languages multiple translations of this field can be added. It is only relevant for listed add-"
+"ons."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/media.html:3
@@ -5317,19 +4454,14 @@ msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/support.html:22
 msgid ""
-"If you wish to display an e-mail address for support\n"
-"                          inquiries, enter it here. If you have different\n"
-"                          addresses for each language multiple translations of\n"
-"                          this field can be added. It is only relevant for\n"
-"                          listed add-ons."
+"If you wish to display an e-mail address for support inquiries, enter it here. If you have different addresses for each language multiple translations of this field can be added. It is only "
+"relevant for listed add-ons."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/support.html:45
 msgid ""
-"If your add-on has a support website or forum, enter\n"
-"                          its address here. If your website is localized into\n"
-"                          other languages, multiple translations of this field can\n"
-"                          be added. It is only relevant for listed add-ons."
+"If your add-on has a support website or forum, enter its address here. If your website is localized into other languages, multiple translations of this field can be added. It is only relevant for "
+"listed add-ons."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:6
@@ -5343,11 +4475,8 @@ msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:23
 msgid ""
-"Any information end users may want to know that isn't\n"
-"                          necessarily applicable to the add-on summary or description.\n"
-"                          Common uses include listing known major bugs, information on\n"
-"                          how to report bugs, anticipated release date of a new version,\n"
-"                          etc. It is only relevant for listed add-ons."
+"Any information end users may want to know that isn't necessarily applicable to the add-on summary or description. Common uses include listing known major bugs, information on how to report bugs, "
+"anticipated release date of a new version, etc. It is only relevant for listed add-ons."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:46
@@ -5359,9 +4488,7 @@ msgid "Add-on Flags"
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:69
-msgid ""
-"These flags are used to classify add-ons. It is only\n"
-"                        relevant for listed add-ons."
+msgid "These flags are used to classify add-ons. It is only relevant for listed add-ons."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:74
@@ -5377,9 +4504,7 @@ msgid "View Source?"
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:90
-msgid ""
-"Whether the source of your add-on can be displayed in our\n"
-"                        online viewer. It is only relevant for listed add-ons."
+msgid "Whether the source of your add-on can be displayed in our online viewer. It is only relevant for listed add-ons."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:94
@@ -5395,10 +4520,7 @@ msgid "Public Stats?"
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:102
-msgid ""
-"Whether the download and usage stats of your add-on can\n"
-"                        be displayed in our online viewer.\n"
-"                        It is only relevant for listed add-ons."
+msgid "Whether the download and usage stats of your add-on can be displayed in our online viewer. It is only relevant for listed add-ons."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:107
@@ -5414,16 +4536,11 @@ msgid "Upgrade SDK?"
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:116
-msgid ""
-"If selected, we will try to automatically upgrade your\n"
-"                        add-on when a new version of the SDK is released.\n"
-"                        It is only relevant for listed add-ons."
+msgid "If selected, we will try to automatically upgrade your add-on when a new version of the SDK is released. It is only relevant for listed add-ons."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:121
-msgid ""
-"This add-on will be automatically upgraded to new versions of the Add-on "
-"SDK."
+msgid "This add-on will be automatically upgraded to new versions of the Add-on SDK."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:123
@@ -5439,22 +4556,17 @@ msgid "UUID"
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:132
-msgid ""
-"The UUID of your add-on is specified in its install manifest and uniquely "
-"identifies it. You cannot change your UUID once it has been submitted."
+msgid "The UUID of your add-on is specified in its install manifest and uniquely identifies it. You cannot change your UUID once it has been submitted."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/addons/edit/technical.html:143
-#: src/olympia/devhub/templates/devhub/addons/edit/technical.html:144
+#: src/olympia/devhub/templates/devhub/addons/edit/technical.html:143 src/olympia/devhub/templates/devhub/addons/edit/technical.html:144
 msgid "Whiteboard"
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:146
 msgid ""
-"The whiteboard is the place to provide information relevant to your addon, "
-"whatever the version, to the editor. Use it to provide ways to test the "
-"addon, and any additional information that may help. This whiteboard is also"
-" editable by editors."
+"The whiteboard is the place to provide information relevant to your addon, whatever the version, to the editor. Use it to provide ways to test the addon, and any additional information that may "
+"help. This whiteboard is also editable by editors."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/technical_dependencies.html:9
@@ -5475,10 +4587,8 @@ msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/forms_shared/media.html:16
 msgid ""
-"Upload an icon for your add-on or choose from one of ours. The\n"
-"                      icon is displayed nearly everywhere your add-on is. Uploaded images\n"
-"                      must be one of the following image types: .png, .jpg.\n"
-"                      It is only relevant for listed add-ons."
+"Upload an icon for your add-on or choose from one of ours. The icon is displayed nearly everywhere your add-on is. Uploaded images must be one of the following image types: .png, .jpg. It is only "
+"relevant for listed add-ons."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/forms_shared/media.html:25
@@ -5491,9 +4601,7 @@ msgid "32x32px"
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/forms_shared/media.html:39
-msgid ""
-"Used in listings of add-ons, like search results\n"
-"                            and featured add-ons."
+msgid "Used in listings of add-ons, like search results and featured add-ons."
 msgstr ""
 
 #. The size of the icon
@@ -5533,60 +4641,49 @@ msgstr ""
 msgid "Tests"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/addons/includes/validation_compat_test_results.html:25
-#: src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:5
+#: src/olympia/devhub/templates/devhub/addons/includes/validation_compat_test_results.html:25 src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:5
 #: src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:53
 msgid "General Tests"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/addons/includes/validation_compat_test_results.html:32
-#: src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:9
+#: src/olympia/devhub/templates/devhub/addons/includes/validation_compat_test_results.html:32 src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:9
 #: src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:67
 msgid "Security Tests"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/addons/includes/validation_compat_test_results.html:39
-#: src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:13
+#: src/olympia/devhub/templates/devhub/addons/includes/validation_compat_test_results.html:39 src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:13
 #: src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:80
 msgid "Extension Tests"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/addons/includes/validation_compat_test_results.html:46
-#: src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:17
+#: src/olympia/devhub/templates/devhub/addons/includes/validation_compat_test_results.html:46 src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:17
 #: src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:93
 msgid "Localization Tests"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:21
-#: src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:106
+#: src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:21 src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:106
 msgid "Compatibility Tests"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:29
-#: src/olympia/files/templates/files/viewer.html:142
+#: src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:29 src/olympia/files/templates/files/viewer.html:142
 msgid "Hide messages not required for automated signing"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:35
-#: src/olympia/files/templates/files/viewer.html:150
+#: src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:35 src/olympia/files/templates/files/viewer.html:150
 msgid "Hide messages present in previous version and ignored"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:50
-#: src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:64
-#: src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:77
-#: src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:90
+#: src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:50 src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:64
+#: src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:77 src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:90
 #: src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:103
 msgid "Top"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:2
-#: src/olympia/devhub/templates/devhub/personas/edit.html:63
+#: src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:2 src/olympia/devhub/templates/devhub/personas/edit.html:63
 msgid "Delete Theme"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:2
-#: src/olympia/devhub/templates/devhub/versions/list.html:117
+#: src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:2 src/olympia/devhub/templates/devhub/versions/list.html:117
 msgid "Delete Add-on"
 msgstr ""
 
@@ -5595,27 +4692,22 @@ msgid "Deleting your theme will permanently remove it from the site."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:14
-msgid ""
-"Deleting your add-on will permanently remove it from the site and prevent "
-"its GUID from being submitted again by others."
+msgid "Deleting your add-on will permanently remove it from the site and prevent its GUID from being submitted again by others."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:24
-msgid ""
-"Enter the following text confirm your decision:\n"
-"           {slug}"
+msgid "Enter the following text confirm your decision: {slug}"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:34
+#: src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:33
 msgid "Please tell us why you are deleting your theme:"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:36
+#: src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:35
 msgid "Please tell us why you are deleting your add-on:"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/addons/listing/item_actions.html:1
-#: src/olympia/devhub/templates/devhub/addons/listing/item_actions_theme.html:1
+#: src/olympia/devhub/templates/devhub/addons/listing/item_actions.html:1 src/olympia/devhub/templates/devhub/addons/listing/item_actions_theme.html:1
 #: src/olympia/editors/templates/editors/review.html:253
 msgid "Actions"
 msgstr ""
@@ -5648,22 +4740,17 @@ msgstr ""
 msgid "Daily statistics on downloads and users."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/addons/listing/item_actions.html:45
-#: src/olympia/stats/templates/stats/stats.html:75
-#: src/olympia/stats/templates/stats/stats.html:79
-#: src/olympia/stats/templates/stats/stats.html:81
+#: src/olympia/devhub/templates/devhub/addons/listing/item_actions.html:45 src/olympia/stats/templates/stats/stats.html:31 src/olympia/stats/templates/stats/stats.html:35
+#: src/olympia/stats/templates/stats/stats.html:37
 msgid "Statistics"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/addons/listing/item_actions.html:54
-#: src/olympia/devhub/templates/devhub/includes/addons_edit_nav.html:5
-#: src/olympia/devhub/templates/devhub/payments/payments.html:3
-#: src/olympia/devhub/templates/devhub/payments/tier.html:4
+#: src/olympia/devhub/templates/devhub/addons/listing/item_actions.html:54 src/olympia/devhub/templates/devhub/includes/addons_edit_nav.html:5
+#: src/olympia/devhub/templates/devhub/payments/payments.html:3 src/olympia/devhub/templates/devhub/payments/tier.html:4
 msgid "Manage Payments"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/addons/listing/item_actions.html:55
-#: src/olympia/devhub/templates/devhub/includes/addons_edit_nav.html:6
+#: src/olympia/devhub/templates/devhub/addons/listing/item_actions.html:55 src/olympia/devhub/templates/devhub/includes/addons_edit_nav.html:6
 msgid "Manage Status & Versions"
 msgstr ""
 
@@ -5671,10 +4758,8 @@ msgstr ""
 msgid "View Add-on Listing"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/addons/listing/item_actions.html:64
-#: src/olympia/devhub/templates/devhub/addons/listing/item_actions_theme.html:12
-#: src/olympia/devhub/templates/devhub/includes/addons_edit_nav.html:37
-#: src/olympia/devhub/templates/devhub/personas/edit.html:58
+#: src/olympia/devhub/templates/devhub/addons/listing/item_actions.html:64 src/olympia/devhub/templates/devhub/addons/listing/item_actions_theme.html:12
+#: src/olympia/devhub/templates/devhub/includes/addons_edit_nav.html:37 src/olympia/devhub/templates/devhub/personas/edit.html:58
 msgid "View Recent Changes"
 msgstr ""
 
@@ -5699,9 +4784,7 @@ msgid "Delete this theme."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/listing/items.html:10
-msgid ""
-"This add-on will be deleted automatically after a few days if the submission"
-" process is not completed."
+msgid "This add-on will be deleted automatically after a few days if the submission process is not completed."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/listing/items.html:27
@@ -5718,6 +4801,7 @@ msgstr ""
 msgid "<strong>{0}</strong> active user"
 msgid_plural "<strong>{0}</strong> active users"
 msgstr[0] ""
+msgstr[1] ""
 
 #: src/olympia/devhub/templates/devhub/addons/submit/base.html:11
 msgid "Submit Add-on"
@@ -5739,9 +4823,7 @@ msgstr ""
 msgid "The detail page will be:"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/addons/submit/describe.html:24
-#: src/olympia/devhub/templates/devhub/personas/edit.html:89
-#: src/olympia/devhub/templates/devhub/personas/submit.html:38
+#: src/olympia/devhub/templates/devhub/addons/submit/describe.html:24 src/olympia/devhub/templates/devhub/personas/edit.html:89 src/olympia/devhub/templates/devhub/personas/submit.html:38
 msgid "Please use only letters, numbers, underscores, and dashes in your URL."
 msgstr ""
 
@@ -5761,14 +4843,11 @@ msgstr ""
 msgid "The description will appear on the detail page."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/addons/submit/done.html:4
-#: src/olympia/devhub/templates/devhub/personas/submit_done.html:4
+#: src/olympia/devhub/templates/devhub/addons/submit/done.html:4 src/olympia/devhub/templates/devhub/personas/submit_done.html:4
 msgid "Submission Complete"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/addons/submit/done.html:8
-#: src/olympia/devhub/templates/devhub/addons/submit/sidebar.html:13
-#: src/olympia/devhub/templates/devhub/personas/submit_done.html:8
+#: src/olympia/devhub/templates/devhub/addons/submit/done.html:8 src/olympia/devhub/templates/devhub/addons/submit/sidebar.html:13 src/olympia/devhub/templates/devhub/personas/submit_done.html:8
 msgid "You're done!"
 msgstr "მორჩა!"
 
@@ -5781,20 +4860,14 @@ msgid "Your add-on has been submitted to the Full Review queue."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/submit/done.html:18
-msgid ""
-"You'll receive an email once it has been reviewed by an editor. In\n"
-"          the meantime, you and your friends can install it directly from its\n"
-"          details page:"
+msgid "You'll receive an email once it has been reviewed by an editor. In the meantime, you and your friends can install it directly from its details page:"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/addons/submit/done.html:27
-#: src/olympia/devhub/templates/devhub/addons/submit/done.html:77
-#: src/olympia/devhub/templates/devhub/personas/submit_done.html:16
+#: src/olympia/devhub/templates/devhub/addons/submit/done.html:27 src/olympia/devhub/templates/devhub/addons/submit/done.html:77 src/olympia/devhub/templates/devhub/personas/submit_done.html:16
 msgid "Next steps:"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/addons/submit/done.html:32
-#: src/olympia/devhub/templates/devhub/addons/submit/done.html:82
+#: src/olympia/devhub/templates/devhub/addons/submit/done.html:32 src/olympia/devhub/templates/devhub/addons/submit/done.html:82
 msgid "<a href=\"{0}\">Upload</a> another platform-specific file to this version."
 msgstr ""
 
@@ -5803,19 +4876,14 @@ msgid "Provide more details by <a href=\"{0}\">editing its listing</a>."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/submit/done.html:35
-msgid ""
-"Tell your users why you created this in your <a href=\"{0}\">Developer "
-"Profile</a>."
+msgid "Tell your users why you created this in your <a href=\"{0}\">Developer Profile</a>."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/submit/done.html:36
-msgid ""
-"View and subscribe to your add-on's <a href=\"{0}\">activity feed</a> to "
-"stay updated on reviews, collections, and more."
+msgid "View and subscribe to your add-on's <a href=\"{0}\">activity feed</a> to stay updated on reviews, collections, and more."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/addons/submit/done.html:37
-#: src/olympia/devhub/templates/devhub/addons/submit/done.html:86
+#: src/olympia/devhub/templates/devhub/addons/submit/done.html:37 src/olympia/devhub/templates/devhub/addons/submit/done.html:86
 msgid "View approximate review queue <a href=\"{0}\">wait times</a>."
 msgstr ""
 
@@ -5828,13 +4896,11 @@ msgid "Become an AMO Reviewer today and get your add-ons reviewed faster."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/submit/done.html:54
-msgid ""
-"Your add-on has been signed and it's ready to use. You can download it here:"
+msgid "Your add-on has been signed and it's ready to use. You can download it here:"
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/submit/done.html:64
-msgid ""
-"Your add-on has been submitted to the Unlisted Preliminary Review queue."
+msgid "Your add-on has been submitted to the Unlisted Preliminary Review queue."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/submit/done.html:66
@@ -5842,8 +4908,7 @@ msgid "Your add-on has been submitted to the Unlisted Full Review queue."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/submit/done.html:70
-msgid ""
-"You'll receive an email once it has been reviewed by an editor and signed."
+msgid "You'll receive an email once it has been reviewed by an editor and signed."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/submit/done.html:74
@@ -5851,9 +4916,7 @@ msgid "Your add-on will not be publicly available on this website."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/submit/done.html:84
-msgid ""
-"You can upload new versions of your add-on in the <a href=\"{0}\">add-on's "
-"developer page</a>."
+msgid "You can upload new versions of your add-on in the <a href=\"{0}\">add-on's developer page</a>."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/submit/license.html:4
@@ -5865,10 +4928,7 @@ msgid "Step 5. Select a License"
 msgstr "ნაბიჯი 5. აირჩიეთ ლიცენზია"
 
 #: src/olympia/devhub/templates/devhub/addons/submit/license.html:9
-msgid ""
-"We require all add-ons to indicate the terms under which their source code "
-"is licensed. Please select a license from the list below or enter a custom "
-"license."
+msgid "We require all add-ons to indicate the terms under which their source code is licensed. Please select a license from the list below or enter a custom license."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/submit/license.html:18
@@ -5885,9 +4945,8 @@ msgstr "მე-4 ნაბიჯი. დაამატეთ ნახატე
 
 #: src/olympia/devhub/templates/devhub/addons/submit/media.html:9
 msgid ""
-"Custom icons and screenshots draw attention and help users understand what "
-"it does. We strongly recommend uploading a custom icon, as in some areas of "
-"the website, only the icon and name will appear."
+"Custom icons and screenshots draw attention and help users understand what it does. We strongly recommend uploading a custom icon, as in some areas of the website, only the icon and name will "
+"appear."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/submit/select-review.html:5
@@ -5900,17 +4959,13 @@ msgstr "ნაბიჯი 6. აირჩიეთ განხილვის 
 
 #: src/olympia/devhub/templates/devhub/addons/submit/select-review.html:10
 msgid ""
-"All add-ons hosted in our gallery must be reviewed by an editor before they "
-"appear in categories or search results. While waiting for review, your add-"
-"on can still be accessed through its direct URL. Please choose the review "
-"process below that best fits your add-on."
+"All add-ons hosted in our gallery must be reviewed by an editor before they appear in categories or search results. While waiting for review, your add-on can still be accessed through its direct "
+"URL. Please choose the review process below that best fits your add-on."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/submit/select-review.html:26
 #, python-format
-msgid ""
-"A complete review of your add-on's source and functionality. <a "
-"href=\"%(url)s\">Learn more&hellip;</a>"
+msgid "A complete review of your add-on's source and functionality. <a href=\"%(url)s\">Learn more&hellip;</a>"
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/submit/select-review.html:32
@@ -5939,9 +4994,7 @@ msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/submit/select-review.html:49
 #, python-format
-msgid ""
-"A faster review of your add-on's source for any major problems. <a "
-"href=\"%(url)s\">Learn more&hellip;</a>"
+msgid "A faster review of your add-on's source for any major problems. <a href=\"%(url)s\">Learn more&hellip;</a>"
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/submit/select-review.html:55
@@ -5988,10 +5041,8 @@ msgstr "აირჩიეთ ლიცენზია"
 msgid "Select a review process"
 msgstr "აირჩიეთ განხილვის პროცესი"
 
-#: src/olympia/devhub/templates/devhub/addons/submit/sidebar.html:18
-#: src/olympia/devhub/templates/devhub/docs/policies-submission.html:3
-#: src/olympia/devhub/templates/devhub/docs/policies-submission.html:7
-#: src/olympia/devhub/templates/devhub/docs/policies-submission.html:9
+#: src/olympia/devhub/templates/devhub/addons/submit/sidebar.html:18 src/olympia/devhub/templates/devhub/docs/policies-submission.html:3
+#: src/olympia/devhub/templates/devhub/docs/policies-submission.html:7 src/olympia/devhub/templates/devhub/docs/policies-submission.html:9
 msgid "Submission Process"
 msgstr "წარდგენის პროცესი"
 
@@ -6012,24 +5063,18 @@ msgid "Step 2. Upload Your Add-on"
 msgstr "მე-2 ნაბიჯი. ატვირთეთ თქვენი დამატება"
 
 #: src/olympia/devhub/templates/devhub/addons/submit/upload.html:11
-msgid ""
-"Use the fields below to upload your add-on package and select any platform "
-"restrictions. After upload, a series of automated validation tests will be "
-"run on your file."
+msgid "Use the fields below to upload your add-on package and select any platform restrictions. After upload, a series of automated validation tests will be run on your file."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/addons/submit/upload.html:59
-#: src/olympia/devhub/templates/devhub/versions/add_file_modal.html:39
+#: src/olympia/devhub/templates/devhub/addons/submit/upload.html:51 src/olympia/devhub/templates/devhub/versions/add_file_modal.html:28
 msgid "Which platforms is this file compatible with?"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/addons/submit/upload.html:67
-#: src/olympia/devhub/templates/devhub/versions/add_file_modal.html:65
+#: src/olympia/devhub/templates/devhub/addons/submit/upload.html:59 src/olympia/devhub/templates/devhub/versions/add_file_modal.html:45
 msgid "Administrative overrides"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/api/agreement.html:3
-#: src/olympia/devhub/templates/devhub/api/agreement.html:11
+#: src/olympia/devhub/templates/devhub/api/agreement.html:3 src/olympia/devhub/templates/devhub/api/agreement.html:11
 msgid "Firefox Add-on Distribution Agreement"
 msgstr ""
 
@@ -6039,9 +5084,7 @@ msgstr ""
 
 #: src/olympia/devhub/templates/devhub/api/key.html:20
 #, python-format
-msgid ""
-"For detailed instructions, consult the <a href=\"%(docs_url)s\">API "
-"documentation</a>."
+msgid "For detailed instructions, consult the <a href=\"%(docs_url)s\">API documentation</a>."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/api/key.html:28
@@ -6055,10 +5098,8 @@ msgstr ""
 #: src/olympia/devhub/templates/devhub/api/key.html:37
 #, python-format
 msgid ""
-"To make API requests, send a <a href=\"%(jwt_url)s\">JSON Web Token "
-"(JWT)</a> as the authorization header. You'll need to generate a JWT for "
-"every request as explained in the <a href=\"%(docs_url)s\">API "
-"documentation</a>."
+"To make API requests, send a <a href=\"%(jwt_url)s\">JSON Web Token (JWT)</a> as the authorization header. You'll need to generate a JWT for every request as explained in the <a href=\"%(docs_url)s"
+"\">API documentation</a>."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/api/key.html:47
@@ -6067,9 +5108,7 @@ msgstr ""
 
 #: src/olympia/devhub/templates/devhub/api/key.html:53
 #, python-format
-msgid ""
-"This feature is under active development. If you find a problem please <a "
-"target=\"_blank\" href=\"%(bug_link)s\">report a bug</a>."
+msgid "This feature is under active development. If you find a problem please <a target=\"_blank\" href=\"%(bug_link)s\">report a bug</a>."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/api/key.html:61
@@ -6080,26 +5119,18 @@ msgstr ""
 msgid "Generate new credentials"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/docs/policies-agreement.html:3
-#: src/olympia/devhub/templates/devhub/docs/policies-agreement.html:7
-#: src/olympia/devhub/templates/devhub/docs/policies-agreement.html:9
-#: src/olympia/devhub/templates/devhub/docs/policies.html:24
-#: src/olympia/devhub/templates/devhub/docs/policies.html:103
+#: src/olympia/devhub/templates/devhub/docs/policies-agreement.html:3 src/olympia/devhub/templates/devhub/docs/policies-agreement.html:7
+#: src/olympia/devhub/templates/devhub/docs/policies-agreement.html:9 src/olympia/devhub/templates/devhub/docs/policies.html:24 src/olympia/devhub/templates/devhub/docs/policies.html:103
 msgid "Developer Agreement"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/docs/policies-contact.html:3
-#: src/olympia/devhub/templates/devhub/docs/policies-contact.html:7
-#: src/olympia/devhub/templates/devhub/docs/policies-contact.html:9
-#: src/olympia/devhub/templates/devhub/docs/policies.html:27
-#: src/olympia/devhub/templates/devhub/docs/policies.html:115
+#: src/olympia/devhub/templates/devhub/docs/policies-contact.html:3 src/olympia/devhub/templates/devhub/docs/policies-contact.html:7 src/olympia/devhub/templates/devhub/docs/policies-contact.html:9
+#: src/olympia/devhub/templates/devhub/docs/policies.html:27 src/olympia/devhub/templates/devhub/docs/policies.html:115
 msgid "Contacting Us"
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/docs/policies-contact.html:12
-msgid ""
-"Thanks for your interest in contacting the Mozilla Add-ons team. Please read"
-" this page carefully to ensure your request goes to the right place."
+msgid "Thanks for your interest in contacting the Mozilla Add-ons team. Please read this page carefully to ensure your request goes to the right place."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/docs/policies-contact.html:17
@@ -6108,10 +5139,8 @@ msgstr ""
 
 #: src/olympia/devhub/templates/devhub/docs/policies-contact.html:19
 msgid ""
-"If you have a support question about a particular add-on, such as \"how do I"
-" use this add-on?\" or \"why doesn't this work properly?\", please contact "
-"that add-on's author through the support channels listed on the add-on's "
-"listing page."
+"If you have a support question about a particular add-on, such as \"how do I use this add-on?\" or \"why doesn't this work properly?\", please contact that add-on's author through the support "
+"channels listed on the add-on's listing page."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/docs/policies-contact.html:24
@@ -6125,11 +5154,8 @@ msgstr ""
 #: src/olympia/devhub/templates/devhub/docs/policies-contact.html:26
 #, python-format
 msgid ""
-"If you have a question about an Editor's review of an add-on or want to "
-"report a policy violation, please email %(mail_editors)s. <strong>Almost all"
-" add-on reports fall under this category.</strong> Please be sure to include"
-" a link to the add-on in question and a detailed description of your "
-"question or comment."
+"If you have a question about an Editor's review of an add-on or want to report a policy violation, please email %(mail_editors)s. <strong>Almost all add-on reports fall under this category.</"
+"strong> Please be sure to include a link to the add-on in question and a detailed description of your question or comment."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/docs/policies-contact.html:31
@@ -6143,13 +5169,9 @@ msgstr ""
 #: src/olympia/devhub/templates/devhub/docs/policies-contact.html:36
 #, python-format
 msgid ""
-"If you have discovered a security vulnerability in an add-on, even if it is "
-"not hosted here, Mozilla is very interested in your discovery and will work "
-"with the add-on developer to correct the issue as soon as possible. Add-on "
-"security issues can be reported <a "
-"href=\"http://www.mozilla.org/projects/security/security-bugs-"
-"policy.html\">confidentially</a> in <a "
-"href=\"%(link_bugzilla)s\">Bugzilla</a> or by emailing %(mail_admins)s."
+"If you have discovered a security vulnerability in an add-on, even if it is not hosted here, Mozilla is very interested in your discovery and will work with the add-on developer to correct the "
+"issue as soon as possible. Add-on security issues can be reported <a href=\"http://www.mozilla.org/projects/security/security-bugs-policy.html\">confidentially</a> in <a href=\"%(link_bugzilla)s"
+"\">Bugzilla</a> or by emailing %(mail_admins)s."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/docs/policies-contact.html:42
@@ -6158,13 +5180,11 @@ msgstr ""
 
 #: src/olympia/devhub/templates/devhub/docs/policies-contact.html:44
 msgid ""
-"If you've found a problem with the site, we'd love to fix it. Please <a "
-"href=\"https://github.com/mozilla/olympia/issues\">file a bug report</a> in "
-"GitHub, including the location of the problem and how you encountered it."
+"If you've found a problem with the site, we'd love to fix it. Please <a href=\"https://github.com/mozilla/addons/issues/new\">file a bug report</a> in GitHub, including the location of the problem "
+"and how you encountered it."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/docs/policies-maintenance.html:3
-#: src/olympia/devhub/templates/devhub/docs/policies-maintenance.html:7
+#: src/olympia/devhub/templates/devhub/docs/policies-maintenance.html:3 src/olympia/devhub/templates/devhub/docs/policies-maintenance.html:7
 #: src/olympia/devhub/templates/devhub/docs/policies-maintenance.html:8
 msgid "Maintaining Your Add-ons"
 msgstr ""
@@ -6175,20 +5195,13 @@ msgstr ""
 
 #: src/olympia/devhub/templates/devhub/docs/policies-maintenance.html:12
 msgid ""
-"Developers are encouraged to submit updates to their add-ons to fix bugs, "
-"add features, and otherwise improve their product. New versions of an add-on"
-" must have a <a "
-"href=\"https://developer.mozilla.org/en/Toolkit_version_format\">higher "
-"version number</a> and can be submitted through the Developer Tools "
-"provided. There is no limit to the number of versions that can be submitted,"
-" but please remember that versions must be reviewed by an editor."
+"Developers are encouraged to submit updates to their add-ons to fix bugs, add features, and otherwise improve their product. New versions of an add-on must have a <a href=\"https://developer."
+"mozilla.org/en/Toolkit_version_format\">higher version number</a> and can be submitted through the Developer Tools provided. There is no limit to the number of versions that can be submitted, but "
+"please remember that versions must be reviewed by an editor."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/docs/policies-maintenance.html:18
-msgid ""
-"New versions will be added to a pending review queue, and any additional "
-"versions submitted before the review is completed will move that version to "
-"the end of the queue."
+msgid "New versions will be added to a pending review queue, and any additional versions submitted before the review is completed will move that version to the end of the queue."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/docs/policies-maintenance.html:23
@@ -6201,31 +5214,22 @@ msgstr ""
 
 #: src/olympia/devhub/templates/devhub/docs/policies-maintenance.html:31
 msgid ""
-"To create a beta channel, upload a file with a unique version string that "
-"contains any of the following strings: <code>a,b,alpha,beta,pre,rc</code>, "
-"with an optional number at the end. This text must come at the end of the "
-"version string. If you understand regex format, here's what we look for in "
-"the version number: <code>\"(a|alpha|b|beta|pre|rc)\\d*$\"</code>."
+"To create a beta channel, upload a file with a unique version string that contains any of the following strings: <code>a,b,alpha,beta,pre,rc</code>, with an optional number at the end. This text "
+"must come at the end of the version string. If you understand regex format, here's what we look for in the version number: <code>\"(a|alpha|b|beta|pre|rc)\\d*$\"</code>."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/docs/policies-maintenance.html:37
 msgid ""
-"Once a file meeting this criteria is uploaded to AMO, it will automatically "
-"be marked as a beta version. Users of add-ons with these unique version "
-"numbers will automatically be served the newest beta updates."
+"Once a file meeting this criteria is uploaded to AMO, it will automatically be marked as a beta version. Users of add-ons with these unique version numbers will automatically be served the newest "
+"beta updates."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/docs/policies-maintenance.html:43
 msgid ""
-"While we call these \"Beta versions\", you can use this channel for "
-"nightlies, or alphas, or prerelease versions as you wish. Please note that "
-"there is only one channel for this purpose and all of your users on this "
-"channel will receive the latest add-ons submitted. For instance, if you "
-"upload <code>1.0beta1</code> to the release channel and then upload "
-"<code>1.1alpha1</code>, all users of <code>1.0beta1</code> will be offered "
-"an upgrade to <code>1.1alpha1</code>. Updates are pushed by submission date "
-"and not version number, so users will always get the most recent channel "
-"update regardless of any kind of alphabetical sorting."
+"While we call these \"Beta versions\", you can use this channel for nightlies, or alphas, or prerelease versions as you wish. Please note that there is only one channel for this purpose and all of "
+"your users on this channel will receive the latest add-ons submitted. For instance, if you upload <code>1.0beta1</code> to the release channel and then upload <code>1.1alpha1</code>, all users of "
+"<code>1.0beta1</code> will be offered an upgrade to <code>1.1alpha1</code>. Updates are pushed by submission date and not version number, so users will always get the most recent channel update "
+"regardless of any kind of alphabetical sorting."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/docs/policies-maintenance.html:48
@@ -6234,13 +5238,9 @@ msgstr ""
 
 #: src/olympia/devhub/templates/devhub/docs/policies-maintenance.html:50
 msgid ""
-"Certain situations may arise in which Mozilla requests that an add-on "
-"developer update their add-on within a given time period to address a major "
-"security issue or policy violation. We work with developers to reasonably "
-"accommodate their own schedules, but if the issue is of a serious enough "
-"nature, add-ons that cannot issue an update with the requested fix may be "
-"demoted from fully-reviewed status, disabled, or permanently removed from "
-"the site."
+"Certain situations may arise in which Mozilla requests that an add-on developer update their add-on within a given time period to address a major security issue or policy violation. We work with "
+"developers to reasonably accommodate their own schedules, but if the issue is of a serious enough nature, add-ons that cannot issue an update with the requested fix may be demoted from fully-"
+"reviewed status, disabled, or permanently removed from the site."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/docs/policies-maintenance.html:55
@@ -6249,43 +5249,32 @@ msgstr ""
 
 #: src/olympia/devhub/templates/devhub/docs/policies-maintenance.html:57
 msgid ""
-"Add-ons can have multiple users with permission to update and manage the "
-"listing. Existing authors of an add-on can transfer ownership and add "
-"additional developers to an add-on's listing through the Developer Tools "
-"provided. No interaction with Mozilla representatives is necessary for a "
-"transfer of ownership."
+"Add-ons can have multiple users with permission to update and manage the listing. Existing authors of an add-on can transfer ownership and add additional developers to an add-on's listing through "
+"the Developer Tools provided. No interaction with Mozilla representatives is necessary for a transfer of ownership."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/docs/policies-maintenance.html:63
 #, python-format
-msgid ""
-"Mozilla can assist with granting additional permissions of an add-on's "
-"listing if <a href=\"%(link_contact)s\">contacted</a> by the add-on's "
-"current owner."
+msgid "Mozilla can assist with granting additional permissions of an add-on's listing if <a href=\"%(link_contact)s\">contacted</a> by the add-on's current owner."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/docs/policies-maintenance.html:70
 msgid ""
-"Mozilla encourages its users to offer feedback on their experiences when "
-"using an add-on. This allows other users to determine if the add-on is "
-"stable and useful. It also provides valuable feedback to developers, "
-"allowing them to continuously improve their add-on to meet user needs."
+"Mozilla encourages its users to offer feedback on their experiences when using an add-on. This allows other users to determine if the add-on is stable and useful. It also provides valuable feedback "
+"to developers, allowing them to continuously improve their add-on to meet user needs."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/docs/policies-maintenance.html:76
 #, python-format
 msgid ""
-"Reviews must follow the <a href=\"%(link_guidelines)s\">review "
-"guidelines</a>. Reviews that do not meet these guidelines may be flagged for"
-" moderation, but negative reviews will not be removed unless they provide "
-"false information."
+"Reviews must follow the <a href=\"%(link_guidelines)s\">review guidelines</a>. Reviews that do not meet these guidelines may be flagged for moderation, but negative reviews will not be removed "
+"unless they provide false information."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/docs/policies-maintenance.html:82
 msgid ""
-"Many developers provide a support mechanism, such as a forum, discussion "
-"group, or email address. It is recommended that support questions be posted "
-"via those mediums instead of in an add-on's review section."
+"Many developers provide a support mechanism, such as a forum, discussion group, or email address. It is recommended that support questions be posted via those mediums instead of in an add-on's "
+"review section."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/docs/policies-maintenance.html:87
@@ -6294,31 +5283,21 @@ msgstr ""
 
 #: src/olympia/devhub/templates/devhub/docs/policies-maintenance.html:90
 msgid ""
-"Many add-ons allow their source code to be openly viewed. This does not mean"
-" that the source code is open source or available for use in another add-on."
-" The original author of an add-on retains copyright of their work unless "
-"otherwise noted in the add-on's license."
+"Many add-ons allow their source code to be openly viewed. This does not mean that the source code is open source or available for use in another add-on. The original author of an add-on retains "
+"copyright of their work unless otherwise noted in the add-on's license."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/docs/policies-maintenance.html:96
 msgid ""
-"In the event that we're notified of a copyright or license infringement, we "
-"will take steps to review the situation and determine if an actual "
-"infringement has occurred. If we determine that there is an infringement, we"
-" will remove the offending add-on and contact the author. New add-on "
-"submissions (including updates) containing infringing code will be denied "
-"approval for public status."
+"In the event that we're notified of a copyright or license infringement, we will take steps to review the situation and determine if an actual infringement has occurred. If we determine that there "
+"is an infringement, we will remove the offending add-on and contact the author. New add-on submissions (including updates) containing infringing code will be denied approval for public status."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/docs/policies-maintenance.html:102
-msgid ""
-"If you are unsure of the current copyright status of an add-on's source "
-"code, you must contact the original author and receive explicit permission "
-"before using the source code."
+msgid "If you are unsure of the current copyright status of an add-on's source code, you must contact the original author and receive explicit permission before using the source code."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/docs/policies-maintenance.html:107
-#: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:306
+#: src/olympia/devhub/templates/devhub/docs/policies-maintenance.html:107 src/olympia/devhub/templates/devhub/docs/policies-reviews.html:306
 #: src/olympia/devhub/templates/devhub/docs/policies-submission.html:97
 msgid "Last updated: January 13, 2011"
 msgstr "ბოლო განახლება: 13 იანვარი, 2011"
@@ -6326,25 +5305,18 @@ msgstr "ბოლო განახლება: 13 იანვარი, 2011
 #: src/olympia/devhub/templates/devhub/docs/policies-recommended.html:13
 #, python-format
 msgid ""
-"Featured add-ons are top-quality extensions and themes highlighted on <a "
-"href=\"%(link_gallery)s\">AMO</a>, Firefox's Add-ons Manager, and across "
-"other Mozilla websites. These add-ons showcase the power of Firefox "
-"customization and are useful to a wide audience."
+"Featured add-ons are top-quality extensions and themes highlighted on <a href=\"%(link_gallery)s\">AMO</a>, Firefox's Add-ons Manager, and across other Mozilla websites. These add-ons showcase the "
+"power of Firefox customization and are useful to a wide audience."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/docs/policies-recommended.html:19
 msgid ""
-"Featured add-ons are chosen by the Featured Add-ons Advisory Board, a small "
-"group of add-on developers and fans from the Mozilla community who have "
-"volunteered to review and vote on nominations."
+"Featured add-ons are chosen by the Featured Add-ons Advisory Board, a small group of add-on developers and fans from the Mozilla community who have volunteered to review and vote on nominations."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/docs/policies-recommended.html:25
 #, python-format
-msgid ""
-"<a href=\"%(link_featured)s\">Featured extensions</a> are chosen every "
-"month, and <a href=\"%(link_themes)s\">featured complete themes</a> are "
-"chosen every quarter."
+msgid "<a href=\"%(link_featured)s\">Featured extensions</a> are chosen every month, and <a href=\"%(link_themes)s\">featured complete themes</a> are chosen every quarter."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/docs/policies-recommended.html:30
@@ -6352,14 +5324,11 @@ msgid "Criteria for Featured Add-ons"
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/docs/policies-recommended.html:33
-msgid ""
-"Before nominating an add-on to be featured, please ensure it meets the "
-"following criteria:"
+msgid "Before nominating an add-on to be featured, please ensure it meets the following criteria:"
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/docs/policies-recommended.html:39
-msgid ""
-"The add-on must have a complete and informative listing on AMO. This means:"
+msgid "The add-on must have a complete and informative listing on AMO. This means:"
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/docs/policies-recommended.html:41
@@ -6383,14 +5352,11 @@ msgid "updated screenshots of the add-on's functionality"
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/docs/policies-recommended.html:46
-msgid ""
-"must be fully approved by AMO editors (no preliminarily reviewed entries)"
+msgid "must be fully approved by AMO editors (no preliminarily reviewed entries)"
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/docs/policies-recommended.html:48
-msgid ""
-"The add-on must have excellent user reviews and any problems or support "
-"requests must be promptly addressed by the developer."
+msgid "The add-on must have excellent user reviews and any problems or support requests must be promptly addressed by the developer."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/docs/policies-recommended.html:49
@@ -6398,17 +5364,13 @@ msgid "The add-on must have a minimum of 2,000 users."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/docs/policies-recommended.html:50
-msgid ""
-"The add-on must be compatible with the latest release of Firefox and must be"
-" compatible with beta versions 4 weeks before their final release."
+msgid "The add-on must be compatible with the latest release of Firefox and must be compatible with beta versions 4 weeks before their final release."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/docs/policies-recommended.html:51
 msgid ""
-"<strong>Most importantly</strong>, the add-on must have wide consumer appeal"
-" to Firefox's users and be outstanding in nearly every way: user experience,"
-" performance, security, and usefulness or entertainment value. Featured "
-"complete themes must also be visually appealing."
+"<strong>Most importantly</strong>, the add-on must have wide consumer appeal to Firefox's users and be outstanding in nearly every way: user experience, performance, security, and usefulness or "
+"entertainment value. Featured complete themes must also be visually appealing."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/docs/policies-recommended.html:54
@@ -6421,9 +5383,7 @@ msgstr ""
 
 #: src/olympia/devhub/templates/devhub/docs/policies-recommended.html:57
 #, python-format
-msgid ""
-"If you wish to nominate an add-on to be featured and it meets the criteria "
-"above, send an email to %(mail_featured)s with:"
+msgid "If you wish to nominate an add-on to be featured and it meets the criteria above, send an email to %(mail_featured)s with:"
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/docs/policies-recommended.html:62
@@ -6431,22 +5391,17 @@ msgid "the add-on name, URL, and whether you are its developer"
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/docs/policies-recommended.html:63
-msgid ""
-"a short explanation of why the add-on has wide appeal and should be featured"
+msgid "a short explanation of why the add-on has wide appeal and should be featured"
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/docs/policies-recommended.html:64
-msgid ""
-"optionally, links to any external reviews or articles mentioning the add-on"
+msgid "optionally, links to any external reviews or articles mentioning the add-on"
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/docs/policies-recommended.html:68
 msgid ""
-"Add-on nominations are reviewed by the Advisory Board once a month (once "
-"every 3 months for complete theme nominations). Common reasons for rejection"
-" include lacking wide appeal to consumers, a suboptimal user experience, "
-"quality or security issues, incompatibility, and similarity to another "
-"featured add-on. Rejected add-ons cannot be re-nominated within 3 months."
+"Add-on nominations are reviewed by the Advisory Board once a month (once every 3 months for complete theme nominations). Common reasons for rejection include lacking wide appeal to consumers, a "
+"suboptimal user experience, quality or security issues, incompatibility, and similarity to another featured add-on. Rejected add-ons cannot be re-nominated within 3 months."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/docs/policies-recommended.html:73
@@ -6454,32 +5409,23 @@ msgid "Rotating Featured Add-ons"
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/docs/policies-recommended.html:76
-msgid ""
-"Mozilla and the Featured Add-ons Advisory Board regularly evaluate and "
-"rotate out featured add-ons. Some of the most common reasons for add-ons "
-"being removed from the featured list are:"
+msgid "Mozilla and the Featured Add-ons Advisory Board regularly evaluate and rotate out featured add-ons. Some of the most common reasons for add-ons being removed from the featured list are:"
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/docs/policies-recommended.html:83
 msgid ""
-"Lack of growth &mdash; Add-ons that are featured typically experience a "
-"substantial gain in both downloads and active users. If an add-on is not "
-"demonstrating growth in any substantial way, that's a good indicator the "
-"add-on may not be very useful to our users."
+"Lack of growth &mdash; Add-ons that are featured typically experience a substantial gain in both downloads and active users. If an add-on is not demonstrating growth in any substantial way, that's "
+"a good indicator the add-on may not be very useful to our users."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/docs/policies-recommended.html:88
-msgid ""
-"Negative reviews &mdash; Featured add-ons should have a great experience and"
-" very few bugs, so add-ons with many negative reviews may be reconsidered."
+msgid "Negative reviews &mdash; Featured add-ons should have a great experience and very few bugs, so add-ons with many negative reviews may be reconsidered."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/docs/policies-recommended.html:93
 msgid ""
-"Incompatibility with upcoming Firefox versions &mdash; Featured add-ons are "
-"expected to be compatible with stable and beta versions of Firefox. Add-ons "
-"not yet compatible with a Beta version of Firefox four weeks before its "
-"expected release will lose their featured status."
+"Incompatibility with upcoming Firefox versions &mdash; Featured add-ons are expected to be compatible with stable and beta versions of Firefox. Add-ons not yet compatible with a Beta version of "
+"Firefox four weeks before its expected release will lose their featured status."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/docs/policies-recommended.html:99
@@ -6487,121 +5433,87 @@ msgid "Joining the Featured Add-ons Advisory Board"
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/docs/policies-recommended.html:102
-msgid ""
-"Every six months a new Advisory Board is chosen based on applications from "
-"the add-ons community. Members must:"
+msgid "Every six months a new Advisory Board is chosen based on applications from the add-ons community. Members must:"
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/docs/policies-recommended.html:108
-msgid ""
-"be active members of the add-ons community, whether as a developer, "
-"evangelist, or fan"
+msgid "be active members of the add-ons community, whether as a developer, evangelist, or fan"
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/docs/policies-recommended.html:109
-msgid ""
-"commit to trying all the nominations submitted, giving their feedback, and "
-"casting their votes every month"
+msgid "commit to trying all the nominations submitted, giving their feedback, and casting their votes every month"
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/docs/policies-recommended.html:110
-msgid ""
-"abstain from voting on add-ons that they have any business or personal "
-"affiliations with, as well as direct competitors of any such add-ons"
+msgid "abstain from voting on add-ons that they have any business or personal affiliations with, as well as direct competitors of any such add-ons"
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/docs/policies-recommended.html:114
 msgid ""
-"Members of the Mozilla Add-ons team may veto any add-on's selection because "
-"of security, privacy, compatibility, or any other reason, but in general it "
-"is up to the Board to select add-ons to feature."
+"Members of the Mozilla Add-ons team may veto any add-on's selection because of security, privacy, compatibility, or any other reason, but in general it is up to the Board to select add-ons to "
+"feature."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/docs/policies-recommended.html:120
 msgid ""
-"This featured policy only applies to the addons.mozilla.org global list of "
-"featured add-ons. Add-ons featured in other locations are often pulled from "
-"this list, but Mozilla may feature any add-on in other locations without the"
-" Board's consent. Additionally, locale-specific features override the global"
-" defaults, so if a locale has opted to select its own features, some or all "
-"of the global features may not appear in that locale."
+"This featured policy only applies to the addons.mozilla.org global list of featured add-ons. Add-ons featured in other locations are often pulled from this list, but Mozilla may feature any add-on "
+"in other locations without the Board's consent. Additionally, locale-specific features override the global defaults, so if a locale has opted to select its own features, some or all of the global "
+"features may not appear in that locale."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/docs/policies-recommended.html:126
 #, python-format
-msgid ""
-"Follow the <a href=\"%(link_blog)s\">Add-ons Blog</a> or <a "
-"href=\"%(link_twitter)s\">@mozamo</a> on Twitter to learn when the next "
-"application period opens."
+msgid "Follow the <a href=\"%(link_blog)s\">Add-ons Blog</a> or <a href=\"%(link_twitter)s\">@mozamo</a> on Twitter to learn when the next application period opens."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/docs/policies-recommended.html:131
 msgid "Last updated: January 31, 2013"
 msgstr "ბოლო განახლება: 31 იანვარი, 2013"
 
-#: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:3
-#: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:7
-#: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:8
-#: src/olympia/devhub/templates/devhub/docs/policies.html:15
-#: src/olympia/devhub/templates/devhub/docs/policies.html:64
+#: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:3 src/olympia/devhub/templates/devhub/docs/policies-reviews.html:7 src/olympia/devhub/templates/devhub/docs/policies-reviews.html:8
+#: src/olympia/devhub/templates/devhub/docs/policies.html:15 src/olympia/devhub/templates/devhub/docs/policies.html:64
 msgid "Review Process"
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:12
 msgid ""
-"In order to ensure all add-ons hosted in our gallery are safe for users to "
-"install, Mozilla will begin requiring all hosted add-ons to undergo review. "
-"We offer two types of review and developers are free to choose the best fit "
-"for their add-on."
+"In order to ensure all add-ons hosted in our gallery are safe for users to install, Mozilla will begin requiring all hosted add-ons to undergo review. We offer two types of review and developers "
+"are free to choose the best fit for their add-on."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:19
 msgid ""
-"<strong><a href=\"#full\">Full Review</a></strong> &mdash; a thorough "
-"functional and code review of the add-on, appropriate for add-ons ready for "
-"distribution to the masses. All site features are available to these add-"
-"ons."
+"<strong><a href=\"#full\">Full Review</a></strong> &mdash; a thorough functional and code review of the add-on, appropriate for add-ons ready for distribution to the masses. All site features are "
+"available to these add-ons."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:24
 msgid ""
-"<strong><a href=\"#preliminary\">Preliminary Review</a></strong> &mdash; a "
-"faster review intended for experimental add-ons. Preliminary reviews do not "
-"check for functionality or full policy compliance, but the reviewed add-ons "
-"have install button cautions and some feature limitations."
+"<strong><a href=\"#preliminary\">Preliminary Review</a></strong> &mdash; a faster review intended for experimental add-ons. Preliminary reviews do not check for functionality or full policy "
+"compliance, but the reviewed add-ons have install button cautions and some feature limitations."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:31
 msgid ""
-"Detailed descriptions of each option are below. After selecting a review "
-"process at submission, the add-on will be placed in the queue. Add-ons are "
-"reviewed by the <a href=\"https://wiki.mozilla.org/AMO:Editors\">AMO "
-"Editors</a>, a group of talented developers that volunteer to help the "
-"Mozilla project by reviewing add-ons to ensure a stable and safe experience "
-"for users. Developers will receive an email with any updates throughout the "
-"review process."
+"Detailed descriptions of each option are below. After selecting a review process at submission, the add-on will be placed in the queue. Add-ons are reviewed by the <a href=\"https://wiki.mozilla."
+"org/AMO:Editors\">AMO Editors</a>, a group of talented developers that volunteer to help the Mozilla project by reviewing add-ons to ensure a stable and safe experience for users. Developers will "
+"receive an email with any updates throughout the review process."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:37
 msgid ""
-"While waiting for review, add-ons will not appear anywhere in the gallery "
-"publicly, but direct links to the add-on's details page will work. This "
-"allows the author to blog or share the link with friends, inviting them to "
-"try it out, even when not yet reviewed."
+"While waiting for review, add-ons will not appear anywhere in the gallery publicly, but direct links to the add-on's details page will work. This allows the author to blog or share the link with "
+"friends, inviting them to try it out, even when not yet reviewed."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:44
 msgid ""
-"Full reviews are appropriate for add-ons that are well-tested, stable, fast,"
-" and have wide appeal to our users. If you aren't confident that your add-on"
-" meets that criteria, please consider working out the kinks while in "
-"preliminary review and accumulating user feedback first."
+"Full reviews are appropriate for add-ons that are well-tested, stable, fast, and have wide appeal to our users. If you aren't confident that your add-on meets that criteria, please consider working "
+"out the kinks while in preliminary review and accumulating user feedback first."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:50
-msgid ""
-"We aim to perform full reviews in under 10 days, though most add-ons are "
-"reviewed in much less time."
+msgid "We aim to perform full reviews in under 10 days, though most add-ons are reviewed in much less time."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:55
@@ -6613,15 +5525,11 @@ msgid "When performing a full review, editors will:"
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:64
-msgid ""
-"install the add-on, making sure it functions as described and is free of "
-"major defects"
+msgid "install the add-on, making sure it functions as described and is free of major defects"
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:69
-msgid ""
-"perform a source code review, looking for performance and security best "
-"practices"
+msgid "perform a source code review, looking for performance and security best practices"
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:74
@@ -6629,28 +5537,21 @@ msgid "ensure the add-on's privacy policy is in line with its functionality"
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:79
-msgid ""
-"look for compliance with all of Mozilla's policies, detailed in these "
-"documents"
+msgid "look for compliance with all of Mozilla's policies, detailed in these documents"
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:86
-msgid ""
-"Some of the most common issues we see when performing these reviews are:"
+msgid "Some of the most common issues we see when performing these reviews are:"
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:93
 msgid ""
-"<strong>JavaScript namespace pollution</strong> &mdash; the most common "
-"violation. Be sure to <a "
-"href=\"https://developer.mozilla.org/en/XUL_School/JavaScript_Object_Management\">wrap"
-" your loose variables</a>"
+"<strong>JavaScript namespace pollution</strong> &mdash; the most common violation. Be sure to <a href=\"https://developer.mozilla.org/en/XUL_School/JavaScript_Object_Management\">wrap your loose "
+"variables</a>"
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:99
-msgid ""
-"proper preference naming - all preference names should begin with "
-"\"extensions.\", followed by the add-on name or some other unique identifier"
+msgid "proper preference naming - all preference names should begin with \"extensions.\", followed by the add-on name or some other unique identifier"
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:103
@@ -6696,67 +5597,49 @@ msgstr ""
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:117
 #, python-format
 msgid ""
-"For information on how to avoid these problems, please see our <a "
-"href=\"%(link_howto)s\">How-to Library</a>. Some of these practices, such as"
-" binary or obfuscated code, are allowed under certain conditions outlined "
-"below."
+"For information on how to avoid these problems, please see our <a href=\"%(link_howto)s\">How-to Library</a>. Some of these practices, such as binary or obfuscated code, are allowed under certain "
+"conditions outlined below."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:123
 #, python-format
 msgid ""
-"Many of the above restrictions are tested automatically by an extension "
-"scanner that will flag suspicious add-ons for editor review. You can read "
-"more about this scanner in the <a href=\"%(link_validation)s\">Validation "
-"Help</a> document."
+"Many of the above restrictions are tested automatically by an extension scanner that will flag suspicious add-ons for editor review. You can read more about this scanner in the <a href="
+"\"%(link_validation)s\">Validation Help</a> document."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:129
 msgid ""
-"If the add-on is site-specific, it is recommended that a test account is "
-"provided for use during the review process. Additionally, including detailed"
-" testing instructions will allow an editor to better understand how the add-"
-"on functions and expedite the testing process. This information can be "
-"placed in the Notes to Reviewer field when editing a version in the "
-"Developer Hub."
+"If the add-on is site-specific, it is recommended that a test account is provided for use during the review process. Additionally, including detailed testing instructions will allow an editor to "
+"better understand how the add-on functions and expedite the testing process. This information can be placed in the Notes to Reviewer field when editing a version in the Developer Hub."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:134
-#: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:168
+#: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:134 src/olympia/devhub/templates/devhub/docs/policies-reviews.html:168
 msgid "After the Review"
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:136
 msgid ""
-"Once an add-on is granted full review, it will immediately be available in "
-"the gallery, showing in browse and search results with a warning-free "
-"install button. All features, including voluntary contributions and beta "
-"channels will be available."
+"Once an add-on is granted full review, it will immediately be available in the gallery, showing in browse and search results with a warning-free install button. All features, including voluntary "
+"contributions and beta channels will be available."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:142
 msgid ""
-"Subsequent versions of the add-on will automatically be placed in the full "
-"review queue. Until the review is completed, the new version will only be "
-"displayed on the Version History page of the add-on. Once reviewed, the "
-"version will be updated across the site and deployed through the automatic "
-"update service."
+"Subsequent versions of the add-on will automatically be placed in the full review queue. Until the review is completed, the new version will only be displayed on the Version History page of the add-"
+"on. Once reviewed, the version will be updated across the site and deployed through the automatic update service."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:148
 msgid ""
-"If a version does not meet the criteria for full review, it can either be "
-"granted preliminary review or disabled if there is a security concern. The "
-"author will receive an email explaining the action taken and how to fix it. "
-"In most cases, the developer can simply fix the problem and re-submit for "
-"full review."
+"If a version does not meet the criteria for full review, it can either be granted preliminary review or disabled if there is a security concern. The author will receive an email explaining the "
+"action taken and how to fix it. In most cases, the developer can simply fix the problem and re-submit for full review."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:155
 msgid ""
-"Preliminary reviews are appropriate for experimental add-ons and provide a "
-"way to get user testing and feedback without going through the longer, more "
-"thorough review process. We aim to complete these reviews in under 3 days."
+"Preliminary reviews are appropriate for experimental add-ons and provide a way to get user testing and feedback without going through the longer, more thorough review process. We aim to complete "
+"these reviews in under 3 days."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:160
@@ -6765,36 +5648,25 @@ msgstr ""
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:162
 msgid ""
-"When performing a preliminary review, editors will review the source code "
-"for security issues and major policy violations, but will not install the "
-"add-on to test functionality in most cases. Preliminary review will be "
-"granted unless a security vulnerability or major policy violation is "
-"discovered."
+"When performing a preliminary review, editors will review the source code for security issues and major policy violations, but will not install the add-on to test functionality in most cases. "
+"Preliminary review will be granted unless a security vulnerability or major policy violation is discovered."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:171
 msgid ""
-"Once preliminary review is granted, the add-on will be immediately available"
-" in the gallery, showing in browse and search results but ranked lower than "
-"fully-reviewed add-ons. Install buttons will have caution stripes and a "
-"notice that the add-on is experimental and not fully reviewed by Mozilla, "
-"though no click-through is required. Additionally, these add-ons cannot use "
-"the voluntary contributions and beta channel features."
+"Once preliminary review is granted, the add-on will be immediately available in the gallery, showing in browse and search results but ranked lower than fully-reviewed add-ons. Install buttons will "
+"have caution stripes and a notice that the add-on is experimental and not fully reviewed by Mozilla, though no click-through is required. Additionally, these add-ons cannot use the voluntary "
+"contributions and beta channel features."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:177
-msgid ""
-"After being granted preliminary review, Mozilla may later revoke the review "
-"if other serious problems are reported to us by users."
+msgid "After being granted preliminary review, Mozilla may later revoke the review if other serious problems are reported to us by users."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:183
 msgid ""
-"Subsequent versions of the add-on will automatically be placed in the "
-"preliminary review queue. Until the review is completed, the new version "
-"will only be displayed on the Version History page of the add-on. Once "
-"reviewed, the version will be updated across the site and deployed through "
-"the automatic update service."
+"Subsequent versions of the add-on will automatically be placed in the preliminary review queue. Until the review is completed, the new version will only be displayed on the Version History page of "
+"the add-on. Once reviewed, the version will be updated across the site and deployed through the automatic update service."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:188
@@ -6810,41 +5682,29 @@ msgid "The following add-ons are not permitted in any form:"
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:194
-msgid ""
-"Add-ons that embed known <a "
-"href=\"http://en.wikipedia.org/wiki/Spyware\">spyware</a> or <a "
-"href=\"http://en.wikipedia.org/wiki/Malware\">malware</a>"
+msgid "Add-ons that embed known <a href=\"http://en.wikipedia.org/wiki/Spyware\">spyware</a> or <a href=\"http://en.wikipedia.org/wiki/Malware\">malware</a>"
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:199
 msgid ""
-"Illegal and criminal add-ons, such as <a "
-"href=\"http://en.wikipedia.org/wiki/Click_fraud\">click fraud</a> "
-"generators, <a href=\"http://en.wikipedia.org/wiki/Warez\">warez</a> "
-"download and directory assistants, child pornography finders, etc."
+"Illegal and criminal add-ons, such as <a href=\"http://en.wikipedia.org/wiki/Click_fraud\">click fraud</a> generators, <a href=\"http://en.wikipedia.org/wiki/Warez\">warez</a> download and "
+"directory assistants, child pornography finders, etc."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:204
-msgid ""
-"Add-ons whose main purpose is to facilitate access to pornographic material,"
-" or include references to this material in their descriptions"
+msgid "Add-ons whose main purpose is to facilitate access to pornographic material, or include references to this material in their descriptions"
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:210
-msgid ""
-"Add-ons that, upon installation, auto-install or launch installers of non-"
-"Firefox software"
+msgid "Add-ons that, upon installation, auto-install or launch installers of non-Firefox software"
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:215
-msgid ""
-"Add-ons that provide their own update mechanism for code or search engines"
+msgid "Add-ons that provide their own update mechanism for code or search engines"
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:220
-msgid ""
-"Add-ons that make changes to web content in ways that are non-obvious or "
-"difficult to trace by their users"
+msgid "Add-ons that make changes to web content in ways that are non-obvious or difficult to trace by their users"
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:225
@@ -6861,41 +5721,25 @@ msgstr ""
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:238
 msgid ""
-"Surprises can be appropriate in many situations, but they are not welcome "
-"when user security, privacy, and control are at stake. It is extremely "
-"important to be as transparent as possible when submitting an add-on for "
-"hosting on this site. A Mozilla user should be able to easily discern what "
-"the functionality of an add-on is and not be presented with unexpected "
-"experiences post-install."
+"Surprises can be appropriate in many situations, but they are not welcome when user security, privacy, and control are at stake. It is extremely important to be as transparent as possible when "
+"submitting an add-on for hosting on this site. A Mozilla user should be able to easily discern what the functionality of an add-on is and not be presented with unexpected experiences post-install."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:243
 msgid ""
-"<p> Whenever an add-on includes any unexpected* feature that </p> <ul> "
-"<li>compromises user privacy or security (like sending data to third "
-"parties),</li> <li>changes default settings like the homepage or search "
-"engine, or</li> <li>changes settings or features in other add-ons or "
-"deactivates them altogether</li> </ul> <p>the features must adhere to the "
-"following requirements:</p> <ul> <li>The add-on description must clearly "
-"state what changes the add-on makes.</li> <li>All changes must be opt-in, "
-"meaning the user must take non-default action to enact the change.</li> "
-"<li>The opt-in dialog must clearly state the name of the add-on requesting "
-"the change.</li> <li>Uninstalling the add-on restores the user's original "
-"settings if they were changed.</li> </ul> <p>*Unexpected features are those "
-"that are unrelated to the add-on's primary function.</p>"
+"<p> Whenever an add-on includes any unexpected* feature that </p> <ul> <li>compromises user privacy or security (like sending data to third parties),</li> <li>changes default settings like the "
+"homepage or search engine, or</li> <li>changes settings or features in other add-ons or deactivates them altogether</li> </ul> <p>the features must adhere to the following requirements:</p> <ul> "
+"<li>The add-on description must clearly state what changes the add-on makes.</li> <li>All changes must be opt-in, meaning the user must take non-default action to enact the change.</li> <li>The opt-"
+"in dialog must clearly state the name of the add-on requesting the change.</li> <li>Uninstalling the add-on restores the user's original settings if they were changed.</li> </ul> <p>*Unexpected "
+"features are those that are unrelated to the add-on's primary function.</p>"
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:268
-msgid ""
-"These features cannot be introduced into an update of a fully-reviewed add-"
-"on; the opt-in change process must be part of the initial review."
+msgid "These features cannot be introduced into an update of a fully-reviewed add-on; the opt-in change process must be part of the initial review."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:274
-msgid ""
-"These are minimum requirements and not a guarantee that the add-on will be "
-"approved. This section applies to all add-ons hosted on the site, including "
-"preliminarily reviewed add-ons."
+msgid "These are minimum requirements and not a guarantee that the add-on will be approved. This section applies to all add-ons hosted on the site, including preliminarily reviewed add-ons."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:279
@@ -6904,11 +5748,8 @@ msgstr ""
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:282
 msgid ""
-"Add-ons that store or otherwise handle browsing data must support <a "
-"href=\"https://developer.mozilla.org/En/Supporting_private_browsing_mode\">Private"
-" Browsing Mode</a>.  During a Private Browsing session, no browsing data can"
-" be written to disk, and all of this data must be cleared when Firefox quits"
-" or the Private Browsing session ends."
+"Add-ons that store or otherwise handle browsing data must support <a href=\"https://developer.mozilla.org/En/Supporting_private_browsing_mode\">Private Browsing Mode</a>. During a Private Browsing "
+"session, no browsing data can be written to disk, and all of this data must be cleared when Firefox quits or the Private Browsing session ends."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:287
@@ -6917,27 +5758,19 @@ msgstr ""
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:289
 msgid ""
-"Add-ons may contain binary, obfuscated and minified source code, but Mozilla"
-" must be allowed to review a copy of the human-readable source code of each "
-"version of an add-on submitted for review. These add-ons are ineligible for "
-"preliminary review and must choose the full review process."
+"Add-ons may contain binary, obfuscated and minified source code, but Mozilla must be allowed to review a copy of the human-readable source code of each version of an add-on submitted for review. "
+"These add-ons are ineligible for preliminary review and must choose the full review process."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:295
 msgid ""
-"If an add-on contains binary or obfuscated source code, the author will "
-"receive a message when the add-on is reviewed indicating whom to contact at "
-"Mozilla to coordinate review of the source code. This code will be reviewed "
-"by an administrator and will not be shared or redistributed in any way. The "
-"code will only be used for the purpose of reviewing the add-on."
+"If an add-on contains binary or obfuscated source code, the author will receive a message when the add-on is reviewed indicating whom to contact at Mozilla to coordinate review of the source code. "
+"This code will be reviewed by an administrator and will not be shared or redistributed in any way. The code will only be used for the purpose of reviewing the add-on."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:301
 #, python-format
-msgid ""
-"If your add-on contains binary or obfuscated code that you don't own or "
-"can't get the source code for, you may <a href=\"%(link_contact)s\">contact "
-"us</a> for information on how to proceed."
+msgid "If your add-on contains binary or obfuscated code that you don't own or can't get the source code for, you may <a href=\"%(link_contact)s\">contact us</a> for information on how to proceed."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/docs/policies-submission.html:11
@@ -6946,138 +5779,86 @@ msgstr ""
 
 #: src/olympia/devhub/templates/devhub/docs/policies-submission.html:13
 msgid ""
-"Add-ons hosted on Mozilla Add-ons should be of high quality and give users "
-"an improved web experience. We look for the following things when deciding "
-"whether an add-on is appropriate to be public and unrestricted:"
+"Add-ons hosted on Mozilla Add-ons should be of high quality and give users an improved web experience. We look for the following things when deciding whether an add-on is appropriate to be public "
+"and unrestricted:"
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/docs/policies-submission.html:19
 msgid ""
-"<strong>Are you responsive?</strong> We expect that an author who is "
-"promoting their add-on to our applications' many users is responsive to "
-"problem reports, maintains their contact information, and updates their add-"
-"on promptly to keep current with Firefox releases and changes in our "
-"policies. This doesn't mean that you have to reply to every question that "
-"someone posts in the discussions, or that you even need to fix every bug, "
-"but we do expect that you will respond to issues in a manner that's "
-"appropriate to the severity of the issue in question."
+"<strong>Are you responsive?</strong> We expect that an author who is promoting their add-on to our applications' many users is responsive to problem reports, maintains their contact information, "
+"and updates their add-on promptly to keep current with Firefox releases and changes in our policies. This doesn't mean that you have to reply to every question that someone posts in the "
+"discussions, or that you even need to fix every bug, but we do expect that you will respond to issues in a manner that's appropriate to the severity of the issue in question."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/docs/policies-submission.html:25
 msgid ""
-"<strong>Is the add-on clearly and accurately described?</strong> It's of the"
-" utmost importance to us that users get what they expect when they try a new"
-" add-on. Your add-on name should be clear and concise, and you should "
-"refrain from using special characters or numbers to get higher search "
-"rankings or for decorative purposes. Your description should provide details"
-" about what the add-on does, how a user should take advantage of it, and "
-"what the user should expect when they install it. Links to external "
-"documents for detailed instructions are fine, but the description itself "
-"should cover the basics and leave users confident that they know what "
-"they'll get. Also, it is important that you maintain version notes "
-"appropriately as you improve and change your add-on. Users should be able to"
-" see what's new in an add-on they may have tried previously, and should be "
-"made aware of changes that might affect their current use of the add-on when"
-" they update."
+"<strong>Is the add-on clearly and accurately described?</strong> It's of the utmost importance to us that users get what they expect when they try a new add-on. Your add-on name should be clear and "
+"concise, and you should refrain from using special characters or numbers to get higher search rankings or for decorative purposes. Your description should provide details about what the add-on "
+"does, how a user should take advantage of it, and what the user should expect when they install it. Links to external documents for detailed instructions are fine, but the description itself should "
+"cover the basics and leave users confident that they know what they'll get. Also, it is important that you maintain version notes appropriately as you improve and change your add-on. Users should "
+"be able to see what's new in an add-on they may have tried previously, and should be made aware of changes that might affect their current use of the add-on when they update."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/docs/policies-submission.html:31
 msgid ""
-"<strong>Are all privacy and security concerns clearly spelled out?</strong> "
-"This is an aspect of a clear and accurate description, but such an important"
-" one that we feel it deserves specific mention. Many very useful and well-"
-"written add-ons manipulate some form of user data, or can present security "
-"hazards if misused; they are welcome on the site, but they must make it very"
-" clear to users what risks they might encounter, and what they can do to "
-"protect themselves."
+"<strong>Are all privacy and security concerns clearly spelled out?</strong> This is an aspect of a clear and accurate description, but such an important one that we feel it deserves specific "
+"mention. Many very useful and well-written add-ons manipulate some form of user data, or can present security hazards if misused; they are welcome on the site, but they must make it very clear to "
+"users what risks they might encounter, and what they can do to protect themselves."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/docs/policies-submission.html:37
 msgid ""
-"<strong>Has the add-on been well-tested, and is it free of obvious or "
-"serious defects?</strong> One important thing that we look for when "
-"considering an add-on is whether its user reviews indicate that it has "
-"received thorough testing, and that it doesn't have serious problems or "
-"negative impacts on the browser. If reviewers report problems such as major "
-"performance issues, crashes, frequent problems using the functions of the "
-"add-on, or spamming of messages to the error console, you should take those "
-"reports to heart, and re-submit your add-on after you've addressed them as "
-"best you can. We don't expect you to perfectly optimize or have zero bugs "
-"&mdash; Firefox itself undergoes constant improvement in these areas &mdash;"
-" but we do want you to take reasonable efforts to minimize downsides, and to"
-" clearly call out cases where users may be surprised by those that remain."
+"<strong>Has the add-on been well-tested, and is it free of obvious or serious defects?</strong> One important thing that we look for when considering an add-on is whether its user reviews indicate "
+"that it has received thorough testing, and that it doesn't have serious problems or negative impacts on the browser. If reviewers report problems such as major performance issues, crashes, frequent "
+"problems using the functions of the add-on, or spamming of messages to the error console, you should take those reports to heart, and re-submit your add-on after you've addressed them as best you "
+"can. We don't expect you to perfectly optimize or have zero bugs &mdash; Firefox itself undergoes constant improvement in these areas &mdash; but we do want you to take reasonable efforts to "
+"minimize downsides, and to clearly call out cases where users may be surprised by those that remain."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/docs/policies-submission.html:43
 msgid ""
-"<strong>Do the add-on and add-on author both treat the user "
-"respectfully?</strong> Your software should not intrude on the user "
-"unnecessarily, try to trick the user, or conceal any of its activities from "
-"the user. Users (or even non-users) are sometimes rude in their comments, "
-"and while we will do our best to filter out inaccurate reviews as they're "
-"reported to us, we do expect that authors will avoid retaliating with "
-"rudeness of their own."
+"<strong>Do the add-on and add-on author both treat the user respectfully?</strong> Your software should not intrude on the user unnecessarily, try to trick the user, or conceal any of its "
+"activities from the user. Users (or even non-users) are sometimes rude in their comments, and while we will do our best to filter out inaccurate reviews as they're reported to us, we do expect that "
+"authors will avoid retaliating with rudeness of their own."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/docs/policies-submission.html:49
 msgid ""
-"<strong>Is the add-on useful to an appropriately wide portion of Firefox's "
-"users?</strong> Your add-on doesn't need to be the next Greasemonkey or "
-"Firebug, but if it is only useful to people at your company or who are part "
-"of a small web community, we may feel that it's not yet appropriate to put "
-"it in front of all of our users."
+"<strong>Is the add-on useful to an appropriately wide portion of Firefox's users?</strong> Your add-on doesn't need to be the next Greasemonkey or Firebug, but if it is only useful to people at "
+"your company or who are part of a small web community, we may feel that it's not yet appropriate to put it in front of all of our users."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/docs/policies-submission.html:55
 msgid ""
-"We are constantly looking at ways to improve the organization of the site to"
-" better accommodate add-ons that are exemplary in other ways, but are aimed "
-"at only a small community of potential users. Correctly categorizing and "
-"maintaining the metadata of your add-on will help us figure out how we can "
-"surface more of those sorts of add-ons to people who are most likely to "
-"benefit from them."
+"We are constantly looking at ways to improve the organization of the site to better accommodate add-ons that are exemplary in other ways, but are aimed at only a small community of potential users. "
+"Correctly categorizing and maintaining the metadata of your add-on will help us figure out how we can surface more of those sorts of add-ons to people who are most likely to benefit from them."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/docs/policies-submission.html:61
 msgid ""
-"If your add-on just provides bookmarks or other simple access points to your"
-" site, it's probably not appropriate for the gallery. Like the rest of the "
-"Mozilla project, we love web applications and new web services, but Firefox "
-"add-ons should provide an improved browsing experience for the user and not "
-"just be a way to promote a new site or service through a Mozilla Add-ons "
-"listing."
+"If your add-on just provides bookmarks or other simple access points to your site, it's probably not appropriate for the gallery. Like the rest of the Mozilla project, we love web applications and "
+"new web services, but Firefox add-ons should provide an improved browsing experience for the user and not just be a way to promote a new site or service through a Mozilla Add-ons listing."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/docs/policies-submission.html:67
 msgid ""
-"<strong>Is the add-on free of unlicensed trademarks and copyrights?</strong>"
-" Though you may mean no harm to the holder of a trademark, or the owner of a"
-" copyrighted work, we can't host add-ons that infringe on trademarks or "
-"copyrights. If you don't have permission to use a trademarked name or image,"
-" please do not submit your add-on to us. If your add-on includes code that "
-"is copyrighted by someone else, and is not licensed to you to use in your "
-"add-on, please do not submit your add-on to us."
+"<strong>Is the add-on free of unlicensed trademarks and copyrights?</strong> Though you may mean no harm to the holder of a trademark, or the owner of a copyrighted work, we can't host add-ons that "
+"infringe on trademarks or copyrights. If you don't have permission to use a trademarked name or image, please do not submit your add-on to us. If your add-on includes code that is copyrighted by "
+"someone else, and is not licensed to you to use in your add-on, please do not submit your add-on to us."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/docs/policies-submission.html:73
 msgid ""
-"In terms of reuse of source code from other add-ons, if the author has not "
-"clearly stated that you are permitted to use his or her code in your own "
-"work &mdash; such as by placing it under an open source license &mdash; then"
-" you should assume that you do not have the right to do so. You can contact "
-"the author to seek such permission, but we can't provide you with any "
-"special rights to it just because it's listed on the site, or because the "
-"author isn't responding to your request."
+"In terms of reuse of source code from other add-ons, if the author has not clearly stated that you are permitted to use his or her code in your own work &mdash; such as by placing it under an open "
+"source license &mdash; then you should assume that you do not have the right to do so. You can contact the author to seek such permission, but we can't provide you with any special rights to it "
+"just because it's listed on the site, or because the author isn't responding to your request."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/docs/policies-submission.html:79
 msgid ""
-"This applies to the Mozilla Foundation's trademarks as well, including "
-"\"Mozilla\", \"Firefox\", and \"Thunderbird\". The Mozilla policy on "
-"trademark use is designed to protect against confusion, and prevent the "
-"trademarks from being overturned due to lack of protection; please respect "
-"the need for such protection, and help us preserve some of the most valuable"
-" assets of the Mozilla Foundation."
+"This applies to the Mozilla Foundation's trademarks as well, including \"Mozilla\", \"Firefox\", and \"Thunderbird\". The Mozilla policy on trademark use is designed to protect against confusion, "
+"and prevent the trademarks from being overturned due to lack of protection; please respect the need for such protection, and help us preserve some of the most valuable assets of the Mozilla "
+"Foundation."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/docs/policies-submission.html:84
@@ -7086,197 +5867,141 @@ msgstr ""
 
 #: src/olympia/devhub/templates/devhub/docs/policies-submission.html:86
 msgid ""
-"Selecting an appropriate license for your add-on is a very important step in"
-" the submission process. A license specifies the rights you grant on your "
-"source code and is important in protecting your intellectual property."
+"Selecting an appropriate license for your add-on is a very important step in the submission process. A license specifies the rights you grant on your source code and is important in protecting your "
+"intellectual property."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/docs/policies-submission.html:92
 msgid ""
-"During the add-on submission process, you will be presented with a list of "
-"popular licenses to choose from, as well as the ability to specify your own "
-"license. It is best to consult with a legal professional about which license"
-" option is best for you. Choosing the right license for your source code "
-"will help to prevent confusion and code conflicts in the future."
+"During the add-on submission process, you will be presented with a list of popular licenses to choose from, as well as the ability to specify your own license. It is best to consult with a legal "
+"professional about which license option is best for you. Choosing the right license for your source code will help to prevent confusion and code conflicts in the future."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/docs/policies.html:12
-#: src/olympia/devhub/templates/devhub/docs/policies.html:52
+#: src/olympia/devhub/templates/devhub/docs/policies.html:12 src/olympia/devhub/templates/devhub/docs/policies.html:52
 msgid "Add-on Submission"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/docs/policies.html:18
-#: src/olympia/devhub/templates/devhub/docs/policies.html:78
+#: src/olympia/devhub/templates/devhub/docs/policies.html:18 src/olympia/devhub/templates/devhub/docs/policies.html:78
 msgid "Maintaining Your Add-on"
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/docs/policies.html:43
-msgid ""
-"Mozilla is committed to ensuring a great add-ons experience for our users "
-"and developers. Please review the policies below before submitting your add-"
-"on."
+msgid "Mozilla is committed to ensuring a great add-ons experience for our users and developers. Please review the policies below before submitting your add-on."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/docs/policies.html:55
-msgid ""
-"Find out what is expected of add-ons we host and our policies on specific "
-"add-on practices."
+msgid "Find out what is expected of add-ons we host and our policies on specific add-on practices."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/docs/policies.html:67
-msgid ""
-"What happens after your add-on is submitted? Learn about how our Editors "
-"review submissions."
+msgid "What happens after your add-on is submitted? Learn about how our Editors review submissions."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/docs/policies.html:81
-msgid ""
-"Add-on updates, transferring ownership, user reviews, and what to expect "
-"once your add-on is approved."
+msgid "Add-on updates, transferring ownership, user reviews, and what to expect once your add-on is approved."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/docs/policies.html:93
-msgid ""
-"How up-and-coming add-ons become featured and what&#039;s involved in the "
-"process."
+msgid "How up-and-coming add-ons become featured and what&#039;s involved in the process."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/docs/policies.html:106
-msgid ""
-"Terms of Service for submitting your work to our site. Developers are "
-"required to accept this agreement before submission."
+msgid "Terms of Service for submitting your work to our site. Developers are required to accept this agreement before submission."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/docs/policies.html:118
 msgid "How to get in touch with us regarding these policies or your add-on."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:6
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:10
 msgid "You have disabled this add-on"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:20
-msgid ""
-"Your add-on's listing is disabled and is not showing\n"
-"                             anywhere in our gallery or update service."
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:24
+msgid "Your add-on's listing is disabled and is not showing anywhere in our gallery or update service."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:25
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:27
 msgid "Please complete your add-on."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:29
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:30
 msgid "You will receive an email when the review is complete."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:34
-msgid ""
-"You will receive an email when the review is complete. Until\n"
-"                             then, your add-on is not listed in our gallery but can be\n"
-"                             accessed directly from its details page."
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:33
+msgid "You will receive an email when the review is complete. Until then, your add-on is not listed in our gallery but can be accessed directly from its details page."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:38
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:48
-msgid ""
-"You will receive an email when the review is\n"
-"                             complete and your add-on is signed."
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:37 src/olympia/devhub/templates/devhub/includes/addon_details.html:45
+msgid "You will receive an email when the review is complete and your add-on is signed."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:44
-msgid ""
-"You will receive an email when the review is complete. Until\n"
-"                             then, your add-on is not listed in our gallery but can be\n"
-"                             accessed directly from its details page. "
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:41
+msgid "You will receive an email when the review is complete. Until then, your add-on is not listed in our gallery but can be accessed directly from its details page. "
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:54
-msgid ""
-"Your add-on is displayed in our gallery and users are\n"
-"                             receiving automatic updates."
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:49
+msgid "Your add-on is displayed in our gallery and users are receiving automatic updates."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:57
-msgid ""
-"Your add-on has been signed and can be bundled with an\n"
-"                             application installer."
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:52
+msgid "Your add-on has been signed and can be bundled with an application installer."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:63
-msgid ""
-"Your add-on was disabled by a site administrator and is no\n"
-"                             longer shown in our gallery. If you have any questions,\n"
-"                             please email amo-admins@mozilla.org."
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:56
+msgid "Your add-on was disabled by a site administrator and is no longer shown in our gallery. If you have any questions, please email amo-admins@mozilla.org."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:70
-msgid ""
-"Your add-on is displayed in our gallery as experimental\n"
-"                             and users are receiving automatic updates. Some features\n"
-"                             are unavailable to your add-on."
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:62
+msgid "Your add-on is displayed in our gallery as experimental and users are receiving automatic updates. Some features are unavailable to your add-on."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:74
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:66
 msgid "Your add-on has been signed."
 msgstr ""
 
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:69
+msgid ""
+"You will receive an email when the full review is complete. Until then, your add-on is displayed in our gallery as experimental and users are receiving automatic updates. Some features are "
+"unavailable to your add-on."
+msgstr ""
+
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:74
+msgid "You will receive an email when the full review is complete, making you able to bundle your add-on with an application installer."
+msgstr ""
+
 #: src/olympia/devhub/templates/devhub/includes/addon_details.html:79
-msgid ""
-"You will receive an email when the full review is complete.\n"
-"                             Until then, your add-on is displayed in our gallery as\n"
-"                             experimental and users are receiving automatic updates.\n"
-"                             Some features are unavailable to your add-on."
+msgid "All add-ons hosted in our gallery must now be reviewed by an editor. If you wish to continue hosting your add-on, please click to select a review process."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:84
-msgid ""
-"You will receive an email when the full review is\n"
-"                             complete, making you able to bundle your add-on with an\n"
-"                             application installer."
-msgstr ""
-
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:91
-msgid ""
-"All add-ons hosted in our gallery must now be reviewed by an\n"
-"                             editor. If you wish to continue hosting your add-on, please\n"
-"                             click to select a review process."
-msgstr ""
-
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:113
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:100
 msgid "Current Version:"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:115
-msgid ""
-"This is the version of your add-on that will\n"
-"                                           be installed if someone clicks the Install\n"
-"                                           button on addons.mozilla.org. It is only\n"
-"                                           relevant for listed add-ons."
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:102
+msgid "This is the version of your add-on that will be installed if someone clicks the Install button on addons.mozilla.org. It is only relevant for listed add-ons."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:123
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:110
 msgid "Created:"
 msgstr ""
 
 #. {0} is a date. dennis-ignore: E201
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:125
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:131
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:112 src/olympia/devhub/templates/devhub/includes/addon_details.html:118
 #, python-format
 msgid "%%b %%e, %%Y"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:136
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:123
 msgid "Next Version:"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:138
-msgid ""
-"This is the newest uploaded version, however\n"
-"                                           it isn’t live on the site yet."
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:125
+msgid "This is the newest uploaded version, however it isn’t live on the site yet."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:144
-#: src/olympia/devhub/templates/devhub/versions/list.html:30
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:130 src/olympia/devhub/templates/devhub/versions/list.html:30
 msgid "Queues are not reviewed strictly in order"
 msgstr ""
 
@@ -7294,10 +6019,8 @@ msgstr ""
 
 #: src/olympia/devhub/templates/devhub/includes/addons_create_profile.html:24
 msgid ""
-"Your developer profile will tell users about you, why you made this add-on, "
-"and what's next for the add-on. This profile is required for add-ons "
-"requesting contributions, but can be useful for any developer interested in "
-"connecting with users."
+"Your developer profile will tell users about you, why you made this add-on, and what's next for the add-on. This profile is required for add-ons requesting contributions, but can be useful for any "
+"developer interested in connecting with users."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/includes/addons_create_profile.html:32
@@ -7310,15 +6033,11 @@ msgid "<a href=\"%(url)s\"><strong>Update your user profile.</strong></a>"
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/includes/addons_create_profile.html:45
-msgid ""
-"Whether it was an idea while in line at the grocery store or the solution to"
-" one of life's great problems, share your story."
+msgid "Whether it was an idea while in line at the grocery store or the solution to one of life's great problems, share your story."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/includes/addons_create_profile.html:61
-msgid ""
-"Telling your users what's coming soon will give them something to look "
-"forward to."
+msgid "Telling your users what's coming soon will give them something to look forward to."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/includes/addons_edit_nav.html:23
@@ -7350,9 +6069,7 @@ msgid "View the blog &#9658;"
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/includes/license_form.html:6
-msgid ""
-"Please choose a license appropriate for the rights you grant on your source code.\n"
-"                  It is only relevant for listed add-ons."
+msgid "Please choose a license appropriate for the rights you grant on your source code. It is only relevant for listed add-ons."
 msgstr ""
 
 #. {0} is a list of HTML tags.
@@ -7368,30 +6085,26 @@ msgstr ""
 msgid "Remove this application"
 msgstr ""
 
-#. {0} is the maximum number of add-on categories allowed.                {1}
-#. is
+#. {0} is the maximum number of add-on categories allowed.                {1} is
 #. the application name.
 #: src/olympia/devhub/templates/devhub/includes/macros.html:70
 msgid "Select <b>up to {0}</b> {1} category for this add-on:"
 msgid_plural "Select <b>up to {0}</b> {1} categories for this add-on:"
 msgstr[0] ""
+msgstr[1] ""
 
 #: src/olympia/devhub/templates/devhub/includes/policy_form.html:4
 msgid ""
-"Users will be required to accept the following End-User License Agreement (EULA) prior to installing your add-on. The presence of a EULA significantly affects the number of downloads an add-on receives. Please note that a EULA is not the same as a code license, such as the GPL or MPL.\n"
-"                It is only relevant for listed add-ons."
+"Users will be required to accept the following End-User License Agreement (EULA) prior to installing your add-on. The presence of a EULA significantly affects the number of downloads an add-on "
+"receives. Please note that a EULA is not the same as a code license, such as the GPL or MPL.It is only relevant for listed add-ons."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/policy_form.html:21
-msgid ""
-"If your add-on transmits any data from the user's computer, a privacy policy is required that explains what data is sent and how it is used.\n"
-"                It is only relevant for listed add-ons."
+#: src/olympia/devhub/templates/devhub/includes/policy_form.html:24
+msgid "If your add-on transmits any data from the user's computer, a privacy policy is required that explains what data is sent and how it is used. It is only relevant for listed add-ons."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/includes/source_form_field.html:2
-msgid ""
-"If your add-on contains binary or obfuscated code other than known "
-"libraries, upload its sources for review."
+msgid "If your add-on contains binary or obfuscated code other than known libraries, upload its sources for review."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/includes/source_form_field.html:3
@@ -7399,9 +6112,7 @@ msgid "Read more about the source code review policy."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/includes/version_file.html:20
-msgid ""
-"You cannot remove an individual file after the review process has begun. You"
-" must delete the entire version."
+msgid "You cannot remove an individual file after the review process has begun. You must delete the entire version."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/includes/version_file.html:36
@@ -7430,9 +6141,7 @@ msgid "Voluntary Contributions"
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/payments/payments.html:38
-msgid ""
-"Add-ons enrolled in our contributions program can request voluntary "
-"financial support from users."
+msgid "Add-ons enrolled in our contributions program can request voluntary financial support from users."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/payments/payments.html:40
@@ -7444,9 +6153,7 @@ msgid "Choose when and how users are asked to contribute"
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/payments/payments.html:42
-msgid ""
-"Receive contributions in your PayPal account or send them to an organization"
-" of your choice"
+msgid "Receive contributions in your PayPal account or send them to an organization of your choice"
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/payments/payments.html:46
@@ -7455,17 +6162,14 @@ msgstr ""
 
 #: src/olympia/devhub/templates/devhub/payments/payments.html:53
 #, python-format
-msgid ""
-"Contributions are only available for add-ons with a <a "
-"href=\"%(url)s\">completed developer profile</a>."
+msgid "Contributions are only available for add-ons with a <a href=\"%(url)s\">completed developer profile</a>."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/payments/payments.html:59
 msgid "Contributions are only available for fully reviewed add-ons."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/payments/payments.html:65
-#: src/olympia/devhub/templates/devhub/payments/voluntary.html:2
+#: src/olympia/devhub/templates/devhub/payments/payments.html:65 src/olympia/devhub/templates/devhub/payments/voluntary.html:2
 msgid "Set up Contributions"
 msgstr ""
 
@@ -7478,15 +6182,12 @@ msgstr ""
 msgid "or <a href=\"%(cancel)s\">Cancel</a>"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/payments/voluntary.html:2
-#: src/olympia/stats/templates/stats/addon_report_menu.html:39
+#: src/olympia/devhub/templates/devhub/payments/voluntary.html:2 src/olympia/stats/templates/stats/addon_report_menu.html:39
 msgid "Contributions"
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/payments/voluntary.html:3
-msgid ""
-"Fill in the fields below to begin asking for voluntary contributions from "
-"users."
+msgid "Fill in the fields below to begin asking for voluntary contributions from users."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/payments/voluntary.html:11
@@ -7530,16 +6231,13 @@ msgid "Send a thank-you note?"
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/payments/voluntary.html:47
-msgid ""
-"We'll automatically email users who contribute to your add-on with this "
-"message."
+msgid "We'll automatically email users who contribute to your add-on with this message."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/payments/voluntary.html:49
 msgid ""
-"We recommend thanking the user and telling them how much you appreciate "
-"their support. You might also want to tell them about what's next for your "
-"add-on and about any other add-ons you've made for them to try."
+"We recommend thanking the user and telling them how much you appreciate their support. You might also want to tell them about what's next for your add-on and about any other add-ons you've made for "
+"them to try."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/payments/voluntary.html:64
@@ -7554,132 +6252,94 @@ msgstr ""
 msgid "Transfer ownership"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/personas/edit.html:77
-#: src/olympia/devhub/templates/devhub/personas/submit.html:31
+#: src/olympia/devhub/templates/devhub/personas/edit.html:77 src/olympia/devhub/templates/devhub/personas/submit.html:31
 msgid "Theme Details"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/personas/edit.html:87
-#: src/olympia/devhub/templates/devhub/personas/submit.html:36
+#: src/olympia/devhub/templates/devhub/personas/edit.html:87 src/olympia/devhub/templates/devhub/personas/submit.html:36
 msgid "Supply a pretty URL for your detail page."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/personas/edit.html:92
-#: src/olympia/devhub/templates/devhub/personas/submit.html:41
+#: src/olympia/devhub/templates/devhub/personas/edit.html:92 src/olympia/devhub/templates/devhub/personas/submit.html:41
 msgid "Select the category that best describes your Theme."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/personas/edit.html:95
-#: src/olympia/devhub/templates/devhub/personas/submit.html:44
+#: src/olympia/devhub/templates/devhub/personas/edit.html:95 src/olympia/devhub/templates/devhub/personas/submit.html:44
 msgid "Add some tags to describe your Theme."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/personas/edit.html:106
-msgid ""
-"A short explanation of your theme's\n"
-"                                basic functionality that is displayed in\n"
-"                                search and browse listings, as well as at\n"
-"                                the top of your theme's details page."
+#: src/olympia/devhub/templates/devhub/personas/edit.html:106 src/olympia/devhub/templates/devhub/personas/submit.html:54
+msgid "A short explanation of your theme's basic functionality that is displayed in search and browse listings, as well as at the top of your theme's details page."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/personas/edit.html:122
-#: src/olympia/devhub/templates/devhub/personas/submit.html:68
+#: src/olympia/devhub/templates/devhub/personas/edit.html:122 src/olympia/devhub/templates/devhub/personas/submit.html:68
 msgid "Theme License"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/personas/edit.html:126
-#: src/olympia/devhub/templates/devhub/personas/submit.html:72
+#: src/olympia/devhub/templates/devhub/personas/edit.html:126 src/olympia/devhub/templates/devhub/personas/submit.html:72
 msgid "Can others share your Theme, as long as you're given credit?"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/personas/edit.html:132
-#: src/olympia/devhub/templates/devhub/personas/edit.html:153
-#: src/olympia/devhub/templates/devhub/personas/submit.html:78
+#: src/olympia/devhub/templates/devhub/personas/edit.html:132 src/olympia/devhub/templates/devhub/personas/edit.html:153 src/olympia/devhub/templates/devhub/personas/submit.html:78
 #: src/olympia/devhub/templates/devhub/personas/submit.html:99
-msgid ""
-"The licensor permits others to copy, distribute, display, and perform the "
-"work, including for commercial purposes."
+msgid "The licensor permits others to copy, distribute, display, and perform the work, including for commercial purposes."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/personas/edit.html:141
-#: src/olympia/devhub/templates/devhub/personas/edit.html:162
-#: src/olympia/devhub/templates/devhub/personas/submit.html:87
+#: src/olympia/devhub/templates/devhub/personas/edit.html:141 src/olympia/devhub/templates/devhub/personas/edit.html:162 src/olympia/devhub/templates/devhub/personas/submit.html:87
 #: src/olympia/devhub/templates/devhub/personas/submit.html:108
-msgid ""
-"The licensor permits others to copy, distribute, display, and perform the "
-"work for non-commercial purposes only."
+msgid "The licensor permits others to copy, distribute, display, and perform the work for non-commercial purposes only."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/personas/edit.html:147
-#: src/olympia/devhub/templates/devhub/personas/submit.html:93
+#: src/olympia/devhub/templates/devhub/personas/edit.html:147 src/olympia/devhub/templates/devhub/personas/submit.html:93
 msgid "Can others make commercial use of your Theme?"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/personas/edit.html:168
-#: src/olympia/devhub/templates/devhub/personas/submit.html:114
+#: src/olympia/devhub/templates/devhub/personas/edit.html:168 src/olympia/devhub/templates/devhub/personas/submit.html:114
 msgid "Can others create derivative works from your Theme?"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/personas/edit.html:174
-#: src/olympia/devhub/templates/devhub/personas/submit.html:120
-msgid ""
-"The licensor permits others to copy, distribute, display and perform the "
-"work, as well as make derivative works based on it."
+#: src/olympia/devhub/templates/devhub/personas/edit.html:174 src/olympia/devhub/templates/devhub/personas/submit.html:120
+msgid "The licensor permits others to copy, distribute, display and perform the work, as well as make derivative works based on it."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/personas/edit.html:182
-#: src/olympia/devhub/templates/devhub/personas/submit.html:128
+#: src/olympia/devhub/templates/devhub/personas/edit.html:182 src/olympia/devhub/templates/devhub/personas/submit.html:128
 msgid "Yes, as long as they share alike"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/personas/edit.html:183
-#: src/olympia/devhub/templates/devhub/personas/submit.html:129
-msgid ""
-"The licensor permits others to distribute derivativeworks only under the "
-"same license or one compatible with the one that governs the licensor's "
-"work."
+#: src/olympia/devhub/templates/devhub/personas/edit.html:183 src/olympia/devhub/templates/devhub/personas/submit.html:129
+msgid "The licensor permits others to distribute derivativeworks only under the same license or one compatible with the one that governs the licensor's work."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/personas/edit.html:192
-#: src/olympia/devhub/templates/devhub/personas/submit.html:138
-msgid ""
-"The licensor permits others to copy, distribute and transmit only unaltered "
-"copies of the work — not derivative works based on it."
+#: src/olympia/devhub/templates/devhub/personas/edit.html:192 src/olympia/devhub/templates/devhub/personas/submit.html:138
+msgid "The licensor permits others to copy, distribute and transmit only unaltered copies of the work — not derivative works based on it."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/personas/edit.html:199
-#: src/olympia/devhub/templates/devhub/personas/submit.html:145
+#: src/olympia/devhub/templates/devhub/personas/edit.html:199 src/olympia/devhub/templates/devhub/personas/submit.html:145
 msgid "Your Theme will be released under the following license:"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/personas/edit.html:202
-#: src/olympia/devhub/templates/devhub/personas/submit.html:148
+#: src/olympia/devhub/templates/devhub/personas/edit.html:202 src/olympia/devhub/templates/devhub/personas/submit.html:148
 msgid "Select a different license."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/personas/edit.html:207
-#: src/olympia/devhub/templates/devhub/personas/submit.html:153
+#: src/olympia/devhub/templates/devhub/personas/edit.html:207 src/olympia/devhub/templates/devhub/personas/submit.html:153
 msgid "Select a license for your Theme."
 msgstr "აირჩიეთ ლიცენზია თქვენი თემისთვის."
 
-#: src/olympia/devhub/templates/devhub/personas/edit.html:217
-#: src/olympia/devhub/templates/devhub/personas/submit.html:163
+#: src/olympia/devhub/templates/devhub/personas/edit.html:217 src/olympia/devhub/templates/devhub/personas/submit.html:163
 msgid "Theme Design"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/personas/edit.html:221
-#: src/olympia/devhub/templates/devhub/personas/edit.html:224
+#: src/olympia/devhub/templates/devhub/personas/edit.html:221 src/olympia/devhub/templates/devhub/personas/edit.html:224
 msgid "Upload New Design"
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/personas/edit.html:226
-msgid ""
-"Upon upload and form submission, the AMO Team will review your updated "
-"design. Your current design will still be public in the meantime."
+msgid "Upon upload and form submission, the AMO Team will review your updated design. Your current design will still be public in the meantime."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/personas/edit.html:241
-msgid "Your previously resubmitted design,  which is under pending review."
+msgid "Your previously resubmitted design, which is under pending review."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/personas/edit.html:245
@@ -7702,43 +6362,35 @@ msgstr ""
 msgid "Footer"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/personas/edit.html:274
-#: src/olympia/devhub/templates/devhub/personas/submit.html:167
+#: src/olympia/devhub/templates/devhub/personas/edit.html:274 src/olympia/devhub/templates/devhub/personas/submit.html:167
 msgid "Select colors for your Theme."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/personas/edit.html:276
-#: src/olympia/devhub/templates/devhub/personas/submit.html:169
+#: src/olympia/devhub/templates/devhub/personas/edit.html:276 src/olympia/devhub/templates/devhub/personas/submit.html:169
 msgid "Foreground Text"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/personas/edit.html:277
-#: src/olympia/devhub/templates/devhub/personas/submit.html:170
+#: src/olympia/devhub/templates/devhub/personas/edit.html:277 src/olympia/devhub/templates/devhub/personas/submit.html:170
 msgid "This is the color of the tab text."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/personas/edit.html:279
-#: src/olympia/devhub/templates/devhub/personas/submit.html:172
+#: src/olympia/devhub/templates/devhub/personas/edit.html:279 src/olympia/devhub/templates/devhub/personas/submit.html:172
 msgid "Background"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/personas/edit.html:280
-#: src/olympia/devhub/templates/devhub/personas/submit.html:173
+#: src/olympia/devhub/templates/devhub/personas/edit.html:280 src/olympia/devhub/templates/devhub/personas/submit.html:173
 msgid "This is the color of the tabs."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/personas/edit.html:285
-#: src/olympia/devhub/templates/devhub/personas/submit.html:178
+#: src/olympia/devhub/templates/devhub/personas/edit.html:285 src/olympia/devhub/templates/devhub/personas/submit.html:178
 msgid "Preview"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/personas/edit.html:291
-#: src/olympia/devhub/templates/devhub/personas/submit.html:183
+#: src/olympia/devhub/templates/devhub/personas/edit.html:291 src/olympia/devhub/templates/devhub/personas/submit.html:183
 msgid "Your Theme's Name"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/personas/edit.html:294
-#: src/olympia/devhub/templates/devhub/personas/submit.html:186
+#: src/olympia/devhub/templates/devhub/personas/edit.html:294 src/olympia/devhub/templates/devhub/personas/submit.html:186
 #, python-format
 msgid "by <a href=\"%(profile_url)s\" target=\"_blank\">%(user)s</a>"
 msgstr ""
@@ -7749,30 +6401,17 @@ msgstr ""
 
 #: src/olympia/devhub/templates/devhub/personas/submit.html:18
 #, python-format
-msgid ""
-"Background themes let you easily personalize the look of your Firefox. "
-"Submit your own design below, or <a href=\"%(submit_url)s\">learn how to "
-"create one</a>!"
+msgid "Background themes let you easily personalize the look of your Firefox. Submit your own design below, or <a href=\"%(submit_url)s\">learn how to create one</a>!"
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/personas/submit.html:33
 msgid "Give your Theme a name."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/personas/submit.html:54
-msgid ""
-"A short explanation of your theme's\n"
-"                                      basic functionality that is displayed in\n"
-"                                      search and browse listings, as well as at\n"
-"                                      the top of your theme's details page."
-msgstr ""
-
 #: src/olympia/devhub/templates/devhub/personas/submit.html:198
 #, python-format
 msgid ""
-"I agree to the <a href=\"%(agreement_url)s\" target=\"_blank\">Firefox Add-"
-"on Distribution Agreement</a> and to my information being handled as "
-"described in the <a href=\"%(privacy_notice_url)s\" "
+"I agree to the <a href=\"%(agreement_url)s\" target=\"_blank\">Firefox Add-on Distribution Agreement</a> and to my information being handled as described in the <a href=\"%(privacy_notice_url)s\" "
 "target=\"_blank\">Websites, Communications and Cookies Privacy Notice</a>."
 msgstr ""
 
@@ -7781,23 +6420,17 @@ msgid "Submit Theme"
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/personas/submit_done.html:11
-msgid ""
-"Your theme has been submitted to the Review Queue. You'll receive an email "
-"once it has been reviewed, typically within 24 hours."
+msgid "Your theme has been submitted to the Review Queue. You'll receive an email once it has been reviewed, typically within 24 hours."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/personas/submit_done.html:19
 #, python-format
-msgid ""
-"Provide more details about your theme by <a href=\"%(edit_url)s\">editing "
-"its listing</a>."
+msgid "Provide more details about your theme by <a href=\"%(edit_url)s\">editing its listing</a>."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/personas/submit_done.html:25
 #, python-format
-msgid ""
-"View and subscribe to your theme's <a href=\"%(feed_url)s\">activity "
-"feed</a> to stay updated on reviews, collections, and more."
+msgid "View and subscribe to your theme's <a href=\"%(feed_url)s\">activity feed</a> to stay updated on reviews, collections, and more."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/personas/submit_done.html:32
@@ -7813,13 +6446,11 @@ msgstr ""
 msgid "3000 &times; 200 pixels"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/personas/includes/theme_design.html:9
-#: src/olympia/devhub/templates/devhub/personas/includes/theme_design.html:25
+#: src/olympia/devhub/templates/devhub/personas/includes/theme_design.html:9 src/olympia/devhub/templates/devhub/personas/includes/theme_design.html:25
 msgid "300 KB max"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/personas/includes/theme_design.html:10
-#: src/olympia/devhub/templates/devhub/personas/includes/theme_design.html:26
+#: src/olympia/devhub/templates/devhub/personas/includes/theme_design.html:10 src/olympia/devhub/templates/devhub/personas/includes/theme_design.html:26
 msgid "PNG or JPG"
 msgstr ""
 
@@ -7848,48 +6479,26 @@ msgid "Select a different footer image"
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/versions/add_file_modal.html:8
-msgid ""
-"Files added to reviewed versions must be reviewed before they will be "
-"available for download."
+msgid "Files added to reviewed versions must be reviewed before they will be available for download."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/add_file_modal.html:15
-#, python-format
-msgid ""
-"Submission of updates to unlisted add-ons for signing is currently in an "
-"open beta. Manual review may still be required for a large number of add-"
-"ons. Please <a href=\"%(url)s\" target=\"_blank\">report any bugs</a> that "
-"you encounter."
-msgstr ""
-
-#: src/olympia/devhub/templates/devhub/versions/add_file_modal.html:35
+#: src/olympia/devhub/templates/devhub/versions/add_file_modal.html:24
 msgid "Select the target platform for this file."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/add_file_modal.html:46
+#: src/olympia/devhub/templates/devhub/versions/add_file_modal.html:35
 msgid "Which review type would you like to nominate for?"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/add_file_modal.html:51
+#: src/olympia/devhub/templates/devhub/versions/add_file_modal.html:40
 msgid "Only publish this version to my beta channel."
-msgstr ""
-
-#: src/olympia/devhub/templates/devhub/versions/add_file_modal.html:54
-#, python-format
-msgid ""
-"The behavior of the beta channel has changed to accommodate <a "
-"href=\"%(addon_signing_url)s\" target=\"_blank\">mandatory add-on "
-"signing</a>. The new process is currently in an open beta, and may change "
-"significantly in the near future. Please <a href=\"%(issues_url)s\" "
-"target=\"_blank\">report any bugs</a> that you encounter."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/versions/edit.html:5
 msgid "Manage Version {0}"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/edit.html:12
-#: src/olympia/devhub/templates/devhub/versions/list.html:3
+#: src/olympia/devhub/templates/devhub/versions/edit.html:12 src/olympia/devhub/templates/devhub/versions/list.html:3
 msgid "Status & Versions"
 msgstr ""
 
@@ -7906,35 +6515,22 @@ msgstr ""
 msgid "Upload Another File"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/edit.html:45
-msgid ""
-"Adjusting application information here will allow users to install your\n"
-"                          add-on even if the install manifest in the package indicates that the\n"
-"                          add-on is incompatible."
-msgstr ""
-
 #: src/olympia/devhub/templates/devhub/versions/edit.html:74
 msgid ""
-"Information about changes in this release, new features,\n"
-"                              known bugs, and other useful information specific to this\n"
-"                              release/version. This information is also shown in the\n"
-"                              Add-ons Manager when updating."
+"Information about changes in this release, new features, known bugs, and other useful information specific to this release/version. This information is also shown in the Add-ons Manager when "
+"updating."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/versions/edit.html:99
 msgid "Approval Status"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/edit.html:113
-#: src/olympia/editors/templates/editors/review.html:108
+#: src/olympia/devhub/templates/devhub/versions/edit.html:113 src/olympia/editors/templates/editors/review.html:108
 msgid "Notes for Reviewers"
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/versions/edit.html:114
-msgid ""
-"Optionally, enter any information that may be useful\n"
-"                              to the Editor reviewing this add-on, such as test\n"
-"                              account information."
+msgid "Optionally, enter any information that may be useful to the Editor reviewing this add-on, such as test account information."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/versions/edit.html:127
@@ -7942,13 +6538,10 @@ msgid "Source code"
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/versions/edit.html:128
-msgid ""
-"If your add-on contain binary or obfuscated code, make the source available "
-"here for reviewers."
+msgid "If your add-on contain binary or obfuscated code, make the source available here for reviewers."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/edit.html:145
-#: src/olympia/devhub/templates/devhub/versions/edit.html:149
+#: src/olympia/devhub/templates/devhub/versions/edit.html:145 src/olympia/devhub/templates/devhub/versions/edit.html:149
 msgid "Upload a new file"
 msgstr ""
 
@@ -7988,6 +6581,7 @@ msgstr ""
 msgid "{0} file"
 msgid_plural "{0} files"
 msgstr[0] ""
+msgstr[1] ""
 
 #: src/olympia/devhub/templates/devhub/versions/list.html:25
 msgid "0 files"
@@ -8014,9 +6608,7 @@ msgstr ""
 msgid "Request Preliminary Review"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:80
-#: src/olympia/devhub/templates/devhub/versions/list.html:327
-#: src/olympia/devhub/templates/devhub/versions/list.html:350
+#: src/olympia/devhub/templates/devhub/versions/list.html:80 src/olympia/devhub/templates/devhub/versions/list.html:325 src/olympia/devhub/templates/devhub/versions/list.html:348
 msgid "Cancel Review Request"
 msgstr ""
 
@@ -8029,8 +6621,7 @@ msgid "Listed:"
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/versions/list.html:102
-msgid ""
-"Visible to everyone on {0} and included in search results and listing pages"
+msgid "Visible to everyone on {0} and included in search results and listing pages"
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/versions/list.html:108
@@ -8038,9 +6629,7 @@ msgid "Hidden:"
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/versions/list.html:108
-msgid ""
-"Hosted on {0}, but hidden to anyone but authors. Used to temporarily hide "
-"listings or discontinue them."
+msgid "Hosted on {0}, but hidden to anyone but authors. Used to temporarily hide listings or discontinue them."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/versions/list.html:114
@@ -8048,9 +6637,7 @@ msgid "Unlisted:"
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/versions/list.html:114
-msgid ""
-"Not distributed on {0}. Developers will upload new versions for signing and "
-"distribute the add-ons on their own. (beta)"
+msgid "Not distributed on {0}. Developers will upload new versions for signing and distribute the add-ons on their own."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/versions/list.html:122
@@ -8061,17 +6648,12 @@ msgstr ""
 msgid "Currently on AMO"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:129
-#: src/olympia/devhub/templates/devhub/versions/list.html:147
-#: src/olympia/devhub/templates/devhub/versions/list.html:164
-#: src/olympia/editors/templates/editors/includes/search_results_themes.html:7
-#: src/olympia/editors/templates/editors/themes/queue_list.html:50
+#: src/olympia/devhub/templates/devhub/versions/list.html:129 src/olympia/devhub/templates/devhub/versions/list.html:147 src/olympia/devhub/templates/devhub/versions/list.html:164
+#: src/olympia/editors/templates/editors/includes/search_results_themes.html:7 src/olympia/editors/templates/editors/themes/queue_list.html:50
 msgid "Status"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:130
-#: src/olympia/devhub/templates/devhub/versions/list.html:148
-#: src/olympia/devhub/templates/devhub/versions/list.html:165
+#: src/olympia/devhub/templates/devhub/versions/list.html:130 src/olympia/devhub/templates/devhub/versions/list.html:148 src/olympia/devhub/templates/devhub/versions/list.html:165
 #: src/olympia/editors/templates/editors/includes/files_view.html:11
 msgid "Validation"
 msgstr ""
@@ -8093,10 +6675,7 @@ msgid "Full review may not be required"
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/versions/list.html:201
-msgid ""
-"Unlisted add-ons don't need Full Review unless they are distributed as part "
-"of an application installer. Read <a href=\"{link}\" target=\"_blank\">this "
-"documentation</a> for more information."
+msgid "Unlisted add-ons don't need Full Review unless they are distributed as part of an application installer. Read <a href=\"{link}\" target=\"_blank\">this documentation</a> for more information."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/versions/list.html:209
@@ -8109,9 +6688,7 @@ msgstr ""
 
 #: src/olympia/devhub/templates/devhub/versions/list.html:218
 msgid ""
-"You are about to delete the current version of your add-on. This may cause "
-"your add-on status to change, or your listing to lose public visibility, if "
-"this is the only public version of your add-on."
+"You are about to delete the current version of your add-on. This may cause your add-on status to change, or your listing to lose public visibility, if this is the only public version of your add-on."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/versions/list.html:219
@@ -8119,102 +6696,77 @@ msgid "Deleting this version will permanently delete:"
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/versions/list.html:225
-msgid ""
-"<strong>Important:</strong> Once a version has been deleted, you may not "
-"upload a new version with the same version number."
+msgid "<strong>Important:</strong> Once a version has been deleted, you may not upload a new version with the same version number."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/versions/list.html:230
-msgid ""
-"Deleting a version which has already been reviewed\n"
-"               may also cause a significant delay in the review of\n"
-"               your next update."
-msgstr ""
-
-#: src/olympia/devhub/templates/devhub/versions/list.html:233
 msgid "Are you sure you wish to delete this version?"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:238
+#: src/olympia/devhub/templates/devhub/versions/list.html:235
 msgid "Delete Version"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:240
+#: src/olympia/devhub/templates/devhub/versions/list.html:237
 msgid "Disable Version"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:247
+#: src/olympia/devhub/templates/devhub/versions/list.html:244
 msgid "Add a new Version"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:249
+#: src/olympia/devhub/templates/devhub/versions/list.html:246
 msgid "Add Version"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:256
-#: src/olympia/devhub/templates/devhub/versions/list.html:274
+#: src/olympia/devhub/templates/devhub/versions/list.html:253 src/olympia/devhub/templates/devhub/versions/list.html:279
 msgid "Hide Add-on"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:259
-msgid ""
-"Hiding your add-on will prevent it from appearing anywhere in our gallery "
-"and will stop users from receiving automatic updates."
+#: src/olympia/devhub/templates/devhub/versions/list.html:256
+msgid "Hiding your add-on will prevent it from appearing anywhere in our gallery and will stop users from receiving automatic updates."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:265
+#: src/olympia/devhub/templates/devhub/versions/list.html:263
+msgid "The files awaiting review will be disabled and you will need to upload new versions."
+msgstr ""
+
+#: src/olympia/devhub/templates/devhub/versions/list.html:270
 msgid "Are you sure you wish to hide your add-on?"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:286
-#: src/olympia/devhub/templates/devhub/versions/list.html:315
+#: src/olympia/devhub/templates/devhub/versions/list.html:291 src/olympia/devhub/templates/devhub/versions/list.html:313
 msgid "Unlist Add-on"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:289
+#: src/olympia/devhub/templates/devhub/versions/list.html:294
 #, python-format
 msgid ""
-"Unlisting your add-on will make it (and each of its versions/files) "
-"invisible on this website. It won't show up in searches, won't have a public"
-" facing page, and won't be updated automatically for current users.  It is "
-"recommended for unlisted add-ons to provide a custom <a "
-"href=\"%(update_url)s\" target=\"_blank\">updateURL</a> in their manifest "
-"file for automatic updates."
+"Unlisting your add-on will make it (and each of its versions/files) invisible on this website. It won't show up in searches, won't have a public facing page, and won't be updated automatically for "
+"current users. It is recommended for unlisted add-ons to provide a custom <a href=\"%(update_url)s\" target=\"_blank\">updateURL</a> in their manifest file for automatic updates."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:299
-#, python-format
-msgid ""
-"Switching add-ons to unlisted is currently in an open beta. Please <a "
-"href=\"%(url)s\" target=\"_blank\">report any bugs</a> that you encounter."
-msgstr ""
-
-#: src/olympia/devhub/templates/devhub/versions/list.html:305
+#: src/olympia/devhub/templates/devhub/versions/list.html:303
 msgid "Unlisting an add-on is irreversible!"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:305
+#: src/olympia/devhub/templates/devhub/versions/list.html:303
 msgid "An unlisted add-on cannot be switched to be listed."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:307
+#: src/olympia/devhub/templates/devhub/versions/list.html:305
 msgid "Are you sure you wish to unlist your add-on?"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:330
-msgid ""
-"Canceling your review request will leave your add-on as preliminarily "
-"reviewed."
+#: src/olympia/devhub/templates/devhub/versions/list.html:328
+msgid "Canceling your review request will leave your add-on as preliminarily reviewed."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:335
-msgid ""
-"Canceling your review request will mark your add-on incomplete. If you do "
-"not complete your add-on after several days by re-requesting review, it will"
-" be deleted."
+#: src/olympia/devhub/templates/devhub/versions/list.html:333
+msgid "Canceling your review request will mark your add-on incomplete. If you do not complete your add-on after several days by re-requesting review, it will be deleted."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:343
+#: src/olympia/devhub/templates/devhub/versions/list.html:341
 msgid "Are you sure you wish to cancel your review request?"
 msgstr ""
 
@@ -8247,14 +6799,11 @@ msgid "Translate content on the web from and into over 40 languages."
 msgstr ""
 
 #: src/olympia/discovery/modules.py:171
-msgid ""
-"Easily connect to your social networks, and share or comment on the page "
-"you're visiting."
+msgid "Easily connect to your social networks, and share or comment on the page you're visiting."
 msgstr ""
 
 #: src/olympia/discovery/modules.py:173
-msgid ""
-"A quick view to compare prices when you shop online or search for flights."
+msgid "A quick view to compare prices when you shop online or search for flights."
 msgstr ""
 
 #: src/olympia/discovery/modules.py:183
@@ -8298,9 +6847,7 @@ msgid "Add-ons that help you on your travels!"
 msgstr ""
 
 #: src/olympia/discovery/modules.py:226
-msgid ""
-"Displays a country flag depicting the location of the current website's "
-"server and more."
+msgid "Displays a country flag depicting the location of the current website's server and more."
 msgstr ""
 
 #: src/olympia/discovery/modules.py:228
@@ -8308,9 +6855,7 @@ msgid "FoxClocks let you keep an eye on the time around the world."
 msgstr ""
 
 #: src/olympia/discovery/modules.py:230
-msgid ""
-"Automatically get the lowest price when you shop online or search for "
-"flights."
+msgid "Automatically get the lowest price when you shop online or search for flights."
 msgstr ""
 
 #: src/olympia/discovery/modules.py:240
@@ -8350,9 +6895,7 @@ msgid "Put a Theme on It!"
 msgstr ""
 
 #: src/olympia/discovery/modules.py:281
-msgid ""
-"Visit addons.mozilla.org from Firefox for Android and dress up your mobile "
-"browser to match your style, mood, or the season."
+msgid "Visit addons.mozilla.org from Firefox for Android and dress up your mobile browser to match your style, mood, or the season."
 msgstr ""
 
 #: src/olympia/discovery/modules.py:290
@@ -8380,9 +6923,7 @@ msgid "Protect your privacy online with the add-ons in this collection."
 msgstr ""
 
 #: src/olympia/discovery/modules.py:342
-msgid ""
-"Great add-ons for work, fun, privacy, productivity&hellip; just about "
-"anything!"
+msgid "Great add-ons for work, fun, privacy, productivity&hellip; just about anything!"
 msgstr ""
 
 #: src/olympia/discovery/modules.py:350
@@ -8403,18 +6944,14 @@ msgstr ""
 
 #: src/olympia/discovery/templates/discovery/pane.html:28
 #, python-format
-msgid ""
-"Add-ons are applications that let you personalize %(app)s with extra "
-"functionality or style. Try a time-saving sidebar, a weather notifier, or a "
-"themed look to make %(app)s your own."
+msgid "Add-ons are applications that let you personalize %(app)s with extra functionality or style. Try a time-saving sidebar, a weather notifier, or a themed look to make %(app)s your own."
 msgstr ""
 
 #: src/olympia/discovery/templates/discovery/pane.html:62
 msgid "Learn More About Add-ons"
 msgstr ""
 
-#: src/olympia/discovery/templates/discovery/pane.html:66
-#: src/olympia/discovery/templates/discovery/pane.html:73
+#: src/olympia/discovery/templates/discovery/pane.html:66 src/olympia/discovery/templates/discovery/pane.html:73
 msgid "See all"
 msgstr ""
 
@@ -8445,9 +6982,7 @@ msgstr ""
 
 #: src/olympia/discovery/templates/discovery/pane_account.html:17
 #, python-format
-msgid ""
-"Thanks for using %(app)s and supporting <a href=\"%(url)s\">Mozilla's "
-"mission</a>!"
+msgid "Thanks for using %(app)s and supporting <a href=\"%(url)s\">Mozilla's mission</a>!"
 msgstr ""
 
 #: src/olympia/discovery/templates/discovery/pane_account.html:23
@@ -8472,10 +7007,7 @@ msgstr ""
 
 #: src/olympia/discovery/templates/discovery/modules/go-mobile.html:8
 #, python-format
-msgid ""
-"Visit <a href=\"%(url)s\">firefox.com/m</a> to get Firefox on your phone and"
-" personalize your browser anytime, anywhere. Easily discover and install "
-"add-ons from the mobile Add-ons Manager."
+msgid "Visit <a href=\"%(url)s\">firefox.com/m</a> to get Firefox on your phone and personalize your browser anytime, anywhere. Easily discover and install add-ons from the mobile Add-ons Manager."
 msgstr ""
 
 #: src/olympia/discovery/templates/discovery/modules/go-mobile.html:13
@@ -8491,15 +7023,11 @@ msgid "Find great add-ons to help you with all your holiday shopping needs."
 msgstr ""
 
 #: src/olympia/discovery/templates/discovery/modules/holiday.html:13
-msgid ""
-"Install the Amazon Browser Apps and receive special Amazon features right at"
-" your fingertips."
+msgid "Install the Amazon Browser Apps and receive special Amazon features right at your fingertips."
 msgstr ""
 
 #: src/olympia/discovery/templates/discovery/modules/holiday.html:22
-msgid ""
-"Keep an eye on your eBay activity wherever you are on the web when you "
-"install the eBay Sidebar for Firefox."
+msgid "Keep an eye on your eBay activity wherever you are on the web when you install the eBay Sidebar for Firefox."
 msgstr ""
 
 #: src/olympia/discovery/templates/discovery/modules/holiday.html:31
@@ -8577,19 +7105,19 @@ msgstr ""
 msgid "Search by add-on name / author email"
 msgstr ""
 
-#: src/olympia/editors/forms.py:103
+#: src/olympia/editors/forms.py:103 src/olympia/editors/forms.py:244 src/olympia/editors/forms.py:257
 msgid "yes"
 msgstr ""
 
-#: src/olympia/editors/forms.py:104
+#: src/olympia/editors/forms.py:104 src/olympia/editors/forms.py:244 src/olympia/editors/forms.py:257
 msgid "no"
 msgstr ""
 
-#: src/olympia/editors/forms.py:105
+#: src/olympia/editors/forms.py:105 src/olympia/editors/forms.py:245
 msgid "Admin Flag"
 msgstr ""
 
-#: src/olympia/editors/forms.py:113
+#: src/olympia/editors/forms.py:113 src/olympia/editors/forms.py:253
 msgid "Max. Version"
 msgstr ""
 
@@ -8601,57 +7129,59 @@ msgstr ""
 msgid "Add-on Types"
 msgstr ""
 
-#: src/olympia/editors/forms.py:126 src/olympia/editors/helpers.py:267
+#: src/olympia/editors/forms.py:126 src/olympia/editors/helpers.py:279
 msgid "Platforms"
 msgstr ""
 
+#: src/olympia/editors/forms.py:237
+msgid "Search by add-on name / author email / guid"
+msgstr ""
+
 #. L10n: 0 = platform, 1 = filename, 2 = status message
-#: src/olympia/editors/forms.py:238
+#: src/olympia/editors/forms.py:342
 #, python-format
 msgid "<strong>%s</strong> &middot; %s &middot; %s"
 msgstr ""
 
-#: src/olympia/editors/forms.py:252
+#: src/olympia/editors/forms.py:356
 msgid "Comments:"
 msgstr ""
 
-#: src/olympia/editors/forms.py:256
+#: src/olympia/editors/forms.py:360
 msgid "Operating systems:"
 msgstr ""
 
-#: src/olympia/editors/forms.py:258
+#: src/olympia/editors/forms.py:362
 msgid "Applications:"
 msgstr ""
 
-#: src/olympia/editors/forms.py:260
-msgid ""
-"Notify me the next time this add-on is updated. (Subsequent updates will not"
-" generate an email)"
+#: src/olympia/editors/forms.py:364
+msgid "Notify me the next time this add-on is updated. (Subsequent updates will not generate an email)"
 msgstr ""
 
-#: src/olympia/editors/forms.py:265
+#: src/olympia/editors/forms.py:369
 msgid "Clear Admin Review Flag"
 msgstr ""
 
-#: src/olympia/editors/forms.py:267
+#: src/olympia/editors/forms.py:371
 msgid "Clear more info requested flag"
 msgstr ""
 
-#: src/olympia/editors/forms.py:281
+#: src/olympia/editors/forms.py:385
 msgid "Choose a canned response..."
 msgstr ""
 
 #. L10n: Description of what can be searched for.
-#: src/olympia/editors/forms.py:324
+#: src/olympia/editors/forms.py:423
 msgid "theme name"
 msgstr ""
 
-#: src/olympia/editors/forms.py:350
+#: src/olympia/editors/forms.py:449
 msgid "Someone else is reviewing this theme."
 msgstr ""
 
 #. L10n: Description of what can be searched for.
-#: src/olympia/editors/forms.py:447
+#: src/olympia/editors/forms.py:546
 msgid "app, reviewer, or comment"
 msgstr ""
 
@@ -8667,261 +7197,264 @@ msgstr ""
 msgid "Rejected or Unreviewed"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:123 src/olympia/editors/helpers.py:136
+#: src/olympia/editors/helpers.py:125 src/olympia/editors/helpers.py:138
 msgid "Queue"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:124
-#: src/olympia/editors/templates/editors/base.html:50
-#: src/olympia/editors/templates/editors/base.html:65
+#: src/olympia/editors/helpers.py:126 src/olympia/editors/templates/editors/base.html:50 src/olympia/editors/templates/editors/base.html:65
 msgid "Pending Updates"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:125
-#: src/olympia/editors/templates/editors/base.html:48
-#: src/olympia/editors/templates/editors/base.html:63
+#: src/olympia/editors/helpers.py:127 src/olympia/editors/templates/editors/base.html:48 src/olympia/editors/templates/editors/base.html:63
 msgid "Full Reviews"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:126
-#: src/olympia/editors/templates/editors/base.html:52
-#: src/olympia/editors/templates/editors/base.html:67
+#: src/olympia/editors/helpers.py:128 src/olympia/editors/templates/editors/base.html:52 src/olympia/editors/templates/editors/base.html:67
 msgid "Preliminary Reviews"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:127
-#: src/olympia/editors/templates/editors/base.html:54
+#: src/olympia/editors/helpers.py:129 src/olympia/editors/templates/editors/base.html:54
 msgid "Moderated Reviews"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:128
-#: src/olympia/editors/templates/editors/base.html:46
+#: src/olympia/editors/helpers.py:130 src/olympia/editors/templates/editors/base.html:46
 msgid "Fast Track"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:130
+#: src/olympia/editors/helpers.py:132
 msgid "Pending Themes"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:131
-#: src/olympia/editors/templates/editors/themes/queue.html:4
+#: src/olympia/editors/helpers.py:133 src/olympia/editors/templates/editors/themes/queue.html:4
 msgid "Flagged Themes"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:132
+#: src/olympia/editors/helpers.py:134
 msgid "Update Themes"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:137
+#: src/olympia/editors/helpers.py:139
 msgid "Unlisted Pending Updates"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:138
+#: src/olympia/editors/helpers.py:140
 msgid "Unlisted Full Reviews"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:139
+#: src/olympia/editors/helpers.py:141
 msgid "Unlisted Preliminary Reviews"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:170
+#: src/olympia/editors/helpers.py:142
+msgid "Unlisted All Add-ons"
+msgstr ""
+
+#: src/olympia/editors/helpers.py:173
 msgid "Fast Track ({0})"
 msgid_plural "Fast Track ({0})"
 msgstr[0] ""
+msgstr[1] ""
 
-#: src/olympia/editors/helpers.py:175
+#: src/olympia/editors/helpers.py:178
 msgid "Full Review ({0})"
 msgid_plural "Full Reviews ({0})"
 msgstr[0] ""
+msgstr[1] ""
 
-#: src/olympia/editors/helpers.py:180
+#: src/olympia/editors/helpers.py:183
 msgid "Pending Update ({0})"
 msgid_plural "Pending Updates ({0})"
 msgstr[0] ""
+msgstr[1] ""
 
-#: src/olympia/editors/helpers.py:185
+#: src/olympia/editors/helpers.py:188
 msgid "Preliminary Review ({0})"
 msgid_plural "Preliminary Reviews ({0})"
 msgstr[0] ""
+msgstr[1] ""
 
-#: src/olympia/editors/helpers.py:190
+#: src/olympia/editors/helpers.py:193
 msgid "Moderated Review ({0})"
 msgid_plural "Moderated Reviews ({0})"
 msgstr[0] ""
+msgstr[1] ""
 
-#: src/olympia/editors/helpers.py:196
+#: src/olympia/editors/helpers.py:199
 msgid "Unlisted Full Review ({0})"
 msgid_plural "Unlisted Full Reviews ({0})"
 msgstr[0] ""
+msgstr[1] ""
 
-#: src/olympia/editors/helpers.py:201
+#: src/olympia/editors/helpers.py:204
 msgid "Unlisted Pending Update ({0})"
 msgid_plural "Unlisted Pending Updates ({0})"
 msgstr[0] ""
+msgstr[1] ""
 
-#: src/olympia/editors/helpers.py:206
+#: src/olympia/editors/helpers.py:209
 msgid "Unlisted Preliminary Review ({0})"
 msgid_plural "Unlisted Preliminary Reviews ({0})"
 msgstr[0] ""
+msgstr[1] ""
 
-#: src/olympia/editors/helpers.py:261
-msgid "Addon"
-msgstr ""
+#: src/olympia/editors/helpers.py:214
+msgid "Unlisted All Add-ons ({0})"
+msgid_plural "Unlisted All Add-ons ({0})"
+msgstr[0] ""
+msgstr[1] ""
 
-#: src/olympia/editors/helpers.py:262
+#: src/olympia/editors/helpers.py:274
 msgid "Type"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:263
+#: src/olympia/editors/helpers.py:275
 msgid "Waiting Time"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:264
-#: src/olympia/editors/templates/editors/review.html:285
+#: src/olympia/editors/helpers.py:276 src/olympia/editors/templates/editors/review.html:285
 msgid "Flags"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:265
+#: src/olympia/editors/helpers.py:277
 msgid "Applications"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:270
+#: src/olympia/editors/helpers.py:282
 msgid "Additional"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:285
+#: src/olympia/editors/helpers.py:302
 msgid "Site Specific"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:287
+#: src/olympia/editors/helpers.py:304
 msgid "Requires External Software"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:289
+#: src/olympia/editors/helpers.py:306
 msgid "Binary Components"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:313
+#: src/olympia/editors/helpers.py:339
 msgid "moments ago"
 msgstr ""
 
 #. L10n: first argument is number of minutes
-#: src/olympia/editors/helpers.py:316
+#: src/olympia/editors/helpers.py:342
 msgid "{0} minute"
 msgid_plural "{0} minutes"
 msgstr[0] ""
+msgstr[1] ""
 
 #. L10n: first argument is number of hours
-#: src/olympia/editors/helpers.py:320
+#: src/olympia/editors/helpers.py:346
 msgid "{0} hour"
 msgid_plural "{0} hours"
 msgstr[0] ""
+msgstr[1] ""
 
 #. L10n: first argument is number of days
-#: src/olympia/editors/helpers.py:324
+#: src/olympia/editors/helpers.py:350
 msgid "{0} day"
 msgid_plural "{0} days"
 msgstr[0] ""
+msgstr[1] ""
 
-#: src/olympia/editors/helpers.py:488
-msgid "Push to public"
+#: src/olympia/editors/helpers.py:364
+msgid "Last Review"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:490
-msgid "Grant full review"
+#: src/olympia/editors/helpers.py:366
+msgid "Last Update"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:505
-msgid "Request more information"
-msgstr ""
-
-#: src/olympia/editors/helpers.py:508
-msgid "Request super-review"
-msgstr ""
-
-#: src/olympia/editors/helpers.py:519
-msgid "Grant preliminary review"
-msgstr ""
-
-#: src/olympia/editors/helpers.py:520
-msgid "This will mark the files as preliminarily reviewed."
-msgstr ""
-
-#: src/olympia/editors/helpers.py:522
-msgid ""
-"Use this form to request more information from the author. They will receive"
-" an email and be able to answer here. You will be notified by email when "
-"they reply."
-msgstr ""
-
-#: src/olympia/editors/helpers.py:526
-msgid ""
-"If you have concerns about this add-on's security, copyright issues, or "
-"other concerns that an administrator should look into, enter your comments "
-"in the area below. They will be sent to administrators, not the author."
-msgstr ""
-
-#: src/olympia/editors/helpers.py:532
-msgid "This will reject the add-on and remove it from the review queue."
-msgstr ""
-
-#: src/olympia/editors/helpers.py:534
-msgid "Make a comment on this version.  The author won't be able to see this."
-msgstr ""
-
-#: src/olympia/editors/helpers.py:538
-msgid "This will reject the files and remove them from the review queue."
-msgstr ""
-
-#: src/olympia/editors/helpers.py:542
-msgid ""
-"This will mark the add-on as preliminarily reviewed. Future versions will "
-"undergo preliminary review."
-msgstr ""
-
-#: src/olympia/editors/helpers.py:547
-msgid ""
-"This will mark the files as preliminarily reviewed. Future versions will "
-"undergo preliminary review."
-msgstr ""
-
-#: src/olympia/editors/helpers.py:552
-msgid "Retain preliminary review"
-msgstr ""
-
-#: src/olympia/editors/helpers.py:553
-msgid ""
-"This will retain the add-on as preliminarily reviewed. Future versions will "
-"undergo preliminary review."
-msgstr ""
-
-#: src/olympia/editors/helpers.py:558
-msgid ""
-"This will approve a sandboxed version of a public add-on to appear on the "
-"public side."
+#: src/olympia/editors/helpers.py:387
+msgid "No Reviews"
 msgstr ""
 
 #: src/olympia/editors/helpers.py:561
-msgid ""
-"This will reject a version of a public add-on and remove it from the queue."
+msgid "Push to public"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:564
+#: src/olympia/editors/helpers.py:563
+msgid "Grant full review"
+msgstr ""
+
+#: src/olympia/editors/helpers.py:578
+msgid "Request more information"
+msgstr ""
+
+#: src/olympia/editors/helpers.py:581
+msgid "Request super-review"
+msgstr ""
+
+#: src/olympia/editors/helpers.py:592
+msgid "Grant preliminary review"
+msgstr ""
+
+#: src/olympia/editors/helpers.py:593
+msgid "This will mark the files as preliminarily reviewed."
+msgstr ""
+
+#: src/olympia/editors/helpers.py:595
+msgid "Use this form to request more information from the author. They will receive an email and be able to answer here. You will be notified by email when they reply."
+msgstr ""
+
+#: src/olympia/editors/helpers.py:599
 msgid ""
-"This will mark the add-on and its most recent version and files as public. "
-"Future versions will go into the sandbox until they are reviewed by an "
-"editor."
+"If you have concerns about this add-on's security, copyright issues, or other concerns that an administrator should look into, enter your comments in the area below. They will be sent to "
+"administrators, not the author."
+msgstr ""
+
+#: src/olympia/editors/helpers.py:605
+msgid "This will reject the add-on and remove it from the review queue."
+msgstr ""
+
+#: src/olympia/editors/helpers.py:607
+msgid "Make a comment on this version. The author won't be able to see this."
+msgstr ""
+
+#: src/olympia/editors/helpers.py:611
+msgid "This will reject the files and remove them from the review queue."
+msgstr ""
+
+#: src/olympia/editors/helpers.py:615
+msgid "This will mark the add-on as preliminarily reviewed. Future versions will undergo preliminary review."
+msgstr ""
+
+#: src/olympia/editors/helpers.py:620
+msgid "This will mark the files as preliminarily reviewed. Future versions will undergo preliminary review."
+msgstr ""
+
+#: src/olympia/editors/helpers.py:625
+msgid "Retain preliminary review"
+msgstr ""
+
+#: src/olympia/editors/helpers.py:626
+msgid "This will retain the add-on as preliminarily reviewed. Future versions will undergo preliminary review."
+msgstr ""
+
+#: src/olympia/editors/helpers.py:631
+msgid "This will approve a sandboxed version of a public add-on to appear on the public side."
+msgstr ""
+
+#: src/olympia/editors/helpers.py:634
+msgid "This will reject a version of a public add-on and remove it from the queue."
 msgstr ""
 
 #: src/olympia/editors/helpers.py:637
+msgid "This will mark the add-on and its most recent version and files as public. Future versions will go into the sandbox until they are reviewed by an editor."
+msgstr ""
+
+#: src/olympia/editors/helpers.py:714
 msgid "add-on"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:940 src/olympia/editors/helpers.py:960
+#: src/olympia/editors/helpers.py:1020 src/olympia/editors/helpers.py:1040
 msgid "Flagged"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:944 src/olympia/editors/helpers.py:963
+#: src/olympia/editors/helpers.py:1024 src/olympia/editors/helpers.py:1043
 msgid "Updates"
 msgstr ""
 
@@ -8973,70 +7506,67 @@ msgstr ""
 msgid "A question about your Theme submission"
 msgstr ""
 
-#: src/olympia/editors/views.py:144
+#: src/olympia/editors/views.py:146
 msgid "New Add-ons (Under 5 days)"
 msgstr ""
 
-#: src/olympia/editors/views.py:145
+#: src/olympia/editors/views.py:147
 msgid "Passable (5 to 10 days)"
 msgstr ""
 
-#: src/olympia/editors/views.py:146
+#: src/olympia/editors/views.py:148
 msgid "Overdue (Over 10 days)"
 msgstr ""
 
-#: src/olympia/editors/views.py:532
+#: src/olympia/editors/views.py:539
 msgid "An unknown error occurred"
 msgstr ""
 
-#: src/olympia/editors/views.py:587
+#: src/olympia/editors/views.py:592
 msgid "Self-reviews are not allowed."
 msgstr ""
 
-#: src/olympia/editors/views.py:609
+#: src/olympia/editors/views.py:613
 msgid "Review successfully processed."
 msgstr ""
 
-#: src/olympia/editors/views.py:807
+#: src/olympia/editors/views.py:812
 msgid "was approved"
 msgstr ""
 
-#: src/olympia/editors/views.py:808
+#: src/olympia/editors/views.py:813
 msgid "given preliminary review"
 msgstr ""
 
-#: src/olympia/editors/views.py:809
+#: src/olympia/editors/views.py:814
 msgid "rejected"
 msgstr ""
 
-#: src/olympia/editors/views.py:810
+#: src/olympia/editors/views.py:815
 msgctxt "editors_review_history_nominated_adminreview"
 msgid "escalated"
 msgstr ""
 
-#: src/olympia/editors/views.py:812
+#: src/olympia/editors/views.py:817
 msgid "needs more information"
 msgstr ""
 
-#: src/olympia/editors/views.py:813
+#: src/olympia/editors/views.py:818
 msgid "needs super review"
 msgstr ""
 
-#: src/olympia/editors/views.py:814
+#: src/olympia/editors/views.py:819
 msgid "commented"
 msgstr ""
 
 #: src/olympia/editors/views_themes.py:326
 msgid "{0} theme review successfully processed (+{1} points, {2} total)."
-msgid_plural ""
-"{0} theme reviews successfully processed (+{1} points, {2} total)."
+msgid_plural "{0} theme reviews successfully processed (+{1} points, {2} total)."
 msgstr[0] ""
+msgstr[1] ""
 
 #: src/olympia/editors/views_themes.py:341
-msgid ""
-"Your theme locks have successfully been released. Other reviewers may now "
-"review those released themes. You may have to refresh the page to see the "
-"changes reflected in the table below."
+msgid "Your theme locks have successfully been released. Other reviewers may now review those released themes. You may have to refresh the page to see the changes reflected in the table below."
 msgstr ""
 
 #: src/olympia/editors/templates/editors/abuse_reports.html:4
@@ -9061,9 +7591,7 @@ msgstr ""
 msgid "Return to the Editor Tools homepage"
 msgstr ""
 
-#: src/olympia/editors/templates/editors/base.html:43
-#: src/olympia/editors/templates/editors/themes/base.html:14
-#: src/olympia/editors/templates/editors/themes/base.html:28
+#: src/olympia/editors/templates/editors/base.html:43 src/olympia/editors/templates/editors/themes/base.html:14 src/olympia/editors/templates/editors/themes/base.html:28
 #: src/olympia/editors/templates/editors/themes/queue.html:25
 msgid "Queues"
 msgstr ""
@@ -9072,71 +7600,51 @@ msgstr ""
 msgid "Unlisted Queues"
 msgstr ""
 
-#: src/olympia/editors/templates/editors/base.html:72
-#: src/olympia/editors/templates/editors/performance.html:6
+#: src/olympia/editors/templates/editors/base.html:74 src/olympia/editors/templates/editors/performance.html:6
 msgid "Performance"
 msgstr ""
 
-#: src/olympia/editors/templates/editors/base.html:75
-#: src/olympia/editors/templates/editors/themes/base.html:19
-#: src/olympia/editors/templates/editors/themes/base.html:38
+#: src/olympia/editors/templates/editors/base.html:77 src/olympia/editors/templates/editors/themes/base.html:19 src/olympia/editors/templates/editors/themes/base.html:38
 msgid "Logs"
 msgstr ""
 
-#: src/olympia/editors/templates/editors/base.html:78
-#: src/olympia/editors/templates/editors/reviewlog.html:4
-#: src/olympia/editors/templates/editors/reviewlog.html:27
+#: src/olympia/editors/templates/editors/base.html:80 src/olympia/editors/templates/editors/reviewlog.html:4 src/olympia/editors/templates/editors/reviewlog.html:27
 msgid "Add-on Review Log"
 msgstr ""
 
-#: src/olympia/editors/templates/editors/base.html:80
-#: src/olympia/editors/templates/editors/eventlog.html:4
-#: src/olympia/editors/templates/editors/eventlog.html:8
+#: src/olympia/editors/templates/editors/base.html:82 src/olympia/editors/templates/editors/eventlog.html:4 src/olympia/editors/templates/editors/eventlog.html:8
 #: src/olympia/editors/templates/editors/eventlog_detail.html:4
 msgid "Moderated Review Log"
 msgstr ""
 
-#: src/olympia/editors/templates/editors/base.html:82
-#: src/olympia/editors/templates/editors/beta_signed_log.html:4
-#: src/olympia/editors/templates/editors/beta_signed_log.html:8
+#: src/olympia/editors/templates/editors/base.html:84 src/olympia/editors/templates/editors/beta_signed_log.html:4 src/olympia/editors/templates/editors/beta_signed_log.html:8
 msgid "Signed Beta Files Log"
 msgstr ""
 
-#: src/olympia/editors/templates/editors/base.html:87
-#: src/olympia/editors/templates/editors/includes/daily-message.html:4
+#: src/olympia/editors/templates/editors/base.html:89 src/olympia/editors/templates/editors/includes/daily-message.html:4
 msgid "Announcement"
 msgstr ""
 
 #. "Filter" is a button label (verb)
-#: src/olympia/editors/templates/editors/beta_signed_log.html:17
-#: src/olympia/editors/templates/editors/eventlog.html:24
-#: src/olympia/editors/templates/editors/reviewlog.html:21
-#: src/olympia/editors/templates/editors/themes/macros.html:45
-#: src/olympia/editors/templates/editors/themes/includes/logs_filter_deleted.html:12
+#: src/olympia/editors/templates/editors/beta_signed_log.html:17 src/olympia/editors/templates/editors/eventlog.html:24 src/olympia/editors/templates/editors/reviewlog.html:21
+#: src/olympia/editors/templates/editors/themes/macros.html:45 src/olympia/editors/templates/editors/themes/includes/logs_filter_deleted.html:12
 msgid "Filter"
 msgstr ""
 
-#: src/olympia/editors/templates/editors/beta_signed_log.html:23
-#: src/olympia/editors/templates/editors/eventlog.html:30
-#: src/olympia/editors/templates/editors/reviewlog.html:34
+#: src/olympia/editors/templates/editors/beta_signed_log.html:23 src/olympia/editors/templates/editors/eventlog.html:30 src/olympia/editors/templates/editors/reviewlog.html:34
 #: src/olympia/editors/templates/editors/themes/logs.html:16
 msgid "Date"
 msgstr ""
 
-#: src/olympia/editors/templates/editors/beta_signed_log.html:24
-#: src/olympia/editors/templates/editors/eventlog.html:31
-#: src/olympia/editors/templates/editors/reviewlog.html:35
+#: src/olympia/editors/templates/editors/beta_signed_log.html:24 src/olympia/editors/templates/editors/eventlog.html:31 src/olympia/editors/templates/editors/reviewlog.html:35
 msgid "Event"
 msgstr ""
 
-#: src/olympia/editors/templates/editors/beta_signed_log.html:37
-#: src/olympia/editors/templates/editors/eventlog.html:44
-#: src/olympia/editors/templates/editors/home.html:180
+#: src/olympia/editors/templates/editors/beta_signed_log.html:37 src/olympia/editors/templates/editors/eventlog.html:44 src/olympia/editors/templates/editors/home.html:180
 msgid "More details."
 msgstr ""
 
-#: src/olympia/editors/templates/editors/beta_signed_log.html:46
-#: src/olympia/editors/templates/editors/eventlog.html:53
+#: src/olympia/editors/templates/editors/beta_signed_log.html:46 src/olympia/editors/templates/editors/eventlog.html:53
 msgid "No events found for this period."
 msgstr ""
 
@@ -9172,30 +7680,31 @@ msgstr ""
 msgid "Full Review ({num})"
 msgid_plural "Full Reviews ({num})"
 msgstr[0] ""
+msgstr[1] ""
 
 #: src/olympia/editors/templates/editors/home.html:18
 msgid "Pending Update ({num})"
 msgid_plural "Pending Updates ({num})"
 msgstr[0] ""
+msgstr[1] ""
 
 #: src/olympia/editors/templates/editors/home.html:25
 msgid "Preliminary Review ({num})"
 msgid_plural "Preliminary Reviews ({num})"
 msgstr[0] ""
+msgstr[1] ""
 
-#: src/olympia/editors/templates/editors/home.html:36
-#: src/olympia/editors/templates/editors/home.html:86
+#: src/olympia/editors/templates/editors/home.html:36 src/olympia/editors/templates/editors/home.html:86
 msgid "Current waiting times:"
 msgstr ""
 
-#: src/olympia/editors/templates/editors/home.html:44
-#: src/olympia/editors/templates/editors/home.html:94
+#: src/olympia/editors/templates/editors/home.html:44 src/olympia/editors/templates/editors/home.html:94
 msgid "{0} add-on"
 msgid_plural "{0} add-ons"
 msgstr[0] ""
+msgstr[1] ""
 
-#: src/olympia/editors/templates/editors/home.html:45
-#: src/olympia/editors/templates/editors/home.html:95
+#: src/olympia/editors/templates/editors/home.html:45 src/olympia/editors/templates/editors/home.html:95
 #, python-format
 msgid "{0}%%"
 msgstr ""
@@ -9204,25 +7713,25 @@ msgstr ""
 msgid "Unlisted Full Review ({num})"
 msgid_plural "Unlisted Full Reviews ({num})"
 msgstr[0] ""
+msgstr[1] ""
 
 #: src/olympia/editors/templates/editors/home.html:68
 msgid "Unlisted Pending Update ({num})"
 msgid_plural "Unlisted Pending Updates ({num})"
 msgstr[0] ""
+msgstr[1] ""
 
 #: src/olympia/editors/templates/editors/home.html:75
 msgid "Unlisted Preliminary Review ({num})"
 msgid_plural "Unlisted Preliminary Reviews ({num})"
 msgstr[0] ""
+msgstr[1] ""
 
-#: src/olympia/editors/templates/editors/home.html:109
-#: src/olympia/editors/templates/editors/performance.html:37
-#: src/olympia/editors/templates/editors/themes/home.html:54
+#: src/olympia/editors/templates/editors/home.html:109 src/olympia/editors/templates/editors/performance.html:37 src/olympia/editors/templates/editors/themes/home.html:54
 msgid "Total Reviews"
 msgstr ""
 
-#: src/olympia/editors/templates/editors/home.html:110
-#: src/olympia/editors/templates/editors/themes/home.html:55
+#: src/olympia/editors/templates/editors/home.html:110 src/olympia/editors/templates/editors/themes/home.html:55
 msgid "Reviews This Month"
 msgstr ""
 
@@ -9230,8 +7739,7 @@ msgstr ""
 msgid "New Editors"
 msgstr ""
 
-#: src/olympia/editors/templates/editors/home.html:126
-#: src/olympia/editors/templates/editors/home.html:141
+#: src/olympia/editors/templates/editors/home.html:126 src/olympia/editors/templates/editors/home.html:141
 msgid "You're #{0} with {1} reviews"
 msgstr ""
 
@@ -9240,14 +7748,13 @@ msgstr ""
 msgid "Moderated Review ({num})"
 msgid_plural "Moderated Reviews ({num})"
 msgstr[0] ""
+msgstr[1] ""
 
-#: src/olympia/editors/templates/editors/leaderboard.html:3
-#: src/olympia/editors/templates/editors/includes/reviewers_score_bar.html:56
+#: src/olympia/editors/templates/editors/leaderboard.html:3 src/olympia/editors/templates/editors/includes/reviewers_score_bar.html:56
 msgid "Reviewer Leaderboard"
 msgstr ""
 
-#: src/olympia/editors/templates/editors/leaderboard.html:18
-#: src/olympia/editors/templates/editors/performance.html:65
+#: src/olympia/editors/templates/editors/leaderboard.html:18 src/olympia/editors/templates/editors/performance.html:65
 msgid "No review points awarded yet."
 msgstr ""
 
@@ -9267,8 +7774,7 @@ msgstr ""
 msgid "Update message of the day"
 msgstr ""
 
-#: src/olympia/editors/templates/editors/motd.html:15
-#: src/olympia/editors/templates/editors/review.html:224
+#: src/olympia/editors/templates/editors/motd.html:15 src/olympia/editors/templates/editors/review.html:224
 msgid "Save"
 msgstr ""
 
@@ -9336,49 +7842,45 @@ msgstr ""
 msgid "clear search"
 msgstr ""
 
-#: src/olympia/editors/templates/editors/queue.html:72
-#: src/olympia/editors/templates/editors/queue.html:122
+#: src/olympia/editors/templates/editors/queue.html:78 src/olympia/editors/templates/editors/queue.html:128
 msgid "Process Reviews"
 msgstr ""
 
-#: src/olympia/editors/templates/editors/queue.html:80
+#: src/olympia/editors/templates/editors/queue.html:86
 msgid "Moderation actions:"
 msgstr ""
 
-#: src/olympia/editors/templates/editors/queue.html:90
+#: src/olympia/editors/templates/editors/queue.html:96
 #, python-format
 msgid "by %(user)s on %(date)s %(stars)s (%(locale)s)"
 msgstr ""
 
-#: src/olympia/editors/templates/editors/queue.html:106
+#: src/olympia/editors/templates/editors/queue.html:112
 #, python-format
-msgid ""
-"<strong>%(reason)s</strong> <span class=\"light\">Flagged by %(user)s on "
-"%(date)s</span>"
+msgid "<strong>%(reason)s</strong> <span class=\"light\">Flagged by %(user)s on %(date)s</span>"
 msgstr ""
 
-#: src/olympia/editors/templates/editors/queue.html:119
-msgid "All reviews have been moderated.  Good work!"
+#: src/olympia/editors/templates/editors/queue.html:125
+msgid "All reviews have been moderated. Good work!"
 msgstr ""
 
-#: src/olympia/editors/templates/editors/queue.html:161
+#: src/olympia/editors/templates/editors/queue.html:167
 msgid "Version Notes / Notes for Reviewer"
 msgstr ""
 
-#: src/olympia/editors/templates/editors/queue.html:169
+#: src/olympia/editors/templates/editors/queue.html:175
 msgid "There are currently no add-ons of this type to review."
 msgstr ""
 
-#: src/olympia/editors/templates/editors/queue.html:181
-#: src/olympia/editors/templates/editors/themes/queue_list.html:85
+#: src/olympia/editors/templates/editors/queue.html:187 src/olympia/editors/templates/editors/themes/queue_list.html:85
 msgid "Helpful Links:"
 msgstr ""
 
-#: src/olympia/editors/templates/editors/queue.html:182
+#: src/olympia/editors/templates/editors/queue.html:188
 msgid "Add-on Policy"
 msgstr ""
 
-#: src/olympia/editors/templates/editors/queue.html:184
+#: src/olympia/editors/templates/editors/queue.html:190
 msgid "Editors' Guide"
 msgstr ""
 
@@ -9391,16 +7893,13 @@ msgstr ""
 msgid "Add-on user change history"
 msgstr ""
 
-#: src/olympia/editors/templates/editors/review.html:52
-#: src/olympia/editors/templates/editors/review.html:266
+#: src/olympia/editors/templates/editors/review.html:52 src/olympia/editors/templates/editors/review.html:266
 msgid "Add-on History"
 msgstr ""
 
 #: src/olympia/editors/templates/editors/review.html:64
 #, python-format
-msgid ""
-"Version %(version)s &middot; %(created)s <span class=\"light\">&middot; "
-"%(version_status)s</span>"
+msgid "Version %(version)s &middot; %(created)s <span class=\"light\">&middot; %(version_status)s</span>"
 msgstr ""
 
 #: src/olympia/editors/templates/editors/review.html:73
@@ -9424,17 +7923,14 @@ msgid "This version has not been reviewed."
 msgstr ""
 
 #: src/olympia/editors/templates/editors/review.html:154
-msgid ""
-"You can still submit this form, however only do so if you know it won't "
-"conflict."
+msgid "You can still submit this form, however only do so if you know it won't conflict."
 msgstr ""
 
 #: src/olympia/editors/templates/editors/review.html:161
 msgid "Insert canned response..."
 msgstr ""
 
-#: src/olympia/editors/templates/editors/review.html:167
-#: src/olympia/files/templates/files/viewer.html:54
+#: src/olympia/editors/templates/editors/review.html:167 src/olympia/files/templates/files/viewer.html:54
 msgid "Files:"
 msgstr ""
 
@@ -9443,23 +7939,18 @@ msgid "Tested on:"
 msgstr ""
 
 #: src/olympia/editors/templates/editors/review.html:220
-msgid ""
-"<strong>Warning!</strong> Another user was viewing this page before you."
+msgid "<strong>Warning!</strong> Another user was viewing this page before you."
 msgstr ""
 
 #: src/olympia/editors/templates/editors/review.html:237
-msgid ""
-"The whiteboard is the place to exchange information relevant to\n"
-"               this addon (whatever the version), between the developer and the\n"
-"               editor. This is visible and editable by both."
+msgid "The whiteboard is the place to exchange information relevant to this addon (whatever the version), between the developer and the editor. This is visible and editable by both."
 msgstr ""
 
 #: src/olympia/editors/templates/editors/review.html:241
 msgid "Update the whiteboard"
 msgstr ""
 
-#: src/olympia/editors/templates/editors/review.html:257
-#: src/olympia/editors/templates/editors/review.html:258
+#: src/olympia/editors/templates/editors/review.html:257 src/olympia/editors/templates/editors/review.html:258
 msgid "(admin)"
 msgstr ""
 
@@ -9487,18 +7978,15 @@ msgstr ""
 msgid "Add-on has been deleted."
 msgstr ""
 
-#: src/olympia/editors/templates/editors/reviewlog.html:59
-#: src/olympia/editors/templates/editors/themes/logs.html:36
+#: src/olympia/editors/templates/editors/reviewlog.html:59 src/olympia/editors/templates/editors/themes/logs.html:36
 msgid "Show Comments"
 msgstr ""
 
-#: src/olympia/editors/templates/editors/reviewlog.html:60
-#: src/olympia/editors/templates/editors/themes/logs.html:37
+#: src/olympia/editors/templates/editors/reviewlog.html:60 src/olympia/editors/templates/editors/themes/logs.html:37
 msgid "Hide Comments"
 msgstr ""
 
-#: src/olympia/editors/templates/editors/reviewlog.html:72
-#: src/olympia/editors/templates/editors/themes/logs.html:54
+#: src/olympia/editors/templates/editors/reviewlog.html:72 src/olympia/editors/templates/editors/themes/logs.html:54
 msgid "No reviews found for this period."
 msgstr ""
 
@@ -9556,11 +8044,8 @@ msgstr ""
 msgid "You have <span>{0}</span> points."
 msgstr ""
 
-#: src/olympia/editors/templates/editors/includes/search_results_themes.html:6
-#: src/olympia/editors/templates/editors/themes/history_table.html:7
-#: src/olympia/editors/templates/editors/themes/logs.html:19
-#: src/olympia/editors/templates/editors/themes/queue_list.html:49
-#: src/olympia/editors/templates/editors/themes/single.html:26
+#: src/olympia/editors/templates/editors/includes/search_results_themes.html:6 src/olympia/editors/templates/editors/themes/history_table.html:7
+#: src/olympia/editors/templates/editors/themes/logs.html:19 src/olympia/editors/templates/editors/themes/queue_list.html:49 src/olympia/editors/templates/editors/themes/single.html:26
 #: src/olympia/editors/templates/editors/themes/themes.html:45
 msgid "Reviewer"
 msgstr ""
@@ -9585,8 +8070,7 @@ msgstr ""
 msgid "Review Date"
 msgstr ""
 
-#: src/olympia/editors/templates/editors/themes/history_table.html:9
-#: src/olympia/editors/templates/editors/themes/logs.html:18
+#: src/olympia/editors/templates/editors/themes/history_table.html:9 src/olympia/editors/templates/editors/themes/logs.html:18
 msgid "Action"
 msgstr ""
 
@@ -9602,16 +8086,19 @@ msgstr ""
 msgid "{num} Pending Theme Review"
 msgid_plural "{num} Pending Theme Reviews"
 msgstr[0] ""
+msgstr[1] ""
 
 #: src/olympia/editors/templates/editors/themes/home.html:27
 msgid "{num} Flagged Review"
 msgid_plural "{num} Flagged Reviews"
 msgstr[0] ""
+msgstr[1] ""
 
 #: src/olympia/editors/templates/editors/themes/home.html:34
 msgid "{num} Update"
 msgid_plural "{num} Updates"
 msgstr[0] ""
+msgstr[1] ""
 
 #: src/olympia/editors/templates/editors/themes/logs.html:4
 msgid "Theme Review Log"
@@ -9730,7 +8217,7 @@ msgstr "მხატვრისთვვის შეკითხვის დ�
 msgid "Describe your reason for flagging"
 msgstr ""
 
-#: src/olympia/files/forms.py:88
+#: src/olympia/files/forms.py:90
 msgid "Cannot diff a version against itself"
 msgstr ""
 
@@ -9748,9 +8235,7 @@ msgid "Problems decoding {0}."
 msgstr ""
 
 #: src/olympia/files/helpers.py:186
-msgid ""
-"This file is not viewable online. Please download the file to view the "
-"contents."
+msgid "This file is not viewable online. Please download the file to view the contents."
 msgstr ""
 
 #: src/olympia/files/helpers.py:194
@@ -9767,53 +8252,51 @@ msgstr ""
 msgid "There was an error accessing file %s."
 msgstr ""
 
-#: src/olympia/files/utils.py:343
+#: src/olympia/files/utils.py:340
 msgid "Could not parse uploaded file."
 msgstr ""
 
-#: src/olympia/files/utils.py:380
+#: src/olympia/files/utils.py:377
 msgid "Invalid file name in archive: {0}"
 msgstr ""
 
-#: src/olympia/files/utils.py:388
+#: src/olympia/files/utils.py:385
 msgid "File exceeding size limit in archive: {0}"
 msgstr ""
 
-#: src/olympia/files/utils.py:439
+#: src/olympia/files/utils.py:436
 msgid "Invalid archive."
 msgstr ""
 
-#: src/olympia/files/utils.py:529 src/olympia/files/utils.py:532
+#: src/olympia/files/utils.py:526 src/olympia/files/utils.py:529
 msgid "Could not parse the manifest file."
 msgstr ""
 
-#: src/olympia/files/utils.py:551
+#: src/olympia/files/utils.py:548
 msgid "Could not find an add-on ID."
 msgstr ""
 
-#: src/olympia/files/utils.py:554
+#: src/olympia/files/utils.py:551
 msgid "Add-on ID must be 64 characters or less."
 msgstr ""
 
-#: src/olympia/files/utils.py:556
+#: src/olympia/files/utils.py:553
 msgid "Add-on ID doesn't match add-on."
 msgstr ""
 
-#: src/olympia/files/utils.py:564
+#: src/olympia/files/utils.py:561
 msgid "Duplicate add-on ID found."
 msgstr ""
 
-#: src/olympia/files/utils.py:567
+#: src/olympia/files/utils.py:564
 msgid "Version numbers should have fewer than 32 characters."
 msgstr ""
 
-#: src/olympia/files/utils.py:570
-msgid ""
-"Version numbers should only contain letters, numbers, and these punctuation "
-"characters: +*.-_."
+#: src/olympia/files/utils.py:567
+msgid "Version numbers should only contain letters, numbers, and these punctuation characters: +*.-_."
 msgstr ""
 
-#: src/olympia/files/utils.py:587
+#: src/olympia/files/utils.py:584
 msgid "<em:type> doesn't match add-on"
 msgstr ""
 
@@ -9831,9 +8314,7 @@ msgstr ""
 
 #: src/olympia/files/templates/files/file.html:4
 #, python-format
-msgid ""
-"Version: %(version)s &bull; Size: %(size)s &bull; MD5 hash: %(md5)s &bull; "
-"Mimetype: %(mimetype)s"
+msgid "Version: %(version)s &bull; Size: %(size)s &bull; MD5 hash: %(md5)s &bull; Mimetype: %(mimetype)s"
 msgstr ""
 
 #: src/olympia/files/templates/files/viewer.html:4
@@ -9872,48 +8353,39 @@ msgstr ""
 msgid "Tab stops:"
 msgstr ""
 
-#: src/olympia/files/templates/files/viewer.html:79
-#: src/olympia/files/templates/files/viewer.html:80
+#: src/olympia/files/templates/files/viewer.html:79 src/olympia/files/templates/files/viewer.html:80
 msgid "Up file"
 msgstr ""
 
-#: src/olympia/files/templates/files/viewer.html:84
-#: src/olympia/files/templates/files/viewer.html:85
+#: src/olympia/files/templates/files/viewer.html:84 src/olympia/files/templates/files/viewer.html:85
 msgid "Down file"
 msgstr ""
 
-#: src/olympia/files/templates/files/viewer.html:90
-#: src/olympia/files/templates/files/viewer.html:91
+#: src/olympia/files/templates/files/viewer.html:90 src/olympia/files/templates/files/viewer.html:91
 msgid "Previous diff"
 msgstr ""
 
-#: src/olympia/files/templates/files/viewer.html:93
-#: src/olympia/files/templates/files/viewer.html:94
+#: src/olympia/files/templates/files/viewer.html:93 src/olympia/files/templates/files/viewer.html:94
 msgid "Previous note"
 msgstr ""
 
-#: src/olympia/files/templates/files/viewer.html:100
-#: src/olympia/files/templates/files/viewer.html:101
+#: src/olympia/files/templates/files/viewer.html:100 src/olympia/files/templates/files/viewer.html:101
 msgid "Next diff"
 msgstr ""
 
-#: src/olympia/files/templates/files/viewer.html:103
-#: src/olympia/files/templates/files/viewer.html:104
+#: src/olympia/files/templates/files/viewer.html:103 src/olympia/files/templates/files/viewer.html:104
 msgid "Next note"
 msgstr ""
 
-#: src/olympia/files/templates/files/viewer.html:109
-#: src/olympia/files/templates/files/viewer.html:110
+#: src/olympia/files/templates/files/viewer.html:109 src/olympia/files/templates/files/viewer.html:110
 msgid "Expand all"
 msgstr ""
 
-#: src/olympia/files/templates/files/viewer.html:114
-#: src/olympia/files/templates/files/viewer.html:115
+#: src/olympia/files/templates/files/viewer.html:114 src/olympia/files/templates/files/viewer.html:115
 msgid "Hide or unhide tree"
 msgstr ""
 
-#: src/olympia/files/templates/files/viewer.html:119
-#: src/olympia/files/templates/files/viewer.html:120
+#: src/olympia/files/templates/files/viewer.html:119 src/olympia/files/templates/files/viewer.html:120
 msgid "Wrap or unwrap text"
 msgstr ""
 
@@ -9923,6 +8395,10 @@ msgstr ""
 
 #: src/olympia/files/templates/files/viewer.html:134
 msgid "Fetching file."
+msgstr ""
+
+#: src/olympia/legacy_api/views.py:255
+msgid "Not implemented yet."
 msgstr ""
 
 #: src/olympia/lib/constants.py:6
@@ -10581,12 +9057,7 @@ msgstr ""
 msgid "Zimbabwe Dollar"
 msgstr ""
 
-#: src/olympia/lib/video/ffmpeg.py:112 src/olympia/lib/video/totem.py:81
-msgid "Videos must be in WebM."
-msgstr ""
-
-#: src/olympia/pages/templates/pages/about.lhtml:3
-#: src/olympia/pages/templates/pages/about.lhtml:10
+#: src/olympia/pages/templates/pages/about.lhtml:3 src/olympia/pages/templates/pages/about.lhtml:10
 msgid "About Mozilla Add-ons"
 msgstr ""
 
@@ -10596,11 +9067,8 @@ msgstr ""
 
 #: src/olympia/pages/templates/pages/about.lhtml:13
 msgid ""
-"addons.mozilla.org, commonly known as \"AMO\", is Mozilla's official site "
-"for add-ons to Mozilla software, such as Firefox, Thunderbird, and "
-"SeaMonkey. Add-ons let you add new features and change the way your browser "
-"or application works.  Take a look around and explore the thousands of ways "
-"to customize the way you do things online."
+"addons.mozilla.org, commonly known as \"AMO\", is Mozilla's official site for add-ons to Mozilla software, such as Firefox, Thunderbird, and SeaMonkey. Add-ons let you add new features and change "
+"the way your browser or application works. Take a look around and explore the thousands of ways to customize the way you do things online."
 msgstr ""
 
 #: src/olympia/pages/templates/pages/about.lhtml:19
@@ -10609,11 +9077,8 @@ msgstr ""
 
 #: src/olympia/pages/templates/pages/about.lhtml:20
 msgid ""
-"The add-ons listed here have been created by thousands of developers from "
-"our community, ranging from individual hobbyists to large corporations. All "
-"publicly listed add-ons are reviewed by a team of editors before being "
-"released. Add-ons marked as Experimental have not been reviewed and should "
-"only be installed with caution."
+"The add-ons listed here have been created by thousands of developers from our community, ranging from individual hobbyists to large corporations. All publicly listed add-ons are reviewed by a team "
+"of editors before being released. Add-ons marked as Experimental have not been reviewed and should only be installed with caution."
 msgstr ""
 
 #: src/olympia/pages/templates/pages/about.lhtml:26
@@ -10621,30 +9086,22 @@ msgid "How do I keep up with what's happening at AMO?"
 msgstr ""
 
 #: src/olympia/pages/templates/pages/about.lhtml:27
-msgid ""
-"There are several ways to find out the latest news from the world of add-"
-"ons:"
+msgid "There are several ways to find out the latest news from the world of add-ons:"
 msgstr ""
 
 #: src/olympia/pages/templates/pages/about.lhtml:29
 #, python-format
-msgid ""
-"Our <a href=\"%(url)s\">Add-ons Blog</a> is regularly updated with "
-"information for both add-on enthusiasts and developers."
+msgid "Our <a href=\"%(url)s\">Add-ons Blog</a> is regularly updated with information for both add-on enthusiasts and developers."
 msgstr ""
 
 #: src/olympia/pages/templates/pages/about.lhtml:32
 #, python-format
-msgid ""
-"We often post news, tips, and tricks to our Twitter account, <a "
-"href=\"%(url)s\">mozamo</a>"
+msgid "We often post news, tips, and tricks to our Twitter account, <a href=\"%(url)s\">mozamo</a>"
 msgstr ""
 
 #: src/olympia/pages/templates/pages/about.lhtml:34
 #, python-format
-msgid ""
-"Our <a href=\"%(url)s\">forums</a> are a good place to interact with the "
-"add-ons community and discuss upcoming changes to AMO."
+msgid "Our <a href=\"%(url)s\">forums</a> are a good place to interact with the add-ons community and discuss upcoming changes to AMO."
 msgstr ""
 
 #: src/olympia/pages/templates/pages/about.lhtml:39
@@ -10652,37 +9109,27 @@ msgid "This sounds great! How can I get involved?"
 msgstr ""
 
 #: src/olympia/pages/templates/pages/about.lhtml:40
-msgid ""
-"There are plenty of ways to get involved. If you're on the technical side:"
+msgid "There are plenty of ways to get involved. If you're on the technical side:"
 msgstr ""
 
 #: src/olympia/pages/templates/pages/about.lhtml:42
 #, python-format
-msgid ""
-"<a href=\"%(url)s\">Make your own add-on</a>. We provide free hosting and "
-"update services and can help you reach a large audience of users."
+msgid "<a href=\"%(url)s\">Make your own add-on</a>. We provide free hosting and update services and can help you reach a large audience of users."
 msgstr ""
 
 #: src/olympia/pages/templates/pages/about.lhtml:45
 #, python-format
-msgid ""
-"If you have add-on development experience, <a href=\"%(url)s\"> become an "
-"editor</a>! Our editors are add-on fans with a technical background who "
-"review add-ons for code quality and stability."
+msgid "If you have add-on development experience, <a href=\"%(url)s\"> become an editor</a>! Our editors are add-on fans with a technical background who review add-ons for code quality and stability."
 msgstr ""
 
 #: src/olympia/pages/templates/pages/about.lhtml:49
 #, python-format
 msgid ""
-"Help improve this website. It's open source, and you can file bugs and "
-"submit patches. <a href=\"%(url)s\"> GitHub</a> contains all of our current "
-"bugs, legacy bugs can still be found in Bugzilla."
+"Help improve this website. It's open source, and you can file bugs and submit patches. <a href=\"%(url)s\"> GitHub</a> contains all of our current bugs, legacy bugs can still be found in Bugzilla."
 msgstr ""
 
 #: src/olympia/pages/templates/pages/about.lhtml:55
-msgid ""
-"If you're interested in add-ons but not quite as technical, there are still "
-"ways to help:"
+msgid "If you're interested in add-ons but not quite as technical, there are still ways to help:"
 msgstr ""
 
 #: src/olympia/pages/templates/pages/about.lhtml:58
@@ -10695,9 +9142,7 @@ msgid "Participate in our <a href=\"%(url)s\">forums</a>."
 msgstr ""
 
 #: src/olympia/pages/templates/pages/about.lhtml:61
-msgid ""
-"Review add-ons on the site. Add-on authors are more likely to improve their "
-"add-ons and write new ones when they know people appreciate their work."
+msgid "Review add-ons on the site. Add-on authors are more likely to improve their add-ons and write new ones when they know people appreciate their work."
 msgstr ""
 
 #: src/olympia/pages/templates/pages/about.lhtml:66
@@ -10707,16 +9152,13 @@ msgstr ""
 #: src/olympia/pages/templates/pages/about.lhtml:67
 #, python-format
 msgid ""
-"A good place to start is our <a href=\"%(faq_url)s\"><abbr "
-"title=\"Frequently Asked Questions\">FAQ</abbr></a>. If you don't find an "
-"answer there, you can <a href=\"%(forum_url)s\"> ask on our forums</a>."
+"A good place to start is our <a href=\"%(faq_url)s\"><abbr title=\"Frequently Asked Questions\">FAQ</abbr></a>. If you don't find an answer there, you can <a href=\"%(forum_url)s\"> ask on our "
+"forums</a>."
 msgstr ""
 
 #: src/olympia/pages/templates/pages/about.lhtml:72
 #, python-format
-msgid ""
-"If you really need to contact someone from the Mozilla team, please see our "
-"<a href=\"%(url)s\"> contact information</a> page."
+msgid "If you really need to contact someone from the Mozilla team, please see our <a href=\"%(url)s\"> contact information</a> page."
 msgstr ""
 
 #: src/olympia/pages/templates/pages/about.lhtml:76
@@ -10726,10 +9168,8 @@ msgstr ""
 #: src/olympia/pages/templates/pages/about.lhtml:77
 #, python-format
 msgid ""
-"Over the years, many people have contributed to this website, including both"
-" volunteers from the community and a dedicated AMO team. A list of "
-"significant contributors can be found on our <a href=\"%(url)s\"> Site "
-"Credits</a> page."
+"Over the years, many people have contributed to this website, including both volunteers from the community and a dedicated AMO team. A list of significant contributors can be found on our <a href="
+"\"%(url)s\"> Site Credits</a> page."
 msgstr ""
 
 #: src/olympia/pages/templates/pages/acr_firstrun.html:4
@@ -10741,9 +9181,7 @@ msgid "Add-on Compatibility Reporter has been installed"
 msgstr ""
 
 #: src/olympia/pages/templates/pages/acr_firstrun.html:28
-msgid ""
-"It’s easy to help us make sure add-ons are updated in time for the release "
-"of the next version of Firefox."
+msgid "It’s easy to help us make sure add-ons are updated in time for the release of the next version of Firefox."
 msgstr ""
 
 #: src/olympia/pages/templates/pages/acr_firstrun.html:35
@@ -10752,35 +9190,27 @@ msgstr ""
 
 #: src/olympia/pages/templates/pages/acr_firstrun.html:40
 msgid ""
-"As you start browsing and using your add-ons, take careful note of anything "
-"that seems different from when you last used the extension. This might be a "
-"display glitch, such as a menu item missing, or something more serious, like"
-" the add-on not working at all or showing errors."
+"As you start browsing and using your add-ons, take careful note of anything that seems different from when you last used the extension. This might be a display glitch, such as a menu item missing, "
+"or something more serious, like the add-on not working at all or showing errors."
 msgstr ""
 
 #: src/olympia/pages/templates/pages/acr_firstrun.html:49
 msgid ""
-"Once you know whether a particular add-on works properly or has problems, "
-"open the Add-ons Manager and click Compatibility next to the add-on to let "
-"Mozilla know what you found in your testing. Submitting a report will help "
-"us tell the add-on developer whether their add-on is working properly in "
-"this version or might need some fixes."
+"Once you know whether a particular add-on works properly or has problems, open the Add-ons Manager and click Compatibility next to the add-on to let Mozilla know what you found in your testing. "
+"Submitting a report will help us tell the add-on developer whether their add-on is working properly in this version or might need some fixes."
 msgstr ""
 
 #: src/olympia/pages/templates/pages/acr_firstrun.html:61
 #, python-format
 msgid ""
-"If you upgrade to a new version of Firefox or update your add-ons, your "
-"reports for the old versions will be hidden to allow you to test the new "
-"version. If you have any questions, please ask in <a href=\"%(url)s\">our "
-"forums</a>."
+"If you upgrade to a new version of Firefox or update your add-ons, your reports for the old versions will be hidden to allow you to test the new version. If you have any questions, please ask in <a "
+"href=\"%(url)s\">our forums</a>."
 msgstr ""
 
 #: src/olympia/pages/templates/pages/acr_firstrun.html:69
 msgid ""
-"Thousands of add-ons are made by our community every year, and your "
-"assistance with compatibility testing helps us make sure these add-ons stay "
-"useful as we strive to provide a great user experience."
+"Thousands of add-ons are made by our community every year, and your assistance with compatibility testing helps us make sure these add-ons stay useful as we strive to provide a great user "
+"experience."
 msgstr ""
 
 #: src/olympia/pages/templates/pages/acr_firstrun.html:75
@@ -10792,9 +9222,7 @@ msgid "Site Credits"
 msgstr ""
 
 #: src/olympia/pages/templates/pages/credits.html:12
-msgid ""
-"Mozilla would like to thank the following people for their contributions to "
-"the addons.mozilla.org project over the years:"
+msgid "Mozilla would like to thank the following people for their contributions to the addons.mozilla.org project over the years:"
 msgstr ""
 
 #: src/olympia/pages/templates/pages/credits.html:18
@@ -10828,73 +9256,57 @@ msgstr ""
 
 #: src/olympia/pages/templates/pages/credits.html:59
 msgid ""
-"Some icons used are from the <a "
-"href=\"http://www.famfamfam.com/lab/icons/silk/\">famfamfam Silk Icon "
-"Set</a>, licensed under a <a "
-"href=\"http://creativecommons.org/licenses/by/2.5/\">Creative Commons "
-"Attribution 2.5 License</a>."
+"Some icons used are from the <a href=\"http://www.famfamfam.com/lab/icons/silk/\">famfamfam Silk Icon Set</a>, licensed under a <a href=\"http://creativecommons.org/licenses/by/2.5/\">Creative "
+"Commons Attribution 2.5 License</a>."
 msgstr ""
 
 #: src/olympia/pages/templates/pages/credits.html:60
 msgid ""
-"Some icons used are from the <a href=\"http://www.fatcow.com/free-"
-"icons/\">FatCow Farm-Fresh Web Icons Set</a>, licensed under a <a "
-"href=\"http://creativecommons.org/licenses/by/3.0/us/\">Creative Commons "
-"Attribution 3.0 License</a>."
+"Some icons used are from the <a href=\"http://www.fatcow.com/free-icons/\">FatCow Farm-Fresh Web Icons Set</a>, licensed under a <a href=\"http://creativecommons.org/licenses/by/3.0/us/\">Creative "
+"Commons Attribution 3.0 License</a>."
 msgstr ""
 
 #: src/olympia/pages/templates/pages/credits.html:61
 msgid ""
-"Some pages use elements of <a "
-"href=\"http://shop.highsoft.com/highcharts.html\">Highcharts</a> (non-"
-"commercial), licensed under a <a href=\"http://creativecommons.org/licenses"
-"/by-nc/3.0/\">Creative Commons Attribution-NonCommercial 3.0 License</a>."
+"Some pages use elements of <a href=\"http://shop.highsoft.com/highcharts.html\">Highcharts</a> (non-commercial), licensed under a <a href=\"http://creativecommons.org/licenses/by-nc/3.0/\">Creative "
+"Commons Attribution-NonCommercial 3.0 License</a>."
 msgstr ""
 
 #: src/olympia/pages/templates/pages/credits.html:65
 #, python-format
-msgid ""
-"For information on contributing, please see our <a href=\"%(url)s\">wiki "
-"page</a>."
+msgid "For information on contributing, please see our <a href=\"%(url)s\">wiki page</a>."
 msgstr ""
 
 #: src/olympia/pages/templates/pages/dev_faq.html:4
 msgid "Developer FAQ"
 msgstr ""
 
-#: src/olympia/pages/templates/pages/dev_faq.html:31
-#: src/olympia/pages/templates/pages/review_guide.html:33
+#: src/olympia/pages/templates/pages/dev_faq.html:31 src/olympia/pages/templates/pages/review_guide.html:33
 msgid "Sections"
 msgstr ""
 
-#: src/olympia/pages/templates/pages/dev_faq.html:33
-#: src/olympia/pages/templates/pages/dev_faq.html:45
+#: src/olympia/pages/templates/pages/dev_faq.html:33 src/olympia/pages/templates/pages/dev_faq.html:45
 msgid "Developing an Add-on"
 msgstr ""
 
 #. Heading for a list of resources for developers
-#: src/olympia/pages/templates/pages/dev_faq.html:34
-#: src/olympia/pages/templates/pages/dev_faq.html:208
+#: src/olympia/pages/templates/pages/dev_faq.html:34 src/olympia/pages/templates/pages/dev_faq.html:208
 msgid "Support Resources"
 msgstr ""
 
-#: src/olympia/pages/templates/pages/dev_faq.html:35
-#: src/olympia/pages/templates/pages/dev_faq.html:261
+#: src/olympia/pages/templates/pages/dev_faq.html:35 src/olympia/pages/templates/pages/dev_faq.html:261
 msgid "Contributing your Add-on"
 msgstr ""
 
-#: src/olympia/pages/templates/pages/dev_faq.html:36
-#: src/olympia/pages/templates/pages/dev_faq.html:381
+#: src/olympia/pages/templates/pages/dev_faq.html:36 src/olympia/pages/templates/pages/dev_faq.html:381
 msgid "Add-on Review Process"
 msgstr ""
 
-#: src/olympia/pages/templates/pages/dev_faq.html:37
-#: src/olympia/pages/templates/pages/dev_faq.html:444
+#: src/olympia/pages/templates/pages/dev_faq.html:37 src/olympia/pages/templates/pages/dev_faq.html:444
 msgid "Managing Your Add-on"
 msgstr ""
 
-#: src/olympia/pages/templates/pages/dev_faq.html:39
-#: src/olympia/pages/templates/pages/dev_faq.html:528
+#: src/olympia/pages/templates/pages/dev_faq.html:39 src/olympia/pages/templates/pages/dev_faq.html:528
 msgid "References for Open Source Licenses"
 msgstr ""
 
@@ -10904,10 +9316,7 @@ msgstr ""
 
 #: src/olympia/pages/templates/pages/dev_faq.html:47
 #, python-format
-msgid ""
-"<h3>How do I build an Add-on?</h3> <p> Mozilla provides documentation on how"
-" to build an add-on via the <a href=\"%(url)s\">Mozilla Developer "
-"Network</a>. </p>"
+msgid "<h3>How do I build an Add-on?</h3> <p> Mozilla provides documentation on how to build an add-on via the <a href=\"%(url)s\">Mozilla Developer Network</a>. </p>"
 msgstr ""
 
 #: src/olympia/pages/templates/pages/dev_faq.html:55
@@ -10928,9 +9337,8 @@ msgstr ""
 
 #: src/olympia/pages/templates/pages/dev_faq.html:68
 msgid ""
-"You will need to have a version of the Mozilla software that you're building"
-" the add-on for and a code editor of your choice. Add-ons can be built for "
-"almost all Mozilla software but are primarily targeted for:"
+"You will need to have a version of the Mozilla software that you're building the add-on for and a code editor of your choice. Add-ons can be built for almost all Mozilla software but are primarily "
+"targeted for:"
 msgstr ""
 
 #: src/olympia/pages/templates/pages/dev_faq.html:82
@@ -10940,18 +9348,13 @@ msgstr ""
 #. This is a list of popular code editors.  Feel free to adjust as you like.
 #: src/olympia/pages/templates/pages/dev_faq.html:85
 msgid ""
-"<li><a href=\"http://komodoide.com/komodo-edit/\">Komodo Edit</a></li> "
-"<li><a href=\"http://macromates.com/\">TextMate</a></li> <li><a href=\"http"
-"://notepad-plus-plus.org/\">Notepad++</a></li> <li><a "
-"href=\"http://www.eclipse.org/\">Eclipse IDE</a></li>"
+"<li><a href=\"http://komodoide.com/komodo-edit/\">Komodo Edit</a></li> <li><a href=\"http://macromates.com/\">TextMate</a></li> <li><a href=\"http://notepad-plus-plus.org/\">Notepad++</a></li> "
+"<li><a href=\"http://www.eclipse.org/\">Eclipse IDE</a></li>"
 msgstr ""
 
 #: src/olympia/pages/templates/pages/dev_faq.html:94
 #, python-format
-msgid ""
-"You can also learn more about setting up your development environment via "
-"the MDN article <a href=\"%(url)s\">Setting up extension development "
-"environment</a>"
+msgid "You can also learn more about setting up your development environment via the MDN article <a href=\"%(url)s\">Setting up extension development environment</a>"
 msgstr ""
 
 #: src/olympia/pages/templates/pages/dev_faq.html:100
@@ -10959,9 +9362,7 @@ msgid "What is a \".xpi\" file?"
 msgstr ""
 
 #: src/olympia/pages/templates/pages/dev_faq.html:102
-msgid ""
-"Extensions are packaged and distributed in ZIP files or Bundles, with the "
-"XPI (pronounced \"zippy\") file extension."
+msgid "Extensions are packaged and distributed in ZIP files or Bundles, with the XPI (pronounced \"zippy\") file extension."
 msgstr ""
 
 #: src/olympia/pages/templates/pages/dev_faq.html:108
@@ -10970,10 +9371,8 @@ msgstr ""
 
 #: src/olympia/pages/templates/pages/dev_faq.html:110
 msgid ""
-"XUL (XML User Interface Language) is Mozilla's XML-based language that lets "
-"you build feature-rich cross platform applications. It provides user "
-"interface widgets like buttons, menus, toolbars, trees, etc that can be used"
-" to enhance add-ons by modifying parts of the browser UI."
+"XUL (XML User Interface Language) is Mozilla's XML-based language that lets you build feature-rich cross platform applications. It provides user interface widgets like buttons, menus, toolbars, "
+"trees, etc that can be used to enhance add-ons by modifying parts of the browser UI."
 msgstr ""
 
 #: src/olympia/pages/templates/pages/dev_faq.html:119
@@ -10983,13 +9382,9 @@ msgstr ""
 #: src/olympia/pages/templates/pages/dev_faq.html:121
 #, python-format
 msgid ""
-"This file, called an <a href=\"%(url)s\">Install Manifest</a>, is used by "
-"Add-on Manager-enabled XUL applications to determine information about an "
-"add-on as it is being installed. It contains metadata identifying the add-"
-"on, providing information about who created it, where more information can "
-"be found about it, which versions of what applications it is compatible "
-"with, how it should be updated, and so on. The format of the Install "
-"Manifest is RDF/XML."
+"This file, called an <a href=\"%(url)s\">Install Manifest</a>, is used by Add-on Manager-enabled XUL applications to determine information about an add-on as it is being installed. It contains "
+"metadata identifying the add-on, providing information about who created it, where more information can be found about it, which versions of what applications it is compatible with, how it should "
+"be updated, and so on. The format of the Install Manifest is RDF/XML."
 msgstr ""
 
 #: src/olympia/pages/templates/pages/dev_faq.html:132
@@ -10997,10 +9392,7 @@ msgid "What does \"maxVersion\" mean?"
 msgstr ""
 
 #: src/olympia/pages/templates/pages/dev_faq.html:134
-msgid ""
-"This determines the maximum version of Firefox you're saying this extension "
-"will work with. Set this to be no newer than the newest currently available "
-"version!"
+msgid "This determines the maximum version of Firefox you're saying this extension will work with. Set this to be no newer than the newest currently available version!"
 msgstr ""
 
 #: src/olympia/pages/templates/pages/dev_faq.html:141
@@ -11010,27 +9402,18 @@ msgstr ""
 #: src/olympia/pages/templates/pages/dev_faq.html:143
 #, python-format
 msgid ""
-"Yes. You can use Mozilla's <a href=\"%(url)s\">XPCOM component object "
-"model</a> to enhance your add-ons. XPCOM components be used and implemented "
-"in JavaScript, Java, and Python in addition to C++."
+"Yes. You can use Mozilla's <a href=\"%(url)s\">XPCOM component object model</a> to enhance your add-ons. XPCOM components be used and implemented in JavaScript, Java, and Python in addition to C++."
 msgstr ""
 
 #: src/olympia/pages/templates/pages/dev_faq.html:150
-msgid ""
-"Can I use a JavaScript library like jQuery, MooTools or Prototype to build "
-"my add-on?"
+msgid "Can I use a JavaScript library like jQuery, MooTools or Prototype to build my add-on?"
 msgstr ""
 
 #: src/olympia/pages/templates/pages/dev_faq.html:152
 msgid ""
-"Yes. It's possible, but some of the functionality provided by these "
-"libraries are available through XPCOM, XUL, and JavaScript. In addition, "
-"authors should take care if libraries modify primitive object prototypes "
-"(String.prototype, Date.prototype, etc.) and/or define global functions (eg."
-" the $ function). These are prone to cause conflict with other add-ons, in "
-"particular if different add-ons use different versions of libraries and so "
-"on. Developers need to be very, very careful with using them.  Mozilla does "
-"not offer documentation on using them to build add-ons."
+"Yes. It's possible, but some of the functionality provided by these libraries are available through XPCOM, XUL, and JavaScript. In addition, authors should take care if libraries modify primitive "
+"object prototypes (String.prototype, Date.prototype, etc.) and/or define global functions (eg. the $ function). These are prone to cause conflict with other add-ons, in particular if different add-"
+"ons use different versions of libraries and so on. Developers need to be very, very careful with using them. Mozilla does not offer documentation on using them to build add-ons."
 msgstr ""
 
 #: src/olympia/pages/templates/pages/dev_faq.html:165
@@ -11043,20 +9426,14 @@ msgid "You can use the <a href=\"%(url)s\">Add-on Debugger</a>."
 msgstr ""
 
 #: src/olympia/pages/templates/pages/dev_faq.html:172
-msgid ""
-"How do I test for compatibility with the latest version of Mozilla software?"
+msgid "How do I test for compatibility with the latest version of Mozilla software?"
 msgstr ""
 
 #: src/olympia/pages/templates/pages/dev_faq.html:174
 msgid ""
-"To ensure compatibility with the latest Mozilla software, it's important to "
-"download updates as they become available and test your add-on to ensure "
-"that it is still functioning as expected. In many cases, the latest version "
-"of Mozilla software may be a beta release. Since these releases at times "
-"introduce architectural changes that may impact the functionality of your "
-"add-on, it's important to be actively involved in the beta process to ensure"
-" that your add-on users are not negatively impacted upon final release of "
-"Mozilla software."
+"To ensure compatibility with the latest Mozilla software, it's important to download updates as they become available and test your add-on to ensure that it is still functioning as expected. In "
+"many cases, the latest version of Mozilla software may be a beta release. Since these releases at times introduce architectural changes that may impact the functionality of your add-on, it's "
+"important to be actively involved in the beta process to ensure that your add-on users are not negatively impacted upon final release of Mozilla software."
 msgstr ""
 
 #: src/olympia/pages/templates/pages/dev_faq.html:185
@@ -11066,11 +9443,8 @@ msgstr ""
 #: src/olympia/pages/templates/pages/dev_faq.html:187
 #, python-format
 msgid ""
-"Poorly written extensions can have a severe impact on the browsing "
-"experience, including on the overall performance of Firefox itself. The "
-"following page contains many good <a href=\"%(url)s\">guides</a> that help "
-"you improve performance, whether you're developing core Mozilla code or an "
-"add-on."
+"Poorly written extensions can have a severe impact on the browsing experience, including on the overall performance of Firefox itself. The following page contains many good <a href=\"%(url)s"
+"\">guides</a> that help you improve performance, whether you're developing core Mozilla code or an add-on."
 msgstr ""
 
 #: src/olympia/pages/templates/pages/dev_faq.html:195
@@ -11080,10 +9454,8 @@ msgstr ""
 #: src/olympia/pages/templates/pages/dev_faq.html:197
 #, python-format
 msgid ""
-"Yes. Details on localizing your add-on can be found in the the <a "
-"href=\"%(l10n_url)s\">Mozilla Developer Network Localization page</a>. <a "
-"href=\"%(bz_url)s\">The BabelZilla project</a> is also a great resource for "
-"learning about localization and volunteering to help translate add-ons."
+"Yes. Details on localizing your add-on can be found in the the <a href=\"%(l10n_url)s\">Mozilla Developer Network Localization page</a>. <a href=\"%(bz_url)s\">The BabelZilla project</a> is also a "
+"great resource for learning about localization and volunteering to help translate add-ons."
 msgstr ""
 
 #: src/olympia/pages/templates/pages/dev_faq.html:210
@@ -11102,9 +9474,7 @@ msgstr ""
 
 #. #jetpack is the name of the IRC channel.  do not change.
 #: src/olympia/pages/templates/pages/dev_faq.html:220
-msgid ""
-"#jetpack (for discussions about the Add-ons SDK and cfx/jpm - formerly known"
-" as Jetpack)"
+msgid "#jetpack (for discussions about the Add-ons SDK and cfx/jpm - formerly known as Jetpack)"
 msgstr ""
 
 #. Label for a link to the extension developers mailing list
@@ -11145,11 +9515,8 @@ msgstr ""
 #: src/olympia/pages/templates/pages/dev_faq.html:248
 #, python-format
 msgid ""
-"Yes. You may find 3rd party developers via the <a href=\"%(forum_url)s"
-"\">Add-ons forum</a>, <a href=\"%(list_url)s\">mozilla.jobs list</a>, <a "
-"href=\"%(mz_url)s\">mozillaZine forums</a> or <a href=\"%(wiki_url)s\">the "
-"Mozilla Wiki</a>. Please note that Mozilla does not offer developer "
-"recommendations."
+"Yes. You may find 3rd party developers via the <a href=\"%(forum_url)s\">Add-ons forum</a>, <a href=\"%(list_url)s\">mozilla.jobs list</a>, <a href=\"%(mz_url)s\">mozillaZine forums</a> or <a href="
+"\"%(wiki_url)s\">the Mozilla Wiki</a>. Please note that Mozilla does not offer developer recommendations."
 msgstr ""
 
 #: src/olympia/pages/templates/pages/dev_faq.html:263
@@ -11159,13 +9526,9 @@ msgstr ""
 #: src/olympia/pages/templates/pages/dev_faq.html:265
 #, python-format
 msgid ""
-"Yes. Many developers choose to host their own add-ons. Choosing to host your"
-" add-on on <a href=\"%(amo_url)s\">Mozilla's add-on site</a>, though, allows"
-" for much greater exposure to your add-on due to the large volume of "
-"visitors to the site.  <a href=\"%(md_url)s\">mozdev.org</a> offers free "
-"project hosting for Mozilla applications and extensions providing developers"
-" with tools to help manage source code, version control, bug tracking and "
-"documentation."
+"Yes. Many developers choose to host their own add-ons. Choosing to host your add-on on <a href=\"%(amo_url)s\">Mozilla's add-on site</a>, though, allows for much greater exposure to your add-on due "
+"to the large volume of visitors to the site. <a href=\"%(md_url)s\">mozdev.org</a> offers free project hosting for Mozilla applications and extensions providing developers with tools to help manage "
+"source code, version control, bug tracking and documentation."
 msgstr ""
 
 #: src/olympia/pages/templates/pages/dev_faq.html:277
@@ -11174,9 +9537,7 @@ msgstr ""
 
 #: src/olympia/pages/templates/pages/dev_faq.html:279
 #, python-format
-msgid ""
-"Yes. You can host your add-on on <a href=\"%(url)s\">Mozilla's add-on "
-"website</a>."
+msgid "Yes. You can host your add-on on <a href=\"%(url)s\">Mozilla's add-on website</a>."
 msgstr ""
 
 #: src/olympia/pages/templates/pages/dev_faq.html:284
@@ -11185,12 +9546,8 @@ msgstr ""
 
 #: src/olympia/pages/templates/pages/dev_faq.html:286
 msgid ""
-"Mozilla's AMO (<a "
-"href=\"https://addons.mozilla.org\">https://addons.mozilla.org</a>) is the "
-"incubator that helps developers build, distribute, and support fantastic "
-"consumer products powered by Mozilla. It provides you the tools and "
-"infrastructure necessary to manage, host and expose your add-on to a massive"
-" base of Mozilla users."
+"Mozilla's AMO (<a href=\"https://addons.mozilla.org\">https://addons.mozilla.org</a>) is the incubator that helps developers build, distribute, and support fantastic consumer products powered by "
+"Mozilla. It provides you the tools and infrastructure necessary to manage, host and expose your add-on to a massive base of Mozilla users."
 msgstr ""
 
 #: src/olympia/pages/templates/pages/dev_faq.html:295
@@ -11199,9 +9556,7 @@ msgstr ""
 
 #: src/olympia/pages/templates/pages/dev_faq.html:297
 #, python-format
-msgid ""
-"Yes. Our <a href=\"%(url)s\">Privacy Policy</a> describes how your "
-"information is managed by Mozilla."
+msgid "Yes. Our <a href=\"%(url)s\">Privacy Policy</a> describes how your information is managed by Mozilla."
 msgstr ""
 
 #: src/olympia/pages/templates/pages/dev_faq.html:302
@@ -11210,25 +9565,19 @@ msgstr ""
 
 #: src/olympia/pages/templates/pages/dev_faq.html:304
 msgid ""
-"The \"Developer Tools\" dashboard is the area that provides you the tools to"
-" successfully manage your add-ons. It provides the functionality necessary "
-"to submit your add-ons to AMO, manage add-on information, and review "
-"statistics."
+"The \"Developer Tools\" dashboard is the area that provides you the tools to successfully manage your add-ons. It provides the functionality necessary to submit your add-ons to AMO, manage add-on "
+"information, and review statistics."
 msgstr ""
 
 #: src/olympia/pages/templates/pages/dev_faq.html:312
-msgid ""
-"Does Mozilla have a policy in place as to what is an acceptable submission?"
+msgid "Does Mozilla have a policy in place as to what is an acceptable submission?"
 msgstr ""
 
 #: src/olympia/pages/templates/pages/dev_faq.html:314
 #, python-format
 msgid ""
-"Yes. Mozilla's <a href=\"%(p_url)s\">Add-on Policy</a> describes what is an "
-"acceptable submission. This policy is subject to change without notice.  In "
-"addition, the AMO editorial team uses the <a href=\"%(g_url)s\">Editors "
-"Reviewing Guide</a> to ensure that your add-on meets specific guidelines for"
-" functionality and security."
+"Yes. Mozilla's <a href=\"%(p_url)s\">Add-on Policy</a> describes what is an acceptable submission. This policy is subject to change without notice. In addition, the AMO editorial team uses the <a "
+"href=\"%(g_url)s\">Editors Reviewing Guide</a> to ensure that your add-on meets specific guidelines for functionality and security."
 msgstr ""
 
 #: src/olympia/pages/templates/pages/dev_faq.html:324
@@ -11238,11 +9587,8 @@ msgstr ""
 #: src/olympia/pages/templates/pages/dev_faq.html:326
 #, python-format
 msgid ""
-"The Developer Tools dashboard will allow you to upload and submit add-ons to"
-" AMO. You must be a registered AMO users before you can submit an add-on. "
-"Before submitting your add-on be sure to you have read the AMO <a "
-"href=\"%(url)s\">Editors Reviewing Guide</a> to ensure that your add-on has "
-"met the guidelines used by editors to review add-ons."
+"The Developer Tools dashboard will allow you to upload and submit add-ons to AMO. You must be a registered AMO users before you can submit an add-on. Before submitting your add-on be sure to you "
+"have read the AMO <a href=\"%(url)s\">Editors Reviewing Guide</a> to ensure that your add-on has met the guidelines used by editors to review add-ons."
 msgstr ""
 
 #: src/olympia/pages/templates/pages/dev_faq.html:336
@@ -11250,9 +9596,7 @@ msgid "What operating system do I choose for my add-on?"
 msgstr ""
 
 #: src/olympia/pages/templates/pages/dev_faq.html:338
-msgid ""
-"You must choose the operating systems on which your add-on will successfully"
-" function."
+msgid "You must choose the operating systems on which your add-on will successfully function."
 msgstr ""
 
 #: src/olympia/pages/templates/pages/dev_faq.html:344
@@ -11261,11 +9605,8 @@ msgstr ""
 
 #: src/olympia/pages/templates/pages/dev_faq.html:346
 msgid ""
-"The choice of category is dependent on what type of audience you are "
-"targeting and the functionality of your add-on. If you're unsure of which "
-"category your add-on falls into, please choose \"Other\". The AMO team may "
-"re-categorize your add-on if it's determined that it's better suited in a "
-"different category."
+"The choice of category is dependent on what type of audience you are targeting and the functionality of your add-on. If you're unsure of which category your add-on falls into, please choose \"Other"
+"\". The AMO team may re-categorize your add-on if it's determined that it's better suited in a different category."
 msgstr ""
 
 #: src/olympia/pages/templates/pages/dev_faq.html:355
@@ -11273,9 +9614,7 @@ msgid "What does \"nominating\" my add-on mean?"
 msgstr ""
 
 #: src/olympia/pages/templates/pages/dev_faq.html:357
-msgid ""
-"Nominated add-ons are new add-ons that the author has nominated to become "
-"public via the Developer Tools."
+msgid "Nominated add-ons are new add-ons that the author has nominated to become public via the Developer Tools."
 msgstr ""
 
 #: src/olympia/pages/templates/pages/dev_faq.html:363
@@ -11283,10 +9622,7 @@ msgid "Can I specify a license agreement for using my add-on?"
 msgstr ""
 
 #: src/olympia/pages/templates/pages/dev_faq.html:365
-msgid ""
-"Yes. You can specify a license agreement when submitting your add-on. You "
-"can also add or update a license agreement via the Developer Tools dashboard"
-" after your add-on has been submitted."
+msgid "Yes. You can specify a license agreement when submitting your add-on. You can also add or update a license agreement via the Developer Tools dashboard after your add-on has been submitted."
 msgstr ""
 
 #: src/olympia/pages/templates/pages/dev_faq.html:372
@@ -11294,10 +9630,7 @@ msgid "Can I include a privacy policy for my add-on?"
 msgstr ""
 
 #: src/olympia/pages/templates/pages/dev_faq.html:374
-msgid ""
-"Yes. You can specify a privacy policy when submitting your add-on. You can "
-"also add or update a privacy policy via the Developer Tools dashboard after "
-"your add-on has been submitted."
+msgid "Yes. You can specify a privacy policy when submitting your add-on. You can also add or update a privacy policy via the Developer Tools dashboard after your add-on has been submitted."
 msgstr ""
 
 #: src/olympia/pages/templates/pages/dev_faq.html:383
@@ -11307,10 +9640,8 @@ msgstr ""
 #: src/olympia/pages/templates/pages/dev_faq.html:385
 #, python-format
 msgid ""
-"All add-ons submitted, whether new or updated, are reviewed to ensure that "
-"Mozilla users have a stable and safe experience. All add-ons submissions are"
-" reviewed using the guidelines outlined in the <a href=\"%(url)s\">Editors "
-"Reviewing Guide</a>."
+"All add-ons submitted, whether new or updated, are reviewed to ensure that Mozilla users have a stable and safe experience. All add-ons submissions are reviewed using the guidelines outlined in the "
+"<a href=\"%(url)s\">Editors Reviewing Guide</a>."
 msgstr ""
 
 #: src/olympia/pages/templates/pages/dev_faq.html:393
@@ -11320,12 +9651,9 @@ msgstr ""
 #: src/olympia/pages/templates/pages/dev_faq.html:395
 #, python-format
 msgid ""
-"Add-ons are reviewed by the AMO Editors, a group of talented developers that"
-" volunteer to help the Mozilla project by reviewing add-ons to ensure a "
-"stable and safe experience for Mozilla users. When communicating with "
-"editors, please be courteous, patient and respectful as they are working "
-"hard to ensure that your add-on is set up correctly and follows the "
-"guidelines outlined in the <a href=\"%(url)s\">Editors Reviewing Guide</a>."
+"Add-ons are reviewed by the AMO Editors, a group of talented developers that volunteer to help the Mozilla project by reviewing add-ons to ensure a stable and safe experience for Mozilla users. "
+"When communicating with editors, please be courteous, patient and respectful as they are working hard to ensure that your add-on is set up correctly and follows the guidelines outlined in the <a "
+"href=\"%(url)s\">Editors Reviewing Guide</a>."
 msgstr ""
 
 #: src/olympia/pages/templates/pages/dev_faq.html:406
@@ -11335,11 +9663,8 @@ msgstr ""
 #: src/olympia/pages/templates/pages/dev_faq.html:408
 #, python-format
 msgid ""
-"The Mozilla editorial team follows the <a href=\"%(url)s\">Editors Reviewing"
-" Guide</a> when testing an add-on for acceptance onto AMO. It is important "
-"that add-on developers review this guide to ensure that common problem areas"
-" are addressed prior to submitting their add-on for review. This will "
-"greatly assist in expediting the review process."
+"The Mozilla editorial team follows the <a href=\"%(url)s\">Editors Reviewing Guide</a> when testing an add-on for acceptance onto AMO. It is important that add-on developers review this guide to "
+"ensure that common problem areas are addressed prior to submitting their add-on for review. This will greatly assist in expediting the review process."
 msgstr ""
 
 #: src/olympia/pages/templates/pages/dev_faq.html:418
@@ -11347,9 +9672,7 @@ msgid "How long will it take for my add-on to be reviewed?"
 msgstr ""
 
 #: src/olympia/pages/templates/pages/dev_faq.html:420
-msgid ""
-"We cannot give a time estimate as to how long it will take before an add-on "
-"is reviewed. Many factors affect the time including the:"
+msgid "We cannot give a time estimate as to how long it will take before an add-on is reviewed. Many factors affect the time including the:"
 msgstr ""
 
 #. part of a list (<li>)
@@ -11370,11 +9693,8 @@ msgstr ""
 #: src/olympia/pages/templates/pages/dev_faq.html:434
 #, python-format
 msgid ""
-"This is why it's very important to read the <a href=\"%(g_url)s\">Editors "
-"Reviewing Guide</a> to ensure that your add-on is setup as expected.  It's "
-"also a good idea to read the blog post, <a "
-"href=\"%(blog_url)s\">Successfully Getting your Add-on Reviewed</a> which "
-"provides excellent insight into ensuring a smooth review of your add-on."
+"This is why it's very important to read the <a href=\"%(g_url)s\">Editors Reviewing Guide</a> to ensure that your add-on is setup as expected. It's also a good idea to read the blog post, <a href="
+"\"%(blog_url)s\">Successfully Getting your Add-on Reviewed</a> which provides excellent insight into ensuring a smooth review of your add-on."
 msgstr ""
 
 #: src/olympia/pages/templates/pages/dev_faq.html:446
@@ -11382,10 +9702,7 @@ msgid "How can I see how many times my add-on has been downloaded?"
 msgstr ""
 
 #: src/olympia/pages/templates/pages/dev_faq.html:448
-msgid ""
-"The Statistics Dashboard found in the Developer Tools dashboard provides "
-"information that can help you determine your add-on downloads since you've "
-"submitted it to AMO."
+msgid "The Statistics Dashboard found in the Developer Tools dashboard provides information that can help you determine your add-on downloads since you've submitted it to AMO."
 msgstr ""
 
 #: src/olympia/pages/templates/pages/dev_faq.html:455
@@ -11394,9 +9711,7 @@ msgstr ""
 
 #: src/olympia/pages/templates/pages/dev_faq.html:457
 msgid ""
-"The Statistics Dashboard found in the Developer Tools dashboard provides "
-"information that can help you determine how many users have been actively "
-"using your add-on since you've submitted it to AMO."
+"The Statistics Dashboard found in the Developer Tools dashboard provides information that can help you determine how many users have been actively using your add-on since you've submitted it to AMO."
 msgstr ""
 
 #: src/olympia/pages/templates/pages/dev_faq.html:464
@@ -11404,10 +9719,7 @@ msgid "How do I submit an update for my add-on?"
 msgstr ""
 
 #: src/olympia/pages/templates/pages/dev_faq.html:466
-msgid ""
-"You can submit an update for your add-on via the Developer Tools dashboard "
-"by choosing the option \"Upload a new version\" and uploading a new .xpi "
-"file for your add-on."
+msgid "You can submit an update for your add-on via the Developer Tools dashboard by choosing the option \"Upload a new version\" and uploading a new .xpi file for your add-on."
 msgstr ""
 
 #: src/olympia/pages/templates/pages/dev_faq.html:473
@@ -11416,39 +9728,30 @@ msgstr ""
 
 #: src/olympia/pages/templates/pages/dev_faq.html:475
 msgid ""
-"That depends. If you are simply changing a description of your add-on or "
-"updating a \"maxVersion\" to ensure compatibility with a new Mozilla "
-"software update, then your add-on does not need to be reviewed again. If, "
-"however, you submit a new updated file, then your add-on update will need to"
-" be reviewed by an editor."
+"That depends. If you are simply changing a description of your add-on or updating a \"maxVersion\" to ensure compatibility with a new Mozilla software update, then your add-on does not need to be "
+"reviewed again. If, however, you submit a new updated file, then your add-on update will need to be reviewed by an editor."
 msgstr ""
 
 #: src/olympia/pages/templates/pages/dev_faq.html:486
-msgid ""
-"How do I reply to a user who has posted a negative review of my add-on?"
+msgid "How do I reply to a user who has posted a negative review of my add-on?"
 msgstr ""
 
 #: src/olympia/pages/templates/pages/dev_faq.html:488
-msgid ""
-"A developer may reply to any review posted to their add-on as long as they "
-"are logged into AMO. In addition, any user can flag a review as:"
+msgid "A developer may reply to any review posted to their add-on as long as they are logged into AMO. In addition, any user can flag a review as:"
 msgstr ""
 
 #. part of a list (<li>)
-#: src/olympia/pages/templates/pages/dev_faq.html:495
-#: src/olympia/reviews/models.py:159
+#: src/olympia/pages/templates/pages/dev_faq.html:495 src/olympia/reviews/models.py:159
 msgid "Spam or otherwise non-review content"
 msgstr ""
 
 #. part of a list (<li>)
-#: src/olympia/pages/templates/pages/dev_faq.html:497
-#: src/olympia/reviews/models.py:160
+#: src/olympia/pages/templates/pages/dev_faq.html:497 src/olympia/reviews/models.py:160
 msgid "Inappropriate language/dialog"
 msgstr ""
 
 #. part of a list (<li>)
-#: src/olympia/pages/templates/pages/dev_faq.html:499
-#: src/olympia/reviews/models.py:161
+#: src/olympia/pages/templates/pages/dev_faq.html:499 src/olympia/reviews/models.py:161
 msgid "Misplaced bug report or support request"
 msgstr ""
 
@@ -11458,10 +9761,7 @@ msgid "Other (provides a pop-up prompt for information)"
 msgstr ""
 
 #: src/olympia/pages/templates/pages/dev_faq.html:504
-msgid ""
-"Currently, AMO does not provide a mechanism to directly communicate with a "
-"reviewer but this feature is being investigated and considered for a future "
-"update."
+msgid "Currently, AMO does not provide a mechanism to directly communicate with a reviewer but this feature is being investigated and considered for a future update."
 msgstr ""
 
 #: src/olympia/pages/templates/pages/dev_faq.html:511
@@ -11469,9 +9769,7 @@ msgid "Can I request that a review be removed if the review is negative?"
 msgstr ""
 
 #: src/olympia/pages/templates/pages/dev_faq.html:513
-msgid ""
-"No. We do not remove negative reviews from add-ons unless they are found to "
-"be false."
+msgid "No. We do not remove negative reviews from add-ons unless they are found to be false."
 msgstr ""
 
 #: src/olympia/pages/templates/pages/dev_faq.html:519
@@ -11479,55 +9777,36 @@ msgid "Can I request that a review be removed if the review is inaccurate?"
 msgstr ""
 
 #: src/olympia/pages/templates/pages/dev_faq.html:521
-msgid ""
-"If an author contacts us and asks for a review containing false or "
-"inaccurate information to be removed, we will review the post and consider "
-"removing it."
+msgid "If an author contacts us and asks for a review containing false or inaccurate information to be removed, we will review the post and consider removing it."
 msgstr ""
 
 #: src/olympia/pages/templates/pages/dev_faq.html:530
 msgid ""
-"Do you need more information about the various open source licenses? Are you"
-" confused as to which license you should select? What rights does a specific"
-" license grant? While nothing replaces reading the full terms of a license, "
-"below are some sites that contain information about some of the key open "
-"source licenses that may help you sort out the differences between them. "
-"These sites are being provided solely for your convenience and as a "
-"reference for your personal use. These resources do not constitute legal "
-"advice nor should they be used in lieu of such advice. Mozilla neither "
-"guarantees nor is responsible for the content of these sites or your "
-"reliance on such content."
+"Do you need more information about the various open source licenses? Are you confused as to which license you should select? What rights does a specific license grant? While nothing replaces "
+"reading the full terms of a license, below are some sites that contain information about some of the key open source licenses that may help you sort out the differences between them. These sites "
+"are being provided solely for your convenience and as a reference for your personal use. These resources do not constitute legal advice nor should they be used in lieu of such advice. Mozilla "
+"neither guarantees nor is responsible for the content of these sites or your reliance on such content."
 msgstr ""
 
 #: src/olympia/pages/templates/pages/dev_faq.html:545
 msgid ""
-"In addition to the full text of the Mozilla Public License(\"MPL\"), this "
-"also provides an annotated version of the MPL and an <abbr "
-"title=\"Frequently Asked Questions\">FAQ</abbr> to help you if you want to "
-"use or distribute code licensed under it."
+"In addition to the full text of the Mozilla Public License(\"MPL\"), this also provides an annotated version of the MPL and an <abbr title=\"Frequently Asked Questions\">FAQ</abbr> to help you if "
+"you want to use or distribute code licensed under it."
 msgstr ""
 
 #: src/olympia/pages/templates/pages/dev_faq.html:559
-msgid ""
-"A table summarizing and comparing how some of the key open source licenses "
-"treat distributions, proprietary software linking, and redistribution of "
-"code with changes."
+msgid "A table summarizing and comparing how some of the key open source licenses treat distributions, proprietary software linking, and redistribution of code with changes."
 msgstr ""
 
 #: src/olympia/pages/templates/pages/dev_faq.html:572
 msgid ""
-"Free Software Foundation provides short summaries of the key open source "
-"licenses, including whether the license qualifies as a free software license"
-" or a copyleft license.  Also includes a discussion of what constitutes a "
-"free software license or a copyleft license (e.g., a Copyleft license is a "
-"general method for making a program or other work free, and requiring all "
-"modified and extended versions of the program to be free as well.)"
+"Free Software Foundation provides short summaries of the key open source licenses, including whether the license qualifies as a free software license or a copyleft license. Also includes a "
+"discussion of what constitutes a free software license or a copyleft license (e.g., a Copyleft license is a general method for making a program or other work free, and requiring all modified and "
+"extended versions of the program to be free as well.)"
 msgstr ""
 
 #: src/olympia/pages/templates/pages/dev_faq.html:589
-msgid ""
-"Open Source Initiative provides the terms of some of the key open source "
-"licenses."
+msgid "Open Source Initiative provides the terms of some of the key open source licenses."
 msgstr ""
 
 #: src/olympia/pages/templates/pages/dev_faq.html:599
@@ -11535,14 +9814,10 @@ msgid "A comparison of known open source licenses on Wikipedia."
 msgstr ""
 
 #: src/olympia/pages/templates/pages/dev_faq.html:605
-msgid ""
-"A site to provide non-judgmental guidance on choosing a license for your "
-"open source project."
+msgid "A site to provide non-judgmental guidance on choosing a license for your open source project."
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:3
-#: src/olympia/pages/templates/pages/faq.html:9
-#: src/olympia/pages/templates/pages/faq.html:10
+#: src/olympia/pages/templates/pages/faq.html:3 src/olympia/pages/templates/pages/faq.html:9 src/olympia/pages/templates/pages/faq.html:10
 msgid "Frequently Asked Questions"
 msgstr ""
 
@@ -11557,12 +9832,8 @@ msgstr ""
 #: src/olympia/pages/templates/pages/faq.html:16
 #, python-format
 msgid ""
-"Add-ons are small pieces of software that add new features or functionality "
-"to your installation of %(app_name)s. Add-ons can augment %(app_name)s with "
-"new features, foreign language dictionaries, or change its visual "
-"appearance. Through add-ons, you can customize %(app_name)s to meet your "
-"needs and tastes. <a href=\"%(learnmore_url)s\">Learn more about "
-"customization</a>"
+"Add-ons are small pieces of software that add new features or functionality to your installation of %(app_name)s. Add-ons can augment %(app_name)s with new features, foreign language dictionaries, "
+"or change its visual appearance. Through add-ons, you can customize %(app_name)s to meet your needs and tastes. <a href=\"%(learnmore_url)s\">Learn more about customization</a>"
 msgstr ""
 
 #: src/olympia/pages/templates/pages/faq.html:26
@@ -11572,15 +9843,9 @@ msgstr ""
 #: src/olympia/pages/templates/pages/faq.html:27
 #, python-format
 msgid ""
-"Add-ons listed in this gallery only work with Mozilla-based applications, "
-"such as <a href=\"%(getfirefox_url)s\">Firefox</a>, <a "
-"href=\"%(getmobile_url)s\">Firefox Mobile</a>, <a "
-"href=\"%(getseamonkey_url)s\">SeaMonkey</a>, and <a "
-"href=\"%(getthunderbird_url)s\">Thunderbird</a>. However, not all add-ons "
-"work with each of those applications or every version of those applications."
-" Each add-on specifies which applications and versions it works with, such "
-"as Firefox 2.0 - 3.6.*. For Firefox add-ons, the install buttons will "
-"indicate whether the add-on is compatible or not."
+"Add-ons listed in this gallery only work with Mozilla-based applications, such as <a href=\"%(getfirefox_url)s\">Firefox</a>, <a href=\"%(getmobile_url)s\">Firefox Mobile</a>, <a href="
+"\"%(getseamonkey_url)s\">SeaMonkey</a>, and <a href=\"%(getthunderbird_url)s\">Thunderbird</a>. However, not all add-ons work with each of those applications or every version of those applications. "
+"Each add-on specifies which applications and versions it works with, such as Firefox 2.0 - 3.6.*. For Firefox add-ons, the install buttons will indicate whether the add-on is compatible or not."
 msgstr ""
 
 #: src/olympia/pages/templates/pages/faq.html:42
@@ -11589,57 +9854,39 @@ msgstr ""
 
 #: src/olympia/pages/templates/pages/faq.html:43
 #, python-format
-msgid ""
-"There are several kinds of add-ons that customize %(app_name)s in different "
-"ways:"
+msgid "There are several kinds of add-ons that customize %(app_name)s in different ways:"
 msgstr ""
 
 #: src/olympia/pages/templates/pages/faq.html:47
 #, python-format
 msgid ""
-"<strong><a href=\"%(browse_url)s\">Extensions</a></strong> add new features "
-"to %(app_name)s or modify existing functionality. There are extensions that "
-"allow you to block advertisements, download videos from websites, integrate "
-"more closely with social websites, and add features you see in other "
-"applications."
+"<strong><a href=\"%(browse_url)s\">Extensions</a></strong> add new features to %(app_name)s or modify existing functionality. There are extensions that allow you to block advertisements, download "
+"videos from websites, integrate more closely with social websites, and add features you see in other applications."
 msgstr ""
 
 #: src/olympia/pages/templates/pages/faq.html:55
 #, python-format
-msgid ""
-"<strong><a href=\"%(browse_url)s\">Complete Themes</a></strong> change the "
-"entire appearance of %(app_name)s, usually including icons, colors, dialogs,"
-" and other visual styles."
+msgid "<strong><a href=\"%(browse_url)s\">Complete Themes</a></strong> change the entire appearance of %(app_name)s, usually including icons, colors, dialogs, and other visual styles."
 msgstr ""
 
 #: src/olympia/pages/templates/pages/faq.html:61
 #, python-format
-msgid ""
-"<strong><a href=\"%(browse_url)s\">Themes</a></strong> are lightweight "
-"themes that use background images to customize your %(app_name)s toolbars."
+msgid "<strong><a href=\"%(browse_url)s\">Themes</a></strong> are lightweight themes that use background images to customize your %(app_name)s toolbars."
 msgstr ""
 
 #: src/olympia/pages/templates/pages/faq.html:66
 #, python-format
-msgid ""
-"<strong><a href=\"%(browse_url)s\">Search Providers</a> </strong> add "
-"additional choices to the search box dropdown. These providers allow you to "
-"quickly search any website."
+msgid "<strong><a href=\"%(browse_url)s\">Search Providers</a> </strong> add additional choices to the search box dropdown. These providers allow you to quickly search any website."
 msgstr ""
 
 #: src/olympia/pages/templates/pages/faq.html:72
 #, python-format
-msgid ""
-"<strong><a href=\"%(browse_url)s\">Dictionaries & Language "
-"Packs</a></strong> add support for additional languages to %(app_name)s."
+msgid "<strong><a href=\"%(browse_url)s\">Dictionaries & Language Packs</a></strong> add support for additional languages to %(app_name)s."
 msgstr ""
 
 #: src/olympia/pages/templates/pages/faq.html:77
 #, python-format
-msgid ""
-"<strong><a href=\"%(browse_url)s\">Plugins</a></strong> help %(app_name)s "
-"display or understand different types of media, such as Adobe Flash or Apple"
-" Quicktime."
+msgid "<strong><a href=\"%(browse_url)s\">Plugins</a></strong> help %(app_name)s display or understand different types of media, such as Adobe Flash or Apple Quicktime."
 msgstr ""
 
 #: src/olympia/pages/templates/pages/faq.html:85
@@ -11649,13 +9896,9 @@ msgstr ""
 #: src/olympia/pages/templates/pages/faq.html:86
 #, python-format
 msgid ""
-"In most cases, add-ons can be installed by simply clicking the install "
-"button provided. Add-ons can be managed, disabled, or uninstalled from the "
-"Add-ons Manager in %(app_name)s. For more detailed instructions, read <a "
-"href=\"%(extension_url)s\">this article on extensions</a> or <a "
-"href=\"%(theme_url)s\">this one for Themes and Complete Themes</a>. If you "
-"have difficulty installing add-ons, see <a "
-"href=\"%(troubleshooting_url)s\">Troubleshooting Extensions and Themes</a>."
+"In most cases, add-ons can be installed by simply clicking the install button provided. Add-ons can be managed, disabled, or uninstalled from the Add-ons Manager in %(app_name)s. For more detailed "
+"instructions, read <a href=\"%(extension_url)s\">this article on extensions</a> or <a href=\"%(theme_url)s\">this one for Themes and Complete Themes</a>. If you have difficulty installing add-ons, "
+"see <a href=\"%(troubleshooting_url)s\">Troubleshooting Extensions and Themes</a>."
 msgstr ""
 
 #: src/olympia/pages/templates/pages/faq.html:100
@@ -11665,11 +9908,8 @@ msgstr ""
 #: src/olympia/pages/templates/pages/faq.html:101
 #, python-format
 msgid ""
-"In Firefox, add-ons marked with \"No restart required\" can be installed "
-"without restarting. These add-ons have been created using the <a "
-"href=\"%(sdk_url)s\">Add-on SDK</a> or <a "
-"href=\"%(bootstrap_url)s\">bootstrapping</a>. Other add-ons will still "
-"require a restart before you can use them."
+"In Firefox, add-ons marked with \"No restart required\" can be installed without restarting. These add-ons have been created using the <a href=\"%(sdk_url)s\">Add-on SDK</a> or <a href="
+"\"%(bootstrap_url)s\">bootstrapping</a>. Other add-ons will still require a restart before you can use them."
 msgstr ""
 
 #: src/olympia/pages/templates/pages/faq.html:110
@@ -11679,13 +9919,9 @@ msgstr ""
 #: src/olympia/pages/templates/pages/faq.html:111
 #, python-format
 msgid ""
-"Add-ons, unlike plugins, are automatically checked for updates once every "
-"day. In Firefox, updates are automatically installed by default. Versions of"
-" Firefox prior to 4 (and other applications) will alert you that updates to "
-"your add-ons are available. <a href=\"%(plugin_url)s\">Plugins</a> are not "
-"currently automatically checked for updates, so be sure to regularly visit "
-"the <a href=\"%(plugincheck_url)s\">Plugin Check</a> page to stay up-to-"
-"date."
+"Add-ons, unlike plugins, are automatically checked for updates once every day. In Firefox, updates are automatically installed by default. Versions of Firefox prior to 4 (and other applications) "
+"will alert you that updates to your add-ons are available. <a href=\"%(plugin_url)s\">Plugins</a> are not currently automatically checked for updates, so be sure to regularly visit the <a href="
+"\"%(plugincheck_url)s\">Plugin Check</a> page to stay up-to-date."
 msgstr ""
 
 #: src/olympia/pages/templates/pages/faq.html:122
@@ -11695,12 +9931,9 @@ msgstr ""
 #: src/olympia/pages/templates/pages/faq.html:123
 #, python-format
 msgid ""
-"Unless clearly marked otherwise, add-ons available from this gallery have "
-"been checked and approved by Mozilla's team of editors and are safe to "
-"install. We recommend that you only install approved add-ons. If you wish to"
-" install unapproved add-ons or add-ons from third-party websites, use "
-"caution as these add-ons may harm your computer or violate your privacy. <a "
-"href=\"%(learnmore_url)s\">Learn more about our approval process</a>"
+"Unless clearly marked otherwise, add-ons available from this gallery have been checked and approved by Mozilla's team of editors and are safe to install. We recommend that you only install approved "
+"add-ons. If you wish to install unapproved add-ons or add-ons from third-party websites, use caution as these add-ons may harm your computer or violate your privacy. <a href=\"%(learnmore_url)s"
+"\">Learn more about our approval process</a>"
 msgstr ""
 
 #: src/olympia/pages/templates/pages/faq.html:133
@@ -11711,30 +9944,21 @@ msgstr ""
 #: src/olympia/pages/templates/pages/faq.html:135
 #, python-format
 msgid ""
-"Most add-ons do not cause a perceivable performance decrease in "
-"%(app_name)s, though installing an excessive number may have adverse "
-"effects. If you suspect an add-on is causing %(app_name)s to be slow, try "
-"disabling it."
+"Most add-ons do not cause a perceivable performance decrease in %(app_name)s, though installing an excessive number may have adverse effects. If you suspect an add-on is causing %(app_name)s to be "
+"slow, try disabling it."
 msgstr ""
 
 #: src/olympia/pages/templates/pages/faq.html:141
 #, python-format
-msgid ""
-"%(app_name)s told me an add-on isn't compatible. Is there a way I can still "
-"use it?"
+msgid "%(app_name)s told me an add-on isn't compatible. Is there a way I can still use it?"
 msgstr ""
 
 #: src/olympia/pages/templates/pages/faq.html:144
 #, python-format
 msgid ""
-"If an add-on isn't compatible with your version of %(app_name)s, it is "
-"usually either because your version of %(app_name)s is outdated or the add-"
-"on author has not yet updated the add-on to be compatible with a newer "
-"version you are using. Mozilla does not recommend trying to circumvent these"
-" compatibility checks, as they can lead to browser instability or in some "
-"cases loss of data. For users who are testing out alpha or beta versions of "
-"Firefox, we offer the <a href=\"%(acr_url)s\">Add-on Compatibility "
-"Reporter</a> to help add-on developers update their compatibility."
+"If an add-on isn't compatible with your version of %(app_name)s, it is usually either because your version of %(app_name)s is outdated or the add-on author has not yet updated the add-on to be "
+"compatible with a newer version you are using. Mozilla does not recommend trying to circumvent these compatibility checks, as they can lead to browser instability or in some cases loss of data. For "
+"users who are testing out alpha or beta versions of Firefox, we offer the <a href=\"%(acr_url)s\">Add-on Compatibility Reporter</a> to help add-on developers update their compatibility."
 msgstr ""
 
 #: src/olympia/pages/templates/pages/faq.html:156
@@ -11744,12 +9968,9 @@ msgstr ""
 #: src/olympia/pages/templates/pages/faq.html:157
 #, python-format
 msgid ""
-"Add-ons are usually created by third-party developers from around the world,"
-" so the best way to get help with an add-on is to look for support links on "
-"the add-on's homepage or contact the developer. If you are having issues "
-"with %(app_name)s that you suspect are related to add-ons you have "
-"installed, <a href=\"%(troubleshooting_url)s\">visit this support "
-"article</a> for troubleshooting tips."
+"Add-ons are usually created by third-party developers from around the world, so the best way to get help with an add-on is to look for support links on the add-on's homepage or contact the "
+"developer. If you are having issues with %(app_name)s that you suspect are related to add-ons you have installed, <a href=\"%(troubleshooting_url)s\">visit this support article</a> for "
+"troubleshooting tips."
 msgstr ""
 
 #: src/olympia/pages/templates/pages/faq.html:169
@@ -11757,19 +9978,13 @@ msgid "Add-on Gallery"
 msgstr ""
 
 #: src/olympia/pages/templates/pages/faq.html:171
-msgid ""
-"How do I choose between add-ons that seem to do the same\n"
-"    thing?"
+msgid "How do I choose between add-ons that seem to do the same thing?"
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:173
+#: src/olympia/pages/templates/pages/faq.html:172
 msgid ""
-"There are often several add-ons that have similar features. To\n"
-"    figure out which is right for you, read the entire description of the\n"
-"    add-on and view its screenshots. If there are still several in the running,\n"
-"    read through the add-on's ratings, user reviews, and statistics to see\n"
-"    which is most liked by other users. Remember that you can also just try\n"
-"    out both and see which you like better."
+"There are often several add-ons that have similar features. To figure out which is right for you, read the entire description of the add-on and view its screenshots. If there are still several in "
+"the running, read through the add-on's ratings, user reviews, and statistics to see which is most liked by other users. Remember that you can also just try out both and see which you like better."
 msgstr ""
 
 #: src/olympia/pages/templates/pages/faq.html:180
@@ -11779,26 +9994,19 @@ msgstr ""
 #: src/olympia/pages/templates/pages/faq.html:181
 #, python-format
 msgid ""
-"With thousands of add-ons available, there's something for everyone. But if "
-"you're looking for a particular add-on and can't find it, you might try "
-"searching on other sites or posting about it in our <a href=\"%(forum_url)s"
-"\">Add-ons </a>forum."
+"With thousands of add-ons available, there's something for everyone. But if you're looking for a particular add-on and can't find it, you might try searching on other sites or posting about it in "
+"our <a href=\"%(forum_url)s\">Add-ons </a>forum."
 msgstr ""
 
 #: src/olympia/pages/templates/pages/faq.html:187
-msgid ""
-"What does it mean if an add-on is \"experimental\" or \"preliminarily "
-"reviewed\"?"
+msgid "What does it mean if an add-on is \"experimental\" or \"preliminarily reviewed\"?"
 msgstr ""
 
 #: src/olympia/pages/templates/pages/faq.html:188
 #, python-format
 msgid ""
-"Experimental add-ons have been checked by our editors to make sure they "
-"don't have security problems, but they may still have bugs or not work "
-"properly. Use caution when installing experimental add-ons and uninstall the"
-" add-on immediately if you notice problems. <a href=\"%(url)s\">Learn more "
-"about our review process</a></dd>"
+"Experimental add-ons have been checked by our editors to make sure they don't have security problems, but they may still have bugs or not work properly. Use caution when installing experimental add-"
+"ons and uninstall the add-on immediately if you notice problems. <a href=\"%(url)s\">Learn more about our review process</a></dd>"
 msgstr ""
 
 #: src/olympia/pages/templates/pages/faq.html:196
@@ -11808,12 +10016,8 @@ msgstr ""
 #: src/olympia/pages/templates/pages/faq.html:197
 #, python-format
 msgid ""
-"While all add-ons publicly available in our gallery are reviewed by an "
-"editor, you may receive a direct link to an add-on that hasn't yet been "
-"reviewed. Use caution when installing these add-ons, as they could harm your"
-" computer or violate your privacy. We recommend that you only install "
-"reviewed add-ons. <a href=\"%(url)s\">Learn more about our review "
-"process</a></dd>"
+"While all add-ons publicly available in our gallery are reviewed by an editor, you may receive a direct link to an add-on that hasn't yet been reviewed. Use caution when installing these add-ons, "
+"as they could harm your computer or violate your privacy. We recommend that you only install reviewed add-ons. <a href=\"%(url)s\">Learn more about our review process</a></dd>"
 msgstr ""
 
 #: src/olympia/pages/templates/pages/faq.html:206
@@ -11821,181 +10025,144 @@ msgid "How much do add-ons cost to purchase?"
 msgstr ""
 
 #: src/olympia/pages/templates/pages/faq.html:207
-msgid ""
-"Add-ons hosted in our gallery are free unless clearly marked\n"
-"    otherwise."
+msgid "Add-ons hosted in our gallery are free unless clearly marked otherwise."
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:210
+#: src/olympia/pages/templates/pages/faq.html:209
 msgid "What does it mean when an add-on asks for contributions?"
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:211
+#: src/olympia/pages/templates/pages/faq.html:210
 msgid ""
-"Some add-on authors request users who enjoy an add-on to\n"
-"        contribute to its development by making a monetary contribution. These\n"
-"        contributions go directly to the developer unless a third party is\n"
-"        indicated, such as the non-profit Mozilla Foundation."
+"Some add-on authors request users who enjoy an add-on to contribute to its development by making a monetary contribution. These contributions go directly to the developer unless a third party is "
+"indicated, such as the non-profit Mozilla Foundation."
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:216
+#: src/olympia/pages/templates/pages/faq.html:215
 msgid "What are beta add-ons?"
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:218
+#: src/olympia/pages/templates/pages/faq.html:217
 msgid ""
-"Beta add-ons are unreviewed versions which represent the\n"
-"        latest work of an add-on author. While different authors have different\n"
-"        standards for beta code quality, you should assume that these add-ons\n"
-"        are less stable than the general add-on releases."
+"Beta add-ons are unreviewed versions which represent the latest work of an add-on author. While different authors have different standards for beta code quality, you should assume that these add-"
+"ons are less stable than the general add-on releases."
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:222
+#: src/olympia/pages/templates/pages/faq.html:221
 msgid ""
-"Please note that when you install an add-on from the \"Beta Version\" "
-"section of an add-on's listing, you will continue to receive updates for "
-"that add-on as they become available. Like the initial version you "
-"installed, all beta releases are unreviewed by Mozilla and may harm your "
-"computer."
+"Please note that when you install an add-on from the \"Beta Version\" section of an add-on's listing, you will continue to receive updates for that add-on as they become available. Like the initial "
+"version you installed, all beta releases are unreviewed by Mozilla and may harm your computer."
+msgstr ""
+
+#: src/olympia/pages/templates/pages/faq.html:228
+msgid "What does it mean when an add-on is flagged as slow?"
 msgstr ""
 
 #: src/olympia/pages/templates/pages/faq.html:229
-msgid ""
-"What does it mean when an add-on is flagged as\n"
-"    slow?"
+msgid "Most add-ons load code and resources at the same time Firefox is starting up. In most cases the impact in start-up time is minimal, but some add-ons can cause a noticeable slowdown."
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:231
-msgid ""
-"Most add-ons load code and resources at the same time Firefox\n"
-"        is starting up. In most cases the impact in start-up time is minimal,\n"
-"        but some add-ons can cause a noticeable slowdown."
-msgstr ""
-
-#: src/olympia/pages/templates/pages/faq.html:236
+#: src/olympia/pages/templates/pages/faq.html:234
 msgid "How do I report an inappropriate or spam user review?"
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:237
+#: src/olympia/pages/templates/pages/faq.html:235
 msgid ""
-"To report a user review of an add-on, log in with your account\n"
-"    and visit the add-on's reviews page. Find the review you wish to report,\n"
-"    click \"Report this review\" and select a reason. Our editorial team will\n"
-"    investigate the review and take appropriate action."
+"To report a user review of an add-on, log in with your account and visit the add-on's reviews page. Find the review you wish to report, click \"Report this review\" and select a reason. Our "
+"editorial team will investigate the review and take appropriate action."
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:242
+#: src/olympia/pages/templates/pages/faq.html:240
 msgid "How do I report a bug or contact the Mozilla Add-ons team?"
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:243
+#: src/olympia/pages/templates/pages/faq.html:241
 #, python-format
 msgid "Please visit our <a href=\"%(contact_url)s\">Contact page</a>."
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:246
+#: src/olympia/pages/templates/pages/faq.html:244
 msgid "What is a Source Code License?"
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:247
+#: src/olympia/pages/templates/pages/faq.html:245
 #, python-format
 msgid ""
-"The source code used to create an add-on is an exclusive copyright of the "
-"add-on author, unless otherwise declared in a source code license. Many add-"
-"ons on this site have <a href=\"%(url)s\" lang=\"en\">open source "
-"licenses</a> that make the source code publicly available for copy and reuse"
-" under conditions determined by the author. Most authors choose widely known"
-" open source licenses like the GPL or BSD licenses instead of making up "
-"their own."
+"The source code used to create an add-on is an exclusive copyright of the add-on author, unless otherwise declared in a source code license. Many add-ons on this site have <a href=\"%(url)s\" lang="
+"\"en\">open source licenses</a> that make the source code publicly available for copy and reuse under conditions determined by the author. Most authors choose widely known open source licenses like "
+"the GPL or BSD licenses instead of making up their own."
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:256
+#: src/olympia/pages/templates/pages/faq.html:254
 #, python-format
-msgid ""
-"Firefox and other Mozilla software are <a href=\"%(url)s\">open source</a>."
+msgid "Firefox and other Mozilla software are <a href=\"%(url)s\">open source</a>."
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:264
+#: src/olympia/pages/templates/pages/faq.html:262
 msgid "Collections and Favorites"
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:267
+#: src/olympia/pages/templates/pages/faq.html:265
 msgid "What is a collection?"
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:268
+#: src/olympia/pages/templates/pages/faq.html:266
 msgid "Collections are groups of related add-ons created by users to share."
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:270
+#: src/olympia/pages/templates/pages/faq.html:268
 msgid "What is the My Favorites collection?"
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:271
-msgid ""
-"Favorite add-ons are add-ons that you have bookmarked to easily get back to "
-"later. You can add an add-on to your favorites collection by clicking \"Add "
-"to favorites\" on its details page."
+#: src/olympia/pages/templates/pages/faq.html:269
+msgid "Favorite add-ons are add-ons that you have bookmarked to easily get back to later. You can add an add-on to your favorites collection by clicking \"Add to favorites\" on its details page."
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:275
-#: src/olympia/templates/menu_links.html:13
-#: src/olympia/templates/impala/header_title.html:17
+#: src/olympia/pages/templates/pages/faq.html:273 src/olympia/templates/menu_links.html:13 src/olympia/templates/impala/header_title.html:17
 msgid "Mobile Add-ons"
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:278
+#: src/olympia/pages/templates/pages/faq.html:276
 msgid "What are mobile add-ons?"
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:279
+#: src/olympia/pages/templates/pages/faq.html:277
 #, python-format
 msgid ""
-"Mobile add-ons work with <a href=\"%(mobile_url)s\">Firefox for Mobile</a> "
-"and add or modify functionality just like desktop add-ons. You can find add-"
-"ons that work with Firefox for Mobile in our <a "
-"href=\"%(gallery_url)s\">gallery</a>."
+"Mobile add-ons work with <a href=\"%(mobile_url)s\">Firefox for Mobile</a> and add or modify functionality just like desktop add-ons. You can find add-ons that work with Firefox for Mobile in our "
+"<a href=\"%(gallery_url)s\">gallery</a>."
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:288
+#: src/olympia/pages/templates/pages/faq.html:286
 msgid "Developer Topics"
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:289
+#: src/olympia/pages/templates/pages/faq.html:287
 #, python-format
-msgid ""
-"Please see our <a href=\"%(faq_url)s\">Developer FAQ</a> and <a "
-"href=\"%(hub_url)s\">Developer Hub</a> for answers to add-on developer-"
-"related questions."
+msgid "Please see our <a href=\"%(faq_url)s\">Developer FAQ</a> and <a href=\"%(hub_url)s\">Developer Hub</a> for answers to add-on developer-related questions."
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:294
+#: src/olympia/pages/templates/pages/faq.html:292
 msgid "Still have questions?"
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:295
+#: src/olympia/pages/templates/pages/faq.html:293
 #, python-format
-msgid ""
-"For general Firefox support, visit our <a href=\"%(sumo_url)s\">support "
-"website</a>. For general add-on and website questions, visit our <a "
-"href=\"%(forum_url)s\">forum</a>."
+msgid "For general Firefox support, visit our <a href=\"%(sumo_url)s\">support website</a>. For general add-on and website questions, visit our <a href=\"%(forum_url)s\">forum</a>."
 msgstr ""
 
-#: src/olympia/pages/templates/pages/review_guide.html:36
-#: src/olympia/pages/templates/pages/review_guide.html:51
+#: src/olympia/pages/templates/pages/review_guide.html:36 src/olympia/pages/templates/pages/review_guide.html:51
 msgid "Some tips for writing a great review"
 msgstr ""
 
-#: src/olympia/pages/templates/pages/review_guide.html:39
-#: src/olympia/pages/templates/pages/review_guide.html:131
+#: src/olympia/pages/templates/pages/review_guide.html:39 src/olympia/pages/templates/pages/review_guide.html:131
 msgid "Frequently Asked Questions about Reviews"
 msgstr ""
 
 #: src/olympia/pages/templates/pages/review_guide.html:46
 msgid ""
-"Add-on reviews are a way for you to share your opinions about the add-ons "
-"you’ve installed and used. Our review moderation team reserves the right to "
-"refuse or remove any review that does not comply with these guidelines."
+"Add-on reviews are a way for you to share your opinions about the add-ons you’ve installed and used. Our review moderation team reserves the right to refuse or remove any review that does not "
+"comply with these guidelines."
 msgstr ""
 
 #: src/olympia/pages/templates/pages/review_guide.html:53
@@ -12003,8 +10170,7 @@ msgid "Do:"
 msgstr ""
 
 #: src/olympia/pages/templates/pages/review_guide.html:56
-msgid ""
-"Write like you are telling a friend about your experience with the add-on."
+msgid "Write like you are telling a friend about your experience with the add-on."
 msgstr ""
 
 #: src/olympia/pages/templates/pages/review_guide.html:61
@@ -12036,8 +10202,7 @@ msgid "Will you continue to use this add-on?"
 msgstr ""
 
 #: src/olympia/pages/templates/pages/review_guide.html:73
-msgid ""
-"Take a moment to read your review before submitting it to minimize typos."
+msgid "Take a moment to read your review before submitting it to minimize typos."
 msgstr ""
 
 #: src/olympia/pages/templates/pages/review_guide.html:79
@@ -12050,9 +10215,8 @@ msgstr ""
 
 #: src/olympia/pages/templates/pages/review_guide.html:87
 msgid ""
-"Post technical issues, support requests, or feature suggestions. Use the "
-"available support options for each add-on, if available. You can find them "
-"in the side column next to the About this Add-on section."
+"Post technical issues, support requests, or feature suggestions. Use the available support options for each add-on, if available. You can find them in the side column next to the About this Add-on "
+"section."
 msgstr ""
 
 #: src/olympia/pages/templates/pages/review_guide.html:92
@@ -12060,38 +10224,29 @@ msgid "Write reviews for add-ons which you have not personally used."
 msgstr ""
 
 #: src/olympia/pages/templates/pages/review_guide.html:97
-msgid ""
-"Use profanity, sexual language or language that can be construed as hateful."
+msgid "Use profanity, sexual language or language that can be construed as hateful."
 msgstr ""
 
 #: src/olympia/pages/templates/pages/review_guide.html:103
-msgid ""
-"Include HTML, links, source code or code snippets. Reviews are meant to be "
-"text only."
+msgid "Include HTML, links, source code or code snippets. Reviews are meant to be text only."
 msgstr ""
 
 #: src/olympia/pages/templates/pages/review_guide.html:108
-msgid ""
-"Make false statements, disparage add-on authors or personally insult them."
+msgid "Make false statements, disparage add-on authors or personally insult them."
 msgstr ""
 
 #: src/olympia/pages/templates/pages/review_guide.html:114
-msgid ""
-"Include your own or anyone else’s email, phone number, or other personal "
-"details."
+msgid "Include your own or anyone else’s email, phone number, or other personal details."
 msgstr ""
 
 #: src/olympia/pages/templates/pages/review_guide.html:119
-msgid ""
-"Post reviews for an add-on you or your organization wrote or represent."
+msgid "Post reviews for an add-on you or your organization wrote or represent."
 msgstr ""
 
 #: src/olympia/pages/templates/pages/review_guide.html:125
 msgid ""
-"Criticize an add-on for something it’s intended to do. For example, leaving "
-"a negative review of an add-on for displaying ads or requiring data "
-"gathering, when that is the intended purpose of the add-on, or the add-on "
-"requires gathering data to function."
+"Criticize an add-on for something it’s intended to do. For example, leaving a negative review of an add-on for displaying ads or requiring data gathering, when that is the intended purpose of the "
+"add-on, or the add-on requires gathering data to function."
 msgstr ""
 
 #: src/olympia/pages/templates/pages/review_guide.html:133
@@ -12100,10 +10255,8 @@ msgstr ""
 
 #: src/olympia/pages/templates/pages/review_guide.html:135
 msgid ""
-"Please report or flag any questionable reviews by clicking the \"Report this"
-" review\" and it will be submitted to the site for moderation. Our "
-"moderation team will use the Review Guidelines to evaluate whether or not to"
-" delete the review or restore it back to the site."
+"Please report or flag any questionable reviews by clicking the \"Report this review\" and it will be submitted to the site for moderation. Our moderation team will use the Review Guidelines to "
+"evaluate whether or not to delete the review or restore it back to the site."
 msgstr ""
 
 #: src/olympia/pages/templates/pages/review_guide.html:140
@@ -12112,10 +10265,7 @@ msgstr ""
 
 #: src/olympia/pages/templates/pages/review_guide.html:142
 #, python-format
-msgid ""
-"Yes, add-on authors can provide a single response to a review. You can set "
-"up a discussion topic in our <a href=\"%(forum_url)s\">forum</a> to engage "
-"in additional discussion or follow-up."
+msgid "Yes, add-on authors can provide a single response to a review. You can set up a discussion topic in our <a href=\"%(forum_url)s\">forum</a> to engage in additional discussion or follow-up."
 msgstr ""
 
 #: src/olympia/pages/templates/pages/review_guide.html:149
@@ -12124,11 +10274,8 @@ msgstr ""
 
 #: src/olympia/pages/templates/pages/review_guide.html:151
 msgid ""
-"In general, no. But if the review did not meet the review guidelines "
-"outlined above, you can click \"Report this review\" and have it moderated. "
-"If a review included a complaint that is no longer valid due to a new "
-"release of your add-on, we may consider deleting the review. Submit your "
-"detailed request to amo-editors@mozilla.org."
+"In general, no. But if the review did not meet the review guidelines outlined above, you can click \"Report this review\" and have it moderated. If a review included a complaint that is no longer "
+"valid due to a new release of your add-on, we may consider deleting the review. Submit your detailed request to amo-editors@mozilla.org."
 msgstr ""
 
 #: src/olympia/pages/templates/pages/sunbird.html:26
@@ -12137,17 +10284,13 @@ msgstr ""
 
 #: src/olympia/pages/templates/pages/sunbird.html:29
 msgid ""
-"Development on the Sunbird project has halted and its final release was on "
-"March 30, 2010.  We've been proud to host Sunbird add-ons on this site but "
-"as the project is no longer maintained we have disabled our support for the "
-"add-ons."
+"Development on the Sunbird project has halted and its final release was on March 30, 2010. We've been proud to host Sunbird add-ons on this site but as the project is no longer maintained we have "
+"disabled our support for the add-ons."
 msgstr ""
 
 #: src/olympia/pages/templates/pages/sunbird.html:38
 #, python-format
-msgid ""
-"We recommend upgrading to <a href=\"%(tb_url)s\">Thunderbird</a> and <a "
-"href=\"%(lightning_url)s\">Lightning</a>."
+msgid "We recommend upgrading to <a href=\"%(tb_url)s\">Thunderbird</a> and <a href=\"%(lightning_url)s\">Lightning</a>."
 msgstr ""
 
 #: src/olympia/pages/templates/pages/sunbird.html:45
@@ -12199,8 +10342,7 @@ msgstr ""
 msgid "Skip for now"
 msgstr ""
 
-#: src/olympia/reviews/forms.py:151
-#: src/olympia/reviews/templates/reviews/review.html:107
+#: src/olympia/reviews/forms.py:151 src/olympia/reviews/templates/reviews/review.html:107
 msgid "Delete review"
 msgstr ""
 
@@ -12219,27 +10361,18 @@ msgstr ""
 #: src/olympia/reviews/templates/reviews/add.html:26
 #, python-format
 msgid ""
-"<h2>Keep these tips in mind:</h2> <ul> <li> Write like you're telling a "
-"friend about your experience with the add-on. Give specifics and helpful "
-"details, such as what features you liked and/or disliked, how easy to use it"
-" is, and any disadvantages it has.  Avoid generic language such as calling "
-"it \"Great\" or \"Bad\" unless you can give reasons why you believe this is "
-"so. </li> <li> Please do not post bug reports in reviews. We do not make "
-"your email address available to add-on developers and they may need to "
-"contact you to help resolve your issue. See the <a "
-"href=\"%(support)s\">support section</a> to find out where to get assistance"
-" for this add-on. </li> <li>Please keep reviews clean, avoid the use of "
-"improper language and do not post any personal information. </li> </ul> "
-"<p>Please read the <a href=\"%(guide)s\" target=\"_blank\">Review "
-"Guidelines</a> for more detail about user add-on reviews.</p>"
+"<h2>Keep these tips in mind:</h2> <ul> <li> Write like you're telling a friend about your experience with the add-on. Give specifics and helpful details, such as what features you liked and/or "
+"disliked, how easy to use it is, and any disadvantages it has. Avoid generic language such as calling it \"Great\" or \"Bad\" unless you can give reasons why you believe this is so. </li> <li> "
+"Please do not post bug reports in reviews. We do not make your email address available to add-on developers and they may need to contact you to help resolve your issue. See the <a href=\"%(support)s"
+"\">support section</a> to find out where to get assistance for this add-on. </li> <li>Please keep reviews clean, avoid the use of improper language and do not post any personal information. </li> </"
+"ul> <p>Please read the <a href=\"%(guide)s\" target=\"_blank\">Review Guidelines</a> for more detail about user add-on reviews.</p>"
 msgstr ""
 
 #: src/olympia/reviews/templates/reviews/reply.html:4
 msgid "Reply to review by {0}"
 msgstr ""
 
-#: src/olympia/reviews/templates/reviews/reply.html:15
-#: src/olympia/reviews/templates/reviews/reply.html:31
+#: src/olympia/reviews/templates/reviews/reply.html:15 src/olympia/reviews/templates/reviews/reply.html:31
 msgid "Reply"
 msgstr ""
 
@@ -12247,8 +10380,7 @@ msgstr ""
 msgid "Write a Reply"
 msgstr ""
 
-#: src/olympia/reviews/templates/reviews/reply.html:36
-#: src/olympia/reviews/templates/reviews/report_review.html:12
+#: src/olympia/reviews/templates/reviews/reply.html:36 src/olympia/reviews/templates/reviews/report_review.html:12
 msgid "Submit"
 msgstr ""
 
@@ -12268,26 +10400,20 @@ msgid "by %(user)s <b>(Developer)</b> on %(date)s"
 msgstr ""
 
 #. {0} is a version number (like 1.01)
-#: src/olympia/reviews/templates/reviews/review.html:50
-#: src/olympia/reviews/templates/reviews/mobile/review_list.html:41
+#: src/olympia/reviews/templates/reviews/review.html:50 src/olympia/reviews/templates/reviews/mobile/review_list.html:41
 msgid "This review is for a previous version of the add-on ({0})."
 msgstr ""
 
 #: src/olympia/reviews/templates/reviews/review.html:56
 #, python-format
-msgid ""
-"This user has a <a href=\"%(user_review_url)s\">previous review</a> of this "
-"add-on."
-msgid_plural ""
-"This user has <a href=\"%(user_review_url)s\">%(cnt)s previous reviews</a> "
-"of this add-on."
+msgid "This user has a <a href=\"%(user_review_url)s\">previous review</a> of this add-on."
+msgid_plural "This user has <a href=\"%(user_review_url)s\">%(cnt)s previous reviews</a> of this add-on."
 msgstr[0] ""
+msgstr[1] ""
 
 #: src/olympia/reviews/templates/reviews/review.html:62
 #, python-format
-msgid ""
-"This user has <a href=\"%(user_review_url)s\">other reviews</a> of this add-"
-"on."
+msgid "This user has <a href=\"%(user_review_url)s\">other reviews</a> of this add-on."
 msgstr ""
 
 #: src/olympia/reviews/templates/reviews/review.html:72
@@ -12320,9 +10446,7 @@ msgid "{0} :: Reviews"
 msgstr ""
 
 #. {0} is an addon name.
-#: src/olympia/reviews/templates/reviews/review_list.html:24
-#: src/olympia/reviews/templates/reviews/mobile/add.html:4
-#: src/olympia/reviews/templates/reviews/mobile/review_list.html:4
+#: src/olympia/reviews/templates/reviews/review_list.html:24 src/olympia/reviews/templates/reviews/mobile/add.html:4 src/olympia/reviews/templates/reviews/mobile/review_list.html:4
 msgid "Reviews for {0}"
 msgstr ""
 
@@ -12331,6 +10455,7 @@ msgstr ""
 msgid "<b>{0}</b> review for this add-on"
 msgid_plural "<b>{0}</b> reviews for this add-on"
 msgstr[0] ""
+msgstr[1] ""
 
 #. {0} is a developer's name.
 #: src/olympia/reviews/templates/reviews/review_list.html:33
@@ -12342,6 +10467,7 @@ msgstr ""
 msgid "Review for %(addon)s by %(user)s"
 msgid_plural "Reviews for %(addon)s by %(user)s"
 msgstr[0] ""
+msgstr[1] ""
 
 #: src/olympia/reviews/templates/reviews/review_list.html:42
 msgid "No reviews found."
@@ -12356,8 +10482,7 @@ msgstr ""
 msgid "Write a New Review"
 msgstr ""
 
-#: src/olympia/reviews/templates/reviews/review_list.html:81
-#: src/olympia/reviews/templates/reviews/mobile/reviews_link.html:15
+#: src/olympia/reviews/templates/reviews/review_list.html:81 src/olympia/reviews/templates/reviews/mobile/reviews_link.html:15
 msgid "Be the first to write a review."
 msgstr ""
 
@@ -12365,6 +10490,7 @@ msgstr ""
 msgid "{num} review"
 msgid_plural "{num} reviews"
 msgstr[0] ""
+msgstr[1] ""
 
 #: src/olympia/reviews/templates/reviews/impala/reviews_rating.html:1
 msgid "Rated {0} out of 5 stars"
@@ -12375,8 +10501,7 @@ msgstr ""
 msgid "Rated %(rating)s out of 5 stars"
 msgstr ""
 
-#: src/olympia/reviews/templates/reviews/mobile/add_form.html:3
-#: src/olympia/reviews/templates/reviews/mobile/add_form.html:8
+#: src/olympia/reviews/templates/reviews/mobile/add_form.html:3 src/olympia/reviews/templates/reviews/mobile/add_form.html:8
 msgid "Add a Review"
 msgstr ""
 
@@ -12392,6 +10517,7 @@ msgstr ""
 msgid "Average from {0} Rating"
 msgid_plural "Average from {0} Ratings"
 msgstr[0] ""
+msgstr[1] ""
 
 #: src/olympia/reviews/templates/reviews/mobile/review_list.html:34
 #, python-format
@@ -12407,6 +10533,7 @@ msgstr ""
 msgid "See All Reviews"
 msgid_plural "See All %(cnt)s Reviews"
 msgstr[0] ""
+msgstr[1] ""
 
 #: src/olympia/search/forms.py:11
 msgid "Most popular this week"
@@ -12445,14 +10572,11 @@ msgid "Relevance"
 msgstr ""
 
 #: src/olympia/search/helpers.py:24
-msgid ""
-"Results <strong>{0}</strong>-<strong>{1}</strong> of <strong>{2}</strong>"
+msgid "Results <strong>{0}</strong>-<strong>{1}</strong> of <strong>{2}</strong>"
 msgstr ""
 
 #: src/olympia/search/helpers.py:44
-msgid ""
-"Showing {0} - {1} of {2} results for <strong>{3}</strong> tagged with "
-"<strong>{4}</strong>"
+msgid "Showing {0} - {1} of {2} results for <strong>{3}</strong> tagged with <strong>{4}</strong>"
 msgstr ""
 
 #: src/olympia/search/helpers.py:49
@@ -12468,24 +10592,22 @@ msgid "Showing {0} - {1} of {2} results"
 msgstr ""
 
 #. {0} is an application, like Firefox.
-#: src/olympia/search/views.py:264 src/olympia/templates/base.html:17
-#: src/olympia/templates/impala/base.html:17
-#: src/olympia/templates/mobile/base_addons.html:17
+#: src/olympia/search/views.py:264 src/olympia/templates/base.html:17 src/olympia/templates/impala/base.html:17 src/olympia/templates/mobile/base_addons.html:17
 msgid "{0} Add-ons"
 msgstr ""
 
 #. L10n: {0} is an application, such as Firefox. This means "any version of
 #. Firefox."
-#: src/olympia/search/views.py:554
+#: src/olympia/search/views.py:547
 msgid "Any {0}"
 msgstr ""
 
 #. L10n: "All Systems" means show everything regardless of platform.
-#: src/olympia/search/views.py:589
+#: src/olympia/search/views.py:582
 msgid "All Systems"
 msgstr ""
 
-#: src/olympia/search/views.py:600
+#: src/olympia/search/views.py:593
 msgid "All Tags"
 msgstr ""
 
@@ -12529,6 +10651,7 @@ msgstr ""
 msgid "<b>{0}</b> matching result"
 msgid_plural "<b>{0}</b> matching results"
 msgstr[0] ""
+msgstr[1] ""
 
 #: src/olympia/search/templates/search/results.html:67
 msgid "Filter Results"
@@ -12550,6 +10673,7 @@ msgstr ""
 msgid "{0} post"
 msgid_plural "{0} posts"
 msgstr[0] ""
+msgstr[1] ""
 
 #: src/olympia/sharing/__init__.py:20
 msgid "Post to Facebook"
@@ -12559,6 +10683,7 @@ msgstr ""
 msgid "{0} Like"
 msgid_plural "{0} Likes"
 msgstr[0] ""
+msgstr[1] ""
 
 #: src/olympia/sharing/__init__.py:30
 msgid "Tweet on Twitter"
@@ -12568,6 +10693,7 @@ msgstr ""
 msgid "{0} tweet"
 msgid_plural "{0} tweets"
 msgstr[0] ""
+msgstr[1] ""
 
 #: src/olympia/sharing/__init__.py:40
 msgid "Share on g+"
@@ -12601,6 +10727,7 @@ msgstr ""
 msgid "{0} post on localservice1"
 msgid_plural "{0} posts on localservice1"
 msgstr[0] ""
+msgstr[1] ""
 
 #. L10n: Only change if you have reason! wiki.mozilla.org/AMO:Localizers
 #: src/olympia/sharing/__init__.py:76
@@ -12622,6 +10749,7 @@ msgstr ""
 msgid "{0} post on localservice2"
 msgid_plural "{0} posts on localservice2"
 msgstr[0] ""
+msgstr[1] ""
 
 #. L10n: Only change if you have reason! wiki.mozilla.org/AMO:Localizers
 #: src/olympia/sharing/__init__.py:91
@@ -12643,6 +10771,7 @@ msgstr ""
 msgid "{0} post on localservice3"
 msgid_plural "{0} posts on localservice3"
 msgstr[0] ""
+msgstr[1] ""
 
 #: src/olympia/sharing/templates/sharing/sharing_widget.html:2
 msgid "Share this Add-on"
@@ -12652,34 +10781,31 @@ msgstr ""
 msgid "Share this Collection"
 msgstr ""
 
-#: src/olympia/signing/views.py:30 src/olympia/templates/base.html:75
-#: src/olympia/templates/impala/base.html:115
-msgid ""
-"Some features are temporarily disabled while we perform website maintenance."
-" We'll be back to full capacity shortly."
+#: src/olympia/signing/views.py:33 src/olympia/templates/base.html:71 src/olympia/templates/impala/base.html:112
+msgid "Some features are temporarily disabled while we perform website maintenance. We'll be back to full capacity shortly."
 msgstr ""
 
-#: src/olympia/signing/views.py:53
+#: src/olympia/signing/views.py:56
 msgid "Could not find add-on with id \"{}\"."
 msgstr ""
 
-#: src/olympia/signing/views.py:67
+#: src/olympia/signing/views.py:70
 msgid "You do not own this addon."
 msgstr ""
 
-#: src/olympia/signing/views.py:82
+#: src/olympia/signing/views.py:87
 msgid "Missing \"upload\" key in multipart file data."
 msgstr ""
 
-#: src/olympia/signing/views.py:96
+#: src/olympia/signing/views.py:101
 msgid "Version does not match the manifest file."
 msgstr ""
 
-#: src/olympia/signing/views.py:100
+#: src/olympia/signing/views.py:105
 msgid "Version already exists."
 msgstr ""
 
-#: src/olympia/signing/views.py:136
+#: src/olympia/signing/views.py:141
 msgid "No uploaded file for that addon and version."
 msgstr ""
 
@@ -12771,8 +10897,7 @@ msgstr ""
 msgid "To"
 msgstr ""
 
-#: src/olympia/stats/templates/stats/popup.html:27
-#: src/olympia/users/templates/users/pwreset_confirm.html:38
+#: src/olympia/stats/templates/stats/popup.html:27 src/olympia/users/templates/users/pwreset_confirm.html:38
 msgid "Update"
 msgstr ""
 
@@ -12793,95 +10918,89 @@ msgstr ""
 msgid "Statistics Dashboard :: Add-ons for {0}"
 msgstr ""
 
-#: src/olympia/stats/templates/stats/stats.html:30
-msgid "Controls:"
-msgstr ""
-
-#: src/olympia/stats/templates/stats/stats.html:33
-msgid "reset zoom"
-msgstr ""
-
-#: src/olympia/stats/templates/stats/stats.html:40
-msgid "Group by:"
-msgstr ""
-
-#: src/olympia/stats/templates/stats/stats.html:42
-msgid "day"
-msgstr ""
-
-#: src/olympia/stats/templates/stats/stats.html:45
-msgid "week"
-msgstr ""
-
-#: src/olympia/stats/templates/stats/stats.html:48
-msgid "month"
-msgstr ""
-
-#: src/olympia/stats/templates/stats/stats.html:54
-msgid "For last:"
-msgstr ""
-
-#: src/olympia/stats/templates/stats/stats.html:57
-msgid "7 days"
-msgstr ""
-
-#: src/olympia/stats/templates/stats/stats.html:60
-msgid "30 days"
-msgstr ""
-
-#: src/olympia/stats/templates/stats/stats.html:63
-msgid "90 days"
-msgstr ""
-
-#: src/olympia/stats/templates/stats/stats.html:66
-msgid "365 days"
-msgstr ""
-
-#: src/olympia/stats/templates/stats/stats.html:69
-msgid "Custom..."
-msgstr ""
-
 #. {0} is an add-on name
-#: src/olympia/stats/templates/stats/stats.html:88
-#: src/olympia/stats/templates/stats/stats.html:91
+#: src/olympia/stats/templates/stats/stats.html:44 src/olympia/stats/templates/stats/stats.html:47
 msgid "Statistics for {0}"
 msgstr ""
 
-#: src/olympia/stats/templates/stats/stats.html:94
+#: src/olympia/stats/templates/stats/stats.html:50
 msgid "Statistics Dashboard"
 msgstr ""
 
-#: src/olympia/stats/templates/stats/stats.html:104
-msgid ""
-"Statistics processing is currently disabled, so recent data is unavailable. "
-"The statistics are still being collected and this page will be updated soon "
-"with the missing data."
+#: src/olympia/stats/templates/stats/stats.html:57
+msgid "Controls:"
 msgstr ""
 
-#: src/olympia/stats/templates/stats/stats.html:110
+#: src/olympia/stats/templates/stats/stats.html:60
+msgid "reset zoom"
+msgstr ""
+
+#: src/olympia/stats/templates/stats/stats.html:67
+msgid "Group by:"
+msgstr ""
+
+#: src/olympia/stats/templates/stats/stats.html:69
+msgid "day"
+msgstr ""
+
+#: src/olympia/stats/templates/stats/stats.html:72
+msgid "week"
+msgstr ""
+
+#: src/olympia/stats/templates/stats/stats.html:75
+msgid "month"
+msgstr ""
+
+#: src/olympia/stats/templates/stats/stats.html:81
+msgid "For last:"
+msgstr ""
+
+#: src/olympia/stats/templates/stats/stats.html:84
+msgid "7 days"
+msgstr ""
+
+#: src/olympia/stats/templates/stats/stats.html:87
+msgid "30 days"
+msgstr ""
+
+#: src/olympia/stats/templates/stats/stats.html:90
+msgid "90 days"
+msgstr ""
+
+#: src/olympia/stats/templates/stats/stats.html:93
+msgid "365 days"
+msgstr ""
+
+#: src/olympia/stats/templates/stats/stats.html:96
+msgid "Custom..."
+msgstr ""
+
+#: src/olympia/stats/templates/stats/stats.html:106
+msgid "Statistics processing is currently disabled, so recent data is unavailable. The statistics are still being collected and this page will be updated soon with the missing data."
+msgstr ""
+
+#: src/olympia/stats/templates/stats/stats.html:112
 msgid "Loading the latest data&hellip;"
 msgstr ""
 
-#: src/olympia/stats/templates/stats/stats.html:142
-#: src/olympia/stats/templates/stats/reports/overview.html:25
-#: src/olympia/stats/templates/stats/reports/overview.html:37
+#: src/olympia/stats/templates/stats/stats.html:144 src/olympia/stats/templates/stats/reports/overview.html:25 src/olympia/stats/templates/stats/reports/overview.html:37
 #: src/olympia/stats/templates/stats/reports/overview.html:49
 msgid "No data available."
 msgstr ""
 
-#: src/olympia/stats/templates/stats/stats.html:177
+#: src/olympia/stats/templates/stats/stats.html:179
 msgid "This dashboard is currently <b>public</b>."
 msgstr ""
 
-#: src/olympia/stats/templates/stats/stats.html:179
+#: src/olympia/stats/templates/stats/stats.html:181
 msgid "Contribution stats are currently <b>private</b>."
 msgstr ""
 
-#: src/olympia/stats/templates/stats/stats.html:182
+#: src/olympia/stats/templates/stats/stats.html:184
 msgid "This dashboard is currently <b>private</b>."
 msgstr ""
 
-#: src/olympia/stats/templates/stats/stats.html:185
+#: src/olympia/stats/templates/stats/stats.html:187
 msgid "Change settings."
 msgstr ""
 
@@ -12923,9 +11042,8 @@ msgstr ""
 
 #: src/olympia/stats/templates/stats/reports/downloads.html:10
 msgid ""
-"<h2>How are downloads counted?</h2> <p> Download counts are updated every "
-"evening and only include original add-on downloads, not updates. Downloads "
-"can be broken down by the specific source referring the download. </p>"
+"<h2>How are downloads counted?</h2> <p> Download counts are updated every evening and only include original add-on downloads, not updates. Downloads can be broken down by the specific source "
+"referring the download. </p>"
 msgstr ""
 
 #: src/olympia/stats/templates/stats/reports/locales.html:3
@@ -12940,8 +11058,7 @@ msgstr ""
 msgid "<b>{0}</b> Downloads"
 msgstr ""
 
-#: src/olympia/stats/templates/stats/reports/overview.html:9
-#: src/olympia/stats/templates/stats/reports/overview.html:13
+#: src/olympia/stats/templates/stats/reports/overview.html:9 src/olympia/stats/templates/stats/reports/overview.html:13
 msgid "Loading..."
 msgstr ""
 
@@ -12992,19 +11109,11 @@ msgstr ""
 #: src/olympia/stats/templates/stats/reports/sources.html:10
 #, python-format
 msgid ""
-"<h2>Tracking external sources</h2> <p> If you link to your add-on's details "
-"page or directly to its file from an external site, such as your blog or "
-"website, you can append a parameter to be tracked as an additional download "
-"source on this page. For example, the following links would appear as "
-"sourced by your blog: <dl> <dt>Add-on Details Page</dt> "
-"<dd>https://addons.mozilla.org/addon/%(slug)s?src=<b>external-blog</b></dd> "
-"<dt>Direct File Link</dt> "
-"<dd>https://addons.mozilla.org/downloads/latest/%(id)s/addon-%(id)s-latest.xpi?src=<b"
-">external-blog</b></dd> </dl> <p> Only src parameters that begin with "
-"\"external-\" will be tracked, up to 61 additional characters. Any text "
-"after \"external-\" can be used to describe the source, such as \"external-"
-"blog\", \"external-sidebar\", \"external-campaign225\", etc. The following "
-"URL-safe characters are allowed: <code>a-z A-Z - . _ ~ %% +</code>"
+"<h2>Tracking external sources</h2> <p> If you link to your add-on's details page or directly to its file from an external site, such as your blog or website, you can append a parameter to be "
+"tracked as an additional download source on this page. For example, the following links would appear as sourced by your blog: <dl> <dt>Add-on Details Page</dt> <dd>https://addons.mozilla.org/addon/"
+"%(slug)s?src=<b>external-blog</b></dd> <dt>Direct File Link</dt> <dd>https://addons.mozilla.org/downloads/latest/%(id)s/addon-%(id)s-latest.xpi?src=<b>external-blog</b></dd> </dl> <p> Only src "
+"parameters that begin with \"external-\" will be tracked, up to 61 additional characters. Any text after \"external-\" can be used to describe the source, such as \"external-blog\", \"external-"
+"sidebar\", \"external-campaign225\", etc. The following URL-safe characters are allowed: <code>a-z A-Z - . _ ~ %% +</code>"
 msgstr ""
 
 #: src/olympia/stats/templates/stats/reports/statuses.html:3
@@ -13025,18 +11134,14 @@ msgstr ""
 
 #: src/olympia/stats/templates/stats/reports/usage.html:11
 msgid ""
-"<h2>What are daily users?</h2> <p> Themes installed from this site check for"
-" updates once per day. The total number of these update pings is known as "
-"Active Daily Users, or the total number of people using your theme by day. "
-"</p>"
+"<h2>What are daily users?</h2> <p> Themes installed from this site check for updates once per day. The total number of these update pings is known as Active Daily Users, or the total number of "
+"people using your theme by day. </p>"
 msgstr ""
 
 #: src/olympia/stats/templates/stats/reports/usage.html:20
 msgid ""
-"<h2>What are daily users?</h2> <p> Add-ons downloaded from this site check "
-"for updates once per day. The total number of these update pings is known as"
-" Active Daily Users. Daily users can be broken down by add-on version, "
-"operating system, add-on status, application, and locale. </p>"
+"<h2>What are daily users?</h2> <p> Add-ons downloaded from this site check for updates once per day. The total number of these update pings is known as Active Daily Users. Daily users can be broken "
+"down by add-on version, operating system, add-on status, application, and locale. </p>"
 msgstr ""
 
 #: src/olympia/stats/templates/stats/reports/users_created.html:3
@@ -13047,43 +11152,27 @@ msgstr ""
 msgid "Application versions by Date"
 msgstr ""
 
-#: src/olympia/tags/templates/tags/top_cloud.html:4
-msgid "Top {0} Tags"
-msgstr ""
-
-#. {0} is the current application name
-#: src/olympia/tags/templates/tags/top_cloud.html:14
-msgid "{0} Top Tags"
-msgstr ""
-
-#: src/olympia/templates/amo_footer.html:6
-#: src/olympia/templates/includes/lang_switcher.html:2
+#: src/olympia/templates/amo_footer.html:6 src/olympia/templates/includes/lang_switcher.html:2
 msgid "Other languages"
 msgstr "სხვა ენები"
 
-#: src/olympia/templates/base.html:9 src/olympia/templates/impala/base.html:9
-#: src/olympia/templates/mobile/base_addons.html:9
+#: src/olympia/templates/base.html:9 src/olympia/templates/impala/base.html:9 src/olympia/templates/mobile/base_addons.html:9
 msgid "Mozilla Add-ons"
 msgstr ""
 
-#: src/olympia/templates/base.html:91
-#: src/olympia/templates/impala/base.html:81
+#: src/olympia/templates/base.html:89 src/olympia/templates/impala/base.html:78
 msgid "Find add-ons for other applications"
 msgstr ""
 
-#: src/olympia/templates/base.html:92
-#: src/olympia/templates/impala/base.html:81
+#: src/olympia/templates/base.html:90 src/olympia/templates/impala/base.html:78
 msgid "Other Applications"
 msgstr ""
 
-#: src/olympia/templates/base.html:141
-#: src/olympia/templates/impala/base.html:194
-msgid ""
-"To create your own collections, you must have a Mozilla Add-ons account."
+#: src/olympia/templates/base.html:141 src/olympia/templates/impala/base.html:194
+msgid "To create your own collections, you must have a Mozilla Add-ons account."
 msgstr ""
 
-#: src/olympia/templates/base.html:168
-#: src/olympia/templates/impala/base.html:215
+#: src/olympia/templates/base.html:168 src/olympia/templates/impala/base.html:215
 msgid "Footer logo"
 msgstr ""
 
@@ -13100,20 +11189,18 @@ msgid "View Mobile Site"
 msgstr ""
 
 #: src/olympia/templates/copyright.html:7
-msgid "Site Status "
+msgid "Site Status"
 msgstr ""
 
 #: src/olympia/templates/footer.html:3
 msgid "get to know <b>add-ons</b>"
 msgstr ""
 
-#: src/olympia/templates/footer.html:4
-#: src/olympia/templates/menu_links.html:20
+#: src/olympia/templates/footer.html:4 src/olympia/templates/menu_links.html:20
 msgid "About"
 msgstr ""
 
-#: src/olympia/templates/footer.html:5
-#: src/olympia/templates/menu_links.html:32
+#: src/olympia/templates/footer.html:5 src/olympia/templates/menu_links.html:32
 msgid "Blog"
 msgstr ""
 
@@ -13189,9 +11276,7 @@ msgstr ""
 msgid "Contact Us"
 msgstr ""
 
-#: src/olympia/templates/user_login.html:22
-#: src/olympia/users/templates/users/edit.html:31
-#: src/olympia/users/templates/users/includes/navigation.html:12
+#: src/olympia/templates/user_login.html:22 src/olympia/users/templates/users/edit.html:31 src/olympia/users/templates/users/includes/navigation.html:12
 msgid "My Account"
 msgstr ""
 
@@ -13199,49 +11284,40 @@ msgstr ""
 msgid "Welcome, {0}"
 msgstr ""
 
-#: src/olympia/templates/user_login.html:41
-#: src/olympia/templates/impala/user_login.html:20
+#: src/olympia/templates/user_login.html:41 src/olympia/templates/impala/user_login.html:20
 #, python-format
 msgid "<a href=\"%(reg)s\">Register</a> or <a href=\"%(login)s\">Log in</a>"
 msgstr ""
 
-#: src/olympia/templates/impala/base.html:126
+#: src/olympia/templates/impala/base.html:123
 #, python-format
-msgid ""
-"To try the thousands of add-ons available here, download <a "
-"href=\"%(url)s\">Mozilla Firefox</a>, a fast, free way to surf the Web!"
-msgstr ""
-"აქ ხელმისაწვდომი ათასობით დამატების გამოსაცდელად, ჩამოტვირთეთ <a "
-"href=\"%(url)s\">Mozilla Firefox</a>, სწრაფი, უფაზო საშუალება ვებ-"
-"სერფინგისთვის!"
+msgid "To try the thousands of add-ons available here, download <a href=\"%(url)s\">Mozilla Firefox</a>, a fast, free way to surf the Web!"
+msgstr "აქ ხელმისაწვდომი ათასობით დამატების გამოსაცდელად, ჩამოტვირთეთ <a href=\"%(url)s\">Mozilla Firefox</a>, სწრაფი, უფაზო საშუალება ვებ-სერფინგისთვის!"
 
-#: src/olympia/templates/impala/base.html:138
+#: src/olympia/templates/impala/base.html:135
 #, python-format
-msgid ""
-"Add-ons is switching to Firefox Accounts for login. <a href=\"%(url)s\" "
-"class=\"fxa-login\">Sign in now to transfer your account.</a>"
+msgid "Add-ons is switching to Firefox Accounts for login. <a href=\"%(url)s\" class=\"fxa-login\">Sign in now to transfer your account.</a>"
 msgstr ""
 
 #. {0} is an application, such as Firefox.
-#: src/olympia/templates/impala/base.html:148
+#: src/olympia/templates/impala/base.html:145
 msgid "Welcome to {0} Add-ons."
 msgstr ""
 
-#: src/olympia/templates/impala/base.html:151
-msgid ""
-"Choose from thousands of extra features and styles to make Firefox your own."
+#: src/olympia/templates/impala/base.html:148
+msgid "Choose from thousands of extra features and styles to make Firefox your own."
 msgstr ""
 
-#: src/olympia/templates/impala/base.html:156
+#: src/olympia/templates/impala/base.html:153
 #, python-format
 msgid "Add extra features and styles to make %(app)s your own."
 msgstr ""
 
-#: src/olympia/templates/impala/base.html:164
+#: src/olympia/templates/impala/base.html:161
 msgid "On the go?"
 msgstr ""
 
-#: src/olympia/templates/impala/base.html:166
+#: src/olympia/templates/impala/base.html:163
 msgid "Check out our <a class=\"mobile-link\" href=\"#\">Mobile Add-ons site</a>."
 msgstr ""
 
@@ -13249,8 +11325,7 @@ msgstr ""
 msgid "Android Add-ons"
 msgstr "Android დამატებები"
 
-#: src/olympia/templates/includes/forms.html:2
-#: src/olympia/templates/includes/forms.html:6
+#: src/olympia/templates/includes/forms.html:2 src/olympia/templates/includes/forms.html:6
 msgid "required"
 msgstr ""
 
@@ -13295,15 +11370,11 @@ msgstr ""
 msgid "menu"
 msgstr ""
 
-#: src/olympia/templates/mobile/header_auth.html:7
-#: src/olympia/users/templates/users/register.html:41
-#: src/olympia/users/templates/users/register.html:89
+#: src/olympia/templates/mobile/header_auth.html:7 src/olympia/users/templates/users/register.html:41 src/olympia/users/templates/users/register.html:89
 msgid "Register"
 msgstr ""
 
-#: src/olympia/templates/mobile/header_auth.html:8
-#: src/olympia/users/templates/users/login_form.html:41
-#: src/olympia/users/templates/users/pwreset_complete.html:15
+#: src/olympia/templates/mobile/header_auth.html:8 src/olympia/users/templates/users/login_form.html:41 src/olympia/users/templates/users/pwreset_complete.html:15
 #: src/olympia/users/templates/users/mobile/login.html:56
 msgid "Log in"
 msgstr ""
@@ -13314,8 +11385,7 @@ msgstr ""
 msgid "Localize for: <a id=\"change-locale\" href=\"#\">%(dl)s</a>"
 msgstr ""
 
-#: src/olympia/translations/templates/translations/trans-menu.html:16
-#: src/olympia/translations/templates/translations/trans-menu.html:29
+#: src/olympia/translations/templates/translations/trans-menu.html:16 src/olympia/translations/templates/translations/trans-menu.html:29
 #, python-format
 msgid "%(title)s <em>&middot; %(lang)s</em>"
 msgstr ""
@@ -13330,9 +11400,7 @@ msgstr ""
 
 #. {0} is a language name, like 'French'
 #: src/olympia/translations/templates/translations/trans-menu.html:42
-msgid ""
-"You have unsaved changes in the <b>{0}</b> locale. Would you like to save "
-"your changes before switching locales?"
+msgid "You have unsaved changes in the <b>{0}</b> locale. Would you like to save your changes before switching locales?"
 msgstr ""
 
 #: src/olympia/translations/templates/translations/trans-menu.html:49
@@ -13341,9 +11409,7 @@ msgstr ""
 
 #. {0} is a language name, like 'French'
 #: src/olympia/translations/templates/translations/trans-menu.html:56
-msgid ""
-"Are you sure you want to remove all <b>{0}</b> translations? This cannot be "
-"undone."
+msgid "Are you sure you want to remove all <b>{0}</b> translations? This cannot be undone."
 msgstr ""
 
 #: src/olympia/translations/templates/translations/trans-menu.html:61
@@ -13365,20 +11431,14 @@ msgstr ""
 
 #: src/olympia/users/forms.py:90
 #, python-format
-msgid ""
-"As part of our new password policy, your password must be %s characters or "
-"more. Please update your password by <a href=\"%s\">issuing a password "
-"reset</a>."
+msgid "As part of our new password policy, your password must be %s characters or more. Please update your password by <a href=\"%s\">issuing a password reset</a>."
 msgstr ""
 
 #: src/olympia/users/forms.py:115
-msgid ""
-"You must recover your password through Firefox Accounts. Try logging in "
-"instead."
+msgid "You must recover your password through Firefox Accounts. Try logging in instead."
 msgstr ""
 
-#: src/olympia/users/forms.py:206
-#: src/olympia/users/templates/users/pwreset_confirm.html:24
+#: src/olympia/users/forms.py:206 src/olympia/users/templates/users/pwreset_confirm.html:24
 msgid "New password"
 msgstr ""
 
@@ -13391,9 +11451,7 @@ msgid "Usernames cannot contain only digits."
 msgstr ""
 
 #: src/olympia/users/forms.py:274
-msgid ""
-"Enter a valid username consisting of letters, numbers, underscores or "
-"hyphens."
+msgid "Enter a valid username consisting of letters, numbers, underscores or hyphens."
 msgstr ""
 
 #: src/olympia/users/forms.py:277
@@ -13404,33 +11462,24 @@ msgstr ""
 msgid "This username is already in use."
 msgstr ""
 
-#: src/olympia/users/forms.py:296
-#: src/olympia/users/templates/users/edit.html:107
+#: src/olympia/users/forms.py:296 src/olympia/users/templates/users/edit.html:107
 msgid "Display Name"
 msgstr ""
 
-#: src/olympia/users/forms.py:298
-#: src/olympia/users/templates/users/edit.html:112
-#: src/olympia/users/templates/users/vcard.html:10
+#: src/olympia/users/forms.py:298 src/olympia/users/templates/users/edit.html:112 src/olympia/users/templates/users/vcard.html:10
 msgid "Location"
 msgstr ""
 
-#: src/olympia/users/forms.py:300
-#: src/olympia/users/templates/users/edit.html:117
-#: src/olympia/users/templates/users/vcard.html:16
+#: src/olympia/users/forms.py:300 src/olympia/users/templates/users/edit.html:117 src/olympia/users/templates/users/vcard.html:16
 msgid "Occupation"
 msgstr ""
 
 #: src/olympia/users/forms.py:329
-msgid ""
-"This URL has an invalid format. Valid URLs look like "
-"http://example.com/my_page."
+msgid "This URL has an invalid format. Valid URLs look like http://example.com/my_page."
 msgstr ""
 
 #: src/olympia/users/forms.py:337
-msgid ""
-"Please use an email address from a different provider to complete your "
-"registration."
+msgid "Please use an email address from a different provider to complete your registration."
 msgstr ""
 
 #: src/olympia/users/forms.py:345
@@ -13441,13 +11490,11 @@ msgstr ""
 msgid "The passwords did not match."
 msgstr ""
 
-#: src/olympia/users/forms.py:377
-#: src/olympia/users/templates/users/edit.html:128
+#: src/olympia/users/forms.py:377 src/olympia/users/templates/users/edit.html:128
 msgid "Profile Photo"
 msgstr ""
 
-#: src/olympia/users/forms.py:385
-#: src/olympia/users/templates/users/edit.html:142
+#: src/olympia/users/forms.py:385 src/olympia/users/templates/users/edit.html:142
 msgid "Default locale"
 msgstr ""
 
@@ -13464,9 +11511,7 @@ msgid "Email cannot be changed."
 msgstr ""
 
 #: src/olympia/users/forms.py:541
-msgid ""
-"To anonymize, enter a reason for the change but do not change any other "
-"field."
+msgid "To anonymize, enter a reason for the change but do not change any other field."
 msgstr ""
 
 #: src/olympia/users/forms.py:587
@@ -13496,19 +11541,19 @@ msgstr ""
 
 #. L10n: {id} will be something like "13ad6a", just a random number
 #. to differentiate this user from other anonymous users.
-#: src/olympia/users/models.py:353
+#: src/olympia/users/models.py:362
 msgid "Anonymous user {id}"
 msgstr ""
 
-#: src/olympia/users/models.py:410
+#: src/olympia/users/models.py:419
 msgid "Your account has been restricted"
 msgstr ""
 
-#: src/olympia/users/models.py:480
+#: src/olympia/users/models.py:489
 msgid "Please confirm your email address"
 msgstr ""
 
-#: src/olympia/users/models.py:506
+#: src/olympia/users/models.py:515
 msgid "My Mobile Add-ons"
 msgstr ""
 
@@ -13573,8 +11618,7 @@ msgid "Mozilla needs to contact me about my individual app"
 msgstr ""
 
 #: src/olympia/users/notifications.py:139
-msgid ""
-"Mozilla wants to contact me about relevant App Developer news and surveys"
+msgid "Mozilla wants to contact me about relevant App Developer news and surveys"
 msgstr ""
 
 #: src/olympia/users/notifications.py:150
@@ -13602,10 +11646,7 @@ msgid "Successfully verified!"
 msgstr ""
 
 #: src/olympia/users/views.py:132
-msgid ""
-"An email has been sent to your address to confirm your account. Before you "
-"can log in, you have to activate your account by clicking on the link "
-"provided in this email."
+msgid "An email has been sent to your address to confirm your account. Before you can log in, you have to activate your account by clicking on the link provided in this email."
 msgstr ""
 
 #: src/olympia/users/views.py:136 src/olympia/users/views.py:619
@@ -13630,9 +11671,8 @@ msgstr ""
 
 #: src/olympia/users/views.py:197
 msgid ""
-"An email has been sent to {0} to confirm your new email address. For the "
-"change to take effect, you need to click on the link provided in this email."
-" Until then, you can keep logging in with your current email address."
+"An email has been sent to {0} to confirm your new email address. For the change to take effect, you need to click on the link provided in this email. Until then, you can keep logging in with your "
+"current email address."
 msgstr ""
 
 #: src/olympia/users/views.py:210
@@ -13645,13 +11685,11 @@ msgid "Errors Found"
 msgstr ""
 
 #: src/olympia/users/views.py:225
-msgid ""
-"There were errors in the changes you made. Please correct them and resubmit."
+msgid "There were errors in the changes you made. Please correct them and resubmit."
 msgstr ""
 
 #: src/olympia/users/views.py:273
-msgid ""
-"We're sorry, but you are not eligible to request a t-shirt at this time."
+msgid "We're sorry, but you are not eligible to request a t-shirt at this time."
 msgstr ""
 
 #: src/olympia/users/views.py:329
@@ -13667,18 +11705,14 @@ msgid "Wrong email address or password!"
 msgstr ""
 
 #: src/olympia/users/views.py:434
-msgid ""
-"A link to activate your user account was sent by email to your address {0}. "
-"You have to click it before you can log in."
+msgid "A link to activate your user account was sent by email to your address {0}. You have to click it before you can log in."
 msgstr ""
 
 #: src/olympia/users/views.py:439
 #, python-format
 msgid ""
-"If you did not receive the confirmation email, make sure your email service "
-"did not mark it as \"junk mail\" or \"spam\". If you need to, you can have "
-"us <a href=\"%s\">resend the confirmation message</a> to your email address "
-"mentioned above."
+"If you did not receive the confirmation email, make sure your email service did not mark it as \"junk mail\" or \"spam\". If you need to, you can have us <a href=\"%s\">resend the confirmation "
+"message</a> to your email address mentioned above."
 msgstr ""
 
 #: src/olympia/users/views.py:444
@@ -13698,10 +11732,7 @@ msgid "Congratulations! Your user account was successfully created."
 msgstr ""
 
 #: src/olympia/users/views.py:615
-msgid ""
-"An email has been sent to your address {0} to confirm your account. Before "
-"you can log in, you have to activate your account by clicking on the link "
-"provided in this email."
+msgid "An email has been sent to your address {0} to confirm your account. Before you can log in, you have to activate your account by clicking on the link provided in this email."
 msgstr ""
 
 #: src/olympia/users/views.py:639
@@ -13720,24 +11751,19 @@ msgstr ""
 msgid "new"
 msgstr ""
 
-#: src/olympia/users/templates/users/delete.html:4
-#: src/olympia/users/templates/users/delete.html:10
+#: src/olympia/users/templates/users/delete.html:4 src/olympia/users/templates/users/delete.html:10
 msgid "Delete User Account"
 msgstr ""
 
 #: src/olympia/users/templates/users/delete.html:14
 #, python-format
 msgid ""
-"You cannot delete your account if you are listed as an <a href=\"%(link)s\">"
-" author of any add-ons</a>. To delete your account, please have another "
-"person in your development group delete you from the list of authors for "
-"your add-ons. Afterwards you will be able to delete your account here."
+"You cannot delete your account if you are listed as an <a href=\"%(link)s\"> author of any add-ons</a>. To delete your account, please have another person in your development group delete you from "
+"the list of authors for your add-ons. Afterwards you will be able to delete your account here."
 msgstr ""
 
 #: src/olympia/users/templates/users/delete.html:29
-msgid ""
-"By clicking \"delete\" your account is going to be <strong>permanently "
-"removed</strong>. That means:"
+msgid "By clicking \"delete\" your account is going to be <strong>permanently removed</strong>. That means:"
 msgstr ""
 
 #: src/olympia/users/templates/users/delete.html:35
@@ -13746,9 +11772,7 @@ msgid "You will not be able to log into %(site)s anymore."
 msgstr ""
 
 #: src/olympia/users/templates/users/delete.html:40
-msgid ""
-"Your reviews and ratings will not be deleted, but they will no longer be "
-"associated with you."
+msgid "Your reviews and ratings will not be deleted, but they will no longer be associated with you."
 msgstr ""
 
 #: src/olympia/users/templates/users/delete.html:46
@@ -13763,8 +11787,7 @@ msgstr ""
 msgid "Delete my user account now"
 msgstr ""
 
-#: src/olympia/users/templates/users/delete_photo.html:3
-#: src/olympia/users/templates/users/delete_photo.html:9
+#: src/olympia/users/templates/users/delete_photo.html:3 src/olympia/users/templates/users/delete_photo.html:9
 msgid "Delete User Photo"
 msgstr ""
 
@@ -13777,23 +11800,18 @@ msgid "Please set your display name"
 msgstr ""
 
 #: src/olympia/users/templates/users/edit.html:21
-msgid ""
-"Please set your display name or username to complete the registration "
-"process."
+msgid "Please set your display name or username to complete the registration process."
 msgstr ""
 
 #: src/olympia/users/templates/users/edit.html:33
 msgid "Manage basic account information, such as username and email address."
 msgstr ""
 
-#: src/olympia/users/templates/users/edit.html:39
-#: src/olympia/users/templates/users/register.html:47
+#: src/olympia/users/templates/users/edit.html:39 src/olympia/users/templates/users/register.html:47
 msgid "Username"
 msgstr ""
 
-#: src/olympia/users/templates/users/edit.html:45
-#: src/olympia/users/templates/users/pwreset_request.html:21
-#: src/olympia/users/templates/users/register.html:62
+#: src/olympia/users/templates/users/edit.html:45 src/olympia/users/templates/users/pwreset_request.html:21 src/olympia/users/templates/users/register.html:62
 msgid "Email Address"
 msgstr ""
 
@@ -13805,18 +11823,14 @@ msgstr ""
 msgid "Change Password"
 msgstr ""
 
-#: src/olympia/users/templates/users/edit.html:68
-#: src/olympia/users/templates/users/login_form.html:22
-#: src/olympia/users/templates/users/register.html:67
+#: src/olympia/users/templates/users/edit.html:68 src/olympia/users/templates/users/login_form.html:22 src/olympia/users/templates/users/register.html:67
 #: src/olympia/users/templates/users/mobile/login.html:37
 msgid "Password"
 msgstr ""
 
 #: src/olympia/users/templates/users/edit.html:70
 #, python-format
-msgid ""
-"Change your password.  If you forgot your password, you can <a "
-"href=\"%(reset_url)s\">use the reset form</a>."
+msgid "Change your password. If you forgot your password, you can <a href=\"%(reset_url)s\">use the reset form</a>."
 msgstr ""
 
 #: src/olympia/users/templates/users/edit.html:76
@@ -13836,9 +11850,7 @@ msgid "Profile"
 msgstr ""
 
 #: src/olympia/users/templates/users/edit.html:100
-msgid ""
-"Give us a bit more information about yourself.  All these fields are "
-"optional, but they'll help other users get to know you better."
+msgid "Give us a bit more information about yourself. All these fields are optional, but they'll help other users get to know you better."
 msgstr ""
 
 #: src/olympia/users/templates/users/edit.html:124
@@ -13854,15 +11866,11 @@ msgid "Delete current photo"
 msgstr ""
 
 #: src/olympia/users/templates/users/edit.html:144
-msgid ""
-"This is the default locale used to display information about you (like your "
-"description)."
+msgid "This is the default locale used to display information about you (like your description)."
 msgstr ""
 
 #: src/olympia/users/templates/users/edit.html:152
-msgid ""
-"Introduce yourself to the community, if you like! This text will appear "
-"publicly on your user info page."
+msgid "Introduce yourself to the community, if you like! This text will appear publicly on your user info page."
 msgstr ""
 
 #: src/olympia/users/templates/users/edit.html:161
@@ -13890,15 +11898,11 @@ msgid "Notifications"
 msgstr ""
 
 #: src/olympia/users/templates/users/edit.html:195
-msgid ""
-"From time to time, Mozilla may send you email about upcoming releases and "
-"add-on events. Please select the topics you are interested in."
+msgid "From time to time, Mozilla may send you email about upcoming releases and add-on events. Please select the topics you are interested in."
 msgstr ""
 
 #: src/olympia/users/templates/users/edit.html:205
-msgid ""
-"Mozilla reserves the right to contact you individually about specific "
-"concerns with your hosted add-ons."
+msgid "Mozilla reserves the right to contact you individually about specific concerns with your hosted add-ons."
 msgstr ""
 
 #: src/olympia/users/templates/users/edit.html:215
@@ -13921,60 +11925,48 @@ msgstr ""
 msgid "all"
 msgstr ""
 
-#: src/olympia/users/templates/users/fxa_migration.html:3
-#: src/olympia/users/templates/users/fxa_migration.html:11
-#: src/olympia/users/templates/users/mobile/fxa_migration.html:3
+#: src/olympia/users/templates/users/fxa_migration.html:3 src/olympia/users/templates/users/fxa_migration.html:11 src/olympia/users/templates/users/mobile/fxa_migration.html:3
 #: src/olympia/users/templates/users/mobile/fxa_migration.html:8
 msgid "Migrate to Firefox Accounts"
 msgstr ""
 
 #: src/olympia/users/templates/users/fxa_migration_prompt_content.html:3
-msgid ""
-"Mozilla Add-ons has transitioned to Firefox Accounts for login. Continue to "
-"complete the simple upgrade process."
+msgid "Mozilla Add-ons has transitioned to Firefox Accounts for login. Continue to complete the simple upgrade process."
 msgstr ""
 
 #: src/olympia/users/templates/users/fxa_migration_prompt_content.html:14
 msgid "Skip"
 msgstr ""
 
-#: src/olympia/users/templates/users/login.html:3
-#: src/olympia/users/templates/users/mobile/login.html:3
+#: src/olympia/users/templates/users/login.html:3 src/olympia/users/templates/users/mobile/login.html:3
 msgid "User Login"
 msgstr ""
 
-#: src/olympia/users/templates/users/login.html:13
-#: src/olympia/users/templates/users/mobile/login.html:21
+#: src/olympia/users/templates/users/login.html:13 src/olympia/users/templates/users/mobile/login.html:21
 msgid "Enter your email"
 msgstr ""
 
-#: src/olympia/users/templates/users/login.html:15
-#: src/olympia/users/templates/users/mobile/login.html:23
+#: src/olympia/users/templates/users/login.html:15 src/olympia/users/templates/users/mobile/login.html:23
 msgid "Log In"
 msgstr ""
 
-#: src/olympia/users/templates/users/login_form.html:17
-#: src/olympia/users/templates/users/mobile/login.html:32
+#: src/olympia/users/templates/users/login_form.html:17 src/olympia/users/templates/users/mobile/login.html:32
 msgid "Email address"
 msgstr ""
 
-#: src/olympia/users/templates/users/login_form.html:30
-#: src/olympia/users/templates/users/mobile/login.html:44
+#: src/olympia/users/templates/users/login_form.html:30 src/olympia/users/templates/users/mobile/login.html:44
 msgid "Remember me on this device"
 msgstr ""
 
-#: src/olympia/users/templates/users/login_help.html:3
-#: src/olympia/users/templates/users/mobile/login.html:63
+#: src/olympia/users/templates/users/login_help.html:3 src/olympia/users/templates/users/mobile/login.html:63
 msgid "Login Problems?"
 msgstr ""
 
-#: src/olympia/users/templates/users/login_help.html:5
-#: src/olympia/users/templates/users/mobile/login.html:65
+#: src/olympia/users/templates/users/login_help.html:5 src/olympia/users/templates/users/mobile/login.html:65
 msgid "I don't have an account."
 msgstr ""
 
-#: src/olympia/users/templates/users/login_help.html:6
-#: src/olympia/users/templates/users/mobile/login.html:66
+#: src/olympia/users/templates/users/login_help.html:6 src/olympia/users/templates/users/mobile/login.html:66
 msgid "I forgot my password."
 msgstr ""
 
@@ -13983,15 +11975,9 @@ msgstr ""
 msgid "You are now logged in as <strong>%(user_email)s</strong>!"
 msgstr ""
 
-#: src/olympia/users/templates/users/newpw_sent.html:3
-#: src/olympia/users/templates/users/newpw_sent.html:8
-#: src/olympia/users/templates/users/pwreset_complete.html:3
-#: src/olympia/users/templates/users/pwreset_confirm.html:4
-#: src/olympia/users/templates/users/pwreset_confirm.html:18
-#: src/olympia/users/templates/users/pwreset_request.html:4
-#: src/olympia/users/templates/users/pwreset_request.html:10
-#: src/olympia/users/templates/users/pwreset_sent.html:3
-#: src/olympia/users/templates/users/pwreset_sent.html:8
+#: src/olympia/users/templates/users/newpw_sent.html:3 src/olympia/users/templates/users/newpw_sent.html:8 src/olympia/users/templates/users/pwreset_complete.html:3
+#: src/olympia/users/templates/users/pwreset_confirm.html:4 src/olympia/users/templates/users/pwreset_confirm.html:18 src/olympia/users/templates/users/pwreset_request.html:4
+#: src/olympia/users/templates/users/pwreset_request.html:10 src/olympia/users/templates/users/pwreset_sent.html:3 src/olympia/users/templates/users/pwreset_sent.html:8
 msgid "Password Reset"
 msgstr ""
 
@@ -14007,8 +11993,7 @@ msgstr ""
 msgid "Manage user"
 msgstr ""
 
-#: src/olympia/users/templates/users/profile.html:18
-#: src/olympia/users/templates/users/report_abuse_full.html:9
+#: src/olympia/users/templates/users/profile.html:18 src/olympia/users/templates/users/report_abuse_full.html:9
 msgid "Report user"
 msgstr ""
 
@@ -14068,32 +12053,24 @@ msgstr ""
 msgid "Password successfully reset."
 msgstr ""
 
-#: src/olympia/users/templates/users/pwreset_confirm.html:13
-#: src/olympia/users/templates/users/pwreset_confirm.html:46
+#: src/olympia/users/templates/users/pwreset_confirm.html:13 src/olympia/users/templates/users/pwreset_confirm.html:46
 msgid "Password reset unsuccessful"
 msgstr ""
 
 #: src/olympia/users/templates/users/pwreset_confirm.html:14
-msgid ""
-"You have migrated to Firefox Accounts. You can no longer change your "
-"password here."
+msgid "You have migrated to Firefox Accounts. You can no longer change your password here."
 msgstr ""
 
-#: src/olympia/users/templates/users/pwreset_confirm.html:31
-#: src/olympia/users/templates/users/register.html:72
+#: src/olympia/users/templates/users/pwreset_confirm.html:31 src/olympia/users/templates/users/register.html:72
 msgid "Confirm password"
 msgstr ""
 
 #: src/olympia/users/templates/users/pwreset_confirm.html:47
-msgid ""
-"The password reset link was invalid, possibly because it has already been "
-"used.  Please request a new password reset."
+msgid "The password reset link was invalid, possibly because it has already been used. Please request a new password reset."
 msgstr ""
 
 #: src/olympia/users/templates/users/pwreset_request.html:15
-msgid ""
-"Forgotten your password? Enter your e-mail address below, and we'll e-mail "
-"instructions for setting a new one."
+msgid "Forgotten your password? Enter your e-mail address below, and we'll e-mail instructions for setting a new one."
 msgstr ""
 
 #: src/olympia/users/templates/users/pwreset_request.html:25
@@ -14102,9 +12079,7 @@ msgstr ""
 
 #: src/olympia/users/templates/users/pwreset_sent.html:10
 msgid ""
-"An email has been sent to the requested account with further information. If"
-" you do not receive an email then please confirm you have entered the same "
-"email address used during account registration."
+"An email has been sent to the requested account with further information. If you do not receive an email then please confirm you have entered the same email address used during account registration."
 msgstr ""
 
 #: src/olympia/users/templates/users/register.html:4
@@ -14116,9 +12091,7 @@ msgid "Why register?"
 msgstr ""
 
 #: src/olympia/users/templates/users/register.html:14
-msgid ""
-"Registration on AMO is <strong>not required</strong> if you simply want to "
-"download and install public add-ons."
+msgid "Registration on AMO is <strong>not required</strong> if you simply want to download and install public add-ons."
 msgstr ""
 
 #: src/olympia/users/templates/users/register.html:16
@@ -14130,30 +12103,20 @@ msgid "You want to submit reviews for add-ons"
 msgstr ""
 
 #: src/olympia/users/templates/users/register.html:19
-msgid ""
-"You want to keep track of your favorite add-on collections or create one "
-"yourself"
+msgid "You want to keep track of your favorite add-on collections or create one yourself"
 msgstr ""
 
 #: src/olympia/users/templates/users/register.html:20
-msgid ""
-"You are an add-on developer and want to upload your add-on for hosting on "
-"AMO"
+msgid "You are an add-on developer and want to upload your add-on for hosting on AMO"
 msgstr ""
 
 #: src/olympia/users/templates/users/register.html:23
-msgid ""
-"Upon successful registration, you will be sent a confirmation email to the "
-"address you provided. Please follow the instructions there to confirm your "
-"account."
+msgid "Upon successful registration, you will be sent a confirmation email to the address you provided. Please follow the instructions there to confirm your account."
 msgstr ""
 
 #: src/olympia/users/templates/users/register.html:30
 #, python-format
-msgid ""
-"If you like, you can read our <a href=\"%(legal)s\" title=\"Legal "
-"Notices\">Legal Notices</a> and <a href=\"%(privacy)s\" title=\"Privacy "
-"Policy\">Privacy Policy</a>."
+msgid "If you like, you can read our <a href=\"%(legal)s\" title=\"Legal Notices\">Legal Notices</a> and <a href=\"%(privacy)s\" title=\"Privacy Policy\">Privacy Policy</a>."
 msgstr ""
 
 #: src/olympia/users/templates/users/register.html:52
@@ -14161,9 +12124,7 @@ msgid "Display name"
 msgstr ""
 
 #: src/olympia/users/templates/users/report_abuse.html:7
-msgid ""
-"Please describe why you are reporting this user, such as for spam or an "
-"inappropriate picture."
+msgid "Please describe why you are reporting this user, such as for spam or an inappropriate picture."
 msgstr ""
 
 #: src/olympia/users/templates/users/report_abuse_full.html:3
@@ -14178,32 +12139,24 @@ msgstr ""
 msgid "Special Edition Add-on Creator T-shirt"
 msgstr ""
 
-#: src/olympia/users/templates/users/t-shirt.html:14
-#: src/olympia/users/templates/users/t-shirt.html:120
+#: src/olympia/users/templates/users/t-shirt.html:14 src/olympia/users/templates/users/t-shirt.html:120
 msgid "Note:"
 msgstr ""
 
 #: src/olympia/users/templates/users/t-shirt.html:15
-msgid ""
-"You have already submitted a request for a t-shirt. You may re-submit this "
-"form to update your information, but you will only receive one shirt."
+msgid "You have already submitted a request for a t-shirt. You may re-submit this form to update your information, but you will only receive one shirt."
 msgstr ""
 
 #: src/olympia/users/templates/users/t-shirt.html:26
-msgid ""
-"Thank you for helping to make Firefox the most extensible browser available!"
+msgid "Thank you for helping to make Firefox the most extensible browser available!"
 msgstr ""
 
 #: src/olympia/users/templates/users/t-shirt.html:33
-msgid ""
-"As a thank you gift, we'd like to send you a special-edition, community-"
-"designed t-shirt. To receive your shirt, please fill out the form below."
+msgid "As a thank you gift, we'd like to send you a special-edition, community-designed t-shirt. To receive your shirt, please fill out the form below."
 msgstr ""
 
 #: src/olympia/users/templates/users/t-shirt.html:41
-msgid ""
-"Your contact information will only be used by Mozilla to ship this special "
-"edition t-shirt."
+msgid "Your contact information will only be used by Mozilla to ship this special edition t-shirt."
 msgstr ""
 
 #: src/olympia/users/templates/users/t-shirt.html:60
@@ -14260,16 +12213,12 @@ msgstr ""
 
 #: src/olympia/users/templates/users/t-shirt.html:137
 msgid ""
-"We're sorry, but in order to qualify for our special edition t-shirt, you "
-"must be an add-on developer with at least one listed add-on, one unlisted "
-"but signed add-on, or any number of background themes with a combined total "
-"of 10,000 average daily users."
+"We're sorry, but in order to qualify for our special edition t-shirt, you must be an add-on developer with at least one listed add-on, one unlisted but signed add-on, or any number of background "
+"themes with a combined total of 10,000 average daily users."
 msgstr ""
 
 #: src/olympia/users/templates/users/tougher_password.html:2
-msgid ""
-"For your account a password must contain at least 8 characters including "
-"letters and numbers."
+msgid "For your account a password must contain at least 8 characters including letters and numbers."
 msgstr ""
 
 #: src/olympia/users/templates/users/unsubscribe.html:2
@@ -14282,9 +12231,7 @@ msgstr ""
 
 #: src/olympia/users/templates/users/unsubscribe.html:10
 #, python-format
-msgid ""
-"The email address <strong>%(email)s</strong> will no longer get messages "
-"when:"
+msgid "The email address <strong>%(email)s</strong> will no longer get messages when:"
 msgstr ""
 
 #: src/olympia/users/templates/users/unsubscribe.html:20
@@ -14305,10 +12252,7 @@ msgstr ""
 
 #: src/olympia/users/templates/users/unsubscribe.html:30
 #, python-format
-msgid ""
-"Unfortunately, we weren't able to unsubscribe you.  The link you clicked is "
-"invalid. However, you can unsubscribe still unsubscribe on your <a "
-"href=\"%(edit_url)s\">edit profile page</a>."
+msgid "Unfortunately, we weren't able to unsubscribe you. The link you clicked is invalid. However, you can unsubscribe still unsubscribe on your <a href=\"%(edit_url)s\">edit profile page</a>."
 msgstr ""
 
 #: src/olympia/users/templates/users/vcard.html:2
@@ -14340,12 +12284,14 @@ msgstr ""
 msgid "%(num)s theme"
 msgid_plural "%(num)s themes"
 msgstr[0] ""
+msgstr[1] ""
 
 #: src/olympia/users/templates/users/vcard.html:62
 #, python-format
 msgid "%(num)s add-on"
 msgid_plural "%(num)s add-ons"
 msgstr[0] ""
+msgstr[1] ""
 
 #: src/olympia/users/templates/users/vcard.html:75
 msgid "Average rating of developer's add-ons"
@@ -14360,15 +12306,15 @@ msgstr ""
 msgid "Version History with Changelogs"
 msgstr ""
 
-#: src/olympia/versions/models.py:314
+#: src/olympia/versions/models.py:313
 msgid "Add-on uses binary components."
 msgstr ""
 
-#: src/olympia/versions/models.py:317
+#: src/olympia/versions/models.py:316
 msgid "Add-on has opted into strict compatibility checking."
 msgstr ""
 
-#: src/olympia/versions/models.py:715
+#: src/olympia/versions/models.py:711
 msgid "{app} {min} and later"
 msgstr ""
 
@@ -14405,18 +12351,15 @@ msgstr ""
 msgid "<b>{0}</b> version"
 msgid_plural "<b>{0}</b> versions"
 msgstr[0] ""
+msgstr[1] ""
 
-#: src/olympia/versions/templates/versions/version_list.html:35
-#: src/olympia/versions/templates/versions/mobile/version_list.html:14
+#: src/olympia/versions/templates/versions/version_list.html:35 src/olympia/versions/templates/versions/mobile/version_list.html:14
 msgid "Be careful with old versions!"
 msgstr ""
 
-#: src/olympia/versions/templates/versions/version_list.html:36
-#: src/olympia/versions/templates/versions/mobile/version_list.html:15
+#: src/olympia/versions/templates/versions/version_list.html:36 src/olympia/versions/templates/versions/mobile/version_list.html:15
 #, python-format
-msgid ""
-"These versions are displayed for reference and testing purposes. You should "
-"always use the <a href=\"%(url)s\">latest version</a> of an add-on."
+msgid "These versions are displayed for reference and testing purposes. You should always use the <a href=\"%(url)s\">latest version</a> of an add-on."
 msgstr ""
 
 #: src/olympia/versions/templates/versions/mobile/version.html:4
@@ -14446,4 +12389,8 @@ msgstr ""
 
 #: src/olympia/zadmin/forms.py:105
 msgid "Log emails instead of sending"
+msgstr ""
+
+#: src/olympia/zadmin/forms.py:215
+msgid "Deleted versions can`t be changed."
 msgstr ""

--- a/locale/ka/LC_MESSAGES/djangojs.po
+++ b/locale/ka/LC_MESSAGES/djangojs.po
@@ -1,1256 +1,1253 @@
-# 
+#
 #, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2016-02-24 21:23+0000\n"
-"PO-Revision-Date: 2016-04-18 21:59+0000\n"
+"POT-Creation-Date: 2016-04-18 15:47+0000\n"
+"PO-Revision-Date: 2016-04-18 12:56+0000\n"
 "Last-Translator: ბექა არაბული <arabulibeqa@yahoo.com>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
-"Language: ka\n"
+"Language: \n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=1; plural=0;\n"
-"X-Generator: Pontoon\n"
+"Generated-By: Babel 2.2.0\n"
 
-#: static/js/common/ratingwidget.js:31
+#: static/js/common-all.js:1426 static/js/impala-all.js:1511 static/js/zamboni/discovery-all.js:12598 static/js/zamboni/init.js:28 static/js/zamboni/mobile-all.js:14945
+msgid "This feature is temporarily disabled while we perform website maintenance. Please check back a little later."
+msgstr "ვებ-საიტზე ტექნიკური მომსახურების გამო ეს ფუნქცია დროებით გამორთულია. გთხოვთ, შემოიარეთ მოგვიანებით."
+
+#. L10n: {0} is an app name like Firefox.
+#: static/js/common-all.js:1837 static/js/impala-all.js:1922 static/js/zamboni/buttons.js:73 static/js/zamboni/discovery-all.js:13108
+msgid "Accept and Install"
+msgstr "მიღება და ინსტალაცია"
+
+#: static/js/common-all.js:1837 static/js/impala-all.js:1922 static/js/zamboni/buttons.js:73 static/js/zamboni/discovery-all.js:13108
+msgid "Add to {0}"
+msgstr "{0}-ში დამატება"
+
+#: static/js/common-all.js:1842 static/js/impala-all.js:1927 static/js/zamboni/buttons.js:78 static/js/zamboni/discovery-all.js:13113
+msgid "Download Now"
+msgstr "ჩამოტვირთვა ახლავე"
+
+#: static/js/common-all.js:1883 static/js/impala-all.js:1968 static/js/zamboni/buttons.js:119 static/js/zamboni/discovery-all.js:13154
+msgid "Add-on has not been updated to support default-to-compatible."
+msgstr ""
+
+#: static/js/common-all.js:1888 static/js/impala-all.js:1973 static/js/zamboni/buttons.js:124 static/js/zamboni/discovery-all.js:13159
+msgid "You need to be using Firefox 10.0 or higher."
+msgstr "თქვენ უნდა იყენებდეთ Firefox 10.0-ს ან უფრო მაღალ ვერსიას."
+
+#: static/js/common-all.js:1900 static/js/impala-all.js:1985 static/js/zamboni/buttons.js:136 static/js/zamboni/discovery-all.js:13171
+msgid "Mozilla has marked this version as incompatible with your Firefox version."
+msgstr "Mozilla ეს ვერსია თქვენი Firefox-ის ვერსიასთან შეუთავსებლად მონიშნა."
+
+#. L10n: {0} is an platform like Windows or Linux.
+#: static/js/common-all.js:1981 static/js/impala-all.js:2066 static/js/zamboni/buttons.js:217 static/js/zamboni/discovery-all.js:13252
+msgid "Install for {0} anyway"
+msgstr ""
+
+#: static/js/common-all.js:1981 static/js/impala-all.js:2066 static/js/zamboni/buttons.js:217 static/js/zamboni/discovery-all.js:13252
+msgid "Download for {0} anyway"
+msgstr ""
+
+#: static/js/common-all.js:2038 static/js/impala-all.js:2123 static/js/zamboni/buttons.js:274 static/js/zamboni/discovery-all.js:13309
+msgid "Not available for your platform"
+msgstr "თქვენს პლატოფმრაზე ხელმისაწვდომი არაა"
+
+#. L10n: {0} is an app name, {1} is the app version.
+#: static/js/common-all.js:2049 static/js/common-all.js:2086 static/js/impala-all.js:2134 static/js/impala-all.js:2171 static/js/zamboni/buttons.js:286 static/js/zamboni/buttons.js:324
+#: static/js/zamboni/discovery-all.js:13320 static/js/zamboni/discovery-all.js:13357
+msgid "Not available for {0} {1}"
+msgstr ""
+
+#: static/js/common-all.js:2112 static/js/impala-all.js:2197 static/js/zamboni/buttons.js:351 static/js/zamboni/discovery-all.js:13383
+msgid "Works with {app} {min} - {max}"
+msgstr "მუშაობს {app} ვერსიებთან: {min} - {max}"
+
+#: static/js/common-all.js:2114 static/js/impala-all.js:2199 static/js/zamboni/buttons.js:353 static/js/zamboni/discovery-all.js:13385
+msgid "View other versions"
+msgstr "სხვა ვერსიების ნახვა"
+
+#: static/js/common-all.js:2162 static/js/impala-all.js:2247 static/js/zamboni/buttons.js:401 static/js/zamboni/discovery-all.js:13433
+msgid "Only with Firefox — Get Firefox Now!"
+msgstr "მხოლოდ Firefox-ზე — ჩამოტვირთეთ Firefox!"
+
+#: static/js/common-all.js:2278 static/js/impala-all.js:2363 static/js/zamboni/buttons.js:517 static/js/zamboni/discovery-all.js:13549 static/js/zamboni/mobile-all.js:15177
+#: static/js/zamboni/mobile/buttons.js:43
+msgid "Sorry, you need a Mozilla-based browser (such as Firefox) to install a search plugin."
+msgstr "ბოდიში, საძიებო მოდულის დასაინტსტალირებლად გესაჭირეობათ Mozilla-ზე დაფუძნებული ბრაუზერი (მაგალითად Firefox)."
+
+#: static/js/common-all.js:9088 static/js/impala-all.js:9649 static/js/zamboni/global.js:410
+msgid "Loading..."
+msgstr "იტვირთება...."
+
+#. L10n: {0} is the number of characters left.
+#: static/js/common-all.js:9152 static/js/impala-all.js:9713 static/js/zamboni/global.js:474
+msgid "<b>{0}</b> character left."
+msgid_plural "<b>{0}</b> characters left."
+msgstr[0] "დარჩენილია <b>{0}</b> სიმბოლო."
+msgstr[1] ""
+
+#: static/js/common-all.js:9589 static/js/common-min.js:6 static/js/impala-all.js:10052 static/js/impala-min.js:6 static/js/common/ratingwidget.js:31 static/js/zamboni/mobile-all.js:16123
+#: static/js/zamboni/mobile-min.js:6
 msgid "{0} star"
 msgid_plural "{0} stars"
 msgstr[0] "{0} ვარსკვლავი"
+msgstr[1] ""
 
-#: static/js/common/upload-addon.js:41 static/js/common/upload-image.js:128
+#: static/js/common-all.js:9676 static/js/common-min.js:6 static/js/impala-all.js:10139 static/js/impala-min.js:6 static/js/zamboni/l10n.js:45
+msgid "Remove this localization"
+msgstr "ამ ლოკალიზაციის წაშლა"
+
+#: static/js/common-all.js:10193 static/js/common-min.js:6 static/js/impala-all.js:10674 static/js/impala-min.js:6 static/js/zamboni/discovery-all.js:13678
+msgid "close"
+msgstr ""
+
+#: static/js/common-all.js:10860 static/js/common-min.js:6 static/js/impala-all.js:11481 static/js/impala-min.js:6 static/js/impala/reviews.js:23 static/js/zamboni/reviews.js:18
+msgid "Flagged for review"
+msgstr "განსახილველად მონიშნული"
+
+#: static/js/common-all.js:10876 static/js/common-min.js:6 static/js/impala-all.js:11498 static/js/impala-min.js:6 static/js/impala/reviews.js:40 static/js/zamboni/reviews.js:34
+msgid "Your input is required"
+msgstr "საჭიროა მონაცემების შეყვანა"
+
+#: static/js/common-all.js:10945 static/js/common-min.js:6 static/js/impala-all.js:11610 static/js/impala-min.js:7 static/js/impala/reviews.js:152 static/js/zamboni/reviews.js:103
+msgid "Marked for deletion"
+msgstr "წასაშლელად მონიშნული"
+
+#: static/js/common-all.js:11573 static/js/common-min.js:7 static/js/impala-all.js:13809 static/js/impala-min.js:8 static/js/zamboni/collections.js:229
+msgid "Adding to Favorites&hellip;"
+msgstr "ემატება რჩეულებში &hellip;"
+
+#: static/js/common-all.js:11576 static/js/common-min.js:7 static/js/impala-all.js:13812 static/js/impala-min.js:8 static/js/zamboni/collections.js:232
+msgid "Removing Favorite&hellip;"
+msgstr "რჩეული იშლება &hellip;"
+
+#: static/js/common-all.js:11579 static/js/common-min.js:7 static/js/impala-all.js:13815 static/js/impala-min.js:8 static/js/zamboni/collections.js:235
+msgid "Add to Favorites"
+msgstr "რჩეულებში დამატება"
+
+#: static/js/common-all.js:11582 static/js/common-min.js:7 static/js/impala-all.js:13818 static/js/impala-min.js:8 static/js/zamboni/collections.js:238
+msgid "Remove from Favorites"
+msgstr "რჩეულებიდან ამოღება"
+
+#: static/js/common-all.js:11647 static/js/common-min.js:7 static/js/impala-all.js:13883 static/js/impala-min.js:8 static/js/zamboni/collections.js:303
+msgid "Pending"
+msgstr "განხილვის პროცესში"
+
+#: static/js/common-all.js:11648 static/js/common-min.js:7 static/js/impala-all.js:13884 static/js/impala-min.js:8 static/js/zamboni/collections.js:304
+msgid "Add a comment"
+msgstr "კომენტარის დამატება"
+
+#: static/js/common-all.js:11648 static/js/common-min.js:7 static/js/impala-all.js:13884 static/js/impala-min.js:8 static/js/zamboni/collections.js:304
+msgid "Comment"
+msgstr "კომენტარი"
+
+#: static/js/common-all.js:11649 static/js/common-min.js:7 static/js/impala-all.js:13885 static/js/impala-min.js:8 static/js/zamboni/collections.js:305
+msgid "Remove this add-on from the collection"
+msgstr "ამ დამატების კრებულიდან ამოღება"
+
+#: static/js/common-all.js:11649 static/js/common-all.js:11678 static/js/common-min.js:7 static/js/impala-all.js:13885 static/js/impala-all.js:13914 static/js/impala-min.js:8
+#: static/js/zamboni/collections.js:305 static/js/zamboni/collections.js:334
+msgid "Remove"
+msgstr "ამოღება"
+
+#: static/js/common-all.js:11678 static/js/common-min.js:7 static/js/impala-all.js:13914 static/js/impala-min.js:8 static/js/zamboni/collections.js:334
+msgid "Remove this user as a contributor"
+msgstr "ამ მომხმარებლის წვლილის შემტანებიდან ამოღება"
+
+#: static/js/common-all.js:11690 static/js/common-min.js:7 static/js/impala-all.js:13926 static/js/impala-min.js:8 static/js/zamboni/collections.js:346
+msgid "An email address is required."
+msgstr "ელფოსტის მისამართი საჭიროა."
+
+#: static/js/common-all.js:11708 static/js/common-min.js:7 static/js/impala-all.js:13944 static/js/impala-min.js:8 static/js/zamboni/collections.js:364
+msgid "You cannot add yourself as a contributor."
+msgstr "საკუთარი თავის წვლილის შემტანად დამატება არ შეგიძლიათ."
+
+#: static/js/common-all.js:11710 static/js/common-min.js:7 static/js/impala-all.js:13946 static/js/impala-min.js:8 static/js/zamboni/collections.js:366
+msgid "You have already added that user."
+msgstr "ეს მომხმარებელი უკვე დაამატეთ."
+
+#: static/js/common-all.js:11917 static/js/common-min.js:7 static/js/impala-all.js:14153 static/js/impala-min.js:8 static/js/zamboni/collections.js:573
+msgid "Add to favorites"
+msgstr "რჩეულებში დამატება"
+
+#: static/js/common-all.js:11921 static/js/common-min.js:7 static/js/impala-all.js:14157 static/js/impala-min.js:8 static/js/zamboni/collections.js:577
+msgid "Remove from favorites"
+msgstr "რჩეულებიდან ამოღება"
+
+#: static/js/common-all.js:11939 static/js/common-min.js:7 static/js/impala-all.js:14175 static/js/impala-all.js:14233 static/js/impala-min.js:8 static/js/impala/collections.js:10
+#: static/js/zamboni/collections.js:595
+msgid "Follow this Collection"
+msgstr "კოლექციის გაყოლა"
+
+#: static/js/common-all.js:11948 static/js/common-min.js:7 static/js/impala-all.js:14184 static/js/impala-min.js:8 static/js/zamboni/collections.js:604
+msgid "Stop following"
+msgstr "ადევნების შეწყვეტა"
+
+#: static/js/common-all.js:12096 static/js/common-min.js:7 static/js/zamboni/password-strength.js:20
+msgid "Password strength:"
+msgstr "პაროლის სიძლიერე:"
+
+#: static/js/common-all.js:12102 static/js/common-min.js:7 static/js/zamboni/password-strength.js:26
+msgid "At least {0} character left."
+msgid_plural "At least {0} characters left."
+msgstr[0] "დარჩენილია სულ მცირე {0} სიმბოლო."
+msgstr[1] ""
+
+#: static/js/common-all.js:12286 static/js/common-min.js:7 static/js/impala-all.js:14632 static/js/impala-min.js:8 static/js/impala/suggestions.js:39
+msgid "Search themes for <b>{0}</b>"
+msgstr "<b>{0}-ს</b> ძიება თემებში"
+
+#: static/js/common-all.js:12288 static/js/common-min.js:7 static/js/impala-all.js:14634 static/js/impala-min.js:8 static/js/impala/suggestions.js:41
+msgid "Search apps for <b>{0}</b>"
+msgstr "<b>{0}-ს</b> ძიება აპებში"
+
+#: static/js/common-all.js:12290 static/js/common-min.js:7 static/js/impala-all.js:14636 static/js/impala-min.js:8 static/js/impala/suggestions.js:43
+msgid "Search add-ons for <b>{0}</b>"
+msgstr "<b>{0}-ს</b> ძიება დამატებებში"
+
+#: static/js/common-all.js:12521 static/js/common-min.js:7 static/js/impala-all.js:14867 static/js/impala-min.js:8 static/js/impala/site_suggestions.js:46
+msgid "Category"
+msgstr "კატეგორია"
+
+#. L10n: {0} is an app name.
+#: static/js/impala-all.js:11632 static/js/impala-min.js:7 static/js/impala/listing.js:11 static/js/zamboni/themes.js:13
+msgid "This theme is incompatible with your version of {0}"
+msgstr "ეს თემა {0}-ის თქვენს ვერსიასთან შეუთავსებელია"
+
+#: static/js/impala-all.js:12146 static/js/impala-all.js:14331 static/js/impala-min.js:7 static/js/impala-min.js:8 static/js/common/upload-image.js:97 static/js/impala/users.js:51
+#: static/js/zamboni/devhub-all.js:894 static/js/zamboni/devhub-min.js:1
+msgid "Images must be either PNG or JPG."
+msgstr "ნახატი უნდა იყოს PNG ან JPG."
+
+#: static/js/impala-all.js:12150 static/js/impala-min.js:7 static/js/common/upload-image.js:101 static/js/zamboni/devhub-all.js:898 static/js/zamboni/devhub-min.js:1
+msgid "Videos must be in WebM."
+msgstr "ვიდეო უნდა იყოს WebM."
+
+#: static/js/impala-all.js:12177 static/js/impala-min.js:7 static/js/common/upload-addon.js:41 static/js/common/upload-image.js:128 static/js/zamboni/devhub-all.js:272
+#: static/js/zamboni/devhub-all.js:925 static/js/zamboni/devhub-min.js:1
 msgid "There was a problem contacting the server."
 msgstr "სერვერთან დაკავშირება ვერ მოხერხდა."
 
-#: static/js/common/upload-addon.js:69
+#: static/js/impala-all.js:13298 static/js/impala-min.js:7 static/js/impala/persona_creation.js:60
+msgid "All Rights Reserved"
+msgstr "ყველა უფლება დაცულია"
+
+#: static/js/impala-all.js:13302 static/js/impala-min.js:7 static/js/impala/persona_creation.js:64
+msgid "Creative Commons Attribution 3.0"
+msgstr "Creative Commons Attribution 3.0"
+
+#: static/js/impala-all.js:13307 static/js/impala-min.js:7 static/js/impala/persona_creation.js:69
+msgid "Creative Commons Attribution-NonCommercial 3.0"
+msgstr "Creative Commons Attribution-NonCommercial 3.0"
+
+#: static/js/impala-all.js:13312 static/js/impala-min.js:7 static/js/impala/persona_creation.js:74
+msgid "Creative Commons Attribution-NonCommercial-NoDerivs 3.0"
+msgstr "Creative Commons Attribution-NonCommercial-NoDerivs 3.0"
+
+#: static/js/impala-all.js:13317 static/js/impala-min.js:7 static/js/impala/persona_creation.js:79
+msgid "Creative Commons Attribution-NonCommercial-Share Alike 3.0"
+msgstr "Creative Commons Attribution-NonCommercial-Share Alike 3.0"
+
+#: static/js/impala-all.js:13322 static/js/impala-min.js:7 static/js/impala/persona_creation.js:84
+msgid "Creative Commons Attribution-NoDerivs 3.0"
+msgstr "Creative Commons Attribution-NoDerivs 3.0"
+
+#: static/js/impala-all.js:13327 static/js/impala-min.js:7 static/js/impala/persona_creation.js:89
+msgid "Creative Commons Attribution-ShareAlike 3.0"
+msgstr "Creative Commons Attribution-ShareAlike 3.0"
+
+#: static/js/impala-all.js:13530 static/js/impala-min.js:7 static/js/impala/persona_creation.js:292
+msgid "Your Theme's Name"
+msgstr "თქვენი თემის სახელი"
+
+#: static/js/impala-all.js:14242 static/js/impala-min.js:8 static/js/impala/collections.js:19
+msgid "Stop Following"
+msgstr "გაყოლის შეჩერება"
+
+#: static/js/impala-all.js:14243 static/js/impala-min.js:8 static/js/impala/collections.js:20
+msgid "Following"
+msgstr "მიჰყვებით"
+
+#: static/js/impala-all.js:14313 static/js/impala-min.js:8 static/js/impala/users.js:33
+msgid "use original"
+msgstr "ორიგინალის გამოყენება"
+
+#: static/js/impala-all.js:14523 static/js/impala-min.js:8 static/js/impala/search.js:114
+msgid "Updating results&hellip;"
+msgstr "შედეგების განახლება&hellip;"
+
+#: static/js/common/upload-addon.js:69 static/js/zamboni/devhub-all.js:300 static/js/zamboni/devhub-min.js:1
 msgid "Select a file..."
 msgstr "ფაილის არჩევა..."
 
-#: static/js/common/upload-addon.js:70
+#: static/js/common/upload-addon.js:70 static/js/zamboni/devhub-all.js:301 static/js/zamboni/devhub-min.js:1
 msgid "Your add-on should end with .xpi, .jar or .xml"
 msgstr "თქვენი დამატება უნდა სრულდებოდეს .xpi, .jar ან .xml გაფართოებით."
 
 #. L10n: {0} is the percent of the file that has been uploaded.
-#: static/js/common/upload-addon.js:104
+#: static/js/common/upload-addon.js:104 static/js/zamboni/devhub-all.js:335 static/js/zamboni/devhub-min.js:1
 #, python-format
 msgid "{0}% complete"
 msgstr "{0}% დასრულებულია"
 
 #. L10n: "{bytes uploaded} of {total filesize}".
-#: static/js/common/upload-addon.js:107
+#: static/js/common/upload-addon.js:107 static/js/zamboni/devhub-all.js:338 static/js/zamboni/devhub-min.js:1
 msgid "{0} of {1}"
 msgstr "{0} / {1}"
 
-#: static/js/common/upload-addon.js:140
+#: static/js/common/upload-addon.js:140 static/js/zamboni/devhub-all.js:371 static/js/zamboni/devhub-min.js:1
 msgid "Cancel"
 msgstr "გაუქმება"
 
-#: static/js/common/upload-addon.js:162
+#: static/js/common/upload-addon.js:162 static/js/zamboni/devhub-all.js:393 static/js/zamboni/devhub-min.js:1
 msgid "Uploading {0}"
 msgstr "იტვირთება {0}"
 
-#: static/js/common/upload-addon.js:189
+#: static/js/common/upload-addon.js:189 static/js/zamboni/devhub-all.js:420 static/js/zamboni/devhub-min.js:1
 msgid "Error with {0}"
 msgstr "{0} - შეცდომა"
 
-#: static/js/common/upload-addon.js:194
+#: static/js/common/upload-addon.js:194 static/js/zamboni/devhub-all.js:425 static/js/zamboni/devhub-min.js:1
 msgid "Your add-on failed validation with {0} error."
 msgid_plural "Your add-on failed validation with {0} errors."
 msgstr[0] "თქვენმა დამატებამ გადამოწმება {0} შეცდომის გამო ვერ გაიარა."
+msgstr[1] ""
 
-#: static/js/common/upload-addon.js:208
+#: static/js/common/upload-addon.js:208 static/js/zamboni/devhub-all.js:439 static/js/zamboni/devhub-min.js:1
 msgid "&hellip;and {0} more"
 msgid_plural "&hellip;and {0} more"
 msgstr[0] "&hellip;და კიდევ {0}"
+msgstr[1] ""
 
-#: static/js/common/upload-addon.js:222 static/js/common/upload-addon.js:512
+#: static/js/common/upload-addon.js:222 static/js/common/upload-addon.js:497 static/js/zamboni/devhub-all.js:453 static/js/zamboni/devhub-all.js:743 static/js/zamboni/devhub-min.js:1
 msgid "See full validation report"
 msgstr "დამოწმების სრული ანგარიშგების ნახვა"
 
-#: static/js/common/upload-addon.js:234
+#: static/js/common/upload-addon.js:234 static/js/zamboni/devhub-all.js:465 static/js/zamboni/devhub-min.js:1
 msgid "Validating {0}"
 msgstr "მოწმდება {0}"
 
 #. L10n: first argument is an HTTP status code
-#: static/js/common/upload-addon.js:273
+#: static/js/common/upload-addon.js:273 static/js/zamboni/devhub-all.js:504 static/js/zamboni/devhub-min.js:1
 msgid "Received an empty response from the server; status: {0}"
 msgstr "სერვერისგან მოვიდა უშინაარსო პასუხი; სტატუსი: {0}"
 
-#: static/js/common/upload-addon.js:373
+#: static/js/common/upload-addon.js:370 static/js/zamboni/devhub-all.js:604 static/js/zamboni/devhub-min.js:1
 msgid "Unexpected server error while validating."
 msgstr "გადამოწმებისას დაფიქსირდა სერვერის მოულოდნელი შეცდომა."
 
-#: static/js/common/upload-addon.js:412
+#: static/js/common/upload-addon.js:409 static/js/zamboni/devhub-all.js:643 static/js/zamboni/devhub-min.js:1
 msgid "Finished validating {0}"
 msgstr "{0}-ის გადამოწმება დასრულდა"
 
-#: static/js/common/upload-addon.js:418
+#: static/js/common/upload-addon.js:415 static/js/zamboni/devhub-all.js:649 static/js/zamboni/devhub-min.js:1
 msgid "Your add-on validation timed out, it will be manually reviewed."
 msgstr "დამატების გადამოწმების დრო ამოიწურა, ის ხელით იქნება განხილული."
 
-#: static/js/common/upload-addon.js:421
+#: static/js/common/upload-addon.js:418 static/js/zamboni/devhub-all.js:652 static/js/zamboni/devhub-min.js:1
 msgid "Your add-on was validated with no errors and {0} warning."
 msgid_plural "Your add-on was validated with no errors and {0} warnings."
-msgstr[0] ""
-"დამატების გადამოწმება დასრულდა შეცდომის გარეშე და {0} გაფრთხილებით."
+msgstr[0] "დამატების გადამოწმება დასრულდა შეცდომის გარეშე და {0} გაფრთხილებით."
+msgstr[1] ""
 
-#: static/js/common/upload-addon.js:426
+#: static/js/common/upload-addon.js:423 static/js/zamboni/devhub-all.js:657 static/js/zamboni/devhub-min.js:1
 msgid "Your add-on was validated with no errors and {0} message."
 msgid_plural "Your add-on was validated with no errors and {0} messages."
-msgstr[0] ""
-"დამატების გადამოწმება დასრულდა შეცდომის გარეშე და {0} შეტყობინებით."
+msgstr[0] "დამატების გადამოწმება დასრულდა შეცდომის გარეშე და {0} შეტყობინებით."
+msgstr[1] ""
 
-#: static/js/common/upload-addon.js:431
+#: static/js/common/upload-addon.js:428 static/js/zamboni/devhub-all.js:662 static/js/zamboni/devhub-min.js:1
 msgid "Your add-on was validated with no errors or warnings."
 msgstr "დამატების გადამოწმება დასრულდა შეცდომის და გაფრთხილებების გარეშე."
 
-#: static/js/common/upload-addon.js:446
+#: static/js/common/upload-addon.js:443 static/js/zamboni/devhub-all.js:677 static/js/zamboni/devhub-min.js:1
 msgid "Your submission will be automatically signed."
 msgstr "თქვენი შენატანი ავტომატურად იქნება ხელმოწერილი."
 
-#: static/js/common/upload-addon.js:465
+#: static/js/common/upload-addon.js:450 static/js/zamboni/devhub-all.js:696 static/js/zamboni/devhub-min.js:1
 msgid "Include detailed version notes (this can be done in the next step)."
-msgstr ""
-"მიუთითეთ ვერსიის შენიშვნები დეტალურად (ამის გაკეთება მომდევნო ნაბიჯში "
-"შეიძლება)."
+msgstr "მიუთითეთ ვერსიის შენიშვნები დეტალურად (ამის გაკეთება მომდევნო ნაბიჯში შეიძლება)."
 
-#: static/js/common/upload-addon.js:466
-msgid ""
-"If your add-on requires an account to a website in order to be fully tested,"
-" include a test username and password in the Notes to Reviewer (this can be "
-"done in the next step)."
+#: static/js/common/upload-addon.js:451 static/js/zamboni/devhub-all.js:697 static/js/zamboni/devhub-min.js:1
+msgid "If your add-on requires an account to a website in order to be fully tested, include a test username and password in the Notes to Reviewer (this can be done in the next step)."
 msgstr ""
 "თუ თქვენი დამატების სრულყოფილად გამოსაცდელად საჭიროა საიტის ანგარიში, "
 "მიმომხილველებისთვის განკუთვნილ შენიშვნებში მიუთითეთ საცდელი მომხმარებლის "
 "სახელი და პაროლი (ამის გაკეთება, შემდეგ ნაბიჯზეა შესაძლებელი)."
 
-#: static/js/common/upload-addon.js:467
-msgid ""
-"If your add-on is intended for a limited audience you should choose "
-"Preliminary Review instead of Full Review."
+#: static/js/common/upload-addon.js:452 static/js/zamboni/devhub-all.js:698 static/js/zamboni/devhub-min.js:1
+msgid "If your add-on is intended for a limited audience you should choose Preliminary Review instead of Full Review."
 msgstr ""
 "თუ თქვენი დამატება განკუთვნილია მხოლოდ შერჩეული სამიზნე აუდიტორიისთვის, "
 "სრული განხილვის ნაცვლად უნდა აირჩიოთ წინასწარი განხილვა."
 
-#: static/js/common/upload-addon.js:480
+#: static/js/common/upload-addon.js:465 static/js/zamboni/devhub-all.js:711 static/js/zamboni/devhub-min.js:1
 msgid "Add-on submission checklist"
 msgstr "საკონტროლო სია დამატების წარსადგენად"
 
-#: static/js/common/upload-addon.js:481
-msgid ""
-"Please verify the following points before finalizing your submission. This "
-"will minimize delays or misunderstanding during the review process:"
+#: static/js/common/upload-addon.js:466 static/js/zamboni/devhub-all.js:712 static/js/zamboni/devhub-min.js:1
+msgid "Please verify the following points before finalizing your submission. This will minimize delays or misunderstanding during the review process:"
 msgstr ""
 "გთხოვთ, გადაამოწმოთ მოცემული პუნქტები წარდგენის დასასრულებლად. ეს შეამცირებს"
 " განხილვის დროს შეფერხების ან გაუგებრობის წარმოშობას."
 
-#: static/js/common/upload-addon.js:483
+#: static/js/common/upload-addon.js:468 static/js/zamboni/devhub-all.js:714 static/js/zamboni/devhub-min.js:1
 msgid ""
-"Compiled binaries, as well as minified or obfuscated scripts (excluding "
-"known libraries) need to have their sources submitted separately for review."
-" Make sure that you use the source code upload field to avoid having your "
-"submission rejected."
+"Compiled binaries, as well as minified or obfuscated scripts (excluding known libraries) need to have their sources submitted separately for review. Make sure that you use the source code upload "
+"field to avoid having your submission rejected."
 msgstr ""
 "შედგენილი ბინარული, ისევე როგორც ოპტიმიზებული ან დაცული კოდის (ცნობილი "
 "ბიბლიოთეკების გარდა) ორიგინალის გადაგზავნა განსახილველად, საჭიროა სათითაოდ. "
 "დარწმუნდით, რომ სარგებლობთ საწყისი კოდის ასატვირთი ველით, რომ თავიდან "
 "აიცილოთ უარი მიღებაზე."
 
-#: static/js/common/upload-addon.js:501
+#: static/js/common/upload-addon.js:486 static/js/zamboni/devhub-all.js:732 static/js/zamboni/devhub-min.js:1
 msgid "The validation process found these issues that can lead to rejections:"
 msgstr ""
 "გადამოწმებისას აღმოჩენილია გარკვეული საკითხები, რაც შეიძლება უარყოფის "
 "საფუძველი გახდეს."
 
-#: static/js/common/upload-addon.js:518
-msgid ""
-"If you are unfamiliar with the add-ons review process, you can read about it"
-" here."
+#: static/js/common/upload-addon.js:503 static/js/zamboni/devhub-all.js:749 static/js/zamboni/devhub-min.js:1
+msgid "If you are unfamiliar with the add-ons review process, you can read about it here."
 msgstr ""
 "თუ არ ხართ გარკვეული მიმოხილვასთან დაკავშირებულ საკითხებში, ამის შესახებ "
 "შეგიძლიათ წაიკითხოთ აქ."
 
-#: static/js/common/upload-addon.js:555
+#: static/js/common/upload-addon.js:540 static/js/zamboni/devhub-all.js:786 static/js/zamboni/devhub-min.js:1
 msgid "Sorry, no supported platform has been found."
 msgstr "სამწუხაროდ, მხარდაჭერილი პლატფორმები არ მოიძებნა."
 
-#: static/js/common/upload-base.js:57
+#: static/js/common/upload-base.js:57 static/js/zamboni/devhub-all.js:187 static/js/zamboni/devhub-min.js:1
 msgid "The filetype you uploaded isn't recognized."
 msgstr "ატვირთული ფაილის ტიპი,  გაურკვეველია."
 
-#: static/js/common/upload-base.js:79
+#: static/js/common/upload-base.js:79 static/js/zamboni/devhub-all.js:209 static/js/zamboni/devhub-min.js:1
 msgid "You cancelled the upload."
 msgstr "თქვენ გააუქმეთ ატვირთვა."
 
-#: static/js/common/upload-image.js:97 static/js/impala/users.js:51
-msgid "Images must be either PNG or JPG."
-msgstr "ნახატი უნდა იყოს PNG ან JPG."
-
-#: static/js/common/upload-image.js:101
-msgid "Videos must be in WebM."
-msgstr "ვიდეო უნდა იყოს WebM."
-
-#: static/js/impala/collections.js:10 static/js/zamboni/collections.js:595
-msgid "Follow this Collection"
-msgstr "კოლექციის გაყოლა"
-
-#: static/js/impala/collections.js:19
-msgid "Stop Following"
-msgstr "გაყოლის შეჩერება"
-
-#: static/js/impala/collections.js:20
-msgid "Following"
-msgstr "მიჰყვებით"
-
-#. L10n: {0} is an app name.
-#: static/js/impala/listing.js:11 static/js/zamboni/themes.js:13
-msgid "This theme is incompatible with your version of {0}"
-msgstr "ეს თემა {0}-ის თქვენს ვერსიასთან შეუთავსებელია"
-
-#: static/js/impala/persona_creation.js:60
-msgid "All Rights Reserved"
-msgstr "ყველა უფლება დაცულია"
-
-#: static/js/impala/persona_creation.js:64
-msgid "Creative Commons Attribution 3.0"
-msgstr "Creative Commons Attribution 3.0"
-
-#: static/js/impala/persona_creation.js:69
-msgid "Creative Commons Attribution-NonCommercial 3.0"
-msgstr "Creative Commons Attribution-NonCommercial 3.0"
-
-#: static/js/impala/persona_creation.js:74
-msgid "Creative Commons Attribution-NonCommercial-NoDerivs 3.0"
-msgstr "Creative Commons Attribution-NonCommercial-NoDerivs 3.0"
-
-#: static/js/impala/persona_creation.js:79
-msgid "Creative Commons Attribution-NonCommercial-Share Alike 3.0"
-msgstr "Creative Commons Attribution-NonCommercial-Share Alike 3.0"
-
-#: static/js/impala/persona_creation.js:84
-msgid "Creative Commons Attribution-NoDerivs 3.0"
-msgstr "Creative Commons Attribution-NoDerivs 3.0"
-
-#: static/js/impala/persona_creation.js:89
-msgid "Creative Commons Attribution-ShareAlike 3.0"
-msgstr "Creative Commons Attribution-ShareAlike 3.0"
-
-#: static/js/impala/persona_creation.js:292
-msgid "Your Theme's Name"
-msgstr "თქვენი თემის სახელი"
-
-#: static/js/impala/reviews.js:23 static/js/zamboni/reviews.js:18
-msgid "Flagged for review"
-msgstr "განსახილველად მონიშნული"
-
-#: static/js/impala/reviews.js:40 static/js/zamboni/reviews.js:34
-msgid "Your input is required"
-msgstr "საჭიროა მონაცემების შეყვანა"
-
-#: static/js/impala/reviews.js:152 static/js/zamboni/reviews.js:103
-msgid "Marked for deletion"
-msgstr "წასაშლელად მონიშნული"
-
-#: static/js/impala/search.js:114
-msgid "Updating results&hellip;"
-msgstr "შედეგების განახლება&hellip;"
-
-#: static/js/impala/site_suggestions.js:46
-msgid "Category"
-msgstr "კატეგორია"
-
-#: static/js/impala/suggestions.js:39
-msgid "Search themes for <b>{0}</b>"
-msgstr "<b>{0}-ს</b> ძიება თემებში"
-
-#: static/js/impala/suggestions.js:41
-msgid "Search apps for <b>{0}</b>"
-msgstr "<b>{0}-ს</b> ძიება აპებში"
-
-#: static/js/impala/suggestions.js:43
-msgid "Search add-ons for <b>{0}</b>"
-msgstr "<b>{0}-ს</b> ძიება დამატებებში"
-
-#: static/js/impala/users.js:33
-msgid "use original"
-msgstr "ორიგინალის გამოყენება"
-
-#: static/js/impala/stats/chart.js:267
+#: static/js/impala/stats/chart.js:267 static/js/zamboni/stats-all.js:16898 static/js/zamboni/stats-min.js:5
 msgid "Week of {0}"
 msgstr "{0} კვირა"
 
-#: static/js/impala/stats/chart.js:269
+#: static/js/impala/stats/chart.js:269 static/js/zamboni/stats-all.js:16900 static/js/zamboni/stats-min.js:5
 msgid " downloads"
-msgstr " ჩამოტვირთვა"
+msgstr ""
 
-#: static/js/impala/stats/chart.js:270
+#: static/js/impala/stats/chart.js:270 static/js/zamboni/stats-all.js:16901 static/js/zamboni/stats-min.js:5
 msgid "{0} users"
 msgstr "{0} მომხმარებელი"
 
-#: static/js/impala/stats/chart.js:271
+#: static/js/impala/stats/chart.js:271 static/js/zamboni/stats-all.js:16902 static/js/zamboni/stats-min.js:5
 msgid "{0} add-ons"
 msgstr "{0} დამატება"
 
-#: static/js/impala/stats/chart.js:272
+#: static/js/impala/stats/chart.js:272 static/js/zamboni/stats-all.js:16903 static/js/zamboni/stats-min.js:5
 msgid "{0} collections"
 msgstr "{0} კოლექცია"
 
-#: static/js/impala/stats/chart.js:273
+#: static/js/impala/stats/chart.js:273 static/js/zamboni/stats-all.js:16904 static/js/zamboni/stats-min.js:5
 msgid "{0} reviews"
 msgstr "{0} მიმოხილვა"
 
-#: static/js/impala/stats/chart.js:275
+#: static/js/impala/stats/chart.js:275 static/js/zamboni/stats-all.js:16906 static/js/zamboni/stats-min.js:5
 msgid "{0} sales"
 msgstr "{0} გაყიდვა"
 
-#: static/js/impala/stats/chart.js:276
+#: static/js/impala/stats/chart.js:276 static/js/zamboni/stats-all.js:16907 static/js/zamboni/stats-min.js:5
 msgid "{0} refunds"
 msgstr "{0} ანაზღაურება"
 
-#: static/js/impala/stats/chart.js:277
+#: static/js/impala/stats/chart.js:277 static/js/zamboni/stats-all.js:16908 static/js/zamboni/stats-min.js:5
 msgid "{0} installs"
 msgstr "{0} დაყენება"
 
-#: static/js/impala/stats/chart.js:369 static/js/impala/stats/csv_keys.js:3
-#: static/js/impala/stats/csv_keys.js:109
+#: static/js/impala/stats/chart.js:369 static/js/impala/stats/csv_keys.js:3 static/js/impala/stats/csv_keys.js:109 static/js/zamboni/stats-all.js:15284 static/js/zamboni/stats-all.js:15390
+#: static/js/zamboni/stats-all.js:17000 static/js/zamboni/stats-min.js:4 static/js/zamboni/stats-min.js:5
 msgid "Downloads"
 msgstr "ჩამოტვირთვები"
 
-#: static/js/impala/stats/chart.js:379 static/js/impala/stats/csv_keys.js:6
-#: static/js/impala/stats/csv_keys.js:110
+#: static/js/impala/stats/chart.js:379 static/js/impala/stats/csv_keys.js:6 static/js/impala/stats/csv_keys.js:110 static/js/zamboni/stats-all.js:15287 static/js/zamboni/stats-all.js:15391
+#: static/js/zamboni/stats-all.js:17010 static/js/zamboni/stats-min.js:4 static/js/zamboni/stats-min.js:5
 msgid "Daily Users"
 msgstr "დღიური მომხმარებლები"
 
-#: static/js/impala/stats/chart.js:410
+#: static/js/impala/stats/chart.js:410 static/js/zamboni/stats-all.js:17041 static/js/zamboni/stats-min.js:5
 msgid "Amount, in USD"
 msgstr "ოდენობა, USD-ში"
 
-#: static/js/impala/stats/chart.js:421 static/js/impala/stats/csv_keys.js:104
+#: static/js/impala/stats/chart.js:421 static/js/impala/stats/csv_keys.js:104 static/js/zamboni/stats-all.js:15385 static/js/zamboni/stats-all.js:17052 static/js/zamboni/stats-min.js:5
 msgid "Number of Contributions"
 msgstr "დამხმარეების რაოდენობა"
 
-#: static/js/impala/stats/chart.js:447
+#: static/js/impala/stats/chart.js:447 static/js/zamboni/stats-all.js:17078 static/js/zamboni/stats-min.js:5
 msgid "More Info..."
 msgstr "მეტი ინფო..."
 
 #. L10n: {0} is an ISO-formatted date.
-#: static/js/impala/stats/chart.js:451
+#: static/js/impala/stats/chart.js:451 static/js/zamboni/stats-all.js:17082 static/js/zamboni/stats-min.js:5
 msgid "Details for {0}"
 msgstr "{0}-ის დეტალები"
 
-#: static/js/impala/stats/csv_keys.js:9
+#: static/js/impala/stats/csv_keys.js:9 static/js/zamboni/stats-all.js:15290 static/js/zamboni/stats-min.js:4
 msgid "Collections Created"
 msgstr "კრებულები შეიქმნა"
 
-#: static/js/impala/stats/csv_keys.js:12
+#: static/js/impala/stats/csv_keys.js:12 static/js/zamboni/stats-all.js:15293 static/js/zamboni/stats-min.js:4
 msgid "Add-ons in Use"
 msgstr "დამატებები, რომლებიც გამოიყენება"
 
-#: static/js/impala/stats/csv_keys.js:15
+#: static/js/impala/stats/csv_keys.js:15 static/js/zamboni/stats-all.js:15296 static/js/zamboni/stats-min.js:4
 msgid "Add-ons Created"
 msgstr "შექმნილი დამატებები"
 
-#: static/js/impala/stats/csv_keys.js:18
+#: static/js/impala/stats/csv_keys.js:18 static/js/zamboni/stats-all.js:15299 static/js/zamboni/stats-min.js:4
 msgid "Add-ons Downloaded"
 msgstr "ჩამოტვირთული დამატებები"
 
-#: static/js/impala/stats/csv_keys.js:21
+#: static/js/impala/stats/csv_keys.js:21 static/js/zamboni/stats-all.js:15302 static/js/zamboni/stats-min.js:4
 msgid "Add-ons Updated"
 msgstr "განახლებული დამატებები"
 
-#: static/js/impala/stats/csv_keys.js:24
+#: static/js/impala/stats/csv_keys.js:24 static/js/zamboni/stats-all.js:15305 static/js/zamboni/stats-min.js:4
 msgid "Reviews Written"
 msgstr "მიმოხილვები გაკეთებულია"
 
-#: static/js/impala/stats/csv_keys.js:27
+#: static/js/impala/stats/csv_keys.js:27 static/js/zamboni/stats-all.js:15308 static/js/zamboni/stats-min.js:4
 msgid "User Signups"
 msgstr "დარეგისტრებული მომხმარებლები"
 
-#: static/js/impala/stats/csv_keys.js:30
+#: static/js/impala/stats/csv_keys.js:30 static/js/zamboni/stats-all.js:15311 static/js/zamboni/stats-min.js:4
 msgid "Subscribers"
 msgstr "გამომწერები"
 
-#: static/js/impala/stats/csv_keys.js:33
+#: static/js/impala/stats/csv_keys.js:33 static/js/zamboni/stats-all.js:15314 static/js/zamboni/stats-min.js:4
 msgid "Ratings"
 msgstr "შეფასებები"
 
-#: static/js/impala/stats/csv_keys.js:36
-#: static/js/impala/stats/csv_keys.js:114
+#: static/js/impala/stats/csv_keys.js:36 static/js/impala/stats/csv_keys.js:114 static/js/zamboni/stats-all.js:15317 static/js/zamboni/stats-all.js:15395 static/js/zamboni/stats-min.js:4
+#: static/js/zamboni/stats-min.js:5
 msgid "Sales"
 msgstr "გაყიდვები"
 
-#: static/js/impala/stats/csv_keys.js:39
-#: static/js/impala/stats/csv_keys.js:113
+#: static/js/impala/stats/csv_keys.js:39 static/js/impala/stats/csv_keys.js:113 static/js/zamboni/stats-all.js:15320 static/js/zamboni/stats-all.js:15394 static/js/zamboni/stats-min.js:4
+#: static/js/zamboni/stats-min.js:5
 msgid "Installs"
 msgstr "დაყენების რაოდ."
 
-#: static/js/impala/stats/csv_keys.js:42
+#: static/js/impala/stats/csv_keys.js:42 static/js/zamboni/stats-all.js:15323 static/js/zamboni/stats-min.js:4
 msgid "Unknown"
 msgstr "უცნობი"
 
-#: static/js/impala/stats/csv_keys.js:43
+#: static/js/impala/stats/csv_keys.js:43 static/js/zamboni/stats-all.js:15324 static/js/zamboni/stats-min.js:4
 msgid "Add-ons Manager"
 msgstr "დამატებების მმართველი"
 
-#: static/js/impala/stats/csv_keys.js:44
+#: static/js/impala/stats/csv_keys.js:44 static/js/zamboni/stats-all.js:15325 static/js/zamboni/stats-min.js:4
 msgid "Add-ons Manager Promo"
 msgstr "დამატებების მმართველის პრომო"
 
-#: static/js/impala/stats/csv_keys.js:45
+#: static/js/impala/stats/csv_keys.js:45 static/js/zamboni/stats-all.js:15326 static/js/zamboni/stats-min.js:4
 msgid "Add-ons Manager Featured"
 msgstr "დამატებების მმართველის რჩეულები"
 
-#: static/js/impala/stats/csv_keys.js:46
+#: static/js/impala/stats/csv_keys.js:46 static/js/zamboni/stats-all.js:15327 static/js/zamboni/stats-min.js:4
 msgid "Add-ons Manager Learn More"
 msgstr "დამატებების მმართველის დაწვრილებით"
 
-#: static/js/impala/stats/csv_keys.js:47
+#: static/js/impala/stats/csv_keys.js:47 static/js/zamboni/stats-all.js:15328 static/js/zamboni/stats-min.js:4
 msgid "Search Suggestions"
 msgstr "ძიების შემოთავაზებები"
 
-#: static/js/impala/stats/csv_keys.js:48
+#: static/js/impala/stats/csv_keys.js:48 static/js/zamboni/stats-all.js:15329 static/js/zamboni/stats-min.js:4
 msgid "Search Results"
 msgstr "ძიების შედეგები"
 
-#: static/js/impala/stats/csv_keys.js:49 static/js/impala/stats/csv_keys.js:50
-#: static/js/impala/stats/csv_keys.js:51
+#: static/js/impala/stats/csv_keys.js:49 static/js/impala/stats/csv_keys.js:50 static/js/impala/stats/csv_keys.js:51 static/js/zamboni/stats-all.js:15330 static/js/zamboni/stats-all.js:15331
+#: static/js/zamboni/stats-all.js:15332 static/js/zamboni/stats-min.js:4
 msgid "Homepage Promo"
 msgstr "მთავარ გვერდზე დაწინაურებული"
 
-#: static/js/impala/stats/csv_keys.js:52 static/js/impala/stats/csv_keys.js:53
+#: static/js/impala/stats/csv_keys.js:52 static/js/impala/stats/csv_keys.js:53 static/js/zamboni/stats-all.js:15333 static/js/zamboni/stats-all.js:15334 static/js/zamboni/stats-min.js:4
 msgid "Homepage Featured"
 msgstr "მთავარ გვერდზე შემოთავაზებულებში"
 
-#: static/js/impala/stats/csv_keys.js:54 static/js/impala/stats/csv_keys.js:55
+#: static/js/impala/stats/csv_keys.js:54 static/js/impala/stats/csv_keys.js:55 static/js/zamboni/stats-all.js:15335 static/js/zamboni/stats-all.js:15336 static/js/zamboni/stats-min.js:4
 msgid "Homepage Up and Coming"
 msgstr "მთავარ გვერდზე მზარდი მოთხოვნის"
 
-#: static/js/impala/stats/csv_keys.js:56
+#: static/js/impala/stats/csv_keys.js:56 static/js/zamboni/stats-all.js:15337 static/js/zamboni/stats-min.js:4
 msgid "Homepage Most Popular"
 msgstr "მთავარ გვერდზე ყველაზე მოთხოვნადი"
 
-#: static/js/impala/stats/csv_keys.js:57 static/js/impala/stats/csv_keys.js:59
+#: static/js/impala/stats/csv_keys.js:57 static/js/impala/stats/csv_keys.js:59 static/js/zamboni/stats-all.js:15338 static/js/zamboni/stats-all.js:15340 static/js/zamboni/stats-min.js:4
 msgid "Detail Page"
 msgstr "აღწერის გვერდი"
 
-#: static/js/impala/stats/csv_keys.js:58 static/js/impala/stats/csv_keys.js:60
+#: static/js/impala/stats/csv_keys.js:58 static/js/impala/stats/csv_keys.js:60 static/js/zamboni/stats-all.js:15339 static/js/zamboni/stats-all.js:15341 static/js/zamboni/stats-min.js:4
 msgid "Detail Page (bottom)"
 msgstr "აღწერის გვერდი (ქვემოთ)"
 
-#: static/js/impala/stats/csv_keys.js:61
+#: static/js/impala/stats/csv_keys.js:61 static/js/zamboni/stats-all.js:15342 static/js/zamboni/stats-min.js:4
 msgid "Detail Page (Development Channel)"
 msgstr "ინფორმაციის გვერდი (განვითარების არხი)"
 
-#: static/js/impala/stats/csv_keys.js:62 static/js/impala/stats/csv_keys.js:63
-#: static/js/impala/stats/csv_keys.js:64
+#: static/js/impala/stats/csv_keys.js:62 static/js/impala/stats/csv_keys.js:63 static/js/impala/stats/csv_keys.js:64 static/js/zamboni/stats-all.js:15343 static/js/zamboni/stats-all.js:15344
+#: static/js/zamboni/stats-all.js:15345 static/js/zamboni/stats-min.js:4
 msgid "Often Used With"
 msgstr "ამასთან, ხშირად იყენებენ"
 
-#: static/js/impala/stats/csv_keys.js:65 static/js/impala/stats/csv_keys.js:66
+#: static/js/impala/stats/csv_keys.js:65 static/js/impala/stats/csv_keys.js:66 static/js/zamboni/stats-all.js:15346 static/js/zamboni/stats-all.js:15347 static/js/zamboni/stats-min.js:4
 msgid "Others By Author"
 msgstr "ამ ავტორის სხვა პროდუქტები"
 
-#: static/js/impala/stats/csv_keys.js:67 static/js/impala/stats/csv_keys.js:68
+#: static/js/impala/stats/csv_keys.js:67 static/js/impala/stats/csv_keys.js:68 static/js/zamboni/stats-all.js:15348 static/js/zamboni/stats-all.js:15349 static/js/zamboni/stats-min.js:4
 msgid "Dependencies"
 msgstr "დამოკიდებულებები"
 
-#: static/js/impala/stats/csv_keys.js:69 static/js/impala/stats/csv_keys.js:70
+#: static/js/impala/stats/csv_keys.js:69 static/js/impala/stats/csv_keys.js:70 static/js/zamboni/stats-all.js:15350 static/js/zamboni/stats-all.js:15351 static/js/zamboni/stats-min.js:4
 msgid "Upsell"
 msgstr "სარეკლამო"
 
-#: static/js/impala/stats/csv_keys.js:71
+#: static/js/impala/stats/csv_keys.js:71 static/js/zamboni/stats-all.js:15352 static/js/zamboni/stats-min.js:4
 msgid "Meet the Developer"
 msgstr "გაიცანით შემქმნელი"
 
-#: static/js/impala/stats/csv_keys.js:72
+#: static/js/impala/stats/csv_keys.js:72 static/js/zamboni/stats-all.js:15353 static/js/zamboni/stats-min.js:4
 msgid "User Profile"
 msgstr "მომხმარებლის პროფილი"
 
-#: static/js/impala/stats/csv_keys.js:73
+#: static/js/impala/stats/csv_keys.js:73 static/js/zamboni/stats-all.js:15354 static/js/zamboni/stats-min.js:4
 msgid "Version History"
 msgstr "ვერსიის ისტორია"
 
-#: static/js/impala/stats/csv_keys.js:75
+#: static/js/impala/stats/csv_keys.js:75 static/js/zamboni/stats-all.js:15356 static/js/zamboni/stats-min.js:4
 msgid "Sharing"
 msgstr "გაზიარება"
 
-#: static/js/impala/stats/csv_keys.js:76
+#: static/js/impala/stats/csv_keys.js:76 static/js/zamboni/stats-all.js:15357 static/js/zamboni/stats-min.js:4
 msgid "Category Pages"
 msgstr "კატეგორიის გვერდები"
 
-#: static/js/impala/stats/csv_keys.js:77
+#: static/js/impala/stats/csv_keys.js:77 static/js/zamboni/stats-all.js:15358 static/js/zamboni/stats-min.js:4
 msgid "Collections"
 msgstr "კოლექციები"
 
-#: static/js/impala/stats/csv_keys.js:78 static/js/impala/stats/csv_keys.js:79
+#: static/js/impala/stats/csv_keys.js:78 static/js/impala/stats/csv_keys.js:79 static/js/zamboni/stats-all.js:15359 static/js/zamboni/stats-all.js:15360 static/js/zamboni/stats-min.js:4
 msgid "Category Landing Featured Carousel"
 msgstr "განთავსება კატეგორიაში რჩეულები"
 
-#: static/js/impala/stats/csv_keys.js:80 static/js/impala/stats/csv_keys.js:81
+#: static/js/impala/stats/csv_keys.js:80 static/js/impala/stats/csv_keys.js:81 static/js/zamboni/stats-all.js:15361 static/js/zamboni/stats-all.js:15362 static/js/zamboni/stats-min.js:4
 msgid "Category Landing Top Rated"
 msgstr "განთავსება კატეგორიაში უმაღლესად შეფასებულები"
 
-#: static/js/impala/stats/csv_keys.js:82 static/js/impala/stats/csv_keys.js:83
+#: static/js/impala/stats/csv_keys.js:82 static/js/impala/stats/csv_keys.js:83 static/js/zamboni/stats-all.js:15363 static/js/zamboni/stats-all.js:15364 static/js/zamboni/stats-min.js:5
 msgid "Category Landing Most Popular"
 msgstr "განთავსება კატეგორიაში ყველაზე მოთხოვნადი"
 
-#: static/js/impala/stats/csv_keys.js:84 static/js/impala/stats/csv_keys.js:85
+#: static/js/impala/stats/csv_keys.js:84 static/js/impala/stats/csv_keys.js:85 static/js/zamboni/stats-all.js:15365 static/js/zamboni/stats-all.js:15366 static/js/zamboni/stats-min.js:5
 msgid "Category Landing Recently Added"
 msgstr "განთავსება კატეგორიაში ბოლოს დამატებულები"
 
-#: static/js/impala/stats/csv_keys.js:86 static/js/impala/stats/csv_keys.js:87
+#: static/js/impala/stats/csv_keys.js:86 static/js/impala/stats/csv_keys.js:87 static/js/zamboni/stats-all.js:15367 static/js/zamboni/stats-all.js:15368 static/js/zamboni/stats-min.js:5
 msgid "Browse Listing Featured Sort"
 msgstr "რჩეულობის მიხედვით დახარისხებულის დათვალიერება"
 
-#: static/js/impala/stats/csv_keys.js:88 static/js/impala/stats/csv_keys.js:89
+#: static/js/impala/stats/csv_keys.js:88 static/js/impala/stats/csv_keys.js:89 static/js/zamboni/stats-all.js:15369 static/js/zamboni/stats-all.js:15370 static/js/zamboni/stats-min.js:5
 msgid "Browse Listing Users Sort"
 msgstr "მომხმარებლის მიხედვით დახარისხებულის დათვალიერება"
 
-#: static/js/impala/stats/csv_keys.js:90 static/js/impala/stats/csv_keys.js:91
+#: static/js/impala/stats/csv_keys.js:90 static/js/impala/stats/csv_keys.js:91 static/js/zamboni/stats-all.js:15371 static/js/zamboni/stats-all.js:15372 static/js/zamboni/stats-min.js:5
 msgid "Browse Listing Rating Sort"
 msgstr "შეფასების მიხედვით დახარისხებულის დათვალიერება"
 
-#: static/js/impala/stats/csv_keys.js:92 static/js/impala/stats/csv_keys.js:93
+#: static/js/impala/stats/csv_keys.js:92 static/js/impala/stats/csv_keys.js:93 static/js/zamboni/stats-all.js:15373 static/js/zamboni/stats-all.js:15374 static/js/zamboni/stats-min.js:5
 msgid "Browse Listing Created Sort"
 msgstr "შემქნელის მიხედვით დახარისხებულის დათვალიერება"
 
-#: static/js/impala/stats/csv_keys.js:94 static/js/impala/stats/csv_keys.js:95
+#: static/js/impala/stats/csv_keys.js:94 static/js/impala/stats/csv_keys.js:95 static/js/zamboni/stats-all.js:15375 static/js/zamboni/stats-all.js:15376 static/js/zamboni/stats-min.js:5
 msgid "Browse Listing Name Sort"
 msgstr "სახელის მიხედვით დახარისხებულის დათვალიერება"
 
-#: static/js/impala/stats/csv_keys.js:96 static/js/impala/stats/csv_keys.js:97
+#: static/js/impala/stats/csv_keys.js:96 static/js/impala/stats/csv_keys.js:97 static/js/zamboni/stats-all.js:15377 static/js/zamboni/stats-all.js:15378 static/js/zamboni/stats-min.js:5
 msgid "Browse Listing Popular Sort"
 msgstr "მოთხოვნის მიხედვით დახარისხებულის დათვალიერება"
 
-#: static/js/impala/stats/csv_keys.js:98 static/js/impala/stats/csv_keys.js:99
+#: static/js/impala/stats/csv_keys.js:98 static/js/impala/stats/csv_keys.js:99 static/js/zamboni/stats-all.js:15379 static/js/zamboni/stats-all.js:15380 static/js/zamboni/stats-min.js:5
 msgid "Browse Listing Updated Sort"
 msgstr "განახლების თარიღის მიხედვით დახარისხებულის დათვალიერება"
 
-#: static/js/impala/stats/csv_keys.js:100
-#: static/js/impala/stats/csv_keys.js:101
+#: static/js/impala/stats/csv_keys.js:100 static/js/impala/stats/csv_keys.js:101 static/js/zamboni/stats-all.js:15381 static/js/zamboni/stats-all.js:15382 static/js/zamboni/stats-min.js:5
 msgid "Browse Listing Up and Coming Sort"
 msgstr "მზარდი მოთხოვნის მიხედვით დახარისხებულის დათვალიერება"
 
-#: static/js/impala/stats/csv_keys.js:105
+#: static/js/impala/stats/csv_keys.js:105 static/js/zamboni/stats-all.js:15386 static/js/zamboni/stats-min.js:5
 msgid "Total Amount Contributed"
 msgstr "შემოწირულობის საერთო რაოდენობა"
 
-#: static/js/impala/stats/csv_keys.js:106
+#: static/js/impala/stats/csv_keys.js:106 static/js/zamboni/stats-all.js:15387 static/js/zamboni/stats-min.js:5
 msgid "Average Contribution"
 msgstr "შემოწირულობის საშუალო რაოდენობა"
 
-#: static/js/impala/stats/csv_keys.js:115
+#: static/js/impala/stats/csv_keys.js:115 static/js/zamboni/stats-all.js:15396 static/js/zamboni/stats-min.js:5
 msgid "Usage"
 msgstr "მოხმარება"
 
-#: static/js/impala/stats/csv_keys.js:118
+#: static/js/impala/stats/csv_keys.js:118 static/js/zamboni/stats-all.js:15399 static/js/zamboni/stats-min.js:5
 msgid "Firefox"
 msgstr "Firefox"
 
-#: static/js/impala/stats/csv_keys.js:119
+#: static/js/impala/stats/csv_keys.js:119 static/js/zamboni/stats-all.js:15400 static/js/zamboni/stats-min.js:5
 msgid "Mozilla"
 msgstr "Mozilla"
 
-#: static/js/impala/stats/csv_keys.js:120
+#: static/js/impala/stats/csv_keys.js:120 static/js/zamboni/stats-all.js:15401 static/js/zamboni/stats-min.js:5
 msgid "Thunderbird"
 msgstr "Thunderbird"
 
-#: static/js/impala/stats/csv_keys.js:121
+#: static/js/impala/stats/csv_keys.js:121 static/js/zamboni/stats-all.js:15402 static/js/zamboni/stats-min.js:5
 msgid "Sunbird"
 msgstr "Sunbird"
 
-#: static/js/impala/stats/csv_keys.js:122
+#: static/js/impala/stats/csv_keys.js:122 static/js/zamboni/stats-all.js:15403 static/js/zamboni/stats-min.js:5
 msgid "SeaMonkey"
 msgstr "SeaMonkey"
 
-#: static/js/impala/stats/csv_keys.js:123
+#: static/js/impala/stats/csv_keys.js:123 static/js/zamboni/stats-all.js:15404 static/js/zamboni/stats-min.js:5
 msgid "Fennec"
 msgstr "Fennec"
 
-#: static/js/impala/stats/csv_keys.js:124
+#: static/js/impala/stats/csv_keys.js:124 static/js/zamboni/stats-all.js:15405 static/js/zamboni/stats-min.js:5
 msgid "Android"
 msgstr "Android"
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:129
+#: static/js/impala/stats/csv_keys.js:129 static/js/zamboni/stats-all.js:15410 static/js/zamboni/stats-min.js:5
 msgid "Downloads and Daily Users, last {0} days"
 msgstr "ჩამოტვირთვების და ყოვედღიური მომხმარებლების რაოდენობა, ბოლო {0} დღეში"
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:131
+#: static/js/impala/stats/csv_keys.js:131 static/js/zamboni/stats-all.js:15412 static/js/zamboni/stats-min.js:5
 msgid "Downloads and Daily Users from {0} to {1}"
 msgstr "ჩამოტვირთვების და ყოვედღიური მომხმარებლების რაოდენობა {0}-დან {1}-მდე"
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:135
+#: static/js/impala/stats/csv_keys.js:135 static/js/zamboni/stats-all.js:15416 static/js/zamboni/stats-min.js:5
 msgid "Installs and Daily Users, last {0} days"
 msgstr "დაყენების და ყოვედღიური მომხმარებლების რაოდენობა, ბოლო {0} დღეში"
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:137
+#: static/js/impala/stats/csv_keys.js:137 static/js/zamboni/stats-all.js:15418 static/js/zamboni/stats-min.js:5
 msgid "Installs and Daily Users from {0} to {1}"
 msgstr "დაყენების და ყოვედღიური მომხმარებლების რაოდენობა {0}-დან {1}-მდე"
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:141
+#: static/js/impala/stats/csv_keys.js:141 static/js/zamboni/stats-all.js:15422 static/js/zamboni/stats-min.js:5
 msgid "Downloads, last {0} days"
 msgstr "ჩამოტვირთვები, ბოლო {0} დღეში"
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:143
+#: static/js/impala/stats/csv_keys.js:143 static/js/zamboni/stats-all.js:15424 static/js/zamboni/stats-min.js:5
 msgid "Downloads from {0} to {1}"
 msgstr "ჩამოტვირთვები {0}-დან {1}-მდე"
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:147
+#: static/js/impala/stats/csv_keys.js:147 static/js/zamboni/stats-all.js:15428 static/js/zamboni/stats-min.js:5
 msgid "Daily Users, last {0} days"
 msgstr "ყოველდღიური მომხმარებლები, ბოლო {0} დღეში"
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:149
+#: static/js/impala/stats/csv_keys.js:149 static/js/zamboni/stats-all.js:15430 static/js/zamboni/stats-min.js:5
 msgid "Daily Users from {0} to {1}"
 msgstr "ყოველდღიური მომხმარებლები {0}-იდან {1}-მდე"
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:153
+#: static/js/impala/stats/csv_keys.js:153 static/js/zamboni/stats-all.js:15434 static/js/zamboni/stats-min.js:5
 msgid "Applications, last {0} days"
 msgstr "პროგრამები, ბოლო {0} დღეში"
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:155
+#: static/js/impala/stats/csv_keys.js:155 static/js/zamboni/stats-all.js:15436 static/js/zamboni/stats-min.js:5
 msgid "Applications from {0} to {1}"
 msgstr "პროგრამები {0}-დან {1}-მდე"
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:159
+#: static/js/impala/stats/csv_keys.js:159 static/js/zamboni/stats-all.js:15440 static/js/zamboni/stats-min.js:5
 msgid "Platforms, last {0} days"
 msgstr "პლატფორმები, ბოლო {0} დღეში"
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:161
+#: static/js/impala/stats/csv_keys.js:161 static/js/zamboni/stats-all.js:15442 static/js/zamboni/stats-min.js:5
 msgid "Platforms from {0} to {1}"
 msgstr "პლატფორმები {0}-დან {1}-მდე"
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:165
+#: static/js/impala/stats/csv_keys.js:165 static/js/zamboni/stats-all.js:15446 static/js/zamboni/stats-min.js:5
 msgid "Languages, last {0} days"
 msgstr "ენები, ბოლო {0} დღეში"
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:167
+#: static/js/impala/stats/csv_keys.js:167 static/js/zamboni/stats-all.js:15448 static/js/zamboni/stats-min.js:5
 msgid "Languages from {0} to {1}"
 msgstr "ენები {0}-დან {1}-მდე"
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:171
+#: static/js/impala/stats/csv_keys.js:171 static/js/zamboni/stats-all.js:15452 static/js/zamboni/stats-min.js:5
 msgid "Add-on Versions, last {0} days"
 msgstr "დამატების ვერსიები, ბოლო {0} დღეში"
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:173
+#: static/js/impala/stats/csv_keys.js:173 static/js/zamboni/stats-all.js:15454 static/js/zamboni/stats-min.js:5
 msgid "Add-on Versions from {0} to {1}"
 msgstr "დამატების ვერსიები {0}-დან {1}-მდე"
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:177
+#: static/js/impala/stats/csv_keys.js:177 static/js/zamboni/stats-all.js:15458 static/js/zamboni/stats-min.js:5
 msgid "Add-on Status, last {0} days"
 msgstr "დამატების სტატუსი, ბოლო {0} დღეში"
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:179
+#: static/js/impala/stats/csv_keys.js:179 static/js/zamboni/stats-all.js:15460 static/js/zamboni/stats-min.js:5
 msgid "Add-on Status from {0} to {1}"
 msgstr "დამატების სტატუსი {0}-დან {1}-მდე"
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:183
+#: static/js/impala/stats/csv_keys.js:183 static/js/zamboni/stats-all.js:15464 static/js/zamboni/stats-min.js:5
 msgid "Download Sources, last {0} days"
 msgstr "ჩამოტვირთვის წყაროები, ბოლო {0} დღეში"
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:185
+#: static/js/impala/stats/csv_keys.js:185 static/js/zamboni/stats-all.js:15466 static/js/zamboni/stats-min.js:5
 msgid "Download Sources from {0} to {1}"
 msgstr "ჩამოტვირთვის წყაროები {0}-დან {1}-მდე"
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:189
+#: static/js/impala/stats/csv_keys.js:189 static/js/zamboni/stats-all.js:15470 static/js/zamboni/stats-min.js:5
 msgid "Contributions, last {0} days"
 msgstr "შემოწირულობა, ბოლო {0} დღეში"
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:191
+#: static/js/impala/stats/csv_keys.js:191 static/js/zamboni/stats-all.js:15472 static/js/zamboni/stats-min.js:5
 msgid "Contributions from {0} to {1}"
 msgstr "შემოწირულობა {0}-დან {1}-მდე"
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:195
+#: static/js/impala/stats/csv_keys.js:195 static/js/zamboni/stats-all.js:15476 static/js/zamboni/stats-min.js:5
 msgid "Site Metrics, last {0} days"
 msgstr "ვებ-გვერდის სტატისტიკა, ბოლო {0} დღეში"
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:197
+#: static/js/impala/stats/csv_keys.js:197 static/js/zamboni/stats-all.js:15478 static/js/zamboni/stats-min.js:5
 msgid "Site Metrics from {0} to {1}"
 msgstr "ვებ-გვერდის სტატისტიკა {0}-დან {1}-მდე"
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:201
+#: static/js/impala/stats/csv_keys.js:201 static/js/zamboni/stats-all.js:15482 static/js/zamboni/stats-min.js:5
 msgid "Add-ons in Use, last {0} days"
 msgstr "დამატებების მოხმარება, ბოლო {0} დღეში"
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:203
+#: static/js/impala/stats/csv_keys.js:203 static/js/zamboni/stats-all.js:15484 static/js/zamboni/stats-min.js:5
 msgid "Add-ons in Use from {0} to {1}"
 msgstr "დამატებების მოხმარება {0}-დან {1}-მდე"
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:207
+#: static/js/impala/stats/csv_keys.js:207 static/js/zamboni/stats-all.js:15488 static/js/zamboni/stats-min.js:5
 msgid "Add-ons Downloaded, last {0} days"
 msgstr "ჩამოტვირთული დამატებები, ბოლო {0} დღეში"
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:209
+#: static/js/impala/stats/csv_keys.js:209 static/js/zamboni/stats-all.js:15490 static/js/zamboni/stats-min.js:5
 msgid "Add-ons Downloaded from {0} to {1}"
 msgstr "ჩამოტვირთული დამატებები {0}-დან {1}-მდე"
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:213
+#: static/js/impala/stats/csv_keys.js:213 static/js/zamboni/stats-all.js:15494 static/js/zamboni/stats-min.js:5
 msgid "Add-ons Created, last {0} days"
 msgstr "შექმნილი დამატებები, ბოლო {0} დღეში"
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:215
+#: static/js/impala/stats/csv_keys.js:215 static/js/zamboni/stats-all.js:15496 static/js/zamboni/stats-min.js:5
 msgid "Add-ons Created from {0} to {1}"
 msgstr "შექმნილი დამატებები {0}-დან {1}-მდე"
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:219
+#: static/js/impala/stats/csv_keys.js:219 static/js/zamboni/stats-all.js:15500 static/js/zamboni/stats-min.js:5
 msgid "Add-ons Updated, last {0} days"
 msgstr "განახლებული დამატებები, ბოლო {0} დღეში"
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:221
+#: static/js/impala/stats/csv_keys.js:221 static/js/zamboni/stats-all.js:15502 static/js/zamboni/stats-min.js:5
 msgid "Add-ons Updated from {0} to {1}"
 msgstr "განახლებული დამატებები {0}-დან {1}-მდე"
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:225
+#: static/js/impala/stats/csv_keys.js:225 static/js/zamboni/stats-all.js:15506 static/js/zamboni/stats-min.js:5
 msgid "Reviews Written, last {0} days"
 msgstr "გაკეთებული მიმოხილვები, ბოლო {0} დღეში"
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:227
+#: static/js/impala/stats/csv_keys.js:227 static/js/zamboni/stats-all.js:15508 static/js/zamboni/stats-min.js:5
 msgid "Reviews Written from {0} to {1}"
 msgstr "გაკეთებული მიმოხილვები {0}-დან {1}-მდე"
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:231
+#: static/js/impala/stats/csv_keys.js:231 static/js/zamboni/stats-all.js:15512 static/js/zamboni/stats-min.js:5
 msgid "User Signups, last {0} days"
 msgstr "დარეგისტრებული მომხმარებლები, ბოლო {0} დღეში"
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:233
+#: static/js/impala/stats/csv_keys.js:233 static/js/zamboni/stats-all.js:15514 static/js/zamboni/stats-min.js:5
 msgid "User Signups from {0} to {1}"
 msgstr "დარეგისტრებული მომხმარებლები {0}-დან {1}-მდე"
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:237
+#: static/js/impala/stats/csv_keys.js:237 static/js/zamboni/stats-all.js:15518 static/js/zamboni/stats-min.js:5
 msgid "Collections Created, last {0} days"
 msgstr "შექმნილი კრებულები, ბოლო {0} დღეში"
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:239
+#: static/js/impala/stats/csv_keys.js:239 static/js/zamboni/stats-all.js:15520 static/js/zamboni/stats-min.js:5
 msgid "Collections Created from {0} to {1}"
 msgstr "შექმნილი კრებულები {0}-დან {1}-მდე"
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:243
+#: static/js/impala/stats/csv_keys.js:243 static/js/zamboni/stats-all.js:15524 static/js/zamboni/stats-min.js:5
 msgid "Subscribers, last {0} days"
 msgstr "გამომწერები, ბოლო {0} დღეში"
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:245
+#: static/js/impala/stats/csv_keys.js:245 static/js/zamboni/stats-all.js:15526 static/js/zamboni/stats-min.js:5
 msgid "Subscribers from {0} to {1}"
 msgstr "გამომწერები {0}-დან {1}-მდე"
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:249
+#: static/js/impala/stats/csv_keys.js:249 static/js/zamboni/stats-all.js:15530 static/js/zamboni/stats-min.js:5
 msgid "Ratings, last {0} days"
 msgstr "შეფასებები, ბოლო {0} დღეში"
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:251
+#: static/js/impala/stats/csv_keys.js:251 static/js/zamboni/stats-all.js:15532 static/js/zamboni/stats-min.js:5
 msgid "Ratings from {0} to {1}"
 msgstr "შეფასებები {0}-დან {1}-მდე"
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:255
+#: static/js/impala/stats/csv_keys.js:255 static/js/zamboni/stats-all.js:15536 static/js/zamboni/stats-min.js:5
 msgid "Sales, last {0} days"
 msgstr "გაყიდვები, ბოლო {0} დღეში"
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:257
+#: static/js/impala/stats/csv_keys.js:257 static/js/zamboni/stats-all.js:15538 static/js/zamboni/stats-min.js:5
 msgid "Sales from {0} to {1}"
 msgstr "გაყიდვები {0}-დან {1}-მდე"
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:261
+#: static/js/impala/stats/csv_keys.js:261 static/js/zamboni/stats-all.js:15542 static/js/zamboni/stats-min.js:5
 msgid "Installs, last {0} days"
 msgstr "დაყენების რაოდ. ბოლო {0} დღეში"
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:263
+#: static/js/impala/stats/csv_keys.js:263 static/js/zamboni/stats-all.js:15544 static/js/zamboni/stats-min.js:5
 msgid "Installs from {0} to {1}"
 msgstr "დაყენებების რაოდ. {0}-დან {1}-მდე"
 
 #. L10n: {0} and {1} are integers.
-#: static/js/impala/stats/csv_keys.js:269
+#: static/js/impala/stats/csv_keys.js:269 static/js/zamboni/stats-all.js:15550 static/js/zamboni/stats-min.js:5
 msgid "<b>{0}</b> in last {1} days"
 msgstr "<b>{0}</b> ბოლო {1} დღეში"
 
 #. L10n: {0} is an integer and {1} and {2} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:271
-#: static/js/impala/stats/csv_keys.js:277
+#: static/js/impala/stats/csv_keys.js:271 static/js/impala/stats/csv_keys.js:277 static/js/zamboni/stats-all.js:15552 static/js/zamboni/stats-all.js:15558 static/js/zamboni/stats-min.js:5
 msgid "<b>{0}</b> from {1} to {2}"
 msgstr "<b>{0}</b> {1}-დან {2}-მდე"
 
 #. L10n: {0} and {1} are integers.
-#: static/js/impala/stats/csv_keys.js:275
+#: static/js/impala/stats/csv_keys.js:275 static/js/zamboni/stats-all.js:15556 static/js/zamboni/stats-min.js:5
 msgid "<b>{0}</b> average in last {1} days"
 msgstr "საშუალო <b>{0}</b> ბოლო {1} დღეში"
 
-#: static/js/impala/stats/overview.js:19
+#: static/js/impala/stats/overview.js:19 static/js/zamboni/stats-all.js:16469 static/js/zamboni/stats-min.js:5
 msgid "No data available."
 msgstr "მონაცემები არაა ხელმისაწვდომი."
 
-#: static/js/impala/stats/table.js:74
+#: static/js/impala/stats/table.js:74 static/js/zamboni/stats-all.js:17209 static/js/zamboni/stats-min.js:5
 msgid "Date"
 msgstr "თარიღი "
 
-#: static/js/impala/stats/topchart.js:96
+#: static/js/impala/stats/topchart.js:96 static/js/zamboni/stats-all.js:16600 static/js/zamboni/stats-min.js:5
 msgid "Other"
 msgstr "სხვა"
 
-#: static/js/zamboni/admin_validation.js:24 static/js/zamboni/devhub.js:1229
-#: static/js/zamboni/editors.js:295
+#: static/js/zamboni/admin-all.js:180 static/js/zamboni/admin-min.js:1 static/js/zamboni/admin_validation.js:24 static/js/zamboni/devhub-all.js:2408 static/js/zamboni/devhub-min.js:2
+#: static/js/zamboni/devhub.js:1229 static/js/zamboni/editors-all.js:15576 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:295
 msgid "Select an application first"
 msgstr "დასაწყისისთვის აირჩიეთ პროგრამა"
 
-#: static/js/zamboni/admin_validation.js:51
+#: static/js/zamboni/admin-all.js:207 static/js/zamboni/admin-min.js:1 static/js/zamboni/admin_validation.js:51
 msgid "Set {0} add-on to a max version of {1} and email the author."
 msgid_plural "Set {0} add-ons to a max version of {1} and email the authors."
 msgstr[0] ""
-"მიუთითეთ {0} დამატებისთვის {1} ვერსიის უმაღლესი მნიშვნელობა და მიწერეთ "
-"ავტორებს."
+msgstr[1] ""
 
-#: static/js/zamboni/admin_validation.js:54
+#: static/js/zamboni/admin-all.js:210 static/js/zamboni/admin-min.js:1 static/js/zamboni/admin_validation.js:54
 msgid "Email author of {2} add-on which failed validation."
 msgid_plural "Email authors of {2} add-ons which failed validation."
 msgstr[0] ""
-"შეტყობინების მიწერა ავტორისთვის, რომლის {2} დამატებამ ვერ გაიარა შემოწმება."
+msgstr[1] ""
 
-#. L10n: {0} is an app name like Firefox.
-#: static/js/zamboni/buttons.js:66
-msgid "Accept and Install"
-msgstr "მიღება და ინსტალაცია"
-
-#: static/js/zamboni/buttons.js:66
-msgid "Add to {0}"
-msgstr "{0}-ში დამატება"
-
-#: static/js/zamboni/buttons.js:71
-msgid "Download Now"
-msgstr "ჩამოტვირთვა ახლავე"
-
-#: static/js/zamboni/buttons.js:112
-msgid "Add-on has not been updated to support default-to-compatible."
-msgstr "დამატება არ განახლებულა და ვერ იქნება ნაგულისხმევად თავსებადი."
-
-#: static/js/zamboni/buttons.js:117
-msgid "You need to be using Firefox 10.0 or higher."
-msgstr "თქვენ უნდა იყენებდეთ Firefox 10.0-ს ან უფრო მაღალ ვერსიას."
-
-#: static/js/zamboni/buttons.js:129
-msgid ""
-"Mozilla has marked this version as incompatible with your Firefox version."
-msgstr "Mozilla ეს ვერსია თქვენი Firefox-ის ვერსიასთან შეუთავსებლად მონიშნა."
-
-#. L10n: {0} is an platform like Windows or Linux.
-#: static/js/zamboni/buttons.js:210
-msgid "Install for {0} anyway"
-msgstr "{0}-ის დაყენება მიუხედავად ყველაფრისა"
-
-#: static/js/zamboni/buttons.js:210
-msgid "Download for {0} anyway"
-msgstr "{0}-ის ჩამოტვირთვა მიუხედავად ყველაფრისა"
-
-#: static/js/zamboni/buttons.js:267
-msgid "Not available for your platform"
-msgstr "თქვენს პლატოფმრაზე ხელმისაწვდომი არაა"
-
-#. L10n: {0} is an app name, {1} is the app version.
-#: static/js/zamboni/buttons.js:278 static/js/zamboni/buttons.js:315
-msgid "Not available for {0} {1}"
-msgstr "{0} {1}-სთვის არაა ხელმისაწვდომი"
-
-#: static/js/zamboni/buttons.js:341
-msgid "Works with {app} {min} - {max}"
-msgstr "მუშაობს {app} ვერსიებთან: {min} - {max}"
-
-#: static/js/zamboni/buttons.js:343
-msgid "View other versions"
-msgstr "სხვა ვერსიების ნახვა"
-
-#: static/js/zamboni/buttons.js:391
-msgid "Only with Firefox — Get Firefox Now!"
-msgstr "მხოლოდ Firefox-ზე — ჩამოტვირთეთ Firefox!"
-
-#: static/js/zamboni/buttons.js:507 static/js/zamboni/mobile/buttons.js:43
-msgid ""
-"Sorry, you need a Mozilla-based browser (such as Firefox) to install a "
-"search plugin."
-msgstr ""
-"ბოდიში, საძიებო მოდულის დასაინტსტალირებლად გესაჭირეობათ Mozilla-ზე "
-"დაფუძნებული ბრაუზერი (მაგალითად Firefox)."
-
-#: static/js/zamboni/collections.js:229
-msgid "Adding to Favorites&hellip;"
-msgstr "ემატება რჩეულებში &hellip;"
-
-#: static/js/zamboni/collections.js:232
-msgid "Removing Favorite&hellip;"
-msgstr "რჩეული იშლება &hellip;"
-
-#: static/js/zamboni/collections.js:235
-msgid "Add to Favorites"
-msgstr "რჩეულებში დამატება"
-
-#: static/js/zamboni/collections.js:238
-msgid "Remove from Favorites"
-msgstr "რჩეულებიდან ამოღება"
-
-#: static/js/zamboni/collections.js:303
-msgid "Pending"
-msgstr "განხილვის პროცესში"
-
-#: static/js/zamboni/collections.js:304
-msgid "Add a comment"
-msgstr "კომენტარის დამატება"
-
-#: static/js/zamboni/collections.js:304
-msgid "Comment"
-msgstr "კომენტარი"
-
-#: static/js/zamboni/collections.js:305
-msgid "Remove this add-on from the collection"
-msgstr "ამ დამატების კრებულიდან ამოღება"
-
-#: static/js/zamboni/collections.js:305 static/js/zamboni/collections.js:334
-msgid "Remove"
-msgstr "ამოღება"
-
-#: static/js/zamboni/collections.js:334
-msgid "Remove this user as a contributor"
-msgstr "ამ მომხმარებლის წვლილის შემტანებიდან ამოღება"
-
-#: static/js/zamboni/collections.js:346
-msgid "An email address is required."
-msgstr "ელფოსტის მისამართი საჭიროა."
-
-#: static/js/zamboni/collections.js:364
-msgid "You cannot add yourself as a contributor."
-msgstr "საკუთარი თავის წვლილის შემტანად დამატება არ შეგიძლიათ."
-
-#: static/js/zamboni/collections.js:366
-msgid "You have already added that user."
-msgstr "ეს მომხმარებელი უკვე დაამატეთ."
-
-#: static/js/zamboni/collections.js:573
-msgid "Add to favorites"
-msgstr "რჩეულებში დამატება"
-
-#: static/js/zamboni/collections.js:577
-msgid "Remove from favorites"
-msgstr "რჩეულებიდან ამოღება"
-
-#: static/js/zamboni/collections.js:604
-msgid "Stop following"
-msgstr "ადევნების შეწყვეტა"
-
-#: static/js/zamboni/devhub.js:110
+#: static/js/zamboni/devhub-all.js:1289 static/js/zamboni/devhub-min.js:1 static/js/zamboni/devhub.js:110
 msgid "Your browser does not support the video tag"
 msgstr "თქვენი ბრაუზერს არ აქვს ვიდეო ნაჭდევების მხარდაჭერა"
 
-#: static/js/zamboni/devhub.js:371
+#: static/js/zamboni/devhub-all.js:1550 static/js/zamboni/devhub-min.js:1 static/js/zamboni/devhub.js:371
 msgid "Changes Saved"
 msgstr "ცვლილებები შენახულია"
 
-#: static/js/zamboni/devhub.js:387
+#: static/js/zamboni/devhub-all.js:1566 static/js/zamboni/devhub-min.js:1 static/js/zamboni/devhub.js:387
 msgid "Enter a new author's email address"
 msgstr "შეიყვანეთ ავტორის ახალი ელ-ფოსტის მისამართი"
 
-#: static/js/zamboni/devhub.js:536
+#: static/js/zamboni/devhub-all.js:1715 static/js/zamboni/devhub-min.js:1 static/js/zamboni/devhub.js:536
 msgid "There was an error uploading your file."
 msgstr "ფაილის ატვირთვისას წარმოიშვა შეცდომა."
 
-#: static/js/zamboni/devhub.js:681
+#: static/js/zamboni/devhub-all.js:1860 static/js/zamboni/devhub-min.js:1 static/js/zamboni/devhub.js:681
 msgid "{files} file"
 msgid_plural "{files} files"
-msgstr[0] "{files} ფაილი"
+msgstr[0] ""
+msgstr[1] ""
 
-#: static/js/zamboni/devhub.js:684
+#: static/js/zamboni/devhub-all.js:1863 static/js/zamboni/devhub-min.js:1 static/js/zamboni/devhub.js:684
 msgid "{reviews} user review"
 msgid_plural "{reviews} user reviews"
-msgstr[0] "{reviews} მიმოხილვა"
+msgstr[0] ""
+msgstr[1] ""
 
-#: static/js/zamboni/devhub.js:796
+#: static/js/zamboni/devhub-all.js:1975 static/js/zamboni/devhub-min.js:2 static/js/zamboni/devhub.js:796
 msgid "Learn more"
 msgstr "შეიტყვეთ მეტი"
 
-#: static/js/zamboni/devhub.js:800
+#: static/js/zamboni/devhub-all.js:1979 static/js/zamboni/devhub-min.js:2 static/js/zamboni/devhub.js:800
 msgid "Example"
 msgstr "მაგალითი"
 
-#: static/js/zamboni/devhub.js:1130
+#: static/js/zamboni/devhub-all.js:2309 static/js/zamboni/devhub-min.js:2 static/js/zamboni/devhub.js:1130
 msgid "Image changes being processed"
 msgstr "სურათის ცვლილებები მუშავდება"
 
-#: static/js/zamboni/devhub.js:1280
+#: static/js/zamboni/devhub-all.js:2459 static/js/zamboni/devhub-min.js:2 static/js/zamboni/devhub.js:1280
 msgid "Must be a valid e-mail address."
 msgstr "ელ-ფოსტის მისამართი უნდა იყოს ნამდვილი"
 
+#: static/js/zamboni/devhub-all.js:2613 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:80
+msgid "All tests passed successfully."
+msgstr ""
+
+#: static/js/zamboni/devhub-all.js:2616 static/js/zamboni/devhub-all.js:3011 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:83 static/js/zamboni/validator.js:478
+msgid "These tests were not run."
+msgstr ""
+
+#: static/js/zamboni/devhub-all.js:2664 static/js/zamboni/devhub-all.js:2677 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:131 static/js/zamboni/validator.js:144
+msgid "Tests"
+msgstr ""
+
+#: static/js/zamboni/devhub-all.js:2779 static/js/zamboni/devhub-all.js:3108 static/js/zamboni/devhub-all.js:3127 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:246
+#: static/js/zamboni/validator.js:575 static/js/zamboni/validator.js:594
+msgid "Error"
+msgstr ""
+
+#: static/js/zamboni/devhub-all.js:2780 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:247
+msgid "Warning"
+msgstr ""
+
+#: static/js/zamboni/devhub-all.js:2794 static/js/zamboni/devhub-min.js:2 static/js/zamboni/files-all.js:5657 static/js/zamboni/files-min.js:3 static/js/zamboni/files.js:411
+#: static/js/zamboni/validator.js:261
+msgid "Ignore this message in future updates"
+msgstr ""
+
+#: static/js/zamboni/devhub-all.js:2817 static/js/zamboni/devhub-min.js:2 static/js/zamboni/files-all.js:5663 static/js/zamboni/files-min.js:3 static/js/zamboni/files.js:417
+#: static/js/zamboni/validator.js:284
+msgid "Severity for automated signing:"
+msgstr ""
+
+#: static/js/zamboni/devhub-all.js:2832 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:299
+msgid "Suggestions for passing automated signing:"
+msgstr ""
+
+#: static/js/zamboni/devhub-all.js:2920 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:387
+msgid "Compatibility Tests"
+msgstr ""
+
+#: static/js/zamboni/devhub-all.js:2999 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:466
+msgid "Add-on failed validation."
+msgstr ""
+
+#: static/js/zamboni/devhub-all.js:3001 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:468
+msgid "Add-on passed validation."
+msgstr ""
+
+#: static/js/zamboni/devhub-all.js:3014 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:481
+msgid "{0} error"
+msgid_plural "{0} errors"
+msgstr[0] ""
+msgstr[1] ""
+
+#: static/js/zamboni/devhub-all.js:3016 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:483
+msgid "{0} warning"
+msgid_plural "{0} warnings"
+msgstr[0] ""
+msgstr[1] ""
+
+#: static/js/zamboni/devhub-all.js:3018 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:485
+msgid "{0} notice"
+msgid_plural "{0} notices"
+msgstr[0] ""
+msgstr[1] ""
+
+#: static/js/zamboni/devhub-all.js:3110 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:577
+msgid "Validation task could not complete or completed with errors"
+msgstr ""
+
+#: static/js/zamboni/devhub-all.js:3128 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:595
+msgid "Internal server error"
+msgstr ""
+
 #: static/js/zamboni/devhub_search.js:8
 msgid "No results found."
-msgstr "შედეგები ვერ მოიძებნა."
+msgstr ""
 
-#: static/js/zamboni/editors.js:121
+#: static/js/zamboni/editors-all.js:15402 static/js/zamboni/editors-min.js:4 static/js/zamboni/editors.js:121
 msgid "{name} was viewing this page first."
-msgstr "{name} პირველმა მოინახულა ეს გვერდი."
+msgstr ""
 
-#: static/js/zamboni/editors.js:171
+#: static/js/zamboni/editors-all.js:15452 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:171
 msgid "Receipt checked by app."
-msgstr "დასტური მიღებულია პროგრამის მიერ."
+msgstr ""
 
-#: static/js/zamboni/editors.js:173
+#: static/js/zamboni/editors-all.js:15454 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:173
 msgid "Receipt was not checked by app."
-msgstr "დასტური არაა მიღებული პროგრამის მიერ."
+msgstr ""
 
-#: static/js/zamboni/editors.js:244
+#: static/js/zamboni/editors-all.js:15525 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:244
 msgid "{name} was viewing this add-on first."
-msgstr "{name} პირველმა იხილა ეს დამატება."
+msgstr ""
 
-#: static/js/zamboni/editors.js:255
+#: static/js/zamboni/editors-all.js:15536 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:255
 msgid "Loading&hellip;"
-msgstr "იტვირთება&hellip;"
+msgstr ""
 
-#: static/js/zamboni/editors.js:260
+#: static/js/zamboni/editors-all.js:15541 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:260
 msgid "Version Notes"
 msgstr "ვერსიის შენიშვნები"
 
-#: static/js/zamboni/editors.js:265
+#: static/js/zamboni/editors-all.js:15546 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:265
 msgid "Notes for Reviewers"
-msgstr "შენიშვნები მიმომხილველთათვის"
-
-#: static/js/zamboni/editors.js:270
-msgid "No version notes found"
-msgstr "შენიშვნები ვერსიის შესახებ არ მოიძებნა"
-
-#: static/js/zamboni/editors.js:330
-msgid "Average Reviews"
-msgstr "განხილვების საშუალო რაოდ."
-
-#: static/js/zamboni/editors.js:386
-msgid "Number of Reviews"
-msgstr "განხილვების რაოდენობა:"
-
-#: static/js/zamboni/editors.js:445
-msgid "Error loading translation"
-msgstr "შეცდომა თარგმანის ჩატვირთვისას"
-
-#: static/js/zamboni/files.js:411 static/js/zamboni/validator.js:261
-msgid "Ignore this message in future updates"
-msgstr "ამ შეტყობინების უგულებელყოფა მომავალ განახლებებში"
-
-#: static/js/zamboni/files.js:417 static/js/zamboni/validator.js:284
-msgid "Severity for automated signing:"
-msgstr "ანგარიშზე ავტომატური შესვლის გამკაცრება:"
-
-#: static/js/zamboni/global.js:410
-msgid "Loading..."
-msgstr "იტვირთება...."
-
-#. L10n: {0} is the number of characters left.
-#: static/js/zamboni/global.js:474
-msgid "<b>{0}</b> character left."
-msgid_plural "<b>{0}</b> characters left."
-msgstr[0] "დარჩენილია <b>{0}</b> სიმბოლო."
-
-#: static/js/zamboni/init.js:28
-msgid ""
-"This feature is temporarily disabled while we perform website maintenance. "
-"Please check back a little later."
 msgstr ""
-"ვებ-საიტზე ტექნიკური მომსახურების გამო ეს ფუნქცია დროებით გამორთულია. "
-"გთხოვთ, შემოიარეთ მოგვიანებით."
 
-#: static/js/zamboni/l10n.js:45
-msgid "Remove this localization"
-msgstr "ამ ლოკალიზაციის წაშლა"
+#: static/js/zamboni/editors-all.js:15551 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:270
+msgid "No version notes found"
+msgstr ""
 
-#: static/js/zamboni/password-strength.js:20
-msgid "Password strength:"
-msgstr "პაროლის სიძლიერე:"
+#: static/js/zamboni/editors-all.js:15611 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:330
+msgid "Average Reviews"
+msgstr ""
 
-#: static/js/zamboni/password-strength.js:26
-msgid "At least {0} character left."
-msgid_plural "At least {0} characters left."
-msgstr[0] "დარჩენილია სულ მცირე {0} სიმბოლო."
+#: static/js/zamboni/editors-all.js:15667 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:386
+msgid "Number of Reviews"
+msgstr ""
 
-#: static/js/zamboni/themes_review.js:176
-msgid "Requested Info"
-msgstr "მოთხოვნილი ინფორმაცია"
+#: static/js/zamboni/editors-all.js:15726 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:445
+msgid "Error loading translation"
+msgstr ""
 
-#: static/js/zamboni/themes_review.js:177
-msgid "Flagged"
-msgstr "დანიშნული"
-
-#: static/js/zamboni/themes_review.js:178
-msgid "Duplicate"
-msgstr "დუბლირება"
-
-#: static/js/zamboni/themes_review.js:179
-msgid "Rejected"
-msgstr "უარყოფილია"
-
-#: static/js/zamboni/themes_review.js:180
-msgid "Approved"
-msgstr "მიღებულია"
-
-#: static/js/zamboni/themes_review.js:424
-msgid "No results found"
-msgstr "შედეგები ვერ მოიძებნა."
-
-#: static/js/zamboni/themes_review_templates.js:31
+#: static/js/zamboni/editors-all.js:15975 static/js/zamboni/editors-min.js:5 static/js/zamboni/themes_review_templates.js:31
 msgid "Theme"
-msgstr "თემა"
+msgstr ""
 
-#: static/js/zamboni/themes_review_templates.js:33
+#: static/js/zamboni/editors-all.js:15977 static/js/zamboni/editors-min.js:5 static/js/zamboni/themes_review_templates.js:33
 msgid "Reviewer"
-msgstr "მიმომხილველი"
+msgstr ""
 
-#: static/js/zamboni/themes_review_templates.js:35
+#: static/js/zamboni/editors-all.js:15979 static/js/zamboni/editors-min.js:5 static/js/zamboni/themes_review_templates.js:35
 msgid "Status"
-msgstr "სტატუსი"
+msgstr ""
 
-#: static/js/zamboni/validator.js:80
-msgid "All tests passed successfully."
-msgstr "ყველა შემოწმება დასრულდა წარმატებით."
+#: static/js/zamboni/editors-all.js:16196 static/js/zamboni/editors-min.js:5 static/js/zamboni/themes_review.js:176
+msgid "Requested Info"
+msgstr ""
 
-#: static/js/zamboni/validator.js:83 static/js/zamboni/validator.js:478
-msgid "These tests were not run."
-msgstr "ეს შემოწმებები არ განხორციელებულა."
+#: static/js/zamboni/editors-all.js:16197 static/js/zamboni/editors-min.js:5 static/js/zamboni/themes_review.js:177
+msgid "Flagged"
+msgstr ""
 
-#: static/js/zamboni/validator.js:131 static/js/zamboni/validator.js:144
-msgid "Tests"
-msgstr "შემოწმება"
+#: static/js/zamboni/editors-all.js:16198 static/js/zamboni/editors-min.js:5 static/js/zamboni/themes_review.js:178
+msgid "Duplicate"
+msgstr ""
 
-#: static/js/zamboni/validator.js:246 static/js/zamboni/validator.js:575
-#: static/js/zamboni/validator.js:594
-msgid "Error"
-msgstr "შეცდომა"
+#: static/js/zamboni/editors-all.js:16199 static/js/zamboni/editors-min.js:5 static/js/zamboni/themes_review.js:179
+msgid "Rejected"
+msgstr ""
 
-#: static/js/zamboni/validator.js:247
-msgid "Warning"
-msgstr "გაფრთხილება"
+#: static/js/zamboni/editors-all.js:16200 static/js/zamboni/editors-min.js:5 static/js/zamboni/themes_review.js:180
+msgid "Approved"
+msgstr ""
 
-#: static/js/zamboni/validator.js:299
-msgid "Suggestions for passing automated signing:"
-msgstr "შემოთავაზებები, ანგარიშზე ავტომატურად შესვლისთვის:"
+#: static/js/zamboni/editors-all.js:16444 static/js/zamboni/editors-min.js:5 static/js/zamboni/themes_review.js:424
+msgid "No results found"
+msgstr ""
 
-#: static/js/zamboni/validator.js:387
-msgid "Compatibility Tests"
-msgstr "შემოწმებები თავსებადობაზე"
-
-#: static/js/zamboni/validator.js:466
-msgid "Add-on failed validation."
-msgstr "დამატებამ შემოწმება ვერ გაიარა."
-
-#: static/js/zamboni/validator.js:468
-msgid "Add-on passed validation."
-msgstr "დამატებამ შემოწმება გაიარა."
-
-#: static/js/zamboni/validator.js:481
-msgid "{0} error"
-msgid_plural "{0} errors"
-msgstr[0] "{0} შეცდომა"
-
-#: static/js/zamboni/validator.js:483
-msgid "{0} warning"
-msgid_plural "{0} warnings"
-msgstr[0] "{0} გაფრთხილება"
-
-#: static/js/zamboni/validator.js:485
-msgid "{0} notice"
-msgid_plural "{0} notices"
-msgstr[0] "{0} შენიშვნა"
-
-#: static/js/zamboni/validator.js:577
-msgid "Validation task could not complete or completed with errors"
-msgstr "შემოწმება დასრულება ვერ მოხერხდა ან დასრულდა ხარვეზებით"
-
-#: static/js/zamboni/validator.js:595
-msgid "Internal server error"
-msgstr "სერვერის შიდა შეცდომა"
-
-#: static/js/zamboni/mobile/buttons.js:52
+#: static/js/zamboni/mobile-all.js:15186 static/js/zamboni/mobile/buttons.js:52
 msgid "Not Updated for {0} {1}"
 msgstr "არაა განახლებული {0} {1}"
 
-#: static/js/zamboni/mobile/buttons.js:53
+#: static/js/zamboni/mobile-all.js:15187 static/js/zamboni/mobile/buttons.js:53
 msgid "Requires Newer Version of {0}"
 msgstr "საჭიროებს {0}-ის უფრო ახალ ვერსიას"
 
-#: static/js/zamboni/mobile/buttons.js:54
+#: static/js/zamboni/mobile-all.js:15188 static/js/zamboni/mobile/buttons.js:54
 msgid "Unreviewed"
 msgstr "განუხილველია"
 
-#: static/js/zamboni/mobile/buttons.js:55
+#: static/js/zamboni/mobile-all.js:15189 static/js/zamboni/mobile/buttons.js:55
 msgid "Experimental <span>(Learn More)</span>"
 msgstr "სადცელი <span>(შეიტყვეთ მეტი)</span>"
 
-#: static/js/zamboni/mobile/buttons.js:56
-#: static/js/zamboni/mobile/buttons.js:57
+#: static/js/zamboni/mobile-all.js:15190 static/js/zamboni/mobile-all.js:15191 static/js/zamboni/mobile/buttons.js:56 static/js/zamboni/mobile/buttons.js:57
 msgid "Not Available for {0}"
 msgstr "{0}-სთვის არაა ხელმისაწვდომი"
 
-#: static/js/zamboni/mobile/buttons.js:58
+#: static/js/zamboni/mobile-all.js:15192 static/js/zamboni/mobile/buttons.js:58
 msgid "Experimental"
 msgstr "საცდელი"
 
-#: static/js/zamboni/mobile/buttons.js:59
+#: static/js/zamboni/mobile-all.js:15193 static/js/zamboni/mobile/buttons.js:59
 msgid "Themes Require Newer Version of {0}"
 msgstr "თემისთვის საჭიროა {0}-ის უფრო ახალი ვერსია"
 
-#: static/js/zamboni/mobile/buttons.js:60
+#: static/js/zamboni/mobile-all.js:15194 static/js/zamboni/mobile/buttons.js:60
 msgid "Themes Require {0}"
 msgstr "თემა საჭიროებს {0}-ს"
 
-#: static/js/zamboni/mobile/buttons.js:105
+#: static/js/zamboni/mobile-all.js:15239 static/js/zamboni/mobile/buttons.js:105
 msgid "Installing..."
 msgstr "ყენდება..."
 
-#: static/js/zamboni/mobile/buttons.js:125
+#: static/js/zamboni/mobile-all.js:15259 static/js/zamboni/mobile/buttons.js:125
 msgid "This add-on has been preliminarily reviewed by Mozilla."
 msgstr "ეს დამატება წინასწარ განხილულია Mozilla-ს მიერ."
 
-#: static/js/zamboni/mobile/buttons.js:250
+#: static/js/zamboni/mobile-all.js:15384 static/js/zamboni/mobile/buttons.js:250
 msgid "Keep it"
 msgstr "დატოვება"
 
-#: static/js/zamboni/mobile/general.js:344
+#: static/js/zamboni/mobile-all.js:16049 static/js/zamboni/mobile-min.js:6 static/js/zamboni/mobile/general.js:344
 msgid "You're trying it on!"
 msgstr "გამოსცადეთ!"
 
-#: static/js/zamboni/mobile/general.js:356
+#: static/js/zamboni/mobile-all.js:16061 static/js/zamboni/mobile-min.js:6 static/js/zamboni/mobile/general.js:356
 msgid "Added to Firefox"
 msgstr "დაემატა Firefox-ს"

--- a/locale/km/LC_MESSAGES/django.po
+++ b/locale/km/LC_MESSAGES/django.po
@@ -3,69 +3,70 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2016-02-24 21:23+0000\n"
+"POT-Creation-Date: 2016-04-18 15:47+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
+"Language: \n"
 "MIME-Version: 1.0\n"
-"Content-Type: text/plain; charset=utf-8\n"
+"Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Generated-By: Babel 2.2.0\n"
 
-#: src/olympia/accounts/views.py:52
+#: src/olympia/accounts/views.py:54
 msgid "Your log in attempt could not be parsed. Please try again."
 msgstr ""
 
-#: src/olympia/accounts/views.py:54
+#: src/olympia/accounts/views.py:56
 msgid "Your Firefox Account could not be found. Please try again."
 msgstr ""
 
-#: src/olympia/accounts/views.py:55
+#: src/olympia/accounts/views.py:57
 msgid "You could not be logged in. Please try again."
 msgstr ""
 
-#: src/olympia/accounts/views.py:57
+#: src/olympia/accounts/views.py:59
 msgid "Your account has already been migrated to Firefox Accounts."
 msgstr ""
 
-#: src/olympia/accounts/views.py:59
+#: src/olympia/accounts/views.py:61
 msgid "Your Firefox Account already exists on this site."
 msgstr ""
 
-#: src/olympia/accounts/views.py:108
+#: src/olympia/accounts/views.py:110
 msgid "Great job!"
 msgstr ""
 
-#: src/olympia/accounts/views.py:109
+#: src/olympia/accounts/views.py:111
 msgid "You can now log in to Add-ons with your Firefox Account."
 msgstr ""
 
-#: src/olympia/accounts/views.py:121
+#: src/olympia/accounts/views.py:123
 msgid "Need help?"
 msgstr ""
 
-#: src/olympia/addons/buttons.py:180
+#: src/olympia/addons/buttons.py:177
 msgid "Download Now"
 msgstr ""
 
-#: src/olympia/addons/buttons.py:182
+#: src/olympia/addons/buttons.py:179
 msgid "Download"
 msgstr ""
 
 #. L10n: please keep &nbsp; in the string so &rarr; does not wrap.
-#: src/olympia/addons/buttons.py:186
+#: src/olympia/addons/buttons.py:183
 msgid "Continue to Download&nbsp;&rarr;"
 msgstr ""
 
-#: src/olympia/addons/buttons.py:202 src/olympia/addons/helpers.py:35 src/olympia/addons/views.py:319 src/olympia/addons/templates/addons/impala/details.html:114
+#: src/olympia/addons/buttons.py:199 src/olympia/addons/helpers.py:35 src/olympia/addons/views.py:333 src/olympia/addons/templates/addons/impala/details.html:111
 #: src/olympia/addons/templates/addons/impala/listing/items.html:17 src/olympia/addons/templates/addons/mobile/home.html:40 src/olympia/amo/templates/amo/side_nav.html:6
-#: src/olympia/amo/templates/amo/side_nav.html:10 src/olympia/amo/templates/amo/site_nav.html:2 src/olympia/amo/templates/amo/site_nav.html:55 src/olympia/bandwagon/views.py:95
-#: src/olympia/browse/views.py:54 src/olympia/browse/views.py:68 src/olympia/browse/views.py:235 src/olympia/browse/templates/browse/impala/category_landing.html:22
+#: src/olympia/amo/templates/amo/side_nav.html:10 src/olympia/amo/templates/amo/site_nav.html:2 src/olympia/amo/templates/amo/site_nav.html:53 src/olympia/bandwagon/views.py:95
+#: src/olympia/browse/views.py:54 src/olympia/browse/views.py:68 src/olympia/browse/views.py:202 src/olympia/browse/templates/browse/impala/category_landing.html:22
 #: src/olympia/browse/templates/browse/personas/mobile/category_landing.html:26
 msgid "Featured"
 msgstr ""
 
-#: src/olympia/addons/buttons.py:221
+#: src/olympia/addons/buttons.py:218
 msgid "Add to {0}"
 msgstr ""
 
@@ -113,39 +114,39 @@ msgid_plural "All tags must be at least {0} characters."
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/olympia/addons/forms.py:234
+#: src/olympia/addons/forms.py:238
 msgid "Categories cannot be changed while your add-on is featured for this application."
 msgstr ""
 
 #. L10n: {0} is the number of categories.
-#: src/olympia/addons/forms.py:238
+#: src/olympia/addons/forms.py:242
 msgid "You can have only {0} category."
 msgid_plural "You can have only {0} categories."
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/olympia/addons/forms.py:246
+#: src/olympia/addons/forms.py:250
 msgid "The miscellaneous category cannot be combined with additional categories."
 msgstr ""
 
-#: src/olympia/addons/forms.py:369
+#: src/olympia/addons/forms.py:374
 #, python-format
 msgid "Before changing your default locale you must have a name, summary, and description in that locale. You are missing %s."
 msgstr ""
 
-#: src/olympia/addons/forms.py:484 src/olympia/addons/forms.py:575
+#: src/olympia/addons/forms.py:455 src/olympia/addons/forms.py:546
 msgid "A license must be selected."
 msgstr ""
 
-#: src/olympia/addons/forms.py:556
+#: src/olympia/addons/forms.py:527
 msgid "Give Your Theme a Name."
 msgstr ""
 
-#: src/olympia/addons/forms.py:562 src/olympia/devhub/templates/devhub/personas/submit.html:53
+#: src/olympia/addons/forms.py:533 src/olympia/devhub/templates/devhub/personas/submit.html:53
 msgid "Describe your Theme."
 msgstr ""
 
-#: src/olympia/addons/forms.py:704
+#: src/olympia/addons/forms.py:675
 msgid "Enter a new author's email address"
 msgstr ""
 
@@ -153,37 +154,37 @@ msgstr ""
 msgid "Not Reviewed"
 msgstr ""
 
-#: src/olympia/addons/models.py:301
+#: src/olympia/addons/models.py:298
 msgid "Users have the option of contributing more or less than this amount."
 msgstr ""
 
-#: src/olympia/addons/models.py:309
-msgid "Users will always be asked in the Add-ons Manager (Firefox 4 and above)"
+#: src/olympia/addons/models.py:306
+msgid "Users will always be asked in the Add-ons Manager (Firefox 4 and above). Only applies to desktop."
 msgstr ""
 
-#: src/olympia/addons/models.py:1804 src/olympia/addons/templates/addons/details_box.html:55 src/olympia/devhub/templates/devhub/index.html:92
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:102
+#: src/olympia/addons/models.py:1802 src/olympia/addons/templates/addons/details_box.html:55 src/olympia/devhub/templates/devhub/index.html:92
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:89
 msgid "Listed"
 msgstr ""
 
-#: src/olympia/addons/views.py:320 src/olympia/browse/templates/browse/personas/mobile/category_landing.html:27
+#: src/olympia/addons/views.py:334 src/olympia/browse/templates/browse/personas/mobile/category_landing.html:27
 msgid "Popular"
 msgstr ""
 
-#: src/olympia/addons/views.py:321 src/olympia/browse/views.py:238 src/olympia/browse/views.py:280 src/olympia/browse/views.py:482
+#: src/olympia/addons/views.py:335 src/olympia/browse/views.py:205 src/olympia/browse/views.py:247 src/olympia/browse/views.py:449
 msgid "Recently Added"
 msgstr ""
 
-#: src/olympia/addons/views.py:322 src/olympia/bandwagon/views.py:99 src/olympia/browse/views.py:60 src/olympia/browse/views.py:71 src/olympia/search/forms.py:16 src/olympia/search/forms.py:91
+#: src/olympia/addons/views.py:336 src/olympia/bandwagon/views.py:99 src/olympia/browse/views.py:60 src/olympia/browse/views.py:71 src/olympia/search/forms.py:16 src/olympia/search/forms.py:91
 msgid "Recently Updated"
 msgstr ""
 
 #. l10n: {0} is the addon name
-#: src/olympia/addons/views.py:520
+#: src/olympia/addons/views.py:534
 msgid "Contribution for {0}"
 msgstr ""
 
-#: src/olympia/addons/views.py:613
+#: src/olympia/addons/views.py:627
 msgid "Abuse reported."
 msgstr ""
 
@@ -250,9 +251,9 @@ msgstr ""
 #: src/olympia/devhub/templates/devhub/addons/ajax_compat_update.html:36 src/olympia/devhub/templates/devhub/addons/profile.html:44 src/olympia/devhub/templates/devhub/addons/edit/admin.html:101
 #: src/olympia/devhub/templates/devhub/addons/edit/basic.html:152 src/olympia/devhub/templates/devhub/addons/edit/details.html:85 src/olympia/devhub/templates/devhub/addons/edit/support.html:67
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:166 src/olympia/devhub/templates/devhub/addons/forms_shared/media.html:149
-#: src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:44 src/olympia/devhub/templates/devhub/versions/add_file_modal.html:78 src/olympia/devhub/templates/devhub/versions/edit.html:139
-#: src/olympia/devhub/templates/devhub/versions/list.html:242 src/olympia/devhub/templates/devhub/versions/list.html:276 src/olympia/devhub/templates/devhub/versions/list.html:317
-#: src/olympia/devhub/templates/devhub/versions/list.html:351 src/olympia/reviews/templates/reviews/edit_review.html:16 src/olympia/translations/templates/translations/trans-menu.html:50
+#: src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:43 src/olympia/devhub/templates/devhub/versions/add_file_modal.html:58 src/olympia/devhub/templates/devhub/versions/edit.html:139
+#: src/olympia/devhub/templates/devhub/versions/list.html:239 src/olympia/devhub/templates/devhub/versions/list.html:281 src/olympia/devhub/templates/devhub/versions/list.html:315
+#: src/olympia/devhub/templates/devhub/versions/list.html:349 src/olympia/reviews/templates/reviews/edit_review.html:16 src/olympia/translations/templates/translations/trans-menu.html:50
 #: src/olympia/translations/templates/translations/trans-menu.html:62
 msgid "or"
 msgstr ""
@@ -363,7 +364,7 @@ msgid "Add-on Information for {0}"
 msgstr ""
 
 #: src/olympia/addons/templates/addons/details_box.html:30 src/olympia/addons/templates/addons/persona_detail_table.html:3 src/olympia/addons/templates/addons/mobile/details.html:63
-#: src/olympia/addons/templates/addons/mobile/persona_detail_table.html:7 src/olympia/browse/views.py:459 src/olympia/devhub/views.py:75
+#: src/olympia/addons/templates/addons/mobile/persona_detail_table.html:7 src/olympia/browse/views.py:426 src/olympia/devhub/views.py:73
 msgid "Updated"
 msgstr ""
 
@@ -382,11 +383,11 @@ msgstr ""
 msgid "Visibility"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/details_box.html:57 src/olympia/devhub/templates/devhub/index.html:94 src/olympia/devhub/templates/devhub/includes/addon_details.html:104
+#: src/olympia/addons/templates/addons/details_box.html:57 src/olympia/devhub/templates/devhub/index.html:94 src/olympia/devhub/templates/devhub/includes/addon_details.html:91
 msgid "Hidden"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/details_box.html:59 src/olympia/devhub/templates/devhub/index.html:96 src/olympia/devhub/templates/devhub/includes/addon_details.html:106
+#: src/olympia/addons/templates/addons/details_box.html:59 src/olympia/devhub/templates/devhub/index.html:96 src/olympia/devhub/templates/devhub/includes/addon_details.html:93
 msgid "Unlisted"
 msgstr ""
 
@@ -394,13 +395,13 @@ msgstr ""
 msgid "Required Add-ons"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/details_box.html:81 src/olympia/addons/templates/addons/persona_detail_table.html:15 src/olympia/browse/views.py:462 src/olympia/devhub/views.py:78
-#: src/olympia/devhub/views.py:85 src/olympia/discovery/templates/discovery/addons/detail.html:57 src/olympia/reviews/forms.py:62 src/olympia/reviews/templates/reviews/add.html:57
+#: src/olympia/addons/templates/addons/details_box.html:81 src/olympia/addons/templates/addons/persona_detail_table.html:15 src/olympia/browse/views.py:429 src/olympia/devhub/views.py:76
+#: src/olympia/devhub/views.py:83 src/olympia/discovery/templates/discovery/addons/detail.html:57 src/olympia/reviews/forms.py:62 src/olympia/reviews/templates/reviews/add.html:57
 #: src/olympia/reviews/templates/reviews/mobile/review_list.html:18
 msgid "Rating"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/details_box.html:85 src/olympia/browse/views.py:461 src/olympia/devhub/views.py:77 src/olympia/devhub/views.py:84
+#: src/olympia/addons/templates/addons/details_box.html:85 src/olympia/browse/views.py:428 src/olympia/devhub/views.py:75 src/olympia/devhub/views.py:82
 #: src/olympia/stats/templates/stats/addon_report_menu.html:8 src/olympia/stats/templates/stats/collection_report_menu.html:18
 msgid "Downloads"
 msgstr ""
@@ -420,7 +421,7 @@ msgstr ""
 
 #. The Privacy Policy for this add-on.
 #: src/olympia/addons/templates/addons/details_box.html:121 src/olympia/addons/templates/addons/privacy.html:19 src/olympia/addons/templates/addons/privacy.html:23
-#: src/olympia/addons/templates/addons/impala/button.html:43 src/olympia/addons/templates/addons/impala/details.html:307 src/olympia/devhub/templates/devhub/includes/policy_form.html:20
+#: src/olympia/addons/templates/addons/impala/button.html:43 src/olympia/addons/templates/addons/impala/details.html:312 src/olympia/devhub/templates/devhub/includes/policy_form.html:23
 #: src/olympia/templates/mobile/base_addons.html:87
 msgid "Privacy Policy"
 msgstr ""
@@ -445,7 +446,7 @@ msgstr ""
 msgid "Developer Comments"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/details_box.html:199 src/olympia/addons/templates/addons/impala/details.html:259
+#: src/olympia/addons/templates/addons/details_box.html:199 src/olympia/addons/templates/addons/impala/details.html:264
 msgid "Development Channel"
 msgstr ""
 
@@ -465,7 +466,7 @@ msgid ""
 "developer. To stop receiving development updates, reinstall the default version from the link above."
 msgstr ""
 
-#: src/olympia/addons/templates/addons/details_box.html:220 src/olympia/addons/templates/addons/impala/details.html:278
+#: src/olympia/addons/templates/addons/details_box.html:220 src/olympia/addons/templates/addons/impala/details.html:283
 msgid "Version {0}:"
 msgstr ""
 
@@ -484,7 +485,7 @@ msgid "End-User License Agreement for {0}"
 msgstr ""
 
 #: src/olympia/addons/templates/addons/eula.html:17 src/olympia/addons/templates/addons/eula.html:21 src/olympia/addons/templates/addons/impala/button.html:48
-#: src/olympia/addons/templates/addons/impala/details.html:316 src/olympia/devhub/templates/devhub/includes/policy_form.html:3 src/olympia/discovery/templates/discovery/addons/eula.html:11
+#: src/olympia/addons/templates/addons/impala/details.html:321 src/olympia/devhub/templates/devhub/includes/policy_form.html:3 src/olympia/discovery/templates/discovery/addons/eula.html:11
 msgid "End-User License Agreement"
 msgstr ""
 
@@ -501,7 +502,7 @@ msgstr ""
 msgid "Add-ons for {0}"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/home.html:10 src/olympia/addons/templates/addons/home.html:51 src/olympia/browse/templates/browse/impala/base_listing.html:11
+#: src/olympia/addons/templates/addons/home.html:10 src/olympia/addons/templates/addons/home.html:53 src/olympia/browse/templates/browse/impala/base_listing.html:11
 msgid "Featured Extensions"
 msgstr ""
 
@@ -509,29 +510,29 @@ msgstr ""
 msgid "Popular Extensions"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/home.html:42 src/olympia/amo/templates/amo/side_nav.html:3 src/olympia/amo/templates/amo/side_nav.html:11 src/olympia/amo/templates/amo/site_nav.html:3
-#: src/olympia/amo/templates/amo/site_nav.html:25 src/olympia/browse/views.py:236 src/olympia/browse/views.py:281 src/olympia/browse/views.py:481
+#: src/olympia/addons/templates/addons/home.html:44 src/olympia/amo/templates/amo/side_nav.html:3 src/olympia/amo/templates/amo/side_nav.html:11 src/olympia/amo/templates/amo/site_nav.html:3
+#: src/olympia/amo/templates/amo/site_nav.html:25 src/olympia/browse/views.py:203 src/olympia/browse/views.py:248 src/olympia/browse/views.py:448
 msgid "Most Popular"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/home.html:43
+#: src/olympia/addons/templates/addons/home.html:45
 msgid "All »"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/home.html:52 src/olympia/addons/templates/addons/home.html:61 src/olympia/addons/templates/addons/home.html:70 src/olympia/addons/templates/addons/home.html:78
+#: src/olympia/addons/templates/addons/home.html:54 src/olympia/addons/templates/addons/home.html:63 src/olympia/addons/templates/addons/home.html:72 src/olympia/addons/templates/addons/home.html:80
 #: src/olympia/browse/templates/browse/impala/category_landing.html:36
 msgid "See all »"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/home.html:60
+#: src/olympia/addons/templates/addons/home.html:62
 msgid "Up &amp; Coming Extensions"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/home.html:69 src/olympia/browse/templates/browse/personas/category_landing.html:61 src/olympia/discovery/templates/discovery/pane.html:74
+#: src/olympia/addons/templates/addons/home.html:71 src/olympia/browse/templates/browse/personas/category_landing.html:61 src/olympia/discovery/templates/discovery/pane.html:74
 msgid "Featured Themes"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/home.html:77 src/olympia/bandwagon/templates/bandwagon/impala/collection_listing.html:5
+#: src/olympia/addons/templates/addons/home.html:79 src/olympia/bandwagon/templates/bandwagon/impala/collection_listing.html:5
 msgid "Featured Collections"
 msgstr ""
 
@@ -549,7 +550,7 @@ msgid "Updated {0}"
 msgstr ""
 
 #. {0} is a date.
-#: src/olympia/addons/templates/addons/macros.html:10 src/olympia/addons/templates/addons/macros.html:69 src/olympia/addons/templates/addons/persona_preview.html:21
+#: src/olympia/addons/templates/addons/macros.html:10 src/olympia/addons/templates/addons/macros.html:69 src/olympia/addons/templates/addons/persona_preview.html:22
 #: src/olympia/addons/templates/addons/listing/items_mobile.html:44 src/olympia/addons/templates/addons/listing/macros.html:39
 #: src/olympia/bandwagon/templates/bandwagon/collection_listing_items.html:37 src/olympia/bandwagon/templates/bandwagon/impala/collection_listing_items.html:37
 msgid "Added {0}"
@@ -570,15 +571,14 @@ msgstr[0] ""
 msgstr[1] ""
 
 #. {0} is the number of downloads.
-#: src/olympia/addons/templates/addons/macros.html:53 src/olympia/addons/templates/addons/impala/details.html:61
+#: src/olympia/addons/templates/addons/macros.html:53 src/olympia/addons/templates/addons/impala/details.html:59
 msgid "{0} weekly download"
 msgid_plural "{0} weekly downloads"
 msgstr[0] ""
 msgstr[1] ""
 
 #. {0} is the number of users.
-#: src/olympia/addons/templates/addons/macros.html:61 src/olympia/addons/templates/addons/impala/details.html:54 src/olympia/compat/templates/compat/index.html:71
-#: src/olympia/zadmin/templates/zadmin/compat.html:67
+#: src/olympia/addons/templates/addons/macros.html:61 src/olympia/addons/templates/addons/impala/details.html:52 src/olympia/zadmin/templates/zadmin/compat.html:67
 msgid "{0} user"
 msgid_plural "{0} users"
 msgstr[0] ""
@@ -596,7 +596,7 @@ msgstr ""
 msgid "Return to the addon."
 msgstr ""
 
-#: src/olympia/addons/templates/addons/persona_detail.html:17 src/olympia/addons/templates/addons/impala/details.html:106 src/olympia/addons/templates/addons/mobile/details.html:23
+#: src/olympia/addons/templates/addons/persona_detail.html:17 src/olympia/addons/templates/addons/impala/details.html:103 src/olympia/addons/templates/addons/mobile/details.html:23
 #: src/olympia/addons/templates/addons/mobile/persona_detail.html:21 src/olympia/discovery/templates/discovery/addons/base.html:27 src/olympia/editors/templates/editors/review.html:31
 msgid "by"
 msgstr ""
@@ -640,34 +640,35 @@ msgstr ""
 msgid "License"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/persona_preview.html:12 src/olympia/constants/base.py:48
+#: src/olympia/addons/templates/addons/persona_preview.html:13 src/olympia/constants/base.py:48
 msgid "Awaiting Review"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/persona_preview.html:14 src/olympia/amo/log.py:180 src/olympia/constants/base.py:42 src/olympia/editors/helpers.py:62
+#: src/olympia/addons/templates/addons/persona_preview.html:15 src/olympia/amo/log.py:180 src/olympia/constants/base.py:42 src/olympia/editors/helpers.py:62
 msgid "Rejected"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/persona_preview.html:16 src/olympia/amo/log.py:159
+#: src/olympia/addons/templates/addons/persona_preview.html:17 src/olympia/amo/log.py:159
 msgid "Approved"
 msgstr ""
 
 #. {0} is the number of users.
-#: src/olympia/addons/templates/addons/persona_preview.html:26 src/olympia/addons/templates/addons/listing/items_mobile.html:36 src/olympia/addons/templates/addons/listing/macros.html:31
+#: src/olympia/addons/templates/addons/persona_preview.html:27 src/olympia/addons/templates/addons/listing/items_mobile.html:36 src/olympia/addons/templates/addons/listing/macros.html:31
 msgid "<strong>{0}</strong> user"
 msgid_plural "<strong>{0}</strong> users"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/olympia/addons/templates/addons/persona_preview.html:40
+#: src/olympia/addons/templates/addons/persona_preview.html:41
 msgid "Hover to Preview"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/persona_preview.html:46 src/olympia/addons/templates/addons/persona_preview.html:48 src/olympia/reviews/templates/reviews/add.html:15
+#: src/olympia/addons/templates/addons/persona_preview.html:47 src/olympia/addons/templates/addons/persona_preview.html:49 src/olympia/addons/templates/addons/persona_preview.html:97
+#: src/olympia/reviews/templates/reviews/add.html:15
 msgid "Add"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/persona_preview.html:57 src/olympia/bandwagon/templates/bandwagon/ajax_new.html:16 src/olympia/bandwagon/templates/bandwagon/edit.html:19
+#: src/olympia/addons/templates/addons/persona_preview.html:58 src/olympia/bandwagon/templates/bandwagon/ajax_new.html:16 src/olympia/bandwagon/templates/bandwagon/edit.html:19
 #: src/olympia/bandwagon/templates/bandwagon/includes/addedit.html:19 src/olympia/devhub/templates/devhub/addons/edit/admin.html:13 src/olympia/devhub/templates/devhub/addons/edit/basic.html:10
 #: src/olympia/devhub/templates/devhub/addons/edit/details.html:8 src/olympia/devhub/templates/devhub/addons/edit/media.html:6 src/olympia/devhub/templates/devhub/addons/edit/support.html:8
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:9 src/olympia/devhub/templates/devhub/addons/submit/describe.html:29 src/olympia/editors/templates/editors/review.html:257
@@ -676,21 +677,21 @@ msgstr ""
 
 #. For datetime formatting, see the table on
 #. http://docs.python.org/library/datetime.html#strftime-and-strptime-behavior
-#: src/olympia/addons/templates/addons/persona_preview.html:66
+#: src/olympia/addons/templates/addons/persona_preview.html:67
 #, python-format
 msgid "%%Y-%%m-%%d"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/persona_preview.html:67
+#: src/olympia/addons/templates/addons/persona_preview.html:68
 msgid "by {0} on {1}"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/persona_preview.html:75 src/olympia/reviews/helpers.py:17 src/olympia/reviews/templates/reviews/review_list.html:63
+#: src/olympia/addons/templates/addons/persona_preview.html:76 src/olympia/reviews/helpers.py:17 src/olympia/reviews/templates/reviews/review_list.html:63
 #: src/olympia/reviews/templates/reviews/reviews_link.html:21 src/olympia/reviews/templates/reviews/impala/reviews_link.html:16
 msgid "Not yet rated"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/persona_preview.html:78
+#: src/olympia/addons/templates/addons/persona_preview.html:79
 msgid "<b>{0}</b> users"
 msgstr ""
 
@@ -703,7 +704,7 @@ msgid "Learn more about Firefox"
 msgstr ""
 
 #: src/olympia/addons/templates/addons/popups.html:22
-msgid "or <b><a class=\"installer\" href=\"{url}\">download anyway</a></b>"
+msgid "or <b><a class=\"button installer\" href=\"{url}\">download anyway</a></b>"
 msgstr ""
 
 #: src/olympia/addons/templates/addons/popups.html:26
@@ -802,7 +803,7 @@ msgid ""
 msgstr ""
 
 #: src/olympia/addons/templates/addons/report_abuse.html:6 src/olympia/addons/templates/addons/report_abuse_full.html:10 src/olympia/addons/templates/addons/impala/details-more.html:23
-#: src/olympia/addons/templates/addons/impala/details.html:328
+#: src/olympia/addons/templates/addons/impala/details.html:333
 msgid "Report Abuse"
 msgstr ""
 
@@ -821,9 +822,9 @@ msgstr ""
 #: src/olympia/devhub/templates/devhub/addons/ajax_compat_update.html:36 src/olympia/devhub/templates/devhub/addons/profile.html:44 src/olympia/devhub/templates/devhub/addons/edit/admin.html:104
 #: src/olympia/devhub/templates/devhub/addons/edit/basic.html:155 src/olympia/devhub/templates/devhub/addons/edit/details.html:88 src/olympia/devhub/templates/devhub/addons/edit/support.html:70
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:169 src/olympia/devhub/templates/devhub/addons/forms_shared/media.html:152
-#: src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:44 src/olympia/devhub/templates/devhub/personas/edit.html:222 src/olympia/devhub/templates/devhub/versions/add_file_modal.html:79
-#: src/olympia/devhub/templates/devhub/versions/edit.html:140 src/olympia/devhub/templates/devhub/versions/list.html:208 src/olympia/devhub/templates/devhub/versions/list.html:242
-#: src/olympia/devhub/templates/devhub/versions/list.html:276 src/olympia/devhub/templates/devhub/versions/list.html:317 src/olympia/reviews/templates/reviews/edit_review.html:16
+#: src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:43 src/olympia/devhub/templates/devhub/personas/edit.html:222 src/olympia/devhub/templates/devhub/versions/add_file_modal.html:59
+#: src/olympia/devhub/templates/devhub/versions/edit.html:140 src/olympia/devhub/templates/devhub/versions/list.html:208 src/olympia/devhub/templates/devhub/versions/list.html:239
+#: src/olympia/devhub/templates/devhub/versions/list.html:281 src/olympia/devhub/templates/devhub/versions/list.html:315 src/olympia/reviews/templates/reviews/edit_review.html:16
 #: src/olympia/translations/templates/translations/trans-menu.html:50 src/olympia/translations/templates/translations/trans-menu.html:62 src/olympia/zadmin/templates/zadmin/validation.html:105
 msgid "Cancel"
 msgstr ""
@@ -868,7 +869,7 @@ msgstr ""
 msgid "Review Guidelines"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/review_list_box.html:5 src/olympia/addons/templates/addons/impala/details-more.html:27 src/olympia/editors/helpers.py:921
+#: src/olympia/addons/templates/addons/review_list_box.html:5 src/olympia/addons/templates/addons/impala/details-more.html:27 src/olympia/editors/helpers.py:1001
 #: src/olympia/reviews/templates/reviews/add.html:14 src/olympia/reviews/templates/reviews/reply.html:14 src/olympia/reviews/templates/reviews/review_list.html:19
 #: src/olympia/reviews/templates/reviews/mobile/review_list.html:26
 msgid "Reviews"
@@ -959,119 +960,119 @@ msgid_plural "Other add-ons by these authors"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/olympia/addons/templates/addons/impala/details.html:41
+#: src/olympia/addons/templates/addons/impala/details.html:39
 #, python-format
 msgid "<span itemprop=\"ratingCount\">%(num)s</span> user review"
 msgid_plural "<span itemprop=\"ratingCount\">%(num)s</span> user reviews"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/olympia/addons/templates/addons/impala/details.html:69
+#: src/olympia/addons/templates/addons/impala/details.html:66
 msgid "View statistics"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/impala/details.html:84
+#: src/olympia/addons/templates/addons/impala/details.html:81
 msgid "Manage"
 msgstr ""
 
 #. {0} is an add-on name.
-#: src/olympia/addons/templates/addons/impala/details.html:96
+#: src/olympia/addons/templates/addons/impala/details.html:93
 msgid "Icon of {0}"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/impala/details.html:103 src/olympia/addons/templates/addons/impala/listing/items.html:14
+#: src/olympia/addons/templates/addons/impala/details.html:100 src/olympia/addons/templates/addons/impala/listing/items.html:14
 msgid "No Restart"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/impala/details.html:127
+#: src/olympia/addons/templates/addons/impala/details.html:124
 #, python-format
 msgid "Meet the Developer: <a href=\"%(url)s\">%(name)s</a>"
 msgid_plural "<a href=\"%(url)s\">Meet the Developers</a>"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/olympia/addons/templates/addons/impala/details.html:137
+#: src/olympia/addons/templates/addons/impala/details.html:134
 msgid "Learn why {0} was created and find out what's next for this add-on."
 msgstr ""
 
 #. {0} is an index.
-#: src/olympia/addons/templates/addons/impala/details.html:156
+#: src/olympia/addons/templates/addons/impala/details.html:161
 msgid "Add-on screenshot #{0}"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/impala/details.html:182
+#: src/olympia/addons/templates/addons/impala/details.html:187
 msgid "Add-on home page"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/impala/details.html:185
+#: src/olympia/addons/templates/addons/impala/details.html:190
 msgid "Support site"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/impala/details.html:189
+#: src/olympia/addons/templates/addons/impala/details.html:194
 msgid "Support E-mail"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/impala/details.html:194 src/olympia/devhub/models.py:378 src/olympia/devhub/templates/devhub/versions/list.html:12
+#: src/olympia/addons/templates/addons/impala/details.html:199 src/olympia/devhub/models.py:378 src/olympia/devhub/templates/devhub/versions/list.html:12
 #: src/olympia/versions/templates/versions/version.html:6 src/olympia/versions/templates/versions/mobile/version.html:6
 msgid "Version {0}"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/impala/details.html:194
+#: src/olympia/addons/templates/addons/impala/details.html:199
 msgid "Info"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/impala/details.html:195 src/olympia/devhub/templates/devhub/includes/addon_details.html:129
+#: src/olympia/addons/templates/addons/impala/details.html:200 src/olympia/devhub/templates/devhub/includes/addon_details.html:116
 msgid "Last Updated:"
-msgstr ""
-
-#: src/olympia/addons/templates/addons/impala/details.html:200
-#, python-format
-msgid "Released under <a target=\"_blank\" href=\"%(url)s\">%(name)s</a>"
-msgstr ""
-
-#: src/olympia/addons/templates/addons/impala/details.html:201 src/olympia/addons/templates/addons/impala/details.html:206 src/olympia/amo/helpers.py:398 src/olympia/devhub/forms.py:142
-#: src/olympia/devhub/forms.py:173 src/olympia/versions/templates/versions/version.html:40 src/olympia/versions/templates/versions/version.html:45
-msgid "Custom License"
 msgstr ""
 
 #: src/olympia/addons/templates/addons/impala/details.html:205
 #, python-format
+msgid "Released under <a target=\"_blank\" href=\"%(url)s\">%(name)s</a>"
+msgstr ""
+
+#: src/olympia/addons/templates/addons/impala/details.html:206 src/olympia/addons/templates/addons/impala/details.html:211 src/olympia/amo/helpers.py:398 src/olympia/devhub/forms.py:142
+#: src/olympia/devhub/forms.py:173 src/olympia/versions/templates/versions/version.html:40 src/olympia/versions/templates/versions/version.html:45
+msgid "Custom License"
+msgstr ""
+
+#: src/olympia/addons/templates/addons/impala/details.html:210
+#, python-format
 msgid "Released under <a href=\"%(url)s\">%(name)s</a>"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/impala/details.html:217
+#: src/olympia/addons/templates/addons/impala/details.html:222
 msgid "About this Add-on"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/impala/details.html:233
+#: src/olympia/addons/templates/addons/impala/details.html:238
 msgid "Developer’s Comments"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/impala/details.html:243
+#: src/olympia/addons/templates/addons/impala/details.html:248
 msgid "Version Information"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/impala/details.html:250
+#: src/olympia/addons/templates/addons/impala/details.html:255
 msgid "See complete version history"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/impala/details.html:262
+#: src/olympia/addons/templates/addons/impala/details.html:267
 msgid ""
 "The Development Channel lets you test an experimental new version of this add-on before it's released to the general public. Once you install the development version, you will continue to get "
 "updates from this channel. To stop receiving development updates, reinstall the default version from the link above."
 msgstr ""
 
-#: src/olympia/addons/templates/addons/impala/details.html:272
+#: src/olympia/addons/templates/addons/impala/details.html:277
 msgid "<strong>Caution:</strong> Development versions of this add-on have not been reviewed by Mozilla."
 msgstr ""
 
-#: src/olympia/addons/templates/addons/impala/details.html:287
+#: src/olympia/addons/templates/addons/impala/details.html:292
 msgid "See complete development channel history"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/impala/details.html:306 src/olympia/addons/templates/addons/impala/details.html:315 src/olympia/addons/templates/addons/impala/details.html:327
+#: src/olympia/addons/templates/addons/impala/details.html:311 src/olympia/addons/templates/addons/impala/details.html:320 src/olympia/addons/templates/addons/impala/details.html:332
 #: src/olympia/addons/templates/addons/impala/review_add_box.html:4 src/olympia/stats/templates/stats/popup.html:2 src/olympia/stats/templates/stats/popup.html:8
-#: src/olympia/stats/templates/stats/stats.html:202 src/olympia/users/templates/users/profile.html:119
+#: src/olympia/stats/templates/stats/stats.html:204 src/olympia/users/templates/users/profile.html:119
 msgid "close"
 msgstr ""
 
@@ -1127,15 +1128,11 @@ msgstr ""
 msgid "Source Code License"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/impala/persona_grid.html:16 src/olympia/addons/templates/addons/impala/toplist.html:6
-msgid "{0} users"
-msgstr ""
-
 #: src/olympia/addons/templates/addons/impala/review_list_box.html:19 src/olympia/reviews/templates/reviews/review.html:40
 msgid "permalink"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/impala/review_list_box.html:23 src/olympia/editors/templates/editors/queue.html:98 src/olympia/reviews/templates/reviews/review.html:44
+#: src/olympia/addons/templates/addons/impala/review_list_box.html:23 src/olympia/editors/templates/editors/queue.html:104 src/olympia/reviews/templates/reviews/review.html:44
 msgid "translate"
 msgstr ""
 
@@ -1154,6 +1151,10 @@ msgstr ""
 msgid "Be the first!"
 msgstr ""
 
+#: src/olympia/addons/templates/addons/impala/toplist.html:6
+msgid "{0} users"
+msgstr ""
+
 #: src/olympia/addons/templates/addons/impala/listing/sorter.html:14 src/olympia/devhub/templates/devhub/addons/listing/item_actions.html:49
 msgid "More"
 msgstr ""
@@ -1166,7 +1167,7 @@ msgstr ""
 msgid "My Add-ons"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/includes/dashboard_tabs.html:6 src/olympia/amo/context_processors.py:51
+#: src/olympia/addons/templates/addons/includes/dashboard_tabs.html:6 src/olympia/amo/context_processors.py:50
 msgid "My Themes"
 msgstr ""
 
@@ -1221,7 +1222,7 @@ msgstr ""
 msgid "Weekly Downloads"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/mobile/details.html:99 src/olympia/compat/templates/compat/reporter_detail.html:46 src/olympia/devhub/forms.py:787
+#: src/olympia/addons/templates/addons/mobile/details.html:99 src/olympia/compat/templates/compat/reporter_detail.html:46 src/olympia/devhub/forms.py:788
 #: src/olympia/devhub/templates/devhub/versions/list.html:163
 msgid "Version"
 msgstr ""
@@ -1305,7 +1306,7 @@ msgstr ""
 #: src/olympia/browse/templates/browse/personas/category_landing.html:21 src/olympia/browse/templates/browse/personas/category_landing.html:23
 #: src/olympia/browse/templates/browse/personas/category_landing.html:38 src/olympia/browse/templates/browse/personas/grid.html:7 src/olympia/browse/templates/browse/personas/grid.html:11
 #: src/olympia/browse/templates/browse/personas/mobile/base.html:7 src/olympia/browse/templates/browse/personas/mobile/category_landing.html:19 src/olympia/constants/base.py:180
-#: src/olympia/devhub/templates/devhub/personas/submit.html:13 src/olympia/editors/helpers.py:105 src/olympia/editors/templates/editors/base.html:26
+#: src/olympia/devhub/templates/devhub/personas/submit.html:13 src/olympia/editors/helpers.py:107 src/olympia/editors/templates/editors/base.html:26
 #: src/olympia/editors/templates/editors/performance.html:73 src/olympia/search/templates/search/personas.html:39 src/olympia/templates/menu_links.html:9
 msgid "Themes"
 msgstr ""
@@ -1326,7 +1327,7 @@ msgstr ""
 msgid "Highest Rated"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/mobile/home.html:74 src/olympia/amo/templates/amo/side_nav.html:5 src/olympia/amo/templates/amo/site_nav.html:27 src/olympia/amo/templates/amo/site_nav.html:57
+#: src/olympia/addons/templates/addons/mobile/home.html:74 src/olympia/amo/templates/amo/side_nav.html:5 src/olympia/amo/templates/amo/site_nav.html:27 src/olympia/amo/templates/amo/site_nav.html:55
 #: src/olympia/bandwagon/views.py:97 src/olympia/browse/views.py:57 src/olympia/browse/views.py:67 src/olympia/browse/templates/browse/personas/mobile/category_landing.html:65
 #: src/olympia/search/forms.py:15 src/olympia/search/forms.py:87
 msgid "Newest"
@@ -1340,90 +1341,90 @@ msgstr ""
 msgid "Theme Info &raquo;"
 msgstr ""
 
-#: src/olympia/amo/context_processors.py:39 src/olympia/devhub/templates/devhub/nav.html:43
+#: src/olympia/amo/context_processors.py:37 src/olympia/devhub/templates/devhub/nav.html:43
 msgid "Tools"
 msgstr ""
 
-#: src/olympia/amo/context_processors.py:48 src/olympia/discovery/templates/discovery/pane_account.html:8 src/olympia/users/templates/users/includes/navigation.html:2
+#: src/olympia/amo/context_processors.py:47 src/olympia/discovery/templates/discovery/pane_account.html:8 src/olympia/users/templates/users/includes/navigation.html:2
 msgid "My Profile"
 msgstr ""
 
-#: src/olympia/amo/context_processors.py:54 src/olympia/users/templates/users/edit.html:5 src/olympia/users/templates/users/includes/navigation.html:3
+#: src/olympia/amo/context_processors.py:53 src/olympia/users/templates/users/edit.html:5 src/olympia/users/templates/users/includes/navigation.html:3
 msgid "Account Settings"
 msgstr ""
 
-#: src/olympia/amo/context_processors.py:57 src/olympia/discovery/templates/discovery/pane_account.html:11 src/olympia/users/templates/users/profile.html:83
+#: src/olympia/amo/context_processors.py:56 src/olympia/discovery/templates/discovery/pane_account.html:11 src/olympia/users/templates/users/profile.html:83
 #: src/olympia/users/templates/users/includes/navigation.html:4
 msgid "My Collections"
 msgstr ""
 
-#: src/olympia/amo/context_processors.py:62 src/olympia/discovery/templates/discovery/pane_account.html:10 src/olympia/users/templates/users/includes/navigation.html:7
+#: src/olympia/amo/context_processors.py:61 src/olympia/discovery/templates/discovery/pane_account.html:10 src/olympia/users/templates/users/includes/navigation.html:7
 msgid "My Favorites"
 msgstr ""
 
-#: src/olympia/amo/context_processors.py:67 src/olympia/discovery/templates/discovery/pane_account.html:13 src/olympia/templates/impala/user_login.html:14
+#: src/olympia/amo/context_processors.py:66 src/olympia/discovery/templates/discovery/pane_account.html:13 src/olympia/templates/impala/user_login.html:14
 #: src/olympia/templates/mobile/header_auth.html:5
 msgid "Log out"
 msgstr ""
 
-#: src/olympia/amo/context_processors.py:72 src/olympia/devhub/templates/devhub/addons/dashboard.html:4
+#: src/olympia/amo/context_processors.py:71 src/olympia/devhub/templates/devhub/addons/dashboard.html:4
 msgid "Manage My Submissions"
 msgstr ""
 
-#: src/olympia/amo/context_processors.py:75 src/olympia/devhub/templates/devhub/nav.html:27 src/olympia/devhub/templates/devhub/addons/dashboard.html:25
+#: src/olympia/amo/context_processors.py:74 src/olympia/devhub/templates/devhub/nav.html:27 src/olympia/devhub/templates/devhub/addons/dashboard.html:25
 #: src/olympia/devhub/templates/devhub/addons/submit/base.html:4
 msgid "Submit a New Add-on"
 msgstr ""
 
-#: src/olympia/amo/context_processors.py:77 src/olympia/browse/templates/browse/personas/base.html:50 src/olympia/devhub/templates/devhub/index.html:24
+#: src/olympia/amo/context_processors.py:76 src/olympia/browse/templates/browse/personas/base.html:50 src/olympia/devhub/templates/devhub/index.html:24
 #: src/olympia/devhub/templates/devhub/addons/dashboard.html:29
 msgid "Submit a New Theme"
 msgstr ""
 
-#: src/olympia/amo/context_processors.py:79 src/olympia/amo/templates/amo/site_nav.html:87 src/olympia/devhub/helpers.py:36 src/olympia/devhub/helpers.py:68 src/olympia/devhub/helpers.py:102
+#: src/olympia/amo/context_processors.py:78 src/olympia/amo/templates/amo/site_nav.html:85 src/olympia/devhub/helpers.py:36 src/olympia/devhub/helpers.py:68 src/olympia/devhub/helpers.py:102
 #: src/olympia/templates/footer.html:6 src/olympia/templates/menu_links.html:14
 msgid "Developer Hub"
 msgstr ""
 
-#: src/olympia/amo/context_processors.py:83 src/olympia/devhub/views.py:1792
+#: src/olympia/amo/context_processors.py:81 src/olympia/devhub/views.py:1796
 msgid "Manage API Keys"
 msgstr ""
 
-#: src/olympia/amo/context_processors.py:88 src/olympia/editors/helpers.py:82 src/olympia/editors/helpers.py:102 src/olympia/editors/templates/editors/base.html:10
+#: src/olympia/amo/context_processors.py:86 src/olympia/editors/helpers.py:84 src/olympia/editors/helpers.py:104 src/olympia/editors/templates/editors/base.html:10
 msgid "Editor Tools"
 msgstr ""
 
-#: src/olympia/amo/context_processors.py:92
+#: src/olympia/amo/context_processors.py:90
 msgid "Admin Tools"
 msgstr ""
 
-#: src/olympia/amo/fields.py:15
+#: src/olympia/amo/fields.py:20
 msgid "Incorrect, please try again."
 msgstr ""
 
-#: src/olympia/amo/fields.py:16
+#: src/olympia/amo/fields.py:21
 msgid "Error verifying input, please try again."
 msgstr ""
 
-#: src/olympia/amo/fields.py:32
+#: src/olympia/amo/fields.py:37
 msgid "This must be a valid hex color code, such as #000000."
 msgstr ""
 
-#: src/olympia/amo/fields.py:58
+#: src/olympia/amo/fields.py:63
 msgid "Enter at least one value."
 msgstr ""
 
-#: src/olympia/amo/helpers.py:162 src/olympia/amo/templates/amo/site_nav.html:61 src/olympia/bandwagon/templates/bandwagon/add.html:9
+#: src/olympia/amo/helpers.py:162 src/olympia/amo/templates/amo/site_nav.html:59 src/olympia/bandwagon/templates/bandwagon/add.html:9
 #: src/olympia/bandwagon/templates/bandwagon/collection_detail.html:15 src/olympia/bandwagon/templates/bandwagon/delete.html:9 src/olympia/bandwagon/templates/bandwagon/edit.html:15
 #: src/olympia/bandwagon/templates/bandwagon/user_listing.html:18 src/olympia/bandwagon/templates/bandwagon/user_listing.html:21
 #: src/olympia/bandwagon/templates/bandwagon/impala/collection_listing.html:12 src/olympia/bandwagon/templates/bandwagon/impala/collection_listing.html:20
 #: src/olympia/bandwagon/templates/bandwagon/impala/collection_listing.html:24 src/olympia/bandwagon/templates/bandwagon/impala/collection_sidebar.html:3
 #: src/olympia/bandwagon/templates/bandwagon/includes/collection_sidebar.html:2 src/olympia/bandwagon/templates/bandwagon/mobile/collection_listing.html:3
-#: src/olympia/stats/templates/stats/stats.html:77 src/olympia/templates/menu_links.html:12
+#: src/olympia/stats/templates/stats/stats.html:33 src/olympia/templates/menu_links.html:12
 msgid "Collections"
 msgstr ""
 
-#: src/olympia/amo/helpers.py:171 src/olympia/amo/templates/amo/site_nav.html:85 src/olympia/browse/templates/browse/language_tools.html:3
+#: src/olympia/amo/helpers.py:171 src/olympia/amo/templates/amo/site_nav.html:83 src/olympia/browse/templates/browse/language_tools.html:3
 msgid "Dictionaries & Language Packs"
 msgstr ""
 
@@ -1575,8 +1576,8 @@ msgstr ""
 msgid "Comment on {addon} {version}."
 msgstr ""
 
-#: src/olympia/amo/log.py:236 src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:19 src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:47
-#: src/olympia/editors/helpers.py:511 src/olympia/editors/templates/editors/themes/history_table.html:11
+#: src/olympia/amo/log.py:236 src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:17 src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:45
+#: src/olympia/editors/helpers.py:584 src/olympia/editors/templates/editors/themes/history_table.html:11
 msgid "Comment"
 msgstr ""
 
@@ -1899,7 +1900,7 @@ msgstr ""
 #: src/olympia/amo/templates/amo/mobile/paginator.html:14 src/olympia/amo/templates/amo/mobile/paginator.html:16 src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:51
 #: src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:65 src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:78
 #: src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:91 src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:104
-#: src/olympia/discovery/templates/discovery/pane.html:45 src/olympia/discovery/templates/discovery/addons/detail.html:39 src/olympia/stats/templates/stats/stats.html:167
+#: src/olympia/discovery/templates/discovery/pane.html:45 src/olympia/discovery/templates/discovery/addons/detail.html:39 src/olympia/stats/templates/stats/stats.html:169
 msgid "Next"
 msgstr ""
 
@@ -1931,7 +1932,7 @@ msgid ""
 msgstr ""
 
 #: src/olympia/amo/templates/amo/side_nav.html:4 src/olympia/amo/templates/amo/side_nav.html:12 src/olympia/amo/templates/amo/site_nav.html:4 src/olympia/amo/templates/amo/site_nav.html:26
-#: src/olympia/browse/views.py:56 src/olympia/browse/views.py:66 src/olympia/browse/views.py:237 src/olympia/browse/views.py:282 src/olympia/search/forms.py:86
+#: src/olympia/browse/views.py:56 src/olympia/browse/views.py:66 src/olympia/browse/views.py:204 src/olympia/browse/views.py:249 src/olympia/search/forms.py:86
 msgid "Top Rated"
 msgstr ""
 
@@ -1945,38 +1946,38 @@ msgstr ""
 msgid "Extensions"
 msgstr ""
 
-#: src/olympia/amo/templates/amo/site_nav.html:45
+#: src/olympia/amo/templates/amo/site_nav.html:44
 msgid "Want more customization? Try <b>Complete Themes</b>"
 msgstr ""
 
-#: src/olympia/amo/templates/amo/site_nav.html:56 src/olympia/bandwagon/views.py:96
+#: src/olympia/amo/templates/amo/site_nav.html:54 src/olympia/bandwagon/views.py:96
 msgid "Most Followers"
 msgstr ""
 
-#: src/olympia/amo/templates/amo/site_nav.html:68 src/olympia/bandwagon/templates/bandwagon/impala/collection_sidebar.html:16
+#: src/olympia/amo/templates/amo/site_nav.html:66 src/olympia/bandwagon/templates/bandwagon/impala/collection_sidebar.html:16
 #: src/olympia/bandwagon/templates/bandwagon/includes/collection_sidebar.html:18
 msgid "Collections I've Made"
 msgstr ""
 
-#: src/olympia/amo/templates/amo/site_nav.html:70 src/olympia/bandwagon/templates/bandwagon/user_listing.html:4 src/olympia/bandwagon/templates/bandwagon/impala/collection_sidebar.html:13
+#: src/olympia/amo/templates/amo/site_nav.html:68 src/olympia/bandwagon/templates/bandwagon/user_listing.html:4 src/olympia/bandwagon/templates/bandwagon/impala/collection_sidebar.html:13
 #: src/olympia/bandwagon/templates/bandwagon/includes/collection_sidebar.html:15
 msgid "Collections I'm Following"
 msgstr ""
 
-#: src/olympia/amo/templates/amo/site_nav.html:73 src/olympia/bandwagon/templates/bandwagon/impala/collection_sidebar.html:18
-#: src/olympia/bandwagon/templates/bandwagon/includes/collection_sidebar.html:20 src/olympia/users/models.py:512
+#: src/olympia/amo/templates/amo/site_nav.html:71 src/olympia/bandwagon/templates/bandwagon/impala/collection_sidebar.html:18
+#: src/olympia/bandwagon/templates/bandwagon/includes/collection_sidebar.html:20 src/olympia/users/models.py:521
 msgid "My Favorite Add-ons"
 msgstr ""
 
-#: src/olympia/amo/templates/amo/site_nav.html:78
+#: src/olympia/amo/templates/amo/site_nav.html:76
 msgid "More&hellip;"
 msgstr ""
 
-#: src/olympia/amo/templates/amo/site_nav.html:82
+#: src/olympia/amo/templates/amo/site_nav.html:80
 msgid "Add-ons for Mobile"
 msgstr ""
 
-#: src/olympia/amo/templates/amo/site_nav.html:86 src/olympia/browse/feeds.py:207 src/olympia/browse/templates/browse/search_tools.html:3 src/olympia/constants/base.py:176
+#: src/olympia/amo/templates/amo/site_nav.html:84 src/olympia/browse/feeds.py:207 src/olympia/browse/templates/browse/search_tools.html:3 src/olympia/constants/base.py:176
 #: src/olympia/templates/menu_links.html:10
 msgid "Search Tools"
 msgstr ""
@@ -1992,7 +1993,7 @@ msgid "Jump to first page"
 msgstr ""
 
 #: src/olympia/amo/templates/amo/impala/paginator.html:22 src/olympia/amo/templates/amo/mobile/impala_paginator.html:12 src/olympia/discovery/templates/discovery/pane.html:44
-#: src/olympia/discovery/templates/discovery/addons/detail.html:38 src/olympia/stats/templates/stats/stats.html:164
+#: src/olympia/discovery/templates/discovery/addons/detail.html:38 src/olympia/stats/templates/stats/stats.html:166
 msgid "Previous"
 msgstr ""
 
@@ -2015,30 +2016,49 @@ msgid_plural "Page {n}"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/olympia/amo/templates/services/install.html:38
-#, python-format
-msgid "If you are not prompted to install %(addon_name)s in a moment, please <a href=\"%(addon_xpi)s\">click here</a>."
-msgstr ""
-
-#: src/olympia/amo/tests/test_messages.py:57 src/olympia/amo/tests/test_messages.py:58 src/olympia/reviews/forms.py:25 src/olympia/reviews/forms.py:50 src/olympia/reviews/templates/reviews/add.html:56
+#: src/olympia/amo/tests/test_messages.py:56 src/olympia/amo/tests/test_messages.py:57 src/olympia/reviews/forms.py:25 src/olympia/reviews/forms.py:50 src/olympia/reviews/templates/reviews/add.html:56
 #: src/olympia/reviews/templates/reviews/reply.html:30
 msgid "Title"
 msgstr ""
 
-#: src/olympia/amo/tests/test_messages.py:57 src/olympia/amo/tests/test_messages.py:58
+#: src/olympia/amo/tests/test_messages.py:56 src/olympia/amo/tests/test_messages.py:57
 msgid "Body"
 msgstr ""
 
-#: src/olympia/amo/tests/test_messages.py:59
+#: src/olympia/amo/tests/test_messages.py:58
 msgid "Another Title"
 msgstr ""
 
-#: src/olympia/amo/tests/test_messages.py:59
+#: src/olympia/amo/tests/test_messages.py:58
 msgid "Another Body"
 msgstr ""
 
-#: src/olympia/api/views.py:255
-msgid "Not implemented yet."
+#: src/olympia/api/authentication.py:76
+msgid "Signature has expired."
+msgstr ""
+
+#: src/olympia/api/authentication.py:79
+msgid "Error decoding signature."
+msgstr ""
+
+#: src/olympia/api/authentication.py:82
+msgid "Invalid JWT Token."
+msgstr ""
+
+#: src/olympia/api/authentication.py:130
+msgid "Invalid Authorization header. No credentials provided."
+msgstr ""
+
+#: src/olympia/api/authentication.py:133
+msgid "Invalid Authorization header. Credentials string should not contain spaces."
+msgstr ""
+
+#: src/olympia/api/fields.py:29
+msgid "The field must have a length of at least {num} characters."
+msgstr ""
+
+#: src/olympia/api/fields.py:31
+msgid "The language code {lang_code} is invalid."
 msgstr ""
 
 #: src/olympia/applications/views.py:39 src/olympia/applications/templates/applications/appversions.html:3
@@ -2057,7 +2077,7 @@ msgstr ""
 msgid "Add-ons submitted to Mozilla Add-ons must have a manifest file with at least one of the below applications supported. Only the versions listed below are allowed for these applications."
 msgstr ""
 
-#: src/olympia/applications/templates/applications/appversions.html:25
+#: src/olympia/applications/templates/applications/appversions.html:25 src/olympia/editors/helpers.py:361
 msgid "GUID"
 msgstr ""
 
@@ -2171,8 +2191,8 @@ msgstr ""
 msgid "Remove from favorites"
 msgstr ""
 
-#: src/olympia/bandwagon/views.py:98 src/olympia/bandwagon/views.py:191 src/olympia/browse/views.py:58 src/olympia/browse/views.py:69 src/olympia/browse/views.py:458 src/olympia/devhub/views.py:74
-#: src/olympia/devhub/views.py:82 src/olympia/devhub/templates/devhub/addons/edit/basic.html:20 src/olympia/editors/templates/editors/leaderboard.html:24
+#: src/olympia/bandwagon/views.py:98 src/olympia/bandwagon/views.py:191 src/olympia/browse/views.py:58 src/olympia/browse/views.py:69 src/olympia/browse/views.py:425 src/olympia/devhub/views.py:72
+#: src/olympia/devhub/views.py:80 src/olympia/devhub/templates/devhub/addons/edit/basic.html:20 src/olympia/editors/templates/editors/leaderboard.html:24
 #: src/olympia/editors/templates/editors/themes/queue_list.html:48 src/olympia/search/forms.py:17 src/olympia/search/forms.py:89 src/olympia/users/templates/users/vcard.html:5
 msgid "Name"
 msgstr ""
@@ -2181,7 +2201,7 @@ msgstr ""
 msgid "Recently Popular"
 msgstr ""
 
-#: src/olympia/bandwagon/views.py:189 src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:18
+#: src/olympia/bandwagon/views.py:189 src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:16
 msgid "Added"
 msgstr ""
 
@@ -2195,7 +2215,7 @@ msgstr ""
 
 #: src/olympia/bandwagon/views.py:316
 #, python-format
-msgid "Your new collection is shown below. You can <ahref=\"%(url)s\">edit additional settings</a> if you'dlike."
+msgid "Your new collection is shown below. You can <a href=\"%(url)s\">edit additional settings</a> if you'd like."
 msgstr ""
 
 #: src/olympia/bandwagon/views.py:322
@@ -2323,8 +2343,8 @@ msgid_plural "%(num)s Add-ons in this Collection"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/olympia/bandwagon/templates/bandwagon/collection_detail.html:125 src/olympia/compat/templates/compat/index.html:25 src/olympia/compat/templates/compat/reporter_detail.html:29
-#: src/olympia/files/templates/files/viewer.html:29 src/olympia/templates/amo_footer.html:17 src/olympia/templates/includes/lang_switcher.html:10
+#: src/olympia/bandwagon/templates/bandwagon/collection_detail.html:125 src/olympia/compat/templates/compat/reporter_detail.html:29 src/olympia/files/templates/files/viewer.html:29
+#: src/olympia/templates/amo_footer.html:17 src/olympia/templates/includes/lang_switcher.html:10
 msgid "Go"
 msgstr ""
 
@@ -2491,7 +2511,7 @@ msgid "Remove this user as a contributor"
 msgstr ""
 
 #: src/olympia/bandwagon/templates/bandwagon/edit_contributors.html:18 src/olympia/bandwagon/templates/bandwagon/edit_contributors.html:43
-#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:20 src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:48
+#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:18 src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:46
 #: src/olympia/devhub/templates/devhub/addons/ajax_compat_update.html:19
 msgid "Remove"
 msgstr ""
@@ -2539,7 +2559,7 @@ msgid "<b>Warning:</b> By changing the owner of this collection, you will no lon
 msgstr ""
 
 #: src/olympia/bandwagon/templates/bandwagon/edit_contributors.html:83 src/olympia/devhub/templates/devhub/addons/forms_shared/media.html:157
-#: src/olympia/devhub/templates/devhub/addons/submit/describe.html:69 src/olympia/devhub/templates/devhub/addons/submit/license.html:60 src/olympia/devhub/templates/devhub/addons/submit/upload.html:78
+#: src/olympia/devhub/templates/devhub/addons/submit/describe.html:69 src/olympia/devhub/templates/devhub/addons/submit/license.html:60 src/olympia/devhub/templates/devhub/addons/submit/upload.html:70
 #: src/olympia/devhub/templates/devhub/payments/tier.html:17 src/olympia/editors/templates/editors/themes/themes.html:111 src/olympia/editors/templates/editors/themes/themes.html:128
 #: src/olympia/editors/templates/editors/themes/themes.html:134 src/olympia/editors/templates/editors/themes/themes.html:141 src/olympia/users/templates/users/fxa_migration_prompt_content.html:10
 #: src/olympia/users/templates/users/login_form.html:42 src/olympia/users/templates/users/mobile/login.html:57
@@ -2622,31 +2642,31 @@ msgid "Add-ons in Your Collection"
 msgstr ""
 
 #: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:4
-msgid ""
-"To include an add-on in this collection, enter its name in the box below and hit enter.  You can also use the <strong>Add to Collection</strong> links throughout the site to include add-ons later."
+msgid "To include an add-on in this collection, enter its name in the box below and hit enter."
 msgstr ""
 
-#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:17 src/olympia/constants/base.py:400 src/olympia/devhub/templates/devhub/addons/activity.html:62
+#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:15 src/olympia/constants/base.py:400 src/olympia/devhub/templates/devhub/addons/activity.html:62
+#: src/olympia/editors/helpers.py:273 src/olympia/editors/helpers.py:360
 msgid "Add-on"
 msgstr ""
 
-#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:26
+#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:24
 msgid "Enter the name of the add-on to include"
 msgstr ""
 
-#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:28
+#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:26
 msgid "Add to Collection"
 msgstr ""
 
-#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:45 src/olympia/editors/helpers.py:936 src/olympia/editors/helpers.py:956
+#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:43 src/olympia/editors/helpers.py:1016 src/olympia/editors/helpers.py:1036
 msgid "Pending"
 msgstr ""
 
-#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:47
+#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:45
 msgid "Add a comment"
 msgstr ""
 
-#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:48
+#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:46
 msgid "Remove this add-on from the collection"
 msgstr ""
 
@@ -2753,12 +2773,12 @@ msgstr ""
 msgid "Most Users"
 msgstr ""
 
-#: src/olympia/browse/views.py:61 src/olympia/browse/views.py:72 src/olympia/browse/views.py:279 src/olympia/browse/templates/browse/personas/mobile/category_landing.html:63
+#: src/olympia/browse/views.py:61 src/olympia/browse/views.py:72 src/olympia/browse/views.py:246 src/olympia/browse/templates/browse/personas/mobile/category_landing.html:63
 #: src/olympia/discovery/templates/discovery/pane.html:67 src/olympia/search/forms.py:92
 msgid "Up & Coming"
 msgstr ""
 
-#: src/olympia/browse/views.py:460 src/olympia/devhub/views.py:76 src/olympia/devhub/views.py:83 src/olympia/discovery/templates/discovery/addons/detail.html:66
+#: src/olympia/browse/views.py:427 src/olympia/devhub/views.py:74 src/olympia/devhub/views.py:81 src/olympia/discovery/templates/discovery/addons/detail.html:66
 msgid "Created"
 msgstr ""
 
@@ -2946,8 +2966,8 @@ msgid_plural "See all %(cnt)s extensions in %(name)s &raquo;"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/olympia/browse/templates/browse/mobile/extensions.html:13 src/olympia/compat/templates/compat/index.html:82 src/olympia/devhub/templates/devhub/devhub_search.html:24
-#: src/olympia/devhub/templates/devhub/addons/activity.html:47 src/olympia/search/templates/search/no_results.html:4 src/olympia/search/templates/search/mobile/results.html:36
+#: src/olympia/browse/templates/browse/mobile/extensions.html:13 src/olympia/devhub/templates/devhub/devhub_search.html:24 src/olympia/devhub/templates/devhub/addons/activity.html:47
+#: src/olympia/search/templates/search/no_results.html:4 src/olympia/search/templates/search/mobile/results.html:36
 msgid "No results found."
 msgstr ""
 
@@ -3032,7 +3052,7 @@ msgstr ""
 msgid "All"
 msgstr ""
 
-#: src/olympia/compat/forms.py:22 src/olympia/search/views.py:525
+#: src/olympia/compat/forms.py:22 src/olympia/editors/templates/editors/base.html:69 src/olympia/search/views.py:518
 msgid "All Add-ons"
 msgstr ""
 
@@ -3042,53 +3062,6 @@ msgstr ""
 
 #: src/olympia/compat/forms.py:24
 msgid "Non-binary"
-msgstr ""
-
-#. Review points sources other than add-ons and themes.
-#: src/olympia/compat/views.py:87 src/olympia/constants/base.py:388 src/olympia/devhub/forms.py:162 src/olympia/editors/templates/editors/performance.html:75
-msgid "Other"
-msgstr ""
-
-#: src/olympia/compat/templates/compat/index.html:4
-msgid "Add-on Compatibility Report for {app} {version}"
-msgstr ""
-
-#: src/olympia/compat/templates/compat/index.html:11
-msgid "{app} {version} Compatibility"
-msgstr ""
-
-#: src/olympia/compat/templates/compat/index.html:17
-#, python-format
-msgid "Top 95%% compatible with previous version"
-msgstr ""
-
-#: src/olympia/compat/templates/compat/index.html:18
-#, python-format
-msgid "Top 95%% of all add-ons"
-msgstr ""
-
-#: src/olympia/compat/templates/compat/index.html:19
-msgid "All active add-ons"
-msgstr ""
-
-#: src/olympia/compat/templates/compat/index.html:23 src/olympia/constants/base.py:401
-msgid "App"
-msgstr ""
-
-#: src/olympia/compat/templates/compat/index.html:55
-msgid "Details for add-ons compatible with previous version:"
-msgstr ""
-
-#: src/olympia/compat/templates/compat/index.html:57
-msgid "Show all versions"
-msgstr ""
-
-#: src/olympia/compat/templates/compat/index.html:59
-msgid "Details for add-ons compatible with all versions:"
-msgstr ""
-
-#: src/olympia/compat/templates/compat/index.html:61
-msgid "Show previous version only"
 msgstr ""
 
 #: src/olympia/compat/templates/compat/reporter.html:3
@@ -3142,8 +3115,8 @@ msgstr ""
 msgid "Report Type"
 msgstr ""
 
-#: src/olympia/compat/templates/compat/reporter_detail.html:47 src/olympia/devhub/forms.py:784 src/olympia/devhub/templates/devhub/addons/ajax_compat_update.html:17 src/olympia/editors/forms.py:108
-#: src/olympia/zadmin/forms.py:45
+#: src/olympia/compat/templates/compat/reporter_detail.html:47 src/olympia/devhub/forms.py:785 src/olympia/devhub/templates/devhub/addons/ajax_compat_update.html:17 src/olympia/editors/forms.py:108
+#: src/olympia/editors/forms.py:248 src/olympia/zadmin/forms.py:45
 msgid "Application"
 msgstr ""
 
@@ -3231,7 +3204,8 @@ msgstr ""
 msgid "Preliminarily Reviewed and Awaiting Full Review"
 msgstr ""
 
-#: src/olympia/constants/base.py:33 src/olympia/editors/helpers.py:924 src/olympia/editors/templates/editors/themes/history_table.html:34
+#: src/olympia/constants/base.py:33 src/olympia/editors/forms.py:258 src/olympia/editors/helpers.py:73 src/olympia/editors/helpers.py:1004
+#: src/olympia/editors/templates/editors/themes/history_table.html:34
 msgid "Deleted"
 msgstr ""
 
@@ -3328,6 +3302,11 @@ msgstr ""
 msgid "Ask before users can download this add-on"
 msgstr ""
 
+#. Review points sources other than add-ons and themes.
+#: src/olympia/constants/base.py:388 src/olympia/devhub/forms.py:162 src/olympia/editors/templates/editors/performance.html:75
+msgid "Other"
+msgstr ""
+
 #: src/olympia/constants/base.py:389
 msgid "Exception"
 msgstr ""
@@ -3338,6 +3317,10 @@ msgstr ""
 
 #: src/olympia/constants/base.py:391
 msgid "Change"
+msgstr ""
+
+#: src/olympia/constants/base.py:401
+msgid "App"
 msgstr ""
 
 #: src/olympia/constants/base.py:402
@@ -3488,7 +3471,7 @@ msgstr ""
 msgid "Duplicate"
 msgstr ""
 
-#: src/olympia/constants/editors.py:17 src/olympia/editors/helpers.py:502 src/olympia/editors/templates/editors/themes/queue.html:71 src/olympia/editors/templates/editors/themes/themes.html:94
+#: src/olympia/constants/editors.py:17 src/olympia/editors/helpers.py:575 src/olympia/editors/templates/editors/themes/queue.html:71 src/olympia/editors/templates/editors/themes/themes.html:94
 msgid "Reject"
 msgstr ""
 
@@ -3588,7 +3571,7 @@ msgstr ""
 msgid "Android"
 msgstr ""
 
-#: src/olympia/core/apps.py:19
+#: src/olympia/core/apps.py:21
 msgid "Core"
 msgstr ""
 
@@ -3722,7 +3705,7 @@ msgid "Submit my add-on for manual review."
 msgstr ""
 
 #: src/olympia/devhub/forms.py:537
-msgid "Do not list my add-on on this site (beta)"
+msgid "Do not list my add-on on this site"
 msgstr ""
 
 #: src/olympia/devhub/forms.py:538
@@ -3755,46 +3738,46 @@ msgstr ""
 
 #: src/olympia/devhub/forms.py:592
 #, python-format
-msgid "Version %s already exists"
+msgid "Version %s already exists, or was uploaded before."
 msgstr ""
 
-#: src/olympia/devhub/forms.py:604
+#: src/olympia/devhub/forms.py:605
 msgid "Select a valid choice. That choice is not one of the available choices."
 msgstr ""
 
-#: src/olympia/devhub/forms.py:610
+#: src/olympia/devhub/forms.py:611
 msgid "A file with a version ending with a|alpha|b|beta and an optional number is detected as beta."
 msgstr ""
 
-#: src/olympia/devhub/forms.py:633
+#: src/olympia/devhub/forms.py:634
 msgid "You cannot upload any more files for this version."
 msgstr ""
 
-#: src/olympia/devhub/forms.py:639
+#: src/olympia/devhub/forms.py:640
 msgid "Version doesn't match"
 msgstr ""
 
-#: src/olympia/devhub/forms.py:668
+#: src/olympia/devhub/forms.py:669
 msgid "You cannot delete a file once the review process has started.  You must delete the whole version."
 msgstr ""
 
-#: src/olympia/devhub/forms.py:688
+#: src/olympia/devhub/forms.py:689
 msgid "The platform All cannot be combined with specific platforms."
 msgstr ""
 
-#: src/olympia/devhub/forms.py:693
+#: src/olympia/devhub/forms.py:694
 msgid "A platform can only be chosen once."
 msgstr ""
 
-#: src/olympia/devhub/forms.py:706
+#: src/olympia/devhub/forms.py:707
 msgid "A review type must be selected."
 msgstr ""
 
-#: src/olympia/devhub/forms.py:788 src/olympia/editors/forms.py:114 src/olympia/zadmin/forms.py:49 src/olympia/zadmin/forms.py:52
+#: src/olympia/devhub/forms.py:789 src/olympia/editors/forms.py:114 src/olympia/editors/forms.py:254 src/olympia/zadmin/forms.py:49 src/olympia/zadmin/forms.py:52
 msgid "Select an application first"
 msgstr ""
 
-#: src/olympia/devhub/forms.py:840
+#: src/olympia/devhub/forms.py:841
 msgid "There cannot be more than 3 required add-ons."
 msgstr ""
 
@@ -3828,76 +3811,76 @@ msgstr[1] ""
 msgid "Review"
 msgstr ""
 
-#: src/olympia/devhub/tasks.py:551
+#: src/olympia/devhub/tasks.py:583
 #, python-format
 msgid "%s responded with %s (%s)."
 msgstr ""
 
-#: src/olympia/devhub/tasks.py:555
+#: src/olympia/devhub/tasks.py:587
 #, python-format
 msgid "Connection to \"%s\" timed out."
 msgstr ""
 
-#: src/olympia/devhub/tasks.py:557
+#: src/olympia/devhub/tasks.py:589
 #, python-format
 msgid "Could not contact host at \"%s\"."
 msgstr ""
 
-#: src/olympia/devhub/utils.py:104
+#: src/olympia/devhub/utils.py:105
 #, python-format
 msgid "Validation generated too many errors/warnings so %s messages were truncated. After addressing the visible messages, you'll be able to see the others."
 msgstr ""
 
-#: src/olympia/devhub/views.py:183
+#: src/olympia/devhub/views.py:181
 msgid "All My Add-ons"
 msgstr ""
 
-#: src/olympia/devhub/views.py:210
+#: src/olympia/devhub/views.py:208
 msgid "All Activity"
 msgstr ""
 
-#: src/olympia/devhub/views.py:211
+#: src/olympia/devhub/views.py:209
 msgid "Add-on Updates"
 msgstr ""
 
-#: src/olympia/devhub/views.py:212
+#: src/olympia/devhub/views.py:210
 msgid "Add-on Status"
 msgstr ""
 
-#: src/olympia/devhub/views.py:213
+#: src/olympia/devhub/views.py:211
 msgid "User Collections"
 msgstr ""
 
-#: src/olympia/devhub/views.py:214 src/olympia/devhub/templates/devhub/docs/policies-maintenance.html:68 src/olympia/pages/templates/pages/dev_faq.html:38
+#: src/olympia/devhub/views.py:212 src/olympia/devhub/templates/devhub/docs/policies-maintenance.html:68 src/olympia/pages/templates/pages/dev_faq.html:38
 #: src/olympia/pages/templates/pages/dev_faq.html:484
 msgid "User Reviews"
 msgstr ""
 
-#: src/olympia/devhub/views.py:327 src/olympia/devhub/views.py:331 src/olympia/devhub/views.py:484 src/olympia/devhub/views.py:513 src/olympia/devhub/views.py:564 src/olympia/devhub/views.py:1150
+#: src/olympia/devhub/views.py:325 src/olympia/devhub/views.py:329 src/olympia/devhub/views.py:484 src/olympia/devhub/views.py:513 src/olympia/devhub/views.py:564 src/olympia/devhub/views.py:1156
 msgid "Changes successfully saved."
 msgstr ""
 
-#: src/olympia/devhub/views.py:334 src/olympia/devhub/views.py:1631
+#: src/olympia/devhub/views.py:332 src/olympia/devhub/views.py:1637
 msgid "Please check the form for errors."
 msgstr ""
 
-#: src/olympia/devhub/views.py:346
+#: src/olympia/devhub/views.py:344
 msgid "Add-on cannot be deleted. Disable this add-on instead."
 msgstr ""
 
-#: src/olympia/devhub/views.py:356
+#: src/olympia/devhub/views.py:354
 msgid "Theme deleted."
 msgstr ""
 
-#: src/olympia/devhub/views.py:356
+#: src/olympia/devhub/views.py:354
 msgid "Add-on deleted."
 msgstr ""
 
-#: src/olympia/devhub/views.py:362
+#: src/olympia/devhub/views.py:360
 msgid "URL name was incorrect. Theme was not deleted."
 msgstr ""
 
-#: src/olympia/devhub/views.py:367
+#: src/olympia/devhub/views.py:365
 msgid "URL name was incorrect. Add-on was not deleted."
 msgstr ""
 
@@ -3925,7 +3908,7 @@ msgstr ""
 msgid "Check Add-on Compatibility"
 msgstr ""
 
-#: src/olympia/devhub/views.py:808 src/olympia/signing/views.py:90
+#: src/olympia/devhub/views.py:808 src/olympia/signing/views.py:95
 msgid "You cannot submit this type of add-on"
 msgstr ""
 
@@ -3955,33 +3938,33 @@ msgstr ""
 msgid "There was an error uploading your preview."
 msgstr ""
 
-#: src/olympia/devhub/views.py:1189
+#: src/olympia/devhub/views.py:1195
 #, python-format
 msgid "Version %s disabled."
 msgstr ""
 
-#: src/olympia/devhub/views.py:1193
+#: src/olympia/devhub/views.py:1199
 #, python-format
 msgid "Version %s deleted."
 msgstr ""
 
-#: src/olympia/devhub/views.py:1203
+#: src/olympia/devhub/views.py:1209
 msgid "This upload has failed validation, and may lack complete validation results. Please take due care when reviewing it."
 msgstr ""
 
-#: src/olympia/devhub/views.py:1677
+#: src/olympia/devhub/views.py:1683
 msgid "Preliminary Review Requested."
 msgstr ""
 
-#: src/olympia/devhub/views.py:1678
+#: src/olympia/devhub/views.py:1684
 msgid "Full Review Requested."
 msgstr ""
 
-#: src/olympia/devhub/views.py:1779
+#: src/olympia/devhub/views.py:1783
 msgid "Your old credentials were revoked and are no longer valid. Be sure to update all API clients with the new credentials."
 msgstr ""
 
-#: src/olympia/devhub/views.py:1797
+#: src/olympia/devhub/views.py:1801
 msgid "New API key created"
 msgstr ""
 
@@ -4011,7 +3994,7 @@ msgstr ""
 msgid "{0} :: Search"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/devhub_search.html:6 src/olympia/devhub/templates/devhub/search.html:8 src/olympia/editors/forms.py:435 src/olympia/editors/forms.py:437
+#: src/olympia/devhub/templates/devhub/devhub_search.html:6 src/olympia/devhub/templates/devhub/search.html:8 src/olympia/editors/forms.py:534 src/olympia/editors/forms.py:536
 #: src/olympia/editors/templates/editors/queue.html:27 src/olympia/editors/templates/editors/themes/queue_list.html:14 src/olympia/search/templates/search/collections.html:17
 #: src/olympia/search/templates/search/personas.html:18 src/olympia/search/templates/search/results.html:18 src/olympia/search/templates/search/mobile/results.html:8
 #: src/olympia/templates/search.html:14 src/olympia/templates/impala/search.html:18
@@ -4071,12 +4054,12 @@ msgstr ""
 msgid "Start Making Add-ons"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/index.html:86 src/olympia/devhub/templates/devhub/addons/listing/items.html:25 src/olympia/devhub/templates/devhub/includes/addon_details.html:15
+#: src/olympia/devhub/templates/devhub/index.html:86 src/olympia/devhub/templates/devhub/addons/listing/items.html:25 src/olympia/devhub/templates/devhub/includes/addon_details.html:20
 #: src/olympia/devhub/templates/devhub/personas/edit.html:43
 msgid "Status:"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/index.html:90 src/olympia/devhub/templates/devhub/includes/addon_details.html:100
+#: src/olympia/devhub/templates/devhub/index.html:90 src/olympia/devhub/templates/devhub/includes/addon_details.html:87
 msgid "Visibility:"
 msgstr ""
 
@@ -4084,11 +4067,11 @@ msgstr ""
 msgid "Latest Version:"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/index.html:109 src/olympia/devhub/templates/devhub/includes/addon_details.html:145 src/olympia/devhub/templates/devhub/personas/edit.html:49
+#: src/olympia/devhub/templates/devhub/index.html:109 src/olympia/devhub/templates/devhub/includes/addon_details.html:131 src/olympia/devhub/templates/devhub/personas/edit.html:49
 msgid "Queue Position:"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/index.html:110 src/olympia/devhub/templates/devhub/includes/addon_details.html:146 src/olympia/devhub/templates/devhub/personas/edit.html:50
+#: src/olympia/devhub/templates/devhub/index.html:110 src/olympia/devhub/templates/devhub/includes/addon_details.html:132 src/olympia/devhub/templates/devhub/personas/edit.html:50
 #, python-format
 msgid "%(position)s of %(total)s"
 msgstr ""
@@ -4190,16 +4173,6 @@ msgstr ""
 msgid "Do you want your add-on to be distributed on this site?"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/validate_addon.html:49 src/olympia/devhub/templates/devhub/addons/submit/upload.html:30 src/olympia/devhub/templates/devhub/versions/add_file_modal.html:14
-#: src/olympia/devhub/templates/devhub/versions/add_file_modal.html:53 src/olympia/devhub/templates/devhub/versions/list.html:298
-msgid "Warning:"
-msgstr ""
-
-#: src/olympia/devhub/templates/devhub/validate_addon.html:50 src/olympia/devhub/templates/devhub/addons/submit/upload.html:31
-#, python-format
-msgid "Submission of unlisted add-ons for signing is currently in an open beta. Please <a href=\"%(url)s\" target=\"_blank\">report any bugs</a> that you encounter."
-msgstr ""
-
 #. first parameter is a filename like lorem-ipsum-1.0.2.xpi
 #: src/olympia/devhub/templates/devhub/validation.html:5
 msgid "Validation Results for {0}"
@@ -4274,7 +4247,7 @@ msgstr ""
 msgid "Update Compatibility"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/addons/ajax_compat_update.html:4
+#: src/olympia/devhub/templates/devhub/addons/ajax_compat_update.html:4 src/olympia/devhub/templates/devhub/versions/edit.html:45
 msgid "Adjusting application information here will allow users to install your add-on even if the install manifest in the package indicates that the add-on is incompatible."
 msgstr ""
 
@@ -4286,9 +4259,9 @@ msgstr ""
 msgid "Add Another Application&hellip;"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/addons/ajax_compat_update.html:38 src/olympia/devhub/templates/devhub/addons/owner.html:86 src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:46
-#: src/olympia/devhub/templates/devhub/versions/list.html:351 src/olympia/devhub/templates/devhub/versions/list.html:353 src/olympia/templates/impala/base.html:132
-#: src/olympia/templates/impala/base.html:143 src/olympia/templates/impala/base.html:161 src/olympia/templates/impala/base.html:171
+#: src/olympia/devhub/templates/devhub/addons/ajax_compat_update.html:38 src/olympia/devhub/templates/devhub/addons/owner.html:86 src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:45
+#: src/olympia/devhub/templates/devhub/versions/list.html:349 src/olympia/devhub/templates/devhub/versions/list.html:351 src/olympia/templates/impala/base.html:129
+#: src/olympia/templates/impala/base.html:140 src/olympia/templates/impala/base.html:158 src/olympia/templates/impala/base.html:168
 msgid "Close"
 msgstr ""
 
@@ -4322,7 +4295,7 @@ msgstr ""
 msgid "Manage Authors & License"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/addons/owner.html:29 src/olympia/editors/templates/editors/review.html:270
+#: src/olympia/devhub/templates/devhub/addons/owner.html:29 src/olympia/editors/helpers.py:362 src/olympia/editors/templates/editors/review.html:270
 msgid "Authors"
 msgstr ""
 
@@ -4391,17 +4364,11 @@ msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/basic.html:52
 msgid ""
-"A short explanation of your add-on's basic\n"
-"                          functionality that is displayed in search and browse\n"
-"                          listings, as well as at the top of your add-on's\n"
-"                          details page. It is only relevant for listed add-ons."
+"A short explanation of your add-on's basic functionality that is displayed in search and browse listings, as well as at the top of your add-on's details page. It is only relevant for listed add-ons."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/basic.html:73
-msgid ""
-"Categories are the primary way users browse through add-ons.\n"
-"                        Choose any that fit your add-on's functionality for the most\n"
-"                        exposure. It is only relevant for listed add-ons."
+msgid "Categories are the primary way users browse through add-ons. Choose any that fit your add-on's functionality for the most exposure. It is only relevant for listed add-ons."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/basic.html:90
@@ -4411,11 +4378,7 @@ msgid ""
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/basic.html:119
-msgid ""
-"Tags help users find your add-on and should be short\n"
-"                        descriptors such as tabs, toolbar, or twitter.  You\n"
-"                        may have a maximum of {0} tags. It is only relevant\n"
-"                        for listed add-ons."
+msgid "Tags help users find your add-on and should be short descriptors such as tabs, toolbar, or twitter. You may have a maximum of {0} tags. It is only relevant for listed add-ons."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/basic.html:129 src/olympia/devhub/templates/devhub/personas/edit.html:97 src/olympia/devhub/templates/devhub/personas/submit.html:46
@@ -4443,11 +4406,7 @@ msgid "Add-on Details for {0}"
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/details.html:22
-msgid ""
-"A longer explanation of features,\n"
-"                          functionality, and other relevant information. This\n"
-"                          field is only displayed on the add-on's details\n"
-"                          page. It is only relevant for listed add-ons."
+msgid "A longer explanation of features, functionality, and other relevant information. This field is only displayed on the add-on's details page. It is only relevant for listed add-ons."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/details.html:44 src/olympia/translations/templates/translations/trans-menu.html:13
@@ -4455,10 +4414,7 @@ msgid "Default Locale"
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/details.html:45
-msgid ""
-"Information about your add-on is displayed in this locale\n"
-"                        unless you override it with a locale-specific translation.\n"
-"                        It is only relevant for listed add-ons."
+msgid "Information about your add-on is displayed in this locale unless you override it with a locale-specific translation. It is only relevant for listed add-ons."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/details.html:61 src/olympia/users/forms.py:311 src/olympia/users/templates/users/edit.html:122 src/olympia/users/templates/users/register.html:57
@@ -4468,10 +4424,8 @@ msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/details.html:63
 msgid ""
-"If your add-on has another homepage, enter its\n"
-"                          address here. If your website is localized into other\n"
-"                          languages multiple translations of this field can be\n"
-"                          added. It is only relevant for listed add-ons."
+"If your add-on has another homepage, enter its address here. If your website is localized into other languages multiple translations of this field can be added. It is only relevant for listed add-"
+"ons."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/media.html:3
@@ -4489,19 +4443,14 @@ msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/support.html:22
 msgid ""
-"If you wish to display an e-mail address for support\n"
-"                          inquiries, enter it here. If you have different\n"
-"                          addresses for each language multiple translations of\n"
-"                          this field can be added. It is only relevant for\n"
-"                          listed add-ons."
+"If you wish to display an e-mail address for support inquiries, enter it here. If you have different addresses for each language multiple translations of this field can be added. It is only "
+"relevant for listed add-ons."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/support.html:45
 msgid ""
-"If your add-on has a support website or forum, enter\n"
-"                          its address here. If your website is localized into\n"
-"                          other languages, multiple translations of this field can\n"
-"                          be added. It is only relevant for listed add-ons."
+"If your add-on has a support website or forum, enter its address here. If your website is localized into other languages, multiple translations of this field can be added. It is only relevant for "
+"listed add-ons."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:6
@@ -4515,11 +4464,8 @@ msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:23
 msgid ""
-"Any information end users may want to know that isn't\n"
-"                          necessarily applicable to the add-on summary or description.\n"
-"                          Common uses include listing known major bugs, information on\n"
-"                          how to report bugs, anticipated release date of a new version,\n"
-"                          etc. It is only relevant for listed add-ons."
+"Any information end users may want to know that isn't necessarily applicable to the add-on summary or description. Common uses include listing known major bugs, information on how to report bugs, "
+"anticipated release date of a new version, etc. It is only relevant for listed add-ons."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:46
@@ -4531,9 +4477,7 @@ msgid "Add-on Flags"
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:69
-msgid ""
-"These flags are used to classify add-ons. It is only\n"
-"                        relevant for listed add-ons."
+msgid "These flags are used to classify add-ons. It is only relevant for listed add-ons."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:74
@@ -4549,9 +4493,7 @@ msgid "View Source?"
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:90
-msgid ""
-"Whether the source of your add-on can be displayed in our\n"
-"                        online viewer. It is only relevant for listed add-ons."
+msgid "Whether the source of your add-on can be displayed in our online viewer. It is only relevant for listed add-ons."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:94
@@ -4567,10 +4509,7 @@ msgid "Public Stats?"
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:102
-msgid ""
-"Whether the download and usage stats of your add-on can\n"
-"                        be displayed in our online viewer.\n"
-"                        It is only relevant for listed add-ons."
+msgid "Whether the download and usage stats of your add-on can be displayed in our online viewer. It is only relevant for listed add-ons."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:107
@@ -4586,10 +4525,7 @@ msgid "Upgrade SDK?"
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:116
-msgid ""
-"If selected, we will try to automatically upgrade your\n"
-"                        add-on when a new version of the SDK is released.\n"
-"                        It is only relevant for listed add-ons."
+msgid "If selected, we will try to automatically upgrade your add-on when a new version of the SDK is released. It is only relevant for listed add-ons."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:121
@@ -4640,10 +4576,8 @@ msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/forms_shared/media.html:16
 msgid ""
-"Upload an icon for your add-on or choose from one of ours. The\n"
-"                      icon is displayed nearly everywhere your add-on is. Uploaded images\n"
-"                      must be one of the following image types: .png, .jpg.\n"
-"                      It is only relevant for listed add-ons."
+"Upload an icon for your add-on or choose from one of ours. The icon is displayed nearly everywhere your add-on is. Uploaded images must be one of the following image types: .png, .jpg. It is only "
+"relevant for listed add-ons."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/forms_shared/media.html:25
@@ -4656,9 +4590,7 @@ msgid "32x32px"
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/forms_shared/media.html:39
-msgid ""
-"Used in listings of add-ons, like search results\n"
-"                            and featured add-ons."
+msgid "Used in listings of add-ons, like search results and featured add-ons."
 msgstr ""
 
 #. The size of the icon
@@ -4753,16 +4685,14 @@ msgid "Deleting your add-on will permanently remove it from the site and prevent
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:24
-msgid ""
-"Enter the following text confirm your decision:\n"
-"           {slug}"
+msgid "Enter the following text confirm your decision: {slug}"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:34
+#: src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:33
 msgid "Please tell us why you are deleting your theme:"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:36
+#: src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:35
 msgid "Please tell us why you are deleting your add-on:"
 msgstr ""
 
@@ -4799,8 +4729,8 @@ msgstr ""
 msgid "Daily statistics on downloads and users."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/addons/listing/item_actions.html:45 src/olympia/stats/templates/stats/stats.html:75 src/olympia/stats/templates/stats/stats.html:79
-#: src/olympia/stats/templates/stats/stats.html:81
+#: src/olympia/devhub/templates/devhub/addons/listing/item_actions.html:45 src/olympia/stats/templates/stats/stats.html:31 src/olympia/stats/templates/stats/stats.html:35
+#: src/olympia/stats/templates/stats/stats.html:37
 msgid "Statistics"
 msgstr ""
 
@@ -4919,10 +4849,7 @@ msgid "Your add-on has been submitted to the Full Review queue."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/submit/done.html:18
-msgid ""
-"You'll receive an email once it has been reviewed by an editor. In\n"
-"          the meantime, you and your friends can install it directly from its\n"
-"          details page:"
+msgid "You'll receive an email once it has been reviewed by an editor. In the meantime, you and your friends can install it directly from its details page:"
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/submit/done.html:27 src/olympia/devhub/templates/devhub/addons/submit/done.html:77 src/olympia/devhub/templates/devhub/personas/submit_done.html:16
@@ -5128,11 +5055,11 @@ msgstr ""
 msgid "Use the fields below to upload your add-on package and select any platform restrictions. After upload, a series of automated validation tests will be run on your file."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/addons/submit/upload.html:59 src/olympia/devhub/templates/devhub/versions/add_file_modal.html:39
+#: src/olympia/devhub/templates/devhub/addons/submit/upload.html:51 src/olympia/devhub/templates/devhub/versions/add_file_modal.html:28
 msgid "Which platforms is this file compatible with?"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/addons/submit/upload.html:67 src/olympia/devhub/templates/devhub/versions/add_file_modal.html:65
+#: src/olympia/devhub/templates/devhub/addons/submit/upload.html:59 src/olympia/devhub/templates/devhub/versions/add_file_modal.html:45
 msgid "Administrative overrides"
 msgstr ""
 
@@ -5242,8 +5169,8 @@ msgstr ""
 
 #: src/olympia/devhub/templates/devhub/docs/policies-contact.html:44
 msgid ""
-"If you've found a problem with the site, we'd love to fix it. Please <a href=\"https://github.com/mozilla/olympia/issues\">file a bug report</a> in GitHub, including the location of the problem and "
-"how you encountered it."
+"If you've found a problem with the site, we'd love to fix it. Please <a href=\"https://github.com/mozilla/addons/issues/new\">file a bug report</a> in GitHub, including the location of the problem "
+"and how you encountered it."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/docs/policies-maintenance.html:3 src/olympia/devhub/templates/devhub/docs/policies-maintenance.html:7
@@ -5810,7 +5737,7 @@ msgstr ""
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:282
 msgid ""
-"Add-ons that store or otherwise handle browsing data must support <a href=\"https://developer.mozilla.org/En/Supporting_private_browsing_mode\">Private Browsing Mode</a>.  During a Private Browsing "
+"Add-ons that store or otherwise handle browsing data must support <a href=\"https://developer.mozilla.org/En/Supporting_private_browsing_mode\">Private Browsing Mode</a>. During a Private Browsing "
 "session, no browsing data can be written to disk, and all of this data must be cleared when Firefox quits or the Private Browsing session ends."
 msgstr ""
 
@@ -5975,129 +5902,95 @@ msgstr ""
 msgid "How to get in touch with us regarding these policies or your add-on."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:6
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:10
 msgid "You have disabled this add-on"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:20
-msgid ""
-"Your add-on's listing is disabled and is not showing\n"
-"                             anywhere in our gallery or update service."
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:24
+msgid "Your add-on's listing is disabled and is not showing anywhere in our gallery or update service."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:25
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:27
 msgid "Please complete your add-on."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:29
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:30
 msgid "You will receive an email when the review is complete."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:34
-msgid ""
-"You will receive an email when the review is complete. Until\n"
-"                             then, your add-on is not listed in our gallery but can be\n"
-"                             accessed directly from its details page."
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:33
+msgid "You will receive an email when the review is complete. Until then, your add-on is not listed in our gallery but can be accessed directly from its details page."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:38 src/olympia/devhub/templates/devhub/includes/addon_details.html:48
-msgid ""
-"You will receive an email when the review is\n"
-"                             complete and your add-on is signed."
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:37 src/olympia/devhub/templates/devhub/includes/addon_details.html:45
+msgid "You will receive an email when the review is complete and your add-on is signed."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:44
-msgid ""
-"You will receive an email when the review is complete. Until\n"
-"                             then, your add-on is not listed in our gallery but can be\n"
-"                             accessed directly from its details page. "
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:41
+msgid "You will receive an email when the review is complete. Until then, your add-on is not listed in our gallery but can be accessed directly from its details page. "
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:54
-msgid ""
-"Your add-on is displayed in our gallery and users are\n"
-"                             receiving automatic updates."
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:49
+msgid "Your add-on is displayed in our gallery and users are receiving automatic updates."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:57
-msgid ""
-"Your add-on has been signed and can be bundled with an\n"
-"                             application installer."
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:52
+msgid "Your add-on has been signed and can be bundled with an application installer."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:63
-msgid ""
-"Your add-on was disabled by a site administrator and is no\n"
-"                             longer shown in our gallery. If you have any questions,\n"
-"                             please email amo-admins@mozilla.org."
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:56
+msgid "Your add-on was disabled by a site administrator and is no longer shown in our gallery. If you have any questions, please email amo-admins@mozilla.org."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:70
-msgid ""
-"Your add-on is displayed in our gallery as experimental\n"
-"                             and users are receiving automatic updates. Some features\n"
-"                             are unavailable to your add-on."
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:62
+msgid "Your add-on is displayed in our gallery as experimental and users are receiving automatic updates. Some features are unavailable to your add-on."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:74
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:66
 msgid "Your add-on has been signed."
 msgstr ""
 
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:69
+msgid ""
+"You will receive an email when the full review is complete. Until then, your add-on is displayed in our gallery as experimental and users are receiving automatic updates. Some features are "
+"unavailable to your add-on."
+msgstr ""
+
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:74
+msgid "You will receive an email when the full review is complete, making you able to bundle your add-on with an application installer."
+msgstr ""
+
 #: src/olympia/devhub/templates/devhub/includes/addon_details.html:79
-msgid ""
-"You will receive an email when the full review is complete.\n"
-"                             Until then, your add-on is displayed in our gallery as\n"
-"                             experimental and users are receiving automatic updates.\n"
-"                             Some features are unavailable to your add-on."
+msgid "All add-ons hosted in our gallery must now be reviewed by an editor. If you wish to continue hosting your add-on, please click to select a review process."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:84
-msgid ""
-"You will receive an email when the full review is\n"
-"                             complete, making you able to bundle your add-on with an\n"
-"                             application installer."
-msgstr ""
-
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:91
-msgid ""
-"All add-ons hosted in our gallery must now be reviewed by an\n"
-"                             editor. If you wish to continue hosting your add-on, please\n"
-"                             click to select a review process."
-msgstr ""
-
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:113
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:100
 msgid "Current Version:"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:115
-msgid ""
-"This is the version of your add-on that will\n"
-"                                           be installed if someone clicks the Install\n"
-"                                           button on addons.mozilla.org. It is only\n"
-"                                           relevant for listed add-ons."
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:102
+msgid "This is the version of your add-on that will be installed if someone clicks the Install button on addons.mozilla.org. It is only relevant for listed add-ons."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:123
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:110
 msgid "Created:"
 msgstr ""
 
 #. {0} is a date. dennis-ignore: E201
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:125 src/olympia/devhub/templates/devhub/includes/addon_details.html:131
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:112 src/olympia/devhub/templates/devhub/includes/addon_details.html:118
 #, python-format
 msgid "%%b %%e, %%Y"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:136
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:123
 msgid "Next Version:"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:138
-msgid ""
-"This is the newest uploaded version, however\n"
-"                                           it isn’t live on the site yet."
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:125
+msgid "This is the newest uploaded version, however it isn’t live on the site yet."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:144 src/olympia/devhub/templates/devhub/versions/list.html:30
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:130 src/olympia/devhub/templates/devhub/versions/list.html:30
 msgid "Queues are not reviewed strictly in order"
 msgstr ""
 
@@ -6165,9 +6058,7 @@ msgid "View the blog &#9658;"
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/includes/license_form.html:6
-msgid ""
-"Please choose a license appropriate for the rights you grant on your source code.\n"
-"                  It is only relevant for listed add-ons."
+msgid "Please choose a license appropriate for the rights you grant on your source code. It is only relevant for listed add-ons."
 msgstr ""
 
 #. {0} is a list of HTML tags.
@@ -6194,14 +6085,11 @@ msgstr[1] ""
 #: src/olympia/devhub/templates/devhub/includes/policy_form.html:4
 msgid ""
 "Users will be required to accept the following End-User License Agreement (EULA) prior to installing your add-on. The presence of a EULA significantly affects the number of downloads an add-on "
-"receives. Please note that a EULA is not the same as a code license, such as the GPL or MPL.\n"
-"                It is only relevant for listed add-ons."
+"receives. Please note that a EULA is not the same as a code license, such as the GPL or MPL.It is only relevant for listed add-ons."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/policy_form.html:21
-msgid ""
-"If your add-on transmits any data from the user's computer, a privacy policy is required that explains what data is sent and how it is used.\n"
-"                It is only relevant for listed add-ons."
+#: src/olympia/devhub/templates/devhub/includes/policy_form.html:24
+msgid "If your add-on transmits any data from the user's computer, a privacy policy is required that explains what data is sent and how it is used. It is only relevant for listed add-ons."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/includes/source_form_field.html:2
@@ -6369,12 +6257,8 @@ msgstr ""
 msgid "Add some tags to describe your Theme."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/personas/edit.html:106
-msgid ""
-"A short explanation of your theme's\n"
-"                                basic functionality that is displayed in\n"
-"                                search and browse listings, as well as at\n"
-"                                the top of your theme's details page."
+#: src/olympia/devhub/templates/devhub/personas/edit.html:106 src/olympia/devhub/templates/devhub/personas/submit.html:54
+msgid "A short explanation of your theme's basic functionality that is displayed in search and browse listings, as well as at the top of your theme's details page."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/personas/edit.html:122 src/olympia/devhub/templates/devhub/personas/submit.html:68
@@ -6444,7 +6328,7 @@ msgid "Upon upload and form submission, the AMO Team will review your updated de
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/personas/edit.html:241
-msgid "Your previously resubmitted design,  which is under pending review."
+msgid "Your previously resubmitted design, which is under pending review."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/personas/edit.html:245
@@ -6511,14 +6395,6 @@ msgstr ""
 
 #: src/olympia/devhub/templates/devhub/personas/submit.html:33
 msgid "Give your Theme a name."
-msgstr ""
-
-#: src/olympia/devhub/templates/devhub/personas/submit.html:54
-msgid ""
-"A short explanation of your theme's\n"
-"                                      basic functionality that is displayed in\n"
-"                                      search and browse listings, as well as at\n"
-"                                      the top of your theme's details page."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/personas/submit.html:198
@@ -6595,30 +6471,16 @@ msgstr ""
 msgid "Files added to reviewed versions must be reviewed before they will be available for download."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/add_file_modal.html:15
-#, python-format
-msgid ""
-"Submission of updates to unlisted add-ons for signing is currently in an open beta. Manual review may still be required for a large number of add-ons. Please <a href=\"%(url)s\" target=\"_blank"
-"\">report any bugs</a> that you encounter."
-msgstr ""
-
-#: src/olympia/devhub/templates/devhub/versions/add_file_modal.html:35
+#: src/olympia/devhub/templates/devhub/versions/add_file_modal.html:24
 msgid "Select the target platform for this file."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/add_file_modal.html:46
+#: src/olympia/devhub/templates/devhub/versions/add_file_modal.html:35
 msgid "Which review type would you like to nominate for?"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/add_file_modal.html:51
+#: src/olympia/devhub/templates/devhub/versions/add_file_modal.html:40
 msgid "Only publish this version to my beta channel."
-msgstr ""
-
-#: src/olympia/devhub/templates/devhub/versions/add_file_modal.html:54
-#, python-format
-msgid ""
-"The behavior of the beta channel has changed to accommodate <a href=\"%(addon_signing_url)s\" target=\"_blank\">mandatory add-on signing</a>. The new process is currently in an open beta, and may "
-"change significantly in the near future. Please <a href=\"%(issues_url)s\" target=\"_blank\">report any bugs</a> that you encounter."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/versions/edit.html:5
@@ -6642,19 +6504,10 @@ msgstr ""
 msgid "Upload Another File"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/edit.html:45
-msgid ""
-"Adjusting application information here will allow users to install your\n"
-"                          add-on even if the install manifest in the package indicates that the\n"
-"                          add-on is incompatible."
-msgstr ""
-
 #: src/olympia/devhub/templates/devhub/versions/edit.html:74
 msgid ""
-"Information about changes in this release, new features,\n"
-"                              known bugs, and other useful information specific to this\n"
-"                              release/version. This information is also shown in the\n"
-"                              Add-ons Manager when updating."
+"Information about changes in this release, new features, known bugs, and other useful information specific to this release/version. This information is also shown in the Add-ons Manager when "
+"updating."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/versions/edit.html:99
@@ -6666,10 +6519,7 @@ msgid "Notes for Reviewers"
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/versions/edit.html:114
-msgid ""
-"Optionally, enter any information that may be useful\n"
-"                              to the Editor reviewing this add-on, such as test\n"
-"                              account information."
+msgid "Optionally, enter any information that may be useful to the Editor reviewing this add-on, such as test account information."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/versions/edit.html:127
@@ -6747,7 +6597,7 @@ msgstr ""
 msgid "Request Preliminary Review"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:80 src/olympia/devhub/templates/devhub/versions/list.html:327 src/olympia/devhub/templates/devhub/versions/list.html:350
+#: src/olympia/devhub/templates/devhub/versions/list.html:80 src/olympia/devhub/templates/devhub/versions/list.html:325 src/olympia/devhub/templates/devhub/versions/list.html:348
 msgid "Cancel Review Request"
 msgstr ""
 
@@ -6776,7 +6626,7 @@ msgid "Unlisted:"
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/versions/list.html:114
-msgid "Not distributed on {0}. Developers will upload new versions for signing and distribute the add-ons on their own. (beta)"
+msgid "Not distributed on {0}. Developers will upload new versions for signing and distribute the add-ons on their own."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/versions/list.html:122
@@ -6839,81 +6689,73 @@ msgid "<strong>Important:</strong> Once a version has been deleted, you may not 
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/versions/list.html:230
-msgid ""
-"Deleting a version which has already been reviewed\n"
-"               may also cause a significant delay in the review of\n"
-"               your next update."
-msgstr ""
-
-#: src/olympia/devhub/templates/devhub/versions/list.html:233
 msgid "Are you sure you wish to delete this version?"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:238
+#: src/olympia/devhub/templates/devhub/versions/list.html:235
 msgid "Delete Version"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:240
+#: src/olympia/devhub/templates/devhub/versions/list.html:237
 msgid "Disable Version"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:247
+#: src/olympia/devhub/templates/devhub/versions/list.html:244
 msgid "Add a new Version"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:249
+#: src/olympia/devhub/templates/devhub/versions/list.html:246
 msgid "Add Version"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:256 src/olympia/devhub/templates/devhub/versions/list.html:274
+#: src/olympia/devhub/templates/devhub/versions/list.html:253 src/olympia/devhub/templates/devhub/versions/list.html:279
 msgid "Hide Add-on"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:259
+#: src/olympia/devhub/templates/devhub/versions/list.html:256
 msgid "Hiding your add-on will prevent it from appearing anywhere in our gallery and will stop users from receiving automatic updates."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:265
+#: src/olympia/devhub/templates/devhub/versions/list.html:263
+msgid "The files awaiting review will be disabled and you will need to upload new versions."
+msgstr ""
+
+#: src/olympia/devhub/templates/devhub/versions/list.html:270
 msgid "Are you sure you wish to hide your add-on?"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:286 src/olympia/devhub/templates/devhub/versions/list.html:315
+#: src/olympia/devhub/templates/devhub/versions/list.html:291 src/olympia/devhub/templates/devhub/versions/list.html:313
 msgid "Unlist Add-on"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:289
+#: src/olympia/devhub/templates/devhub/versions/list.html:294
 #, python-format
 msgid ""
 "Unlisting your add-on will make it (and each of its versions/files) invisible on this website. It won't show up in searches, won't have a public facing page, and won't be updated automatically for "
-"current users.  It is recommended for unlisted add-ons to provide a custom <a href=\"%(update_url)s\" target=\"_blank\">updateURL</a> in their manifest file for automatic updates."
+"current users. It is recommended for unlisted add-ons to provide a custom <a href=\"%(update_url)s\" target=\"_blank\">updateURL</a> in their manifest file for automatic updates."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:299
-#, python-format
-msgid "Switching add-ons to unlisted is currently in an open beta. Please <a href=\"%(url)s\" target=\"_blank\">report any bugs</a> that you encounter."
-msgstr ""
-
-#: src/olympia/devhub/templates/devhub/versions/list.html:305
+#: src/olympia/devhub/templates/devhub/versions/list.html:303
 msgid "Unlisting an add-on is irreversible!"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:305
+#: src/olympia/devhub/templates/devhub/versions/list.html:303
 msgid "An unlisted add-on cannot be switched to be listed."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:307
+#: src/olympia/devhub/templates/devhub/versions/list.html:305
 msgid "Are you sure you wish to unlist your add-on?"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:330
+#: src/olympia/devhub/templates/devhub/versions/list.html:328
 msgid "Canceling your review request will leave your add-on as preliminarily reviewed."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:335
+#: src/olympia/devhub/templates/devhub/versions/list.html:333
 msgid "Canceling your review request will mark your add-on incomplete. If you do not complete your add-on after several days by re-requesting review, it will be deleted."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:343
+#: src/olympia/devhub/templates/devhub/versions/list.html:341
 msgid "Are you sure you wish to cancel your review request?"
 msgstr ""
 
@@ -7252,19 +7094,19 @@ msgstr ""
 msgid "Search by add-on name / author email"
 msgstr ""
 
-#: src/olympia/editors/forms.py:103
+#: src/olympia/editors/forms.py:103 src/olympia/editors/forms.py:244 src/olympia/editors/forms.py:257
 msgid "yes"
 msgstr ""
 
-#: src/olympia/editors/forms.py:104
+#: src/olympia/editors/forms.py:104 src/olympia/editors/forms.py:244 src/olympia/editors/forms.py:257
 msgid "no"
 msgstr ""
 
-#: src/olympia/editors/forms.py:105
+#: src/olympia/editors/forms.py:105 src/olympia/editors/forms.py:245
 msgid "Admin Flag"
 msgstr ""
 
-#: src/olympia/editors/forms.py:113
+#: src/olympia/editors/forms.py:113 src/olympia/editors/forms.py:253
 msgid "Max. Version"
 msgstr ""
 
@@ -7276,55 +7118,59 @@ msgstr ""
 msgid "Add-on Types"
 msgstr ""
 
-#: src/olympia/editors/forms.py:126 src/olympia/editors/helpers.py:267
+#: src/olympia/editors/forms.py:126 src/olympia/editors/helpers.py:279
 msgid "Platforms"
 msgstr ""
 
+#: src/olympia/editors/forms.py:237
+msgid "Search by add-on name / author email / guid"
+msgstr ""
+
 #. L10n: 0 = platform, 1 = filename, 2 = status message
-#: src/olympia/editors/forms.py:238
+#: src/olympia/editors/forms.py:342
 #, python-format
 msgid "<strong>%s</strong> &middot; %s &middot; %s"
 msgstr ""
 
-#: src/olympia/editors/forms.py:252
+#: src/olympia/editors/forms.py:356
 msgid "Comments:"
 msgstr ""
 
-#: src/olympia/editors/forms.py:256
+#: src/olympia/editors/forms.py:360
 msgid "Operating systems:"
 msgstr ""
 
-#: src/olympia/editors/forms.py:258
+#: src/olympia/editors/forms.py:362
 msgid "Applications:"
 msgstr ""
 
-#: src/olympia/editors/forms.py:260
+#: src/olympia/editors/forms.py:364
 msgid "Notify me the next time this add-on is updated. (Subsequent updates will not generate an email)"
 msgstr ""
 
-#: src/olympia/editors/forms.py:265
+#: src/olympia/editors/forms.py:369
 msgid "Clear Admin Review Flag"
 msgstr ""
 
-#: src/olympia/editors/forms.py:267
+#: src/olympia/editors/forms.py:371
 msgid "Clear more info requested flag"
 msgstr ""
 
-#: src/olympia/editors/forms.py:281
+#: src/olympia/editors/forms.py:385
 msgid "Choose a canned response..."
 msgstr ""
 
 #. L10n: Description of what can be searched for.
-#: src/olympia/editors/forms.py:324
+#: src/olympia/editors/forms.py:423
 msgid "theme name"
 msgstr ""
 
-#: src/olympia/editors/forms.py:350
+#: src/olympia/editors/forms.py:449
 msgid "Someone else is reviewing this theme."
 msgstr ""
 
 #. L10n: Description of what can be searched for.
-#: src/olympia/editors/forms.py:447
+#: src/olympia/editors/forms.py:546
 msgid "app, reviewer, or comment"
 msgstr ""
 
@@ -7340,246 +7186,264 @@ msgstr ""
 msgid "Rejected or Unreviewed"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:123 src/olympia/editors/helpers.py:136
+#: src/olympia/editors/helpers.py:125 src/olympia/editors/helpers.py:138
 msgid "Queue"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:124 src/olympia/editors/templates/editors/base.html:50 src/olympia/editors/templates/editors/base.html:65
+#: src/olympia/editors/helpers.py:126 src/olympia/editors/templates/editors/base.html:50 src/olympia/editors/templates/editors/base.html:65
 msgid "Pending Updates"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:125 src/olympia/editors/templates/editors/base.html:48 src/olympia/editors/templates/editors/base.html:63
+#: src/olympia/editors/helpers.py:127 src/olympia/editors/templates/editors/base.html:48 src/olympia/editors/templates/editors/base.html:63
 msgid "Full Reviews"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:126 src/olympia/editors/templates/editors/base.html:52 src/olympia/editors/templates/editors/base.html:67
+#: src/olympia/editors/helpers.py:128 src/olympia/editors/templates/editors/base.html:52 src/olympia/editors/templates/editors/base.html:67
 msgid "Preliminary Reviews"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:127 src/olympia/editors/templates/editors/base.html:54
+#: src/olympia/editors/helpers.py:129 src/olympia/editors/templates/editors/base.html:54
 msgid "Moderated Reviews"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:128 src/olympia/editors/templates/editors/base.html:46
+#: src/olympia/editors/helpers.py:130 src/olympia/editors/templates/editors/base.html:46
 msgid "Fast Track"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:130
+#: src/olympia/editors/helpers.py:132
 msgid "Pending Themes"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:131 src/olympia/editors/templates/editors/themes/queue.html:4
+#: src/olympia/editors/helpers.py:133 src/olympia/editors/templates/editors/themes/queue.html:4
 msgid "Flagged Themes"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:132
+#: src/olympia/editors/helpers.py:134
 msgid "Update Themes"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:137
+#: src/olympia/editors/helpers.py:139
 msgid "Unlisted Pending Updates"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:138
+#: src/olympia/editors/helpers.py:140
 msgid "Unlisted Full Reviews"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:139
+#: src/olympia/editors/helpers.py:141
 msgid "Unlisted Preliminary Reviews"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:170
+#: src/olympia/editors/helpers.py:142
+msgid "Unlisted All Add-ons"
+msgstr ""
+
+#: src/olympia/editors/helpers.py:173
 msgid "Fast Track ({0})"
 msgid_plural "Fast Track ({0})"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/olympia/editors/helpers.py:175
+#: src/olympia/editors/helpers.py:178
 msgid "Full Review ({0})"
 msgid_plural "Full Reviews ({0})"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/olympia/editors/helpers.py:180
+#: src/olympia/editors/helpers.py:183
 msgid "Pending Update ({0})"
 msgid_plural "Pending Updates ({0})"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/olympia/editors/helpers.py:185
+#: src/olympia/editors/helpers.py:188
 msgid "Preliminary Review ({0})"
 msgid_plural "Preliminary Reviews ({0})"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/olympia/editors/helpers.py:190
+#: src/olympia/editors/helpers.py:193
 msgid "Moderated Review ({0})"
 msgid_plural "Moderated Reviews ({0})"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/olympia/editors/helpers.py:196
+#: src/olympia/editors/helpers.py:199
 msgid "Unlisted Full Review ({0})"
 msgid_plural "Unlisted Full Reviews ({0})"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/olympia/editors/helpers.py:201
+#: src/olympia/editors/helpers.py:204
 msgid "Unlisted Pending Update ({0})"
 msgid_plural "Unlisted Pending Updates ({0})"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/olympia/editors/helpers.py:206
+#: src/olympia/editors/helpers.py:209
 msgid "Unlisted Preliminary Review ({0})"
 msgid_plural "Unlisted Preliminary Reviews ({0})"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/olympia/editors/helpers.py:261
-msgid "Addon"
-msgstr ""
+#: src/olympia/editors/helpers.py:214
+msgid "Unlisted All Add-ons ({0})"
+msgid_plural "Unlisted All Add-ons ({0})"
+msgstr[0] ""
+msgstr[1] ""
 
-#: src/olympia/editors/helpers.py:262
+#: src/olympia/editors/helpers.py:274
 msgid "Type"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:263
+#: src/olympia/editors/helpers.py:275
 msgid "Waiting Time"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:264 src/olympia/editors/templates/editors/review.html:285
+#: src/olympia/editors/helpers.py:276 src/olympia/editors/templates/editors/review.html:285
 msgid "Flags"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:265
+#: src/olympia/editors/helpers.py:277
 msgid "Applications"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:270
+#: src/olympia/editors/helpers.py:282
 msgid "Additional"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:285
+#: src/olympia/editors/helpers.py:302
 msgid "Site Specific"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:287
+#: src/olympia/editors/helpers.py:304
 msgid "Requires External Software"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:289
+#: src/olympia/editors/helpers.py:306
 msgid "Binary Components"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:313
+#: src/olympia/editors/helpers.py:339
 msgid "moments ago"
 msgstr ""
 
 #. L10n: first argument is number of minutes
-#: src/olympia/editors/helpers.py:316
+#: src/olympia/editors/helpers.py:342
 msgid "{0} minute"
 msgid_plural "{0} minutes"
 msgstr[0] ""
 msgstr[1] ""
 
 #. L10n: first argument is number of hours
-#: src/olympia/editors/helpers.py:320
+#: src/olympia/editors/helpers.py:346
 msgid "{0} hour"
 msgid_plural "{0} hours"
 msgstr[0] ""
 msgstr[1] ""
 
 #. L10n: first argument is number of days
-#: src/olympia/editors/helpers.py:324
+#: src/olympia/editors/helpers.py:350
 msgid "{0} day"
 msgid_plural "{0} days"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/olympia/editors/helpers.py:488
+#: src/olympia/editors/helpers.py:364
+msgid "Last Review"
+msgstr ""
+
+#: src/olympia/editors/helpers.py:366
+msgid "Last Update"
+msgstr ""
+
+#: src/olympia/editors/helpers.py:387
+msgid "No Reviews"
+msgstr ""
+
+#: src/olympia/editors/helpers.py:561
 msgid "Push to public"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:490
+#: src/olympia/editors/helpers.py:563
 msgid "Grant full review"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:505
+#: src/olympia/editors/helpers.py:578
 msgid "Request more information"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:508
+#: src/olympia/editors/helpers.py:581
 msgid "Request super-review"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:519
+#: src/olympia/editors/helpers.py:592
 msgid "Grant preliminary review"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:520
+#: src/olympia/editors/helpers.py:593
 msgid "This will mark the files as preliminarily reviewed."
 msgstr ""
 
-#: src/olympia/editors/helpers.py:522
+#: src/olympia/editors/helpers.py:595
 msgid "Use this form to request more information from the author. They will receive an email and be able to answer here. You will be notified by email when they reply."
 msgstr ""
 
-#: src/olympia/editors/helpers.py:526
+#: src/olympia/editors/helpers.py:599
 msgid ""
 "If you have concerns about this add-on's security, copyright issues, or other concerns that an administrator should look into, enter your comments in the area below. They will be sent to "
 "administrators, not the author."
 msgstr ""
 
-#: src/olympia/editors/helpers.py:532
+#: src/olympia/editors/helpers.py:605
 msgid "This will reject the add-on and remove it from the review queue."
 msgstr ""
 
-#: src/olympia/editors/helpers.py:534
-msgid "Make a comment on this version.  The author won't be able to see this."
+#: src/olympia/editors/helpers.py:607
+msgid "Make a comment on this version. The author won't be able to see this."
 msgstr ""
 
-#: src/olympia/editors/helpers.py:538
+#: src/olympia/editors/helpers.py:611
 msgid "This will reject the files and remove them from the review queue."
 msgstr ""
 
-#: src/olympia/editors/helpers.py:542
+#: src/olympia/editors/helpers.py:615
 msgid "This will mark the add-on as preliminarily reviewed. Future versions will undergo preliminary review."
 msgstr ""
 
-#: src/olympia/editors/helpers.py:547
+#: src/olympia/editors/helpers.py:620
 msgid "This will mark the files as preliminarily reviewed. Future versions will undergo preliminary review."
 msgstr ""
 
-#: src/olympia/editors/helpers.py:552
+#: src/olympia/editors/helpers.py:625
 msgid "Retain preliminary review"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:553
+#: src/olympia/editors/helpers.py:626
 msgid "This will retain the add-on as preliminarily reviewed. Future versions will undergo preliminary review."
 msgstr ""
 
-#: src/olympia/editors/helpers.py:558
+#: src/olympia/editors/helpers.py:631
 msgid "This will approve a sandboxed version of a public add-on to appear on the public side."
 msgstr ""
 
-#: src/olympia/editors/helpers.py:561
+#: src/olympia/editors/helpers.py:634
 msgid "This will reject a version of a public add-on and remove it from the queue."
 msgstr ""
 
-#: src/olympia/editors/helpers.py:564
+#: src/olympia/editors/helpers.py:637
 msgid "This will mark the add-on and its most recent version and files as public. Future versions will go into the sandbox until they are reviewed by an editor."
 msgstr ""
 
-#: src/olympia/editors/helpers.py:637
+#: src/olympia/editors/helpers.py:714
 msgid "add-on"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:940 src/olympia/editors/helpers.py:960
+#: src/olympia/editors/helpers.py:1020 src/olympia/editors/helpers.py:1040
 msgid "Flagged"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:944 src/olympia/editors/helpers.py:963
+#: src/olympia/editors/helpers.py:1024 src/olympia/editors/helpers.py:1043
 msgid "Updates"
 msgstr ""
 
@@ -7631,56 +7495,56 @@ msgstr ""
 msgid "A question about your Theme submission"
 msgstr ""
 
-#: src/olympia/editors/views.py:144
+#: src/olympia/editors/views.py:146
 msgid "New Add-ons (Under 5 days)"
 msgstr ""
 
-#: src/olympia/editors/views.py:145
+#: src/olympia/editors/views.py:147
 msgid "Passable (5 to 10 days)"
 msgstr ""
 
-#: src/olympia/editors/views.py:146
+#: src/olympia/editors/views.py:148
 msgid "Overdue (Over 10 days)"
 msgstr ""
 
-#: src/olympia/editors/views.py:532
+#: src/olympia/editors/views.py:539
 msgid "An unknown error occurred"
 msgstr ""
 
-#: src/olympia/editors/views.py:587
+#: src/olympia/editors/views.py:592
 msgid "Self-reviews are not allowed."
 msgstr ""
 
-#: src/olympia/editors/views.py:609
+#: src/olympia/editors/views.py:613
 msgid "Review successfully processed."
 msgstr ""
 
-#: src/olympia/editors/views.py:807
+#: src/olympia/editors/views.py:812
 msgid "was approved"
 msgstr ""
 
-#: src/olympia/editors/views.py:808
+#: src/olympia/editors/views.py:813
 msgid "given preliminary review"
 msgstr ""
 
-#: src/olympia/editors/views.py:809
+#: src/olympia/editors/views.py:814
 msgid "rejected"
 msgstr ""
 
-#: src/olympia/editors/views.py:810
+#: src/olympia/editors/views.py:815
 msgctxt "editors_review_history_nominated_adminreview"
 msgid "escalated"
 msgstr ""
 
-#: src/olympia/editors/views.py:812
+#: src/olympia/editors/views.py:817
 msgid "needs more information"
 msgstr ""
 
-#: src/olympia/editors/views.py:813
+#: src/olympia/editors/views.py:818
 msgid "needs super review"
 msgstr ""
 
-#: src/olympia/editors/views.py:814
+#: src/olympia/editors/views.py:819
 msgid "commented"
 msgstr ""
 
@@ -7725,28 +7589,28 @@ msgstr ""
 msgid "Unlisted Queues"
 msgstr ""
 
-#: src/olympia/editors/templates/editors/base.html:72 src/olympia/editors/templates/editors/performance.html:6
+#: src/olympia/editors/templates/editors/base.html:74 src/olympia/editors/templates/editors/performance.html:6
 msgid "Performance"
 msgstr ""
 
-#: src/olympia/editors/templates/editors/base.html:75 src/olympia/editors/templates/editors/themes/base.html:19 src/olympia/editors/templates/editors/themes/base.html:38
+#: src/olympia/editors/templates/editors/base.html:77 src/olympia/editors/templates/editors/themes/base.html:19 src/olympia/editors/templates/editors/themes/base.html:38
 msgid "Logs"
 msgstr ""
 
-#: src/olympia/editors/templates/editors/base.html:78 src/olympia/editors/templates/editors/reviewlog.html:4 src/olympia/editors/templates/editors/reviewlog.html:27
+#: src/olympia/editors/templates/editors/base.html:80 src/olympia/editors/templates/editors/reviewlog.html:4 src/olympia/editors/templates/editors/reviewlog.html:27
 msgid "Add-on Review Log"
 msgstr ""
 
-#: src/olympia/editors/templates/editors/base.html:80 src/olympia/editors/templates/editors/eventlog.html:4 src/olympia/editors/templates/editors/eventlog.html:8
+#: src/olympia/editors/templates/editors/base.html:82 src/olympia/editors/templates/editors/eventlog.html:4 src/olympia/editors/templates/editors/eventlog.html:8
 #: src/olympia/editors/templates/editors/eventlog_detail.html:4
 msgid "Moderated Review Log"
 msgstr ""
 
-#: src/olympia/editors/templates/editors/base.html:82 src/olympia/editors/templates/editors/beta_signed_log.html:4 src/olympia/editors/templates/editors/beta_signed_log.html:8
+#: src/olympia/editors/templates/editors/base.html:84 src/olympia/editors/templates/editors/beta_signed_log.html:4 src/olympia/editors/templates/editors/beta_signed_log.html:8
 msgid "Signed Beta Files Log"
 msgstr ""
 
-#: src/olympia/editors/templates/editors/base.html:87 src/olympia/editors/templates/editors/includes/daily-message.html:4
+#: src/olympia/editors/templates/editors/base.html:89 src/olympia/editors/templates/editors/includes/daily-message.html:4
 msgid "Announcement"
 msgstr ""
 
@@ -7967,45 +7831,45 @@ msgstr ""
 msgid "clear search"
 msgstr ""
 
-#: src/olympia/editors/templates/editors/queue.html:72 src/olympia/editors/templates/editors/queue.html:122
+#: src/olympia/editors/templates/editors/queue.html:78 src/olympia/editors/templates/editors/queue.html:128
 msgid "Process Reviews"
 msgstr ""
 
-#: src/olympia/editors/templates/editors/queue.html:80
+#: src/olympia/editors/templates/editors/queue.html:86
 msgid "Moderation actions:"
 msgstr ""
 
-#: src/olympia/editors/templates/editors/queue.html:90
+#: src/olympia/editors/templates/editors/queue.html:96
 #, python-format
 msgid "by %(user)s on %(date)s %(stars)s (%(locale)s)"
 msgstr ""
 
-#: src/olympia/editors/templates/editors/queue.html:106
+#: src/olympia/editors/templates/editors/queue.html:112
 #, python-format
 msgid "<strong>%(reason)s</strong> <span class=\"light\">Flagged by %(user)s on %(date)s</span>"
 msgstr ""
 
-#: src/olympia/editors/templates/editors/queue.html:119
-msgid "All reviews have been moderated.  Good work!"
+#: src/olympia/editors/templates/editors/queue.html:125
+msgid "All reviews have been moderated. Good work!"
 msgstr ""
 
-#: src/olympia/editors/templates/editors/queue.html:161
+#: src/olympia/editors/templates/editors/queue.html:167
 msgid "Version Notes / Notes for Reviewer"
 msgstr ""
 
-#: src/olympia/editors/templates/editors/queue.html:169
+#: src/olympia/editors/templates/editors/queue.html:175
 msgid "There are currently no add-ons of this type to review."
 msgstr ""
 
-#: src/olympia/editors/templates/editors/queue.html:181 src/olympia/editors/templates/editors/themes/queue_list.html:85
+#: src/olympia/editors/templates/editors/queue.html:187 src/olympia/editors/templates/editors/themes/queue_list.html:85
 msgid "Helpful Links:"
 msgstr ""
 
-#: src/olympia/editors/templates/editors/queue.html:182
+#: src/olympia/editors/templates/editors/queue.html:188
 msgid "Add-on Policy"
 msgstr ""
 
-#: src/olympia/editors/templates/editors/queue.html:184
+#: src/olympia/editors/templates/editors/queue.html:190
 msgid "Editors' Guide"
 msgstr ""
 
@@ -8068,10 +7932,7 @@ msgid "<strong>Warning!</strong> Another user was viewing this page before you."
 msgstr ""
 
 #: src/olympia/editors/templates/editors/review.html:237
-msgid ""
-"The whiteboard is the place to exchange information relevant to\n"
-"               this addon (whatever the version), between the developer and the\n"
-"               editor. This is visible and editable by both."
+msgid "The whiteboard is the place to exchange information relevant to this addon (whatever the version), between the developer and the editor. This is visible and editable by both."
 msgstr ""
 
 #: src/olympia/editors/templates/editors/review.html:241
@@ -8345,7 +8206,7 @@ msgstr ""
 msgid "Describe your reason for flagging"
 msgstr ""
 
-#: src/olympia/files/forms.py:88
+#: src/olympia/files/forms.py:90
 msgid "Cannot diff a version against itself"
 msgstr ""
 
@@ -8380,51 +8241,51 @@ msgstr ""
 msgid "There was an error accessing file %s."
 msgstr ""
 
-#: src/olympia/files/utils.py:343
+#: src/olympia/files/utils.py:340
 msgid "Could not parse uploaded file."
 msgstr ""
 
-#: src/olympia/files/utils.py:380
+#: src/olympia/files/utils.py:377
 msgid "Invalid file name in archive: {0}"
 msgstr ""
 
-#: src/olympia/files/utils.py:388
+#: src/olympia/files/utils.py:385
 msgid "File exceeding size limit in archive: {0}"
 msgstr ""
 
-#: src/olympia/files/utils.py:439
+#: src/olympia/files/utils.py:436
 msgid "Invalid archive."
 msgstr ""
 
-#: src/olympia/files/utils.py:529 src/olympia/files/utils.py:532
+#: src/olympia/files/utils.py:526 src/olympia/files/utils.py:529
 msgid "Could not parse the manifest file."
 msgstr ""
 
-#: src/olympia/files/utils.py:551
+#: src/olympia/files/utils.py:548
 msgid "Could not find an add-on ID."
 msgstr ""
 
-#: src/olympia/files/utils.py:554
+#: src/olympia/files/utils.py:551
 msgid "Add-on ID must be 64 characters or less."
 msgstr ""
 
-#: src/olympia/files/utils.py:556
+#: src/olympia/files/utils.py:553
 msgid "Add-on ID doesn't match add-on."
 msgstr ""
 
-#: src/olympia/files/utils.py:564
+#: src/olympia/files/utils.py:561
 msgid "Duplicate add-on ID found."
 msgstr ""
 
-#: src/olympia/files/utils.py:567
+#: src/olympia/files/utils.py:564
 msgid "Version numbers should have fewer than 32 characters."
 msgstr ""
 
-#: src/olympia/files/utils.py:570
+#: src/olympia/files/utils.py:567
 msgid "Version numbers should only contain letters, numbers, and these punctuation characters: +*.-_."
 msgstr ""
 
-#: src/olympia/files/utils.py:587
+#: src/olympia/files/utils.py:584
 msgid "<em:type> doesn't match add-on"
 msgstr ""
 
@@ -8523,6 +8384,10 @@ msgstr ""
 
 #: src/olympia/files/templates/files/viewer.html:134
 msgid "Fetching file."
+msgstr ""
+
+#: src/olympia/legacy_api/views.py:255
+msgid "Not implemented yet."
 msgstr ""
 
 #: src/olympia/lib/constants.py:6
@@ -9181,10 +9046,6 @@ msgstr ""
 msgid "Zimbabwe Dollar"
 msgstr ""
 
-#: src/olympia/lib/video/ffmpeg.py:112 src/olympia/lib/video/totem.py:81
-msgid "Videos must be in WebM."
-msgstr ""
-
 #: src/olympia/pages/templates/pages/about.lhtml:3 src/olympia/pages/templates/pages/about.lhtml:10
 msgid "About Mozilla Add-ons"
 msgstr ""
@@ -9196,7 +9057,7 @@ msgstr ""
 #: src/olympia/pages/templates/pages/about.lhtml:13
 msgid ""
 "addons.mozilla.org, commonly known as \"AMO\", is Mozilla's official site for add-ons to Mozilla software, such as Firefox, Thunderbird, and SeaMonkey. Add-ons let you add new features and change "
-"the way your browser or application works.  Take a look around and explore the thousands of ways to customize the way you do things online."
+"the way your browser or application works. Take a look around and explore the thousands of ways to customize the way you do things online."
 msgstr ""
 
 #: src/olympia/pages/templates/pages/about.lhtml:19
@@ -9541,7 +9402,7 @@ msgstr ""
 msgid ""
 "Yes. It's possible, but some of the functionality provided by these libraries are available through XPCOM, XUL, and JavaScript. In addition, authors should take care if libraries modify primitive "
 "object prototypes (String.prototype, Date.prototype, etc.) and/or define global functions (eg. the $ function). These are prone to cause conflict with other add-ons, in particular if different add-"
-"ons use different versions of libraries and so on. Developers need to be very, very careful with using them.  Mozilla does not offer documentation on using them to build add-ons."
+"ons use different versions of libraries and so on. Developers need to be very, very careful with using them. Mozilla does not offer documentation on using them to build add-ons."
 msgstr ""
 
 #: src/olympia/pages/templates/pages/dev_faq.html:165
@@ -9655,8 +9516,8 @@ msgstr ""
 #, python-format
 msgid ""
 "Yes. Many developers choose to host their own add-ons. Choosing to host your add-on on <a href=\"%(amo_url)s\">Mozilla's add-on site</a>, though, allows for much greater exposure to your add-on due "
-"to the large volume of visitors to the site.  <a href=\"%(md_url)s\">mozdev.org</a> offers free project hosting for Mozilla applications and extensions providing developers with tools to help "
-"manage source code, version control, bug tracking and documentation."
+"to the large volume of visitors to the site. <a href=\"%(md_url)s\">mozdev.org</a> offers free project hosting for Mozilla applications and extensions providing developers with tools to help manage "
+"source code, version control, bug tracking and documentation."
 msgstr ""
 
 #: src/olympia/pages/templates/pages/dev_faq.html:277
@@ -9704,7 +9565,7 @@ msgstr ""
 #: src/olympia/pages/templates/pages/dev_faq.html:314
 #, python-format
 msgid ""
-"Yes. Mozilla's <a href=\"%(p_url)s\">Add-on Policy</a> describes what is an acceptable submission. This policy is subject to change without notice.  In addition, the AMO editorial team uses the <a "
+"Yes. Mozilla's <a href=\"%(p_url)s\">Add-on Policy</a> describes what is an acceptable submission. This policy is subject to change without notice. In addition, the AMO editorial team uses the <a "
 "href=\"%(g_url)s\">Editors Reviewing Guide</a> to ensure that your add-on meets specific guidelines for functionality and security."
 msgstr ""
 
@@ -9821,7 +9682,7 @@ msgstr ""
 #: src/olympia/pages/templates/pages/dev_faq.html:434
 #, python-format
 msgid ""
-"This is why it's very important to read the <a href=\"%(g_url)s\">Editors Reviewing Guide</a> to ensure that your add-on is setup as expected.  It's also a good idea to read the blog post, <a href="
+"This is why it's very important to read the <a href=\"%(g_url)s\">Editors Reviewing Guide</a> to ensure that your add-on is setup as expected. It's also a good idea to read the blog post, <a href="
 "\"%(blog_url)s\">Successfully Getting your Add-on Reviewed</a> which provides excellent insight into ensuring a smooth review of your add-on."
 msgstr ""
 
@@ -9928,7 +9789,7 @@ msgstr ""
 
 #: src/olympia/pages/templates/pages/dev_faq.html:572
 msgid ""
-"Free Software Foundation provides short summaries of the key open source licenses, including whether the license qualifies as a free software license or a copyleft license.  Also includes a "
+"Free Software Foundation provides short summaries of the key open source licenses, including whether the license qualifies as a free software license or a copyleft license. Also includes a "
 "discussion of what constitutes a free software license or a copyleft license (e.g., a Copyleft license is a general method for making a program or other work free, and requiring all modified and "
 "extended versions of the program to be free as well.)"
 msgstr ""
@@ -10106,19 +9967,13 @@ msgid "Add-on Gallery"
 msgstr ""
 
 #: src/olympia/pages/templates/pages/faq.html:171
-msgid ""
-"How do I choose between add-ons that seem to do the same\n"
-"    thing?"
+msgid "How do I choose between add-ons that seem to do the same thing?"
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:173
+#: src/olympia/pages/templates/pages/faq.html:172
 msgid ""
-"There are often several add-ons that have similar features. To\n"
-"    figure out which is right for you, read the entire description of the\n"
-"    add-on and view its screenshots. If there are still several in the running,\n"
-"    read through the add-on's ratings, user reviews, and statistics to see\n"
-"    which is most liked by other users. Remember that you can also just try\n"
-"    out both and see which you like better."
+"There are often several add-ons that have similar features. To figure out which is right for you, read the entire description of the add-on and view its screenshots. If there are still several in "
+"the running, read through the add-on's ratings, user reviews, and statistics to see which is most liked by other users. Remember that you can also just try out both and see which you like better."
 msgstr ""
 
 #: src/olympia/pages/templates/pages/faq.html:180
@@ -10159,80 +10014,67 @@ msgid "How much do add-ons cost to purchase?"
 msgstr ""
 
 #: src/olympia/pages/templates/pages/faq.html:207
-msgid ""
-"Add-ons hosted in our gallery are free unless clearly marked\n"
-"    otherwise."
+msgid "Add-ons hosted in our gallery are free unless clearly marked otherwise."
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:210
+#: src/olympia/pages/templates/pages/faq.html:209
 msgid "What does it mean when an add-on asks for contributions?"
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:211
+#: src/olympia/pages/templates/pages/faq.html:210
 msgid ""
-"Some add-on authors request users who enjoy an add-on to\n"
-"        contribute to its development by making a monetary contribution. These\n"
-"        contributions go directly to the developer unless a third party is\n"
-"        indicated, such as the non-profit Mozilla Foundation."
+"Some add-on authors request users who enjoy an add-on to contribute to its development by making a monetary contribution. These contributions go directly to the developer unless a third party is "
+"indicated, such as the non-profit Mozilla Foundation."
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:216
+#: src/olympia/pages/templates/pages/faq.html:215
 msgid "What are beta add-ons?"
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:218
+#: src/olympia/pages/templates/pages/faq.html:217
 msgid ""
-"Beta add-ons are unreviewed versions which represent the\n"
-"        latest work of an add-on author. While different authors have different\n"
-"        standards for beta code quality, you should assume that these add-ons\n"
-"        are less stable than the general add-on releases."
+"Beta add-ons are unreviewed versions which represent the latest work of an add-on author. While different authors have different standards for beta code quality, you should assume that these add-"
+"ons are less stable than the general add-on releases."
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:222
+#: src/olympia/pages/templates/pages/faq.html:221
 msgid ""
 "Please note that when you install an add-on from the \"Beta Version\" section of an add-on's listing, you will continue to receive updates for that add-on as they become available. Like the initial "
 "version you installed, all beta releases are unreviewed by Mozilla and may harm your computer."
 msgstr ""
 
+#: src/olympia/pages/templates/pages/faq.html:228
+msgid "What does it mean when an add-on is flagged as slow?"
+msgstr ""
+
 #: src/olympia/pages/templates/pages/faq.html:229
-msgid ""
-"What does it mean when an add-on is flagged as\n"
-"    slow?"
+msgid "Most add-ons load code and resources at the same time Firefox is starting up. In most cases the impact in start-up time is minimal, but some add-ons can cause a noticeable slowdown."
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:231
-msgid ""
-"Most add-ons load code and resources at the same time Firefox\n"
-"        is starting up. In most cases the impact in start-up time is minimal,\n"
-"        but some add-ons can cause a noticeable slowdown."
-msgstr ""
-
-#: src/olympia/pages/templates/pages/faq.html:236
+#: src/olympia/pages/templates/pages/faq.html:234
 msgid "How do I report an inappropriate or spam user review?"
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:237
+#: src/olympia/pages/templates/pages/faq.html:235
 msgid ""
-"To report a user review of an add-on, log in with your account\n"
-"    and visit the add-on's reviews page. Find the review you wish to report,\n"
-"    click \"Report this review\" and select a reason. Our editorial team will\n"
-"    investigate the review and take appropriate action."
+"To report a user review of an add-on, log in with your account and visit the add-on's reviews page. Find the review you wish to report, click \"Report this review\" and select a reason. Our "
+"editorial team will investigate the review and take appropriate action."
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:242
+#: src/olympia/pages/templates/pages/faq.html:240
 msgid "How do I report a bug or contact the Mozilla Add-ons team?"
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:243
+#: src/olympia/pages/templates/pages/faq.html:241
 #, python-format
 msgid "Please visit our <a href=\"%(contact_url)s\">Contact page</a>."
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:246
+#: src/olympia/pages/templates/pages/faq.html:244
 msgid "What is a Source Code License?"
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:247
+#: src/olympia/pages/templates/pages/faq.html:245
 #, python-format
 msgid ""
 "The source code used to create an add-on is an exclusive copyright of the add-on author, unless otherwise declared in a source code license. Many add-ons on this site have <a href=\"%(url)s\" lang="
@@ -10240,60 +10082,60 @@ msgid ""
 "the GPL or BSD licenses instead of making up their own."
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:256
+#: src/olympia/pages/templates/pages/faq.html:254
 #, python-format
 msgid "Firefox and other Mozilla software are <a href=\"%(url)s\">open source</a>."
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:264
+#: src/olympia/pages/templates/pages/faq.html:262
 msgid "Collections and Favorites"
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:267
+#: src/olympia/pages/templates/pages/faq.html:265
 msgid "What is a collection?"
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:268
+#: src/olympia/pages/templates/pages/faq.html:266
 msgid "Collections are groups of related add-ons created by users to share."
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:270
+#: src/olympia/pages/templates/pages/faq.html:268
 msgid "What is the My Favorites collection?"
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:271
+#: src/olympia/pages/templates/pages/faq.html:269
 msgid "Favorite add-ons are add-ons that you have bookmarked to easily get back to later. You can add an add-on to your favorites collection by clicking \"Add to favorites\" on its details page."
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:275 src/olympia/templates/menu_links.html:13 src/olympia/templates/impala/header_title.html:17
+#: src/olympia/pages/templates/pages/faq.html:273 src/olympia/templates/menu_links.html:13 src/olympia/templates/impala/header_title.html:17
 msgid "Mobile Add-ons"
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:278
+#: src/olympia/pages/templates/pages/faq.html:276
 msgid "What are mobile add-ons?"
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:279
+#: src/olympia/pages/templates/pages/faq.html:277
 #, python-format
 msgid ""
 "Mobile add-ons work with <a href=\"%(mobile_url)s\">Firefox for Mobile</a> and add or modify functionality just like desktop add-ons. You can find add-ons that work with Firefox for Mobile in our "
 "<a href=\"%(gallery_url)s\">gallery</a>."
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:288
+#: src/olympia/pages/templates/pages/faq.html:286
 msgid "Developer Topics"
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:289
+#: src/olympia/pages/templates/pages/faq.html:287
 #, python-format
 msgid "Please see our <a href=\"%(faq_url)s\">Developer FAQ</a> and <a href=\"%(hub_url)s\">Developer Hub</a> for answers to add-on developer-related questions."
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:294
+#: src/olympia/pages/templates/pages/faq.html:292
 msgid "Still have questions?"
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:295
+#: src/olympia/pages/templates/pages/faq.html:293
 #, python-format
 msgid "For general Firefox support, visit our <a href=\"%(sumo_url)s\">support website</a>. For general add-on and website questions, visit our <a href=\"%(forum_url)s\">forum</a>."
 msgstr ""
@@ -10431,7 +10273,7 @@ msgstr ""
 
 #: src/olympia/pages/templates/pages/sunbird.html:29
 msgid ""
-"Development on the Sunbird project has halted and its final release was on March 30, 2010.  We've been proud to host Sunbird add-ons on this site but as the project is no longer maintained we have "
+"Development on the Sunbird project has halted and its final release was on March 30, 2010. We've been proud to host Sunbird add-ons on this site but as the project is no longer maintained we have "
 "disabled our support for the add-ons."
 msgstr ""
 
@@ -10509,7 +10351,7 @@ msgstr ""
 #, python-format
 msgid ""
 "<h2>Keep these tips in mind:</h2> <ul> <li> Write like you're telling a friend about your experience with the add-on. Give specifics and helpful details, such as what features you liked and/or "
-"disliked, how easy to use it is, and any disadvantages it has.  Avoid generic language such as calling it \"Great\" or \"Bad\" unless you can give reasons why you believe this is so. </li> <li> "
+"disliked, how easy to use it is, and any disadvantages it has. Avoid generic language such as calling it \"Great\" or \"Bad\" unless you can give reasons why you believe this is so. </li> <li> "
 "Please do not post bug reports in reviews. We do not make your email address available to add-on developers and they may need to contact you to help resolve your issue. See the <a href=\"%(support)s"
 "\">support section</a> to find out where to get assistance for this add-on. </li> <li>Please keep reviews clean, avoid the use of improper language and do not post any personal information. </li> </"
 "ul> <p>Please read the <a href=\"%(guide)s\" target=\"_blank\">Review Guidelines</a> for more detail about user add-on reviews.</p>"
@@ -10745,16 +10587,16 @@ msgstr ""
 
 #. L10n: {0} is an application, such as Firefox. This means "any version of
 #. Firefox."
-#: src/olympia/search/views.py:554
+#: src/olympia/search/views.py:547
 msgid "Any {0}"
 msgstr ""
 
 #. L10n: "All Systems" means show everything regardless of platform.
-#: src/olympia/search/views.py:589
+#: src/olympia/search/views.py:582
 msgid "All Systems"
 msgstr ""
 
-#: src/olympia/search/views.py:600
+#: src/olympia/search/views.py:593
 msgid "All Tags"
 msgstr ""
 
@@ -10928,31 +10770,31 @@ msgstr ""
 msgid "Share this Collection"
 msgstr ""
 
-#: src/olympia/signing/views.py:30 src/olympia/templates/base.html:75 src/olympia/templates/impala/base.html:115
+#: src/olympia/signing/views.py:33 src/olympia/templates/base.html:71 src/olympia/templates/impala/base.html:112
 msgid "Some features are temporarily disabled while we perform website maintenance. We'll be back to full capacity shortly."
 msgstr ""
 
-#: src/olympia/signing/views.py:53
+#: src/olympia/signing/views.py:56
 msgid "Could not find add-on with id \"{}\"."
 msgstr ""
 
-#: src/olympia/signing/views.py:67
+#: src/olympia/signing/views.py:70
 msgid "You do not own this addon."
 msgstr ""
 
-#: src/olympia/signing/views.py:82
+#: src/olympia/signing/views.py:87
 msgid "Missing \"upload\" key in multipart file data."
 msgstr ""
 
-#: src/olympia/signing/views.py:96
+#: src/olympia/signing/views.py:101
 msgid "Version does not match the manifest file."
 msgstr ""
 
-#: src/olympia/signing/views.py:100
+#: src/olympia/signing/views.py:105
 msgid "Version already exists."
 msgstr ""
 
-#: src/olympia/signing/views.py:136
+#: src/olympia/signing/views.py:141
 msgid "No uploaded file for that addon and version."
 msgstr ""
 
@@ -11065,89 +10907,89 @@ msgstr ""
 msgid "Statistics Dashboard :: Add-ons for {0}"
 msgstr ""
 
-#: src/olympia/stats/templates/stats/stats.html:30
-msgid "Controls:"
-msgstr ""
-
-#: src/olympia/stats/templates/stats/stats.html:33
-msgid "reset zoom"
-msgstr ""
-
-#: src/olympia/stats/templates/stats/stats.html:40
-msgid "Group by:"
-msgstr ""
-
-#: src/olympia/stats/templates/stats/stats.html:42
-msgid "day"
-msgstr ""
-
-#: src/olympia/stats/templates/stats/stats.html:45
-msgid "week"
-msgstr ""
-
-#: src/olympia/stats/templates/stats/stats.html:48
-msgid "month"
-msgstr ""
-
-#: src/olympia/stats/templates/stats/stats.html:54
-msgid "For last:"
-msgstr ""
-
-#: src/olympia/stats/templates/stats/stats.html:57
-msgid "7 days"
-msgstr ""
-
-#: src/olympia/stats/templates/stats/stats.html:60
-msgid "30 days"
-msgstr ""
-
-#: src/olympia/stats/templates/stats/stats.html:63
-msgid "90 days"
-msgstr ""
-
-#: src/olympia/stats/templates/stats/stats.html:66
-msgid "365 days"
-msgstr ""
-
-#: src/olympia/stats/templates/stats/stats.html:69
-msgid "Custom..."
-msgstr ""
-
 #. {0} is an add-on name
-#: src/olympia/stats/templates/stats/stats.html:88 src/olympia/stats/templates/stats/stats.html:91
+#: src/olympia/stats/templates/stats/stats.html:44 src/olympia/stats/templates/stats/stats.html:47
 msgid "Statistics for {0}"
 msgstr ""
 
-#: src/olympia/stats/templates/stats/stats.html:94
+#: src/olympia/stats/templates/stats/stats.html:50
 msgid "Statistics Dashboard"
 msgstr ""
 
-#: src/olympia/stats/templates/stats/stats.html:104
+#: src/olympia/stats/templates/stats/stats.html:57
+msgid "Controls:"
+msgstr ""
+
+#: src/olympia/stats/templates/stats/stats.html:60
+msgid "reset zoom"
+msgstr ""
+
+#: src/olympia/stats/templates/stats/stats.html:67
+msgid "Group by:"
+msgstr ""
+
+#: src/olympia/stats/templates/stats/stats.html:69
+msgid "day"
+msgstr ""
+
+#: src/olympia/stats/templates/stats/stats.html:72
+msgid "week"
+msgstr ""
+
+#: src/olympia/stats/templates/stats/stats.html:75
+msgid "month"
+msgstr ""
+
+#: src/olympia/stats/templates/stats/stats.html:81
+msgid "For last:"
+msgstr ""
+
+#: src/olympia/stats/templates/stats/stats.html:84
+msgid "7 days"
+msgstr ""
+
+#: src/olympia/stats/templates/stats/stats.html:87
+msgid "30 days"
+msgstr ""
+
+#: src/olympia/stats/templates/stats/stats.html:90
+msgid "90 days"
+msgstr ""
+
+#: src/olympia/stats/templates/stats/stats.html:93
+msgid "365 days"
+msgstr ""
+
+#: src/olympia/stats/templates/stats/stats.html:96
+msgid "Custom..."
+msgstr ""
+
+#: src/olympia/stats/templates/stats/stats.html:106
 msgid "Statistics processing is currently disabled, so recent data is unavailable. The statistics are still being collected and this page will be updated soon with the missing data."
 msgstr ""
 
-#: src/olympia/stats/templates/stats/stats.html:110
+#: src/olympia/stats/templates/stats/stats.html:112
 msgid "Loading the latest data&hellip;"
 msgstr ""
 
-#: src/olympia/stats/templates/stats/stats.html:142 src/olympia/stats/templates/stats/reports/overview.html:25 src/olympia/stats/templates/stats/reports/overview.html:37
+#: src/olympia/stats/templates/stats/stats.html:144 src/olympia/stats/templates/stats/reports/overview.html:25 src/olympia/stats/templates/stats/reports/overview.html:37
 #: src/olympia/stats/templates/stats/reports/overview.html:49
 msgid "No data available."
 msgstr ""
 
-#: src/olympia/stats/templates/stats/stats.html:177
+#: src/olympia/stats/templates/stats/stats.html:179
 msgid "This dashboard is currently <b>public</b>."
 msgstr ""
 
-#: src/olympia/stats/templates/stats/stats.html:179
+#: src/olympia/stats/templates/stats/stats.html:181
 msgid "Contribution stats are currently <b>private</b>."
 msgstr ""
 
-#: src/olympia/stats/templates/stats/stats.html:182
+#: src/olympia/stats/templates/stats/stats.html:184
 msgid "This dashboard is currently <b>private</b>."
 msgstr ""
 
-#: src/olympia/stats/templates/stats/stats.html:185
+#: src/olympia/stats/templates/stats/stats.html:187
 msgid "Change settings."
 msgstr ""
 
@@ -11299,15 +11141,6 @@ msgstr ""
 msgid "Application versions by Date"
 msgstr ""
 
-#: src/olympia/tags/templates/tags/top_cloud.html:4
-msgid "Top {0} Tags"
-msgstr ""
-
-#. {0} is the current application name
-#: src/olympia/tags/templates/tags/top_cloud.html:14
-msgid "{0} Top Tags"
-msgstr ""
-
 #: src/olympia/templates/amo_footer.html:6 src/olympia/templates/includes/lang_switcher.html:2
 msgid "Other languages"
 msgstr ""
@@ -11316,11 +11149,11 @@ msgstr ""
 msgid "Mozilla Add-ons"
 msgstr ""
 
-#: src/olympia/templates/base.html:91 src/olympia/templates/impala/base.html:81
+#: src/olympia/templates/base.html:89 src/olympia/templates/impala/base.html:78
 msgid "Find add-ons for other applications"
 msgstr ""
 
-#: src/olympia/templates/base.html:92 src/olympia/templates/impala/base.html:81
+#: src/olympia/templates/base.html:90 src/olympia/templates/impala/base.html:78
 msgid "Other Applications"
 msgstr ""
 
@@ -11345,7 +11178,7 @@ msgid "View Mobile Site"
 msgstr ""
 
 #: src/olympia/templates/copyright.html:7
-msgid "Site Status "
+msgid "Site Status"
 msgstr ""
 
 #: src/olympia/templates/footer.html:3
@@ -11445,35 +11278,35 @@ msgstr ""
 msgid "<a href=\"%(reg)s\">Register</a> or <a href=\"%(login)s\">Log in</a>"
 msgstr ""
 
-#: src/olympia/templates/impala/base.html:126
+#: src/olympia/templates/impala/base.html:123
 #, python-format
 msgid "To try the thousands of add-ons available here, download <a href=\"%(url)s\">Mozilla Firefox</a>, a fast, free way to surf the Web!"
 msgstr ""
 
-#: src/olympia/templates/impala/base.html:138
+#: src/olympia/templates/impala/base.html:135
 #, python-format
 msgid "Add-ons is switching to Firefox Accounts for login. <a href=\"%(url)s\" class=\"fxa-login\">Sign in now to transfer your account.</a>"
 msgstr ""
 
 #. {0} is an application, such as Firefox.
-#: src/olympia/templates/impala/base.html:148
+#: src/olympia/templates/impala/base.html:145
 msgid "Welcome to {0} Add-ons."
 msgstr ""
 
-#: src/olympia/templates/impala/base.html:151
+#: src/olympia/templates/impala/base.html:148
 msgid "Choose from thousands of extra features and styles to make Firefox your own."
 msgstr ""
 
-#: src/olympia/templates/impala/base.html:156
+#: src/olympia/templates/impala/base.html:153
 #, python-format
 msgid "Add extra features and styles to make %(app)s your own."
 msgstr ""
 
-#: src/olympia/templates/impala/base.html:164
+#: src/olympia/templates/impala/base.html:161
 msgid "On the go?"
 msgstr ""
 
-#: src/olympia/templates/impala/base.html:166
+#: src/olympia/templates/impala/base.html:163
 msgid "Check out our <a class=\"mobile-link\" href=\"#\">Mobile Add-ons site</a>."
 msgstr ""
 
@@ -11697,19 +11530,19 @@ msgstr ""
 
 #. L10n: {id} will be something like "13ad6a", just a random number
 #. to differentiate this user from other anonymous users.
-#: src/olympia/users/models.py:353
+#: src/olympia/users/models.py:362
 msgid "Anonymous user {id}"
 msgstr ""
 
-#: src/olympia/users/models.py:410
+#: src/olympia/users/models.py:419
 msgid "Your account has been restricted"
 msgstr ""
 
-#: src/olympia/users/models.py:480
+#: src/olympia/users/models.py:489
 msgid "Please confirm your email address"
 msgstr ""
 
-#: src/olympia/users/models.py:506
+#: src/olympia/users/models.py:515
 msgid "My Mobile Add-ons"
 msgstr ""
 
@@ -11986,7 +11819,7 @@ msgstr ""
 
 #: src/olympia/users/templates/users/edit.html:70
 #, python-format
-msgid "Change your password.  If you forgot your password, you can <a href=\"%(reset_url)s\">use the reset form</a>."
+msgid "Change your password. If you forgot your password, you can <a href=\"%(reset_url)s\">use the reset form</a>."
 msgstr ""
 
 #: src/olympia/users/templates/users/edit.html:76
@@ -12006,7 +11839,7 @@ msgid "Profile"
 msgstr ""
 
 #: src/olympia/users/templates/users/edit.html:100
-msgid "Give us a bit more information about yourself.  All these fields are optional, but they'll help other users get to know you better."
+msgid "Give us a bit more information about yourself. All these fields are optional, but they'll help other users get to know you better."
 msgstr ""
 
 #: src/olympia/users/templates/users/edit.html:124
@@ -12222,7 +12055,7 @@ msgid "Confirm password"
 msgstr ""
 
 #: src/olympia/users/templates/users/pwreset_confirm.html:47
-msgid "The password reset link was invalid, possibly because it has already been used.  Please request a new password reset."
+msgid "The password reset link was invalid, possibly because it has already been used. Please request a new password reset."
 msgstr ""
 
 #: src/olympia/users/templates/users/pwreset_request.html:15
@@ -12408,7 +12241,7 @@ msgstr ""
 
 #: src/olympia/users/templates/users/unsubscribe.html:30
 #, python-format
-msgid "Unfortunately, we weren't able to unsubscribe you.  The link you clicked is invalid. However, you can unsubscribe still unsubscribe on your <a href=\"%(edit_url)s\">edit profile page</a>."
+msgid "Unfortunately, we weren't able to unsubscribe you. The link you clicked is invalid. However, you can unsubscribe still unsubscribe on your <a href=\"%(edit_url)s\">edit profile page</a>."
 msgstr ""
 
 #: src/olympia/users/templates/users/vcard.html:2
@@ -12462,15 +12295,15 @@ msgstr ""
 msgid "Version History with Changelogs"
 msgstr ""
 
-#: src/olympia/versions/models.py:314
+#: src/olympia/versions/models.py:313
 msgid "Add-on uses binary components."
 msgstr ""
 
-#: src/olympia/versions/models.py:317
+#: src/olympia/versions/models.py:316
 msgid "Add-on has opted into strict compatibility checking."
 msgstr ""
 
-#: src/olympia/versions/models.py:715
+#: src/olympia/versions/models.py:711
 msgid "{app} {min} and later"
 msgstr ""
 
@@ -12545,4 +12378,8 @@ msgstr ""
 
 #: src/olympia/zadmin/forms.py:105
 msgid "Log emails instead of sending"
+msgstr ""
+
+#: src/olympia/zadmin/forms.py:215
+msgid "Deleted versions can`t be changed."
 msgstr ""

--- a/locale/km/LC_MESSAGES/djangojs.po
+++ b/locale/km/LC_MESSAGES/djangojs.po
@@ -1,1216 +1,1236 @@
-
 #, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2016-02-24 21:23+0000\n"
+"POT-Creation-Date: 2016-04-18 15:47+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
+"Language: \n"
 "MIME-Version: 1.0\n"
-"Content-Type: text/plain; charset=utf-8\n"
+"Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Generated-By: Babel 2.2.0\n"
 
-#: static/js/common/ratingwidget.js:31
+#: static/js/common-all.js:1426 static/js/impala-all.js:1511 static/js/zamboni/discovery-all.js:12598 static/js/zamboni/init.js:28 static/js/zamboni/mobile-all.js:14945
+msgid "This feature is temporarily disabled while we perform website maintenance. Please check back a little later."
+msgstr ""
+
+#. L10n: {0} is an app name like Firefox.
+#: static/js/common-all.js:1837 static/js/impala-all.js:1922 static/js/zamboni/buttons.js:73 static/js/zamboni/discovery-all.js:13108
+msgid "Accept and Install"
+msgstr ""
+
+#: static/js/common-all.js:1837 static/js/impala-all.js:1922 static/js/zamboni/buttons.js:73 static/js/zamboni/discovery-all.js:13108
+msgid "Add to {0}"
+msgstr ""
+
+#: static/js/common-all.js:1842 static/js/impala-all.js:1927 static/js/zamboni/buttons.js:78 static/js/zamboni/discovery-all.js:13113
+msgid "Download Now"
+msgstr ""
+
+#: static/js/common-all.js:1883 static/js/impala-all.js:1968 static/js/zamboni/buttons.js:119 static/js/zamboni/discovery-all.js:13154
+msgid "Add-on has not been updated to support default-to-compatible."
+msgstr ""
+
+#: static/js/common-all.js:1888 static/js/impala-all.js:1973 static/js/zamboni/buttons.js:124 static/js/zamboni/discovery-all.js:13159
+msgid "You need to be using Firefox 10.0 or higher."
+msgstr ""
+
+#: static/js/common-all.js:1900 static/js/impala-all.js:1985 static/js/zamboni/buttons.js:136 static/js/zamboni/discovery-all.js:13171
+msgid "Mozilla has marked this version as incompatible with your Firefox version."
+msgstr ""
+
+#. L10n: {0} is an platform like Windows or Linux.
+#: static/js/common-all.js:1981 static/js/impala-all.js:2066 static/js/zamboni/buttons.js:217 static/js/zamboni/discovery-all.js:13252
+msgid "Install for {0} anyway"
+msgstr ""
+
+#: static/js/common-all.js:1981 static/js/impala-all.js:2066 static/js/zamboni/buttons.js:217 static/js/zamboni/discovery-all.js:13252
+msgid "Download for {0} anyway"
+msgstr ""
+
+#: static/js/common-all.js:2038 static/js/impala-all.js:2123 static/js/zamboni/buttons.js:274 static/js/zamboni/discovery-all.js:13309
+msgid "Not available for your platform"
+msgstr ""
+
+#. L10n: {0} is an app name, {1} is the app version.
+#: static/js/common-all.js:2049 static/js/common-all.js:2086 static/js/impala-all.js:2134 static/js/impala-all.js:2171 static/js/zamboni/buttons.js:286 static/js/zamboni/buttons.js:324
+#: static/js/zamboni/discovery-all.js:13320 static/js/zamboni/discovery-all.js:13357
+msgid "Not available for {0} {1}"
+msgstr ""
+
+#: static/js/common-all.js:2112 static/js/impala-all.js:2197 static/js/zamboni/buttons.js:351 static/js/zamboni/discovery-all.js:13383
+msgid "Works with {app} {min} - {max}"
+msgstr ""
+
+#: static/js/common-all.js:2114 static/js/impala-all.js:2199 static/js/zamboni/buttons.js:353 static/js/zamboni/discovery-all.js:13385
+msgid "View other versions"
+msgstr ""
+
+#: static/js/common-all.js:2162 static/js/impala-all.js:2247 static/js/zamboni/buttons.js:401 static/js/zamboni/discovery-all.js:13433
+msgid "Only with Firefox — Get Firefox Now!"
+msgstr ""
+
+#: static/js/common-all.js:2278 static/js/impala-all.js:2363 static/js/zamboni/buttons.js:517 static/js/zamboni/discovery-all.js:13549 static/js/zamboni/mobile-all.js:15177
+#: static/js/zamboni/mobile/buttons.js:43
+msgid "Sorry, you need a Mozilla-based browser (such as Firefox) to install a search plugin."
+msgstr ""
+
+#: static/js/common-all.js:9088 static/js/impala-all.js:9649 static/js/zamboni/global.js:410
+msgid "Loading..."
+msgstr ""
+
+#. L10n: {0} is the number of characters left.
+#: static/js/common-all.js:9152 static/js/impala-all.js:9713 static/js/zamboni/global.js:474
+msgid "<b>{0}</b> character left."
+msgid_plural "<b>{0}</b> characters left."
+msgstr[0] ""
+msgstr[1] ""
+
+#: static/js/common-all.js:9589 static/js/common-min.js:6 static/js/impala-all.js:10052 static/js/impala-min.js:6 static/js/common/ratingwidget.js:31 static/js/zamboni/mobile-all.js:16123
+#: static/js/zamboni/mobile-min.js:6
 msgid "{0} star"
 msgid_plural "{0} stars"
 msgstr[0] ""
 msgstr[1] ""
 
-#: static/js/common/upload-addon.js:41 static/js/common/upload-image.js:128
+#: static/js/common-all.js:9676 static/js/common-min.js:6 static/js/impala-all.js:10139 static/js/impala-min.js:6 static/js/zamboni/l10n.js:45
+msgid "Remove this localization"
+msgstr ""
+
+#: static/js/common-all.js:10193 static/js/common-min.js:6 static/js/impala-all.js:10674 static/js/impala-min.js:6 static/js/zamboni/discovery-all.js:13678
+msgid "close"
+msgstr ""
+
+#: static/js/common-all.js:10860 static/js/common-min.js:6 static/js/impala-all.js:11481 static/js/impala-min.js:6 static/js/impala/reviews.js:23 static/js/zamboni/reviews.js:18
+msgid "Flagged for review"
+msgstr ""
+
+#: static/js/common-all.js:10876 static/js/common-min.js:6 static/js/impala-all.js:11498 static/js/impala-min.js:6 static/js/impala/reviews.js:40 static/js/zamboni/reviews.js:34
+msgid "Your input is required"
+msgstr ""
+
+#: static/js/common-all.js:10945 static/js/common-min.js:6 static/js/impala-all.js:11610 static/js/impala-min.js:7 static/js/impala/reviews.js:152 static/js/zamboni/reviews.js:103
+msgid "Marked for deletion"
+msgstr ""
+
+#: static/js/common-all.js:11573 static/js/common-min.js:7 static/js/impala-all.js:13809 static/js/impala-min.js:8 static/js/zamboni/collections.js:229
+msgid "Adding to Favorites&hellip;"
+msgstr ""
+
+#: static/js/common-all.js:11576 static/js/common-min.js:7 static/js/impala-all.js:13812 static/js/impala-min.js:8 static/js/zamboni/collections.js:232
+msgid "Removing Favorite&hellip;"
+msgstr ""
+
+#: static/js/common-all.js:11579 static/js/common-min.js:7 static/js/impala-all.js:13815 static/js/impala-min.js:8 static/js/zamboni/collections.js:235
+msgid "Add to Favorites"
+msgstr ""
+
+#: static/js/common-all.js:11582 static/js/common-min.js:7 static/js/impala-all.js:13818 static/js/impala-min.js:8 static/js/zamboni/collections.js:238
+msgid "Remove from Favorites"
+msgstr ""
+
+#: static/js/common-all.js:11647 static/js/common-min.js:7 static/js/impala-all.js:13883 static/js/impala-min.js:8 static/js/zamboni/collections.js:303
+msgid "Pending"
+msgstr ""
+
+#: static/js/common-all.js:11648 static/js/common-min.js:7 static/js/impala-all.js:13884 static/js/impala-min.js:8 static/js/zamboni/collections.js:304
+msgid "Add a comment"
+msgstr ""
+
+#: static/js/common-all.js:11648 static/js/common-min.js:7 static/js/impala-all.js:13884 static/js/impala-min.js:8 static/js/zamboni/collections.js:304
+msgid "Comment"
+msgstr ""
+
+#: static/js/common-all.js:11649 static/js/common-min.js:7 static/js/impala-all.js:13885 static/js/impala-min.js:8 static/js/zamboni/collections.js:305
+msgid "Remove this add-on from the collection"
+msgstr ""
+
+#: static/js/common-all.js:11649 static/js/common-all.js:11678 static/js/common-min.js:7 static/js/impala-all.js:13885 static/js/impala-all.js:13914 static/js/impala-min.js:8
+#: static/js/zamboni/collections.js:305 static/js/zamboni/collections.js:334
+msgid "Remove"
+msgstr ""
+
+#: static/js/common-all.js:11678 static/js/common-min.js:7 static/js/impala-all.js:13914 static/js/impala-min.js:8 static/js/zamboni/collections.js:334
+msgid "Remove this user as a contributor"
+msgstr ""
+
+#: static/js/common-all.js:11690 static/js/common-min.js:7 static/js/impala-all.js:13926 static/js/impala-min.js:8 static/js/zamboni/collections.js:346
+msgid "An email address is required."
+msgstr ""
+
+#: static/js/common-all.js:11708 static/js/common-min.js:7 static/js/impala-all.js:13944 static/js/impala-min.js:8 static/js/zamboni/collections.js:364
+msgid "You cannot add yourself as a contributor."
+msgstr ""
+
+#: static/js/common-all.js:11710 static/js/common-min.js:7 static/js/impala-all.js:13946 static/js/impala-min.js:8 static/js/zamboni/collections.js:366
+msgid "You have already added that user."
+msgstr ""
+
+#: static/js/common-all.js:11917 static/js/common-min.js:7 static/js/impala-all.js:14153 static/js/impala-min.js:8 static/js/zamboni/collections.js:573
+msgid "Add to favorites"
+msgstr ""
+
+#: static/js/common-all.js:11921 static/js/common-min.js:7 static/js/impala-all.js:14157 static/js/impala-min.js:8 static/js/zamboni/collections.js:577
+msgid "Remove from favorites"
+msgstr ""
+
+#: static/js/common-all.js:11939 static/js/common-min.js:7 static/js/impala-all.js:14175 static/js/impala-all.js:14233 static/js/impala-min.js:8 static/js/impala/collections.js:10
+#: static/js/zamboni/collections.js:595
+msgid "Follow this Collection"
+msgstr ""
+
+#: static/js/common-all.js:11948 static/js/common-min.js:7 static/js/impala-all.js:14184 static/js/impala-min.js:8 static/js/zamboni/collections.js:604
+msgid "Stop following"
+msgstr ""
+
+#: static/js/common-all.js:12096 static/js/common-min.js:7 static/js/zamboni/password-strength.js:20
+msgid "Password strength:"
+msgstr ""
+
+#: static/js/common-all.js:12102 static/js/common-min.js:7 static/js/zamboni/password-strength.js:26
+msgid "At least {0} character left."
+msgid_plural "At least {0} characters left."
+msgstr[0] ""
+msgstr[1] ""
+
+#: static/js/common-all.js:12286 static/js/common-min.js:7 static/js/impala-all.js:14632 static/js/impala-min.js:8 static/js/impala/suggestions.js:39
+msgid "Search themes for <b>{0}</b>"
+msgstr ""
+
+#: static/js/common-all.js:12288 static/js/common-min.js:7 static/js/impala-all.js:14634 static/js/impala-min.js:8 static/js/impala/suggestions.js:41
+msgid "Search apps for <b>{0}</b>"
+msgstr ""
+
+#: static/js/common-all.js:12290 static/js/common-min.js:7 static/js/impala-all.js:14636 static/js/impala-min.js:8 static/js/impala/suggestions.js:43
+msgid "Search add-ons for <b>{0}</b>"
+msgstr ""
+
+#: static/js/common-all.js:12521 static/js/common-min.js:7 static/js/impala-all.js:14867 static/js/impala-min.js:8 static/js/impala/site_suggestions.js:46
+msgid "Category"
+msgstr ""
+
+#. L10n: {0} is an app name.
+#: static/js/impala-all.js:11632 static/js/impala-min.js:7 static/js/impala/listing.js:11 static/js/zamboni/themes.js:13
+msgid "This theme is incompatible with your version of {0}"
+msgstr ""
+
+#: static/js/impala-all.js:12146 static/js/impala-all.js:14331 static/js/impala-min.js:7 static/js/impala-min.js:8 static/js/common/upload-image.js:97 static/js/impala/users.js:51
+#: static/js/zamboni/devhub-all.js:894 static/js/zamboni/devhub-min.js:1
+msgid "Images must be either PNG or JPG."
+msgstr ""
+
+#: static/js/impala-all.js:12150 static/js/impala-min.js:7 static/js/common/upload-image.js:101 static/js/zamboni/devhub-all.js:898 static/js/zamboni/devhub-min.js:1
+msgid "Videos must be in WebM."
+msgstr ""
+
+#: static/js/impala-all.js:12177 static/js/impala-min.js:7 static/js/common/upload-addon.js:41 static/js/common/upload-image.js:128 static/js/zamboni/devhub-all.js:272
+#: static/js/zamboni/devhub-all.js:925 static/js/zamboni/devhub-min.js:1
 msgid "There was a problem contacting the server."
 msgstr ""
 
-#: static/js/common/upload-addon.js:69
+#: static/js/impala-all.js:13298 static/js/impala-min.js:7 static/js/impala/persona_creation.js:60
+msgid "All Rights Reserved"
+msgstr ""
+
+#: static/js/impala-all.js:13302 static/js/impala-min.js:7 static/js/impala/persona_creation.js:64
+msgid "Creative Commons Attribution 3.0"
+msgstr ""
+
+#: static/js/impala-all.js:13307 static/js/impala-min.js:7 static/js/impala/persona_creation.js:69
+msgid "Creative Commons Attribution-NonCommercial 3.0"
+msgstr ""
+
+#: static/js/impala-all.js:13312 static/js/impala-min.js:7 static/js/impala/persona_creation.js:74
+msgid "Creative Commons Attribution-NonCommercial-NoDerivs 3.0"
+msgstr ""
+
+#: static/js/impala-all.js:13317 static/js/impala-min.js:7 static/js/impala/persona_creation.js:79
+msgid "Creative Commons Attribution-NonCommercial-Share Alike 3.0"
+msgstr ""
+
+#: static/js/impala-all.js:13322 static/js/impala-min.js:7 static/js/impala/persona_creation.js:84
+msgid "Creative Commons Attribution-NoDerivs 3.0"
+msgstr ""
+
+#: static/js/impala-all.js:13327 static/js/impala-min.js:7 static/js/impala/persona_creation.js:89
+msgid "Creative Commons Attribution-ShareAlike 3.0"
+msgstr ""
+
+#: static/js/impala-all.js:13530 static/js/impala-min.js:7 static/js/impala/persona_creation.js:292
+msgid "Your Theme's Name"
+msgstr ""
+
+#: static/js/impala-all.js:14242 static/js/impala-min.js:8 static/js/impala/collections.js:19
+msgid "Stop Following"
+msgstr ""
+
+#: static/js/impala-all.js:14243 static/js/impala-min.js:8 static/js/impala/collections.js:20
+msgid "Following"
+msgstr ""
+
+#: static/js/impala-all.js:14313 static/js/impala-min.js:8 static/js/impala/users.js:33
+msgid "use original"
+msgstr ""
+
+#: static/js/impala-all.js:14523 static/js/impala-min.js:8 static/js/impala/search.js:114
+msgid "Updating results&hellip;"
+msgstr ""
+
+#: static/js/common/upload-addon.js:69 static/js/zamboni/devhub-all.js:300 static/js/zamboni/devhub-min.js:1
 msgid "Select a file..."
 msgstr ""
 
-#: static/js/common/upload-addon.js:70
+#: static/js/common/upload-addon.js:70 static/js/zamboni/devhub-all.js:301 static/js/zamboni/devhub-min.js:1
 msgid "Your add-on should end with .xpi, .jar or .xml"
 msgstr ""
 
 #. L10n: {0} is the percent of the file that has been uploaded.
-#: static/js/common/upload-addon.js:104
+#: static/js/common/upload-addon.js:104 static/js/zamboni/devhub-all.js:335 static/js/zamboni/devhub-min.js:1
 #, python-format
 msgid "{0}% complete"
 msgstr ""
 
 #. L10n: "{bytes uploaded} of {total filesize}".
-#: static/js/common/upload-addon.js:107
+#: static/js/common/upload-addon.js:107 static/js/zamboni/devhub-all.js:338 static/js/zamboni/devhub-min.js:1
 msgid "{0} of {1}"
 msgstr ""
 
-#: static/js/common/upload-addon.js:140
+#: static/js/common/upload-addon.js:140 static/js/zamboni/devhub-all.js:371 static/js/zamboni/devhub-min.js:1
 msgid "Cancel"
 msgstr ""
 
-#: static/js/common/upload-addon.js:162
+#: static/js/common/upload-addon.js:162 static/js/zamboni/devhub-all.js:393 static/js/zamboni/devhub-min.js:1
 msgid "Uploading {0}"
 msgstr ""
 
-#: static/js/common/upload-addon.js:189
+#: static/js/common/upload-addon.js:189 static/js/zamboni/devhub-all.js:420 static/js/zamboni/devhub-min.js:1
 msgid "Error with {0}"
 msgstr ""
 
-#: static/js/common/upload-addon.js:194
+#: static/js/common/upload-addon.js:194 static/js/zamboni/devhub-all.js:425 static/js/zamboni/devhub-min.js:1
 msgid "Your add-on failed validation with {0} error."
 msgid_plural "Your add-on failed validation with {0} errors."
 msgstr[0] ""
 msgstr[1] ""
 
-#: static/js/common/upload-addon.js:208
+#: static/js/common/upload-addon.js:208 static/js/zamboni/devhub-all.js:439 static/js/zamboni/devhub-min.js:1
 msgid "&hellip;and {0} more"
 msgid_plural "&hellip;and {0} more"
 msgstr[0] ""
 msgstr[1] ""
 
-#: static/js/common/upload-addon.js:222 static/js/common/upload-addon.js:512
+#: static/js/common/upload-addon.js:222 static/js/common/upload-addon.js:497 static/js/zamboni/devhub-all.js:453 static/js/zamboni/devhub-all.js:743 static/js/zamboni/devhub-min.js:1
 msgid "See full validation report"
 msgstr ""
 
-#: static/js/common/upload-addon.js:234
+#: static/js/common/upload-addon.js:234 static/js/zamboni/devhub-all.js:465 static/js/zamboni/devhub-min.js:1
 msgid "Validating {0}"
 msgstr ""
 
 #. L10n: first argument is an HTTP status code
-#: static/js/common/upload-addon.js:273
+#: static/js/common/upload-addon.js:273 static/js/zamboni/devhub-all.js:504 static/js/zamboni/devhub-min.js:1
 msgid "Received an empty response from the server; status: {0}"
 msgstr ""
 
-#: static/js/common/upload-addon.js:373
+#: static/js/common/upload-addon.js:370 static/js/zamboni/devhub-all.js:604 static/js/zamboni/devhub-min.js:1
 msgid "Unexpected server error while validating."
 msgstr ""
 
-#: static/js/common/upload-addon.js:412
+#: static/js/common/upload-addon.js:409 static/js/zamboni/devhub-all.js:643 static/js/zamboni/devhub-min.js:1
 msgid "Finished validating {0}"
 msgstr ""
 
-#: static/js/common/upload-addon.js:418
+#: static/js/common/upload-addon.js:415 static/js/zamboni/devhub-all.js:649 static/js/zamboni/devhub-min.js:1
 msgid "Your add-on validation timed out, it will be manually reviewed."
 msgstr ""
 
-#: static/js/common/upload-addon.js:421
+#: static/js/common/upload-addon.js:418 static/js/zamboni/devhub-all.js:652 static/js/zamboni/devhub-min.js:1
 msgid "Your add-on was validated with no errors and {0} warning."
 msgid_plural "Your add-on was validated with no errors and {0} warnings."
 msgstr[0] ""
 msgstr[1] ""
 
-#: static/js/common/upload-addon.js:426
+#: static/js/common/upload-addon.js:423 static/js/zamboni/devhub-all.js:657 static/js/zamboni/devhub-min.js:1
 msgid "Your add-on was validated with no errors and {0} message."
 msgid_plural "Your add-on was validated with no errors and {0} messages."
 msgstr[0] ""
 msgstr[1] ""
 
-#: static/js/common/upload-addon.js:431
+#: static/js/common/upload-addon.js:428 static/js/zamboni/devhub-all.js:662 static/js/zamboni/devhub-min.js:1
 msgid "Your add-on was validated with no errors or warnings."
 msgstr ""
 
-#: static/js/common/upload-addon.js:446
+#: static/js/common/upload-addon.js:443 static/js/zamboni/devhub-all.js:677 static/js/zamboni/devhub-min.js:1
 msgid "Your submission will be automatically signed."
 msgstr ""
 
-#: static/js/common/upload-addon.js:465
+#: static/js/common/upload-addon.js:450 static/js/zamboni/devhub-all.js:696 static/js/zamboni/devhub-min.js:1
 msgid "Include detailed version notes (this can be done in the next step)."
 msgstr ""
 
-#: static/js/common/upload-addon.js:466
+#: static/js/common/upload-addon.js:451 static/js/zamboni/devhub-all.js:697 static/js/zamboni/devhub-min.js:1
 msgid "If your add-on requires an account to a website in order to be fully tested, include a test username and password in the Notes to Reviewer (this can be done in the next step)."
 msgstr ""
 
-#: static/js/common/upload-addon.js:467
+#: static/js/common/upload-addon.js:452 static/js/zamboni/devhub-all.js:698 static/js/zamboni/devhub-min.js:1
 msgid "If your add-on is intended for a limited audience you should choose Preliminary Review instead of Full Review."
 msgstr ""
 
-#: static/js/common/upload-addon.js:480
+#: static/js/common/upload-addon.js:465 static/js/zamboni/devhub-all.js:711 static/js/zamboni/devhub-min.js:1
 msgid "Add-on submission checklist"
 msgstr ""
 
-#: static/js/common/upload-addon.js:481
+#: static/js/common/upload-addon.js:466 static/js/zamboni/devhub-all.js:712 static/js/zamboni/devhub-min.js:1
 msgid "Please verify the following points before finalizing your submission. This will minimize delays or misunderstanding during the review process:"
 msgstr ""
 
-#: static/js/common/upload-addon.js:483
+#: static/js/common/upload-addon.js:468 static/js/zamboni/devhub-all.js:714 static/js/zamboni/devhub-min.js:1
 msgid ""
 "Compiled binaries, as well as minified or obfuscated scripts (excluding known libraries) need to have their sources submitted separately for review. Make sure that you use the source code upload "
 "field to avoid having your submission rejected."
 msgstr ""
 
-#: static/js/common/upload-addon.js:501
+#: static/js/common/upload-addon.js:486 static/js/zamboni/devhub-all.js:732 static/js/zamboni/devhub-min.js:1
 msgid "The validation process found these issues that can lead to rejections:"
 msgstr ""
 
-#: static/js/common/upload-addon.js:518
+#: static/js/common/upload-addon.js:503 static/js/zamboni/devhub-all.js:749 static/js/zamboni/devhub-min.js:1
 msgid "If you are unfamiliar with the add-ons review process, you can read about it here."
 msgstr ""
 
-#: static/js/common/upload-addon.js:555
+#: static/js/common/upload-addon.js:540 static/js/zamboni/devhub-all.js:786 static/js/zamboni/devhub-min.js:1
 msgid "Sorry, no supported platform has been found."
 msgstr ""
 
-#: static/js/common/upload-base.js:57
+#: static/js/common/upload-base.js:57 static/js/zamboni/devhub-all.js:187 static/js/zamboni/devhub-min.js:1
 msgid "The filetype you uploaded isn't recognized."
 msgstr ""
 
-#: static/js/common/upload-base.js:79
+#: static/js/common/upload-base.js:79 static/js/zamboni/devhub-all.js:209 static/js/zamboni/devhub-min.js:1
 msgid "You cancelled the upload."
 msgstr ""
 
-#: static/js/common/upload-image.js:97 static/js/impala/users.js:51
-msgid "Images must be either PNG or JPG."
-msgstr ""
-
-#: static/js/common/upload-image.js:101
-msgid "Videos must be in WebM."
-msgstr ""
-
-#: static/js/impala/collections.js:10 static/js/zamboni/collections.js:595
-msgid "Follow this Collection"
-msgstr ""
-
-#: static/js/impala/collections.js:19
-msgid "Stop Following"
-msgstr ""
-
-#: static/js/impala/collections.js:20
-msgid "Following"
-msgstr ""
-
-#. L10n: {0} is an app name.
-#: static/js/impala/listing.js:11 static/js/zamboni/themes.js:13
-msgid "This theme is incompatible with your version of {0}"
-msgstr ""
-
-#: static/js/impala/persona_creation.js:60
-msgid "All Rights Reserved"
-msgstr ""
-
-#: static/js/impala/persona_creation.js:64
-msgid "Creative Commons Attribution 3.0"
-msgstr ""
-
-#: static/js/impala/persona_creation.js:69
-msgid "Creative Commons Attribution-NonCommercial 3.0"
-msgstr ""
-
-#: static/js/impala/persona_creation.js:74
-msgid "Creative Commons Attribution-NonCommercial-NoDerivs 3.0"
-msgstr ""
-
-#: static/js/impala/persona_creation.js:79
-msgid "Creative Commons Attribution-NonCommercial-Share Alike 3.0"
-msgstr ""
-
-#: static/js/impala/persona_creation.js:84
-msgid "Creative Commons Attribution-NoDerivs 3.0"
-msgstr ""
-
-#: static/js/impala/persona_creation.js:89
-msgid "Creative Commons Attribution-ShareAlike 3.0"
-msgstr ""
-
-#: static/js/impala/persona_creation.js:292
-msgid "Your Theme's Name"
-msgstr ""
-
-#: static/js/impala/reviews.js:23 static/js/zamboni/reviews.js:18
-msgid "Flagged for review"
-msgstr ""
-
-#: static/js/impala/reviews.js:40 static/js/zamboni/reviews.js:34
-msgid "Your input is required"
-msgstr ""
-
-#: static/js/impala/reviews.js:152 static/js/zamboni/reviews.js:103
-msgid "Marked for deletion"
-msgstr ""
-
-#: static/js/impala/search.js:114
-msgid "Updating results&hellip;"
-msgstr ""
-
-#: static/js/impala/site_suggestions.js:46
-msgid "Category"
-msgstr ""
-
-#: static/js/impala/suggestions.js:39
-msgid "Search themes for <b>{0}</b>"
-msgstr ""
-
-#: static/js/impala/suggestions.js:41
-msgid "Search apps for <b>{0}</b>"
-msgstr ""
-
-#: static/js/impala/suggestions.js:43
-msgid "Search add-ons for <b>{0}</b>"
-msgstr ""
-
-#: static/js/impala/users.js:33
-msgid "use original"
-msgstr ""
-
-#: static/js/impala/stats/chart.js:267
+#: static/js/impala/stats/chart.js:267 static/js/zamboni/stats-all.js:16898 static/js/zamboni/stats-min.js:5
 msgid "Week of {0}"
 msgstr ""
 
-#: static/js/impala/stats/chart.js:269
+#: static/js/impala/stats/chart.js:269 static/js/zamboni/stats-all.js:16900 static/js/zamboni/stats-min.js:5
 msgid " downloads"
 msgstr ""
 
-#: static/js/impala/stats/chart.js:270
+#: static/js/impala/stats/chart.js:270 static/js/zamboni/stats-all.js:16901 static/js/zamboni/stats-min.js:5
 msgid "{0} users"
 msgstr ""
 
-#: static/js/impala/stats/chart.js:271
+#: static/js/impala/stats/chart.js:271 static/js/zamboni/stats-all.js:16902 static/js/zamboni/stats-min.js:5
 msgid "{0} add-ons"
 msgstr ""
 
-#: static/js/impala/stats/chart.js:272
+#: static/js/impala/stats/chart.js:272 static/js/zamboni/stats-all.js:16903 static/js/zamboni/stats-min.js:5
 msgid "{0} collections"
 msgstr ""
 
-#: static/js/impala/stats/chart.js:273
+#: static/js/impala/stats/chart.js:273 static/js/zamboni/stats-all.js:16904 static/js/zamboni/stats-min.js:5
 msgid "{0} reviews"
 msgstr ""
 
-#: static/js/impala/stats/chart.js:275
+#: static/js/impala/stats/chart.js:275 static/js/zamboni/stats-all.js:16906 static/js/zamboni/stats-min.js:5
 msgid "{0} sales"
 msgstr ""
 
-#: static/js/impala/stats/chart.js:276
+#: static/js/impala/stats/chart.js:276 static/js/zamboni/stats-all.js:16907 static/js/zamboni/stats-min.js:5
 msgid "{0} refunds"
 msgstr ""
 
-#: static/js/impala/stats/chart.js:277
+#: static/js/impala/stats/chart.js:277 static/js/zamboni/stats-all.js:16908 static/js/zamboni/stats-min.js:5
 msgid "{0} installs"
 msgstr ""
 
-#: static/js/impala/stats/chart.js:369 static/js/impala/stats/csv_keys.js:3 static/js/impala/stats/csv_keys.js:109
+#: static/js/impala/stats/chart.js:369 static/js/impala/stats/csv_keys.js:3 static/js/impala/stats/csv_keys.js:109 static/js/zamboni/stats-all.js:15284 static/js/zamboni/stats-all.js:15390
+#: static/js/zamboni/stats-all.js:17000 static/js/zamboni/stats-min.js:4 static/js/zamboni/stats-min.js:5
 msgid "Downloads"
 msgstr ""
 
-#: static/js/impala/stats/chart.js:379 static/js/impala/stats/csv_keys.js:6 static/js/impala/stats/csv_keys.js:110
+#: static/js/impala/stats/chart.js:379 static/js/impala/stats/csv_keys.js:6 static/js/impala/stats/csv_keys.js:110 static/js/zamboni/stats-all.js:15287 static/js/zamboni/stats-all.js:15391
+#: static/js/zamboni/stats-all.js:17010 static/js/zamboni/stats-min.js:4 static/js/zamboni/stats-min.js:5
 msgid "Daily Users"
 msgstr ""
 
-#: static/js/impala/stats/chart.js:410
+#: static/js/impala/stats/chart.js:410 static/js/zamboni/stats-all.js:17041 static/js/zamboni/stats-min.js:5
 msgid "Amount, in USD"
 msgstr ""
 
-#: static/js/impala/stats/chart.js:421 static/js/impala/stats/csv_keys.js:104
+#: static/js/impala/stats/chart.js:421 static/js/impala/stats/csv_keys.js:104 static/js/zamboni/stats-all.js:15385 static/js/zamboni/stats-all.js:17052 static/js/zamboni/stats-min.js:5
 msgid "Number of Contributions"
 msgstr ""
 
-#: static/js/impala/stats/chart.js:447
+#: static/js/impala/stats/chart.js:447 static/js/zamboni/stats-all.js:17078 static/js/zamboni/stats-min.js:5
 msgid "More Info..."
 msgstr ""
 
 #. L10n: {0} is an ISO-formatted date.
-#: static/js/impala/stats/chart.js:451
+#: static/js/impala/stats/chart.js:451 static/js/zamboni/stats-all.js:17082 static/js/zamboni/stats-min.js:5
 msgid "Details for {0}"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:9
+#: static/js/impala/stats/csv_keys.js:9 static/js/zamboni/stats-all.js:15290 static/js/zamboni/stats-min.js:4
 msgid "Collections Created"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:12
+#: static/js/impala/stats/csv_keys.js:12 static/js/zamboni/stats-all.js:15293 static/js/zamboni/stats-min.js:4
 msgid "Add-ons in Use"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:15
+#: static/js/impala/stats/csv_keys.js:15 static/js/zamboni/stats-all.js:15296 static/js/zamboni/stats-min.js:4
 msgid "Add-ons Created"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:18
+#: static/js/impala/stats/csv_keys.js:18 static/js/zamboni/stats-all.js:15299 static/js/zamboni/stats-min.js:4
 msgid "Add-ons Downloaded"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:21
+#: static/js/impala/stats/csv_keys.js:21 static/js/zamboni/stats-all.js:15302 static/js/zamboni/stats-min.js:4
 msgid "Add-ons Updated"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:24
+#: static/js/impala/stats/csv_keys.js:24 static/js/zamboni/stats-all.js:15305 static/js/zamboni/stats-min.js:4
 msgid "Reviews Written"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:27
+#: static/js/impala/stats/csv_keys.js:27 static/js/zamboni/stats-all.js:15308 static/js/zamboni/stats-min.js:4
 msgid "User Signups"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:30
+#: static/js/impala/stats/csv_keys.js:30 static/js/zamboni/stats-all.js:15311 static/js/zamboni/stats-min.js:4
 msgid "Subscribers"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:33
+#: static/js/impala/stats/csv_keys.js:33 static/js/zamboni/stats-all.js:15314 static/js/zamboni/stats-min.js:4
 msgid "Ratings"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:36 static/js/impala/stats/csv_keys.js:114
+#: static/js/impala/stats/csv_keys.js:36 static/js/impala/stats/csv_keys.js:114 static/js/zamboni/stats-all.js:15317 static/js/zamboni/stats-all.js:15395 static/js/zamboni/stats-min.js:4
+#: static/js/zamboni/stats-min.js:5
 msgid "Sales"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:39 static/js/impala/stats/csv_keys.js:113
+#: static/js/impala/stats/csv_keys.js:39 static/js/impala/stats/csv_keys.js:113 static/js/zamboni/stats-all.js:15320 static/js/zamboni/stats-all.js:15394 static/js/zamboni/stats-min.js:4
+#: static/js/zamboni/stats-min.js:5
 msgid "Installs"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:42
+#: static/js/impala/stats/csv_keys.js:42 static/js/zamboni/stats-all.js:15323 static/js/zamboni/stats-min.js:4
 msgid "Unknown"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:43
+#: static/js/impala/stats/csv_keys.js:43 static/js/zamboni/stats-all.js:15324 static/js/zamboni/stats-min.js:4
 msgid "Add-ons Manager"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:44
+#: static/js/impala/stats/csv_keys.js:44 static/js/zamboni/stats-all.js:15325 static/js/zamboni/stats-min.js:4
 msgid "Add-ons Manager Promo"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:45
+#: static/js/impala/stats/csv_keys.js:45 static/js/zamboni/stats-all.js:15326 static/js/zamboni/stats-min.js:4
 msgid "Add-ons Manager Featured"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:46
+#: static/js/impala/stats/csv_keys.js:46 static/js/zamboni/stats-all.js:15327 static/js/zamboni/stats-min.js:4
 msgid "Add-ons Manager Learn More"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:47
+#: static/js/impala/stats/csv_keys.js:47 static/js/zamboni/stats-all.js:15328 static/js/zamboni/stats-min.js:4
 msgid "Search Suggestions"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:48
+#: static/js/impala/stats/csv_keys.js:48 static/js/zamboni/stats-all.js:15329 static/js/zamboni/stats-min.js:4
 msgid "Search Results"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:49 static/js/impala/stats/csv_keys.js:50 static/js/impala/stats/csv_keys.js:51
+#: static/js/impala/stats/csv_keys.js:49 static/js/impala/stats/csv_keys.js:50 static/js/impala/stats/csv_keys.js:51 static/js/zamboni/stats-all.js:15330 static/js/zamboni/stats-all.js:15331
+#: static/js/zamboni/stats-all.js:15332 static/js/zamboni/stats-min.js:4
 msgid "Homepage Promo"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:52 static/js/impala/stats/csv_keys.js:53
+#: static/js/impala/stats/csv_keys.js:52 static/js/impala/stats/csv_keys.js:53 static/js/zamboni/stats-all.js:15333 static/js/zamboni/stats-all.js:15334 static/js/zamboni/stats-min.js:4
 msgid "Homepage Featured"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:54 static/js/impala/stats/csv_keys.js:55
+#: static/js/impala/stats/csv_keys.js:54 static/js/impala/stats/csv_keys.js:55 static/js/zamboni/stats-all.js:15335 static/js/zamboni/stats-all.js:15336 static/js/zamboni/stats-min.js:4
 msgid "Homepage Up and Coming"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:56
+#: static/js/impala/stats/csv_keys.js:56 static/js/zamboni/stats-all.js:15337 static/js/zamboni/stats-min.js:4
 msgid "Homepage Most Popular"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:57 static/js/impala/stats/csv_keys.js:59
+#: static/js/impala/stats/csv_keys.js:57 static/js/impala/stats/csv_keys.js:59 static/js/zamboni/stats-all.js:15338 static/js/zamboni/stats-all.js:15340 static/js/zamboni/stats-min.js:4
 msgid "Detail Page"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:58 static/js/impala/stats/csv_keys.js:60
+#: static/js/impala/stats/csv_keys.js:58 static/js/impala/stats/csv_keys.js:60 static/js/zamboni/stats-all.js:15339 static/js/zamboni/stats-all.js:15341 static/js/zamboni/stats-min.js:4
 msgid "Detail Page (bottom)"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:61
+#: static/js/impala/stats/csv_keys.js:61 static/js/zamboni/stats-all.js:15342 static/js/zamboni/stats-min.js:4
 msgid "Detail Page (Development Channel)"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:62 static/js/impala/stats/csv_keys.js:63 static/js/impala/stats/csv_keys.js:64
+#: static/js/impala/stats/csv_keys.js:62 static/js/impala/stats/csv_keys.js:63 static/js/impala/stats/csv_keys.js:64 static/js/zamboni/stats-all.js:15343 static/js/zamboni/stats-all.js:15344
+#: static/js/zamboni/stats-all.js:15345 static/js/zamboni/stats-min.js:4
 msgid "Often Used With"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:65 static/js/impala/stats/csv_keys.js:66
+#: static/js/impala/stats/csv_keys.js:65 static/js/impala/stats/csv_keys.js:66 static/js/zamboni/stats-all.js:15346 static/js/zamboni/stats-all.js:15347 static/js/zamboni/stats-min.js:4
 msgid "Others By Author"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:67 static/js/impala/stats/csv_keys.js:68
+#: static/js/impala/stats/csv_keys.js:67 static/js/impala/stats/csv_keys.js:68 static/js/zamboni/stats-all.js:15348 static/js/zamboni/stats-all.js:15349 static/js/zamboni/stats-min.js:4
 msgid "Dependencies"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:69 static/js/impala/stats/csv_keys.js:70
+#: static/js/impala/stats/csv_keys.js:69 static/js/impala/stats/csv_keys.js:70 static/js/zamboni/stats-all.js:15350 static/js/zamboni/stats-all.js:15351 static/js/zamboni/stats-min.js:4
 msgid "Upsell"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:71
+#: static/js/impala/stats/csv_keys.js:71 static/js/zamboni/stats-all.js:15352 static/js/zamboni/stats-min.js:4
 msgid "Meet the Developer"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:72
+#: static/js/impala/stats/csv_keys.js:72 static/js/zamboni/stats-all.js:15353 static/js/zamboni/stats-min.js:4
 msgid "User Profile"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:73
+#: static/js/impala/stats/csv_keys.js:73 static/js/zamboni/stats-all.js:15354 static/js/zamboni/stats-min.js:4
 msgid "Version History"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:75
+#: static/js/impala/stats/csv_keys.js:75 static/js/zamboni/stats-all.js:15356 static/js/zamboni/stats-min.js:4
 msgid "Sharing"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:76
+#: static/js/impala/stats/csv_keys.js:76 static/js/zamboni/stats-all.js:15357 static/js/zamboni/stats-min.js:4
 msgid "Category Pages"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:77
+#: static/js/impala/stats/csv_keys.js:77 static/js/zamboni/stats-all.js:15358 static/js/zamboni/stats-min.js:4
 msgid "Collections"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:78 static/js/impala/stats/csv_keys.js:79
+#: static/js/impala/stats/csv_keys.js:78 static/js/impala/stats/csv_keys.js:79 static/js/zamboni/stats-all.js:15359 static/js/zamboni/stats-all.js:15360 static/js/zamboni/stats-min.js:4
 msgid "Category Landing Featured Carousel"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:80 static/js/impala/stats/csv_keys.js:81
+#: static/js/impala/stats/csv_keys.js:80 static/js/impala/stats/csv_keys.js:81 static/js/zamboni/stats-all.js:15361 static/js/zamboni/stats-all.js:15362 static/js/zamboni/stats-min.js:4
 msgid "Category Landing Top Rated"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:82 static/js/impala/stats/csv_keys.js:83
+#: static/js/impala/stats/csv_keys.js:82 static/js/impala/stats/csv_keys.js:83 static/js/zamboni/stats-all.js:15363 static/js/zamboni/stats-all.js:15364 static/js/zamboni/stats-min.js:5
 msgid "Category Landing Most Popular"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:84 static/js/impala/stats/csv_keys.js:85
+#: static/js/impala/stats/csv_keys.js:84 static/js/impala/stats/csv_keys.js:85 static/js/zamboni/stats-all.js:15365 static/js/zamboni/stats-all.js:15366 static/js/zamboni/stats-min.js:5
 msgid "Category Landing Recently Added"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:86 static/js/impala/stats/csv_keys.js:87
+#: static/js/impala/stats/csv_keys.js:86 static/js/impala/stats/csv_keys.js:87 static/js/zamboni/stats-all.js:15367 static/js/zamboni/stats-all.js:15368 static/js/zamboni/stats-min.js:5
 msgid "Browse Listing Featured Sort"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:88 static/js/impala/stats/csv_keys.js:89
+#: static/js/impala/stats/csv_keys.js:88 static/js/impala/stats/csv_keys.js:89 static/js/zamboni/stats-all.js:15369 static/js/zamboni/stats-all.js:15370 static/js/zamboni/stats-min.js:5
 msgid "Browse Listing Users Sort"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:90 static/js/impala/stats/csv_keys.js:91
+#: static/js/impala/stats/csv_keys.js:90 static/js/impala/stats/csv_keys.js:91 static/js/zamboni/stats-all.js:15371 static/js/zamboni/stats-all.js:15372 static/js/zamboni/stats-min.js:5
 msgid "Browse Listing Rating Sort"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:92 static/js/impala/stats/csv_keys.js:93
+#: static/js/impala/stats/csv_keys.js:92 static/js/impala/stats/csv_keys.js:93 static/js/zamboni/stats-all.js:15373 static/js/zamboni/stats-all.js:15374 static/js/zamboni/stats-min.js:5
 msgid "Browse Listing Created Sort"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:94 static/js/impala/stats/csv_keys.js:95
+#: static/js/impala/stats/csv_keys.js:94 static/js/impala/stats/csv_keys.js:95 static/js/zamboni/stats-all.js:15375 static/js/zamboni/stats-all.js:15376 static/js/zamboni/stats-min.js:5
 msgid "Browse Listing Name Sort"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:96 static/js/impala/stats/csv_keys.js:97
+#: static/js/impala/stats/csv_keys.js:96 static/js/impala/stats/csv_keys.js:97 static/js/zamboni/stats-all.js:15377 static/js/zamboni/stats-all.js:15378 static/js/zamboni/stats-min.js:5
 msgid "Browse Listing Popular Sort"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:98 static/js/impala/stats/csv_keys.js:99
+#: static/js/impala/stats/csv_keys.js:98 static/js/impala/stats/csv_keys.js:99 static/js/zamboni/stats-all.js:15379 static/js/zamboni/stats-all.js:15380 static/js/zamboni/stats-min.js:5
 msgid "Browse Listing Updated Sort"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:100 static/js/impala/stats/csv_keys.js:101
+#: static/js/impala/stats/csv_keys.js:100 static/js/impala/stats/csv_keys.js:101 static/js/zamboni/stats-all.js:15381 static/js/zamboni/stats-all.js:15382 static/js/zamboni/stats-min.js:5
 msgid "Browse Listing Up and Coming Sort"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:105
+#: static/js/impala/stats/csv_keys.js:105 static/js/zamboni/stats-all.js:15386 static/js/zamboni/stats-min.js:5
 msgid "Total Amount Contributed"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:106
+#: static/js/impala/stats/csv_keys.js:106 static/js/zamboni/stats-all.js:15387 static/js/zamboni/stats-min.js:5
 msgid "Average Contribution"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:115
+#: static/js/impala/stats/csv_keys.js:115 static/js/zamboni/stats-all.js:15396 static/js/zamboni/stats-min.js:5
 msgid "Usage"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:118
+#: static/js/impala/stats/csv_keys.js:118 static/js/zamboni/stats-all.js:15399 static/js/zamboni/stats-min.js:5
 msgid "Firefox"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:119
+#: static/js/impala/stats/csv_keys.js:119 static/js/zamboni/stats-all.js:15400 static/js/zamboni/stats-min.js:5
 msgid "Mozilla"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:120
+#: static/js/impala/stats/csv_keys.js:120 static/js/zamboni/stats-all.js:15401 static/js/zamboni/stats-min.js:5
 msgid "Thunderbird"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:121
+#: static/js/impala/stats/csv_keys.js:121 static/js/zamboni/stats-all.js:15402 static/js/zamboni/stats-min.js:5
 msgid "Sunbird"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:122
+#: static/js/impala/stats/csv_keys.js:122 static/js/zamboni/stats-all.js:15403 static/js/zamboni/stats-min.js:5
 msgid "SeaMonkey"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:123
+#: static/js/impala/stats/csv_keys.js:123 static/js/zamboni/stats-all.js:15404 static/js/zamboni/stats-min.js:5
 msgid "Fennec"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:124
+#: static/js/impala/stats/csv_keys.js:124 static/js/zamboni/stats-all.js:15405 static/js/zamboni/stats-min.js:5
 msgid "Android"
 msgstr ""
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:129
+#: static/js/impala/stats/csv_keys.js:129 static/js/zamboni/stats-all.js:15410 static/js/zamboni/stats-min.js:5
 msgid "Downloads and Daily Users, last {0} days"
 msgstr ""
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:131
+#: static/js/impala/stats/csv_keys.js:131 static/js/zamboni/stats-all.js:15412 static/js/zamboni/stats-min.js:5
 msgid "Downloads and Daily Users from {0} to {1}"
 msgstr ""
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:135
+#: static/js/impala/stats/csv_keys.js:135 static/js/zamboni/stats-all.js:15416 static/js/zamboni/stats-min.js:5
 msgid "Installs and Daily Users, last {0} days"
 msgstr ""
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:137
+#: static/js/impala/stats/csv_keys.js:137 static/js/zamboni/stats-all.js:15418 static/js/zamboni/stats-min.js:5
 msgid "Installs and Daily Users from {0} to {1}"
 msgstr ""
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:141
+#: static/js/impala/stats/csv_keys.js:141 static/js/zamboni/stats-all.js:15422 static/js/zamboni/stats-min.js:5
 msgid "Downloads, last {0} days"
 msgstr ""
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:143
+#: static/js/impala/stats/csv_keys.js:143 static/js/zamboni/stats-all.js:15424 static/js/zamboni/stats-min.js:5
 msgid "Downloads from {0} to {1}"
 msgstr ""
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:147
+#: static/js/impala/stats/csv_keys.js:147 static/js/zamboni/stats-all.js:15428 static/js/zamboni/stats-min.js:5
 msgid "Daily Users, last {0} days"
 msgstr ""
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:149
+#: static/js/impala/stats/csv_keys.js:149 static/js/zamboni/stats-all.js:15430 static/js/zamboni/stats-min.js:5
 msgid "Daily Users from {0} to {1}"
 msgstr ""
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:153
+#: static/js/impala/stats/csv_keys.js:153 static/js/zamboni/stats-all.js:15434 static/js/zamboni/stats-min.js:5
 msgid "Applications, last {0} days"
 msgstr ""
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:155
+#: static/js/impala/stats/csv_keys.js:155 static/js/zamboni/stats-all.js:15436 static/js/zamboni/stats-min.js:5
 msgid "Applications from {0} to {1}"
 msgstr ""
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:159
+#: static/js/impala/stats/csv_keys.js:159 static/js/zamboni/stats-all.js:15440 static/js/zamboni/stats-min.js:5
 msgid "Platforms, last {0} days"
 msgstr ""
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:161
+#: static/js/impala/stats/csv_keys.js:161 static/js/zamboni/stats-all.js:15442 static/js/zamboni/stats-min.js:5
 msgid "Platforms from {0} to {1}"
 msgstr ""
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:165
+#: static/js/impala/stats/csv_keys.js:165 static/js/zamboni/stats-all.js:15446 static/js/zamboni/stats-min.js:5
 msgid "Languages, last {0} days"
 msgstr ""
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:167
+#: static/js/impala/stats/csv_keys.js:167 static/js/zamboni/stats-all.js:15448 static/js/zamboni/stats-min.js:5
 msgid "Languages from {0} to {1}"
 msgstr ""
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:171
+#: static/js/impala/stats/csv_keys.js:171 static/js/zamboni/stats-all.js:15452 static/js/zamboni/stats-min.js:5
 msgid "Add-on Versions, last {0} days"
 msgstr ""
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:173
+#: static/js/impala/stats/csv_keys.js:173 static/js/zamboni/stats-all.js:15454 static/js/zamboni/stats-min.js:5
 msgid "Add-on Versions from {0} to {1}"
 msgstr ""
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:177
+#: static/js/impala/stats/csv_keys.js:177 static/js/zamboni/stats-all.js:15458 static/js/zamboni/stats-min.js:5
 msgid "Add-on Status, last {0} days"
 msgstr ""
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:179
+#: static/js/impala/stats/csv_keys.js:179 static/js/zamboni/stats-all.js:15460 static/js/zamboni/stats-min.js:5
 msgid "Add-on Status from {0} to {1}"
 msgstr ""
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:183
+#: static/js/impala/stats/csv_keys.js:183 static/js/zamboni/stats-all.js:15464 static/js/zamboni/stats-min.js:5
 msgid "Download Sources, last {0} days"
 msgstr ""
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:185
+#: static/js/impala/stats/csv_keys.js:185 static/js/zamboni/stats-all.js:15466 static/js/zamboni/stats-min.js:5
 msgid "Download Sources from {0} to {1}"
 msgstr ""
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:189
+#: static/js/impala/stats/csv_keys.js:189 static/js/zamboni/stats-all.js:15470 static/js/zamboni/stats-min.js:5
 msgid "Contributions, last {0} days"
 msgstr ""
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:191
+#: static/js/impala/stats/csv_keys.js:191 static/js/zamboni/stats-all.js:15472 static/js/zamboni/stats-min.js:5
 msgid "Contributions from {0} to {1}"
 msgstr ""
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:195
+#: static/js/impala/stats/csv_keys.js:195 static/js/zamboni/stats-all.js:15476 static/js/zamboni/stats-min.js:5
 msgid "Site Metrics, last {0} days"
 msgstr ""
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:197
+#: static/js/impala/stats/csv_keys.js:197 static/js/zamboni/stats-all.js:15478 static/js/zamboni/stats-min.js:5
 msgid "Site Metrics from {0} to {1}"
 msgstr ""
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:201
+#: static/js/impala/stats/csv_keys.js:201 static/js/zamboni/stats-all.js:15482 static/js/zamboni/stats-min.js:5
 msgid "Add-ons in Use, last {0} days"
 msgstr ""
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:203
+#: static/js/impala/stats/csv_keys.js:203 static/js/zamboni/stats-all.js:15484 static/js/zamboni/stats-min.js:5
 msgid "Add-ons in Use from {0} to {1}"
 msgstr ""
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:207
+#: static/js/impala/stats/csv_keys.js:207 static/js/zamboni/stats-all.js:15488 static/js/zamboni/stats-min.js:5
 msgid "Add-ons Downloaded, last {0} days"
 msgstr ""
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:209
+#: static/js/impala/stats/csv_keys.js:209 static/js/zamboni/stats-all.js:15490 static/js/zamboni/stats-min.js:5
 msgid "Add-ons Downloaded from {0} to {1}"
 msgstr ""
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:213
+#: static/js/impala/stats/csv_keys.js:213 static/js/zamboni/stats-all.js:15494 static/js/zamboni/stats-min.js:5
 msgid "Add-ons Created, last {0} days"
 msgstr ""
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:215
+#: static/js/impala/stats/csv_keys.js:215 static/js/zamboni/stats-all.js:15496 static/js/zamboni/stats-min.js:5
 msgid "Add-ons Created from {0} to {1}"
 msgstr ""
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:219
+#: static/js/impala/stats/csv_keys.js:219 static/js/zamboni/stats-all.js:15500 static/js/zamboni/stats-min.js:5
 msgid "Add-ons Updated, last {0} days"
 msgstr ""
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:221
+#: static/js/impala/stats/csv_keys.js:221 static/js/zamboni/stats-all.js:15502 static/js/zamboni/stats-min.js:5
 msgid "Add-ons Updated from {0} to {1}"
 msgstr ""
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:225
+#: static/js/impala/stats/csv_keys.js:225 static/js/zamboni/stats-all.js:15506 static/js/zamboni/stats-min.js:5
 msgid "Reviews Written, last {0} days"
 msgstr ""
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:227
+#: static/js/impala/stats/csv_keys.js:227 static/js/zamboni/stats-all.js:15508 static/js/zamboni/stats-min.js:5
 msgid "Reviews Written from {0} to {1}"
 msgstr ""
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:231
+#: static/js/impala/stats/csv_keys.js:231 static/js/zamboni/stats-all.js:15512 static/js/zamboni/stats-min.js:5
 msgid "User Signups, last {0} days"
 msgstr ""
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:233
+#: static/js/impala/stats/csv_keys.js:233 static/js/zamboni/stats-all.js:15514 static/js/zamboni/stats-min.js:5
 msgid "User Signups from {0} to {1}"
 msgstr ""
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:237
+#: static/js/impala/stats/csv_keys.js:237 static/js/zamboni/stats-all.js:15518 static/js/zamboni/stats-min.js:5
 msgid "Collections Created, last {0} days"
 msgstr ""
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:239
+#: static/js/impala/stats/csv_keys.js:239 static/js/zamboni/stats-all.js:15520 static/js/zamboni/stats-min.js:5
 msgid "Collections Created from {0} to {1}"
 msgstr ""
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:243
+#: static/js/impala/stats/csv_keys.js:243 static/js/zamboni/stats-all.js:15524 static/js/zamboni/stats-min.js:5
 msgid "Subscribers, last {0} days"
 msgstr ""
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:245
+#: static/js/impala/stats/csv_keys.js:245 static/js/zamboni/stats-all.js:15526 static/js/zamboni/stats-min.js:5
 msgid "Subscribers from {0} to {1}"
 msgstr ""
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:249
+#: static/js/impala/stats/csv_keys.js:249 static/js/zamboni/stats-all.js:15530 static/js/zamboni/stats-min.js:5
 msgid "Ratings, last {0} days"
 msgstr ""
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:251
+#: static/js/impala/stats/csv_keys.js:251 static/js/zamboni/stats-all.js:15532 static/js/zamboni/stats-min.js:5
 msgid "Ratings from {0} to {1}"
 msgstr ""
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:255
+#: static/js/impala/stats/csv_keys.js:255 static/js/zamboni/stats-all.js:15536 static/js/zamboni/stats-min.js:5
 msgid "Sales, last {0} days"
 msgstr ""
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:257
+#: static/js/impala/stats/csv_keys.js:257 static/js/zamboni/stats-all.js:15538 static/js/zamboni/stats-min.js:5
 msgid "Sales from {0} to {1}"
 msgstr ""
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:261
+#: static/js/impala/stats/csv_keys.js:261 static/js/zamboni/stats-all.js:15542 static/js/zamboni/stats-min.js:5
 msgid "Installs, last {0} days"
 msgstr ""
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:263
+#: static/js/impala/stats/csv_keys.js:263 static/js/zamboni/stats-all.js:15544 static/js/zamboni/stats-min.js:5
 msgid "Installs from {0} to {1}"
 msgstr ""
 
 #. L10n: {0} and {1} are integers.
-#: static/js/impala/stats/csv_keys.js:269
+#: static/js/impala/stats/csv_keys.js:269 static/js/zamboni/stats-all.js:15550 static/js/zamboni/stats-min.js:5
 msgid "<b>{0}</b> in last {1} days"
 msgstr ""
 
 #. L10n: {0} is an integer and {1} and {2} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:271 static/js/impala/stats/csv_keys.js:277
+#: static/js/impala/stats/csv_keys.js:271 static/js/impala/stats/csv_keys.js:277 static/js/zamboni/stats-all.js:15552 static/js/zamboni/stats-all.js:15558 static/js/zamboni/stats-min.js:5
 msgid "<b>{0}</b> from {1} to {2}"
 msgstr ""
 
 #. L10n: {0} and {1} are integers.
-#: static/js/impala/stats/csv_keys.js:275
+#: static/js/impala/stats/csv_keys.js:275 static/js/zamboni/stats-all.js:15556 static/js/zamboni/stats-min.js:5
 msgid "<b>{0}</b> average in last {1} days"
 msgstr ""
 
-#: static/js/impala/stats/overview.js:19
+#: static/js/impala/stats/overview.js:19 static/js/zamboni/stats-all.js:16469 static/js/zamboni/stats-min.js:5
 msgid "No data available."
 msgstr ""
 
-#: static/js/impala/stats/table.js:74
+#: static/js/impala/stats/table.js:74 static/js/zamboni/stats-all.js:17209 static/js/zamboni/stats-min.js:5
 msgid "Date"
 msgstr ""
 
-#: static/js/impala/stats/topchart.js:96
+#: static/js/impala/stats/topchart.js:96 static/js/zamboni/stats-all.js:16600 static/js/zamboni/stats-min.js:5
 msgid "Other"
 msgstr ""
 
-#: static/js/zamboni/admin_validation.js:24 static/js/zamboni/devhub.js:1229 static/js/zamboni/editors.js:295
+#: static/js/zamboni/admin-all.js:180 static/js/zamboni/admin-min.js:1 static/js/zamboni/admin_validation.js:24 static/js/zamboni/devhub-all.js:2408 static/js/zamboni/devhub-min.js:2
+#: static/js/zamboni/devhub.js:1229 static/js/zamboni/editors-all.js:15576 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:295
 msgid "Select an application first"
 msgstr ""
 
-#: static/js/zamboni/admin_validation.js:51
+#: static/js/zamboni/admin-all.js:207 static/js/zamboni/admin-min.js:1 static/js/zamboni/admin_validation.js:51
 msgid "Set {0} add-on to a max version of {1} and email the author."
 msgid_plural "Set {0} add-ons to a max version of {1} and email the authors."
 msgstr[0] ""
 msgstr[1] ""
 
-#: static/js/zamboni/admin_validation.js:54
+#: static/js/zamboni/admin-all.js:210 static/js/zamboni/admin-min.js:1 static/js/zamboni/admin_validation.js:54
 msgid "Email author of {2} add-on which failed validation."
 msgid_plural "Email authors of {2} add-ons which failed validation."
 msgstr[0] ""
 msgstr[1] ""
 
-#. L10n: {0} is an app name like Firefox.
-#: static/js/zamboni/buttons.js:66
-msgid "Accept and Install"
-msgstr ""
-
-#: static/js/zamboni/buttons.js:66
-msgid "Add to {0}"
-msgstr ""
-
-#: static/js/zamboni/buttons.js:71
-msgid "Download Now"
-msgstr ""
-
-#: static/js/zamboni/buttons.js:112
-msgid "Add-on has not been updated to support default-to-compatible."
-msgstr ""
-
-#: static/js/zamboni/buttons.js:117
-msgid "You need to be using Firefox 10.0 or higher."
-msgstr ""
-
-#: static/js/zamboni/buttons.js:129
-msgid "Mozilla has marked this version as incompatible with your Firefox version."
-msgstr ""
-
-#. L10n: {0} is an platform like Windows or Linux.
-#: static/js/zamboni/buttons.js:210
-msgid "Install for {0} anyway"
-msgstr ""
-
-#: static/js/zamboni/buttons.js:210
-msgid "Download for {0} anyway"
-msgstr ""
-
-#: static/js/zamboni/buttons.js:267
-msgid "Not available for your platform"
-msgstr ""
-
-#. L10n: {0} is an app name, {1} is the app version.
-#: static/js/zamboni/buttons.js:278 static/js/zamboni/buttons.js:315
-msgid "Not available for {0} {1}"
-msgstr ""
-
-#: static/js/zamboni/buttons.js:341
-msgid "Works with {app} {min} - {max}"
-msgstr ""
-
-#: static/js/zamboni/buttons.js:343
-msgid "View other versions"
-msgstr ""
-
-#: static/js/zamboni/buttons.js:391
-msgid "Only with Firefox — Get Firefox Now!"
-msgstr ""
-
-#: static/js/zamboni/buttons.js:507 static/js/zamboni/mobile/buttons.js:43
-msgid "Sorry, you need a Mozilla-based browser (such as Firefox) to install a search plugin."
-msgstr ""
-
-#: static/js/zamboni/collections.js:229
-msgid "Adding to Favorites&hellip;"
-msgstr ""
-
-#: static/js/zamboni/collections.js:232
-msgid "Removing Favorite&hellip;"
-msgstr ""
-
-#: static/js/zamboni/collections.js:235
-msgid "Add to Favorites"
-msgstr ""
-
-#: static/js/zamboni/collections.js:238
-msgid "Remove from Favorites"
-msgstr ""
-
-#: static/js/zamboni/collections.js:303
-msgid "Pending"
-msgstr ""
-
-#: static/js/zamboni/collections.js:304
-msgid "Add a comment"
-msgstr ""
-
-#: static/js/zamboni/collections.js:304
-msgid "Comment"
-msgstr ""
-
-#: static/js/zamboni/collections.js:305
-msgid "Remove this add-on from the collection"
-msgstr ""
-
-#: static/js/zamboni/collections.js:305 static/js/zamboni/collections.js:334
-msgid "Remove"
-msgstr ""
-
-#: static/js/zamboni/collections.js:334
-msgid "Remove this user as a contributor"
-msgstr ""
-
-#: static/js/zamboni/collections.js:346
-msgid "An email address is required."
-msgstr ""
-
-#: static/js/zamboni/collections.js:364
-msgid "You cannot add yourself as a contributor."
-msgstr ""
-
-#: static/js/zamboni/collections.js:366
-msgid "You have already added that user."
-msgstr ""
-
-#: static/js/zamboni/collections.js:573
-msgid "Add to favorites"
-msgstr ""
-
-#: static/js/zamboni/collections.js:577
-msgid "Remove from favorites"
-msgstr ""
-
-#: static/js/zamboni/collections.js:604
-msgid "Stop following"
-msgstr ""
-
-#: static/js/zamboni/devhub.js:110
+#: static/js/zamboni/devhub-all.js:1289 static/js/zamboni/devhub-min.js:1 static/js/zamboni/devhub.js:110
 msgid "Your browser does not support the video tag"
 msgstr ""
 
-#: static/js/zamboni/devhub.js:371
+#: static/js/zamboni/devhub-all.js:1550 static/js/zamboni/devhub-min.js:1 static/js/zamboni/devhub.js:371
 msgid "Changes Saved"
 msgstr ""
 
-#: static/js/zamboni/devhub.js:387
+#: static/js/zamboni/devhub-all.js:1566 static/js/zamboni/devhub-min.js:1 static/js/zamboni/devhub.js:387
 msgid "Enter a new author's email address"
 msgstr ""
 
-#: static/js/zamboni/devhub.js:536
+#: static/js/zamboni/devhub-all.js:1715 static/js/zamboni/devhub-min.js:1 static/js/zamboni/devhub.js:536
 msgid "There was an error uploading your file."
 msgstr ""
 
-#: static/js/zamboni/devhub.js:681
+#: static/js/zamboni/devhub-all.js:1860 static/js/zamboni/devhub-min.js:1 static/js/zamboni/devhub.js:681
 msgid "{files} file"
 msgid_plural "{files} files"
 msgstr[0] ""
 msgstr[1] ""
 
-#: static/js/zamboni/devhub.js:684
+#: static/js/zamboni/devhub-all.js:1863 static/js/zamboni/devhub-min.js:1 static/js/zamboni/devhub.js:684
 msgid "{reviews} user review"
 msgid_plural "{reviews} user reviews"
 msgstr[0] ""
 msgstr[1] ""
 
-#: static/js/zamboni/devhub.js:796
+#: static/js/zamboni/devhub-all.js:1975 static/js/zamboni/devhub-min.js:2 static/js/zamboni/devhub.js:796
 msgid "Learn more"
 msgstr ""
 
-#: static/js/zamboni/devhub.js:800
+#: static/js/zamboni/devhub-all.js:1979 static/js/zamboni/devhub-min.js:2 static/js/zamboni/devhub.js:800
 msgid "Example"
 msgstr ""
 
-#: static/js/zamboni/devhub.js:1130
+#: static/js/zamboni/devhub-all.js:2309 static/js/zamboni/devhub-min.js:2 static/js/zamboni/devhub.js:1130
 msgid "Image changes being processed"
 msgstr ""
 
-#: static/js/zamboni/devhub.js:1280
+#: static/js/zamboni/devhub-all.js:2459 static/js/zamboni/devhub-min.js:2 static/js/zamboni/devhub.js:1280
 msgid "Must be a valid e-mail address."
+msgstr ""
+
+#: static/js/zamboni/devhub-all.js:2613 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:80
+msgid "All tests passed successfully."
+msgstr ""
+
+#: static/js/zamboni/devhub-all.js:2616 static/js/zamboni/devhub-all.js:3011 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:83 static/js/zamboni/validator.js:478
+msgid "These tests were not run."
+msgstr ""
+
+#: static/js/zamboni/devhub-all.js:2664 static/js/zamboni/devhub-all.js:2677 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:131 static/js/zamboni/validator.js:144
+msgid "Tests"
+msgstr ""
+
+#: static/js/zamboni/devhub-all.js:2779 static/js/zamboni/devhub-all.js:3108 static/js/zamboni/devhub-all.js:3127 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:246
+#: static/js/zamboni/validator.js:575 static/js/zamboni/validator.js:594
+msgid "Error"
+msgstr ""
+
+#: static/js/zamboni/devhub-all.js:2780 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:247
+msgid "Warning"
+msgstr ""
+
+#: static/js/zamboni/devhub-all.js:2794 static/js/zamboni/devhub-min.js:2 static/js/zamboni/files-all.js:5657 static/js/zamboni/files-min.js:3 static/js/zamboni/files.js:411
+#: static/js/zamboni/validator.js:261
+msgid "Ignore this message in future updates"
+msgstr ""
+
+#: static/js/zamboni/devhub-all.js:2817 static/js/zamboni/devhub-min.js:2 static/js/zamboni/files-all.js:5663 static/js/zamboni/files-min.js:3 static/js/zamboni/files.js:417
+#: static/js/zamboni/validator.js:284
+msgid "Severity for automated signing:"
+msgstr ""
+
+#: static/js/zamboni/devhub-all.js:2832 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:299
+msgid "Suggestions for passing automated signing:"
+msgstr ""
+
+#: static/js/zamboni/devhub-all.js:2920 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:387
+msgid "Compatibility Tests"
+msgstr ""
+
+#: static/js/zamboni/devhub-all.js:2999 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:466
+msgid "Add-on failed validation."
+msgstr ""
+
+#: static/js/zamboni/devhub-all.js:3001 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:468
+msgid "Add-on passed validation."
+msgstr ""
+
+#: static/js/zamboni/devhub-all.js:3014 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:481
+msgid "{0} error"
+msgid_plural "{0} errors"
+msgstr[0] ""
+msgstr[1] ""
+
+#: static/js/zamboni/devhub-all.js:3016 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:483
+msgid "{0} warning"
+msgid_plural "{0} warnings"
+msgstr[0] ""
+msgstr[1] ""
+
+#: static/js/zamboni/devhub-all.js:3018 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:485
+msgid "{0} notice"
+msgid_plural "{0} notices"
+msgstr[0] ""
+msgstr[1] ""
+
+#: static/js/zamboni/devhub-all.js:3110 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:577
+msgid "Validation task could not complete or completed with errors"
+msgstr ""
+
+#: static/js/zamboni/devhub-all.js:3128 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:595
+msgid "Internal server error"
 msgstr ""
 
 #: static/js/zamboni/devhub_search.js:8
 msgid "No results found."
 msgstr ""
 
-#: static/js/zamboni/editors.js:121
+#: static/js/zamboni/editors-all.js:15402 static/js/zamboni/editors-min.js:4 static/js/zamboni/editors.js:121
 msgid "{name} was viewing this page first."
 msgstr ""
 
-#: static/js/zamboni/editors.js:171
+#: static/js/zamboni/editors-all.js:15452 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:171
 msgid "Receipt checked by app."
 msgstr ""
 
-#: static/js/zamboni/editors.js:173
+#: static/js/zamboni/editors-all.js:15454 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:173
 msgid "Receipt was not checked by app."
 msgstr ""
 
-#: static/js/zamboni/editors.js:244
+#: static/js/zamboni/editors-all.js:15525 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:244
 msgid "{name} was viewing this add-on first."
 msgstr ""
 
-#: static/js/zamboni/editors.js:255
+#: static/js/zamboni/editors-all.js:15536 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:255
 msgid "Loading&hellip;"
 msgstr ""
 
-#: static/js/zamboni/editors.js:260
+#: static/js/zamboni/editors-all.js:15541 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:260
 msgid "Version Notes"
 msgstr ""
 
-#: static/js/zamboni/editors.js:265
+#: static/js/zamboni/editors-all.js:15546 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:265
 msgid "Notes for Reviewers"
 msgstr ""
 
-#: static/js/zamboni/editors.js:270
+#: static/js/zamboni/editors-all.js:15551 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:270
 msgid "No version notes found"
 msgstr ""
 
-#: static/js/zamboni/editors.js:330
+#: static/js/zamboni/editors-all.js:15611 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:330
 msgid "Average Reviews"
 msgstr ""
 
-#: static/js/zamboni/editors.js:386
+#: static/js/zamboni/editors-all.js:15667 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:386
 msgid "Number of Reviews"
 msgstr ""
 
-#: static/js/zamboni/editors.js:445
+#: static/js/zamboni/editors-all.js:15726 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:445
 msgid "Error loading translation"
 msgstr ""
 
-#: static/js/zamboni/files.js:411 static/js/zamboni/validator.js:261
-msgid "Ignore this message in future updates"
-msgstr ""
-
-#: static/js/zamboni/files.js:417 static/js/zamboni/validator.js:284
-msgid "Severity for automated signing:"
-msgstr ""
-
-#: static/js/zamboni/global.js:410
-msgid "Loading..."
-msgstr ""
-
-#. L10n: {0} is the number of characters left.
-#: static/js/zamboni/global.js:474
-msgid "<b>{0}</b> character left."
-msgid_plural "<b>{0}</b> characters left."
-msgstr[0] ""
-msgstr[1] ""
-
-#: static/js/zamboni/init.js:28
-msgid "This feature is temporarily disabled while we perform website maintenance. Please check back a little later."
-msgstr ""
-
-#: static/js/zamboni/l10n.js:45
-msgid "Remove this localization"
-msgstr ""
-
-#: static/js/zamboni/password-strength.js:20
-msgid "Password strength:"
-msgstr ""
-
-#: static/js/zamboni/password-strength.js:26
-msgid "At least {0} character left."
-msgid_plural "At least {0} characters left."
-msgstr[0] ""
-msgstr[1] ""
-
-#: static/js/zamboni/themes_review.js:176
-msgid "Requested Info"
-msgstr ""
-
-#: static/js/zamboni/themes_review.js:177
-msgid "Flagged"
-msgstr ""
-
-#: static/js/zamboni/themes_review.js:178
-msgid "Duplicate"
-msgstr ""
-
-#: static/js/zamboni/themes_review.js:179
-msgid "Rejected"
-msgstr ""
-
-#: static/js/zamboni/themes_review.js:180
-msgid "Approved"
-msgstr ""
-
-#: static/js/zamboni/themes_review.js:424
-msgid "No results found"
-msgstr ""
-
-#: static/js/zamboni/themes_review_templates.js:31
+#: static/js/zamboni/editors-all.js:15975 static/js/zamboni/editors-min.js:5 static/js/zamboni/themes_review_templates.js:31
 msgid "Theme"
 msgstr ""
 
-#: static/js/zamboni/themes_review_templates.js:33
+#: static/js/zamboni/editors-all.js:15977 static/js/zamboni/editors-min.js:5 static/js/zamboni/themes_review_templates.js:33
 msgid "Reviewer"
 msgstr ""
 
-#: static/js/zamboni/themes_review_templates.js:35
+#: static/js/zamboni/editors-all.js:15979 static/js/zamboni/editors-min.js:5 static/js/zamboni/themes_review_templates.js:35
 msgid "Status"
 msgstr ""
 
-#: static/js/zamboni/validator.js:80
-msgid "All tests passed successfully."
+#: static/js/zamboni/editors-all.js:16196 static/js/zamboni/editors-min.js:5 static/js/zamboni/themes_review.js:176
+msgid "Requested Info"
 msgstr ""
 
-#: static/js/zamboni/validator.js:83 static/js/zamboni/validator.js:478
-msgid "These tests were not run."
+#: static/js/zamboni/editors-all.js:16197 static/js/zamboni/editors-min.js:5 static/js/zamboni/themes_review.js:177
+msgid "Flagged"
 msgstr ""
 
-#: static/js/zamboni/validator.js:131 static/js/zamboni/validator.js:144
-msgid "Tests"
+#: static/js/zamboni/editors-all.js:16198 static/js/zamboni/editors-min.js:5 static/js/zamboni/themes_review.js:178
+msgid "Duplicate"
 msgstr ""
 
-#: static/js/zamboni/validator.js:246 static/js/zamboni/validator.js:575 static/js/zamboni/validator.js:594
-msgid "Error"
+#: static/js/zamboni/editors-all.js:16199 static/js/zamboni/editors-min.js:5 static/js/zamboni/themes_review.js:179
+msgid "Rejected"
 msgstr ""
 
-#: static/js/zamboni/validator.js:247
-msgid "Warning"
+#: static/js/zamboni/editors-all.js:16200 static/js/zamboni/editors-min.js:5 static/js/zamboni/themes_review.js:180
+msgid "Approved"
 msgstr ""
 
-#: static/js/zamboni/validator.js:299
-msgid "Suggestions for passing automated signing:"
+#: static/js/zamboni/editors-all.js:16444 static/js/zamboni/editors-min.js:5 static/js/zamboni/themes_review.js:424
+msgid "No results found"
 msgstr ""
 
-#: static/js/zamboni/validator.js:387
-msgid "Compatibility Tests"
-msgstr ""
-
-#: static/js/zamboni/validator.js:466
-msgid "Add-on failed validation."
-msgstr ""
-
-#: static/js/zamboni/validator.js:468
-msgid "Add-on passed validation."
-msgstr ""
-
-#: static/js/zamboni/validator.js:481
-msgid "{0} error"
-msgid_plural "{0} errors"
-msgstr[0] ""
-msgstr[1] ""
-
-#: static/js/zamboni/validator.js:483
-msgid "{0} warning"
-msgid_plural "{0} warnings"
-msgstr[0] ""
-msgstr[1] ""
-
-#: static/js/zamboni/validator.js:485
-msgid "{0} notice"
-msgid_plural "{0} notices"
-msgstr[0] ""
-msgstr[1] ""
-
-#: static/js/zamboni/validator.js:577
-msgid "Validation task could not complete or completed with errors"
-msgstr ""
-
-#: static/js/zamboni/validator.js:595
-msgid "Internal server error"
-msgstr ""
-
-#: static/js/zamboni/mobile/buttons.js:52
+#: static/js/zamboni/mobile-all.js:15186 static/js/zamboni/mobile/buttons.js:52
 msgid "Not Updated for {0} {1}"
 msgstr ""
 
-#: static/js/zamboni/mobile/buttons.js:53
+#: static/js/zamboni/mobile-all.js:15187 static/js/zamboni/mobile/buttons.js:53
 msgid "Requires Newer Version of {0}"
 msgstr ""
 
-#: static/js/zamboni/mobile/buttons.js:54
+#: static/js/zamboni/mobile-all.js:15188 static/js/zamboni/mobile/buttons.js:54
 msgid "Unreviewed"
 msgstr ""
 
-#: static/js/zamboni/mobile/buttons.js:55
+#: static/js/zamboni/mobile-all.js:15189 static/js/zamboni/mobile/buttons.js:55
 msgid "Experimental <span>(Learn More)</span>"
 msgstr ""
 
-#: static/js/zamboni/mobile/buttons.js:56 static/js/zamboni/mobile/buttons.js:57
+#: static/js/zamboni/mobile-all.js:15190 static/js/zamboni/mobile-all.js:15191 static/js/zamboni/mobile/buttons.js:56 static/js/zamboni/mobile/buttons.js:57
 msgid "Not Available for {0}"
 msgstr ""
 
-#: static/js/zamboni/mobile/buttons.js:58
+#: static/js/zamboni/mobile-all.js:15192 static/js/zamboni/mobile/buttons.js:58
 msgid "Experimental"
 msgstr ""
 
-#: static/js/zamboni/mobile/buttons.js:59
+#: static/js/zamboni/mobile-all.js:15193 static/js/zamboni/mobile/buttons.js:59
 msgid "Themes Require Newer Version of {0}"
 msgstr ""
 
-#: static/js/zamboni/mobile/buttons.js:60
+#: static/js/zamboni/mobile-all.js:15194 static/js/zamboni/mobile/buttons.js:60
 msgid "Themes Require {0}"
 msgstr ""
 
-#: static/js/zamboni/mobile/buttons.js:105
+#: static/js/zamboni/mobile-all.js:15239 static/js/zamboni/mobile/buttons.js:105
 msgid "Installing..."
 msgstr ""
 
-#: static/js/zamboni/mobile/buttons.js:125
+#: static/js/zamboni/mobile-all.js:15259 static/js/zamboni/mobile/buttons.js:125
 msgid "This add-on has been preliminarily reviewed by Mozilla."
 msgstr ""
 
-#: static/js/zamboni/mobile/buttons.js:250
+#: static/js/zamboni/mobile-all.js:15384 static/js/zamboni/mobile/buttons.js:250
 msgid "Keep it"
 msgstr ""
 
-#: static/js/zamboni/mobile/general.js:344
+#: static/js/zamboni/mobile-all.js:16049 static/js/zamboni/mobile-min.js:6 static/js/zamboni/mobile/general.js:344
 msgid "You're trying it on!"
 msgstr ""
 
-#: static/js/zamboni/mobile/general.js:356
+#: static/js/zamboni/mobile-all.js:16061 static/js/zamboni/mobile-min.js:6 static/js/zamboni/mobile/general.js:356
 msgid "Added to Firefox"
 msgstr ""
-

--- a/locale/kn/LC_MESSAGES/django.po
+++ b/locale/kn/LC_MESSAGES/django.po
@@ -3,69 +3,70 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2016-02-24 21:23+0000\n"
+"POT-Creation-Date: 2016-04-18 15:47+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
+"Language: \n"
 "MIME-Version: 1.0\n"
-"Content-Type: text/plain; charset=utf-8\n"
+"Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Generated-By: Babel 2.2.0\n"
 
-#: src/olympia/accounts/views.py:52
+#: src/olympia/accounts/views.py:54
 msgid "Your log in attempt could not be parsed. Please try again."
 msgstr ""
 
-#: src/olympia/accounts/views.py:54
+#: src/olympia/accounts/views.py:56
 msgid "Your Firefox Account could not be found. Please try again."
 msgstr ""
 
-#: src/olympia/accounts/views.py:55
+#: src/olympia/accounts/views.py:57
 msgid "You could not be logged in. Please try again."
 msgstr ""
 
-#: src/olympia/accounts/views.py:57
+#: src/olympia/accounts/views.py:59
 msgid "Your account has already been migrated to Firefox Accounts."
 msgstr ""
 
-#: src/olympia/accounts/views.py:59
+#: src/olympia/accounts/views.py:61
 msgid "Your Firefox Account already exists on this site."
 msgstr ""
 
-#: src/olympia/accounts/views.py:108
+#: src/olympia/accounts/views.py:110
 msgid "Great job!"
 msgstr ""
 
-#: src/olympia/accounts/views.py:109
+#: src/olympia/accounts/views.py:111
 msgid "You can now log in to Add-ons with your Firefox Account."
 msgstr ""
 
-#: src/olympia/accounts/views.py:121
+#: src/olympia/accounts/views.py:123
 msgid "Need help?"
 msgstr ""
 
-#: src/olympia/addons/buttons.py:180
+#: src/olympia/addons/buttons.py:177
 msgid "Download Now"
 msgstr ""
 
-#: src/olympia/addons/buttons.py:182
+#: src/olympia/addons/buttons.py:179
 msgid "Download"
 msgstr ""
 
 #. L10n: please keep &nbsp; in the string so &rarr; does not wrap.
-#: src/olympia/addons/buttons.py:186
+#: src/olympia/addons/buttons.py:183
 msgid "Continue to Download&nbsp;&rarr;"
 msgstr ""
 
-#: src/olympia/addons/buttons.py:202 src/olympia/addons/helpers.py:35 src/olympia/addons/views.py:319 src/olympia/addons/templates/addons/impala/details.html:114
+#: src/olympia/addons/buttons.py:199 src/olympia/addons/helpers.py:35 src/olympia/addons/views.py:333 src/olympia/addons/templates/addons/impala/details.html:111
 #: src/olympia/addons/templates/addons/impala/listing/items.html:17 src/olympia/addons/templates/addons/mobile/home.html:40 src/olympia/amo/templates/amo/side_nav.html:6
-#: src/olympia/amo/templates/amo/side_nav.html:10 src/olympia/amo/templates/amo/site_nav.html:2 src/olympia/amo/templates/amo/site_nav.html:55 src/olympia/bandwagon/views.py:95
-#: src/olympia/browse/views.py:54 src/olympia/browse/views.py:68 src/olympia/browse/views.py:235 src/olympia/browse/templates/browse/impala/category_landing.html:22
+#: src/olympia/amo/templates/amo/side_nav.html:10 src/olympia/amo/templates/amo/site_nav.html:2 src/olympia/amo/templates/amo/site_nav.html:53 src/olympia/bandwagon/views.py:95
+#: src/olympia/browse/views.py:54 src/olympia/browse/views.py:68 src/olympia/browse/views.py:202 src/olympia/browse/templates/browse/impala/category_landing.html:22
 #: src/olympia/browse/templates/browse/personas/mobile/category_landing.html:26
 msgid "Featured"
 msgstr ""
 
-#: src/olympia/addons/buttons.py:221
+#: src/olympia/addons/buttons.py:218
 msgid "Add to {0}"
 msgstr ""
 
@@ -113,39 +114,39 @@ msgid_plural "All tags must be at least {0} characters."
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/olympia/addons/forms.py:234
+#: src/olympia/addons/forms.py:238
 msgid "Categories cannot be changed while your add-on is featured for this application."
 msgstr ""
 
 #. L10n: {0} is the number of categories.
-#: src/olympia/addons/forms.py:238
+#: src/olympia/addons/forms.py:242
 msgid "You can have only {0} category."
 msgid_plural "You can have only {0} categories."
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/olympia/addons/forms.py:246
+#: src/olympia/addons/forms.py:250
 msgid "The miscellaneous category cannot be combined with additional categories."
 msgstr ""
 
-#: src/olympia/addons/forms.py:369
+#: src/olympia/addons/forms.py:374
 #, python-format
 msgid "Before changing your default locale you must have a name, summary, and description in that locale. You are missing %s."
 msgstr ""
 
-#: src/olympia/addons/forms.py:484 src/olympia/addons/forms.py:575
+#: src/olympia/addons/forms.py:455 src/olympia/addons/forms.py:546
 msgid "A license must be selected."
 msgstr ""
 
-#: src/olympia/addons/forms.py:556
+#: src/olympia/addons/forms.py:527
 msgid "Give Your Theme a Name."
 msgstr ""
 
-#: src/olympia/addons/forms.py:562 src/olympia/devhub/templates/devhub/personas/submit.html:53
+#: src/olympia/addons/forms.py:533 src/olympia/devhub/templates/devhub/personas/submit.html:53
 msgid "Describe your Theme."
 msgstr ""
 
-#: src/olympia/addons/forms.py:704
+#: src/olympia/addons/forms.py:675
 msgid "Enter a new author's email address"
 msgstr ""
 
@@ -153,37 +154,37 @@ msgstr ""
 msgid "Not Reviewed"
 msgstr ""
 
-#: src/olympia/addons/models.py:301
+#: src/olympia/addons/models.py:298
 msgid "Users have the option of contributing more or less than this amount."
 msgstr ""
 
-#: src/olympia/addons/models.py:309
-msgid "Users will always be asked in the Add-ons Manager (Firefox 4 and above)"
+#: src/olympia/addons/models.py:306
+msgid "Users will always be asked in the Add-ons Manager (Firefox 4 and above). Only applies to desktop."
 msgstr ""
 
-#: src/olympia/addons/models.py:1804 src/olympia/addons/templates/addons/details_box.html:55 src/olympia/devhub/templates/devhub/index.html:92
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:102
+#: src/olympia/addons/models.py:1802 src/olympia/addons/templates/addons/details_box.html:55 src/olympia/devhub/templates/devhub/index.html:92
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:89
 msgid "Listed"
 msgstr ""
 
-#: src/olympia/addons/views.py:320 src/olympia/browse/templates/browse/personas/mobile/category_landing.html:27
+#: src/olympia/addons/views.py:334 src/olympia/browse/templates/browse/personas/mobile/category_landing.html:27
 msgid "Popular"
 msgstr ""
 
-#: src/olympia/addons/views.py:321 src/olympia/browse/views.py:238 src/olympia/browse/views.py:280 src/olympia/browse/views.py:482
+#: src/olympia/addons/views.py:335 src/olympia/browse/views.py:205 src/olympia/browse/views.py:247 src/olympia/browse/views.py:449
 msgid "Recently Added"
 msgstr ""
 
-#: src/olympia/addons/views.py:322 src/olympia/bandwagon/views.py:99 src/olympia/browse/views.py:60 src/olympia/browse/views.py:71 src/olympia/search/forms.py:16 src/olympia/search/forms.py:91
+#: src/olympia/addons/views.py:336 src/olympia/bandwagon/views.py:99 src/olympia/browse/views.py:60 src/olympia/browse/views.py:71 src/olympia/search/forms.py:16 src/olympia/search/forms.py:91
 msgid "Recently Updated"
 msgstr ""
 
 #. l10n: {0} is the addon name
-#: src/olympia/addons/views.py:520
+#: src/olympia/addons/views.py:534
 msgid "Contribution for {0}"
 msgstr ""
 
-#: src/olympia/addons/views.py:613
+#: src/olympia/addons/views.py:627
 msgid "Abuse reported."
 msgstr ""
 
@@ -250,9 +251,9 @@ msgstr ""
 #: src/olympia/devhub/templates/devhub/addons/ajax_compat_update.html:36 src/olympia/devhub/templates/devhub/addons/profile.html:44 src/olympia/devhub/templates/devhub/addons/edit/admin.html:101
 #: src/olympia/devhub/templates/devhub/addons/edit/basic.html:152 src/olympia/devhub/templates/devhub/addons/edit/details.html:85 src/olympia/devhub/templates/devhub/addons/edit/support.html:67
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:166 src/olympia/devhub/templates/devhub/addons/forms_shared/media.html:149
-#: src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:44 src/olympia/devhub/templates/devhub/versions/add_file_modal.html:78 src/olympia/devhub/templates/devhub/versions/edit.html:139
-#: src/olympia/devhub/templates/devhub/versions/list.html:242 src/olympia/devhub/templates/devhub/versions/list.html:276 src/olympia/devhub/templates/devhub/versions/list.html:317
-#: src/olympia/devhub/templates/devhub/versions/list.html:351 src/olympia/reviews/templates/reviews/edit_review.html:16 src/olympia/translations/templates/translations/trans-menu.html:50
+#: src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:43 src/olympia/devhub/templates/devhub/versions/add_file_modal.html:58 src/olympia/devhub/templates/devhub/versions/edit.html:139
+#: src/olympia/devhub/templates/devhub/versions/list.html:239 src/olympia/devhub/templates/devhub/versions/list.html:281 src/olympia/devhub/templates/devhub/versions/list.html:315
+#: src/olympia/devhub/templates/devhub/versions/list.html:349 src/olympia/reviews/templates/reviews/edit_review.html:16 src/olympia/translations/templates/translations/trans-menu.html:50
 #: src/olympia/translations/templates/translations/trans-menu.html:62
 msgid "or"
 msgstr ""
@@ -363,7 +364,7 @@ msgid "Add-on Information for {0}"
 msgstr ""
 
 #: src/olympia/addons/templates/addons/details_box.html:30 src/olympia/addons/templates/addons/persona_detail_table.html:3 src/olympia/addons/templates/addons/mobile/details.html:63
-#: src/olympia/addons/templates/addons/mobile/persona_detail_table.html:7 src/olympia/browse/views.py:459 src/olympia/devhub/views.py:75
+#: src/olympia/addons/templates/addons/mobile/persona_detail_table.html:7 src/olympia/browse/views.py:426 src/olympia/devhub/views.py:73
 msgid "Updated"
 msgstr ""
 
@@ -382,11 +383,11 @@ msgstr ""
 msgid "Visibility"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/details_box.html:57 src/olympia/devhub/templates/devhub/index.html:94 src/olympia/devhub/templates/devhub/includes/addon_details.html:104
+#: src/olympia/addons/templates/addons/details_box.html:57 src/olympia/devhub/templates/devhub/index.html:94 src/olympia/devhub/templates/devhub/includes/addon_details.html:91
 msgid "Hidden"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/details_box.html:59 src/olympia/devhub/templates/devhub/index.html:96 src/olympia/devhub/templates/devhub/includes/addon_details.html:106
+#: src/olympia/addons/templates/addons/details_box.html:59 src/olympia/devhub/templates/devhub/index.html:96 src/olympia/devhub/templates/devhub/includes/addon_details.html:93
 msgid "Unlisted"
 msgstr ""
 
@@ -394,13 +395,13 @@ msgstr ""
 msgid "Required Add-ons"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/details_box.html:81 src/olympia/addons/templates/addons/persona_detail_table.html:15 src/olympia/browse/views.py:462 src/olympia/devhub/views.py:78
-#: src/olympia/devhub/views.py:85 src/olympia/discovery/templates/discovery/addons/detail.html:57 src/olympia/reviews/forms.py:62 src/olympia/reviews/templates/reviews/add.html:57
+#: src/olympia/addons/templates/addons/details_box.html:81 src/olympia/addons/templates/addons/persona_detail_table.html:15 src/olympia/browse/views.py:429 src/olympia/devhub/views.py:76
+#: src/olympia/devhub/views.py:83 src/olympia/discovery/templates/discovery/addons/detail.html:57 src/olympia/reviews/forms.py:62 src/olympia/reviews/templates/reviews/add.html:57
 #: src/olympia/reviews/templates/reviews/mobile/review_list.html:18
 msgid "Rating"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/details_box.html:85 src/olympia/browse/views.py:461 src/olympia/devhub/views.py:77 src/olympia/devhub/views.py:84
+#: src/olympia/addons/templates/addons/details_box.html:85 src/olympia/browse/views.py:428 src/olympia/devhub/views.py:75 src/olympia/devhub/views.py:82
 #: src/olympia/stats/templates/stats/addon_report_menu.html:8 src/olympia/stats/templates/stats/collection_report_menu.html:18
 msgid "Downloads"
 msgstr ""
@@ -420,7 +421,7 @@ msgstr ""
 
 #. The Privacy Policy for this add-on.
 #: src/olympia/addons/templates/addons/details_box.html:121 src/olympia/addons/templates/addons/privacy.html:19 src/olympia/addons/templates/addons/privacy.html:23
-#: src/olympia/addons/templates/addons/impala/button.html:43 src/olympia/addons/templates/addons/impala/details.html:307 src/olympia/devhub/templates/devhub/includes/policy_form.html:20
+#: src/olympia/addons/templates/addons/impala/button.html:43 src/olympia/addons/templates/addons/impala/details.html:312 src/olympia/devhub/templates/devhub/includes/policy_form.html:23
 #: src/olympia/templates/mobile/base_addons.html:87
 msgid "Privacy Policy"
 msgstr ""
@@ -445,7 +446,7 @@ msgstr ""
 msgid "Developer Comments"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/details_box.html:199 src/olympia/addons/templates/addons/impala/details.html:259
+#: src/olympia/addons/templates/addons/details_box.html:199 src/olympia/addons/templates/addons/impala/details.html:264
 msgid "Development Channel"
 msgstr ""
 
@@ -465,7 +466,7 @@ msgid ""
 "developer. To stop receiving development updates, reinstall the default version from the link above."
 msgstr ""
 
-#: src/olympia/addons/templates/addons/details_box.html:220 src/olympia/addons/templates/addons/impala/details.html:278
+#: src/olympia/addons/templates/addons/details_box.html:220 src/olympia/addons/templates/addons/impala/details.html:283
 msgid "Version {0}:"
 msgstr ""
 
@@ -484,7 +485,7 @@ msgid "End-User License Agreement for {0}"
 msgstr ""
 
 #: src/olympia/addons/templates/addons/eula.html:17 src/olympia/addons/templates/addons/eula.html:21 src/olympia/addons/templates/addons/impala/button.html:48
-#: src/olympia/addons/templates/addons/impala/details.html:316 src/olympia/devhub/templates/devhub/includes/policy_form.html:3 src/olympia/discovery/templates/discovery/addons/eula.html:11
+#: src/olympia/addons/templates/addons/impala/details.html:321 src/olympia/devhub/templates/devhub/includes/policy_form.html:3 src/olympia/discovery/templates/discovery/addons/eula.html:11
 msgid "End-User License Agreement"
 msgstr ""
 
@@ -501,7 +502,7 @@ msgstr ""
 msgid "Add-ons for {0}"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/home.html:10 src/olympia/addons/templates/addons/home.html:51 src/olympia/browse/templates/browse/impala/base_listing.html:11
+#: src/olympia/addons/templates/addons/home.html:10 src/olympia/addons/templates/addons/home.html:53 src/olympia/browse/templates/browse/impala/base_listing.html:11
 msgid "Featured Extensions"
 msgstr ""
 
@@ -509,29 +510,29 @@ msgstr ""
 msgid "Popular Extensions"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/home.html:42 src/olympia/amo/templates/amo/side_nav.html:3 src/olympia/amo/templates/amo/side_nav.html:11 src/olympia/amo/templates/amo/site_nav.html:3
-#: src/olympia/amo/templates/amo/site_nav.html:25 src/olympia/browse/views.py:236 src/olympia/browse/views.py:281 src/olympia/browse/views.py:481
+#: src/olympia/addons/templates/addons/home.html:44 src/olympia/amo/templates/amo/side_nav.html:3 src/olympia/amo/templates/amo/side_nav.html:11 src/olympia/amo/templates/amo/site_nav.html:3
+#: src/olympia/amo/templates/amo/site_nav.html:25 src/olympia/browse/views.py:203 src/olympia/browse/views.py:248 src/olympia/browse/views.py:448
 msgid "Most Popular"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/home.html:43
+#: src/olympia/addons/templates/addons/home.html:45
 msgid "All »"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/home.html:52 src/olympia/addons/templates/addons/home.html:61 src/olympia/addons/templates/addons/home.html:70 src/olympia/addons/templates/addons/home.html:78
+#: src/olympia/addons/templates/addons/home.html:54 src/olympia/addons/templates/addons/home.html:63 src/olympia/addons/templates/addons/home.html:72 src/olympia/addons/templates/addons/home.html:80
 #: src/olympia/browse/templates/browse/impala/category_landing.html:36
 msgid "See all »"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/home.html:60
+#: src/olympia/addons/templates/addons/home.html:62
 msgid "Up &amp; Coming Extensions"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/home.html:69 src/olympia/browse/templates/browse/personas/category_landing.html:61 src/olympia/discovery/templates/discovery/pane.html:74
+#: src/olympia/addons/templates/addons/home.html:71 src/olympia/browse/templates/browse/personas/category_landing.html:61 src/olympia/discovery/templates/discovery/pane.html:74
 msgid "Featured Themes"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/home.html:77 src/olympia/bandwagon/templates/bandwagon/impala/collection_listing.html:5
+#: src/olympia/addons/templates/addons/home.html:79 src/olympia/bandwagon/templates/bandwagon/impala/collection_listing.html:5
 msgid "Featured Collections"
 msgstr ""
 
@@ -549,7 +550,7 @@ msgid "Updated {0}"
 msgstr ""
 
 #. {0} is a date.
-#: src/olympia/addons/templates/addons/macros.html:10 src/olympia/addons/templates/addons/macros.html:69 src/olympia/addons/templates/addons/persona_preview.html:21
+#: src/olympia/addons/templates/addons/macros.html:10 src/olympia/addons/templates/addons/macros.html:69 src/olympia/addons/templates/addons/persona_preview.html:22
 #: src/olympia/addons/templates/addons/listing/items_mobile.html:44 src/olympia/addons/templates/addons/listing/macros.html:39
 #: src/olympia/bandwagon/templates/bandwagon/collection_listing_items.html:37 src/olympia/bandwagon/templates/bandwagon/impala/collection_listing_items.html:37
 msgid "Added {0}"
@@ -570,15 +571,14 @@ msgstr[0] ""
 msgstr[1] ""
 
 #. {0} is the number of downloads.
-#: src/olympia/addons/templates/addons/macros.html:53 src/olympia/addons/templates/addons/impala/details.html:61
+#: src/olympia/addons/templates/addons/macros.html:53 src/olympia/addons/templates/addons/impala/details.html:59
 msgid "{0} weekly download"
 msgid_plural "{0} weekly downloads"
 msgstr[0] ""
 msgstr[1] ""
 
 #. {0} is the number of users.
-#: src/olympia/addons/templates/addons/macros.html:61 src/olympia/addons/templates/addons/impala/details.html:54 src/olympia/compat/templates/compat/index.html:71
-#: src/olympia/zadmin/templates/zadmin/compat.html:67
+#: src/olympia/addons/templates/addons/macros.html:61 src/olympia/addons/templates/addons/impala/details.html:52 src/olympia/zadmin/templates/zadmin/compat.html:67
 msgid "{0} user"
 msgid_plural "{0} users"
 msgstr[0] ""
@@ -596,7 +596,7 @@ msgstr ""
 msgid "Return to the addon."
 msgstr ""
 
-#: src/olympia/addons/templates/addons/persona_detail.html:17 src/olympia/addons/templates/addons/impala/details.html:106 src/olympia/addons/templates/addons/mobile/details.html:23
+#: src/olympia/addons/templates/addons/persona_detail.html:17 src/olympia/addons/templates/addons/impala/details.html:103 src/olympia/addons/templates/addons/mobile/details.html:23
 #: src/olympia/addons/templates/addons/mobile/persona_detail.html:21 src/olympia/discovery/templates/discovery/addons/base.html:27 src/olympia/editors/templates/editors/review.html:31
 msgid "by"
 msgstr ""
@@ -640,34 +640,35 @@ msgstr ""
 msgid "License"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/persona_preview.html:12 src/olympia/constants/base.py:48
+#: src/olympia/addons/templates/addons/persona_preview.html:13 src/olympia/constants/base.py:48
 msgid "Awaiting Review"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/persona_preview.html:14 src/olympia/amo/log.py:180 src/olympia/constants/base.py:42 src/olympia/editors/helpers.py:62
+#: src/olympia/addons/templates/addons/persona_preview.html:15 src/olympia/amo/log.py:180 src/olympia/constants/base.py:42 src/olympia/editors/helpers.py:62
 msgid "Rejected"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/persona_preview.html:16 src/olympia/amo/log.py:159
+#: src/olympia/addons/templates/addons/persona_preview.html:17 src/olympia/amo/log.py:159
 msgid "Approved"
 msgstr ""
 
 #. {0} is the number of users.
-#: src/olympia/addons/templates/addons/persona_preview.html:26 src/olympia/addons/templates/addons/listing/items_mobile.html:36 src/olympia/addons/templates/addons/listing/macros.html:31
+#: src/olympia/addons/templates/addons/persona_preview.html:27 src/olympia/addons/templates/addons/listing/items_mobile.html:36 src/olympia/addons/templates/addons/listing/macros.html:31
 msgid "<strong>{0}</strong> user"
 msgid_plural "<strong>{0}</strong> users"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/olympia/addons/templates/addons/persona_preview.html:40
+#: src/olympia/addons/templates/addons/persona_preview.html:41
 msgid "Hover to Preview"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/persona_preview.html:46 src/olympia/addons/templates/addons/persona_preview.html:48 src/olympia/reviews/templates/reviews/add.html:15
+#: src/olympia/addons/templates/addons/persona_preview.html:47 src/olympia/addons/templates/addons/persona_preview.html:49 src/olympia/addons/templates/addons/persona_preview.html:97
+#: src/olympia/reviews/templates/reviews/add.html:15
 msgid "Add"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/persona_preview.html:57 src/olympia/bandwagon/templates/bandwagon/ajax_new.html:16 src/olympia/bandwagon/templates/bandwagon/edit.html:19
+#: src/olympia/addons/templates/addons/persona_preview.html:58 src/olympia/bandwagon/templates/bandwagon/ajax_new.html:16 src/olympia/bandwagon/templates/bandwagon/edit.html:19
 #: src/olympia/bandwagon/templates/bandwagon/includes/addedit.html:19 src/olympia/devhub/templates/devhub/addons/edit/admin.html:13 src/olympia/devhub/templates/devhub/addons/edit/basic.html:10
 #: src/olympia/devhub/templates/devhub/addons/edit/details.html:8 src/olympia/devhub/templates/devhub/addons/edit/media.html:6 src/olympia/devhub/templates/devhub/addons/edit/support.html:8
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:9 src/olympia/devhub/templates/devhub/addons/submit/describe.html:29 src/olympia/editors/templates/editors/review.html:257
@@ -676,21 +677,21 @@ msgstr ""
 
 #. For datetime formatting, see the table on
 #. http://docs.python.org/library/datetime.html#strftime-and-strptime-behavior
-#: src/olympia/addons/templates/addons/persona_preview.html:66
+#: src/olympia/addons/templates/addons/persona_preview.html:67
 #, python-format
 msgid "%%Y-%%m-%%d"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/persona_preview.html:67
+#: src/olympia/addons/templates/addons/persona_preview.html:68
 msgid "by {0} on {1}"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/persona_preview.html:75 src/olympia/reviews/helpers.py:17 src/olympia/reviews/templates/reviews/review_list.html:63
+#: src/olympia/addons/templates/addons/persona_preview.html:76 src/olympia/reviews/helpers.py:17 src/olympia/reviews/templates/reviews/review_list.html:63
 #: src/olympia/reviews/templates/reviews/reviews_link.html:21 src/olympia/reviews/templates/reviews/impala/reviews_link.html:16
 msgid "Not yet rated"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/persona_preview.html:78
+#: src/olympia/addons/templates/addons/persona_preview.html:79
 msgid "<b>{0}</b> users"
 msgstr ""
 
@@ -703,7 +704,7 @@ msgid "Learn more about Firefox"
 msgstr ""
 
 #: src/olympia/addons/templates/addons/popups.html:22
-msgid "or <b><a class=\"installer\" href=\"{url}\">download anyway</a></b>"
+msgid "or <b><a class=\"button installer\" href=\"{url}\">download anyway</a></b>"
 msgstr ""
 
 #: src/olympia/addons/templates/addons/popups.html:26
@@ -802,7 +803,7 @@ msgid ""
 msgstr ""
 
 #: src/olympia/addons/templates/addons/report_abuse.html:6 src/olympia/addons/templates/addons/report_abuse_full.html:10 src/olympia/addons/templates/addons/impala/details-more.html:23
-#: src/olympia/addons/templates/addons/impala/details.html:328
+#: src/olympia/addons/templates/addons/impala/details.html:333
 msgid "Report Abuse"
 msgstr ""
 
@@ -821,9 +822,9 @@ msgstr ""
 #: src/olympia/devhub/templates/devhub/addons/ajax_compat_update.html:36 src/olympia/devhub/templates/devhub/addons/profile.html:44 src/olympia/devhub/templates/devhub/addons/edit/admin.html:104
 #: src/olympia/devhub/templates/devhub/addons/edit/basic.html:155 src/olympia/devhub/templates/devhub/addons/edit/details.html:88 src/olympia/devhub/templates/devhub/addons/edit/support.html:70
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:169 src/olympia/devhub/templates/devhub/addons/forms_shared/media.html:152
-#: src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:44 src/olympia/devhub/templates/devhub/personas/edit.html:222 src/olympia/devhub/templates/devhub/versions/add_file_modal.html:79
-#: src/olympia/devhub/templates/devhub/versions/edit.html:140 src/olympia/devhub/templates/devhub/versions/list.html:208 src/olympia/devhub/templates/devhub/versions/list.html:242
-#: src/olympia/devhub/templates/devhub/versions/list.html:276 src/olympia/devhub/templates/devhub/versions/list.html:317 src/olympia/reviews/templates/reviews/edit_review.html:16
+#: src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:43 src/olympia/devhub/templates/devhub/personas/edit.html:222 src/olympia/devhub/templates/devhub/versions/add_file_modal.html:59
+#: src/olympia/devhub/templates/devhub/versions/edit.html:140 src/olympia/devhub/templates/devhub/versions/list.html:208 src/olympia/devhub/templates/devhub/versions/list.html:239
+#: src/olympia/devhub/templates/devhub/versions/list.html:281 src/olympia/devhub/templates/devhub/versions/list.html:315 src/olympia/reviews/templates/reviews/edit_review.html:16
 #: src/olympia/translations/templates/translations/trans-menu.html:50 src/olympia/translations/templates/translations/trans-menu.html:62 src/olympia/zadmin/templates/zadmin/validation.html:105
 msgid "Cancel"
 msgstr ""
@@ -868,7 +869,7 @@ msgstr ""
 msgid "Review Guidelines"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/review_list_box.html:5 src/olympia/addons/templates/addons/impala/details-more.html:27 src/olympia/editors/helpers.py:921
+#: src/olympia/addons/templates/addons/review_list_box.html:5 src/olympia/addons/templates/addons/impala/details-more.html:27 src/olympia/editors/helpers.py:1001
 #: src/olympia/reviews/templates/reviews/add.html:14 src/olympia/reviews/templates/reviews/reply.html:14 src/olympia/reviews/templates/reviews/review_list.html:19
 #: src/olympia/reviews/templates/reviews/mobile/review_list.html:26
 msgid "Reviews"
@@ -959,119 +960,119 @@ msgid_plural "Other add-ons by these authors"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/olympia/addons/templates/addons/impala/details.html:41
+#: src/olympia/addons/templates/addons/impala/details.html:39
 #, python-format
 msgid "<span itemprop=\"ratingCount\">%(num)s</span> user review"
 msgid_plural "<span itemprop=\"ratingCount\">%(num)s</span> user reviews"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/olympia/addons/templates/addons/impala/details.html:69
+#: src/olympia/addons/templates/addons/impala/details.html:66
 msgid "View statistics"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/impala/details.html:84
+#: src/olympia/addons/templates/addons/impala/details.html:81
 msgid "Manage"
 msgstr ""
 
 #. {0} is an add-on name.
-#: src/olympia/addons/templates/addons/impala/details.html:96
+#: src/olympia/addons/templates/addons/impala/details.html:93
 msgid "Icon of {0}"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/impala/details.html:103 src/olympia/addons/templates/addons/impala/listing/items.html:14
+#: src/olympia/addons/templates/addons/impala/details.html:100 src/olympia/addons/templates/addons/impala/listing/items.html:14
 msgid "No Restart"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/impala/details.html:127
+#: src/olympia/addons/templates/addons/impala/details.html:124
 #, python-format
 msgid "Meet the Developer: <a href=\"%(url)s\">%(name)s</a>"
 msgid_plural "<a href=\"%(url)s\">Meet the Developers</a>"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/olympia/addons/templates/addons/impala/details.html:137
+#: src/olympia/addons/templates/addons/impala/details.html:134
 msgid "Learn why {0} was created and find out what's next for this add-on."
 msgstr ""
 
 #. {0} is an index.
-#: src/olympia/addons/templates/addons/impala/details.html:156
+#: src/olympia/addons/templates/addons/impala/details.html:161
 msgid "Add-on screenshot #{0}"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/impala/details.html:182
+#: src/olympia/addons/templates/addons/impala/details.html:187
 msgid "Add-on home page"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/impala/details.html:185
+#: src/olympia/addons/templates/addons/impala/details.html:190
 msgid "Support site"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/impala/details.html:189
+#: src/olympia/addons/templates/addons/impala/details.html:194
 msgid "Support E-mail"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/impala/details.html:194 src/olympia/devhub/models.py:378 src/olympia/devhub/templates/devhub/versions/list.html:12
+#: src/olympia/addons/templates/addons/impala/details.html:199 src/olympia/devhub/models.py:378 src/olympia/devhub/templates/devhub/versions/list.html:12
 #: src/olympia/versions/templates/versions/version.html:6 src/olympia/versions/templates/versions/mobile/version.html:6
 msgid "Version {0}"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/impala/details.html:194
+#: src/olympia/addons/templates/addons/impala/details.html:199
 msgid "Info"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/impala/details.html:195 src/olympia/devhub/templates/devhub/includes/addon_details.html:129
+#: src/olympia/addons/templates/addons/impala/details.html:200 src/olympia/devhub/templates/devhub/includes/addon_details.html:116
 msgid "Last Updated:"
-msgstr ""
-
-#: src/olympia/addons/templates/addons/impala/details.html:200
-#, python-format
-msgid "Released under <a target=\"_blank\" href=\"%(url)s\">%(name)s</a>"
-msgstr ""
-
-#: src/olympia/addons/templates/addons/impala/details.html:201 src/olympia/addons/templates/addons/impala/details.html:206 src/olympia/amo/helpers.py:398 src/olympia/devhub/forms.py:142
-#: src/olympia/devhub/forms.py:173 src/olympia/versions/templates/versions/version.html:40 src/olympia/versions/templates/versions/version.html:45
-msgid "Custom License"
 msgstr ""
 
 #: src/olympia/addons/templates/addons/impala/details.html:205
 #, python-format
+msgid "Released under <a target=\"_blank\" href=\"%(url)s\">%(name)s</a>"
+msgstr ""
+
+#: src/olympia/addons/templates/addons/impala/details.html:206 src/olympia/addons/templates/addons/impala/details.html:211 src/olympia/amo/helpers.py:398 src/olympia/devhub/forms.py:142
+#: src/olympia/devhub/forms.py:173 src/olympia/versions/templates/versions/version.html:40 src/olympia/versions/templates/versions/version.html:45
+msgid "Custom License"
+msgstr ""
+
+#: src/olympia/addons/templates/addons/impala/details.html:210
+#, python-format
 msgid "Released under <a href=\"%(url)s\">%(name)s</a>"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/impala/details.html:217
+#: src/olympia/addons/templates/addons/impala/details.html:222
 msgid "About this Add-on"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/impala/details.html:233
+#: src/olympia/addons/templates/addons/impala/details.html:238
 msgid "Developer’s Comments"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/impala/details.html:243
+#: src/olympia/addons/templates/addons/impala/details.html:248
 msgid "Version Information"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/impala/details.html:250
+#: src/olympia/addons/templates/addons/impala/details.html:255
 msgid "See complete version history"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/impala/details.html:262
+#: src/olympia/addons/templates/addons/impala/details.html:267
 msgid ""
 "The Development Channel lets you test an experimental new version of this add-on before it's released to the general public. Once you install the development version, you will continue to get "
 "updates from this channel. To stop receiving development updates, reinstall the default version from the link above."
 msgstr ""
 
-#: src/olympia/addons/templates/addons/impala/details.html:272
+#: src/olympia/addons/templates/addons/impala/details.html:277
 msgid "<strong>Caution:</strong> Development versions of this add-on have not been reviewed by Mozilla."
 msgstr ""
 
-#: src/olympia/addons/templates/addons/impala/details.html:287
+#: src/olympia/addons/templates/addons/impala/details.html:292
 msgid "See complete development channel history"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/impala/details.html:306 src/olympia/addons/templates/addons/impala/details.html:315 src/olympia/addons/templates/addons/impala/details.html:327
+#: src/olympia/addons/templates/addons/impala/details.html:311 src/olympia/addons/templates/addons/impala/details.html:320 src/olympia/addons/templates/addons/impala/details.html:332
 #: src/olympia/addons/templates/addons/impala/review_add_box.html:4 src/olympia/stats/templates/stats/popup.html:2 src/olympia/stats/templates/stats/popup.html:8
-#: src/olympia/stats/templates/stats/stats.html:202 src/olympia/users/templates/users/profile.html:119
+#: src/olympia/stats/templates/stats/stats.html:204 src/olympia/users/templates/users/profile.html:119
 msgid "close"
 msgstr ""
 
@@ -1127,15 +1128,11 @@ msgstr ""
 msgid "Source Code License"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/impala/persona_grid.html:16 src/olympia/addons/templates/addons/impala/toplist.html:6
-msgid "{0} users"
-msgstr ""
-
 #: src/olympia/addons/templates/addons/impala/review_list_box.html:19 src/olympia/reviews/templates/reviews/review.html:40
 msgid "permalink"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/impala/review_list_box.html:23 src/olympia/editors/templates/editors/queue.html:98 src/olympia/reviews/templates/reviews/review.html:44
+#: src/olympia/addons/templates/addons/impala/review_list_box.html:23 src/olympia/editors/templates/editors/queue.html:104 src/olympia/reviews/templates/reviews/review.html:44
 msgid "translate"
 msgstr ""
 
@@ -1154,6 +1151,10 @@ msgstr ""
 msgid "Be the first!"
 msgstr ""
 
+#: src/olympia/addons/templates/addons/impala/toplist.html:6
+msgid "{0} users"
+msgstr ""
+
 #: src/olympia/addons/templates/addons/impala/listing/sorter.html:14 src/olympia/devhub/templates/devhub/addons/listing/item_actions.html:49
 msgid "More"
 msgstr ""
@@ -1166,7 +1167,7 @@ msgstr ""
 msgid "My Add-ons"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/includes/dashboard_tabs.html:6 src/olympia/amo/context_processors.py:51
+#: src/olympia/addons/templates/addons/includes/dashboard_tabs.html:6 src/olympia/amo/context_processors.py:50
 msgid "My Themes"
 msgstr ""
 
@@ -1221,7 +1222,7 @@ msgstr ""
 msgid "Weekly Downloads"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/mobile/details.html:99 src/olympia/compat/templates/compat/reporter_detail.html:46 src/olympia/devhub/forms.py:787
+#: src/olympia/addons/templates/addons/mobile/details.html:99 src/olympia/compat/templates/compat/reporter_detail.html:46 src/olympia/devhub/forms.py:788
 #: src/olympia/devhub/templates/devhub/versions/list.html:163
 msgid "Version"
 msgstr ""
@@ -1305,7 +1306,7 @@ msgstr ""
 #: src/olympia/browse/templates/browse/personas/category_landing.html:21 src/olympia/browse/templates/browse/personas/category_landing.html:23
 #: src/olympia/browse/templates/browse/personas/category_landing.html:38 src/olympia/browse/templates/browse/personas/grid.html:7 src/olympia/browse/templates/browse/personas/grid.html:11
 #: src/olympia/browse/templates/browse/personas/mobile/base.html:7 src/olympia/browse/templates/browse/personas/mobile/category_landing.html:19 src/olympia/constants/base.py:180
-#: src/olympia/devhub/templates/devhub/personas/submit.html:13 src/olympia/editors/helpers.py:105 src/olympia/editors/templates/editors/base.html:26
+#: src/olympia/devhub/templates/devhub/personas/submit.html:13 src/olympia/editors/helpers.py:107 src/olympia/editors/templates/editors/base.html:26
 #: src/olympia/editors/templates/editors/performance.html:73 src/olympia/search/templates/search/personas.html:39 src/olympia/templates/menu_links.html:9
 msgid "Themes"
 msgstr ""
@@ -1326,7 +1327,7 @@ msgstr ""
 msgid "Highest Rated"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/mobile/home.html:74 src/olympia/amo/templates/amo/side_nav.html:5 src/olympia/amo/templates/amo/site_nav.html:27 src/olympia/amo/templates/amo/site_nav.html:57
+#: src/olympia/addons/templates/addons/mobile/home.html:74 src/olympia/amo/templates/amo/side_nav.html:5 src/olympia/amo/templates/amo/site_nav.html:27 src/olympia/amo/templates/amo/site_nav.html:55
 #: src/olympia/bandwagon/views.py:97 src/olympia/browse/views.py:57 src/olympia/browse/views.py:67 src/olympia/browse/templates/browse/personas/mobile/category_landing.html:65
 #: src/olympia/search/forms.py:15 src/olympia/search/forms.py:87
 msgid "Newest"
@@ -1340,90 +1341,90 @@ msgstr ""
 msgid "Theme Info &raquo;"
 msgstr ""
 
-#: src/olympia/amo/context_processors.py:39 src/olympia/devhub/templates/devhub/nav.html:43
+#: src/olympia/amo/context_processors.py:37 src/olympia/devhub/templates/devhub/nav.html:43
 msgid "Tools"
 msgstr ""
 
-#: src/olympia/amo/context_processors.py:48 src/olympia/discovery/templates/discovery/pane_account.html:8 src/olympia/users/templates/users/includes/navigation.html:2
+#: src/olympia/amo/context_processors.py:47 src/olympia/discovery/templates/discovery/pane_account.html:8 src/olympia/users/templates/users/includes/navigation.html:2
 msgid "My Profile"
 msgstr ""
 
-#: src/olympia/amo/context_processors.py:54 src/olympia/users/templates/users/edit.html:5 src/olympia/users/templates/users/includes/navigation.html:3
+#: src/olympia/amo/context_processors.py:53 src/olympia/users/templates/users/edit.html:5 src/olympia/users/templates/users/includes/navigation.html:3
 msgid "Account Settings"
 msgstr ""
 
-#: src/olympia/amo/context_processors.py:57 src/olympia/discovery/templates/discovery/pane_account.html:11 src/olympia/users/templates/users/profile.html:83
+#: src/olympia/amo/context_processors.py:56 src/olympia/discovery/templates/discovery/pane_account.html:11 src/olympia/users/templates/users/profile.html:83
 #: src/olympia/users/templates/users/includes/navigation.html:4
 msgid "My Collections"
 msgstr ""
 
-#: src/olympia/amo/context_processors.py:62 src/olympia/discovery/templates/discovery/pane_account.html:10 src/olympia/users/templates/users/includes/navigation.html:7
+#: src/olympia/amo/context_processors.py:61 src/olympia/discovery/templates/discovery/pane_account.html:10 src/olympia/users/templates/users/includes/navigation.html:7
 msgid "My Favorites"
 msgstr ""
 
-#: src/olympia/amo/context_processors.py:67 src/olympia/discovery/templates/discovery/pane_account.html:13 src/olympia/templates/impala/user_login.html:14
+#: src/olympia/amo/context_processors.py:66 src/olympia/discovery/templates/discovery/pane_account.html:13 src/olympia/templates/impala/user_login.html:14
 #: src/olympia/templates/mobile/header_auth.html:5
 msgid "Log out"
 msgstr ""
 
-#: src/olympia/amo/context_processors.py:72 src/olympia/devhub/templates/devhub/addons/dashboard.html:4
+#: src/olympia/amo/context_processors.py:71 src/olympia/devhub/templates/devhub/addons/dashboard.html:4
 msgid "Manage My Submissions"
 msgstr ""
 
-#: src/olympia/amo/context_processors.py:75 src/olympia/devhub/templates/devhub/nav.html:27 src/olympia/devhub/templates/devhub/addons/dashboard.html:25
+#: src/olympia/amo/context_processors.py:74 src/olympia/devhub/templates/devhub/nav.html:27 src/olympia/devhub/templates/devhub/addons/dashboard.html:25
 #: src/olympia/devhub/templates/devhub/addons/submit/base.html:4
 msgid "Submit a New Add-on"
 msgstr ""
 
-#: src/olympia/amo/context_processors.py:77 src/olympia/browse/templates/browse/personas/base.html:50 src/olympia/devhub/templates/devhub/index.html:24
+#: src/olympia/amo/context_processors.py:76 src/olympia/browse/templates/browse/personas/base.html:50 src/olympia/devhub/templates/devhub/index.html:24
 #: src/olympia/devhub/templates/devhub/addons/dashboard.html:29
 msgid "Submit a New Theme"
 msgstr ""
 
-#: src/olympia/amo/context_processors.py:79 src/olympia/amo/templates/amo/site_nav.html:87 src/olympia/devhub/helpers.py:36 src/olympia/devhub/helpers.py:68 src/olympia/devhub/helpers.py:102
+#: src/olympia/amo/context_processors.py:78 src/olympia/amo/templates/amo/site_nav.html:85 src/olympia/devhub/helpers.py:36 src/olympia/devhub/helpers.py:68 src/olympia/devhub/helpers.py:102
 #: src/olympia/templates/footer.html:6 src/olympia/templates/menu_links.html:14
 msgid "Developer Hub"
 msgstr ""
 
-#: src/olympia/amo/context_processors.py:83 src/olympia/devhub/views.py:1792
+#: src/olympia/amo/context_processors.py:81 src/olympia/devhub/views.py:1796
 msgid "Manage API Keys"
 msgstr ""
 
-#: src/olympia/amo/context_processors.py:88 src/olympia/editors/helpers.py:82 src/olympia/editors/helpers.py:102 src/olympia/editors/templates/editors/base.html:10
+#: src/olympia/amo/context_processors.py:86 src/olympia/editors/helpers.py:84 src/olympia/editors/helpers.py:104 src/olympia/editors/templates/editors/base.html:10
 msgid "Editor Tools"
 msgstr ""
 
-#: src/olympia/amo/context_processors.py:92
+#: src/olympia/amo/context_processors.py:90
 msgid "Admin Tools"
 msgstr ""
 
-#: src/olympia/amo/fields.py:15
+#: src/olympia/amo/fields.py:20
 msgid "Incorrect, please try again."
 msgstr ""
 
-#: src/olympia/amo/fields.py:16
+#: src/olympia/amo/fields.py:21
 msgid "Error verifying input, please try again."
 msgstr ""
 
-#: src/olympia/amo/fields.py:32
+#: src/olympia/amo/fields.py:37
 msgid "This must be a valid hex color code, such as #000000."
 msgstr ""
 
-#: src/olympia/amo/fields.py:58
+#: src/olympia/amo/fields.py:63
 msgid "Enter at least one value."
 msgstr ""
 
-#: src/olympia/amo/helpers.py:162 src/olympia/amo/templates/amo/site_nav.html:61 src/olympia/bandwagon/templates/bandwagon/add.html:9
+#: src/olympia/amo/helpers.py:162 src/olympia/amo/templates/amo/site_nav.html:59 src/olympia/bandwagon/templates/bandwagon/add.html:9
 #: src/olympia/bandwagon/templates/bandwagon/collection_detail.html:15 src/olympia/bandwagon/templates/bandwagon/delete.html:9 src/olympia/bandwagon/templates/bandwagon/edit.html:15
 #: src/olympia/bandwagon/templates/bandwagon/user_listing.html:18 src/olympia/bandwagon/templates/bandwagon/user_listing.html:21
 #: src/olympia/bandwagon/templates/bandwagon/impala/collection_listing.html:12 src/olympia/bandwagon/templates/bandwagon/impala/collection_listing.html:20
 #: src/olympia/bandwagon/templates/bandwagon/impala/collection_listing.html:24 src/olympia/bandwagon/templates/bandwagon/impala/collection_sidebar.html:3
 #: src/olympia/bandwagon/templates/bandwagon/includes/collection_sidebar.html:2 src/olympia/bandwagon/templates/bandwagon/mobile/collection_listing.html:3
-#: src/olympia/stats/templates/stats/stats.html:77 src/olympia/templates/menu_links.html:12
+#: src/olympia/stats/templates/stats/stats.html:33 src/olympia/templates/menu_links.html:12
 msgid "Collections"
 msgstr ""
 
-#: src/olympia/amo/helpers.py:171 src/olympia/amo/templates/amo/site_nav.html:85 src/olympia/browse/templates/browse/language_tools.html:3
+#: src/olympia/amo/helpers.py:171 src/olympia/amo/templates/amo/site_nav.html:83 src/olympia/browse/templates/browse/language_tools.html:3
 msgid "Dictionaries & Language Packs"
 msgstr ""
 
@@ -1575,8 +1576,8 @@ msgstr ""
 msgid "Comment on {addon} {version}."
 msgstr ""
 
-#: src/olympia/amo/log.py:236 src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:19 src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:47
-#: src/olympia/editors/helpers.py:511 src/olympia/editors/templates/editors/themes/history_table.html:11
+#: src/olympia/amo/log.py:236 src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:17 src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:45
+#: src/olympia/editors/helpers.py:584 src/olympia/editors/templates/editors/themes/history_table.html:11
 msgid "Comment"
 msgstr ""
 
@@ -1899,7 +1900,7 @@ msgstr ""
 #: src/olympia/amo/templates/amo/mobile/paginator.html:14 src/olympia/amo/templates/amo/mobile/paginator.html:16 src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:51
 #: src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:65 src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:78
 #: src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:91 src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:104
-#: src/olympia/discovery/templates/discovery/pane.html:45 src/olympia/discovery/templates/discovery/addons/detail.html:39 src/olympia/stats/templates/stats/stats.html:167
+#: src/olympia/discovery/templates/discovery/pane.html:45 src/olympia/discovery/templates/discovery/addons/detail.html:39 src/olympia/stats/templates/stats/stats.html:169
 msgid "Next"
 msgstr ""
 
@@ -1931,7 +1932,7 @@ msgid ""
 msgstr ""
 
 #: src/olympia/amo/templates/amo/side_nav.html:4 src/olympia/amo/templates/amo/side_nav.html:12 src/olympia/amo/templates/amo/site_nav.html:4 src/olympia/amo/templates/amo/site_nav.html:26
-#: src/olympia/browse/views.py:56 src/olympia/browse/views.py:66 src/olympia/browse/views.py:237 src/olympia/browse/views.py:282 src/olympia/search/forms.py:86
+#: src/olympia/browse/views.py:56 src/olympia/browse/views.py:66 src/olympia/browse/views.py:204 src/olympia/browse/views.py:249 src/olympia/search/forms.py:86
 msgid "Top Rated"
 msgstr ""
 
@@ -1945,38 +1946,38 @@ msgstr ""
 msgid "Extensions"
 msgstr ""
 
-#: src/olympia/amo/templates/amo/site_nav.html:45
+#: src/olympia/amo/templates/amo/site_nav.html:44
 msgid "Want more customization? Try <b>Complete Themes</b>"
 msgstr ""
 
-#: src/olympia/amo/templates/amo/site_nav.html:56 src/olympia/bandwagon/views.py:96
+#: src/olympia/amo/templates/amo/site_nav.html:54 src/olympia/bandwagon/views.py:96
 msgid "Most Followers"
 msgstr ""
 
-#: src/olympia/amo/templates/amo/site_nav.html:68 src/olympia/bandwagon/templates/bandwagon/impala/collection_sidebar.html:16
+#: src/olympia/amo/templates/amo/site_nav.html:66 src/olympia/bandwagon/templates/bandwagon/impala/collection_sidebar.html:16
 #: src/olympia/bandwagon/templates/bandwagon/includes/collection_sidebar.html:18
 msgid "Collections I've Made"
 msgstr ""
 
-#: src/olympia/amo/templates/amo/site_nav.html:70 src/olympia/bandwagon/templates/bandwagon/user_listing.html:4 src/olympia/bandwagon/templates/bandwagon/impala/collection_sidebar.html:13
+#: src/olympia/amo/templates/amo/site_nav.html:68 src/olympia/bandwagon/templates/bandwagon/user_listing.html:4 src/olympia/bandwagon/templates/bandwagon/impala/collection_sidebar.html:13
 #: src/olympia/bandwagon/templates/bandwagon/includes/collection_sidebar.html:15
 msgid "Collections I'm Following"
 msgstr ""
 
-#: src/olympia/amo/templates/amo/site_nav.html:73 src/olympia/bandwagon/templates/bandwagon/impala/collection_sidebar.html:18
-#: src/olympia/bandwagon/templates/bandwagon/includes/collection_sidebar.html:20 src/olympia/users/models.py:512
+#: src/olympia/amo/templates/amo/site_nav.html:71 src/olympia/bandwagon/templates/bandwagon/impala/collection_sidebar.html:18
+#: src/olympia/bandwagon/templates/bandwagon/includes/collection_sidebar.html:20 src/olympia/users/models.py:521
 msgid "My Favorite Add-ons"
 msgstr ""
 
-#: src/olympia/amo/templates/amo/site_nav.html:78
+#: src/olympia/amo/templates/amo/site_nav.html:76
 msgid "More&hellip;"
 msgstr ""
 
-#: src/olympia/amo/templates/amo/site_nav.html:82
+#: src/olympia/amo/templates/amo/site_nav.html:80
 msgid "Add-ons for Mobile"
 msgstr ""
 
-#: src/olympia/amo/templates/amo/site_nav.html:86 src/olympia/browse/feeds.py:207 src/olympia/browse/templates/browse/search_tools.html:3 src/olympia/constants/base.py:176
+#: src/olympia/amo/templates/amo/site_nav.html:84 src/olympia/browse/feeds.py:207 src/olympia/browse/templates/browse/search_tools.html:3 src/olympia/constants/base.py:176
 #: src/olympia/templates/menu_links.html:10
 msgid "Search Tools"
 msgstr ""
@@ -1992,7 +1993,7 @@ msgid "Jump to first page"
 msgstr ""
 
 #: src/olympia/amo/templates/amo/impala/paginator.html:22 src/olympia/amo/templates/amo/mobile/impala_paginator.html:12 src/olympia/discovery/templates/discovery/pane.html:44
-#: src/olympia/discovery/templates/discovery/addons/detail.html:38 src/olympia/stats/templates/stats/stats.html:164
+#: src/olympia/discovery/templates/discovery/addons/detail.html:38 src/olympia/stats/templates/stats/stats.html:166
 msgid "Previous"
 msgstr ""
 
@@ -2015,30 +2016,49 @@ msgid_plural "Page {n}"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/olympia/amo/templates/services/install.html:38
-#, python-format
-msgid "If you are not prompted to install %(addon_name)s in a moment, please <a href=\"%(addon_xpi)s\">click here</a>."
-msgstr ""
-
-#: src/olympia/amo/tests/test_messages.py:57 src/olympia/amo/tests/test_messages.py:58 src/olympia/reviews/forms.py:25 src/olympia/reviews/forms.py:50 src/olympia/reviews/templates/reviews/add.html:56
+#: src/olympia/amo/tests/test_messages.py:56 src/olympia/amo/tests/test_messages.py:57 src/olympia/reviews/forms.py:25 src/olympia/reviews/forms.py:50 src/olympia/reviews/templates/reviews/add.html:56
 #: src/olympia/reviews/templates/reviews/reply.html:30
 msgid "Title"
 msgstr ""
 
-#: src/olympia/amo/tests/test_messages.py:57 src/olympia/amo/tests/test_messages.py:58
+#: src/olympia/amo/tests/test_messages.py:56 src/olympia/amo/tests/test_messages.py:57
 msgid "Body"
 msgstr ""
 
-#: src/olympia/amo/tests/test_messages.py:59
+#: src/olympia/amo/tests/test_messages.py:58
 msgid "Another Title"
 msgstr ""
 
-#: src/olympia/amo/tests/test_messages.py:59
+#: src/olympia/amo/tests/test_messages.py:58
 msgid "Another Body"
 msgstr ""
 
-#: src/olympia/api/views.py:255
-msgid "Not implemented yet."
+#: src/olympia/api/authentication.py:76
+msgid "Signature has expired."
+msgstr ""
+
+#: src/olympia/api/authentication.py:79
+msgid "Error decoding signature."
+msgstr ""
+
+#: src/olympia/api/authentication.py:82
+msgid "Invalid JWT Token."
+msgstr ""
+
+#: src/olympia/api/authentication.py:130
+msgid "Invalid Authorization header. No credentials provided."
+msgstr ""
+
+#: src/olympia/api/authentication.py:133
+msgid "Invalid Authorization header. Credentials string should not contain spaces."
+msgstr ""
+
+#: src/olympia/api/fields.py:29
+msgid "The field must have a length of at least {num} characters."
+msgstr ""
+
+#: src/olympia/api/fields.py:31
+msgid "The language code {lang_code} is invalid."
 msgstr ""
 
 #: src/olympia/applications/views.py:39 src/olympia/applications/templates/applications/appversions.html:3
@@ -2057,7 +2077,7 @@ msgstr ""
 msgid "Add-ons submitted to Mozilla Add-ons must have a manifest file with at least one of the below applications supported. Only the versions listed below are allowed for these applications."
 msgstr ""
 
-#: src/olympia/applications/templates/applications/appversions.html:25
+#: src/olympia/applications/templates/applications/appversions.html:25 src/olympia/editors/helpers.py:361
 msgid "GUID"
 msgstr ""
 
@@ -2171,8 +2191,8 @@ msgstr ""
 msgid "Remove from favorites"
 msgstr ""
 
-#: src/olympia/bandwagon/views.py:98 src/olympia/bandwagon/views.py:191 src/olympia/browse/views.py:58 src/olympia/browse/views.py:69 src/olympia/browse/views.py:458 src/olympia/devhub/views.py:74
-#: src/olympia/devhub/views.py:82 src/olympia/devhub/templates/devhub/addons/edit/basic.html:20 src/olympia/editors/templates/editors/leaderboard.html:24
+#: src/olympia/bandwagon/views.py:98 src/olympia/bandwagon/views.py:191 src/olympia/browse/views.py:58 src/olympia/browse/views.py:69 src/olympia/browse/views.py:425 src/olympia/devhub/views.py:72
+#: src/olympia/devhub/views.py:80 src/olympia/devhub/templates/devhub/addons/edit/basic.html:20 src/olympia/editors/templates/editors/leaderboard.html:24
 #: src/olympia/editors/templates/editors/themes/queue_list.html:48 src/olympia/search/forms.py:17 src/olympia/search/forms.py:89 src/olympia/users/templates/users/vcard.html:5
 msgid "Name"
 msgstr ""
@@ -2181,7 +2201,7 @@ msgstr ""
 msgid "Recently Popular"
 msgstr ""
 
-#: src/olympia/bandwagon/views.py:189 src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:18
+#: src/olympia/bandwagon/views.py:189 src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:16
 msgid "Added"
 msgstr ""
 
@@ -2195,7 +2215,7 @@ msgstr ""
 
 #: src/olympia/bandwagon/views.py:316
 #, python-format
-msgid "Your new collection is shown below. You can <ahref=\"%(url)s\">edit additional settings</a> if you'dlike."
+msgid "Your new collection is shown below. You can <a href=\"%(url)s\">edit additional settings</a> if you'd like."
 msgstr ""
 
 #: src/olympia/bandwagon/views.py:322
@@ -2323,8 +2343,8 @@ msgid_plural "%(num)s Add-ons in this Collection"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/olympia/bandwagon/templates/bandwagon/collection_detail.html:125 src/olympia/compat/templates/compat/index.html:25 src/olympia/compat/templates/compat/reporter_detail.html:29
-#: src/olympia/files/templates/files/viewer.html:29 src/olympia/templates/amo_footer.html:17 src/olympia/templates/includes/lang_switcher.html:10
+#: src/olympia/bandwagon/templates/bandwagon/collection_detail.html:125 src/olympia/compat/templates/compat/reporter_detail.html:29 src/olympia/files/templates/files/viewer.html:29
+#: src/olympia/templates/amo_footer.html:17 src/olympia/templates/includes/lang_switcher.html:10
 msgid "Go"
 msgstr ""
 
@@ -2491,7 +2511,7 @@ msgid "Remove this user as a contributor"
 msgstr ""
 
 #: src/olympia/bandwagon/templates/bandwagon/edit_contributors.html:18 src/olympia/bandwagon/templates/bandwagon/edit_contributors.html:43
-#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:20 src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:48
+#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:18 src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:46
 #: src/olympia/devhub/templates/devhub/addons/ajax_compat_update.html:19
 msgid "Remove"
 msgstr ""
@@ -2539,7 +2559,7 @@ msgid "<b>Warning:</b> By changing the owner of this collection, you will no lon
 msgstr ""
 
 #: src/olympia/bandwagon/templates/bandwagon/edit_contributors.html:83 src/olympia/devhub/templates/devhub/addons/forms_shared/media.html:157
-#: src/olympia/devhub/templates/devhub/addons/submit/describe.html:69 src/olympia/devhub/templates/devhub/addons/submit/license.html:60 src/olympia/devhub/templates/devhub/addons/submit/upload.html:78
+#: src/olympia/devhub/templates/devhub/addons/submit/describe.html:69 src/olympia/devhub/templates/devhub/addons/submit/license.html:60 src/olympia/devhub/templates/devhub/addons/submit/upload.html:70
 #: src/olympia/devhub/templates/devhub/payments/tier.html:17 src/olympia/editors/templates/editors/themes/themes.html:111 src/olympia/editors/templates/editors/themes/themes.html:128
 #: src/olympia/editors/templates/editors/themes/themes.html:134 src/olympia/editors/templates/editors/themes/themes.html:141 src/olympia/users/templates/users/fxa_migration_prompt_content.html:10
 #: src/olympia/users/templates/users/login_form.html:42 src/olympia/users/templates/users/mobile/login.html:57
@@ -2622,31 +2642,31 @@ msgid "Add-ons in Your Collection"
 msgstr ""
 
 #: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:4
-msgid ""
-"To include an add-on in this collection, enter its name in the box below and hit enter.  You can also use the <strong>Add to Collection</strong> links throughout the site to include add-ons later."
+msgid "To include an add-on in this collection, enter its name in the box below and hit enter."
 msgstr ""
 
-#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:17 src/olympia/constants/base.py:400 src/olympia/devhub/templates/devhub/addons/activity.html:62
+#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:15 src/olympia/constants/base.py:400 src/olympia/devhub/templates/devhub/addons/activity.html:62
+#: src/olympia/editors/helpers.py:273 src/olympia/editors/helpers.py:360
 msgid "Add-on"
 msgstr ""
 
-#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:26
+#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:24
 msgid "Enter the name of the add-on to include"
 msgstr ""
 
-#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:28
+#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:26
 msgid "Add to Collection"
 msgstr ""
 
-#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:45 src/olympia/editors/helpers.py:936 src/olympia/editors/helpers.py:956
+#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:43 src/olympia/editors/helpers.py:1016 src/olympia/editors/helpers.py:1036
 msgid "Pending"
 msgstr ""
 
-#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:47
+#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:45
 msgid "Add a comment"
 msgstr ""
 
-#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:48
+#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:46
 msgid "Remove this add-on from the collection"
 msgstr ""
 
@@ -2753,12 +2773,12 @@ msgstr ""
 msgid "Most Users"
 msgstr ""
 
-#: src/olympia/browse/views.py:61 src/olympia/browse/views.py:72 src/olympia/browse/views.py:279 src/olympia/browse/templates/browse/personas/mobile/category_landing.html:63
+#: src/olympia/browse/views.py:61 src/olympia/browse/views.py:72 src/olympia/browse/views.py:246 src/olympia/browse/templates/browse/personas/mobile/category_landing.html:63
 #: src/olympia/discovery/templates/discovery/pane.html:67 src/olympia/search/forms.py:92
 msgid "Up & Coming"
 msgstr ""
 
-#: src/olympia/browse/views.py:460 src/olympia/devhub/views.py:76 src/olympia/devhub/views.py:83 src/olympia/discovery/templates/discovery/addons/detail.html:66
+#: src/olympia/browse/views.py:427 src/olympia/devhub/views.py:74 src/olympia/devhub/views.py:81 src/olympia/discovery/templates/discovery/addons/detail.html:66
 msgid "Created"
 msgstr ""
 
@@ -2946,8 +2966,8 @@ msgid_plural "See all %(cnt)s extensions in %(name)s &raquo;"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/olympia/browse/templates/browse/mobile/extensions.html:13 src/olympia/compat/templates/compat/index.html:82 src/olympia/devhub/templates/devhub/devhub_search.html:24
-#: src/olympia/devhub/templates/devhub/addons/activity.html:47 src/olympia/search/templates/search/no_results.html:4 src/olympia/search/templates/search/mobile/results.html:36
+#: src/olympia/browse/templates/browse/mobile/extensions.html:13 src/olympia/devhub/templates/devhub/devhub_search.html:24 src/olympia/devhub/templates/devhub/addons/activity.html:47
+#: src/olympia/search/templates/search/no_results.html:4 src/olympia/search/templates/search/mobile/results.html:36
 msgid "No results found."
 msgstr ""
 
@@ -3032,7 +3052,7 @@ msgstr ""
 msgid "All"
 msgstr ""
 
-#: src/olympia/compat/forms.py:22 src/olympia/search/views.py:525
+#: src/olympia/compat/forms.py:22 src/olympia/editors/templates/editors/base.html:69 src/olympia/search/views.py:518
 msgid "All Add-ons"
 msgstr ""
 
@@ -3042,53 +3062,6 @@ msgstr ""
 
 #: src/olympia/compat/forms.py:24
 msgid "Non-binary"
-msgstr ""
-
-#. Review points sources other than add-ons and themes.
-#: src/olympia/compat/views.py:87 src/olympia/constants/base.py:388 src/olympia/devhub/forms.py:162 src/olympia/editors/templates/editors/performance.html:75
-msgid "Other"
-msgstr ""
-
-#: src/olympia/compat/templates/compat/index.html:4
-msgid "Add-on Compatibility Report for {app} {version}"
-msgstr ""
-
-#: src/olympia/compat/templates/compat/index.html:11
-msgid "{app} {version} Compatibility"
-msgstr ""
-
-#: src/olympia/compat/templates/compat/index.html:17
-#, python-format
-msgid "Top 95%% compatible with previous version"
-msgstr ""
-
-#: src/olympia/compat/templates/compat/index.html:18
-#, python-format
-msgid "Top 95%% of all add-ons"
-msgstr ""
-
-#: src/olympia/compat/templates/compat/index.html:19
-msgid "All active add-ons"
-msgstr ""
-
-#: src/olympia/compat/templates/compat/index.html:23 src/olympia/constants/base.py:401
-msgid "App"
-msgstr ""
-
-#: src/olympia/compat/templates/compat/index.html:55
-msgid "Details for add-ons compatible with previous version:"
-msgstr ""
-
-#: src/olympia/compat/templates/compat/index.html:57
-msgid "Show all versions"
-msgstr ""
-
-#: src/olympia/compat/templates/compat/index.html:59
-msgid "Details for add-ons compatible with all versions:"
-msgstr ""
-
-#: src/olympia/compat/templates/compat/index.html:61
-msgid "Show previous version only"
 msgstr ""
 
 #: src/olympia/compat/templates/compat/reporter.html:3
@@ -3142,8 +3115,8 @@ msgstr ""
 msgid "Report Type"
 msgstr ""
 
-#: src/olympia/compat/templates/compat/reporter_detail.html:47 src/olympia/devhub/forms.py:784 src/olympia/devhub/templates/devhub/addons/ajax_compat_update.html:17 src/olympia/editors/forms.py:108
-#: src/olympia/zadmin/forms.py:45
+#: src/olympia/compat/templates/compat/reporter_detail.html:47 src/olympia/devhub/forms.py:785 src/olympia/devhub/templates/devhub/addons/ajax_compat_update.html:17 src/olympia/editors/forms.py:108
+#: src/olympia/editors/forms.py:248 src/olympia/zadmin/forms.py:45
 msgid "Application"
 msgstr ""
 
@@ -3231,7 +3204,8 @@ msgstr ""
 msgid "Preliminarily Reviewed and Awaiting Full Review"
 msgstr ""
 
-#: src/olympia/constants/base.py:33 src/olympia/editors/helpers.py:924 src/olympia/editors/templates/editors/themes/history_table.html:34
+#: src/olympia/constants/base.py:33 src/olympia/editors/forms.py:258 src/olympia/editors/helpers.py:73 src/olympia/editors/helpers.py:1004
+#: src/olympia/editors/templates/editors/themes/history_table.html:34
 msgid "Deleted"
 msgstr ""
 
@@ -3328,6 +3302,11 @@ msgstr ""
 msgid "Ask before users can download this add-on"
 msgstr ""
 
+#. Review points sources other than add-ons and themes.
+#: src/olympia/constants/base.py:388 src/olympia/devhub/forms.py:162 src/olympia/editors/templates/editors/performance.html:75
+msgid "Other"
+msgstr ""
+
 #: src/olympia/constants/base.py:389
 msgid "Exception"
 msgstr ""
@@ -3338,6 +3317,10 @@ msgstr ""
 
 #: src/olympia/constants/base.py:391
 msgid "Change"
+msgstr ""
+
+#: src/olympia/constants/base.py:401
+msgid "App"
 msgstr ""
 
 #: src/olympia/constants/base.py:402
@@ -3488,7 +3471,7 @@ msgstr ""
 msgid "Duplicate"
 msgstr ""
 
-#: src/olympia/constants/editors.py:17 src/olympia/editors/helpers.py:502 src/olympia/editors/templates/editors/themes/queue.html:71 src/olympia/editors/templates/editors/themes/themes.html:94
+#: src/olympia/constants/editors.py:17 src/olympia/editors/helpers.py:575 src/olympia/editors/templates/editors/themes/queue.html:71 src/olympia/editors/templates/editors/themes/themes.html:94
 msgid "Reject"
 msgstr ""
 
@@ -3588,7 +3571,7 @@ msgstr ""
 msgid "Android"
 msgstr ""
 
-#: src/olympia/core/apps.py:19
+#: src/olympia/core/apps.py:21
 msgid "Core"
 msgstr ""
 
@@ -3722,7 +3705,7 @@ msgid "Submit my add-on for manual review."
 msgstr ""
 
 #: src/olympia/devhub/forms.py:537
-msgid "Do not list my add-on on this site (beta)"
+msgid "Do not list my add-on on this site"
 msgstr ""
 
 #: src/olympia/devhub/forms.py:538
@@ -3755,46 +3738,46 @@ msgstr ""
 
 #: src/olympia/devhub/forms.py:592
 #, python-format
-msgid "Version %s already exists"
+msgid "Version %s already exists, or was uploaded before."
 msgstr ""
 
-#: src/olympia/devhub/forms.py:604
+#: src/olympia/devhub/forms.py:605
 msgid "Select a valid choice. That choice is not one of the available choices."
 msgstr ""
 
-#: src/olympia/devhub/forms.py:610
+#: src/olympia/devhub/forms.py:611
 msgid "A file with a version ending with a|alpha|b|beta and an optional number is detected as beta."
 msgstr ""
 
-#: src/olympia/devhub/forms.py:633
+#: src/olympia/devhub/forms.py:634
 msgid "You cannot upload any more files for this version."
 msgstr ""
 
-#: src/olympia/devhub/forms.py:639
+#: src/olympia/devhub/forms.py:640
 msgid "Version doesn't match"
 msgstr ""
 
-#: src/olympia/devhub/forms.py:668
+#: src/olympia/devhub/forms.py:669
 msgid "You cannot delete a file once the review process has started.  You must delete the whole version."
 msgstr ""
 
-#: src/olympia/devhub/forms.py:688
+#: src/olympia/devhub/forms.py:689
 msgid "The platform All cannot be combined with specific platforms."
 msgstr ""
 
-#: src/olympia/devhub/forms.py:693
+#: src/olympia/devhub/forms.py:694
 msgid "A platform can only be chosen once."
 msgstr ""
 
-#: src/olympia/devhub/forms.py:706
+#: src/olympia/devhub/forms.py:707
 msgid "A review type must be selected."
 msgstr ""
 
-#: src/olympia/devhub/forms.py:788 src/olympia/editors/forms.py:114 src/olympia/zadmin/forms.py:49 src/olympia/zadmin/forms.py:52
+#: src/olympia/devhub/forms.py:789 src/olympia/editors/forms.py:114 src/olympia/editors/forms.py:254 src/olympia/zadmin/forms.py:49 src/olympia/zadmin/forms.py:52
 msgid "Select an application first"
 msgstr ""
 
-#: src/olympia/devhub/forms.py:840
+#: src/olympia/devhub/forms.py:841
 msgid "There cannot be more than 3 required add-ons."
 msgstr ""
 
@@ -3828,76 +3811,76 @@ msgstr[1] ""
 msgid "Review"
 msgstr ""
 
-#: src/olympia/devhub/tasks.py:551
+#: src/olympia/devhub/tasks.py:583
 #, python-format
 msgid "%s responded with %s (%s)."
 msgstr ""
 
-#: src/olympia/devhub/tasks.py:555
+#: src/olympia/devhub/tasks.py:587
 #, python-format
 msgid "Connection to \"%s\" timed out."
 msgstr ""
 
-#: src/olympia/devhub/tasks.py:557
+#: src/olympia/devhub/tasks.py:589
 #, python-format
 msgid "Could not contact host at \"%s\"."
 msgstr ""
 
-#: src/olympia/devhub/utils.py:104
+#: src/olympia/devhub/utils.py:105
 #, python-format
 msgid "Validation generated too many errors/warnings so %s messages were truncated. After addressing the visible messages, you'll be able to see the others."
 msgstr ""
 
-#: src/olympia/devhub/views.py:183
+#: src/olympia/devhub/views.py:181
 msgid "All My Add-ons"
 msgstr ""
 
-#: src/olympia/devhub/views.py:210
+#: src/olympia/devhub/views.py:208
 msgid "All Activity"
 msgstr ""
 
-#: src/olympia/devhub/views.py:211
+#: src/olympia/devhub/views.py:209
 msgid "Add-on Updates"
 msgstr ""
 
-#: src/olympia/devhub/views.py:212
+#: src/olympia/devhub/views.py:210
 msgid "Add-on Status"
 msgstr ""
 
-#: src/olympia/devhub/views.py:213
+#: src/olympia/devhub/views.py:211
 msgid "User Collections"
 msgstr ""
 
-#: src/olympia/devhub/views.py:214 src/olympia/devhub/templates/devhub/docs/policies-maintenance.html:68 src/olympia/pages/templates/pages/dev_faq.html:38
+#: src/olympia/devhub/views.py:212 src/olympia/devhub/templates/devhub/docs/policies-maintenance.html:68 src/olympia/pages/templates/pages/dev_faq.html:38
 #: src/olympia/pages/templates/pages/dev_faq.html:484
 msgid "User Reviews"
 msgstr ""
 
-#: src/olympia/devhub/views.py:327 src/olympia/devhub/views.py:331 src/olympia/devhub/views.py:484 src/olympia/devhub/views.py:513 src/olympia/devhub/views.py:564 src/olympia/devhub/views.py:1150
+#: src/olympia/devhub/views.py:325 src/olympia/devhub/views.py:329 src/olympia/devhub/views.py:484 src/olympia/devhub/views.py:513 src/olympia/devhub/views.py:564 src/olympia/devhub/views.py:1156
 msgid "Changes successfully saved."
 msgstr ""
 
-#: src/olympia/devhub/views.py:334 src/olympia/devhub/views.py:1631
+#: src/olympia/devhub/views.py:332 src/olympia/devhub/views.py:1637
 msgid "Please check the form for errors."
 msgstr ""
 
-#: src/olympia/devhub/views.py:346
+#: src/olympia/devhub/views.py:344
 msgid "Add-on cannot be deleted. Disable this add-on instead."
 msgstr ""
 
-#: src/olympia/devhub/views.py:356
+#: src/olympia/devhub/views.py:354
 msgid "Theme deleted."
 msgstr ""
 
-#: src/olympia/devhub/views.py:356
+#: src/olympia/devhub/views.py:354
 msgid "Add-on deleted."
 msgstr ""
 
-#: src/olympia/devhub/views.py:362
+#: src/olympia/devhub/views.py:360
 msgid "URL name was incorrect. Theme was not deleted."
 msgstr ""
 
-#: src/olympia/devhub/views.py:367
+#: src/olympia/devhub/views.py:365
 msgid "URL name was incorrect. Add-on was not deleted."
 msgstr ""
 
@@ -3925,7 +3908,7 @@ msgstr ""
 msgid "Check Add-on Compatibility"
 msgstr ""
 
-#: src/olympia/devhub/views.py:808 src/olympia/signing/views.py:90
+#: src/olympia/devhub/views.py:808 src/olympia/signing/views.py:95
 msgid "You cannot submit this type of add-on"
 msgstr ""
 
@@ -3955,33 +3938,33 @@ msgstr ""
 msgid "There was an error uploading your preview."
 msgstr ""
 
-#: src/olympia/devhub/views.py:1189
+#: src/olympia/devhub/views.py:1195
 #, python-format
 msgid "Version %s disabled."
 msgstr ""
 
-#: src/olympia/devhub/views.py:1193
+#: src/olympia/devhub/views.py:1199
 #, python-format
 msgid "Version %s deleted."
 msgstr ""
 
-#: src/olympia/devhub/views.py:1203
+#: src/olympia/devhub/views.py:1209
 msgid "This upload has failed validation, and may lack complete validation results. Please take due care when reviewing it."
 msgstr ""
 
-#: src/olympia/devhub/views.py:1677
+#: src/olympia/devhub/views.py:1683
 msgid "Preliminary Review Requested."
 msgstr ""
 
-#: src/olympia/devhub/views.py:1678
+#: src/olympia/devhub/views.py:1684
 msgid "Full Review Requested."
 msgstr ""
 
-#: src/olympia/devhub/views.py:1779
+#: src/olympia/devhub/views.py:1783
 msgid "Your old credentials were revoked and are no longer valid. Be sure to update all API clients with the new credentials."
 msgstr ""
 
-#: src/olympia/devhub/views.py:1797
+#: src/olympia/devhub/views.py:1801
 msgid "New API key created"
 msgstr ""
 
@@ -4011,7 +3994,7 @@ msgstr ""
 msgid "{0} :: Search"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/devhub_search.html:6 src/olympia/devhub/templates/devhub/search.html:8 src/olympia/editors/forms.py:435 src/olympia/editors/forms.py:437
+#: src/olympia/devhub/templates/devhub/devhub_search.html:6 src/olympia/devhub/templates/devhub/search.html:8 src/olympia/editors/forms.py:534 src/olympia/editors/forms.py:536
 #: src/olympia/editors/templates/editors/queue.html:27 src/olympia/editors/templates/editors/themes/queue_list.html:14 src/olympia/search/templates/search/collections.html:17
 #: src/olympia/search/templates/search/personas.html:18 src/olympia/search/templates/search/results.html:18 src/olympia/search/templates/search/mobile/results.html:8
 #: src/olympia/templates/search.html:14 src/olympia/templates/impala/search.html:18
@@ -4071,12 +4054,12 @@ msgstr ""
 msgid "Start Making Add-ons"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/index.html:86 src/olympia/devhub/templates/devhub/addons/listing/items.html:25 src/olympia/devhub/templates/devhub/includes/addon_details.html:15
+#: src/olympia/devhub/templates/devhub/index.html:86 src/olympia/devhub/templates/devhub/addons/listing/items.html:25 src/olympia/devhub/templates/devhub/includes/addon_details.html:20
 #: src/olympia/devhub/templates/devhub/personas/edit.html:43
 msgid "Status:"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/index.html:90 src/olympia/devhub/templates/devhub/includes/addon_details.html:100
+#: src/olympia/devhub/templates/devhub/index.html:90 src/olympia/devhub/templates/devhub/includes/addon_details.html:87
 msgid "Visibility:"
 msgstr ""
 
@@ -4084,11 +4067,11 @@ msgstr ""
 msgid "Latest Version:"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/index.html:109 src/olympia/devhub/templates/devhub/includes/addon_details.html:145 src/olympia/devhub/templates/devhub/personas/edit.html:49
+#: src/olympia/devhub/templates/devhub/index.html:109 src/olympia/devhub/templates/devhub/includes/addon_details.html:131 src/olympia/devhub/templates/devhub/personas/edit.html:49
 msgid "Queue Position:"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/index.html:110 src/olympia/devhub/templates/devhub/includes/addon_details.html:146 src/olympia/devhub/templates/devhub/personas/edit.html:50
+#: src/olympia/devhub/templates/devhub/index.html:110 src/olympia/devhub/templates/devhub/includes/addon_details.html:132 src/olympia/devhub/templates/devhub/personas/edit.html:50
 #, python-format
 msgid "%(position)s of %(total)s"
 msgstr ""
@@ -4190,16 +4173,6 @@ msgstr ""
 msgid "Do you want your add-on to be distributed on this site?"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/validate_addon.html:49 src/olympia/devhub/templates/devhub/addons/submit/upload.html:30 src/olympia/devhub/templates/devhub/versions/add_file_modal.html:14
-#: src/olympia/devhub/templates/devhub/versions/add_file_modal.html:53 src/olympia/devhub/templates/devhub/versions/list.html:298
-msgid "Warning:"
-msgstr ""
-
-#: src/olympia/devhub/templates/devhub/validate_addon.html:50 src/olympia/devhub/templates/devhub/addons/submit/upload.html:31
-#, python-format
-msgid "Submission of unlisted add-ons for signing is currently in an open beta. Please <a href=\"%(url)s\" target=\"_blank\">report any bugs</a> that you encounter."
-msgstr ""
-
 #. first parameter is a filename like lorem-ipsum-1.0.2.xpi
 #: src/olympia/devhub/templates/devhub/validation.html:5
 msgid "Validation Results for {0}"
@@ -4274,7 +4247,7 @@ msgstr ""
 msgid "Update Compatibility"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/addons/ajax_compat_update.html:4
+#: src/olympia/devhub/templates/devhub/addons/ajax_compat_update.html:4 src/olympia/devhub/templates/devhub/versions/edit.html:45
 msgid "Adjusting application information here will allow users to install your add-on even if the install manifest in the package indicates that the add-on is incompatible."
 msgstr ""
 
@@ -4286,9 +4259,9 @@ msgstr ""
 msgid "Add Another Application&hellip;"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/addons/ajax_compat_update.html:38 src/olympia/devhub/templates/devhub/addons/owner.html:86 src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:46
-#: src/olympia/devhub/templates/devhub/versions/list.html:351 src/olympia/devhub/templates/devhub/versions/list.html:353 src/olympia/templates/impala/base.html:132
-#: src/olympia/templates/impala/base.html:143 src/olympia/templates/impala/base.html:161 src/olympia/templates/impala/base.html:171
+#: src/olympia/devhub/templates/devhub/addons/ajax_compat_update.html:38 src/olympia/devhub/templates/devhub/addons/owner.html:86 src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:45
+#: src/olympia/devhub/templates/devhub/versions/list.html:349 src/olympia/devhub/templates/devhub/versions/list.html:351 src/olympia/templates/impala/base.html:129
+#: src/olympia/templates/impala/base.html:140 src/olympia/templates/impala/base.html:158 src/olympia/templates/impala/base.html:168
 msgid "Close"
 msgstr ""
 
@@ -4322,7 +4295,7 @@ msgstr ""
 msgid "Manage Authors & License"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/addons/owner.html:29 src/olympia/editors/templates/editors/review.html:270
+#: src/olympia/devhub/templates/devhub/addons/owner.html:29 src/olympia/editors/helpers.py:362 src/olympia/editors/templates/editors/review.html:270
 msgid "Authors"
 msgstr ""
 
@@ -4391,17 +4364,11 @@ msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/basic.html:52
 msgid ""
-"A short explanation of your add-on's basic\n"
-"                          functionality that is displayed in search and browse\n"
-"                          listings, as well as at the top of your add-on's\n"
-"                          details page. It is only relevant for listed add-ons."
+"A short explanation of your add-on's basic functionality that is displayed in search and browse listings, as well as at the top of your add-on's details page. It is only relevant for listed add-ons."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/basic.html:73
-msgid ""
-"Categories are the primary way users browse through add-ons.\n"
-"                        Choose any that fit your add-on's functionality for the most\n"
-"                        exposure. It is only relevant for listed add-ons."
+msgid "Categories are the primary way users browse through add-ons. Choose any that fit your add-on's functionality for the most exposure. It is only relevant for listed add-ons."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/basic.html:90
@@ -4411,11 +4378,7 @@ msgid ""
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/basic.html:119
-msgid ""
-"Tags help users find your add-on and should be short\n"
-"                        descriptors such as tabs, toolbar, or twitter.  You\n"
-"                        may have a maximum of {0} tags. It is only relevant\n"
-"                        for listed add-ons."
+msgid "Tags help users find your add-on and should be short descriptors such as tabs, toolbar, or twitter. You may have a maximum of {0} tags. It is only relevant for listed add-ons."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/basic.html:129 src/olympia/devhub/templates/devhub/personas/edit.html:97 src/olympia/devhub/templates/devhub/personas/submit.html:46
@@ -4443,11 +4406,7 @@ msgid "Add-on Details for {0}"
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/details.html:22
-msgid ""
-"A longer explanation of features,\n"
-"                          functionality, and other relevant information. This\n"
-"                          field is only displayed on the add-on's details\n"
-"                          page. It is only relevant for listed add-ons."
+msgid "A longer explanation of features, functionality, and other relevant information. This field is only displayed on the add-on's details page. It is only relevant for listed add-ons."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/details.html:44 src/olympia/translations/templates/translations/trans-menu.html:13
@@ -4455,10 +4414,7 @@ msgid "Default Locale"
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/details.html:45
-msgid ""
-"Information about your add-on is displayed in this locale\n"
-"                        unless you override it with a locale-specific translation.\n"
-"                        It is only relevant for listed add-ons."
+msgid "Information about your add-on is displayed in this locale unless you override it with a locale-specific translation. It is only relevant for listed add-ons."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/details.html:61 src/olympia/users/forms.py:311 src/olympia/users/templates/users/edit.html:122 src/olympia/users/templates/users/register.html:57
@@ -4468,10 +4424,8 @@ msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/details.html:63
 msgid ""
-"If your add-on has another homepage, enter its\n"
-"                          address here. If your website is localized into other\n"
-"                          languages multiple translations of this field can be\n"
-"                          added. It is only relevant for listed add-ons."
+"If your add-on has another homepage, enter its address here. If your website is localized into other languages multiple translations of this field can be added. It is only relevant for listed add-"
+"ons."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/media.html:3
@@ -4489,19 +4443,14 @@ msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/support.html:22
 msgid ""
-"If you wish to display an e-mail address for support\n"
-"                          inquiries, enter it here. If you have different\n"
-"                          addresses for each language multiple translations of\n"
-"                          this field can be added. It is only relevant for\n"
-"                          listed add-ons."
+"If you wish to display an e-mail address for support inquiries, enter it here. If you have different addresses for each language multiple translations of this field can be added. It is only "
+"relevant for listed add-ons."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/support.html:45
 msgid ""
-"If your add-on has a support website or forum, enter\n"
-"                          its address here. If your website is localized into\n"
-"                          other languages, multiple translations of this field can\n"
-"                          be added. It is only relevant for listed add-ons."
+"If your add-on has a support website or forum, enter its address here. If your website is localized into other languages, multiple translations of this field can be added. It is only relevant for "
+"listed add-ons."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:6
@@ -4515,11 +4464,8 @@ msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:23
 msgid ""
-"Any information end users may want to know that isn't\n"
-"                          necessarily applicable to the add-on summary or description.\n"
-"                          Common uses include listing known major bugs, information on\n"
-"                          how to report bugs, anticipated release date of a new version,\n"
-"                          etc. It is only relevant for listed add-ons."
+"Any information end users may want to know that isn't necessarily applicable to the add-on summary or description. Common uses include listing known major bugs, information on how to report bugs, "
+"anticipated release date of a new version, etc. It is only relevant for listed add-ons."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:46
@@ -4531,9 +4477,7 @@ msgid "Add-on Flags"
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:69
-msgid ""
-"These flags are used to classify add-ons. It is only\n"
-"                        relevant for listed add-ons."
+msgid "These flags are used to classify add-ons. It is only relevant for listed add-ons."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:74
@@ -4549,9 +4493,7 @@ msgid "View Source?"
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:90
-msgid ""
-"Whether the source of your add-on can be displayed in our\n"
-"                        online viewer. It is only relevant for listed add-ons."
+msgid "Whether the source of your add-on can be displayed in our online viewer. It is only relevant for listed add-ons."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:94
@@ -4567,10 +4509,7 @@ msgid "Public Stats?"
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:102
-msgid ""
-"Whether the download and usage stats of your add-on can\n"
-"                        be displayed in our online viewer.\n"
-"                        It is only relevant for listed add-ons."
+msgid "Whether the download and usage stats of your add-on can be displayed in our online viewer. It is only relevant for listed add-ons."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:107
@@ -4586,10 +4525,7 @@ msgid "Upgrade SDK?"
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:116
-msgid ""
-"If selected, we will try to automatically upgrade your\n"
-"                        add-on when a new version of the SDK is released.\n"
-"                        It is only relevant for listed add-ons."
+msgid "If selected, we will try to automatically upgrade your add-on when a new version of the SDK is released. It is only relevant for listed add-ons."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:121
@@ -4640,10 +4576,8 @@ msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/forms_shared/media.html:16
 msgid ""
-"Upload an icon for your add-on or choose from one of ours. The\n"
-"                      icon is displayed nearly everywhere your add-on is. Uploaded images\n"
-"                      must be one of the following image types: .png, .jpg.\n"
-"                      It is only relevant for listed add-ons."
+"Upload an icon for your add-on or choose from one of ours. The icon is displayed nearly everywhere your add-on is. Uploaded images must be one of the following image types: .png, .jpg. It is only "
+"relevant for listed add-ons."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/forms_shared/media.html:25
@@ -4656,9 +4590,7 @@ msgid "32x32px"
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/forms_shared/media.html:39
-msgid ""
-"Used in listings of add-ons, like search results\n"
-"                            and featured add-ons."
+msgid "Used in listings of add-ons, like search results and featured add-ons."
 msgstr ""
 
 #. The size of the icon
@@ -4753,16 +4685,14 @@ msgid "Deleting your add-on will permanently remove it from the site and prevent
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:24
-msgid ""
-"Enter the following text confirm your decision:\n"
-"           {slug}"
+msgid "Enter the following text confirm your decision: {slug}"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:34
+#: src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:33
 msgid "Please tell us why you are deleting your theme:"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:36
+#: src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:35
 msgid "Please tell us why you are deleting your add-on:"
 msgstr ""
 
@@ -4799,8 +4729,8 @@ msgstr ""
 msgid "Daily statistics on downloads and users."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/addons/listing/item_actions.html:45 src/olympia/stats/templates/stats/stats.html:75 src/olympia/stats/templates/stats/stats.html:79
-#: src/olympia/stats/templates/stats/stats.html:81
+#: src/olympia/devhub/templates/devhub/addons/listing/item_actions.html:45 src/olympia/stats/templates/stats/stats.html:31 src/olympia/stats/templates/stats/stats.html:35
+#: src/olympia/stats/templates/stats/stats.html:37
 msgid "Statistics"
 msgstr ""
 
@@ -4919,10 +4849,7 @@ msgid "Your add-on has been submitted to the Full Review queue."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/submit/done.html:18
-msgid ""
-"You'll receive an email once it has been reviewed by an editor. In\n"
-"          the meantime, you and your friends can install it directly from its\n"
-"          details page:"
+msgid "You'll receive an email once it has been reviewed by an editor. In the meantime, you and your friends can install it directly from its details page:"
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/submit/done.html:27 src/olympia/devhub/templates/devhub/addons/submit/done.html:77 src/olympia/devhub/templates/devhub/personas/submit_done.html:16
@@ -5128,11 +5055,11 @@ msgstr ""
 msgid "Use the fields below to upload your add-on package and select any platform restrictions. After upload, a series of automated validation tests will be run on your file."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/addons/submit/upload.html:59 src/olympia/devhub/templates/devhub/versions/add_file_modal.html:39
+#: src/olympia/devhub/templates/devhub/addons/submit/upload.html:51 src/olympia/devhub/templates/devhub/versions/add_file_modal.html:28
 msgid "Which platforms is this file compatible with?"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/addons/submit/upload.html:67 src/olympia/devhub/templates/devhub/versions/add_file_modal.html:65
+#: src/olympia/devhub/templates/devhub/addons/submit/upload.html:59 src/olympia/devhub/templates/devhub/versions/add_file_modal.html:45
 msgid "Administrative overrides"
 msgstr ""
 
@@ -5242,8 +5169,8 @@ msgstr ""
 
 #: src/olympia/devhub/templates/devhub/docs/policies-contact.html:44
 msgid ""
-"If you've found a problem with the site, we'd love to fix it. Please <a href=\"https://github.com/mozilla/olympia/issues\">file a bug report</a> in GitHub, including the location of the problem and "
-"how you encountered it."
+"If you've found a problem with the site, we'd love to fix it. Please <a href=\"https://github.com/mozilla/addons/issues/new\">file a bug report</a> in GitHub, including the location of the problem "
+"and how you encountered it."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/docs/policies-maintenance.html:3 src/olympia/devhub/templates/devhub/docs/policies-maintenance.html:7
@@ -5810,7 +5737,7 @@ msgstr ""
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:282
 msgid ""
-"Add-ons that store or otherwise handle browsing data must support <a href=\"https://developer.mozilla.org/En/Supporting_private_browsing_mode\">Private Browsing Mode</a>.  During a Private Browsing "
+"Add-ons that store or otherwise handle browsing data must support <a href=\"https://developer.mozilla.org/En/Supporting_private_browsing_mode\">Private Browsing Mode</a>. During a Private Browsing "
 "session, no browsing data can be written to disk, and all of this data must be cleared when Firefox quits or the Private Browsing session ends."
 msgstr ""
 
@@ -5975,129 +5902,95 @@ msgstr ""
 msgid "How to get in touch with us regarding these policies or your add-on."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:6
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:10
 msgid "You have disabled this add-on"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:20
-msgid ""
-"Your add-on's listing is disabled and is not showing\n"
-"                             anywhere in our gallery or update service."
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:24
+msgid "Your add-on's listing is disabled and is not showing anywhere in our gallery or update service."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:25
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:27
 msgid "Please complete your add-on."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:29
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:30
 msgid "You will receive an email when the review is complete."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:34
-msgid ""
-"You will receive an email when the review is complete. Until\n"
-"                             then, your add-on is not listed in our gallery but can be\n"
-"                             accessed directly from its details page."
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:33
+msgid "You will receive an email when the review is complete. Until then, your add-on is not listed in our gallery but can be accessed directly from its details page."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:38 src/olympia/devhub/templates/devhub/includes/addon_details.html:48
-msgid ""
-"You will receive an email when the review is\n"
-"                             complete and your add-on is signed."
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:37 src/olympia/devhub/templates/devhub/includes/addon_details.html:45
+msgid "You will receive an email when the review is complete and your add-on is signed."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:44
-msgid ""
-"You will receive an email when the review is complete. Until\n"
-"                             then, your add-on is not listed in our gallery but can be\n"
-"                             accessed directly from its details page. "
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:41
+msgid "You will receive an email when the review is complete. Until then, your add-on is not listed in our gallery but can be accessed directly from its details page. "
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:54
-msgid ""
-"Your add-on is displayed in our gallery and users are\n"
-"                             receiving automatic updates."
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:49
+msgid "Your add-on is displayed in our gallery and users are receiving automatic updates."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:57
-msgid ""
-"Your add-on has been signed and can be bundled with an\n"
-"                             application installer."
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:52
+msgid "Your add-on has been signed and can be bundled with an application installer."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:63
-msgid ""
-"Your add-on was disabled by a site administrator and is no\n"
-"                             longer shown in our gallery. If you have any questions,\n"
-"                             please email amo-admins@mozilla.org."
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:56
+msgid "Your add-on was disabled by a site administrator and is no longer shown in our gallery. If you have any questions, please email amo-admins@mozilla.org."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:70
-msgid ""
-"Your add-on is displayed in our gallery as experimental\n"
-"                             and users are receiving automatic updates. Some features\n"
-"                             are unavailable to your add-on."
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:62
+msgid "Your add-on is displayed in our gallery as experimental and users are receiving automatic updates. Some features are unavailable to your add-on."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:74
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:66
 msgid "Your add-on has been signed."
 msgstr ""
 
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:69
+msgid ""
+"You will receive an email when the full review is complete. Until then, your add-on is displayed in our gallery as experimental and users are receiving automatic updates. Some features are "
+"unavailable to your add-on."
+msgstr ""
+
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:74
+msgid "You will receive an email when the full review is complete, making you able to bundle your add-on with an application installer."
+msgstr ""
+
 #: src/olympia/devhub/templates/devhub/includes/addon_details.html:79
-msgid ""
-"You will receive an email when the full review is complete.\n"
-"                             Until then, your add-on is displayed in our gallery as\n"
-"                             experimental and users are receiving automatic updates.\n"
-"                             Some features are unavailable to your add-on."
+msgid "All add-ons hosted in our gallery must now be reviewed by an editor. If you wish to continue hosting your add-on, please click to select a review process."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:84
-msgid ""
-"You will receive an email when the full review is\n"
-"                             complete, making you able to bundle your add-on with an\n"
-"                             application installer."
-msgstr ""
-
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:91
-msgid ""
-"All add-ons hosted in our gallery must now be reviewed by an\n"
-"                             editor. If you wish to continue hosting your add-on, please\n"
-"                             click to select a review process."
-msgstr ""
-
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:113
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:100
 msgid "Current Version:"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:115
-msgid ""
-"This is the version of your add-on that will\n"
-"                                           be installed if someone clicks the Install\n"
-"                                           button on addons.mozilla.org. It is only\n"
-"                                           relevant for listed add-ons."
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:102
+msgid "This is the version of your add-on that will be installed if someone clicks the Install button on addons.mozilla.org. It is only relevant for listed add-ons."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:123
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:110
 msgid "Created:"
 msgstr ""
 
 #. {0} is a date. dennis-ignore: E201
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:125 src/olympia/devhub/templates/devhub/includes/addon_details.html:131
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:112 src/olympia/devhub/templates/devhub/includes/addon_details.html:118
 #, python-format
 msgid "%%b %%e, %%Y"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:136
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:123
 msgid "Next Version:"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:138
-msgid ""
-"This is the newest uploaded version, however\n"
-"                                           it isn’t live on the site yet."
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:125
+msgid "This is the newest uploaded version, however it isn’t live on the site yet."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:144 src/olympia/devhub/templates/devhub/versions/list.html:30
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:130 src/olympia/devhub/templates/devhub/versions/list.html:30
 msgid "Queues are not reviewed strictly in order"
 msgstr ""
 
@@ -6165,9 +6058,7 @@ msgid "View the blog &#9658;"
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/includes/license_form.html:6
-msgid ""
-"Please choose a license appropriate for the rights you grant on your source code.\n"
-"                  It is only relevant for listed add-ons."
+msgid "Please choose a license appropriate for the rights you grant on your source code. It is only relevant for listed add-ons."
 msgstr ""
 
 #. {0} is a list of HTML tags.
@@ -6194,14 +6085,11 @@ msgstr[1] ""
 #: src/olympia/devhub/templates/devhub/includes/policy_form.html:4
 msgid ""
 "Users will be required to accept the following End-User License Agreement (EULA) prior to installing your add-on. The presence of a EULA significantly affects the number of downloads an add-on "
-"receives. Please note that a EULA is not the same as a code license, such as the GPL or MPL.\n"
-"                It is only relevant for listed add-ons."
+"receives. Please note that a EULA is not the same as a code license, such as the GPL or MPL.It is only relevant for listed add-ons."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/policy_form.html:21
-msgid ""
-"If your add-on transmits any data from the user's computer, a privacy policy is required that explains what data is sent and how it is used.\n"
-"                It is only relevant for listed add-ons."
+#: src/olympia/devhub/templates/devhub/includes/policy_form.html:24
+msgid "If your add-on transmits any data from the user's computer, a privacy policy is required that explains what data is sent and how it is used. It is only relevant for listed add-ons."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/includes/source_form_field.html:2
@@ -6369,12 +6257,8 @@ msgstr ""
 msgid "Add some tags to describe your Theme."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/personas/edit.html:106
-msgid ""
-"A short explanation of your theme's\n"
-"                                basic functionality that is displayed in\n"
-"                                search and browse listings, as well as at\n"
-"                                the top of your theme's details page."
+#: src/olympia/devhub/templates/devhub/personas/edit.html:106 src/olympia/devhub/templates/devhub/personas/submit.html:54
+msgid "A short explanation of your theme's basic functionality that is displayed in search and browse listings, as well as at the top of your theme's details page."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/personas/edit.html:122 src/olympia/devhub/templates/devhub/personas/submit.html:68
@@ -6444,7 +6328,7 @@ msgid "Upon upload and form submission, the AMO Team will review your updated de
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/personas/edit.html:241
-msgid "Your previously resubmitted design,  which is under pending review."
+msgid "Your previously resubmitted design, which is under pending review."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/personas/edit.html:245
@@ -6511,14 +6395,6 @@ msgstr ""
 
 #: src/olympia/devhub/templates/devhub/personas/submit.html:33
 msgid "Give your Theme a name."
-msgstr ""
-
-#: src/olympia/devhub/templates/devhub/personas/submit.html:54
-msgid ""
-"A short explanation of your theme's\n"
-"                                      basic functionality that is displayed in\n"
-"                                      search and browse listings, as well as at\n"
-"                                      the top of your theme's details page."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/personas/submit.html:198
@@ -6595,30 +6471,16 @@ msgstr ""
 msgid "Files added to reviewed versions must be reviewed before they will be available for download."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/add_file_modal.html:15
-#, python-format
-msgid ""
-"Submission of updates to unlisted add-ons for signing is currently in an open beta. Manual review may still be required for a large number of add-ons. Please <a href=\"%(url)s\" target=\"_blank"
-"\">report any bugs</a> that you encounter."
-msgstr ""
-
-#: src/olympia/devhub/templates/devhub/versions/add_file_modal.html:35
+#: src/olympia/devhub/templates/devhub/versions/add_file_modal.html:24
 msgid "Select the target platform for this file."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/add_file_modal.html:46
+#: src/olympia/devhub/templates/devhub/versions/add_file_modal.html:35
 msgid "Which review type would you like to nominate for?"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/add_file_modal.html:51
+#: src/olympia/devhub/templates/devhub/versions/add_file_modal.html:40
 msgid "Only publish this version to my beta channel."
-msgstr ""
-
-#: src/olympia/devhub/templates/devhub/versions/add_file_modal.html:54
-#, python-format
-msgid ""
-"The behavior of the beta channel has changed to accommodate <a href=\"%(addon_signing_url)s\" target=\"_blank\">mandatory add-on signing</a>. The new process is currently in an open beta, and may "
-"change significantly in the near future. Please <a href=\"%(issues_url)s\" target=\"_blank\">report any bugs</a> that you encounter."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/versions/edit.html:5
@@ -6642,19 +6504,10 @@ msgstr ""
 msgid "Upload Another File"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/edit.html:45
-msgid ""
-"Adjusting application information here will allow users to install your\n"
-"                          add-on even if the install manifest in the package indicates that the\n"
-"                          add-on is incompatible."
-msgstr ""
-
 #: src/olympia/devhub/templates/devhub/versions/edit.html:74
 msgid ""
-"Information about changes in this release, new features,\n"
-"                              known bugs, and other useful information specific to this\n"
-"                              release/version. This information is also shown in the\n"
-"                              Add-ons Manager when updating."
+"Information about changes in this release, new features, known bugs, and other useful information specific to this release/version. This information is also shown in the Add-ons Manager when "
+"updating."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/versions/edit.html:99
@@ -6666,10 +6519,7 @@ msgid "Notes for Reviewers"
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/versions/edit.html:114
-msgid ""
-"Optionally, enter any information that may be useful\n"
-"                              to the Editor reviewing this add-on, such as test\n"
-"                              account information."
+msgid "Optionally, enter any information that may be useful to the Editor reviewing this add-on, such as test account information."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/versions/edit.html:127
@@ -6747,7 +6597,7 @@ msgstr ""
 msgid "Request Preliminary Review"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:80 src/olympia/devhub/templates/devhub/versions/list.html:327 src/olympia/devhub/templates/devhub/versions/list.html:350
+#: src/olympia/devhub/templates/devhub/versions/list.html:80 src/olympia/devhub/templates/devhub/versions/list.html:325 src/olympia/devhub/templates/devhub/versions/list.html:348
 msgid "Cancel Review Request"
 msgstr ""
 
@@ -6776,7 +6626,7 @@ msgid "Unlisted:"
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/versions/list.html:114
-msgid "Not distributed on {0}. Developers will upload new versions for signing and distribute the add-ons on their own. (beta)"
+msgid "Not distributed on {0}. Developers will upload new versions for signing and distribute the add-ons on their own."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/versions/list.html:122
@@ -6839,81 +6689,73 @@ msgid "<strong>Important:</strong> Once a version has been deleted, you may not 
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/versions/list.html:230
-msgid ""
-"Deleting a version which has already been reviewed\n"
-"               may also cause a significant delay in the review of\n"
-"               your next update."
-msgstr ""
-
-#: src/olympia/devhub/templates/devhub/versions/list.html:233
 msgid "Are you sure you wish to delete this version?"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:238
+#: src/olympia/devhub/templates/devhub/versions/list.html:235
 msgid "Delete Version"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:240
+#: src/olympia/devhub/templates/devhub/versions/list.html:237
 msgid "Disable Version"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:247
+#: src/olympia/devhub/templates/devhub/versions/list.html:244
 msgid "Add a new Version"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:249
+#: src/olympia/devhub/templates/devhub/versions/list.html:246
 msgid "Add Version"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:256 src/olympia/devhub/templates/devhub/versions/list.html:274
+#: src/olympia/devhub/templates/devhub/versions/list.html:253 src/olympia/devhub/templates/devhub/versions/list.html:279
 msgid "Hide Add-on"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:259
+#: src/olympia/devhub/templates/devhub/versions/list.html:256
 msgid "Hiding your add-on will prevent it from appearing anywhere in our gallery and will stop users from receiving automatic updates."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:265
+#: src/olympia/devhub/templates/devhub/versions/list.html:263
+msgid "The files awaiting review will be disabled and you will need to upload new versions."
+msgstr ""
+
+#: src/olympia/devhub/templates/devhub/versions/list.html:270
 msgid "Are you sure you wish to hide your add-on?"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:286 src/olympia/devhub/templates/devhub/versions/list.html:315
+#: src/olympia/devhub/templates/devhub/versions/list.html:291 src/olympia/devhub/templates/devhub/versions/list.html:313
 msgid "Unlist Add-on"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:289
+#: src/olympia/devhub/templates/devhub/versions/list.html:294
 #, python-format
 msgid ""
 "Unlisting your add-on will make it (and each of its versions/files) invisible on this website. It won't show up in searches, won't have a public facing page, and won't be updated automatically for "
-"current users.  It is recommended for unlisted add-ons to provide a custom <a href=\"%(update_url)s\" target=\"_blank\">updateURL</a> in their manifest file for automatic updates."
+"current users. It is recommended for unlisted add-ons to provide a custom <a href=\"%(update_url)s\" target=\"_blank\">updateURL</a> in their manifest file for automatic updates."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:299
-#, python-format
-msgid "Switching add-ons to unlisted is currently in an open beta. Please <a href=\"%(url)s\" target=\"_blank\">report any bugs</a> that you encounter."
-msgstr ""
-
-#: src/olympia/devhub/templates/devhub/versions/list.html:305
+#: src/olympia/devhub/templates/devhub/versions/list.html:303
 msgid "Unlisting an add-on is irreversible!"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:305
+#: src/olympia/devhub/templates/devhub/versions/list.html:303
 msgid "An unlisted add-on cannot be switched to be listed."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:307
+#: src/olympia/devhub/templates/devhub/versions/list.html:305
 msgid "Are you sure you wish to unlist your add-on?"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:330
+#: src/olympia/devhub/templates/devhub/versions/list.html:328
 msgid "Canceling your review request will leave your add-on as preliminarily reviewed."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:335
+#: src/olympia/devhub/templates/devhub/versions/list.html:333
 msgid "Canceling your review request will mark your add-on incomplete. If you do not complete your add-on after several days by re-requesting review, it will be deleted."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:343
+#: src/olympia/devhub/templates/devhub/versions/list.html:341
 msgid "Are you sure you wish to cancel your review request?"
 msgstr ""
 
@@ -7252,19 +7094,19 @@ msgstr ""
 msgid "Search by add-on name / author email"
 msgstr ""
 
-#: src/olympia/editors/forms.py:103
+#: src/olympia/editors/forms.py:103 src/olympia/editors/forms.py:244 src/olympia/editors/forms.py:257
 msgid "yes"
 msgstr ""
 
-#: src/olympia/editors/forms.py:104
+#: src/olympia/editors/forms.py:104 src/olympia/editors/forms.py:244 src/olympia/editors/forms.py:257
 msgid "no"
 msgstr ""
 
-#: src/olympia/editors/forms.py:105
+#: src/olympia/editors/forms.py:105 src/olympia/editors/forms.py:245
 msgid "Admin Flag"
 msgstr ""
 
-#: src/olympia/editors/forms.py:113
+#: src/olympia/editors/forms.py:113 src/olympia/editors/forms.py:253
 msgid "Max. Version"
 msgstr ""
 
@@ -7276,55 +7118,59 @@ msgstr ""
 msgid "Add-on Types"
 msgstr ""
 
-#: src/olympia/editors/forms.py:126 src/olympia/editors/helpers.py:267
+#: src/olympia/editors/forms.py:126 src/olympia/editors/helpers.py:279
 msgid "Platforms"
 msgstr ""
 
+#: src/olympia/editors/forms.py:237
+msgid "Search by add-on name / author email / guid"
+msgstr ""
+
 #. L10n: 0 = platform, 1 = filename, 2 = status message
-#: src/olympia/editors/forms.py:238
+#: src/olympia/editors/forms.py:342
 #, python-format
 msgid "<strong>%s</strong> &middot; %s &middot; %s"
 msgstr ""
 
-#: src/olympia/editors/forms.py:252
+#: src/olympia/editors/forms.py:356
 msgid "Comments:"
 msgstr ""
 
-#: src/olympia/editors/forms.py:256
+#: src/olympia/editors/forms.py:360
 msgid "Operating systems:"
 msgstr ""
 
-#: src/olympia/editors/forms.py:258
+#: src/olympia/editors/forms.py:362
 msgid "Applications:"
 msgstr ""
 
-#: src/olympia/editors/forms.py:260
+#: src/olympia/editors/forms.py:364
 msgid "Notify me the next time this add-on is updated. (Subsequent updates will not generate an email)"
 msgstr ""
 
-#: src/olympia/editors/forms.py:265
+#: src/olympia/editors/forms.py:369
 msgid "Clear Admin Review Flag"
 msgstr ""
 
-#: src/olympia/editors/forms.py:267
+#: src/olympia/editors/forms.py:371
 msgid "Clear more info requested flag"
 msgstr ""
 
-#: src/olympia/editors/forms.py:281
+#: src/olympia/editors/forms.py:385
 msgid "Choose a canned response..."
 msgstr ""
 
 #. L10n: Description of what can be searched for.
-#: src/olympia/editors/forms.py:324
+#: src/olympia/editors/forms.py:423
 msgid "theme name"
 msgstr ""
 
-#: src/olympia/editors/forms.py:350
+#: src/olympia/editors/forms.py:449
 msgid "Someone else is reviewing this theme."
 msgstr ""
 
 #. L10n: Description of what can be searched for.
-#: src/olympia/editors/forms.py:447
+#: src/olympia/editors/forms.py:546
 msgid "app, reviewer, or comment"
 msgstr ""
 
@@ -7340,246 +7186,264 @@ msgstr ""
 msgid "Rejected or Unreviewed"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:123 src/olympia/editors/helpers.py:136
+#: src/olympia/editors/helpers.py:125 src/olympia/editors/helpers.py:138
 msgid "Queue"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:124 src/olympia/editors/templates/editors/base.html:50 src/olympia/editors/templates/editors/base.html:65
+#: src/olympia/editors/helpers.py:126 src/olympia/editors/templates/editors/base.html:50 src/olympia/editors/templates/editors/base.html:65
 msgid "Pending Updates"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:125 src/olympia/editors/templates/editors/base.html:48 src/olympia/editors/templates/editors/base.html:63
+#: src/olympia/editors/helpers.py:127 src/olympia/editors/templates/editors/base.html:48 src/olympia/editors/templates/editors/base.html:63
 msgid "Full Reviews"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:126 src/olympia/editors/templates/editors/base.html:52 src/olympia/editors/templates/editors/base.html:67
+#: src/olympia/editors/helpers.py:128 src/olympia/editors/templates/editors/base.html:52 src/olympia/editors/templates/editors/base.html:67
 msgid "Preliminary Reviews"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:127 src/olympia/editors/templates/editors/base.html:54
+#: src/olympia/editors/helpers.py:129 src/olympia/editors/templates/editors/base.html:54
 msgid "Moderated Reviews"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:128 src/olympia/editors/templates/editors/base.html:46
+#: src/olympia/editors/helpers.py:130 src/olympia/editors/templates/editors/base.html:46
 msgid "Fast Track"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:130
+#: src/olympia/editors/helpers.py:132
 msgid "Pending Themes"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:131 src/olympia/editors/templates/editors/themes/queue.html:4
+#: src/olympia/editors/helpers.py:133 src/olympia/editors/templates/editors/themes/queue.html:4
 msgid "Flagged Themes"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:132
+#: src/olympia/editors/helpers.py:134
 msgid "Update Themes"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:137
+#: src/olympia/editors/helpers.py:139
 msgid "Unlisted Pending Updates"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:138
+#: src/olympia/editors/helpers.py:140
 msgid "Unlisted Full Reviews"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:139
+#: src/olympia/editors/helpers.py:141
 msgid "Unlisted Preliminary Reviews"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:170
+#: src/olympia/editors/helpers.py:142
+msgid "Unlisted All Add-ons"
+msgstr ""
+
+#: src/olympia/editors/helpers.py:173
 msgid "Fast Track ({0})"
 msgid_plural "Fast Track ({0})"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/olympia/editors/helpers.py:175
+#: src/olympia/editors/helpers.py:178
 msgid "Full Review ({0})"
 msgid_plural "Full Reviews ({0})"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/olympia/editors/helpers.py:180
+#: src/olympia/editors/helpers.py:183
 msgid "Pending Update ({0})"
 msgid_plural "Pending Updates ({0})"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/olympia/editors/helpers.py:185
+#: src/olympia/editors/helpers.py:188
 msgid "Preliminary Review ({0})"
 msgid_plural "Preliminary Reviews ({0})"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/olympia/editors/helpers.py:190
+#: src/olympia/editors/helpers.py:193
 msgid "Moderated Review ({0})"
 msgid_plural "Moderated Reviews ({0})"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/olympia/editors/helpers.py:196
+#: src/olympia/editors/helpers.py:199
 msgid "Unlisted Full Review ({0})"
 msgid_plural "Unlisted Full Reviews ({0})"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/olympia/editors/helpers.py:201
+#: src/olympia/editors/helpers.py:204
 msgid "Unlisted Pending Update ({0})"
 msgid_plural "Unlisted Pending Updates ({0})"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/olympia/editors/helpers.py:206
+#: src/olympia/editors/helpers.py:209
 msgid "Unlisted Preliminary Review ({0})"
 msgid_plural "Unlisted Preliminary Reviews ({0})"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/olympia/editors/helpers.py:261
-msgid "Addon"
-msgstr ""
+#: src/olympia/editors/helpers.py:214
+msgid "Unlisted All Add-ons ({0})"
+msgid_plural "Unlisted All Add-ons ({0})"
+msgstr[0] ""
+msgstr[1] ""
 
-#: src/olympia/editors/helpers.py:262
+#: src/olympia/editors/helpers.py:274
 msgid "Type"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:263
+#: src/olympia/editors/helpers.py:275
 msgid "Waiting Time"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:264 src/olympia/editors/templates/editors/review.html:285
+#: src/olympia/editors/helpers.py:276 src/olympia/editors/templates/editors/review.html:285
 msgid "Flags"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:265
+#: src/olympia/editors/helpers.py:277
 msgid "Applications"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:270
+#: src/olympia/editors/helpers.py:282
 msgid "Additional"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:285
+#: src/olympia/editors/helpers.py:302
 msgid "Site Specific"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:287
+#: src/olympia/editors/helpers.py:304
 msgid "Requires External Software"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:289
+#: src/olympia/editors/helpers.py:306
 msgid "Binary Components"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:313
+#: src/olympia/editors/helpers.py:339
 msgid "moments ago"
 msgstr ""
 
 #. L10n: first argument is number of minutes
-#: src/olympia/editors/helpers.py:316
+#: src/olympia/editors/helpers.py:342
 msgid "{0} minute"
 msgid_plural "{0} minutes"
 msgstr[0] ""
 msgstr[1] ""
 
 #. L10n: first argument is number of hours
-#: src/olympia/editors/helpers.py:320
+#: src/olympia/editors/helpers.py:346
 msgid "{0} hour"
 msgid_plural "{0} hours"
 msgstr[0] ""
 msgstr[1] ""
 
 #. L10n: first argument is number of days
-#: src/olympia/editors/helpers.py:324
+#: src/olympia/editors/helpers.py:350
 msgid "{0} day"
 msgid_plural "{0} days"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/olympia/editors/helpers.py:488
+#: src/olympia/editors/helpers.py:364
+msgid "Last Review"
+msgstr ""
+
+#: src/olympia/editors/helpers.py:366
+msgid "Last Update"
+msgstr ""
+
+#: src/olympia/editors/helpers.py:387
+msgid "No Reviews"
+msgstr ""
+
+#: src/olympia/editors/helpers.py:561
 msgid "Push to public"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:490
+#: src/olympia/editors/helpers.py:563
 msgid "Grant full review"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:505
+#: src/olympia/editors/helpers.py:578
 msgid "Request more information"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:508
+#: src/olympia/editors/helpers.py:581
 msgid "Request super-review"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:519
+#: src/olympia/editors/helpers.py:592
 msgid "Grant preliminary review"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:520
+#: src/olympia/editors/helpers.py:593
 msgid "This will mark the files as preliminarily reviewed."
 msgstr ""
 
-#: src/olympia/editors/helpers.py:522
+#: src/olympia/editors/helpers.py:595
 msgid "Use this form to request more information from the author. They will receive an email and be able to answer here. You will be notified by email when they reply."
 msgstr ""
 
-#: src/olympia/editors/helpers.py:526
+#: src/olympia/editors/helpers.py:599
 msgid ""
 "If you have concerns about this add-on's security, copyright issues, or other concerns that an administrator should look into, enter your comments in the area below. They will be sent to "
 "administrators, not the author."
 msgstr ""
 
-#: src/olympia/editors/helpers.py:532
+#: src/olympia/editors/helpers.py:605
 msgid "This will reject the add-on and remove it from the review queue."
 msgstr ""
 
-#: src/olympia/editors/helpers.py:534
-msgid "Make a comment on this version.  The author won't be able to see this."
+#: src/olympia/editors/helpers.py:607
+msgid "Make a comment on this version. The author won't be able to see this."
 msgstr ""
 
-#: src/olympia/editors/helpers.py:538
+#: src/olympia/editors/helpers.py:611
 msgid "This will reject the files and remove them from the review queue."
 msgstr ""
 
-#: src/olympia/editors/helpers.py:542
+#: src/olympia/editors/helpers.py:615
 msgid "This will mark the add-on as preliminarily reviewed. Future versions will undergo preliminary review."
 msgstr ""
 
-#: src/olympia/editors/helpers.py:547
+#: src/olympia/editors/helpers.py:620
 msgid "This will mark the files as preliminarily reviewed. Future versions will undergo preliminary review."
 msgstr ""
 
-#: src/olympia/editors/helpers.py:552
+#: src/olympia/editors/helpers.py:625
 msgid "Retain preliminary review"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:553
+#: src/olympia/editors/helpers.py:626
 msgid "This will retain the add-on as preliminarily reviewed. Future versions will undergo preliminary review."
 msgstr ""
 
-#: src/olympia/editors/helpers.py:558
+#: src/olympia/editors/helpers.py:631
 msgid "This will approve a sandboxed version of a public add-on to appear on the public side."
 msgstr ""
 
-#: src/olympia/editors/helpers.py:561
+#: src/olympia/editors/helpers.py:634
 msgid "This will reject a version of a public add-on and remove it from the queue."
 msgstr ""
 
-#: src/olympia/editors/helpers.py:564
+#: src/olympia/editors/helpers.py:637
 msgid "This will mark the add-on and its most recent version and files as public. Future versions will go into the sandbox until they are reviewed by an editor."
 msgstr ""
 
-#: src/olympia/editors/helpers.py:637
+#: src/olympia/editors/helpers.py:714
 msgid "add-on"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:940 src/olympia/editors/helpers.py:960
+#: src/olympia/editors/helpers.py:1020 src/olympia/editors/helpers.py:1040
 msgid "Flagged"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:944 src/olympia/editors/helpers.py:963
+#: src/olympia/editors/helpers.py:1024 src/olympia/editors/helpers.py:1043
 msgid "Updates"
 msgstr ""
 
@@ -7631,56 +7495,56 @@ msgstr ""
 msgid "A question about your Theme submission"
 msgstr ""
 
-#: src/olympia/editors/views.py:144
+#: src/olympia/editors/views.py:146
 msgid "New Add-ons (Under 5 days)"
 msgstr ""
 
-#: src/olympia/editors/views.py:145
+#: src/olympia/editors/views.py:147
 msgid "Passable (5 to 10 days)"
 msgstr ""
 
-#: src/olympia/editors/views.py:146
+#: src/olympia/editors/views.py:148
 msgid "Overdue (Over 10 days)"
 msgstr ""
 
-#: src/olympia/editors/views.py:532
+#: src/olympia/editors/views.py:539
 msgid "An unknown error occurred"
 msgstr ""
 
-#: src/olympia/editors/views.py:587
+#: src/olympia/editors/views.py:592
 msgid "Self-reviews are not allowed."
 msgstr ""
 
-#: src/olympia/editors/views.py:609
+#: src/olympia/editors/views.py:613
 msgid "Review successfully processed."
 msgstr ""
 
-#: src/olympia/editors/views.py:807
+#: src/olympia/editors/views.py:812
 msgid "was approved"
 msgstr ""
 
-#: src/olympia/editors/views.py:808
+#: src/olympia/editors/views.py:813
 msgid "given preliminary review"
 msgstr ""
 
-#: src/olympia/editors/views.py:809
+#: src/olympia/editors/views.py:814
 msgid "rejected"
 msgstr ""
 
-#: src/olympia/editors/views.py:810
+#: src/olympia/editors/views.py:815
 msgctxt "editors_review_history_nominated_adminreview"
 msgid "escalated"
 msgstr ""
 
-#: src/olympia/editors/views.py:812
+#: src/olympia/editors/views.py:817
 msgid "needs more information"
 msgstr ""
 
-#: src/olympia/editors/views.py:813
+#: src/olympia/editors/views.py:818
 msgid "needs super review"
 msgstr ""
 
-#: src/olympia/editors/views.py:814
+#: src/olympia/editors/views.py:819
 msgid "commented"
 msgstr ""
 
@@ -7725,28 +7589,28 @@ msgstr ""
 msgid "Unlisted Queues"
 msgstr ""
 
-#: src/olympia/editors/templates/editors/base.html:72 src/olympia/editors/templates/editors/performance.html:6
+#: src/olympia/editors/templates/editors/base.html:74 src/olympia/editors/templates/editors/performance.html:6
 msgid "Performance"
 msgstr ""
 
-#: src/olympia/editors/templates/editors/base.html:75 src/olympia/editors/templates/editors/themes/base.html:19 src/olympia/editors/templates/editors/themes/base.html:38
+#: src/olympia/editors/templates/editors/base.html:77 src/olympia/editors/templates/editors/themes/base.html:19 src/olympia/editors/templates/editors/themes/base.html:38
 msgid "Logs"
 msgstr ""
 
-#: src/olympia/editors/templates/editors/base.html:78 src/olympia/editors/templates/editors/reviewlog.html:4 src/olympia/editors/templates/editors/reviewlog.html:27
+#: src/olympia/editors/templates/editors/base.html:80 src/olympia/editors/templates/editors/reviewlog.html:4 src/olympia/editors/templates/editors/reviewlog.html:27
 msgid "Add-on Review Log"
 msgstr ""
 
-#: src/olympia/editors/templates/editors/base.html:80 src/olympia/editors/templates/editors/eventlog.html:4 src/olympia/editors/templates/editors/eventlog.html:8
+#: src/olympia/editors/templates/editors/base.html:82 src/olympia/editors/templates/editors/eventlog.html:4 src/olympia/editors/templates/editors/eventlog.html:8
 #: src/olympia/editors/templates/editors/eventlog_detail.html:4
 msgid "Moderated Review Log"
 msgstr ""
 
-#: src/olympia/editors/templates/editors/base.html:82 src/olympia/editors/templates/editors/beta_signed_log.html:4 src/olympia/editors/templates/editors/beta_signed_log.html:8
+#: src/olympia/editors/templates/editors/base.html:84 src/olympia/editors/templates/editors/beta_signed_log.html:4 src/olympia/editors/templates/editors/beta_signed_log.html:8
 msgid "Signed Beta Files Log"
 msgstr ""
 
-#: src/olympia/editors/templates/editors/base.html:87 src/olympia/editors/templates/editors/includes/daily-message.html:4
+#: src/olympia/editors/templates/editors/base.html:89 src/olympia/editors/templates/editors/includes/daily-message.html:4
 msgid "Announcement"
 msgstr ""
 
@@ -7967,45 +7831,45 @@ msgstr ""
 msgid "clear search"
 msgstr ""
 
-#: src/olympia/editors/templates/editors/queue.html:72 src/olympia/editors/templates/editors/queue.html:122
+#: src/olympia/editors/templates/editors/queue.html:78 src/olympia/editors/templates/editors/queue.html:128
 msgid "Process Reviews"
 msgstr ""
 
-#: src/olympia/editors/templates/editors/queue.html:80
+#: src/olympia/editors/templates/editors/queue.html:86
 msgid "Moderation actions:"
 msgstr ""
 
-#: src/olympia/editors/templates/editors/queue.html:90
+#: src/olympia/editors/templates/editors/queue.html:96
 #, python-format
 msgid "by %(user)s on %(date)s %(stars)s (%(locale)s)"
 msgstr ""
 
-#: src/olympia/editors/templates/editors/queue.html:106
+#: src/olympia/editors/templates/editors/queue.html:112
 #, python-format
 msgid "<strong>%(reason)s</strong> <span class=\"light\">Flagged by %(user)s on %(date)s</span>"
 msgstr ""
 
-#: src/olympia/editors/templates/editors/queue.html:119
-msgid "All reviews have been moderated.  Good work!"
+#: src/olympia/editors/templates/editors/queue.html:125
+msgid "All reviews have been moderated. Good work!"
 msgstr ""
 
-#: src/olympia/editors/templates/editors/queue.html:161
+#: src/olympia/editors/templates/editors/queue.html:167
 msgid "Version Notes / Notes for Reviewer"
 msgstr ""
 
-#: src/olympia/editors/templates/editors/queue.html:169
+#: src/olympia/editors/templates/editors/queue.html:175
 msgid "There are currently no add-ons of this type to review."
 msgstr ""
 
-#: src/olympia/editors/templates/editors/queue.html:181 src/olympia/editors/templates/editors/themes/queue_list.html:85
+#: src/olympia/editors/templates/editors/queue.html:187 src/olympia/editors/templates/editors/themes/queue_list.html:85
 msgid "Helpful Links:"
 msgstr ""
 
-#: src/olympia/editors/templates/editors/queue.html:182
+#: src/olympia/editors/templates/editors/queue.html:188
 msgid "Add-on Policy"
 msgstr ""
 
-#: src/olympia/editors/templates/editors/queue.html:184
+#: src/olympia/editors/templates/editors/queue.html:190
 msgid "Editors' Guide"
 msgstr ""
 
@@ -8068,10 +7932,7 @@ msgid "<strong>Warning!</strong> Another user was viewing this page before you."
 msgstr ""
 
 #: src/olympia/editors/templates/editors/review.html:237
-msgid ""
-"The whiteboard is the place to exchange information relevant to\n"
-"               this addon (whatever the version), between the developer and the\n"
-"               editor. This is visible and editable by both."
+msgid "The whiteboard is the place to exchange information relevant to this addon (whatever the version), between the developer and the editor. This is visible and editable by both."
 msgstr ""
 
 #: src/olympia/editors/templates/editors/review.html:241
@@ -8345,7 +8206,7 @@ msgstr ""
 msgid "Describe your reason for flagging"
 msgstr ""
 
-#: src/olympia/files/forms.py:88
+#: src/olympia/files/forms.py:90
 msgid "Cannot diff a version against itself"
 msgstr ""
 
@@ -8380,51 +8241,51 @@ msgstr ""
 msgid "There was an error accessing file %s."
 msgstr ""
 
-#: src/olympia/files/utils.py:343
+#: src/olympia/files/utils.py:340
 msgid "Could not parse uploaded file."
 msgstr ""
 
-#: src/olympia/files/utils.py:380
+#: src/olympia/files/utils.py:377
 msgid "Invalid file name in archive: {0}"
 msgstr ""
 
-#: src/olympia/files/utils.py:388
+#: src/olympia/files/utils.py:385
 msgid "File exceeding size limit in archive: {0}"
 msgstr ""
 
-#: src/olympia/files/utils.py:439
+#: src/olympia/files/utils.py:436
 msgid "Invalid archive."
 msgstr ""
 
-#: src/olympia/files/utils.py:529 src/olympia/files/utils.py:532
+#: src/olympia/files/utils.py:526 src/olympia/files/utils.py:529
 msgid "Could not parse the manifest file."
 msgstr ""
 
-#: src/olympia/files/utils.py:551
+#: src/olympia/files/utils.py:548
 msgid "Could not find an add-on ID."
 msgstr ""
 
-#: src/olympia/files/utils.py:554
+#: src/olympia/files/utils.py:551
 msgid "Add-on ID must be 64 characters or less."
 msgstr ""
 
-#: src/olympia/files/utils.py:556
+#: src/olympia/files/utils.py:553
 msgid "Add-on ID doesn't match add-on."
 msgstr ""
 
-#: src/olympia/files/utils.py:564
+#: src/olympia/files/utils.py:561
 msgid "Duplicate add-on ID found."
 msgstr ""
 
-#: src/olympia/files/utils.py:567
+#: src/olympia/files/utils.py:564
 msgid "Version numbers should have fewer than 32 characters."
 msgstr ""
 
-#: src/olympia/files/utils.py:570
+#: src/olympia/files/utils.py:567
 msgid "Version numbers should only contain letters, numbers, and these punctuation characters: +*.-_."
 msgstr ""
 
-#: src/olympia/files/utils.py:587
+#: src/olympia/files/utils.py:584
 msgid "<em:type> doesn't match add-on"
 msgstr ""
 
@@ -8523,6 +8384,10 @@ msgstr ""
 
 #: src/olympia/files/templates/files/viewer.html:134
 msgid "Fetching file."
+msgstr ""
+
+#: src/olympia/legacy_api/views.py:255
+msgid "Not implemented yet."
 msgstr ""
 
 #: src/olympia/lib/constants.py:6
@@ -9181,10 +9046,6 @@ msgstr ""
 msgid "Zimbabwe Dollar"
 msgstr ""
 
-#: src/olympia/lib/video/ffmpeg.py:112 src/olympia/lib/video/totem.py:81
-msgid "Videos must be in WebM."
-msgstr ""
-
 #: src/olympia/pages/templates/pages/about.lhtml:3 src/olympia/pages/templates/pages/about.lhtml:10
 msgid "About Mozilla Add-ons"
 msgstr ""
@@ -9196,7 +9057,7 @@ msgstr ""
 #: src/olympia/pages/templates/pages/about.lhtml:13
 msgid ""
 "addons.mozilla.org, commonly known as \"AMO\", is Mozilla's official site for add-ons to Mozilla software, such as Firefox, Thunderbird, and SeaMonkey. Add-ons let you add new features and change "
-"the way your browser or application works.  Take a look around and explore the thousands of ways to customize the way you do things online."
+"the way your browser or application works. Take a look around and explore the thousands of ways to customize the way you do things online."
 msgstr ""
 
 #: src/olympia/pages/templates/pages/about.lhtml:19
@@ -9541,7 +9402,7 @@ msgstr ""
 msgid ""
 "Yes. It's possible, but some of the functionality provided by these libraries are available through XPCOM, XUL, and JavaScript. In addition, authors should take care if libraries modify primitive "
 "object prototypes (String.prototype, Date.prototype, etc.) and/or define global functions (eg. the $ function). These are prone to cause conflict with other add-ons, in particular if different add-"
-"ons use different versions of libraries and so on. Developers need to be very, very careful with using them.  Mozilla does not offer documentation on using them to build add-ons."
+"ons use different versions of libraries and so on. Developers need to be very, very careful with using them. Mozilla does not offer documentation on using them to build add-ons."
 msgstr ""
 
 #: src/olympia/pages/templates/pages/dev_faq.html:165
@@ -9655,8 +9516,8 @@ msgstr ""
 #, python-format
 msgid ""
 "Yes. Many developers choose to host their own add-ons. Choosing to host your add-on on <a href=\"%(amo_url)s\">Mozilla's add-on site</a>, though, allows for much greater exposure to your add-on due "
-"to the large volume of visitors to the site.  <a href=\"%(md_url)s\">mozdev.org</a> offers free project hosting for Mozilla applications and extensions providing developers with tools to help "
-"manage source code, version control, bug tracking and documentation."
+"to the large volume of visitors to the site. <a href=\"%(md_url)s\">mozdev.org</a> offers free project hosting for Mozilla applications and extensions providing developers with tools to help manage "
+"source code, version control, bug tracking and documentation."
 msgstr ""
 
 #: src/olympia/pages/templates/pages/dev_faq.html:277
@@ -9704,7 +9565,7 @@ msgstr ""
 #: src/olympia/pages/templates/pages/dev_faq.html:314
 #, python-format
 msgid ""
-"Yes. Mozilla's <a href=\"%(p_url)s\">Add-on Policy</a> describes what is an acceptable submission. This policy is subject to change without notice.  In addition, the AMO editorial team uses the <a "
+"Yes. Mozilla's <a href=\"%(p_url)s\">Add-on Policy</a> describes what is an acceptable submission. This policy is subject to change without notice. In addition, the AMO editorial team uses the <a "
 "href=\"%(g_url)s\">Editors Reviewing Guide</a> to ensure that your add-on meets specific guidelines for functionality and security."
 msgstr ""
 
@@ -9821,7 +9682,7 @@ msgstr ""
 #: src/olympia/pages/templates/pages/dev_faq.html:434
 #, python-format
 msgid ""
-"This is why it's very important to read the <a href=\"%(g_url)s\">Editors Reviewing Guide</a> to ensure that your add-on is setup as expected.  It's also a good idea to read the blog post, <a href="
+"This is why it's very important to read the <a href=\"%(g_url)s\">Editors Reviewing Guide</a> to ensure that your add-on is setup as expected. It's also a good idea to read the blog post, <a href="
 "\"%(blog_url)s\">Successfully Getting your Add-on Reviewed</a> which provides excellent insight into ensuring a smooth review of your add-on."
 msgstr ""
 
@@ -9928,7 +9789,7 @@ msgstr ""
 
 #: src/olympia/pages/templates/pages/dev_faq.html:572
 msgid ""
-"Free Software Foundation provides short summaries of the key open source licenses, including whether the license qualifies as a free software license or a copyleft license.  Also includes a "
+"Free Software Foundation provides short summaries of the key open source licenses, including whether the license qualifies as a free software license or a copyleft license. Also includes a "
 "discussion of what constitutes a free software license or a copyleft license (e.g., a Copyleft license is a general method for making a program or other work free, and requiring all modified and "
 "extended versions of the program to be free as well.)"
 msgstr ""
@@ -10106,19 +9967,13 @@ msgid "Add-on Gallery"
 msgstr ""
 
 #: src/olympia/pages/templates/pages/faq.html:171
-msgid ""
-"How do I choose between add-ons that seem to do the same\n"
-"    thing?"
+msgid "How do I choose between add-ons that seem to do the same thing?"
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:173
+#: src/olympia/pages/templates/pages/faq.html:172
 msgid ""
-"There are often several add-ons that have similar features. To\n"
-"    figure out which is right for you, read the entire description of the\n"
-"    add-on and view its screenshots. If there are still several in the running,\n"
-"    read through the add-on's ratings, user reviews, and statistics to see\n"
-"    which is most liked by other users. Remember that you can also just try\n"
-"    out both and see which you like better."
+"There are often several add-ons that have similar features. To figure out which is right for you, read the entire description of the add-on and view its screenshots. If there are still several in "
+"the running, read through the add-on's ratings, user reviews, and statistics to see which is most liked by other users. Remember that you can also just try out both and see which you like better."
 msgstr ""
 
 #: src/olympia/pages/templates/pages/faq.html:180
@@ -10159,80 +10014,67 @@ msgid "How much do add-ons cost to purchase?"
 msgstr ""
 
 #: src/olympia/pages/templates/pages/faq.html:207
-msgid ""
-"Add-ons hosted in our gallery are free unless clearly marked\n"
-"    otherwise."
+msgid "Add-ons hosted in our gallery are free unless clearly marked otherwise."
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:210
+#: src/olympia/pages/templates/pages/faq.html:209
 msgid "What does it mean when an add-on asks for contributions?"
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:211
+#: src/olympia/pages/templates/pages/faq.html:210
 msgid ""
-"Some add-on authors request users who enjoy an add-on to\n"
-"        contribute to its development by making a monetary contribution. These\n"
-"        contributions go directly to the developer unless a third party is\n"
-"        indicated, such as the non-profit Mozilla Foundation."
+"Some add-on authors request users who enjoy an add-on to contribute to its development by making a monetary contribution. These contributions go directly to the developer unless a third party is "
+"indicated, such as the non-profit Mozilla Foundation."
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:216
+#: src/olympia/pages/templates/pages/faq.html:215
 msgid "What are beta add-ons?"
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:218
+#: src/olympia/pages/templates/pages/faq.html:217
 msgid ""
-"Beta add-ons are unreviewed versions which represent the\n"
-"        latest work of an add-on author. While different authors have different\n"
-"        standards for beta code quality, you should assume that these add-ons\n"
-"        are less stable than the general add-on releases."
+"Beta add-ons are unreviewed versions which represent the latest work of an add-on author. While different authors have different standards for beta code quality, you should assume that these add-"
+"ons are less stable than the general add-on releases."
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:222
+#: src/olympia/pages/templates/pages/faq.html:221
 msgid ""
 "Please note that when you install an add-on from the \"Beta Version\" section of an add-on's listing, you will continue to receive updates for that add-on as they become available. Like the initial "
 "version you installed, all beta releases are unreviewed by Mozilla and may harm your computer."
 msgstr ""
 
+#: src/olympia/pages/templates/pages/faq.html:228
+msgid "What does it mean when an add-on is flagged as slow?"
+msgstr ""
+
 #: src/olympia/pages/templates/pages/faq.html:229
-msgid ""
-"What does it mean when an add-on is flagged as\n"
-"    slow?"
+msgid "Most add-ons load code and resources at the same time Firefox is starting up. In most cases the impact in start-up time is minimal, but some add-ons can cause a noticeable slowdown."
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:231
-msgid ""
-"Most add-ons load code and resources at the same time Firefox\n"
-"        is starting up. In most cases the impact in start-up time is minimal,\n"
-"        but some add-ons can cause a noticeable slowdown."
-msgstr ""
-
-#: src/olympia/pages/templates/pages/faq.html:236
+#: src/olympia/pages/templates/pages/faq.html:234
 msgid "How do I report an inappropriate or spam user review?"
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:237
+#: src/olympia/pages/templates/pages/faq.html:235
 msgid ""
-"To report a user review of an add-on, log in with your account\n"
-"    and visit the add-on's reviews page. Find the review you wish to report,\n"
-"    click \"Report this review\" and select a reason. Our editorial team will\n"
-"    investigate the review and take appropriate action."
+"To report a user review of an add-on, log in with your account and visit the add-on's reviews page. Find the review you wish to report, click \"Report this review\" and select a reason. Our "
+"editorial team will investigate the review and take appropriate action."
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:242
+#: src/olympia/pages/templates/pages/faq.html:240
 msgid "How do I report a bug or contact the Mozilla Add-ons team?"
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:243
+#: src/olympia/pages/templates/pages/faq.html:241
 #, python-format
 msgid "Please visit our <a href=\"%(contact_url)s\">Contact page</a>."
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:246
+#: src/olympia/pages/templates/pages/faq.html:244
 msgid "What is a Source Code License?"
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:247
+#: src/olympia/pages/templates/pages/faq.html:245
 #, python-format
 msgid ""
 "The source code used to create an add-on is an exclusive copyright of the add-on author, unless otherwise declared in a source code license. Many add-ons on this site have <a href=\"%(url)s\" lang="
@@ -10240,60 +10082,60 @@ msgid ""
 "the GPL or BSD licenses instead of making up their own."
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:256
+#: src/olympia/pages/templates/pages/faq.html:254
 #, python-format
 msgid "Firefox and other Mozilla software are <a href=\"%(url)s\">open source</a>."
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:264
+#: src/olympia/pages/templates/pages/faq.html:262
 msgid "Collections and Favorites"
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:267
+#: src/olympia/pages/templates/pages/faq.html:265
 msgid "What is a collection?"
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:268
+#: src/olympia/pages/templates/pages/faq.html:266
 msgid "Collections are groups of related add-ons created by users to share."
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:270
+#: src/olympia/pages/templates/pages/faq.html:268
 msgid "What is the My Favorites collection?"
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:271
+#: src/olympia/pages/templates/pages/faq.html:269
 msgid "Favorite add-ons are add-ons that you have bookmarked to easily get back to later. You can add an add-on to your favorites collection by clicking \"Add to favorites\" on its details page."
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:275 src/olympia/templates/menu_links.html:13 src/olympia/templates/impala/header_title.html:17
+#: src/olympia/pages/templates/pages/faq.html:273 src/olympia/templates/menu_links.html:13 src/olympia/templates/impala/header_title.html:17
 msgid "Mobile Add-ons"
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:278
+#: src/olympia/pages/templates/pages/faq.html:276
 msgid "What are mobile add-ons?"
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:279
+#: src/olympia/pages/templates/pages/faq.html:277
 #, python-format
 msgid ""
 "Mobile add-ons work with <a href=\"%(mobile_url)s\">Firefox for Mobile</a> and add or modify functionality just like desktop add-ons. You can find add-ons that work with Firefox for Mobile in our "
 "<a href=\"%(gallery_url)s\">gallery</a>."
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:288
+#: src/olympia/pages/templates/pages/faq.html:286
 msgid "Developer Topics"
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:289
+#: src/olympia/pages/templates/pages/faq.html:287
 #, python-format
 msgid "Please see our <a href=\"%(faq_url)s\">Developer FAQ</a> and <a href=\"%(hub_url)s\">Developer Hub</a> for answers to add-on developer-related questions."
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:294
+#: src/olympia/pages/templates/pages/faq.html:292
 msgid "Still have questions?"
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:295
+#: src/olympia/pages/templates/pages/faq.html:293
 #, python-format
 msgid "For general Firefox support, visit our <a href=\"%(sumo_url)s\">support website</a>. For general add-on and website questions, visit our <a href=\"%(forum_url)s\">forum</a>."
 msgstr ""
@@ -10431,7 +10273,7 @@ msgstr ""
 
 #: src/olympia/pages/templates/pages/sunbird.html:29
 msgid ""
-"Development on the Sunbird project has halted and its final release was on March 30, 2010.  We've been proud to host Sunbird add-ons on this site but as the project is no longer maintained we have "
+"Development on the Sunbird project has halted and its final release was on March 30, 2010. We've been proud to host Sunbird add-ons on this site but as the project is no longer maintained we have "
 "disabled our support for the add-ons."
 msgstr ""
 
@@ -10509,7 +10351,7 @@ msgstr ""
 #, python-format
 msgid ""
 "<h2>Keep these tips in mind:</h2> <ul> <li> Write like you're telling a friend about your experience with the add-on. Give specifics and helpful details, such as what features you liked and/or "
-"disliked, how easy to use it is, and any disadvantages it has.  Avoid generic language such as calling it \"Great\" or \"Bad\" unless you can give reasons why you believe this is so. </li> <li> "
+"disliked, how easy to use it is, and any disadvantages it has. Avoid generic language such as calling it \"Great\" or \"Bad\" unless you can give reasons why you believe this is so. </li> <li> "
 "Please do not post bug reports in reviews. We do not make your email address available to add-on developers and they may need to contact you to help resolve your issue. See the <a href=\"%(support)s"
 "\">support section</a> to find out where to get assistance for this add-on. </li> <li>Please keep reviews clean, avoid the use of improper language and do not post any personal information. </li> </"
 "ul> <p>Please read the <a href=\"%(guide)s\" target=\"_blank\">Review Guidelines</a> for more detail about user add-on reviews.</p>"
@@ -10745,16 +10587,16 @@ msgstr ""
 
 #. L10n: {0} is an application, such as Firefox. This means "any version of
 #. Firefox."
-#: src/olympia/search/views.py:554
+#: src/olympia/search/views.py:547
 msgid "Any {0}"
 msgstr ""
 
 #. L10n: "All Systems" means show everything regardless of platform.
-#: src/olympia/search/views.py:589
+#: src/olympia/search/views.py:582
 msgid "All Systems"
 msgstr ""
 
-#: src/olympia/search/views.py:600
+#: src/olympia/search/views.py:593
 msgid "All Tags"
 msgstr ""
 
@@ -10928,31 +10770,31 @@ msgstr ""
 msgid "Share this Collection"
 msgstr ""
 
-#: src/olympia/signing/views.py:30 src/olympia/templates/base.html:75 src/olympia/templates/impala/base.html:115
+#: src/olympia/signing/views.py:33 src/olympia/templates/base.html:71 src/olympia/templates/impala/base.html:112
 msgid "Some features are temporarily disabled while we perform website maintenance. We'll be back to full capacity shortly."
 msgstr ""
 
-#: src/olympia/signing/views.py:53
+#: src/olympia/signing/views.py:56
 msgid "Could not find add-on with id \"{}\"."
 msgstr ""
 
-#: src/olympia/signing/views.py:67
+#: src/olympia/signing/views.py:70
 msgid "You do not own this addon."
 msgstr ""
 
-#: src/olympia/signing/views.py:82
+#: src/olympia/signing/views.py:87
 msgid "Missing \"upload\" key in multipart file data."
 msgstr ""
 
-#: src/olympia/signing/views.py:96
+#: src/olympia/signing/views.py:101
 msgid "Version does not match the manifest file."
 msgstr ""
 
-#: src/olympia/signing/views.py:100
+#: src/olympia/signing/views.py:105
 msgid "Version already exists."
 msgstr ""
 
-#: src/olympia/signing/views.py:136
+#: src/olympia/signing/views.py:141
 msgid "No uploaded file for that addon and version."
 msgstr ""
 
@@ -11065,89 +10907,89 @@ msgstr ""
 msgid "Statistics Dashboard :: Add-ons for {0}"
 msgstr ""
 
-#: src/olympia/stats/templates/stats/stats.html:30
-msgid "Controls:"
-msgstr ""
-
-#: src/olympia/stats/templates/stats/stats.html:33
-msgid "reset zoom"
-msgstr ""
-
-#: src/olympia/stats/templates/stats/stats.html:40
-msgid "Group by:"
-msgstr ""
-
-#: src/olympia/stats/templates/stats/stats.html:42
-msgid "day"
-msgstr ""
-
-#: src/olympia/stats/templates/stats/stats.html:45
-msgid "week"
-msgstr ""
-
-#: src/olympia/stats/templates/stats/stats.html:48
-msgid "month"
-msgstr ""
-
-#: src/olympia/stats/templates/stats/stats.html:54
-msgid "For last:"
-msgstr ""
-
-#: src/olympia/stats/templates/stats/stats.html:57
-msgid "7 days"
-msgstr ""
-
-#: src/olympia/stats/templates/stats/stats.html:60
-msgid "30 days"
-msgstr ""
-
-#: src/olympia/stats/templates/stats/stats.html:63
-msgid "90 days"
-msgstr ""
-
-#: src/olympia/stats/templates/stats/stats.html:66
-msgid "365 days"
-msgstr ""
-
-#: src/olympia/stats/templates/stats/stats.html:69
-msgid "Custom..."
-msgstr ""
-
 #. {0} is an add-on name
-#: src/olympia/stats/templates/stats/stats.html:88 src/olympia/stats/templates/stats/stats.html:91
+#: src/olympia/stats/templates/stats/stats.html:44 src/olympia/stats/templates/stats/stats.html:47
 msgid "Statistics for {0}"
 msgstr ""
 
-#: src/olympia/stats/templates/stats/stats.html:94
+#: src/olympia/stats/templates/stats/stats.html:50
 msgid "Statistics Dashboard"
 msgstr ""
 
-#: src/olympia/stats/templates/stats/stats.html:104
+#: src/olympia/stats/templates/stats/stats.html:57
+msgid "Controls:"
+msgstr ""
+
+#: src/olympia/stats/templates/stats/stats.html:60
+msgid "reset zoom"
+msgstr ""
+
+#: src/olympia/stats/templates/stats/stats.html:67
+msgid "Group by:"
+msgstr ""
+
+#: src/olympia/stats/templates/stats/stats.html:69
+msgid "day"
+msgstr ""
+
+#: src/olympia/stats/templates/stats/stats.html:72
+msgid "week"
+msgstr ""
+
+#: src/olympia/stats/templates/stats/stats.html:75
+msgid "month"
+msgstr ""
+
+#: src/olympia/stats/templates/stats/stats.html:81
+msgid "For last:"
+msgstr ""
+
+#: src/olympia/stats/templates/stats/stats.html:84
+msgid "7 days"
+msgstr ""
+
+#: src/olympia/stats/templates/stats/stats.html:87
+msgid "30 days"
+msgstr ""
+
+#: src/olympia/stats/templates/stats/stats.html:90
+msgid "90 days"
+msgstr ""
+
+#: src/olympia/stats/templates/stats/stats.html:93
+msgid "365 days"
+msgstr ""
+
+#: src/olympia/stats/templates/stats/stats.html:96
+msgid "Custom..."
+msgstr ""
+
+#: src/olympia/stats/templates/stats/stats.html:106
 msgid "Statistics processing is currently disabled, so recent data is unavailable. The statistics are still being collected and this page will be updated soon with the missing data."
 msgstr ""
 
-#: src/olympia/stats/templates/stats/stats.html:110
+#: src/olympia/stats/templates/stats/stats.html:112
 msgid "Loading the latest data&hellip;"
 msgstr ""
 
-#: src/olympia/stats/templates/stats/stats.html:142 src/olympia/stats/templates/stats/reports/overview.html:25 src/olympia/stats/templates/stats/reports/overview.html:37
+#: src/olympia/stats/templates/stats/stats.html:144 src/olympia/stats/templates/stats/reports/overview.html:25 src/olympia/stats/templates/stats/reports/overview.html:37
 #: src/olympia/stats/templates/stats/reports/overview.html:49
 msgid "No data available."
 msgstr ""
 
-#: src/olympia/stats/templates/stats/stats.html:177
+#: src/olympia/stats/templates/stats/stats.html:179
 msgid "This dashboard is currently <b>public</b>."
 msgstr ""
 
-#: src/olympia/stats/templates/stats/stats.html:179
+#: src/olympia/stats/templates/stats/stats.html:181
 msgid "Contribution stats are currently <b>private</b>."
 msgstr ""
 
-#: src/olympia/stats/templates/stats/stats.html:182
+#: src/olympia/stats/templates/stats/stats.html:184
 msgid "This dashboard is currently <b>private</b>."
 msgstr ""
 
-#: src/olympia/stats/templates/stats/stats.html:185
+#: src/olympia/stats/templates/stats/stats.html:187
 msgid "Change settings."
 msgstr ""
 
@@ -11299,15 +11141,6 @@ msgstr ""
 msgid "Application versions by Date"
 msgstr ""
 
-#: src/olympia/tags/templates/tags/top_cloud.html:4
-msgid "Top {0} Tags"
-msgstr ""
-
-#. {0} is the current application name
-#: src/olympia/tags/templates/tags/top_cloud.html:14
-msgid "{0} Top Tags"
-msgstr ""
-
 #: src/olympia/templates/amo_footer.html:6 src/olympia/templates/includes/lang_switcher.html:2
 msgid "Other languages"
 msgstr ""
@@ -11316,11 +11149,11 @@ msgstr ""
 msgid "Mozilla Add-ons"
 msgstr ""
 
-#: src/olympia/templates/base.html:91 src/olympia/templates/impala/base.html:81
+#: src/olympia/templates/base.html:89 src/olympia/templates/impala/base.html:78
 msgid "Find add-ons for other applications"
 msgstr ""
 
-#: src/olympia/templates/base.html:92 src/olympia/templates/impala/base.html:81
+#: src/olympia/templates/base.html:90 src/olympia/templates/impala/base.html:78
 msgid "Other Applications"
 msgstr ""
 
@@ -11345,7 +11178,7 @@ msgid "View Mobile Site"
 msgstr ""
 
 #: src/olympia/templates/copyright.html:7
-msgid "Site Status "
+msgid "Site Status"
 msgstr ""
 
 #: src/olympia/templates/footer.html:3
@@ -11445,35 +11278,35 @@ msgstr ""
 msgid "<a href=\"%(reg)s\">Register</a> or <a href=\"%(login)s\">Log in</a>"
 msgstr ""
 
-#: src/olympia/templates/impala/base.html:126
+#: src/olympia/templates/impala/base.html:123
 #, python-format
 msgid "To try the thousands of add-ons available here, download <a href=\"%(url)s\">Mozilla Firefox</a>, a fast, free way to surf the Web!"
 msgstr ""
 
-#: src/olympia/templates/impala/base.html:138
+#: src/olympia/templates/impala/base.html:135
 #, python-format
 msgid "Add-ons is switching to Firefox Accounts for login. <a href=\"%(url)s\" class=\"fxa-login\">Sign in now to transfer your account.</a>"
 msgstr ""
 
 #. {0} is an application, such as Firefox.
-#: src/olympia/templates/impala/base.html:148
+#: src/olympia/templates/impala/base.html:145
 msgid "Welcome to {0} Add-ons."
 msgstr ""
 
-#: src/olympia/templates/impala/base.html:151
+#: src/olympia/templates/impala/base.html:148
 msgid "Choose from thousands of extra features and styles to make Firefox your own."
 msgstr ""
 
-#: src/olympia/templates/impala/base.html:156
+#: src/olympia/templates/impala/base.html:153
 #, python-format
 msgid "Add extra features and styles to make %(app)s your own."
 msgstr ""
 
-#: src/olympia/templates/impala/base.html:164
+#: src/olympia/templates/impala/base.html:161
 msgid "On the go?"
 msgstr ""
 
-#: src/olympia/templates/impala/base.html:166
+#: src/olympia/templates/impala/base.html:163
 msgid "Check out our <a class=\"mobile-link\" href=\"#\">Mobile Add-ons site</a>."
 msgstr ""
 
@@ -11697,19 +11530,19 @@ msgstr ""
 
 #. L10n: {id} will be something like "13ad6a", just a random number
 #. to differentiate this user from other anonymous users.
-#: src/olympia/users/models.py:353
+#: src/olympia/users/models.py:362
 msgid "Anonymous user {id}"
 msgstr ""
 
-#: src/olympia/users/models.py:410
+#: src/olympia/users/models.py:419
 msgid "Your account has been restricted"
 msgstr ""
 
-#: src/olympia/users/models.py:480
+#: src/olympia/users/models.py:489
 msgid "Please confirm your email address"
 msgstr ""
 
-#: src/olympia/users/models.py:506
+#: src/olympia/users/models.py:515
 msgid "My Mobile Add-ons"
 msgstr ""
 
@@ -11986,7 +11819,7 @@ msgstr ""
 
 #: src/olympia/users/templates/users/edit.html:70
 #, python-format
-msgid "Change your password.  If you forgot your password, you can <a href=\"%(reset_url)s\">use the reset form</a>."
+msgid "Change your password. If you forgot your password, you can <a href=\"%(reset_url)s\">use the reset form</a>."
 msgstr ""
 
 #: src/olympia/users/templates/users/edit.html:76
@@ -12006,7 +11839,7 @@ msgid "Profile"
 msgstr ""
 
 #: src/olympia/users/templates/users/edit.html:100
-msgid "Give us a bit more information about yourself.  All these fields are optional, but they'll help other users get to know you better."
+msgid "Give us a bit more information about yourself. All these fields are optional, but they'll help other users get to know you better."
 msgstr ""
 
 #: src/olympia/users/templates/users/edit.html:124
@@ -12222,7 +12055,7 @@ msgid "Confirm password"
 msgstr ""
 
 #: src/olympia/users/templates/users/pwreset_confirm.html:47
-msgid "The password reset link was invalid, possibly because it has already been used.  Please request a new password reset."
+msgid "The password reset link was invalid, possibly because it has already been used. Please request a new password reset."
 msgstr ""
 
 #: src/olympia/users/templates/users/pwreset_request.html:15
@@ -12408,7 +12241,7 @@ msgstr ""
 
 #: src/olympia/users/templates/users/unsubscribe.html:30
 #, python-format
-msgid "Unfortunately, we weren't able to unsubscribe you.  The link you clicked is invalid. However, you can unsubscribe still unsubscribe on your <a href=\"%(edit_url)s\">edit profile page</a>."
+msgid "Unfortunately, we weren't able to unsubscribe you. The link you clicked is invalid. However, you can unsubscribe still unsubscribe on your <a href=\"%(edit_url)s\">edit profile page</a>."
 msgstr ""
 
 #: src/olympia/users/templates/users/vcard.html:2
@@ -12462,15 +12295,15 @@ msgstr ""
 msgid "Version History with Changelogs"
 msgstr ""
 
-#: src/olympia/versions/models.py:314
+#: src/olympia/versions/models.py:313
 msgid "Add-on uses binary components."
 msgstr ""
 
-#: src/olympia/versions/models.py:317
+#: src/olympia/versions/models.py:316
 msgid "Add-on has opted into strict compatibility checking."
 msgstr ""
 
-#: src/olympia/versions/models.py:715
+#: src/olympia/versions/models.py:711
 msgid "{app} {min} and later"
 msgstr ""
 
@@ -12545,4 +12378,8 @@ msgstr ""
 
 #: src/olympia/zadmin/forms.py:105
 msgid "Log emails instead of sending"
+msgstr ""
+
+#: src/olympia/zadmin/forms.py:215
+msgid "Deleted versions can`t be changed."
 msgstr ""

--- a/locale/kn/LC_MESSAGES/djangojs.po
+++ b/locale/kn/LC_MESSAGES/djangojs.po
@@ -1,1216 +1,1236 @@
-
 #, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2016-02-24 21:23+0000\n"
+"POT-Creation-Date: 2016-04-18 15:47+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
+"Language: \n"
 "MIME-Version: 1.0\n"
-"Content-Type: text/plain; charset=utf-8\n"
+"Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Generated-By: Babel 2.2.0\n"
 
-#: static/js/common/ratingwidget.js:31
+#: static/js/common-all.js:1426 static/js/impala-all.js:1511 static/js/zamboni/discovery-all.js:12598 static/js/zamboni/init.js:28 static/js/zamboni/mobile-all.js:14945
+msgid "This feature is temporarily disabled while we perform website maintenance. Please check back a little later."
+msgstr ""
+
+#. L10n: {0} is an app name like Firefox.
+#: static/js/common-all.js:1837 static/js/impala-all.js:1922 static/js/zamboni/buttons.js:73 static/js/zamboni/discovery-all.js:13108
+msgid "Accept and Install"
+msgstr ""
+
+#: static/js/common-all.js:1837 static/js/impala-all.js:1922 static/js/zamboni/buttons.js:73 static/js/zamboni/discovery-all.js:13108
+msgid "Add to {0}"
+msgstr ""
+
+#: static/js/common-all.js:1842 static/js/impala-all.js:1927 static/js/zamboni/buttons.js:78 static/js/zamboni/discovery-all.js:13113
+msgid "Download Now"
+msgstr ""
+
+#: static/js/common-all.js:1883 static/js/impala-all.js:1968 static/js/zamboni/buttons.js:119 static/js/zamboni/discovery-all.js:13154
+msgid "Add-on has not been updated to support default-to-compatible."
+msgstr ""
+
+#: static/js/common-all.js:1888 static/js/impala-all.js:1973 static/js/zamboni/buttons.js:124 static/js/zamboni/discovery-all.js:13159
+msgid "You need to be using Firefox 10.0 or higher."
+msgstr ""
+
+#: static/js/common-all.js:1900 static/js/impala-all.js:1985 static/js/zamboni/buttons.js:136 static/js/zamboni/discovery-all.js:13171
+msgid "Mozilla has marked this version as incompatible with your Firefox version."
+msgstr ""
+
+#. L10n: {0} is an platform like Windows or Linux.
+#: static/js/common-all.js:1981 static/js/impala-all.js:2066 static/js/zamboni/buttons.js:217 static/js/zamboni/discovery-all.js:13252
+msgid "Install for {0} anyway"
+msgstr ""
+
+#: static/js/common-all.js:1981 static/js/impala-all.js:2066 static/js/zamboni/buttons.js:217 static/js/zamboni/discovery-all.js:13252
+msgid "Download for {0} anyway"
+msgstr ""
+
+#: static/js/common-all.js:2038 static/js/impala-all.js:2123 static/js/zamboni/buttons.js:274 static/js/zamboni/discovery-all.js:13309
+msgid "Not available for your platform"
+msgstr ""
+
+#. L10n: {0} is an app name, {1} is the app version.
+#: static/js/common-all.js:2049 static/js/common-all.js:2086 static/js/impala-all.js:2134 static/js/impala-all.js:2171 static/js/zamboni/buttons.js:286 static/js/zamboni/buttons.js:324
+#: static/js/zamboni/discovery-all.js:13320 static/js/zamboni/discovery-all.js:13357
+msgid "Not available for {0} {1}"
+msgstr ""
+
+#: static/js/common-all.js:2112 static/js/impala-all.js:2197 static/js/zamboni/buttons.js:351 static/js/zamboni/discovery-all.js:13383
+msgid "Works with {app} {min} - {max}"
+msgstr ""
+
+#: static/js/common-all.js:2114 static/js/impala-all.js:2199 static/js/zamboni/buttons.js:353 static/js/zamboni/discovery-all.js:13385
+msgid "View other versions"
+msgstr ""
+
+#: static/js/common-all.js:2162 static/js/impala-all.js:2247 static/js/zamboni/buttons.js:401 static/js/zamboni/discovery-all.js:13433
+msgid "Only with Firefox — Get Firefox Now!"
+msgstr ""
+
+#: static/js/common-all.js:2278 static/js/impala-all.js:2363 static/js/zamboni/buttons.js:517 static/js/zamboni/discovery-all.js:13549 static/js/zamboni/mobile-all.js:15177
+#: static/js/zamboni/mobile/buttons.js:43
+msgid "Sorry, you need a Mozilla-based browser (such as Firefox) to install a search plugin."
+msgstr ""
+
+#: static/js/common-all.js:9088 static/js/impala-all.js:9649 static/js/zamboni/global.js:410
+msgid "Loading..."
+msgstr ""
+
+#. L10n: {0} is the number of characters left.
+#: static/js/common-all.js:9152 static/js/impala-all.js:9713 static/js/zamboni/global.js:474
+msgid "<b>{0}</b> character left."
+msgid_plural "<b>{0}</b> characters left."
+msgstr[0] ""
+msgstr[1] ""
+
+#: static/js/common-all.js:9589 static/js/common-min.js:6 static/js/impala-all.js:10052 static/js/impala-min.js:6 static/js/common/ratingwidget.js:31 static/js/zamboni/mobile-all.js:16123
+#: static/js/zamboni/mobile-min.js:6
 msgid "{0} star"
 msgid_plural "{0} stars"
 msgstr[0] ""
 msgstr[1] ""
 
-#: static/js/common/upload-addon.js:41 static/js/common/upload-image.js:128
+#: static/js/common-all.js:9676 static/js/common-min.js:6 static/js/impala-all.js:10139 static/js/impala-min.js:6 static/js/zamboni/l10n.js:45
+msgid "Remove this localization"
+msgstr ""
+
+#: static/js/common-all.js:10193 static/js/common-min.js:6 static/js/impala-all.js:10674 static/js/impala-min.js:6 static/js/zamboni/discovery-all.js:13678
+msgid "close"
+msgstr ""
+
+#: static/js/common-all.js:10860 static/js/common-min.js:6 static/js/impala-all.js:11481 static/js/impala-min.js:6 static/js/impala/reviews.js:23 static/js/zamboni/reviews.js:18
+msgid "Flagged for review"
+msgstr ""
+
+#: static/js/common-all.js:10876 static/js/common-min.js:6 static/js/impala-all.js:11498 static/js/impala-min.js:6 static/js/impala/reviews.js:40 static/js/zamboni/reviews.js:34
+msgid "Your input is required"
+msgstr ""
+
+#: static/js/common-all.js:10945 static/js/common-min.js:6 static/js/impala-all.js:11610 static/js/impala-min.js:7 static/js/impala/reviews.js:152 static/js/zamboni/reviews.js:103
+msgid "Marked for deletion"
+msgstr ""
+
+#: static/js/common-all.js:11573 static/js/common-min.js:7 static/js/impala-all.js:13809 static/js/impala-min.js:8 static/js/zamboni/collections.js:229
+msgid "Adding to Favorites&hellip;"
+msgstr ""
+
+#: static/js/common-all.js:11576 static/js/common-min.js:7 static/js/impala-all.js:13812 static/js/impala-min.js:8 static/js/zamboni/collections.js:232
+msgid "Removing Favorite&hellip;"
+msgstr ""
+
+#: static/js/common-all.js:11579 static/js/common-min.js:7 static/js/impala-all.js:13815 static/js/impala-min.js:8 static/js/zamboni/collections.js:235
+msgid "Add to Favorites"
+msgstr ""
+
+#: static/js/common-all.js:11582 static/js/common-min.js:7 static/js/impala-all.js:13818 static/js/impala-min.js:8 static/js/zamboni/collections.js:238
+msgid "Remove from Favorites"
+msgstr ""
+
+#: static/js/common-all.js:11647 static/js/common-min.js:7 static/js/impala-all.js:13883 static/js/impala-min.js:8 static/js/zamboni/collections.js:303
+msgid "Pending"
+msgstr ""
+
+#: static/js/common-all.js:11648 static/js/common-min.js:7 static/js/impala-all.js:13884 static/js/impala-min.js:8 static/js/zamboni/collections.js:304
+msgid "Add a comment"
+msgstr ""
+
+#: static/js/common-all.js:11648 static/js/common-min.js:7 static/js/impala-all.js:13884 static/js/impala-min.js:8 static/js/zamboni/collections.js:304
+msgid "Comment"
+msgstr ""
+
+#: static/js/common-all.js:11649 static/js/common-min.js:7 static/js/impala-all.js:13885 static/js/impala-min.js:8 static/js/zamboni/collections.js:305
+msgid "Remove this add-on from the collection"
+msgstr ""
+
+#: static/js/common-all.js:11649 static/js/common-all.js:11678 static/js/common-min.js:7 static/js/impala-all.js:13885 static/js/impala-all.js:13914 static/js/impala-min.js:8
+#: static/js/zamboni/collections.js:305 static/js/zamboni/collections.js:334
+msgid "Remove"
+msgstr ""
+
+#: static/js/common-all.js:11678 static/js/common-min.js:7 static/js/impala-all.js:13914 static/js/impala-min.js:8 static/js/zamboni/collections.js:334
+msgid "Remove this user as a contributor"
+msgstr ""
+
+#: static/js/common-all.js:11690 static/js/common-min.js:7 static/js/impala-all.js:13926 static/js/impala-min.js:8 static/js/zamboni/collections.js:346
+msgid "An email address is required."
+msgstr ""
+
+#: static/js/common-all.js:11708 static/js/common-min.js:7 static/js/impala-all.js:13944 static/js/impala-min.js:8 static/js/zamboni/collections.js:364
+msgid "You cannot add yourself as a contributor."
+msgstr ""
+
+#: static/js/common-all.js:11710 static/js/common-min.js:7 static/js/impala-all.js:13946 static/js/impala-min.js:8 static/js/zamboni/collections.js:366
+msgid "You have already added that user."
+msgstr ""
+
+#: static/js/common-all.js:11917 static/js/common-min.js:7 static/js/impala-all.js:14153 static/js/impala-min.js:8 static/js/zamboni/collections.js:573
+msgid "Add to favorites"
+msgstr ""
+
+#: static/js/common-all.js:11921 static/js/common-min.js:7 static/js/impala-all.js:14157 static/js/impala-min.js:8 static/js/zamboni/collections.js:577
+msgid "Remove from favorites"
+msgstr ""
+
+#: static/js/common-all.js:11939 static/js/common-min.js:7 static/js/impala-all.js:14175 static/js/impala-all.js:14233 static/js/impala-min.js:8 static/js/impala/collections.js:10
+#: static/js/zamboni/collections.js:595
+msgid "Follow this Collection"
+msgstr ""
+
+#: static/js/common-all.js:11948 static/js/common-min.js:7 static/js/impala-all.js:14184 static/js/impala-min.js:8 static/js/zamboni/collections.js:604
+msgid "Stop following"
+msgstr ""
+
+#: static/js/common-all.js:12096 static/js/common-min.js:7 static/js/zamboni/password-strength.js:20
+msgid "Password strength:"
+msgstr ""
+
+#: static/js/common-all.js:12102 static/js/common-min.js:7 static/js/zamboni/password-strength.js:26
+msgid "At least {0} character left."
+msgid_plural "At least {0} characters left."
+msgstr[0] ""
+msgstr[1] ""
+
+#: static/js/common-all.js:12286 static/js/common-min.js:7 static/js/impala-all.js:14632 static/js/impala-min.js:8 static/js/impala/suggestions.js:39
+msgid "Search themes for <b>{0}</b>"
+msgstr ""
+
+#: static/js/common-all.js:12288 static/js/common-min.js:7 static/js/impala-all.js:14634 static/js/impala-min.js:8 static/js/impala/suggestions.js:41
+msgid "Search apps for <b>{0}</b>"
+msgstr ""
+
+#: static/js/common-all.js:12290 static/js/common-min.js:7 static/js/impala-all.js:14636 static/js/impala-min.js:8 static/js/impala/suggestions.js:43
+msgid "Search add-ons for <b>{0}</b>"
+msgstr ""
+
+#: static/js/common-all.js:12521 static/js/common-min.js:7 static/js/impala-all.js:14867 static/js/impala-min.js:8 static/js/impala/site_suggestions.js:46
+msgid "Category"
+msgstr ""
+
+#. L10n: {0} is an app name.
+#: static/js/impala-all.js:11632 static/js/impala-min.js:7 static/js/impala/listing.js:11 static/js/zamboni/themes.js:13
+msgid "This theme is incompatible with your version of {0}"
+msgstr ""
+
+#: static/js/impala-all.js:12146 static/js/impala-all.js:14331 static/js/impala-min.js:7 static/js/impala-min.js:8 static/js/common/upload-image.js:97 static/js/impala/users.js:51
+#: static/js/zamboni/devhub-all.js:894 static/js/zamboni/devhub-min.js:1
+msgid "Images must be either PNG or JPG."
+msgstr ""
+
+#: static/js/impala-all.js:12150 static/js/impala-min.js:7 static/js/common/upload-image.js:101 static/js/zamboni/devhub-all.js:898 static/js/zamboni/devhub-min.js:1
+msgid "Videos must be in WebM."
+msgstr ""
+
+#: static/js/impala-all.js:12177 static/js/impala-min.js:7 static/js/common/upload-addon.js:41 static/js/common/upload-image.js:128 static/js/zamboni/devhub-all.js:272
+#: static/js/zamboni/devhub-all.js:925 static/js/zamboni/devhub-min.js:1
 msgid "There was a problem contacting the server."
 msgstr ""
 
-#: static/js/common/upload-addon.js:69
+#: static/js/impala-all.js:13298 static/js/impala-min.js:7 static/js/impala/persona_creation.js:60
+msgid "All Rights Reserved"
+msgstr ""
+
+#: static/js/impala-all.js:13302 static/js/impala-min.js:7 static/js/impala/persona_creation.js:64
+msgid "Creative Commons Attribution 3.0"
+msgstr ""
+
+#: static/js/impala-all.js:13307 static/js/impala-min.js:7 static/js/impala/persona_creation.js:69
+msgid "Creative Commons Attribution-NonCommercial 3.0"
+msgstr ""
+
+#: static/js/impala-all.js:13312 static/js/impala-min.js:7 static/js/impala/persona_creation.js:74
+msgid "Creative Commons Attribution-NonCommercial-NoDerivs 3.0"
+msgstr ""
+
+#: static/js/impala-all.js:13317 static/js/impala-min.js:7 static/js/impala/persona_creation.js:79
+msgid "Creative Commons Attribution-NonCommercial-Share Alike 3.0"
+msgstr ""
+
+#: static/js/impala-all.js:13322 static/js/impala-min.js:7 static/js/impala/persona_creation.js:84
+msgid "Creative Commons Attribution-NoDerivs 3.0"
+msgstr ""
+
+#: static/js/impala-all.js:13327 static/js/impala-min.js:7 static/js/impala/persona_creation.js:89
+msgid "Creative Commons Attribution-ShareAlike 3.0"
+msgstr ""
+
+#: static/js/impala-all.js:13530 static/js/impala-min.js:7 static/js/impala/persona_creation.js:292
+msgid "Your Theme's Name"
+msgstr ""
+
+#: static/js/impala-all.js:14242 static/js/impala-min.js:8 static/js/impala/collections.js:19
+msgid "Stop Following"
+msgstr ""
+
+#: static/js/impala-all.js:14243 static/js/impala-min.js:8 static/js/impala/collections.js:20
+msgid "Following"
+msgstr ""
+
+#: static/js/impala-all.js:14313 static/js/impala-min.js:8 static/js/impala/users.js:33
+msgid "use original"
+msgstr ""
+
+#: static/js/impala-all.js:14523 static/js/impala-min.js:8 static/js/impala/search.js:114
+msgid "Updating results&hellip;"
+msgstr ""
+
+#: static/js/common/upload-addon.js:69 static/js/zamboni/devhub-all.js:300 static/js/zamboni/devhub-min.js:1
 msgid "Select a file..."
 msgstr ""
 
-#: static/js/common/upload-addon.js:70
+#: static/js/common/upload-addon.js:70 static/js/zamboni/devhub-all.js:301 static/js/zamboni/devhub-min.js:1
 msgid "Your add-on should end with .xpi, .jar or .xml"
 msgstr ""
 
 #. L10n: {0} is the percent of the file that has been uploaded.
-#: static/js/common/upload-addon.js:104
+#: static/js/common/upload-addon.js:104 static/js/zamboni/devhub-all.js:335 static/js/zamboni/devhub-min.js:1
 #, python-format
 msgid "{0}% complete"
 msgstr ""
 
 #. L10n: "{bytes uploaded} of {total filesize}".
-#: static/js/common/upload-addon.js:107
+#: static/js/common/upload-addon.js:107 static/js/zamboni/devhub-all.js:338 static/js/zamboni/devhub-min.js:1
 msgid "{0} of {1}"
 msgstr ""
 
-#: static/js/common/upload-addon.js:140
+#: static/js/common/upload-addon.js:140 static/js/zamboni/devhub-all.js:371 static/js/zamboni/devhub-min.js:1
 msgid "Cancel"
 msgstr ""
 
-#: static/js/common/upload-addon.js:162
+#: static/js/common/upload-addon.js:162 static/js/zamboni/devhub-all.js:393 static/js/zamboni/devhub-min.js:1
 msgid "Uploading {0}"
 msgstr ""
 
-#: static/js/common/upload-addon.js:189
+#: static/js/common/upload-addon.js:189 static/js/zamboni/devhub-all.js:420 static/js/zamboni/devhub-min.js:1
 msgid "Error with {0}"
 msgstr ""
 
-#: static/js/common/upload-addon.js:194
+#: static/js/common/upload-addon.js:194 static/js/zamboni/devhub-all.js:425 static/js/zamboni/devhub-min.js:1
 msgid "Your add-on failed validation with {0} error."
 msgid_plural "Your add-on failed validation with {0} errors."
 msgstr[0] ""
 msgstr[1] ""
 
-#: static/js/common/upload-addon.js:208
+#: static/js/common/upload-addon.js:208 static/js/zamboni/devhub-all.js:439 static/js/zamboni/devhub-min.js:1
 msgid "&hellip;and {0} more"
 msgid_plural "&hellip;and {0} more"
 msgstr[0] ""
 msgstr[1] ""
 
-#: static/js/common/upload-addon.js:222 static/js/common/upload-addon.js:512
+#: static/js/common/upload-addon.js:222 static/js/common/upload-addon.js:497 static/js/zamboni/devhub-all.js:453 static/js/zamboni/devhub-all.js:743 static/js/zamboni/devhub-min.js:1
 msgid "See full validation report"
 msgstr ""
 
-#: static/js/common/upload-addon.js:234
+#: static/js/common/upload-addon.js:234 static/js/zamboni/devhub-all.js:465 static/js/zamboni/devhub-min.js:1
 msgid "Validating {0}"
 msgstr ""
 
 #. L10n: first argument is an HTTP status code
-#: static/js/common/upload-addon.js:273
+#: static/js/common/upload-addon.js:273 static/js/zamboni/devhub-all.js:504 static/js/zamboni/devhub-min.js:1
 msgid "Received an empty response from the server; status: {0}"
 msgstr ""
 
-#: static/js/common/upload-addon.js:373
+#: static/js/common/upload-addon.js:370 static/js/zamboni/devhub-all.js:604 static/js/zamboni/devhub-min.js:1
 msgid "Unexpected server error while validating."
 msgstr ""
 
-#: static/js/common/upload-addon.js:412
+#: static/js/common/upload-addon.js:409 static/js/zamboni/devhub-all.js:643 static/js/zamboni/devhub-min.js:1
 msgid "Finished validating {0}"
 msgstr ""
 
-#: static/js/common/upload-addon.js:418
+#: static/js/common/upload-addon.js:415 static/js/zamboni/devhub-all.js:649 static/js/zamboni/devhub-min.js:1
 msgid "Your add-on validation timed out, it will be manually reviewed."
 msgstr ""
 
-#: static/js/common/upload-addon.js:421
+#: static/js/common/upload-addon.js:418 static/js/zamboni/devhub-all.js:652 static/js/zamboni/devhub-min.js:1
 msgid "Your add-on was validated with no errors and {0} warning."
 msgid_plural "Your add-on was validated with no errors and {0} warnings."
 msgstr[0] ""
 msgstr[1] ""
 
-#: static/js/common/upload-addon.js:426
+#: static/js/common/upload-addon.js:423 static/js/zamboni/devhub-all.js:657 static/js/zamboni/devhub-min.js:1
 msgid "Your add-on was validated with no errors and {0} message."
 msgid_plural "Your add-on was validated with no errors and {0} messages."
 msgstr[0] ""
 msgstr[1] ""
 
-#: static/js/common/upload-addon.js:431
+#: static/js/common/upload-addon.js:428 static/js/zamboni/devhub-all.js:662 static/js/zamboni/devhub-min.js:1
 msgid "Your add-on was validated with no errors or warnings."
 msgstr ""
 
-#: static/js/common/upload-addon.js:446
+#: static/js/common/upload-addon.js:443 static/js/zamboni/devhub-all.js:677 static/js/zamboni/devhub-min.js:1
 msgid "Your submission will be automatically signed."
 msgstr ""
 
-#: static/js/common/upload-addon.js:465
+#: static/js/common/upload-addon.js:450 static/js/zamboni/devhub-all.js:696 static/js/zamboni/devhub-min.js:1
 msgid "Include detailed version notes (this can be done in the next step)."
 msgstr ""
 
-#: static/js/common/upload-addon.js:466
+#: static/js/common/upload-addon.js:451 static/js/zamboni/devhub-all.js:697 static/js/zamboni/devhub-min.js:1
 msgid "If your add-on requires an account to a website in order to be fully tested, include a test username and password in the Notes to Reviewer (this can be done in the next step)."
 msgstr ""
 
-#: static/js/common/upload-addon.js:467
+#: static/js/common/upload-addon.js:452 static/js/zamboni/devhub-all.js:698 static/js/zamboni/devhub-min.js:1
 msgid "If your add-on is intended for a limited audience you should choose Preliminary Review instead of Full Review."
 msgstr ""
 
-#: static/js/common/upload-addon.js:480
+#: static/js/common/upload-addon.js:465 static/js/zamboni/devhub-all.js:711 static/js/zamboni/devhub-min.js:1
 msgid "Add-on submission checklist"
 msgstr ""
 
-#: static/js/common/upload-addon.js:481
+#: static/js/common/upload-addon.js:466 static/js/zamboni/devhub-all.js:712 static/js/zamboni/devhub-min.js:1
 msgid "Please verify the following points before finalizing your submission. This will minimize delays or misunderstanding during the review process:"
 msgstr ""
 
-#: static/js/common/upload-addon.js:483
+#: static/js/common/upload-addon.js:468 static/js/zamboni/devhub-all.js:714 static/js/zamboni/devhub-min.js:1
 msgid ""
 "Compiled binaries, as well as minified or obfuscated scripts (excluding known libraries) need to have their sources submitted separately for review. Make sure that you use the source code upload "
 "field to avoid having your submission rejected."
 msgstr ""
 
-#: static/js/common/upload-addon.js:501
+#: static/js/common/upload-addon.js:486 static/js/zamboni/devhub-all.js:732 static/js/zamboni/devhub-min.js:1
 msgid "The validation process found these issues that can lead to rejections:"
 msgstr ""
 
-#: static/js/common/upload-addon.js:518
+#: static/js/common/upload-addon.js:503 static/js/zamboni/devhub-all.js:749 static/js/zamboni/devhub-min.js:1
 msgid "If you are unfamiliar with the add-ons review process, you can read about it here."
 msgstr ""
 
-#: static/js/common/upload-addon.js:555
+#: static/js/common/upload-addon.js:540 static/js/zamboni/devhub-all.js:786 static/js/zamboni/devhub-min.js:1
 msgid "Sorry, no supported platform has been found."
 msgstr ""
 
-#: static/js/common/upload-base.js:57
+#: static/js/common/upload-base.js:57 static/js/zamboni/devhub-all.js:187 static/js/zamboni/devhub-min.js:1
 msgid "The filetype you uploaded isn't recognized."
 msgstr ""
 
-#: static/js/common/upload-base.js:79
+#: static/js/common/upload-base.js:79 static/js/zamboni/devhub-all.js:209 static/js/zamboni/devhub-min.js:1
 msgid "You cancelled the upload."
 msgstr ""
 
-#: static/js/common/upload-image.js:97 static/js/impala/users.js:51
-msgid "Images must be either PNG or JPG."
-msgstr ""
-
-#: static/js/common/upload-image.js:101
-msgid "Videos must be in WebM."
-msgstr ""
-
-#: static/js/impala/collections.js:10 static/js/zamboni/collections.js:595
-msgid "Follow this Collection"
-msgstr ""
-
-#: static/js/impala/collections.js:19
-msgid "Stop Following"
-msgstr ""
-
-#: static/js/impala/collections.js:20
-msgid "Following"
-msgstr ""
-
-#. L10n: {0} is an app name.
-#: static/js/impala/listing.js:11 static/js/zamboni/themes.js:13
-msgid "This theme is incompatible with your version of {0}"
-msgstr ""
-
-#: static/js/impala/persona_creation.js:60
-msgid "All Rights Reserved"
-msgstr ""
-
-#: static/js/impala/persona_creation.js:64
-msgid "Creative Commons Attribution 3.0"
-msgstr ""
-
-#: static/js/impala/persona_creation.js:69
-msgid "Creative Commons Attribution-NonCommercial 3.0"
-msgstr ""
-
-#: static/js/impala/persona_creation.js:74
-msgid "Creative Commons Attribution-NonCommercial-NoDerivs 3.0"
-msgstr ""
-
-#: static/js/impala/persona_creation.js:79
-msgid "Creative Commons Attribution-NonCommercial-Share Alike 3.0"
-msgstr ""
-
-#: static/js/impala/persona_creation.js:84
-msgid "Creative Commons Attribution-NoDerivs 3.0"
-msgstr ""
-
-#: static/js/impala/persona_creation.js:89
-msgid "Creative Commons Attribution-ShareAlike 3.0"
-msgstr ""
-
-#: static/js/impala/persona_creation.js:292
-msgid "Your Theme's Name"
-msgstr ""
-
-#: static/js/impala/reviews.js:23 static/js/zamboni/reviews.js:18
-msgid "Flagged for review"
-msgstr ""
-
-#: static/js/impala/reviews.js:40 static/js/zamboni/reviews.js:34
-msgid "Your input is required"
-msgstr ""
-
-#: static/js/impala/reviews.js:152 static/js/zamboni/reviews.js:103
-msgid "Marked for deletion"
-msgstr ""
-
-#: static/js/impala/search.js:114
-msgid "Updating results&hellip;"
-msgstr ""
-
-#: static/js/impala/site_suggestions.js:46
-msgid "Category"
-msgstr ""
-
-#: static/js/impala/suggestions.js:39
-msgid "Search themes for <b>{0}</b>"
-msgstr ""
-
-#: static/js/impala/suggestions.js:41
-msgid "Search apps for <b>{0}</b>"
-msgstr ""
-
-#: static/js/impala/suggestions.js:43
-msgid "Search add-ons for <b>{0}</b>"
-msgstr ""
-
-#: static/js/impala/users.js:33
-msgid "use original"
-msgstr ""
-
-#: static/js/impala/stats/chart.js:267
+#: static/js/impala/stats/chart.js:267 static/js/zamboni/stats-all.js:16898 static/js/zamboni/stats-min.js:5
 msgid "Week of {0}"
 msgstr ""
 
-#: static/js/impala/stats/chart.js:269
+#: static/js/impala/stats/chart.js:269 static/js/zamboni/stats-all.js:16900 static/js/zamboni/stats-min.js:5
 msgid " downloads"
 msgstr ""
 
-#: static/js/impala/stats/chart.js:270
+#: static/js/impala/stats/chart.js:270 static/js/zamboni/stats-all.js:16901 static/js/zamboni/stats-min.js:5
 msgid "{0} users"
 msgstr ""
 
-#: static/js/impala/stats/chart.js:271
+#: static/js/impala/stats/chart.js:271 static/js/zamboni/stats-all.js:16902 static/js/zamboni/stats-min.js:5
 msgid "{0} add-ons"
 msgstr ""
 
-#: static/js/impala/stats/chart.js:272
+#: static/js/impala/stats/chart.js:272 static/js/zamboni/stats-all.js:16903 static/js/zamboni/stats-min.js:5
 msgid "{0} collections"
 msgstr ""
 
-#: static/js/impala/stats/chart.js:273
+#: static/js/impala/stats/chart.js:273 static/js/zamboni/stats-all.js:16904 static/js/zamboni/stats-min.js:5
 msgid "{0} reviews"
 msgstr ""
 
-#: static/js/impala/stats/chart.js:275
+#: static/js/impala/stats/chart.js:275 static/js/zamboni/stats-all.js:16906 static/js/zamboni/stats-min.js:5
 msgid "{0} sales"
 msgstr ""
 
-#: static/js/impala/stats/chart.js:276
+#: static/js/impala/stats/chart.js:276 static/js/zamboni/stats-all.js:16907 static/js/zamboni/stats-min.js:5
 msgid "{0} refunds"
 msgstr ""
 
-#: static/js/impala/stats/chart.js:277
+#: static/js/impala/stats/chart.js:277 static/js/zamboni/stats-all.js:16908 static/js/zamboni/stats-min.js:5
 msgid "{0} installs"
 msgstr ""
 
-#: static/js/impala/stats/chart.js:369 static/js/impala/stats/csv_keys.js:3 static/js/impala/stats/csv_keys.js:109
+#: static/js/impala/stats/chart.js:369 static/js/impala/stats/csv_keys.js:3 static/js/impala/stats/csv_keys.js:109 static/js/zamboni/stats-all.js:15284 static/js/zamboni/stats-all.js:15390
+#: static/js/zamboni/stats-all.js:17000 static/js/zamboni/stats-min.js:4 static/js/zamboni/stats-min.js:5
 msgid "Downloads"
 msgstr ""
 
-#: static/js/impala/stats/chart.js:379 static/js/impala/stats/csv_keys.js:6 static/js/impala/stats/csv_keys.js:110
+#: static/js/impala/stats/chart.js:379 static/js/impala/stats/csv_keys.js:6 static/js/impala/stats/csv_keys.js:110 static/js/zamboni/stats-all.js:15287 static/js/zamboni/stats-all.js:15391
+#: static/js/zamboni/stats-all.js:17010 static/js/zamboni/stats-min.js:4 static/js/zamboni/stats-min.js:5
 msgid "Daily Users"
 msgstr ""
 
-#: static/js/impala/stats/chart.js:410
+#: static/js/impala/stats/chart.js:410 static/js/zamboni/stats-all.js:17041 static/js/zamboni/stats-min.js:5
 msgid "Amount, in USD"
 msgstr ""
 
-#: static/js/impala/stats/chart.js:421 static/js/impala/stats/csv_keys.js:104
+#: static/js/impala/stats/chart.js:421 static/js/impala/stats/csv_keys.js:104 static/js/zamboni/stats-all.js:15385 static/js/zamboni/stats-all.js:17052 static/js/zamboni/stats-min.js:5
 msgid "Number of Contributions"
 msgstr ""
 
-#: static/js/impala/stats/chart.js:447
+#: static/js/impala/stats/chart.js:447 static/js/zamboni/stats-all.js:17078 static/js/zamboni/stats-min.js:5
 msgid "More Info..."
 msgstr ""
 
 #. L10n: {0} is an ISO-formatted date.
-#: static/js/impala/stats/chart.js:451
+#: static/js/impala/stats/chart.js:451 static/js/zamboni/stats-all.js:17082 static/js/zamboni/stats-min.js:5
 msgid "Details for {0}"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:9
+#: static/js/impala/stats/csv_keys.js:9 static/js/zamboni/stats-all.js:15290 static/js/zamboni/stats-min.js:4
 msgid "Collections Created"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:12
+#: static/js/impala/stats/csv_keys.js:12 static/js/zamboni/stats-all.js:15293 static/js/zamboni/stats-min.js:4
 msgid "Add-ons in Use"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:15
+#: static/js/impala/stats/csv_keys.js:15 static/js/zamboni/stats-all.js:15296 static/js/zamboni/stats-min.js:4
 msgid "Add-ons Created"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:18
+#: static/js/impala/stats/csv_keys.js:18 static/js/zamboni/stats-all.js:15299 static/js/zamboni/stats-min.js:4
 msgid "Add-ons Downloaded"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:21
+#: static/js/impala/stats/csv_keys.js:21 static/js/zamboni/stats-all.js:15302 static/js/zamboni/stats-min.js:4
 msgid "Add-ons Updated"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:24
+#: static/js/impala/stats/csv_keys.js:24 static/js/zamboni/stats-all.js:15305 static/js/zamboni/stats-min.js:4
 msgid "Reviews Written"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:27
+#: static/js/impala/stats/csv_keys.js:27 static/js/zamboni/stats-all.js:15308 static/js/zamboni/stats-min.js:4
 msgid "User Signups"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:30
+#: static/js/impala/stats/csv_keys.js:30 static/js/zamboni/stats-all.js:15311 static/js/zamboni/stats-min.js:4
 msgid "Subscribers"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:33
+#: static/js/impala/stats/csv_keys.js:33 static/js/zamboni/stats-all.js:15314 static/js/zamboni/stats-min.js:4
 msgid "Ratings"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:36 static/js/impala/stats/csv_keys.js:114
+#: static/js/impala/stats/csv_keys.js:36 static/js/impala/stats/csv_keys.js:114 static/js/zamboni/stats-all.js:15317 static/js/zamboni/stats-all.js:15395 static/js/zamboni/stats-min.js:4
+#: static/js/zamboni/stats-min.js:5
 msgid "Sales"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:39 static/js/impala/stats/csv_keys.js:113
+#: static/js/impala/stats/csv_keys.js:39 static/js/impala/stats/csv_keys.js:113 static/js/zamboni/stats-all.js:15320 static/js/zamboni/stats-all.js:15394 static/js/zamboni/stats-min.js:4
+#: static/js/zamboni/stats-min.js:5
 msgid "Installs"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:42
+#: static/js/impala/stats/csv_keys.js:42 static/js/zamboni/stats-all.js:15323 static/js/zamboni/stats-min.js:4
 msgid "Unknown"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:43
+#: static/js/impala/stats/csv_keys.js:43 static/js/zamboni/stats-all.js:15324 static/js/zamboni/stats-min.js:4
 msgid "Add-ons Manager"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:44
+#: static/js/impala/stats/csv_keys.js:44 static/js/zamboni/stats-all.js:15325 static/js/zamboni/stats-min.js:4
 msgid "Add-ons Manager Promo"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:45
+#: static/js/impala/stats/csv_keys.js:45 static/js/zamboni/stats-all.js:15326 static/js/zamboni/stats-min.js:4
 msgid "Add-ons Manager Featured"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:46
+#: static/js/impala/stats/csv_keys.js:46 static/js/zamboni/stats-all.js:15327 static/js/zamboni/stats-min.js:4
 msgid "Add-ons Manager Learn More"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:47
+#: static/js/impala/stats/csv_keys.js:47 static/js/zamboni/stats-all.js:15328 static/js/zamboni/stats-min.js:4
 msgid "Search Suggestions"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:48
+#: static/js/impala/stats/csv_keys.js:48 static/js/zamboni/stats-all.js:15329 static/js/zamboni/stats-min.js:4
 msgid "Search Results"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:49 static/js/impala/stats/csv_keys.js:50 static/js/impala/stats/csv_keys.js:51
+#: static/js/impala/stats/csv_keys.js:49 static/js/impala/stats/csv_keys.js:50 static/js/impala/stats/csv_keys.js:51 static/js/zamboni/stats-all.js:15330 static/js/zamboni/stats-all.js:15331
+#: static/js/zamboni/stats-all.js:15332 static/js/zamboni/stats-min.js:4
 msgid "Homepage Promo"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:52 static/js/impala/stats/csv_keys.js:53
+#: static/js/impala/stats/csv_keys.js:52 static/js/impala/stats/csv_keys.js:53 static/js/zamboni/stats-all.js:15333 static/js/zamboni/stats-all.js:15334 static/js/zamboni/stats-min.js:4
 msgid "Homepage Featured"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:54 static/js/impala/stats/csv_keys.js:55
+#: static/js/impala/stats/csv_keys.js:54 static/js/impala/stats/csv_keys.js:55 static/js/zamboni/stats-all.js:15335 static/js/zamboni/stats-all.js:15336 static/js/zamboni/stats-min.js:4
 msgid "Homepage Up and Coming"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:56
+#: static/js/impala/stats/csv_keys.js:56 static/js/zamboni/stats-all.js:15337 static/js/zamboni/stats-min.js:4
 msgid "Homepage Most Popular"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:57 static/js/impala/stats/csv_keys.js:59
+#: static/js/impala/stats/csv_keys.js:57 static/js/impala/stats/csv_keys.js:59 static/js/zamboni/stats-all.js:15338 static/js/zamboni/stats-all.js:15340 static/js/zamboni/stats-min.js:4
 msgid "Detail Page"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:58 static/js/impala/stats/csv_keys.js:60
+#: static/js/impala/stats/csv_keys.js:58 static/js/impala/stats/csv_keys.js:60 static/js/zamboni/stats-all.js:15339 static/js/zamboni/stats-all.js:15341 static/js/zamboni/stats-min.js:4
 msgid "Detail Page (bottom)"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:61
+#: static/js/impala/stats/csv_keys.js:61 static/js/zamboni/stats-all.js:15342 static/js/zamboni/stats-min.js:4
 msgid "Detail Page (Development Channel)"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:62 static/js/impala/stats/csv_keys.js:63 static/js/impala/stats/csv_keys.js:64
+#: static/js/impala/stats/csv_keys.js:62 static/js/impala/stats/csv_keys.js:63 static/js/impala/stats/csv_keys.js:64 static/js/zamboni/stats-all.js:15343 static/js/zamboni/stats-all.js:15344
+#: static/js/zamboni/stats-all.js:15345 static/js/zamboni/stats-min.js:4
 msgid "Often Used With"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:65 static/js/impala/stats/csv_keys.js:66
+#: static/js/impala/stats/csv_keys.js:65 static/js/impala/stats/csv_keys.js:66 static/js/zamboni/stats-all.js:15346 static/js/zamboni/stats-all.js:15347 static/js/zamboni/stats-min.js:4
 msgid "Others By Author"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:67 static/js/impala/stats/csv_keys.js:68
+#: static/js/impala/stats/csv_keys.js:67 static/js/impala/stats/csv_keys.js:68 static/js/zamboni/stats-all.js:15348 static/js/zamboni/stats-all.js:15349 static/js/zamboni/stats-min.js:4
 msgid "Dependencies"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:69 static/js/impala/stats/csv_keys.js:70
+#: static/js/impala/stats/csv_keys.js:69 static/js/impala/stats/csv_keys.js:70 static/js/zamboni/stats-all.js:15350 static/js/zamboni/stats-all.js:15351 static/js/zamboni/stats-min.js:4
 msgid "Upsell"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:71
+#: static/js/impala/stats/csv_keys.js:71 static/js/zamboni/stats-all.js:15352 static/js/zamboni/stats-min.js:4
 msgid "Meet the Developer"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:72
+#: static/js/impala/stats/csv_keys.js:72 static/js/zamboni/stats-all.js:15353 static/js/zamboni/stats-min.js:4
 msgid "User Profile"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:73
+#: static/js/impala/stats/csv_keys.js:73 static/js/zamboni/stats-all.js:15354 static/js/zamboni/stats-min.js:4
 msgid "Version History"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:75
+#: static/js/impala/stats/csv_keys.js:75 static/js/zamboni/stats-all.js:15356 static/js/zamboni/stats-min.js:4
 msgid "Sharing"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:76
+#: static/js/impala/stats/csv_keys.js:76 static/js/zamboni/stats-all.js:15357 static/js/zamboni/stats-min.js:4
 msgid "Category Pages"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:77
+#: static/js/impala/stats/csv_keys.js:77 static/js/zamboni/stats-all.js:15358 static/js/zamboni/stats-min.js:4
 msgid "Collections"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:78 static/js/impala/stats/csv_keys.js:79
+#: static/js/impala/stats/csv_keys.js:78 static/js/impala/stats/csv_keys.js:79 static/js/zamboni/stats-all.js:15359 static/js/zamboni/stats-all.js:15360 static/js/zamboni/stats-min.js:4
 msgid "Category Landing Featured Carousel"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:80 static/js/impala/stats/csv_keys.js:81
+#: static/js/impala/stats/csv_keys.js:80 static/js/impala/stats/csv_keys.js:81 static/js/zamboni/stats-all.js:15361 static/js/zamboni/stats-all.js:15362 static/js/zamboni/stats-min.js:4
 msgid "Category Landing Top Rated"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:82 static/js/impala/stats/csv_keys.js:83
+#: static/js/impala/stats/csv_keys.js:82 static/js/impala/stats/csv_keys.js:83 static/js/zamboni/stats-all.js:15363 static/js/zamboni/stats-all.js:15364 static/js/zamboni/stats-min.js:5
 msgid "Category Landing Most Popular"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:84 static/js/impala/stats/csv_keys.js:85
+#: static/js/impala/stats/csv_keys.js:84 static/js/impala/stats/csv_keys.js:85 static/js/zamboni/stats-all.js:15365 static/js/zamboni/stats-all.js:15366 static/js/zamboni/stats-min.js:5
 msgid "Category Landing Recently Added"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:86 static/js/impala/stats/csv_keys.js:87
+#: static/js/impala/stats/csv_keys.js:86 static/js/impala/stats/csv_keys.js:87 static/js/zamboni/stats-all.js:15367 static/js/zamboni/stats-all.js:15368 static/js/zamboni/stats-min.js:5
 msgid "Browse Listing Featured Sort"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:88 static/js/impala/stats/csv_keys.js:89
+#: static/js/impala/stats/csv_keys.js:88 static/js/impala/stats/csv_keys.js:89 static/js/zamboni/stats-all.js:15369 static/js/zamboni/stats-all.js:15370 static/js/zamboni/stats-min.js:5
 msgid "Browse Listing Users Sort"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:90 static/js/impala/stats/csv_keys.js:91
+#: static/js/impala/stats/csv_keys.js:90 static/js/impala/stats/csv_keys.js:91 static/js/zamboni/stats-all.js:15371 static/js/zamboni/stats-all.js:15372 static/js/zamboni/stats-min.js:5
 msgid "Browse Listing Rating Sort"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:92 static/js/impala/stats/csv_keys.js:93
+#: static/js/impala/stats/csv_keys.js:92 static/js/impala/stats/csv_keys.js:93 static/js/zamboni/stats-all.js:15373 static/js/zamboni/stats-all.js:15374 static/js/zamboni/stats-min.js:5
 msgid "Browse Listing Created Sort"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:94 static/js/impala/stats/csv_keys.js:95
+#: static/js/impala/stats/csv_keys.js:94 static/js/impala/stats/csv_keys.js:95 static/js/zamboni/stats-all.js:15375 static/js/zamboni/stats-all.js:15376 static/js/zamboni/stats-min.js:5
 msgid "Browse Listing Name Sort"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:96 static/js/impala/stats/csv_keys.js:97
+#: static/js/impala/stats/csv_keys.js:96 static/js/impala/stats/csv_keys.js:97 static/js/zamboni/stats-all.js:15377 static/js/zamboni/stats-all.js:15378 static/js/zamboni/stats-min.js:5
 msgid "Browse Listing Popular Sort"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:98 static/js/impala/stats/csv_keys.js:99
+#: static/js/impala/stats/csv_keys.js:98 static/js/impala/stats/csv_keys.js:99 static/js/zamboni/stats-all.js:15379 static/js/zamboni/stats-all.js:15380 static/js/zamboni/stats-min.js:5
 msgid "Browse Listing Updated Sort"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:100 static/js/impala/stats/csv_keys.js:101
+#: static/js/impala/stats/csv_keys.js:100 static/js/impala/stats/csv_keys.js:101 static/js/zamboni/stats-all.js:15381 static/js/zamboni/stats-all.js:15382 static/js/zamboni/stats-min.js:5
 msgid "Browse Listing Up and Coming Sort"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:105
+#: static/js/impala/stats/csv_keys.js:105 static/js/zamboni/stats-all.js:15386 static/js/zamboni/stats-min.js:5
 msgid "Total Amount Contributed"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:106
+#: static/js/impala/stats/csv_keys.js:106 static/js/zamboni/stats-all.js:15387 static/js/zamboni/stats-min.js:5
 msgid "Average Contribution"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:115
+#: static/js/impala/stats/csv_keys.js:115 static/js/zamboni/stats-all.js:15396 static/js/zamboni/stats-min.js:5
 msgid "Usage"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:118
+#: static/js/impala/stats/csv_keys.js:118 static/js/zamboni/stats-all.js:15399 static/js/zamboni/stats-min.js:5
 msgid "Firefox"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:119
+#: static/js/impala/stats/csv_keys.js:119 static/js/zamboni/stats-all.js:15400 static/js/zamboni/stats-min.js:5
 msgid "Mozilla"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:120
+#: static/js/impala/stats/csv_keys.js:120 static/js/zamboni/stats-all.js:15401 static/js/zamboni/stats-min.js:5
 msgid "Thunderbird"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:121
+#: static/js/impala/stats/csv_keys.js:121 static/js/zamboni/stats-all.js:15402 static/js/zamboni/stats-min.js:5
 msgid "Sunbird"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:122
+#: static/js/impala/stats/csv_keys.js:122 static/js/zamboni/stats-all.js:15403 static/js/zamboni/stats-min.js:5
 msgid "SeaMonkey"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:123
+#: static/js/impala/stats/csv_keys.js:123 static/js/zamboni/stats-all.js:15404 static/js/zamboni/stats-min.js:5
 msgid "Fennec"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:124
+#: static/js/impala/stats/csv_keys.js:124 static/js/zamboni/stats-all.js:15405 static/js/zamboni/stats-min.js:5
 msgid "Android"
 msgstr ""
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:129
+#: static/js/impala/stats/csv_keys.js:129 static/js/zamboni/stats-all.js:15410 static/js/zamboni/stats-min.js:5
 msgid "Downloads and Daily Users, last {0} days"
 msgstr ""
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:131
+#: static/js/impala/stats/csv_keys.js:131 static/js/zamboni/stats-all.js:15412 static/js/zamboni/stats-min.js:5
 msgid "Downloads and Daily Users from {0} to {1}"
 msgstr ""
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:135
+#: static/js/impala/stats/csv_keys.js:135 static/js/zamboni/stats-all.js:15416 static/js/zamboni/stats-min.js:5
 msgid "Installs and Daily Users, last {0} days"
 msgstr ""
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:137
+#: static/js/impala/stats/csv_keys.js:137 static/js/zamboni/stats-all.js:15418 static/js/zamboni/stats-min.js:5
 msgid "Installs and Daily Users from {0} to {1}"
 msgstr ""
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:141
+#: static/js/impala/stats/csv_keys.js:141 static/js/zamboni/stats-all.js:15422 static/js/zamboni/stats-min.js:5
 msgid "Downloads, last {0} days"
 msgstr ""
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:143
+#: static/js/impala/stats/csv_keys.js:143 static/js/zamboni/stats-all.js:15424 static/js/zamboni/stats-min.js:5
 msgid "Downloads from {0} to {1}"
 msgstr ""
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:147
+#: static/js/impala/stats/csv_keys.js:147 static/js/zamboni/stats-all.js:15428 static/js/zamboni/stats-min.js:5
 msgid "Daily Users, last {0} days"
 msgstr ""
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:149
+#: static/js/impala/stats/csv_keys.js:149 static/js/zamboni/stats-all.js:15430 static/js/zamboni/stats-min.js:5
 msgid "Daily Users from {0} to {1}"
 msgstr ""
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:153
+#: static/js/impala/stats/csv_keys.js:153 static/js/zamboni/stats-all.js:15434 static/js/zamboni/stats-min.js:5
 msgid "Applications, last {0} days"
 msgstr ""
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:155
+#: static/js/impala/stats/csv_keys.js:155 static/js/zamboni/stats-all.js:15436 static/js/zamboni/stats-min.js:5
 msgid "Applications from {0} to {1}"
 msgstr ""
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:159
+#: static/js/impala/stats/csv_keys.js:159 static/js/zamboni/stats-all.js:15440 static/js/zamboni/stats-min.js:5
 msgid "Platforms, last {0} days"
 msgstr ""
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:161
+#: static/js/impala/stats/csv_keys.js:161 static/js/zamboni/stats-all.js:15442 static/js/zamboni/stats-min.js:5
 msgid "Platforms from {0} to {1}"
 msgstr ""
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:165
+#: static/js/impala/stats/csv_keys.js:165 static/js/zamboni/stats-all.js:15446 static/js/zamboni/stats-min.js:5
 msgid "Languages, last {0} days"
 msgstr ""
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:167
+#: static/js/impala/stats/csv_keys.js:167 static/js/zamboni/stats-all.js:15448 static/js/zamboni/stats-min.js:5
 msgid "Languages from {0} to {1}"
 msgstr ""
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:171
+#: static/js/impala/stats/csv_keys.js:171 static/js/zamboni/stats-all.js:15452 static/js/zamboni/stats-min.js:5
 msgid "Add-on Versions, last {0} days"
 msgstr ""
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:173
+#: static/js/impala/stats/csv_keys.js:173 static/js/zamboni/stats-all.js:15454 static/js/zamboni/stats-min.js:5
 msgid "Add-on Versions from {0} to {1}"
 msgstr ""
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:177
+#: static/js/impala/stats/csv_keys.js:177 static/js/zamboni/stats-all.js:15458 static/js/zamboni/stats-min.js:5
 msgid "Add-on Status, last {0} days"
 msgstr ""
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:179
+#: static/js/impala/stats/csv_keys.js:179 static/js/zamboni/stats-all.js:15460 static/js/zamboni/stats-min.js:5
 msgid "Add-on Status from {0} to {1}"
 msgstr ""
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:183
+#: static/js/impala/stats/csv_keys.js:183 static/js/zamboni/stats-all.js:15464 static/js/zamboni/stats-min.js:5
 msgid "Download Sources, last {0} days"
 msgstr ""
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:185
+#: static/js/impala/stats/csv_keys.js:185 static/js/zamboni/stats-all.js:15466 static/js/zamboni/stats-min.js:5
 msgid "Download Sources from {0} to {1}"
 msgstr ""
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:189
+#: static/js/impala/stats/csv_keys.js:189 static/js/zamboni/stats-all.js:15470 static/js/zamboni/stats-min.js:5
 msgid "Contributions, last {0} days"
 msgstr ""
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:191
+#: static/js/impala/stats/csv_keys.js:191 static/js/zamboni/stats-all.js:15472 static/js/zamboni/stats-min.js:5
 msgid "Contributions from {0} to {1}"
 msgstr ""
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:195
+#: static/js/impala/stats/csv_keys.js:195 static/js/zamboni/stats-all.js:15476 static/js/zamboni/stats-min.js:5
 msgid "Site Metrics, last {0} days"
 msgstr ""
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:197
+#: static/js/impala/stats/csv_keys.js:197 static/js/zamboni/stats-all.js:15478 static/js/zamboni/stats-min.js:5
 msgid "Site Metrics from {0} to {1}"
 msgstr ""
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:201
+#: static/js/impala/stats/csv_keys.js:201 static/js/zamboni/stats-all.js:15482 static/js/zamboni/stats-min.js:5
 msgid "Add-ons in Use, last {0} days"
 msgstr ""
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:203
+#: static/js/impala/stats/csv_keys.js:203 static/js/zamboni/stats-all.js:15484 static/js/zamboni/stats-min.js:5
 msgid "Add-ons in Use from {0} to {1}"
 msgstr ""
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:207
+#: static/js/impala/stats/csv_keys.js:207 static/js/zamboni/stats-all.js:15488 static/js/zamboni/stats-min.js:5
 msgid "Add-ons Downloaded, last {0} days"
 msgstr ""
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:209
+#: static/js/impala/stats/csv_keys.js:209 static/js/zamboni/stats-all.js:15490 static/js/zamboni/stats-min.js:5
 msgid "Add-ons Downloaded from {0} to {1}"
 msgstr ""
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:213
+#: static/js/impala/stats/csv_keys.js:213 static/js/zamboni/stats-all.js:15494 static/js/zamboni/stats-min.js:5
 msgid "Add-ons Created, last {0} days"
 msgstr ""
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:215
+#: static/js/impala/stats/csv_keys.js:215 static/js/zamboni/stats-all.js:15496 static/js/zamboni/stats-min.js:5
 msgid "Add-ons Created from {0} to {1}"
 msgstr ""
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:219
+#: static/js/impala/stats/csv_keys.js:219 static/js/zamboni/stats-all.js:15500 static/js/zamboni/stats-min.js:5
 msgid "Add-ons Updated, last {0} days"
 msgstr ""
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:221
+#: static/js/impala/stats/csv_keys.js:221 static/js/zamboni/stats-all.js:15502 static/js/zamboni/stats-min.js:5
 msgid "Add-ons Updated from {0} to {1}"
 msgstr ""
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:225
+#: static/js/impala/stats/csv_keys.js:225 static/js/zamboni/stats-all.js:15506 static/js/zamboni/stats-min.js:5
 msgid "Reviews Written, last {0} days"
 msgstr ""
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:227
+#: static/js/impala/stats/csv_keys.js:227 static/js/zamboni/stats-all.js:15508 static/js/zamboni/stats-min.js:5
 msgid "Reviews Written from {0} to {1}"
 msgstr ""
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:231
+#: static/js/impala/stats/csv_keys.js:231 static/js/zamboni/stats-all.js:15512 static/js/zamboni/stats-min.js:5
 msgid "User Signups, last {0} days"
 msgstr ""
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:233
+#: static/js/impala/stats/csv_keys.js:233 static/js/zamboni/stats-all.js:15514 static/js/zamboni/stats-min.js:5
 msgid "User Signups from {0} to {1}"
 msgstr ""
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:237
+#: static/js/impala/stats/csv_keys.js:237 static/js/zamboni/stats-all.js:15518 static/js/zamboni/stats-min.js:5
 msgid "Collections Created, last {0} days"
 msgstr ""
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:239
+#: static/js/impala/stats/csv_keys.js:239 static/js/zamboni/stats-all.js:15520 static/js/zamboni/stats-min.js:5
 msgid "Collections Created from {0} to {1}"
 msgstr ""
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:243
+#: static/js/impala/stats/csv_keys.js:243 static/js/zamboni/stats-all.js:15524 static/js/zamboni/stats-min.js:5
 msgid "Subscribers, last {0} days"
 msgstr ""
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:245
+#: static/js/impala/stats/csv_keys.js:245 static/js/zamboni/stats-all.js:15526 static/js/zamboni/stats-min.js:5
 msgid "Subscribers from {0} to {1}"
 msgstr ""
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:249
+#: static/js/impala/stats/csv_keys.js:249 static/js/zamboni/stats-all.js:15530 static/js/zamboni/stats-min.js:5
 msgid "Ratings, last {0} days"
 msgstr ""
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:251
+#: static/js/impala/stats/csv_keys.js:251 static/js/zamboni/stats-all.js:15532 static/js/zamboni/stats-min.js:5
 msgid "Ratings from {0} to {1}"
 msgstr ""
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:255
+#: static/js/impala/stats/csv_keys.js:255 static/js/zamboni/stats-all.js:15536 static/js/zamboni/stats-min.js:5
 msgid "Sales, last {0} days"
 msgstr ""
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:257
+#: static/js/impala/stats/csv_keys.js:257 static/js/zamboni/stats-all.js:15538 static/js/zamboni/stats-min.js:5
 msgid "Sales from {0} to {1}"
 msgstr ""
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:261
+#: static/js/impala/stats/csv_keys.js:261 static/js/zamboni/stats-all.js:15542 static/js/zamboni/stats-min.js:5
 msgid "Installs, last {0} days"
 msgstr ""
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:263
+#: static/js/impala/stats/csv_keys.js:263 static/js/zamboni/stats-all.js:15544 static/js/zamboni/stats-min.js:5
 msgid "Installs from {0} to {1}"
 msgstr ""
 
 #. L10n: {0} and {1} are integers.
-#: static/js/impala/stats/csv_keys.js:269
+#: static/js/impala/stats/csv_keys.js:269 static/js/zamboni/stats-all.js:15550 static/js/zamboni/stats-min.js:5
 msgid "<b>{0}</b> in last {1} days"
 msgstr ""
 
 #. L10n: {0} is an integer and {1} and {2} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:271 static/js/impala/stats/csv_keys.js:277
+#: static/js/impala/stats/csv_keys.js:271 static/js/impala/stats/csv_keys.js:277 static/js/zamboni/stats-all.js:15552 static/js/zamboni/stats-all.js:15558 static/js/zamboni/stats-min.js:5
 msgid "<b>{0}</b> from {1} to {2}"
 msgstr ""
 
 #. L10n: {0} and {1} are integers.
-#: static/js/impala/stats/csv_keys.js:275
+#: static/js/impala/stats/csv_keys.js:275 static/js/zamboni/stats-all.js:15556 static/js/zamboni/stats-min.js:5
 msgid "<b>{0}</b> average in last {1} days"
 msgstr ""
 
-#: static/js/impala/stats/overview.js:19
+#: static/js/impala/stats/overview.js:19 static/js/zamboni/stats-all.js:16469 static/js/zamboni/stats-min.js:5
 msgid "No data available."
 msgstr ""
 
-#: static/js/impala/stats/table.js:74
+#: static/js/impala/stats/table.js:74 static/js/zamboni/stats-all.js:17209 static/js/zamboni/stats-min.js:5
 msgid "Date"
 msgstr ""
 
-#: static/js/impala/stats/topchart.js:96
+#: static/js/impala/stats/topchart.js:96 static/js/zamboni/stats-all.js:16600 static/js/zamboni/stats-min.js:5
 msgid "Other"
 msgstr ""
 
-#: static/js/zamboni/admin_validation.js:24 static/js/zamboni/devhub.js:1229 static/js/zamboni/editors.js:295
+#: static/js/zamboni/admin-all.js:180 static/js/zamboni/admin-min.js:1 static/js/zamboni/admin_validation.js:24 static/js/zamboni/devhub-all.js:2408 static/js/zamboni/devhub-min.js:2
+#: static/js/zamboni/devhub.js:1229 static/js/zamboni/editors-all.js:15576 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:295
 msgid "Select an application first"
 msgstr ""
 
-#: static/js/zamboni/admin_validation.js:51
+#: static/js/zamboni/admin-all.js:207 static/js/zamboni/admin-min.js:1 static/js/zamboni/admin_validation.js:51
 msgid "Set {0} add-on to a max version of {1} and email the author."
 msgid_plural "Set {0} add-ons to a max version of {1} and email the authors."
 msgstr[0] ""
 msgstr[1] ""
 
-#: static/js/zamboni/admin_validation.js:54
+#: static/js/zamboni/admin-all.js:210 static/js/zamboni/admin-min.js:1 static/js/zamboni/admin_validation.js:54
 msgid "Email author of {2} add-on which failed validation."
 msgid_plural "Email authors of {2} add-ons which failed validation."
 msgstr[0] ""
 msgstr[1] ""
 
-#. L10n: {0} is an app name like Firefox.
-#: static/js/zamboni/buttons.js:66
-msgid "Accept and Install"
-msgstr ""
-
-#: static/js/zamboni/buttons.js:66
-msgid "Add to {0}"
-msgstr ""
-
-#: static/js/zamboni/buttons.js:71
-msgid "Download Now"
-msgstr ""
-
-#: static/js/zamboni/buttons.js:112
-msgid "Add-on has not been updated to support default-to-compatible."
-msgstr ""
-
-#: static/js/zamboni/buttons.js:117
-msgid "You need to be using Firefox 10.0 or higher."
-msgstr ""
-
-#: static/js/zamboni/buttons.js:129
-msgid "Mozilla has marked this version as incompatible with your Firefox version."
-msgstr ""
-
-#. L10n: {0} is an platform like Windows or Linux.
-#: static/js/zamboni/buttons.js:210
-msgid "Install for {0} anyway"
-msgstr ""
-
-#: static/js/zamboni/buttons.js:210
-msgid "Download for {0} anyway"
-msgstr ""
-
-#: static/js/zamboni/buttons.js:267
-msgid "Not available for your platform"
-msgstr ""
-
-#. L10n: {0} is an app name, {1} is the app version.
-#: static/js/zamboni/buttons.js:278 static/js/zamboni/buttons.js:315
-msgid "Not available for {0} {1}"
-msgstr ""
-
-#: static/js/zamboni/buttons.js:341
-msgid "Works with {app} {min} - {max}"
-msgstr ""
-
-#: static/js/zamboni/buttons.js:343
-msgid "View other versions"
-msgstr ""
-
-#: static/js/zamboni/buttons.js:391
-msgid "Only with Firefox — Get Firefox Now!"
-msgstr ""
-
-#: static/js/zamboni/buttons.js:507 static/js/zamboni/mobile/buttons.js:43
-msgid "Sorry, you need a Mozilla-based browser (such as Firefox) to install a search plugin."
-msgstr ""
-
-#: static/js/zamboni/collections.js:229
-msgid "Adding to Favorites&hellip;"
-msgstr ""
-
-#: static/js/zamboni/collections.js:232
-msgid "Removing Favorite&hellip;"
-msgstr ""
-
-#: static/js/zamboni/collections.js:235
-msgid "Add to Favorites"
-msgstr ""
-
-#: static/js/zamboni/collections.js:238
-msgid "Remove from Favorites"
-msgstr ""
-
-#: static/js/zamboni/collections.js:303
-msgid "Pending"
-msgstr ""
-
-#: static/js/zamboni/collections.js:304
-msgid "Add a comment"
-msgstr ""
-
-#: static/js/zamboni/collections.js:304
-msgid "Comment"
-msgstr ""
-
-#: static/js/zamboni/collections.js:305
-msgid "Remove this add-on from the collection"
-msgstr ""
-
-#: static/js/zamboni/collections.js:305 static/js/zamboni/collections.js:334
-msgid "Remove"
-msgstr ""
-
-#: static/js/zamboni/collections.js:334
-msgid "Remove this user as a contributor"
-msgstr ""
-
-#: static/js/zamboni/collections.js:346
-msgid "An email address is required."
-msgstr ""
-
-#: static/js/zamboni/collections.js:364
-msgid "You cannot add yourself as a contributor."
-msgstr ""
-
-#: static/js/zamboni/collections.js:366
-msgid "You have already added that user."
-msgstr ""
-
-#: static/js/zamboni/collections.js:573
-msgid "Add to favorites"
-msgstr ""
-
-#: static/js/zamboni/collections.js:577
-msgid "Remove from favorites"
-msgstr ""
-
-#: static/js/zamboni/collections.js:604
-msgid "Stop following"
-msgstr ""
-
-#: static/js/zamboni/devhub.js:110
+#: static/js/zamboni/devhub-all.js:1289 static/js/zamboni/devhub-min.js:1 static/js/zamboni/devhub.js:110
 msgid "Your browser does not support the video tag"
 msgstr ""
 
-#: static/js/zamboni/devhub.js:371
+#: static/js/zamboni/devhub-all.js:1550 static/js/zamboni/devhub-min.js:1 static/js/zamboni/devhub.js:371
 msgid "Changes Saved"
 msgstr ""
 
-#: static/js/zamboni/devhub.js:387
+#: static/js/zamboni/devhub-all.js:1566 static/js/zamboni/devhub-min.js:1 static/js/zamboni/devhub.js:387
 msgid "Enter a new author's email address"
 msgstr ""
 
-#: static/js/zamboni/devhub.js:536
+#: static/js/zamboni/devhub-all.js:1715 static/js/zamboni/devhub-min.js:1 static/js/zamboni/devhub.js:536
 msgid "There was an error uploading your file."
 msgstr ""
 
-#: static/js/zamboni/devhub.js:681
+#: static/js/zamboni/devhub-all.js:1860 static/js/zamboni/devhub-min.js:1 static/js/zamboni/devhub.js:681
 msgid "{files} file"
 msgid_plural "{files} files"
 msgstr[0] ""
 msgstr[1] ""
 
-#: static/js/zamboni/devhub.js:684
+#: static/js/zamboni/devhub-all.js:1863 static/js/zamboni/devhub-min.js:1 static/js/zamboni/devhub.js:684
 msgid "{reviews} user review"
 msgid_plural "{reviews} user reviews"
 msgstr[0] ""
 msgstr[1] ""
 
-#: static/js/zamboni/devhub.js:796
+#: static/js/zamboni/devhub-all.js:1975 static/js/zamboni/devhub-min.js:2 static/js/zamboni/devhub.js:796
 msgid "Learn more"
 msgstr ""
 
-#: static/js/zamboni/devhub.js:800
+#: static/js/zamboni/devhub-all.js:1979 static/js/zamboni/devhub-min.js:2 static/js/zamboni/devhub.js:800
 msgid "Example"
 msgstr ""
 
-#: static/js/zamboni/devhub.js:1130
+#: static/js/zamboni/devhub-all.js:2309 static/js/zamboni/devhub-min.js:2 static/js/zamboni/devhub.js:1130
 msgid "Image changes being processed"
 msgstr ""
 
-#: static/js/zamboni/devhub.js:1280
+#: static/js/zamboni/devhub-all.js:2459 static/js/zamboni/devhub-min.js:2 static/js/zamboni/devhub.js:1280
 msgid "Must be a valid e-mail address."
+msgstr ""
+
+#: static/js/zamboni/devhub-all.js:2613 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:80
+msgid "All tests passed successfully."
+msgstr ""
+
+#: static/js/zamboni/devhub-all.js:2616 static/js/zamboni/devhub-all.js:3011 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:83 static/js/zamboni/validator.js:478
+msgid "These tests were not run."
+msgstr ""
+
+#: static/js/zamboni/devhub-all.js:2664 static/js/zamboni/devhub-all.js:2677 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:131 static/js/zamboni/validator.js:144
+msgid "Tests"
+msgstr ""
+
+#: static/js/zamboni/devhub-all.js:2779 static/js/zamboni/devhub-all.js:3108 static/js/zamboni/devhub-all.js:3127 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:246
+#: static/js/zamboni/validator.js:575 static/js/zamboni/validator.js:594
+msgid "Error"
+msgstr ""
+
+#: static/js/zamboni/devhub-all.js:2780 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:247
+msgid "Warning"
+msgstr ""
+
+#: static/js/zamboni/devhub-all.js:2794 static/js/zamboni/devhub-min.js:2 static/js/zamboni/files-all.js:5657 static/js/zamboni/files-min.js:3 static/js/zamboni/files.js:411
+#: static/js/zamboni/validator.js:261
+msgid "Ignore this message in future updates"
+msgstr ""
+
+#: static/js/zamboni/devhub-all.js:2817 static/js/zamboni/devhub-min.js:2 static/js/zamboni/files-all.js:5663 static/js/zamboni/files-min.js:3 static/js/zamboni/files.js:417
+#: static/js/zamboni/validator.js:284
+msgid "Severity for automated signing:"
+msgstr ""
+
+#: static/js/zamboni/devhub-all.js:2832 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:299
+msgid "Suggestions for passing automated signing:"
+msgstr ""
+
+#: static/js/zamboni/devhub-all.js:2920 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:387
+msgid "Compatibility Tests"
+msgstr ""
+
+#: static/js/zamboni/devhub-all.js:2999 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:466
+msgid "Add-on failed validation."
+msgstr ""
+
+#: static/js/zamboni/devhub-all.js:3001 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:468
+msgid "Add-on passed validation."
+msgstr ""
+
+#: static/js/zamboni/devhub-all.js:3014 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:481
+msgid "{0} error"
+msgid_plural "{0} errors"
+msgstr[0] ""
+msgstr[1] ""
+
+#: static/js/zamboni/devhub-all.js:3016 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:483
+msgid "{0} warning"
+msgid_plural "{0} warnings"
+msgstr[0] ""
+msgstr[1] ""
+
+#: static/js/zamboni/devhub-all.js:3018 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:485
+msgid "{0} notice"
+msgid_plural "{0} notices"
+msgstr[0] ""
+msgstr[1] ""
+
+#: static/js/zamboni/devhub-all.js:3110 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:577
+msgid "Validation task could not complete or completed with errors"
+msgstr ""
+
+#: static/js/zamboni/devhub-all.js:3128 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:595
+msgid "Internal server error"
 msgstr ""
 
 #: static/js/zamboni/devhub_search.js:8
 msgid "No results found."
 msgstr ""
 
-#: static/js/zamboni/editors.js:121
+#: static/js/zamboni/editors-all.js:15402 static/js/zamboni/editors-min.js:4 static/js/zamboni/editors.js:121
 msgid "{name} was viewing this page first."
 msgstr ""
 
-#: static/js/zamboni/editors.js:171
+#: static/js/zamboni/editors-all.js:15452 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:171
 msgid "Receipt checked by app."
 msgstr ""
 
-#: static/js/zamboni/editors.js:173
+#: static/js/zamboni/editors-all.js:15454 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:173
 msgid "Receipt was not checked by app."
 msgstr ""
 
-#: static/js/zamboni/editors.js:244
+#: static/js/zamboni/editors-all.js:15525 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:244
 msgid "{name} was viewing this add-on first."
 msgstr ""
 
-#: static/js/zamboni/editors.js:255
+#: static/js/zamboni/editors-all.js:15536 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:255
 msgid "Loading&hellip;"
 msgstr ""
 
-#: static/js/zamboni/editors.js:260
+#: static/js/zamboni/editors-all.js:15541 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:260
 msgid "Version Notes"
 msgstr ""
 
-#: static/js/zamboni/editors.js:265
+#: static/js/zamboni/editors-all.js:15546 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:265
 msgid "Notes for Reviewers"
 msgstr ""
 
-#: static/js/zamboni/editors.js:270
+#: static/js/zamboni/editors-all.js:15551 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:270
 msgid "No version notes found"
 msgstr ""
 
-#: static/js/zamboni/editors.js:330
+#: static/js/zamboni/editors-all.js:15611 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:330
 msgid "Average Reviews"
 msgstr ""
 
-#: static/js/zamboni/editors.js:386
+#: static/js/zamboni/editors-all.js:15667 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:386
 msgid "Number of Reviews"
 msgstr ""
 
-#: static/js/zamboni/editors.js:445
+#: static/js/zamboni/editors-all.js:15726 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:445
 msgid "Error loading translation"
 msgstr ""
 
-#: static/js/zamboni/files.js:411 static/js/zamboni/validator.js:261
-msgid "Ignore this message in future updates"
-msgstr ""
-
-#: static/js/zamboni/files.js:417 static/js/zamboni/validator.js:284
-msgid "Severity for automated signing:"
-msgstr ""
-
-#: static/js/zamboni/global.js:410
-msgid "Loading..."
-msgstr ""
-
-#. L10n: {0} is the number of characters left.
-#: static/js/zamboni/global.js:474
-msgid "<b>{0}</b> character left."
-msgid_plural "<b>{0}</b> characters left."
-msgstr[0] ""
-msgstr[1] ""
-
-#: static/js/zamboni/init.js:28
-msgid "This feature is temporarily disabled while we perform website maintenance. Please check back a little later."
-msgstr ""
-
-#: static/js/zamboni/l10n.js:45
-msgid "Remove this localization"
-msgstr ""
-
-#: static/js/zamboni/password-strength.js:20
-msgid "Password strength:"
-msgstr ""
-
-#: static/js/zamboni/password-strength.js:26
-msgid "At least {0} character left."
-msgid_plural "At least {0} characters left."
-msgstr[0] ""
-msgstr[1] ""
-
-#: static/js/zamboni/themes_review.js:176
-msgid "Requested Info"
-msgstr ""
-
-#: static/js/zamboni/themes_review.js:177
-msgid "Flagged"
-msgstr ""
-
-#: static/js/zamboni/themes_review.js:178
-msgid "Duplicate"
-msgstr ""
-
-#: static/js/zamboni/themes_review.js:179
-msgid "Rejected"
-msgstr ""
-
-#: static/js/zamboni/themes_review.js:180
-msgid "Approved"
-msgstr ""
-
-#: static/js/zamboni/themes_review.js:424
-msgid "No results found"
-msgstr ""
-
-#: static/js/zamboni/themes_review_templates.js:31
+#: static/js/zamboni/editors-all.js:15975 static/js/zamboni/editors-min.js:5 static/js/zamboni/themes_review_templates.js:31
 msgid "Theme"
 msgstr ""
 
-#: static/js/zamboni/themes_review_templates.js:33
+#: static/js/zamboni/editors-all.js:15977 static/js/zamboni/editors-min.js:5 static/js/zamboni/themes_review_templates.js:33
 msgid "Reviewer"
 msgstr ""
 
-#: static/js/zamboni/themes_review_templates.js:35
+#: static/js/zamboni/editors-all.js:15979 static/js/zamboni/editors-min.js:5 static/js/zamboni/themes_review_templates.js:35
 msgid "Status"
 msgstr ""
 
-#: static/js/zamboni/validator.js:80
-msgid "All tests passed successfully."
+#: static/js/zamboni/editors-all.js:16196 static/js/zamboni/editors-min.js:5 static/js/zamboni/themes_review.js:176
+msgid "Requested Info"
 msgstr ""
 
-#: static/js/zamboni/validator.js:83 static/js/zamboni/validator.js:478
-msgid "These tests were not run."
+#: static/js/zamboni/editors-all.js:16197 static/js/zamboni/editors-min.js:5 static/js/zamboni/themes_review.js:177
+msgid "Flagged"
 msgstr ""
 
-#: static/js/zamboni/validator.js:131 static/js/zamboni/validator.js:144
-msgid "Tests"
+#: static/js/zamboni/editors-all.js:16198 static/js/zamboni/editors-min.js:5 static/js/zamboni/themes_review.js:178
+msgid "Duplicate"
 msgstr ""
 
-#: static/js/zamboni/validator.js:246 static/js/zamboni/validator.js:575 static/js/zamboni/validator.js:594
-msgid "Error"
+#: static/js/zamboni/editors-all.js:16199 static/js/zamboni/editors-min.js:5 static/js/zamboni/themes_review.js:179
+msgid "Rejected"
 msgstr ""
 
-#: static/js/zamboni/validator.js:247
-msgid "Warning"
+#: static/js/zamboni/editors-all.js:16200 static/js/zamboni/editors-min.js:5 static/js/zamboni/themes_review.js:180
+msgid "Approved"
 msgstr ""
 
-#: static/js/zamboni/validator.js:299
-msgid "Suggestions for passing automated signing:"
+#: static/js/zamboni/editors-all.js:16444 static/js/zamboni/editors-min.js:5 static/js/zamboni/themes_review.js:424
+msgid "No results found"
 msgstr ""
 
-#: static/js/zamboni/validator.js:387
-msgid "Compatibility Tests"
-msgstr ""
-
-#: static/js/zamboni/validator.js:466
-msgid "Add-on failed validation."
-msgstr ""
-
-#: static/js/zamboni/validator.js:468
-msgid "Add-on passed validation."
-msgstr ""
-
-#: static/js/zamboni/validator.js:481
-msgid "{0} error"
-msgid_plural "{0} errors"
-msgstr[0] ""
-msgstr[1] ""
-
-#: static/js/zamboni/validator.js:483
-msgid "{0} warning"
-msgid_plural "{0} warnings"
-msgstr[0] ""
-msgstr[1] ""
-
-#: static/js/zamboni/validator.js:485
-msgid "{0} notice"
-msgid_plural "{0} notices"
-msgstr[0] ""
-msgstr[1] ""
-
-#: static/js/zamboni/validator.js:577
-msgid "Validation task could not complete or completed with errors"
-msgstr ""
-
-#: static/js/zamboni/validator.js:595
-msgid "Internal server error"
-msgstr ""
-
-#: static/js/zamboni/mobile/buttons.js:52
+#: static/js/zamboni/mobile-all.js:15186 static/js/zamboni/mobile/buttons.js:52
 msgid "Not Updated for {0} {1}"
 msgstr ""
 
-#: static/js/zamboni/mobile/buttons.js:53
+#: static/js/zamboni/mobile-all.js:15187 static/js/zamboni/mobile/buttons.js:53
 msgid "Requires Newer Version of {0}"
 msgstr ""
 
-#: static/js/zamboni/mobile/buttons.js:54
+#: static/js/zamboni/mobile-all.js:15188 static/js/zamboni/mobile/buttons.js:54
 msgid "Unreviewed"
 msgstr ""
 
-#: static/js/zamboni/mobile/buttons.js:55
+#: static/js/zamboni/mobile-all.js:15189 static/js/zamboni/mobile/buttons.js:55
 msgid "Experimental <span>(Learn More)</span>"
 msgstr ""
 
-#: static/js/zamboni/mobile/buttons.js:56 static/js/zamboni/mobile/buttons.js:57
+#: static/js/zamboni/mobile-all.js:15190 static/js/zamboni/mobile-all.js:15191 static/js/zamboni/mobile/buttons.js:56 static/js/zamboni/mobile/buttons.js:57
 msgid "Not Available for {0}"
 msgstr ""
 
-#: static/js/zamboni/mobile/buttons.js:58
+#: static/js/zamboni/mobile-all.js:15192 static/js/zamboni/mobile/buttons.js:58
 msgid "Experimental"
 msgstr ""
 
-#: static/js/zamboni/mobile/buttons.js:59
+#: static/js/zamboni/mobile-all.js:15193 static/js/zamboni/mobile/buttons.js:59
 msgid "Themes Require Newer Version of {0}"
 msgstr ""
 
-#: static/js/zamboni/mobile/buttons.js:60
+#: static/js/zamboni/mobile-all.js:15194 static/js/zamboni/mobile/buttons.js:60
 msgid "Themes Require {0}"
 msgstr ""
 
-#: static/js/zamboni/mobile/buttons.js:105
+#: static/js/zamboni/mobile-all.js:15239 static/js/zamboni/mobile/buttons.js:105
 msgid "Installing..."
 msgstr ""
 
-#: static/js/zamboni/mobile/buttons.js:125
+#: static/js/zamboni/mobile-all.js:15259 static/js/zamboni/mobile/buttons.js:125
 msgid "This add-on has been preliminarily reviewed by Mozilla."
 msgstr ""
 
-#: static/js/zamboni/mobile/buttons.js:250
+#: static/js/zamboni/mobile-all.js:15384 static/js/zamboni/mobile/buttons.js:250
 msgid "Keep it"
 msgstr ""
 
-#: static/js/zamboni/mobile/general.js:344
+#: static/js/zamboni/mobile-all.js:16049 static/js/zamboni/mobile-min.js:6 static/js/zamboni/mobile/general.js:344
 msgid "You're trying it on!"
 msgstr ""
 
-#: static/js/zamboni/mobile/general.js:356
+#: static/js/zamboni/mobile-all.js:16061 static/js/zamboni/mobile-min.js:6 static/js/zamboni/mobile/general.js:356
 msgid "Added to Firefox"
 msgstr ""
-

--- a/locale/ko/LC_MESSAGES/django.po
+++ b/locale/ko/LC_MESSAGES/django.po
@@ -4,82 +4,72 @@
 # Made by Seong-wook Gong, 2009.
 msgid ""
 msgstr ""
-"Project-Id-Version: addons-ko\n"
+"Project-Id-Version:  addons-ko\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2016-02-24 21:23+0000\n"
+"POT-Creation-Date: 2016-04-18 15:40+0000\n"
 "PO-Revision-Date: 2016-03-20 23:04+0000\n"
 "Last-Translator: Hyeonseok Shin <hyeonseok@gmail.com>\n"
 "Language-Team: none\n"
-"Language: ko\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=1; plural=0;\n"
 "Generated-By: Babel 2.2.0\n"
-"X-Generator: Pontoon\n"
 
-#: src/olympia/accounts/views.py:52
+#: src/olympia/accounts/views.py:54
 msgid "Your log in attempt could not be parsed. Please try again."
 msgstr ""
 
-#: src/olympia/accounts/views.py:54
+#: src/olympia/accounts/views.py:56
 msgid "Your Firefox Account could not be found. Please try again."
 msgstr ""
 
-#: src/olympia/accounts/views.py:55
+#: src/olympia/accounts/views.py:57
 msgid "You could not be logged in. Please try again."
 msgstr ""
 
-#: src/olympia/accounts/views.py:57
+#: src/olympia/accounts/views.py:59
 msgid "Your account has already been migrated to Firefox Accounts."
 msgstr ""
 
-#: src/olympia/accounts/views.py:59
+#: src/olympia/accounts/views.py:61
 msgid "Your Firefox Account already exists on this site."
 msgstr ""
 
-#: src/olympia/accounts/views.py:108
+#: src/olympia/accounts/views.py:110
 msgid "Great job!"
 msgstr ""
 
-#: src/olympia/accounts/views.py:109
+#: src/olympia/accounts/views.py:111
 msgid "You can now log in to Add-ons with your Firefox Account."
 msgstr ""
 
-#: src/olympia/accounts/views.py:121
+#: src/olympia/accounts/views.py:123
 msgid "Need help?"
 msgstr "도움이 필요하십니까?"
 
-#: src/olympia/addons/buttons.py:180
+#: src/olympia/addons/buttons.py:177
 msgid "Download Now"
 msgstr "다운로드"
 
-#: src/olympia/addons/buttons.py:182
+#: src/olympia/addons/buttons.py:179
 msgid "Download"
 msgstr "다운로드"
 
 #. L10n: please keep &nbsp; in the string so &rarr; does not wrap.
-#: src/olympia/addons/buttons.py:186
+#: src/olympia/addons/buttons.py:183
 msgid "Continue to Download&nbsp;&rarr;"
 msgstr "다운로드&nbsp;&rarr;"
 
-#: src/olympia/addons/buttons.py:202 src/olympia/addons/helpers.py:35
-#: src/olympia/addons/views.py:319
-#: src/olympia/addons/templates/addons/impala/details.html:114
-#: src/olympia/addons/templates/addons/impala/listing/items.html:17
-#: src/olympia/addons/templates/addons/mobile/home.html:40
-#: src/olympia/amo/templates/amo/side_nav.html:6
-#: src/olympia/amo/templates/amo/side_nav.html:10
-#: src/olympia/amo/templates/amo/site_nav.html:2
-#: src/olympia/amo/templates/amo/site_nav.html:55
-#: src/olympia/bandwagon/views.py:95 src/olympia/browse/views.py:54
-#: src/olympia/browse/views.py:68 src/olympia/browse/views.py:235
-#: src/olympia/browse/templates/browse/impala/category_landing.html:22
+#: src/olympia/addons/buttons.py:199 src/olympia/addons/helpers.py:35 src/olympia/addons/views.py:333 src/olympia/addons/templates/addons/impala/details.html:111
+#: src/olympia/addons/templates/addons/impala/listing/items.html:17 src/olympia/addons/templates/addons/mobile/home.html:40 src/olympia/amo/templates/amo/side_nav.html:6
+#: src/olympia/amo/templates/amo/side_nav.html:10 src/olympia/amo/templates/amo/site_nav.html:2 src/olympia/amo/templates/amo/site_nav.html:53 src/olympia/bandwagon/views.py:95
+#: src/olympia/browse/views.py:54 src/olympia/browse/views.py:68 src/olympia/browse/views.py:202 src/olympia/browse/templates/browse/impala/category_landing.html:22
 #: src/olympia/browse/templates/browse/personas/mobile/category_landing.html:26
 msgid "Featured"
 msgstr "추천"
 
-#: src/olympia/addons/buttons.py:221
+#: src/olympia/addons/buttons.py:218
 msgid "Add to {0}"
 msgstr "{0}에 추가"
 
@@ -101,67 +91,65 @@ msgstr "이 주화는 \"%s\"이(가) 될 수 없습니다. 다른걸 사용해 �
 msgid "Invalid tag: {0}"
 msgid_plural "Invalid tags: {0}"
 msgstr[0] "유효하지 않은 태그: {0}"
+msgstr[1] ""
 
 #. L10n: {0} is a single tag or a comma-separated list of tags.
 #: src/olympia/addons/forms.py:103
 msgid "\"{0}\" is a reserved tag and cannot be used."
 msgid_plural "\"{0}\" are reserved tags and cannot be used."
 msgstr[0] "\"{0}\"은(는) 금지 태그로 사용하실 수 없습니다."
+msgstr[1] ""
 
 #: src/olympia/addons/forms.py:111
 msgid "You have {0} too many tags."
 msgid_plural "You have {0} too many tags."
 msgstr[0] "{0}에 태그가 너무 많습니다."
+msgstr[1] ""
 
 #: src/olympia/addons/forms.py:117
 #, python-format
-msgid ""
-"All tags must be %s characters or less after invalid characters are removed."
+msgid "All tags must be %s characters or less after invalid characters are removed."
 msgstr "모든 태그는 유효하지 않은 글자 제거 후 %s자 이하여야 합니다."
 
 #: src/olympia/addons/forms.py:121
 msgid "All tags must be at least {0} character."
 msgid_plural "All tags must be at least {0} characters."
 msgstr[0] "태그는 최소한 {0} 글자 이상이어야 합니다."
+msgstr[1] ""
 
-#: src/olympia/addons/forms.py:234
-msgid ""
-"Categories cannot be changed while your add-on is featured for this "
-"application."
+#: src/olympia/addons/forms.py:238
+msgid "Categories cannot be changed while your add-on is featured for this application."
 msgstr "이 애플리케이션의 추천 부가 기능으로 선정되어 있는 동안은 분류를 변경할 수 없습니다."
 
 #. L10n: {0} is the number of categories.
-#: src/olympia/addons/forms.py:238
+#: src/olympia/addons/forms.py:242
 msgid "You can have only {0} category."
 msgid_plural "You can have only {0} categories."
 msgstr[0] "{0}개의 분류만 사용할 수 있습니다."
+msgstr[1] ""
 
-#: src/olympia/addons/forms.py:246
-msgid ""
-"The miscellaneous category cannot be combined with additional categories."
+#: src/olympia/addons/forms.py:250
+msgid "The miscellaneous category cannot be combined with additional categories."
 msgstr "기타 카테고리는 다른 카테고리와 결합할 수 없습니다."
 
-#: src/olympia/addons/forms.py:369
+#: src/olympia/addons/forms.py:374
 #, python-format
-msgid ""
-"Before changing your default locale you must have a name, summary, and "
-"description in that locale. You are missing %s."
+msgid "Before changing your default locale you must have a name, summary, and description in that locale. You are missing %s."
 msgstr "기본 언어를 변경하려면 먼저 이름, 요약 정보, 설명을 해당 언어로 작성해야 합니다. %s 정보가 현재 빠져 있습니다."
 
-#: src/olympia/addons/forms.py:484 src/olympia/addons/forms.py:575
+#: src/olympia/addons/forms.py:455 src/olympia/addons/forms.py:546
 msgid "A license must be selected."
 msgstr "라이선스를 선택해야 합니다."
 
-#: src/olympia/addons/forms.py:556
+#: src/olympia/addons/forms.py:527
 msgid "Give Your Theme a Name."
 msgstr "테마 이름을 입력하세요."
 
-#: src/olympia/addons/forms.py:562
-#: src/olympia/devhub/templates/devhub/personas/submit.html:53
+#: src/olympia/addons/forms.py:533 src/olympia/devhub/templates/devhub/personas/submit.html:53
 msgid "Describe your Theme."
 msgstr "테마에 대해 설명해 주세요."
 
-#: src/olympia/addons/forms.py:704
+#: src/olympia/addons/forms.py:675
 msgid "Enter a new author's email address"
 msgstr "새 제작자의 이메일 주소를 입력하세요"
 
@@ -169,46 +157,39 @@ msgstr "새 제작자의 이메일 주소를 입력하세요"
 msgid "Not Reviewed"
 msgstr "미심사"
 
-#: src/olympia/addons/models.py:301
+#: src/olympia/addons/models.py:298
 msgid "Users have the option of contributing more or less than this amount."
 msgstr "사용자는 이 금액보다 많거나 적게 기부할 수 있는 선택권을 가지고 있습니다."
 
-#: src/olympia/addons/models.py:309
-msgid ""
-"Users will always be asked in the Add-ons Manager (Firefox 4 and above)"
-msgstr "사용자는 항상 부가 기능 관리자의 권유를 받게 됩니다 (Firefox 4 이상)"
+#: src/olympia/addons/models.py:306
+msgid "Users will always be asked in the Add-ons Manager (Firefox 4 and above). Only applies to desktop."
+msgstr ""
 
 # Column name in a table.
-#: src/olympia/addons/models.py:1804
-#: src/olympia/addons/templates/addons/details_box.html:55
-#: src/olympia/devhub/templates/devhub/index.html:92
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:102
+#: src/olympia/addons/models.py:1802 src/olympia/addons/templates/addons/details_box.html:55 src/olympia/devhub/templates/devhub/index.html:92
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:89
 msgid "Listed"
 msgstr "나열됨"
 
-#: src/olympia/addons/views.py:320
-#: src/olympia/browse/templates/browse/personas/mobile/category_landing.html:27
+#: src/olympia/addons/views.py:334 src/olympia/browse/templates/browse/personas/mobile/category_landing.html:27
 msgid "Popular"
 msgstr "인기"
 
-#: src/olympia/addons/views.py:321 src/olympia/browse/views.py:238
-#: src/olympia/browse/views.py:280 src/olympia/browse/views.py:482
+#: src/olympia/addons/views.py:335 src/olympia/browse/views.py:205 src/olympia/browse/views.py:247 src/olympia/browse/views.py:449
 msgid "Recently Added"
 msgstr "신규 등록"
 
-#: src/olympia/addons/views.py:322 src/olympia/bandwagon/views.py:99
-#: src/olympia/browse/views.py:60 src/olympia/browse/views.py:71
-#: src/olympia/search/forms.py:16 src/olympia/search/forms.py:91
+#: src/olympia/addons/views.py:336 src/olympia/bandwagon/views.py:99 src/olympia/browse/views.py:60 src/olympia/browse/views.py:71 src/olympia/search/forms.py:16 src/olympia/search/forms.py:91
 msgid "Recently Updated"
 msgstr "최근 업데이트"
 
-#. l10n: {0} is the addon name
 # %1 is an add-on name.
-#: src/olympia/addons/views.py:520
+#. l10n: {0} is the addon name
+#: src/olympia/addons/views.py:534
 msgid "Contribution for {0}"
 msgstr "{0}에 기부하기"
 
-#: src/olympia/addons/views.py:613
+#: src/olympia/addons/views.py:627
 msgid "Abuse reported."
 msgstr "정책 위반을 신고했습니다."
 
@@ -216,110 +197,70 @@ msgstr "정책 위반을 신고했습니다."
 msgid "My add-on doesn't fit into any of the categories"
 msgstr "어떤 분류에도 이 부가 기능과 부합하지 않습니다"
 
-#: src/olympia/addons/templates/addons/button.html:27
-#: src/olympia/addons/templates/addons/impala/button.html:11
-#: src/olympia/addons/templates/addons/mobile/button.html:11
+#: src/olympia/addons/templates/addons/button.html:27 src/olympia/addons/templates/addons/impala/button.html:11 src/olympia/addons/templates/addons/mobile/button.html:11
 msgid "No compatible versions"
 msgstr "호환 가능한 버전이 없음"
 
-#: src/olympia/addons/templates/addons/button.html:35
-#: src/olympia/addons/templates/addons/impala/button.html:19
+#: src/olympia/addons/templates/addons/button.html:35 src/olympia/addons/templates/addons/impala/button.html:19
 msgid "Added to Mobile"
 msgstr "모바일에 추가"
 
-#: src/olympia/addons/templates/addons/button.html:37
-#: src/olympia/addons/templates/addons/impala/button.html:21
+#: src/olympia/addons/templates/addons/button.html:37 src/olympia/addons/templates/addons/impala/button.html:21
 msgid "Add to Mobile"
 msgstr "모바일에 추가"
 
 #. {0} is a platform name like Windows or Mac OS X.
-#: src/olympia/addons/templates/addons/button.html:66
-#: src/olympia/addons/templates/addons/includes/install_button.html:19
+#: src/olympia/addons/templates/addons/button.html:66 src/olympia/addons/templates/addons/includes/install_button.html:19
 msgid "for {0}"
 msgstr "{0}용"
 
-#: src/olympia/addons/templates/addons/button.html:82
-#: src/olympia/addons/templates/addons/mobile/button.html:23
+#: src/olympia/addons/templates/addons/button.html:82 src/olympia/addons/templates/addons/mobile/button.html:23
 msgid "View privacy policy"
 msgstr "개인 정보 보호 정책 보기"
 
-#: src/olympia/addons/templates/addons/button.html:87
-#: src/olympia/addons/templates/addons/details_box.html:133
-#: src/olympia/addons/templates/addons/mobile/button.html:28
+#: src/olympia/addons/templates/addons/button.html:87 src/olympia/addons/templates/addons/details_box.html:133 src/olympia/addons/templates/addons/mobile/button.html:28
 #: src/olympia/discovery/templates/discovery/addons/detail.html:28
 msgid "View End-User License Agreement"
 msgstr "일반 사용자 계약서 보기"
 
-#: src/olympia/addons/templates/addons/button.html:92
-#: src/olympia/addons/templates/addons/impala/button.html:54
+#: src/olympia/addons/templates/addons/button.html:92 src/olympia/addons/templates/addons/impala/button.html:54
 #, python-format
-msgid ""
-"This add-on has not been reviewed by Mozilla. <a href=\"%(url)s\">Learn "
-"more</a>"
+msgid "This add-on has not been reviewed by Mozilla. <a href=\"%(url)s\">Learn more</a>"
 msgstr "이 부가 기능은 Mozilla의 심사를 받지 않았습니다. <a href=\"%(url)s\">자세히 알아보기</a>"
 
-#: src/olympia/addons/templates/addons/button.html:97
-#: src/olympia/addons/templates/addons/impala/button.html:60
+#: src/olympia/addons/templates/addons/button.html:97 src/olympia/addons/templates/addons/impala/button.html:60
 #, python-format
-msgid ""
-"This add-on has been preliminarily reviewed by Mozilla. <a "
-"href=\"%(url)s\">Learn more</a>"
+msgid "This add-on has been preliminarily reviewed by Mozilla. <a href=\"%(url)s\">Learn more</a>"
 msgstr "이 부가 기능은 Mozilla의 예비 심사를 통과했습니다. <a href=\"%(url)s\">자세히 알아보기</a>"
 
-#: src/olympia/addons/templates/addons/contribution.html:11
-#: src/olympia/addons/templates/addons/impala/developers.html:44
-msgid ""
-"The developer of this add-on asks that you help support its continued "
-"development by making a small contribution."
+#: src/olympia/addons/templates/addons/contribution.html:11 src/olympia/addons/templates/addons/impala/developers.html:44
+msgid "The developer of this add-on asks that you help support its continued development by making a small contribution."
 msgstr "이 부가 기능의 개발자는 개발을 계속하기 위해 소액 기부를 통한 도움을 청하고 있습니다."
 
 #: src/olympia/addons/templates/addons/contribution.html:14
 #, python-format
-msgid ""
-"The developer of this add-on asks that you show your support by making a "
-"donation to the <a href=\"%(charity_url)s\">%(charity_name)s</a>."
-msgstr ""
-"부가 기능 개발자가 <a href=\"%(charity_url)s\">%(charity_name)s</a> 기부를 통한 지원을 요청하고 "
-"있습니다."
+msgid "The developer of this add-on asks that you show your support by making a donation to the <a href=\"%(charity_url)s\">%(charity_name)s</a>."
+msgstr "부가 기능 개발자가 <a href=\"%(charity_url)s\">%(charity_name)s</a> 기부를 통한 지원을 요청하고 있습니다."
 
 #: src/olympia/addons/templates/addons/contribution.html:19
 #, python-format
-msgid ""
-"The developer of this add-on asks that you show your support by making a "
-"small contribution to <a href=\"%(charity_url)s\">%(charity_name)s</a>."
-msgstr ""
-"부가 기능 개발자가 <a href=\"%(charity_url)s\">%(charity_name)s</a>에 소정의 기부를 통한 지원을 "
-"요청하고 있습니다."
+msgid "The developer of this add-on asks that you show your support by making a small contribution to <a href=\"%(charity_url)s\">%(charity_name)s</a>."
+msgstr "부가 기능 개발자가 <a href=\"%(charity_url)s\">%(charity_name)s</a>에 소정의 기부를 통한 지원을 요청하고 있습니다."
 
-#: src/olympia/addons/templates/addons/contribution.html:30
-#: src/olympia/addons/templates/addons/impala/contribution.html:18
-#: src/olympia/templates/menu_links.html:25
+#: src/olympia/addons/templates/addons/contribution.html:30 src/olympia/addons/templates/addons/impala/contribution.html:18 src/olympia/templates/menu_links.html:25
 msgid "Contribute"
 msgstr "기부하기"
 
-#. Click Contribute button OR Install button
 # This is a separator between the graphical [contribute] button and the
 # graphical [download now] button
-#: src/olympia/addons/templates/addons/contribution.html:34
-#: src/olympia/addons/templates/addons/report_abuse.html:26
-#: src/olympia/addons/templates/addons/impala/contribution.html:32
-#: src/olympia/devhub/templates/devhub/addons/ajax_compat_update.html:36
-#: src/olympia/devhub/templates/devhub/addons/profile.html:44
-#: src/olympia/devhub/templates/devhub/addons/edit/admin.html:101
-#: src/olympia/devhub/templates/devhub/addons/edit/basic.html:152
-#: src/olympia/devhub/templates/devhub/addons/edit/details.html:85
-#: src/olympia/devhub/templates/devhub/addons/edit/support.html:67
-#: src/olympia/devhub/templates/devhub/addons/edit/technical.html:166
-#: src/olympia/devhub/templates/devhub/addons/forms_shared/media.html:149
-#: src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:44
-#: src/olympia/devhub/templates/devhub/versions/add_file_modal.html:78
-#: src/olympia/devhub/templates/devhub/versions/edit.html:139
-#: src/olympia/devhub/templates/devhub/versions/list.html:242
-#: src/olympia/devhub/templates/devhub/versions/list.html:276
-#: src/olympia/devhub/templates/devhub/versions/list.html:317
-#: src/olympia/devhub/templates/devhub/versions/list.html:351
-#: src/olympia/reviews/templates/reviews/edit_review.html:16
-#: src/olympia/translations/templates/translations/trans-menu.html:50
+#. Click Contribute button OR Install button
+#: src/olympia/addons/templates/addons/contribution.html:34 src/olympia/addons/templates/addons/report_abuse.html:26 src/olympia/addons/templates/addons/impala/contribution.html:32
+#: src/olympia/devhub/templates/devhub/addons/ajax_compat_update.html:36 src/olympia/devhub/templates/devhub/addons/profile.html:44 src/olympia/devhub/templates/devhub/addons/edit/admin.html:101
+#: src/olympia/devhub/templates/devhub/addons/edit/basic.html:152 src/olympia/devhub/templates/devhub/addons/edit/details.html:85 src/olympia/devhub/templates/devhub/addons/edit/support.html:67
+#: src/olympia/devhub/templates/devhub/addons/edit/technical.html:166 src/olympia/devhub/templates/devhub/addons/forms_shared/media.html:149
+#: src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:43 src/olympia/devhub/templates/devhub/versions/add_file_modal.html:58 src/olympia/devhub/templates/devhub/versions/edit.html:139
+#: src/olympia/devhub/templates/devhub/versions/list.html:239 src/olympia/devhub/templates/devhub/versions/list.html:281 src/olympia/devhub/templates/devhub/versions/list.html:315
+#: src/olympia/devhub/templates/devhub/versions/list.html:349 src/olympia/reviews/templates/reviews/edit_review.html:16 src/olympia/translations/templates/translations/trans-menu.html:50
 #: src/olympia/translations/templates/translations/trans-menu.html:62
 msgid "or"
 msgstr "또는"
@@ -328,39 +269,23 @@ msgstr "또는"
 msgid "Suggested Contribution: {0}"
 msgstr "권장 기부금: {0}"
 
-#: src/olympia/addons/templates/addons/contribution.html:48
-#: src/olympia/amo/templates/amo/recaptcha.html:5
-#: src/olympia/versions/templates/versions/version.html:52
+#: src/olympia/addons/templates/addons/contribution.html:48 src/olympia/amo/templates/amo/recaptcha.html:5 src/olympia/versions/templates/versions/version.html:52
 msgid "What's this?"
 msgstr "이게 뭐죠?"
 
 #: src/olympia/addons/templates/addons/contribution.html:63
 #, python-format
-msgid ""
-"The developer of this add-on would like you to consider making a donation to"
-" the <a href=\"%(charity_url)s\">%(charity_name)s</a> if you enjoy using it."
-msgstr ""
-"부가 기능 개발자는 <a href=\"%(charity_url)s\">%(charity_name)s</a>을(를) 통한 기부를 호소하고 "
-"있습니다."
+msgid "The developer of this add-on would like you to consider making a donation to the <a href=\"%(charity_url)s\">%(charity_name)s</a> if you enjoy using it."
+msgstr "부가 기능 개발자는 <a href=\"%(charity_url)s\">%(charity_name)s</a>을(를) 통한 기부를 호소하고 있습니다."
 
 #: src/olympia/addons/templates/addons/contribution.html:69
 #, python-format
-msgid ""
-"The developer of this add-on would like you to consider making a small "
-"contribution to <a href=\"%(charity_url)s\">%(charity_name)s</a> if you "
-"enjoy using it."
-msgstr ""
-"부가 기능 개발자는 <a href=\"%(charity_url)s\">%(charity_name)s</a>을(를) 통한 소정의 기부를 "
-"호소하고 있습니다."
+msgid "The developer of this add-on would like you to consider making a small contribution to <a href=\"%(charity_url)s\">%(charity_name)s</a> if you enjoy using it."
+msgstr "부가 기능 개발자는 <a href=\"%(charity_url)s\">%(charity_name)s</a>을(를) 통한 소정의 기부를 호소하고 있습니다."
 
 #: src/olympia/addons/templates/addons/contribution.html:76
-msgid ""
-"Mozilla is committed to supporting a vibrant and healthy developer "
-"ecosystem. Your optional contribution helps sustain further development of "
-"this add-on."
-msgstr ""
-"Mozilla는 활기넘치고 건전한 개발자 생태계 지원에 전념하고 있습니다. 당신의 기부는 이 부가 기능의 개발과 유지, 보수를 돕게 "
-"됩니다."
+msgid "Mozilla is committed to supporting a vibrant and healthy developer ecosystem. Your optional contribution helps sustain further development of this add-on."
+msgstr "Mozilla는 활기넘치고 건전한 개발자 생태계 지원에 전념하고 있습니다. 당신의 기부는 이 부가 기능의 개발과 유지, 보수를 돕게 됩니다."
 
 #: src/olympia/addons/templates/addons/contributions_lightbox.html:5
 msgid "Make a Contribution"
@@ -368,33 +293,20 @@ msgstr "기부해 주세요"
 
 #: src/olympia/addons/templates/addons/contributions_lightbox.html:9
 #, python-format
-msgid ""
-"Help support the continued development of <strong>%(addon_name)s</strong> by"
-" making a small contribution through <a href=\"%(paypal_url)s\">PayPal</a>."
-msgstr ""
-"<a href=\"%(paypal_url)s\">PayPal</a>을 통한 소정의 기부로 "
-"<strong>%(addon_name)s</strong>이(가) 계속 개발될 수 있도록 도와주세요."
+msgid "Help support the continued development of <strong>%(addon_name)s</strong> by making a small contribution through <a href=\"%(paypal_url)s\">PayPal</a>."
+msgstr "<a href=\"%(paypal_url)s\">PayPal</a>을 통한 소정의 기부로 <strong>%(addon_name)s</strong>이(가) 계속 개발될 수 있도록 도와주세요."
 
 #: src/olympia/addons/templates/addons/contributions_lightbox.html:15
 #, python-format
-msgid ""
-"To show your support for <b>%(addon_name)s</b>, the developer asks that you "
-"make a donation to the <a href=\"%(charity_url)s\">%(charity_name)s</a> "
-"through <a href=\"%(paypal_url)s\">PayPal</a>."
-msgstr ""
-"<b>%(addon_name)s</b>의 개발 지원을 위해 개발자가 <a href=\"%(paypal_url)s\">PayPal</a>을"
-" 통해 <a href=\"%(charity_url)s\">%(charity_name)s</a>로의 기부를 요청하고 있습니다."
+msgid "To show your support for <b>%(addon_name)s</b>, the developer asks that you make a donation to the <a href=\"%(charity_url)s\">%(charity_name)s</a> through <a href=\"%(paypal_url)s\">PayPal</a>."
+msgstr "<b>%(addon_name)s</b>의 개발 지원을 위해 개발자가 <a href=\"%(paypal_url)s\">PayPal</a>을 통해 <a href=\"%(charity_url)s\">%(charity_name)s</a>로의 기부를 요청하고 있습니다."
 
 #: src/olympia/addons/templates/addons/contributions_lightbox.html:21
 #, python-format
 msgid ""
-"To show your support for <b>%(addon_name)s</b>, the developer asks that you "
-"make a small contribution to <a "
-"href=\"%(charity_url)s\">%(charity_name)s</a> through <a "
+"To show your support for <b>%(addon_name)s</b>, the developer asks that you make a small contribution to <a href=\"%(charity_url)s\">%(charity_name)s</a> through <a "
 "href=\"%(paypal_url)s\">PayPal</a>."
-msgstr ""
-"<b>%(addon_name)s</b>의 개발 지원을 위해 개발자가 <a href=\"%(paypal_url)s\">PayPal</a>을"
-" 통해 <a href=\"%(charity_url)s\">%(charity_name)s</a>로의 소정의 기부를 요청하고 있습니다."
+msgstr "<b>%(addon_name)s</b>의 개발 지원을 위해 개발자가 <a href=\"%(paypal_url)s\">PayPal</a>을 통해 <a href=\"%(charity_url)s\">%(charity_name)s</a>로의 소정의 기부를 요청하고 있습니다."
 
 #: src/olympia/addons/templates/addons/contributions_lightbox.html:30
 msgid "How much would you like to contribute?"
@@ -417,8 +329,7 @@ msgstr "기부액은 숫자만 입력해야 합니다."
 msgid "A one-time suggested contribution of {0}"
 msgstr "권장 1회 기부금: {0}"
 
-#. {0} is a currency symbol (e.g., $),                    {1} is an amount
-#. input
+#. {0} is a currency symbol (e.g., $),                    {1} is an amount input
 #. field
 #: src/olympia/addons/templates/addons/contributions_lightbox.html:64
 msgid "A one-time contribution of {0} {1}"
@@ -428,11 +339,8 @@ msgstr "1회 기부금: {0} {1}"
 msgid "Leave a comment or request with your contribution."
 msgstr "기부에 코멘트나 요구 사항을 남겨주세요."
 
-#: src/olympia/addons/templates/addons/contributions_lightbox.html:74
-#: src/olympia/bandwagon/templates/bandwagon/ajax_new.html:20
-#: src/olympia/bandwagon/templates/bandwagon/includes/addedit.html:37
-#: src/olympia/reviews/templates/reviews/mobile/add_form.html:13
-#: src/olympia/templates/includes/forms.html:10
+#: src/olympia/addons/templates/addons/contributions_lightbox.html:74 src/olympia/bandwagon/templates/bandwagon/ajax_new.html:20 src/olympia/bandwagon/templates/bandwagon/includes/addedit.html:37
+#: src/olympia/reviews/templates/reviews/mobile/add_form.html:13 src/olympia/templates/includes/forms.html:10
 msgid "(optional)"
 msgstr "(선택사항)"
 
@@ -452,36 +360,27 @@ msgstr "사양하겠습니다"
 msgid "Contribution made, thank you."
 msgstr "기부가 되었습니다. 감사합니다."
 
-#: src/olympia/addons/templates/addons/details_box.html:10
-#: src/olympia/discovery/templates/discovery/addons/detail.html:19
+#: src/olympia/addons/templates/addons/details_box.html:10 src/olympia/discovery/templates/discovery/addons/detail.html:19
 msgid "No restart required"
 msgstr "재시작 필요 없음"
 
 #. This is a caption for a table. {0} is an add-on name.
-#: src/olympia/addons/templates/addons/details_box.html:26
-#: src/olympia/addons/templates/addons/includes/persona.html:9
+#: src/olympia/addons/templates/addons/details_box.html:26 src/olympia/addons/templates/addons/includes/persona.html:9
 msgid "Add-on Information for {0}"
 msgstr "{0}의 부가 기능 정보"
 
-#: src/olympia/addons/templates/addons/details_box.html:30
-#: src/olympia/addons/templates/addons/persona_detail_table.html:3
-#: src/olympia/addons/templates/addons/mobile/details.html:63
-#: src/olympia/addons/templates/addons/mobile/persona_detail_table.html:7
-#: src/olympia/browse/views.py:459 src/olympia/devhub/views.py:75
+#: src/olympia/addons/templates/addons/details_box.html:30 src/olympia/addons/templates/addons/persona_detail_table.html:3 src/olympia/addons/templates/addons/mobile/details.html:63
+#: src/olympia/addons/templates/addons/mobile/persona_detail_table.html:7 src/olympia/browse/views.py:426 src/olympia/devhub/views.py:74
 msgid "Updated"
 msgstr "최근 업데이트"
 
-#: src/olympia/addons/templates/addons/details_box.html:38
-#: src/olympia/addons/templates/addons/mobile/details.html:71
-#: src/olympia/devhub/templates/devhub/addons/edit/support.html:43
+#: src/olympia/addons/templates/addons/details_box.html:38 src/olympia/addons/templates/addons/mobile/details.html:71 src/olympia/devhub/templates/devhub/addons/edit/support.html:43
 #: src/olympia/discovery/templates/discovery/addons/detail.html:77
 msgid "Website"
 msgstr "웹사이트"
 
 #. This refers to this version's compatible applications, such as Firefox 8.0
-#: src/olympia/addons/templates/addons/details_box.html:47
-#: src/olympia/addons/templates/addons/mobile/details.html:80
-#: src/olympia/search/templates/search/results.html:72
+#: src/olympia/addons/templates/addons/details_box.html:47 src/olympia/addons/templates/addons/mobile/details.html:80 src/olympia/search/templates/search/results.html:72
 #: src/olympia/versions/templates/versions/version.html:21
 msgid "Works with"
 msgstr "작동 버전"
@@ -490,45 +389,30 @@ msgstr "작동 버전"
 msgid "Visibility"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/details_box.html:57
-#: src/olympia/devhub/templates/devhub/index.html:94
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:104
+#: src/olympia/addons/templates/addons/details_box.html:57 src/olympia/devhub/templates/devhub/index.html:94 src/olympia/devhub/templates/devhub/includes/addon_details.html:91
 msgid "Hidden"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/details_box.html:59
-#: src/olympia/devhub/templates/devhub/index.html:96
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:106
+#: src/olympia/addons/templates/addons/details_box.html:59 src/olympia/devhub/templates/devhub/index.html:96 src/olympia/devhub/templates/devhub/includes/addon_details.html:93
 msgid "Unlisted"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/details_box.html:67
-#: src/olympia/devhub/templates/devhub/addons/edit/technical.html:44
+#: src/olympia/addons/templates/addons/details_box.html:67 src/olympia/devhub/templates/devhub/addons/edit/technical.html:44
 msgid "Required Add-ons"
 msgstr "설치되어 있어야 하는 부가 기능"
 
-#: src/olympia/addons/templates/addons/details_box.html:81
-#: src/olympia/addons/templates/addons/persona_detail_table.html:15
-#: src/olympia/browse/views.py:462 src/olympia/devhub/views.py:78
-#: src/olympia/devhub/views.py:85
-#: src/olympia/discovery/templates/discovery/addons/detail.html:57
-#: src/olympia/reviews/forms.py:62
-#: src/olympia/reviews/templates/reviews/add.html:57
+#: src/olympia/addons/templates/addons/details_box.html:81 src/olympia/addons/templates/addons/persona_detail_table.html:15 src/olympia/browse/views.py:429 src/olympia/devhub/views.py:77
+#: src/olympia/devhub/views.py:84 src/olympia/discovery/templates/discovery/addons/detail.html:57 src/olympia/reviews/forms.py:62 src/olympia/reviews/templates/reviews/add.html:57
 #: src/olympia/reviews/templates/reviews/mobile/review_list.html:18
 msgid "Rating"
 msgstr "별점"
 
-#: src/olympia/addons/templates/addons/details_box.html:85
-#: src/olympia/browse/views.py:461 src/olympia/devhub/views.py:77
-#: src/olympia/devhub/views.py:84
-#: src/olympia/stats/templates/stats/addon_report_menu.html:8
-#: src/olympia/stats/templates/stats/collection_report_menu.html:18
+#: src/olympia/addons/templates/addons/details_box.html:85 src/olympia/browse/views.py:428 src/olympia/devhub/views.py:76 src/olympia/devhub/views.py:83
+#: src/olympia/stats/templates/stats/addon_report_menu.html:8 src/olympia/stats/templates/stats/collection_report_menu.html:18
 msgid "Downloads"
 msgstr "다운로드 횟수"
 
-#: src/olympia/addons/templates/addons/details_box.html:91
-#: src/olympia/addons/templates/addons/details_box.html:103
-#: src/olympia/devhub/templates/devhub/addons/listing/item_actions_theme.html:17
+#: src/olympia/addons/templates/addons/details_box.html:91 src/olympia/addons/templates/addons/details_box.html:103 src/olympia/devhub/templates/devhub/addons/listing/item_actions_theme.html:17
 #: src/olympia/devhub/templates/devhub/personas/edit.html:60
 msgid "View Statistics"
 msgstr "통계 보기"
@@ -542,18 +426,13 @@ msgid "Abuse Reports"
 msgstr "정책 위반 신고"
 
 #. The Privacy Policy for this add-on.
-#: src/olympia/addons/templates/addons/details_box.html:121
-#: src/olympia/addons/templates/addons/privacy.html:19
-#: src/olympia/addons/templates/addons/privacy.html:23
-#: src/olympia/addons/templates/addons/impala/button.html:43
-#: src/olympia/addons/templates/addons/impala/details.html:307
-#: src/olympia/devhub/templates/devhub/includes/policy_form.html:20
+#: src/olympia/addons/templates/addons/details_box.html:121 src/olympia/addons/templates/addons/privacy.html:19 src/olympia/addons/templates/addons/privacy.html:23
+#: src/olympia/addons/templates/addons/impala/button.html:43 src/olympia/addons/templates/addons/impala/details.html:312 src/olympia/devhub/templates/devhub/includes/policy_form.html:23
 #: src/olympia/templates/mobile/base_addons.html:87
 msgid "Privacy Policy"
 msgstr "개인 정보 보호 정책"
 
-#: src/olympia/addons/templates/addons/details_box.html:124
-#: src/olympia/discovery/templates/discovery/addons/detail.html:24
+#: src/olympia/addons/templates/addons/details_box.html:124 src/olympia/discovery/templates/discovery/addons/detail.html:24
 msgid "View Privacy Policy"
 msgstr "개인 정보 보호 정책 보기"
 
@@ -561,8 +440,7 @@ msgstr "개인 정보 보호 정책 보기"
 msgid "EULA"
 msgstr "EULA"
 
-#: src/olympia/addons/templates/addons/details_box.html:171
-#: src/olympia/addons/templates/addons/details_box.html:231
+#: src/olympia/addons/templates/addons/details_box.html:171 src/olympia/addons/templates/addons/details_box.html:231
 msgid "More about this add-on"
 msgstr "상세 정보"
 
@@ -570,25 +448,19 @@ msgstr "상세 정보"
 msgid "Image Gallery"
 msgstr "이미지 갤러리"
 
-#: src/olympia/addons/templates/addons/details_box.html:190
-#: src/olympia/devhub/templates/devhub/addons/edit/technical.html:21
+#: src/olympia/addons/templates/addons/details_box.html:190 src/olympia/devhub/templates/devhub/addons/edit/technical.html:21
 msgid "Developer Comments"
 msgstr "개발자 코멘트"
 
-#: src/olympia/addons/templates/addons/details_box.html:199
-#: src/olympia/addons/templates/addons/impala/details.html:259
+#: src/olympia/addons/templates/addons/details_box.html:199 src/olympia/addons/templates/addons/impala/details.html:264
 msgid "Development Channel"
 msgstr "개발 채널"
 
-#: src/olympia/addons/templates/addons/details_box.html:202
-#: src/olympia/addons/templates/addons/mobile/details.html:124
+#: src/olympia/addons/templates/addons/details_box.html:202 src/olympia/addons/templates/addons/mobile/details.html:124
 msgid ""
-"The Development Channel lets you test an experimental new version of this "
-"add-on before it's released to the general public. Once you install the "
-"development version, you will continue to get updates from this channel."
-msgstr ""
-"개발 채널은 이 부가 기능이 공개되기 이전의 새 시험용 버전을 테스트해주는 곳입니다. 개발자 버전을 설치하면 이 채널을 통해 업데이트를 "
-"지속적으로 받아볼 수 있습니다."
+"The Development Channel lets you test an experimental new version of this add-on before it's released to the general public. Once you install the development version, you will continue to get "
+"updates from this channel."
+msgstr "개발 채널은 이 부가 기능이 공개되기 이전의 새 시험용 버전을 테스트해주는 곳입니다. 개발자 버전을 설치하면 이 채널을 통해 업데이트를 지속적으로 받아볼 수 있습니다."
 
 #: src/olympia/addons/templates/addons/details_box.html:207
 msgid "Install development version"
@@ -596,18 +468,11 @@ msgstr "개발자 버전 설치"
 
 #: src/olympia/addons/templates/addons/details_box.html:211
 msgid ""
-"<strong>Caution:</strong> Development versions of this add-on have not been "
-"reviewed by Mozilla. Once you install a development version you will "
-"continue to receive development updates from this developer. To stop "
-"receiving development updates, reinstall the default version from the link "
-"above."
-msgstr ""
-"<strong>주의:</strong> 이 부가 기능의 개발자 버전은 Mozilla의 심사를 거치지 않은 것입니다. 개발자 버전을 설치하면"
-" 해당 개발자를 통해 개발자용 업데이트를 계속 받을 수 있습니다. 개발자용 업데이트를 그만 받으려면 위의 링크를 통해 기본 버전으로 "
-"재설치 하시면 됩니다."
+"<strong>Caution:</strong> Development versions of this add-on have not been reviewed by Mozilla. Once you install a development version you will continue to receive development updates from this "
+"developer. To stop receiving development updates, reinstall the default version from the link above."
+msgstr "<strong>주의:</strong> 이 부가 기능의 개발자 버전은 Mozilla의 심사를 거치지 않은 것입니다. 개발자 버전을 설치하면 해당 개발자를 통해 개발자용 업데이트를 계속 받을 수 있습니다. 개발자용 업데이트를 그만 받으려면 위의 링크를 통해 기본 버전으로 재설치 하시면 됩니다."
 
-#: src/olympia/addons/templates/addons/details_box.html:220
-#: src/olympia/addons/templates/addons/impala/details.html:278
+#: src/olympia/addons/templates/addons/details_box.html:220 src/olympia/addons/templates/addons/impala/details.html:283
 msgid "Version {0}:"
 msgstr "버전 {0}:"
 
@@ -615,53 +480,38 @@ msgstr "버전 {0}:"
 msgid "Nothing to see here! The developer did not include any details."
 msgstr "내용이 아무것도 없습니다! 이 개발자는 세부 정보를 전혀 올려놓지 않았습니다."
 
-#: src/olympia/addons/templates/addons/details_box.html:251
-#: src/olympia/devhub/templates/devhub/versions/edit.html:73
-#: src/olympia/editors/templates/editors/review.html:98
+#: src/olympia/addons/templates/addons/details_box.html:251 src/olympia/devhub/templates/devhub/versions/edit.html:73 src/olympia/editors/templates/editors/review.html:98
 msgid "Version Notes"
 msgstr "버전 기록"
 
 #. {0} is the name of the add-on.
 #. {0} is the name of the add-on
-#: src/olympia/addons/templates/addons/eula.html:6
-#: src/olympia/discovery/templates/discovery/addons/eula.html:5
+#: src/olympia/addons/templates/addons/eula.html:6 src/olympia/discovery/templates/discovery/addons/eula.html:5
 msgid "End-User License Agreement for {0}"
 msgstr "{0}의 최종 사용자 라이선스 동의서"
 
-#: src/olympia/addons/templates/addons/eula.html:17
-#: src/olympia/addons/templates/addons/eula.html:21
-#: src/olympia/addons/templates/addons/impala/button.html:48
-#: src/olympia/addons/templates/addons/impala/details.html:316
-#: src/olympia/devhub/templates/devhub/includes/policy_form.html:3
-#: src/olympia/discovery/templates/discovery/addons/eula.html:11
+#: src/olympia/addons/templates/addons/eula.html:17 src/olympia/addons/templates/addons/eula.html:21 src/olympia/addons/templates/addons/impala/button.html:48
+#: src/olympia/addons/templates/addons/impala/details.html:321 src/olympia/devhub/templates/devhub/includes/policy_form.html:3 src/olympia/discovery/templates/discovery/addons/eula.html:11
 msgid "End-User License Agreement"
 msgstr "최종 사용자 라이선스 동의서"
 
-#: src/olympia/addons/templates/addons/eula.html:23
-#: src/olympia/discovery/templates/discovery/addons/eula.html:13
+#: src/olympia/addons/templates/addons/eula.html:23 src/olympia/discovery/templates/discovery/addons/eula.html:13
 #, python-format
-msgid ""
-"%(addon_name)s requires that you accept the following End-User License "
-"Agreement before installation can proceed:"
+msgid "%(addon_name)s requires that you accept the following End-User License Agreement before installation can proceed:"
 msgstr "%(addon_name)s의 설치를 진행하기 위해선 아래의 최종 사용자 라이선스에 동의하셔야 합니다:"
 
-#: src/olympia/addons/templates/addons/eula.html:34
-#: src/olympia/addons/templates/addons/privacy.html:26
+#: src/olympia/addons/templates/addons/eula.html:34 src/olympia/addons/templates/addons/privacy.html:26
 msgid "Back to {0}…"
 msgstr "{0}(으)로 돌아가기..."
 
 # {0} is the application the user is browsing.  Examples:  Thunderbird,
 # Firefox,
 # Sunbird
-#: src/olympia/addons/templates/addons/home.html:3
-#: src/olympia/addons/templates/addons/mobile/home.html:3
-#: src/olympia/amo/helpers.py:235
+#: src/olympia/addons/templates/addons/home.html:3 src/olympia/addons/templates/addons/mobile/home.html:3 src/olympia/amo/helpers.py:235
 msgid "Add-ons for {0}"
 msgstr "{0} 부가 기능"
 
-#: src/olympia/addons/templates/addons/home.html:10
-#: src/olympia/addons/templates/addons/home.html:51
-#: src/olympia/browse/templates/browse/impala/base_listing.html:11
+#: src/olympia/addons/templates/addons/home.html:10 src/olympia/addons/templates/addons/home.html:53 src/olympia/browse/templates/browse/impala/base_listing.html:11
 msgid "Featured Extensions"
 msgstr "추천 확장 기능"
 
@@ -669,69 +519,48 @@ msgstr "추천 확장 기능"
 msgid "Popular Extensions"
 msgstr "인기 확장 기능"
 
-#: src/olympia/addons/templates/addons/home.html:42
-#: src/olympia/amo/templates/amo/side_nav.html:3
-#: src/olympia/amo/templates/amo/side_nav.html:11
-#: src/olympia/amo/templates/amo/site_nav.html:3
-#: src/olympia/amo/templates/amo/site_nav.html:25
-#: src/olympia/browse/views.py:236 src/olympia/browse/views.py:281
-#: src/olympia/browse/views.py:481
+#: src/olympia/addons/templates/addons/home.html:44 src/olympia/amo/templates/amo/side_nav.html:3 src/olympia/amo/templates/amo/side_nav.html:11 src/olympia/amo/templates/amo/site_nav.html:3
+#: src/olympia/amo/templates/amo/site_nav.html:25 src/olympia/browse/views.py:203 src/olympia/browse/views.py:248 src/olympia/browse/views.py:448
 msgid "Most Popular"
 msgstr "인기"
 
-#: src/olympia/addons/templates/addons/home.html:43
+#: src/olympia/addons/templates/addons/home.html:45
 msgid "All »"
 msgstr "전부 »"
 
-#: src/olympia/addons/templates/addons/home.html:52
-#: src/olympia/addons/templates/addons/home.html:61
-#: src/olympia/addons/templates/addons/home.html:70
-#: src/olympia/addons/templates/addons/home.html:78
+#: src/olympia/addons/templates/addons/home.html:54 src/olympia/addons/templates/addons/home.html:63 src/olympia/addons/templates/addons/home.html:72 src/olympia/addons/templates/addons/home.html:80
 #: src/olympia/browse/templates/browse/impala/category_landing.html:36
 msgid "See all »"
 msgstr "모두 보기 »"
 
-#: src/olympia/addons/templates/addons/home.html:60
+#: src/olympia/addons/templates/addons/home.html:62
 msgid "Up &amp; Coming Extensions"
 msgstr "인기 급상승 확장 기능"
 
-#: src/olympia/addons/templates/addons/home.html:69
-#: src/olympia/browse/templates/browse/personas/category_landing.html:61
-#: src/olympia/discovery/templates/discovery/pane.html:74
+#: src/olympia/addons/templates/addons/home.html:71 src/olympia/browse/templates/browse/personas/category_landing.html:61 src/olympia/discovery/templates/discovery/pane.html:74
 msgid "Featured Themes"
 msgstr "추천 테마"
 
-#: src/olympia/addons/templates/addons/home.html:77
-#: src/olympia/bandwagon/templates/bandwagon/impala/collection_listing.html:5
+#: src/olympia/addons/templates/addons/home.html:79 src/olympia/bandwagon/templates/bandwagon/impala/collection_listing.html:5
 msgid "Featured Collections"
 msgstr "추천 모음집"
 
-#: src/olympia/addons/templates/addons/listing_header.html:3
-#: src/olympia/addons/templates/addons/impala/listing/sorter.html:2
-#: src/olympia/amo/templates/amo/mobile/sort_by.html:2
+#: src/olympia/addons/templates/addons/listing_header.html:3 src/olympia/addons/templates/addons/impala/listing/sorter.html:2 src/olympia/amo/templates/amo/mobile/sort_by.html:2
 #: src/olympia/bandwagon/templates/bandwagon/collection_detail.html:118
 msgid "Sort by:"
 msgstr "정렬 방식:"
 
 #. {0} is a date.
 #. {0} is a date
-#: src/olympia/addons/templates/addons/macros.html:7
-#: src/olympia/addons/templates/addons/macros.html:72
-#: src/olympia/addons/templates/addons/listing/items_mobile.html:48
-#: src/olympia/addons/templates/addons/listing/macros.html:42
-#: src/olympia/bandwagon/templates/bandwagon/collection_detail.html:50
-#: src/olympia/bandwagon/templates/bandwagon/collection_listing_items.html:40
-#: src/olympia/bandwagon/templates/bandwagon/impala/collection_listing_items.html:40
+#: src/olympia/addons/templates/addons/macros.html:7 src/olympia/addons/templates/addons/macros.html:72 src/olympia/addons/templates/addons/listing/items_mobile.html:48
+#: src/olympia/addons/templates/addons/listing/macros.html:42 src/olympia/bandwagon/templates/bandwagon/collection_detail.html:50
+#: src/olympia/bandwagon/templates/bandwagon/collection_listing_items.html:40 src/olympia/bandwagon/templates/bandwagon/impala/collection_listing_items.html:40
 msgid "Updated {0}"
 msgstr "최근 업데이트: {0}"
 
 #. {0} is a date.
-#: src/olympia/addons/templates/addons/macros.html:10
-#: src/olympia/addons/templates/addons/macros.html:69
-#: src/olympia/addons/templates/addons/persona_preview.html:21
-#: src/olympia/addons/templates/addons/listing/items_mobile.html:44
-#: src/olympia/addons/templates/addons/listing/macros.html:39
-#: src/olympia/bandwagon/templates/bandwagon/collection_listing_items.html:37
+#: src/olympia/addons/templates/addons/macros.html:10 src/olympia/addons/templates/addons/macros.html:69 src/olympia/addons/templates/addons/persona_preview.html:22
+#: src/olympia/addons/templates/addons/listing/items_mobile.html:44 src/olympia/addons/templates/addons/listing/macros.html:39 src/olympia/bandwagon/templates/bandwagon/collection_listing_items.html:37
 #: src/olympia/bandwagon/templates/bandwagon/impala/collection_listing_items.html:37
 msgid "Added {0}"
 msgstr "{0}에 등록"
@@ -741,28 +570,28 @@ msgstr "{0}에 등록"
 msgid "%(num)s weekly download"
 msgid_plural "%(num)s weekly downloads"
 msgstr[0] "주간 다운로드 %(num)s회"
+msgstr[1] ""
 
 #: src/olympia/addons/templates/addons/macros.html:28
 #, python-format
 msgid "%(num)s user"
 msgid_plural "%(num)s users"
 msgstr[0] "사용자 %(num)s명"
+msgstr[1] ""
 
 #. {0} is the number of downloads.
-#: src/olympia/addons/templates/addons/macros.html:53
-#: src/olympia/addons/templates/addons/impala/details.html:61
+#: src/olympia/addons/templates/addons/macros.html:53 src/olympia/addons/templates/addons/impala/details.html:59
 msgid "{0} weekly download"
 msgid_plural "{0} weekly downloads"
 msgstr[0] "주간 다운로드 {0}회"
+msgstr[1] ""
 
 #. {0} is the number of users.
-#: src/olympia/addons/templates/addons/macros.html:61
-#: src/olympia/addons/templates/addons/impala/details.html:54
-#: src/olympia/compat/templates/compat/index.html:71
-#: src/olympia/zadmin/templates/zadmin/compat.html:67
+#: src/olympia/addons/templates/addons/macros.html:61 src/olympia/addons/templates/addons/impala/details.html:52 src/olympia/zadmin/templates/zadmin/compat.html:67
 msgid "{0} user"
 msgid_plural "{0} users"
 msgstr[0] "사용자 {0}명"
+msgstr[1] ""
 
 #: src/olympia/addons/templates/addons/paypal_result.html:12
 msgid "Payment cancelled"
@@ -776,12 +605,8 @@ msgstr "모금 계획이 완료되었습니다"
 msgid "Return to the addon."
 msgstr "부가 기능으로 돌아갑니다."
 
-#: src/olympia/addons/templates/addons/persona_detail.html:17
-#: src/olympia/addons/templates/addons/impala/details.html:106
-#: src/olympia/addons/templates/addons/mobile/details.html:23
-#: src/olympia/addons/templates/addons/mobile/persona_detail.html:21
-#: src/olympia/discovery/templates/discovery/addons/base.html:27
-#: src/olympia/editors/templates/editors/review.html:31
+#: src/olympia/addons/templates/addons/persona_detail.html:17 src/olympia/addons/templates/addons/impala/details.html:103 src/olympia/addons/templates/addons/mobile/details.html:23
+#: src/olympia/addons/templates/addons/mobile/persona_detail.html:21 src/olympia/discovery/templates/discovery/addons/base.html:27 src/olympia/editors/templates/editors/review.html:31
 msgid "by"
 msgstr "제작: "
 
@@ -791,8 +616,7 @@ msgid "More {0} Themes"
 msgstr "더 많은 {0} 테마"
 
 #. {0} is a category name, such as Nature
-#: src/olympia/addons/templates/addons/persona_detail.html:39
-#: src/olympia/addons/templates/addons/mobile/persona_detail.html:66
+#: src/olympia/addons/templates/addons/persona_detail.html:39 src/olympia/addons/templates/addons/mobile/persona_detail.html:66
 msgid "See all {0} Themes"
 msgstr "모든 {0} 테마 보기"
 
@@ -800,180 +624,129 @@ msgstr "모든 {0} 테마 보기"
 msgid "More by this Artist"
 msgstr "이 아티스트의 다른 작품"
 
-#: src/olympia/addons/templates/addons/persona_detail.html:52
-#: src/olympia/addons/templates/addons/mobile/persona_detail.html:49
+#: src/olympia/addons/templates/addons/persona_detail.html:52 src/olympia/addons/templates/addons/mobile/persona_detail.html:49
 msgid "See all Themes by this Artist"
 msgstr "아티스트별 모든 테마 보기"
 
-#: src/olympia/addons/templates/addons/persona_detail.html:71
-#: src/olympia/addons/templates/addons/mobile/home.html:42
-#: src/olympia/amo/templates/amo/side_nav.html:22
-#: src/olympia/browse/templates/browse/personas/mobile/category_landing.html:28
-#: src/olympia/devhub/templates/devhub/addons/edit/basic.html:72
-#: src/olympia/editors/templates/editors/review.html:277
-#: src/olympia/editors/templates/editors/themes/themes.html:34
-#: src/olympia/templates/categories.html:7
+#: src/olympia/addons/templates/addons/persona_detail.html:71 src/olympia/addons/templates/addons/mobile/home.html:42 src/olympia/amo/templates/amo/side_nav.html:22
+#: src/olympia/browse/templates/browse/personas/mobile/category_landing.html:28 src/olympia/devhub/templates/devhub/addons/edit/basic.html:72 src/olympia/editors/templates/editors/review.html:277
+#: src/olympia/editors/templates/editors/themes/themes.html:34 src/olympia/templates/categories.html:7
 msgid "Categories"
 msgstr "분류"
 
-#: src/olympia/addons/templates/addons/persona_detail_table.html:10
-#: src/olympia/addons/templates/addons/mobile/persona_detail_table.html:3
-#: src/olympia/editors/templates/editors/themes/deleted.html:19
+#: src/olympia/addons/templates/addons/persona_detail_table.html:10 src/olympia/addons/templates/addons/mobile/persona_detail_table.html:3 src/olympia/editors/templates/editors/themes/deleted.html:19
 #: src/olympia/editors/templates/editors/themes/themes.html:25
 msgid "Artist"
 msgstr "아티스트"
 
-#: src/olympia/addons/templates/addons/persona_detail_table.html:19
-#: src/olympia/addons/templates/addons/mobile/persona_detail_table.html:14
-#: src/olympia/stats/templates/stats/addon_report_menu.html:17
+#: src/olympia/addons/templates/addons/persona_detail_table.html:19 src/olympia/addons/templates/addons/mobile/persona_detail_table.html:14 src/olympia/stats/templates/stats/addon_report_menu.html:17
 msgid "Daily Users"
 msgstr "일일 사용자"
 
 #. The License for this add-on.
-#: src/olympia/addons/templates/addons/persona_detail_table.html:26
-#: src/olympia/addons/templates/addons/impala/license.html:17
-#: src/olympia/addons/templates/addons/mobile/persona_detail_table.html:21
-#: src/olympia/devhub/templates/devhub/includes/license_form.html:5
-#: src/olympia/devhub/templates/devhub/versions/edit.html:89
-#: src/olympia/editors/templates/editors/themes/themes.html:41
+#: src/olympia/addons/templates/addons/persona_detail_table.html:26 src/olympia/addons/templates/addons/impala/license.html:17 src/olympia/addons/templates/addons/mobile/persona_detail_table.html:21
+#: src/olympia/devhub/templates/devhub/includes/license_form.html:5 src/olympia/devhub/templates/devhub/versions/edit.html:89 src/olympia/editors/templates/editors/themes/themes.html:41
 msgid "License"
 msgstr "라이선스"
 
-#: src/olympia/addons/templates/addons/persona_preview.html:12
-#: src/olympia/constants/base.py:48
+#: src/olympia/addons/templates/addons/persona_preview.html:13 src/olympia/constants/base.py:48
 msgid "Awaiting Review"
 msgstr "심사 대기중"
 
-#: src/olympia/addons/templates/addons/persona_preview.html:14
-#: src/olympia/amo/log.py:180 src/olympia/constants/base.py:42
-#: src/olympia/editors/helpers.py:62
+#: src/olympia/addons/templates/addons/persona_preview.html:15 src/olympia/amo/log.py:180 src/olympia/constants/base.py:42 src/olympia/editors/helpers.py:62
 msgid "Rejected"
 msgstr "심사 거부됨"
 
-#: src/olympia/addons/templates/addons/persona_preview.html:16
-#: src/olympia/amo/log.py:159
+#: src/olympia/addons/templates/addons/persona_preview.html:17 src/olympia/amo/log.py:159
 msgid "Approved"
 msgstr "승인됨"
 
 #. {0} is the number of users.
-#: src/olympia/addons/templates/addons/persona_preview.html:26
-#: src/olympia/addons/templates/addons/listing/items_mobile.html:36
-#: src/olympia/addons/templates/addons/listing/macros.html:31
+#: src/olympia/addons/templates/addons/persona_preview.html:27 src/olympia/addons/templates/addons/listing/items_mobile.html:36 src/olympia/addons/templates/addons/listing/macros.html:31
 msgid "<strong>{0}</strong> user"
 msgid_plural "<strong>{0}</strong> users"
 msgstr[0] "사용자 <strong>{0}</strong>명"
+msgstr[1] ""
 
-#: src/olympia/addons/templates/addons/persona_preview.html:40
+#: src/olympia/addons/templates/addons/persona_preview.html:41
 msgid "Hover to Preview"
 msgstr "커서를 올려서 미리보기 확인"
 
-#: src/olympia/addons/templates/addons/persona_preview.html:46
-#: src/olympia/addons/templates/addons/persona_preview.html:48
+#: src/olympia/addons/templates/addons/persona_preview.html:47 src/olympia/addons/templates/addons/persona_preview.html:49 src/olympia/addons/templates/addons/persona_preview.html:97
 #: src/olympia/reviews/templates/reviews/add.html:15
 msgid "Add"
 msgstr "추가"
 
-#: src/olympia/addons/templates/addons/persona_preview.html:57
-#: src/olympia/bandwagon/templates/bandwagon/ajax_new.html:16
-#: src/olympia/bandwagon/templates/bandwagon/edit.html:19
-#: src/olympia/bandwagon/templates/bandwagon/includes/addedit.html:19
-#: src/olympia/devhub/templates/devhub/addons/edit/admin.html:13
-#: src/olympia/devhub/templates/devhub/addons/edit/basic.html:10
-#: src/olympia/devhub/templates/devhub/addons/edit/details.html:8
-#: src/olympia/devhub/templates/devhub/addons/edit/media.html:6
-#: src/olympia/devhub/templates/devhub/addons/edit/support.html:8
-#: src/olympia/devhub/templates/devhub/addons/edit/technical.html:9
-#: src/olympia/devhub/templates/devhub/addons/submit/describe.html:29
-#: src/olympia/editors/templates/editors/review.html:257
+#: src/olympia/addons/templates/addons/persona_preview.html:58 src/olympia/bandwagon/templates/bandwagon/ajax_new.html:16 src/olympia/bandwagon/templates/bandwagon/edit.html:19
+#: src/olympia/bandwagon/templates/bandwagon/includes/addedit.html:19 src/olympia/devhub/templates/devhub/addons/edit/admin.html:13 src/olympia/devhub/templates/devhub/addons/edit/basic.html:10
+#: src/olympia/devhub/templates/devhub/addons/edit/details.html:8 src/olympia/devhub/templates/devhub/addons/edit/media.html:6 src/olympia/devhub/templates/devhub/addons/edit/support.html:8
+#: src/olympia/devhub/templates/devhub/addons/edit/technical.html:9 src/olympia/devhub/templates/devhub/addons/submit/describe.html:29 src/olympia/editors/templates/editors/review.html:257
 msgid "Edit"
 msgstr "편집"
 
 #. For datetime formatting, see the table on
 #. http://docs.python.org/library/datetime.html#strftime-and-strptime-behavior
-#: src/olympia/addons/templates/addons/persona_preview.html:66
+#: src/olympia/addons/templates/addons/persona_preview.html:67
 #, python-format
 msgid "%%Y-%%m-%%d"
 msgstr "%%Y-%%m-%%d"
 
-#: src/olympia/addons/templates/addons/persona_preview.html:67
+#: src/olympia/addons/templates/addons/persona_preview.html:68
 msgid "by {0} on {1}"
 msgstr "제작: {0}, 등록일: {1}"
 
-#: src/olympia/addons/templates/addons/persona_preview.html:75
-#: src/olympia/reviews/helpers.py:17
-#: src/olympia/reviews/templates/reviews/review_list.html:63
-#: src/olympia/reviews/templates/reviews/reviews_link.html:21
-#: src/olympia/reviews/templates/reviews/impala/reviews_link.html:16
+#: src/olympia/addons/templates/addons/persona_preview.html:76 src/olympia/reviews/helpers.py:17 src/olympia/reviews/templates/reviews/review_list.html:63
+#: src/olympia/reviews/templates/reviews/reviews_link.html:21 src/olympia/reviews/templates/reviews/impala/reviews_link.html:16
 msgid "Not yet rated"
 msgstr "아직 별점 없음"
 
-#: src/olympia/addons/templates/addons/persona_preview.html:78
+#: src/olympia/addons/templates/addons/persona_preview.html:79
 msgid "<b>{0}</b> users"
 msgstr "사용자 <b>{0}</b>명"
 
 #: src/olympia/addons/templates/addons/popups.html:17
-msgid ""
-"To install this add-on and thousands more, <b>get Firefox</b>, a free and "
-"open web browser from Mozilla."
-msgstr ""
-"이 부가 기능은 물론 수천가지 다른 부가 기능을 설치하고 싶으시면 <b>Firefox를 다운로드 받으세요</b>. Mozilla에서 "
-"개발한 무료 오픈소스 웹브라우저 입니다."
+msgid "To install this add-on and thousands more, <b>get Firefox</b>, a free and open web browser from Mozilla."
+msgstr "이 부가 기능은 물론 수천가지 다른 부가 기능을 설치하고 싶으시면 <b>Firefox를 다운로드 받으세요</b>. Mozilla에서 개발한 무료 오픈소스 웹브라우저 입니다."
 
-#: src/olympia/addons/templates/addons/popups.html:21
-#: src/olympia/addons/templates/addons/popups.html:52
+#: src/olympia/addons/templates/addons/popups.html:21 src/olympia/addons/templates/addons/popups.html:52
 msgid "Learn more about Firefox"
 msgstr "Firefox에 대해 자세히 알아보기"
 
 #: src/olympia/addons/templates/addons/popups.html:22
-msgid "or <b><a class=\"installer\" href=\"{url}\">download anyway</a></b>"
-msgstr "또는 <b><a class=\"installer\" href=\"{url}\">일단 다운로드 받기</a></b>"
+msgid "or <b><a class=\"button installer\" href=\"{url}\">download anyway</a></b>"
+msgstr ""
 
 #: src/olympia/addons/templates/addons/popups.html:26
 msgid ""
-"<strong>How to Install in Thunderbird</strong> <ol> <li>Download and save "
-"the file to your hard disk.</li> <li>In Mozilla Thunderbird, open Add-ons "
-"from the Tools menu.</li> <li>From the options button next to the add-on "
-"search field, select \"Install Add-on From File...\" and locate the "
-"downloaded add-on.</li> </ol>"
+"<strong>How to Install in Thunderbird</strong> <ol> <li>Download and save the file to your hard disk.</li> <li>In Mozilla Thunderbird, open Add-ons from the Tools menu.</li> <li>From the options "
+"button next to the add-on search field, select \"Install Add-on From File...\" and locate the downloaded add-on.</li> </ol>"
 msgstr ""
-"<strong>Thunderbird에서 설치 방법</strong> <ol> <li>하드 디스크에 파일을 다운받습니다.</li> "
-"<li>Mozilla Thunderbird의 도구 메뉴에서 부가 기능을 엽니다.</li> <li>부가 기능 검색창 옆에 옵션 버튼을 눌러"
-" \"파일에서 부가 기능 설치...\"를 선택한 다음 다운받은 부가 기능을 선택합니다.</li> </ol>"
+"<strong>Thunderbird에서 설치 방법</strong> <ol> <li>하드 디스크에 파일을 다운받습니다.</li> <li>Mozilla Thunderbird의 도구 메뉴에서 부가 기능을 엽니다.</li> <li>부가 기능 검색창 옆에 옵션 버튼을 눌러 \"파일에서 부가 기능 설치...\"를 선택한 다음 다운받은 부가 기능을 "
+"선택합니다.</li> </ol>"
 
 #: src/olympia/addons/templates/addons/popups.html:41
-msgid ""
-"To install this Theme, <b>get Thunderbird</b>, a free and open source email "
-"client from Mozilla Messaging and install the Personas Plus add-on."
-msgstr ""
-"이 테마를 설치하려면, <b>Thunderbird와</b>, Mozilla 메시징에서 무료 오픈 소스 이메일 클라이언트를 구하시고 "
-"Personas Plus 애드온을 설치하세요."
+msgid "To install this Theme, <b>get Thunderbird</b>, a free and open source email client from Mozilla Messaging and install the Personas Plus add-on."
+msgstr "이 테마를 설치하려면, <b>Thunderbird와</b>, Mozilla 메시징에서 무료 오픈 소스 이메일 클라이언트를 구하시고 Personas Plus 애드온을 설치하세요."
 
 #: src/olympia/addons/templates/addons/popups.html:46
 msgid "Learn more about Thunderbird"
 msgstr "Thunderbird에 대해 자세히 알아보기"
 
 #: src/olympia/addons/templates/addons/popups.html:48
-msgid ""
-"To install this Theme and thousands more, <b>get Firefox</b>, a free and "
-"open web browser from Mozilla."
-msgstr ""
-"이 테마와 수 천 가지 다른 것들을 설치하려면, Mozilla의 무료 오픈 웹 브라우저인, <b>Firefox를 다운로드 "
-"받으세요</b>."
+msgid "To install this Theme and thousands more, <b>get Firefox</b>, a free and open web browser from Mozilla."
+msgstr "이 테마와 수 천 가지 다른 것들을 설치하려면, Mozilla의 무료 오픈 웹 브라우저인, <b>Firefox를 다운로드 받으세요</b>."
 
 #: src/olympia/addons/templates/addons/popups.html:60
 #, python-format
 msgid "This add-on has not been updated to work with your version of %(app)s."
 msgstr "이 부가 기능은 현재 사용중인 %(app)s 버전에서 작동할 수 있도록 업데이트 되지 않았습니다."
 
-#: src/olympia/addons/templates/addons/popups.html:63
-#: src/olympia/addons/templates/addons/popups.html:140
-#: src/olympia/addons/templates/addons/popups.html:150
+#: src/olympia/addons/templates/addons/popups.html:63 src/olympia/addons/templates/addons/popups.html:140 src/olympia/addons/templates/addons/popups.html:150
 msgid "Install Anyway"
 msgstr "무조건 설치하기"
 
 #: src/olympia/addons/templates/addons/popups.html:71
-msgid ""
-"This add-on requires a version of Firefox that has not been released yet."
+msgid "This add-on requires a version of Firefox that has not been released yet."
 msgstr "이 부가 기능은 아직 공개되지 않은 Firefox 버전을 필요로 합니다."
 
 #: src/olympia/addons/templates/addons/popups.html:74
@@ -982,16 +755,11 @@ msgstr "새 Firefox 버전 테스트 돕기"
 
 #: src/olympia/addons/templates/addons/popups.html:77
 #, python-format
-msgid ""
-"This add-on requires %(app)s {new_version}. You are currently using %(app)s "
-"{old_version}."
-msgstr ""
-"이 부가 기능은 %(app)s {new_version}이(가) 필요합니다. 현재 사용중인 버전은 %(app)s "
-"{old_version}입니다."
+msgid "This add-on requires %(app)s {new_version}. You are currently using %(app)s {old_version}."
+msgstr "이 부가 기능은 %(app)s {new_version}이(가) 필요합니다. 현재 사용중인 버전은 %(app)s {old_version}입니다."
 
 #. {0} is an app name, like Firefox.
-#: src/olympia/addons/templates/addons/popups.html:82
-#: src/olympia/addons/templates/addons/popups.html:101
+#: src/olympia/addons/templates/addons/popups.html:82 src/olympia/addons/templates/addons/popups.html:101
 msgid "Upgrade {0}"
 msgstr "{0} 업그레이드"
 
@@ -1002,36 +770,25 @@ msgstr "또는 <a href=\"%(href)s\">이 부가 기능의 구버전</a> 보기."
 
 #: src/olympia/addons/templates/addons/popups.html:96
 #, python-format
-msgid ""
-"This Persona requires %(app)s %(new_version)s. You are currently using "
-"%(app)s {old_version}."
-msgstr ""
-"이 페르소나는 %(app)s %(new_version)s을(를) 필요로 합니다. 현재 사용중인 버전은 %(app)s "
-"{old_version} 입니다."
+msgid "This Persona requires %(app)s %(new_version)s. You are currently using %(app)s {old_version}."
+msgstr "이 페르소나는 %(app)s %(new_version)s을(를) 필요로 합니다. 현재 사용중인 버전은 %(app)s {old_version} 입니다."
 
 #: src/olympia/addons/templates/addons/popups.html:108
 msgid ""
-"<strong>Caution:</strong> This add-on has not been reviewed by Mozilla and "
-"can't be installed on release versions of Firefox 43 and above.  Be careful "
-"when installing third-party software that might harm your computer."
+"<strong>Caution:</strong> This add-on has not been reviewed by Mozilla and can't be installed on release versions of Firefox 43 and above. Be careful when installing third-party software that might"
+" harm your computer."
 msgstr ""
 
 #: src/olympia/addons/templates/addons/popups.html:120
-msgid ""
-"<strong>Please note:</strong> This add-on is not compatible with your "
-"operating system."
+msgid "<strong>Please note:</strong> This add-on is not compatible with your operating system."
 msgstr "<strong>알림:</strong> 이 부가 기능은 사용중인 운영 체제와 호환되지 않습니다."
 
-#: src/olympia/addons/templates/addons/popups.html:136
-#: src/olympia/addons/templates/addons/impala/button.html:70
+#: src/olympia/addons/templates/addons/popups.html:136 src/olympia/addons/templates/addons/impala/button.html:70
 #, python-format
-msgid ""
-"This add-on is not compatible with your version of %(app)s because of the "
-"following:"
+msgid "This add-on is not compatible with your version of %(app)s because of the following:"
 msgstr "이 부가 기능은 다음 이유로 인해 사용중인 %(app)s와 호환되지 않습니다:"
 
-#: src/olympia/addons/templates/addons/popups.html:141
-#: src/olympia/addons/templates/addons/popups.html:151
+#: src/olympia/addons/templates/addons/popups.html:141 src/olympia/addons/templates/addons/popups.html:151
 msgid "View other versions"
 msgstr "다른 버전 보기"
 
@@ -1050,143 +807,88 @@ msgid "QR code for add-on"
 msgstr "부가 기능 QR 코드"
 
 #: src/olympia/addons/templates/addons/qr_code.html:6
-msgid ""
-"Want {0} on your mobile Firefox? Scan this QR code to install directly to "
-"your phone. (You'll need a QR reader. Search your phone's marketplace if "
-"don't have one.)"
-msgstr ""
-"모바일용 Firefox에 {0}을(를) 설치하고 싶으세요? 이 QR 코드를 스캔하면 바로 스마트폰에 설치하실 수 있습니다. (QR리더가 "
-"필요합니다. 없을 경우 보유하신 스마트폰의 앱스토어에서 찾아보세요.)"
+msgid "Want {0} on your mobile Firefox? Scan this QR code to install directly to your phone. (You'll need a QR reader. Search your phone's marketplace if don't have one.)"
+msgstr "모바일용 Firefox에 {0}을(를) 설치하고 싶으세요? 이 QR 코드를 스캔하면 바로 스마트폰에 설치하실 수 있습니다. (QR리더가 필요합니다. 없을 경우 보유하신 스마트폰의 앱스토어에서 찾아보세요.)"
 
-#: src/olympia/addons/templates/addons/report_abuse.html:6
-#: src/olympia/addons/templates/addons/report_abuse_full.html:10
-#: src/olympia/addons/templates/addons/impala/details-more.html:23
-#: src/olympia/addons/templates/addons/impala/details.html:328
+#: src/olympia/addons/templates/addons/report_abuse.html:6 src/olympia/addons/templates/addons/report_abuse_full.html:10 src/olympia/addons/templates/addons/impala/details-more.html:23
+#: src/olympia/addons/templates/addons/impala/details.html:333
 msgid "Report Abuse"
 msgstr "정책 위반 신고"
 
 #: src/olympia/addons/templates/addons/report_abuse.html:10
 #, python-format
 msgid ""
-"If you suspect this add-on violates <a href=\"%(url)s\">our policies</a> or "
-"has security or privacy issues, please use the form below to describe your "
-"concerns. Please do not use this form for any other reason."
-msgstr ""
-"이 부가 기능이 <a href=\"%(url)s\">저희의 정책</a>이나 보안 및 개인 정보 정책을 위반하고 있는 것 같으면 아래의 "
-"양식을 사용해 우려되는 점을 기입해 주세요. 다른 사유로는 이 기능을 사용하지 말아 주십시오."
+"If you suspect this add-on violates <a href=\"%(url)s\">our policies</a> or has security or privacy issues, please use the form below to describe your concerns. Please do not use this form for any "
+"other reason."
+msgstr "이 부가 기능이 <a href=\"%(url)s\">저희의 정책</a>이나 보안 및 개인 정보 정책을 위반하고 있는 것 같으면 아래의 양식을 사용해 우려되는 점을 기입해 주세요. 다른 사유로는 이 기능을 사용하지 말아 주십시오."
 
-#: src/olympia/addons/templates/addons/report_abuse.html:24
-#: src/olympia/users/templates/users/report_abuse.html:19
+#: src/olympia/addons/templates/addons/report_abuse.html:24 src/olympia/users/templates/users/report_abuse.html:19
 msgid "Send Report"
 msgstr "신고 접수"
 
-#: src/olympia/addons/templates/addons/report_abuse.html:26
-#: src/olympia/addons/templates/addons/mobile/eula.html:16
-#: src/olympia/addons/templates/addons/mobile/persona_confirm.html:7
-#: src/olympia/devhub/templates/devhub/addons/ajax_compat_update.html:36
-#: src/olympia/devhub/templates/devhub/addons/profile.html:44
-#: src/olympia/devhub/templates/devhub/addons/edit/admin.html:104
-#: src/olympia/devhub/templates/devhub/addons/edit/basic.html:155
-#: src/olympia/devhub/templates/devhub/addons/edit/details.html:88
-#: src/olympia/devhub/templates/devhub/addons/edit/support.html:70
-#: src/olympia/devhub/templates/devhub/addons/edit/technical.html:169
-#: src/olympia/devhub/templates/devhub/addons/forms_shared/media.html:152
-#: src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:44
-#: src/olympia/devhub/templates/devhub/personas/edit.html:222
-#: src/olympia/devhub/templates/devhub/versions/add_file_modal.html:79
-#: src/olympia/devhub/templates/devhub/versions/edit.html:140
-#: src/olympia/devhub/templates/devhub/versions/list.html:208
-#: src/olympia/devhub/templates/devhub/versions/list.html:242
-#: src/olympia/devhub/templates/devhub/versions/list.html:276
-#: src/olympia/devhub/templates/devhub/versions/list.html:317
-#: src/olympia/reviews/templates/reviews/edit_review.html:16
-#: src/olympia/translations/templates/translations/trans-menu.html:50
-#: src/olympia/translations/templates/translations/trans-menu.html:62
-#: src/olympia/zadmin/templates/zadmin/validation.html:105
+#: src/olympia/addons/templates/addons/report_abuse.html:26 src/olympia/addons/templates/addons/mobile/eula.html:16 src/olympia/addons/templates/addons/mobile/persona_confirm.html:7
+#: src/olympia/devhub/templates/devhub/addons/ajax_compat_update.html:36 src/olympia/devhub/templates/devhub/addons/profile.html:44 src/olympia/devhub/templates/devhub/addons/edit/admin.html:104
+#: src/olympia/devhub/templates/devhub/addons/edit/basic.html:155 src/olympia/devhub/templates/devhub/addons/edit/details.html:88 src/olympia/devhub/templates/devhub/addons/edit/support.html:70
+#: src/olympia/devhub/templates/devhub/addons/edit/technical.html:169 src/olympia/devhub/templates/devhub/addons/forms_shared/media.html:152
+#: src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:43 src/olympia/devhub/templates/devhub/personas/edit.html:222 src/olympia/devhub/templates/devhub/versions/add_file_modal.html:59
+#: src/olympia/devhub/templates/devhub/versions/edit.html:140 src/olympia/devhub/templates/devhub/versions/list.html:208 src/olympia/devhub/templates/devhub/versions/list.html:239
+#: src/olympia/devhub/templates/devhub/versions/list.html:281 src/olympia/devhub/templates/devhub/versions/list.html:315 src/olympia/reviews/templates/reviews/edit_review.html:16
+#: src/olympia/translations/templates/translations/trans-menu.html:50 src/olympia/translations/templates/translations/trans-menu.html:62 src/olympia/zadmin/templates/zadmin/validation.html:105
 msgid "Cancel"
 msgstr "취소"
 
-#: src/olympia/addons/templates/addons/review_add_box.html:3
-#: src/olympia/addons/templates/addons/impala/review_add_box.html:5
+#: src/olympia/addons/templates/addons/review_add_box.html:3 src/olympia/addons/templates/addons/impala/review_add_box.html:5
 msgid "What do you think?"
 msgstr "당신은 어떻게 생각하세요?"
 
-#: src/olympia/addons/templates/addons/review_add_box.html:7
-#: src/olympia/addons/templates/addons/impala/review_add_box.html:9
+#: src/olympia/addons/templates/addons/review_add_box.html:7 src/olympia/addons/templates/addons/impala/review_add_box.html:9
 #, python-format
 msgid "Please <a href=\"%(login)s\">log in</a> to submit a review"
 msgstr "평가를 작성하려면 <a href=\"%(login)s\">로그인</a> 하세요"
 
-#: src/olympia/addons/templates/addons/review_add_box.html:16
-#: src/olympia/addons/templates/addons/impala/review_add_box.html:18
-#: src/olympia/reviews/templates/reviews/mobile/add_form.html:13
+#: src/olympia/addons/templates/addons/review_add_box.html:16 src/olympia/addons/templates/addons/impala/review_add_box.html:18 src/olympia/reviews/templates/reviews/mobile/add_form.html:13
 msgid "Title:"
 msgstr "제목:"
 
-#: src/olympia/addons/templates/addons/review_add_box.html:17
-#: src/olympia/addons/templates/addons/impala/review_add_box.html:19
-#: src/olympia/reviews/templates/reviews/mobile/add_form.html:17
+#: src/olympia/addons/templates/addons/review_add_box.html:17 src/olympia/addons/templates/addons/impala/review_add_box.html:19 src/olympia/reviews/templates/reviews/mobile/add_form.html:17
 msgid "Review:"
 msgstr "평가:"
 
-#: src/olympia/addons/templates/addons/review_add_box.html:18
-#: src/olympia/addons/templates/addons/impala/review_add_box.html:20
-#: src/olympia/reviews/templates/reviews/mobile/add_form.html:16
+#: src/olympia/addons/templates/addons/review_add_box.html:18 src/olympia/addons/templates/addons/impala/review_add_box.html:20 src/olympia/reviews/templates/reviews/mobile/add_form.html:16
 msgid "Rating:"
 msgstr "별점:"
 
-#: src/olympia/addons/templates/addons/review_add_box.html:19
-#: src/olympia/addons/templates/addons/impala/review_add_box.html:21
-#: src/olympia/reviews/templates/reviews/add.html:63
-#: src/olympia/reviews/templates/reviews/edit_review.html:15
-#: src/olympia/reviews/templates/reviews/mobile/add_form.html:18
+#: src/olympia/addons/templates/addons/review_add_box.html:19 src/olympia/addons/templates/addons/impala/review_add_box.html:21 src/olympia/reviews/templates/reviews/add.html:63
+#: src/olympia/reviews/templates/reviews/edit_review.html:15 src/olympia/reviews/templates/reviews/mobile/add_form.html:18
 msgid "Submit review"
 msgstr "평가 작성"
 
-#: src/olympia/addons/templates/addons/review_add_box.html:24
-#: src/olympia/addons/templates/addons/impala/review_add_box.html:26
-msgid ""
-"Please do not post bug reports in reviews. We do not make your email address"
-" available to add-on developers and they may need to contact you to help "
-"resolve your issue."
-msgstr ""
-"평가엔 버그 리포트를 올리지 마세요. 저희는 부가 기능 개발자가 여러분의 이메일 주소를 사용하는 것을 허용하지 않는데, 이메일 주소가 "
-"올라와 있으면 개발자가 문제 해결을 돕기위해 직접 연락을 하려 들 수 있기 때문입니다."
+#: src/olympia/addons/templates/addons/review_add_box.html:24 src/olympia/addons/templates/addons/impala/review_add_box.html:26
+msgid "Please do not post bug reports in reviews. We do not make your email address available to add-on developers and they may need to contact you to help resolve your issue."
+msgstr "평가엔 버그 리포트를 올리지 마세요. 저희는 부가 기능 개발자가 여러분의 이메일 주소를 사용하는 것을 허용하지 않는데, 이메일 주소가 올라와 있으면 개발자가 문제 해결을 돕기위해 직접 연락을 하려 들 수 있기 때문입니다."
 
-#: src/olympia/addons/templates/addons/review_add_box.html:32
-#: src/olympia/addons/templates/addons/impala/review_add_box.html:35
+#: src/olympia/addons/templates/addons/review_add_box.html:32 src/olympia/addons/templates/addons/impala/review_add_box.html:35
 #, python-format
-msgid ""
-"See the <a href=\"%(support)s\">support section</a> to find out where to get"
-" assistance for this add-on."
+msgid "See the <a href=\"%(support)s\">support section</a> to find out where to get assistance for this add-on."
 msgstr "이 부가 기능에 대한 지원은 <a href=\"%(support)s\">기술 지원 항목</a>에 명시되어 있습니다."
 
-#: src/olympia/addons/templates/addons/review_add_box.html:38
-#: src/olympia/addons/templates/addons/impala/review_add_box.html:42
-#: src/olympia/pages/templates/pages/review_guide.html:3
+#: src/olympia/addons/templates/addons/review_add_box.html:38 src/olympia/addons/templates/addons/impala/review_add_box.html:42 src/olympia/pages/templates/pages/review_guide.html:3
 #: src/olympia/pages/templates/pages/review_guide.html:44
 msgid "Review Guidelines"
 msgstr "평가 지침"
 
-#: src/olympia/addons/templates/addons/review_list_box.html:5
-#: src/olympia/addons/templates/addons/impala/details-more.html:27
-#: src/olympia/editors/helpers.py:921
-#: src/olympia/reviews/templates/reviews/add.html:14
-#: src/olympia/reviews/templates/reviews/reply.html:14
-#: src/olympia/reviews/templates/reviews/review_list.html:19
+#: src/olympia/addons/templates/addons/review_list_box.html:5 src/olympia/addons/templates/addons/impala/details-more.html:27 src/olympia/editors/helpers.py:1001
+#: src/olympia/reviews/templates/reviews/add.html:14 src/olympia/reviews/templates/reviews/reply.html:14 src/olympia/reviews/templates/reviews/review_list.html:19
 #: src/olympia/reviews/templates/reviews/mobile/review_list.html:26
 msgid "Reviews"
 msgstr "평가"
 
-#: src/olympia/addons/templates/addons/review_list_box.html:14
-#: src/olympia/addons/templates/addons/impala/review_list_box.html:14
-#: src/olympia/reviews/templates/reviews/review.html:30
+#: src/olympia/addons/templates/addons/review_list_box.html:14 src/olympia/addons/templates/addons/impala/review_list_box.html:14 src/olympia/reviews/templates/reviews/review.html:30
 #, python-format
 msgid "by %(user)s on %(date)s"
 msgstr "작성: %(user)s, 날짜: %(date)s"
 
-#: src/olympia/addons/templates/addons/review_list_box.html:19
-#: src/olympia/addons/templates/addons/impala/review_list_box.html:29
+#: src/olympia/addons/templates/addons/review_list_box.html:19 src/olympia/addons/templates/addons/impala/review_list_box.html:29
 msgid "Show the developer's reply to this review"
 msgstr "이 평가에 달린 개발자 답변 보기"
 
@@ -1195,22 +897,18 @@ msgstr "이 평가에 달린 개발자 답변 보기"
 msgid "See all reviews of this add-on"
 msgid_plural "See all %(cnt)s reviews of this add-on"
 msgstr[0] "평가 전부 보기"
+msgstr[1] ""
 
-#: src/olympia/addons/templates/addons/tags_box.html:3
-#: src/olympia/devhub/templates/devhub/addons/edit/basic.html:118
+#: src/olympia/addons/templates/addons/tags_box.html:3 src/olympia/devhub/templates/devhub/addons/edit/basic.html:118
 msgid "Tags"
 msgstr "태그"
 
-#: src/olympia/addons/templates/addons/impala/addon_hovercard.html:7
-#: src/olympia/addons/templates/addons/impala/addon_hovercard.html:9
+#: src/olympia/addons/templates/addons/impala/addon_hovercard.html:7 src/olympia/addons/templates/addons/impala/addon_hovercard.html:9
 msgid "Icon for {0}"
 msgstr "{0} 아이콘"
 
-#: src/olympia/addons/templates/addons/impala/addon_hovercard.html:34
-#: src/olympia/addons/templates/addons/impala/featured_grid.html:26
-#: src/olympia/addons/templates/addons/impala/theme_grid.html:22
-#: src/olympia/bandwagon/templates/bandwagon/collection_detail.html:31
-#: src/olympia/users/templates/users/helpers/addon_users_list.html:7
+#: src/olympia/addons/templates/addons/impala/addon_hovercard.html:34 src/olympia/addons/templates/addons/impala/featured_grid.html:26 src/olympia/addons/templates/addons/impala/theme_grid.html:22
+#: src/olympia/bandwagon/templates/bandwagon/collection_detail.html:31 src/olympia/users/templates/users/helpers/addon_users_list.html:7
 #, python-format
 msgid "by %(users)s"
 msgstr "제작: %(users)s"
@@ -1230,32 +928,18 @@ msgstr "이 부가 기능이 마음에 드시나요?"
 
 #: src/olympia/addons/templates/addons/impala/contribution.html:43
 #, python-format
-msgid ""
-"The <a href=\"%(meet_url)s\">developer of this add-on</a> asks that you help"
-" support its continued development by making a small contribution."
-msgstr ""
-"<a href=\"%(meet_url)s\">이 부가 기능의 개발자</a>는 개발 작업을 계속 할 수 있도록 소정의 기부를 통한 지원을 "
-"요청하고 있습니다."
+msgid "The <a href=\"%(meet_url)s\">developer of this add-on</a> asks that you help support its continued development by making a small contribution."
+msgstr "<a href=\"%(meet_url)s\">이 부가 기능의 개발자</a>는 개발 작업을 계속 할 수 있도록 소정의 기부를 통한 지원을 요청하고 있습니다."
 
 #: src/olympia/addons/templates/addons/impala/contribution.html:48
 #, python-format
-msgid ""
-"The <a href=\"%(meet_url)s\">developer of this add-on</a> asks that you show"
-" your support by making a donation to the <a "
-"href=\"%(charity_url)s\">%(charity_name)s</a>."
-msgstr ""
-"<a href=\"%(meet_url)s\">이 부가 기능의 개발자</a>는 <a "
-"href=\"%(charity_url)s\">%(charity_name)s</a>로의 기부를 통한 지원을 요청하고 있습니다."
+msgid "The <a href=\"%(meet_url)s\">developer of this add-on</a> asks that you show your support by making a donation to the <a href=\"%(charity_url)s\">%(charity_name)s</a>."
+msgstr "<a href=\"%(meet_url)s\">이 부가 기능의 개발자</a>는 <a href=\"%(charity_url)s\">%(charity_name)s</a>로의 기부를 통한 지원을 요청하고 있습니다."
 
 #: src/olympia/addons/templates/addons/impala/contribution.html:53
 #, python-format
-msgid ""
-"The <a href=\"%(meet_url)s\">developer of this add-on</a> asks that you show"
-" your support by making a small contribution to <a "
-"href=\"%(charity_url)s\">%(charity_name)s</a>."
-msgstr ""
-"<a href=\"%(meet_url)s\">이 부가 기능의 개발자</a>는 <a "
-"href=\"%(charity_url)s\">%(charity_name)s</a>로의 소정의 기부를 통한 지원을 요청하고 있습니다."
+msgid "The <a href=\"%(meet_url)s\">developer of this add-on</a> asks that you show your support by making a small contribution to <a href=\"%(charity_url)s\">%(charity_name)s</a>."
+msgstr "<a href=\"%(meet_url)s\">이 부가 기능의 개발자</a>는 <a href=\"%(charity_url)s\">%(charity_name)s</a>로의 소정의 기부를 통한 지원을 요청하고 있습니다."
 
 #: src/olympia/addons/templates/addons/impala/dependencies_note.html:4
 msgid "This add-on requires the following add-ons to work properly:"
@@ -1282,141 +966,122 @@ msgstr "속해있는 모음집"
 msgid "Other add-ons by %(author)s"
 msgid_plural "Other add-ons by these authors"
 msgstr[0] "이 제작자의 다른 부가 기능"
+msgstr[1] ""
 
-#: src/olympia/addons/templates/addons/impala/details.html:41
+#: src/olympia/addons/templates/addons/impala/details.html:39
 #, python-format
 msgid "<span itemprop=\"ratingCount\">%(num)s</span> user review"
 msgid_plural "<span itemprop=\"ratingCount\">%(num)s</span> user reviews"
 msgstr[0] "사용자 평가 <span itemprop=\"ratingCount\">%(num)s</span>개"
+msgstr[1] ""
 
-#: src/olympia/addons/templates/addons/impala/details.html:69
+#: src/olympia/addons/templates/addons/impala/details.html:66
 msgid "View statistics"
 msgstr "통계 보기"
 
-#: src/olympia/addons/templates/addons/impala/details.html:84
+#: src/olympia/addons/templates/addons/impala/details.html:81
 msgid "Manage"
 msgstr "관리"
 
 #. {0} is an add-on name.
-#: src/olympia/addons/templates/addons/impala/details.html:96
+#: src/olympia/addons/templates/addons/impala/details.html:93
 msgid "Icon of {0}"
 msgstr "{0} 아이콘"
 
-#: src/olympia/addons/templates/addons/impala/details.html:103
-#: src/olympia/addons/templates/addons/impala/listing/items.html:14
+#: src/olympia/addons/templates/addons/impala/details.html:100 src/olympia/addons/templates/addons/impala/listing/items.html:14
 msgid "No Restart"
 msgstr "재시작 필요 없음"
 
-#: src/olympia/addons/templates/addons/impala/details.html:127
+#: src/olympia/addons/templates/addons/impala/details.html:124
 #, python-format
 msgid "Meet the Developer: <a href=\"%(url)s\">%(name)s</a>"
 msgid_plural "<a href=\"%(url)s\">Meet the Developers</a>"
 msgstr[0] "<a href=\"%(url)s\">개발자 만나기</a>"
+msgstr[1] ""
 
 # {0} is an add-on name.
-#: src/olympia/addons/templates/addons/impala/details.html:137
+#: src/olympia/addons/templates/addons/impala/details.html:134
 msgid "Learn why {0} was created and find out what's next for this add-on."
 msgstr "{0}을(를) 제작한 이유와 이 부가 기능의 향후 계획에 대해 알아봅시다."
 
 #. {0} is an index.
-#: src/olympia/addons/templates/addons/impala/details.html:156
+#: src/olympia/addons/templates/addons/impala/details.html:161
 msgid "Add-on screenshot #{0}"
 msgstr "#{0} 부가기능 스크린샷"
 
-#: src/olympia/addons/templates/addons/impala/details.html:182
+#: src/olympia/addons/templates/addons/impala/details.html:187
 msgid "Add-on home page"
 msgstr "부가 기능 홈페이지"
 
-#: src/olympia/addons/templates/addons/impala/details.html:185
+#: src/olympia/addons/templates/addons/impala/details.html:190
 msgid "Support site"
 msgstr "기술 지원 사이트"
 
-#: src/olympia/addons/templates/addons/impala/details.html:189
+#: src/olympia/addons/templates/addons/impala/details.html:194
 msgid "Support E-mail"
 msgstr "기술 지원 이메일"
 
-#: src/olympia/addons/templates/addons/impala/details.html:194
-#: src/olympia/devhub/models.py:378
-#: src/olympia/devhub/templates/devhub/versions/list.html:12
-#: src/olympia/versions/templates/versions/version.html:6
-#: src/olympia/versions/templates/versions/mobile/version.html:6
+#: src/olympia/addons/templates/addons/impala/details.html:199 src/olympia/devhub/models.py:378 src/olympia/devhub/templates/devhub/versions/list.html:12
+#: src/olympia/versions/templates/versions/version.html:6 src/olympia/versions/templates/versions/mobile/version.html:6
 msgid "Version {0}"
 msgstr "버전 {0}"
 
-#: src/olympia/addons/templates/addons/impala/details.html:194
+#: src/olympia/addons/templates/addons/impala/details.html:199
 msgid "Info"
 msgstr "정보"
 
-#: src/olympia/addons/templates/addons/impala/details.html:195
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:129
+#: src/olympia/addons/templates/addons/impala/details.html:200 src/olympia/devhub/templates/devhub/includes/addon_details.html:116
 msgid "Last Updated:"
 msgstr "마지막 업데이트:"
 
-#: src/olympia/addons/templates/addons/impala/details.html:200
+#: src/olympia/addons/templates/addons/impala/details.html:205
 #, python-format
 msgid "Released under <a target=\"_blank\" href=\"%(url)s\">%(name)s</a>"
 msgstr "<a target=\"_blank\" href=\"%(url)s\">%(name)s</a> 라이선스를 사용해서 출시"
 
-#: src/olympia/addons/templates/addons/impala/details.html:201
-#: src/olympia/addons/templates/addons/impala/details.html:206
-#: src/olympia/amo/helpers.py:398 src/olympia/devhub/forms.py:142
-#: src/olympia/devhub/forms.py:173
-#: src/olympia/versions/templates/versions/version.html:40
-#: src/olympia/versions/templates/versions/version.html:45
+#: src/olympia/addons/templates/addons/impala/details.html:206 src/olympia/addons/templates/addons/impala/details.html:211 src/olympia/amo/helpers.py:398 src/olympia/devhub/forms.py:142
+#: src/olympia/devhub/forms.py:173 src/olympia/versions/templates/versions/version.html:40 src/olympia/versions/templates/versions/version.html:45
 msgid "Custom License"
 msgstr "사용자 정의 라이선스"
 
-#: src/olympia/addons/templates/addons/impala/details.html:205
+#: src/olympia/addons/templates/addons/impala/details.html:210
 #, python-format
 msgid "Released under <a href=\"%(url)s\">%(name)s</a>"
 msgstr "<a href=\"%(url)s\">%(name)s</a>를 사용해서 출시"
 
-#: src/olympia/addons/templates/addons/impala/details.html:217
+#: src/olympia/addons/templates/addons/impala/details.html:222
 msgid "About this Add-on"
 msgstr "부가 기능 정보"
 
-#: src/olympia/addons/templates/addons/impala/details.html:233
+#: src/olympia/addons/templates/addons/impala/details.html:238
 msgid "Developer’s Comments"
 msgstr "개발자 코멘트"
 
-#: src/olympia/addons/templates/addons/impala/details.html:243
+#: src/olympia/addons/templates/addons/impala/details.html:248
 msgid "Version Information"
 msgstr "버전 정보"
 
-#: src/olympia/addons/templates/addons/impala/details.html:250
+#: src/olympia/addons/templates/addons/impala/details.html:255
 msgid "See complete version history"
 msgstr "전체 버전 기록 보기"
 
-#: src/olympia/addons/templates/addons/impala/details.html:262
+#: src/olympia/addons/templates/addons/impala/details.html:267
 msgid ""
-"The Development Channel lets you test an experimental new version of this "
-"add-on before it's released to the general public. Once you install the "
-"development version, you will continue to get updates from this channel. To "
-"stop receiving development updates, reinstall the default version from the "
-"link above."
-msgstr ""
-"개발 채널에선 부가 기능의 최신 시험용 버전을 일반에 공개되기 전에 먼저 테스트해 볼 수 있습니다. 개발 버전을 설치하고 나면 이 채널을"
-" 통해 업데이트를 지속적으로 받아보실 수 있습니다. 개발 버전의 업데이트를 그만 받으시려면 위의 링크를 통해 기본 버전을 재설치 하시면 "
-"됩니다."
+"The Development Channel lets you test an experimental new version of this add-on before it's released to the general public. Once you install the development version, you will continue to get "
+"updates from this channel. To stop receiving development updates, reinstall the default version from the link above."
+msgstr "개발 채널에선 부가 기능의 최신 시험용 버전을 일반에 공개되기 전에 먼저 테스트해 볼 수 있습니다. 개발 버전을 설치하고 나면 이 채널을 통해 업데이트를 지속적으로 받아보실 수 있습니다. 개발 버전의 업데이트를 그만 받으시려면 위의 링크를 통해 기본 버전을 재설치 하시면 됩니다."
 
-#: src/olympia/addons/templates/addons/impala/details.html:272
-msgid ""
-"<strong>Caution:</strong> Development versions of this add-on have not been "
-"reviewed by Mozilla."
+#: src/olympia/addons/templates/addons/impala/details.html:277
+msgid "<strong>Caution:</strong> Development versions of this add-on have not been reviewed by Mozilla."
 msgstr ""
 
-#: src/olympia/addons/templates/addons/impala/details.html:287
+#: src/olympia/addons/templates/addons/impala/details.html:292
 msgid "See complete development channel history"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/impala/details.html:306
-#: src/olympia/addons/templates/addons/impala/details.html:315
-#: src/olympia/addons/templates/addons/impala/details.html:327
-#: src/olympia/addons/templates/addons/impala/review_add_box.html:4
-#: src/olympia/stats/templates/stats/popup.html:2
-#: src/olympia/stats/templates/stats/popup.html:8
-#: src/olympia/stats/templates/stats/stats.html:202
-#: src/olympia/users/templates/users/profile.html:119
+#: src/olympia/addons/templates/addons/impala/details.html:311 src/olympia/addons/templates/addons/impala/details.html:320 src/olympia/addons/templates/addons/impala/details.html:332
+#: src/olympia/addons/templates/addons/impala/review_add_box.html:4 src/olympia/stats/templates/stats/popup.html:2 src/olympia/stats/templates/stats/popup.html:8
+#: src/olympia/stats/templates/stats/stats.html:204 src/olympia/users/templates/users/profile.html:119
 msgid "close"
 msgstr "닫기"
 
@@ -1425,16 +1090,14 @@ msgstr "닫기"
 msgid "Thank you for installing {0}"
 msgstr "{0}을(를) 설치해 주셔서 대단히 감사합니다"
 
-#. {0} is an add-on name.
 # %1 is an add-on name.
+#. {0} is an add-on name.
 #: src/olympia/addons/templates/addons/impala/developers.html:12
 msgid "Meet the {0} Developer"
 msgstr "{0} 개발자 만나기"
 
 #: src/olympia/addons/templates/addons/impala/developers.html:41
-msgid ""
-"Before downloading this add-on, please consider supporting the development "
-"of this add-on by making a small contribution."
+msgid "Before downloading this add-on, please consider supporting the development of this add-on by making a small contribution."
 msgstr "이 부가 기능을 다운로드 하기 전에, 소액 기부를 통한 부가 기능 개발 후원을 고려해 보세요."
 
 # %1 is an add-on name.
@@ -1451,10 +1114,9 @@ msgstr "{0}의 향후 계획은?"
 msgid "About the Developer"
 msgid_plural "About the Developers"
 msgstr[0] "개발자 소개"
+msgstr[1] ""
 
-#: src/olympia/addons/templates/addons/impala/developers.html:96
-#: src/olympia/users/templates/users/edit.html:130
-#: src/olympia/users/templates/users/profile.html:26
+#: src/olympia/addons/templates/addons/impala/developers.html:96 src/olympia/users/templates/users/edit.html:130 src/olympia/users/templates/users/profile.html:26
 msgid "No Photo"
 msgstr "사진 없음"
 
@@ -1474,24 +1136,15 @@ msgstr "이 부가 기능은 관리자에 의해 사용 정지 되었습니다."
 msgid "Source Code License for {addon}"
 msgstr "{addon}의 소스 코드 라이선스"
 
-#: src/olympia/addons/templates/addons/impala/license.html:21
-#: src/olympia/versions/templates/versions/mobile/version.html:18
+#: src/olympia/addons/templates/addons/impala/license.html:21 src/olympia/versions/templates/versions/mobile/version.html:18
 msgid "Source Code License"
 msgstr "소스 코드라이선스"
 
-#: src/olympia/addons/templates/addons/impala/persona_grid.html:16
-#: src/olympia/addons/templates/addons/impala/toplist.html:6
-msgid "{0} users"
-msgstr "사용자 {0}명"
-
-#: src/olympia/addons/templates/addons/impala/review_list_box.html:19
-#: src/olympia/reviews/templates/reviews/review.html:40
+#: src/olympia/addons/templates/addons/impala/review_list_box.html:19 src/olympia/reviews/templates/reviews/review.html:40
 msgid "permalink"
 msgstr "고유 주소"
 
-#: src/olympia/addons/templates/addons/impala/review_list_box.html:23
-#: src/olympia/editors/templates/editors/queue.html:98
-#: src/olympia/reviews/templates/reviews/review.html:44
+#: src/olympia/addons/templates/addons/impala/review_list_box.html:23 src/olympia/editors/templates/editors/queue.html:104 src/olympia/reviews/templates/reviews/review.html:44
 msgid "translate"
 msgstr "번역하기"
 
@@ -1500,9 +1153,9 @@ msgstr "번역하기"
 msgid "See all user reviews"
 msgid_plural "See all %(cnt)s user reviews"
 msgstr[0] "사용자 평가 전부 보기"
+msgstr[1] ""
 
-#: src/olympia/addons/templates/addons/impala/review_list_box.html:47
-#: src/olympia/reviews/templates/reviews/review_list.html:84
+#: src/olympia/addons/templates/addons/impala/review_list_box.html:47 src/olympia/reviews/templates/reviews/review_list.html:84
 msgid "This add-on has not yet been reviewed."
 msgstr "이 부가 기능은 아직 심사를 거치지 않았습니다."
 
@@ -1510,24 +1163,23 @@ msgstr "이 부가 기능은 아직 심사를 거치지 않았습니다."
 msgid "Be the first!"
 msgstr "1등으로 달아보세요!"
 
-#: src/olympia/addons/templates/addons/impala/listing/sorter.html:14
-#: src/olympia/devhub/templates/devhub/addons/listing/item_actions.html:49
+#: src/olympia/addons/templates/addons/impala/toplist.html:6
+msgid "{0} users"
+msgstr "사용자 {0}명"
+
+#: src/olympia/addons/templates/addons/impala/listing/sorter.html:14 src/olympia/devhub/templates/devhub/addons/listing/item_actions.html:49
 msgid "More"
 msgstr "더 보기"
 
-#: src/olympia/addons/templates/addons/includes/collection_add_widget.html:7
-#: src/olympia/addons/templates/addons/includes/collection_add_widget.html:10
+#: src/olympia/addons/templates/addons/includes/collection_add_widget.html:7 src/olympia/addons/templates/addons/includes/collection_add_widget.html:10
 msgid "Add to collection"
 msgstr "모음집에 추가하기"
 
-#: src/olympia/addons/templates/addons/includes/dashboard_tabs.html:4
-#: src/olympia/devhub/templates/devhub/index.html:73
-#: src/olympia/devhub/templates/devhub/nav.html:14
+#: src/olympia/addons/templates/addons/includes/dashboard_tabs.html:4 src/olympia/devhub/templates/devhub/index.html:73 src/olympia/devhub/templates/devhub/nav.html:14
 msgid "My Add-ons"
 msgstr "나의 부가 기능"
 
-#: src/olympia/addons/templates/addons/includes/dashboard_tabs.html:6
-#: src/olympia/amo/context_processors.py:51
+#: src/olympia/addons/templates/addons/includes/dashboard_tabs.html:6 src/olympia/amo/context_processors.py:52
 msgid "My Themes"
 msgstr "내 테마"
 
@@ -1543,8 +1195,7 @@ msgstr "테마 수정하기"
 msgid "Approve / Reject"
 msgstr "승인 / 거부"
 
-#: src/olympia/addons/templates/addons/includes/persona.html:25
-#: src/olympia/editors/templates/editors/themes/single.html:43
+#: src/olympia/addons/templates/addons/includes/persona.html:25 src/olympia/editors/templates/editors/themes/single.html:43
 msgid "Review History"
 msgstr "심사 기록"
 
@@ -1565,12 +1216,11 @@ msgid "Not Yet Rated"
 msgstr "아직 별점 없음"
 
 #. {0} is the number of downloads.
-#: src/olympia/addons/templates/addons/listing/items_mobile.html:27
-#: src/olympia/addons/templates/addons/listing/macros.html:24
-#: src/olympia/devhub/templates/devhub/addons/listing/macros.html:15
+#: src/olympia/addons/templates/addons/listing/items_mobile.html:27 src/olympia/addons/templates/addons/listing/macros.html:24 src/olympia/devhub/templates/devhub/addons/listing/macros.html:15
 msgid "<strong>{0}</strong> weekly download"
 msgid_plural "<strong>{0}</strong> weekly downloads"
 msgstr[0] "주간 다운로드 <strong>{0}</strong>회"
+msgstr[1] ""
 
 #: src/olympia/addons/templates/addons/mobile/details.html:32
 msgid "Read More"
@@ -1580,15 +1230,11 @@ msgstr "더 보기"
 msgid "Users"
 msgstr "사용자"
 
-#: src/olympia/addons/templates/addons/mobile/details.html:92
-#: src/olympia/browse/views.py:59 src/olympia/browse/views.py:70
-#: src/olympia/search/forms.py:90
+#: src/olympia/addons/templates/addons/mobile/details.html:92 src/olympia/browse/views.py:59 src/olympia/browse/views.py:70 src/olympia/search/forms.py:90
 msgid "Weekly Downloads"
 msgstr "주간 다운로드"
 
-#: src/olympia/addons/templates/addons/mobile/details.html:99
-#: src/olympia/compat/templates/compat/reporter_detail.html:46
-#: src/olympia/devhub/forms.py:787
+#: src/olympia/addons/templates/addons/mobile/details.html:99 src/olympia/compat/templates/compat/reporter_detail.html:46 src/olympia/devhub/forms.py:788
 #: src/olympia/devhub/templates/devhub/versions/list.html:163
 msgid "Version"
 msgstr "버전"
@@ -1624,48 +1270,29 @@ msgstr "라이선스 동의서"
 
 #: src/olympia/addons/templates/addons/mobile/eula.html:5
 #, python-format
-msgid ""
-"%(name)s requires that you accept the following End-User License Agreement "
-"before installation can proceed:"
+msgid "%(name)s requires that you accept the following End-User License Agreement before installation can proceed:"
 msgstr "%(name)s이(가) 설치 작업을 수행하기에 앞서 다음의 최종 사용자 라이선스 동의서에 동의하기를 요구하고 있습니다:"
 
 #: src/olympia/addons/templates/addons/mobile/eula.html:15
 msgid "Accept"
 msgstr "동의"
 
-#: src/olympia/addons/templates/addons/mobile/home.html:10
-#: src/olympia/templates/mobile/base_addons.html:53
+#: src/olympia/addons/templates/addons/mobile/home.html:10 src/olympia/templates/mobile/base_addons.html:53
 msgid "Add-ons are not currently available on Firefox for iOS."
 msgstr ""
 
-#: src/olympia/addons/templates/addons/mobile/home.html:12
-#: src/olympia/templates/mobile/base_addons.html:55
-msgid ""
-"You need Firefox to install add-ons. <a "
-"href=\"http://mozilla.com/mobile\">Learn More&nbsp;&raquo;</a>"
-msgstr ""
-"부가 기능을 설치하려면 Firefox가 필요합니다. <a href=\"http://mozilla.com/mobile\">자세히 "
-"알아보기&nbsp;&raquo;</a>"
+#: src/olympia/addons/templates/addons/mobile/home.html:12 src/olympia/templates/mobile/base_addons.html:55
+msgid "You need Firefox to install add-ons. <a href=\"http://mozilla.com/mobile\">Learn More&nbsp;&raquo;</a>"
+msgstr "부가 기능을 설치하려면 Firefox가 필요합니다. <a href=\"http://mozilla.com/mobile\">자세히 알아보기&nbsp;&raquo;</a>"
 
 # {0} is the application name.  Example:  Firefox
-#: src/olympia/addons/templates/addons/mobile/home.html:19
-#: src/olympia/templates/header_title.html:4
-#: src/olympia/templates/impala/header_title.html:3
+#: src/olympia/addons/templates/addons/mobile/home.html:19 src/olympia/templates/header_title.html:4 src/olympia/templates/impala/header_title.html:3
 msgid "Return to the {0} Add-ons homepage"
 msgstr "{0} 부가 기능 대문으로 돌아가기"
 
-#: src/olympia/addons/templates/addons/mobile/home.html:21
-#: src/olympia/amo/helpers.py:237
-#: src/olympia/bandwagon/templates/bandwagon/edit.html:34
-#: src/olympia/discovery/templates/discovery/pane.html:92
-#: src/olympia/editors/templates/editors/base.html:21
-#: src/olympia/editors/templates/editors/performance.html:72
-#: src/olympia/templates/menu_links.html:4
-#: src/olympia/templates/impala/header_title.html:13
-#: src/olympia/templates/impala/header_title.html:15
-#: src/olympia/templates/impala/header_title.html:19
-#: src/olympia/templates/impala/header_title.html:23
-#: src/olympia/templates/mobile/base_addons.html:47
+#: src/olympia/addons/templates/addons/mobile/home.html:21 src/olympia/amo/helpers.py:237 src/olympia/bandwagon/templates/bandwagon/edit.html:34 src/olympia/discovery/templates/discovery/pane.html:92
+#: src/olympia/editors/templates/editors/base.html:21 src/olympia/editors/templates/editors/performance.html:72 src/olympia/templates/menu_links.html:4 src/olympia/templates/impala/header_title.html:13
+#: src/olympia/templates/impala/header_title.html:15 src/olympia/templates/impala/header_title.html:19 src/olympia/templates/impala/header_title.html:23 src/olympia/templates/mobile/base_addons.html:47
 msgid "Add-ons"
 msgstr "부가 기능"
 
@@ -1673,46 +1300,25 @@ msgstr "부가 기능"
 msgid "Easy ways to personalize."
 msgstr "개인화를 쉽게 하는 방법."
 
-#: src/olympia/addons/templates/addons/mobile/home.html:24
-#: src/olympia/devhub/templates/devhub/addons/submit/done.html:47
-#: src/olympia/discovery/templates/discovery/pane.html:34
-#: src/olympia/discovery/templates/discovery/addons/detail.html:16
-#: src/olympia/discovery/templates/discovery/modules/featured.html:21
-#: src/olympia/discovery/templates/discovery/modules/monthly.html:22
+#: src/olympia/addons/templates/addons/mobile/home.html:24 src/olympia/devhub/templates/devhub/addons/submit/done.html:47 src/olympia/discovery/templates/discovery/pane.html:34
+#: src/olympia/discovery/templates/discovery/addons/detail.html:16 src/olympia/discovery/templates/discovery/modules/featured.html:21 src/olympia/discovery/templates/discovery/modules/monthly.html:22
 msgid "Learn More"
 msgstr "더 알아보기"
 
 #: src/olympia/addons/templates/addons/mobile/home.html:26
 msgid ""
-"Add-ons are applications that let you personalize Firefox with extra "
-"functionality and style. Whether you mistype the name of a website or can't "
-"read a busy page, there's an add-on to improve your on-the-go browsing."
-msgstr ""
-"부가 기능이란 Firefox에 추가 기능과 스타일을 마음대로 넣을 수 있게 하는 애플리케이션을 말합니다. 웹사이트 주소를 잘못 입력하거나"
-" 웹사이트가 과부하라 로딩이 안될때, 부가 기능이 있으면 향상된 웹서핑을 가능하게 해줍니다."
+"Add-ons are applications that let you personalize Firefox with extra functionality and style. Whether you mistype the name of a website or can't read a busy page, there's an add-on to improve your "
+"on-the-go browsing."
+msgstr "부가 기능이란 Firefox에 추가 기능과 스타일을 마음대로 넣을 수 있게 하는 애플리케이션을 말합니다. 웹사이트 주소를 잘못 입력하거나 웹사이트가 과부하라 로딩이 안될때, 부가 기능이 있으면 향상된 웹서핑을 가능하게 해줍니다."
 
 #. {0} is a category name. Ex: "Sports"
 #. {0} is a category name, such as Nature.
-#: src/olympia/addons/templates/addons/mobile/home.html:43
-#: src/olympia/amo/templates/amo/site_nav.html:32
-#: src/olympia/browse/feeds.py:107
-#: src/olympia/browse/templates/browse/impala/base_listing.html:38
-#: src/olympia/browse/templates/browse/personas/base.html:6
-#: src/olympia/browse/templates/browse/personas/base.html:42
-#: src/olympia/browse/templates/browse/personas/category_landing.html:21
-#: src/olympia/browse/templates/browse/personas/category_landing.html:23
-#: src/olympia/browse/templates/browse/personas/category_landing.html:38
-#: src/olympia/browse/templates/browse/personas/grid.html:7
-#: src/olympia/browse/templates/browse/personas/grid.html:11
-#: src/olympia/browse/templates/browse/personas/mobile/base.html:7
-#: src/olympia/browse/templates/browse/personas/mobile/category_landing.html:19
-#: src/olympia/constants/base.py:180
-#: src/olympia/devhub/templates/devhub/personas/submit.html:13
-#: src/olympia/editors/helpers.py:105
-#: src/olympia/editors/templates/editors/base.html:26
-#: src/olympia/editors/templates/editors/performance.html:73
-#: src/olympia/search/templates/search/personas.html:39
-#: src/olympia/templates/menu_links.html:9
+#: src/olympia/addons/templates/addons/mobile/home.html:43 src/olympia/amo/templates/amo/site_nav.html:32 src/olympia/browse/feeds.py:107 src/olympia/browse/templates/browse/impala/base_listing.html:38
+#: src/olympia/browse/templates/browse/personas/base.html:6 src/olympia/browse/templates/browse/personas/base.html:42 src/olympia/browse/templates/browse/personas/category_landing.html:21
+#: src/olympia/browse/templates/browse/personas/category_landing.html:23 src/olympia/browse/templates/browse/personas/category_landing.html:38 src/olympia/browse/templates/browse/personas/grid.html:7
+#: src/olympia/browse/templates/browse/personas/grid.html:11 src/olympia/browse/templates/browse/personas/mobile/base.html:7 src/olympia/browse/templates/browse/personas/mobile/category_landing.html:19
+#: src/olympia/constants/base.py:180 src/olympia/devhub/templates/devhub/personas/submit.html:13 src/olympia/editors/helpers.py:107 src/olympia/editors/templates/editors/base.html:26
+#: src/olympia/editors/templates/editors/performance.html:73 src/olympia/search/templates/search/personas.html:39 src/olympia/templates/menu_links.html:9
 msgid "Themes"
 msgstr "테마"
 
@@ -1728,19 +1334,12 @@ msgstr "인기 부가 기능 전부 보기"
 msgid "More Add-ons"
 msgstr "그밖의 부가 기능"
 
-#: src/olympia/addons/templates/addons/mobile/home.html:72
-#: src/olympia/browse/templates/browse/personas/mobile/category_landing.html:64
-#: src/olympia/search/forms.py:14
+#: src/olympia/addons/templates/addons/mobile/home.html:72 src/olympia/browse/templates/browse/personas/mobile/category_landing.html:64 src/olympia/search/forms.py:14
 msgid "Highest Rated"
 msgstr "상위 평가도"
 
-#: src/olympia/addons/templates/addons/mobile/home.html:74
-#: src/olympia/amo/templates/amo/side_nav.html:5
-#: src/olympia/amo/templates/amo/site_nav.html:27
-#: src/olympia/amo/templates/amo/site_nav.html:57
-#: src/olympia/bandwagon/views.py:97 src/olympia/browse/views.py:57
-#: src/olympia/browse/views.py:67
-#: src/olympia/browse/templates/browse/personas/mobile/category_landing.html:65
+#: src/olympia/addons/templates/addons/mobile/home.html:74 src/olympia/amo/templates/amo/side_nav.html:5 src/olympia/amo/templates/amo/site_nav.html:27 src/olympia/amo/templates/amo/site_nav.html:55
+#: src/olympia/bandwagon/views.py:97 src/olympia/browse/views.py:57 src/olympia/browse/views.py:67 src/olympia/browse/templates/browse/personas/mobile/category_landing.html:65
 #: src/olympia/search/forms.py:15 src/olympia/search/forms.py:87
 msgid "Newest"
 msgstr "신규 등록"
@@ -1753,122 +1352,88 @@ msgstr "써봅시다!"
 msgid "Theme Info &raquo;"
 msgstr "테마 정보 &raquo;"
 
-#: src/olympia/amo/context_processors.py:39
-#: src/olympia/devhub/templates/devhub/nav.html:43
+#: src/olympia/amo/context_processors.py:39 src/olympia/devhub/templates/devhub/nav.html:43
 msgid "Tools"
 msgstr "도구"
 
-#: src/olympia/amo/context_processors.py:48
-#: src/olympia/discovery/templates/discovery/pane_account.html:8
-#: src/olympia/users/templates/users/includes/navigation.html:2
+#: src/olympia/amo/context_processors.py:49 src/olympia/discovery/templates/discovery/pane_account.html:8 src/olympia/users/templates/users/includes/navigation.html:2
 msgid "My Profile"
 msgstr "내 프로필"
 
-#: src/olympia/amo/context_processors.py:54
-#: src/olympia/users/templates/users/edit.html:5
-#: src/olympia/users/templates/users/includes/navigation.html:3
+#: src/olympia/amo/context_processors.py:55 src/olympia/users/templates/users/edit.html:5 src/olympia/users/templates/users/includes/navigation.html:3
 msgid "Account Settings"
 msgstr "계정 설정"
 
-#: src/olympia/amo/context_processors.py:57
-#: src/olympia/discovery/templates/discovery/pane_account.html:11
-#: src/olympia/users/templates/users/profile.html:83
+#: src/olympia/amo/context_processors.py:58 src/olympia/discovery/templates/discovery/pane_account.html:11 src/olympia/users/templates/users/profile.html:83
 #: src/olympia/users/templates/users/includes/navigation.html:4
 msgid "My Collections"
 msgstr "내 모음집"
 
-#: src/olympia/amo/context_processors.py:62
-#: src/olympia/discovery/templates/discovery/pane_account.html:10
-#: src/olympia/users/templates/users/includes/navigation.html:7
+#: src/olympia/amo/context_processors.py:63 src/olympia/discovery/templates/discovery/pane_account.html:10 src/olympia/users/templates/users/includes/navigation.html:7
 msgid "My Favorites"
 msgstr "내 선호목록"
 
-#: src/olympia/amo/context_processors.py:67
-#: src/olympia/discovery/templates/discovery/pane_account.html:13
-#: src/olympia/templates/impala/user_login.html:14
-#: src/olympia/templates/mobile/header_auth.html:5
+#: src/olympia/amo/context_processors.py:68 src/olympia/discovery/templates/discovery/pane_account.html:13 src/olympia/templates/impala/user_login.html:14 src/olympia/templates/mobile/header_auth.html:5
 msgid "Log out"
 msgstr "로그아웃"
 
-#: src/olympia/amo/context_processors.py:72
-#: src/olympia/devhub/templates/devhub/addons/dashboard.html:4
+#: src/olympia/amo/context_processors.py:73 src/olympia/devhub/templates/devhub/addons/dashboard.html:4
 msgid "Manage My Submissions"
 msgstr "제출 내역 관리하기"
 
-#: src/olympia/amo/context_processors.py:75
-#: src/olympia/devhub/templates/devhub/nav.html:27
-#: src/olympia/devhub/templates/devhub/addons/dashboard.html:25
+#: src/olympia/amo/context_processors.py:76 src/olympia/devhub/templates/devhub/nav.html:27 src/olympia/devhub/templates/devhub/addons/dashboard.html:25
 #: src/olympia/devhub/templates/devhub/addons/submit/base.html:4
 msgid "Submit a New Add-on"
 msgstr "새 부가 기능 등록"
 
-#: src/olympia/amo/context_processors.py:77
-#: src/olympia/browse/templates/browse/personas/base.html:50
-#: src/olympia/devhub/templates/devhub/index.html:24
+#: src/olympia/amo/context_processors.py:78 src/olympia/browse/templates/browse/personas/base.html:50 src/olympia/devhub/templates/devhub/index.html:24
 #: src/olympia/devhub/templates/devhub/addons/dashboard.html:29
 msgid "Submit a New Theme"
 msgstr "새로운 테마 올리기"
 
-#: src/olympia/amo/context_processors.py:79
-#: src/olympia/amo/templates/amo/site_nav.html:87
-#: src/olympia/devhub/helpers.py:36 src/olympia/devhub/helpers.py:68
-#: src/olympia/devhub/helpers.py:102 src/olympia/templates/footer.html:6
-#: src/olympia/templates/menu_links.html:14
+#: src/olympia/amo/context_processors.py:80 src/olympia/amo/templates/amo/site_nav.html:85 src/olympia/devhub/helpers.py:36 src/olympia/devhub/helpers.py:68 src/olympia/devhub/helpers.py:102
+#: src/olympia/templates/footer.html:6 src/olympia/templates/menu_links.html:14
 msgid "Developer Hub"
 msgstr "개발자 허브"
 
-#: src/olympia/amo/context_processors.py:83 src/olympia/devhub/views.py:1792
+#: src/olympia/amo/context_processors.py:84 src/olympia/devhub/views.py:1799
 msgid "Manage API Keys"
 msgstr ""
 
-#: src/olympia/amo/context_processors.py:88 src/olympia/editors/helpers.py:82
-#: src/olympia/editors/helpers.py:102
-#: src/olympia/editors/templates/editors/base.html:10
+#: src/olympia/amo/context_processors.py:89 src/olympia/editors/helpers.py:84 src/olympia/editors/helpers.py:104 src/olympia/editors/templates/editors/base.html:10
 msgid "Editor Tools"
 msgstr "편집자 도구"
 
-#: src/olympia/amo/context_processors.py:92
+#: src/olympia/amo/context_processors.py:93
 msgid "Admin Tools"
 msgstr "관리자 도구"
 
-#: src/olympia/amo/fields.py:15
+#: src/olympia/amo/fields.py:20
 msgid "Incorrect, please try again."
 msgstr ""
 
-#: src/olympia/amo/fields.py:16
+#: src/olympia/amo/fields.py:21
 msgid "Error verifying input, please try again."
 msgstr ""
 
-#: src/olympia/amo/fields.py:32
+#: src/olympia/amo/fields.py:37
 msgid "This must be a valid hex color code, such as #000000."
 msgstr "#000000 처럼 올바른 16진수 색상 코드를 입력해야 합니다."
 
-#: src/olympia/amo/fields.py:58
+#: src/olympia/amo/fields.py:63
 msgid "Enter at least one value."
 msgstr "한개 이상의 값을 입력해 주세요."
 
-#: src/olympia/amo/helpers.py:162
-#: src/olympia/amo/templates/amo/site_nav.html:61
-#: src/olympia/bandwagon/templates/bandwagon/add.html:9
-#: src/olympia/bandwagon/templates/bandwagon/collection_detail.html:15
-#: src/olympia/bandwagon/templates/bandwagon/delete.html:9
-#: src/olympia/bandwagon/templates/bandwagon/edit.html:15
-#: src/olympia/bandwagon/templates/bandwagon/user_listing.html:18
-#: src/olympia/bandwagon/templates/bandwagon/user_listing.html:21
-#: src/olympia/bandwagon/templates/bandwagon/impala/collection_listing.html:12
-#: src/olympia/bandwagon/templates/bandwagon/impala/collection_listing.html:20
-#: src/olympia/bandwagon/templates/bandwagon/impala/collection_listing.html:24
-#: src/olympia/bandwagon/templates/bandwagon/impala/collection_sidebar.html:3
-#: src/olympia/bandwagon/templates/bandwagon/includes/collection_sidebar.html:2
-#: src/olympia/bandwagon/templates/bandwagon/mobile/collection_listing.html:3
-#: src/olympia/stats/templates/stats/stats.html:77
-#: src/olympia/templates/menu_links.html:12
+#: src/olympia/amo/helpers.py:162 src/olympia/amo/templates/amo/site_nav.html:59 src/olympia/bandwagon/templates/bandwagon/add.html:9 src/olympia/bandwagon/templates/bandwagon/collection_detail.html:15
+#: src/olympia/bandwagon/templates/bandwagon/delete.html:9 src/olympia/bandwagon/templates/bandwagon/edit.html:15 src/olympia/bandwagon/templates/bandwagon/user_listing.html:18
+#: src/olympia/bandwagon/templates/bandwagon/user_listing.html:21 src/olympia/bandwagon/templates/bandwagon/impala/collection_listing.html:12
+#: src/olympia/bandwagon/templates/bandwagon/impala/collection_listing.html:20 src/olympia/bandwagon/templates/bandwagon/impala/collection_listing.html:24
+#: src/olympia/bandwagon/templates/bandwagon/impala/collection_sidebar.html:3 src/olympia/bandwagon/templates/bandwagon/includes/collection_sidebar.html:2
+#: src/olympia/bandwagon/templates/bandwagon/mobile/collection_listing.html:3 src/olympia/stats/templates/stats/stats.html:33 src/olympia/templates/menu_links.html:12
 msgid "Collections"
 msgstr "모음집"
 
-#: src/olympia/amo/helpers.py:171
-#: src/olympia/amo/templates/amo/site_nav.html:85
-#: src/olympia/browse/templates/browse/language_tools.html:3
+#: src/olympia/amo/helpers.py:171 src/olympia/amo/templates/amo/site_nav.html:83 src/olympia/browse/templates/browse/language_tools.html:3
 msgid "Dictionaries & Language Packs"
 msgstr "맞춤법 사전 및 언어팩"
 
@@ -2022,11 +1587,8 @@ msgstr "상급 심사 요청됨"
 msgid "Comment on {addon} {version}."
 msgstr "{addon} {version}에 코멘트가 달렸습니다."
 
-#: src/olympia/amo/log.py:236
-#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:19
-#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:47
-#: src/olympia/editors/helpers.py:511
-#: src/olympia/editors/templates/editors/themes/history_table.html:11
+#: src/olympia/amo/log.py:236 src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:17 src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:45
+#: src/olympia/editors/helpers.py:584 src/olympia/editors/templates/editors/themes/history_table.html:11
 msgid "Comment"
 msgstr "코멘트"
 
@@ -2284,10 +1846,7 @@ msgstr "{addon} 콘텐츠 등급을 변경하였습니다."
 msgid "{addon} unlisted."
 msgstr ""
 
-#: src/olympia/amo/log.py:592 src/olympia/amo/log.py:598
-#: src/olympia/amo/log.py:612 src/olympia/amo/log.py:618
-#: src/olympia/amo/log.py:624 src/olympia/amo/log.py:630
-#: src/olympia/amo/log.py:636
+#: src/olympia/amo/log.py:592 src/olympia/amo/log.py:598 src/olympia/amo/log.py:612 src/olympia/amo/log.py:618 src/olympia/amo/log.py:624 src/olympia/amo/log.py:630 src/olympia/amo/log.py:636
 msgid "{file} was signed."
 msgstr ""
 
@@ -2301,15 +1860,11 @@ msgid "Not allowed"
 msgstr "허가 안됨"
 
 #: src/olympia/amo/templates/amo/403.html:7
-msgid ""
-"<h1>Oops! Not allowed.</h1> <p>You tried to do something that you weren't "
-"allowed to.</p>"
+msgid "<h1>Oops! Not allowed.</h1> <p>You tried to do something that you weren't allowed to.</p>"
 msgstr "<h1>이런! 허용되지 않은 작업입니다.</h1> <p>허용되지 않은 작업을 시도하셨습니다.</p>"
 
 #: src/olympia/amo/templates/amo/403.html:12
-msgid ""
-"<p>Try going back to the previous page, refreshing and then trying "
-"again.</p>"
+msgid "<p>Try going back to the previous page, refreshing and then trying again.</p>"
 msgstr "<p>이전 페이지로 돌아가려고 하고 있습니다. 새로고침 한 다음 다시 시도해 주세요.</p>"
 
 #: src/olympia/amo/templates/amo/404.html:3
@@ -2319,31 +1874,17 @@ msgstr "찾을 수 없습니다."
 #: src/olympia/amo/templates/amo/404.html:6
 #, python-format
 msgid ""
-"<h1>We're sorry, but we can't find what you're looking for.</h1> <p> The "
-"page or file you requested wasn't found on our site. It's possible that you "
-"clicked a link that's out of date, or typed in the address incorrectly. </p>"
-" <ul> <li>If you typed in the address, please double check the "
-"spelling.</li> <li> If you followed a link from somewhere, please let us "
-"know at <a href=\"mailto:webmaster@mozilla.com\">webmaster@mozilla.com</a>. "
-"Tell us where you came from and what you were looking for, and we'll do our "
-"best to fix it. </li> </ul> <p>Or you can just jump over to some of the "
-"popular pages on our website.</p> <ul> <li>Are you interested in a <a "
-"href=\"%(rec)s\">list of featured add-ons</a>?</li> <li> Do you want to <a "
-"href=\"%(search)s\">search for add-ons</a>? You may go to the <a "
-"href=\"%(search)s\">search page</a> or just use the search field above. "
-"</li> <li> If you prefer to start over, just go to the <a href=\"%(home)s"
-"\">add-ons front page</a>. </li> </ul>"
+"<h1>We're sorry, but we can't find what you're looking for.</h1> <p> The page or file you requested wasn't found on our site. It's possible that you clicked a link that's out of date, or typed in "
+"the address incorrectly. </p> <ul> <li>If you typed in the address, please double check the spelling.</li> <li> If you followed a link from somewhere, please let us know at <a "
+"href=\"mailto:webmaster@mozilla.com\">webmaster@mozilla.com</a>. Tell us where you came from and what you were looking for, and we'll do our best to fix it. </li> </ul> <p>Or you can just jump over"
+" to some of the popular pages on our website.</p> <ul> <li>Are you interested in a <a href=\"%(rec)s\">list of featured add-ons</a>?</li> <li> Do you want to <a href=\"%(search)s\">search for add-"
+"ons</a>? You may go to the <a href=\"%(search)s\">search page</a> or just use the search field above. </li> <li> If you prefer to start over, just go to the <a href=\"%(home)s\">add-ons front "
+"page</a>. </li> </ul>"
 msgstr ""
-"<h1>죄송합니다. 현재 찾으시는 것을 발견하지 못했습니다.</h1> <p> 찾고자 하시는 페이지나 파일은 저희 사이트 내에 없었습니다."
-" 너무 오래된 링크를 클릭했거나 주소를 정확히 입력하지 않았을 수도 있습니다. </p> <ul> <li>주소를 입력하신 거였다면 주소 "
-"철자를 다시 한번 점검해 보시기 바랍니다.</li> <li> 다른 사이트에 올라온 링크를 따라서 오신 거라면 <a "
-"href=\"mailto:webmaster@mozilla.com\">webmaster@mozilla.com 주소를 통해 저희에게 연락해 "
-"주십시오</a>. 사이트의 이름과 어떤 것을 찾고 있었는지 말씀해 주시면 저희가 최선을 다해 수정하도록 하겠습니다. </li> </ul>"
-" <p>저희 웹사이트의 인기 페이지로 가보시는 것도 권해드립니다.</p> <ul> <li><a href=\"%(rec)s\">추천 부가 "
-"기능 목록</a>에 관심이 있으십니까?</li> <li> <a href=\"%(search)s\">부가 기능을 검색</a>하고 "
-"싶으신가요? <a href=\"%(search)s\">검색 페이지</a>로 이동하시거나 윗부분의 검색창을 사용하셔도 됩니다. </li>"
-"  <li> 첫 페이지로 가서 다시 시작하고자 하신다면 <a href=\"%(home)s\">부가 기능 첫 페이지</a>로 이동하시기 "
-"바랍니다. </li> </ul>"
+"<h1>죄송합니다. 현재 찾으시는 것을 발견하지 못했습니다.</h1> <p> 찾고자 하시는 페이지나 파일은 저희 사이트 내에 없었습니다. 너무 오래된 링크를 클릭했거나 주소를 정확히 입력하지 않았을 수도 있습니다. </p> <ul> <li>주소를 입력하신 거였다면 주소 철자를 다시 한번 점검해 보시기 바랍니다.</li> <li> 다른 사이트에 올라온 "
+"링크를 따라서 오신 거라면 <a href=\"mailto:webmaster@mozilla.com\">webmaster@mozilla.com 주소를 통해 저희에게 연락해 주십시오</a>. 사이트의 이름과 어떤 것을 찾고 있었는지 말씀해 주시면 저희가 최선을 다해 수정하도록 하겠습니다. </li> </ul> <p>저희 웹사이트의 인기 페이지로 가보시는 "
+"것도 권해드립니다.</p> <ul> <li><a href=\"%(rec)s\">추천 부가 기능 목록</a>에 관심이 있으십니까?</li> <li> <a href=\"%(search)s\">부가 기능을 검색</a>하고 싶으신가요? <a href=\"%(search)s\">검색 페이지</a>로 이동하시거나 윗부분의 검색창을 사용하셔도 됩니다. </li>"
+"  <li> 첫 페이지로 가서 다시 시작하고자 하신다면 <a href=\"%(home)s\">부가 기능 첫 페이지</a>로 이동하시기 바랍니다. </li> </ul>"
 
 #: src/olympia/amo/templates/amo/500.html:3
 msgid "Oops"
@@ -2351,78 +1892,48 @@ msgstr "앗 이런"
 
 #: src/olympia/amo/templates/amo/500.html:6
 #, python-format
-msgid ""
-"<h1>Oops! We had an error.</h1> <p>We'll get to fixing that soon.</p> <p> "
-"You can try refreshing the page, or head back to the <a href=\"%(home)s"
-"\">Add-ons homepage</a>. </p>"
-msgstr ""
-"<h1>저런! 오류가 발생했습니다.</h1> <p>빠른 시일 내에 고치도록 하겠습니다.</p> <p> 현재 페이지를 새로고침해 보시거나 "
-"<a href=\"%(home)s\">부가 기능 대문</a>으로 돌아가시기 바랍니다. </p>"
+msgid "<h1>Oops! We had an error.</h1> <p>We'll get to fixing that soon.</p> <p> You can try refreshing the page, or head back to the <a href=\"%(home)s\">Add-ons homepage</a>. </p>"
+msgstr "<h1>저런! 오류가 발생했습니다.</h1> <p>빠른 시일 내에 고치도록 하겠습니다.</p> <p> 현재 페이지를 새로고침해 보시거나 <a href=\"%(home)s\">부가 기능 대문</a>으로 돌아가시기 바랍니다. </p>"
 
 #: src/olympia/amo/templates/amo/license_link.html:10
 msgid "Some rights reserved"
 msgstr "Some rights reserved"
 
-#: src/olympia/amo/templates/amo/no_results.html:1
-#: src/olympia/editors/templates/editors/includes/search_results_themes.html:26
+#: src/olympia/amo/templates/amo/no_results.html:1 src/olympia/editors/templates/editors/includes/search_results_themes.html:26
 msgid "No results found"
 msgstr "결과 없음"
 
 #. abbreviation of 'previous'
-#: src/olympia/amo/templates/amo/paginator.html:6
-#: src/olympia/amo/templates/amo/mobile/paginator.html:4
-#: src/olympia/amo/templates/amo/mobile/paginator.html:6
-#: src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:49
-#: src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:63
-#: src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:76
-#: src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:89
+#: src/olympia/amo/templates/amo/paginator.html:6 src/olympia/amo/templates/amo/mobile/paginator.html:4 src/olympia/amo/templates/amo/mobile/paginator.html:6
+#: src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:49 src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:63
+#: src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:76 src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:89
 #: src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:102
 msgid "Prev"
 msgstr "이전"
 
-#: src/olympia/amo/templates/amo/paginator.html:26
-#: src/olympia/amo/templates/amo/impala/paginator.html:26
-#: src/olympia/amo/templates/amo/mobile/impala_paginator.html:16
-#: src/olympia/amo/templates/amo/mobile/paginator.html:14
-#: src/olympia/amo/templates/amo/mobile/paginator.html:16
-#: src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:51
-#: src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:65
-#: src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:78
-#: src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:91
-#: src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:104
-#: src/olympia/discovery/templates/discovery/pane.html:45
-#: src/olympia/discovery/templates/discovery/addons/detail.html:39
-#: src/olympia/stats/templates/stats/stats.html:167
+#: src/olympia/amo/templates/amo/paginator.html:26 src/olympia/amo/templates/amo/impala/paginator.html:26 src/olympia/amo/templates/amo/mobile/impala_paginator.html:16
+#: src/olympia/amo/templates/amo/mobile/paginator.html:14 src/olympia/amo/templates/amo/mobile/paginator.html:16 src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:51
+#: src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:65 src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:78
+#: src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:91 src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:104
+#: src/olympia/discovery/templates/discovery/pane.html:45 src/olympia/discovery/templates/discovery/addons/detail.html:39 src/olympia/stats/templates/stats/stats.html:169
 msgid "Next"
 msgstr "다음"
 
-#: src/olympia/amo/templates/amo/paginator.html:32
-#: src/olympia/editors/templates/editors/includes/paginator_history.html:11
+#: src/olympia/amo/templates/amo/paginator.html:32 src/olympia/editors/templates/editors/includes/paginator_history.html:11
 #, python-format
-msgid ""
-"Results <strong>%(begin)s</strong>&ndash;<strong>%(end)s</strong> of "
-"<strong>%(count)s</strong>"
-msgstr ""
-"전체 <strong>%(count)s</strong>개 중 "
-"<strong>%(begin)s</strong>&ndash;<strong>%(end)s</strong>"
+msgid "Results <strong>%(begin)s</strong>&ndash;<strong>%(end)s</strong> of <strong>%(count)s</strong>"
+msgstr "전체 <strong>%(count)s</strong>개 중 <strong>%(begin)s</strong>&ndash;<strong>%(end)s</strong>"
 
-#: src/olympia/amo/templates/amo/read-only.html:3
-#: src/olympia/amo/templates/amo/read-only.html:7
+#: src/olympia/amo/templates/amo/read-only.html:3 src/olympia/amo/templates/amo/read-only.html:7
 msgid "Maintenance in progress"
 msgstr "서버 점검 현황"
 
 #: src/olympia/amo/templates/amo/read-only.html:9
-msgid ""
-"This feature is temporarily disabled while we perform website maintenance. "
-"Please use your browser's Back button and try again a little later."
-msgstr ""
-"웹사이트 점검 관계로 이 기능은 잠시 사용하실 수 없습니다. 웹브라우저의 뒤로 가기 버튼을 사용하신 뒤 잠시 후에 다시 시도하시기 "
-"바랍니다."
+msgid "This feature is temporarily disabled while we perform website maintenance. Please use your browser's Back button and try again a little later."
+msgstr "웹사이트 점검 관계로 이 기능은 잠시 사용하실 수 없습니다. 웹브라우저의 뒤로 가기 버튼을 사용하신 뒤 잠시 후에 다시 시도하시기 바랍니다."
 
 #: src/olympia/amo/templates/amo/read-only.html:14
-msgid ""
-"Some features on this page are temporarily disabled while we perform website"
-" maintenance. Please try again a little later."
+msgid "Some features on this page are temporarily disabled while we perform website maintenance. Please try again a little later."
 msgstr "웹사이트 점검 관계로 이 페이지의 일부 기능을 잠시동안 사용할 수 없습니다. 잠시 후 다시 시도해 주세요."
 
 #: src/olympia/amo/templates/amo/recaptcha.html:4
@@ -2431,20 +1942,12 @@ msgstr "자동 등록 방지"
 
 #: src/olympia/amo/templates/amo/recaptcha.html:8
 msgid ""
-"<p> Please enter <strong>all the words</strong> below, <strong>separated by "
-"a space if necessary</strong>. </p> <p> If this is hard to read, you can <a "
-"href=\"#\" id=\"recaptcha_different\">try different words</a> or <a "
-"href=\"#\" id=\"recaptcha_audio\">try a different type of challenge</a> "
-"instead. </p>"
+"<p> Please enter <strong>all the words</strong> below, <strong>separated by a space if necessary</strong>. </p> <p> If this is hard to read, you can <a href=\"#\" id=\"recaptcha_different\">try "
+"different words</a> or <a href=\"#\" id=\"recaptcha_audio\">try a different type of challenge</a> instead. </p>"
 msgstr ""
 
-#: src/olympia/amo/templates/amo/side_nav.html:4
-#: src/olympia/amo/templates/amo/side_nav.html:12
-#: src/olympia/amo/templates/amo/site_nav.html:4
-#: src/olympia/amo/templates/amo/site_nav.html:26
-#: src/olympia/browse/views.py:56 src/olympia/browse/views.py:66
-#: src/olympia/browse/views.py:237 src/olympia/browse/views.py:282
-#: src/olympia/search/forms.py:86
+#: src/olympia/amo/templates/amo/side_nav.html:4 src/olympia/amo/templates/amo/side_nav.html:12 src/olympia/amo/templates/amo/site_nav.html:4 src/olympia/amo/templates/amo/site_nav.html:26
+#: src/olympia/browse/views.py:56 src/olympia/browse/views.py:66 src/olympia/browse/views.py:204 src/olympia/browse/views.py:249 src/olympia/search/forms.py:86
 msgid "Top Rated"
 msgstr "상위 별점"
 
@@ -2453,81 +1956,59 @@ msgid "Explore"
 msgstr "열기"
 
 # Plural in this context means many of the add-on type
-#: src/olympia/amo/templates/amo/site_nav.html:23
-#: src/olympia/browse/feeds.py:65 src/olympia/browse/feeds.py:78
-#: src/olympia/browse/feeds.py:92 src/olympia/browse/feeds.py:100
-#: src/olympia/browse/templates/browse/base_listing.html:7
-#: src/olympia/browse/templates/browse/creatured.html:10
-#: src/olympia/browse/templates/browse/impala/base_listing.html:37
+#: src/olympia/amo/templates/amo/site_nav.html:23 src/olympia/browse/feeds.py:65 src/olympia/browse/feeds.py:78 src/olympia/browse/feeds.py:92 src/olympia/browse/feeds.py:100
+#: src/olympia/browse/templates/browse/base_listing.html:7 src/olympia/browse/templates/browse/creatured.html:10 src/olympia/browse/templates/browse/impala/base_listing.html:37
 #: src/olympia/constants/base.py:173 src/olympia/templates/menu_links.html:8
 msgid "Extensions"
 msgstr "확장 기능"
 
-#: src/olympia/amo/templates/amo/site_nav.html:45
+#: src/olympia/amo/templates/amo/site_nav.html:44
 msgid "Want more customization? Try <b>Complete Themes</b>"
 msgstr ""
 
-#: src/olympia/amo/templates/amo/site_nav.html:56
-#: src/olympia/bandwagon/views.py:96
+#: src/olympia/amo/templates/amo/site_nav.html:54 src/olympia/bandwagon/views.py:96
 msgid "Most Followers"
 msgstr "최대 팔로워 수"
 
-#: src/olympia/amo/templates/amo/site_nav.html:68
-#: src/olympia/bandwagon/templates/bandwagon/impala/collection_sidebar.html:16
-#: src/olympia/bandwagon/templates/bandwagon/includes/collection_sidebar.html:18
+#: src/olympia/amo/templates/amo/site_nav.html:66 src/olympia/bandwagon/templates/bandwagon/impala/collection_sidebar.html:16 src/olympia/bandwagon/templates/bandwagon/includes/collection_sidebar.html:18
 msgid "Collections I've Made"
 msgstr "내가 만든 모음집"
 
-#: src/olympia/amo/templates/amo/site_nav.html:70
-#: src/olympia/bandwagon/templates/bandwagon/user_listing.html:4
-#: src/olympia/bandwagon/templates/bandwagon/impala/collection_sidebar.html:13
+#: src/olympia/amo/templates/amo/site_nav.html:68 src/olympia/bandwagon/templates/bandwagon/user_listing.html:4 src/olympia/bandwagon/templates/bandwagon/impala/collection_sidebar.html:13
 #: src/olympia/bandwagon/templates/bandwagon/includes/collection_sidebar.html:15
 msgid "Collections I'm Following"
 msgstr "팔로우 중인 모음집"
 
-#: src/olympia/amo/templates/amo/site_nav.html:73
-#: src/olympia/bandwagon/templates/bandwagon/impala/collection_sidebar.html:18
-#: src/olympia/bandwagon/templates/bandwagon/includes/collection_sidebar.html:20
-#: src/olympia/users/models.py:512
+#: src/olympia/amo/templates/amo/site_nav.html:71 src/olympia/bandwagon/templates/bandwagon/impala/collection_sidebar.html:18 src/olympia/bandwagon/templates/bandwagon/includes/collection_sidebar.html:20
+#: src/olympia/users/models.py:521
 msgid "My Favorite Add-ons"
 msgstr "좋아하는 부가 기능"
 
-#: src/olympia/amo/templates/amo/site_nav.html:78
+#: src/olympia/amo/templates/amo/site_nav.html:76
 msgid "More&hellip;"
 msgstr "기타 메뉴&hellip;"
 
-#: src/olympia/amo/templates/amo/site_nav.html:82
+#: src/olympia/amo/templates/amo/site_nav.html:80
 msgid "Add-ons for Mobile"
 msgstr "모바일 부가 기능"
 
-#: src/olympia/amo/templates/amo/site_nav.html:86
-#: src/olympia/browse/feeds.py:207
-#: src/olympia/browse/templates/browse/search_tools.html:3
-#: src/olympia/constants/base.py:176 src/olympia/templates/menu_links.html:10
+#: src/olympia/amo/templates/amo/site_nav.html:84 src/olympia/browse/feeds.py:207 src/olympia/browse/templates/browse/search_tools.html:3 src/olympia/constants/base.py:176
+#: src/olympia/templates/menu_links.html:10
 msgid "Search Tools"
 msgstr "검색 도구"
 
 #. This is a page range (e.g., Page 1 of 50).
-#: src/olympia/amo/templates/amo/impala/paginator.html:5
-#: src/olympia/amo/templates/amo/mobile/impala_paginator.html:26
+#: src/olympia/amo/templates/amo/impala/paginator.html:5 src/olympia/amo/templates/amo/mobile/impala_paginator.html:26
 #, python-format
-msgid ""
-"Page <a href=\"%(current_pg_url)s\">%(current_pg)s</a> of <a "
-"href=\"%(last_pg_url)s\">%(last_pg)s</a>"
-msgstr ""
-"페이지 <a href=\"%(current_pg_url)s\">%(current_pg)s</a> / <a "
-"href=\"%(last_pg_url)s\">%(last_pg)s</a>"
+msgid "Page <a href=\"%(current_pg_url)s\">%(current_pg)s</a> of <a href=\"%(last_pg_url)s\">%(last_pg)s</a>"
+msgstr "페이지 <a href=\"%(current_pg_url)s\">%(current_pg)s</a> / <a href=\"%(last_pg_url)s\">%(last_pg)s</a>"
 
-#: src/olympia/amo/templates/amo/impala/paginator.html:16
-#: src/olympia/amo/templates/amo/mobile/impala_paginator.html:6
+#: src/olympia/amo/templates/amo/impala/paginator.html:16 src/olympia/amo/templates/amo/mobile/impala_paginator.html:6
 msgid "Jump to first page"
 msgstr "첫 페이지로 이동"
 
-#: src/olympia/amo/templates/amo/impala/paginator.html:22
-#: src/olympia/amo/templates/amo/mobile/impala_paginator.html:12
-#: src/olympia/discovery/templates/discovery/pane.html:44
-#: src/olympia/discovery/templates/discovery/addons/detail.html:38
-#: src/olympia/stats/templates/stats/stats.html:164
+#: src/olympia/amo/templates/amo/impala/paginator.html:22 src/olympia/amo/templates/amo/mobile/impala_paginator.html:12 src/olympia/discovery/templates/discovery/pane.html:44
+#: src/olympia/discovery/templates/discovery/addons/detail.html:38 src/olympia/stats/templates/stats/stats.html:166
 msgid "Previous"
 msgstr "이전"
 
@@ -2537,10 +2018,9 @@ msgstr ""
 
 #. First and second arguments are the result range (e.g., 1-20);
 #. third argument is the number of total results (e.g., 1,000).
-#. third
+#. First and second arguments are the result range (e.g., 1-20);              third
 #. argument is the number of total results (e.g., 1,000).
-#: src/olympia/amo/templates/amo/impala/paginator.html:36
-#: src/olympia/amo/templates/amo/mobile/impala_paginator.html:38
+#: src/olympia/amo/templates/amo/impala/paginator.html:36 src/olympia/amo/templates/amo/mobile/impala_paginator.html:38
 #, python-format
 msgid "Showing <b>%(begin)s</b>&ndash;<b>%(end)s</b> of <b>%(count)s</b>"
 msgstr "총 <b>%(count)s</b>개 / <b>%(begin)s</b>&ndash;<b>%(end)s</b> 표시중"
@@ -2549,42 +2029,54 @@ msgstr "총 <b>%(count)s</b>개 / <b>%(begin)s</b>&ndash;<b>%(end)s</b> 표시�
 msgid "Page {n}"
 msgid_plural "Page {n}"
 msgstr[0] "{n} 페이지"
+msgstr[1] ""
 
-#: src/olympia/amo/templates/services/install.html:38
-#, python-format
-msgid ""
-"If you are not prompted to install %(addon_name)s in a moment, please <a "
-"href=\"%(addon_xpi)s\">click here</a>."
-msgstr ""
-"%(addon_name)s 설치를 묻는 창이 나오지 않을 경우 <a href=\"%(addon_xpi)s\">여기를 클릭</a>하세요."
-
-#: src/olympia/amo/tests/test_messages.py:57
-#: src/olympia/amo/tests/test_messages.py:58 src/olympia/reviews/forms.py:25
-#: src/olympia/reviews/forms.py:50
-#: src/olympia/reviews/templates/reviews/add.html:56
+#: src/olympia/amo/tests/test_messages.py:56 src/olympia/amo/tests/test_messages.py:57 src/olympia/reviews/forms.py:25 src/olympia/reviews/forms.py:50 src/olympia/reviews/templates/reviews/add.html:56
 #: src/olympia/reviews/templates/reviews/reply.html:30
 msgid "Title"
 msgstr "제목"
 
-#: src/olympia/amo/tests/test_messages.py:57
-#: src/olympia/amo/tests/test_messages.py:58
+#: src/olympia/amo/tests/test_messages.py:56 src/olympia/amo/tests/test_messages.py:57
 msgid "Body"
 msgstr "본문"
 
-#: src/olympia/amo/tests/test_messages.py:59
+#: src/olympia/amo/tests/test_messages.py:58
 msgid "Another Title"
 msgstr "다른 제목"
 
-#: src/olympia/amo/tests/test_messages.py:59
+#: src/olympia/amo/tests/test_messages.py:58
 msgid "Another Body"
 msgstr "다른 본문"
 
-#: src/olympia/api/views.py:255
-msgid "Not implemented yet."
-msgstr "아직 제대로 작동되지 않습니다."
+#: src/olympia/api/authentication.py:76
+msgid "Signature has expired."
+msgstr ""
 
-#: src/olympia/applications/views.py:39
-#: src/olympia/applications/templates/applications/appversions.html:3
+#: src/olympia/api/authentication.py:79
+msgid "Error decoding signature."
+msgstr ""
+
+#: src/olympia/api/authentication.py:82
+msgid "Invalid JWT Token."
+msgstr ""
+
+#: src/olympia/api/authentication.py:130
+msgid "Invalid Authorization header. No credentials provided."
+msgstr ""
+
+#: src/olympia/api/authentication.py:133
+msgid "Invalid Authorization header. Credentials string should not contain spaces."
+msgstr ""
+
+#: src/olympia/api/fields.py:29
+msgid "The field must have a length of at least {num} characters."
+msgstr ""
+
+#: src/olympia/api/fields.py:31
+msgid "The language code {lang_code} is invalid."
+msgstr ""
+
+#: src/olympia/applications/views.py:39 src/olympia/applications/templates/applications/appversions.html:3
 msgid "Application Versions"
 msgstr "애플리케이션 버전"
 
@@ -2597,19 +2089,15 @@ msgid "Valid Application Versions"
 msgstr "올바른 애플리케이션 버전"
 
 #: src/olympia/applications/templates/applications/appversions.html:12
-msgid ""
-"Add-ons submitted to Mozilla Add-ons must have a manifest file with at least"
-" one of the below applications supported. Only the versions listed below are"
-" allowed for these applications."
+msgid "Add-ons submitted to Mozilla Add-ons must have a manifest file with at least one of the below applications supported. Only the versions listed below are allowed for these applications."
 msgstr ""
 
-#: src/olympia/applications/templates/applications/appversions.html:25
+#: src/olympia/applications/templates/applications/appversions.html:25 src/olympia/editors/helpers.py:361
 msgid "GUID"
 msgstr "GUID"
 
 #. {0} is an add-on name.
-#: src/olympia/applications/templates/applications/appversions.html:26
-#: src/olympia/versions/templates/versions/version_list.html:23
+#: src/olympia/applications/templates/applications/appversions.html:26 src/olympia/versions/templates/versions/version_list.html:23
 msgid "Versions"
 msgstr "버전"
 
@@ -2619,10 +2107,7 @@ msgstr "http://developer.mozilla.org/en/docs/Install_Manifests"
 
 #: src/olympia/applications/templates/applications/appversions.html:31
 #, python-format
-msgid ""
-"If your supported application does not require a manifest file, you still "
-"must include one with the required properties as specified <a "
-"href=\"%(url)s\">here</a>."
+msgid "If your supported application does not require a manifest file, you still must include one with the required properties as specified <a href=\"%(url)s\">here</a>."
 msgstr ""
 
 #. L10n: {0} is 'Add-ons for <app>'.
@@ -2631,10 +2116,8 @@ msgstr ""
 msgid "Collections :: %s"
 msgstr "모음집 :: %s"
 
-#: src/olympia/bandwagon/feeds.py:50
-#: src/olympia/bandwagon/templates/bandwagon/collection_detail.html:137
-msgid ""
-"Collections are groups of related add-ons that anyone can create and share."
+#: src/olympia/bandwagon/feeds.py:50 src/olympia/bandwagon/templates/bandwagon/collection_detail.html:137
+msgid "Collections are groups of related add-ons that anyone can create and share."
 msgstr "모음집은 서로 관련이 있는 부가 기능을 한데 엮어놓은 것으로 누구나 제작과 공유가 가능합니다."
 
 #. L10n: {0} is a collection name, {1} is 'Add-ons for <app>'.
@@ -2686,12 +2169,11 @@ msgstr "링크는 넣을 수 없습니다."
 msgid "This url is already in use by another collection"
 msgstr "이 url은 이미 다른 모음집에서 사용중입니다"
 
-#: src/olympia/bandwagon/forms.py:197 src/olympia/devhub/views.py:1049
+#: src/olympia/bandwagon/forms.py:197 src/olympia/devhub/views.py:1050
 msgid "Icons must be either PNG or JPG."
 msgstr "아이콘은 반드시 PNG나 JPG 형식이어야 합니다."
 
-#: src/olympia/bandwagon/forms.py:202 src/olympia/devhub/views.py:1067
-#: src/olympia/users/forms.py:476
+#: src/olympia/bandwagon/forms.py:202 src/olympia/devhub/views.py:1068 src/olympia/users/forms.py:476
 #, python-format
 msgid "Please use images smaller than %dMB."
 msgstr "%dMB보다 작은 이미지를 사용해 주세요."
@@ -2712,8 +2194,7 @@ msgstr "이 모음집에서 내 표 삭제하기"
 msgid "Log in to vote for this collection"
 msgstr "이 모음집에 투표하려면 로그인 하세요."
 
-#: src/olympia/bandwagon/helpers.py:123
-#: src/olympia/bandwagon/templates/bandwagon/favorites_widget.html:2
+#: src/olympia/bandwagon/helpers.py:123 src/olympia/bandwagon/templates/bandwagon/favorites_widget.html:2
 msgid "Add to favorites"
 msgstr "선호목록에 추가하기"
 
@@ -2721,20 +2202,13 @@ msgstr "선호목록에 추가하기"
 msgid "Favorite"
 msgstr "선호 목록"
 
-#: src/olympia/bandwagon/helpers.py:124
-#: src/olympia/bandwagon/templates/bandwagon/favorites_widget.html:2
+#: src/olympia/bandwagon/helpers.py:124 src/olympia/bandwagon/templates/bandwagon/favorites_widget.html:2
 msgid "Remove from favorites"
 msgstr "선호 목록에서 삭제하기"
 
-#: src/olympia/bandwagon/views.py:98 src/olympia/bandwagon/views.py:191
-#: src/olympia/browse/views.py:58 src/olympia/browse/views.py:69
-#: src/olympia/browse/views.py:458 src/olympia/devhub/views.py:74
-#: src/olympia/devhub/views.py:82
-#: src/olympia/devhub/templates/devhub/addons/edit/basic.html:20
-#: src/olympia/editors/templates/editors/leaderboard.html:24
-#: src/olympia/editors/templates/editors/themes/queue_list.html:48
-#: src/olympia/search/forms.py:17 src/olympia/search/forms.py:89
-#: src/olympia/users/templates/users/vcard.html:5
+#: src/olympia/bandwagon/views.py:98 src/olympia/bandwagon/views.py:191 src/olympia/browse/views.py:58 src/olympia/browse/views.py:69 src/olympia/browse/views.py:425 src/olympia/devhub/views.py:73
+#: src/olympia/devhub/views.py:81 src/olympia/devhub/templates/devhub/addons/edit/basic.html:20 src/olympia/editors/templates/editors/leaderboard.html:24
+#: src/olympia/editors/templates/editors/themes/queue_list.html:48 src/olympia/search/forms.py:17 src/olympia/search/forms.py:89 src/olympia/users/templates/users/vcard.html:5
 msgid "Name"
 msgstr "이름"
 
@@ -2742,8 +2216,7 @@ msgstr "이름"
 msgid "Recently Popular"
 msgstr "최근 인기"
 
-#: src/olympia/bandwagon/views.py:189
-#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:18
+#: src/olympia/bandwagon/views.py:189 src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:16
 msgid "Added"
 msgstr "신규"
 
@@ -2757,10 +2230,8 @@ msgstr "모음집이 제작되었습니다!"
 
 #: src/olympia/bandwagon/views.py:316
 #, python-format
-msgid ""
-"Your new collection is shown below. You can <ahref=\"%(url)s\">edit "
-"additional settings</a> if you'dlike."
-msgstr ""
+msgid "Your new collection is shown below. You can <a href=\"%(url)s\">edit additional settings</a> if you'd like."
+msgstr "새 모음집이 아래에 표시되었습니다. 원할 경우 <a href=\"%(url)s\">추가 설정 사항을 편집</a>하실 수도 있습니다."
 
 #: src/olympia/bandwagon/views.py:322
 msgid "Collection updated!"
@@ -2775,30 +2246,20 @@ msgstr "변경 내역을 보려면 <a href=\"%(url)s\">모음집을 확인하세
 msgid "Icon Deleted"
 msgstr "아이콘이 삭제되었습니다"
 
-#: src/olympia/bandwagon/templates/bandwagon/add.html:3
-#: src/olympia/bandwagon/templates/bandwagon/add.html:11
-#: src/olympia/bandwagon/templates/bandwagon/includes/collection_sidebar.html:26
+#: src/olympia/bandwagon/templates/bandwagon/add.html:3 src/olympia/bandwagon/templates/bandwagon/add.html:11 src/olympia/bandwagon/templates/bandwagon/includes/collection_sidebar.html:26
 msgid "Create a New Collection"
 msgstr "새 모음집 제작하기"
 
-#: src/olympia/bandwagon/templates/bandwagon/add.html:9
-#: src/olympia/devhub/templates/devhub/personas/submit.html:14
+#: src/olympia/bandwagon/templates/bandwagon/add.html:9 src/olympia/devhub/templates/devhub/personas/submit.html:14
 msgid "Create"
 msgstr "제작"
 
-#: src/olympia/bandwagon/templates/bandwagon/add.html:24
-#: src/olympia/bandwagon/templates/bandwagon/ajax_new.html:28
+#: src/olympia/bandwagon/templates/bandwagon/add.html:24 src/olympia/bandwagon/templates/bandwagon/ajax_new.html:28
 #, python-format
-msgid ""
-"As noted in our <a href=\"%(legal)s\">Legal Notices</a>, individual "
-"collection arrangements are governed by the Creative Commons Attribution "
-"Share-Alike License"
-msgstr ""
-"저희 <a href=\"%(legal)s\">법적 고지</a>에 언급된 바와 같이 각 모음집의 고유 구성 방식은 크리에이티브 커먼즈 "
-"저작자표시-동일조건변경허락 라이선스 하에 있습니다"
+msgid "As noted in our <a href=\"%(legal)s\">Legal Notices</a>, individual collection arrangements are governed by the Creative Commons Attribution Share-Alike License"
+msgstr "저희 <a href=\"%(legal)s\">법적 고지</a>에 언급된 바와 같이 각 모음집의 고유 구성 방식은 크리에이티브 커먼즈 저작자표시-동일조건변경허락 라이선스 하에 있습니다"
 
-#: src/olympia/bandwagon/templates/bandwagon/add.html:33
-#: src/olympia/bandwagon/templates/bandwagon/ajax_new.html:38
+#: src/olympia/bandwagon/templates/bandwagon/add.html:33 src/olympia/bandwagon/templates/bandwagon/ajax_new.html:38
 msgid "Create Collection"
 msgstr "모음집 제작"
 
@@ -2814,8 +2275,7 @@ msgstr "새 모음집 만들기 시작..."
 msgid "Start a New Collection"
 msgstr "새 모음집 만들기 시작"
 
-#: src/olympia/bandwagon/templates/bandwagon/ajax_new.html:6
-#: src/olympia/bandwagon/templates/bandwagon/includes/addedit.html:7
+#: src/olympia/bandwagon/templates/bandwagon/ajax_new.html:6 src/olympia/bandwagon/templates/bandwagon/includes/addedit.html:7
 msgid "Name:"
 msgstr "이름:"
 
@@ -2828,15 +2288,11 @@ msgstr "또는 <a id=\"collections-new-cancel\" href=\"#\">취소</a>"
 msgid "To rate collections, you must have an add-ons account."
 msgstr "모음집을 평가하려면 부가 기능 계정이 있어야 합니다."
 
-#: src/olympia/bandwagon/templates/bandwagon/barometer.html:18
-#: src/olympia/templates/base.html:145
-#: src/olympia/templates/impala/base.html:198
+#: src/olympia/bandwagon/templates/bandwagon/barometer.html:18 src/olympia/templates/base.html:145 src/olympia/templates/impala/base.html:198
 msgid "Create an Add-ons Account"
 msgstr "부가 기능 계정 만들기"
 
-#: src/olympia/bandwagon/templates/bandwagon/barometer.html:21
-#: src/olympia/templates/base.html:148
-#: src/olympia/templates/impala/base.html:201
+#: src/olympia/bandwagon/templates/bandwagon/barometer.html:21 src/olympia/templates/base.html:148 src/olympia/templates/impala/base.html:201
 #, python-format
 msgid "or <a href=\"%(login)s\">log in to your current account</a>"
 msgstr "아니면 <a href=\"%(login)s\">현재 사용중인 계정으로 로그인</a> 하세요"
@@ -2849,12 +2305,12 @@ msgstr "{0} :: 모음집"
 msgid "private"
 msgstr "비공개"
 
-#: src/olympia/bandwagon/templates/bandwagon/collection_detail.html:45
-#: src/olympia/bandwagon/templates/bandwagon/mobile/listing_items.html:9
+#: src/olympia/bandwagon/templates/bandwagon/collection_detail.html:45 src/olympia/bandwagon/templates/bandwagon/mobile/listing_items.html:9
 #, python-format
 msgid "<span>%(num)s</span> follower"
 msgid_plural "<span>%(num)s</span> followers"
 msgstr[0] "팔로워 <span>%(num)s</span>명"
+msgstr[1] ""
 
 #: src/olympia/bandwagon/templates/bandwagon/collection_detail.html:54
 msgid "About this Collection"
@@ -2884,8 +2340,7 @@ msgstr "추가 옵션:"
 msgid "Edit Collection"
 msgstr "모음집 편집"
 
-#: src/olympia/bandwagon/templates/bandwagon/collection_detail.html:88
-#: src/olympia/bandwagon/templates/bandwagon/includes/delete.html:3
+#: src/olympia/bandwagon/templates/bandwagon/collection_detail.html:88 src/olympia/bandwagon/templates/bandwagon/includes/delete.html:3
 msgid "Delete Collection"
 msgstr "모음집 삭제"
 
@@ -2894,19 +2349,17 @@ msgstr "모음집 삭제"
 msgid "%(num)s Theme in this Collection"
 msgid_plural "%(num)s Themes in this Collection"
 msgstr[0] "이 콜렉션에 있는 %(num)s개의 테마"
+msgstr[1] ""
 
 #: src/olympia/bandwagon/templates/bandwagon/collection_detail.html:111
 #, python-format
 msgid "%(num)s Add-on in this Collection"
 msgid_plural "%(num)s Add-ons in this Collection"
 msgstr[0] "모음집에 포함된 부가 기능: %(num)s개"
+msgstr[1] ""
 
-#: src/olympia/bandwagon/templates/bandwagon/collection_detail.html:125
-#: src/olympia/compat/templates/compat/index.html:25
-#: src/olympia/compat/templates/compat/reporter_detail.html:29
-#: src/olympia/files/templates/files/viewer.html:29
-#: src/olympia/templates/amo_footer.html:17
-#: src/olympia/templates/includes/lang_switcher.html:10
+#: src/olympia/bandwagon/templates/bandwagon/collection_detail.html:125 src/olympia/compat/templates/compat/reporter_detail.html:29 src/olympia/files/templates/files/viewer.html:29
+#: src/olympia/templates/amo_footer.html:17 src/olympia/templates/includes/lang_switcher.html:10
 msgid "Go"
 msgstr "실행"
 
@@ -2932,25 +2385,15 @@ msgstr "이 사용자가 제작한 모든 모음집 보기"
 
 #: src/olympia/bandwagon/templates/bandwagon/collection_detail.html:179
 msgid ""
-"Add-ons that you mark as favorites using the <b>Add to Favorites</b> feature"
-" appear below. This collection is currently <b>public</b>, which means "
-"everyone can see it. If you would like to hide it from public view, click "
-"the button below to make it private."
-msgstr ""
-"아래의 <b>선호 목록에 추가하기</b>를 선택하면 해당 부가 기능은 좋아하는 부가 기능으로 표시가 됩니다. 이 목록은 현재 "
-"<b>공개</b> 상태로, 모든 사람들이 목록을 볼 수 있다는 의미입니다. 남에게 보이고 싶지 않다면 아래의 버튼을 클릭해서 비공개 "
-"상태로 전환하시기 바랍니다."
+"Add-ons that you mark as favorites using the <b>Add to Favorites</b> feature appear below. This collection is currently <b>public</b>, which means everyone can see it. If you would like to hide it "
+"from public view, click the button below to make it private."
+msgstr "아래의 <b>선호 목록에 추가하기</b>를 선택하면 해당 부가 기능은 좋아하는 부가 기능으로 표시가 됩니다. 이 목록은 현재 <b>공개</b> 상태로, 모든 사람들이 목록을 볼 수 있다는 의미입니다. 남에게 보이고 싶지 않다면 아래의 버튼을 클릭해서 비공개 상태로 전환하시기 바랍니다."
 
 #: src/olympia/bandwagon/templates/bandwagon/collection_detail.html:186
 msgid ""
-"Add-ons that you mark as favorites using the <b>Add to Favorites</b> feature"
-" appear below. This collection is currently <b>private</b>, which means only"
-" you can see it. If you would like everyone to be able to see your "
-"favorites, click the button below to make it public."
-msgstr ""
-"아래의 <b>선호 목록에 추가하기</b>를 선택하면 해당 부가 기능은 좋아하는 부가 기능으로 표시가 됩니다. 이 목록은 현재 "
-"<b>비공개</b> 상태로, 자기 자신만 볼 수 있다는 의미입니다. 다른 사람들도 내 선호 목록을 보게 하고 싶다면 아래의 버튼을 "
-"클릭해서 공개 상태로 전환하시기 바랍니다."
+"Add-ons that you mark as favorites using the <b>Add to Favorites</b> feature appear below. This collection is currently <b>private</b>, which means only you can see it. If you would like everyone "
+"to be able to see your favorites, click the button below to make it public."
+msgstr "아래의 <b>선호 목록에 추가하기</b>를 선택하면 해당 부가 기능은 좋아하는 부가 기능으로 표시가 됩니다. 이 목록은 현재 <b>비공개</b> 상태로, 자기 자신만 볼 수 있다는 의미입니다. 다른 사람들도 내 선호 목록을 보게 하고 싶다면 아래의 버튼을 클릭해서 공개 상태로 전환하시기 바랍니다."
 
 #: src/olympia/bandwagon/templates/bandwagon/collection_detail.html:196
 msgid "My favorite add-ons"
@@ -2961,58 +2404,57 @@ msgstr "좋아하는 부가 기능"
 msgid "<span>%(addons)s</span> add-on"
 msgid_plural "<span>%(addons)s</span> add-ons"
 msgstr[0] "부가 기능 <span>%(addons)s</span>개"
+msgstr[1] ""
 
 #: src/olympia/bandwagon/templates/bandwagon/collection_grid.html:32
 #, python-format
 msgid "<span>%(followers)s</span> follower"
 msgid_plural "<span>%(followers)s</span> followers"
 msgstr[0] "팔로워 <span>%(followers)s</span>명"
+msgstr[1] ""
 
-#. People "follow" collections to get notified of updates.
-#. Like
+#. People "follow" collections to get notified of updates.                    Like
 #. Twitter followers.
+#. People "follow" collections to get notified of updates.
 #. Like Twitter followers.
-#: src/olympia/bandwagon/templates/bandwagon/collection_listing_items.html:10
-#: src/olympia/bandwagon/templates/bandwagon/impala/collection_listing_items.html:18
+#: src/olympia/bandwagon/templates/bandwagon/collection_listing_items.html:10 src/olympia/bandwagon/templates/bandwagon/impala/collection_listing_items.html:18
 #, python-format
 msgid "%(num)s weekly follower"
 msgid_plural "%(num)s weekly followers"
 msgstr[0] "주간 팔로워 %(num)s명"
+msgstr[1] ""
 
-#. People "follow" collections to get notified of updates.
-#. Like
+#. People "follow" collections to get notified of updates.                    Like
 #. Twitter followers.
 #: src/olympia/bandwagon/templates/bandwagon/collection_listing_items.html:18
 #, python-format
 msgid "%(num)s monthly follower"
 msgid_plural "%(num)s monthly followers"
 msgstr[0] "월간 팔로워 %(num)s명"
+msgstr[1] ""
 
-#. People "follow" collections to get notified of updates.
-#. Like
+#. People "follow" collections to get notified of updates.                    Like
 #. Twitter followers.
+#. People "follow" collections to get notified of updates.
 #. Like Twitter followers.
-#: src/olympia/bandwagon/templates/bandwagon/collection_listing_items.html:26
-#: src/olympia/bandwagon/templates/bandwagon/impala/collection_listing_items.html:26
+#: src/olympia/bandwagon/templates/bandwagon/collection_listing_items.html:26 src/olympia/bandwagon/templates/bandwagon/impala/collection_listing_items.html:26
 #, python-format
 msgid "%(num)s follower"
 msgid_plural "%(num)s followers"
 msgstr[0] "팔로워 %(num)s명"
+msgstr[1] ""
 
-#: src/olympia/bandwagon/templates/bandwagon/collection_listing_items.html:56
-#: src/olympia/bandwagon/templates/bandwagon/impala/collection_listing_items.html:9
+#: src/olympia/bandwagon/templates/bandwagon/collection_listing_items.html:56 src/olympia/bandwagon/templates/bandwagon/impala/collection_listing_items.html:9
 #: src/olympia/devhub/templates/devhub/personas/edit.html:27
 msgid "by {0}"
 msgstr "제작: {0}"
 
-#: src/olympia/bandwagon/templates/bandwagon/collection_widgets.html:5
-#: src/olympia/bandwagon/templates/bandwagon/collection_widgets.html:7
+#: src/olympia/bandwagon/templates/bandwagon/collection_widgets.html:5 src/olympia/bandwagon/templates/bandwagon/collection_widgets.html:7
 #: src/olympia/bandwagon/templates/bandwagon/impala/collection_listing_items.html:53
 msgid "Stop Following"
 msgstr "팔로윙 중단"
 
-#: src/olympia/bandwagon/templates/bandwagon/collection_widgets.html:6
-#: src/olympia/bandwagon/templates/bandwagon/collection_widgets.html:7
+#: src/olympia/bandwagon/templates/bandwagon/collection_widgets.html:6 src/olympia/bandwagon/templates/bandwagon/collection_widgets.html:7
 #: src/olympia/bandwagon/templates/bandwagon/impala/collection_listing_items.html:53
 msgid "Follow this Collection"
 msgstr "이 모음집 팔로우 하기"
@@ -3022,16 +2464,12 @@ msgid "Edit this Collection"
 msgstr "모음집 편집하기"
 
 #. %s is the name of the collection.
-#: src/olympia/bandwagon/templates/bandwagon/delete.html:4
-#: src/olympia/bandwagon/templates/bandwagon/delete.html:15
+#: src/olympia/bandwagon/templates/bandwagon/delete.html:4 src/olympia/bandwagon/templates/bandwagon/delete.html:15
 msgid "Delete {0}"
 msgstr "{0} 삭제하기"
 
-#: src/olympia/bandwagon/templates/bandwagon/delete.html:13
-#: src/olympia/devhub/templates/devhub/addons/listing/item_actions.html:14
-#: src/olympia/devhub/templates/devhub/addons/listing/item_actions_theme.html:28
-#: src/olympia/devhub/templates/devhub/versions/list.html:131
-#: src/olympia/devhub/templates/devhub/versions/list.html:149
+#: src/olympia/bandwagon/templates/bandwagon/delete.html:13 src/olympia/devhub/templates/devhub/addons/listing/item_actions.html:14
+#: src/olympia/devhub/templates/devhub/addons/listing/item_actions_theme.html:28 src/olympia/devhub/templates/devhub/versions/list.html:131 src/olympia/devhub/templates/devhub/versions/list.html:149
 #: src/olympia/devhub/templates/devhub/versions/list.html:166
 msgid "Delete"
 msgstr "삭제"
@@ -3040,35 +2478,24 @@ msgstr "삭제"
 msgid "Are you sure?"
 msgstr "확실합니까?"
 
-#: src/olympia/bandwagon/templates/bandwagon/delete.html:21
-#: src/olympia/devhub/templates/devhub/personas/edit.html:131
-#: src/olympia/devhub/templates/devhub/personas/edit.html:152
-#: src/olympia/devhub/templates/devhub/personas/edit.html:173
-#: src/olympia/devhub/templates/devhub/personas/submit.html:77
-#: src/olympia/devhub/templates/devhub/personas/submit.html:98
+#: src/olympia/bandwagon/templates/bandwagon/delete.html:21 src/olympia/devhub/templates/devhub/personas/edit.html:131 src/olympia/devhub/templates/devhub/personas/edit.html:152
+#: src/olympia/devhub/templates/devhub/personas/edit.html:173 src/olympia/devhub/templates/devhub/personas/submit.html:77 src/olympia/devhub/templates/devhub/personas/submit.html:98
 #: src/olympia/devhub/templates/devhub/personas/submit.html:119
 msgid "Yes"
 msgstr "예"
 
-#: src/olympia/bandwagon/templates/bandwagon/delete.html:22
-#: src/olympia/devhub/templates/devhub/personas/edit.html:140
-#: src/olympia/devhub/templates/devhub/personas/edit.html:161
-#: src/olympia/devhub/templates/devhub/personas/edit.html:191
-#: src/olympia/devhub/templates/devhub/personas/submit.html:86
-#: src/olympia/devhub/templates/devhub/personas/submit.html:107
+#: src/olympia/bandwagon/templates/bandwagon/delete.html:22 src/olympia/devhub/templates/devhub/personas/edit.html:140 src/olympia/devhub/templates/devhub/personas/edit.html:161
+#: src/olympia/devhub/templates/devhub/personas/edit.html:191 src/olympia/devhub/templates/devhub/personas/submit.html:86 src/olympia/devhub/templates/devhub/personas/submit.html:107
 #: src/olympia/devhub/templates/devhub/personas/submit.html:137
 msgid "No"
 msgstr "아니오"
 
 #. {0} is the name of the collection.
-#: src/olympia/bandwagon/templates/bandwagon/edit.html:5
-#: src/olympia/bandwagon/templates/bandwagon/edit.html:21
+#: src/olympia/bandwagon/templates/bandwagon/edit.html:5 src/olympia/bandwagon/templates/bandwagon/edit.html:21
 msgid "Edit {0}"
 msgstr "{0} 편집"
 
-#: src/olympia/bandwagon/templates/bandwagon/edit.html:29
-#: src/olympia/devhub/templates/devhub/addons/edit/details.html:20
-#: src/olympia/editors/templates/editors/themes/themes.html:62
+#: src/olympia/bandwagon/templates/bandwagon/edit.html:29 src/olympia/devhub/templates/devhub/addons/edit/details.html:20 src/olympia/editors/templates/editors/themes/themes.html:62
 msgid "Description"
 msgstr "설명"
 
@@ -3076,32 +2503,18 @@ msgstr "설명"
 msgid "Contributors & More"
 msgstr "기여자 및 그 외"
 
-#: src/olympia/bandwagon/templates/bandwagon/edit.html:54
-#: src/olympia/bandwagon/templates/bandwagon/edit.html:67
-#: src/olympia/bandwagon/templates/bandwagon/edit.html:82
-#: src/olympia/devhub/templates/devhub/addons/ajax_compat_update.html:35
-#: src/olympia/devhub/templates/devhub/addons/owner.html:59
-#: src/olympia/devhub/templates/devhub/addons/profile.html:42
-#: src/olympia/devhub/templates/devhub/addons/edit/admin.html:101
-#: src/olympia/devhub/templates/devhub/addons/edit/basic.html:152
-#: src/olympia/devhub/templates/devhub/addons/edit/details.html:85
-#: src/olympia/devhub/templates/devhub/addons/edit/support.html:67
-#: src/olympia/devhub/templates/devhub/addons/edit/technical.html:166
-#: src/olympia/devhub/templates/devhub/addons/forms_shared/media.html:149
-#: src/olympia/devhub/templates/devhub/payments/voluntary.html:64
-#: src/olympia/devhub/templates/devhub/personas/edit.html:35
-#: src/olympia/devhub/templates/devhub/personas/edit.html:304
-#: src/olympia/devhub/templates/devhub/versions/edit.html:139
-#: src/olympia/translations/templates/translations/trans-menu.html:48
+#: src/olympia/bandwagon/templates/bandwagon/edit.html:54 src/olympia/bandwagon/templates/bandwagon/edit.html:67 src/olympia/bandwagon/templates/bandwagon/edit.html:82
+#: src/olympia/devhub/templates/devhub/addons/ajax_compat_update.html:35 src/olympia/devhub/templates/devhub/addons/owner.html:59 src/olympia/devhub/templates/devhub/addons/profile.html:42
+#: src/olympia/devhub/templates/devhub/addons/edit/admin.html:101 src/olympia/devhub/templates/devhub/addons/edit/basic.html:152 src/olympia/devhub/templates/devhub/addons/edit/details.html:85
+#: src/olympia/devhub/templates/devhub/addons/edit/support.html:67 src/olympia/devhub/templates/devhub/addons/edit/technical.html:166
+#: src/olympia/devhub/templates/devhub/addons/forms_shared/media.html:149 src/olympia/devhub/templates/devhub/payments/voluntary.html:64 src/olympia/devhub/templates/devhub/personas/edit.html:35
+#: src/olympia/devhub/templates/devhub/personas/edit.html:304 src/olympia/devhub/templates/devhub/versions/edit.html:139 src/olympia/translations/templates/translations/trans-menu.html:48
 msgid "Save Changes"
 msgstr "변경사항 저장"
 
 # <option> text in a <select> for Author role in an add-on.
-#: src/olympia/bandwagon/templates/bandwagon/edit_contributors.html:9
-#: src/olympia/bandwagon/templates/bandwagon/edit_contributors.html:12
-#: src/olympia/bandwagon/templates/bandwagon/edit_contributors.html:17
-#: src/olympia/bandwagon/templates/bandwagon/edit_contributors.html:58
-#: src/olympia/constants/base.py:134
+#: src/olympia/bandwagon/templates/bandwagon/edit_contributors.html:9 src/olympia/bandwagon/templates/bandwagon/edit_contributors.html:12
+#: src/olympia/bandwagon/templates/bandwagon/edit_contributors.html:17 src/olympia/bandwagon/templates/bandwagon/edit_contributors.html:58 src/olympia/constants/base.py:134
 msgid "Owner"
 msgstr "소유자"
 
@@ -3113,10 +2526,8 @@ msgstr "소유자 생성"
 msgid "Remove this user as a contributor"
 msgstr "이 사용자를 기여자 명단에서 삭제하기"
 
-#: src/olympia/bandwagon/templates/bandwagon/edit_contributors.html:18
-#: src/olympia/bandwagon/templates/bandwagon/edit_contributors.html:43
-#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:20
-#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:48
+#: src/olympia/bandwagon/templates/bandwagon/edit_contributors.html:18 src/olympia/bandwagon/templates/bandwagon/edit_contributors.html:43
+#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:18 src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:46
 #: src/olympia/devhub/templates/devhub/addons/ajax_compat_update.html:19
 msgid "Remove"
 msgstr "삭제"
@@ -3127,22 +2538,15 @@ msgstr "모음집 기여자"
 
 #: src/olympia/bandwagon/templates/bandwagon/edit_contributors.html:26
 msgid ""
-"You can add multiple contributors to this collection. A contributor can add "
-"and remove add-ons from this collection, but cannot change its name or "
-"description. To add a contributor, enter their email in the box below. "
-"Contributors must have a Mozilla Add-ons account."
-msgstr ""
-"모음집엔 여러 기여자를 추가할 수 있습니다. 기여자는 부가 기능의 추가 삭제가 가능하지만, 모음집의 이름이나 설명을 바꿀 수는 없습니다."
-" 기여자를 추가하려면 아래 상자에 추가하려는 기여자의 이메일 주소를 입력해 주세요. 기여자는 Mozilla 부가 기능 계정을 가지고 "
-"있어야만 합니다."
+"You can add multiple contributors to this collection. A contributor can add and remove add-ons from this collection, but cannot change its name or description. To add a contributor, enter their "
+"email in the box below. Contributors must have a Mozilla Add-ons account."
+msgstr "모음집엔 여러 기여자를 추가할 수 있습니다. 기여자는 부가 기능의 추가 삭제가 가능하지만, 모음집의 이름이나 설명을 바꿀 수는 없습니다. 기여자를 추가하려면 아래 상자에 추가하려는 기여자의 이메일 주소를 입력해 주세요. 기여자는 Mozilla 부가 기능 계정을 가지고 있어야만 합니다."
 
 #: src/olympia/bandwagon/templates/bandwagon/edit_contributors.html:40
 msgid "User"
 msgstr "사용자"
 
-#: src/olympia/bandwagon/templates/bandwagon/edit_contributors.html:41
-#: src/olympia/devhub/templates/devhub/addons/edit/support.html:20
-#: src/olympia/users/templates/users/delete.html:49
+#: src/olympia/bandwagon/templates/bandwagon/edit_contributors.html:41 src/olympia/devhub/templates/devhub/addons/edit/support.html:20 src/olympia/users/templates/users/delete.html:49
 msgid "Email"
 msgstr "이메일"
 
@@ -3168,27 +2572,14 @@ msgid "Admin Settings"
 msgstr "관리자 설정"
 
 #: src/olympia/bandwagon/templates/bandwagon/edit_contributors.html:76
-msgid ""
-"<b>Warning:</b> By changing the owner of this collection, you will no longer"
-" be able to edit it. You will only be able to add and remove add-ons from "
-"it."
-msgstr ""
-"<b>경고:</b> 이 모음집의 소유자를 변경하고 나면 더이상 편집을 하실 수 없습니다. 이후부터는 이 모음집의 부가 기능의 추가 및 "
-"삭제만 가능하게 될 것입니다."
+msgid "<b>Warning:</b> By changing the owner of this collection, you will no longer be able to edit it. You will only be able to add and remove add-ons from it."
+msgstr "<b>경고:</b> 이 모음집의 소유자를 변경하고 나면 더이상 편집을 하실 수 없습니다. 이후부터는 이 모음집의 부가 기능의 추가 및 삭제만 가능하게 될 것입니다."
 
-#: src/olympia/bandwagon/templates/bandwagon/edit_contributors.html:83
-#: src/olympia/devhub/templates/devhub/addons/forms_shared/media.html:157
-#: src/olympia/devhub/templates/devhub/addons/submit/describe.html:69
-#: src/olympia/devhub/templates/devhub/addons/submit/license.html:60
-#: src/olympia/devhub/templates/devhub/addons/submit/upload.html:78
-#: src/olympia/devhub/templates/devhub/payments/tier.html:17
-#: src/olympia/editors/templates/editors/themes/themes.html:111
-#: src/olympia/editors/templates/editors/themes/themes.html:128
-#: src/olympia/editors/templates/editors/themes/themes.html:134
-#: src/olympia/editors/templates/editors/themes/themes.html:141
-#: src/olympia/users/templates/users/fxa_migration_prompt_content.html:10
-#: src/olympia/users/templates/users/login_form.html:42
-#: src/olympia/users/templates/users/mobile/login.html:57
+#: src/olympia/bandwagon/templates/bandwagon/edit_contributors.html:83 src/olympia/devhub/templates/devhub/addons/forms_shared/media.html:157
+#: src/olympia/devhub/templates/devhub/addons/submit/describe.html:69 src/olympia/devhub/templates/devhub/addons/submit/license.html:60 src/olympia/devhub/templates/devhub/addons/submit/upload.html:70
+#: src/olympia/devhub/templates/devhub/payments/tier.html:17 src/olympia/editors/templates/editors/themes/themes.html:111 src/olympia/editors/templates/editors/themes/themes.html:128
+#: src/olympia/editors/templates/editors/themes/themes.html:134 src/olympia/editors/templates/editors/themes/themes.html:141 src/olympia/users/templates/users/fxa_migration_prompt_content.html:10
+#: src/olympia/users/templates/users/login_form.html:42 src/olympia/users/templates/users/mobile/login.html:57
 msgid "Continue"
 msgstr "계속"
 
@@ -3227,17 +2618,10 @@ msgstr "최근 인기 모음집"
 
 #: src/olympia/bandwagon/templates/bandwagon/impala/collection_listing.html:28
 #, python-format
-msgid ""
-"Collections are groups of related add-ons that anyone can create and share. "
-"Explore collections created by other users or <a href=\"%(url)s\">create "
-"your own</a>."
-msgstr ""
-"모음집은 서로 관련이 있는 부가 기능을 한데 엮어놓은 것으로 누구나 제작과 공유가 가능합니다. 다른 사용자가 제작한 모음집을 살펴보거나 "
-"<a href=\"%(url)s\">나만의 모음집을 제작</a>할 수도 있습니다."
+msgid "Collections are groups of related add-ons that anyone can create and share. Explore collections created by other users or <a href=\"%(url)s\">create your own</a>."
+msgstr "모음집은 서로 관련이 있는 부가 기능을 한데 엮어놓은 것으로 누구나 제작과 공유가 가능합니다. 다른 사용자가 제작한 모음집을 살펴보거나 <a href=\"%(url)s\">나만의 모음집을 제작</a>할 수도 있습니다."
 
-#: src/olympia/bandwagon/templates/bandwagon/impala/collection_listing.html:37
-#: src/olympia/browse/templates/browse/extensions.html:13
-#: src/olympia/browse/templates/browse/themes.html:14
+#: src/olympia/bandwagon/templates/bandwagon/impala/collection_listing.html:37 src/olympia/browse/templates/browse/extensions.html:13 src/olympia/browse/templates/browse/themes.html:14
 msgid "Subscribe"
 msgstr "구독하기"
 
@@ -3245,19 +2629,14 @@ msgstr "구독하기"
 msgid "Following"
 msgstr "팔로윙"
 
-#: src/olympia/bandwagon/templates/bandwagon/impala/collection_sidebar.html:22
-#: src/olympia/bandwagon/templates/bandwagon/impala/collection_sidebar.html:28
+#: src/olympia/bandwagon/templates/bandwagon/impala/collection_sidebar.html:22 src/olympia/bandwagon/templates/bandwagon/impala/collection_sidebar.html:28
 #: src/olympia/bandwagon/templates/bandwagon/includes/collection_sidebar.html:32
 msgid "Create a Collection"
 msgstr "모음집 제작하기"
 
-#: src/olympia/bandwagon/templates/bandwagon/impala/collection_sidebar.html:23
-#: src/olympia/bandwagon/templates/bandwagon/includes/collection_sidebar.html:27
-msgid ""
-"Collections make it easy to keep track of favorite add-ons and share your "
-"perfectly customized browser with others."
-msgstr ""
-"모음집은 좋아하는 부가 기능을 쉽게 찾을 수 있게 해주며 남들에게 완벽하게 개인화한 브라우저 환경을 공유할 수 있게 해줍니다."
+#: src/olympia/bandwagon/templates/bandwagon/impala/collection_sidebar.html:23 src/olympia/bandwagon/templates/bandwagon/includes/collection_sidebar.html:27
+msgid "Collections make it easy to keep track of favorite add-ons and share your perfectly customized browser with others."
+msgstr "모음집은 좋아하는 부가 기능을 쉽게 찾을 수 있게 해주며 남들에게 완벽하게 개인화한 브라우저 환경을 공유할 수 있게 해줍니다."
 
 #: src/olympia/bandwagon/templates/bandwagon/includes/addedit.html:42
 msgid "Collection Icon"
@@ -3280,38 +2659,31 @@ msgid "Add-ons in Your Collection"
 msgstr "모음집에 들어있는 부가 기능"
 
 #: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:4
-msgid ""
-"To include an add-on in this collection, enter its name in the box below and"
-" hit enter. You can also use the <strong>Add to Collection</strong> links "
-"throughout the site to include add-ons later."
+msgid "To include an add-on in this collection, enter its name in the box below and hit enter."
 msgstr ""
-"모음집에 부가 기능을 추가하려면, 아래 상자에 이름을 입력 후 엔터를 눌러주세요. 나중에 부가 기능을 추가하려면 사이트 내에 "
-"<strong>모음집에 추가하기</strong> 링크를 사용하시면 됩니다."
 
-#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:17
-#: src/olympia/constants/base.py:400
-#: src/olympia/devhub/templates/devhub/addons/activity.html:62
+#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:15 src/olympia/constants/base.py:400 src/olympia/devhub/templates/devhub/addons/activity.html:62
+#: src/olympia/editors/helpers.py:273 src/olympia/editors/helpers.py:360
 msgid "Add-on"
 msgstr "부가 기능"
 
-#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:26
+#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:24
 msgid "Enter the name of the add-on to include"
 msgstr "추가하고자 하는 부가 기능의 이름을 입력하세요"
 
-#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:28
+#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:26
 msgid "Add to Collection"
 msgstr "모음집에 추가하기"
 
-#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:45
-#: src/olympia/editors/helpers.py:936 src/olympia/editors/helpers.py:956
+#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:43 src/olympia/editors/helpers.py:1016 src/olympia/editors/helpers.py:1036
 msgid "Pending"
 msgstr "대기중"
 
-#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:47
+#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:45
 msgid "Add a comment"
 msgstr "코멘트 작성"
 
-#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:48
+#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:46
 msgid "Remove this add-on from the collection"
 msgstr "모음집에서 부가 기능 삭제하기"
 
@@ -3323,14 +2695,11 @@ msgstr "모음집"
 msgid "Groups of related add-ons that anyone can create."
 msgstr "누구나 제작 가능한 유사한 부가 기능끼리의 모음집입니다."
 
-#: src/olympia/blocklist/templates/blocklist/blocked_detail.html:3
-#: src/olympia/blocklist/templates/blocklist/blocked_list.html:3
-#: src/olympia/blocklist/templates/blocklist/blocked_list.html:10
+#: src/olympia/blocklist/templates/blocklist/blocked_detail.html:3 src/olympia/blocklist/templates/blocklist/blocked_list.html:3 src/olympia/blocklist/templates/blocklist/blocked_list.html:10
 msgid "Blocked Add-ons"
 msgstr "차단된 부가 기능"
 
-#: src/olympia/blocklist/templates/blocklist/blocked_detail.html:8
-#: src/olympia/blocklist/templates/blocklist/blocked_list.html:6
+#: src/olympia/blocklist/templates/blocklist/blocked_detail.html:8 src/olympia/blocklist/templates/blocklist/blocked_list.html:6
 msgid "Blocklist"
 msgstr "차단 목록"
 
@@ -3352,31 +2721,21 @@ msgid "What does this mean?"
 msgstr "차단되면 어떻게 되는건가요?"
 
 #: src/olympia/blocklist/templates/blocklist/blocked_detail.html:22
-msgid ""
-"Users are strongly encouraged to disable the problematic add-on or plugin, "
-"but may choose to continue using it if they accept the risks described."
-msgstr ""
-"문제가 발생한 부가 기능 및 플러그인을 사용할 수 없게 되어 굉장히 불편한 사용자들은 위험 요소에 대한 설명에 동의할 경우에 한해 계속 "
-"사용할 수 있는 방법도 있습니다."
+msgid "Users are strongly encouraged to disable the problematic add-on or plugin, but may choose to continue using it if they accept the risks described."
+msgstr "문제가 발생한 부가 기능 및 플러그인을 사용할 수 없게 되어 굉장히 불편한 사용자들은 위험 요소에 대한 설명에 동의할 경우에 한해 계속 사용할 수 있는 방법도 있습니다."
 
 #: src/olympia/blocklist/templates/blocklist/blocked_detail.html:27
-msgid ""
-"The problematic add-on or plugin will be automatically disabled and no "
-"longer usable."
+msgid "The problematic add-on or plugin will be automatically disabled and no longer usable."
 msgstr "문제가 발생한 부가 기능 및 플러그인은 자동으로 사용 중단 처리되어 더이상 사용할 수 없게 됩니다."
 
 #: src/olympia/blocklist/templates/blocklist/blocked_detail.html:33
 #, python-format
 msgid ""
-"When Mozilla becomes aware of add-ons, plugins, or other third-party "
-"software that seriously compromises %(app)s security, stability, or "
-"performance and meets <a href=\"%(criteria)s\">certain criteria</a>, the "
-"software may be blocked from general use. For more information, please read "
-"<a href=\"%(support)s\">this support article</a>."
+"When Mozilla becomes aware of add-ons, plugins, or other third-party software that seriously compromises %(app)s security, stability, or performance and meets <a href=\"%(criteria)s\">certain "
+"criteria</a>, the software may be blocked from general use. For more information, please read <a href=\"%(support)s\">this support article</a>."
 msgstr ""
-"Mozilla에선 부가 기능, 플러그인, 기타 서드파티 소프트웨어에서 %(app)s에 심각한 보안, 안정성, 성능 저하 문제를 초래하는 "
-"것이 있을 경우 <a href=\"%(criteria)s\">규정</a>에 의거, 해당 소프트웨어를 일반적인 사용을 할 수 없도록 "
-"차단하게 됩니다. 보다 자세한 정보를 보시려면 <a href=\"%(support)s\">다음의 도움말</a>을 읽어보시기 바랍니다."
+"Mozilla에선 부가 기능, 플러그인, 기타 서드파티 소프트웨어에서 %(app)s에 심각한 보안, 안정성, 성능 저하 문제를 초래하는 것이 있을 경우 <a href=\"%(criteria)s\">규정</a>에 의거, 해당 소프트웨어를 일반적인 사용을 할 수 없도록 차단하게 됩니다. 보다 자세한 정보를 보시려면 <a "
+"href=\"%(support)s\">다음의 도움말</a>을 읽어보시기 바랍니다."
 
 #: src/olympia/blocklist/templates/blocklist/blocked_detail.html:44
 #, python-format
@@ -3389,9 +2748,7 @@ msgid "Blocked on %(date)s."
 msgstr "%(date)s자로 차단되었습니다."
 
 #: src/olympia/blocklist/templates/blocklist/blocked_list.html:11
-msgid ""
-"The following software is known to cause serious security, stability, or "
-"performance issues with {app}."
+msgid "The following software is known to cause serious security, stability, or performance issues with {app}."
 msgstr "다음의 소프트웨어들은 {app}에 심각한 보안, 안정성, 성능 저하 문제를 일으키는 것으로 알려져 있습니다."
 
 #. L10n: %s is a category name.
@@ -3414,8 +2771,7 @@ msgstr "추천 부가 기능 :: %s"
 #. L10n: %s is an app name.
 #: src/olympia/browse/feeds.py:138
 #, python-format
-msgid ""
-"Here's a few of our favorite add-ons to help you get started customizing %s."
+msgid "Here's a few of our favorite add-ons to help you get started customizing %s."
 msgstr "%s을(를) 처음 개인화 할 때 도움이 되는 유용한 부가 기능들이 여기에 마련되어 있습니다."
 
 #. L10n: %s is a category name.
@@ -3432,43 +2788,28 @@ msgstr "검색 도구 및 검색 관련 확장 기능"
 msgid "Search tools"
 msgstr "검색 도구"
 
-#: src/olympia/browse/views.py:55 src/olympia/browse/views.py:65
-#: src/olympia/search/forms.py:85
+#: src/olympia/browse/views.py:55 src/olympia/browse/views.py:65 src/olympia/search/forms.py:85
 msgid "Most Users"
 msgstr "최고 사용자 수"
 
-#: src/olympia/browse/views.py:61 src/olympia/browse/views.py:72
-#: src/olympia/browse/views.py:279
-#: src/olympia/browse/templates/browse/personas/mobile/category_landing.html:63
-#: src/olympia/discovery/templates/discovery/pane.html:67
-#: src/olympia/search/forms.py:92
+#: src/olympia/browse/views.py:61 src/olympia/browse/views.py:72 src/olympia/browse/views.py:246 src/olympia/browse/templates/browse/personas/mobile/category_landing.html:63
+#: src/olympia/discovery/templates/discovery/pane.html:67 src/olympia/search/forms.py:92
 msgid "Up & Coming"
 msgstr "인기 급상승"
 
-#: src/olympia/browse/views.py:460 src/olympia/devhub/views.py:76
-#: src/olympia/devhub/views.py:83
-#: src/olympia/discovery/templates/discovery/addons/detail.html:66
+#: src/olympia/browse/views.py:427 src/olympia/devhub/views.py:75 src/olympia/devhub/views.py:82 src/olympia/discovery/templates/discovery/addons/detail.html:66
 msgid "Created"
 msgstr "신규 등록"
 
 #. {0} is the category name. Ex: Sports
-#: src/olympia/browse/templates/browse/creatured.html:5
-#: src/olympia/browse/templates/browse/creatured.html:13
+#: src/olympia/browse/templates/browse/creatured.html:5 src/olympia/browse/templates/browse/creatured.html:13
 msgid "{0}: Featured Add-ons"
 msgstr "{0}: 추천 부가 기능"
 
-#: src/olympia/browse/templates/browse/creatured.html:12
-#: src/olympia/browse/templates/browse/featured.html:4
-#: src/olympia/browse/templates/browse/featured.html:12
-#: src/olympia/browse/templates/browse/featured.html:13
-#: src/olympia/devhub/templates/devhub/docs/policies-recommended.html:3
-#: src/olympia/devhub/templates/devhub/docs/policies-recommended.html:7
-#: src/olympia/devhub/templates/devhub/docs/policies-recommended.html:9
-#: src/olympia/devhub/templates/devhub/docs/policies.html:21
-#: src/olympia/devhub/templates/devhub/docs/policies.html:90
-#: src/olympia/discovery/modules.py:341
-#: src/olympia/discovery/templates/discovery/pane.html:52
-#: src/olympia/templates/menu_links.html:7
+#: src/olympia/browse/templates/browse/creatured.html:12 src/olympia/browse/templates/browse/featured.html:4 src/olympia/browse/templates/browse/featured.html:12
+#: src/olympia/browse/templates/browse/featured.html:13 src/olympia/devhub/templates/devhub/docs/policies-recommended.html:3 src/olympia/devhub/templates/devhub/docs/policies-recommended.html:7
+#: src/olympia/devhub/templates/devhub/docs/policies-recommended.html:9 src/olympia/devhub/templates/devhub/docs/policies.html:21 src/olympia/devhub/templates/devhub/docs/policies.html:90
+#: src/olympia/discovery/modules.py:341 src/olympia/discovery/templates/discovery/pane.html:52 src/olympia/templates/menu_links.html:7
 msgid "Featured Add-ons"
 msgstr "추천 부가 기능"
 
@@ -3479,9 +2820,7 @@ msgstr "{0}에 추천 부가 기능이 없습니다."
 
 #: src/olympia/browse/templates/browse/featured.html:15
 #, python-format
-msgid ""
-"Here's a few of our favorite add-ons to help you get started customizing "
-"%(app)s."
+msgid "Here's a few of our favorite add-ons to help you get started customizing %(app)s."
 msgstr "%(app)s을(를) 처음 개인화 할 때 도움이 되는 유용한 부가 기능들이 여기에 마련되어 있습니다."
 
 #: src/olympia/browse/templates/browse/language_tools.html:9
@@ -3508,19 +2847,15 @@ msgstr "한글판 있음"
 msgid "List of language packs and dictionaries available in your locale."
 msgstr "현재 사용중인 언어로 언어팩과 맞춤법 사전 목록을 사용할 수 있습니다."
 
-#: src/olympia/browse/templates/browse/language_tools.html:41
-#: src/olympia/browse/templates/browse/language_tools.html:63
+#: src/olympia/browse/templates/browse/language_tools.html:41 src/olympia/browse/templates/browse/language_tools.html:63
 msgid "Language"
 msgstr "언어별"
 
-#: src/olympia/browse/templates/browse/language_tools.html:42
-#: src/olympia/browse/templates/browse/language_tools.html:64
-#: src/olympia/constants/base.py:162
+#: src/olympia/browse/templates/browse/language_tools.html:42 src/olympia/browse/templates/browse/language_tools.html:64 src/olympia/constants/base.py:162
 msgid "Dictionary"
 msgstr "맞춤법 사전"
 
-#: src/olympia/browse/templates/browse/language_tools.html:43
-#: src/olympia/browse/templates/browse/language_tools.html:65
+#: src/olympia/browse/templates/browse/language_tools.html:43 src/olympia/browse/templates/browse/language_tools.html:65
 msgid "Language Pack"
 msgstr "언어팩"
 
@@ -3538,11 +2873,11 @@ msgid "{0} :: Search Tools"
 msgstr "{0} :: 검색 도구"
 
 #. {0} is an integer.
-#: src/olympia/browse/templates/browse/search_tools.html:39
-#: src/olympia/devhub/templates/devhub/addons/dashboard.html:17
+#: src/olympia/browse/templates/browse/search_tools.html:39 src/olympia/devhub/templates/devhub/addons/dashboard.html:17
 msgid "<b>{0}</b> add-on"
 msgid_plural "<b>{0}</b> add-ons"
 msgstr[0] "부가 기능 <b>{0}</b>개"
+msgstr[1] ""
 
 #: src/olympia/browse/templates/browse/search_tools.html:61
 msgid "Search Extensions"
@@ -3566,31 +2901,18 @@ msgstr "부가 정보"
 
 #. {0} is an app name, like Firefox.
 #: src/olympia/browse/templates/browse/search_tools.html:93
-msgid ""
-"Learn more about the <a "
-"href=\"http://support.mozilla.com/kb/Search+bar\">search bar</a> in {0}"
-msgstr ""
-"{0}의 <a href=\"http://support.mozilla.com/kb/Search+bar\">검색 바</a>에 대해 더 "
-"알아보기"
+msgid "Learn more about the <a href=\"http://support.mozilla.com/kb/Search+bar\">search bar</a> in {0}"
+msgstr "{0}의 <a href=\"http://support.mozilla.com/kb/Search+bar\">검색 바</a>에 대해 더 알아보기"
 
 #: src/olympia/browse/templates/browse/search_tools.html:94
-msgid ""
-"Browse through even more search providers at <a "
-"href=\"http://mycroft.mozdev.org/\">mycroft.mozdev.org</a>"
-msgstr ""
-"<a href=\"http://mycroft.mozdev.org/\">mycroft.mozdev.org</a>에서 더 많은 검색 도구를 "
-"찾아보실 수 있습니다"
+msgid "Browse through even more search providers at <a href=\"http://mycroft.mozdev.org/\">mycroft.mozdev.org</a>"
+msgstr "<a href=\"http://mycroft.mozdev.org/\">mycroft.mozdev.org</a>에서 더 많은 검색 도구를 찾아보실 수 있습니다"
 
 #: src/olympia/browse/templates/browse/search_tools.html:95
-msgid ""
-"<a "
-"href=\"https://developer.mozilla.org/en/Creating_OpenSearch_plugins_for_Firefox\">Make"
-" your own</a> search tool"
+msgid "<a href=\"https://developer.mozilla.org/en/Creating_OpenSearch_plugins_for_Firefox\">Make your own</a> search tool"
 msgstr ""
 
-#: src/olympia/browse/templates/browse/themes.html:6
-#: src/olympia/browse/templates/browse/themes.html:9
-#: src/olympia/constants/base.py:174
+#: src/olympia/browse/templates/browse/themes.html:6 src/olympia/browse/templates/browse/themes.html:9 src/olympia/constants/base.py:174
 msgid "Complete Themes"
 msgstr "완전 테마"
 
@@ -3661,25 +2983,19 @@ msgstr "인기 급상승 완전 테마"
 msgid "See the %(cnt)s extension in %(name)s &raquo;"
 msgid_plural "See all %(cnt)s extensions in %(name)s &raquo;"
 msgstr[0] "%(name)s내 모든 확장 기능 (%(cnt)s) 보기 &raquo;"
+msgstr[1] ""
 
-#: src/olympia/browse/templates/browse/mobile/extensions.html:13
-#: src/olympia/compat/templates/compat/index.html:82
-#: src/olympia/devhub/templates/devhub/devhub_search.html:24
-#: src/olympia/devhub/templates/devhub/addons/activity.html:47
-#: src/olympia/search/templates/search/no_results.html:4
-#: src/olympia/search/templates/search/mobile/results.html:36
+#: src/olympia/browse/templates/browse/mobile/extensions.html:13 src/olympia/devhub/templates/devhub/devhub_search.html:24 src/olympia/devhub/templates/devhub/addons/activity.html:47
+#: src/olympia/search/templates/search/no_results.html:4 src/olympia/search/templates/search/mobile/results.html:36
 msgid "No results found."
 msgstr "검색 결과가 없습니다."
 
-#: src/olympia/browse/templates/browse/personas/base.html:6
-#: src/olympia/browse/templates/browse/personas/mobile/base.html:7
+#: src/olympia/browse/templates/browse/personas/base.html:6 src/olympia/browse/templates/browse/personas/mobile/base.html:7
 msgid "{0} Themes"
 msgstr "{0} 테마"
 
 #. {0} is a user's name.
-#: src/olympia/browse/templates/browse/personas/base.html:15
-#: src/olympia/browse/templates/browse/personas/base.html:40
-#: src/olympia/browse/templates/browse/personas/grid.html:8
+#: src/olympia/browse/templates/browse/personas/base.html:15 src/olympia/browse/templates/browse/personas/base.html:40 src/olympia/browse/templates/browse/personas/grid.html:8
 msgid "{0}'s Themes"
 msgstr "{0}의 테마"
 
@@ -3699,30 +3015,22 @@ msgstr "내 웹 브라우저를 나만의 스타일대로! 나만의 디자인�
 msgid "Learn more"
 msgstr "자세히 보기"
 
-#: src/olympia/browse/templates/browse/personas/category_landing.html:6
-#: src/olympia/browse/templates/browse/personas/mobile/category_landing.html:5
+#: src/olympia/browse/templates/browse/personas/category_landing.html:6 src/olympia/browse/templates/browse/personas/mobile/category_landing.html:5
 msgid "View All Recently Added"
 msgstr "최근 등록된 순으로 모두 보기"
 
-#: src/olympia/browse/templates/browse/personas/category_landing.html:7
-#: src/olympia/browse/templates/browse/personas/mobile/category_landing.html:6
+#: src/olympia/browse/templates/browse/personas/category_landing.html:7 src/olympia/browse/templates/browse/personas/mobile/category_landing.html:6
 msgid "View All Most Popular"
 msgstr "가장 인기있는 순으로 모두 보기"
 
-#: src/olympia/browse/templates/browse/personas/category_landing.html:8
-#: src/olympia/browse/templates/browse/personas/mobile/category_landing.html:7
+#: src/olympia/browse/templates/browse/personas/category_landing.html:8 src/olympia/browse/templates/browse/personas/mobile/category_landing.html:7
 msgid "View All Top Rated"
 msgstr "상위 별점 순으로 모두 보기"
 
 #: src/olympia/browse/templates/browse/personas/category_landing.html:40
 #, python-format
-msgid ""
-"Over 300,000 designs to personalize your browser! Move your mouse over a "
-"Background Theme to try it on. <a href=\"%(url)s\" class=\"more-info\">Start"
-" exploring</a>"
-msgstr ""
-"30만개가 넘는 디자인으로 웹 브라우저를 꾸밀 수 있습니다! 마우스 커서를 테마 위에 올려서 미리 입혀보세요. <a "
-"href=\"%(url)s\" class=\"more-info\">둘러보기</a>"
+msgid "Over 300,000 designs to personalize your browser! Move your mouse over a Background Theme to try it on. <a href=\"%(url)s\" class=\"more-info\">Start exploring</a>"
+msgstr "30만개가 넘는 디자인으로 웹 브라우저를 꾸밀 수 있습니다! 마우스 커서를 테마 위에 올려서 미리 입혀보세요. <a href=\"%(url)s\" class=\"more-info\">둘러보기</a>"
 
 #: src/olympia/browse/templates/browse/personas/category_landing.html:47
 msgid "Want more personalization?"
@@ -3732,13 +3040,8 @@ msgstr "더 개인화를 원하세요?"
 #. theme.
 #: src/olympia/browse/templates/browse/personas/category_landing.html:50
 #, python-format
-msgid ""
-"Complete Themes transform the look of your browser with styles for the "
-"window frame, address bar, buttons, tabs, and menus. <a href=\"%(url)s\" "
-"class=\"more-info\">Start exploring</a>"
-msgstr ""
-"완전 테마는 웹 브라우저의 창 프레임, 주소 줄, 버튼, 탭, 메뉴 스타일을 일정한 스타일로 변형합니다. <a "
-"href=\"%(url)s\" class=\"more-info\">둘러보기</a>"
+msgid "Complete Themes transform the look of your browser with styles for the window frame, address bar, buttons, tabs, and menus. <a href=\"%(url)s\" class=\"more-info\">Start exploring</a>"
+msgstr "완전 테마는 웹 브라우저의 창 프레임, 주소 줄, 버튼, 탭, 메뉴 스타일을 일정한 스타일로 변형합니다. <a href=\"%(url)s\" class=\"more-info\">둘러보기</a>"
 
 #: src/olympia/browse/templates/browse/personas/category_landing.html:76
 msgid "Up & Coming Themes"
@@ -3768,7 +3071,7 @@ msgstr "&laquo; 모든 테마"
 msgid "All"
 msgstr "전체"
 
-#: src/olympia/compat/forms.py:22 src/olympia/search/views.py:525
+#: src/olympia/compat/forms.py:22 src/olympia/editors/templates/editors/base.html:69 src/olympia/search/views.py:518
 msgid "All Add-ons"
 msgstr "모든 부가 기능"
 
@@ -3780,79 +3083,22 @@ msgstr "이진"
 msgid "Non-binary"
 msgstr "비 이진"
 
-#. Review points sources other than add-ons and themes.
-#: src/olympia/compat/views.py:87 src/olympia/constants/base.py:388
-#: src/olympia/devhub/forms.py:162
-#: src/olympia/editors/templates/editors/performance.html:75
-msgid "Other"
-msgstr "기타"
-
-#: src/olympia/compat/templates/compat/index.html:4
-msgid "Add-on Compatibility Report for {app} {version}"
-msgstr "{app} {version}의 부가 기능 호환성 보고서"
-
-#: src/olympia/compat/templates/compat/index.html:11
-msgid "{app} {version} Compatibility"
-msgstr "{app} {version} 호환성"
-
-#: src/olympia/compat/templates/compat/index.html:17
-#, python-format
-msgid "Top 95%% compatible with previous version"
-msgstr ""
-
-#: src/olympia/compat/templates/compat/index.html:18
-#, python-format
-msgid "Top 95%% of all add-ons"
-msgstr ""
-
-#: src/olympia/compat/templates/compat/index.html:19
-msgid "All active add-ons"
-msgstr "활동중인 모든 부가 기능"
-
-#: src/olympia/compat/templates/compat/index.html:23
-#: src/olympia/constants/base.py:401
-msgid "App"
-msgstr "App"
-
-#: src/olympia/compat/templates/compat/index.html:55
-msgid "Details for add-ons compatible with previous version:"
-msgstr "이전 버전과의 호환성 세부 정보:"
-
-#: src/olympia/compat/templates/compat/index.html:57
-msgid "Show all versions"
-msgstr "모든 버전 보기"
-
-#: src/olympia/compat/templates/compat/index.html:59
-msgid "Details for add-ons compatible with all versions:"
-msgstr "모든 버전의 부가 기능 호환성 상세 정보:"
-
-#: src/olympia/compat/templates/compat/index.html:61
-msgid "Show previous version only"
-msgstr "구버전만 표시"
-
 #: src/olympia/compat/templates/compat/reporter.html:3
 msgid "Add-on Compatibility Reports"
 msgstr "부가 기능 호환성 제보"
 
-#: src/olympia/compat/templates/compat/reporter.html:11
-#: src/olympia/compat/templates/compat/reporter_detail.html:35
+#: src/olympia/compat/templates/compat/reporter.html:11 src/olympia/compat/templates/compat/reporter_detail.html:35
 #, python-format
 msgid ""
-"<p> Reports submitted to us through the <a href=\"%(url_)s\">Add-on "
-"Compatibility Reporter</a> are collected here for developers to view. These "
-"reports help us determine which add-ons will need help supporting an "
-"upcoming Firefox version. </p>"
-msgstr ""
-"<p> <a href=\"%(url_)s\">부가 기능 호환성 제보자</a>를 통해 들어온 제보들은 개발자들을 위해 이곳에 정리되어 "
-"있습니다. 이러한 제보들은 앞으로 올라올 Firefox 버전과의 호환성 작업 지원이 필요한 부가 기능을 판별하는데 많은 도움이 되고 "
-"있습니다. </p>"
+"<p> Reports submitted to us through the <a href=\"%(url_)s\">Add-on Compatibility Reporter</a> are collected here for developers to view. These reports help us determine which add-ons will need "
+"help supporting an upcoming Firefox version. </p>"
+msgstr "<p> <a href=\"%(url_)s\">부가 기능 호환성 제보자</a>를 통해 들어온 제보들은 개발자들을 위해 이곳에 정리되어 있습니다. 이러한 제보들은 앞으로 올라올 Firefox 버전과의 호환성 작업 지원이 필요한 부가 기능을 판별하는데 많은 도움이 되고 있습니다. </p>"
 
 #: src/olympia/compat/templates/compat/reporter.html:18
 msgid "Reports for your Add-ons"
 msgstr "내 부가 기능의 호환성 제보"
 
-#: src/olympia/compat/templates/compat/reporter.html:30
-#: src/olympia/compat/templates/compat/reporter_detail.html:9
+#: src/olympia/compat/templates/compat/reporter.html:30 src/olympia/compat/templates/compat/reporter_detail.html:9
 msgid "Add-on Compatibility Center"
 msgstr "부가 기능 호환성 센터"
 
@@ -3860,9 +3106,7 @@ msgstr "부가 기능 호환성 센터"
 msgid "Enter the GUID of an add-on below to view any reports we've received."
 msgstr "제보된 내역을 보려면 아래에 부가 기능의 GUID를 입력하세요."
 
-#: src/olympia/compat/templates/compat/reporter_detail.html:3
-#: src/olympia/compat/templates/compat/reporter_detail.html:10
-#: src/olympia/compat/templates/compat/reporter_detail.html:25
+#: src/olympia/compat/templates/compat/reporter_detail.html:3 src/olympia/compat/templates/compat/reporter_detail.html:10 src/olympia/compat/templates/compat/reporter_detail.html:25
 msgid "{addon} Compatibility Reports"
 msgstr "{addon}에 대한 호환성 제보"
 
@@ -3870,14 +3114,15 @@ msgstr "{addon}에 대한 호환성 제보"
 msgid "{0} success report"
 msgid_plural "{0} success reports"
 msgstr[0] "성공 제보 {0}개"
+msgstr[1] ""
 
 #: src/olympia/compat/templates/compat/reporter_detail.html:17
 msgid "{0} problem report"
 msgid_plural "{0} problem reports"
 msgstr[0] "문제 제보 {0}개"
+msgstr[1] ""
 
-#: src/olympia/compat/templates/compat/reporter_detail.html:21
-#: src/olympia/users/templates/users/profile.html:70
+#: src/olympia/compat/templates/compat/reporter_detail.html:21 src/olympia/users/templates/users/profile.html:70
 msgid "View all"
 msgstr "모두 보기"
 
@@ -3889,10 +3134,8 @@ msgstr "애플리케이션 별로 보기"
 msgid "Report Type"
 msgstr "제보 종류"
 
-#: src/olympia/compat/templates/compat/reporter_detail.html:47
-#: src/olympia/devhub/forms.py:784
-#: src/olympia/devhub/templates/devhub/addons/ajax_compat_update.html:17
-#: src/olympia/editors/forms.py:108 src/olympia/zadmin/forms.py:45
+#: src/olympia/compat/templates/compat/reporter_detail.html:47 src/olympia/devhub/forms.py:785 src/olympia/devhub/templates/devhub/addons/ajax_compat_update.html:17 src/olympia/editors/forms.py:108
+#: src/olympia/editors/forms.py:248 src/olympia/zadmin/forms.py:45
 msgid "Application"
 msgstr "애플리케이션"
 
@@ -3904,8 +3147,7 @@ msgstr "애플리케이션 빌드"
 msgid "Platform"
 msgstr "플랫폼"
 
-#: src/olympia/compat/templates/compat/reporter_detail.html:50
-#: src/olympia/editors/templates/editors/themes/themes.html:40
+#: src/olympia/compat/templates/compat/reporter_detail.html:50 src/olympia/editors/templates/editors/themes/themes.html:40
 msgid "Submitted"
 msgstr "등록 완료"
 
@@ -3933,8 +3175,7 @@ msgstr "Thunderbird"
 msgid "SeaMonkey"
 msgstr "SeaMonkey"
 
-#: src/olympia/constants/applications.py:75
-#: src/olympia/pages/templates/pages/sunbird.html:4
+#: src/olympia/constants/applications.py:75 src/olympia/pages/templates/pages/sunbird.html:4
 msgid "Sunbird"
 msgstr "Sunbird"
 
@@ -3982,7 +3223,7 @@ msgstr "예비 심사 통과"
 msgid "Preliminarily Reviewed and Awaiting Full Review"
 msgstr "예비 심사 완료 및 전체 심사 대기중"
 
-#: src/olympia/constants/base.py:33 src/olympia/editors/helpers.py:924
+#: src/olympia/constants/base.py:33 src/olympia/editors/forms.py:258 src/olympia/editors/helpers.py:73 src/olympia/editors/helpers.py:1004
 #: src/olympia/editors/templates/editors/themes/history_table.html:34
 msgid "Deleted"
 msgstr "삭제됨"
@@ -4016,13 +3257,11 @@ msgstr "개발자"
 msgid "Viewer"
 msgstr "참관인"
 
-#: src/olympia/constants/base.py:137
-#: src/olympia/templates/mobile/header.html:7
+#: src/olympia/constants/base.py:137 src/olympia/templates/mobile/header.html:7
 msgid "Support"
 msgstr "도움말"
 
-#: src/olympia/constants/base.py:159 src/olympia/constants/base.py:172
-#: src/olympia/constants/platforms.py:10
+#: src/olympia/constants/base.py:159 src/olympia/constants/base.py:172 src/olympia/constants/platforms.py:10
 msgid "Any"
 msgstr "모든 종류"
 
@@ -4050,11 +3289,8 @@ msgstr ""
 msgid "Plugin"
 msgstr "플러그인"
 
-#: src/olympia/constants/base.py:167
-#: src/olympia/editors/templates/editors/includes/search_results_themes.html:5
-#: src/olympia/editors/templates/editors/themes/deleted.html:18
-#: src/olympia/editors/templates/editors/themes/history_table.html:8
-#: src/olympia/editors/templates/editors/themes/logs.html:17
+#: src/olympia/constants/base.py:167 src/olympia/editors/templates/editors/includes/search_results_themes.html:5 src/olympia/editors/templates/editors/themes/deleted.html:18
+#: src/olympia/editors/templates/editors/themes/history_table.html:8 src/olympia/editors/templates/editors/themes/logs.html:17
 msgid "Theme"
 msgstr "테마"
 
@@ -4088,6 +3324,11 @@ msgstr "사용자가 부가 기능을 다운로드한 다음에 요청하기"
 msgid "Ask before users can download this add-on"
 msgstr "사용자가 부가 기능을 다운로드하기 전에 요청하기"
 
+#. Review points sources other than add-ons and themes.
+#: src/olympia/constants/base.py:388 src/olympia/devhub/forms.py:162 src/olympia/editors/templates/editors/performance.html:75
+msgid "Other"
+msgstr "기타"
+
 #: src/olympia/constants/base.py:389
 msgid "Exception"
 msgstr "Exception"
@@ -4099,6 +3340,10 @@ msgstr "Release"
 #: src/olympia/constants/base.py:391
 msgid "Change"
 msgstr "Change"
+
+#: src/olympia/constants/base.py:401
+msgid "App"
+msgstr "App"
 
 #: src/olympia/constants/base.py:402
 msgid "Persona"
@@ -4236,34 +3481,25 @@ msgstr ""
 msgid "Signed of a preliminary review"
 msgstr ""
 
-#: src/olympia/constants/editors.py:14
-#: src/olympia/editors/templates/editors/themes/queue.html:76
-#: src/olympia/editors/templates/editors/themes/themes.html:87
+#: src/olympia/constants/editors.py:14 src/olympia/editors/templates/editors/themes/queue.html:76 src/olympia/editors/templates/editors/themes/themes.html:87
 msgid "Request More Info"
 msgstr "추가 정보 요청하기"
 
 # 80%
-#: src/olympia/constants/editors.py:15
-#: src/olympia/editors/templates/editors/themes/queue.html:74
-#: src/olympia/editors/templates/editors/themes/themes.html:91
+#: src/olympia/constants/editors.py:15 src/olympia/editors/templates/editors/themes/queue.html:74 src/olympia/editors/templates/editors/themes/themes.html:91
 msgid "Flag"
 msgstr "표시하기"
 
-#: src/olympia/constants/editors.py:16
-#: src/olympia/editors/templates/editors/themes/queue.html:72
-#: src/olympia/editors/templates/editors/themes/themes.html:93
+#: src/olympia/constants/editors.py:16 src/olympia/editors/templates/editors/themes/queue.html:72 src/olympia/editors/templates/editors/themes/themes.html:93
 msgid "Duplicate"
 msgstr "복사하기"
 
-#: src/olympia/constants/editors.py:17 src/olympia/editors/helpers.py:502
-#: src/olympia/editors/templates/editors/themes/queue.html:71
-#: src/olympia/editors/templates/editors/themes/themes.html:94
+#: src/olympia/constants/editors.py:17 src/olympia/editors/helpers.py:575 src/olympia/editors/templates/editors/themes/queue.html:71 src/olympia/editors/templates/editors/themes/themes.html:94
 msgid "Reject"
 msgstr "거부"
 
 # 87%
-#: src/olympia/constants/editors.py:18
-#: src/olympia/editors/templates/editors/themes/queue.html:70
+#: src/olympia/constants/editors.py:18 src/olympia/editors/templates/editors/themes/queue.html:70
 msgid "Approve"
 msgstr "승인하기"
 
@@ -4359,7 +3595,7 @@ msgstr "Solaris"
 msgid "Android"
 msgstr "안드로이드"
 
-#: src/olympia/core/apps.py:19
+#: src/olympia/core/apps.py:21
 msgid "Core"
 msgstr ""
 
@@ -4396,9 +3632,7 @@ msgstr ""
 msgid "Message not eligible for annotation"
 msgstr ""
 
-#: src/olympia/devhub/forms.py:124
-#: src/olympia/devhub/templates/devhub/versions/edit.html:94
-#: src/olympia/users/templates/users/edit.html:150
+#: src/olympia/devhub/forms.py:124 src/olympia/devhub/templates/devhub/versions/edit.html:94 src/olympia/users/templates/users/edit.html:150
 msgid "Details"
 msgstr "세부 내역"
 
@@ -4495,13 +3729,11 @@ msgid "Submit my add-on for manual review."
 msgstr ""
 
 #: src/olympia/devhub/forms.py:537
-msgid "Do not list my add-on on this site (beta)"
+msgid "Do not list my add-on on this site"
 msgstr ""
 
 #: src/olympia/devhub/forms.py:538
-msgid ""
-"Check this option if you intend to distribute your add-on on your own and "
-"only need it to be signed by Mozilla."
+msgid "Check this option if you intend to distribute your add-on on your own and only need it to be signed by Mozilla."
 msgstr ""
 
 #: src/olympia/devhub/forms.py:544
@@ -4509,20 +3741,14 @@ msgid "This add-on will be bundled with an application installer."
 msgstr ""
 
 #: src/olympia/devhub/forms.py:546
-msgid ""
-"Add-ons that are bundled with application installers will be code reviewed "
-"by Mozilla before they are signed and are held to a higher quality standard."
+msgid "Add-ons that are bundled with application installers will be code reviewed by Mozilla before they are signed and are held to a higher quality standard."
 msgstr ""
 
-#: src/olympia/devhub/forms.py:565
-#: src/olympia/devhub/templates/devhub/addons/submit/select-review.html:24
-#: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:42
+#: src/olympia/devhub/forms.py:565 src/olympia/devhub/templates/devhub/addons/submit/select-review.html:24 src/olympia/devhub/templates/devhub/docs/policies-reviews.html:42
 msgid "Full Review"
 msgstr "전체 심사"
 
-#: src/olympia/devhub/forms.py:566
-#: src/olympia/devhub/templates/devhub/addons/submit/select-review.html:47
-#: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:153
+#: src/olympia/devhub/forms.py:566 src/olympia/devhub/templates/devhub/addons/submit/select-review.html:47 src/olympia/devhub/templates/devhub/docs/policies-reviews.html:153
 msgid "Preliminary Review"
 msgstr "예비 심사"
 
@@ -4531,61 +3757,53 @@ msgid "Please choose a review nomination type"
 msgstr "받고자 하는 심사의 종류를 선택하세요"
 
 #: src/olympia/devhub/forms.py:574
-msgid ""
-"A file with a version ending with a|alpha|b|beta|pre|rc and an optional "
-"number is detected as beta."
+msgid "A file with a version ending with a|alpha|b|beta|pre|rc and an optional number is detected as beta."
 msgstr ""
 
 #: src/olympia/devhub/forms.py:592
 #, python-format
-msgid "Version %s already exists"
-msgstr "버전 %s이(가) 이미 있습니다"
-
-#: src/olympia/devhub/forms.py:604
-msgid ""
-"Select a valid choice. That choice is not one of the available choices."
+msgid "Version %s already exists, or was uploaded before."
 msgstr ""
 
-#: src/olympia/devhub/forms.py:610
-msgid ""
-"A file with a version ending with a|alpha|b|beta and an optional number is "
-"detected as beta."
+#: src/olympia/devhub/forms.py:605
+msgid "Select a valid choice. That choice is not one of the available choices."
 msgstr ""
 
-#: src/olympia/devhub/forms.py:633
+#: src/olympia/devhub/forms.py:611
+msgid "A file with a version ending with a|alpha|b|beta and an optional number is detected as beta."
+msgstr ""
+
+#: src/olympia/devhub/forms.py:634
 msgid "You cannot upload any more files for this version."
 msgstr "이 버전엔 이이상 많은 파일을 업로드 할 수 없습니다."
 
-#: src/olympia/devhub/forms.py:639
+#: src/olympia/devhub/forms.py:640
 msgid "Version doesn't match"
 msgstr "버전이 일치하지 않습니다"
 
-#: src/olympia/devhub/forms.py:668
-msgid ""
-"You cannot delete a file once the review process has started. You must "
-"delete the whole version."
+#: src/olympia/devhub/forms.py:669
+msgid "You cannot delete a file once the review process has started. You must delete the whole version."
 msgstr "심사가 시작된 이후엔 파일을 삭제할 수 없습니다. 버전 전체를 삭제해야 합니다."
 
 # 98%
 # 100%
-#: src/olympia/devhub/forms.py:688
+#: src/olympia/devhub/forms.py:689
 msgid "The platform All cannot be combined with specific platforms."
 msgstr "모든 플랫폼을 특정 플랫폼과 합칠 수는 없습니다. "
 
-#: src/olympia/devhub/forms.py:693
+#: src/olympia/devhub/forms.py:694
 msgid "A platform can only be chosen once."
 msgstr "플랫폼은 한번에 한개만 선택할 수 있습니다."
 
-#: src/olympia/devhub/forms.py:706
+#: src/olympia/devhub/forms.py:707
 msgid "A review type must be selected."
 msgstr "심사 종류를 선택해야 합니다."
 
-#: src/olympia/devhub/forms.py:788 src/olympia/editors/forms.py:114
-#: src/olympia/zadmin/forms.py:49 src/olympia/zadmin/forms.py:52
+#: src/olympia/devhub/forms.py:789 src/olympia/editors/forms.py:114 src/olympia/editors/forms.py:254 src/olympia/zadmin/forms.py:49 src/olympia/zadmin/forms.py:52
 msgid "Select an application first"
 msgstr "먼저 지원할 애플리케이션 선택"
 
-#: src/olympia/devhub/forms.py:840
+#: src/olympia/devhub/forms.py:841
 msgid "There cannot be more than 3 required add-ons."
 msgstr "설치가 필요한 부가 기능은 3개 이상 지정할 수 없습니다."
 
@@ -4601,199 +3819,185 @@ msgstr "내 제출 내역"
 msgid "Developer Docs"
 msgstr "개발자 문서"
 
-#. L10n: first parameter is the number of errors
 # {0} is a number
+#. L10n: first parameter is the number of errors
 #: src/olympia/devhub/helpers.py:200
 msgid "{0} error"
 msgid_plural "{0} errors"
 msgstr[0] "오류 {0}개"
+msgstr[1] ""
 
-#. L10n: first parameter is the number of warnings
 # {0} is a number
+#. L10n: first parameter is the number of warnings
 #: src/olympia/devhub/helpers.py:203
 msgid "{0} warning"
 msgid_plural "{0} warnings"
 msgstr[0] "경고 {0}개"
+msgstr[1] ""
 
-#: src/olympia/devhub/models.py:375
-#: src/olympia/reviews/templates/reviews/add.html:58
+#: src/olympia/devhub/models.py:375 src/olympia/reviews/templates/reviews/add.html:58
 msgid "Review"
 msgstr "평가"
 
-#: src/olympia/devhub/tasks.py:551
+#: src/olympia/devhub/tasks.py:583
 #, python-format
 msgid "%s responded with %s (%s)."
 msgstr "%s이(가) %s (%s)에 응답했습니다."
 
-#: src/olympia/devhub/tasks.py:555
+#: src/olympia/devhub/tasks.py:587
 #, python-format
 msgid "Connection to \"%s\" timed out."
 msgstr "\"%s\"에 대한 연결 시간이 초과됐습니다."
 
-#: src/olympia/devhub/tasks.py:557
+#: src/olympia/devhub/tasks.py:589
 #, python-format
 msgid "Could not contact host at \"%s\"."
 msgstr "\"%s\"에 호스트 접속을 할 수 없습니다."
 
-#: src/olympia/devhub/utils.py:104
+#: src/olympia/devhub/utils.py:105
 #, python-format
-msgid ""
-"Validation generated too many errors/warnings so %s messages were truncated."
-" After addressing the visible messages, you'll be able to see the others."
-msgstr ""
-"검사 과정에서 너무 많은 오류/경고가 발생했으며 %s개의 메세지가 잘려져 있는 상태입니다. 현재 표시된 메세지부터 확인 후에 나머지 "
-"메세지를 확인하실 수 있습니다."
+msgid "Validation generated too many errors/warnings so %s messages were truncated. After addressing the visible messages, you'll be able to see the others."
+msgstr "검사 과정에서 너무 많은 오류/경고가 발생했으며 %s개의 메세지가 잘려져 있는 상태입니다. 현재 표시된 메세지부터 확인 후에 나머지 메세지를 확인하실 수 있습니다."
 
-#: src/olympia/devhub/views.py:183
+#: src/olympia/devhub/views.py:182
 msgid "All My Add-ons"
 msgstr "내가 제작한 모든 부가 기능"
 
-#: src/olympia/devhub/views.py:210
+#: src/olympia/devhub/views.py:209
 msgid "All Activity"
 msgstr "전체 활동 내역"
 
-#: src/olympia/devhub/views.py:211
+#: src/olympia/devhub/views.py:210
 msgid "Add-on Updates"
 msgstr "부가 기능 업데이트"
 
-#: src/olympia/devhub/views.py:212
+#: src/olympia/devhub/views.py:211
 msgid "Add-on Status"
 msgstr "부가 기능 상태"
 
-#: src/olympia/devhub/views.py:213
+#: src/olympia/devhub/views.py:212
 msgid "User Collections"
 msgstr "사용자 모음집"
 
-#: src/olympia/devhub/views.py:214
-#: src/olympia/devhub/templates/devhub/docs/policies-maintenance.html:68
-#: src/olympia/pages/templates/pages/dev_faq.html:38
+#: src/olympia/devhub/views.py:213 src/olympia/devhub/templates/devhub/docs/policies-maintenance.html:68 src/olympia/pages/templates/pages/dev_faq.html:38
 #: src/olympia/pages/templates/pages/dev_faq.html:484
 msgid "User Reviews"
 msgstr "사용자 평가"
 
-#: src/olympia/devhub/views.py:327 src/olympia/devhub/views.py:331
-#: src/olympia/devhub/views.py:484 src/olympia/devhub/views.py:513
-#: src/olympia/devhub/views.py:564 src/olympia/devhub/views.py:1150
+#: src/olympia/devhub/views.py:326 src/olympia/devhub/views.py:330 src/olympia/devhub/views.py:485 src/olympia/devhub/views.py:514 src/olympia/devhub/views.py:565 src/olympia/devhub/views.py:1157
 msgid "Changes successfully saved."
 msgstr "변경 내역이 성공적으로 저장되었습니다."
 
-#: src/olympia/devhub/views.py:334 src/olympia/devhub/views.py:1631
+#: src/olympia/devhub/views.py:333 src/olympia/devhub/views.py:1638
 msgid "Please check the form for errors."
 msgstr "오류 유형에 체크해 주세요."
 
-#: src/olympia/devhub/views.py:346
+#: src/olympia/devhub/views.py:345
 msgid "Add-on cannot be deleted. Disable this add-on instead."
 msgstr "부가 기능을 삭제할 수 없습니다. 사용 정지 상태로 만드세요."
 
-#: src/olympia/devhub/views.py:356
+#: src/olympia/devhub/views.py:355
 msgid "Theme deleted."
 msgstr "테마가 삭제됐습니다."
 
-#: src/olympia/devhub/views.py:356
+#: src/olympia/devhub/views.py:355
 msgid "Add-on deleted."
 msgstr "부가 기능이 삭제되었습니다."
 
-#: src/olympia/devhub/views.py:362
+#: src/olympia/devhub/views.py:361
 msgid "URL name was incorrect. Theme was not deleted."
 msgstr ""
 
-#: src/olympia/devhub/views.py:367
+#: src/olympia/devhub/views.py:366
 msgid "URL name was incorrect. Add-on was not deleted."
 msgstr ""
 
-#: src/olympia/devhub/views.py:449
+#: src/olympia/devhub/views.py:450
 msgid "An author has been added to your add-on"
 msgstr ""
 
-#: src/olympia/devhub/views.py:456
+#: src/olympia/devhub/views.py:457
 msgid "An author has a role changed on your add-on"
 msgstr ""
 
-#: src/olympia/devhub/views.py:476
+#: src/olympia/devhub/views.py:477
 msgid "An author has been removed from your add-on"
 msgstr ""
 
-#: src/olympia/devhub/views.py:519
+#: src/olympia/devhub/views.py:520
 msgid "There were errors in your submission."
 msgstr "등록 과정 도중 오류가 발생했습니다."
 
-#: src/olympia/devhub/views.py:583
+#: src/olympia/devhub/views.py:584
 msgid "Validate Add-on"
 msgstr "부가 기능 검사"
 
-#: src/olympia/devhub/views.py:594
+#: src/olympia/devhub/views.py:595
 msgid "Check Add-on Compatibility"
 msgstr "부가 기능 호환성 검사"
 
-#: src/olympia/devhub/views.py:808 src/olympia/signing/views.py:90
+#: src/olympia/devhub/views.py:809 src/olympia/signing/views.py:95
 msgid "You cannot submit this type of add-on"
 msgstr ""
 
-#: src/olympia/devhub/views.py:1051 src/olympia/users/forms.py:471
+#: src/olympia/devhub/views.py:1052 src/olympia/users/forms.py:471
 msgid "Images must be either PNG or JPG."
 msgstr "이미지는 PNG나 JPG 형식이어야 합니다."
 
-#: src/olympia/devhub/views.py:1055
+#: src/olympia/devhub/views.py:1056
 msgid "Icons cannot be animated."
 msgstr "움직이는 아이콘은 사용할 수 없습니다."
 
-#: src/olympia/devhub/views.py:1057
+#: src/olympia/devhub/views.py:1058
 msgid "Images cannot be animated."
 msgstr "움직이는 이미지는 제대로 작동하지 않습니다."
 
-#: src/olympia/devhub/views.py:1070
+#: src/olympia/devhub/views.py:1071
 #, python-format
 msgid "Images cannot be larger than %dKB."
 msgstr "이미지는 %dKB보다 작아야 합니다."
 
 #. L10n: {0} is an image width (in pixels), {1} is a height.
-#: src/olympia/devhub/views.py:1080
+#: src/olympia/devhub/views.py:1081
 msgid "Image must be exactly {0} pixels wide and {1} pixels tall."
 msgstr "이미지 크기는 가로 {0} 픽셀 세로 {1} 픽셀로 정확히 맞춰야 합니다."
 
-#: src/olympia/devhub/views.py:1087
+#: src/olympia/devhub/views.py:1088
 msgid "There was an error uploading your preview."
 msgstr "미리보기 업로드 도중 오류가 있었습니다."
 
-#: src/olympia/devhub/views.py:1189
+#: src/olympia/devhub/views.py:1196
 #, python-format
 msgid "Version %s disabled."
 msgstr "%s 버전이 사용 불가 상태가 되었습니다."
 
-#: src/olympia/devhub/views.py:1193
+#: src/olympia/devhub/views.py:1200
 #, python-format
 msgid "Version %s deleted."
 msgstr "%s 버전이 삭제되었습니다."
 
-#: src/olympia/devhub/views.py:1203
-msgid ""
-"This upload has failed validation, and may lack complete validation results."
-" Please take due care when reviewing it."
+#: src/olympia/devhub/views.py:1210
+msgid "This upload has failed validation, and may lack complete validation results. Please take due care when reviewing it."
 msgstr "업로드한 파일의 검사 작업에 실패했으므로 완전한 검사 결과가 누락되었을 수 있습니다. 심사시 이점에 유의해 주세요."
 
-#: src/olympia/devhub/views.py:1677
+#: src/olympia/devhub/views.py:1684
 msgid "Preliminary Review Requested."
 msgstr "예비 심사를 요청했습니다."
 
-#: src/olympia/devhub/views.py:1678
+#: src/olympia/devhub/views.py:1685
 msgid "Full Review Requested."
 msgstr "전체 심사를 요청했습니다."
 
-#: src/olympia/devhub/views.py:1779
-msgid ""
-"Your old credentials were revoked and are no longer valid. Be sure to update"
-" all API clients with the new credentials."
+#: src/olympia/devhub/views.py:1786
+msgid "Your old credentials were revoked and are no longer valid. Be sure to update all API clients with the new credentials."
 msgstr ""
 
-#: src/olympia/devhub/views.py:1797
+#: src/olympia/devhub/views.py:1804
 msgid "New API key created"
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/agreement.html:2
-msgid ""
-"Before starting, please read and accept our Firefox Add-on Distribution "
-"Agreement. It also links to our Privacy Notice which explains how we handle "
-"your information."
+msgid "Before starting, please read and accept our Firefox Add-on Distribution Agreement. It also links to our Privacy Notice which explains how we handle your information."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/agreement.html:13
@@ -4808,44 +4012,30 @@ msgstr "약관에 동의합니다"
 msgid "or <a href=\"{0}\">Cancel</a>"
 msgstr "또는 <a href=\"{0}\">취소</a>"
 
-#: src/olympia/devhub/templates/devhub/base.html:23
-#: src/olympia/devhub/templates/devhub/base_impala.html:20
-#: src/olympia/discovery/templates/discovery/addons/base.html:17
+#: src/olympia/devhub/templates/devhub/base.html:23 src/olympia/devhub/templates/devhub/base_impala.html:20 src/olympia/discovery/templates/discovery/addons/base.html:17
 msgid "Back to Add-ons"
 msgstr "부가 기능으로 돌아가기"
 
 #. {0} is a search term, such as Firebug.
 #. {0} is a search query.
-#: src/olympia/devhub/templates/devhub/devhub_search.html:4
-#: src/olympia/search/templates/search/results.html:9
-#: src/olympia/search/templates/search/mobile/results.html:6
+#: src/olympia/devhub/templates/devhub/devhub_search.html:4 src/olympia/search/templates/search/results.html:9 src/olympia/search/templates/search/mobile/results.html:6
 msgid "{0} :: Search"
 msgstr "{0} :: 검색"
 
-#: src/olympia/devhub/templates/devhub/devhub_search.html:6
-#: src/olympia/devhub/templates/devhub/search.html:8
-#: src/olympia/editors/forms.py:435 src/olympia/editors/forms.py:437
-#: src/olympia/editors/templates/editors/queue.html:27
-#: src/olympia/editors/templates/editors/themes/queue_list.html:14
-#: src/olympia/search/templates/search/collections.html:17
-#: src/olympia/search/templates/search/personas.html:18
-#: src/olympia/search/templates/search/results.html:18
-#: src/olympia/search/templates/search/mobile/results.html:8
-#: src/olympia/templates/search.html:14
+#: src/olympia/devhub/templates/devhub/devhub_search.html:6 src/olympia/devhub/templates/devhub/search.html:8 src/olympia/editors/forms.py:534 src/olympia/editors/forms.py:536
+#: src/olympia/editors/templates/editors/queue.html:27 src/olympia/editors/templates/editors/themes/queue_list.html:14 src/olympia/search/templates/search/collections.html:17
+#: src/olympia/search/templates/search/personas.html:18 src/olympia/search/templates/search/results.html:18 src/olympia/search/templates/search/mobile/results.html:8 src/olympia/templates/search.html:14
 #: src/olympia/templates/impala/search.html:18
 msgid "Search"
 msgstr "검색"
 
-#: src/olympia/devhub/templates/devhub/devhub_search.html:11
-#: src/olympia/devhub/templates/devhub/devhub_search.html:15
-#: src/olympia/search/templates/search/collections.html:18
+#: src/olympia/devhub/templates/devhub/devhub_search.html:11 src/olympia/devhub/templates/devhub/devhub_search.html:15 src/olympia/search/templates/search/collections.html:18
 #: src/olympia/search/templates/search/personas.html:20
 msgid "Search Results"
 msgstr "검색 결과"
 
 #. {0} is a search term, such as Firebug.
-#: src/olympia/devhub/templates/devhub/devhub_search.html:13
-#: src/olympia/search/templates/search/results.html:11
+#: src/olympia/devhub/templates/devhub/devhub_search.html:13 src/olympia/search/templates/search/results.html:11
 msgid "Search Results for \"{0}\""
 msgstr "\"{0}\"에 대한 검색 결과"
 
@@ -4866,9 +4056,7 @@ msgid "AMO Reviewers"
 msgstr "AMO 심사원"
 
 #: src/olympia/devhub/templates/devhub/index.html:29
-msgid ""
-"Get ahead! Become an AMO Reviewer today and get your add-ons reviewed "
-"faster."
+msgid "Get ahead! Become an AMO Reviewer today and get your add-ons reviewed faster."
 msgstr "출세의 지름길! AMO 심사원이 되서 내 부가 기능을 빠르게 심사합시다."
 
 #: src/olympia/devhub/templates/devhub/index.html:32
@@ -4881,33 +4069,25 @@ msgstr ""
 
 #: src/olympia/devhub/templates/devhub/index.html:41
 msgid ""
-"Add-ons let millions of Firefox users enhance and customize their browsing "
-"experience. If you're a Web developer and know <a "
-"href=\"https://developer.mozilla.org/docs/Web/HTML\">HTML</a>, <a "
-"href=\"https://developer.mozilla.org/docs/Web/JavaScript\">JavaScript</a>, "
-"and <a href=\"https://developer.mozilla.org/docs/Web/CSS\">CSS</a>, you "
-"already have all the necessary skills to make a great add-on."
+"Add-ons let millions of Firefox users enhance and customize their browsing experience. If you're a Web developer and know <a href=\"https://developer.mozilla.org/docs/Web/HTML\">HTML</a>, <a "
+"href=\"https://developer.mozilla.org/docs/Web/JavaScript\">JavaScript</a>, and <a href=\"https://developer.mozilla.org/docs/Web/CSS\">CSS</a>, you already have all the necessary skills to make a "
+"great add-on."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/index.html:51
-msgid ""
-"Head over to the <a href=\"https://developer.mozilla.org/Add-ons\">Mozilla "
-"Developer Network</a> to learn everything you need to know to get started."
+msgid "Head over to the <a href=\"https://developer.mozilla.org/Add-ons\">Mozilla Developer Network</a> to learn everything you need to know to get started."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/index.html:58
 msgid "Start Making Add-ons"
 msgstr "부가 기능 제작 시작"
 
-#: src/olympia/devhub/templates/devhub/index.html:86
-#: src/olympia/devhub/templates/devhub/addons/listing/items.html:25
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:15
+#: src/olympia/devhub/templates/devhub/index.html:86 src/olympia/devhub/templates/devhub/addons/listing/items.html:25 src/olympia/devhub/templates/devhub/includes/addon_details.html:20
 #: src/olympia/devhub/templates/devhub/personas/edit.html:43
 msgid "Status:"
 msgstr "상태:"
 
-#: src/olympia/devhub/templates/devhub/index.html:90
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:100
+#: src/olympia/devhub/templates/devhub/index.html:90 src/olympia/devhub/templates/devhub/includes/addon_details.html:87
 msgid "Visibility:"
 msgstr ""
 
@@ -4915,21 +4095,16 @@ msgstr ""
 msgid "Latest Version:"
 msgstr "최신 버전:"
 
-#: src/olympia/devhub/templates/devhub/index.html:109
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:145
-#: src/olympia/devhub/templates/devhub/personas/edit.html:49
+#: src/olympia/devhub/templates/devhub/index.html:109 src/olympia/devhub/templates/devhub/includes/addon_details.html:131 src/olympia/devhub/templates/devhub/personas/edit.html:49
 msgid "Queue Position:"
 msgstr "현재 대기열:"
 
-#: src/olympia/devhub/templates/devhub/index.html:110
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:146
-#: src/olympia/devhub/templates/devhub/personas/edit.html:50
+#: src/olympia/devhub/templates/devhub/index.html:110 src/olympia/devhub/templates/devhub/includes/addon_details.html:132 src/olympia/devhub/templates/devhub/personas/edit.html:50
 #, python-format
 msgid "%(position)s of %(total)s"
 msgstr "%(position)s / %(total)s"
 
-#: src/olympia/devhub/templates/devhub/index.html:120
-#: src/olympia/devhub/templates/devhub/includes/addons_edit_nav.html:19
+#: src/olympia/devhub/templates/devhub/index.html:120 src/olympia/devhub/templates/devhub/includes/addons_edit_nav.html:19
 msgid "Upload New Version"
 msgstr "새 버전 업로드하기"
 
@@ -4943,9 +4118,7 @@ msgstr ""
 
 #: src/olympia/devhub/templates/devhub/index.html:136
 #, python-format
-msgid ""
-"Upload an <a href=\"%(addon_url)s\">add-on</a> or <a "
-"href=\"%(theme_url)s\">theme</a> to get started!"
+msgid "Upload an <a href=\"%(addon_url)s\">add-on</a> or <a href=\"%(theme_url)s\">theme</a> to get started!"
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/nav.html:2
@@ -4973,17 +4146,10 @@ msgstr "확장 기능 개발"
 msgid "Lightweight Themes"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/nav.html:39
-#: src/olympia/devhub/templates/devhub/docs/policies-agreement.html:6
-#: src/olympia/devhub/templates/devhub/docs/policies-contact.html:6
-#: src/olympia/devhub/templates/devhub/docs/policies-maintenance.html:6
-#: src/olympia/devhub/templates/devhub/docs/policies-recommended.html:6
-#: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:6
-#: src/olympia/devhub/templates/devhub/docs/policies-submission.html:6
-#: src/olympia/devhub/templates/devhub/docs/policies.html:3
-#: src/olympia/devhub/templates/devhub/docs/policies.html:9
-#: src/olympia/devhub/templates/devhub/docs/policies.html:38
-#: src/olympia/devhub/templates/devhub/docs/policies.html:39
+#: src/olympia/devhub/templates/devhub/nav.html:39 src/olympia/devhub/templates/devhub/docs/policies-agreement.html:6 src/olympia/devhub/templates/devhub/docs/policies-contact.html:6
+#: src/olympia/devhub/templates/devhub/docs/policies-maintenance.html:6 src/olympia/devhub/templates/devhub/docs/policies-recommended.html:6
+#: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:6 src/olympia/devhub/templates/devhub/docs/policies-submission.html:6 src/olympia/devhub/templates/devhub/docs/policies.html:3
+#: src/olympia/devhub/templates/devhub/docs/policies.html:9 src/olympia/devhub/templates/devhub/docs/policies.html:38 src/olympia/devhub/templates/devhub/docs/policies.html:39
 msgid "Add-on Policies"
 msgstr "부가 기능 정책"
 
@@ -5024,37 +4190,15 @@ msgid "Use the field below to upload your add-on package."
 msgstr "부가 기능 패키지를 업로드 하려면 아래 항목을 입력해 주세요."
 
 #: src/olympia/devhub/templates/devhub/validate_addon.html:19
-msgid ""
-"After upload, a series of automated validation tests will run to check "
-"compatibility with the following application version:"
+msgid "After upload, a series of automated validation tests will run to check compatibility with the following application version:"
 msgstr "업로드 후엔 여러 자동 검사기가 다음 애플리케이션 버전들과의 호환성을 점검하게 됩니다:"
 
 #: src/olympia/devhub/templates/devhub/validate_addon.html:34
-msgid ""
-"After upload, a series of automated validation tests will be run on your "
-"file."
+msgid "After upload, a series of automated validation tests will be run on your file."
 msgstr "업로드 후엔 여러 자동 검사기가 파일을 실행해 볼 것입니다."
 
-#: src/olympia/devhub/templates/devhub/validate_addon.html:42
-#: src/olympia/devhub/templates/devhub/addons/submit/upload.html:23
+#: src/olympia/devhub/templates/devhub/validate_addon.html:42 src/olympia/devhub/templates/devhub/addons/submit/upload.html:23
 msgid "Do you want your add-on to be distributed on this site?"
-msgstr ""
-
-#: src/olympia/devhub/templates/devhub/validate_addon.html:49
-#: src/olympia/devhub/templates/devhub/addons/submit/upload.html:30
-#: src/olympia/devhub/templates/devhub/versions/add_file_modal.html:14
-#: src/olympia/devhub/templates/devhub/versions/add_file_modal.html:53
-#: src/olympia/devhub/templates/devhub/versions/list.html:298
-msgid "Warning:"
-msgstr ""
-
-#: src/olympia/devhub/templates/devhub/validate_addon.html:50
-#: src/olympia/devhub/templates/devhub/addons/submit/upload.html:31
-#, python-format
-msgid ""
-"Submission of unlisted add-ons for signing is currently in an open beta. "
-"Please <a href=\"%(url)s\" target=\"_blank\">report any bugs</a> that you "
-"encounter."
 msgstr ""
 
 #. first parameter is a filename like lorem-ipsum-1.0.2.xpi
@@ -5074,14 +4218,11 @@ msgstr "검사일:"
 msgid "Tested for compatibility against:"
 msgstr "호환성 검사 완료:"
 
-#: src/olympia/devhub/templates/devhub/addons/activity.html:4
-#: src/olympia/devhub/templates/devhub/addons/activity.html:20
+#: src/olympia/devhub/templates/devhub/addons/activity.html:4 src/olympia/devhub/templates/devhub/addons/activity.html:20
 msgid "Recent Activity for My Add-ons"
 msgstr "내 부가 기능의 최근 활동 내역"
 
-#: src/olympia/devhub/templates/devhub/addons/activity.html:14
-#: src/olympia/devhub/templates/devhub/addons/activity.html:19
-#: src/olympia/devhub/templates/devhub/addons/dashboard.html:33
+#: src/olympia/devhub/templates/devhub/addons/activity.html:14 src/olympia/devhub/templates/devhub/addons/activity.html:19 src/olympia/devhub/templates/devhub/addons/dashboard.html:33
 msgid "Recent Activity"
 msgstr "최근 활동 내역"
 
@@ -5103,42 +4244,30 @@ msgstr "활동 내역 정리"
 msgid "Activity"
 msgstr "활동 내역"
 
-#: src/olympia/devhub/templates/devhub/addons/activity.html:83
-#: src/olympia/devhub/templates/devhub/addons/dashboard.html:34
-#: src/olympia/devhub/templates/devhub/addons/dashboard.html:35
-#: src/olympia/devhub/templates/devhub/includes/blog_posts.html:4
-#: src/olympia/devhub/templates/devhub/includes/blog_posts.html:6
+#: src/olympia/devhub/templates/devhub/addons/activity.html:83 src/olympia/devhub/templates/devhub/addons/dashboard.html:34 src/olympia/devhub/templates/devhub/addons/dashboard.html:35
+#: src/olympia/devhub/templates/devhub/includes/blog_posts.html:4 src/olympia/devhub/templates/devhub/includes/blog_posts.html:6
 msgid "Subscribe to this feed"
 msgstr "이 피드 구독하기"
 
 #: src/olympia/devhub/templates/devhub/addons/ajax_compat_error.html:7
 #, python-format
 msgid ""
-"This add-on is incompatible with <b>%(app_name)s %(app_version)s</b>, the "
-"latest release of %(app_name)s. Please consider updating your add-on's "
-"compatibility info, or uploading a newer version of this add-on."
-msgstr ""
-"이 부가 기능은 %(app_name)s의 최신 버전인 <b>%(app_name)s %(app_version)s</b>에서 호환되지 "
-"않습니다. 부가 기능의 호환성 정보를 업데이트 하거나 최신 버전을 올리는 것을 검토해 주시기 바랍니다."
+"This add-on is incompatible with <b>%(app_name)s %(app_version)s</b>, the latest release of %(app_name)s. Please consider updating your add-on's compatibility info, or uploading a newer version of "
+"this add-on."
+msgstr "이 부가 기능은 %(app_name)s의 최신 버전인 <b>%(app_name)s %(app_version)s</b>에서 호환되지 않습니다. 부가 기능의 호환성 정보를 업데이트 하거나 최신 버전을 올리는 것을 검토해 주시기 바랍니다."
 
 #: src/olympia/devhub/templates/devhub/addons/ajax_compat_error.html:15
 #, python-format
 msgid ""
-"<a href=\"#\" class=\"button compat-update\" data-"
-"updateurl=\"%(update_url)s\">Update Compatibility</a> <a "
-"href=\"%(version_url)s\" class=\"button\">Upload New Version</a> or <a "
-"href=\"#\" class=\"close\">Ignore</a>"
-msgstr ""
-"<a href=\"#\" class=\"button compat-update\" data-"
-"updateurl=\"%(update_url)s\">호환성 업데이트</a> <a href=\"%(version_url)s\" "
-"class=\"button\">새 버전 업로드</a> or <a href=\"#\" class=\"close\">무시</a>"
+"<a href=\"#\" class=\"button compat-update\" data-updateurl=\"%(update_url)s\">Update Compatibility</a> <a href=\"%(version_url)s\" class=\"button\">Upload New Version</a> or <a href=\"#\" "
+"class=\"close\">Ignore</a>"
+msgstr "<a href=\"#\" class=\"button compat-update\" data-updateurl=\"%(update_url)s\">호환성 업데이트</a> <a href=\"%(version_url)s\" class=\"button\">새 버전 업로드</a> or <a href=\"#\" class=\"close\">무시</a>"
 
 #: src/olympia/devhub/templates/devhub/addons/ajax_compat_status.html:5
 msgid "View and update application compatibility ranges."
 msgstr "호환 가능 범위 내의 애플리케이션을 보고 업데이트를 하세요."
 
-#: src/olympia/devhub/templates/devhub/addons/ajax_compat_status.html:6
-#: src/olympia/devhub/templates/devhub/versions/edit.html:44
+#: src/olympia/devhub/templates/devhub/addons/ajax_compat_status.html:6 src/olympia/devhub/templates/devhub/versions/edit.html:44
 msgid "Compatibility"
 msgstr "호환성"
 
@@ -5146,38 +4275,25 @@ msgstr "호환성"
 msgid "Update Compatibility"
 msgstr "업데이트 호환성"
 
-#: src/olympia/devhub/templates/devhub/addons/ajax_compat_update.html:4
-msgid ""
-"Adjusting application information here will allow users to install your add-"
-"on even if the install manifest in the package indicates that the add-on is "
-"incompatible."
-msgstr ""
-"이곳의 애플리케이션 정보를 수정하면 패키지 내의 앱 정보 설정 파일이 비호환으로 인식하고 있던 부가 기능도 사용자가 설치할 수 있게 "
-"됩니다."
+#: src/olympia/devhub/templates/devhub/addons/ajax_compat_update.html:4 src/olympia/devhub/templates/devhub/versions/edit.html:45
+msgid "Adjusting application information here will allow users to install your add-on even if the install manifest in the package indicates that the add-on is incompatible."
+msgstr "이곳의 애플리케이션 정보를 수정하면 패키지 내의 앱 정보 설정 파일이 비호환으로 인식하고 있던 부가 기능도 사용자가 설치할 수 있게 됩니다."
 
 #: src/olympia/devhub/templates/devhub/addons/ajax_compat_update.html:18
 msgid "Supported Versions"
 msgstr "지원 버전"
 
-#: src/olympia/devhub/templates/devhub/addons/ajax_compat_update.html:31
-#: src/olympia/devhub/templates/devhub/versions/edit.html:63
+#: src/olympia/devhub/templates/devhub/addons/ajax_compat_update.html:31 src/olympia/devhub/templates/devhub/versions/edit.html:63
 msgid "Add Another Application&hellip;"
 msgstr "다른 애플리케이션 추가&hellip;"
 
-#: src/olympia/devhub/templates/devhub/addons/ajax_compat_update.html:38
-#: src/olympia/devhub/templates/devhub/addons/owner.html:86
-#: src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:46
-#: src/olympia/devhub/templates/devhub/versions/list.html:351
-#: src/olympia/devhub/templates/devhub/versions/list.html:353
-#: src/olympia/templates/impala/base.html:132
-#: src/olympia/templates/impala/base.html:143
-#: src/olympia/templates/impala/base.html:161
-#: src/olympia/templates/impala/base.html:171
+#: src/olympia/devhub/templates/devhub/addons/ajax_compat_update.html:38 src/olympia/devhub/templates/devhub/addons/owner.html:86 src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:45
+#: src/olympia/devhub/templates/devhub/versions/list.html:349 src/olympia/devhub/templates/devhub/versions/list.html:351 src/olympia/templates/impala/base.html:129
+#: src/olympia/templates/impala/base.html:140 src/olympia/templates/impala/base.html:158 src/olympia/templates/impala/base.html:168
 msgid "Close"
 msgstr "닫기"
 
-#: src/olympia/devhub/templates/devhub/addons/dashboard.html:43
-#: src/olympia/zadmin/templates/zadmin/index.html:22
+#: src/olympia/devhub/templates/devhub/addons/dashboard.html:43 src/olympia/zadmin/templates/zadmin/index.html:22
 #, python-format
 msgid "%(ago)s by %(user)s"
 msgstr "%(user)s님 %(ago)s 전"
@@ -5191,30 +4307,23 @@ msgstr "내 부가 기능의 이전 활동 내역"
 msgid "<b>{0}</b> theme"
 msgid_plural "<b>{0}</b> themes"
 msgstr[0] "<b>{0}</b> 테마"
+msgstr[1] ""
 
-#: src/olympia/devhub/templates/devhub/addons/edit.html:3
-#: src/olympia/devhub/templates/devhub/addons/listing/item_actions.html:25
-#: src/olympia/devhub/templates/devhub/addons/listing/item_actions_theme.html:7
-#: src/olympia/devhub/templates/devhub/includes/addons_edit_nav.html:2
-#: src/olympia/devhub/templates/devhub/personas/edit.html:6
-#: src/olympia/editors/templates/editors/themes/single.html:37
+#: src/olympia/devhub/templates/devhub/addons/edit.html:3 src/olympia/devhub/templates/devhub/addons/listing/item_actions.html:25
+#: src/olympia/devhub/templates/devhub/addons/listing/item_actions_theme.html:7 src/olympia/devhub/templates/devhub/includes/addons_edit_nav.html:2
+#: src/olympia/devhub/templates/devhub/personas/edit.html:6 src/olympia/editors/templates/editors/themes/single.html:37
 msgid "Edit Listing"
 msgstr "목록 표시 내역 편집하기"
 
-#: src/olympia/devhub/templates/devhub/addons/edit.html:13
-#: src/olympia/devhub/templates/devhub/includes/macros.html:18
-#: src/olympia/translations/templates/translations/all-locales.html:6
+#: src/olympia/devhub/templates/devhub/addons/edit.html:13 src/olympia/devhub/templates/devhub/includes/macros.html:18 src/olympia/translations/templates/translations/all-locales.html:6
 msgid "None"
 msgstr "없음"
 
-#: src/olympia/devhub/templates/devhub/addons/owner.html:4
-#: src/olympia/devhub/templates/devhub/addons/listing/item_actions.html:52
-#: src/olympia/devhub/templates/devhub/includes/addons_edit_nav.html:3
+#: src/olympia/devhub/templates/devhub/addons/owner.html:4 src/olympia/devhub/templates/devhub/addons/listing/item_actions.html:52 src/olympia/devhub/templates/devhub/includes/addons_edit_nav.html:3
 msgid "Manage Authors & License"
 msgstr "제작자 및 라이선스 관리"
 
-#: src/olympia/devhub/templates/devhub/addons/owner.html:29
-#: src/olympia/editors/templates/editors/review.html:270
+#: src/olympia/devhub/templates/devhub/addons/owner.html:29 src/olympia/editors/helpers.py:362 src/olympia/editors/templates/editors/review.html:270
 msgid "Authors"
 msgstr "제작자"
 
@@ -5224,31 +4333,21 @@ msgstr "제작자 역할 안내"
 
 #: src/olympia/devhub/templates/devhub/addons/owner.html:78
 msgid ""
-"<p>Add-ons can have any number of authors with 3 possible roles:</p> <ul> "
-"<li><b>Owner:</b> Can manage all aspects of the add-on's listing, including "
-"adding and removing other authors</li> <li><b>Developer:</b> Can manage all "
-"aspects of the add-on's listing, except for adding and removing other "
-"authors and managing payments</li> <li><b>Viewer:</b> Can view the add-on's "
-"settings and statistics, but cannot make any changes</li> </ul>"
+"<p>Add-ons can have any number of authors with 3 possible roles:</p> <ul> <li><b>Owner:</b> Can manage all aspects of the add-on's listing, including adding and removing other authors</li> "
+"<li><b>Developer:</b> Can manage all aspects of the add-on's listing, except for adding and removing other authors and managing payments</li> <li><b>Viewer:</b> Can view the add-on's settings and "
+"statistics, but cannot make any changes</li> </ul>"
 msgstr ""
-"<p>부가 기능 제작자엔 3가지 종류가 있습니다:</p> <ul> <li><b>소유자:</b> 다른 제작자의 추가와 삭제 및 부가 기능 "
-"전시에 사용되는 모든 항목의 관리 권한 보유</li> <li><b>개발자:</b> 다른 제작자의 추가 기능 및 결제 관련 권한을 제외한 "
-"권한 보유</li> <li><b>참관인:</b> 부가 기능의 설정 및 통계를 조회할 수 있지만 변경 불가</li> </ul>"
+"<p>부가 기능 제작자엔 3가지 종류가 있습니다:</p> <ul> <li><b>소유자:</b> 다른 제작자의 추가와 삭제 및 부가 기능 전시에 사용되는 모든 항목의 관리 권한 보유</li> <li><b>개발자:</b> 다른 제작자의 추가 기능 및 결제 관련 권한을 제외한 권한 보유</li> <li><b>참관인:</b> 부가 기능의 설정 및 통계를 "
+"조회할 수 있지만 변경 불가</li> </ul>"
 
-#: src/olympia/devhub/templates/devhub/addons/profile.html:3
-#: src/olympia/devhub/templates/devhub/addons/listing/item_actions.html:53
-#: src/olympia/devhub/templates/devhub/includes/addons_edit_nav.html:4
+#: src/olympia/devhub/templates/devhub/addons/profile.html:3 src/olympia/devhub/templates/devhub/addons/listing/item_actions.html:53 src/olympia/devhub/templates/devhub/includes/addons_edit_nav.html:4
 msgid "Manage Developer Profile"
 msgstr "개발자 프로필 관리"
 
 #: src/olympia/devhub/templates/devhub/addons/profile.html:16
 #, python-format
-msgid ""
-"Your <a href=\"%(url)s\">developer profile</a> is currently "
-"<strong>public</strong> and <strong>required</strong> for contributions."
-msgstr ""
-"<a href=\"%(url)s\">개발자 프로필</a>이 현재 <strong>공개</strong> 상태이며 기부를 "
-"<strong>요청</strong>중에 있습니다."
+msgid "Your <a href=\"%(url)s\">developer profile</a> is currently <strong>public</strong> and <strong>required</strong> for contributions."
+msgstr "<a href=\"%(url)s\">개발자 프로필</a>이 현재 <strong>공개</strong> 상태이며 기부를 <strong>요청</strong>중에 있습니다."
 
 #: src/olympia/devhub/templates/devhub/addons/profile.html:22
 msgid "Remove Both"
@@ -5256,9 +4355,7 @@ msgstr "둘 다 삭제"
 
 #: src/olympia/devhub/templates/devhub/addons/profile.html:27
 #, python-format
-msgid ""
-"Your <a href=\"%(url)s\">developer profile</a> is currently "
-"<strong>public</strong>."
+msgid "Your <a href=\"%(url)s\">developer profile</a> is currently <strong>public</strong>."
 msgstr "<a href=\"%(url)s\">개발자 프로필</a>이 현재 <strong>공개</strong> 상태입니다."
 
 #: src/olympia/devhub/templates/devhub/addons/profile.html:33
@@ -5286,11 +4383,8 @@ msgstr "부가 기능 URL"
 msgid "Choose a short, unique URL slug for your add-on."
 msgstr "부가 기능이 갖게될 짧고 고유한 URL 주소로 선택해 주세요."
 
-#: src/olympia/devhub/templates/devhub/addons/edit/basic.html:43
-#: src/olympia/devhub/templates/devhub/includes/addons_edit_nav.html:35
-#: src/olympia/devhub/templates/devhub/personas/edit.html:56
-#: src/olympia/editors/templates/editors/review.html:255
-#: src/olympia/editors/templates/editors/themes/single.html:33
+#: src/olympia/devhub/templates/devhub/addons/edit/basic.html:43 src/olympia/devhub/templates/devhub/includes/addons_edit_nav.html:35 src/olympia/devhub/templates/devhub/personas/edit.html:56
+#: src/olympia/editors/templates/editors/review.html:255 src/olympia/editors/templates/editors/themes/single.html:33
 msgid "View Listing"
 msgstr "목록 보기"
 
@@ -5299,48 +4393,29 @@ msgid "Summary"
 msgstr "요약 정보"
 
 #: src/olympia/devhub/templates/devhub/addons/edit/basic.html:52
-msgid ""
-"A short explanation of your add-on's basic\n"
-"                          functionality that is displayed in search and browse\n"
-"                          listings, as well as at the top of your add-on's\n"
-"                          details page. It is only relevant for listed add-ons."
+msgid "A short explanation of your add-on's basic functionality that is displayed in search and browse listings, as well as at the top of your add-on's details page. It is only relevant for listed add-ons."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/basic.html:73
-msgid ""
-"Categories are the primary way users browse through add-ons.\n"
-"                        Choose any that fit your add-on's functionality for the most\n"
-"                        exposure. It is only relevant for listed add-ons."
+msgid "Categories are the primary way users browse through add-ons. Choose any that fit your add-on's functionality for the most exposure. It is only relevant for listed add-ons."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/basic.html:90
 #, python-format
-msgid ""
-"Categories cannot be changed while your add-on is featured for this "
-"application. Please email <a href=\"mailto:%(email)s\">%(email)s</a> if "
-"there is a reason you need to modify your categories."
-msgstr ""
-"이 애플리케이션의 추천 부가 기능이 된 동안은 분류를 변경할 수 없습니다. 굳이 분류를 조정해야 할 이유가 있으시다면 <a "
-"href=\"mailto:%(email)s\">%(email)s</a> 주소로 메일을 보내주세요."
+msgid "Categories cannot be changed while your add-on is featured for this application. Please email <a href=\"mailto:%(email)s\">%(email)s</a> if there is a reason you need to modify your categories."
+msgstr "이 애플리케이션의 추천 부가 기능이 된 동안은 분류를 변경할 수 없습니다. 굳이 분류를 조정해야 할 이유가 있으시다면 <a href=\"mailto:%(email)s\">%(email)s</a> 주소로 메일을 보내주세요."
 
 #: src/olympia/devhub/templates/devhub/addons/edit/basic.html:119
-msgid ""
-"Tags help users find your add-on and should be short\n"
-"                        descriptors such as tabs, toolbar, or twitter.  You\n"
-"                        may have a maximum of {0} tags. It is only relevant\n"
-"                        for listed add-ons."
+msgid "Tags help users find your add-on and should be short descriptors such as tabs, toolbar, or twitter. You may have a maximum of {0} tags. It is only relevant for listed add-ons."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/addons/edit/basic.html:129
-#: src/olympia/devhub/templates/devhub/personas/edit.html:97
-#: src/olympia/devhub/templates/devhub/personas/submit.html:46
+#: src/olympia/devhub/templates/devhub/addons/edit/basic.html:129 src/olympia/devhub/templates/devhub/personas/edit.html:97 src/olympia/devhub/templates/devhub/personas/submit.html:46
 msgid "Comma-separated, minimum of {0} character."
 msgid_plural "Comma-separated, minimum of {0} characters."
 msgstr[0] "콤마로 구분하며 최소 {0} 글자 이상 입력해야 합니다."
+msgstr[1] ""
 
-#: src/olympia/devhub/templates/devhub/addons/edit/basic.html:132
-#: src/olympia/devhub/templates/devhub/personas/edit.html:100
-#: src/olympia/devhub/templates/devhub/personas/submit.html:49
+#: src/olympia/devhub/templates/devhub/addons/edit/basic.html:132 src/olympia/devhub/templates/devhub/personas/edit.html:100 src/olympia/devhub/templates/devhub/personas/submit.html:49
 msgid "Example: dark, cinema, noir. Limit 20."
 msgstr "예: dark, cinema, noir. 단어는 20자 이내로 제한됩니다."
 
@@ -5348,6 +4423,7 @@ msgstr "예: dark, cinema, noir. 단어는 20자 이내로 제한됩니다."
 msgid "Reserved tag:"
 msgid_plural "Reserved tags:"
 msgstr[0] "금지 태그:"
+msgstr[1] ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/details.html:5
 msgid "Add-on Details"
@@ -5358,39 +4434,26 @@ msgid "Add-on Details for {0}"
 msgstr "{0} 부가 기능 세부 설명"
 
 #: src/olympia/devhub/templates/devhub/addons/edit/details.html:22
-msgid ""
-"A longer explanation of features,\n"
-"                          functionality, and other relevant information. This\n"
-"                          field is only displayed on the add-on's details\n"
-"                          page. It is only relevant for listed add-ons."
+msgid "A longer explanation of features, functionality, and other relevant information. This field is only displayed on the add-on's details page. It is only relevant for listed add-ons."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/addons/edit/details.html:44
-#: src/olympia/translations/templates/translations/trans-menu.html:13
+#: src/olympia/devhub/templates/devhub/addons/edit/details.html:44 src/olympia/translations/templates/translations/trans-menu.html:13
 msgid "Default Locale"
 msgstr "기본 언어"
 
 #: src/olympia/devhub/templates/devhub/addons/edit/details.html:45
-msgid ""
-"Information about your add-on is displayed in this locale\n"
-"                        unless you override it with a locale-specific translation.\n"
-"                        It is only relevant for listed add-ons."
+msgid "Information about your add-on is displayed in this locale unless you override it with a locale-specific translation. It is only relevant for listed add-ons."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/addons/edit/details.html:61
-#: src/olympia/users/forms.py:311
-#: src/olympia/users/templates/users/edit.html:122
-#: src/olympia/users/templates/users/register.html:57
+#: src/olympia/devhub/templates/devhub/addons/edit/details.html:61 src/olympia/users/forms.py:311 src/olympia/users/templates/users/edit.html:122 src/olympia/users/templates/users/register.html:57
 #: src/olympia/users/templates/users/vcard.html:22
 msgid "Homepage"
 msgstr "홈페이지"
 
 #: src/olympia/devhub/templates/devhub/addons/edit/details.html:63
 msgid ""
-"If your add-on has another homepage, enter its\n"
-"                          address here. If your website is localized into other\n"
-"                          languages multiple translations of this field can be\n"
-"                          added. It is only relevant for listed add-ons."
+"If your add-on has another homepage, enter its address here. If your website is localized into other languages multiple translations of this field can be added. It is only relevant for listed add-"
+"ons."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/media.html:3
@@ -5408,19 +4471,14 @@ msgstr "{0}의 기술 지원 정보"
 
 #: src/olympia/devhub/templates/devhub/addons/edit/support.html:22
 msgid ""
-"If you wish to display an e-mail address for support\n"
-"                          inquiries, enter it here. If you have different\n"
-"                          addresses for each language multiple translations of\n"
-"                          this field can be added. It is only relevant for\n"
-"                          listed add-ons."
+"If you wish to display an e-mail address for support inquiries, enter it here. If you have different addresses for each language multiple translations of this field can be added. It is only "
+"relevant for listed add-ons."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/support.html:45
 msgid ""
-"If your add-on has a support website or forum, enter\n"
-"                          its address here. If your website is localized into\n"
-"                          other languages, multiple translations of this field can\n"
-"                          be added. It is only relevant for listed add-ons."
+"If your add-on has a support website or forum, enter its address here. If your website is localized into other languages, multiple translations of this field can be added. It is only relevant for "
+"listed add-ons."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:6
@@ -5434,11 +4492,8 @@ msgstr "{0}의 세부 기술 정보"
 
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:23
 msgid ""
-"Any information end users may want to know that isn't\n"
-"                          necessarily applicable to the add-on summary or description.\n"
-"                          Common uses include listing known major bugs, information on\n"
-"                          how to report bugs, anticipated release date of a new version,\n"
-"                          etc. It is only relevant for listed add-ons."
+"Any information end users may want to know that isn't necessarily applicable to the add-on summary or description. Common uses include listing known major bugs, information on how to report bugs, "
+"anticipated release date of a new version, etc. It is only relevant for listed add-ons."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:46
@@ -5450,9 +4505,7 @@ msgid "Add-on Flags"
 msgstr "부가 기능 상징"
 
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:69
-msgid ""
-"These flags are used to classify add-ons. It is only\n"
-"                        relevant for listed add-ons."
+msgid "These flags are used to classify add-ons. It is only relevant for listed add-ons."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:74
@@ -5468,9 +4521,7 @@ msgid "View Source?"
 msgstr "소스를 볼까요?"
 
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:90
-msgid ""
-"Whether the source of your add-on can be displayed in our\n"
-"                        online viewer. It is only relevant for listed add-ons."
+msgid "Whether the source of your add-on can be displayed in our online viewer. It is only relevant for listed add-ons."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:94
@@ -5486,10 +4537,7 @@ msgid "Public Stats?"
 msgstr "통계를 공개할까요?"
 
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:102
-msgid ""
-"Whether the download and usage stats of your add-on can\n"
-"                        be displayed in our online viewer.\n"
-"                        It is only relevant for listed add-ons."
+msgid "Whether the download and usage stats of your add-on can be displayed in our online viewer. It is only relevant for listed add-ons."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:107
@@ -5505,16 +4553,11 @@ msgid "Upgrade SDK?"
 msgstr "SDK를 업그레이드 하시겠습니까?"
 
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:116
-msgid ""
-"If selected, we will try to automatically upgrade your\n"
-"                        add-on when a new version of the SDK is released.\n"
-"                        It is only relevant for listed add-ons."
+msgid "If selected, we will try to automatically upgrade your add-on when a new version of the SDK is released. It is only relevant for listed add-ons."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:121
-msgid ""
-"This add-on will be automatically upgraded to new versions of the Add-on "
-"SDK."
+msgid "This add-on will be automatically upgraded to new versions of the Add-on SDK."
 msgstr "이 부가 기능은 최신 부가 기능 SDK가 올라오면 자동으로 업그레이드 됩니다."
 
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:123
@@ -5530,24 +4573,17 @@ msgid "UUID"
 msgstr "UUID"
 
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:132
-msgid ""
-"The UUID of your add-on is specified in its install manifest and uniquely "
-"identifies it. You cannot change your UUID once it has been submitted."
-msgstr ""
-"부가 기능의 UUID는 해당 앱 정보 설정 파일에 특화되어 고유한 식별자 역할을 수행합니다. 한번 입력된 UUID는 변경하실 수 "
-"없습니다."
+msgid "The UUID of your add-on is specified in its install manifest and uniquely identifies it. You cannot change your UUID once it has been submitted."
+msgstr "부가 기능의 UUID는 해당 앱 정보 설정 파일에 특화되어 고유한 식별자 역할을 수행합니다. 한번 입력된 UUID는 변경하실 수 없습니다."
 
-#: src/olympia/devhub/templates/devhub/addons/edit/technical.html:143
-#: src/olympia/devhub/templates/devhub/addons/edit/technical.html:144
+#: src/olympia/devhub/templates/devhub/addons/edit/technical.html:143 src/olympia/devhub/templates/devhub/addons/edit/technical.html:144
 msgid "Whiteboard"
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:146
 msgid ""
-"The whiteboard is the place to provide information relevant to your addon, "
-"whatever the version, to the editor. Use it to provide ways to test the "
-"addon, and any additional information that may help. This whiteboard is also"
-" editable by editors."
+"The whiteboard is the place to provide information relevant to your addon, whatever the version, to the editor. Use it to provide ways to test the addon, and any additional information that may "
+"help. This whiteboard is also editable by editors."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/technical_dependencies.html:9
@@ -5568,10 +4604,8 @@ msgstr "부가 기능 아이콘"
 
 #: src/olympia/devhub/templates/devhub/addons/forms_shared/media.html:16
 msgid ""
-"Upload an icon for your add-on or choose from one of ours. The\n"
-"                      icon is displayed nearly everywhere your add-on is. Uploaded images\n"
-"                      must be one of the following image types: .png, .jpg.\n"
-"                      It is only relevant for listed add-ons."
+"Upload an icon for your add-on or choose from one of ours. The icon is displayed nearly everywhere your add-on is. Uploaded images must be one of the following image types: .png, .jpg. It is only "
+"relevant for listed add-ons."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/forms_shared/media.html:25
@@ -5624,62 +4658,51 @@ msgstr "스크린샷 추가...."
 msgid "Tests"
 msgstr "테스트"
 
-#: src/olympia/devhub/templates/devhub/addons/includes/validation_compat_test_results.html:25
-#: src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:5
+#: src/olympia/devhub/templates/devhub/addons/includes/validation_compat_test_results.html:25 src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:5
 #: src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:53
 msgid "General Tests"
 msgstr "일반 테스트"
 
-#: src/olympia/devhub/templates/devhub/addons/includes/validation_compat_test_results.html:32
-#: src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:9
+#: src/olympia/devhub/templates/devhub/addons/includes/validation_compat_test_results.html:32 src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:9
 #: src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:67
 msgid "Security Tests"
 msgstr "보안성 테스트"
 
-#: src/olympia/devhub/templates/devhub/addons/includes/validation_compat_test_results.html:39
-#: src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:13
+#: src/olympia/devhub/templates/devhub/addons/includes/validation_compat_test_results.html:39 src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:13
 #: src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:80
 msgid "Extension Tests"
 msgstr "확장 기능 테스트"
 
-#: src/olympia/devhub/templates/devhub/addons/includes/validation_compat_test_results.html:46
-#: src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:17
+#: src/olympia/devhub/templates/devhub/addons/includes/validation_compat_test_results.html:46 src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:17
 #: src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:93
 msgid "Localization Tests"
 msgstr "번역 테스트"
 
 # 80%
 # 100%
-#: src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:21
-#: src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:106
+#: src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:21 src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:106
 msgid "Compatibility Tests"
 msgstr "호환성 테스트"
 
-#: src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:29
-#: src/olympia/files/templates/files/viewer.html:142
+#: src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:29 src/olympia/files/templates/files/viewer.html:142
 msgid "Hide messages not required for automated signing"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:35
-#: src/olympia/files/templates/files/viewer.html:150
+#: src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:35 src/olympia/files/templates/files/viewer.html:150
 msgid "Hide messages present in previous version and ignored"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:50
-#: src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:64
-#: src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:77
-#: src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:90
+#: src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:50 src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:64
+#: src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:77 src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:90
 #: src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:103
 msgid "Top"
 msgstr "최상위"
 
-#: src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:2
-#: src/olympia/devhub/templates/devhub/personas/edit.html:63
+#: src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:2 src/olympia/devhub/templates/devhub/personas/edit.html:63
 msgid "Delete Theme"
 msgstr "테마 삭제"
 
-#: src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:2
-#: src/olympia/devhub/templates/devhub/versions/list.html:117
+#: src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:2 src/olympia/devhub/templates/devhub/versions/list.html:117
 msgid "Delete Add-on"
 msgstr "부가 기능 삭제"
 
@@ -5688,27 +4711,22 @@ msgid "Deleting your theme will permanently remove it from the site."
 msgstr "테마를 삭제하면 사이트에서도 영원히 삭제됩니다."
 
 #: src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:14
-msgid ""
-"Deleting your add-on will permanently remove it from the site and prevent "
-"its GUID from being submitted again by others."
+msgid "Deleting your add-on will permanently remove it from the site and prevent its GUID from being submitted again by others."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:24
-msgid ""
-"Enter the following text confirm your decision:\n"
-"           {slug}"
+msgid "Enter the following text confirm your decision: {slug}"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:34
+#: src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:33
 msgid "Please tell us why you are deleting your theme:"
 msgstr "테마를 삭제하려는 이유를 설명해 주세요:"
 
-#: src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:36
+#: src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:35
 msgid "Please tell us why you are deleting your add-on:"
 msgstr "부가 기능을 삭제하려는 이유를 설명해 주세요:"
 
-#: src/olympia/devhub/templates/devhub/addons/listing/item_actions.html:1
-#: src/olympia/devhub/templates/devhub/addons/listing/item_actions_theme.html:1
+#: src/olympia/devhub/templates/devhub/addons/listing/item_actions.html:1 src/olympia/devhub/templates/devhub/addons/listing/item_actions_theme.html:1
 #: src/olympia/editors/templates/editors/review.html:253
 msgid "Actions"
 msgstr "활동"
@@ -5741,22 +4759,17 @@ msgstr "새 버전"
 msgid "Daily statistics on downloads and users."
 msgstr "다운로드 횟수 및 사용자 수에 대한 일일 통계입니다."
 
-#: src/olympia/devhub/templates/devhub/addons/listing/item_actions.html:45
-#: src/olympia/stats/templates/stats/stats.html:75
-#: src/olympia/stats/templates/stats/stats.html:79
-#: src/olympia/stats/templates/stats/stats.html:81
+#: src/olympia/devhub/templates/devhub/addons/listing/item_actions.html:45 src/olympia/stats/templates/stats/stats.html:31 src/olympia/stats/templates/stats/stats.html:35
+#: src/olympia/stats/templates/stats/stats.html:37
 msgid "Statistics"
 msgstr "통계"
 
-#: src/olympia/devhub/templates/devhub/addons/listing/item_actions.html:54
-#: src/olympia/devhub/templates/devhub/includes/addons_edit_nav.html:5
-#: src/olympia/devhub/templates/devhub/payments/payments.html:3
+#: src/olympia/devhub/templates/devhub/addons/listing/item_actions.html:54 src/olympia/devhub/templates/devhub/includes/addons_edit_nav.html:5 src/olympia/devhub/templates/devhub/payments/payments.html:3
 #: src/olympia/devhub/templates/devhub/payments/tier.html:4
 msgid "Manage Payments"
 msgstr "기부금 관리"
 
-#: src/olympia/devhub/templates/devhub/addons/listing/item_actions.html:55
-#: src/olympia/devhub/templates/devhub/includes/addons_edit_nav.html:6
+#: src/olympia/devhub/templates/devhub/addons/listing/item_actions.html:55 src/olympia/devhub/templates/devhub/includes/addons_edit_nav.html:6
 msgid "Manage Status & Versions"
 msgstr "상태 및 버전 관리"
 
@@ -5764,10 +4777,8 @@ msgstr "상태 및 버전 관리"
 msgid "View Add-on Listing"
 msgstr "부가 기능 나열 상태 보기"
 
-#: src/olympia/devhub/templates/devhub/addons/listing/item_actions.html:64
-#: src/olympia/devhub/templates/devhub/addons/listing/item_actions_theme.html:12
-#: src/olympia/devhub/templates/devhub/includes/addons_edit_nav.html:37
-#: src/olympia/devhub/templates/devhub/personas/edit.html:58
+#: src/olympia/devhub/templates/devhub/addons/listing/item_actions.html:64 src/olympia/devhub/templates/devhub/addons/listing/item_actions_theme.html:12
+#: src/olympia/devhub/templates/devhub/includes/addons_edit_nav.html:37 src/olympia/devhub/templates/devhub/personas/edit.html:58
 msgid "View Recent Changes"
 msgstr "최근 변경 사항 보기"
 
@@ -5792,9 +4803,7 @@ msgid "Delete this theme."
 msgstr "이 테마 삭제하기."
 
 #: src/olympia/devhub/templates/devhub/addons/listing/items.html:10
-msgid ""
-"This add-on will be deleted automatically after a few days if the submission"
-" process is not completed."
+msgid "This add-on will be deleted automatically after a few days if the submission process is not completed."
 msgstr "이 부가 기능은  등록 과정이 완료되지 않을 시 몇일 후 자동으로 삭제될 것입니다."
 
 #: src/olympia/devhub/templates/devhub/addons/listing/items.html:27
@@ -5811,6 +4820,7 @@ msgstr "<b>대기열 번호:</b> %(pos)s번 / %(total)s"
 msgid "<strong>{0}</strong> active user"
 msgid_plural "<strong>{0}</strong> active users"
 msgstr[0] "현재 사용자 <strong>{0}</strong>명"
+msgstr[1] ""
 
 #: src/olympia/devhub/templates/devhub/addons/submit/base.html:11
 msgid "Submit Add-on"
@@ -5832,9 +4842,7 @@ msgstr "이름과 버전:"
 msgid "The detail page will be:"
 msgstr "상세 정보 페이지란:"
 
-#: src/olympia/devhub/templates/devhub/addons/submit/describe.html:24
-#: src/olympia/devhub/templates/devhub/personas/edit.html:89
-#: src/olympia/devhub/templates/devhub/personas/submit.html:38
+#: src/olympia/devhub/templates/devhub/addons/submit/describe.html:24 src/olympia/devhub/templates/devhub/personas/edit.html:89 src/olympia/devhub/templates/devhub/personas/submit.html:38
 msgid "Please use only letters, numbers, underscores, and dashes in your URL."
 msgstr "URL엔 문자, 숫자, 밑줄과 대시문자만 사용하세요."
 
@@ -5854,14 +4862,11 @@ msgstr "좀 더 자세한 설명을 적어주세요:"
 msgid "The description will appear on the detail page."
 msgstr "이 정보는 상세 정보 페이지 상에 노출됩니다."
 
-#: src/olympia/devhub/templates/devhub/addons/submit/done.html:4
-#: src/olympia/devhub/templates/devhub/personas/submit_done.html:4
+#: src/olympia/devhub/templates/devhub/addons/submit/done.html:4 src/olympia/devhub/templates/devhub/personas/submit_done.html:4
 msgid "Submission Complete"
 msgstr "등록 완료"
 
-#: src/olympia/devhub/templates/devhub/addons/submit/done.html:8
-#: src/olympia/devhub/templates/devhub/addons/submit/sidebar.html:13
-#: src/olympia/devhub/templates/devhub/personas/submit_done.html:8
+#: src/olympia/devhub/templates/devhub/addons/submit/done.html:8 src/olympia/devhub/templates/devhub/addons/submit/sidebar.html:13 src/olympia/devhub/templates/devhub/personas/submit_done.html:8
 msgid "You're done!"
 msgstr "완료하셨습니다!"
 
@@ -5874,22 +4879,14 @@ msgid "Your add-on has been submitted to the Full Review queue."
 msgstr "당신의 부가 기능이 전체 심사 대기열에 등록되었습니다."
 
 #: src/olympia/devhub/templates/devhub/addons/submit/done.html:18
-msgid ""
-"You'll receive an email once it has been reviewed by an editor. In the "
-"meantime, you and your friends can install it directly from its details "
-"page:"
-msgstr ""
-"편집자의 심사가 끝나면 이메일을 받아보시게 됩니다. 그 전까진 해당 부가 기능의 상세 정보 페이지에서 친구들과 함께 다운로드를 받아 "
-"설치해 볼 수 있습니다."
+msgid "You'll receive an email once it has been reviewed by an editor. In the meantime, you and your friends can install it directly from its details page:"
+msgstr "편집자의 심사가 끝나면 이메일을 받아보시게 됩니다. 그 전까진 해당 부가 기능의 상세 정보 페이지에서 친구들과 함께 다운로드를 받아 설치해 볼 수 있습니다."
 
-#: src/olympia/devhub/templates/devhub/addons/submit/done.html:27
-#: src/olympia/devhub/templates/devhub/addons/submit/done.html:77
-#: src/olympia/devhub/templates/devhub/personas/submit_done.html:16
+#: src/olympia/devhub/templates/devhub/addons/submit/done.html:27 src/olympia/devhub/templates/devhub/addons/submit/done.html:77 src/olympia/devhub/templates/devhub/personas/submit_done.html:16
 msgid "Next steps:"
 msgstr "다음 단계:"
 
-#: src/olympia/devhub/templates/devhub/addons/submit/done.html:32
-#: src/olympia/devhub/templates/devhub/addons/submit/done.html:82
+#: src/olympia/devhub/templates/devhub/addons/submit/done.html:32 src/olympia/devhub/templates/devhub/addons/submit/done.html:82
 msgid "<a href=\"{0}\">Upload</a> another platform-specific file to this version."
 msgstr "해당 버전에 다른 플랫폼 전용 파일을 <a href=\"{0}\">업로드</a> 합니다."
 
@@ -5898,21 +4895,14 @@ msgid "Provide more details by <a href=\"{0}\">editing its listing</a>."
 msgstr "<a href=\"{0}\">목록 노출 내역 편집</a>을 통해 보다 자세한 정보를 적어주세요."
 
 #: src/olympia/devhub/templates/devhub/addons/submit/done.html:35
-msgid ""
-"Tell your users why you created this in your <a href=\"{0}\">Developer "
-"Profile</a>."
+msgid "Tell your users why you created this in your <a href=\"{0}\">Developer Profile</a>."
 msgstr "<a href=\"{0}\">개발자 프로필</a>에서 이걸 만든 이유를 사용자에게 알려주세요."
 
 #: src/olympia/devhub/templates/devhub/addons/submit/done.html:36
-msgid ""
-"View and subscribe to your add-on's <a href=\"{0}\">activity feed</a> to "
-"stay updated on reviews, collections, and more."
-msgstr ""
-"<a href=\"{0}\">활동 내역 피드</a>를 구독해서 제작한 부가 기능에 대한 사용자 평가, 모음집 수록, 그밖에 여러 정보의 "
-"업데이트를 받아보세요."
+msgid "View and subscribe to your add-on's <a href=\"{0}\">activity feed</a> to stay updated on reviews, collections, and more."
+msgstr "<a href=\"{0}\">활동 내역 피드</a>를 구독해서 제작한 부가 기능에 대한 사용자 평가, 모음집 수록, 그밖에 여러 정보의 업데이트를 받아보세요."
 
-#: src/olympia/devhub/templates/devhub/addons/submit/done.html:37
-#: src/olympia/devhub/templates/devhub/addons/submit/done.html:86
+#: src/olympia/devhub/templates/devhub/addons/submit/done.html:37 src/olympia/devhub/templates/devhub/addons/submit/done.html:86
 msgid "View approximate review queue <a href=\"{0}\">wait times</a>."
 msgstr "대략적인 심사 <a href=\"{0}\">대기 시간</a>을 조회해 보세요."
 
@@ -5925,13 +4915,11 @@ msgid "Become an AMO Reviewer today and get your add-ons reviewed faster."
 msgstr "AMO 심사원이 되서 부가 기능 심사를 더 빠르게 받아봅시다."
 
 #: src/olympia/devhub/templates/devhub/addons/submit/done.html:54
-msgid ""
-"Your add-on has been signed and it's ready to use. You can download it here:"
+msgid "Your add-on has been signed and it's ready to use. You can download it here:"
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/submit/done.html:64
-msgid ""
-"Your add-on has been submitted to the Unlisted Preliminary Review queue."
+msgid "Your add-on has been submitted to the Unlisted Preliminary Review queue."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/submit/done.html:66
@@ -5939,8 +4927,7 @@ msgid "Your add-on has been submitted to the Unlisted Full Review queue."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/submit/done.html:70
-msgid ""
-"You'll receive an email once it has been reviewed by an editor and signed."
+msgid "You'll receive an email once it has been reviewed by an editor and signed."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/submit/done.html:74
@@ -5948,9 +4935,7 @@ msgid "Your add-on will not be publicly available on this website."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/submit/done.html:84
-msgid ""
-"You can upload new versions of your add-on in the <a href=\"{0}\">add-on's "
-"developer page</a>."
+msgid "You can upload new versions of your add-on in the <a href=\"{0}\">add-on's developer page</a>."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/submit/license.html:4
@@ -5962,13 +4947,8 @@ msgid "Step 5. Select a License"
 msgstr "5단계. 라이선스 선택"
 
 #: src/olympia/devhub/templates/devhub/addons/submit/license.html:9
-msgid ""
-"We require all add-ons to indicate the terms under which their source code "
-"is licensed. Please select a license from the list below or enter a custom "
-"license."
-msgstr ""
-"모든 부가 기능은 라이선스가 있는 소스 코드임을 알려야 합니다. 아래 목록의 라이선스 중 하나를 선택하시거나 사용자 정의 라이선스를 "
-"입력해 주세요."
+msgid "We require all add-ons to indicate the terms under which their source code is licensed. Please select a license from the list below or enter a custom license."
+msgstr "모든 부가 기능은 라이선스가 있는 소스 코드임을 알려야 합니다. 아래 목록의 라이선스 중 하나를 선택하시거나 사용자 정의 라이선스를 입력해 주세요."
 
 #: src/olympia/devhub/templates/devhub/addons/submit/license.html:18
 msgid "Select a license for your add-on:"
@@ -5984,12 +4964,9 @@ msgstr "4단계. 이미지 등록"
 
 #: src/olympia/devhub/templates/devhub/addons/submit/media.html:9
 msgid ""
-"Custom icons and screenshots draw attention and help users understand what "
-"it does. We strongly recommend uploading a custom icon, as in some areas of "
-"the website, only the icon and name will appear."
-msgstr ""
-"직접 제작한 아이콘과 스크린샷은 이목을 집중시키고 사용자가 어떤 기능이 있는지를 이해하는데 도웁이 됩니다. 저희는 아이콘을 직접 제작해서"
-" 올리는걸 강력히 권장하고 있으며, 웹 사이트의 일부 구역에선 아이콘과 이름만 노출되기도 합니다."
+"Custom icons and screenshots draw attention and help users understand what it does. We strongly recommend uploading a custom icon, as in some areas of the website, only the icon and name will "
+"appear."
+msgstr "직접 제작한 아이콘과 스크린샷은 이목을 집중시키고 사용자가 어떤 기능이 있는지를 이해하는데 도웁이 됩니다. 저희는 아이콘을 직접 제작해서 올리는걸 강력히 권장하고 있으며, 웹 사이트의 일부 구역에선 아이콘과 이름만 노출되기도 합니다."
 
 #: src/olympia/devhub/templates/devhub/addons/submit/select-review.html:5
 msgid "Step 6"
@@ -6001,19 +4978,13 @@ msgstr "6단계. 심사 과정 선택"
 
 #: src/olympia/devhub/templates/devhub/addons/submit/select-review.html:10
 msgid ""
-"All add-ons hosted in our gallery must be reviewed by an editor before they "
-"appear in categories or search results. While waiting for review, your add-"
-"on can still be accessed through its direct URL. Please choose the review "
-"process below that best fits your add-on."
-msgstr ""
-"저희 갤러리에서 호스팅되고 있는 모든 부가 기능들은 공개되기에 앞서 편집자의 심사를 반드시 받게 되어 있습니다. 심사 기간 동안에도 "
-"당신의 부가 기능은 URL을 입력하면 접근이 가능합니다. 아래의 심사 과정 중에서 적합한 방식을 선택해 주세요."
+"All add-ons hosted in our gallery must be reviewed by an editor before they appear in categories or search results. While waiting for review, your add-on can still be accessed through its direct "
+"URL. Please choose the review process below that best fits your add-on."
+msgstr "저희 갤러리에서 호스팅되고 있는 모든 부가 기능들은 공개되기에 앞서 편집자의 심사를 반드시 받게 되어 있습니다. 심사 기간 동안에도 당신의 부가 기능은 URL을 입력하면 접근이 가능합니다. 아래의 심사 과정 중에서 적합한 방식을 선택해 주세요."
 
 #: src/olympia/devhub/templates/devhub/addons/submit/select-review.html:26
 #, python-format
-msgid ""
-"A complete review of your add-on's source and functionality. <a "
-"href=\"%(url)s\">Learn more&hellip;</a>"
+msgid "A complete review of your add-on's source and functionality. <a href=\"%(url)s\">Learn more&hellip;</a>"
 msgstr "부가 기능의 소스 및 기능에 대한 전체 심사를 합니다. <a href=\"%(url)s\">자세히 알아보기&hellip;</a>"
 
 #: src/olympia/devhub/templates/devhub/addons/submit/select-review.html:32
@@ -6042,9 +5013,7 @@ msgstr "전체 심사 선택"
 
 #: src/olympia/devhub/templates/devhub/addons/submit/select-review.html:49
 #, python-format
-msgid ""
-"A faster review of your add-on's source for any major problems. <a "
-"href=\"%(url)s\">Learn more&hellip;</a>"
+msgid "A faster review of your add-on's source for any major problems. <a href=\"%(url)s\">Learn more&hellip;</a>"
 msgstr "부가 기능의 소스 및 기능에 대한 빠른 심사를 합니다. <a href=\"%(url)s\">자세히 알아보기&hellip;</a>"
 
 #: src/olympia/devhub/templates/devhub/addons/submit/select-review.html:55
@@ -6091,10 +5060,8 @@ msgstr "라이선스를 선택하세요"
 msgid "Select a review process"
 msgstr "심사 절차를 선택하세요"
 
-#: src/olympia/devhub/templates/devhub/addons/submit/sidebar.html:18
-#: src/olympia/devhub/templates/devhub/docs/policies-submission.html:3
-#: src/olympia/devhub/templates/devhub/docs/policies-submission.html:7
-#: src/olympia/devhub/templates/devhub/docs/policies-submission.html:9
+#: src/olympia/devhub/templates/devhub/addons/submit/sidebar.html:18 src/olympia/devhub/templates/devhub/docs/policies-submission.html:3
+#: src/olympia/devhub/templates/devhub/docs/policies-submission.html:7 src/olympia/devhub/templates/devhub/docs/policies-submission.html:9
 msgid "Submission Process"
 msgstr "등록 절차"
 
@@ -6115,26 +5082,18 @@ msgid "Step 2. Upload Your Add-on"
 msgstr "2단계. 부가 기능 업로드"
 
 #: src/olympia/devhub/templates/devhub/addons/submit/upload.html:11
-msgid ""
-"Use the fields below to upload your add-on package and select any platform "
-"restrictions. After upload, a series of automated validation tests will be "
-"run on your file."
-msgstr ""
-"부가 기능 패키지를 업로드 하시려면 아래 항목을 이용하신 후 플랫폼 제한 사항을 선택해 주세요. 업로드가 끝나면 파일들에 대한 몇가지 "
-"검사가 자동으로 이루어질 것입니다."
+msgid "Use the fields below to upload your add-on package and select any platform restrictions. After upload, a series of automated validation tests will be run on your file."
+msgstr "부가 기능 패키지를 업로드 하시려면 아래 항목을 이용하신 후 플랫폼 제한 사항을 선택해 주세요. 업로드가 끝나면 파일들에 대한 몇가지 검사가 자동으로 이루어질 것입니다."
 
-#: src/olympia/devhub/templates/devhub/addons/submit/upload.html:59
-#: src/olympia/devhub/templates/devhub/versions/add_file_modal.html:39
+#: src/olympia/devhub/templates/devhub/addons/submit/upload.html:51 src/olympia/devhub/templates/devhub/versions/add_file_modal.html:28
 msgid "Which platforms is this file compatible with?"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/addons/submit/upload.html:67
-#: src/olympia/devhub/templates/devhub/versions/add_file_modal.html:65
+#: src/olympia/devhub/templates/devhub/addons/submit/upload.html:59 src/olympia/devhub/templates/devhub/versions/add_file_modal.html:45
 msgid "Administrative overrides"
 msgstr "관리자 우선 작업내역"
 
-#: src/olympia/devhub/templates/devhub/api/agreement.html:3
-#: src/olympia/devhub/templates/devhub/api/agreement.html:11
+#: src/olympia/devhub/templates/devhub/api/agreement.html:3 src/olympia/devhub/templates/devhub/api/agreement.html:11
 msgid "Firefox Add-on Distribution Agreement"
 msgstr ""
 
@@ -6144,9 +5103,7 @@ msgstr ""
 
 #: src/olympia/devhub/templates/devhub/api/key.html:20
 #, python-format
-msgid ""
-"For detailed instructions, consult the <a href=\"%(docs_url)s\">API "
-"documentation</a>."
+msgid "For detailed instructions, consult the <a href=\"%(docs_url)s\">API documentation</a>."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/api/key.html:28
@@ -6160,10 +5117,8 @@ msgstr ""
 #: src/olympia/devhub/templates/devhub/api/key.html:37
 #, python-format
 msgid ""
-"To make API requests, send a <a href=\"%(jwt_url)s\">JSON Web Token "
-"(JWT)</a> as the authorization header. You'll need to generate a JWT for "
-"every request as explained in the <a href=\"%(docs_url)s\">API "
-"documentation</a>."
+"To make API requests, send a <a href=\"%(jwt_url)s\">JSON Web Token (JWT)</a> as the authorization header. You'll need to generate a JWT for every request as explained in the <a "
+"href=\"%(docs_url)s\">API documentation</a>."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/api/key.html:47
@@ -6172,9 +5127,7 @@ msgstr ""
 
 #: src/olympia/devhub/templates/devhub/api/key.html:53
 #, python-format
-msgid ""
-"This feature is under active development. If you find a problem please <a "
-"target=\"_blank\" href=\"%(bug_link)s\">report a bug</a>."
+msgid "This feature is under active development. If you find a problem please <a target=\"_blank\" href=\"%(bug_link)s\">report a bug</a>."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/api/key.html:61
@@ -6185,28 +5138,19 @@ msgstr ""
 msgid "Generate new credentials"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/docs/policies-agreement.html:3
-#: src/olympia/devhub/templates/devhub/docs/policies-agreement.html:7
-#: src/olympia/devhub/templates/devhub/docs/policies-agreement.html:9
-#: src/olympia/devhub/templates/devhub/docs/policies.html:24
-#: src/olympia/devhub/templates/devhub/docs/policies.html:103
+#: src/olympia/devhub/templates/devhub/docs/policies-agreement.html:3 src/olympia/devhub/templates/devhub/docs/policies-agreement.html:7 src/olympia/devhub/templates/devhub/docs/policies-agreement.html:9
+#: src/olympia/devhub/templates/devhub/docs/policies.html:24 src/olympia/devhub/templates/devhub/docs/policies.html:103
 msgid "Developer Agreement"
 msgstr "개발자 동의서"
 
-#: src/olympia/devhub/templates/devhub/docs/policies-contact.html:3
-#: src/olympia/devhub/templates/devhub/docs/policies-contact.html:7
-#: src/olympia/devhub/templates/devhub/docs/policies-contact.html:9
-#: src/olympia/devhub/templates/devhub/docs/policies.html:27
-#: src/olympia/devhub/templates/devhub/docs/policies.html:115
+#: src/olympia/devhub/templates/devhub/docs/policies-contact.html:3 src/olympia/devhub/templates/devhub/docs/policies-contact.html:7 src/olympia/devhub/templates/devhub/docs/policies-contact.html:9
+#: src/olympia/devhub/templates/devhub/docs/policies.html:27 src/olympia/devhub/templates/devhub/docs/policies.html:115
 msgid "Contacting Us"
 msgstr "연락하기"
 
 #: src/olympia/devhub/templates/devhub/docs/policies-contact.html:12
-msgid ""
-"Thanks for your interest in contacting the Mozilla Add-ons team. Please read"
-" this page carefully to ensure your request goes to the right place."
-msgstr ""
-"Mozilla 부가 기능 팀과의 연락에 관심을 보여주셔서 감사합니다. 이 페이지를 잘 읽어보시고 알맞은 위치에 요구 사항을 적어주세요."
+msgid "Thanks for your interest in contacting the Mozilla Add-ons team. Please read this page carefully to ensure your request goes to the right place."
+msgstr "Mozilla 부가 기능 팀과의 연락에 관심을 보여주셔서 감사합니다. 이 페이지를 잘 읽어보시고 알맞은 위치에 요구 사항을 적어주세요."
 
 #: src/olympia/devhub/templates/devhub/docs/policies-contact.html:17
 msgid "Add-on Support"
@@ -6214,13 +5158,9 @@ msgstr "부가 기능 기술 지원"
 
 #: src/olympia/devhub/templates/devhub/docs/policies-contact.html:19
 msgid ""
-"If you have a support question about a particular add-on, such as \"how do I"
-" use this add-on?\" or \"why doesn't this work properly?\", please contact "
-"that add-on's author through the support channels listed on the add-on's "
-"listing page."
-msgstr ""
-"특정 부가 기능에 대한 질문, 이를테면 \"이 부가 기능은 어떻게 사용하죠?\" 또는 \"어째서 이 기능이 제대로 작동하지 않는거죠?\""
-" 같은 질문에 도움을 받으려면, 부가 기능 페이지에 나와있는 기술 지원 항목을 통해 해당 부가 기능 제작자와 연락하시기 바랍니다."
+"If you have a support question about a particular add-on, such as \"how do I use this add-on?\" or \"why doesn't this work properly?\", please contact that add-on's author through the support "
+"channels listed on the add-on's listing page."
+msgstr "특정 부가 기능에 대한 질문, 이를테면 \"이 부가 기능은 어떻게 사용하죠?\" 또는 \"어째서 이 기능이 제대로 작동하지 않는거죠?\" 같은 질문에 도움을 받으려면, 부가 기능 페이지에 나와있는 기술 지원 항목을 통해 해당 부가 기능 제작자와 연락하시기 바랍니다."
 
 #: src/olympia/devhub/templates/devhub/docs/policies-contact.html:24
 msgid "Add-on Editorial Concerns"
@@ -6233,15 +5173,11 @@ msgstr "amo-editors 골뱅이 mozilla 점 org"
 #: src/olympia/devhub/templates/devhub/docs/policies-contact.html:26
 #, python-format
 msgid ""
-"If you have a question about an Editor's review of an add-on or want to "
-"report a policy violation, please email %(mail_editors)s. <strong>Almost all"
-" add-on reports fall under this category.</strong> Please be sure to include"
-" a link to the add-on in question and a detailed description of your "
-"question or comment."
+"If you have a question about an Editor's review of an add-on or want to report a policy violation, please email %(mail_editors)s. <strong>Almost all add-on reports fall under this "
+"category.</strong> Please be sure to include a link to the add-on in question and a detailed description of your question or comment."
 msgstr ""
-"부가 기능의 편집자 심사에 대한 질문이 있거나 개인 정보 침해 신고를 하고 싶을 때, 자신의 부가 기능을 추천 부가 기능으로 제안하고 "
-"싶을 땐 %(mail_editors)s로 이메일을 보내주시기 바랍니다. <strong>대부분의 부가 기능 신고가 이 분류 내에 "
-"있습니다.</strong> 질문시 포함된 부가 기능의 링크와 질문 및 코멘트의 세부 설명이 확실한 지 확인해 주십시오."
+"부가 기능의 편집자 심사에 대한 질문이 있거나 개인 정보 침해 신고를 하고 싶을 때, 자신의 부가 기능을 추천 부가 기능으로 제안하고 싶을 땐 %(mail_editors)s로 이메일을 보내주시기 바랍니다. <strong>대부분의 부가 기능 신고가 이 분류 내에 있습니다.</strong> 질문시 포함된 부가 기능의 링크와 질문 및 코멘트의 세부 설명이 "
+"확실한 지 확인해 주십시오."
 
 #: src/olympia/devhub/templates/devhub/docs/policies-contact.html:31
 msgid "Add-on Security Vulnerabilities"
@@ -6254,19 +5190,12 @@ msgstr ""
 #: src/olympia/devhub/templates/devhub/docs/policies-contact.html:36
 #, python-format
 msgid ""
-"If you have discovered a security vulnerability in an add-on, even if it is "
-"not hosted here, Mozilla is very interested in your discovery and will work "
-"with the add-on developer to correct the issue as soon as possible. Add-on "
-"security issues can be reported <a "
-"href=\"http://www.mozilla.org/projects/security/security-bugs-"
-"policy.html\">confidentially</a> in <a "
+"If you have discovered a security vulnerability in an add-on, even if it is not hosted here, Mozilla is very interested in your discovery and will work with the add-on developer to correct the "
+"issue as soon as possible. Add-on security issues can be reported <a href=\"http://www.mozilla.org/projects/security/security-bugs-policy.html\">confidentially</a> in <a "
 "href=\"%(link_bugzilla)s\">Bugzilla</a> or by emailing %(mail_admins)s."
 msgstr ""
-"부가 기능에 보안 취약점을 발견했다면, 이곳에 호스팅되고 있는 것이 아니라도 Mozilla에선 이러한 발견에 관심을 가질 것이며 가능한한"
-" 빨리 부가 기능 개발자와 이 문제를 바로잡을 것입니다. 부가 기능 보안 문제는 <a "
-"href=\"%(link_bugzilla)s\">Bugzilla</a> 또는 %(mail_admins)s로 이메일 전송을 통해 <a "
-"href=\"http://www.mozilla.org/projects/security/security-bugs-"
-"policy.html\">비밀리에</a> 보고될 수 있습니다."
+"부가 기능에 보안 취약점을 발견했다면, 이곳에 호스팅되고 있는 것이 아니라도 Mozilla에선 이러한 발견에 관심을 가질 것이며 가능한한 빨리 부가 기능 개발자와 이 문제를 바로잡을 것입니다. 부가 기능 보안 문제는 <a href=\"%(link_bugzilla)s\">Bugzilla</a> 또는 %(mail_admins)s로 이메일 전송을 통해 <a"
+" href=\"http://www.mozilla.org/projects/security/security-bugs-policy.html\">비밀리에</a> 보고될 수 있습니다."
 
 #: src/olympia/devhub/templates/devhub/docs/policies-contact.html:42
 msgid "Website Functionality & Development"
@@ -6274,13 +5203,11 @@ msgstr "웹 사이트 기능 및 개발"
 
 #: src/olympia/devhub/templates/devhub/docs/policies-contact.html:44
 msgid ""
-"If you've found a problem with the site, we'd love to fix it. Please <a "
-"href=\"https://github.com/mozilla/olympia/issues\">file a bug report</a> in "
-"GitHub, including the location of the problem and how you encountered it."
+"If you've found a problem with the site, we'd love to fix it. Please <a href=\"https://github.com/mozilla/addons/issues/new\">file a bug report</a> in GitHub, including the location of the problem "
+"and how you encountered it."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/docs/policies-maintenance.html:3
-#: src/olympia/devhub/templates/devhub/docs/policies-maintenance.html:7
+#: src/olympia/devhub/templates/devhub/docs/policies-maintenance.html:3 src/olympia/devhub/templates/devhub/docs/policies-maintenance.html:7
 #: src/olympia/devhub/templates/devhub/docs/policies-maintenance.html:8
 msgid "Maintaining Your Add-ons"
 msgstr "부가 기능의 유지 보수"
@@ -6291,27 +5218,16 @@ msgstr "부가 기능의 최신 버전 등록"
 
 #: src/olympia/devhub/templates/devhub/docs/policies-maintenance.html:12
 msgid ""
-"Developers are encouraged to submit updates to their add-ons to fix bugs, "
-"add features, and otherwise improve their product. New versions of an add-on"
-" must have a <a "
-"href=\"https://developer.mozilla.org/en/Toolkit_version_format\">higher "
-"version number</a> and can be submitted through the Developer Tools "
-"provided. There is no limit to the number of versions that can be submitted,"
-" but please remember that versions must be reviewed by an editor."
+"Developers are encouraged to submit updates to their add-ons to fix bugs, add features, and otherwise improve their product. New versions of an add-on must have a <a "
+"href=\"https://developer.mozilla.org/en/Toolkit_version_format\">higher version number</a> and can be submitted through the Developer Tools provided. There is no limit to the number of versions "
+"that can be submitted, but please remember that versions must be reviewed by an editor."
 msgstr ""
-"개발자는 자신의 부가 기능에 버그 수정, 기능 추가, 기타 여러가지 향상을 위해 업데이트 제공에 최선을 다해야 합니다. 부가 기능의 새 "
-"버전은 반드시 <a "
-"href=\"https://developer.mozilla.org/en/Toolkit_version_format\">더 높은 버전 "
-"넘버</a>를 가져야 하며 제공된 개발자 도구를 통해 제출되야 합니다. 등록 가능한 버전 갯수에 제한은 없지만, 제출된 버전은 편집자의 "
-"심사를 받아야 한다는 사실을 기억해 주십시오."
+"개발자는 자신의 부가 기능에 버그 수정, 기능 추가, 기타 여러가지 향상을 위해 업데이트 제공에 최선을 다해야 합니다. 부가 기능의 새 버전은 반드시 <a href=\"https://developer.mozilla.org/en/Toolkit_version_format\">더 높은 버전 넘버</a>를 가져야 하며 제공된 개발자 도구를 통해 제출되야 "
+"합니다. 등록 가능한 버전 갯수에 제한은 없지만, 제출된 버전은 편집자의 심사를 받아야 한다는 사실을 기억해 주십시오."
 
 #: src/olympia/devhub/templates/devhub/docs/policies-maintenance.html:18
-msgid ""
-"New versions will be added to a pending review queue, and any additional "
-"versions submitted before the review is completed will move that version to "
-"the end of the queue."
-msgstr ""
-"새 버전은 심사 대기열에 추가되며 심사가 완료되기 전에 다른 버전이 추가될 경우 나중에 추가된 버전은 대기열 가장 끝으로 이동됩니다."
+msgid "New versions will be added to a pending review queue, and any additional versions submitted before the review is completed will move that version to the end of the queue."
+msgstr "새 버전은 심사 대기열에 추가되며 심사가 완료되기 전에 다른 버전이 추가될 경우 나중에 추가된 버전은 대기열 가장 끝으로 이동됩니다."
 
 #: src/olympia/devhub/templates/devhub/docs/policies-maintenance.html:23
 msgid "How do I submit a Beta add-on?"
@@ -6323,44 +5239,28 @@ msgstr "베타 채널은 전체 심사를 통과한 부가 기능만 사용할 �
 
 #: src/olympia/devhub/templates/devhub/docs/policies-maintenance.html:31
 msgid ""
-"To create a beta channel, upload a file with a unique version string that "
-"contains any of the following strings: <code>a,b,alpha,beta,pre,rc</code>, "
-"with an optional number at the end. This text must come at the end of the "
-"version string. If you understand regex format, here's what we look for in "
-"the version number: <code>\"(a|alpha|b|beta|pre|rc)\\d*$\"</code>."
+"To create a beta channel, upload a file with a unique version string that contains any of the following strings: <code>a,b,alpha,beta,pre,rc</code>, with an optional number at the end. This text "
+"must come at the end of the version string. If you understand regex format, here's what we look for in the version number: <code>\"(a|alpha|b|beta|pre|rc)\\d*$\"</code>."
 msgstr ""
-"베타 채널을 생성하려면 아래 스트링중 하나가 들어간 고유 버전 스트링의 이름을 가진 파일을 업로드해야 합니다: "
-"<code>a,b,alpha,beta,pre,rc</code> 옵션 넘버는 마지막에 붙입니다. 이 텍스트는 버전 스트링의 가장 끝에 "
-"붙여야 합니다. 정규 표현식을 알고 있다면 이런 방식으로 버전 넘버에서 스트링을 인식하고 있는 것입니다: "
+"베타 채널을 생성하려면 아래 스트링중 하나가 들어간 고유 버전 스트링의 이름을 가진 파일을 업로드해야 합니다: <code>a,b,alpha,beta,pre,rc</code> 옵션 넘버는 마지막에 붙입니다. 이 텍스트는 버전 스트링의 가장 끝에 붙여야 합니다. 정규 표현식을 알고 있다면 이런 방식으로 버전 넘버에서 스트링을 인식하고 있는 것입니다: "
 "<code>\"(a|alpha|b|beta|pre|rc)\\d*$\"</code>"
 
 #: src/olympia/devhub/templates/devhub/docs/policies-maintenance.html:37
 msgid ""
-"Once a file meeting this criteria is uploaded to AMO, it will automatically "
-"be marked as a beta version. Users of add-ons with these unique version "
-"numbers will automatically be served the newest beta updates."
-msgstr ""
-"이러한 기준에 맞춘 파일을 AMO에 업로드하면 자동으로 베타 버전으로 표시가 됩니다. 이러한 고유 버전 넘버를 가진 부가 기능의 사용자는"
-" 자동으로 최신 베타 업데이트를 받아보게 될 것입니다."
+"Once a file meeting this criteria is uploaded to AMO, it will automatically be marked as a beta version. Users of add-ons with these unique version numbers will automatically be served the newest "
+"beta updates."
+msgstr "이러한 기준에 맞춘 파일을 AMO에 업로드하면 자동으로 베타 버전으로 표시가 됩니다. 이러한 고유 버전 넘버를 가진 부가 기능의 사용자는 자동으로 최신 베타 업데이트를 받아보게 될 것입니다."
 
 #: src/olympia/devhub/templates/devhub/docs/policies-maintenance.html:43
 msgid ""
-"While we call these \"Beta versions\", you can use this channel for "
-"nightlies, or alphas, or prerelease versions as you wish. Please note that "
-"there is only one channel for this purpose and all of your users on this "
-"channel will receive the latest add-ons submitted. For instance, if you "
-"upload <code>1.0beta1</code> to the release channel and then upload "
-"<code>1.1alpha1</code>, all users of <code>1.0beta1</code> will be offered "
-"an upgrade to <code>1.1alpha1</code>. Updates are pushed by submission date "
-"and not version number, so users will always get the most recent channel "
-"update regardless of any kind of alphabetical sorting."
+"While we call these \"Beta versions\", you can use this channel for nightlies, or alphas, or prerelease versions as you wish. Please note that there is only one channel for this purpose and all of "
+"your users on this channel will receive the latest add-ons submitted. For instance, if you upload <code>1.0beta1</code> to the release channel and then upload <code>1.1alpha1</code>, all users of "
+"<code>1.0beta1</code> will be offered an upgrade to <code>1.1alpha1</code>. Updates are pushed by submission date and not version number, so users will always get the most recent channel update "
+"regardless of any kind of alphabetical sorting."
 msgstr ""
-"\"베타 버전\"이라 불리는 동안엔 베타 채널을 통해서 나이티, 알파, 프리릴리즈 버전을 원하는대로 사용할 수 있습니다. 이러한 사유로 "
-"채널은 한개 뿐이며 이 채널의 모든 사용자는 가장 최근에 올라온 부가 기능을 받아보게 됩니다. 예를 들어 "
-"<code>1.0beta1</code> 버전을 공개 채널에 업로드 한 다음 <code>1.1alpha1</code> 버전을 또 업로드하게"
-" 되면 <code>1.0beta1</code> 버전의 모든 사용자들은 <code>1.1alpha1</code>으로 업그레이드를 통보받게 "
-"됩니다. 업데이트는 버전 넘버가 아닌, 제출일을 기준으로 제공되므로 사용자들은 항상 가장 최근 채널에 업데이트된 버전을 받아야 하며 "
-"알파벳 순으로 버전 순서를 이해해선 안됩니다."
+"\"베타 버전\"이라 불리는 동안엔 베타 채널을 통해서 나이티, 알파, 프리릴리즈 버전을 원하는대로 사용할 수 있습니다. 이러한 사유로 채널은 한개 뿐이며 이 채널의 모든 사용자는 가장 최근에 올라온 부가 기능을 받아보게 됩니다. 예를 들어 <code>1.0beta1</code> 버전을 공개 채널에 업로드 한 다음 "
+"<code>1.1alpha1</code> 버전을 또 업로드하게 되면 <code>1.0beta1</code> 버전의 모든 사용자들은 <code>1.1alpha1</code>으로 업그레이드를 통보받게 됩니다. 업데이트는 버전 넘버가 아닌, 제출일을 기준으로 제공되므로 사용자들은 항상 가장 최근 채널에 업데이트된 버전을 받아야 하며 알파벳 순으로 버전 "
+"순서를 이해해선 안됩니다."
 
 #: src/olympia/devhub/templates/devhub/docs/policies-maintenance.html:48
 msgid "Required Updates"
@@ -6368,17 +5268,12 @@ msgstr "업데이트 요구사항"
 
 #: src/olympia/devhub/templates/devhub/docs/policies-maintenance.html:50
 msgid ""
-"Certain situations may arise in which Mozilla requests that an add-on "
-"developer update their add-on within a given time period to address a major "
-"security issue or policy violation. We work with developers to reasonably "
-"accommodate their own schedules, but if the issue is of a serious enough "
-"nature, add-ons that cannot issue an update with the requested fix may be "
-"demoted from fully-reviewed status, disabled, or permanently removed from "
-"the site."
+"Certain situations may arise in which Mozilla requests that an add-on developer update their add-on within a given time period to address a major security issue or policy violation. We work with "
+"developers to reasonably accommodate their own schedules, but if the issue is of a serious enough nature, add-ons that cannot issue an update with the requested fix may be demoted from fully-"
+"reviewed status, disabled, or permanently removed from the site."
 msgstr ""
-"일정 주기마다 Mozilla측에서 긴급 보안 문제나 개인 정보 침해에 대한 부가 기능 업데이트를 개발자에게 요구하는 상황이 종종 발생할 "
-"것입니다. 저희는 개발자와 합리적인 일정 조정을 통해 작업을 하지만, 문제가 근본적 수준의 심각한 상태라면 부가 기능은 문제를 수정할 "
-"업데이트를 내놓지 못하고 시험용 상태, 사용 중단 상태로 돌아가거나 사이트에서 영구 삭제될 것입니다."
+"일정 주기마다 Mozilla측에서 긴급 보안 문제나 개인 정보 침해에 대한 부가 기능 업데이트를 개발자에게 요구하는 상황이 종종 발생할 것입니다. 저희는 개발자와 합리적인 일정 조정을 통해 작업을 하지만, 문제가 근본적 수준의 심각한 상태라면 부가 기능은 문제를 수정할 업데이트를 내놓지 못하고 시험용 상태, 사용 중단 상태로 돌아가거나 사이트에서 영구"
+" 삭제될 것입니다."
 
 #: src/olympia/devhub/templates/devhub/docs/policies-maintenance.html:55
 msgid "Transfer of Ownership"
@@ -6386,55 +5281,33 @@ msgstr "소유권 이전"
 
 #: src/olympia/devhub/templates/devhub/docs/policies-maintenance.html:57
 msgid ""
-"Add-ons can have multiple users with permission to update and manage the "
-"listing. Existing authors of an add-on can transfer ownership and add "
-"additional developers to an add-on's listing through the Developer Tools "
-"provided. No interaction with Mozilla representatives is necessary for a "
-"transfer of ownership."
-msgstr ""
-"부가 기능은 업데이트할 권리 및 등록 관리에 있어 여러 사용자를 보유할 수 있습니다. 부가 기능 제작자는 개발자 도구를 통해 소유권 "
-"이전과 추가 개발자 임명을 할 수 있습니다. 소유권 이전에 있어 Mozilla측 대표와 대화를 할 필요는 없습니다."
+"Add-ons can have multiple users with permission to update and manage the listing. Existing authors of an add-on can transfer ownership and add additional developers to an add-on's listing through "
+"the Developer Tools provided. No interaction with Mozilla representatives is necessary for a transfer of ownership."
+msgstr "부가 기능은 업데이트할 권리 및 등록 관리에 있어 여러 사용자를 보유할 수 있습니다. 부가 기능 제작자는 개발자 도구를 통해 소유권 이전과 추가 개발자 임명을 할 수 있습니다. 소유권 이전에 있어 Mozilla측 대표와 대화를 할 필요는 없습니다."
 
 #: src/olympia/devhub/templates/devhub/docs/policies-maintenance.html:63
 #, python-format
-msgid ""
-"Mozilla can assist with granting additional permissions of an add-on's "
-"listing if <a href=\"%(link_contact)s\">contacted</a> by the add-on's "
-"current owner."
-msgstr ""
-"부가 기능의 현 소유자와 <a href=\"%(link_contact)s\">연락</a>이 되어있을 경우엔 부가 기능 등재와 추가 권한 "
-"획득 작업을 Mozilla에서 도와줄 수 있습니다."
+msgid "Mozilla can assist with granting additional permissions of an add-on's listing if <a href=\"%(link_contact)s\">contacted</a> by the add-on's current owner."
+msgstr "부가 기능의 현 소유자와 <a href=\"%(link_contact)s\">연락</a>이 되어있을 경우엔 부가 기능 등재와 추가 권한 획득 작업을 Mozilla에서 도와줄 수 있습니다."
 
 #: src/olympia/devhub/templates/devhub/docs/policies-maintenance.html:70
 msgid ""
-"Mozilla encourages its users to offer feedback on their experiences when "
-"using an add-on. This allows other users to determine if the add-on is "
-"stable and useful. It also provides valuable feedback to developers, "
-"allowing them to continuously improve their add-on to meet user needs."
-msgstr ""
-"Mozilla에선 사용자가 부가 기능 사용시 경험한 것을 토대로 한 피드백 제공을 장려하고 있습니다. 이는 다른 사용자가 부가 기능이 "
-"안정적이고 유용한지를 판단하는데 쓰입니다. 또한 개발자에게 유용한 피드백을 제공하며, 사용자의 요구사항에 맞출수 있도록 부가 기능의 "
-"지속적인 향상도 이끌어줍니다."
+"Mozilla encourages its users to offer feedback on their experiences when using an add-on. This allows other users to determine if the add-on is stable and useful. It also provides valuable feedback"
+" to developers, allowing them to continuously improve their add-on to meet user needs."
+msgstr "Mozilla에선 사용자가 부가 기능 사용시 경험한 것을 토대로 한 피드백 제공을 장려하고 있습니다. 이는 다른 사용자가 부가 기능이 안정적이고 유용한지를 판단하는데 쓰입니다. 또한 개발자에게 유용한 피드백을 제공하며, 사용자의 요구사항에 맞출수 있도록 부가 기능의 지속적인 향상도 이끌어줍니다."
 
 #: src/olympia/devhub/templates/devhub/docs/policies-maintenance.html:76
 #, python-format
 msgid ""
-"Reviews must follow the <a href=\"%(link_guidelines)s\">review "
-"guidelines</a>. Reviews that do not meet these guidelines may be flagged for"
-" moderation, but negative reviews will not be removed unless they provide "
-"false information."
-msgstr ""
-"평가는 <a href=\"%(link_guidelines)s\">평가 가이드라인</a>을 따라야 합니다. 가이드라인에 맞지 않는 평가는 "
-"중재 대상으로 표시될 것이나, 잘못된 정보를 제공하지 않는 한 부정적인 평가가 삭제되진 않을 것입니다."
+"Reviews must follow the <a href=\"%(link_guidelines)s\">review guidelines</a>. Reviews that do not meet these guidelines may be flagged for moderation, but negative reviews will not be removed "
+"unless they provide false information."
+msgstr "평가는 <a href=\"%(link_guidelines)s\">평가 가이드라인</a>을 따라야 합니다. 가이드라인에 맞지 않는 평가는 중재 대상으로 표시될 것이나, 잘못된 정보를 제공하지 않는 한 부정적인 평가가 삭제되진 않을 것입니다."
 
 #: src/olympia/devhub/templates/devhub/docs/policies-maintenance.html:82
 msgid ""
-"Many developers provide a support mechanism, such as a forum, discussion "
-"group, or email address. It is recommended that support questions be posted "
-"via those mediums instead of in an add-on's review section."
-msgstr ""
-"많은 개발자들이 포럼, 토론 그룹, 이메일 주소와 같은 기술 지원 수단을 제공하고 있습니다. 본 사이트의 부가 기능 사용자 평가 페이지 "
-"보다는 위의 수단을 통해 질문 사항을 올리는 것이 좋습니다."
+"Many developers provide a support mechanism, such as a forum, discussion group, or email address. It is recommended that support questions be posted via those mediums instead of in an add-on's "
+"review section."
+msgstr "많은 개발자들이 포럼, 토론 그룹, 이메일 주소와 같은 기술 지원 수단을 제공하고 있습니다. 본 사이트의 부가 기능 사용자 평가 페이지 보다는 위의 수단을 통해 질문 사항을 올리는 것이 좋습니다."
 
 #: src/olympia/devhub/templates/devhub/docs/policies-maintenance.html:87
 msgid "Code Disputes"
@@ -6442,39 +5315,21 @@ msgstr "코드 관련 분쟁"
 
 #: src/olympia/devhub/templates/devhub/docs/policies-maintenance.html:90
 msgid ""
-"Many add-ons allow their source code to be openly viewed. This does not mean"
-" that the source code is open source or available for use in another add-on."
-" The original author of an add-on retains copyright of their work unless "
-"otherwise noted in the add-on's license."
-msgstr ""
-"많은 부가 기능이 소스 코드를 열람할 수 있도록 허용하고 있습니다. 이는 소스 코드가 오픈 소스라던지 다른 부가 기능에도 사용할 수 "
-"있다는 뜻은 아닙니다. 부가 기능의 원 제작자는 부가 기능의 라이선스에서 따로 고지하지 않는 한 자신의 저작물에 대한 저작권을 보유하고 "
-"있습니다."
+"Many add-ons allow their source code to be openly viewed. This does not mean that the source code is open source or available for use in another add-on. The original author of an add-on retains "
+"copyright of their work unless otherwise noted in the add-on's license."
+msgstr "많은 부가 기능이 소스 코드를 열람할 수 있도록 허용하고 있습니다. 이는 소스 코드가 오픈 소스라던지 다른 부가 기능에도 사용할 수 있다는 뜻은 아닙니다. 부가 기능의 원 제작자는 부가 기능의 라이선스에서 따로 고지하지 않는 한 자신의 저작물에 대한 저작권을 보유하고 있습니다."
 
 #: src/olympia/devhub/templates/devhub/docs/policies-maintenance.html:96
 msgid ""
-"In the event that we're notified of a copyright or license infringement, we "
-"will take steps to review the situation and determine if an actual "
-"infringement has occurred. If we determine that there is an infringement, we"
-" will remove the offending add-on and contact the author. New add-on "
-"submissions (including updates) containing infringing code will be denied "
-"approval for public status."
-msgstr ""
-"저작권이나 라이선스 위반이 신고되었을 땐, 상황을 검토하고 실제 위반 사실이 발생할 경우 판단을 내릴 단계를 거치게 될 것입니다. 위반 "
-"사실이 있다고 판단할 경우, 해당 부가 기능은 삭제되며 제작자에게 연락이 취해질 것입니다. 침해한 코드가 포함된 새 부가 기능이 제출되면"
-" (업데이트 포함) 공개 상태 승인 과정에서 거부될 것입니다."
+"In the event that we're notified of a copyright or license infringement, we will take steps to review the situation and determine if an actual infringement has occurred. If we determine that there "
+"is an infringement, we will remove the offending add-on and contact the author. New add-on submissions (including updates) containing infringing code will be denied approval for public status."
+msgstr "저작권이나 라이선스 위반이 신고되었을 땐, 상황을 검토하고 실제 위반 사실이 발생할 경우 판단을 내릴 단계를 거치게 될 것입니다. 위반 사실이 있다고 판단할 경우, 해당 부가 기능은 삭제되며 제작자에게 연락이 취해질 것입니다. 침해한 코드가 포함된 새 부가 기능이 제출되면 (업데이트 포함) 공개 상태 승인 과정에서 거부될 것입니다."
 
 #: src/olympia/devhub/templates/devhub/docs/policies-maintenance.html:102
-msgid ""
-"If you are unsure of the current copyright status of an add-on's source "
-"code, you must contact the original author and receive explicit permission "
-"before using the source code."
-msgstr ""
-"현재 부가 기능의 소스 코드 저작권을 확실하게 알고있지 않다면, 원 제작자에게 연락을 취하고 소스 코드 사용 전에 확실한 권리를 받아놔야"
-" 합니다."
+msgid "If you are unsure of the current copyright status of an add-on's source code, you must contact the original author and receive explicit permission before using the source code."
+msgstr "현재 부가 기능의 소스 코드 저작권을 확실하게 알고있지 않다면, 원 제작자에게 연락을 취하고 소스 코드 사용 전에 확실한 권리를 받아놔야 합니다."
 
-#: src/olympia/devhub/templates/devhub/docs/policies-maintenance.html:107
-#: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:306
+#: src/olympia/devhub/templates/devhub/docs/policies-maintenance.html:107 src/olympia/devhub/templates/devhub/docs/policies-reviews.html:306
 #: src/olympia/devhub/templates/devhub/docs/policies-submission.html:97
 msgid "Last updated: January 13, 2011"
 msgstr "마지막 업데이트: 2011년 1월 13일"
@@ -6482,47 +5337,29 @@ msgstr "마지막 업데이트: 2011년 1월 13일"
 #: src/olympia/devhub/templates/devhub/docs/policies-recommended.html:13
 #, python-format
 msgid ""
-"Featured add-ons are top-quality extensions and themes highlighted on <a "
-"href=\"%(link_gallery)s\">AMO</a>, Firefox's Add-ons Manager, and across "
-"other Mozilla websites. These add-ons showcase the power of Firefox "
-"customization and are useful to a wide audience."
-msgstr ""
-"추천 부가 기능은 <a href=\"%(link_gallery)s\">AMO</a>, Firefox의 부가 기능 관리자, 그리고 다른 "
-"Mozilla 웹사이트에 하이라이트된 상위 품질의 확장 기능과 테마입니다. 이런 부가 기능은 Firefox 사용자화의 능력을 보여주며 더"
-" 많은 사람들에게 유용합니다."
+"Featured add-ons are top-quality extensions and themes highlighted on <a href=\"%(link_gallery)s\">AMO</a>, Firefox's Add-ons Manager, and across other Mozilla websites. These add-ons showcase the "
+"power of Firefox customization and are useful to a wide audience."
+msgstr "추천 부가 기능은 <a href=\"%(link_gallery)s\">AMO</a>, Firefox의 부가 기능 관리자, 그리고 다른 Mozilla 웹사이트에 하이라이트된 상위 품질의 확장 기능과 테마입니다. 이런 부가 기능은 Firefox 사용자화의 능력을 보여주며 더 많은 사람들에게 유용합니다."
 
 #: src/olympia/devhub/templates/devhub/docs/policies-recommended.html:19
-msgid ""
-"Featured add-ons are chosen by the Featured Add-ons Advisory Board, a small "
-"group of add-on developers and fans from the Mozilla community who have "
-"volunteered to review and vote on nominations."
-msgstr ""
-"추천 부가 기능 자문 위원회가 추천할 부가 기능을 선정합니다. 자문회는 Mozilla 커뮤니티의 부가 기능 개발자와 팬으로 이루어진 "
-"소규모 조직으로, 후보의 심사와 투표를 자원하신 분들입니다."
+msgid "Featured add-ons are chosen by the Featured Add-ons Advisory Board, a small group of add-on developers and fans from the Mozilla community who have volunteered to review and vote on nominations."
+msgstr "추천 부가 기능 자문 위원회가 추천할 부가 기능을 선정합니다. 자문회는 Mozilla 커뮤니티의 부가 기능 개발자와 팬으로 이루어진 소규모 조직으로, 후보의 심사와 투표를 자원하신 분들입니다."
 
 #: src/olympia/devhub/templates/devhub/docs/policies-recommended.html:25
 #, python-format
-msgid ""
-"<a href=\"%(link_featured)s\">Featured extensions</a> are chosen every "
-"month, and <a href=\"%(link_themes)s\">featured complete themes</a> are "
-"chosen every quarter."
-msgstr ""
-"<a href=\"%(link_featured)s\">추천 확장 기능</a>은 매달 선정되며, <a "
-"href=\"%(link_themes)s\">추천 완전 테마</a>는 매 분기마다 선정됩니다."
+msgid "<a href=\"%(link_featured)s\">Featured extensions</a> are chosen every month, and <a href=\"%(link_themes)s\">featured complete themes</a> are chosen every quarter."
+msgstr "<a href=\"%(link_featured)s\">추천 확장 기능</a>은 매달 선정되며, <a href=\"%(link_themes)s\">추천 완전 테마</a>는 매 분기마다 선정됩니다."
 
 #: src/olympia/devhub/templates/devhub/docs/policies-recommended.html:30
 msgid "Criteria for Featured Add-ons"
 msgstr "추천 부가 기능 선정 기준"
 
 #: src/olympia/devhub/templates/devhub/docs/policies-recommended.html:33
-msgid ""
-"Before nominating an add-on to be featured, please ensure it meets the "
-"following criteria:"
+msgid "Before nominating an add-on to be featured, please ensure it meets the following criteria:"
 msgstr "부가 기능을 추천하기 전에, 다음의 영역에 부합하는지 먼저 확인해주세요:"
 
 #: src/olympia/devhub/templates/devhub/docs/policies-recommended.html:39
-msgid ""
-"The add-on must have a complete and informative listing on AMO. This means:"
+msgid "The add-on must have a complete and informative listing on AMO. This means:"
 msgstr "AMO에 올라온 부가 기능은 모든 요소를 갖추고 있어야 하며 유용하게 쓸 수 있어야 합니다. 구체적으로 말하자면:"
 
 #: src/olympia/devhub/templates/devhub/docs/policies-recommended.html:41
@@ -6546,14 +5383,11 @@ msgid "updated screenshots of the add-on's functionality"
 msgstr "기능 작동 스크린샷의 최신 업데이트 유지"
 
 #: src/olympia/devhub/templates/devhub/docs/policies-recommended.html:46
-msgid ""
-"must be fully approved by AMO editors (no preliminarily reviewed entries)"
+msgid "must be fully approved by AMO editors (no preliminarily reviewed entries)"
 msgstr "AMO 편집자의 완벽한 승인을 받아야 함 (예비 심사 상태로는 불가)"
 
 #: src/olympia/devhub/templates/devhub/docs/policies-recommended.html:48
-msgid ""
-"The add-on must have excellent user reviews and any problems or support "
-"requests must be promptly addressed by the developer."
+msgid "The add-on must have excellent user reviews and any problems or support requests must be promptly addressed by the developer."
 msgstr "사용자들에게 좋은 평가를 받고 있어야 하며 문제 발생 및 기술 지원 요청이 있을시 즉시 개발자에게 내용이 전달되야 합니다."
 
 #: src/olympia/devhub/templates/devhub/docs/policies-recommended.html:49
@@ -6561,21 +5395,14 @@ msgid "The add-on must have a minimum of 2,000 users."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/docs/policies-recommended.html:50
-msgid ""
-"The add-on must be compatible with the latest release of Firefox and must be"
-" compatible with beta versions 4 weeks before their final release."
-msgstr ""
-"Firefox 최신 버전과 호환되야 하며 최종 출시 버전보다 4주 이전에 나온 베타 버전과도 호환성을 확보하고 있어야 합니다."
+msgid "The add-on must be compatible with the latest release of Firefox and must be compatible with beta versions 4 weeks before their final release."
+msgstr "Firefox 최신 버전과 호환되야 하며 최종 출시 버전보다 4주 이전에 나온 베타 버전과도 호환성을 확보하고 있어야 합니다."
 
 #: src/olympia/devhub/templates/devhub/docs/policies-recommended.html:51
 msgid ""
-"<strong>Most importantly</strong>, the add-on must have wide consumer appeal"
-" to Firefox's users and be outstanding in nearly every way: user experience,"
-" performance, security, and usefulness or entertainment value. Featured "
-"complete themes must also be visually appealing."
-msgstr ""
-"<strong>가장 중요한 사항으로</strong>, 부가 기능은 Firefox 사용자에게 매력적이어야 하며 거의 모든 방면에서 뛰어나야"
-" 합니다: 사용자 경험, 성능, 보안, 유용함, 오락성에 대해 가치를 담보해야 합니다. 추천 완전 테마 역시 시각적으로 돋보여야 합니다."
+"<strong>Most importantly</strong>, the add-on must have wide consumer appeal to Firefox's users and be outstanding in nearly every way: user experience, performance, security, and usefulness or "
+"entertainment value. Featured complete themes must also be visually appealing."
+msgstr "<strong>가장 중요한 사항으로</strong>, 부가 기능은 Firefox 사용자에게 매력적이어야 하며 거의 모든 방면에서 뛰어나야 합니다: 사용자 경험, 성능, 보안, 유용함, 오락성에 대해 가치를 담보해야 합니다. 추천 완전 테마 역시 시각적으로 돋보여야 합니다."
 
 #: src/olympia/devhub/templates/devhub/docs/policies-recommended.html:54
 msgid "Nominating an Add-on"
@@ -6587,34 +5414,25 @@ msgstr "amo-featured 골뱅이 mozilla 점 org"
 
 #: src/olympia/devhub/templates/devhub/docs/policies-recommended.html:57
 #, python-format
-msgid ""
-"If you wish to nominate an add-on to be featured and it meets the criteria "
-"above, send an email to %(mail_featured)s with:"
-msgstr ""
-"추천 부가 기능으로의 추천을 원하신다면 위의 기준을 충족하는지 확인하신 다음 다음의 내용을 적어서 %(mail_featured)s로 "
-"메일을 보내주세요:"
+msgid "If you wish to nominate an add-on to be featured and it meets the criteria above, send an email to %(mail_featured)s with:"
+msgstr "추천 부가 기능으로의 추천을 원하신다면 위의 기준을 충족하는지 확인하신 다음 다음의 내용을 적어서 %(mail_featured)s로 메일을 보내주세요:"
 
 #: src/olympia/devhub/templates/devhub/docs/policies-recommended.html:62
 msgid "the add-on name, URL, and whether you are its developer"
 msgstr "부가 기능 이름, URL, 본인이 해당 부가 기능의 개발자인지 여부"
 
 #: src/olympia/devhub/templates/devhub/docs/policies-recommended.html:63
-msgid ""
-"a short explanation of why the add-on has wide appeal and should be featured"
+msgid "a short explanation of why the add-on has wide appeal and should be featured"
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/docs/policies-recommended.html:64
-msgid ""
-"optionally, links to any external reviews or articles mentioning the add-on"
+msgid "optionally, links to any external reviews or articles mentioning the add-on"
 msgstr "선택사항으로, 외부 사이트의 평가나 언급이 되어있는 게시물에 대한 링크"
 
 #: src/olympia/devhub/templates/devhub/docs/policies-recommended.html:68
 msgid ""
-"Add-on nominations are reviewed by the Advisory Board once a month (once "
-"every 3 months for complete theme nominations). Common reasons for rejection"
-" include lacking wide appeal to consumers, a suboptimal user experience, "
-"quality or security issues, incompatibility, and similarity to another "
-"featured add-on. Rejected add-ons cannot be re-nominated within 3 months."
+"Add-on nominations are reviewed by the Advisory Board once a month (once every 3 months for complete theme nominations). Common reasons for rejection include lacking wide appeal to consumers, a "
+"suboptimal user experience, quality or security issues, incompatibility, and similarity to another featured add-on. Rejected add-ons cannot be re-nominated within 3 months."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/docs/policies-recommended.html:73
@@ -6622,187 +5440,115 @@ msgid "Rotating Featured Add-ons"
 msgstr "추천 부가 기능 순환 등재"
 
 #: src/olympia/devhub/templates/devhub/docs/policies-recommended.html:76
-msgid ""
-"Mozilla and the Featured Add-ons Advisory Board regularly evaluate and "
-"rotate out featured add-ons. Some of the most common reasons for add-ons "
-"being removed from the featured list are:"
-msgstr ""
-"Mozilla와 추천 부가 기능 자문 위원회에선 정기적으로 추천 부가 기능 상태를 만료시켜 목록을 순환시킵니다. 추천 목록에서 삭제되는 "
-"가장 일반적인 사유는 다음과 같습니다:"
+msgid "Mozilla and the Featured Add-ons Advisory Board regularly evaluate and rotate out featured add-ons. Some of the most common reasons for add-ons being removed from the featured list are:"
+msgstr "Mozilla와 추천 부가 기능 자문 위원회에선 정기적으로 추천 부가 기능 상태를 만료시켜 목록을 순환시킵니다. 추천 목록에서 삭제되는 가장 일반적인 사유는 다음과 같습니다:"
 
 #: src/olympia/devhub/templates/devhub/docs/policies-recommended.html:83
 msgid ""
-"Lack of growth &mdash; Add-ons that are featured typically experience a "
-"substantial gain in both downloads and active users. If an add-on is not "
-"demonstrating growth in any substantial way, that's a good indicator the "
-"add-on may not be very useful to our users."
-msgstr ""
-"성장 부진 &mdash; 추천 상태의 부가 기능은 대개 다운로드와 실 사용자 모두 엄청난 성장을 하게 됩니다. 이러한 모습을 보여주고 "
-"있지 못한다면 이는 해당 부가 기능이 사용자에게 크게 쓸모가 없음을 나타내는 좋은 신호라고 할 수 있습니다."
+"Lack of growth &mdash; Add-ons that are featured typically experience a substantial gain in both downloads and active users. If an add-on is not demonstrating growth in any substantial way, that's "
+"a good indicator the add-on may not be very useful to our users."
+msgstr "성장 부진 &mdash; 추천 상태의 부가 기능은 대개 다운로드와 실 사용자 모두 엄청난 성장을 하게 됩니다. 이러한 모습을 보여주고 있지 못한다면 이는 해당 부가 기능이 사용자에게 크게 쓸모가 없음을 나타내는 좋은 신호라고 할 수 있습니다."
 
 #: src/olympia/devhub/templates/devhub/docs/policies-recommended.html:88
-msgid ""
-"Negative reviews &mdash; Featured add-ons should have a great experience and"
-" very few bugs, so add-ons with many negative reviews may be reconsidered."
-msgstr ""
-"부정적인 평가 &mdash; 추천 부가 기능은 훌륭한 사용자 경험을 제공해야 하며 버그도 거의 없어야 합니다. 따라서 부정적인 평가가 "
-"많은 부가 기능은 추천 상태를 재검토하게 될 것입니다."
+msgid "Negative reviews &mdash; Featured add-ons should have a great experience and very few bugs, so add-ons with many negative reviews may be reconsidered."
+msgstr "부정적인 평가 &mdash; 추천 부가 기능은 훌륭한 사용자 경험을 제공해야 하며 버그도 거의 없어야 합니다. 따라서 부정적인 평가가 많은 부가 기능은 추천 상태를 재검토하게 될 것입니다."
 
 #: src/olympia/devhub/templates/devhub/docs/policies-recommended.html:93
 msgid ""
-"Incompatibility with upcoming Firefox versions &mdash; Featured add-ons are "
-"expected to be compatible with stable and beta versions of Firefox. Add-ons "
-"not yet compatible with a Beta version of Firefox four weeks before its "
-"expected release will lose their featured status."
-msgstr ""
-"차기 Firefox 버전과의 비호환 &mdash; 추천 부가 기능은 Firefox 안정, 베타 버전 모두 호환성을 유지하고 있어야 "
-"합니다. 최종 출시 버전으로 예상되는 버전의 4주 이전 베타 버전과 호환되지 않는 부가 기능은 추천 상태를 박탈당하게 됩니다."
+"Incompatibility with upcoming Firefox versions &mdash; Featured add-ons are expected to be compatible with stable and beta versions of Firefox. Add-ons not yet compatible with a Beta version of "
+"Firefox four weeks before its expected release will lose their featured status."
+msgstr "차기 Firefox 버전과의 비호환 &mdash; 추천 부가 기능은 Firefox 안정, 베타 버전 모두 호환성을 유지하고 있어야 합니다. 최종 출시 버전으로 예상되는 버전의 4주 이전 베타 버전과 호환되지 않는 부가 기능은 추천 상태를 박탈당하게 됩니다."
 
 #: src/olympia/devhub/templates/devhub/docs/policies-recommended.html:99
 msgid "Joining the Featured Add-ons Advisory Board"
 msgstr "추천 부가 기능 자문 위원회에 가입하기"
 
 #: src/olympia/devhub/templates/devhub/docs/policies-recommended.html:102
-msgid ""
-"Every six months a new Advisory Board is chosen based on applications from "
-"the add-ons community. Members must:"
+msgid "Every six months a new Advisory Board is chosen based on applications from the add-ons community. Members must:"
 msgstr "6개월마다 부가 기능 커뮤니티의 지원자를 기반으로 추천 심의 위원회가 새로 선출됩니다. 심의 위원 준수 사항:"
 
 #: src/olympia/devhub/templates/devhub/docs/policies-recommended.html:108
-msgid ""
-"be active members of the add-ons community, whether as a developer, "
-"evangelist, or fan"
+msgid "be active members of the add-ons community, whether as a developer, evangelist, or fan"
 msgstr "개발자, 전도사, 팬, 역할에 관계 없이 부가 기능 커뮤니티에서 적극 활동"
 
 #: src/olympia/devhub/templates/devhub/docs/policies-recommended.html:109
-msgid ""
-"commit to trying all the nominations submitted, giving their feedback, and "
-"casting their votes every month"
+msgid "commit to trying all the nominations submitted, giving their feedback, and casting their votes every month"
 msgstr "모든 심사 대상에 대해 심의 실시, 피드백 제공, 매 달마다 투표"
 
 #: src/olympia/devhub/templates/devhub/docs/policies-recommended.html:110
-msgid ""
-"abstain from voting on add-ons that they have any business or personal "
-"affiliations with, as well as direct competitors of any such add-ons"
+msgid "abstain from voting on add-ons that they have any business or personal affiliations with, as well as direct competitors of any such add-ons"
 msgstr "상업적 내지는 개인적으로 관련이 있거나 직접적인 경쟁 상대인 부가 기능에는 투표를 기권"
 
 #: src/olympia/devhub/templates/devhub/docs/policies-recommended.html:114
 msgid ""
-"Members of the Mozilla Add-ons team may veto any add-on's selection because "
-"of security, privacy, compatibility, or any other reason, but in general it "
-"is up to the Board to select add-ons to feature."
-msgstr ""
-"Mozilla 부가 기능 팀의 일원은 부가 기능 선정시 보안, 개인 정보, 호환성, 그 밖의 이유로 거부권 행사가 가능하나 일반적으로 "
-"추천 부가 기능 선정은 위원회의 소관입니다."
+"Members of the Mozilla Add-ons team may veto any add-on's selection because of security, privacy, compatibility, or any other reason, but in general it is up to the Board to select add-ons to "
+"feature."
+msgstr "Mozilla 부가 기능 팀의 일원은 부가 기능 선정시 보안, 개인 정보, 호환성, 그 밖의 이유로 거부권 행사가 가능하나 일반적으로 추천 부가 기능 선정은 위원회의 소관입니다."
 
 #: src/olympia/devhub/templates/devhub/docs/policies-recommended.html:120
 msgid ""
-"This featured policy only applies to the addons.mozilla.org global list of "
-"featured add-ons. Add-ons featured in other locations are often pulled from "
-"this list, but Mozilla may feature any add-on in other locations without the"
-" Board's consent. Additionally, locale-specific features override the global"
-" defaults, so if a locale has opted to select its own features, some or all "
-"of the global features may not appear in that locale."
+"This featured policy only applies to the addons.mozilla.org global list of featured add-ons. Add-ons featured in other locations are often pulled from this list, but Mozilla may feature any add-on "
+"in other locations without the Board's consent. Additionally, locale-specific features override the global defaults, so if a locale has opted to select its own features, some or all of the global "
+"features may not appear in that locale."
 msgstr ""
-"추천 부가 기능 정책은 addons.mozilla.org 사이트의 추천 부가 기능의 글로벌 목록으로만 적용됩니다. 다른 지역의 추천 부가"
-" 기능에선 이 목록에서 몇 가지가 종종 빠지며, Mozilla가 위원회의 동의 없이 임의로 다른 추천 부가 기능을 선정할 수 있습니다. "
-"추가적으로, 지역별 추천 내역은 글로벌 사이트의 기본값을 대체하기 때문에, 가령 어느 지역에서 자체 추천 목록을 사용하기로 결정했을 "
-"경우엔 글로벌 목록은 해당 지역에서 일부 또는 전체가 노출되지 않을 수 있습니다."
+"추천 부가 기능 정책은 addons.mozilla.org 사이트의 추천 부가 기능의 글로벌 목록으로만 적용됩니다. 다른 지역의 추천 부가 기능에선 이 목록에서 몇 가지가 종종 빠지며, Mozilla가 위원회의 동의 없이 임의로 다른 추천 부가 기능을 선정할 수 있습니다. 추가적으로, 지역별 추천 내역은 글로벌 사이트의 기본값을 대체하기 때문에, 가령 "
+"어느 지역에서 자체 추천 목록을 사용하기로 결정했을 경우엔 글로벌 목록은 해당 지역에서 일부 또는 전체가 노출되지 않을 수 있습니다."
 
 #: src/olympia/devhub/templates/devhub/docs/policies-recommended.html:126
 #, python-format
-msgid ""
-"Follow the <a href=\"%(link_blog)s\">Add-ons Blog</a> or <a "
-"href=\"%(link_twitter)s\">@mozamo</a> on Twitter to learn when the next "
-"application period opens."
-msgstr ""
-"차기 부가 기능 행사 시기를 알고 싶다면 <a href=\"%(link_blog)s\">부가 기능 블로그</a>나 트위터에서 <a "
-"href=\"%(link_twitter)s\">@mozamo</a>를 팔로우 하세요."
+msgid "Follow the <a href=\"%(link_blog)s\">Add-ons Blog</a> or <a href=\"%(link_twitter)s\">@mozamo</a> on Twitter to learn when the next application period opens."
+msgstr "차기 부가 기능 행사 시기를 알고 싶다면 <a href=\"%(link_blog)s\">부가 기능 블로그</a>나 트위터에서 <a href=\"%(link_twitter)s\">@mozamo</a>를 팔로우 하세요."
 
 #: src/olympia/devhub/templates/devhub/docs/policies-recommended.html:131
 msgid "Last updated: January 31, 2013"
 msgstr "마지막 갱신: 2013/01/31"
 
-#: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:3
-#: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:7
-#: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:8
-#: src/olympia/devhub/templates/devhub/docs/policies.html:15
-#: src/olympia/devhub/templates/devhub/docs/policies.html:64
+#: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:3 src/olympia/devhub/templates/devhub/docs/policies-reviews.html:7 src/olympia/devhub/templates/devhub/docs/policies-reviews.html:8
+#: src/olympia/devhub/templates/devhub/docs/policies.html:15 src/olympia/devhub/templates/devhub/docs/policies.html:64
 msgid "Review Process"
 msgstr "심사 과정"
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:12
 msgid ""
-"In order to ensure all add-ons hosted in our gallery are safe for users to "
-"install, Mozilla will begin requiring all hosted add-ons to undergo review. "
-"We offer two types of review and developers are free to choose the best fit "
-"for their add-on."
-msgstr ""
-"사용자들이 저희 갤러리 상에 호스팅 되어있는 부가 기능들을 안전하게 설치할 수 있도록 Mozilla에선 호스팅을 준비중인 부가 기능에 "
-"심사를 하게 될 것입니다. 저희가 마련한 심사 방식엔 2가지 종류가 있으며 개발자들은 이 중 자신의 부가 기능과 가장 어울리는 방식을 "
-"자유롭게 선택해서 심사를 받으실 수 있습니다."
+"In order to ensure all add-ons hosted in our gallery are safe for users to install, Mozilla will begin requiring all hosted add-ons to undergo review. We offer two types of review and developers "
+"are free to choose the best fit for their add-on."
+msgstr "사용자들이 저희 갤러리 상에 호스팅 되어있는 부가 기능들을 안전하게 설치할 수 있도록 Mozilla에선 호스팅을 준비중인 부가 기능에 심사를 하게 될 것입니다. 저희가 마련한 심사 방식엔 2가지 종류가 있으며 개발자들은 이 중 자신의 부가 기능과 가장 어울리는 방식을 자유롭게 선택해서 심사를 받으실 수 있습니다."
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:19
 msgid ""
-"<strong><a href=\"#full\">Full Review</a></strong> &mdash; a thorough "
-"functional and code review of the add-on, appropriate for add-ons ready for "
-"distribution to the masses. All site features are available to these add-"
-"ons."
-msgstr ""
-"<strong><a href=\"#full\">전체 심사</a></strong> &mdash; 대중에게 배포할 준비가 된 부가 기능에 "
-"대해 기능적인 부분부터 코드까지 전부 심사하는 방식입니다. 심사가 끝나면 사이트의 모든 기능을 이용하실 수 있습니다."
+"<strong><a href=\"#full\">Full Review</a></strong> &mdash; a thorough functional and code review of the add-on, appropriate for add-ons ready for distribution to the masses. All site features are "
+"available to these add-ons."
+msgstr "<strong><a href=\"#full\">전체 심사</a></strong> &mdash; 대중에게 배포할 준비가 된 부가 기능에 대해 기능적인 부분부터 코드까지 전부 심사하는 방식입니다. 심사가 끝나면 사이트의 모든 기능을 이용하실 수 있습니다."
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:24
 msgid ""
-"<strong><a href=\"#preliminary\">Preliminary Review</a></strong> &mdash; a "
-"faster review intended for experimental add-ons. Preliminary reviews do not "
-"check for functionality or full policy compliance, but the reviewed add-ons "
-"have install button cautions and some feature limitations."
-msgstr ""
-"<strong><a href=\"#preliminary\">예비 심사</a></strong> &mdash; 시험용 부가 기능에 맞춘 보다"
-" 간략한 심사 방식입니다. 예비 심사에선 기능성이나 정책 준수가 완벽히 이루어지는지 등을 검사하지 않는 대신, 심사를 거친 부가 기능에 "
-"경고 및 일부 기능이 제한될 수 있다는 내용이 포함된 설치 버튼이 부여됩니다."
+"<strong><a href=\"#preliminary\">Preliminary Review</a></strong> &mdash; a faster review intended for experimental add-ons. Preliminary reviews do not check for functionality or full policy "
+"compliance, but the reviewed add-ons have install button cautions and some feature limitations."
+msgstr "<strong><a href=\"#preliminary\">예비 심사</a></strong> &mdash; 시험용 부가 기능에 맞춘 보다 간략한 심사 방식입니다. 예비 심사에선 기능성이나 정책 준수가 완벽히 이루어지는지 등을 검사하지 않는 대신, 심사를 거친 부가 기능에 경고 및 일부 기능이 제한될 수 있다는 내용이 포함된 설치 버튼이 부여됩니다."
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:31
 msgid ""
-"Detailed descriptions of each option are below. After selecting a review "
-"process at submission, the add-on will be placed in the queue. Add-ons are "
-"reviewed by the <a href=\"https://wiki.mozilla.org/AMO:Editors\">AMO "
-"Editors</a>, a group of talented developers that volunteer to help the "
-"Mozilla project by reviewing add-ons to ensure a stable and safe experience "
-"for users. Developers will receive an email with any updates throughout the "
-"review process."
+"Detailed descriptions of each option are below. After selecting a review process at submission, the add-on will be placed in the queue. Add-ons are reviewed by the <a "
+"href=\"https://wiki.mozilla.org/AMO:Editors\">AMO Editors</a>, a group of talented developers that volunteer to help the Mozilla project by reviewing add-ons to ensure a stable and safe experience "
+"for users. Developers will receive an email with any updates throughout the review process."
 msgstr ""
-"각 심사 방식에 대한 자세한 설명은 아래에 나와 있습니다. 심사 방식의 선택이 끝나면 대기열에 해당 부가 기능이 등록됩니다. 부가 기능은"
-" <a href=\"https://wiki.mozilla.org/AMO:Editors\">AMO 편집자</a>의 심사를 받게 되는데, 이"
-" 분들은 Mozilla 프로젝트의 자원 봉사를 위해 뭉친 재능있는 개발자 집단으로 사용자가 안정적인 사용자 경험을 할 수 있도록 부가 "
-"기능을 심사하게 됩니다. 개발자는 심사를 받는 동안 갱신되는 정보가 있을 때마다 이메일을 받아보게 될 것입니다."
+"각 심사 방식에 대한 자세한 설명은 아래에 나와 있습니다. 심사 방식의 선택이 끝나면 대기열에 해당 부가 기능이 등록됩니다. 부가 기능은 <a href=\"https://wiki.mozilla.org/AMO:Editors\">AMO 편집자</a>의 심사를 받게 되는데, 이 분들은 Mozilla 프로젝트의 자원 봉사를 위해 뭉친 재능있는 개발자 집단으로"
+" 사용자가 안정적인 사용자 경험을 할 수 있도록 부가 기능을 심사하게 됩니다. 개발자는 심사를 받는 동안 갱신되는 정보가 있을 때마다 이메일을 받아보게 될 것입니다."
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:37
 msgid ""
-"While waiting for review, add-ons will not appear anywhere in the gallery "
-"publicly, but direct links to the add-on's details page will work. This "
-"allows the author to blog or share the link with friends, inviting them to "
-"try it out, even when not yet reviewed."
-msgstr ""
-"심사 결과를 기다리는 동안 부가 기능은 갤러리 상에 공개적으로 노출이 되지는 않지만, 부가 기능 상세 정보 페이지로 이동하는 링크는 "
-"여전히 작동합니다. 이 링크를 통해 블로그를 통하거나 또는 친구들과 공유해서 심사가 끝나지 않은 상태에서도 미리 이용해보도록 하실 수 "
-"있습니다."
+"While waiting for review, add-ons will not appear anywhere in the gallery publicly, but direct links to the add-on's details page will work. This allows the author to blog or share the link with "
+"friends, inviting them to try it out, even when not yet reviewed."
+msgstr "심사 결과를 기다리는 동안 부가 기능은 갤러리 상에 공개적으로 노출이 되지는 않지만, 부가 기능 상세 정보 페이지로 이동하는 링크는 여전히 작동합니다. 이 링크를 통해 블로그를 통하거나 또는 친구들과 공유해서 심사가 끝나지 않은 상태에서도 미리 이용해보도록 하실 수 있습니다."
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:44
 msgid ""
-"Full reviews are appropriate for add-ons that are well-tested, stable, fast,"
-" and have wide appeal to our users. If you aren't confident that your add-on"
-" meets that criteria, please consider working out the kinks while in "
-"preliminary review and accumulating user feedback first."
-msgstr ""
-"전체 심사 방식은 이미 충분한 테스트를 거쳐서 안정적이며 빠르고 사용자들에게 대중적인 인기를 얻고 있는 부가 기능에 적합합니다. 심사 "
-"기준에 맞출 자신이 없다면 예비 심사를 받는 동안 해결하는 방법을 고려해 보시고 무엇보다도 사용자의 피드백을 축적해두는 것이 좋습니다."
+"Full reviews are appropriate for add-ons that are well-tested, stable, fast, and have wide appeal to our users. If you aren't confident that your add-on meets that criteria, please consider working"
+" out the kinks while in preliminary review and accumulating user feedback first."
+msgstr "전체 심사 방식은 이미 충분한 테스트를 거쳐서 안정적이며 빠르고 사용자들에게 대중적인 인기를 얻고 있는 부가 기능에 적합합니다. 심사 기준에 맞출 자신이 없다면 예비 심사를 받는 동안 해결하는 방법을 고려해 보시고 무엇보다도 사용자의 피드백을 축적해두는 것이 좋습니다."
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:50
-msgid ""
-"We aim to perform full reviews in under 10 days, though most add-ons are "
-"reviewed in much less time."
+msgid "We aim to perform full reviews in under 10 days, though most add-ons are reviewed in much less time."
 msgstr "전체 심사를 10일 안에 끝내는게 저희 방침입니다만, 대부분의 부가 기능은 그보다 빨리 심사가 끝나게 됩니다."
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:55
@@ -6814,15 +5560,11 @@ msgid "When performing a full review, editors will:"
 msgstr "전체 심사를 실시할 때 편집자는 이러한 일을 합니다:"
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:64
-msgid ""
-"install the add-on, making sure it functions as described and is free of "
-"major defects"
+msgid "install the add-on, making sure it functions as described and is free of major defects"
 msgstr "부가 기능을 설치, 기능이 설명한 대로 제대로 작동하고 치명적인 결함이 없는지 확인"
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:69
-msgid ""
-"perform a source code review, looking for performance and security best "
-"practices"
+msgid "perform a source code review, looking for performance and security best practices"
 msgstr "소스 코드의 심사 실시, 작동 속도와 보안에 있어서 모범적인 코딩을 했는지 검사"
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:74
@@ -6830,34 +5572,22 @@ msgid "ensure the add-on's privacy policy is in line with its functionality"
 msgstr "부가 기능의 개인 정보 보호 정책이 기능 작동시 제대로 지켜지는지 확인"
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:79
-msgid ""
-"look for compliance with all of Mozilla's policies, detailed in these "
-"documents"
+msgid "look for compliance with all of Mozilla's policies, detailed in these documents"
 msgstr "Mozilla의 모든 정책을 문서 자료에 나와있는 대로 준수하는지 점검"
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:86
-msgid ""
-"Some of the most common issues we see when performing these reviews are:"
+msgid "Some of the most common issues we see when performing these reviews are:"
 msgstr "심사를 실시하면서 흔히 발생하는 문제들은 다음과 같습니다:"
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:93
 msgid ""
-"<strong>JavaScript namespace pollution</strong> &mdash; the most common "
-"violation. Be sure to <a "
-"href=\"https://developer.mozilla.org/en/XUL_School/JavaScript_Object_Management\">wrap"
-" your loose variables</a>"
-msgstr ""
-"<strong>자바스크립트 네임스페이스 오염</strong> &mdash; 가장 흔히 발생하는 위반 사항입니다. <a "
-"href=\"https://developer.mozilla.org/en/XUL_School/JavaScript_Object_Management\">묶여있지"
-" 않은 변수 감싸기</a> 문서를 꼭 읽어보시기 바랍니다"
+"<strong>JavaScript namespace pollution</strong> &mdash; the most common violation. Be sure to <a href=\"https://developer.mozilla.org/en/XUL_School/JavaScript_Object_Management\">wrap your loose "
+"variables</a>"
+msgstr "<strong>자바스크립트 네임스페이스 오염</strong> &mdash; 가장 흔히 발생하는 위반 사항입니다. <a href=\"https://developer.mozilla.org/en/XUL_School/JavaScript_Object_Management\">묶여있지 않은 변수 감싸기</a> 문서를 꼭 읽어보시기 바랍니다"
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:99
-msgid ""
-"proper preference naming - all preference names should begin with "
-"\"extensions.\", followed by the add-on name or some other unique identifier"
-msgstr ""
-"적절한 형식 구분명 짓기 - 모든 형식 구분명은 \"extensions.\"으로 시작하고 그 뒤에 부가 기능 이름이나 다른 고유 인식명이"
-" 붙어야 합니다"
+msgid "proper preference naming - all preference names should begin with \"extensions.\", followed by the add-on name or some other unique identifier"
+msgstr "적절한 형식 구분명 짓기 - 모든 형식 구분명은 \"extensions.\"으로 시작하고 그 뒤에 부가 기능 이름이나 다른 고유 인식명이 붙어야 합니다"
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:103
 msgid "remote JavaScript execution or injection"
@@ -6902,86 +5632,50 @@ msgstr "애플리케이션 실행 및 페이지 로딩시 속도 저하"
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:117
 #, python-format
 msgid ""
-"For information on how to avoid these problems, please see our <a "
-"href=\"%(link_howto)s\">How-to Library</a>. Some of these practices, such as"
-" binary or obfuscated code, are allowed under certain conditions outlined "
-"below."
-msgstr ""
-"이러한 문제를 피하는 방법이 적힌 정보를 보시려면 <a href=\"%(link_howto)s\">How-to 도서관</a>을 참고하시기"
-" 바랍니다. 이들 사례중 이진 코드나 변조된 코드같은 것은 아래 밑줄로 표시된 특수한 경우에만 허용됩니다."
+"For information on how to avoid these problems, please see our <a href=\"%(link_howto)s\">How-to Library</a>. Some of these practices, such as binary or obfuscated code, are allowed under certain "
+"conditions outlined below."
+msgstr "이러한 문제를 피하는 방법이 적힌 정보를 보시려면 <a href=\"%(link_howto)s\">How-to 도서관</a>을 참고하시기 바랍니다. 이들 사례중 이진 코드나 변조된 코드같은 것은 아래 밑줄로 표시된 특수한 경우에만 허용됩니다."
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:123
 #, python-format
 msgid ""
-"Many of the above restrictions are tested automatically by an extension "
-"scanner that will flag suspicious add-ons for editor review. You can read "
-"more about this scanner in the <a href=\"%(link_validation)s\">Validation "
-"Help</a> document."
-msgstr ""
-"위에 소개된 제한 사항의 대부분은 확장 기능 스캐너에 의해 자동으로 검사되므로 편집자 심사를 받을 땐 문제 부가 기능으로 표시가 될 "
-"것입니다. 스캐너에 관한 사항은 <a href=\"%(link_validation)s\">검사기 도움말</a>에 보다 자세한 내용을 "
-"읽어보실 수 있습니다."
+"Many of the above restrictions are tested automatically by an extension scanner that will flag suspicious add-ons for editor review. You can read more about this scanner in the <a "
+"href=\"%(link_validation)s\">Validation Help</a> document."
+msgstr "위에 소개된 제한 사항의 대부분은 확장 기능 스캐너에 의해 자동으로 검사되므로 편집자 심사를 받을 땐 문제 부가 기능으로 표시가 될 것입니다. 스캐너에 관한 사항은 <a href=\"%(link_validation)s\">검사기 도움말</a>에 보다 자세한 내용을 읽어보실 수 있습니다."
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:129
 msgid ""
-"If the add-on is site-specific, it is recommended that a test account is "
-"provided for use during the review process. Additionally, including detailed"
-" testing instructions will allow an editor to better understand how the add-"
-"on functions and expedite the testing process. This information can be "
-"placed in the Notes to Reviewer field when editing a version in the "
-"Developer Hub."
-msgstr ""
-"특정 사이트에 특화된 부가 기능의 경우 심사 과정에서 이용 가능한 테스트 계정을 제공하는 것이 좋습니다. 추가로 테스트 방침에 관한 것도"
-" 적어놓는다면 편집자가 부가 기능이 작동되는 원리를 보다 잘 이해하고 테스트를 빠르게 마칠 수 있을겁니다. 이러한 정보는 개발자 허브에서"
-" 버전 편집시 심사원에게 남기는 메모란에 기입하시면 됩니다."
+"If the add-on is site-specific, it is recommended that a test account is provided for use during the review process. Additionally, including detailed testing instructions will allow an editor to "
+"better understand how the add-on functions and expedite the testing process. This information can be placed in the Notes to Reviewer field when editing a version in the Developer Hub."
+msgstr "특정 사이트에 특화된 부가 기능의 경우 심사 과정에서 이용 가능한 테스트 계정을 제공하는 것이 좋습니다. 추가로 테스트 방침에 관한 것도 적어놓는다면 편집자가 부가 기능이 작동되는 원리를 보다 잘 이해하고 테스트를 빠르게 마칠 수 있을겁니다. 이러한 정보는 개발자 허브에서 버전 편집시 심사원에게 남기는 메모란에 기입하시면 됩니다."
 
-#: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:134
-#: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:168
+#: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:134 src/olympia/devhub/templates/devhub/docs/policies-reviews.html:168
 msgid "After the Review"
 msgstr "심사 이후"
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:136
 msgid ""
-"Once an add-on is granted full review, it will immediately be available in "
-"the gallery, showing in browse and search results with a warning-free "
-"install button. All features, including voluntary contributions and beta "
-"channels will be available."
-msgstr ""
-"부가 기능이 전체 심사를 통과하고 나면 즉시 갤러리 상에 등재되어 찾아볼 수 있으며 경고문이 없는 설치 버튼도 부여됩니다. 기부 제도 및"
-" 베타 채널 등의 모든 기능도 이용이 가능하게 됩니다."
+"Once an add-on is granted full review, it will immediately be available in the gallery, showing in browse and search results with a warning-free install button. All features, including voluntary "
+"contributions and beta channels will be available."
+msgstr "부가 기능이 전체 심사를 통과하고 나면 즉시 갤러리 상에 등재되어 찾아볼 수 있으며 경고문이 없는 설치 버튼도 부여됩니다. 기부 제도 및 베타 채널 등의 모든 기능도 이용이 가능하게 됩니다."
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:142
 msgid ""
-"Subsequent versions of the add-on will automatically be placed in the full "
-"review queue. Until the review is completed, the new version will only be "
-"displayed on the Version History page of the add-on. Once reviewed, the "
-"version will be updated across the site and deployed through the automatic "
-"update service."
-msgstr ""
-"해당 부가 기능의 차기 버전은 자동으로 전체 심사 대기열에 올라가게 됩니다. 심사가 끝나기 전까지 새 버전은 부가 기능의 버전 내역 "
-"페이지에만 노출됩니다. 심사가 끝나면 새 버전은 사이트 상에 전체적인 업데이트가 되고 자동 업데이트 서비스를 통해 사용자에게 제공될 "
-"것입니다."
+"Subsequent versions of the add-on will automatically be placed in the full review queue. Until the review is completed, the new version will only be displayed on the Version History page of the "
+"add-on. Once reviewed, the version will be updated across the site and deployed through the automatic update service."
+msgstr "해당 부가 기능의 차기 버전은 자동으로 전체 심사 대기열에 올라가게 됩니다. 심사가 끝나기 전까지 새 버전은 부가 기능의 버전 내역 페이지에만 노출됩니다. 심사가 끝나면 새 버전은 사이트 상에 전체적인 업데이트가 되고 자동 업데이트 서비스를 통해 사용자에게 제공될 것입니다."
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:148
 msgid ""
-"If a version does not meet the criteria for full review, it can either be "
-"granted preliminary review or disabled if there is a security concern. The "
-"author will receive an email explaining the action taken and how to fix it. "
-"In most cases, the developer can simply fix the problem and re-submit for "
-"full review."
-msgstr ""
-"전체 심사 기준에 적합하지 않은 버전이 있을 경우 예비 심사를 받거나 보안 문제가 있을시 사용을 정지하는 것 중 한가지를 할 수 "
-"있습니다. 제작자는 어떤 조치가 있었는지와 어떻게 수정했는지를 설명하는 이메일을 받아보게 됩니다. 대부분의 경우 개발자가 문제를 수정 후"
-" 전체 심사를 다시 신청하는 쪽으로 해결합니다."
+"If a version does not meet the criteria for full review, it can either be granted preliminary review or disabled if there is a security concern. The author will receive an email explaining the "
+"action taken and how to fix it. In most cases, the developer can simply fix the problem and re-submit for full review."
+msgstr "전체 심사 기준에 적합하지 않은 버전이 있을 경우 예비 심사를 받거나 보안 문제가 있을시 사용을 정지하는 것 중 한가지를 할 수 있습니다. 제작자는 어떤 조치가 있었는지와 어떻게 수정했는지를 설명하는 이메일을 받아보게 됩니다. 대부분의 경우 개발자가 문제를 수정 후 전체 심사를 다시 신청하는 쪽으로 해결합니다."
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:155
 msgid ""
-"Preliminary reviews are appropriate for experimental add-ons and provide a "
-"way to get user testing and feedback without going through the longer, more "
-"thorough review process. We aim to complete these reviews in under 3 days."
-msgstr ""
-"예비 심사는 시험용 부가 기능에 적합하며 심사를 더 오래 받지 않고도 사용자의 테스트와 피드백을 받을 수 있게됩니다. 이 심사는 3일 "
-"안에 끝내는게 저희 방침입니다."
+"Preliminary reviews are appropriate for experimental add-ons and provide a way to get user testing and feedback without going through the longer, more thorough review process. We aim to complete "
+"these reviews in under 3 days."
+msgstr "예비 심사는 시험용 부가 기능에 적합하며 심사를 더 오래 받지 않고도 사용자의 테스트와 피드백을 받을 수 있게됩니다. 이 심사는 3일 안에 끝내는게 저희 방침입니다."
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:160
 msgid "Testing Methods"
@@ -6989,48 +5683,28 @@ msgstr "테스트 방법"
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:162
 msgid ""
-"When performing a preliminary review, editors will review the source code "
-"for security issues and major policy violations, but will not install the "
-"add-on to test functionality in most cases. Preliminary review will be "
-"granted unless a security vulnerability or major policy violation is "
-"discovered."
-msgstr ""
-"예비 심사시 편집자는 보안 문제가 있는지 치명적인 정책 위반 사항은 없는지 등을 소스 코드를 보고 심사는 하지만 기능 작동 여부를 "
-"테스트하기 위해 설치는 웬만하면 하지 않을 것입니다. 보안상 취약점 내지는 치명적인 정책 위반 사항이 발견되지 않는 한 예비 심사는 "
-"통과됩니다."
+"When performing a preliminary review, editors will review the source code for security issues and major policy violations, but will not install the add-on to test functionality in most cases. "
+"Preliminary review will be granted unless a security vulnerability or major policy violation is discovered."
+msgstr "예비 심사시 편집자는 보안 문제가 있는지 치명적인 정책 위반 사항은 없는지 등을 소스 코드를 보고 심사는 하지만 기능 작동 여부를 테스트하기 위해 설치는 웬만하면 하지 않을 것입니다. 보안상 취약점 내지는 치명적인 정책 위반 사항이 발견되지 않는 한 예비 심사는 통과됩니다."
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:171
 msgid ""
-"Once preliminary review is granted, the add-on will be immediately available"
-" in the gallery, showing in browse and search results but ranked lower than "
-"fully-reviewed add-ons. Install buttons will have caution stripes and a "
-"notice that the add-on is experimental and not fully reviewed by Mozilla, "
-"though no click-through is required. Additionally, these add-ons cannot use "
-"the voluntary contributions and beta channel features."
+"Once preliminary review is granted, the add-on will be immediately available in the gallery, showing in browse and search results but ranked lower than fully-reviewed add-ons. Install buttons will "
+"have caution stripes and a notice that the add-on is experimental and not fully reviewed by Mozilla, though no click-through is required. Additionally, these add-ons cannot use the voluntary "
+"contributions and beta channel features."
 msgstr ""
-"예비 심사가 통과되면 부가 기능은 갤러리 상에서 바로 사용이 가능하지만 전체 심사를 통과한 부가 기능보다 하위 등급으로 노출됩니다. 설치"
-" 버튼엔 주의를 의미하는 줄무늬가 그려지며 클릭하지 않더라도 해당 부가 기능은 시험용이고 Mozilla의 전체 심사를 거치지 않았다는 "
-"문구가 표시됩니다. 추가로 이러한 부가 기능엔 기부 제도나 베타 채널 기능을 사용할 수 없습니다."
+"예비 심사가 통과되면 부가 기능은 갤러리 상에서 바로 사용이 가능하지만 전체 심사를 통과한 부가 기능보다 하위 등급으로 노출됩니다. 설치 버튼엔 주의를 의미하는 줄무늬가 그려지며 클릭하지 않더라도 해당 부가 기능은 시험용이고 Mozilla의 전체 심사를 거치지 않았다는 문구가 표시됩니다. 추가로 이러한 부가 기능엔 기부 제도나 베타 채널 기능을 사용할"
+" 수 없습니다."
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:177
-msgid ""
-"After being granted preliminary review, Mozilla may later revoke the review "
-"if other serious problems are reported to us by users."
-msgstr ""
-"예비 심사를 통과한 뒤에도 사용자가 다른 심각한 문제가 있다고 제보해 올 경우 Mozilla에선 해당 부가 기능의 심사 통과 상태를 "
-"박탈할 수도 있습니다."
+msgid "After being granted preliminary review, Mozilla may later revoke the review if other serious problems are reported to us by users."
+msgstr "예비 심사를 통과한 뒤에도 사용자가 다른 심각한 문제가 있다고 제보해 올 경우 Mozilla에선 해당 부가 기능의 심사 통과 상태를 박탈할 수도 있습니다."
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:183
 msgid ""
-"Subsequent versions of the add-on will automatically be placed in the "
-"preliminary review queue. Until the review is completed, the new version "
-"will only be displayed on the Version History page of the add-on. Once "
-"reviewed, the version will be updated across the site and deployed through "
-"the automatic update service."
-msgstr ""
-"해당 부가 기능의 차기 버전은 자동으로 예비 심사 대기열에 올라가게 됩니다. 심사가 끝나기 전까지 새 버전은 부가 기능의 버전 내역 "
-"페이지에만 노출됩니다. 심사가 끝나면 새 버전은 사이트 상에 전체적인 업데이트가 되고 자동 업데이트 서비스를 통해 사용자에게 제공될 "
-"것입니다."
+"Subsequent versions of the add-on will automatically be placed in the preliminary review queue. Until the review is completed, the new version will only be displayed on the Version History page of "
+"the add-on. Once reviewed, the version will be updated across the site and deployed through the automatic update service."
+msgstr "해당 부가 기능의 차기 버전은 자동으로 예비 심사 대기열에 올라가게 됩니다. 심사가 끝나기 전까지 새 버전은 부가 기능의 버전 내역 페이지에만 노출됩니다. 심사가 끝나면 새 버전은 사이트 상에 전체적인 업데이트가 되고 자동 업데이트 서비스를 통해 사용자에게 제공될 것입니다."
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:188
 msgid "Policies on Specific Add-on Practices"
@@ -7045,46 +5719,29 @@ msgid "The following add-ons are not permitted in any form:"
 msgstr "다음 부가 기능은 어떤 형태로든 허용되지 않습니다:"
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:194
-msgid ""
-"Add-ons that embed known <a "
-"href=\"http://en.wikipedia.org/wiki/Spyware\">spyware</a> or <a "
-"href=\"http://en.wikipedia.org/wiki/Malware\">malware</a>"
-msgstr ""
-"<a href=\"http://en.wikipedia.org/wiki/Spyware\">스파이웨어</a>나 <a "
-"href=\"http://en.wikipedia.org/wiki/Malware\">맬웨어</a>로 알려진 기능이 내장된 부가 기능"
+msgid "Add-ons that embed known <a href=\"http://en.wikipedia.org/wiki/Spyware\">spyware</a> or <a href=\"http://en.wikipedia.org/wiki/Malware\">malware</a>"
+msgstr "<a href=\"http://en.wikipedia.org/wiki/Spyware\">스파이웨어</a>나 <a href=\"http://en.wikipedia.org/wiki/Malware\">맬웨어</a>로 알려진 기능이 내장된 부가 기능"
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:199
 msgid ""
-"Illegal and criminal add-ons, such as <a "
-"href=\"http://en.wikipedia.org/wiki/Click_fraud\">click fraud</a> "
-"generators, <a href=\"http://en.wikipedia.org/wiki/Warez\">warez</a> "
-"download and directory assistants, child pornography finders, etc."
-msgstr ""
-"<a href=\"http://en.wikipedia.org/wiki/Click_fraud\">클릭 사기</a> 생성기, <a "
-"href=\"http://en.wikipedia.org/wiki/Warez\">와레즈</a> 다운로드 및 사이트 안내, 아동 포르노 "
-"검색기 등과 같은 불법 부가 기능"
+"Illegal and criminal add-ons, such as <a href=\"http://en.wikipedia.org/wiki/Click_fraud\">click fraud</a> generators, <a href=\"http://en.wikipedia.org/wiki/Warez\">warez</a> download and "
+"directory assistants, child pornography finders, etc."
+msgstr "<a href=\"http://en.wikipedia.org/wiki/Click_fraud\">클릭 사기</a> 생성기, <a href=\"http://en.wikipedia.org/wiki/Warez\">와레즈</a> 다운로드 및 사이트 안내, 아동 포르노 검색기 등과 같은 불법 부가 기능"
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:204
-msgid ""
-"Add-ons whose main purpose is to facilitate access to pornographic material,"
-" or include references to this material in their descriptions"
+msgid "Add-ons whose main purpose is to facilitate access to pornographic material, or include references to this material in their descriptions"
 msgstr "주 목적이 포르노 자료 검색이거나 설명에 이러한 자료에 관한 내용이 언급되어 있는 부가 기능"
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:210
-msgid ""
-"Add-ons that, upon installation, auto-install or launch installers of non-"
-"Firefox software"
+msgid "Add-ons that, upon installation, auto-install or launch installers of non-Firefox software"
 msgstr "설치시 Firefox용이 아닌 소프트웨어를 자동으로 설치하거나 설치 프로그램이 실행되는 부가 기능"
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:215
-msgid ""
-"Add-ons that provide their own update mechanism for code or search engines"
+msgid "Add-ons that provide their own update mechanism for code or search engines"
 msgstr "자체 업데이트 메커니즘을 통해 코드나 검색 엔진을 제공하는 부가 기능"
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:220
-msgid ""
-"Add-ons that make changes to web content in ways that are non-obvious or "
-"difficult to trace by their users"
+msgid "Add-ons that make changes to web content in ways that are non-obvious or difficult to trace by their users"
 msgstr "모호한 방법을 통하거나 사용자의 추적이 어려운 방법을 통해 웹 컨텐트를 수정하는 부가 기능"
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:225
@@ -7101,58 +5758,31 @@ msgstr "기본값을 변경하고 사전 설명이 되어있지 않은 기능"
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:238
 msgid ""
-"Surprises can be appropriate in many situations, but they are not welcome "
-"when user security, privacy, and control are at stake. It is extremely "
-"important to be as transparent as possible when submitting an add-on for "
-"hosting on this site. A Mozilla user should be able to easily discern what "
-"the functionality of an add-on is and not be presented with unexpected "
-"experiences post-install."
+"Surprises can be appropriate in many situations, but they are not welcome when user security, privacy, and control are at stake. It is extremely important to be as transparent as possible when "
+"submitting an add-on for hosting on this site. A Mozilla user should be able to easily discern what the functionality of an add-on is and not be presented with unexpected experiences post-install."
 msgstr ""
-"때로는 깜짝 놀라게 만드는 것이 좋은 반응을 얻기도 하지만 사용자 보안, 개인 정보, 제어 등이 필요한 상황에선 그다지 환영받지 "
-"못합니다. 저희 사이트 상의 호스팅을 위해 부가 기능을 제출하게 될 경우 가능한 이러한 부분은 극단적으로 투명해지는 것이 중요합니다. "
-"Mozilla 사용자들이 부가 기능에 어떤 기능이 있는지 쉽게 알아볼 수 있어야 하며 설치 후 예기치 않은 사용자 경험도 발생해선 "
-"안됩니다."
+"때로는 깜짝 놀라게 만드는 것이 좋은 반응을 얻기도 하지만 사용자 보안, 개인 정보, 제어 등이 필요한 상황에선 그다지 환영받지 못합니다. 저희 사이트 상의 호스팅을 위해 부가 기능을 제출하게 될 경우 가능한 이러한 부분은 극단적으로 투명해지는 것이 중요합니다. Mozilla 사용자들이 부가 기능에 어떤 기능이 있는지 쉽게 알아볼 수 있어야 하며 설치"
+" 후 예기치 않은 사용자 경험도 발생해선 안됩니다."
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:243
 msgid ""
-"<p> Whenever an add-on includes any unexpected* feature that </p> <ul> "
-"<li>compromises user privacy or security (like sending data to third "
-"parties),</li> <li>changes default settings like the homepage or search "
-"engine, or</li> <li>changes settings or features in other add-ons or "
-"deactivates them altogether</li> </ul> <p>the features must adhere to the "
-"following requirements:</p> <ul> <li>The add-on description must clearly "
-"state what changes the add-on makes.</li> <li>All changes must be opt-in, "
-"meaning the user must take non-default action to enact the change.</li> "
-"<li>The opt-in dialog must clearly state the name of the add-on requesting "
-"the change.</li> <li>Uninstalling the add-on restores the user's original "
-"settings if they were changed.</li> </ul> <p>*Unexpected features are those "
-"that are unrelated to the add-on's primary function.</p>"
+"<p> Whenever an add-on includes any unexpected* feature that </p> <ul> <li>compromises user privacy or security (like sending data to third parties),</li> <li>changes default settings like the "
+"homepage or search engine, or</li> <li>changes settings or features in other add-ons or deactivates them altogether</li> </ul> <p>the features must adhere to the following requirements:</p> <ul> "
+"<li>The add-on description must clearly state what changes the add-on makes.</li> <li>All changes must be opt-in, meaning the user must take non-default action to enact the change.</li> <li>The "
+"opt-in dialog must clearly state the name of the add-on requesting the change.</li> <li>Uninstalling the add-on restores the user's original settings if they were changed.</li> </ul> <p>*Unexpected"
+" features are those that are unrelated to the add-on's primary function.</p>"
 msgstr ""
-"<p> 부가 기능이 사전에 고려하지 않은* 기능을 포함하고 있을시, 즉 </p> <ul> <li>사용자 개인정보나 보안에 대한 타협 "
-"(서드파티에 데이터 전송과 같은),</li> <li>홈페이지나 검색 엔진과 같은 기본 설정 변경, 또는</li> <li>다른 부가 기능의"
-" 설정 및 기능을 변경하거나 완전한 무력화</li> </ul> <p>기능은 다음 요구 사항에 반드시 부합해야 합니다:</p> <ul> "
-"<li>부가 기능이 어떤 사항을 변경하는지 명확하게 설명에 명시되어 있어야 합니다.</li> <li>모든 변경 사항은 기본 외 작업을 "
-"통한 변경을 사용자가 경험하게 된다는 것을 의미한다는 사실에 대한 사전 동의가 반드시 필요합니다.</li> <li>사전 동의를 묻는 "
-"대화창은 특정 부가 기능의 이름이 변경을 요청하고 있다는 사실을 명확하게 명시하고 있어야 합니다.</li> <li>부가 기능 삭제시 "
-"그동안 변경한 사용자의 기본 설정이 복구되야 합니다.</li> </ul> <p>*사전에 고려하지 않은 기능이란 부가 기능의 주요 기능과 "
-"관련이 없는 기능을 의미합니다.</p>"
+"<p> 부가 기능이 사전에 고려하지 않은* 기능을 포함하고 있을시, 즉 </p> <ul> <li>사용자 개인정보나 보안에 대한 타협 (서드파티에 데이터 전송과 같은),</li> <li>홈페이지나 검색 엔진과 같은 기본 설정 변경, 또는</li> <li>다른 부가 기능의 설정 및 기능을 변경하거나 완전한 무력화</li> </ul> <p>기능은 다음 요구"
+" 사항에 반드시 부합해야 합니다:</p> <ul> <li>부가 기능이 어떤 사항을 변경하는지 명확하게 설명에 명시되어 있어야 합니다.</li> <li>모든 변경 사항은 기본 외 작업을 통한 변경을 사용자가 경험하게 된다는 것을 의미한다는 사실에 대한 사전 동의가 반드시 필요합니다.</li> <li>사전 동의를 묻는 대화창은 특정 부가 기능의 이름이 "
+"변경을 요청하고 있다는 사실을 명확하게 명시하고 있어야 합니다.</li> <li>부가 기능 삭제시 그동안 변경한 사용자의 기본 설정이 복구되야 합니다.</li> </ul> <p>*사전에 고려하지 않은 기능이란 부가 기능의 주요 기능과 관련이 없는 기능을 의미합니다.</p>"
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:268
-msgid ""
-"These features cannot be introduced into an update of a fully-reviewed add-"
-"on; the opt-in change process must be part of the initial review."
-msgstr ""
-"이러한 기능들은 전체 심사를 거친 부가 기능의 업데이트시 따로 안내할 수 없습니다; 변경점 사전 동의 절차는 초기 심사의 한 과정으로만 "
-"넣어야 합니다."
+msgid "These features cannot be introduced into an update of a fully-reviewed add-on; the opt-in change process must be part of the initial review."
+msgstr "이러한 기능들은 전체 심사를 거친 부가 기능의 업데이트시 따로 안내할 수 없습니다; 변경점 사전 동의 절차는 초기 심사의 한 과정으로만 넣어야 합니다."
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:274
-msgid ""
-"These are minimum requirements and not a guarantee that the add-on will be "
-"approved. This section applies to all add-ons hosted on the site, including "
-"preliminarily reviewed add-ons."
-msgstr ""
-"이러한 최소 요구 사항은 부가 기능이 승인되기 위한 절대적인 규정은 될 수 없습니다. 본 항목의 내용은 예비 심사를 통과한 부가 기능을 "
-"포함한 본 사이트 상에 호스팅되고 있는 모든 부가 기능에 적용됩니다."
+msgid "These are minimum requirements and not a guarantee that the add-on will be approved. This section applies to all add-ons hosted on the site, including preliminarily reviewed add-ons."
+msgstr "이러한 최소 요구 사항은 부가 기능이 승인되기 위한 절대적인 규정은 될 수 없습니다. 본 항목의 내용은 예비 심사를 통과한 부가 기능을 포함한 본 사이트 상에 호스팅되고 있는 모든 부가 기능에 적용됩니다."
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:279
 msgid "Private Browsing Mode"
@@ -7160,16 +5790,11 @@ msgstr "비공개 브라우징 모드"
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:282
 msgid ""
-"Add-ons that store or otherwise handle browsing data must support <a "
-"href=\"https://developer.mozilla.org/En/Supporting_private_browsing_mode\">Private"
-" Browsing Mode</a>. During a Private Browsing session, no browsing data can "
-"be written to disk, and all of this data must be cleared when Firefox quits "
-"or the Private Browsing session ends."
+"Add-ons that store or otherwise handle browsing data must support <a href=\"https://developer.mozilla.org/En/Supporting_private_browsing_mode\">Private Browsing Mode</a>. During a Private Browsing "
+"session, no browsing data can be written to disk, and all of this data must be cleared when Firefox quits or the Private Browsing session ends."
 msgstr ""
-"자료를 수집하거나 읽어들이는 부가 기능은 반드시 <a "
-"href=\"https://developer.mozilla.org/En/Supporting_private_browsing_mode\">비공개"
-" 브라우징 모드</a>를 지원해야 합니다. 비공개 브라우징 세션 도중엔 읽어들인 데이터를 디스크에 저장할 수 없으며 모든 데이터는 "
-"Firefox 종료 내지는 비공개 브라우징 세션이 종료시 삭제됩니다."
+"자료를 수집하거나 읽어들이는 부가 기능은 반드시 <a href=\"https://developer.mozilla.org/En/Supporting_private_browsing_mode\">비공개 브라우징 모드</a>를 지원해야 합니다. 비공개 브라우징 세션 도중엔 읽어들인 데이터를 디스크에 저장할 수 없으며 모든 데이터는 Firefox 종료 내지는 "
+"비공개 브라우징 세션이 종료시 삭제됩니다."
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:287
 msgid "Binary Components & Obfuscated Code"
@@ -7177,36 +5802,20 @@ msgstr "이진 콤포넌트와 변조된 코드"
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:289
 msgid ""
-"Add-ons may contain binary, obfuscated and minified source code, but Mozilla"
-" must be allowed to review a copy of the human-readable source code of each "
-"version of an add-on submitted for review. These add-ons are ineligible for "
-"preliminary review and must choose the full review process."
-msgstr ""
-"부가 기능에 이진, 변조되었거나 축약된 소스 코드가 포함되었지만 심사에 제출된 부가 기능의 각 버전별로 사람이 읽을 수 있는 소스 코드가"
-" 제출될 경우 Mozilla에선 심사를 허용합니다. 단, 이러한 부가 기능은 예비 심사를 받기엔 적합하지 않으므로 전체 심사 과정만 "
-"선택할 수 있습니다."
+"Add-ons may contain binary, obfuscated and minified source code, but Mozilla must be allowed to review a copy of the human-readable source code of each version of an add-on submitted for review. "
+"These add-ons are ineligible for preliminary review and must choose the full review process."
+msgstr "부가 기능에 이진, 변조되었거나 축약된 소스 코드가 포함되었지만 심사에 제출된 부가 기능의 각 버전별로 사람이 읽을 수 있는 소스 코드가 제출될 경우 Mozilla에선 심사를 허용합니다. 단, 이러한 부가 기능은 예비 심사를 받기엔 적합하지 않으므로 전체 심사 과정만 선택할 수 있습니다."
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:295
 msgid ""
-"If an add-on contains binary or obfuscated source code, the author will "
-"receive a message when the add-on is reviewed indicating whom to contact at "
-"Mozilla to coordinate review of the source code. This code will be reviewed "
-"by an administrator and will not be shared or redistributed in any way. The "
-"code will only be used for the purpose of reviewing the add-on."
-msgstr ""
-"부가 기능에 이진 코드나 변조된 코드가 포함되어 있을 경우 제작자는 부가 기능 심사시 조직화된 소스 코드 심사를 위해 Mozilla와 "
-"연락을 취할 사람을 알려달라는 메시지를 받아보게 됩니다. 해당 소스 코드는 관리자의 심사를 받게 되며 공유나 재배포는 어떤 식으로든 할 "
-"수 없습니다. 소스 코드는 부가 기능 심사를 위한 목적으로만 이용됩니다."
+"If an add-on contains binary or obfuscated source code, the author will receive a message when the add-on is reviewed indicating whom to contact at Mozilla to coordinate review of the source code. "
+"This code will be reviewed by an administrator and will not be shared or redistributed in any way. The code will only be used for the purpose of reviewing the add-on."
+msgstr "부가 기능에 이진 코드나 변조된 코드가 포함되어 있을 경우 제작자는 부가 기능 심사시 조직화된 소스 코드 심사를 위해 Mozilla와 연락을 취할 사람을 알려달라는 메시지를 받아보게 됩니다. 해당 소스 코드는 관리자의 심사를 받게 되며 공유나 재배포는 어떤 식으로든 할 수 없습니다. 소스 코드는 부가 기능 심사를 위한 목적으로만 이용됩니다."
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:301
 #, python-format
-msgid ""
-"If your add-on contains binary or obfuscated code that you don't own or "
-"can't get the source code for, you may <a href=\"%(link_contact)s\">contact "
-"us</a> for information on how to proceed."
-msgstr ""
-"부가 기능에 이진 코드나 변조된 코드가 포함되어 있을 경우 소스 코드를 소유하거나 유용할 수 없으며 진행 방법에 관한 정보를 알려면 <a"
-" href=\"%(link_contact)s\">저희와 연락</a>을 취해야 할 것입니다."
+msgid "If your add-on contains binary or obfuscated code that you don't own or can't get the source code for, you may <a href=\"%(link_contact)s\">contact us</a> for information on how to proceed."
+msgstr "부가 기능에 이진 코드나 변조된 코드가 포함되어 있을 경우 소스 코드를 소유하거나 유용할 수 없으며 진행 방법에 관한 정보를 알려면 <a href=\"%(link_contact)s\">저희와 연락</a>을 취해야 할 것입니다."
 
 #: src/olympia/devhub/templates/devhub/docs/policies-submission.html:11
 msgid "Criteria for Submission"
@@ -7214,185 +5823,109 @@ msgstr "부가 기능 제출 규범"
 
 #: src/olympia/devhub/templates/devhub/docs/policies-submission.html:13
 msgid ""
-"Add-ons hosted on Mozilla Add-ons should be of high quality and give users "
-"an improved web experience. We look for the following things when deciding "
-"whether an add-on is appropriate to be public and unrestricted:"
-msgstr ""
-"Mozilla 부가 기능에 호스팅되고 있는 부가 기능은 뛰어난 품질이어야 하며 사용자에게 향상된 웹 서핑 경험을 제공할 수 있어야 "
-"합니다. 저희는 부가 기능을 어떻게 공개하고 제한을 해제해야 할 지를 결정할 때 아래의 규범을 따르고 있습니다:"
+"Add-ons hosted on Mozilla Add-ons should be of high quality and give users an improved web experience. We look for the following things when deciding whether an add-on is appropriate to be public "
+"and unrestricted:"
+msgstr "Mozilla 부가 기능에 호스팅되고 있는 부가 기능은 뛰어난 품질이어야 하며 사용자에게 향상된 웹 서핑 경험을 제공할 수 있어야 합니다. 저희는 부가 기능을 어떻게 공개하고 제한을 해제해야 할 지를 결정할 때 아래의 규범을 따르고 있습니다:"
 
 #: src/olympia/devhub/templates/devhub/docs/policies-submission.html:19
 msgid ""
-"<strong>Are you responsive?</strong> We expect that an author who is "
-"promoting their add-on to our applications' many users is responsive to "
-"problem reports, maintains their contact information, and updates their add-"
-"on promptly to keep current with Firefox releases and changes in our "
-"policies. This doesn't mean that you have to reply to every question that "
-"someone posts in the discussions, or that you even need to fix every bug, "
-"but we do expect that you will respond to issues in a manner that's "
-"appropriate to the severity of the issue in question."
+"<strong>Are you responsive?</strong> We expect that an author who is promoting their add-on to our applications' many users is responsive to problem reports, maintains their contact information, "
+"and updates their add-on promptly to keep current with Firefox releases and changes in our policies. This doesn't mean that you have to reply to every question that someone posts in the "
+"discussions, or that you even need to fix every bug, but we do expect that you will respond to issues in a manner that's appropriate to the severity of the issue in question."
 msgstr ""
-"<strong>활동적입니까?</strong> 저희 정책에선 애플리케이션 이용자에게 적극적으로 부가 기능을 장려하는 제작자는 문제 보고서,"
-" 꾸준한 연락처 정보 관리, Firefox 출시와 변경사항에 대한 빠르고 꾸준한 부가 기능 업데이트에도 활동적이라고 보고 있습니다. 이는"
-" 토론실에 올라온 모든 질문에 대답해야 한다든지 모든 버그를 고쳐야 한다는 뜻은 더더욱 아닙니다. 다만, 질문 중에서 심각한 수준의 "
-"문제에 대해선 어느 정도는 직접 반응을 보여줬으면 합니다."
+"<strong>활동적입니까?</strong> 저희 정책에선 애플리케이션 이용자에게 적극적으로 부가 기능을 장려하는 제작자는 문제 보고서, 꾸준한 연락처 정보 관리, Firefox 출시와 변경사항에 대한 빠르고 꾸준한 부가 기능 업데이트에도 활동적이라고 보고 있습니다. 이는 토론실에 올라온 모든 질문에 대답해야 한다든지 모든 버그를 고쳐야 한다는 뜻은 "
+"더더욱 아닙니다. 다만, 질문 중에서 심각한 수준의 문제에 대해선 어느 정도는 직접 반응을 보여줬으면 합니다."
 
 #: src/olympia/devhub/templates/devhub/docs/policies-submission.html:25
 msgid ""
-"<strong>Is the add-on clearly and accurately described?</strong> It's of the"
-" utmost importance to us that users get what they expect when they try a new"
-" add-on. Your add-on name should be clear and concise, and you should "
-"refrain from using special characters or numbers to get higher search "
-"rankings or for decorative purposes. Your description should provide details"
-" about what the add-on does, how a user should take advantage of it, and "
-"what the user should expect when they install it. Links to external "
-"documents for detailed instructions are fine, but the description itself "
-"should cover the basics and leave users confident that they know what "
-"they'll get. Also, it is important that you maintain version notes "
-"appropriately as you improve and change your add-on. Users should be able to"
-" see what's new in an add-on they may have tried previously, and should be "
-"made aware of changes that might affect their current use of the add-on when"
-" they update."
+"<strong>Is the add-on clearly and accurately described?</strong> It's of the utmost importance to us that users get what they expect when they try a new add-on. Your add-on name should be clear and"
+" concise, and you should refrain from using special characters or numbers to get higher search rankings or for decorative purposes. Your description should provide details about what the add-on "
+"does, how a user should take advantage of it, and what the user should expect when they install it. Links to external documents for detailed instructions are fine, but the description itself should"
+" cover the basics and leave users confident that they know what they'll get. Also, it is important that you maintain version notes appropriately as you improve and change your add-on. Users should "
+"be able to see what's new in an add-on they may have tried previously, and should be made aware of changes that might affect their current use of the add-on when they update."
 msgstr ""
-"<strong>부가 기능에 대해 명확하게 기술하고 있습니까?</strong> 사용자가 새 부가 기능을 설치할 때 어떤 생각을 하게 "
-"되는가는 저희에게 있어 가장 중요한 부분입니다. 당신의 설명은 부가 기능이 무엇을 하고, 사용자에겐 어떤 혜택이 주어지며, 설치하면 어떤"
-" 것이 일어날 것인가에 대한 자세한 사항을 제공해야 합니다. 자세한 소개를 위해 외부 문서로 링크하는 것도 좋습니다. 하지만, 자체적인 "
-"설명은 기본적이며 사용자가 어떤 기능을 갖게 될 지 확신을 줄 수 있어야 합니다. 부가 기능을 업그레이드하고 변경한 사항은 버전 노트에 "
-"적절히 기입하는것도 중요합니다. 사용자가 사용하고 있던 부가 기능에 어떤 새 기능이 추가되었는지 볼 수 있어야 하며, 업데이트시 현재 "
-"사용중인 부가 기능에 작용될 변경점에 대해 알 수 있어야 합니다."
+"<strong>부가 기능에 대해 명확하게 기술하고 있습니까?</strong> 사용자가 새 부가 기능을 설치할 때 어떤 생각을 하게 되는가는 저희에게 있어 가장 중요한 부분입니다. 당신의 설명은 부가 기능이 무엇을 하고, 사용자에겐 어떤 혜택이 주어지며, 설치하면 어떤 것이 일어날 것인가에 대한 자세한 사항을 제공해야 합니다. 자세한 소개를 위해 외부 "
+"문서로 링크하는 것도 좋습니다. 하지만, 자체적인 설명은 기본적이며 사용자가 어떤 기능을 갖게 될 지 확신을 줄 수 있어야 합니다. 부가 기능을 업그레이드하고 변경한 사항은 버전 노트에 적절히 기입하는것도 중요합니다. 사용자가 사용하고 있던 부가 기능에 어떤 새 기능이 추가되었는지 볼 수 있어야 하며, 업데이트시 현재 사용중인 부가 기능에 작용될 "
+"변경점에 대해 알 수 있어야 합니다."
 
 #: src/olympia/devhub/templates/devhub/docs/policies-submission.html:31
 msgid ""
-"<strong>Are all privacy and security concerns clearly spelled out?</strong> "
-"This is an aspect of a clear and accurate description, but such an important"
-" one that we feel it deserves specific mention. Many very useful and well-"
-"written add-ons manipulate some form of user data, or can present security "
-"hazards if misused; they are welcome on the site, but they must make it very"
-" clear to users what risks they might encounter, and what they can do to "
-"protect themselves."
+"<strong>Are all privacy and security concerns clearly spelled out?</strong> This is an aspect of a clear and accurate description, but such an important one that we feel it deserves specific "
+"mention. Many very useful and well-written add-ons manipulate some form of user data, or can present security hazards if misused; they are welcome on the site, but they must make it very clear to "
+"users what risks they might encounter, and what they can do to protect themselves."
 msgstr ""
-"<strong>개인 정보와 보안 사항이 모두 명확하게 서술되었습니까?</strong> 이 부분은 명확한 서술로 이루어져야 하며 중요한 "
-"것은 충분히 구체적인 설명을 하는지를 느낄 수 있는가입니다. 여러 유용하고 잘 만들어진 부가 기능도 사용자 정보 형태를 조작하거나, 보안"
-" 위험을 야기할 수 있습니다. 이러한 부가 기능은 악용할 경우 사이트의 전면에선 환영받게 되나, 사용자에게 명백히 직접적인 위험이 될 "
-"것이며 이들은 스스로를 변호할 수 있게될 것입니다."
+"<strong>개인 정보와 보안 사항이 모두 명확하게 서술되었습니까?</strong> 이 부분은 명확한 서술로 이루어져야 하며 중요한 것은 충분히 구체적인 설명을 하는지를 느낄 수 있는가입니다. 여러 유용하고 잘 만들어진 부가 기능도 사용자 정보 형태를 조작하거나, 보안 위험을 야기할 수 있습니다. 이러한 부가 기능은 악용할 경우 사이트의 전면에선 "
+"환영받게 되나, 사용자에게 명백히 직접적인 위험이 될 것이며 이들은 스스로를 변호할 수 있게될 것입니다."
 
 #: src/olympia/devhub/templates/devhub/docs/policies-submission.html:37
 msgid ""
-"<strong>Has the add-on been well-tested, and is it free of obvious or "
-"serious defects?</strong> One important thing that we look for when "
-"considering an add-on is whether its user reviews indicate that it has "
-"received thorough testing, and that it doesn't have serious problems or "
-"negative impacts on the browser. If reviewers report problems such as major "
-"performance issues, crashes, frequent problems using the functions of the "
-"add-on, or spamming of messages to the error console, you should take those "
-"reports to heart, and re-submit your add-on after you've addressed them as "
-"best you can. We don't expect you to perfectly optimize or have zero bugs "
-"&mdash; Firefox itself undergoes constant improvement in these areas &mdash;"
-" but we do want you to take reasonable efforts to minimize downsides, and to"
-" clearly call out cases where users may be surprised by those that remain."
+"<strong>Has the add-on been well-tested, and is it free of obvious or serious defects?</strong> One important thing that we look for when considering an add-on is whether its user reviews indicate "
+"that it has received thorough testing, and that it doesn't have serious problems or negative impacts on the browser. If reviewers report problems such as major performance issues, crashes, frequent"
+" problems using the functions of the add-on, or spamming of messages to the error console, you should take those reports to heart, and re-submit your add-on after you've addressed them as best you "
+"can. We don't expect you to perfectly optimize or have zero bugs &mdash; Firefox itself undergoes constant improvement in these areas &mdash; but we do want you to take reasonable efforts to "
+"minimize downsides, and to clearly call out cases where users may be surprised by those that remain."
 msgstr ""
-"<strong>부가 기능이 제대로 검사됐고 치명적인 결점이 확실히 없습니까?</strong> 부가 기능의 공개적 접근 여부를 고려할 때 "
-"가장 중요하게 생각하는 것은 심사 보고서로써 시험용 기간동안 테스팅을 거쳐 웹 브라우저에 심각한 문제나 부정적 충돌 현상이 일어나지 "
-"않았는지 등을 표시하고 있습니다. 심사원이 부가 기능을 사용해보고 높은 수준의 문제점, 충돌, 빈번한 문제 발생 및 오류 콘솔의 메시지 "
-"도배현상 등을 보고했다면 이 보고서를 명심하고 최선을 다해 다시 작업한 후 재심을 요청해야 합니다. 완벽한 최적화나 버그 박멸을 기대하는"
-" 것이 아닙니다 &mdash; Firefox도 이러한 과정속에 꾸준한 발전을 거쳐왔죠 &mdash; 다만 이러한 것들을 최소화하려는 "
-"확실한 노력을 보여주고 그래도 남아있는 문제가 있을시엔 사용자에게 명확하게 사실 여부를 알려주는 걸 저희는 희망하고 있습니다."
+"<strong>부가 기능이 제대로 검사됐고 치명적인 결점이 확실히 없습니까?</strong> 부가 기능의 공개적 접근 여부를 고려할 때 가장 중요하게 생각하는 것은 심사 보고서로써 시험용 기간동안 테스팅을 거쳐 웹 브라우저에 심각한 문제나 부정적 충돌 현상이 일어나지 않았는지 등을 표시하고 있습니다. 심사원이 부가 기능을 사용해보고 높은 수준의 "
+"문제점, 충돌, 빈번한 문제 발생 및 오류 콘솔의 메시지 도배현상 등을 보고했다면 이 보고서를 명심하고 최선을 다해 다시 작업한 후 재심을 요청해야 합니다. 완벽한 최적화나 버그 박멸을 기대하는 것이 아닙니다 &mdash; Firefox도 이러한 과정속에 꾸준한 발전을 거쳐왔죠 &mdash; 다만 이러한 것들을 최소화하려는 확실한 노력을 보여주고 "
+"그래도 남아있는 문제가 있을시엔 사용자에게 명확하게 사실 여부를 알려주는 걸 저희는 희망하고 있습니다."
 
 #: src/olympia/devhub/templates/devhub/docs/policies-submission.html:43
 msgid ""
-"<strong>Do the add-on and add-on author both treat the user "
-"respectfully?</strong> Your software should not intrude on the user "
-"unnecessarily, try to trick the user, or conceal any of its activities from "
-"the user. Users (or even non-users) are sometimes rude in their comments, "
-"and while we will do our best to filter out inaccurate reviews as they're "
-"reported to us, we do expect that authors will avoid retaliating with "
-"rudeness of their own."
+"<strong>Do the add-on and add-on author both treat the user respectfully?</strong> Your software should not intrude on the user unnecessarily, try to trick the user, or conceal any of its "
+"activities from the user. Users (or even non-users) are sometimes rude in their comments, and while we will do our best to filter out inaccurate reviews as they're reported to us, we do expect that"
+" authors will avoid retaliating with rudeness of their own."
 msgstr ""
-"<strong>부가 기능과 제작자 모두 사용자에게서 존중받고 있습니까?</strong> 소프트웨어는 쓸데없이 사용자에게 강요되거나, "
-"속임수를 쓰거나, 활동내역을 숨겨선 안됩니다. 사용자는 (비 사용자라도) 종종 악성 코멘트를 달곤 하는데, 이들이 보고한 것 가운데 "
-"부정확한 평가는 최선을 다해 걸러낼 것입니다. 악성 코멘트에 제작자도 악성 답글로 보복하게 되는 것은 피해야 한다고 생각합니다."
+"<strong>부가 기능과 제작자 모두 사용자에게서 존중받고 있습니까?</strong> 소프트웨어는 쓸데없이 사용자에게 강요되거나, 속임수를 쓰거나, 활동내역을 숨겨선 안됩니다. 사용자는 (비 사용자라도) 종종 악성 코멘트를 달곤 하는데, 이들이 보고한 것 가운데 부정확한 평가는 최선을 다해 걸러낼 것입니다. 악성 코멘트에 제작자도 악성 답글로 "
+"보복하게 되는 것은 피해야 한다고 생각합니다."
 
 #: src/olympia/devhub/templates/devhub/docs/policies-submission.html:49
 msgid ""
-"<strong>Is the add-on useful to an appropriately wide portion of Firefox's "
-"users?</strong> Your add-on doesn't need to be the next Greasemonkey or "
-"Firebug, but if it is only useful to people at your company or who are part "
-"of a small web community, we may feel that it's not yet appropriate to put "
-"it in front of all of our users."
-msgstr ""
-"<strong>유용하며 Firefox 사용자에게 널리 쓰이기에 적합한 부가 기능입니까?</strong> 자신의 부가 기능이 차세대 "
-"Greasemonkey나 Firebug가 될 필요까진 없겠지만 직장이나 소규모 커뮤니티 웹사이트 사람들에게만 유용한 것이라면 저희는 이게"
-" 아직은 모든 사용자 앞에 내보일만한 것이 아니라고 판단하게 될 것입니다."
+"<strong>Is the add-on useful to an appropriately wide portion of Firefox's users?</strong> Your add-on doesn't need to be the next Greasemonkey or Firebug, but if it is only useful to people at "
+"your company or who are part of a small web community, we may feel that it's not yet appropriate to put it in front of all of our users."
+msgstr "<strong>유용하며 Firefox 사용자에게 널리 쓰이기에 적합한 부가 기능입니까?</strong> 자신의 부가 기능이 차세대 Greasemonkey나 Firebug가 될 필요까진 없겠지만 직장이나 소규모 커뮤니티 웹사이트 사람들에게만 유용한 것이라면 저희는 이게 아직은 모든 사용자 앞에 내보일만한 것이 아니라고 판단하게 될 것입니다."
 
 #: src/olympia/devhub/templates/devhub/docs/policies-submission.html:55
 msgid ""
-"We are constantly looking at ways to improve the organization of the site to"
-" better accommodate add-ons that are exemplary in other ways, but are aimed "
-"at only a small community of potential users. Correctly categorizing and "
-"maintaining the metadata of your add-on will help us figure out how we can "
-"surface more of those sorts of add-ons to people who are most likely to "
-"benefit from them."
+"We are constantly looking at ways to improve the organization of the site to better accommodate add-ons that are exemplary in other ways, but are aimed at only a small community of potential users."
+" Correctly categorizing and maintaining the metadata of your add-on will help us figure out how we can surface more of those sorts of add-ons to people who are most likely to benefit from them."
 msgstr ""
-"대표적인 다른 방법으론 더 나은 부가 기능 공급을 위한 사이트 구조 개선책의 꾸준한 모색이 있겠으나, 잠재적 사용자로 이루어진 소규모 "
-"커뮤니티만 관심을 가지고 일을 하고 있는 것이 현실입니다. 자신의 부가 기능의 메타 데이터를 정확히 분류 및 유지 보수하는 것은 부가 "
-"기능의 분류를 어떻게 보다 표면화하여 사람들에게 최대한 이득을 줄 수 있을지를 찾는데 도움이 될 것입니다."
+"대표적인 다른 방법으론 더 나은 부가 기능 공급을 위한 사이트 구조 개선책의 꾸준한 모색이 있겠으나, 잠재적 사용자로 이루어진 소규모 커뮤니티만 관심을 가지고 일을 하고 있는 것이 현실입니다. 자신의 부가 기능의 메타 데이터를 정확히 분류 및 유지 보수하는 것은 부가 기능의 분류를 어떻게 보다 표면화하여 사람들에게 최대한 이득을 줄 수 있을지를 찾는데"
+" 도움이 될 것입니다."
 
 #: src/olympia/devhub/templates/devhub/docs/policies-submission.html:61
 msgid ""
-"If your add-on just provides bookmarks or other simple access points to your"
-" site, it's probably not appropriate for the gallery. Like the rest of the "
-"Mozilla project, we love web applications and new web services, but Firefox "
-"add-ons should provide an improved browsing experience for the user and not "
-"just be a way to promote a new site or service through a Mozilla Add-ons "
-"listing."
+"If your add-on just provides bookmarks or other simple access points to your site, it's probably not appropriate for the gallery. Like the rest of the Mozilla project, we love web applications and "
+"new web services, but Firefox add-ons should provide an improved browsing experience for the user and not just be a way to promote a new site or service through a Mozilla Add-ons listing."
 msgstr ""
-"부가 기능이 북마크 내지는 그 외에 당신의 사이트에서 간단한 접속 지점만을 제공한다면, 사이트에 공개되기엔 적합하지 않습니다. 저희는 웹"
-" 애플리케이션과 새로운 웹 서비스를 Mozilla 프로젝트만큼이나 사랑합니다. 그러나, Firefox 부가 기능은 사용자에게 향상된 웹 "
-"서핑 경험을 제공해야지 Mozilla 부가 기능 사이트를 통한 새 사이트, 서비스 홍보 수단이 되어선 안됩니다. 부가 기능 설명이 대체로"
-" 사용자의 웹 서핑 향상보다 서비스에 대한 내용으로 이루어져 있다면 당신은 지금 잘못 생각하고 있는겁니다."
+"부가 기능이 북마크 내지는 그 외에 당신의 사이트에서 간단한 접속 지점만을 제공한다면, 사이트에 공개되기엔 적합하지 않습니다. 저희는 웹 애플리케이션과 새로운 웹 서비스를 Mozilla 프로젝트만큼이나 사랑합니다. 그러나, Firefox 부가 기능은 사용자에게 향상된 웹 서핑 경험을 제공해야지 Mozilla 부가 기능 사이트를 통한 새 사이트, 서비스"
+" 홍보 수단이 되어선 안됩니다. 부가 기능 설명이 대체로 사용자의 웹 서핑 향상보다 서비스에 대한 내용으로 이루어져 있다면 당신은 지금 잘못 생각하고 있는겁니다."
 
 #: src/olympia/devhub/templates/devhub/docs/policies-submission.html:67
 msgid ""
-"<strong>Is the add-on free of unlicensed trademarks and copyrights?</strong>"
-" Though you may mean no harm to the holder of a trademark, or the owner of a"
-" copyrighted work, we can't host add-ons that infringe on trademarks or "
-"copyrights. If you don't have permission to use a trademarked name or image,"
-" please do not submit your add-on to us. If your add-on includes code that "
-"is copyrighted by someone else, and is not licensed to you to use in your "
-"add-on, please do not submit your add-on to us."
+"<strong>Is the add-on free of unlicensed trademarks and copyrights?</strong> Though you may mean no harm to the holder of a trademark, or the owner of a copyrighted work, we can't host add-ons that"
+" infringe on trademarks or copyrights. If you don't have permission to use a trademarked name or image, please do not submit your add-on to us. If your add-on includes code that is copyrighted by "
+"someone else, and is not licensed to you to use in your add-on, please do not submit your add-on to us."
 msgstr ""
-"<strong>부가 기능에 허가되지 않은 상표권이나 저작권 문제는 없습니까?</strong> 상표 권리자나 저작권 소유자에게 아무 피해가"
-" 없다는 것을 나타냈더라도, 상표권이나 저작권을 어긴 부가 기능을 호스팅할 순 없습니다. 등록된 이름이나 이미지를 사용할 권리가 없다면,"
-" 부가 기능에 이러한 것을 올리진 말아주십시오. 부가 기능에 다른 사람의 저작권이 있는 코드가 포함되어 있고 부가 기능 사용에 허가를 "
-"받지 않았다면, 부가 기능에 이 코드를 제출하지 말아주십시오."
+"<strong>부가 기능에 허가되지 않은 상표권이나 저작권 문제는 없습니까?</strong> 상표 권리자나 저작권 소유자에게 아무 피해가 없다는 것을 나타냈더라도, 상표권이나 저작권을 어긴 부가 기능을 호스팅할 순 없습니다. 등록된 이름이나 이미지를 사용할 권리가 없다면, 부가 기능에 이러한 것을 올리진 말아주십시오. 부가 기능에 다른 사람의 저작권이"
+" 있는 코드가 포함되어 있고 부가 기능 사용에 허가를 받지 않았다면, 부가 기능에 이 코드를 제출하지 말아주십시오."
 
 #: src/olympia/devhub/templates/devhub/docs/policies-submission.html:73
 msgid ""
-"In terms of reuse of source code from other add-ons, if the author has not "
-"clearly stated that you are permitted to use his or her code in your own "
-"work &mdash; such as by placing it under an open source license &mdash; then"
-" you should assume that you do not have the right to do so. You can contact "
-"the author to seek such permission, but we can't provide you with any "
-"special rights to it just because it's listed on the site, or because the "
-"author isn't responding to your request."
+"In terms of reuse of source code from other add-ons, if the author has not clearly stated that you are permitted to use his or her code in your own work &mdash; such as by placing it under an open "
+"source license &mdash; then you should assume that you do not have the right to do so. You can contact the author to seek such permission, but we can't provide you with any special rights to it "
+"just because it's listed on the site, or because the author isn't responding to your request."
 msgstr ""
-"다른 부가 기능의 소스 코드 재사용에 관해, 제작자가 당신의 저작물에 자신의 코드 사용 허락에 있어 태도가 분명치 않다면 &mdash; "
-"오픈 소스 라이선스 하에 있는 것이라도 &mdash; 그것을 사용할 권리는 없다고 생각해야 합니다. 권리를 찾기 위해 제작자에게 연락을 "
-"취할 수 있지만, 사이트에 명시된 사항이 이미 있고 제작자가 당신의 요구에 응답하지 않을 수도 있으므로 저희는 어떠한 특별 권리도 "
-"당신에게 제공할 수 없습니다."
+"다른 부가 기능의 소스 코드 재사용에 관해, 제작자가 당신의 저작물에 자신의 코드 사용 허락에 있어 태도가 분명치 않다면 &mdash; 오픈 소스 라이선스 하에 있는 것이라도 &mdash; 그것을 사용할 권리는 없다고 생각해야 합니다. 권리를 찾기 위해 제작자에게 연락을 취할 수 있지만, 사이트에 명시된 사항이 이미 있고 제작자가 당신의 요구에 "
+"응답하지 않을 수도 있으므로 저희는 어떠한 특별 권리도 당신에게 제공할 수 없습니다."
 
 #: src/olympia/devhub/templates/devhub/docs/policies-submission.html:79
 msgid ""
-"This applies to the Mozilla Foundation's trademarks as well, including "
-"\"Mozilla\", \"Firefox\", and \"Thunderbird\". The Mozilla policy on "
-"trademark use is designed to protect against confusion, and prevent the "
-"trademarks from being overturned due to lack of protection; please respect "
-"the need for such protection, and help us preserve some of the most valuable"
-" assets of the Mozilla Foundation."
+"This applies to the Mozilla Foundation's trademarks as well, including \"Mozilla\", \"Firefox\", and \"Thunderbird\". The Mozilla policy on trademark use is designed to protect against confusion, "
+"and prevent the trademarks from being overturned due to lack of protection; please respect the need for such protection, and help us preserve some of the most valuable assets of the Mozilla "
+"Foundation."
 msgstr ""
-"\"Mozilla\", \"Firefox\", \"Thunderbird\" 등은 Mozilla 재단의 상표로 등록되어 있습니다. 상표 "
-"사용에 있어 Mozilla의 정책은 혼동 및 보호 장치의 결함으로 인한 상표권 기각을 방지하도록 설계되어 있습니다. 이러한 보호 장치의 "
-"필요성을 존중해주시고 Mozilla 재단의 소중한 자산 보호를 위해 저희를 도와주십시오."
+"\"Mozilla\", \"Firefox\", \"Thunderbird\" 등은 Mozilla 재단의 상표로 등록되어 있습니다. 상표 사용에 있어 Mozilla의 정책은 혼동 및 보호 장치의 결함으로 인한 상표권 기각을 방지하도록 설계되어 있습니다. 이러한 보호 장치의 필요성을 존중해주시고 Mozilla 재단의 소중한 자산 보호를 위해 저희를 "
+"도와주십시오."
 
 #: src/olympia/devhub/templates/devhub/docs/policies-submission.html:84
 msgid "Licensing"
@@ -7400,211 +5933,141 @@ msgstr "라이센싱"
 
 #: src/olympia/devhub/templates/devhub/docs/policies-submission.html:86
 msgid ""
-"Selecting an appropriate license for your add-on is a very important step in"
-" the submission process. A license specifies the rights you grant on your "
-"source code and is important in protecting your intellectual property."
-msgstr ""
-"부가 기능에 적합한 라이선스를 선택하는 것은 제출 과정에서 매우 중요한 단계입니다. 라이선스는 소스 코드에 부여된 권리를 설명하고 있으며"
-" 당신의 지적 재산권 보호에 있어 매우 중요합니다."
+"Selecting an appropriate license for your add-on is a very important step in the submission process. A license specifies the rights you grant on your source code and is important in protecting your"
+" intellectual property."
+msgstr "부가 기능에 적합한 라이선스를 선택하는 것은 제출 과정에서 매우 중요한 단계입니다. 라이선스는 소스 코드에 부여된 권리를 설명하고 있으며 당신의 지적 재산권 보호에 있어 매우 중요합니다."
 
 #: src/olympia/devhub/templates/devhub/docs/policies-submission.html:92
 msgid ""
-"During the add-on submission process, you will be presented with a list of "
-"popular licenses to choose from, as well as the ability to specify your own "
-"license. It is best to consult with a legal professional about which license"
-" option is best for you. Choosing the right license for your source code "
-"will help to prevent confusion and code conflicts in the future."
-msgstr ""
-"부가 기능 제출 과정 도중에, 선택한 라이선스의 인기 목록을 제공받게 될 것이며 거기엔 자신이 고른 라이선스의 기능이 열거되어 있을 "
-"것입니다. 어떤 라이선스 옵션이 자신에게 맞는지는 법률 전문가와 상담하는 것이 가장 좋습니다. 소스 코드의 권리 라이선스 선택은 훗날 "
-"혼동 및 코드 분쟁을 방지하는데 도움이 될 것입니다."
+"During the add-on submission process, you will be presented with a list of popular licenses to choose from, as well as the ability to specify your own license. It is best to consult with a legal "
+"professional about which license option is best for you. Choosing the right license for your source code will help to prevent confusion and code conflicts in the future."
+msgstr "부가 기능 제출 과정 도중에, 선택한 라이선스의 인기 목록을 제공받게 될 것이며 거기엔 자신이 고른 라이선스의 기능이 열거되어 있을 것입니다. 어떤 라이선스 옵션이 자신에게 맞는지는 법률 전문가와 상담하는 것이 가장 좋습니다. 소스 코드의 권리 라이선스 선택은 훗날 혼동 및 코드 분쟁을 방지하는데 도움이 될 것입니다."
 
-#: src/olympia/devhub/templates/devhub/docs/policies.html:12
-#: src/olympia/devhub/templates/devhub/docs/policies.html:52
+#: src/olympia/devhub/templates/devhub/docs/policies.html:12 src/olympia/devhub/templates/devhub/docs/policies.html:52
 msgid "Add-on Submission"
 msgstr "부가 기능 제출"
 
-#: src/olympia/devhub/templates/devhub/docs/policies.html:18
-#: src/olympia/devhub/templates/devhub/docs/policies.html:78
+#: src/olympia/devhub/templates/devhub/docs/policies.html:18 src/olympia/devhub/templates/devhub/docs/policies.html:78
 msgid "Maintaining Your Add-on"
 msgstr "부가 기능의 유지 보수"
 
 #: src/olympia/devhub/templates/devhub/docs/policies.html:43
-msgid ""
-"Mozilla is committed to ensuring a great add-ons experience for our users "
-"and developers. Please review the policies below before submitting your add-"
-"on."
-msgstr ""
-"Mozilla는 사용자와 개발자가 굉장한 부가 기능 경험을 만끽할 수 있도록 최선의 노력을 다하고 있습니다. 부가 기능을 제출하기 전에 "
-"먼저 아래의 정책을 읽어주시기 바랍니다."
+msgid "Mozilla is committed to ensuring a great add-ons experience for our users and developers. Please review the policies below before submitting your add-on."
+msgstr "Mozilla는 사용자와 개발자가 굉장한 부가 기능 경험을 만끽할 수 있도록 최선의 노력을 다하고 있습니다. 부가 기능을 제출하기 전에 먼저 아래의 정책을 읽어주시기 바랍니다."
 
 #: src/olympia/devhub/templates/devhub/docs/policies.html:55
-msgid ""
-"Find out what is expected of add-ons we host and our policies on specific "
-"add-on practices."
+msgid "Find out what is expected of add-ons we host and our policies on specific add-on practices."
 msgstr "저희에게 부가 기능 호스팅을 맡기면 어떤 것을 기대할 수 있는지와 부가 기능 전용 관행에 나와있는 정책에 대해서 알아봅니다."
 
 #: src/olympia/devhub/templates/devhub/docs/policies.html:67
-msgid ""
-"What happens after your add-on is submitted? Learn about how our Editors "
-"review submissions."
+msgid "What happens after your add-on is submitted? Learn about how our Editors review submissions."
 msgstr "부가 기능이 제출된 다음엔 어떤 일이 일어날까요? 편집자가 제출품을 어떻게 심사하는지 알아봅시다."
 
 #: src/olympia/devhub/templates/devhub/docs/policies.html:81
-msgid ""
-"Add-on updates, transferring ownership, user reviews, and what to expect "
-"once your add-on is approved."
-msgstr ""
-"부가 기능 업데이트, 소유권 이전, 사용자 평가, 그 외에도 부가 기능이 승인되면 사용할 수 있는 여러가지 기능에 대해 알아봅니다."
+msgid "Add-on updates, transferring ownership, user reviews, and what to expect once your add-on is approved."
+msgstr "부가 기능 업데이트, 소유권 이전, 사용자 평가, 그 외에도 부가 기능이 승인되면 사용할 수 있는 여러가지 기능에 대해 알아봅니다."
 
 #: src/olympia/devhub/templates/devhub/docs/policies.html:93
-msgid ""
-"How up-and-coming add-ons become featured and what&#039;s involved in the "
-"process."
+msgid "How up-and-coming add-ons become featured and what&#039;s involved in the process."
 msgstr "인기 급상승 부가 기능이 어떻게 추천 부가 기능이 되며 선정 과정엔 어떤 것이 있는지 알아봅니다."
 
 #: src/olympia/devhub/templates/devhub/docs/policies.html:106
-msgid ""
-"Terms of Service for submitting your work to our site. Developers are "
-"required to accept this agreement before submission."
+msgid "Terms of Service for submitting your work to our site. Developers are required to accept this agreement before submission."
 msgstr "사이트에 작업물을 제출할 때 필요한 서비스 이용 약관입니다. 개발자는 제출 전에 이 동의서의 수락을 요구받게 됩니다."
 
 #: src/olympia/devhub/templates/devhub/docs/policies.html:118
 msgid "How to get in touch with us regarding these policies or your add-on."
 msgstr "여러 정책 및 부가 기능에 관해 저희에게 연락을 취하는 방법이 나와있습니다."
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:6
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:10
 msgid "You have disabled this add-on"
 msgstr "사용 불가 상태인 부가 기능이 있습니다"
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:20
-msgid ""
-"Your add-on's listing is disabled and is not showing anywhere in our gallery"
-" or update service."
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:24
+msgid "Your add-on's listing is disabled and is not showing anywhere in our gallery or update service."
 msgstr "부가 기능이 목록에 노출되지 않으며 갤러리 및 업데이트 서비스 어느곳에서도 보이지 않습니다."
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:25
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:27
 msgid "Please complete your add-on."
 msgstr "부가 기능을 마무리 해 주세요."
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:29
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:30
 msgid "You will receive an email when the review is complete."
 msgstr "심사가 완료되면 이메일을 받게 됩니다."
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:34
-msgid ""
-"You will receive an email when the review is complete. Until then, your add-"
-"on is not listed in our gallery but can be accessed directly from its "
-"details page."
-msgstr ""
-"심사 완료시 이메일을 받아보게 됩니다. 그 전까지 부가 기능은 갤러리에 노출되지 않지만 해당 부가 기능의 상세 정보 페이지로 바로 접근은"
-" 가능합니다."
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:33
+msgid "You will receive an email when the review is complete. Until then, your add-on is not listed in our gallery but can be accessed directly from its details page."
+msgstr "심사 완료시 이메일을 받아보게 됩니다. 그 전까지 부가 기능은 갤러리에 노출되지 않지만 해당 부가 기능의 상세 정보 페이지로 바로 접근은 가능합니다."
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:38
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:48
-msgid ""
-"You will receive an email when the review is\n"
-"                             complete and your add-on is signed."
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:37 src/olympia/devhub/templates/devhub/includes/addon_details.html:45
+msgid "You will receive an email when the review is complete and your add-on is signed."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:44
-msgid ""
-"You will receive an email when the review is complete. Until then, your add-"
-"on is not listed in our gallery but can be accessed directly from its "
-"details page."
-msgstr ""
-"심사 완료시 이메일을 받아보게 됩니다. 그 전까지 부가 기능은 갤러리에 노출되지 않지만 해당 부가 기능의 상세 정보 페이지로 바로 접근은"
-" 가능합니다."
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:41
+msgid "You will receive an email when the review is complete. Until then, your add-on is not listed in our gallery but can be accessed directly from its details page."
+msgstr "심사 완료시 이메일을 받아보게 됩니다. 그 전까지 부가 기능은 갤러리에 노출되지 않지만 해당 부가 기능의 상세 정보 페이지로 바로 접근은 가능합니다."
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:54
-msgid ""
-"Your add-on is displayed in our gallery and users are receiving automatic "
-"updates."
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:49
+msgid "Your add-on is displayed in our gallery and users are receiving automatic updates."
 msgstr "부가 기능이 갤러리에 노출되고 있고 사용자들은 자동으로 업데이트를 받아보게 됩니다."
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:57
-msgid ""
-"Your add-on has been signed and can be bundled with an\n"
-"                             application installer."
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:52
+msgid "Your add-on has been signed and can be bundled with an application installer."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:63
-msgid ""
-"Your add-on was disabled by a site administrator and is no\n"
-"                             longer shown in our gallery. If you have any questions,\n"
-"                             please email amo-admins@mozilla.org."
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:56
+msgid "Your add-on was disabled by a site administrator and is no longer shown in our gallery. If you have any questions, please email amo-admins@mozilla.org."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:70
-msgid ""
-"Your add-on is displayed in our gallery as experimental and users are "
-"receiving automatic updates. Some features are unavailable to your add-on."
-msgstr ""
-"부가 기능이 시험용으로 갤러리에 표시되며 사용자들은 자동 업데이트를 받을 수 있습니다. 부가 기능의 일부 기능은 사용할 수 없습니다."
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:62
+msgid "Your add-on is displayed in our gallery as experimental and users are receiving automatic updates. Some features are unavailable to your add-on."
+msgstr "부가 기능이 시험용으로 갤러리에 표시되며 사용자들은 자동 업데이트를 받을 수 있습니다. 부가 기능의 일부 기능은 사용할 수 없습니다."
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:74
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:66
 msgid "Your add-on has been signed."
 msgstr ""
 
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:69
+msgid ""
+"You will receive an email when the full review is complete. Until then, your add-on is displayed in our gallery as experimental and users are receiving automatic updates. Some features are "
+"unavailable to your add-on."
+msgstr "전체 심사가 완료되면 이메일을 받아볼 수 있습니다. 그 전까지 부가 기능은 시험용으로 갤러리 상에 표시되며 사용자들은 자동 업데이트를 받을 수 있습니다. 일부 기능은 사용할 수 없습니다."
+
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:74
+msgid "You will receive an email when the full review is complete, making you able to bundle your add-on with an application installer."
+msgstr ""
+
 #: src/olympia/devhub/templates/devhub/includes/addon_details.html:79
-msgid ""
-"You will receive an email when the full review is complete. Until then, your"
-" add-on is displayed in our gallery as experimental and users are receiving "
-"automatic updates. Some features are unavailable to your add-on."
-msgstr ""
-"전체 심사가 완료되면 이메일을 받아볼 수 있습니다. 그 전까지 부가 기능은 시험용으로 갤러리 상에 표시되며 사용자들은 자동 업데이트를 "
-"받을 수 있습니다. 일부 기능은 사용할 수 없습니다."
+msgid "All add-ons hosted in our gallery must now be reviewed by an editor. If you wish to continue hosting your add-on, please click to select a review process."
+msgstr "저희 갤러리에서 호스팅 중인 모든 부가 기능은 편집자에 의해 심사를 받아야 합니다. 호스팅 작업을 계속 하고 싶다면 심사 절차 선택을 위해 클릭해주세요."
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:84
-msgid ""
-"You will receive an email when the full review is\n"
-"                             complete, making you able to bundle your add-on with an\n"
-"                             application installer."
-msgstr ""
-
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:91
-msgid ""
-"All add-ons hosted in our gallery must now be reviewed by an editor. If you "
-"wish to continue hosting your add-on, please click to select a review "
-"process."
-msgstr ""
-"저희 갤러리에서 호스팅 중인 모든 부가 기능은 편집자에 의해 심사를 받아야 합니다. 호스팅 작업을 계속 하고 싶다면 심사 절차 선택을 "
-"위해 클릭해주세요."
-
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:113
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:100
 msgid "Current Version:"
 msgstr "현재 버전:"
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:115
-msgid ""
-"This is the version of your add-on that will\n"
-"                                           be installed if someone clicks the Install\n"
-"                                           button on addons.mozilla.org. It is only\n"
-"                                           relevant for listed add-ons."
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:102
+msgid "This is the version of your add-on that will be installed if someone clicks the Install button on addons.mozilla.org. It is only relevant for listed add-ons."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:123
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:110
 msgid "Created:"
 msgstr "제작일:"
 
 #. {0} is a date. dennis-ignore: E201
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:125
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:131
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:112 src/olympia/devhub/templates/devhub/includes/addon_details.html:118
 #, python-format
 msgid "%%b %%e, %%Y"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:136
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:123
 msgid "Next Version:"
 msgstr "다음 버전:"
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:138
-msgid ""
-"This is the newest uploaded version, however it isn’t live on the site yet."
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:125
+msgid "This is the newest uploaded version, however it isn’t live on the site yet."
 msgstr "이 버전이 최신이지만 아직 사이트 상에 올라가지는 않았습니다."
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:144
-#: src/olympia/devhub/templates/devhub/versions/list.html:30
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:130 src/olympia/devhub/templates/devhub/versions/list.html:30
 msgid "Queues are not reviewed strictly in order"
 msgstr "대기열 순서를 정확하게 지켜가며 심사되지는 않습니다."
 
@@ -7622,13 +6085,9 @@ msgstr "개발자 프로필 만들기"
 
 #: src/olympia/devhub/templates/devhub/includes/addons_create_profile.html:24
 msgid ""
-"Your developer profile will tell users about you, why you made this add-on, "
-"and what's next for the add-on. This profile is required for add-ons "
-"requesting contributions, but can be useful for any developer interested in "
-"connecting with users."
-msgstr ""
-"개발자 프로필은 사용자에게 당신에 대한 정보, 이 부가 기능을 만든 이유, 부가 기능의 추후 계획 등을 알려주는 곳이 될 것입니다. 이 "
-"프로필은 기부 제도를 사용해야만 만들수 있으며 개발자가 사용자와 소통하며 흥미를 가질 수 있게 해주는 유용한 기능입니다."
+"Your developer profile will tell users about you, why you made this add-on, and what's next for the add-on. This profile is required for add-ons requesting contributions, but can be useful for any "
+"developer interested in connecting with users."
+msgstr "개발자 프로필은 사용자에게 당신에 대한 정보, 이 부가 기능을 만든 이유, 부가 기능의 추후 계획 등을 알려주는 곳이 될 것입니다. 이 프로필은 기부 제도를 사용해야만 만들수 있으며 개발자가 사용자와 소통하며 흥미를 가질 수 있게 해주는 유용한 기능입니다."
 
 #: src/olympia/devhub/templates/devhub/includes/addons_create_profile.html:32
 msgid "Make sure your user profile is up to date."
@@ -7640,15 +6099,11 @@ msgid "<a href=\"%(url)s\"><strong>Update your user profile.</strong></a>"
 msgstr "<a href=\"%(url)s\"><strong>사용자 프로필을 업데이트해 주세요.</strong></a>"
 
 #: src/olympia/devhub/templates/devhub/includes/addons_create_profile.html:45
-msgid ""
-"Whether it was an idea while in line at the grocery store or the solution to"
-" one of life's great problems, share your story."
+msgid "Whether it was an idea while in line at the grocery store or the solution to one of life's great problems, share your story."
 msgstr "마트에서 줄을 서면서 떠오른 아이디어가 인생의 난제를 해결하는 묘안일 때가 있습니다. 생각을 공유해 보세요."
 
 #: src/olympia/devhub/templates/devhub/includes/addons_create_profile.html:61
-msgid ""
-"Telling your users what's coming soon will give them something to look "
-"forward to."
+msgid "Telling your users what's coming soon will give them something to look forward to."
 msgstr "사람들에게 앞으로 어떤 기능이 추가되는지 말해준다면 이들은 기대감을 갖고 당신을 지켜볼 것입니다."
 
 #: src/olympia/devhub/templates/devhub/includes/addons_edit_nav.html:23
@@ -7680,9 +6135,7 @@ msgid "View the blog &#9658;"
 msgstr "블로그 보기 &#9658;"
 
 #: src/olympia/devhub/templates/devhub/includes/license_form.html:6
-msgid ""
-"Please choose a license appropriate for the rights you grant on your source code.\n"
-"                  It is only relevant for listed add-ons."
+msgid "Please choose a license appropriate for the rights you grant on your source code. It is only relevant for listed add-ons."
 msgstr ""
 
 #. {0} is a list of HTML tags.
@@ -7698,30 +6151,26 @@ msgstr "일부 HTML 코드를 사용할 수 있습니다."
 msgid "Remove this application"
 msgstr "애플리케이션 삭제하기"
 
-#. {0} is the maximum number of add-on categories allowed.                {1}
-#. is
+#. {0} is the maximum number of add-on categories allowed.                {1} is
 #. the application name.
 #: src/olympia/devhub/templates/devhub/includes/macros.html:70
 msgid "Select <b>up to {0}</b> {1} category for this add-on:"
 msgid_plural "Select <b>up to {0}</b> {1} categories for this add-on:"
 msgstr[0] "부가 기능이 속할 {1}용 분류를 <b>{0}개 까지</b> 선택하세요:"
+msgstr[1] ""
 
 #: src/olympia/devhub/templates/devhub/includes/policy_form.html:4
 msgid ""
-"Users will be required to accept the following End-User License Agreement (EULA) prior to installing your add-on. The presence of a EULA significantly affects the number of downloads an add-on receives. Please note that a EULA is not the same as a code license, such as the GPL or MPL.\n"
-"                It is only relevant for listed add-ons."
+"Users will be required to accept the following End-User License Agreement (EULA) prior to installing your add-on. The presence of a EULA significantly affects the number of downloads an add-on "
+"receives. Please note that a EULA is not the same as a code license, such as the GPL or MPL.It is only relevant for listed add-ons."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/policy_form.html:21
-msgid ""
-"If your add-on transmits any data from the user's computer, a privacy policy is required that explains what data is sent and how it is used.\n"
-"                It is only relevant for listed add-ons."
+#: src/olympia/devhub/templates/devhub/includes/policy_form.html:24
+msgid "If your add-on transmits any data from the user's computer, a privacy policy is required that explains what data is sent and how it is used. It is only relevant for listed add-ons."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/includes/source_form_field.html:2
-msgid ""
-"If your add-on contains binary or obfuscated code other than known "
-"libraries, upload its sources for review."
+msgid "If your add-on contains binary or obfuscated code other than known libraries, upload its sources for review."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/includes/source_form_field.html:3
@@ -7729,9 +6178,7 @@ msgid "Read more about the source code review policy."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/includes/version_file.html:20
-msgid ""
-"You cannot remove an individual file after the review process has begun. You"
-" must delete the entire version."
+msgid "You cannot remove an individual file after the review process has begun. You must delete the entire version."
 msgstr "심사가 시작된 뒤에는 파일을 개별적으로 지울 수 없습니다. 버전 전체를 삭제해야 합니다."
 
 #: src/olympia/devhub/templates/devhub/includes/version_file.html:36
@@ -7760,9 +6207,7 @@ msgid "Voluntary Contributions"
 msgstr "기부금"
 
 #: src/olympia/devhub/templates/devhub/payments/payments.html:38
-msgid ""
-"Add-ons enrolled in our contributions program can request voluntary "
-"financial support from users."
+msgid "Add-ons enrolled in our contributions program can request voluntary financial support from users."
 msgstr "기부 프로그램에 등록된 부가 기능은 사용자에게서 자발적인 재정 지원을 요구할 수 있습니다."
 
 #: src/olympia/devhub/templates/devhub/payments/payments.html:40
@@ -7774,9 +6219,7 @@ msgid "Choose when and how users are asked to contribute"
 msgstr "기부금 요청 방식 선택"
 
 #: src/olympia/devhub/templates/devhub/payments/payments.html:42
-msgid ""
-"Receive contributions in your PayPal account or send them to an organization"
-" of your choice"
+msgid "Receive contributions in your PayPal account or send them to an organization of your choice"
 msgstr "PayPal 계정을 통해 기부금을 받거나 임의로 선정한 결제 대행 업체로 기부자들을 유도할 수 있습니다"
 
 #: src/olympia/devhub/templates/devhub/payments/payments.html:46
@@ -7785,17 +6228,14 @@ msgstr ""
 
 #: src/olympia/devhub/templates/devhub/payments/payments.html:53
 #, python-format
-msgid ""
-"Contributions are only available for add-ons with a <a "
-"href=\"%(url)s\">completed developer profile</a>."
+msgid "Contributions are only available for add-ons with a <a href=\"%(url)s\">completed developer profile</a>."
 msgstr "기부 제도는 <a href=\"%(url)s\">개발자 프로필 작성을 완료한</a> 부가 기능만 사용할 수 있습니다."
 
 #: src/olympia/devhub/templates/devhub/payments/payments.html:59
 msgid "Contributions are only available for fully reviewed add-ons."
 msgstr "기부 제도는 전체 심사를 거친 부가 기능만 사용할 수 있습니다."
 
-#: src/olympia/devhub/templates/devhub/payments/payments.html:65
-#: src/olympia/devhub/templates/devhub/payments/voluntary.html:2
+#: src/olympia/devhub/templates/devhub/payments/payments.html:65 src/olympia/devhub/templates/devhub/payments/voluntary.html:2
 msgid "Set up Contributions"
 msgstr "기부금 설정"
 
@@ -7808,15 +6248,12 @@ msgstr "2단계. 가격 책정 및 유효 기간 책정"
 msgid "or <a href=\"%(cancel)s\">Cancel</a>"
 msgstr "또는 <a href=\"%(cancel)s\">취소</a>"
 
-#: src/olympia/devhub/templates/devhub/payments/voluntary.html:2
-#: src/olympia/stats/templates/stats/addon_report_menu.html:39
+#: src/olympia/devhub/templates/devhub/payments/voluntary.html:2 src/olympia/stats/templates/stats/addon_report_menu.html:39
 msgid "Contributions"
 msgstr "기부금"
 
 #: src/olympia/devhub/templates/devhub/payments/voluntary.html:3
-msgid ""
-"Fill in the fields below to begin asking for voluntary contributions from "
-"users."
+msgid "Fill in the fields below to begin asking for voluntary contributions from users."
 msgstr "사용자들에게 자발적 기부를 요청하시려면 아래의 항목을 입력해 주세요."
 
 #: src/olympia/devhub/templates/devhub/payments/voluntary.html:11
@@ -7860,19 +6297,14 @@ msgid "Send a thank-you note?"
 msgstr "감사 쪽지를 보내시겠습니까?"
 
 #: src/olympia/devhub/templates/devhub/payments/voluntary.html:47
-msgid ""
-"We'll automatically email users who contribute to your add-on with this "
-"message."
+msgid "We'll automatically email users who contribute to your add-on with this message."
 msgstr "당신의 부가 기능에 기부한 사용자들에게 자동으로 해당 메시지를 담은 이메일이 전송됩니다."
 
 #: src/olympia/devhub/templates/devhub/payments/voluntary.html:49
 msgid ""
-"We recommend thanking the user and telling them how much you appreciate "
-"their support. You might also want to tell them about what's next for your "
-"add-on and about any other add-ons you've made for them to try."
-msgstr ""
-"사용자들에게 감사를 표하고 지원해준 것에 대해 얼마나 기쁜 마음을 갖고 있는지를 표현해 주시는게 좋습니다. 거기에 다음엔 어떤 기능을 "
-"계획하고 있는지 그리고 제작중인 다른 부가 기능은 어떤 것이 있는지 등도 알려주시면 더 좋겠지요."
+"We recommend thanking the user and telling them how much you appreciate their support. You might also want to tell them about what's next for your add-on and about any other add-ons you've made for"
+" them to try."
+msgstr "사용자들에게 감사를 표하고 지원해준 것에 대해 얼마나 기쁜 마음을 갖고 있는지를 표현해 주시는게 좋습니다. 거기에 다음엔 어떤 기능을 계획하고 있는지 그리고 제작중인 다른 부가 기능은 어떤 것이 있는지 등도 알려주시면 더 좋겠지요."
 
 #: src/olympia/devhub/templates/devhub/payments/voluntary.html:64
 msgid "Activate Contributions"
@@ -7886,138 +6318,96 @@ msgstr "또는 <a id=\"setup-cancel\" href=\"#\">무시</a>"
 msgid "Transfer ownership"
 msgstr "소유권 이전"
 
-#: src/olympia/devhub/templates/devhub/personas/edit.html:77
-#: src/olympia/devhub/templates/devhub/personas/submit.html:31
+#: src/olympia/devhub/templates/devhub/personas/edit.html:77 src/olympia/devhub/templates/devhub/personas/submit.html:31
 msgid "Theme Details"
 msgstr "테마 상세 정보"
 
-#: src/olympia/devhub/templates/devhub/personas/edit.html:87
-#: src/olympia/devhub/templates/devhub/personas/submit.html:36
+#: src/olympia/devhub/templates/devhub/personas/edit.html:87 src/olympia/devhub/templates/devhub/personas/submit.html:36
 msgid "Supply a pretty URL for your detail page."
 msgstr "상세 정보 페이지에 쓸 보기 좋은 URL로 제공해 주세요."
 
 # 86%
-#: src/olympia/devhub/templates/devhub/personas/edit.html:92
-#: src/olympia/devhub/templates/devhub/personas/submit.html:41
+#: src/olympia/devhub/templates/devhub/personas/edit.html:92 src/olympia/devhub/templates/devhub/personas/submit.html:41
 msgid "Select the category that best describes your Theme."
 msgstr "테마를 가장 잘 설명하고 있는 분류를 선택하세요."
 
-#: src/olympia/devhub/templates/devhub/personas/edit.html:95
-#: src/olympia/devhub/templates/devhub/personas/submit.html:44
+#: src/olympia/devhub/templates/devhub/personas/edit.html:95 src/olympia/devhub/templates/devhub/personas/submit.html:44
 msgid "Add some tags to describe your Theme."
 msgstr "테마를 설명할 수 있는 태그를 추가하세요."
 
-#: src/olympia/devhub/templates/devhub/personas/edit.html:106
-msgid ""
-"A short explanation of your theme's basic functionality that is displayed in"
-" search and browse listings, as well as at the top of your theme's details "
-"page."
+#: src/olympia/devhub/templates/devhub/personas/edit.html:106 src/olympia/devhub/templates/devhub/personas/submit.html:54
+msgid "A short explanation of your theme's basic functionality that is displayed in search and browse listings, as well as at the top of your theme's details page."
 msgstr "테마의 기본적인 기능에 대해 짧은 설명을 적어주세요. 검색 또는 테마 목록, 테마 세부 정보 페이지 상단에 노출됩니다."
 
-#: src/olympia/devhub/templates/devhub/personas/edit.html:122
-#: src/olympia/devhub/templates/devhub/personas/submit.html:68
+#: src/olympia/devhub/templates/devhub/personas/edit.html:122 src/olympia/devhub/templates/devhub/personas/submit.html:68
 msgid "Theme License"
 msgstr "테마 라이선스"
 
 # 88%
-#: src/olympia/devhub/templates/devhub/personas/edit.html:126
-#: src/olympia/devhub/templates/devhub/personas/submit.html:72
+#: src/olympia/devhub/templates/devhub/personas/edit.html:126 src/olympia/devhub/templates/devhub/personas/submit.html:72
 msgid "Can others share your Theme, as long as you're given credit?"
 msgstr "인증받은 사람에 한해 테마를 공유하게 할까요?"
 
-#: src/olympia/devhub/templates/devhub/personas/edit.html:132
-#: src/olympia/devhub/templates/devhub/personas/edit.html:153
-#: src/olympia/devhub/templates/devhub/personas/submit.html:78
+#: src/olympia/devhub/templates/devhub/personas/edit.html:132 src/olympia/devhub/templates/devhub/personas/edit.html:153 src/olympia/devhub/templates/devhub/personas/submit.html:78
 #: src/olympia/devhub/templates/devhub/personas/submit.html:99
-msgid ""
-"The licensor permits others to copy, distribute, display, and perform the "
-"work, including for commercial purposes."
+msgid "The licensor permits others to copy, distribute, display, and perform the work, including for commercial purposes."
 msgstr "라이선스 보유자가 다른 사람이 복사, 배포, 전시, 상업적 용도로 작품을 제작하는 것을 허용합니다."
 
-#: src/olympia/devhub/templates/devhub/personas/edit.html:141
-#: src/olympia/devhub/templates/devhub/personas/edit.html:162
-#: src/olympia/devhub/templates/devhub/personas/submit.html:87
+#: src/olympia/devhub/templates/devhub/personas/edit.html:141 src/olympia/devhub/templates/devhub/personas/edit.html:162 src/olympia/devhub/templates/devhub/personas/submit.html:87
 #: src/olympia/devhub/templates/devhub/personas/submit.html:108
-msgid ""
-"The licensor permits others to copy, distribute, display, and perform the "
-"work for non-commercial purposes only."
+msgid "The licensor permits others to copy, distribute, display, and perform the work for non-commercial purposes only."
 msgstr "라이선스 보유자가 다른 사람의 복사, 배포, 전시, 비 상업적 용도일때에 한해 작품을 제작하는 것을 허용합니다."
 
 # 85%
-#: src/olympia/devhub/templates/devhub/personas/edit.html:147
-#: src/olympia/devhub/templates/devhub/personas/submit.html:93
+#: src/olympia/devhub/templates/devhub/personas/edit.html:147 src/olympia/devhub/templates/devhub/personas/submit.html:93
 msgid "Can others make commercial use of your Theme?"
 msgstr "다른 사람이 당신의 테마를 상업적으로 사용할 수 있도록 허용할까요?"
 
 # 86%
-#: src/olympia/devhub/templates/devhub/personas/edit.html:168
-#: src/olympia/devhub/templates/devhub/personas/submit.html:114
+#: src/olympia/devhub/templates/devhub/personas/edit.html:168 src/olympia/devhub/templates/devhub/personas/submit.html:114
 msgid "Can others create derivative works from your Theme?"
 msgstr "다른 사람이 당신의 테마를 사용해서 작품을 만들 수 있도록 허용할까요?"
 
-#: src/olympia/devhub/templates/devhub/personas/edit.html:174
-#: src/olympia/devhub/templates/devhub/personas/submit.html:120
-msgid ""
-"The licensor permits others to copy, distribute, display and perform the "
-"work, as well as make derivative works based on it."
+#: src/olympia/devhub/templates/devhub/personas/edit.html:174 src/olympia/devhub/templates/devhub/personas/submit.html:120
+msgid "The licensor permits others to copy, distribute, display and perform the work, as well as make derivative works based on it."
 msgstr "라이선스 보유자가 다른 사람이 복사, 배포, 전시, 페르소나를 바탕으로 한 파생 작품을 제작하는 것 까지도 허용합니다."
 
-#: src/olympia/devhub/templates/devhub/personas/edit.html:182
-#: src/olympia/devhub/templates/devhub/personas/submit.html:128
+#: src/olympia/devhub/templates/devhub/personas/edit.html:182 src/olympia/devhub/templates/devhub/personas/submit.html:128
 msgid "Yes, as long as they share alike"
 msgstr "모두에게 동일한 자격을 부여한다는 전제하에 허락합니다"
 
-#: src/olympia/devhub/templates/devhub/personas/edit.html:183
-#: src/olympia/devhub/templates/devhub/personas/submit.html:129
-msgid ""
-"The licensor permits others to distribute derivativeworks only under the "
-"same license or one compatible with the one that governs the licensor's "
-"work."
-msgstr ""
-"라이선스 보유자가 동일 라이선스 내지는 라이선스 보유자의 저작물을 관장하는 곳과 호환되는 라이선스가 적용될 때에 한해서 다른 사람이 파생"
-" 저작물을 배포할 수 있도록 허용합니다."
+#: src/olympia/devhub/templates/devhub/personas/edit.html:183 src/olympia/devhub/templates/devhub/personas/submit.html:129
+msgid "The licensor permits others to distribute derivativeworks only under the same license or one compatible with the one that governs the licensor's work."
+msgstr "라이선스 보유자가 동일 라이선스 내지는 라이선스 보유자의 저작물을 관장하는 곳과 호환되는 라이선스가 적용될 때에 한해서 다른 사람이 파생 저작물을 배포할 수 있도록 허용합니다."
 
-#: src/olympia/devhub/templates/devhub/personas/edit.html:192
-#: src/olympia/devhub/templates/devhub/personas/submit.html:138
-msgid ""
-"The licensor permits others to copy, distribute and transmit only unaltered "
-"copies of the work — not derivative works based on it."
-msgstr ""
-"라이선스 보유자가 다른 사람이 복사, 배포, 변형되지 않은 저작물 사본을 전송하는 것을 허용합니다. 단, 저작물을 사용한 파생 작품은 "
-"제외합니다."
+#: src/olympia/devhub/templates/devhub/personas/edit.html:192 src/olympia/devhub/templates/devhub/personas/submit.html:138
+msgid "The licensor permits others to copy, distribute and transmit only unaltered copies of the work — not derivative works based on it."
+msgstr "라이선스 보유자가 다른 사람이 복사, 배포, 변형되지 않은 저작물 사본을 전송하는 것을 허용합니다. 단, 저작물을 사용한 파생 작품은 제외합니다."
 
 # 87%
-#: src/olympia/devhub/templates/devhub/personas/edit.html:199
-#: src/olympia/devhub/templates/devhub/personas/submit.html:145
+#: src/olympia/devhub/templates/devhub/personas/edit.html:199 src/olympia/devhub/templates/devhub/personas/submit.html:145
 msgid "Your Theme will be released under the following license:"
 msgstr "테마가 다음의 라이선스 하에 공개됩니다:"
 
-#: src/olympia/devhub/templates/devhub/personas/edit.html:202
-#: src/olympia/devhub/templates/devhub/personas/submit.html:148
+#: src/olympia/devhub/templates/devhub/personas/edit.html:202 src/olympia/devhub/templates/devhub/personas/submit.html:148
 msgid "Select a different license."
 msgstr "다른 라이선스를 선택하세요."
 
-#: src/olympia/devhub/templates/devhub/personas/edit.html:207
-#: src/olympia/devhub/templates/devhub/personas/submit.html:153
+#: src/olympia/devhub/templates/devhub/personas/edit.html:207 src/olympia/devhub/templates/devhub/personas/submit.html:153
 msgid "Select a license for your Theme."
 msgstr "여러분의 테마를 위한 라이선스를 선택하세요."
 
-#: src/olympia/devhub/templates/devhub/personas/edit.html:217
-#: src/olympia/devhub/templates/devhub/personas/submit.html:163
+#: src/olympia/devhub/templates/devhub/personas/edit.html:217 src/olympia/devhub/templates/devhub/personas/submit.html:163
 msgid "Theme Design"
 msgstr "테마 디자인"
 
-#: src/olympia/devhub/templates/devhub/personas/edit.html:221
-#: src/olympia/devhub/templates/devhub/personas/edit.html:224
+#: src/olympia/devhub/templates/devhub/personas/edit.html:221 src/olympia/devhub/templates/devhub/personas/edit.html:224
 msgid "Upload New Design"
 msgstr "새 디자인 업로드"
 
 #: src/olympia/devhub/templates/devhub/personas/edit.html:226
-msgid ""
-"Upon upload and form submission, the AMO Team will review your updated "
-"design. Your current design will still be public in the meantime."
-msgstr ""
-"업로드 및 양식 제출시 AMO 팀이 업데이트한 디자인을 심사하게 됩니다. 현재 디자인은 심사가 끝날때까지는 계속 공개 상태일 것입니다."
+msgid "Upon upload and form submission, the AMO Team will review your updated design. Your current design will still be public in the meantime."
+msgstr "업로드 및 양식 제출시 AMO 팀이 업데이트한 디자인을 심사하게 됩니다. 현재 디자인은 심사가 끝날때까지는 계속 공개 상태일 것입니다."
 
 #: src/olympia/devhub/templates/devhub/personas/edit.html:241
 msgid "Your previously resubmitted design, which is under pending review."
@@ -8043,43 +6433,35 @@ msgstr "상단"
 msgid "Footer"
 msgstr "하단"
 
-#: src/olympia/devhub/templates/devhub/personas/edit.html:274
-#: src/olympia/devhub/templates/devhub/personas/submit.html:167
+#: src/olympia/devhub/templates/devhub/personas/edit.html:274 src/olympia/devhub/templates/devhub/personas/submit.html:167
 msgid "Select colors for your Theme."
 msgstr "테마에 사용할 색을 설정하세요."
 
-#: src/olympia/devhub/templates/devhub/personas/edit.html:276
-#: src/olympia/devhub/templates/devhub/personas/submit.html:169
+#: src/olympia/devhub/templates/devhub/personas/edit.html:276 src/olympia/devhub/templates/devhub/personas/submit.html:169
 msgid "Foreground Text"
 msgstr "글자 전경색"
 
-#: src/olympia/devhub/templates/devhub/personas/edit.html:277
-#: src/olympia/devhub/templates/devhub/personas/submit.html:170
+#: src/olympia/devhub/templates/devhub/personas/edit.html:277 src/olympia/devhub/templates/devhub/personas/submit.html:170
 msgid "This is the color of the tab text."
 msgstr "탭 부분의 글자색입니다."
 
-#: src/olympia/devhub/templates/devhub/personas/edit.html:279
-#: src/olympia/devhub/templates/devhub/personas/submit.html:172
+#: src/olympia/devhub/templates/devhub/personas/edit.html:279 src/olympia/devhub/templates/devhub/personas/submit.html:172
 msgid "Background"
 msgstr "바탕색"
 
-#: src/olympia/devhub/templates/devhub/personas/edit.html:280
-#: src/olympia/devhub/templates/devhub/personas/submit.html:173
+#: src/olympia/devhub/templates/devhub/personas/edit.html:280 src/olympia/devhub/templates/devhub/personas/submit.html:173
 msgid "This is the color of the tabs."
 msgstr "탭의 색상입니다."
 
-#: src/olympia/devhub/templates/devhub/personas/edit.html:285
-#: src/olympia/devhub/templates/devhub/personas/submit.html:178
+#: src/olympia/devhub/templates/devhub/personas/edit.html:285 src/olympia/devhub/templates/devhub/personas/submit.html:178
 msgid "Preview"
 msgstr "미리보기"
 
-#: src/olympia/devhub/templates/devhub/personas/edit.html:291
-#: src/olympia/devhub/templates/devhub/personas/submit.html:183
+#: src/olympia/devhub/templates/devhub/personas/edit.html:291 src/olympia/devhub/templates/devhub/personas/submit.html:183
 msgid "Your Theme's Name"
 msgstr "테마의 이름"
 
-#: src/olympia/devhub/templates/devhub/personas/edit.html:294
-#: src/olympia/devhub/templates/devhub/personas/submit.html:186
+#: src/olympia/devhub/templates/devhub/personas/edit.html:294 src/olympia/devhub/templates/devhub/personas/submit.html:186
 #, python-format
 msgid "by <a href=\"%(profile_url)s\" target=\"_blank\">%(user)s</a>"
 msgstr "제작: <a href=\"%(profile_url)s\" target=\"_blank\">%(user)s</a>"
@@ -8090,31 +6472,17 @@ msgstr "새로운 테마 만들기"
 
 #: src/olympia/devhub/templates/devhub/personas/submit.html:18
 #, python-format
-msgid ""
-"Background themes let you easily personalize the look of your Firefox. "
-"Submit your own design below, or <a href=\"%(submit_url)s\">learn how to "
-"create one</a>!"
-msgstr ""
-"배경 테마는 Firefox 외형을 쉽게 개인화해 줍니다. 직접 만든 디자인을 올려주세요. 잘 모르겠다면 <a "
-"href=\"%(submit_url)s\">제작 방법을 익혀보세요</a>!"
+msgid "Background themes let you easily personalize the look of your Firefox. Submit your own design below, or <a href=\"%(submit_url)s\">learn how to create one</a>!"
+msgstr "배경 테마는 Firefox 외형을 쉽게 개인화해 줍니다. 직접 만든 디자인을 올려주세요. 잘 모르겠다면 <a href=\"%(submit_url)s\">제작 방법을 익혀보세요</a>!"
 
 #: src/olympia/devhub/templates/devhub/personas/submit.html:33
 msgid "Give your Theme a name."
 msgstr "테마 이름 짓기"
 
-#: src/olympia/devhub/templates/devhub/personas/submit.html:54
-msgid ""
-"A short explanation of your theme's basic functionality that is displayed in"
-" search and browse listings, as well as at the top of your theme's details "
-"page."
-msgstr "테마의 기본적인 기능에 대해 짧은 설명을 적어주세요. 검색 또는 테마 목록, 테마 세부 정보 페이지 상단에 노출됩니다."
-
 #: src/olympia/devhub/templates/devhub/personas/submit.html:198
 #, python-format
 msgid ""
-"I agree to the <a href=\"%(agreement_url)s\" target=\"_blank\">Firefox Add-"
-"on Distribution Agreement</a> and to my information being handled as "
-"described in the <a href=\"%(privacy_notice_url)s\" "
+"I agree to the <a href=\"%(agreement_url)s\" target=\"_blank\">Firefox Add-on Distribution Agreement</a> and to my information being handled as described in the <a href=\"%(privacy_notice_url)s\" "
 "target=\"_blank\">Websites, Communications and Cookies Privacy Notice</a>."
 msgstr ""
 
@@ -8123,26 +6491,18 @@ msgid "Submit Theme"
 msgstr "테마 제출"
 
 #: src/olympia/devhub/templates/devhub/personas/submit_done.html:11
-msgid ""
-"Your theme has been submitted to the Review Queue. You'll receive an email "
-"once it has been reviewed, typically within 24 hours."
+msgid "Your theme has been submitted to the Review Queue. You'll receive an email once it has been reviewed, typically within 24 hours."
 msgstr "테마가 심사 대기열에 등록됐습니다. 심사가 끝나면 보통 24시간 안으로 이메일을 받아보게 됩니다."
 
 #: src/olympia/devhub/templates/devhub/personas/submit_done.html:19
 #, python-format
-msgid ""
-"Provide more details about your theme by <a href=\"%(edit_url)s\">editing "
-"its listing</a>."
+msgid "Provide more details about your theme by <a href=\"%(edit_url)s\">editing its listing</a>."
 msgstr "<a href=\"%(edit_url)s\">등재 정보를 편집해서</a> 테마에 보다 자세한 정보를 입력하세요."
 
 #: src/olympia/devhub/templates/devhub/personas/submit_done.html:25
 #, python-format
-msgid ""
-"View and subscribe to your theme's <a href=\"%(feed_url)s\">activity "
-"feed</a> to stay updated on reviews, collections, and more."
-msgstr ""
-"테마의 <a href=\"%(feed_url)s\">활동량 피드</a>를 보고 구독하세요. 사용자 평가, 모음집 등록 등의 정보가 "
-"지속적으로 업데이트됩니다."
+msgid "View and subscribe to your theme's <a href=\"%(feed_url)s\">activity feed</a> to stay updated on reviews, collections, and more."
+msgstr "테마의 <a href=\"%(feed_url)s\">활동량 피드</a>를 보고 구독하세요. 사용자 평가, 모음집 등록 등의 정보가 지속적으로 업데이트됩니다."
 
 #: src/olympia/devhub/templates/devhub/personas/submit_done.html:32
 #, python-format
@@ -8158,13 +6518,11 @@ msgstr "테마의 상단 이미지를 선택하세요."
 msgid "3000 &times; 200 pixels"
 msgstr "3000 &times; 200 픽셀"
 
-#: src/olympia/devhub/templates/devhub/personas/includes/theme_design.html:9
-#: src/olympia/devhub/templates/devhub/personas/includes/theme_design.html:25
+#: src/olympia/devhub/templates/devhub/personas/includes/theme_design.html:9 src/olympia/devhub/templates/devhub/personas/includes/theme_design.html:25
 msgid "300 KB max"
 msgstr "최대 용량 300 KB"
 
-#: src/olympia/devhub/templates/devhub/personas/includes/theme_design.html:10
-#: src/olympia/devhub/templates/devhub/personas/includes/theme_design.html:26
+#: src/olympia/devhub/templates/devhub/personas/includes/theme_design.html:10 src/olympia/devhub/templates/devhub/personas/includes/theme_design.html:26
 msgid "PNG or JPG"
 msgstr "PNG 나 JPG"
 
@@ -8194,53 +6552,31 @@ msgid "Select a different footer image"
 msgstr "다른 하단 이미지 선택"
 
 #: src/olympia/devhub/templates/devhub/versions/add_file_modal.html:8
-msgid ""
-"Files added to reviewed versions must be reviewed before they will be "
-"available for download."
+msgid "Files added to reviewed versions must be reviewed before they will be available for download."
 msgstr "심사가 끝난 버전에 추가된 파일은 반드시 심사를 거쳐야 다운로드가 가능해 집니다."
 
-#: src/olympia/devhub/templates/devhub/versions/add_file_modal.html:15
-#, python-format
-msgid ""
-"Submission of updates to unlisted add-ons for signing is currently in an "
-"open beta. Manual review may still be required for a large number of add-"
-"ons. Please <a href=\"%(url)s\" target=\"_blank\">report any bugs</a> that "
-"you encounter."
-msgstr ""
-
-#: src/olympia/devhub/templates/devhub/versions/add_file_modal.html:35
+#: src/olympia/devhub/templates/devhub/versions/add_file_modal.html:24
 msgid "Select the target platform for this file."
 msgstr "이 파일을 쓸 플랫폼을 선택하세요"
 
-#: src/olympia/devhub/templates/devhub/versions/add_file_modal.html:46
+#: src/olympia/devhub/templates/devhub/versions/add_file_modal.html:35
 msgid "Which review type would you like to nominate for?"
 msgstr "어떤 심사를 받길 원하십니까?"
 
-#: src/olympia/devhub/templates/devhub/versions/add_file_modal.html:51
+#: src/olympia/devhub/templates/devhub/versions/add_file_modal.html:40
 msgid "Only publish this version to my beta channel."
-msgstr ""
-
-#: src/olympia/devhub/templates/devhub/versions/add_file_modal.html:54
-#, python-format
-msgid ""
-"The behavior of the beta channel has changed to accommodate <a "
-"href=\"%(addon_signing_url)s\" target=\"_blank\">mandatory add-on "
-"signing</a>. The new process is currently in an open beta, and may change "
-"significantly in the near future. Please <a href=\"%(issues_url)s\" "
-"target=\"_blank\">report any bugs</a> that you encounter."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/versions/edit.html:5
 msgid "Manage Version {0}"
 msgstr "버전 {0} 관리"
 
-#: src/olympia/devhub/templates/devhub/versions/edit.html:12
-#: src/olympia/devhub/templates/devhub/versions/list.html:3
+#: src/olympia/devhub/templates/devhub/versions/edit.html:12 src/olympia/devhub/templates/devhub/versions/list.html:3
 msgid "Status & Versions"
 msgstr "상태 및 버전"
 
-#. {0} is an add-on name.
 # {0} is the name of the collection
+#. {0} is an add-on name.
 #: src/olympia/devhub/templates/devhub/versions/edit.html:16
 msgid "Manage {0}"
 msgstr "{0} 관리"
@@ -8253,37 +6589,22 @@ msgstr "파일"
 msgid "Upload Another File"
 msgstr "다른 파일 업로드"
 
-#: src/olympia/devhub/templates/devhub/versions/edit.html:45
-msgid ""
-"Adjusting application information here will allow users to install your add-"
-"on even if the install manifest in the package indicates that the add-on is "
-"incompatible."
-msgstr ""
-"이곳의 애플리케이션 정보를 수정하면 패키지 내의 앱 정보 설정 파일이 비호환으로 인식하고 있던 부가 기능도 사용자가 설치할 수 있게 "
-"됩니다."
-
 #: src/olympia/devhub/templates/devhub/versions/edit.html:74
 msgid ""
-"Information about changes in this release, new features, known bugs, and "
-"other useful information specific to this release/version. This information "
-"is also shown in the Add-ons Manager when updating."
-msgstr ""
-"변경사항에 관한 정보, 새로운 기능, 알려진 버그, 그밖의 여러 유용한 정보 등을 이번 공개판/버전에 입력해 주세요. 해당 정보는 "
-"업데이트시 부가 기능 관리자에도 표시됩니다."
+"Information about changes in this release, new features, known bugs, and other useful information specific to this release/version. This information is also shown in the Add-ons Manager when "
+"updating."
+msgstr "변경사항에 관한 정보, 새로운 기능, 알려진 버그, 그밖의 여러 유용한 정보 등을 이번 공개판/버전에 입력해 주세요. 해당 정보는 업데이트시 부가 기능 관리자에도 표시됩니다."
 
 #: src/olympia/devhub/templates/devhub/versions/edit.html:99
 msgid "Approval Status"
 msgstr "승인 상태"
 
-#: src/olympia/devhub/templates/devhub/versions/edit.html:113
-#: src/olympia/editors/templates/editors/review.html:108
+#: src/olympia/devhub/templates/devhub/versions/edit.html:113 src/olympia/editors/templates/editors/review.html:108
 msgid "Notes for Reviewers"
 msgstr "심사원 주의 사항"
 
 #: src/olympia/devhub/templates/devhub/versions/edit.html:114
-msgid ""
-"Optionally, enter any information that may be useful to the Editor reviewing"
-" this add-on, such as test account information."
+msgid "Optionally, enter any information that may be useful to the Editor reviewing this add-on, such as test account information."
 msgstr "추가로, 이 부가 기능을 심사할 편집자에게 도움이 될만한 정보(테스트용 계정 정보 같은)를 입력해 주세요."
 
 #: src/olympia/devhub/templates/devhub/versions/edit.html:127
@@ -8291,13 +6612,10 @@ msgid "Source code"
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/versions/edit.html:128
-msgid ""
-"If your add-on contain binary or obfuscated code, make the source available "
-"here for reviewers."
+msgid "If your add-on contain binary or obfuscated code, make the source available here for reviewers."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/edit.html:145
-#: src/olympia/devhub/templates/devhub/versions/edit.html:149
+#: src/olympia/devhub/templates/devhub/versions/edit.html:145 src/olympia/devhub/templates/devhub/versions/edit.html:149
 msgid "Upload a new file"
 msgstr "새 파일 업로드"
 
@@ -8337,6 +6655,7 @@ msgstr "이 버전 편집하기"
 msgid "{0} file"
 msgid_plural "{0} files"
 msgstr[0] "파일 {0}개"
+msgstr[1] ""
 
 #: src/olympia/devhub/templates/devhub/versions/list.html:25
 msgid "0 files"
@@ -8363,9 +6682,7 @@ msgstr "전체 심사 요청"
 msgid "Request Preliminary Review"
 msgstr "예비 심사 요청"
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:80
-#: src/olympia/devhub/templates/devhub/versions/list.html:327
-#: src/olympia/devhub/templates/devhub/versions/list.html:350
+#: src/olympia/devhub/templates/devhub/versions/list.html:80 src/olympia/devhub/templates/devhub/versions/list.html:325 src/olympia/devhub/templates/devhub/versions/list.html:348
 msgid "Cancel Review Request"
 msgstr "심사 요청 취소"
 
@@ -8378,8 +6695,7 @@ msgid "Listed:"
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/versions/list.html:102
-msgid ""
-"Visible to everyone on {0} and included in search results and listing pages"
+msgid "Visible to everyone on {0} and included in search results and listing pages"
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/versions/list.html:108
@@ -8387,9 +6703,7 @@ msgid "Hidden:"
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/versions/list.html:108
-msgid ""
-"Hosted on {0}, but hidden to anyone but authors. Used to temporarily hide "
-"listings or discontinue them."
+msgid "Hosted on {0}, but hidden to anyone but authors. Used to temporarily hide listings or discontinue them."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/versions/list.html:114
@@ -8397,9 +6711,7 @@ msgid "Unlisted:"
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/versions/list.html:114
-msgid ""
-"Not distributed on {0}. Developers will upload new versions for signing and "
-"distribute the add-ons on their own. (beta)"
+msgid "Not distributed on {0}. Developers will upload new versions for signing and distribute the add-ons on their own."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/versions/list.html:122
@@ -8410,18 +6722,13 @@ msgstr ""
 msgid "Currently on AMO"
 msgstr "AMO상의 버전"
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:129
-#: src/olympia/devhub/templates/devhub/versions/list.html:147
-#: src/olympia/devhub/templates/devhub/versions/list.html:164
-#: src/olympia/editors/templates/editors/includes/search_results_themes.html:7
-#: src/olympia/editors/templates/editors/themes/queue_list.html:50
+#: src/olympia/devhub/templates/devhub/versions/list.html:129 src/olympia/devhub/templates/devhub/versions/list.html:147 src/olympia/devhub/templates/devhub/versions/list.html:164
+#: src/olympia/editors/templates/editors/includes/search_results_themes.html:7 src/olympia/editors/templates/editors/themes/queue_list.html:50
 msgid "Status"
 msgstr "상태"
 
 # Header for a column in a table
-#: src/olympia/devhub/templates/devhub/versions/list.html:130
-#: src/olympia/devhub/templates/devhub/versions/list.html:148
-#: src/olympia/devhub/templates/devhub/versions/list.html:165
+#: src/olympia/devhub/templates/devhub/versions/list.html:130 src/olympia/devhub/templates/devhub/versions/list.html:148 src/olympia/devhub/templates/devhub/versions/list.html:165
 #: src/olympia/editors/templates/editors/includes/files_view.html:11
 msgid "Validation"
 msgstr "검사"
@@ -8443,10 +6750,7 @@ msgid "Full review may not be required"
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/versions/list.html:201
-msgid ""
-"Unlisted add-ons don't need Full Review unless they are distributed as part "
-"of an application installer. Read <a href=\"{link}\" target=\"_blank\">this "
-"documentation</a> for more information."
+msgid "Unlisted add-ons don't need Full Review unless they are distributed as part of an application installer. Read <a href=\"{link}\" target=\"_blank\">this documentation</a> for more information."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/versions/list.html:209
@@ -8458,10 +6762,7 @@ msgid "Delete Version {version}"
 msgstr "버전 {version} 삭제"
 
 #: src/olympia/devhub/templates/devhub/versions/list.html:218
-msgid ""
-"You are about to delete the current version of your add-on. This may cause "
-"your add-on status to change, or your listing to lose public visibility, if "
-"this is the only public version of your add-on."
+msgid "You are about to delete the current version of your add-on. This may cause your add-on status to change, or your listing to lose public visibility, if this is the only public version of your add-on."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/versions/list.html:219
@@ -8469,102 +6770,77 @@ msgid "Deleting this version will permanently delete:"
 msgstr "삭제하면 이 버전은 다시는 복구할 수 없습니다:"
 
 #: src/olympia/devhub/templates/devhub/versions/list.html:225
-msgid ""
-"<strong>Important:</strong> Once a version has been deleted, you may not "
-"upload a new version with the same version number."
+msgid "<strong>Important:</strong> Once a version has been deleted, you may not upload a new version with the same version number."
 msgstr "<strong>중요:</strong> 버전을 삭제하면 같은 버전 넘버로는 다시 올릴 수 없습니다."
 
 #: src/olympia/devhub/templates/devhub/versions/list.html:230
-msgid ""
-"Deleting a version which has already been reviewed may also cause a "
-"significant delay in the review of your next update."
-msgstr "이미 심사가 끝난 버전을 삭제하면 다음 업데이트 심사가 상당히 지연될 수 있습니다."
-
-#: src/olympia/devhub/templates/devhub/versions/list.html:233
 msgid "Are you sure you wish to delete this version?"
 msgstr "정말 이 버전을 삭제하겠습니까?"
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:238
+#: src/olympia/devhub/templates/devhub/versions/list.html:235
 msgid "Delete Version"
 msgstr "버전 삭제"
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:240
+#: src/olympia/devhub/templates/devhub/versions/list.html:237
 msgid "Disable Version"
 msgstr "버전 사용 불가 상태 만들기"
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:247
+#: src/olympia/devhub/templates/devhub/versions/list.html:244
 msgid "Add a new Version"
 msgstr "새 버전 추가"
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:249
+#: src/olympia/devhub/templates/devhub/versions/list.html:246
 msgid "Add Version"
 msgstr "버전 추가"
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:256
-#: src/olympia/devhub/templates/devhub/versions/list.html:274
+#: src/olympia/devhub/templates/devhub/versions/list.html:253 src/olympia/devhub/templates/devhub/versions/list.html:279
 msgid "Hide Add-on"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:259
-msgid ""
-"Hiding your add-on will prevent it from appearing anywhere in our gallery "
-"and will stop users from receiving automatic updates."
+#: src/olympia/devhub/templates/devhub/versions/list.html:256
+msgid "Hiding your add-on will prevent it from appearing anywhere in our gallery and will stop users from receiving automatic updates."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:265
+#: src/olympia/devhub/templates/devhub/versions/list.html:263
+msgid "The files awaiting review will be disabled and you will need to upload new versions."
+msgstr ""
+
+#: src/olympia/devhub/templates/devhub/versions/list.html:270
 msgid "Are you sure you wish to hide your add-on?"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:286
-#: src/olympia/devhub/templates/devhub/versions/list.html:315
+#: src/olympia/devhub/templates/devhub/versions/list.html:291 src/olympia/devhub/templates/devhub/versions/list.html:313
 msgid "Unlist Add-on"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:289
+#: src/olympia/devhub/templates/devhub/versions/list.html:294
 #, python-format
 msgid ""
-"Unlisting your add-on will make it (and each of its versions/files) "
-"invisible on this website. It won't show up in searches, won't have a public"
-" facing page, and won't be updated automatically for current users.  It is "
-"recommended for unlisted add-ons to provide a custom <a "
-"href=\"%(update_url)s\" target=\"_blank\">updateURL</a> in their manifest "
-"file for automatic updates."
+"Unlisting your add-on will make it (and each of its versions/files) invisible on this website. It won't show up in searches, won't have a public facing page, and won't be updated automatically for "
+"current users. It is recommended for unlisted add-ons to provide a custom <a href=\"%(update_url)s\" target=\"_blank\">updateURL</a> in their manifest file for automatic updates."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:299
-#, python-format
-msgid ""
-"Switching add-ons to unlisted is currently in an open beta. Please <a "
-"href=\"%(url)s\" target=\"_blank\">report any bugs</a> that you encounter."
-msgstr ""
-
-#: src/olympia/devhub/templates/devhub/versions/list.html:305
+#: src/olympia/devhub/templates/devhub/versions/list.html:303
 msgid "Unlisting an add-on is irreversible!"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:305
+#: src/olympia/devhub/templates/devhub/versions/list.html:303
 msgid "An unlisted add-on cannot be switched to be listed."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:307
+#: src/olympia/devhub/templates/devhub/versions/list.html:305
 msgid "Are you sure you wish to unlist your add-on?"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:330
-msgid ""
-"Canceling your review request will leave your add-on as preliminarily "
-"reviewed."
+#: src/olympia/devhub/templates/devhub/versions/list.html:328
+msgid "Canceling your review request will leave your add-on as preliminarily reviewed."
 msgstr "심사 요청을 취소하면 부가 기능이 예비 심사 완료 상태가 아니게 됩니다."
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:335
-msgid ""
-"Canceling your review request will mark your add-on incomplete. If you do "
-"not complete your add-on after several days by re-requesting review, it will"
-" be deleted."
-msgstr ""
-"심사 요청을 취소하면 부가 기능이 미완료 상태로 표시됩니다. 심사 재요청을 몇일 내로 하지 않으면 이 부가 기능은 삭제됩니다."
+#: src/olympia/devhub/templates/devhub/versions/list.html:333
+msgid "Canceling your review request will mark your add-on incomplete. If you do not complete your add-on after several days by re-requesting review, it will be deleted."
+msgstr "심사 요청을 취소하면 부가 기능이 미완료 상태로 표시됩니다. 심사 재요청을 몇일 내로 하지 않으면 이 부가 기능은 삭제됩니다."
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:343
+#: src/olympia/devhub/templates/devhub/versions/list.html:341
 msgid "Are you sure you wish to cancel your review request?"
 msgstr "정말 심사 요청을 취소하시겠습니까?"
 
@@ -8597,14 +6873,11 @@ msgid "Translate content on the web from and into over 40 languages."
 msgstr "웹사이트는 40개국어 이상으로 번역되어 제공되고 있습니다."
 
 #: src/olympia/discovery/modules.py:171
-msgid ""
-"Easily connect to your social networks, and share or comment on the page "
-"you're visiting."
+msgid "Easily connect to your social networks, and share or comment on the page you're visiting."
 msgstr "방문한 웹페이지 상에서 간편하게 소셜 네트워크 접속, 공유, 코멘트 작성등을 하실 수 있습니다."
 
 #: src/olympia/discovery/modules.py:173
-msgid ""
-"A quick view to compare prices when you shop online or search for flights."
+msgid "A quick view to compare prices when you shop online or search for flights."
 msgstr "온라인 쇼핑몰이나 항공 예약시 가격을 빠르게 비교해 볼 수 있습니다."
 
 #: src/olympia/discovery/modules.py:183
@@ -8648,9 +6921,7 @@ msgid "Add-ons that help you on your travels!"
 msgstr "여행을 도와주는 부가 기능입니다!"
 
 #: src/olympia/discovery/modules.py:226
-msgid ""
-"Displays a country flag depicting the location of the current website's "
-"server and more."
+msgid "Displays a country flag depicting the location of the current website's server and more."
 msgstr "현재 웹사이트 서버가 있는 곳을 국기로 표시하고 그 외 여러 정보를 보여줍니다."
 
 #: src/olympia/discovery/modules.py:228
@@ -8658,9 +6929,7 @@ msgid "FoxClocks let you keep an eye on the time around the world."
 msgstr "FoxClocks는 세계 각지의 시간을 알려줍니다."
 
 #: src/olympia/discovery/modules.py:230
-msgid ""
-"Automatically get the lowest price when you shop online or search for "
-"flights."
+msgid "Automatically get the lowest price when you shop online or search for flights."
 msgstr "온라인 쇼핑이나 비행기 티켓 구입시 자동으로 최저가를 찾아줍니다."
 
 #: src/olympia/discovery/modules.py:240
@@ -8700,12 +6969,8 @@ msgid "Put a Theme on It!"
 msgstr "테마를 입혀보세요!"
 
 #: src/olympia/discovery/modules.py:281
-msgid ""
-"Visit addons.mozilla.org from Firefox for Android and dress up your mobile "
-"browser to match your style, mood, or the season."
-msgstr ""
-"안드로이드용 Firefox로 addons.mozilla.org에 접속해 모바일 브라우저를 나만의 스타일, 분위기, 또는 계절에 맞게 "
-"바꿔보세요."
+msgid "Visit addons.mozilla.org from Firefox for Android and dress up your mobile browser to match your style, mood, or the season."
+msgstr "안드로이드용 Firefox로 addons.mozilla.org에 접속해 모바일 브라우저를 나만의 스타일, 분위기, 또는 계절에 맞게 바꿔보세요."
 
 #: src/olympia/discovery/modules.py:290
 msgid "Get up and move!"
@@ -8732,9 +6997,7 @@ msgid "Protect your privacy online with the add-ons in this collection."
 msgstr "이 모음집의 부가 기능만 있으면 개인 정보를 온라인 환경에서 보호할 수 있습니다."
 
 #: src/olympia/discovery/modules.py:342
-msgid ""
-"Great add-ons for work, fun, privacy, productivity&hellip; just about "
-"anything!"
+msgid "Great add-ons for work, fun, privacy, productivity&hellip; just about anything!"
 msgstr "업무, 오락, 개인 정보 보호, 생산성&hellip; 그냥 모든 면에서 전부 훌륭한 부가 기능들입니다!"
 
 #: src/olympia/discovery/modules.py:350
@@ -8755,20 +7018,14 @@ msgstr "부가 기능이란?"
 
 #: src/olympia/discovery/templates/discovery/pane.html:28
 #, python-format
-msgid ""
-"Add-ons are applications that let you personalize %(app)s with extra "
-"functionality or style. Try a time-saving sidebar, a weather notifier, or a "
-"themed look to make %(app)s your own."
-msgstr ""
-"부가 기능이란 %(app)s에 추가적인 기능이나 외형을 추가해서 개인화를 도와주는 애플리케이션을 말합니다. 시간을 절약시켜주는 사이드바,"
-" 날씨 알리미를 깔아 보시거나 테마를 통해 자신만의 %(app)s 룩을 만들어 보세요."
+msgid "Add-ons are applications that let you personalize %(app)s with extra functionality or style. Try a time-saving sidebar, a weather notifier, or a themed look to make %(app)s your own."
+msgstr "부가 기능이란 %(app)s에 추가적인 기능이나 외형을 추가해서 개인화를 도와주는 애플리케이션을 말합니다. 시간을 절약시켜주는 사이드바, 날씨 알리미를 깔아 보시거나 테마를 통해 자신만의 %(app)s 룩을 만들어 보세요."
 
 #: src/olympia/discovery/templates/discovery/pane.html:62
 msgid "Learn More About Add-ons"
 msgstr "부가 기능에 대해 더 알아보기"
 
-#: src/olympia/discovery/templates/discovery/pane.html:66
-#: src/olympia/discovery/templates/discovery/pane.html:73
+#: src/olympia/discovery/templates/discovery/pane.html:66 src/olympia/discovery/templates/discovery/pane.html:73
 msgid "See all"
 msgstr "전부 보기"
 
@@ -8799,9 +7056,7 @@ msgstr "{0}님, 안녕하세요"
 
 #: src/olympia/discovery/templates/discovery/pane_account.html:17
 #, python-format
-msgid ""
-"Thanks for using %(app)s and supporting <a href=\"%(url)s\">Mozilla's "
-"mission</a>!"
+msgid "Thanks for using %(app)s and supporting <a href=\"%(url)s\">Mozilla's mission</a>!"
 msgstr "%(app)s를 사용하시고 <a href=\"%(url)s\">Mozilla의 사명</a> 구현도 지원해 주신데에 감사드립니다!"
 
 #: src/olympia/discovery/templates/discovery/pane_account.html:23
@@ -8826,13 +7081,8 @@ msgstr "계속해서 부가 기능을 받아보세요"
 
 #: src/olympia/discovery/templates/discovery/modules/go-mobile.html:8
 #, python-format
-msgid ""
-"Visit <a href=\"%(url)s\">firefox.com/m</a> to get Firefox on your phone and"
-" personalize your browser anytime, anywhere. Easily discover and install "
-"add-ons from the mobile Add-ons Manager."
-msgstr ""
-"스마트폰에서 <a href=\"%(url)s\">firefox.com/m</a> 주소에 들어가 Firefox를 받으시고 브라우저를 언제 "
-"어디서든 개인화해 보세요. 모바일 부가 기능 관리자를 통해 부가 기능을 쉽게 검색하고 설치할 수 있습니다."
+msgid "Visit <a href=\"%(url)s\">firefox.com/m</a> to get Firefox on your phone and personalize your browser anytime, anywhere. Easily discover and install add-ons from the mobile Add-ons Manager."
+msgstr "스마트폰에서 <a href=\"%(url)s\">firefox.com/m</a> 주소에 들어가 Firefox를 받으시고 브라우저를 언제 어디서든 개인화해 보세요. 모바일 부가 기능 관리자를 통해 부가 기능을 쉽게 검색하고 설치할 수 있습니다."
 
 #: src/olympia/discovery/templates/discovery/modules/go-mobile.html:13
 msgid "Get Mobile Add-ons"
@@ -8847,15 +7097,11 @@ msgid "Find great add-ons to help you with all your holiday shopping needs."
 msgstr "명절 기간동안 쇼핑을 도와주는 훌륭한 부가 기능들을 찾아봅시다."
 
 #: src/olympia/discovery/templates/discovery/modules/holiday.html:13
-msgid ""
-"Install the Amazon Browser Apps and receive special Amazon features right at"
-" your fingertips."
+msgid "Install the Amazon Browser Apps and receive special Amazon features right at your fingertips."
 msgstr "Amazon 브라우저 앱을 설치하고 손 끝에서 특별한 Amazon 기능을 즐겨봅시다."
 
 #: src/olympia/discovery/templates/discovery/modules/holiday.html:22
-msgid ""
-"Keep an eye on your eBay activity wherever you are on the web when you "
-"install the eBay Sidebar for Firefox."
+msgid "Keep an eye on your eBay activity wherever you are on the web when you install the eBay Sidebar for Firefox."
 msgstr "Firefox용 eBay 사이드바를 설치하면 어느 웹사이트에 있든 eBay를 주시할 수 있습니다."
 
 #: src/olympia/discovery/templates/discovery/modules/holiday.html:31
@@ -8933,19 +7179,19 @@ msgstr "부가 기능, 편집자 내지는 코멘트"
 msgid "Search by add-on name / author email"
 msgstr "검색 (부가 기능 이름 / 제작자 이메일)"
 
-#: src/olympia/editors/forms.py:103
+#: src/olympia/editors/forms.py:103 src/olympia/editors/forms.py:244 src/olympia/editors/forms.py:257
 msgid "yes"
 msgstr "예"
 
-#: src/olympia/editors/forms.py:104
+#: src/olympia/editors/forms.py:104 src/olympia/editors/forms.py:244 src/olympia/editors/forms.py:257
 msgid "no"
 msgstr "아니오"
 
-#: src/olympia/editors/forms.py:105
+#: src/olympia/editors/forms.py:105 src/olympia/editors/forms.py:245
 msgid "Admin Flag"
 msgstr "관리자 표시"
 
-#: src/olympia/editors/forms.py:113
+#: src/olympia/editors/forms.py:113 src/olympia/editors/forms.py:253
 msgid "Max. Version"
 msgstr "최대 버전"
 
@@ -8957,57 +7203,59 @@ msgstr "부가 기능 제출 시기"
 msgid "Add-on Types"
 msgstr "부가 기능 종류"
 
-#: src/olympia/editors/forms.py:126 src/olympia/editors/helpers.py:267
+#: src/olympia/editors/forms.py:126 src/olympia/editors/helpers.py:279
 msgid "Platforms"
 msgstr "플랫폼"
 
+#: src/olympia/editors/forms.py:237
+msgid "Search by add-on name / author email / guid"
+msgstr ""
+
 #. L10n: 0 = platform, 1 = filename, 2 = status message
-#: src/olympia/editors/forms.py:238
+#: src/olympia/editors/forms.py:342
 #, python-format
 msgid "<strong>%s</strong> &middot; %s &middot; %s"
 msgstr "<strong>%s</strong> &middot; %s &middot; %s"
 
-#: src/olympia/editors/forms.py:252
+#: src/olympia/editors/forms.py:356
 msgid "Comments:"
 msgstr "코멘트:"
 
-#: src/olympia/editors/forms.py:256
+#: src/olympia/editors/forms.py:360
 msgid "Operating systems:"
 msgstr "운영 체제:"
 
-#: src/olympia/editors/forms.py:258
+#: src/olympia/editors/forms.py:362
 msgid "Applications:"
 msgstr "애플리케이션:"
 
-#: src/olympia/editors/forms.py:260
-msgid ""
-"Notify me the next time this add-on is updated. (Subsequent updates will not"
-" generate an email)"
+#: src/olympia/editors/forms.py:364
+msgid "Notify me the next time this add-on is updated. (Subsequent updates will not generate an email)"
 msgstr "다음에 이 부가 기능이 업데이트 되면 알립니다. (이후 업데이트는 이메일을 생성하지 않을 것입니다)"
 
-#: src/olympia/editors/forms.py:265
+#: src/olympia/editors/forms.py:369
 msgid "Clear Admin Review Flag"
 msgstr "관리자 심사 플래그 지우기"
 
-#: src/olympia/editors/forms.py:267
+#: src/olympia/editors/forms.py:371
 msgid "Clear more info requested flag"
 msgstr ""
 
-#: src/olympia/editors/forms.py:281
+#: src/olympia/editors/forms.py:385
 msgid "Choose a canned response..."
 msgstr "자동 응답 메시지를 선택해 주세요..."
 
 #. L10n: Description of what can be searched for.
-#: src/olympia/editors/forms.py:324
+#: src/olympia/editors/forms.py:423
 msgid "theme name"
 msgstr "테마 이름"
 
-#: src/olympia/editors/forms.py:350
+#: src/olympia/editors/forms.py:449
 msgid "Someone else is reviewing this theme."
 msgstr "다른 사람이 이 테마를 심사중입니다."
 
 #. L10n: Description of what can be searched for.
-#: src/olympia/editors/forms.py:447
+#: src/olympia/editors/forms.py:546
 msgid "app, reviewer, or comment"
 msgstr "앱, 심사원, 코멘트"
 
@@ -9023,268 +7271,265 @@ msgstr "예비 심사 대기중"
 msgid "Rejected or Unreviewed"
 msgstr "거부 또는 미심사"
 
-#: src/olympia/editors/helpers.py:123 src/olympia/editors/helpers.py:136
+#: src/olympia/editors/helpers.py:125 src/olympia/editors/helpers.py:138
 msgid "Queue"
 msgstr "대기열"
 
-#: src/olympia/editors/helpers.py:124
-#: src/olympia/editors/templates/editors/base.html:50
-#: src/olympia/editors/templates/editors/base.html:65
+#: src/olympia/editors/helpers.py:126 src/olympia/editors/templates/editors/base.html:50 src/olympia/editors/templates/editors/base.html:65
 msgid "Pending Updates"
 msgstr "업데이트 대기"
 
-#: src/olympia/editors/helpers.py:125
-#: src/olympia/editors/templates/editors/base.html:48
-#: src/olympia/editors/templates/editors/base.html:63
+#: src/olympia/editors/helpers.py:127 src/olympia/editors/templates/editors/base.html:48 src/olympia/editors/templates/editors/base.html:63
 msgid "Full Reviews"
 msgstr "전체 심사"
 
-#: src/olympia/editors/helpers.py:126
-#: src/olympia/editors/templates/editors/base.html:52
-#: src/olympia/editors/templates/editors/base.html:67
+#: src/olympia/editors/helpers.py:128 src/olympia/editors/templates/editors/base.html:52 src/olympia/editors/templates/editors/base.html:67
 msgid "Preliminary Reviews"
 msgstr "예비 심사"
 
-#: src/olympia/editors/helpers.py:127
-#: src/olympia/editors/templates/editors/base.html:54
+#: src/olympia/editors/helpers.py:129 src/olympia/editors/templates/editors/base.html:54
 msgid "Moderated Reviews"
 msgstr "심사 조정중"
 
-#: src/olympia/editors/helpers.py:128
-#: src/olympia/editors/templates/editors/base.html:46
+#: src/olympia/editors/helpers.py:130 src/olympia/editors/templates/editors/base.html:46
 msgid "Fast Track"
 msgstr "고속 심사"
 
-#: src/olympia/editors/helpers.py:130
+#: src/olympia/editors/helpers.py:132
 msgid "Pending Themes"
 msgstr "대기중인 테마"
 
-#: src/olympia/editors/helpers.py:131
-#: src/olympia/editors/templates/editors/themes/queue.html:4
+#: src/olympia/editors/helpers.py:133 src/olympia/editors/templates/editors/themes/queue.html:4
 msgid "Flagged Themes"
 msgstr "표시된 테마"
 
-#: src/olympia/editors/helpers.py:132
+#: src/olympia/editors/helpers.py:134
 msgid "Update Themes"
 msgstr "테마 업데이트"
 
-#: src/olympia/editors/helpers.py:137
+#: src/olympia/editors/helpers.py:139
 msgid "Unlisted Pending Updates"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:138
+#: src/olympia/editors/helpers.py:140
 msgid "Unlisted Full Reviews"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:139
+#: src/olympia/editors/helpers.py:141
 msgid "Unlisted Preliminary Reviews"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:170
+#: src/olympia/editors/helpers.py:142
+msgid "Unlisted All Add-ons"
+msgstr ""
+
+#: src/olympia/editors/helpers.py:173
 msgid "Fast Track ({0})"
 msgid_plural "Fast Track ({0})"
 msgstr[0] "고속 심사 ({0})"
+msgstr[1] ""
 
-#: src/olympia/editors/helpers.py:175
+#: src/olympia/editors/helpers.py:178
 msgid "Full Review ({0})"
 msgid_plural "Full Reviews ({0})"
 msgstr[0] "전체 심사 ({0})"
+msgstr[1] ""
 
-#: src/olympia/editors/helpers.py:180
+#: src/olympia/editors/helpers.py:183
 msgid "Pending Update ({0})"
 msgid_plural "Pending Updates ({0})"
 msgstr[0] "업데이트 대기 ({0})"
+msgstr[1] ""
 
-#: src/olympia/editors/helpers.py:185
+#: src/olympia/editors/helpers.py:188
 msgid "Preliminary Review ({0})"
 msgid_plural "Preliminary Reviews ({0})"
 msgstr[0] "예비 심사 ({0})"
+msgstr[1] ""
 
-#: src/olympia/editors/helpers.py:190
+#: src/olympia/editors/helpers.py:193
 msgid "Moderated Review ({0})"
 msgid_plural "Moderated Reviews ({0})"
 msgstr[0] "심사 조정 ({0})"
+msgstr[1] ""
 
-#: src/olympia/editors/helpers.py:196
+#: src/olympia/editors/helpers.py:199
 msgid "Unlisted Full Review ({0})"
 msgid_plural "Unlisted Full Reviews ({0})"
 msgstr[0] ""
+msgstr[1] ""
 
-#: src/olympia/editors/helpers.py:201
+#: src/olympia/editors/helpers.py:204
 msgid "Unlisted Pending Update ({0})"
 msgid_plural "Unlisted Pending Updates ({0})"
 msgstr[0] ""
+msgstr[1] ""
 
-#: src/olympia/editors/helpers.py:206
+#: src/olympia/editors/helpers.py:209
 msgid "Unlisted Preliminary Review ({0})"
 msgid_plural "Unlisted Preliminary Reviews ({0})"
 msgstr[0] ""
+msgstr[1] ""
 
-#: src/olympia/editors/helpers.py:261
-msgid "Addon"
-msgstr "부가 기능"
+#: src/olympia/editors/helpers.py:214
+msgid "Unlisted All Add-ons ({0})"
+msgid_plural "Unlisted All Add-ons ({0})"
+msgstr[0] ""
+msgstr[1] ""
 
-#: src/olympia/editors/helpers.py:262
+#: src/olympia/editors/helpers.py:274
 msgid "Type"
 msgstr "종류"
 
-#: src/olympia/editors/helpers.py:263
+#: src/olympia/editors/helpers.py:275
 msgid "Waiting Time"
 msgstr "대기 시간"
 
-#: src/olympia/editors/helpers.py:264
-#: src/olympia/editors/templates/editors/review.html:285
+#: src/olympia/editors/helpers.py:276 src/olympia/editors/templates/editors/review.html:285
 msgid "Flags"
 msgstr "표시"
 
-#: src/olympia/editors/helpers.py:265
+#: src/olympia/editors/helpers.py:277
 msgid "Applications"
 msgstr "애플리케이션"
 
-#: src/olympia/editors/helpers.py:270
+#: src/olympia/editors/helpers.py:282
 msgid "Additional"
 msgstr "추가 사항"
 
-#: src/olympia/editors/helpers.py:285
+#: src/olympia/editors/helpers.py:302
 msgid "Site Specific"
 msgstr "사이트 기반"
 
-#: src/olympia/editors/helpers.py:287
+#: src/olympia/editors/helpers.py:304
 msgid "Requires External Software"
 msgstr "외부 소프트웨어 필요"
 
-#: src/olympia/editors/helpers.py:289
+#: src/olympia/editors/helpers.py:306
 msgid "Binary Components"
 msgstr "이진 컴포넌트"
 
-#: src/olympia/editors/helpers.py:313
+#: src/olympia/editors/helpers.py:339
 msgid "moments ago"
 msgstr "방금"
 
 #. L10n: first argument is number of minutes
-#: src/olympia/editors/helpers.py:316
+#: src/olympia/editors/helpers.py:342
 msgid "{0} minute"
 msgid_plural "{0} minutes"
 msgstr[0] "{0} 분"
+msgstr[1] ""
 
 #. L10n: first argument is number of hours
-#: src/olympia/editors/helpers.py:320
+#: src/olympia/editors/helpers.py:346
 msgid "{0} hour"
 msgid_plural "{0} hours"
 msgstr[0] "{0} 시간"
+msgstr[1] ""
 
 #. L10n: first argument is number of days
-#: src/olympia/editors/helpers.py:324
+#: src/olympia/editors/helpers.py:350
 msgid "{0} day"
 msgid_plural "{0} days"
 msgstr[0] "{0} 일"
+msgstr[1] ""
 
-#: src/olympia/editors/helpers.py:488
+#: src/olympia/editors/helpers.py:364
+msgid "Last Review"
+msgstr ""
+
+#: src/olympia/editors/helpers.py:366
+msgid "Last Update"
+msgstr ""
+
+#: src/olympia/editors/helpers.py:387
+msgid "No Reviews"
+msgstr ""
+
+#: src/olympia/editors/helpers.py:561
 msgid "Push to public"
 msgstr "공개로 전환"
 
-#: src/olympia/editors/helpers.py:490
+#: src/olympia/editors/helpers.py:563
 msgid "Grant full review"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:505
+#: src/olympia/editors/helpers.py:578
 msgid "Request more information"
 msgstr "추가 정보 요구"
 
-#: src/olympia/editors/helpers.py:508
+#: src/olympia/editors/helpers.py:581
 msgid "Request super-review"
 msgstr "상급 심사 요구"
 
-#: src/olympia/editors/helpers.py:519
+#: src/olympia/editors/helpers.py:592
 msgid "Grant preliminary review"
 msgstr "예비 심사 등급 부여"
 
-#: src/olympia/editors/helpers.py:520
+#: src/olympia/editors/helpers.py:593
 msgid "This will mark the files as preliminarily reviewed."
 msgstr "이 작업은 파일에 예비 심사 등급을 부여하게 됩니다."
 
-#: src/olympia/editors/helpers.py:522
-msgid ""
-"Use this form to request more information from the author. They will receive"
-" an email and be able to answer here. You will be notified by email when "
-"they reply."
-msgstr ""
-"제작자에게 추가 정보를 요청하려면 다음의 양식을 기입해 주세요. 제작자들은 이메일을 받은 후 이곳에 답변을 적을 수 있게 됩니다. "
-"제작자의 답변이 오면 이메일로 알림 메시지를 받게 됩니다."
+#: src/olympia/editors/helpers.py:595
+msgid "Use this form to request more information from the author. They will receive an email and be able to answer here. You will be notified by email when they reply."
+msgstr "제작자에게 추가 정보를 요청하려면 다음의 양식을 기입해 주세요. 제작자들은 이메일을 받은 후 이곳에 답변을 적을 수 있게 됩니다. 제작자의 답변이 오면 이메일로 알림 메시지를 받게 됩니다."
 
-#: src/olympia/editors/helpers.py:526
+#: src/olympia/editors/helpers.py:599
 msgid ""
-"If you have concerns about this add-on's security, copyright issues, or "
-"other concerns that an administrator should look into, enter your comments "
-"in the area below. They will be sent to administrators, not the author."
-msgstr ""
-"이 부가 기능이 보안, 저작권 등 관리자가 검토해야 한다고 생각되시면 아래에 코멘트를 입력해 주세요. 이 코멘트는 제작자가 아닌, "
-"관리자에게만 전송될 것입니다."
+"If you have concerns about this add-on's security, copyright issues, or other concerns that an administrator should look into, enter your comments in the area below. They will be sent to "
+"administrators, not the author."
+msgstr "이 부가 기능이 보안, 저작권 등 관리자가 검토해야 한다고 생각되시면 아래에 코멘트를 입력해 주세요. 이 코멘트는 제작자가 아닌, 관리자에게만 전송될 것입니다."
 
-#: src/olympia/editors/helpers.py:532
+#: src/olympia/editors/helpers.py:605
 msgid "This will reject the add-on and remove it from the review queue."
 msgstr "부가 기능 심사를 거부하며 심사 대기열에서 삭제합니다."
 
-#: src/olympia/editors/helpers.py:534
+#: src/olympia/editors/helpers.py:607
 msgid "Make a comment on this version. The author won't be able to see this."
 msgstr "이 버전에 코멘트를 남겨주세요. 제작자는 코멘트를 볼 수 없습니다."
 
-#: src/olympia/editors/helpers.py:538
+#: src/olympia/editors/helpers.py:611
 msgid "This will reject the files and remove them from the review queue."
 msgstr "파일들의 심사를 거부하며 심사 대기열에서 삭제합니다."
 
-#: src/olympia/editors/helpers.py:542
-msgid ""
-"This will mark the add-on as preliminarily reviewed. Future versions will "
-"undergo preliminary review."
+#: src/olympia/editors/helpers.py:615
+msgid "This will mark the add-on as preliminarily reviewed. Future versions will undergo preliminary review."
 msgstr "부가 기능을 예비 심사 완료로 표시합니다. 향후 버전도 예비 심사를 받아야 합니다."
 
-#: src/olympia/editors/helpers.py:547
-msgid ""
-"This will mark the files as preliminarily reviewed. Future versions will "
-"undergo preliminary review."
+#: src/olympia/editors/helpers.py:620
+msgid "This will mark the files as preliminarily reviewed. Future versions will undergo preliminary review."
 msgstr "파일들을 예비 심사 완료로 표시합니다. 향후 버전도 예비 심사를 받아야 합니다."
 
-#: src/olympia/editors/helpers.py:552
+#: src/olympia/editors/helpers.py:625
 msgid "Retain preliminary review"
 msgstr "예비 심사 등급 유지"
 
-#: src/olympia/editors/helpers.py:553
-msgid ""
-"This will retain the add-on as preliminarily reviewed. Future versions will "
-"undergo preliminary review."
+#: src/olympia/editors/helpers.py:626
+msgid "This will retain the add-on as preliminarily reviewed. Future versions will undergo preliminary review."
 msgstr "부가 기능을 예비 심사 완료 상태로 유지합니다. 향후 버전도 예비 심사를 받아야 합니다."
 
-#: src/olympia/editors/helpers.py:558
-msgid ""
-"This will approve a sandboxed version of a public add-on to appear on the "
-"public side."
+#: src/olympia/editors/helpers.py:631
+msgid "This will approve a sandboxed version of a public add-on to appear on the public side."
 msgstr "공개 이전 샌드박스 버전의 부가 기능을 공개 상태로 승인합니다."
 
-#: src/olympia/editors/helpers.py:561
-msgid ""
-"This will reject a version of a public add-on and remove it from the queue."
+#: src/olympia/editors/helpers.py:634
+msgid "This will reject a version of a public add-on and remove it from the queue."
 msgstr "공개 부가 기능 버전을 거부하고 대기열에서 해당 부가 기능을 삭제합니다."
 
-#: src/olympia/editors/helpers.py:564
-msgid ""
-"This will mark the add-on and its most recent version and files as public. "
-"Future versions will go into the sandbox until they are reviewed by an "
-"editor."
-msgstr ""
-"이 명령을 사용하면 부가 기능의 최신 버전과 파일을 공개 버전으로 승급하게 됩니다. 이후 등록되는 버전의 경우 편집자의 심사가 있기 "
-"전까진 샌드박스로 보내지게 될 것입니다."
-
 #: src/olympia/editors/helpers.py:637
+msgid "This will mark the add-on and its most recent version and files as public. Future versions will go into the sandbox until they are reviewed by an editor."
+msgstr "이 명령을 사용하면 부가 기능의 최신 버전과 파일을 공개 버전으로 승급하게 됩니다. 이후 등록되는 버전의 경우 편집자의 심사가 있기 전까진 샌드박스로 보내지게 될 것입니다."
+
+#: src/olympia/editors/helpers.py:714
 msgid "add-on"
 msgstr "부가 기능"
 
-#: src/olympia/editors/helpers.py:940 src/olympia/editors/helpers.py:960
+#: src/olympia/editors/helpers.py:1020 src/olympia/editors/helpers.py:1040
 msgid "Flagged"
 msgstr "표시됨"
 
 # 85%
-#: src/olympia/editors/helpers.py:944 src/olympia/editors/helpers.py:963
+#: src/olympia/editors/helpers.py:1024 src/olympia/editors/helpers.py:1043
 msgid "Updates"
 msgstr "업데이트"
 
@@ -9336,75 +7581,70 @@ msgstr "제출된 테마가 심사 상태로 표시됐습니다"
 msgid "A question about your Theme submission"
 msgstr "제출된 테마에 대한 질문사항"
 
-#: src/olympia/editors/views.py:144
+#: src/olympia/editors/views.py:146
 msgid "New Add-ons (Under 5 days)"
 msgstr "신규 부가 기능 (최근 5일 이내)"
 
-#: src/olympia/editors/views.py:145
+#: src/olympia/editors/views.py:147
 msgid "Passable (5 to 10 days)"
 msgstr "통과 가능 (5~10일 이내)"
 
-#: src/olympia/editors/views.py:146
+#: src/olympia/editors/views.py:148
 msgid "Overdue (Over 10 days)"
 msgstr "기한 초과 (10일 초과)"
 
-#: src/olympia/editors/views.py:532
+#: src/olympia/editors/views.py:539
 msgid "An unknown error occurred"
 msgstr "알 수 없는 오류 발생"
 
-#: src/olympia/editors/views.py:587
+#: src/olympia/editors/views.py:592
 msgid "Self-reviews are not allowed."
 msgstr "자신의 부가 기능은 심사할 수 없습니다."
 
-#: src/olympia/editors/views.py:609
+#: src/olympia/editors/views.py:613
 msgid "Review successfully processed."
 msgstr "심사 작업을 진행 합니다."
 
-#: src/olympia/editors/views.py:807
+#: src/olympia/editors/views.py:812
 msgid "was approved"
 msgstr "이(가) 승인되었습니다"
 
-#: src/olympia/editors/views.py:808
+#: src/olympia/editors/views.py:813
 msgid "given preliminary review"
 msgstr "이(가) 예비 심사 등급이 주어졌습니다"
 
-#: src/olympia/editors/views.py:809
+#: src/olympia/editors/views.py:814
 msgid "rejected"
 msgstr "이(가) 심사 거부되었습니다"
 
-#: src/olympia/editors/views.py:810
+#: src/olympia/editors/views.py:815
 msgctxt "editors_review_history_nominated_adminreview"
 msgid "escalated"
 msgstr "이(가) 검토 대상이 되었습니다"
 
 # 79%
 # 100%
-#: src/olympia/editors/views.py:812
+#: src/olympia/editors/views.py:817
 msgid "needs more information"
 msgstr "추가 정보 요구"
 
-#: src/olympia/editors/views.py:813
+#: src/olympia/editors/views.py:818
 msgid "needs super review"
 msgstr "상급 심사 필요"
 
-#: src/olympia/editors/views.py:814
+#: src/olympia/editors/views.py:819
 msgid "commented"
 msgstr ""
 
 #: src/olympia/editors/views_themes.py:326
 msgid "{0} theme review successfully processed (+{1} points, {2} total)."
-msgid_plural ""
-"{0} theme reviews successfully processed (+{1} points, {2} total)."
+msgid_plural "{0} theme reviews successfully processed (+{1} points, {2} total)."
 msgstr[0] "테마 심사 {0}건이 처리되었습니다. (+{1} 포인트, 총 {2}건)"
+msgstr[1] ""
 
 #: src/olympia/editors/views_themes.py:341
-msgid ""
-"Your theme locks have successfully been released. Other reviewers may now "
-"review those released themes. You may have to refresh the page to see the "
-"changes reflected in the table below."
-msgstr ""
-"테마 잠금 상태가 해제되었습니다. 이제 다른 심사원이 해금된 테마를 심사합니다. 본 페이지를 새로고침하면 아래 테이블에 변경 내역이 "
-"반영됩니다."
+msgid "Your theme locks have successfully been released. Other reviewers may now review those released themes. You may have to refresh the page to see the changes reflected in the table below."
+msgstr "테마 잠금 상태가 해제되었습니다. 이제 다른 심사원이 해금된 테마를 심사합니다. 본 페이지를 새로고침하면 아래 테이블에 변경 내역이 반영됩니다."
 
 #: src/olympia/editors/templates/editors/abuse_reports.html:4
 msgid "{addon} :: Abuse Reports"
@@ -9428,9 +7668,7 @@ msgstr "사용자: <i>익명</i> 날짜: %(date)s [%(ip_address)s]"
 msgid "Return to the Editor Tools homepage"
 msgstr "편집자 도구 대문으로 돌아가기"
 
-#: src/olympia/editors/templates/editors/base.html:43
-#: src/olympia/editors/templates/editors/themes/base.html:14
-#: src/olympia/editors/templates/editors/themes/base.html:28
+#: src/olympia/editors/templates/editors/base.html:43 src/olympia/editors/templates/editors/themes/base.html:14 src/olympia/editors/templates/editors/themes/base.html:28
 #: src/olympia/editors/templates/editors/themes/queue.html:25
 msgid "Queues"
 msgstr "대기열"
@@ -9439,73 +7677,53 @@ msgstr "대기열"
 msgid "Unlisted Queues"
 msgstr ""
 
-#: src/olympia/editors/templates/editors/base.html:72
-#: src/olympia/editors/templates/editors/performance.html:6
+#: src/olympia/editors/templates/editors/base.html:74 src/olympia/editors/templates/editors/performance.html:6
 msgid "Performance"
 msgstr "성능 향상"
 
-#: src/olympia/editors/templates/editors/base.html:75
-#: src/olympia/editors/templates/editors/themes/base.html:19
-#: src/olympia/editors/templates/editors/themes/base.html:38
+#: src/olympia/editors/templates/editors/base.html:77 src/olympia/editors/templates/editors/themes/base.html:19 src/olympia/editors/templates/editors/themes/base.html:38
 msgid "Logs"
 msgstr "기록"
 
-#: src/olympia/editors/templates/editors/base.html:78
-#: src/olympia/editors/templates/editors/reviewlog.html:4
-#: src/olympia/editors/templates/editors/reviewlog.html:27
+#: src/olympia/editors/templates/editors/base.html:80 src/olympia/editors/templates/editors/reviewlog.html:4 src/olympia/editors/templates/editors/reviewlog.html:27
 msgid "Add-on Review Log"
 msgstr "부가 기능 심사 기록"
 
 # 80%
 # 100%
-#: src/olympia/editors/templates/editors/base.html:80
-#: src/olympia/editors/templates/editors/eventlog.html:4
-#: src/olympia/editors/templates/editors/eventlog.html:8
+#: src/olympia/editors/templates/editors/base.html:82 src/olympia/editors/templates/editors/eventlog.html:4 src/olympia/editors/templates/editors/eventlog.html:8
 #: src/olympia/editors/templates/editors/eventlog_detail.html:4
 msgid "Moderated Review Log"
 msgstr "심사 조정 기록"
 
-#: src/olympia/editors/templates/editors/base.html:82
-#: src/olympia/editors/templates/editors/beta_signed_log.html:4
-#: src/olympia/editors/templates/editors/beta_signed_log.html:8
+#: src/olympia/editors/templates/editors/base.html:84 src/olympia/editors/templates/editors/beta_signed_log.html:4 src/olympia/editors/templates/editors/beta_signed_log.html:8
 msgid "Signed Beta Files Log"
 msgstr ""
 
-#: src/olympia/editors/templates/editors/base.html:87
-#: src/olympia/editors/templates/editors/includes/daily-message.html:4
+#: src/olympia/editors/templates/editors/base.html:89 src/olympia/editors/templates/editors/includes/daily-message.html:4
 msgid "Announcement"
 msgstr "알림"
 
 #. "Filter" is a button label (verb)
-#: src/olympia/editors/templates/editors/beta_signed_log.html:17
-#: src/olympia/editors/templates/editors/eventlog.html:24
-#: src/olympia/editors/templates/editors/reviewlog.html:21
-#: src/olympia/editors/templates/editors/themes/macros.html:45
-#: src/olympia/editors/templates/editors/themes/includes/logs_filter_deleted.html:12
+#: src/olympia/editors/templates/editors/beta_signed_log.html:17 src/olympia/editors/templates/editors/eventlog.html:24 src/olympia/editors/templates/editors/reviewlog.html:21
+#: src/olympia/editors/templates/editors/themes/macros.html:45 src/olympia/editors/templates/editors/themes/includes/logs_filter_deleted.html:12
 msgid "Filter"
 msgstr "필터"
 
-#: src/olympia/editors/templates/editors/beta_signed_log.html:23
-#: src/olympia/editors/templates/editors/eventlog.html:30
-#: src/olympia/editors/templates/editors/reviewlog.html:34
+#: src/olympia/editors/templates/editors/beta_signed_log.html:23 src/olympia/editors/templates/editors/eventlog.html:30 src/olympia/editors/templates/editors/reviewlog.html:34
 #: src/olympia/editors/templates/editors/themes/logs.html:16
 msgid "Date"
 msgstr "날짜"
 
-#: src/olympia/editors/templates/editors/beta_signed_log.html:24
-#: src/olympia/editors/templates/editors/eventlog.html:31
-#: src/olympia/editors/templates/editors/reviewlog.html:35
+#: src/olympia/editors/templates/editors/beta_signed_log.html:24 src/olympia/editors/templates/editors/eventlog.html:31 src/olympia/editors/templates/editors/reviewlog.html:35
 msgid "Event"
 msgstr "이벤트"
 
-#: src/olympia/editors/templates/editors/beta_signed_log.html:37
-#: src/olympia/editors/templates/editors/eventlog.html:44
-#: src/olympia/editors/templates/editors/home.html:180
+#: src/olympia/editors/templates/editors/beta_signed_log.html:37 src/olympia/editors/templates/editors/eventlog.html:44 src/olympia/editors/templates/editors/home.html:180
 msgid "More details."
 msgstr "보다 자세한 정보를 봅니다."
 
-#: src/olympia/editors/templates/editors/beta_signed_log.html:46
-#: src/olympia/editors/templates/editors/eventlog.html:53
+#: src/olympia/editors/templates/editors/beta_signed_log.html:46 src/olympia/editors/templates/editors/eventlog.html:53
 msgid "No events found for this period."
 msgstr "이 기간 동안엔 이벤트가 없습니다."
 
@@ -9543,6 +7761,7 @@ msgstr ""
 msgid "Full Review ({num})"
 msgid_plural "Full Reviews ({num})"
 msgstr[0] "전체 심사 ({num})"
+msgstr[1] ""
 
 # 86%
 # 100%
@@ -9550,6 +7769,7 @@ msgstr[0] "전체 심사 ({num})"
 msgid "Pending Update ({num})"
 msgid_plural "Pending Updates ({num})"
 msgstr[0] "업데이트 대기 ({num})"
+msgstr[1] ""
 
 # 88%
 # 100%
@@ -9557,22 +7777,21 @@ msgstr[0] "업데이트 대기 ({num})"
 msgid "Preliminary Review ({num})"
 msgid_plural "Preliminary Reviews ({num})"
 msgstr[0] "예비 심사 ({num})"
+msgstr[1] ""
 
-#: src/olympia/editors/templates/editors/home.html:36
-#: src/olympia/editors/templates/editors/home.html:86
+#: src/olympia/editors/templates/editors/home.html:36 src/olympia/editors/templates/editors/home.html:86
 msgid "Current waiting times:"
 msgstr "현재 대기 시간:"
 
 # 81%
 # 100%
-#: src/olympia/editors/templates/editors/home.html:44
-#: src/olympia/editors/templates/editors/home.html:94
+#: src/olympia/editors/templates/editors/home.html:44 src/olympia/editors/templates/editors/home.html:94
 msgid "{0} add-on"
 msgid_plural "{0} add-ons"
 msgstr[0] "부가 기능 {0}개"
+msgstr[1] ""
 
-#: src/olympia/editors/templates/editors/home.html:45
-#: src/olympia/editors/templates/editors/home.html:95
+#: src/olympia/editors/templates/editors/home.html:45 src/olympia/editors/templates/editors/home.html:95
 #, python-format
 msgid "{0}%%"
 msgstr ""
@@ -9581,25 +7800,25 @@ msgstr ""
 msgid "Unlisted Full Review ({num})"
 msgid_plural "Unlisted Full Reviews ({num})"
 msgstr[0] ""
+msgstr[1] ""
 
 #: src/olympia/editors/templates/editors/home.html:68
 msgid "Unlisted Pending Update ({num})"
 msgid_plural "Unlisted Pending Updates ({num})"
 msgstr[0] ""
+msgstr[1] ""
 
 #: src/olympia/editors/templates/editors/home.html:75
 msgid "Unlisted Preliminary Review ({num})"
 msgid_plural "Unlisted Preliminary Reviews ({num})"
 msgstr[0] ""
+msgstr[1] ""
 
-#: src/olympia/editors/templates/editors/home.html:109
-#: src/olympia/editors/templates/editors/performance.html:37
-#: src/olympia/editors/templates/editors/themes/home.html:54
+#: src/olympia/editors/templates/editors/home.html:109 src/olympia/editors/templates/editors/performance.html:37 src/olympia/editors/templates/editors/themes/home.html:54
 msgid "Total Reviews"
 msgstr "총 심사 수"
 
-#: src/olympia/editors/templates/editors/home.html:110
-#: src/olympia/editors/templates/editors/themes/home.html:55
+#: src/olympia/editors/templates/editors/home.html:110 src/olympia/editors/templates/editors/themes/home.html:55
 msgid "Reviews This Month"
 msgstr "이달의 심사"
 
@@ -9607,27 +7826,25 @@ msgstr "이달의 심사"
 msgid "New Editors"
 msgstr "새 편집자"
 
-#: src/olympia/editors/templates/editors/home.html:126
-#: src/olympia/editors/templates/editors/home.html:141
+#: src/olympia/editors/templates/editors/home.html:126 src/olympia/editors/templates/editors/home.html:141
 msgid "You're #{0} with {1} reviews"
 msgstr "당신은 {0}번이며 {1}개의 심사가 있습니다"
 
-#. num = number of reviews in the queue
 # 87%
 # 100%
+#. num = number of reviews in the queue
 #: src/olympia/editors/templates/editors/home.html:171
 msgid "Moderated Review ({num})"
 msgid_plural "Moderated Reviews ({num})"
 msgstr[0] "조정중인 심사 ({num})"
+msgstr[1] ""
 
-#: src/olympia/editors/templates/editors/leaderboard.html:3
-#: src/olympia/editors/templates/editors/includes/reviewers_score_bar.html:56
+#: src/olympia/editors/templates/editors/leaderboard.html:3 src/olympia/editors/templates/editors/includes/reviewers_score_bar.html:56
 msgid "Reviewer Leaderboard"
 msgstr "심사원 현황판"
 
 # 75%
-#: src/olympia/editors/templates/editors/leaderboard.html:18
-#: src/olympia/editors/templates/editors/performance.html:65
+#: src/olympia/editors/templates/editors/leaderboard.html:18 src/olympia/editors/templates/editors/performance.html:65
 msgid "No review points awarded yet."
 msgstr "아직 받은 평가 점수가 없습니다."
 
@@ -9647,8 +7864,7 @@ msgstr "오늘의 메시지"
 msgid "Update message of the day"
 msgstr "오늘의 메시지 업데이트"
 
-#: src/olympia/editors/templates/editors/motd.html:15
-#: src/olympia/editors/templates/editors/review.html:224
+#: src/olympia/editors/templates/editors/motd.html:15 src/olympia/editors/templates/editors/review.html:224
 msgid "Save"
 msgstr "저장"
 
@@ -9718,52 +7934,46 @@ msgstr "고급 검색"
 msgid "clear search"
 msgstr "검색 초기화"
 
-#: src/olympia/editors/templates/editors/queue.html:72
-#: src/olympia/editors/templates/editors/queue.html:122
+#: src/olympia/editors/templates/editors/queue.html:78 src/olympia/editors/templates/editors/queue.html:128
 msgid "Process Reviews"
 msgstr "심사 처리하기"
 
-#: src/olympia/editors/templates/editors/queue.html:80
+#: src/olympia/editors/templates/editors/queue.html:86
 msgid "Moderation actions:"
 msgstr "조정 행동:"
 
-#: src/olympia/editors/templates/editors/queue.html:90
+#: src/olympia/editors/templates/editors/queue.html:96
 #, python-format
 msgid "by %(user)s on %(date)s %(stars)s (%(locale)s)"
 msgstr "제작자: %(user)s 날짜: %(date)s %(stars)s (%(locale)s)"
 
-#: src/olympia/editors/templates/editors/queue.html:106
+#: src/olympia/editors/templates/editors/queue.html:112
 #, python-format
-msgid ""
-"<strong>%(reason)s</strong> <span class=\"light\">Flagged by %(user)s on "
-"%(date)s</span>"
-msgstr ""
-"<strong>%(reason)s</strong> <span class=\"light\">표시자: %(user)s 날짜: "
-"%(date)s</span>"
+msgid "<strong>%(reason)s</strong> <span class=\"light\">Flagged by %(user)s on %(date)s</span>"
+msgstr "<strong>%(reason)s</strong> <span class=\"light\">표시자: %(user)s 날짜: %(date)s</span>"
 
-#: src/olympia/editors/templates/editors/queue.html:119
+#: src/olympia/editors/templates/editors/queue.html:125
 msgid "All reviews have been moderated. Good work!"
 msgstr "모든 심사가 처리되었습니다. 수고하셨습니다!"
 
-#: src/olympia/editors/templates/editors/queue.html:161
+#: src/olympia/editors/templates/editors/queue.html:167
 msgid "Version Notes / Notes for Reviewer"
 msgstr "버전 기록서 / 심사원에게 남기는 메모"
 
 # %1 is the queue mode
-#: src/olympia/editors/templates/editors/queue.html:169
+#: src/olympia/editors/templates/editors/queue.html:175
 msgid "There are currently no add-ons of this type to review."
 msgstr "현재 이러한 종류의 부가 기능에선 심사할 수 있는 것이 없습니다."
 
-#: src/olympia/editors/templates/editors/queue.html:181
-#: src/olympia/editors/templates/editors/themes/queue_list.html:85
+#: src/olympia/editors/templates/editors/queue.html:187 src/olympia/editors/templates/editors/themes/queue_list.html:85
 msgid "Helpful Links:"
 msgstr "도움이 될만한 링크:"
 
-#: src/olympia/editors/templates/editors/queue.html:182
+#: src/olympia/editors/templates/editors/queue.html:188
 msgid "Add-on Policy"
 msgstr "부가 기능 정책"
 
-#: src/olympia/editors/templates/editors/queue.html:184
+#: src/olympia/editors/templates/editors/queue.html:190
 msgid "Editors' Guide"
 msgstr "편집자 지침"
 
@@ -9776,19 +7986,14 @@ msgstr "심사 {0}"
 msgid "Add-on user change history"
 msgstr ""
 
-#: src/olympia/editors/templates/editors/review.html:52
-#: src/olympia/editors/templates/editors/review.html:266
+#: src/olympia/editors/templates/editors/review.html:52 src/olympia/editors/templates/editors/review.html:266
 msgid "Add-on History"
 msgstr "부가 기능 변경 내역"
 
 #: src/olympia/editors/templates/editors/review.html:64
 #, python-format
-msgid ""
-"Version %(version)s &middot; %(created)s <span class=\"light\">&middot; "
-"%(version_status)s</span>"
-msgstr ""
-"버전 %(version)s &middot; %(created)s <span class=\"light\">&middot; "
-"%(version_status)s</span>"
+msgid "Version %(version)s &middot; %(created)s <span class=\"light\">&middot; %(version_status)s</span>"
+msgstr "버전 %(version)s &middot; %(created)s <span class=\"light\">&middot; %(version_status)s</span>"
 
 #: src/olympia/editors/templates/editors/review.html:73
 msgid "Compatibility:"
@@ -9811,17 +8016,14 @@ msgid "This version has not been reviewed."
 msgstr "이 버전은 아직 심사를 거치지 않았습니다."
 
 #: src/olympia/editors/templates/editors/review.html:154
-msgid ""
-"You can still submit this form, however only do so if you know it won't "
-"conflict."
+msgid "You can still submit this form, however only do so if you know it won't conflict."
 msgstr "이 양식은 제출 가능하지만 어떠한 충돌도 없을 거라는 확신이 있을 때만 제출하시기 바랍니다."
 
 #: src/olympia/editors/templates/editors/review.html:161
 msgid "Insert canned response..."
 msgstr "자동 응답 메시지를 입력하세요..."
 
-#: src/olympia/editors/templates/editors/review.html:167
-#: src/olympia/files/templates/files/viewer.html:54
+#: src/olympia/editors/templates/editors/review.html:167 src/olympia/files/templates/files/viewer.html:54
 msgid "Files:"
 msgstr "파일:"
 
@@ -9830,23 +8032,18 @@ msgid "Tested on:"
 msgstr "테스트:"
 
 #: src/olympia/editors/templates/editors/review.html:220
-msgid ""
-"<strong>Warning!</strong> Another user was viewing this page before you."
+msgid "<strong>Warning!</strong> Another user was viewing this page before you."
 msgstr "<strong>경고!</strong> 다른 사용자가 먼저 이 페이지를 조회했습니다."
 
 #: src/olympia/editors/templates/editors/review.html:237
-msgid ""
-"The whiteboard is the place to exchange information relevant to\n"
-"               this addon (whatever the version), between the developer and the\n"
-"               editor. This is visible and editable by both."
+msgid "The whiteboard is the place to exchange information relevant to this addon (whatever the version), between the developer and the editor. This is visible and editable by both."
 msgstr ""
 
 #: src/olympia/editors/templates/editors/review.html:241
 msgid "Update the whiteboard"
 msgstr ""
 
-#: src/olympia/editors/templates/editors/review.html:257
-#: src/olympia/editors/templates/editors/review.html:258
+#: src/olympia/editors/templates/editors/review.html:257 src/olympia/editors/templates/editors/review.html:258
 msgid "(admin)"
 msgstr "(관리자)"
 
@@ -9874,18 +8071,15 @@ msgstr "편집자"
 msgid "Add-on has been deleted."
 msgstr "부가 기능이 삭제되었습니다."
 
-#: src/olympia/editors/templates/editors/reviewlog.html:59
-#: src/olympia/editors/templates/editors/themes/logs.html:36
+#: src/olympia/editors/templates/editors/reviewlog.html:59 src/olympia/editors/templates/editors/themes/logs.html:36
 msgid "Show Comments"
 msgstr "코멘트 표시"
 
-#: src/olympia/editors/templates/editors/reviewlog.html:60
-#: src/olympia/editors/templates/editors/themes/logs.html:37
+#: src/olympia/editors/templates/editors/reviewlog.html:60 src/olympia/editors/templates/editors/themes/logs.html:37
 msgid "Hide Comments"
 msgstr "코멘트 숨김"
 
-#: src/olympia/editors/templates/editors/reviewlog.html:72
-#: src/olympia/editors/templates/editors/themes/logs.html:54
+#: src/olympia/editors/templates/editors/reviewlog.html:72 src/olympia/editors/templates/editors/themes/logs.html:54
 msgid "No reviews found for this period."
 msgstr "기간 내 제출된 심사 항목이 없습니다."
 
@@ -9943,12 +8137,8 @@ msgstr "전체 시간"
 msgid "You have <span>{0}</span> points."
 msgstr "<span>{0}</span> 포인트가 있습니다."
 
-#: src/olympia/editors/templates/editors/includes/search_results_themes.html:6
-#: src/olympia/editors/templates/editors/themes/history_table.html:7
-#: src/olympia/editors/templates/editors/themes/logs.html:19
-#: src/olympia/editors/templates/editors/themes/queue_list.html:49
-#: src/olympia/editors/templates/editors/themes/single.html:26
-#: src/olympia/editors/templates/editors/themes/themes.html:45
+#: src/olympia/editors/templates/editors/includes/search_results_themes.html:6 src/olympia/editors/templates/editors/themes/history_table.html:7 src/olympia/editors/templates/editors/themes/logs.html:19
+#: src/olympia/editors/templates/editors/themes/queue_list.html:49 src/olympia/editors/templates/editors/themes/single.html:26 src/olympia/editors/templates/editors/themes/themes.html:45
 msgid "Reviewer"
 msgstr "심사원"
 
@@ -9972,8 +8162,7 @@ msgstr "{0}의 테마 심사 기록"
 msgid "Review Date"
 msgstr "심사일"
 
-#: src/olympia/editors/templates/editors/themes/history_table.html:9
-#: src/olympia/editors/templates/editors/themes/logs.html:18
+#: src/olympia/editors/templates/editors/themes/history_table.html:9 src/olympia/editors/templates/editors/themes/logs.html:18
 msgid "Action"
 msgstr "작업"
 
@@ -9989,16 +8178,19 @@ msgstr "심사중인 테마가 없습니다."
 msgid "{num} Pending Theme Review"
 msgid_plural "{num} Pending Theme Reviews"
 msgstr[0] "대기중인 테마 심사 {num}건"
+msgstr[1] ""
 
 #: src/olympia/editors/templates/editors/themes/home.html:27
 msgid "{num} Flagged Review"
 msgid_plural "{num} Flagged Reviews"
 msgstr[0] "표시된 심사 {num}건"
+msgstr[1] ""
 
 #: src/olympia/editors/templates/editors/themes/home.html:34
 msgid "{num} Update"
 msgid_plural "{num} Updates"
 msgstr[0] "업데이트 {num}건"
+msgstr[1] ""
 
 #: src/olympia/editors/templates/editors/themes/logs.html:4
 msgid "Theme Review Log"
@@ -10117,7 +8309,7 @@ msgstr "만든이에게 질문하기"
 msgid "Describe your reason for flagging"
 msgstr "표시 사유를 기입해 주세요"
 
-#: src/olympia/files/forms.py:88
+#: src/olympia/files/forms.py:90
 msgid "Cannot diff a version against itself"
 msgstr "같은 파일끼리 버전 비교는 할 수 없습니다."
 
@@ -10135,9 +8327,7 @@ msgid "Problems decoding {0}."
 msgstr "{0} 디코딩 문제입니다."
 
 #: src/olympia/files/helpers.py:186
-msgid ""
-"This file is not viewable online. Please download the file to view the "
-"contents."
+msgid "This file is not viewable online. Please download the file to view the contents."
 msgstr "이 파일은 온라인상에서 조회가 불가능합니다. 내용을 보시려면 해당 파일을 다운로드 해주세요."
 
 #: src/olympia/files/helpers.py:194
@@ -10154,53 +8344,51 @@ msgstr "%s 파일을 접근하는 과정에서 오류가 발생했습니다. %s.
 msgid "There was an error accessing file %s."
 msgstr "%s 파일을 접근하는 과정에서 오류가 발생했습니다."
 
-#: src/olympia/files/utils.py:343
+#: src/olympia/files/utils.py:340
 msgid "Could not parse uploaded file."
 msgstr "업로드한 파일을 인식할 수 없습니다."
 
-#: src/olympia/files/utils.py:380
+#: src/olympia/files/utils.py:377
 msgid "Invalid file name in archive: {0}"
 msgstr "압축 파일내 잘못된 파일 이름: {0}"
 
-#: src/olympia/files/utils.py:388
+#: src/olympia/files/utils.py:385
 msgid "File exceeding size limit in archive: {0}"
 msgstr "압축 파일내 파일 용량 제한 초과: {0}"
 
-#: src/olympia/files/utils.py:439
+#: src/olympia/files/utils.py:436
 msgid "Invalid archive."
 msgstr "잘못된 압축 파일입니다."
 
-#: src/olympia/files/utils.py:529 src/olympia/files/utils.py:532
+#: src/olympia/files/utils.py:526 src/olympia/files/utils.py:529
 msgid "Could not parse the manifest file."
 msgstr ""
 
-#: src/olympia/files/utils.py:551
+#: src/olympia/files/utils.py:548
 msgid "Could not find an add-on ID."
 msgstr ""
 
-#: src/olympia/files/utils.py:554
+#: src/olympia/files/utils.py:551
 msgid "Add-on ID must be 64 characters or less."
 msgstr ""
 
-#: src/olympia/files/utils.py:556
+#: src/olympia/files/utils.py:553
 msgid "Add-on ID doesn't match add-on."
 msgstr ""
 
-#: src/olympia/files/utils.py:564
+#: src/olympia/files/utils.py:561
 msgid "Duplicate add-on ID found."
 msgstr ""
 
-#: src/olympia/files/utils.py:567
+#: src/olympia/files/utils.py:564
 msgid "Version numbers should have fewer than 32 characters."
 msgstr "버전 번호는 32 글자 미만이어야 합니다."
 
-#: src/olympia/files/utils.py:570
-msgid ""
-"Version numbers should only contain letters, numbers, and these punctuation "
-"characters: +*.-_."
+#: src/olympia/files/utils.py:567
+msgid "Version numbers should only contain letters, numbers, and these punctuation characters: +*.-_."
 msgstr "버전 번호엔 문자, 숫자, 다음의 특수 기호만 들어있어야 합니다: +*.-_"
 
-#: src/olympia/files/utils.py:587
+#: src/olympia/files/utils.py:584
 msgid "<em:type> doesn't match add-on"
 msgstr "<em:type>이(가) 부가 기능과 일치하지 않습니다"
 
@@ -10222,12 +8410,8 @@ msgstr "다운로드 {0}"
 
 #: src/olympia/files/templates/files/file.html:4
 #, python-format
-msgid ""
-"Version: %(version)s &bull; Size: %(size)s &bull; MD5 hash: %(md5)s &bull; "
-"Mimetype: %(mimetype)s"
-msgstr ""
-"버전: %(version)s &bull; 크기: %(size)s &bull; MD5 해쉬값: %(md5)s &bull; Mimetype:"
-" %(mimetype)s"
+msgid "Version: %(version)s &bull; Size: %(size)s &bull; MD5 hash: %(md5)s &bull; Mimetype: %(mimetype)s"
+msgstr "버전: %(version)s &bull; 크기: %(size)s &bull; MD5 해쉬값: %(md5)s &bull; Mimetype: %(mimetype)s"
 
 #: src/olympia/files/templates/files/viewer.html:4
 msgid "File Compare :: Editor tools"
@@ -10265,50 +8449,41 @@ msgstr "부가 기능 SDK 버전:"
 msgid "Tab stops:"
 msgstr "탭 중단:"
 
-#: src/olympia/files/templates/files/viewer.html:79
-#: src/olympia/files/templates/files/viewer.html:80
+#: src/olympia/files/templates/files/viewer.html:79 src/olympia/files/templates/files/viewer.html:80
 msgid "Up file"
 msgstr "파일 위로"
 
-#: src/olympia/files/templates/files/viewer.html:84
-#: src/olympia/files/templates/files/viewer.html:85
+#: src/olympia/files/templates/files/viewer.html:84 src/olympia/files/templates/files/viewer.html:85
 msgid "Down file"
 msgstr "파일 아래로"
 
-#: src/olympia/files/templates/files/viewer.html:90
-#: src/olympia/files/templates/files/viewer.html:91
+#: src/olympia/files/templates/files/viewer.html:90 src/olympia/files/templates/files/viewer.html:91
 msgid "Previous diff"
 msgstr "이전 비교"
 
-#: src/olympia/files/templates/files/viewer.html:93
-#: src/olympia/files/templates/files/viewer.html:94
+#: src/olympia/files/templates/files/viewer.html:93 src/olympia/files/templates/files/viewer.html:94
 msgid "Previous note"
 msgstr "이전 메모"
 
-#: src/olympia/files/templates/files/viewer.html:100
-#: src/olympia/files/templates/files/viewer.html:101
+#: src/olympia/files/templates/files/viewer.html:100 src/olympia/files/templates/files/viewer.html:101
 msgid "Next diff"
 msgstr "다음 비교"
 
-#: src/olympia/files/templates/files/viewer.html:103
-#: src/olympia/files/templates/files/viewer.html:104
+#: src/olympia/files/templates/files/viewer.html:103 src/olympia/files/templates/files/viewer.html:104
 msgid "Next note"
 msgstr "다음 메모"
 
 # 90%
 # 100%
-#: src/olympia/files/templates/files/viewer.html:109
-#: src/olympia/files/templates/files/viewer.html:110
+#: src/olympia/files/templates/files/viewer.html:109 src/olympia/files/templates/files/viewer.html:110
 msgid "Expand all"
 msgstr "전부 보기"
 
-#: src/olympia/files/templates/files/viewer.html:114
-#: src/olympia/files/templates/files/viewer.html:115
+#: src/olympia/files/templates/files/viewer.html:114 src/olympia/files/templates/files/viewer.html:115
 msgid "Hide or unhide tree"
 msgstr "트리 숨김/표시"
 
-#: src/olympia/files/templates/files/viewer.html:119
-#: src/olympia/files/templates/files/viewer.html:120
+#: src/olympia/files/templates/files/viewer.html:119 src/olympia/files/templates/files/viewer.html:120
 msgid "Wrap or unwrap text"
 msgstr "텍스트 감싸기/해제"
 
@@ -10319,6 +8494,10 @@ msgstr "업로드한 파일 내역에 파일이 없습니다."
 #: src/olympia/files/templates/files/viewer.html:134
 msgid "Fetching file."
 msgstr "파일을 가져오고 있습니다."
+
+#: src/olympia/legacy_api/views.py:255
+msgid "Not implemented yet."
+msgstr "아직 제대로 작동되지 않습니다."
 
 #: src/olympia/lib/constants.py:6
 msgid "United Arab Emirates Dirham"
@@ -10976,12 +9155,7 @@ msgstr ""
 msgid "Zimbabwe Dollar"
 msgstr ""
 
-#: src/olympia/lib/video/ffmpeg.py:112 src/olympia/lib/video/totem.py:81
-msgid "Videos must be in WebM."
-msgstr ""
-
-#: src/olympia/pages/templates/pages/about.lhtml:3
-#: src/olympia/pages/templates/pages/about.lhtml:10
+#: src/olympia/pages/templates/pages/about.lhtml:3 src/olympia/pages/templates/pages/about.lhtml:10
 msgid "About Mozilla Add-ons"
 msgstr "Mozilla 부가 기능 소개"
 
@@ -10991,15 +9165,11 @@ msgstr "이 웹 사이트는 어떤 곳인가요?"
 
 #: src/olympia/pages/templates/pages/about.lhtml:13
 msgid ""
-"addons.mozilla.org, commonly known as \"AMO\", is Mozilla's official site "
-"for add-ons to Mozilla software, such as Firefox, Thunderbird, and "
-"SeaMonkey. Add-ons let you add new features and change the way your browser "
-"or application works. Take a look around and explore the thousands of ways "
-"to customize the way you do things online."
+"addons.mozilla.org, commonly known as \"AMO\", is Mozilla's official site for add-ons to Mozilla software, such as Firefox, Thunderbird, and SeaMonkey. Add-ons let you add new features and change "
+"the way your browser or application works. Take a look around and explore the thousands of ways to customize the way you do things online."
 msgstr ""
-"흔히 \"AMO\"로 통하는 addons.mozilla.org는 Firefox, Thunderbird, SeaMonkey 등과 같은 "
-"Mozilla 소프트웨어의 부가 기능을 관리하는 공식 사이트입니다. 부가 기능은 웹 브라우저나 애플리케이션에 새 기능을 추가하고 구동 "
-"방식을 바꿀 수 있습니다. 한번 둘러보시고 온라인을 통한 수천가지 개인화 방법들을 탐구해 보시기 바랍니다."
+"흔히 \"AMO\"로 통하는 addons.mozilla.org는 Firefox, Thunderbird, SeaMonkey 등과 같은 Mozilla 소프트웨어의 부가 기능을 관리하는 공식 사이트입니다. 부가 기능은 웹 브라우저나 애플리케이션에 새 기능을 추가하고 구동 방식을 바꿀 수 있습니다. 한번 둘러보시고 온라인을 통한 수천가지 개인화 방법들을 "
+"탐구해 보시기 바랍니다."
 
 #: src/olympia/pages/templates/pages/about.lhtml:19
 msgid "Who creates these add-ons?"
@@ -11007,89 +9177,58 @@ msgstr "누가 이런 부가 기능들을 만들고 있나요?"
 
 #: src/olympia/pages/templates/pages/about.lhtml:20
 msgid ""
-"The add-ons listed here have been created by thousands of developers from "
-"our community, ranging from individual hobbyists to large corporations. All "
-"publicly listed add-ons are reviewed by a team of editors before being "
-"released. Add-ons marked as Experimental have not been reviewed and should "
-"only be installed with caution."
-msgstr ""
-"이곳에 등재된 부가 기능들은 저희 커뮤니티에 있는 수천명의 개발자가 제작한 것들로써, 개인적인 취미 활동부터 거대 기업들까지 그 영역은 "
-"광범위합니다. 모든 공개 부가 기능은 출시에 앞서 편집자 팀에 의해 심사를 받습니다. 시험용으로 표시된 부가 기능은 심사를 받지 "
-"않았으므로 설치시 주의해야 합니다."
+"The add-ons listed here have been created by thousands of developers from our community, ranging from individual hobbyists to large corporations. All publicly listed add-ons are reviewed by a team "
+"of editors before being released. Add-ons marked as Experimental have not been reviewed and should only be installed with caution."
+msgstr "이곳에 등재된 부가 기능들은 저희 커뮤니티에 있는 수천명의 개발자가 제작한 것들로써, 개인적인 취미 활동부터 거대 기업들까지 그 영역은 광범위합니다. 모든 공개 부가 기능은 출시에 앞서 편집자 팀에 의해 심사를 받습니다. 시험용으로 표시된 부가 기능은 심사를 받지 않았으므로 설치시 주의해야 합니다."
 
 #: src/olympia/pages/templates/pages/about.lhtml:26
 msgid "How do I keep up with what's happening at AMO?"
 msgstr "AMO에 대한 소식을 계속 받아볼 수 있을까요?"
 
 #: src/olympia/pages/templates/pages/about.lhtml:27
-msgid ""
-"There are several ways to find out the latest news from the world of add-"
-"ons:"
+msgid "There are several ways to find out the latest news from the world of add-ons:"
 msgstr "부가 기능 세계의 최신 뉴스를 볼 수 있는 여러 방법들이 있습니다:"
 
 #: src/olympia/pages/templates/pages/about.lhtml:29
 #, python-format
-msgid ""
-"Our <a href=\"%(url)s\">Add-ons Blog</a> is regularly updated with "
-"information for both add-on enthusiasts and developers."
+msgid "Our <a href=\"%(url)s\">Add-ons Blog</a> is regularly updated with information for both add-on enthusiasts and developers."
 msgstr "<a href=\"%(url)s\">부가 기능 블로그</a>에 정기적으로 부가 기능 열성 팬과 개발자에 관한 정보가 올라옵니다."
 
 #: src/olympia/pages/templates/pages/about.lhtml:32
 #, python-format
-msgid ""
-"We often post news, tips, and tricks to our Twitter account, <a "
-"href=\"%(url)s\">mozamo</a>"
+msgid "We often post news, tips, and tricks to our Twitter account, <a href=\"%(url)s\">mozamo</a>"
 msgstr "트위터 계정 <a href=\"%(url)s\">mozamo</a>에 뉴스, 팁, 트릭 등이 자주 올라옵니다."
 
 #: src/olympia/pages/templates/pages/about.lhtml:34
 #, python-format
-msgid ""
-"Our <a href=\"%(url)s\">forums</a> are a good place to interact with the "
-"add-ons community and discuss upcoming changes to AMO."
-msgstr ""
-"<a href=\"%(url)s\">포럼</a>은 부가 기능 커뮤니티와 교류하고 AMO의 향후 변경 사항에 관해 토론할 수 있는 최적의 "
-"장소입니다."
+msgid "Our <a href=\"%(url)s\">forums</a> are a good place to interact with the add-ons community and discuss upcoming changes to AMO."
+msgstr "<a href=\"%(url)s\">포럼</a>은 부가 기능 커뮤니티와 교류하고 AMO의 향후 변경 사항에 관해 토론할 수 있는 최적의 장소입니다."
 
 #: src/olympia/pages/templates/pages/about.lhtml:39
 msgid "This sounds great! How can I get involved?"
 msgstr "멋지군요! 저도 참여하고 싶은데 어떻게 해야죠?"
 
 #: src/olympia/pages/templates/pages/about.lhtml:40
-msgid ""
-"There are plenty of ways to get involved. If you're on the technical side:"
+msgid "There are plenty of ways to get involved. If you're on the technical side:"
 msgstr "참여할 수 있는 매우 다양한 방법들이 있습니다. 기술적 지식이 있다면:"
 
 #: src/olympia/pages/templates/pages/about.lhtml:42
 #, python-format
-msgid ""
-"<a href=\"%(url)s\">Make your own add-on</a>. We provide free hosting and "
-"update services and can help you reach a large audience of users."
-msgstr ""
-"<a href=\"%(url)s\">나만의 부가 기능을 만들어 보세요</a>. 무료 호스팅과 업데이트 서비스를 제공하고 있으며 사용자에게"
-" 쉽게 다가갈 수 있도록 도와드리겠습니다."
+msgid "<a href=\"%(url)s\">Make your own add-on</a>. We provide free hosting and update services and can help you reach a large audience of users."
+msgstr "<a href=\"%(url)s\">나만의 부가 기능을 만들어 보세요</a>. 무료 호스팅과 업데이트 서비스를 제공하고 있으며 사용자에게 쉽게 다가갈 수 있도록 도와드리겠습니다."
 
 #: src/olympia/pages/templates/pages/about.lhtml:45
 #, python-format
-msgid ""
-"If you have add-on development experience, <a href=\"%(url)s\"> become an "
-"editor</a>! Our editors are add-on fans with a technical background who "
-"review add-ons for code quality and stability."
-msgstr ""
-"부가 기능 개발 경험이 있다면 <a href=\"%(url)s\">편집자가 되어보세요</a>! 저희 편집자들은 기술적 배경 지식은 가진 "
-"부가 기능 팬 집단으로 부가 기능의 코드 품질과 안정성을 심사합니다."
+msgid "If you have add-on development experience, <a href=\"%(url)s\"> become an editor</a>! Our editors are add-on fans with a technical background who review add-ons for code quality and stability."
+msgstr "부가 기능 개발 경험이 있다면 <a href=\"%(url)s\">편집자가 되어보세요</a>! 저희 편집자들은 기술적 배경 지식은 가진 부가 기능 팬 집단으로 부가 기능의 코드 품질과 안정성을 심사합니다."
 
 #: src/olympia/pages/templates/pages/about.lhtml:49
 #, python-format
-msgid ""
-"Help improve this website. It's open source, and you can file bugs and "
-"submit patches. <a href=\"%(url)s\"> GitHub</a> contains all of our current "
-"bugs, legacy bugs can still be found in Bugzilla."
+msgid "Help improve this website. It's open source, and you can file bugs and submit patches. <a href=\"%(url)s\"> GitHub</a> contains all of our current bugs, legacy bugs can still be found in Bugzilla."
 msgstr ""
 
 #: src/olympia/pages/templates/pages/about.lhtml:55
-msgid ""
-"If you're interested in add-ons but not quite as technical, there are still "
-"ways to help:"
+msgid "If you're interested in add-ons but not quite as technical, there are still ways to help:"
 msgstr "부가 기능에 관심이 있긴 하지만 기술적 지식이 많지 않을 경우에도, 여전히 도울 방법은 있습니다:"
 
 #: src/olympia/pages/templates/pages/about.lhtml:58
@@ -11102,12 +9241,8 @@ msgid "Participate in our <a href=\"%(url)s\">forums</a>."
 msgstr "<a href=\"%(url)s\">포럼</a>에도 참여해 보세요."
 
 #: src/olympia/pages/templates/pages/about.lhtml:61
-msgid ""
-"Review add-ons on the site. Add-on authors are more likely to improve their "
-"add-ons and write new ones when they know people appreciate their work."
-msgstr ""
-"부가 기능에 평가를 적어주세요. 제작자들은 사람들이 자기 작품을 쓰면서 기뻐한다는 걸 알면 좀 더 개선하거나 새 작품을 만들려고 "
-"하니까요."
+msgid "Review add-ons on the site. Add-on authors are more likely to improve their add-ons and write new ones when they know people appreciate their work."
+msgstr "부가 기능에 평가를 적어주세요. 제작자들은 사람들이 자기 작품을 쓰면서 기뻐한다는 걸 알면 좀 더 개선하거나 새 작품을 만들려고 하니까요."
 
 #: src/olympia/pages/templates/pages/about.lhtml:66
 msgid "I have a question"
@@ -11116,20 +9251,14 @@ msgstr "질문이 있어요"
 #: src/olympia/pages/templates/pages/about.lhtml:67
 #, python-format
 msgid ""
-"A good place to start is our <a href=\"%(faq_url)s\"><abbr "
-"title=\"Frequently Asked Questions\">FAQ</abbr></a>. If you don't find an "
-"answer there, you can <a href=\"%(forum_url)s\"> ask on our forums</a>."
-msgstr ""
-"먼저 <a href=\"%(faq_url)s\"><abbr title=\"자주 묻는 질문\">FAQ</abbr></a>에서 시작하는게 "
-"좋겠네요. 저기에서 원하는 답을 찾지 못했다면 <a href=\"%(forum_url)s\">포럼에 물어보세요</a>."
+"A good place to start is our <a href=\"%(faq_url)s\"><abbr title=\"Frequently Asked Questions\">FAQ</abbr></a>. If you don't find an answer there, you can <a href=\"%(forum_url)s\"> ask on our "
+"forums</a>."
+msgstr "먼저 <a href=\"%(faq_url)s\"><abbr title=\"자주 묻는 질문\">FAQ</abbr></a>에서 시작하는게 좋겠네요. 저기에서 원하는 답을 찾지 못했다면 <a href=\"%(forum_url)s\">포럼에 물어보세요</a>."
 
 #: src/olympia/pages/templates/pages/about.lhtml:72
 #, python-format
-msgid ""
-"If you really need to contact someone from the Mozilla team, please see our "
-"<a href=\"%(url)s\"> contact information</a> page."
-msgstr ""
-"정말 Mozilla 팀원과 연락을 취하고 싶다면 <a href=\"%(url)s\">연락처 정보</a> 페이지를 참고하시기 바랍니다."
+msgid "If you really need to contact someone from the Mozilla team, please see our <a href=\"%(url)s\"> contact information</a> page."
+msgstr "정말 Mozilla 팀원과 연락을 취하고 싶다면 <a href=\"%(url)s\">연락처 정보</a> 페이지를 참고하시기 바랍니다."
 
 #: src/olympia/pages/templates/pages/about.lhtml:76
 msgid "Who works on this website?"
@@ -11138,13 +9267,9 @@ msgstr "누가 이 사이트를 운영하나요?"
 #: src/olympia/pages/templates/pages/about.lhtml:77
 #, python-format
 msgid ""
-"Over the years, many people have contributed to this website, including both"
-" volunteers from the community and a dedicated AMO team. A list of "
-"significant contributors can be found on our <a href=\"%(url)s\"> Site "
-"Credits</a> page."
-msgstr ""
-"커뮤니티에서 오신 자원 봉사자들과 헌신적인 AMO팀을 포함한 많은 사람들이 여러해 동안 이곳 웹사이트에 공헌해 주셨습니다. 전체 공헌자 "
-"명단은 <a href=\"%(url)s\">사이트 공헌자</a> 페이지에서 확인하실 수 있습니다."
+"Over the years, many people have contributed to this website, including both volunteers from the community and a dedicated AMO team. A list of significant contributors can be found on our <a "
+"href=\"%(url)s\"> Site Credits</a> page."
+msgstr "커뮤니티에서 오신 자원 봉사자들과 헌신적인 AMO팀을 포함한 많은 사람들이 여러해 동안 이곳 웹사이트에 공헌해 주셨습니다. 전체 공헌자 명단은 <a href=\"%(url)s\">사이트 공헌자</a> 페이지에서 확인하실 수 있습니다."
 
 #: src/olympia/pages/templates/pages/acr_firstrun.html:4
 msgid "Add-on Compatibility Reporter"
@@ -11155,9 +9280,7 @@ msgid "Add-on Compatibility Reporter has been installed"
 msgstr "부가 기능 호환성 제보기가 설치됐습니다"
 
 #: src/olympia/pages/templates/pages/acr_firstrun.html:28
-msgid ""
-"It’s easy to help us make sure add-ons are updated in time for the release "
-"of the next version of Firefox."
+msgid "It’s easy to help us make sure add-ons are updated in time for the release of the next version of Firefox."
 msgstr "차기 Firefox 버전용으로 부가 기능이 업데이트 됐는지 여부를 확인해주는 역할을 하는 부가 기능입니다."
 
 #: src/olympia/pages/templates/pages/acr_firstrun.html:35
@@ -11166,46 +9289,28 @@ msgstr "부가 기능 호환성을 제보하는 방법:"
 
 #: src/olympia/pages/templates/pages/acr_firstrun.html:40
 msgid ""
-"As you start browsing and using your add-ons, take careful note of anything "
-"that seems different from when you last used the extension. This might be a "
-"display glitch, such as a menu item missing, or something more serious, like"
-" the add-on not working at all or showing errors."
-msgstr ""
-"웹 서핑 및 부가 기능 사용을 시작하게 되면 마지막으로 확장 기능을 사용했을 때와 다른 점이 있는지 주의깊게 살펴보세요. 메뉴 항목 "
-"사라짐 같은 표시 관련 결함 내지는 부가 기능이 제대로 작동하지 않거나 오류 메시지가 출력되는 등의 보다 심각한 결함이 있을 수 "
-"있습니다."
+"As you start browsing and using your add-ons, take careful note of anything that seems different from when you last used the extension. This might be a display glitch, such as a menu item missing, "
+"or something more serious, like the add-on not working at all or showing errors."
+msgstr "웹 서핑 및 부가 기능 사용을 시작하게 되면 마지막으로 확장 기능을 사용했을 때와 다른 점이 있는지 주의깊게 살펴보세요. 메뉴 항목 사라짐 같은 표시 관련 결함 내지는 부가 기능이 제대로 작동하지 않거나 오류 메시지가 출력되는 등의 보다 심각한 결함이 있을 수 있습니다."
 
 #: src/olympia/pages/templates/pages/acr_firstrun.html:49
 msgid ""
-"Once you know whether a particular add-on works properly or has problems, "
-"open the Add-ons Manager and click Compatibility next to the add-on to let "
-"Mozilla know what you found in your testing. Submitting a report will help "
-"us tell the add-on developer whether their add-on is working properly in "
-"this version or might need some fixes."
-msgstr ""
-"어떤 부가 기능이 제대로 작동하고 문제가 있는지를 인지했다면 부가 기능 관리자를 열어서 부가 기능 메뉴 옆에 호환성 메뉴를 클릭한 다음 "
-"Mozilla에 테스트 과정에서 발견한 사항을 제보해 주세요. 제출된 보고서는 부가 기능 개발자에게 전달되어 현재 버전에서 제대로 "
-"작동하고 있는지 아니면 수정 작업이 필요한 지 등을 알려주는 역할을 하게 됩니다."
+"Once you know whether a particular add-on works properly or has problems, open the Add-ons Manager and click Compatibility next to the add-on to let Mozilla know what you found in your testing. "
+"Submitting a report will help us tell the add-on developer whether their add-on is working properly in this version or might need some fixes."
+msgstr "어떤 부가 기능이 제대로 작동하고 문제가 있는지를 인지했다면 부가 기능 관리자를 열어서 부가 기능 메뉴 옆에 호환성 메뉴를 클릭한 다음 Mozilla에 테스트 과정에서 발견한 사항을 제보해 주세요. 제출된 보고서는 부가 기능 개발자에게 전달되어 현재 버전에서 제대로 작동하고 있는지 아니면 수정 작업이 필요한 지 등을 알려주는 역할을 하게 됩니다."
 
 #: src/olympia/pages/templates/pages/acr_firstrun.html:61
 #, python-format
 msgid ""
-"If you upgrade to a new version of Firefox or update your add-ons, your "
-"reports for the old versions will be hidden to allow you to test the new "
-"version. If you have any questions, please ask in <a href=\"%(url)s\">our "
-"forums</a>."
-msgstr ""
-"Firefox나 부가 기능을 새 버전으로 업그레이드할 경우 구 버전에 대해 보고한 내용은 새 버전 테스트를 위해 숨김 처리될 것입니다. "
-"문의사항이 있다면 <a href=\"%(url)s\">저희 포럼</a>에 문의해 주세요."
+"If you upgrade to a new version of Firefox or update your add-ons, your reports for the old versions will be hidden to allow you to test the new version. If you have any questions, please ask in <a"
+" href=\"%(url)s\">our forums</a>."
+msgstr "Firefox나 부가 기능을 새 버전으로 업그레이드할 경우 구 버전에 대해 보고한 내용은 새 버전 테스트를 위해 숨김 처리될 것입니다. 문의사항이 있다면 <a href=\"%(url)s\">저희 포럼</a>에 문의해 주세요."
 
 #: src/olympia/pages/templates/pages/acr_firstrun.html:69
 msgid ""
-"Thousands of add-ons are made by our community every year, and your "
-"assistance with compatibility testing helps us make sure these add-ons stay "
-"useful as we strive to provide a great user experience."
-msgstr ""
-"매년 수천가지 부가 기능이 저희 커뮤니티를 중심으로 제작됩니다. 당신의 호환성 테스트는 이들 부가 기능이 뛰어난 사용자 경험을 제공하여 "
-"쓸만한 부가 기능으로 자리매김 하도록 일조하고 있습니다."
+"Thousands of add-ons are made by our community every year, and your assistance with compatibility testing helps us make sure these add-ons stay useful as we strive to provide a great user "
+"experience."
+msgstr "매년 수천가지 부가 기능이 저희 커뮤니티를 중심으로 제작됩니다. 당신의 호환성 테스트는 이들 부가 기능이 뛰어난 사용자 경험을 제공하여 쓸만한 부가 기능으로 자리매김 하도록 일조하고 있습니다."
 
 #: src/olympia/pages/templates/pages/acr_firstrun.html:75
 msgid "Thank you!"
@@ -11216,9 +9321,7 @@ msgid "Site Credits"
 msgstr "사이트 공헌자"
 
 #: src/olympia/pages/templates/pages/credits.html:12
-msgid ""
-"Mozilla would like to thank the following people for their contributions to "
-"the addons.mozilla.org project over the years:"
+msgid "Mozilla would like to thank the following people for their contributions to the addons.mozilla.org project over the years:"
 msgstr "수년간 addons.mozilla.org 프로젝트에 기여해주신 다음 분들에게 Mozilla가 감사의 인사를 드립니다:"
 
 #: src/olympia/pages/templates/pages/credits.html:18
@@ -11252,85 +9355,63 @@ msgstr "소프트웨어 및 이미지"
 
 #: src/olympia/pages/templates/pages/credits.html:59
 msgid ""
-"Some icons used are from the <a "
-"href=\"http://www.famfamfam.com/lab/icons/silk/\">famfamfam Silk Icon "
-"Set</a>, licensed under a <a "
-"href=\"http://creativecommons.org/licenses/by/2.5/\">Creative Commons "
-"Attribution 2.5 License</a>."
+"Some icons used are from the <a href=\"http://www.famfamfam.com/lab/icons/silk/\">famfamfam Silk Icon Set</a>, licensed under a <a href=\"http://creativecommons.org/licenses/by/2.5/\">Creative "
+"Commons Attribution 2.5 License</a>."
 msgstr ""
-"일부 아이콘은 <a href=\"http://www.famfamfam.com/lab/icons/silk/\">famfamfam Silk "
-"Icon Set</a>의 것을 사용하고 있으며, <a "
-"href=\"http://creativecommons.org/licenses/by/2.5/\">Creative Commons "
-"Attribution 2.5 License</a>를 따르고 있습니다."
+"일부 아이콘은 <a href=\"http://www.famfamfam.com/lab/icons/silk/\">famfamfam Silk Icon Set</a>의 것을 사용하고 있으며, <a href=\"http://creativecommons.org/licenses/by/2.5/\">Creative Commons Attribution 2.5 "
+"License</a>를 따르고 있습니다."
 
 #: src/olympia/pages/templates/pages/credits.html:60
 msgid ""
-"Some icons used are from the <a href=\"http://www.fatcow.com/free-"
-"icons/\">FatCow Farm-Fresh Web Icons Set</a>, licensed under a <a "
-"href=\"http://creativecommons.org/licenses/by/3.0/us/\">Creative Commons "
-"Attribution 3.0 License</a>."
+"Some icons used are from the <a href=\"http://www.fatcow.com/free-icons/\">FatCow Farm-Fresh Web Icons Set</a>, licensed under a <a href=\"http://creativecommons.org/licenses/by/3.0/us/\">Creative "
+"Commons Attribution 3.0 License</a>."
 msgstr ""
-"일부 아이콘은 <a href=\"http://www.fatcow.com/free-icons/\">FatCow Farm-Fresh Web "
-"Icons Set</a>의 것을 사용하고 있으며, <a "
-"href=\"http://creativecommons.org/licenses/by/3.0/us/\">Creative Commons "
-"Attribution 3.0 License</a>를 따르고 있습니다."
+"일부 아이콘은 <a href=\"http://www.fatcow.com/free-icons/\">FatCow Farm-Fresh Web Icons Set</a>의 것을 사용하고 있으며, <a href=\"http://creativecommons.org/licenses/by/3.0/us/\">Creative Commons Attribution 3.0 "
+"License</a>를 따르고 있습니다."
 
 #: src/olympia/pages/templates/pages/credits.html:61
 msgid ""
-"Some pages use elements of <a "
-"href=\"http://shop.highsoft.com/highcharts.html\">Highcharts</a> (non-"
-"commercial), licensed under a <a href=\"http://creativecommons.org/licenses"
-"/by-nc/3.0/\">Creative Commons Attribution-NonCommercial 3.0 License</a>."
+"Some pages use elements of <a href=\"http://shop.highsoft.com/highcharts.html\">Highcharts</a> (non-commercial), licensed under a <a href=\"http://creativecommons.org/licenses/by-nc/3.0/\">Creative"
+" Commons Attribution-NonCommercial 3.0 License</a>."
 msgstr ""
-"일부 페이지는 <a href=\"http://shop.highsoft.com/highcharts.html\">Highcharts</a> "
-"(비영리)의 자원을 사용하고 있으며, <a href=\"http://creativecommons.org/licenses/by-"
-"nc/3.0/\">Creative Commons Attribution-NonCommercial 3.0 License</a>를 따르고 "
-"있습니다."
+"일부 페이지는 <a href=\"http://shop.highsoft.com/highcharts.html\">Highcharts</a> (비영리)의 자원을 사용하고 있으며, <a href=\"http://creativecommons.org/licenses/by-nc/3.0/\">Creative Commons Attribution-"
+"NonCommercial 3.0 License</a>를 따르고 있습니다."
 
 #: src/olympia/pages/templates/pages/credits.html:65
 #, python-format
-msgid ""
-"For information on contributing, please see our <a href=\"%(url)s\">wiki "
-"page</a>."
+msgid "For information on contributing, please see our <a href=\"%(url)s\">wiki page</a>."
 msgstr "기여에 관한 정보는 저희의 <a href=\"%(url)s\">위키 페이지</a>를 참고하시기 바랍니다."
 
 #: src/olympia/pages/templates/pages/dev_faq.html:4
 msgid "Developer FAQ"
 msgstr "개발자 FAQ"
 
-#: src/olympia/pages/templates/pages/dev_faq.html:31
-#: src/olympia/pages/templates/pages/review_guide.html:33
+#: src/olympia/pages/templates/pages/dev_faq.html:31 src/olympia/pages/templates/pages/review_guide.html:33
 msgid "Sections"
 msgstr "항목"
 
-#: src/olympia/pages/templates/pages/dev_faq.html:33
-#: src/olympia/pages/templates/pages/dev_faq.html:45
+#: src/olympia/pages/templates/pages/dev_faq.html:33 src/olympia/pages/templates/pages/dev_faq.html:45
 msgid "Developing an Add-on"
 msgstr "부가 기능 개발"
 
 #. Heading for a list of resources for developers
-#: src/olympia/pages/templates/pages/dev_faq.html:34
-#: src/olympia/pages/templates/pages/dev_faq.html:208
+#: src/olympia/pages/templates/pages/dev_faq.html:34 src/olympia/pages/templates/pages/dev_faq.html:208
 msgid "Support Resources"
 msgstr "자원 제공"
 
-#: src/olympia/pages/templates/pages/dev_faq.html:35
-#: src/olympia/pages/templates/pages/dev_faq.html:261
+#: src/olympia/pages/templates/pages/dev_faq.html:35 src/olympia/pages/templates/pages/dev_faq.html:261
 msgid "Contributing your Add-on"
 msgstr "부가 기능에 기부금 설정하기"
 
-#: src/olympia/pages/templates/pages/dev_faq.html:36
-#: src/olympia/pages/templates/pages/dev_faq.html:381
+#: src/olympia/pages/templates/pages/dev_faq.html:36 src/olympia/pages/templates/pages/dev_faq.html:381
 msgid "Add-on Review Process"
 msgstr "부가 기능 심사 과정"
 
-#: src/olympia/pages/templates/pages/dev_faq.html:37
-#: src/olympia/pages/templates/pages/dev_faq.html:444
+#: src/olympia/pages/templates/pages/dev_faq.html:37 src/olympia/pages/templates/pages/dev_faq.html:444
 msgid "Managing Your Add-on"
 msgstr "부가 기능 관리하기"
 
-#: src/olympia/pages/templates/pages/dev_faq.html:39
-#: src/olympia/pages/templates/pages/dev_faq.html:528
+#: src/olympia/pages/templates/pages/dev_faq.html:39 src/olympia/pages/templates/pages/dev_faq.html:528
 msgid "References for Open Source Licenses"
 msgstr "오픈 소스 라이선스에 대해 알아보기"
 
@@ -11340,10 +9421,7 @@ msgstr "부가 기능 개발자 FAQ"
 
 #: src/olympia/pages/templates/pages/dev_faq.html:47
 #, python-format
-msgid ""
-"<h3>How do I build an Add-on?</h3> <p> Mozilla provides documentation on how"
-" to build an add-on via the <a href=\"%(url)s\">Mozilla Developer "
-"Network</a>. </p>"
+msgid "<h3>How do I build an Add-on?</h3> <p> Mozilla provides documentation on how to build an add-on via the <a href=\"%(url)s\">Mozilla Developer Network</a>. </p>"
 msgstr ""
 
 #: src/olympia/pages/templates/pages/dev_faq.html:55
@@ -11364,12 +9442,9 @@ msgstr "부가 기능을 개발하려면 무슨 도구가 필요한가요?"
 
 #: src/olympia/pages/templates/pages/dev_faq.html:68
 msgid ""
-"You will need to have a version of the Mozilla software that you're building"
-" the add-on for and a code editor of your choice. Add-ons can be built for "
-"almost all Mozilla software but are primarily targeted for:"
-msgstr ""
-"개발할 부가 기능에 맞는 Mozilla 소프트웨어와 취향에 맞는 코드 편집기가 필요할 겁니다. 부가 기능은 모든 Mozilla "
-"소프트웨어용으로 제작이 가능하지만 가장 선호되는 소프트웨어는 바로 이것이죠:"
+"You will need to have a version of the Mozilla software that you're building the add-on for and a code editor of your choice. Add-ons can be built for almost all Mozilla software but are primarily "
+"targeted for:"
+msgstr "개발할 부가 기능에 맞는 Mozilla 소프트웨어와 취향에 맞는 코드 편집기가 필요할 겁니다. 부가 기능은 모든 Mozilla 소프트웨어용으로 제작이 가능하지만 가장 선호되는 소프트웨어는 바로 이것이죠:"
 
 #: src/olympia/pages/templates/pages/dev_faq.html:82
 msgid "Popular code editors include:"
@@ -11378,18 +9453,13 @@ msgstr "인기 코드 편집기:"
 #. This is a list of popular code editors.  Feel free to adjust as you like.
 #: src/olympia/pages/templates/pages/dev_faq.html:85
 msgid ""
-"<li><a href=\"http://komodoide.com/komodo-edit/\">Komodo Edit</a></li> "
-"<li><a href=\"http://macromates.com/\">TextMate</a></li> <li><a href=\"http"
-"://notepad-plus-plus.org/\">Notepad++</a></li> <li><a "
-"href=\"http://www.eclipse.org/\">Eclipse IDE</a></li>"
+"<li><a href=\"http://komodoide.com/komodo-edit/\">Komodo Edit</a></li> <li><a href=\"http://macromates.com/\">TextMate</a></li> <li><a href=\"http://notepad-plus-plus.org/\">Notepad++</a></li> "
+"<li><a href=\"http://www.eclipse.org/\">Eclipse IDE</a></li>"
 msgstr ""
 
 #: src/olympia/pages/templates/pages/dev_faq.html:94
 #, python-format
-msgid ""
-"You can also learn more about setting up your development environment via "
-"the MDN article <a href=\"%(url)s\">Setting up extension development "
-"environment</a>"
+msgid "You can also learn more about setting up your development environment via the MDN article <a href=\"%(url)s\">Setting up extension development environment</a>"
 msgstr ""
 
 #: src/olympia/pages/templates/pages/dev_faq.html:100
@@ -11397,9 +9467,7 @@ msgid "What is a \".xpi\" file?"
 msgstr "\".xpi\"는 무슨 파일인가요?"
 
 #: src/olympia/pages/templates/pages/dev_faq.html:102
-msgid ""
-"Extensions are packaged and distributed in ZIP files or Bundles, with the "
-"XPI (pronounced \"zippy\") file extension."
+msgid "Extensions are packaged and distributed in ZIP files or Bundles, with the XPI (pronounced \"zippy\") file extension."
 msgstr "확장 기능은 XPI (\"지피\"로 발음) 확장자를 통해 ZIP 파일이나 묶음 상태로 패키징되어 배포됩니다."
 
 #: src/olympia/pages/templates/pages/dev_faq.html:108
@@ -11408,14 +9476,9 @@ msgstr "XUL이 무엇인가요?"
 
 #: src/olympia/pages/templates/pages/dev_faq.html:110
 msgid ""
-"XUL (XML User Interface Language) is Mozilla's XML-based language that lets "
-"you build feature-rich cross platform applications. It provides user "
-"interface widgets like buttons, menus, toolbars, trees, etc that can be used"
-" to enhance add-ons by modifying parts of the browser UI."
-msgstr ""
-"XUL (XML User Interface Language)이란 Mozilla의 XML 기반 언어로 풍부한 기능을 가진 크로스 플랫폼 "
-"애플리케이션을 개발할 수 있습니다. 버튼, 메뉴, 도구 모음, 트리 등의 사용자 인터페이스 자원을 제공하며 웹 브라우저 UI의 각 부위를"
-" 조정해서 부가 기능을 향상시키는데 쓸 수 있습니다."
+"XUL (XML User Interface Language) is Mozilla's XML-based language that lets you build feature-rich cross platform applications. It provides user interface widgets like buttons, menus, toolbars, "
+"trees, etc that can be used to enhance add-ons by modifying parts of the browser UI."
+msgstr "XUL (XML User Interface Language)이란 Mozilla의 XML 기반 언어로 풍부한 기능을 가진 크로스 플랫폼 애플리케이션을 개발할 수 있습니다. 버튼, 메뉴, 도구 모음, 트리 등의 사용자 인터페이스 자원을 제공하며 웹 브라우저 UI의 각 부위를 조정해서 부가 기능을 향상시키는데 쓸 수 있습니다."
 
 #: src/olympia/pages/templates/pages/dev_faq.html:119
 msgid "What is the \"install.rdf\" file used for?"
@@ -11424,28 +9487,19 @@ msgstr "\"install.rdf\" 파일은 어떤 용도로 쓰이나요?"
 #: src/olympia/pages/templates/pages/dev_faq.html:121
 #, python-format
 msgid ""
-"This file, called an <a href=\"%(url)s\">Install Manifest</a>, is used by "
-"Add-on Manager-enabled XUL applications to determine information about an "
-"add-on as it is being installed. It contains metadata identifying the add-"
-"on, providing information about who created it, where more information can "
-"be found about it, which versions of what applications it is compatible "
-"with, how it should be updated, and so on. The format of the Install "
-"Manifest is RDF/XML."
+"This file, called an <a href=\"%(url)s\">Install Manifest</a>, is used by Add-on Manager-enabled XUL applications to determine information about an add-on as it is being installed. It contains "
+"metadata identifying the add-on, providing information about who created it, where more information can be found about it, which versions of what applications it is compatible with, how it should "
+"be updated, and so on. The format of the Install Manifest is RDF/XML."
 msgstr ""
-"<a href=\"%(url)s\">설치 선언문</a>이라 불리는 이 파일은 부가 기능 관리자가 인식해서 부가 기능이 설치시 관련 정보를"
-" 읽어들이는데 쓰입니다. 부가 기능을 인식하는 메타 데이터를 담고 있으며, 제작자는 누구이며 어디서 추가적인 정보를 찾아볼 수 있는지, "
-"호환되는 애플리케이션 버전은 어떤 것이 있는지, 업데이트는 어떻게 해야 하는지 등에 관한 정보를 제공합니다. 설치 선언문의 형식은 "
-"RDF/XML 입니다."
+"<a href=\"%(url)s\">설치 선언문</a>이라 불리는 이 파일은 부가 기능 관리자가 인식해서 부가 기능이 설치시 관련 정보를 읽어들이는데 쓰입니다. 부가 기능을 인식하는 메타 데이터를 담고 있으며, 제작자는 누구이며 어디서 추가적인 정보를 찾아볼 수 있는지, 호환되는 애플리케이션 버전은 어떤 것이 있는지, 업데이트는 어떻게 해야 하는지 "
+"등에 관한 정보를 제공합니다. 설치 선언문의 형식은 RDF/XML 입니다."
 
 #: src/olympia/pages/templates/pages/dev_faq.html:132
 msgid "What does \"maxVersion\" mean?"
 msgstr "\"maxVersion\"은 뭘 의미하나요?"
 
 #: src/olympia/pages/templates/pages/dev_faq.html:134
-msgid ""
-"This determines the maximum version of Firefox you're saying this extension "
-"will work with. Set this to be no newer than the newest currently available "
-"version!"
+msgid "This determines the maximum version of Firefox you're saying this extension will work with. Set this to be no newer than the newest currently available version!"
 msgstr "이 확장 기능이 작동 가능한 Firefox의 최대 버전을 말합니다. 현재 최신 버전보다 높은 버전으로 설정하면 안됩니다!"
 
 #: src/olympia/pages/templates/pages/dev_faq.html:141
@@ -11454,30 +9508,18 @@ msgstr "부가 기능에 이진 콤포넌트를 넣을 수도 있나요?"
 
 #: src/olympia/pages/templates/pages/dev_faq.html:143
 #, python-format
-msgid ""
-"Yes. You can use Mozilla's <a href=\"%(url)s\">XPCOM component object "
-"model</a> to enhance your add-ons. XPCOM components be used and implemented "
-"in JavaScript, Java, and Python in addition to C++."
-msgstr ""
-"예. Mozilla의 <a href=\"%(url)s\">XPCOM 콤포넌트 오브젝트 모델</a>을 사용하면 부가 기능의 성능을 향상시킬"
-" 수 있습니다. XPCOM 콤포넌트는 C++뿐 아니라 자바스크립트, 자바, 파이썬으로도 구현할 수 있습니다."
+msgid "Yes. You can use Mozilla's <a href=\"%(url)s\">XPCOM component object model</a> to enhance your add-ons. XPCOM components be used and implemented in JavaScript, Java, and Python in addition to C++."
+msgstr "예. Mozilla의 <a href=\"%(url)s\">XPCOM 콤포넌트 오브젝트 모델</a>을 사용하면 부가 기능의 성능을 향상시킬 수 있습니다. XPCOM 콤포넌트는 C++뿐 아니라 자바스크립트, 자바, 파이썬으로도 구현할 수 있습니다."
 
 #: src/olympia/pages/templates/pages/dev_faq.html:150
-msgid ""
-"Can I use a JavaScript library like jQuery, MooTools or Prototype to build "
-"my add-on?"
+msgid "Can I use a JavaScript library like jQuery, MooTools or Prototype to build my add-on?"
 msgstr "jQuery, MooTools, Prototype 같은 자바스크립트 라이브러리를 사용해서 부가 기능을 제작할 수 있나요?"
 
 #: src/olympia/pages/templates/pages/dev_faq.html:152
 msgid ""
-"Yes. It's possible, but some of the functionality provided by these "
-"libraries are available through XPCOM, XUL, and JavaScript. In addition, "
-"authors should take care if libraries modify primitive object prototypes "
-"(String.prototype, Date.prototype, etc.) and/or define global functions (eg."
-" the $ function). These are prone to cause conflict with other add-ons, in "
-"particular if different add-ons use different versions of libraries and so "
-"on. Developers need to be very, very careful with using them.  Mozilla does "
-"not offer documentation on using them to build add-ons."
+"Yes. It's possible, but some of the functionality provided by these libraries are available through XPCOM, XUL, and JavaScript. In addition, authors should take care if libraries modify primitive "
+"object prototypes (String.prototype, Date.prototype, etc.) and/or define global functions (eg. the $ function). These are prone to cause conflict with other add-ons, in particular if different add-"
+"ons use different versions of libraries and so on. Developers need to be very, very careful with using them. Mozilla does not offer documentation on using them to build add-ons."
 msgstr ""
 
 #: src/olympia/pages/templates/pages/dev_faq.html:165
@@ -11490,20 +9532,14 @@ msgid "You can use the <a href=\"%(url)s\">Add-on Debugger</a>."
 msgstr ""
 
 #: src/olympia/pages/templates/pages/dev_faq.html:172
-msgid ""
-"How do I test for compatibility with the latest version of Mozilla software?"
+msgid "How do I test for compatibility with the latest version of Mozilla software?"
 msgstr "최신 버전의 Mozilla 소프트웨어에 대한 호환성 테스트를 하려면 어떻게 해야 하나요?"
 
 #: src/olympia/pages/templates/pages/dev_faq.html:174
 msgid ""
-"To ensure compatibility with the latest Mozilla software, it's important to "
-"download updates as they become available and test your add-on to ensure "
-"that it is still functioning as expected. In many cases, the latest version "
-"of Mozilla software may be a beta release. Since these releases at times "
-"introduce architectural changes that may impact the functionality of your "
-"add-on, it's important to be actively involved in the beta process to ensure"
-" that your add-on users are not negatively impacted upon final release of "
-"Mozilla software."
+"To ensure compatibility with the latest Mozilla software, it's important to download updates as they become available and test your add-on to ensure that it is still functioning as expected. In "
+"many cases, the latest version of Mozilla software may be a beta release. Since these releases at times introduce architectural changes that may impact the functionality of your add-on, it's "
+"important to be actively involved in the beta process to ensure that your add-on users are not negatively impacted upon final release of Mozilla software."
 msgstr ""
 
 #: src/olympia/pages/templates/pages/dev_faq.html:185
@@ -11513,11 +9549,8 @@ msgstr ""
 #: src/olympia/pages/templates/pages/dev_faq.html:187
 #, python-format
 msgid ""
-"Poorly written extensions can have a severe impact on the browsing "
-"experience, including on the overall performance of Firefox itself. The "
-"following page contains many good <a href=\"%(url)s\">guides</a> that help "
-"you improve performance, whether you're developing core Mozilla code or an "
-"add-on."
+"Poorly written extensions can have a severe impact on the browsing experience, including on the overall performance of Firefox itself. The following page contains many good <a "
+"href=\"%(url)s\">guides</a> that help you improve performance, whether you're developing core Mozilla code or an add-on."
 msgstr ""
 
 #: src/olympia/pages/templates/pages/dev_faq.html:195
@@ -11527,10 +9560,8 @@ msgstr "부가 기능이 다국어를 지원할 수 있나요?"
 #: src/olympia/pages/templates/pages/dev_faq.html:197
 #, python-format
 msgid ""
-"Yes. Details on localizing your add-on can be found in the the <a "
-"href=\"%(l10n_url)s\">Mozilla Developer Network Localization page</a>. <a "
-"href=\"%(bz_url)s\">The BabelZilla project</a> is also a great resource for "
-"learning about localization and volunteering to help translate add-ons."
+"Yes. Details on localizing your add-on can be found in the the <a href=\"%(l10n_url)s\">Mozilla Developer Network Localization page</a>. <a href=\"%(bz_url)s\">The BabelZilla project</a> is also a "
+"great resource for learning about localization and volunteering to help translate add-ons."
 msgstr ""
 
 #: src/olympia/pages/templates/pages/dev_faq.html:210
@@ -11549,9 +9580,7 @@ msgstr "#amo (AMO 상에 부가 기능 호스팅 관련 도움)"
 
 #. #jetpack is the name of the IRC channel.  do not change.
 #: src/olympia/pages/templates/pages/dev_faq.html:220
-msgid ""
-"#jetpack (for discussions about the Add-ons SDK and cfx/jpm - formerly known"
-" as Jetpack)"
+msgid "#jetpack (for discussions about the Add-ons SDK and cfx/jpm - formerly known as Jetpack)"
 msgstr ""
 
 #. Label for a link to the extension developers mailing list
@@ -11592,11 +9621,8 @@ msgstr "부가 기능 제작에 고용할 서드파티 개발자가 있을까요
 #: src/olympia/pages/templates/pages/dev_faq.html:248
 #, python-format
 msgid ""
-"Yes. You may find 3rd party developers via the <a href=\"%(forum_url)s"
-"\">Add-ons forum</a>, <a href=\"%(list_url)s\">mozilla.jobs list</a>, <a "
-"href=\"%(mz_url)s\">mozillaZine forums</a> or <a href=\"%(wiki_url)s\">the "
-"Mozilla Wiki</a>. Please note that Mozilla does not offer developer "
-"recommendations."
+"Yes. You may find 3rd party developers via the <a href=\"%(forum_url)s\">Add-ons forum</a>, <a href=\"%(list_url)s\">mozilla.jobs list</a>, <a href=\"%(mz_url)s\">mozillaZine forums</a> or <a "
+"href=\"%(wiki_url)s\">the Mozilla Wiki</a>. Please note that Mozilla does not offer developer recommendations."
 msgstr ""
 
 #: src/olympia/pages/templates/pages/dev_faq.html:263
@@ -11606,18 +9632,12 @@ msgstr "부가 기능을 직접 호스팅해도 될까요?"
 #: src/olympia/pages/templates/pages/dev_faq.html:265
 #, python-format
 msgid ""
-"Yes. Many developers choose to host their own add-ons. Choosing to host your"
-" add-on on <a href=\"%(amo_url)s\">Mozilla's add-on site</a>, though, allows"
-" for much greater exposure to your add-on due to the large volume of "
-"visitors to the site. <a href=\"%(md_url)s\">mozdev.org</a> offers free "
-"project hosting for Mozilla applications and extensions providing developers"
-" with tools to help manage source code, version control, bug tracking and "
-"documentation."
+"Yes. Many developers choose to host their own add-ons. Choosing to host your add-on on <a href=\"%(amo_url)s\">Mozilla's add-on site</a>, though, allows for much greater exposure to your add-on due"
+" to the large volume of visitors to the site. <a href=\"%(md_url)s\">mozdev.org</a> offers free project hosting for Mozilla applications and extensions providing developers with tools to help "
+"manage source code, version control, bug tracking and documentation."
 msgstr ""
-"예. 많은 개발자들이 호스팅을 선택하고 있습니다. 다만, <a href=\"%(amo_url)s\">Mozilla의 부가 기능 "
-"사이트</a>에 호스팅하는 쪽이 많은 방문자에게 부가 기능을 더욱 많이 노출시킬 수 있을겁니다. <a "
-"href=\"%(md_url)s\">mozdev.org</a>의 경우 Mozilla 애플리케이션 및 확장기능에 대한 무료 프로젝트 "
-"호스팅을 제공합니다. 이곳에선 소스 코드 관리 도구, 버전 콘트롤, 버그 트래킹, 문서자료 등을 지원하고 있습니다."
+"예. 많은 개발자들이 호스팅을 선택하고 있습니다. 다만, <a href=\"%(amo_url)s\">Mozilla의 부가 기능 사이트</a>에 호스팅하는 쪽이 많은 방문자에게 부가 기능을 더욱 많이 노출시킬 수 있을겁니다. <a href=\"%(md_url)s\">mozdev.org</a>의 경우 Mozilla 애플리케이션 및 확장기능에 대한 무료 "
+"프로젝트 호스팅을 제공합니다. 이곳에선 소스 코드 관리 도구, 버전 콘트롤, 버그 트래킹, 문서자료 등을 지원하고 있습니다."
 
 #: src/olympia/pages/templates/pages/dev_faq.html:277
 msgid "Can Mozilla host my add-on?"
@@ -11625,9 +9645,7 @@ msgstr "Mozilla에서 부가 기능을 호스팅 해준다구요?"
 
 #: src/olympia/pages/templates/pages/dev_faq.html:279
 #, python-format
-msgid ""
-"Yes. You can host your add-on on <a href=\"%(url)s\">Mozilla's add-on "
-"website</a>."
+msgid "Yes. You can host your add-on on <a href=\"%(url)s\">Mozilla's add-on website</a>."
 msgstr "예. <a href=\"%(url)s\">Mozilla의 부가 기능 웹사이트</a>에서 호스팅 할 수 있습니다."
 
 #: src/olympia/pages/templates/pages/dev_faq.html:284
@@ -11636,17 +9654,11 @@ msgstr "AMO가 뭔가요?"
 
 #: src/olympia/pages/templates/pages/dev_faq.html:286
 msgid ""
-"Mozilla's AMO (<a "
-"href=\"https://addons.mozilla.org\">https://addons.mozilla.org</a>) is the "
-"incubator that helps developers build, distribute, and support fantastic "
-"consumer products powered by Mozilla. It provides you the tools and "
-"infrastructure necessary to manage, host and expose your add-on to a massive"
-" base of Mozilla users."
+"Mozilla's AMO (<a href=\"https://addons.mozilla.org\">https://addons.mozilla.org</a>) is the incubator that helps developers build, distribute, and support fantastic consumer products powered by "
+"Mozilla. It provides you the tools and infrastructure necessary to manage, host and expose your add-on to a massive base of Mozilla users."
 msgstr ""
-"Mozilla의 AMO(<a "
-"href=\"https://addons.mozilla.org\">https://addons.mozilla.org</a>)는 개발자에게 "
-"개발, 배포, Mozilla가 제공하는 환상적인 소비자 기술 지원 등의 도움을 주는 인큐베이터라 할 수 있습니다. 도구 및 관리에 필요한"
-" 기반 시설 등을 제공함으로써 부가 기능을 수많은 Mozilla 이용자들에게 노출시키는 역할을 하고 있습니다."
+"Mozilla의 AMO(<a href=\"https://addons.mozilla.org\">https://addons.mozilla.org</a>)는 개발자에게 개발, 배포, Mozilla가 제공하는 환상적인 소비자 기술 지원 등의 도움을 주는 인큐베이터라 할 수 있습니다. 도구 및 관리에 필요한 기반 시설 등을 제공함으로써 부가 기능을 수많은 "
+"Mozilla 이용자들에게 노출시키는 역할을 하고 있습니다."
 
 #: src/olympia/pages/templates/pages/dev_faq.html:295
 msgid "Does Mozilla keep my account information private?"
@@ -11654,12 +9666,8 @@ msgstr "Mozilla에선 제 계정 정보를 안전하게 지켜주나요?"
 
 #: src/olympia/pages/templates/pages/dev_faq.html:297
 #, python-format
-msgid ""
-"Yes. Our <a href=\"%(url)s\">Privacy Policy</a> describes how your "
-"information is managed by Mozilla."
-msgstr ""
-"예. 저희의 <a href=\"%(url)s\">개인 정보 보호 정책</a>에 Mozilla가 어떻게 개인 정보를 관리하는지 서술되어 "
-"있습니다."
+msgid "Yes. Our <a href=\"%(url)s\">Privacy Policy</a> describes how your information is managed by Mozilla."
+msgstr "예. 저희의 <a href=\"%(url)s\">개인 정보 보호 정책</a>에 Mozilla가 어떻게 개인 정보를 관리하는지 서술되어 있습니다."
 
 #: src/olympia/pages/templates/pages/dev_faq.html:302
 msgid "What are the \"developer tools\" listed on AMO?"
@@ -11667,31 +9675,20 @@ msgstr "AMO에 있는 \"개발자 도구\"란 무엇을 말하는 건가요?"
 
 #: src/olympia/pages/templates/pages/dev_faq.html:304
 msgid ""
-"The \"Developer Tools\" dashboard is the area that provides you the tools to"
-" successfully manage your add-ons. It provides the functionality necessary "
-"to submit your add-ons to AMO, manage add-on information, and review "
-"statistics."
-msgstr ""
-"\"개발자 도구\" 대쉬보드는 부가 기능을 관리하기 위해 제공되는 도구들이 있는 구역을 말합니다. AMO에 부가 기능을 제출하거나, 부가"
-" 기능 정보 관리, 통계 조회 등에 필요한 기능들을 제공하고 있습니다."
+"The \"Developer Tools\" dashboard is the area that provides you the tools to successfully manage your add-ons. It provides the functionality necessary to submit your add-ons to AMO, manage add-on "
+"information, and review statistics."
+msgstr "\"개발자 도구\" 대쉬보드는 부가 기능을 관리하기 위해 제공되는 도구들이 있는 구역을 말합니다. AMO에 부가 기능을 제출하거나, 부가 기능 정보 관리, 통계 조회 등에 필요한 기능들을 제공하고 있습니다."
 
 #: src/olympia/pages/templates/pages/dev_faq.html:312
-msgid ""
-"Does Mozilla have a policy in place as to what is an acceptable submission?"
+msgid "Does Mozilla have a policy in place as to what is an acceptable submission?"
 msgstr "Mozilla에선 어떤 부가 기능이 용인되는지에 대한 정책을 마련하고 있나요?"
 
 #: src/olympia/pages/templates/pages/dev_faq.html:314
 #, python-format
 msgid ""
-"Yes. Mozilla's <a href=\"%(p_url)s\">Add-on Policy</a> describes what is an "
-"acceptable submission. This policy is subject to change without notice. In "
-"addition, the AMO editorial team uses the <a href=\"%(g_url)s\">Editors "
-"Reviewing Guide</a> to ensure that your add-on meets specific guidelines for"
-" functionality and security."
-msgstr ""
-"예. Mozilla의 <a href=\"%(p_url)s\">부가 기능 정책</a>에 어떤 것이 용인되는지 서술되어 있습니다. 이 정책은"
-" 별도의 고지 없이 변경됩니다. 여기에 추가로 AMO 편집자 팀에선 <a href=\"%(g_url)s\">편집자 심사 지침</a>을 "
-"사용해 기능이나 보안 유지가 지침에 부합하는지도 검사합니다."
+"Yes. Mozilla's <a href=\"%(p_url)s\">Add-on Policy</a> describes what is an acceptable submission. This policy is subject to change without notice. In addition, the AMO editorial team uses the <a "
+"href=\"%(g_url)s\">Editors Reviewing Guide</a> to ensure that your add-on meets specific guidelines for functionality and security."
+msgstr "예. Mozilla의 <a href=\"%(p_url)s\">부가 기능 정책</a>에 어떤 것이 용인되는지 서술되어 있습니다. 이 정책은 별도의 고지 없이 변경됩니다. 여기에 추가로 AMO 편집자 팀에선 <a href=\"%(g_url)s\">편집자 심사 지침</a>을 사용해 기능이나 보안 유지가 지침에 부합하는지도 검사합니다."
 
 #: src/olympia/pages/templates/pages/dev_faq.html:324
 msgid "How do I submit my add-on for review?"
@@ -11700,24 +9697,16 @@ msgstr "심사를 받기 위해 부가 기능을 제출하려면 어떻게 해�
 #: src/olympia/pages/templates/pages/dev_faq.html:326
 #, python-format
 msgid ""
-"The Developer Tools dashboard will allow you to upload and submit add-ons to"
-" AMO. You must be a registered AMO users before you can submit an add-on. "
-"Before submitting your add-on be sure to you have read the AMO <a "
-"href=\"%(url)s\">Editors Reviewing Guide</a> to ensure that your add-on has "
-"met the guidelines used by editors to review add-ons."
-msgstr ""
-"개발자 도구 대시보드에서 부가 기능을 업로드하면 AMO에 제출됩니다. 부가 기능을 제출하기 전에 AMO에 등록해야 합니다. 부가 기능을 "
-"제출하기 전에 AMO <a href=\"%(url)s\">편집자 심사 지침</a>을 읽어보고 편집자 지침에 부합하는지 여부도 확인해 "
-"보시기 바랍니다."
+"The Developer Tools dashboard will allow you to upload and submit add-ons to AMO. You must be a registered AMO users before you can submit an add-on. Before submitting your add-on be sure to you "
+"have read the AMO <a href=\"%(url)s\">Editors Reviewing Guide</a> to ensure that your add-on has met the guidelines used by editors to review add-ons."
+msgstr "개발자 도구 대시보드에서 부가 기능을 업로드하면 AMO에 제출됩니다. 부가 기능을 제출하기 전에 AMO에 등록해야 합니다. 부가 기능을 제출하기 전에 AMO <a href=\"%(url)s\">편집자 심사 지침</a>을 읽어보고 편집자 지침에 부합하는지 여부도 확인해 보시기 바랍니다."
 
 #: src/olympia/pages/templates/pages/dev_faq.html:336
 msgid "What operating system do I choose for my add-on?"
 msgstr "부가 기능에 어떤 운영 체제를 선택해야 하나요?"
 
 #: src/olympia/pages/templates/pages/dev_faq.html:338
-msgid ""
-"You must choose the operating systems on which your add-on will successfully"
-" function."
+msgid "You must choose the operating systems on which your add-on will successfully function."
 msgstr "부가 기능이 제대로 작동하는 운영 체제로 선택해야 합니다."
 
 #: src/olympia/pages/templates/pages/dev_faq.html:344
@@ -11726,23 +9715,16 @@ msgstr "부가 기능에 어떤 분류를 지정해줘야 하나요?"
 
 #: src/olympia/pages/templates/pages/dev_faq.html:346
 msgid ""
-"The choice of category is dependent on what type of audience you are "
-"targeting and the functionality of your add-on. If you're unsure of which "
-"category your add-on falls into, please choose \"Other\". The AMO team may "
-"re-categorize your add-on if it's determined that it's better suited in a "
-"different category."
-msgstr ""
-"분류 선정은 주 이용층과 기능적 측면에서 검토한 후 선정합니다. 넣을만한 적당한 분류가 없다고 생각되면 \"기타\"를 골라주세요. AMO"
-" 팀에서 보다 알맞는 분류가 있다고 판단되면 향후 다른 분류로 재분류할 수도 있습니다."
+"The choice of category is dependent on what type of audience you are targeting and the functionality of your add-on. If you're unsure of which category your add-on falls into, please choose "
+"\"Other\". The AMO team may re-categorize your add-on if it's determined that it's better suited in a different category."
+msgstr "분류 선정은 주 이용층과 기능적 측면에서 검토한 후 선정합니다. 넣을만한 적당한 분류가 없다고 생각되면 \"기타\"를 골라주세요. AMO 팀에서 보다 알맞는 분류가 있다고 판단되면 향후 다른 분류로 재분류할 수도 있습니다."
 
 #: src/olympia/pages/templates/pages/dev_faq.html:355
 msgid "What does \"nominating\" my add-on mean?"
 msgstr "부가 기능이 \"심사 후보\"라는게 무슨 뜻인가요?"
 
 #: src/olympia/pages/templates/pages/dev_faq.html:357
-msgid ""
-"Nominated add-ons are new add-ons that the author has nominated to become "
-"public via the Developer Tools."
+msgid "Nominated add-ons are new add-ons that the author has nominated to become public via the Developer Tools."
 msgstr "심사 후보란 개발자의 새 부가 기능이 개발자 도구를 통해 공개 상태가 될 후보에 올라 있다는 것을 말합니다."
 
 #: src/olympia/pages/templates/pages/dev_faq.html:363
@@ -11750,26 +9732,16 @@ msgid "Can I specify a license agreement for using my add-on?"
 msgstr "부가 기능 사용시 라이선스 동의서를 표시하게 수 있나요?"
 
 #: src/olympia/pages/templates/pages/dev_faq.html:365
-msgid ""
-"Yes. You can specify a license agreement when submitting your add-on. You "
-"can also add or update a license agreement via the Developer Tools dashboard"
-" after your add-on has been submitted."
-msgstr ""
-"예. 부가 기능 제출시 라이선스 동의서를 넣을 수 있습니다. 부가 기능 제출 후에도 언제든 개발자 도구를 통해 라이선스 동의서를 "
-"추가하거나 갱신할 수 있습니다."
+msgid "Yes. You can specify a license agreement when submitting your add-on. You can also add or update a license agreement via the Developer Tools dashboard after your add-on has been submitted."
+msgstr "예. 부가 기능 제출시 라이선스 동의서를 넣을 수 있습니다. 부가 기능 제출 후에도 언제든 개발자 도구를 통해 라이선스 동의서를 추가하거나 갱신할 수 있습니다."
 
 #: src/olympia/pages/templates/pages/dev_faq.html:372
 msgid "Can I include a privacy policy for my add-on?"
 msgstr "개인 정보 보호 정책을 부가 기능에 삽입할 수 있나요?"
 
 #: src/olympia/pages/templates/pages/dev_faq.html:374
-msgid ""
-"Yes. You can specify a privacy policy when submitting your add-on. You can "
-"also add or update a privacy policy via the Developer Tools dashboard after "
-"your add-on has been submitted."
-msgstr ""
-"예. 부가 기능 제출시 개인 정보 보호 정책을 넣을 수 있습니다. 부가 기능 제출 후에도 언제든 개발자 도구를 통해 개인 정보 보호 "
-"정책을 추가하거나 갱신할 수 있습니다."
+msgid "Yes. You can specify a privacy policy when submitting your add-on. You can also add or update a privacy policy via the Developer Tools dashboard after your add-on has been submitted."
+msgstr "예. 부가 기능 제출시 개인 정보 보호 정책을 넣을 수 있습니다. 부가 기능 제출 후에도 언제든 개발자 도구를 통해 개인 정보 보호 정책을 추가하거나 갱신할 수 있습니다."
 
 #: src/olympia/pages/templates/pages/dev_faq.html:383
 msgid "Why must my add-on be reviewed?"
@@ -11778,13 +9750,9 @@ msgstr "부가 기능을 반드시 심사받아야 하는 이유가 뭔가요?"
 #: src/olympia/pages/templates/pages/dev_faq.html:385
 #, python-format
 msgid ""
-"All add-ons submitted, whether new or updated, are reviewed to ensure that "
-"Mozilla users have a stable and safe experience. All add-ons submissions are"
-" reviewed using the guidelines outlined in the <a href=\"%(url)s\">Editors "
-"Reviewing Guide</a>."
-msgstr ""
-"제출된 모든 부가 기능은 신규든 업데이트든 Mozilla 이용자가 안정적이고 안전한 경험을 제공받도록 심사를 거쳐야 합니다. 모든 부가 "
-"기능은 <a href=\"%(url)s\">편집자 심사 가이드</a>에 명시된 가이드라인을 통해 심사를 받습니다."
+"All add-ons submitted, whether new or updated, are reviewed to ensure that Mozilla users have a stable and safe experience. All add-ons submissions are reviewed using the guidelines outlined in the"
+" <a href=\"%(url)s\">Editors Reviewing Guide</a>."
+msgstr "제출된 모든 부가 기능은 신규든 업데이트든 Mozilla 이용자가 안정적이고 안전한 경험을 제공받도록 심사를 거쳐야 합니다. 모든 부가 기능은 <a href=\"%(url)s\">편집자 심사 가이드</a>에 명시된 가이드라인을 통해 심사를 받습니다."
 
 #: src/olympia/pages/templates/pages/dev_faq.html:393
 msgid "Who reviews my add-on?"
@@ -11793,17 +9761,12 @@ msgstr "부가 기능은 누가 심사하나요?"
 #: src/olympia/pages/templates/pages/dev_faq.html:395
 #, python-format
 msgid ""
-"Add-ons are reviewed by the AMO Editors, a group of talented developers that"
-" volunteer to help the Mozilla project by reviewing add-ons to ensure a "
-"stable and safe experience for Mozilla users. When communicating with "
-"editors, please be courteous, patient and respectful as they are working "
-"hard to ensure that your add-on is set up correctly and follows the "
-"guidelines outlined in the <a href=\"%(url)s\">Editors Reviewing Guide</a>."
+"Add-ons are reviewed by the AMO Editors, a group of talented developers that volunteer to help the Mozilla project by reviewing add-ons to ensure a stable and safe experience for Mozilla users. "
+"When communicating with editors, please be courteous, patient and respectful as they are working hard to ensure that your add-on is set up correctly and follows the guidelines outlined in the <a "
+"href=\"%(url)s\">Editors Reviewing Guide</a>."
 msgstr ""
-"부가 기능은 AMO 편집자에 의해 심사를 받습니다. 편집자들은 Mozilla 사용자들에게 안정성을 확보하고 제대로 된 사용 경험을 "
-"유지하기 위한 부가 기능 심사 프로젝트를 돕기 위해 선발된 유능한 개발자로 이루어진 자원 봉사자 조직입니다. 편집자들과 소통시엔 예의를 "
-"지켜서 말씀해 주시기 바랍니다. 이 분들은 당신의 부가 기능이 정확하게 설정되어 있는지, <a href=\"%(url)s\">편집자 심사"
-" 지침</a>에서 밑줄 친 사항을 잘 따르고 있는지를 가려내기 위해 열심히 일하는 중이니까요."
+"부가 기능은 AMO 편집자에 의해 심사를 받습니다. 편집자들은 Mozilla 사용자들에게 안정성을 확보하고 제대로 된 사용 경험을 유지하기 위한 부가 기능 심사 프로젝트를 돕기 위해 선발된 유능한 개발자로 이루어진 자원 봉사자 조직입니다. 편집자들과 소통시엔 예의를 지켜서 말씀해 주시기 바랍니다. 이 분들은 당신의 부가 기능이 정확하게 설정되어 "
+"있는지, <a href=\"%(url)s\">편집자 심사 지침</a>에서 밑줄 친 사항을 잘 따르고 있는지를 가려내기 위해 열심히 일하는 중이니까요."
 
 #: src/olympia/pages/templates/pages/dev_faq.html:406
 msgid "What are the guidelines used to review my add-on?"
@@ -11812,11 +9775,8 @@ msgstr "부가 기능 심사에 쓰이는 지침이 뭔가요?"
 #: src/olympia/pages/templates/pages/dev_faq.html:408
 #, python-format
 msgid ""
-"The Mozilla editorial team follows the <a href=\"%(url)s\">Editors Reviewing"
-" Guide</a> when testing an add-on for acceptance onto AMO. It is important "
-"that add-on developers review this guide to ensure that common problem areas"
-" are addressed prior to submitting their add-on for review. This will "
-"greatly assist in expediting the review process."
+"The Mozilla editorial team follows the <a href=\"%(url)s\">Editors Reviewing Guide</a> when testing an add-on for acceptance onto AMO. It is important that add-on developers review this guide to "
+"ensure that common problem areas are addressed prior to submitting their add-on for review. This will greatly assist in expediting the review process."
 msgstr ""
 
 #: src/olympia/pages/templates/pages/dev_faq.html:418
@@ -11824,9 +9784,7 @@ msgid "How long will it take for my add-on to be reviewed?"
 msgstr "부가 기능 심사엔 어느 정도 기간이 소요되나요?"
 
 #: src/olympia/pages/templates/pages/dev_faq.html:420
-msgid ""
-"We cannot give a time estimate as to how long it will take before an add-on "
-"is reviewed. Many factors affect the time including the:"
+msgid "We cannot give a time estimate as to how long it will take before an add-on is reviewed. Many factors affect the time including the:"
 msgstr "심사를 해보기 전까진 어느정도 걸릴지 예측이 불가능합니다. 다음의 여러 요소들이 시간에 영향을 끼칩니다:"
 
 #. part of a list (<li>)
@@ -11847,25 +9805,16 @@ msgstr "문제 지역 발견 횟수"
 #: src/olympia/pages/templates/pages/dev_faq.html:434
 #, python-format
 msgid ""
-"This is why it's very important to read the <a href=\"%(g_url)s\">Editors "
-"Reviewing Guide</a> to ensure that your add-on is setup as expected. It's "
-"also a good idea to read the blog post, <a "
-"href=\"%(blog_url)s\">Successfully Getting your Add-on Reviewed</a> which "
-"provides excellent insight into ensuring a smooth review of your add-on."
-msgstr ""
-"이러한 이유로 <a href=\"%(g_url)s\">편집자 심사 지침</a>을 읽어보고 부가 기능이 의도한 대로 설정되었는지 확인하는 "
-"작업이 매우 중요하다는 것입니다. <a href=\"%(blog_url)s\">성공적인 부가 기능 심사</a>와 같은 블로그 글을 읽고 "
-"원만한 부가 기능 심사 통과에 대한 이해를 높이는 것도 좋은 생각입니다."
+"This is why it's very important to read the <a href=\"%(g_url)s\">Editors Reviewing Guide</a> to ensure that your add-on is setup as expected. It's also a good idea to read the blog post, <a "
+"href=\"%(blog_url)s\">Successfully Getting your Add-on Reviewed</a> which provides excellent insight into ensuring a smooth review of your add-on."
+msgstr "이러한 이유로 <a href=\"%(g_url)s\">편집자 심사 지침</a>을 읽어보고 부가 기능이 의도한 대로 설정되었는지 확인하는 작업이 매우 중요하다는 것입니다. <a href=\"%(blog_url)s\">성공적인 부가 기능 심사</a>와 같은 블로그 글을 읽고 원만한 부가 기능 심사 통과에 대한 이해를 높이는 것도 좋은 생각입니다."
 
 #: src/olympia/pages/templates/pages/dev_faq.html:446
 msgid "How can I see how many times my add-on has been downloaded?"
 msgstr "부가 기능이 몇회나 다운로드 되었는지 알 수 있나요?"
 
 #: src/olympia/pages/templates/pages/dev_faq.html:448
-msgid ""
-"The Statistics Dashboard found in the Developer Tools dashboard provides "
-"information that can help you determine your add-on downloads since you've "
-"submitted it to AMO."
+msgid "The Statistics Dashboard found in the Developer Tools dashboard provides information that can help you determine your add-on downloads since you've submitted it to AMO."
 msgstr "개발자 도구의 통계 대시보드에서 AMO에 제출된 이후 다운로드 횟수에 대한 정보를 제공하고 있습니다."
 
 #: src/olympia/pages/templates/pages/dev_faq.html:455
@@ -11873,10 +9822,7 @@ msgid "How can I see how many active users are using my add-on?"
 msgstr "부가 기능을 실제 사용중인 이용자 수를 알 수 있나요?"
 
 #: src/olympia/pages/templates/pages/dev_faq.html:457
-msgid ""
-"The Statistics Dashboard found in the Developer Tools dashboard provides "
-"information that can help you determine how many users have been actively "
-"using your add-on since you've submitted it to AMO."
+msgid "The Statistics Dashboard found in the Developer Tools dashboard provides information that can help you determine how many users have been actively using your add-on since you've submitted it to AMO."
 msgstr "개발자 도구의 통계 대시보드에서 AMO에 제출된 이후 실제 사용중인 이용자 수가 몇인지에 대한 정보를 제공하고 있습니다."
 
 #: src/olympia/pages/templates/pages/dev_faq.html:464
@@ -11884,10 +9830,7 @@ msgid "How do I submit an update for my add-on?"
 msgstr "부가 기능의 업데이트는 어떻게 제출하나요?"
 
 #: src/olympia/pages/templates/pages/dev_faq.html:466
-msgid ""
-"You can submit an update for your add-on via the Developer Tools dashboard "
-"by choosing the option \"Upload a new version\" and uploading a new .xpi "
-"file for your add-on."
+msgid "You can submit an update for your add-on via the Developer Tools dashboard by choosing the option \"Upload a new version\" and uploading a new .xpi file for your add-on."
 msgstr "개발자 도구 대시보드의 \"새 버전 업로드\" 옵션을 골라 새 .xpi 파일을 업로드해서 업데이트를 제출할 수 있습니다."
 
 #: src/olympia/pages/templates/pages/dev_faq.html:473
@@ -11896,41 +9839,30 @@ msgstr "업데이트도 편집자의 심사가 필요한가요?"
 
 #: src/olympia/pages/templates/pages/dev_faq.html:475
 msgid ""
-"That depends. If you are simply changing a description of your add-on or "
-"updating a \"maxVersion\" to ensure compatibility with a new Mozilla "
-"software update, then your add-on does not need to be reviewed again. If, "
-"however, you submit a new updated file, then your add-on update will need to"
-" be reviewed by an editor."
-msgstr ""
-"그때그때 다릅니다. 단순히 부가 기능 설명이나 Mozilla 소프트웨어 신버전과의 호환성 유지를 목적으로 \"maxVersion\" "
-"정도만 변경한다면 재심사가 필요하지 않습니다. 하지만 새로 업데이트된 파일을 제출했을 시엔 편집자의 심사를 받게 될 것입니다."
+"That depends. If you are simply changing a description of your add-on or updating a \"maxVersion\" to ensure compatibility with a new Mozilla software update, then your add-on does not need to be "
+"reviewed again. If, however, you submit a new updated file, then your add-on update will need to be reviewed by an editor."
+msgstr "그때그때 다릅니다. 단순히 부가 기능 설명이나 Mozilla 소프트웨어 신버전과의 호환성 유지를 목적으로 \"maxVersion\" 정도만 변경한다면 재심사가 필요하지 않습니다. 하지만 새로 업데이트된 파일을 제출했을 시엔 편집자의 심사를 받게 될 것입니다."
 
 #: src/olympia/pages/templates/pages/dev_faq.html:486
-msgid ""
-"How do I reply to a user who has posted a negative review of my add-on?"
+msgid "How do I reply to a user who has posted a negative review of my add-on?"
 msgstr "부가 기능에 부정적인 평가를 올린 이용자에게 답글을 올리려면 어떻게 해야 하나요?"
 
 #: src/olympia/pages/templates/pages/dev_faq.html:488
-msgid ""
-"A developer may reply to any review posted to their add-on as long as they "
-"are logged into AMO. In addition, any user can flag a review as:"
+msgid "A developer may reply to any review posted to their add-on as long as they are logged into AMO. In addition, any user can flag a review as:"
 msgstr "개발자는 AMO에 로그인만 하면 어떤 평가든 답글을 달 수 있습니다. 거기에 이용자에겐 다음과 같은 표식도 할 수 있습니다:"
 
 #. part of a list (<li>)
-#: src/olympia/pages/templates/pages/dev_faq.html:495
-#: src/olympia/reviews/models.py:159
+#: src/olympia/pages/templates/pages/dev_faq.html:495 src/olympia/reviews/models.py:159
 msgid "Spam or otherwise non-review content"
 msgstr "스팸이거나 내용이 평가가 아닙니다"
 
 #. part of a list (<li>)
-#: src/olympia/pages/templates/pages/dev_faq.html:497
-#: src/olympia/reviews/models.py:160
+#: src/olympia/pages/templates/pages/dev_faq.html:497 src/olympia/reviews/models.py:160
 msgid "Inappropriate language/dialog"
 msgstr "부적절한 언어/대화입니다"
 
 #. part of a list (<li>)
-#: src/olympia/pages/templates/pages/dev_faq.html:499
-#: src/olympia/reviews/models.py:161
+#: src/olympia/pages/templates/pages/dev_faq.html:499 src/olympia/reviews/models.py:161
 msgid "Misplaced bug report or support request"
 msgstr "없는 버그를 신고했거나 기술 지원을 요청합니다"
 
@@ -11940,21 +9872,15 @@ msgid "Other (provides a pop-up prompt for information)"
 msgstr "기타 (세부 사항을 묻는 팝업창이 뜹니다)"
 
 #: src/olympia/pages/templates/pages/dev_faq.html:504
-msgid ""
-"Currently, AMO does not provide a mechanism to directly communicate with a "
-"reviewer but this feature is being investigated and considered for a future "
-"update."
-msgstr ""
-"현재 AMO에선 심사원과 직접 연결해주는 메커니즘을 제공하고 있지 않지만 이러한 기능은 향후 업데이트를 통해 개발을 고려중에 있습니다."
+msgid "Currently, AMO does not provide a mechanism to directly communicate with a reviewer but this feature is being investigated and considered for a future update."
+msgstr "현재 AMO에선 심사원과 직접 연결해주는 메커니즘을 제공하고 있지 않지만 이러한 기능은 향후 업데이트를 통해 개발을 고려중에 있습니다."
 
 #: src/olympia/pages/templates/pages/dev_faq.html:511
 msgid "Can I request that a review be removed if the review is negative?"
 msgstr "부정적인 평가에 대해서 삭제를 요청할 수 있나요?"
 
 #: src/olympia/pages/templates/pages/dev_faq.html:513
-msgid ""
-"No. We do not remove negative reviews from add-ons unless they are found to "
-"be false."
+msgid "No. We do not remove negative reviews from add-ons unless they are found to be false."
 msgstr "아니오. 저희는 부정적인 평가들이 허위라고 판단되지 않는 이상 평가들을 제거하지 않습니다."
 
 #: src/olympia/pages/templates/pages/dev_faq.html:519
@@ -11962,63 +9888,38 @@ msgid "Can I request that a review be removed if the review is inaccurate?"
 msgstr "정확하지 않은 평가에 대해서 제거를 신청할 수 있나요?"
 
 #: src/olympia/pages/templates/pages/dev_faq.html:521
-msgid ""
-"If an author contacts us and asks for a review containing false or "
-"inaccurate information to be removed, we will review the post and consider "
-"removing it."
-msgstr ""
-"작성자가 부정확한 내용이 있는 평가에 대해 저희에게 삭제를 요청할 경우, 저희가 그 글을 검토해본뒤 삭제여부에 대해 결정하게됩니다. "
+msgid "If an author contacts us and asks for a review containing false or inaccurate information to be removed, we will review the post and consider removing it."
+msgstr "작성자가 부정확한 내용이 있는 평가에 대해 저희에게 삭제를 요청할 경우, 저희가 그 글을 검토해본뒤 삭제여부에 대해 결정하게됩니다. "
 
 #: src/olympia/pages/templates/pages/dev_faq.html:530
 msgid ""
-"Do you need more information about the various open source licenses? Are you"
-" confused as to which license you should select? What rights does a specific"
-" license grant? While nothing replaces reading the full terms of a license, "
-"below are some sites that contain information about some of the key open "
-"source licenses that may help you sort out the differences between them. "
-"These sites are being provided solely for your convenience and as a "
-"reference for your personal use. These resources do not constitute legal "
-"advice nor should they be used in lieu of such advice. Mozilla neither "
-"guarantees nor is responsible for the content of these sites or your "
-"reliance on such content."
+"Do you need more information about the various open source licenses? Are you confused as to which license you should select? What rights does a specific license grant? While nothing replaces "
+"reading the full terms of a license, below are some sites that contain information about some of the key open source licenses that may help you sort out the differences between them. These sites "
+"are being provided solely for your convenience and as a reference for your personal use. These resources do not constitute legal advice nor should they be used in lieu of such advice. Mozilla "
+"neither guarantees nor is responsible for the content of these sites or your reliance on such content."
 msgstr ""
-"다양한 오픈소스 라이선스에 대한 정보가 필요하십니까? 어떤 라이선스를 선택해야 할지 궁금하신가요? 전체 라이선스 내용을 확인하지 않더라도"
-" 아래 사이트에서 각종 라이선스 정보를 비교해 드립니다. 그러나, 이 정보들은 개인적인 용도 및 정보의 역할만 하는 것이고 법적인 정보는"
-" 아닙니다. Mozilla는 이들 정보에 대해 책임을 지거나 정보의 신뢰성에 대한 보장을 하지 않습니다. "
+"다양한 오픈소스 라이선스에 대한 정보가 필요하십니까? 어떤 라이선스를 선택해야 할지 궁금하신가요? 전체 라이선스 내용을 확인하지 않더라도 아래 사이트에서 각종 라이선스 정보를 비교해 드립니다. 그러나, 이 정보들은 개인적인 용도 및 정보의 역할만 하는 것이고 법적인 정보는 아닙니다. Mozilla는 이들 정보에 대해 책임을 지거나 정보의 신뢰성에 대한"
+" 보장을 하지 않습니다. "
 
 #: src/olympia/pages/templates/pages/dev_faq.html:545
 msgid ""
-"In addition to the full text of the Mozilla Public License(\"MPL\"), this "
-"also provides an annotated version of the MPL and an <abbr "
-"title=\"Frequently Asked Questions\">FAQ</abbr> to help you if you want to "
-"use or distribute code licensed under it."
-msgstr ""
-"Mozilla Public License(\"MPL\")에 대한 전체 내용에 대해 <abbr title=\"Frequently Asked"
-" Questions\">FAQ</abbr>를 이용하시면 자주 묻는 질문에 대한 답을 보실 수 있습니다."
+"In addition to the full text of the Mozilla Public License(\"MPL\"), this also provides an annotated version of the MPL and an <abbr title=\"Frequently Asked Questions\">FAQ</abbr> to help you if "
+"you want to use or distribute code licensed under it."
+msgstr "Mozilla Public License(\"MPL\")에 대한 전체 내용에 대해 <abbr title=\"Frequently Asked Questions\">FAQ</abbr>를 이용하시면 자주 묻는 질문에 대한 답을 보실 수 있습니다."
 
 #: src/olympia/pages/templates/pages/dev_faq.html:559
-msgid ""
-"A table summarizing and comparing how some of the key open source licenses "
-"treat distributions, proprietary software linking, and redistribution of "
-"code with changes."
+msgid "A table summarizing and comparing how some of the key open source licenses treat distributions, proprietary software linking, and redistribution of code with changes."
 msgstr "오픈 소스 라이선스별로 상용 소프트웨어 연결 및 변경 코드 재배포 등에 대한 비교 및 요약 정보"
 
 #: src/olympia/pages/templates/pages/dev_faq.html:572
 msgid ""
-"Free Software Foundation provides short summaries of the key open source "
-"licenses, including whether the license qualifies as a free software license"
-" or a copyleft license. Also includes a discussion of what constitutes a "
-"free software license or a copyleft license (e.g., a Copyleft license is a "
-"general method for making a program or other work free, and requiring all "
-"modified and extended versions of the program to be free as well.)"
-msgstr ""
-"자유소프트웨어재단은 주요 오픈 소스 라이선스에 대한 간단한 요약 및 카피레프트나 자유 SW 라이선스에 대한 정보와 이에 대한 토론 정보를"
-" 제공합니다."
+"Free Software Foundation provides short summaries of the key open source licenses, including whether the license qualifies as a free software license or a copyleft license. Also includes a "
+"discussion of what constitutes a free software license or a copyleft license (e.g., a Copyleft license is a general method for making a program or other work free, and requiring all modified and "
+"extended versions of the program to be free as well.)"
+msgstr "자유소프트웨어재단은 주요 오픈 소스 라이선스에 대한 간단한 요약 및 카피레프트나 자유 SW 라이선스에 대한 정보와 이에 대한 토론 정보를 제공합니다."
 
 #: src/olympia/pages/templates/pages/dev_faq.html:589
-msgid ""
-"Open Source Initiative provides the terms of some of the key open source "
-"licenses."
+msgid "Open Source Initiative provides the terms of some of the key open source licenses."
 msgstr "오픈 소스 이니시티브도 주요 오픈 소스 라이선스에 대한 정보를 제공합니다."
 
 #: src/olympia/pages/templates/pages/dev_faq.html:599
@@ -12026,14 +9927,10 @@ msgid "A comparison of known open source licenses on Wikipedia."
 msgstr ""
 
 #: src/olympia/pages/templates/pages/dev_faq.html:605
-msgid ""
-"A site to provide non-judgmental guidance on choosing a license for your "
-"open source project."
+msgid "A site to provide non-judgmental guidance on choosing a license for your open source project."
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:3
-#: src/olympia/pages/templates/pages/faq.html:9
-#: src/olympia/pages/templates/pages/faq.html:10
+#: src/olympia/pages/templates/pages/faq.html:3 src/olympia/pages/templates/pages/faq.html:9 src/olympia/pages/templates/pages/faq.html:10
 msgid "Frequently Asked Questions"
 msgstr "자주 묻는 질문"
 
@@ -12048,17 +9945,11 @@ msgstr "부가 기능이 뭔가요?"
 #: src/olympia/pages/templates/pages/faq.html:16
 #, python-format
 msgid ""
-"Add-ons are small pieces of software that add new features or functionality "
-"to your installation of %(app_name)s. Add-ons can augment %(app_name)s with "
-"new features, foreign language dictionaries, or change its visual "
-"appearance. Through add-ons, you can customize %(app_name)s to meet your "
-"needs and tastes. <a href=\"%(learnmore_url)s\">Learn more about "
-"customization</a>"
+"Add-ons are small pieces of software that add new features or functionality to your installation of %(app_name)s. Add-ons can augment %(app_name)s with new features, foreign language dictionaries, "
+"or change its visual appearance. Through add-ons, you can customize %(app_name)s to meet your needs and tastes. <a href=\"%(learnmore_url)s\">Learn more about customization</a>"
 msgstr ""
-"부가 기능이란 %(app_name)s에 새로운 기능 및 기능성을 향상시키는 간단한 소프트웨어를 말합니다. 부가 기능은 "
-"%(app_name)s에 새로운 기능, 외국어 사전, 외형 등을 추가시킬 수 있습니다. 부가 기능을 통해 입맛대로 "
-"%(app_name)s을(를) 개인화 할 수 있는겁니다. <a href=\"%(learnmore_url)s\">개인화에 대해 더 "
-"알아보기</a>"
+"부가 기능이란 %(app_name)s에 새로운 기능 및 기능성을 향상시키는 간단한 소프트웨어를 말합니다. 부가 기능은 %(app_name)s에 새로운 기능, 외국어 사전, 외형 등을 추가시킬 수 있습니다. 부가 기능을 통해 입맛대로 %(app_name)s을(를) 개인화 할 수 있는겁니다. <a href=\"%(learnmore_url)s\">개인화에 "
+"대해 더 알아보기</a>"
 
 #: src/olympia/pages/templates/pages/faq.html:26
 msgid "Will add-ons work with my web browser or application?"
@@ -12067,23 +9958,14 @@ msgstr "부가 기능이 제 웹 브라우저나 애플리케이션에서 작동
 #: src/olympia/pages/templates/pages/faq.html:27
 #, python-format
 msgid ""
-"Add-ons listed in this gallery only work with Mozilla-based applications, "
-"such as <a href=\"%(getfirefox_url)s\">Firefox</a>, <a "
-"href=\"%(getmobile_url)s\">Firefox Mobile</a>, <a "
-"href=\"%(getseamonkey_url)s\">SeaMonkey</a>, and <a "
-"href=\"%(getthunderbird_url)s\">Thunderbird</a>. However, not all add-ons "
-"work with each of those applications or every version of those applications."
-" Each add-on specifies which applications and versions it works with, such "
-"as Firefox 2.0 - 3.6.*. For Firefox add-ons, the install buttons will "
-"indicate whether the add-on is compatible or not."
+"Add-ons listed in this gallery only work with Mozilla-based applications, such as <a href=\"%(getfirefox_url)s\">Firefox</a>, <a href=\"%(getmobile_url)s\">Firefox Mobile</a>, <a "
+"href=\"%(getseamonkey_url)s\">SeaMonkey</a>, and <a href=\"%(getthunderbird_url)s\">Thunderbird</a>. However, not all add-ons work with each of those applications or every version of those "
+"applications. Each add-on specifies which applications and versions it works with, such as Firefox 2.0 - 3.6.*. For Firefox add-ons, the install buttons will indicate whether the add-on is "
+"compatible or not."
 msgstr ""
-"이 갤러리에 등재된 부가 기능들은 <a href=\"%(getfirefox_url)s\">Firefox</a>, <a "
-"href=\"%(getmobile_url)s\">Firefox Mobile</a>, <a "
-"href=\"%(getseamonkey_url)s\">SeaMonkey</a>, <a "
-"href=\"%(getthunderbird_url)s\">Thunderbird</a> 등의 Mozilla 기반 애플리케이션에서만 "
-"작동합니다. 그러나 모든 부가 기능이 애플리케이션의 종류 및 버전에 관계없이 무조건 작동하는 것은 아닙니다. 각 부가 기능엔 "
-"Firefox 2.0 - 3.6.* 과 같이 작동하는 애플리케이션의 종류와 버전이 정해져 있습니다. Firefox 부가 기능의 경우 부가"
-" 기능 호환 여부에 따라 설치 버튼이 표시될 것입니다."
+"이 갤러리에 등재된 부가 기능들은 <a href=\"%(getfirefox_url)s\">Firefox</a>, <a href=\"%(getmobile_url)s\">Firefox Mobile</a>, <a href=\"%(getseamonkey_url)s\">SeaMonkey</a>, <a "
+"href=\"%(getthunderbird_url)s\">Thunderbird</a> 등의 Mozilla 기반 애플리케이션에서만 작동합니다. 그러나 모든 부가 기능이 애플리케이션의 종류 및 버전에 관계없이 무조건 작동하는 것은 아닙니다. 각 부가 기능엔 Firefox 2.0 - 3.6.* 과 같이 작동하는 애플리케이션의 종류와 버전이 정해져 있습니다."
+" Firefox 부가 기능의 경우 부가 기능 호환 여부에 따라 설치 버튼이 표시될 것입니다."
 
 #: src/olympia/pages/templates/pages/faq.html:42
 msgid "What are the different types of add-ons?"
@@ -12091,71 +9973,42 @@ msgstr "부가 기능의 종류엔 어떤 것이 있나요?"
 
 #: src/olympia/pages/templates/pages/faq.html:43
 #, python-format
-msgid ""
-"There are several kinds of add-ons that customize %(app_name)s in different "
-"ways:"
+msgid "There are several kinds of add-ons that customize %(app_name)s in different ways:"
 msgstr "%(app_name)s을(를) 여러 방법으로 개인화할 수 있는 다양한 부가 기능들이 있습니다:"
 
 #: src/olympia/pages/templates/pages/faq.html:47
 #, python-format
 msgid ""
-"<strong><a href=\"%(browse_url)s\">Extensions</a></strong> add new features "
-"to %(app_name)s or modify existing functionality. There are extensions that "
-"allow you to block advertisements, download videos from websites, integrate "
-"more closely with social websites, and add features you see in other "
-"applications."
+"<strong><a href=\"%(browse_url)s\">Extensions</a></strong> add new features to %(app_name)s or modify existing functionality. There are extensions that allow you to block advertisements, download "
+"videos from websites, integrate more closely with social websites, and add features you see in other applications."
 msgstr ""
-"<strong><a href=\"%(browse_url)s\">확장 기능</a></strong>은 %(app_name)s에 새로운 기능을"
-" 추가시키거나 기존 기능의 기능성을 개조하는 역할을 합니다. 광고 차단, 웹 사이트에 있는 동영상 다운로드, 소셜 웹사이트의 보다 편리한"
-" 사용 등을 가능하게 해주는 확장 기능이 있으며 다른 웹 브라우저에서 봤음직한 기능도 추가시켜 줍니다."
+"<strong><a href=\"%(browse_url)s\">확장 기능</a></strong>은 %(app_name)s에 새로운 기능을 추가시키거나 기존 기능의 기능성을 개조하는 역할을 합니다. 광고 차단, 웹 사이트에 있는 동영상 다운로드, 소셜 웹사이트의 보다 편리한 사용 등을 가능하게 해주는 확장 기능이 있으며 다른 웹 브라우저에서 봤음직한 "
+"기능도 추가시켜 줍니다."
 
 #: src/olympia/pages/templates/pages/faq.html:55
 #, python-format
-msgid ""
-"<strong><a href=\"%(browse_url)s\">Complete Themes</a></strong> change the "
-"entire appearance of %(app_name)s, usually including icons, colors, dialogs,"
-" and other visual styles."
-msgstr ""
-"<strong><a href=\"%(browse_url)s\">완전 테마</a></strong>는 %(app_name)s의 전체적인 "
-"외형을 변형하며, 아이콘, 색상, 다이얼로그, 그 외 시각적 스타일을 포함하고 있습니다."
+msgid "<strong><a href=\"%(browse_url)s\">Complete Themes</a></strong> change the entire appearance of %(app_name)s, usually including icons, colors, dialogs, and other visual styles."
+msgstr "<strong><a href=\"%(browse_url)s\">완전 테마</a></strong>는 %(app_name)s의 전체적인 외형을 변형하며, 아이콘, 색상, 다이얼로그, 그 외 시각적 스타일을 포함하고 있습니다."
 
 #: src/olympia/pages/templates/pages/faq.html:61
 #, python-format
-msgid ""
-"<strong><a href=\"%(browse_url)s\">Themes</a></strong> are lightweight "
-"themes that use background images to customize your %(app_name)s toolbars."
-msgstr ""
-"<strong><a href=\"%(browse_url)s\">테마</a></strong>는 배경 이미지를 사용해서 "
-"%(app_name)s의 도구 모음 모양을 임의로 변경할 수 있는 가벼운 테마입니다."
+msgid "<strong><a href=\"%(browse_url)s\">Themes</a></strong> are lightweight themes that use background images to customize your %(app_name)s toolbars."
+msgstr "<strong><a href=\"%(browse_url)s\">테마</a></strong>는 배경 이미지를 사용해서 %(app_name)s의 도구 모음 모양을 임의로 변경할 수 있는 가벼운 테마입니다."
 
 #: src/olympia/pages/templates/pages/faq.html:66
 #, python-format
-msgid ""
-"<strong><a href=\"%(browse_url)s\">Search Providers</a> </strong> add "
-"additional choices to the search box dropdown. These providers allow you to "
-"quickly search any website."
-msgstr ""
-"<strong><a href=\"%(browse_url)s\">검색 도구</a></strong>는 검색 상자의 드롭다운 메뉴에 검색 "
-"도구를 추가시켜 줍니다. 이들 검색 도구를 통해 웹 사이트를 빠르게 검색할 수 있습니다."
+msgid "<strong><a href=\"%(browse_url)s\">Search Providers</a> </strong> add additional choices to the search box dropdown. These providers allow you to quickly search any website."
+msgstr "<strong><a href=\"%(browse_url)s\">검색 도구</a></strong>는 검색 상자의 드롭다운 메뉴에 검색 도구를 추가시켜 줍니다. 이들 검색 도구를 통해 웹 사이트를 빠르게 검색할 수 있습니다."
 
 #: src/olympia/pages/templates/pages/faq.html:72
 #, python-format
-msgid ""
-"<strong><a href=\"%(browse_url)s\">Dictionaries & Language "
-"Packs</a></strong> add support for additional languages to %(app_name)s."
-msgstr ""
-"<strong><a href=\"%(browse_url)s\">맞춤법 사전 및 언어팩</a></strong>은 %(app_name)s에 "
-"다른 언어를 추가시켜 줍니다."
+msgid "<strong><a href=\"%(browse_url)s\">Dictionaries & Language Packs</a></strong> add support for additional languages to %(app_name)s."
+msgstr "<strong><a href=\"%(browse_url)s\">맞춤법 사전 및 언어팩</a></strong>은 %(app_name)s에 다른 언어를 추가시켜 줍니다."
 
 #: src/olympia/pages/templates/pages/faq.html:77
 #, python-format
-msgid ""
-"<strong><a href=\"%(browse_url)s\">Plugins</a></strong> help %(app_name)s "
-"display or understand different types of media, such as Adobe Flash or Apple"
-" Quicktime."
-msgstr ""
-"<strong><a href=\"%(browse_url)s\">플러그인</a></strong>은 %(app_name)s가 Adobe "
-"Flash나 Apple Quicktime과 같은 다양한 종류의 매체를 인식하고 표시할 수 있도록 도와줍니다."
+msgid "<strong><a href=\"%(browse_url)s\">Plugins</a></strong> help %(app_name)s display or understand different types of media, such as Adobe Flash or Apple Quicktime."
+msgstr "<strong><a href=\"%(browse_url)s\">플러그인</a></strong>은 %(app_name)s가 Adobe Flash나 Apple Quicktime과 같은 다양한 종류의 매체를 인식하고 표시할 수 있도록 도와줍니다."
 
 #: src/olympia/pages/templates/pages/faq.html:85
 msgid "How do I install, manage, or remove an add-on?"
@@ -12164,19 +10017,12 @@ msgstr "부가 기능의 설치, 관리나 삭제는 어떻게 하는 건가요?
 #: src/olympia/pages/templates/pages/faq.html:86
 #, python-format
 msgid ""
-"In most cases, add-ons can be installed by simply clicking the install "
-"button provided. Add-ons can be managed, disabled, or uninstalled from the "
-"Add-ons Manager in %(app_name)s. For more detailed instructions, read <a "
-"href=\"%(extension_url)s\">this article on extensions</a> or <a "
-"href=\"%(theme_url)s\">this one for Themes and Complete Themes</a>. If you "
-"have difficulty installing add-ons, see <a "
-"href=\"%(troubleshooting_url)s\">Troubleshooting Extensions and Themes</a>."
+"In most cases, add-ons can be installed by simply clicking the install button provided. Add-ons can be managed, disabled, or uninstalled from the Add-ons Manager in %(app_name)s. For more detailed "
+"instructions, read <a href=\"%(extension_url)s\">this article on extensions</a> or <a href=\"%(theme_url)s\">this one for Themes and Complete Themes</a>. If you have difficulty installing add-ons, "
+"see <a href=\"%(troubleshooting_url)s\">Troubleshooting Extensions and Themes</a>."
 msgstr ""
-"부가 기능은 대부분의 경우 설치 버튼 클릭 한번으로 설치가 가능합니다. 설치된 부가 기능은 %(app_name)s의 부가 기능 관리자에서"
-" 관리, 사용 안함, 삭제할 수 있습니다. 자세한 사용법을 알고 싶다면 <a href=\"%(extension_url)s\">확장 기능에"
-" 관한 문서</a>나 <a href=\"%(theme_url)s\">테마 및 완전 테마에 관한 문서</a>를 읽어보시기 바랍니다. 부가 "
-"기능 설치에 어려움을 겪으신다면 <a href=\"%(troubleshooting_url)s\">확장 기능 및 테마 관련 문제 "
-"해결</a> 문서를 참고하십시오."
+"부가 기능은 대부분의 경우 설치 버튼 클릭 한번으로 설치가 가능합니다. 설치된 부가 기능은 %(app_name)s의 부가 기능 관리자에서 관리, 사용 안함, 삭제할 수 있습니다. 자세한 사용법을 알고 싶다면 <a href=\"%(extension_url)s\">확장 기능에 관한 문서</a>나 <a href=\"%(theme_url)s\">테마 및 완전"
+" 테마에 관한 문서</a>를 읽어보시기 바랍니다. 부가 기능 설치에 어려움을 겪으신다면 <a href=\"%(troubleshooting_url)s\">확장 기능 및 테마 관련 문제 해결</a> 문서를 참고하십시오."
 
 #: src/olympia/pages/templates/pages/faq.html:100
 msgid "How do I install add-ons without restarting Firefox?"
@@ -12185,15 +10031,11 @@ msgstr "Firefox를 재시작하지 않고 부가 기능을 설치하려면 어�
 #: src/olympia/pages/templates/pages/faq.html:101
 #, python-format
 msgid ""
-"In Firefox, add-ons marked with \"No restart required\" can be installed "
-"without restarting. These add-ons have been created using the <a "
-"href=\"%(sdk_url)s\">Add-on SDK</a> or <a "
-"href=\"%(bootstrap_url)s\">bootstrapping</a>. Other add-ons will still "
-"require a restart before you can use them."
+"In Firefox, add-ons marked with \"No restart required\" can be installed without restarting. These add-ons have been created using the <a href=\"%(sdk_url)s\">Add-on SDK</a> or <a "
+"href=\"%(bootstrap_url)s\">bootstrapping</a>. Other add-ons will still require a restart before you can use them."
 msgstr ""
-"Firefox에서 \"재시작 필요 없음\"이라고 표시된 부가 기능은 재시작할 필요 없이 설치가 가능합니다. 이러한 부가 기능들은 <a "
-"href=\"%(sdk_url)s\">부가 기능 SDK</a>나 <a href=\"%(bootstrap_url)s\">부트스트랩 "
-"방식</a>을 사용해서 제작됩니다. 이런 방식을 사용하지 않는 경우, 사용하려면 예전처럼 재시작부터 해야 합니다."
+"Firefox에서 \"재시작 필요 없음\"이라고 표시된 부가 기능은 재시작할 필요 없이 설치가 가능합니다. 이러한 부가 기능들은 <a href=\"%(sdk_url)s\">부가 기능 SDK</a>나 <a href=\"%(bootstrap_url)s\">부트스트랩 방식</a>을 사용해서 제작됩니다. 이런 방식을 사용하지 않는 경우, 사용하려면 예전처럼 "
+"재시작부터 해야 합니다."
 
 #: src/olympia/pages/templates/pages/faq.html:110
 msgid "How do I keep add-ons up-to-date?"
@@ -12202,18 +10044,12 @@ msgstr "부가 기능을 어떻게 하면 꾸준히 업데이트를 받을 수 �
 #: src/olympia/pages/templates/pages/faq.html:111
 #, python-format
 msgid ""
-"Add-ons, unlike plugins, are automatically checked for updates once every "
-"day. In Firefox, updates are automatically installed by default. Versions of"
-" Firefox prior to 4 (and other applications) will alert you that updates to "
-"your add-ons are available. <a href=\"%(plugin_url)s\">Plugins</a> are not "
-"currently automatically checked for updates, so be sure to regularly visit "
-"the <a href=\"%(plugincheck_url)s\">Plugin Check</a> page to stay up-to-"
-"date."
+"Add-ons, unlike plugins, are automatically checked for updates once every day. In Firefox, updates are automatically installed by default. Versions of Firefox prior to 4 (and other applications) "
+"will alert you that updates to your add-ons are available. <a href=\"%(plugin_url)s\">Plugins</a> are not currently automatically checked for updates, so be sure to regularly visit the <a "
+"href=\"%(plugincheck_url)s\">Plugin Check</a> page to stay up-to-date."
 msgstr ""
-"부가 기능은 플러그인과 달리 Firefox 내에서 하루에 한번씩 업데이트가 있는지 검사를 해서 자동으로 설치합니다. Firefox "
-"4까지의 구버전은 업데이트가 있을 경우 알림 메세지만 표시됩니다. <a href=\"%(plugin_url)s\">플러그인</a>의 경우"
-" 현재는 업데이트를 자동으로 검사하지는 않지만 정기적으로 <a href=\"%(plugincheck_url)s\">플러그인 "
-"검사</a>페이지 방문해서 업데이트 여부를 확인할 수 있습니다."
+"부가 기능은 플러그인과 달리 Firefox 내에서 하루에 한번씩 업데이트가 있는지 검사를 해서 자동으로 설치합니다. Firefox 4까지의 구버전은 업데이트가 있을 경우 알림 메세지만 표시됩니다. <a href=\"%(plugin_url)s\">플러그인</a>의 경우 현재는 업데이트를 자동으로 검사하지는 않지만 정기적으로 <a "
+"href=\"%(plugincheck_url)s\">플러그인 검사</a>페이지 방문해서 업데이트 여부를 확인할 수 있습니다."
 
 #: src/olympia/pages/templates/pages/faq.html:122
 msgid "Are add-ons safe to install?"
@@ -12222,17 +10058,12 @@ msgstr "부가 기능 설치시 보안에 문제는 없을까요?"
 #: src/olympia/pages/templates/pages/faq.html:123
 #, python-format
 msgid ""
-"Unless clearly marked otherwise, add-ons available from this gallery have "
-"been checked and approved by Mozilla's team of editors and are safe to "
-"install. We recommend that you only install approved add-ons. If you wish to"
-" install unapproved add-ons or add-ons from third-party websites, use "
-"caution as these add-ons may harm your computer or violate your privacy. <a "
+"Unless clearly marked otherwise, add-ons available from this gallery have been checked and approved by Mozilla's team of editors and are safe to install. We recommend that you only install approved"
+" add-ons. If you wish to install unapproved add-ons or add-ons from third-party websites, use caution as these add-ons may harm your computer or violate your privacy. <a "
 "href=\"%(learnmore_url)s\">Learn more about our approval process</a>"
 msgstr ""
-"극히 일부 예외를 제외하고, 이 갤러리에 등재된 부가 기능은 Mozilla 편집자 팀에 의해 검사 및 승인된 것으로 설치하셔도 "
-"안전합니다. 승인된 부가 기능만 설치하는 것을 권장합니다. 승인되지 않은 부가 기능이나 서드파티 웹사이트에 있는 부가 기능을 설치하실 "
-"경우엔 해당 부가 기능이 컴퓨터에 문제를 야기할 수 있거나 개인 정보를 침해할 수 있다는 사실에 주의하시기 바랍니다. <a "
-"href=\"%(learnmore_url)s\">승인 절차에 대해 자세히 알아보기</a>"
+"극히 일부 예외를 제외하고, 이 갤러리에 등재된 부가 기능은 Mozilla 편집자 팀에 의해 검사 및 승인된 것으로 설치하셔도 안전합니다. 승인된 부가 기능만 설치하는 것을 권장합니다. 승인되지 않은 부가 기능이나 서드파티 웹사이트에 있는 부가 기능을 설치하실 경우엔 해당 부가 기능이 컴퓨터에 문제를 야기할 수 있거나 개인 정보를 침해할 수 있다는 "
+"사실에 주의하시기 바랍니다. <a href=\"%(learnmore_url)s\">승인 절차에 대해 자세히 알아보기</a>"
 
 #: src/olympia/pages/templates/pages/faq.html:133
 #, python-format
@@ -12242,36 +10073,24 @@ msgstr "부가 기능이 %(app_name)s을(를) 느리게 만들 수도 있나요?
 #: src/olympia/pages/templates/pages/faq.html:135
 #, python-format
 msgid ""
-"Most add-ons do not cause a perceivable performance decrease in "
-"%(app_name)s, though installing an excessive number may have adverse "
-"effects. If you suspect an add-on is causing %(app_name)s to be slow, try "
-"disabling it."
+"Most add-ons do not cause a perceivable performance decrease in %(app_name)s, though installing an excessive number may have adverse effects. If you suspect an add-on is causing %(app_name)s to be "
+"slow, try disabling it."
 msgstr ""
 
 #: src/olympia/pages/templates/pages/faq.html:141
 #, python-format
-msgid ""
-"%(app_name)s told me an add-on isn't compatible. Is there a way I can still "
-"use it?"
+msgid "%(app_name)s told me an add-on isn't compatible. Is there a way I can still use it?"
 msgstr "%(app_name)s에서 호환되지 않는 부가 기능이 있다고 합니다. 어떻게 계속 쓸 수 있는 방법이 없을까요?"
 
 #: src/olympia/pages/templates/pages/faq.html:144
 #, python-format
 msgid ""
-"If an add-on isn't compatible with your version of %(app_name)s, it is "
-"usually either because your version of %(app_name)s is outdated or the add-"
-"on author has not yet updated the add-on to be compatible with a newer "
-"version you are using. Mozilla does not recommend trying to circumvent these"
-" compatibility checks, as they can lead to browser instability or in some "
-"cases loss of data. For users who are testing out alpha or beta versions of "
-"Firefox, we offer the <a href=\"%(acr_url)s\">Add-on Compatibility "
-"Reporter</a> to help add-on developers update their compatibility."
+"If an add-on isn't compatible with your version of %(app_name)s, it is usually either because your version of %(app_name)s is outdated or the add-on author has not yet updated the add-on to be "
+"compatible with a newer version you are using. Mozilla does not recommend trying to circumvent these compatibility checks, as they can lead to browser instability or in some cases loss of data. For"
+" users who are testing out alpha or beta versions of Firefox, we offer the <a href=\"%(acr_url)s\">Add-on Compatibility Reporter</a> to help add-on developers update their compatibility."
 msgstr ""
-"부가 기능이 현재 사용중인 %(app_name)s 버전과 호환되지 않는다면, 대개는 현재 사용하고 있는 %(app_name)s 버전이 "
-"오래된 것이거나 부가 기능 제작자가 아직 사용중인 신규 버전에 맞게 업데이트를 하지 못했기 때문입니다. Mozilla에선 호환성 검사를 "
-"회피하는 방법을 권장하지 않는데, 브라우저의 안정성에 문제를 야기하거나 어떤 경우엔 데이터 손실도 발생하기 때문입니다. Firefox "
-"알파 또는 베타 버전을 테스트하고 있는 사용자의 경우, <a href=\"%(acr_url)s\">부가 기능 호환성 보고자</a>를 통해"
-" 부가 기능 개발자의 호환성 업데이트를 도와주시면 좋습니다."
+"부가 기능이 현재 사용중인 %(app_name)s 버전과 호환되지 않는다면, 대개는 현재 사용하고 있는 %(app_name)s 버전이 오래된 것이거나 부가 기능 제작자가 아직 사용중인 신규 버전에 맞게 업데이트를 하지 못했기 때문입니다. Mozilla에선 호환성 검사를 회피하는 방법을 권장하지 않는데, 브라우저의 안정성에 문제를 야기하거나 어떤 경우엔"
+" 데이터 손실도 발생하기 때문입니다. Firefox 알파 또는 베타 버전을 테스트하고 있는 사용자의 경우, <a href=\"%(acr_url)s\">부가 기능 호환성 보고자</a>를 통해 부가 기능 개발자의 호환성 업데이트를 도와주시면 좋습니다."
 
 #: src/olympia/pages/templates/pages/faq.html:156
 msgid "What if I have problems with an add-on?"
@@ -12280,17 +10099,12 @@ msgstr "부가 기능을 사용하다 문제가 발생하면 어떻게 해야 �
 #: src/olympia/pages/templates/pages/faq.html:157
 #, python-format
 msgid ""
-"Add-ons are usually created by third-party developers from around the world,"
-" so the best way to get help with an add-on is to look for support links on "
-"the add-on's homepage or contact the developer. If you are having issues "
-"with %(app_name)s that you suspect are related to add-ons you have "
-"installed, <a href=\"%(troubleshooting_url)s\">visit this support "
-"article</a> for troubleshooting tips."
+"Add-ons are usually created by third-party developers from around the world, so the best way to get help with an add-on is to look for support links on the add-on's homepage or contact the "
+"developer. If you are having issues with %(app_name)s that you suspect are related to add-ons you have installed, <a href=\"%(troubleshooting_url)s\">visit this support article</a> for "
+"troubleshooting tips."
 msgstr ""
-"부가 기능은 세계 각지의 서드파티 개발자들에 의해 제작되고 있습니다. 그러므로 부가 기능 사용에 대한 도움을 받고자 한다면 해당 부가 "
-"기능의 홈페이지에 있는 기술 지원 링크를 들어가 보거나 개발자와 직접 연락하는 방법이 가장 좋습니다. %(app_name)s에 문제가 "
-"발생했을 경우, 일단 설치해놓은 부가 기능을 먼저 의심해 보도록 하십시오. 문제 해결에 관한 팁을 찾아보시려면 <a "
-"href=\"%(troubleshooting_url)s\">다음의 기술 지원 게시물을 읽어보시기 바랍니다</a>."
+"부가 기능은 세계 각지의 서드파티 개발자들에 의해 제작되고 있습니다. 그러므로 부가 기능 사용에 대한 도움을 받고자 한다면 해당 부가 기능의 홈페이지에 있는 기술 지원 링크를 들어가 보거나 개발자와 직접 연락하는 방법이 가장 좋습니다. %(app_name)s에 문제가 발생했을 경우, 일단 설치해놓은 부가 기능을 먼저 의심해 보도록 하십시오. 문제 "
+"해결에 관한 팁을 찾아보시려면 <a href=\"%(troubleshooting_url)s\">다음의 기술 지원 게시물을 읽어보시기 바랍니다</a>."
 
 #: src/olympia/pages/templates/pages/faq.html:169
 msgid "Add-on Gallery"
@@ -12300,18 +10114,13 @@ msgstr "부가 기능 갤러리"
 msgid "How do I choose between add-ons that seem to do the same thing?"
 msgstr "똑같아 보이는 두 부가 기능 중 어느 것을 고르면 될까요?"
 
-#: src/olympia/pages/templates/pages/faq.html:173
+#: src/olympia/pages/templates/pages/faq.html:172
 msgid ""
-"There are often several add-ons that have similar features. To figure out "
-"which is right for you, read the entire description of the add-on and view "
-"its screenshots. If there are still several in the running, read through the"
-" add-on's ratings, user reviews, and statistics to see which is most liked "
-"by other users. Remember that you can also just try out both and see which "
-"you like better."
+"There are often several add-ons that have similar features. To figure out which is right for you, read the entire description of the add-on and view its screenshots. If there are still several in "
+"the running, read through the add-on's ratings, user reviews, and statistics to see which is most liked by other users. Remember that you can also just try out both and see which you like better."
 msgstr ""
-"유사한 기능을 가진 부가 기능들이 여럿 있습니다. 자신에게 맞는 것이 어떤 것인가 알아보려면 부가 기능 설명을 모두 읽어보거나 스크린샷을"
-" 살펴보는 것이 좋습니다. 그래도 추려내지 못하겠다면, 부가 기능에 매겨진 별점, 사용자 평가, 통계 등을 통해 다른 사용자들이 어느것을"
-" 가장 좋아하는가를 살펴보도록 하세요. 둘 다 써본 후 어느것이 더 좋은가 보는 방법도 있다는 것을 기억하시구요."
+"유사한 기능을 가진 부가 기능들이 여럿 있습니다. 자신에게 맞는 것이 어떤 것인가 알아보려면 부가 기능 설명을 모두 읽어보거나 스크린샷을 살펴보는 것이 좋습니다. 그래도 추려내지 못하겠다면, 부가 기능에 매겨진 별점, 사용자 평가, 통계 등을 통해 다른 사용자들이 어느것을 가장 좋아하는가를 살펴보도록 하세요. 둘 다 써본 후 어느것이 더 좋은가 보는 "
+"방법도 있다는 것을 기억하시구요."
 
 #: src/olympia/pages/templates/pages/faq.html:180
 msgid "What if I can't find an add-on I'm looking for?"
@@ -12320,30 +10129,20 @@ msgstr "부가 기능을 찾지 못할 경우 어떻게 해야 하나요?"
 #: src/olympia/pages/templates/pages/faq.html:181
 #, python-format
 msgid ""
-"With thousands of add-ons available, there's something for everyone. But if "
-"you're looking for a particular add-on and can't find it, you might try "
-"searching on other sites or posting about it in our <a href=\"%(forum_url)s"
-"\">Add-ons </a>forum."
+"With thousands of add-ons available, there's something for everyone. But if you're looking for a particular add-on and can't find it, you might try searching on other sites or posting about it in "
+"our <a href=\"%(forum_url)s\">Add-ons </a>forum."
 msgstr ""
 
 #: src/olympia/pages/templates/pages/faq.html:187
-msgid ""
-"What does it mean if an add-on is \"experimental\" or \"preliminarily "
-"reviewed\"?"
+msgid "What does it mean if an add-on is \"experimental\" or \"preliminarily reviewed\"?"
 msgstr "부가 기능이 \"시험용\" 이나 \"예비 심사 완료\" 되었다는 것이 뭘 의미하나요?"
 
 #: src/olympia/pages/templates/pages/faq.html:188
 #, python-format
 msgid ""
-"Experimental add-ons have been checked by our editors to make sure they "
-"don't have security problems, but they may still have bugs or not work "
-"properly. Use caution when installing experimental add-ons and uninstall the"
-" add-on immediately if you notice problems. <a href=\"%(url)s\">Learn more "
-"about our review process</a></dd>"
-msgstr ""
-"시험용 부가 기능은 편집자에 의해 보안 문제가 없음을 확인받았지만 버그가 다수 있어 제대로 작동이 되지 않는다는 의미를 가지고 있습니다."
-" 시험용 부가 기능은 주의해서 설치하시고 문제점이 발견되면 바로 삭제를 해 주세요. <a href=\"%(url)s\">심사 과정에 대해"
-" 더 알아보기</a></dd>"
+"Experimental add-ons have been checked by our editors to make sure they don't have security problems, but they may still have bugs or not work properly. Use caution when installing experimental "
+"add-ons and uninstall the add-on immediately if you notice problems. <a href=\"%(url)s\">Learn more about our review process</a></dd>"
+msgstr "시험용 부가 기능은 편집자에 의해 보안 문제가 없음을 확인받았지만 버그가 다수 있어 제대로 작동이 되지 않는다는 의미를 가지고 있습니다. 시험용 부가 기능은 주의해서 설치하시고 문제점이 발견되면 바로 삭제를 해 주세요. <a href=\"%(url)s\">심사 과정에 대해 더 알아보기</a></dd>"
 
 #: src/olympia/pages/templates/pages/faq.html:196
 msgid "What does it mean if an add-on is \"not reviewed\"?"
@@ -12352,217 +10151,157 @@ msgstr "부가 기능이 \"심사되지 않음\"이 뭘 의미하는 건가요?"
 #: src/olympia/pages/templates/pages/faq.html:197
 #, python-format
 msgid ""
-"While all add-ons publicly available in our gallery are reviewed by an "
-"editor, you may receive a direct link to an add-on that hasn't yet been "
-"reviewed. Use caution when installing these add-ons, as they could harm your"
-" computer or violate your privacy. We recommend that you only install "
-"reviewed add-ons. <a href=\"%(url)s\">Learn more about our review "
-"process</a></dd>"
+"While all add-ons publicly available in our gallery are reviewed by an editor, you may receive a direct link to an add-on that hasn't yet been reviewed. Use caution when installing these add-ons, "
+"as they could harm your computer or violate your privacy. We recommend that you only install reviewed add-ons. <a href=\"%(url)s\">Learn more about our review process</a></dd>"
 msgstr ""
-"갤러리에 등재된 모든 부가 기능은 편집자의 심사를 거친 것으로, 심사를 받지 않은 부가 기능은 다이렉트 링크를 통해서 접근해야 합니다. "
-"이러한 부가 기능은 컴퓨터 내지는 자신의 개인 정보에 해가 될 우려가 있으므로 설치시 주의가 필요합니다. 저희는 심사를 거친 부가 기능만"
-" 설치하는 것을 권장하고 있습니다. <a href=\"%(url)s\">심사 과정에 대해 더 알아보기</a></dd>"
+"갤러리에 등재된 모든 부가 기능은 편집자의 심사를 거친 것으로, 심사를 받지 않은 부가 기능은 다이렉트 링크를 통해서 접근해야 합니다. 이러한 부가 기능은 컴퓨터 내지는 자신의 개인 정보에 해가 될 우려가 있으므로 설치시 주의가 필요합니다. 저희는 심사를 거친 부가 기능만 설치하는 것을 권장하고 있습니다. <a href=\"%(url)s\">심사 "
+"과정에 대해 더 알아보기</a></dd>"
 
 #: src/olympia/pages/templates/pages/faq.html:206
 msgid "How much do add-ons cost to purchase?"
 msgstr "부가 기능을 구입하려면 얼마 정도가 드나요?"
 
 #: src/olympia/pages/templates/pages/faq.html:207
-msgid ""
-"Add-ons hosted in our gallery are free unless clearly marked otherwise."
+msgid "Add-ons hosted in our gallery are free unless clearly marked otherwise."
 msgstr "저희 갤러리에 등록된 부가 기능들은 모두 무료입니다."
 
-#: src/olympia/pages/templates/pages/faq.html:210
+#: src/olympia/pages/templates/pages/faq.html:209
 msgid "What does it mean when an add-on asks for contributions?"
 msgstr "부가 기능이 기부자를 찾는 이유가 뭔가요?"
 
-#: src/olympia/pages/templates/pages/faq.html:211
+#: src/olympia/pages/templates/pages/faq.html:210
 msgid ""
-"Some add-on authors request users who enjoy an add-on to contribute to its "
-"development by making a monetary contribution. These contributions go "
-"directly to the developer unless a third party is indicated, such as the "
-"non-profit Mozilla Foundation."
-msgstr ""
-"부가 기능 제작자들 중 일부는 금전 기부를 통해 개발 지원을 돕는 사용자를 필요로 하고 있습니다. 기부를 원하는 사람은 Mozilla "
-"재단과 같이 비영리 서드파티를 표방하는 개발자가 아닌 이상 어떤 개발자든 즉시 기부금을 보탤 수 있습니다."
+"Some add-on authors request users who enjoy an add-on to contribute to its development by making a monetary contribution. These contributions go directly to the developer unless a third party is "
+"indicated, such as the non-profit Mozilla Foundation."
+msgstr "부가 기능 제작자들 중 일부는 금전 기부를 통해 개발 지원을 돕는 사용자를 필요로 하고 있습니다. 기부를 원하는 사람은 Mozilla 재단과 같이 비영리 서드파티를 표방하는 개발자가 아닌 이상 어떤 개발자든 즉시 기부금을 보탤 수 있습니다."
 
-#: src/olympia/pages/templates/pages/faq.html:216
+#: src/olympia/pages/templates/pages/faq.html:215
 msgid "What are beta add-ons?"
 msgstr "베타 부가 기능이 뭔가요?"
 
-#: src/olympia/pages/templates/pages/faq.html:218
+#: src/olympia/pages/templates/pages/faq.html:217
 msgid ""
-"Beta add-ons are unreviewed versions which represent the latest work of an "
-"add-on author. While different authors have different standards for beta "
-"code quality, you should assume that these add-ons are less stable than the "
-"general add-on releases."
-msgstr ""
-"베타 버전 부가 기능은 부가 기능 제작자의 최신 작업 버전으로 심사되지 않은 버전을 말합니다. 제작자마다 베타 상태의 코드 품질이 "
-"다르므로, 이들 부가 기능은 정식 배포판 부가 기능보다 안정성이 떨어진다는 점을 양지해 주시기 바랍니다."
+"Beta add-ons are unreviewed versions which represent the latest work of an add-on author. While different authors have different standards for beta code quality, you should assume that these add-"
+"ons are less stable than the general add-on releases."
+msgstr "베타 버전 부가 기능은 부가 기능 제작자의 최신 작업 버전으로 심사되지 않은 버전을 말합니다. 제작자마다 베타 상태의 코드 품질이 다르므로, 이들 부가 기능은 정식 배포판 부가 기능보다 안정성이 떨어진다는 점을 양지해 주시기 바랍니다."
 
-#: src/olympia/pages/templates/pages/faq.html:222
+#: src/olympia/pages/templates/pages/faq.html:221
 msgid ""
-"Please note that when you install an add-on from the \"Beta Version\" "
-"section of an add-on's listing, you will continue to receive updates for "
-"that add-on as they become available. Like the initial version you "
-"installed, all beta releases are unreviewed by Mozilla and may harm your "
-"computer."
-msgstr ""
-"부가 기능 일람 페이지의 \"베타 버전\" 항목에서 부가 기능을 설치하시면 지속적으로 해당 부가 기능의 업데이트를 제공받게 된다는 사실도"
-" 기억하시기 바랍니다. 처음 설치했던 버전과 마찬가지로 모든 베타 버전은 Mozilla의 심사를 받지 않았기 때문에 컴퓨터에 해가 될 "
-"수도 있습니다."
+"Please note that when you install an add-on from the \"Beta Version\" section of an add-on's listing, you will continue to receive updates for that add-on as they become available. Like the initial"
+" version you installed, all beta releases are unreviewed by Mozilla and may harm your computer."
+msgstr "부가 기능 일람 페이지의 \"베타 버전\" 항목에서 부가 기능을 설치하시면 지속적으로 해당 부가 기능의 업데이트를 제공받게 된다는 사실도 기억하시기 바랍니다. 처음 설치했던 버전과 마찬가지로 모든 베타 버전은 Mozilla의 심사를 받지 않았기 때문에 컴퓨터에 해가 될 수도 있습니다."
 
-#: src/olympia/pages/templates/pages/faq.html:229
+#: src/olympia/pages/templates/pages/faq.html:228
 msgid "What does it mean when an add-on is flagged as slow?"
 msgstr "느리다는 표시가 되어있는 부가 기능은 무슨 의미인가요?"
 
-#: src/olympia/pages/templates/pages/faq.html:231
-msgid ""
-"Most add-ons load code and resources at the same time Firefox\n"
-"        is starting up. In most cases the impact in start-up time is minimal,\n"
-"        but some add-ons can cause a noticeable slowdown."
+#: src/olympia/pages/templates/pages/faq.html:229
+msgid "Most add-ons load code and resources at the same time Firefox is starting up. In most cases the impact in start-up time is minimal, but some add-ons can cause a noticeable slowdown."
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:236
+#: src/olympia/pages/templates/pages/faq.html:234
 msgid "How do I report an inappropriate or spam user review?"
 msgstr "부적절한 평가나 스팸을 신고하려면 어떻게 해야 하나요?"
 
-#: src/olympia/pages/templates/pages/faq.html:237
+#: src/olympia/pages/templates/pages/faq.html:235
 msgid ""
-"To report a user review of an add-on, log in with your account and visit the"
-" add-on's reviews page. Find the review you wish to report, click \"Report "
-"this review\" and select a reason. Our editorial team will investigate the "
-"review and take appropriate action."
-msgstr ""
-"부가 기능의 사용자 평가를 신고하려면, 계정 로그인을 한 후 부가 기능 평가 페이지로 들어가세요. 신고하려는 평가를 찾은 후, \"평가 "
-"신고하기\"를 클릭해서 사유를 선택하시면 됩니다. 저희 편집자 팀이 해당 평가를 조사한 후 적절한 조치를 취하게 될 것입니다."
+"To report a user review of an add-on, log in with your account and visit the add-on's reviews page. Find the review you wish to report, click \"Report this review\" and select a reason. Our "
+"editorial team will investigate the review and take appropriate action."
+msgstr "부가 기능의 사용자 평가를 신고하려면, 계정 로그인을 한 후 부가 기능 평가 페이지로 들어가세요. 신고하려는 평가를 찾은 후, \"평가 신고하기\"를 클릭해서 사유를 선택하시면 됩니다. 저희 편집자 팀이 해당 평가를 조사한 후 적절한 조치를 취하게 될 것입니다."
 
-#: src/olympia/pages/templates/pages/faq.html:242
+#: src/olympia/pages/templates/pages/faq.html:240
 msgid "How do I report a bug or contact the Mozilla Add-ons team?"
 msgstr "Mozilla 부가 기능 팀에 연락을 취하거나 버그를 신고하려면 어떻게 해야 하나요?"
 
-#: src/olympia/pages/templates/pages/faq.html:243
+#: src/olympia/pages/templates/pages/faq.html:241
 #, python-format
 msgid "Please visit our <a href=\"%(contact_url)s\">Contact page</a>."
 msgstr "<a href=\"%(contact_url)s\">연락처 정보 페이지</a>를 들어가 보세요."
 
-#: src/olympia/pages/templates/pages/faq.html:246
+#: src/olympia/pages/templates/pages/faq.html:244
 msgid "What is a Source Code License?"
 msgstr "소스 코드 라이선스가 무엇입니까?"
 
-#: src/olympia/pages/templates/pages/faq.html:247
+#: src/olympia/pages/templates/pages/faq.html:245
 #, python-format
 msgid ""
-"The source code used to create an add-on is an exclusive copyright of the "
-"add-on author, unless otherwise declared in a source code license. Many add-"
-"ons on this site have <a href=\"%(url)s\" lang=\"en\">open source "
-"licenses</a> that make the source code publicly available for copy and reuse"
-" under conditions determined by the author. Most authors choose widely known"
-" open source licenses like the GPL or BSD licenses instead of making up "
-"their own."
+"The source code used to create an add-on is an exclusive copyright of the add-on author, unless otherwise declared in a source code license. Many add-ons on this site have <a href=\"%(url)s\" "
+"lang=\"en\">open source licenses</a> that make the source code publicly available for copy and reuse under conditions determined by the author. Most authors choose widely known open source licenses"
+" like the GPL or BSD licenses instead of making up their own."
 msgstr ""
-"부가 기능 제작시 소스 코드는 제작자의 배타적 저작권 내지는 적어도 소스 코드에 라이선스가 있다는 선언 정도는 해야 합니다. 이곳 "
-"사이트의 여러 부가 기능이 <a href=\"%(url)s\" lang=\"en\">오픈 소스 라이선스</a>를 가지고 있으며 이는 소스"
-" 코드를 공개해서 복제 및 재사용이 가능하다는 제작자의 의지가 반영된 상태로 제작되었음을 의미합니다. 많은 제작자들이 자체 라이선스를 "
-"제작히기 보다는 널리 알려진 GPL이나 BSD 라이선스를 채용하고 있습니다."
+"부가 기능 제작시 소스 코드는 제작자의 배타적 저작권 내지는 적어도 소스 코드에 라이선스가 있다는 선언 정도는 해야 합니다. 이곳 사이트의 여러 부가 기능이 <a href=\"%(url)s\" lang=\"en\">오픈 소스 라이선스</a>를 가지고 있으며 이는 소스 코드를 공개해서 복제 및 재사용이 가능하다는 제작자의 의지가 반영된 상태로 "
+"제작되었음을 의미합니다. 많은 제작자들이 자체 라이선스를 제작히기 보다는 널리 알려진 GPL이나 BSD 라이선스를 채용하고 있습니다."
 
-#: src/olympia/pages/templates/pages/faq.html:256
+#: src/olympia/pages/templates/pages/faq.html:254
 #, python-format
-msgid ""
-"Firefox and other Mozilla software are <a href=\"%(url)s\">open source</a>."
+msgid "Firefox and other Mozilla software are <a href=\"%(url)s\">open source</a>."
 msgstr "Firefox 및 다른 Moziila 소프트웨어들은 <a href=\"%(url)s\">오픈 소스</a> 프로그램 입니다."
 
-#: src/olympia/pages/templates/pages/faq.html:264
+#: src/olympia/pages/templates/pages/faq.html:262
 msgid "Collections and Favorites"
 msgstr "모음집 및 선호 목록"
 
-#: src/olympia/pages/templates/pages/faq.html:267
+#: src/olympia/pages/templates/pages/faq.html:265
 msgid "What is a collection?"
 msgstr "모음집이 뭐지요?"
 
-#: src/olympia/pages/templates/pages/faq.html:268
+#: src/olympia/pages/templates/pages/faq.html:266
 msgid "Collections are groups of related add-ons created by users to share."
 msgstr "모음집이란 공유를 위해 사용자가 서로 관련이 있는 부가 기능을 묶어서 제작한 것을 말합니다."
 
-#: src/olympia/pages/templates/pages/faq.html:270
+#: src/olympia/pages/templates/pages/faq.html:268
 msgid "What is the My Favorites collection?"
 msgstr "내가 좋아하는 모음집이 뭔가요?"
 
-#: src/olympia/pages/templates/pages/faq.html:271
-msgid ""
-"Favorite add-ons are add-ons that you have bookmarked to easily get back to "
-"later. You can add an add-on to your favorites collection by clicking \"Add "
-"to favorites\" on its details page."
-msgstr ""
-"부가 기능을 선호 목록에 추가하면 나중에 쉽게 찾아볼 수 있습니다. 이곳 세부 내역 페이지에 있는 \"선호 목록에 추가하기\"를 클릭해서"
-" 선호 목록에 부가 기능을 추가할 수 있습니다."
+#: src/olympia/pages/templates/pages/faq.html:269
+msgid "Favorite add-ons are add-ons that you have bookmarked to easily get back to later. You can add an add-on to your favorites collection by clicking \"Add to favorites\" on its details page."
+msgstr "부가 기능을 선호 목록에 추가하면 나중에 쉽게 찾아볼 수 있습니다. 이곳 세부 내역 페이지에 있는 \"선호 목록에 추가하기\"를 클릭해서 선호 목록에 부가 기능을 추가할 수 있습니다."
 
-#: src/olympia/pages/templates/pages/faq.html:275
-#: src/olympia/templates/menu_links.html:13
-#: src/olympia/templates/impala/header_title.html:17
+#: src/olympia/pages/templates/pages/faq.html:273 src/olympia/templates/menu_links.html:13 src/olympia/templates/impala/header_title.html:17
 msgid "Mobile Add-ons"
 msgstr "모바일 부가 기능"
 
-#: src/olympia/pages/templates/pages/faq.html:278
+#: src/olympia/pages/templates/pages/faq.html:276
 msgid "What are mobile add-ons?"
 msgstr "모바일 부가 기능이 뭔가요?"
 
-#: src/olympia/pages/templates/pages/faq.html:279
+#: src/olympia/pages/templates/pages/faq.html:277
 #, python-format
 msgid ""
-"Mobile add-ons work with <a href=\"%(mobile_url)s\">Firefox for Mobile</a> "
-"and add or modify functionality just like desktop add-ons. You can find add-"
-"ons that work with Firefox for Mobile in our <a "
-"href=\"%(gallery_url)s\">gallery</a>."
-msgstr ""
-"모바일 부가 기능은 <a href=\"%(mobile_url)s\">Mobile Firefox</a>에서 작동하며 데스크톱 부가 기능과 "
-"마찬가지로 기능의 추가와 개조가 가능합니다. 저희 <a href=\"%(gallery_url)s\">갤러리</a>에서 Firefox "
-"모바일 부가 기능을 만나보실 수 있습니다."
+"Mobile add-ons work with <a href=\"%(mobile_url)s\">Firefox for Mobile</a> and add or modify functionality just like desktop add-ons. You can find add-ons that work with Firefox for Mobile in our "
+"<a href=\"%(gallery_url)s\">gallery</a>."
+msgstr "모바일 부가 기능은 <a href=\"%(mobile_url)s\">Mobile Firefox</a>에서 작동하며 데스크톱 부가 기능과 마찬가지로 기능의 추가와 개조가 가능합니다. 저희 <a href=\"%(gallery_url)s\">갤러리</a>에서 Firefox 모바일 부가 기능을 만나보실 수 있습니다."
 
-#: src/olympia/pages/templates/pages/faq.html:288
+#: src/olympia/pages/templates/pages/faq.html:286
 msgid "Developer Topics"
 msgstr "개발자 관련"
 
-#: src/olympia/pages/templates/pages/faq.html:289
+#: src/olympia/pages/templates/pages/faq.html:287
 #, python-format
-msgid ""
-"Please see our <a href=\"%(faq_url)s\">Developer FAQ</a> and <a "
-"href=\"%(hub_url)s\">Developer Hub</a> for answers to add-on developer-"
-"related questions."
-msgstr ""
-"개발자와 관련된 질문에 대한 답을 얻으려면 저희 <a href=\"%(faq_url)s\">개발자 FAQ</a>와 <a "
-"href=\"%(hub_url)s\">개발자 허브</a>를 살펴보세요."
+msgid "Please see our <a href=\"%(faq_url)s\">Developer FAQ</a> and <a href=\"%(hub_url)s\">Developer Hub</a> for answers to add-on developer-related questions."
+msgstr "개발자와 관련된 질문에 대한 답을 얻으려면 저희 <a href=\"%(faq_url)s\">개발자 FAQ</a>와 <a href=\"%(hub_url)s\">개발자 허브</a>를 살펴보세요."
 
-#: src/olympia/pages/templates/pages/faq.html:294
+#: src/olympia/pages/templates/pages/faq.html:292
 msgid "Still have questions?"
 msgstr "궁금한게 더 있으신가요?"
 
-#: src/olympia/pages/templates/pages/faq.html:295
+#: src/olympia/pages/templates/pages/faq.html:293
 #, python-format
-msgid ""
-"For general Firefox support, visit our <a href=\"%(sumo_url)s\">support "
-"website</a>. For general add-on and website questions, visit our <a "
-"href=\"%(forum_url)s\">forum</a>."
-msgstr ""
-"Firefox의 일반적인 고객 지원을 받으시려면 <a href=\"%(sumo_url)s\">고객 지원 웹사이트</a>를 방문하시기 "
-"바랍니다. 일반적인 부가 기능 및 웹사이트에 관한 문제라면 저희 <a href=\"%(forum_url)s\">포럼</a>을 방문해 "
-"주세요."
+msgid "For general Firefox support, visit our <a href=\"%(sumo_url)s\">support website</a>. For general add-on and website questions, visit our <a href=\"%(forum_url)s\">forum</a>."
+msgstr "Firefox의 일반적인 고객 지원을 받으시려면 <a href=\"%(sumo_url)s\">고객 지원 웹사이트</a>를 방문하시기 바랍니다. 일반적인 부가 기능 및 웹사이트에 관한 문제라면 저희 <a href=\"%(forum_url)s\">포럼</a>을 방문해 주세요."
 
-#: src/olympia/pages/templates/pages/review_guide.html:36
-#: src/olympia/pages/templates/pages/review_guide.html:51
+#: src/olympia/pages/templates/pages/review_guide.html:36 src/olympia/pages/templates/pages/review_guide.html:51
 msgid "Some tips for writing a great review"
 msgstr "훌륭한 평가를 쓰기 위한 몇 가지 팁"
 
-#: src/olympia/pages/templates/pages/review_guide.html:39
-#: src/olympia/pages/templates/pages/review_guide.html:131
+#: src/olympia/pages/templates/pages/review_guide.html:39 src/olympia/pages/templates/pages/review_guide.html:131
 msgid "Frequently Asked Questions about Reviews"
 msgstr "평가 작성에 관한 자주 묻는 질문들"
 
 #: src/olympia/pages/templates/pages/review_guide.html:46
 msgid ""
-"Add-on reviews are a way for you to share your opinions about the add-ons "
-"you’ve installed and used. Our review moderation team reserves the right to "
-"refuse or remove any review that does not comply with these guidelines."
+"Add-on reviews are a way for you to share your opinions about the add-ons you’ve installed and used. Our review moderation team reserves the right to refuse or remove any review that does not "
+"comply with these guidelines."
 msgstr ""
 
 #: src/olympia/pages/templates/pages/review_guide.html:53
@@ -12570,8 +10309,7 @@ msgid "Do:"
 msgstr "하세요:"
 
 #: src/olympia/pages/templates/pages/review_guide.html:56
-msgid ""
-"Write like you are telling a friend about your experience with the add-on."
+msgid "Write like you are telling a friend about your experience with the add-on."
 msgstr "친구에게 부가 기능 사용 경험을 이야기하는 식으로 작성해 주세요."
 
 #: src/olympia/pages/templates/pages/review_guide.html:61
@@ -12603,8 +10341,7 @@ msgid "Will you continue to use this add-on?"
 msgstr "이 부가 기능을 앞으로도 사용할 용의가 있는지?"
 
 #: src/olympia/pages/templates/pages/review_guide.html:73
-msgid ""
-"Take a moment to read your review before submitting it to minimize typos."
+msgid "Take a moment to read your review before submitting it to minimize typos."
 msgstr ""
 
 #: src/olympia/pages/templates/pages/review_guide.html:79
@@ -12617,9 +10354,8 @@ msgstr ""
 
 #: src/olympia/pages/templates/pages/review_guide.html:87
 msgid ""
-"Post technical issues, support requests, or feature suggestions. Use the "
-"available support options for each add-on, if available. You can find them "
-"in the side column next to the About this Add-on section."
+"Post technical issues, support requests, or feature suggestions. Use the available support options for each add-on, if available. You can find them in the side column next to the About this Add-on "
+"section."
 msgstr ""
 
 #: src/olympia/pages/templates/pages/review_guide.html:92
@@ -12627,38 +10363,29 @@ msgid "Write reviews for add-ons which you have not personally used."
 msgstr "사용하고 있지도 않은 부가 기능에 대한 평가는 올리지 마세요."
 
 #: src/olympia/pages/templates/pages/review_guide.html:97
-msgid ""
-"Use profanity, sexual language or language that can be construed as hateful."
+msgid "Use profanity, sexual language or language that can be construed as hateful."
 msgstr "신성 모독, 외설적이거나 혐오감을 줄 수 있는 단어를 적지 마세요."
 
 #: src/olympia/pages/templates/pages/review_guide.html:103
-msgid ""
-"Include HTML, links, source code or code snippets. Reviews are meant to be "
-"text only."
+msgid "Include HTML, links, source code or code snippets. Reviews are meant to be text only."
 msgstr ""
 
 #: src/olympia/pages/templates/pages/review_guide.html:108
-msgid ""
-"Make false statements, disparage add-on authors or personally insult them."
+msgid "Make false statements, disparage add-on authors or personally insult them."
 msgstr "부가 기능 제작자를 깎아내리거나 개인적인 모욕을 주려는 의도로 날조된 글을 올리지 마세요."
 
 #: src/olympia/pages/templates/pages/review_guide.html:114
-msgid ""
-"Include your own or anyone else’s email, phone number, or other personal "
-"details."
+msgid "Include your own or anyone else’s email, phone number, or other personal details."
 msgstr ""
 
 #: src/olympia/pages/templates/pages/review_guide.html:119
-msgid ""
-"Post reviews for an add-on you or your organization wrote or represent."
+msgid "Post reviews for an add-on you or your organization wrote or represent."
 msgstr "집단이나 조직 명의로 평가를 작성하거나 그들을 대표해서 작성하지 마세요."
 
 #: src/olympia/pages/templates/pages/review_guide.html:125
 msgid ""
-"Criticize an add-on for something it’s intended to do. For example, leaving "
-"a negative review of an add-on for displaying ads or requiring data "
-"gathering, when that is the intended purpose of the add-on, or the add-on "
-"requires gathering data to function."
+"Criticize an add-on for something it’s intended to do. For example, leaving a negative review of an add-on for displaying ads or requiring data gathering, when that is the intended purpose of the "
+"add-on, or the add-on requires gathering data to function."
 msgstr ""
 
 #: src/olympia/pages/templates/pages/review_guide.html:133
@@ -12667,10 +10394,8 @@ msgstr "문제성 평가는 어떻게 신고할 수 있나요?"
 
 #: src/olympia/pages/templates/pages/review_guide.html:135
 msgid ""
-"Please report or flag any questionable reviews by clicking the \"Report this"
-" review\" and it will be submitted to the site for moderation. Our "
-"moderation team will use the Review Guidelines to evaluate whether or not to"
-" delete the review or restore it back to the site."
+"Please report or flag any questionable reviews by clicking the \"Report this review\" and it will be submitted to the site for moderation. Our moderation team will use the Review Guidelines to "
+"evaluate whether or not to delete the review or restore it back to the site."
 msgstr ""
 
 #: src/olympia/pages/templates/pages/review_guide.html:140
@@ -12679,10 +10404,7 @@ msgstr "부가 기능 제작자입니다. 평가에 답변을 달 수 있나요?
 
 #: src/olympia/pages/templates/pages/review_guide.html:142
 #, python-format
-msgid ""
-"Yes, add-on authors can provide a single response to a review. You can set "
-"up a discussion topic in our <a href=\"%(forum_url)s\">forum</a> to engage "
-"in additional discussion or follow-up."
+msgid "Yes, add-on authors can provide a single response to a review. You can set up a discussion topic in our <a href=\"%(forum_url)s\">forum</a> to engage in additional discussion or follow-up."
 msgstr ""
 
 #: src/olympia/pages/templates/pages/review_guide.html:149
@@ -12691,11 +10413,8 @@ msgstr "부가 기능 제작자입니다. 맘에 들지 않는 평가나 별점�
 
 #: src/olympia/pages/templates/pages/review_guide.html:151
 msgid ""
-"In general, no. But if the review did not meet the review guidelines "
-"outlined above, you can click \"Report this review\" and have it moderated. "
-"If a review included a complaint that is no longer valid due to a new "
-"release of your add-on, we may consider deleting the review. Submit your "
-"detailed request to amo-editors@mozilla.org."
+"In general, no. But if the review did not meet the review guidelines outlined above, you can click \"Report this review\" and have it moderated. If a review included a complaint that is no longer "
+"valid due to a new release of your add-on, we may consider deleting the review. Submit your detailed request to amo-editors@mozilla.org."
 msgstr ""
 
 #: src/olympia/pages/templates/pages/sunbird.html:26
@@ -12704,22 +10423,14 @@ msgstr "Sunbird 개발 중단"
 
 #: src/olympia/pages/templates/pages/sunbird.html:29
 msgid ""
-"Development on the Sunbird project has halted and its final release was on "
-"March 30, 2010. We've been proud to host Sunbird add-ons on this site but as"
-" the project is no longer maintained we have disabled our support for the "
-"add-ons."
-msgstr ""
-"Sunbird 개발 프로젝트가 중단되었으며 마지막 버전은 2010년 3월 30일에 출시되었습니다. 본 사이트에선 Sunbird 부가 "
-"기능을 제공하고 있었으나 프로젝트가 중단되었으므로 관련 부가 기능에 대한 기술 지원을 중단합니다."
+"Development on the Sunbird project has halted and its final release was on March 30, 2010. We've been proud to host Sunbird add-ons on this site but as the project is no longer maintained we have "
+"disabled our support for the add-ons."
+msgstr "Sunbird 개발 프로젝트가 중단되었으며 마지막 버전은 2010년 3월 30일에 출시되었습니다. 본 사이트에선 Sunbird 부가 기능을 제공하고 있었으나 프로젝트가 중단되었으므로 관련 부가 기능에 대한 기술 지원을 중단합니다."
 
 #: src/olympia/pages/templates/pages/sunbird.html:38
 #, python-format
-msgid ""
-"We recommend upgrading to <a href=\"%(tb_url)s\">Thunderbird</a> and <a "
-"href=\"%(lightning_url)s\">Lightning</a>."
-msgstr ""
-"또한 <a href=\"%(tb_url)s\">Thunderbird</a>나 <a "
-"href=\"%(lightning_url)s\">Lightning</a>으로 업그레이드를 권장하고 있습니다."
+msgid "We recommend upgrading to <a href=\"%(tb_url)s\">Thunderbird</a> and <a href=\"%(lightning_url)s\">Lightning</a>."
+msgstr "또한 <a href=\"%(tb_url)s\">Thunderbird</a>나 <a href=\"%(lightning_url)s\">Lightning</a>으로 업그레이드를 권장하고 있습니다."
 
 #: src/olympia/pages/templates/pages/sunbird.html:45
 msgid "Read more about Sunbird"
@@ -12770,8 +10481,7 @@ msgstr "계속 평가; 표시 삭제"
 msgid "Skip for now"
 msgstr "지금은 접어두기"
 
-#: src/olympia/reviews/forms.py:151
-#: src/olympia/reviews/templates/reviews/review.html:107
+#: src/olympia/reviews/forms.py:151 src/olympia/reviews/templates/reviews/review.html:107
 msgid "Delete review"
 msgstr "심사 삭제"
 
@@ -12790,35 +10500,21 @@ msgstr "{0}에 대한 평가 작성"
 #: src/olympia/reviews/templates/reviews/add.html:26
 #, python-format
 msgid ""
-"<h2>Keep these tips in mind:</h2> <ul> <li> Write like you're telling a "
-"friend about your experience with the add-on. Give specifics and helpful "
-"details, such as what features you liked and/or disliked, how easy to use it"
-" is, and any disadvantages it has. Avoid generic language such as calling it"
-" \"Great\" or \"Bad\" unless you can give reasons why you believe this is "
-"so. </li> <li> Please do not post bug reports in reviews. We do not make "
-"your email address available to add-on developers and they may need to "
-"contact you to help resolve your issue. See the <a "
-"href=\"%(support)s\">support section</a> to find out where to get assistance"
-" for this add-on. </li> <li>Please keep reviews clean, avoid the use of "
-"improper language and do not post any personal information. </li> </ul> "
-"<p>Please read the <a href=\"%(guide)s\" target=\"_blank\">Review "
-"Guidelines</a> for more detail about user add-on reviews.</p>"
+"<h2>Keep these tips in mind:</h2> <ul> <li> Write like you're telling a friend about your experience with the add-on. Give specifics and helpful details, such as what features you liked and/or "
+"disliked, how easy to use it is, and any disadvantages it has. Avoid generic language such as calling it \"Great\" or \"Bad\" unless you can give reasons why you believe this is so. </li> <li> "
+"Please do not post bug reports in reviews. We do not make your email address available to add-on developers and they may need to contact you to help resolve your issue. See the <a "
+"href=\"%(support)s\">support section</a> to find out where to get assistance for this add-on. </li> <li>Please keep reviews clean, avoid the use of improper language and do not post any personal "
+"information. </li> </ul> <p>Please read the <a href=\"%(guide)s\" target=\"_blank\">Review Guidelines</a> for more detail about user add-on reviews.</p>"
 msgstr ""
-"<h2>다음 사항을 지켜주세요:</h2> <ul> <li> 친구에게 이 부가 기능을 사용했던 경험을 얘기하듯 적어주세요. 어떤 기능을 "
-"좋아하고 좋아하지 않는지, 사용하기는 편한지, 단점은 무엇인지 같은 명확하고 도움이 될만한 자세한 정보를 제공해 주시기 바랍니다. "
-"\"죽인다\" \"비추천\" 같은 일반적인 단어보다는 왜 그렇게 생각하는지 이유를 적어주세요. </li> <li> 평가엔 버그 리포트를 "
-"올리지 마세요. 저희는 부가 기능 개발자가 여러분의 이메일 주소를 사용하는 것을 허용하지 않는데, 이메일 주소가 올라와 있으면 개발자가 "
-"문제 해결을 돕기위해 직접 연락을 하려 들 수 있기 때문입니다. 부가 기능 개발을 돕고 싶다면 <a "
-"href=\"%(support)s\">기술 지원 항목</a>을 살펴보시기 바랍니다. </li> <li>건전한 평가를 만들어주세요. "
-"부적절한 언어 사용을 자제하시고 어떠한 개인 정보도 올리지 마세요. </li> </ul> <p>보다 자세한 사항은 <a "
-"href=\"%(guide)s\" target=\"_blank\">평가 지침</a>을 읽어주시기 바랍니다.</p>"
+"<h2>다음 사항을 지켜주세요:</h2> <ul> <li> 친구에게 이 부가 기능을 사용했던 경험을 얘기하듯 적어주세요. 어떤 기능을 좋아하고 좋아하지 않는지, 사용하기는 편한지, 단점은 무엇인지 같은 명확하고 도움이 될만한 자세한 정보를 제공해 주시기 바랍니다. \"죽인다\" \"비추천\" 같은 일반적인 단어보다는 왜 그렇게 생각하는지 이유를 "
+"적어주세요. </li> <li> 평가엔 버그 리포트를 올리지 마세요. 저희는 부가 기능 개발자가 여러분의 이메일 주소를 사용하는 것을 허용하지 않는데, 이메일 주소가 올라와 있으면 개발자가 문제 해결을 돕기위해 직접 연락을 하려 들 수 있기 때문입니다. 부가 기능 개발을 돕고 싶다면 <a href=\"%(support)s\">기술 지원 항목</a>을 "
+"살펴보시기 바랍니다. </li> <li>건전한 평가를 만들어주세요. 부적절한 언어 사용을 자제하시고 어떠한 개인 정보도 올리지 마세요. </li> </ul> <p>보다 자세한 사항은 <a href=\"%(guide)s\" target=\"_blank\">평가 지침</a>을 읽어주시기 바랍니다.</p>"
 
 #: src/olympia/reviews/templates/reviews/reply.html:4
 msgid "Reply to review by {0}"
 msgstr "{0}님의 평가 답변"
 
-#: src/olympia/reviews/templates/reviews/reply.html:15
-#: src/olympia/reviews/templates/reviews/reply.html:31
+#: src/olympia/reviews/templates/reviews/reply.html:15 src/olympia/reviews/templates/reviews/reply.html:31
 msgid "Reply"
 msgstr "댓글"
 
@@ -12826,8 +10522,7 @@ msgstr "댓글"
 msgid "Write a Reply"
 msgstr "댓글 작성하기"
 
-#: src/olympia/reviews/templates/reviews/reply.html:36
-#: src/olympia/reviews/templates/reviews/report_review.html:12
+#: src/olympia/reviews/templates/reviews/reply.html:36 src/olympia/reviews/templates/reviews/report_review.html:12
 msgid "Submit"
 msgstr "입력하기"
 
@@ -12847,26 +10542,20 @@ msgid "by %(user)s <b>(Developer)</b> on %(date)s"
 msgstr "작성: %(user)s <b>(개발자)</b>, 날짜: %(date)s"
 
 #. {0} is a version number (like 1.01)
-#: src/olympia/reviews/templates/reviews/review.html:50
-#: src/olympia/reviews/templates/reviews/mobile/review_list.html:41
+#: src/olympia/reviews/templates/reviews/review.html:50 src/olympia/reviews/templates/reviews/mobile/review_list.html:41
 msgid "This review is for a previous version of the add-on ({0})."
 msgstr "이 평가는 현재 부가 기능의 이전 버전 ({0})에 대한 것입니다."
 
 #: src/olympia/reviews/templates/reviews/review.html:56
 #, fuzzy, python-format
-msgid ""
-"This user has a <a href=\"%(user_review_url)s\">previous review</a> of this "
-"add-on."
-msgid_plural ""
-"This user has <a href=\"%(user_review_url)s\">%(cnt)s previous reviews</a> "
-"of this add-on."
+msgid "This user has a <a href=\"%(user_review_url)s\">previous review</a> of this add-on."
+msgid_plural "This user has <a href=\"%(user_review_url)s\">%(cnt)s previous reviews</a> of this add-on."
 msgstr[0] "이 사용자는 이 부가 기능에 <a href=\"%(user_review_url)s\">평가를 전에</a> 작성해 놓았습니다."
+msgstr[1] ""
 
 #: src/olympia/reviews/templates/reviews/review.html:62
 #, python-format
-msgid ""
-"This user has <a href=\"%(user_review_url)s\">other reviews</a> of this add-"
-"on."
+msgid "This user has <a href=\"%(user_review_url)s\">other reviews</a> of this add-on."
 msgstr "이 사용자는 이 부가 기능의 <a href=\"%(user_review_url)s\">다른 평가</a>를 작성해 놓았습니다."
 
 #: src/olympia/reviews/templates/reviews/review.html:72
@@ -12899,9 +10588,7 @@ msgid "{0} :: Reviews"
 msgstr "{0} :: 평가"
 
 #. {0} is an addon name.
-#: src/olympia/reviews/templates/reviews/review_list.html:24
-#: src/olympia/reviews/templates/reviews/mobile/add.html:4
-#: src/olympia/reviews/templates/reviews/mobile/review_list.html:4
+#: src/olympia/reviews/templates/reviews/review_list.html:24 src/olympia/reviews/templates/reviews/mobile/add.html:4 src/olympia/reviews/templates/reviews/mobile/review_list.html:4
 msgid "Reviews for {0}"
 msgstr "{0}에 대한 평가"
 
@@ -12910,6 +10597,7 @@ msgstr "{0}에 대한 평가"
 msgid "<b>{0}</b> review for this add-on"
 msgid_plural "<b>{0}</b> reviews for this add-on"
 msgstr[0] "전체 평가: <b>{0}</b>개"
+msgstr[1] ""
 
 #. {0} is a developer's name.
 #: src/olympia/reviews/templates/reviews/review_list.html:33
@@ -12921,6 +10609,7 @@ msgstr "{0}님의 개발자 댓글"
 msgid "Review for %(addon)s by %(user)s"
 msgid_plural "Reviews for %(addon)s by %(user)s"
 msgstr[0] "%(user)s님의 %(addon)s 평가"
+msgstr[1] ""
 
 #: src/olympia/reviews/templates/reviews/review_list.html:42
 msgid "No reviews found."
@@ -12935,8 +10624,7 @@ msgstr "<strong>평균</strong> (%(total)s)"
 msgid "Write a New Review"
 msgstr "새 평가 작성하기"
 
-#: src/olympia/reviews/templates/reviews/review_list.html:81
-#: src/olympia/reviews/templates/reviews/mobile/reviews_link.html:15
+#: src/olympia/reviews/templates/reviews/review_list.html:81 src/olympia/reviews/templates/reviews/mobile/reviews_link.html:15
 msgid "Be the first to write a review."
 msgstr "1등으로 평가를 써 보세요."
 
@@ -12944,6 +10632,7 @@ msgstr "1등으로 평가를 써 보세요."
 msgid "{num} review"
 msgid_plural "{num} reviews"
 msgstr[0] "평가 {num}개"
+msgstr[1] ""
 
 #: src/olympia/reviews/templates/reviews/impala/reviews_rating.html:1
 msgid "Rated {0} out of 5 stars"
@@ -12954,8 +10643,7 @@ msgstr "5점중 {0}점 받음"
 msgid "Rated %(rating)s out of 5 stars"
 msgstr "5점중 %(rating)s점 받음"
 
-#: src/olympia/reviews/templates/reviews/mobile/add_form.html:3
-#: src/olympia/reviews/templates/reviews/mobile/add_form.html:8
+#: src/olympia/reviews/templates/reviews/mobile/add_form.html:3 src/olympia/reviews/templates/reviews/mobile/add_form.html:8
 msgid "Add a Review"
 msgstr "평가 작성하기"
 
@@ -12971,6 +10659,7 @@ msgstr "아직 별점이 없습니다."
 msgid "Average from {0} Rating"
 msgid_plural "Average from {0} Ratings"
 msgstr[0] "평균 별점 {0}"
+msgstr[1] ""
 
 #: src/olympia/reviews/templates/reviews/mobile/review_list.html:34
 #, python-format
@@ -12986,6 +10675,7 @@ msgstr "더 보기&nbsp;&raquo;"
 msgid "See All Reviews"
 msgid_plural "See All %(cnt)s Reviews"
 msgstr[0] "평가 전부 보기"
+msgstr[1] ""
 
 #: src/olympia/search/forms.py:11
 msgid "Most popular this week"
@@ -13024,8 +10714,7 @@ msgid "Relevance"
 msgstr "연관성"
 
 #: src/olympia/search/helpers.py:24
-msgid ""
-"Results <strong>{0}</strong>-<strong>{1}</strong> of <strong>{2}</strong>"
+msgid "Results <strong>{0}</strong>-<strong>{1}</strong> of <strong>{2}</strong>"
 msgstr "전체 <strong>{2}</strong>개 중 <strong>{0}</strong>-<strong>{1}</strong>"
 
 # {0} is a number
@@ -13034,12 +10723,8 @@ msgstr "전체 <strong>{2}</strong>개 중 <strong>{0}</strong>-<strong>{1}</str
 # {3} is the word the person is searching for
 # {4} is a word (the add-on is tagged with it)
 #: src/olympia/search/helpers.py:44
-msgid ""
-"Showing {0} - {1} of {2} results for <strong>{3}</strong> tagged with "
-"<strong>{4}</strong>"
-msgstr ""
-"<strong>{4}</strong> 태그와 검색어 <strong>{3}</strong>(으)로 {2}개 검색 / {0} - {1} "
-"표시중"
+msgid "Showing {0} - {1} of {2} results for <strong>{3}</strong> tagged with <strong>{4}</strong>"
+msgstr "<strong>{4}</strong> 태그와 검색어 <strong>{3}</strong>(으)로 {2}개 검색 / {0} - {1} 표시중"
 
 # {0} is a number
 # {1} is a number
@@ -13065,24 +10750,22 @@ msgid "Showing {0} - {1} of {2} results"
 msgstr "{2}개 검색 / {0} - {1} 표시중"
 
 #. {0} is an application, like Firefox.
-#: src/olympia/search/views.py:264 src/olympia/templates/base.html:17
-#: src/olympia/templates/impala/base.html:17
-#: src/olympia/templates/mobile/base_addons.html:17
+#: src/olympia/search/views.py:264 src/olympia/templates/base.html:17 src/olympia/templates/impala/base.html:17 src/olympia/templates/mobile/base_addons.html:17
 msgid "{0} Add-ons"
 msgstr "{0} 부가 기능"
 
 #. L10n: {0} is an application, such as Firefox. This means "any version of
 #. Firefox."
-#: src/olympia/search/views.py:554
+#: src/olympia/search/views.py:547
 msgid "Any {0}"
 msgstr "{0} 모든 버전"
 
 #. L10n: "All Systems" means show everything regardless of platform.
-#: src/olympia/search/views.py:589
+#: src/olympia/search/views.py:582
 msgid "All Systems"
 msgstr "모든 운영 체제"
 
-#: src/olympia/search/views.py:600
+#: src/olympia/search/views.py:593
 msgid "All Tags"
 msgstr "모든 태그"
 
@@ -13126,6 +10809,7 @@ msgstr "\"{0}\" 태그의 검색 결과"
 msgid "<b>{0}</b> matching result"
 msgid_plural "<b>{0}</b> matching results"
 msgstr[0] "검색 결과 <b>{0}</b>개"
+msgstr[1] ""
 
 #: src/olympia/search/templates/search/results.html:67
 msgid "Filter Results"
@@ -13147,6 +10831,7 @@ msgstr "검색 결과 <i>({num})</i>"
 msgid "{0} post"
 msgid_plural "{0} posts"
 msgstr[0] "글 {0}개"
+msgstr[1] ""
 
 #: src/olympia/sharing/__init__.py:20
 msgid "Post to Facebook"
@@ -13156,6 +10841,7 @@ msgstr "Facebook에 올리기"
 msgid "{0} Like"
 msgid_plural "{0} Likes"
 msgstr[0] ""
+msgstr[1] ""
 
 #: src/olympia/sharing/__init__.py:30
 msgid "Tweet on Twitter"
@@ -13165,6 +10851,7 @@ msgstr ""
 msgid "{0} tweet"
 msgid_plural "{0} tweets"
 msgstr[0] "트윗 {0}개"
+msgstr[1] ""
 
 #: src/olympia/sharing/__init__.py:40
 msgid "Share on g+"
@@ -13198,6 +10885,7 @@ msgstr "http://localservice1/?url={url}&title={title}"
 msgid "{0} post on localservice1"
 msgid_plural "{0} posts on localservice1"
 msgstr[0] "{0} posts on localservice1"
+msgstr[1] ""
 
 #. L10n: Only change if you have reason! wiki.mozilla.org/AMO:Localizers
 #: src/olympia/sharing/__init__.py:76
@@ -13219,6 +10907,7 @@ msgstr "http://localservice2/?url={url}&title={title}"
 msgid "{0} post on localservice2"
 msgid_plural "{0} posts on localservice2"
 msgstr[0] "{0} posts on localservice2"
+msgstr[1] ""
 
 #. L10n: Only change if you have reason! wiki.mozilla.org/AMO:Localizers
 #: src/olympia/sharing/__init__.py:91
@@ -13240,6 +10929,7 @@ msgstr "http://localservice3/?url={url}&title={title}"
 msgid "{0} post on localservice3"
 msgid_plural "{0} posts on localservice3"
 msgstr[0] "{0} posts on localservice3"
+msgstr[1] ""
 
 #: src/olympia/sharing/templates/sharing/sharing_widget.html:2
 msgid "Share this Add-on"
@@ -13249,34 +10939,31 @@ msgstr "이 부가 기능 공유하기"
 msgid "Share this Collection"
 msgstr "이 모음집 공유하기"
 
-#: src/olympia/signing/views.py:30 src/olympia/templates/base.html:75
-#: src/olympia/templates/impala/base.html:115
-msgid ""
-"Some features are temporarily disabled while we perform website maintenance."
-" We'll be back to full capacity shortly."
+#: src/olympia/signing/views.py:33 src/olympia/templates/base.html:71 src/olympia/templates/impala/base.html:112
+msgid "Some features are temporarily disabled while we perform website maintenance. We'll be back to full capacity shortly."
 msgstr "웹사이트 점검 관계로 일부 기능을 잠시동안 사용할 수 없습니다. 최대한 빨리 사이트를 정상화 하도록 하겠습니다."
 
-#: src/olympia/signing/views.py:53
+#: src/olympia/signing/views.py:56
 msgid "Could not find add-on with id \"{}\"."
 msgstr ""
 
-#: src/olympia/signing/views.py:67
+#: src/olympia/signing/views.py:70
 msgid "You do not own this addon."
 msgstr ""
 
-#: src/olympia/signing/views.py:82
+#: src/olympia/signing/views.py:87
 msgid "Missing \"upload\" key in multipart file data."
 msgstr ""
 
-#: src/olympia/signing/views.py:96
+#: src/olympia/signing/views.py:101
 msgid "Version does not match the manifest file."
 msgstr ""
 
-#: src/olympia/signing/views.py:100
+#: src/olympia/signing/views.py:105
 msgid "Version already exists."
 msgstr ""
 
-#: src/olympia/signing/views.py:136
+#: src/olympia/signing/views.py:141
 msgid "No uploaded file for that addon and version."
 msgstr ""
 
@@ -13368,8 +11055,7 @@ msgstr "시작일"
 msgid "To"
 msgstr "종료일"
 
-#: src/olympia/stats/templates/stats/popup.html:27
-#: src/olympia/users/templates/users/pwreset_confirm.html:38
+#: src/olympia/stats/templates/stats/popup.html:27 src/olympia/users/templates/users/pwreset_confirm.html:38
 msgid "Update"
 msgstr "업데이트"
 
@@ -13390,106 +11076,100 @@ msgstr "{0} :: 통계 대시보드"
 msgid "Statistics Dashboard :: Add-ons for {0}"
 msgstr "통계 대시보드 :: {0} 부가 기능"
 
-#: src/olympia/stats/templates/stats/stats.html:30
+#. {0} is an add-on name
+#: src/olympia/stats/templates/stats/stats.html:44 src/olympia/stats/templates/stats/stats.html:47
+msgid "Statistics for {0}"
+msgstr "{0}의 통계"
+
+#: src/olympia/stats/templates/stats/stats.html:50
+msgid "Statistics Dashboard"
+msgstr "통계 대시보드"
+
+#: src/olympia/stats/templates/stats/stats.html:57
 msgid "Controls:"
 msgstr "조작:"
 
-#: src/olympia/stats/templates/stats/stats.html:33
+#: src/olympia/stats/templates/stats/stats.html:60
 msgid "reset zoom"
 msgstr "확대 초기화"
 
-#: src/olympia/stats/templates/stats/stats.html:40
+#: src/olympia/stats/templates/stats/stats.html:67
 msgid "Group by:"
 msgstr "그룹 정렬:"
 
-#: src/olympia/stats/templates/stats/stats.html:42
+#: src/olympia/stats/templates/stats/stats.html:69
 msgid "day"
 msgstr "일"
 
-#: src/olympia/stats/templates/stats/stats.html:45
+#: src/olympia/stats/templates/stats/stats.html:72
 msgid "week"
 msgstr "주"
 
-#: src/olympia/stats/templates/stats/stats.html:48
+#: src/olympia/stats/templates/stats/stats.html:75
 msgid "month"
 msgstr "월"
 
 # 88%
 # 100%
-#: src/olympia/stats/templates/stats/stats.html:54
+#: src/olympia/stats/templates/stats/stats.html:81
 msgid "For last:"
 msgstr "최근 통계:"
 
 # 83%
 # 100%
-#: src/olympia/stats/templates/stats/stats.html:57
+#: src/olympia/stats/templates/stats/stats.html:84
 msgid "7 days"
 msgstr "7일"
 
 # 85%
 # 100%
-#: src/olympia/stats/templates/stats/stats.html:60
+#: src/olympia/stats/templates/stats/stats.html:87
 msgid "30 days"
 msgstr "30일"
 
 # 85%
 # 100%
-#: src/olympia/stats/templates/stats/stats.html:63
+#: src/olympia/stats/templates/stats/stats.html:90
 msgid "90 days"
 msgstr "90일"
 
 # 85%
 # 75%
 # 100%
-#: src/olympia/stats/templates/stats/stats.html:66
+#: src/olympia/stats/templates/stats/stats.html:93
 msgid "365 days"
 msgstr "365일"
 
-#: src/olympia/stats/templates/stats/stats.html:69
+#: src/olympia/stats/templates/stats/stats.html:96
 msgid "Custom..."
 msgstr "사용자 정의..."
 
-#. {0} is an add-on name
-#: src/olympia/stats/templates/stats/stats.html:88
-#: src/olympia/stats/templates/stats/stats.html:91
-msgid "Statistics for {0}"
-msgstr "{0}의 통계"
-
-#: src/olympia/stats/templates/stats/stats.html:94
-msgid "Statistics Dashboard"
-msgstr "통계 대시보드"
-
-#: src/olympia/stats/templates/stats/stats.html:104
-msgid ""
-"Statistics processing is currently disabled, so recent data is unavailable. "
-"The statistics are still being collected and this page will be updated soon "
-"with the missing data."
+#: src/olympia/stats/templates/stats/stats.html:106
+msgid "Statistics processing is currently disabled, so recent data is unavailable. The statistics are still being collected and this page will be updated soon with the missing data."
 msgstr ""
 
-#: src/olympia/stats/templates/stats/stats.html:110
+#: src/olympia/stats/templates/stats/stats.html:112
 msgid "Loading the latest data&hellip;"
 msgstr "최신 데이터를 불러오는 중입니다&hellip;"
 
-#: src/olympia/stats/templates/stats/stats.html:142
-#: src/olympia/stats/templates/stats/reports/overview.html:25
-#: src/olympia/stats/templates/stats/reports/overview.html:37
+#: src/olympia/stats/templates/stats/stats.html:144 src/olympia/stats/templates/stats/reports/overview.html:25 src/olympia/stats/templates/stats/reports/overview.html:37
 #: src/olympia/stats/templates/stats/reports/overview.html:49
 msgid "No data available."
 msgstr "데이터가 없습니다."
 
-#: src/olympia/stats/templates/stats/stats.html:177
+#: src/olympia/stats/templates/stats/stats.html:179
 msgid "This dashboard is currently <b>public</b>."
 msgstr "대시보드가 현재 <b>공개</b> 상태입니다."
 
-#: src/olympia/stats/templates/stats/stats.html:179
+#: src/olympia/stats/templates/stats/stats.html:181
 msgid "Contribution stats are currently <b>private</b>."
 msgstr "기부금 통계가 현재 <b>비공개</b> 상태입니다."
 
-#: src/olympia/stats/templates/stats/stats.html:182
+#: src/olympia/stats/templates/stats/stats.html:184
 msgid "This dashboard is currently <b>private</b>."
 msgstr "대시보드가 현재 <b>비공개</b> 상태입니다."
 
-#: src/olympia/stats/templates/stats/stats.html:185
+#: src/olympia/stats/templates/stats/stats.html:187
 msgid "Change settings."
 msgstr "설정을 변경합니다."
 
@@ -13531,12 +11211,9 @@ msgstr "다운로드 횟수는 어떤 방식으로 집계되나요?"
 
 #: src/olympia/stats/templates/stats/reports/downloads.html:10
 msgid ""
-"<h2>How are downloads counted?</h2> <p> Download counts are updated every "
-"evening and only include original add-on downloads, not updates. Downloads "
-"can be broken down by the specific source referring the download. </p>"
-msgstr ""
-"<h2>다운로드 횟수는 어떤 방식으로 집계되나요?</h2> <p>다운로드 횟수는 매일 저녁에 갱신되며 업데이트를 뺀 순수 다운로드 횟수만"
-" 포함됩니다. 다운로드 횟수는 명시된 출처의 다운로드 조회 과정에 따라 제대로 표시되지 않을 수도 있습니다. </p>"
+"<h2>How are downloads counted?</h2> <p> Download counts are updated every evening and only include original add-on downloads, not updates. Downloads can be broken down by the specific source "
+"referring the download. </p>"
+msgstr "<h2>다운로드 횟수는 어떤 방식으로 집계되나요?</h2> <p>다운로드 횟수는 매일 저녁에 갱신되며 업데이트를 뺀 순수 다운로드 횟수만 포함됩니다. 다운로드 횟수는 명시된 출처의 다운로드 조회 과정에 따라 제대로 표시되지 않을 수도 있습니다. </p>"
 
 #: src/olympia/stats/templates/stats/reports/locales.html:3
 msgid "User languages by Date"
@@ -13550,8 +11227,7 @@ msgstr "날짜별 플랫폼 점유율"
 msgid "<b>{0}</b> Downloads"
 msgstr "다운로드 <b>{0}</b>회"
 
-#: src/olympia/stats/templates/stats/reports/overview.html:9
-#: src/olympia/stats/templates/stats/reports/overview.html:13
+#: src/olympia/stats/templates/stats/reports/overview.html:9 src/olympia/stats/templates/stats/reports/overview.html:13
 msgid "Loading..."
 msgstr "불러오는 중..."
 
@@ -13602,30 +11278,16 @@ msgstr "외부 자원 추적 안내..."
 #: src/olympia/stats/templates/stats/reports/sources.html:10
 #, python-format
 msgid ""
-"<h2>Tracking external sources</h2> <p> If you link to your add-on's details "
-"page or directly to its file from an external site, such as your blog or "
-"website, you can append a parameter to be tracked as an additional download "
-"source on this page. For example, the following links would appear as "
-"sourced by your blog: <dl> <dt>Add-on Details Page</dt> "
-"<dd>https://addons.mozilla.org/addon/%(slug)s?src=<b>external-blog</b></dd> "
-"<dt>Direct File Link</dt> "
-"<dd>https://addons.mozilla.org/downloads/latest/%(id)s/addon-%(id)s-latest.xpi?src=<b"
-">external-blog</b></dd> </dl> <p> Only src parameters that begin with "
-"\"external-\" will be tracked, up to 61 additional characters. Any text "
-"after \"external-\" can be used to describe the source, such as \"external-"
-"blog\", \"external-sidebar\", \"external-campaign225\", etc. The following "
-"URL-safe characters are allowed: <code>a-z A-Z - . _ ~ %% +</code>"
+"<h2>Tracking external sources</h2> <p> If you link to your add-on's details page or directly to its file from an external site, such as your blog or website, you can append a parameter to be "
+"tracked as an additional download source on this page. For example, the following links would appear as sourced by your blog: <dl> <dt>Add-on Details Page</dt> "
+"<dd>https://addons.mozilla.org/addon/%(slug)s?src=<b>external-blog</b></dd> <dt>Direct File Link</dt> <dd>https://addons.mozilla.org/downloads/latest/%(id)s/addon-%(id)s-latest.xpi?src=<b>external-"
+"blog</b></dd> </dl> <p> Only src parameters that begin with \"external-\" will be tracked, up to 61 additional characters. Any text after \"external-\" can be used to describe the source, such as "
+"\"external-blog\", \"external-sidebar\", \"external-campaign225\", etc. The following URL-safe characters are allowed: <code>a-z A-Z - . _ ~ %% +</code>"
 msgstr ""
-"<h2>외부 자원 추적</h2> <p>부가 기능 상세 정보 페이지나 파일과 직접 연결되어 있는 블로그 내지는 웹 사이트 등과 같은 외부 "
-"사이트를 보유하고 있을 경우, 추가 다운로드 출처를 추적할 수 있는 파라미터를 적용할 수 있습니다. 그 예로, 아래의 링크는 블로그를 "
-"출처로 하게 될 것입니다: <dl> <dt>부가 기능 상세 정보 페이지로 링크 예제</dt> "
-"<dd>https://addons.mozilla.org/addon/%(slug)s?src=<b>external-blog</b></dd> "
-"<dt>파일 직접 연결 예제</dt> "
-"<dd>https://addons.mozilla.org/downloads/latest/%(id)s/addon-%(id)s-latest.xpi?src=<b"
-">external-blog</b></dd> </dl> <p> src 파라미터는 반드시 \"external-\"로 시작해야 하며 영문 "
-"61자를 넘어선 안됩니다. \"external-\" 뒤에는 \"external-blog\", \"external-sidebar\", "
-"\"external-campaign225\" 등과 같이 출처를 설명하는 텍스트를 입력해야 합니다. 다음의 URL 입력 가능 문자만 "
-"허용됩니다: <code>a-z A-Z - . _ ~ %% +</code>"
+"<h2>외부 자원 추적</h2> <p>부가 기능 상세 정보 페이지나 파일과 직접 연결되어 있는 블로그 내지는 웹 사이트 등과 같은 외부 사이트를 보유하고 있을 경우, 추가 다운로드 출처를 추적할 수 있는 파라미터를 적용할 수 있습니다. 그 예로, 아래의 링크는 블로그를 출처로 하게 될 것입니다: <dl> <dt>부가 기능 상세 정보 페이지로 링크 "
+"예제</dt> <dd>https://addons.mozilla.org/addon/%(slug)s?src=<b>external-blog</b></dd> <dt>파일 직접 연결 예제</dt> <dd>https://addons.mozilla.org/downloads/latest/%(id)s/addon-%(id)s-latest.xpi?src=<b"
+">external-blog</b></dd> </dl> <p> src 파라미터는 반드시 \"external-\"로 시작해야 하며 영문 61자를 넘어선 안됩니다. \"external-\" 뒤에는 \"external-blog\", \"external-sidebar\", \"external-campaign225\" 등과 같이 출처를 설명하는 텍스트를 입력해야"
+" 합니다. 다음의 URL 입력 가능 문자만 허용됩니다: <code>a-z A-Z - . _ ~ %% +</code>"
 
 #: src/olympia/stats/templates/stats/reports/statuses.html:3
 msgid "Add-on Status by Date"
@@ -13645,24 +11307,15 @@ msgstr "일일 사용자 수란?"
 
 #: src/olympia/stats/templates/stats/reports/usage.html:11
 msgid ""
-"<h2>What are daily users?</h2> <p> Themes installed from this site check for"
-" updates once per day. The total number of these update pings is known as "
-"Active Daily Users, or the total number of people using your theme by day. "
-"</p>"
-msgstr ""
-"<h2>일일 사용자 수란?</h2> <p> 본 사이트를 통해 설치된 테마들은 하루에 한 번 업데이트가 있는지 확인을 하게 됩니다. 이러한"
-" 업데이트 확인 핑의 총 숫자를 일일 사용자 수로 집계하게 되며, 하루동안 테마를 사용하고 있는 사람들의 숫자가 되기도 합니다. </p>"
+"<h2>What are daily users?</h2> <p> Themes installed from this site check for updates once per day. The total number of these update pings is known as Active Daily Users, or the total number of "
+"people using your theme by day. </p>"
+msgstr "<h2>일일 사용자 수란?</h2> <p> 본 사이트를 통해 설치된 테마들은 하루에 한 번 업데이트가 있는지 확인을 하게 됩니다. 이러한 업데이트 확인 핑의 총 숫자를 일일 사용자 수로 집계하게 되며, 하루동안 테마를 사용하고 있는 사람들의 숫자가 되기도 합니다. </p>"
 
 #: src/olympia/stats/templates/stats/reports/usage.html:20
 msgid ""
-"<h2>What are daily users?</h2> <p> Add-ons downloaded from this site check "
-"for updates once per day. The total number of these update pings is known as"
-" Active Daily Users. Daily users can be broken down by add-on version, "
-"operating system, add-on status, application, and locale. </p>"
-msgstr ""
-"<h2>일일 사용자 수란?</h2> <p> 이 사이트를 통해 다운로드 된 부가 기능의 수는 일일 단위로 업데이트 됩니다. 이러한 업데이트"
-" 핑의 총합이 일일 사용자 수가 됩니다. 일일 사용자 수는 부가 기능 버전, 운영 체제, 부가 기능 상태, 애플리케이션 종류, 사용 "
-"언어별로 제대로 집계가 되지 않을 수도 있습니다. </p>"
+"<h2>What are daily users?</h2> <p> Add-ons downloaded from this site check for updates once per day. The total number of these update pings is known as Active Daily Users. Daily users can be broken"
+" down by add-on version, operating system, add-on status, application, and locale. </p>"
+msgstr "<h2>일일 사용자 수란?</h2> <p> 이 사이트를 통해 다운로드 된 부가 기능의 수는 일일 단위로 업데이트 됩니다. 이러한 업데이트 핑의 총합이 일일 사용자 수가 됩니다. 일일 사용자 수는 부가 기능 버전, 운영 체제, 부가 기능 상태, 애플리케이션 종류, 사용 언어별로 제대로 집계가 되지 않을 수도 있습니다. </p>"
 
 #: src/olympia/stats/templates/stats/reports/users_created.html:3
 msgid "User Signups by Date"
@@ -13672,44 +11325,27 @@ msgstr "날짜별 등록한 사용자"
 msgid "Application versions by Date"
 msgstr "날짜별 애플리케이션 버전"
 
-# {0} is a number
-#: src/olympia/tags/templates/tags/top_cloud.html:4
-msgid "Top {0} Tags"
-msgstr "상위 태그 {0}개"
-
-#. {0} is the current application name
-#: src/olympia/tags/templates/tags/top_cloud.html:14
-msgid "{0} Top Tags"
-msgstr "{0}의 상위 태그"
-
-#: src/olympia/templates/amo_footer.html:6
-#: src/olympia/templates/includes/lang_switcher.html:2
+#: src/olympia/templates/amo_footer.html:6 src/olympia/templates/includes/lang_switcher.html:2
 msgid "Other languages"
 msgstr "다른 언어 보기"
 
-#: src/olympia/templates/base.html:9 src/olympia/templates/impala/base.html:9
-#: src/olympia/templates/mobile/base_addons.html:9
+#: src/olympia/templates/base.html:9 src/olympia/templates/impala/base.html:9 src/olympia/templates/mobile/base_addons.html:9
 msgid "Mozilla Add-ons"
 msgstr "Mozilla 부가 기능"
 
-#: src/olympia/templates/base.html:91
-#: src/olympia/templates/impala/base.html:81
+#: src/olympia/templates/base.html:89 src/olympia/templates/impala/base.html:78
 msgid "Find add-ons for other applications"
 msgstr "다른 애플리케이션의 부가 기능도 찾아보세요"
 
-#: src/olympia/templates/base.html:92
-#: src/olympia/templates/impala/base.html:81
+#: src/olympia/templates/base.html:90 src/olympia/templates/impala/base.html:78
 msgid "Other Applications"
 msgstr "다른 애플리케이션"
 
-#: src/olympia/templates/base.html:141
-#: src/olympia/templates/impala/base.html:194
-msgid ""
-"To create your own collections, you must have a Mozilla Add-ons account."
+#: src/olympia/templates/base.html:141 src/olympia/templates/impala/base.html:194
+msgid "To create your own collections, you must have a Mozilla Add-ons account."
 msgstr "모음집을 제작하시려면 Mozilla 부가 기능 계정이 있어야 합니다."
 
-#: src/olympia/templates/base.html:168
-#: src/olympia/templates/impala/base.html:215
+#: src/olympia/templates/base.html:168 src/olympia/templates/impala/base.html:215
 msgid "Footer logo"
 msgstr ""
 
@@ -13726,21 +11362,19 @@ msgid "View Mobile Site"
 msgstr "모바일 사이트 보기"
 
 #: src/olympia/templates/copyright.html:7
-msgid "Site Status "
+msgid "Site Status"
 msgstr ""
 
 #: src/olympia/templates/footer.html:3
 msgid "get to know <b>add-ons</b>"
 msgstr "<b>부가 기능</b> 안내"
 
-#: src/olympia/templates/footer.html:4
-#: src/olympia/templates/menu_links.html:20
+#: src/olympia/templates/footer.html:4 src/olympia/templates/menu_links.html:20
 msgid "About"
 msgstr "소개"
 
 # Link text to the AMO blog.
-#: src/olympia/templates/footer.html:5
-#: src/olympia/templates/menu_links.html:32
+#: src/olympia/templates/footer.html:5 src/olympia/templates/menu_links.html:32
 msgid "Blog"
 msgstr "블로그"
 
@@ -13817,9 +11451,7 @@ msgstr "법적 고지"
 msgid "Contact Us"
 msgstr "연락처"
 
-#: src/olympia/templates/user_login.html:22
-#: src/olympia/users/templates/users/edit.html:31
-#: src/olympia/users/templates/users/includes/navigation.html:12
+#: src/olympia/templates/user_login.html:22 src/olympia/users/templates/users/edit.html:31 src/olympia/users/templates/users/includes/navigation.html:12
 msgid "My Account"
 msgstr "내 계정"
 
@@ -13827,48 +11459,40 @@ msgstr "내 계정"
 msgid "Welcome, {0}"
 msgstr "{0}님, 어서오세요"
 
-#: src/olympia/templates/user_login.html:41
-#: src/olympia/templates/impala/user_login.html:20
+#: src/olympia/templates/user_login.html:41 src/olympia/templates/impala/user_login.html:20
 #, python-format
 msgid "<a href=\"%(reg)s\">Register</a> or <a href=\"%(login)s\">Log in</a>"
 msgstr "<a href=\"%(reg)s\">계정 등록</a> 또는 <a href=\"%(login)s\">로그인</a>"
 
-#: src/olympia/templates/impala/base.html:126
+#: src/olympia/templates/impala/base.html:123
 #, python-format
-msgid ""
-"To try the thousands of add-ons available here, download <a "
-"href=\"%(url)s\">Mozilla Firefox</a>, a fast, free way to surf the Web!"
-msgstr ""
-"웹사이트를 빠르고 자유롭게 누빌 수 있는 <a href=\"%(url)s\">Mozilla Firefox</a>를 다운로드하면 이곳에서 "
-"수천가지 부가 기능을 사용하실 수 있습니다!"
+msgid "To try the thousands of add-ons available here, download <a href=\"%(url)s\">Mozilla Firefox</a>, a fast, free way to surf the Web!"
+msgstr "웹사이트를 빠르고 자유롭게 누빌 수 있는 <a href=\"%(url)s\">Mozilla Firefox</a>를 다운로드하면 이곳에서 수천가지 부가 기능을 사용하실 수 있습니다!"
 
-#: src/olympia/templates/impala/base.html:138
+#: src/olympia/templates/impala/base.html:135
 #, python-format
-msgid ""
-"Add-ons is switching to Firefox Accounts for login. <a href=\"%(url)s\" "
-"class=\"fxa-login\">Sign in now to transfer your account.</a>"
+msgid "Add-ons is switching to Firefox Accounts for login. <a href=\"%(url)s\" class=\"fxa-login\">Sign in now to transfer your account.</a>"
 msgstr ""
 
 #. {0} is an application, such as Firefox.
-#: src/olympia/templates/impala/base.html:148
+#: src/olympia/templates/impala/base.html:145
 msgid "Welcome to {0} Add-ons."
 msgstr "{0} 부가 기능에 오신것을 환영합니다."
 
-#: src/olympia/templates/impala/base.html:151
-msgid ""
-"Choose from thousands of extra features and styles to make Firefox your own."
+#: src/olympia/templates/impala/base.html:148
+msgid "Choose from thousands of extra features and styles to make Firefox your own."
 msgstr "수천가지 다양한 기능과 스타일을 선택해서 Firefox를 원하는 대로 만들어 보세요."
 
-#: src/olympia/templates/impala/base.html:156
+#: src/olympia/templates/impala/base.html:153
 #, python-format
 msgid "Add extra features and styles to make %(app)s your own."
 msgstr "수천가지 다양한 기능과 스타일을 추가해서 %(app)s을(를) 원하는 대로 만들어 보세요."
 
-#: src/olympia/templates/impala/base.html:164
+#: src/olympia/templates/impala/base.html:161
 msgid "On the go?"
 msgstr "시작해 볼까요?"
 
-#: src/olympia/templates/impala/base.html:166
+#: src/olympia/templates/impala/base.html:163
 msgid "Check out our <a class=\"mobile-link\" href=\"#\">Mobile Add-ons site</a>."
 msgstr "<a class=\"mobile-link\" href=\"#\">모바일 부가 기능 사이트</a>를 방문해 보세요."
 
@@ -13876,8 +11500,7 @@ msgstr "<a class=\"mobile-link\" href=\"#\">모바일 부가 기능 사이트</a
 msgid "Android Add-ons"
 msgstr "안드로이드용 부가 기능"
 
-#: src/olympia/templates/includes/forms.html:2
-#: src/olympia/templates/includes/forms.html:6
+#: src/olympia/templates/includes/forms.html:2 src/olympia/templates/includes/forms.html:6
 msgid "required"
 msgstr "필수 입력"
 
@@ -13922,15 +11545,11 @@ msgstr "Mozilla 방문"
 msgid "menu"
 msgstr "메뉴"
 
-#: src/olympia/templates/mobile/header_auth.html:7
-#: src/olympia/users/templates/users/register.html:41
-#: src/olympia/users/templates/users/register.html:89
+#: src/olympia/templates/mobile/header_auth.html:7 src/olympia/users/templates/users/register.html:41 src/olympia/users/templates/users/register.html:89
 msgid "Register"
 msgstr "등록"
 
-#: src/olympia/templates/mobile/header_auth.html:8
-#: src/olympia/users/templates/users/login_form.html:41
-#: src/olympia/users/templates/users/pwreset_complete.html:15
+#: src/olympia/templates/mobile/header_auth.html:8 src/olympia/users/templates/users/login_form.html:41 src/olympia/users/templates/users/pwreset_complete.html:15
 #: src/olympia/users/templates/users/mobile/login.html:56
 msgid "Log in"
 msgstr "로그인"
@@ -13941,8 +11560,7 @@ msgstr "로그인"
 msgid "Localize for: <a id=\"change-locale\" href=\"#\">%(dl)s</a>"
 msgstr "번역 언어: <a id=\"change-locale\" href=\"#\">%(dl)s</a>"
 
-#: src/olympia/translations/templates/translations/trans-menu.html:16
-#: src/olympia/translations/templates/translations/trans-menu.html:29
+#: src/olympia/translations/templates/translations/trans-menu.html:16 src/olympia/translations/templates/translations/trans-menu.html:29
 #, python-format
 msgid "%(title)s <em>&middot; %(lang)s</em>"
 msgstr "%(title)s <em>&middot; %(lang)s</em>"
@@ -13957,9 +11575,7 @@ msgstr "새 번역판"
 
 #. {0} is a language name, like 'French'
 #: src/olympia/translations/templates/translations/trans-menu.html:42
-msgid ""
-"You have unsaved changes in the <b>{0}</b> locale. Would you like to save "
-"your changes before switching locales?"
+msgid "You have unsaved changes in the <b>{0}</b> locale. Would you like to save your changes before switching locales?"
 msgstr "<b>{0}</b> 언어에 저장되지 않은 변경 사항이 있습니다. 언어를 변경하기 전에 먼저 변경 사항부터 저장하시겠습니까?"
 
 #: src/olympia/translations/templates/translations/trans-menu.html:49
@@ -13968,9 +11584,7 @@ msgstr "폐기한 사항 변경"
 
 #. {0} is a language name, like 'French'
 #: src/olympia/translations/templates/translations/trans-menu.html:56
-msgid ""
-"Are you sure you want to remove all <b>{0}</b> translations? This cannot be "
-"undone."
+msgid "Are you sure you want to remove all <b>{0}</b> translations? This cannot be undone."
 msgstr "정말 <b>{0}</b>개의 전체 번역판을 삭제하시겠습니까? 이 작업은 되돌릴 수 없습니다."
 
 #: src/olympia/translations/templates/translations/trans-menu.html:61
@@ -13992,20 +11606,14 @@ msgstr "그 비밀번호는 허용되지 않습니다."
 
 #: src/olympia/users/forms.py:90
 #, python-format
-msgid ""
-"As part of our new password policy, your password must be %s characters or "
-"more. Please update your password by <a href=\"%s\">issuing a password "
-"reset</a>."
+msgid "As part of our new password policy, your password must be %s characters or more. Please update your password by <a href=\"%s\">issuing a password reset</a>."
 msgstr ""
 
 #: src/olympia/users/forms.py:115
-msgid ""
-"You must recover your password through Firefox Accounts. Try logging in "
-"instead."
+msgid "You must recover your password through Firefox Accounts. Try logging in instead."
 msgstr ""
 
-#: src/olympia/users/forms.py:206
-#: src/olympia/users/templates/users/pwreset_confirm.html:24
+#: src/olympia/users/forms.py:206 src/olympia/users/templates/users/pwreset_confirm.html:24
 msgid "New password"
 msgstr "새 비밀번호"
 
@@ -14018,9 +11626,7 @@ msgid "Usernames cannot contain only digits."
 msgstr "사용자 이름은 숫자로만 만들 수 없습니다."
 
 #: src/olympia/users/forms.py:274
-msgid ""
-"Enter a valid username consisting of letters, numbers, underscores or "
-"hyphens."
+msgid "Enter a valid username consisting of letters, numbers, underscores or hyphens."
 msgstr "문자, 숫자, 밑줄, 하이픈으로 이루어진 올바른 사용자 이름을 입력하세요."
 
 #: src/olympia/users/forms.py:277
@@ -14031,33 +11637,24 @@ msgstr "이 사용자 이름은 사용할 수 없습니다."
 msgid "This username is already in use."
 msgstr "이 사용자 이름은 이미 사용되고 있습니다."
 
-#: src/olympia/users/forms.py:296
-#: src/olympia/users/templates/users/edit.html:107
+#: src/olympia/users/forms.py:296 src/olympia/users/templates/users/edit.html:107
 msgid "Display Name"
 msgstr "별명"
 
-#: src/olympia/users/forms.py:298
-#: src/olympia/users/templates/users/edit.html:112
-#: src/olympia/users/templates/users/vcard.html:10
+#: src/olympia/users/forms.py:298 src/olympia/users/templates/users/edit.html:112 src/olympia/users/templates/users/vcard.html:10
 msgid "Location"
 msgstr "사는 곳"
 
-#: src/olympia/users/forms.py:300
-#: src/olympia/users/templates/users/edit.html:117
-#: src/olympia/users/templates/users/vcard.html:16
+#: src/olympia/users/forms.py:300 src/olympia/users/templates/users/edit.html:117 src/olympia/users/templates/users/vcard.html:16
 msgid "Occupation"
 msgstr "직업"
 
 #: src/olympia/users/forms.py:329
-msgid ""
-"This URL has an invalid format. Valid URLs look like "
-"http://example.com/my_page."
+msgid "This URL has an invalid format. Valid URLs look like http://example.com/my_page."
 msgstr "잘못된 형식의 URL입니다. http://example.com/my_page 와 같은 것이 올바른 URL입니다."
 
 #: src/olympia/users/forms.py:337
-msgid ""
-"Please use an email address from a different provider to complete your "
-"registration."
+msgid "Please use an email address from a different provider to complete your registration."
 msgstr "등록 절차를 완료하시려면 다른 이메일을 사용해 주세요."
 
 #: src/olympia/users/forms.py:345
@@ -14068,13 +11665,11 @@ msgstr ""
 msgid "The passwords did not match."
 msgstr "비밀번호가 일치하지 않습니다."
 
-#: src/olympia/users/forms.py:377
-#: src/olympia/users/templates/users/edit.html:128
+#: src/olympia/users/forms.py:377 src/olympia/users/templates/users/edit.html:128
 msgid "Profile Photo"
 msgstr "프로필 사진"
 
-#: src/olympia/users/forms.py:385
-#: src/olympia/users/templates/users/edit.html:142
+#: src/olympia/users/forms.py:385 src/olympia/users/templates/users/edit.html:142
 msgid "Default locale"
 msgstr ""
 
@@ -14091,9 +11686,7 @@ msgid "Email cannot be changed."
 msgstr ""
 
 #: src/olympia/users/forms.py:541
-msgid ""
-"To anonymize, enter a reason for the change but do not change any other "
-"field."
+msgid "To anonymize, enter a reason for the change but do not change any other field."
 msgstr "익명으로 표시하려면 변경 사유를 입력하시고 그 외 다른 항목은 변경하지 마세요."
 
 #: src/olympia/users/forms.py:587
@@ -14123,19 +11716,19 @@ msgstr "해당 이메일로 등록된 사용자가 없습니다"
 
 #. L10n: {id} will be something like "13ad6a", just a random number
 #. to differentiate this user from other anonymous users.
-#: src/olympia/users/models.py:353
+#: src/olympia/users/models.py:362
 msgid "Anonymous user {id}"
 msgstr ""
 
-#: src/olympia/users/models.py:410
+#: src/olympia/users/models.py:419
 msgid "Your account has been restricted"
 msgstr "당신의 계정은 권한이 제한되어 있습니다."
 
-#: src/olympia/users/models.py:480
+#: src/olympia/users/models.py:489
 msgid "Please confirm your email address"
 msgstr "이메일 주소를 확인해 주세요"
 
-#: src/olympia/users/models.py:506
+#: src/olympia/users/models.py:515
 msgid "My Mobile Add-ons"
 msgstr "내 모바일 부가 기능"
 
@@ -14200,8 +11793,7 @@ msgid "Mozilla needs to contact me about my individual app"
 msgstr "Mozilla에서 앱과 관련해서 연락을 하고 싶어합니다"
 
 #: src/olympia/users/notifications.py:139
-msgid ""
-"Mozilla wants to contact me about relevant App Developer news and surveys"
+msgid "Mozilla wants to contact me about relevant App Developer news and surveys"
 msgstr "Mozilla에서 앱 개발자 뉴스와 설문을 위해 연락을 하고 싶어합니다"
 
 #: src/olympia/users/notifications.py:150
@@ -14229,10 +11821,7 @@ msgid "Successfully verified!"
 msgstr "검증 완료!"
 
 #: src/olympia/users/views.py:132
-msgid ""
-"An email has been sent to your address to confirm your account. Before you "
-"can log in, you have to activate your account by clicking on the link "
-"provided in this email."
+msgid "An email has been sent to your address to confirm your account. Before you can log in, you have to activate your account by clicking on the link provided in this email."
 msgstr ""
 
 #: src/olympia/users/views.py:136 src/olympia/users/views.py:619
@@ -14257,12 +11846,9 @@ msgstr "확인 이메일이 전송되었습니다"
 
 #: src/olympia/users/views.py:197
 msgid ""
-"An email has been sent to {0} to confirm your new email address. For the "
-"change to take effect, you need to click on the link provided in this email."
-" Until then, you can keep logging in with your current email address."
-msgstr ""
-"새 이메일 주소를 확인하기 위해 {0} 주소로 이메일이 전송됐습니다. 변경 사항을 적용하려면 전송된 이메일에 제공된 링크를 클릭해 "
-"주세요. 그 전까진 현재 이메일 주소로 계속 로그인하실 수 있습니다."
+"An email has been sent to {0} to confirm your new email address. For the change to take effect, you need to click on the link provided in this email. Until then, you can keep logging in with your "
+"current email address."
+msgstr "새 이메일 주소를 확인하기 위해 {0} 주소로 이메일이 전송됐습니다. 변경 사항을 적용하려면 전송된 이메일에 제공된 링크를 클릭해 주세요. 그 전까진 현재 이메일 주소로 계속 로그인하실 수 있습니다."
 
 #: src/olympia/users/views.py:210
 #, python-format
@@ -14274,13 +11860,11 @@ msgid "Errors Found"
 msgstr "오류 발견"
 
 #: src/olympia/users/views.py:225
-msgid ""
-"There were errors in the changes you made. Please correct them and resubmit."
+msgid "There were errors in the changes you made. Please correct them and resubmit."
 msgstr "변경 내용 중 오류가 있습니다. 오류를 정정한 후 다시 제출해 주세요."
 
 #: src/olympia/users/views.py:273
-msgid ""
-"We're sorry, but you are not eligible to request a t-shirt at this time."
+msgid "We're sorry, but you are not eligible to request a t-shirt at this time."
 msgstr ""
 
 #: src/olympia/users/views.py:329
@@ -14296,21 +11880,15 @@ msgid "Wrong email address or password!"
 msgstr "잘못된 이메일 주소 또는 비밀번호입니다!"
 
 #: src/olympia/users/views.py:434
-msgid ""
-"A link to activate your user account was sent by email to your address {0}. "
-"You have to click it before you can log in."
+msgid "A link to activate your user account was sent by email to your address {0}. You have to click it before you can log in."
 msgstr "사용자 계정을 활성화하는 링크가 담긴 이메일이 {0} 주소로 전송됐습니다. 로그인 전에 먼저 링크를 클릭해야 합니다."
 
 #: src/olympia/users/views.py:439
 #, python-format
 msgid ""
-"If you did not receive the confirmation email, make sure your email service "
-"did not mark it as \"junk mail\" or \"spam\". If you need to, you can have "
-"us <a href=\"%s\">resend the confirmation message</a> to your email address "
-"mentioned above."
-msgstr ""
-"확인 이메일을 받지 못했다면 이메일 서비스에서 \"스팸 메일\"로 표시한 것은 아닌지 확인해 보시기 바랍니다. 필요할 경우 위에 나와있는"
-" 이메일 주소로 <a href=\"%s\">확인 메시지를 재전송</a>할 수 있습니다."
+"If you did not receive the confirmation email, make sure your email service did not mark it as \"junk mail\" or \"spam\". If you need to, you can have us <a href=\"%s\">resend the confirmation "
+"message</a> to your email address mentioned above."
+msgstr "확인 이메일을 받지 못했다면 이메일 서비스에서 \"스팸 메일\"로 표시한 것은 아닌지 확인해 보시기 바랍니다. 필요할 경우 위에 나와있는 이메일 주소로 <a href=\"%s\">확인 메시지를 재전송</a>할 수 있습니다."
 
 #: src/olympia/users/views.py:444
 msgid "Activation Email Sent"
@@ -14330,13 +11908,8 @@ msgstr "축하합니다! 계정 등록이 완료 되었습니다."
 
 # %1 is the user's email address
 #: src/olympia/users/views.py:615
-msgid ""
-"An email has been sent to your address {0} to confirm your account. Before "
-"you can log in, you have to activate your account by clicking on the link "
-"provided in this email."
-msgstr ""
-"이메일 정보가 정확한지 {0}로 확인 이메일을 보냈습니다. 로그인 전에 메일을 확인하고 제공된 링크를 클릭해 계정을 먼저 활성화 시켜야 "
-"합니다."
+msgid "An email has been sent to your address {0} to confirm your account. Before you can log in, you have to activate your account by clicking on the link provided in this email."
+msgstr "이메일 정보가 정확한지 {0}로 확인 이메일을 보냈습니다. 로그인 전에 메일을 확인하고 제공된 링크를 클릭해 계정을 먼저 활성화 시켜야 합니다."
 
 #: src/olympia/users/views.py:639
 msgid "There are errors in this form"
@@ -14354,27 +11927,19 @@ msgstr "사용자가 신고되었습니다."
 msgid "new"
 msgstr "신규"
 
-#: src/olympia/users/templates/users/delete.html:4
-#: src/olympia/users/templates/users/delete.html:10
+#: src/olympia/users/templates/users/delete.html:4 src/olympia/users/templates/users/delete.html:10
 msgid "Delete User Account"
 msgstr "사용자 계정 삭제"
 
 #: src/olympia/users/templates/users/delete.html:14
 #, python-format
 msgid ""
-"You cannot delete your account if you are listed as an <a href=\"%(link)s\">"
-" author of any add-ons</a>. To delete your account, please have another "
-"person in your development group delete you from the list of authors for "
-"your add-ons. Afterwards you will be able to delete your account here."
-msgstr ""
-"<a href=\"%(link)s\"> 부가 기능 제작자</a> 명단에 등록되어 있을땐 계정을 삭제할 수 없습니다. 계정을 삭제하려면, "
-"당신의 개발 그룹에서 다른 사람을 확보한 후 부가 기능 제작자 명단에서 자신을 삭제해야 합니다. 그 후에 여기서 계정을 삭제할 수 "
-"있습니다."
+"You cannot delete your account if you are listed as an <a href=\"%(link)s\"> author of any add-ons</a>. To delete your account, please have another person in your development group delete you from "
+"the list of authors for your add-ons. Afterwards you will be able to delete your account here."
+msgstr "<a href=\"%(link)s\"> 부가 기능 제작자</a> 명단에 등록되어 있을땐 계정을 삭제할 수 없습니다. 계정을 삭제하려면, 당신의 개발 그룹에서 다른 사람을 확보한 후 부가 기능 제작자 명단에서 자신을 삭제해야 합니다. 그 후에 여기서 계정을 삭제할 수 있습니다."
 
 #: src/olympia/users/templates/users/delete.html:29
-msgid ""
-"By clicking \"delete\" your account is going to be <strong>permanently "
-"removed</strong>. That means:"
+msgid "By clicking \"delete\" your account is going to be <strong>permanently removed</strong>. That means:"
 msgstr "\"삭제\"를 클릭하면 당신의 계정은 <strong>영원히 삭제</strong>됩니다. 이는:"
 
 #: src/olympia/users/templates/users/delete.html:35
@@ -14383,9 +11948,7 @@ msgid "You will not be able to log into %(site)s anymore."
 msgstr "더이상 %(site)s에 로그인 할 수 없게 됩니다."
 
 #: src/olympia/users/templates/users/delete.html:40
-msgid ""
-"Your reviews and ratings will not be deleted, but they will no longer be "
-"associated with you."
+msgid "Your reviews and ratings will not be deleted, but they will no longer be associated with you."
 msgstr "당신이 작성한 평가와 별점은 삭제되지는 않지만 권한을 잃게 됩니다."
 
 #: src/olympia/users/templates/users/delete.html:46
@@ -14400,8 +11963,7 @@ msgstr "이 단계는 되돌릴 수 없다는 것을 확인했습니다."
 msgid "Delete my user account now"
 msgstr "지금 내 사용자 계정 삭제하기"
 
-#: src/olympia/users/templates/users/delete_photo.html:3
-#: src/olympia/users/templates/users/delete_photo.html:9
+#: src/olympia/users/templates/users/delete_photo.html:3 src/olympia/users/templates/users/delete_photo.html:9
 msgid "Delete User Photo"
 msgstr "사용자 사진 삭제"
 
@@ -14414,23 +11976,18 @@ msgid "Please set your display name"
 msgstr ""
 
 #: src/olympia/users/templates/users/edit.html:21
-msgid ""
-"Please set your display name or username to complete the registration "
-"process."
+msgid "Please set your display name or username to complete the registration process."
 msgstr ""
 
 #: src/olympia/users/templates/users/edit.html:33
 msgid "Manage basic account information, such as username and email address."
 msgstr "사용자 이름이나 이메일 주소와 같은 기본 계정 정보를 관리합니다."
 
-#: src/olympia/users/templates/users/edit.html:39
-#: src/olympia/users/templates/users/register.html:47
+#: src/olympia/users/templates/users/edit.html:39 src/olympia/users/templates/users/register.html:47
 msgid "Username"
 msgstr "사용자 이름"
 
-#: src/olympia/users/templates/users/edit.html:45
-#: src/olympia/users/templates/users/pwreset_request.html:21
-#: src/olympia/users/templates/users/register.html:62
+#: src/olympia/users/templates/users/edit.html:45 src/olympia/users/templates/users/pwreset_request.html:21 src/olympia/users/templates/users/register.html:62
 msgid "Email Address"
 msgstr "이메일 주소"
 
@@ -14442,20 +11999,15 @@ msgstr ""
 msgid "Change Password"
 msgstr "비밀번호 변경"
 
-#: src/olympia/users/templates/users/edit.html:68
-#: src/olympia/users/templates/users/login_form.html:22
-#: src/olympia/users/templates/users/register.html:67
+#: src/olympia/users/templates/users/edit.html:68 src/olympia/users/templates/users/login_form.html:22 src/olympia/users/templates/users/register.html:67
 #: src/olympia/users/templates/users/mobile/login.html:37
 msgid "Password"
 msgstr "비밀번호"
 
 #: src/olympia/users/templates/users/edit.html:70
 #, python-format
-msgid ""
-"Change your password. If you forgot your password, you can <a "
-"href=\"%(reset_url)s\">use the reset form</a>."
-msgstr ""
-"비밀번호를 변경하세요. 비밀번호를 잊었을 경우 <a href=\"%(reset_url)s\">초기화 양식을 사용</a>하시면 됩니다."
+msgid "Change your password. If you forgot your password, you can <a href=\"%(reset_url)s\">use the reset form</a>."
+msgstr "비밀번호를 변경하세요. 비밀번호를 잊었을 경우 <a href=\"%(reset_url)s\">초기화 양식을 사용</a>하시면 됩니다."
 
 #: src/olympia/users/templates/users/edit.html:76
 msgid "Old Password"
@@ -14474,12 +12026,8 @@ msgid "Profile"
 msgstr "프로필"
 
 #: src/olympia/users/templates/users/edit.html:100
-msgid ""
-"Give us a bit more information about yourself. All these fields are "
-"optional, but they'll help other users get to know you better."
-msgstr ""
-"당신에 관한 정보를 조금은 공개해 주세요. 다음 항목들은 모두 선택 사항이긴 하지만 입력해 놓으면 다른 사람들이 당신을 보다 잘 알 수 "
-"있게 도와주는 역할을 하게 됩니다."
+msgid "Give us a bit more information about yourself. All these fields are optional, but they'll help other users get to know you better."
+msgstr "당신에 관한 정보를 조금은 공개해 주세요. 다음 항목들은 모두 선택 사항이긴 하지만 입력해 놓으면 다른 사람들이 당신을 보다 잘 알 수 있게 도와주는 역할을 하게 됩니다."
 
 #: src/olympia/users/templates/users/edit.html:124
 msgid "This URL will only be visible if you are a developer."
@@ -14494,15 +12042,11 @@ msgid "Delete current photo"
 msgstr "현재 사진 삭제"
 
 #: src/olympia/users/templates/users/edit.html:144
-msgid ""
-"This is the default locale used to display information about you (like your "
-"description)."
+msgid "This is the default locale used to display information about you (like your description)."
 msgstr ""
 
 #: src/olympia/users/templates/users/edit.html:152
-msgid ""
-"Introduce yourself to the community, if you like! This text will appear "
-"publicly on your user info page."
+msgid "Introduce yourself to the community, if you like! This text will appear publicly on your user info page."
 msgstr "자기소개 하길 좋아한다면, 커뮤니티에 한번 해보세요! 아래 문구가 사용자 정보 페이지에 공개적으로 표시될 것입니다."
 
 #: src/olympia/users/templates/users/edit.html:161
@@ -14530,17 +12074,11 @@ msgid "Notifications"
 msgstr "알림 메시지"
 
 #: src/olympia/users/templates/users/edit.html:195
-msgid ""
-"From time to time, Mozilla may send you email about upcoming releases and "
-"add-on events. Please select the topics you are interested in."
-msgstr ""
-"가끔씩 Mozilla에선 곧 출시될 최신 버전 정보와 부가 기능 이벤트에 관한 정보를 이메일로 보냅니다. 관심을 갖고 있는 주제를 선택해"
-" 주세요."
+msgid "From time to time, Mozilla may send you email about upcoming releases and add-on events. Please select the topics you are interested in."
+msgstr "가끔씩 Mozilla에선 곧 출시될 최신 버전 정보와 부가 기능 이벤트에 관한 정보를 이메일로 보냅니다. 관심을 갖고 있는 주제를 선택해 주세요."
 
 #: src/olympia/users/templates/users/edit.html:205
-msgid ""
-"Mozilla reserves the right to contact you individually about specific "
-"concerns with your hosted add-ons."
+msgid "Mozilla reserves the right to contact you individually about specific concerns with your hosted add-ons."
 msgstr "Mozilla는 당신이 등록한 부가 기능의 특정 사항에 대한 개인적 연락을 할 권리를 보장하고 있습니다."
 
 #: src/olympia/users/templates/users/edit.html:215
@@ -14563,61 +12101,49 @@ msgstr "없음"
 msgid "all"
 msgstr "전부"
 
-#: src/olympia/users/templates/users/fxa_migration.html:3
-#: src/olympia/users/templates/users/fxa_migration.html:11
-#: src/olympia/users/templates/users/mobile/fxa_migration.html:3
+#: src/olympia/users/templates/users/fxa_migration.html:3 src/olympia/users/templates/users/fxa_migration.html:11 src/olympia/users/templates/users/mobile/fxa_migration.html:3
 #: src/olympia/users/templates/users/mobile/fxa_migration.html:8
 msgid "Migrate to Firefox Accounts"
 msgstr ""
 
 #: src/olympia/users/templates/users/fxa_migration_prompt_content.html:3
-msgid ""
-"Mozilla Add-ons has transitioned to Firefox Accounts for login. Continue to "
-"complete the simple upgrade process."
+msgid "Mozilla Add-ons has transitioned to Firefox Accounts for login. Continue to complete the simple upgrade process."
 msgstr ""
 
 #: src/olympia/users/templates/users/fxa_migration_prompt_content.html:14
 msgid "Skip"
 msgstr ""
 
-#: src/olympia/users/templates/users/login.html:3
-#: src/olympia/users/templates/users/mobile/login.html:3
+#: src/olympia/users/templates/users/login.html:3 src/olympia/users/templates/users/mobile/login.html:3
 msgid "User Login"
 msgstr "사용자 로그인"
 
-#: src/olympia/users/templates/users/login.html:13
-#: src/olympia/users/templates/users/mobile/login.html:21
+#: src/olympia/users/templates/users/login.html:13 src/olympia/users/templates/users/mobile/login.html:21
 msgid "Enter your email"
 msgstr ""
 
-#: src/olympia/users/templates/users/login.html:15
-#: src/olympia/users/templates/users/mobile/login.html:23
+#: src/olympia/users/templates/users/login.html:15 src/olympia/users/templates/users/mobile/login.html:23
 msgid "Log In"
 msgstr "로그인"
 
-#: src/olympia/users/templates/users/login_form.html:17
-#: src/olympia/users/templates/users/mobile/login.html:32
+#: src/olympia/users/templates/users/login_form.html:17 src/olympia/users/templates/users/mobile/login.html:32
 msgid "Email address"
 msgstr "이메일 주소"
 
-#: src/olympia/users/templates/users/login_form.html:30
-#: src/olympia/users/templates/users/mobile/login.html:44
+#: src/olympia/users/templates/users/login_form.html:30 src/olympia/users/templates/users/mobile/login.html:44
 msgid "Remember me on this device"
 msgstr "이 장치에서 계정 이름 저장"
 
 # This is a header for additional help options
-#: src/olympia/users/templates/users/login_help.html:3
-#: src/olympia/users/templates/users/mobile/login.html:63
+#: src/olympia/users/templates/users/login_help.html:3 src/olympia/users/templates/users/mobile/login.html:63
 msgid "Login Problems?"
 msgstr "로그인에 문제가 있나요?"
 
-#: src/olympia/users/templates/users/login_help.html:5
-#: src/olympia/users/templates/users/mobile/login.html:65
+#: src/olympia/users/templates/users/login_help.html:5 src/olympia/users/templates/users/mobile/login.html:65
 msgid "I don't have an account."
 msgstr "계정이 없습니다."
 
-#: src/olympia/users/templates/users/login_help.html:6
-#: src/olympia/users/templates/users/mobile/login.html:66
+#: src/olympia/users/templates/users/login_help.html:6 src/olympia/users/templates/users/mobile/login.html:66
 msgid "I forgot my password."
 msgstr "비밀번호가 기억나지 않습니다."
 
@@ -14626,15 +12152,9 @@ msgstr "비밀번호가 기억나지 않습니다."
 msgid "You are now logged in as <strong>%(user_email)s</strong>!"
 msgstr "<strong>%(user_email)s</strong>(으)로 로그인 하셨습니다!"
 
-#: src/olympia/users/templates/users/newpw_sent.html:3
-#: src/olympia/users/templates/users/newpw_sent.html:8
-#: src/olympia/users/templates/users/pwreset_complete.html:3
-#: src/olympia/users/templates/users/pwreset_confirm.html:4
-#: src/olympia/users/templates/users/pwreset_confirm.html:18
-#: src/olympia/users/templates/users/pwreset_request.html:4
-#: src/olympia/users/templates/users/pwreset_request.html:10
-#: src/olympia/users/templates/users/pwreset_sent.html:3
-#: src/olympia/users/templates/users/pwreset_sent.html:8
+#: src/olympia/users/templates/users/newpw_sent.html:3 src/olympia/users/templates/users/newpw_sent.html:8 src/olympia/users/templates/users/pwreset_complete.html:3
+#: src/olympia/users/templates/users/pwreset_confirm.html:4 src/olympia/users/templates/users/pwreset_confirm.html:18 src/olympia/users/templates/users/pwreset_request.html:4
+#: src/olympia/users/templates/users/pwreset_request.html:10 src/olympia/users/templates/users/pwreset_sent.html:3 src/olympia/users/templates/users/pwreset_sent.html:8
 msgid "Password Reset"
 msgstr "비밀번호 초기화"
 
@@ -14650,8 +12170,7 @@ msgstr "프로필 수정"
 msgid "Manage user"
 msgstr "사용자 관리"
 
-#: src/olympia/users/templates/users/profile.html:18
-#: src/olympia/users/templates/users/report_abuse_full.html:9
+#: src/olympia/users/templates/users/profile.html:18 src/olympia/users/templates/users/report_abuse_full.html:9
 msgid "Report user"
 msgstr "사용자 신고"
 
@@ -14714,32 +12233,24 @@ msgstr "성공했습니다!"
 msgid "Password successfully reset."
 msgstr "비밀번호를 성공적으로 초기화 하였습니다."
 
-#: src/olympia/users/templates/users/pwreset_confirm.html:13
-#: src/olympia/users/templates/users/pwreset_confirm.html:46
+#: src/olympia/users/templates/users/pwreset_confirm.html:13 src/olympia/users/templates/users/pwreset_confirm.html:46
 msgid "Password reset unsuccessful"
 msgstr "비밀번호 초기화에 실패했습니다"
 
 #: src/olympia/users/templates/users/pwreset_confirm.html:14
-msgid ""
-"You have migrated to Firefox Accounts. You can no longer change your "
-"password here."
+msgid "You have migrated to Firefox Accounts. You can no longer change your password here."
 msgstr ""
 
-#: src/olympia/users/templates/users/pwreset_confirm.html:31
-#: src/olympia/users/templates/users/register.html:72
+#: src/olympia/users/templates/users/pwreset_confirm.html:31 src/olympia/users/templates/users/register.html:72
 msgid "Confirm password"
 msgstr "비밀번호 확인"
 
 #: src/olympia/users/templates/users/pwreset_confirm.html:47
-msgid ""
-"The password reset link was invalid, possibly because it has already been "
-"used. Please request a new password reset."
+msgid "The password reset link was invalid, possibly because it has already been used. Please request a new password reset."
 msgstr "비밀번호 초기화 링크가 잘못되었는데, 이미 사용해서 그런것 같습니다. 비밀번호 초기화 요청을 새로 해주세요."
 
 #: src/olympia/users/templates/users/pwreset_request.html:15
-msgid ""
-"Forgotten your password? Enter your e-mail address below, and we'll e-mail "
-"instructions for setting a new one."
+msgid "Forgotten your password? Enter your e-mail address below, and we'll e-mail instructions for setting a new one."
 msgstr "비밀번호가 기억나지 않으시나요? 아래에다 이메일 주소를 입력해 주시면 새 비밀번호 설정 안내문이 담긴 이메일을 보내드립니다."
 
 #: src/olympia/users/templates/users/pwreset_request.html:25
@@ -14747,13 +12258,8 @@ msgid "Send password reset link"
 msgstr "비밀번호 초기화 링크 보내기"
 
 #: src/olympia/users/templates/users/pwreset_sent.html:10
-msgid ""
-"An email has been sent to the requested account with further information. If"
-" you do not receive an email then please confirm you have entered the same "
-"email address used during account registration."
-msgstr ""
-"입력하신 계정으로 자세한 정보가 첨부된 이메일이 전송되었습니다. 이메일을 받아보지 못하셨다면 이메일 주소가 아직 계정 등록중에 있는건 "
-"아닌지 확인해 보시기 바랍니다."
+msgid "An email has been sent to the requested account with further information. If you do not receive an email then please confirm you have entered the same email address used during account registration."
+msgstr "입력하신 계정으로 자세한 정보가 첨부된 이메일이 전송되었습니다. 이메일을 받아보지 못하셨다면 이메일 주소가 아직 계정 등록중에 있는건 아닌지 확인해 보시기 바랍니다."
 
 #: src/olympia/users/templates/users/register.html:4
 msgid "New User Registration"
@@ -14764,9 +12270,7 @@ msgid "Why register?"
 msgstr "계정을 만들어야 하는 이유가 있나요?"
 
 #: src/olympia/users/templates/users/register.html:14
-msgid ""
-"Registration on AMO is <strong>not required</strong> if you simply want to "
-"download and install public add-ons."
+msgid "Registration on AMO is <strong>not required</strong> if you simply want to download and install public add-ons."
 msgstr "단순히 공개 부가 기능을 다운받고 설치하는 정도라면 AMO에 <strong>가입할 필요는 없습니다</strong>."
 
 #: src/olympia/users/templates/users/register.html:16
@@ -14778,42 +12282,28 @@ msgid "You want to submit reviews for add-ons"
 msgstr "부가 기능 평가를 쓰고 싶을 경우"
 
 #: src/olympia/users/templates/users/register.html:19
-msgid ""
-"You want to keep track of your favorite add-on collections or create one "
-"yourself"
+msgid "You want to keep track of your favorite add-on collections or create one yourself"
 msgstr "부가 기능 모음집을 즐겨찾기 하거나 나만의 모음집을 만들고 싶을 때"
 
 #: src/olympia/users/templates/users/register.html:20
-msgid ""
-"You are an add-on developer and want to upload your add-on for hosting on "
-"AMO"
+msgid "You are an add-on developer and want to upload your add-on for hosting on AMO"
 msgstr "부가 기능 개발자로 AMO에 부가 기능을 올려서 호스팅을 받길 원할 때"
 
 #: src/olympia/users/templates/users/register.html:23
-msgid ""
-"Upon successful registration, you will be sent a confirmation email to the "
-"address you provided. Please follow the instructions there to confirm your "
-"account."
+msgid "Upon successful registration, you will be sent a confirmation email to the address you provided. Please follow the instructions there to confirm your account."
 msgstr "가입이 완료되면 입력한 이메일 주소로 확인용 메일을 받게 됩니다. 메일에 적힌 절차에 따라 계정을 확인해 주세요."
 
 #: src/olympia/users/templates/users/register.html:30
 #, python-format
-msgid ""
-"If you like, you can read our <a href=\"%(legal)s\" title=\"Legal "
-"Notices\">Legal Notices</a> and <a href=\"%(privacy)s\" title=\"Privacy "
-"Policy\">Privacy Policy</a>."
-msgstr ""
-"원하신다면 저희의 <a href=\"%(legal)s\" title=\"법적 고지\">법적 고지</a>와 <a "
-"href=\"%(privacy)s\" title=\"개인 정보 보호 정책\">개인 정보 보호 정책</a>을 읽어보실 수 있습니다."
+msgid "If you like, you can read our <a href=\"%(legal)s\" title=\"Legal Notices\">Legal Notices</a> and <a href=\"%(privacy)s\" title=\"Privacy Policy\">Privacy Policy</a>."
+msgstr "원하신다면 저희의 <a href=\"%(legal)s\" title=\"법적 고지\">법적 고지</a>와 <a href=\"%(privacy)s\" title=\"개인 정보 보호 정책\">개인 정보 보호 정책</a>을 읽어보실 수 있습니다."
 
 #: src/olympia/users/templates/users/register.html:52
 msgid "Display name"
 msgstr "별명"
 
 #: src/olympia/users/templates/users/report_abuse.html:7
-msgid ""
-"Please describe why you are reporting this user, such as for spam or an "
-"inappropriate picture."
+msgid "Please describe why you are reporting this user, such as for spam or an inappropriate picture."
 msgstr "이 사용자를 신고한 이유(스팸, 부적절한 사진 등록 등)를 적어주세요."
 
 #: src/olympia/users/templates/users/report_abuse_full.html:3
@@ -14828,32 +12318,24 @@ msgstr "티셔츠 주문"
 msgid "Special Edition Add-on Creator T-shirt"
 msgstr ""
 
-#: src/olympia/users/templates/users/t-shirt.html:14
-#: src/olympia/users/templates/users/t-shirt.html:120
+#: src/olympia/users/templates/users/t-shirt.html:14 src/olympia/users/templates/users/t-shirt.html:120
 msgid "Note:"
 msgstr ""
 
 #: src/olympia/users/templates/users/t-shirt.html:15
-msgid ""
-"You have already submitted a request for a t-shirt. You may re-submit this "
-"form to update your information, but you will only receive one shirt."
+msgid "You have already submitted a request for a t-shirt. You may re-submit this form to update your information, but you will only receive one shirt."
 msgstr ""
 
 #: src/olympia/users/templates/users/t-shirt.html:26
-msgid ""
-"Thank you for helping to make Firefox the most extensible browser available!"
+msgid "Thank you for helping to make Firefox the most extensible browser available!"
 msgstr ""
 
 #: src/olympia/users/templates/users/t-shirt.html:33
-msgid ""
-"As a thank you gift, we'd like to send you a special-edition, community-"
-"designed t-shirt. To receive your shirt, please fill out the form below."
+msgid "As a thank you gift, we'd like to send you a special-edition, community-designed t-shirt. To receive your shirt, please fill out the form below."
 msgstr ""
 
 #: src/olympia/users/templates/users/t-shirt.html:41
-msgid ""
-"Your contact information will only be used by Mozilla to ship this special "
-"edition t-shirt."
+msgid "Your contact information will only be used by Mozilla to ship this special edition t-shirt."
 msgstr ""
 
 #: src/olympia/users/templates/users/t-shirt.html:60
@@ -14910,16 +12392,12 @@ msgstr ""
 
 #: src/olympia/users/templates/users/t-shirt.html:137
 msgid ""
-"We're sorry, but in order to qualify for our special edition t-shirt, you "
-"must be an add-on developer with at least one listed add-on, one unlisted "
-"but signed add-on, or any number of background themes with a combined total "
-"of 10,000 average daily users."
+"We're sorry, but in order to qualify for our special edition t-shirt, you must be an add-on developer with at least one listed add-on, one unlisted but signed add-on, or any number of background "
+"themes with a combined total of 10,000 average daily users."
 msgstr ""
 
 #: src/olympia/users/templates/users/tougher_password.html:2
-msgid ""
-"For your account a password must contain at least 8 characters including "
-"letters and numbers."
+msgid "For your account a password must contain at least 8 characters including letters and numbers."
 msgstr "계정의 비밀번호는 최소 8글자 이상이어야 하며 문자와 숫자를 반드시 포함하고 있어야 합니다."
 
 #: src/olympia/users/templates/users/unsubscribe.html:2
@@ -14932,9 +12410,7 @@ msgstr "구독을 해제했습니다!"
 
 #: src/olympia/users/templates/users/unsubscribe.html:10
 #, python-format
-msgid ""
-"The email address <strong>%(email)s</strong> will no longer get messages "
-"when:"
+msgid "The email address <strong>%(email)s</strong> will no longer get messages when:"
 msgstr "이메일 주소 <strong>%(email)s</strong>은(는) 다음 시간 이후로 더이상 메시지를 받지 않습니다:"
 
 #: src/olympia/users/templates/users/unsubscribe.html:20
@@ -14955,13 +12431,8 @@ msgstr "구독 해제를 할 수 없습니다"
 
 #: src/olympia/users/templates/users/unsubscribe.html:30
 #, python-format
-msgid ""
-"Unfortunately, we weren't able to unsubscribe you. The link you clicked is "
-"invalid. However, you can unsubscribe still unsubscribe on your <a "
-"href=\"%(edit_url)s\">edit profile page</a>."
-msgstr ""
-"죄송하지만 당신을 구독 해제할 수 없었습니다. 클릭하신 링크가 올바르지 않았습니다. <a href=\"%(edit_url)s\">프로필 "
-"페이지 수정</a>을 통해 구독 해제를 하실 수 있습니다."
+msgid "Unfortunately, we weren't able to unsubscribe you. The link you clicked is invalid. However, you can unsubscribe still unsubscribe on your <a href=\"%(edit_url)s\">edit profile page</a>."
+msgstr "죄송하지만 당신을 구독 해제할 수 없었습니다. 클릭하신 링크가 올바르지 않았습니다. <a href=\"%(edit_url)s\">프로필 페이지 수정</a>을 통해 구독 해제를 하실 수 있습니다."
 
 #: src/olympia/users/templates/users/vcard.html:2
 msgid "Developer Information"
@@ -14992,12 +12463,14 @@ msgstr "부가 기능 {0}개"
 msgid "%(num)s theme"
 msgid_plural "%(num)s themes"
 msgstr[0] "테마 %(num)s개"
+msgstr[1] ""
 
 #: src/olympia/users/templates/users/vcard.html:62
 #, python-format
 msgid "%(num)s add-on"
 msgid_plural "%(num)s add-ons"
 msgstr[0] "부가 기능 %(num)s개"
+msgstr[1] ""
 
 #: src/olympia/users/templates/users/vcard.html:75
 msgid "Average rating of developer's add-ons"
@@ -15012,15 +12485,15 @@ msgstr "%s의 판올림 내역"
 msgid "Version History with Changelogs"
 msgstr "각 버전별 변경 사항"
 
-#: src/olympia/versions/models.py:314
+#: src/olympia/versions/models.py:313
 msgid "Add-on uses binary components."
 msgstr "부가 기능이 이진 콤포넌트를 사용하고 있습니다."
 
-#: src/olympia/versions/models.py:317
+#: src/olympia/versions/models.py:316
 msgid "Add-on has opted into strict compatibility checking."
 msgstr "부가 기능이 엄격한 호환성 검사 방식을 채택했습니다."
 
-#: src/olympia/versions/models.py:715
+#: src/olympia/versions/models.py:711
 msgid "{app} {min} and later"
 msgstr "{app} {min} 이상"
 
@@ -15047,8 +12520,8 @@ msgstr "<a href=\"%(url)s\">%(name)s</a>를 사용해서 소스 코드 공개"
 msgid "View the source"
 msgstr "소스 코드 보기"
 
-#. {0} is an add-on name.
 # {0} is the add-on name
+#. {0} is an add-on name.
 #: src/olympia/versions/templates/versions/version_list.html:26
 msgid "{0} Version History"
 msgstr "{0}의 버전 기록"
@@ -15058,21 +12531,16 @@ msgstr "{0}의 버전 기록"
 msgid "<b>{0}</b> version"
 msgid_plural "<b>{0}</b> versions"
 msgstr[0] "버전 <b>{0}</b>개"
+msgstr[1] ""
 
-#: src/olympia/versions/templates/versions/version_list.html:35
-#: src/olympia/versions/templates/versions/mobile/version_list.html:14
+#: src/olympia/versions/templates/versions/version_list.html:35 src/olympia/versions/templates/versions/mobile/version_list.html:14
 msgid "Be careful with old versions!"
 msgstr "오래된 버전인지 확인하세요!"
 
-#: src/olympia/versions/templates/versions/version_list.html:36
-#: src/olympia/versions/templates/versions/mobile/version_list.html:15
+#: src/olympia/versions/templates/versions/version_list.html:36 src/olympia/versions/templates/versions/mobile/version_list.html:15
 #, python-format
-msgid ""
-"These versions are displayed for reference and testing purposes. You should "
-"always use the <a href=\"%(url)s\">latest version</a> of an add-on."
-msgstr ""
-"아래 버전들은 테스트 목적 및 참고용입니다. 항상 <a href=\"%(url)s\">최신 버전</a>의 부가 기능만을 사용하시기 "
-"바랍니다."
+msgid "These versions are displayed for reference and testing purposes. You should always use the <a href=\"%(url)s\">latest version</a> of an add-on."
+msgstr "아래 버전들은 테스트 목적 및 참고용입니다. 항상 <a href=\"%(url)s\">최신 버전</a>의 부가 기능만을 사용하시기 바랍니다."
 
 #: src/olympia/versions/templates/versions/mobile/version.html:4
 msgid "Beta Version {0}"
@@ -15102,3 +12570,8 @@ msgstr "완료시 이메일 알림"
 #: src/olympia/zadmin/forms.py:105
 msgid "Log emails instead of sending"
 msgstr "이메일 전송 대신 기록"
+
+#: src/olympia/zadmin/forms.py:215
+msgid "Deleted versions can`t be changed."
+msgstr ""
+

--- a/locale/ko/LC_MESSAGES/djangojs.po
+++ b/locale/ko/LC_MESSAGES/djangojs.po
@@ -1,1230 +1,1237 @@
-# 
+#
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2016-02-24 21:23+0000\n"
+"POT-Creation-Date: 2016-04-18 15:47+0000\n"
 "PO-Revision-Date: 2016-03-25 16:05+0000\n"
 "Last-Translator: DONGHOON IM <dongttang@gmail.com>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
-"Language: ko\n"
+"Language: \n"
 "MIME-Version: 1.0\n"
-"Content-Type: text/plain; charset=utf-8\n"
+"Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=1; plural=0;\n"
 "Generated-By: Babel 2.2.0\n"
-"X-Generator: Pontoon\n"
 
-#: static/js/common/ratingwidget.js:31
+#: static/js/common-all.js:1426 static/js/impala-all.js:1511 static/js/zamboni/discovery-all.js:12598 static/js/zamboni/init.js:28 static/js/zamboni/mobile-all.js:14945
+msgid "This feature is temporarily disabled while we perform website maintenance. Please check back a little later."
+msgstr "이 기능은 웹사이트 점검으로 인해 잠시 사용할 수 없습니다. 잠시 후 다시 사용해 주세요."
+
+#. L10n: {0} is an app name like Firefox.
+#: static/js/common-all.js:1837 static/js/impala-all.js:1922 static/js/zamboni/buttons.js:73 static/js/zamboni/discovery-all.js:13108
+msgid "Accept and Install"
+msgstr "동의 및 설치"
+
+#: static/js/common-all.js:1837 static/js/impala-all.js:1922 static/js/zamboni/buttons.js:73 static/js/zamboni/discovery-all.js:13108
+msgid "Add to {0}"
+msgstr "{0}에 추가"
+
+#: static/js/common-all.js:1842 static/js/impala-all.js:1927 static/js/zamboni/buttons.js:78 static/js/zamboni/discovery-all.js:13113
+msgid "Download Now"
+msgstr "다운로드"
+
+#: static/js/common-all.js:1883 static/js/impala-all.js:1968 static/js/zamboni/buttons.js:119 static/js/zamboni/discovery-all.js:13154
+msgid "Add-on has not been updated to support default-to-compatible."
+msgstr "부가 기능이 기본으로 호환성을 갖출 수 있도록 업데이트 되지 않았습니다."
+
+#: static/js/common-all.js:1888 static/js/impala-all.js:1973 static/js/zamboni/buttons.js:124 static/js/zamboni/discovery-all.js:13159
+msgid "You need to be using Firefox 10.0 or higher."
+msgstr "Firefox 10.0 이상 버전이 필요합니다."
+
+#: static/js/common-all.js:1900 static/js/impala-all.js:1985 static/js/zamboni/buttons.js:136 static/js/zamboni/discovery-all.js:13171
+msgid "Mozilla has marked this version as incompatible with your Firefox version."
+msgstr "Mozilla에서 이 버전이 현재 사용중인 Firefox 버전과 호환되지 않음을 표시하고 있습니다."
+
+#. L10n: {0} is an platform like Windows or Linux.
+#: static/js/common-all.js:1981 static/js/impala-all.js:2066 static/js/zamboni/buttons.js:217 static/js/zamboni/discovery-all.js:13252
+msgid "Install for {0} anyway"
+msgstr "{0}용 강제 설치"
+
+#: static/js/common-all.js:1981 static/js/impala-all.js:2066 static/js/zamboni/buttons.js:217 static/js/zamboni/discovery-all.js:13252
+msgid "Download for {0} anyway"
+msgstr "{0}용 강제 다운로드"
+
+#: static/js/common-all.js:2038 static/js/impala-all.js:2123 static/js/zamboni/buttons.js:274 static/js/zamboni/discovery-all.js:13309
+msgid "Not available for your platform"
+msgstr "현재 플랫폼에서 사용 불가"
+
+#. L10n: {0} is an app name, {1} is the app version.
+#: static/js/common-all.js:2049 static/js/common-all.js:2086 static/js/impala-all.js:2134 static/js/impala-all.js:2171 static/js/zamboni/buttons.js:286 static/js/zamboni/buttons.js:324
+#: static/js/zamboni/discovery-all.js:13320 static/js/zamboni/discovery-all.js:13357
+msgid "Not available for {0} {1}"
+msgstr "{0} {1}에서 사용 불가"
+
+#: static/js/common-all.js:2112 static/js/impala-all.js:2197 static/js/zamboni/buttons.js:351 static/js/zamboni/discovery-all.js:13383
+msgid "Works with {app} {min} - {max}"
+msgstr "{app} {min} - {max}에서 작동"
+
+#: static/js/common-all.js:2114 static/js/impala-all.js:2199 static/js/zamboni/buttons.js:353 static/js/zamboni/discovery-all.js:13385
+msgid "View other versions"
+msgstr "다른 버전 보기"
+
+#: static/js/common-all.js:2162 static/js/impala-all.js:2247 static/js/zamboni/buttons.js:401 static/js/zamboni/discovery-all.js:13433
+msgid "Only with Firefox — Get Firefox Now!"
+msgstr ""
+
+#: static/js/common-all.js:2278 static/js/impala-all.js:2363 static/js/zamboni/buttons.js:517 static/js/zamboni/discovery-all.js:13549 static/js/zamboni/mobile-all.js:15177
+#: static/js/zamboni/mobile/buttons.js:43
+msgid "Sorry, you need a Mozilla-based browser (such as Firefox) to install a search plugin."
+msgstr "죄송합니다. 검색 플러그인을 설치하려면 Mozilla 기반 브라우저(Firefox 같은)가 필요합니다."
+
+#: static/js/common-all.js:9088 static/js/impala-all.js:9649 static/js/zamboni/global.js:410
+msgid "Loading..."
+msgstr "읽는 중..."
+
+#. L10n: {0} is the number of characters left.
+#: static/js/common-all.js:9152 static/js/impala-all.js:9713 static/js/zamboni/global.js:474
+msgid "<b>{0}</b> character left."
+msgid_plural "<b>{0}</b> characters left."
+msgstr[0] "<b>{0}</b>자 남았습니다."
+msgstr[1] ""
+
+#: static/js/common-all.js:9589 static/js/common-min.js:6 static/js/impala-all.js:10052 static/js/impala-min.js:6 static/js/common/ratingwidget.js:31 static/js/zamboni/mobile-all.js:16123
+#: static/js/zamboni/mobile-min.js:6
 msgid "{0} star"
 msgid_plural "{0} stars"
 msgstr[0] "별점 {0}점"
+msgstr[1] ""
 
-#: static/js/common/upload-addon.js:41 static/js/common/upload-image.js:128
+#: static/js/common-all.js:9676 static/js/common-min.js:6 static/js/impala-all.js:10139 static/js/impala-min.js:6 static/js/zamboni/l10n.js:45
+msgid "Remove this localization"
+msgstr "이 번역 삭제"
+
+#: static/js/common-all.js:10193 static/js/common-min.js:6 static/js/impala-all.js:10674 static/js/impala-min.js:6 static/js/zamboni/discovery-all.js:13678
+msgid "close"
+msgstr ""
+
+#: static/js/common-all.js:10860 static/js/common-min.js:6 static/js/impala-all.js:11481 static/js/impala-min.js:6 static/js/impala/reviews.js:23 static/js/zamboni/reviews.js:18
+msgid "Flagged for review"
+msgstr "평가에 표시하기"
+
+#: static/js/common-all.js:10876 static/js/common-min.js:6 static/js/impala-all.js:11498 static/js/impala-min.js:6 static/js/impala/reviews.js:40 static/js/zamboni/reviews.js:34
+msgid "Your input is required"
+msgstr "글을 입력해야 합니다"
+
+#: static/js/common-all.js:10945 static/js/common-min.js:6 static/js/impala-all.js:11610 static/js/impala-min.js:7 static/js/impala/reviews.js:152 static/js/zamboni/reviews.js:103
+msgid "Marked for deletion"
+msgstr "삭제 표시"
+
+#: static/js/common-all.js:11573 static/js/common-min.js:7 static/js/impala-all.js:13809 static/js/impala-min.js:8 static/js/zamboni/collections.js:229
+msgid "Adding to Favorites&hellip;"
+msgstr "선호 목록에 추가중&hellip;"
+
+#: static/js/common-all.js:11576 static/js/common-min.js:7 static/js/impala-all.js:13812 static/js/impala-min.js:8 static/js/zamboni/collections.js:232
+msgid "Removing Favorite&hellip;"
+msgstr "선호 목록에서 삭제중&hellip;"
+
+#: static/js/common-all.js:11579 static/js/common-min.js:7 static/js/impala-all.js:13815 static/js/impala-min.js:8 static/js/zamboni/collections.js:235
+msgid "Add to Favorites"
+msgstr "선호 목록에 추가"
+
+#: static/js/common-all.js:11582 static/js/common-min.js:7 static/js/impala-all.js:13818 static/js/impala-min.js:8 static/js/zamboni/collections.js:238
+msgid "Remove from Favorites"
+msgstr "선호 목록에서 삭제"
+
+#: static/js/common-all.js:11647 static/js/common-min.js:7 static/js/impala-all.js:13883 static/js/impala-min.js:8 static/js/zamboni/collections.js:303
+msgid "Pending"
+msgstr "대기중"
+
+#: static/js/common-all.js:11648 static/js/common-min.js:7 static/js/impala-all.js:13884 static/js/impala-min.js:8 static/js/zamboni/collections.js:304
+msgid "Add a comment"
+msgstr "코멘트 추가"
+
+#: static/js/common-all.js:11648 static/js/common-min.js:7 static/js/impala-all.js:13884 static/js/impala-min.js:8 static/js/zamboni/collections.js:304
+msgid "Comment"
+msgstr "코멘트"
+
+#: static/js/common-all.js:11649 static/js/common-min.js:7 static/js/impala-all.js:13885 static/js/impala-min.js:8 static/js/zamboni/collections.js:305
+msgid "Remove this add-on from the collection"
+msgstr "모음집에서 이 부가 기능 삭제"
+
+#: static/js/common-all.js:11649 static/js/common-all.js:11678 static/js/common-min.js:7 static/js/impala-all.js:13885 static/js/impala-all.js:13914 static/js/impala-min.js:8
+#: static/js/zamboni/collections.js:305 static/js/zamboni/collections.js:334
+msgid "Remove"
+msgstr "삭제"
+
+#: static/js/common-all.js:11678 static/js/common-min.js:7 static/js/impala-all.js:13914 static/js/impala-min.js:8 static/js/zamboni/collections.js:334
+msgid "Remove this user as a contributor"
+msgstr "기여자에서 이 사용자 삭제"
+
+#: static/js/common-all.js:11690 static/js/common-min.js:7 static/js/impala-all.js:13926 static/js/impala-min.js:8 static/js/zamboni/collections.js:346
+msgid "An email address is required."
+msgstr "이메일 주소를 입력해야 합니다."
+
+#: static/js/common-all.js:11708 static/js/common-min.js:7 static/js/impala-all.js:13944 static/js/impala-min.js:8 static/js/zamboni/collections.js:364
+msgid "You cannot add yourself as a contributor."
+msgstr "자신의 계정은 기여자로 추가할 수 없습니다."
+
+#: static/js/common-all.js:11710 static/js/common-min.js:7 static/js/impala-all.js:13946 static/js/impala-min.js:8 static/js/zamboni/collections.js:366
+msgid "You have already added that user."
+msgstr "이미 추가된 사용자입니다."
+
+#: static/js/common-all.js:11917 static/js/common-min.js:7 static/js/impala-all.js:14153 static/js/impala-min.js:8 static/js/zamboni/collections.js:573
+msgid "Add to favorites"
+msgstr "선호 목록에 추가"
+
+#: static/js/common-all.js:11921 static/js/common-min.js:7 static/js/impala-all.js:14157 static/js/impala-min.js:8 static/js/zamboni/collections.js:577
+msgid "Remove from favorites"
+msgstr "선호 목록에서 삭제"
+
+#: static/js/common-all.js:11939 static/js/common-min.js:7 static/js/impala-all.js:14175 static/js/impala-all.js:14233 static/js/impala-min.js:8 static/js/impala/collections.js:10
+#: static/js/zamboni/collections.js:595
+msgid "Follow this Collection"
+msgstr "이 모음집 팔로우 하기"
+
+#: static/js/common-all.js:11948 static/js/common-min.js:7 static/js/impala-all.js:14184 static/js/impala-min.js:8 static/js/zamboni/collections.js:604
+msgid "Stop following"
+msgstr "팔로우 중단"
+
+#: static/js/common-all.js:12096 static/js/common-min.js:7 static/js/zamboni/password-strength.js:20
+msgid "Password strength:"
+msgstr "비밀번호 보안 등급:"
+
+#: static/js/common-all.js:12102 static/js/common-min.js:7 static/js/zamboni/password-strength.js:26
+msgid "At least {0} character left."
+msgid_plural "At least {0} characters left."
+msgstr[0] "최소 {0}글자를 더 입력해야 합니다."
+msgstr[1] ""
+
+#: static/js/common-all.js:12286 static/js/common-min.js:7 static/js/impala-all.js:14632 static/js/impala-min.js:8 static/js/impala/suggestions.js:39
+msgid "Search themes for <b>{0}</b>"
+msgstr "<b>{0}</b>의 테마 검색"
+
+#: static/js/common-all.js:12288 static/js/common-min.js:7 static/js/impala-all.js:14634 static/js/impala-min.js:8 static/js/impala/suggestions.js:41
+msgid "Search apps for <b>{0}</b>"
+msgstr "<b>{0}</b> 앱 검색"
+
+#: static/js/common-all.js:12290 static/js/common-min.js:7 static/js/impala-all.js:14636 static/js/impala-min.js:8 static/js/impala/suggestions.js:43
+msgid "Search add-ons for <b>{0}</b>"
+msgstr "<b>{0}</b> 부가 기능 검색"
+
+#: static/js/common-all.js:12521 static/js/common-min.js:7 static/js/impala-all.js:14867 static/js/impala-min.js:8 static/js/impala/site_suggestions.js:46
+msgid "Category"
+msgstr "분류"
+
+#. L10n: {0} is an app name.
+#: static/js/impala-all.js:11632 static/js/impala-min.js:7 static/js/impala/listing.js:11 static/js/zamboni/themes.js:13
+msgid "This theme is incompatible with your version of {0}"
+msgstr "이 테마는 현재 {0} 버전과 호환되지 않습니다"
+
+#: static/js/impala-all.js:12146 static/js/impala-all.js:14331 static/js/impala-min.js:7 static/js/impala-min.js:8 static/js/common/upload-image.js:97 static/js/impala/users.js:51
+#: static/js/zamboni/devhub-all.js:894 static/js/zamboni/devhub-min.js:1
+msgid "Images must be either PNG or JPG."
+msgstr "이미지는 PNG나 JPG를 써야 합니다."
+
+#: static/js/impala-all.js:12150 static/js/impala-min.js:7 static/js/common/upload-image.js:101 static/js/zamboni/devhub-all.js:898 static/js/zamboni/devhub-min.js:1
+msgid "Videos must be in WebM."
+msgstr "동영상은 WebM으로 된 것만 사용 가능합니다."
+
+#: static/js/impala-all.js:12177 static/js/impala-min.js:7 static/js/common/upload-addon.js:41 static/js/common/upload-image.js:128 static/js/zamboni/devhub-all.js:272
+#: static/js/zamboni/devhub-all.js:925 static/js/zamboni/devhub-min.js:1
 msgid "There was a problem contacting the server."
 msgstr "서버와 연결 도중 문제가 발생했습니다."
 
-#: static/js/common/upload-addon.js:69
+#: static/js/impala-all.js:13298 static/js/impala-min.js:7 static/js/impala/persona_creation.js:60
+msgid "All Rights Reserved"
+msgstr "All Rights Reserved"
+
+#: static/js/impala-all.js:13302 static/js/impala-min.js:7 static/js/impala/persona_creation.js:64
+msgid "Creative Commons Attribution 3.0"
+msgstr "Creative Commons Attribution 3.0"
+
+#: static/js/impala-all.js:13307 static/js/impala-min.js:7 static/js/impala/persona_creation.js:69
+msgid "Creative Commons Attribution-NonCommercial 3.0"
+msgstr "Creative Commons Attribution-NonCommercial 3.0"
+
+#: static/js/impala-all.js:13312 static/js/impala-min.js:7 static/js/impala/persona_creation.js:74
+msgid "Creative Commons Attribution-NonCommercial-NoDerivs 3.0"
+msgstr "Creative Commons Attribution-NonCommercial-NoDerivs 3.0"
+
+#: static/js/impala-all.js:13317 static/js/impala-min.js:7 static/js/impala/persona_creation.js:79
+msgid "Creative Commons Attribution-NonCommercial-Share Alike 3.0"
+msgstr "Creative Commons Attribution-NonCommercial-Share Alike 3.0"
+
+#: static/js/impala-all.js:13322 static/js/impala-min.js:7 static/js/impala/persona_creation.js:84
+msgid "Creative Commons Attribution-NoDerivs 3.0"
+msgstr "Creative Commons Attribution-NoDerivs 3.0"
+
+#: static/js/impala-all.js:13327 static/js/impala-min.js:7 static/js/impala/persona_creation.js:89
+msgid "Creative Commons Attribution-ShareAlike 3.0"
+msgstr "Creative Commons Attribution-ShareAlike 3.0"
+
+#: static/js/impala-all.js:13530 static/js/impala-min.js:7 static/js/impala/persona_creation.js:292
+msgid "Your Theme's Name"
+msgstr "테마 이름"
+
+#: static/js/impala-all.js:14242 static/js/impala-min.js:8 static/js/impala/collections.js:19
+msgid "Stop Following"
+msgstr "팔로잉 중단"
+
+#: static/js/impala-all.js:14243 static/js/impala-min.js:8 static/js/impala/collections.js:20
+msgid "Following"
+msgstr "팔로잉"
+
+#: static/js/impala-all.js:14313 static/js/impala-min.js:8 static/js/impala/users.js:33
+msgid "use original"
+msgstr "오리지널 사용"
+
+#: static/js/impala-all.js:14523 static/js/impala-min.js:8 static/js/impala/search.js:114
+msgid "Updating results&hellip;"
+msgstr "결과 갱신중&hellip;"
+
+#: static/js/common/upload-addon.js:69 static/js/zamboni/devhub-all.js:300 static/js/zamboni/devhub-min.js:1
 msgid "Select a file..."
 msgstr "파일을 선택하세요..."
 
-#: static/js/common/upload-addon.js:70
+#: static/js/common/upload-addon.js:70 static/js/zamboni/devhub-all.js:301 static/js/zamboni/devhub-min.js:1
 msgid "Your add-on should end with .xpi, .jar or .xml"
 msgstr "부가 기능의 확장자는 .xpi, .jar, .xml을 사용해야 합니다."
 
 #. L10n: {0} is the percent of the file that has been uploaded.
-#: static/js/common/upload-addon.js:104
+#: static/js/common/upload-addon.js:104 static/js/zamboni/devhub-all.js:335 static/js/zamboni/devhub-min.js:1
 #, fuzzy, python-format
 msgid "{0}% complete"
 msgstr "{0}% 완료됨"
 
 #. L10n: "{bytes uploaded} of {total filesize}".
-#: static/js/common/upload-addon.js:107
+#: static/js/common/upload-addon.js:107 static/js/zamboni/devhub-all.js:338 static/js/zamboni/devhub-min.js:1
 msgid "{0} of {1}"
 msgstr "{0} / {1}"
 
-#: static/js/common/upload-addon.js:140
+#: static/js/common/upload-addon.js:140 static/js/zamboni/devhub-all.js:371 static/js/zamboni/devhub-min.js:1
 msgid "Cancel"
 msgstr "취소"
 
-#: static/js/common/upload-addon.js:162
+#: static/js/common/upload-addon.js:162 static/js/zamboni/devhub-all.js:393 static/js/zamboni/devhub-min.js:1
 msgid "Uploading {0}"
 msgstr "{0} 업로드 중"
 
-#: static/js/common/upload-addon.js:189
+#: static/js/common/upload-addon.js:189 static/js/zamboni/devhub-all.js:420 static/js/zamboni/devhub-min.js:1
 msgid "Error with {0}"
 msgstr "오류 {0}개"
 
-#: static/js/common/upload-addon.js:194
+#: static/js/common/upload-addon.js:194 static/js/zamboni/devhub-all.js:425 static/js/zamboni/devhub-min.js:1
 msgid "Your add-on failed validation with {0} error."
 msgid_plural "Your add-on failed validation with {0} errors."
 msgstr[0] "부가 기능이 {0}개의 오류와 함께 검사를 통과하지 못했습니다."
+msgstr[1] ""
 
-#: static/js/common/upload-addon.js:208
+#: static/js/common/upload-addon.js:208 static/js/zamboni/devhub-all.js:439 static/js/zamboni/devhub-min.js:1
 msgid "&hellip;and {0} more"
 msgid_plural "&hellip;and {0} more"
 msgstr[0] "&hellip;추가 오류 {0}개"
+msgstr[1] ""
 
-#: static/js/common/upload-addon.js:222 static/js/common/upload-addon.js:512
+#: static/js/common/upload-addon.js:222 static/js/common/upload-addon.js:497 static/js/zamboni/devhub-all.js:453 static/js/zamboni/devhub-all.js:743 static/js/zamboni/devhub-min.js:1
 msgid "See full validation report"
 msgstr "전체 검사 보고서 보기"
 
-#: static/js/common/upload-addon.js:234
+#: static/js/common/upload-addon.js:234 static/js/zamboni/devhub-all.js:465 static/js/zamboni/devhub-min.js:1
 msgid "Validating {0}"
 msgstr "{0} 검사중"
 
 #. L10n: first argument is an HTTP status code
-#: static/js/common/upload-addon.js:273
+#: static/js/common/upload-addon.js:273 static/js/zamboni/devhub-all.js:504 static/js/zamboni/devhub-min.js:1
 msgid "Received an empty response from the server; status: {0}"
 msgstr "서버로부터 공백의 응답을 받았습니다; 상태: {0}"
 
-#: static/js/common/upload-addon.js:373
+#: static/js/common/upload-addon.js:370 static/js/zamboni/devhub-all.js:604 static/js/zamboni/devhub-min.js:1
 msgid "Unexpected server error while validating."
 msgstr "검사 도중 예상치 못한 오류가 발생했습니다."
 
-#: static/js/common/upload-addon.js:412
+#: static/js/common/upload-addon.js:409 static/js/zamboni/devhub-all.js:643 static/js/zamboni/devhub-min.js:1
 msgid "Finished validating {0}"
 msgstr "{0} 검사 완료"
 
-#: static/js/common/upload-addon.js:418
+#: static/js/common/upload-addon.js:415 static/js/zamboni/devhub-all.js:649 static/js/zamboni/devhub-min.js:1
 msgid "Your add-on validation timed out, it will be manually reviewed."
 msgstr ""
 
-#: static/js/common/upload-addon.js:421
+#: static/js/common/upload-addon.js:418 static/js/zamboni/devhub-all.js:652 static/js/zamboni/devhub-min.js:1
 msgid "Your add-on was validated with no errors and {0} warning."
 msgid_plural "Your add-on was validated with no errors and {0} warnings."
 msgstr[0] ""
+msgstr[1] ""
 
-#: static/js/common/upload-addon.js:426
+#: static/js/common/upload-addon.js:423 static/js/zamboni/devhub-all.js:657 static/js/zamboni/devhub-min.js:1
 msgid "Your add-on was validated with no errors and {0} message."
 msgid_plural "Your add-on was validated with no errors and {0} messages."
 msgstr[0] ""
+msgstr[1] ""
 
-#: static/js/common/upload-addon.js:431
+#: static/js/common/upload-addon.js:428 static/js/zamboni/devhub-all.js:662 static/js/zamboni/devhub-min.js:1
 msgid "Your add-on was validated with no errors or warnings."
 msgstr ""
 
-#: static/js/common/upload-addon.js:446
+#: static/js/common/upload-addon.js:443 static/js/zamboni/devhub-all.js:677 static/js/zamboni/devhub-min.js:1
 msgid "Your submission will be automatically signed."
 msgstr ""
 
-#: static/js/common/upload-addon.js:465
+#: static/js/common/upload-addon.js:450 static/js/zamboni/devhub-all.js:696 static/js/zamboni/devhub-min.js:1
 msgid "Include detailed version notes (this can be done in the next step)."
 msgstr ""
 
-#: static/js/common/upload-addon.js:466
-msgid ""
-"If your add-on requires an account to a website in order to be fully tested,"
-" include a test username and password in the Notes to Reviewer (this can be "
-"done in the next step)."
+#: static/js/common/upload-addon.js:451 static/js/zamboni/devhub-all.js:697 static/js/zamboni/devhub-min.js:1
+msgid "If your add-on requires an account to a website in order to be fully tested, include a test username and password in the Notes to Reviewer (this can be done in the next step)."
 msgstr ""
 
-#: static/js/common/upload-addon.js:467
-msgid ""
-"If your add-on is intended for a limited audience you should choose "
-"Preliminary Review instead of Full Review."
+#: static/js/common/upload-addon.js:452 static/js/zamboni/devhub-all.js:698 static/js/zamboni/devhub-min.js:1
+msgid "If your add-on is intended for a limited audience you should choose Preliminary Review instead of Full Review."
 msgstr ""
 
-#: static/js/common/upload-addon.js:480
+#: static/js/common/upload-addon.js:465 static/js/zamboni/devhub-all.js:711 static/js/zamboni/devhub-min.js:1
 msgid "Add-on submission checklist"
 msgstr ""
 
-#: static/js/common/upload-addon.js:481
-msgid ""
-"Please verify the following points before finalizing your submission. This "
-"will minimize delays or misunderstanding during the review process:"
+#: static/js/common/upload-addon.js:466 static/js/zamboni/devhub-all.js:712 static/js/zamboni/devhub-min.js:1
+msgid "Please verify the following points before finalizing your submission. This will minimize delays or misunderstanding during the review process:"
 msgstr ""
 
-#: static/js/common/upload-addon.js:483
+#: static/js/common/upload-addon.js:468 static/js/zamboni/devhub-all.js:714 static/js/zamboni/devhub-min.js:1
 msgid ""
-"Compiled binaries, as well as minified or obfuscated scripts (excluding "
-"known libraries) need to have their sources submitted separately for review."
-" Make sure that you use the source code upload field to avoid having your "
-"submission rejected."
+"Compiled binaries, as well as minified or obfuscated scripts (excluding known libraries) need to have their sources submitted separately for review. Make sure that you use the source code upload "
+"field to avoid having your submission rejected."
 msgstr ""
 
-#: static/js/common/upload-addon.js:501
+#: static/js/common/upload-addon.js:486 static/js/zamboni/devhub-all.js:732 static/js/zamboni/devhub-min.js:1
 msgid "The validation process found these issues that can lead to rejections:"
 msgstr ""
 
-#: static/js/common/upload-addon.js:518
-msgid ""
-"If you are unfamiliar with the add-ons review process, you can read about it"
-" here."
+#: static/js/common/upload-addon.js:503 static/js/zamboni/devhub-all.js:749 static/js/zamboni/devhub-min.js:1
+msgid "If you are unfamiliar with the add-ons review process, you can read about it here."
 msgstr ""
 
-#: static/js/common/upload-addon.js:555
+#: static/js/common/upload-addon.js:540 static/js/zamboni/devhub-all.js:786 static/js/zamboni/devhub-min.js:1
 msgid "Sorry, no supported platform has been found."
 msgstr "죄송합니다, 지원되는 플랫폼을 찾지 못하였습니다."
 
-#: static/js/common/upload-base.js:57
+#: static/js/common/upload-base.js:57 static/js/zamboni/devhub-all.js:187 static/js/zamboni/devhub-min.js:1
 msgid "The filetype you uploaded isn't recognized."
 msgstr "업로드한 파일 형식을 인식할 수 없습니다."
 
-#: static/js/common/upload-base.js:79
+#: static/js/common/upload-base.js:79 static/js/zamboni/devhub-all.js:209 static/js/zamboni/devhub-min.js:1
 msgid "You cancelled the upload."
 msgstr "업로드를 취소했습니다."
 
-#: static/js/common/upload-image.js:97 static/js/impala/users.js:51
-msgid "Images must be either PNG or JPG."
-msgstr "이미지는 PNG나 JPG를 써야 합니다."
-
-#: static/js/common/upload-image.js:101
-msgid "Videos must be in WebM."
-msgstr "동영상은 WebM으로 된 것만 사용 가능합니다."
-
-#: static/js/impala/collections.js:10 static/js/zamboni/collections.js:595
-msgid "Follow this Collection"
-msgstr "이 모음집 팔로우 하기"
-
-#: static/js/impala/collections.js:19
-msgid "Stop Following"
-msgstr "팔로잉 중단"
-
-#: static/js/impala/collections.js:20
-msgid "Following"
-msgstr "팔로잉"
-
-#. L10n: {0} is an app name.
-#: static/js/impala/listing.js:11 static/js/zamboni/themes.js:13
-msgid "This theme is incompatible with your version of {0}"
-msgstr "이 테마는 현재 {0} 버전과 호환되지 않습니다"
-
-#: static/js/impala/persona_creation.js:60
-msgid "All Rights Reserved"
-msgstr "All Rights Reserved"
-
-#: static/js/impala/persona_creation.js:64
-msgid "Creative Commons Attribution 3.0"
-msgstr "Creative Commons Attribution 3.0"
-
-#: static/js/impala/persona_creation.js:69
-msgid "Creative Commons Attribution-NonCommercial 3.0"
-msgstr "Creative Commons Attribution-NonCommercial 3.0"
-
-#: static/js/impala/persona_creation.js:74
-msgid "Creative Commons Attribution-NonCommercial-NoDerivs 3.0"
-msgstr "Creative Commons Attribution-NonCommercial-NoDerivs 3.0"
-
-#: static/js/impala/persona_creation.js:79
-msgid "Creative Commons Attribution-NonCommercial-Share Alike 3.0"
-msgstr "Creative Commons Attribution-NonCommercial-Share Alike 3.0"
-
-#: static/js/impala/persona_creation.js:84
-msgid "Creative Commons Attribution-NoDerivs 3.0"
-msgstr "Creative Commons Attribution-NoDerivs 3.0"
-
-#: static/js/impala/persona_creation.js:89
-msgid "Creative Commons Attribution-ShareAlike 3.0"
-msgstr "Creative Commons Attribution-ShareAlike 3.0"
-
-#: static/js/impala/persona_creation.js:292
-msgid "Your Theme's Name"
-msgstr "테마 이름"
-
-#: static/js/impala/reviews.js:23 static/js/zamboni/reviews.js:18
-msgid "Flagged for review"
-msgstr "평가에 표시하기"
-
-#: static/js/impala/reviews.js:40 static/js/zamboni/reviews.js:34
-msgid "Your input is required"
-msgstr "글을 입력해야 합니다"
-
-#: static/js/impala/reviews.js:152 static/js/zamboni/reviews.js:103
-msgid "Marked for deletion"
-msgstr "삭제 표시"
-
-#: static/js/impala/search.js:114
-msgid "Updating results&hellip;"
-msgstr "결과 갱신중&hellip;"
-
-#: static/js/impala/site_suggestions.js:46
-msgid "Category"
-msgstr "분류"
-
-#: static/js/impala/suggestions.js:39
-msgid "Search themes for <b>{0}</b>"
-msgstr "<b>{0}</b>의 테마 검색"
-
-#: static/js/impala/suggestions.js:41
-msgid "Search apps for <b>{0}</b>"
-msgstr "<b>{0}</b> 앱 검색"
-
-#: static/js/impala/suggestions.js:43
-msgid "Search add-ons for <b>{0}</b>"
-msgstr "<b>{0}</b> 부가 기능 검색"
-
-#: static/js/impala/users.js:33
-msgid "use original"
-msgstr "오리지널 사용"
-
-#: static/js/impala/stats/chart.js:267
+#: static/js/impala/stats/chart.js:267 static/js/zamboni/stats-all.js:16898 static/js/zamboni/stats-min.js:5
 msgid "Week of {0}"
 msgstr "{0}번째 주"
 
-#: static/js/impala/stats/chart.js:269
+#: static/js/impala/stats/chart.js:269 static/js/zamboni/stats-all.js:16900 static/js/zamboni/stats-min.js:5
 msgid " downloads"
-msgstr " 다운로드"
+msgstr ""
 
-#: static/js/impala/stats/chart.js:270
+#: static/js/impala/stats/chart.js:270 static/js/zamboni/stats-all.js:16901 static/js/zamboni/stats-min.js:5
 msgid "{0} users"
 msgstr "사용자 {0}명"
 
-#: static/js/impala/stats/chart.js:271
+#: static/js/impala/stats/chart.js:271 static/js/zamboni/stats-all.js:16902 static/js/zamboni/stats-min.js:5
 msgid "{0} add-ons"
 msgstr "부가 기능 {0}개"
 
-#: static/js/impala/stats/chart.js:272
+#: static/js/impala/stats/chart.js:272 static/js/zamboni/stats-all.js:16903 static/js/zamboni/stats-min.js:5
 msgid "{0} collections"
 msgstr "모음집 {0}개"
 
-#: static/js/impala/stats/chart.js:273
+#: static/js/impala/stats/chart.js:273 static/js/zamboni/stats-all.js:16904 static/js/zamboni/stats-min.js:5
 msgid "{0} reviews"
 msgstr "평가 {0}개"
 
-#: static/js/impala/stats/chart.js:275
+#: static/js/impala/stats/chart.js:275 static/js/zamboni/stats-all.js:16906 static/js/zamboni/stats-min.js:5
 msgid "{0} sales"
 msgstr "판매 {0}회"
 
-#: static/js/impala/stats/chart.js:276
+#: static/js/impala/stats/chart.js:276 static/js/zamboni/stats-all.js:16907 static/js/zamboni/stats-min.js:5
 msgid "{0} refunds"
 msgstr "환불 {0}회"
 
-#: static/js/impala/stats/chart.js:277
+#: static/js/impala/stats/chart.js:277 static/js/zamboni/stats-all.js:16908 static/js/zamboni/stats-min.js:5
 msgid "{0} installs"
 msgstr "설치 {0}회"
 
-#: static/js/impala/stats/chart.js:369 static/js/impala/stats/csv_keys.js:3
-#: static/js/impala/stats/csv_keys.js:109
+#: static/js/impala/stats/chart.js:369 static/js/impala/stats/csv_keys.js:3 static/js/impala/stats/csv_keys.js:109 static/js/zamboni/stats-all.js:15284 static/js/zamboni/stats-all.js:15390
+#: static/js/zamboni/stats-all.js:17000 static/js/zamboni/stats-min.js:4 static/js/zamboni/stats-min.js:5
 msgid "Downloads"
 msgstr "다운로드 횟수"
 
-#: static/js/impala/stats/chart.js:379 static/js/impala/stats/csv_keys.js:6
-#: static/js/impala/stats/csv_keys.js:110
+#: static/js/impala/stats/chart.js:379 static/js/impala/stats/csv_keys.js:6 static/js/impala/stats/csv_keys.js:110 static/js/zamboni/stats-all.js:15287 static/js/zamboni/stats-all.js:15391
+#: static/js/zamboni/stats-all.js:17010 static/js/zamboni/stats-min.js:4 static/js/zamboni/stats-min.js:5
 msgid "Daily Users"
 msgstr "일일 사용자 수"
 
-#: static/js/impala/stats/chart.js:410
+#: static/js/impala/stats/chart.js:410 static/js/zamboni/stats-all.js:17041 static/js/zamboni/stats-min.js:5
 msgid "Amount, in USD"
 msgstr "금액 (미국 달러화)"
 
-#: static/js/impala/stats/chart.js:421 static/js/impala/stats/csv_keys.js:104
+#: static/js/impala/stats/chart.js:421 static/js/impala/stats/csv_keys.js:104 static/js/zamboni/stats-all.js:15385 static/js/zamboni/stats-all.js:17052 static/js/zamboni/stats-min.js:5
 msgid "Number of Contributions"
 msgstr "기부 횟수"
 
-#: static/js/impala/stats/chart.js:447
+#: static/js/impala/stats/chart.js:447 static/js/zamboni/stats-all.js:17078 static/js/zamboni/stats-min.js:5
 msgid "More Info..."
 msgstr "자세히 알아보기..."
 
 #. L10n: {0} is an ISO-formatted date.
-#: static/js/impala/stats/chart.js:451
+#: static/js/impala/stats/chart.js:451 static/js/zamboni/stats-all.js:17082 static/js/zamboni/stats-min.js:5
 msgid "Details for {0}"
 msgstr "{0}에 대한 상세 정보"
 
-#: static/js/impala/stats/csv_keys.js:9
+#: static/js/impala/stats/csv_keys.js:9 static/js/zamboni/stats-all.js:15290 static/js/zamboni/stats-min.js:4
 msgid "Collections Created"
 msgstr "만들어진 모음집"
 
-#: static/js/impala/stats/csv_keys.js:12
+#: static/js/impala/stats/csv_keys.js:12 static/js/zamboni/stats-all.js:15293 static/js/zamboni/stats-min.js:4
 msgid "Add-ons in Use"
 msgstr "사용 중인 부가 기능"
 
-#: static/js/impala/stats/csv_keys.js:15
+#: static/js/impala/stats/csv_keys.js:15 static/js/zamboni/stats-all.js:15296 static/js/zamboni/stats-min.js:4
 msgid "Add-ons Created"
 msgstr "만들어진 부가 기능"
 
-#: static/js/impala/stats/csv_keys.js:18
+#: static/js/impala/stats/csv_keys.js:18 static/js/zamboni/stats-all.js:15299 static/js/zamboni/stats-min.js:4
 msgid "Add-ons Downloaded"
 msgstr "다운로드한 부가 기능"
 
-#: static/js/impala/stats/csv_keys.js:21
+#: static/js/impala/stats/csv_keys.js:21 static/js/zamboni/stats-all.js:15302 static/js/zamboni/stats-min.js:4
 msgid "Add-ons Updated"
 msgstr "업데이트한 부가 기능"
 
-#: static/js/impala/stats/csv_keys.js:24
+#: static/js/impala/stats/csv_keys.js:24 static/js/zamboni/stats-all.js:15305 static/js/zamboni/stats-min.js:4
 msgid "Reviews Written"
 msgstr "평가가 있는 부가 기능"
 
-#: static/js/impala/stats/csv_keys.js:27
+#: static/js/impala/stats/csv_keys.js:27 static/js/zamboni/stats-all.js:15308 static/js/zamboni/stats-min.js:4
 msgid "User Signups"
 msgstr "사용자 등록"
 
-#: static/js/impala/stats/csv_keys.js:30
+#: static/js/impala/stats/csv_keys.js:30 static/js/zamboni/stats-all.js:15311 static/js/zamboni/stats-min.js:4
 msgid "Subscribers"
 msgstr "구독자"
 
-#: static/js/impala/stats/csv_keys.js:33
+#: static/js/impala/stats/csv_keys.js:33 static/js/zamboni/stats-all.js:15314 static/js/zamboni/stats-min.js:4
 msgid "Ratings"
 msgstr "평가"
 
-#: static/js/impala/stats/csv_keys.js:36
-#: static/js/impala/stats/csv_keys.js:114
+#: static/js/impala/stats/csv_keys.js:36 static/js/impala/stats/csv_keys.js:114 static/js/zamboni/stats-all.js:15317 static/js/zamboni/stats-all.js:15395 static/js/zamboni/stats-min.js:4
+#: static/js/zamboni/stats-min.js:5
 msgid "Sales"
 msgstr "판매중"
 
-#: static/js/impala/stats/csv_keys.js:39
-#: static/js/impala/stats/csv_keys.js:113
+#: static/js/impala/stats/csv_keys.js:39 static/js/impala/stats/csv_keys.js:113 static/js/zamboni/stats-all.js:15320 static/js/zamboni/stats-all.js:15394 static/js/zamboni/stats-min.js:4
+#: static/js/zamboni/stats-min.js:5
 msgid "Installs"
 msgstr "설치"
 
-#: static/js/impala/stats/csv_keys.js:42
+#: static/js/impala/stats/csv_keys.js:42 static/js/zamboni/stats-all.js:15323 static/js/zamboni/stats-min.js:4
 msgid "Unknown"
 msgstr "알 수 없음"
 
-#: static/js/impala/stats/csv_keys.js:43
+#: static/js/impala/stats/csv_keys.js:43 static/js/zamboni/stats-all.js:15324 static/js/zamboni/stats-min.js:4
 msgid "Add-ons Manager"
 msgstr "부가 기능 관리자"
 
-#: static/js/impala/stats/csv_keys.js:44
+#: static/js/impala/stats/csv_keys.js:44 static/js/zamboni/stats-all.js:15325 static/js/zamboni/stats-min.js:4
 msgid "Add-ons Manager Promo"
 msgstr "부가 기능 관리자 프로모션"
 
-#: static/js/impala/stats/csv_keys.js:45
+#: static/js/impala/stats/csv_keys.js:45 static/js/zamboni/stats-all.js:15326 static/js/zamboni/stats-min.js:4
 msgid "Add-ons Manager Featured"
 msgstr "부가 기능 관리자 기능"
 
-#: static/js/impala/stats/csv_keys.js:46
+#: static/js/impala/stats/csv_keys.js:46 static/js/zamboni/stats-all.js:15327 static/js/zamboni/stats-min.js:4
 msgid "Add-ons Manager Learn More"
 msgstr "부가 기능 관리자 자세히 알아보기"
 
-#: static/js/impala/stats/csv_keys.js:47
+#: static/js/impala/stats/csv_keys.js:47 static/js/zamboni/stats-all.js:15328 static/js/zamboni/stats-min.js:4
 msgid "Search Suggestions"
 msgstr "검색 추천"
 
-#: static/js/impala/stats/csv_keys.js:48
+#: static/js/impala/stats/csv_keys.js:48 static/js/zamboni/stats-all.js:15329 static/js/zamboni/stats-min.js:4
 msgid "Search Results"
 msgstr "검색 결과"
 
-#: static/js/impala/stats/csv_keys.js:49 static/js/impala/stats/csv_keys.js:50
-#: static/js/impala/stats/csv_keys.js:51
+#: static/js/impala/stats/csv_keys.js:49 static/js/impala/stats/csv_keys.js:50 static/js/impala/stats/csv_keys.js:51 static/js/zamboni/stats-all.js:15330 static/js/zamboni/stats-all.js:15331
+#: static/js/zamboni/stats-all.js:15332 static/js/zamboni/stats-min.js:4
 msgid "Homepage Promo"
 msgstr "홈페이지 홍보"
 
-#: static/js/impala/stats/csv_keys.js:52 static/js/impala/stats/csv_keys.js:53
+#: static/js/impala/stats/csv_keys.js:52 static/js/impala/stats/csv_keys.js:53 static/js/zamboni/stats-all.js:15333 static/js/zamboni/stats-all.js:15334 static/js/zamboni/stats-min.js:4
 msgid "Homepage Featured"
 msgstr "추천 홈페이지"
 
-#: static/js/impala/stats/csv_keys.js:54 static/js/impala/stats/csv_keys.js:55
+#: static/js/impala/stats/csv_keys.js:54 static/js/impala/stats/csv_keys.js:55 static/js/zamboni/stats-all.js:15335 static/js/zamboni/stats-all.js:15336 static/js/zamboni/stats-min.js:4
 msgid "Homepage Up and Coming"
 msgstr "인기 급상승 홈페이지"
 
-#: static/js/impala/stats/csv_keys.js:56
+#: static/js/impala/stats/csv_keys.js:56 static/js/zamboni/stats-all.js:15337 static/js/zamboni/stats-min.js:4
 msgid "Homepage Most Popular"
 msgstr "인기 홈페이지"
 
-#: static/js/impala/stats/csv_keys.js:57 static/js/impala/stats/csv_keys.js:59
+#: static/js/impala/stats/csv_keys.js:57 static/js/impala/stats/csv_keys.js:59 static/js/zamboni/stats-all.js:15338 static/js/zamboni/stats-all.js:15340 static/js/zamboni/stats-min.js:4
 msgid "Detail Page"
 msgstr "상세 정보 페이지"
 
-#: static/js/impala/stats/csv_keys.js:58 static/js/impala/stats/csv_keys.js:60
+#: static/js/impala/stats/csv_keys.js:58 static/js/impala/stats/csv_keys.js:60 static/js/zamboni/stats-all.js:15339 static/js/zamboni/stats-all.js:15341 static/js/zamboni/stats-min.js:4
 msgid "Detail Page (bottom)"
 msgstr "상세 정보 페이지 (하단)"
 
-#: static/js/impala/stats/csv_keys.js:61
+#: static/js/impala/stats/csv_keys.js:61 static/js/zamboni/stats-all.js:15342 static/js/zamboni/stats-min.js:4
 msgid "Detail Page (Development Channel)"
 msgstr "상세 정보 페이지 (개발 채널)"
 
-#: static/js/impala/stats/csv_keys.js:62 static/js/impala/stats/csv_keys.js:63
-#: static/js/impala/stats/csv_keys.js:64
+#: static/js/impala/stats/csv_keys.js:62 static/js/impala/stats/csv_keys.js:63 static/js/impala/stats/csv_keys.js:64 static/js/zamboni/stats-all.js:15343 static/js/zamboni/stats-all.js:15344
+#: static/js/zamboni/stats-all.js:15345 static/js/zamboni/stats-min.js:4
 msgid "Often Used With"
 msgstr "이것과 자주 쓰입니다"
 
-#: static/js/impala/stats/csv_keys.js:65 static/js/impala/stats/csv_keys.js:66
+#: static/js/impala/stats/csv_keys.js:65 static/js/impala/stats/csv_keys.js:66 static/js/zamboni/stats-all.js:15346 static/js/zamboni/stats-all.js:15347 static/js/zamboni/stats-min.js:4
 msgid "Others By Author"
 msgstr "제작자의 다른 저작물"
 
-#: static/js/impala/stats/csv_keys.js:67 static/js/impala/stats/csv_keys.js:68
+#: static/js/impala/stats/csv_keys.js:67 static/js/impala/stats/csv_keys.js:68 static/js/zamboni/stats-all.js:15348 static/js/zamboni/stats-all.js:15349 static/js/zamboni/stats-min.js:4
 msgid "Dependencies"
 msgstr "의존성"
 
-#: static/js/impala/stats/csv_keys.js:69 static/js/impala/stats/csv_keys.js:70
+#: static/js/impala/stats/csv_keys.js:69 static/js/impala/stats/csv_keys.js:70 static/js/zamboni/stats-all.js:15350 static/js/zamboni/stats-all.js:15351 static/js/zamboni/stats-min.js:4
 msgid "Upsell"
 msgstr "판촉행위"
 
-#: static/js/impala/stats/csv_keys.js:71
+#: static/js/impala/stats/csv_keys.js:71 static/js/zamboni/stats-all.js:15352 static/js/zamboni/stats-min.js:4
 msgid "Meet the Developer"
 msgstr "개발자 만나기"
 
-#: static/js/impala/stats/csv_keys.js:72
+#: static/js/impala/stats/csv_keys.js:72 static/js/zamboni/stats-all.js:15353 static/js/zamboni/stats-min.js:4
 msgid "User Profile"
 msgstr "사용자 프로필"
 
-#: static/js/impala/stats/csv_keys.js:73
+#: static/js/impala/stats/csv_keys.js:73 static/js/zamboni/stats-all.js:15354 static/js/zamboni/stats-min.js:4
 msgid "Version History"
 msgstr "버전 기록"
 
-#: static/js/impala/stats/csv_keys.js:75
+#: static/js/impala/stats/csv_keys.js:75 static/js/zamboni/stats-all.js:15356 static/js/zamboni/stats-min.js:4
 msgid "Sharing"
 msgstr "공유"
 
-#: static/js/impala/stats/csv_keys.js:76
+#: static/js/impala/stats/csv_keys.js:76 static/js/zamboni/stats-all.js:15357 static/js/zamboni/stats-min.js:4
 msgid "Category Pages"
 msgstr "분류 페이지"
 
-#: static/js/impala/stats/csv_keys.js:77
+#: static/js/impala/stats/csv_keys.js:77 static/js/zamboni/stats-all.js:15358 static/js/zamboni/stats-min.js:4
 msgid "Collections"
 msgstr "모음집"
 
-#: static/js/impala/stats/csv_keys.js:78 static/js/impala/stats/csv_keys.js:79
+#: static/js/impala/stats/csv_keys.js:78 static/js/impala/stats/csv_keys.js:79 static/js/zamboni/stats-all.js:15359 static/js/zamboni/stats-all.js:15360 static/js/zamboni/stats-min.js:4
 msgid "Category Landing Featured Carousel"
 msgstr "분류별 추천 부가 기능"
 
-#: static/js/impala/stats/csv_keys.js:80 static/js/impala/stats/csv_keys.js:81
+#: static/js/impala/stats/csv_keys.js:80 static/js/impala/stats/csv_keys.js:81 static/js/zamboni/stats-all.js:15361 static/js/zamboni/stats-all.js:15362 static/js/zamboni/stats-min.js:4
 msgid "Category Landing Top Rated"
 msgstr "분류별 최다 별점 부가 기능"
 
-#: static/js/impala/stats/csv_keys.js:82 static/js/impala/stats/csv_keys.js:83
+#: static/js/impala/stats/csv_keys.js:82 static/js/impala/stats/csv_keys.js:83 static/js/zamboni/stats-all.js:15363 static/js/zamboni/stats-all.js:15364 static/js/zamboni/stats-min.js:5
 msgid "Category Landing Most Popular"
 msgstr "분류별 인기 부가 기능"
 
-#: static/js/impala/stats/csv_keys.js:84 static/js/impala/stats/csv_keys.js:85
+#: static/js/impala/stats/csv_keys.js:84 static/js/impala/stats/csv_keys.js:85 static/js/zamboni/stats-all.js:15365 static/js/zamboni/stats-all.js:15366 static/js/zamboni/stats-min.js:5
 msgid "Category Landing Recently Added"
 msgstr "분류별 신규 등록 부가 기능"
 
-#: static/js/impala/stats/csv_keys.js:86 static/js/impala/stats/csv_keys.js:87
+#: static/js/impala/stats/csv_keys.js:86 static/js/impala/stats/csv_keys.js:87 static/js/zamboni/stats-all.js:15367 static/js/zamboni/stats-all.js:15368 static/js/zamboni/stats-min.js:5
 msgid "Browse Listing Featured Sort"
 msgstr "추천 순으로 둘러보기"
 
-#: static/js/impala/stats/csv_keys.js:88 static/js/impala/stats/csv_keys.js:89
+#: static/js/impala/stats/csv_keys.js:88 static/js/impala/stats/csv_keys.js:89 static/js/zamboni/stats-all.js:15369 static/js/zamboni/stats-all.js:15370 static/js/zamboni/stats-min.js:5
 msgid "Browse Listing Users Sort"
 msgstr "사용자 순으로 둘러보기"
 
-#: static/js/impala/stats/csv_keys.js:90 static/js/impala/stats/csv_keys.js:91
+#: static/js/impala/stats/csv_keys.js:90 static/js/impala/stats/csv_keys.js:91 static/js/zamboni/stats-all.js:15371 static/js/zamboni/stats-all.js:15372 static/js/zamboni/stats-min.js:5
 msgid "Browse Listing Rating Sort"
 msgstr "별점 순으로 둘러보기"
 
-#: static/js/impala/stats/csv_keys.js:92 static/js/impala/stats/csv_keys.js:93
+#: static/js/impala/stats/csv_keys.js:92 static/js/impala/stats/csv_keys.js:93 static/js/zamboni/stats-all.js:15373 static/js/zamboni/stats-all.js:15374 static/js/zamboni/stats-min.js:5
 msgid "Browse Listing Created Sort"
 msgstr "등록일 순으로 둘러보기"
 
-#: static/js/impala/stats/csv_keys.js:94 static/js/impala/stats/csv_keys.js:95
+#: static/js/impala/stats/csv_keys.js:94 static/js/impala/stats/csv_keys.js:95 static/js/zamboni/stats-all.js:15375 static/js/zamboni/stats-all.js:15376 static/js/zamboni/stats-min.js:5
 msgid "Browse Listing Name Sort"
 msgstr "이름 순으로 둘러보기"
 
-#: static/js/impala/stats/csv_keys.js:96 static/js/impala/stats/csv_keys.js:97
+#: static/js/impala/stats/csv_keys.js:96 static/js/impala/stats/csv_keys.js:97 static/js/zamboni/stats-all.js:15377 static/js/zamboni/stats-all.js:15378 static/js/zamboni/stats-min.js:5
 msgid "Browse Listing Popular Sort"
 msgstr "인기도 순으로 둘러보기"
 
-#: static/js/impala/stats/csv_keys.js:98 static/js/impala/stats/csv_keys.js:99
+#: static/js/impala/stats/csv_keys.js:98 static/js/impala/stats/csv_keys.js:99 static/js/zamboni/stats-all.js:15379 static/js/zamboni/stats-all.js:15380 static/js/zamboni/stats-min.js:5
 msgid "Browse Listing Updated Sort"
 msgstr "업데이트 날짜 순으로 둘러보기"
 
-#: static/js/impala/stats/csv_keys.js:100
-#: static/js/impala/stats/csv_keys.js:101
+#: static/js/impala/stats/csv_keys.js:100 static/js/impala/stats/csv_keys.js:101 static/js/zamboni/stats-all.js:15381 static/js/zamboni/stats-all.js:15382 static/js/zamboni/stats-min.js:5
 msgid "Browse Listing Up and Coming Sort"
 msgstr "최근 급상승 순으로 둘러보기"
 
-#: static/js/impala/stats/csv_keys.js:105
+#: static/js/impala/stats/csv_keys.js:105 static/js/zamboni/stats-all.js:15386 static/js/zamboni/stats-min.js:5
 msgid "Total Amount Contributed"
 msgstr "총 기부금액"
 
-#: static/js/impala/stats/csv_keys.js:106
+#: static/js/impala/stats/csv_keys.js:106 static/js/zamboni/stats-all.js:15387 static/js/zamboni/stats-min.js:5
 msgid "Average Contribution"
 msgstr "평균 기부금"
 
-#: static/js/impala/stats/csv_keys.js:115
+#: static/js/impala/stats/csv_keys.js:115 static/js/zamboni/stats-all.js:15396 static/js/zamboni/stats-min.js:5
 msgid "Usage"
 msgstr "사용처"
 
-#: static/js/impala/stats/csv_keys.js:118
+#: static/js/impala/stats/csv_keys.js:118 static/js/zamboni/stats-all.js:15399 static/js/zamboni/stats-min.js:5
 msgid "Firefox"
 msgstr "Firefox"
 
-#: static/js/impala/stats/csv_keys.js:119
+#: static/js/impala/stats/csv_keys.js:119 static/js/zamboni/stats-all.js:15400 static/js/zamboni/stats-min.js:5
 msgid "Mozilla"
 msgstr "Mozilla"
 
-#: static/js/impala/stats/csv_keys.js:120
+#: static/js/impala/stats/csv_keys.js:120 static/js/zamboni/stats-all.js:15401 static/js/zamboni/stats-min.js:5
 msgid "Thunderbird"
 msgstr "Thunderbird"
 
-#: static/js/impala/stats/csv_keys.js:121
+#: static/js/impala/stats/csv_keys.js:121 static/js/zamboni/stats-all.js:15402 static/js/zamboni/stats-min.js:5
 msgid "Sunbird"
 msgstr "Sunbird"
 
-#: static/js/impala/stats/csv_keys.js:122
+#: static/js/impala/stats/csv_keys.js:122 static/js/zamboni/stats-all.js:15403 static/js/zamboni/stats-min.js:5
 msgid "SeaMonkey"
 msgstr "SeaMonkey"
 
-#: static/js/impala/stats/csv_keys.js:123
+#: static/js/impala/stats/csv_keys.js:123 static/js/zamboni/stats-all.js:15404 static/js/zamboni/stats-min.js:5
 msgid "Fennec"
 msgstr "Fennec"
 
-#: static/js/impala/stats/csv_keys.js:124
+#: static/js/impala/stats/csv_keys.js:124 static/js/zamboni/stats-all.js:15405 static/js/zamboni/stats-min.js:5
 msgid "Android"
 msgstr "Android"
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:129
+#: static/js/impala/stats/csv_keys.js:129 static/js/zamboni/stats-all.js:15410 static/js/zamboni/stats-min.js:5
 msgid "Downloads and Daily Users, last {0} days"
 msgstr "최근 {0}일간 다운로드 횟수와 일일 사용자 수"
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:131
+#: static/js/impala/stats/csv_keys.js:131 static/js/zamboni/stats-all.js:15412 static/js/zamboni/stats-min.js:5
 msgid "Downloads and Daily Users from {0} to {1}"
 msgstr "{0} 부터 {1} 까지 다운로드 횟수와 일일 사용자 수"
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:135
+#: static/js/impala/stats/csv_keys.js:135 static/js/zamboni/stats-all.js:15416 static/js/zamboni/stats-min.js:5
 msgid "Installs and Daily Users, last {0} days"
 msgstr "설치 및 일일 사용자 (지난 {0}일)"
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:137
+#: static/js/impala/stats/csv_keys.js:137 static/js/zamboni/stats-all.js:15418 static/js/zamboni/stats-min.js:5
 msgid "Installs and Daily Users from {0} to {1}"
 msgstr "설치 및 일일 사용자 ({0}~{1})"
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:141
+#: static/js/impala/stats/csv_keys.js:141 static/js/zamboni/stats-all.js:15422 static/js/zamboni/stats-min.js:5
 msgid "Downloads, last {0} days"
 msgstr "최근 {0}일간 다운로드 횟수"
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:143
+#: static/js/impala/stats/csv_keys.js:143 static/js/zamboni/stats-all.js:15424 static/js/zamboni/stats-min.js:5
 msgid "Downloads from {0} to {1}"
 msgstr "{0}부터 {1} 까지 다운로드 횟수"
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:147
+#: static/js/impala/stats/csv_keys.js:147 static/js/zamboni/stats-all.js:15428 static/js/zamboni/stats-min.js:5
 msgid "Daily Users, last {0} days"
 msgstr "최근 {0}일간 일일 사용자 수"
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:149
+#: static/js/impala/stats/csv_keys.js:149 static/js/zamboni/stats-all.js:15430 static/js/zamboni/stats-min.js:5
 msgid "Daily Users from {0} to {1}"
 msgstr "{0}부터 {1} 까지 일일 사용자 수"
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:153
+#: static/js/impala/stats/csv_keys.js:153 static/js/zamboni/stats-all.js:15434 static/js/zamboni/stats-min.js:5
 msgid "Applications, last {0} days"
 msgstr "최근 {0}일간 애플리케이션"
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:155
+#: static/js/impala/stats/csv_keys.js:155 static/js/zamboni/stats-all.js:15436 static/js/zamboni/stats-min.js:5
 msgid "Applications from {0} to {1}"
 msgstr "{0}부터 {1} 까지 애플리케이션"
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:159
+#: static/js/impala/stats/csv_keys.js:159 static/js/zamboni/stats-all.js:15440 static/js/zamboni/stats-min.js:5
 msgid "Platforms, last {0} days"
 msgstr "최근 {0}일간 플랫폼"
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:161
+#: static/js/impala/stats/csv_keys.js:161 static/js/zamboni/stats-all.js:15442 static/js/zamboni/stats-min.js:5
 msgid "Platforms from {0} to {1}"
 msgstr "{0}부터 {1} 까지 플랫폼"
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:165
+#: static/js/impala/stats/csv_keys.js:165 static/js/zamboni/stats-all.js:15446 static/js/zamboni/stats-min.js:5
 msgid "Languages, last {0} days"
 msgstr "최근 {0}일간 언어"
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:167
+#: static/js/impala/stats/csv_keys.js:167 static/js/zamboni/stats-all.js:15448 static/js/zamboni/stats-min.js:5
 msgid "Languages from {0} to {1}"
 msgstr "{0}부터 {1} 까지 언어"
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:171
+#: static/js/impala/stats/csv_keys.js:171 static/js/zamboni/stats-all.js:15452 static/js/zamboni/stats-min.js:5
 msgid "Add-on Versions, last {0} days"
 msgstr "최근 {0}일간 부가 기능 버전"
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:173
+#: static/js/impala/stats/csv_keys.js:173 static/js/zamboni/stats-all.js:15454 static/js/zamboni/stats-min.js:5
 msgid "Add-on Versions from {0} to {1}"
 msgstr "{0}부터 {1} 까지 부가 기능 버전"
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:177
+#: static/js/impala/stats/csv_keys.js:177 static/js/zamboni/stats-all.js:15458 static/js/zamboni/stats-min.js:5
 msgid "Add-on Status, last {0} days"
 msgstr "최근 {0}일간 부가 기능 상태"
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:179
+#: static/js/impala/stats/csv_keys.js:179 static/js/zamboni/stats-all.js:15460 static/js/zamboni/stats-min.js:5
 msgid "Add-on Status from {0} to {1}"
 msgstr "{0}부터 {1} 까지 부가 기능 상태"
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:183
+#: static/js/impala/stats/csv_keys.js:183 static/js/zamboni/stats-all.js:15464 static/js/zamboni/stats-min.js:5
 msgid "Download Sources, last {0} days"
 msgstr "최근 {0}일간 다운로드 출처"
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:185
+#: static/js/impala/stats/csv_keys.js:185 static/js/zamboni/stats-all.js:15466 static/js/zamboni/stats-min.js:5
 msgid "Download Sources from {0} to {1}"
 msgstr "{0}부터 {1} 까지 다운로드 출처"
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:189
+#: static/js/impala/stats/csv_keys.js:189 static/js/zamboni/stats-all.js:15470 static/js/zamboni/stats-min.js:5
 msgid "Contributions, last {0} days"
 msgstr "최근 {0}일간 기부금"
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:191
+#: static/js/impala/stats/csv_keys.js:191 static/js/zamboni/stats-all.js:15472 static/js/zamboni/stats-min.js:5
 msgid "Contributions from {0} to {1}"
 msgstr "{0}부터 {1} 까지 기부금"
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:195
+#: static/js/impala/stats/csv_keys.js:195 static/js/zamboni/stats-all.js:15476 static/js/zamboni/stats-min.js:5
 msgid "Site Metrics, last {0} days"
 msgstr "웹사이트 통계 (지난 {0}일)"
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:197
+#: static/js/impala/stats/csv_keys.js:197 static/js/zamboni/stats-all.js:15478 static/js/zamboni/stats-min.js:5
 msgid "Site Metrics from {0} to {1}"
 msgstr "웹사이트 통계 ({0}~{1})"
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:201
+#: static/js/impala/stats/csv_keys.js:201 static/js/zamboni/stats-all.js:15482 static/js/zamboni/stats-min.js:5
 msgid "Add-ons in Use, last {0} days"
 msgstr "최근 {0}일간 사용중인 부가 기능"
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:203
+#: static/js/impala/stats/csv_keys.js:203 static/js/zamboni/stats-all.js:15484 static/js/zamboni/stats-min.js:5
 msgid "Add-ons in Use from {0} to {1}"
 msgstr "{0}부터 {1}까지 사용중인 부가 기능"
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:207
+#: static/js/impala/stats/csv_keys.js:207 static/js/zamboni/stats-all.js:15488 static/js/zamboni/stats-min.js:5
 msgid "Add-ons Downloaded, last {0} days"
 msgstr "최근 {0}일간 다운로드 된 부가 기능"
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:209
+#: static/js/impala/stats/csv_keys.js:209 static/js/zamboni/stats-all.js:15490 static/js/zamboni/stats-min.js:5
 msgid "Add-ons Downloaded from {0} to {1}"
 msgstr "{0}부터 {1}까지 다운로드 된 부가 기능"
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:213
+#: static/js/impala/stats/csv_keys.js:213 static/js/zamboni/stats-all.js:15494 static/js/zamboni/stats-min.js:5
 msgid "Add-ons Created, last {0} days"
 msgstr "최근 {0}일간 제작된 부가 기능"
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:215
+#: static/js/impala/stats/csv_keys.js:215 static/js/zamboni/stats-all.js:15496 static/js/zamboni/stats-min.js:5
 msgid "Add-ons Created from {0} to {1}"
 msgstr "{0}부터 {1}까지 제작된 부가 기능"
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:219
+#: static/js/impala/stats/csv_keys.js:219 static/js/zamboni/stats-all.js:15500 static/js/zamboni/stats-min.js:5
 msgid "Add-ons Updated, last {0} days"
 msgstr "최근 {0}일간 업데이트된 부가 기능"
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:221
+#: static/js/impala/stats/csv_keys.js:221 static/js/zamboni/stats-all.js:15502 static/js/zamboni/stats-min.js:5
 msgid "Add-ons Updated from {0} to {1}"
 msgstr "{0}부터 {1}까지 업데이트된 부가 기능"
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:225
+#: static/js/impala/stats/csv_keys.js:225 static/js/zamboni/stats-all.js:15506 static/js/zamboni/stats-min.js:5
 msgid "Reviews Written, last {0} days"
 msgstr "최근 {0}일간 작성된 평가"
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:227
+#: static/js/impala/stats/csv_keys.js:227 static/js/zamboni/stats-all.js:15508 static/js/zamboni/stats-min.js:5
 msgid "Reviews Written from {0} to {1}"
 msgstr "{0}부터 {1}까지 작성된 평가"
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:231
+#: static/js/impala/stats/csv_keys.js:231 static/js/zamboni/stats-all.js:15512 static/js/zamboni/stats-min.js:5
 msgid "User Signups, last {0} days"
 msgstr "최근 {0}일간 가입한 사용자"
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:233
+#: static/js/impala/stats/csv_keys.js:233 static/js/zamboni/stats-all.js:15514 static/js/zamboni/stats-min.js:5
 msgid "User Signups from {0} to {1}"
 msgstr "{0}부터 {1}까지 가입한 사용자"
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:237
+#: static/js/impala/stats/csv_keys.js:237 static/js/zamboni/stats-all.js:15518 static/js/zamboni/stats-min.js:5
 msgid "Collections Created, last {0} days"
 msgstr "최근 {0}일간 제작된 모음집"
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:239
+#: static/js/impala/stats/csv_keys.js:239 static/js/zamboni/stats-all.js:15520 static/js/zamboni/stats-min.js:5
 msgid "Collections Created from {0} to {1}"
 msgstr "{0}부터 {1}까지 제작된 모음집"
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:243
+#: static/js/impala/stats/csv_keys.js:243 static/js/zamboni/stats-all.js:15524 static/js/zamboni/stats-min.js:5
 msgid "Subscribers, last {0} days"
 msgstr "최근 {0}일간 구독자"
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:245
+#: static/js/impala/stats/csv_keys.js:245 static/js/zamboni/stats-all.js:15526 static/js/zamboni/stats-min.js:5
 msgid "Subscribers from {0} to {1}"
 msgstr "{0}부터 {1}까지 구독자"
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:249
+#: static/js/impala/stats/csv_keys.js:249 static/js/zamboni/stats-all.js:15530 static/js/zamboni/stats-min.js:5
 msgid "Ratings, last {0} days"
 msgstr "최근 {0}일간 별점"
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:251
+#: static/js/impala/stats/csv_keys.js:251 static/js/zamboni/stats-all.js:15532 static/js/zamboni/stats-min.js:5
 msgid "Ratings from {0} to {1}"
 msgstr "{0}부터 {1}까지 별점"
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:255
+#: static/js/impala/stats/csv_keys.js:255 static/js/zamboni/stats-all.js:15536 static/js/zamboni/stats-min.js:5
 msgid "Sales, last {0} days"
 msgstr "최근 {0}일간 매상"
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:257
+#: static/js/impala/stats/csv_keys.js:257 static/js/zamboni/stats-all.js:15538 static/js/zamboni/stats-min.js:5
 msgid "Sales from {0} to {1}"
 msgstr "{0}부터 {1}까지 매상"
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:261
+#: static/js/impala/stats/csv_keys.js:261 static/js/zamboni/stats-all.js:15542 static/js/zamboni/stats-min.js:5
 msgid "Installs, last {0} days"
 msgstr "최근 {0}일간 설치"
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:263
+#: static/js/impala/stats/csv_keys.js:263 static/js/zamboni/stats-all.js:15544 static/js/zamboni/stats-min.js:5
 msgid "Installs from {0} to {1}"
 msgstr "{0}부터 {1}까지 설치"
 
 #. L10n: {0} and {1} are integers.
-#: static/js/impala/stats/csv_keys.js:269
+#: static/js/impala/stats/csv_keys.js:269 static/js/zamboni/stats-all.js:15550 static/js/zamboni/stats-min.js:5
 msgid "<b>{0}</b> in last {1} days"
 msgstr "<b>{0}</b> (최근 {1}일간)"
 
 #. L10n: {0} is an integer and {1} and {2} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:271
-#: static/js/impala/stats/csv_keys.js:277
+#: static/js/impala/stats/csv_keys.js:271 static/js/impala/stats/csv_keys.js:277 static/js/zamboni/stats-all.js:15552 static/js/zamboni/stats-all.js:15558 static/js/zamboni/stats-min.js:5
 msgid "<b>{0}</b> from {1} to {2}"
 msgstr "<b>{0}</b> ({1}부터 {2}까지)"
 
 #. L10n: {0} and {1} are integers.
-#: static/js/impala/stats/csv_keys.js:275
+#: static/js/impala/stats/csv_keys.js:275 static/js/zamboni/stats-all.js:15556 static/js/zamboni/stats-min.js:5
 msgid "<b>{0}</b> average in last {1} days"
 msgstr "<b>{0}</b> (최근 {1}일간 평균)"
 
-#: static/js/impala/stats/overview.js:19
+#: static/js/impala/stats/overview.js:19 static/js/zamboni/stats-all.js:16469 static/js/zamboni/stats-min.js:5
 msgid "No data available."
 msgstr "데이터가 없습니다."
 
-#: static/js/impala/stats/table.js:74
+#: static/js/impala/stats/table.js:74 static/js/zamboni/stats-all.js:17209 static/js/zamboni/stats-min.js:5
 msgid "Date"
 msgstr "날짜"
 
-#: static/js/impala/stats/topchart.js:96
+#: static/js/impala/stats/topchart.js:96 static/js/zamboni/stats-all.js:16600 static/js/zamboni/stats-min.js:5
 msgid "Other"
 msgstr "기타"
 
-#: static/js/zamboni/admin_validation.js:24 static/js/zamboni/devhub.js:1229
-#: static/js/zamboni/editors.js:295
+#: static/js/zamboni/admin-all.js:180 static/js/zamboni/admin-min.js:1 static/js/zamboni/admin_validation.js:24 static/js/zamboni/devhub-all.js:2408 static/js/zamboni/devhub-min.js:2
+#: static/js/zamboni/devhub.js:1229 static/js/zamboni/editors-all.js:15576 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:295
 msgid "Select an application first"
 msgstr "먼저 애플리케이션을 선택하세요"
 
-#: static/js/zamboni/admin_validation.js:51
+#: static/js/zamboni/admin-all.js:207 static/js/zamboni/admin-min.js:1 static/js/zamboni/admin_validation.js:51
 msgid "Set {0} add-on to a max version of {1} and email the author."
 msgid_plural "Set {0} add-ons to a max version of {1} and email the authors."
 msgstr[0] "{1}의 최신 버전에 부가 기능 {0}개를 설정하고 제작자에게 이메일을 보냅니다."
+msgstr[1] ""
 
-#: static/js/zamboni/admin_validation.js:54
+#: static/js/zamboni/admin-all.js:210 static/js/zamboni/admin-min.js:1 static/js/zamboni/admin_validation.js:54
 msgid "Email author of {2} add-on which failed validation."
 msgid_plural "Email authors of {2} add-ons which failed validation."
 msgstr[0] "유효성 확인에 실패한 {2} 부가 기능 개발자에게 메일을 보냅니다."
+msgstr[1] ""
 
-#. L10n: {0} is an app name like Firefox.
-#: static/js/zamboni/buttons.js:66
-msgid "Accept and Install"
-msgstr "동의 및 설치"
-
-#: static/js/zamboni/buttons.js:66
-msgid "Add to {0}"
-msgstr "{0}에 추가"
-
-#: static/js/zamboni/buttons.js:71
-msgid "Download Now"
-msgstr "다운로드"
-
-#: static/js/zamboni/buttons.js:112
-msgid "Add-on has not been updated to support default-to-compatible."
-msgstr "부가 기능이 기본으로 호환성을 갖출 수 있도록 업데이트 되지 않았습니다."
-
-#: static/js/zamboni/buttons.js:117
-msgid "You need to be using Firefox 10.0 or higher."
-msgstr "Firefox 10.0 이상 버전이 필요합니다."
-
-#: static/js/zamboni/buttons.js:129
-msgid ""
-"Mozilla has marked this version as incompatible with your Firefox version."
-msgstr "Mozilla에서 이 버전이 현재 사용중인 Firefox 버전과 호환되지 않음을 표시하고 있습니다."
-
-#. L10n: {0} is an platform like Windows or Linux.
-#: static/js/zamboni/buttons.js:210
-msgid "Install for {0} anyway"
-msgstr "{0}용 강제 설치"
-
-#: static/js/zamboni/buttons.js:210
-msgid "Download for {0} anyway"
-msgstr "{0}용 강제 다운로드"
-
-#: static/js/zamboni/buttons.js:267
-msgid "Not available for your platform"
-msgstr "현재 플랫폼에서 사용 불가"
-
-#. L10n: {0} is an app name, {1} is the app version.
-#: static/js/zamboni/buttons.js:278 static/js/zamboni/buttons.js:315
-msgid "Not available for {0} {1}"
-msgstr "{0} {1}에서 사용 불가"
-
-#: static/js/zamboni/buttons.js:341
-msgid "Works with {app} {min} - {max}"
-msgstr "{app} {min} - {max}에서 작동"
-
-#: static/js/zamboni/buttons.js:343
-msgid "View other versions"
-msgstr "다른 버전 보기"
-
-#: static/js/zamboni/buttons.js:391
-msgid "Only with Firefox — Get Firefox Now!"
-msgstr ""
-
-#: static/js/zamboni/buttons.js:507 static/js/zamboni/mobile/buttons.js:43
-msgid ""
-"Sorry, you need a Mozilla-based browser (such as Firefox) to install a "
-"search plugin."
-msgstr "죄송합니다. 검색 플러그인을 설치하려면 Mozilla 기반 브라우저(Firefox 같은)가 필요합니다."
-
-#: static/js/zamboni/collections.js:229
-msgid "Adding to Favorites&hellip;"
-msgstr "선호 목록에 추가중&hellip;"
-
-#: static/js/zamboni/collections.js:232
-msgid "Removing Favorite&hellip;"
-msgstr "선호 목록에서 삭제중&hellip;"
-
-#: static/js/zamboni/collections.js:235
-msgid "Add to Favorites"
-msgstr "선호 목록에 추가"
-
-#: static/js/zamboni/collections.js:238
-msgid "Remove from Favorites"
-msgstr "선호 목록에서 삭제"
-
-#: static/js/zamboni/collections.js:303
-msgid "Pending"
-msgstr "대기중"
-
-#: static/js/zamboni/collections.js:304
-msgid "Add a comment"
-msgstr "코멘트 추가"
-
-#: static/js/zamboni/collections.js:304
-msgid "Comment"
-msgstr "코멘트"
-
-#: static/js/zamboni/collections.js:305
-msgid "Remove this add-on from the collection"
-msgstr "모음집에서 이 부가 기능 삭제"
-
-#: static/js/zamboni/collections.js:305 static/js/zamboni/collections.js:334
-msgid "Remove"
-msgstr "삭제"
-
-#: static/js/zamboni/collections.js:334
-msgid "Remove this user as a contributor"
-msgstr "기여자에서 이 사용자 삭제"
-
-#: static/js/zamboni/collections.js:346
-msgid "An email address is required."
-msgstr "이메일 주소를 입력해야 합니다."
-
-#: static/js/zamboni/collections.js:364
-msgid "You cannot add yourself as a contributor."
-msgstr "자신의 계정은 기여자로 추가할 수 없습니다."
-
-#: static/js/zamboni/collections.js:366
-msgid "You have already added that user."
-msgstr "이미 추가된 사용자입니다."
-
-#: static/js/zamboni/collections.js:573
-msgid "Add to favorites"
-msgstr "선호 목록에 추가"
-
-#: static/js/zamboni/collections.js:577
-msgid "Remove from favorites"
-msgstr "선호 목록에서 삭제"
-
-#: static/js/zamboni/collections.js:604
-msgid "Stop following"
-msgstr "팔로우 중단"
-
-#: static/js/zamboni/devhub.js:110
+#: static/js/zamboni/devhub-all.js:1289 static/js/zamboni/devhub-min.js:1 static/js/zamboni/devhub.js:110
 msgid "Your browser does not support the video tag"
 msgstr "이 웹 브라우저는 비디오 태그를 지원하지 않습니다"
 
-#: static/js/zamboni/devhub.js:371
+#: static/js/zamboni/devhub-all.js:1550 static/js/zamboni/devhub-min.js:1 static/js/zamboni/devhub.js:371
 msgid "Changes Saved"
 msgstr "변경 사항이 저장되었습니다"
 
-#: static/js/zamboni/devhub.js:387
+#: static/js/zamboni/devhub-all.js:1566 static/js/zamboni/devhub-min.js:1 static/js/zamboni/devhub.js:387
 msgid "Enter a new author's email address"
 msgstr "새 제작자의 이메일 주소를 입력하세요"
 
-#: static/js/zamboni/devhub.js:536
+#: static/js/zamboni/devhub-all.js:1715 static/js/zamboni/devhub-min.js:1 static/js/zamboni/devhub.js:536
 msgid "There was an error uploading your file."
 msgstr "파일을 업로드하는 과정에서 오류가 발생했습니다."
 
-#: static/js/zamboni/devhub.js:681
+#: static/js/zamboni/devhub-all.js:1860 static/js/zamboni/devhub-min.js:1 static/js/zamboni/devhub.js:681
 msgid "{files} file"
 msgid_plural "{files} files"
 msgstr[0] "파일 {files}개"
+msgstr[1] ""
 
-#: static/js/zamboni/devhub.js:684
+#: static/js/zamboni/devhub-all.js:1863 static/js/zamboni/devhub-min.js:1 static/js/zamboni/devhub.js:684
 msgid "{reviews} user review"
 msgid_plural "{reviews} user reviews"
 msgstr[0] "{reviews} 사용자 리뷰"
+msgstr[1] ""
 
-#: static/js/zamboni/devhub.js:796
+#: static/js/zamboni/devhub-all.js:1975 static/js/zamboni/devhub-min.js:2 static/js/zamboni/devhub.js:796
 msgid "Learn more"
 msgstr "자세히 알아보기"
 
-#: static/js/zamboni/devhub.js:800
+#: static/js/zamboni/devhub-all.js:1979 static/js/zamboni/devhub-min.js:2 static/js/zamboni/devhub.js:800
 msgid "Example"
 msgstr "예"
 
-#: static/js/zamboni/devhub.js:1130
+#: static/js/zamboni/devhub-all.js:2309 static/js/zamboni/devhub-min.js:2 static/js/zamboni/devhub.js:1130
 msgid "Image changes being processed"
 msgstr "이미지 변경이 처리되었습니다"
 
-#: static/js/zamboni/devhub.js:1280
+#: static/js/zamboni/devhub-all.js:2459 static/js/zamboni/devhub-min.js:2 static/js/zamboni/devhub.js:1280
 msgid "Must be a valid e-mail address."
 msgstr "올바른 이메일 주소를 입력해야 합니다."
+
+#: static/js/zamboni/devhub-all.js:2613 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:80
+msgid "All tests passed successfully."
+msgstr "모든 테스트에 통과했습니다."
+
+#: static/js/zamboni/devhub-all.js:2616 static/js/zamboni/devhub-all.js:3011 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:83 static/js/zamboni/validator.js:478
+msgid "These tests were not run."
+msgstr "이 테스트는 실행되지 않았습니다."
+
+#: static/js/zamboni/devhub-all.js:2664 static/js/zamboni/devhub-all.js:2677 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:131 static/js/zamboni/validator.js:144
+msgid "Tests"
+msgstr "검사"
+
+#: static/js/zamboni/devhub-all.js:2779 static/js/zamboni/devhub-all.js:3108 static/js/zamboni/devhub-all.js:3127 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:246
+#: static/js/zamboni/validator.js:575 static/js/zamboni/validator.js:594
+msgid "Error"
+msgstr "오류"
+
+#: static/js/zamboni/devhub-all.js:2780 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:247
+msgid "Warning"
+msgstr "경고"
+
+#: static/js/zamboni/devhub-all.js:2794 static/js/zamboni/devhub-min.js:2 static/js/zamboni/files-all.js:5657 static/js/zamboni/files-min.js:3 static/js/zamboni/files.js:411
+#: static/js/zamboni/validator.js:261
+msgid "Ignore this message in future updates"
+msgstr "향후 업데이트에서 이 메시지를 무시"
+
+#: static/js/zamboni/devhub-all.js:2817 static/js/zamboni/devhub-min.js:2 static/js/zamboni/files-all.js:5663 static/js/zamboni/files-min.js:3 static/js/zamboni/files.js:417
+#: static/js/zamboni/validator.js:284
+msgid "Severity for automated signing:"
+msgstr ""
+
+#: static/js/zamboni/devhub-all.js:2832 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:299
+msgid "Suggestions for passing automated signing:"
+msgstr "자동 서명 전달에 대한 제안:"
+
+#: static/js/zamboni/devhub-all.js:2920 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:387
+msgid "Compatibility Tests"
+msgstr "호환성 검사"
+
+#: static/js/zamboni/devhub-all.js:2999 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:466
+msgid "Add-on failed validation."
+msgstr "부가 기능이 검사를 통과하지 못했습니다."
+
+#: static/js/zamboni/devhub-all.js:3001 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:468
+msgid "Add-on passed validation."
+msgstr "부가 기능이 검사를 통과했습니다."
+
+#: static/js/zamboni/devhub-all.js:3014 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:481
+msgid "{0} error"
+msgid_plural "{0} errors"
+msgstr[0] "오류 {0}개"
+msgstr[1] ""
+
+#: static/js/zamboni/devhub-all.js:3016 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:483
+msgid "{0} warning"
+msgid_plural "{0} warnings"
+msgstr[0] "경고 {0}개"
+msgstr[1] ""
+
+#: static/js/zamboni/devhub-all.js:3018 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:485
+msgid "{0} notice"
+msgid_plural "{0} notices"
+msgstr[0] "알림 {0}개"
+msgstr[1] ""
+
+#: static/js/zamboni/devhub-all.js:3110 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:577
+msgid "Validation task could not complete or completed with errors"
+msgstr "검사 작업이 오류로 인해 완료되지 못했습니다"
+
+#: static/js/zamboni/devhub-all.js:3128 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:595
+msgid "Internal server error"
+msgstr "내부 서버 오류"
 
 #: static/js/zamboni/devhub_search.js:8
 msgid "No results found."
 msgstr "검색한 결과가 없습니다."
 
-#: static/js/zamboni/editors.js:121
+#: static/js/zamboni/editors-all.js:15402 static/js/zamboni/editors-min.js:4 static/js/zamboni/editors.js:121
 msgid "{name} was viewing this page first."
 msgstr "{name}님이 먼저 이 페이지를 살펴보셨습니다."
 
-#: static/js/zamboni/editors.js:171
+#: static/js/zamboni/editors-all.js:15452 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:171
 msgid "Receipt checked by app."
 msgstr "앱이 영수증을 확인했습니다."
 
-#: static/js/zamboni/editors.js:173
+#: static/js/zamboni/editors-all.js:15454 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:173
 msgid "Receipt was not checked by app."
 msgstr "앱이 영수증을 확인하지 못했습니다."
 
-#: static/js/zamboni/editors.js:244
+#: static/js/zamboni/editors-all.js:15525 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:244
 msgid "{name} was viewing this add-on first."
 msgstr "{name}님이 먼저 이 부가 기능을 조회하셨습니다."
 
-#: static/js/zamboni/editors.js:255
+#: static/js/zamboni/editors-all.js:15536 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:255
 msgid "Loading&hellip;"
 msgstr "불러오는 중&hellip;"
 
-#: static/js/zamboni/editors.js:260
+#: static/js/zamboni/editors-all.js:15541 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:260
 msgid "Version Notes"
 msgstr "버전 기록서"
 
-#: static/js/zamboni/editors.js:265
+#: static/js/zamboni/editors-all.js:15546 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:265
 msgid "Notes for Reviewers"
 msgstr "심사자의 메모"
 
-#: static/js/zamboni/editors.js:270
+#: static/js/zamboni/editors-all.js:15551 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:270
 msgid "No version notes found"
 msgstr "버전 기록서가 없습니다"
 
-#: static/js/zamboni/editors.js:330
+#: static/js/zamboni/editors-all.js:15611 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:330
 msgid "Average Reviews"
 msgstr ""
 
-#: static/js/zamboni/editors.js:386
+#: static/js/zamboni/editors-all.js:15667 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:386
 msgid "Number of Reviews"
 msgstr ""
 
-#: static/js/zamboni/editors.js:445
+#: static/js/zamboni/editors-all.js:15726 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:445
 msgid "Error loading translation"
 msgstr "번역 결과를 불러오는 과정에서 오류 발생"
 
-#: static/js/zamboni/files.js:411 static/js/zamboni/validator.js:261
-msgid "Ignore this message in future updates"
-msgstr "향후 업데이트에서 이 메시지를 무시"
-
-#: static/js/zamboni/files.js:417 static/js/zamboni/validator.js:284
-msgid "Severity for automated signing:"
-msgstr ""
-
-#: static/js/zamboni/global.js:410
-msgid "Loading..."
-msgstr "읽는 중..."
-
-#. L10n: {0} is the number of characters left.
-#: static/js/zamboni/global.js:474
-msgid "<b>{0}</b> character left."
-msgid_plural "<b>{0}</b> characters left."
-msgstr[0] "<b>{0}</b>자 남았습니다."
-
-#: static/js/zamboni/init.js:28
-msgid ""
-"This feature is temporarily disabled while we perform website maintenance. "
-"Please check back a little later."
-msgstr "이 기능은 웹사이트 점검으로 인해 잠시 사용할 수 없습니다. 잠시 후 다시 사용해 주세요."
-
-#: static/js/zamboni/l10n.js:45
-msgid "Remove this localization"
-msgstr "이 번역 삭제"
-
-#: static/js/zamboni/password-strength.js:20
-msgid "Password strength:"
-msgstr "비밀번호 보안 등급:"
-
-#: static/js/zamboni/password-strength.js:26
-msgid "At least {0} character left."
-msgid_plural "At least {0} characters left."
-msgstr[0] "최소 {0}글자를 더 입력해야 합니다."
-
-#: static/js/zamboni/themes_review.js:176
-msgid "Requested Info"
-msgstr "요청된 정보"
-
-#: static/js/zamboni/themes_review.js:177
-msgid "Flagged"
-msgstr "표시됨"
-
-#: static/js/zamboni/themes_review.js:178
-msgid "Duplicate"
-msgstr "복사하기"
-
-#: static/js/zamboni/themes_review.js:179
-msgid "Rejected"
-msgstr "거부됨"
-
-#: static/js/zamboni/themes_review.js:180
-msgid "Approved"
-msgstr "승인됨"
-
-#: static/js/zamboni/themes_review.js:424
-msgid "No results found"
-msgstr "검색 결과 없음"
-
-#: static/js/zamboni/themes_review_templates.js:31
+#: static/js/zamboni/editors-all.js:15975 static/js/zamboni/editors-min.js:5 static/js/zamboni/themes_review_templates.js:31
 msgid "Theme"
 msgstr "테마"
 
-#: static/js/zamboni/themes_review_templates.js:33
+#: static/js/zamboni/editors-all.js:15977 static/js/zamboni/editors-min.js:5 static/js/zamboni/themes_review_templates.js:33
 msgid "Reviewer"
 msgstr "심사원"
 
-#: static/js/zamboni/themes_review_templates.js:35
+#: static/js/zamboni/editors-all.js:15979 static/js/zamboni/editors-min.js:5 static/js/zamboni/themes_review_templates.js:35
 msgid "Status"
 msgstr "상태"
 
-#: static/js/zamboni/validator.js:80
-msgid "All tests passed successfully."
-msgstr "모든 테스트에 통과했습니다."
+#: static/js/zamboni/editors-all.js:16196 static/js/zamboni/editors-min.js:5 static/js/zamboni/themes_review.js:176
+msgid "Requested Info"
+msgstr "요청된 정보"
 
-#: static/js/zamboni/validator.js:83 static/js/zamboni/validator.js:478
-msgid "These tests were not run."
-msgstr "이 테스트는 실행되지 않았습니다."
+#: static/js/zamboni/editors-all.js:16197 static/js/zamboni/editors-min.js:5 static/js/zamboni/themes_review.js:177
+msgid "Flagged"
+msgstr "표시됨"
 
-#: static/js/zamboni/validator.js:131 static/js/zamboni/validator.js:144
-msgid "Tests"
-msgstr "검사"
+#: static/js/zamboni/editors-all.js:16198 static/js/zamboni/editors-min.js:5 static/js/zamboni/themes_review.js:178
+msgid "Duplicate"
+msgstr "복사하기"
 
-#: static/js/zamboni/validator.js:246 static/js/zamboni/validator.js:575
-#: static/js/zamboni/validator.js:594
-msgid "Error"
-msgstr "오류"
+#: static/js/zamboni/editors-all.js:16199 static/js/zamboni/editors-min.js:5 static/js/zamboni/themes_review.js:179
+msgid "Rejected"
+msgstr "거부됨"
 
-#: static/js/zamboni/validator.js:247
-msgid "Warning"
-msgstr "경고"
+#: static/js/zamboni/editors-all.js:16200 static/js/zamboni/editors-min.js:5 static/js/zamboni/themes_review.js:180
+msgid "Approved"
+msgstr "승인됨"
 
-#: static/js/zamboni/validator.js:299
-msgid "Suggestions for passing automated signing:"
-msgstr "자동 서명 전달에 대한 제안:"
+#: static/js/zamboni/editors-all.js:16444 static/js/zamboni/editors-min.js:5 static/js/zamboni/themes_review.js:424
+msgid "No results found"
+msgstr "검색 결과 없음"
 
-#: static/js/zamboni/validator.js:387
-msgid "Compatibility Tests"
-msgstr "호환성 검사"
-
-#: static/js/zamboni/validator.js:466
-msgid "Add-on failed validation."
-msgstr "부가 기능이 검사를 통과하지 못했습니다."
-
-#: static/js/zamboni/validator.js:468
-msgid "Add-on passed validation."
-msgstr "부가 기능이 검사를 통과했습니다."
-
-#: static/js/zamboni/validator.js:481
-msgid "{0} error"
-msgid_plural "{0} errors"
-msgstr[0] "오류 {0}개"
-
-#: static/js/zamboni/validator.js:483
-msgid "{0} warning"
-msgid_plural "{0} warnings"
-msgstr[0] "경고 {0}개"
-
-#: static/js/zamboni/validator.js:485
-msgid "{0} notice"
-msgid_plural "{0} notices"
-msgstr[0] "알림 {0}개"
-
-#: static/js/zamboni/validator.js:577
-msgid "Validation task could not complete or completed with errors"
-msgstr "검사 작업이 오류로 인해 완료되지 못했습니다"
-
-#: static/js/zamboni/validator.js:595
-msgid "Internal server error"
-msgstr "내부 서버 오류"
-
-#: static/js/zamboni/mobile/buttons.js:52
+#: static/js/zamboni/mobile-all.js:15186 static/js/zamboni/mobile/buttons.js:52
 msgid "Not Updated for {0} {1}"
 msgstr "{0} {1}용으로 아직 업데이트 되지 않음"
 
-#: static/js/zamboni/mobile/buttons.js:53
+#: static/js/zamboni/mobile-all.js:15187 static/js/zamboni/mobile/buttons.js:53
 msgid "Requires Newer Version of {0}"
 msgstr "{0} 최신 버전 필요"
 
-#: static/js/zamboni/mobile/buttons.js:54
+#: static/js/zamboni/mobile-all.js:15188 static/js/zamboni/mobile/buttons.js:54
 msgid "Unreviewed"
 msgstr "미심사"
 
-#: static/js/zamboni/mobile/buttons.js:55
+#: static/js/zamboni/mobile-all.js:15189 static/js/zamboni/mobile/buttons.js:55
 msgid "Experimental <span>(Learn More)</span>"
 msgstr "시험용 <span>(자세히 알아보기)</span>"
 
-#: static/js/zamboni/mobile/buttons.js:56
-#: static/js/zamboni/mobile/buttons.js:57
+#: static/js/zamboni/mobile-all.js:15190 static/js/zamboni/mobile-all.js:15191 static/js/zamboni/mobile/buttons.js:56 static/js/zamboni/mobile/buttons.js:57
 msgid "Not Available for {0}"
 msgstr "{0}용으로 사용 불가"
 
-#: static/js/zamboni/mobile/buttons.js:58
+#: static/js/zamboni/mobile-all.js:15192 static/js/zamboni/mobile/buttons.js:58
 msgid "Experimental"
 msgstr "시험용"
 
-#: static/js/zamboni/mobile/buttons.js:59
+#: static/js/zamboni/mobile-all.js:15193 static/js/zamboni/mobile/buttons.js:59
 msgid "Themes Require Newer Version of {0}"
 msgstr "새로운 버전의 {0}이 필요한 테마"
 
-#: static/js/zamboni/mobile/buttons.js:60
+#: static/js/zamboni/mobile-all.js:15194 static/js/zamboni/mobile/buttons.js:60
 msgid "Themes Require {0}"
 msgstr "{0}이 필요한 테마"
 
-#: static/js/zamboni/mobile/buttons.js:105
+#: static/js/zamboni/mobile-all.js:15239 static/js/zamboni/mobile/buttons.js:105
 msgid "Installing..."
 msgstr "설치 중..."
 
-#: static/js/zamboni/mobile/buttons.js:125
+#: static/js/zamboni/mobile-all.js:15259 static/js/zamboni/mobile/buttons.js:125
 msgid "This add-on has been preliminarily reviewed by Mozilla."
 msgstr "이 부가 기능은 Mozilla의 예비 심사를 통과했습니다."
 
-#: static/js/zamboni/mobile/buttons.js:250
+#: static/js/zamboni/mobile-all.js:15384 static/js/zamboni/mobile/buttons.js:250
 msgid "Keep it"
 msgstr "받기"
 
-#: static/js/zamboni/mobile/general.js:344
+#: static/js/zamboni/mobile-all.js:16049 static/js/zamboni/mobile-min.js:6 static/js/zamboni/mobile/general.js:344
 msgid "You're trying it on!"
 msgstr "시도중입니다!"
 
-#: static/js/zamboni/mobile/general.js:356
+#: static/js/zamboni/mobile-all.js:16061 static/js/zamboni/mobile-min.js:6 static/js/zamboni/mobile/general.js:356
 msgid "Added to Firefox"
 msgstr "Firefox에 추가"

--- a/locale/ku/LC_MESSAGES/django.po
+++ b/locale/ku/LC_MESSAGES/django.po
@@ -2,69 +2,70 @@ msgid ""
 msgstr ""
 "Project-Id-Version:  0.1\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2016-02-24 21:23+0000\n"
+"POT-Creation-Date: 2016-04-18 15:47+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
+"Language: \n"
 "MIME-Version: 1.0\n"
-"Content-Type: text/plain; charset=utf-8\n"
+"Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Generated-By: Babel 2.2.0\n"
 
-#: src/olympia/accounts/views.py:52
+#: src/olympia/accounts/views.py:54
 msgid "Your log in attempt could not be parsed. Please try again."
 msgstr ""
 
-#: src/olympia/accounts/views.py:54
+#: src/olympia/accounts/views.py:56
 msgid "Your Firefox Account could not be found. Please try again."
 msgstr ""
 
-#: src/olympia/accounts/views.py:55
+#: src/olympia/accounts/views.py:57
 msgid "You could not be logged in. Please try again."
 msgstr ""
 
-#: src/olympia/accounts/views.py:57
+#: src/olympia/accounts/views.py:59
 msgid "Your account has already been migrated to Firefox Accounts."
 msgstr ""
 
-#: src/olympia/accounts/views.py:59
+#: src/olympia/accounts/views.py:61
 msgid "Your Firefox Account already exists on this site."
 msgstr ""
 
-#: src/olympia/accounts/views.py:108
+#: src/olympia/accounts/views.py:110
 msgid "Great job!"
 msgstr ""
 
-#: src/olympia/accounts/views.py:109
+#: src/olympia/accounts/views.py:111
 msgid "You can now log in to Add-ons with your Firefox Account."
 msgstr ""
 
-#: src/olympia/accounts/views.py:121
+#: src/olympia/accounts/views.py:123
 msgid "Need help?"
 msgstr ""
 
-#: src/olympia/addons/buttons.py:180
+#: src/olympia/addons/buttons.py:177
 msgid "Download Now"
 msgstr ""
 
-#: src/olympia/addons/buttons.py:182
+#: src/olympia/addons/buttons.py:179
 msgid "Download"
 msgstr ""
 
 #. L10n: please keep &nbsp; in the string so &rarr; does not wrap.
-#: src/olympia/addons/buttons.py:186
+#: src/olympia/addons/buttons.py:183
 msgid "Continue to Download&nbsp;&rarr;"
 msgstr ""
 
-#: src/olympia/addons/buttons.py:202 src/olympia/addons/helpers.py:35 src/olympia/addons/views.py:319 src/olympia/addons/templates/addons/impala/details.html:114
+#: src/olympia/addons/buttons.py:199 src/olympia/addons/helpers.py:35 src/olympia/addons/views.py:333 src/olympia/addons/templates/addons/impala/details.html:111
 #: src/olympia/addons/templates/addons/impala/listing/items.html:17 src/olympia/addons/templates/addons/mobile/home.html:40 src/olympia/amo/templates/amo/side_nav.html:6
-#: src/olympia/amo/templates/amo/side_nav.html:10 src/olympia/amo/templates/amo/site_nav.html:2 src/olympia/amo/templates/amo/site_nav.html:55 src/olympia/bandwagon/views.py:95
-#: src/olympia/browse/views.py:54 src/olympia/browse/views.py:68 src/olympia/browse/views.py:235 src/olympia/browse/templates/browse/impala/category_landing.html:22
+#: src/olympia/amo/templates/amo/side_nav.html:10 src/olympia/amo/templates/amo/site_nav.html:2 src/olympia/amo/templates/amo/site_nav.html:53 src/olympia/bandwagon/views.py:95
+#: src/olympia/browse/views.py:54 src/olympia/browse/views.py:68 src/olympia/browse/views.py:202 src/olympia/browse/templates/browse/impala/category_landing.html:22
 #: src/olympia/browse/templates/browse/personas/mobile/category_landing.html:26
 msgid "Featured"
 msgstr ""
 
-#: src/olympia/addons/buttons.py:221
+#: src/olympia/addons/buttons.py:218
 msgid "Add to {0}"
 msgstr ""
 
@@ -112,39 +113,39 @@ msgid_plural "All tags must be at least {0} characters."
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/olympia/addons/forms.py:234
+#: src/olympia/addons/forms.py:238
 msgid "Categories cannot be changed while your add-on is featured for this application."
 msgstr ""
 
 #. L10n: {0} is the number of categories.
-#: src/olympia/addons/forms.py:238
+#: src/olympia/addons/forms.py:242
 msgid "You can have only {0} category."
 msgid_plural "You can have only {0} categories."
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/olympia/addons/forms.py:246
+#: src/olympia/addons/forms.py:250
 msgid "The miscellaneous category cannot be combined with additional categories."
 msgstr ""
 
-#: src/olympia/addons/forms.py:369
+#: src/olympia/addons/forms.py:374
 #, python-format
 msgid "Before changing your default locale you must have a name, summary, and description in that locale. You are missing %s."
 msgstr ""
 
-#: src/olympia/addons/forms.py:484 src/olympia/addons/forms.py:575
+#: src/olympia/addons/forms.py:455 src/olympia/addons/forms.py:546
 msgid "A license must be selected."
 msgstr ""
 
-#: src/olympia/addons/forms.py:556
+#: src/olympia/addons/forms.py:527
 msgid "Give Your Theme a Name."
 msgstr ""
 
-#: src/olympia/addons/forms.py:562 src/olympia/devhub/templates/devhub/personas/submit.html:53
+#: src/olympia/addons/forms.py:533 src/olympia/devhub/templates/devhub/personas/submit.html:53
 msgid "Describe your Theme."
 msgstr ""
 
-#: src/olympia/addons/forms.py:704
+#: src/olympia/addons/forms.py:675
 msgid "Enter a new author's email address"
 msgstr ""
 
@@ -152,37 +153,37 @@ msgstr ""
 msgid "Not Reviewed"
 msgstr ""
 
-#: src/olympia/addons/models.py:301
+#: src/olympia/addons/models.py:298
 msgid "Users have the option of contributing more or less than this amount."
 msgstr ""
 
-#: src/olympia/addons/models.py:309
-msgid "Users will always be asked in the Add-ons Manager (Firefox 4 and above)"
+#: src/olympia/addons/models.py:306
+msgid "Users will always be asked in the Add-ons Manager (Firefox 4 and above). Only applies to desktop."
 msgstr ""
 
-#: src/olympia/addons/models.py:1804 src/olympia/addons/templates/addons/details_box.html:55 src/olympia/devhub/templates/devhub/index.html:92
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:102
+#: src/olympia/addons/models.py:1802 src/olympia/addons/templates/addons/details_box.html:55 src/olympia/devhub/templates/devhub/index.html:92
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:89
 msgid "Listed"
 msgstr ""
 
-#: src/olympia/addons/views.py:320 src/olympia/browse/templates/browse/personas/mobile/category_landing.html:27
+#: src/olympia/addons/views.py:334 src/olympia/browse/templates/browse/personas/mobile/category_landing.html:27
 msgid "Popular"
 msgstr ""
 
-#: src/olympia/addons/views.py:321 src/olympia/browse/views.py:238 src/olympia/browse/views.py:280 src/olympia/browse/views.py:482
+#: src/olympia/addons/views.py:335 src/olympia/browse/views.py:205 src/olympia/browse/views.py:247 src/olympia/browse/views.py:449
 msgid "Recently Added"
 msgstr ""
 
-#: src/olympia/addons/views.py:322 src/olympia/bandwagon/views.py:99 src/olympia/browse/views.py:60 src/olympia/browse/views.py:71 src/olympia/search/forms.py:16 src/olympia/search/forms.py:91
+#: src/olympia/addons/views.py:336 src/olympia/bandwagon/views.py:99 src/olympia/browse/views.py:60 src/olympia/browse/views.py:71 src/olympia/search/forms.py:16 src/olympia/search/forms.py:91
 msgid "Recently Updated"
 msgstr ""
 
 #. l10n: {0} is the addon name
-#: src/olympia/addons/views.py:520
+#: src/olympia/addons/views.py:534
 msgid "Contribution for {0}"
 msgstr ""
 
-#: src/olympia/addons/views.py:613
+#: src/olympia/addons/views.py:627
 msgid "Abuse reported."
 msgstr ""
 
@@ -249,9 +250,9 @@ msgstr ""
 #: src/olympia/devhub/templates/devhub/addons/ajax_compat_update.html:36 src/olympia/devhub/templates/devhub/addons/profile.html:44 src/olympia/devhub/templates/devhub/addons/edit/admin.html:101
 #: src/olympia/devhub/templates/devhub/addons/edit/basic.html:152 src/olympia/devhub/templates/devhub/addons/edit/details.html:85 src/olympia/devhub/templates/devhub/addons/edit/support.html:67
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:166 src/olympia/devhub/templates/devhub/addons/forms_shared/media.html:149
-#: src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:44 src/olympia/devhub/templates/devhub/versions/add_file_modal.html:78 src/olympia/devhub/templates/devhub/versions/edit.html:139
-#: src/olympia/devhub/templates/devhub/versions/list.html:242 src/olympia/devhub/templates/devhub/versions/list.html:276 src/olympia/devhub/templates/devhub/versions/list.html:317
-#: src/olympia/devhub/templates/devhub/versions/list.html:351 src/olympia/reviews/templates/reviews/edit_review.html:16 src/olympia/translations/templates/translations/trans-menu.html:50
+#: src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:43 src/olympia/devhub/templates/devhub/versions/add_file_modal.html:58 src/olympia/devhub/templates/devhub/versions/edit.html:139
+#: src/olympia/devhub/templates/devhub/versions/list.html:239 src/olympia/devhub/templates/devhub/versions/list.html:281 src/olympia/devhub/templates/devhub/versions/list.html:315
+#: src/olympia/devhub/templates/devhub/versions/list.html:349 src/olympia/reviews/templates/reviews/edit_review.html:16 src/olympia/translations/templates/translations/trans-menu.html:50
 #: src/olympia/translations/templates/translations/trans-menu.html:62
 msgid "or"
 msgstr ""
@@ -362,7 +363,7 @@ msgid "Add-on Information for {0}"
 msgstr ""
 
 #: src/olympia/addons/templates/addons/details_box.html:30 src/olympia/addons/templates/addons/persona_detail_table.html:3 src/olympia/addons/templates/addons/mobile/details.html:63
-#: src/olympia/addons/templates/addons/mobile/persona_detail_table.html:7 src/olympia/browse/views.py:459 src/olympia/devhub/views.py:75
+#: src/olympia/addons/templates/addons/mobile/persona_detail_table.html:7 src/olympia/browse/views.py:426 src/olympia/devhub/views.py:73
 msgid "Updated"
 msgstr ""
 
@@ -381,11 +382,11 @@ msgstr ""
 msgid "Visibility"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/details_box.html:57 src/olympia/devhub/templates/devhub/index.html:94 src/olympia/devhub/templates/devhub/includes/addon_details.html:104
+#: src/olympia/addons/templates/addons/details_box.html:57 src/olympia/devhub/templates/devhub/index.html:94 src/olympia/devhub/templates/devhub/includes/addon_details.html:91
 msgid "Hidden"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/details_box.html:59 src/olympia/devhub/templates/devhub/index.html:96 src/olympia/devhub/templates/devhub/includes/addon_details.html:106
+#: src/olympia/addons/templates/addons/details_box.html:59 src/olympia/devhub/templates/devhub/index.html:96 src/olympia/devhub/templates/devhub/includes/addon_details.html:93
 msgid "Unlisted"
 msgstr ""
 
@@ -393,13 +394,13 @@ msgstr ""
 msgid "Required Add-ons"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/details_box.html:81 src/olympia/addons/templates/addons/persona_detail_table.html:15 src/olympia/browse/views.py:462 src/olympia/devhub/views.py:78
-#: src/olympia/devhub/views.py:85 src/olympia/discovery/templates/discovery/addons/detail.html:57 src/olympia/reviews/forms.py:62 src/olympia/reviews/templates/reviews/add.html:57
+#: src/olympia/addons/templates/addons/details_box.html:81 src/olympia/addons/templates/addons/persona_detail_table.html:15 src/olympia/browse/views.py:429 src/olympia/devhub/views.py:76
+#: src/olympia/devhub/views.py:83 src/olympia/discovery/templates/discovery/addons/detail.html:57 src/olympia/reviews/forms.py:62 src/olympia/reviews/templates/reviews/add.html:57
 #: src/olympia/reviews/templates/reviews/mobile/review_list.html:18
 msgid "Rating"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/details_box.html:85 src/olympia/browse/views.py:461 src/olympia/devhub/views.py:77 src/olympia/devhub/views.py:84
+#: src/olympia/addons/templates/addons/details_box.html:85 src/olympia/browse/views.py:428 src/olympia/devhub/views.py:75 src/olympia/devhub/views.py:82
 #: src/olympia/stats/templates/stats/addon_report_menu.html:8 src/olympia/stats/templates/stats/collection_report_menu.html:18
 msgid "Downloads"
 msgstr ""
@@ -419,7 +420,7 @@ msgstr ""
 
 #. The Privacy Policy for this add-on.
 #: src/olympia/addons/templates/addons/details_box.html:121 src/olympia/addons/templates/addons/privacy.html:19 src/olympia/addons/templates/addons/privacy.html:23
-#: src/olympia/addons/templates/addons/impala/button.html:43 src/olympia/addons/templates/addons/impala/details.html:307 src/olympia/devhub/templates/devhub/includes/policy_form.html:20
+#: src/olympia/addons/templates/addons/impala/button.html:43 src/olympia/addons/templates/addons/impala/details.html:312 src/olympia/devhub/templates/devhub/includes/policy_form.html:23
 #: src/olympia/templates/mobile/base_addons.html:87
 msgid "Privacy Policy"
 msgstr ""
@@ -444,7 +445,7 @@ msgstr ""
 msgid "Developer Comments"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/details_box.html:199 src/olympia/addons/templates/addons/impala/details.html:259
+#: src/olympia/addons/templates/addons/details_box.html:199 src/olympia/addons/templates/addons/impala/details.html:264
 msgid "Development Channel"
 msgstr ""
 
@@ -464,7 +465,7 @@ msgid ""
 "developer. To stop receiving development updates, reinstall the default version from the link above."
 msgstr ""
 
-#: src/olympia/addons/templates/addons/details_box.html:220 src/olympia/addons/templates/addons/impala/details.html:278
+#: src/olympia/addons/templates/addons/details_box.html:220 src/olympia/addons/templates/addons/impala/details.html:283
 msgid "Version {0}:"
 msgstr ""
 
@@ -483,7 +484,7 @@ msgid "End-User License Agreement for {0}"
 msgstr ""
 
 #: src/olympia/addons/templates/addons/eula.html:17 src/olympia/addons/templates/addons/eula.html:21 src/olympia/addons/templates/addons/impala/button.html:48
-#: src/olympia/addons/templates/addons/impala/details.html:316 src/olympia/devhub/templates/devhub/includes/policy_form.html:3 src/olympia/discovery/templates/discovery/addons/eula.html:11
+#: src/olympia/addons/templates/addons/impala/details.html:321 src/olympia/devhub/templates/devhub/includes/policy_form.html:3 src/olympia/discovery/templates/discovery/addons/eula.html:11
 msgid "End-User License Agreement"
 msgstr ""
 
@@ -500,7 +501,7 @@ msgstr ""
 msgid "Add-ons for {0}"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/home.html:10 src/olympia/addons/templates/addons/home.html:51 src/olympia/browse/templates/browse/impala/base_listing.html:11
+#: src/olympia/addons/templates/addons/home.html:10 src/olympia/addons/templates/addons/home.html:53 src/olympia/browse/templates/browse/impala/base_listing.html:11
 msgid "Featured Extensions"
 msgstr ""
 
@@ -508,29 +509,29 @@ msgstr ""
 msgid "Popular Extensions"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/home.html:42 src/olympia/amo/templates/amo/side_nav.html:3 src/olympia/amo/templates/amo/side_nav.html:11 src/olympia/amo/templates/amo/site_nav.html:3
-#: src/olympia/amo/templates/amo/site_nav.html:25 src/olympia/browse/views.py:236 src/olympia/browse/views.py:281 src/olympia/browse/views.py:481
+#: src/olympia/addons/templates/addons/home.html:44 src/olympia/amo/templates/amo/side_nav.html:3 src/olympia/amo/templates/amo/side_nav.html:11 src/olympia/amo/templates/amo/site_nav.html:3
+#: src/olympia/amo/templates/amo/site_nav.html:25 src/olympia/browse/views.py:203 src/olympia/browse/views.py:248 src/olympia/browse/views.py:448
 msgid "Most Popular"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/home.html:43
+#: src/olympia/addons/templates/addons/home.html:45
 msgid "All »"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/home.html:52 src/olympia/addons/templates/addons/home.html:61 src/olympia/addons/templates/addons/home.html:70 src/olympia/addons/templates/addons/home.html:78
+#: src/olympia/addons/templates/addons/home.html:54 src/olympia/addons/templates/addons/home.html:63 src/olympia/addons/templates/addons/home.html:72 src/olympia/addons/templates/addons/home.html:80
 #: src/olympia/browse/templates/browse/impala/category_landing.html:36
 msgid "See all »"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/home.html:60
+#: src/olympia/addons/templates/addons/home.html:62
 msgid "Up &amp; Coming Extensions"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/home.html:69 src/olympia/browse/templates/browse/personas/category_landing.html:61 src/olympia/discovery/templates/discovery/pane.html:74
+#: src/olympia/addons/templates/addons/home.html:71 src/olympia/browse/templates/browse/personas/category_landing.html:61 src/olympia/discovery/templates/discovery/pane.html:74
 msgid "Featured Themes"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/home.html:77 src/olympia/bandwagon/templates/bandwagon/impala/collection_listing.html:5
+#: src/olympia/addons/templates/addons/home.html:79 src/olympia/bandwagon/templates/bandwagon/impala/collection_listing.html:5
 msgid "Featured Collections"
 msgstr ""
 
@@ -548,7 +549,7 @@ msgid "Updated {0}"
 msgstr ""
 
 #. {0} is a date.
-#: src/olympia/addons/templates/addons/macros.html:10 src/olympia/addons/templates/addons/macros.html:69 src/olympia/addons/templates/addons/persona_preview.html:21
+#: src/olympia/addons/templates/addons/macros.html:10 src/olympia/addons/templates/addons/macros.html:69 src/olympia/addons/templates/addons/persona_preview.html:22
 #: src/olympia/addons/templates/addons/listing/items_mobile.html:44 src/olympia/addons/templates/addons/listing/macros.html:39
 #: src/olympia/bandwagon/templates/bandwagon/collection_listing_items.html:37 src/olympia/bandwagon/templates/bandwagon/impala/collection_listing_items.html:37
 msgid "Added {0}"
@@ -569,15 +570,14 @@ msgstr[0] ""
 msgstr[1] ""
 
 #. {0} is the number of downloads.
-#: src/olympia/addons/templates/addons/macros.html:53 src/olympia/addons/templates/addons/impala/details.html:61
+#: src/olympia/addons/templates/addons/macros.html:53 src/olympia/addons/templates/addons/impala/details.html:59
 msgid "{0} weekly download"
 msgid_plural "{0} weekly downloads"
 msgstr[0] ""
 msgstr[1] ""
 
 #. {0} is the number of users.
-#: src/olympia/addons/templates/addons/macros.html:61 src/olympia/addons/templates/addons/impala/details.html:54 src/olympia/compat/templates/compat/index.html:71
-#: src/olympia/zadmin/templates/zadmin/compat.html:67
+#: src/olympia/addons/templates/addons/macros.html:61 src/olympia/addons/templates/addons/impala/details.html:52 src/olympia/zadmin/templates/zadmin/compat.html:67
 msgid "{0} user"
 msgid_plural "{0} users"
 msgstr[0] ""
@@ -595,7 +595,7 @@ msgstr ""
 msgid "Return to the addon."
 msgstr ""
 
-#: src/olympia/addons/templates/addons/persona_detail.html:17 src/olympia/addons/templates/addons/impala/details.html:106 src/olympia/addons/templates/addons/mobile/details.html:23
+#: src/olympia/addons/templates/addons/persona_detail.html:17 src/olympia/addons/templates/addons/impala/details.html:103 src/olympia/addons/templates/addons/mobile/details.html:23
 #: src/olympia/addons/templates/addons/mobile/persona_detail.html:21 src/olympia/discovery/templates/discovery/addons/base.html:27 src/olympia/editors/templates/editors/review.html:31
 msgid "by"
 msgstr ""
@@ -639,34 +639,35 @@ msgstr ""
 msgid "License"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/persona_preview.html:12 src/olympia/constants/base.py:48
+#: src/olympia/addons/templates/addons/persona_preview.html:13 src/olympia/constants/base.py:48
 msgid "Awaiting Review"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/persona_preview.html:14 src/olympia/amo/log.py:180 src/olympia/constants/base.py:42 src/olympia/editors/helpers.py:62
+#: src/olympia/addons/templates/addons/persona_preview.html:15 src/olympia/amo/log.py:180 src/olympia/constants/base.py:42 src/olympia/editors/helpers.py:62
 msgid "Rejected"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/persona_preview.html:16 src/olympia/amo/log.py:159
+#: src/olympia/addons/templates/addons/persona_preview.html:17 src/olympia/amo/log.py:159
 msgid "Approved"
 msgstr ""
 
 #. {0} is the number of users.
-#: src/olympia/addons/templates/addons/persona_preview.html:26 src/olympia/addons/templates/addons/listing/items_mobile.html:36 src/olympia/addons/templates/addons/listing/macros.html:31
+#: src/olympia/addons/templates/addons/persona_preview.html:27 src/olympia/addons/templates/addons/listing/items_mobile.html:36 src/olympia/addons/templates/addons/listing/macros.html:31
 msgid "<strong>{0}</strong> user"
 msgid_plural "<strong>{0}</strong> users"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/olympia/addons/templates/addons/persona_preview.html:40
+#: src/olympia/addons/templates/addons/persona_preview.html:41
 msgid "Hover to Preview"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/persona_preview.html:46 src/olympia/addons/templates/addons/persona_preview.html:48 src/olympia/reviews/templates/reviews/add.html:15
+#: src/olympia/addons/templates/addons/persona_preview.html:47 src/olympia/addons/templates/addons/persona_preview.html:49 src/olympia/addons/templates/addons/persona_preview.html:97
+#: src/olympia/reviews/templates/reviews/add.html:15
 msgid "Add"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/persona_preview.html:57 src/olympia/bandwagon/templates/bandwagon/ajax_new.html:16 src/olympia/bandwagon/templates/bandwagon/edit.html:19
+#: src/olympia/addons/templates/addons/persona_preview.html:58 src/olympia/bandwagon/templates/bandwagon/ajax_new.html:16 src/olympia/bandwagon/templates/bandwagon/edit.html:19
 #: src/olympia/bandwagon/templates/bandwagon/includes/addedit.html:19 src/olympia/devhub/templates/devhub/addons/edit/admin.html:13 src/olympia/devhub/templates/devhub/addons/edit/basic.html:10
 #: src/olympia/devhub/templates/devhub/addons/edit/details.html:8 src/olympia/devhub/templates/devhub/addons/edit/media.html:6 src/olympia/devhub/templates/devhub/addons/edit/support.html:8
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:9 src/olympia/devhub/templates/devhub/addons/submit/describe.html:29 src/olympia/editors/templates/editors/review.html:257
@@ -675,21 +676,21 @@ msgstr ""
 
 #. For datetime formatting, see the table on
 #. http://docs.python.org/library/datetime.html#strftime-and-strptime-behavior
-#: src/olympia/addons/templates/addons/persona_preview.html:66
+#: src/olympia/addons/templates/addons/persona_preview.html:67
 #, python-format
 msgid "%%Y-%%m-%%d"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/persona_preview.html:67
+#: src/olympia/addons/templates/addons/persona_preview.html:68
 msgid "by {0} on {1}"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/persona_preview.html:75 src/olympia/reviews/helpers.py:17 src/olympia/reviews/templates/reviews/review_list.html:63
+#: src/olympia/addons/templates/addons/persona_preview.html:76 src/olympia/reviews/helpers.py:17 src/olympia/reviews/templates/reviews/review_list.html:63
 #: src/olympia/reviews/templates/reviews/reviews_link.html:21 src/olympia/reviews/templates/reviews/impala/reviews_link.html:16
 msgid "Not yet rated"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/persona_preview.html:78
+#: src/olympia/addons/templates/addons/persona_preview.html:79
 msgid "<b>{0}</b> users"
 msgstr ""
 
@@ -702,7 +703,7 @@ msgid "Learn more about Firefox"
 msgstr ""
 
 #: src/olympia/addons/templates/addons/popups.html:22
-msgid "or <b><a class=\"installer\" href=\"{url}\">download anyway</a></b>"
+msgid "or <b><a class=\"button installer\" href=\"{url}\">download anyway</a></b>"
 msgstr ""
 
 #: src/olympia/addons/templates/addons/popups.html:26
@@ -801,7 +802,7 @@ msgid ""
 msgstr ""
 
 #: src/olympia/addons/templates/addons/report_abuse.html:6 src/olympia/addons/templates/addons/report_abuse_full.html:10 src/olympia/addons/templates/addons/impala/details-more.html:23
-#: src/olympia/addons/templates/addons/impala/details.html:328
+#: src/olympia/addons/templates/addons/impala/details.html:333
 msgid "Report Abuse"
 msgstr ""
 
@@ -820,9 +821,9 @@ msgstr ""
 #: src/olympia/devhub/templates/devhub/addons/ajax_compat_update.html:36 src/olympia/devhub/templates/devhub/addons/profile.html:44 src/olympia/devhub/templates/devhub/addons/edit/admin.html:104
 #: src/olympia/devhub/templates/devhub/addons/edit/basic.html:155 src/olympia/devhub/templates/devhub/addons/edit/details.html:88 src/olympia/devhub/templates/devhub/addons/edit/support.html:70
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:169 src/olympia/devhub/templates/devhub/addons/forms_shared/media.html:152
-#: src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:44 src/olympia/devhub/templates/devhub/personas/edit.html:222 src/olympia/devhub/templates/devhub/versions/add_file_modal.html:79
-#: src/olympia/devhub/templates/devhub/versions/edit.html:140 src/olympia/devhub/templates/devhub/versions/list.html:208 src/olympia/devhub/templates/devhub/versions/list.html:242
-#: src/olympia/devhub/templates/devhub/versions/list.html:276 src/olympia/devhub/templates/devhub/versions/list.html:317 src/olympia/reviews/templates/reviews/edit_review.html:16
+#: src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:43 src/olympia/devhub/templates/devhub/personas/edit.html:222 src/olympia/devhub/templates/devhub/versions/add_file_modal.html:59
+#: src/olympia/devhub/templates/devhub/versions/edit.html:140 src/olympia/devhub/templates/devhub/versions/list.html:208 src/olympia/devhub/templates/devhub/versions/list.html:239
+#: src/olympia/devhub/templates/devhub/versions/list.html:281 src/olympia/devhub/templates/devhub/versions/list.html:315 src/olympia/reviews/templates/reviews/edit_review.html:16
 #: src/olympia/translations/templates/translations/trans-menu.html:50 src/olympia/translations/templates/translations/trans-menu.html:62 src/olympia/zadmin/templates/zadmin/validation.html:105
 msgid "Cancel"
 msgstr ""
@@ -867,7 +868,7 @@ msgstr ""
 msgid "Review Guidelines"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/review_list_box.html:5 src/olympia/addons/templates/addons/impala/details-more.html:27 src/olympia/editors/helpers.py:921
+#: src/olympia/addons/templates/addons/review_list_box.html:5 src/olympia/addons/templates/addons/impala/details-more.html:27 src/olympia/editors/helpers.py:1001
 #: src/olympia/reviews/templates/reviews/add.html:14 src/olympia/reviews/templates/reviews/reply.html:14 src/olympia/reviews/templates/reviews/review_list.html:19
 #: src/olympia/reviews/templates/reviews/mobile/review_list.html:26
 msgid "Reviews"
@@ -958,119 +959,119 @@ msgid_plural "Other add-ons by these authors"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/olympia/addons/templates/addons/impala/details.html:41
+#: src/olympia/addons/templates/addons/impala/details.html:39
 #, python-format
 msgid "<span itemprop=\"ratingCount\">%(num)s</span> user review"
 msgid_plural "<span itemprop=\"ratingCount\">%(num)s</span> user reviews"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/olympia/addons/templates/addons/impala/details.html:69
+#: src/olympia/addons/templates/addons/impala/details.html:66
 msgid "View statistics"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/impala/details.html:84
+#: src/olympia/addons/templates/addons/impala/details.html:81
 msgid "Manage"
 msgstr ""
 
 #. {0} is an add-on name.
-#: src/olympia/addons/templates/addons/impala/details.html:96
+#: src/olympia/addons/templates/addons/impala/details.html:93
 msgid "Icon of {0}"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/impala/details.html:103 src/olympia/addons/templates/addons/impala/listing/items.html:14
+#: src/olympia/addons/templates/addons/impala/details.html:100 src/olympia/addons/templates/addons/impala/listing/items.html:14
 msgid "No Restart"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/impala/details.html:127
+#: src/olympia/addons/templates/addons/impala/details.html:124
 #, python-format
 msgid "Meet the Developer: <a href=\"%(url)s\">%(name)s</a>"
 msgid_plural "<a href=\"%(url)s\">Meet the Developers</a>"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/olympia/addons/templates/addons/impala/details.html:137
+#: src/olympia/addons/templates/addons/impala/details.html:134
 msgid "Learn why {0} was created and find out what's next for this add-on."
 msgstr ""
 
 #. {0} is an index.
-#: src/olympia/addons/templates/addons/impala/details.html:156
+#: src/olympia/addons/templates/addons/impala/details.html:161
 msgid "Add-on screenshot #{0}"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/impala/details.html:182
+#: src/olympia/addons/templates/addons/impala/details.html:187
 msgid "Add-on home page"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/impala/details.html:185
+#: src/olympia/addons/templates/addons/impala/details.html:190
 msgid "Support site"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/impala/details.html:189
+#: src/olympia/addons/templates/addons/impala/details.html:194
 msgid "Support E-mail"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/impala/details.html:194 src/olympia/devhub/models.py:378 src/olympia/devhub/templates/devhub/versions/list.html:12
+#: src/olympia/addons/templates/addons/impala/details.html:199 src/olympia/devhub/models.py:378 src/olympia/devhub/templates/devhub/versions/list.html:12
 #: src/olympia/versions/templates/versions/version.html:6 src/olympia/versions/templates/versions/mobile/version.html:6
 msgid "Version {0}"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/impala/details.html:194
+#: src/olympia/addons/templates/addons/impala/details.html:199
 msgid "Info"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/impala/details.html:195 src/olympia/devhub/templates/devhub/includes/addon_details.html:129
+#: src/olympia/addons/templates/addons/impala/details.html:200 src/olympia/devhub/templates/devhub/includes/addon_details.html:116
 msgid "Last Updated:"
-msgstr ""
-
-#: src/olympia/addons/templates/addons/impala/details.html:200
-#, python-format
-msgid "Released under <a target=\"_blank\" href=\"%(url)s\">%(name)s</a>"
-msgstr ""
-
-#: src/olympia/addons/templates/addons/impala/details.html:201 src/olympia/addons/templates/addons/impala/details.html:206 src/olympia/amo/helpers.py:398 src/olympia/devhub/forms.py:142
-#: src/olympia/devhub/forms.py:173 src/olympia/versions/templates/versions/version.html:40 src/olympia/versions/templates/versions/version.html:45
-msgid "Custom License"
 msgstr ""
 
 #: src/olympia/addons/templates/addons/impala/details.html:205
 #, python-format
+msgid "Released under <a target=\"_blank\" href=\"%(url)s\">%(name)s</a>"
+msgstr ""
+
+#: src/olympia/addons/templates/addons/impala/details.html:206 src/olympia/addons/templates/addons/impala/details.html:211 src/olympia/amo/helpers.py:398 src/olympia/devhub/forms.py:142
+#: src/olympia/devhub/forms.py:173 src/olympia/versions/templates/versions/version.html:40 src/olympia/versions/templates/versions/version.html:45
+msgid "Custom License"
+msgstr ""
+
+#: src/olympia/addons/templates/addons/impala/details.html:210
+#, python-format
 msgid "Released under <a href=\"%(url)s\">%(name)s</a>"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/impala/details.html:217
+#: src/olympia/addons/templates/addons/impala/details.html:222
 msgid "About this Add-on"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/impala/details.html:233
+#: src/olympia/addons/templates/addons/impala/details.html:238
 msgid "Developer’s Comments"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/impala/details.html:243
+#: src/olympia/addons/templates/addons/impala/details.html:248
 msgid "Version Information"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/impala/details.html:250
+#: src/olympia/addons/templates/addons/impala/details.html:255
 msgid "See complete version history"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/impala/details.html:262
+#: src/olympia/addons/templates/addons/impala/details.html:267
 msgid ""
 "The Development Channel lets you test an experimental new version of this add-on before it's released to the general public. Once you install the development version, you will continue to get "
 "updates from this channel. To stop receiving development updates, reinstall the default version from the link above."
 msgstr ""
 
-#: src/olympia/addons/templates/addons/impala/details.html:272
+#: src/olympia/addons/templates/addons/impala/details.html:277
 msgid "<strong>Caution:</strong> Development versions of this add-on have not been reviewed by Mozilla."
 msgstr ""
 
-#: src/olympia/addons/templates/addons/impala/details.html:287
+#: src/olympia/addons/templates/addons/impala/details.html:292
 msgid "See complete development channel history"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/impala/details.html:306 src/olympia/addons/templates/addons/impala/details.html:315 src/olympia/addons/templates/addons/impala/details.html:327
+#: src/olympia/addons/templates/addons/impala/details.html:311 src/olympia/addons/templates/addons/impala/details.html:320 src/olympia/addons/templates/addons/impala/details.html:332
 #: src/olympia/addons/templates/addons/impala/review_add_box.html:4 src/olympia/stats/templates/stats/popup.html:2 src/olympia/stats/templates/stats/popup.html:8
-#: src/olympia/stats/templates/stats/stats.html:202 src/olympia/users/templates/users/profile.html:119
+#: src/olympia/stats/templates/stats/stats.html:204 src/olympia/users/templates/users/profile.html:119
 msgid "close"
 msgstr ""
 
@@ -1126,15 +1127,11 @@ msgstr ""
 msgid "Source Code License"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/impala/persona_grid.html:16 src/olympia/addons/templates/addons/impala/toplist.html:6
-msgid "{0} users"
-msgstr ""
-
 #: src/olympia/addons/templates/addons/impala/review_list_box.html:19 src/olympia/reviews/templates/reviews/review.html:40
 msgid "permalink"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/impala/review_list_box.html:23 src/olympia/editors/templates/editors/queue.html:98 src/olympia/reviews/templates/reviews/review.html:44
+#: src/olympia/addons/templates/addons/impala/review_list_box.html:23 src/olympia/editors/templates/editors/queue.html:104 src/olympia/reviews/templates/reviews/review.html:44
 msgid "translate"
 msgstr ""
 
@@ -1153,6 +1150,10 @@ msgstr ""
 msgid "Be the first!"
 msgstr ""
 
+#: src/olympia/addons/templates/addons/impala/toplist.html:6
+msgid "{0} users"
+msgstr ""
+
 #: src/olympia/addons/templates/addons/impala/listing/sorter.html:14 src/olympia/devhub/templates/devhub/addons/listing/item_actions.html:49
 msgid "More"
 msgstr ""
@@ -1165,7 +1166,7 @@ msgstr ""
 msgid "My Add-ons"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/includes/dashboard_tabs.html:6 src/olympia/amo/context_processors.py:51
+#: src/olympia/addons/templates/addons/includes/dashboard_tabs.html:6 src/olympia/amo/context_processors.py:50
 msgid "My Themes"
 msgstr ""
 
@@ -1220,7 +1221,7 @@ msgstr ""
 msgid "Weekly Downloads"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/mobile/details.html:99 src/olympia/compat/templates/compat/reporter_detail.html:46 src/olympia/devhub/forms.py:787
+#: src/olympia/addons/templates/addons/mobile/details.html:99 src/olympia/compat/templates/compat/reporter_detail.html:46 src/olympia/devhub/forms.py:788
 #: src/olympia/devhub/templates/devhub/versions/list.html:163
 msgid "Version"
 msgstr ""
@@ -1304,7 +1305,7 @@ msgstr ""
 #: src/olympia/browse/templates/browse/personas/category_landing.html:21 src/olympia/browse/templates/browse/personas/category_landing.html:23
 #: src/olympia/browse/templates/browse/personas/category_landing.html:38 src/olympia/browse/templates/browse/personas/grid.html:7 src/olympia/browse/templates/browse/personas/grid.html:11
 #: src/olympia/browse/templates/browse/personas/mobile/base.html:7 src/olympia/browse/templates/browse/personas/mobile/category_landing.html:19 src/olympia/constants/base.py:180
-#: src/olympia/devhub/templates/devhub/personas/submit.html:13 src/olympia/editors/helpers.py:105 src/olympia/editors/templates/editors/base.html:26
+#: src/olympia/devhub/templates/devhub/personas/submit.html:13 src/olympia/editors/helpers.py:107 src/olympia/editors/templates/editors/base.html:26
 #: src/olympia/editors/templates/editors/performance.html:73 src/olympia/search/templates/search/personas.html:39 src/olympia/templates/menu_links.html:9
 msgid "Themes"
 msgstr ""
@@ -1325,7 +1326,7 @@ msgstr ""
 msgid "Highest Rated"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/mobile/home.html:74 src/olympia/amo/templates/amo/side_nav.html:5 src/olympia/amo/templates/amo/site_nav.html:27 src/olympia/amo/templates/amo/site_nav.html:57
+#: src/olympia/addons/templates/addons/mobile/home.html:74 src/olympia/amo/templates/amo/side_nav.html:5 src/olympia/amo/templates/amo/site_nav.html:27 src/olympia/amo/templates/amo/site_nav.html:55
 #: src/olympia/bandwagon/views.py:97 src/olympia/browse/views.py:57 src/olympia/browse/views.py:67 src/olympia/browse/templates/browse/personas/mobile/category_landing.html:65
 #: src/olympia/search/forms.py:15 src/olympia/search/forms.py:87
 msgid "Newest"
@@ -1339,90 +1340,90 @@ msgstr ""
 msgid "Theme Info &raquo;"
 msgstr ""
 
-#: src/olympia/amo/context_processors.py:39 src/olympia/devhub/templates/devhub/nav.html:43
+#: src/olympia/amo/context_processors.py:37 src/olympia/devhub/templates/devhub/nav.html:43
 msgid "Tools"
 msgstr ""
 
-#: src/olympia/amo/context_processors.py:48 src/olympia/discovery/templates/discovery/pane_account.html:8 src/olympia/users/templates/users/includes/navigation.html:2
+#: src/olympia/amo/context_processors.py:47 src/olympia/discovery/templates/discovery/pane_account.html:8 src/olympia/users/templates/users/includes/navigation.html:2
 msgid "My Profile"
 msgstr ""
 
-#: src/olympia/amo/context_processors.py:54 src/olympia/users/templates/users/edit.html:5 src/olympia/users/templates/users/includes/navigation.html:3
+#: src/olympia/amo/context_processors.py:53 src/olympia/users/templates/users/edit.html:5 src/olympia/users/templates/users/includes/navigation.html:3
 msgid "Account Settings"
 msgstr ""
 
-#: src/olympia/amo/context_processors.py:57 src/olympia/discovery/templates/discovery/pane_account.html:11 src/olympia/users/templates/users/profile.html:83
+#: src/olympia/amo/context_processors.py:56 src/olympia/discovery/templates/discovery/pane_account.html:11 src/olympia/users/templates/users/profile.html:83
 #: src/olympia/users/templates/users/includes/navigation.html:4
 msgid "My Collections"
 msgstr ""
 
-#: src/olympia/amo/context_processors.py:62 src/olympia/discovery/templates/discovery/pane_account.html:10 src/olympia/users/templates/users/includes/navigation.html:7
+#: src/olympia/amo/context_processors.py:61 src/olympia/discovery/templates/discovery/pane_account.html:10 src/olympia/users/templates/users/includes/navigation.html:7
 msgid "My Favorites"
 msgstr ""
 
-#: src/olympia/amo/context_processors.py:67 src/olympia/discovery/templates/discovery/pane_account.html:13 src/olympia/templates/impala/user_login.html:14
+#: src/olympia/amo/context_processors.py:66 src/olympia/discovery/templates/discovery/pane_account.html:13 src/olympia/templates/impala/user_login.html:14
 #: src/olympia/templates/mobile/header_auth.html:5
 msgid "Log out"
 msgstr ""
 
-#: src/olympia/amo/context_processors.py:72 src/olympia/devhub/templates/devhub/addons/dashboard.html:4
+#: src/olympia/amo/context_processors.py:71 src/olympia/devhub/templates/devhub/addons/dashboard.html:4
 msgid "Manage My Submissions"
 msgstr ""
 
-#: src/olympia/amo/context_processors.py:75 src/olympia/devhub/templates/devhub/nav.html:27 src/olympia/devhub/templates/devhub/addons/dashboard.html:25
+#: src/olympia/amo/context_processors.py:74 src/olympia/devhub/templates/devhub/nav.html:27 src/olympia/devhub/templates/devhub/addons/dashboard.html:25
 #: src/olympia/devhub/templates/devhub/addons/submit/base.html:4
 msgid "Submit a New Add-on"
 msgstr ""
 
-#: src/olympia/amo/context_processors.py:77 src/olympia/browse/templates/browse/personas/base.html:50 src/olympia/devhub/templates/devhub/index.html:24
+#: src/olympia/amo/context_processors.py:76 src/olympia/browse/templates/browse/personas/base.html:50 src/olympia/devhub/templates/devhub/index.html:24
 #: src/olympia/devhub/templates/devhub/addons/dashboard.html:29
 msgid "Submit a New Theme"
 msgstr ""
 
-#: src/olympia/amo/context_processors.py:79 src/olympia/amo/templates/amo/site_nav.html:87 src/olympia/devhub/helpers.py:36 src/olympia/devhub/helpers.py:68 src/olympia/devhub/helpers.py:102
+#: src/olympia/amo/context_processors.py:78 src/olympia/amo/templates/amo/site_nav.html:85 src/olympia/devhub/helpers.py:36 src/olympia/devhub/helpers.py:68 src/olympia/devhub/helpers.py:102
 #: src/olympia/templates/footer.html:6 src/olympia/templates/menu_links.html:14
 msgid "Developer Hub"
 msgstr ""
 
-#: src/olympia/amo/context_processors.py:83 src/olympia/devhub/views.py:1792
+#: src/olympia/amo/context_processors.py:81 src/olympia/devhub/views.py:1796
 msgid "Manage API Keys"
 msgstr ""
 
-#: src/olympia/amo/context_processors.py:88 src/olympia/editors/helpers.py:82 src/olympia/editors/helpers.py:102 src/olympia/editors/templates/editors/base.html:10
+#: src/olympia/amo/context_processors.py:86 src/olympia/editors/helpers.py:84 src/olympia/editors/helpers.py:104 src/olympia/editors/templates/editors/base.html:10
 msgid "Editor Tools"
 msgstr ""
 
-#: src/olympia/amo/context_processors.py:92
+#: src/olympia/amo/context_processors.py:90
 msgid "Admin Tools"
 msgstr ""
 
-#: src/olympia/amo/fields.py:15
+#: src/olympia/amo/fields.py:20
 msgid "Incorrect, please try again."
 msgstr ""
 
-#: src/olympia/amo/fields.py:16
+#: src/olympia/amo/fields.py:21
 msgid "Error verifying input, please try again."
 msgstr ""
 
-#: src/olympia/amo/fields.py:32
+#: src/olympia/amo/fields.py:37
 msgid "This must be a valid hex color code, such as #000000."
 msgstr ""
 
-#: src/olympia/amo/fields.py:58
+#: src/olympia/amo/fields.py:63
 msgid "Enter at least one value."
 msgstr ""
 
-#: src/olympia/amo/helpers.py:162 src/olympia/amo/templates/amo/site_nav.html:61 src/olympia/bandwagon/templates/bandwagon/add.html:9
+#: src/olympia/amo/helpers.py:162 src/olympia/amo/templates/amo/site_nav.html:59 src/olympia/bandwagon/templates/bandwagon/add.html:9
 #: src/olympia/bandwagon/templates/bandwagon/collection_detail.html:15 src/olympia/bandwagon/templates/bandwagon/delete.html:9 src/olympia/bandwagon/templates/bandwagon/edit.html:15
 #: src/olympia/bandwagon/templates/bandwagon/user_listing.html:18 src/olympia/bandwagon/templates/bandwagon/user_listing.html:21
 #: src/olympia/bandwagon/templates/bandwagon/impala/collection_listing.html:12 src/olympia/bandwagon/templates/bandwagon/impala/collection_listing.html:20
 #: src/olympia/bandwagon/templates/bandwagon/impala/collection_listing.html:24 src/olympia/bandwagon/templates/bandwagon/impala/collection_sidebar.html:3
 #: src/olympia/bandwagon/templates/bandwagon/includes/collection_sidebar.html:2 src/olympia/bandwagon/templates/bandwagon/mobile/collection_listing.html:3
-#: src/olympia/stats/templates/stats/stats.html:77 src/olympia/templates/menu_links.html:12
+#: src/olympia/stats/templates/stats/stats.html:33 src/olympia/templates/menu_links.html:12
 msgid "Collections"
 msgstr ""
 
-#: src/olympia/amo/helpers.py:171 src/olympia/amo/templates/amo/site_nav.html:85 src/olympia/browse/templates/browse/language_tools.html:3
+#: src/olympia/amo/helpers.py:171 src/olympia/amo/templates/amo/site_nav.html:83 src/olympia/browse/templates/browse/language_tools.html:3
 msgid "Dictionaries & Language Packs"
 msgstr ""
 
@@ -1574,8 +1575,8 @@ msgstr ""
 msgid "Comment on {addon} {version}."
 msgstr ""
 
-#: src/olympia/amo/log.py:236 src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:19 src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:47
-#: src/olympia/editors/helpers.py:511 src/olympia/editors/templates/editors/themes/history_table.html:11
+#: src/olympia/amo/log.py:236 src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:17 src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:45
+#: src/olympia/editors/helpers.py:584 src/olympia/editors/templates/editors/themes/history_table.html:11
 msgid "Comment"
 msgstr ""
 
@@ -1898,7 +1899,7 @@ msgstr ""
 #: src/olympia/amo/templates/amo/mobile/paginator.html:14 src/olympia/amo/templates/amo/mobile/paginator.html:16 src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:51
 #: src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:65 src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:78
 #: src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:91 src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:104
-#: src/olympia/discovery/templates/discovery/pane.html:45 src/olympia/discovery/templates/discovery/addons/detail.html:39 src/olympia/stats/templates/stats/stats.html:167
+#: src/olympia/discovery/templates/discovery/pane.html:45 src/olympia/discovery/templates/discovery/addons/detail.html:39 src/olympia/stats/templates/stats/stats.html:169
 msgid "Next"
 msgstr ""
 
@@ -1930,7 +1931,7 @@ msgid ""
 msgstr ""
 
 #: src/olympia/amo/templates/amo/side_nav.html:4 src/olympia/amo/templates/amo/side_nav.html:12 src/olympia/amo/templates/amo/site_nav.html:4 src/olympia/amo/templates/amo/site_nav.html:26
-#: src/olympia/browse/views.py:56 src/olympia/browse/views.py:66 src/olympia/browse/views.py:237 src/olympia/browse/views.py:282 src/olympia/search/forms.py:86
+#: src/olympia/browse/views.py:56 src/olympia/browse/views.py:66 src/olympia/browse/views.py:204 src/olympia/browse/views.py:249 src/olympia/search/forms.py:86
 msgid "Top Rated"
 msgstr ""
 
@@ -1944,38 +1945,38 @@ msgstr ""
 msgid "Extensions"
 msgstr ""
 
-#: src/olympia/amo/templates/amo/site_nav.html:45
+#: src/olympia/amo/templates/amo/site_nav.html:44
 msgid "Want more customization? Try <b>Complete Themes</b>"
 msgstr ""
 
-#: src/olympia/amo/templates/amo/site_nav.html:56 src/olympia/bandwagon/views.py:96
+#: src/olympia/amo/templates/amo/site_nav.html:54 src/olympia/bandwagon/views.py:96
 msgid "Most Followers"
 msgstr ""
 
-#: src/olympia/amo/templates/amo/site_nav.html:68 src/olympia/bandwagon/templates/bandwagon/impala/collection_sidebar.html:16
+#: src/olympia/amo/templates/amo/site_nav.html:66 src/olympia/bandwagon/templates/bandwagon/impala/collection_sidebar.html:16
 #: src/olympia/bandwagon/templates/bandwagon/includes/collection_sidebar.html:18
 msgid "Collections I've Made"
 msgstr ""
 
-#: src/olympia/amo/templates/amo/site_nav.html:70 src/olympia/bandwagon/templates/bandwagon/user_listing.html:4 src/olympia/bandwagon/templates/bandwagon/impala/collection_sidebar.html:13
+#: src/olympia/amo/templates/amo/site_nav.html:68 src/olympia/bandwagon/templates/bandwagon/user_listing.html:4 src/olympia/bandwagon/templates/bandwagon/impala/collection_sidebar.html:13
 #: src/olympia/bandwagon/templates/bandwagon/includes/collection_sidebar.html:15
 msgid "Collections I'm Following"
 msgstr ""
 
-#: src/olympia/amo/templates/amo/site_nav.html:73 src/olympia/bandwagon/templates/bandwagon/impala/collection_sidebar.html:18
-#: src/olympia/bandwagon/templates/bandwagon/includes/collection_sidebar.html:20 src/olympia/users/models.py:512
+#: src/olympia/amo/templates/amo/site_nav.html:71 src/olympia/bandwagon/templates/bandwagon/impala/collection_sidebar.html:18
+#: src/olympia/bandwagon/templates/bandwagon/includes/collection_sidebar.html:20 src/olympia/users/models.py:521
 msgid "My Favorite Add-ons"
 msgstr ""
 
-#: src/olympia/amo/templates/amo/site_nav.html:78
+#: src/olympia/amo/templates/amo/site_nav.html:76
 msgid "More&hellip;"
 msgstr ""
 
-#: src/olympia/amo/templates/amo/site_nav.html:82
+#: src/olympia/amo/templates/amo/site_nav.html:80
 msgid "Add-ons for Mobile"
 msgstr ""
 
-#: src/olympia/amo/templates/amo/site_nav.html:86 src/olympia/browse/feeds.py:207 src/olympia/browse/templates/browse/search_tools.html:3 src/olympia/constants/base.py:176
+#: src/olympia/amo/templates/amo/site_nav.html:84 src/olympia/browse/feeds.py:207 src/olympia/browse/templates/browse/search_tools.html:3 src/olympia/constants/base.py:176
 #: src/olympia/templates/menu_links.html:10
 msgid "Search Tools"
 msgstr ""
@@ -1991,7 +1992,7 @@ msgid "Jump to first page"
 msgstr ""
 
 #: src/olympia/amo/templates/amo/impala/paginator.html:22 src/olympia/amo/templates/amo/mobile/impala_paginator.html:12 src/olympia/discovery/templates/discovery/pane.html:44
-#: src/olympia/discovery/templates/discovery/addons/detail.html:38 src/olympia/stats/templates/stats/stats.html:164
+#: src/olympia/discovery/templates/discovery/addons/detail.html:38 src/olympia/stats/templates/stats/stats.html:166
 msgid "Previous"
 msgstr ""
 
@@ -2014,30 +2015,49 @@ msgid_plural "Page {n}"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/olympia/amo/templates/services/install.html:38
-#, python-format
-msgid "If you are not prompted to install %(addon_name)s in a moment, please <a href=\"%(addon_xpi)s\">click here</a>."
-msgstr ""
-
-#: src/olympia/amo/tests/test_messages.py:57 src/olympia/amo/tests/test_messages.py:58 src/olympia/reviews/forms.py:25 src/olympia/reviews/forms.py:50 src/olympia/reviews/templates/reviews/add.html:56
+#: src/olympia/amo/tests/test_messages.py:56 src/olympia/amo/tests/test_messages.py:57 src/olympia/reviews/forms.py:25 src/olympia/reviews/forms.py:50 src/olympia/reviews/templates/reviews/add.html:56
 #: src/olympia/reviews/templates/reviews/reply.html:30
 msgid "Title"
 msgstr ""
 
-#: src/olympia/amo/tests/test_messages.py:57 src/olympia/amo/tests/test_messages.py:58
+#: src/olympia/amo/tests/test_messages.py:56 src/olympia/amo/tests/test_messages.py:57
 msgid "Body"
 msgstr ""
 
-#: src/olympia/amo/tests/test_messages.py:59
+#: src/olympia/amo/tests/test_messages.py:58
 msgid "Another Title"
 msgstr ""
 
-#: src/olympia/amo/tests/test_messages.py:59
+#: src/olympia/amo/tests/test_messages.py:58
 msgid "Another Body"
 msgstr ""
 
-#: src/olympia/api/views.py:255
-msgid "Not implemented yet."
+#: src/olympia/api/authentication.py:76
+msgid "Signature has expired."
+msgstr ""
+
+#: src/olympia/api/authentication.py:79
+msgid "Error decoding signature."
+msgstr ""
+
+#: src/olympia/api/authentication.py:82
+msgid "Invalid JWT Token."
+msgstr ""
+
+#: src/olympia/api/authentication.py:130
+msgid "Invalid Authorization header. No credentials provided."
+msgstr ""
+
+#: src/olympia/api/authentication.py:133
+msgid "Invalid Authorization header. Credentials string should not contain spaces."
+msgstr ""
+
+#: src/olympia/api/fields.py:29
+msgid "The field must have a length of at least {num} characters."
+msgstr ""
+
+#: src/olympia/api/fields.py:31
+msgid "The language code {lang_code} is invalid."
 msgstr ""
 
 #: src/olympia/applications/views.py:39 src/olympia/applications/templates/applications/appversions.html:3
@@ -2056,7 +2076,7 @@ msgstr ""
 msgid "Add-ons submitted to Mozilla Add-ons must have a manifest file with at least one of the below applications supported. Only the versions listed below are allowed for these applications."
 msgstr ""
 
-#: src/olympia/applications/templates/applications/appversions.html:25
+#: src/olympia/applications/templates/applications/appversions.html:25 src/olympia/editors/helpers.py:361
 msgid "GUID"
 msgstr ""
 
@@ -2170,8 +2190,8 @@ msgstr ""
 msgid "Remove from favorites"
 msgstr ""
 
-#: src/olympia/bandwagon/views.py:98 src/olympia/bandwagon/views.py:191 src/olympia/browse/views.py:58 src/olympia/browse/views.py:69 src/olympia/browse/views.py:458 src/olympia/devhub/views.py:74
-#: src/olympia/devhub/views.py:82 src/olympia/devhub/templates/devhub/addons/edit/basic.html:20 src/olympia/editors/templates/editors/leaderboard.html:24
+#: src/olympia/bandwagon/views.py:98 src/olympia/bandwagon/views.py:191 src/olympia/browse/views.py:58 src/olympia/browse/views.py:69 src/olympia/browse/views.py:425 src/olympia/devhub/views.py:72
+#: src/olympia/devhub/views.py:80 src/olympia/devhub/templates/devhub/addons/edit/basic.html:20 src/olympia/editors/templates/editors/leaderboard.html:24
 #: src/olympia/editors/templates/editors/themes/queue_list.html:48 src/olympia/search/forms.py:17 src/olympia/search/forms.py:89 src/olympia/users/templates/users/vcard.html:5
 msgid "Name"
 msgstr ""
@@ -2180,7 +2200,7 @@ msgstr ""
 msgid "Recently Popular"
 msgstr ""
 
-#: src/olympia/bandwagon/views.py:189 src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:18
+#: src/olympia/bandwagon/views.py:189 src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:16
 msgid "Added"
 msgstr ""
 
@@ -2194,7 +2214,7 @@ msgstr ""
 
 #: src/olympia/bandwagon/views.py:316
 #, python-format
-msgid "Your new collection is shown below. You can <ahref=\"%(url)s\">edit additional settings</a> if you'dlike."
+msgid "Your new collection is shown below. You can <a href=\"%(url)s\">edit additional settings</a> if you'd like."
 msgstr ""
 
 #: src/olympia/bandwagon/views.py:322
@@ -2322,8 +2342,8 @@ msgid_plural "%(num)s Add-ons in this Collection"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/olympia/bandwagon/templates/bandwagon/collection_detail.html:125 src/olympia/compat/templates/compat/index.html:25 src/olympia/compat/templates/compat/reporter_detail.html:29
-#: src/olympia/files/templates/files/viewer.html:29 src/olympia/templates/amo_footer.html:17 src/olympia/templates/includes/lang_switcher.html:10
+#: src/olympia/bandwagon/templates/bandwagon/collection_detail.html:125 src/olympia/compat/templates/compat/reporter_detail.html:29 src/olympia/files/templates/files/viewer.html:29
+#: src/olympia/templates/amo_footer.html:17 src/olympia/templates/includes/lang_switcher.html:10
 msgid "Go"
 msgstr ""
 
@@ -2490,7 +2510,7 @@ msgid "Remove this user as a contributor"
 msgstr ""
 
 #: src/olympia/bandwagon/templates/bandwagon/edit_contributors.html:18 src/olympia/bandwagon/templates/bandwagon/edit_contributors.html:43
-#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:20 src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:48
+#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:18 src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:46
 #: src/olympia/devhub/templates/devhub/addons/ajax_compat_update.html:19
 msgid "Remove"
 msgstr ""
@@ -2538,7 +2558,7 @@ msgid "<b>Warning:</b> By changing the owner of this collection, you will no lon
 msgstr ""
 
 #: src/olympia/bandwagon/templates/bandwagon/edit_contributors.html:83 src/olympia/devhub/templates/devhub/addons/forms_shared/media.html:157
-#: src/olympia/devhub/templates/devhub/addons/submit/describe.html:69 src/olympia/devhub/templates/devhub/addons/submit/license.html:60 src/olympia/devhub/templates/devhub/addons/submit/upload.html:78
+#: src/olympia/devhub/templates/devhub/addons/submit/describe.html:69 src/olympia/devhub/templates/devhub/addons/submit/license.html:60 src/olympia/devhub/templates/devhub/addons/submit/upload.html:70
 #: src/olympia/devhub/templates/devhub/payments/tier.html:17 src/olympia/editors/templates/editors/themes/themes.html:111 src/olympia/editors/templates/editors/themes/themes.html:128
 #: src/olympia/editors/templates/editors/themes/themes.html:134 src/olympia/editors/templates/editors/themes/themes.html:141 src/olympia/users/templates/users/fxa_migration_prompt_content.html:10
 #: src/olympia/users/templates/users/login_form.html:42 src/olympia/users/templates/users/mobile/login.html:57
@@ -2621,31 +2641,31 @@ msgid "Add-ons in Your Collection"
 msgstr ""
 
 #: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:4
-msgid ""
-"To include an add-on in this collection, enter its name in the box below and hit enter.  You can also use the <strong>Add to Collection</strong> links throughout the site to include add-ons later."
+msgid "To include an add-on in this collection, enter its name in the box below and hit enter."
 msgstr ""
 
-#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:17 src/olympia/constants/base.py:400 src/olympia/devhub/templates/devhub/addons/activity.html:62
+#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:15 src/olympia/constants/base.py:400 src/olympia/devhub/templates/devhub/addons/activity.html:62
+#: src/olympia/editors/helpers.py:273 src/olympia/editors/helpers.py:360
 msgid "Add-on"
 msgstr ""
 
-#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:26
+#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:24
 msgid "Enter the name of the add-on to include"
 msgstr ""
 
-#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:28
+#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:26
 msgid "Add to Collection"
 msgstr ""
 
-#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:45 src/olympia/editors/helpers.py:936 src/olympia/editors/helpers.py:956
+#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:43 src/olympia/editors/helpers.py:1016 src/olympia/editors/helpers.py:1036
 msgid "Pending"
 msgstr ""
 
-#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:47
+#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:45
 msgid "Add a comment"
 msgstr ""
 
-#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:48
+#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:46
 msgid "Remove this add-on from the collection"
 msgstr ""
 
@@ -2752,12 +2772,12 @@ msgstr ""
 msgid "Most Users"
 msgstr ""
 
-#: src/olympia/browse/views.py:61 src/olympia/browse/views.py:72 src/olympia/browse/views.py:279 src/olympia/browse/templates/browse/personas/mobile/category_landing.html:63
+#: src/olympia/browse/views.py:61 src/olympia/browse/views.py:72 src/olympia/browse/views.py:246 src/olympia/browse/templates/browse/personas/mobile/category_landing.html:63
 #: src/olympia/discovery/templates/discovery/pane.html:67 src/olympia/search/forms.py:92
 msgid "Up & Coming"
 msgstr ""
 
-#: src/olympia/browse/views.py:460 src/olympia/devhub/views.py:76 src/olympia/devhub/views.py:83 src/olympia/discovery/templates/discovery/addons/detail.html:66
+#: src/olympia/browse/views.py:427 src/olympia/devhub/views.py:74 src/olympia/devhub/views.py:81 src/olympia/discovery/templates/discovery/addons/detail.html:66
 msgid "Created"
 msgstr ""
 
@@ -2945,8 +2965,8 @@ msgid_plural "See all %(cnt)s extensions in %(name)s &raquo;"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/olympia/browse/templates/browse/mobile/extensions.html:13 src/olympia/compat/templates/compat/index.html:82 src/olympia/devhub/templates/devhub/devhub_search.html:24
-#: src/olympia/devhub/templates/devhub/addons/activity.html:47 src/olympia/search/templates/search/no_results.html:4 src/olympia/search/templates/search/mobile/results.html:36
+#: src/olympia/browse/templates/browse/mobile/extensions.html:13 src/olympia/devhub/templates/devhub/devhub_search.html:24 src/olympia/devhub/templates/devhub/addons/activity.html:47
+#: src/olympia/search/templates/search/no_results.html:4 src/olympia/search/templates/search/mobile/results.html:36
 msgid "No results found."
 msgstr ""
 
@@ -3031,7 +3051,7 @@ msgstr ""
 msgid "All"
 msgstr ""
 
-#: src/olympia/compat/forms.py:22 src/olympia/search/views.py:525
+#: src/olympia/compat/forms.py:22 src/olympia/editors/templates/editors/base.html:69 src/olympia/search/views.py:518
 msgid "All Add-ons"
 msgstr ""
 
@@ -3041,53 +3061,6 @@ msgstr ""
 
 #: src/olympia/compat/forms.py:24
 msgid "Non-binary"
-msgstr ""
-
-#. Review points sources other than add-ons and themes.
-#: src/olympia/compat/views.py:87 src/olympia/constants/base.py:388 src/olympia/devhub/forms.py:162 src/olympia/editors/templates/editors/performance.html:75
-msgid "Other"
-msgstr ""
-
-#: src/olympia/compat/templates/compat/index.html:4
-msgid "Add-on Compatibility Report for {app} {version}"
-msgstr ""
-
-#: src/olympia/compat/templates/compat/index.html:11
-msgid "{app} {version} Compatibility"
-msgstr ""
-
-#: src/olympia/compat/templates/compat/index.html:17
-#, python-format
-msgid "Top 95%% compatible with previous version"
-msgstr ""
-
-#: src/olympia/compat/templates/compat/index.html:18
-#, python-format
-msgid "Top 95%% of all add-ons"
-msgstr ""
-
-#: src/olympia/compat/templates/compat/index.html:19
-msgid "All active add-ons"
-msgstr ""
-
-#: src/olympia/compat/templates/compat/index.html:23 src/olympia/constants/base.py:401
-msgid "App"
-msgstr ""
-
-#: src/olympia/compat/templates/compat/index.html:55
-msgid "Details for add-ons compatible with previous version:"
-msgstr ""
-
-#: src/olympia/compat/templates/compat/index.html:57
-msgid "Show all versions"
-msgstr ""
-
-#: src/olympia/compat/templates/compat/index.html:59
-msgid "Details for add-ons compatible with all versions:"
-msgstr ""
-
-#: src/olympia/compat/templates/compat/index.html:61
-msgid "Show previous version only"
 msgstr ""
 
 #: src/olympia/compat/templates/compat/reporter.html:3
@@ -3141,8 +3114,8 @@ msgstr ""
 msgid "Report Type"
 msgstr ""
 
-#: src/olympia/compat/templates/compat/reporter_detail.html:47 src/olympia/devhub/forms.py:784 src/olympia/devhub/templates/devhub/addons/ajax_compat_update.html:17 src/olympia/editors/forms.py:108
-#: src/olympia/zadmin/forms.py:45
+#: src/olympia/compat/templates/compat/reporter_detail.html:47 src/olympia/devhub/forms.py:785 src/olympia/devhub/templates/devhub/addons/ajax_compat_update.html:17 src/olympia/editors/forms.py:108
+#: src/olympia/editors/forms.py:248 src/olympia/zadmin/forms.py:45
 msgid "Application"
 msgstr ""
 
@@ -3230,7 +3203,8 @@ msgstr ""
 msgid "Preliminarily Reviewed and Awaiting Full Review"
 msgstr ""
 
-#: src/olympia/constants/base.py:33 src/olympia/editors/helpers.py:924 src/olympia/editors/templates/editors/themes/history_table.html:34
+#: src/olympia/constants/base.py:33 src/olympia/editors/forms.py:258 src/olympia/editors/helpers.py:73 src/olympia/editors/helpers.py:1004
+#: src/olympia/editors/templates/editors/themes/history_table.html:34
 msgid "Deleted"
 msgstr ""
 
@@ -3327,6 +3301,11 @@ msgstr ""
 msgid "Ask before users can download this add-on"
 msgstr ""
 
+#. Review points sources other than add-ons and themes.
+#: src/olympia/constants/base.py:388 src/olympia/devhub/forms.py:162 src/olympia/editors/templates/editors/performance.html:75
+msgid "Other"
+msgstr ""
+
 #: src/olympia/constants/base.py:389
 msgid "Exception"
 msgstr ""
@@ -3337,6 +3316,10 @@ msgstr ""
 
 #: src/olympia/constants/base.py:391
 msgid "Change"
+msgstr ""
+
+#: src/olympia/constants/base.py:401
+msgid "App"
 msgstr ""
 
 #: src/olympia/constants/base.py:402
@@ -3487,7 +3470,7 @@ msgstr ""
 msgid "Duplicate"
 msgstr ""
 
-#: src/olympia/constants/editors.py:17 src/olympia/editors/helpers.py:502 src/olympia/editors/templates/editors/themes/queue.html:71 src/olympia/editors/templates/editors/themes/themes.html:94
+#: src/olympia/constants/editors.py:17 src/olympia/editors/helpers.py:575 src/olympia/editors/templates/editors/themes/queue.html:71 src/olympia/editors/templates/editors/themes/themes.html:94
 msgid "Reject"
 msgstr ""
 
@@ -3587,7 +3570,7 @@ msgstr ""
 msgid "Android"
 msgstr ""
 
-#: src/olympia/core/apps.py:19
+#: src/olympia/core/apps.py:21
 msgid "Core"
 msgstr ""
 
@@ -3721,7 +3704,7 @@ msgid "Submit my add-on for manual review."
 msgstr ""
 
 #: src/olympia/devhub/forms.py:537
-msgid "Do not list my add-on on this site (beta)"
+msgid "Do not list my add-on on this site"
 msgstr ""
 
 #: src/olympia/devhub/forms.py:538
@@ -3754,46 +3737,46 @@ msgstr ""
 
 #: src/olympia/devhub/forms.py:592
 #, python-format
-msgid "Version %s already exists"
+msgid "Version %s already exists, or was uploaded before."
 msgstr ""
 
-#: src/olympia/devhub/forms.py:604
+#: src/olympia/devhub/forms.py:605
 msgid "Select a valid choice. That choice is not one of the available choices."
 msgstr ""
 
-#: src/olympia/devhub/forms.py:610
+#: src/olympia/devhub/forms.py:611
 msgid "A file with a version ending with a|alpha|b|beta and an optional number is detected as beta."
 msgstr ""
 
-#: src/olympia/devhub/forms.py:633
+#: src/olympia/devhub/forms.py:634
 msgid "You cannot upload any more files for this version."
 msgstr ""
 
-#: src/olympia/devhub/forms.py:639
+#: src/olympia/devhub/forms.py:640
 msgid "Version doesn't match"
 msgstr ""
 
-#: src/olympia/devhub/forms.py:668
+#: src/olympia/devhub/forms.py:669
 msgid "You cannot delete a file once the review process has started.  You must delete the whole version."
 msgstr ""
 
-#: src/olympia/devhub/forms.py:688
+#: src/olympia/devhub/forms.py:689
 msgid "The platform All cannot be combined with specific platforms."
 msgstr ""
 
-#: src/olympia/devhub/forms.py:693
+#: src/olympia/devhub/forms.py:694
 msgid "A platform can only be chosen once."
 msgstr ""
 
-#: src/olympia/devhub/forms.py:706
+#: src/olympia/devhub/forms.py:707
 msgid "A review type must be selected."
 msgstr ""
 
-#: src/olympia/devhub/forms.py:788 src/olympia/editors/forms.py:114 src/olympia/zadmin/forms.py:49 src/olympia/zadmin/forms.py:52
+#: src/olympia/devhub/forms.py:789 src/olympia/editors/forms.py:114 src/olympia/editors/forms.py:254 src/olympia/zadmin/forms.py:49 src/olympia/zadmin/forms.py:52
 msgid "Select an application first"
 msgstr ""
 
-#: src/olympia/devhub/forms.py:840
+#: src/olympia/devhub/forms.py:841
 msgid "There cannot be more than 3 required add-ons."
 msgstr ""
 
@@ -3827,76 +3810,76 @@ msgstr[1] ""
 msgid "Review"
 msgstr ""
 
-#: src/olympia/devhub/tasks.py:551
+#: src/olympia/devhub/tasks.py:583
 #, python-format
 msgid "%s responded with %s (%s)."
 msgstr ""
 
-#: src/olympia/devhub/tasks.py:555
+#: src/olympia/devhub/tasks.py:587
 #, python-format
 msgid "Connection to \"%s\" timed out."
 msgstr ""
 
-#: src/olympia/devhub/tasks.py:557
+#: src/olympia/devhub/tasks.py:589
 #, python-format
 msgid "Could not contact host at \"%s\"."
 msgstr ""
 
-#: src/olympia/devhub/utils.py:104
+#: src/olympia/devhub/utils.py:105
 #, python-format
 msgid "Validation generated too many errors/warnings so %s messages were truncated. After addressing the visible messages, you'll be able to see the others."
 msgstr ""
 
-#: src/olympia/devhub/views.py:183
+#: src/olympia/devhub/views.py:181
 msgid "All My Add-ons"
 msgstr ""
 
-#: src/olympia/devhub/views.py:210
+#: src/olympia/devhub/views.py:208
 msgid "All Activity"
 msgstr ""
 
-#: src/olympia/devhub/views.py:211
+#: src/olympia/devhub/views.py:209
 msgid "Add-on Updates"
 msgstr ""
 
-#: src/olympia/devhub/views.py:212
+#: src/olympia/devhub/views.py:210
 msgid "Add-on Status"
 msgstr ""
 
-#: src/olympia/devhub/views.py:213
+#: src/olympia/devhub/views.py:211
 msgid "User Collections"
 msgstr ""
 
-#: src/olympia/devhub/views.py:214 src/olympia/devhub/templates/devhub/docs/policies-maintenance.html:68 src/olympia/pages/templates/pages/dev_faq.html:38
+#: src/olympia/devhub/views.py:212 src/olympia/devhub/templates/devhub/docs/policies-maintenance.html:68 src/olympia/pages/templates/pages/dev_faq.html:38
 #: src/olympia/pages/templates/pages/dev_faq.html:484
 msgid "User Reviews"
 msgstr ""
 
-#: src/olympia/devhub/views.py:327 src/olympia/devhub/views.py:331 src/olympia/devhub/views.py:484 src/olympia/devhub/views.py:513 src/olympia/devhub/views.py:564 src/olympia/devhub/views.py:1150
+#: src/olympia/devhub/views.py:325 src/olympia/devhub/views.py:329 src/olympia/devhub/views.py:484 src/olympia/devhub/views.py:513 src/olympia/devhub/views.py:564 src/olympia/devhub/views.py:1156
 msgid "Changes successfully saved."
 msgstr ""
 
-#: src/olympia/devhub/views.py:334 src/olympia/devhub/views.py:1631
+#: src/olympia/devhub/views.py:332 src/olympia/devhub/views.py:1637
 msgid "Please check the form for errors."
 msgstr ""
 
-#: src/olympia/devhub/views.py:346
+#: src/olympia/devhub/views.py:344
 msgid "Add-on cannot be deleted. Disable this add-on instead."
 msgstr ""
 
-#: src/olympia/devhub/views.py:356
+#: src/olympia/devhub/views.py:354
 msgid "Theme deleted."
 msgstr ""
 
-#: src/olympia/devhub/views.py:356
+#: src/olympia/devhub/views.py:354
 msgid "Add-on deleted."
 msgstr ""
 
-#: src/olympia/devhub/views.py:362
+#: src/olympia/devhub/views.py:360
 msgid "URL name was incorrect. Theme was not deleted."
 msgstr ""
 
-#: src/olympia/devhub/views.py:367
+#: src/olympia/devhub/views.py:365
 msgid "URL name was incorrect. Add-on was not deleted."
 msgstr ""
 
@@ -3924,7 +3907,7 @@ msgstr ""
 msgid "Check Add-on Compatibility"
 msgstr ""
 
-#: src/olympia/devhub/views.py:808 src/olympia/signing/views.py:90
+#: src/olympia/devhub/views.py:808 src/olympia/signing/views.py:95
 msgid "You cannot submit this type of add-on"
 msgstr ""
 
@@ -3954,33 +3937,33 @@ msgstr ""
 msgid "There was an error uploading your preview."
 msgstr ""
 
-#: src/olympia/devhub/views.py:1189
+#: src/olympia/devhub/views.py:1195
 #, python-format
 msgid "Version %s disabled."
 msgstr ""
 
-#: src/olympia/devhub/views.py:1193
+#: src/olympia/devhub/views.py:1199
 #, python-format
 msgid "Version %s deleted."
 msgstr ""
 
-#: src/olympia/devhub/views.py:1203
+#: src/olympia/devhub/views.py:1209
 msgid "This upload has failed validation, and may lack complete validation results. Please take due care when reviewing it."
 msgstr ""
 
-#: src/olympia/devhub/views.py:1677
+#: src/olympia/devhub/views.py:1683
 msgid "Preliminary Review Requested."
 msgstr ""
 
-#: src/olympia/devhub/views.py:1678
+#: src/olympia/devhub/views.py:1684
 msgid "Full Review Requested."
 msgstr ""
 
-#: src/olympia/devhub/views.py:1779
+#: src/olympia/devhub/views.py:1783
 msgid "Your old credentials were revoked and are no longer valid. Be sure to update all API clients with the new credentials."
 msgstr ""
 
-#: src/olympia/devhub/views.py:1797
+#: src/olympia/devhub/views.py:1801
 msgid "New API key created"
 msgstr ""
 
@@ -4010,7 +3993,7 @@ msgstr ""
 msgid "{0} :: Search"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/devhub_search.html:6 src/olympia/devhub/templates/devhub/search.html:8 src/olympia/editors/forms.py:435 src/olympia/editors/forms.py:437
+#: src/olympia/devhub/templates/devhub/devhub_search.html:6 src/olympia/devhub/templates/devhub/search.html:8 src/olympia/editors/forms.py:534 src/olympia/editors/forms.py:536
 #: src/olympia/editors/templates/editors/queue.html:27 src/olympia/editors/templates/editors/themes/queue_list.html:14 src/olympia/search/templates/search/collections.html:17
 #: src/olympia/search/templates/search/personas.html:18 src/olympia/search/templates/search/results.html:18 src/olympia/search/templates/search/mobile/results.html:8
 #: src/olympia/templates/search.html:14 src/olympia/templates/impala/search.html:18
@@ -4070,12 +4053,12 @@ msgstr ""
 msgid "Start Making Add-ons"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/index.html:86 src/olympia/devhub/templates/devhub/addons/listing/items.html:25 src/olympia/devhub/templates/devhub/includes/addon_details.html:15
+#: src/olympia/devhub/templates/devhub/index.html:86 src/olympia/devhub/templates/devhub/addons/listing/items.html:25 src/olympia/devhub/templates/devhub/includes/addon_details.html:20
 #: src/olympia/devhub/templates/devhub/personas/edit.html:43
 msgid "Status:"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/index.html:90 src/olympia/devhub/templates/devhub/includes/addon_details.html:100
+#: src/olympia/devhub/templates/devhub/index.html:90 src/olympia/devhub/templates/devhub/includes/addon_details.html:87
 msgid "Visibility:"
 msgstr ""
 
@@ -4083,11 +4066,11 @@ msgstr ""
 msgid "Latest Version:"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/index.html:109 src/olympia/devhub/templates/devhub/includes/addon_details.html:145 src/olympia/devhub/templates/devhub/personas/edit.html:49
+#: src/olympia/devhub/templates/devhub/index.html:109 src/olympia/devhub/templates/devhub/includes/addon_details.html:131 src/olympia/devhub/templates/devhub/personas/edit.html:49
 msgid "Queue Position:"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/index.html:110 src/olympia/devhub/templates/devhub/includes/addon_details.html:146 src/olympia/devhub/templates/devhub/personas/edit.html:50
+#: src/olympia/devhub/templates/devhub/index.html:110 src/olympia/devhub/templates/devhub/includes/addon_details.html:132 src/olympia/devhub/templates/devhub/personas/edit.html:50
 #, python-format
 msgid "%(position)s of %(total)s"
 msgstr ""
@@ -4189,16 +4172,6 @@ msgstr ""
 msgid "Do you want your add-on to be distributed on this site?"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/validate_addon.html:49 src/olympia/devhub/templates/devhub/addons/submit/upload.html:30 src/olympia/devhub/templates/devhub/versions/add_file_modal.html:14
-#: src/olympia/devhub/templates/devhub/versions/add_file_modal.html:53 src/olympia/devhub/templates/devhub/versions/list.html:298
-msgid "Warning:"
-msgstr ""
-
-#: src/olympia/devhub/templates/devhub/validate_addon.html:50 src/olympia/devhub/templates/devhub/addons/submit/upload.html:31
-#, python-format
-msgid "Submission of unlisted add-ons for signing is currently in an open beta. Please <a href=\"%(url)s\" target=\"_blank\">report any bugs</a> that you encounter."
-msgstr ""
-
 #. first parameter is a filename like lorem-ipsum-1.0.2.xpi
 #: src/olympia/devhub/templates/devhub/validation.html:5
 msgid "Validation Results for {0}"
@@ -4273,7 +4246,7 @@ msgstr ""
 msgid "Update Compatibility"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/addons/ajax_compat_update.html:4
+#: src/olympia/devhub/templates/devhub/addons/ajax_compat_update.html:4 src/olympia/devhub/templates/devhub/versions/edit.html:45
 msgid "Adjusting application information here will allow users to install your add-on even if the install manifest in the package indicates that the add-on is incompatible."
 msgstr ""
 
@@ -4285,9 +4258,9 @@ msgstr ""
 msgid "Add Another Application&hellip;"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/addons/ajax_compat_update.html:38 src/olympia/devhub/templates/devhub/addons/owner.html:86 src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:46
-#: src/olympia/devhub/templates/devhub/versions/list.html:351 src/olympia/devhub/templates/devhub/versions/list.html:353 src/olympia/templates/impala/base.html:132
-#: src/olympia/templates/impala/base.html:143 src/olympia/templates/impala/base.html:161 src/olympia/templates/impala/base.html:171
+#: src/olympia/devhub/templates/devhub/addons/ajax_compat_update.html:38 src/olympia/devhub/templates/devhub/addons/owner.html:86 src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:45
+#: src/olympia/devhub/templates/devhub/versions/list.html:349 src/olympia/devhub/templates/devhub/versions/list.html:351 src/olympia/templates/impala/base.html:129
+#: src/olympia/templates/impala/base.html:140 src/olympia/templates/impala/base.html:158 src/olympia/templates/impala/base.html:168
 msgid "Close"
 msgstr ""
 
@@ -4321,7 +4294,7 @@ msgstr ""
 msgid "Manage Authors & License"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/addons/owner.html:29 src/olympia/editors/templates/editors/review.html:270
+#: src/olympia/devhub/templates/devhub/addons/owner.html:29 src/olympia/editors/helpers.py:362 src/olympia/editors/templates/editors/review.html:270
 msgid "Authors"
 msgstr ""
 
@@ -4390,17 +4363,11 @@ msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/basic.html:52
 msgid ""
-"A short explanation of your add-on's basic\n"
-"                          functionality that is displayed in search and browse\n"
-"                          listings, as well as at the top of your add-on's\n"
-"                          details page. It is only relevant for listed add-ons."
+"A short explanation of your add-on's basic functionality that is displayed in search and browse listings, as well as at the top of your add-on's details page. It is only relevant for listed add-ons."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/basic.html:73
-msgid ""
-"Categories are the primary way users browse through add-ons.\n"
-"                        Choose any that fit your add-on's functionality for the most\n"
-"                        exposure. It is only relevant for listed add-ons."
+msgid "Categories are the primary way users browse through add-ons. Choose any that fit your add-on's functionality for the most exposure. It is only relevant for listed add-ons."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/basic.html:90
@@ -4410,11 +4377,7 @@ msgid ""
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/basic.html:119
-msgid ""
-"Tags help users find your add-on and should be short\n"
-"                        descriptors such as tabs, toolbar, or twitter.  You\n"
-"                        may have a maximum of {0} tags. It is only relevant\n"
-"                        for listed add-ons."
+msgid "Tags help users find your add-on and should be short descriptors such as tabs, toolbar, or twitter. You may have a maximum of {0} tags. It is only relevant for listed add-ons."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/basic.html:129 src/olympia/devhub/templates/devhub/personas/edit.html:97 src/olympia/devhub/templates/devhub/personas/submit.html:46
@@ -4442,11 +4405,7 @@ msgid "Add-on Details for {0}"
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/details.html:22
-msgid ""
-"A longer explanation of features,\n"
-"                          functionality, and other relevant information. This\n"
-"                          field is only displayed on the add-on's details\n"
-"                          page. It is only relevant for listed add-ons."
+msgid "A longer explanation of features, functionality, and other relevant information. This field is only displayed on the add-on's details page. It is only relevant for listed add-ons."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/details.html:44 src/olympia/translations/templates/translations/trans-menu.html:13
@@ -4454,10 +4413,7 @@ msgid "Default Locale"
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/details.html:45
-msgid ""
-"Information about your add-on is displayed in this locale\n"
-"                        unless you override it with a locale-specific translation.\n"
-"                        It is only relevant for listed add-ons."
+msgid "Information about your add-on is displayed in this locale unless you override it with a locale-specific translation. It is only relevant for listed add-ons."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/details.html:61 src/olympia/users/forms.py:311 src/olympia/users/templates/users/edit.html:122 src/olympia/users/templates/users/register.html:57
@@ -4467,10 +4423,8 @@ msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/details.html:63
 msgid ""
-"If your add-on has another homepage, enter its\n"
-"                          address here. If your website is localized into other\n"
-"                          languages multiple translations of this field can be\n"
-"                          added. It is only relevant for listed add-ons."
+"If your add-on has another homepage, enter its address here. If your website is localized into other languages multiple translations of this field can be added. It is only relevant for listed add-"
+"ons."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/media.html:3
@@ -4488,19 +4442,14 @@ msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/support.html:22
 msgid ""
-"If you wish to display an e-mail address for support\n"
-"                          inquiries, enter it here. If you have different\n"
-"                          addresses for each language multiple translations of\n"
-"                          this field can be added. It is only relevant for\n"
-"                          listed add-ons."
+"If you wish to display an e-mail address for support inquiries, enter it here. If you have different addresses for each language multiple translations of this field can be added. It is only "
+"relevant for listed add-ons."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/support.html:45
 msgid ""
-"If your add-on has a support website or forum, enter\n"
-"                          its address here. If your website is localized into\n"
-"                          other languages, multiple translations of this field can\n"
-"                          be added. It is only relevant for listed add-ons."
+"If your add-on has a support website or forum, enter its address here. If your website is localized into other languages, multiple translations of this field can be added. It is only relevant for "
+"listed add-ons."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:6
@@ -4514,11 +4463,8 @@ msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:23
 msgid ""
-"Any information end users may want to know that isn't\n"
-"                          necessarily applicable to the add-on summary or description.\n"
-"                          Common uses include listing known major bugs, information on\n"
-"                          how to report bugs, anticipated release date of a new version,\n"
-"                          etc. It is only relevant for listed add-ons."
+"Any information end users may want to know that isn't necessarily applicable to the add-on summary or description. Common uses include listing known major bugs, information on how to report bugs, "
+"anticipated release date of a new version, etc. It is only relevant for listed add-ons."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:46
@@ -4530,9 +4476,7 @@ msgid "Add-on Flags"
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:69
-msgid ""
-"These flags are used to classify add-ons. It is only\n"
-"                        relevant for listed add-ons."
+msgid "These flags are used to classify add-ons. It is only relevant for listed add-ons."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:74
@@ -4548,9 +4492,7 @@ msgid "View Source?"
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:90
-msgid ""
-"Whether the source of your add-on can be displayed in our\n"
-"                        online viewer. It is only relevant for listed add-ons."
+msgid "Whether the source of your add-on can be displayed in our online viewer. It is only relevant for listed add-ons."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:94
@@ -4566,10 +4508,7 @@ msgid "Public Stats?"
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:102
-msgid ""
-"Whether the download and usage stats of your add-on can\n"
-"                        be displayed in our online viewer.\n"
-"                        It is only relevant for listed add-ons."
+msgid "Whether the download and usage stats of your add-on can be displayed in our online viewer. It is only relevant for listed add-ons."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:107
@@ -4585,10 +4524,7 @@ msgid "Upgrade SDK?"
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:116
-msgid ""
-"If selected, we will try to automatically upgrade your\n"
-"                        add-on when a new version of the SDK is released.\n"
-"                        It is only relevant for listed add-ons."
+msgid "If selected, we will try to automatically upgrade your add-on when a new version of the SDK is released. It is only relevant for listed add-ons."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:121
@@ -4639,10 +4575,8 @@ msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/forms_shared/media.html:16
 msgid ""
-"Upload an icon for your add-on or choose from one of ours. The\n"
-"                      icon is displayed nearly everywhere your add-on is. Uploaded images\n"
-"                      must be one of the following image types: .png, .jpg.\n"
-"                      It is only relevant for listed add-ons."
+"Upload an icon for your add-on or choose from one of ours. The icon is displayed nearly everywhere your add-on is. Uploaded images must be one of the following image types: .png, .jpg. It is only "
+"relevant for listed add-ons."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/forms_shared/media.html:25
@@ -4655,9 +4589,7 @@ msgid "32x32px"
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/forms_shared/media.html:39
-msgid ""
-"Used in listings of add-ons, like search results\n"
-"                            and featured add-ons."
+msgid "Used in listings of add-ons, like search results and featured add-ons."
 msgstr ""
 
 #. The size of the icon
@@ -4752,16 +4684,14 @@ msgid "Deleting your add-on will permanently remove it from the site and prevent
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:24
-msgid ""
-"Enter the following text confirm your decision:\n"
-"           {slug}"
+msgid "Enter the following text confirm your decision: {slug}"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:34
+#: src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:33
 msgid "Please tell us why you are deleting your theme:"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:36
+#: src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:35
 msgid "Please tell us why you are deleting your add-on:"
 msgstr ""
 
@@ -4798,8 +4728,8 @@ msgstr ""
 msgid "Daily statistics on downloads and users."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/addons/listing/item_actions.html:45 src/olympia/stats/templates/stats/stats.html:75 src/olympia/stats/templates/stats/stats.html:79
-#: src/olympia/stats/templates/stats/stats.html:81
+#: src/olympia/devhub/templates/devhub/addons/listing/item_actions.html:45 src/olympia/stats/templates/stats/stats.html:31 src/olympia/stats/templates/stats/stats.html:35
+#: src/olympia/stats/templates/stats/stats.html:37
 msgid "Statistics"
 msgstr ""
 
@@ -4918,10 +4848,7 @@ msgid "Your add-on has been submitted to the Full Review queue."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/submit/done.html:18
-msgid ""
-"You'll receive an email once it has been reviewed by an editor. In\n"
-"          the meantime, you and your friends can install it directly from its\n"
-"          details page:"
+msgid "You'll receive an email once it has been reviewed by an editor. In the meantime, you and your friends can install it directly from its details page:"
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/submit/done.html:27 src/olympia/devhub/templates/devhub/addons/submit/done.html:77 src/olympia/devhub/templates/devhub/personas/submit_done.html:16
@@ -5127,11 +5054,11 @@ msgstr ""
 msgid "Use the fields below to upload your add-on package and select any platform restrictions. After upload, a series of automated validation tests will be run on your file."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/addons/submit/upload.html:59 src/olympia/devhub/templates/devhub/versions/add_file_modal.html:39
+#: src/olympia/devhub/templates/devhub/addons/submit/upload.html:51 src/olympia/devhub/templates/devhub/versions/add_file_modal.html:28
 msgid "Which platforms is this file compatible with?"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/addons/submit/upload.html:67 src/olympia/devhub/templates/devhub/versions/add_file_modal.html:65
+#: src/olympia/devhub/templates/devhub/addons/submit/upload.html:59 src/olympia/devhub/templates/devhub/versions/add_file_modal.html:45
 msgid "Administrative overrides"
 msgstr ""
 
@@ -5241,8 +5168,8 @@ msgstr ""
 
 #: src/olympia/devhub/templates/devhub/docs/policies-contact.html:44
 msgid ""
-"If you've found a problem with the site, we'd love to fix it. Please <a href=\"https://github.com/mozilla/olympia/issues\">file a bug report</a> in GitHub, including the location of the problem and "
-"how you encountered it."
+"If you've found a problem with the site, we'd love to fix it. Please <a href=\"https://github.com/mozilla/addons/issues/new\">file a bug report</a> in GitHub, including the location of the problem "
+"and how you encountered it."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/docs/policies-maintenance.html:3 src/olympia/devhub/templates/devhub/docs/policies-maintenance.html:7
@@ -5809,7 +5736,7 @@ msgstr ""
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:282
 msgid ""
-"Add-ons that store or otherwise handle browsing data must support <a href=\"https://developer.mozilla.org/En/Supporting_private_browsing_mode\">Private Browsing Mode</a>.  During a Private Browsing "
+"Add-ons that store or otherwise handle browsing data must support <a href=\"https://developer.mozilla.org/En/Supporting_private_browsing_mode\">Private Browsing Mode</a>. During a Private Browsing "
 "session, no browsing data can be written to disk, and all of this data must be cleared when Firefox quits or the Private Browsing session ends."
 msgstr ""
 
@@ -5974,129 +5901,95 @@ msgstr ""
 msgid "How to get in touch with us regarding these policies or your add-on."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:6
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:10
 msgid "You have disabled this add-on"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:20
-msgid ""
-"Your add-on's listing is disabled and is not showing\n"
-"                             anywhere in our gallery or update service."
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:24
+msgid "Your add-on's listing is disabled and is not showing anywhere in our gallery or update service."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:25
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:27
 msgid "Please complete your add-on."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:29
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:30
 msgid "You will receive an email when the review is complete."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:34
-msgid ""
-"You will receive an email when the review is complete. Until\n"
-"                             then, your add-on is not listed in our gallery but can be\n"
-"                             accessed directly from its details page."
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:33
+msgid "You will receive an email when the review is complete. Until then, your add-on is not listed in our gallery but can be accessed directly from its details page."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:38 src/olympia/devhub/templates/devhub/includes/addon_details.html:48
-msgid ""
-"You will receive an email when the review is\n"
-"                             complete and your add-on is signed."
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:37 src/olympia/devhub/templates/devhub/includes/addon_details.html:45
+msgid "You will receive an email when the review is complete and your add-on is signed."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:44
-msgid ""
-"You will receive an email when the review is complete. Until\n"
-"                             then, your add-on is not listed in our gallery but can be\n"
-"                             accessed directly from its details page. "
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:41
+msgid "You will receive an email when the review is complete. Until then, your add-on is not listed in our gallery but can be accessed directly from its details page. "
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:54
-msgid ""
-"Your add-on is displayed in our gallery and users are\n"
-"                             receiving automatic updates."
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:49
+msgid "Your add-on is displayed in our gallery and users are receiving automatic updates."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:57
-msgid ""
-"Your add-on has been signed and can be bundled with an\n"
-"                             application installer."
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:52
+msgid "Your add-on has been signed and can be bundled with an application installer."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:63
-msgid ""
-"Your add-on was disabled by a site administrator and is no\n"
-"                             longer shown in our gallery. If you have any questions,\n"
-"                             please email amo-admins@mozilla.org."
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:56
+msgid "Your add-on was disabled by a site administrator and is no longer shown in our gallery. If you have any questions, please email amo-admins@mozilla.org."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:70
-msgid ""
-"Your add-on is displayed in our gallery as experimental\n"
-"                             and users are receiving automatic updates. Some features\n"
-"                             are unavailable to your add-on."
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:62
+msgid "Your add-on is displayed in our gallery as experimental and users are receiving automatic updates. Some features are unavailable to your add-on."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:74
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:66
 msgid "Your add-on has been signed."
 msgstr ""
 
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:69
+msgid ""
+"You will receive an email when the full review is complete. Until then, your add-on is displayed in our gallery as experimental and users are receiving automatic updates. Some features are "
+"unavailable to your add-on."
+msgstr ""
+
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:74
+msgid "You will receive an email when the full review is complete, making you able to bundle your add-on with an application installer."
+msgstr ""
+
 #: src/olympia/devhub/templates/devhub/includes/addon_details.html:79
-msgid ""
-"You will receive an email when the full review is complete.\n"
-"                             Until then, your add-on is displayed in our gallery as\n"
-"                             experimental and users are receiving automatic updates.\n"
-"                             Some features are unavailable to your add-on."
+msgid "All add-ons hosted in our gallery must now be reviewed by an editor. If you wish to continue hosting your add-on, please click to select a review process."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:84
-msgid ""
-"You will receive an email when the full review is\n"
-"                             complete, making you able to bundle your add-on with an\n"
-"                             application installer."
-msgstr ""
-
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:91
-msgid ""
-"All add-ons hosted in our gallery must now be reviewed by an\n"
-"                             editor. If you wish to continue hosting your add-on, please\n"
-"                             click to select a review process."
-msgstr ""
-
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:113
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:100
 msgid "Current Version:"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:115
-msgid ""
-"This is the version of your add-on that will\n"
-"                                           be installed if someone clicks the Install\n"
-"                                           button on addons.mozilla.org. It is only\n"
-"                                           relevant for listed add-ons."
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:102
+msgid "This is the version of your add-on that will be installed if someone clicks the Install button on addons.mozilla.org. It is only relevant for listed add-ons."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:123
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:110
 msgid "Created:"
 msgstr ""
 
 #. {0} is a date. dennis-ignore: E201
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:125 src/olympia/devhub/templates/devhub/includes/addon_details.html:131
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:112 src/olympia/devhub/templates/devhub/includes/addon_details.html:118
 #, python-format
 msgid "%%b %%e, %%Y"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:136
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:123
 msgid "Next Version:"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:138
-msgid ""
-"This is the newest uploaded version, however\n"
-"                                           it isn’t live on the site yet."
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:125
+msgid "This is the newest uploaded version, however it isn’t live on the site yet."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:144 src/olympia/devhub/templates/devhub/versions/list.html:30
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:130 src/olympia/devhub/templates/devhub/versions/list.html:30
 msgid "Queues are not reviewed strictly in order"
 msgstr ""
 
@@ -6164,9 +6057,7 @@ msgid "View the blog &#9658;"
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/includes/license_form.html:6
-msgid ""
-"Please choose a license appropriate for the rights you grant on your source code.\n"
-"                  It is only relevant for listed add-ons."
+msgid "Please choose a license appropriate for the rights you grant on your source code. It is only relevant for listed add-ons."
 msgstr ""
 
 #. {0} is a list of HTML tags.
@@ -6193,14 +6084,11 @@ msgstr[1] ""
 #: src/olympia/devhub/templates/devhub/includes/policy_form.html:4
 msgid ""
 "Users will be required to accept the following End-User License Agreement (EULA) prior to installing your add-on. The presence of a EULA significantly affects the number of downloads an add-on "
-"receives. Please note that a EULA is not the same as a code license, such as the GPL or MPL.\n"
-"                It is only relevant for listed add-ons."
+"receives. Please note that a EULA is not the same as a code license, such as the GPL or MPL.It is only relevant for listed add-ons."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/policy_form.html:21
-msgid ""
-"If your add-on transmits any data from the user's computer, a privacy policy is required that explains what data is sent and how it is used.\n"
-"                It is only relevant for listed add-ons."
+#: src/olympia/devhub/templates/devhub/includes/policy_form.html:24
+msgid "If your add-on transmits any data from the user's computer, a privacy policy is required that explains what data is sent and how it is used. It is only relevant for listed add-ons."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/includes/source_form_field.html:2
@@ -6368,12 +6256,8 @@ msgstr ""
 msgid "Add some tags to describe your Theme."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/personas/edit.html:106
-msgid ""
-"A short explanation of your theme's\n"
-"                                basic functionality that is displayed in\n"
-"                                search and browse listings, as well as at\n"
-"                                the top of your theme's details page."
+#: src/olympia/devhub/templates/devhub/personas/edit.html:106 src/olympia/devhub/templates/devhub/personas/submit.html:54
+msgid "A short explanation of your theme's basic functionality that is displayed in search and browse listings, as well as at the top of your theme's details page."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/personas/edit.html:122 src/olympia/devhub/templates/devhub/personas/submit.html:68
@@ -6443,7 +6327,7 @@ msgid "Upon upload and form submission, the AMO Team will review your updated de
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/personas/edit.html:241
-msgid "Your previously resubmitted design,  which is under pending review."
+msgid "Your previously resubmitted design, which is under pending review."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/personas/edit.html:245
@@ -6510,14 +6394,6 @@ msgstr ""
 
 #: src/olympia/devhub/templates/devhub/personas/submit.html:33
 msgid "Give your Theme a name."
-msgstr ""
-
-#: src/olympia/devhub/templates/devhub/personas/submit.html:54
-msgid ""
-"A short explanation of your theme's\n"
-"                                      basic functionality that is displayed in\n"
-"                                      search and browse listings, as well as at\n"
-"                                      the top of your theme's details page."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/personas/submit.html:198
@@ -6594,30 +6470,16 @@ msgstr ""
 msgid "Files added to reviewed versions must be reviewed before they will be available for download."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/add_file_modal.html:15
-#, python-format
-msgid ""
-"Submission of updates to unlisted add-ons for signing is currently in an open beta. Manual review may still be required for a large number of add-ons. Please <a href=\"%(url)s\" target=\"_blank"
-"\">report any bugs</a> that you encounter."
-msgstr ""
-
-#: src/olympia/devhub/templates/devhub/versions/add_file_modal.html:35
+#: src/olympia/devhub/templates/devhub/versions/add_file_modal.html:24
 msgid "Select the target platform for this file."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/add_file_modal.html:46
+#: src/olympia/devhub/templates/devhub/versions/add_file_modal.html:35
 msgid "Which review type would you like to nominate for?"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/add_file_modal.html:51
+#: src/olympia/devhub/templates/devhub/versions/add_file_modal.html:40
 msgid "Only publish this version to my beta channel."
-msgstr ""
-
-#: src/olympia/devhub/templates/devhub/versions/add_file_modal.html:54
-#, python-format
-msgid ""
-"The behavior of the beta channel has changed to accommodate <a href=\"%(addon_signing_url)s\" target=\"_blank\">mandatory add-on signing</a>. The new process is currently in an open beta, and may "
-"change significantly in the near future. Please <a href=\"%(issues_url)s\" target=\"_blank\">report any bugs</a> that you encounter."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/versions/edit.html:5
@@ -6641,19 +6503,10 @@ msgstr ""
 msgid "Upload Another File"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/edit.html:45
-msgid ""
-"Adjusting application information here will allow users to install your\n"
-"                          add-on even if the install manifest in the package indicates that the\n"
-"                          add-on is incompatible."
-msgstr ""
-
 #: src/olympia/devhub/templates/devhub/versions/edit.html:74
 msgid ""
-"Information about changes in this release, new features,\n"
-"                              known bugs, and other useful information specific to this\n"
-"                              release/version. This information is also shown in the\n"
-"                              Add-ons Manager when updating."
+"Information about changes in this release, new features, known bugs, and other useful information specific to this release/version. This information is also shown in the Add-ons Manager when "
+"updating."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/versions/edit.html:99
@@ -6665,10 +6518,7 @@ msgid "Notes for Reviewers"
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/versions/edit.html:114
-msgid ""
-"Optionally, enter any information that may be useful\n"
-"                              to the Editor reviewing this add-on, such as test\n"
-"                              account information."
+msgid "Optionally, enter any information that may be useful to the Editor reviewing this add-on, such as test account information."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/versions/edit.html:127
@@ -6746,7 +6596,7 @@ msgstr ""
 msgid "Request Preliminary Review"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:80 src/olympia/devhub/templates/devhub/versions/list.html:327 src/olympia/devhub/templates/devhub/versions/list.html:350
+#: src/olympia/devhub/templates/devhub/versions/list.html:80 src/olympia/devhub/templates/devhub/versions/list.html:325 src/olympia/devhub/templates/devhub/versions/list.html:348
 msgid "Cancel Review Request"
 msgstr ""
 
@@ -6775,7 +6625,7 @@ msgid "Unlisted:"
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/versions/list.html:114
-msgid "Not distributed on {0}. Developers will upload new versions for signing and distribute the add-ons on their own. (beta)"
+msgid "Not distributed on {0}. Developers will upload new versions for signing and distribute the add-ons on their own."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/versions/list.html:122
@@ -6838,81 +6688,73 @@ msgid "<strong>Important:</strong> Once a version has been deleted, you may not 
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/versions/list.html:230
-msgid ""
-"Deleting a version which has already been reviewed\n"
-"               may also cause a significant delay in the review of\n"
-"               your next update."
-msgstr ""
-
-#: src/olympia/devhub/templates/devhub/versions/list.html:233
 msgid "Are you sure you wish to delete this version?"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:238
+#: src/olympia/devhub/templates/devhub/versions/list.html:235
 msgid "Delete Version"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:240
+#: src/olympia/devhub/templates/devhub/versions/list.html:237
 msgid "Disable Version"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:247
+#: src/olympia/devhub/templates/devhub/versions/list.html:244
 msgid "Add a new Version"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:249
+#: src/olympia/devhub/templates/devhub/versions/list.html:246
 msgid "Add Version"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:256 src/olympia/devhub/templates/devhub/versions/list.html:274
+#: src/olympia/devhub/templates/devhub/versions/list.html:253 src/olympia/devhub/templates/devhub/versions/list.html:279
 msgid "Hide Add-on"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:259
+#: src/olympia/devhub/templates/devhub/versions/list.html:256
 msgid "Hiding your add-on will prevent it from appearing anywhere in our gallery and will stop users from receiving automatic updates."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:265
+#: src/olympia/devhub/templates/devhub/versions/list.html:263
+msgid "The files awaiting review will be disabled and you will need to upload new versions."
+msgstr ""
+
+#: src/olympia/devhub/templates/devhub/versions/list.html:270
 msgid "Are you sure you wish to hide your add-on?"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:286 src/olympia/devhub/templates/devhub/versions/list.html:315
+#: src/olympia/devhub/templates/devhub/versions/list.html:291 src/olympia/devhub/templates/devhub/versions/list.html:313
 msgid "Unlist Add-on"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:289
+#: src/olympia/devhub/templates/devhub/versions/list.html:294
 #, python-format
 msgid ""
 "Unlisting your add-on will make it (and each of its versions/files) invisible on this website. It won't show up in searches, won't have a public facing page, and won't be updated automatically for "
-"current users.  It is recommended for unlisted add-ons to provide a custom <a href=\"%(update_url)s\" target=\"_blank\">updateURL</a> in their manifest file for automatic updates."
+"current users. It is recommended for unlisted add-ons to provide a custom <a href=\"%(update_url)s\" target=\"_blank\">updateURL</a> in their manifest file for automatic updates."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:299
-#, python-format
-msgid "Switching add-ons to unlisted is currently in an open beta. Please <a href=\"%(url)s\" target=\"_blank\">report any bugs</a> that you encounter."
-msgstr ""
-
-#: src/olympia/devhub/templates/devhub/versions/list.html:305
+#: src/olympia/devhub/templates/devhub/versions/list.html:303
 msgid "Unlisting an add-on is irreversible!"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:305
+#: src/olympia/devhub/templates/devhub/versions/list.html:303
 msgid "An unlisted add-on cannot be switched to be listed."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:307
+#: src/olympia/devhub/templates/devhub/versions/list.html:305
 msgid "Are you sure you wish to unlist your add-on?"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:330
+#: src/olympia/devhub/templates/devhub/versions/list.html:328
 msgid "Canceling your review request will leave your add-on as preliminarily reviewed."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:335
+#: src/olympia/devhub/templates/devhub/versions/list.html:333
 msgid "Canceling your review request will mark your add-on incomplete. If you do not complete your add-on after several days by re-requesting review, it will be deleted."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:343
+#: src/olympia/devhub/templates/devhub/versions/list.html:341
 msgid "Are you sure you wish to cancel your review request?"
 msgstr ""
 
@@ -7251,19 +7093,19 @@ msgstr ""
 msgid "Search by add-on name / author email"
 msgstr ""
 
-#: src/olympia/editors/forms.py:103
+#: src/olympia/editors/forms.py:103 src/olympia/editors/forms.py:244 src/olympia/editors/forms.py:257
 msgid "yes"
 msgstr ""
 
-#: src/olympia/editors/forms.py:104
+#: src/olympia/editors/forms.py:104 src/olympia/editors/forms.py:244 src/olympia/editors/forms.py:257
 msgid "no"
 msgstr ""
 
-#: src/olympia/editors/forms.py:105
+#: src/olympia/editors/forms.py:105 src/olympia/editors/forms.py:245
 msgid "Admin Flag"
 msgstr ""
 
-#: src/olympia/editors/forms.py:113
+#: src/olympia/editors/forms.py:113 src/olympia/editors/forms.py:253
 msgid "Max. Version"
 msgstr ""
 
@@ -7275,55 +7117,59 @@ msgstr ""
 msgid "Add-on Types"
 msgstr ""
 
-#: src/olympia/editors/forms.py:126 src/olympia/editors/helpers.py:267
+#: src/olympia/editors/forms.py:126 src/olympia/editors/helpers.py:279
 msgid "Platforms"
 msgstr ""
 
+#: src/olympia/editors/forms.py:237
+msgid "Search by add-on name / author email / guid"
+msgstr ""
+
 #. L10n: 0 = platform, 1 = filename, 2 = status message
-#: src/olympia/editors/forms.py:238
+#: src/olympia/editors/forms.py:342
 #, python-format
 msgid "<strong>%s</strong> &middot; %s &middot; %s"
 msgstr ""
 
-#: src/olympia/editors/forms.py:252
+#: src/olympia/editors/forms.py:356
 msgid "Comments:"
 msgstr ""
 
-#: src/olympia/editors/forms.py:256
+#: src/olympia/editors/forms.py:360
 msgid "Operating systems:"
 msgstr ""
 
-#: src/olympia/editors/forms.py:258
+#: src/olympia/editors/forms.py:362
 msgid "Applications:"
 msgstr ""
 
-#: src/olympia/editors/forms.py:260
+#: src/olympia/editors/forms.py:364
 msgid "Notify me the next time this add-on is updated. (Subsequent updates will not generate an email)"
 msgstr ""
 
-#: src/olympia/editors/forms.py:265
+#: src/olympia/editors/forms.py:369
 msgid "Clear Admin Review Flag"
 msgstr ""
 
-#: src/olympia/editors/forms.py:267
+#: src/olympia/editors/forms.py:371
 msgid "Clear more info requested flag"
 msgstr ""
 
-#: src/olympia/editors/forms.py:281
+#: src/olympia/editors/forms.py:385
 msgid "Choose a canned response..."
 msgstr ""
 
 #. L10n: Description of what can be searched for.
-#: src/olympia/editors/forms.py:324
+#: src/olympia/editors/forms.py:423
 msgid "theme name"
 msgstr ""
 
-#: src/olympia/editors/forms.py:350
+#: src/olympia/editors/forms.py:449
 msgid "Someone else is reviewing this theme."
 msgstr ""
 
 #. L10n: Description of what can be searched for.
-#: src/olympia/editors/forms.py:447
+#: src/olympia/editors/forms.py:546
 msgid "app, reviewer, or comment"
 msgstr ""
 
@@ -7339,246 +7185,264 @@ msgstr ""
 msgid "Rejected or Unreviewed"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:123 src/olympia/editors/helpers.py:136
+#: src/olympia/editors/helpers.py:125 src/olympia/editors/helpers.py:138
 msgid "Queue"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:124 src/olympia/editors/templates/editors/base.html:50 src/olympia/editors/templates/editors/base.html:65
+#: src/olympia/editors/helpers.py:126 src/olympia/editors/templates/editors/base.html:50 src/olympia/editors/templates/editors/base.html:65
 msgid "Pending Updates"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:125 src/olympia/editors/templates/editors/base.html:48 src/olympia/editors/templates/editors/base.html:63
+#: src/olympia/editors/helpers.py:127 src/olympia/editors/templates/editors/base.html:48 src/olympia/editors/templates/editors/base.html:63
 msgid "Full Reviews"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:126 src/olympia/editors/templates/editors/base.html:52 src/olympia/editors/templates/editors/base.html:67
+#: src/olympia/editors/helpers.py:128 src/olympia/editors/templates/editors/base.html:52 src/olympia/editors/templates/editors/base.html:67
 msgid "Preliminary Reviews"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:127 src/olympia/editors/templates/editors/base.html:54
+#: src/olympia/editors/helpers.py:129 src/olympia/editors/templates/editors/base.html:54
 msgid "Moderated Reviews"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:128 src/olympia/editors/templates/editors/base.html:46
+#: src/olympia/editors/helpers.py:130 src/olympia/editors/templates/editors/base.html:46
 msgid "Fast Track"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:130
+#: src/olympia/editors/helpers.py:132
 msgid "Pending Themes"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:131 src/olympia/editors/templates/editors/themes/queue.html:4
+#: src/olympia/editors/helpers.py:133 src/olympia/editors/templates/editors/themes/queue.html:4
 msgid "Flagged Themes"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:132
+#: src/olympia/editors/helpers.py:134
 msgid "Update Themes"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:137
+#: src/olympia/editors/helpers.py:139
 msgid "Unlisted Pending Updates"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:138
+#: src/olympia/editors/helpers.py:140
 msgid "Unlisted Full Reviews"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:139
+#: src/olympia/editors/helpers.py:141
 msgid "Unlisted Preliminary Reviews"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:170
+#: src/olympia/editors/helpers.py:142
+msgid "Unlisted All Add-ons"
+msgstr ""
+
+#: src/olympia/editors/helpers.py:173
 msgid "Fast Track ({0})"
 msgid_plural "Fast Track ({0})"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/olympia/editors/helpers.py:175
+#: src/olympia/editors/helpers.py:178
 msgid "Full Review ({0})"
 msgid_plural "Full Reviews ({0})"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/olympia/editors/helpers.py:180
+#: src/olympia/editors/helpers.py:183
 msgid "Pending Update ({0})"
 msgid_plural "Pending Updates ({0})"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/olympia/editors/helpers.py:185
+#: src/olympia/editors/helpers.py:188
 msgid "Preliminary Review ({0})"
 msgid_plural "Preliminary Reviews ({0})"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/olympia/editors/helpers.py:190
+#: src/olympia/editors/helpers.py:193
 msgid "Moderated Review ({0})"
 msgid_plural "Moderated Reviews ({0})"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/olympia/editors/helpers.py:196
+#: src/olympia/editors/helpers.py:199
 msgid "Unlisted Full Review ({0})"
 msgid_plural "Unlisted Full Reviews ({0})"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/olympia/editors/helpers.py:201
+#: src/olympia/editors/helpers.py:204
 msgid "Unlisted Pending Update ({0})"
 msgid_plural "Unlisted Pending Updates ({0})"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/olympia/editors/helpers.py:206
+#: src/olympia/editors/helpers.py:209
 msgid "Unlisted Preliminary Review ({0})"
 msgid_plural "Unlisted Preliminary Reviews ({0})"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/olympia/editors/helpers.py:261
-msgid "Addon"
-msgstr ""
+#: src/olympia/editors/helpers.py:214
+msgid "Unlisted All Add-ons ({0})"
+msgid_plural "Unlisted All Add-ons ({0})"
+msgstr[0] ""
+msgstr[1] ""
 
-#: src/olympia/editors/helpers.py:262
+#: src/olympia/editors/helpers.py:274
 msgid "Type"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:263
+#: src/olympia/editors/helpers.py:275
 msgid "Waiting Time"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:264 src/olympia/editors/templates/editors/review.html:285
+#: src/olympia/editors/helpers.py:276 src/olympia/editors/templates/editors/review.html:285
 msgid "Flags"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:265
+#: src/olympia/editors/helpers.py:277
 msgid "Applications"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:270
+#: src/olympia/editors/helpers.py:282
 msgid "Additional"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:285
+#: src/olympia/editors/helpers.py:302
 msgid "Site Specific"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:287
+#: src/olympia/editors/helpers.py:304
 msgid "Requires External Software"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:289
+#: src/olympia/editors/helpers.py:306
 msgid "Binary Components"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:313
+#: src/olympia/editors/helpers.py:339
 msgid "moments ago"
 msgstr ""
 
 #. L10n: first argument is number of minutes
-#: src/olympia/editors/helpers.py:316
+#: src/olympia/editors/helpers.py:342
 msgid "{0} minute"
 msgid_plural "{0} minutes"
 msgstr[0] ""
 msgstr[1] ""
 
 #. L10n: first argument is number of hours
-#: src/olympia/editors/helpers.py:320
+#: src/olympia/editors/helpers.py:346
 msgid "{0} hour"
 msgid_plural "{0} hours"
 msgstr[0] ""
 msgstr[1] ""
 
 #. L10n: first argument is number of days
-#: src/olympia/editors/helpers.py:324
+#: src/olympia/editors/helpers.py:350
 msgid "{0} day"
 msgid_plural "{0} days"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/olympia/editors/helpers.py:488
+#: src/olympia/editors/helpers.py:364
+msgid "Last Review"
+msgstr ""
+
+#: src/olympia/editors/helpers.py:366
+msgid "Last Update"
+msgstr ""
+
+#: src/olympia/editors/helpers.py:387
+msgid "No Reviews"
+msgstr ""
+
+#: src/olympia/editors/helpers.py:561
 msgid "Push to public"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:490
+#: src/olympia/editors/helpers.py:563
 msgid "Grant full review"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:505
+#: src/olympia/editors/helpers.py:578
 msgid "Request more information"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:508
+#: src/olympia/editors/helpers.py:581
 msgid "Request super-review"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:519
+#: src/olympia/editors/helpers.py:592
 msgid "Grant preliminary review"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:520
+#: src/olympia/editors/helpers.py:593
 msgid "This will mark the files as preliminarily reviewed."
 msgstr ""
 
-#: src/olympia/editors/helpers.py:522
+#: src/olympia/editors/helpers.py:595
 msgid "Use this form to request more information from the author. They will receive an email and be able to answer here. You will be notified by email when they reply."
 msgstr ""
 
-#: src/olympia/editors/helpers.py:526
+#: src/olympia/editors/helpers.py:599
 msgid ""
 "If you have concerns about this add-on's security, copyright issues, or other concerns that an administrator should look into, enter your comments in the area below. They will be sent to "
 "administrators, not the author."
 msgstr ""
 
-#: src/olympia/editors/helpers.py:532
+#: src/olympia/editors/helpers.py:605
 msgid "This will reject the add-on and remove it from the review queue."
 msgstr ""
 
-#: src/olympia/editors/helpers.py:534
-msgid "Make a comment on this version.  The author won't be able to see this."
+#: src/olympia/editors/helpers.py:607
+msgid "Make a comment on this version. The author won't be able to see this."
 msgstr ""
 
-#: src/olympia/editors/helpers.py:538
+#: src/olympia/editors/helpers.py:611
 msgid "This will reject the files and remove them from the review queue."
 msgstr ""
 
-#: src/olympia/editors/helpers.py:542
+#: src/olympia/editors/helpers.py:615
 msgid "This will mark the add-on as preliminarily reviewed. Future versions will undergo preliminary review."
 msgstr ""
 
-#: src/olympia/editors/helpers.py:547
+#: src/olympia/editors/helpers.py:620
 msgid "This will mark the files as preliminarily reviewed. Future versions will undergo preliminary review."
 msgstr ""
 
-#: src/olympia/editors/helpers.py:552
+#: src/olympia/editors/helpers.py:625
 msgid "Retain preliminary review"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:553
+#: src/olympia/editors/helpers.py:626
 msgid "This will retain the add-on as preliminarily reviewed. Future versions will undergo preliminary review."
 msgstr ""
 
-#: src/olympia/editors/helpers.py:558
+#: src/olympia/editors/helpers.py:631
 msgid "This will approve a sandboxed version of a public add-on to appear on the public side."
 msgstr ""
 
-#: src/olympia/editors/helpers.py:561
+#: src/olympia/editors/helpers.py:634
 msgid "This will reject a version of a public add-on and remove it from the queue."
 msgstr ""
 
-#: src/olympia/editors/helpers.py:564
+#: src/olympia/editors/helpers.py:637
 msgid "This will mark the add-on and its most recent version and files as public. Future versions will go into the sandbox until they are reviewed by an editor."
 msgstr ""
 
-#: src/olympia/editors/helpers.py:637
+#: src/olympia/editors/helpers.py:714
 msgid "add-on"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:940 src/olympia/editors/helpers.py:960
+#: src/olympia/editors/helpers.py:1020 src/olympia/editors/helpers.py:1040
 msgid "Flagged"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:944 src/olympia/editors/helpers.py:963
+#: src/olympia/editors/helpers.py:1024 src/olympia/editors/helpers.py:1043
 msgid "Updates"
 msgstr ""
 
@@ -7630,56 +7494,56 @@ msgstr ""
 msgid "A question about your Theme submission"
 msgstr ""
 
-#: src/olympia/editors/views.py:144
+#: src/olympia/editors/views.py:146
 msgid "New Add-ons (Under 5 days)"
 msgstr ""
 
-#: src/olympia/editors/views.py:145
+#: src/olympia/editors/views.py:147
 msgid "Passable (5 to 10 days)"
 msgstr ""
 
-#: src/olympia/editors/views.py:146
+#: src/olympia/editors/views.py:148
 msgid "Overdue (Over 10 days)"
 msgstr ""
 
-#: src/olympia/editors/views.py:532
+#: src/olympia/editors/views.py:539
 msgid "An unknown error occurred"
 msgstr ""
 
-#: src/olympia/editors/views.py:587
+#: src/olympia/editors/views.py:592
 msgid "Self-reviews are not allowed."
 msgstr ""
 
-#: src/olympia/editors/views.py:609
+#: src/olympia/editors/views.py:613
 msgid "Review successfully processed."
 msgstr ""
 
-#: src/olympia/editors/views.py:807
+#: src/olympia/editors/views.py:812
 msgid "was approved"
 msgstr ""
 
-#: src/olympia/editors/views.py:808
+#: src/olympia/editors/views.py:813
 msgid "given preliminary review"
 msgstr ""
 
-#: src/olympia/editors/views.py:809
+#: src/olympia/editors/views.py:814
 msgid "rejected"
 msgstr ""
 
-#: src/olympia/editors/views.py:810
+#: src/olympia/editors/views.py:815
 msgctxt "editors_review_history_nominated_adminreview"
 msgid "escalated"
 msgstr ""
 
-#: src/olympia/editors/views.py:812
+#: src/olympia/editors/views.py:817
 msgid "needs more information"
 msgstr ""
 
-#: src/olympia/editors/views.py:813
+#: src/olympia/editors/views.py:818
 msgid "needs super review"
 msgstr ""
 
-#: src/olympia/editors/views.py:814
+#: src/olympia/editors/views.py:819
 msgid "commented"
 msgstr ""
 
@@ -7724,28 +7588,28 @@ msgstr ""
 msgid "Unlisted Queues"
 msgstr ""
 
-#: src/olympia/editors/templates/editors/base.html:72 src/olympia/editors/templates/editors/performance.html:6
+#: src/olympia/editors/templates/editors/base.html:74 src/olympia/editors/templates/editors/performance.html:6
 msgid "Performance"
 msgstr ""
 
-#: src/olympia/editors/templates/editors/base.html:75 src/olympia/editors/templates/editors/themes/base.html:19 src/olympia/editors/templates/editors/themes/base.html:38
+#: src/olympia/editors/templates/editors/base.html:77 src/olympia/editors/templates/editors/themes/base.html:19 src/olympia/editors/templates/editors/themes/base.html:38
 msgid "Logs"
 msgstr ""
 
-#: src/olympia/editors/templates/editors/base.html:78 src/olympia/editors/templates/editors/reviewlog.html:4 src/olympia/editors/templates/editors/reviewlog.html:27
+#: src/olympia/editors/templates/editors/base.html:80 src/olympia/editors/templates/editors/reviewlog.html:4 src/olympia/editors/templates/editors/reviewlog.html:27
 msgid "Add-on Review Log"
 msgstr ""
 
-#: src/olympia/editors/templates/editors/base.html:80 src/olympia/editors/templates/editors/eventlog.html:4 src/olympia/editors/templates/editors/eventlog.html:8
+#: src/olympia/editors/templates/editors/base.html:82 src/olympia/editors/templates/editors/eventlog.html:4 src/olympia/editors/templates/editors/eventlog.html:8
 #: src/olympia/editors/templates/editors/eventlog_detail.html:4
 msgid "Moderated Review Log"
 msgstr ""
 
-#: src/olympia/editors/templates/editors/base.html:82 src/olympia/editors/templates/editors/beta_signed_log.html:4 src/olympia/editors/templates/editors/beta_signed_log.html:8
+#: src/olympia/editors/templates/editors/base.html:84 src/olympia/editors/templates/editors/beta_signed_log.html:4 src/olympia/editors/templates/editors/beta_signed_log.html:8
 msgid "Signed Beta Files Log"
 msgstr ""
 
-#: src/olympia/editors/templates/editors/base.html:87 src/olympia/editors/templates/editors/includes/daily-message.html:4
+#: src/olympia/editors/templates/editors/base.html:89 src/olympia/editors/templates/editors/includes/daily-message.html:4
 msgid "Announcement"
 msgstr ""
 
@@ -7966,45 +7830,45 @@ msgstr ""
 msgid "clear search"
 msgstr ""
 
-#: src/olympia/editors/templates/editors/queue.html:72 src/olympia/editors/templates/editors/queue.html:122
+#: src/olympia/editors/templates/editors/queue.html:78 src/olympia/editors/templates/editors/queue.html:128
 msgid "Process Reviews"
 msgstr ""
 
-#: src/olympia/editors/templates/editors/queue.html:80
+#: src/olympia/editors/templates/editors/queue.html:86
 msgid "Moderation actions:"
 msgstr ""
 
-#: src/olympia/editors/templates/editors/queue.html:90
+#: src/olympia/editors/templates/editors/queue.html:96
 #, python-format
 msgid "by %(user)s on %(date)s %(stars)s (%(locale)s)"
 msgstr ""
 
-#: src/olympia/editors/templates/editors/queue.html:106
+#: src/olympia/editors/templates/editors/queue.html:112
 #, python-format
 msgid "<strong>%(reason)s</strong> <span class=\"light\">Flagged by %(user)s on %(date)s</span>"
 msgstr ""
 
-#: src/olympia/editors/templates/editors/queue.html:119
-msgid "All reviews have been moderated.  Good work!"
+#: src/olympia/editors/templates/editors/queue.html:125
+msgid "All reviews have been moderated. Good work!"
 msgstr ""
 
-#: src/olympia/editors/templates/editors/queue.html:161
+#: src/olympia/editors/templates/editors/queue.html:167
 msgid "Version Notes / Notes for Reviewer"
 msgstr ""
 
-#: src/olympia/editors/templates/editors/queue.html:169
+#: src/olympia/editors/templates/editors/queue.html:175
 msgid "There are currently no add-ons of this type to review."
 msgstr ""
 
-#: src/olympia/editors/templates/editors/queue.html:181 src/olympia/editors/templates/editors/themes/queue_list.html:85
+#: src/olympia/editors/templates/editors/queue.html:187 src/olympia/editors/templates/editors/themes/queue_list.html:85
 msgid "Helpful Links:"
 msgstr ""
 
-#: src/olympia/editors/templates/editors/queue.html:182
+#: src/olympia/editors/templates/editors/queue.html:188
 msgid "Add-on Policy"
 msgstr ""
 
-#: src/olympia/editors/templates/editors/queue.html:184
+#: src/olympia/editors/templates/editors/queue.html:190
 msgid "Editors' Guide"
 msgstr ""
 
@@ -8067,10 +7931,7 @@ msgid "<strong>Warning!</strong> Another user was viewing this page before you."
 msgstr ""
 
 #: src/olympia/editors/templates/editors/review.html:237
-msgid ""
-"The whiteboard is the place to exchange information relevant to\n"
-"               this addon (whatever the version), between the developer and the\n"
-"               editor. This is visible and editable by both."
+msgid "The whiteboard is the place to exchange information relevant to this addon (whatever the version), between the developer and the editor. This is visible and editable by both."
 msgstr ""
 
 #: src/olympia/editors/templates/editors/review.html:241
@@ -8344,7 +8205,7 @@ msgstr ""
 msgid "Describe your reason for flagging"
 msgstr ""
 
-#: src/olympia/files/forms.py:88
+#: src/olympia/files/forms.py:90
 msgid "Cannot diff a version against itself"
 msgstr ""
 
@@ -8379,51 +8240,51 @@ msgstr ""
 msgid "There was an error accessing file %s."
 msgstr ""
 
-#: src/olympia/files/utils.py:343
+#: src/olympia/files/utils.py:340
 msgid "Could not parse uploaded file."
 msgstr ""
 
-#: src/olympia/files/utils.py:380
+#: src/olympia/files/utils.py:377
 msgid "Invalid file name in archive: {0}"
 msgstr ""
 
-#: src/olympia/files/utils.py:388
+#: src/olympia/files/utils.py:385
 msgid "File exceeding size limit in archive: {0}"
 msgstr ""
 
-#: src/olympia/files/utils.py:439
+#: src/olympia/files/utils.py:436
 msgid "Invalid archive."
 msgstr ""
 
-#: src/olympia/files/utils.py:529 src/olympia/files/utils.py:532
+#: src/olympia/files/utils.py:526 src/olympia/files/utils.py:529
 msgid "Could not parse the manifest file."
 msgstr ""
 
-#: src/olympia/files/utils.py:551
+#: src/olympia/files/utils.py:548
 msgid "Could not find an add-on ID."
 msgstr ""
 
-#: src/olympia/files/utils.py:554
+#: src/olympia/files/utils.py:551
 msgid "Add-on ID must be 64 characters or less."
 msgstr ""
 
-#: src/olympia/files/utils.py:556
+#: src/olympia/files/utils.py:553
 msgid "Add-on ID doesn't match add-on."
 msgstr ""
 
-#: src/olympia/files/utils.py:564
+#: src/olympia/files/utils.py:561
 msgid "Duplicate add-on ID found."
 msgstr ""
 
-#: src/olympia/files/utils.py:567
+#: src/olympia/files/utils.py:564
 msgid "Version numbers should have fewer than 32 characters."
 msgstr ""
 
-#: src/olympia/files/utils.py:570
+#: src/olympia/files/utils.py:567
 msgid "Version numbers should only contain letters, numbers, and these punctuation characters: +*.-_."
 msgstr ""
 
-#: src/olympia/files/utils.py:587
+#: src/olympia/files/utils.py:584
 msgid "<em:type> doesn't match add-on"
 msgstr ""
 
@@ -8522,6 +8383,10 @@ msgstr ""
 
 #: src/olympia/files/templates/files/viewer.html:134
 msgid "Fetching file."
+msgstr ""
+
+#: src/olympia/legacy_api/views.py:255
+msgid "Not implemented yet."
 msgstr ""
 
 #: src/olympia/lib/constants.py:6
@@ -9180,10 +9045,6 @@ msgstr ""
 msgid "Zimbabwe Dollar"
 msgstr ""
 
-#: src/olympia/lib/video/ffmpeg.py:112 src/olympia/lib/video/totem.py:81
-msgid "Videos must be in WebM."
-msgstr ""
-
 #: src/olympia/pages/templates/pages/about.lhtml:3 src/olympia/pages/templates/pages/about.lhtml:10
 msgid "About Mozilla Add-ons"
 msgstr ""
@@ -9195,7 +9056,7 @@ msgstr ""
 #: src/olympia/pages/templates/pages/about.lhtml:13
 msgid ""
 "addons.mozilla.org, commonly known as \"AMO\", is Mozilla's official site for add-ons to Mozilla software, such as Firefox, Thunderbird, and SeaMonkey. Add-ons let you add new features and change "
-"the way your browser or application works.  Take a look around and explore the thousands of ways to customize the way you do things online."
+"the way your browser or application works. Take a look around and explore the thousands of ways to customize the way you do things online."
 msgstr ""
 
 #: src/olympia/pages/templates/pages/about.lhtml:19
@@ -9540,7 +9401,7 @@ msgstr ""
 msgid ""
 "Yes. It's possible, but some of the functionality provided by these libraries are available through XPCOM, XUL, and JavaScript. In addition, authors should take care if libraries modify primitive "
 "object prototypes (String.prototype, Date.prototype, etc.) and/or define global functions (eg. the $ function). These are prone to cause conflict with other add-ons, in particular if different add-"
-"ons use different versions of libraries and so on. Developers need to be very, very careful with using them.  Mozilla does not offer documentation on using them to build add-ons."
+"ons use different versions of libraries and so on. Developers need to be very, very careful with using them. Mozilla does not offer documentation on using them to build add-ons."
 msgstr ""
 
 #: src/olympia/pages/templates/pages/dev_faq.html:165
@@ -9654,8 +9515,8 @@ msgstr ""
 #, python-format
 msgid ""
 "Yes. Many developers choose to host their own add-ons. Choosing to host your add-on on <a href=\"%(amo_url)s\">Mozilla's add-on site</a>, though, allows for much greater exposure to your add-on due "
-"to the large volume of visitors to the site.  <a href=\"%(md_url)s\">mozdev.org</a> offers free project hosting for Mozilla applications and extensions providing developers with tools to help "
-"manage source code, version control, bug tracking and documentation."
+"to the large volume of visitors to the site. <a href=\"%(md_url)s\">mozdev.org</a> offers free project hosting for Mozilla applications and extensions providing developers with tools to help manage "
+"source code, version control, bug tracking and documentation."
 msgstr ""
 
 #: src/olympia/pages/templates/pages/dev_faq.html:277
@@ -9703,7 +9564,7 @@ msgstr ""
 #: src/olympia/pages/templates/pages/dev_faq.html:314
 #, python-format
 msgid ""
-"Yes. Mozilla's <a href=\"%(p_url)s\">Add-on Policy</a> describes what is an acceptable submission. This policy is subject to change without notice.  In addition, the AMO editorial team uses the <a "
+"Yes. Mozilla's <a href=\"%(p_url)s\">Add-on Policy</a> describes what is an acceptable submission. This policy is subject to change without notice. In addition, the AMO editorial team uses the <a "
 "href=\"%(g_url)s\">Editors Reviewing Guide</a> to ensure that your add-on meets specific guidelines for functionality and security."
 msgstr ""
 
@@ -9820,7 +9681,7 @@ msgstr ""
 #: src/olympia/pages/templates/pages/dev_faq.html:434
 #, python-format
 msgid ""
-"This is why it's very important to read the <a href=\"%(g_url)s\">Editors Reviewing Guide</a> to ensure that your add-on is setup as expected.  It's also a good idea to read the blog post, <a href="
+"This is why it's very important to read the <a href=\"%(g_url)s\">Editors Reviewing Guide</a> to ensure that your add-on is setup as expected. It's also a good idea to read the blog post, <a href="
 "\"%(blog_url)s\">Successfully Getting your Add-on Reviewed</a> which provides excellent insight into ensuring a smooth review of your add-on."
 msgstr ""
 
@@ -9927,7 +9788,7 @@ msgstr ""
 
 #: src/olympia/pages/templates/pages/dev_faq.html:572
 msgid ""
-"Free Software Foundation provides short summaries of the key open source licenses, including whether the license qualifies as a free software license or a copyleft license.  Also includes a "
+"Free Software Foundation provides short summaries of the key open source licenses, including whether the license qualifies as a free software license or a copyleft license. Also includes a "
 "discussion of what constitutes a free software license or a copyleft license (e.g., a Copyleft license is a general method for making a program or other work free, and requiring all modified and "
 "extended versions of the program to be free as well.)"
 msgstr ""
@@ -10105,19 +9966,13 @@ msgid "Add-on Gallery"
 msgstr ""
 
 #: src/olympia/pages/templates/pages/faq.html:171
-msgid ""
-"How do I choose between add-ons that seem to do the same\n"
-"    thing?"
+msgid "How do I choose between add-ons that seem to do the same thing?"
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:173
+#: src/olympia/pages/templates/pages/faq.html:172
 msgid ""
-"There are often several add-ons that have similar features. To\n"
-"    figure out which is right for you, read the entire description of the\n"
-"    add-on and view its screenshots. If there are still several in the running,\n"
-"    read through the add-on's ratings, user reviews, and statistics to see\n"
-"    which is most liked by other users. Remember that you can also just try\n"
-"    out both and see which you like better."
+"There are often several add-ons that have similar features. To figure out which is right for you, read the entire description of the add-on and view its screenshots. If there are still several in "
+"the running, read through the add-on's ratings, user reviews, and statistics to see which is most liked by other users. Remember that you can also just try out both and see which you like better."
 msgstr ""
 
 #: src/olympia/pages/templates/pages/faq.html:180
@@ -10158,80 +10013,67 @@ msgid "How much do add-ons cost to purchase?"
 msgstr ""
 
 #: src/olympia/pages/templates/pages/faq.html:207
-msgid ""
-"Add-ons hosted in our gallery are free unless clearly marked\n"
-"    otherwise."
+msgid "Add-ons hosted in our gallery are free unless clearly marked otherwise."
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:210
+#: src/olympia/pages/templates/pages/faq.html:209
 msgid "What does it mean when an add-on asks for contributions?"
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:211
+#: src/olympia/pages/templates/pages/faq.html:210
 msgid ""
-"Some add-on authors request users who enjoy an add-on to\n"
-"        contribute to its development by making a monetary contribution. These\n"
-"        contributions go directly to the developer unless a third party is\n"
-"        indicated, such as the non-profit Mozilla Foundation."
+"Some add-on authors request users who enjoy an add-on to contribute to its development by making a monetary contribution. These contributions go directly to the developer unless a third party is "
+"indicated, such as the non-profit Mozilla Foundation."
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:216
+#: src/olympia/pages/templates/pages/faq.html:215
 msgid "What are beta add-ons?"
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:218
+#: src/olympia/pages/templates/pages/faq.html:217
 msgid ""
-"Beta add-ons are unreviewed versions which represent the\n"
-"        latest work of an add-on author. While different authors have different\n"
-"        standards for beta code quality, you should assume that these add-ons\n"
-"        are less stable than the general add-on releases."
+"Beta add-ons are unreviewed versions which represent the latest work of an add-on author. While different authors have different standards for beta code quality, you should assume that these add-"
+"ons are less stable than the general add-on releases."
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:222
+#: src/olympia/pages/templates/pages/faq.html:221
 msgid ""
 "Please note that when you install an add-on from the \"Beta Version\" section of an add-on's listing, you will continue to receive updates for that add-on as they become available. Like the initial "
 "version you installed, all beta releases are unreviewed by Mozilla and may harm your computer."
 msgstr ""
 
+#: src/olympia/pages/templates/pages/faq.html:228
+msgid "What does it mean when an add-on is flagged as slow?"
+msgstr ""
+
 #: src/olympia/pages/templates/pages/faq.html:229
-msgid ""
-"What does it mean when an add-on is flagged as\n"
-"    slow?"
+msgid "Most add-ons load code and resources at the same time Firefox is starting up. In most cases the impact in start-up time is minimal, but some add-ons can cause a noticeable slowdown."
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:231
-msgid ""
-"Most add-ons load code and resources at the same time Firefox\n"
-"        is starting up. In most cases the impact in start-up time is minimal,\n"
-"        but some add-ons can cause a noticeable slowdown."
-msgstr ""
-
-#: src/olympia/pages/templates/pages/faq.html:236
+#: src/olympia/pages/templates/pages/faq.html:234
 msgid "How do I report an inappropriate or spam user review?"
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:237
+#: src/olympia/pages/templates/pages/faq.html:235
 msgid ""
-"To report a user review of an add-on, log in with your account\n"
-"    and visit the add-on's reviews page. Find the review you wish to report,\n"
-"    click \"Report this review\" and select a reason. Our editorial team will\n"
-"    investigate the review and take appropriate action."
+"To report a user review of an add-on, log in with your account and visit the add-on's reviews page. Find the review you wish to report, click \"Report this review\" and select a reason. Our "
+"editorial team will investigate the review and take appropriate action."
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:242
+#: src/olympia/pages/templates/pages/faq.html:240
 msgid "How do I report a bug or contact the Mozilla Add-ons team?"
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:243
+#: src/olympia/pages/templates/pages/faq.html:241
 #, python-format
 msgid "Please visit our <a href=\"%(contact_url)s\">Contact page</a>."
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:246
+#: src/olympia/pages/templates/pages/faq.html:244
 msgid "What is a Source Code License?"
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:247
+#: src/olympia/pages/templates/pages/faq.html:245
 #, python-format
 msgid ""
 "The source code used to create an add-on is an exclusive copyright of the add-on author, unless otherwise declared in a source code license. Many add-ons on this site have <a href=\"%(url)s\" lang="
@@ -10239,60 +10081,60 @@ msgid ""
 "the GPL or BSD licenses instead of making up their own."
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:256
+#: src/olympia/pages/templates/pages/faq.html:254
 #, python-format
 msgid "Firefox and other Mozilla software are <a href=\"%(url)s\">open source</a>."
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:264
+#: src/olympia/pages/templates/pages/faq.html:262
 msgid "Collections and Favorites"
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:267
+#: src/olympia/pages/templates/pages/faq.html:265
 msgid "What is a collection?"
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:268
+#: src/olympia/pages/templates/pages/faq.html:266
 msgid "Collections are groups of related add-ons created by users to share."
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:270
+#: src/olympia/pages/templates/pages/faq.html:268
 msgid "What is the My Favorites collection?"
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:271
+#: src/olympia/pages/templates/pages/faq.html:269
 msgid "Favorite add-ons are add-ons that you have bookmarked to easily get back to later. You can add an add-on to your favorites collection by clicking \"Add to favorites\" on its details page."
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:275 src/olympia/templates/menu_links.html:13 src/olympia/templates/impala/header_title.html:17
+#: src/olympia/pages/templates/pages/faq.html:273 src/olympia/templates/menu_links.html:13 src/olympia/templates/impala/header_title.html:17
 msgid "Mobile Add-ons"
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:278
+#: src/olympia/pages/templates/pages/faq.html:276
 msgid "What are mobile add-ons?"
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:279
+#: src/olympia/pages/templates/pages/faq.html:277
 #, python-format
 msgid ""
 "Mobile add-ons work with <a href=\"%(mobile_url)s\">Firefox for Mobile</a> and add or modify functionality just like desktop add-ons. You can find add-ons that work with Firefox for Mobile in our "
 "<a href=\"%(gallery_url)s\">gallery</a>."
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:288
+#: src/olympia/pages/templates/pages/faq.html:286
 msgid "Developer Topics"
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:289
+#: src/olympia/pages/templates/pages/faq.html:287
 #, python-format
 msgid "Please see our <a href=\"%(faq_url)s\">Developer FAQ</a> and <a href=\"%(hub_url)s\">Developer Hub</a> for answers to add-on developer-related questions."
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:294
+#: src/olympia/pages/templates/pages/faq.html:292
 msgid "Still have questions?"
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:295
+#: src/olympia/pages/templates/pages/faq.html:293
 #, python-format
 msgid "For general Firefox support, visit our <a href=\"%(sumo_url)s\">support website</a>. For general add-on and website questions, visit our <a href=\"%(forum_url)s\">forum</a>."
 msgstr ""
@@ -10430,7 +10272,7 @@ msgstr ""
 
 #: src/olympia/pages/templates/pages/sunbird.html:29
 msgid ""
-"Development on the Sunbird project has halted and its final release was on March 30, 2010.  We've been proud to host Sunbird add-ons on this site but as the project is no longer maintained we have "
+"Development on the Sunbird project has halted and its final release was on March 30, 2010. We've been proud to host Sunbird add-ons on this site but as the project is no longer maintained we have "
 "disabled our support for the add-ons."
 msgstr ""
 
@@ -10508,7 +10350,7 @@ msgstr ""
 #, python-format
 msgid ""
 "<h2>Keep these tips in mind:</h2> <ul> <li> Write like you're telling a friend about your experience with the add-on. Give specifics and helpful details, such as what features you liked and/or "
-"disliked, how easy to use it is, and any disadvantages it has.  Avoid generic language such as calling it \"Great\" or \"Bad\" unless you can give reasons why you believe this is so. </li> <li> "
+"disliked, how easy to use it is, and any disadvantages it has. Avoid generic language such as calling it \"Great\" or \"Bad\" unless you can give reasons why you believe this is so. </li> <li> "
 "Please do not post bug reports in reviews. We do not make your email address available to add-on developers and they may need to contact you to help resolve your issue. See the <a href=\"%(support)s"
 "\">support section</a> to find out where to get assistance for this add-on. </li> <li>Please keep reviews clean, avoid the use of improper language and do not post any personal information. </li> </"
 "ul> <p>Please read the <a href=\"%(guide)s\" target=\"_blank\">Review Guidelines</a> for more detail about user add-on reviews.</p>"
@@ -10744,16 +10586,16 @@ msgstr ""
 
 #. L10n: {0} is an application, such as Firefox. This means "any version of
 #. Firefox."
-#: src/olympia/search/views.py:554
+#: src/olympia/search/views.py:547
 msgid "Any {0}"
 msgstr ""
 
 #. L10n: "All Systems" means show everything regardless of platform.
-#: src/olympia/search/views.py:589
+#: src/olympia/search/views.py:582
 msgid "All Systems"
 msgstr ""
 
-#: src/olympia/search/views.py:600
+#: src/olympia/search/views.py:593
 msgid "All Tags"
 msgstr ""
 
@@ -10927,31 +10769,31 @@ msgstr ""
 msgid "Share this Collection"
 msgstr ""
 
-#: src/olympia/signing/views.py:30 src/olympia/templates/base.html:75 src/olympia/templates/impala/base.html:115
+#: src/olympia/signing/views.py:33 src/olympia/templates/base.html:71 src/olympia/templates/impala/base.html:112
 msgid "Some features are temporarily disabled while we perform website maintenance. We'll be back to full capacity shortly."
 msgstr ""
 
-#: src/olympia/signing/views.py:53
+#: src/olympia/signing/views.py:56
 msgid "Could not find add-on with id \"{}\"."
 msgstr ""
 
-#: src/olympia/signing/views.py:67
+#: src/olympia/signing/views.py:70
 msgid "You do not own this addon."
 msgstr ""
 
-#: src/olympia/signing/views.py:82
+#: src/olympia/signing/views.py:87
 msgid "Missing \"upload\" key in multipart file data."
 msgstr ""
 
-#: src/olympia/signing/views.py:96
+#: src/olympia/signing/views.py:101
 msgid "Version does not match the manifest file."
 msgstr ""
 
-#: src/olympia/signing/views.py:100
+#: src/olympia/signing/views.py:105
 msgid "Version already exists."
 msgstr ""
 
-#: src/olympia/signing/views.py:136
+#: src/olympia/signing/views.py:141
 msgid "No uploaded file for that addon and version."
 msgstr ""
 
@@ -11064,89 +10906,89 @@ msgstr ""
 msgid "Statistics Dashboard :: Add-ons for {0}"
 msgstr ""
 
-#: src/olympia/stats/templates/stats/stats.html:30
-msgid "Controls:"
-msgstr ""
-
-#: src/olympia/stats/templates/stats/stats.html:33
-msgid "reset zoom"
-msgstr ""
-
-#: src/olympia/stats/templates/stats/stats.html:40
-msgid "Group by:"
-msgstr ""
-
-#: src/olympia/stats/templates/stats/stats.html:42
-msgid "day"
-msgstr ""
-
-#: src/olympia/stats/templates/stats/stats.html:45
-msgid "week"
-msgstr ""
-
-#: src/olympia/stats/templates/stats/stats.html:48
-msgid "month"
-msgstr ""
-
-#: src/olympia/stats/templates/stats/stats.html:54
-msgid "For last:"
-msgstr ""
-
-#: src/olympia/stats/templates/stats/stats.html:57
-msgid "7 days"
-msgstr ""
-
-#: src/olympia/stats/templates/stats/stats.html:60
-msgid "30 days"
-msgstr ""
-
-#: src/olympia/stats/templates/stats/stats.html:63
-msgid "90 days"
-msgstr ""
-
-#: src/olympia/stats/templates/stats/stats.html:66
-msgid "365 days"
-msgstr ""
-
-#: src/olympia/stats/templates/stats/stats.html:69
-msgid "Custom..."
-msgstr ""
-
 #. {0} is an add-on name
-#: src/olympia/stats/templates/stats/stats.html:88 src/olympia/stats/templates/stats/stats.html:91
+#: src/olympia/stats/templates/stats/stats.html:44 src/olympia/stats/templates/stats/stats.html:47
 msgid "Statistics for {0}"
 msgstr ""
 
-#: src/olympia/stats/templates/stats/stats.html:94
+#: src/olympia/stats/templates/stats/stats.html:50
 msgid "Statistics Dashboard"
 msgstr ""
 
-#: src/olympia/stats/templates/stats/stats.html:104
+#: src/olympia/stats/templates/stats/stats.html:57
+msgid "Controls:"
+msgstr ""
+
+#: src/olympia/stats/templates/stats/stats.html:60
+msgid "reset zoom"
+msgstr ""
+
+#: src/olympia/stats/templates/stats/stats.html:67
+msgid "Group by:"
+msgstr ""
+
+#: src/olympia/stats/templates/stats/stats.html:69
+msgid "day"
+msgstr ""
+
+#: src/olympia/stats/templates/stats/stats.html:72
+msgid "week"
+msgstr ""
+
+#: src/olympia/stats/templates/stats/stats.html:75
+msgid "month"
+msgstr ""
+
+#: src/olympia/stats/templates/stats/stats.html:81
+msgid "For last:"
+msgstr ""
+
+#: src/olympia/stats/templates/stats/stats.html:84
+msgid "7 days"
+msgstr ""
+
+#: src/olympia/stats/templates/stats/stats.html:87
+msgid "30 days"
+msgstr ""
+
+#: src/olympia/stats/templates/stats/stats.html:90
+msgid "90 days"
+msgstr ""
+
+#: src/olympia/stats/templates/stats/stats.html:93
+msgid "365 days"
+msgstr ""
+
+#: src/olympia/stats/templates/stats/stats.html:96
+msgid "Custom..."
+msgstr ""
+
+#: src/olympia/stats/templates/stats/stats.html:106
 msgid "Statistics processing is currently disabled, so recent data is unavailable. The statistics are still being collected and this page will be updated soon with the missing data."
 msgstr ""
 
-#: src/olympia/stats/templates/stats/stats.html:110
+#: src/olympia/stats/templates/stats/stats.html:112
 msgid "Loading the latest data&hellip;"
 msgstr ""
 
-#: src/olympia/stats/templates/stats/stats.html:142 src/olympia/stats/templates/stats/reports/overview.html:25 src/olympia/stats/templates/stats/reports/overview.html:37
+#: src/olympia/stats/templates/stats/stats.html:144 src/olympia/stats/templates/stats/reports/overview.html:25 src/olympia/stats/templates/stats/reports/overview.html:37
 #: src/olympia/stats/templates/stats/reports/overview.html:49
 msgid "No data available."
 msgstr ""
 
-#: src/olympia/stats/templates/stats/stats.html:177
+#: src/olympia/stats/templates/stats/stats.html:179
 msgid "This dashboard is currently <b>public</b>."
 msgstr ""
 
-#: src/olympia/stats/templates/stats/stats.html:179
+#: src/olympia/stats/templates/stats/stats.html:181
 msgid "Contribution stats are currently <b>private</b>."
 msgstr ""
 
-#: src/olympia/stats/templates/stats/stats.html:182
+#: src/olympia/stats/templates/stats/stats.html:184
 msgid "This dashboard is currently <b>private</b>."
 msgstr ""
 
-#: src/olympia/stats/templates/stats/stats.html:185
+#: src/olympia/stats/templates/stats/stats.html:187
 msgid "Change settings."
 msgstr ""
 
@@ -11298,15 +11140,6 @@ msgstr ""
 msgid "Application versions by Date"
 msgstr ""
 
-#: src/olympia/tags/templates/tags/top_cloud.html:4
-msgid "Top {0} Tags"
-msgstr ""
-
-#. {0} is the current application name
-#: src/olympia/tags/templates/tags/top_cloud.html:14
-msgid "{0} Top Tags"
-msgstr ""
-
 #: src/olympia/templates/amo_footer.html:6 src/olympia/templates/includes/lang_switcher.html:2
 msgid "Other languages"
 msgstr ""
@@ -11315,11 +11148,11 @@ msgstr ""
 msgid "Mozilla Add-ons"
 msgstr ""
 
-#: src/olympia/templates/base.html:91 src/olympia/templates/impala/base.html:81
+#: src/olympia/templates/base.html:89 src/olympia/templates/impala/base.html:78
 msgid "Find add-ons for other applications"
 msgstr ""
 
-#: src/olympia/templates/base.html:92 src/olympia/templates/impala/base.html:81
+#: src/olympia/templates/base.html:90 src/olympia/templates/impala/base.html:78
 msgid "Other Applications"
 msgstr ""
 
@@ -11344,7 +11177,7 @@ msgid "View Mobile Site"
 msgstr ""
 
 #: src/olympia/templates/copyright.html:7
-msgid "Site Status "
+msgid "Site Status"
 msgstr ""
 
 #: src/olympia/templates/footer.html:3
@@ -11444,35 +11277,35 @@ msgstr ""
 msgid "<a href=\"%(reg)s\">Register</a> or <a href=\"%(login)s\">Log in</a>"
 msgstr ""
 
-#: src/olympia/templates/impala/base.html:126
+#: src/olympia/templates/impala/base.html:123
 #, python-format
 msgid "To try the thousands of add-ons available here, download <a href=\"%(url)s\">Mozilla Firefox</a>, a fast, free way to surf the Web!"
 msgstr ""
 
-#: src/olympia/templates/impala/base.html:138
+#: src/olympia/templates/impala/base.html:135
 #, python-format
 msgid "Add-ons is switching to Firefox Accounts for login. <a href=\"%(url)s\" class=\"fxa-login\">Sign in now to transfer your account.</a>"
 msgstr ""
 
 #. {0} is an application, such as Firefox.
-#: src/olympia/templates/impala/base.html:148
+#: src/olympia/templates/impala/base.html:145
 msgid "Welcome to {0} Add-ons."
 msgstr ""
 
-#: src/olympia/templates/impala/base.html:151
+#: src/olympia/templates/impala/base.html:148
 msgid "Choose from thousands of extra features and styles to make Firefox your own."
 msgstr ""
 
-#: src/olympia/templates/impala/base.html:156
+#: src/olympia/templates/impala/base.html:153
 #, python-format
 msgid "Add extra features and styles to make %(app)s your own."
 msgstr ""
 
-#: src/olympia/templates/impala/base.html:164
+#: src/olympia/templates/impala/base.html:161
 msgid "On the go?"
 msgstr ""
 
-#: src/olympia/templates/impala/base.html:166
+#: src/olympia/templates/impala/base.html:163
 msgid "Check out our <a class=\"mobile-link\" href=\"#\">Mobile Add-ons site</a>."
 msgstr ""
 
@@ -11696,19 +11529,19 @@ msgstr ""
 
 #. L10n: {id} will be something like "13ad6a", just a random number
 #. to differentiate this user from other anonymous users.
-#: src/olympia/users/models.py:353
+#: src/olympia/users/models.py:362
 msgid "Anonymous user {id}"
 msgstr ""
 
-#: src/olympia/users/models.py:410
+#: src/olympia/users/models.py:419
 msgid "Your account has been restricted"
 msgstr ""
 
-#: src/olympia/users/models.py:480
+#: src/olympia/users/models.py:489
 msgid "Please confirm your email address"
 msgstr ""
 
-#: src/olympia/users/models.py:506
+#: src/olympia/users/models.py:515
 msgid "My Mobile Add-ons"
 msgstr ""
 
@@ -11985,7 +11818,7 @@ msgstr ""
 
 #: src/olympia/users/templates/users/edit.html:70
 #, python-format
-msgid "Change your password.  If you forgot your password, you can <a href=\"%(reset_url)s\">use the reset form</a>."
+msgid "Change your password. If you forgot your password, you can <a href=\"%(reset_url)s\">use the reset form</a>."
 msgstr ""
 
 #: src/olympia/users/templates/users/edit.html:76
@@ -12005,7 +11838,7 @@ msgid "Profile"
 msgstr ""
 
 #: src/olympia/users/templates/users/edit.html:100
-msgid "Give us a bit more information about yourself.  All these fields are optional, but they'll help other users get to know you better."
+msgid "Give us a bit more information about yourself. All these fields are optional, but they'll help other users get to know you better."
 msgstr ""
 
 #: src/olympia/users/templates/users/edit.html:124
@@ -12221,7 +12054,7 @@ msgid "Confirm password"
 msgstr ""
 
 #: src/olympia/users/templates/users/pwreset_confirm.html:47
-msgid "The password reset link was invalid, possibly because it has already been used.  Please request a new password reset."
+msgid "The password reset link was invalid, possibly because it has already been used. Please request a new password reset."
 msgstr ""
 
 #: src/olympia/users/templates/users/pwreset_request.html:15
@@ -12407,7 +12240,7 @@ msgstr ""
 
 #: src/olympia/users/templates/users/unsubscribe.html:30
 #, python-format
-msgid "Unfortunately, we weren't able to unsubscribe you.  The link you clicked is invalid. However, you can unsubscribe still unsubscribe on your <a href=\"%(edit_url)s\">edit profile page</a>."
+msgid "Unfortunately, we weren't able to unsubscribe you. The link you clicked is invalid. However, you can unsubscribe still unsubscribe on your <a href=\"%(edit_url)s\">edit profile page</a>."
 msgstr ""
 
 #: src/olympia/users/templates/users/vcard.html:2
@@ -12461,15 +12294,15 @@ msgstr ""
 msgid "Version History with Changelogs"
 msgstr ""
 
-#: src/olympia/versions/models.py:314
+#: src/olympia/versions/models.py:313
 msgid "Add-on uses binary components."
 msgstr ""
 
-#: src/olympia/versions/models.py:317
+#: src/olympia/versions/models.py:316
 msgid "Add-on has opted into strict compatibility checking."
 msgstr ""
 
-#: src/olympia/versions/models.py:715
+#: src/olympia/versions/models.py:711
 msgid "{app} {min} and later"
 msgstr ""
 
@@ -12544,4 +12377,8 @@ msgstr ""
 
 #: src/olympia/zadmin/forms.py:105
 msgid "Log emails instead of sending"
+msgstr ""
+
+#: src/olympia/zadmin/forms.py:215
+msgid "Deleted versions can`t be changed."
 msgstr ""

--- a/locale/ku/LC_MESSAGES/djangojs.po
+++ b/locale/ku/LC_MESSAGES/djangojs.po
@@ -1,1215 +1,1235 @@
-
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2016-02-24 21:23+0000\n"
+"POT-Creation-Date: 2016-04-18 15:47+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
+"Language: \n"
 "MIME-Version: 1.0\n"
-"Content-Type: text/plain; charset=utf-8\n"
+"Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Generated-By: Babel 2.2.0\n"
 
-#: static/js/common/ratingwidget.js:31
+#: static/js/common-all.js:1426 static/js/impala-all.js:1511 static/js/zamboni/discovery-all.js:12598 static/js/zamboni/init.js:28 static/js/zamboni/mobile-all.js:14945
+msgid "This feature is temporarily disabled while we perform website maintenance. Please check back a little later."
+msgstr ""
+
+#. L10n: {0} is an app name like Firefox.
+#: static/js/common-all.js:1837 static/js/impala-all.js:1922 static/js/zamboni/buttons.js:73 static/js/zamboni/discovery-all.js:13108
+msgid "Accept and Install"
+msgstr ""
+
+#: static/js/common-all.js:1837 static/js/impala-all.js:1922 static/js/zamboni/buttons.js:73 static/js/zamboni/discovery-all.js:13108
+msgid "Add to {0}"
+msgstr ""
+
+#: static/js/common-all.js:1842 static/js/impala-all.js:1927 static/js/zamboni/buttons.js:78 static/js/zamboni/discovery-all.js:13113
+msgid "Download Now"
+msgstr ""
+
+#: static/js/common-all.js:1883 static/js/impala-all.js:1968 static/js/zamboni/buttons.js:119 static/js/zamboni/discovery-all.js:13154
+msgid "Add-on has not been updated to support default-to-compatible."
+msgstr ""
+
+#: static/js/common-all.js:1888 static/js/impala-all.js:1973 static/js/zamboni/buttons.js:124 static/js/zamboni/discovery-all.js:13159
+msgid "You need to be using Firefox 10.0 or higher."
+msgstr ""
+
+#: static/js/common-all.js:1900 static/js/impala-all.js:1985 static/js/zamboni/buttons.js:136 static/js/zamboni/discovery-all.js:13171
+msgid "Mozilla has marked this version as incompatible with your Firefox version."
+msgstr ""
+
+#. L10n: {0} is an platform like Windows or Linux.
+#: static/js/common-all.js:1981 static/js/impala-all.js:2066 static/js/zamboni/buttons.js:217 static/js/zamboni/discovery-all.js:13252
+msgid "Install for {0} anyway"
+msgstr ""
+
+#: static/js/common-all.js:1981 static/js/impala-all.js:2066 static/js/zamboni/buttons.js:217 static/js/zamboni/discovery-all.js:13252
+msgid "Download for {0} anyway"
+msgstr ""
+
+#: static/js/common-all.js:2038 static/js/impala-all.js:2123 static/js/zamboni/buttons.js:274 static/js/zamboni/discovery-all.js:13309
+msgid "Not available for your platform"
+msgstr ""
+
+#. L10n: {0} is an app name, {1} is the app version.
+#: static/js/common-all.js:2049 static/js/common-all.js:2086 static/js/impala-all.js:2134 static/js/impala-all.js:2171 static/js/zamboni/buttons.js:286 static/js/zamboni/buttons.js:324
+#: static/js/zamboni/discovery-all.js:13320 static/js/zamboni/discovery-all.js:13357
+msgid "Not available for {0} {1}"
+msgstr ""
+
+#: static/js/common-all.js:2112 static/js/impala-all.js:2197 static/js/zamboni/buttons.js:351 static/js/zamboni/discovery-all.js:13383
+msgid "Works with {app} {min} - {max}"
+msgstr ""
+
+#: static/js/common-all.js:2114 static/js/impala-all.js:2199 static/js/zamboni/buttons.js:353 static/js/zamboni/discovery-all.js:13385
+msgid "View other versions"
+msgstr ""
+
+#: static/js/common-all.js:2162 static/js/impala-all.js:2247 static/js/zamboni/buttons.js:401 static/js/zamboni/discovery-all.js:13433
+msgid "Only with Firefox — Get Firefox Now!"
+msgstr ""
+
+#: static/js/common-all.js:2278 static/js/impala-all.js:2363 static/js/zamboni/buttons.js:517 static/js/zamboni/discovery-all.js:13549 static/js/zamboni/mobile-all.js:15177
+#: static/js/zamboni/mobile/buttons.js:43
+msgid "Sorry, you need a Mozilla-based browser (such as Firefox) to install a search plugin."
+msgstr ""
+
+#: static/js/common-all.js:9088 static/js/impala-all.js:9649 static/js/zamboni/global.js:410
+msgid "Loading..."
+msgstr ""
+
+#. L10n: {0} is the number of characters left.
+#: static/js/common-all.js:9152 static/js/impala-all.js:9713 static/js/zamboni/global.js:474
+msgid "<b>{0}</b> character left."
+msgid_plural "<b>{0}</b> characters left."
+msgstr[0] ""
+msgstr[1] ""
+
+#: static/js/common-all.js:9589 static/js/common-min.js:6 static/js/impala-all.js:10052 static/js/impala-min.js:6 static/js/common/ratingwidget.js:31 static/js/zamboni/mobile-all.js:16123
+#: static/js/zamboni/mobile-min.js:6
 msgid "{0} star"
 msgid_plural "{0} stars"
 msgstr[0] ""
 msgstr[1] ""
 
-#: static/js/common/upload-addon.js:41 static/js/common/upload-image.js:128
+#: static/js/common-all.js:9676 static/js/common-min.js:6 static/js/impala-all.js:10139 static/js/impala-min.js:6 static/js/zamboni/l10n.js:45
+msgid "Remove this localization"
+msgstr ""
+
+#: static/js/common-all.js:10193 static/js/common-min.js:6 static/js/impala-all.js:10674 static/js/impala-min.js:6 static/js/zamboni/discovery-all.js:13678
+msgid "close"
+msgstr ""
+
+#: static/js/common-all.js:10860 static/js/common-min.js:6 static/js/impala-all.js:11481 static/js/impala-min.js:6 static/js/impala/reviews.js:23 static/js/zamboni/reviews.js:18
+msgid "Flagged for review"
+msgstr ""
+
+#: static/js/common-all.js:10876 static/js/common-min.js:6 static/js/impala-all.js:11498 static/js/impala-min.js:6 static/js/impala/reviews.js:40 static/js/zamboni/reviews.js:34
+msgid "Your input is required"
+msgstr ""
+
+#: static/js/common-all.js:10945 static/js/common-min.js:6 static/js/impala-all.js:11610 static/js/impala-min.js:7 static/js/impala/reviews.js:152 static/js/zamboni/reviews.js:103
+msgid "Marked for deletion"
+msgstr ""
+
+#: static/js/common-all.js:11573 static/js/common-min.js:7 static/js/impala-all.js:13809 static/js/impala-min.js:8 static/js/zamboni/collections.js:229
+msgid "Adding to Favorites&hellip;"
+msgstr ""
+
+#: static/js/common-all.js:11576 static/js/common-min.js:7 static/js/impala-all.js:13812 static/js/impala-min.js:8 static/js/zamboni/collections.js:232
+msgid "Removing Favorite&hellip;"
+msgstr ""
+
+#: static/js/common-all.js:11579 static/js/common-min.js:7 static/js/impala-all.js:13815 static/js/impala-min.js:8 static/js/zamboni/collections.js:235
+msgid "Add to Favorites"
+msgstr ""
+
+#: static/js/common-all.js:11582 static/js/common-min.js:7 static/js/impala-all.js:13818 static/js/impala-min.js:8 static/js/zamboni/collections.js:238
+msgid "Remove from Favorites"
+msgstr ""
+
+#: static/js/common-all.js:11647 static/js/common-min.js:7 static/js/impala-all.js:13883 static/js/impala-min.js:8 static/js/zamboni/collections.js:303
+msgid "Pending"
+msgstr ""
+
+#: static/js/common-all.js:11648 static/js/common-min.js:7 static/js/impala-all.js:13884 static/js/impala-min.js:8 static/js/zamboni/collections.js:304
+msgid "Add a comment"
+msgstr ""
+
+#: static/js/common-all.js:11648 static/js/common-min.js:7 static/js/impala-all.js:13884 static/js/impala-min.js:8 static/js/zamboni/collections.js:304
+msgid "Comment"
+msgstr ""
+
+#: static/js/common-all.js:11649 static/js/common-min.js:7 static/js/impala-all.js:13885 static/js/impala-min.js:8 static/js/zamboni/collections.js:305
+msgid "Remove this add-on from the collection"
+msgstr ""
+
+#: static/js/common-all.js:11649 static/js/common-all.js:11678 static/js/common-min.js:7 static/js/impala-all.js:13885 static/js/impala-all.js:13914 static/js/impala-min.js:8
+#: static/js/zamboni/collections.js:305 static/js/zamboni/collections.js:334
+msgid "Remove"
+msgstr ""
+
+#: static/js/common-all.js:11678 static/js/common-min.js:7 static/js/impala-all.js:13914 static/js/impala-min.js:8 static/js/zamboni/collections.js:334
+msgid "Remove this user as a contributor"
+msgstr ""
+
+#: static/js/common-all.js:11690 static/js/common-min.js:7 static/js/impala-all.js:13926 static/js/impala-min.js:8 static/js/zamboni/collections.js:346
+msgid "An email address is required."
+msgstr ""
+
+#: static/js/common-all.js:11708 static/js/common-min.js:7 static/js/impala-all.js:13944 static/js/impala-min.js:8 static/js/zamboni/collections.js:364
+msgid "You cannot add yourself as a contributor."
+msgstr ""
+
+#: static/js/common-all.js:11710 static/js/common-min.js:7 static/js/impala-all.js:13946 static/js/impala-min.js:8 static/js/zamboni/collections.js:366
+msgid "You have already added that user."
+msgstr ""
+
+#: static/js/common-all.js:11917 static/js/common-min.js:7 static/js/impala-all.js:14153 static/js/impala-min.js:8 static/js/zamboni/collections.js:573
+msgid "Add to favorites"
+msgstr ""
+
+#: static/js/common-all.js:11921 static/js/common-min.js:7 static/js/impala-all.js:14157 static/js/impala-min.js:8 static/js/zamboni/collections.js:577
+msgid "Remove from favorites"
+msgstr ""
+
+#: static/js/common-all.js:11939 static/js/common-min.js:7 static/js/impala-all.js:14175 static/js/impala-all.js:14233 static/js/impala-min.js:8 static/js/impala/collections.js:10
+#: static/js/zamboni/collections.js:595
+msgid "Follow this Collection"
+msgstr ""
+
+#: static/js/common-all.js:11948 static/js/common-min.js:7 static/js/impala-all.js:14184 static/js/impala-min.js:8 static/js/zamboni/collections.js:604
+msgid "Stop following"
+msgstr ""
+
+#: static/js/common-all.js:12096 static/js/common-min.js:7 static/js/zamboni/password-strength.js:20
+msgid "Password strength:"
+msgstr ""
+
+#: static/js/common-all.js:12102 static/js/common-min.js:7 static/js/zamboni/password-strength.js:26
+msgid "At least {0} character left."
+msgid_plural "At least {0} characters left."
+msgstr[0] ""
+msgstr[1] ""
+
+#: static/js/common-all.js:12286 static/js/common-min.js:7 static/js/impala-all.js:14632 static/js/impala-min.js:8 static/js/impala/suggestions.js:39
+msgid "Search themes for <b>{0}</b>"
+msgstr ""
+
+#: static/js/common-all.js:12288 static/js/common-min.js:7 static/js/impala-all.js:14634 static/js/impala-min.js:8 static/js/impala/suggestions.js:41
+msgid "Search apps for <b>{0}</b>"
+msgstr ""
+
+#: static/js/common-all.js:12290 static/js/common-min.js:7 static/js/impala-all.js:14636 static/js/impala-min.js:8 static/js/impala/suggestions.js:43
+msgid "Search add-ons for <b>{0}</b>"
+msgstr ""
+
+#: static/js/common-all.js:12521 static/js/common-min.js:7 static/js/impala-all.js:14867 static/js/impala-min.js:8 static/js/impala/site_suggestions.js:46
+msgid "Category"
+msgstr ""
+
+#. L10n: {0} is an app name.
+#: static/js/impala-all.js:11632 static/js/impala-min.js:7 static/js/impala/listing.js:11 static/js/zamboni/themes.js:13
+msgid "This theme is incompatible with your version of {0}"
+msgstr ""
+
+#: static/js/impala-all.js:12146 static/js/impala-all.js:14331 static/js/impala-min.js:7 static/js/impala-min.js:8 static/js/common/upload-image.js:97 static/js/impala/users.js:51
+#: static/js/zamboni/devhub-all.js:894 static/js/zamboni/devhub-min.js:1
+msgid "Images must be either PNG or JPG."
+msgstr ""
+
+#: static/js/impala-all.js:12150 static/js/impala-min.js:7 static/js/common/upload-image.js:101 static/js/zamboni/devhub-all.js:898 static/js/zamboni/devhub-min.js:1
+msgid "Videos must be in WebM."
+msgstr ""
+
+#: static/js/impala-all.js:12177 static/js/impala-min.js:7 static/js/common/upload-addon.js:41 static/js/common/upload-image.js:128 static/js/zamboni/devhub-all.js:272
+#: static/js/zamboni/devhub-all.js:925 static/js/zamboni/devhub-min.js:1
 msgid "There was a problem contacting the server."
 msgstr ""
 
-#: static/js/common/upload-addon.js:69
+#: static/js/impala-all.js:13298 static/js/impala-min.js:7 static/js/impala/persona_creation.js:60
+msgid "All Rights Reserved"
+msgstr ""
+
+#: static/js/impala-all.js:13302 static/js/impala-min.js:7 static/js/impala/persona_creation.js:64
+msgid "Creative Commons Attribution 3.0"
+msgstr ""
+
+#: static/js/impala-all.js:13307 static/js/impala-min.js:7 static/js/impala/persona_creation.js:69
+msgid "Creative Commons Attribution-NonCommercial 3.0"
+msgstr ""
+
+#: static/js/impala-all.js:13312 static/js/impala-min.js:7 static/js/impala/persona_creation.js:74
+msgid "Creative Commons Attribution-NonCommercial-NoDerivs 3.0"
+msgstr ""
+
+#: static/js/impala-all.js:13317 static/js/impala-min.js:7 static/js/impala/persona_creation.js:79
+msgid "Creative Commons Attribution-NonCommercial-Share Alike 3.0"
+msgstr ""
+
+#: static/js/impala-all.js:13322 static/js/impala-min.js:7 static/js/impala/persona_creation.js:84
+msgid "Creative Commons Attribution-NoDerivs 3.0"
+msgstr ""
+
+#: static/js/impala-all.js:13327 static/js/impala-min.js:7 static/js/impala/persona_creation.js:89
+msgid "Creative Commons Attribution-ShareAlike 3.0"
+msgstr ""
+
+#: static/js/impala-all.js:13530 static/js/impala-min.js:7 static/js/impala/persona_creation.js:292
+msgid "Your Theme's Name"
+msgstr ""
+
+#: static/js/impala-all.js:14242 static/js/impala-min.js:8 static/js/impala/collections.js:19
+msgid "Stop Following"
+msgstr ""
+
+#: static/js/impala-all.js:14243 static/js/impala-min.js:8 static/js/impala/collections.js:20
+msgid "Following"
+msgstr ""
+
+#: static/js/impala-all.js:14313 static/js/impala-min.js:8 static/js/impala/users.js:33
+msgid "use original"
+msgstr ""
+
+#: static/js/impala-all.js:14523 static/js/impala-min.js:8 static/js/impala/search.js:114
+msgid "Updating results&hellip;"
+msgstr ""
+
+#: static/js/common/upload-addon.js:69 static/js/zamboni/devhub-all.js:300 static/js/zamboni/devhub-min.js:1
 msgid "Select a file..."
 msgstr ""
 
-#: static/js/common/upload-addon.js:70
+#: static/js/common/upload-addon.js:70 static/js/zamboni/devhub-all.js:301 static/js/zamboni/devhub-min.js:1
 msgid "Your add-on should end with .xpi, .jar or .xml"
 msgstr ""
 
 #. L10n: {0} is the percent of the file that has been uploaded.
-#: static/js/common/upload-addon.js:104
+#: static/js/common/upload-addon.js:104 static/js/zamboni/devhub-all.js:335 static/js/zamboni/devhub-min.js:1
 #, python-format
 msgid "{0}% complete"
 msgstr ""
 
 #. L10n: "{bytes uploaded} of {total filesize}".
-#: static/js/common/upload-addon.js:107
+#: static/js/common/upload-addon.js:107 static/js/zamboni/devhub-all.js:338 static/js/zamboni/devhub-min.js:1
 msgid "{0} of {1}"
 msgstr ""
 
-#: static/js/common/upload-addon.js:140
+#: static/js/common/upload-addon.js:140 static/js/zamboni/devhub-all.js:371 static/js/zamboni/devhub-min.js:1
 msgid "Cancel"
 msgstr ""
 
-#: static/js/common/upload-addon.js:162
+#: static/js/common/upload-addon.js:162 static/js/zamboni/devhub-all.js:393 static/js/zamboni/devhub-min.js:1
 msgid "Uploading {0}"
 msgstr ""
 
-#: static/js/common/upload-addon.js:189
+#: static/js/common/upload-addon.js:189 static/js/zamboni/devhub-all.js:420 static/js/zamboni/devhub-min.js:1
 msgid "Error with {0}"
 msgstr ""
 
-#: static/js/common/upload-addon.js:194
+#: static/js/common/upload-addon.js:194 static/js/zamboni/devhub-all.js:425 static/js/zamboni/devhub-min.js:1
 msgid "Your add-on failed validation with {0} error."
 msgid_plural "Your add-on failed validation with {0} errors."
 msgstr[0] ""
 msgstr[1] ""
 
-#: static/js/common/upload-addon.js:208
+#: static/js/common/upload-addon.js:208 static/js/zamboni/devhub-all.js:439 static/js/zamboni/devhub-min.js:1
 msgid "&hellip;and {0} more"
 msgid_plural "&hellip;and {0} more"
 msgstr[0] ""
 msgstr[1] ""
 
-#: static/js/common/upload-addon.js:222 static/js/common/upload-addon.js:512
+#: static/js/common/upload-addon.js:222 static/js/common/upload-addon.js:497 static/js/zamboni/devhub-all.js:453 static/js/zamboni/devhub-all.js:743 static/js/zamboni/devhub-min.js:1
 msgid "See full validation report"
 msgstr ""
 
-#: static/js/common/upload-addon.js:234
+#: static/js/common/upload-addon.js:234 static/js/zamboni/devhub-all.js:465 static/js/zamboni/devhub-min.js:1
 msgid "Validating {0}"
 msgstr ""
 
 #. L10n: first argument is an HTTP status code
-#: static/js/common/upload-addon.js:273
+#: static/js/common/upload-addon.js:273 static/js/zamboni/devhub-all.js:504 static/js/zamboni/devhub-min.js:1
 msgid "Received an empty response from the server; status: {0}"
 msgstr ""
 
-#: static/js/common/upload-addon.js:373
+#: static/js/common/upload-addon.js:370 static/js/zamboni/devhub-all.js:604 static/js/zamboni/devhub-min.js:1
 msgid "Unexpected server error while validating."
 msgstr ""
 
-#: static/js/common/upload-addon.js:412
+#: static/js/common/upload-addon.js:409 static/js/zamboni/devhub-all.js:643 static/js/zamboni/devhub-min.js:1
 msgid "Finished validating {0}"
 msgstr ""
 
-#: static/js/common/upload-addon.js:418
+#: static/js/common/upload-addon.js:415 static/js/zamboni/devhub-all.js:649 static/js/zamboni/devhub-min.js:1
 msgid "Your add-on validation timed out, it will be manually reviewed."
 msgstr ""
 
-#: static/js/common/upload-addon.js:421
+#: static/js/common/upload-addon.js:418 static/js/zamboni/devhub-all.js:652 static/js/zamboni/devhub-min.js:1
 msgid "Your add-on was validated with no errors and {0} warning."
 msgid_plural "Your add-on was validated with no errors and {0} warnings."
 msgstr[0] ""
 msgstr[1] ""
 
-#: static/js/common/upload-addon.js:426
+#: static/js/common/upload-addon.js:423 static/js/zamboni/devhub-all.js:657 static/js/zamboni/devhub-min.js:1
 msgid "Your add-on was validated with no errors and {0} message."
 msgid_plural "Your add-on was validated with no errors and {0} messages."
 msgstr[0] ""
 msgstr[1] ""
 
-#: static/js/common/upload-addon.js:431
+#: static/js/common/upload-addon.js:428 static/js/zamboni/devhub-all.js:662 static/js/zamboni/devhub-min.js:1
 msgid "Your add-on was validated with no errors or warnings."
 msgstr ""
 
-#: static/js/common/upload-addon.js:446
+#: static/js/common/upload-addon.js:443 static/js/zamboni/devhub-all.js:677 static/js/zamboni/devhub-min.js:1
 msgid "Your submission will be automatically signed."
 msgstr ""
 
-#: static/js/common/upload-addon.js:465
+#: static/js/common/upload-addon.js:450 static/js/zamboni/devhub-all.js:696 static/js/zamboni/devhub-min.js:1
 msgid "Include detailed version notes (this can be done in the next step)."
 msgstr ""
 
-#: static/js/common/upload-addon.js:466
+#: static/js/common/upload-addon.js:451 static/js/zamboni/devhub-all.js:697 static/js/zamboni/devhub-min.js:1
 msgid "If your add-on requires an account to a website in order to be fully tested, include a test username and password in the Notes to Reviewer (this can be done in the next step)."
 msgstr ""
 
-#: static/js/common/upload-addon.js:467
+#: static/js/common/upload-addon.js:452 static/js/zamboni/devhub-all.js:698 static/js/zamboni/devhub-min.js:1
 msgid "If your add-on is intended for a limited audience you should choose Preliminary Review instead of Full Review."
 msgstr ""
 
-#: static/js/common/upload-addon.js:480
+#: static/js/common/upload-addon.js:465 static/js/zamboni/devhub-all.js:711 static/js/zamboni/devhub-min.js:1
 msgid "Add-on submission checklist"
 msgstr ""
 
-#: static/js/common/upload-addon.js:481
+#: static/js/common/upload-addon.js:466 static/js/zamboni/devhub-all.js:712 static/js/zamboni/devhub-min.js:1
 msgid "Please verify the following points before finalizing your submission. This will minimize delays or misunderstanding during the review process:"
 msgstr ""
 
-#: static/js/common/upload-addon.js:483
+#: static/js/common/upload-addon.js:468 static/js/zamboni/devhub-all.js:714 static/js/zamboni/devhub-min.js:1
 msgid ""
 "Compiled binaries, as well as minified or obfuscated scripts (excluding known libraries) need to have their sources submitted separately for review. Make sure that you use the source code upload "
 "field to avoid having your submission rejected."
 msgstr ""
 
-#: static/js/common/upload-addon.js:501
+#: static/js/common/upload-addon.js:486 static/js/zamboni/devhub-all.js:732 static/js/zamboni/devhub-min.js:1
 msgid "The validation process found these issues that can lead to rejections:"
 msgstr ""
 
-#: static/js/common/upload-addon.js:518
+#: static/js/common/upload-addon.js:503 static/js/zamboni/devhub-all.js:749 static/js/zamboni/devhub-min.js:1
 msgid "If you are unfamiliar with the add-ons review process, you can read about it here."
 msgstr ""
 
-#: static/js/common/upload-addon.js:555
+#: static/js/common/upload-addon.js:540 static/js/zamboni/devhub-all.js:786 static/js/zamboni/devhub-min.js:1
 msgid "Sorry, no supported platform has been found."
 msgstr ""
 
-#: static/js/common/upload-base.js:57
+#: static/js/common/upload-base.js:57 static/js/zamboni/devhub-all.js:187 static/js/zamboni/devhub-min.js:1
 msgid "The filetype you uploaded isn't recognized."
 msgstr ""
 
-#: static/js/common/upload-base.js:79
+#: static/js/common/upload-base.js:79 static/js/zamboni/devhub-all.js:209 static/js/zamboni/devhub-min.js:1
 msgid "You cancelled the upload."
 msgstr ""
 
-#: static/js/common/upload-image.js:97 static/js/impala/users.js:51
-msgid "Images must be either PNG or JPG."
-msgstr ""
-
-#: static/js/common/upload-image.js:101
-msgid "Videos must be in WebM."
-msgstr ""
-
-#: static/js/impala/collections.js:10 static/js/zamboni/collections.js:595
-msgid "Follow this Collection"
-msgstr ""
-
-#: static/js/impala/collections.js:19
-msgid "Stop Following"
-msgstr ""
-
-#: static/js/impala/collections.js:20
-msgid "Following"
-msgstr ""
-
-#. L10n: {0} is an app name.
-#: static/js/impala/listing.js:11 static/js/zamboni/themes.js:13
-msgid "This theme is incompatible with your version of {0}"
-msgstr ""
-
-#: static/js/impala/persona_creation.js:60
-msgid "All Rights Reserved"
-msgstr ""
-
-#: static/js/impala/persona_creation.js:64
-msgid "Creative Commons Attribution 3.0"
-msgstr ""
-
-#: static/js/impala/persona_creation.js:69
-msgid "Creative Commons Attribution-NonCommercial 3.0"
-msgstr ""
-
-#: static/js/impala/persona_creation.js:74
-msgid "Creative Commons Attribution-NonCommercial-NoDerivs 3.0"
-msgstr ""
-
-#: static/js/impala/persona_creation.js:79
-msgid "Creative Commons Attribution-NonCommercial-Share Alike 3.0"
-msgstr ""
-
-#: static/js/impala/persona_creation.js:84
-msgid "Creative Commons Attribution-NoDerivs 3.0"
-msgstr ""
-
-#: static/js/impala/persona_creation.js:89
-msgid "Creative Commons Attribution-ShareAlike 3.0"
-msgstr ""
-
-#: static/js/impala/persona_creation.js:292
-msgid "Your Theme's Name"
-msgstr ""
-
-#: static/js/impala/reviews.js:23 static/js/zamboni/reviews.js:18
-msgid "Flagged for review"
-msgstr ""
-
-#: static/js/impala/reviews.js:40 static/js/zamboni/reviews.js:34
-msgid "Your input is required"
-msgstr ""
-
-#: static/js/impala/reviews.js:152 static/js/zamboni/reviews.js:103
-msgid "Marked for deletion"
-msgstr ""
-
-#: static/js/impala/search.js:114
-msgid "Updating results&hellip;"
-msgstr ""
-
-#: static/js/impala/site_suggestions.js:46
-msgid "Category"
-msgstr ""
-
-#: static/js/impala/suggestions.js:39
-msgid "Search themes for <b>{0}</b>"
-msgstr ""
-
-#: static/js/impala/suggestions.js:41
-msgid "Search apps for <b>{0}</b>"
-msgstr ""
-
-#: static/js/impala/suggestions.js:43
-msgid "Search add-ons for <b>{0}</b>"
-msgstr ""
-
-#: static/js/impala/users.js:33
-msgid "use original"
-msgstr ""
-
-#: static/js/impala/stats/chart.js:267
+#: static/js/impala/stats/chart.js:267 static/js/zamboni/stats-all.js:16898 static/js/zamboni/stats-min.js:5
 msgid "Week of {0}"
 msgstr ""
 
-#: static/js/impala/stats/chart.js:269
+#: static/js/impala/stats/chart.js:269 static/js/zamboni/stats-all.js:16900 static/js/zamboni/stats-min.js:5
 msgid " downloads"
 msgstr ""
 
-#: static/js/impala/stats/chart.js:270
+#: static/js/impala/stats/chart.js:270 static/js/zamboni/stats-all.js:16901 static/js/zamboni/stats-min.js:5
 msgid "{0} users"
 msgstr ""
 
-#: static/js/impala/stats/chart.js:271
+#: static/js/impala/stats/chart.js:271 static/js/zamboni/stats-all.js:16902 static/js/zamboni/stats-min.js:5
 msgid "{0} add-ons"
 msgstr ""
 
-#: static/js/impala/stats/chart.js:272
+#: static/js/impala/stats/chart.js:272 static/js/zamboni/stats-all.js:16903 static/js/zamboni/stats-min.js:5
 msgid "{0} collections"
 msgstr ""
 
-#: static/js/impala/stats/chart.js:273
+#: static/js/impala/stats/chart.js:273 static/js/zamboni/stats-all.js:16904 static/js/zamboni/stats-min.js:5
 msgid "{0} reviews"
 msgstr ""
 
-#: static/js/impala/stats/chart.js:275
+#: static/js/impala/stats/chart.js:275 static/js/zamboni/stats-all.js:16906 static/js/zamboni/stats-min.js:5
 msgid "{0} sales"
 msgstr ""
 
-#: static/js/impala/stats/chart.js:276
+#: static/js/impala/stats/chart.js:276 static/js/zamboni/stats-all.js:16907 static/js/zamboni/stats-min.js:5
 msgid "{0} refunds"
 msgstr ""
 
-#: static/js/impala/stats/chart.js:277
+#: static/js/impala/stats/chart.js:277 static/js/zamboni/stats-all.js:16908 static/js/zamboni/stats-min.js:5
 msgid "{0} installs"
 msgstr ""
 
-#: static/js/impala/stats/chart.js:369 static/js/impala/stats/csv_keys.js:3 static/js/impala/stats/csv_keys.js:109
+#: static/js/impala/stats/chart.js:369 static/js/impala/stats/csv_keys.js:3 static/js/impala/stats/csv_keys.js:109 static/js/zamboni/stats-all.js:15284 static/js/zamboni/stats-all.js:15390
+#: static/js/zamboni/stats-all.js:17000 static/js/zamboni/stats-min.js:4 static/js/zamboni/stats-min.js:5
 msgid "Downloads"
 msgstr ""
 
-#: static/js/impala/stats/chart.js:379 static/js/impala/stats/csv_keys.js:6 static/js/impala/stats/csv_keys.js:110
+#: static/js/impala/stats/chart.js:379 static/js/impala/stats/csv_keys.js:6 static/js/impala/stats/csv_keys.js:110 static/js/zamboni/stats-all.js:15287 static/js/zamboni/stats-all.js:15391
+#: static/js/zamboni/stats-all.js:17010 static/js/zamboni/stats-min.js:4 static/js/zamboni/stats-min.js:5
 msgid "Daily Users"
 msgstr ""
 
-#: static/js/impala/stats/chart.js:410
+#: static/js/impala/stats/chart.js:410 static/js/zamboni/stats-all.js:17041 static/js/zamboni/stats-min.js:5
 msgid "Amount, in USD"
 msgstr ""
 
-#: static/js/impala/stats/chart.js:421 static/js/impala/stats/csv_keys.js:104
+#: static/js/impala/stats/chart.js:421 static/js/impala/stats/csv_keys.js:104 static/js/zamboni/stats-all.js:15385 static/js/zamboni/stats-all.js:17052 static/js/zamboni/stats-min.js:5
 msgid "Number of Contributions"
 msgstr ""
 
-#: static/js/impala/stats/chart.js:447
+#: static/js/impala/stats/chart.js:447 static/js/zamboni/stats-all.js:17078 static/js/zamboni/stats-min.js:5
 msgid "More Info..."
 msgstr ""
 
 #. L10n: {0} is an ISO-formatted date.
-#: static/js/impala/stats/chart.js:451
+#: static/js/impala/stats/chart.js:451 static/js/zamboni/stats-all.js:17082 static/js/zamboni/stats-min.js:5
 msgid "Details for {0}"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:9
+#: static/js/impala/stats/csv_keys.js:9 static/js/zamboni/stats-all.js:15290 static/js/zamboni/stats-min.js:4
 msgid "Collections Created"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:12
+#: static/js/impala/stats/csv_keys.js:12 static/js/zamboni/stats-all.js:15293 static/js/zamboni/stats-min.js:4
 msgid "Add-ons in Use"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:15
+#: static/js/impala/stats/csv_keys.js:15 static/js/zamboni/stats-all.js:15296 static/js/zamboni/stats-min.js:4
 msgid "Add-ons Created"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:18
+#: static/js/impala/stats/csv_keys.js:18 static/js/zamboni/stats-all.js:15299 static/js/zamboni/stats-min.js:4
 msgid "Add-ons Downloaded"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:21
+#: static/js/impala/stats/csv_keys.js:21 static/js/zamboni/stats-all.js:15302 static/js/zamboni/stats-min.js:4
 msgid "Add-ons Updated"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:24
+#: static/js/impala/stats/csv_keys.js:24 static/js/zamboni/stats-all.js:15305 static/js/zamboni/stats-min.js:4
 msgid "Reviews Written"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:27
+#: static/js/impala/stats/csv_keys.js:27 static/js/zamboni/stats-all.js:15308 static/js/zamboni/stats-min.js:4
 msgid "User Signups"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:30
+#: static/js/impala/stats/csv_keys.js:30 static/js/zamboni/stats-all.js:15311 static/js/zamboni/stats-min.js:4
 msgid "Subscribers"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:33
+#: static/js/impala/stats/csv_keys.js:33 static/js/zamboni/stats-all.js:15314 static/js/zamboni/stats-min.js:4
 msgid "Ratings"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:36 static/js/impala/stats/csv_keys.js:114
+#: static/js/impala/stats/csv_keys.js:36 static/js/impala/stats/csv_keys.js:114 static/js/zamboni/stats-all.js:15317 static/js/zamboni/stats-all.js:15395 static/js/zamboni/stats-min.js:4
+#: static/js/zamboni/stats-min.js:5
 msgid "Sales"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:39 static/js/impala/stats/csv_keys.js:113
+#: static/js/impala/stats/csv_keys.js:39 static/js/impala/stats/csv_keys.js:113 static/js/zamboni/stats-all.js:15320 static/js/zamboni/stats-all.js:15394 static/js/zamboni/stats-min.js:4
+#: static/js/zamboni/stats-min.js:5
 msgid "Installs"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:42
+#: static/js/impala/stats/csv_keys.js:42 static/js/zamboni/stats-all.js:15323 static/js/zamboni/stats-min.js:4
 msgid "Unknown"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:43
+#: static/js/impala/stats/csv_keys.js:43 static/js/zamboni/stats-all.js:15324 static/js/zamboni/stats-min.js:4
 msgid "Add-ons Manager"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:44
+#: static/js/impala/stats/csv_keys.js:44 static/js/zamboni/stats-all.js:15325 static/js/zamboni/stats-min.js:4
 msgid "Add-ons Manager Promo"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:45
+#: static/js/impala/stats/csv_keys.js:45 static/js/zamboni/stats-all.js:15326 static/js/zamboni/stats-min.js:4
 msgid "Add-ons Manager Featured"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:46
+#: static/js/impala/stats/csv_keys.js:46 static/js/zamboni/stats-all.js:15327 static/js/zamboni/stats-min.js:4
 msgid "Add-ons Manager Learn More"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:47
+#: static/js/impala/stats/csv_keys.js:47 static/js/zamboni/stats-all.js:15328 static/js/zamboni/stats-min.js:4
 msgid "Search Suggestions"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:48
+#: static/js/impala/stats/csv_keys.js:48 static/js/zamboni/stats-all.js:15329 static/js/zamboni/stats-min.js:4
 msgid "Search Results"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:49 static/js/impala/stats/csv_keys.js:50 static/js/impala/stats/csv_keys.js:51
+#: static/js/impala/stats/csv_keys.js:49 static/js/impala/stats/csv_keys.js:50 static/js/impala/stats/csv_keys.js:51 static/js/zamboni/stats-all.js:15330 static/js/zamboni/stats-all.js:15331
+#: static/js/zamboni/stats-all.js:15332 static/js/zamboni/stats-min.js:4
 msgid "Homepage Promo"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:52 static/js/impala/stats/csv_keys.js:53
+#: static/js/impala/stats/csv_keys.js:52 static/js/impala/stats/csv_keys.js:53 static/js/zamboni/stats-all.js:15333 static/js/zamboni/stats-all.js:15334 static/js/zamboni/stats-min.js:4
 msgid "Homepage Featured"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:54 static/js/impala/stats/csv_keys.js:55
+#: static/js/impala/stats/csv_keys.js:54 static/js/impala/stats/csv_keys.js:55 static/js/zamboni/stats-all.js:15335 static/js/zamboni/stats-all.js:15336 static/js/zamboni/stats-min.js:4
 msgid "Homepage Up and Coming"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:56
+#: static/js/impala/stats/csv_keys.js:56 static/js/zamboni/stats-all.js:15337 static/js/zamboni/stats-min.js:4
 msgid "Homepage Most Popular"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:57 static/js/impala/stats/csv_keys.js:59
+#: static/js/impala/stats/csv_keys.js:57 static/js/impala/stats/csv_keys.js:59 static/js/zamboni/stats-all.js:15338 static/js/zamboni/stats-all.js:15340 static/js/zamboni/stats-min.js:4
 msgid "Detail Page"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:58 static/js/impala/stats/csv_keys.js:60
+#: static/js/impala/stats/csv_keys.js:58 static/js/impala/stats/csv_keys.js:60 static/js/zamboni/stats-all.js:15339 static/js/zamboni/stats-all.js:15341 static/js/zamboni/stats-min.js:4
 msgid "Detail Page (bottom)"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:61
+#: static/js/impala/stats/csv_keys.js:61 static/js/zamboni/stats-all.js:15342 static/js/zamboni/stats-min.js:4
 msgid "Detail Page (Development Channel)"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:62 static/js/impala/stats/csv_keys.js:63 static/js/impala/stats/csv_keys.js:64
+#: static/js/impala/stats/csv_keys.js:62 static/js/impala/stats/csv_keys.js:63 static/js/impala/stats/csv_keys.js:64 static/js/zamboni/stats-all.js:15343 static/js/zamboni/stats-all.js:15344
+#: static/js/zamboni/stats-all.js:15345 static/js/zamboni/stats-min.js:4
 msgid "Often Used With"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:65 static/js/impala/stats/csv_keys.js:66
+#: static/js/impala/stats/csv_keys.js:65 static/js/impala/stats/csv_keys.js:66 static/js/zamboni/stats-all.js:15346 static/js/zamboni/stats-all.js:15347 static/js/zamboni/stats-min.js:4
 msgid "Others By Author"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:67 static/js/impala/stats/csv_keys.js:68
+#: static/js/impala/stats/csv_keys.js:67 static/js/impala/stats/csv_keys.js:68 static/js/zamboni/stats-all.js:15348 static/js/zamboni/stats-all.js:15349 static/js/zamboni/stats-min.js:4
 msgid "Dependencies"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:69 static/js/impala/stats/csv_keys.js:70
+#: static/js/impala/stats/csv_keys.js:69 static/js/impala/stats/csv_keys.js:70 static/js/zamboni/stats-all.js:15350 static/js/zamboni/stats-all.js:15351 static/js/zamboni/stats-min.js:4
 msgid "Upsell"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:71
+#: static/js/impala/stats/csv_keys.js:71 static/js/zamboni/stats-all.js:15352 static/js/zamboni/stats-min.js:4
 msgid "Meet the Developer"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:72
+#: static/js/impala/stats/csv_keys.js:72 static/js/zamboni/stats-all.js:15353 static/js/zamboni/stats-min.js:4
 msgid "User Profile"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:73
+#: static/js/impala/stats/csv_keys.js:73 static/js/zamboni/stats-all.js:15354 static/js/zamboni/stats-min.js:4
 msgid "Version History"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:75
+#: static/js/impala/stats/csv_keys.js:75 static/js/zamboni/stats-all.js:15356 static/js/zamboni/stats-min.js:4
 msgid "Sharing"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:76
+#: static/js/impala/stats/csv_keys.js:76 static/js/zamboni/stats-all.js:15357 static/js/zamboni/stats-min.js:4
 msgid "Category Pages"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:77
+#: static/js/impala/stats/csv_keys.js:77 static/js/zamboni/stats-all.js:15358 static/js/zamboni/stats-min.js:4
 msgid "Collections"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:78 static/js/impala/stats/csv_keys.js:79
+#: static/js/impala/stats/csv_keys.js:78 static/js/impala/stats/csv_keys.js:79 static/js/zamboni/stats-all.js:15359 static/js/zamboni/stats-all.js:15360 static/js/zamboni/stats-min.js:4
 msgid "Category Landing Featured Carousel"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:80 static/js/impala/stats/csv_keys.js:81
+#: static/js/impala/stats/csv_keys.js:80 static/js/impala/stats/csv_keys.js:81 static/js/zamboni/stats-all.js:15361 static/js/zamboni/stats-all.js:15362 static/js/zamboni/stats-min.js:4
 msgid "Category Landing Top Rated"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:82 static/js/impala/stats/csv_keys.js:83
+#: static/js/impala/stats/csv_keys.js:82 static/js/impala/stats/csv_keys.js:83 static/js/zamboni/stats-all.js:15363 static/js/zamboni/stats-all.js:15364 static/js/zamboni/stats-min.js:5
 msgid "Category Landing Most Popular"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:84 static/js/impala/stats/csv_keys.js:85
+#: static/js/impala/stats/csv_keys.js:84 static/js/impala/stats/csv_keys.js:85 static/js/zamboni/stats-all.js:15365 static/js/zamboni/stats-all.js:15366 static/js/zamboni/stats-min.js:5
 msgid "Category Landing Recently Added"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:86 static/js/impala/stats/csv_keys.js:87
+#: static/js/impala/stats/csv_keys.js:86 static/js/impala/stats/csv_keys.js:87 static/js/zamboni/stats-all.js:15367 static/js/zamboni/stats-all.js:15368 static/js/zamboni/stats-min.js:5
 msgid "Browse Listing Featured Sort"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:88 static/js/impala/stats/csv_keys.js:89
+#: static/js/impala/stats/csv_keys.js:88 static/js/impala/stats/csv_keys.js:89 static/js/zamboni/stats-all.js:15369 static/js/zamboni/stats-all.js:15370 static/js/zamboni/stats-min.js:5
 msgid "Browse Listing Users Sort"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:90 static/js/impala/stats/csv_keys.js:91
+#: static/js/impala/stats/csv_keys.js:90 static/js/impala/stats/csv_keys.js:91 static/js/zamboni/stats-all.js:15371 static/js/zamboni/stats-all.js:15372 static/js/zamboni/stats-min.js:5
 msgid "Browse Listing Rating Sort"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:92 static/js/impala/stats/csv_keys.js:93
+#: static/js/impala/stats/csv_keys.js:92 static/js/impala/stats/csv_keys.js:93 static/js/zamboni/stats-all.js:15373 static/js/zamboni/stats-all.js:15374 static/js/zamboni/stats-min.js:5
 msgid "Browse Listing Created Sort"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:94 static/js/impala/stats/csv_keys.js:95
+#: static/js/impala/stats/csv_keys.js:94 static/js/impala/stats/csv_keys.js:95 static/js/zamboni/stats-all.js:15375 static/js/zamboni/stats-all.js:15376 static/js/zamboni/stats-min.js:5
 msgid "Browse Listing Name Sort"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:96 static/js/impala/stats/csv_keys.js:97
+#: static/js/impala/stats/csv_keys.js:96 static/js/impala/stats/csv_keys.js:97 static/js/zamboni/stats-all.js:15377 static/js/zamboni/stats-all.js:15378 static/js/zamboni/stats-min.js:5
 msgid "Browse Listing Popular Sort"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:98 static/js/impala/stats/csv_keys.js:99
+#: static/js/impala/stats/csv_keys.js:98 static/js/impala/stats/csv_keys.js:99 static/js/zamboni/stats-all.js:15379 static/js/zamboni/stats-all.js:15380 static/js/zamboni/stats-min.js:5
 msgid "Browse Listing Updated Sort"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:100 static/js/impala/stats/csv_keys.js:101
+#: static/js/impala/stats/csv_keys.js:100 static/js/impala/stats/csv_keys.js:101 static/js/zamboni/stats-all.js:15381 static/js/zamboni/stats-all.js:15382 static/js/zamboni/stats-min.js:5
 msgid "Browse Listing Up and Coming Sort"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:105
+#: static/js/impala/stats/csv_keys.js:105 static/js/zamboni/stats-all.js:15386 static/js/zamboni/stats-min.js:5
 msgid "Total Amount Contributed"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:106
+#: static/js/impala/stats/csv_keys.js:106 static/js/zamboni/stats-all.js:15387 static/js/zamboni/stats-min.js:5
 msgid "Average Contribution"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:115
+#: static/js/impala/stats/csv_keys.js:115 static/js/zamboni/stats-all.js:15396 static/js/zamboni/stats-min.js:5
 msgid "Usage"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:118
+#: static/js/impala/stats/csv_keys.js:118 static/js/zamboni/stats-all.js:15399 static/js/zamboni/stats-min.js:5
 msgid "Firefox"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:119
+#: static/js/impala/stats/csv_keys.js:119 static/js/zamboni/stats-all.js:15400 static/js/zamboni/stats-min.js:5
 msgid "Mozilla"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:120
+#: static/js/impala/stats/csv_keys.js:120 static/js/zamboni/stats-all.js:15401 static/js/zamboni/stats-min.js:5
 msgid "Thunderbird"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:121
+#: static/js/impala/stats/csv_keys.js:121 static/js/zamboni/stats-all.js:15402 static/js/zamboni/stats-min.js:5
 msgid "Sunbird"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:122
+#: static/js/impala/stats/csv_keys.js:122 static/js/zamboni/stats-all.js:15403 static/js/zamboni/stats-min.js:5
 msgid "SeaMonkey"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:123
+#: static/js/impala/stats/csv_keys.js:123 static/js/zamboni/stats-all.js:15404 static/js/zamboni/stats-min.js:5
 msgid "Fennec"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:124
+#: static/js/impala/stats/csv_keys.js:124 static/js/zamboni/stats-all.js:15405 static/js/zamboni/stats-min.js:5
 msgid "Android"
 msgstr ""
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:129
+#: static/js/impala/stats/csv_keys.js:129 static/js/zamboni/stats-all.js:15410 static/js/zamboni/stats-min.js:5
 msgid "Downloads and Daily Users, last {0} days"
 msgstr ""
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:131
+#: static/js/impala/stats/csv_keys.js:131 static/js/zamboni/stats-all.js:15412 static/js/zamboni/stats-min.js:5
 msgid "Downloads and Daily Users from {0} to {1}"
 msgstr ""
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:135
+#: static/js/impala/stats/csv_keys.js:135 static/js/zamboni/stats-all.js:15416 static/js/zamboni/stats-min.js:5
 msgid "Installs and Daily Users, last {0} days"
 msgstr ""
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:137
+#: static/js/impala/stats/csv_keys.js:137 static/js/zamboni/stats-all.js:15418 static/js/zamboni/stats-min.js:5
 msgid "Installs and Daily Users from {0} to {1}"
 msgstr ""
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:141
+#: static/js/impala/stats/csv_keys.js:141 static/js/zamboni/stats-all.js:15422 static/js/zamboni/stats-min.js:5
 msgid "Downloads, last {0} days"
 msgstr ""
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:143
+#: static/js/impala/stats/csv_keys.js:143 static/js/zamboni/stats-all.js:15424 static/js/zamboni/stats-min.js:5
 msgid "Downloads from {0} to {1}"
 msgstr ""
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:147
+#: static/js/impala/stats/csv_keys.js:147 static/js/zamboni/stats-all.js:15428 static/js/zamboni/stats-min.js:5
 msgid "Daily Users, last {0} days"
 msgstr ""
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:149
+#: static/js/impala/stats/csv_keys.js:149 static/js/zamboni/stats-all.js:15430 static/js/zamboni/stats-min.js:5
 msgid "Daily Users from {0} to {1}"
 msgstr ""
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:153
+#: static/js/impala/stats/csv_keys.js:153 static/js/zamboni/stats-all.js:15434 static/js/zamboni/stats-min.js:5
 msgid "Applications, last {0} days"
 msgstr ""
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:155
+#: static/js/impala/stats/csv_keys.js:155 static/js/zamboni/stats-all.js:15436 static/js/zamboni/stats-min.js:5
 msgid "Applications from {0} to {1}"
 msgstr ""
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:159
+#: static/js/impala/stats/csv_keys.js:159 static/js/zamboni/stats-all.js:15440 static/js/zamboni/stats-min.js:5
 msgid "Platforms, last {0} days"
 msgstr ""
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:161
+#: static/js/impala/stats/csv_keys.js:161 static/js/zamboni/stats-all.js:15442 static/js/zamboni/stats-min.js:5
 msgid "Platforms from {0} to {1}"
 msgstr ""
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:165
+#: static/js/impala/stats/csv_keys.js:165 static/js/zamboni/stats-all.js:15446 static/js/zamboni/stats-min.js:5
 msgid "Languages, last {0} days"
 msgstr ""
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:167
+#: static/js/impala/stats/csv_keys.js:167 static/js/zamboni/stats-all.js:15448 static/js/zamboni/stats-min.js:5
 msgid "Languages from {0} to {1}"
 msgstr ""
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:171
+#: static/js/impala/stats/csv_keys.js:171 static/js/zamboni/stats-all.js:15452 static/js/zamboni/stats-min.js:5
 msgid "Add-on Versions, last {0} days"
 msgstr ""
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:173
+#: static/js/impala/stats/csv_keys.js:173 static/js/zamboni/stats-all.js:15454 static/js/zamboni/stats-min.js:5
 msgid "Add-on Versions from {0} to {1}"
 msgstr ""
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:177
+#: static/js/impala/stats/csv_keys.js:177 static/js/zamboni/stats-all.js:15458 static/js/zamboni/stats-min.js:5
 msgid "Add-on Status, last {0} days"
 msgstr ""
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:179
+#: static/js/impala/stats/csv_keys.js:179 static/js/zamboni/stats-all.js:15460 static/js/zamboni/stats-min.js:5
 msgid "Add-on Status from {0} to {1}"
 msgstr ""
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:183
+#: static/js/impala/stats/csv_keys.js:183 static/js/zamboni/stats-all.js:15464 static/js/zamboni/stats-min.js:5
 msgid "Download Sources, last {0} days"
 msgstr ""
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:185
+#: static/js/impala/stats/csv_keys.js:185 static/js/zamboni/stats-all.js:15466 static/js/zamboni/stats-min.js:5
 msgid "Download Sources from {0} to {1}"
 msgstr ""
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:189
+#: static/js/impala/stats/csv_keys.js:189 static/js/zamboni/stats-all.js:15470 static/js/zamboni/stats-min.js:5
 msgid "Contributions, last {0} days"
 msgstr ""
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:191
+#: static/js/impala/stats/csv_keys.js:191 static/js/zamboni/stats-all.js:15472 static/js/zamboni/stats-min.js:5
 msgid "Contributions from {0} to {1}"
 msgstr ""
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:195
+#: static/js/impala/stats/csv_keys.js:195 static/js/zamboni/stats-all.js:15476 static/js/zamboni/stats-min.js:5
 msgid "Site Metrics, last {0} days"
 msgstr ""
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:197
+#: static/js/impala/stats/csv_keys.js:197 static/js/zamboni/stats-all.js:15478 static/js/zamboni/stats-min.js:5
 msgid "Site Metrics from {0} to {1}"
 msgstr ""
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:201
+#: static/js/impala/stats/csv_keys.js:201 static/js/zamboni/stats-all.js:15482 static/js/zamboni/stats-min.js:5
 msgid "Add-ons in Use, last {0} days"
 msgstr ""
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:203
+#: static/js/impala/stats/csv_keys.js:203 static/js/zamboni/stats-all.js:15484 static/js/zamboni/stats-min.js:5
 msgid "Add-ons in Use from {0} to {1}"
 msgstr ""
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:207
+#: static/js/impala/stats/csv_keys.js:207 static/js/zamboni/stats-all.js:15488 static/js/zamboni/stats-min.js:5
 msgid "Add-ons Downloaded, last {0} days"
 msgstr ""
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:209
+#: static/js/impala/stats/csv_keys.js:209 static/js/zamboni/stats-all.js:15490 static/js/zamboni/stats-min.js:5
 msgid "Add-ons Downloaded from {0} to {1}"
 msgstr ""
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:213
+#: static/js/impala/stats/csv_keys.js:213 static/js/zamboni/stats-all.js:15494 static/js/zamboni/stats-min.js:5
 msgid "Add-ons Created, last {0} days"
 msgstr ""
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:215
+#: static/js/impala/stats/csv_keys.js:215 static/js/zamboni/stats-all.js:15496 static/js/zamboni/stats-min.js:5
 msgid "Add-ons Created from {0} to {1}"
 msgstr ""
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:219
+#: static/js/impala/stats/csv_keys.js:219 static/js/zamboni/stats-all.js:15500 static/js/zamboni/stats-min.js:5
 msgid "Add-ons Updated, last {0} days"
 msgstr ""
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:221
+#: static/js/impala/stats/csv_keys.js:221 static/js/zamboni/stats-all.js:15502 static/js/zamboni/stats-min.js:5
 msgid "Add-ons Updated from {0} to {1}"
 msgstr ""
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:225
+#: static/js/impala/stats/csv_keys.js:225 static/js/zamboni/stats-all.js:15506 static/js/zamboni/stats-min.js:5
 msgid "Reviews Written, last {0} days"
 msgstr ""
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:227
+#: static/js/impala/stats/csv_keys.js:227 static/js/zamboni/stats-all.js:15508 static/js/zamboni/stats-min.js:5
 msgid "Reviews Written from {0} to {1}"
 msgstr ""
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:231
+#: static/js/impala/stats/csv_keys.js:231 static/js/zamboni/stats-all.js:15512 static/js/zamboni/stats-min.js:5
 msgid "User Signups, last {0} days"
 msgstr ""
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:233
+#: static/js/impala/stats/csv_keys.js:233 static/js/zamboni/stats-all.js:15514 static/js/zamboni/stats-min.js:5
 msgid "User Signups from {0} to {1}"
 msgstr ""
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:237
+#: static/js/impala/stats/csv_keys.js:237 static/js/zamboni/stats-all.js:15518 static/js/zamboni/stats-min.js:5
 msgid "Collections Created, last {0} days"
 msgstr ""
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:239
+#: static/js/impala/stats/csv_keys.js:239 static/js/zamboni/stats-all.js:15520 static/js/zamboni/stats-min.js:5
 msgid "Collections Created from {0} to {1}"
 msgstr ""
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:243
+#: static/js/impala/stats/csv_keys.js:243 static/js/zamboni/stats-all.js:15524 static/js/zamboni/stats-min.js:5
 msgid "Subscribers, last {0} days"
 msgstr ""
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:245
+#: static/js/impala/stats/csv_keys.js:245 static/js/zamboni/stats-all.js:15526 static/js/zamboni/stats-min.js:5
 msgid "Subscribers from {0} to {1}"
 msgstr ""
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:249
+#: static/js/impala/stats/csv_keys.js:249 static/js/zamboni/stats-all.js:15530 static/js/zamboni/stats-min.js:5
 msgid "Ratings, last {0} days"
 msgstr ""
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:251
+#: static/js/impala/stats/csv_keys.js:251 static/js/zamboni/stats-all.js:15532 static/js/zamboni/stats-min.js:5
 msgid "Ratings from {0} to {1}"
 msgstr ""
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:255
+#: static/js/impala/stats/csv_keys.js:255 static/js/zamboni/stats-all.js:15536 static/js/zamboni/stats-min.js:5
 msgid "Sales, last {0} days"
 msgstr ""
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:257
+#: static/js/impala/stats/csv_keys.js:257 static/js/zamboni/stats-all.js:15538 static/js/zamboni/stats-min.js:5
 msgid "Sales from {0} to {1}"
 msgstr ""
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:261
+#: static/js/impala/stats/csv_keys.js:261 static/js/zamboni/stats-all.js:15542 static/js/zamboni/stats-min.js:5
 msgid "Installs, last {0} days"
 msgstr ""
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:263
+#: static/js/impala/stats/csv_keys.js:263 static/js/zamboni/stats-all.js:15544 static/js/zamboni/stats-min.js:5
 msgid "Installs from {0} to {1}"
 msgstr ""
 
 #. L10n: {0} and {1} are integers.
-#: static/js/impala/stats/csv_keys.js:269
+#: static/js/impala/stats/csv_keys.js:269 static/js/zamboni/stats-all.js:15550 static/js/zamboni/stats-min.js:5
 msgid "<b>{0}</b> in last {1} days"
 msgstr ""
 
 #. L10n: {0} is an integer and {1} and {2} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:271 static/js/impala/stats/csv_keys.js:277
+#: static/js/impala/stats/csv_keys.js:271 static/js/impala/stats/csv_keys.js:277 static/js/zamboni/stats-all.js:15552 static/js/zamboni/stats-all.js:15558 static/js/zamboni/stats-min.js:5
 msgid "<b>{0}</b> from {1} to {2}"
 msgstr ""
 
 #. L10n: {0} and {1} are integers.
-#: static/js/impala/stats/csv_keys.js:275
+#: static/js/impala/stats/csv_keys.js:275 static/js/zamboni/stats-all.js:15556 static/js/zamboni/stats-min.js:5
 msgid "<b>{0}</b> average in last {1} days"
 msgstr ""
 
-#: static/js/impala/stats/overview.js:19
+#: static/js/impala/stats/overview.js:19 static/js/zamboni/stats-all.js:16469 static/js/zamboni/stats-min.js:5
 msgid "No data available."
 msgstr ""
 
-#: static/js/impala/stats/table.js:74
+#: static/js/impala/stats/table.js:74 static/js/zamboni/stats-all.js:17209 static/js/zamboni/stats-min.js:5
 msgid "Date"
 msgstr ""
 
-#: static/js/impala/stats/topchart.js:96
+#: static/js/impala/stats/topchart.js:96 static/js/zamboni/stats-all.js:16600 static/js/zamboni/stats-min.js:5
 msgid "Other"
 msgstr ""
 
-#: static/js/zamboni/admin_validation.js:24 static/js/zamboni/devhub.js:1229 static/js/zamboni/editors.js:295
+#: static/js/zamboni/admin-all.js:180 static/js/zamboni/admin-min.js:1 static/js/zamboni/admin_validation.js:24 static/js/zamboni/devhub-all.js:2408 static/js/zamboni/devhub-min.js:2
+#: static/js/zamboni/devhub.js:1229 static/js/zamboni/editors-all.js:15576 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:295
 msgid "Select an application first"
 msgstr ""
 
-#: static/js/zamboni/admin_validation.js:51
+#: static/js/zamboni/admin-all.js:207 static/js/zamboni/admin-min.js:1 static/js/zamboni/admin_validation.js:51
 msgid "Set {0} add-on to a max version of {1} and email the author."
 msgid_plural "Set {0} add-ons to a max version of {1} and email the authors."
 msgstr[0] ""
 msgstr[1] ""
 
-#: static/js/zamboni/admin_validation.js:54
+#: static/js/zamboni/admin-all.js:210 static/js/zamboni/admin-min.js:1 static/js/zamboni/admin_validation.js:54
 msgid "Email author of {2} add-on which failed validation."
 msgid_plural "Email authors of {2} add-ons which failed validation."
 msgstr[0] ""
 msgstr[1] ""
 
-#. L10n: {0} is an app name like Firefox.
-#: static/js/zamboni/buttons.js:66
-msgid "Accept and Install"
-msgstr ""
-
-#: static/js/zamboni/buttons.js:66
-msgid "Add to {0}"
-msgstr ""
-
-#: static/js/zamboni/buttons.js:71
-msgid "Download Now"
-msgstr ""
-
-#: static/js/zamboni/buttons.js:112
-msgid "Add-on has not been updated to support default-to-compatible."
-msgstr ""
-
-#: static/js/zamboni/buttons.js:117
-msgid "You need to be using Firefox 10.0 or higher."
-msgstr ""
-
-#: static/js/zamboni/buttons.js:129
-msgid "Mozilla has marked this version as incompatible with your Firefox version."
-msgstr ""
-
-#. L10n: {0} is an platform like Windows or Linux.
-#: static/js/zamboni/buttons.js:210
-msgid "Install for {0} anyway"
-msgstr ""
-
-#: static/js/zamboni/buttons.js:210
-msgid "Download for {0} anyway"
-msgstr ""
-
-#: static/js/zamboni/buttons.js:267
-msgid "Not available for your platform"
-msgstr ""
-
-#. L10n: {0} is an app name, {1} is the app version.
-#: static/js/zamboni/buttons.js:278 static/js/zamboni/buttons.js:315
-msgid "Not available for {0} {1}"
-msgstr ""
-
-#: static/js/zamboni/buttons.js:341
-msgid "Works with {app} {min} - {max}"
-msgstr ""
-
-#: static/js/zamboni/buttons.js:343
-msgid "View other versions"
-msgstr ""
-
-#: static/js/zamboni/buttons.js:391
-msgid "Only with Firefox — Get Firefox Now!"
-msgstr ""
-
-#: static/js/zamboni/buttons.js:507 static/js/zamboni/mobile/buttons.js:43
-msgid "Sorry, you need a Mozilla-based browser (such as Firefox) to install a search plugin."
-msgstr ""
-
-#: static/js/zamboni/collections.js:229
-msgid "Adding to Favorites&hellip;"
-msgstr ""
-
-#: static/js/zamboni/collections.js:232
-msgid "Removing Favorite&hellip;"
-msgstr ""
-
-#: static/js/zamboni/collections.js:235
-msgid "Add to Favorites"
-msgstr ""
-
-#: static/js/zamboni/collections.js:238
-msgid "Remove from Favorites"
-msgstr ""
-
-#: static/js/zamboni/collections.js:303
-msgid "Pending"
-msgstr ""
-
-#: static/js/zamboni/collections.js:304
-msgid "Add a comment"
-msgstr ""
-
-#: static/js/zamboni/collections.js:304
-msgid "Comment"
-msgstr ""
-
-#: static/js/zamboni/collections.js:305
-msgid "Remove this add-on from the collection"
-msgstr ""
-
-#: static/js/zamboni/collections.js:305 static/js/zamboni/collections.js:334
-msgid "Remove"
-msgstr ""
-
-#: static/js/zamboni/collections.js:334
-msgid "Remove this user as a contributor"
-msgstr ""
-
-#: static/js/zamboni/collections.js:346
-msgid "An email address is required."
-msgstr ""
-
-#: static/js/zamboni/collections.js:364
-msgid "You cannot add yourself as a contributor."
-msgstr ""
-
-#: static/js/zamboni/collections.js:366
-msgid "You have already added that user."
-msgstr ""
-
-#: static/js/zamboni/collections.js:573
-msgid "Add to favorites"
-msgstr ""
-
-#: static/js/zamboni/collections.js:577
-msgid "Remove from favorites"
-msgstr ""
-
-#: static/js/zamboni/collections.js:604
-msgid "Stop following"
-msgstr ""
-
-#: static/js/zamboni/devhub.js:110
+#: static/js/zamboni/devhub-all.js:1289 static/js/zamboni/devhub-min.js:1 static/js/zamboni/devhub.js:110
 msgid "Your browser does not support the video tag"
 msgstr ""
 
-#: static/js/zamboni/devhub.js:371
+#: static/js/zamboni/devhub-all.js:1550 static/js/zamboni/devhub-min.js:1 static/js/zamboni/devhub.js:371
 msgid "Changes Saved"
 msgstr ""
 
-#: static/js/zamboni/devhub.js:387
+#: static/js/zamboni/devhub-all.js:1566 static/js/zamboni/devhub-min.js:1 static/js/zamboni/devhub.js:387
 msgid "Enter a new author's email address"
 msgstr ""
 
-#: static/js/zamboni/devhub.js:536
+#: static/js/zamboni/devhub-all.js:1715 static/js/zamboni/devhub-min.js:1 static/js/zamboni/devhub.js:536
 msgid "There was an error uploading your file."
 msgstr ""
 
-#: static/js/zamboni/devhub.js:681
+#: static/js/zamboni/devhub-all.js:1860 static/js/zamboni/devhub-min.js:1 static/js/zamboni/devhub.js:681
 msgid "{files} file"
 msgid_plural "{files} files"
 msgstr[0] ""
 msgstr[1] ""
 
-#: static/js/zamboni/devhub.js:684
+#: static/js/zamboni/devhub-all.js:1863 static/js/zamboni/devhub-min.js:1 static/js/zamboni/devhub.js:684
 msgid "{reviews} user review"
 msgid_plural "{reviews} user reviews"
 msgstr[0] ""
 msgstr[1] ""
 
-#: static/js/zamboni/devhub.js:796
+#: static/js/zamboni/devhub-all.js:1975 static/js/zamboni/devhub-min.js:2 static/js/zamboni/devhub.js:796
 msgid "Learn more"
 msgstr ""
 
-#: static/js/zamboni/devhub.js:800
+#: static/js/zamboni/devhub-all.js:1979 static/js/zamboni/devhub-min.js:2 static/js/zamboni/devhub.js:800
 msgid "Example"
 msgstr ""
 
-#: static/js/zamboni/devhub.js:1130
+#: static/js/zamboni/devhub-all.js:2309 static/js/zamboni/devhub-min.js:2 static/js/zamboni/devhub.js:1130
 msgid "Image changes being processed"
 msgstr ""
 
-#: static/js/zamboni/devhub.js:1280
+#: static/js/zamboni/devhub-all.js:2459 static/js/zamboni/devhub-min.js:2 static/js/zamboni/devhub.js:1280
 msgid "Must be a valid e-mail address."
+msgstr ""
+
+#: static/js/zamboni/devhub-all.js:2613 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:80
+msgid "All tests passed successfully."
+msgstr ""
+
+#: static/js/zamboni/devhub-all.js:2616 static/js/zamboni/devhub-all.js:3011 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:83 static/js/zamboni/validator.js:478
+msgid "These tests were not run."
+msgstr ""
+
+#: static/js/zamboni/devhub-all.js:2664 static/js/zamboni/devhub-all.js:2677 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:131 static/js/zamboni/validator.js:144
+msgid "Tests"
+msgstr ""
+
+#: static/js/zamboni/devhub-all.js:2779 static/js/zamboni/devhub-all.js:3108 static/js/zamboni/devhub-all.js:3127 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:246
+#: static/js/zamboni/validator.js:575 static/js/zamboni/validator.js:594
+msgid "Error"
+msgstr ""
+
+#: static/js/zamboni/devhub-all.js:2780 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:247
+msgid "Warning"
+msgstr ""
+
+#: static/js/zamboni/devhub-all.js:2794 static/js/zamboni/devhub-min.js:2 static/js/zamboni/files-all.js:5657 static/js/zamboni/files-min.js:3 static/js/zamboni/files.js:411
+#: static/js/zamboni/validator.js:261
+msgid "Ignore this message in future updates"
+msgstr ""
+
+#: static/js/zamboni/devhub-all.js:2817 static/js/zamboni/devhub-min.js:2 static/js/zamboni/files-all.js:5663 static/js/zamboni/files-min.js:3 static/js/zamboni/files.js:417
+#: static/js/zamboni/validator.js:284
+msgid "Severity for automated signing:"
+msgstr ""
+
+#: static/js/zamboni/devhub-all.js:2832 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:299
+msgid "Suggestions for passing automated signing:"
+msgstr ""
+
+#: static/js/zamboni/devhub-all.js:2920 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:387
+msgid "Compatibility Tests"
+msgstr ""
+
+#: static/js/zamboni/devhub-all.js:2999 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:466
+msgid "Add-on failed validation."
+msgstr ""
+
+#: static/js/zamboni/devhub-all.js:3001 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:468
+msgid "Add-on passed validation."
+msgstr ""
+
+#: static/js/zamboni/devhub-all.js:3014 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:481
+msgid "{0} error"
+msgid_plural "{0} errors"
+msgstr[0] ""
+msgstr[1] ""
+
+#: static/js/zamboni/devhub-all.js:3016 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:483
+msgid "{0} warning"
+msgid_plural "{0} warnings"
+msgstr[0] ""
+msgstr[1] ""
+
+#: static/js/zamboni/devhub-all.js:3018 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:485
+msgid "{0} notice"
+msgid_plural "{0} notices"
+msgstr[0] ""
+msgstr[1] ""
+
+#: static/js/zamboni/devhub-all.js:3110 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:577
+msgid "Validation task could not complete or completed with errors"
+msgstr ""
+
+#: static/js/zamboni/devhub-all.js:3128 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:595
+msgid "Internal server error"
 msgstr ""
 
 #: static/js/zamboni/devhub_search.js:8
 msgid "No results found."
 msgstr ""
 
-#: static/js/zamboni/editors.js:121
+#: static/js/zamboni/editors-all.js:15402 static/js/zamboni/editors-min.js:4 static/js/zamboni/editors.js:121
 msgid "{name} was viewing this page first."
 msgstr ""
 
-#: static/js/zamboni/editors.js:171
+#: static/js/zamboni/editors-all.js:15452 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:171
 msgid "Receipt checked by app."
 msgstr ""
 
-#: static/js/zamboni/editors.js:173
+#: static/js/zamboni/editors-all.js:15454 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:173
 msgid "Receipt was not checked by app."
 msgstr ""
 
-#: static/js/zamboni/editors.js:244
+#: static/js/zamboni/editors-all.js:15525 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:244
 msgid "{name} was viewing this add-on first."
 msgstr ""
 
-#: static/js/zamboni/editors.js:255
+#: static/js/zamboni/editors-all.js:15536 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:255
 msgid "Loading&hellip;"
 msgstr ""
 
-#: static/js/zamboni/editors.js:260
+#: static/js/zamboni/editors-all.js:15541 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:260
 msgid "Version Notes"
 msgstr ""
 
-#: static/js/zamboni/editors.js:265
+#: static/js/zamboni/editors-all.js:15546 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:265
 msgid "Notes for Reviewers"
 msgstr ""
 
-#: static/js/zamboni/editors.js:270
+#: static/js/zamboni/editors-all.js:15551 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:270
 msgid "No version notes found"
 msgstr ""
 
-#: static/js/zamboni/editors.js:330
+#: static/js/zamboni/editors-all.js:15611 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:330
 msgid "Average Reviews"
 msgstr ""
 
-#: static/js/zamboni/editors.js:386
+#: static/js/zamboni/editors-all.js:15667 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:386
 msgid "Number of Reviews"
 msgstr ""
 
-#: static/js/zamboni/editors.js:445
+#: static/js/zamboni/editors-all.js:15726 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:445
 msgid "Error loading translation"
 msgstr ""
 
-#: static/js/zamboni/files.js:411 static/js/zamboni/validator.js:261
-msgid "Ignore this message in future updates"
-msgstr ""
-
-#: static/js/zamboni/files.js:417 static/js/zamboni/validator.js:284
-msgid "Severity for automated signing:"
-msgstr ""
-
-#: static/js/zamboni/global.js:410
-msgid "Loading..."
-msgstr ""
-
-#. L10n: {0} is the number of characters left.
-#: static/js/zamboni/global.js:474
-msgid "<b>{0}</b> character left."
-msgid_plural "<b>{0}</b> characters left."
-msgstr[0] ""
-msgstr[1] ""
-
-#: static/js/zamboni/init.js:28
-msgid "This feature is temporarily disabled while we perform website maintenance. Please check back a little later."
-msgstr ""
-
-#: static/js/zamboni/l10n.js:45
-msgid "Remove this localization"
-msgstr ""
-
-#: static/js/zamboni/password-strength.js:20
-msgid "Password strength:"
-msgstr ""
-
-#: static/js/zamboni/password-strength.js:26
-msgid "At least {0} character left."
-msgid_plural "At least {0} characters left."
-msgstr[0] ""
-msgstr[1] ""
-
-#: static/js/zamboni/themes_review.js:176
-msgid "Requested Info"
-msgstr ""
-
-#: static/js/zamboni/themes_review.js:177
-msgid "Flagged"
-msgstr ""
-
-#: static/js/zamboni/themes_review.js:178
-msgid "Duplicate"
-msgstr ""
-
-#: static/js/zamboni/themes_review.js:179
-msgid "Rejected"
-msgstr ""
-
-#: static/js/zamboni/themes_review.js:180
-msgid "Approved"
-msgstr ""
-
-#: static/js/zamboni/themes_review.js:424
-msgid "No results found"
-msgstr ""
-
-#: static/js/zamboni/themes_review_templates.js:31
+#: static/js/zamboni/editors-all.js:15975 static/js/zamboni/editors-min.js:5 static/js/zamboni/themes_review_templates.js:31
 msgid "Theme"
 msgstr ""
 
-#: static/js/zamboni/themes_review_templates.js:33
+#: static/js/zamboni/editors-all.js:15977 static/js/zamboni/editors-min.js:5 static/js/zamboni/themes_review_templates.js:33
 msgid "Reviewer"
 msgstr ""
 
-#: static/js/zamboni/themes_review_templates.js:35
+#: static/js/zamboni/editors-all.js:15979 static/js/zamboni/editors-min.js:5 static/js/zamboni/themes_review_templates.js:35
 msgid "Status"
 msgstr ""
 
-#: static/js/zamboni/validator.js:80
-msgid "All tests passed successfully."
+#: static/js/zamboni/editors-all.js:16196 static/js/zamboni/editors-min.js:5 static/js/zamboni/themes_review.js:176
+msgid "Requested Info"
 msgstr ""
 
-#: static/js/zamboni/validator.js:83 static/js/zamboni/validator.js:478
-msgid "These tests were not run."
+#: static/js/zamboni/editors-all.js:16197 static/js/zamboni/editors-min.js:5 static/js/zamboni/themes_review.js:177
+msgid "Flagged"
 msgstr ""
 
-#: static/js/zamboni/validator.js:131 static/js/zamboni/validator.js:144
-msgid "Tests"
+#: static/js/zamboni/editors-all.js:16198 static/js/zamboni/editors-min.js:5 static/js/zamboni/themes_review.js:178
+msgid "Duplicate"
 msgstr ""
 
-#: static/js/zamboni/validator.js:246 static/js/zamboni/validator.js:575 static/js/zamboni/validator.js:594
-msgid "Error"
+#: static/js/zamboni/editors-all.js:16199 static/js/zamboni/editors-min.js:5 static/js/zamboni/themes_review.js:179
+msgid "Rejected"
 msgstr ""
 
-#: static/js/zamboni/validator.js:247
-msgid "Warning"
+#: static/js/zamboni/editors-all.js:16200 static/js/zamboni/editors-min.js:5 static/js/zamboni/themes_review.js:180
+msgid "Approved"
 msgstr ""
 
-#: static/js/zamboni/validator.js:299
-msgid "Suggestions for passing automated signing:"
+#: static/js/zamboni/editors-all.js:16444 static/js/zamboni/editors-min.js:5 static/js/zamboni/themes_review.js:424
+msgid "No results found"
 msgstr ""
 
-#: static/js/zamboni/validator.js:387
-msgid "Compatibility Tests"
-msgstr ""
-
-#: static/js/zamboni/validator.js:466
-msgid "Add-on failed validation."
-msgstr ""
-
-#: static/js/zamboni/validator.js:468
-msgid "Add-on passed validation."
-msgstr ""
-
-#: static/js/zamboni/validator.js:481
-msgid "{0} error"
-msgid_plural "{0} errors"
-msgstr[0] ""
-msgstr[1] ""
-
-#: static/js/zamboni/validator.js:483
-msgid "{0} warning"
-msgid_plural "{0} warnings"
-msgstr[0] ""
-msgstr[1] ""
-
-#: static/js/zamboni/validator.js:485
-msgid "{0} notice"
-msgid_plural "{0} notices"
-msgstr[0] ""
-msgstr[1] ""
-
-#: static/js/zamboni/validator.js:577
-msgid "Validation task could not complete or completed with errors"
-msgstr ""
-
-#: static/js/zamboni/validator.js:595
-msgid "Internal server error"
-msgstr ""
-
-#: static/js/zamboni/mobile/buttons.js:52
+#: static/js/zamboni/mobile-all.js:15186 static/js/zamboni/mobile/buttons.js:52
 msgid "Not Updated for {0} {1}"
 msgstr ""
 
-#: static/js/zamboni/mobile/buttons.js:53
+#: static/js/zamboni/mobile-all.js:15187 static/js/zamboni/mobile/buttons.js:53
 msgid "Requires Newer Version of {0}"
 msgstr ""
 
-#: static/js/zamboni/mobile/buttons.js:54
+#: static/js/zamboni/mobile-all.js:15188 static/js/zamboni/mobile/buttons.js:54
 msgid "Unreviewed"
 msgstr ""
 
-#: static/js/zamboni/mobile/buttons.js:55
+#: static/js/zamboni/mobile-all.js:15189 static/js/zamboni/mobile/buttons.js:55
 msgid "Experimental <span>(Learn More)</span>"
 msgstr ""
 
-#: static/js/zamboni/mobile/buttons.js:56 static/js/zamboni/mobile/buttons.js:57
+#: static/js/zamboni/mobile-all.js:15190 static/js/zamboni/mobile-all.js:15191 static/js/zamboni/mobile/buttons.js:56 static/js/zamboni/mobile/buttons.js:57
 msgid "Not Available for {0}"
 msgstr ""
 
-#: static/js/zamboni/mobile/buttons.js:58
+#: static/js/zamboni/mobile-all.js:15192 static/js/zamboni/mobile/buttons.js:58
 msgid "Experimental"
 msgstr ""
 
-#: static/js/zamboni/mobile/buttons.js:59
+#: static/js/zamboni/mobile-all.js:15193 static/js/zamboni/mobile/buttons.js:59
 msgid "Themes Require Newer Version of {0}"
 msgstr ""
 
-#: static/js/zamboni/mobile/buttons.js:60
+#: static/js/zamboni/mobile-all.js:15194 static/js/zamboni/mobile/buttons.js:60
 msgid "Themes Require {0}"
 msgstr ""
 
-#: static/js/zamboni/mobile/buttons.js:105
+#: static/js/zamboni/mobile-all.js:15239 static/js/zamboni/mobile/buttons.js:105
 msgid "Installing..."
 msgstr ""
 
-#: static/js/zamboni/mobile/buttons.js:125
+#: static/js/zamboni/mobile-all.js:15259 static/js/zamboni/mobile/buttons.js:125
 msgid "This add-on has been preliminarily reviewed by Mozilla."
 msgstr ""
 
-#: static/js/zamboni/mobile/buttons.js:250
+#: static/js/zamboni/mobile-all.js:15384 static/js/zamboni/mobile/buttons.js:250
 msgid "Keep it"
 msgstr ""
 
-#: static/js/zamboni/mobile/general.js:344
+#: static/js/zamboni/mobile-all.js:16049 static/js/zamboni/mobile-min.js:6 static/js/zamboni/mobile/general.js:344
 msgid "You're trying it on!"
 msgstr ""
 
-#: static/js/zamboni/mobile/general.js:356
+#: static/js/zamboni/mobile-all.js:16061 static/js/zamboni/mobile-min.js:6 static/js/zamboni/mobile/general.js:356
 msgid "Added to Firefox"
 msgstr ""
-

--- a/locale/lij/LC_MESSAGES/django.po
+++ b/locale/lij/LC_MESSAGES/django.po
@@ -3,69 +3,70 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2016-02-24 21:23+0000\n"
+"POT-Creation-Date: 2016-04-18 15:47+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
+"Language: \n"
 "MIME-Version: 1.0\n"
-"Content-Type: text/plain; charset=utf-8\n"
+"Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Generated-By: Babel 2.2.0\n"
 
-#: src/olympia/accounts/views.py:52
+#: src/olympia/accounts/views.py:54
 msgid "Your log in attempt could not be parsed. Please try again."
 msgstr ""
 
-#: src/olympia/accounts/views.py:54
+#: src/olympia/accounts/views.py:56
 msgid "Your Firefox Account could not be found. Please try again."
 msgstr ""
 
-#: src/olympia/accounts/views.py:55
+#: src/olympia/accounts/views.py:57
 msgid "You could not be logged in. Please try again."
 msgstr ""
 
-#: src/olympia/accounts/views.py:57
+#: src/olympia/accounts/views.py:59
 msgid "Your account has already been migrated to Firefox Accounts."
 msgstr ""
 
-#: src/olympia/accounts/views.py:59
+#: src/olympia/accounts/views.py:61
 msgid "Your Firefox Account already exists on this site."
 msgstr ""
 
-#: src/olympia/accounts/views.py:108
+#: src/olympia/accounts/views.py:110
 msgid "Great job!"
 msgstr ""
 
-#: src/olympia/accounts/views.py:109
+#: src/olympia/accounts/views.py:111
 msgid "You can now log in to Add-ons with your Firefox Account."
 msgstr ""
 
-#: src/olympia/accounts/views.py:121
+#: src/olympia/accounts/views.py:123
 msgid "Need help?"
 msgstr ""
 
-#: src/olympia/addons/buttons.py:180
+#: src/olympia/addons/buttons.py:177
 msgid "Download Now"
 msgstr ""
 
-#: src/olympia/addons/buttons.py:182
+#: src/olympia/addons/buttons.py:179
 msgid "Download"
 msgstr ""
 
 #. L10n: please keep &nbsp; in the string so &rarr; does not wrap.
-#: src/olympia/addons/buttons.py:186
+#: src/olympia/addons/buttons.py:183
 msgid "Continue to Download&nbsp;&rarr;"
 msgstr ""
 
-#: src/olympia/addons/buttons.py:202 src/olympia/addons/helpers.py:35 src/olympia/addons/views.py:319 src/olympia/addons/templates/addons/impala/details.html:114
+#: src/olympia/addons/buttons.py:199 src/olympia/addons/helpers.py:35 src/olympia/addons/views.py:333 src/olympia/addons/templates/addons/impala/details.html:111
 #: src/olympia/addons/templates/addons/impala/listing/items.html:17 src/olympia/addons/templates/addons/mobile/home.html:40 src/olympia/amo/templates/amo/side_nav.html:6
-#: src/olympia/amo/templates/amo/side_nav.html:10 src/olympia/amo/templates/amo/site_nav.html:2 src/olympia/amo/templates/amo/site_nav.html:55 src/olympia/bandwagon/views.py:95
-#: src/olympia/browse/views.py:54 src/olympia/browse/views.py:68 src/olympia/browse/views.py:235 src/olympia/browse/templates/browse/impala/category_landing.html:22
+#: src/olympia/amo/templates/amo/side_nav.html:10 src/olympia/amo/templates/amo/site_nav.html:2 src/olympia/amo/templates/amo/site_nav.html:53 src/olympia/bandwagon/views.py:95
+#: src/olympia/browse/views.py:54 src/olympia/browse/views.py:68 src/olympia/browse/views.py:202 src/olympia/browse/templates/browse/impala/category_landing.html:22
 #: src/olympia/browse/templates/browse/personas/mobile/category_landing.html:26
 msgid "Featured"
 msgstr ""
 
-#: src/olympia/addons/buttons.py:221
+#: src/olympia/addons/buttons.py:218
 msgid "Add to {0}"
 msgstr ""
 
@@ -113,39 +114,39 @@ msgid_plural "All tags must be at least {0} characters."
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/olympia/addons/forms.py:234
+#: src/olympia/addons/forms.py:238
 msgid "Categories cannot be changed while your add-on is featured for this application."
 msgstr ""
 
 #. L10n: {0} is the number of categories.
-#: src/olympia/addons/forms.py:238
+#: src/olympia/addons/forms.py:242
 msgid "You can have only {0} category."
 msgid_plural "You can have only {0} categories."
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/olympia/addons/forms.py:246
+#: src/olympia/addons/forms.py:250
 msgid "The miscellaneous category cannot be combined with additional categories."
 msgstr ""
 
-#: src/olympia/addons/forms.py:369
+#: src/olympia/addons/forms.py:374
 #, python-format
 msgid "Before changing your default locale you must have a name, summary, and description in that locale. You are missing %s."
 msgstr ""
 
-#: src/olympia/addons/forms.py:484 src/olympia/addons/forms.py:575
+#: src/olympia/addons/forms.py:455 src/olympia/addons/forms.py:546
 msgid "A license must be selected."
 msgstr ""
 
-#: src/olympia/addons/forms.py:556
+#: src/olympia/addons/forms.py:527
 msgid "Give Your Theme a Name."
 msgstr ""
 
-#: src/olympia/addons/forms.py:562 src/olympia/devhub/templates/devhub/personas/submit.html:53
+#: src/olympia/addons/forms.py:533 src/olympia/devhub/templates/devhub/personas/submit.html:53
 msgid "Describe your Theme."
 msgstr ""
 
-#: src/olympia/addons/forms.py:704
+#: src/olympia/addons/forms.py:675
 msgid "Enter a new author's email address"
 msgstr ""
 
@@ -153,37 +154,37 @@ msgstr ""
 msgid "Not Reviewed"
 msgstr ""
 
-#: src/olympia/addons/models.py:301
+#: src/olympia/addons/models.py:298
 msgid "Users have the option of contributing more or less than this amount."
 msgstr ""
 
-#: src/olympia/addons/models.py:309
-msgid "Users will always be asked in the Add-ons Manager (Firefox 4 and above)"
+#: src/olympia/addons/models.py:306
+msgid "Users will always be asked in the Add-ons Manager (Firefox 4 and above). Only applies to desktop."
 msgstr ""
 
-#: src/olympia/addons/models.py:1804 src/olympia/addons/templates/addons/details_box.html:55 src/olympia/devhub/templates/devhub/index.html:92
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:102
+#: src/olympia/addons/models.py:1802 src/olympia/addons/templates/addons/details_box.html:55 src/olympia/devhub/templates/devhub/index.html:92
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:89
 msgid "Listed"
 msgstr ""
 
-#: src/olympia/addons/views.py:320 src/olympia/browse/templates/browse/personas/mobile/category_landing.html:27
+#: src/olympia/addons/views.py:334 src/olympia/browse/templates/browse/personas/mobile/category_landing.html:27
 msgid "Popular"
 msgstr ""
 
-#: src/olympia/addons/views.py:321 src/olympia/browse/views.py:238 src/olympia/browse/views.py:280 src/olympia/browse/views.py:482
+#: src/olympia/addons/views.py:335 src/olympia/browse/views.py:205 src/olympia/browse/views.py:247 src/olympia/browse/views.py:449
 msgid "Recently Added"
 msgstr ""
 
-#: src/olympia/addons/views.py:322 src/olympia/bandwagon/views.py:99 src/olympia/browse/views.py:60 src/olympia/browse/views.py:71 src/olympia/search/forms.py:16 src/olympia/search/forms.py:91
+#: src/olympia/addons/views.py:336 src/olympia/bandwagon/views.py:99 src/olympia/browse/views.py:60 src/olympia/browse/views.py:71 src/olympia/search/forms.py:16 src/olympia/search/forms.py:91
 msgid "Recently Updated"
 msgstr ""
 
 #. l10n: {0} is the addon name
-#: src/olympia/addons/views.py:520
+#: src/olympia/addons/views.py:534
 msgid "Contribution for {0}"
 msgstr ""
 
-#: src/olympia/addons/views.py:613
+#: src/olympia/addons/views.py:627
 msgid "Abuse reported."
 msgstr ""
 
@@ -250,9 +251,9 @@ msgstr ""
 #: src/olympia/devhub/templates/devhub/addons/ajax_compat_update.html:36 src/olympia/devhub/templates/devhub/addons/profile.html:44 src/olympia/devhub/templates/devhub/addons/edit/admin.html:101
 #: src/olympia/devhub/templates/devhub/addons/edit/basic.html:152 src/olympia/devhub/templates/devhub/addons/edit/details.html:85 src/olympia/devhub/templates/devhub/addons/edit/support.html:67
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:166 src/olympia/devhub/templates/devhub/addons/forms_shared/media.html:149
-#: src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:44 src/olympia/devhub/templates/devhub/versions/add_file_modal.html:78 src/olympia/devhub/templates/devhub/versions/edit.html:139
-#: src/olympia/devhub/templates/devhub/versions/list.html:242 src/olympia/devhub/templates/devhub/versions/list.html:276 src/olympia/devhub/templates/devhub/versions/list.html:317
-#: src/olympia/devhub/templates/devhub/versions/list.html:351 src/olympia/reviews/templates/reviews/edit_review.html:16 src/olympia/translations/templates/translations/trans-menu.html:50
+#: src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:43 src/olympia/devhub/templates/devhub/versions/add_file_modal.html:58 src/olympia/devhub/templates/devhub/versions/edit.html:139
+#: src/olympia/devhub/templates/devhub/versions/list.html:239 src/olympia/devhub/templates/devhub/versions/list.html:281 src/olympia/devhub/templates/devhub/versions/list.html:315
+#: src/olympia/devhub/templates/devhub/versions/list.html:349 src/olympia/reviews/templates/reviews/edit_review.html:16 src/olympia/translations/templates/translations/trans-menu.html:50
 #: src/olympia/translations/templates/translations/trans-menu.html:62
 msgid "or"
 msgstr ""
@@ -363,7 +364,7 @@ msgid "Add-on Information for {0}"
 msgstr ""
 
 #: src/olympia/addons/templates/addons/details_box.html:30 src/olympia/addons/templates/addons/persona_detail_table.html:3 src/olympia/addons/templates/addons/mobile/details.html:63
-#: src/olympia/addons/templates/addons/mobile/persona_detail_table.html:7 src/olympia/browse/views.py:459 src/olympia/devhub/views.py:75
+#: src/olympia/addons/templates/addons/mobile/persona_detail_table.html:7 src/olympia/browse/views.py:426 src/olympia/devhub/views.py:73
 msgid "Updated"
 msgstr ""
 
@@ -382,11 +383,11 @@ msgstr ""
 msgid "Visibility"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/details_box.html:57 src/olympia/devhub/templates/devhub/index.html:94 src/olympia/devhub/templates/devhub/includes/addon_details.html:104
+#: src/olympia/addons/templates/addons/details_box.html:57 src/olympia/devhub/templates/devhub/index.html:94 src/olympia/devhub/templates/devhub/includes/addon_details.html:91
 msgid "Hidden"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/details_box.html:59 src/olympia/devhub/templates/devhub/index.html:96 src/olympia/devhub/templates/devhub/includes/addon_details.html:106
+#: src/olympia/addons/templates/addons/details_box.html:59 src/olympia/devhub/templates/devhub/index.html:96 src/olympia/devhub/templates/devhub/includes/addon_details.html:93
 msgid "Unlisted"
 msgstr ""
 
@@ -394,13 +395,13 @@ msgstr ""
 msgid "Required Add-ons"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/details_box.html:81 src/olympia/addons/templates/addons/persona_detail_table.html:15 src/olympia/browse/views.py:462 src/olympia/devhub/views.py:78
-#: src/olympia/devhub/views.py:85 src/olympia/discovery/templates/discovery/addons/detail.html:57 src/olympia/reviews/forms.py:62 src/olympia/reviews/templates/reviews/add.html:57
+#: src/olympia/addons/templates/addons/details_box.html:81 src/olympia/addons/templates/addons/persona_detail_table.html:15 src/olympia/browse/views.py:429 src/olympia/devhub/views.py:76
+#: src/olympia/devhub/views.py:83 src/olympia/discovery/templates/discovery/addons/detail.html:57 src/olympia/reviews/forms.py:62 src/olympia/reviews/templates/reviews/add.html:57
 #: src/olympia/reviews/templates/reviews/mobile/review_list.html:18
 msgid "Rating"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/details_box.html:85 src/olympia/browse/views.py:461 src/olympia/devhub/views.py:77 src/olympia/devhub/views.py:84
+#: src/olympia/addons/templates/addons/details_box.html:85 src/olympia/browse/views.py:428 src/olympia/devhub/views.py:75 src/olympia/devhub/views.py:82
 #: src/olympia/stats/templates/stats/addon_report_menu.html:8 src/olympia/stats/templates/stats/collection_report_menu.html:18
 msgid "Downloads"
 msgstr ""
@@ -420,7 +421,7 @@ msgstr ""
 
 #. The Privacy Policy for this add-on.
 #: src/olympia/addons/templates/addons/details_box.html:121 src/olympia/addons/templates/addons/privacy.html:19 src/olympia/addons/templates/addons/privacy.html:23
-#: src/olympia/addons/templates/addons/impala/button.html:43 src/olympia/addons/templates/addons/impala/details.html:307 src/olympia/devhub/templates/devhub/includes/policy_form.html:20
+#: src/olympia/addons/templates/addons/impala/button.html:43 src/olympia/addons/templates/addons/impala/details.html:312 src/olympia/devhub/templates/devhub/includes/policy_form.html:23
 #: src/olympia/templates/mobile/base_addons.html:87
 msgid "Privacy Policy"
 msgstr ""
@@ -445,7 +446,7 @@ msgstr ""
 msgid "Developer Comments"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/details_box.html:199 src/olympia/addons/templates/addons/impala/details.html:259
+#: src/olympia/addons/templates/addons/details_box.html:199 src/olympia/addons/templates/addons/impala/details.html:264
 msgid "Development Channel"
 msgstr ""
 
@@ -465,7 +466,7 @@ msgid ""
 "developer. To stop receiving development updates, reinstall the default version from the link above."
 msgstr ""
 
-#: src/olympia/addons/templates/addons/details_box.html:220 src/olympia/addons/templates/addons/impala/details.html:278
+#: src/olympia/addons/templates/addons/details_box.html:220 src/olympia/addons/templates/addons/impala/details.html:283
 msgid "Version {0}:"
 msgstr ""
 
@@ -484,7 +485,7 @@ msgid "End-User License Agreement for {0}"
 msgstr ""
 
 #: src/olympia/addons/templates/addons/eula.html:17 src/olympia/addons/templates/addons/eula.html:21 src/olympia/addons/templates/addons/impala/button.html:48
-#: src/olympia/addons/templates/addons/impala/details.html:316 src/olympia/devhub/templates/devhub/includes/policy_form.html:3 src/olympia/discovery/templates/discovery/addons/eula.html:11
+#: src/olympia/addons/templates/addons/impala/details.html:321 src/olympia/devhub/templates/devhub/includes/policy_form.html:3 src/olympia/discovery/templates/discovery/addons/eula.html:11
 msgid "End-User License Agreement"
 msgstr ""
 
@@ -501,7 +502,7 @@ msgstr ""
 msgid "Add-ons for {0}"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/home.html:10 src/olympia/addons/templates/addons/home.html:51 src/olympia/browse/templates/browse/impala/base_listing.html:11
+#: src/olympia/addons/templates/addons/home.html:10 src/olympia/addons/templates/addons/home.html:53 src/olympia/browse/templates/browse/impala/base_listing.html:11
 msgid "Featured Extensions"
 msgstr ""
 
@@ -509,29 +510,29 @@ msgstr ""
 msgid "Popular Extensions"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/home.html:42 src/olympia/amo/templates/amo/side_nav.html:3 src/olympia/amo/templates/amo/side_nav.html:11 src/olympia/amo/templates/amo/site_nav.html:3
-#: src/olympia/amo/templates/amo/site_nav.html:25 src/olympia/browse/views.py:236 src/olympia/browse/views.py:281 src/olympia/browse/views.py:481
+#: src/olympia/addons/templates/addons/home.html:44 src/olympia/amo/templates/amo/side_nav.html:3 src/olympia/amo/templates/amo/side_nav.html:11 src/olympia/amo/templates/amo/site_nav.html:3
+#: src/olympia/amo/templates/amo/site_nav.html:25 src/olympia/browse/views.py:203 src/olympia/browse/views.py:248 src/olympia/browse/views.py:448
 msgid "Most Popular"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/home.html:43
+#: src/olympia/addons/templates/addons/home.html:45
 msgid "All »"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/home.html:52 src/olympia/addons/templates/addons/home.html:61 src/olympia/addons/templates/addons/home.html:70 src/olympia/addons/templates/addons/home.html:78
+#: src/olympia/addons/templates/addons/home.html:54 src/olympia/addons/templates/addons/home.html:63 src/olympia/addons/templates/addons/home.html:72 src/olympia/addons/templates/addons/home.html:80
 #: src/olympia/browse/templates/browse/impala/category_landing.html:36
 msgid "See all »"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/home.html:60
+#: src/olympia/addons/templates/addons/home.html:62
 msgid "Up &amp; Coming Extensions"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/home.html:69 src/olympia/browse/templates/browse/personas/category_landing.html:61 src/olympia/discovery/templates/discovery/pane.html:74
+#: src/olympia/addons/templates/addons/home.html:71 src/olympia/browse/templates/browse/personas/category_landing.html:61 src/olympia/discovery/templates/discovery/pane.html:74
 msgid "Featured Themes"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/home.html:77 src/olympia/bandwagon/templates/bandwagon/impala/collection_listing.html:5
+#: src/olympia/addons/templates/addons/home.html:79 src/olympia/bandwagon/templates/bandwagon/impala/collection_listing.html:5
 msgid "Featured Collections"
 msgstr ""
 
@@ -549,7 +550,7 @@ msgid "Updated {0}"
 msgstr ""
 
 #. {0} is a date.
-#: src/olympia/addons/templates/addons/macros.html:10 src/olympia/addons/templates/addons/macros.html:69 src/olympia/addons/templates/addons/persona_preview.html:21
+#: src/olympia/addons/templates/addons/macros.html:10 src/olympia/addons/templates/addons/macros.html:69 src/olympia/addons/templates/addons/persona_preview.html:22
 #: src/olympia/addons/templates/addons/listing/items_mobile.html:44 src/olympia/addons/templates/addons/listing/macros.html:39
 #: src/olympia/bandwagon/templates/bandwagon/collection_listing_items.html:37 src/olympia/bandwagon/templates/bandwagon/impala/collection_listing_items.html:37
 msgid "Added {0}"
@@ -570,15 +571,14 @@ msgstr[0] ""
 msgstr[1] ""
 
 #. {0} is the number of downloads.
-#: src/olympia/addons/templates/addons/macros.html:53 src/olympia/addons/templates/addons/impala/details.html:61
+#: src/olympia/addons/templates/addons/macros.html:53 src/olympia/addons/templates/addons/impala/details.html:59
 msgid "{0} weekly download"
 msgid_plural "{0} weekly downloads"
 msgstr[0] ""
 msgstr[1] ""
 
 #. {0} is the number of users.
-#: src/olympia/addons/templates/addons/macros.html:61 src/olympia/addons/templates/addons/impala/details.html:54 src/olympia/compat/templates/compat/index.html:71
-#: src/olympia/zadmin/templates/zadmin/compat.html:67
+#: src/olympia/addons/templates/addons/macros.html:61 src/olympia/addons/templates/addons/impala/details.html:52 src/olympia/zadmin/templates/zadmin/compat.html:67
 msgid "{0} user"
 msgid_plural "{0} users"
 msgstr[0] ""
@@ -596,7 +596,7 @@ msgstr ""
 msgid "Return to the addon."
 msgstr ""
 
-#: src/olympia/addons/templates/addons/persona_detail.html:17 src/olympia/addons/templates/addons/impala/details.html:106 src/olympia/addons/templates/addons/mobile/details.html:23
+#: src/olympia/addons/templates/addons/persona_detail.html:17 src/olympia/addons/templates/addons/impala/details.html:103 src/olympia/addons/templates/addons/mobile/details.html:23
 #: src/olympia/addons/templates/addons/mobile/persona_detail.html:21 src/olympia/discovery/templates/discovery/addons/base.html:27 src/olympia/editors/templates/editors/review.html:31
 msgid "by"
 msgstr ""
@@ -640,34 +640,35 @@ msgstr ""
 msgid "License"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/persona_preview.html:12 src/olympia/constants/base.py:48
+#: src/olympia/addons/templates/addons/persona_preview.html:13 src/olympia/constants/base.py:48
 msgid "Awaiting Review"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/persona_preview.html:14 src/olympia/amo/log.py:180 src/olympia/constants/base.py:42 src/olympia/editors/helpers.py:62
+#: src/olympia/addons/templates/addons/persona_preview.html:15 src/olympia/amo/log.py:180 src/olympia/constants/base.py:42 src/olympia/editors/helpers.py:62
 msgid "Rejected"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/persona_preview.html:16 src/olympia/amo/log.py:159
+#: src/olympia/addons/templates/addons/persona_preview.html:17 src/olympia/amo/log.py:159
 msgid "Approved"
 msgstr ""
 
 #. {0} is the number of users.
-#: src/olympia/addons/templates/addons/persona_preview.html:26 src/olympia/addons/templates/addons/listing/items_mobile.html:36 src/olympia/addons/templates/addons/listing/macros.html:31
+#: src/olympia/addons/templates/addons/persona_preview.html:27 src/olympia/addons/templates/addons/listing/items_mobile.html:36 src/olympia/addons/templates/addons/listing/macros.html:31
 msgid "<strong>{0}</strong> user"
 msgid_plural "<strong>{0}</strong> users"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/olympia/addons/templates/addons/persona_preview.html:40
+#: src/olympia/addons/templates/addons/persona_preview.html:41
 msgid "Hover to Preview"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/persona_preview.html:46 src/olympia/addons/templates/addons/persona_preview.html:48 src/olympia/reviews/templates/reviews/add.html:15
+#: src/olympia/addons/templates/addons/persona_preview.html:47 src/olympia/addons/templates/addons/persona_preview.html:49 src/olympia/addons/templates/addons/persona_preview.html:97
+#: src/olympia/reviews/templates/reviews/add.html:15
 msgid "Add"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/persona_preview.html:57 src/olympia/bandwagon/templates/bandwagon/ajax_new.html:16 src/olympia/bandwagon/templates/bandwagon/edit.html:19
+#: src/olympia/addons/templates/addons/persona_preview.html:58 src/olympia/bandwagon/templates/bandwagon/ajax_new.html:16 src/olympia/bandwagon/templates/bandwagon/edit.html:19
 #: src/olympia/bandwagon/templates/bandwagon/includes/addedit.html:19 src/olympia/devhub/templates/devhub/addons/edit/admin.html:13 src/olympia/devhub/templates/devhub/addons/edit/basic.html:10
 #: src/olympia/devhub/templates/devhub/addons/edit/details.html:8 src/olympia/devhub/templates/devhub/addons/edit/media.html:6 src/olympia/devhub/templates/devhub/addons/edit/support.html:8
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:9 src/olympia/devhub/templates/devhub/addons/submit/describe.html:29 src/olympia/editors/templates/editors/review.html:257
@@ -676,21 +677,21 @@ msgstr ""
 
 #. For datetime formatting, see the table on
 #. http://docs.python.org/library/datetime.html#strftime-and-strptime-behavior
-#: src/olympia/addons/templates/addons/persona_preview.html:66
+#: src/olympia/addons/templates/addons/persona_preview.html:67
 #, python-format
 msgid "%%Y-%%m-%%d"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/persona_preview.html:67
+#: src/olympia/addons/templates/addons/persona_preview.html:68
 msgid "by {0} on {1}"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/persona_preview.html:75 src/olympia/reviews/helpers.py:17 src/olympia/reviews/templates/reviews/review_list.html:63
+#: src/olympia/addons/templates/addons/persona_preview.html:76 src/olympia/reviews/helpers.py:17 src/olympia/reviews/templates/reviews/review_list.html:63
 #: src/olympia/reviews/templates/reviews/reviews_link.html:21 src/olympia/reviews/templates/reviews/impala/reviews_link.html:16
 msgid "Not yet rated"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/persona_preview.html:78
+#: src/olympia/addons/templates/addons/persona_preview.html:79
 msgid "<b>{0}</b> users"
 msgstr ""
 
@@ -703,7 +704,7 @@ msgid "Learn more about Firefox"
 msgstr ""
 
 #: src/olympia/addons/templates/addons/popups.html:22
-msgid "or <b><a class=\"installer\" href=\"{url}\">download anyway</a></b>"
+msgid "or <b><a class=\"button installer\" href=\"{url}\">download anyway</a></b>"
 msgstr ""
 
 #: src/olympia/addons/templates/addons/popups.html:26
@@ -802,7 +803,7 @@ msgid ""
 msgstr ""
 
 #: src/olympia/addons/templates/addons/report_abuse.html:6 src/olympia/addons/templates/addons/report_abuse_full.html:10 src/olympia/addons/templates/addons/impala/details-more.html:23
-#: src/olympia/addons/templates/addons/impala/details.html:328
+#: src/olympia/addons/templates/addons/impala/details.html:333
 msgid "Report Abuse"
 msgstr ""
 
@@ -821,9 +822,9 @@ msgstr ""
 #: src/olympia/devhub/templates/devhub/addons/ajax_compat_update.html:36 src/olympia/devhub/templates/devhub/addons/profile.html:44 src/olympia/devhub/templates/devhub/addons/edit/admin.html:104
 #: src/olympia/devhub/templates/devhub/addons/edit/basic.html:155 src/olympia/devhub/templates/devhub/addons/edit/details.html:88 src/olympia/devhub/templates/devhub/addons/edit/support.html:70
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:169 src/olympia/devhub/templates/devhub/addons/forms_shared/media.html:152
-#: src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:44 src/olympia/devhub/templates/devhub/personas/edit.html:222 src/olympia/devhub/templates/devhub/versions/add_file_modal.html:79
-#: src/olympia/devhub/templates/devhub/versions/edit.html:140 src/olympia/devhub/templates/devhub/versions/list.html:208 src/olympia/devhub/templates/devhub/versions/list.html:242
-#: src/olympia/devhub/templates/devhub/versions/list.html:276 src/olympia/devhub/templates/devhub/versions/list.html:317 src/olympia/reviews/templates/reviews/edit_review.html:16
+#: src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:43 src/olympia/devhub/templates/devhub/personas/edit.html:222 src/olympia/devhub/templates/devhub/versions/add_file_modal.html:59
+#: src/olympia/devhub/templates/devhub/versions/edit.html:140 src/olympia/devhub/templates/devhub/versions/list.html:208 src/olympia/devhub/templates/devhub/versions/list.html:239
+#: src/olympia/devhub/templates/devhub/versions/list.html:281 src/olympia/devhub/templates/devhub/versions/list.html:315 src/olympia/reviews/templates/reviews/edit_review.html:16
 #: src/olympia/translations/templates/translations/trans-menu.html:50 src/olympia/translations/templates/translations/trans-menu.html:62 src/olympia/zadmin/templates/zadmin/validation.html:105
 msgid "Cancel"
 msgstr ""
@@ -868,7 +869,7 @@ msgstr ""
 msgid "Review Guidelines"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/review_list_box.html:5 src/olympia/addons/templates/addons/impala/details-more.html:27 src/olympia/editors/helpers.py:921
+#: src/olympia/addons/templates/addons/review_list_box.html:5 src/olympia/addons/templates/addons/impala/details-more.html:27 src/olympia/editors/helpers.py:1001
 #: src/olympia/reviews/templates/reviews/add.html:14 src/olympia/reviews/templates/reviews/reply.html:14 src/olympia/reviews/templates/reviews/review_list.html:19
 #: src/olympia/reviews/templates/reviews/mobile/review_list.html:26
 msgid "Reviews"
@@ -959,119 +960,119 @@ msgid_plural "Other add-ons by these authors"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/olympia/addons/templates/addons/impala/details.html:41
+#: src/olympia/addons/templates/addons/impala/details.html:39
 #, python-format
 msgid "<span itemprop=\"ratingCount\">%(num)s</span> user review"
 msgid_plural "<span itemprop=\"ratingCount\">%(num)s</span> user reviews"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/olympia/addons/templates/addons/impala/details.html:69
+#: src/olympia/addons/templates/addons/impala/details.html:66
 msgid "View statistics"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/impala/details.html:84
+#: src/olympia/addons/templates/addons/impala/details.html:81
 msgid "Manage"
 msgstr ""
 
 #. {0} is an add-on name.
-#: src/olympia/addons/templates/addons/impala/details.html:96
+#: src/olympia/addons/templates/addons/impala/details.html:93
 msgid "Icon of {0}"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/impala/details.html:103 src/olympia/addons/templates/addons/impala/listing/items.html:14
+#: src/olympia/addons/templates/addons/impala/details.html:100 src/olympia/addons/templates/addons/impala/listing/items.html:14
 msgid "No Restart"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/impala/details.html:127
+#: src/olympia/addons/templates/addons/impala/details.html:124
 #, python-format
 msgid "Meet the Developer: <a href=\"%(url)s\">%(name)s</a>"
 msgid_plural "<a href=\"%(url)s\">Meet the Developers</a>"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/olympia/addons/templates/addons/impala/details.html:137
+#: src/olympia/addons/templates/addons/impala/details.html:134
 msgid "Learn why {0} was created and find out what's next for this add-on."
 msgstr ""
 
 #. {0} is an index.
-#: src/olympia/addons/templates/addons/impala/details.html:156
+#: src/olympia/addons/templates/addons/impala/details.html:161
 msgid "Add-on screenshot #{0}"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/impala/details.html:182
+#: src/olympia/addons/templates/addons/impala/details.html:187
 msgid "Add-on home page"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/impala/details.html:185
+#: src/olympia/addons/templates/addons/impala/details.html:190
 msgid "Support site"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/impala/details.html:189
+#: src/olympia/addons/templates/addons/impala/details.html:194
 msgid "Support E-mail"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/impala/details.html:194 src/olympia/devhub/models.py:378 src/olympia/devhub/templates/devhub/versions/list.html:12
+#: src/olympia/addons/templates/addons/impala/details.html:199 src/olympia/devhub/models.py:378 src/olympia/devhub/templates/devhub/versions/list.html:12
 #: src/olympia/versions/templates/versions/version.html:6 src/olympia/versions/templates/versions/mobile/version.html:6
 msgid "Version {0}"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/impala/details.html:194
+#: src/olympia/addons/templates/addons/impala/details.html:199
 msgid "Info"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/impala/details.html:195 src/olympia/devhub/templates/devhub/includes/addon_details.html:129
+#: src/olympia/addons/templates/addons/impala/details.html:200 src/olympia/devhub/templates/devhub/includes/addon_details.html:116
 msgid "Last Updated:"
-msgstr ""
-
-#: src/olympia/addons/templates/addons/impala/details.html:200
-#, python-format
-msgid "Released under <a target=\"_blank\" href=\"%(url)s\">%(name)s</a>"
-msgstr ""
-
-#: src/olympia/addons/templates/addons/impala/details.html:201 src/olympia/addons/templates/addons/impala/details.html:206 src/olympia/amo/helpers.py:398 src/olympia/devhub/forms.py:142
-#: src/olympia/devhub/forms.py:173 src/olympia/versions/templates/versions/version.html:40 src/olympia/versions/templates/versions/version.html:45
-msgid "Custom License"
 msgstr ""
 
 #: src/olympia/addons/templates/addons/impala/details.html:205
 #, python-format
+msgid "Released under <a target=\"_blank\" href=\"%(url)s\">%(name)s</a>"
+msgstr ""
+
+#: src/olympia/addons/templates/addons/impala/details.html:206 src/olympia/addons/templates/addons/impala/details.html:211 src/olympia/amo/helpers.py:398 src/olympia/devhub/forms.py:142
+#: src/olympia/devhub/forms.py:173 src/olympia/versions/templates/versions/version.html:40 src/olympia/versions/templates/versions/version.html:45
+msgid "Custom License"
+msgstr ""
+
+#: src/olympia/addons/templates/addons/impala/details.html:210
+#, python-format
 msgid "Released under <a href=\"%(url)s\">%(name)s</a>"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/impala/details.html:217
+#: src/olympia/addons/templates/addons/impala/details.html:222
 msgid "About this Add-on"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/impala/details.html:233
+#: src/olympia/addons/templates/addons/impala/details.html:238
 msgid "Developer’s Comments"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/impala/details.html:243
+#: src/olympia/addons/templates/addons/impala/details.html:248
 msgid "Version Information"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/impala/details.html:250
+#: src/olympia/addons/templates/addons/impala/details.html:255
 msgid "See complete version history"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/impala/details.html:262
+#: src/olympia/addons/templates/addons/impala/details.html:267
 msgid ""
 "The Development Channel lets you test an experimental new version of this add-on before it's released to the general public. Once you install the development version, you will continue to get "
 "updates from this channel. To stop receiving development updates, reinstall the default version from the link above."
 msgstr ""
 
-#: src/olympia/addons/templates/addons/impala/details.html:272
+#: src/olympia/addons/templates/addons/impala/details.html:277
 msgid "<strong>Caution:</strong> Development versions of this add-on have not been reviewed by Mozilla."
 msgstr ""
 
-#: src/olympia/addons/templates/addons/impala/details.html:287
+#: src/olympia/addons/templates/addons/impala/details.html:292
 msgid "See complete development channel history"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/impala/details.html:306 src/olympia/addons/templates/addons/impala/details.html:315 src/olympia/addons/templates/addons/impala/details.html:327
+#: src/olympia/addons/templates/addons/impala/details.html:311 src/olympia/addons/templates/addons/impala/details.html:320 src/olympia/addons/templates/addons/impala/details.html:332
 #: src/olympia/addons/templates/addons/impala/review_add_box.html:4 src/olympia/stats/templates/stats/popup.html:2 src/olympia/stats/templates/stats/popup.html:8
-#: src/olympia/stats/templates/stats/stats.html:202 src/olympia/users/templates/users/profile.html:119
+#: src/olympia/stats/templates/stats/stats.html:204 src/olympia/users/templates/users/profile.html:119
 msgid "close"
 msgstr ""
 
@@ -1127,15 +1128,11 @@ msgstr ""
 msgid "Source Code License"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/impala/persona_grid.html:16 src/olympia/addons/templates/addons/impala/toplist.html:6
-msgid "{0} users"
-msgstr ""
-
 #: src/olympia/addons/templates/addons/impala/review_list_box.html:19 src/olympia/reviews/templates/reviews/review.html:40
 msgid "permalink"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/impala/review_list_box.html:23 src/olympia/editors/templates/editors/queue.html:98 src/olympia/reviews/templates/reviews/review.html:44
+#: src/olympia/addons/templates/addons/impala/review_list_box.html:23 src/olympia/editors/templates/editors/queue.html:104 src/olympia/reviews/templates/reviews/review.html:44
 msgid "translate"
 msgstr ""
 
@@ -1154,6 +1151,10 @@ msgstr ""
 msgid "Be the first!"
 msgstr ""
 
+#: src/olympia/addons/templates/addons/impala/toplist.html:6
+msgid "{0} users"
+msgstr ""
+
 #: src/olympia/addons/templates/addons/impala/listing/sorter.html:14 src/olympia/devhub/templates/devhub/addons/listing/item_actions.html:49
 msgid "More"
 msgstr ""
@@ -1166,7 +1167,7 @@ msgstr ""
 msgid "My Add-ons"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/includes/dashboard_tabs.html:6 src/olympia/amo/context_processors.py:51
+#: src/olympia/addons/templates/addons/includes/dashboard_tabs.html:6 src/olympia/amo/context_processors.py:50
 msgid "My Themes"
 msgstr ""
 
@@ -1221,7 +1222,7 @@ msgstr ""
 msgid "Weekly Downloads"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/mobile/details.html:99 src/olympia/compat/templates/compat/reporter_detail.html:46 src/olympia/devhub/forms.py:787
+#: src/olympia/addons/templates/addons/mobile/details.html:99 src/olympia/compat/templates/compat/reporter_detail.html:46 src/olympia/devhub/forms.py:788
 #: src/olympia/devhub/templates/devhub/versions/list.html:163
 msgid "Version"
 msgstr ""
@@ -1305,7 +1306,7 @@ msgstr ""
 #: src/olympia/browse/templates/browse/personas/category_landing.html:21 src/olympia/browse/templates/browse/personas/category_landing.html:23
 #: src/olympia/browse/templates/browse/personas/category_landing.html:38 src/olympia/browse/templates/browse/personas/grid.html:7 src/olympia/browse/templates/browse/personas/grid.html:11
 #: src/olympia/browse/templates/browse/personas/mobile/base.html:7 src/olympia/browse/templates/browse/personas/mobile/category_landing.html:19 src/olympia/constants/base.py:180
-#: src/olympia/devhub/templates/devhub/personas/submit.html:13 src/olympia/editors/helpers.py:105 src/olympia/editors/templates/editors/base.html:26
+#: src/olympia/devhub/templates/devhub/personas/submit.html:13 src/olympia/editors/helpers.py:107 src/olympia/editors/templates/editors/base.html:26
 #: src/olympia/editors/templates/editors/performance.html:73 src/olympia/search/templates/search/personas.html:39 src/olympia/templates/menu_links.html:9
 msgid "Themes"
 msgstr ""
@@ -1326,7 +1327,7 @@ msgstr ""
 msgid "Highest Rated"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/mobile/home.html:74 src/olympia/amo/templates/amo/side_nav.html:5 src/olympia/amo/templates/amo/site_nav.html:27 src/olympia/amo/templates/amo/site_nav.html:57
+#: src/olympia/addons/templates/addons/mobile/home.html:74 src/olympia/amo/templates/amo/side_nav.html:5 src/olympia/amo/templates/amo/site_nav.html:27 src/olympia/amo/templates/amo/site_nav.html:55
 #: src/olympia/bandwagon/views.py:97 src/olympia/browse/views.py:57 src/olympia/browse/views.py:67 src/olympia/browse/templates/browse/personas/mobile/category_landing.html:65
 #: src/olympia/search/forms.py:15 src/olympia/search/forms.py:87
 msgid "Newest"
@@ -1340,90 +1341,90 @@ msgstr ""
 msgid "Theme Info &raquo;"
 msgstr ""
 
-#: src/olympia/amo/context_processors.py:39 src/olympia/devhub/templates/devhub/nav.html:43
+#: src/olympia/amo/context_processors.py:37 src/olympia/devhub/templates/devhub/nav.html:43
 msgid "Tools"
 msgstr ""
 
-#: src/olympia/amo/context_processors.py:48 src/olympia/discovery/templates/discovery/pane_account.html:8 src/olympia/users/templates/users/includes/navigation.html:2
+#: src/olympia/amo/context_processors.py:47 src/olympia/discovery/templates/discovery/pane_account.html:8 src/olympia/users/templates/users/includes/navigation.html:2
 msgid "My Profile"
 msgstr ""
 
-#: src/olympia/amo/context_processors.py:54 src/olympia/users/templates/users/edit.html:5 src/olympia/users/templates/users/includes/navigation.html:3
+#: src/olympia/amo/context_processors.py:53 src/olympia/users/templates/users/edit.html:5 src/olympia/users/templates/users/includes/navigation.html:3
 msgid "Account Settings"
 msgstr ""
 
-#: src/olympia/amo/context_processors.py:57 src/olympia/discovery/templates/discovery/pane_account.html:11 src/olympia/users/templates/users/profile.html:83
+#: src/olympia/amo/context_processors.py:56 src/olympia/discovery/templates/discovery/pane_account.html:11 src/olympia/users/templates/users/profile.html:83
 #: src/olympia/users/templates/users/includes/navigation.html:4
 msgid "My Collections"
 msgstr ""
 
-#: src/olympia/amo/context_processors.py:62 src/olympia/discovery/templates/discovery/pane_account.html:10 src/olympia/users/templates/users/includes/navigation.html:7
+#: src/olympia/amo/context_processors.py:61 src/olympia/discovery/templates/discovery/pane_account.html:10 src/olympia/users/templates/users/includes/navigation.html:7
 msgid "My Favorites"
 msgstr ""
 
-#: src/olympia/amo/context_processors.py:67 src/olympia/discovery/templates/discovery/pane_account.html:13 src/olympia/templates/impala/user_login.html:14
+#: src/olympia/amo/context_processors.py:66 src/olympia/discovery/templates/discovery/pane_account.html:13 src/olympia/templates/impala/user_login.html:14
 #: src/olympia/templates/mobile/header_auth.html:5
 msgid "Log out"
 msgstr ""
 
-#: src/olympia/amo/context_processors.py:72 src/olympia/devhub/templates/devhub/addons/dashboard.html:4
+#: src/olympia/amo/context_processors.py:71 src/olympia/devhub/templates/devhub/addons/dashboard.html:4
 msgid "Manage My Submissions"
 msgstr ""
 
-#: src/olympia/amo/context_processors.py:75 src/olympia/devhub/templates/devhub/nav.html:27 src/olympia/devhub/templates/devhub/addons/dashboard.html:25
+#: src/olympia/amo/context_processors.py:74 src/olympia/devhub/templates/devhub/nav.html:27 src/olympia/devhub/templates/devhub/addons/dashboard.html:25
 #: src/olympia/devhub/templates/devhub/addons/submit/base.html:4
 msgid "Submit a New Add-on"
 msgstr ""
 
-#: src/olympia/amo/context_processors.py:77 src/olympia/browse/templates/browse/personas/base.html:50 src/olympia/devhub/templates/devhub/index.html:24
+#: src/olympia/amo/context_processors.py:76 src/olympia/browse/templates/browse/personas/base.html:50 src/olympia/devhub/templates/devhub/index.html:24
 #: src/olympia/devhub/templates/devhub/addons/dashboard.html:29
 msgid "Submit a New Theme"
 msgstr ""
 
-#: src/olympia/amo/context_processors.py:79 src/olympia/amo/templates/amo/site_nav.html:87 src/olympia/devhub/helpers.py:36 src/olympia/devhub/helpers.py:68 src/olympia/devhub/helpers.py:102
+#: src/olympia/amo/context_processors.py:78 src/olympia/amo/templates/amo/site_nav.html:85 src/olympia/devhub/helpers.py:36 src/olympia/devhub/helpers.py:68 src/olympia/devhub/helpers.py:102
 #: src/olympia/templates/footer.html:6 src/olympia/templates/menu_links.html:14
 msgid "Developer Hub"
 msgstr ""
 
-#: src/olympia/amo/context_processors.py:83 src/olympia/devhub/views.py:1792
+#: src/olympia/amo/context_processors.py:81 src/olympia/devhub/views.py:1796
 msgid "Manage API Keys"
 msgstr ""
 
-#: src/olympia/amo/context_processors.py:88 src/olympia/editors/helpers.py:82 src/olympia/editors/helpers.py:102 src/olympia/editors/templates/editors/base.html:10
+#: src/olympia/amo/context_processors.py:86 src/olympia/editors/helpers.py:84 src/olympia/editors/helpers.py:104 src/olympia/editors/templates/editors/base.html:10
 msgid "Editor Tools"
 msgstr ""
 
-#: src/olympia/amo/context_processors.py:92
+#: src/olympia/amo/context_processors.py:90
 msgid "Admin Tools"
 msgstr ""
 
-#: src/olympia/amo/fields.py:15
+#: src/olympia/amo/fields.py:20
 msgid "Incorrect, please try again."
 msgstr ""
 
-#: src/olympia/amo/fields.py:16
+#: src/olympia/amo/fields.py:21
 msgid "Error verifying input, please try again."
 msgstr ""
 
-#: src/olympia/amo/fields.py:32
+#: src/olympia/amo/fields.py:37
 msgid "This must be a valid hex color code, such as #000000."
 msgstr ""
 
-#: src/olympia/amo/fields.py:58
+#: src/olympia/amo/fields.py:63
 msgid "Enter at least one value."
 msgstr ""
 
-#: src/olympia/amo/helpers.py:162 src/olympia/amo/templates/amo/site_nav.html:61 src/olympia/bandwagon/templates/bandwagon/add.html:9
+#: src/olympia/amo/helpers.py:162 src/olympia/amo/templates/amo/site_nav.html:59 src/olympia/bandwagon/templates/bandwagon/add.html:9
 #: src/olympia/bandwagon/templates/bandwagon/collection_detail.html:15 src/olympia/bandwagon/templates/bandwagon/delete.html:9 src/olympia/bandwagon/templates/bandwagon/edit.html:15
 #: src/olympia/bandwagon/templates/bandwagon/user_listing.html:18 src/olympia/bandwagon/templates/bandwagon/user_listing.html:21
 #: src/olympia/bandwagon/templates/bandwagon/impala/collection_listing.html:12 src/olympia/bandwagon/templates/bandwagon/impala/collection_listing.html:20
 #: src/olympia/bandwagon/templates/bandwagon/impala/collection_listing.html:24 src/olympia/bandwagon/templates/bandwagon/impala/collection_sidebar.html:3
 #: src/olympia/bandwagon/templates/bandwagon/includes/collection_sidebar.html:2 src/olympia/bandwagon/templates/bandwagon/mobile/collection_listing.html:3
-#: src/olympia/stats/templates/stats/stats.html:77 src/olympia/templates/menu_links.html:12
+#: src/olympia/stats/templates/stats/stats.html:33 src/olympia/templates/menu_links.html:12
 msgid "Collections"
 msgstr ""
 
-#: src/olympia/amo/helpers.py:171 src/olympia/amo/templates/amo/site_nav.html:85 src/olympia/browse/templates/browse/language_tools.html:3
+#: src/olympia/amo/helpers.py:171 src/olympia/amo/templates/amo/site_nav.html:83 src/olympia/browse/templates/browse/language_tools.html:3
 msgid "Dictionaries & Language Packs"
 msgstr ""
 
@@ -1575,8 +1576,8 @@ msgstr ""
 msgid "Comment on {addon} {version}."
 msgstr ""
 
-#: src/olympia/amo/log.py:236 src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:19 src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:47
-#: src/olympia/editors/helpers.py:511 src/olympia/editors/templates/editors/themes/history_table.html:11
+#: src/olympia/amo/log.py:236 src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:17 src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:45
+#: src/olympia/editors/helpers.py:584 src/olympia/editors/templates/editors/themes/history_table.html:11
 msgid "Comment"
 msgstr ""
 
@@ -1899,7 +1900,7 @@ msgstr ""
 #: src/olympia/amo/templates/amo/mobile/paginator.html:14 src/olympia/amo/templates/amo/mobile/paginator.html:16 src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:51
 #: src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:65 src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:78
 #: src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:91 src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:104
-#: src/olympia/discovery/templates/discovery/pane.html:45 src/olympia/discovery/templates/discovery/addons/detail.html:39 src/olympia/stats/templates/stats/stats.html:167
+#: src/olympia/discovery/templates/discovery/pane.html:45 src/olympia/discovery/templates/discovery/addons/detail.html:39 src/olympia/stats/templates/stats/stats.html:169
 msgid "Next"
 msgstr ""
 
@@ -1931,7 +1932,7 @@ msgid ""
 msgstr ""
 
 #: src/olympia/amo/templates/amo/side_nav.html:4 src/olympia/amo/templates/amo/side_nav.html:12 src/olympia/amo/templates/amo/site_nav.html:4 src/olympia/amo/templates/amo/site_nav.html:26
-#: src/olympia/browse/views.py:56 src/olympia/browse/views.py:66 src/olympia/browse/views.py:237 src/olympia/browse/views.py:282 src/olympia/search/forms.py:86
+#: src/olympia/browse/views.py:56 src/olympia/browse/views.py:66 src/olympia/browse/views.py:204 src/olympia/browse/views.py:249 src/olympia/search/forms.py:86
 msgid "Top Rated"
 msgstr ""
 
@@ -1945,38 +1946,38 @@ msgstr ""
 msgid "Extensions"
 msgstr ""
 
-#: src/olympia/amo/templates/amo/site_nav.html:45
+#: src/olympia/amo/templates/amo/site_nav.html:44
 msgid "Want more customization? Try <b>Complete Themes</b>"
 msgstr ""
 
-#: src/olympia/amo/templates/amo/site_nav.html:56 src/olympia/bandwagon/views.py:96
+#: src/olympia/amo/templates/amo/site_nav.html:54 src/olympia/bandwagon/views.py:96
 msgid "Most Followers"
 msgstr ""
 
-#: src/olympia/amo/templates/amo/site_nav.html:68 src/olympia/bandwagon/templates/bandwagon/impala/collection_sidebar.html:16
+#: src/olympia/amo/templates/amo/site_nav.html:66 src/olympia/bandwagon/templates/bandwagon/impala/collection_sidebar.html:16
 #: src/olympia/bandwagon/templates/bandwagon/includes/collection_sidebar.html:18
 msgid "Collections I've Made"
 msgstr ""
 
-#: src/olympia/amo/templates/amo/site_nav.html:70 src/olympia/bandwagon/templates/bandwagon/user_listing.html:4 src/olympia/bandwagon/templates/bandwagon/impala/collection_sidebar.html:13
+#: src/olympia/amo/templates/amo/site_nav.html:68 src/olympia/bandwagon/templates/bandwagon/user_listing.html:4 src/olympia/bandwagon/templates/bandwagon/impala/collection_sidebar.html:13
 #: src/olympia/bandwagon/templates/bandwagon/includes/collection_sidebar.html:15
 msgid "Collections I'm Following"
 msgstr ""
 
-#: src/olympia/amo/templates/amo/site_nav.html:73 src/olympia/bandwagon/templates/bandwagon/impala/collection_sidebar.html:18
-#: src/olympia/bandwagon/templates/bandwagon/includes/collection_sidebar.html:20 src/olympia/users/models.py:512
+#: src/olympia/amo/templates/amo/site_nav.html:71 src/olympia/bandwagon/templates/bandwagon/impala/collection_sidebar.html:18
+#: src/olympia/bandwagon/templates/bandwagon/includes/collection_sidebar.html:20 src/olympia/users/models.py:521
 msgid "My Favorite Add-ons"
 msgstr ""
 
-#: src/olympia/amo/templates/amo/site_nav.html:78
+#: src/olympia/amo/templates/amo/site_nav.html:76
 msgid "More&hellip;"
 msgstr ""
 
-#: src/olympia/amo/templates/amo/site_nav.html:82
+#: src/olympia/amo/templates/amo/site_nav.html:80
 msgid "Add-ons for Mobile"
 msgstr ""
 
-#: src/olympia/amo/templates/amo/site_nav.html:86 src/olympia/browse/feeds.py:207 src/olympia/browse/templates/browse/search_tools.html:3 src/olympia/constants/base.py:176
+#: src/olympia/amo/templates/amo/site_nav.html:84 src/olympia/browse/feeds.py:207 src/olympia/browse/templates/browse/search_tools.html:3 src/olympia/constants/base.py:176
 #: src/olympia/templates/menu_links.html:10
 msgid "Search Tools"
 msgstr ""
@@ -1992,7 +1993,7 @@ msgid "Jump to first page"
 msgstr ""
 
 #: src/olympia/amo/templates/amo/impala/paginator.html:22 src/olympia/amo/templates/amo/mobile/impala_paginator.html:12 src/olympia/discovery/templates/discovery/pane.html:44
-#: src/olympia/discovery/templates/discovery/addons/detail.html:38 src/olympia/stats/templates/stats/stats.html:164
+#: src/olympia/discovery/templates/discovery/addons/detail.html:38 src/olympia/stats/templates/stats/stats.html:166
 msgid "Previous"
 msgstr ""
 
@@ -2015,30 +2016,49 @@ msgid_plural "Page {n}"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/olympia/amo/templates/services/install.html:38
-#, python-format
-msgid "If you are not prompted to install %(addon_name)s in a moment, please <a href=\"%(addon_xpi)s\">click here</a>."
-msgstr ""
-
-#: src/olympia/amo/tests/test_messages.py:57 src/olympia/amo/tests/test_messages.py:58 src/olympia/reviews/forms.py:25 src/olympia/reviews/forms.py:50 src/olympia/reviews/templates/reviews/add.html:56
+#: src/olympia/amo/tests/test_messages.py:56 src/olympia/amo/tests/test_messages.py:57 src/olympia/reviews/forms.py:25 src/olympia/reviews/forms.py:50 src/olympia/reviews/templates/reviews/add.html:56
 #: src/olympia/reviews/templates/reviews/reply.html:30
 msgid "Title"
 msgstr ""
 
-#: src/olympia/amo/tests/test_messages.py:57 src/olympia/amo/tests/test_messages.py:58
+#: src/olympia/amo/tests/test_messages.py:56 src/olympia/amo/tests/test_messages.py:57
 msgid "Body"
 msgstr ""
 
-#: src/olympia/amo/tests/test_messages.py:59
+#: src/olympia/amo/tests/test_messages.py:58
 msgid "Another Title"
 msgstr ""
 
-#: src/olympia/amo/tests/test_messages.py:59
+#: src/olympia/amo/tests/test_messages.py:58
 msgid "Another Body"
 msgstr ""
 
-#: src/olympia/api/views.py:255
-msgid "Not implemented yet."
+#: src/olympia/api/authentication.py:76
+msgid "Signature has expired."
+msgstr ""
+
+#: src/olympia/api/authentication.py:79
+msgid "Error decoding signature."
+msgstr ""
+
+#: src/olympia/api/authentication.py:82
+msgid "Invalid JWT Token."
+msgstr ""
+
+#: src/olympia/api/authentication.py:130
+msgid "Invalid Authorization header. No credentials provided."
+msgstr ""
+
+#: src/olympia/api/authentication.py:133
+msgid "Invalid Authorization header. Credentials string should not contain spaces."
+msgstr ""
+
+#: src/olympia/api/fields.py:29
+msgid "The field must have a length of at least {num} characters."
+msgstr ""
+
+#: src/olympia/api/fields.py:31
+msgid "The language code {lang_code} is invalid."
 msgstr ""
 
 #: src/olympia/applications/views.py:39 src/olympia/applications/templates/applications/appversions.html:3
@@ -2057,7 +2077,7 @@ msgstr ""
 msgid "Add-ons submitted to Mozilla Add-ons must have a manifest file with at least one of the below applications supported. Only the versions listed below are allowed for these applications."
 msgstr ""
 
-#: src/olympia/applications/templates/applications/appversions.html:25
+#: src/olympia/applications/templates/applications/appversions.html:25 src/olympia/editors/helpers.py:361
 msgid "GUID"
 msgstr ""
 
@@ -2171,8 +2191,8 @@ msgstr ""
 msgid "Remove from favorites"
 msgstr ""
 
-#: src/olympia/bandwagon/views.py:98 src/olympia/bandwagon/views.py:191 src/olympia/browse/views.py:58 src/olympia/browse/views.py:69 src/olympia/browse/views.py:458 src/olympia/devhub/views.py:74
-#: src/olympia/devhub/views.py:82 src/olympia/devhub/templates/devhub/addons/edit/basic.html:20 src/olympia/editors/templates/editors/leaderboard.html:24
+#: src/olympia/bandwagon/views.py:98 src/olympia/bandwagon/views.py:191 src/olympia/browse/views.py:58 src/olympia/browse/views.py:69 src/olympia/browse/views.py:425 src/olympia/devhub/views.py:72
+#: src/olympia/devhub/views.py:80 src/olympia/devhub/templates/devhub/addons/edit/basic.html:20 src/olympia/editors/templates/editors/leaderboard.html:24
 #: src/olympia/editors/templates/editors/themes/queue_list.html:48 src/olympia/search/forms.py:17 src/olympia/search/forms.py:89 src/olympia/users/templates/users/vcard.html:5
 msgid "Name"
 msgstr ""
@@ -2181,7 +2201,7 @@ msgstr ""
 msgid "Recently Popular"
 msgstr ""
 
-#: src/olympia/bandwagon/views.py:189 src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:18
+#: src/olympia/bandwagon/views.py:189 src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:16
 msgid "Added"
 msgstr ""
 
@@ -2195,7 +2215,7 @@ msgstr ""
 
 #: src/olympia/bandwagon/views.py:316
 #, python-format
-msgid "Your new collection is shown below. You can <ahref=\"%(url)s\">edit additional settings</a> if you'dlike."
+msgid "Your new collection is shown below. You can <a href=\"%(url)s\">edit additional settings</a> if you'd like."
 msgstr ""
 
 #: src/olympia/bandwagon/views.py:322
@@ -2323,8 +2343,8 @@ msgid_plural "%(num)s Add-ons in this Collection"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/olympia/bandwagon/templates/bandwagon/collection_detail.html:125 src/olympia/compat/templates/compat/index.html:25 src/olympia/compat/templates/compat/reporter_detail.html:29
-#: src/olympia/files/templates/files/viewer.html:29 src/olympia/templates/amo_footer.html:17 src/olympia/templates/includes/lang_switcher.html:10
+#: src/olympia/bandwagon/templates/bandwagon/collection_detail.html:125 src/olympia/compat/templates/compat/reporter_detail.html:29 src/olympia/files/templates/files/viewer.html:29
+#: src/olympia/templates/amo_footer.html:17 src/olympia/templates/includes/lang_switcher.html:10
 msgid "Go"
 msgstr ""
 
@@ -2491,7 +2511,7 @@ msgid "Remove this user as a contributor"
 msgstr ""
 
 #: src/olympia/bandwagon/templates/bandwagon/edit_contributors.html:18 src/olympia/bandwagon/templates/bandwagon/edit_contributors.html:43
-#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:20 src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:48
+#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:18 src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:46
 #: src/olympia/devhub/templates/devhub/addons/ajax_compat_update.html:19
 msgid "Remove"
 msgstr ""
@@ -2539,7 +2559,7 @@ msgid "<b>Warning:</b> By changing the owner of this collection, you will no lon
 msgstr ""
 
 #: src/olympia/bandwagon/templates/bandwagon/edit_contributors.html:83 src/olympia/devhub/templates/devhub/addons/forms_shared/media.html:157
-#: src/olympia/devhub/templates/devhub/addons/submit/describe.html:69 src/olympia/devhub/templates/devhub/addons/submit/license.html:60 src/olympia/devhub/templates/devhub/addons/submit/upload.html:78
+#: src/olympia/devhub/templates/devhub/addons/submit/describe.html:69 src/olympia/devhub/templates/devhub/addons/submit/license.html:60 src/olympia/devhub/templates/devhub/addons/submit/upload.html:70
 #: src/olympia/devhub/templates/devhub/payments/tier.html:17 src/olympia/editors/templates/editors/themes/themes.html:111 src/olympia/editors/templates/editors/themes/themes.html:128
 #: src/olympia/editors/templates/editors/themes/themes.html:134 src/olympia/editors/templates/editors/themes/themes.html:141 src/olympia/users/templates/users/fxa_migration_prompt_content.html:10
 #: src/olympia/users/templates/users/login_form.html:42 src/olympia/users/templates/users/mobile/login.html:57
@@ -2622,31 +2642,31 @@ msgid "Add-ons in Your Collection"
 msgstr ""
 
 #: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:4
-msgid ""
-"To include an add-on in this collection, enter its name in the box below and hit enter.  You can also use the <strong>Add to Collection</strong> links throughout the site to include add-ons later."
+msgid "To include an add-on in this collection, enter its name in the box below and hit enter."
 msgstr ""
 
-#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:17 src/olympia/constants/base.py:400 src/olympia/devhub/templates/devhub/addons/activity.html:62
+#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:15 src/olympia/constants/base.py:400 src/olympia/devhub/templates/devhub/addons/activity.html:62
+#: src/olympia/editors/helpers.py:273 src/olympia/editors/helpers.py:360
 msgid "Add-on"
 msgstr ""
 
-#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:26
+#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:24
 msgid "Enter the name of the add-on to include"
 msgstr ""
 
-#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:28
+#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:26
 msgid "Add to Collection"
 msgstr ""
 
-#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:45 src/olympia/editors/helpers.py:936 src/olympia/editors/helpers.py:956
+#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:43 src/olympia/editors/helpers.py:1016 src/olympia/editors/helpers.py:1036
 msgid "Pending"
 msgstr ""
 
-#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:47
+#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:45
 msgid "Add a comment"
 msgstr ""
 
-#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:48
+#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:46
 msgid "Remove this add-on from the collection"
 msgstr ""
 
@@ -2753,12 +2773,12 @@ msgstr ""
 msgid "Most Users"
 msgstr ""
 
-#: src/olympia/browse/views.py:61 src/olympia/browse/views.py:72 src/olympia/browse/views.py:279 src/olympia/browse/templates/browse/personas/mobile/category_landing.html:63
+#: src/olympia/browse/views.py:61 src/olympia/browse/views.py:72 src/olympia/browse/views.py:246 src/olympia/browse/templates/browse/personas/mobile/category_landing.html:63
 #: src/olympia/discovery/templates/discovery/pane.html:67 src/olympia/search/forms.py:92
 msgid "Up & Coming"
 msgstr ""
 
-#: src/olympia/browse/views.py:460 src/olympia/devhub/views.py:76 src/olympia/devhub/views.py:83 src/olympia/discovery/templates/discovery/addons/detail.html:66
+#: src/olympia/browse/views.py:427 src/olympia/devhub/views.py:74 src/olympia/devhub/views.py:81 src/olympia/discovery/templates/discovery/addons/detail.html:66
 msgid "Created"
 msgstr ""
 
@@ -2946,8 +2966,8 @@ msgid_plural "See all %(cnt)s extensions in %(name)s &raquo;"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/olympia/browse/templates/browse/mobile/extensions.html:13 src/olympia/compat/templates/compat/index.html:82 src/olympia/devhub/templates/devhub/devhub_search.html:24
-#: src/olympia/devhub/templates/devhub/addons/activity.html:47 src/olympia/search/templates/search/no_results.html:4 src/olympia/search/templates/search/mobile/results.html:36
+#: src/olympia/browse/templates/browse/mobile/extensions.html:13 src/olympia/devhub/templates/devhub/devhub_search.html:24 src/olympia/devhub/templates/devhub/addons/activity.html:47
+#: src/olympia/search/templates/search/no_results.html:4 src/olympia/search/templates/search/mobile/results.html:36
 msgid "No results found."
 msgstr ""
 
@@ -3032,7 +3052,7 @@ msgstr ""
 msgid "All"
 msgstr ""
 
-#: src/olympia/compat/forms.py:22 src/olympia/search/views.py:525
+#: src/olympia/compat/forms.py:22 src/olympia/editors/templates/editors/base.html:69 src/olympia/search/views.py:518
 msgid "All Add-ons"
 msgstr ""
 
@@ -3042,53 +3062,6 @@ msgstr ""
 
 #: src/olympia/compat/forms.py:24
 msgid "Non-binary"
-msgstr ""
-
-#. Review points sources other than add-ons and themes.
-#: src/olympia/compat/views.py:87 src/olympia/constants/base.py:388 src/olympia/devhub/forms.py:162 src/olympia/editors/templates/editors/performance.html:75
-msgid "Other"
-msgstr ""
-
-#: src/olympia/compat/templates/compat/index.html:4
-msgid "Add-on Compatibility Report for {app} {version}"
-msgstr ""
-
-#: src/olympia/compat/templates/compat/index.html:11
-msgid "{app} {version} Compatibility"
-msgstr ""
-
-#: src/olympia/compat/templates/compat/index.html:17
-#, python-format
-msgid "Top 95%% compatible with previous version"
-msgstr ""
-
-#: src/olympia/compat/templates/compat/index.html:18
-#, python-format
-msgid "Top 95%% of all add-ons"
-msgstr ""
-
-#: src/olympia/compat/templates/compat/index.html:19
-msgid "All active add-ons"
-msgstr ""
-
-#: src/olympia/compat/templates/compat/index.html:23 src/olympia/constants/base.py:401
-msgid "App"
-msgstr ""
-
-#: src/olympia/compat/templates/compat/index.html:55
-msgid "Details for add-ons compatible with previous version:"
-msgstr ""
-
-#: src/olympia/compat/templates/compat/index.html:57
-msgid "Show all versions"
-msgstr ""
-
-#: src/olympia/compat/templates/compat/index.html:59
-msgid "Details for add-ons compatible with all versions:"
-msgstr ""
-
-#: src/olympia/compat/templates/compat/index.html:61
-msgid "Show previous version only"
 msgstr ""
 
 #: src/olympia/compat/templates/compat/reporter.html:3
@@ -3142,8 +3115,8 @@ msgstr ""
 msgid "Report Type"
 msgstr ""
 
-#: src/olympia/compat/templates/compat/reporter_detail.html:47 src/olympia/devhub/forms.py:784 src/olympia/devhub/templates/devhub/addons/ajax_compat_update.html:17 src/olympia/editors/forms.py:108
-#: src/olympia/zadmin/forms.py:45
+#: src/olympia/compat/templates/compat/reporter_detail.html:47 src/olympia/devhub/forms.py:785 src/olympia/devhub/templates/devhub/addons/ajax_compat_update.html:17 src/olympia/editors/forms.py:108
+#: src/olympia/editors/forms.py:248 src/olympia/zadmin/forms.py:45
 msgid "Application"
 msgstr ""
 
@@ -3231,7 +3204,8 @@ msgstr ""
 msgid "Preliminarily Reviewed and Awaiting Full Review"
 msgstr ""
 
-#: src/olympia/constants/base.py:33 src/olympia/editors/helpers.py:924 src/olympia/editors/templates/editors/themes/history_table.html:34
+#: src/olympia/constants/base.py:33 src/olympia/editors/forms.py:258 src/olympia/editors/helpers.py:73 src/olympia/editors/helpers.py:1004
+#: src/olympia/editors/templates/editors/themes/history_table.html:34
 msgid "Deleted"
 msgstr ""
 
@@ -3328,6 +3302,11 @@ msgstr ""
 msgid "Ask before users can download this add-on"
 msgstr ""
 
+#. Review points sources other than add-ons and themes.
+#: src/olympia/constants/base.py:388 src/olympia/devhub/forms.py:162 src/olympia/editors/templates/editors/performance.html:75
+msgid "Other"
+msgstr ""
+
 #: src/olympia/constants/base.py:389
 msgid "Exception"
 msgstr ""
@@ -3338,6 +3317,10 @@ msgstr ""
 
 #: src/olympia/constants/base.py:391
 msgid "Change"
+msgstr ""
+
+#: src/olympia/constants/base.py:401
+msgid "App"
 msgstr ""
 
 #: src/olympia/constants/base.py:402
@@ -3488,7 +3471,7 @@ msgstr ""
 msgid "Duplicate"
 msgstr ""
 
-#: src/olympia/constants/editors.py:17 src/olympia/editors/helpers.py:502 src/olympia/editors/templates/editors/themes/queue.html:71 src/olympia/editors/templates/editors/themes/themes.html:94
+#: src/olympia/constants/editors.py:17 src/olympia/editors/helpers.py:575 src/olympia/editors/templates/editors/themes/queue.html:71 src/olympia/editors/templates/editors/themes/themes.html:94
 msgid "Reject"
 msgstr ""
 
@@ -3588,7 +3571,7 @@ msgstr ""
 msgid "Android"
 msgstr ""
 
-#: src/olympia/core/apps.py:19
+#: src/olympia/core/apps.py:21
 msgid "Core"
 msgstr ""
 
@@ -3722,7 +3705,7 @@ msgid "Submit my add-on for manual review."
 msgstr ""
 
 #: src/olympia/devhub/forms.py:537
-msgid "Do not list my add-on on this site (beta)"
+msgid "Do not list my add-on on this site"
 msgstr ""
 
 #: src/olympia/devhub/forms.py:538
@@ -3755,46 +3738,46 @@ msgstr ""
 
 #: src/olympia/devhub/forms.py:592
 #, python-format
-msgid "Version %s already exists"
+msgid "Version %s already exists, or was uploaded before."
 msgstr ""
 
-#: src/olympia/devhub/forms.py:604
+#: src/olympia/devhub/forms.py:605
 msgid "Select a valid choice. That choice is not one of the available choices."
 msgstr ""
 
-#: src/olympia/devhub/forms.py:610
+#: src/olympia/devhub/forms.py:611
 msgid "A file with a version ending with a|alpha|b|beta and an optional number is detected as beta."
 msgstr ""
 
-#: src/olympia/devhub/forms.py:633
+#: src/olympia/devhub/forms.py:634
 msgid "You cannot upload any more files for this version."
 msgstr ""
 
-#: src/olympia/devhub/forms.py:639
+#: src/olympia/devhub/forms.py:640
 msgid "Version doesn't match"
 msgstr ""
 
-#: src/olympia/devhub/forms.py:668
+#: src/olympia/devhub/forms.py:669
 msgid "You cannot delete a file once the review process has started.  You must delete the whole version."
 msgstr ""
 
-#: src/olympia/devhub/forms.py:688
+#: src/olympia/devhub/forms.py:689
 msgid "The platform All cannot be combined with specific platforms."
 msgstr ""
 
-#: src/olympia/devhub/forms.py:693
+#: src/olympia/devhub/forms.py:694
 msgid "A platform can only be chosen once."
 msgstr ""
 
-#: src/olympia/devhub/forms.py:706
+#: src/olympia/devhub/forms.py:707
 msgid "A review type must be selected."
 msgstr ""
 
-#: src/olympia/devhub/forms.py:788 src/olympia/editors/forms.py:114 src/olympia/zadmin/forms.py:49 src/olympia/zadmin/forms.py:52
+#: src/olympia/devhub/forms.py:789 src/olympia/editors/forms.py:114 src/olympia/editors/forms.py:254 src/olympia/zadmin/forms.py:49 src/olympia/zadmin/forms.py:52
 msgid "Select an application first"
 msgstr ""
 
-#: src/olympia/devhub/forms.py:840
+#: src/olympia/devhub/forms.py:841
 msgid "There cannot be more than 3 required add-ons."
 msgstr ""
 
@@ -3828,76 +3811,76 @@ msgstr[1] ""
 msgid "Review"
 msgstr ""
 
-#: src/olympia/devhub/tasks.py:551
+#: src/olympia/devhub/tasks.py:583
 #, python-format
 msgid "%s responded with %s (%s)."
 msgstr ""
 
-#: src/olympia/devhub/tasks.py:555
+#: src/olympia/devhub/tasks.py:587
 #, python-format
 msgid "Connection to \"%s\" timed out."
 msgstr ""
 
-#: src/olympia/devhub/tasks.py:557
+#: src/olympia/devhub/tasks.py:589
 #, python-format
 msgid "Could not contact host at \"%s\"."
 msgstr ""
 
-#: src/olympia/devhub/utils.py:104
+#: src/olympia/devhub/utils.py:105
 #, python-format
 msgid "Validation generated too many errors/warnings so %s messages were truncated. After addressing the visible messages, you'll be able to see the others."
 msgstr ""
 
-#: src/olympia/devhub/views.py:183
+#: src/olympia/devhub/views.py:181
 msgid "All My Add-ons"
 msgstr ""
 
-#: src/olympia/devhub/views.py:210
+#: src/olympia/devhub/views.py:208
 msgid "All Activity"
 msgstr ""
 
-#: src/olympia/devhub/views.py:211
+#: src/olympia/devhub/views.py:209
 msgid "Add-on Updates"
 msgstr ""
 
-#: src/olympia/devhub/views.py:212
+#: src/olympia/devhub/views.py:210
 msgid "Add-on Status"
 msgstr ""
 
-#: src/olympia/devhub/views.py:213
+#: src/olympia/devhub/views.py:211
 msgid "User Collections"
 msgstr ""
 
-#: src/olympia/devhub/views.py:214 src/olympia/devhub/templates/devhub/docs/policies-maintenance.html:68 src/olympia/pages/templates/pages/dev_faq.html:38
+#: src/olympia/devhub/views.py:212 src/olympia/devhub/templates/devhub/docs/policies-maintenance.html:68 src/olympia/pages/templates/pages/dev_faq.html:38
 #: src/olympia/pages/templates/pages/dev_faq.html:484
 msgid "User Reviews"
 msgstr ""
 
-#: src/olympia/devhub/views.py:327 src/olympia/devhub/views.py:331 src/olympia/devhub/views.py:484 src/olympia/devhub/views.py:513 src/olympia/devhub/views.py:564 src/olympia/devhub/views.py:1150
+#: src/olympia/devhub/views.py:325 src/olympia/devhub/views.py:329 src/olympia/devhub/views.py:484 src/olympia/devhub/views.py:513 src/olympia/devhub/views.py:564 src/olympia/devhub/views.py:1156
 msgid "Changes successfully saved."
 msgstr ""
 
-#: src/olympia/devhub/views.py:334 src/olympia/devhub/views.py:1631
+#: src/olympia/devhub/views.py:332 src/olympia/devhub/views.py:1637
 msgid "Please check the form for errors."
 msgstr ""
 
-#: src/olympia/devhub/views.py:346
+#: src/olympia/devhub/views.py:344
 msgid "Add-on cannot be deleted. Disable this add-on instead."
 msgstr ""
 
-#: src/olympia/devhub/views.py:356
+#: src/olympia/devhub/views.py:354
 msgid "Theme deleted."
 msgstr ""
 
-#: src/olympia/devhub/views.py:356
+#: src/olympia/devhub/views.py:354
 msgid "Add-on deleted."
 msgstr ""
 
-#: src/olympia/devhub/views.py:362
+#: src/olympia/devhub/views.py:360
 msgid "URL name was incorrect. Theme was not deleted."
 msgstr ""
 
-#: src/olympia/devhub/views.py:367
+#: src/olympia/devhub/views.py:365
 msgid "URL name was incorrect. Add-on was not deleted."
 msgstr ""
 
@@ -3925,7 +3908,7 @@ msgstr ""
 msgid "Check Add-on Compatibility"
 msgstr ""
 
-#: src/olympia/devhub/views.py:808 src/olympia/signing/views.py:90
+#: src/olympia/devhub/views.py:808 src/olympia/signing/views.py:95
 msgid "You cannot submit this type of add-on"
 msgstr ""
 
@@ -3955,33 +3938,33 @@ msgstr ""
 msgid "There was an error uploading your preview."
 msgstr ""
 
-#: src/olympia/devhub/views.py:1189
+#: src/olympia/devhub/views.py:1195
 #, python-format
 msgid "Version %s disabled."
 msgstr ""
 
-#: src/olympia/devhub/views.py:1193
+#: src/olympia/devhub/views.py:1199
 #, python-format
 msgid "Version %s deleted."
 msgstr ""
 
-#: src/olympia/devhub/views.py:1203
+#: src/olympia/devhub/views.py:1209
 msgid "This upload has failed validation, and may lack complete validation results. Please take due care when reviewing it."
 msgstr ""
 
-#: src/olympia/devhub/views.py:1677
+#: src/olympia/devhub/views.py:1683
 msgid "Preliminary Review Requested."
 msgstr ""
 
-#: src/olympia/devhub/views.py:1678
+#: src/olympia/devhub/views.py:1684
 msgid "Full Review Requested."
 msgstr ""
 
-#: src/olympia/devhub/views.py:1779
+#: src/olympia/devhub/views.py:1783
 msgid "Your old credentials were revoked and are no longer valid. Be sure to update all API clients with the new credentials."
 msgstr ""
 
-#: src/olympia/devhub/views.py:1797
+#: src/olympia/devhub/views.py:1801
 msgid "New API key created"
 msgstr ""
 
@@ -4011,7 +3994,7 @@ msgstr ""
 msgid "{0} :: Search"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/devhub_search.html:6 src/olympia/devhub/templates/devhub/search.html:8 src/olympia/editors/forms.py:435 src/olympia/editors/forms.py:437
+#: src/olympia/devhub/templates/devhub/devhub_search.html:6 src/olympia/devhub/templates/devhub/search.html:8 src/olympia/editors/forms.py:534 src/olympia/editors/forms.py:536
 #: src/olympia/editors/templates/editors/queue.html:27 src/olympia/editors/templates/editors/themes/queue_list.html:14 src/olympia/search/templates/search/collections.html:17
 #: src/olympia/search/templates/search/personas.html:18 src/olympia/search/templates/search/results.html:18 src/olympia/search/templates/search/mobile/results.html:8
 #: src/olympia/templates/search.html:14 src/olympia/templates/impala/search.html:18
@@ -4071,12 +4054,12 @@ msgstr ""
 msgid "Start Making Add-ons"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/index.html:86 src/olympia/devhub/templates/devhub/addons/listing/items.html:25 src/olympia/devhub/templates/devhub/includes/addon_details.html:15
+#: src/olympia/devhub/templates/devhub/index.html:86 src/olympia/devhub/templates/devhub/addons/listing/items.html:25 src/olympia/devhub/templates/devhub/includes/addon_details.html:20
 #: src/olympia/devhub/templates/devhub/personas/edit.html:43
 msgid "Status:"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/index.html:90 src/olympia/devhub/templates/devhub/includes/addon_details.html:100
+#: src/olympia/devhub/templates/devhub/index.html:90 src/olympia/devhub/templates/devhub/includes/addon_details.html:87
 msgid "Visibility:"
 msgstr ""
 
@@ -4084,11 +4067,11 @@ msgstr ""
 msgid "Latest Version:"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/index.html:109 src/olympia/devhub/templates/devhub/includes/addon_details.html:145 src/olympia/devhub/templates/devhub/personas/edit.html:49
+#: src/olympia/devhub/templates/devhub/index.html:109 src/olympia/devhub/templates/devhub/includes/addon_details.html:131 src/olympia/devhub/templates/devhub/personas/edit.html:49
 msgid "Queue Position:"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/index.html:110 src/olympia/devhub/templates/devhub/includes/addon_details.html:146 src/olympia/devhub/templates/devhub/personas/edit.html:50
+#: src/olympia/devhub/templates/devhub/index.html:110 src/olympia/devhub/templates/devhub/includes/addon_details.html:132 src/olympia/devhub/templates/devhub/personas/edit.html:50
 #, python-format
 msgid "%(position)s of %(total)s"
 msgstr ""
@@ -4190,16 +4173,6 @@ msgstr ""
 msgid "Do you want your add-on to be distributed on this site?"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/validate_addon.html:49 src/olympia/devhub/templates/devhub/addons/submit/upload.html:30 src/olympia/devhub/templates/devhub/versions/add_file_modal.html:14
-#: src/olympia/devhub/templates/devhub/versions/add_file_modal.html:53 src/olympia/devhub/templates/devhub/versions/list.html:298
-msgid "Warning:"
-msgstr ""
-
-#: src/olympia/devhub/templates/devhub/validate_addon.html:50 src/olympia/devhub/templates/devhub/addons/submit/upload.html:31
-#, python-format
-msgid "Submission of unlisted add-ons for signing is currently in an open beta. Please <a href=\"%(url)s\" target=\"_blank\">report any bugs</a> that you encounter."
-msgstr ""
-
 #. first parameter is a filename like lorem-ipsum-1.0.2.xpi
 #: src/olympia/devhub/templates/devhub/validation.html:5
 msgid "Validation Results for {0}"
@@ -4274,7 +4247,7 @@ msgstr ""
 msgid "Update Compatibility"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/addons/ajax_compat_update.html:4
+#: src/olympia/devhub/templates/devhub/addons/ajax_compat_update.html:4 src/olympia/devhub/templates/devhub/versions/edit.html:45
 msgid "Adjusting application information here will allow users to install your add-on even if the install manifest in the package indicates that the add-on is incompatible."
 msgstr ""
 
@@ -4286,9 +4259,9 @@ msgstr ""
 msgid "Add Another Application&hellip;"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/addons/ajax_compat_update.html:38 src/olympia/devhub/templates/devhub/addons/owner.html:86 src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:46
-#: src/olympia/devhub/templates/devhub/versions/list.html:351 src/olympia/devhub/templates/devhub/versions/list.html:353 src/olympia/templates/impala/base.html:132
-#: src/olympia/templates/impala/base.html:143 src/olympia/templates/impala/base.html:161 src/olympia/templates/impala/base.html:171
+#: src/olympia/devhub/templates/devhub/addons/ajax_compat_update.html:38 src/olympia/devhub/templates/devhub/addons/owner.html:86 src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:45
+#: src/olympia/devhub/templates/devhub/versions/list.html:349 src/olympia/devhub/templates/devhub/versions/list.html:351 src/olympia/templates/impala/base.html:129
+#: src/olympia/templates/impala/base.html:140 src/olympia/templates/impala/base.html:158 src/olympia/templates/impala/base.html:168
 msgid "Close"
 msgstr ""
 
@@ -4322,7 +4295,7 @@ msgstr ""
 msgid "Manage Authors & License"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/addons/owner.html:29 src/olympia/editors/templates/editors/review.html:270
+#: src/olympia/devhub/templates/devhub/addons/owner.html:29 src/olympia/editors/helpers.py:362 src/olympia/editors/templates/editors/review.html:270
 msgid "Authors"
 msgstr ""
 
@@ -4391,17 +4364,11 @@ msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/basic.html:52
 msgid ""
-"A short explanation of your add-on's basic\n"
-"                          functionality that is displayed in search and browse\n"
-"                          listings, as well as at the top of your add-on's\n"
-"                          details page. It is only relevant for listed add-ons."
+"A short explanation of your add-on's basic functionality that is displayed in search and browse listings, as well as at the top of your add-on's details page. It is only relevant for listed add-ons."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/basic.html:73
-msgid ""
-"Categories are the primary way users browse through add-ons.\n"
-"                        Choose any that fit your add-on's functionality for the most\n"
-"                        exposure. It is only relevant for listed add-ons."
+msgid "Categories are the primary way users browse through add-ons. Choose any that fit your add-on's functionality for the most exposure. It is only relevant for listed add-ons."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/basic.html:90
@@ -4411,11 +4378,7 @@ msgid ""
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/basic.html:119
-msgid ""
-"Tags help users find your add-on and should be short\n"
-"                        descriptors such as tabs, toolbar, or twitter.  You\n"
-"                        may have a maximum of {0} tags. It is only relevant\n"
-"                        for listed add-ons."
+msgid "Tags help users find your add-on and should be short descriptors such as tabs, toolbar, or twitter. You may have a maximum of {0} tags. It is only relevant for listed add-ons."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/basic.html:129 src/olympia/devhub/templates/devhub/personas/edit.html:97 src/olympia/devhub/templates/devhub/personas/submit.html:46
@@ -4443,11 +4406,7 @@ msgid "Add-on Details for {0}"
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/details.html:22
-msgid ""
-"A longer explanation of features,\n"
-"                          functionality, and other relevant information. This\n"
-"                          field is only displayed on the add-on's details\n"
-"                          page. It is only relevant for listed add-ons."
+msgid "A longer explanation of features, functionality, and other relevant information. This field is only displayed on the add-on's details page. It is only relevant for listed add-ons."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/details.html:44 src/olympia/translations/templates/translations/trans-menu.html:13
@@ -4455,10 +4414,7 @@ msgid "Default Locale"
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/details.html:45
-msgid ""
-"Information about your add-on is displayed in this locale\n"
-"                        unless you override it with a locale-specific translation.\n"
-"                        It is only relevant for listed add-ons."
+msgid "Information about your add-on is displayed in this locale unless you override it with a locale-specific translation. It is only relevant for listed add-ons."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/details.html:61 src/olympia/users/forms.py:311 src/olympia/users/templates/users/edit.html:122 src/olympia/users/templates/users/register.html:57
@@ -4468,10 +4424,8 @@ msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/details.html:63
 msgid ""
-"If your add-on has another homepage, enter its\n"
-"                          address here. If your website is localized into other\n"
-"                          languages multiple translations of this field can be\n"
-"                          added. It is only relevant for listed add-ons."
+"If your add-on has another homepage, enter its address here. If your website is localized into other languages multiple translations of this field can be added. It is only relevant for listed add-"
+"ons."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/media.html:3
@@ -4489,19 +4443,14 @@ msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/support.html:22
 msgid ""
-"If you wish to display an e-mail address for support\n"
-"                          inquiries, enter it here. If you have different\n"
-"                          addresses for each language multiple translations of\n"
-"                          this field can be added. It is only relevant for\n"
-"                          listed add-ons."
+"If you wish to display an e-mail address for support inquiries, enter it here. If you have different addresses for each language multiple translations of this field can be added. It is only "
+"relevant for listed add-ons."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/support.html:45
 msgid ""
-"If your add-on has a support website or forum, enter\n"
-"                          its address here. If your website is localized into\n"
-"                          other languages, multiple translations of this field can\n"
-"                          be added. It is only relevant for listed add-ons."
+"If your add-on has a support website or forum, enter its address here. If your website is localized into other languages, multiple translations of this field can be added. It is only relevant for "
+"listed add-ons."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:6
@@ -4515,11 +4464,8 @@ msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:23
 msgid ""
-"Any information end users may want to know that isn't\n"
-"                          necessarily applicable to the add-on summary or description.\n"
-"                          Common uses include listing known major bugs, information on\n"
-"                          how to report bugs, anticipated release date of a new version,\n"
-"                          etc. It is only relevant for listed add-ons."
+"Any information end users may want to know that isn't necessarily applicable to the add-on summary or description. Common uses include listing known major bugs, information on how to report bugs, "
+"anticipated release date of a new version, etc. It is only relevant for listed add-ons."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:46
@@ -4531,9 +4477,7 @@ msgid "Add-on Flags"
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:69
-msgid ""
-"These flags are used to classify add-ons. It is only\n"
-"                        relevant for listed add-ons."
+msgid "These flags are used to classify add-ons. It is only relevant for listed add-ons."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:74
@@ -4549,9 +4493,7 @@ msgid "View Source?"
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:90
-msgid ""
-"Whether the source of your add-on can be displayed in our\n"
-"                        online viewer. It is only relevant for listed add-ons."
+msgid "Whether the source of your add-on can be displayed in our online viewer. It is only relevant for listed add-ons."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:94
@@ -4567,10 +4509,7 @@ msgid "Public Stats?"
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:102
-msgid ""
-"Whether the download and usage stats of your add-on can\n"
-"                        be displayed in our online viewer.\n"
-"                        It is only relevant for listed add-ons."
+msgid "Whether the download and usage stats of your add-on can be displayed in our online viewer. It is only relevant for listed add-ons."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:107
@@ -4586,10 +4525,7 @@ msgid "Upgrade SDK?"
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:116
-msgid ""
-"If selected, we will try to automatically upgrade your\n"
-"                        add-on when a new version of the SDK is released.\n"
-"                        It is only relevant for listed add-ons."
+msgid "If selected, we will try to automatically upgrade your add-on when a new version of the SDK is released. It is only relevant for listed add-ons."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:121
@@ -4640,10 +4576,8 @@ msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/forms_shared/media.html:16
 msgid ""
-"Upload an icon for your add-on or choose from one of ours. The\n"
-"                      icon is displayed nearly everywhere your add-on is. Uploaded images\n"
-"                      must be one of the following image types: .png, .jpg.\n"
-"                      It is only relevant for listed add-ons."
+"Upload an icon for your add-on or choose from one of ours. The icon is displayed nearly everywhere your add-on is. Uploaded images must be one of the following image types: .png, .jpg. It is only "
+"relevant for listed add-ons."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/forms_shared/media.html:25
@@ -4656,9 +4590,7 @@ msgid "32x32px"
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/forms_shared/media.html:39
-msgid ""
-"Used in listings of add-ons, like search results\n"
-"                            and featured add-ons."
+msgid "Used in listings of add-ons, like search results and featured add-ons."
 msgstr ""
 
 #. The size of the icon
@@ -4753,16 +4685,14 @@ msgid "Deleting your add-on will permanently remove it from the site and prevent
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:24
-msgid ""
-"Enter the following text confirm your decision:\n"
-"           {slug}"
+msgid "Enter the following text confirm your decision: {slug}"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:34
+#: src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:33
 msgid "Please tell us why you are deleting your theme:"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:36
+#: src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:35
 msgid "Please tell us why you are deleting your add-on:"
 msgstr ""
 
@@ -4799,8 +4729,8 @@ msgstr ""
 msgid "Daily statistics on downloads and users."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/addons/listing/item_actions.html:45 src/olympia/stats/templates/stats/stats.html:75 src/olympia/stats/templates/stats/stats.html:79
-#: src/olympia/stats/templates/stats/stats.html:81
+#: src/olympia/devhub/templates/devhub/addons/listing/item_actions.html:45 src/olympia/stats/templates/stats/stats.html:31 src/olympia/stats/templates/stats/stats.html:35
+#: src/olympia/stats/templates/stats/stats.html:37
 msgid "Statistics"
 msgstr ""
 
@@ -4919,10 +4849,7 @@ msgid "Your add-on has been submitted to the Full Review queue."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/submit/done.html:18
-msgid ""
-"You'll receive an email once it has been reviewed by an editor. In\n"
-"          the meantime, you and your friends can install it directly from its\n"
-"          details page:"
+msgid "You'll receive an email once it has been reviewed by an editor. In the meantime, you and your friends can install it directly from its details page:"
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/submit/done.html:27 src/olympia/devhub/templates/devhub/addons/submit/done.html:77 src/olympia/devhub/templates/devhub/personas/submit_done.html:16
@@ -5128,11 +5055,11 @@ msgstr ""
 msgid "Use the fields below to upload your add-on package and select any platform restrictions. After upload, a series of automated validation tests will be run on your file."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/addons/submit/upload.html:59 src/olympia/devhub/templates/devhub/versions/add_file_modal.html:39
+#: src/olympia/devhub/templates/devhub/addons/submit/upload.html:51 src/olympia/devhub/templates/devhub/versions/add_file_modal.html:28
 msgid "Which platforms is this file compatible with?"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/addons/submit/upload.html:67 src/olympia/devhub/templates/devhub/versions/add_file_modal.html:65
+#: src/olympia/devhub/templates/devhub/addons/submit/upload.html:59 src/olympia/devhub/templates/devhub/versions/add_file_modal.html:45
 msgid "Administrative overrides"
 msgstr ""
 
@@ -5242,8 +5169,8 @@ msgstr ""
 
 #: src/olympia/devhub/templates/devhub/docs/policies-contact.html:44
 msgid ""
-"If you've found a problem with the site, we'd love to fix it. Please <a href=\"https://github.com/mozilla/olympia/issues\">file a bug report</a> in GitHub, including the location of the problem and "
-"how you encountered it."
+"If you've found a problem with the site, we'd love to fix it. Please <a href=\"https://github.com/mozilla/addons/issues/new\">file a bug report</a> in GitHub, including the location of the problem "
+"and how you encountered it."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/docs/policies-maintenance.html:3 src/olympia/devhub/templates/devhub/docs/policies-maintenance.html:7
@@ -5810,7 +5737,7 @@ msgstr ""
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:282
 msgid ""
-"Add-ons that store or otherwise handle browsing data must support <a href=\"https://developer.mozilla.org/En/Supporting_private_browsing_mode\">Private Browsing Mode</a>.  During a Private Browsing "
+"Add-ons that store or otherwise handle browsing data must support <a href=\"https://developer.mozilla.org/En/Supporting_private_browsing_mode\">Private Browsing Mode</a>. During a Private Browsing "
 "session, no browsing data can be written to disk, and all of this data must be cleared when Firefox quits or the Private Browsing session ends."
 msgstr ""
 
@@ -5975,129 +5902,95 @@ msgstr ""
 msgid "How to get in touch with us regarding these policies or your add-on."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:6
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:10
 msgid "You have disabled this add-on"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:20
-msgid ""
-"Your add-on's listing is disabled and is not showing\n"
-"                             anywhere in our gallery or update service."
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:24
+msgid "Your add-on's listing is disabled and is not showing anywhere in our gallery or update service."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:25
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:27
 msgid "Please complete your add-on."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:29
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:30
 msgid "You will receive an email when the review is complete."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:34
-msgid ""
-"You will receive an email when the review is complete. Until\n"
-"                             then, your add-on is not listed in our gallery but can be\n"
-"                             accessed directly from its details page."
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:33
+msgid "You will receive an email when the review is complete. Until then, your add-on is not listed in our gallery but can be accessed directly from its details page."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:38 src/olympia/devhub/templates/devhub/includes/addon_details.html:48
-msgid ""
-"You will receive an email when the review is\n"
-"                             complete and your add-on is signed."
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:37 src/olympia/devhub/templates/devhub/includes/addon_details.html:45
+msgid "You will receive an email when the review is complete and your add-on is signed."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:44
-msgid ""
-"You will receive an email when the review is complete. Until\n"
-"                             then, your add-on is not listed in our gallery but can be\n"
-"                             accessed directly from its details page. "
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:41
+msgid "You will receive an email when the review is complete. Until then, your add-on is not listed in our gallery but can be accessed directly from its details page. "
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:54
-msgid ""
-"Your add-on is displayed in our gallery and users are\n"
-"                             receiving automatic updates."
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:49
+msgid "Your add-on is displayed in our gallery and users are receiving automatic updates."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:57
-msgid ""
-"Your add-on has been signed and can be bundled with an\n"
-"                             application installer."
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:52
+msgid "Your add-on has been signed and can be bundled with an application installer."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:63
-msgid ""
-"Your add-on was disabled by a site administrator and is no\n"
-"                             longer shown in our gallery. If you have any questions,\n"
-"                             please email amo-admins@mozilla.org."
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:56
+msgid "Your add-on was disabled by a site administrator and is no longer shown in our gallery. If you have any questions, please email amo-admins@mozilla.org."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:70
-msgid ""
-"Your add-on is displayed in our gallery as experimental\n"
-"                             and users are receiving automatic updates. Some features\n"
-"                             are unavailable to your add-on."
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:62
+msgid "Your add-on is displayed in our gallery as experimental and users are receiving automatic updates. Some features are unavailable to your add-on."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:74
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:66
 msgid "Your add-on has been signed."
 msgstr ""
 
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:69
+msgid ""
+"You will receive an email when the full review is complete. Until then, your add-on is displayed in our gallery as experimental and users are receiving automatic updates. Some features are "
+"unavailable to your add-on."
+msgstr ""
+
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:74
+msgid "You will receive an email when the full review is complete, making you able to bundle your add-on with an application installer."
+msgstr ""
+
 #: src/olympia/devhub/templates/devhub/includes/addon_details.html:79
-msgid ""
-"You will receive an email when the full review is complete.\n"
-"                             Until then, your add-on is displayed in our gallery as\n"
-"                             experimental and users are receiving automatic updates.\n"
-"                             Some features are unavailable to your add-on."
+msgid "All add-ons hosted in our gallery must now be reviewed by an editor. If you wish to continue hosting your add-on, please click to select a review process."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:84
-msgid ""
-"You will receive an email when the full review is\n"
-"                             complete, making you able to bundle your add-on with an\n"
-"                             application installer."
-msgstr ""
-
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:91
-msgid ""
-"All add-ons hosted in our gallery must now be reviewed by an\n"
-"                             editor. If you wish to continue hosting your add-on, please\n"
-"                             click to select a review process."
-msgstr ""
-
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:113
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:100
 msgid "Current Version:"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:115
-msgid ""
-"This is the version of your add-on that will\n"
-"                                           be installed if someone clicks the Install\n"
-"                                           button on addons.mozilla.org. It is only\n"
-"                                           relevant for listed add-ons."
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:102
+msgid "This is the version of your add-on that will be installed if someone clicks the Install button on addons.mozilla.org. It is only relevant for listed add-ons."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:123
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:110
 msgid "Created:"
 msgstr ""
 
 #. {0} is a date. dennis-ignore: E201
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:125 src/olympia/devhub/templates/devhub/includes/addon_details.html:131
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:112 src/olympia/devhub/templates/devhub/includes/addon_details.html:118
 #, python-format
 msgid "%%b %%e, %%Y"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:136
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:123
 msgid "Next Version:"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:138
-msgid ""
-"This is the newest uploaded version, however\n"
-"                                           it isn’t live on the site yet."
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:125
+msgid "This is the newest uploaded version, however it isn’t live on the site yet."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:144 src/olympia/devhub/templates/devhub/versions/list.html:30
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:130 src/olympia/devhub/templates/devhub/versions/list.html:30
 msgid "Queues are not reviewed strictly in order"
 msgstr ""
 
@@ -6165,9 +6058,7 @@ msgid "View the blog &#9658;"
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/includes/license_form.html:6
-msgid ""
-"Please choose a license appropriate for the rights you grant on your source code.\n"
-"                  It is only relevant for listed add-ons."
+msgid "Please choose a license appropriate for the rights you grant on your source code. It is only relevant for listed add-ons."
 msgstr ""
 
 #. {0} is a list of HTML tags.
@@ -6194,14 +6085,11 @@ msgstr[1] ""
 #: src/olympia/devhub/templates/devhub/includes/policy_form.html:4
 msgid ""
 "Users will be required to accept the following End-User License Agreement (EULA) prior to installing your add-on. The presence of a EULA significantly affects the number of downloads an add-on "
-"receives. Please note that a EULA is not the same as a code license, such as the GPL or MPL.\n"
-"                It is only relevant for listed add-ons."
+"receives. Please note that a EULA is not the same as a code license, such as the GPL or MPL.It is only relevant for listed add-ons."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/policy_form.html:21
-msgid ""
-"If your add-on transmits any data from the user's computer, a privacy policy is required that explains what data is sent and how it is used.\n"
-"                It is only relevant for listed add-ons."
+#: src/olympia/devhub/templates/devhub/includes/policy_form.html:24
+msgid "If your add-on transmits any data from the user's computer, a privacy policy is required that explains what data is sent and how it is used. It is only relevant for listed add-ons."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/includes/source_form_field.html:2
@@ -6369,12 +6257,8 @@ msgstr ""
 msgid "Add some tags to describe your Theme."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/personas/edit.html:106
-msgid ""
-"A short explanation of your theme's\n"
-"                                basic functionality that is displayed in\n"
-"                                search and browse listings, as well as at\n"
-"                                the top of your theme's details page."
+#: src/olympia/devhub/templates/devhub/personas/edit.html:106 src/olympia/devhub/templates/devhub/personas/submit.html:54
+msgid "A short explanation of your theme's basic functionality that is displayed in search and browse listings, as well as at the top of your theme's details page."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/personas/edit.html:122 src/olympia/devhub/templates/devhub/personas/submit.html:68
@@ -6444,7 +6328,7 @@ msgid "Upon upload and form submission, the AMO Team will review your updated de
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/personas/edit.html:241
-msgid "Your previously resubmitted design,  which is under pending review."
+msgid "Your previously resubmitted design, which is under pending review."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/personas/edit.html:245
@@ -6511,14 +6395,6 @@ msgstr ""
 
 #: src/olympia/devhub/templates/devhub/personas/submit.html:33
 msgid "Give your Theme a name."
-msgstr ""
-
-#: src/olympia/devhub/templates/devhub/personas/submit.html:54
-msgid ""
-"A short explanation of your theme's\n"
-"                                      basic functionality that is displayed in\n"
-"                                      search and browse listings, as well as at\n"
-"                                      the top of your theme's details page."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/personas/submit.html:198
@@ -6595,30 +6471,16 @@ msgstr ""
 msgid "Files added to reviewed versions must be reviewed before they will be available for download."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/add_file_modal.html:15
-#, python-format
-msgid ""
-"Submission of updates to unlisted add-ons for signing is currently in an open beta. Manual review may still be required for a large number of add-ons. Please <a href=\"%(url)s\" target=\"_blank"
-"\">report any bugs</a> that you encounter."
-msgstr ""
-
-#: src/olympia/devhub/templates/devhub/versions/add_file_modal.html:35
+#: src/olympia/devhub/templates/devhub/versions/add_file_modal.html:24
 msgid "Select the target platform for this file."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/add_file_modal.html:46
+#: src/olympia/devhub/templates/devhub/versions/add_file_modal.html:35
 msgid "Which review type would you like to nominate for?"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/add_file_modal.html:51
+#: src/olympia/devhub/templates/devhub/versions/add_file_modal.html:40
 msgid "Only publish this version to my beta channel."
-msgstr ""
-
-#: src/olympia/devhub/templates/devhub/versions/add_file_modal.html:54
-#, python-format
-msgid ""
-"The behavior of the beta channel has changed to accommodate <a href=\"%(addon_signing_url)s\" target=\"_blank\">mandatory add-on signing</a>. The new process is currently in an open beta, and may "
-"change significantly in the near future. Please <a href=\"%(issues_url)s\" target=\"_blank\">report any bugs</a> that you encounter."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/versions/edit.html:5
@@ -6642,19 +6504,10 @@ msgstr ""
 msgid "Upload Another File"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/edit.html:45
-msgid ""
-"Adjusting application information here will allow users to install your\n"
-"                          add-on even if the install manifest in the package indicates that the\n"
-"                          add-on is incompatible."
-msgstr ""
-
 #: src/olympia/devhub/templates/devhub/versions/edit.html:74
 msgid ""
-"Information about changes in this release, new features,\n"
-"                              known bugs, and other useful information specific to this\n"
-"                              release/version. This information is also shown in the\n"
-"                              Add-ons Manager when updating."
+"Information about changes in this release, new features, known bugs, and other useful information specific to this release/version. This information is also shown in the Add-ons Manager when "
+"updating."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/versions/edit.html:99
@@ -6666,10 +6519,7 @@ msgid "Notes for Reviewers"
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/versions/edit.html:114
-msgid ""
-"Optionally, enter any information that may be useful\n"
-"                              to the Editor reviewing this add-on, such as test\n"
-"                              account information."
+msgid "Optionally, enter any information that may be useful to the Editor reviewing this add-on, such as test account information."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/versions/edit.html:127
@@ -6747,7 +6597,7 @@ msgstr ""
 msgid "Request Preliminary Review"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:80 src/olympia/devhub/templates/devhub/versions/list.html:327 src/olympia/devhub/templates/devhub/versions/list.html:350
+#: src/olympia/devhub/templates/devhub/versions/list.html:80 src/olympia/devhub/templates/devhub/versions/list.html:325 src/olympia/devhub/templates/devhub/versions/list.html:348
 msgid "Cancel Review Request"
 msgstr ""
 
@@ -6776,7 +6626,7 @@ msgid "Unlisted:"
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/versions/list.html:114
-msgid "Not distributed on {0}. Developers will upload new versions for signing and distribute the add-ons on their own. (beta)"
+msgid "Not distributed on {0}. Developers will upload new versions for signing and distribute the add-ons on their own."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/versions/list.html:122
@@ -6839,81 +6689,73 @@ msgid "<strong>Important:</strong> Once a version has been deleted, you may not 
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/versions/list.html:230
-msgid ""
-"Deleting a version which has already been reviewed\n"
-"               may also cause a significant delay in the review of\n"
-"               your next update."
-msgstr ""
-
-#: src/olympia/devhub/templates/devhub/versions/list.html:233
 msgid "Are you sure you wish to delete this version?"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:238
+#: src/olympia/devhub/templates/devhub/versions/list.html:235
 msgid "Delete Version"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:240
+#: src/olympia/devhub/templates/devhub/versions/list.html:237
 msgid "Disable Version"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:247
+#: src/olympia/devhub/templates/devhub/versions/list.html:244
 msgid "Add a new Version"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:249
+#: src/olympia/devhub/templates/devhub/versions/list.html:246
 msgid "Add Version"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:256 src/olympia/devhub/templates/devhub/versions/list.html:274
+#: src/olympia/devhub/templates/devhub/versions/list.html:253 src/olympia/devhub/templates/devhub/versions/list.html:279
 msgid "Hide Add-on"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:259
+#: src/olympia/devhub/templates/devhub/versions/list.html:256
 msgid "Hiding your add-on will prevent it from appearing anywhere in our gallery and will stop users from receiving automatic updates."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:265
+#: src/olympia/devhub/templates/devhub/versions/list.html:263
+msgid "The files awaiting review will be disabled and you will need to upload new versions."
+msgstr ""
+
+#: src/olympia/devhub/templates/devhub/versions/list.html:270
 msgid "Are you sure you wish to hide your add-on?"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:286 src/olympia/devhub/templates/devhub/versions/list.html:315
+#: src/olympia/devhub/templates/devhub/versions/list.html:291 src/olympia/devhub/templates/devhub/versions/list.html:313
 msgid "Unlist Add-on"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:289
+#: src/olympia/devhub/templates/devhub/versions/list.html:294
 #, python-format
 msgid ""
 "Unlisting your add-on will make it (and each of its versions/files) invisible on this website. It won't show up in searches, won't have a public facing page, and won't be updated automatically for "
-"current users.  It is recommended for unlisted add-ons to provide a custom <a href=\"%(update_url)s\" target=\"_blank\">updateURL</a> in their manifest file for automatic updates."
+"current users. It is recommended for unlisted add-ons to provide a custom <a href=\"%(update_url)s\" target=\"_blank\">updateURL</a> in their manifest file for automatic updates."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:299
-#, python-format
-msgid "Switching add-ons to unlisted is currently in an open beta. Please <a href=\"%(url)s\" target=\"_blank\">report any bugs</a> that you encounter."
-msgstr ""
-
-#: src/olympia/devhub/templates/devhub/versions/list.html:305
+#: src/olympia/devhub/templates/devhub/versions/list.html:303
 msgid "Unlisting an add-on is irreversible!"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:305
+#: src/olympia/devhub/templates/devhub/versions/list.html:303
 msgid "An unlisted add-on cannot be switched to be listed."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:307
+#: src/olympia/devhub/templates/devhub/versions/list.html:305
 msgid "Are you sure you wish to unlist your add-on?"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:330
+#: src/olympia/devhub/templates/devhub/versions/list.html:328
 msgid "Canceling your review request will leave your add-on as preliminarily reviewed."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:335
+#: src/olympia/devhub/templates/devhub/versions/list.html:333
 msgid "Canceling your review request will mark your add-on incomplete. If you do not complete your add-on after several days by re-requesting review, it will be deleted."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:343
+#: src/olympia/devhub/templates/devhub/versions/list.html:341
 msgid "Are you sure you wish to cancel your review request?"
 msgstr ""
 
@@ -7252,19 +7094,19 @@ msgstr ""
 msgid "Search by add-on name / author email"
 msgstr ""
 
-#: src/olympia/editors/forms.py:103
+#: src/olympia/editors/forms.py:103 src/olympia/editors/forms.py:244 src/olympia/editors/forms.py:257
 msgid "yes"
 msgstr ""
 
-#: src/olympia/editors/forms.py:104
+#: src/olympia/editors/forms.py:104 src/olympia/editors/forms.py:244 src/olympia/editors/forms.py:257
 msgid "no"
 msgstr ""
 
-#: src/olympia/editors/forms.py:105
+#: src/olympia/editors/forms.py:105 src/olympia/editors/forms.py:245
 msgid "Admin Flag"
 msgstr ""
 
-#: src/olympia/editors/forms.py:113
+#: src/olympia/editors/forms.py:113 src/olympia/editors/forms.py:253
 msgid "Max. Version"
 msgstr ""
 
@@ -7276,55 +7118,59 @@ msgstr ""
 msgid "Add-on Types"
 msgstr ""
 
-#: src/olympia/editors/forms.py:126 src/olympia/editors/helpers.py:267
+#: src/olympia/editors/forms.py:126 src/olympia/editors/helpers.py:279
 msgid "Platforms"
 msgstr ""
 
+#: src/olympia/editors/forms.py:237
+msgid "Search by add-on name / author email / guid"
+msgstr ""
+
 #. L10n: 0 = platform, 1 = filename, 2 = status message
-#: src/olympia/editors/forms.py:238
+#: src/olympia/editors/forms.py:342
 #, python-format
 msgid "<strong>%s</strong> &middot; %s &middot; %s"
 msgstr ""
 
-#: src/olympia/editors/forms.py:252
+#: src/olympia/editors/forms.py:356
 msgid "Comments:"
 msgstr ""
 
-#: src/olympia/editors/forms.py:256
+#: src/olympia/editors/forms.py:360
 msgid "Operating systems:"
 msgstr ""
 
-#: src/olympia/editors/forms.py:258
+#: src/olympia/editors/forms.py:362
 msgid "Applications:"
 msgstr ""
 
-#: src/olympia/editors/forms.py:260
+#: src/olympia/editors/forms.py:364
 msgid "Notify me the next time this add-on is updated. (Subsequent updates will not generate an email)"
 msgstr ""
 
-#: src/olympia/editors/forms.py:265
+#: src/olympia/editors/forms.py:369
 msgid "Clear Admin Review Flag"
 msgstr ""
 
-#: src/olympia/editors/forms.py:267
+#: src/olympia/editors/forms.py:371
 msgid "Clear more info requested flag"
 msgstr ""
 
-#: src/olympia/editors/forms.py:281
+#: src/olympia/editors/forms.py:385
 msgid "Choose a canned response..."
 msgstr ""
 
 #. L10n: Description of what can be searched for.
-#: src/olympia/editors/forms.py:324
+#: src/olympia/editors/forms.py:423
 msgid "theme name"
 msgstr ""
 
-#: src/olympia/editors/forms.py:350
+#: src/olympia/editors/forms.py:449
 msgid "Someone else is reviewing this theme."
 msgstr ""
 
 #. L10n: Description of what can be searched for.
-#: src/olympia/editors/forms.py:447
+#: src/olympia/editors/forms.py:546
 msgid "app, reviewer, or comment"
 msgstr ""
 
@@ -7340,246 +7186,264 @@ msgstr ""
 msgid "Rejected or Unreviewed"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:123 src/olympia/editors/helpers.py:136
+#: src/olympia/editors/helpers.py:125 src/olympia/editors/helpers.py:138
 msgid "Queue"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:124 src/olympia/editors/templates/editors/base.html:50 src/olympia/editors/templates/editors/base.html:65
+#: src/olympia/editors/helpers.py:126 src/olympia/editors/templates/editors/base.html:50 src/olympia/editors/templates/editors/base.html:65
 msgid "Pending Updates"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:125 src/olympia/editors/templates/editors/base.html:48 src/olympia/editors/templates/editors/base.html:63
+#: src/olympia/editors/helpers.py:127 src/olympia/editors/templates/editors/base.html:48 src/olympia/editors/templates/editors/base.html:63
 msgid "Full Reviews"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:126 src/olympia/editors/templates/editors/base.html:52 src/olympia/editors/templates/editors/base.html:67
+#: src/olympia/editors/helpers.py:128 src/olympia/editors/templates/editors/base.html:52 src/olympia/editors/templates/editors/base.html:67
 msgid "Preliminary Reviews"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:127 src/olympia/editors/templates/editors/base.html:54
+#: src/olympia/editors/helpers.py:129 src/olympia/editors/templates/editors/base.html:54
 msgid "Moderated Reviews"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:128 src/olympia/editors/templates/editors/base.html:46
+#: src/olympia/editors/helpers.py:130 src/olympia/editors/templates/editors/base.html:46
 msgid "Fast Track"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:130
+#: src/olympia/editors/helpers.py:132
 msgid "Pending Themes"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:131 src/olympia/editors/templates/editors/themes/queue.html:4
+#: src/olympia/editors/helpers.py:133 src/olympia/editors/templates/editors/themes/queue.html:4
 msgid "Flagged Themes"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:132
+#: src/olympia/editors/helpers.py:134
 msgid "Update Themes"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:137
+#: src/olympia/editors/helpers.py:139
 msgid "Unlisted Pending Updates"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:138
+#: src/olympia/editors/helpers.py:140
 msgid "Unlisted Full Reviews"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:139
+#: src/olympia/editors/helpers.py:141
 msgid "Unlisted Preliminary Reviews"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:170
+#: src/olympia/editors/helpers.py:142
+msgid "Unlisted All Add-ons"
+msgstr ""
+
+#: src/olympia/editors/helpers.py:173
 msgid "Fast Track ({0})"
 msgid_plural "Fast Track ({0})"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/olympia/editors/helpers.py:175
+#: src/olympia/editors/helpers.py:178
 msgid "Full Review ({0})"
 msgid_plural "Full Reviews ({0})"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/olympia/editors/helpers.py:180
+#: src/olympia/editors/helpers.py:183
 msgid "Pending Update ({0})"
 msgid_plural "Pending Updates ({0})"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/olympia/editors/helpers.py:185
+#: src/olympia/editors/helpers.py:188
 msgid "Preliminary Review ({0})"
 msgid_plural "Preliminary Reviews ({0})"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/olympia/editors/helpers.py:190
+#: src/olympia/editors/helpers.py:193
 msgid "Moderated Review ({0})"
 msgid_plural "Moderated Reviews ({0})"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/olympia/editors/helpers.py:196
+#: src/olympia/editors/helpers.py:199
 msgid "Unlisted Full Review ({0})"
 msgid_plural "Unlisted Full Reviews ({0})"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/olympia/editors/helpers.py:201
+#: src/olympia/editors/helpers.py:204
 msgid "Unlisted Pending Update ({0})"
 msgid_plural "Unlisted Pending Updates ({0})"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/olympia/editors/helpers.py:206
+#: src/olympia/editors/helpers.py:209
 msgid "Unlisted Preliminary Review ({0})"
 msgid_plural "Unlisted Preliminary Reviews ({0})"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/olympia/editors/helpers.py:261
-msgid "Addon"
-msgstr ""
+#: src/olympia/editors/helpers.py:214
+msgid "Unlisted All Add-ons ({0})"
+msgid_plural "Unlisted All Add-ons ({0})"
+msgstr[0] ""
+msgstr[1] ""
 
-#: src/olympia/editors/helpers.py:262
+#: src/olympia/editors/helpers.py:274
 msgid "Type"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:263
+#: src/olympia/editors/helpers.py:275
 msgid "Waiting Time"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:264 src/olympia/editors/templates/editors/review.html:285
+#: src/olympia/editors/helpers.py:276 src/olympia/editors/templates/editors/review.html:285
 msgid "Flags"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:265
+#: src/olympia/editors/helpers.py:277
 msgid "Applications"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:270
+#: src/olympia/editors/helpers.py:282
 msgid "Additional"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:285
+#: src/olympia/editors/helpers.py:302
 msgid "Site Specific"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:287
+#: src/olympia/editors/helpers.py:304
 msgid "Requires External Software"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:289
+#: src/olympia/editors/helpers.py:306
 msgid "Binary Components"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:313
+#: src/olympia/editors/helpers.py:339
 msgid "moments ago"
 msgstr ""
 
 #. L10n: first argument is number of minutes
-#: src/olympia/editors/helpers.py:316
+#: src/olympia/editors/helpers.py:342
 msgid "{0} minute"
 msgid_plural "{0} minutes"
 msgstr[0] ""
 msgstr[1] ""
 
 #. L10n: first argument is number of hours
-#: src/olympia/editors/helpers.py:320
+#: src/olympia/editors/helpers.py:346
 msgid "{0} hour"
 msgid_plural "{0} hours"
 msgstr[0] ""
 msgstr[1] ""
 
 #. L10n: first argument is number of days
-#: src/olympia/editors/helpers.py:324
+#: src/olympia/editors/helpers.py:350
 msgid "{0} day"
 msgid_plural "{0} days"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/olympia/editors/helpers.py:488
+#: src/olympia/editors/helpers.py:364
+msgid "Last Review"
+msgstr ""
+
+#: src/olympia/editors/helpers.py:366
+msgid "Last Update"
+msgstr ""
+
+#: src/olympia/editors/helpers.py:387
+msgid "No Reviews"
+msgstr ""
+
+#: src/olympia/editors/helpers.py:561
 msgid "Push to public"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:490
+#: src/olympia/editors/helpers.py:563
 msgid "Grant full review"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:505
+#: src/olympia/editors/helpers.py:578
 msgid "Request more information"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:508
+#: src/olympia/editors/helpers.py:581
 msgid "Request super-review"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:519
+#: src/olympia/editors/helpers.py:592
 msgid "Grant preliminary review"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:520
+#: src/olympia/editors/helpers.py:593
 msgid "This will mark the files as preliminarily reviewed."
 msgstr ""
 
-#: src/olympia/editors/helpers.py:522
+#: src/olympia/editors/helpers.py:595
 msgid "Use this form to request more information from the author. They will receive an email and be able to answer here. You will be notified by email when they reply."
 msgstr ""
 
-#: src/olympia/editors/helpers.py:526
+#: src/olympia/editors/helpers.py:599
 msgid ""
 "If you have concerns about this add-on's security, copyright issues, or other concerns that an administrator should look into, enter your comments in the area below. They will be sent to "
 "administrators, not the author."
 msgstr ""
 
-#: src/olympia/editors/helpers.py:532
+#: src/olympia/editors/helpers.py:605
 msgid "This will reject the add-on and remove it from the review queue."
 msgstr ""
 
-#: src/olympia/editors/helpers.py:534
-msgid "Make a comment on this version.  The author won't be able to see this."
+#: src/olympia/editors/helpers.py:607
+msgid "Make a comment on this version. The author won't be able to see this."
 msgstr ""
 
-#: src/olympia/editors/helpers.py:538
+#: src/olympia/editors/helpers.py:611
 msgid "This will reject the files and remove them from the review queue."
 msgstr ""
 
-#: src/olympia/editors/helpers.py:542
+#: src/olympia/editors/helpers.py:615
 msgid "This will mark the add-on as preliminarily reviewed. Future versions will undergo preliminary review."
 msgstr ""
 
-#: src/olympia/editors/helpers.py:547
+#: src/olympia/editors/helpers.py:620
 msgid "This will mark the files as preliminarily reviewed. Future versions will undergo preliminary review."
 msgstr ""
 
-#: src/olympia/editors/helpers.py:552
+#: src/olympia/editors/helpers.py:625
 msgid "Retain preliminary review"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:553
+#: src/olympia/editors/helpers.py:626
 msgid "This will retain the add-on as preliminarily reviewed. Future versions will undergo preliminary review."
 msgstr ""
 
-#: src/olympia/editors/helpers.py:558
+#: src/olympia/editors/helpers.py:631
 msgid "This will approve a sandboxed version of a public add-on to appear on the public side."
 msgstr ""
 
-#: src/olympia/editors/helpers.py:561
+#: src/olympia/editors/helpers.py:634
 msgid "This will reject a version of a public add-on and remove it from the queue."
 msgstr ""
 
-#: src/olympia/editors/helpers.py:564
+#: src/olympia/editors/helpers.py:637
 msgid "This will mark the add-on and its most recent version and files as public. Future versions will go into the sandbox until they are reviewed by an editor."
 msgstr ""
 
-#: src/olympia/editors/helpers.py:637
+#: src/olympia/editors/helpers.py:714
 msgid "add-on"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:940 src/olympia/editors/helpers.py:960
+#: src/olympia/editors/helpers.py:1020 src/olympia/editors/helpers.py:1040
 msgid "Flagged"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:944 src/olympia/editors/helpers.py:963
+#: src/olympia/editors/helpers.py:1024 src/olympia/editors/helpers.py:1043
 msgid "Updates"
 msgstr ""
 
@@ -7631,56 +7495,56 @@ msgstr ""
 msgid "A question about your Theme submission"
 msgstr ""
 
-#: src/olympia/editors/views.py:144
+#: src/olympia/editors/views.py:146
 msgid "New Add-ons (Under 5 days)"
 msgstr ""
 
-#: src/olympia/editors/views.py:145
+#: src/olympia/editors/views.py:147
 msgid "Passable (5 to 10 days)"
 msgstr ""
 
-#: src/olympia/editors/views.py:146
+#: src/olympia/editors/views.py:148
 msgid "Overdue (Over 10 days)"
 msgstr ""
 
-#: src/olympia/editors/views.py:532
+#: src/olympia/editors/views.py:539
 msgid "An unknown error occurred"
 msgstr ""
 
-#: src/olympia/editors/views.py:587
+#: src/olympia/editors/views.py:592
 msgid "Self-reviews are not allowed."
 msgstr ""
 
-#: src/olympia/editors/views.py:609
+#: src/olympia/editors/views.py:613
 msgid "Review successfully processed."
 msgstr ""
 
-#: src/olympia/editors/views.py:807
+#: src/olympia/editors/views.py:812
 msgid "was approved"
 msgstr ""
 
-#: src/olympia/editors/views.py:808
+#: src/olympia/editors/views.py:813
 msgid "given preliminary review"
 msgstr ""
 
-#: src/olympia/editors/views.py:809
+#: src/olympia/editors/views.py:814
 msgid "rejected"
 msgstr ""
 
-#: src/olympia/editors/views.py:810
+#: src/olympia/editors/views.py:815
 msgctxt "editors_review_history_nominated_adminreview"
 msgid "escalated"
 msgstr ""
 
-#: src/olympia/editors/views.py:812
+#: src/olympia/editors/views.py:817
 msgid "needs more information"
 msgstr ""
 
-#: src/olympia/editors/views.py:813
+#: src/olympia/editors/views.py:818
 msgid "needs super review"
 msgstr ""
 
-#: src/olympia/editors/views.py:814
+#: src/olympia/editors/views.py:819
 msgid "commented"
 msgstr ""
 
@@ -7725,28 +7589,28 @@ msgstr ""
 msgid "Unlisted Queues"
 msgstr ""
 
-#: src/olympia/editors/templates/editors/base.html:72 src/olympia/editors/templates/editors/performance.html:6
+#: src/olympia/editors/templates/editors/base.html:74 src/olympia/editors/templates/editors/performance.html:6
 msgid "Performance"
 msgstr ""
 
-#: src/olympia/editors/templates/editors/base.html:75 src/olympia/editors/templates/editors/themes/base.html:19 src/olympia/editors/templates/editors/themes/base.html:38
+#: src/olympia/editors/templates/editors/base.html:77 src/olympia/editors/templates/editors/themes/base.html:19 src/olympia/editors/templates/editors/themes/base.html:38
 msgid "Logs"
 msgstr ""
 
-#: src/olympia/editors/templates/editors/base.html:78 src/olympia/editors/templates/editors/reviewlog.html:4 src/olympia/editors/templates/editors/reviewlog.html:27
+#: src/olympia/editors/templates/editors/base.html:80 src/olympia/editors/templates/editors/reviewlog.html:4 src/olympia/editors/templates/editors/reviewlog.html:27
 msgid "Add-on Review Log"
 msgstr ""
 
-#: src/olympia/editors/templates/editors/base.html:80 src/olympia/editors/templates/editors/eventlog.html:4 src/olympia/editors/templates/editors/eventlog.html:8
+#: src/olympia/editors/templates/editors/base.html:82 src/olympia/editors/templates/editors/eventlog.html:4 src/olympia/editors/templates/editors/eventlog.html:8
 #: src/olympia/editors/templates/editors/eventlog_detail.html:4
 msgid "Moderated Review Log"
 msgstr ""
 
-#: src/olympia/editors/templates/editors/base.html:82 src/olympia/editors/templates/editors/beta_signed_log.html:4 src/olympia/editors/templates/editors/beta_signed_log.html:8
+#: src/olympia/editors/templates/editors/base.html:84 src/olympia/editors/templates/editors/beta_signed_log.html:4 src/olympia/editors/templates/editors/beta_signed_log.html:8
 msgid "Signed Beta Files Log"
 msgstr ""
 
-#: src/olympia/editors/templates/editors/base.html:87 src/olympia/editors/templates/editors/includes/daily-message.html:4
+#: src/olympia/editors/templates/editors/base.html:89 src/olympia/editors/templates/editors/includes/daily-message.html:4
 msgid "Announcement"
 msgstr ""
 
@@ -7967,45 +7831,45 @@ msgstr ""
 msgid "clear search"
 msgstr ""
 
-#: src/olympia/editors/templates/editors/queue.html:72 src/olympia/editors/templates/editors/queue.html:122
+#: src/olympia/editors/templates/editors/queue.html:78 src/olympia/editors/templates/editors/queue.html:128
 msgid "Process Reviews"
 msgstr ""
 
-#: src/olympia/editors/templates/editors/queue.html:80
+#: src/olympia/editors/templates/editors/queue.html:86
 msgid "Moderation actions:"
 msgstr ""
 
-#: src/olympia/editors/templates/editors/queue.html:90
+#: src/olympia/editors/templates/editors/queue.html:96
 #, python-format
 msgid "by %(user)s on %(date)s %(stars)s (%(locale)s)"
 msgstr ""
 
-#: src/olympia/editors/templates/editors/queue.html:106
+#: src/olympia/editors/templates/editors/queue.html:112
 #, python-format
 msgid "<strong>%(reason)s</strong> <span class=\"light\">Flagged by %(user)s on %(date)s</span>"
 msgstr ""
 
-#: src/olympia/editors/templates/editors/queue.html:119
-msgid "All reviews have been moderated.  Good work!"
+#: src/olympia/editors/templates/editors/queue.html:125
+msgid "All reviews have been moderated. Good work!"
 msgstr ""
 
-#: src/olympia/editors/templates/editors/queue.html:161
+#: src/olympia/editors/templates/editors/queue.html:167
 msgid "Version Notes / Notes for Reviewer"
 msgstr ""
 
-#: src/olympia/editors/templates/editors/queue.html:169
+#: src/olympia/editors/templates/editors/queue.html:175
 msgid "There are currently no add-ons of this type to review."
 msgstr ""
 
-#: src/olympia/editors/templates/editors/queue.html:181 src/olympia/editors/templates/editors/themes/queue_list.html:85
+#: src/olympia/editors/templates/editors/queue.html:187 src/olympia/editors/templates/editors/themes/queue_list.html:85
 msgid "Helpful Links:"
 msgstr ""
 
-#: src/olympia/editors/templates/editors/queue.html:182
+#: src/olympia/editors/templates/editors/queue.html:188
 msgid "Add-on Policy"
 msgstr ""
 
-#: src/olympia/editors/templates/editors/queue.html:184
+#: src/olympia/editors/templates/editors/queue.html:190
 msgid "Editors' Guide"
 msgstr ""
 
@@ -8068,10 +7932,7 @@ msgid "<strong>Warning!</strong> Another user was viewing this page before you."
 msgstr ""
 
 #: src/olympia/editors/templates/editors/review.html:237
-msgid ""
-"The whiteboard is the place to exchange information relevant to\n"
-"               this addon (whatever the version), between the developer and the\n"
-"               editor. This is visible and editable by both."
+msgid "The whiteboard is the place to exchange information relevant to this addon (whatever the version), between the developer and the editor. This is visible and editable by both."
 msgstr ""
 
 #: src/olympia/editors/templates/editors/review.html:241
@@ -8345,7 +8206,7 @@ msgstr ""
 msgid "Describe your reason for flagging"
 msgstr ""
 
-#: src/olympia/files/forms.py:88
+#: src/olympia/files/forms.py:90
 msgid "Cannot diff a version against itself"
 msgstr ""
 
@@ -8380,51 +8241,51 @@ msgstr ""
 msgid "There was an error accessing file %s."
 msgstr ""
 
-#: src/olympia/files/utils.py:343
+#: src/olympia/files/utils.py:340
 msgid "Could not parse uploaded file."
 msgstr ""
 
-#: src/olympia/files/utils.py:380
+#: src/olympia/files/utils.py:377
 msgid "Invalid file name in archive: {0}"
 msgstr ""
 
-#: src/olympia/files/utils.py:388
+#: src/olympia/files/utils.py:385
 msgid "File exceeding size limit in archive: {0}"
 msgstr ""
 
-#: src/olympia/files/utils.py:439
+#: src/olympia/files/utils.py:436
 msgid "Invalid archive."
 msgstr ""
 
-#: src/olympia/files/utils.py:529 src/olympia/files/utils.py:532
+#: src/olympia/files/utils.py:526 src/olympia/files/utils.py:529
 msgid "Could not parse the manifest file."
 msgstr ""
 
-#: src/olympia/files/utils.py:551
+#: src/olympia/files/utils.py:548
 msgid "Could not find an add-on ID."
 msgstr ""
 
-#: src/olympia/files/utils.py:554
+#: src/olympia/files/utils.py:551
 msgid "Add-on ID must be 64 characters or less."
 msgstr ""
 
-#: src/olympia/files/utils.py:556
+#: src/olympia/files/utils.py:553
 msgid "Add-on ID doesn't match add-on."
 msgstr ""
 
-#: src/olympia/files/utils.py:564
+#: src/olympia/files/utils.py:561
 msgid "Duplicate add-on ID found."
 msgstr ""
 
-#: src/olympia/files/utils.py:567
+#: src/olympia/files/utils.py:564
 msgid "Version numbers should have fewer than 32 characters."
 msgstr ""
 
-#: src/olympia/files/utils.py:570
+#: src/olympia/files/utils.py:567
 msgid "Version numbers should only contain letters, numbers, and these punctuation characters: +*.-_."
 msgstr ""
 
-#: src/olympia/files/utils.py:587
+#: src/olympia/files/utils.py:584
 msgid "<em:type> doesn't match add-on"
 msgstr ""
 
@@ -8523,6 +8384,10 @@ msgstr ""
 
 #: src/olympia/files/templates/files/viewer.html:134
 msgid "Fetching file."
+msgstr ""
+
+#: src/olympia/legacy_api/views.py:255
+msgid "Not implemented yet."
 msgstr ""
 
 #: src/olympia/lib/constants.py:6
@@ -9181,10 +9046,6 @@ msgstr ""
 msgid "Zimbabwe Dollar"
 msgstr ""
 
-#: src/olympia/lib/video/ffmpeg.py:112 src/olympia/lib/video/totem.py:81
-msgid "Videos must be in WebM."
-msgstr ""
-
 #: src/olympia/pages/templates/pages/about.lhtml:3 src/olympia/pages/templates/pages/about.lhtml:10
 msgid "About Mozilla Add-ons"
 msgstr ""
@@ -9196,7 +9057,7 @@ msgstr ""
 #: src/olympia/pages/templates/pages/about.lhtml:13
 msgid ""
 "addons.mozilla.org, commonly known as \"AMO\", is Mozilla's official site for add-ons to Mozilla software, such as Firefox, Thunderbird, and SeaMonkey. Add-ons let you add new features and change "
-"the way your browser or application works.  Take a look around and explore the thousands of ways to customize the way you do things online."
+"the way your browser or application works. Take a look around and explore the thousands of ways to customize the way you do things online."
 msgstr ""
 
 #: src/olympia/pages/templates/pages/about.lhtml:19
@@ -9541,7 +9402,7 @@ msgstr ""
 msgid ""
 "Yes. It's possible, but some of the functionality provided by these libraries are available through XPCOM, XUL, and JavaScript. In addition, authors should take care if libraries modify primitive "
 "object prototypes (String.prototype, Date.prototype, etc.) and/or define global functions (eg. the $ function). These are prone to cause conflict with other add-ons, in particular if different add-"
-"ons use different versions of libraries and so on. Developers need to be very, very careful with using them.  Mozilla does not offer documentation on using them to build add-ons."
+"ons use different versions of libraries and so on. Developers need to be very, very careful with using them. Mozilla does not offer documentation on using them to build add-ons."
 msgstr ""
 
 #: src/olympia/pages/templates/pages/dev_faq.html:165
@@ -9655,8 +9516,8 @@ msgstr ""
 #, python-format
 msgid ""
 "Yes. Many developers choose to host their own add-ons. Choosing to host your add-on on <a href=\"%(amo_url)s\">Mozilla's add-on site</a>, though, allows for much greater exposure to your add-on due "
-"to the large volume of visitors to the site.  <a href=\"%(md_url)s\">mozdev.org</a> offers free project hosting for Mozilla applications and extensions providing developers with tools to help "
-"manage source code, version control, bug tracking and documentation."
+"to the large volume of visitors to the site. <a href=\"%(md_url)s\">mozdev.org</a> offers free project hosting for Mozilla applications and extensions providing developers with tools to help manage "
+"source code, version control, bug tracking and documentation."
 msgstr ""
 
 #: src/olympia/pages/templates/pages/dev_faq.html:277
@@ -9704,7 +9565,7 @@ msgstr ""
 #: src/olympia/pages/templates/pages/dev_faq.html:314
 #, python-format
 msgid ""
-"Yes. Mozilla's <a href=\"%(p_url)s\">Add-on Policy</a> describes what is an acceptable submission. This policy is subject to change without notice.  In addition, the AMO editorial team uses the <a "
+"Yes. Mozilla's <a href=\"%(p_url)s\">Add-on Policy</a> describes what is an acceptable submission. This policy is subject to change without notice. In addition, the AMO editorial team uses the <a "
 "href=\"%(g_url)s\">Editors Reviewing Guide</a> to ensure that your add-on meets specific guidelines for functionality and security."
 msgstr ""
 
@@ -9821,7 +9682,7 @@ msgstr ""
 #: src/olympia/pages/templates/pages/dev_faq.html:434
 #, python-format
 msgid ""
-"This is why it's very important to read the <a href=\"%(g_url)s\">Editors Reviewing Guide</a> to ensure that your add-on is setup as expected.  It's also a good idea to read the blog post, <a href="
+"This is why it's very important to read the <a href=\"%(g_url)s\">Editors Reviewing Guide</a> to ensure that your add-on is setup as expected. It's also a good idea to read the blog post, <a href="
 "\"%(blog_url)s\">Successfully Getting your Add-on Reviewed</a> which provides excellent insight into ensuring a smooth review of your add-on."
 msgstr ""
 
@@ -9928,7 +9789,7 @@ msgstr ""
 
 #: src/olympia/pages/templates/pages/dev_faq.html:572
 msgid ""
-"Free Software Foundation provides short summaries of the key open source licenses, including whether the license qualifies as a free software license or a copyleft license.  Also includes a "
+"Free Software Foundation provides short summaries of the key open source licenses, including whether the license qualifies as a free software license or a copyleft license. Also includes a "
 "discussion of what constitutes a free software license or a copyleft license (e.g., a Copyleft license is a general method for making a program or other work free, and requiring all modified and "
 "extended versions of the program to be free as well.)"
 msgstr ""
@@ -10106,19 +9967,13 @@ msgid "Add-on Gallery"
 msgstr ""
 
 #: src/olympia/pages/templates/pages/faq.html:171
-msgid ""
-"How do I choose between add-ons that seem to do the same\n"
-"    thing?"
+msgid "How do I choose between add-ons that seem to do the same thing?"
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:173
+#: src/olympia/pages/templates/pages/faq.html:172
 msgid ""
-"There are often several add-ons that have similar features. To\n"
-"    figure out which is right for you, read the entire description of the\n"
-"    add-on and view its screenshots. If there are still several in the running,\n"
-"    read through the add-on's ratings, user reviews, and statistics to see\n"
-"    which is most liked by other users. Remember that you can also just try\n"
-"    out both and see which you like better."
+"There are often several add-ons that have similar features. To figure out which is right for you, read the entire description of the add-on and view its screenshots. If there are still several in "
+"the running, read through the add-on's ratings, user reviews, and statistics to see which is most liked by other users. Remember that you can also just try out both and see which you like better."
 msgstr ""
 
 #: src/olympia/pages/templates/pages/faq.html:180
@@ -10159,80 +10014,67 @@ msgid "How much do add-ons cost to purchase?"
 msgstr ""
 
 #: src/olympia/pages/templates/pages/faq.html:207
-msgid ""
-"Add-ons hosted in our gallery are free unless clearly marked\n"
-"    otherwise."
+msgid "Add-ons hosted in our gallery are free unless clearly marked otherwise."
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:210
+#: src/olympia/pages/templates/pages/faq.html:209
 msgid "What does it mean when an add-on asks for contributions?"
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:211
+#: src/olympia/pages/templates/pages/faq.html:210
 msgid ""
-"Some add-on authors request users who enjoy an add-on to\n"
-"        contribute to its development by making a monetary contribution. These\n"
-"        contributions go directly to the developer unless a third party is\n"
-"        indicated, such as the non-profit Mozilla Foundation."
+"Some add-on authors request users who enjoy an add-on to contribute to its development by making a monetary contribution. These contributions go directly to the developer unless a third party is "
+"indicated, such as the non-profit Mozilla Foundation."
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:216
+#: src/olympia/pages/templates/pages/faq.html:215
 msgid "What are beta add-ons?"
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:218
+#: src/olympia/pages/templates/pages/faq.html:217
 msgid ""
-"Beta add-ons are unreviewed versions which represent the\n"
-"        latest work of an add-on author. While different authors have different\n"
-"        standards for beta code quality, you should assume that these add-ons\n"
-"        are less stable than the general add-on releases."
+"Beta add-ons are unreviewed versions which represent the latest work of an add-on author. While different authors have different standards for beta code quality, you should assume that these add-"
+"ons are less stable than the general add-on releases."
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:222
+#: src/olympia/pages/templates/pages/faq.html:221
 msgid ""
 "Please note that when you install an add-on from the \"Beta Version\" section of an add-on's listing, you will continue to receive updates for that add-on as they become available. Like the initial "
 "version you installed, all beta releases are unreviewed by Mozilla and may harm your computer."
 msgstr ""
 
+#: src/olympia/pages/templates/pages/faq.html:228
+msgid "What does it mean when an add-on is flagged as slow?"
+msgstr ""
+
 #: src/olympia/pages/templates/pages/faq.html:229
-msgid ""
-"What does it mean when an add-on is flagged as\n"
-"    slow?"
+msgid "Most add-ons load code and resources at the same time Firefox is starting up. In most cases the impact in start-up time is minimal, but some add-ons can cause a noticeable slowdown."
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:231
-msgid ""
-"Most add-ons load code and resources at the same time Firefox\n"
-"        is starting up. In most cases the impact in start-up time is minimal,\n"
-"        but some add-ons can cause a noticeable slowdown."
-msgstr ""
-
-#: src/olympia/pages/templates/pages/faq.html:236
+#: src/olympia/pages/templates/pages/faq.html:234
 msgid "How do I report an inappropriate or spam user review?"
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:237
+#: src/olympia/pages/templates/pages/faq.html:235
 msgid ""
-"To report a user review of an add-on, log in with your account\n"
-"    and visit the add-on's reviews page. Find the review you wish to report,\n"
-"    click \"Report this review\" and select a reason. Our editorial team will\n"
-"    investigate the review and take appropriate action."
+"To report a user review of an add-on, log in with your account and visit the add-on's reviews page. Find the review you wish to report, click \"Report this review\" and select a reason. Our "
+"editorial team will investigate the review and take appropriate action."
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:242
+#: src/olympia/pages/templates/pages/faq.html:240
 msgid "How do I report a bug or contact the Mozilla Add-ons team?"
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:243
+#: src/olympia/pages/templates/pages/faq.html:241
 #, python-format
 msgid "Please visit our <a href=\"%(contact_url)s\">Contact page</a>."
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:246
+#: src/olympia/pages/templates/pages/faq.html:244
 msgid "What is a Source Code License?"
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:247
+#: src/olympia/pages/templates/pages/faq.html:245
 #, python-format
 msgid ""
 "The source code used to create an add-on is an exclusive copyright of the add-on author, unless otherwise declared in a source code license. Many add-ons on this site have <a href=\"%(url)s\" lang="
@@ -10240,60 +10082,60 @@ msgid ""
 "the GPL or BSD licenses instead of making up their own."
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:256
+#: src/olympia/pages/templates/pages/faq.html:254
 #, python-format
 msgid "Firefox and other Mozilla software are <a href=\"%(url)s\">open source</a>."
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:264
+#: src/olympia/pages/templates/pages/faq.html:262
 msgid "Collections and Favorites"
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:267
+#: src/olympia/pages/templates/pages/faq.html:265
 msgid "What is a collection?"
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:268
+#: src/olympia/pages/templates/pages/faq.html:266
 msgid "Collections are groups of related add-ons created by users to share."
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:270
+#: src/olympia/pages/templates/pages/faq.html:268
 msgid "What is the My Favorites collection?"
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:271
+#: src/olympia/pages/templates/pages/faq.html:269
 msgid "Favorite add-ons are add-ons that you have bookmarked to easily get back to later. You can add an add-on to your favorites collection by clicking \"Add to favorites\" on its details page."
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:275 src/olympia/templates/menu_links.html:13 src/olympia/templates/impala/header_title.html:17
+#: src/olympia/pages/templates/pages/faq.html:273 src/olympia/templates/menu_links.html:13 src/olympia/templates/impala/header_title.html:17
 msgid "Mobile Add-ons"
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:278
+#: src/olympia/pages/templates/pages/faq.html:276
 msgid "What are mobile add-ons?"
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:279
+#: src/olympia/pages/templates/pages/faq.html:277
 #, python-format
 msgid ""
 "Mobile add-ons work with <a href=\"%(mobile_url)s\">Firefox for Mobile</a> and add or modify functionality just like desktop add-ons. You can find add-ons that work with Firefox for Mobile in our "
 "<a href=\"%(gallery_url)s\">gallery</a>."
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:288
+#: src/olympia/pages/templates/pages/faq.html:286
 msgid "Developer Topics"
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:289
+#: src/olympia/pages/templates/pages/faq.html:287
 #, python-format
 msgid "Please see our <a href=\"%(faq_url)s\">Developer FAQ</a> and <a href=\"%(hub_url)s\">Developer Hub</a> for answers to add-on developer-related questions."
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:294
+#: src/olympia/pages/templates/pages/faq.html:292
 msgid "Still have questions?"
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:295
+#: src/olympia/pages/templates/pages/faq.html:293
 #, python-format
 msgid "For general Firefox support, visit our <a href=\"%(sumo_url)s\">support website</a>. For general add-on and website questions, visit our <a href=\"%(forum_url)s\">forum</a>."
 msgstr ""
@@ -10431,7 +10273,7 @@ msgstr ""
 
 #: src/olympia/pages/templates/pages/sunbird.html:29
 msgid ""
-"Development on the Sunbird project has halted and its final release was on March 30, 2010.  We've been proud to host Sunbird add-ons on this site but as the project is no longer maintained we have "
+"Development on the Sunbird project has halted and its final release was on March 30, 2010. We've been proud to host Sunbird add-ons on this site but as the project is no longer maintained we have "
 "disabled our support for the add-ons."
 msgstr ""
 
@@ -10509,7 +10351,7 @@ msgstr ""
 #, python-format
 msgid ""
 "<h2>Keep these tips in mind:</h2> <ul> <li> Write like you're telling a friend about your experience with the add-on. Give specifics and helpful details, such as what features you liked and/or "
-"disliked, how easy to use it is, and any disadvantages it has.  Avoid generic language such as calling it \"Great\" or \"Bad\" unless you can give reasons why you believe this is so. </li> <li> "
+"disliked, how easy to use it is, and any disadvantages it has. Avoid generic language such as calling it \"Great\" or \"Bad\" unless you can give reasons why you believe this is so. </li> <li> "
 "Please do not post bug reports in reviews. We do not make your email address available to add-on developers and they may need to contact you to help resolve your issue. See the <a href=\"%(support)s"
 "\">support section</a> to find out where to get assistance for this add-on. </li> <li>Please keep reviews clean, avoid the use of improper language and do not post any personal information. </li> </"
 "ul> <p>Please read the <a href=\"%(guide)s\" target=\"_blank\">Review Guidelines</a> for more detail about user add-on reviews.</p>"
@@ -10745,16 +10587,16 @@ msgstr ""
 
 #. L10n: {0} is an application, such as Firefox. This means "any version of
 #. Firefox."
-#: src/olympia/search/views.py:554
+#: src/olympia/search/views.py:547
 msgid "Any {0}"
 msgstr ""
 
 #. L10n: "All Systems" means show everything regardless of platform.
-#: src/olympia/search/views.py:589
+#: src/olympia/search/views.py:582
 msgid "All Systems"
 msgstr ""
 
-#: src/olympia/search/views.py:600
+#: src/olympia/search/views.py:593
 msgid "All Tags"
 msgstr ""
 
@@ -10928,31 +10770,31 @@ msgstr ""
 msgid "Share this Collection"
 msgstr ""
 
-#: src/olympia/signing/views.py:30 src/olympia/templates/base.html:75 src/olympia/templates/impala/base.html:115
+#: src/olympia/signing/views.py:33 src/olympia/templates/base.html:71 src/olympia/templates/impala/base.html:112
 msgid "Some features are temporarily disabled while we perform website maintenance. We'll be back to full capacity shortly."
 msgstr ""
 
-#: src/olympia/signing/views.py:53
+#: src/olympia/signing/views.py:56
 msgid "Could not find add-on with id \"{}\"."
 msgstr ""
 
-#: src/olympia/signing/views.py:67
+#: src/olympia/signing/views.py:70
 msgid "You do not own this addon."
 msgstr ""
 
-#: src/olympia/signing/views.py:82
+#: src/olympia/signing/views.py:87
 msgid "Missing \"upload\" key in multipart file data."
 msgstr ""
 
-#: src/olympia/signing/views.py:96
+#: src/olympia/signing/views.py:101
 msgid "Version does not match the manifest file."
 msgstr ""
 
-#: src/olympia/signing/views.py:100
+#: src/olympia/signing/views.py:105
 msgid "Version already exists."
 msgstr ""
 
-#: src/olympia/signing/views.py:136
+#: src/olympia/signing/views.py:141
 msgid "No uploaded file for that addon and version."
 msgstr ""
 
@@ -11065,89 +10907,89 @@ msgstr ""
 msgid "Statistics Dashboard :: Add-ons for {0}"
 msgstr ""
 
-#: src/olympia/stats/templates/stats/stats.html:30
-msgid "Controls:"
-msgstr ""
-
-#: src/olympia/stats/templates/stats/stats.html:33
-msgid "reset zoom"
-msgstr ""
-
-#: src/olympia/stats/templates/stats/stats.html:40
-msgid "Group by:"
-msgstr ""
-
-#: src/olympia/stats/templates/stats/stats.html:42
-msgid "day"
-msgstr ""
-
-#: src/olympia/stats/templates/stats/stats.html:45
-msgid "week"
-msgstr ""
-
-#: src/olympia/stats/templates/stats/stats.html:48
-msgid "month"
-msgstr ""
-
-#: src/olympia/stats/templates/stats/stats.html:54
-msgid "For last:"
-msgstr ""
-
-#: src/olympia/stats/templates/stats/stats.html:57
-msgid "7 days"
-msgstr ""
-
-#: src/olympia/stats/templates/stats/stats.html:60
-msgid "30 days"
-msgstr ""
-
-#: src/olympia/stats/templates/stats/stats.html:63
-msgid "90 days"
-msgstr ""
-
-#: src/olympia/stats/templates/stats/stats.html:66
-msgid "365 days"
-msgstr ""
-
-#: src/olympia/stats/templates/stats/stats.html:69
-msgid "Custom..."
-msgstr ""
-
 #. {0} is an add-on name
-#: src/olympia/stats/templates/stats/stats.html:88 src/olympia/stats/templates/stats/stats.html:91
+#: src/olympia/stats/templates/stats/stats.html:44 src/olympia/stats/templates/stats/stats.html:47
 msgid "Statistics for {0}"
 msgstr ""
 
-#: src/olympia/stats/templates/stats/stats.html:94
+#: src/olympia/stats/templates/stats/stats.html:50
 msgid "Statistics Dashboard"
 msgstr ""
 
-#: src/olympia/stats/templates/stats/stats.html:104
+#: src/olympia/stats/templates/stats/stats.html:57
+msgid "Controls:"
+msgstr ""
+
+#: src/olympia/stats/templates/stats/stats.html:60
+msgid "reset zoom"
+msgstr ""
+
+#: src/olympia/stats/templates/stats/stats.html:67
+msgid "Group by:"
+msgstr ""
+
+#: src/olympia/stats/templates/stats/stats.html:69
+msgid "day"
+msgstr ""
+
+#: src/olympia/stats/templates/stats/stats.html:72
+msgid "week"
+msgstr ""
+
+#: src/olympia/stats/templates/stats/stats.html:75
+msgid "month"
+msgstr ""
+
+#: src/olympia/stats/templates/stats/stats.html:81
+msgid "For last:"
+msgstr ""
+
+#: src/olympia/stats/templates/stats/stats.html:84
+msgid "7 days"
+msgstr ""
+
+#: src/olympia/stats/templates/stats/stats.html:87
+msgid "30 days"
+msgstr ""
+
+#: src/olympia/stats/templates/stats/stats.html:90
+msgid "90 days"
+msgstr ""
+
+#: src/olympia/stats/templates/stats/stats.html:93
+msgid "365 days"
+msgstr ""
+
+#: src/olympia/stats/templates/stats/stats.html:96
+msgid "Custom..."
+msgstr ""
+
+#: src/olympia/stats/templates/stats/stats.html:106
 msgid "Statistics processing is currently disabled, so recent data is unavailable. The statistics are still being collected and this page will be updated soon with the missing data."
 msgstr ""
 
-#: src/olympia/stats/templates/stats/stats.html:110
+#: src/olympia/stats/templates/stats/stats.html:112
 msgid "Loading the latest data&hellip;"
 msgstr ""
 
-#: src/olympia/stats/templates/stats/stats.html:142 src/olympia/stats/templates/stats/reports/overview.html:25 src/olympia/stats/templates/stats/reports/overview.html:37
+#: src/olympia/stats/templates/stats/stats.html:144 src/olympia/stats/templates/stats/reports/overview.html:25 src/olympia/stats/templates/stats/reports/overview.html:37
 #: src/olympia/stats/templates/stats/reports/overview.html:49
 msgid "No data available."
 msgstr ""
 
-#: src/olympia/stats/templates/stats/stats.html:177
+#: src/olympia/stats/templates/stats/stats.html:179
 msgid "This dashboard is currently <b>public</b>."
 msgstr ""
 
-#: src/olympia/stats/templates/stats/stats.html:179
+#: src/olympia/stats/templates/stats/stats.html:181
 msgid "Contribution stats are currently <b>private</b>."
 msgstr ""
 
-#: src/olympia/stats/templates/stats/stats.html:182
+#: src/olympia/stats/templates/stats/stats.html:184
 msgid "This dashboard is currently <b>private</b>."
 msgstr ""
 
-#: src/olympia/stats/templates/stats/stats.html:185
+#: src/olympia/stats/templates/stats/stats.html:187
 msgid "Change settings."
 msgstr ""
 
@@ -11299,15 +11141,6 @@ msgstr ""
 msgid "Application versions by Date"
 msgstr ""
 
-#: src/olympia/tags/templates/tags/top_cloud.html:4
-msgid "Top {0} Tags"
-msgstr ""
-
-#. {0} is the current application name
-#: src/olympia/tags/templates/tags/top_cloud.html:14
-msgid "{0} Top Tags"
-msgstr ""
-
 #: src/olympia/templates/amo_footer.html:6 src/olympia/templates/includes/lang_switcher.html:2
 msgid "Other languages"
 msgstr ""
@@ -11316,11 +11149,11 @@ msgstr ""
 msgid "Mozilla Add-ons"
 msgstr ""
 
-#: src/olympia/templates/base.html:91 src/olympia/templates/impala/base.html:81
+#: src/olympia/templates/base.html:89 src/olympia/templates/impala/base.html:78
 msgid "Find add-ons for other applications"
 msgstr ""
 
-#: src/olympia/templates/base.html:92 src/olympia/templates/impala/base.html:81
+#: src/olympia/templates/base.html:90 src/olympia/templates/impala/base.html:78
 msgid "Other Applications"
 msgstr ""
 
@@ -11345,7 +11178,7 @@ msgid "View Mobile Site"
 msgstr ""
 
 #: src/olympia/templates/copyright.html:7
-msgid "Site Status "
+msgid "Site Status"
 msgstr ""
 
 #: src/olympia/templates/footer.html:3
@@ -11445,35 +11278,35 @@ msgstr ""
 msgid "<a href=\"%(reg)s\">Register</a> or <a href=\"%(login)s\">Log in</a>"
 msgstr ""
 
-#: src/olympia/templates/impala/base.html:126
+#: src/olympia/templates/impala/base.html:123
 #, python-format
 msgid "To try the thousands of add-ons available here, download <a href=\"%(url)s\">Mozilla Firefox</a>, a fast, free way to surf the Web!"
 msgstr ""
 
-#: src/olympia/templates/impala/base.html:138
+#: src/olympia/templates/impala/base.html:135
 #, python-format
 msgid "Add-ons is switching to Firefox Accounts for login. <a href=\"%(url)s\" class=\"fxa-login\">Sign in now to transfer your account.</a>"
 msgstr ""
 
 #. {0} is an application, such as Firefox.
-#: src/olympia/templates/impala/base.html:148
+#: src/olympia/templates/impala/base.html:145
 msgid "Welcome to {0} Add-ons."
 msgstr ""
 
-#: src/olympia/templates/impala/base.html:151
+#: src/olympia/templates/impala/base.html:148
 msgid "Choose from thousands of extra features and styles to make Firefox your own."
 msgstr ""
 
-#: src/olympia/templates/impala/base.html:156
+#: src/olympia/templates/impala/base.html:153
 #, python-format
 msgid "Add extra features and styles to make %(app)s your own."
 msgstr ""
 
-#: src/olympia/templates/impala/base.html:164
+#: src/olympia/templates/impala/base.html:161
 msgid "On the go?"
 msgstr ""
 
-#: src/olympia/templates/impala/base.html:166
+#: src/olympia/templates/impala/base.html:163
 msgid "Check out our <a class=\"mobile-link\" href=\"#\">Mobile Add-ons site</a>."
 msgstr ""
 
@@ -11697,19 +11530,19 @@ msgstr ""
 
 #. L10n: {id} will be something like "13ad6a", just a random number
 #. to differentiate this user from other anonymous users.
-#: src/olympia/users/models.py:353
+#: src/olympia/users/models.py:362
 msgid "Anonymous user {id}"
 msgstr ""
 
-#: src/olympia/users/models.py:410
+#: src/olympia/users/models.py:419
 msgid "Your account has been restricted"
 msgstr ""
 
-#: src/olympia/users/models.py:480
+#: src/olympia/users/models.py:489
 msgid "Please confirm your email address"
 msgstr ""
 
-#: src/olympia/users/models.py:506
+#: src/olympia/users/models.py:515
 msgid "My Mobile Add-ons"
 msgstr ""
 
@@ -11986,7 +11819,7 @@ msgstr ""
 
 #: src/olympia/users/templates/users/edit.html:70
 #, python-format
-msgid "Change your password.  If you forgot your password, you can <a href=\"%(reset_url)s\">use the reset form</a>."
+msgid "Change your password. If you forgot your password, you can <a href=\"%(reset_url)s\">use the reset form</a>."
 msgstr ""
 
 #: src/olympia/users/templates/users/edit.html:76
@@ -12006,7 +11839,7 @@ msgid "Profile"
 msgstr ""
 
 #: src/olympia/users/templates/users/edit.html:100
-msgid "Give us a bit more information about yourself.  All these fields are optional, but they'll help other users get to know you better."
+msgid "Give us a bit more information about yourself. All these fields are optional, but they'll help other users get to know you better."
 msgstr ""
 
 #: src/olympia/users/templates/users/edit.html:124
@@ -12222,7 +12055,7 @@ msgid "Confirm password"
 msgstr ""
 
 #: src/olympia/users/templates/users/pwreset_confirm.html:47
-msgid "The password reset link was invalid, possibly because it has already been used.  Please request a new password reset."
+msgid "The password reset link was invalid, possibly because it has already been used. Please request a new password reset."
 msgstr ""
 
 #: src/olympia/users/templates/users/pwreset_request.html:15
@@ -12408,7 +12241,7 @@ msgstr ""
 
 #: src/olympia/users/templates/users/unsubscribe.html:30
 #, python-format
-msgid "Unfortunately, we weren't able to unsubscribe you.  The link you clicked is invalid. However, you can unsubscribe still unsubscribe on your <a href=\"%(edit_url)s\">edit profile page</a>."
+msgid "Unfortunately, we weren't able to unsubscribe you. The link you clicked is invalid. However, you can unsubscribe still unsubscribe on your <a href=\"%(edit_url)s\">edit profile page</a>."
 msgstr ""
 
 #: src/olympia/users/templates/users/vcard.html:2
@@ -12462,15 +12295,15 @@ msgstr ""
 msgid "Version History with Changelogs"
 msgstr ""
 
-#: src/olympia/versions/models.py:314
+#: src/olympia/versions/models.py:313
 msgid "Add-on uses binary components."
 msgstr ""
 
-#: src/olympia/versions/models.py:317
+#: src/olympia/versions/models.py:316
 msgid "Add-on has opted into strict compatibility checking."
 msgstr ""
 
-#: src/olympia/versions/models.py:715
+#: src/olympia/versions/models.py:711
 msgid "{app} {min} and later"
 msgstr ""
 
@@ -12545,4 +12378,8 @@ msgstr ""
 
 #: src/olympia/zadmin/forms.py:105
 msgid "Log emails instead of sending"
+msgstr ""
+
+#: src/olympia/zadmin/forms.py:215
+msgid "Deleted versions can`t be changed."
 msgstr ""

--- a/locale/lij/LC_MESSAGES/djangojs.po
+++ b/locale/lij/LC_MESSAGES/djangojs.po
@@ -1,1216 +1,1236 @@
-
 #, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2016-02-24 21:23+0000\n"
+"POT-Creation-Date: 2016-04-18 15:47+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
+"Language: \n"
 "MIME-Version: 1.0\n"
-"Content-Type: text/plain; charset=utf-8\n"
+"Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Generated-By: Babel 2.2.0\n"
 
-#: static/js/common/ratingwidget.js:31
+#: static/js/common-all.js:1426 static/js/impala-all.js:1511 static/js/zamboni/discovery-all.js:12598 static/js/zamboni/init.js:28 static/js/zamboni/mobile-all.js:14945
+msgid "This feature is temporarily disabled while we perform website maintenance. Please check back a little later."
+msgstr ""
+
+#. L10n: {0} is an app name like Firefox.
+#: static/js/common-all.js:1837 static/js/impala-all.js:1922 static/js/zamboni/buttons.js:73 static/js/zamboni/discovery-all.js:13108
+msgid "Accept and Install"
+msgstr ""
+
+#: static/js/common-all.js:1837 static/js/impala-all.js:1922 static/js/zamboni/buttons.js:73 static/js/zamboni/discovery-all.js:13108
+msgid "Add to {0}"
+msgstr ""
+
+#: static/js/common-all.js:1842 static/js/impala-all.js:1927 static/js/zamboni/buttons.js:78 static/js/zamboni/discovery-all.js:13113
+msgid "Download Now"
+msgstr ""
+
+#: static/js/common-all.js:1883 static/js/impala-all.js:1968 static/js/zamboni/buttons.js:119 static/js/zamboni/discovery-all.js:13154
+msgid "Add-on has not been updated to support default-to-compatible."
+msgstr ""
+
+#: static/js/common-all.js:1888 static/js/impala-all.js:1973 static/js/zamboni/buttons.js:124 static/js/zamboni/discovery-all.js:13159
+msgid "You need to be using Firefox 10.0 or higher."
+msgstr ""
+
+#: static/js/common-all.js:1900 static/js/impala-all.js:1985 static/js/zamboni/buttons.js:136 static/js/zamboni/discovery-all.js:13171
+msgid "Mozilla has marked this version as incompatible with your Firefox version."
+msgstr ""
+
+#. L10n: {0} is an platform like Windows or Linux.
+#: static/js/common-all.js:1981 static/js/impala-all.js:2066 static/js/zamboni/buttons.js:217 static/js/zamboni/discovery-all.js:13252
+msgid "Install for {0} anyway"
+msgstr ""
+
+#: static/js/common-all.js:1981 static/js/impala-all.js:2066 static/js/zamboni/buttons.js:217 static/js/zamboni/discovery-all.js:13252
+msgid "Download for {0} anyway"
+msgstr ""
+
+#: static/js/common-all.js:2038 static/js/impala-all.js:2123 static/js/zamboni/buttons.js:274 static/js/zamboni/discovery-all.js:13309
+msgid "Not available for your platform"
+msgstr ""
+
+#. L10n: {0} is an app name, {1} is the app version.
+#: static/js/common-all.js:2049 static/js/common-all.js:2086 static/js/impala-all.js:2134 static/js/impala-all.js:2171 static/js/zamboni/buttons.js:286 static/js/zamboni/buttons.js:324
+#: static/js/zamboni/discovery-all.js:13320 static/js/zamboni/discovery-all.js:13357
+msgid "Not available for {0} {1}"
+msgstr ""
+
+#: static/js/common-all.js:2112 static/js/impala-all.js:2197 static/js/zamboni/buttons.js:351 static/js/zamboni/discovery-all.js:13383
+msgid "Works with {app} {min} - {max}"
+msgstr ""
+
+#: static/js/common-all.js:2114 static/js/impala-all.js:2199 static/js/zamboni/buttons.js:353 static/js/zamboni/discovery-all.js:13385
+msgid "View other versions"
+msgstr ""
+
+#: static/js/common-all.js:2162 static/js/impala-all.js:2247 static/js/zamboni/buttons.js:401 static/js/zamboni/discovery-all.js:13433
+msgid "Only with Firefox — Get Firefox Now!"
+msgstr ""
+
+#: static/js/common-all.js:2278 static/js/impala-all.js:2363 static/js/zamboni/buttons.js:517 static/js/zamboni/discovery-all.js:13549 static/js/zamboni/mobile-all.js:15177
+#: static/js/zamboni/mobile/buttons.js:43
+msgid "Sorry, you need a Mozilla-based browser (such as Firefox) to install a search plugin."
+msgstr ""
+
+#: static/js/common-all.js:9088 static/js/impala-all.js:9649 static/js/zamboni/global.js:410
+msgid "Loading..."
+msgstr ""
+
+#. L10n: {0} is the number of characters left.
+#: static/js/common-all.js:9152 static/js/impala-all.js:9713 static/js/zamboni/global.js:474
+msgid "<b>{0}</b> character left."
+msgid_plural "<b>{0}</b> characters left."
+msgstr[0] ""
+msgstr[1] ""
+
+#: static/js/common-all.js:9589 static/js/common-min.js:6 static/js/impala-all.js:10052 static/js/impala-min.js:6 static/js/common/ratingwidget.js:31 static/js/zamboni/mobile-all.js:16123
+#: static/js/zamboni/mobile-min.js:6
 msgid "{0} star"
 msgid_plural "{0} stars"
 msgstr[0] ""
 msgstr[1] ""
 
-#: static/js/common/upload-addon.js:41 static/js/common/upload-image.js:128
+#: static/js/common-all.js:9676 static/js/common-min.js:6 static/js/impala-all.js:10139 static/js/impala-min.js:6 static/js/zamboni/l10n.js:45
+msgid "Remove this localization"
+msgstr ""
+
+#: static/js/common-all.js:10193 static/js/common-min.js:6 static/js/impala-all.js:10674 static/js/impala-min.js:6 static/js/zamboni/discovery-all.js:13678
+msgid "close"
+msgstr ""
+
+#: static/js/common-all.js:10860 static/js/common-min.js:6 static/js/impala-all.js:11481 static/js/impala-min.js:6 static/js/impala/reviews.js:23 static/js/zamboni/reviews.js:18
+msgid "Flagged for review"
+msgstr ""
+
+#: static/js/common-all.js:10876 static/js/common-min.js:6 static/js/impala-all.js:11498 static/js/impala-min.js:6 static/js/impala/reviews.js:40 static/js/zamboni/reviews.js:34
+msgid "Your input is required"
+msgstr ""
+
+#: static/js/common-all.js:10945 static/js/common-min.js:6 static/js/impala-all.js:11610 static/js/impala-min.js:7 static/js/impala/reviews.js:152 static/js/zamboni/reviews.js:103
+msgid "Marked for deletion"
+msgstr ""
+
+#: static/js/common-all.js:11573 static/js/common-min.js:7 static/js/impala-all.js:13809 static/js/impala-min.js:8 static/js/zamboni/collections.js:229
+msgid "Adding to Favorites&hellip;"
+msgstr ""
+
+#: static/js/common-all.js:11576 static/js/common-min.js:7 static/js/impala-all.js:13812 static/js/impala-min.js:8 static/js/zamboni/collections.js:232
+msgid "Removing Favorite&hellip;"
+msgstr ""
+
+#: static/js/common-all.js:11579 static/js/common-min.js:7 static/js/impala-all.js:13815 static/js/impala-min.js:8 static/js/zamboni/collections.js:235
+msgid "Add to Favorites"
+msgstr ""
+
+#: static/js/common-all.js:11582 static/js/common-min.js:7 static/js/impala-all.js:13818 static/js/impala-min.js:8 static/js/zamboni/collections.js:238
+msgid "Remove from Favorites"
+msgstr ""
+
+#: static/js/common-all.js:11647 static/js/common-min.js:7 static/js/impala-all.js:13883 static/js/impala-min.js:8 static/js/zamboni/collections.js:303
+msgid "Pending"
+msgstr ""
+
+#: static/js/common-all.js:11648 static/js/common-min.js:7 static/js/impala-all.js:13884 static/js/impala-min.js:8 static/js/zamboni/collections.js:304
+msgid "Add a comment"
+msgstr ""
+
+#: static/js/common-all.js:11648 static/js/common-min.js:7 static/js/impala-all.js:13884 static/js/impala-min.js:8 static/js/zamboni/collections.js:304
+msgid "Comment"
+msgstr ""
+
+#: static/js/common-all.js:11649 static/js/common-min.js:7 static/js/impala-all.js:13885 static/js/impala-min.js:8 static/js/zamboni/collections.js:305
+msgid "Remove this add-on from the collection"
+msgstr ""
+
+#: static/js/common-all.js:11649 static/js/common-all.js:11678 static/js/common-min.js:7 static/js/impala-all.js:13885 static/js/impala-all.js:13914 static/js/impala-min.js:8
+#: static/js/zamboni/collections.js:305 static/js/zamboni/collections.js:334
+msgid "Remove"
+msgstr ""
+
+#: static/js/common-all.js:11678 static/js/common-min.js:7 static/js/impala-all.js:13914 static/js/impala-min.js:8 static/js/zamboni/collections.js:334
+msgid "Remove this user as a contributor"
+msgstr ""
+
+#: static/js/common-all.js:11690 static/js/common-min.js:7 static/js/impala-all.js:13926 static/js/impala-min.js:8 static/js/zamboni/collections.js:346
+msgid "An email address is required."
+msgstr ""
+
+#: static/js/common-all.js:11708 static/js/common-min.js:7 static/js/impala-all.js:13944 static/js/impala-min.js:8 static/js/zamboni/collections.js:364
+msgid "You cannot add yourself as a contributor."
+msgstr ""
+
+#: static/js/common-all.js:11710 static/js/common-min.js:7 static/js/impala-all.js:13946 static/js/impala-min.js:8 static/js/zamboni/collections.js:366
+msgid "You have already added that user."
+msgstr ""
+
+#: static/js/common-all.js:11917 static/js/common-min.js:7 static/js/impala-all.js:14153 static/js/impala-min.js:8 static/js/zamboni/collections.js:573
+msgid "Add to favorites"
+msgstr ""
+
+#: static/js/common-all.js:11921 static/js/common-min.js:7 static/js/impala-all.js:14157 static/js/impala-min.js:8 static/js/zamboni/collections.js:577
+msgid "Remove from favorites"
+msgstr ""
+
+#: static/js/common-all.js:11939 static/js/common-min.js:7 static/js/impala-all.js:14175 static/js/impala-all.js:14233 static/js/impala-min.js:8 static/js/impala/collections.js:10
+#: static/js/zamboni/collections.js:595
+msgid "Follow this Collection"
+msgstr ""
+
+#: static/js/common-all.js:11948 static/js/common-min.js:7 static/js/impala-all.js:14184 static/js/impala-min.js:8 static/js/zamboni/collections.js:604
+msgid "Stop following"
+msgstr ""
+
+#: static/js/common-all.js:12096 static/js/common-min.js:7 static/js/zamboni/password-strength.js:20
+msgid "Password strength:"
+msgstr ""
+
+#: static/js/common-all.js:12102 static/js/common-min.js:7 static/js/zamboni/password-strength.js:26
+msgid "At least {0} character left."
+msgid_plural "At least {0} characters left."
+msgstr[0] ""
+msgstr[1] ""
+
+#: static/js/common-all.js:12286 static/js/common-min.js:7 static/js/impala-all.js:14632 static/js/impala-min.js:8 static/js/impala/suggestions.js:39
+msgid "Search themes for <b>{0}</b>"
+msgstr ""
+
+#: static/js/common-all.js:12288 static/js/common-min.js:7 static/js/impala-all.js:14634 static/js/impala-min.js:8 static/js/impala/suggestions.js:41
+msgid "Search apps for <b>{0}</b>"
+msgstr ""
+
+#: static/js/common-all.js:12290 static/js/common-min.js:7 static/js/impala-all.js:14636 static/js/impala-min.js:8 static/js/impala/suggestions.js:43
+msgid "Search add-ons for <b>{0}</b>"
+msgstr ""
+
+#: static/js/common-all.js:12521 static/js/common-min.js:7 static/js/impala-all.js:14867 static/js/impala-min.js:8 static/js/impala/site_suggestions.js:46
+msgid "Category"
+msgstr ""
+
+#. L10n: {0} is an app name.
+#: static/js/impala-all.js:11632 static/js/impala-min.js:7 static/js/impala/listing.js:11 static/js/zamboni/themes.js:13
+msgid "This theme is incompatible with your version of {0}"
+msgstr ""
+
+#: static/js/impala-all.js:12146 static/js/impala-all.js:14331 static/js/impala-min.js:7 static/js/impala-min.js:8 static/js/common/upload-image.js:97 static/js/impala/users.js:51
+#: static/js/zamboni/devhub-all.js:894 static/js/zamboni/devhub-min.js:1
+msgid "Images must be either PNG or JPG."
+msgstr ""
+
+#: static/js/impala-all.js:12150 static/js/impala-min.js:7 static/js/common/upload-image.js:101 static/js/zamboni/devhub-all.js:898 static/js/zamboni/devhub-min.js:1
+msgid "Videos must be in WebM."
+msgstr ""
+
+#: static/js/impala-all.js:12177 static/js/impala-min.js:7 static/js/common/upload-addon.js:41 static/js/common/upload-image.js:128 static/js/zamboni/devhub-all.js:272
+#: static/js/zamboni/devhub-all.js:925 static/js/zamboni/devhub-min.js:1
 msgid "There was a problem contacting the server."
 msgstr ""
 
-#: static/js/common/upload-addon.js:69
+#: static/js/impala-all.js:13298 static/js/impala-min.js:7 static/js/impala/persona_creation.js:60
+msgid "All Rights Reserved"
+msgstr ""
+
+#: static/js/impala-all.js:13302 static/js/impala-min.js:7 static/js/impala/persona_creation.js:64
+msgid "Creative Commons Attribution 3.0"
+msgstr ""
+
+#: static/js/impala-all.js:13307 static/js/impala-min.js:7 static/js/impala/persona_creation.js:69
+msgid "Creative Commons Attribution-NonCommercial 3.0"
+msgstr ""
+
+#: static/js/impala-all.js:13312 static/js/impala-min.js:7 static/js/impala/persona_creation.js:74
+msgid "Creative Commons Attribution-NonCommercial-NoDerivs 3.0"
+msgstr ""
+
+#: static/js/impala-all.js:13317 static/js/impala-min.js:7 static/js/impala/persona_creation.js:79
+msgid "Creative Commons Attribution-NonCommercial-Share Alike 3.0"
+msgstr ""
+
+#: static/js/impala-all.js:13322 static/js/impala-min.js:7 static/js/impala/persona_creation.js:84
+msgid "Creative Commons Attribution-NoDerivs 3.0"
+msgstr ""
+
+#: static/js/impala-all.js:13327 static/js/impala-min.js:7 static/js/impala/persona_creation.js:89
+msgid "Creative Commons Attribution-ShareAlike 3.0"
+msgstr ""
+
+#: static/js/impala-all.js:13530 static/js/impala-min.js:7 static/js/impala/persona_creation.js:292
+msgid "Your Theme's Name"
+msgstr ""
+
+#: static/js/impala-all.js:14242 static/js/impala-min.js:8 static/js/impala/collections.js:19
+msgid "Stop Following"
+msgstr ""
+
+#: static/js/impala-all.js:14243 static/js/impala-min.js:8 static/js/impala/collections.js:20
+msgid "Following"
+msgstr ""
+
+#: static/js/impala-all.js:14313 static/js/impala-min.js:8 static/js/impala/users.js:33
+msgid "use original"
+msgstr ""
+
+#: static/js/impala-all.js:14523 static/js/impala-min.js:8 static/js/impala/search.js:114
+msgid "Updating results&hellip;"
+msgstr ""
+
+#: static/js/common/upload-addon.js:69 static/js/zamboni/devhub-all.js:300 static/js/zamboni/devhub-min.js:1
 msgid "Select a file..."
 msgstr ""
 
-#: static/js/common/upload-addon.js:70
+#: static/js/common/upload-addon.js:70 static/js/zamboni/devhub-all.js:301 static/js/zamboni/devhub-min.js:1
 msgid "Your add-on should end with .xpi, .jar or .xml"
 msgstr ""
 
 #. L10n: {0} is the percent of the file that has been uploaded.
-#: static/js/common/upload-addon.js:104
+#: static/js/common/upload-addon.js:104 static/js/zamboni/devhub-all.js:335 static/js/zamboni/devhub-min.js:1
 #, python-format
 msgid "{0}% complete"
 msgstr ""
 
 #. L10n: "{bytes uploaded} of {total filesize}".
-#: static/js/common/upload-addon.js:107
+#: static/js/common/upload-addon.js:107 static/js/zamboni/devhub-all.js:338 static/js/zamboni/devhub-min.js:1
 msgid "{0} of {1}"
 msgstr ""
 
-#: static/js/common/upload-addon.js:140
+#: static/js/common/upload-addon.js:140 static/js/zamboni/devhub-all.js:371 static/js/zamboni/devhub-min.js:1
 msgid "Cancel"
 msgstr ""
 
-#: static/js/common/upload-addon.js:162
+#: static/js/common/upload-addon.js:162 static/js/zamboni/devhub-all.js:393 static/js/zamboni/devhub-min.js:1
 msgid "Uploading {0}"
 msgstr ""
 
-#: static/js/common/upload-addon.js:189
+#: static/js/common/upload-addon.js:189 static/js/zamboni/devhub-all.js:420 static/js/zamboni/devhub-min.js:1
 msgid "Error with {0}"
 msgstr ""
 
-#: static/js/common/upload-addon.js:194
+#: static/js/common/upload-addon.js:194 static/js/zamboni/devhub-all.js:425 static/js/zamboni/devhub-min.js:1
 msgid "Your add-on failed validation with {0} error."
 msgid_plural "Your add-on failed validation with {0} errors."
 msgstr[0] ""
 msgstr[1] ""
 
-#: static/js/common/upload-addon.js:208
+#: static/js/common/upload-addon.js:208 static/js/zamboni/devhub-all.js:439 static/js/zamboni/devhub-min.js:1
 msgid "&hellip;and {0} more"
 msgid_plural "&hellip;and {0} more"
 msgstr[0] ""
 msgstr[1] ""
 
-#: static/js/common/upload-addon.js:222 static/js/common/upload-addon.js:512
+#: static/js/common/upload-addon.js:222 static/js/common/upload-addon.js:497 static/js/zamboni/devhub-all.js:453 static/js/zamboni/devhub-all.js:743 static/js/zamboni/devhub-min.js:1
 msgid "See full validation report"
 msgstr ""
 
-#: static/js/common/upload-addon.js:234
+#: static/js/common/upload-addon.js:234 static/js/zamboni/devhub-all.js:465 static/js/zamboni/devhub-min.js:1
 msgid "Validating {0}"
 msgstr ""
 
 #. L10n: first argument is an HTTP status code
-#: static/js/common/upload-addon.js:273
+#: static/js/common/upload-addon.js:273 static/js/zamboni/devhub-all.js:504 static/js/zamboni/devhub-min.js:1
 msgid "Received an empty response from the server; status: {0}"
 msgstr ""
 
-#: static/js/common/upload-addon.js:373
+#: static/js/common/upload-addon.js:370 static/js/zamboni/devhub-all.js:604 static/js/zamboni/devhub-min.js:1
 msgid "Unexpected server error while validating."
 msgstr ""
 
-#: static/js/common/upload-addon.js:412
+#: static/js/common/upload-addon.js:409 static/js/zamboni/devhub-all.js:643 static/js/zamboni/devhub-min.js:1
 msgid "Finished validating {0}"
 msgstr ""
 
-#: static/js/common/upload-addon.js:418
+#: static/js/common/upload-addon.js:415 static/js/zamboni/devhub-all.js:649 static/js/zamboni/devhub-min.js:1
 msgid "Your add-on validation timed out, it will be manually reviewed."
 msgstr ""
 
-#: static/js/common/upload-addon.js:421
+#: static/js/common/upload-addon.js:418 static/js/zamboni/devhub-all.js:652 static/js/zamboni/devhub-min.js:1
 msgid "Your add-on was validated with no errors and {0} warning."
 msgid_plural "Your add-on was validated with no errors and {0} warnings."
 msgstr[0] ""
 msgstr[1] ""
 
-#: static/js/common/upload-addon.js:426
+#: static/js/common/upload-addon.js:423 static/js/zamboni/devhub-all.js:657 static/js/zamboni/devhub-min.js:1
 msgid "Your add-on was validated with no errors and {0} message."
 msgid_plural "Your add-on was validated with no errors and {0} messages."
 msgstr[0] ""
 msgstr[1] ""
 
-#: static/js/common/upload-addon.js:431
+#: static/js/common/upload-addon.js:428 static/js/zamboni/devhub-all.js:662 static/js/zamboni/devhub-min.js:1
 msgid "Your add-on was validated with no errors or warnings."
 msgstr ""
 
-#: static/js/common/upload-addon.js:446
+#: static/js/common/upload-addon.js:443 static/js/zamboni/devhub-all.js:677 static/js/zamboni/devhub-min.js:1
 msgid "Your submission will be automatically signed."
 msgstr ""
 
-#: static/js/common/upload-addon.js:465
+#: static/js/common/upload-addon.js:450 static/js/zamboni/devhub-all.js:696 static/js/zamboni/devhub-min.js:1
 msgid "Include detailed version notes (this can be done in the next step)."
 msgstr ""
 
-#: static/js/common/upload-addon.js:466
+#: static/js/common/upload-addon.js:451 static/js/zamboni/devhub-all.js:697 static/js/zamboni/devhub-min.js:1
 msgid "If your add-on requires an account to a website in order to be fully tested, include a test username and password in the Notes to Reviewer (this can be done in the next step)."
 msgstr ""
 
-#: static/js/common/upload-addon.js:467
+#: static/js/common/upload-addon.js:452 static/js/zamboni/devhub-all.js:698 static/js/zamboni/devhub-min.js:1
 msgid "If your add-on is intended for a limited audience you should choose Preliminary Review instead of Full Review."
 msgstr ""
 
-#: static/js/common/upload-addon.js:480
+#: static/js/common/upload-addon.js:465 static/js/zamboni/devhub-all.js:711 static/js/zamboni/devhub-min.js:1
 msgid "Add-on submission checklist"
 msgstr ""
 
-#: static/js/common/upload-addon.js:481
+#: static/js/common/upload-addon.js:466 static/js/zamboni/devhub-all.js:712 static/js/zamboni/devhub-min.js:1
 msgid "Please verify the following points before finalizing your submission. This will minimize delays or misunderstanding during the review process:"
 msgstr ""
 
-#: static/js/common/upload-addon.js:483
+#: static/js/common/upload-addon.js:468 static/js/zamboni/devhub-all.js:714 static/js/zamboni/devhub-min.js:1
 msgid ""
 "Compiled binaries, as well as minified or obfuscated scripts (excluding known libraries) need to have their sources submitted separately for review. Make sure that you use the source code upload "
 "field to avoid having your submission rejected."
 msgstr ""
 
-#: static/js/common/upload-addon.js:501
+#: static/js/common/upload-addon.js:486 static/js/zamboni/devhub-all.js:732 static/js/zamboni/devhub-min.js:1
 msgid "The validation process found these issues that can lead to rejections:"
 msgstr ""
 
-#: static/js/common/upload-addon.js:518
+#: static/js/common/upload-addon.js:503 static/js/zamboni/devhub-all.js:749 static/js/zamboni/devhub-min.js:1
 msgid "If you are unfamiliar with the add-ons review process, you can read about it here."
 msgstr ""
 
-#: static/js/common/upload-addon.js:555
+#: static/js/common/upload-addon.js:540 static/js/zamboni/devhub-all.js:786 static/js/zamboni/devhub-min.js:1
 msgid "Sorry, no supported platform has been found."
 msgstr ""
 
-#: static/js/common/upload-base.js:57
+#: static/js/common/upload-base.js:57 static/js/zamboni/devhub-all.js:187 static/js/zamboni/devhub-min.js:1
 msgid "The filetype you uploaded isn't recognized."
 msgstr ""
 
-#: static/js/common/upload-base.js:79
+#: static/js/common/upload-base.js:79 static/js/zamboni/devhub-all.js:209 static/js/zamboni/devhub-min.js:1
 msgid "You cancelled the upload."
 msgstr ""
 
-#: static/js/common/upload-image.js:97 static/js/impala/users.js:51
-msgid "Images must be either PNG or JPG."
-msgstr ""
-
-#: static/js/common/upload-image.js:101
-msgid "Videos must be in WebM."
-msgstr ""
-
-#: static/js/impala/collections.js:10 static/js/zamboni/collections.js:595
-msgid "Follow this Collection"
-msgstr ""
-
-#: static/js/impala/collections.js:19
-msgid "Stop Following"
-msgstr ""
-
-#: static/js/impala/collections.js:20
-msgid "Following"
-msgstr ""
-
-#. L10n: {0} is an app name.
-#: static/js/impala/listing.js:11 static/js/zamboni/themes.js:13
-msgid "This theme is incompatible with your version of {0}"
-msgstr ""
-
-#: static/js/impala/persona_creation.js:60
-msgid "All Rights Reserved"
-msgstr ""
-
-#: static/js/impala/persona_creation.js:64
-msgid "Creative Commons Attribution 3.0"
-msgstr ""
-
-#: static/js/impala/persona_creation.js:69
-msgid "Creative Commons Attribution-NonCommercial 3.0"
-msgstr ""
-
-#: static/js/impala/persona_creation.js:74
-msgid "Creative Commons Attribution-NonCommercial-NoDerivs 3.0"
-msgstr ""
-
-#: static/js/impala/persona_creation.js:79
-msgid "Creative Commons Attribution-NonCommercial-Share Alike 3.0"
-msgstr ""
-
-#: static/js/impala/persona_creation.js:84
-msgid "Creative Commons Attribution-NoDerivs 3.0"
-msgstr ""
-
-#: static/js/impala/persona_creation.js:89
-msgid "Creative Commons Attribution-ShareAlike 3.0"
-msgstr ""
-
-#: static/js/impala/persona_creation.js:292
-msgid "Your Theme's Name"
-msgstr ""
-
-#: static/js/impala/reviews.js:23 static/js/zamboni/reviews.js:18
-msgid "Flagged for review"
-msgstr ""
-
-#: static/js/impala/reviews.js:40 static/js/zamboni/reviews.js:34
-msgid "Your input is required"
-msgstr ""
-
-#: static/js/impala/reviews.js:152 static/js/zamboni/reviews.js:103
-msgid "Marked for deletion"
-msgstr ""
-
-#: static/js/impala/search.js:114
-msgid "Updating results&hellip;"
-msgstr ""
-
-#: static/js/impala/site_suggestions.js:46
-msgid "Category"
-msgstr ""
-
-#: static/js/impala/suggestions.js:39
-msgid "Search themes for <b>{0}</b>"
-msgstr ""
-
-#: static/js/impala/suggestions.js:41
-msgid "Search apps for <b>{0}</b>"
-msgstr ""
-
-#: static/js/impala/suggestions.js:43
-msgid "Search add-ons for <b>{0}</b>"
-msgstr ""
-
-#: static/js/impala/users.js:33
-msgid "use original"
-msgstr ""
-
-#: static/js/impala/stats/chart.js:267
+#: static/js/impala/stats/chart.js:267 static/js/zamboni/stats-all.js:16898 static/js/zamboni/stats-min.js:5
 msgid "Week of {0}"
 msgstr ""
 
-#: static/js/impala/stats/chart.js:269
+#: static/js/impala/stats/chart.js:269 static/js/zamboni/stats-all.js:16900 static/js/zamboni/stats-min.js:5
 msgid " downloads"
 msgstr ""
 
-#: static/js/impala/stats/chart.js:270
+#: static/js/impala/stats/chart.js:270 static/js/zamboni/stats-all.js:16901 static/js/zamboni/stats-min.js:5
 msgid "{0} users"
 msgstr ""
 
-#: static/js/impala/stats/chart.js:271
+#: static/js/impala/stats/chart.js:271 static/js/zamboni/stats-all.js:16902 static/js/zamboni/stats-min.js:5
 msgid "{0} add-ons"
 msgstr ""
 
-#: static/js/impala/stats/chart.js:272
+#: static/js/impala/stats/chart.js:272 static/js/zamboni/stats-all.js:16903 static/js/zamboni/stats-min.js:5
 msgid "{0} collections"
 msgstr ""
 
-#: static/js/impala/stats/chart.js:273
+#: static/js/impala/stats/chart.js:273 static/js/zamboni/stats-all.js:16904 static/js/zamboni/stats-min.js:5
 msgid "{0} reviews"
 msgstr ""
 
-#: static/js/impala/stats/chart.js:275
+#: static/js/impala/stats/chart.js:275 static/js/zamboni/stats-all.js:16906 static/js/zamboni/stats-min.js:5
 msgid "{0} sales"
 msgstr ""
 
-#: static/js/impala/stats/chart.js:276
+#: static/js/impala/stats/chart.js:276 static/js/zamboni/stats-all.js:16907 static/js/zamboni/stats-min.js:5
 msgid "{0} refunds"
 msgstr ""
 
-#: static/js/impala/stats/chart.js:277
+#: static/js/impala/stats/chart.js:277 static/js/zamboni/stats-all.js:16908 static/js/zamboni/stats-min.js:5
 msgid "{0} installs"
 msgstr ""
 
-#: static/js/impala/stats/chart.js:369 static/js/impala/stats/csv_keys.js:3 static/js/impala/stats/csv_keys.js:109
+#: static/js/impala/stats/chart.js:369 static/js/impala/stats/csv_keys.js:3 static/js/impala/stats/csv_keys.js:109 static/js/zamboni/stats-all.js:15284 static/js/zamboni/stats-all.js:15390
+#: static/js/zamboni/stats-all.js:17000 static/js/zamboni/stats-min.js:4 static/js/zamboni/stats-min.js:5
 msgid "Downloads"
 msgstr ""
 
-#: static/js/impala/stats/chart.js:379 static/js/impala/stats/csv_keys.js:6 static/js/impala/stats/csv_keys.js:110
+#: static/js/impala/stats/chart.js:379 static/js/impala/stats/csv_keys.js:6 static/js/impala/stats/csv_keys.js:110 static/js/zamboni/stats-all.js:15287 static/js/zamboni/stats-all.js:15391
+#: static/js/zamboni/stats-all.js:17010 static/js/zamboni/stats-min.js:4 static/js/zamboni/stats-min.js:5
 msgid "Daily Users"
 msgstr ""
 
-#: static/js/impala/stats/chart.js:410
+#: static/js/impala/stats/chart.js:410 static/js/zamboni/stats-all.js:17041 static/js/zamboni/stats-min.js:5
 msgid "Amount, in USD"
 msgstr ""
 
-#: static/js/impala/stats/chart.js:421 static/js/impala/stats/csv_keys.js:104
+#: static/js/impala/stats/chart.js:421 static/js/impala/stats/csv_keys.js:104 static/js/zamboni/stats-all.js:15385 static/js/zamboni/stats-all.js:17052 static/js/zamboni/stats-min.js:5
 msgid "Number of Contributions"
 msgstr ""
 
-#: static/js/impala/stats/chart.js:447
+#: static/js/impala/stats/chart.js:447 static/js/zamboni/stats-all.js:17078 static/js/zamboni/stats-min.js:5
 msgid "More Info..."
 msgstr ""
 
 #. L10n: {0} is an ISO-formatted date.
-#: static/js/impala/stats/chart.js:451
+#: static/js/impala/stats/chart.js:451 static/js/zamboni/stats-all.js:17082 static/js/zamboni/stats-min.js:5
 msgid "Details for {0}"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:9
+#: static/js/impala/stats/csv_keys.js:9 static/js/zamboni/stats-all.js:15290 static/js/zamboni/stats-min.js:4
 msgid "Collections Created"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:12
+#: static/js/impala/stats/csv_keys.js:12 static/js/zamboni/stats-all.js:15293 static/js/zamboni/stats-min.js:4
 msgid "Add-ons in Use"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:15
+#: static/js/impala/stats/csv_keys.js:15 static/js/zamboni/stats-all.js:15296 static/js/zamboni/stats-min.js:4
 msgid "Add-ons Created"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:18
+#: static/js/impala/stats/csv_keys.js:18 static/js/zamboni/stats-all.js:15299 static/js/zamboni/stats-min.js:4
 msgid "Add-ons Downloaded"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:21
+#: static/js/impala/stats/csv_keys.js:21 static/js/zamboni/stats-all.js:15302 static/js/zamboni/stats-min.js:4
 msgid "Add-ons Updated"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:24
+#: static/js/impala/stats/csv_keys.js:24 static/js/zamboni/stats-all.js:15305 static/js/zamboni/stats-min.js:4
 msgid "Reviews Written"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:27
+#: static/js/impala/stats/csv_keys.js:27 static/js/zamboni/stats-all.js:15308 static/js/zamboni/stats-min.js:4
 msgid "User Signups"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:30
+#: static/js/impala/stats/csv_keys.js:30 static/js/zamboni/stats-all.js:15311 static/js/zamboni/stats-min.js:4
 msgid "Subscribers"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:33
+#: static/js/impala/stats/csv_keys.js:33 static/js/zamboni/stats-all.js:15314 static/js/zamboni/stats-min.js:4
 msgid "Ratings"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:36 static/js/impala/stats/csv_keys.js:114
+#: static/js/impala/stats/csv_keys.js:36 static/js/impala/stats/csv_keys.js:114 static/js/zamboni/stats-all.js:15317 static/js/zamboni/stats-all.js:15395 static/js/zamboni/stats-min.js:4
+#: static/js/zamboni/stats-min.js:5
 msgid "Sales"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:39 static/js/impala/stats/csv_keys.js:113
+#: static/js/impala/stats/csv_keys.js:39 static/js/impala/stats/csv_keys.js:113 static/js/zamboni/stats-all.js:15320 static/js/zamboni/stats-all.js:15394 static/js/zamboni/stats-min.js:4
+#: static/js/zamboni/stats-min.js:5
 msgid "Installs"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:42
+#: static/js/impala/stats/csv_keys.js:42 static/js/zamboni/stats-all.js:15323 static/js/zamboni/stats-min.js:4
 msgid "Unknown"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:43
+#: static/js/impala/stats/csv_keys.js:43 static/js/zamboni/stats-all.js:15324 static/js/zamboni/stats-min.js:4
 msgid "Add-ons Manager"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:44
+#: static/js/impala/stats/csv_keys.js:44 static/js/zamboni/stats-all.js:15325 static/js/zamboni/stats-min.js:4
 msgid "Add-ons Manager Promo"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:45
+#: static/js/impala/stats/csv_keys.js:45 static/js/zamboni/stats-all.js:15326 static/js/zamboni/stats-min.js:4
 msgid "Add-ons Manager Featured"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:46
+#: static/js/impala/stats/csv_keys.js:46 static/js/zamboni/stats-all.js:15327 static/js/zamboni/stats-min.js:4
 msgid "Add-ons Manager Learn More"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:47
+#: static/js/impala/stats/csv_keys.js:47 static/js/zamboni/stats-all.js:15328 static/js/zamboni/stats-min.js:4
 msgid "Search Suggestions"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:48
+#: static/js/impala/stats/csv_keys.js:48 static/js/zamboni/stats-all.js:15329 static/js/zamboni/stats-min.js:4
 msgid "Search Results"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:49 static/js/impala/stats/csv_keys.js:50 static/js/impala/stats/csv_keys.js:51
+#: static/js/impala/stats/csv_keys.js:49 static/js/impala/stats/csv_keys.js:50 static/js/impala/stats/csv_keys.js:51 static/js/zamboni/stats-all.js:15330 static/js/zamboni/stats-all.js:15331
+#: static/js/zamboni/stats-all.js:15332 static/js/zamboni/stats-min.js:4
 msgid "Homepage Promo"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:52 static/js/impala/stats/csv_keys.js:53
+#: static/js/impala/stats/csv_keys.js:52 static/js/impala/stats/csv_keys.js:53 static/js/zamboni/stats-all.js:15333 static/js/zamboni/stats-all.js:15334 static/js/zamboni/stats-min.js:4
 msgid "Homepage Featured"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:54 static/js/impala/stats/csv_keys.js:55
+#: static/js/impala/stats/csv_keys.js:54 static/js/impala/stats/csv_keys.js:55 static/js/zamboni/stats-all.js:15335 static/js/zamboni/stats-all.js:15336 static/js/zamboni/stats-min.js:4
 msgid "Homepage Up and Coming"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:56
+#: static/js/impala/stats/csv_keys.js:56 static/js/zamboni/stats-all.js:15337 static/js/zamboni/stats-min.js:4
 msgid "Homepage Most Popular"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:57 static/js/impala/stats/csv_keys.js:59
+#: static/js/impala/stats/csv_keys.js:57 static/js/impala/stats/csv_keys.js:59 static/js/zamboni/stats-all.js:15338 static/js/zamboni/stats-all.js:15340 static/js/zamboni/stats-min.js:4
 msgid "Detail Page"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:58 static/js/impala/stats/csv_keys.js:60
+#: static/js/impala/stats/csv_keys.js:58 static/js/impala/stats/csv_keys.js:60 static/js/zamboni/stats-all.js:15339 static/js/zamboni/stats-all.js:15341 static/js/zamboni/stats-min.js:4
 msgid "Detail Page (bottom)"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:61
+#: static/js/impala/stats/csv_keys.js:61 static/js/zamboni/stats-all.js:15342 static/js/zamboni/stats-min.js:4
 msgid "Detail Page (Development Channel)"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:62 static/js/impala/stats/csv_keys.js:63 static/js/impala/stats/csv_keys.js:64
+#: static/js/impala/stats/csv_keys.js:62 static/js/impala/stats/csv_keys.js:63 static/js/impala/stats/csv_keys.js:64 static/js/zamboni/stats-all.js:15343 static/js/zamboni/stats-all.js:15344
+#: static/js/zamboni/stats-all.js:15345 static/js/zamboni/stats-min.js:4
 msgid "Often Used With"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:65 static/js/impala/stats/csv_keys.js:66
+#: static/js/impala/stats/csv_keys.js:65 static/js/impala/stats/csv_keys.js:66 static/js/zamboni/stats-all.js:15346 static/js/zamboni/stats-all.js:15347 static/js/zamboni/stats-min.js:4
 msgid "Others By Author"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:67 static/js/impala/stats/csv_keys.js:68
+#: static/js/impala/stats/csv_keys.js:67 static/js/impala/stats/csv_keys.js:68 static/js/zamboni/stats-all.js:15348 static/js/zamboni/stats-all.js:15349 static/js/zamboni/stats-min.js:4
 msgid "Dependencies"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:69 static/js/impala/stats/csv_keys.js:70
+#: static/js/impala/stats/csv_keys.js:69 static/js/impala/stats/csv_keys.js:70 static/js/zamboni/stats-all.js:15350 static/js/zamboni/stats-all.js:15351 static/js/zamboni/stats-min.js:4
 msgid "Upsell"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:71
+#: static/js/impala/stats/csv_keys.js:71 static/js/zamboni/stats-all.js:15352 static/js/zamboni/stats-min.js:4
 msgid "Meet the Developer"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:72
+#: static/js/impala/stats/csv_keys.js:72 static/js/zamboni/stats-all.js:15353 static/js/zamboni/stats-min.js:4
 msgid "User Profile"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:73
+#: static/js/impala/stats/csv_keys.js:73 static/js/zamboni/stats-all.js:15354 static/js/zamboni/stats-min.js:4
 msgid "Version History"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:75
+#: static/js/impala/stats/csv_keys.js:75 static/js/zamboni/stats-all.js:15356 static/js/zamboni/stats-min.js:4
 msgid "Sharing"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:76
+#: static/js/impala/stats/csv_keys.js:76 static/js/zamboni/stats-all.js:15357 static/js/zamboni/stats-min.js:4
 msgid "Category Pages"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:77
+#: static/js/impala/stats/csv_keys.js:77 static/js/zamboni/stats-all.js:15358 static/js/zamboni/stats-min.js:4
 msgid "Collections"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:78 static/js/impala/stats/csv_keys.js:79
+#: static/js/impala/stats/csv_keys.js:78 static/js/impala/stats/csv_keys.js:79 static/js/zamboni/stats-all.js:15359 static/js/zamboni/stats-all.js:15360 static/js/zamboni/stats-min.js:4
 msgid "Category Landing Featured Carousel"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:80 static/js/impala/stats/csv_keys.js:81
+#: static/js/impala/stats/csv_keys.js:80 static/js/impala/stats/csv_keys.js:81 static/js/zamboni/stats-all.js:15361 static/js/zamboni/stats-all.js:15362 static/js/zamboni/stats-min.js:4
 msgid "Category Landing Top Rated"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:82 static/js/impala/stats/csv_keys.js:83
+#: static/js/impala/stats/csv_keys.js:82 static/js/impala/stats/csv_keys.js:83 static/js/zamboni/stats-all.js:15363 static/js/zamboni/stats-all.js:15364 static/js/zamboni/stats-min.js:5
 msgid "Category Landing Most Popular"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:84 static/js/impala/stats/csv_keys.js:85
+#: static/js/impala/stats/csv_keys.js:84 static/js/impala/stats/csv_keys.js:85 static/js/zamboni/stats-all.js:15365 static/js/zamboni/stats-all.js:15366 static/js/zamboni/stats-min.js:5
 msgid "Category Landing Recently Added"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:86 static/js/impala/stats/csv_keys.js:87
+#: static/js/impala/stats/csv_keys.js:86 static/js/impala/stats/csv_keys.js:87 static/js/zamboni/stats-all.js:15367 static/js/zamboni/stats-all.js:15368 static/js/zamboni/stats-min.js:5
 msgid "Browse Listing Featured Sort"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:88 static/js/impala/stats/csv_keys.js:89
+#: static/js/impala/stats/csv_keys.js:88 static/js/impala/stats/csv_keys.js:89 static/js/zamboni/stats-all.js:15369 static/js/zamboni/stats-all.js:15370 static/js/zamboni/stats-min.js:5
 msgid "Browse Listing Users Sort"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:90 static/js/impala/stats/csv_keys.js:91
+#: static/js/impala/stats/csv_keys.js:90 static/js/impala/stats/csv_keys.js:91 static/js/zamboni/stats-all.js:15371 static/js/zamboni/stats-all.js:15372 static/js/zamboni/stats-min.js:5
 msgid "Browse Listing Rating Sort"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:92 static/js/impala/stats/csv_keys.js:93
+#: static/js/impala/stats/csv_keys.js:92 static/js/impala/stats/csv_keys.js:93 static/js/zamboni/stats-all.js:15373 static/js/zamboni/stats-all.js:15374 static/js/zamboni/stats-min.js:5
 msgid "Browse Listing Created Sort"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:94 static/js/impala/stats/csv_keys.js:95
+#: static/js/impala/stats/csv_keys.js:94 static/js/impala/stats/csv_keys.js:95 static/js/zamboni/stats-all.js:15375 static/js/zamboni/stats-all.js:15376 static/js/zamboni/stats-min.js:5
 msgid "Browse Listing Name Sort"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:96 static/js/impala/stats/csv_keys.js:97
+#: static/js/impala/stats/csv_keys.js:96 static/js/impala/stats/csv_keys.js:97 static/js/zamboni/stats-all.js:15377 static/js/zamboni/stats-all.js:15378 static/js/zamboni/stats-min.js:5
 msgid "Browse Listing Popular Sort"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:98 static/js/impala/stats/csv_keys.js:99
+#: static/js/impala/stats/csv_keys.js:98 static/js/impala/stats/csv_keys.js:99 static/js/zamboni/stats-all.js:15379 static/js/zamboni/stats-all.js:15380 static/js/zamboni/stats-min.js:5
 msgid "Browse Listing Updated Sort"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:100 static/js/impala/stats/csv_keys.js:101
+#: static/js/impala/stats/csv_keys.js:100 static/js/impala/stats/csv_keys.js:101 static/js/zamboni/stats-all.js:15381 static/js/zamboni/stats-all.js:15382 static/js/zamboni/stats-min.js:5
 msgid "Browse Listing Up and Coming Sort"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:105
+#: static/js/impala/stats/csv_keys.js:105 static/js/zamboni/stats-all.js:15386 static/js/zamboni/stats-min.js:5
 msgid "Total Amount Contributed"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:106
+#: static/js/impala/stats/csv_keys.js:106 static/js/zamboni/stats-all.js:15387 static/js/zamboni/stats-min.js:5
 msgid "Average Contribution"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:115
+#: static/js/impala/stats/csv_keys.js:115 static/js/zamboni/stats-all.js:15396 static/js/zamboni/stats-min.js:5
 msgid "Usage"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:118
+#: static/js/impala/stats/csv_keys.js:118 static/js/zamboni/stats-all.js:15399 static/js/zamboni/stats-min.js:5
 msgid "Firefox"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:119
+#: static/js/impala/stats/csv_keys.js:119 static/js/zamboni/stats-all.js:15400 static/js/zamboni/stats-min.js:5
 msgid "Mozilla"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:120
+#: static/js/impala/stats/csv_keys.js:120 static/js/zamboni/stats-all.js:15401 static/js/zamboni/stats-min.js:5
 msgid "Thunderbird"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:121
+#: static/js/impala/stats/csv_keys.js:121 static/js/zamboni/stats-all.js:15402 static/js/zamboni/stats-min.js:5
 msgid "Sunbird"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:122
+#: static/js/impala/stats/csv_keys.js:122 static/js/zamboni/stats-all.js:15403 static/js/zamboni/stats-min.js:5
 msgid "SeaMonkey"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:123
+#: static/js/impala/stats/csv_keys.js:123 static/js/zamboni/stats-all.js:15404 static/js/zamboni/stats-min.js:5
 msgid "Fennec"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:124
+#: static/js/impala/stats/csv_keys.js:124 static/js/zamboni/stats-all.js:15405 static/js/zamboni/stats-min.js:5
 msgid "Android"
 msgstr ""
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:129
+#: static/js/impala/stats/csv_keys.js:129 static/js/zamboni/stats-all.js:15410 static/js/zamboni/stats-min.js:5
 msgid "Downloads and Daily Users, last {0} days"
 msgstr ""
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:131
+#: static/js/impala/stats/csv_keys.js:131 static/js/zamboni/stats-all.js:15412 static/js/zamboni/stats-min.js:5
 msgid "Downloads and Daily Users from {0} to {1}"
 msgstr ""
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:135
+#: static/js/impala/stats/csv_keys.js:135 static/js/zamboni/stats-all.js:15416 static/js/zamboni/stats-min.js:5
 msgid "Installs and Daily Users, last {0} days"
 msgstr ""
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:137
+#: static/js/impala/stats/csv_keys.js:137 static/js/zamboni/stats-all.js:15418 static/js/zamboni/stats-min.js:5
 msgid "Installs and Daily Users from {0} to {1}"
 msgstr ""
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:141
+#: static/js/impala/stats/csv_keys.js:141 static/js/zamboni/stats-all.js:15422 static/js/zamboni/stats-min.js:5
 msgid "Downloads, last {0} days"
 msgstr ""
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:143
+#: static/js/impala/stats/csv_keys.js:143 static/js/zamboni/stats-all.js:15424 static/js/zamboni/stats-min.js:5
 msgid "Downloads from {0} to {1}"
 msgstr ""
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:147
+#: static/js/impala/stats/csv_keys.js:147 static/js/zamboni/stats-all.js:15428 static/js/zamboni/stats-min.js:5
 msgid "Daily Users, last {0} days"
 msgstr ""
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:149
+#: static/js/impala/stats/csv_keys.js:149 static/js/zamboni/stats-all.js:15430 static/js/zamboni/stats-min.js:5
 msgid "Daily Users from {0} to {1}"
 msgstr ""
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:153
+#: static/js/impala/stats/csv_keys.js:153 static/js/zamboni/stats-all.js:15434 static/js/zamboni/stats-min.js:5
 msgid "Applications, last {0} days"
 msgstr ""
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:155
+#: static/js/impala/stats/csv_keys.js:155 static/js/zamboni/stats-all.js:15436 static/js/zamboni/stats-min.js:5
 msgid "Applications from {0} to {1}"
 msgstr ""
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:159
+#: static/js/impala/stats/csv_keys.js:159 static/js/zamboni/stats-all.js:15440 static/js/zamboni/stats-min.js:5
 msgid "Platforms, last {0} days"
 msgstr ""
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:161
+#: static/js/impala/stats/csv_keys.js:161 static/js/zamboni/stats-all.js:15442 static/js/zamboni/stats-min.js:5
 msgid "Platforms from {0} to {1}"
 msgstr ""
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:165
+#: static/js/impala/stats/csv_keys.js:165 static/js/zamboni/stats-all.js:15446 static/js/zamboni/stats-min.js:5
 msgid "Languages, last {0} days"
 msgstr ""
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:167
+#: static/js/impala/stats/csv_keys.js:167 static/js/zamboni/stats-all.js:15448 static/js/zamboni/stats-min.js:5
 msgid "Languages from {0} to {1}"
 msgstr ""
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:171
+#: static/js/impala/stats/csv_keys.js:171 static/js/zamboni/stats-all.js:15452 static/js/zamboni/stats-min.js:5
 msgid "Add-on Versions, last {0} days"
 msgstr ""
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:173
+#: static/js/impala/stats/csv_keys.js:173 static/js/zamboni/stats-all.js:15454 static/js/zamboni/stats-min.js:5
 msgid "Add-on Versions from {0} to {1}"
 msgstr ""
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:177
+#: static/js/impala/stats/csv_keys.js:177 static/js/zamboni/stats-all.js:15458 static/js/zamboni/stats-min.js:5
 msgid "Add-on Status, last {0} days"
 msgstr ""
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:179
+#: static/js/impala/stats/csv_keys.js:179 static/js/zamboni/stats-all.js:15460 static/js/zamboni/stats-min.js:5
 msgid "Add-on Status from {0} to {1}"
 msgstr ""
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:183
+#: static/js/impala/stats/csv_keys.js:183 static/js/zamboni/stats-all.js:15464 static/js/zamboni/stats-min.js:5
 msgid "Download Sources, last {0} days"
 msgstr ""
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:185
+#: static/js/impala/stats/csv_keys.js:185 static/js/zamboni/stats-all.js:15466 static/js/zamboni/stats-min.js:5
 msgid "Download Sources from {0} to {1}"
 msgstr ""
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:189
+#: static/js/impala/stats/csv_keys.js:189 static/js/zamboni/stats-all.js:15470 static/js/zamboni/stats-min.js:5
 msgid "Contributions, last {0} days"
 msgstr ""
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:191
+#: static/js/impala/stats/csv_keys.js:191 static/js/zamboni/stats-all.js:15472 static/js/zamboni/stats-min.js:5
 msgid "Contributions from {0} to {1}"
 msgstr ""
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:195
+#: static/js/impala/stats/csv_keys.js:195 static/js/zamboni/stats-all.js:15476 static/js/zamboni/stats-min.js:5
 msgid "Site Metrics, last {0} days"
 msgstr ""
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:197
+#: static/js/impala/stats/csv_keys.js:197 static/js/zamboni/stats-all.js:15478 static/js/zamboni/stats-min.js:5
 msgid "Site Metrics from {0} to {1}"
 msgstr ""
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:201
+#: static/js/impala/stats/csv_keys.js:201 static/js/zamboni/stats-all.js:15482 static/js/zamboni/stats-min.js:5
 msgid "Add-ons in Use, last {0} days"
 msgstr ""
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:203
+#: static/js/impala/stats/csv_keys.js:203 static/js/zamboni/stats-all.js:15484 static/js/zamboni/stats-min.js:5
 msgid "Add-ons in Use from {0} to {1}"
 msgstr ""
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:207
+#: static/js/impala/stats/csv_keys.js:207 static/js/zamboni/stats-all.js:15488 static/js/zamboni/stats-min.js:5
 msgid "Add-ons Downloaded, last {0} days"
 msgstr ""
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:209
+#: static/js/impala/stats/csv_keys.js:209 static/js/zamboni/stats-all.js:15490 static/js/zamboni/stats-min.js:5
 msgid "Add-ons Downloaded from {0} to {1}"
 msgstr ""
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:213
+#: static/js/impala/stats/csv_keys.js:213 static/js/zamboni/stats-all.js:15494 static/js/zamboni/stats-min.js:5
 msgid "Add-ons Created, last {0} days"
 msgstr ""
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:215
+#: static/js/impala/stats/csv_keys.js:215 static/js/zamboni/stats-all.js:15496 static/js/zamboni/stats-min.js:5
 msgid "Add-ons Created from {0} to {1}"
 msgstr ""
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:219
+#: static/js/impala/stats/csv_keys.js:219 static/js/zamboni/stats-all.js:15500 static/js/zamboni/stats-min.js:5
 msgid "Add-ons Updated, last {0} days"
 msgstr ""
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:221
+#: static/js/impala/stats/csv_keys.js:221 static/js/zamboni/stats-all.js:15502 static/js/zamboni/stats-min.js:5
 msgid "Add-ons Updated from {0} to {1}"
 msgstr ""
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:225
+#: static/js/impala/stats/csv_keys.js:225 static/js/zamboni/stats-all.js:15506 static/js/zamboni/stats-min.js:5
 msgid "Reviews Written, last {0} days"
 msgstr ""
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:227
+#: static/js/impala/stats/csv_keys.js:227 static/js/zamboni/stats-all.js:15508 static/js/zamboni/stats-min.js:5
 msgid "Reviews Written from {0} to {1}"
 msgstr ""
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:231
+#: static/js/impala/stats/csv_keys.js:231 static/js/zamboni/stats-all.js:15512 static/js/zamboni/stats-min.js:5
 msgid "User Signups, last {0} days"
 msgstr ""
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:233
+#: static/js/impala/stats/csv_keys.js:233 static/js/zamboni/stats-all.js:15514 static/js/zamboni/stats-min.js:5
 msgid "User Signups from {0} to {1}"
 msgstr ""
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:237
+#: static/js/impala/stats/csv_keys.js:237 static/js/zamboni/stats-all.js:15518 static/js/zamboni/stats-min.js:5
 msgid "Collections Created, last {0} days"
 msgstr ""
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:239
+#: static/js/impala/stats/csv_keys.js:239 static/js/zamboni/stats-all.js:15520 static/js/zamboni/stats-min.js:5
 msgid "Collections Created from {0} to {1}"
 msgstr ""
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:243
+#: static/js/impala/stats/csv_keys.js:243 static/js/zamboni/stats-all.js:15524 static/js/zamboni/stats-min.js:5
 msgid "Subscribers, last {0} days"
 msgstr ""
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:245
+#: static/js/impala/stats/csv_keys.js:245 static/js/zamboni/stats-all.js:15526 static/js/zamboni/stats-min.js:5
 msgid "Subscribers from {0} to {1}"
 msgstr ""
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:249
+#: static/js/impala/stats/csv_keys.js:249 static/js/zamboni/stats-all.js:15530 static/js/zamboni/stats-min.js:5
 msgid "Ratings, last {0} days"
 msgstr ""
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:251
+#: static/js/impala/stats/csv_keys.js:251 static/js/zamboni/stats-all.js:15532 static/js/zamboni/stats-min.js:5
 msgid "Ratings from {0} to {1}"
 msgstr ""
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:255
+#: static/js/impala/stats/csv_keys.js:255 static/js/zamboni/stats-all.js:15536 static/js/zamboni/stats-min.js:5
 msgid "Sales, last {0} days"
 msgstr ""
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:257
+#: static/js/impala/stats/csv_keys.js:257 static/js/zamboni/stats-all.js:15538 static/js/zamboni/stats-min.js:5
 msgid "Sales from {0} to {1}"
 msgstr ""
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:261
+#: static/js/impala/stats/csv_keys.js:261 static/js/zamboni/stats-all.js:15542 static/js/zamboni/stats-min.js:5
 msgid "Installs, last {0} days"
 msgstr ""
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:263
+#: static/js/impala/stats/csv_keys.js:263 static/js/zamboni/stats-all.js:15544 static/js/zamboni/stats-min.js:5
 msgid "Installs from {0} to {1}"
 msgstr ""
 
 #. L10n: {0} and {1} are integers.
-#: static/js/impala/stats/csv_keys.js:269
+#: static/js/impala/stats/csv_keys.js:269 static/js/zamboni/stats-all.js:15550 static/js/zamboni/stats-min.js:5
 msgid "<b>{0}</b> in last {1} days"
 msgstr ""
 
 #. L10n: {0} is an integer and {1} and {2} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:271 static/js/impala/stats/csv_keys.js:277
+#: static/js/impala/stats/csv_keys.js:271 static/js/impala/stats/csv_keys.js:277 static/js/zamboni/stats-all.js:15552 static/js/zamboni/stats-all.js:15558 static/js/zamboni/stats-min.js:5
 msgid "<b>{0}</b> from {1} to {2}"
 msgstr ""
 
 #. L10n: {0} and {1} are integers.
-#: static/js/impala/stats/csv_keys.js:275
+#: static/js/impala/stats/csv_keys.js:275 static/js/zamboni/stats-all.js:15556 static/js/zamboni/stats-min.js:5
 msgid "<b>{0}</b> average in last {1} days"
 msgstr ""
 
-#: static/js/impala/stats/overview.js:19
+#: static/js/impala/stats/overview.js:19 static/js/zamboni/stats-all.js:16469 static/js/zamboni/stats-min.js:5
 msgid "No data available."
 msgstr ""
 
-#: static/js/impala/stats/table.js:74
+#: static/js/impala/stats/table.js:74 static/js/zamboni/stats-all.js:17209 static/js/zamboni/stats-min.js:5
 msgid "Date"
 msgstr ""
 
-#: static/js/impala/stats/topchart.js:96
+#: static/js/impala/stats/topchart.js:96 static/js/zamboni/stats-all.js:16600 static/js/zamboni/stats-min.js:5
 msgid "Other"
 msgstr ""
 
-#: static/js/zamboni/admin_validation.js:24 static/js/zamboni/devhub.js:1229 static/js/zamboni/editors.js:295
+#: static/js/zamboni/admin-all.js:180 static/js/zamboni/admin-min.js:1 static/js/zamboni/admin_validation.js:24 static/js/zamboni/devhub-all.js:2408 static/js/zamboni/devhub-min.js:2
+#: static/js/zamboni/devhub.js:1229 static/js/zamboni/editors-all.js:15576 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:295
 msgid "Select an application first"
 msgstr ""
 
-#: static/js/zamboni/admin_validation.js:51
+#: static/js/zamboni/admin-all.js:207 static/js/zamboni/admin-min.js:1 static/js/zamboni/admin_validation.js:51
 msgid "Set {0} add-on to a max version of {1} and email the author."
 msgid_plural "Set {0} add-ons to a max version of {1} and email the authors."
 msgstr[0] ""
 msgstr[1] ""
 
-#: static/js/zamboni/admin_validation.js:54
+#: static/js/zamboni/admin-all.js:210 static/js/zamboni/admin-min.js:1 static/js/zamboni/admin_validation.js:54
 msgid "Email author of {2} add-on which failed validation."
 msgid_plural "Email authors of {2} add-ons which failed validation."
 msgstr[0] ""
 msgstr[1] ""
 
-#. L10n: {0} is an app name like Firefox.
-#: static/js/zamboni/buttons.js:66
-msgid "Accept and Install"
-msgstr ""
-
-#: static/js/zamboni/buttons.js:66
-msgid "Add to {0}"
-msgstr ""
-
-#: static/js/zamboni/buttons.js:71
-msgid "Download Now"
-msgstr ""
-
-#: static/js/zamboni/buttons.js:112
-msgid "Add-on has not been updated to support default-to-compatible."
-msgstr ""
-
-#: static/js/zamboni/buttons.js:117
-msgid "You need to be using Firefox 10.0 or higher."
-msgstr ""
-
-#: static/js/zamboni/buttons.js:129
-msgid "Mozilla has marked this version as incompatible with your Firefox version."
-msgstr ""
-
-#. L10n: {0} is an platform like Windows or Linux.
-#: static/js/zamboni/buttons.js:210
-msgid "Install for {0} anyway"
-msgstr ""
-
-#: static/js/zamboni/buttons.js:210
-msgid "Download for {0} anyway"
-msgstr ""
-
-#: static/js/zamboni/buttons.js:267
-msgid "Not available for your platform"
-msgstr ""
-
-#. L10n: {0} is an app name, {1} is the app version.
-#: static/js/zamboni/buttons.js:278 static/js/zamboni/buttons.js:315
-msgid "Not available for {0} {1}"
-msgstr ""
-
-#: static/js/zamboni/buttons.js:341
-msgid "Works with {app} {min} - {max}"
-msgstr ""
-
-#: static/js/zamboni/buttons.js:343
-msgid "View other versions"
-msgstr ""
-
-#: static/js/zamboni/buttons.js:391
-msgid "Only with Firefox — Get Firefox Now!"
-msgstr ""
-
-#: static/js/zamboni/buttons.js:507 static/js/zamboni/mobile/buttons.js:43
-msgid "Sorry, you need a Mozilla-based browser (such as Firefox) to install a search plugin."
-msgstr ""
-
-#: static/js/zamboni/collections.js:229
-msgid "Adding to Favorites&hellip;"
-msgstr ""
-
-#: static/js/zamboni/collections.js:232
-msgid "Removing Favorite&hellip;"
-msgstr ""
-
-#: static/js/zamboni/collections.js:235
-msgid "Add to Favorites"
-msgstr ""
-
-#: static/js/zamboni/collections.js:238
-msgid "Remove from Favorites"
-msgstr ""
-
-#: static/js/zamboni/collections.js:303
-msgid "Pending"
-msgstr ""
-
-#: static/js/zamboni/collections.js:304
-msgid "Add a comment"
-msgstr ""
-
-#: static/js/zamboni/collections.js:304
-msgid "Comment"
-msgstr ""
-
-#: static/js/zamboni/collections.js:305
-msgid "Remove this add-on from the collection"
-msgstr ""
-
-#: static/js/zamboni/collections.js:305 static/js/zamboni/collections.js:334
-msgid "Remove"
-msgstr ""
-
-#: static/js/zamboni/collections.js:334
-msgid "Remove this user as a contributor"
-msgstr ""
-
-#: static/js/zamboni/collections.js:346
-msgid "An email address is required."
-msgstr ""
-
-#: static/js/zamboni/collections.js:364
-msgid "You cannot add yourself as a contributor."
-msgstr ""
-
-#: static/js/zamboni/collections.js:366
-msgid "You have already added that user."
-msgstr ""
-
-#: static/js/zamboni/collections.js:573
-msgid "Add to favorites"
-msgstr ""
-
-#: static/js/zamboni/collections.js:577
-msgid "Remove from favorites"
-msgstr ""
-
-#: static/js/zamboni/collections.js:604
-msgid "Stop following"
-msgstr ""
-
-#: static/js/zamboni/devhub.js:110
+#: static/js/zamboni/devhub-all.js:1289 static/js/zamboni/devhub-min.js:1 static/js/zamboni/devhub.js:110
 msgid "Your browser does not support the video tag"
 msgstr ""
 
-#: static/js/zamboni/devhub.js:371
+#: static/js/zamboni/devhub-all.js:1550 static/js/zamboni/devhub-min.js:1 static/js/zamboni/devhub.js:371
 msgid "Changes Saved"
 msgstr ""
 
-#: static/js/zamboni/devhub.js:387
+#: static/js/zamboni/devhub-all.js:1566 static/js/zamboni/devhub-min.js:1 static/js/zamboni/devhub.js:387
 msgid "Enter a new author's email address"
 msgstr ""
 
-#: static/js/zamboni/devhub.js:536
+#: static/js/zamboni/devhub-all.js:1715 static/js/zamboni/devhub-min.js:1 static/js/zamboni/devhub.js:536
 msgid "There was an error uploading your file."
 msgstr ""
 
-#: static/js/zamboni/devhub.js:681
+#: static/js/zamboni/devhub-all.js:1860 static/js/zamboni/devhub-min.js:1 static/js/zamboni/devhub.js:681
 msgid "{files} file"
 msgid_plural "{files} files"
 msgstr[0] ""
 msgstr[1] ""
 
-#: static/js/zamboni/devhub.js:684
+#: static/js/zamboni/devhub-all.js:1863 static/js/zamboni/devhub-min.js:1 static/js/zamboni/devhub.js:684
 msgid "{reviews} user review"
 msgid_plural "{reviews} user reviews"
 msgstr[0] ""
 msgstr[1] ""
 
-#: static/js/zamboni/devhub.js:796
+#: static/js/zamboni/devhub-all.js:1975 static/js/zamboni/devhub-min.js:2 static/js/zamboni/devhub.js:796
 msgid "Learn more"
 msgstr ""
 
-#: static/js/zamboni/devhub.js:800
+#: static/js/zamboni/devhub-all.js:1979 static/js/zamboni/devhub-min.js:2 static/js/zamboni/devhub.js:800
 msgid "Example"
 msgstr ""
 
-#: static/js/zamboni/devhub.js:1130
+#: static/js/zamboni/devhub-all.js:2309 static/js/zamboni/devhub-min.js:2 static/js/zamboni/devhub.js:1130
 msgid "Image changes being processed"
 msgstr ""
 
-#: static/js/zamboni/devhub.js:1280
+#: static/js/zamboni/devhub-all.js:2459 static/js/zamboni/devhub-min.js:2 static/js/zamboni/devhub.js:1280
 msgid "Must be a valid e-mail address."
+msgstr ""
+
+#: static/js/zamboni/devhub-all.js:2613 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:80
+msgid "All tests passed successfully."
+msgstr ""
+
+#: static/js/zamboni/devhub-all.js:2616 static/js/zamboni/devhub-all.js:3011 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:83 static/js/zamboni/validator.js:478
+msgid "These tests were not run."
+msgstr ""
+
+#: static/js/zamboni/devhub-all.js:2664 static/js/zamboni/devhub-all.js:2677 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:131 static/js/zamboni/validator.js:144
+msgid "Tests"
+msgstr ""
+
+#: static/js/zamboni/devhub-all.js:2779 static/js/zamboni/devhub-all.js:3108 static/js/zamboni/devhub-all.js:3127 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:246
+#: static/js/zamboni/validator.js:575 static/js/zamboni/validator.js:594
+msgid "Error"
+msgstr ""
+
+#: static/js/zamboni/devhub-all.js:2780 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:247
+msgid "Warning"
+msgstr ""
+
+#: static/js/zamboni/devhub-all.js:2794 static/js/zamboni/devhub-min.js:2 static/js/zamboni/files-all.js:5657 static/js/zamboni/files-min.js:3 static/js/zamboni/files.js:411
+#: static/js/zamboni/validator.js:261
+msgid "Ignore this message in future updates"
+msgstr ""
+
+#: static/js/zamboni/devhub-all.js:2817 static/js/zamboni/devhub-min.js:2 static/js/zamboni/files-all.js:5663 static/js/zamboni/files-min.js:3 static/js/zamboni/files.js:417
+#: static/js/zamboni/validator.js:284
+msgid "Severity for automated signing:"
+msgstr ""
+
+#: static/js/zamboni/devhub-all.js:2832 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:299
+msgid "Suggestions for passing automated signing:"
+msgstr ""
+
+#: static/js/zamboni/devhub-all.js:2920 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:387
+msgid "Compatibility Tests"
+msgstr ""
+
+#: static/js/zamboni/devhub-all.js:2999 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:466
+msgid "Add-on failed validation."
+msgstr ""
+
+#: static/js/zamboni/devhub-all.js:3001 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:468
+msgid "Add-on passed validation."
+msgstr ""
+
+#: static/js/zamboni/devhub-all.js:3014 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:481
+msgid "{0} error"
+msgid_plural "{0} errors"
+msgstr[0] ""
+msgstr[1] ""
+
+#: static/js/zamboni/devhub-all.js:3016 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:483
+msgid "{0} warning"
+msgid_plural "{0} warnings"
+msgstr[0] ""
+msgstr[1] ""
+
+#: static/js/zamboni/devhub-all.js:3018 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:485
+msgid "{0} notice"
+msgid_plural "{0} notices"
+msgstr[0] ""
+msgstr[1] ""
+
+#: static/js/zamboni/devhub-all.js:3110 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:577
+msgid "Validation task could not complete or completed with errors"
+msgstr ""
+
+#: static/js/zamboni/devhub-all.js:3128 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:595
+msgid "Internal server error"
 msgstr ""
 
 #: static/js/zamboni/devhub_search.js:8
 msgid "No results found."
 msgstr ""
 
-#: static/js/zamboni/editors.js:121
+#: static/js/zamboni/editors-all.js:15402 static/js/zamboni/editors-min.js:4 static/js/zamboni/editors.js:121
 msgid "{name} was viewing this page first."
 msgstr ""
 
-#: static/js/zamboni/editors.js:171
+#: static/js/zamboni/editors-all.js:15452 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:171
 msgid "Receipt checked by app."
 msgstr ""
 
-#: static/js/zamboni/editors.js:173
+#: static/js/zamboni/editors-all.js:15454 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:173
 msgid "Receipt was not checked by app."
 msgstr ""
 
-#: static/js/zamboni/editors.js:244
+#: static/js/zamboni/editors-all.js:15525 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:244
 msgid "{name} was viewing this add-on first."
 msgstr ""
 
-#: static/js/zamboni/editors.js:255
+#: static/js/zamboni/editors-all.js:15536 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:255
 msgid "Loading&hellip;"
 msgstr ""
 
-#: static/js/zamboni/editors.js:260
+#: static/js/zamboni/editors-all.js:15541 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:260
 msgid "Version Notes"
 msgstr ""
 
-#: static/js/zamboni/editors.js:265
+#: static/js/zamboni/editors-all.js:15546 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:265
 msgid "Notes for Reviewers"
 msgstr ""
 
-#: static/js/zamboni/editors.js:270
+#: static/js/zamboni/editors-all.js:15551 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:270
 msgid "No version notes found"
 msgstr ""
 
-#: static/js/zamboni/editors.js:330
+#: static/js/zamboni/editors-all.js:15611 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:330
 msgid "Average Reviews"
 msgstr ""
 
-#: static/js/zamboni/editors.js:386
+#: static/js/zamboni/editors-all.js:15667 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:386
 msgid "Number of Reviews"
 msgstr ""
 
-#: static/js/zamboni/editors.js:445
+#: static/js/zamboni/editors-all.js:15726 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:445
 msgid "Error loading translation"
 msgstr ""
 
-#: static/js/zamboni/files.js:411 static/js/zamboni/validator.js:261
-msgid "Ignore this message in future updates"
-msgstr ""
-
-#: static/js/zamboni/files.js:417 static/js/zamboni/validator.js:284
-msgid "Severity for automated signing:"
-msgstr ""
-
-#: static/js/zamboni/global.js:410
-msgid "Loading..."
-msgstr ""
-
-#. L10n: {0} is the number of characters left.
-#: static/js/zamboni/global.js:474
-msgid "<b>{0}</b> character left."
-msgid_plural "<b>{0}</b> characters left."
-msgstr[0] ""
-msgstr[1] ""
-
-#: static/js/zamboni/init.js:28
-msgid "This feature is temporarily disabled while we perform website maintenance. Please check back a little later."
-msgstr ""
-
-#: static/js/zamboni/l10n.js:45
-msgid "Remove this localization"
-msgstr ""
-
-#: static/js/zamboni/password-strength.js:20
-msgid "Password strength:"
-msgstr ""
-
-#: static/js/zamboni/password-strength.js:26
-msgid "At least {0} character left."
-msgid_plural "At least {0} characters left."
-msgstr[0] ""
-msgstr[1] ""
-
-#: static/js/zamboni/themes_review.js:176
-msgid "Requested Info"
-msgstr ""
-
-#: static/js/zamboni/themes_review.js:177
-msgid "Flagged"
-msgstr ""
-
-#: static/js/zamboni/themes_review.js:178
-msgid "Duplicate"
-msgstr ""
-
-#: static/js/zamboni/themes_review.js:179
-msgid "Rejected"
-msgstr ""
-
-#: static/js/zamboni/themes_review.js:180
-msgid "Approved"
-msgstr ""
-
-#: static/js/zamboni/themes_review.js:424
-msgid "No results found"
-msgstr ""
-
-#: static/js/zamboni/themes_review_templates.js:31
+#: static/js/zamboni/editors-all.js:15975 static/js/zamboni/editors-min.js:5 static/js/zamboni/themes_review_templates.js:31
 msgid "Theme"
 msgstr ""
 
-#: static/js/zamboni/themes_review_templates.js:33
+#: static/js/zamboni/editors-all.js:15977 static/js/zamboni/editors-min.js:5 static/js/zamboni/themes_review_templates.js:33
 msgid "Reviewer"
 msgstr ""
 
-#: static/js/zamboni/themes_review_templates.js:35
+#: static/js/zamboni/editors-all.js:15979 static/js/zamboni/editors-min.js:5 static/js/zamboni/themes_review_templates.js:35
 msgid "Status"
 msgstr ""
 
-#: static/js/zamboni/validator.js:80
-msgid "All tests passed successfully."
+#: static/js/zamboni/editors-all.js:16196 static/js/zamboni/editors-min.js:5 static/js/zamboni/themes_review.js:176
+msgid "Requested Info"
 msgstr ""
 
-#: static/js/zamboni/validator.js:83 static/js/zamboni/validator.js:478
-msgid "These tests were not run."
+#: static/js/zamboni/editors-all.js:16197 static/js/zamboni/editors-min.js:5 static/js/zamboni/themes_review.js:177
+msgid "Flagged"
 msgstr ""
 
-#: static/js/zamboni/validator.js:131 static/js/zamboni/validator.js:144
-msgid "Tests"
+#: static/js/zamboni/editors-all.js:16198 static/js/zamboni/editors-min.js:5 static/js/zamboni/themes_review.js:178
+msgid "Duplicate"
 msgstr ""
 
-#: static/js/zamboni/validator.js:246 static/js/zamboni/validator.js:575 static/js/zamboni/validator.js:594
-msgid "Error"
+#: static/js/zamboni/editors-all.js:16199 static/js/zamboni/editors-min.js:5 static/js/zamboni/themes_review.js:179
+msgid "Rejected"
 msgstr ""
 
-#: static/js/zamboni/validator.js:247
-msgid "Warning"
+#: static/js/zamboni/editors-all.js:16200 static/js/zamboni/editors-min.js:5 static/js/zamboni/themes_review.js:180
+msgid "Approved"
 msgstr ""
 
-#: static/js/zamboni/validator.js:299
-msgid "Suggestions for passing automated signing:"
+#: static/js/zamboni/editors-all.js:16444 static/js/zamboni/editors-min.js:5 static/js/zamboni/themes_review.js:424
+msgid "No results found"
 msgstr ""
 
-#: static/js/zamboni/validator.js:387
-msgid "Compatibility Tests"
-msgstr ""
-
-#: static/js/zamboni/validator.js:466
-msgid "Add-on failed validation."
-msgstr ""
-
-#: static/js/zamboni/validator.js:468
-msgid "Add-on passed validation."
-msgstr ""
-
-#: static/js/zamboni/validator.js:481
-msgid "{0} error"
-msgid_plural "{0} errors"
-msgstr[0] ""
-msgstr[1] ""
-
-#: static/js/zamboni/validator.js:483
-msgid "{0} warning"
-msgid_plural "{0} warnings"
-msgstr[0] ""
-msgstr[1] ""
-
-#: static/js/zamboni/validator.js:485
-msgid "{0} notice"
-msgid_plural "{0} notices"
-msgstr[0] ""
-msgstr[1] ""
-
-#: static/js/zamboni/validator.js:577
-msgid "Validation task could not complete or completed with errors"
-msgstr ""
-
-#: static/js/zamboni/validator.js:595
-msgid "Internal server error"
-msgstr ""
-
-#: static/js/zamboni/mobile/buttons.js:52
+#: static/js/zamboni/mobile-all.js:15186 static/js/zamboni/mobile/buttons.js:52
 msgid "Not Updated for {0} {1}"
 msgstr ""
 
-#: static/js/zamboni/mobile/buttons.js:53
+#: static/js/zamboni/mobile-all.js:15187 static/js/zamboni/mobile/buttons.js:53
 msgid "Requires Newer Version of {0}"
 msgstr ""
 
-#: static/js/zamboni/mobile/buttons.js:54
+#: static/js/zamboni/mobile-all.js:15188 static/js/zamboni/mobile/buttons.js:54
 msgid "Unreviewed"
 msgstr ""
 
-#: static/js/zamboni/mobile/buttons.js:55
+#: static/js/zamboni/mobile-all.js:15189 static/js/zamboni/mobile/buttons.js:55
 msgid "Experimental <span>(Learn More)</span>"
 msgstr ""
 
-#: static/js/zamboni/mobile/buttons.js:56 static/js/zamboni/mobile/buttons.js:57
+#: static/js/zamboni/mobile-all.js:15190 static/js/zamboni/mobile-all.js:15191 static/js/zamboni/mobile/buttons.js:56 static/js/zamboni/mobile/buttons.js:57
 msgid "Not Available for {0}"
 msgstr ""
 
-#: static/js/zamboni/mobile/buttons.js:58
+#: static/js/zamboni/mobile-all.js:15192 static/js/zamboni/mobile/buttons.js:58
 msgid "Experimental"
 msgstr ""
 
-#: static/js/zamboni/mobile/buttons.js:59
+#: static/js/zamboni/mobile-all.js:15193 static/js/zamboni/mobile/buttons.js:59
 msgid "Themes Require Newer Version of {0}"
 msgstr ""
 
-#: static/js/zamboni/mobile/buttons.js:60
+#: static/js/zamboni/mobile-all.js:15194 static/js/zamboni/mobile/buttons.js:60
 msgid "Themes Require {0}"
 msgstr ""
 
-#: static/js/zamboni/mobile/buttons.js:105
+#: static/js/zamboni/mobile-all.js:15239 static/js/zamboni/mobile/buttons.js:105
 msgid "Installing..."
 msgstr ""
 
-#: static/js/zamboni/mobile/buttons.js:125
+#: static/js/zamboni/mobile-all.js:15259 static/js/zamboni/mobile/buttons.js:125
 msgid "This add-on has been preliminarily reviewed by Mozilla."
 msgstr ""
 
-#: static/js/zamboni/mobile/buttons.js:250
+#: static/js/zamboni/mobile-all.js:15384 static/js/zamboni/mobile/buttons.js:250
 msgid "Keep it"
 msgstr ""
 
-#: static/js/zamboni/mobile/general.js:344
+#: static/js/zamboni/mobile-all.js:16049 static/js/zamboni/mobile-min.js:6 static/js/zamboni/mobile/general.js:344
 msgid "You're trying it on!"
 msgstr ""
 
-#: static/js/zamboni/mobile/general.js:356
+#: static/js/zamboni/mobile-all.js:16061 static/js/zamboni/mobile-min.js:6 static/js/zamboni/mobile/general.js:356
 msgid "Added to Firefox"
 msgstr ""
-

--- a/locale/lt/LC_MESSAGES/django.po
+++ b/locale/lt/LC_MESSAGES/django.po
@@ -2,69 +2,70 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2016-02-24 21:23+0000\n"
+"POT-Creation-Date: 2016-04-18 15:47+0000\n"
 "PO-Revision-Date: 2014-02-24 21:21+0000\n"
 "Last-Translator: Paulius <ekstras@gmail.com>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
+"Language: \n"
 "MIME-Version: 1.0\n"
-"Content-Type: text/plain; charset=utf-8\n"
+"Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Generated-By: Babel 2.2.0\n"
 
-#: src/olympia/accounts/views.py:52
+#: src/olympia/accounts/views.py:54
 msgid "Your log in attempt could not be parsed. Please try again."
 msgstr ""
 
-#: src/olympia/accounts/views.py:54
+#: src/olympia/accounts/views.py:56
 msgid "Your Firefox Account could not be found. Please try again."
 msgstr ""
 
-#: src/olympia/accounts/views.py:55
+#: src/olympia/accounts/views.py:57
 msgid "You could not be logged in. Please try again."
 msgstr ""
 
-#: src/olympia/accounts/views.py:57
+#: src/olympia/accounts/views.py:59
 msgid "Your account has already been migrated to Firefox Accounts."
 msgstr ""
 
-#: src/olympia/accounts/views.py:59
+#: src/olympia/accounts/views.py:61
 msgid "Your Firefox Account already exists on this site."
 msgstr ""
 
-#: src/olympia/accounts/views.py:108
+#: src/olympia/accounts/views.py:110
 msgid "Great job!"
 msgstr ""
 
-#: src/olympia/accounts/views.py:109
+#: src/olympia/accounts/views.py:111
 msgid "You can now log in to Add-ons with your Firefox Account."
 msgstr ""
 
-#: src/olympia/accounts/views.py:121
+#: src/olympia/accounts/views.py:123
 msgid "Need help?"
 msgstr ""
 
-#: src/olympia/addons/buttons.py:180
+#: src/olympia/addons/buttons.py:177
 msgid "Download Now"
 msgstr "Parsisiųsti"
 
-#: src/olympia/addons/buttons.py:182
+#: src/olympia/addons/buttons.py:179
 msgid "Download"
 msgstr "Siųstis"
 
 #. L10n: please keep &nbsp; in the string so &rarr; does not wrap.
-#: src/olympia/addons/buttons.py:186
+#: src/olympia/addons/buttons.py:183
 msgid "Continue to Download&nbsp;&rarr;"
 msgstr "Pereiti prie parsisiuntimo"
 
-#: src/olympia/addons/buttons.py:202 src/olympia/addons/helpers.py:35 src/olympia/addons/views.py:319 src/olympia/addons/templates/addons/impala/details.html:114
+#: src/olympia/addons/buttons.py:199 src/olympia/addons/helpers.py:35 src/olympia/addons/views.py:333 src/olympia/addons/templates/addons/impala/details.html:111
 #: src/olympia/addons/templates/addons/impala/listing/items.html:17 src/olympia/addons/templates/addons/mobile/home.html:40 src/olympia/amo/templates/amo/side_nav.html:6
-#: src/olympia/amo/templates/amo/side_nav.html:10 src/olympia/amo/templates/amo/site_nav.html:2 src/olympia/amo/templates/amo/site_nav.html:55 src/olympia/bandwagon/views.py:95
-#: src/olympia/browse/views.py:54 src/olympia/browse/views.py:68 src/olympia/browse/views.py:235 src/olympia/browse/templates/browse/impala/category_landing.html:22
+#: src/olympia/amo/templates/amo/side_nav.html:10 src/olympia/amo/templates/amo/site_nav.html:2 src/olympia/amo/templates/amo/site_nav.html:53 src/olympia/bandwagon/views.py:95
+#: src/olympia/browse/views.py:54 src/olympia/browse/views.py:68 src/olympia/browse/views.py:202 src/olympia/browse/templates/browse/impala/category_landing.html:22
 #: src/olympia/browse/templates/browse/personas/mobile/category_landing.html:26
 msgid "Featured"
 msgstr "Rekomenduojamas"
 
-#: src/olympia/addons/buttons.py:221
+#: src/olympia/addons/buttons.py:218
 msgid "Add to {0}"
 msgstr "Pridėti į {0}"
 
@@ -87,7 +88,6 @@ msgid "Invalid tag: {0}"
 msgid_plural "Invalid tags: {0}"
 msgstr[0] "Klaidinga žyma: {0}"
 msgstr[1] "Klaidingos žymos: {0}"
-msgstr[2] "Klaidingos žymos: {0}"
 
 #. L10n: {0} is a single tag or a comma-separated list of tags.
 #: src/olympia/addons/forms.py:103
@@ -95,14 +95,12 @@ msgid "\"{0}\" is a reserved tag and cannot be used."
 msgid_plural "\"{0}\" are reserved tags and cannot be used."
 msgstr[0] "\"{0}\" yra rezervuota žyma ir negali būtų naudojama."
 msgstr[1] "\"{0}\" yra rezervuotos žymos ir negali būti naudojamos."
-msgstr[2] "\"{0}\" yra rezervuotos žymos ir negali būti naudojamos."
 
 #: src/olympia/addons/forms.py:111
 msgid "You have {0} too many tags."
 msgid_plural "You have {0} too many tags."
 msgstr[0] "Jūs turite {0} žyma per daug."
 msgstr[1] "Jūs turite {0} žymomis per daug."
-msgstr[2] "Jūs turite {0} žymų per daug."
 
 #: src/olympia/addons/forms.py:117
 #, python-format
@@ -114,42 +112,40 @@ msgid "All tags must be at least {0} character."
 msgid_plural "All tags must be at least {0} characters."
 msgstr[0] "Visos žymos turi būti bent iš {0} simbolio."
 msgstr[1] "Visos žymos turi būti bent iš {0} simbolių."
-msgstr[2] "Visos žymos turi būti bent iš {0} simbolių."
 
-#: src/olympia/addons/forms.py:234
+#: src/olympia/addons/forms.py:238
 msgid "Categories cannot be changed while your add-on is featured for this application."
 msgstr "Kategorijos negali būti keičiamos kol jūsų priedas yra rekomenduojamas šiai programėlei."
 
 #. L10n: {0} is the number of categories.
-#: src/olympia/addons/forms.py:238
+#: src/olympia/addons/forms.py:242
 msgid "You can have only {0} category."
 msgid_plural "You can have only {0} categories."
 msgstr[0] "Jūs galite turėti tik {0} kategoriją."
 msgstr[1] "Jūs galite turėti tik {0} kategorijas."
-msgstr[2] "Jūs galite turėti tik {0} kategorijų."
 
-#: src/olympia/addons/forms.py:246
+#: src/olympia/addons/forms.py:250
 msgid "The miscellaneous category cannot be combined with additional categories."
 msgstr "The miscellaneous category cannot be combined with additional categories."
 
-#: src/olympia/addons/forms.py:369
+#: src/olympia/addons/forms.py:374
 #, python-format
 msgid "Before changing your default locale you must have a name, summary, and description in that locale. You are missing %s."
 msgstr "Prieš keisdami savo numatytąją lokalę, turite turėti pavadinimą, santrauką bei aprašymą toje lokalėje. Jums trūksta %s."
 
-#: src/olympia/addons/forms.py:484 src/olympia/addons/forms.py:575
+#: src/olympia/addons/forms.py:455 src/olympia/addons/forms.py:546
 msgid "A license must be selected."
 msgstr "Turi būti pasirinkta licencija"
 
-#: src/olympia/addons/forms.py:556
+#: src/olympia/addons/forms.py:527
 msgid "Give Your Theme a Name."
 msgstr ""
 
-#: src/olympia/addons/forms.py:562 src/olympia/devhub/templates/devhub/personas/submit.html:53
+#: src/olympia/addons/forms.py:533 src/olympia/devhub/templates/devhub/personas/submit.html:53
 msgid "Describe your Theme."
 msgstr ""
 
-#: src/olympia/addons/forms.py:704
+#: src/olympia/addons/forms.py:675
 msgid "Enter a new author's email address"
 msgstr ""
 
@@ -157,37 +153,37 @@ msgstr ""
 msgid "Not Reviewed"
 msgstr "Neperžiūrėtas"
 
-#: src/olympia/addons/models.py:301
+#: src/olympia/addons/models.py:298
 msgid "Users have the option of contributing more or less than this amount."
 msgstr "Naudotojai turi galimybę paremti didesne ar mažesne suma už šią."
 
-#: src/olympia/addons/models.py:309
-msgid "Users will always be asked in the Add-ons Manager (Firefox 4 and above)"
-msgstr "Naudotojų bus visada klausiama „Priedų tvarkytuvėje“ („Firefox 4“ ir naujesnėse versijose)"
+#: src/olympia/addons/models.py:306
+msgid "Users will always be asked in the Add-ons Manager (Firefox 4 and above). Only applies to desktop."
+msgstr ""
 
-#: src/olympia/addons/models.py:1804 src/olympia/addons/templates/addons/details_box.html:55 src/olympia/devhub/templates/devhub/index.html:92
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:102
+#: src/olympia/addons/models.py:1802 src/olympia/addons/templates/addons/details_box.html:55 src/olympia/devhub/templates/devhub/index.html:92
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:89
 msgid "Listed"
 msgstr "Išvardinta"
 
-#: src/olympia/addons/views.py:320 src/olympia/browse/templates/browse/personas/mobile/category_landing.html:27
+#: src/olympia/addons/views.py:334 src/olympia/browse/templates/browse/personas/mobile/category_landing.html:27
 msgid "Popular"
 msgstr "Populiarus"
 
-#: src/olympia/addons/views.py:321 src/olympia/browse/views.py:238 src/olympia/browse/views.py:280 src/olympia/browse/views.py:482
+#: src/olympia/addons/views.py:335 src/olympia/browse/views.py:205 src/olympia/browse/views.py:247 src/olympia/browse/views.py:449
 msgid "Recently Added"
 msgstr "Neseniai pridėtas"
 
-#: src/olympia/addons/views.py:322 src/olympia/bandwagon/views.py:99 src/olympia/browse/views.py:60 src/olympia/browse/views.py:71 src/olympia/search/forms.py:16 src/olympia/search/forms.py:91
+#: src/olympia/addons/views.py:336 src/olympia/bandwagon/views.py:99 src/olympia/browse/views.py:60 src/olympia/browse/views.py:71 src/olympia/search/forms.py:16 src/olympia/search/forms.py:91
 msgid "Recently Updated"
 msgstr "Neseniai atnaujintas"
 
 #. l10n: {0} is the addon name
-#: src/olympia/addons/views.py:520
+#: src/olympia/addons/views.py:534
 msgid "Contribution for {0}"
 msgstr "Paremti už {0}"
 
-#: src/olympia/addons/views.py:613
+#: src/olympia/addons/views.py:627
 msgid "Abuse reported."
 msgstr "Pranešta apie piktnaudžiavimą."
 
@@ -254,9 +250,9 @@ msgstr "Paaukoti"
 #: src/olympia/devhub/templates/devhub/addons/ajax_compat_update.html:36 src/olympia/devhub/templates/devhub/addons/profile.html:44 src/olympia/devhub/templates/devhub/addons/edit/admin.html:101
 #: src/olympia/devhub/templates/devhub/addons/edit/basic.html:152 src/olympia/devhub/templates/devhub/addons/edit/details.html:85 src/olympia/devhub/templates/devhub/addons/edit/support.html:67
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:166 src/olympia/devhub/templates/devhub/addons/forms_shared/media.html:149
-#: src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:44 src/olympia/devhub/templates/devhub/versions/add_file_modal.html:78 src/olympia/devhub/templates/devhub/versions/edit.html:139
-#: src/olympia/devhub/templates/devhub/versions/list.html:242 src/olympia/devhub/templates/devhub/versions/list.html:276 src/olympia/devhub/templates/devhub/versions/list.html:317
-#: src/olympia/devhub/templates/devhub/versions/list.html:351 src/olympia/reviews/templates/reviews/edit_review.html:16 src/olympia/translations/templates/translations/trans-menu.html:50
+#: src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:43 src/olympia/devhub/templates/devhub/versions/add_file_modal.html:58 src/olympia/devhub/templates/devhub/versions/edit.html:139
+#: src/olympia/devhub/templates/devhub/versions/list.html:239 src/olympia/devhub/templates/devhub/versions/list.html:281 src/olympia/devhub/templates/devhub/versions/list.html:315
+#: src/olympia/devhub/templates/devhub/versions/list.html:349 src/olympia/reviews/templates/reviews/edit_review.html:16 src/olympia/translations/templates/translations/trans-menu.html:50
 #: src/olympia/translations/templates/translations/trans-menu.html:62
 msgid "or"
 msgstr "arba"
@@ -369,7 +365,7 @@ msgid "Add-on Information for {0}"
 msgstr " Priedo {0} indormacija"
 
 #: src/olympia/addons/templates/addons/details_box.html:30 src/olympia/addons/templates/addons/persona_detail_table.html:3 src/olympia/addons/templates/addons/mobile/details.html:63
-#: src/olympia/addons/templates/addons/mobile/persona_detail_table.html:7 src/olympia/browse/views.py:459 src/olympia/devhub/views.py:75
+#: src/olympia/addons/templates/addons/mobile/persona_detail_table.html:7 src/olympia/browse/views.py:426 src/olympia/devhub/views.py:73
 msgid "Updated"
 msgstr "Atnaujinta"
 
@@ -388,11 +384,11 @@ msgstr "Veikia su"
 msgid "Visibility"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/details_box.html:57 src/olympia/devhub/templates/devhub/index.html:94 src/olympia/devhub/templates/devhub/includes/addon_details.html:104
+#: src/olympia/addons/templates/addons/details_box.html:57 src/olympia/devhub/templates/devhub/index.html:94 src/olympia/devhub/templates/devhub/includes/addon_details.html:91
 msgid "Hidden"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/details_box.html:59 src/olympia/devhub/templates/devhub/index.html:96 src/olympia/devhub/templates/devhub/includes/addon_details.html:106
+#: src/olympia/addons/templates/addons/details_box.html:59 src/olympia/devhub/templates/devhub/index.html:96 src/olympia/devhub/templates/devhub/includes/addon_details.html:93
 msgid "Unlisted"
 msgstr ""
 
@@ -400,13 +396,13 @@ msgstr ""
 msgid "Required Add-ons"
 msgstr "Reikalingi priedai"
 
-#: src/olympia/addons/templates/addons/details_box.html:81 src/olympia/addons/templates/addons/persona_detail_table.html:15 src/olympia/browse/views.py:462 src/olympia/devhub/views.py:78
-#: src/olympia/devhub/views.py:85 src/olympia/discovery/templates/discovery/addons/detail.html:57 src/olympia/reviews/forms.py:62 src/olympia/reviews/templates/reviews/add.html:57
+#: src/olympia/addons/templates/addons/details_box.html:81 src/olympia/addons/templates/addons/persona_detail_table.html:15 src/olympia/browse/views.py:429 src/olympia/devhub/views.py:76
+#: src/olympia/devhub/views.py:83 src/olympia/discovery/templates/discovery/addons/detail.html:57 src/olympia/reviews/forms.py:62 src/olympia/reviews/templates/reviews/add.html:57
 #: src/olympia/reviews/templates/reviews/mobile/review_list.html:18
 msgid "Rating"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/details_box.html:85 src/olympia/browse/views.py:461 src/olympia/devhub/views.py:77 src/olympia/devhub/views.py:84
+#: src/olympia/addons/templates/addons/details_box.html:85 src/olympia/browse/views.py:428 src/olympia/devhub/views.py:75 src/olympia/devhub/views.py:82
 #: src/olympia/stats/templates/stats/addon_report_menu.html:8 src/olympia/stats/templates/stats/collection_report_menu.html:18
 msgid "Downloads"
 msgstr ""
@@ -426,7 +422,7 @@ msgstr "Pranešimai apie piktnaudžiavimą"
 
 #. The Privacy Policy for this add-on.
 #: src/olympia/addons/templates/addons/details_box.html:121 src/olympia/addons/templates/addons/privacy.html:19 src/olympia/addons/templates/addons/privacy.html:23
-#: src/olympia/addons/templates/addons/impala/button.html:43 src/olympia/addons/templates/addons/impala/details.html:307 src/olympia/devhub/templates/devhub/includes/policy_form.html:20
+#: src/olympia/addons/templates/addons/impala/button.html:43 src/olympia/addons/templates/addons/impala/details.html:312 src/olympia/devhub/templates/devhub/includes/policy_form.html:23
 #: src/olympia/templates/mobile/base_addons.html:87
 msgid "Privacy Policy"
 msgstr "Privatumo politika"
@@ -451,7 +447,7 @@ msgstr "Paveikslėlių galerija"
 msgid "Developer Comments"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/details_box.html:199 src/olympia/addons/templates/addons/impala/details.html:259
+#: src/olympia/addons/templates/addons/details_box.html:199 src/olympia/addons/templates/addons/impala/details.html:264
 msgid "Development Channel"
 msgstr "Plėtojimo kanalas"
 
@@ -475,13 +471,13 @@ msgstr ""
 "<strong>Dėmesio:</strong> šio priedo plėtojimo versijos nebuvo peržiūrėtos Mozilla atstovų. Įsidiegę plėtojimo versiją jūs toliaugausite plėtojimo atnaujinimus iš šio kūrėjo. Norėdami tai "
 "nutraukti, persirašykite įprastinę priedo versiją iš nuorodos viršuje."
 
-#: src/olympia/addons/templates/addons/details_box.html:220 src/olympia/addons/templates/addons/impala/details.html:278
+#: src/olympia/addons/templates/addons/details_box.html:220 src/olympia/addons/templates/addons/impala/details.html:283
 msgid "Version {0}:"
 msgstr "Versija {0}:"
 
 #: src/olympia/addons/templates/addons/details_box.html:234
-msgid "Nothing to see here! The developer did not include any details."
-msgstr "Čia nieko nėra! Kūrėjas nepateikė jokių detalių."
+msgid "Nothing to see here!  The developer did not include any details."
+msgstr ""
 
 #: src/olympia/addons/templates/addons/details_box.html:251 src/olympia/devhub/templates/devhub/versions/edit.html:73 src/olympia/editors/templates/editors/review.html:98
 msgid "Version Notes"
@@ -494,7 +490,7 @@ msgid "End-User License Agreement for {0}"
 msgstr "Galutinio naudotojo licencijos sutikimas (EULA), skirtas {0}"
 
 #: src/olympia/addons/templates/addons/eula.html:17 src/olympia/addons/templates/addons/eula.html:21 src/olympia/addons/templates/addons/impala/button.html:48
-#: src/olympia/addons/templates/addons/impala/details.html:316 src/olympia/devhub/templates/devhub/includes/policy_form.html:3 src/olympia/discovery/templates/discovery/addons/eula.html:11
+#: src/olympia/addons/templates/addons/impala/details.html:321 src/olympia/devhub/templates/devhub/includes/policy_form.html:3 src/olympia/discovery/templates/discovery/addons/eula.html:11
 msgid "End-User License Agreement"
 msgstr "Galutinio naudotojo licencijos sutikimas (EULA)"
 
@@ -511,7 +507,7 @@ msgstr "Grįžti į {0}…"
 msgid "Add-ons for {0}"
 msgstr "Priedai, skirti {0}"
 
-#: src/olympia/addons/templates/addons/home.html:10 src/olympia/addons/templates/addons/home.html:51 src/olympia/browse/templates/browse/impala/base_listing.html:11
+#: src/olympia/addons/templates/addons/home.html:10 src/olympia/addons/templates/addons/home.html:53 src/olympia/browse/templates/browse/impala/base_listing.html:11
 msgid "Featured Extensions"
 msgstr "Rekomenduojami plėtiniai"
 
@@ -519,29 +515,29 @@ msgstr "Rekomenduojami plėtiniai"
 msgid "Popular Extensions"
 msgstr "Populiarūs plėtiniai"
 
-#: src/olympia/addons/templates/addons/home.html:42 src/olympia/amo/templates/amo/side_nav.html:3 src/olympia/amo/templates/amo/side_nav.html:11 src/olympia/amo/templates/amo/site_nav.html:3
-#: src/olympia/amo/templates/amo/site_nav.html:25 src/olympia/browse/views.py:236 src/olympia/browse/views.py:281 src/olympia/browse/views.py:481
+#: src/olympia/addons/templates/addons/home.html:44 src/olympia/amo/templates/amo/side_nav.html:3 src/olympia/amo/templates/amo/side_nav.html:11 src/olympia/amo/templates/amo/site_nav.html:3
+#: src/olympia/amo/templates/amo/site_nav.html:25 src/olympia/browse/views.py:203 src/olympia/browse/views.py:248 src/olympia/browse/views.py:448
 msgid "Most Popular"
 msgstr "Populiariausi"
 
-#: src/olympia/addons/templates/addons/home.html:43
+#: src/olympia/addons/templates/addons/home.html:45
 msgid "All »"
 msgstr "Visi"
 
-#: src/olympia/addons/templates/addons/home.html:52 src/olympia/addons/templates/addons/home.html:61 src/olympia/addons/templates/addons/home.html:70 src/olympia/addons/templates/addons/home.html:78
+#: src/olympia/addons/templates/addons/home.html:54 src/olympia/addons/templates/addons/home.html:63 src/olympia/addons/templates/addons/home.html:72 src/olympia/addons/templates/addons/home.html:80
 #: src/olympia/browse/templates/browse/impala/category_landing.html:36
 msgid "See all »"
 msgstr "Rodyti visus »"
 
-#: src/olympia/addons/templates/addons/home.html:60
+#: src/olympia/addons/templates/addons/home.html:62
 msgid "Up &amp; Coming Extensions"
 msgstr "Up &amp; Coming plėtiniai"
 
-#: src/olympia/addons/templates/addons/home.html:69 src/olympia/browse/templates/browse/personas/category_landing.html:61 src/olympia/discovery/templates/discovery/pane.html:74
+#: src/olympia/addons/templates/addons/home.html:71 src/olympia/browse/templates/browse/personas/category_landing.html:61 src/olympia/discovery/templates/discovery/pane.html:74
 msgid "Featured Themes"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/home.html:77 src/olympia/bandwagon/templates/bandwagon/impala/collection_listing.html:5
+#: src/olympia/addons/templates/addons/home.html:79 src/olympia/bandwagon/templates/bandwagon/impala/collection_listing.html:5
 msgid "Featured Collections"
 msgstr "Rekomenduojamos kolekcijos"
 
@@ -559,7 +555,7 @@ msgid "Updated {0}"
 msgstr "Atnaujinta {0}"
 
 #. {0} is a date.
-#: src/olympia/addons/templates/addons/macros.html:10 src/olympia/addons/templates/addons/macros.html:69 src/olympia/addons/templates/addons/persona_preview.html:21
+#: src/olympia/addons/templates/addons/macros.html:10 src/olympia/addons/templates/addons/macros.html:69 src/olympia/addons/templates/addons/persona_preview.html:22
 #: src/olympia/addons/templates/addons/listing/items_mobile.html:44 src/olympia/addons/templates/addons/listing/macros.html:39
 #: src/olympia/bandwagon/templates/bandwagon/collection_listing_items.html:37 src/olympia/bandwagon/templates/bandwagon/impala/collection_listing_items.html:37
 msgid "Added {0}"
@@ -571,7 +567,6 @@ msgid "%(num)s weekly download"
 msgid_plural "%(num)s weekly downloads"
 msgstr[0] "%(num)s parsisiuntimas per savaitę"
 msgstr[1] "%(num)s parsisiuntimai per savaitę"
-msgstr[2] "%(num)s parsisiuntimų per savaitę"
 
 #: src/olympia/addons/templates/addons/macros.html:28
 #, python-format
@@ -579,24 +574,20 @@ msgid "%(num)s user"
 msgid_plural "%(num)s users"
 msgstr[0] "%(num)s naudotojas"
 msgstr[1] "%(num)s naudotojai"
-msgstr[2] "%(num)s naudotojų"
 
 #. {0} is the number of downloads.
-#: src/olympia/addons/templates/addons/macros.html:53 src/olympia/addons/templates/addons/impala/details.html:61
+#: src/olympia/addons/templates/addons/macros.html:53 src/olympia/addons/templates/addons/impala/details.html:59
 msgid "{0} weekly download"
 msgid_plural "{0} weekly downloads"
 msgstr[0] "{0} parsisiuntimas per savaitę"
 msgstr[1] "{0} parsisiuntimai per savaitę"
-msgstr[2] "{0} parsisiuntimų per savaitę"
 
 #. {0} is the number of users.
-#: src/olympia/addons/templates/addons/macros.html:61 src/olympia/addons/templates/addons/impala/details.html:54 src/olympia/compat/templates/compat/index.html:71
-#: src/olympia/zadmin/templates/zadmin/compat.html:67
+#: src/olympia/addons/templates/addons/macros.html:61 src/olympia/addons/templates/addons/impala/details.html:52 src/olympia/zadmin/templates/zadmin/compat.html:67
 msgid "{0} user"
 msgid_plural "{0} users"
 msgstr[0] "{0} vartotojas"
 msgstr[1] "{0} vartotojai"
-msgstr[2] "{0} vartotojų"
 
 #: src/olympia/addons/templates/addons/paypal_result.html:12
 msgid "Payment cancelled"
@@ -610,7 +601,7 @@ msgstr "Mokėjimas atliktas"
 msgid "Return to the addon."
 msgstr "Grįžti į priedą"
 
-#: src/olympia/addons/templates/addons/persona_detail.html:17 src/olympia/addons/templates/addons/impala/details.html:106 src/olympia/addons/templates/addons/mobile/details.html:23
+#: src/olympia/addons/templates/addons/persona_detail.html:17 src/olympia/addons/templates/addons/impala/details.html:103 src/olympia/addons/templates/addons/mobile/details.html:23
 #: src/olympia/addons/templates/addons/mobile/persona_detail.html:21 src/olympia/discovery/templates/discovery/addons/base.html:27 src/olympia/editors/templates/editors/review.html:31
 msgid "by"
 msgstr "sukūrė"
@@ -654,35 +645,35 @@ msgstr "Kasdienių naudotojų"
 msgid "License"
 msgstr "Licencija"
 
-#: src/olympia/addons/templates/addons/persona_preview.html:12 src/olympia/constants/base.py:48
+#: src/olympia/addons/templates/addons/persona_preview.html:13 src/olympia/constants/base.py:48
 msgid "Awaiting Review"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/persona_preview.html:14 src/olympia/amo/log.py:180 src/olympia/constants/base.py:42 src/olympia/editors/helpers.py:62
+#: src/olympia/addons/templates/addons/persona_preview.html:15 src/olympia/amo/log.py:180 src/olympia/constants/base.py:42 src/olympia/editors/helpers.py:62
 msgid "Rejected"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/persona_preview.html:16 src/olympia/amo/log.py:159
+#: src/olympia/addons/templates/addons/persona_preview.html:17 src/olympia/amo/log.py:159
 msgid "Approved"
 msgstr ""
 
 #. {0} is the number of users.
-#: src/olympia/addons/templates/addons/persona_preview.html:26 src/olympia/addons/templates/addons/listing/items_mobile.html:36 src/olympia/addons/templates/addons/listing/macros.html:31
+#: src/olympia/addons/templates/addons/persona_preview.html:27 src/olympia/addons/templates/addons/listing/items_mobile.html:36 src/olympia/addons/templates/addons/listing/macros.html:31
 msgid "<strong>{0}</strong> user"
 msgid_plural "<strong>{0}</strong> users"
 msgstr[0] "<strong>{0}</strong> naudotojas"
 msgstr[1] "<strong>{0}</strong> naudotojai"
-msgstr[2] "<strong>{0}</strong> naudotojų"
 
-#: src/olympia/addons/templates/addons/persona_preview.html:40
+#: src/olympia/addons/templates/addons/persona_preview.html:41
 msgid "Hover to Preview"
 msgstr "Užveskite pelę peržiūrai"
 
-#: src/olympia/addons/templates/addons/persona_preview.html:46 src/olympia/addons/templates/addons/persona_preview.html:48 src/olympia/reviews/templates/reviews/add.html:15
+#: src/olympia/addons/templates/addons/persona_preview.html:47 src/olympia/addons/templates/addons/persona_preview.html:49 src/olympia/addons/templates/addons/persona_preview.html:97
+#: src/olympia/reviews/templates/reviews/add.html:15
 msgid "Add"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/persona_preview.html:57 src/olympia/bandwagon/templates/bandwagon/ajax_new.html:16 src/olympia/bandwagon/templates/bandwagon/edit.html:19
+#: src/olympia/addons/templates/addons/persona_preview.html:58 src/olympia/bandwagon/templates/bandwagon/ajax_new.html:16 src/olympia/bandwagon/templates/bandwagon/edit.html:19
 #: src/olympia/bandwagon/templates/bandwagon/includes/addedit.html:19 src/olympia/devhub/templates/devhub/addons/edit/admin.html:13 src/olympia/devhub/templates/devhub/addons/edit/basic.html:10
 #: src/olympia/devhub/templates/devhub/addons/edit/details.html:8 src/olympia/devhub/templates/devhub/addons/edit/media.html:6 src/olympia/devhub/templates/devhub/addons/edit/support.html:8
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:9 src/olympia/devhub/templates/devhub/addons/submit/describe.html:29 src/olympia/editors/templates/editors/review.html:257
@@ -691,21 +682,21 @@ msgstr ""
 
 #. For datetime formatting, see the table on
 #. http://docs.python.org/library/datetime.html#strftime-and-strptime-behavior
-#: src/olympia/addons/templates/addons/persona_preview.html:66
+#: src/olympia/addons/templates/addons/persona_preview.html:67
 #, python-format
 msgid "%%Y-%%m-%%d"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/persona_preview.html:67
+#: src/olympia/addons/templates/addons/persona_preview.html:68
 msgid "by {0} on {1}"
 msgstr "sukūrė {0}, tarp {1}"
 
-#: src/olympia/addons/templates/addons/persona_preview.html:75 src/olympia/reviews/helpers.py:17 src/olympia/reviews/templates/reviews/review_list.html:63
+#: src/olympia/addons/templates/addons/persona_preview.html:76 src/olympia/reviews/helpers.py:17 src/olympia/reviews/templates/reviews/review_list.html:63
 #: src/olympia/reviews/templates/reviews/reviews_link.html:21 src/olympia/reviews/templates/reviews/impala/reviews_link.html:16
 msgid "Not yet rated"
 msgstr "Dar neįvertintas"
 
-#: src/olympia/addons/templates/addons/persona_preview.html:78
+#: src/olympia/addons/templates/addons/persona_preview.html:79
 msgid "<b>{0}</b> users"
 msgstr "<b>{0}</b> naudotojų"
 
@@ -718,8 +709,8 @@ msgid "Learn more about Firefox"
 msgstr "Sužinokite daugiau apie Firefox"
 
 #: src/olympia/addons/templates/addons/popups.html:22
-msgid "or <b><a class=\"installer\" href=\"{url}\">download anyway</a></b>"
-msgstr "arba <b><a class=\"installer\" href=\"{url}\">siųskitės vistiek</a></b>"
+msgid "or <b><a class=\"button installer\" href=\"{url}\">download anyway</a></b>"
+msgstr ""
 
 #: src/olympia/addons/templates/addons/popups.html:26
 msgid ""
@@ -812,13 +803,14 @@ msgid "QR code for add-on"
 msgstr "Priedo QR kodas"
 
 #: src/olympia/addons/templates/addons/qr_code.html:6
-msgid "Want {0} on your mobile Firefox? Scan this QR code to install directly to your phone. (You'll need a QR reader. Search your phone's marketplace if don't have one.)"
+msgid ""
+"Want {0} on your mobile Firefox?  Scan this QR code to install directly\n"
+"  to your phone.  (You'll need a QR reader.  Search your phone's marketplace if\n"
+"  don't have one.)"
 msgstr ""
-"Norite {0} savo mobiliojoje Firefox? Nuskenuokite šį QR kodą ir galėsite įdiegti iškart savo telefone. (Jums reikės QR kodų skaitytuvo. Paieškote savo telefono programėlių parduotuvėje, jeigu jo "
-"dar neturite)."
 
 #: src/olympia/addons/templates/addons/report_abuse.html:6 src/olympia/addons/templates/addons/report_abuse_full.html:10 src/olympia/addons/templates/addons/impala/details-more.html:23
-#: src/olympia/addons/templates/addons/impala/details.html:328
+#: src/olympia/addons/templates/addons/impala/details.html:333
 msgid "Report Abuse"
 msgstr "Pranešti apie piktnaudžiavimą"
 
@@ -839,9 +831,9 @@ msgstr "Siųsti pranešimą"
 #: src/olympia/devhub/templates/devhub/addons/ajax_compat_update.html:36 src/olympia/devhub/templates/devhub/addons/profile.html:44 src/olympia/devhub/templates/devhub/addons/edit/admin.html:104
 #: src/olympia/devhub/templates/devhub/addons/edit/basic.html:155 src/olympia/devhub/templates/devhub/addons/edit/details.html:88 src/olympia/devhub/templates/devhub/addons/edit/support.html:70
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:169 src/olympia/devhub/templates/devhub/addons/forms_shared/media.html:152
-#: src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:44 src/olympia/devhub/templates/devhub/personas/edit.html:222 src/olympia/devhub/templates/devhub/versions/add_file_modal.html:79
-#: src/olympia/devhub/templates/devhub/versions/edit.html:140 src/olympia/devhub/templates/devhub/versions/list.html:208 src/olympia/devhub/templates/devhub/versions/list.html:242
-#: src/olympia/devhub/templates/devhub/versions/list.html:276 src/olympia/devhub/templates/devhub/versions/list.html:317 src/olympia/reviews/templates/reviews/edit_review.html:16
+#: src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:43 src/olympia/devhub/templates/devhub/personas/edit.html:222 src/olympia/devhub/templates/devhub/versions/add_file_modal.html:59
+#: src/olympia/devhub/templates/devhub/versions/edit.html:140 src/olympia/devhub/templates/devhub/versions/list.html:208 src/olympia/devhub/templates/devhub/versions/list.html:239
+#: src/olympia/devhub/templates/devhub/versions/list.html:281 src/olympia/devhub/templates/devhub/versions/list.html:315 src/olympia/reviews/templates/reviews/edit_review.html:16
 #: src/olympia/translations/templates/translations/trans-menu.html:50 src/olympia/translations/templates/translations/trans-menu.html:62 src/olympia/zadmin/templates/zadmin/validation.html:105
 msgid "Cancel"
 msgstr ""
@@ -886,7 +878,7 @@ msgstr ""
 msgid "Review Guidelines"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/review_list_box.html:5 src/olympia/addons/templates/addons/impala/details-more.html:27 src/olympia/editors/helpers.py:921
+#: src/olympia/addons/templates/addons/review_list_box.html:5 src/olympia/addons/templates/addons/impala/details-more.html:27 src/olympia/editors/helpers.py:1001
 #: src/olympia/reviews/templates/reviews/add.html:14 src/olympia/reviews/templates/reviews/reply.html:14 src/olympia/reviews/templates/reviews/review_list.html:19
 #: src/olympia/reviews/templates/reviews/mobile/review_list.html:26
 msgid "Reviews"
@@ -907,7 +899,6 @@ msgid "See all reviews of this add-on"
 msgid_plural "See all %(cnt)s reviews of this add-on"
 msgstr[0] ""
 msgstr[1] ""
-msgstr[2] ""
 
 #: src/olympia/addons/templates/addons/tags_box.html:3 src/olympia/devhub/templates/devhub/addons/edit/basic.html:118
 msgid "Tags"
@@ -977,123 +968,120 @@ msgid "Other add-ons by %(author)s"
 msgid_plural "Other add-ons by these authors"
 msgstr[0] "Kiti %(author)s priedai"
 msgstr[1] "Kiti šių autorių priedai"
-msgstr[2] "Kiti šių autorių priedai"
 
-#: src/olympia/addons/templates/addons/impala/details.html:41
+#: src/olympia/addons/templates/addons/impala/details.html:39
 #, python-format
 msgid "<span itemprop=\"ratingCount\">%(num)s</span> user review"
 msgid_plural "<span itemprop=\"ratingCount\">%(num)s</span> user reviews"
 msgstr[0] ""
 msgstr[1] ""
-msgstr[2] ""
 
-#: src/olympia/addons/templates/addons/impala/details.html:69
+#: src/olympia/addons/templates/addons/impala/details.html:66
 msgid "View statistics"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/impala/details.html:84
+#: src/olympia/addons/templates/addons/impala/details.html:81
 msgid "Manage"
 msgstr ""
 
 #. {0} is an add-on name.
-#: src/olympia/addons/templates/addons/impala/details.html:96
+#: src/olympia/addons/templates/addons/impala/details.html:93
 msgid "Icon of {0}"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/impala/details.html:103 src/olympia/addons/templates/addons/impala/listing/items.html:14
+#: src/olympia/addons/templates/addons/impala/details.html:100 src/olympia/addons/templates/addons/impala/listing/items.html:14
 msgid "No Restart"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/impala/details.html:127
+#: src/olympia/addons/templates/addons/impala/details.html:124
 #, python-format
 msgid "Meet the Developer: <a href=\"%(url)s\">%(name)s</a>"
 msgid_plural "<a href=\"%(url)s\">Meet the Developers</a>"
 msgstr[0] ""
 msgstr[1] ""
-msgstr[2] ""
 
-#: src/olympia/addons/templates/addons/impala/details.html:137
+#: src/olympia/addons/templates/addons/impala/details.html:134
 msgid "Learn why {0} was created and find out what's next for this add-on."
 msgstr ""
 
 #. {0} is an index.
-#: src/olympia/addons/templates/addons/impala/details.html:156
+#: src/olympia/addons/templates/addons/impala/details.html:161
 msgid "Add-on screenshot #{0}"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/impala/details.html:182
+#: src/olympia/addons/templates/addons/impala/details.html:187
 msgid "Add-on home page"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/impala/details.html:185
+#: src/olympia/addons/templates/addons/impala/details.html:190
 msgid "Support site"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/impala/details.html:189
+#: src/olympia/addons/templates/addons/impala/details.html:194
 msgid "Support E-mail"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/impala/details.html:194 src/olympia/devhub/models.py:378 src/olympia/devhub/templates/devhub/versions/list.html:12
+#: src/olympia/addons/templates/addons/impala/details.html:199 src/olympia/devhub/models.py:378 src/olympia/devhub/templates/devhub/versions/list.html:12
 #: src/olympia/versions/templates/versions/version.html:6 src/olympia/versions/templates/versions/mobile/version.html:6
 msgid "Version {0}"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/impala/details.html:194
+#: src/olympia/addons/templates/addons/impala/details.html:199
 msgid "Info"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/impala/details.html:195 src/olympia/devhub/templates/devhub/includes/addon_details.html:129
+#: src/olympia/addons/templates/addons/impala/details.html:200 src/olympia/devhub/templates/devhub/includes/addon_details.html:116
 msgid "Last Updated:"
-msgstr ""
-
-#: src/olympia/addons/templates/addons/impala/details.html:200
-#, python-format
-msgid "Released under <a target=\"_blank\" href=\"%(url)s\">%(name)s</a>"
-msgstr ""
-
-#: src/olympia/addons/templates/addons/impala/details.html:201 src/olympia/addons/templates/addons/impala/details.html:206 src/olympia/amo/helpers.py:398 src/olympia/devhub/forms.py:142
-#: src/olympia/devhub/forms.py:173 src/olympia/versions/templates/versions/version.html:40 src/olympia/versions/templates/versions/version.html:45
-msgid "Custom License"
 msgstr ""
 
 #: src/olympia/addons/templates/addons/impala/details.html:205
 #, python-format
+msgid "Released under <a target=\"_blank\" href=\"%(url)s\">%(name)s</a>"
+msgstr ""
+
+#: src/olympia/addons/templates/addons/impala/details.html:206 src/olympia/addons/templates/addons/impala/details.html:211 src/olympia/amo/helpers.py:398 src/olympia/devhub/forms.py:142
+#: src/olympia/devhub/forms.py:173 src/olympia/versions/templates/versions/version.html:40 src/olympia/versions/templates/versions/version.html:45
+msgid "Custom License"
+msgstr ""
+
+#: src/olympia/addons/templates/addons/impala/details.html:210
+#, python-format
 msgid "Released under <a href=\"%(url)s\">%(name)s</a>"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/impala/details.html:217
+#: src/olympia/addons/templates/addons/impala/details.html:222
 msgid "About this Add-on"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/impala/details.html:233
+#: src/olympia/addons/templates/addons/impala/details.html:238
 msgid "Developer’s Comments"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/impala/details.html:243
+#: src/olympia/addons/templates/addons/impala/details.html:248
 msgid "Version Information"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/impala/details.html:250
+#: src/olympia/addons/templates/addons/impala/details.html:255
 msgid "See complete version history"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/impala/details.html:262
+#: src/olympia/addons/templates/addons/impala/details.html:267
 msgid ""
 "The Development Channel lets you test an experimental new version of this add-on before it's released to the general public. Once you install the development version, you will continue to get "
 "updates from this channel. To stop receiving development updates, reinstall the default version from the link above."
 msgstr ""
 
-#: src/olympia/addons/templates/addons/impala/details.html:272
+#: src/olympia/addons/templates/addons/impala/details.html:277
 msgid "<strong>Caution:</strong> Development versions of this add-on have not been reviewed by Mozilla."
 msgstr ""
 
-#: src/olympia/addons/templates/addons/impala/details.html:287
+#: src/olympia/addons/templates/addons/impala/details.html:292
 msgid "See complete development channel history"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/impala/details.html:306 src/olympia/addons/templates/addons/impala/details.html:315 src/olympia/addons/templates/addons/impala/details.html:327
+#: src/olympia/addons/templates/addons/impala/details.html:311 src/olympia/addons/templates/addons/impala/details.html:320 src/olympia/addons/templates/addons/impala/details.html:332
 #: src/olympia/addons/templates/addons/impala/review_add_box.html:4 src/olympia/stats/templates/stats/popup.html:2 src/olympia/stats/templates/stats/popup.html:8
-#: src/olympia/stats/templates/stats/stats.html:202 src/olympia/users/templates/users/profile.html:119
+#: src/olympia/stats/templates/stats/stats.html:204 src/olympia/users/templates/users/profile.html:119
 msgid "close"
 msgstr ""
 
@@ -1124,7 +1112,6 @@ msgid "About the Developer"
 msgid_plural "About the Developers"
 msgstr[0] ""
 msgstr[1] ""
-msgstr[2] ""
 
 #: src/olympia/addons/templates/addons/impala/developers.html:96 src/olympia/users/templates/users/edit.html:130 src/olympia/users/templates/users/profile.html:26
 msgid "No Photo"
@@ -1150,15 +1137,11 @@ msgstr ""
 msgid "Source Code License"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/impala/persona_grid.html:16 src/olympia/addons/templates/addons/impala/toplist.html:6
-msgid "{0} users"
-msgstr ""
-
 #: src/olympia/addons/templates/addons/impala/review_list_box.html:19 src/olympia/reviews/templates/reviews/review.html:40
 msgid "permalink"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/impala/review_list_box.html:23 src/olympia/editors/templates/editors/queue.html:98 src/olympia/reviews/templates/reviews/review.html:44
+#: src/olympia/addons/templates/addons/impala/review_list_box.html:23 src/olympia/editors/templates/editors/queue.html:104 src/olympia/reviews/templates/reviews/review.html:44
 msgid "translate"
 msgstr ""
 
@@ -1168,7 +1151,6 @@ msgid "See all user reviews"
 msgid_plural "See all %(cnt)s user reviews"
 msgstr[0] ""
 msgstr[1] ""
-msgstr[2] ""
 
 #: src/olympia/addons/templates/addons/impala/review_list_box.html:47 src/olympia/reviews/templates/reviews/review_list.html:84
 msgid "This add-on has not yet been reviewed."
@@ -1176,6 +1158,10 @@ msgstr ""
 
 #: src/olympia/addons/templates/addons/impala/review_list_box.html:50
 msgid "Be the first!"
+msgstr ""
+
+#: src/olympia/addons/templates/addons/impala/toplist.html:6
+msgid "{0} users"
 msgstr ""
 
 #: src/olympia/addons/templates/addons/impala/listing/sorter.html:14 src/olympia/devhub/templates/devhub/addons/listing/item_actions.html:49
@@ -1190,7 +1176,7 @@ msgstr ""
 msgid "My Add-ons"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/includes/dashboard_tabs.html:6 src/olympia/amo/context_processors.py:51
+#: src/olympia/addons/templates/addons/includes/dashboard_tabs.html:6 src/olympia/amo/context_processors.py:50
 msgid "My Themes"
 msgstr ""
 
@@ -1232,7 +1218,6 @@ msgid "<strong>{0}</strong> weekly download"
 msgid_plural "<strong>{0}</strong> weekly downloads"
 msgstr[0] ""
 msgstr[1] ""
-msgstr[2] ""
 
 #: src/olympia/addons/templates/addons/mobile/details.html:32
 msgid "Read More"
@@ -1246,7 +1231,7 @@ msgstr ""
 msgid "Weekly Downloads"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/mobile/details.html:99 src/olympia/compat/templates/compat/reporter_detail.html:46 src/olympia/devhub/forms.py:787
+#: src/olympia/addons/templates/addons/mobile/details.html:99 src/olympia/compat/templates/compat/reporter_detail.html:46 src/olympia/devhub/forms.py:788
 #: src/olympia/devhub/templates/devhub/versions/list.html:163
 msgid "Version"
 msgstr ""
@@ -1330,7 +1315,7 @@ msgstr ""
 #: src/olympia/browse/templates/browse/personas/category_landing.html:21 src/olympia/browse/templates/browse/personas/category_landing.html:23
 #: src/olympia/browse/templates/browse/personas/category_landing.html:38 src/olympia/browse/templates/browse/personas/grid.html:7 src/olympia/browse/templates/browse/personas/grid.html:11
 #: src/olympia/browse/templates/browse/personas/mobile/base.html:7 src/olympia/browse/templates/browse/personas/mobile/category_landing.html:19 src/olympia/constants/base.py:180
-#: src/olympia/devhub/templates/devhub/personas/submit.html:13 src/olympia/editors/helpers.py:105 src/olympia/editors/templates/editors/base.html:26
+#: src/olympia/devhub/templates/devhub/personas/submit.html:13 src/olympia/editors/helpers.py:107 src/olympia/editors/templates/editors/base.html:26
 #: src/olympia/editors/templates/editors/performance.html:73 src/olympia/search/templates/search/personas.html:39 src/olympia/templates/menu_links.html:9
 msgid "Themes"
 msgstr "Temos"
@@ -1351,7 +1336,7 @@ msgstr ""
 msgid "Highest Rated"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/mobile/home.html:74 src/olympia/amo/templates/amo/side_nav.html:5 src/olympia/amo/templates/amo/site_nav.html:27 src/olympia/amo/templates/amo/site_nav.html:57
+#: src/olympia/addons/templates/addons/mobile/home.html:74 src/olympia/amo/templates/amo/side_nav.html:5 src/olympia/amo/templates/amo/site_nav.html:27 src/olympia/amo/templates/amo/site_nav.html:55
 #: src/olympia/bandwagon/views.py:97 src/olympia/browse/views.py:57 src/olympia/browse/views.py:67 src/olympia/browse/templates/browse/personas/mobile/category_landing.html:65
 #: src/olympia/search/forms.py:15 src/olympia/search/forms.py:87
 msgid "Newest"
@@ -1365,90 +1350,90 @@ msgstr ""
 msgid "Theme Info &raquo;"
 msgstr ""
 
-#: src/olympia/amo/context_processors.py:39 src/olympia/devhub/templates/devhub/nav.html:43
+#: src/olympia/amo/context_processors.py:37 src/olympia/devhub/templates/devhub/nav.html:43
 msgid "Tools"
 msgstr ""
 
-#: src/olympia/amo/context_processors.py:48 src/olympia/discovery/templates/discovery/pane_account.html:8 src/olympia/users/templates/users/includes/navigation.html:2
+#: src/olympia/amo/context_processors.py:47 src/olympia/discovery/templates/discovery/pane_account.html:8 src/olympia/users/templates/users/includes/navigation.html:2
 msgid "My Profile"
 msgstr ""
 
-#: src/olympia/amo/context_processors.py:54 src/olympia/users/templates/users/edit.html:5 src/olympia/users/templates/users/includes/navigation.html:3
+#: src/olympia/amo/context_processors.py:53 src/olympia/users/templates/users/edit.html:5 src/olympia/users/templates/users/includes/navigation.html:3
 msgid "Account Settings"
 msgstr ""
 
-#: src/olympia/amo/context_processors.py:57 src/olympia/discovery/templates/discovery/pane_account.html:11 src/olympia/users/templates/users/profile.html:83
+#: src/olympia/amo/context_processors.py:56 src/olympia/discovery/templates/discovery/pane_account.html:11 src/olympia/users/templates/users/profile.html:83
 #: src/olympia/users/templates/users/includes/navigation.html:4
 msgid "My Collections"
 msgstr ""
 
-#: src/olympia/amo/context_processors.py:62 src/olympia/discovery/templates/discovery/pane_account.html:10 src/olympia/users/templates/users/includes/navigation.html:7
+#: src/olympia/amo/context_processors.py:61 src/olympia/discovery/templates/discovery/pane_account.html:10 src/olympia/users/templates/users/includes/navigation.html:7
 msgid "My Favorites"
 msgstr ""
 
-#: src/olympia/amo/context_processors.py:67 src/olympia/discovery/templates/discovery/pane_account.html:13 src/olympia/templates/impala/user_login.html:14
+#: src/olympia/amo/context_processors.py:66 src/olympia/discovery/templates/discovery/pane_account.html:13 src/olympia/templates/impala/user_login.html:14
 #: src/olympia/templates/mobile/header_auth.html:5
 msgid "Log out"
 msgstr ""
 
-#: src/olympia/amo/context_processors.py:72 src/olympia/devhub/templates/devhub/addons/dashboard.html:4
+#: src/olympia/amo/context_processors.py:71 src/olympia/devhub/templates/devhub/addons/dashboard.html:4
 msgid "Manage My Submissions"
 msgstr ""
 
-#: src/olympia/amo/context_processors.py:75 src/olympia/devhub/templates/devhub/nav.html:27 src/olympia/devhub/templates/devhub/addons/dashboard.html:25
+#: src/olympia/amo/context_processors.py:74 src/olympia/devhub/templates/devhub/nav.html:27 src/olympia/devhub/templates/devhub/addons/dashboard.html:25
 #: src/olympia/devhub/templates/devhub/addons/submit/base.html:4
 msgid "Submit a New Add-on"
 msgstr ""
 
-#: src/olympia/amo/context_processors.py:77 src/olympia/browse/templates/browse/personas/base.html:50 src/olympia/devhub/templates/devhub/index.html:24
+#: src/olympia/amo/context_processors.py:76 src/olympia/browse/templates/browse/personas/base.html:50 src/olympia/devhub/templates/devhub/index.html:24
 #: src/olympia/devhub/templates/devhub/addons/dashboard.html:29
 msgid "Submit a New Theme"
 msgstr ""
 
-#: src/olympia/amo/context_processors.py:79 src/olympia/amo/templates/amo/site_nav.html:87 src/olympia/devhub/helpers.py:36 src/olympia/devhub/helpers.py:68 src/olympia/devhub/helpers.py:102
+#: src/olympia/amo/context_processors.py:78 src/olympia/amo/templates/amo/site_nav.html:85 src/olympia/devhub/helpers.py:36 src/olympia/devhub/helpers.py:68 src/olympia/devhub/helpers.py:102
 #: src/olympia/templates/footer.html:6 src/olympia/templates/menu_links.html:14
 msgid "Developer Hub"
 msgstr ""
 
-#: src/olympia/amo/context_processors.py:83 src/olympia/devhub/views.py:1792
+#: src/olympia/amo/context_processors.py:81 src/olympia/devhub/views.py:1796
 msgid "Manage API Keys"
 msgstr ""
 
-#: src/olympia/amo/context_processors.py:88 src/olympia/editors/helpers.py:82 src/olympia/editors/helpers.py:102 src/olympia/editors/templates/editors/base.html:10
+#: src/olympia/amo/context_processors.py:86 src/olympia/editors/helpers.py:84 src/olympia/editors/helpers.py:104 src/olympia/editors/templates/editors/base.html:10
 msgid "Editor Tools"
 msgstr ""
 
-#: src/olympia/amo/context_processors.py:92
+#: src/olympia/amo/context_processors.py:90
 msgid "Admin Tools"
 msgstr ""
 
-#: src/olympia/amo/fields.py:15
+#: src/olympia/amo/fields.py:20
 msgid "Incorrect, please try again."
 msgstr ""
 
-#: src/olympia/amo/fields.py:16
+#: src/olympia/amo/fields.py:21
 msgid "Error verifying input, please try again."
 msgstr ""
 
-#: src/olympia/amo/fields.py:32
+#: src/olympia/amo/fields.py:37
 msgid "This must be a valid hex color code, such as #000000."
 msgstr ""
 
-#: src/olympia/amo/fields.py:58
+#: src/olympia/amo/fields.py:63
 msgid "Enter at least one value."
 msgstr ""
 
-#: src/olympia/amo/helpers.py:162 src/olympia/amo/templates/amo/site_nav.html:61 src/olympia/bandwagon/templates/bandwagon/add.html:9
+#: src/olympia/amo/helpers.py:162 src/olympia/amo/templates/amo/site_nav.html:59 src/olympia/bandwagon/templates/bandwagon/add.html:9
 #: src/olympia/bandwagon/templates/bandwagon/collection_detail.html:15 src/olympia/bandwagon/templates/bandwagon/delete.html:9 src/olympia/bandwagon/templates/bandwagon/edit.html:15
 #: src/olympia/bandwagon/templates/bandwagon/user_listing.html:18 src/olympia/bandwagon/templates/bandwagon/user_listing.html:21
 #: src/olympia/bandwagon/templates/bandwagon/impala/collection_listing.html:12 src/olympia/bandwagon/templates/bandwagon/impala/collection_listing.html:20
 #: src/olympia/bandwagon/templates/bandwagon/impala/collection_listing.html:24 src/olympia/bandwagon/templates/bandwagon/impala/collection_sidebar.html:3
 #: src/olympia/bandwagon/templates/bandwagon/includes/collection_sidebar.html:2 src/olympia/bandwagon/templates/bandwagon/mobile/collection_listing.html:3
-#: src/olympia/stats/templates/stats/stats.html:77 src/olympia/templates/menu_links.html:12
+#: src/olympia/stats/templates/stats/stats.html:33 src/olympia/templates/menu_links.html:12
 msgid "Collections"
 msgstr ""
 
-#: src/olympia/amo/helpers.py:171 src/olympia/amo/templates/amo/site_nav.html:85 src/olympia/browse/templates/browse/language_tools.html:3
+#: src/olympia/amo/helpers.py:171 src/olympia/amo/templates/amo/site_nav.html:83 src/olympia/browse/templates/browse/language_tools.html:3
 msgid "Dictionaries & Language Packs"
 msgstr ""
 
@@ -1600,8 +1585,8 @@ msgstr ""
 msgid "Comment on {addon} {version}."
 msgstr ""
 
-#: src/olympia/amo/log.py:236 src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:19 src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:47
-#: src/olympia/editors/helpers.py:511 src/olympia/editors/templates/editors/themes/history_table.html:11
+#: src/olympia/amo/log.py:236 src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:17 src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:45
+#: src/olympia/editors/helpers.py:584 src/olympia/editors/templates/editors/themes/history_table.html:11
 msgid "Comment"
 msgstr ""
 
@@ -1924,7 +1909,7 @@ msgstr ""
 #: src/olympia/amo/templates/amo/mobile/paginator.html:14 src/olympia/amo/templates/amo/mobile/paginator.html:16 src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:51
 #: src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:65 src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:78
 #: src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:91 src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:104
-#: src/olympia/discovery/templates/discovery/pane.html:45 src/olympia/discovery/templates/discovery/addons/detail.html:39 src/olympia/stats/templates/stats/stats.html:167
+#: src/olympia/discovery/templates/discovery/pane.html:45 src/olympia/discovery/templates/discovery/addons/detail.html:39 src/olympia/stats/templates/stats/stats.html:169
 msgid "Next"
 msgstr ""
 
@@ -1956,7 +1941,7 @@ msgid ""
 msgstr ""
 
 #: src/olympia/amo/templates/amo/side_nav.html:4 src/olympia/amo/templates/amo/side_nav.html:12 src/olympia/amo/templates/amo/site_nav.html:4 src/olympia/amo/templates/amo/site_nav.html:26
-#: src/olympia/browse/views.py:56 src/olympia/browse/views.py:66 src/olympia/browse/views.py:237 src/olympia/browse/views.py:282 src/olympia/search/forms.py:86
+#: src/olympia/browse/views.py:56 src/olympia/browse/views.py:66 src/olympia/browse/views.py:204 src/olympia/browse/views.py:249 src/olympia/search/forms.py:86
 msgid "Top Rated"
 msgstr ""
 
@@ -1970,38 +1955,38 @@ msgstr ""
 msgid "Extensions"
 msgstr ""
 
-#: src/olympia/amo/templates/amo/site_nav.html:45
+#: src/olympia/amo/templates/amo/site_nav.html:44
 msgid "Want more customization? Try <b>Complete Themes</b>"
 msgstr ""
 
-#: src/olympia/amo/templates/amo/site_nav.html:56 src/olympia/bandwagon/views.py:96
+#: src/olympia/amo/templates/amo/site_nav.html:54 src/olympia/bandwagon/views.py:96
 msgid "Most Followers"
 msgstr ""
 
-#: src/olympia/amo/templates/amo/site_nav.html:68 src/olympia/bandwagon/templates/bandwagon/impala/collection_sidebar.html:16
+#: src/olympia/amo/templates/amo/site_nav.html:66 src/olympia/bandwagon/templates/bandwagon/impala/collection_sidebar.html:16
 #: src/olympia/bandwagon/templates/bandwagon/includes/collection_sidebar.html:18
 msgid "Collections I've Made"
 msgstr ""
 
-#: src/olympia/amo/templates/amo/site_nav.html:70 src/olympia/bandwagon/templates/bandwagon/user_listing.html:4 src/olympia/bandwagon/templates/bandwagon/impala/collection_sidebar.html:13
+#: src/olympia/amo/templates/amo/site_nav.html:68 src/olympia/bandwagon/templates/bandwagon/user_listing.html:4 src/olympia/bandwagon/templates/bandwagon/impala/collection_sidebar.html:13
 #: src/olympia/bandwagon/templates/bandwagon/includes/collection_sidebar.html:15
 msgid "Collections I'm Following"
 msgstr ""
 
-#: src/olympia/amo/templates/amo/site_nav.html:73 src/olympia/bandwagon/templates/bandwagon/impala/collection_sidebar.html:18
-#: src/olympia/bandwagon/templates/bandwagon/includes/collection_sidebar.html:20 src/olympia/users/models.py:512
+#: src/olympia/amo/templates/amo/site_nav.html:71 src/olympia/bandwagon/templates/bandwagon/impala/collection_sidebar.html:18
+#: src/olympia/bandwagon/templates/bandwagon/includes/collection_sidebar.html:20 src/olympia/users/models.py:521
 msgid "My Favorite Add-ons"
 msgstr ""
 
-#: src/olympia/amo/templates/amo/site_nav.html:78
+#: src/olympia/amo/templates/amo/site_nav.html:76
 msgid "More&hellip;"
 msgstr "Daugiau&hellip;"
 
-#: src/olympia/amo/templates/amo/site_nav.html:82
+#: src/olympia/amo/templates/amo/site_nav.html:80
 msgid "Add-ons for Mobile"
 msgstr ""
 
-#: src/olympia/amo/templates/amo/site_nav.html:86 src/olympia/browse/feeds.py:207 src/olympia/browse/templates/browse/search_tools.html:3 src/olympia/constants/base.py:176
+#: src/olympia/amo/templates/amo/site_nav.html:84 src/olympia/browse/feeds.py:207 src/olympia/browse/templates/browse/search_tools.html:3 src/olympia/constants/base.py:176
 #: src/olympia/templates/menu_links.html:10
 msgid "Search Tools"
 msgstr ""
@@ -2017,7 +2002,7 @@ msgid "Jump to first page"
 msgstr ""
 
 #: src/olympia/amo/templates/amo/impala/paginator.html:22 src/olympia/amo/templates/amo/mobile/impala_paginator.html:12 src/olympia/discovery/templates/discovery/pane.html:44
-#: src/olympia/discovery/templates/discovery/addons/detail.html:38 src/olympia/stats/templates/stats/stats.html:164
+#: src/olympia/discovery/templates/discovery/addons/detail.html:38 src/olympia/stats/templates/stats/stats.html:166
 msgid "Previous"
 msgstr ""
 
@@ -2039,32 +2024,50 @@ msgid "Page {n}"
 msgid_plural "Page {n}"
 msgstr[0] ""
 msgstr[1] ""
-msgstr[2] ""
 
-#: src/olympia/amo/templates/services/install.html:38
-#, python-format
-msgid "If you are not prompted to install %(addon_name)s in a moment, please <a href=\"%(addon_xpi)s\">click here</a>."
-msgstr ""
-
-#: src/olympia/amo/tests/test_messages.py:57 src/olympia/amo/tests/test_messages.py:58 src/olympia/reviews/forms.py:25 src/olympia/reviews/forms.py:50 src/olympia/reviews/templates/reviews/add.html:56
+#: src/olympia/amo/tests/test_messages.py:56 src/olympia/amo/tests/test_messages.py:57 src/olympia/reviews/forms.py:25 src/olympia/reviews/forms.py:50 src/olympia/reviews/templates/reviews/add.html:56
 #: src/olympia/reviews/templates/reviews/reply.html:30
 msgid "Title"
 msgstr ""
 
-#: src/olympia/amo/tests/test_messages.py:57 src/olympia/amo/tests/test_messages.py:58
+#: src/olympia/amo/tests/test_messages.py:56 src/olympia/amo/tests/test_messages.py:57
 msgid "Body"
 msgstr ""
 
-#: src/olympia/amo/tests/test_messages.py:59
+#: src/olympia/amo/tests/test_messages.py:58
 msgid "Another Title"
 msgstr ""
 
-#: src/olympia/amo/tests/test_messages.py:59
+#: src/olympia/amo/tests/test_messages.py:58
 msgid "Another Body"
 msgstr ""
 
-#: src/olympia/api/views.py:255
-msgid "Not implemented yet."
+#: src/olympia/api/authentication.py:76
+msgid "Signature has expired."
+msgstr ""
+
+#: src/olympia/api/authentication.py:79
+msgid "Error decoding signature."
+msgstr ""
+
+#: src/olympia/api/authentication.py:82
+msgid "Invalid JWT Token."
+msgstr ""
+
+#: src/olympia/api/authentication.py:130
+msgid "Invalid Authorization header. No credentials provided."
+msgstr ""
+
+#: src/olympia/api/authentication.py:133
+msgid "Invalid Authorization header. Credentials string should not contain spaces."
+msgstr ""
+
+#: src/olympia/api/fields.py:29
+msgid "The field must have a length of at least {num} characters."
+msgstr ""
+
+#: src/olympia/api/fields.py:31
+msgid "The language code {lang_code} is invalid."
 msgstr ""
 
 #: src/olympia/applications/views.py:39 src/olympia/applications/templates/applications/appversions.html:3
@@ -2083,7 +2086,7 @@ msgstr ""
 msgid "Add-ons submitted to Mozilla Add-ons must have a manifest file with at least one of the below applications supported. Only the versions listed below are allowed for these applications."
 msgstr ""
 
-#: src/olympia/applications/templates/applications/appversions.html:25
+#: src/olympia/applications/templates/applications/appversions.html:25 src/olympia/editors/helpers.py:361
 msgid "GUID"
 msgstr ""
 
@@ -2197,8 +2200,8 @@ msgstr ""
 msgid "Remove from favorites"
 msgstr ""
 
-#: src/olympia/bandwagon/views.py:98 src/olympia/bandwagon/views.py:191 src/olympia/browse/views.py:58 src/olympia/browse/views.py:69 src/olympia/browse/views.py:458 src/olympia/devhub/views.py:74
-#: src/olympia/devhub/views.py:82 src/olympia/devhub/templates/devhub/addons/edit/basic.html:20 src/olympia/editors/templates/editors/leaderboard.html:24
+#: src/olympia/bandwagon/views.py:98 src/olympia/bandwagon/views.py:191 src/olympia/browse/views.py:58 src/olympia/browse/views.py:69 src/olympia/browse/views.py:425 src/olympia/devhub/views.py:72
+#: src/olympia/devhub/views.py:80 src/olympia/devhub/templates/devhub/addons/edit/basic.html:20 src/olympia/editors/templates/editors/leaderboard.html:24
 #: src/olympia/editors/templates/editors/themes/queue_list.html:48 src/olympia/search/forms.py:17 src/olympia/search/forms.py:89 src/olympia/users/templates/users/vcard.html:5
 msgid "Name"
 msgstr ""
@@ -2207,7 +2210,7 @@ msgstr ""
 msgid "Recently Popular"
 msgstr ""
 
-#: src/olympia/bandwagon/views.py:189 src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:18
+#: src/olympia/bandwagon/views.py:189 src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:16
 msgid "Added"
 msgstr ""
 
@@ -2221,7 +2224,7 @@ msgstr ""
 
 #: src/olympia/bandwagon/views.py:316
 #, python-format
-msgid "Your new collection is shown below. You can <ahref=\"%(url)s\">edit additional settings</a> if you'dlike."
+msgid "Your new collection is shown below. You can <a href=\"%(url)s\">edit additional settings</a> if you'd like."
 msgstr ""
 
 #: src/olympia/bandwagon/views.py:322
@@ -2302,7 +2305,6 @@ msgid "<span>%(num)s</span> follower"
 msgid_plural "<span>%(num)s</span> followers"
 msgstr[0] ""
 msgstr[1] ""
-msgstr[2] ""
 
 #: src/olympia/bandwagon/templates/bandwagon/collection_detail.html:54
 msgid "About this Collection"
@@ -2342,7 +2344,6 @@ msgid "%(num)s Theme in this Collection"
 msgid_plural "%(num)s Themes in this Collection"
 msgstr[0] ""
 msgstr[1] ""
-msgstr[2] ""
 
 #: src/olympia/bandwagon/templates/bandwagon/collection_detail.html:111
 #, python-format
@@ -2350,10 +2351,9 @@ msgid "%(num)s Add-on in this Collection"
 msgid_plural "%(num)s Add-ons in this Collection"
 msgstr[0] ""
 msgstr[1] ""
-msgstr[2] ""
 
-#: src/olympia/bandwagon/templates/bandwagon/collection_detail.html:125 src/olympia/compat/templates/compat/index.html:25 src/olympia/compat/templates/compat/reporter_detail.html:29
-#: src/olympia/files/templates/files/viewer.html:29 src/olympia/templates/amo_footer.html:17 src/olympia/templates/includes/lang_switcher.html:10
+#: src/olympia/bandwagon/templates/bandwagon/collection_detail.html:125 src/olympia/compat/templates/compat/reporter_detail.html:29 src/olympia/files/templates/files/viewer.html:29
+#: src/olympia/templates/amo_footer.html:17 src/olympia/templates/includes/lang_switcher.html:10
 msgid "Go"
 msgstr ""
 
@@ -2399,7 +2399,6 @@ msgid "<span>%(addons)s</span> add-on"
 msgid_plural "<span>%(addons)s</span> add-ons"
 msgstr[0] ""
 msgstr[1] ""
-msgstr[2] ""
 
 #: src/olympia/bandwagon/templates/bandwagon/collection_grid.html:32
 #, python-format
@@ -2407,7 +2406,6 @@ msgid "<span>%(followers)s</span> follower"
 msgid_plural "<span>%(followers)s</span> followers"
 msgstr[0] ""
 msgstr[1] ""
-msgstr[2] ""
 
 #. People "follow" collections to get notified of updates.                    Like
 #. Twitter followers.
@@ -2419,7 +2417,6 @@ msgid "%(num)s weekly follower"
 msgid_plural "%(num)s weekly followers"
 msgstr[0] ""
 msgstr[1] ""
-msgstr[2] ""
 
 #. People "follow" collections to get notified of updates.                    Like
 #. Twitter followers.
@@ -2429,7 +2426,6 @@ msgid "%(num)s monthly follower"
 msgid_plural "%(num)s monthly followers"
 msgstr[0] ""
 msgstr[1] ""
-msgstr[2] ""
 
 #. People "follow" collections to get notified of updates.                    Like
 #. Twitter followers.
@@ -2441,7 +2437,6 @@ msgid "%(num)s follower"
 msgid_plural "%(num)s followers"
 msgstr[0] ""
 msgstr[1] ""
-msgstr[2] ""
 
 #: src/olympia/bandwagon/templates/bandwagon/collection_listing_items.html:56 src/olympia/bandwagon/templates/bandwagon/impala/collection_listing_items.html:9
 #: src/olympia/devhub/templates/devhub/personas/edit.html:27
@@ -2525,7 +2520,7 @@ msgid "Remove this user as a contributor"
 msgstr ""
 
 #: src/olympia/bandwagon/templates/bandwagon/edit_contributors.html:18 src/olympia/bandwagon/templates/bandwagon/edit_contributors.html:43
-#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:20 src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:48
+#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:18 src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:46
 #: src/olympia/devhub/templates/devhub/addons/ajax_compat_update.html:19
 msgid "Remove"
 msgstr ""
@@ -2573,7 +2568,7 @@ msgid "<b>Warning:</b> By changing the owner of this collection, you will no lon
 msgstr ""
 
 #: src/olympia/bandwagon/templates/bandwagon/edit_contributors.html:83 src/olympia/devhub/templates/devhub/addons/forms_shared/media.html:157
-#: src/olympia/devhub/templates/devhub/addons/submit/describe.html:69 src/olympia/devhub/templates/devhub/addons/submit/license.html:60 src/olympia/devhub/templates/devhub/addons/submit/upload.html:78
+#: src/olympia/devhub/templates/devhub/addons/submit/describe.html:69 src/olympia/devhub/templates/devhub/addons/submit/license.html:60 src/olympia/devhub/templates/devhub/addons/submit/upload.html:70
 #: src/olympia/devhub/templates/devhub/payments/tier.html:17 src/olympia/editors/templates/editors/themes/themes.html:111 src/olympia/editors/templates/editors/themes/themes.html:128
 #: src/olympia/editors/templates/editors/themes/themes.html:134 src/olympia/editors/templates/editors/themes/themes.html:141 src/olympia/users/templates/users/fxa_migration_prompt_content.html:10
 #: src/olympia/users/templates/users/login_form.html:42 src/olympia/users/templates/users/mobile/login.html:57
@@ -2656,31 +2651,31 @@ msgid "Add-ons in Your Collection"
 msgstr ""
 
 #: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:4
-msgid ""
-"To include an add-on in this collection, enter its name in the box below and hit enter.  You can also use the <strong>Add to Collection</strong> links throughout the site to include add-ons later."
+msgid "To include an add-on in this collection, enter its name in the box below and hit enter."
 msgstr ""
 
-#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:17 src/olympia/constants/base.py:400 src/olympia/devhub/templates/devhub/addons/activity.html:62
+#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:15 src/olympia/constants/base.py:400 src/olympia/devhub/templates/devhub/addons/activity.html:62
+#: src/olympia/editors/helpers.py:273 src/olympia/editors/helpers.py:360
 msgid "Add-on"
 msgstr ""
 
-#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:26
+#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:24
 msgid "Enter the name of the add-on to include"
 msgstr ""
 
-#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:28
+#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:26
 msgid "Add to Collection"
 msgstr ""
 
-#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:45 src/olympia/editors/helpers.py:936 src/olympia/editors/helpers.py:956
+#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:43 src/olympia/editors/helpers.py:1016 src/olympia/editors/helpers.py:1036
 msgid "Pending"
 msgstr ""
 
-#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:47
+#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:45
 msgid "Add a comment"
 msgstr ""
 
-#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:48
+#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:46
 msgid "Remove this add-on from the collection"
 msgstr ""
 
@@ -2787,12 +2782,12 @@ msgstr ""
 msgid "Most Users"
 msgstr ""
 
-#: src/olympia/browse/views.py:61 src/olympia/browse/views.py:72 src/olympia/browse/views.py:279 src/olympia/browse/templates/browse/personas/mobile/category_landing.html:63
+#: src/olympia/browse/views.py:61 src/olympia/browse/views.py:72 src/olympia/browse/views.py:246 src/olympia/browse/templates/browse/personas/mobile/category_landing.html:63
 #: src/olympia/discovery/templates/discovery/pane.html:67 src/olympia/search/forms.py:92
 msgid "Up & Coming"
 msgstr ""
 
-#: src/olympia/browse/views.py:460 src/olympia/devhub/views.py:76 src/olympia/devhub/views.py:83 src/olympia/discovery/templates/discovery/addons/detail.html:66
+#: src/olympia/browse/views.py:427 src/olympia/devhub/views.py:74 src/olympia/devhub/views.py:81 src/olympia/discovery/templates/discovery/addons/detail.html:66
 msgid "Created"
 msgstr ""
 
@@ -2873,7 +2868,6 @@ msgid "<b>{0}</b> add-on"
 msgid_plural "<b>{0}</b> add-ons"
 msgstr[0] ""
 msgstr[1] ""
-msgstr[2] ""
 
 #: src/olympia/browse/templates/browse/search_tools.html:61
 msgid "Search Extensions"
@@ -2980,10 +2974,9 @@ msgid "See the %(cnt)s extension in %(name)s &raquo;"
 msgid_plural "See all %(cnt)s extensions in %(name)s &raquo;"
 msgstr[0] ""
 msgstr[1] ""
-msgstr[2] ""
 
-#: src/olympia/browse/templates/browse/mobile/extensions.html:13 src/olympia/compat/templates/compat/index.html:82 src/olympia/devhub/templates/devhub/devhub_search.html:24
-#: src/olympia/devhub/templates/devhub/addons/activity.html:47 src/olympia/search/templates/search/no_results.html:4 src/olympia/search/templates/search/mobile/results.html:36
+#: src/olympia/browse/templates/browse/mobile/extensions.html:13 src/olympia/devhub/templates/devhub/devhub_search.html:24 src/olympia/devhub/templates/devhub/addons/activity.html:47
+#: src/olympia/search/templates/search/no_results.html:4 src/olympia/search/templates/search/mobile/results.html:36
 msgid "No results found."
 msgstr ""
 
@@ -3068,7 +3061,7 @@ msgstr ""
 msgid "All"
 msgstr ""
 
-#: src/olympia/compat/forms.py:22 src/olympia/search/views.py:525
+#: src/olympia/compat/forms.py:22 src/olympia/editors/templates/editors/base.html:69 src/olympia/search/views.py:518
 msgid "All Add-ons"
 msgstr ""
 
@@ -3078,53 +3071,6 @@ msgstr ""
 
 #: src/olympia/compat/forms.py:24
 msgid "Non-binary"
-msgstr ""
-
-#. Review points sources other than add-ons and themes.
-#: src/olympia/compat/views.py:87 src/olympia/constants/base.py:388 src/olympia/devhub/forms.py:162 src/olympia/editors/templates/editors/performance.html:75
-msgid "Other"
-msgstr ""
-
-#: src/olympia/compat/templates/compat/index.html:4
-msgid "Add-on Compatibility Report for {app} {version}"
-msgstr ""
-
-#: src/olympia/compat/templates/compat/index.html:11
-msgid "{app} {version} Compatibility"
-msgstr ""
-
-#: src/olympia/compat/templates/compat/index.html:17
-#, python-format
-msgid "Top 95%% compatible with previous version"
-msgstr ""
-
-#: src/olympia/compat/templates/compat/index.html:18
-#, python-format
-msgid "Top 95%% of all add-ons"
-msgstr ""
-
-#: src/olympia/compat/templates/compat/index.html:19
-msgid "All active add-ons"
-msgstr ""
-
-#: src/olympia/compat/templates/compat/index.html:23 src/olympia/constants/base.py:401
-msgid "App"
-msgstr ""
-
-#: src/olympia/compat/templates/compat/index.html:55
-msgid "Details for add-ons compatible with previous version:"
-msgstr ""
-
-#: src/olympia/compat/templates/compat/index.html:57
-msgid "Show all versions"
-msgstr ""
-
-#: src/olympia/compat/templates/compat/index.html:59
-msgid "Details for add-ons compatible with all versions:"
-msgstr ""
-
-#: src/olympia/compat/templates/compat/index.html:61
-msgid "Show previous version only"
 msgstr ""
 
 #: src/olympia/compat/templates/compat/reporter.html:3
@@ -3159,14 +3105,12 @@ msgid "{0} success report"
 msgid_plural "{0} success reports"
 msgstr[0] ""
 msgstr[1] ""
-msgstr[2] ""
 
 #: src/olympia/compat/templates/compat/reporter_detail.html:17
 msgid "{0} problem report"
 msgid_plural "{0} problem reports"
 msgstr[0] ""
 msgstr[1] ""
-msgstr[2] ""
 
 #: src/olympia/compat/templates/compat/reporter_detail.html:21 src/olympia/users/templates/users/profile.html:70
 msgid "View all"
@@ -3180,8 +3124,8 @@ msgstr ""
 msgid "Report Type"
 msgstr ""
 
-#: src/olympia/compat/templates/compat/reporter_detail.html:47 src/olympia/devhub/forms.py:784 src/olympia/devhub/templates/devhub/addons/ajax_compat_update.html:17 src/olympia/editors/forms.py:108
-#: src/olympia/zadmin/forms.py:45
+#: src/olympia/compat/templates/compat/reporter_detail.html:47 src/olympia/devhub/forms.py:785 src/olympia/devhub/templates/devhub/addons/ajax_compat_update.html:17 src/olympia/editors/forms.py:108
+#: src/olympia/editors/forms.py:248 src/olympia/zadmin/forms.py:45
 msgid "Application"
 msgstr ""
 
@@ -3269,7 +3213,8 @@ msgstr ""
 msgid "Preliminarily Reviewed and Awaiting Full Review"
 msgstr ""
 
-#: src/olympia/constants/base.py:33 src/olympia/editors/helpers.py:924 src/olympia/editors/templates/editors/themes/history_table.html:34
+#: src/olympia/constants/base.py:33 src/olympia/editors/forms.py:258 src/olympia/editors/helpers.py:73 src/olympia/editors/helpers.py:1004
+#: src/olympia/editors/templates/editors/themes/history_table.html:34
 msgid "Deleted"
 msgstr ""
 
@@ -3366,6 +3311,11 @@ msgstr ""
 msgid "Ask before users can download this add-on"
 msgstr ""
 
+#. Review points sources other than add-ons and themes.
+#: src/olympia/constants/base.py:388 src/olympia/devhub/forms.py:162 src/olympia/editors/templates/editors/performance.html:75
+msgid "Other"
+msgstr ""
+
 #: src/olympia/constants/base.py:389
 msgid "Exception"
 msgstr ""
@@ -3376,6 +3326,10 @@ msgstr ""
 
 #: src/olympia/constants/base.py:391
 msgid "Change"
+msgstr ""
+
+#: src/olympia/constants/base.py:401
+msgid "App"
 msgstr ""
 
 #: src/olympia/constants/base.py:402
@@ -3526,7 +3480,7 @@ msgstr ""
 msgid "Duplicate"
 msgstr ""
 
-#: src/olympia/constants/editors.py:17 src/olympia/editors/helpers.py:502 src/olympia/editors/templates/editors/themes/queue.html:71 src/olympia/editors/templates/editors/themes/themes.html:94
+#: src/olympia/constants/editors.py:17 src/olympia/editors/helpers.py:575 src/olympia/editors/templates/editors/themes/queue.html:71 src/olympia/editors/templates/editors/themes/themes.html:94
 msgid "Reject"
 msgstr ""
 
@@ -3626,7 +3580,7 @@ msgstr ""
 msgid "Android"
 msgstr ""
 
-#: src/olympia/core/apps.py:19
+#: src/olympia/core/apps.py:21
 msgid "Core"
 msgstr ""
 
@@ -3760,7 +3714,7 @@ msgid "Submit my add-on for manual review."
 msgstr ""
 
 #: src/olympia/devhub/forms.py:537
-msgid "Do not list my add-on on this site (beta)"
+msgid "Do not list my add-on on this site"
 msgstr ""
 
 #: src/olympia/devhub/forms.py:538
@@ -3793,46 +3747,46 @@ msgstr ""
 
 #: src/olympia/devhub/forms.py:592
 #, python-format
-msgid "Version %s already exists"
+msgid "Version %s already exists, or was uploaded before."
 msgstr ""
 
-#: src/olympia/devhub/forms.py:604
+#: src/olympia/devhub/forms.py:605
 msgid "Select a valid choice. That choice is not one of the available choices."
 msgstr ""
 
-#: src/olympia/devhub/forms.py:610
+#: src/olympia/devhub/forms.py:611
 msgid "A file with a version ending with a|alpha|b|beta and an optional number is detected as beta."
 msgstr ""
 
-#: src/olympia/devhub/forms.py:633
+#: src/olympia/devhub/forms.py:634
 msgid "You cannot upload any more files for this version."
 msgstr ""
 
-#: src/olympia/devhub/forms.py:639
+#: src/olympia/devhub/forms.py:640
 msgid "Version doesn't match"
 msgstr ""
 
-#: src/olympia/devhub/forms.py:668
+#: src/olympia/devhub/forms.py:669
 msgid "You cannot delete a file once the review process has started.  You must delete the whole version."
 msgstr ""
 
-#: src/olympia/devhub/forms.py:688
+#: src/olympia/devhub/forms.py:689
 msgid "The platform All cannot be combined with specific platforms."
 msgstr ""
 
-#: src/olympia/devhub/forms.py:693
+#: src/olympia/devhub/forms.py:694
 msgid "A platform can only be chosen once."
 msgstr ""
 
-#: src/olympia/devhub/forms.py:706
+#: src/olympia/devhub/forms.py:707
 msgid "A review type must be selected."
 msgstr ""
 
-#: src/olympia/devhub/forms.py:788 src/olympia/editors/forms.py:114 src/olympia/zadmin/forms.py:49 src/olympia/zadmin/forms.py:52
+#: src/olympia/devhub/forms.py:789 src/olympia/editors/forms.py:114 src/olympia/editors/forms.py:254 src/olympia/zadmin/forms.py:49 src/olympia/zadmin/forms.py:52
 msgid "Select an application first"
 msgstr ""
 
-#: src/olympia/devhub/forms.py:840
+#: src/olympia/devhub/forms.py:841
 msgid "There cannot be more than 3 required add-ons."
 msgstr ""
 
@@ -3854,7 +3808,6 @@ msgid "{0} error"
 msgid_plural "{0} errors"
 msgstr[0] ""
 msgstr[1] ""
-msgstr[2] ""
 
 #. L10n: first parameter is the number of warnings
 #: src/olympia/devhub/helpers.py:203
@@ -3862,82 +3815,81 @@ msgid "{0} warning"
 msgid_plural "{0} warnings"
 msgstr[0] ""
 msgstr[1] ""
-msgstr[2] ""
 
 #: src/olympia/devhub/models.py:375 src/olympia/reviews/templates/reviews/add.html:58
 msgid "Review"
 msgstr ""
 
-#: src/olympia/devhub/tasks.py:551
+#: src/olympia/devhub/tasks.py:583
 #, python-format
 msgid "%s responded with %s (%s)."
 msgstr ""
 
-#: src/olympia/devhub/tasks.py:555
+#: src/olympia/devhub/tasks.py:587
 #, python-format
 msgid "Connection to \"%s\" timed out."
 msgstr ""
 
-#: src/olympia/devhub/tasks.py:557
+#: src/olympia/devhub/tasks.py:589
 #, python-format
 msgid "Could not contact host at \"%s\"."
 msgstr ""
 
-#: src/olympia/devhub/utils.py:104
+#: src/olympia/devhub/utils.py:105
 #, python-format
 msgid "Validation generated too many errors/warnings so %s messages were truncated. After addressing the visible messages, you'll be able to see the others."
 msgstr ""
 
-#: src/olympia/devhub/views.py:183
+#: src/olympia/devhub/views.py:181
 msgid "All My Add-ons"
 msgstr ""
 
-#: src/olympia/devhub/views.py:210
+#: src/olympia/devhub/views.py:208
 msgid "All Activity"
 msgstr ""
 
-#: src/olympia/devhub/views.py:211
+#: src/olympia/devhub/views.py:209
 msgid "Add-on Updates"
 msgstr ""
 
-#: src/olympia/devhub/views.py:212
+#: src/olympia/devhub/views.py:210
 msgid "Add-on Status"
 msgstr ""
 
-#: src/olympia/devhub/views.py:213
+#: src/olympia/devhub/views.py:211
 msgid "User Collections"
 msgstr ""
 
-#: src/olympia/devhub/views.py:214 src/olympia/devhub/templates/devhub/docs/policies-maintenance.html:68 src/olympia/pages/templates/pages/dev_faq.html:38
+#: src/olympia/devhub/views.py:212 src/olympia/devhub/templates/devhub/docs/policies-maintenance.html:68 src/olympia/pages/templates/pages/dev_faq.html:38
 #: src/olympia/pages/templates/pages/dev_faq.html:484
 msgid "User Reviews"
 msgstr ""
 
-#: src/olympia/devhub/views.py:327 src/olympia/devhub/views.py:331 src/olympia/devhub/views.py:484 src/olympia/devhub/views.py:513 src/olympia/devhub/views.py:564 src/olympia/devhub/views.py:1150
+#: src/olympia/devhub/views.py:325 src/olympia/devhub/views.py:329 src/olympia/devhub/views.py:484 src/olympia/devhub/views.py:513 src/olympia/devhub/views.py:564 src/olympia/devhub/views.py:1156
 msgid "Changes successfully saved."
 msgstr ""
 
-#: src/olympia/devhub/views.py:334 src/olympia/devhub/views.py:1631
+#: src/olympia/devhub/views.py:332 src/olympia/devhub/views.py:1637
 msgid "Please check the form for errors."
 msgstr ""
 
-#: src/olympia/devhub/views.py:346
+#: src/olympia/devhub/views.py:344
 msgid "Add-on cannot be deleted. Disable this add-on instead."
 msgstr ""
 
-#: src/olympia/devhub/views.py:356
+#: src/olympia/devhub/views.py:354
 msgid "Theme deleted."
 msgstr ""
 
-#: src/olympia/devhub/views.py:356
+#: src/olympia/devhub/views.py:354
 msgid "Add-on deleted."
 msgstr ""
 
-#: src/olympia/devhub/views.py:362
+#: src/olympia/devhub/views.py:360
 msgid "URL name was incorrect. Theme was not deleted."
 msgstr ""
 
-#: src/olympia/devhub/views.py:367
+#: src/olympia/devhub/views.py:365
 msgid "URL name was incorrect. Add-on was not deleted."
 msgstr ""
 
@@ -3965,7 +3917,7 @@ msgstr ""
 msgid "Check Add-on Compatibility"
 msgstr ""
 
-#: src/olympia/devhub/views.py:808 src/olympia/signing/views.py:90
+#: src/olympia/devhub/views.py:808 src/olympia/signing/views.py:95
 msgid "You cannot submit this type of add-on"
 msgstr ""
 
@@ -3995,33 +3947,33 @@ msgstr ""
 msgid "There was an error uploading your preview."
 msgstr ""
 
-#: src/olympia/devhub/views.py:1189
+#: src/olympia/devhub/views.py:1195
 #, python-format
 msgid "Version %s disabled."
 msgstr ""
 
-#: src/olympia/devhub/views.py:1193
+#: src/olympia/devhub/views.py:1199
 #, python-format
 msgid "Version %s deleted."
 msgstr ""
 
-#: src/olympia/devhub/views.py:1203
+#: src/olympia/devhub/views.py:1209
 msgid "This upload has failed validation, and may lack complete validation results. Please take due care when reviewing it."
 msgstr ""
 
-#: src/olympia/devhub/views.py:1677
+#: src/olympia/devhub/views.py:1683
 msgid "Preliminary Review Requested."
 msgstr ""
 
-#: src/olympia/devhub/views.py:1678
+#: src/olympia/devhub/views.py:1684
 msgid "Full Review Requested."
 msgstr ""
 
-#: src/olympia/devhub/views.py:1779
+#: src/olympia/devhub/views.py:1783
 msgid "Your old credentials were revoked and are no longer valid. Be sure to update all API clients with the new credentials."
 msgstr ""
 
-#: src/olympia/devhub/views.py:1797
+#: src/olympia/devhub/views.py:1801
 msgid "New API key created"
 msgstr ""
 
@@ -4051,7 +4003,7 @@ msgstr ""
 msgid "{0} :: Search"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/devhub_search.html:6 src/olympia/devhub/templates/devhub/search.html:8 src/olympia/editors/forms.py:435 src/olympia/editors/forms.py:437
+#: src/olympia/devhub/templates/devhub/devhub_search.html:6 src/olympia/devhub/templates/devhub/search.html:8 src/olympia/editors/forms.py:534 src/olympia/editors/forms.py:536
 #: src/olympia/editors/templates/editors/queue.html:27 src/olympia/editors/templates/editors/themes/queue_list.html:14 src/olympia/search/templates/search/collections.html:17
 #: src/olympia/search/templates/search/personas.html:18 src/olympia/search/templates/search/results.html:18 src/olympia/search/templates/search/mobile/results.html:8
 #: src/olympia/templates/search.html:14 src/olympia/templates/impala/search.html:18
@@ -4111,12 +4063,12 @@ msgstr ""
 msgid "Start Making Add-ons"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/index.html:86 src/olympia/devhub/templates/devhub/addons/listing/items.html:25 src/olympia/devhub/templates/devhub/includes/addon_details.html:15
+#: src/olympia/devhub/templates/devhub/index.html:86 src/olympia/devhub/templates/devhub/addons/listing/items.html:25 src/olympia/devhub/templates/devhub/includes/addon_details.html:20
 #: src/olympia/devhub/templates/devhub/personas/edit.html:43
 msgid "Status:"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/index.html:90 src/olympia/devhub/templates/devhub/includes/addon_details.html:100
+#: src/olympia/devhub/templates/devhub/index.html:90 src/olympia/devhub/templates/devhub/includes/addon_details.html:87
 msgid "Visibility:"
 msgstr ""
 
@@ -4124,11 +4076,11 @@ msgstr ""
 msgid "Latest Version:"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/index.html:109 src/olympia/devhub/templates/devhub/includes/addon_details.html:145 src/olympia/devhub/templates/devhub/personas/edit.html:49
+#: src/olympia/devhub/templates/devhub/index.html:109 src/olympia/devhub/templates/devhub/includes/addon_details.html:131 src/olympia/devhub/templates/devhub/personas/edit.html:49
 msgid "Queue Position:"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/index.html:110 src/olympia/devhub/templates/devhub/includes/addon_details.html:146 src/olympia/devhub/templates/devhub/personas/edit.html:50
+#: src/olympia/devhub/templates/devhub/index.html:110 src/olympia/devhub/templates/devhub/includes/addon_details.html:132 src/olympia/devhub/templates/devhub/personas/edit.html:50
 #, python-format
 msgid "%(position)s of %(total)s"
 msgstr ""
@@ -4230,16 +4182,6 @@ msgstr ""
 msgid "Do you want your add-on to be distributed on this site?"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/validate_addon.html:49 src/olympia/devhub/templates/devhub/addons/submit/upload.html:30 src/olympia/devhub/templates/devhub/versions/add_file_modal.html:14
-#: src/olympia/devhub/templates/devhub/versions/add_file_modal.html:53 src/olympia/devhub/templates/devhub/versions/list.html:298
-msgid "Warning:"
-msgstr ""
-
-#: src/olympia/devhub/templates/devhub/validate_addon.html:50 src/olympia/devhub/templates/devhub/addons/submit/upload.html:31
-#, python-format
-msgid "Submission of unlisted add-ons for signing is currently in an open beta. Please <a href=\"%(url)s\" target=\"_blank\">report any bugs</a> that you encounter."
-msgstr ""
-
 #. first parameter is a filename like lorem-ipsum-1.0.2.xpi
 #: src/olympia/devhub/templates/devhub/validation.html:5
 msgid "Validation Results for {0}"
@@ -4314,7 +4256,7 @@ msgstr ""
 msgid "Update Compatibility"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/addons/ajax_compat_update.html:4
+#: src/olympia/devhub/templates/devhub/addons/ajax_compat_update.html:4 src/olympia/devhub/templates/devhub/versions/edit.html:45
 msgid "Adjusting application information here will allow users to install your add-on even if the install manifest in the package indicates that the add-on is incompatible."
 msgstr ""
 
@@ -4326,9 +4268,9 @@ msgstr ""
 msgid "Add Another Application&hellip;"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/addons/ajax_compat_update.html:38 src/olympia/devhub/templates/devhub/addons/owner.html:86 src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:46
-#: src/olympia/devhub/templates/devhub/versions/list.html:351 src/olympia/devhub/templates/devhub/versions/list.html:353 src/olympia/templates/impala/base.html:132
-#: src/olympia/templates/impala/base.html:143 src/olympia/templates/impala/base.html:161 src/olympia/templates/impala/base.html:171
+#: src/olympia/devhub/templates/devhub/addons/ajax_compat_update.html:38 src/olympia/devhub/templates/devhub/addons/owner.html:86 src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:45
+#: src/olympia/devhub/templates/devhub/versions/list.html:349 src/olympia/devhub/templates/devhub/versions/list.html:351 src/olympia/templates/impala/base.html:129
+#: src/olympia/templates/impala/base.html:140 src/olympia/templates/impala/base.html:158 src/olympia/templates/impala/base.html:168
 msgid "Close"
 msgstr ""
 
@@ -4347,7 +4289,6 @@ msgid "<b>{0}</b> theme"
 msgid_plural "<b>{0}</b> themes"
 msgstr[0] ""
 msgstr[1] ""
-msgstr[2] ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit.html:3 src/olympia/devhub/templates/devhub/addons/listing/item_actions.html:25
 #: src/olympia/devhub/templates/devhub/addons/listing/item_actions_theme.html:7 src/olympia/devhub/templates/devhub/includes/addons_edit_nav.html:2
@@ -4363,7 +4304,7 @@ msgstr ""
 msgid "Manage Authors & License"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/addons/owner.html:29 src/olympia/editors/templates/editors/review.html:270
+#: src/olympia/devhub/templates/devhub/addons/owner.html:29 src/olympia/editors/helpers.py:362 src/olympia/editors/templates/editors/review.html:270
 msgid "Authors"
 msgstr ""
 
@@ -4432,17 +4373,11 @@ msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/basic.html:52
 msgid ""
-"A short explanation of your add-on's basic\n"
-"                          functionality that is displayed in search and browse\n"
-"                          listings, as well as at the top of your add-on's\n"
-"                          details page. It is only relevant for listed add-ons."
+"A short explanation of your add-on's basic functionality that is displayed in search and browse listings, as well as at the top of your add-on's details page. It is only relevant for listed add-ons."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/basic.html:73
-msgid ""
-"Categories are the primary way users browse through add-ons.\n"
-"                        Choose any that fit your add-on's functionality for the most\n"
-"                        exposure. It is only relevant for listed add-ons."
+msgid "Categories are the primary way users browse through add-ons. Choose any that fit your add-on's functionality for the most exposure. It is only relevant for listed add-ons."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/basic.html:90
@@ -4452,11 +4387,7 @@ msgid ""
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/basic.html:119
-msgid ""
-"Tags help users find your add-on and should be short\n"
-"                        descriptors such as tabs, toolbar, or twitter.  You\n"
-"                        may have a maximum of {0} tags. It is only relevant\n"
-"                        for listed add-ons."
+msgid "Tags help users find your add-on and should be short descriptors such as tabs, toolbar, or twitter. You may have a maximum of {0} tags. It is only relevant for listed add-ons."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/basic.html:129 src/olympia/devhub/templates/devhub/personas/edit.html:97 src/olympia/devhub/templates/devhub/personas/submit.html:46
@@ -4464,7 +4395,6 @@ msgid "Comma-separated, minimum of {0} character."
 msgid_plural "Comma-separated, minimum of {0} characters."
 msgstr[0] ""
 msgstr[1] ""
-msgstr[2] ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/basic.html:132 src/olympia/devhub/templates/devhub/personas/edit.html:100 src/olympia/devhub/templates/devhub/personas/submit.html:49
 msgid "Example: dark, cinema, noir. Limit 20."
@@ -4475,7 +4405,6 @@ msgid "Reserved tag:"
 msgid_plural "Reserved tags:"
 msgstr[0] ""
 msgstr[1] ""
-msgstr[2] ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/details.html:5
 msgid "Add-on Details"
@@ -4486,11 +4415,7 @@ msgid "Add-on Details for {0}"
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/details.html:22
-msgid ""
-"A longer explanation of features,\n"
-"                          functionality, and other relevant information. This\n"
-"                          field is only displayed on the add-on's details\n"
-"                          page. It is only relevant for listed add-ons."
+msgid "A longer explanation of features, functionality, and other relevant information. This field is only displayed on the add-on's details page. It is only relevant for listed add-ons."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/details.html:44 src/olympia/translations/templates/translations/trans-menu.html:13
@@ -4498,10 +4423,7 @@ msgid "Default Locale"
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/details.html:45
-msgid ""
-"Information about your add-on is displayed in this locale\n"
-"                        unless you override it with a locale-specific translation.\n"
-"                        It is only relevant for listed add-ons."
+msgid "Information about your add-on is displayed in this locale unless you override it with a locale-specific translation. It is only relevant for listed add-ons."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/details.html:61 src/olympia/users/forms.py:311 src/olympia/users/templates/users/edit.html:122 src/olympia/users/templates/users/register.html:57
@@ -4511,10 +4433,8 @@ msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/details.html:63
 msgid ""
-"If your add-on has another homepage, enter its\n"
-"                          address here. If your website is localized into other\n"
-"                          languages multiple translations of this field can be\n"
-"                          added. It is only relevant for listed add-ons."
+"If your add-on has another homepage, enter its address here. If your website is localized into other languages multiple translations of this field can be added. It is only relevant for listed add-"
+"ons."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/media.html:3
@@ -4532,19 +4452,14 @@ msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/support.html:22
 msgid ""
-"If you wish to display an e-mail address for support\n"
-"                          inquiries, enter it here. If you have different\n"
-"                          addresses for each language multiple translations of\n"
-"                          this field can be added. It is only relevant for\n"
-"                          listed add-ons."
+"If you wish to display an e-mail address for support inquiries, enter it here. If you have different addresses for each language multiple translations of this field can be added. It is only "
+"relevant for listed add-ons."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/support.html:45
 msgid ""
-"If your add-on has a support website or forum, enter\n"
-"                          its address here. If your website is localized into\n"
-"                          other languages, multiple translations of this field can\n"
-"                          be added. It is only relevant for listed add-ons."
+"If your add-on has a support website or forum, enter its address here. If your website is localized into other languages, multiple translations of this field can be added. It is only relevant for "
+"listed add-ons."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:6
@@ -4558,11 +4473,8 @@ msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:23
 msgid ""
-"Any information end users may want to know that isn't\n"
-"                          necessarily applicable to the add-on summary or description.\n"
-"                          Common uses include listing known major bugs, information on\n"
-"                          how to report bugs, anticipated release date of a new version,\n"
-"                          etc. It is only relevant for listed add-ons."
+"Any information end users may want to know that isn't necessarily applicable to the add-on summary or description. Common uses include listing known major bugs, information on how to report bugs, "
+"anticipated release date of a new version, etc. It is only relevant for listed add-ons."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:46
@@ -4574,9 +4486,7 @@ msgid "Add-on Flags"
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:69
-msgid ""
-"These flags are used to classify add-ons. It is only\n"
-"                        relevant for listed add-ons."
+msgid "These flags are used to classify add-ons. It is only relevant for listed add-ons."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:74
@@ -4592,9 +4502,7 @@ msgid "View Source?"
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:90
-msgid ""
-"Whether the source of your add-on can be displayed in our\n"
-"                        online viewer. It is only relevant for listed add-ons."
+msgid "Whether the source of your add-on can be displayed in our online viewer. It is only relevant for listed add-ons."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:94
@@ -4610,10 +4518,7 @@ msgid "Public Stats?"
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:102
-msgid ""
-"Whether the download and usage stats of your add-on can\n"
-"                        be displayed in our online viewer.\n"
-"                        It is only relevant for listed add-ons."
+msgid "Whether the download and usage stats of your add-on can be displayed in our online viewer. It is only relevant for listed add-ons."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:107
@@ -4629,10 +4534,7 @@ msgid "Upgrade SDK?"
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:116
-msgid ""
-"If selected, we will try to automatically upgrade your\n"
-"                        add-on when a new version of the SDK is released.\n"
-"                        It is only relevant for listed add-ons."
+msgid "If selected, we will try to automatically upgrade your add-on when a new version of the SDK is released. It is only relevant for listed add-ons."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:121
@@ -4683,10 +4585,8 @@ msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/forms_shared/media.html:16
 msgid ""
-"Upload an icon for your add-on or choose from one of ours. The\n"
-"                      icon is displayed nearly everywhere your add-on is. Uploaded images\n"
-"                      must be one of the following image types: .png, .jpg.\n"
-"                      It is only relevant for listed add-ons."
+"Upload an icon for your add-on or choose from one of ours. The icon is displayed nearly everywhere your add-on is. Uploaded images must be one of the following image types: .png, .jpg. It is only "
+"relevant for listed add-ons."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/forms_shared/media.html:25
@@ -4699,9 +4599,7 @@ msgid "32x32px"
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/forms_shared/media.html:39
-msgid ""
-"Used in listings of add-ons, like search results\n"
-"                            and featured add-ons."
+msgid "Used in listings of add-ons, like search results and featured add-ons."
 msgstr ""
 
 #. The size of the icon
@@ -4796,16 +4694,14 @@ msgid "Deleting your add-on will permanently remove it from the site and prevent
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:24
-msgid ""
-"Enter the following text confirm your decision:\n"
-"           {slug}"
+msgid "Enter the following text confirm your decision: {slug}"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:34
+#: src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:33
 msgid "Please tell us why you are deleting your theme:"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:36
+#: src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:35
 msgid "Please tell us why you are deleting your add-on:"
 msgstr ""
 
@@ -4842,8 +4738,8 @@ msgstr ""
 msgid "Daily statistics on downloads and users."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/addons/listing/item_actions.html:45 src/olympia/stats/templates/stats/stats.html:75 src/olympia/stats/templates/stats/stats.html:79
-#: src/olympia/stats/templates/stats/stats.html:81
+#: src/olympia/devhub/templates/devhub/addons/listing/item_actions.html:45 src/olympia/stats/templates/stats/stats.html:31 src/olympia/stats/templates/stats/stats.html:35
+#: src/olympia/stats/templates/stats/stats.html:37
 msgid "Statistics"
 msgstr ""
 
@@ -4904,7 +4800,6 @@ msgid "<strong>{0}</strong> active user"
 msgid_plural "<strong>{0}</strong> active users"
 msgstr[0] ""
 msgstr[1] ""
-msgstr[2] ""
 
 #: src/olympia/devhub/templates/devhub/addons/submit/base.html:11
 msgid "Submit Add-on"
@@ -4963,10 +4858,7 @@ msgid "Your add-on has been submitted to the Full Review queue."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/submit/done.html:18
-msgid ""
-"You'll receive an email once it has been reviewed by an editor. In\n"
-"          the meantime, you and your friends can install it directly from its\n"
-"          details page:"
+msgid "You'll receive an email once it has been reviewed by an editor. In the meantime, you and your friends can install it directly from its details page:"
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/submit/done.html:27 src/olympia/devhub/templates/devhub/addons/submit/done.html:77 src/olympia/devhub/templates/devhub/personas/submit_done.html:16
@@ -5172,11 +5064,11 @@ msgstr ""
 msgid "Use the fields below to upload your add-on package and select any platform restrictions. After upload, a series of automated validation tests will be run on your file."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/addons/submit/upload.html:59 src/olympia/devhub/templates/devhub/versions/add_file_modal.html:39
+#: src/olympia/devhub/templates/devhub/addons/submit/upload.html:51 src/olympia/devhub/templates/devhub/versions/add_file_modal.html:28
 msgid "Which platforms is this file compatible with?"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/addons/submit/upload.html:67 src/olympia/devhub/templates/devhub/versions/add_file_modal.html:65
+#: src/olympia/devhub/templates/devhub/addons/submit/upload.html:59 src/olympia/devhub/templates/devhub/versions/add_file_modal.html:45
 msgid "Administrative overrides"
 msgstr ""
 
@@ -5286,8 +5178,8 @@ msgstr ""
 
 #: src/olympia/devhub/templates/devhub/docs/policies-contact.html:44
 msgid ""
-"If you've found a problem with the site, we'd love to fix it. Please <a href=\"https://github.com/mozilla/olympia/issues\">file a bug report</a> in GitHub, including the location of the problem and "
-"how you encountered it."
+"If you've found a problem with the site, we'd love to fix it. Please <a href=\"https://github.com/mozilla/addons/issues/new\">file a bug report</a> in GitHub, including the location of the problem "
+"and how you encountered it."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/docs/policies-maintenance.html:3 src/olympia/devhub/templates/devhub/docs/policies-maintenance.html:7
@@ -5854,7 +5746,7 @@ msgstr ""
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:282
 msgid ""
-"Add-ons that store or otherwise handle browsing data must support <a href=\"https://developer.mozilla.org/En/Supporting_private_browsing_mode\">Private Browsing Mode</a>.  During a Private Browsing "
+"Add-ons that store or otherwise handle browsing data must support <a href=\"https://developer.mozilla.org/En/Supporting_private_browsing_mode\">Private Browsing Mode</a>. During a Private Browsing "
 "session, no browsing data can be written to disk, and all of this data must be cleared when Firefox quits or the Private Browsing session ends."
 msgstr ""
 
@@ -6019,129 +5911,95 @@ msgstr ""
 msgid "How to get in touch with us regarding these policies or your add-on."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:6
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:10
 msgid "You have disabled this add-on"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:20
-msgid ""
-"Your add-on's listing is disabled and is not showing\n"
-"                             anywhere in our gallery or update service."
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:24
+msgid "Your add-on's listing is disabled and is not showing anywhere in our gallery or update service."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:25
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:27
 msgid "Please complete your add-on."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:29
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:30
 msgid "You will receive an email when the review is complete."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:34
-msgid ""
-"You will receive an email when the review is complete. Until\n"
-"                             then, your add-on is not listed in our gallery but can be\n"
-"                             accessed directly from its details page."
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:33
+msgid "You will receive an email when the review is complete. Until then, your add-on is not listed in our gallery but can be accessed directly from its details page."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:38 src/olympia/devhub/templates/devhub/includes/addon_details.html:48
-msgid ""
-"You will receive an email when the review is\n"
-"                             complete and your add-on is signed."
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:37 src/olympia/devhub/templates/devhub/includes/addon_details.html:45
+msgid "You will receive an email when the review is complete and your add-on is signed."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:44
-msgid ""
-"You will receive an email when the review is complete. Until\n"
-"                             then, your add-on is not listed in our gallery but can be\n"
-"                             accessed directly from its details page. "
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:41
+msgid "You will receive an email when the review is complete. Until then, your add-on is not listed in our gallery but can be accessed directly from its details page. "
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:54
-msgid ""
-"Your add-on is displayed in our gallery and users are\n"
-"                             receiving automatic updates."
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:49
+msgid "Your add-on is displayed in our gallery and users are receiving automatic updates."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:57
-msgid ""
-"Your add-on has been signed and can be bundled with an\n"
-"                             application installer."
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:52
+msgid "Your add-on has been signed and can be bundled with an application installer."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:63
-msgid ""
-"Your add-on was disabled by a site administrator and is no\n"
-"                             longer shown in our gallery. If you have any questions,\n"
-"                             please email amo-admins@mozilla.org."
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:56
+msgid "Your add-on was disabled by a site administrator and is no longer shown in our gallery. If you have any questions, please email amo-admins@mozilla.org."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:70
-msgid ""
-"Your add-on is displayed in our gallery as experimental\n"
-"                             and users are receiving automatic updates. Some features\n"
-"                             are unavailable to your add-on."
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:62
+msgid "Your add-on is displayed in our gallery as experimental and users are receiving automatic updates. Some features are unavailable to your add-on."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:74
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:66
 msgid "Your add-on has been signed."
 msgstr ""
 
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:69
+msgid ""
+"You will receive an email when the full review is complete. Until then, your add-on is displayed in our gallery as experimental and users are receiving automatic updates. Some features are "
+"unavailable to your add-on."
+msgstr ""
+
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:74
+msgid "You will receive an email when the full review is complete, making you able to bundle your add-on with an application installer."
+msgstr ""
+
 #: src/olympia/devhub/templates/devhub/includes/addon_details.html:79
-msgid ""
-"You will receive an email when the full review is complete.\n"
-"                             Until then, your add-on is displayed in our gallery as\n"
-"                             experimental and users are receiving automatic updates.\n"
-"                             Some features are unavailable to your add-on."
+msgid "All add-ons hosted in our gallery must now be reviewed by an editor. If you wish to continue hosting your add-on, please click to select a review process."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:84
-msgid ""
-"You will receive an email when the full review is\n"
-"                             complete, making you able to bundle your add-on with an\n"
-"                             application installer."
-msgstr ""
-
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:91
-msgid ""
-"All add-ons hosted in our gallery must now be reviewed by an\n"
-"                             editor. If you wish to continue hosting your add-on, please\n"
-"                             click to select a review process."
-msgstr ""
-
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:113
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:100
 msgid "Current Version:"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:115
-msgid ""
-"This is the version of your add-on that will\n"
-"                                           be installed if someone clicks the Install\n"
-"                                           button on addons.mozilla.org. It is only\n"
-"                                           relevant for listed add-ons."
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:102
+msgid "This is the version of your add-on that will be installed if someone clicks the Install button on addons.mozilla.org. It is only relevant for listed add-ons."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:123
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:110
 msgid "Created:"
 msgstr ""
 
 #. {0} is a date. dennis-ignore: E201
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:125 src/olympia/devhub/templates/devhub/includes/addon_details.html:131
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:112 src/olympia/devhub/templates/devhub/includes/addon_details.html:118
 #, python-format
 msgid "%%b %%e, %%Y"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:136
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:123
 msgid "Next Version:"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:138
-msgid ""
-"This is the newest uploaded version, however\n"
-"                                           it isn’t live on the site yet."
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:125
+msgid "This is the newest uploaded version, however it isn’t live on the site yet."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:144 src/olympia/devhub/templates/devhub/versions/list.html:30
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:130 src/olympia/devhub/templates/devhub/versions/list.html:30
 msgid "Queues are not reviewed strictly in order"
 msgstr ""
 
@@ -6209,9 +6067,7 @@ msgid "View the blog &#9658;"
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/includes/license_form.html:6
-msgid ""
-"Please choose a license appropriate for the rights you grant on your source code.\n"
-"                  It is only relevant for listed add-ons."
+msgid "Please choose a license appropriate for the rights you grant on your source code. It is only relevant for listed add-ons."
 msgstr ""
 
 #. {0} is a list of HTML tags.
@@ -6234,19 +6090,15 @@ msgid "Select <b>up to {0}</b> {1} category for this add-on:"
 msgid_plural "Select <b>up to {0}</b> {1} categories for this add-on:"
 msgstr[0] ""
 msgstr[1] ""
-msgstr[2] ""
 
 #: src/olympia/devhub/templates/devhub/includes/policy_form.html:4
 msgid ""
 "Users will be required to accept the following End-User License Agreement (EULA) prior to installing your add-on. The presence of a EULA significantly affects the number of downloads an add-on "
-"receives. Please note that a EULA is not the same as a code license, such as the GPL or MPL.\n"
-"                It is only relevant for listed add-ons."
+"receives. Please note that a EULA is not the same as a code license, such as the GPL or MPL.It is only relevant for listed add-ons."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/policy_form.html:21
-msgid ""
-"If your add-on transmits any data from the user's computer, a privacy policy is required that explains what data is sent and how it is used.\n"
-"                It is only relevant for listed add-ons."
+#: src/olympia/devhub/templates/devhub/includes/policy_form.html:24
+msgid "If your add-on transmits any data from the user's computer, a privacy policy is required that explains what data is sent and how it is used. It is only relevant for listed add-ons."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/includes/source_form_field.html:2
@@ -6414,12 +6266,8 @@ msgstr ""
 msgid "Add some tags to describe your Theme."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/personas/edit.html:106
-msgid ""
-"A short explanation of your theme's\n"
-"                                basic functionality that is displayed in\n"
-"                                search and browse listings, as well as at\n"
-"                                the top of your theme's details page."
+#: src/olympia/devhub/templates/devhub/personas/edit.html:106 src/olympia/devhub/templates/devhub/personas/submit.html:54
+msgid "A short explanation of your theme's basic functionality that is displayed in search and browse listings, as well as at the top of your theme's details page."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/personas/edit.html:122 src/olympia/devhub/templates/devhub/personas/submit.html:68
@@ -6489,7 +6337,7 @@ msgid "Upon upload and form submission, the AMO Team will review your updated de
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/personas/edit.html:241
-msgid "Your previously resubmitted design,  which is under pending review."
+msgid "Your previously resubmitted design, which is under pending review."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/personas/edit.html:245
@@ -6556,14 +6404,6 @@ msgstr ""
 
 #: src/olympia/devhub/templates/devhub/personas/submit.html:33
 msgid "Give your Theme a name."
-msgstr ""
-
-#: src/olympia/devhub/templates/devhub/personas/submit.html:54
-msgid ""
-"A short explanation of your theme's\n"
-"                                      basic functionality that is displayed in\n"
-"                                      search and browse listings, as well as at\n"
-"                                      the top of your theme's details page."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/personas/submit.html:198
@@ -6640,30 +6480,16 @@ msgstr ""
 msgid "Files added to reviewed versions must be reviewed before they will be available for download."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/add_file_modal.html:15
-#, python-format
-msgid ""
-"Submission of updates to unlisted add-ons for signing is currently in an open beta. Manual review may still be required for a large number of add-ons. Please <a href=\"%(url)s\" target=\"_blank"
-"\">report any bugs</a> that you encounter."
-msgstr ""
-
-#: src/olympia/devhub/templates/devhub/versions/add_file_modal.html:35
+#: src/olympia/devhub/templates/devhub/versions/add_file_modal.html:24
 msgid "Select the target platform for this file."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/add_file_modal.html:46
+#: src/olympia/devhub/templates/devhub/versions/add_file_modal.html:35
 msgid "Which review type would you like to nominate for?"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/add_file_modal.html:51
+#: src/olympia/devhub/templates/devhub/versions/add_file_modal.html:40
 msgid "Only publish this version to my beta channel."
-msgstr ""
-
-#: src/olympia/devhub/templates/devhub/versions/add_file_modal.html:54
-#, python-format
-msgid ""
-"The behavior of the beta channel has changed to accommodate <a href=\"%(addon_signing_url)s\" target=\"_blank\">mandatory add-on signing</a>. The new process is currently in an open beta, and may "
-"change significantly in the near future. Please <a href=\"%(issues_url)s\" target=\"_blank\">report any bugs</a> that you encounter."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/versions/edit.html:5
@@ -6687,19 +6513,10 @@ msgstr ""
 msgid "Upload Another File"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/edit.html:45
-msgid ""
-"Adjusting application information here will allow users to install your\n"
-"                          add-on even if the install manifest in the package indicates that the\n"
-"                          add-on is incompatible."
-msgstr ""
-
 #: src/olympia/devhub/templates/devhub/versions/edit.html:74
 msgid ""
-"Information about changes in this release, new features,\n"
-"                              known bugs, and other useful information specific to this\n"
-"                              release/version. This information is also shown in the\n"
-"                              Add-ons Manager when updating."
+"Information about changes in this release, new features, known bugs, and other useful information specific to this release/version. This information is also shown in the Add-ons Manager when "
+"updating."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/versions/edit.html:99
@@ -6711,10 +6528,7 @@ msgid "Notes for Reviewers"
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/versions/edit.html:114
-msgid ""
-"Optionally, enter any information that may be useful\n"
-"                              to the Editor reviewing this add-on, such as test\n"
-"                              account information."
+msgid "Optionally, enter any information that may be useful to the Editor reviewing this add-on, such as test account information."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/versions/edit.html:127
@@ -6766,7 +6580,6 @@ msgid "{0} file"
 msgid_plural "{0} files"
 msgstr[0] ""
 msgstr[1] ""
-msgstr[2] ""
 
 #: src/olympia/devhub/templates/devhub/versions/list.html:25
 msgid "0 files"
@@ -6793,7 +6606,7 @@ msgstr ""
 msgid "Request Preliminary Review"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:80 src/olympia/devhub/templates/devhub/versions/list.html:327 src/olympia/devhub/templates/devhub/versions/list.html:350
+#: src/olympia/devhub/templates/devhub/versions/list.html:80 src/olympia/devhub/templates/devhub/versions/list.html:325 src/olympia/devhub/templates/devhub/versions/list.html:348
 msgid "Cancel Review Request"
 msgstr ""
 
@@ -6822,7 +6635,7 @@ msgid "Unlisted:"
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/versions/list.html:114
-msgid "Not distributed on {0}. Developers will upload new versions for signing and distribute the add-ons on their own. (beta)"
+msgid "Not distributed on {0}. Developers will upload new versions for signing and distribute the add-ons on their own."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/versions/list.html:122
@@ -6885,81 +6698,73 @@ msgid "<strong>Important:</strong> Once a version has been deleted, you may not 
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/versions/list.html:230
-msgid ""
-"Deleting a version which has already been reviewed\n"
-"               may also cause a significant delay in the review of\n"
-"               your next update."
-msgstr ""
-
-#: src/olympia/devhub/templates/devhub/versions/list.html:233
 msgid "Are you sure you wish to delete this version?"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:238
+#: src/olympia/devhub/templates/devhub/versions/list.html:235
 msgid "Delete Version"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:240
+#: src/olympia/devhub/templates/devhub/versions/list.html:237
 msgid "Disable Version"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:247
+#: src/olympia/devhub/templates/devhub/versions/list.html:244
 msgid "Add a new Version"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:249
+#: src/olympia/devhub/templates/devhub/versions/list.html:246
 msgid "Add Version"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:256 src/olympia/devhub/templates/devhub/versions/list.html:274
+#: src/olympia/devhub/templates/devhub/versions/list.html:253 src/olympia/devhub/templates/devhub/versions/list.html:279
 msgid "Hide Add-on"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:259
+#: src/olympia/devhub/templates/devhub/versions/list.html:256
 msgid "Hiding your add-on will prevent it from appearing anywhere in our gallery and will stop users from receiving automatic updates."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:265
+#: src/olympia/devhub/templates/devhub/versions/list.html:263
+msgid "The files awaiting review will be disabled and you will need to upload new versions."
+msgstr ""
+
+#: src/olympia/devhub/templates/devhub/versions/list.html:270
 msgid "Are you sure you wish to hide your add-on?"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:286 src/olympia/devhub/templates/devhub/versions/list.html:315
+#: src/olympia/devhub/templates/devhub/versions/list.html:291 src/olympia/devhub/templates/devhub/versions/list.html:313
 msgid "Unlist Add-on"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:289
+#: src/olympia/devhub/templates/devhub/versions/list.html:294
 #, python-format
 msgid ""
 "Unlisting your add-on will make it (and each of its versions/files) invisible on this website. It won't show up in searches, won't have a public facing page, and won't be updated automatically for "
-"current users.  It is recommended for unlisted add-ons to provide a custom <a href=\"%(update_url)s\" target=\"_blank\">updateURL</a> in their manifest file for automatic updates."
+"current users. It is recommended for unlisted add-ons to provide a custom <a href=\"%(update_url)s\" target=\"_blank\">updateURL</a> in their manifest file for automatic updates."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:299
-#, python-format
-msgid "Switching add-ons to unlisted is currently in an open beta. Please <a href=\"%(url)s\" target=\"_blank\">report any bugs</a> that you encounter."
-msgstr ""
-
-#: src/olympia/devhub/templates/devhub/versions/list.html:305
+#: src/olympia/devhub/templates/devhub/versions/list.html:303
 msgid "Unlisting an add-on is irreversible!"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:305
+#: src/olympia/devhub/templates/devhub/versions/list.html:303
 msgid "An unlisted add-on cannot be switched to be listed."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:307
+#: src/olympia/devhub/templates/devhub/versions/list.html:305
 msgid "Are you sure you wish to unlist your add-on?"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:330
+#: src/olympia/devhub/templates/devhub/versions/list.html:328
 msgid "Canceling your review request will leave your add-on as preliminarily reviewed."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:335
+#: src/olympia/devhub/templates/devhub/versions/list.html:333
 msgid "Canceling your review request will mark your add-on incomplete. If you do not complete your add-on after several days by re-requesting review, it will be deleted."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:343
+#: src/olympia/devhub/templates/devhub/versions/list.html:341
 msgid "Are you sure you wish to cancel your review request?"
 msgstr ""
 
@@ -7298,19 +7103,19 @@ msgstr ""
 msgid "Search by add-on name / author email"
 msgstr ""
 
-#: src/olympia/editors/forms.py:103
+#: src/olympia/editors/forms.py:103 src/olympia/editors/forms.py:244 src/olympia/editors/forms.py:257
 msgid "yes"
 msgstr ""
 
-#: src/olympia/editors/forms.py:104
+#: src/olympia/editors/forms.py:104 src/olympia/editors/forms.py:244 src/olympia/editors/forms.py:257
 msgid "no"
 msgstr ""
 
-#: src/olympia/editors/forms.py:105
+#: src/olympia/editors/forms.py:105 src/olympia/editors/forms.py:245
 msgid "Admin Flag"
 msgstr ""
 
-#: src/olympia/editors/forms.py:113
+#: src/olympia/editors/forms.py:113 src/olympia/editors/forms.py:253
 msgid "Max. Version"
 msgstr ""
 
@@ -7322,55 +7127,59 @@ msgstr ""
 msgid "Add-on Types"
 msgstr ""
 
-#: src/olympia/editors/forms.py:126 src/olympia/editors/helpers.py:267
+#: src/olympia/editors/forms.py:126 src/olympia/editors/helpers.py:279
 msgid "Platforms"
 msgstr ""
 
+#: src/olympia/editors/forms.py:237
+msgid "Search by add-on name / author email / guid"
+msgstr ""
+
 #. L10n: 0 = platform, 1 = filename, 2 = status message
-#: src/olympia/editors/forms.py:238
+#: src/olympia/editors/forms.py:342
 #, python-format
 msgid "<strong>%s</strong> &middot; %s &middot; %s"
 msgstr ""
 
-#: src/olympia/editors/forms.py:252
+#: src/olympia/editors/forms.py:356
 msgid "Comments:"
 msgstr ""
 
-#: src/olympia/editors/forms.py:256
+#: src/olympia/editors/forms.py:360
 msgid "Operating systems:"
 msgstr ""
 
-#: src/olympia/editors/forms.py:258
+#: src/olympia/editors/forms.py:362
 msgid "Applications:"
 msgstr ""
 
-#: src/olympia/editors/forms.py:260
+#: src/olympia/editors/forms.py:364
 msgid "Notify me the next time this add-on is updated. (Subsequent updates will not generate an email)"
 msgstr ""
 
-#: src/olympia/editors/forms.py:265
+#: src/olympia/editors/forms.py:369
 msgid "Clear Admin Review Flag"
 msgstr ""
 
-#: src/olympia/editors/forms.py:267
+#: src/olympia/editors/forms.py:371
 msgid "Clear more info requested flag"
 msgstr ""
 
-#: src/olympia/editors/forms.py:281
+#: src/olympia/editors/forms.py:385
 msgid "Choose a canned response..."
 msgstr ""
 
 #. L10n: Description of what can be searched for.
-#: src/olympia/editors/forms.py:324
+#: src/olympia/editors/forms.py:423
 msgid "theme name"
 msgstr ""
 
-#: src/olympia/editors/forms.py:350
+#: src/olympia/editors/forms.py:449
 msgid "Someone else is reviewing this theme."
 msgstr ""
 
 #. L10n: Description of what can be searched for.
-#: src/olympia/editors/forms.py:447
+#: src/olympia/editors/forms.py:546
 msgid "app, reviewer, or comment"
 msgstr ""
 
@@ -7386,257 +7195,264 @@ msgstr ""
 msgid "Rejected or Unreviewed"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:123 src/olympia/editors/helpers.py:136
+#: src/olympia/editors/helpers.py:125 src/olympia/editors/helpers.py:138
 msgid "Queue"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:124 src/olympia/editors/templates/editors/base.html:50 src/olympia/editors/templates/editors/base.html:65
+#: src/olympia/editors/helpers.py:126 src/olympia/editors/templates/editors/base.html:50 src/olympia/editors/templates/editors/base.html:65
 msgid "Pending Updates"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:125 src/olympia/editors/templates/editors/base.html:48 src/olympia/editors/templates/editors/base.html:63
+#: src/olympia/editors/helpers.py:127 src/olympia/editors/templates/editors/base.html:48 src/olympia/editors/templates/editors/base.html:63
 msgid "Full Reviews"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:126 src/olympia/editors/templates/editors/base.html:52 src/olympia/editors/templates/editors/base.html:67
+#: src/olympia/editors/helpers.py:128 src/olympia/editors/templates/editors/base.html:52 src/olympia/editors/templates/editors/base.html:67
 msgid "Preliminary Reviews"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:127 src/olympia/editors/templates/editors/base.html:54
+#: src/olympia/editors/helpers.py:129 src/olympia/editors/templates/editors/base.html:54
 msgid "Moderated Reviews"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:128 src/olympia/editors/templates/editors/base.html:46
+#: src/olympia/editors/helpers.py:130 src/olympia/editors/templates/editors/base.html:46
 msgid "Fast Track"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:130
+#: src/olympia/editors/helpers.py:132
 msgid "Pending Themes"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:131 src/olympia/editors/templates/editors/themes/queue.html:4
+#: src/olympia/editors/helpers.py:133 src/olympia/editors/templates/editors/themes/queue.html:4
 msgid "Flagged Themes"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:132
+#: src/olympia/editors/helpers.py:134
 msgid "Update Themes"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:137
+#: src/olympia/editors/helpers.py:139
 msgid "Unlisted Pending Updates"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:138
+#: src/olympia/editors/helpers.py:140
 msgid "Unlisted Full Reviews"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:139
+#: src/olympia/editors/helpers.py:141
 msgid "Unlisted Preliminary Reviews"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:170
+#: src/olympia/editors/helpers.py:142
+msgid "Unlisted All Add-ons"
+msgstr ""
+
+#: src/olympia/editors/helpers.py:173
 msgid "Fast Track ({0})"
 msgid_plural "Fast Track ({0})"
 msgstr[0] ""
 msgstr[1] ""
-msgstr[2] ""
 
-#: src/olympia/editors/helpers.py:175
+#: src/olympia/editors/helpers.py:178
 msgid "Full Review ({0})"
 msgid_plural "Full Reviews ({0})"
 msgstr[0] ""
 msgstr[1] ""
-msgstr[2] ""
 
-#: src/olympia/editors/helpers.py:180
+#: src/olympia/editors/helpers.py:183
 msgid "Pending Update ({0})"
 msgid_plural "Pending Updates ({0})"
 msgstr[0] ""
 msgstr[1] ""
-msgstr[2] ""
 
-#: src/olympia/editors/helpers.py:185
+#: src/olympia/editors/helpers.py:188
 msgid "Preliminary Review ({0})"
 msgid_plural "Preliminary Reviews ({0})"
 msgstr[0] ""
 msgstr[1] ""
-msgstr[2] ""
 
-#: src/olympia/editors/helpers.py:190
+#: src/olympia/editors/helpers.py:193
 msgid "Moderated Review ({0})"
 msgid_plural "Moderated Reviews ({0})"
 msgstr[0] ""
 msgstr[1] ""
-msgstr[2] ""
 
-#: src/olympia/editors/helpers.py:196
+#: src/olympia/editors/helpers.py:199
 msgid "Unlisted Full Review ({0})"
 msgid_plural "Unlisted Full Reviews ({0})"
 msgstr[0] ""
 msgstr[1] ""
-msgstr[2] ""
 
-#: src/olympia/editors/helpers.py:201
+#: src/olympia/editors/helpers.py:204
 msgid "Unlisted Pending Update ({0})"
 msgid_plural "Unlisted Pending Updates ({0})"
 msgstr[0] ""
 msgstr[1] ""
-msgstr[2] ""
 
-#: src/olympia/editors/helpers.py:206
+#: src/olympia/editors/helpers.py:209
 msgid "Unlisted Preliminary Review ({0})"
 msgid_plural "Unlisted Preliminary Reviews ({0})"
 msgstr[0] ""
 msgstr[1] ""
-msgstr[2] ""
 
-#: src/olympia/editors/helpers.py:261
-msgid "Addon"
-msgstr ""
+#: src/olympia/editors/helpers.py:214
+msgid "Unlisted All Add-ons ({0})"
+msgid_plural "Unlisted All Add-ons ({0})"
+msgstr[0] ""
+msgstr[1] ""
 
-#: src/olympia/editors/helpers.py:262
+#: src/olympia/editors/helpers.py:274
 msgid "Type"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:263
+#: src/olympia/editors/helpers.py:275
 msgid "Waiting Time"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:264 src/olympia/editors/templates/editors/review.html:285
+#: src/olympia/editors/helpers.py:276 src/olympia/editors/templates/editors/review.html:285
 msgid "Flags"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:265
+#: src/olympia/editors/helpers.py:277
 msgid "Applications"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:270
+#: src/olympia/editors/helpers.py:282
 msgid "Additional"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:285
+#: src/olympia/editors/helpers.py:302
 msgid "Site Specific"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:287
+#: src/olympia/editors/helpers.py:304
 msgid "Requires External Software"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:289
+#: src/olympia/editors/helpers.py:306
 msgid "Binary Components"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:313
+#: src/olympia/editors/helpers.py:339
 msgid "moments ago"
 msgstr ""
 
 #. L10n: first argument is number of minutes
-#: src/olympia/editors/helpers.py:316
+#: src/olympia/editors/helpers.py:342
 msgid "{0} minute"
 msgid_plural "{0} minutes"
 msgstr[0] ""
 msgstr[1] ""
-msgstr[2] ""
 
 #. L10n: first argument is number of hours
-#: src/olympia/editors/helpers.py:320
+#: src/olympia/editors/helpers.py:346
 msgid "{0} hour"
 msgid_plural "{0} hours"
 msgstr[0] ""
 msgstr[1] ""
-msgstr[2] ""
 
 #. L10n: first argument is number of days
-#: src/olympia/editors/helpers.py:324
+#: src/olympia/editors/helpers.py:350
 msgid "{0} day"
 msgid_plural "{0} days"
 msgstr[0] ""
 msgstr[1] ""
-msgstr[2] ""
 
-#: src/olympia/editors/helpers.py:488
+#: src/olympia/editors/helpers.py:364
+msgid "Last Review"
+msgstr ""
+
+#: src/olympia/editors/helpers.py:366
+msgid "Last Update"
+msgstr ""
+
+#: src/olympia/editors/helpers.py:387
+msgid "No Reviews"
+msgstr ""
+
+#: src/olympia/editors/helpers.py:561
 msgid "Push to public"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:490
+#: src/olympia/editors/helpers.py:563
 msgid "Grant full review"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:505
+#: src/olympia/editors/helpers.py:578
 msgid "Request more information"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:508
+#: src/olympia/editors/helpers.py:581
 msgid "Request super-review"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:519
+#: src/olympia/editors/helpers.py:592
 msgid "Grant preliminary review"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:520
+#: src/olympia/editors/helpers.py:593
 msgid "This will mark the files as preliminarily reviewed."
 msgstr ""
 
-#: src/olympia/editors/helpers.py:522
+#: src/olympia/editors/helpers.py:595
 msgid "Use this form to request more information from the author. They will receive an email and be able to answer here. You will be notified by email when they reply."
 msgstr ""
 
-#: src/olympia/editors/helpers.py:526
+#: src/olympia/editors/helpers.py:599
 msgid ""
 "If you have concerns about this add-on's security, copyright issues, or other concerns that an administrator should look into, enter your comments in the area below. They will be sent to "
 "administrators, not the author."
 msgstr ""
 
-#: src/olympia/editors/helpers.py:532
+#: src/olympia/editors/helpers.py:605
 msgid "This will reject the add-on and remove it from the review queue."
 msgstr ""
 
-#: src/olympia/editors/helpers.py:534
-msgid "Make a comment on this version.  The author won't be able to see this."
+#: src/olympia/editors/helpers.py:607
+msgid "Make a comment on this version. The author won't be able to see this."
 msgstr ""
 
-#: src/olympia/editors/helpers.py:538
+#: src/olympia/editors/helpers.py:611
 msgid "This will reject the files and remove them from the review queue."
 msgstr ""
 
-#: src/olympia/editors/helpers.py:542
+#: src/olympia/editors/helpers.py:615
 msgid "This will mark the add-on as preliminarily reviewed. Future versions will undergo preliminary review."
 msgstr ""
 
-#: src/olympia/editors/helpers.py:547
+#: src/olympia/editors/helpers.py:620
 msgid "This will mark the files as preliminarily reviewed. Future versions will undergo preliminary review."
 msgstr ""
 
-#: src/olympia/editors/helpers.py:552
+#: src/olympia/editors/helpers.py:625
 msgid "Retain preliminary review"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:553
+#: src/olympia/editors/helpers.py:626
 msgid "This will retain the add-on as preliminarily reviewed. Future versions will undergo preliminary review."
 msgstr ""
 
-#: src/olympia/editors/helpers.py:558
+#: src/olympia/editors/helpers.py:631
 msgid "This will approve a sandboxed version of a public add-on to appear on the public side."
 msgstr ""
 
-#: src/olympia/editors/helpers.py:561
+#: src/olympia/editors/helpers.py:634
 msgid "This will reject a version of a public add-on and remove it from the queue."
 msgstr ""
 
-#: src/olympia/editors/helpers.py:564
+#: src/olympia/editors/helpers.py:637
 msgid "This will mark the add-on and its most recent version and files as public. Future versions will go into the sandbox until they are reviewed by an editor."
 msgstr ""
 
-#: src/olympia/editors/helpers.py:637
+#: src/olympia/editors/helpers.py:714
 msgid "add-on"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:940 src/olympia/editors/helpers.py:960
+#: src/olympia/editors/helpers.py:1020 src/olympia/editors/helpers.py:1040
 msgid "Flagged"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:944 src/olympia/editors/helpers.py:963
+#: src/olympia/editors/helpers.py:1024 src/olympia/editors/helpers.py:1043
 msgid "Updates"
 msgstr ""
 
@@ -7688,56 +7504,56 @@ msgstr ""
 msgid "A question about your Theme submission"
 msgstr ""
 
-#: src/olympia/editors/views.py:144
+#: src/olympia/editors/views.py:146
 msgid "New Add-ons (Under 5 days)"
 msgstr ""
 
-#: src/olympia/editors/views.py:145
+#: src/olympia/editors/views.py:147
 msgid "Passable (5 to 10 days)"
 msgstr ""
 
-#: src/olympia/editors/views.py:146
+#: src/olympia/editors/views.py:148
 msgid "Overdue (Over 10 days)"
 msgstr ""
 
-#: src/olympia/editors/views.py:532
+#: src/olympia/editors/views.py:539
 msgid "An unknown error occurred"
 msgstr ""
 
-#: src/olympia/editors/views.py:587
+#: src/olympia/editors/views.py:592
 msgid "Self-reviews are not allowed."
 msgstr ""
 
-#: src/olympia/editors/views.py:609
+#: src/olympia/editors/views.py:613
 msgid "Review successfully processed."
 msgstr ""
 
-#: src/olympia/editors/views.py:807
+#: src/olympia/editors/views.py:812
 msgid "was approved"
 msgstr ""
 
-#: src/olympia/editors/views.py:808
+#: src/olympia/editors/views.py:813
 msgid "given preliminary review"
 msgstr ""
 
-#: src/olympia/editors/views.py:809
+#: src/olympia/editors/views.py:814
 msgid "rejected"
 msgstr ""
 
-#: src/olympia/editors/views.py:810
+#: src/olympia/editors/views.py:815
 msgctxt "editors_review_history_nominated_adminreview"
 msgid "escalated"
 msgstr ""
 
-#: src/olympia/editors/views.py:812
+#: src/olympia/editors/views.py:817
 msgid "needs more information"
 msgstr ""
 
-#: src/olympia/editors/views.py:813
+#: src/olympia/editors/views.py:818
 msgid "needs super review"
 msgstr ""
 
-#: src/olympia/editors/views.py:814
+#: src/olympia/editors/views.py:819
 msgid "commented"
 msgstr ""
 
@@ -7746,7 +7562,6 @@ msgid "{0} theme review successfully processed (+{1} points, {2} total)."
 msgid_plural "{0} theme reviews successfully processed (+{1} points, {2} total)."
 msgstr[0] ""
 msgstr[1] ""
-msgstr[2] ""
 
 #: src/olympia/editors/views_themes.py:341
 msgid "Your theme locks have successfully been released. Other reviewers may now review those released themes. You may have to refresh the page to see the changes reflected in the table below."
@@ -7783,28 +7598,28 @@ msgstr ""
 msgid "Unlisted Queues"
 msgstr ""
 
-#: src/olympia/editors/templates/editors/base.html:72 src/olympia/editors/templates/editors/performance.html:6
+#: src/olympia/editors/templates/editors/base.html:74 src/olympia/editors/templates/editors/performance.html:6
 msgid "Performance"
 msgstr ""
 
-#: src/olympia/editors/templates/editors/base.html:75 src/olympia/editors/templates/editors/themes/base.html:19 src/olympia/editors/templates/editors/themes/base.html:38
+#: src/olympia/editors/templates/editors/base.html:77 src/olympia/editors/templates/editors/themes/base.html:19 src/olympia/editors/templates/editors/themes/base.html:38
 msgid "Logs"
 msgstr ""
 
-#: src/olympia/editors/templates/editors/base.html:78 src/olympia/editors/templates/editors/reviewlog.html:4 src/olympia/editors/templates/editors/reviewlog.html:27
+#: src/olympia/editors/templates/editors/base.html:80 src/olympia/editors/templates/editors/reviewlog.html:4 src/olympia/editors/templates/editors/reviewlog.html:27
 msgid "Add-on Review Log"
 msgstr ""
 
-#: src/olympia/editors/templates/editors/base.html:80 src/olympia/editors/templates/editors/eventlog.html:4 src/olympia/editors/templates/editors/eventlog.html:8
+#: src/olympia/editors/templates/editors/base.html:82 src/olympia/editors/templates/editors/eventlog.html:4 src/olympia/editors/templates/editors/eventlog.html:8
 #: src/olympia/editors/templates/editors/eventlog_detail.html:4
 msgid "Moderated Review Log"
 msgstr ""
 
-#: src/olympia/editors/templates/editors/base.html:82 src/olympia/editors/templates/editors/beta_signed_log.html:4 src/olympia/editors/templates/editors/beta_signed_log.html:8
+#: src/olympia/editors/templates/editors/base.html:84 src/olympia/editors/templates/editors/beta_signed_log.html:4 src/olympia/editors/templates/editors/beta_signed_log.html:8
 msgid "Signed Beta Files Log"
 msgstr ""
 
-#: src/olympia/editors/templates/editors/base.html:87 src/olympia/editors/templates/editors/includes/daily-message.html:4
+#: src/olympia/editors/templates/editors/base.html:89 src/olympia/editors/templates/editors/includes/daily-message.html:4
 msgid "Announcement"
 msgstr ""
 
@@ -7864,21 +7679,18 @@ msgid "Full Review ({num})"
 msgid_plural "Full Reviews ({num})"
 msgstr[0] ""
 msgstr[1] ""
-msgstr[2] ""
 
 #: src/olympia/editors/templates/editors/home.html:18
 msgid "Pending Update ({num})"
 msgid_plural "Pending Updates ({num})"
 msgstr[0] ""
 msgstr[1] ""
-msgstr[2] ""
 
 #: src/olympia/editors/templates/editors/home.html:25
 msgid "Preliminary Review ({num})"
 msgid_plural "Preliminary Reviews ({num})"
 msgstr[0] ""
 msgstr[1] ""
-msgstr[2] ""
 
 #: src/olympia/editors/templates/editors/home.html:36 src/olympia/editors/templates/editors/home.html:86
 msgid "Current waiting times:"
@@ -7889,7 +7701,6 @@ msgid "{0} add-on"
 msgid_plural "{0} add-ons"
 msgstr[0] ""
 msgstr[1] ""
-msgstr[2] ""
 
 #: src/olympia/editors/templates/editors/home.html:45 src/olympia/editors/templates/editors/home.html:95
 #, python-format
@@ -7901,21 +7712,18 @@ msgid "Unlisted Full Review ({num})"
 msgid_plural "Unlisted Full Reviews ({num})"
 msgstr[0] ""
 msgstr[1] ""
-msgstr[2] ""
 
 #: src/olympia/editors/templates/editors/home.html:68
 msgid "Unlisted Pending Update ({num})"
 msgid_plural "Unlisted Pending Updates ({num})"
 msgstr[0] ""
 msgstr[1] ""
-msgstr[2] ""
 
 #: src/olympia/editors/templates/editors/home.html:75
 msgid "Unlisted Preliminary Review ({num})"
 msgid_plural "Unlisted Preliminary Reviews ({num})"
 msgstr[0] ""
 msgstr[1] ""
-msgstr[2] ""
 
 #: src/olympia/editors/templates/editors/home.html:109 src/olympia/editors/templates/editors/performance.html:37 src/olympia/editors/templates/editors/themes/home.html:54
 msgid "Total Reviews"
@@ -7939,7 +7747,6 @@ msgid "Moderated Review ({num})"
 msgid_plural "Moderated Reviews ({num})"
 msgstr[0] ""
 msgstr[1] ""
-msgstr[2] ""
 
 #: src/olympia/editors/templates/editors/leaderboard.html:3 src/olympia/editors/templates/editors/includes/reviewers_score_bar.html:56
 msgid "Reviewer Leaderboard"
@@ -8033,45 +7840,45 @@ msgstr ""
 msgid "clear search"
 msgstr ""
 
-#: src/olympia/editors/templates/editors/queue.html:72 src/olympia/editors/templates/editors/queue.html:122
+#: src/olympia/editors/templates/editors/queue.html:78 src/olympia/editors/templates/editors/queue.html:128
 msgid "Process Reviews"
 msgstr ""
 
-#: src/olympia/editors/templates/editors/queue.html:80
+#: src/olympia/editors/templates/editors/queue.html:86
 msgid "Moderation actions:"
 msgstr ""
 
-#: src/olympia/editors/templates/editors/queue.html:90
+#: src/olympia/editors/templates/editors/queue.html:96
 #, python-format
 msgid "by %(user)s on %(date)s %(stars)s (%(locale)s)"
 msgstr ""
 
-#: src/olympia/editors/templates/editors/queue.html:106
+#: src/olympia/editors/templates/editors/queue.html:112
 #, python-format
 msgid "<strong>%(reason)s</strong> <span class=\"light\">Flagged by %(user)s on %(date)s</span>"
 msgstr ""
 
-#: src/olympia/editors/templates/editors/queue.html:119
-msgid "All reviews have been moderated.  Good work!"
+#: src/olympia/editors/templates/editors/queue.html:125
+msgid "All reviews have been moderated. Good work!"
 msgstr ""
 
-#: src/olympia/editors/templates/editors/queue.html:161
+#: src/olympia/editors/templates/editors/queue.html:167
 msgid "Version Notes / Notes for Reviewer"
 msgstr ""
 
-#: src/olympia/editors/templates/editors/queue.html:169
+#: src/olympia/editors/templates/editors/queue.html:175
 msgid "There are currently no add-ons of this type to review."
 msgstr ""
 
-#: src/olympia/editors/templates/editors/queue.html:181 src/olympia/editors/templates/editors/themes/queue_list.html:85
+#: src/olympia/editors/templates/editors/queue.html:187 src/olympia/editors/templates/editors/themes/queue_list.html:85
 msgid "Helpful Links:"
 msgstr ""
 
-#: src/olympia/editors/templates/editors/queue.html:182
+#: src/olympia/editors/templates/editors/queue.html:188
 msgid "Add-on Policy"
 msgstr ""
 
-#: src/olympia/editors/templates/editors/queue.html:184
+#: src/olympia/editors/templates/editors/queue.html:190
 msgid "Editors' Guide"
 msgstr ""
 
@@ -8134,10 +7941,7 @@ msgid "<strong>Warning!</strong> Another user was viewing this page before you."
 msgstr ""
 
 #: src/olympia/editors/templates/editors/review.html:237
-msgid ""
-"The whiteboard is the place to exchange information relevant to\n"
-"               this addon (whatever the version), between the developer and the\n"
-"               editor. This is visible and editable by both."
+msgid "The whiteboard is the place to exchange information relevant to this addon (whatever the version), between the developer and the editor. This is visible and editable by both."
 msgstr ""
 
 #: src/olympia/editors/templates/editors/review.html:241
@@ -8281,21 +8085,18 @@ msgid "{num} Pending Theme Review"
 msgid_plural "{num} Pending Theme Reviews"
 msgstr[0] ""
 msgstr[1] ""
-msgstr[2] ""
 
 #: src/olympia/editors/templates/editors/themes/home.html:27
 msgid "{num} Flagged Review"
 msgid_plural "{num} Flagged Reviews"
 msgstr[0] ""
 msgstr[1] ""
-msgstr[2] ""
 
 #: src/olympia/editors/templates/editors/themes/home.html:34
 msgid "{num} Update"
 msgid_plural "{num} Updates"
 msgstr[0] ""
 msgstr[1] ""
-msgstr[2] ""
 
 #: src/olympia/editors/templates/editors/themes/logs.html:4
 msgid "Theme Review Log"
@@ -8414,7 +8215,7 @@ msgstr ""
 msgid "Describe your reason for flagging"
 msgstr ""
 
-#: src/olympia/files/forms.py:88
+#: src/olympia/files/forms.py:90
 msgid "Cannot diff a version against itself"
 msgstr ""
 
@@ -8449,51 +8250,51 @@ msgstr ""
 msgid "There was an error accessing file %s."
 msgstr ""
 
-#: src/olympia/files/utils.py:343
+#: src/olympia/files/utils.py:340
 msgid "Could not parse uploaded file."
 msgstr ""
 
-#: src/olympia/files/utils.py:380
+#: src/olympia/files/utils.py:377
 msgid "Invalid file name in archive: {0}"
 msgstr ""
 
-#: src/olympia/files/utils.py:388
+#: src/olympia/files/utils.py:385
 msgid "File exceeding size limit in archive: {0}"
 msgstr ""
 
-#: src/olympia/files/utils.py:439
+#: src/olympia/files/utils.py:436
 msgid "Invalid archive."
 msgstr ""
 
-#: src/olympia/files/utils.py:529 src/olympia/files/utils.py:532
+#: src/olympia/files/utils.py:526 src/olympia/files/utils.py:529
 msgid "Could not parse the manifest file."
 msgstr ""
 
-#: src/olympia/files/utils.py:551
+#: src/olympia/files/utils.py:548
 msgid "Could not find an add-on ID."
 msgstr ""
 
-#: src/olympia/files/utils.py:554
+#: src/olympia/files/utils.py:551
 msgid "Add-on ID must be 64 characters or less."
 msgstr ""
 
-#: src/olympia/files/utils.py:556
+#: src/olympia/files/utils.py:553
 msgid "Add-on ID doesn't match add-on."
 msgstr ""
 
-#: src/olympia/files/utils.py:564
+#: src/olympia/files/utils.py:561
 msgid "Duplicate add-on ID found."
 msgstr ""
 
-#: src/olympia/files/utils.py:567
+#: src/olympia/files/utils.py:564
 msgid "Version numbers should have fewer than 32 characters."
 msgstr ""
 
-#: src/olympia/files/utils.py:570
+#: src/olympia/files/utils.py:567
 msgid "Version numbers should only contain letters, numbers, and these punctuation characters: +*.-_."
 msgstr ""
 
-#: src/olympia/files/utils.py:587
+#: src/olympia/files/utils.py:584
 msgid "<em:type> doesn't match add-on"
 msgstr ""
 
@@ -8592,6 +8393,10 @@ msgstr ""
 
 #: src/olympia/files/templates/files/viewer.html:134
 msgid "Fetching file."
+msgstr ""
+
+#: src/olympia/legacy_api/views.py:255
+msgid "Not implemented yet."
 msgstr ""
 
 #: src/olympia/lib/constants.py:6
@@ -9250,10 +9055,6 @@ msgstr ""
 msgid "Zimbabwe Dollar"
 msgstr ""
 
-#: src/olympia/lib/video/ffmpeg.py:112 src/olympia/lib/video/totem.py:81
-msgid "Videos must be in WebM."
-msgstr ""
-
 #: src/olympia/pages/templates/pages/about.lhtml:3 src/olympia/pages/templates/pages/about.lhtml:10
 msgid "About Mozilla Add-ons"
 msgstr ""
@@ -9265,7 +9066,7 @@ msgstr ""
 #: src/olympia/pages/templates/pages/about.lhtml:13
 msgid ""
 "addons.mozilla.org, commonly known as \"AMO\", is Mozilla's official site for add-ons to Mozilla software, such as Firefox, Thunderbird, and SeaMonkey. Add-ons let you add new features and change "
-"the way your browser or application works.  Take a look around and explore the thousands of ways to customize the way you do things online."
+"the way your browser or application works. Take a look around and explore the thousands of ways to customize the way you do things online."
 msgstr ""
 
 #: src/olympia/pages/templates/pages/about.lhtml:19
@@ -9610,7 +9411,7 @@ msgstr ""
 msgid ""
 "Yes. It's possible, but some of the functionality provided by these libraries are available through XPCOM, XUL, and JavaScript. In addition, authors should take care if libraries modify primitive "
 "object prototypes (String.prototype, Date.prototype, etc.) and/or define global functions (eg. the $ function). These are prone to cause conflict with other add-ons, in particular if different add-"
-"ons use different versions of libraries and so on. Developers need to be very, very careful with using them.  Mozilla does not offer documentation on using them to build add-ons."
+"ons use different versions of libraries and so on. Developers need to be very, very careful with using them. Mozilla does not offer documentation on using them to build add-ons."
 msgstr ""
 
 #: src/olympia/pages/templates/pages/dev_faq.html:165
@@ -9724,8 +9525,8 @@ msgstr ""
 #, python-format
 msgid ""
 "Yes. Many developers choose to host their own add-ons. Choosing to host your add-on on <a href=\"%(amo_url)s\">Mozilla's add-on site</a>, though, allows for much greater exposure to your add-on due "
-"to the large volume of visitors to the site.  <a href=\"%(md_url)s\">mozdev.org</a> offers free project hosting for Mozilla applications and extensions providing developers with tools to help "
-"manage source code, version control, bug tracking and documentation."
+"to the large volume of visitors to the site. <a href=\"%(md_url)s\">mozdev.org</a> offers free project hosting for Mozilla applications and extensions providing developers with tools to help manage "
+"source code, version control, bug tracking and documentation."
 msgstr ""
 
 #: src/olympia/pages/templates/pages/dev_faq.html:277
@@ -9773,7 +9574,7 @@ msgstr ""
 #: src/olympia/pages/templates/pages/dev_faq.html:314
 #, python-format
 msgid ""
-"Yes. Mozilla's <a href=\"%(p_url)s\">Add-on Policy</a> describes what is an acceptable submission. This policy is subject to change without notice.  In addition, the AMO editorial team uses the <a "
+"Yes. Mozilla's <a href=\"%(p_url)s\">Add-on Policy</a> describes what is an acceptable submission. This policy is subject to change without notice. In addition, the AMO editorial team uses the <a "
 "href=\"%(g_url)s\">Editors Reviewing Guide</a> to ensure that your add-on meets specific guidelines for functionality and security."
 msgstr ""
 
@@ -9890,7 +9691,7 @@ msgstr ""
 #: src/olympia/pages/templates/pages/dev_faq.html:434
 #, python-format
 msgid ""
-"This is why it's very important to read the <a href=\"%(g_url)s\">Editors Reviewing Guide</a> to ensure that your add-on is setup as expected.  It's also a good idea to read the blog post, <a href="
+"This is why it's very important to read the <a href=\"%(g_url)s\">Editors Reviewing Guide</a> to ensure that your add-on is setup as expected. It's also a good idea to read the blog post, <a href="
 "\"%(blog_url)s\">Successfully Getting your Add-on Reviewed</a> which provides excellent insight into ensuring a smooth review of your add-on."
 msgstr ""
 
@@ -9997,7 +9798,7 @@ msgstr ""
 
 #: src/olympia/pages/templates/pages/dev_faq.html:572
 msgid ""
-"Free Software Foundation provides short summaries of the key open source licenses, including whether the license qualifies as a free software license or a copyleft license.  Also includes a "
+"Free Software Foundation provides short summaries of the key open source licenses, including whether the license qualifies as a free software license or a copyleft license. Also includes a "
 "discussion of what constitutes a free software license or a copyleft license (e.g., a Copyleft license is a general method for making a program or other work free, and requiring all modified and "
 "extended versions of the program to be free as well.)"
 msgstr ""
@@ -10175,19 +9976,13 @@ msgid "Add-on Gallery"
 msgstr ""
 
 #: src/olympia/pages/templates/pages/faq.html:171
-msgid ""
-"How do I choose between add-ons that seem to do the same\n"
-"    thing?"
+msgid "How do I choose between add-ons that seem to do the same thing?"
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:173
+#: src/olympia/pages/templates/pages/faq.html:172
 msgid ""
-"There are often several add-ons that have similar features. To\n"
-"    figure out which is right for you, read the entire description of the\n"
-"    add-on and view its screenshots. If there are still several in the running,\n"
-"    read through the add-on's ratings, user reviews, and statistics to see\n"
-"    which is most liked by other users. Remember that you can also just try\n"
-"    out both and see which you like better."
+"There are often several add-ons that have similar features. To figure out which is right for you, read the entire description of the add-on and view its screenshots. If there are still several in "
+"the running, read through the add-on's ratings, user reviews, and statistics to see which is most liked by other users. Remember that you can also just try out both and see which you like better."
 msgstr ""
 
 #: src/olympia/pages/templates/pages/faq.html:180
@@ -10228,80 +10023,67 @@ msgid "How much do add-ons cost to purchase?"
 msgstr ""
 
 #: src/olympia/pages/templates/pages/faq.html:207
-msgid ""
-"Add-ons hosted in our gallery are free unless clearly marked\n"
-"    otherwise."
+msgid "Add-ons hosted in our gallery are free unless clearly marked otherwise."
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:210
+#: src/olympia/pages/templates/pages/faq.html:209
 msgid "What does it mean when an add-on asks for contributions?"
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:211
+#: src/olympia/pages/templates/pages/faq.html:210
 msgid ""
-"Some add-on authors request users who enjoy an add-on to\n"
-"        contribute to its development by making a monetary contribution. These\n"
-"        contributions go directly to the developer unless a third party is\n"
-"        indicated, such as the non-profit Mozilla Foundation."
+"Some add-on authors request users who enjoy an add-on to contribute to its development by making a monetary contribution. These contributions go directly to the developer unless a third party is "
+"indicated, such as the non-profit Mozilla Foundation."
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:216
+#: src/olympia/pages/templates/pages/faq.html:215
 msgid "What are beta add-ons?"
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:218
+#: src/olympia/pages/templates/pages/faq.html:217
 msgid ""
-"Beta add-ons are unreviewed versions which represent the\n"
-"        latest work of an add-on author. While different authors have different\n"
-"        standards for beta code quality, you should assume that these add-ons\n"
-"        are less stable than the general add-on releases."
+"Beta add-ons are unreviewed versions which represent the latest work of an add-on author. While different authors have different standards for beta code quality, you should assume that these add-"
+"ons are less stable than the general add-on releases."
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:222
+#: src/olympia/pages/templates/pages/faq.html:221
 msgid ""
 "Please note that when you install an add-on from the \"Beta Version\" section of an add-on's listing, you will continue to receive updates for that add-on as they become available. Like the initial "
 "version you installed, all beta releases are unreviewed by Mozilla and may harm your computer."
 msgstr ""
 
+#: src/olympia/pages/templates/pages/faq.html:228
+msgid "What does it mean when an add-on is flagged as slow?"
+msgstr ""
+
 #: src/olympia/pages/templates/pages/faq.html:229
-msgid ""
-"What does it mean when an add-on is flagged as\n"
-"    slow?"
+msgid "Most add-ons load code and resources at the same time Firefox is starting up. In most cases the impact in start-up time is minimal, but some add-ons can cause a noticeable slowdown."
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:231
-msgid ""
-"Most add-ons load code and resources at the same time Firefox\n"
-"        is starting up. In most cases the impact in start-up time is minimal,\n"
-"        but some add-ons can cause a noticeable slowdown."
-msgstr ""
-
-#: src/olympia/pages/templates/pages/faq.html:236
+#: src/olympia/pages/templates/pages/faq.html:234
 msgid "How do I report an inappropriate or spam user review?"
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:237
+#: src/olympia/pages/templates/pages/faq.html:235
 msgid ""
-"To report a user review of an add-on, log in with your account\n"
-"    and visit the add-on's reviews page. Find the review you wish to report,\n"
-"    click \"Report this review\" and select a reason. Our editorial team will\n"
-"    investigate the review and take appropriate action."
+"To report a user review of an add-on, log in with your account and visit the add-on's reviews page. Find the review you wish to report, click \"Report this review\" and select a reason. Our "
+"editorial team will investigate the review and take appropriate action."
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:242
+#: src/olympia/pages/templates/pages/faq.html:240
 msgid "How do I report a bug or contact the Mozilla Add-ons team?"
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:243
+#: src/olympia/pages/templates/pages/faq.html:241
 #, python-format
 msgid "Please visit our <a href=\"%(contact_url)s\">Contact page</a>."
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:246
+#: src/olympia/pages/templates/pages/faq.html:244
 msgid "What is a Source Code License?"
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:247
+#: src/olympia/pages/templates/pages/faq.html:245
 #, python-format
 msgid ""
 "The source code used to create an add-on is an exclusive copyright of the add-on author, unless otherwise declared in a source code license. Many add-ons on this site have <a href=\"%(url)s\" lang="
@@ -10309,60 +10091,60 @@ msgid ""
 "the GPL or BSD licenses instead of making up their own."
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:256
+#: src/olympia/pages/templates/pages/faq.html:254
 #, python-format
 msgid "Firefox and other Mozilla software are <a href=\"%(url)s\">open source</a>."
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:264
+#: src/olympia/pages/templates/pages/faq.html:262
 msgid "Collections and Favorites"
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:267
+#: src/olympia/pages/templates/pages/faq.html:265
 msgid "What is a collection?"
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:268
+#: src/olympia/pages/templates/pages/faq.html:266
 msgid "Collections are groups of related add-ons created by users to share."
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:270
+#: src/olympia/pages/templates/pages/faq.html:268
 msgid "What is the My Favorites collection?"
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:271
+#: src/olympia/pages/templates/pages/faq.html:269
 msgid "Favorite add-ons are add-ons that you have bookmarked to easily get back to later. You can add an add-on to your favorites collection by clicking \"Add to favorites\" on its details page."
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:275 src/olympia/templates/menu_links.html:13 src/olympia/templates/impala/header_title.html:17
+#: src/olympia/pages/templates/pages/faq.html:273 src/olympia/templates/menu_links.html:13 src/olympia/templates/impala/header_title.html:17
 msgid "Mobile Add-ons"
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:278
+#: src/olympia/pages/templates/pages/faq.html:276
 msgid "What are mobile add-ons?"
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:279
+#: src/olympia/pages/templates/pages/faq.html:277
 #, python-format
 msgid ""
 "Mobile add-ons work with <a href=\"%(mobile_url)s\">Firefox for Mobile</a> and add or modify functionality just like desktop add-ons. You can find add-ons that work with Firefox for Mobile in our "
 "<a href=\"%(gallery_url)s\">gallery</a>."
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:288
+#: src/olympia/pages/templates/pages/faq.html:286
 msgid "Developer Topics"
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:289
+#: src/olympia/pages/templates/pages/faq.html:287
 #, python-format
 msgid "Please see our <a href=\"%(faq_url)s\">Developer FAQ</a> and <a href=\"%(hub_url)s\">Developer Hub</a> for answers to add-on developer-related questions."
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:294
+#: src/olympia/pages/templates/pages/faq.html:292
 msgid "Still have questions?"
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:295
+#: src/olympia/pages/templates/pages/faq.html:293
 #, python-format
 msgid "For general Firefox support, visit our <a href=\"%(sumo_url)s\">support website</a>. For general add-on and website questions, visit our <a href=\"%(forum_url)s\">forum</a>."
 msgstr ""
@@ -10500,7 +10282,7 @@ msgstr ""
 
 #: src/olympia/pages/templates/pages/sunbird.html:29
 msgid ""
-"Development on the Sunbird project has halted and its final release was on March 30, 2010.  We've been proud to host Sunbird add-ons on this site but as the project is no longer maintained we have "
+"Development on the Sunbird project has halted and its final release was on March 30, 2010. We've been proud to host Sunbird add-ons on this site but as the project is no longer maintained we have "
 "disabled our support for the add-ons."
 msgstr ""
 
@@ -10578,7 +10360,7 @@ msgstr ""
 #, python-format
 msgid ""
 "<h2>Keep these tips in mind:</h2> <ul> <li> Write like you're telling a friend about your experience with the add-on. Give specifics and helpful details, such as what features you liked and/or "
-"disliked, how easy to use it is, and any disadvantages it has.  Avoid generic language such as calling it \"Great\" or \"Bad\" unless you can give reasons why you believe this is so. </li> <li> "
+"disliked, how easy to use it is, and any disadvantages it has. Avoid generic language such as calling it \"Great\" or \"Bad\" unless you can give reasons why you believe this is so. </li> <li> "
 "Please do not post bug reports in reviews. We do not make your email address available to add-on developers and they may need to contact you to help resolve your issue. See the <a href=\"%(support)s"
 "\">support section</a> to find out where to get assistance for this add-on. </li> <li>Please keep reviews clean, avoid the use of improper language and do not post any personal information. </li> </"
 "ul> <p>Please read the <a href=\"%(guide)s\" target=\"_blank\">Review Guidelines</a> for more detail about user add-on reviews.</p>"
@@ -10626,7 +10408,6 @@ msgid "This user has a <a href=\"%(user_review_url)s\">previous review</a> of th
 msgid_plural "This user has <a href=\"%(user_review_url)s\">%(cnt)s previous reviews</a> of this add-on."
 msgstr[0] ""
 msgstr[1] ""
-msgstr[2] ""
 
 #: src/olympia/reviews/templates/reviews/review.html:62
 #, python-format
@@ -10673,7 +10454,6 @@ msgid "<b>{0}</b> review for this add-on"
 msgid_plural "<b>{0}</b> reviews for this add-on"
 msgstr[0] ""
 msgstr[1] ""
-msgstr[2] ""
 
 #. {0} is a developer's name.
 #: src/olympia/reviews/templates/reviews/review_list.html:33
@@ -10686,7 +10466,6 @@ msgid "Review for %(addon)s by %(user)s"
 msgid_plural "Reviews for %(addon)s by %(user)s"
 msgstr[0] ""
 msgstr[1] ""
-msgstr[2] ""
 
 #: src/olympia/reviews/templates/reviews/review_list.html:42
 msgid "No reviews found."
@@ -10710,7 +10489,6 @@ msgid "{num} review"
 msgid_plural "{num} reviews"
 msgstr[0] ""
 msgstr[1] ""
-msgstr[2] ""
 
 #: src/olympia/reviews/templates/reviews/impala/reviews_rating.html:1
 msgid "Rated {0} out of 5 stars"
@@ -10738,7 +10516,6 @@ msgid "Average from {0} Rating"
 msgid_plural "Average from {0} Ratings"
 msgstr[0] ""
 msgstr[1] ""
-msgstr[2] ""
 
 #: src/olympia/reviews/templates/reviews/mobile/review_list.html:34
 #, python-format
@@ -10755,7 +10532,6 @@ msgid "See All Reviews"
 msgid_plural "See All %(cnt)s Reviews"
 msgstr[0] ""
 msgstr[1] ""
-msgstr[2] ""
 
 #: src/olympia/search/forms.py:11
 msgid "Most popular this week"
@@ -10820,16 +10596,16 @@ msgstr ""
 
 #. L10n: {0} is an application, such as Firefox. This means "any version of
 #. Firefox."
-#: src/olympia/search/views.py:554
+#: src/olympia/search/views.py:547
 msgid "Any {0}"
 msgstr ""
 
 #. L10n: "All Systems" means show everything regardless of platform.
-#: src/olympia/search/views.py:589
+#: src/olympia/search/views.py:582
 msgid "All Systems"
 msgstr ""
 
-#: src/olympia/search/views.py:600
+#: src/olympia/search/views.py:593
 msgid "All Tags"
 msgstr ""
 
@@ -10874,7 +10650,6 @@ msgid "<b>{0}</b> matching result"
 msgid_plural "<b>{0}</b> matching results"
 msgstr[0] ""
 msgstr[1] ""
-msgstr[2] ""
 
 #: src/olympia/search/templates/search/results.html:67
 msgid "Filter Results"
@@ -10897,7 +10672,6 @@ msgid "{0} post"
 msgid_plural "{0} posts"
 msgstr[0] ""
 msgstr[1] ""
-msgstr[2] ""
 
 #: src/olympia/sharing/__init__.py:20
 msgid "Post to Facebook"
@@ -10908,7 +10682,6 @@ msgid "{0} Like"
 msgid_plural "{0} Likes"
 msgstr[0] ""
 msgstr[1] ""
-msgstr[2] ""
 
 #: src/olympia/sharing/__init__.py:30
 msgid "Tweet on Twitter"
@@ -10919,7 +10692,6 @@ msgid "{0} tweet"
 msgid_plural "{0} tweets"
 msgstr[0] ""
 msgstr[1] ""
-msgstr[2] ""
 
 #: src/olympia/sharing/__init__.py:40
 msgid "Share on g+"
@@ -10954,7 +10726,6 @@ msgid "{0} post on localservice1"
 msgid_plural "{0} posts on localservice1"
 msgstr[0] ""
 msgstr[1] ""
-msgstr[2] ""
 
 #. L10n: Only change if you have reason! wiki.mozilla.org/AMO:Localizers
 #: src/olympia/sharing/__init__.py:76
@@ -10977,7 +10748,6 @@ msgid "{0} post on localservice2"
 msgid_plural "{0} posts on localservice2"
 msgstr[0] ""
 msgstr[1] ""
-msgstr[2] ""
 
 #. L10n: Only change if you have reason! wiki.mozilla.org/AMO:Localizers
 #: src/olympia/sharing/__init__.py:91
@@ -11000,7 +10770,6 @@ msgid "{0} post on localservice3"
 msgid_plural "{0} posts on localservice3"
 msgstr[0] ""
 msgstr[1] ""
-msgstr[2] ""
 
 #: src/olympia/sharing/templates/sharing/sharing_widget.html:2
 msgid "Share this Add-on"
@@ -11010,31 +10779,31 @@ msgstr ""
 msgid "Share this Collection"
 msgstr ""
 
-#: src/olympia/signing/views.py:30 src/olympia/templates/base.html:75 src/olympia/templates/impala/base.html:115
+#: src/olympia/signing/views.py:33 src/olympia/templates/base.html:71 src/olympia/templates/impala/base.html:112
 msgid "Some features are temporarily disabled while we perform website maintenance. We'll be back to full capacity shortly."
 msgstr ""
 
-#: src/olympia/signing/views.py:53
+#: src/olympia/signing/views.py:56
 msgid "Could not find add-on with id \"{}\"."
 msgstr ""
 
-#: src/olympia/signing/views.py:67
+#: src/olympia/signing/views.py:70
 msgid "You do not own this addon."
 msgstr ""
 
-#: src/olympia/signing/views.py:82
+#: src/olympia/signing/views.py:87
 msgid "Missing \"upload\" key in multipart file data."
 msgstr ""
 
-#: src/olympia/signing/views.py:96
+#: src/olympia/signing/views.py:101
 msgid "Version does not match the manifest file."
 msgstr ""
 
-#: src/olympia/signing/views.py:100
+#: src/olympia/signing/views.py:105
 msgid "Version already exists."
 msgstr ""
 
-#: src/olympia/signing/views.py:136
+#: src/olympia/signing/views.py:141
 msgid "No uploaded file for that addon and version."
 msgstr ""
 
@@ -11147,89 +10916,89 @@ msgstr ""
 msgid "Statistics Dashboard :: Add-ons for {0}"
 msgstr ""
 
-#: src/olympia/stats/templates/stats/stats.html:30
-msgid "Controls:"
-msgstr ""
-
-#: src/olympia/stats/templates/stats/stats.html:33
-msgid "reset zoom"
-msgstr ""
-
-#: src/olympia/stats/templates/stats/stats.html:40
-msgid "Group by:"
-msgstr ""
-
-#: src/olympia/stats/templates/stats/stats.html:42
-msgid "day"
-msgstr ""
-
-#: src/olympia/stats/templates/stats/stats.html:45
-msgid "week"
-msgstr ""
-
-#: src/olympia/stats/templates/stats/stats.html:48
-msgid "month"
-msgstr ""
-
-#: src/olympia/stats/templates/stats/stats.html:54
-msgid "For last:"
-msgstr ""
-
-#: src/olympia/stats/templates/stats/stats.html:57
-msgid "7 days"
-msgstr ""
-
-#: src/olympia/stats/templates/stats/stats.html:60
-msgid "30 days"
-msgstr ""
-
-#: src/olympia/stats/templates/stats/stats.html:63
-msgid "90 days"
-msgstr ""
-
-#: src/olympia/stats/templates/stats/stats.html:66
-msgid "365 days"
-msgstr ""
-
-#: src/olympia/stats/templates/stats/stats.html:69
-msgid "Custom..."
-msgstr ""
-
 #. {0} is an add-on name
-#: src/olympia/stats/templates/stats/stats.html:88 src/olympia/stats/templates/stats/stats.html:91
+#: src/olympia/stats/templates/stats/stats.html:44 src/olympia/stats/templates/stats/stats.html:47
 msgid "Statistics for {0}"
 msgstr ""
 
-#: src/olympia/stats/templates/stats/stats.html:94
+#: src/olympia/stats/templates/stats/stats.html:50
 msgid "Statistics Dashboard"
 msgstr ""
 
-#: src/olympia/stats/templates/stats/stats.html:104
+#: src/olympia/stats/templates/stats/stats.html:57
+msgid "Controls:"
+msgstr ""
+
+#: src/olympia/stats/templates/stats/stats.html:60
+msgid "reset zoom"
+msgstr ""
+
+#: src/olympia/stats/templates/stats/stats.html:67
+msgid "Group by:"
+msgstr ""
+
+#: src/olympia/stats/templates/stats/stats.html:69
+msgid "day"
+msgstr ""
+
+#: src/olympia/stats/templates/stats/stats.html:72
+msgid "week"
+msgstr ""
+
+#: src/olympia/stats/templates/stats/stats.html:75
+msgid "month"
+msgstr ""
+
+#: src/olympia/stats/templates/stats/stats.html:81
+msgid "For last:"
+msgstr ""
+
+#: src/olympia/stats/templates/stats/stats.html:84
+msgid "7 days"
+msgstr ""
+
+#: src/olympia/stats/templates/stats/stats.html:87
+msgid "30 days"
+msgstr ""
+
+#: src/olympia/stats/templates/stats/stats.html:90
+msgid "90 days"
+msgstr ""
+
+#: src/olympia/stats/templates/stats/stats.html:93
+msgid "365 days"
+msgstr ""
+
+#: src/olympia/stats/templates/stats/stats.html:96
+msgid "Custom..."
+msgstr ""
+
+#: src/olympia/stats/templates/stats/stats.html:106
 msgid "Statistics processing is currently disabled, so recent data is unavailable. The statistics are still being collected and this page will be updated soon with the missing data."
 msgstr ""
 
-#: src/olympia/stats/templates/stats/stats.html:110
+#: src/olympia/stats/templates/stats/stats.html:112
 msgid "Loading the latest data&hellip;"
 msgstr ""
 
-#: src/olympia/stats/templates/stats/stats.html:142 src/olympia/stats/templates/stats/reports/overview.html:25 src/olympia/stats/templates/stats/reports/overview.html:37
+#: src/olympia/stats/templates/stats/stats.html:144 src/olympia/stats/templates/stats/reports/overview.html:25 src/olympia/stats/templates/stats/reports/overview.html:37
 #: src/olympia/stats/templates/stats/reports/overview.html:49
 msgid "No data available."
 msgstr ""
 
-#: src/olympia/stats/templates/stats/stats.html:177
+#: src/olympia/stats/templates/stats/stats.html:179
 msgid "This dashboard is currently <b>public</b>."
 msgstr ""
 
-#: src/olympia/stats/templates/stats/stats.html:179
+#: src/olympia/stats/templates/stats/stats.html:181
 msgid "Contribution stats are currently <b>private</b>."
 msgstr ""
 
-#: src/olympia/stats/templates/stats/stats.html:182
+#: src/olympia/stats/templates/stats/stats.html:184
 msgid "This dashboard is currently <b>private</b>."
 msgstr ""
 
-#: src/olympia/stats/templates/stats/stats.html:185
+#: src/olympia/stats/templates/stats/stats.html:187
 msgid "Change settings."
 msgstr ""
 
@@ -11381,15 +11150,6 @@ msgstr ""
 msgid "Application versions by Date"
 msgstr ""
 
-#: src/olympia/tags/templates/tags/top_cloud.html:4
-msgid "Top {0} Tags"
-msgstr ""
-
-#. {0} is the current application name
-#: src/olympia/tags/templates/tags/top_cloud.html:14
-msgid "{0} Top Tags"
-msgstr ""
-
 #: src/olympia/templates/amo_footer.html:6 src/olympia/templates/includes/lang_switcher.html:2
 msgid "Other languages"
 msgstr ""
@@ -11398,11 +11158,11 @@ msgstr ""
 msgid "Mozilla Add-ons"
 msgstr ""
 
-#: src/olympia/templates/base.html:91 src/olympia/templates/impala/base.html:81
+#: src/olympia/templates/base.html:89 src/olympia/templates/impala/base.html:78
 msgid "Find add-ons for other applications"
 msgstr ""
 
-#: src/olympia/templates/base.html:92 src/olympia/templates/impala/base.html:81
+#: src/olympia/templates/base.html:90 src/olympia/templates/impala/base.html:78
 msgid "Other Applications"
 msgstr ""
 
@@ -11427,7 +11187,7 @@ msgid "View Mobile Site"
 msgstr ""
 
 #: src/olympia/templates/copyright.html:7
-msgid "Site Status "
+msgid "Site Status"
 msgstr ""
 
 #: src/olympia/templates/footer.html:3
@@ -11527,35 +11287,35 @@ msgstr ""
 msgid "<a href=\"%(reg)s\">Register</a> or <a href=\"%(login)s\">Log in</a>"
 msgstr ""
 
-#: src/olympia/templates/impala/base.html:126
+#: src/olympia/templates/impala/base.html:123
 #, python-format
 msgid "To try the thousands of add-ons available here, download <a href=\"%(url)s\">Mozilla Firefox</a>, a fast, free way to surf the Web!"
 msgstr ""
 
-#: src/olympia/templates/impala/base.html:138
+#: src/olympia/templates/impala/base.html:135
 #, python-format
 msgid "Add-ons is switching to Firefox Accounts for login. <a href=\"%(url)s\" class=\"fxa-login\">Sign in now to transfer your account.</a>"
 msgstr ""
 
 #. {0} is an application, such as Firefox.
-#: src/olympia/templates/impala/base.html:148
+#: src/olympia/templates/impala/base.html:145
 msgid "Welcome to {0} Add-ons."
 msgstr ""
 
-#: src/olympia/templates/impala/base.html:151
+#: src/olympia/templates/impala/base.html:148
 msgid "Choose from thousands of extra features and styles to make Firefox your own."
 msgstr ""
 
-#: src/olympia/templates/impala/base.html:156
+#: src/olympia/templates/impala/base.html:153
 #, python-format
 msgid "Add extra features and styles to make %(app)s your own."
 msgstr ""
 
-#: src/olympia/templates/impala/base.html:164
+#: src/olympia/templates/impala/base.html:161
 msgid "On the go?"
 msgstr ""
 
-#: src/olympia/templates/impala/base.html:166
+#: src/olympia/templates/impala/base.html:163
 msgid "Check out our <a class=\"mobile-link\" href=\"#\">Mobile Add-ons site</a>."
 msgstr ""
 
@@ -11779,19 +11539,19 @@ msgstr ""
 
 #. L10n: {id} will be something like "13ad6a", just a random number
 #. to differentiate this user from other anonymous users.
-#: src/olympia/users/models.py:353
+#: src/olympia/users/models.py:362
 msgid "Anonymous user {id}"
 msgstr ""
 
-#: src/olympia/users/models.py:410
+#: src/olympia/users/models.py:419
 msgid "Your account has been restricted"
 msgstr ""
 
-#: src/olympia/users/models.py:480
+#: src/olympia/users/models.py:489
 msgid "Please confirm your email address"
 msgstr ""
 
-#: src/olympia/users/models.py:506
+#: src/olympia/users/models.py:515
 msgid "My Mobile Add-ons"
 msgstr ""
 
@@ -12068,7 +11828,7 @@ msgstr ""
 
 #: src/olympia/users/templates/users/edit.html:70
 #, python-format
-msgid "Change your password.  If you forgot your password, you can <a href=\"%(reset_url)s\">use the reset form</a>."
+msgid "Change your password. If you forgot your password, you can <a href=\"%(reset_url)s\">use the reset form</a>."
 msgstr ""
 
 #: src/olympia/users/templates/users/edit.html:76
@@ -12088,7 +11848,7 @@ msgid "Profile"
 msgstr ""
 
 #: src/olympia/users/templates/users/edit.html:100
-msgid "Give us a bit more information about yourself.  All these fields are optional, but they'll help other users get to know you better."
+msgid "Give us a bit more information about yourself. All these fields are optional, but they'll help other users get to know you better."
 msgstr ""
 
 #: src/olympia/users/templates/users/edit.html:124
@@ -12304,7 +12064,7 @@ msgid "Confirm password"
 msgstr ""
 
 #: src/olympia/users/templates/users/pwreset_confirm.html:47
-msgid "The password reset link was invalid, possibly because it has already been used.  Please request a new password reset."
+msgid "The password reset link was invalid, possibly because it has already been used. Please request a new password reset."
 msgstr ""
 
 #: src/olympia/users/templates/users/pwreset_request.html:15
@@ -12490,7 +12250,7 @@ msgstr ""
 
 #: src/olympia/users/templates/users/unsubscribe.html:30
 #, python-format
-msgid "Unfortunately, we weren't able to unsubscribe you.  The link you clicked is invalid. However, you can unsubscribe still unsubscribe on your <a href=\"%(edit_url)s\">edit profile page</a>."
+msgid "Unfortunately, we weren't able to unsubscribe you. The link you clicked is invalid. However, you can unsubscribe still unsubscribe on your <a href=\"%(edit_url)s\">edit profile page</a>."
 msgstr ""
 
 #: src/olympia/users/templates/users/vcard.html:2
@@ -12523,7 +12283,6 @@ msgid "%(num)s theme"
 msgid_plural "%(num)s themes"
 msgstr[0] ""
 msgstr[1] ""
-msgstr[2] ""
 
 #: src/olympia/users/templates/users/vcard.html:62
 #, python-format
@@ -12531,7 +12290,6 @@ msgid "%(num)s add-on"
 msgid_plural "%(num)s add-ons"
 msgstr[0] ""
 msgstr[1] ""
-msgstr[2] ""
 
 #: src/olympia/users/templates/users/vcard.html:75
 msgid "Average rating of developer's add-ons"
@@ -12546,15 +12304,15 @@ msgstr ""
 msgid "Version History with Changelogs"
 msgstr ""
 
-#: src/olympia/versions/models.py:314
+#: src/olympia/versions/models.py:313
 msgid "Add-on uses binary components."
 msgstr ""
 
-#: src/olympia/versions/models.py:317
+#: src/olympia/versions/models.py:316
 msgid "Add-on has opted into strict compatibility checking."
 msgstr ""
 
-#: src/olympia/versions/models.py:715
+#: src/olympia/versions/models.py:711
 msgid "{app} {min} and later"
 msgstr ""
 
@@ -12592,7 +12350,6 @@ msgid "<b>{0}</b> version"
 msgid_plural "<b>{0}</b> versions"
 msgstr[0] ""
 msgstr[1] ""
-msgstr[2] ""
 
 #: src/olympia/versions/templates/versions/version_list.html:35 src/olympia/versions/templates/versions/mobile/version_list.html:14
 msgid "Be careful with old versions!"
@@ -12630,4 +12387,8 @@ msgstr ""
 
 #: src/olympia/zadmin/forms.py:105
 msgid "Log emails instead of sending"
+msgstr ""
+
+#: src/olympia/zadmin/forms.py:215
+msgid "Deleted versions can`t be changed."
 msgstr ""

--- a/locale/lt/LC_MESSAGES/djangojs.po
+++ b/locale/lt/LC_MESSAGES/djangojs.po
@@ -1,1229 +1,1235 @@
-
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2016-02-24 21:23+0000\n"
+"POT-Creation-Date: 2016-04-18 15:47+0000\n"
 "PO-Revision-Date: 2014-02-24 21:26+0000\n"
 "Last-Translator: Matjaž <m@owca.info>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
+"Language: \n"
 "MIME-Version: 1.0\n"
-"Content-Type: text/plain; charset=utf-8\n"
+"Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Generated-By: Babel 2.2.0\n"
 
-#: static/js/common/ratingwidget.js:31
+#: static/js/common-all.js:1426 static/js/impala-all.js:1511 static/js/zamboni/discovery-all.js:12598 static/js/zamboni/init.js:28 static/js/zamboni/mobile-all.js:14945
+msgid "This feature is temporarily disabled while we perform website maintenance. Please check back a little later."
+msgstr ""
+
+#. L10n: {0} is an app name like Firefox.
+#: static/js/common-all.js:1837 static/js/impala-all.js:1922 static/js/zamboni/buttons.js:73 static/js/zamboni/discovery-all.js:13108
+msgid "Accept and Install"
+msgstr ""
+
+#: static/js/common-all.js:1837 static/js/impala-all.js:1922 static/js/zamboni/buttons.js:73 static/js/zamboni/discovery-all.js:13108
+msgid "Add to {0}"
+msgstr ""
+
+#: static/js/common-all.js:1842 static/js/impala-all.js:1927 static/js/zamboni/buttons.js:78 static/js/zamboni/discovery-all.js:13113
+msgid "Download Now"
+msgstr ""
+
+#: static/js/common-all.js:1883 static/js/impala-all.js:1968 static/js/zamboni/buttons.js:119 static/js/zamboni/discovery-all.js:13154
+msgid "Add-on has not been updated to support default-to-compatible."
+msgstr ""
+
+#: static/js/common-all.js:1888 static/js/impala-all.js:1973 static/js/zamboni/buttons.js:124 static/js/zamboni/discovery-all.js:13159
+msgid "You need to be using Firefox 10.0 or higher."
+msgstr ""
+
+#: static/js/common-all.js:1900 static/js/impala-all.js:1985 static/js/zamboni/buttons.js:136 static/js/zamboni/discovery-all.js:13171
+msgid "Mozilla has marked this version as incompatible with your Firefox version."
+msgstr ""
+
+#. L10n: {0} is an platform like Windows or Linux.
+#: static/js/common-all.js:1981 static/js/impala-all.js:2066 static/js/zamboni/buttons.js:217 static/js/zamboni/discovery-all.js:13252
+msgid "Install for {0} anyway"
+msgstr ""
+
+#: static/js/common-all.js:1981 static/js/impala-all.js:2066 static/js/zamboni/buttons.js:217 static/js/zamboni/discovery-all.js:13252
+msgid "Download for {0} anyway"
+msgstr ""
+
+#: static/js/common-all.js:2038 static/js/impala-all.js:2123 static/js/zamboni/buttons.js:274 static/js/zamboni/discovery-all.js:13309
+msgid "Not available for your platform"
+msgstr ""
+
+#. L10n: {0} is an app name, {1} is the app version.
+#: static/js/common-all.js:2049 static/js/common-all.js:2086 static/js/impala-all.js:2134 static/js/impala-all.js:2171 static/js/zamboni/buttons.js:286 static/js/zamboni/buttons.js:324
+#: static/js/zamboni/discovery-all.js:13320 static/js/zamboni/discovery-all.js:13357
+msgid "Not available for {0} {1}"
+msgstr ""
+
+#: static/js/common-all.js:2112 static/js/impala-all.js:2197 static/js/zamboni/buttons.js:351 static/js/zamboni/discovery-all.js:13383
+msgid "Works with {app} {min} - {max}"
+msgstr ""
+
+#: static/js/common-all.js:2114 static/js/impala-all.js:2199 static/js/zamboni/buttons.js:353 static/js/zamboni/discovery-all.js:13385
+msgid "View other versions"
+msgstr ""
+
+#: static/js/common-all.js:2162 static/js/impala-all.js:2247 static/js/zamboni/buttons.js:401 static/js/zamboni/discovery-all.js:13433
+msgid "Only with Firefox — Get Firefox Now!"
+msgstr ""
+
+#: static/js/common-all.js:2278 static/js/impala-all.js:2363 static/js/zamboni/buttons.js:517 static/js/zamboni/discovery-all.js:13549 static/js/zamboni/mobile-all.js:15177
+#: static/js/zamboni/mobile/buttons.js:43
+msgid "Sorry, you need a Mozilla-based browser (such as Firefox) to install a search plugin."
+msgstr ""
+
+#: static/js/common-all.js:9088 static/js/impala-all.js:9649 static/js/zamboni/global.js:410
+msgid "Loading..."
+msgstr ""
+
+#. L10n: {0} is the number of characters left.
+#: static/js/common-all.js:9152 static/js/impala-all.js:9713 static/js/zamboni/global.js:474
+msgid "<b>{0}</b> character left."
+msgid_plural "<b>{0}</b> characters left."
+msgstr[0] ""
+msgstr[1] ""
+
+#: static/js/common-all.js:9589 static/js/common-min.js:6 static/js/impala-all.js:10052 static/js/impala-min.js:6 static/js/common/ratingwidget.js:31 static/js/zamboni/mobile-all.js:16123
+#: static/js/zamboni/mobile-min.js:6
 msgid "{0} star"
 msgid_plural "{0} stars"
 msgstr[0] ""
 msgstr[1] ""
-msgstr[2] ""
 
-#: static/js/common/upload-addon.js:41 static/js/common/upload-image.js:128
+#: static/js/common-all.js:9676 static/js/common-min.js:6 static/js/impala-all.js:10139 static/js/impala-min.js:6 static/js/zamboni/l10n.js:45
+msgid "Remove this localization"
+msgstr ""
+
+#: static/js/common-all.js:10193 static/js/common-min.js:6 static/js/impala-all.js:10674 static/js/impala-min.js:6 static/js/zamboni/discovery-all.js:13678
+msgid "close"
+msgstr ""
+
+#: static/js/common-all.js:10860 static/js/common-min.js:6 static/js/impala-all.js:11481 static/js/impala-min.js:6 static/js/impala/reviews.js:23 static/js/zamboni/reviews.js:18
+msgid "Flagged for review"
+msgstr ""
+
+#: static/js/common-all.js:10876 static/js/common-min.js:6 static/js/impala-all.js:11498 static/js/impala-min.js:6 static/js/impala/reviews.js:40 static/js/zamboni/reviews.js:34
+msgid "Your input is required"
+msgstr ""
+
+#: static/js/common-all.js:10945 static/js/common-min.js:6 static/js/impala-all.js:11610 static/js/impala-min.js:7 static/js/impala/reviews.js:152 static/js/zamboni/reviews.js:103
+msgid "Marked for deletion"
+msgstr ""
+
+#: static/js/common-all.js:11573 static/js/common-min.js:7 static/js/impala-all.js:13809 static/js/impala-min.js:8 static/js/zamboni/collections.js:229
+msgid "Adding to Favorites&hellip;"
+msgstr ""
+
+#: static/js/common-all.js:11576 static/js/common-min.js:7 static/js/impala-all.js:13812 static/js/impala-min.js:8 static/js/zamboni/collections.js:232
+msgid "Removing Favorite&hellip;"
+msgstr ""
+
+#: static/js/common-all.js:11579 static/js/common-min.js:7 static/js/impala-all.js:13815 static/js/impala-min.js:8 static/js/zamboni/collections.js:235
+msgid "Add to Favorites"
+msgstr ""
+
+#: static/js/common-all.js:11582 static/js/common-min.js:7 static/js/impala-all.js:13818 static/js/impala-min.js:8 static/js/zamboni/collections.js:238
+msgid "Remove from Favorites"
+msgstr ""
+
+#: static/js/common-all.js:11647 static/js/common-min.js:7 static/js/impala-all.js:13883 static/js/impala-min.js:8 static/js/zamboni/collections.js:303
+msgid "Pending"
+msgstr ""
+
+#: static/js/common-all.js:11648 static/js/common-min.js:7 static/js/impala-all.js:13884 static/js/impala-min.js:8 static/js/zamboni/collections.js:304
+msgid "Add a comment"
+msgstr ""
+
+#: static/js/common-all.js:11648 static/js/common-min.js:7 static/js/impala-all.js:13884 static/js/impala-min.js:8 static/js/zamboni/collections.js:304
+msgid "Comment"
+msgstr ""
+
+#: static/js/common-all.js:11649 static/js/common-min.js:7 static/js/impala-all.js:13885 static/js/impala-min.js:8 static/js/zamboni/collections.js:305
+msgid "Remove this add-on from the collection"
+msgstr ""
+
+#: static/js/common-all.js:11649 static/js/common-all.js:11678 static/js/common-min.js:7 static/js/impala-all.js:13885 static/js/impala-all.js:13914 static/js/impala-min.js:8
+#: static/js/zamboni/collections.js:305 static/js/zamboni/collections.js:334
+msgid "Remove"
+msgstr ""
+
+#: static/js/common-all.js:11678 static/js/common-min.js:7 static/js/impala-all.js:13914 static/js/impala-min.js:8 static/js/zamboni/collections.js:334
+msgid "Remove this user as a contributor"
+msgstr ""
+
+#: static/js/common-all.js:11690 static/js/common-min.js:7 static/js/impala-all.js:13926 static/js/impala-min.js:8 static/js/zamboni/collections.js:346
+msgid "An email address is required."
+msgstr ""
+
+#: static/js/common-all.js:11708 static/js/common-min.js:7 static/js/impala-all.js:13944 static/js/impala-min.js:8 static/js/zamboni/collections.js:364
+msgid "You cannot add yourself as a contributor."
+msgstr ""
+
+#: static/js/common-all.js:11710 static/js/common-min.js:7 static/js/impala-all.js:13946 static/js/impala-min.js:8 static/js/zamboni/collections.js:366
+msgid "You have already added that user."
+msgstr ""
+
+#: static/js/common-all.js:11917 static/js/common-min.js:7 static/js/impala-all.js:14153 static/js/impala-min.js:8 static/js/zamboni/collections.js:573
+msgid "Add to favorites"
+msgstr ""
+
+#: static/js/common-all.js:11921 static/js/common-min.js:7 static/js/impala-all.js:14157 static/js/impala-min.js:8 static/js/zamboni/collections.js:577
+msgid "Remove from favorites"
+msgstr ""
+
+#: static/js/common-all.js:11939 static/js/common-min.js:7 static/js/impala-all.js:14175 static/js/impala-all.js:14233 static/js/impala-min.js:8 static/js/impala/collections.js:10
+#: static/js/zamboni/collections.js:595
+msgid "Follow this Collection"
+msgstr ""
+
+#: static/js/common-all.js:11948 static/js/common-min.js:7 static/js/impala-all.js:14184 static/js/impala-min.js:8 static/js/zamboni/collections.js:604
+msgid "Stop following"
+msgstr ""
+
+#: static/js/common-all.js:12096 static/js/common-min.js:7 static/js/zamboni/password-strength.js:20
+msgid "Password strength:"
+msgstr ""
+
+#: static/js/common-all.js:12102 static/js/common-min.js:7 static/js/zamboni/password-strength.js:26
+msgid "At least {0} character left."
+msgid_plural "At least {0} characters left."
+msgstr[0] ""
+msgstr[1] ""
+
+#: static/js/common-all.js:12286 static/js/common-min.js:7 static/js/impala-all.js:14632 static/js/impala-min.js:8 static/js/impala/suggestions.js:39
+msgid "Search themes for <b>{0}</b>"
+msgstr ""
+
+#: static/js/common-all.js:12288 static/js/common-min.js:7 static/js/impala-all.js:14634 static/js/impala-min.js:8 static/js/impala/suggestions.js:41
+msgid "Search apps for <b>{0}</b>"
+msgstr ""
+
+#: static/js/common-all.js:12290 static/js/common-min.js:7 static/js/impala-all.js:14636 static/js/impala-min.js:8 static/js/impala/suggestions.js:43
+msgid "Search add-ons for <b>{0}</b>"
+msgstr ""
+
+#: static/js/common-all.js:12521 static/js/common-min.js:7 static/js/impala-all.js:14867 static/js/impala-min.js:8 static/js/impala/site_suggestions.js:46
+msgid "Category"
+msgstr ""
+
+#. L10n: {0} is an app name.
+#: static/js/impala-all.js:11632 static/js/impala-min.js:7 static/js/impala/listing.js:11 static/js/zamboni/themes.js:13
+msgid "This theme is incompatible with your version of {0}"
+msgstr ""
+
+#: static/js/impala-all.js:12146 static/js/impala-all.js:14331 static/js/impala-min.js:7 static/js/impala-min.js:8 static/js/common/upload-image.js:97 static/js/impala/users.js:51
+#: static/js/zamboni/devhub-all.js:894 static/js/zamboni/devhub-min.js:1
+msgid "Images must be either PNG or JPG."
+msgstr ""
+
+#: static/js/impala-all.js:12150 static/js/impala-min.js:7 static/js/common/upload-image.js:101 static/js/zamboni/devhub-all.js:898 static/js/zamboni/devhub-min.js:1
+msgid "Videos must be in WebM."
+msgstr ""
+
+#: static/js/impala-all.js:12177 static/js/impala-min.js:7 static/js/common/upload-addon.js:41 static/js/common/upload-image.js:128 static/js/zamboni/devhub-all.js:272
+#: static/js/zamboni/devhub-all.js:925 static/js/zamboni/devhub-min.js:1
 msgid "There was a problem contacting the server."
 msgstr ""
 
-#: static/js/common/upload-addon.js:69
+#: static/js/impala-all.js:13298 static/js/impala-min.js:7 static/js/impala/persona_creation.js:60
+msgid "All Rights Reserved"
+msgstr ""
+
+#: static/js/impala-all.js:13302 static/js/impala-min.js:7 static/js/impala/persona_creation.js:64
+msgid "Creative Commons Attribution 3.0"
+msgstr ""
+
+#: static/js/impala-all.js:13307 static/js/impala-min.js:7 static/js/impala/persona_creation.js:69
+msgid "Creative Commons Attribution-NonCommercial 3.0"
+msgstr ""
+
+#: static/js/impala-all.js:13312 static/js/impala-min.js:7 static/js/impala/persona_creation.js:74
+msgid "Creative Commons Attribution-NonCommercial-NoDerivs 3.0"
+msgstr ""
+
+#: static/js/impala-all.js:13317 static/js/impala-min.js:7 static/js/impala/persona_creation.js:79
+msgid "Creative Commons Attribution-NonCommercial-Share Alike 3.0"
+msgstr ""
+
+#: static/js/impala-all.js:13322 static/js/impala-min.js:7 static/js/impala/persona_creation.js:84
+msgid "Creative Commons Attribution-NoDerivs 3.0"
+msgstr ""
+
+#: static/js/impala-all.js:13327 static/js/impala-min.js:7 static/js/impala/persona_creation.js:89
+msgid "Creative Commons Attribution-ShareAlike 3.0"
+msgstr ""
+
+#: static/js/impala-all.js:13530 static/js/impala-min.js:7 static/js/impala/persona_creation.js:292
+msgid "Your Theme's Name"
+msgstr ""
+
+#: static/js/impala-all.js:14242 static/js/impala-min.js:8 static/js/impala/collections.js:19
+msgid "Stop Following"
+msgstr ""
+
+#: static/js/impala-all.js:14243 static/js/impala-min.js:8 static/js/impala/collections.js:20
+msgid "Following"
+msgstr ""
+
+#: static/js/impala-all.js:14313 static/js/impala-min.js:8 static/js/impala/users.js:33
+msgid "use original"
+msgstr ""
+
+#: static/js/impala-all.js:14523 static/js/impala-min.js:8 static/js/impala/search.js:114
+msgid "Updating results&hellip;"
+msgstr ""
+
+#: static/js/common/upload-addon.js:69 static/js/zamboni/devhub-all.js:300 static/js/zamboni/devhub-min.js:1
 msgid "Select a file..."
 msgstr ""
 
-#: static/js/common/upload-addon.js:70
+#: static/js/common/upload-addon.js:70 static/js/zamboni/devhub-all.js:301 static/js/zamboni/devhub-min.js:1
 msgid "Your add-on should end with .xpi, .jar or .xml"
 msgstr ""
 
 #. L10n: {0} is the percent of the file that has been uploaded.
-#: static/js/common/upload-addon.js:104
+#: static/js/common/upload-addon.js:104 static/js/zamboni/devhub-all.js:335 static/js/zamboni/devhub-min.js:1
 #, python-format
 msgid "{0}% complete"
 msgstr ""
 
 #. L10n: "{bytes uploaded} of {total filesize}".
-#: static/js/common/upload-addon.js:107
+#: static/js/common/upload-addon.js:107 static/js/zamboni/devhub-all.js:338 static/js/zamboni/devhub-min.js:1
 msgid "{0} of {1}"
 msgstr ""
 
-#: static/js/common/upload-addon.js:140
+#: static/js/common/upload-addon.js:140 static/js/zamboni/devhub-all.js:371 static/js/zamboni/devhub-min.js:1
 msgid "Cancel"
 msgstr ""
 
-#: static/js/common/upload-addon.js:162
+#: static/js/common/upload-addon.js:162 static/js/zamboni/devhub-all.js:393 static/js/zamboni/devhub-min.js:1
 msgid "Uploading {0}"
 msgstr ""
 
-#: static/js/common/upload-addon.js:189
+#: static/js/common/upload-addon.js:189 static/js/zamboni/devhub-all.js:420 static/js/zamboni/devhub-min.js:1
 msgid "Error with {0}"
 msgstr ""
 
-#: static/js/common/upload-addon.js:194
+#: static/js/common/upload-addon.js:194 static/js/zamboni/devhub-all.js:425 static/js/zamboni/devhub-min.js:1
 msgid "Your add-on failed validation with {0} error."
 msgid_plural "Your add-on failed validation with {0} errors."
 msgstr[0] ""
 msgstr[1] ""
-msgstr[2] ""
 
-#: static/js/common/upload-addon.js:208
+#: static/js/common/upload-addon.js:208 static/js/zamboni/devhub-all.js:439 static/js/zamboni/devhub-min.js:1
 msgid "&hellip;and {0} more"
 msgid_plural "&hellip;and {0} more"
 msgstr[0] ""
 msgstr[1] ""
-msgstr[2] ""
 
-#: static/js/common/upload-addon.js:222 static/js/common/upload-addon.js:512
+#: static/js/common/upload-addon.js:222 static/js/common/upload-addon.js:497 static/js/zamboni/devhub-all.js:453 static/js/zamboni/devhub-all.js:743 static/js/zamboni/devhub-min.js:1
 msgid "See full validation report"
 msgstr ""
 
-#: static/js/common/upload-addon.js:234
+#: static/js/common/upload-addon.js:234 static/js/zamboni/devhub-all.js:465 static/js/zamboni/devhub-min.js:1
 msgid "Validating {0}"
 msgstr ""
 
 #. L10n: first argument is an HTTP status code
-#: static/js/common/upload-addon.js:273
+#: static/js/common/upload-addon.js:273 static/js/zamboni/devhub-all.js:504 static/js/zamboni/devhub-min.js:1
 msgid "Received an empty response from the server; status: {0}"
 msgstr ""
 
-#: static/js/common/upload-addon.js:373
+#: static/js/common/upload-addon.js:370 static/js/zamboni/devhub-all.js:604 static/js/zamboni/devhub-min.js:1
 msgid "Unexpected server error while validating."
 msgstr ""
 
-#: static/js/common/upload-addon.js:412
+#: static/js/common/upload-addon.js:409 static/js/zamboni/devhub-all.js:643 static/js/zamboni/devhub-min.js:1
 msgid "Finished validating {0}"
 msgstr ""
 
-#: static/js/common/upload-addon.js:418
+#: static/js/common/upload-addon.js:415 static/js/zamboni/devhub-all.js:649 static/js/zamboni/devhub-min.js:1
 msgid "Your add-on validation timed out, it will be manually reviewed."
 msgstr ""
 
-#: static/js/common/upload-addon.js:421
+#: static/js/common/upload-addon.js:418 static/js/zamboni/devhub-all.js:652 static/js/zamboni/devhub-min.js:1
 msgid "Your add-on was validated with no errors and {0} warning."
 msgid_plural "Your add-on was validated with no errors and {0} warnings."
 msgstr[0] ""
 msgstr[1] ""
-msgstr[2] ""
 
-#: static/js/common/upload-addon.js:426
+#: static/js/common/upload-addon.js:423 static/js/zamboni/devhub-all.js:657 static/js/zamboni/devhub-min.js:1
 msgid "Your add-on was validated with no errors and {0} message."
 msgid_plural "Your add-on was validated with no errors and {0} messages."
 msgstr[0] ""
 msgstr[1] ""
-msgstr[2] ""
 
-#: static/js/common/upload-addon.js:431
+#: static/js/common/upload-addon.js:428 static/js/zamboni/devhub-all.js:662 static/js/zamboni/devhub-min.js:1
 msgid "Your add-on was validated with no errors or warnings."
 msgstr ""
 
-#: static/js/common/upload-addon.js:446
+#: static/js/common/upload-addon.js:443 static/js/zamboni/devhub-all.js:677 static/js/zamboni/devhub-min.js:1
 msgid "Your submission will be automatically signed."
 msgstr ""
 
-#: static/js/common/upload-addon.js:465
+#: static/js/common/upload-addon.js:450 static/js/zamboni/devhub-all.js:696 static/js/zamboni/devhub-min.js:1
 msgid "Include detailed version notes (this can be done in the next step)."
 msgstr ""
 
-#: static/js/common/upload-addon.js:466
+#: static/js/common/upload-addon.js:451 static/js/zamboni/devhub-all.js:697 static/js/zamboni/devhub-min.js:1
 msgid "If your add-on requires an account to a website in order to be fully tested, include a test username and password in the Notes to Reviewer (this can be done in the next step)."
 msgstr ""
 
-#: static/js/common/upload-addon.js:467
+#: static/js/common/upload-addon.js:452 static/js/zamboni/devhub-all.js:698 static/js/zamboni/devhub-min.js:1
 msgid "If your add-on is intended for a limited audience you should choose Preliminary Review instead of Full Review."
 msgstr ""
 
-#: static/js/common/upload-addon.js:480
+#: static/js/common/upload-addon.js:465 static/js/zamboni/devhub-all.js:711 static/js/zamboni/devhub-min.js:1
 msgid "Add-on submission checklist"
 msgstr ""
 
-#: static/js/common/upload-addon.js:481
+#: static/js/common/upload-addon.js:466 static/js/zamboni/devhub-all.js:712 static/js/zamboni/devhub-min.js:1
 msgid "Please verify the following points before finalizing your submission. This will minimize delays or misunderstanding during the review process:"
 msgstr ""
 
-#: static/js/common/upload-addon.js:483
+#: static/js/common/upload-addon.js:468 static/js/zamboni/devhub-all.js:714 static/js/zamboni/devhub-min.js:1
 msgid ""
 "Compiled binaries, as well as minified or obfuscated scripts (excluding known libraries) need to have their sources submitted separately for review. Make sure that you use the source code upload "
 "field to avoid having your submission rejected."
 msgstr ""
 
-#: static/js/common/upload-addon.js:501
+#: static/js/common/upload-addon.js:486 static/js/zamboni/devhub-all.js:732 static/js/zamboni/devhub-min.js:1
 msgid "The validation process found these issues that can lead to rejections:"
 msgstr ""
 
-#: static/js/common/upload-addon.js:518
+#: static/js/common/upload-addon.js:503 static/js/zamboni/devhub-all.js:749 static/js/zamboni/devhub-min.js:1
 msgid "If you are unfamiliar with the add-ons review process, you can read about it here."
 msgstr ""
 
-#: static/js/common/upload-addon.js:555
+#: static/js/common/upload-addon.js:540 static/js/zamboni/devhub-all.js:786 static/js/zamboni/devhub-min.js:1
 msgid "Sorry, no supported platform has been found."
 msgstr ""
 
-#: static/js/common/upload-base.js:57
+#: static/js/common/upload-base.js:57 static/js/zamboni/devhub-all.js:187 static/js/zamboni/devhub-min.js:1
 msgid "The filetype you uploaded isn't recognized."
 msgstr ""
 
-#: static/js/common/upload-base.js:79
+#: static/js/common/upload-base.js:79 static/js/zamboni/devhub-all.js:209 static/js/zamboni/devhub-min.js:1
 msgid "You cancelled the upload."
 msgstr ""
 
-#: static/js/common/upload-image.js:97 static/js/impala/users.js:51
-msgid "Images must be either PNG or JPG."
-msgstr ""
-
-#: static/js/common/upload-image.js:101
-msgid "Videos must be in WebM."
-msgstr ""
-
-#: static/js/impala/collections.js:10 static/js/zamboni/collections.js:595
-msgid "Follow this Collection"
-msgstr ""
-
-#: static/js/impala/collections.js:19
-msgid "Stop Following"
-msgstr ""
-
-#: static/js/impala/collections.js:20
-msgid "Following"
-msgstr ""
-
-#. L10n: {0} is an app name.
-#: static/js/impala/listing.js:11 static/js/zamboni/themes.js:13
-msgid "This theme is incompatible with your version of {0}"
-msgstr ""
-
-#: static/js/impala/persona_creation.js:60
-msgid "All Rights Reserved"
-msgstr ""
-
-#: static/js/impala/persona_creation.js:64
-msgid "Creative Commons Attribution 3.0"
-msgstr ""
-
-#: static/js/impala/persona_creation.js:69
-msgid "Creative Commons Attribution-NonCommercial 3.0"
-msgstr ""
-
-#: static/js/impala/persona_creation.js:74
-msgid "Creative Commons Attribution-NonCommercial-NoDerivs 3.0"
-msgstr ""
-
-#: static/js/impala/persona_creation.js:79
-msgid "Creative Commons Attribution-NonCommercial-Share Alike 3.0"
-msgstr ""
-
-#: static/js/impala/persona_creation.js:84
-msgid "Creative Commons Attribution-NoDerivs 3.0"
-msgstr ""
-
-#: static/js/impala/persona_creation.js:89
-msgid "Creative Commons Attribution-ShareAlike 3.0"
-msgstr ""
-
-#: static/js/impala/persona_creation.js:292
-msgid "Your Theme's Name"
-msgstr ""
-
-#: static/js/impala/reviews.js:23 static/js/zamboni/reviews.js:18
-msgid "Flagged for review"
-msgstr ""
-
-#: static/js/impala/reviews.js:40 static/js/zamboni/reviews.js:34
-msgid "Your input is required"
-msgstr ""
-
-#: static/js/impala/reviews.js:152 static/js/zamboni/reviews.js:103
-msgid "Marked for deletion"
-msgstr ""
-
-#: static/js/impala/search.js:114
-msgid "Updating results&hellip;"
-msgstr ""
-
-#: static/js/impala/site_suggestions.js:46
-msgid "Category"
-msgstr ""
-
-#: static/js/impala/suggestions.js:39
-msgid "Search themes for <b>{0}</b>"
-msgstr ""
-
-#: static/js/impala/suggestions.js:41
-msgid "Search apps for <b>{0}</b>"
-msgstr ""
-
-#: static/js/impala/suggestions.js:43
-msgid "Search add-ons for <b>{0}</b>"
-msgstr ""
-
-#: static/js/impala/users.js:33
-msgid "use original"
-msgstr ""
-
-#: static/js/impala/stats/chart.js:267
+#: static/js/impala/stats/chart.js:267 static/js/zamboni/stats-all.js:16898 static/js/zamboni/stats-min.js:5
 msgid "Week of {0}"
 msgstr ""
 
-#: static/js/impala/stats/chart.js:269
+#: static/js/impala/stats/chart.js:269 static/js/zamboni/stats-all.js:16900 static/js/zamboni/stats-min.js:5
 msgid " downloads"
 msgstr ""
 
-#: static/js/impala/stats/chart.js:270
+#: static/js/impala/stats/chart.js:270 static/js/zamboni/stats-all.js:16901 static/js/zamboni/stats-min.js:5
 msgid "{0} users"
 msgstr ""
 
-#: static/js/impala/stats/chart.js:271
+#: static/js/impala/stats/chart.js:271 static/js/zamboni/stats-all.js:16902 static/js/zamboni/stats-min.js:5
 msgid "{0} add-ons"
 msgstr ""
 
-#: static/js/impala/stats/chart.js:272
+#: static/js/impala/stats/chart.js:272 static/js/zamboni/stats-all.js:16903 static/js/zamboni/stats-min.js:5
 msgid "{0} collections"
 msgstr ""
 
-#: static/js/impala/stats/chart.js:273
+#: static/js/impala/stats/chart.js:273 static/js/zamboni/stats-all.js:16904 static/js/zamboni/stats-min.js:5
 msgid "{0} reviews"
 msgstr ""
 
-#: static/js/impala/stats/chart.js:275
+#: static/js/impala/stats/chart.js:275 static/js/zamboni/stats-all.js:16906 static/js/zamboni/stats-min.js:5
 msgid "{0} sales"
 msgstr ""
 
-#: static/js/impala/stats/chart.js:276
+#: static/js/impala/stats/chart.js:276 static/js/zamboni/stats-all.js:16907 static/js/zamboni/stats-min.js:5
 msgid "{0} refunds"
 msgstr ""
 
-#: static/js/impala/stats/chart.js:277
+#: static/js/impala/stats/chart.js:277 static/js/zamboni/stats-all.js:16908 static/js/zamboni/stats-min.js:5
 msgid "{0} installs"
 msgstr ""
 
-#: static/js/impala/stats/chart.js:369 static/js/impala/stats/csv_keys.js:3 static/js/impala/stats/csv_keys.js:109
+#: static/js/impala/stats/chart.js:369 static/js/impala/stats/csv_keys.js:3 static/js/impala/stats/csv_keys.js:109 static/js/zamboni/stats-all.js:15284 static/js/zamboni/stats-all.js:15390
+#: static/js/zamboni/stats-all.js:17000 static/js/zamboni/stats-min.js:4 static/js/zamboni/stats-min.js:5
 msgid "Downloads"
 msgstr ""
 
-#: static/js/impala/stats/chart.js:379 static/js/impala/stats/csv_keys.js:6 static/js/impala/stats/csv_keys.js:110
+#: static/js/impala/stats/chart.js:379 static/js/impala/stats/csv_keys.js:6 static/js/impala/stats/csv_keys.js:110 static/js/zamboni/stats-all.js:15287 static/js/zamboni/stats-all.js:15391
+#: static/js/zamboni/stats-all.js:17010 static/js/zamboni/stats-min.js:4 static/js/zamboni/stats-min.js:5
 msgid "Daily Users"
 msgstr ""
 
-#: static/js/impala/stats/chart.js:410
+#: static/js/impala/stats/chart.js:410 static/js/zamboni/stats-all.js:17041 static/js/zamboni/stats-min.js:5
 msgid "Amount, in USD"
 msgstr ""
 
-#: static/js/impala/stats/chart.js:421 static/js/impala/stats/csv_keys.js:104
+#: static/js/impala/stats/chart.js:421 static/js/impala/stats/csv_keys.js:104 static/js/zamboni/stats-all.js:15385 static/js/zamboni/stats-all.js:17052 static/js/zamboni/stats-min.js:5
 msgid "Number of Contributions"
 msgstr ""
 
-#: static/js/impala/stats/chart.js:447
+#: static/js/impala/stats/chart.js:447 static/js/zamboni/stats-all.js:17078 static/js/zamboni/stats-min.js:5
 msgid "More Info..."
 msgstr ""
 
 #. L10n: {0} is an ISO-formatted date.
-#: static/js/impala/stats/chart.js:451
+#: static/js/impala/stats/chart.js:451 static/js/zamboni/stats-all.js:17082 static/js/zamboni/stats-min.js:5
 msgid "Details for {0}"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:9
+#: static/js/impala/stats/csv_keys.js:9 static/js/zamboni/stats-all.js:15290 static/js/zamboni/stats-min.js:4
 msgid "Collections Created"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:12
+#: static/js/impala/stats/csv_keys.js:12 static/js/zamboni/stats-all.js:15293 static/js/zamboni/stats-min.js:4
 msgid "Add-ons in Use"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:15
+#: static/js/impala/stats/csv_keys.js:15 static/js/zamboni/stats-all.js:15296 static/js/zamboni/stats-min.js:4
 msgid "Add-ons Created"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:18
+#: static/js/impala/stats/csv_keys.js:18 static/js/zamboni/stats-all.js:15299 static/js/zamboni/stats-min.js:4
 msgid "Add-ons Downloaded"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:21
+#: static/js/impala/stats/csv_keys.js:21 static/js/zamboni/stats-all.js:15302 static/js/zamboni/stats-min.js:4
 msgid "Add-ons Updated"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:24
+#: static/js/impala/stats/csv_keys.js:24 static/js/zamboni/stats-all.js:15305 static/js/zamboni/stats-min.js:4
 msgid "Reviews Written"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:27
+#: static/js/impala/stats/csv_keys.js:27 static/js/zamboni/stats-all.js:15308 static/js/zamboni/stats-min.js:4
 msgid "User Signups"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:30
+#: static/js/impala/stats/csv_keys.js:30 static/js/zamboni/stats-all.js:15311 static/js/zamboni/stats-min.js:4
 msgid "Subscribers"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:33
+#: static/js/impala/stats/csv_keys.js:33 static/js/zamboni/stats-all.js:15314 static/js/zamboni/stats-min.js:4
 msgid "Ratings"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:36 static/js/impala/stats/csv_keys.js:114
+#: static/js/impala/stats/csv_keys.js:36 static/js/impala/stats/csv_keys.js:114 static/js/zamboni/stats-all.js:15317 static/js/zamboni/stats-all.js:15395 static/js/zamboni/stats-min.js:4
+#: static/js/zamboni/stats-min.js:5
 msgid "Sales"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:39 static/js/impala/stats/csv_keys.js:113
+#: static/js/impala/stats/csv_keys.js:39 static/js/impala/stats/csv_keys.js:113 static/js/zamboni/stats-all.js:15320 static/js/zamboni/stats-all.js:15394 static/js/zamboni/stats-min.js:4
+#: static/js/zamboni/stats-min.js:5
 msgid "Installs"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:42
+#: static/js/impala/stats/csv_keys.js:42 static/js/zamboni/stats-all.js:15323 static/js/zamboni/stats-min.js:4
 msgid "Unknown"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:43
+#: static/js/impala/stats/csv_keys.js:43 static/js/zamboni/stats-all.js:15324 static/js/zamboni/stats-min.js:4
 msgid "Add-ons Manager"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:44
+#: static/js/impala/stats/csv_keys.js:44 static/js/zamboni/stats-all.js:15325 static/js/zamboni/stats-min.js:4
 msgid "Add-ons Manager Promo"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:45
+#: static/js/impala/stats/csv_keys.js:45 static/js/zamboni/stats-all.js:15326 static/js/zamboni/stats-min.js:4
 msgid "Add-ons Manager Featured"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:46
+#: static/js/impala/stats/csv_keys.js:46 static/js/zamboni/stats-all.js:15327 static/js/zamboni/stats-min.js:4
 msgid "Add-ons Manager Learn More"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:47
+#: static/js/impala/stats/csv_keys.js:47 static/js/zamboni/stats-all.js:15328 static/js/zamboni/stats-min.js:4
 msgid "Search Suggestions"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:48
+#: static/js/impala/stats/csv_keys.js:48 static/js/zamboni/stats-all.js:15329 static/js/zamboni/stats-min.js:4
 msgid "Search Results"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:49 static/js/impala/stats/csv_keys.js:50 static/js/impala/stats/csv_keys.js:51
+#: static/js/impala/stats/csv_keys.js:49 static/js/impala/stats/csv_keys.js:50 static/js/impala/stats/csv_keys.js:51 static/js/zamboni/stats-all.js:15330 static/js/zamboni/stats-all.js:15331
+#: static/js/zamboni/stats-all.js:15332 static/js/zamboni/stats-min.js:4
 msgid "Homepage Promo"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:52 static/js/impala/stats/csv_keys.js:53
+#: static/js/impala/stats/csv_keys.js:52 static/js/impala/stats/csv_keys.js:53 static/js/zamboni/stats-all.js:15333 static/js/zamboni/stats-all.js:15334 static/js/zamboni/stats-min.js:4
 msgid "Homepage Featured"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:54 static/js/impala/stats/csv_keys.js:55
+#: static/js/impala/stats/csv_keys.js:54 static/js/impala/stats/csv_keys.js:55 static/js/zamboni/stats-all.js:15335 static/js/zamboni/stats-all.js:15336 static/js/zamboni/stats-min.js:4
 msgid "Homepage Up and Coming"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:56
+#: static/js/impala/stats/csv_keys.js:56 static/js/zamboni/stats-all.js:15337 static/js/zamboni/stats-min.js:4
 msgid "Homepage Most Popular"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:57 static/js/impala/stats/csv_keys.js:59
+#: static/js/impala/stats/csv_keys.js:57 static/js/impala/stats/csv_keys.js:59 static/js/zamboni/stats-all.js:15338 static/js/zamboni/stats-all.js:15340 static/js/zamboni/stats-min.js:4
 msgid "Detail Page"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:58 static/js/impala/stats/csv_keys.js:60
+#: static/js/impala/stats/csv_keys.js:58 static/js/impala/stats/csv_keys.js:60 static/js/zamboni/stats-all.js:15339 static/js/zamboni/stats-all.js:15341 static/js/zamboni/stats-min.js:4
 msgid "Detail Page (bottom)"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:61
+#: static/js/impala/stats/csv_keys.js:61 static/js/zamboni/stats-all.js:15342 static/js/zamboni/stats-min.js:4
 msgid "Detail Page (Development Channel)"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:62 static/js/impala/stats/csv_keys.js:63 static/js/impala/stats/csv_keys.js:64
+#: static/js/impala/stats/csv_keys.js:62 static/js/impala/stats/csv_keys.js:63 static/js/impala/stats/csv_keys.js:64 static/js/zamboni/stats-all.js:15343 static/js/zamboni/stats-all.js:15344
+#: static/js/zamboni/stats-all.js:15345 static/js/zamboni/stats-min.js:4
 msgid "Often Used With"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:65 static/js/impala/stats/csv_keys.js:66
+#: static/js/impala/stats/csv_keys.js:65 static/js/impala/stats/csv_keys.js:66 static/js/zamboni/stats-all.js:15346 static/js/zamboni/stats-all.js:15347 static/js/zamboni/stats-min.js:4
 msgid "Others By Author"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:67 static/js/impala/stats/csv_keys.js:68
+#: static/js/impala/stats/csv_keys.js:67 static/js/impala/stats/csv_keys.js:68 static/js/zamboni/stats-all.js:15348 static/js/zamboni/stats-all.js:15349 static/js/zamboni/stats-min.js:4
 msgid "Dependencies"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:69 static/js/impala/stats/csv_keys.js:70
+#: static/js/impala/stats/csv_keys.js:69 static/js/impala/stats/csv_keys.js:70 static/js/zamboni/stats-all.js:15350 static/js/zamboni/stats-all.js:15351 static/js/zamboni/stats-min.js:4
 msgid "Upsell"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:71
+#: static/js/impala/stats/csv_keys.js:71 static/js/zamboni/stats-all.js:15352 static/js/zamboni/stats-min.js:4
 msgid "Meet the Developer"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:72
+#: static/js/impala/stats/csv_keys.js:72 static/js/zamboni/stats-all.js:15353 static/js/zamboni/stats-min.js:4
 msgid "User Profile"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:73
+#: static/js/impala/stats/csv_keys.js:73 static/js/zamboni/stats-all.js:15354 static/js/zamboni/stats-min.js:4
 msgid "Version History"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:75
+#: static/js/impala/stats/csv_keys.js:75 static/js/zamboni/stats-all.js:15356 static/js/zamboni/stats-min.js:4
 msgid "Sharing"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:76
+#: static/js/impala/stats/csv_keys.js:76 static/js/zamboni/stats-all.js:15357 static/js/zamboni/stats-min.js:4
 msgid "Category Pages"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:77
+#: static/js/impala/stats/csv_keys.js:77 static/js/zamboni/stats-all.js:15358 static/js/zamboni/stats-min.js:4
 msgid "Collections"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:78 static/js/impala/stats/csv_keys.js:79
+#: static/js/impala/stats/csv_keys.js:78 static/js/impala/stats/csv_keys.js:79 static/js/zamboni/stats-all.js:15359 static/js/zamboni/stats-all.js:15360 static/js/zamboni/stats-min.js:4
 msgid "Category Landing Featured Carousel"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:80 static/js/impala/stats/csv_keys.js:81
+#: static/js/impala/stats/csv_keys.js:80 static/js/impala/stats/csv_keys.js:81 static/js/zamboni/stats-all.js:15361 static/js/zamboni/stats-all.js:15362 static/js/zamboni/stats-min.js:4
 msgid "Category Landing Top Rated"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:82 static/js/impala/stats/csv_keys.js:83
+#: static/js/impala/stats/csv_keys.js:82 static/js/impala/stats/csv_keys.js:83 static/js/zamboni/stats-all.js:15363 static/js/zamboni/stats-all.js:15364 static/js/zamboni/stats-min.js:5
 msgid "Category Landing Most Popular"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:84 static/js/impala/stats/csv_keys.js:85
+#: static/js/impala/stats/csv_keys.js:84 static/js/impala/stats/csv_keys.js:85 static/js/zamboni/stats-all.js:15365 static/js/zamboni/stats-all.js:15366 static/js/zamboni/stats-min.js:5
 msgid "Category Landing Recently Added"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:86 static/js/impala/stats/csv_keys.js:87
+#: static/js/impala/stats/csv_keys.js:86 static/js/impala/stats/csv_keys.js:87 static/js/zamboni/stats-all.js:15367 static/js/zamboni/stats-all.js:15368 static/js/zamboni/stats-min.js:5
 msgid "Browse Listing Featured Sort"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:88 static/js/impala/stats/csv_keys.js:89
+#: static/js/impala/stats/csv_keys.js:88 static/js/impala/stats/csv_keys.js:89 static/js/zamboni/stats-all.js:15369 static/js/zamboni/stats-all.js:15370 static/js/zamboni/stats-min.js:5
 msgid "Browse Listing Users Sort"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:90 static/js/impala/stats/csv_keys.js:91
+#: static/js/impala/stats/csv_keys.js:90 static/js/impala/stats/csv_keys.js:91 static/js/zamboni/stats-all.js:15371 static/js/zamboni/stats-all.js:15372 static/js/zamboni/stats-min.js:5
 msgid "Browse Listing Rating Sort"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:92 static/js/impala/stats/csv_keys.js:93
+#: static/js/impala/stats/csv_keys.js:92 static/js/impala/stats/csv_keys.js:93 static/js/zamboni/stats-all.js:15373 static/js/zamboni/stats-all.js:15374 static/js/zamboni/stats-min.js:5
 msgid "Browse Listing Created Sort"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:94 static/js/impala/stats/csv_keys.js:95
+#: static/js/impala/stats/csv_keys.js:94 static/js/impala/stats/csv_keys.js:95 static/js/zamboni/stats-all.js:15375 static/js/zamboni/stats-all.js:15376 static/js/zamboni/stats-min.js:5
 msgid "Browse Listing Name Sort"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:96 static/js/impala/stats/csv_keys.js:97
+#: static/js/impala/stats/csv_keys.js:96 static/js/impala/stats/csv_keys.js:97 static/js/zamboni/stats-all.js:15377 static/js/zamboni/stats-all.js:15378 static/js/zamboni/stats-min.js:5
 msgid "Browse Listing Popular Sort"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:98 static/js/impala/stats/csv_keys.js:99
+#: static/js/impala/stats/csv_keys.js:98 static/js/impala/stats/csv_keys.js:99 static/js/zamboni/stats-all.js:15379 static/js/zamboni/stats-all.js:15380 static/js/zamboni/stats-min.js:5
 msgid "Browse Listing Updated Sort"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:100 static/js/impala/stats/csv_keys.js:101
+#: static/js/impala/stats/csv_keys.js:100 static/js/impala/stats/csv_keys.js:101 static/js/zamboni/stats-all.js:15381 static/js/zamboni/stats-all.js:15382 static/js/zamboni/stats-min.js:5
 msgid "Browse Listing Up and Coming Sort"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:105
+#: static/js/impala/stats/csv_keys.js:105 static/js/zamboni/stats-all.js:15386 static/js/zamboni/stats-min.js:5
 msgid "Total Amount Contributed"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:106
+#: static/js/impala/stats/csv_keys.js:106 static/js/zamboni/stats-all.js:15387 static/js/zamboni/stats-min.js:5
 msgid "Average Contribution"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:115
+#: static/js/impala/stats/csv_keys.js:115 static/js/zamboni/stats-all.js:15396 static/js/zamboni/stats-min.js:5
 msgid "Usage"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:118
+#: static/js/impala/stats/csv_keys.js:118 static/js/zamboni/stats-all.js:15399 static/js/zamboni/stats-min.js:5
 msgid "Firefox"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:119
+#: static/js/impala/stats/csv_keys.js:119 static/js/zamboni/stats-all.js:15400 static/js/zamboni/stats-min.js:5
 msgid "Mozilla"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:120
+#: static/js/impala/stats/csv_keys.js:120 static/js/zamboni/stats-all.js:15401 static/js/zamboni/stats-min.js:5
 msgid "Thunderbird"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:121
+#: static/js/impala/stats/csv_keys.js:121 static/js/zamboni/stats-all.js:15402 static/js/zamboni/stats-min.js:5
 msgid "Sunbird"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:122
+#: static/js/impala/stats/csv_keys.js:122 static/js/zamboni/stats-all.js:15403 static/js/zamboni/stats-min.js:5
 msgid "SeaMonkey"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:123
+#: static/js/impala/stats/csv_keys.js:123 static/js/zamboni/stats-all.js:15404 static/js/zamboni/stats-min.js:5
 msgid "Fennec"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:124
+#: static/js/impala/stats/csv_keys.js:124 static/js/zamboni/stats-all.js:15405 static/js/zamboni/stats-min.js:5
 msgid "Android"
 msgstr ""
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:129
+#: static/js/impala/stats/csv_keys.js:129 static/js/zamboni/stats-all.js:15410 static/js/zamboni/stats-min.js:5
 msgid "Downloads and Daily Users, last {0} days"
 msgstr ""
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:131
+#: static/js/impala/stats/csv_keys.js:131 static/js/zamboni/stats-all.js:15412 static/js/zamboni/stats-min.js:5
 msgid "Downloads and Daily Users from {0} to {1}"
 msgstr ""
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:135
+#: static/js/impala/stats/csv_keys.js:135 static/js/zamboni/stats-all.js:15416 static/js/zamboni/stats-min.js:5
 msgid "Installs and Daily Users, last {0} days"
 msgstr ""
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:137
+#: static/js/impala/stats/csv_keys.js:137 static/js/zamboni/stats-all.js:15418 static/js/zamboni/stats-min.js:5
 msgid "Installs and Daily Users from {0} to {1}"
 msgstr ""
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:141
+#: static/js/impala/stats/csv_keys.js:141 static/js/zamboni/stats-all.js:15422 static/js/zamboni/stats-min.js:5
 msgid "Downloads, last {0} days"
 msgstr ""
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:143
+#: static/js/impala/stats/csv_keys.js:143 static/js/zamboni/stats-all.js:15424 static/js/zamboni/stats-min.js:5
 msgid "Downloads from {0} to {1}"
 msgstr ""
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:147
+#: static/js/impala/stats/csv_keys.js:147 static/js/zamboni/stats-all.js:15428 static/js/zamboni/stats-min.js:5
 msgid "Daily Users, last {0} days"
 msgstr ""
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:149
+#: static/js/impala/stats/csv_keys.js:149 static/js/zamboni/stats-all.js:15430 static/js/zamboni/stats-min.js:5
 msgid "Daily Users from {0} to {1}"
 msgstr ""
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:153
+#: static/js/impala/stats/csv_keys.js:153 static/js/zamboni/stats-all.js:15434 static/js/zamboni/stats-min.js:5
 msgid "Applications, last {0} days"
 msgstr ""
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:155
+#: static/js/impala/stats/csv_keys.js:155 static/js/zamboni/stats-all.js:15436 static/js/zamboni/stats-min.js:5
 msgid "Applications from {0} to {1}"
 msgstr ""
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:159
+#: static/js/impala/stats/csv_keys.js:159 static/js/zamboni/stats-all.js:15440 static/js/zamboni/stats-min.js:5
 msgid "Platforms, last {0} days"
 msgstr ""
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:161
+#: static/js/impala/stats/csv_keys.js:161 static/js/zamboni/stats-all.js:15442 static/js/zamboni/stats-min.js:5
 msgid "Platforms from {0} to {1}"
 msgstr ""
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:165
+#: static/js/impala/stats/csv_keys.js:165 static/js/zamboni/stats-all.js:15446 static/js/zamboni/stats-min.js:5
 msgid "Languages, last {0} days"
 msgstr ""
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:167
+#: static/js/impala/stats/csv_keys.js:167 static/js/zamboni/stats-all.js:15448 static/js/zamboni/stats-min.js:5
 msgid "Languages from {0} to {1}"
 msgstr ""
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:171
+#: static/js/impala/stats/csv_keys.js:171 static/js/zamboni/stats-all.js:15452 static/js/zamboni/stats-min.js:5
 msgid "Add-on Versions, last {0} days"
 msgstr ""
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:173
+#: static/js/impala/stats/csv_keys.js:173 static/js/zamboni/stats-all.js:15454 static/js/zamboni/stats-min.js:5
 msgid "Add-on Versions from {0} to {1}"
 msgstr ""
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:177
+#: static/js/impala/stats/csv_keys.js:177 static/js/zamboni/stats-all.js:15458 static/js/zamboni/stats-min.js:5
 msgid "Add-on Status, last {0} days"
 msgstr ""
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:179
+#: static/js/impala/stats/csv_keys.js:179 static/js/zamboni/stats-all.js:15460 static/js/zamboni/stats-min.js:5
 msgid "Add-on Status from {0} to {1}"
 msgstr ""
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:183
+#: static/js/impala/stats/csv_keys.js:183 static/js/zamboni/stats-all.js:15464 static/js/zamboni/stats-min.js:5
 msgid "Download Sources, last {0} days"
 msgstr ""
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:185
+#: static/js/impala/stats/csv_keys.js:185 static/js/zamboni/stats-all.js:15466 static/js/zamboni/stats-min.js:5
 msgid "Download Sources from {0} to {1}"
 msgstr ""
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:189
+#: static/js/impala/stats/csv_keys.js:189 static/js/zamboni/stats-all.js:15470 static/js/zamboni/stats-min.js:5
 msgid "Contributions, last {0} days"
 msgstr ""
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:191
+#: static/js/impala/stats/csv_keys.js:191 static/js/zamboni/stats-all.js:15472 static/js/zamboni/stats-min.js:5
 msgid "Contributions from {0} to {1}"
 msgstr ""
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:195
+#: static/js/impala/stats/csv_keys.js:195 static/js/zamboni/stats-all.js:15476 static/js/zamboni/stats-min.js:5
 msgid "Site Metrics, last {0} days"
 msgstr ""
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:197
+#: static/js/impala/stats/csv_keys.js:197 static/js/zamboni/stats-all.js:15478 static/js/zamboni/stats-min.js:5
 msgid "Site Metrics from {0} to {1}"
 msgstr ""
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:201
+#: static/js/impala/stats/csv_keys.js:201 static/js/zamboni/stats-all.js:15482 static/js/zamboni/stats-min.js:5
 msgid "Add-ons in Use, last {0} days"
 msgstr ""
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:203
+#: static/js/impala/stats/csv_keys.js:203 static/js/zamboni/stats-all.js:15484 static/js/zamboni/stats-min.js:5
 msgid "Add-ons in Use from {0} to {1}"
 msgstr ""
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:207
+#: static/js/impala/stats/csv_keys.js:207 static/js/zamboni/stats-all.js:15488 static/js/zamboni/stats-min.js:5
 msgid "Add-ons Downloaded, last {0} days"
 msgstr ""
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:209
+#: static/js/impala/stats/csv_keys.js:209 static/js/zamboni/stats-all.js:15490 static/js/zamboni/stats-min.js:5
 msgid "Add-ons Downloaded from {0} to {1}"
 msgstr ""
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:213
+#: static/js/impala/stats/csv_keys.js:213 static/js/zamboni/stats-all.js:15494 static/js/zamboni/stats-min.js:5
 msgid "Add-ons Created, last {0} days"
 msgstr ""
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:215
+#: static/js/impala/stats/csv_keys.js:215 static/js/zamboni/stats-all.js:15496 static/js/zamboni/stats-min.js:5
 msgid "Add-ons Created from {0} to {1}"
 msgstr ""
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:219
+#: static/js/impala/stats/csv_keys.js:219 static/js/zamboni/stats-all.js:15500 static/js/zamboni/stats-min.js:5
 msgid "Add-ons Updated, last {0} days"
 msgstr ""
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:221
+#: static/js/impala/stats/csv_keys.js:221 static/js/zamboni/stats-all.js:15502 static/js/zamboni/stats-min.js:5
 msgid "Add-ons Updated from {0} to {1}"
 msgstr ""
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:225
+#: static/js/impala/stats/csv_keys.js:225 static/js/zamboni/stats-all.js:15506 static/js/zamboni/stats-min.js:5
 msgid "Reviews Written, last {0} days"
 msgstr ""
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:227
+#: static/js/impala/stats/csv_keys.js:227 static/js/zamboni/stats-all.js:15508 static/js/zamboni/stats-min.js:5
 msgid "Reviews Written from {0} to {1}"
 msgstr ""
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:231
+#: static/js/impala/stats/csv_keys.js:231 static/js/zamboni/stats-all.js:15512 static/js/zamboni/stats-min.js:5
 msgid "User Signups, last {0} days"
 msgstr ""
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:233
+#: static/js/impala/stats/csv_keys.js:233 static/js/zamboni/stats-all.js:15514 static/js/zamboni/stats-min.js:5
 msgid "User Signups from {0} to {1}"
 msgstr ""
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:237
+#: static/js/impala/stats/csv_keys.js:237 static/js/zamboni/stats-all.js:15518 static/js/zamboni/stats-min.js:5
 msgid "Collections Created, last {0} days"
 msgstr ""
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:239
+#: static/js/impala/stats/csv_keys.js:239 static/js/zamboni/stats-all.js:15520 static/js/zamboni/stats-min.js:5
 msgid "Collections Created from {0} to {1}"
 msgstr ""
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:243
+#: static/js/impala/stats/csv_keys.js:243 static/js/zamboni/stats-all.js:15524 static/js/zamboni/stats-min.js:5
 msgid "Subscribers, last {0} days"
 msgstr ""
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:245
+#: static/js/impala/stats/csv_keys.js:245 static/js/zamboni/stats-all.js:15526 static/js/zamboni/stats-min.js:5
 msgid "Subscribers from {0} to {1}"
 msgstr ""
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:249
+#: static/js/impala/stats/csv_keys.js:249 static/js/zamboni/stats-all.js:15530 static/js/zamboni/stats-min.js:5
 msgid "Ratings, last {0} days"
 msgstr ""
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:251
+#: static/js/impala/stats/csv_keys.js:251 static/js/zamboni/stats-all.js:15532 static/js/zamboni/stats-min.js:5
 msgid "Ratings from {0} to {1}"
 msgstr ""
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:255
+#: static/js/impala/stats/csv_keys.js:255 static/js/zamboni/stats-all.js:15536 static/js/zamboni/stats-min.js:5
 msgid "Sales, last {0} days"
 msgstr ""
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:257
+#: static/js/impala/stats/csv_keys.js:257 static/js/zamboni/stats-all.js:15538 static/js/zamboni/stats-min.js:5
 msgid "Sales from {0} to {1}"
 msgstr ""
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:261
+#: static/js/impala/stats/csv_keys.js:261 static/js/zamboni/stats-all.js:15542 static/js/zamboni/stats-min.js:5
 msgid "Installs, last {0} days"
 msgstr ""
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:263
+#: static/js/impala/stats/csv_keys.js:263 static/js/zamboni/stats-all.js:15544 static/js/zamboni/stats-min.js:5
 msgid "Installs from {0} to {1}"
 msgstr ""
 
 #. L10n: {0} and {1} are integers.
-#: static/js/impala/stats/csv_keys.js:269
+#: static/js/impala/stats/csv_keys.js:269 static/js/zamboni/stats-all.js:15550 static/js/zamboni/stats-min.js:5
 msgid "<b>{0}</b> in last {1} days"
 msgstr ""
 
 #. L10n: {0} is an integer and {1} and {2} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:271 static/js/impala/stats/csv_keys.js:277
+#: static/js/impala/stats/csv_keys.js:271 static/js/impala/stats/csv_keys.js:277 static/js/zamboni/stats-all.js:15552 static/js/zamboni/stats-all.js:15558 static/js/zamboni/stats-min.js:5
 msgid "<b>{0}</b> from {1} to {2}"
 msgstr ""
 
 #. L10n: {0} and {1} are integers.
-#: static/js/impala/stats/csv_keys.js:275
+#: static/js/impala/stats/csv_keys.js:275 static/js/zamboni/stats-all.js:15556 static/js/zamboni/stats-min.js:5
 msgid "<b>{0}</b> average in last {1} days"
 msgstr ""
 
-#: static/js/impala/stats/overview.js:19
+#: static/js/impala/stats/overview.js:19 static/js/zamboni/stats-all.js:16469 static/js/zamboni/stats-min.js:5
 msgid "No data available."
 msgstr ""
 
-#: static/js/impala/stats/table.js:74
+#: static/js/impala/stats/table.js:74 static/js/zamboni/stats-all.js:17209 static/js/zamboni/stats-min.js:5
 msgid "Date"
 msgstr ""
 
-#: static/js/impala/stats/topchart.js:96
+#: static/js/impala/stats/topchart.js:96 static/js/zamboni/stats-all.js:16600 static/js/zamboni/stats-min.js:5
 msgid "Other"
 msgstr ""
 
-#: static/js/zamboni/admin_validation.js:24 static/js/zamboni/devhub.js:1229 static/js/zamboni/editors.js:295
+#: static/js/zamboni/admin-all.js:180 static/js/zamboni/admin-min.js:1 static/js/zamboni/admin_validation.js:24 static/js/zamboni/devhub-all.js:2408 static/js/zamboni/devhub-min.js:2
+#: static/js/zamboni/devhub.js:1229 static/js/zamboni/editors-all.js:15576 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:295
 msgid "Select an application first"
 msgstr ""
 
-#: static/js/zamboni/admin_validation.js:51
+#: static/js/zamboni/admin-all.js:207 static/js/zamboni/admin-min.js:1 static/js/zamboni/admin_validation.js:51
 msgid "Set {0} add-on to a max version of {1} and email the author."
 msgid_plural "Set {0} add-ons to a max version of {1} and email the authors."
 msgstr[0] ""
 msgstr[1] ""
-msgstr[2] ""
 
-#: static/js/zamboni/admin_validation.js:54
+#: static/js/zamboni/admin-all.js:210 static/js/zamboni/admin-min.js:1 static/js/zamboni/admin_validation.js:54
 msgid "Email author of {2} add-on which failed validation."
 msgid_plural "Email authors of {2} add-ons which failed validation."
 msgstr[0] ""
 msgstr[1] ""
-msgstr[2] ""
 
-#. L10n: {0} is an app name like Firefox.
-#: static/js/zamboni/buttons.js:66
-msgid "Accept and Install"
-msgstr ""
-
-#: static/js/zamboni/buttons.js:66
-msgid "Add to {0}"
-msgstr ""
-
-#: static/js/zamboni/buttons.js:71
-msgid "Download Now"
-msgstr ""
-
-#: static/js/zamboni/buttons.js:112
-msgid "Add-on has not been updated to support default-to-compatible."
-msgstr ""
-
-#: static/js/zamboni/buttons.js:117
-msgid "You need to be using Firefox 10.0 or higher."
-msgstr ""
-
-#: static/js/zamboni/buttons.js:129
-msgid "Mozilla has marked this version as incompatible with your Firefox version."
-msgstr ""
-
-#. L10n: {0} is an platform like Windows or Linux.
-#: static/js/zamboni/buttons.js:210
-msgid "Install for {0} anyway"
-msgstr ""
-
-#: static/js/zamboni/buttons.js:210
-msgid "Download for {0} anyway"
-msgstr ""
-
-#: static/js/zamboni/buttons.js:267
-msgid "Not available for your platform"
-msgstr ""
-
-#. L10n: {0} is an app name, {1} is the app version.
-#: static/js/zamboni/buttons.js:278 static/js/zamboni/buttons.js:315
-msgid "Not available for {0} {1}"
-msgstr ""
-
-#: static/js/zamboni/buttons.js:341
-msgid "Works with {app} {min} - {max}"
-msgstr ""
-
-#: static/js/zamboni/buttons.js:343
-msgid "View other versions"
-msgstr ""
-
-#: static/js/zamboni/buttons.js:391
-msgid "Only with Firefox — Get Firefox Now!"
-msgstr ""
-
-#: static/js/zamboni/buttons.js:507 static/js/zamboni/mobile/buttons.js:43
-msgid "Sorry, you need a Mozilla-based browser (such as Firefox) to install a search plugin."
-msgstr ""
-
-#: static/js/zamboni/collections.js:229
-msgid "Adding to Favorites&hellip;"
-msgstr ""
-
-#: static/js/zamboni/collections.js:232
-msgid "Removing Favorite&hellip;"
-msgstr ""
-
-#: static/js/zamboni/collections.js:235
-msgid "Add to Favorites"
-msgstr ""
-
-#: static/js/zamboni/collections.js:238
-msgid "Remove from Favorites"
-msgstr ""
-
-#: static/js/zamboni/collections.js:303
-msgid "Pending"
-msgstr ""
-
-#: static/js/zamboni/collections.js:304
-msgid "Add a comment"
-msgstr ""
-
-#: static/js/zamboni/collections.js:304
-msgid "Comment"
-msgstr ""
-
-#: static/js/zamboni/collections.js:305
-msgid "Remove this add-on from the collection"
-msgstr ""
-
-#: static/js/zamboni/collections.js:305 static/js/zamboni/collections.js:334
-msgid "Remove"
-msgstr ""
-
-#: static/js/zamboni/collections.js:334
-msgid "Remove this user as a contributor"
-msgstr ""
-
-#: static/js/zamboni/collections.js:346
-msgid "An email address is required."
-msgstr ""
-
-#: static/js/zamboni/collections.js:364
-msgid "You cannot add yourself as a contributor."
-msgstr ""
-
-#: static/js/zamboni/collections.js:366
-msgid "You have already added that user."
-msgstr ""
-
-#: static/js/zamboni/collections.js:573
-msgid "Add to favorites"
-msgstr ""
-
-#: static/js/zamboni/collections.js:577
-msgid "Remove from favorites"
-msgstr ""
-
-#: static/js/zamboni/collections.js:604
-msgid "Stop following"
-msgstr ""
-
-#: static/js/zamboni/devhub.js:110
+#: static/js/zamboni/devhub-all.js:1289 static/js/zamboni/devhub-min.js:1 static/js/zamboni/devhub.js:110
 msgid "Your browser does not support the video tag"
 msgstr ""
 
-#: static/js/zamboni/devhub.js:371
+#: static/js/zamboni/devhub-all.js:1550 static/js/zamboni/devhub-min.js:1 static/js/zamboni/devhub.js:371
 msgid "Changes Saved"
 msgstr ""
 
-#: static/js/zamboni/devhub.js:387
+#: static/js/zamboni/devhub-all.js:1566 static/js/zamboni/devhub-min.js:1 static/js/zamboni/devhub.js:387
 msgid "Enter a new author's email address"
 msgstr ""
 
-#: static/js/zamboni/devhub.js:536
+#: static/js/zamboni/devhub-all.js:1715 static/js/zamboni/devhub-min.js:1 static/js/zamboni/devhub.js:536
 msgid "There was an error uploading your file."
 msgstr ""
 
-#: static/js/zamboni/devhub.js:681
+#: static/js/zamboni/devhub-all.js:1860 static/js/zamboni/devhub-min.js:1 static/js/zamboni/devhub.js:681
 msgid "{files} file"
 msgid_plural "{files} files"
 msgstr[0] ""
 msgstr[1] ""
-msgstr[2] ""
 
-#: static/js/zamboni/devhub.js:684
+#: static/js/zamboni/devhub-all.js:1863 static/js/zamboni/devhub-min.js:1 static/js/zamboni/devhub.js:684
 msgid "{reviews} user review"
 msgid_plural "{reviews} user reviews"
 msgstr[0] ""
 msgstr[1] ""
-msgstr[2] ""
 
-#: static/js/zamboni/devhub.js:796
+#: static/js/zamboni/devhub-all.js:1975 static/js/zamboni/devhub-min.js:2 static/js/zamboni/devhub.js:796
 msgid "Learn more"
 msgstr ""
 
-#: static/js/zamboni/devhub.js:800
+#: static/js/zamboni/devhub-all.js:1979 static/js/zamboni/devhub-min.js:2 static/js/zamboni/devhub.js:800
 msgid "Example"
 msgstr ""
 
-#: static/js/zamboni/devhub.js:1130
+#: static/js/zamboni/devhub-all.js:2309 static/js/zamboni/devhub-min.js:2 static/js/zamboni/devhub.js:1130
 msgid "Image changes being processed"
 msgstr ""
 
-#: static/js/zamboni/devhub.js:1280
+#: static/js/zamboni/devhub-all.js:2459 static/js/zamboni/devhub-min.js:2 static/js/zamboni/devhub.js:1280
 msgid "Must be a valid e-mail address."
+msgstr ""
+
+#: static/js/zamboni/devhub-all.js:2613 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:80
+msgid "All tests passed successfully."
+msgstr ""
+
+#: static/js/zamboni/devhub-all.js:2616 static/js/zamboni/devhub-all.js:3011 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:83 static/js/zamboni/validator.js:478
+msgid "These tests were not run."
+msgstr ""
+
+#: static/js/zamboni/devhub-all.js:2664 static/js/zamboni/devhub-all.js:2677 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:131 static/js/zamboni/validator.js:144
+msgid "Tests"
+msgstr ""
+
+#: static/js/zamboni/devhub-all.js:2779 static/js/zamboni/devhub-all.js:3108 static/js/zamboni/devhub-all.js:3127 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:246
+#: static/js/zamboni/validator.js:575 static/js/zamboni/validator.js:594
+msgid "Error"
+msgstr ""
+
+#: static/js/zamboni/devhub-all.js:2780 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:247
+msgid "Warning"
+msgstr ""
+
+#: static/js/zamboni/devhub-all.js:2794 static/js/zamboni/devhub-min.js:2 static/js/zamboni/files-all.js:5657 static/js/zamboni/files-min.js:3 static/js/zamboni/files.js:411
+#: static/js/zamboni/validator.js:261
+msgid "Ignore this message in future updates"
+msgstr ""
+
+#: static/js/zamboni/devhub-all.js:2817 static/js/zamboni/devhub-min.js:2 static/js/zamboni/files-all.js:5663 static/js/zamboni/files-min.js:3 static/js/zamboni/files.js:417
+#: static/js/zamboni/validator.js:284
+msgid "Severity for automated signing:"
+msgstr ""
+
+#: static/js/zamboni/devhub-all.js:2832 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:299
+msgid "Suggestions for passing automated signing:"
+msgstr ""
+
+#: static/js/zamboni/devhub-all.js:2920 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:387
+msgid "Compatibility Tests"
+msgstr ""
+
+#: static/js/zamboni/devhub-all.js:2999 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:466
+msgid "Add-on failed validation."
+msgstr ""
+
+#: static/js/zamboni/devhub-all.js:3001 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:468
+msgid "Add-on passed validation."
+msgstr ""
+
+#: static/js/zamboni/devhub-all.js:3014 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:481
+msgid "{0} error"
+msgid_plural "{0} errors"
+msgstr[0] ""
+msgstr[1] ""
+
+#: static/js/zamboni/devhub-all.js:3016 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:483
+msgid "{0} warning"
+msgid_plural "{0} warnings"
+msgstr[0] ""
+msgstr[1] ""
+
+#: static/js/zamboni/devhub-all.js:3018 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:485
+msgid "{0} notice"
+msgid_plural "{0} notices"
+msgstr[0] ""
+msgstr[1] ""
+
+#: static/js/zamboni/devhub-all.js:3110 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:577
+msgid "Validation task could not complete or completed with errors"
+msgstr ""
+
+#: static/js/zamboni/devhub-all.js:3128 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:595
+msgid "Internal server error"
 msgstr ""
 
 #: static/js/zamboni/devhub_search.js:8
 msgid "No results found."
 msgstr ""
 
-#: static/js/zamboni/editors.js:121
+#: static/js/zamboni/editors-all.js:15402 static/js/zamboni/editors-min.js:4 static/js/zamboni/editors.js:121
 msgid "{name} was viewing this page first."
 msgstr ""
 
-#: static/js/zamboni/editors.js:171
+#: static/js/zamboni/editors-all.js:15452 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:171
 msgid "Receipt checked by app."
 msgstr ""
 
-#: static/js/zamboni/editors.js:173
+#: static/js/zamboni/editors-all.js:15454 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:173
 msgid "Receipt was not checked by app."
 msgstr ""
 
-#: static/js/zamboni/editors.js:244
+#: static/js/zamboni/editors-all.js:15525 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:244
 msgid "{name} was viewing this add-on first."
 msgstr ""
 
-#: static/js/zamboni/editors.js:255
+#: static/js/zamboni/editors-all.js:15536 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:255
 msgid "Loading&hellip;"
 msgstr ""
 
-#: static/js/zamboni/editors.js:260
+#: static/js/zamboni/editors-all.js:15541 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:260
 msgid "Version Notes"
 msgstr ""
 
-#: static/js/zamboni/editors.js:265
+#: static/js/zamboni/editors-all.js:15546 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:265
 msgid "Notes for Reviewers"
 msgstr ""
 
-#: static/js/zamboni/editors.js:270
+#: static/js/zamboni/editors-all.js:15551 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:270
 msgid "No version notes found"
 msgstr ""
 
-#: static/js/zamboni/editors.js:330
+#: static/js/zamboni/editors-all.js:15611 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:330
 msgid "Average Reviews"
 msgstr ""
 
-#: static/js/zamboni/editors.js:386
+#: static/js/zamboni/editors-all.js:15667 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:386
 msgid "Number of Reviews"
 msgstr ""
 
-#: static/js/zamboni/editors.js:445
+#: static/js/zamboni/editors-all.js:15726 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:445
 msgid "Error loading translation"
 msgstr ""
 
-#: static/js/zamboni/files.js:411 static/js/zamboni/validator.js:261
-msgid "Ignore this message in future updates"
-msgstr ""
-
-#: static/js/zamboni/files.js:417 static/js/zamboni/validator.js:284
-msgid "Severity for automated signing:"
-msgstr ""
-
-#: static/js/zamboni/global.js:410
-msgid "Loading..."
-msgstr ""
-
-#. L10n: {0} is the number of characters left.
-#: static/js/zamboni/global.js:474
-msgid "<b>{0}</b> character left."
-msgid_plural "<b>{0}</b> characters left."
-msgstr[0] ""
-msgstr[1] ""
-msgstr[2] ""
-
-#: static/js/zamboni/init.js:28
-msgid "This feature is temporarily disabled while we perform website maintenance. Please check back a little later."
-msgstr ""
-
-#: static/js/zamboni/l10n.js:45
-msgid "Remove this localization"
-msgstr ""
-
-#: static/js/zamboni/password-strength.js:20
-msgid "Password strength:"
-msgstr ""
-
-#: static/js/zamboni/password-strength.js:26
-msgid "At least {0} character left."
-msgid_plural "At least {0} characters left."
-msgstr[0] ""
-msgstr[1] ""
-msgstr[2] ""
-
-#: static/js/zamboni/themes_review.js:176
-msgid "Requested Info"
-msgstr ""
-
-#: static/js/zamboni/themes_review.js:177
-msgid "Flagged"
-msgstr ""
-
-#: static/js/zamboni/themes_review.js:178
-msgid "Duplicate"
-msgstr ""
-
-#: static/js/zamboni/themes_review.js:179
-msgid "Rejected"
-msgstr ""
-
-#: static/js/zamboni/themes_review.js:180
-msgid "Approved"
-msgstr ""
-
-#: static/js/zamboni/themes_review.js:424
-msgid "No results found"
-msgstr ""
-
-#: static/js/zamboni/themes_review_templates.js:31
+#: static/js/zamboni/editors-all.js:15975 static/js/zamboni/editors-min.js:5 static/js/zamboni/themes_review_templates.js:31
 msgid "Theme"
 msgstr ""
 
-#: static/js/zamboni/themes_review_templates.js:33
+#: static/js/zamboni/editors-all.js:15977 static/js/zamboni/editors-min.js:5 static/js/zamboni/themes_review_templates.js:33
 msgid "Reviewer"
 msgstr ""
 
-#: static/js/zamboni/themes_review_templates.js:35
+#: static/js/zamboni/editors-all.js:15979 static/js/zamboni/editors-min.js:5 static/js/zamboni/themes_review_templates.js:35
 msgid "Status"
 msgstr ""
 
-#: static/js/zamboni/validator.js:80
-msgid "All tests passed successfully."
+#: static/js/zamboni/editors-all.js:16196 static/js/zamboni/editors-min.js:5 static/js/zamboni/themes_review.js:176
+msgid "Requested Info"
 msgstr ""
 
-#: static/js/zamboni/validator.js:83 static/js/zamboni/validator.js:478
-msgid "These tests were not run."
+#: static/js/zamboni/editors-all.js:16197 static/js/zamboni/editors-min.js:5 static/js/zamboni/themes_review.js:177
+msgid "Flagged"
 msgstr ""
 
-#: static/js/zamboni/validator.js:131 static/js/zamboni/validator.js:144
-msgid "Tests"
+#: static/js/zamboni/editors-all.js:16198 static/js/zamboni/editors-min.js:5 static/js/zamboni/themes_review.js:178
+msgid "Duplicate"
 msgstr ""
 
-#: static/js/zamboni/validator.js:246 static/js/zamboni/validator.js:575 static/js/zamboni/validator.js:594
-msgid "Error"
+#: static/js/zamboni/editors-all.js:16199 static/js/zamboni/editors-min.js:5 static/js/zamboni/themes_review.js:179
+msgid "Rejected"
 msgstr ""
 
-#: static/js/zamboni/validator.js:247
-msgid "Warning"
+#: static/js/zamboni/editors-all.js:16200 static/js/zamboni/editors-min.js:5 static/js/zamboni/themes_review.js:180
+msgid "Approved"
 msgstr ""
 
-#: static/js/zamboni/validator.js:299
-msgid "Suggestions for passing automated signing:"
+#: static/js/zamboni/editors-all.js:16444 static/js/zamboni/editors-min.js:5 static/js/zamboni/themes_review.js:424
+msgid "No results found"
 msgstr ""
 
-#: static/js/zamboni/validator.js:387
-msgid "Compatibility Tests"
-msgstr ""
-
-#: static/js/zamboni/validator.js:466
-msgid "Add-on failed validation."
-msgstr ""
-
-#: static/js/zamboni/validator.js:468
-msgid "Add-on passed validation."
-msgstr ""
-
-#: static/js/zamboni/validator.js:481
-msgid "{0} error"
-msgid_plural "{0} errors"
-msgstr[0] ""
-msgstr[1] ""
-msgstr[2] ""
-
-#: static/js/zamboni/validator.js:483
-msgid "{0} warning"
-msgid_plural "{0} warnings"
-msgstr[0] ""
-msgstr[1] ""
-msgstr[2] ""
-
-#: static/js/zamboni/validator.js:485
-msgid "{0} notice"
-msgid_plural "{0} notices"
-msgstr[0] ""
-msgstr[1] ""
-msgstr[2] ""
-
-#: static/js/zamboni/validator.js:577
-msgid "Validation task could not complete or completed with errors"
-msgstr ""
-
-#: static/js/zamboni/validator.js:595
-msgid "Internal server error"
-msgstr ""
-
-#: static/js/zamboni/mobile/buttons.js:52
+#: static/js/zamboni/mobile-all.js:15186 static/js/zamboni/mobile/buttons.js:52
 msgid "Not Updated for {0} {1}"
 msgstr ""
 
-#: static/js/zamboni/mobile/buttons.js:53
+#: static/js/zamboni/mobile-all.js:15187 static/js/zamboni/mobile/buttons.js:53
 msgid "Requires Newer Version of {0}"
 msgstr ""
 
-#: static/js/zamboni/mobile/buttons.js:54
+#: static/js/zamboni/mobile-all.js:15188 static/js/zamboni/mobile/buttons.js:54
 msgid "Unreviewed"
 msgstr ""
 
-#: static/js/zamboni/mobile/buttons.js:55
+#: static/js/zamboni/mobile-all.js:15189 static/js/zamboni/mobile/buttons.js:55
 msgid "Experimental <span>(Learn More)</span>"
 msgstr ""
 
-#: static/js/zamboni/mobile/buttons.js:56 static/js/zamboni/mobile/buttons.js:57
+#: static/js/zamboni/mobile-all.js:15190 static/js/zamboni/mobile-all.js:15191 static/js/zamboni/mobile/buttons.js:56 static/js/zamboni/mobile/buttons.js:57
 msgid "Not Available for {0}"
 msgstr ""
 
-#: static/js/zamboni/mobile/buttons.js:58
+#: static/js/zamboni/mobile-all.js:15192 static/js/zamboni/mobile/buttons.js:58
 msgid "Experimental"
 msgstr ""
 
-#: static/js/zamboni/mobile/buttons.js:59
+#: static/js/zamboni/mobile-all.js:15193 static/js/zamboni/mobile/buttons.js:59
 msgid "Themes Require Newer Version of {0}"
 msgstr ""
 
-#: static/js/zamboni/mobile/buttons.js:60
+#: static/js/zamboni/mobile-all.js:15194 static/js/zamboni/mobile/buttons.js:60
 msgid "Themes Require {0}"
 msgstr ""
 
-#: static/js/zamboni/mobile/buttons.js:105
+#: static/js/zamboni/mobile-all.js:15239 static/js/zamboni/mobile/buttons.js:105
 msgid "Installing..."
 msgstr ""
 
-#: static/js/zamboni/mobile/buttons.js:125
+#: static/js/zamboni/mobile-all.js:15259 static/js/zamboni/mobile/buttons.js:125
 msgid "This add-on has been preliminarily reviewed by Mozilla."
 msgstr ""
 
-#: static/js/zamboni/mobile/buttons.js:250
+#: static/js/zamboni/mobile-all.js:15384 static/js/zamboni/mobile/buttons.js:250
 msgid "Keep it"
 msgstr ""
 
-#: static/js/zamboni/mobile/general.js:344
+#: static/js/zamboni/mobile-all.js:16049 static/js/zamboni/mobile-min.js:6 static/js/zamboni/mobile/general.js:344
 msgid "You're trying it on!"
 msgstr ""
 
-#: static/js/zamboni/mobile/general.js:356
+#: static/js/zamboni/mobile-all.js:16061 static/js/zamboni/mobile-min.js:6 static/js/zamboni/mobile/general.js:356
 msgid "Added to Firefox"
 msgstr ""
-

--- a/locale/mk/LC_MESSAGES/django.po
+++ b/locale/mk/LC_MESSAGES/django.po
@@ -3,69 +3,70 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2016-02-24 21:23+0000\n"
+"POT-Creation-Date: 2016-04-18 15:47+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
+"Language: \n"
 "MIME-Version: 1.0\n"
-"Content-Type: text/plain; charset=utf-8\n"
+"Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Generated-By: Babel 2.2.0\n"
 
-#: src/olympia/accounts/views.py:52
+#: src/olympia/accounts/views.py:54
 msgid "Your log in attempt could not be parsed. Please try again."
 msgstr ""
 
-#: src/olympia/accounts/views.py:54
+#: src/olympia/accounts/views.py:56
 msgid "Your Firefox Account could not be found. Please try again."
 msgstr ""
 
-#: src/olympia/accounts/views.py:55
+#: src/olympia/accounts/views.py:57
 msgid "You could not be logged in. Please try again."
 msgstr ""
 
-#: src/olympia/accounts/views.py:57
+#: src/olympia/accounts/views.py:59
 msgid "Your account has already been migrated to Firefox Accounts."
 msgstr ""
 
-#: src/olympia/accounts/views.py:59
+#: src/olympia/accounts/views.py:61
 msgid "Your Firefox Account already exists on this site."
 msgstr ""
 
-#: src/olympia/accounts/views.py:108
+#: src/olympia/accounts/views.py:110
 msgid "Great job!"
 msgstr ""
 
-#: src/olympia/accounts/views.py:109
+#: src/olympia/accounts/views.py:111
 msgid "You can now log in to Add-ons with your Firefox Account."
 msgstr ""
 
-#: src/olympia/accounts/views.py:121
+#: src/olympia/accounts/views.py:123
 msgid "Need help?"
 msgstr ""
 
-#: src/olympia/addons/buttons.py:180
+#: src/olympia/addons/buttons.py:177
 msgid "Download Now"
 msgstr ""
 
-#: src/olympia/addons/buttons.py:182
+#: src/olympia/addons/buttons.py:179
 msgid "Download"
 msgstr ""
 
 #. L10n: please keep &nbsp; in the string so &rarr; does not wrap.
-#: src/olympia/addons/buttons.py:186
+#: src/olympia/addons/buttons.py:183
 msgid "Continue to Download&nbsp;&rarr;"
 msgstr ""
 
-#: src/olympia/addons/buttons.py:202 src/olympia/addons/helpers.py:35 src/olympia/addons/views.py:319 src/olympia/addons/templates/addons/impala/details.html:114
+#: src/olympia/addons/buttons.py:199 src/olympia/addons/helpers.py:35 src/olympia/addons/views.py:333 src/olympia/addons/templates/addons/impala/details.html:111
 #: src/olympia/addons/templates/addons/impala/listing/items.html:17 src/olympia/addons/templates/addons/mobile/home.html:40 src/olympia/amo/templates/amo/side_nav.html:6
-#: src/olympia/amo/templates/amo/side_nav.html:10 src/olympia/amo/templates/amo/site_nav.html:2 src/olympia/amo/templates/amo/site_nav.html:55 src/olympia/bandwagon/views.py:95
-#: src/olympia/browse/views.py:54 src/olympia/browse/views.py:68 src/olympia/browse/views.py:235 src/olympia/browse/templates/browse/impala/category_landing.html:22
+#: src/olympia/amo/templates/amo/side_nav.html:10 src/olympia/amo/templates/amo/site_nav.html:2 src/olympia/amo/templates/amo/site_nav.html:53 src/olympia/bandwagon/views.py:95
+#: src/olympia/browse/views.py:54 src/olympia/browse/views.py:68 src/olympia/browse/views.py:202 src/olympia/browse/templates/browse/impala/category_landing.html:22
 #: src/olympia/browse/templates/browse/personas/mobile/category_landing.html:26
 msgid "Featured"
 msgstr ""
 
-#: src/olympia/addons/buttons.py:221
+#: src/olympia/addons/buttons.py:218
 msgid "Add to {0}"
 msgstr ""
 
@@ -113,39 +114,39 @@ msgid_plural "All tags must be at least {0} characters."
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/olympia/addons/forms.py:234
+#: src/olympia/addons/forms.py:238
 msgid "Categories cannot be changed while your add-on is featured for this application."
 msgstr ""
 
 #. L10n: {0} is the number of categories.
-#: src/olympia/addons/forms.py:238
+#: src/olympia/addons/forms.py:242
 msgid "You can have only {0} category."
 msgid_plural "You can have only {0} categories."
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/olympia/addons/forms.py:246
+#: src/olympia/addons/forms.py:250
 msgid "The miscellaneous category cannot be combined with additional categories."
 msgstr ""
 
-#: src/olympia/addons/forms.py:369
+#: src/olympia/addons/forms.py:374
 #, python-format
 msgid "Before changing your default locale you must have a name, summary, and description in that locale. You are missing %s."
 msgstr ""
 
-#: src/olympia/addons/forms.py:484 src/olympia/addons/forms.py:575
+#: src/olympia/addons/forms.py:455 src/olympia/addons/forms.py:546
 msgid "A license must be selected."
 msgstr ""
 
-#: src/olympia/addons/forms.py:556
+#: src/olympia/addons/forms.py:527
 msgid "Give Your Theme a Name."
 msgstr ""
 
-#: src/olympia/addons/forms.py:562 src/olympia/devhub/templates/devhub/personas/submit.html:53
+#: src/olympia/addons/forms.py:533 src/olympia/devhub/templates/devhub/personas/submit.html:53
 msgid "Describe your Theme."
 msgstr ""
 
-#: src/olympia/addons/forms.py:704
+#: src/olympia/addons/forms.py:675
 msgid "Enter a new author's email address"
 msgstr ""
 
@@ -153,37 +154,37 @@ msgstr ""
 msgid "Not Reviewed"
 msgstr ""
 
-#: src/olympia/addons/models.py:301
+#: src/olympia/addons/models.py:298
 msgid "Users have the option of contributing more or less than this amount."
 msgstr ""
 
-#: src/olympia/addons/models.py:309
-msgid "Users will always be asked in the Add-ons Manager (Firefox 4 and above)"
+#: src/olympia/addons/models.py:306
+msgid "Users will always be asked in the Add-ons Manager (Firefox 4 and above). Only applies to desktop."
 msgstr ""
 
-#: src/olympia/addons/models.py:1804 src/olympia/addons/templates/addons/details_box.html:55 src/olympia/devhub/templates/devhub/index.html:92
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:102
+#: src/olympia/addons/models.py:1802 src/olympia/addons/templates/addons/details_box.html:55 src/olympia/devhub/templates/devhub/index.html:92
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:89
 msgid "Listed"
 msgstr ""
 
-#: src/olympia/addons/views.py:320 src/olympia/browse/templates/browse/personas/mobile/category_landing.html:27
+#: src/olympia/addons/views.py:334 src/olympia/browse/templates/browse/personas/mobile/category_landing.html:27
 msgid "Popular"
 msgstr ""
 
-#: src/olympia/addons/views.py:321 src/olympia/browse/views.py:238 src/olympia/browse/views.py:280 src/olympia/browse/views.py:482
+#: src/olympia/addons/views.py:335 src/olympia/browse/views.py:205 src/olympia/browse/views.py:247 src/olympia/browse/views.py:449
 msgid "Recently Added"
 msgstr ""
 
-#: src/olympia/addons/views.py:322 src/olympia/bandwagon/views.py:99 src/olympia/browse/views.py:60 src/olympia/browse/views.py:71 src/olympia/search/forms.py:16 src/olympia/search/forms.py:91
+#: src/olympia/addons/views.py:336 src/olympia/bandwagon/views.py:99 src/olympia/browse/views.py:60 src/olympia/browse/views.py:71 src/olympia/search/forms.py:16 src/olympia/search/forms.py:91
 msgid "Recently Updated"
 msgstr ""
 
 #. l10n: {0} is the addon name
-#: src/olympia/addons/views.py:520
+#: src/olympia/addons/views.py:534
 msgid "Contribution for {0}"
 msgstr ""
 
-#: src/olympia/addons/views.py:613
+#: src/olympia/addons/views.py:627
 msgid "Abuse reported."
 msgstr ""
 
@@ -250,9 +251,9 @@ msgstr ""
 #: src/olympia/devhub/templates/devhub/addons/ajax_compat_update.html:36 src/olympia/devhub/templates/devhub/addons/profile.html:44 src/olympia/devhub/templates/devhub/addons/edit/admin.html:101
 #: src/olympia/devhub/templates/devhub/addons/edit/basic.html:152 src/olympia/devhub/templates/devhub/addons/edit/details.html:85 src/olympia/devhub/templates/devhub/addons/edit/support.html:67
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:166 src/olympia/devhub/templates/devhub/addons/forms_shared/media.html:149
-#: src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:44 src/olympia/devhub/templates/devhub/versions/add_file_modal.html:78 src/olympia/devhub/templates/devhub/versions/edit.html:139
-#: src/olympia/devhub/templates/devhub/versions/list.html:242 src/olympia/devhub/templates/devhub/versions/list.html:276 src/olympia/devhub/templates/devhub/versions/list.html:317
-#: src/olympia/devhub/templates/devhub/versions/list.html:351 src/olympia/reviews/templates/reviews/edit_review.html:16 src/olympia/translations/templates/translations/trans-menu.html:50
+#: src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:43 src/olympia/devhub/templates/devhub/versions/add_file_modal.html:58 src/olympia/devhub/templates/devhub/versions/edit.html:139
+#: src/olympia/devhub/templates/devhub/versions/list.html:239 src/olympia/devhub/templates/devhub/versions/list.html:281 src/olympia/devhub/templates/devhub/versions/list.html:315
+#: src/olympia/devhub/templates/devhub/versions/list.html:349 src/olympia/reviews/templates/reviews/edit_review.html:16 src/olympia/translations/templates/translations/trans-menu.html:50
 #: src/olympia/translations/templates/translations/trans-menu.html:62
 msgid "or"
 msgstr ""
@@ -363,7 +364,7 @@ msgid "Add-on Information for {0}"
 msgstr ""
 
 #: src/olympia/addons/templates/addons/details_box.html:30 src/olympia/addons/templates/addons/persona_detail_table.html:3 src/olympia/addons/templates/addons/mobile/details.html:63
-#: src/olympia/addons/templates/addons/mobile/persona_detail_table.html:7 src/olympia/browse/views.py:459 src/olympia/devhub/views.py:75
+#: src/olympia/addons/templates/addons/mobile/persona_detail_table.html:7 src/olympia/browse/views.py:426 src/olympia/devhub/views.py:73
 msgid "Updated"
 msgstr ""
 
@@ -382,11 +383,11 @@ msgstr ""
 msgid "Visibility"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/details_box.html:57 src/olympia/devhub/templates/devhub/index.html:94 src/olympia/devhub/templates/devhub/includes/addon_details.html:104
+#: src/olympia/addons/templates/addons/details_box.html:57 src/olympia/devhub/templates/devhub/index.html:94 src/olympia/devhub/templates/devhub/includes/addon_details.html:91
 msgid "Hidden"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/details_box.html:59 src/olympia/devhub/templates/devhub/index.html:96 src/olympia/devhub/templates/devhub/includes/addon_details.html:106
+#: src/olympia/addons/templates/addons/details_box.html:59 src/olympia/devhub/templates/devhub/index.html:96 src/olympia/devhub/templates/devhub/includes/addon_details.html:93
 msgid "Unlisted"
 msgstr ""
 
@@ -394,13 +395,13 @@ msgstr ""
 msgid "Required Add-ons"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/details_box.html:81 src/olympia/addons/templates/addons/persona_detail_table.html:15 src/olympia/browse/views.py:462 src/olympia/devhub/views.py:78
-#: src/olympia/devhub/views.py:85 src/olympia/discovery/templates/discovery/addons/detail.html:57 src/olympia/reviews/forms.py:62 src/olympia/reviews/templates/reviews/add.html:57
+#: src/olympia/addons/templates/addons/details_box.html:81 src/olympia/addons/templates/addons/persona_detail_table.html:15 src/olympia/browse/views.py:429 src/olympia/devhub/views.py:76
+#: src/olympia/devhub/views.py:83 src/olympia/discovery/templates/discovery/addons/detail.html:57 src/olympia/reviews/forms.py:62 src/olympia/reviews/templates/reviews/add.html:57
 #: src/olympia/reviews/templates/reviews/mobile/review_list.html:18
 msgid "Rating"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/details_box.html:85 src/olympia/browse/views.py:461 src/olympia/devhub/views.py:77 src/olympia/devhub/views.py:84
+#: src/olympia/addons/templates/addons/details_box.html:85 src/olympia/browse/views.py:428 src/olympia/devhub/views.py:75 src/olympia/devhub/views.py:82
 #: src/olympia/stats/templates/stats/addon_report_menu.html:8 src/olympia/stats/templates/stats/collection_report_menu.html:18
 msgid "Downloads"
 msgstr ""
@@ -420,7 +421,7 @@ msgstr ""
 
 #. The Privacy Policy for this add-on.
 #: src/olympia/addons/templates/addons/details_box.html:121 src/olympia/addons/templates/addons/privacy.html:19 src/olympia/addons/templates/addons/privacy.html:23
-#: src/olympia/addons/templates/addons/impala/button.html:43 src/olympia/addons/templates/addons/impala/details.html:307 src/olympia/devhub/templates/devhub/includes/policy_form.html:20
+#: src/olympia/addons/templates/addons/impala/button.html:43 src/olympia/addons/templates/addons/impala/details.html:312 src/olympia/devhub/templates/devhub/includes/policy_form.html:23
 #: src/olympia/templates/mobile/base_addons.html:87
 msgid "Privacy Policy"
 msgstr ""
@@ -445,7 +446,7 @@ msgstr ""
 msgid "Developer Comments"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/details_box.html:199 src/olympia/addons/templates/addons/impala/details.html:259
+#: src/olympia/addons/templates/addons/details_box.html:199 src/olympia/addons/templates/addons/impala/details.html:264
 msgid "Development Channel"
 msgstr ""
 
@@ -465,7 +466,7 @@ msgid ""
 "developer. To stop receiving development updates, reinstall the default version from the link above."
 msgstr ""
 
-#: src/olympia/addons/templates/addons/details_box.html:220 src/olympia/addons/templates/addons/impala/details.html:278
+#: src/olympia/addons/templates/addons/details_box.html:220 src/olympia/addons/templates/addons/impala/details.html:283
 msgid "Version {0}:"
 msgstr ""
 
@@ -484,7 +485,7 @@ msgid "End-User License Agreement for {0}"
 msgstr ""
 
 #: src/olympia/addons/templates/addons/eula.html:17 src/olympia/addons/templates/addons/eula.html:21 src/olympia/addons/templates/addons/impala/button.html:48
-#: src/olympia/addons/templates/addons/impala/details.html:316 src/olympia/devhub/templates/devhub/includes/policy_form.html:3 src/olympia/discovery/templates/discovery/addons/eula.html:11
+#: src/olympia/addons/templates/addons/impala/details.html:321 src/olympia/devhub/templates/devhub/includes/policy_form.html:3 src/olympia/discovery/templates/discovery/addons/eula.html:11
 msgid "End-User License Agreement"
 msgstr ""
 
@@ -501,7 +502,7 @@ msgstr ""
 msgid "Add-ons for {0}"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/home.html:10 src/olympia/addons/templates/addons/home.html:51 src/olympia/browse/templates/browse/impala/base_listing.html:11
+#: src/olympia/addons/templates/addons/home.html:10 src/olympia/addons/templates/addons/home.html:53 src/olympia/browse/templates/browse/impala/base_listing.html:11
 msgid "Featured Extensions"
 msgstr ""
 
@@ -509,29 +510,29 @@ msgstr ""
 msgid "Popular Extensions"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/home.html:42 src/olympia/amo/templates/amo/side_nav.html:3 src/olympia/amo/templates/amo/side_nav.html:11 src/olympia/amo/templates/amo/site_nav.html:3
-#: src/olympia/amo/templates/amo/site_nav.html:25 src/olympia/browse/views.py:236 src/olympia/browse/views.py:281 src/olympia/browse/views.py:481
+#: src/olympia/addons/templates/addons/home.html:44 src/olympia/amo/templates/amo/side_nav.html:3 src/olympia/amo/templates/amo/side_nav.html:11 src/olympia/amo/templates/amo/site_nav.html:3
+#: src/olympia/amo/templates/amo/site_nav.html:25 src/olympia/browse/views.py:203 src/olympia/browse/views.py:248 src/olympia/browse/views.py:448
 msgid "Most Popular"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/home.html:43
+#: src/olympia/addons/templates/addons/home.html:45
 msgid "All »"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/home.html:52 src/olympia/addons/templates/addons/home.html:61 src/olympia/addons/templates/addons/home.html:70 src/olympia/addons/templates/addons/home.html:78
+#: src/olympia/addons/templates/addons/home.html:54 src/olympia/addons/templates/addons/home.html:63 src/olympia/addons/templates/addons/home.html:72 src/olympia/addons/templates/addons/home.html:80
 #: src/olympia/browse/templates/browse/impala/category_landing.html:36
 msgid "See all »"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/home.html:60
+#: src/olympia/addons/templates/addons/home.html:62
 msgid "Up &amp; Coming Extensions"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/home.html:69 src/olympia/browse/templates/browse/personas/category_landing.html:61 src/olympia/discovery/templates/discovery/pane.html:74
+#: src/olympia/addons/templates/addons/home.html:71 src/olympia/browse/templates/browse/personas/category_landing.html:61 src/olympia/discovery/templates/discovery/pane.html:74
 msgid "Featured Themes"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/home.html:77 src/olympia/bandwagon/templates/bandwagon/impala/collection_listing.html:5
+#: src/olympia/addons/templates/addons/home.html:79 src/olympia/bandwagon/templates/bandwagon/impala/collection_listing.html:5
 msgid "Featured Collections"
 msgstr ""
 
@@ -549,7 +550,7 @@ msgid "Updated {0}"
 msgstr ""
 
 #. {0} is a date.
-#: src/olympia/addons/templates/addons/macros.html:10 src/olympia/addons/templates/addons/macros.html:69 src/olympia/addons/templates/addons/persona_preview.html:21
+#: src/olympia/addons/templates/addons/macros.html:10 src/olympia/addons/templates/addons/macros.html:69 src/olympia/addons/templates/addons/persona_preview.html:22
 #: src/olympia/addons/templates/addons/listing/items_mobile.html:44 src/olympia/addons/templates/addons/listing/macros.html:39
 #: src/olympia/bandwagon/templates/bandwagon/collection_listing_items.html:37 src/olympia/bandwagon/templates/bandwagon/impala/collection_listing_items.html:37
 msgid "Added {0}"
@@ -570,15 +571,14 @@ msgstr[0] ""
 msgstr[1] ""
 
 #. {0} is the number of downloads.
-#: src/olympia/addons/templates/addons/macros.html:53 src/olympia/addons/templates/addons/impala/details.html:61
+#: src/olympia/addons/templates/addons/macros.html:53 src/olympia/addons/templates/addons/impala/details.html:59
 msgid "{0} weekly download"
 msgid_plural "{0} weekly downloads"
 msgstr[0] ""
 msgstr[1] ""
 
 #. {0} is the number of users.
-#: src/olympia/addons/templates/addons/macros.html:61 src/olympia/addons/templates/addons/impala/details.html:54 src/olympia/compat/templates/compat/index.html:71
-#: src/olympia/zadmin/templates/zadmin/compat.html:67
+#: src/olympia/addons/templates/addons/macros.html:61 src/olympia/addons/templates/addons/impala/details.html:52 src/olympia/zadmin/templates/zadmin/compat.html:67
 msgid "{0} user"
 msgid_plural "{0} users"
 msgstr[0] ""
@@ -596,7 +596,7 @@ msgstr ""
 msgid "Return to the addon."
 msgstr ""
 
-#: src/olympia/addons/templates/addons/persona_detail.html:17 src/olympia/addons/templates/addons/impala/details.html:106 src/olympia/addons/templates/addons/mobile/details.html:23
+#: src/olympia/addons/templates/addons/persona_detail.html:17 src/olympia/addons/templates/addons/impala/details.html:103 src/olympia/addons/templates/addons/mobile/details.html:23
 #: src/olympia/addons/templates/addons/mobile/persona_detail.html:21 src/olympia/discovery/templates/discovery/addons/base.html:27 src/olympia/editors/templates/editors/review.html:31
 msgid "by"
 msgstr ""
@@ -640,34 +640,35 @@ msgstr ""
 msgid "License"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/persona_preview.html:12 src/olympia/constants/base.py:48
+#: src/olympia/addons/templates/addons/persona_preview.html:13 src/olympia/constants/base.py:48
 msgid "Awaiting Review"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/persona_preview.html:14 src/olympia/amo/log.py:180 src/olympia/constants/base.py:42 src/olympia/editors/helpers.py:62
+#: src/olympia/addons/templates/addons/persona_preview.html:15 src/olympia/amo/log.py:180 src/olympia/constants/base.py:42 src/olympia/editors/helpers.py:62
 msgid "Rejected"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/persona_preview.html:16 src/olympia/amo/log.py:159
+#: src/olympia/addons/templates/addons/persona_preview.html:17 src/olympia/amo/log.py:159
 msgid "Approved"
 msgstr ""
 
 #. {0} is the number of users.
-#: src/olympia/addons/templates/addons/persona_preview.html:26 src/olympia/addons/templates/addons/listing/items_mobile.html:36 src/olympia/addons/templates/addons/listing/macros.html:31
+#: src/olympia/addons/templates/addons/persona_preview.html:27 src/olympia/addons/templates/addons/listing/items_mobile.html:36 src/olympia/addons/templates/addons/listing/macros.html:31
 msgid "<strong>{0}</strong> user"
 msgid_plural "<strong>{0}</strong> users"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/olympia/addons/templates/addons/persona_preview.html:40
+#: src/olympia/addons/templates/addons/persona_preview.html:41
 msgid "Hover to Preview"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/persona_preview.html:46 src/olympia/addons/templates/addons/persona_preview.html:48 src/olympia/reviews/templates/reviews/add.html:15
+#: src/olympia/addons/templates/addons/persona_preview.html:47 src/olympia/addons/templates/addons/persona_preview.html:49 src/olympia/addons/templates/addons/persona_preview.html:97
+#: src/olympia/reviews/templates/reviews/add.html:15
 msgid "Add"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/persona_preview.html:57 src/olympia/bandwagon/templates/bandwagon/ajax_new.html:16 src/olympia/bandwagon/templates/bandwagon/edit.html:19
+#: src/olympia/addons/templates/addons/persona_preview.html:58 src/olympia/bandwagon/templates/bandwagon/ajax_new.html:16 src/olympia/bandwagon/templates/bandwagon/edit.html:19
 #: src/olympia/bandwagon/templates/bandwagon/includes/addedit.html:19 src/olympia/devhub/templates/devhub/addons/edit/admin.html:13 src/olympia/devhub/templates/devhub/addons/edit/basic.html:10
 #: src/olympia/devhub/templates/devhub/addons/edit/details.html:8 src/olympia/devhub/templates/devhub/addons/edit/media.html:6 src/olympia/devhub/templates/devhub/addons/edit/support.html:8
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:9 src/olympia/devhub/templates/devhub/addons/submit/describe.html:29 src/olympia/editors/templates/editors/review.html:257
@@ -676,21 +677,21 @@ msgstr ""
 
 #. For datetime formatting, see the table on
 #. http://docs.python.org/library/datetime.html#strftime-and-strptime-behavior
-#: src/olympia/addons/templates/addons/persona_preview.html:66
+#: src/olympia/addons/templates/addons/persona_preview.html:67
 #, python-format
 msgid "%%Y-%%m-%%d"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/persona_preview.html:67
+#: src/olympia/addons/templates/addons/persona_preview.html:68
 msgid "by {0} on {1}"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/persona_preview.html:75 src/olympia/reviews/helpers.py:17 src/olympia/reviews/templates/reviews/review_list.html:63
+#: src/olympia/addons/templates/addons/persona_preview.html:76 src/olympia/reviews/helpers.py:17 src/olympia/reviews/templates/reviews/review_list.html:63
 #: src/olympia/reviews/templates/reviews/reviews_link.html:21 src/olympia/reviews/templates/reviews/impala/reviews_link.html:16
 msgid "Not yet rated"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/persona_preview.html:78
+#: src/olympia/addons/templates/addons/persona_preview.html:79
 msgid "<b>{0}</b> users"
 msgstr ""
 
@@ -703,7 +704,7 @@ msgid "Learn more about Firefox"
 msgstr ""
 
 #: src/olympia/addons/templates/addons/popups.html:22
-msgid "or <b><a class=\"installer\" href=\"{url}\">download anyway</a></b>"
+msgid "or <b><a class=\"button installer\" href=\"{url}\">download anyway</a></b>"
 msgstr ""
 
 #: src/olympia/addons/templates/addons/popups.html:26
@@ -802,7 +803,7 @@ msgid ""
 msgstr ""
 
 #: src/olympia/addons/templates/addons/report_abuse.html:6 src/olympia/addons/templates/addons/report_abuse_full.html:10 src/olympia/addons/templates/addons/impala/details-more.html:23
-#: src/olympia/addons/templates/addons/impala/details.html:328
+#: src/olympia/addons/templates/addons/impala/details.html:333
 msgid "Report Abuse"
 msgstr ""
 
@@ -821,9 +822,9 @@ msgstr ""
 #: src/olympia/devhub/templates/devhub/addons/ajax_compat_update.html:36 src/olympia/devhub/templates/devhub/addons/profile.html:44 src/olympia/devhub/templates/devhub/addons/edit/admin.html:104
 #: src/olympia/devhub/templates/devhub/addons/edit/basic.html:155 src/olympia/devhub/templates/devhub/addons/edit/details.html:88 src/olympia/devhub/templates/devhub/addons/edit/support.html:70
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:169 src/olympia/devhub/templates/devhub/addons/forms_shared/media.html:152
-#: src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:44 src/olympia/devhub/templates/devhub/personas/edit.html:222 src/olympia/devhub/templates/devhub/versions/add_file_modal.html:79
-#: src/olympia/devhub/templates/devhub/versions/edit.html:140 src/olympia/devhub/templates/devhub/versions/list.html:208 src/olympia/devhub/templates/devhub/versions/list.html:242
-#: src/olympia/devhub/templates/devhub/versions/list.html:276 src/olympia/devhub/templates/devhub/versions/list.html:317 src/olympia/reviews/templates/reviews/edit_review.html:16
+#: src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:43 src/olympia/devhub/templates/devhub/personas/edit.html:222 src/olympia/devhub/templates/devhub/versions/add_file_modal.html:59
+#: src/olympia/devhub/templates/devhub/versions/edit.html:140 src/olympia/devhub/templates/devhub/versions/list.html:208 src/olympia/devhub/templates/devhub/versions/list.html:239
+#: src/olympia/devhub/templates/devhub/versions/list.html:281 src/olympia/devhub/templates/devhub/versions/list.html:315 src/olympia/reviews/templates/reviews/edit_review.html:16
 #: src/olympia/translations/templates/translations/trans-menu.html:50 src/olympia/translations/templates/translations/trans-menu.html:62 src/olympia/zadmin/templates/zadmin/validation.html:105
 msgid "Cancel"
 msgstr ""
@@ -868,7 +869,7 @@ msgstr ""
 msgid "Review Guidelines"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/review_list_box.html:5 src/olympia/addons/templates/addons/impala/details-more.html:27 src/olympia/editors/helpers.py:921
+#: src/olympia/addons/templates/addons/review_list_box.html:5 src/olympia/addons/templates/addons/impala/details-more.html:27 src/olympia/editors/helpers.py:1001
 #: src/olympia/reviews/templates/reviews/add.html:14 src/olympia/reviews/templates/reviews/reply.html:14 src/olympia/reviews/templates/reviews/review_list.html:19
 #: src/olympia/reviews/templates/reviews/mobile/review_list.html:26
 msgid "Reviews"
@@ -959,119 +960,119 @@ msgid_plural "Other add-ons by these authors"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/olympia/addons/templates/addons/impala/details.html:41
+#: src/olympia/addons/templates/addons/impala/details.html:39
 #, python-format
 msgid "<span itemprop=\"ratingCount\">%(num)s</span> user review"
 msgid_plural "<span itemprop=\"ratingCount\">%(num)s</span> user reviews"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/olympia/addons/templates/addons/impala/details.html:69
+#: src/olympia/addons/templates/addons/impala/details.html:66
 msgid "View statistics"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/impala/details.html:84
+#: src/olympia/addons/templates/addons/impala/details.html:81
 msgid "Manage"
 msgstr ""
 
 #. {0} is an add-on name.
-#: src/olympia/addons/templates/addons/impala/details.html:96
+#: src/olympia/addons/templates/addons/impala/details.html:93
 msgid "Icon of {0}"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/impala/details.html:103 src/olympia/addons/templates/addons/impala/listing/items.html:14
+#: src/olympia/addons/templates/addons/impala/details.html:100 src/olympia/addons/templates/addons/impala/listing/items.html:14
 msgid "No Restart"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/impala/details.html:127
+#: src/olympia/addons/templates/addons/impala/details.html:124
 #, python-format
 msgid "Meet the Developer: <a href=\"%(url)s\">%(name)s</a>"
 msgid_plural "<a href=\"%(url)s\">Meet the Developers</a>"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/olympia/addons/templates/addons/impala/details.html:137
+#: src/olympia/addons/templates/addons/impala/details.html:134
 msgid "Learn why {0} was created and find out what's next for this add-on."
 msgstr ""
 
 #. {0} is an index.
-#: src/olympia/addons/templates/addons/impala/details.html:156
+#: src/olympia/addons/templates/addons/impala/details.html:161
 msgid "Add-on screenshot #{0}"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/impala/details.html:182
+#: src/olympia/addons/templates/addons/impala/details.html:187
 msgid "Add-on home page"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/impala/details.html:185
+#: src/olympia/addons/templates/addons/impala/details.html:190
 msgid "Support site"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/impala/details.html:189
+#: src/olympia/addons/templates/addons/impala/details.html:194
 msgid "Support E-mail"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/impala/details.html:194 src/olympia/devhub/models.py:378 src/olympia/devhub/templates/devhub/versions/list.html:12
+#: src/olympia/addons/templates/addons/impala/details.html:199 src/olympia/devhub/models.py:378 src/olympia/devhub/templates/devhub/versions/list.html:12
 #: src/olympia/versions/templates/versions/version.html:6 src/olympia/versions/templates/versions/mobile/version.html:6
 msgid "Version {0}"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/impala/details.html:194
+#: src/olympia/addons/templates/addons/impala/details.html:199
 msgid "Info"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/impala/details.html:195 src/olympia/devhub/templates/devhub/includes/addon_details.html:129
+#: src/olympia/addons/templates/addons/impala/details.html:200 src/olympia/devhub/templates/devhub/includes/addon_details.html:116
 msgid "Last Updated:"
-msgstr ""
-
-#: src/olympia/addons/templates/addons/impala/details.html:200
-#, python-format
-msgid "Released under <a target=\"_blank\" href=\"%(url)s\">%(name)s</a>"
-msgstr ""
-
-#: src/olympia/addons/templates/addons/impala/details.html:201 src/olympia/addons/templates/addons/impala/details.html:206 src/olympia/amo/helpers.py:398 src/olympia/devhub/forms.py:142
-#: src/olympia/devhub/forms.py:173 src/olympia/versions/templates/versions/version.html:40 src/olympia/versions/templates/versions/version.html:45
-msgid "Custom License"
 msgstr ""
 
 #: src/olympia/addons/templates/addons/impala/details.html:205
 #, python-format
+msgid "Released under <a target=\"_blank\" href=\"%(url)s\">%(name)s</a>"
+msgstr ""
+
+#: src/olympia/addons/templates/addons/impala/details.html:206 src/olympia/addons/templates/addons/impala/details.html:211 src/olympia/amo/helpers.py:398 src/olympia/devhub/forms.py:142
+#: src/olympia/devhub/forms.py:173 src/olympia/versions/templates/versions/version.html:40 src/olympia/versions/templates/versions/version.html:45
+msgid "Custom License"
+msgstr ""
+
+#: src/olympia/addons/templates/addons/impala/details.html:210
+#, python-format
 msgid "Released under <a href=\"%(url)s\">%(name)s</a>"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/impala/details.html:217
+#: src/olympia/addons/templates/addons/impala/details.html:222
 msgid "About this Add-on"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/impala/details.html:233
+#: src/olympia/addons/templates/addons/impala/details.html:238
 msgid "Developer’s Comments"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/impala/details.html:243
+#: src/olympia/addons/templates/addons/impala/details.html:248
 msgid "Version Information"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/impala/details.html:250
+#: src/olympia/addons/templates/addons/impala/details.html:255
 msgid "See complete version history"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/impala/details.html:262
+#: src/olympia/addons/templates/addons/impala/details.html:267
 msgid ""
 "The Development Channel lets you test an experimental new version of this add-on before it's released to the general public. Once you install the development version, you will continue to get "
 "updates from this channel. To stop receiving development updates, reinstall the default version from the link above."
 msgstr ""
 
-#: src/olympia/addons/templates/addons/impala/details.html:272
+#: src/olympia/addons/templates/addons/impala/details.html:277
 msgid "<strong>Caution:</strong> Development versions of this add-on have not been reviewed by Mozilla."
 msgstr ""
 
-#: src/olympia/addons/templates/addons/impala/details.html:287
+#: src/olympia/addons/templates/addons/impala/details.html:292
 msgid "See complete development channel history"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/impala/details.html:306 src/olympia/addons/templates/addons/impala/details.html:315 src/olympia/addons/templates/addons/impala/details.html:327
+#: src/olympia/addons/templates/addons/impala/details.html:311 src/olympia/addons/templates/addons/impala/details.html:320 src/olympia/addons/templates/addons/impala/details.html:332
 #: src/olympia/addons/templates/addons/impala/review_add_box.html:4 src/olympia/stats/templates/stats/popup.html:2 src/olympia/stats/templates/stats/popup.html:8
-#: src/olympia/stats/templates/stats/stats.html:202 src/olympia/users/templates/users/profile.html:119
+#: src/olympia/stats/templates/stats/stats.html:204 src/olympia/users/templates/users/profile.html:119
 msgid "close"
 msgstr ""
 
@@ -1127,15 +1128,11 @@ msgstr ""
 msgid "Source Code License"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/impala/persona_grid.html:16 src/olympia/addons/templates/addons/impala/toplist.html:6
-msgid "{0} users"
-msgstr ""
-
 #: src/olympia/addons/templates/addons/impala/review_list_box.html:19 src/olympia/reviews/templates/reviews/review.html:40
 msgid "permalink"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/impala/review_list_box.html:23 src/olympia/editors/templates/editors/queue.html:98 src/olympia/reviews/templates/reviews/review.html:44
+#: src/olympia/addons/templates/addons/impala/review_list_box.html:23 src/olympia/editors/templates/editors/queue.html:104 src/olympia/reviews/templates/reviews/review.html:44
 msgid "translate"
 msgstr ""
 
@@ -1154,6 +1151,10 @@ msgstr ""
 msgid "Be the first!"
 msgstr ""
 
+#: src/olympia/addons/templates/addons/impala/toplist.html:6
+msgid "{0} users"
+msgstr ""
+
 #: src/olympia/addons/templates/addons/impala/listing/sorter.html:14 src/olympia/devhub/templates/devhub/addons/listing/item_actions.html:49
 msgid "More"
 msgstr ""
@@ -1166,7 +1167,7 @@ msgstr ""
 msgid "My Add-ons"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/includes/dashboard_tabs.html:6 src/olympia/amo/context_processors.py:51
+#: src/olympia/addons/templates/addons/includes/dashboard_tabs.html:6 src/olympia/amo/context_processors.py:50
 msgid "My Themes"
 msgstr ""
 
@@ -1221,7 +1222,7 @@ msgstr ""
 msgid "Weekly Downloads"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/mobile/details.html:99 src/olympia/compat/templates/compat/reporter_detail.html:46 src/olympia/devhub/forms.py:787
+#: src/olympia/addons/templates/addons/mobile/details.html:99 src/olympia/compat/templates/compat/reporter_detail.html:46 src/olympia/devhub/forms.py:788
 #: src/olympia/devhub/templates/devhub/versions/list.html:163
 msgid "Version"
 msgstr ""
@@ -1305,7 +1306,7 @@ msgstr ""
 #: src/olympia/browse/templates/browse/personas/category_landing.html:21 src/olympia/browse/templates/browse/personas/category_landing.html:23
 #: src/olympia/browse/templates/browse/personas/category_landing.html:38 src/olympia/browse/templates/browse/personas/grid.html:7 src/olympia/browse/templates/browse/personas/grid.html:11
 #: src/olympia/browse/templates/browse/personas/mobile/base.html:7 src/olympia/browse/templates/browse/personas/mobile/category_landing.html:19 src/olympia/constants/base.py:180
-#: src/olympia/devhub/templates/devhub/personas/submit.html:13 src/olympia/editors/helpers.py:105 src/olympia/editors/templates/editors/base.html:26
+#: src/olympia/devhub/templates/devhub/personas/submit.html:13 src/olympia/editors/helpers.py:107 src/olympia/editors/templates/editors/base.html:26
 #: src/olympia/editors/templates/editors/performance.html:73 src/olympia/search/templates/search/personas.html:39 src/olympia/templates/menu_links.html:9
 msgid "Themes"
 msgstr ""
@@ -1326,7 +1327,7 @@ msgstr ""
 msgid "Highest Rated"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/mobile/home.html:74 src/olympia/amo/templates/amo/side_nav.html:5 src/olympia/amo/templates/amo/site_nav.html:27 src/olympia/amo/templates/amo/site_nav.html:57
+#: src/olympia/addons/templates/addons/mobile/home.html:74 src/olympia/amo/templates/amo/side_nav.html:5 src/olympia/amo/templates/amo/site_nav.html:27 src/olympia/amo/templates/amo/site_nav.html:55
 #: src/olympia/bandwagon/views.py:97 src/olympia/browse/views.py:57 src/olympia/browse/views.py:67 src/olympia/browse/templates/browse/personas/mobile/category_landing.html:65
 #: src/olympia/search/forms.py:15 src/olympia/search/forms.py:87
 msgid "Newest"
@@ -1340,90 +1341,90 @@ msgstr ""
 msgid "Theme Info &raquo;"
 msgstr ""
 
-#: src/olympia/amo/context_processors.py:39 src/olympia/devhub/templates/devhub/nav.html:43
+#: src/olympia/amo/context_processors.py:37 src/olympia/devhub/templates/devhub/nav.html:43
 msgid "Tools"
 msgstr ""
 
-#: src/olympia/amo/context_processors.py:48 src/olympia/discovery/templates/discovery/pane_account.html:8 src/olympia/users/templates/users/includes/navigation.html:2
+#: src/olympia/amo/context_processors.py:47 src/olympia/discovery/templates/discovery/pane_account.html:8 src/olympia/users/templates/users/includes/navigation.html:2
 msgid "My Profile"
 msgstr ""
 
-#: src/olympia/amo/context_processors.py:54 src/olympia/users/templates/users/edit.html:5 src/olympia/users/templates/users/includes/navigation.html:3
+#: src/olympia/amo/context_processors.py:53 src/olympia/users/templates/users/edit.html:5 src/olympia/users/templates/users/includes/navigation.html:3
 msgid "Account Settings"
 msgstr ""
 
-#: src/olympia/amo/context_processors.py:57 src/olympia/discovery/templates/discovery/pane_account.html:11 src/olympia/users/templates/users/profile.html:83
+#: src/olympia/amo/context_processors.py:56 src/olympia/discovery/templates/discovery/pane_account.html:11 src/olympia/users/templates/users/profile.html:83
 #: src/olympia/users/templates/users/includes/navigation.html:4
 msgid "My Collections"
 msgstr ""
 
-#: src/olympia/amo/context_processors.py:62 src/olympia/discovery/templates/discovery/pane_account.html:10 src/olympia/users/templates/users/includes/navigation.html:7
+#: src/olympia/amo/context_processors.py:61 src/olympia/discovery/templates/discovery/pane_account.html:10 src/olympia/users/templates/users/includes/navigation.html:7
 msgid "My Favorites"
 msgstr ""
 
-#: src/olympia/amo/context_processors.py:67 src/olympia/discovery/templates/discovery/pane_account.html:13 src/olympia/templates/impala/user_login.html:14
+#: src/olympia/amo/context_processors.py:66 src/olympia/discovery/templates/discovery/pane_account.html:13 src/olympia/templates/impala/user_login.html:14
 #: src/olympia/templates/mobile/header_auth.html:5
 msgid "Log out"
 msgstr ""
 
-#: src/olympia/amo/context_processors.py:72 src/olympia/devhub/templates/devhub/addons/dashboard.html:4
+#: src/olympia/amo/context_processors.py:71 src/olympia/devhub/templates/devhub/addons/dashboard.html:4
 msgid "Manage My Submissions"
 msgstr ""
 
-#: src/olympia/amo/context_processors.py:75 src/olympia/devhub/templates/devhub/nav.html:27 src/olympia/devhub/templates/devhub/addons/dashboard.html:25
+#: src/olympia/amo/context_processors.py:74 src/olympia/devhub/templates/devhub/nav.html:27 src/olympia/devhub/templates/devhub/addons/dashboard.html:25
 #: src/olympia/devhub/templates/devhub/addons/submit/base.html:4
 msgid "Submit a New Add-on"
 msgstr ""
 
-#: src/olympia/amo/context_processors.py:77 src/olympia/browse/templates/browse/personas/base.html:50 src/olympia/devhub/templates/devhub/index.html:24
+#: src/olympia/amo/context_processors.py:76 src/olympia/browse/templates/browse/personas/base.html:50 src/olympia/devhub/templates/devhub/index.html:24
 #: src/olympia/devhub/templates/devhub/addons/dashboard.html:29
 msgid "Submit a New Theme"
 msgstr ""
 
-#: src/olympia/amo/context_processors.py:79 src/olympia/amo/templates/amo/site_nav.html:87 src/olympia/devhub/helpers.py:36 src/olympia/devhub/helpers.py:68 src/olympia/devhub/helpers.py:102
+#: src/olympia/amo/context_processors.py:78 src/olympia/amo/templates/amo/site_nav.html:85 src/olympia/devhub/helpers.py:36 src/olympia/devhub/helpers.py:68 src/olympia/devhub/helpers.py:102
 #: src/olympia/templates/footer.html:6 src/olympia/templates/menu_links.html:14
 msgid "Developer Hub"
 msgstr ""
 
-#: src/olympia/amo/context_processors.py:83 src/olympia/devhub/views.py:1792
+#: src/olympia/amo/context_processors.py:81 src/olympia/devhub/views.py:1796
 msgid "Manage API Keys"
 msgstr ""
 
-#: src/olympia/amo/context_processors.py:88 src/olympia/editors/helpers.py:82 src/olympia/editors/helpers.py:102 src/olympia/editors/templates/editors/base.html:10
+#: src/olympia/amo/context_processors.py:86 src/olympia/editors/helpers.py:84 src/olympia/editors/helpers.py:104 src/olympia/editors/templates/editors/base.html:10
 msgid "Editor Tools"
 msgstr ""
 
-#: src/olympia/amo/context_processors.py:92
+#: src/olympia/amo/context_processors.py:90
 msgid "Admin Tools"
 msgstr ""
 
-#: src/olympia/amo/fields.py:15
+#: src/olympia/amo/fields.py:20
 msgid "Incorrect, please try again."
 msgstr ""
 
-#: src/olympia/amo/fields.py:16
+#: src/olympia/amo/fields.py:21
 msgid "Error verifying input, please try again."
 msgstr ""
 
-#: src/olympia/amo/fields.py:32
+#: src/olympia/amo/fields.py:37
 msgid "This must be a valid hex color code, such as #000000."
 msgstr ""
 
-#: src/olympia/amo/fields.py:58
+#: src/olympia/amo/fields.py:63
 msgid "Enter at least one value."
 msgstr ""
 
-#: src/olympia/amo/helpers.py:162 src/olympia/amo/templates/amo/site_nav.html:61 src/olympia/bandwagon/templates/bandwagon/add.html:9
+#: src/olympia/amo/helpers.py:162 src/olympia/amo/templates/amo/site_nav.html:59 src/olympia/bandwagon/templates/bandwagon/add.html:9
 #: src/olympia/bandwagon/templates/bandwagon/collection_detail.html:15 src/olympia/bandwagon/templates/bandwagon/delete.html:9 src/olympia/bandwagon/templates/bandwagon/edit.html:15
 #: src/olympia/bandwagon/templates/bandwagon/user_listing.html:18 src/olympia/bandwagon/templates/bandwagon/user_listing.html:21
 #: src/olympia/bandwagon/templates/bandwagon/impala/collection_listing.html:12 src/olympia/bandwagon/templates/bandwagon/impala/collection_listing.html:20
 #: src/olympia/bandwagon/templates/bandwagon/impala/collection_listing.html:24 src/olympia/bandwagon/templates/bandwagon/impala/collection_sidebar.html:3
 #: src/olympia/bandwagon/templates/bandwagon/includes/collection_sidebar.html:2 src/olympia/bandwagon/templates/bandwagon/mobile/collection_listing.html:3
-#: src/olympia/stats/templates/stats/stats.html:77 src/olympia/templates/menu_links.html:12
+#: src/olympia/stats/templates/stats/stats.html:33 src/olympia/templates/menu_links.html:12
 msgid "Collections"
 msgstr ""
 
-#: src/olympia/amo/helpers.py:171 src/olympia/amo/templates/amo/site_nav.html:85 src/olympia/browse/templates/browse/language_tools.html:3
+#: src/olympia/amo/helpers.py:171 src/olympia/amo/templates/amo/site_nav.html:83 src/olympia/browse/templates/browse/language_tools.html:3
 msgid "Dictionaries & Language Packs"
 msgstr ""
 
@@ -1575,8 +1576,8 @@ msgstr ""
 msgid "Comment on {addon} {version}."
 msgstr ""
 
-#: src/olympia/amo/log.py:236 src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:19 src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:47
-#: src/olympia/editors/helpers.py:511 src/olympia/editors/templates/editors/themes/history_table.html:11
+#: src/olympia/amo/log.py:236 src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:17 src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:45
+#: src/olympia/editors/helpers.py:584 src/olympia/editors/templates/editors/themes/history_table.html:11
 msgid "Comment"
 msgstr ""
 
@@ -1899,7 +1900,7 @@ msgstr ""
 #: src/olympia/amo/templates/amo/mobile/paginator.html:14 src/olympia/amo/templates/amo/mobile/paginator.html:16 src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:51
 #: src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:65 src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:78
 #: src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:91 src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:104
-#: src/olympia/discovery/templates/discovery/pane.html:45 src/olympia/discovery/templates/discovery/addons/detail.html:39 src/olympia/stats/templates/stats/stats.html:167
+#: src/olympia/discovery/templates/discovery/pane.html:45 src/olympia/discovery/templates/discovery/addons/detail.html:39 src/olympia/stats/templates/stats/stats.html:169
 msgid "Next"
 msgstr ""
 
@@ -1931,7 +1932,7 @@ msgid ""
 msgstr ""
 
 #: src/olympia/amo/templates/amo/side_nav.html:4 src/olympia/amo/templates/amo/side_nav.html:12 src/olympia/amo/templates/amo/site_nav.html:4 src/olympia/amo/templates/amo/site_nav.html:26
-#: src/olympia/browse/views.py:56 src/olympia/browse/views.py:66 src/olympia/browse/views.py:237 src/olympia/browse/views.py:282 src/olympia/search/forms.py:86
+#: src/olympia/browse/views.py:56 src/olympia/browse/views.py:66 src/olympia/browse/views.py:204 src/olympia/browse/views.py:249 src/olympia/search/forms.py:86
 msgid "Top Rated"
 msgstr ""
 
@@ -1945,38 +1946,38 @@ msgstr ""
 msgid "Extensions"
 msgstr ""
 
-#: src/olympia/amo/templates/amo/site_nav.html:45
+#: src/olympia/amo/templates/amo/site_nav.html:44
 msgid "Want more customization? Try <b>Complete Themes</b>"
 msgstr ""
 
-#: src/olympia/amo/templates/amo/site_nav.html:56 src/olympia/bandwagon/views.py:96
+#: src/olympia/amo/templates/amo/site_nav.html:54 src/olympia/bandwagon/views.py:96
 msgid "Most Followers"
 msgstr ""
 
-#: src/olympia/amo/templates/amo/site_nav.html:68 src/olympia/bandwagon/templates/bandwagon/impala/collection_sidebar.html:16
+#: src/olympia/amo/templates/amo/site_nav.html:66 src/olympia/bandwagon/templates/bandwagon/impala/collection_sidebar.html:16
 #: src/olympia/bandwagon/templates/bandwagon/includes/collection_sidebar.html:18
 msgid "Collections I've Made"
 msgstr ""
 
-#: src/olympia/amo/templates/amo/site_nav.html:70 src/olympia/bandwagon/templates/bandwagon/user_listing.html:4 src/olympia/bandwagon/templates/bandwagon/impala/collection_sidebar.html:13
+#: src/olympia/amo/templates/amo/site_nav.html:68 src/olympia/bandwagon/templates/bandwagon/user_listing.html:4 src/olympia/bandwagon/templates/bandwagon/impala/collection_sidebar.html:13
 #: src/olympia/bandwagon/templates/bandwagon/includes/collection_sidebar.html:15
 msgid "Collections I'm Following"
 msgstr ""
 
-#: src/olympia/amo/templates/amo/site_nav.html:73 src/olympia/bandwagon/templates/bandwagon/impala/collection_sidebar.html:18
-#: src/olympia/bandwagon/templates/bandwagon/includes/collection_sidebar.html:20 src/olympia/users/models.py:512
+#: src/olympia/amo/templates/amo/site_nav.html:71 src/olympia/bandwagon/templates/bandwagon/impala/collection_sidebar.html:18
+#: src/olympia/bandwagon/templates/bandwagon/includes/collection_sidebar.html:20 src/olympia/users/models.py:521
 msgid "My Favorite Add-ons"
 msgstr ""
 
-#: src/olympia/amo/templates/amo/site_nav.html:78
+#: src/olympia/amo/templates/amo/site_nav.html:76
 msgid "More&hellip;"
 msgstr ""
 
-#: src/olympia/amo/templates/amo/site_nav.html:82
+#: src/olympia/amo/templates/amo/site_nav.html:80
 msgid "Add-ons for Mobile"
 msgstr ""
 
-#: src/olympia/amo/templates/amo/site_nav.html:86 src/olympia/browse/feeds.py:207 src/olympia/browse/templates/browse/search_tools.html:3 src/olympia/constants/base.py:176
+#: src/olympia/amo/templates/amo/site_nav.html:84 src/olympia/browse/feeds.py:207 src/olympia/browse/templates/browse/search_tools.html:3 src/olympia/constants/base.py:176
 #: src/olympia/templates/menu_links.html:10
 msgid "Search Tools"
 msgstr ""
@@ -1992,7 +1993,7 @@ msgid "Jump to first page"
 msgstr ""
 
 #: src/olympia/amo/templates/amo/impala/paginator.html:22 src/olympia/amo/templates/amo/mobile/impala_paginator.html:12 src/olympia/discovery/templates/discovery/pane.html:44
-#: src/olympia/discovery/templates/discovery/addons/detail.html:38 src/olympia/stats/templates/stats/stats.html:164
+#: src/olympia/discovery/templates/discovery/addons/detail.html:38 src/olympia/stats/templates/stats/stats.html:166
 msgid "Previous"
 msgstr ""
 
@@ -2015,30 +2016,49 @@ msgid_plural "Page {n}"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/olympia/amo/templates/services/install.html:38
-#, python-format
-msgid "If you are not prompted to install %(addon_name)s in a moment, please <a href=\"%(addon_xpi)s\">click here</a>."
-msgstr ""
-
-#: src/olympia/amo/tests/test_messages.py:57 src/olympia/amo/tests/test_messages.py:58 src/olympia/reviews/forms.py:25 src/olympia/reviews/forms.py:50 src/olympia/reviews/templates/reviews/add.html:56
+#: src/olympia/amo/tests/test_messages.py:56 src/olympia/amo/tests/test_messages.py:57 src/olympia/reviews/forms.py:25 src/olympia/reviews/forms.py:50 src/olympia/reviews/templates/reviews/add.html:56
 #: src/olympia/reviews/templates/reviews/reply.html:30
 msgid "Title"
 msgstr ""
 
-#: src/olympia/amo/tests/test_messages.py:57 src/olympia/amo/tests/test_messages.py:58
+#: src/olympia/amo/tests/test_messages.py:56 src/olympia/amo/tests/test_messages.py:57
 msgid "Body"
 msgstr ""
 
-#: src/olympia/amo/tests/test_messages.py:59
+#: src/olympia/amo/tests/test_messages.py:58
 msgid "Another Title"
 msgstr ""
 
-#: src/olympia/amo/tests/test_messages.py:59
+#: src/olympia/amo/tests/test_messages.py:58
 msgid "Another Body"
 msgstr ""
 
-#: src/olympia/api/views.py:255
-msgid "Not implemented yet."
+#: src/olympia/api/authentication.py:76
+msgid "Signature has expired."
+msgstr ""
+
+#: src/olympia/api/authentication.py:79
+msgid "Error decoding signature."
+msgstr ""
+
+#: src/olympia/api/authentication.py:82
+msgid "Invalid JWT Token."
+msgstr ""
+
+#: src/olympia/api/authentication.py:130
+msgid "Invalid Authorization header. No credentials provided."
+msgstr ""
+
+#: src/olympia/api/authentication.py:133
+msgid "Invalid Authorization header. Credentials string should not contain spaces."
+msgstr ""
+
+#: src/olympia/api/fields.py:29
+msgid "The field must have a length of at least {num} characters."
+msgstr ""
+
+#: src/olympia/api/fields.py:31
+msgid "The language code {lang_code} is invalid."
 msgstr ""
 
 #: src/olympia/applications/views.py:39 src/olympia/applications/templates/applications/appversions.html:3
@@ -2057,7 +2077,7 @@ msgstr ""
 msgid "Add-ons submitted to Mozilla Add-ons must have a manifest file with at least one of the below applications supported. Only the versions listed below are allowed for these applications."
 msgstr ""
 
-#: src/olympia/applications/templates/applications/appversions.html:25
+#: src/olympia/applications/templates/applications/appversions.html:25 src/olympia/editors/helpers.py:361
 msgid "GUID"
 msgstr ""
 
@@ -2171,8 +2191,8 @@ msgstr ""
 msgid "Remove from favorites"
 msgstr ""
 
-#: src/olympia/bandwagon/views.py:98 src/olympia/bandwagon/views.py:191 src/olympia/browse/views.py:58 src/olympia/browse/views.py:69 src/olympia/browse/views.py:458 src/olympia/devhub/views.py:74
-#: src/olympia/devhub/views.py:82 src/olympia/devhub/templates/devhub/addons/edit/basic.html:20 src/olympia/editors/templates/editors/leaderboard.html:24
+#: src/olympia/bandwagon/views.py:98 src/olympia/bandwagon/views.py:191 src/olympia/browse/views.py:58 src/olympia/browse/views.py:69 src/olympia/browse/views.py:425 src/olympia/devhub/views.py:72
+#: src/olympia/devhub/views.py:80 src/olympia/devhub/templates/devhub/addons/edit/basic.html:20 src/olympia/editors/templates/editors/leaderboard.html:24
 #: src/olympia/editors/templates/editors/themes/queue_list.html:48 src/olympia/search/forms.py:17 src/olympia/search/forms.py:89 src/olympia/users/templates/users/vcard.html:5
 msgid "Name"
 msgstr ""
@@ -2181,7 +2201,7 @@ msgstr ""
 msgid "Recently Popular"
 msgstr ""
 
-#: src/olympia/bandwagon/views.py:189 src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:18
+#: src/olympia/bandwagon/views.py:189 src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:16
 msgid "Added"
 msgstr ""
 
@@ -2195,7 +2215,7 @@ msgstr ""
 
 #: src/olympia/bandwagon/views.py:316
 #, python-format
-msgid "Your new collection is shown below. You can <ahref=\"%(url)s\">edit additional settings</a> if you'dlike."
+msgid "Your new collection is shown below. You can <a href=\"%(url)s\">edit additional settings</a> if you'd like."
 msgstr ""
 
 #: src/olympia/bandwagon/views.py:322
@@ -2323,8 +2343,8 @@ msgid_plural "%(num)s Add-ons in this Collection"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/olympia/bandwagon/templates/bandwagon/collection_detail.html:125 src/olympia/compat/templates/compat/index.html:25 src/olympia/compat/templates/compat/reporter_detail.html:29
-#: src/olympia/files/templates/files/viewer.html:29 src/olympia/templates/amo_footer.html:17 src/olympia/templates/includes/lang_switcher.html:10
+#: src/olympia/bandwagon/templates/bandwagon/collection_detail.html:125 src/olympia/compat/templates/compat/reporter_detail.html:29 src/olympia/files/templates/files/viewer.html:29
+#: src/olympia/templates/amo_footer.html:17 src/olympia/templates/includes/lang_switcher.html:10
 msgid "Go"
 msgstr ""
 
@@ -2491,7 +2511,7 @@ msgid "Remove this user as a contributor"
 msgstr ""
 
 #: src/olympia/bandwagon/templates/bandwagon/edit_contributors.html:18 src/olympia/bandwagon/templates/bandwagon/edit_contributors.html:43
-#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:20 src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:48
+#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:18 src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:46
 #: src/olympia/devhub/templates/devhub/addons/ajax_compat_update.html:19
 msgid "Remove"
 msgstr ""
@@ -2539,7 +2559,7 @@ msgid "<b>Warning:</b> By changing the owner of this collection, you will no lon
 msgstr ""
 
 #: src/olympia/bandwagon/templates/bandwagon/edit_contributors.html:83 src/olympia/devhub/templates/devhub/addons/forms_shared/media.html:157
-#: src/olympia/devhub/templates/devhub/addons/submit/describe.html:69 src/olympia/devhub/templates/devhub/addons/submit/license.html:60 src/olympia/devhub/templates/devhub/addons/submit/upload.html:78
+#: src/olympia/devhub/templates/devhub/addons/submit/describe.html:69 src/olympia/devhub/templates/devhub/addons/submit/license.html:60 src/olympia/devhub/templates/devhub/addons/submit/upload.html:70
 #: src/olympia/devhub/templates/devhub/payments/tier.html:17 src/olympia/editors/templates/editors/themes/themes.html:111 src/olympia/editors/templates/editors/themes/themes.html:128
 #: src/olympia/editors/templates/editors/themes/themes.html:134 src/olympia/editors/templates/editors/themes/themes.html:141 src/olympia/users/templates/users/fxa_migration_prompt_content.html:10
 #: src/olympia/users/templates/users/login_form.html:42 src/olympia/users/templates/users/mobile/login.html:57
@@ -2622,31 +2642,31 @@ msgid "Add-ons in Your Collection"
 msgstr ""
 
 #: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:4
-msgid ""
-"To include an add-on in this collection, enter its name in the box below and hit enter.  You can also use the <strong>Add to Collection</strong> links throughout the site to include add-ons later."
+msgid "To include an add-on in this collection, enter its name in the box below and hit enter."
 msgstr ""
 
-#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:17 src/olympia/constants/base.py:400 src/olympia/devhub/templates/devhub/addons/activity.html:62
+#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:15 src/olympia/constants/base.py:400 src/olympia/devhub/templates/devhub/addons/activity.html:62
+#: src/olympia/editors/helpers.py:273 src/olympia/editors/helpers.py:360
 msgid "Add-on"
 msgstr ""
 
-#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:26
+#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:24
 msgid "Enter the name of the add-on to include"
 msgstr ""
 
-#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:28
+#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:26
 msgid "Add to Collection"
 msgstr ""
 
-#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:45 src/olympia/editors/helpers.py:936 src/olympia/editors/helpers.py:956
+#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:43 src/olympia/editors/helpers.py:1016 src/olympia/editors/helpers.py:1036
 msgid "Pending"
 msgstr ""
 
-#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:47
+#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:45
 msgid "Add a comment"
 msgstr ""
 
-#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:48
+#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:46
 msgid "Remove this add-on from the collection"
 msgstr ""
 
@@ -2753,12 +2773,12 @@ msgstr ""
 msgid "Most Users"
 msgstr ""
 
-#: src/olympia/browse/views.py:61 src/olympia/browse/views.py:72 src/olympia/browse/views.py:279 src/olympia/browse/templates/browse/personas/mobile/category_landing.html:63
+#: src/olympia/browse/views.py:61 src/olympia/browse/views.py:72 src/olympia/browse/views.py:246 src/olympia/browse/templates/browse/personas/mobile/category_landing.html:63
 #: src/olympia/discovery/templates/discovery/pane.html:67 src/olympia/search/forms.py:92
 msgid "Up & Coming"
 msgstr ""
 
-#: src/olympia/browse/views.py:460 src/olympia/devhub/views.py:76 src/olympia/devhub/views.py:83 src/olympia/discovery/templates/discovery/addons/detail.html:66
+#: src/olympia/browse/views.py:427 src/olympia/devhub/views.py:74 src/olympia/devhub/views.py:81 src/olympia/discovery/templates/discovery/addons/detail.html:66
 msgid "Created"
 msgstr ""
 
@@ -2946,8 +2966,8 @@ msgid_plural "See all %(cnt)s extensions in %(name)s &raquo;"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/olympia/browse/templates/browse/mobile/extensions.html:13 src/olympia/compat/templates/compat/index.html:82 src/olympia/devhub/templates/devhub/devhub_search.html:24
-#: src/olympia/devhub/templates/devhub/addons/activity.html:47 src/olympia/search/templates/search/no_results.html:4 src/olympia/search/templates/search/mobile/results.html:36
+#: src/olympia/browse/templates/browse/mobile/extensions.html:13 src/olympia/devhub/templates/devhub/devhub_search.html:24 src/olympia/devhub/templates/devhub/addons/activity.html:47
+#: src/olympia/search/templates/search/no_results.html:4 src/olympia/search/templates/search/mobile/results.html:36
 msgid "No results found."
 msgstr ""
 
@@ -3032,7 +3052,7 @@ msgstr ""
 msgid "All"
 msgstr ""
 
-#: src/olympia/compat/forms.py:22 src/olympia/search/views.py:525
+#: src/olympia/compat/forms.py:22 src/olympia/editors/templates/editors/base.html:69 src/olympia/search/views.py:518
 msgid "All Add-ons"
 msgstr ""
 
@@ -3042,53 +3062,6 @@ msgstr ""
 
 #: src/olympia/compat/forms.py:24
 msgid "Non-binary"
-msgstr ""
-
-#. Review points sources other than add-ons and themes.
-#: src/olympia/compat/views.py:87 src/olympia/constants/base.py:388 src/olympia/devhub/forms.py:162 src/olympia/editors/templates/editors/performance.html:75
-msgid "Other"
-msgstr ""
-
-#: src/olympia/compat/templates/compat/index.html:4
-msgid "Add-on Compatibility Report for {app} {version}"
-msgstr ""
-
-#: src/olympia/compat/templates/compat/index.html:11
-msgid "{app} {version} Compatibility"
-msgstr ""
-
-#: src/olympia/compat/templates/compat/index.html:17
-#, python-format
-msgid "Top 95%% compatible with previous version"
-msgstr ""
-
-#: src/olympia/compat/templates/compat/index.html:18
-#, python-format
-msgid "Top 95%% of all add-ons"
-msgstr ""
-
-#: src/olympia/compat/templates/compat/index.html:19
-msgid "All active add-ons"
-msgstr ""
-
-#: src/olympia/compat/templates/compat/index.html:23 src/olympia/constants/base.py:401
-msgid "App"
-msgstr ""
-
-#: src/olympia/compat/templates/compat/index.html:55
-msgid "Details for add-ons compatible with previous version:"
-msgstr ""
-
-#: src/olympia/compat/templates/compat/index.html:57
-msgid "Show all versions"
-msgstr ""
-
-#: src/olympia/compat/templates/compat/index.html:59
-msgid "Details for add-ons compatible with all versions:"
-msgstr ""
-
-#: src/olympia/compat/templates/compat/index.html:61
-msgid "Show previous version only"
 msgstr ""
 
 #: src/olympia/compat/templates/compat/reporter.html:3
@@ -3142,8 +3115,8 @@ msgstr ""
 msgid "Report Type"
 msgstr ""
 
-#: src/olympia/compat/templates/compat/reporter_detail.html:47 src/olympia/devhub/forms.py:784 src/olympia/devhub/templates/devhub/addons/ajax_compat_update.html:17 src/olympia/editors/forms.py:108
-#: src/olympia/zadmin/forms.py:45
+#: src/olympia/compat/templates/compat/reporter_detail.html:47 src/olympia/devhub/forms.py:785 src/olympia/devhub/templates/devhub/addons/ajax_compat_update.html:17 src/olympia/editors/forms.py:108
+#: src/olympia/editors/forms.py:248 src/olympia/zadmin/forms.py:45
 msgid "Application"
 msgstr ""
 
@@ -3231,7 +3204,8 @@ msgstr ""
 msgid "Preliminarily Reviewed and Awaiting Full Review"
 msgstr ""
 
-#: src/olympia/constants/base.py:33 src/olympia/editors/helpers.py:924 src/olympia/editors/templates/editors/themes/history_table.html:34
+#: src/olympia/constants/base.py:33 src/olympia/editors/forms.py:258 src/olympia/editors/helpers.py:73 src/olympia/editors/helpers.py:1004
+#: src/olympia/editors/templates/editors/themes/history_table.html:34
 msgid "Deleted"
 msgstr ""
 
@@ -3328,6 +3302,11 @@ msgstr ""
 msgid "Ask before users can download this add-on"
 msgstr ""
 
+#. Review points sources other than add-ons and themes.
+#: src/olympia/constants/base.py:388 src/olympia/devhub/forms.py:162 src/olympia/editors/templates/editors/performance.html:75
+msgid "Other"
+msgstr ""
+
 #: src/olympia/constants/base.py:389
 msgid "Exception"
 msgstr ""
@@ -3338,6 +3317,10 @@ msgstr ""
 
 #: src/olympia/constants/base.py:391
 msgid "Change"
+msgstr ""
+
+#: src/olympia/constants/base.py:401
+msgid "App"
 msgstr ""
 
 #: src/olympia/constants/base.py:402
@@ -3488,7 +3471,7 @@ msgstr ""
 msgid "Duplicate"
 msgstr ""
 
-#: src/olympia/constants/editors.py:17 src/olympia/editors/helpers.py:502 src/olympia/editors/templates/editors/themes/queue.html:71 src/olympia/editors/templates/editors/themes/themes.html:94
+#: src/olympia/constants/editors.py:17 src/olympia/editors/helpers.py:575 src/olympia/editors/templates/editors/themes/queue.html:71 src/olympia/editors/templates/editors/themes/themes.html:94
 msgid "Reject"
 msgstr ""
 
@@ -3588,7 +3571,7 @@ msgstr ""
 msgid "Android"
 msgstr ""
 
-#: src/olympia/core/apps.py:19
+#: src/olympia/core/apps.py:21
 msgid "Core"
 msgstr ""
 
@@ -3722,7 +3705,7 @@ msgid "Submit my add-on for manual review."
 msgstr ""
 
 #: src/olympia/devhub/forms.py:537
-msgid "Do not list my add-on on this site (beta)"
+msgid "Do not list my add-on on this site"
 msgstr ""
 
 #: src/olympia/devhub/forms.py:538
@@ -3755,46 +3738,46 @@ msgstr ""
 
 #: src/olympia/devhub/forms.py:592
 #, python-format
-msgid "Version %s already exists"
+msgid "Version %s already exists, or was uploaded before."
 msgstr ""
 
-#: src/olympia/devhub/forms.py:604
+#: src/olympia/devhub/forms.py:605
 msgid "Select a valid choice. That choice is not one of the available choices."
 msgstr ""
 
-#: src/olympia/devhub/forms.py:610
+#: src/olympia/devhub/forms.py:611
 msgid "A file with a version ending with a|alpha|b|beta and an optional number is detected as beta."
 msgstr ""
 
-#: src/olympia/devhub/forms.py:633
+#: src/olympia/devhub/forms.py:634
 msgid "You cannot upload any more files for this version."
 msgstr ""
 
-#: src/olympia/devhub/forms.py:639
+#: src/olympia/devhub/forms.py:640
 msgid "Version doesn't match"
 msgstr ""
 
-#: src/olympia/devhub/forms.py:668
+#: src/olympia/devhub/forms.py:669
 msgid "You cannot delete a file once the review process has started.  You must delete the whole version."
 msgstr ""
 
-#: src/olympia/devhub/forms.py:688
+#: src/olympia/devhub/forms.py:689
 msgid "The platform All cannot be combined with specific platforms."
 msgstr ""
 
-#: src/olympia/devhub/forms.py:693
+#: src/olympia/devhub/forms.py:694
 msgid "A platform can only be chosen once."
 msgstr ""
 
-#: src/olympia/devhub/forms.py:706
+#: src/olympia/devhub/forms.py:707
 msgid "A review type must be selected."
 msgstr ""
 
-#: src/olympia/devhub/forms.py:788 src/olympia/editors/forms.py:114 src/olympia/zadmin/forms.py:49 src/olympia/zadmin/forms.py:52
+#: src/olympia/devhub/forms.py:789 src/olympia/editors/forms.py:114 src/olympia/editors/forms.py:254 src/olympia/zadmin/forms.py:49 src/olympia/zadmin/forms.py:52
 msgid "Select an application first"
 msgstr ""
 
-#: src/olympia/devhub/forms.py:840
+#: src/olympia/devhub/forms.py:841
 msgid "There cannot be more than 3 required add-ons."
 msgstr ""
 
@@ -3828,76 +3811,76 @@ msgstr[1] ""
 msgid "Review"
 msgstr ""
 
-#: src/olympia/devhub/tasks.py:551
+#: src/olympia/devhub/tasks.py:583
 #, python-format
 msgid "%s responded with %s (%s)."
 msgstr ""
 
-#: src/olympia/devhub/tasks.py:555
+#: src/olympia/devhub/tasks.py:587
 #, python-format
 msgid "Connection to \"%s\" timed out."
 msgstr ""
 
-#: src/olympia/devhub/tasks.py:557
+#: src/olympia/devhub/tasks.py:589
 #, python-format
 msgid "Could not contact host at \"%s\"."
 msgstr ""
 
-#: src/olympia/devhub/utils.py:104
+#: src/olympia/devhub/utils.py:105
 #, python-format
 msgid "Validation generated too many errors/warnings so %s messages were truncated. After addressing the visible messages, you'll be able to see the others."
 msgstr ""
 
-#: src/olympia/devhub/views.py:183
+#: src/olympia/devhub/views.py:181
 msgid "All My Add-ons"
 msgstr ""
 
-#: src/olympia/devhub/views.py:210
+#: src/olympia/devhub/views.py:208
 msgid "All Activity"
 msgstr ""
 
-#: src/olympia/devhub/views.py:211
+#: src/olympia/devhub/views.py:209
 msgid "Add-on Updates"
 msgstr ""
 
-#: src/olympia/devhub/views.py:212
+#: src/olympia/devhub/views.py:210
 msgid "Add-on Status"
 msgstr ""
 
-#: src/olympia/devhub/views.py:213
+#: src/olympia/devhub/views.py:211
 msgid "User Collections"
 msgstr ""
 
-#: src/olympia/devhub/views.py:214 src/olympia/devhub/templates/devhub/docs/policies-maintenance.html:68 src/olympia/pages/templates/pages/dev_faq.html:38
+#: src/olympia/devhub/views.py:212 src/olympia/devhub/templates/devhub/docs/policies-maintenance.html:68 src/olympia/pages/templates/pages/dev_faq.html:38
 #: src/olympia/pages/templates/pages/dev_faq.html:484
 msgid "User Reviews"
 msgstr ""
 
-#: src/olympia/devhub/views.py:327 src/olympia/devhub/views.py:331 src/olympia/devhub/views.py:484 src/olympia/devhub/views.py:513 src/olympia/devhub/views.py:564 src/olympia/devhub/views.py:1150
+#: src/olympia/devhub/views.py:325 src/olympia/devhub/views.py:329 src/olympia/devhub/views.py:484 src/olympia/devhub/views.py:513 src/olympia/devhub/views.py:564 src/olympia/devhub/views.py:1156
 msgid "Changes successfully saved."
 msgstr ""
 
-#: src/olympia/devhub/views.py:334 src/olympia/devhub/views.py:1631
+#: src/olympia/devhub/views.py:332 src/olympia/devhub/views.py:1637
 msgid "Please check the form for errors."
 msgstr ""
 
-#: src/olympia/devhub/views.py:346
+#: src/olympia/devhub/views.py:344
 msgid "Add-on cannot be deleted. Disable this add-on instead."
 msgstr ""
 
-#: src/olympia/devhub/views.py:356
+#: src/olympia/devhub/views.py:354
 msgid "Theme deleted."
 msgstr ""
 
-#: src/olympia/devhub/views.py:356
+#: src/olympia/devhub/views.py:354
 msgid "Add-on deleted."
 msgstr ""
 
-#: src/olympia/devhub/views.py:362
+#: src/olympia/devhub/views.py:360
 msgid "URL name was incorrect. Theme was not deleted."
 msgstr ""
 
-#: src/olympia/devhub/views.py:367
+#: src/olympia/devhub/views.py:365
 msgid "URL name was incorrect. Add-on was not deleted."
 msgstr ""
 
@@ -3925,7 +3908,7 @@ msgstr ""
 msgid "Check Add-on Compatibility"
 msgstr ""
 
-#: src/olympia/devhub/views.py:808 src/olympia/signing/views.py:90
+#: src/olympia/devhub/views.py:808 src/olympia/signing/views.py:95
 msgid "You cannot submit this type of add-on"
 msgstr ""
 
@@ -3955,33 +3938,33 @@ msgstr ""
 msgid "There was an error uploading your preview."
 msgstr ""
 
-#: src/olympia/devhub/views.py:1189
+#: src/olympia/devhub/views.py:1195
 #, python-format
 msgid "Version %s disabled."
 msgstr ""
 
-#: src/olympia/devhub/views.py:1193
+#: src/olympia/devhub/views.py:1199
 #, python-format
 msgid "Version %s deleted."
 msgstr ""
 
-#: src/olympia/devhub/views.py:1203
+#: src/olympia/devhub/views.py:1209
 msgid "This upload has failed validation, and may lack complete validation results. Please take due care when reviewing it."
 msgstr ""
 
-#: src/olympia/devhub/views.py:1677
+#: src/olympia/devhub/views.py:1683
 msgid "Preliminary Review Requested."
 msgstr ""
 
-#: src/olympia/devhub/views.py:1678
+#: src/olympia/devhub/views.py:1684
 msgid "Full Review Requested."
 msgstr ""
 
-#: src/olympia/devhub/views.py:1779
+#: src/olympia/devhub/views.py:1783
 msgid "Your old credentials were revoked and are no longer valid. Be sure to update all API clients with the new credentials."
 msgstr ""
 
-#: src/olympia/devhub/views.py:1797
+#: src/olympia/devhub/views.py:1801
 msgid "New API key created"
 msgstr ""
 
@@ -4011,7 +3994,7 @@ msgstr ""
 msgid "{0} :: Search"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/devhub_search.html:6 src/olympia/devhub/templates/devhub/search.html:8 src/olympia/editors/forms.py:435 src/olympia/editors/forms.py:437
+#: src/olympia/devhub/templates/devhub/devhub_search.html:6 src/olympia/devhub/templates/devhub/search.html:8 src/olympia/editors/forms.py:534 src/olympia/editors/forms.py:536
 #: src/olympia/editors/templates/editors/queue.html:27 src/olympia/editors/templates/editors/themes/queue_list.html:14 src/olympia/search/templates/search/collections.html:17
 #: src/olympia/search/templates/search/personas.html:18 src/olympia/search/templates/search/results.html:18 src/olympia/search/templates/search/mobile/results.html:8
 #: src/olympia/templates/search.html:14 src/olympia/templates/impala/search.html:18
@@ -4071,12 +4054,12 @@ msgstr ""
 msgid "Start Making Add-ons"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/index.html:86 src/olympia/devhub/templates/devhub/addons/listing/items.html:25 src/olympia/devhub/templates/devhub/includes/addon_details.html:15
+#: src/olympia/devhub/templates/devhub/index.html:86 src/olympia/devhub/templates/devhub/addons/listing/items.html:25 src/olympia/devhub/templates/devhub/includes/addon_details.html:20
 #: src/olympia/devhub/templates/devhub/personas/edit.html:43
 msgid "Status:"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/index.html:90 src/olympia/devhub/templates/devhub/includes/addon_details.html:100
+#: src/olympia/devhub/templates/devhub/index.html:90 src/olympia/devhub/templates/devhub/includes/addon_details.html:87
 msgid "Visibility:"
 msgstr ""
 
@@ -4084,11 +4067,11 @@ msgstr ""
 msgid "Latest Version:"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/index.html:109 src/olympia/devhub/templates/devhub/includes/addon_details.html:145 src/olympia/devhub/templates/devhub/personas/edit.html:49
+#: src/olympia/devhub/templates/devhub/index.html:109 src/olympia/devhub/templates/devhub/includes/addon_details.html:131 src/olympia/devhub/templates/devhub/personas/edit.html:49
 msgid "Queue Position:"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/index.html:110 src/olympia/devhub/templates/devhub/includes/addon_details.html:146 src/olympia/devhub/templates/devhub/personas/edit.html:50
+#: src/olympia/devhub/templates/devhub/index.html:110 src/olympia/devhub/templates/devhub/includes/addon_details.html:132 src/olympia/devhub/templates/devhub/personas/edit.html:50
 #, python-format
 msgid "%(position)s of %(total)s"
 msgstr ""
@@ -4190,16 +4173,6 @@ msgstr ""
 msgid "Do you want your add-on to be distributed on this site?"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/validate_addon.html:49 src/olympia/devhub/templates/devhub/addons/submit/upload.html:30 src/olympia/devhub/templates/devhub/versions/add_file_modal.html:14
-#: src/olympia/devhub/templates/devhub/versions/add_file_modal.html:53 src/olympia/devhub/templates/devhub/versions/list.html:298
-msgid "Warning:"
-msgstr ""
-
-#: src/olympia/devhub/templates/devhub/validate_addon.html:50 src/olympia/devhub/templates/devhub/addons/submit/upload.html:31
-#, python-format
-msgid "Submission of unlisted add-ons for signing is currently in an open beta. Please <a href=\"%(url)s\" target=\"_blank\">report any bugs</a> that you encounter."
-msgstr ""
-
 #. first parameter is a filename like lorem-ipsum-1.0.2.xpi
 #: src/olympia/devhub/templates/devhub/validation.html:5
 msgid "Validation Results for {0}"
@@ -4274,7 +4247,7 @@ msgstr ""
 msgid "Update Compatibility"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/addons/ajax_compat_update.html:4
+#: src/olympia/devhub/templates/devhub/addons/ajax_compat_update.html:4 src/olympia/devhub/templates/devhub/versions/edit.html:45
 msgid "Adjusting application information here will allow users to install your add-on even if the install manifest in the package indicates that the add-on is incompatible."
 msgstr ""
 
@@ -4286,9 +4259,9 @@ msgstr ""
 msgid "Add Another Application&hellip;"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/addons/ajax_compat_update.html:38 src/olympia/devhub/templates/devhub/addons/owner.html:86 src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:46
-#: src/olympia/devhub/templates/devhub/versions/list.html:351 src/olympia/devhub/templates/devhub/versions/list.html:353 src/olympia/templates/impala/base.html:132
-#: src/olympia/templates/impala/base.html:143 src/olympia/templates/impala/base.html:161 src/olympia/templates/impala/base.html:171
+#: src/olympia/devhub/templates/devhub/addons/ajax_compat_update.html:38 src/olympia/devhub/templates/devhub/addons/owner.html:86 src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:45
+#: src/olympia/devhub/templates/devhub/versions/list.html:349 src/olympia/devhub/templates/devhub/versions/list.html:351 src/olympia/templates/impala/base.html:129
+#: src/olympia/templates/impala/base.html:140 src/olympia/templates/impala/base.html:158 src/olympia/templates/impala/base.html:168
 msgid "Close"
 msgstr ""
 
@@ -4322,7 +4295,7 @@ msgstr ""
 msgid "Manage Authors & License"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/addons/owner.html:29 src/olympia/editors/templates/editors/review.html:270
+#: src/olympia/devhub/templates/devhub/addons/owner.html:29 src/olympia/editors/helpers.py:362 src/olympia/editors/templates/editors/review.html:270
 msgid "Authors"
 msgstr ""
 
@@ -4391,17 +4364,11 @@ msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/basic.html:52
 msgid ""
-"A short explanation of your add-on's basic\n"
-"                          functionality that is displayed in search and browse\n"
-"                          listings, as well as at the top of your add-on's\n"
-"                          details page. It is only relevant for listed add-ons."
+"A short explanation of your add-on's basic functionality that is displayed in search and browse listings, as well as at the top of your add-on's details page. It is only relevant for listed add-ons."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/basic.html:73
-msgid ""
-"Categories are the primary way users browse through add-ons.\n"
-"                        Choose any that fit your add-on's functionality for the most\n"
-"                        exposure. It is only relevant for listed add-ons."
+msgid "Categories are the primary way users browse through add-ons. Choose any that fit your add-on's functionality for the most exposure. It is only relevant for listed add-ons."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/basic.html:90
@@ -4411,11 +4378,7 @@ msgid ""
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/basic.html:119
-msgid ""
-"Tags help users find your add-on and should be short\n"
-"                        descriptors such as tabs, toolbar, or twitter.  You\n"
-"                        may have a maximum of {0} tags. It is only relevant\n"
-"                        for listed add-ons."
+msgid "Tags help users find your add-on and should be short descriptors such as tabs, toolbar, or twitter. You may have a maximum of {0} tags. It is only relevant for listed add-ons."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/basic.html:129 src/olympia/devhub/templates/devhub/personas/edit.html:97 src/olympia/devhub/templates/devhub/personas/submit.html:46
@@ -4443,11 +4406,7 @@ msgid "Add-on Details for {0}"
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/details.html:22
-msgid ""
-"A longer explanation of features,\n"
-"                          functionality, and other relevant information. This\n"
-"                          field is only displayed on the add-on's details\n"
-"                          page. It is only relevant for listed add-ons."
+msgid "A longer explanation of features, functionality, and other relevant information. This field is only displayed on the add-on's details page. It is only relevant for listed add-ons."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/details.html:44 src/olympia/translations/templates/translations/trans-menu.html:13
@@ -4455,10 +4414,7 @@ msgid "Default Locale"
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/details.html:45
-msgid ""
-"Information about your add-on is displayed in this locale\n"
-"                        unless you override it with a locale-specific translation.\n"
-"                        It is only relevant for listed add-ons."
+msgid "Information about your add-on is displayed in this locale unless you override it with a locale-specific translation. It is only relevant for listed add-ons."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/details.html:61 src/olympia/users/forms.py:311 src/olympia/users/templates/users/edit.html:122 src/olympia/users/templates/users/register.html:57
@@ -4468,10 +4424,8 @@ msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/details.html:63
 msgid ""
-"If your add-on has another homepage, enter its\n"
-"                          address here. If your website is localized into other\n"
-"                          languages multiple translations of this field can be\n"
-"                          added. It is only relevant for listed add-ons."
+"If your add-on has another homepage, enter its address here. If your website is localized into other languages multiple translations of this field can be added. It is only relevant for listed add-"
+"ons."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/media.html:3
@@ -4489,19 +4443,14 @@ msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/support.html:22
 msgid ""
-"If you wish to display an e-mail address for support\n"
-"                          inquiries, enter it here. If you have different\n"
-"                          addresses for each language multiple translations of\n"
-"                          this field can be added. It is only relevant for\n"
-"                          listed add-ons."
+"If you wish to display an e-mail address for support inquiries, enter it here. If you have different addresses for each language multiple translations of this field can be added. It is only "
+"relevant for listed add-ons."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/support.html:45
 msgid ""
-"If your add-on has a support website or forum, enter\n"
-"                          its address here. If your website is localized into\n"
-"                          other languages, multiple translations of this field can\n"
-"                          be added. It is only relevant for listed add-ons."
+"If your add-on has a support website or forum, enter its address here. If your website is localized into other languages, multiple translations of this field can be added. It is only relevant for "
+"listed add-ons."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:6
@@ -4515,11 +4464,8 @@ msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:23
 msgid ""
-"Any information end users may want to know that isn't\n"
-"                          necessarily applicable to the add-on summary or description.\n"
-"                          Common uses include listing known major bugs, information on\n"
-"                          how to report bugs, anticipated release date of a new version,\n"
-"                          etc. It is only relevant for listed add-ons."
+"Any information end users may want to know that isn't necessarily applicable to the add-on summary or description. Common uses include listing known major bugs, information on how to report bugs, "
+"anticipated release date of a new version, etc. It is only relevant for listed add-ons."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:46
@@ -4531,9 +4477,7 @@ msgid "Add-on Flags"
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:69
-msgid ""
-"These flags are used to classify add-ons. It is only\n"
-"                        relevant for listed add-ons."
+msgid "These flags are used to classify add-ons. It is only relevant for listed add-ons."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:74
@@ -4549,9 +4493,7 @@ msgid "View Source?"
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:90
-msgid ""
-"Whether the source of your add-on can be displayed in our\n"
-"                        online viewer. It is only relevant for listed add-ons."
+msgid "Whether the source of your add-on can be displayed in our online viewer. It is only relevant for listed add-ons."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:94
@@ -4567,10 +4509,7 @@ msgid "Public Stats?"
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:102
-msgid ""
-"Whether the download and usage stats of your add-on can\n"
-"                        be displayed in our online viewer.\n"
-"                        It is only relevant for listed add-ons."
+msgid "Whether the download and usage stats of your add-on can be displayed in our online viewer. It is only relevant for listed add-ons."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:107
@@ -4586,10 +4525,7 @@ msgid "Upgrade SDK?"
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:116
-msgid ""
-"If selected, we will try to automatically upgrade your\n"
-"                        add-on when a new version of the SDK is released.\n"
-"                        It is only relevant for listed add-ons."
+msgid "If selected, we will try to automatically upgrade your add-on when a new version of the SDK is released. It is only relevant for listed add-ons."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:121
@@ -4640,10 +4576,8 @@ msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/forms_shared/media.html:16
 msgid ""
-"Upload an icon for your add-on or choose from one of ours. The\n"
-"                      icon is displayed nearly everywhere your add-on is. Uploaded images\n"
-"                      must be one of the following image types: .png, .jpg.\n"
-"                      It is only relevant for listed add-ons."
+"Upload an icon for your add-on or choose from one of ours. The icon is displayed nearly everywhere your add-on is. Uploaded images must be one of the following image types: .png, .jpg. It is only "
+"relevant for listed add-ons."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/forms_shared/media.html:25
@@ -4656,9 +4590,7 @@ msgid "32x32px"
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/forms_shared/media.html:39
-msgid ""
-"Used in listings of add-ons, like search results\n"
-"                            and featured add-ons."
+msgid "Used in listings of add-ons, like search results and featured add-ons."
 msgstr ""
 
 #. The size of the icon
@@ -4753,16 +4685,14 @@ msgid "Deleting your add-on will permanently remove it from the site and prevent
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:24
-msgid ""
-"Enter the following text confirm your decision:\n"
-"           {slug}"
+msgid "Enter the following text confirm your decision: {slug}"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:34
+#: src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:33
 msgid "Please tell us why you are deleting your theme:"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:36
+#: src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:35
 msgid "Please tell us why you are deleting your add-on:"
 msgstr ""
 
@@ -4799,8 +4729,8 @@ msgstr ""
 msgid "Daily statistics on downloads and users."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/addons/listing/item_actions.html:45 src/olympia/stats/templates/stats/stats.html:75 src/olympia/stats/templates/stats/stats.html:79
-#: src/olympia/stats/templates/stats/stats.html:81
+#: src/olympia/devhub/templates/devhub/addons/listing/item_actions.html:45 src/olympia/stats/templates/stats/stats.html:31 src/olympia/stats/templates/stats/stats.html:35
+#: src/olympia/stats/templates/stats/stats.html:37
 msgid "Statistics"
 msgstr ""
 
@@ -4919,10 +4849,7 @@ msgid "Your add-on has been submitted to the Full Review queue."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/submit/done.html:18
-msgid ""
-"You'll receive an email once it has been reviewed by an editor. In\n"
-"          the meantime, you and your friends can install it directly from its\n"
-"          details page:"
+msgid "You'll receive an email once it has been reviewed by an editor. In the meantime, you and your friends can install it directly from its details page:"
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/submit/done.html:27 src/olympia/devhub/templates/devhub/addons/submit/done.html:77 src/olympia/devhub/templates/devhub/personas/submit_done.html:16
@@ -5128,11 +5055,11 @@ msgstr ""
 msgid "Use the fields below to upload your add-on package and select any platform restrictions. After upload, a series of automated validation tests will be run on your file."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/addons/submit/upload.html:59 src/olympia/devhub/templates/devhub/versions/add_file_modal.html:39
+#: src/olympia/devhub/templates/devhub/addons/submit/upload.html:51 src/olympia/devhub/templates/devhub/versions/add_file_modal.html:28
 msgid "Which platforms is this file compatible with?"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/addons/submit/upload.html:67 src/olympia/devhub/templates/devhub/versions/add_file_modal.html:65
+#: src/olympia/devhub/templates/devhub/addons/submit/upload.html:59 src/olympia/devhub/templates/devhub/versions/add_file_modal.html:45
 msgid "Administrative overrides"
 msgstr ""
 
@@ -5242,8 +5169,8 @@ msgstr ""
 
 #: src/olympia/devhub/templates/devhub/docs/policies-contact.html:44
 msgid ""
-"If you've found a problem with the site, we'd love to fix it. Please <a href=\"https://github.com/mozilla/olympia/issues\">file a bug report</a> in GitHub, including the location of the problem and "
-"how you encountered it."
+"If you've found a problem with the site, we'd love to fix it. Please <a href=\"https://github.com/mozilla/addons/issues/new\">file a bug report</a> in GitHub, including the location of the problem "
+"and how you encountered it."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/docs/policies-maintenance.html:3 src/olympia/devhub/templates/devhub/docs/policies-maintenance.html:7
@@ -5810,7 +5737,7 @@ msgstr ""
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:282
 msgid ""
-"Add-ons that store or otherwise handle browsing data must support <a href=\"https://developer.mozilla.org/En/Supporting_private_browsing_mode\">Private Browsing Mode</a>.  During a Private Browsing "
+"Add-ons that store or otherwise handle browsing data must support <a href=\"https://developer.mozilla.org/En/Supporting_private_browsing_mode\">Private Browsing Mode</a>. During a Private Browsing "
 "session, no browsing data can be written to disk, and all of this data must be cleared when Firefox quits or the Private Browsing session ends."
 msgstr ""
 
@@ -5975,129 +5902,95 @@ msgstr ""
 msgid "How to get in touch with us regarding these policies or your add-on."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:6
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:10
 msgid "You have disabled this add-on"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:20
-msgid ""
-"Your add-on's listing is disabled and is not showing\n"
-"                             anywhere in our gallery or update service."
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:24
+msgid "Your add-on's listing is disabled and is not showing anywhere in our gallery or update service."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:25
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:27
 msgid "Please complete your add-on."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:29
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:30
 msgid "You will receive an email when the review is complete."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:34
-msgid ""
-"You will receive an email when the review is complete. Until\n"
-"                             then, your add-on is not listed in our gallery but can be\n"
-"                             accessed directly from its details page."
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:33
+msgid "You will receive an email when the review is complete. Until then, your add-on is not listed in our gallery but can be accessed directly from its details page."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:38 src/olympia/devhub/templates/devhub/includes/addon_details.html:48
-msgid ""
-"You will receive an email when the review is\n"
-"                             complete and your add-on is signed."
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:37 src/olympia/devhub/templates/devhub/includes/addon_details.html:45
+msgid "You will receive an email when the review is complete and your add-on is signed."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:44
-msgid ""
-"You will receive an email when the review is complete. Until\n"
-"                             then, your add-on is not listed in our gallery but can be\n"
-"                             accessed directly from its details page. "
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:41
+msgid "You will receive an email when the review is complete. Until then, your add-on is not listed in our gallery but can be accessed directly from its details page. "
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:54
-msgid ""
-"Your add-on is displayed in our gallery and users are\n"
-"                             receiving automatic updates."
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:49
+msgid "Your add-on is displayed in our gallery and users are receiving automatic updates."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:57
-msgid ""
-"Your add-on has been signed and can be bundled with an\n"
-"                             application installer."
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:52
+msgid "Your add-on has been signed and can be bundled with an application installer."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:63
-msgid ""
-"Your add-on was disabled by a site administrator and is no\n"
-"                             longer shown in our gallery. If you have any questions,\n"
-"                             please email amo-admins@mozilla.org."
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:56
+msgid "Your add-on was disabled by a site administrator and is no longer shown in our gallery. If you have any questions, please email amo-admins@mozilla.org."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:70
-msgid ""
-"Your add-on is displayed in our gallery as experimental\n"
-"                             and users are receiving automatic updates. Some features\n"
-"                             are unavailable to your add-on."
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:62
+msgid "Your add-on is displayed in our gallery as experimental and users are receiving automatic updates. Some features are unavailable to your add-on."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:74
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:66
 msgid "Your add-on has been signed."
 msgstr ""
 
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:69
+msgid ""
+"You will receive an email when the full review is complete. Until then, your add-on is displayed in our gallery as experimental and users are receiving automatic updates. Some features are "
+"unavailable to your add-on."
+msgstr ""
+
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:74
+msgid "You will receive an email when the full review is complete, making you able to bundle your add-on with an application installer."
+msgstr ""
+
 #: src/olympia/devhub/templates/devhub/includes/addon_details.html:79
-msgid ""
-"You will receive an email when the full review is complete.\n"
-"                             Until then, your add-on is displayed in our gallery as\n"
-"                             experimental and users are receiving automatic updates.\n"
-"                             Some features are unavailable to your add-on."
+msgid "All add-ons hosted in our gallery must now be reviewed by an editor. If you wish to continue hosting your add-on, please click to select a review process."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:84
-msgid ""
-"You will receive an email when the full review is\n"
-"                             complete, making you able to bundle your add-on with an\n"
-"                             application installer."
-msgstr ""
-
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:91
-msgid ""
-"All add-ons hosted in our gallery must now be reviewed by an\n"
-"                             editor. If you wish to continue hosting your add-on, please\n"
-"                             click to select a review process."
-msgstr ""
-
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:113
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:100
 msgid "Current Version:"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:115
-msgid ""
-"This is the version of your add-on that will\n"
-"                                           be installed if someone clicks the Install\n"
-"                                           button on addons.mozilla.org. It is only\n"
-"                                           relevant for listed add-ons."
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:102
+msgid "This is the version of your add-on that will be installed if someone clicks the Install button on addons.mozilla.org. It is only relevant for listed add-ons."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:123
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:110
 msgid "Created:"
 msgstr ""
 
 #. {0} is a date. dennis-ignore: E201
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:125 src/olympia/devhub/templates/devhub/includes/addon_details.html:131
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:112 src/olympia/devhub/templates/devhub/includes/addon_details.html:118
 #, python-format
 msgid "%%b %%e, %%Y"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:136
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:123
 msgid "Next Version:"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:138
-msgid ""
-"This is the newest uploaded version, however\n"
-"                                           it isn’t live on the site yet."
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:125
+msgid "This is the newest uploaded version, however it isn’t live on the site yet."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:144 src/olympia/devhub/templates/devhub/versions/list.html:30
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:130 src/olympia/devhub/templates/devhub/versions/list.html:30
 msgid "Queues are not reviewed strictly in order"
 msgstr ""
 
@@ -6165,9 +6058,7 @@ msgid "View the blog &#9658;"
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/includes/license_form.html:6
-msgid ""
-"Please choose a license appropriate for the rights you grant on your source code.\n"
-"                  It is only relevant for listed add-ons."
+msgid "Please choose a license appropriate for the rights you grant on your source code. It is only relevant for listed add-ons."
 msgstr ""
 
 #. {0} is a list of HTML tags.
@@ -6194,14 +6085,11 @@ msgstr[1] ""
 #: src/olympia/devhub/templates/devhub/includes/policy_form.html:4
 msgid ""
 "Users will be required to accept the following End-User License Agreement (EULA) prior to installing your add-on. The presence of a EULA significantly affects the number of downloads an add-on "
-"receives. Please note that a EULA is not the same as a code license, such as the GPL or MPL.\n"
-"                It is only relevant for listed add-ons."
+"receives. Please note that a EULA is not the same as a code license, such as the GPL or MPL.It is only relevant for listed add-ons."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/policy_form.html:21
-msgid ""
-"If your add-on transmits any data from the user's computer, a privacy policy is required that explains what data is sent and how it is used.\n"
-"                It is only relevant for listed add-ons."
+#: src/olympia/devhub/templates/devhub/includes/policy_form.html:24
+msgid "If your add-on transmits any data from the user's computer, a privacy policy is required that explains what data is sent and how it is used. It is only relevant for listed add-ons."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/includes/source_form_field.html:2
@@ -6369,12 +6257,8 @@ msgstr ""
 msgid "Add some tags to describe your Theme."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/personas/edit.html:106
-msgid ""
-"A short explanation of your theme's\n"
-"                                basic functionality that is displayed in\n"
-"                                search and browse listings, as well as at\n"
-"                                the top of your theme's details page."
+#: src/olympia/devhub/templates/devhub/personas/edit.html:106 src/olympia/devhub/templates/devhub/personas/submit.html:54
+msgid "A short explanation of your theme's basic functionality that is displayed in search and browse listings, as well as at the top of your theme's details page."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/personas/edit.html:122 src/olympia/devhub/templates/devhub/personas/submit.html:68
@@ -6444,7 +6328,7 @@ msgid "Upon upload and form submission, the AMO Team will review your updated de
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/personas/edit.html:241
-msgid "Your previously resubmitted design,  which is under pending review."
+msgid "Your previously resubmitted design, which is under pending review."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/personas/edit.html:245
@@ -6511,14 +6395,6 @@ msgstr ""
 
 #: src/olympia/devhub/templates/devhub/personas/submit.html:33
 msgid "Give your Theme a name."
-msgstr ""
-
-#: src/olympia/devhub/templates/devhub/personas/submit.html:54
-msgid ""
-"A short explanation of your theme's\n"
-"                                      basic functionality that is displayed in\n"
-"                                      search and browse listings, as well as at\n"
-"                                      the top of your theme's details page."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/personas/submit.html:198
@@ -6595,30 +6471,16 @@ msgstr ""
 msgid "Files added to reviewed versions must be reviewed before they will be available for download."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/add_file_modal.html:15
-#, python-format
-msgid ""
-"Submission of updates to unlisted add-ons for signing is currently in an open beta. Manual review may still be required for a large number of add-ons. Please <a href=\"%(url)s\" target=\"_blank"
-"\">report any bugs</a> that you encounter."
-msgstr ""
-
-#: src/olympia/devhub/templates/devhub/versions/add_file_modal.html:35
+#: src/olympia/devhub/templates/devhub/versions/add_file_modal.html:24
 msgid "Select the target platform for this file."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/add_file_modal.html:46
+#: src/olympia/devhub/templates/devhub/versions/add_file_modal.html:35
 msgid "Which review type would you like to nominate for?"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/add_file_modal.html:51
+#: src/olympia/devhub/templates/devhub/versions/add_file_modal.html:40
 msgid "Only publish this version to my beta channel."
-msgstr ""
-
-#: src/olympia/devhub/templates/devhub/versions/add_file_modal.html:54
-#, python-format
-msgid ""
-"The behavior of the beta channel has changed to accommodate <a href=\"%(addon_signing_url)s\" target=\"_blank\">mandatory add-on signing</a>. The new process is currently in an open beta, and may "
-"change significantly in the near future. Please <a href=\"%(issues_url)s\" target=\"_blank\">report any bugs</a> that you encounter."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/versions/edit.html:5
@@ -6642,19 +6504,10 @@ msgstr ""
 msgid "Upload Another File"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/edit.html:45
-msgid ""
-"Adjusting application information here will allow users to install your\n"
-"                          add-on even if the install manifest in the package indicates that the\n"
-"                          add-on is incompatible."
-msgstr ""
-
 #: src/olympia/devhub/templates/devhub/versions/edit.html:74
 msgid ""
-"Information about changes in this release, new features,\n"
-"                              known bugs, and other useful information specific to this\n"
-"                              release/version. This information is also shown in the\n"
-"                              Add-ons Manager when updating."
+"Information about changes in this release, new features, known bugs, and other useful information specific to this release/version. This information is also shown in the Add-ons Manager when "
+"updating."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/versions/edit.html:99
@@ -6666,10 +6519,7 @@ msgid "Notes for Reviewers"
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/versions/edit.html:114
-msgid ""
-"Optionally, enter any information that may be useful\n"
-"                              to the Editor reviewing this add-on, such as test\n"
-"                              account information."
+msgid "Optionally, enter any information that may be useful to the Editor reviewing this add-on, such as test account information."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/versions/edit.html:127
@@ -6747,7 +6597,7 @@ msgstr ""
 msgid "Request Preliminary Review"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:80 src/olympia/devhub/templates/devhub/versions/list.html:327 src/olympia/devhub/templates/devhub/versions/list.html:350
+#: src/olympia/devhub/templates/devhub/versions/list.html:80 src/olympia/devhub/templates/devhub/versions/list.html:325 src/olympia/devhub/templates/devhub/versions/list.html:348
 msgid "Cancel Review Request"
 msgstr ""
 
@@ -6776,7 +6626,7 @@ msgid "Unlisted:"
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/versions/list.html:114
-msgid "Not distributed on {0}. Developers will upload new versions for signing and distribute the add-ons on their own. (beta)"
+msgid "Not distributed on {0}. Developers will upload new versions for signing and distribute the add-ons on their own."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/versions/list.html:122
@@ -6839,81 +6689,73 @@ msgid "<strong>Important:</strong> Once a version has been deleted, you may not 
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/versions/list.html:230
-msgid ""
-"Deleting a version which has already been reviewed\n"
-"               may also cause a significant delay in the review of\n"
-"               your next update."
-msgstr ""
-
-#: src/olympia/devhub/templates/devhub/versions/list.html:233
 msgid "Are you sure you wish to delete this version?"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:238
+#: src/olympia/devhub/templates/devhub/versions/list.html:235
 msgid "Delete Version"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:240
+#: src/olympia/devhub/templates/devhub/versions/list.html:237
 msgid "Disable Version"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:247
+#: src/olympia/devhub/templates/devhub/versions/list.html:244
 msgid "Add a new Version"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:249
+#: src/olympia/devhub/templates/devhub/versions/list.html:246
 msgid "Add Version"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:256 src/olympia/devhub/templates/devhub/versions/list.html:274
+#: src/olympia/devhub/templates/devhub/versions/list.html:253 src/olympia/devhub/templates/devhub/versions/list.html:279
 msgid "Hide Add-on"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:259
+#: src/olympia/devhub/templates/devhub/versions/list.html:256
 msgid "Hiding your add-on will prevent it from appearing anywhere in our gallery and will stop users from receiving automatic updates."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:265
+#: src/olympia/devhub/templates/devhub/versions/list.html:263
+msgid "The files awaiting review will be disabled and you will need to upload new versions."
+msgstr ""
+
+#: src/olympia/devhub/templates/devhub/versions/list.html:270
 msgid "Are you sure you wish to hide your add-on?"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:286 src/olympia/devhub/templates/devhub/versions/list.html:315
+#: src/olympia/devhub/templates/devhub/versions/list.html:291 src/olympia/devhub/templates/devhub/versions/list.html:313
 msgid "Unlist Add-on"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:289
+#: src/olympia/devhub/templates/devhub/versions/list.html:294
 #, python-format
 msgid ""
 "Unlisting your add-on will make it (and each of its versions/files) invisible on this website. It won't show up in searches, won't have a public facing page, and won't be updated automatically for "
-"current users.  It is recommended for unlisted add-ons to provide a custom <a href=\"%(update_url)s\" target=\"_blank\">updateURL</a> in their manifest file for automatic updates."
+"current users. It is recommended for unlisted add-ons to provide a custom <a href=\"%(update_url)s\" target=\"_blank\">updateURL</a> in their manifest file for automatic updates."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:299
-#, python-format
-msgid "Switching add-ons to unlisted is currently in an open beta. Please <a href=\"%(url)s\" target=\"_blank\">report any bugs</a> that you encounter."
-msgstr ""
-
-#: src/olympia/devhub/templates/devhub/versions/list.html:305
+#: src/olympia/devhub/templates/devhub/versions/list.html:303
 msgid "Unlisting an add-on is irreversible!"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:305
+#: src/olympia/devhub/templates/devhub/versions/list.html:303
 msgid "An unlisted add-on cannot be switched to be listed."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:307
+#: src/olympia/devhub/templates/devhub/versions/list.html:305
 msgid "Are you sure you wish to unlist your add-on?"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:330
+#: src/olympia/devhub/templates/devhub/versions/list.html:328
 msgid "Canceling your review request will leave your add-on as preliminarily reviewed."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:335
+#: src/olympia/devhub/templates/devhub/versions/list.html:333
 msgid "Canceling your review request will mark your add-on incomplete. If you do not complete your add-on after several days by re-requesting review, it will be deleted."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:343
+#: src/olympia/devhub/templates/devhub/versions/list.html:341
 msgid "Are you sure you wish to cancel your review request?"
 msgstr ""
 
@@ -7252,19 +7094,19 @@ msgstr ""
 msgid "Search by add-on name / author email"
 msgstr ""
 
-#: src/olympia/editors/forms.py:103
+#: src/olympia/editors/forms.py:103 src/olympia/editors/forms.py:244 src/olympia/editors/forms.py:257
 msgid "yes"
 msgstr ""
 
-#: src/olympia/editors/forms.py:104
+#: src/olympia/editors/forms.py:104 src/olympia/editors/forms.py:244 src/olympia/editors/forms.py:257
 msgid "no"
 msgstr ""
 
-#: src/olympia/editors/forms.py:105
+#: src/olympia/editors/forms.py:105 src/olympia/editors/forms.py:245
 msgid "Admin Flag"
 msgstr ""
 
-#: src/olympia/editors/forms.py:113
+#: src/olympia/editors/forms.py:113 src/olympia/editors/forms.py:253
 msgid "Max. Version"
 msgstr ""
 
@@ -7276,55 +7118,59 @@ msgstr ""
 msgid "Add-on Types"
 msgstr ""
 
-#: src/olympia/editors/forms.py:126 src/olympia/editors/helpers.py:267
+#: src/olympia/editors/forms.py:126 src/olympia/editors/helpers.py:279
 msgid "Platforms"
 msgstr ""
 
+#: src/olympia/editors/forms.py:237
+msgid "Search by add-on name / author email / guid"
+msgstr ""
+
 #. L10n: 0 = platform, 1 = filename, 2 = status message
-#: src/olympia/editors/forms.py:238
+#: src/olympia/editors/forms.py:342
 #, python-format
 msgid "<strong>%s</strong> &middot; %s &middot; %s"
 msgstr ""
 
-#: src/olympia/editors/forms.py:252
+#: src/olympia/editors/forms.py:356
 msgid "Comments:"
 msgstr ""
 
-#: src/olympia/editors/forms.py:256
+#: src/olympia/editors/forms.py:360
 msgid "Operating systems:"
 msgstr ""
 
-#: src/olympia/editors/forms.py:258
+#: src/olympia/editors/forms.py:362
 msgid "Applications:"
 msgstr ""
 
-#: src/olympia/editors/forms.py:260
+#: src/olympia/editors/forms.py:364
 msgid "Notify me the next time this add-on is updated. (Subsequent updates will not generate an email)"
 msgstr ""
 
-#: src/olympia/editors/forms.py:265
+#: src/olympia/editors/forms.py:369
 msgid "Clear Admin Review Flag"
 msgstr ""
 
-#: src/olympia/editors/forms.py:267
+#: src/olympia/editors/forms.py:371
 msgid "Clear more info requested flag"
 msgstr ""
 
-#: src/olympia/editors/forms.py:281
+#: src/olympia/editors/forms.py:385
 msgid "Choose a canned response..."
 msgstr ""
 
 #. L10n: Description of what can be searched for.
-#: src/olympia/editors/forms.py:324
+#: src/olympia/editors/forms.py:423
 msgid "theme name"
 msgstr ""
 
-#: src/olympia/editors/forms.py:350
+#: src/olympia/editors/forms.py:449
 msgid "Someone else is reviewing this theme."
 msgstr ""
 
 #. L10n: Description of what can be searched for.
-#: src/olympia/editors/forms.py:447
+#: src/olympia/editors/forms.py:546
 msgid "app, reviewer, or comment"
 msgstr ""
 
@@ -7340,246 +7186,264 @@ msgstr ""
 msgid "Rejected or Unreviewed"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:123 src/olympia/editors/helpers.py:136
+#: src/olympia/editors/helpers.py:125 src/olympia/editors/helpers.py:138
 msgid "Queue"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:124 src/olympia/editors/templates/editors/base.html:50 src/olympia/editors/templates/editors/base.html:65
+#: src/olympia/editors/helpers.py:126 src/olympia/editors/templates/editors/base.html:50 src/olympia/editors/templates/editors/base.html:65
 msgid "Pending Updates"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:125 src/olympia/editors/templates/editors/base.html:48 src/olympia/editors/templates/editors/base.html:63
+#: src/olympia/editors/helpers.py:127 src/olympia/editors/templates/editors/base.html:48 src/olympia/editors/templates/editors/base.html:63
 msgid "Full Reviews"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:126 src/olympia/editors/templates/editors/base.html:52 src/olympia/editors/templates/editors/base.html:67
+#: src/olympia/editors/helpers.py:128 src/olympia/editors/templates/editors/base.html:52 src/olympia/editors/templates/editors/base.html:67
 msgid "Preliminary Reviews"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:127 src/olympia/editors/templates/editors/base.html:54
+#: src/olympia/editors/helpers.py:129 src/olympia/editors/templates/editors/base.html:54
 msgid "Moderated Reviews"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:128 src/olympia/editors/templates/editors/base.html:46
+#: src/olympia/editors/helpers.py:130 src/olympia/editors/templates/editors/base.html:46
 msgid "Fast Track"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:130
+#: src/olympia/editors/helpers.py:132
 msgid "Pending Themes"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:131 src/olympia/editors/templates/editors/themes/queue.html:4
+#: src/olympia/editors/helpers.py:133 src/olympia/editors/templates/editors/themes/queue.html:4
 msgid "Flagged Themes"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:132
+#: src/olympia/editors/helpers.py:134
 msgid "Update Themes"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:137
+#: src/olympia/editors/helpers.py:139
 msgid "Unlisted Pending Updates"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:138
+#: src/olympia/editors/helpers.py:140
 msgid "Unlisted Full Reviews"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:139
+#: src/olympia/editors/helpers.py:141
 msgid "Unlisted Preliminary Reviews"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:170
+#: src/olympia/editors/helpers.py:142
+msgid "Unlisted All Add-ons"
+msgstr ""
+
+#: src/olympia/editors/helpers.py:173
 msgid "Fast Track ({0})"
 msgid_plural "Fast Track ({0})"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/olympia/editors/helpers.py:175
+#: src/olympia/editors/helpers.py:178
 msgid "Full Review ({0})"
 msgid_plural "Full Reviews ({0})"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/olympia/editors/helpers.py:180
+#: src/olympia/editors/helpers.py:183
 msgid "Pending Update ({0})"
 msgid_plural "Pending Updates ({0})"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/olympia/editors/helpers.py:185
+#: src/olympia/editors/helpers.py:188
 msgid "Preliminary Review ({0})"
 msgid_plural "Preliminary Reviews ({0})"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/olympia/editors/helpers.py:190
+#: src/olympia/editors/helpers.py:193
 msgid "Moderated Review ({0})"
 msgid_plural "Moderated Reviews ({0})"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/olympia/editors/helpers.py:196
+#: src/olympia/editors/helpers.py:199
 msgid "Unlisted Full Review ({0})"
 msgid_plural "Unlisted Full Reviews ({0})"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/olympia/editors/helpers.py:201
+#: src/olympia/editors/helpers.py:204
 msgid "Unlisted Pending Update ({0})"
 msgid_plural "Unlisted Pending Updates ({0})"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/olympia/editors/helpers.py:206
+#: src/olympia/editors/helpers.py:209
 msgid "Unlisted Preliminary Review ({0})"
 msgid_plural "Unlisted Preliminary Reviews ({0})"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/olympia/editors/helpers.py:261
-msgid "Addon"
-msgstr ""
+#: src/olympia/editors/helpers.py:214
+msgid "Unlisted All Add-ons ({0})"
+msgid_plural "Unlisted All Add-ons ({0})"
+msgstr[0] ""
+msgstr[1] ""
 
-#: src/olympia/editors/helpers.py:262
+#: src/olympia/editors/helpers.py:274
 msgid "Type"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:263
+#: src/olympia/editors/helpers.py:275
 msgid "Waiting Time"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:264 src/olympia/editors/templates/editors/review.html:285
+#: src/olympia/editors/helpers.py:276 src/olympia/editors/templates/editors/review.html:285
 msgid "Flags"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:265
+#: src/olympia/editors/helpers.py:277
 msgid "Applications"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:270
+#: src/olympia/editors/helpers.py:282
 msgid "Additional"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:285
+#: src/olympia/editors/helpers.py:302
 msgid "Site Specific"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:287
+#: src/olympia/editors/helpers.py:304
 msgid "Requires External Software"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:289
+#: src/olympia/editors/helpers.py:306
 msgid "Binary Components"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:313
+#: src/olympia/editors/helpers.py:339
 msgid "moments ago"
 msgstr ""
 
 #. L10n: first argument is number of minutes
-#: src/olympia/editors/helpers.py:316
+#: src/olympia/editors/helpers.py:342
 msgid "{0} minute"
 msgid_plural "{0} minutes"
 msgstr[0] ""
 msgstr[1] ""
 
 #. L10n: first argument is number of hours
-#: src/olympia/editors/helpers.py:320
+#: src/olympia/editors/helpers.py:346
 msgid "{0} hour"
 msgid_plural "{0} hours"
 msgstr[0] ""
 msgstr[1] ""
 
 #. L10n: first argument is number of days
-#: src/olympia/editors/helpers.py:324
+#: src/olympia/editors/helpers.py:350
 msgid "{0} day"
 msgid_plural "{0} days"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/olympia/editors/helpers.py:488
+#: src/olympia/editors/helpers.py:364
+msgid "Last Review"
+msgstr ""
+
+#: src/olympia/editors/helpers.py:366
+msgid "Last Update"
+msgstr ""
+
+#: src/olympia/editors/helpers.py:387
+msgid "No Reviews"
+msgstr ""
+
+#: src/olympia/editors/helpers.py:561
 msgid "Push to public"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:490
+#: src/olympia/editors/helpers.py:563
 msgid "Grant full review"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:505
+#: src/olympia/editors/helpers.py:578
 msgid "Request more information"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:508
+#: src/olympia/editors/helpers.py:581
 msgid "Request super-review"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:519
+#: src/olympia/editors/helpers.py:592
 msgid "Grant preliminary review"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:520
+#: src/olympia/editors/helpers.py:593
 msgid "This will mark the files as preliminarily reviewed."
 msgstr ""
 
-#: src/olympia/editors/helpers.py:522
+#: src/olympia/editors/helpers.py:595
 msgid "Use this form to request more information from the author. They will receive an email and be able to answer here. You will be notified by email when they reply."
 msgstr ""
 
-#: src/olympia/editors/helpers.py:526
+#: src/olympia/editors/helpers.py:599
 msgid ""
 "If you have concerns about this add-on's security, copyright issues, or other concerns that an administrator should look into, enter your comments in the area below. They will be sent to "
 "administrators, not the author."
 msgstr ""
 
-#: src/olympia/editors/helpers.py:532
+#: src/olympia/editors/helpers.py:605
 msgid "This will reject the add-on and remove it from the review queue."
 msgstr ""
 
-#: src/olympia/editors/helpers.py:534
-msgid "Make a comment on this version.  The author won't be able to see this."
+#: src/olympia/editors/helpers.py:607
+msgid "Make a comment on this version. The author won't be able to see this."
 msgstr ""
 
-#: src/olympia/editors/helpers.py:538
+#: src/olympia/editors/helpers.py:611
 msgid "This will reject the files and remove them from the review queue."
 msgstr ""
 
-#: src/olympia/editors/helpers.py:542
+#: src/olympia/editors/helpers.py:615
 msgid "This will mark the add-on as preliminarily reviewed. Future versions will undergo preliminary review."
 msgstr ""
 
-#: src/olympia/editors/helpers.py:547
+#: src/olympia/editors/helpers.py:620
 msgid "This will mark the files as preliminarily reviewed. Future versions will undergo preliminary review."
 msgstr ""
 
-#: src/olympia/editors/helpers.py:552
+#: src/olympia/editors/helpers.py:625
 msgid "Retain preliminary review"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:553
+#: src/olympia/editors/helpers.py:626
 msgid "This will retain the add-on as preliminarily reviewed. Future versions will undergo preliminary review."
 msgstr ""
 
-#: src/olympia/editors/helpers.py:558
+#: src/olympia/editors/helpers.py:631
 msgid "This will approve a sandboxed version of a public add-on to appear on the public side."
 msgstr ""
 
-#: src/olympia/editors/helpers.py:561
+#: src/olympia/editors/helpers.py:634
 msgid "This will reject a version of a public add-on and remove it from the queue."
 msgstr ""
 
-#: src/olympia/editors/helpers.py:564
+#: src/olympia/editors/helpers.py:637
 msgid "This will mark the add-on and its most recent version and files as public. Future versions will go into the sandbox until they are reviewed by an editor."
 msgstr ""
 
-#: src/olympia/editors/helpers.py:637
+#: src/olympia/editors/helpers.py:714
 msgid "add-on"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:940 src/olympia/editors/helpers.py:960
+#: src/olympia/editors/helpers.py:1020 src/olympia/editors/helpers.py:1040
 msgid "Flagged"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:944 src/olympia/editors/helpers.py:963
+#: src/olympia/editors/helpers.py:1024 src/olympia/editors/helpers.py:1043
 msgid "Updates"
 msgstr ""
 
@@ -7631,56 +7495,56 @@ msgstr ""
 msgid "A question about your Theme submission"
 msgstr ""
 
-#: src/olympia/editors/views.py:144
+#: src/olympia/editors/views.py:146
 msgid "New Add-ons (Under 5 days)"
 msgstr ""
 
-#: src/olympia/editors/views.py:145
+#: src/olympia/editors/views.py:147
 msgid "Passable (5 to 10 days)"
 msgstr ""
 
-#: src/olympia/editors/views.py:146
+#: src/olympia/editors/views.py:148
 msgid "Overdue (Over 10 days)"
 msgstr ""
 
-#: src/olympia/editors/views.py:532
+#: src/olympia/editors/views.py:539
 msgid "An unknown error occurred"
 msgstr ""
 
-#: src/olympia/editors/views.py:587
+#: src/olympia/editors/views.py:592
 msgid "Self-reviews are not allowed."
 msgstr ""
 
-#: src/olympia/editors/views.py:609
+#: src/olympia/editors/views.py:613
 msgid "Review successfully processed."
 msgstr ""
 
-#: src/olympia/editors/views.py:807
+#: src/olympia/editors/views.py:812
 msgid "was approved"
 msgstr ""
 
-#: src/olympia/editors/views.py:808
+#: src/olympia/editors/views.py:813
 msgid "given preliminary review"
 msgstr ""
 
-#: src/olympia/editors/views.py:809
+#: src/olympia/editors/views.py:814
 msgid "rejected"
 msgstr ""
 
-#: src/olympia/editors/views.py:810
+#: src/olympia/editors/views.py:815
 msgctxt "editors_review_history_nominated_adminreview"
 msgid "escalated"
 msgstr ""
 
-#: src/olympia/editors/views.py:812
+#: src/olympia/editors/views.py:817
 msgid "needs more information"
 msgstr ""
 
-#: src/olympia/editors/views.py:813
+#: src/olympia/editors/views.py:818
 msgid "needs super review"
 msgstr ""
 
-#: src/olympia/editors/views.py:814
+#: src/olympia/editors/views.py:819
 msgid "commented"
 msgstr ""
 
@@ -7725,28 +7589,28 @@ msgstr ""
 msgid "Unlisted Queues"
 msgstr ""
 
-#: src/olympia/editors/templates/editors/base.html:72 src/olympia/editors/templates/editors/performance.html:6
+#: src/olympia/editors/templates/editors/base.html:74 src/olympia/editors/templates/editors/performance.html:6
 msgid "Performance"
 msgstr ""
 
-#: src/olympia/editors/templates/editors/base.html:75 src/olympia/editors/templates/editors/themes/base.html:19 src/olympia/editors/templates/editors/themes/base.html:38
+#: src/olympia/editors/templates/editors/base.html:77 src/olympia/editors/templates/editors/themes/base.html:19 src/olympia/editors/templates/editors/themes/base.html:38
 msgid "Logs"
 msgstr ""
 
-#: src/olympia/editors/templates/editors/base.html:78 src/olympia/editors/templates/editors/reviewlog.html:4 src/olympia/editors/templates/editors/reviewlog.html:27
+#: src/olympia/editors/templates/editors/base.html:80 src/olympia/editors/templates/editors/reviewlog.html:4 src/olympia/editors/templates/editors/reviewlog.html:27
 msgid "Add-on Review Log"
 msgstr ""
 
-#: src/olympia/editors/templates/editors/base.html:80 src/olympia/editors/templates/editors/eventlog.html:4 src/olympia/editors/templates/editors/eventlog.html:8
+#: src/olympia/editors/templates/editors/base.html:82 src/olympia/editors/templates/editors/eventlog.html:4 src/olympia/editors/templates/editors/eventlog.html:8
 #: src/olympia/editors/templates/editors/eventlog_detail.html:4
 msgid "Moderated Review Log"
 msgstr ""
 
-#: src/olympia/editors/templates/editors/base.html:82 src/olympia/editors/templates/editors/beta_signed_log.html:4 src/olympia/editors/templates/editors/beta_signed_log.html:8
+#: src/olympia/editors/templates/editors/base.html:84 src/olympia/editors/templates/editors/beta_signed_log.html:4 src/olympia/editors/templates/editors/beta_signed_log.html:8
 msgid "Signed Beta Files Log"
 msgstr ""
 
-#: src/olympia/editors/templates/editors/base.html:87 src/olympia/editors/templates/editors/includes/daily-message.html:4
+#: src/olympia/editors/templates/editors/base.html:89 src/olympia/editors/templates/editors/includes/daily-message.html:4
 msgid "Announcement"
 msgstr ""
 
@@ -7967,45 +7831,45 @@ msgstr ""
 msgid "clear search"
 msgstr ""
 
-#: src/olympia/editors/templates/editors/queue.html:72 src/olympia/editors/templates/editors/queue.html:122
+#: src/olympia/editors/templates/editors/queue.html:78 src/olympia/editors/templates/editors/queue.html:128
 msgid "Process Reviews"
 msgstr ""
 
-#: src/olympia/editors/templates/editors/queue.html:80
+#: src/olympia/editors/templates/editors/queue.html:86
 msgid "Moderation actions:"
 msgstr ""
 
-#: src/olympia/editors/templates/editors/queue.html:90
+#: src/olympia/editors/templates/editors/queue.html:96
 #, python-format
 msgid "by %(user)s on %(date)s %(stars)s (%(locale)s)"
 msgstr ""
 
-#: src/olympia/editors/templates/editors/queue.html:106
+#: src/olympia/editors/templates/editors/queue.html:112
 #, python-format
 msgid "<strong>%(reason)s</strong> <span class=\"light\">Flagged by %(user)s on %(date)s</span>"
 msgstr ""
 
-#: src/olympia/editors/templates/editors/queue.html:119
-msgid "All reviews have been moderated.  Good work!"
+#: src/olympia/editors/templates/editors/queue.html:125
+msgid "All reviews have been moderated. Good work!"
 msgstr ""
 
-#: src/olympia/editors/templates/editors/queue.html:161
+#: src/olympia/editors/templates/editors/queue.html:167
 msgid "Version Notes / Notes for Reviewer"
 msgstr ""
 
-#: src/olympia/editors/templates/editors/queue.html:169
+#: src/olympia/editors/templates/editors/queue.html:175
 msgid "There are currently no add-ons of this type to review."
 msgstr ""
 
-#: src/olympia/editors/templates/editors/queue.html:181 src/olympia/editors/templates/editors/themes/queue_list.html:85
+#: src/olympia/editors/templates/editors/queue.html:187 src/olympia/editors/templates/editors/themes/queue_list.html:85
 msgid "Helpful Links:"
 msgstr ""
 
-#: src/olympia/editors/templates/editors/queue.html:182
+#: src/olympia/editors/templates/editors/queue.html:188
 msgid "Add-on Policy"
 msgstr ""
 
-#: src/olympia/editors/templates/editors/queue.html:184
+#: src/olympia/editors/templates/editors/queue.html:190
 msgid "Editors' Guide"
 msgstr ""
 
@@ -8068,10 +7932,7 @@ msgid "<strong>Warning!</strong> Another user was viewing this page before you."
 msgstr ""
 
 #: src/olympia/editors/templates/editors/review.html:237
-msgid ""
-"The whiteboard is the place to exchange information relevant to\n"
-"               this addon (whatever the version), between the developer and the\n"
-"               editor. This is visible and editable by both."
+msgid "The whiteboard is the place to exchange information relevant to this addon (whatever the version), between the developer and the editor. This is visible and editable by both."
 msgstr ""
 
 #: src/olympia/editors/templates/editors/review.html:241
@@ -8345,7 +8206,7 @@ msgstr ""
 msgid "Describe your reason for flagging"
 msgstr ""
 
-#: src/olympia/files/forms.py:88
+#: src/olympia/files/forms.py:90
 msgid "Cannot diff a version against itself"
 msgstr ""
 
@@ -8380,51 +8241,51 @@ msgstr ""
 msgid "There was an error accessing file %s."
 msgstr ""
 
-#: src/olympia/files/utils.py:343
+#: src/olympia/files/utils.py:340
 msgid "Could not parse uploaded file."
 msgstr ""
 
-#: src/olympia/files/utils.py:380
+#: src/olympia/files/utils.py:377
 msgid "Invalid file name in archive: {0}"
 msgstr ""
 
-#: src/olympia/files/utils.py:388
+#: src/olympia/files/utils.py:385
 msgid "File exceeding size limit in archive: {0}"
 msgstr ""
 
-#: src/olympia/files/utils.py:439
+#: src/olympia/files/utils.py:436
 msgid "Invalid archive."
 msgstr ""
 
-#: src/olympia/files/utils.py:529 src/olympia/files/utils.py:532
+#: src/olympia/files/utils.py:526 src/olympia/files/utils.py:529
 msgid "Could not parse the manifest file."
 msgstr ""
 
-#: src/olympia/files/utils.py:551
+#: src/olympia/files/utils.py:548
 msgid "Could not find an add-on ID."
 msgstr ""
 
-#: src/olympia/files/utils.py:554
+#: src/olympia/files/utils.py:551
 msgid "Add-on ID must be 64 characters or less."
 msgstr ""
 
-#: src/olympia/files/utils.py:556
+#: src/olympia/files/utils.py:553
 msgid "Add-on ID doesn't match add-on."
 msgstr ""
 
-#: src/olympia/files/utils.py:564
+#: src/olympia/files/utils.py:561
 msgid "Duplicate add-on ID found."
 msgstr ""
 
-#: src/olympia/files/utils.py:567
+#: src/olympia/files/utils.py:564
 msgid "Version numbers should have fewer than 32 characters."
 msgstr ""
 
-#: src/olympia/files/utils.py:570
+#: src/olympia/files/utils.py:567
 msgid "Version numbers should only contain letters, numbers, and these punctuation characters: +*.-_."
 msgstr ""
 
-#: src/olympia/files/utils.py:587
+#: src/olympia/files/utils.py:584
 msgid "<em:type> doesn't match add-on"
 msgstr ""
 
@@ -8523,6 +8384,10 @@ msgstr ""
 
 #: src/olympia/files/templates/files/viewer.html:134
 msgid "Fetching file."
+msgstr ""
+
+#: src/olympia/legacy_api/views.py:255
+msgid "Not implemented yet."
 msgstr ""
 
 #: src/olympia/lib/constants.py:6
@@ -9181,10 +9046,6 @@ msgstr ""
 msgid "Zimbabwe Dollar"
 msgstr ""
 
-#: src/olympia/lib/video/ffmpeg.py:112 src/olympia/lib/video/totem.py:81
-msgid "Videos must be in WebM."
-msgstr ""
-
 #: src/olympia/pages/templates/pages/about.lhtml:3 src/olympia/pages/templates/pages/about.lhtml:10
 msgid "About Mozilla Add-ons"
 msgstr ""
@@ -9196,7 +9057,7 @@ msgstr ""
 #: src/olympia/pages/templates/pages/about.lhtml:13
 msgid ""
 "addons.mozilla.org, commonly known as \"AMO\", is Mozilla's official site for add-ons to Mozilla software, such as Firefox, Thunderbird, and SeaMonkey. Add-ons let you add new features and change "
-"the way your browser or application works.  Take a look around and explore the thousands of ways to customize the way you do things online."
+"the way your browser or application works. Take a look around and explore the thousands of ways to customize the way you do things online."
 msgstr ""
 
 #: src/olympia/pages/templates/pages/about.lhtml:19
@@ -9541,7 +9402,7 @@ msgstr ""
 msgid ""
 "Yes. It's possible, but some of the functionality provided by these libraries are available through XPCOM, XUL, and JavaScript. In addition, authors should take care if libraries modify primitive "
 "object prototypes (String.prototype, Date.prototype, etc.) and/or define global functions (eg. the $ function). These are prone to cause conflict with other add-ons, in particular if different add-"
-"ons use different versions of libraries and so on. Developers need to be very, very careful with using them.  Mozilla does not offer documentation on using them to build add-ons."
+"ons use different versions of libraries and so on. Developers need to be very, very careful with using them. Mozilla does not offer documentation on using them to build add-ons."
 msgstr ""
 
 #: src/olympia/pages/templates/pages/dev_faq.html:165
@@ -9655,8 +9516,8 @@ msgstr ""
 #, python-format
 msgid ""
 "Yes. Many developers choose to host their own add-ons. Choosing to host your add-on on <a href=\"%(amo_url)s\">Mozilla's add-on site</a>, though, allows for much greater exposure to your add-on due "
-"to the large volume of visitors to the site.  <a href=\"%(md_url)s\">mozdev.org</a> offers free project hosting for Mozilla applications and extensions providing developers with tools to help "
-"manage source code, version control, bug tracking and documentation."
+"to the large volume of visitors to the site. <a href=\"%(md_url)s\">mozdev.org</a> offers free project hosting for Mozilla applications and extensions providing developers with tools to help manage "
+"source code, version control, bug tracking and documentation."
 msgstr ""
 
 #: src/olympia/pages/templates/pages/dev_faq.html:277
@@ -9704,7 +9565,7 @@ msgstr ""
 #: src/olympia/pages/templates/pages/dev_faq.html:314
 #, python-format
 msgid ""
-"Yes. Mozilla's <a href=\"%(p_url)s\">Add-on Policy</a> describes what is an acceptable submission. This policy is subject to change without notice.  In addition, the AMO editorial team uses the <a "
+"Yes. Mozilla's <a href=\"%(p_url)s\">Add-on Policy</a> describes what is an acceptable submission. This policy is subject to change without notice. In addition, the AMO editorial team uses the <a "
 "href=\"%(g_url)s\">Editors Reviewing Guide</a> to ensure that your add-on meets specific guidelines for functionality and security."
 msgstr ""
 
@@ -9821,7 +9682,7 @@ msgstr ""
 #: src/olympia/pages/templates/pages/dev_faq.html:434
 #, python-format
 msgid ""
-"This is why it's very important to read the <a href=\"%(g_url)s\">Editors Reviewing Guide</a> to ensure that your add-on is setup as expected.  It's also a good idea to read the blog post, <a href="
+"This is why it's very important to read the <a href=\"%(g_url)s\">Editors Reviewing Guide</a> to ensure that your add-on is setup as expected. It's also a good idea to read the blog post, <a href="
 "\"%(blog_url)s\">Successfully Getting your Add-on Reviewed</a> which provides excellent insight into ensuring a smooth review of your add-on."
 msgstr ""
 
@@ -9928,7 +9789,7 @@ msgstr ""
 
 #: src/olympia/pages/templates/pages/dev_faq.html:572
 msgid ""
-"Free Software Foundation provides short summaries of the key open source licenses, including whether the license qualifies as a free software license or a copyleft license.  Also includes a "
+"Free Software Foundation provides short summaries of the key open source licenses, including whether the license qualifies as a free software license or a copyleft license. Also includes a "
 "discussion of what constitutes a free software license or a copyleft license (e.g., a Copyleft license is a general method for making a program or other work free, and requiring all modified and "
 "extended versions of the program to be free as well.)"
 msgstr ""
@@ -10106,19 +9967,13 @@ msgid "Add-on Gallery"
 msgstr ""
 
 #: src/olympia/pages/templates/pages/faq.html:171
-msgid ""
-"How do I choose between add-ons that seem to do the same\n"
-"    thing?"
+msgid "How do I choose between add-ons that seem to do the same thing?"
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:173
+#: src/olympia/pages/templates/pages/faq.html:172
 msgid ""
-"There are often several add-ons that have similar features. To\n"
-"    figure out which is right for you, read the entire description of the\n"
-"    add-on and view its screenshots. If there are still several in the running,\n"
-"    read through the add-on's ratings, user reviews, and statistics to see\n"
-"    which is most liked by other users. Remember that you can also just try\n"
-"    out both and see which you like better."
+"There are often several add-ons that have similar features. To figure out which is right for you, read the entire description of the add-on and view its screenshots. If there are still several in "
+"the running, read through the add-on's ratings, user reviews, and statistics to see which is most liked by other users. Remember that you can also just try out both and see which you like better."
 msgstr ""
 
 #: src/olympia/pages/templates/pages/faq.html:180
@@ -10159,80 +10014,67 @@ msgid "How much do add-ons cost to purchase?"
 msgstr ""
 
 #: src/olympia/pages/templates/pages/faq.html:207
-msgid ""
-"Add-ons hosted in our gallery are free unless clearly marked\n"
-"    otherwise."
+msgid "Add-ons hosted in our gallery are free unless clearly marked otherwise."
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:210
+#: src/olympia/pages/templates/pages/faq.html:209
 msgid "What does it mean when an add-on asks for contributions?"
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:211
+#: src/olympia/pages/templates/pages/faq.html:210
 msgid ""
-"Some add-on authors request users who enjoy an add-on to\n"
-"        contribute to its development by making a monetary contribution. These\n"
-"        contributions go directly to the developer unless a third party is\n"
-"        indicated, such as the non-profit Mozilla Foundation."
+"Some add-on authors request users who enjoy an add-on to contribute to its development by making a monetary contribution. These contributions go directly to the developer unless a third party is "
+"indicated, such as the non-profit Mozilla Foundation."
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:216
+#: src/olympia/pages/templates/pages/faq.html:215
 msgid "What are beta add-ons?"
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:218
+#: src/olympia/pages/templates/pages/faq.html:217
 msgid ""
-"Beta add-ons are unreviewed versions which represent the\n"
-"        latest work of an add-on author. While different authors have different\n"
-"        standards for beta code quality, you should assume that these add-ons\n"
-"        are less stable than the general add-on releases."
+"Beta add-ons are unreviewed versions which represent the latest work of an add-on author. While different authors have different standards for beta code quality, you should assume that these add-"
+"ons are less stable than the general add-on releases."
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:222
+#: src/olympia/pages/templates/pages/faq.html:221
 msgid ""
 "Please note that when you install an add-on from the \"Beta Version\" section of an add-on's listing, you will continue to receive updates for that add-on as they become available. Like the initial "
 "version you installed, all beta releases are unreviewed by Mozilla and may harm your computer."
 msgstr ""
 
+#: src/olympia/pages/templates/pages/faq.html:228
+msgid "What does it mean when an add-on is flagged as slow?"
+msgstr ""
+
 #: src/olympia/pages/templates/pages/faq.html:229
-msgid ""
-"What does it mean when an add-on is flagged as\n"
-"    slow?"
+msgid "Most add-ons load code and resources at the same time Firefox is starting up. In most cases the impact in start-up time is minimal, but some add-ons can cause a noticeable slowdown."
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:231
-msgid ""
-"Most add-ons load code and resources at the same time Firefox\n"
-"        is starting up. In most cases the impact in start-up time is minimal,\n"
-"        but some add-ons can cause a noticeable slowdown."
-msgstr ""
-
-#: src/olympia/pages/templates/pages/faq.html:236
+#: src/olympia/pages/templates/pages/faq.html:234
 msgid "How do I report an inappropriate or spam user review?"
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:237
+#: src/olympia/pages/templates/pages/faq.html:235
 msgid ""
-"To report a user review of an add-on, log in with your account\n"
-"    and visit the add-on's reviews page. Find the review you wish to report,\n"
-"    click \"Report this review\" and select a reason. Our editorial team will\n"
-"    investigate the review and take appropriate action."
+"To report a user review of an add-on, log in with your account and visit the add-on's reviews page. Find the review you wish to report, click \"Report this review\" and select a reason. Our "
+"editorial team will investigate the review and take appropriate action."
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:242
+#: src/olympia/pages/templates/pages/faq.html:240
 msgid "How do I report a bug or contact the Mozilla Add-ons team?"
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:243
+#: src/olympia/pages/templates/pages/faq.html:241
 #, python-format
 msgid "Please visit our <a href=\"%(contact_url)s\">Contact page</a>."
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:246
+#: src/olympia/pages/templates/pages/faq.html:244
 msgid "What is a Source Code License?"
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:247
+#: src/olympia/pages/templates/pages/faq.html:245
 #, python-format
 msgid ""
 "The source code used to create an add-on is an exclusive copyright of the add-on author, unless otherwise declared in a source code license. Many add-ons on this site have <a href=\"%(url)s\" lang="
@@ -10240,60 +10082,60 @@ msgid ""
 "the GPL or BSD licenses instead of making up their own."
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:256
+#: src/olympia/pages/templates/pages/faq.html:254
 #, python-format
 msgid "Firefox and other Mozilla software are <a href=\"%(url)s\">open source</a>."
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:264
+#: src/olympia/pages/templates/pages/faq.html:262
 msgid "Collections and Favorites"
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:267
+#: src/olympia/pages/templates/pages/faq.html:265
 msgid "What is a collection?"
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:268
+#: src/olympia/pages/templates/pages/faq.html:266
 msgid "Collections are groups of related add-ons created by users to share."
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:270
+#: src/olympia/pages/templates/pages/faq.html:268
 msgid "What is the My Favorites collection?"
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:271
+#: src/olympia/pages/templates/pages/faq.html:269
 msgid "Favorite add-ons are add-ons that you have bookmarked to easily get back to later. You can add an add-on to your favorites collection by clicking \"Add to favorites\" on its details page."
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:275 src/olympia/templates/menu_links.html:13 src/olympia/templates/impala/header_title.html:17
+#: src/olympia/pages/templates/pages/faq.html:273 src/olympia/templates/menu_links.html:13 src/olympia/templates/impala/header_title.html:17
 msgid "Mobile Add-ons"
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:278
+#: src/olympia/pages/templates/pages/faq.html:276
 msgid "What are mobile add-ons?"
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:279
+#: src/olympia/pages/templates/pages/faq.html:277
 #, python-format
 msgid ""
 "Mobile add-ons work with <a href=\"%(mobile_url)s\">Firefox for Mobile</a> and add or modify functionality just like desktop add-ons. You can find add-ons that work with Firefox for Mobile in our "
 "<a href=\"%(gallery_url)s\">gallery</a>."
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:288
+#: src/olympia/pages/templates/pages/faq.html:286
 msgid "Developer Topics"
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:289
+#: src/olympia/pages/templates/pages/faq.html:287
 #, python-format
 msgid "Please see our <a href=\"%(faq_url)s\">Developer FAQ</a> and <a href=\"%(hub_url)s\">Developer Hub</a> for answers to add-on developer-related questions."
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:294
+#: src/olympia/pages/templates/pages/faq.html:292
 msgid "Still have questions?"
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:295
+#: src/olympia/pages/templates/pages/faq.html:293
 #, python-format
 msgid "For general Firefox support, visit our <a href=\"%(sumo_url)s\">support website</a>. For general add-on and website questions, visit our <a href=\"%(forum_url)s\">forum</a>."
 msgstr ""
@@ -10431,7 +10273,7 @@ msgstr ""
 
 #: src/olympia/pages/templates/pages/sunbird.html:29
 msgid ""
-"Development on the Sunbird project has halted and its final release was on March 30, 2010.  We've been proud to host Sunbird add-ons on this site but as the project is no longer maintained we have "
+"Development on the Sunbird project has halted and its final release was on March 30, 2010. We've been proud to host Sunbird add-ons on this site but as the project is no longer maintained we have "
 "disabled our support for the add-ons."
 msgstr ""
 
@@ -10509,7 +10351,7 @@ msgstr ""
 #, python-format
 msgid ""
 "<h2>Keep these tips in mind:</h2> <ul> <li> Write like you're telling a friend about your experience with the add-on. Give specifics and helpful details, such as what features you liked and/or "
-"disliked, how easy to use it is, and any disadvantages it has.  Avoid generic language such as calling it \"Great\" or \"Bad\" unless you can give reasons why you believe this is so. </li> <li> "
+"disliked, how easy to use it is, and any disadvantages it has. Avoid generic language such as calling it \"Great\" or \"Bad\" unless you can give reasons why you believe this is so. </li> <li> "
 "Please do not post bug reports in reviews. We do not make your email address available to add-on developers and they may need to contact you to help resolve your issue. See the <a href=\"%(support)s"
 "\">support section</a> to find out where to get assistance for this add-on. </li> <li>Please keep reviews clean, avoid the use of improper language and do not post any personal information. </li> </"
 "ul> <p>Please read the <a href=\"%(guide)s\" target=\"_blank\">Review Guidelines</a> for more detail about user add-on reviews.</p>"
@@ -10745,16 +10587,16 @@ msgstr ""
 
 #. L10n: {0} is an application, such as Firefox. This means "any version of
 #. Firefox."
-#: src/olympia/search/views.py:554
+#: src/olympia/search/views.py:547
 msgid "Any {0}"
 msgstr ""
 
 #. L10n: "All Systems" means show everything regardless of platform.
-#: src/olympia/search/views.py:589
+#: src/olympia/search/views.py:582
 msgid "All Systems"
 msgstr ""
 
-#: src/olympia/search/views.py:600
+#: src/olympia/search/views.py:593
 msgid "All Tags"
 msgstr ""
 
@@ -10928,31 +10770,31 @@ msgstr ""
 msgid "Share this Collection"
 msgstr ""
 
-#: src/olympia/signing/views.py:30 src/olympia/templates/base.html:75 src/olympia/templates/impala/base.html:115
+#: src/olympia/signing/views.py:33 src/olympia/templates/base.html:71 src/olympia/templates/impala/base.html:112
 msgid "Some features are temporarily disabled while we perform website maintenance. We'll be back to full capacity shortly."
 msgstr ""
 
-#: src/olympia/signing/views.py:53
+#: src/olympia/signing/views.py:56
 msgid "Could not find add-on with id \"{}\"."
 msgstr ""
 
-#: src/olympia/signing/views.py:67
+#: src/olympia/signing/views.py:70
 msgid "You do not own this addon."
 msgstr ""
 
-#: src/olympia/signing/views.py:82
+#: src/olympia/signing/views.py:87
 msgid "Missing \"upload\" key in multipart file data."
 msgstr ""
 
-#: src/olympia/signing/views.py:96
+#: src/olympia/signing/views.py:101
 msgid "Version does not match the manifest file."
 msgstr ""
 
-#: src/olympia/signing/views.py:100
+#: src/olympia/signing/views.py:105
 msgid "Version already exists."
 msgstr ""
 
-#: src/olympia/signing/views.py:136
+#: src/olympia/signing/views.py:141
 msgid "No uploaded file for that addon and version."
 msgstr ""
 
@@ -11065,89 +10907,89 @@ msgstr ""
 msgid "Statistics Dashboard :: Add-ons for {0}"
 msgstr ""
 
-#: src/olympia/stats/templates/stats/stats.html:30
-msgid "Controls:"
-msgstr ""
-
-#: src/olympia/stats/templates/stats/stats.html:33
-msgid "reset zoom"
-msgstr ""
-
-#: src/olympia/stats/templates/stats/stats.html:40
-msgid "Group by:"
-msgstr ""
-
-#: src/olympia/stats/templates/stats/stats.html:42
-msgid "day"
-msgstr ""
-
-#: src/olympia/stats/templates/stats/stats.html:45
-msgid "week"
-msgstr ""
-
-#: src/olympia/stats/templates/stats/stats.html:48
-msgid "month"
-msgstr ""
-
-#: src/olympia/stats/templates/stats/stats.html:54
-msgid "For last:"
-msgstr ""
-
-#: src/olympia/stats/templates/stats/stats.html:57
-msgid "7 days"
-msgstr ""
-
-#: src/olympia/stats/templates/stats/stats.html:60
-msgid "30 days"
-msgstr ""
-
-#: src/olympia/stats/templates/stats/stats.html:63
-msgid "90 days"
-msgstr ""
-
-#: src/olympia/stats/templates/stats/stats.html:66
-msgid "365 days"
-msgstr ""
-
-#: src/olympia/stats/templates/stats/stats.html:69
-msgid "Custom..."
-msgstr ""
-
 #. {0} is an add-on name
-#: src/olympia/stats/templates/stats/stats.html:88 src/olympia/stats/templates/stats/stats.html:91
+#: src/olympia/stats/templates/stats/stats.html:44 src/olympia/stats/templates/stats/stats.html:47
 msgid "Statistics for {0}"
 msgstr ""
 
-#: src/olympia/stats/templates/stats/stats.html:94
+#: src/olympia/stats/templates/stats/stats.html:50
 msgid "Statistics Dashboard"
 msgstr ""
 
-#: src/olympia/stats/templates/stats/stats.html:104
+#: src/olympia/stats/templates/stats/stats.html:57
+msgid "Controls:"
+msgstr ""
+
+#: src/olympia/stats/templates/stats/stats.html:60
+msgid "reset zoom"
+msgstr ""
+
+#: src/olympia/stats/templates/stats/stats.html:67
+msgid "Group by:"
+msgstr ""
+
+#: src/olympia/stats/templates/stats/stats.html:69
+msgid "day"
+msgstr ""
+
+#: src/olympia/stats/templates/stats/stats.html:72
+msgid "week"
+msgstr ""
+
+#: src/olympia/stats/templates/stats/stats.html:75
+msgid "month"
+msgstr ""
+
+#: src/olympia/stats/templates/stats/stats.html:81
+msgid "For last:"
+msgstr ""
+
+#: src/olympia/stats/templates/stats/stats.html:84
+msgid "7 days"
+msgstr ""
+
+#: src/olympia/stats/templates/stats/stats.html:87
+msgid "30 days"
+msgstr ""
+
+#: src/olympia/stats/templates/stats/stats.html:90
+msgid "90 days"
+msgstr ""
+
+#: src/olympia/stats/templates/stats/stats.html:93
+msgid "365 days"
+msgstr ""
+
+#: src/olympia/stats/templates/stats/stats.html:96
+msgid "Custom..."
+msgstr ""
+
+#: src/olympia/stats/templates/stats/stats.html:106
 msgid "Statistics processing is currently disabled, so recent data is unavailable. The statistics are still being collected and this page will be updated soon with the missing data."
 msgstr ""
 
-#: src/olympia/stats/templates/stats/stats.html:110
+#: src/olympia/stats/templates/stats/stats.html:112
 msgid "Loading the latest data&hellip;"
 msgstr ""
 
-#: src/olympia/stats/templates/stats/stats.html:142 src/olympia/stats/templates/stats/reports/overview.html:25 src/olympia/stats/templates/stats/reports/overview.html:37
+#: src/olympia/stats/templates/stats/stats.html:144 src/olympia/stats/templates/stats/reports/overview.html:25 src/olympia/stats/templates/stats/reports/overview.html:37
 #: src/olympia/stats/templates/stats/reports/overview.html:49
 msgid "No data available."
 msgstr ""
 
-#: src/olympia/stats/templates/stats/stats.html:177
+#: src/olympia/stats/templates/stats/stats.html:179
 msgid "This dashboard is currently <b>public</b>."
 msgstr ""
 
-#: src/olympia/stats/templates/stats/stats.html:179
+#: src/olympia/stats/templates/stats/stats.html:181
 msgid "Contribution stats are currently <b>private</b>."
 msgstr ""
 
-#: src/olympia/stats/templates/stats/stats.html:182
+#: src/olympia/stats/templates/stats/stats.html:184
 msgid "This dashboard is currently <b>private</b>."
 msgstr ""
 
-#: src/olympia/stats/templates/stats/stats.html:185
+#: src/olympia/stats/templates/stats/stats.html:187
 msgid "Change settings."
 msgstr ""
 
@@ -11299,15 +11141,6 @@ msgstr ""
 msgid "Application versions by Date"
 msgstr ""
 
-#: src/olympia/tags/templates/tags/top_cloud.html:4
-msgid "Top {0} Tags"
-msgstr ""
-
-#. {0} is the current application name
-#: src/olympia/tags/templates/tags/top_cloud.html:14
-msgid "{0} Top Tags"
-msgstr ""
-
 #: src/olympia/templates/amo_footer.html:6 src/olympia/templates/includes/lang_switcher.html:2
 msgid "Other languages"
 msgstr ""
@@ -11316,11 +11149,11 @@ msgstr ""
 msgid "Mozilla Add-ons"
 msgstr ""
 
-#: src/olympia/templates/base.html:91 src/olympia/templates/impala/base.html:81
+#: src/olympia/templates/base.html:89 src/olympia/templates/impala/base.html:78
 msgid "Find add-ons for other applications"
 msgstr ""
 
-#: src/olympia/templates/base.html:92 src/olympia/templates/impala/base.html:81
+#: src/olympia/templates/base.html:90 src/olympia/templates/impala/base.html:78
 msgid "Other Applications"
 msgstr ""
 
@@ -11345,7 +11178,7 @@ msgid "View Mobile Site"
 msgstr ""
 
 #: src/olympia/templates/copyright.html:7
-msgid "Site Status "
+msgid "Site Status"
 msgstr ""
 
 #: src/olympia/templates/footer.html:3
@@ -11445,35 +11278,35 @@ msgstr ""
 msgid "<a href=\"%(reg)s\">Register</a> or <a href=\"%(login)s\">Log in</a>"
 msgstr ""
 
-#: src/olympia/templates/impala/base.html:126
+#: src/olympia/templates/impala/base.html:123
 #, python-format
 msgid "To try the thousands of add-ons available here, download <a href=\"%(url)s\">Mozilla Firefox</a>, a fast, free way to surf the Web!"
 msgstr ""
 
-#: src/olympia/templates/impala/base.html:138
+#: src/olympia/templates/impala/base.html:135
 #, python-format
 msgid "Add-ons is switching to Firefox Accounts for login. <a href=\"%(url)s\" class=\"fxa-login\">Sign in now to transfer your account.</a>"
 msgstr ""
 
 #. {0} is an application, such as Firefox.
-#: src/olympia/templates/impala/base.html:148
+#: src/olympia/templates/impala/base.html:145
 msgid "Welcome to {0} Add-ons."
 msgstr ""
 
-#: src/olympia/templates/impala/base.html:151
+#: src/olympia/templates/impala/base.html:148
 msgid "Choose from thousands of extra features and styles to make Firefox your own."
 msgstr ""
 
-#: src/olympia/templates/impala/base.html:156
+#: src/olympia/templates/impala/base.html:153
 #, python-format
 msgid "Add extra features and styles to make %(app)s your own."
 msgstr ""
 
-#: src/olympia/templates/impala/base.html:164
+#: src/olympia/templates/impala/base.html:161
 msgid "On the go?"
 msgstr ""
 
-#: src/olympia/templates/impala/base.html:166
+#: src/olympia/templates/impala/base.html:163
 msgid "Check out our <a class=\"mobile-link\" href=\"#\">Mobile Add-ons site</a>."
 msgstr ""
 
@@ -11697,19 +11530,19 @@ msgstr ""
 
 #. L10n: {id} will be something like "13ad6a", just a random number
 #. to differentiate this user from other anonymous users.
-#: src/olympia/users/models.py:353
+#: src/olympia/users/models.py:362
 msgid "Anonymous user {id}"
 msgstr ""
 
-#: src/olympia/users/models.py:410
+#: src/olympia/users/models.py:419
 msgid "Your account has been restricted"
 msgstr ""
 
-#: src/olympia/users/models.py:480
+#: src/olympia/users/models.py:489
 msgid "Please confirm your email address"
 msgstr ""
 
-#: src/olympia/users/models.py:506
+#: src/olympia/users/models.py:515
 msgid "My Mobile Add-ons"
 msgstr ""
 
@@ -11986,7 +11819,7 @@ msgstr ""
 
 #: src/olympia/users/templates/users/edit.html:70
 #, python-format
-msgid "Change your password.  If you forgot your password, you can <a href=\"%(reset_url)s\">use the reset form</a>."
+msgid "Change your password. If you forgot your password, you can <a href=\"%(reset_url)s\">use the reset form</a>."
 msgstr ""
 
 #: src/olympia/users/templates/users/edit.html:76
@@ -12006,7 +11839,7 @@ msgid "Profile"
 msgstr ""
 
 #: src/olympia/users/templates/users/edit.html:100
-msgid "Give us a bit more information about yourself.  All these fields are optional, but they'll help other users get to know you better."
+msgid "Give us a bit more information about yourself. All these fields are optional, but they'll help other users get to know you better."
 msgstr ""
 
 #: src/olympia/users/templates/users/edit.html:124
@@ -12222,7 +12055,7 @@ msgid "Confirm password"
 msgstr ""
 
 #: src/olympia/users/templates/users/pwreset_confirm.html:47
-msgid "The password reset link was invalid, possibly because it has already been used.  Please request a new password reset."
+msgid "The password reset link was invalid, possibly because it has already been used. Please request a new password reset."
 msgstr ""
 
 #: src/olympia/users/templates/users/pwreset_request.html:15
@@ -12408,7 +12241,7 @@ msgstr ""
 
 #: src/olympia/users/templates/users/unsubscribe.html:30
 #, python-format
-msgid "Unfortunately, we weren't able to unsubscribe you.  The link you clicked is invalid. However, you can unsubscribe still unsubscribe on your <a href=\"%(edit_url)s\">edit profile page</a>."
+msgid "Unfortunately, we weren't able to unsubscribe you. The link you clicked is invalid. However, you can unsubscribe still unsubscribe on your <a href=\"%(edit_url)s\">edit profile page</a>."
 msgstr ""
 
 #: src/olympia/users/templates/users/vcard.html:2
@@ -12462,15 +12295,15 @@ msgstr ""
 msgid "Version History with Changelogs"
 msgstr ""
 
-#: src/olympia/versions/models.py:314
+#: src/olympia/versions/models.py:313
 msgid "Add-on uses binary components."
 msgstr ""
 
-#: src/olympia/versions/models.py:317
+#: src/olympia/versions/models.py:316
 msgid "Add-on has opted into strict compatibility checking."
 msgstr ""
 
-#: src/olympia/versions/models.py:715
+#: src/olympia/versions/models.py:711
 msgid "{app} {min} and later"
 msgstr ""
 
@@ -12545,4 +12378,8 @@ msgstr ""
 
 #: src/olympia/zadmin/forms.py:105
 msgid "Log emails instead of sending"
+msgstr ""
+
+#: src/olympia/zadmin/forms.py:215
+msgid "Deleted versions can`t be changed."
 msgstr ""

--- a/locale/mk/LC_MESSAGES/djangojs.po
+++ b/locale/mk/LC_MESSAGES/djangojs.po
@@ -1,1216 +1,1236 @@
-
 #, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2016-02-24 21:23+0000\n"
+"POT-Creation-Date: 2016-04-18 15:47+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
+"Language: \n"
 "MIME-Version: 1.0\n"
-"Content-Type: text/plain; charset=utf-8\n"
+"Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Generated-By: Babel 2.2.0\n"
 
-#: static/js/common/ratingwidget.js:31
+#: static/js/common-all.js:1426 static/js/impala-all.js:1511 static/js/zamboni/discovery-all.js:12598 static/js/zamboni/init.js:28 static/js/zamboni/mobile-all.js:14945
+msgid "This feature is temporarily disabled while we perform website maintenance. Please check back a little later."
+msgstr ""
+
+#. L10n: {0} is an app name like Firefox.
+#: static/js/common-all.js:1837 static/js/impala-all.js:1922 static/js/zamboni/buttons.js:73 static/js/zamboni/discovery-all.js:13108
+msgid "Accept and Install"
+msgstr ""
+
+#: static/js/common-all.js:1837 static/js/impala-all.js:1922 static/js/zamboni/buttons.js:73 static/js/zamboni/discovery-all.js:13108
+msgid "Add to {0}"
+msgstr ""
+
+#: static/js/common-all.js:1842 static/js/impala-all.js:1927 static/js/zamboni/buttons.js:78 static/js/zamboni/discovery-all.js:13113
+msgid "Download Now"
+msgstr ""
+
+#: static/js/common-all.js:1883 static/js/impala-all.js:1968 static/js/zamboni/buttons.js:119 static/js/zamboni/discovery-all.js:13154
+msgid "Add-on has not been updated to support default-to-compatible."
+msgstr ""
+
+#: static/js/common-all.js:1888 static/js/impala-all.js:1973 static/js/zamboni/buttons.js:124 static/js/zamboni/discovery-all.js:13159
+msgid "You need to be using Firefox 10.0 or higher."
+msgstr ""
+
+#: static/js/common-all.js:1900 static/js/impala-all.js:1985 static/js/zamboni/buttons.js:136 static/js/zamboni/discovery-all.js:13171
+msgid "Mozilla has marked this version as incompatible with your Firefox version."
+msgstr ""
+
+#. L10n: {0} is an platform like Windows or Linux.
+#: static/js/common-all.js:1981 static/js/impala-all.js:2066 static/js/zamboni/buttons.js:217 static/js/zamboni/discovery-all.js:13252
+msgid "Install for {0} anyway"
+msgstr ""
+
+#: static/js/common-all.js:1981 static/js/impala-all.js:2066 static/js/zamboni/buttons.js:217 static/js/zamboni/discovery-all.js:13252
+msgid "Download for {0} anyway"
+msgstr ""
+
+#: static/js/common-all.js:2038 static/js/impala-all.js:2123 static/js/zamboni/buttons.js:274 static/js/zamboni/discovery-all.js:13309
+msgid "Not available for your platform"
+msgstr ""
+
+#. L10n: {0} is an app name, {1} is the app version.
+#: static/js/common-all.js:2049 static/js/common-all.js:2086 static/js/impala-all.js:2134 static/js/impala-all.js:2171 static/js/zamboni/buttons.js:286 static/js/zamboni/buttons.js:324
+#: static/js/zamboni/discovery-all.js:13320 static/js/zamboni/discovery-all.js:13357
+msgid "Not available for {0} {1}"
+msgstr ""
+
+#: static/js/common-all.js:2112 static/js/impala-all.js:2197 static/js/zamboni/buttons.js:351 static/js/zamboni/discovery-all.js:13383
+msgid "Works with {app} {min} - {max}"
+msgstr ""
+
+#: static/js/common-all.js:2114 static/js/impala-all.js:2199 static/js/zamboni/buttons.js:353 static/js/zamboni/discovery-all.js:13385
+msgid "View other versions"
+msgstr ""
+
+#: static/js/common-all.js:2162 static/js/impala-all.js:2247 static/js/zamboni/buttons.js:401 static/js/zamboni/discovery-all.js:13433
+msgid "Only with Firefox — Get Firefox Now!"
+msgstr ""
+
+#: static/js/common-all.js:2278 static/js/impala-all.js:2363 static/js/zamboni/buttons.js:517 static/js/zamboni/discovery-all.js:13549 static/js/zamboni/mobile-all.js:15177
+#: static/js/zamboni/mobile/buttons.js:43
+msgid "Sorry, you need a Mozilla-based browser (such as Firefox) to install a search plugin."
+msgstr ""
+
+#: static/js/common-all.js:9088 static/js/impala-all.js:9649 static/js/zamboni/global.js:410
+msgid "Loading..."
+msgstr ""
+
+#. L10n: {0} is the number of characters left.
+#: static/js/common-all.js:9152 static/js/impala-all.js:9713 static/js/zamboni/global.js:474
+msgid "<b>{0}</b> character left."
+msgid_plural "<b>{0}</b> characters left."
+msgstr[0] ""
+msgstr[1] ""
+
+#: static/js/common-all.js:9589 static/js/common-min.js:6 static/js/impala-all.js:10052 static/js/impala-min.js:6 static/js/common/ratingwidget.js:31 static/js/zamboni/mobile-all.js:16123
+#: static/js/zamboni/mobile-min.js:6
 msgid "{0} star"
 msgid_plural "{0} stars"
 msgstr[0] ""
 msgstr[1] ""
 
-#: static/js/common/upload-addon.js:41 static/js/common/upload-image.js:128
+#: static/js/common-all.js:9676 static/js/common-min.js:6 static/js/impala-all.js:10139 static/js/impala-min.js:6 static/js/zamboni/l10n.js:45
+msgid "Remove this localization"
+msgstr ""
+
+#: static/js/common-all.js:10193 static/js/common-min.js:6 static/js/impala-all.js:10674 static/js/impala-min.js:6 static/js/zamboni/discovery-all.js:13678
+msgid "close"
+msgstr ""
+
+#: static/js/common-all.js:10860 static/js/common-min.js:6 static/js/impala-all.js:11481 static/js/impala-min.js:6 static/js/impala/reviews.js:23 static/js/zamboni/reviews.js:18
+msgid "Flagged for review"
+msgstr ""
+
+#: static/js/common-all.js:10876 static/js/common-min.js:6 static/js/impala-all.js:11498 static/js/impala-min.js:6 static/js/impala/reviews.js:40 static/js/zamboni/reviews.js:34
+msgid "Your input is required"
+msgstr ""
+
+#: static/js/common-all.js:10945 static/js/common-min.js:6 static/js/impala-all.js:11610 static/js/impala-min.js:7 static/js/impala/reviews.js:152 static/js/zamboni/reviews.js:103
+msgid "Marked for deletion"
+msgstr ""
+
+#: static/js/common-all.js:11573 static/js/common-min.js:7 static/js/impala-all.js:13809 static/js/impala-min.js:8 static/js/zamboni/collections.js:229
+msgid "Adding to Favorites&hellip;"
+msgstr ""
+
+#: static/js/common-all.js:11576 static/js/common-min.js:7 static/js/impala-all.js:13812 static/js/impala-min.js:8 static/js/zamboni/collections.js:232
+msgid "Removing Favorite&hellip;"
+msgstr ""
+
+#: static/js/common-all.js:11579 static/js/common-min.js:7 static/js/impala-all.js:13815 static/js/impala-min.js:8 static/js/zamboni/collections.js:235
+msgid "Add to Favorites"
+msgstr ""
+
+#: static/js/common-all.js:11582 static/js/common-min.js:7 static/js/impala-all.js:13818 static/js/impala-min.js:8 static/js/zamboni/collections.js:238
+msgid "Remove from Favorites"
+msgstr ""
+
+#: static/js/common-all.js:11647 static/js/common-min.js:7 static/js/impala-all.js:13883 static/js/impala-min.js:8 static/js/zamboni/collections.js:303
+msgid "Pending"
+msgstr ""
+
+#: static/js/common-all.js:11648 static/js/common-min.js:7 static/js/impala-all.js:13884 static/js/impala-min.js:8 static/js/zamboni/collections.js:304
+msgid "Add a comment"
+msgstr ""
+
+#: static/js/common-all.js:11648 static/js/common-min.js:7 static/js/impala-all.js:13884 static/js/impala-min.js:8 static/js/zamboni/collections.js:304
+msgid "Comment"
+msgstr ""
+
+#: static/js/common-all.js:11649 static/js/common-min.js:7 static/js/impala-all.js:13885 static/js/impala-min.js:8 static/js/zamboni/collections.js:305
+msgid "Remove this add-on from the collection"
+msgstr ""
+
+#: static/js/common-all.js:11649 static/js/common-all.js:11678 static/js/common-min.js:7 static/js/impala-all.js:13885 static/js/impala-all.js:13914 static/js/impala-min.js:8
+#: static/js/zamboni/collections.js:305 static/js/zamboni/collections.js:334
+msgid "Remove"
+msgstr ""
+
+#: static/js/common-all.js:11678 static/js/common-min.js:7 static/js/impala-all.js:13914 static/js/impala-min.js:8 static/js/zamboni/collections.js:334
+msgid "Remove this user as a contributor"
+msgstr ""
+
+#: static/js/common-all.js:11690 static/js/common-min.js:7 static/js/impala-all.js:13926 static/js/impala-min.js:8 static/js/zamboni/collections.js:346
+msgid "An email address is required."
+msgstr ""
+
+#: static/js/common-all.js:11708 static/js/common-min.js:7 static/js/impala-all.js:13944 static/js/impala-min.js:8 static/js/zamboni/collections.js:364
+msgid "You cannot add yourself as a contributor."
+msgstr ""
+
+#: static/js/common-all.js:11710 static/js/common-min.js:7 static/js/impala-all.js:13946 static/js/impala-min.js:8 static/js/zamboni/collections.js:366
+msgid "You have already added that user."
+msgstr ""
+
+#: static/js/common-all.js:11917 static/js/common-min.js:7 static/js/impala-all.js:14153 static/js/impala-min.js:8 static/js/zamboni/collections.js:573
+msgid "Add to favorites"
+msgstr ""
+
+#: static/js/common-all.js:11921 static/js/common-min.js:7 static/js/impala-all.js:14157 static/js/impala-min.js:8 static/js/zamboni/collections.js:577
+msgid "Remove from favorites"
+msgstr ""
+
+#: static/js/common-all.js:11939 static/js/common-min.js:7 static/js/impala-all.js:14175 static/js/impala-all.js:14233 static/js/impala-min.js:8 static/js/impala/collections.js:10
+#: static/js/zamboni/collections.js:595
+msgid "Follow this Collection"
+msgstr ""
+
+#: static/js/common-all.js:11948 static/js/common-min.js:7 static/js/impala-all.js:14184 static/js/impala-min.js:8 static/js/zamboni/collections.js:604
+msgid "Stop following"
+msgstr ""
+
+#: static/js/common-all.js:12096 static/js/common-min.js:7 static/js/zamboni/password-strength.js:20
+msgid "Password strength:"
+msgstr ""
+
+#: static/js/common-all.js:12102 static/js/common-min.js:7 static/js/zamboni/password-strength.js:26
+msgid "At least {0} character left."
+msgid_plural "At least {0} characters left."
+msgstr[0] ""
+msgstr[1] ""
+
+#: static/js/common-all.js:12286 static/js/common-min.js:7 static/js/impala-all.js:14632 static/js/impala-min.js:8 static/js/impala/suggestions.js:39
+msgid "Search themes for <b>{0}</b>"
+msgstr ""
+
+#: static/js/common-all.js:12288 static/js/common-min.js:7 static/js/impala-all.js:14634 static/js/impala-min.js:8 static/js/impala/suggestions.js:41
+msgid "Search apps for <b>{0}</b>"
+msgstr ""
+
+#: static/js/common-all.js:12290 static/js/common-min.js:7 static/js/impala-all.js:14636 static/js/impala-min.js:8 static/js/impala/suggestions.js:43
+msgid "Search add-ons for <b>{0}</b>"
+msgstr ""
+
+#: static/js/common-all.js:12521 static/js/common-min.js:7 static/js/impala-all.js:14867 static/js/impala-min.js:8 static/js/impala/site_suggestions.js:46
+msgid "Category"
+msgstr ""
+
+#. L10n: {0} is an app name.
+#: static/js/impala-all.js:11632 static/js/impala-min.js:7 static/js/impala/listing.js:11 static/js/zamboni/themes.js:13
+msgid "This theme is incompatible with your version of {0}"
+msgstr ""
+
+#: static/js/impala-all.js:12146 static/js/impala-all.js:14331 static/js/impala-min.js:7 static/js/impala-min.js:8 static/js/common/upload-image.js:97 static/js/impala/users.js:51
+#: static/js/zamboni/devhub-all.js:894 static/js/zamboni/devhub-min.js:1
+msgid "Images must be either PNG or JPG."
+msgstr ""
+
+#: static/js/impala-all.js:12150 static/js/impala-min.js:7 static/js/common/upload-image.js:101 static/js/zamboni/devhub-all.js:898 static/js/zamboni/devhub-min.js:1
+msgid "Videos must be in WebM."
+msgstr ""
+
+#: static/js/impala-all.js:12177 static/js/impala-min.js:7 static/js/common/upload-addon.js:41 static/js/common/upload-image.js:128 static/js/zamboni/devhub-all.js:272
+#: static/js/zamboni/devhub-all.js:925 static/js/zamboni/devhub-min.js:1
 msgid "There was a problem contacting the server."
 msgstr ""
 
-#: static/js/common/upload-addon.js:69
+#: static/js/impala-all.js:13298 static/js/impala-min.js:7 static/js/impala/persona_creation.js:60
+msgid "All Rights Reserved"
+msgstr ""
+
+#: static/js/impala-all.js:13302 static/js/impala-min.js:7 static/js/impala/persona_creation.js:64
+msgid "Creative Commons Attribution 3.0"
+msgstr ""
+
+#: static/js/impala-all.js:13307 static/js/impala-min.js:7 static/js/impala/persona_creation.js:69
+msgid "Creative Commons Attribution-NonCommercial 3.0"
+msgstr ""
+
+#: static/js/impala-all.js:13312 static/js/impala-min.js:7 static/js/impala/persona_creation.js:74
+msgid "Creative Commons Attribution-NonCommercial-NoDerivs 3.0"
+msgstr ""
+
+#: static/js/impala-all.js:13317 static/js/impala-min.js:7 static/js/impala/persona_creation.js:79
+msgid "Creative Commons Attribution-NonCommercial-Share Alike 3.0"
+msgstr ""
+
+#: static/js/impala-all.js:13322 static/js/impala-min.js:7 static/js/impala/persona_creation.js:84
+msgid "Creative Commons Attribution-NoDerivs 3.0"
+msgstr ""
+
+#: static/js/impala-all.js:13327 static/js/impala-min.js:7 static/js/impala/persona_creation.js:89
+msgid "Creative Commons Attribution-ShareAlike 3.0"
+msgstr ""
+
+#: static/js/impala-all.js:13530 static/js/impala-min.js:7 static/js/impala/persona_creation.js:292
+msgid "Your Theme's Name"
+msgstr ""
+
+#: static/js/impala-all.js:14242 static/js/impala-min.js:8 static/js/impala/collections.js:19
+msgid "Stop Following"
+msgstr ""
+
+#: static/js/impala-all.js:14243 static/js/impala-min.js:8 static/js/impala/collections.js:20
+msgid "Following"
+msgstr ""
+
+#: static/js/impala-all.js:14313 static/js/impala-min.js:8 static/js/impala/users.js:33
+msgid "use original"
+msgstr ""
+
+#: static/js/impala-all.js:14523 static/js/impala-min.js:8 static/js/impala/search.js:114
+msgid "Updating results&hellip;"
+msgstr ""
+
+#: static/js/common/upload-addon.js:69 static/js/zamboni/devhub-all.js:300 static/js/zamboni/devhub-min.js:1
 msgid "Select a file..."
 msgstr ""
 
-#: static/js/common/upload-addon.js:70
+#: static/js/common/upload-addon.js:70 static/js/zamboni/devhub-all.js:301 static/js/zamboni/devhub-min.js:1
 msgid "Your add-on should end with .xpi, .jar or .xml"
 msgstr ""
 
 #. L10n: {0} is the percent of the file that has been uploaded.
-#: static/js/common/upload-addon.js:104
+#: static/js/common/upload-addon.js:104 static/js/zamboni/devhub-all.js:335 static/js/zamboni/devhub-min.js:1
 #, python-format
 msgid "{0}% complete"
 msgstr ""
 
 #. L10n: "{bytes uploaded} of {total filesize}".
-#: static/js/common/upload-addon.js:107
+#: static/js/common/upload-addon.js:107 static/js/zamboni/devhub-all.js:338 static/js/zamboni/devhub-min.js:1
 msgid "{0} of {1}"
 msgstr ""
 
-#: static/js/common/upload-addon.js:140
+#: static/js/common/upload-addon.js:140 static/js/zamboni/devhub-all.js:371 static/js/zamboni/devhub-min.js:1
 msgid "Cancel"
 msgstr ""
 
-#: static/js/common/upload-addon.js:162
+#: static/js/common/upload-addon.js:162 static/js/zamboni/devhub-all.js:393 static/js/zamboni/devhub-min.js:1
 msgid "Uploading {0}"
 msgstr ""
 
-#: static/js/common/upload-addon.js:189
+#: static/js/common/upload-addon.js:189 static/js/zamboni/devhub-all.js:420 static/js/zamboni/devhub-min.js:1
 msgid "Error with {0}"
 msgstr ""
 
-#: static/js/common/upload-addon.js:194
+#: static/js/common/upload-addon.js:194 static/js/zamboni/devhub-all.js:425 static/js/zamboni/devhub-min.js:1
 msgid "Your add-on failed validation with {0} error."
 msgid_plural "Your add-on failed validation with {0} errors."
 msgstr[0] ""
 msgstr[1] ""
 
-#: static/js/common/upload-addon.js:208
+#: static/js/common/upload-addon.js:208 static/js/zamboni/devhub-all.js:439 static/js/zamboni/devhub-min.js:1
 msgid "&hellip;and {0} more"
 msgid_plural "&hellip;and {0} more"
 msgstr[0] ""
 msgstr[1] ""
 
-#: static/js/common/upload-addon.js:222 static/js/common/upload-addon.js:512
+#: static/js/common/upload-addon.js:222 static/js/common/upload-addon.js:497 static/js/zamboni/devhub-all.js:453 static/js/zamboni/devhub-all.js:743 static/js/zamboni/devhub-min.js:1
 msgid "See full validation report"
 msgstr ""
 
-#: static/js/common/upload-addon.js:234
+#: static/js/common/upload-addon.js:234 static/js/zamboni/devhub-all.js:465 static/js/zamboni/devhub-min.js:1
 msgid "Validating {0}"
 msgstr ""
 
 #. L10n: first argument is an HTTP status code
-#: static/js/common/upload-addon.js:273
+#: static/js/common/upload-addon.js:273 static/js/zamboni/devhub-all.js:504 static/js/zamboni/devhub-min.js:1
 msgid "Received an empty response from the server; status: {0}"
 msgstr ""
 
-#: static/js/common/upload-addon.js:373
+#: static/js/common/upload-addon.js:370 static/js/zamboni/devhub-all.js:604 static/js/zamboni/devhub-min.js:1
 msgid "Unexpected server error while validating."
 msgstr ""
 
-#: static/js/common/upload-addon.js:412
+#: static/js/common/upload-addon.js:409 static/js/zamboni/devhub-all.js:643 static/js/zamboni/devhub-min.js:1
 msgid "Finished validating {0}"
 msgstr ""
 
-#: static/js/common/upload-addon.js:418
+#: static/js/common/upload-addon.js:415 static/js/zamboni/devhub-all.js:649 static/js/zamboni/devhub-min.js:1
 msgid "Your add-on validation timed out, it will be manually reviewed."
 msgstr ""
 
-#: static/js/common/upload-addon.js:421
+#: static/js/common/upload-addon.js:418 static/js/zamboni/devhub-all.js:652 static/js/zamboni/devhub-min.js:1
 msgid "Your add-on was validated with no errors and {0} warning."
 msgid_plural "Your add-on was validated with no errors and {0} warnings."
 msgstr[0] ""
 msgstr[1] ""
 
-#: static/js/common/upload-addon.js:426
+#: static/js/common/upload-addon.js:423 static/js/zamboni/devhub-all.js:657 static/js/zamboni/devhub-min.js:1
 msgid "Your add-on was validated with no errors and {0} message."
 msgid_plural "Your add-on was validated with no errors and {0} messages."
 msgstr[0] ""
 msgstr[1] ""
 
-#: static/js/common/upload-addon.js:431
+#: static/js/common/upload-addon.js:428 static/js/zamboni/devhub-all.js:662 static/js/zamboni/devhub-min.js:1
 msgid "Your add-on was validated with no errors or warnings."
 msgstr ""
 
-#: static/js/common/upload-addon.js:446
+#: static/js/common/upload-addon.js:443 static/js/zamboni/devhub-all.js:677 static/js/zamboni/devhub-min.js:1
 msgid "Your submission will be automatically signed."
 msgstr ""
 
-#: static/js/common/upload-addon.js:465
+#: static/js/common/upload-addon.js:450 static/js/zamboni/devhub-all.js:696 static/js/zamboni/devhub-min.js:1
 msgid "Include detailed version notes (this can be done in the next step)."
 msgstr ""
 
-#: static/js/common/upload-addon.js:466
+#: static/js/common/upload-addon.js:451 static/js/zamboni/devhub-all.js:697 static/js/zamboni/devhub-min.js:1
 msgid "If your add-on requires an account to a website in order to be fully tested, include a test username and password in the Notes to Reviewer (this can be done in the next step)."
 msgstr ""
 
-#: static/js/common/upload-addon.js:467
+#: static/js/common/upload-addon.js:452 static/js/zamboni/devhub-all.js:698 static/js/zamboni/devhub-min.js:1
 msgid "If your add-on is intended for a limited audience you should choose Preliminary Review instead of Full Review."
 msgstr ""
 
-#: static/js/common/upload-addon.js:480
+#: static/js/common/upload-addon.js:465 static/js/zamboni/devhub-all.js:711 static/js/zamboni/devhub-min.js:1
 msgid "Add-on submission checklist"
 msgstr ""
 
-#: static/js/common/upload-addon.js:481
+#: static/js/common/upload-addon.js:466 static/js/zamboni/devhub-all.js:712 static/js/zamboni/devhub-min.js:1
 msgid "Please verify the following points before finalizing your submission. This will minimize delays or misunderstanding during the review process:"
 msgstr ""
 
-#: static/js/common/upload-addon.js:483
+#: static/js/common/upload-addon.js:468 static/js/zamboni/devhub-all.js:714 static/js/zamboni/devhub-min.js:1
 msgid ""
 "Compiled binaries, as well as minified or obfuscated scripts (excluding known libraries) need to have their sources submitted separately for review. Make sure that you use the source code upload "
 "field to avoid having your submission rejected."
 msgstr ""
 
-#: static/js/common/upload-addon.js:501
+#: static/js/common/upload-addon.js:486 static/js/zamboni/devhub-all.js:732 static/js/zamboni/devhub-min.js:1
 msgid "The validation process found these issues that can lead to rejections:"
 msgstr ""
 
-#: static/js/common/upload-addon.js:518
+#: static/js/common/upload-addon.js:503 static/js/zamboni/devhub-all.js:749 static/js/zamboni/devhub-min.js:1
 msgid "If you are unfamiliar with the add-ons review process, you can read about it here."
 msgstr ""
 
-#: static/js/common/upload-addon.js:555
+#: static/js/common/upload-addon.js:540 static/js/zamboni/devhub-all.js:786 static/js/zamboni/devhub-min.js:1
 msgid "Sorry, no supported platform has been found."
 msgstr ""
 
-#: static/js/common/upload-base.js:57
+#: static/js/common/upload-base.js:57 static/js/zamboni/devhub-all.js:187 static/js/zamboni/devhub-min.js:1
 msgid "The filetype you uploaded isn't recognized."
 msgstr ""
 
-#: static/js/common/upload-base.js:79
+#: static/js/common/upload-base.js:79 static/js/zamboni/devhub-all.js:209 static/js/zamboni/devhub-min.js:1
 msgid "You cancelled the upload."
 msgstr ""
 
-#: static/js/common/upload-image.js:97 static/js/impala/users.js:51
-msgid "Images must be either PNG or JPG."
-msgstr ""
-
-#: static/js/common/upload-image.js:101
-msgid "Videos must be in WebM."
-msgstr ""
-
-#: static/js/impala/collections.js:10 static/js/zamboni/collections.js:595
-msgid "Follow this Collection"
-msgstr ""
-
-#: static/js/impala/collections.js:19
-msgid "Stop Following"
-msgstr ""
-
-#: static/js/impala/collections.js:20
-msgid "Following"
-msgstr ""
-
-#. L10n: {0} is an app name.
-#: static/js/impala/listing.js:11 static/js/zamboni/themes.js:13
-msgid "This theme is incompatible with your version of {0}"
-msgstr ""
-
-#: static/js/impala/persona_creation.js:60
-msgid "All Rights Reserved"
-msgstr ""
-
-#: static/js/impala/persona_creation.js:64
-msgid "Creative Commons Attribution 3.0"
-msgstr ""
-
-#: static/js/impala/persona_creation.js:69
-msgid "Creative Commons Attribution-NonCommercial 3.0"
-msgstr ""
-
-#: static/js/impala/persona_creation.js:74
-msgid "Creative Commons Attribution-NonCommercial-NoDerivs 3.0"
-msgstr ""
-
-#: static/js/impala/persona_creation.js:79
-msgid "Creative Commons Attribution-NonCommercial-Share Alike 3.0"
-msgstr ""
-
-#: static/js/impala/persona_creation.js:84
-msgid "Creative Commons Attribution-NoDerivs 3.0"
-msgstr ""
-
-#: static/js/impala/persona_creation.js:89
-msgid "Creative Commons Attribution-ShareAlike 3.0"
-msgstr ""
-
-#: static/js/impala/persona_creation.js:292
-msgid "Your Theme's Name"
-msgstr ""
-
-#: static/js/impala/reviews.js:23 static/js/zamboni/reviews.js:18
-msgid "Flagged for review"
-msgstr ""
-
-#: static/js/impala/reviews.js:40 static/js/zamboni/reviews.js:34
-msgid "Your input is required"
-msgstr ""
-
-#: static/js/impala/reviews.js:152 static/js/zamboni/reviews.js:103
-msgid "Marked for deletion"
-msgstr ""
-
-#: static/js/impala/search.js:114
-msgid "Updating results&hellip;"
-msgstr ""
-
-#: static/js/impala/site_suggestions.js:46
-msgid "Category"
-msgstr ""
-
-#: static/js/impala/suggestions.js:39
-msgid "Search themes for <b>{0}</b>"
-msgstr ""
-
-#: static/js/impala/suggestions.js:41
-msgid "Search apps for <b>{0}</b>"
-msgstr ""
-
-#: static/js/impala/suggestions.js:43
-msgid "Search add-ons for <b>{0}</b>"
-msgstr ""
-
-#: static/js/impala/users.js:33
-msgid "use original"
-msgstr ""
-
-#: static/js/impala/stats/chart.js:267
+#: static/js/impala/stats/chart.js:267 static/js/zamboni/stats-all.js:16898 static/js/zamboni/stats-min.js:5
 msgid "Week of {0}"
 msgstr ""
 
-#: static/js/impala/stats/chart.js:269
+#: static/js/impala/stats/chart.js:269 static/js/zamboni/stats-all.js:16900 static/js/zamboni/stats-min.js:5
 msgid " downloads"
 msgstr ""
 
-#: static/js/impala/stats/chart.js:270
+#: static/js/impala/stats/chart.js:270 static/js/zamboni/stats-all.js:16901 static/js/zamboni/stats-min.js:5
 msgid "{0} users"
 msgstr ""
 
-#: static/js/impala/stats/chart.js:271
+#: static/js/impala/stats/chart.js:271 static/js/zamboni/stats-all.js:16902 static/js/zamboni/stats-min.js:5
 msgid "{0} add-ons"
 msgstr ""
 
-#: static/js/impala/stats/chart.js:272
+#: static/js/impala/stats/chart.js:272 static/js/zamboni/stats-all.js:16903 static/js/zamboni/stats-min.js:5
 msgid "{0} collections"
 msgstr ""
 
-#: static/js/impala/stats/chart.js:273
+#: static/js/impala/stats/chart.js:273 static/js/zamboni/stats-all.js:16904 static/js/zamboni/stats-min.js:5
 msgid "{0} reviews"
 msgstr ""
 
-#: static/js/impala/stats/chart.js:275
+#: static/js/impala/stats/chart.js:275 static/js/zamboni/stats-all.js:16906 static/js/zamboni/stats-min.js:5
 msgid "{0} sales"
 msgstr ""
 
-#: static/js/impala/stats/chart.js:276
+#: static/js/impala/stats/chart.js:276 static/js/zamboni/stats-all.js:16907 static/js/zamboni/stats-min.js:5
 msgid "{0} refunds"
 msgstr ""
 
-#: static/js/impala/stats/chart.js:277
+#: static/js/impala/stats/chart.js:277 static/js/zamboni/stats-all.js:16908 static/js/zamboni/stats-min.js:5
 msgid "{0} installs"
 msgstr ""
 
-#: static/js/impala/stats/chart.js:369 static/js/impala/stats/csv_keys.js:3 static/js/impala/stats/csv_keys.js:109
+#: static/js/impala/stats/chart.js:369 static/js/impala/stats/csv_keys.js:3 static/js/impala/stats/csv_keys.js:109 static/js/zamboni/stats-all.js:15284 static/js/zamboni/stats-all.js:15390
+#: static/js/zamboni/stats-all.js:17000 static/js/zamboni/stats-min.js:4 static/js/zamboni/stats-min.js:5
 msgid "Downloads"
 msgstr ""
 
-#: static/js/impala/stats/chart.js:379 static/js/impala/stats/csv_keys.js:6 static/js/impala/stats/csv_keys.js:110
+#: static/js/impala/stats/chart.js:379 static/js/impala/stats/csv_keys.js:6 static/js/impala/stats/csv_keys.js:110 static/js/zamboni/stats-all.js:15287 static/js/zamboni/stats-all.js:15391
+#: static/js/zamboni/stats-all.js:17010 static/js/zamboni/stats-min.js:4 static/js/zamboni/stats-min.js:5
 msgid "Daily Users"
 msgstr ""
 
-#: static/js/impala/stats/chart.js:410
+#: static/js/impala/stats/chart.js:410 static/js/zamboni/stats-all.js:17041 static/js/zamboni/stats-min.js:5
 msgid "Amount, in USD"
 msgstr ""
 
-#: static/js/impala/stats/chart.js:421 static/js/impala/stats/csv_keys.js:104
+#: static/js/impala/stats/chart.js:421 static/js/impala/stats/csv_keys.js:104 static/js/zamboni/stats-all.js:15385 static/js/zamboni/stats-all.js:17052 static/js/zamboni/stats-min.js:5
 msgid "Number of Contributions"
 msgstr ""
 
-#: static/js/impala/stats/chart.js:447
+#: static/js/impala/stats/chart.js:447 static/js/zamboni/stats-all.js:17078 static/js/zamboni/stats-min.js:5
 msgid "More Info..."
 msgstr ""
 
 #. L10n: {0} is an ISO-formatted date.
-#: static/js/impala/stats/chart.js:451
+#: static/js/impala/stats/chart.js:451 static/js/zamboni/stats-all.js:17082 static/js/zamboni/stats-min.js:5
 msgid "Details for {0}"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:9
+#: static/js/impala/stats/csv_keys.js:9 static/js/zamboni/stats-all.js:15290 static/js/zamboni/stats-min.js:4
 msgid "Collections Created"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:12
+#: static/js/impala/stats/csv_keys.js:12 static/js/zamboni/stats-all.js:15293 static/js/zamboni/stats-min.js:4
 msgid "Add-ons in Use"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:15
+#: static/js/impala/stats/csv_keys.js:15 static/js/zamboni/stats-all.js:15296 static/js/zamboni/stats-min.js:4
 msgid "Add-ons Created"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:18
+#: static/js/impala/stats/csv_keys.js:18 static/js/zamboni/stats-all.js:15299 static/js/zamboni/stats-min.js:4
 msgid "Add-ons Downloaded"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:21
+#: static/js/impala/stats/csv_keys.js:21 static/js/zamboni/stats-all.js:15302 static/js/zamboni/stats-min.js:4
 msgid "Add-ons Updated"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:24
+#: static/js/impala/stats/csv_keys.js:24 static/js/zamboni/stats-all.js:15305 static/js/zamboni/stats-min.js:4
 msgid "Reviews Written"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:27
+#: static/js/impala/stats/csv_keys.js:27 static/js/zamboni/stats-all.js:15308 static/js/zamboni/stats-min.js:4
 msgid "User Signups"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:30
+#: static/js/impala/stats/csv_keys.js:30 static/js/zamboni/stats-all.js:15311 static/js/zamboni/stats-min.js:4
 msgid "Subscribers"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:33
+#: static/js/impala/stats/csv_keys.js:33 static/js/zamboni/stats-all.js:15314 static/js/zamboni/stats-min.js:4
 msgid "Ratings"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:36 static/js/impala/stats/csv_keys.js:114
+#: static/js/impala/stats/csv_keys.js:36 static/js/impala/stats/csv_keys.js:114 static/js/zamboni/stats-all.js:15317 static/js/zamboni/stats-all.js:15395 static/js/zamboni/stats-min.js:4
+#: static/js/zamboni/stats-min.js:5
 msgid "Sales"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:39 static/js/impala/stats/csv_keys.js:113
+#: static/js/impala/stats/csv_keys.js:39 static/js/impala/stats/csv_keys.js:113 static/js/zamboni/stats-all.js:15320 static/js/zamboni/stats-all.js:15394 static/js/zamboni/stats-min.js:4
+#: static/js/zamboni/stats-min.js:5
 msgid "Installs"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:42
+#: static/js/impala/stats/csv_keys.js:42 static/js/zamboni/stats-all.js:15323 static/js/zamboni/stats-min.js:4
 msgid "Unknown"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:43
+#: static/js/impala/stats/csv_keys.js:43 static/js/zamboni/stats-all.js:15324 static/js/zamboni/stats-min.js:4
 msgid "Add-ons Manager"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:44
+#: static/js/impala/stats/csv_keys.js:44 static/js/zamboni/stats-all.js:15325 static/js/zamboni/stats-min.js:4
 msgid "Add-ons Manager Promo"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:45
+#: static/js/impala/stats/csv_keys.js:45 static/js/zamboni/stats-all.js:15326 static/js/zamboni/stats-min.js:4
 msgid "Add-ons Manager Featured"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:46
+#: static/js/impala/stats/csv_keys.js:46 static/js/zamboni/stats-all.js:15327 static/js/zamboni/stats-min.js:4
 msgid "Add-ons Manager Learn More"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:47
+#: static/js/impala/stats/csv_keys.js:47 static/js/zamboni/stats-all.js:15328 static/js/zamboni/stats-min.js:4
 msgid "Search Suggestions"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:48
+#: static/js/impala/stats/csv_keys.js:48 static/js/zamboni/stats-all.js:15329 static/js/zamboni/stats-min.js:4
 msgid "Search Results"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:49 static/js/impala/stats/csv_keys.js:50 static/js/impala/stats/csv_keys.js:51
+#: static/js/impala/stats/csv_keys.js:49 static/js/impala/stats/csv_keys.js:50 static/js/impala/stats/csv_keys.js:51 static/js/zamboni/stats-all.js:15330 static/js/zamboni/stats-all.js:15331
+#: static/js/zamboni/stats-all.js:15332 static/js/zamboni/stats-min.js:4
 msgid "Homepage Promo"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:52 static/js/impala/stats/csv_keys.js:53
+#: static/js/impala/stats/csv_keys.js:52 static/js/impala/stats/csv_keys.js:53 static/js/zamboni/stats-all.js:15333 static/js/zamboni/stats-all.js:15334 static/js/zamboni/stats-min.js:4
 msgid "Homepage Featured"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:54 static/js/impala/stats/csv_keys.js:55
+#: static/js/impala/stats/csv_keys.js:54 static/js/impala/stats/csv_keys.js:55 static/js/zamboni/stats-all.js:15335 static/js/zamboni/stats-all.js:15336 static/js/zamboni/stats-min.js:4
 msgid "Homepage Up and Coming"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:56
+#: static/js/impala/stats/csv_keys.js:56 static/js/zamboni/stats-all.js:15337 static/js/zamboni/stats-min.js:4
 msgid "Homepage Most Popular"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:57 static/js/impala/stats/csv_keys.js:59
+#: static/js/impala/stats/csv_keys.js:57 static/js/impala/stats/csv_keys.js:59 static/js/zamboni/stats-all.js:15338 static/js/zamboni/stats-all.js:15340 static/js/zamboni/stats-min.js:4
 msgid "Detail Page"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:58 static/js/impala/stats/csv_keys.js:60
+#: static/js/impala/stats/csv_keys.js:58 static/js/impala/stats/csv_keys.js:60 static/js/zamboni/stats-all.js:15339 static/js/zamboni/stats-all.js:15341 static/js/zamboni/stats-min.js:4
 msgid "Detail Page (bottom)"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:61
+#: static/js/impala/stats/csv_keys.js:61 static/js/zamboni/stats-all.js:15342 static/js/zamboni/stats-min.js:4
 msgid "Detail Page (Development Channel)"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:62 static/js/impala/stats/csv_keys.js:63 static/js/impala/stats/csv_keys.js:64
+#: static/js/impala/stats/csv_keys.js:62 static/js/impala/stats/csv_keys.js:63 static/js/impala/stats/csv_keys.js:64 static/js/zamboni/stats-all.js:15343 static/js/zamboni/stats-all.js:15344
+#: static/js/zamboni/stats-all.js:15345 static/js/zamboni/stats-min.js:4
 msgid "Often Used With"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:65 static/js/impala/stats/csv_keys.js:66
+#: static/js/impala/stats/csv_keys.js:65 static/js/impala/stats/csv_keys.js:66 static/js/zamboni/stats-all.js:15346 static/js/zamboni/stats-all.js:15347 static/js/zamboni/stats-min.js:4
 msgid "Others By Author"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:67 static/js/impala/stats/csv_keys.js:68
+#: static/js/impala/stats/csv_keys.js:67 static/js/impala/stats/csv_keys.js:68 static/js/zamboni/stats-all.js:15348 static/js/zamboni/stats-all.js:15349 static/js/zamboni/stats-min.js:4
 msgid "Dependencies"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:69 static/js/impala/stats/csv_keys.js:70
+#: static/js/impala/stats/csv_keys.js:69 static/js/impala/stats/csv_keys.js:70 static/js/zamboni/stats-all.js:15350 static/js/zamboni/stats-all.js:15351 static/js/zamboni/stats-min.js:4
 msgid "Upsell"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:71
+#: static/js/impala/stats/csv_keys.js:71 static/js/zamboni/stats-all.js:15352 static/js/zamboni/stats-min.js:4
 msgid "Meet the Developer"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:72
+#: static/js/impala/stats/csv_keys.js:72 static/js/zamboni/stats-all.js:15353 static/js/zamboni/stats-min.js:4
 msgid "User Profile"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:73
+#: static/js/impala/stats/csv_keys.js:73 static/js/zamboni/stats-all.js:15354 static/js/zamboni/stats-min.js:4
 msgid "Version History"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:75
+#: static/js/impala/stats/csv_keys.js:75 static/js/zamboni/stats-all.js:15356 static/js/zamboni/stats-min.js:4
 msgid "Sharing"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:76
+#: static/js/impala/stats/csv_keys.js:76 static/js/zamboni/stats-all.js:15357 static/js/zamboni/stats-min.js:4
 msgid "Category Pages"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:77
+#: static/js/impala/stats/csv_keys.js:77 static/js/zamboni/stats-all.js:15358 static/js/zamboni/stats-min.js:4
 msgid "Collections"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:78 static/js/impala/stats/csv_keys.js:79
+#: static/js/impala/stats/csv_keys.js:78 static/js/impala/stats/csv_keys.js:79 static/js/zamboni/stats-all.js:15359 static/js/zamboni/stats-all.js:15360 static/js/zamboni/stats-min.js:4
 msgid "Category Landing Featured Carousel"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:80 static/js/impala/stats/csv_keys.js:81
+#: static/js/impala/stats/csv_keys.js:80 static/js/impala/stats/csv_keys.js:81 static/js/zamboni/stats-all.js:15361 static/js/zamboni/stats-all.js:15362 static/js/zamboni/stats-min.js:4
 msgid "Category Landing Top Rated"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:82 static/js/impala/stats/csv_keys.js:83
+#: static/js/impala/stats/csv_keys.js:82 static/js/impala/stats/csv_keys.js:83 static/js/zamboni/stats-all.js:15363 static/js/zamboni/stats-all.js:15364 static/js/zamboni/stats-min.js:5
 msgid "Category Landing Most Popular"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:84 static/js/impala/stats/csv_keys.js:85
+#: static/js/impala/stats/csv_keys.js:84 static/js/impala/stats/csv_keys.js:85 static/js/zamboni/stats-all.js:15365 static/js/zamboni/stats-all.js:15366 static/js/zamboni/stats-min.js:5
 msgid "Category Landing Recently Added"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:86 static/js/impala/stats/csv_keys.js:87
+#: static/js/impala/stats/csv_keys.js:86 static/js/impala/stats/csv_keys.js:87 static/js/zamboni/stats-all.js:15367 static/js/zamboni/stats-all.js:15368 static/js/zamboni/stats-min.js:5
 msgid "Browse Listing Featured Sort"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:88 static/js/impala/stats/csv_keys.js:89
+#: static/js/impala/stats/csv_keys.js:88 static/js/impala/stats/csv_keys.js:89 static/js/zamboni/stats-all.js:15369 static/js/zamboni/stats-all.js:15370 static/js/zamboni/stats-min.js:5
 msgid "Browse Listing Users Sort"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:90 static/js/impala/stats/csv_keys.js:91
+#: static/js/impala/stats/csv_keys.js:90 static/js/impala/stats/csv_keys.js:91 static/js/zamboni/stats-all.js:15371 static/js/zamboni/stats-all.js:15372 static/js/zamboni/stats-min.js:5
 msgid "Browse Listing Rating Sort"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:92 static/js/impala/stats/csv_keys.js:93
+#: static/js/impala/stats/csv_keys.js:92 static/js/impala/stats/csv_keys.js:93 static/js/zamboni/stats-all.js:15373 static/js/zamboni/stats-all.js:15374 static/js/zamboni/stats-min.js:5
 msgid "Browse Listing Created Sort"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:94 static/js/impala/stats/csv_keys.js:95
+#: static/js/impala/stats/csv_keys.js:94 static/js/impala/stats/csv_keys.js:95 static/js/zamboni/stats-all.js:15375 static/js/zamboni/stats-all.js:15376 static/js/zamboni/stats-min.js:5
 msgid "Browse Listing Name Sort"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:96 static/js/impala/stats/csv_keys.js:97
+#: static/js/impala/stats/csv_keys.js:96 static/js/impala/stats/csv_keys.js:97 static/js/zamboni/stats-all.js:15377 static/js/zamboni/stats-all.js:15378 static/js/zamboni/stats-min.js:5
 msgid "Browse Listing Popular Sort"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:98 static/js/impala/stats/csv_keys.js:99
+#: static/js/impala/stats/csv_keys.js:98 static/js/impala/stats/csv_keys.js:99 static/js/zamboni/stats-all.js:15379 static/js/zamboni/stats-all.js:15380 static/js/zamboni/stats-min.js:5
 msgid "Browse Listing Updated Sort"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:100 static/js/impala/stats/csv_keys.js:101
+#: static/js/impala/stats/csv_keys.js:100 static/js/impala/stats/csv_keys.js:101 static/js/zamboni/stats-all.js:15381 static/js/zamboni/stats-all.js:15382 static/js/zamboni/stats-min.js:5
 msgid "Browse Listing Up and Coming Sort"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:105
+#: static/js/impala/stats/csv_keys.js:105 static/js/zamboni/stats-all.js:15386 static/js/zamboni/stats-min.js:5
 msgid "Total Amount Contributed"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:106
+#: static/js/impala/stats/csv_keys.js:106 static/js/zamboni/stats-all.js:15387 static/js/zamboni/stats-min.js:5
 msgid "Average Contribution"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:115
+#: static/js/impala/stats/csv_keys.js:115 static/js/zamboni/stats-all.js:15396 static/js/zamboni/stats-min.js:5
 msgid "Usage"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:118
+#: static/js/impala/stats/csv_keys.js:118 static/js/zamboni/stats-all.js:15399 static/js/zamboni/stats-min.js:5
 msgid "Firefox"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:119
+#: static/js/impala/stats/csv_keys.js:119 static/js/zamboni/stats-all.js:15400 static/js/zamboni/stats-min.js:5
 msgid "Mozilla"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:120
+#: static/js/impala/stats/csv_keys.js:120 static/js/zamboni/stats-all.js:15401 static/js/zamboni/stats-min.js:5
 msgid "Thunderbird"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:121
+#: static/js/impala/stats/csv_keys.js:121 static/js/zamboni/stats-all.js:15402 static/js/zamboni/stats-min.js:5
 msgid "Sunbird"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:122
+#: static/js/impala/stats/csv_keys.js:122 static/js/zamboni/stats-all.js:15403 static/js/zamboni/stats-min.js:5
 msgid "SeaMonkey"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:123
+#: static/js/impala/stats/csv_keys.js:123 static/js/zamboni/stats-all.js:15404 static/js/zamboni/stats-min.js:5
 msgid "Fennec"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:124
+#: static/js/impala/stats/csv_keys.js:124 static/js/zamboni/stats-all.js:15405 static/js/zamboni/stats-min.js:5
 msgid "Android"
 msgstr ""
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:129
+#: static/js/impala/stats/csv_keys.js:129 static/js/zamboni/stats-all.js:15410 static/js/zamboni/stats-min.js:5
 msgid "Downloads and Daily Users, last {0} days"
 msgstr ""
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:131
+#: static/js/impala/stats/csv_keys.js:131 static/js/zamboni/stats-all.js:15412 static/js/zamboni/stats-min.js:5
 msgid "Downloads and Daily Users from {0} to {1}"
 msgstr ""
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:135
+#: static/js/impala/stats/csv_keys.js:135 static/js/zamboni/stats-all.js:15416 static/js/zamboni/stats-min.js:5
 msgid "Installs and Daily Users, last {0} days"
 msgstr ""
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:137
+#: static/js/impala/stats/csv_keys.js:137 static/js/zamboni/stats-all.js:15418 static/js/zamboni/stats-min.js:5
 msgid "Installs and Daily Users from {0} to {1}"
 msgstr ""
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:141
+#: static/js/impala/stats/csv_keys.js:141 static/js/zamboni/stats-all.js:15422 static/js/zamboni/stats-min.js:5
 msgid "Downloads, last {0} days"
 msgstr ""
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:143
+#: static/js/impala/stats/csv_keys.js:143 static/js/zamboni/stats-all.js:15424 static/js/zamboni/stats-min.js:5
 msgid "Downloads from {0} to {1}"
 msgstr ""
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:147
+#: static/js/impala/stats/csv_keys.js:147 static/js/zamboni/stats-all.js:15428 static/js/zamboni/stats-min.js:5
 msgid "Daily Users, last {0} days"
 msgstr ""
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:149
+#: static/js/impala/stats/csv_keys.js:149 static/js/zamboni/stats-all.js:15430 static/js/zamboni/stats-min.js:5
 msgid "Daily Users from {0} to {1}"
 msgstr ""
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:153
+#: static/js/impala/stats/csv_keys.js:153 static/js/zamboni/stats-all.js:15434 static/js/zamboni/stats-min.js:5
 msgid "Applications, last {0} days"
 msgstr ""
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:155
+#: static/js/impala/stats/csv_keys.js:155 static/js/zamboni/stats-all.js:15436 static/js/zamboni/stats-min.js:5
 msgid "Applications from {0} to {1}"
 msgstr ""
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:159
+#: static/js/impala/stats/csv_keys.js:159 static/js/zamboni/stats-all.js:15440 static/js/zamboni/stats-min.js:5
 msgid "Platforms, last {0} days"
 msgstr ""
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:161
+#: static/js/impala/stats/csv_keys.js:161 static/js/zamboni/stats-all.js:15442 static/js/zamboni/stats-min.js:5
 msgid "Platforms from {0} to {1}"
 msgstr ""
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:165
+#: static/js/impala/stats/csv_keys.js:165 static/js/zamboni/stats-all.js:15446 static/js/zamboni/stats-min.js:5
 msgid "Languages, last {0} days"
 msgstr ""
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:167
+#: static/js/impala/stats/csv_keys.js:167 static/js/zamboni/stats-all.js:15448 static/js/zamboni/stats-min.js:5
 msgid "Languages from {0} to {1}"
 msgstr ""
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:171
+#: static/js/impala/stats/csv_keys.js:171 static/js/zamboni/stats-all.js:15452 static/js/zamboni/stats-min.js:5
 msgid "Add-on Versions, last {0} days"
 msgstr ""
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:173
+#: static/js/impala/stats/csv_keys.js:173 static/js/zamboni/stats-all.js:15454 static/js/zamboni/stats-min.js:5
 msgid "Add-on Versions from {0} to {1}"
 msgstr ""
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:177
+#: static/js/impala/stats/csv_keys.js:177 static/js/zamboni/stats-all.js:15458 static/js/zamboni/stats-min.js:5
 msgid "Add-on Status, last {0} days"
 msgstr ""
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:179
+#: static/js/impala/stats/csv_keys.js:179 static/js/zamboni/stats-all.js:15460 static/js/zamboni/stats-min.js:5
 msgid "Add-on Status from {0} to {1}"
 msgstr ""
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:183
+#: static/js/impala/stats/csv_keys.js:183 static/js/zamboni/stats-all.js:15464 static/js/zamboni/stats-min.js:5
 msgid "Download Sources, last {0} days"
 msgstr ""
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:185
+#: static/js/impala/stats/csv_keys.js:185 static/js/zamboni/stats-all.js:15466 static/js/zamboni/stats-min.js:5
 msgid "Download Sources from {0} to {1}"
 msgstr ""
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:189
+#: static/js/impala/stats/csv_keys.js:189 static/js/zamboni/stats-all.js:15470 static/js/zamboni/stats-min.js:5
 msgid "Contributions, last {0} days"
 msgstr ""
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:191
+#: static/js/impala/stats/csv_keys.js:191 static/js/zamboni/stats-all.js:15472 static/js/zamboni/stats-min.js:5
 msgid "Contributions from {0} to {1}"
 msgstr ""
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:195
+#: static/js/impala/stats/csv_keys.js:195 static/js/zamboni/stats-all.js:15476 static/js/zamboni/stats-min.js:5
 msgid "Site Metrics, last {0} days"
 msgstr ""
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:197
+#: static/js/impala/stats/csv_keys.js:197 static/js/zamboni/stats-all.js:15478 static/js/zamboni/stats-min.js:5
 msgid "Site Metrics from {0} to {1}"
 msgstr ""
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:201
+#: static/js/impala/stats/csv_keys.js:201 static/js/zamboni/stats-all.js:15482 static/js/zamboni/stats-min.js:5
 msgid "Add-ons in Use, last {0} days"
 msgstr ""
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:203
+#: static/js/impala/stats/csv_keys.js:203 static/js/zamboni/stats-all.js:15484 static/js/zamboni/stats-min.js:5
 msgid "Add-ons in Use from {0} to {1}"
 msgstr ""
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:207
+#: static/js/impala/stats/csv_keys.js:207 static/js/zamboni/stats-all.js:15488 static/js/zamboni/stats-min.js:5
 msgid "Add-ons Downloaded, last {0} days"
 msgstr ""
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:209
+#: static/js/impala/stats/csv_keys.js:209 static/js/zamboni/stats-all.js:15490 static/js/zamboni/stats-min.js:5
 msgid "Add-ons Downloaded from {0} to {1}"
 msgstr ""
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:213
+#: static/js/impala/stats/csv_keys.js:213 static/js/zamboni/stats-all.js:15494 static/js/zamboni/stats-min.js:5
 msgid "Add-ons Created, last {0} days"
 msgstr ""
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:215
+#: static/js/impala/stats/csv_keys.js:215 static/js/zamboni/stats-all.js:15496 static/js/zamboni/stats-min.js:5
 msgid "Add-ons Created from {0} to {1}"
 msgstr ""
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:219
+#: static/js/impala/stats/csv_keys.js:219 static/js/zamboni/stats-all.js:15500 static/js/zamboni/stats-min.js:5
 msgid "Add-ons Updated, last {0} days"
 msgstr ""
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:221
+#: static/js/impala/stats/csv_keys.js:221 static/js/zamboni/stats-all.js:15502 static/js/zamboni/stats-min.js:5
 msgid "Add-ons Updated from {0} to {1}"
 msgstr ""
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:225
+#: static/js/impala/stats/csv_keys.js:225 static/js/zamboni/stats-all.js:15506 static/js/zamboni/stats-min.js:5
 msgid "Reviews Written, last {0} days"
 msgstr ""
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:227
+#: static/js/impala/stats/csv_keys.js:227 static/js/zamboni/stats-all.js:15508 static/js/zamboni/stats-min.js:5
 msgid "Reviews Written from {0} to {1}"
 msgstr ""
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:231
+#: static/js/impala/stats/csv_keys.js:231 static/js/zamboni/stats-all.js:15512 static/js/zamboni/stats-min.js:5
 msgid "User Signups, last {0} days"
 msgstr ""
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:233
+#: static/js/impala/stats/csv_keys.js:233 static/js/zamboni/stats-all.js:15514 static/js/zamboni/stats-min.js:5
 msgid "User Signups from {0} to {1}"
 msgstr ""
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:237
+#: static/js/impala/stats/csv_keys.js:237 static/js/zamboni/stats-all.js:15518 static/js/zamboni/stats-min.js:5
 msgid "Collections Created, last {0} days"
 msgstr ""
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:239
+#: static/js/impala/stats/csv_keys.js:239 static/js/zamboni/stats-all.js:15520 static/js/zamboni/stats-min.js:5
 msgid "Collections Created from {0} to {1}"
 msgstr ""
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:243
+#: static/js/impala/stats/csv_keys.js:243 static/js/zamboni/stats-all.js:15524 static/js/zamboni/stats-min.js:5
 msgid "Subscribers, last {0} days"
 msgstr ""
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:245
+#: static/js/impala/stats/csv_keys.js:245 static/js/zamboni/stats-all.js:15526 static/js/zamboni/stats-min.js:5
 msgid "Subscribers from {0} to {1}"
 msgstr ""
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:249
+#: static/js/impala/stats/csv_keys.js:249 static/js/zamboni/stats-all.js:15530 static/js/zamboni/stats-min.js:5
 msgid "Ratings, last {0} days"
 msgstr ""
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:251
+#: static/js/impala/stats/csv_keys.js:251 static/js/zamboni/stats-all.js:15532 static/js/zamboni/stats-min.js:5
 msgid "Ratings from {0} to {1}"
 msgstr ""
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:255
+#: static/js/impala/stats/csv_keys.js:255 static/js/zamboni/stats-all.js:15536 static/js/zamboni/stats-min.js:5
 msgid "Sales, last {0} days"
 msgstr ""
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:257
+#: static/js/impala/stats/csv_keys.js:257 static/js/zamboni/stats-all.js:15538 static/js/zamboni/stats-min.js:5
 msgid "Sales from {0} to {1}"
 msgstr ""
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:261
+#: static/js/impala/stats/csv_keys.js:261 static/js/zamboni/stats-all.js:15542 static/js/zamboni/stats-min.js:5
 msgid "Installs, last {0} days"
 msgstr ""
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:263
+#: static/js/impala/stats/csv_keys.js:263 static/js/zamboni/stats-all.js:15544 static/js/zamboni/stats-min.js:5
 msgid "Installs from {0} to {1}"
 msgstr ""
 
 #. L10n: {0} and {1} are integers.
-#: static/js/impala/stats/csv_keys.js:269
+#: static/js/impala/stats/csv_keys.js:269 static/js/zamboni/stats-all.js:15550 static/js/zamboni/stats-min.js:5
 msgid "<b>{0}</b> in last {1} days"
 msgstr ""
 
 #. L10n: {0} is an integer and {1} and {2} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:271 static/js/impala/stats/csv_keys.js:277
+#: static/js/impala/stats/csv_keys.js:271 static/js/impala/stats/csv_keys.js:277 static/js/zamboni/stats-all.js:15552 static/js/zamboni/stats-all.js:15558 static/js/zamboni/stats-min.js:5
 msgid "<b>{0}</b> from {1} to {2}"
 msgstr ""
 
 #. L10n: {0} and {1} are integers.
-#: static/js/impala/stats/csv_keys.js:275
+#: static/js/impala/stats/csv_keys.js:275 static/js/zamboni/stats-all.js:15556 static/js/zamboni/stats-min.js:5
 msgid "<b>{0}</b> average in last {1} days"
 msgstr ""
 
-#: static/js/impala/stats/overview.js:19
+#: static/js/impala/stats/overview.js:19 static/js/zamboni/stats-all.js:16469 static/js/zamboni/stats-min.js:5
 msgid "No data available."
 msgstr ""
 
-#: static/js/impala/stats/table.js:74
+#: static/js/impala/stats/table.js:74 static/js/zamboni/stats-all.js:17209 static/js/zamboni/stats-min.js:5
 msgid "Date"
 msgstr ""
 
-#: static/js/impala/stats/topchart.js:96
+#: static/js/impala/stats/topchart.js:96 static/js/zamboni/stats-all.js:16600 static/js/zamboni/stats-min.js:5
 msgid "Other"
 msgstr ""
 
-#: static/js/zamboni/admin_validation.js:24 static/js/zamboni/devhub.js:1229 static/js/zamboni/editors.js:295
+#: static/js/zamboni/admin-all.js:180 static/js/zamboni/admin-min.js:1 static/js/zamboni/admin_validation.js:24 static/js/zamboni/devhub-all.js:2408 static/js/zamboni/devhub-min.js:2
+#: static/js/zamboni/devhub.js:1229 static/js/zamboni/editors-all.js:15576 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:295
 msgid "Select an application first"
 msgstr ""
 
-#: static/js/zamboni/admin_validation.js:51
+#: static/js/zamboni/admin-all.js:207 static/js/zamboni/admin-min.js:1 static/js/zamboni/admin_validation.js:51
 msgid "Set {0} add-on to a max version of {1} and email the author."
 msgid_plural "Set {0} add-ons to a max version of {1} and email the authors."
 msgstr[0] ""
 msgstr[1] ""
 
-#: static/js/zamboni/admin_validation.js:54
+#: static/js/zamboni/admin-all.js:210 static/js/zamboni/admin-min.js:1 static/js/zamboni/admin_validation.js:54
 msgid "Email author of {2} add-on which failed validation."
 msgid_plural "Email authors of {2} add-ons which failed validation."
 msgstr[0] ""
 msgstr[1] ""
 
-#. L10n: {0} is an app name like Firefox.
-#: static/js/zamboni/buttons.js:66
-msgid "Accept and Install"
-msgstr ""
-
-#: static/js/zamboni/buttons.js:66
-msgid "Add to {0}"
-msgstr ""
-
-#: static/js/zamboni/buttons.js:71
-msgid "Download Now"
-msgstr ""
-
-#: static/js/zamboni/buttons.js:112
-msgid "Add-on has not been updated to support default-to-compatible."
-msgstr ""
-
-#: static/js/zamboni/buttons.js:117
-msgid "You need to be using Firefox 10.0 or higher."
-msgstr ""
-
-#: static/js/zamboni/buttons.js:129
-msgid "Mozilla has marked this version as incompatible with your Firefox version."
-msgstr ""
-
-#. L10n: {0} is an platform like Windows or Linux.
-#: static/js/zamboni/buttons.js:210
-msgid "Install for {0} anyway"
-msgstr ""
-
-#: static/js/zamboni/buttons.js:210
-msgid "Download for {0} anyway"
-msgstr ""
-
-#: static/js/zamboni/buttons.js:267
-msgid "Not available for your platform"
-msgstr ""
-
-#. L10n: {0} is an app name, {1} is the app version.
-#: static/js/zamboni/buttons.js:278 static/js/zamboni/buttons.js:315
-msgid "Not available for {0} {1}"
-msgstr ""
-
-#: static/js/zamboni/buttons.js:341
-msgid "Works with {app} {min} - {max}"
-msgstr ""
-
-#: static/js/zamboni/buttons.js:343
-msgid "View other versions"
-msgstr ""
-
-#: static/js/zamboni/buttons.js:391
-msgid "Only with Firefox — Get Firefox Now!"
-msgstr ""
-
-#: static/js/zamboni/buttons.js:507 static/js/zamboni/mobile/buttons.js:43
-msgid "Sorry, you need a Mozilla-based browser (such as Firefox) to install a search plugin."
-msgstr ""
-
-#: static/js/zamboni/collections.js:229
-msgid "Adding to Favorites&hellip;"
-msgstr ""
-
-#: static/js/zamboni/collections.js:232
-msgid "Removing Favorite&hellip;"
-msgstr ""
-
-#: static/js/zamboni/collections.js:235
-msgid "Add to Favorites"
-msgstr ""
-
-#: static/js/zamboni/collections.js:238
-msgid "Remove from Favorites"
-msgstr ""
-
-#: static/js/zamboni/collections.js:303
-msgid "Pending"
-msgstr ""
-
-#: static/js/zamboni/collections.js:304
-msgid "Add a comment"
-msgstr ""
-
-#: static/js/zamboni/collections.js:304
-msgid "Comment"
-msgstr ""
-
-#: static/js/zamboni/collections.js:305
-msgid "Remove this add-on from the collection"
-msgstr ""
-
-#: static/js/zamboni/collections.js:305 static/js/zamboni/collections.js:334
-msgid "Remove"
-msgstr ""
-
-#: static/js/zamboni/collections.js:334
-msgid "Remove this user as a contributor"
-msgstr ""
-
-#: static/js/zamboni/collections.js:346
-msgid "An email address is required."
-msgstr ""
-
-#: static/js/zamboni/collections.js:364
-msgid "You cannot add yourself as a contributor."
-msgstr ""
-
-#: static/js/zamboni/collections.js:366
-msgid "You have already added that user."
-msgstr ""
-
-#: static/js/zamboni/collections.js:573
-msgid "Add to favorites"
-msgstr ""
-
-#: static/js/zamboni/collections.js:577
-msgid "Remove from favorites"
-msgstr ""
-
-#: static/js/zamboni/collections.js:604
-msgid "Stop following"
-msgstr ""
-
-#: static/js/zamboni/devhub.js:110
+#: static/js/zamboni/devhub-all.js:1289 static/js/zamboni/devhub-min.js:1 static/js/zamboni/devhub.js:110
 msgid "Your browser does not support the video tag"
 msgstr ""
 
-#: static/js/zamboni/devhub.js:371
+#: static/js/zamboni/devhub-all.js:1550 static/js/zamboni/devhub-min.js:1 static/js/zamboni/devhub.js:371
 msgid "Changes Saved"
 msgstr ""
 
-#: static/js/zamboni/devhub.js:387
+#: static/js/zamboni/devhub-all.js:1566 static/js/zamboni/devhub-min.js:1 static/js/zamboni/devhub.js:387
 msgid "Enter a new author's email address"
 msgstr ""
 
-#: static/js/zamboni/devhub.js:536
+#: static/js/zamboni/devhub-all.js:1715 static/js/zamboni/devhub-min.js:1 static/js/zamboni/devhub.js:536
 msgid "There was an error uploading your file."
 msgstr ""
 
-#: static/js/zamboni/devhub.js:681
+#: static/js/zamboni/devhub-all.js:1860 static/js/zamboni/devhub-min.js:1 static/js/zamboni/devhub.js:681
 msgid "{files} file"
 msgid_plural "{files} files"
 msgstr[0] ""
 msgstr[1] ""
 
-#: static/js/zamboni/devhub.js:684
+#: static/js/zamboni/devhub-all.js:1863 static/js/zamboni/devhub-min.js:1 static/js/zamboni/devhub.js:684
 msgid "{reviews} user review"
 msgid_plural "{reviews} user reviews"
 msgstr[0] ""
 msgstr[1] ""
 
-#: static/js/zamboni/devhub.js:796
+#: static/js/zamboni/devhub-all.js:1975 static/js/zamboni/devhub-min.js:2 static/js/zamboni/devhub.js:796
 msgid "Learn more"
 msgstr ""
 
-#: static/js/zamboni/devhub.js:800
+#: static/js/zamboni/devhub-all.js:1979 static/js/zamboni/devhub-min.js:2 static/js/zamboni/devhub.js:800
 msgid "Example"
 msgstr ""
 
-#: static/js/zamboni/devhub.js:1130
+#: static/js/zamboni/devhub-all.js:2309 static/js/zamboni/devhub-min.js:2 static/js/zamboni/devhub.js:1130
 msgid "Image changes being processed"
 msgstr ""
 
-#: static/js/zamboni/devhub.js:1280
+#: static/js/zamboni/devhub-all.js:2459 static/js/zamboni/devhub-min.js:2 static/js/zamboni/devhub.js:1280
 msgid "Must be a valid e-mail address."
+msgstr ""
+
+#: static/js/zamboni/devhub-all.js:2613 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:80
+msgid "All tests passed successfully."
+msgstr ""
+
+#: static/js/zamboni/devhub-all.js:2616 static/js/zamboni/devhub-all.js:3011 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:83 static/js/zamboni/validator.js:478
+msgid "These tests were not run."
+msgstr ""
+
+#: static/js/zamboni/devhub-all.js:2664 static/js/zamboni/devhub-all.js:2677 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:131 static/js/zamboni/validator.js:144
+msgid "Tests"
+msgstr ""
+
+#: static/js/zamboni/devhub-all.js:2779 static/js/zamboni/devhub-all.js:3108 static/js/zamboni/devhub-all.js:3127 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:246
+#: static/js/zamboni/validator.js:575 static/js/zamboni/validator.js:594
+msgid "Error"
+msgstr ""
+
+#: static/js/zamboni/devhub-all.js:2780 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:247
+msgid "Warning"
+msgstr ""
+
+#: static/js/zamboni/devhub-all.js:2794 static/js/zamboni/devhub-min.js:2 static/js/zamboni/files-all.js:5657 static/js/zamboni/files-min.js:3 static/js/zamboni/files.js:411
+#: static/js/zamboni/validator.js:261
+msgid "Ignore this message in future updates"
+msgstr ""
+
+#: static/js/zamboni/devhub-all.js:2817 static/js/zamboni/devhub-min.js:2 static/js/zamboni/files-all.js:5663 static/js/zamboni/files-min.js:3 static/js/zamboni/files.js:417
+#: static/js/zamboni/validator.js:284
+msgid "Severity for automated signing:"
+msgstr ""
+
+#: static/js/zamboni/devhub-all.js:2832 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:299
+msgid "Suggestions for passing automated signing:"
+msgstr ""
+
+#: static/js/zamboni/devhub-all.js:2920 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:387
+msgid "Compatibility Tests"
+msgstr ""
+
+#: static/js/zamboni/devhub-all.js:2999 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:466
+msgid "Add-on failed validation."
+msgstr ""
+
+#: static/js/zamboni/devhub-all.js:3001 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:468
+msgid "Add-on passed validation."
+msgstr ""
+
+#: static/js/zamboni/devhub-all.js:3014 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:481
+msgid "{0} error"
+msgid_plural "{0} errors"
+msgstr[0] ""
+msgstr[1] ""
+
+#: static/js/zamboni/devhub-all.js:3016 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:483
+msgid "{0} warning"
+msgid_plural "{0} warnings"
+msgstr[0] ""
+msgstr[1] ""
+
+#: static/js/zamboni/devhub-all.js:3018 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:485
+msgid "{0} notice"
+msgid_plural "{0} notices"
+msgstr[0] ""
+msgstr[1] ""
+
+#: static/js/zamboni/devhub-all.js:3110 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:577
+msgid "Validation task could not complete or completed with errors"
+msgstr ""
+
+#: static/js/zamboni/devhub-all.js:3128 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:595
+msgid "Internal server error"
 msgstr ""
 
 #: static/js/zamboni/devhub_search.js:8
 msgid "No results found."
 msgstr ""
 
-#: static/js/zamboni/editors.js:121
+#: static/js/zamboni/editors-all.js:15402 static/js/zamboni/editors-min.js:4 static/js/zamboni/editors.js:121
 msgid "{name} was viewing this page first."
 msgstr ""
 
-#: static/js/zamboni/editors.js:171
+#: static/js/zamboni/editors-all.js:15452 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:171
 msgid "Receipt checked by app."
 msgstr ""
 
-#: static/js/zamboni/editors.js:173
+#: static/js/zamboni/editors-all.js:15454 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:173
 msgid "Receipt was not checked by app."
 msgstr ""
 
-#: static/js/zamboni/editors.js:244
+#: static/js/zamboni/editors-all.js:15525 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:244
 msgid "{name} was viewing this add-on first."
 msgstr ""
 
-#: static/js/zamboni/editors.js:255
+#: static/js/zamboni/editors-all.js:15536 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:255
 msgid "Loading&hellip;"
 msgstr ""
 
-#: static/js/zamboni/editors.js:260
+#: static/js/zamboni/editors-all.js:15541 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:260
 msgid "Version Notes"
 msgstr ""
 
-#: static/js/zamboni/editors.js:265
+#: static/js/zamboni/editors-all.js:15546 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:265
 msgid "Notes for Reviewers"
 msgstr ""
 
-#: static/js/zamboni/editors.js:270
+#: static/js/zamboni/editors-all.js:15551 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:270
 msgid "No version notes found"
 msgstr ""
 
-#: static/js/zamboni/editors.js:330
+#: static/js/zamboni/editors-all.js:15611 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:330
 msgid "Average Reviews"
 msgstr ""
 
-#: static/js/zamboni/editors.js:386
+#: static/js/zamboni/editors-all.js:15667 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:386
 msgid "Number of Reviews"
 msgstr ""
 
-#: static/js/zamboni/editors.js:445
+#: static/js/zamboni/editors-all.js:15726 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:445
 msgid "Error loading translation"
 msgstr ""
 
-#: static/js/zamboni/files.js:411 static/js/zamboni/validator.js:261
-msgid "Ignore this message in future updates"
-msgstr ""
-
-#: static/js/zamboni/files.js:417 static/js/zamboni/validator.js:284
-msgid "Severity for automated signing:"
-msgstr ""
-
-#: static/js/zamboni/global.js:410
-msgid "Loading..."
-msgstr ""
-
-#. L10n: {0} is the number of characters left.
-#: static/js/zamboni/global.js:474
-msgid "<b>{0}</b> character left."
-msgid_plural "<b>{0}</b> characters left."
-msgstr[0] ""
-msgstr[1] ""
-
-#: static/js/zamboni/init.js:28
-msgid "This feature is temporarily disabled while we perform website maintenance. Please check back a little later."
-msgstr ""
-
-#: static/js/zamboni/l10n.js:45
-msgid "Remove this localization"
-msgstr ""
-
-#: static/js/zamboni/password-strength.js:20
-msgid "Password strength:"
-msgstr ""
-
-#: static/js/zamboni/password-strength.js:26
-msgid "At least {0} character left."
-msgid_plural "At least {0} characters left."
-msgstr[0] ""
-msgstr[1] ""
-
-#: static/js/zamboni/themes_review.js:176
-msgid "Requested Info"
-msgstr ""
-
-#: static/js/zamboni/themes_review.js:177
-msgid "Flagged"
-msgstr ""
-
-#: static/js/zamboni/themes_review.js:178
-msgid "Duplicate"
-msgstr ""
-
-#: static/js/zamboni/themes_review.js:179
-msgid "Rejected"
-msgstr ""
-
-#: static/js/zamboni/themes_review.js:180
-msgid "Approved"
-msgstr ""
-
-#: static/js/zamboni/themes_review.js:424
-msgid "No results found"
-msgstr ""
-
-#: static/js/zamboni/themes_review_templates.js:31
+#: static/js/zamboni/editors-all.js:15975 static/js/zamboni/editors-min.js:5 static/js/zamboni/themes_review_templates.js:31
 msgid "Theme"
 msgstr ""
 
-#: static/js/zamboni/themes_review_templates.js:33
+#: static/js/zamboni/editors-all.js:15977 static/js/zamboni/editors-min.js:5 static/js/zamboni/themes_review_templates.js:33
 msgid "Reviewer"
 msgstr ""
 
-#: static/js/zamboni/themes_review_templates.js:35
+#: static/js/zamboni/editors-all.js:15979 static/js/zamboni/editors-min.js:5 static/js/zamboni/themes_review_templates.js:35
 msgid "Status"
 msgstr ""
 
-#: static/js/zamboni/validator.js:80
-msgid "All tests passed successfully."
+#: static/js/zamboni/editors-all.js:16196 static/js/zamboni/editors-min.js:5 static/js/zamboni/themes_review.js:176
+msgid "Requested Info"
 msgstr ""
 
-#: static/js/zamboni/validator.js:83 static/js/zamboni/validator.js:478
-msgid "These tests were not run."
+#: static/js/zamboni/editors-all.js:16197 static/js/zamboni/editors-min.js:5 static/js/zamboni/themes_review.js:177
+msgid "Flagged"
 msgstr ""
 
-#: static/js/zamboni/validator.js:131 static/js/zamboni/validator.js:144
-msgid "Tests"
+#: static/js/zamboni/editors-all.js:16198 static/js/zamboni/editors-min.js:5 static/js/zamboni/themes_review.js:178
+msgid "Duplicate"
 msgstr ""
 
-#: static/js/zamboni/validator.js:246 static/js/zamboni/validator.js:575 static/js/zamboni/validator.js:594
-msgid "Error"
+#: static/js/zamboni/editors-all.js:16199 static/js/zamboni/editors-min.js:5 static/js/zamboni/themes_review.js:179
+msgid "Rejected"
 msgstr ""
 
-#: static/js/zamboni/validator.js:247
-msgid "Warning"
+#: static/js/zamboni/editors-all.js:16200 static/js/zamboni/editors-min.js:5 static/js/zamboni/themes_review.js:180
+msgid "Approved"
 msgstr ""
 
-#: static/js/zamboni/validator.js:299
-msgid "Suggestions for passing automated signing:"
+#: static/js/zamboni/editors-all.js:16444 static/js/zamboni/editors-min.js:5 static/js/zamboni/themes_review.js:424
+msgid "No results found"
 msgstr ""
 
-#: static/js/zamboni/validator.js:387
-msgid "Compatibility Tests"
-msgstr ""
-
-#: static/js/zamboni/validator.js:466
-msgid "Add-on failed validation."
-msgstr ""
-
-#: static/js/zamboni/validator.js:468
-msgid "Add-on passed validation."
-msgstr ""
-
-#: static/js/zamboni/validator.js:481
-msgid "{0} error"
-msgid_plural "{0} errors"
-msgstr[0] ""
-msgstr[1] ""
-
-#: static/js/zamboni/validator.js:483
-msgid "{0} warning"
-msgid_plural "{0} warnings"
-msgstr[0] ""
-msgstr[1] ""
-
-#: static/js/zamboni/validator.js:485
-msgid "{0} notice"
-msgid_plural "{0} notices"
-msgstr[0] ""
-msgstr[1] ""
-
-#: static/js/zamboni/validator.js:577
-msgid "Validation task could not complete or completed with errors"
-msgstr ""
-
-#: static/js/zamboni/validator.js:595
-msgid "Internal server error"
-msgstr ""
-
-#: static/js/zamboni/mobile/buttons.js:52
+#: static/js/zamboni/mobile-all.js:15186 static/js/zamboni/mobile/buttons.js:52
 msgid "Not Updated for {0} {1}"
 msgstr ""
 
-#: static/js/zamboni/mobile/buttons.js:53
+#: static/js/zamboni/mobile-all.js:15187 static/js/zamboni/mobile/buttons.js:53
 msgid "Requires Newer Version of {0}"
 msgstr ""
 
-#: static/js/zamboni/mobile/buttons.js:54
+#: static/js/zamboni/mobile-all.js:15188 static/js/zamboni/mobile/buttons.js:54
 msgid "Unreviewed"
 msgstr ""
 
-#: static/js/zamboni/mobile/buttons.js:55
+#: static/js/zamboni/mobile-all.js:15189 static/js/zamboni/mobile/buttons.js:55
 msgid "Experimental <span>(Learn More)</span>"
 msgstr ""
 
-#: static/js/zamboni/mobile/buttons.js:56 static/js/zamboni/mobile/buttons.js:57
+#: static/js/zamboni/mobile-all.js:15190 static/js/zamboni/mobile-all.js:15191 static/js/zamboni/mobile/buttons.js:56 static/js/zamboni/mobile/buttons.js:57
 msgid "Not Available for {0}"
 msgstr ""
 
-#: static/js/zamboni/mobile/buttons.js:58
+#: static/js/zamboni/mobile-all.js:15192 static/js/zamboni/mobile/buttons.js:58
 msgid "Experimental"
 msgstr ""
 
-#: static/js/zamboni/mobile/buttons.js:59
+#: static/js/zamboni/mobile-all.js:15193 static/js/zamboni/mobile/buttons.js:59
 msgid "Themes Require Newer Version of {0}"
 msgstr ""
 
-#: static/js/zamboni/mobile/buttons.js:60
+#: static/js/zamboni/mobile-all.js:15194 static/js/zamboni/mobile/buttons.js:60
 msgid "Themes Require {0}"
 msgstr ""
 
-#: static/js/zamboni/mobile/buttons.js:105
+#: static/js/zamboni/mobile-all.js:15239 static/js/zamboni/mobile/buttons.js:105
 msgid "Installing..."
 msgstr ""
 
-#: static/js/zamboni/mobile/buttons.js:125
+#: static/js/zamboni/mobile-all.js:15259 static/js/zamboni/mobile/buttons.js:125
 msgid "This add-on has been preliminarily reviewed by Mozilla."
 msgstr ""
 
-#: static/js/zamboni/mobile/buttons.js:250
+#: static/js/zamboni/mobile-all.js:15384 static/js/zamboni/mobile/buttons.js:250
 msgid "Keep it"
 msgstr ""
 
-#: static/js/zamboni/mobile/general.js:344
+#: static/js/zamboni/mobile-all.js:16049 static/js/zamboni/mobile-min.js:6 static/js/zamboni/mobile/general.js:344
 msgid "You're trying it on!"
 msgstr ""
 
-#: static/js/zamboni/mobile/general.js:356
+#: static/js/zamboni/mobile-all.js:16061 static/js/zamboni/mobile-min.js:6 static/js/zamboni/mobile/general.js:356
 msgid "Added to Firefox"
 msgstr ""
-

--- a/locale/ml/LC_MESSAGES/django.po
+++ b/locale/ml/LC_MESSAGES/django.po
@@ -3,69 +3,70 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2016-02-24 21:23+0000\n"
+"POT-Creation-Date: 2016-04-18 15:47+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
+"Language: \n"
 "MIME-Version: 1.0\n"
-"Content-Type: text/plain; charset=utf-8\n"
+"Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Generated-By: Babel 2.2.0\n"
 
-#: src/olympia/accounts/views.py:52
+#: src/olympia/accounts/views.py:54
 msgid "Your log in attempt could not be parsed. Please try again."
 msgstr ""
 
-#: src/olympia/accounts/views.py:54
+#: src/olympia/accounts/views.py:56
 msgid "Your Firefox Account could not be found. Please try again."
 msgstr ""
 
-#: src/olympia/accounts/views.py:55
+#: src/olympia/accounts/views.py:57
 msgid "You could not be logged in. Please try again."
 msgstr ""
 
-#: src/olympia/accounts/views.py:57
+#: src/olympia/accounts/views.py:59
 msgid "Your account has already been migrated to Firefox Accounts."
 msgstr ""
 
-#: src/olympia/accounts/views.py:59
+#: src/olympia/accounts/views.py:61
 msgid "Your Firefox Account already exists on this site."
 msgstr ""
 
-#: src/olympia/accounts/views.py:108
+#: src/olympia/accounts/views.py:110
 msgid "Great job!"
 msgstr ""
 
-#: src/olympia/accounts/views.py:109
+#: src/olympia/accounts/views.py:111
 msgid "You can now log in to Add-ons with your Firefox Account."
 msgstr ""
 
-#: src/olympia/accounts/views.py:121
+#: src/olympia/accounts/views.py:123
 msgid "Need help?"
 msgstr ""
 
-#: src/olympia/addons/buttons.py:180
+#: src/olympia/addons/buttons.py:177
 msgid "Download Now"
 msgstr ""
 
-#: src/olympia/addons/buttons.py:182
+#: src/olympia/addons/buttons.py:179
 msgid "Download"
 msgstr ""
 
 #. L10n: please keep &nbsp; in the string so &rarr; does not wrap.
-#: src/olympia/addons/buttons.py:186
+#: src/olympia/addons/buttons.py:183
 msgid "Continue to Download&nbsp;&rarr;"
 msgstr ""
 
-#: src/olympia/addons/buttons.py:202 src/olympia/addons/helpers.py:35 src/olympia/addons/views.py:319 src/olympia/addons/templates/addons/impala/details.html:114
+#: src/olympia/addons/buttons.py:199 src/olympia/addons/helpers.py:35 src/olympia/addons/views.py:333 src/olympia/addons/templates/addons/impala/details.html:111
 #: src/olympia/addons/templates/addons/impala/listing/items.html:17 src/olympia/addons/templates/addons/mobile/home.html:40 src/olympia/amo/templates/amo/side_nav.html:6
-#: src/olympia/amo/templates/amo/side_nav.html:10 src/olympia/amo/templates/amo/site_nav.html:2 src/olympia/amo/templates/amo/site_nav.html:55 src/olympia/bandwagon/views.py:95
-#: src/olympia/browse/views.py:54 src/olympia/browse/views.py:68 src/olympia/browse/views.py:235 src/olympia/browse/templates/browse/impala/category_landing.html:22
+#: src/olympia/amo/templates/amo/side_nav.html:10 src/olympia/amo/templates/amo/site_nav.html:2 src/olympia/amo/templates/amo/site_nav.html:53 src/olympia/bandwagon/views.py:95
+#: src/olympia/browse/views.py:54 src/olympia/browse/views.py:68 src/olympia/browse/views.py:202 src/olympia/browse/templates/browse/impala/category_landing.html:22
 #: src/olympia/browse/templates/browse/personas/mobile/category_landing.html:26
 msgid "Featured"
 msgstr ""
 
-#: src/olympia/addons/buttons.py:221
+#: src/olympia/addons/buttons.py:218
 msgid "Add to {0}"
 msgstr ""
 
@@ -113,39 +114,39 @@ msgid_plural "All tags must be at least {0} characters."
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/olympia/addons/forms.py:234
+#: src/olympia/addons/forms.py:238
 msgid "Categories cannot be changed while your add-on is featured for this application."
 msgstr ""
 
 #. L10n: {0} is the number of categories.
-#: src/olympia/addons/forms.py:238
+#: src/olympia/addons/forms.py:242
 msgid "You can have only {0} category."
 msgid_plural "You can have only {0} categories."
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/olympia/addons/forms.py:246
+#: src/olympia/addons/forms.py:250
 msgid "The miscellaneous category cannot be combined with additional categories."
 msgstr ""
 
-#: src/olympia/addons/forms.py:369
+#: src/olympia/addons/forms.py:374
 #, python-format
 msgid "Before changing your default locale you must have a name, summary, and description in that locale. You are missing %s."
 msgstr ""
 
-#: src/olympia/addons/forms.py:484 src/olympia/addons/forms.py:575
+#: src/olympia/addons/forms.py:455 src/olympia/addons/forms.py:546
 msgid "A license must be selected."
 msgstr ""
 
-#: src/olympia/addons/forms.py:556
+#: src/olympia/addons/forms.py:527
 msgid "Give Your Theme a Name."
 msgstr ""
 
-#: src/olympia/addons/forms.py:562 src/olympia/devhub/templates/devhub/personas/submit.html:53
+#: src/olympia/addons/forms.py:533 src/olympia/devhub/templates/devhub/personas/submit.html:53
 msgid "Describe your Theme."
 msgstr ""
 
-#: src/olympia/addons/forms.py:704
+#: src/olympia/addons/forms.py:675
 msgid "Enter a new author's email address"
 msgstr ""
 
@@ -153,37 +154,37 @@ msgstr ""
 msgid "Not Reviewed"
 msgstr ""
 
-#: src/olympia/addons/models.py:301
+#: src/olympia/addons/models.py:298
 msgid "Users have the option of contributing more or less than this amount."
 msgstr ""
 
-#: src/olympia/addons/models.py:309
-msgid "Users will always be asked in the Add-ons Manager (Firefox 4 and above)"
+#: src/olympia/addons/models.py:306
+msgid "Users will always be asked in the Add-ons Manager (Firefox 4 and above). Only applies to desktop."
 msgstr ""
 
-#: src/olympia/addons/models.py:1804 src/olympia/addons/templates/addons/details_box.html:55 src/olympia/devhub/templates/devhub/index.html:92
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:102
+#: src/olympia/addons/models.py:1802 src/olympia/addons/templates/addons/details_box.html:55 src/olympia/devhub/templates/devhub/index.html:92
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:89
 msgid "Listed"
 msgstr ""
 
-#: src/olympia/addons/views.py:320 src/olympia/browse/templates/browse/personas/mobile/category_landing.html:27
+#: src/olympia/addons/views.py:334 src/olympia/browse/templates/browse/personas/mobile/category_landing.html:27
 msgid "Popular"
 msgstr ""
 
-#: src/olympia/addons/views.py:321 src/olympia/browse/views.py:238 src/olympia/browse/views.py:280 src/olympia/browse/views.py:482
+#: src/olympia/addons/views.py:335 src/olympia/browse/views.py:205 src/olympia/browse/views.py:247 src/olympia/browse/views.py:449
 msgid "Recently Added"
 msgstr ""
 
-#: src/olympia/addons/views.py:322 src/olympia/bandwagon/views.py:99 src/olympia/browse/views.py:60 src/olympia/browse/views.py:71 src/olympia/search/forms.py:16 src/olympia/search/forms.py:91
+#: src/olympia/addons/views.py:336 src/olympia/bandwagon/views.py:99 src/olympia/browse/views.py:60 src/olympia/browse/views.py:71 src/olympia/search/forms.py:16 src/olympia/search/forms.py:91
 msgid "Recently Updated"
 msgstr ""
 
 #. l10n: {0} is the addon name
-#: src/olympia/addons/views.py:520
+#: src/olympia/addons/views.py:534
 msgid "Contribution for {0}"
 msgstr ""
 
-#: src/olympia/addons/views.py:613
+#: src/olympia/addons/views.py:627
 msgid "Abuse reported."
 msgstr ""
 
@@ -250,9 +251,9 @@ msgstr ""
 #: src/olympia/devhub/templates/devhub/addons/ajax_compat_update.html:36 src/olympia/devhub/templates/devhub/addons/profile.html:44 src/olympia/devhub/templates/devhub/addons/edit/admin.html:101
 #: src/olympia/devhub/templates/devhub/addons/edit/basic.html:152 src/olympia/devhub/templates/devhub/addons/edit/details.html:85 src/olympia/devhub/templates/devhub/addons/edit/support.html:67
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:166 src/olympia/devhub/templates/devhub/addons/forms_shared/media.html:149
-#: src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:44 src/olympia/devhub/templates/devhub/versions/add_file_modal.html:78 src/olympia/devhub/templates/devhub/versions/edit.html:139
-#: src/olympia/devhub/templates/devhub/versions/list.html:242 src/olympia/devhub/templates/devhub/versions/list.html:276 src/olympia/devhub/templates/devhub/versions/list.html:317
-#: src/olympia/devhub/templates/devhub/versions/list.html:351 src/olympia/reviews/templates/reviews/edit_review.html:16 src/olympia/translations/templates/translations/trans-menu.html:50
+#: src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:43 src/olympia/devhub/templates/devhub/versions/add_file_modal.html:58 src/olympia/devhub/templates/devhub/versions/edit.html:139
+#: src/olympia/devhub/templates/devhub/versions/list.html:239 src/olympia/devhub/templates/devhub/versions/list.html:281 src/olympia/devhub/templates/devhub/versions/list.html:315
+#: src/olympia/devhub/templates/devhub/versions/list.html:349 src/olympia/reviews/templates/reviews/edit_review.html:16 src/olympia/translations/templates/translations/trans-menu.html:50
 #: src/olympia/translations/templates/translations/trans-menu.html:62
 msgid "or"
 msgstr ""
@@ -363,7 +364,7 @@ msgid "Add-on Information for {0}"
 msgstr ""
 
 #: src/olympia/addons/templates/addons/details_box.html:30 src/olympia/addons/templates/addons/persona_detail_table.html:3 src/olympia/addons/templates/addons/mobile/details.html:63
-#: src/olympia/addons/templates/addons/mobile/persona_detail_table.html:7 src/olympia/browse/views.py:459 src/olympia/devhub/views.py:75
+#: src/olympia/addons/templates/addons/mobile/persona_detail_table.html:7 src/olympia/browse/views.py:426 src/olympia/devhub/views.py:73
 msgid "Updated"
 msgstr ""
 
@@ -382,11 +383,11 @@ msgstr ""
 msgid "Visibility"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/details_box.html:57 src/olympia/devhub/templates/devhub/index.html:94 src/olympia/devhub/templates/devhub/includes/addon_details.html:104
+#: src/olympia/addons/templates/addons/details_box.html:57 src/olympia/devhub/templates/devhub/index.html:94 src/olympia/devhub/templates/devhub/includes/addon_details.html:91
 msgid "Hidden"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/details_box.html:59 src/olympia/devhub/templates/devhub/index.html:96 src/olympia/devhub/templates/devhub/includes/addon_details.html:106
+#: src/olympia/addons/templates/addons/details_box.html:59 src/olympia/devhub/templates/devhub/index.html:96 src/olympia/devhub/templates/devhub/includes/addon_details.html:93
 msgid "Unlisted"
 msgstr ""
 
@@ -394,13 +395,13 @@ msgstr ""
 msgid "Required Add-ons"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/details_box.html:81 src/olympia/addons/templates/addons/persona_detail_table.html:15 src/olympia/browse/views.py:462 src/olympia/devhub/views.py:78
-#: src/olympia/devhub/views.py:85 src/olympia/discovery/templates/discovery/addons/detail.html:57 src/olympia/reviews/forms.py:62 src/olympia/reviews/templates/reviews/add.html:57
+#: src/olympia/addons/templates/addons/details_box.html:81 src/olympia/addons/templates/addons/persona_detail_table.html:15 src/olympia/browse/views.py:429 src/olympia/devhub/views.py:76
+#: src/olympia/devhub/views.py:83 src/olympia/discovery/templates/discovery/addons/detail.html:57 src/olympia/reviews/forms.py:62 src/olympia/reviews/templates/reviews/add.html:57
 #: src/olympia/reviews/templates/reviews/mobile/review_list.html:18
 msgid "Rating"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/details_box.html:85 src/olympia/browse/views.py:461 src/olympia/devhub/views.py:77 src/olympia/devhub/views.py:84
+#: src/olympia/addons/templates/addons/details_box.html:85 src/olympia/browse/views.py:428 src/olympia/devhub/views.py:75 src/olympia/devhub/views.py:82
 #: src/olympia/stats/templates/stats/addon_report_menu.html:8 src/olympia/stats/templates/stats/collection_report_menu.html:18
 msgid "Downloads"
 msgstr ""
@@ -420,7 +421,7 @@ msgstr ""
 
 #. The Privacy Policy for this add-on.
 #: src/olympia/addons/templates/addons/details_box.html:121 src/olympia/addons/templates/addons/privacy.html:19 src/olympia/addons/templates/addons/privacy.html:23
-#: src/olympia/addons/templates/addons/impala/button.html:43 src/olympia/addons/templates/addons/impala/details.html:307 src/olympia/devhub/templates/devhub/includes/policy_form.html:20
+#: src/olympia/addons/templates/addons/impala/button.html:43 src/olympia/addons/templates/addons/impala/details.html:312 src/olympia/devhub/templates/devhub/includes/policy_form.html:23
 #: src/olympia/templates/mobile/base_addons.html:87
 msgid "Privacy Policy"
 msgstr ""
@@ -445,7 +446,7 @@ msgstr ""
 msgid "Developer Comments"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/details_box.html:199 src/olympia/addons/templates/addons/impala/details.html:259
+#: src/olympia/addons/templates/addons/details_box.html:199 src/olympia/addons/templates/addons/impala/details.html:264
 msgid "Development Channel"
 msgstr ""
 
@@ -465,7 +466,7 @@ msgid ""
 "developer. To stop receiving development updates, reinstall the default version from the link above."
 msgstr ""
 
-#: src/olympia/addons/templates/addons/details_box.html:220 src/olympia/addons/templates/addons/impala/details.html:278
+#: src/olympia/addons/templates/addons/details_box.html:220 src/olympia/addons/templates/addons/impala/details.html:283
 msgid "Version {0}:"
 msgstr ""
 
@@ -484,7 +485,7 @@ msgid "End-User License Agreement for {0}"
 msgstr ""
 
 #: src/olympia/addons/templates/addons/eula.html:17 src/olympia/addons/templates/addons/eula.html:21 src/olympia/addons/templates/addons/impala/button.html:48
-#: src/olympia/addons/templates/addons/impala/details.html:316 src/olympia/devhub/templates/devhub/includes/policy_form.html:3 src/olympia/discovery/templates/discovery/addons/eula.html:11
+#: src/olympia/addons/templates/addons/impala/details.html:321 src/olympia/devhub/templates/devhub/includes/policy_form.html:3 src/olympia/discovery/templates/discovery/addons/eula.html:11
 msgid "End-User License Agreement"
 msgstr ""
 
@@ -501,7 +502,7 @@ msgstr ""
 msgid "Add-ons for {0}"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/home.html:10 src/olympia/addons/templates/addons/home.html:51 src/olympia/browse/templates/browse/impala/base_listing.html:11
+#: src/olympia/addons/templates/addons/home.html:10 src/olympia/addons/templates/addons/home.html:53 src/olympia/browse/templates/browse/impala/base_listing.html:11
 msgid "Featured Extensions"
 msgstr ""
 
@@ -509,29 +510,29 @@ msgstr ""
 msgid "Popular Extensions"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/home.html:42 src/olympia/amo/templates/amo/side_nav.html:3 src/olympia/amo/templates/amo/side_nav.html:11 src/olympia/amo/templates/amo/site_nav.html:3
-#: src/olympia/amo/templates/amo/site_nav.html:25 src/olympia/browse/views.py:236 src/olympia/browse/views.py:281 src/olympia/browse/views.py:481
+#: src/olympia/addons/templates/addons/home.html:44 src/olympia/amo/templates/amo/side_nav.html:3 src/olympia/amo/templates/amo/side_nav.html:11 src/olympia/amo/templates/amo/site_nav.html:3
+#: src/olympia/amo/templates/amo/site_nav.html:25 src/olympia/browse/views.py:203 src/olympia/browse/views.py:248 src/olympia/browse/views.py:448
 msgid "Most Popular"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/home.html:43
+#: src/olympia/addons/templates/addons/home.html:45
 msgid "All »"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/home.html:52 src/olympia/addons/templates/addons/home.html:61 src/olympia/addons/templates/addons/home.html:70 src/olympia/addons/templates/addons/home.html:78
+#: src/olympia/addons/templates/addons/home.html:54 src/olympia/addons/templates/addons/home.html:63 src/olympia/addons/templates/addons/home.html:72 src/olympia/addons/templates/addons/home.html:80
 #: src/olympia/browse/templates/browse/impala/category_landing.html:36
 msgid "See all »"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/home.html:60
+#: src/olympia/addons/templates/addons/home.html:62
 msgid "Up &amp; Coming Extensions"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/home.html:69 src/olympia/browse/templates/browse/personas/category_landing.html:61 src/olympia/discovery/templates/discovery/pane.html:74
+#: src/olympia/addons/templates/addons/home.html:71 src/olympia/browse/templates/browse/personas/category_landing.html:61 src/olympia/discovery/templates/discovery/pane.html:74
 msgid "Featured Themes"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/home.html:77 src/olympia/bandwagon/templates/bandwagon/impala/collection_listing.html:5
+#: src/olympia/addons/templates/addons/home.html:79 src/olympia/bandwagon/templates/bandwagon/impala/collection_listing.html:5
 msgid "Featured Collections"
 msgstr ""
 
@@ -549,7 +550,7 @@ msgid "Updated {0}"
 msgstr ""
 
 #. {0} is a date.
-#: src/olympia/addons/templates/addons/macros.html:10 src/olympia/addons/templates/addons/macros.html:69 src/olympia/addons/templates/addons/persona_preview.html:21
+#: src/olympia/addons/templates/addons/macros.html:10 src/olympia/addons/templates/addons/macros.html:69 src/olympia/addons/templates/addons/persona_preview.html:22
 #: src/olympia/addons/templates/addons/listing/items_mobile.html:44 src/olympia/addons/templates/addons/listing/macros.html:39
 #: src/olympia/bandwagon/templates/bandwagon/collection_listing_items.html:37 src/olympia/bandwagon/templates/bandwagon/impala/collection_listing_items.html:37
 msgid "Added {0}"
@@ -570,15 +571,14 @@ msgstr[0] ""
 msgstr[1] ""
 
 #. {0} is the number of downloads.
-#: src/olympia/addons/templates/addons/macros.html:53 src/olympia/addons/templates/addons/impala/details.html:61
+#: src/olympia/addons/templates/addons/macros.html:53 src/olympia/addons/templates/addons/impala/details.html:59
 msgid "{0} weekly download"
 msgid_plural "{0} weekly downloads"
 msgstr[0] ""
 msgstr[1] ""
 
 #. {0} is the number of users.
-#: src/olympia/addons/templates/addons/macros.html:61 src/olympia/addons/templates/addons/impala/details.html:54 src/olympia/compat/templates/compat/index.html:71
-#: src/olympia/zadmin/templates/zadmin/compat.html:67
+#: src/olympia/addons/templates/addons/macros.html:61 src/olympia/addons/templates/addons/impala/details.html:52 src/olympia/zadmin/templates/zadmin/compat.html:67
 msgid "{0} user"
 msgid_plural "{0} users"
 msgstr[0] ""
@@ -596,7 +596,7 @@ msgstr ""
 msgid "Return to the addon."
 msgstr ""
 
-#: src/olympia/addons/templates/addons/persona_detail.html:17 src/olympia/addons/templates/addons/impala/details.html:106 src/olympia/addons/templates/addons/mobile/details.html:23
+#: src/olympia/addons/templates/addons/persona_detail.html:17 src/olympia/addons/templates/addons/impala/details.html:103 src/olympia/addons/templates/addons/mobile/details.html:23
 #: src/olympia/addons/templates/addons/mobile/persona_detail.html:21 src/olympia/discovery/templates/discovery/addons/base.html:27 src/olympia/editors/templates/editors/review.html:31
 msgid "by"
 msgstr ""
@@ -640,34 +640,35 @@ msgstr ""
 msgid "License"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/persona_preview.html:12 src/olympia/constants/base.py:48
+#: src/olympia/addons/templates/addons/persona_preview.html:13 src/olympia/constants/base.py:48
 msgid "Awaiting Review"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/persona_preview.html:14 src/olympia/amo/log.py:180 src/olympia/constants/base.py:42 src/olympia/editors/helpers.py:62
+#: src/olympia/addons/templates/addons/persona_preview.html:15 src/olympia/amo/log.py:180 src/olympia/constants/base.py:42 src/olympia/editors/helpers.py:62
 msgid "Rejected"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/persona_preview.html:16 src/olympia/amo/log.py:159
+#: src/olympia/addons/templates/addons/persona_preview.html:17 src/olympia/amo/log.py:159
 msgid "Approved"
 msgstr ""
 
 #. {0} is the number of users.
-#: src/olympia/addons/templates/addons/persona_preview.html:26 src/olympia/addons/templates/addons/listing/items_mobile.html:36 src/olympia/addons/templates/addons/listing/macros.html:31
+#: src/olympia/addons/templates/addons/persona_preview.html:27 src/olympia/addons/templates/addons/listing/items_mobile.html:36 src/olympia/addons/templates/addons/listing/macros.html:31
 msgid "<strong>{0}</strong> user"
 msgid_plural "<strong>{0}</strong> users"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/olympia/addons/templates/addons/persona_preview.html:40
+#: src/olympia/addons/templates/addons/persona_preview.html:41
 msgid "Hover to Preview"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/persona_preview.html:46 src/olympia/addons/templates/addons/persona_preview.html:48 src/olympia/reviews/templates/reviews/add.html:15
+#: src/olympia/addons/templates/addons/persona_preview.html:47 src/olympia/addons/templates/addons/persona_preview.html:49 src/olympia/addons/templates/addons/persona_preview.html:97
+#: src/olympia/reviews/templates/reviews/add.html:15
 msgid "Add"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/persona_preview.html:57 src/olympia/bandwagon/templates/bandwagon/ajax_new.html:16 src/olympia/bandwagon/templates/bandwagon/edit.html:19
+#: src/olympia/addons/templates/addons/persona_preview.html:58 src/olympia/bandwagon/templates/bandwagon/ajax_new.html:16 src/olympia/bandwagon/templates/bandwagon/edit.html:19
 #: src/olympia/bandwagon/templates/bandwagon/includes/addedit.html:19 src/olympia/devhub/templates/devhub/addons/edit/admin.html:13 src/olympia/devhub/templates/devhub/addons/edit/basic.html:10
 #: src/olympia/devhub/templates/devhub/addons/edit/details.html:8 src/olympia/devhub/templates/devhub/addons/edit/media.html:6 src/olympia/devhub/templates/devhub/addons/edit/support.html:8
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:9 src/olympia/devhub/templates/devhub/addons/submit/describe.html:29 src/olympia/editors/templates/editors/review.html:257
@@ -676,21 +677,21 @@ msgstr ""
 
 #. For datetime formatting, see the table on
 #. http://docs.python.org/library/datetime.html#strftime-and-strptime-behavior
-#: src/olympia/addons/templates/addons/persona_preview.html:66
+#: src/olympia/addons/templates/addons/persona_preview.html:67
 #, python-format
 msgid "%%Y-%%m-%%d"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/persona_preview.html:67
+#: src/olympia/addons/templates/addons/persona_preview.html:68
 msgid "by {0} on {1}"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/persona_preview.html:75 src/olympia/reviews/helpers.py:17 src/olympia/reviews/templates/reviews/review_list.html:63
+#: src/olympia/addons/templates/addons/persona_preview.html:76 src/olympia/reviews/helpers.py:17 src/olympia/reviews/templates/reviews/review_list.html:63
 #: src/olympia/reviews/templates/reviews/reviews_link.html:21 src/olympia/reviews/templates/reviews/impala/reviews_link.html:16
 msgid "Not yet rated"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/persona_preview.html:78
+#: src/olympia/addons/templates/addons/persona_preview.html:79
 msgid "<b>{0}</b> users"
 msgstr ""
 
@@ -703,7 +704,7 @@ msgid "Learn more about Firefox"
 msgstr ""
 
 #: src/olympia/addons/templates/addons/popups.html:22
-msgid "or <b><a class=\"installer\" href=\"{url}\">download anyway</a></b>"
+msgid "or <b><a class=\"button installer\" href=\"{url}\">download anyway</a></b>"
 msgstr ""
 
 #: src/olympia/addons/templates/addons/popups.html:26
@@ -802,7 +803,7 @@ msgid ""
 msgstr ""
 
 #: src/olympia/addons/templates/addons/report_abuse.html:6 src/olympia/addons/templates/addons/report_abuse_full.html:10 src/olympia/addons/templates/addons/impala/details-more.html:23
-#: src/olympia/addons/templates/addons/impala/details.html:328
+#: src/olympia/addons/templates/addons/impala/details.html:333
 msgid "Report Abuse"
 msgstr ""
 
@@ -821,9 +822,9 @@ msgstr ""
 #: src/olympia/devhub/templates/devhub/addons/ajax_compat_update.html:36 src/olympia/devhub/templates/devhub/addons/profile.html:44 src/olympia/devhub/templates/devhub/addons/edit/admin.html:104
 #: src/olympia/devhub/templates/devhub/addons/edit/basic.html:155 src/olympia/devhub/templates/devhub/addons/edit/details.html:88 src/olympia/devhub/templates/devhub/addons/edit/support.html:70
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:169 src/olympia/devhub/templates/devhub/addons/forms_shared/media.html:152
-#: src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:44 src/olympia/devhub/templates/devhub/personas/edit.html:222 src/olympia/devhub/templates/devhub/versions/add_file_modal.html:79
-#: src/olympia/devhub/templates/devhub/versions/edit.html:140 src/olympia/devhub/templates/devhub/versions/list.html:208 src/olympia/devhub/templates/devhub/versions/list.html:242
-#: src/olympia/devhub/templates/devhub/versions/list.html:276 src/olympia/devhub/templates/devhub/versions/list.html:317 src/olympia/reviews/templates/reviews/edit_review.html:16
+#: src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:43 src/olympia/devhub/templates/devhub/personas/edit.html:222 src/olympia/devhub/templates/devhub/versions/add_file_modal.html:59
+#: src/olympia/devhub/templates/devhub/versions/edit.html:140 src/olympia/devhub/templates/devhub/versions/list.html:208 src/olympia/devhub/templates/devhub/versions/list.html:239
+#: src/olympia/devhub/templates/devhub/versions/list.html:281 src/olympia/devhub/templates/devhub/versions/list.html:315 src/olympia/reviews/templates/reviews/edit_review.html:16
 #: src/olympia/translations/templates/translations/trans-menu.html:50 src/olympia/translations/templates/translations/trans-menu.html:62 src/olympia/zadmin/templates/zadmin/validation.html:105
 msgid "Cancel"
 msgstr ""
@@ -868,7 +869,7 @@ msgstr ""
 msgid "Review Guidelines"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/review_list_box.html:5 src/olympia/addons/templates/addons/impala/details-more.html:27 src/olympia/editors/helpers.py:921
+#: src/olympia/addons/templates/addons/review_list_box.html:5 src/olympia/addons/templates/addons/impala/details-more.html:27 src/olympia/editors/helpers.py:1001
 #: src/olympia/reviews/templates/reviews/add.html:14 src/olympia/reviews/templates/reviews/reply.html:14 src/olympia/reviews/templates/reviews/review_list.html:19
 #: src/olympia/reviews/templates/reviews/mobile/review_list.html:26
 msgid "Reviews"
@@ -959,119 +960,119 @@ msgid_plural "Other add-ons by these authors"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/olympia/addons/templates/addons/impala/details.html:41
+#: src/olympia/addons/templates/addons/impala/details.html:39
 #, python-format
 msgid "<span itemprop=\"ratingCount\">%(num)s</span> user review"
 msgid_plural "<span itemprop=\"ratingCount\">%(num)s</span> user reviews"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/olympia/addons/templates/addons/impala/details.html:69
+#: src/olympia/addons/templates/addons/impala/details.html:66
 msgid "View statistics"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/impala/details.html:84
+#: src/olympia/addons/templates/addons/impala/details.html:81
 msgid "Manage"
 msgstr ""
 
 #. {0} is an add-on name.
-#: src/olympia/addons/templates/addons/impala/details.html:96
+#: src/olympia/addons/templates/addons/impala/details.html:93
 msgid "Icon of {0}"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/impala/details.html:103 src/olympia/addons/templates/addons/impala/listing/items.html:14
+#: src/olympia/addons/templates/addons/impala/details.html:100 src/olympia/addons/templates/addons/impala/listing/items.html:14
 msgid "No Restart"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/impala/details.html:127
+#: src/olympia/addons/templates/addons/impala/details.html:124
 #, python-format
 msgid "Meet the Developer: <a href=\"%(url)s\">%(name)s</a>"
 msgid_plural "<a href=\"%(url)s\">Meet the Developers</a>"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/olympia/addons/templates/addons/impala/details.html:137
+#: src/olympia/addons/templates/addons/impala/details.html:134
 msgid "Learn why {0} was created and find out what's next for this add-on."
 msgstr ""
 
 #. {0} is an index.
-#: src/olympia/addons/templates/addons/impala/details.html:156
+#: src/olympia/addons/templates/addons/impala/details.html:161
 msgid "Add-on screenshot #{0}"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/impala/details.html:182
+#: src/olympia/addons/templates/addons/impala/details.html:187
 msgid "Add-on home page"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/impala/details.html:185
+#: src/olympia/addons/templates/addons/impala/details.html:190
 msgid "Support site"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/impala/details.html:189
+#: src/olympia/addons/templates/addons/impala/details.html:194
 msgid "Support E-mail"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/impala/details.html:194 src/olympia/devhub/models.py:378 src/olympia/devhub/templates/devhub/versions/list.html:12
+#: src/olympia/addons/templates/addons/impala/details.html:199 src/olympia/devhub/models.py:378 src/olympia/devhub/templates/devhub/versions/list.html:12
 #: src/olympia/versions/templates/versions/version.html:6 src/olympia/versions/templates/versions/mobile/version.html:6
 msgid "Version {0}"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/impala/details.html:194
+#: src/olympia/addons/templates/addons/impala/details.html:199
 msgid "Info"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/impala/details.html:195 src/olympia/devhub/templates/devhub/includes/addon_details.html:129
+#: src/olympia/addons/templates/addons/impala/details.html:200 src/olympia/devhub/templates/devhub/includes/addon_details.html:116
 msgid "Last Updated:"
-msgstr ""
-
-#: src/olympia/addons/templates/addons/impala/details.html:200
-#, python-format
-msgid "Released under <a target=\"_blank\" href=\"%(url)s\">%(name)s</a>"
-msgstr ""
-
-#: src/olympia/addons/templates/addons/impala/details.html:201 src/olympia/addons/templates/addons/impala/details.html:206 src/olympia/amo/helpers.py:398 src/olympia/devhub/forms.py:142
-#: src/olympia/devhub/forms.py:173 src/olympia/versions/templates/versions/version.html:40 src/olympia/versions/templates/versions/version.html:45
-msgid "Custom License"
 msgstr ""
 
 #: src/olympia/addons/templates/addons/impala/details.html:205
 #, python-format
+msgid "Released under <a target=\"_blank\" href=\"%(url)s\">%(name)s</a>"
+msgstr ""
+
+#: src/olympia/addons/templates/addons/impala/details.html:206 src/olympia/addons/templates/addons/impala/details.html:211 src/olympia/amo/helpers.py:398 src/olympia/devhub/forms.py:142
+#: src/olympia/devhub/forms.py:173 src/olympia/versions/templates/versions/version.html:40 src/olympia/versions/templates/versions/version.html:45
+msgid "Custom License"
+msgstr ""
+
+#: src/olympia/addons/templates/addons/impala/details.html:210
+#, python-format
 msgid "Released under <a href=\"%(url)s\">%(name)s</a>"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/impala/details.html:217
+#: src/olympia/addons/templates/addons/impala/details.html:222
 msgid "About this Add-on"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/impala/details.html:233
+#: src/olympia/addons/templates/addons/impala/details.html:238
 msgid "Developer’s Comments"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/impala/details.html:243
+#: src/olympia/addons/templates/addons/impala/details.html:248
 msgid "Version Information"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/impala/details.html:250
+#: src/olympia/addons/templates/addons/impala/details.html:255
 msgid "See complete version history"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/impala/details.html:262
+#: src/olympia/addons/templates/addons/impala/details.html:267
 msgid ""
 "The Development Channel lets you test an experimental new version of this add-on before it's released to the general public. Once you install the development version, you will continue to get "
 "updates from this channel. To stop receiving development updates, reinstall the default version from the link above."
 msgstr ""
 
-#: src/olympia/addons/templates/addons/impala/details.html:272
+#: src/olympia/addons/templates/addons/impala/details.html:277
 msgid "<strong>Caution:</strong> Development versions of this add-on have not been reviewed by Mozilla."
 msgstr ""
 
-#: src/olympia/addons/templates/addons/impala/details.html:287
+#: src/olympia/addons/templates/addons/impala/details.html:292
 msgid "See complete development channel history"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/impala/details.html:306 src/olympia/addons/templates/addons/impala/details.html:315 src/olympia/addons/templates/addons/impala/details.html:327
+#: src/olympia/addons/templates/addons/impala/details.html:311 src/olympia/addons/templates/addons/impala/details.html:320 src/olympia/addons/templates/addons/impala/details.html:332
 #: src/olympia/addons/templates/addons/impala/review_add_box.html:4 src/olympia/stats/templates/stats/popup.html:2 src/olympia/stats/templates/stats/popup.html:8
-#: src/olympia/stats/templates/stats/stats.html:202 src/olympia/users/templates/users/profile.html:119
+#: src/olympia/stats/templates/stats/stats.html:204 src/olympia/users/templates/users/profile.html:119
 msgid "close"
 msgstr ""
 
@@ -1127,15 +1128,11 @@ msgstr ""
 msgid "Source Code License"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/impala/persona_grid.html:16 src/olympia/addons/templates/addons/impala/toplist.html:6
-msgid "{0} users"
-msgstr ""
-
 #: src/olympia/addons/templates/addons/impala/review_list_box.html:19 src/olympia/reviews/templates/reviews/review.html:40
 msgid "permalink"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/impala/review_list_box.html:23 src/olympia/editors/templates/editors/queue.html:98 src/olympia/reviews/templates/reviews/review.html:44
+#: src/olympia/addons/templates/addons/impala/review_list_box.html:23 src/olympia/editors/templates/editors/queue.html:104 src/olympia/reviews/templates/reviews/review.html:44
 msgid "translate"
 msgstr ""
 
@@ -1154,6 +1151,10 @@ msgstr ""
 msgid "Be the first!"
 msgstr ""
 
+#: src/olympia/addons/templates/addons/impala/toplist.html:6
+msgid "{0} users"
+msgstr ""
+
 #: src/olympia/addons/templates/addons/impala/listing/sorter.html:14 src/olympia/devhub/templates/devhub/addons/listing/item_actions.html:49
 msgid "More"
 msgstr ""
@@ -1166,7 +1167,7 @@ msgstr ""
 msgid "My Add-ons"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/includes/dashboard_tabs.html:6 src/olympia/amo/context_processors.py:51
+#: src/olympia/addons/templates/addons/includes/dashboard_tabs.html:6 src/olympia/amo/context_processors.py:50
 msgid "My Themes"
 msgstr ""
 
@@ -1221,7 +1222,7 @@ msgstr ""
 msgid "Weekly Downloads"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/mobile/details.html:99 src/olympia/compat/templates/compat/reporter_detail.html:46 src/olympia/devhub/forms.py:787
+#: src/olympia/addons/templates/addons/mobile/details.html:99 src/olympia/compat/templates/compat/reporter_detail.html:46 src/olympia/devhub/forms.py:788
 #: src/olympia/devhub/templates/devhub/versions/list.html:163
 msgid "Version"
 msgstr ""
@@ -1305,7 +1306,7 @@ msgstr ""
 #: src/olympia/browse/templates/browse/personas/category_landing.html:21 src/olympia/browse/templates/browse/personas/category_landing.html:23
 #: src/olympia/browse/templates/browse/personas/category_landing.html:38 src/olympia/browse/templates/browse/personas/grid.html:7 src/olympia/browse/templates/browse/personas/grid.html:11
 #: src/olympia/browse/templates/browse/personas/mobile/base.html:7 src/olympia/browse/templates/browse/personas/mobile/category_landing.html:19 src/olympia/constants/base.py:180
-#: src/olympia/devhub/templates/devhub/personas/submit.html:13 src/olympia/editors/helpers.py:105 src/olympia/editors/templates/editors/base.html:26
+#: src/olympia/devhub/templates/devhub/personas/submit.html:13 src/olympia/editors/helpers.py:107 src/olympia/editors/templates/editors/base.html:26
 #: src/olympia/editors/templates/editors/performance.html:73 src/olympia/search/templates/search/personas.html:39 src/olympia/templates/menu_links.html:9
 msgid "Themes"
 msgstr ""
@@ -1326,7 +1327,7 @@ msgstr ""
 msgid "Highest Rated"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/mobile/home.html:74 src/olympia/amo/templates/amo/side_nav.html:5 src/olympia/amo/templates/amo/site_nav.html:27 src/olympia/amo/templates/amo/site_nav.html:57
+#: src/olympia/addons/templates/addons/mobile/home.html:74 src/olympia/amo/templates/amo/side_nav.html:5 src/olympia/amo/templates/amo/site_nav.html:27 src/olympia/amo/templates/amo/site_nav.html:55
 #: src/olympia/bandwagon/views.py:97 src/olympia/browse/views.py:57 src/olympia/browse/views.py:67 src/olympia/browse/templates/browse/personas/mobile/category_landing.html:65
 #: src/olympia/search/forms.py:15 src/olympia/search/forms.py:87
 msgid "Newest"
@@ -1340,90 +1341,90 @@ msgstr ""
 msgid "Theme Info &raquo;"
 msgstr ""
 
-#: src/olympia/amo/context_processors.py:39 src/olympia/devhub/templates/devhub/nav.html:43
+#: src/olympia/amo/context_processors.py:37 src/olympia/devhub/templates/devhub/nav.html:43
 msgid "Tools"
 msgstr ""
 
-#: src/olympia/amo/context_processors.py:48 src/olympia/discovery/templates/discovery/pane_account.html:8 src/olympia/users/templates/users/includes/navigation.html:2
+#: src/olympia/amo/context_processors.py:47 src/olympia/discovery/templates/discovery/pane_account.html:8 src/olympia/users/templates/users/includes/navigation.html:2
 msgid "My Profile"
 msgstr ""
 
-#: src/olympia/amo/context_processors.py:54 src/olympia/users/templates/users/edit.html:5 src/olympia/users/templates/users/includes/navigation.html:3
+#: src/olympia/amo/context_processors.py:53 src/olympia/users/templates/users/edit.html:5 src/olympia/users/templates/users/includes/navigation.html:3
 msgid "Account Settings"
 msgstr ""
 
-#: src/olympia/amo/context_processors.py:57 src/olympia/discovery/templates/discovery/pane_account.html:11 src/olympia/users/templates/users/profile.html:83
+#: src/olympia/amo/context_processors.py:56 src/olympia/discovery/templates/discovery/pane_account.html:11 src/olympia/users/templates/users/profile.html:83
 #: src/olympia/users/templates/users/includes/navigation.html:4
 msgid "My Collections"
 msgstr ""
 
-#: src/olympia/amo/context_processors.py:62 src/olympia/discovery/templates/discovery/pane_account.html:10 src/olympia/users/templates/users/includes/navigation.html:7
+#: src/olympia/amo/context_processors.py:61 src/olympia/discovery/templates/discovery/pane_account.html:10 src/olympia/users/templates/users/includes/navigation.html:7
 msgid "My Favorites"
 msgstr ""
 
-#: src/olympia/amo/context_processors.py:67 src/olympia/discovery/templates/discovery/pane_account.html:13 src/olympia/templates/impala/user_login.html:14
+#: src/olympia/amo/context_processors.py:66 src/olympia/discovery/templates/discovery/pane_account.html:13 src/olympia/templates/impala/user_login.html:14
 #: src/olympia/templates/mobile/header_auth.html:5
 msgid "Log out"
 msgstr ""
 
-#: src/olympia/amo/context_processors.py:72 src/olympia/devhub/templates/devhub/addons/dashboard.html:4
+#: src/olympia/amo/context_processors.py:71 src/olympia/devhub/templates/devhub/addons/dashboard.html:4
 msgid "Manage My Submissions"
 msgstr ""
 
-#: src/olympia/amo/context_processors.py:75 src/olympia/devhub/templates/devhub/nav.html:27 src/olympia/devhub/templates/devhub/addons/dashboard.html:25
+#: src/olympia/amo/context_processors.py:74 src/olympia/devhub/templates/devhub/nav.html:27 src/olympia/devhub/templates/devhub/addons/dashboard.html:25
 #: src/olympia/devhub/templates/devhub/addons/submit/base.html:4
 msgid "Submit a New Add-on"
 msgstr ""
 
-#: src/olympia/amo/context_processors.py:77 src/olympia/browse/templates/browse/personas/base.html:50 src/olympia/devhub/templates/devhub/index.html:24
+#: src/olympia/amo/context_processors.py:76 src/olympia/browse/templates/browse/personas/base.html:50 src/olympia/devhub/templates/devhub/index.html:24
 #: src/olympia/devhub/templates/devhub/addons/dashboard.html:29
 msgid "Submit a New Theme"
 msgstr ""
 
-#: src/olympia/amo/context_processors.py:79 src/olympia/amo/templates/amo/site_nav.html:87 src/olympia/devhub/helpers.py:36 src/olympia/devhub/helpers.py:68 src/olympia/devhub/helpers.py:102
+#: src/olympia/amo/context_processors.py:78 src/olympia/amo/templates/amo/site_nav.html:85 src/olympia/devhub/helpers.py:36 src/olympia/devhub/helpers.py:68 src/olympia/devhub/helpers.py:102
 #: src/olympia/templates/footer.html:6 src/olympia/templates/menu_links.html:14
 msgid "Developer Hub"
 msgstr ""
 
-#: src/olympia/amo/context_processors.py:83 src/olympia/devhub/views.py:1792
+#: src/olympia/amo/context_processors.py:81 src/olympia/devhub/views.py:1796
 msgid "Manage API Keys"
 msgstr ""
 
-#: src/olympia/amo/context_processors.py:88 src/olympia/editors/helpers.py:82 src/olympia/editors/helpers.py:102 src/olympia/editors/templates/editors/base.html:10
+#: src/olympia/amo/context_processors.py:86 src/olympia/editors/helpers.py:84 src/olympia/editors/helpers.py:104 src/olympia/editors/templates/editors/base.html:10
 msgid "Editor Tools"
 msgstr ""
 
-#: src/olympia/amo/context_processors.py:92
+#: src/olympia/amo/context_processors.py:90
 msgid "Admin Tools"
 msgstr ""
 
-#: src/olympia/amo/fields.py:15
+#: src/olympia/amo/fields.py:20
 msgid "Incorrect, please try again."
 msgstr ""
 
-#: src/olympia/amo/fields.py:16
+#: src/olympia/amo/fields.py:21
 msgid "Error verifying input, please try again."
 msgstr ""
 
-#: src/olympia/amo/fields.py:32
+#: src/olympia/amo/fields.py:37
 msgid "This must be a valid hex color code, such as #000000."
 msgstr ""
 
-#: src/olympia/amo/fields.py:58
+#: src/olympia/amo/fields.py:63
 msgid "Enter at least one value."
 msgstr ""
 
-#: src/olympia/amo/helpers.py:162 src/olympia/amo/templates/amo/site_nav.html:61 src/olympia/bandwagon/templates/bandwagon/add.html:9
+#: src/olympia/amo/helpers.py:162 src/olympia/amo/templates/amo/site_nav.html:59 src/olympia/bandwagon/templates/bandwagon/add.html:9
 #: src/olympia/bandwagon/templates/bandwagon/collection_detail.html:15 src/olympia/bandwagon/templates/bandwagon/delete.html:9 src/olympia/bandwagon/templates/bandwagon/edit.html:15
 #: src/olympia/bandwagon/templates/bandwagon/user_listing.html:18 src/olympia/bandwagon/templates/bandwagon/user_listing.html:21
 #: src/olympia/bandwagon/templates/bandwagon/impala/collection_listing.html:12 src/olympia/bandwagon/templates/bandwagon/impala/collection_listing.html:20
 #: src/olympia/bandwagon/templates/bandwagon/impala/collection_listing.html:24 src/olympia/bandwagon/templates/bandwagon/impala/collection_sidebar.html:3
 #: src/olympia/bandwagon/templates/bandwagon/includes/collection_sidebar.html:2 src/olympia/bandwagon/templates/bandwagon/mobile/collection_listing.html:3
-#: src/olympia/stats/templates/stats/stats.html:77 src/olympia/templates/menu_links.html:12
+#: src/olympia/stats/templates/stats/stats.html:33 src/olympia/templates/menu_links.html:12
 msgid "Collections"
 msgstr ""
 
-#: src/olympia/amo/helpers.py:171 src/olympia/amo/templates/amo/site_nav.html:85 src/olympia/browse/templates/browse/language_tools.html:3
+#: src/olympia/amo/helpers.py:171 src/olympia/amo/templates/amo/site_nav.html:83 src/olympia/browse/templates/browse/language_tools.html:3
 msgid "Dictionaries & Language Packs"
 msgstr ""
 
@@ -1575,8 +1576,8 @@ msgstr ""
 msgid "Comment on {addon} {version}."
 msgstr ""
 
-#: src/olympia/amo/log.py:236 src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:19 src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:47
-#: src/olympia/editors/helpers.py:511 src/olympia/editors/templates/editors/themes/history_table.html:11
+#: src/olympia/amo/log.py:236 src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:17 src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:45
+#: src/olympia/editors/helpers.py:584 src/olympia/editors/templates/editors/themes/history_table.html:11
 msgid "Comment"
 msgstr ""
 
@@ -1899,7 +1900,7 @@ msgstr ""
 #: src/olympia/amo/templates/amo/mobile/paginator.html:14 src/olympia/amo/templates/amo/mobile/paginator.html:16 src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:51
 #: src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:65 src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:78
 #: src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:91 src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:104
-#: src/olympia/discovery/templates/discovery/pane.html:45 src/olympia/discovery/templates/discovery/addons/detail.html:39 src/olympia/stats/templates/stats/stats.html:167
+#: src/olympia/discovery/templates/discovery/pane.html:45 src/olympia/discovery/templates/discovery/addons/detail.html:39 src/olympia/stats/templates/stats/stats.html:169
 msgid "Next"
 msgstr ""
 
@@ -1931,7 +1932,7 @@ msgid ""
 msgstr ""
 
 #: src/olympia/amo/templates/amo/side_nav.html:4 src/olympia/amo/templates/amo/side_nav.html:12 src/olympia/amo/templates/amo/site_nav.html:4 src/olympia/amo/templates/amo/site_nav.html:26
-#: src/olympia/browse/views.py:56 src/olympia/browse/views.py:66 src/olympia/browse/views.py:237 src/olympia/browse/views.py:282 src/olympia/search/forms.py:86
+#: src/olympia/browse/views.py:56 src/olympia/browse/views.py:66 src/olympia/browse/views.py:204 src/olympia/browse/views.py:249 src/olympia/search/forms.py:86
 msgid "Top Rated"
 msgstr ""
 
@@ -1945,38 +1946,38 @@ msgstr ""
 msgid "Extensions"
 msgstr ""
 
-#: src/olympia/amo/templates/amo/site_nav.html:45
+#: src/olympia/amo/templates/amo/site_nav.html:44
 msgid "Want more customization? Try <b>Complete Themes</b>"
 msgstr ""
 
-#: src/olympia/amo/templates/amo/site_nav.html:56 src/olympia/bandwagon/views.py:96
+#: src/olympia/amo/templates/amo/site_nav.html:54 src/olympia/bandwagon/views.py:96
 msgid "Most Followers"
 msgstr ""
 
-#: src/olympia/amo/templates/amo/site_nav.html:68 src/olympia/bandwagon/templates/bandwagon/impala/collection_sidebar.html:16
+#: src/olympia/amo/templates/amo/site_nav.html:66 src/olympia/bandwagon/templates/bandwagon/impala/collection_sidebar.html:16
 #: src/olympia/bandwagon/templates/bandwagon/includes/collection_sidebar.html:18
 msgid "Collections I've Made"
 msgstr ""
 
-#: src/olympia/amo/templates/amo/site_nav.html:70 src/olympia/bandwagon/templates/bandwagon/user_listing.html:4 src/olympia/bandwagon/templates/bandwagon/impala/collection_sidebar.html:13
+#: src/olympia/amo/templates/amo/site_nav.html:68 src/olympia/bandwagon/templates/bandwagon/user_listing.html:4 src/olympia/bandwagon/templates/bandwagon/impala/collection_sidebar.html:13
 #: src/olympia/bandwagon/templates/bandwagon/includes/collection_sidebar.html:15
 msgid "Collections I'm Following"
 msgstr ""
 
-#: src/olympia/amo/templates/amo/site_nav.html:73 src/olympia/bandwagon/templates/bandwagon/impala/collection_sidebar.html:18
-#: src/olympia/bandwagon/templates/bandwagon/includes/collection_sidebar.html:20 src/olympia/users/models.py:512
+#: src/olympia/amo/templates/amo/site_nav.html:71 src/olympia/bandwagon/templates/bandwagon/impala/collection_sidebar.html:18
+#: src/olympia/bandwagon/templates/bandwagon/includes/collection_sidebar.html:20 src/olympia/users/models.py:521
 msgid "My Favorite Add-ons"
 msgstr ""
 
-#: src/olympia/amo/templates/amo/site_nav.html:78
+#: src/olympia/amo/templates/amo/site_nav.html:76
 msgid "More&hellip;"
 msgstr ""
 
-#: src/olympia/amo/templates/amo/site_nav.html:82
+#: src/olympia/amo/templates/amo/site_nav.html:80
 msgid "Add-ons for Mobile"
 msgstr ""
 
-#: src/olympia/amo/templates/amo/site_nav.html:86 src/olympia/browse/feeds.py:207 src/olympia/browse/templates/browse/search_tools.html:3 src/olympia/constants/base.py:176
+#: src/olympia/amo/templates/amo/site_nav.html:84 src/olympia/browse/feeds.py:207 src/olympia/browse/templates/browse/search_tools.html:3 src/olympia/constants/base.py:176
 #: src/olympia/templates/menu_links.html:10
 msgid "Search Tools"
 msgstr ""
@@ -1992,7 +1993,7 @@ msgid "Jump to first page"
 msgstr ""
 
 #: src/olympia/amo/templates/amo/impala/paginator.html:22 src/olympia/amo/templates/amo/mobile/impala_paginator.html:12 src/olympia/discovery/templates/discovery/pane.html:44
-#: src/olympia/discovery/templates/discovery/addons/detail.html:38 src/olympia/stats/templates/stats/stats.html:164
+#: src/olympia/discovery/templates/discovery/addons/detail.html:38 src/olympia/stats/templates/stats/stats.html:166
 msgid "Previous"
 msgstr ""
 
@@ -2015,30 +2016,49 @@ msgid_plural "Page {n}"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/olympia/amo/templates/services/install.html:38
-#, python-format
-msgid "If you are not prompted to install %(addon_name)s in a moment, please <a href=\"%(addon_xpi)s\">click here</a>."
-msgstr ""
-
-#: src/olympia/amo/tests/test_messages.py:57 src/olympia/amo/tests/test_messages.py:58 src/olympia/reviews/forms.py:25 src/olympia/reviews/forms.py:50 src/olympia/reviews/templates/reviews/add.html:56
+#: src/olympia/amo/tests/test_messages.py:56 src/olympia/amo/tests/test_messages.py:57 src/olympia/reviews/forms.py:25 src/olympia/reviews/forms.py:50 src/olympia/reviews/templates/reviews/add.html:56
 #: src/olympia/reviews/templates/reviews/reply.html:30
 msgid "Title"
 msgstr ""
 
-#: src/olympia/amo/tests/test_messages.py:57 src/olympia/amo/tests/test_messages.py:58
+#: src/olympia/amo/tests/test_messages.py:56 src/olympia/amo/tests/test_messages.py:57
 msgid "Body"
 msgstr ""
 
-#: src/olympia/amo/tests/test_messages.py:59
+#: src/olympia/amo/tests/test_messages.py:58
 msgid "Another Title"
 msgstr ""
 
-#: src/olympia/amo/tests/test_messages.py:59
+#: src/olympia/amo/tests/test_messages.py:58
 msgid "Another Body"
 msgstr ""
 
-#: src/olympia/api/views.py:255
-msgid "Not implemented yet."
+#: src/olympia/api/authentication.py:76
+msgid "Signature has expired."
+msgstr ""
+
+#: src/olympia/api/authentication.py:79
+msgid "Error decoding signature."
+msgstr ""
+
+#: src/olympia/api/authentication.py:82
+msgid "Invalid JWT Token."
+msgstr ""
+
+#: src/olympia/api/authentication.py:130
+msgid "Invalid Authorization header. No credentials provided."
+msgstr ""
+
+#: src/olympia/api/authentication.py:133
+msgid "Invalid Authorization header. Credentials string should not contain spaces."
+msgstr ""
+
+#: src/olympia/api/fields.py:29
+msgid "The field must have a length of at least {num} characters."
+msgstr ""
+
+#: src/olympia/api/fields.py:31
+msgid "The language code {lang_code} is invalid."
 msgstr ""
 
 #: src/olympia/applications/views.py:39 src/olympia/applications/templates/applications/appversions.html:3
@@ -2057,7 +2077,7 @@ msgstr ""
 msgid "Add-ons submitted to Mozilla Add-ons must have a manifest file with at least one of the below applications supported. Only the versions listed below are allowed for these applications."
 msgstr ""
 
-#: src/olympia/applications/templates/applications/appversions.html:25
+#: src/olympia/applications/templates/applications/appversions.html:25 src/olympia/editors/helpers.py:361
 msgid "GUID"
 msgstr ""
 
@@ -2171,8 +2191,8 @@ msgstr ""
 msgid "Remove from favorites"
 msgstr ""
 
-#: src/olympia/bandwagon/views.py:98 src/olympia/bandwagon/views.py:191 src/olympia/browse/views.py:58 src/olympia/browse/views.py:69 src/olympia/browse/views.py:458 src/olympia/devhub/views.py:74
-#: src/olympia/devhub/views.py:82 src/olympia/devhub/templates/devhub/addons/edit/basic.html:20 src/olympia/editors/templates/editors/leaderboard.html:24
+#: src/olympia/bandwagon/views.py:98 src/olympia/bandwagon/views.py:191 src/olympia/browse/views.py:58 src/olympia/browse/views.py:69 src/olympia/browse/views.py:425 src/olympia/devhub/views.py:72
+#: src/olympia/devhub/views.py:80 src/olympia/devhub/templates/devhub/addons/edit/basic.html:20 src/olympia/editors/templates/editors/leaderboard.html:24
 #: src/olympia/editors/templates/editors/themes/queue_list.html:48 src/olympia/search/forms.py:17 src/olympia/search/forms.py:89 src/olympia/users/templates/users/vcard.html:5
 msgid "Name"
 msgstr ""
@@ -2181,7 +2201,7 @@ msgstr ""
 msgid "Recently Popular"
 msgstr ""
 
-#: src/olympia/bandwagon/views.py:189 src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:18
+#: src/olympia/bandwagon/views.py:189 src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:16
 msgid "Added"
 msgstr ""
 
@@ -2195,7 +2215,7 @@ msgstr ""
 
 #: src/olympia/bandwagon/views.py:316
 #, python-format
-msgid "Your new collection is shown below. You can <ahref=\"%(url)s\">edit additional settings</a> if you'dlike."
+msgid "Your new collection is shown below. You can <a href=\"%(url)s\">edit additional settings</a> if you'd like."
 msgstr ""
 
 #: src/olympia/bandwagon/views.py:322
@@ -2323,8 +2343,8 @@ msgid_plural "%(num)s Add-ons in this Collection"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/olympia/bandwagon/templates/bandwagon/collection_detail.html:125 src/olympia/compat/templates/compat/index.html:25 src/olympia/compat/templates/compat/reporter_detail.html:29
-#: src/olympia/files/templates/files/viewer.html:29 src/olympia/templates/amo_footer.html:17 src/olympia/templates/includes/lang_switcher.html:10
+#: src/olympia/bandwagon/templates/bandwagon/collection_detail.html:125 src/olympia/compat/templates/compat/reporter_detail.html:29 src/olympia/files/templates/files/viewer.html:29
+#: src/olympia/templates/amo_footer.html:17 src/olympia/templates/includes/lang_switcher.html:10
 msgid "Go"
 msgstr ""
 
@@ -2491,7 +2511,7 @@ msgid "Remove this user as a contributor"
 msgstr ""
 
 #: src/olympia/bandwagon/templates/bandwagon/edit_contributors.html:18 src/olympia/bandwagon/templates/bandwagon/edit_contributors.html:43
-#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:20 src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:48
+#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:18 src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:46
 #: src/olympia/devhub/templates/devhub/addons/ajax_compat_update.html:19
 msgid "Remove"
 msgstr ""
@@ -2539,7 +2559,7 @@ msgid "<b>Warning:</b> By changing the owner of this collection, you will no lon
 msgstr ""
 
 #: src/olympia/bandwagon/templates/bandwagon/edit_contributors.html:83 src/olympia/devhub/templates/devhub/addons/forms_shared/media.html:157
-#: src/olympia/devhub/templates/devhub/addons/submit/describe.html:69 src/olympia/devhub/templates/devhub/addons/submit/license.html:60 src/olympia/devhub/templates/devhub/addons/submit/upload.html:78
+#: src/olympia/devhub/templates/devhub/addons/submit/describe.html:69 src/olympia/devhub/templates/devhub/addons/submit/license.html:60 src/olympia/devhub/templates/devhub/addons/submit/upload.html:70
 #: src/olympia/devhub/templates/devhub/payments/tier.html:17 src/olympia/editors/templates/editors/themes/themes.html:111 src/olympia/editors/templates/editors/themes/themes.html:128
 #: src/olympia/editors/templates/editors/themes/themes.html:134 src/olympia/editors/templates/editors/themes/themes.html:141 src/olympia/users/templates/users/fxa_migration_prompt_content.html:10
 #: src/olympia/users/templates/users/login_form.html:42 src/olympia/users/templates/users/mobile/login.html:57
@@ -2622,31 +2642,31 @@ msgid "Add-ons in Your Collection"
 msgstr ""
 
 #: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:4
-msgid ""
-"To include an add-on in this collection, enter its name in the box below and hit enter.  You can also use the <strong>Add to Collection</strong> links throughout the site to include add-ons later."
+msgid "To include an add-on in this collection, enter its name in the box below and hit enter."
 msgstr ""
 
-#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:17 src/olympia/constants/base.py:400 src/olympia/devhub/templates/devhub/addons/activity.html:62
+#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:15 src/olympia/constants/base.py:400 src/olympia/devhub/templates/devhub/addons/activity.html:62
+#: src/olympia/editors/helpers.py:273 src/olympia/editors/helpers.py:360
 msgid "Add-on"
 msgstr ""
 
-#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:26
+#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:24
 msgid "Enter the name of the add-on to include"
 msgstr ""
 
-#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:28
+#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:26
 msgid "Add to Collection"
 msgstr ""
 
-#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:45 src/olympia/editors/helpers.py:936 src/olympia/editors/helpers.py:956
+#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:43 src/olympia/editors/helpers.py:1016 src/olympia/editors/helpers.py:1036
 msgid "Pending"
 msgstr ""
 
-#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:47
+#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:45
 msgid "Add a comment"
 msgstr ""
 
-#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:48
+#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:46
 msgid "Remove this add-on from the collection"
 msgstr ""
 
@@ -2753,12 +2773,12 @@ msgstr ""
 msgid "Most Users"
 msgstr ""
 
-#: src/olympia/browse/views.py:61 src/olympia/browse/views.py:72 src/olympia/browse/views.py:279 src/olympia/browse/templates/browse/personas/mobile/category_landing.html:63
+#: src/olympia/browse/views.py:61 src/olympia/browse/views.py:72 src/olympia/browse/views.py:246 src/olympia/browse/templates/browse/personas/mobile/category_landing.html:63
 #: src/olympia/discovery/templates/discovery/pane.html:67 src/olympia/search/forms.py:92
 msgid "Up & Coming"
 msgstr ""
 
-#: src/olympia/browse/views.py:460 src/olympia/devhub/views.py:76 src/olympia/devhub/views.py:83 src/olympia/discovery/templates/discovery/addons/detail.html:66
+#: src/olympia/browse/views.py:427 src/olympia/devhub/views.py:74 src/olympia/devhub/views.py:81 src/olympia/discovery/templates/discovery/addons/detail.html:66
 msgid "Created"
 msgstr ""
 
@@ -2946,8 +2966,8 @@ msgid_plural "See all %(cnt)s extensions in %(name)s &raquo;"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/olympia/browse/templates/browse/mobile/extensions.html:13 src/olympia/compat/templates/compat/index.html:82 src/olympia/devhub/templates/devhub/devhub_search.html:24
-#: src/olympia/devhub/templates/devhub/addons/activity.html:47 src/olympia/search/templates/search/no_results.html:4 src/olympia/search/templates/search/mobile/results.html:36
+#: src/olympia/browse/templates/browse/mobile/extensions.html:13 src/olympia/devhub/templates/devhub/devhub_search.html:24 src/olympia/devhub/templates/devhub/addons/activity.html:47
+#: src/olympia/search/templates/search/no_results.html:4 src/olympia/search/templates/search/mobile/results.html:36
 msgid "No results found."
 msgstr ""
 
@@ -3032,7 +3052,7 @@ msgstr ""
 msgid "All"
 msgstr ""
 
-#: src/olympia/compat/forms.py:22 src/olympia/search/views.py:525
+#: src/olympia/compat/forms.py:22 src/olympia/editors/templates/editors/base.html:69 src/olympia/search/views.py:518
 msgid "All Add-ons"
 msgstr ""
 
@@ -3042,53 +3062,6 @@ msgstr ""
 
 #: src/olympia/compat/forms.py:24
 msgid "Non-binary"
-msgstr ""
-
-#. Review points sources other than add-ons and themes.
-#: src/olympia/compat/views.py:87 src/olympia/constants/base.py:388 src/olympia/devhub/forms.py:162 src/olympia/editors/templates/editors/performance.html:75
-msgid "Other"
-msgstr ""
-
-#: src/olympia/compat/templates/compat/index.html:4
-msgid "Add-on Compatibility Report for {app} {version}"
-msgstr ""
-
-#: src/olympia/compat/templates/compat/index.html:11
-msgid "{app} {version} Compatibility"
-msgstr ""
-
-#: src/olympia/compat/templates/compat/index.html:17
-#, python-format
-msgid "Top 95%% compatible with previous version"
-msgstr ""
-
-#: src/olympia/compat/templates/compat/index.html:18
-#, python-format
-msgid "Top 95%% of all add-ons"
-msgstr ""
-
-#: src/olympia/compat/templates/compat/index.html:19
-msgid "All active add-ons"
-msgstr ""
-
-#: src/olympia/compat/templates/compat/index.html:23 src/olympia/constants/base.py:401
-msgid "App"
-msgstr ""
-
-#: src/olympia/compat/templates/compat/index.html:55
-msgid "Details for add-ons compatible with previous version:"
-msgstr ""
-
-#: src/olympia/compat/templates/compat/index.html:57
-msgid "Show all versions"
-msgstr ""
-
-#: src/olympia/compat/templates/compat/index.html:59
-msgid "Details for add-ons compatible with all versions:"
-msgstr ""
-
-#: src/olympia/compat/templates/compat/index.html:61
-msgid "Show previous version only"
 msgstr ""
 
 #: src/olympia/compat/templates/compat/reporter.html:3
@@ -3142,8 +3115,8 @@ msgstr ""
 msgid "Report Type"
 msgstr ""
 
-#: src/olympia/compat/templates/compat/reporter_detail.html:47 src/olympia/devhub/forms.py:784 src/olympia/devhub/templates/devhub/addons/ajax_compat_update.html:17 src/olympia/editors/forms.py:108
-#: src/olympia/zadmin/forms.py:45
+#: src/olympia/compat/templates/compat/reporter_detail.html:47 src/olympia/devhub/forms.py:785 src/olympia/devhub/templates/devhub/addons/ajax_compat_update.html:17 src/olympia/editors/forms.py:108
+#: src/olympia/editors/forms.py:248 src/olympia/zadmin/forms.py:45
 msgid "Application"
 msgstr ""
 
@@ -3231,7 +3204,8 @@ msgstr ""
 msgid "Preliminarily Reviewed and Awaiting Full Review"
 msgstr ""
 
-#: src/olympia/constants/base.py:33 src/olympia/editors/helpers.py:924 src/olympia/editors/templates/editors/themes/history_table.html:34
+#: src/olympia/constants/base.py:33 src/olympia/editors/forms.py:258 src/olympia/editors/helpers.py:73 src/olympia/editors/helpers.py:1004
+#: src/olympia/editors/templates/editors/themes/history_table.html:34
 msgid "Deleted"
 msgstr ""
 
@@ -3328,6 +3302,11 @@ msgstr ""
 msgid "Ask before users can download this add-on"
 msgstr ""
 
+#. Review points sources other than add-ons and themes.
+#: src/olympia/constants/base.py:388 src/olympia/devhub/forms.py:162 src/olympia/editors/templates/editors/performance.html:75
+msgid "Other"
+msgstr ""
+
 #: src/olympia/constants/base.py:389
 msgid "Exception"
 msgstr ""
@@ -3338,6 +3317,10 @@ msgstr ""
 
 #: src/olympia/constants/base.py:391
 msgid "Change"
+msgstr ""
+
+#: src/olympia/constants/base.py:401
+msgid "App"
 msgstr ""
 
 #: src/olympia/constants/base.py:402
@@ -3488,7 +3471,7 @@ msgstr ""
 msgid "Duplicate"
 msgstr ""
 
-#: src/olympia/constants/editors.py:17 src/olympia/editors/helpers.py:502 src/olympia/editors/templates/editors/themes/queue.html:71 src/olympia/editors/templates/editors/themes/themes.html:94
+#: src/olympia/constants/editors.py:17 src/olympia/editors/helpers.py:575 src/olympia/editors/templates/editors/themes/queue.html:71 src/olympia/editors/templates/editors/themes/themes.html:94
 msgid "Reject"
 msgstr ""
 
@@ -3588,7 +3571,7 @@ msgstr ""
 msgid "Android"
 msgstr ""
 
-#: src/olympia/core/apps.py:19
+#: src/olympia/core/apps.py:21
 msgid "Core"
 msgstr ""
 
@@ -3722,7 +3705,7 @@ msgid "Submit my add-on for manual review."
 msgstr ""
 
 #: src/olympia/devhub/forms.py:537
-msgid "Do not list my add-on on this site (beta)"
+msgid "Do not list my add-on on this site"
 msgstr ""
 
 #: src/olympia/devhub/forms.py:538
@@ -3755,46 +3738,46 @@ msgstr ""
 
 #: src/olympia/devhub/forms.py:592
 #, python-format
-msgid "Version %s already exists"
+msgid "Version %s already exists, or was uploaded before."
 msgstr ""
 
-#: src/olympia/devhub/forms.py:604
+#: src/olympia/devhub/forms.py:605
 msgid "Select a valid choice. That choice is not one of the available choices."
 msgstr ""
 
-#: src/olympia/devhub/forms.py:610
+#: src/olympia/devhub/forms.py:611
 msgid "A file with a version ending with a|alpha|b|beta and an optional number is detected as beta."
 msgstr ""
 
-#: src/olympia/devhub/forms.py:633
+#: src/olympia/devhub/forms.py:634
 msgid "You cannot upload any more files for this version."
 msgstr ""
 
-#: src/olympia/devhub/forms.py:639
+#: src/olympia/devhub/forms.py:640
 msgid "Version doesn't match"
 msgstr ""
 
-#: src/olympia/devhub/forms.py:668
+#: src/olympia/devhub/forms.py:669
 msgid "You cannot delete a file once the review process has started.  You must delete the whole version."
 msgstr ""
 
-#: src/olympia/devhub/forms.py:688
+#: src/olympia/devhub/forms.py:689
 msgid "The platform All cannot be combined with specific platforms."
 msgstr ""
 
-#: src/olympia/devhub/forms.py:693
+#: src/olympia/devhub/forms.py:694
 msgid "A platform can only be chosen once."
 msgstr ""
 
-#: src/olympia/devhub/forms.py:706
+#: src/olympia/devhub/forms.py:707
 msgid "A review type must be selected."
 msgstr ""
 
-#: src/olympia/devhub/forms.py:788 src/olympia/editors/forms.py:114 src/olympia/zadmin/forms.py:49 src/olympia/zadmin/forms.py:52
+#: src/olympia/devhub/forms.py:789 src/olympia/editors/forms.py:114 src/olympia/editors/forms.py:254 src/olympia/zadmin/forms.py:49 src/olympia/zadmin/forms.py:52
 msgid "Select an application first"
 msgstr ""
 
-#: src/olympia/devhub/forms.py:840
+#: src/olympia/devhub/forms.py:841
 msgid "There cannot be more than 3 required add-ons."
 msgstr ""
 
@@ -3828,76 +3811,76 @@ msgstr[1] ""
 msgid "Review"
 msgstr ""
 
-#: src/olympia/devhub/tasks.py:551
+#: src/olympia/devhub/tasks.py:583
 #, python-format
 msgid "%s responded with %s (%s)."
 msgstr ""
 
-#: src/olympia/devhub/tasks.py:555
+#: src/olympia/devhub/tasks.py:587
 #, python-format
 msgid "Connection to \"%s\" timed out."
 msgstr ""
 
-#: src/olympia/devhub/tasks.py:557
+#: src/olympia/devhub/tasks.py:589
 #, python-format
 msgid "Could not contact host at \"%s\"."
 msgstr ""
 
-#: src/olympia/devhub/utils.py:104
+#: src/olympia/devhub/utils.py:105
 #, python-format
 msgid "Validation generated too many errors/warnings so %s messages were truncated. After addressing the visible messages, you'll be able to see the others."
 msgstr ""
 
-#: src/olympia/devhub/views.py:183
+#: src/olympia/devhub/views.py:181
 msgid "All My Add-ons"
 msgstr ""
 
-#: src/olympia/devhub/views.py:210
+#: src/olympia/devhub/views.py:208
 msgid "All Activity"
 msgstr ""
 
-#: src/olympia/devhub/views.py:211
+#: src/olympia/devhub/views.py:209
 msgid "Add-on Updates"
 msgstr ""
 
-#: src/olympia/devhub/views.py:212
+#: src/olympia/devhub/views.py:210
 msgid "Add-on Status"
 msgstr ""
 
-#: src/olympia/devhub/views.py:213
+#: src/olympia/devhub/views.py:211
 msgid "User Collections"
 msgstr ""
 
-#: src/olympia/devhub/views.py:214 src/olympia/devhub/templates/devhub/docs/policies-maintenance.html:68 src/olympia/pages/templates/pages/dev_faq.html:38
+#: src/olympia/devhub/views.py:212 src/olympia/devhub/templates/devhub/docs/policies-maintenance.html:68 src/olympia/pages/templates/pages/dev_faq.html:38
 #: src/olympia/pages/templates/pages/dev_faq.html:484
 msgid "User Reviews"
 msgstr ""
 
-#: src/olympia/devhub/views.py:327 src/olympia/devhub/views.py:331 src/olympia/devhub/views.py:484 src/olympia/devhub/views.py:513 src/olympia/devhub/views.py:564 src/olympia/devhub/views.py:1150
+#: src/olympia/devhub/views.py:325 src/olympia/devhub/views.py:329 src/olympia/devhub/views.py:484 src/olympia/devhub/views.py:513 src/olympia/devhub/views.py:564 src/olympia/devhub/views.py:1156
 msgid "Changes successfully saved."
 msgstr ""
 
-#: src/olympia/devhub/views.py:334 src/olympia/devhub/views.py:1631
+#: src/olympia/devhub/views.py:332 src/olympia/devhub/views.py:1637
 msgid "Please check the form for errors."
 msgstr ""
 
-#: src/olympia/devhub/views.py:346
+#: src/olympia/devhub/views.py:344
 msgid "Add-on cannot be deleted. Disable this add-on instead."
 msgstr ""
 
-#: src/olympia/devhub/views.py:356
+#: src/olympia/devhub/views.py:354
 msgid "Theme deleted."
 msgstr ""
 
-#: src/olympia/devhub/views.py:356
+#: src/olympia/devhub/views.py:354
 msgid "Add-on deleted."
 msgstr ""
 
-#: src/olympia/devhub/views.py:362
+#: src/olympia/devhub/views.py:360
 msgid "URL name was incorrect. Theme was not deleted."
 msgstr ""
 
-#: src/olympia/devhub/views.py:367
+#: src/olympia/devhub/views.py:365
 msgid "URL name was incorrect. Add-on was not deleted."
 msgstr ""
 
@@ -3925,7 +3908,7 @@ msgstr ""
 msgid "Check Add-on Compatibility"
 msgstr ""
 
-#: src/olympia/devhub/views.py:808 src/olympia/signing/views.py:90
+#: src/olympia/devhub/views.py:808 src/olympia/signing/views.py:95
 msgid "You cannot submit this type of add-on"
 msgstr ""
 
@@ -3955,33 +3938,33 @@ msgstr ""
 msgid "There was an error uploading your preview."
 msgstr ""
 
-#: src/olympia/devhub/views.py:1189
+#: src/olympia/devhub/views.py:1195
 #, python-format
 msgid "Version %s disabled."
 msgstr ""
 
-#: src/olympia/devhub/views.py:1193
+#: src/olympia/devhub/views.py:1199
 #, python-format
 msgid "Version %s deleted."
 msgstr ""
 
-#: src/olympia/devhub/views.py:1203
+#: src/olympia/devhub/views.py:1209
 msgid "This upload has failed validation, and may lack complete validation results. Please take due care when reviewing it."
 msgstr ""
 
-#: src/olympia/devhub/views.py:1677
+#: src/olympia/devhub/views.py:1683
 msgid "Preliminary Review Requested."
 msgstr ""
 
-#: src/olympia/devhub/views.py:1678
+#: src/olympia/devhub/views.py:1684
 msgid "Full Review Requested."
 msgstr ""
 
-#: src/olympia/devhub/views.py:1779
+#: src/olympia/devhub/views.py:1783
 msgid "Your old credentials were revoked and are no longer valid. Be sure to update all API clients with the new credentials."
 msgstr ""
 
-#: src/olympia/devhub/views.py:1797
+#: src/olympia/devhub/views.py:1801
 msgid "New API key created"
 msgstr ""
 
@@ -4011,7 +3994,7 @@ msgstr ""
 msgid "{0} :: Search"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/devhub_search.html:6 src/olympia/devhub/templates/devhub/search.html:8 src/olympia/editors/forms.py:435 src/olympia/editors/forms.py:437
+#: src/olympia/devhub/templates/devhub/devhub_search.html:6 src/olympia/devhub/templates/devhub/search.html:8 src/olympia/editors/forms.py:534 src/olympia/editors/forms.py:536
 #: src/olympia/editors/templates/editors/queue.html:27 src/olympia/editors/templates/editors/themes/queue_list.html:14 src/olympia/search/templates/search/collections.html:17
 #: src/olympia/search/templates/search/personas.html:18 src/olympia/search/templates/search/results.html:18 src/olympia/search/templates/search/mobile/results.html:8
 #: src/olympia/templates/search.html:14 src/olympia/templates/impala/search.html:18
@@ -4071,12 +4054,12 @@ msgstr ""
 msgid "Start Making Add-ons"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/index.html:86 src/olympia/devhub/templates/devhub/addons/listing/items.html:25 src/olympia/devhub/templates/devhub/includes/addon_details.html:15
+#: src/olympia/devhub/templates/devhub/index.html:86 src/olympia/devhub/templates/devhub/addons/listing/items.html:25 src/olympia/devhub/templates/devhub/includes/addon_details.html:20
 #: src/olympia/devhub/templates/devhub/personas/edit.html:43
 msgid "Status:"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/index.html:90 src/olympia/devhub/templates/devhub/includes/addon_details.html:100
+#: src/olympia/devhub/templates/devhub/index.html:90 src/olympia/devhub/templates/devhub/includes/addon_details.html:87
 msgid "Visibility:"
 msgstr ""
 
@@ -4084,11 +4067,11 @@ msgstr ""
 msgid "Latest Version:"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/index.html:109 src/olympia/devhub/templates/devhub/includes/addon_details.html:145 src/olympia/devhub/templates/devhub/personas/edit.html:49
+#: src/olympia/devhub/templates/devhub/index.html:109 src/olympia/devhub/templates/devhub/includes/addon_details.html:131 src/olympia/devhub/templates/devhub/personas/edit.html:49
 msgid "Queue Position:"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/index.html:110 src/olympia/devhub/templates/devhub/includes/addon_details.html:146 src/olympia/devhub/templates/devhub/personas/edit.html:50
+#: src/olympia/devhub/templates/devhub/index.html:110 src/olympia/devhub/templates/devhub/includes/addon_details.html:132 src/olympia/devhub/templates/devhub/personas/edit.html:50
 #, python-format
 msgid "%(position)s of %(total)s"
 msgstr ""
@@ -4190,16 +4173,6 @@ msgstr ""
 msgid "Do you want your add-on to be distributed on this site?"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/validate_addon.html:49 src/olympia/devhub/templates/devhub/addons/submit/upload.html:30 src/olympia/devhub/templates/devhub/versions/add_file_modal.html:14
-#: src/olympia/devhub/templates/devhub/versions/add_file_modal.html:53 src/olympia/devhub/templates/devhub/versions/list.html:298
-msgid "Warning:"
-msgstr ""
-
-#: src/olympia/devhub/templates/devhub/validate_addon.html:50 src/olympia/devhub/templates/devhub/addons/submit/upload.html:31
-#, python-format
-msgid "Submission of unlisted add-ons for signing is currently in an open beta. Please <a href=\"%(url)s\" target=\"_blank\">report any bugs</a> that you encounter."
-msgstr ""
-
 #. first parameter is a filename like lorem-ipsum-1.0.2.xpi
 #: src/olympia/devhub/templates/devhub/validation.html:5
 msgid "Validation Results for {0}"
@@ -4274,7 +4247,7 @@ msgstr ""
 msgid "Update Compatibility"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/addons/ajax_compat_update.html:4
+#: src/olympia/devhub/templates/devhub/addons/ajax_compat_update.html:4 src/olympia/devhub/templates/devhub/versions/edit.html:45
 msgid "Adjusting application information here will allow users to install your add-on even if the install manifest in the package indicates that the add-on is incompatible."
 msgstr ""
 
@@ -4286,9 +4259,9 @@ msgstr ""
 msgid "Add Another Application&hellip;"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/addons/ajax_compat_update.html:38 src/olympia/devhub/templates/devhub/addons/owner.html:86 src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:46
-#: src/olympia/devhub/templates/devhub/versions/list.html:351 src/olympia/devhub/templates/devhub/versions/list.html:353 src/olympia/templates/impala/base.html:132
-#: src/olympia/templates/impala/base.html:143 src/olympia/templates/impala/base.html:161 src/olympia/templates/impala/base.html:171
+#: src/olympia/devhub/templates/devhub/addons/ajax_compat_update.html:38 src/olympia/devhub/templates/devhub/addons/owner.html:86 src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:45
+#: src/olympia/devhub/templates/devhub/versions/list.html:349 src/olympia/devhub/templates/devhub/versions/list.html:351 src/olympia/templates/impala/base.html:129
+#: src/olympia/templates/impala/base.html:140 src/olympia/templates/impala/base.html:158 src/olympia/templates/impala/base.html:168
 msgid "Close"
 msgstr ""
 
@@ -4322,7 +4295,7 @@ msgstr ""
 msgid "Manage Authors & License"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/addons/owner.html:29 src/olympia/editors/templates/editors/review.html:270
+#: src/olympia/devhub/templates/devhub/addons/owner.html:29 src/olympia/editors/helpers.py:362 src/olympia/editors/templates/editors/review.html:270
 msgid "Authors"
 msgstr ""
 
@@ -4391,17 +4364,11 @@ msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/basic.html:52
 msgid ""
-"A short explanation of your add-on's basic\n"
-"                          functionality that is displayed in search and browse\n"
-"                          listings, as well as at the top of your add-on's\n"
-"                          details page. It is only relevant for listed add-ons."
+"A short explanation of your add-on's basic functionality that is displayed in search and browse listings, as well as at the top of your add-on's details page. It is only relevant for listed add-ons."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/basic.html:73
-msgid ""
-"Categories are the primary way users browse through add-ons.\n"
-"                        Choose any that fit your add-on's functionality for the most\n"
-"                        exposure. It is only relevant for listed add-ons."
+msgid "Categories are the primary way users browse through add-ons. Choose any that fit your add-on's functionality for the most exposure. It is only relevant for listed add-ons."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/basic.html:90
@@ -4411,11 +4378,7 @@ msgid ""
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/basic.html:119
-msgid ""
-"Tags help users find your add-on and should be short\n"
-"                        descriptors such as tabs, toolbar, or twitter.  You\n"
-"                        may have a maximum of {0} tags. It is only relevant\n"
-"                        for listed add-ons."
+msgid "Tags help users find your add-on and should be short descriptors such as tabs, toolbar, or twitter. You may have a maximum of {0} tags. It is only relevant for listed add-ons."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/basic.html:129 src/olympia/devhub/templates/devhub/personas/edit.html:97 src/olympia/devhub/templates/devhub/personas/submit.html:46
@@ -4443,11 +4406,7 @@ msgid "Add-on Details for {0}"
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/details.html:22
-msgid ""
-"A longer explanation of features,\n"
-"                          functionality, and other relevant information. This\n"
-"                          field is only displayed on the add-on's details\n"
-"                          page. It is only relevant for listed add-ons."
+msgid "A longer explanation of features, functionality, and other relevant information. This field is only displayed on the add-on's details page. It is only relevant for listed add-ons."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/details.html:44 src/olympia/translations/templates/translations/trans-menu.html:13
@@ -4455,10 +4414,7 @@ msgid "Default Locale"
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/details.html:45
-msgid ""
-"Information about your add-on is displayed in this locale\n"
-"                        unless you override it with a locale-specific translation.\n"
-"                        It is only relevant for listed add-ons."
+msgid "Information about your add-on is displayed in this locale unless you override it with a locale-specific translation. It is only relevant for listed add-ons."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/details.html:61 src/olympia/users/forms.py:311 src/olympia/users/templates/users/edit.html:122 src/olympia/users/templates/users/register.html:57
@@ -4468,10 +4424,8 @@ msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/details.html:63
 msgid ""
-"If your add-on has another homepage, enter its\n"
-"                          address here. If your website is localized into other\n"
-"                          languages multiple translations of this field can be\n"
-"                          added. It is only relevant for listed add-ons."
+"If your add-on has another homepage, enter its address here. If your website is localized into other languages multiple translations of this field can be added. It is only relevant for listed add-"
+"ons."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/media.html:3
@@ -4489,19 +4443,14 @@ msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/support.html:22
 msgid ""
-"If you wish to display an e-mail address for support\n"
-"                          inquiries, enter it here. If you have different\n"
-"                          addresses for each language multiple translations of\n"
-"                          this field can be added. It is only relevant for\n"
-"                          listed add-ons."
+"If you wish to display an e-mail address for support inquiries, enter it here. If you have different addresses for each language multiple translations of this field can be added. It is only "
+"relevant for listed add-ons."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/support.html:45
 msgid ""
-"If your add-on has a support website or forum, enter\n"
-"                          its address here. If your website is localized into\n"
-"                          other languages, multiple translations of this field can\n"
-"                          be added. It is only relevant for listed add-ons."
+"If your add-on has a support website or forum, enter its address here. If your website is localized into other languages, multiple translations of this field can be added. It is only relevant for "
+"listed add-ons."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:6
@@ -4515,11 +4464,8 @@ msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:23
 msgid ""
-"Any information end users may want to know that isn't\n"
-"                          necessarily applicable to the add-on summary or description.\n"
-"                          Common uses include listing known major bugs, information on\n"
-"                          how to report bugs, anticipated release date of a new version,\n"
-"                          etc. It is only relevant for listed add-ons."
+"Any information end users may want to know that isn't necessarily applicable to the add-on summary or description. Common uses include listing known major bugs, information on how to report bugs, "
+"anticipated release date of a new version, etc. It is only relevant for listed add-ons."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:46
@@ -4531,9 +4477,7 @@ msgid "Add-on Flags"
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:69
-msgid ""
-"These flags are used to classify add-ons. It is only\n"
-"                        relevant for listed add-ons."
+msgid "These flags are used to classify add-ons. It is only relevant for listed add-ons."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:74
@@ -4549,9 +4493,7 @@ msgid "View Source?"
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:90
-msgid ""
-"Whether the source of your add-on can be displayed in our\n"
-"                        online viewer. It is only relevant for listed add-ons."
+msgid "Whether the source of your add-on can be displayed in our online viewer. It is only relevant for listed add-ons."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:94
@@ -4567,10 +4509,7 @@ msgid "Public Stats?"
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:102
-msgid ""
-"Whether the download and usage stats of your add-on can\n"
-"                        be displayed in our online viewer.\n"
-"                        It is only relevant for listed add-ons."
+msgid "Whether the download and usage stats of your add-on can be displayed in our online viewer. It is only relevant for listed add-ons."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:107
@@ -4586,10 +4525,7 @@ msgid "Upgrade SDK?"
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:116
-msgid ""
-"If selected, we will try to automatically upgrade your\n"
-"                        add-on when a new version of the SDK is released.\n"
-"                        It is only relevant for listed add-ons."
+msgid "If selected, we will try to automatically upgrade your add-on when a new version of the SDK is released. It is only relevant for listed add-ons."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:121
@@ -4640,10 +4576,8 @@ msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/forms_shared/media.html:16
 msgid ""
-"Upload an icon for your add-on or choose from one of ours. The\n"
-"                      icon is displayed nearly everywhere your add-on is. Uploaded images\n"
-"                      must be one of the following image types: .png, .jpg.\n"
-"                      It is only relevant for listed add-ons."
+"Upload an icon for your add-on or choose from one of ours. The icon is displayed nearly everywhere your add-on is. Uploaded images must be one of the following image types: .png, .jpg. It is only "
+"relevant for listed add-ons."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/forms_shared/media.html:25
@@ -4656,9 +4590,7 @@ msgid "32x32px"
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/forms_shared/media.html:39
-msgid ""
-"Used in listings of add-ons, like search results\n"
-"                            and featured add-ons."
+msgid "Used in listings of add-ons, like search results and featured add-ons."
 msgstr ""
 
 #. The size of the icon
@@ -4753,16 +4685,14 @@ msgid "Deleting your add-on will permanently remove it from the site and prevent
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:24
-msgid ""
-"Enter the following text confirm your decision:\n"
-"           {slug}"
+msgid "Enter the following text confirm your decision: {slug}"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:34
+#: src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:33
 msgid "Please tell us why you are deleting your theme:"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:36
+#: src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:35
 msgid "Please tell us why you are deleting your add-on:"
 msgstr ""
 
@@ -4799,8 +4729,8 @@ msgstr ""
 msgid "Daily statistics on downloads and users."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/addons/listing/item_actions.html:45 src/olympia/stats/templates/stats/stats.html:75 src/olympia/stats/templates/stats/stats.html:79
-#: src/olympia/stats/templates/stats/stats.html:81
+#: src/olympia/devhub/templates/devhub/addons/listing/item_actions.html:45 src/olympia/stats/templates/stats/stats.html:31 src/olympia/stats/templates/stats/stats.html:35
+#: src/olympia/stats/templates/stats/stats.html:37
 msgid "Statistics"
 msgstr ""
 
@@ -4919,10 +4849,7 @@ msgid "Your add-on has been submitted to the Full Review queue."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/submit/done.html:18
-msgid ""
-"You'll receive an email once it has been reviewed by an editor. In\n"
-"          the meantime, you and your friends can install it directly from its\n"
-"          details page:"
+msgid "You'll receive an email once it has been reviewed by an editor. In the meantime, you and your friends can install it directly from its details page:"
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/submit/done.html:27 src/olympia/devhub/templates/devhub/addons/submit/done.html:77 src/olympia/devhub/templates/devhub/personas/submit_done.html:16
@@ -5128,11 +5055,11 @@ msgstr ""
 msgid "Use the fields below to upload your add-on package and select any platform restrictions. After upload, a series of automated validation tests will be run on your file."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/addons/submit/upload.html:59 src/olympia/devhub/templates/devhub/versions/add_file_modal.html:39
+#: src/olympia/devhub/templates/devhub/addons/submit/upload.html:51 src/olympia/devhub/templates/devhub/versions/add_file_modal.html:28
 msgid "Which platforms is this file compatible with?"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/addons/submit/upload.html:67 src/olympia/devhub/templates/devhub/versions/add_file_modal.html:65
+#: src/olympia/devhub/templates/devhub/addons/submit/upload.html:59 src/olympia/devhub/templates/devhub/versions/add_file_modal.html:45
 msgid "Administrative overrides"
 msgstr ""
 
@@ -5242,8 +5169,8 @@ msgstr ""
 
 #: src/olympia/devhub/templates/devhub/docs/policies-contact.html:44
 msgid ""
-"If you've found a problem with the site, we'd love to fix it. Please <a href=\"https://github.com/mozilla/olympia/issues\">file a bug report</a> in GitHub, including the location of the problem and "
-"how you encountered it."
+"If you've found a problem with the site, we'd love to fix it. Please <a href=\"https://github.com/mozilla/addons/issues/new\">file a bug report</a> in GitHub, including the location of the problem "
+"and how you encountered it."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/docs/policies-maintenance.html:3 src/olympia/devhub/templates/devhub/docs/policies-maintenance.html:7
@@ -5810,7 +5737,7 @@ msgstr ""
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:282
 msgid ""
-"Add-ons that store or otherwise handle browsing data must support <a href=\"https://developer.mozilla.org/En/Supporting_private_browsing_mode\">Private Browsing Mode</a>.  During a Private Browsing "
+"Add-ons that store or otherwise handle browsing data must support <a href=\"https://developer.mozilla.org/En/Supporting_private_browsing_mode\">Private Browsing Mode</a>. During a Private Browsing "
 "session, no browsing data can be written to disk, and all of this data must be cleared when Firefox quits or the Private Browsing session ends."
 msgstr ""
 
@@ -5975,129 +5902,95 @@ msgstr ""
 msgid "How to get in touch with us regarding these policies or your add-on."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:6
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:10
 msgid "You have disabled this add-on"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:20
-msgid ""
-"Your add-on's listing is disabled and is not showing\n"
-"                             anywhere in our gallery or update service."
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:24
+msgid "Your add-on's listing is disabled and is not showing anywhere in our gallery or update service."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:25
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:27
 msgid "Please complete your add-on."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:29
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:30
 msgid "You will receive an email when the review is complete."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:34
-msgid ""
-"You will receive an email when the review is complete. Until\n"
-"                             then, your add-on is not listed in our gallery but can be\n"
-"                             accessed directly from its details page."
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:33
+msgid "You will receive an email when the review is complete. Until then, your add-on is not listed in our gallery but can be accessed directly from its details page."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:38 src/olympia/devhub/templates/devhub/includes/addon_details.html:48
-msgid ""
-"You will receive an email when the review is\n"
-"                             complete and your add-on is signed."
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:37 src/olympia/devhub/templates/devhub/includes/addon_details.html:45
+msgid "You will receive an email when the review is complete and your add-on is signed."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:44
-msgid ""
-"You will receive an email when the review is complete. Until\n"
-"                             then, your add-on is not listed in our gallery but can be\n"
-"                             accessed directly from its details page. "
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:41
+msgid "You will receive an email when the review is complete. Until then, your add-on is not listed in our gallery but can be accessed directly from its details page. "
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:54
-msgid ""
-"Your add-on is displayed in our gallery and users are\n"
-"                             receiving automatic updates."
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:49
+msgid "Your add-on is displayed in our gallery and users are receiving automatic updates."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:57
-msgid ""
-"Your add-on has been signed and can be bundled with an\n"
-"                             application installer."
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:52
+msgid "Your add-on has been signed and can be bundled with an application installer."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:63
-msgid ""
-"Your add-on was disabled by a site administrator and is no\n"
-"                             longer shown in our gallery. If you have any questions,\n"
-"                             please email amo-admins@mozilla.org."
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:56
+msgid "Your add-on was disabled by a site administrator and is no longer shown in our gallery. If you have any questions, please email amo-admins@mozilla.org."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:70
-msgid ""
-"Your add-on is displayed in our gallery as experimental\n"
-"                             and users are receiving automatic updates. Some features\n"
-"                             are unavailable to your add-on."
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:62
+msgid "Your add-on is displayed in our gallery as experimental and users are receiving automatic updates. Some features are unavailable to your add-on."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:74
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:66
 msgid "Your add-on has been signed."
 msgstr ""
 
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:69
+msgid ""
+"You will receive an email when the full review is complete. Until then, your add-on is displayed in our gallery as experimental and users are receiving automatic updates. Some features are "
+"unavailable to your add-on."
+msgstr ""
+
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:74
+msgid "You will receive an email when the full review is complete, making you able to bundle your add-on with an application installer."
+msgstr ""
+
 #: src/olympia/devhub/templates/devhub/includes/addon_details.html:79
-msgid ""
-"You will receive an email when the full review is complete.\n"
-"                             Until then, your add-on is displayed in our gallery as\n"
-"                             experimental and users are receiving automatic updates.\n"
-"                             Some features are unavailable to your add-on."
+msgid "All add-ons hosted in our gallery must now be reviewed by an editor. If you wish to continue hosting your add-on, please click to select a review process."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:84
-msgid ""
-"You will receive an email when the full review is\n"
-"                             complete, making you able to bundle your add-on with an\n"
-"                             application installer."
-msgstr ""
-
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:91
-msgid ""
-"All add-ons hosted in our gallery must now be reviewed by an\n"
-"                             editor. If you wish to continue hosting your add-on, please\n"
-"                             click to select a review process."
-msgstr ""
-
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:113
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:100
 msgid "Current Version:"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:115
-msgid ""
-"This is the version of your add-on that will\n"
-"                                           be installed if someone clicks the Install\n"
-"                                           button on addons.mozilla.org. It is only\n"
-"                                           relevant for listed add-ons."
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:102
+msgid "This is the version of your add-on that will be installed if someone clicks the Install button on addons.mozilla.org. It is only relevant for listed add-ons."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:123
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:110
 msgid "Created:"
 msgstr ""
 
 #. {0} is a date. dennis-ignore: E201
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:125 src/olympia/devhub/templates/devhub/includes/addon_details.html:131
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:112 src/olympia/devhub/templates/devhub/includes/addon_details.html:118
 #, python-format
 msgid "%%b %%e, %%Y"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:136
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:123
 msgid "Next Version:"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:138
-msgid ""
-"This is the newest uploaded version, however\n"
-"                                           it isn’t live on the site yet."
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:125
+msgid "This is the newest uploaded version, however it isn’t live on the site yet."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:144 src/olympia/devhub/templates/devhub/versions/list.html:30
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:130 src/olympia/devhub/templates/devhub/versions/list.html:30
 msgid "Queues are not reviewed strictly in order"
 msgstr ""
 
@@ -6165,9 +6058,7 @@ msgid "View the blog &#9658;"
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/includes/license_form.html:6
-msgid ""
-"Please choose a license appropriate for the rights you grant on your source code.\n"
-"                  It is only relevant for listed add-ons."
+msgid "Please choose a license appropriate for the rights you grant on your source code. It is only relevant for listed add-ons."
 msgstr ""
 
 #. {0} is a list of HTML tags.
@@ -6194,14 +6085,11 @@ msgstr[1] ""
 #: src/olympia/devhub/templates/devhub/includes/policy_form.html:4
 msgid ""
 "Users will be required to accept the following End-User License Agreement (EULA) prior to installing your add-on. The presence of a EULA significantly affects the number of downloads an add-on "
-"receives. Please note that a EULA is not the same as a code license, such as the GPL or MPL.\n"
-"                It is only relevant for listed add-ons."
+"receives. Please note that a EULA is not the same as a code license, such as the GPL or MPL.It is only relevant for listed add-ons."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/policy_form.html:21
-msgid ""
-"If your add-on transmits any data from the user's computer, a privacy policy is required that explains what data is sent and how it is used.\n"
-"                It is only relevant for listed add-ons."
+#: src/olympia/devhub/templates/devhub/includes/policy_form.html:24
+msgid "If your add-on transmits any data from the user's computer, a privacy policy is required that explains what data is sent and how it is used. It is only relevant for listed add-ons."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/includes/source_form_field.html:2
@@ -6369,12 +6257,8 @@ msgstr ""
 msgid "Add some tags to describe your Theme."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/personas/edit.html:106
-msgid ""
-"A short explanation of your theme's\n"
-"                                basic functionality that is displayed in\n"
-"                                search and browse listings, as well as at\n"
-"                                the top of your theme's details page."
+#: src/olympia/devhub/templates/devhub/personas/edit.html:106 src/olympia/devhub/templates/devhub/personas/submit.html:54
+msgid "A short explanation of your theme's basic functionality that is displayed in search and browse listings, as well as at the top of your theme's details page."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/personas/edit.html:122 src/olympia/devhub/templates/devhub/personas/submit.html:68
@@ -6444,7 +6328,7 @@ msgid "Upon upload and form submission, the AMO Team will review your updated de
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/personas/edit.html:241
-msgid "Your previously resubmitted design,  which is under pending review."
+msgid "Your previously resubmitted design, which is under pending review."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/personas/edit.html:245
@@ -6511,14 +6395,6 @@ msgstr ""
 
 #: src/olympia/devhub/templates/devhub/personas/submit.html:33
 msgid "Give your Theme a name."
-msgstr ""
-
-#: src/olympia/devhub/templates/devhub/personas/submit.html:54
-msgid ""
-"A short explanation of your theme's\n"
-"                                      basic functionality that is displayed in\n"
-"                                      search and browse listings, as well as at\n"
-"                                      the top of your theme's details page."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/personas/submit.html:198
@@ -6595,30 +6471,16 @@ msgstr ""
 msgid "Files added to reviewed versions must be reviewed before they will be available for download."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/add_file_modal.html:15
-#, python-format
-msgid ""
-"Submission of updates to unlisted add-ons for signing is currently in an open beta. Manual review may still be required for a large number of add-ons. Please <a href=\"%(url)s\" target=\"_blank"
-"\">report any bugs</a> that you encounter."
-msgstr ""
-
-#: src/olympia/devhub/templates/devhub/versions/add_file_modal.html:35
+#: src/olympia/devhub/templates/devhub/versions/add_file_modal.html:24
 msgid "Select the target platform for this file."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/add_file_modal.html:46
+#: src/olympia/devhub/templates/devhub/versions/add_file_modal.html:35
 msgid "Which review type would you like to nominate for?"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/add_file_modal.html:51
+#: src/olympia/devhub/templates/devhub/versions/add_file_modal.html:40
 msgid "Only publish this version to my beta channel."
-msgstr ""
-
-#: src/olympia/devhub/templates/devhub/versions/add_file_modal.html:54
-#, python-format
-msgid ""
-"The behavior of the beta channel has changed to accommodate <a href=\"%(addon_signing_url)s\" target=\"_blank\">mandatory add-on signing</a>. The new process is currently in an open beta, and may "
-"change significantly in the near future. Please <a href=\"%(issues_url)s\" target=\"_blank\">report any bugs</a> that you encounter."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/versions/edit.html:5
@@ -6642,19 +6504,10 @@ msgstr ""
 msgid "Upload Another File"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/edit.html:45
-msgid ""
-"Adjusting application information here will allow users to install your\n"
-"                          add-on even if the install manifest in the package indicates that the\n"
-"                          add-on is incompatible."
-msgstr ""
-
 #: src/olympia/devhub/templates/devhub/versions/edit.html:74
 msgid ""
-"Information about changes in this release, new features,\n"
-"                              known bugs, and other useful information specific to this\n"
-"                              release/version. This information is also shown in the\n"
-"                              Add-ons Manager when updating."
+"Information about changes in this release, new features, known bugs, and other useful information specific to this release/version. This information is also shown in the Add-ons Manager when "
+"updating."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/versions/edit.html:99
@@ -6666,10 +6519,7 @@ msgid "Notes for Reviewers"
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/versions/edit.html:114
-msgid ""
-"Optionally, enter any information that may be useful\n"
-"                              to the Editor reviewing this add-on, such as test\n"
-"                              account information."
+msgid "Optionally, enter any information that may be useful to the Editor reviewing this add-on, such as test account information."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/versions/edit.html:127
@@ -6747,7 +6597,7 @@ msgstr ""
 msgid "Request Preliminary Review"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:80 src/olympia/devhub/templates/devhub/versions/list.html:327 src/olympia/devhub/templates/devhub/versions/list.html:350
+#: src/olympia/devhub/templates/devhub/versions/list.html:80 src/olympia/devhub/templates/devhub/versions/list.html:325 src/olympia/devhub/templates/devhub/versions/list.html:348
 msgid "Cancel Review Request"
 msgstr ""
 
@@ -6776,7 +6626,7 @@ msgid "Unlisted:"
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/versions/list.html:114
-msgid "Not distributed on {0}. Developers will upload new versions for signing and distribute the add-ons on their own. (beta)"
+msgid "Not distributed on {0}. Developers will upload new versions for signing and distribute the add-ons on their own."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/versions/list.html:122
@@ -6839,81 +6689,73 @@ msgid "<strong>Important:</strong> Once a version has been deleted, you may not 
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/versions/list.html:230
-msgid ""
-"Deleting a version which has already been reviewed\n"
-"               may also cause a significant delay in the review of\n"
-"               your next update."
-msgstr ""
-
-#: src/olympia/devhub/templates/devhub/versions/list.html:233
 msgid "Are you sure you wish to delete this version?"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:238
+#: src/olympia/devhub/templates/devhub/versions/list.html:235
 msgid "Delete Version"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:240
+#: src/olympia/devhub/templates/devhub/versions/list.html:237
 msgid "Disable Version"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:247
+#: src/olympia/devhub/templates/devhub/versions/list.html:244
 msgid "Add a new Version"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:249
+#: src/olympia/devhub/templates/devhub/versions/list.html:246
 msgid "Add Version"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:256 src/olympia/devhub/templates/devhub/versions/list.html:274
+#: src/olympia/devhub/templates/devhub/versions/list.html:253 src/olympia/devhub/templates/devhub/versions/list.html:279
 msgid "Hide Add-on"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:259
+#: src/olympia/devhub/templates/devhub/versions/list.html:256
 msgid "Hiding your add-on will prevent it from appearing anywhere in our gallery and will stop users from receiving automatic updates."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:265
+#: src/olympia/devhub/templates/devhub/versions/list.html:263
+msgid "The files awaiting review will be disabled and you will need to upload new versions."
+msgstr ""
+
+#: src/olympia/devhub/templates/devhub/versions/list.html:270
 msgid "Are you sure you wish to hide your add-on?"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:286 src/olympia/devhub/templates/devhub/versions/list.html:315
+#: src/olympia/devhub/templates/devhub/versions/list.html:291 src/olympia/devhub/templates/devhub/versions/list.html:313
 msgid "Unlist Add-on"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:289
+#: src/olympia/devhub/templates/devhub/versions/list.html:294
 #, python-format
 msgid ""
 "Unlisting your add-on will make it (and each of its versions/files) invisible on this website. It won't show up in searches, won't have a public facing page, and won't be updated automatically for "
-"current users.  It is recommended for unlisted add-ons to provide a custom <a href=\"%(update_url)s\" target=\"_blank\">updateURL</a> in their manifest file for automatic updates."
+"current users. It is recommended for unlisted add-ons to provide a custom <a href=\"%(update_url)s\" target=\"_blank\">updateURL</a> in their manifest file for automatic updates."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:299
-#, python-format
-msgid "Switching add-ons to unlisted is currently in an open beta. Please <a href=\"%(url)s\" target=\"_blank\">report any bugs</a> that you encounter."
-msgstr ""
-
-#: src/olympia/devhub/templates/devhub/versions/list.html:305
+#: src/olympia/devhub/templates/devhub/versions/list.html:303
 msgid "Unlisting an add-on is irreversible!"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:305
+#: src/olympia/devhub/templates/devhub/versions/list.html:303
 msgid "An unlisted add-on cannot be switched to be listed."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:307
+#: src/olympia/devhub/templates/devhub/versions/list.html:305
 msgid "Are you sure you wish to unlist your add-on?"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:330
+#: src/olympia/devhub/templates/devhub/versions/list.html:328
 msgid "Canceling your review request will leave your add-on as preliminarily reviewed."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:335
+#: src/olympia/devhub/templates/devhub/versions/list.html:333
 msgid "Canceling your review request will mark your add-on incomplete. If you do not complete your add-on after several days by re-requesting review, it will be deleted."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:343
+#: src/olympia/devhub/templates/devhub/versions/list.html:341
 msgid "Are you sure you wish to cancel your review request?"
 msgstr ""
 
@@ -7252,19 +7094,19 @@ msgstr ""
 msgid "Search by add-on name / author email"
 msgstr ""
 
-#: src/olympia/editors/forms.py:103
+#: src/olympia/editors/forms.py:103 src/olympia/editors/forms.py:244 src/olympia/editors/forms.py:257
 msgid "yes"
 msgstr ""
 
-#: src/olympia/editors/forms.py:104
+#: src/olympia/editors/forms.py:104 src/olympia/editors/forms.py:244 src/olympia/editors/forms.py:257
 msgid "no"
 msgstr ""
 
-#: src/olympia/editors/forms.py:105
+#: src/olympia/editors/forms.py:105 src/olympia/editors/forms.py:245
 msgid "Admin Flag"
 msgstr ""
 
-#: src/olympia/editors/forms.py:113
+#: src/olympia/editors/forms.py:113 src/olympia/editors/forms.py:253
 msgid "Max. Version"
 msgstr ""
 
@@ -7276,55 +7118,59 @@ msgstr ""
 msgid "Add-on Types"
 msgstr ""
 
-#: src/olympia/editors/forms.py:126 src/olympia/editors/helpers.py:267
+#: src/olympia/editors/forms.py:126 src/olympia/editors/helpers.py:279
 msgid "Platforms"
 msgstr ""
 
+#: src/olympia/editors/forms.py:237
+msgid "Search by add-on name / author email / guid"
+msgstr ""
+
 #. L10n: 0 = platform, 1 = filename, 2 = status message
-#: src/olympia/editors/forms.py:238
+#: src/olympia/editors/forms.py:342
 #, python-format
 msgid "<strong>%s</strong> &middot; %s &middot; %s"
 msgstr ""
 
-#: src/olympia/editors/forms.py:252
+#: src/olympia/editors/forms.py:356
 msgid "Comments:"
 msgstr ""
 
-#: src/olympia/editors/forms.py:256
+#: src/olympia/editors/forms.py:360
 msgid "Operating systems:"
 msgstr ""
 
-#: src/olympia/editors/forms.py:258
+#: src/olympia/editors/forms.py:362
 msgid "Applications:"
 msgstr ""
 
-#: src/olympia/editors/forms.py:260
+#: src/olympia/editors/forms.py:364
 msgid "Notify me the next time this add-on is updated. (Subsequent updates will not generate an email)"
 msgstr ""
 
-#: src/olympia/editors/forms.py:265
+#: src/olympia/editors/forms.py:369
 msgid "Clear Admin Review Flag"
 msgstr ""
 
-#: src/olympia/editors/forms.py:267
+#: src/olympia/editors/forms.py:371
 msgid "Clear more info requested flag"
 msgstr ""
 
-#: src/olympia/editors/forms.py:281
+#: src/olympia/editors/forms.py:385
 msgid "Choose a canned response..."
 msgstr ""
 
 #. L10n: Description of what can be searched for.
-#: src/olympia/editors/forms.py:324
+#: src/olympia/editors/forms.py:423
 msgid "theme name"
 msgstr ""
 
-#: src/olympia/editors/forms.py:350
+#: src/olympia/editors/forms.py:449
 msgid "Someone else is reviewing this theme."
 msgstr ""
 
 #. L10n: Description of what can be searched for.
-#: src/olympia/editors/forms.py:447
+#: src/olympia/editors/forms.py:546
 msgid "app, reviewer, or comment"
 msgstr ""
 
@@ -7340,246 +7186,264 @@ msgstr ""
 msgid "Rejected or Unreviewed"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:123 src/olympia/editors/helpers.py:136
+#: src/olympia/editors/helpers.py:125 src/olympia/editors/helpers.py:138
 msgid "Queue"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:124 src/olympia/editors/templates/editors/base.html:50 src/olympia/editors/templates/editors/base.html:65
+#: src/olympia/editors/helpers.py:126 src/olympia/editors/templates/editors/base.html:50 src/olympia/editors/templates/editors/base.html:65
 msgid "Pending Updates"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:125 src/olympia/editors/templates/editors/base.html:48 src/olympia/editors/templates/editors/base.html:63
+#: src/olympia/editors/helpers.py:127 src/olympia/editors/templates/editors/base.html:48 src/olympia/editors/templates/editors/base.html:63
 msgid "Full Reviews"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:126 src/olympia/editors/templates/editors/base.html:52 src/olympia/editors/templates/editors/base.html:67
+#: src/olympia/editors/helpers.py:128 src/olympia/editors/templates/editors/base.html:52 src/olympia/editors/templates/editors/base.html:67
 msgid "Preliminary Reviews"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:127 src/olympia/editors/templates/editors/base.html:54
+#: src/olympia/editors/helpers.py:129 src/olympia/editors/templates/editors/base.html:54
 msgid "Moderated Reviews"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:128 src/olympia/editors/templates/editors/base.html:46
+#: src/olympia/editors/helpers.py:130 src/olympia/editors/templates/editors/base.html:46
 msgid "Fast Track"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:130
+#: src/olympia/editors/helpers.py:132
 msgid "Pending Themes"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:131 src/olympia/editors/templates/editors/themes/queue.html:4
+#: src/olympia/editors/helpers.py:133 src/olympia/editors/templates/editors/themes/queue.html:4
 msgid "Flagged Themes"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:132
+#: src/olympia/editors/helpers.py:134
 msgid "Update Themes"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:137
+#: src/olympia/editors/helpers.py:139
 msgid "Unlisted Pending Updates"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:138
+#: src/olympia/editors/helpers.py:140
 msgid "Unlisted Full Reviews"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:139
+#: src/olympia/editors/helpers.py:141
 msgid "Unlisted Preliminary Reviews"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:170
+#: src/olympia/editors/helpers.py:142
+msgid "Unlisted All Add-ons"
+msgstr ""
+
+#: src/olympia/editors/helpers.py:173
 msgid "Fast Track ({0})"
 msgid_plural "Fast Track ({0})"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/olympia/editors/helpers.py:175
+#: src/olympia/editors/helpers.py:178
 msgid "Full Review ({0})"
 msgid_plural "Full Reviews ({0})"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/olympia/editors/helpers.py:180
+#: src/olympia/editors/helpers.py:183
 msgid "Pending Update ({0})"
 msgid_plural "Pending Updates ({0})"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/olympia/editors/helpers.py:185
+#: src/olympia/editors/helpers.py:188
 msgid "Preliminary Review ({0})"
 msgid_plural "Preliminary Reviews ({0})"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/olympia/editors/helpers.py:190
+#: src/olympia/editors/helpers.py:193
 msgid "Moderated Review ({0})"
 msgid_plural "Moderated Reviews ({0})"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/olympia/editors/helpers.py:196
+#: src/olympia/editors/helpers.py:199
 msgid "Unlisted Full Review ({0})"
 msgid_plural "Unlisted Full Reviews ({0})"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/olympia/editors/helpers.py:201
+#: src/olympia/editors/helpers.py:204
 msgid "Unlisted Pending Update ({0})"
 msgid_plural "Unlisted Pending Updates ({0})"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/olympia/editors/helpers.py:206
+#: src/olympia/editors/helpers.py:209
 msgid "Unlisted Preliminary Review ({0})"
 msgid_plural "Unlisted Preliminary Reviews ({0})"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/olympia/editors/helpers.py:261
-msgid "Addon"
-msgstr ""
+#: src/olympia/editors/helpers.py:214
+msgid "Unlisted All Add-ons ({0})"
+msgid_plural "Unlisted All Add-ons ({0})"
+msgstr[0] ""
+msgstr[1] ""
 
-#: src/olympia/editors/helpers.py:262
+#: src/olympia/editors/helpers.py:274
 msgid "Type"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:263
+#: src/olympia/editors/helpers.py:275
 msgid "Waiting Time"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:264 src/olympia/editors/templates/editors/review.html:285
+#: src/olympia/editors/helpers.py:276 src/olympia/editors/templates/editors/review.html:285
 msgid "Flags"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:265
+#: src/olympia/editors/helpers.py:277
 msgid "Applications"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:270
+#: src/olympia/editors/helpers.py:282
 msgid "Additional"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:285
+#: src/olympia/editors/helpers.py:302
 msgid "Site Specific"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:287
+#: src/olympia/editors/helpers.py:304
 msgid "Requires External Software"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:289
+#: src/olympia/editors/helpers.py:306
 msgid "Binary Components"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:313
+#: src/olympia/editors/helpers.py:339
 msgid "moments ago"
 msgstr ""
 
 #. L10n: first argument is number of minutes
-#: src/olympia/editors/helpers.py:316
+#: src/olympia/editors/helpers.py:342
 msgid "{0} minute"
 msgid_plural "{0} minutes"
 msgstr[0] ""
 msgstr[1] ""
 
 #. L10n: first argument is number of hours
-#: src/olympia/editors/helpers.py:320
+#: src/olympia/editors/helpers.py:346
 msgid "{0} hour"
 msgid_plural "{0} hours"
 msgstr[0] ""
 msgstr[1] ""
 
 #. L10n: first argument is number of days
-#: src/olympia/editors/helpers.py:324
+#: src/olympia/editors/helpers.py:350
 msgid "{0} day"
 msgid_plural "{0} days"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/olympia/editors/helpers.py:488
+#: src/olympia/editors/helpers.py:364
+msgid "Last Review"
+msgstr ""
+
+#: src/olympia/editors/helpers.py:366
+msgid "Last Update"
+msgstr ""
+
+#: src/olympia/editors/helpers.py:387
+msgid "No Reviews"
+msgstr ""
+
+#: src/olympia/editors/helpers.py:561
 msgid "Push to public"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:490
+#: src/olympia/editors/helpers.py:563
 msgid "Grant full review"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:505
+#: src/olympia/editors/helpers.py:578
 msgid "Request more information"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:508
+#: src/olympia/editors/helpers.py:581
 msgid "Request super-review"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:519
+#: src/olympia/editors/helpers.py:592
 msgid "Grant preliminary review"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:520
+#: src/olympia/editors/helpers.py:593
 msgid "This will mark the files as preliminarily reviewed."
 msgstr ""
 
-#: src/olympia/editors/helpers.py:522
+#: src/olympia/editors/helpers.py:595
 msgid "Use this form to request more information from the author. They will receive an email and be able to answer here. You will be notified by email when they reply."
 msgstr ""
 
-#: src/olympia/editors/helpers.py:526
+#: src/olympia/editors/helpers.py:599
 msgid ""
 "If you have concerns about this add-on's security, copyright issues, or other concerns that an administrator should look into, enter your comments in the area below. They will be sent to "
 "administrators, not the author."
 msgstr ""
 
-#: src/olympia/editors/helpers.py:532
+#: src/olympia/editors/helpers.py:605
 msgid "This will reject the add-on and remove it from the review queue."
 msgstr ""
 
-#: src/olympia/editors/helpers.py:534
-msgid "Make a comment on this version.  The author won't be able to see this."
+#: src/olympia/editors/helpers.py:607
+msgid "Make a comment on this version. The author won't be able to see this."
 msgstr ""
 
-#: src/olympia/editors/helpers.py:538
+#: src/olympia/editors/helpers.py:611
 msgid "This will reject the files and remove them from the review queue."
 msgstr ""
 
-#: src/olympia/editors/helpers.py:542
+#: src/olympia/editors/helpers.py:615
 msgid "This will mark the add-on as preliminarily reviewed. Future versions will undergo preliminary review."
 msgstr ""
 
-#: src/olympia/editors/helpers.py:547
+#: src/olympia/editors/helpers.py:620
 msgid "This will mark the files as preliminarily reviewed. Future versions will undergo preliminary review."
 msgstr ""
 
-#: src/olympia/editors/helpers.py:552
+#: src/olympia/editors/helpers.py:625
 msgid "Retain preliminary review"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:553
+#: src/olympia/editors/helpers.py:626
 msgid "This will retain the add-on as preliminarily reviewed. Future versions will undergo preliminary review."
 msgstr ""
 
-#: src/olympia/editors/helpers.py:558
+#: src/olympia/editors/helpers.py:631
 msgid "This will approve a sandboxed version of a public add-on to appear on the public side."
 msgstr ""
 
-#: src/olympia/editors/helpers.py:561
+#: src/olympia/editors/helpers.py:634
 msgid "This will reject a version of a public add-on and remove it from the queue."
 msgstr ""
 
-#: src/olympia/editors/helpers.py:564
+#: src/olympia/editors/helpers.py:637
 msgid "This will mark the add-on and its most recent version and files as public. Future versions will go into the sandbox until they are reviewed by an editor."
 msgstr ""
 
-#: src/olympia/editors/helpers.py:637
+#: src/olympia/editors/helpers.py:714
 msgid "add-on"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:940 src/olympia/editors/helpers.py:960
+#: src/olympia/editors/helpers.py:1020 src/olympia/editors/helpers.py:1040
 msgid "Flagged"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:944 src/olympia/editors/helpers.py:963
+#: src/olympia/editors/helpers.py:1024 src/olympia/editors/helpers.py:1043
 msgid "Updates"
 msgstr ""
 
@@ -7631,56 +7495,56 @@ msgstr ""
 msgid "A question about your Theme submission"
 msgstr ""
 
-#: src/olympia/editors/views.py:144
+#: src/olympia/editors/views.py:146
 msgid "New Add-ons (Under 5 days)"
 msgstr ""
 
-#: src/olympia/editors/views.py:145
+#: src/olympia/editors/views.py:147
 msgid "Passable (5 to 10 days)"
 msgstr ""
 
-#: src/olympia/editors/views.py:146
+#: src/olympia/editors/views.py:148
 msgid "Overdue (Over 10 days)"
 msgstr ""
 
-#: src/olympia/editors/views.py:532
+#: src/olympia/editors/views.py:539
 msgid "An unknown error occurred"
 msgstr ""
 
-#: src/olympia/editors/views.py:587
+#: src/olympia/editors/views.py:592
 msgid "Self-reviews are not allowed."
 msgstr ""
 
-#: src/olympia/editors/views.py:609
+#: src/olympia/editors/views.py:613
 msgid "Review successfully processed."
 msgstr ""
 
-#: src/olympia/editors/views.py:807
+#: src/olympia/editors/views.py:812
 msgid "was approved"
 msgstr ""
 
-#: src/olympia/editors/views.py:808
+#: src/olympia/editors/views.py:813
 msgid "given preliminary review"
 msgstr ""
 
-#: src/olympia/editors/views.py:809
+#: src/olympia/editors/views.py:814
 msgid "rejected"
 msgstr ""
 
-#: src/olympia/editors/views.py:810
+#: src/olympia/editors/views.py:815
 msgctxt "editors_review_history_nominated_adminreview"
 msgid "escalated"
 msgstr ""
 
-#: src/olympia/editors/views.py:812
+#: src/olympia/editors/views.py:817
 msgid "needs more information"
 msgstr ""
 
-#: src/olympia/editors/views.py:813
+#: src/olympia/editors/views.py:818
 msgid "needs super review"
 msgstr ""
 
-#: src/olympia/editors/views.py:814
+#: src/olympia/editors/views.py:819
 msgid "commented"
 msgstr ""
 
@@ -7725,28 +7589,28 @@ msgstr ""
 msgid "Unlisted Queues"
 msgstr ""
 
-#: src/olympia/editors/templates/editors/base.html:72 src/olympia/editors/templates/editors/performance.html:6
+#: src/olympia/editors/templates/editors/base.html:74 src/olympia/editors/templates/editors/performance.html:6
 msgid "Performance"
 msgstr ""
 
-#: src/olympia/editors/templates/editors/base.html:75 src/olympia/editors/templates/editors/themes/base.html:19 src/olympia/editors/templates/editors/themes/base.html:38
+#: src/olympia/editors/templates/editors/base.html:77 src/olympia/editors/templates/editors/themes/base.html:19 src/olympia/editors/templates/editors/themes/base.html:38
 msgid "Logs"
 msgstr ""
 
-#: src/olympia/editors/templates/editors/base.html:78 src/olympia/editors/templates/editors/reviewlog.html:4 src/olympia/editors/templates/editors/reviewlog.html:27
+#: src/olympia/editors/templates/editors/base.html:80 src/olympia/editors/templates/editors/reviewlog.html:4 src/olympia/editors/templates/editors/reviewlog.html:27
 msgid "Add-on Review Log"
 msgstr ""
 
-#: src/olympia/editors/templates/editors/base.html:80 src/olympia/editors/templates/editors/eventlog.html:4 src/olympia/editors/templates/editors/eventlog.html:8
+#: src/olympia/editors/templates/editors/base.html:82 src/olympia/editors/templates/editors/eventlog.html:4 src/olympia/editors/templates/editors/eventlog.html:8
 #: src/olympia/editors/templates/editors/eventlog_detail.html:4
 msgid "Moderated Review Log"
 msgstr ""
 
-#: src/olympia/editors/templates/editors/base.html:82 src/olympia/editors/templates/editors/beta_signed_log.html:4 src/olympia/editors/templates/editors/beta_signed_log.html:8
+#: src/olympia/editors/templates/editors/base.html:84 src/olympia/editors/templates/editors/beta_signed_log.html:4 src/olympia/editors/templates/editors/beta_signed_log.html:8
 msgid "Signed Beta Files Log"
 msgstr ""
 
-#: src/olympia/editors/templates/editors/base.html:87 src/olympia/editors/templates/editors/includes/daily-message.html:4
+#: src/olympia/editors/templates/editors/base.html:89 src/olympia/editors/templates/editors/includes/daily-message.html:4
 msgid "Announcement"
 msgstr ""
 
@@ -7967,45 +7831,45 @@ msgstr ""
 msgid "clear search"
 msgstr ""
 
-#: src/olympia/editors/templates/editors/queue.html:72 src/olympia/editors/templates/editors/queue.html:122
+#: src/olympia/editors/templates/editors/queue.html:78 src/olympia/editors/templates/editors/queue.html:128
 msgid "Process Reviews"
 msgstr ""
 
-#: src/olympia/editors/templates/editors/queue.html:80
+#: src/olympia/editors/templates/editors/queue.html:86
 msgid "Moderation actions:"
 msgstr ""
 
-#: src/olympia/editors/templates/editors/queue.html:90
+#: src/olympia/editors/templates/editors/queue.html:96
 #, python-format
 msgid "by %(user)s on %(date)s %(stars)s (%(locale)s)"
 msgstr ""
 
-#: src/olympia/editors/templates/editors/queue.html:106
+#: src/olympia/editors/templates/editors/queue.html:112
 #, python-format
 msgid "<strong>%(reason)s</strong> <span class=\"light\">Flagged by %(user)s on %(date)s</span>"
 msgstr ""
 
-#: src/olympia/editors/templates/editors/queue.html:119
-msgid "All reviews have been moderated.  Good work!"
+#: src/olympia/editors/templates/editors/queue.html:125
+msgid "All reviews have been moderated. Good work!"
 msgstr ""
 
-#: src/olympia/editors/templates/editors/queue.html:161
+#: src/olympia/editors/templates/editors/queue.html:167
 msgid "Version Notes / Notes for Reviewer"
 msgstr ""
 
-#: src/olympia/editors/templates/editors/queue.html:169
+#: src/olympia/editors/templates/editors/queue.html:175
 msgid "There are currently no add-ons of this type to review."
 msgstr ""
 
-#: src/olympia/editors/templates/editors/queue.html:181 src/olympia/editors/templates/editors/themes/queue_list.html:85
+#: src/olympia/editors/templates/editors/queue.html:187 src/olympia/editors/templates/editors/themes/queue_list.html:85
 msgid "Helpful Links:"
 msgstr ""
 
-#: src/olympia/editors/templates/editors/queue.html:182
+#: src/olympia/editors/templates/editors/queue.html:188
 msgid "Add-on Policy"
 msgstr ""
 
-#: src/olympia/editors/templates/editors/queue.html:184
+#: src/olympia/editors/templates/editors/queue.html:190
 msgid "Editors' Guide"
 msgstr ""
 
@@ -8068,10 +7932,7 @@ msgid "<strong>Warning!</strong> Another user was viewing this page before you."
 msgstr ""
 
 #: src/olympia/editors/templates/editors/review.html:237
-msgid ""
-"The whiteboard is the place to exchange information relevant to\n"
-"               this addon (whatever the version), between the developer and the\n"
-"               editor. This is visible and editable by both."
+msgid "The whiteboard is the place to exchange information relevant to this addon (whatever the version), between the developer and the editor. This is visible and editable by both."
 msgstr ""
 
 #: src/olympia/editors/templates/editors/review.html:241
@@ -8345,7 +8206,7 @@ msgstr ""
 msgid "Describe your reason for flagging"
 msgstr ""
 
-#: src/olympia/files/forms.py:88
+#: src/olympia/files/forms.py:90
 msgid "Cannot diff a version against itself"
 msgstr ""
 
@@ -8380,51 +8241,51 @@ msgstr ""
 msgid "There was an error accessing file %s."
 msgstr ""
 
-#: src/olympia/files/utils.py:343
+#: src/olympia/files/utils.py:340
 msgid "Could not parse uploaded file."
 msgstr ""
 
-#: src/olympia/files/utils.py:380
+#: src/olympia/files/utils.py:377
 msgid "Invalid file name in archive: {0}"
 msgstr ""
 
-#: src/olympia/files/utils.py:388
+#: src/olympia/files/utils.py:385
 msgid "File exceeding size limit in archive: {0}"
 msgstr ""
 
-#: src/olympia/files/utils.py:439
+#: src/olympia/files/utils.py:436
 msgid "Invalid archive."
 msgstr ""
 
-#: src/olympia/files/utils.py:529 src/olympia/files/utils.py:532
+#: src/olympia/files/utils.py:526 src/olympia/files/utils.py:529
 msgid "Could not parse the manifest file."
 msgstr ""
 
-#: src/olympia/files/utils.py:551
+#: src/olympia/files/utils.py:548
 msgid "Could not find an add-on ID."
 msgstr ""
 
-#: src/olympia/files/utils.py:554
+#: src/olympia/files/utils.py:551
 msgid "Add-on ID must be 64 characters or less."
 msgstr ""
 
-#: src/olympia/files/utils.py:556
+#: src/olympia/files/utils.py:553
 msgid "Add-on ID doesn't match add-on."
 msgstr ""
 
-#: src/olympia/files/utils.py:564
+#: src/olympia/files/utils.py:561
 msgid "Duplicate add-on ID found."
 msgstr ""
 
-#: src/olympia/files/utils.py:567
+#: src/olympia/files/utils.py:564
 msgid "Version numbers should have fewer than 32 characters."
 msgstr ""
 
-#: src/olympia/files/utils.py:570
+#: src/olympia/files/utils.py:567
 msgid "Version numbers should only contain letters, numbers, and these punctuation characters: +*.-_."
 msgstr ""
 
-#: src/olympia/files/utils.py:587
+#: src/olympia/files/utils.py:584
 msgid "<em:type> doesn't match add-on"
 msgstr ""
 
@@ -8523,6 +8384,10 @@ msgstr ""
 
 #: src/olympia/files/templates/files/viewer.html:134
 msgid "Fetching file."
+msgstr ""
+
+#: src/olympia/legacy_api/views.py:255
+msgid "Not implemented yet."
 msgstr ""
 
 #: src/olympia/lib/constants.py:6
@@ -9181,10 +9046,6 @@ msgstr ""
 msgid "Zimbabwe Dollar"
 msgstr ""
 
-#: src/olympia/lib/video/ffmpeg.py:112 src/olympia/lib/video/totem.py:81
-msgid "Videos must be in WebM."
-msgstr ""
-
 #: src/olympia/pages/templates/pages/about.lhtml:3 src/olympia/pages/templates/pages/about.lhtml:10
 msgid "About Mozilla Add-ons"
 msgstr ""
@@ -9196,7 +9057,7 @@ msgstr ""
 #: src/olympia/pages/templates/pages/about.lhtml:13
 msgid ""
 "addons.mozilla.org, commonly known as \"AMO\", is Mozilla's official site for add-ons to Mozilla software, such as Firefox, Thunderbird, and SeaMonkey. Add-ons let you add new features and change "
-"the way your browser or application works.  Take a look around and explore the thousands of ways to customize the way you do things online."
+"the way your browser or application works. Take a look around and explore the thousands of ways to customize the way you do things online."
 msgstr ""
 
 #: src/olympia/pages/templates/pages/about.lhtml:19
@@ -9541,7 +9402,7 @@ msgstr ""
 msgid ""
 "Yes. It's possible, but some of the functionality provided by these libraries are available through XPCOM, XUL, and JavaScript. In addition, authors should take care if libraries modify primitive "
 "object prototypes (String.prototype, Date.prototype, etc.) and/or define global functions (eg. the $ function). These are prone to cause conflict with other add-ons, in particular if different add-"
-"ons use different versions of libraries and so on. Developers need to be very, very careful with using them.  Mozilla does not offer documentation on using them to build add-ons."
+"ons use different versions of libraries and so on. Developers need to be very, very careful with using them. Mozilla does not offer documentation on using them to build add-ons."
 msgstr ""
 
 #: src/olympia/pages/templates/pages/dev_faq.html:165
@@ -9655,8 +9516,8 @@ msgstr ""
 #, python-format
 msgid ""
 "Yes. Many developers choose to host their own add-ons. Choosing to host your add-on on <a href=\"%(amo_url)s\">Mozilla's add-on site</a>, though, allows for much greater exposure to your add-on due "
-"to the large volume of visitors to the site.  <a href=\"%(md_url)s\">mozdev.org</a> offers free project hosting for Mozilla applications and extensions providing developers with tools to help "
-"manage source code, version control, bug tracking and documentation."
+"to the large volume of visitors to the site. <a href=\"%(md_url)s\">mozdev.org</a> offers free project hosting for Mozilla applications and extensions providing developers with tools to help manage "
+"source code, version control, bug tracking and documentation."
 msgstr ""
 
 #: src/olympia/pages/templates/pages/dev_faq.html:277
@@ -9704,7 +9565,7 @@ msgstr ""
 #: src/olympia/pages/templates/pages/dev_faq.html:314
 #, python-format
 msgid ""
-"Yes. Mozilla's <a href=\"%(p_url)s\">Add-on Policy</a> describes what is an acceptable submission. This policy is subject to change without notice.  In addition, the AMO editorial team uses the <a "
+"Yes. Mozilla's <a href=\"%(p_url)s\">Add-on Policy</a> describes what is an acceptable submission. This policy is subject to change without notice. In addition, the AMO editorial team uses the <a "
 "href=\"%(g_url)s\">Editors Reviewing Guide</a> to ensure that your add-on meets specific guidelines for functionality and security."
 msgstr ""
 
@@ -9821,7 +9682,7 @@ msgstr ""
 #: src/olympia/pages/templates/pages/dev_faq.html:434
 #, python-format
 msgid ""
-"This is why it's very important to read the <a href=\"%(g_url)s\">Editors Reviewing Guide</a> to ensure that your add-on is setup as expected.  It's also a good idea to read the blog post, <a href="
+"This is why it's very important to read the <a href=\"%(g_url)s\">Editors Reviewing Guide</a> to ensure that your add-on is setup as expected. It's also a good idea to read the blog post, <a href="
 "\"%(blog_url)s\">Successfully Getting your Add-on Reviewed</a> which provides excellent insight into ensuring a smooth review of your add-on."
 msgstr ""
 
@@ -9928,7 +9789,7 @@ msgstr ""
 
 #: src/olympia/pages/templates/pages/dev_faq.html:572
 msgid ""
-"Free Software Foundation provides short summaries of the key open source licenses, including whether the license qualifies as a free software license or a copyleft license.  Also includes a "
+"Free Software Foundation provides short summaries of the key open source licenses, including whether the license qualifies as a free software license or a copyleft license. Also includes a "
 "discussion of what constitutes a free software license or a copyleft license (e.g., a Copyleft license is a general method for making a program or other work free, and requiring all modified and "
 "extended versions of the program to be free as well.)"
 msgstr ""
@@ -10106,19 +9967,13 @@ msgid "Add-on Gallery"
 msgstr ""
 
 #: src/olympia/pages/templates/pages/faq.html:171
-msgid ""
-"How do I choose between add-ons that seem to do the same\n"
-"    thing?"
+msgid "How do I choose between add-ons that seem to do the same thing?"
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:173
+#: src/olympia/pages/templates/pages/faq.html:172
 msgid ""
-"There are often several add-ons that have similar features. To\n"
-"    figure out which is right for you, read the entire description of the\n"
-"    add-on and view its screenshots. If there are still several in the running,\n"
-"    read through the add-on's ratings, user reviews, and statistics to see\n"
-"    which is most liked by other users. Remember that you can also just try\n"
-"    out both and see which you like better."
+"There are often several add-ons that have similar features. To figure out which is right for you, read the entire description of the add-on and view its screenshots. If there are still several in "
+"the running, read through the add-on's ratings, user reviews, and statistics to see which is most liked by other users. Remember that you can also just try out both and see which you like better."
 msgstr ""
 
 #: src/olympia/pages/templates/pages/faq.html:180
@@ -10159,80 +10014,67 @@ msgid "How much do add-ons cost to purchase?"
 msgstr ""
 
 #: src/olympia/pages/templates/pages/faq.html:207
-msgid ""
-"Add-ons hosted in our gallery are free unless clearly marked\n"
-"    otherwise."
+msgid "Add-ons hosted in our gallery are free unless clearly marked otherwise."
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:210
+#: src/olympia/pages/templates/pages/faq.html:209
 msgid "What does it mean when an add-on asks for contributions?"
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:211
+#: src/olympia/pages/templates/pages/faq.html:210
 msgid ""
-"Some add-on authors request users who enjoy an add-on to\n"
-"        contribute to its development by making a monetary contribution. These\n"
-"        contributions go directly to the developer unless a third party is\n"
-"        indicated, such as the non-profit Mozilla Foundation."
+"Some add-on authors request users who enjoy an add-on to contribute to its development by making a monetary contribution. These contributions go directly to the developer unless a third party is "
+"indicated, such as the non-profit Mozilla Foundation."
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:216
+#: src/olympia/pages/templates/pages/faq.html:215
 msgid "What are beta add-ons?"
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:218
+#: src/olympia/pages/templates/pages/faq.html:217
 msgid ""
-"Beta add-ons are unreviewed versions which represent the\n"
-"        latest work of an add-on author. While different authors have different\n"
-"        standards for beta code quality, you should assume that these add-ons\n"
-"        are less stable than the general add-on releases."
+"Beta add-ons are unreviewed versions which represent the latest work of an add-on author. While different authors have different standards for beta code quality, you should assume that these add-"
+"ons are less stable than the general add-on releases."
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:222
+#: src/olympia/pages/templates/pages/faq.html:221
 msgid ""
 "Please note that when you install an add-on from the \"Beta Version\" section of an add-on's listing, you will continue to receive updates for that add-on as they become available. Like the initial "
 "version you installed, all beta releases are unreviewed by Mozilla and may harm your computer."
 msgstr ""
 
+#: src/olympia/pages/templates/pages/faq.html:228
+msgid "What does it mean when an add-on is flagged as slow?"
+msgstr ""
+
 #: src/olympia/pages/templates/pages/faq.html:229
-msgid ""
-"What does it mean when an add-on is flagged as\n"
-"    slow?"
+msgid "Most add-ons load code and resources at the same time Firefox is starting up. In most cases the impact in start-up time is minimal, but some add-ons can cause a noticeable slowdown."
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:231
-msgid ""
-"Most add-ons load code and resources at the same time Firefox\n"
-"        is starting up. In most cases the impact in start-up time is minimal,\n"
-"        but some add-ons can cause a noticeable slowdown."
-msgstr ""
-
-#: src/olympia/pages/templates/pages/faq.html:236
+#: src/olympia/pages/templates/pages/faq.html:234
 msgid "How do I report an inappropriate or spam user review?"
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:237
+#: src/olympia/pages/templates/pages/faq.html:235
 msgid ""
-"To report a user review of an add-on, log in with your account\n"
-"    and visit the add-on's reviews page. Find the review you wish to report,\n"
-"    click \"Report this review\" and select a reason. Our editorial team will\n"
-"    investigate the review and take appropriate action."
+"To report a user review of an add-on, log in with your account and visit the add-on's reviews page. Find the review you wish to report, click \"Report this review\" and select a reason. Our "
+"editorial team will investigate the review and take appropriate action."
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:242
+#: src/olympia/pages/templates/pages/faq.html:240
 msgid "How do I report a bug or contact the Mozilla Add-ons team?"
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:243
+#: src/olympia/pages/templates/pages/faq.html:241
 #, python-format
 msgid "Please visit our <a href=\"%(contact_url)s\">Contact page</a>."
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:246
+#: src/olympia/pages/templates/pages/faq.html:244
 msgid "What is a Source Code License?"
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:247
+#: src/olympia/pages/templates/pages/faq.html:245
 #, python-format
 msgid ""
 "The source code used to create an add-on is an exclusive copyright of the add-on author, unless otherwise declared in a source code license. Many add-ons on this site have <a href=\"%(url)s\" lang="
@@ -10240,60 +10082,60 @@ msgid ""
 "the GPL or BSD licenses instead of making up their own."
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:256
+#: src/olympia/pages/templates/pages/faq.html:254
 #, python-format
 msgid "Firefox and other Mozilla software are <a href=\"%(url)s\">open source</a>."
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:264
+#: src/olympia/pages/templates/pages/faq.html:262
 msgid "Collections and Favorites"
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:267
+#: src/olympia/pages/templates/pages/faq.html:265
 msgid "What is a collection?"
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:268
+#: src/olympia/pages/templates/pages/faq.html:266
 msgid "Collections are groups of related add-ons created by users to share."
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:270
+#: src/olympia/pages/templates/pages/faq.html:268
 msgid "What is the My Favorites collection?"
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:271
+#: src/olympia/pages/templates/pages/faq.html:269
 msgid "Favorite add-ons are add-ons that you have bookmarked to easily get back to later. You can add an add-on to your favorites collection by clicking \"Add to favorites\" on its details page."
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:275 src/olympia/templates/menu_links.html:13 src/olympia/templates/impala/header_title.html:17
+#: src/olympia/pages/templates/pages/faq.html:273 src/olympia/templates/menu_links.html:13 src/olympia/templates/impala/header_title.html:17
 msgid "Mobile Add-ons"
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:278
+#: src/olympia/pages/templates/pages/faq.html:276
 msgid "What are mobile add-ons?"
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:279
+#: src/olympia/pages/templates/pages/faq.html:277
 #, python-format
 msgid ""
 "Mobile add-ons work with <a href=\"%(mobile_url)s\">Firefox for Mobile</a> and add or modify functionality just like desktop add-ons. You can find add-ons that work with Firefox for Mobile in our "
 "<a href=\"%(gallery_url)s\">gallery</a>."
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:288
+#: src/olympia/pages/templates/pages/faq.html:286
 msgid "Developer Topics"
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:289
+#: src/olympia/pages/templates/pages/faq.html:287
 #, python-format
 msgid "Please see our <a href=\"%(faq_url)s\">Developer FAQ</a> and <a href=\"%(hub_url)s\">Developer Hub</a> for answers to add-on developer-related questions."
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:294
+#: src/olympia/pages/templates/pages/faq.html:292
 msgid "Still have questions?"
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:295
+#: src/olympia/pages/templates/pages/faq.html:293
 #, python-format
 msgid "For general Firefox support, visit our <a href=\"%(sumo_url)s\">support website</a>. For general add-on and website questions, visit our <a href=\"%(forum_url)s\">forum</a>."
 msgstr ""
@@ -10431,7 +10273,7 @@ msgstr ""
 
 #: src/olympia/pages/templates/pages/sunbird.html:29
 msgid ""
-"Development on the Sunbird project has halted and its final release was on March 30, 2010.  We've been proud to host Sunbird add-ons on this site but as the project is no longer maintained we have "
+"Development on the Sunbird project has halted and its final release was on March 30, 2010. We've been proud to host Sunbird add-ons on this site but as the project is no longer maintained we have "
 "disabled our support for the add-ons."
 msgstr ""
 
@@ -10509,7 +10351,7 @@ msgstr ""
 #, python-format
 msgid ""
 "<h2>Keep these tips in mind:</h2> <ul> <li> Write like you're telling a friend about your experience with the add-on. Give specifics and helpful details, such as what features you liked and/or "
-"disliked, how easy to use it is, and any disadvantages it has.  Avoid generic language such as calling it \"Great\" or \"Bad\" unless you can give reasons why you believe this is so. </li> <li> "
+"disliked, how easy to use it is, and any disadvantages it has. Avoid generic language such as calling it \"Great\" or \"Bad\" unless you can give reasons why you believe this is so. </li> <li> "
 "Please do not post bug reports in reviews. We do not make your email address available to add-on developers and they may need to contact you to help resolve your issue. See the <a href=\"%(support)s"
 "\">support section</a> to find out where to get assistance for this add-on. </li> <li>Please keep reviews clean, avoid the use of improper language and do not post any personal information. </li> </"
 "ul> <p>Please read the <a href=\"%(guide)s\" target=\"_blank\">Review Guidelines</a> for more detail about user add-on reviews.</p>"
@@ -10745,16 +10587,16 @@ msgstr ""
 
 #. L10n: {0} is an application, such as Firefox. This means "any version of
 #. Firefox."
-#: src/olympia/search/views.py:554
+#: src/olympia/search/views.py:547
 msgid "Any {0}"
 msgstr ""
 
 #. L10n: "All Systems" means show everything regardless of platform.
-#: src/olympia/search/views.py:589
+#: src/olympia/search/views.py:582
 msgid "All Systems"
 msgstr ""
 
-#: src/olympia/search/views.py:600
+#: src/olympia/search/views.py:593
 msgid "All Tags"
 msgstr ""
 
@@ -10928,31 +10770,31 @@ msgstr ""
 msgid "Share this Collection"
 msgstr ""
 
-#: src/olympia/signing/views.py:30 src/olympia/templates/base.html:75 src/olympia/templates/impala/base.html:115
+#: src/olympia/signing/views.py:33 src/olympia/templates/base.html:71 src/olympia/templates/impala/base.html:112
 msgid "Some features are temporarily disabled while we perform website maintenance. We'll be back to full capacity shortly."
 msgstr ""
 
-#: src/olympia/signing/views.py:53
+#: src/olympia/signing/views.py:56
 msgid "Could not find add-on with id \"{}\"."
 msgstr ""
 
-#: src/olympia/signing/views.py:67
+#: src/olympia/signing/views.py:70
 msgid "You do not own this addon."
 msgstr ""
 
-#: src/olympia/signing/views.py:82
+#: src/olympia/signing/views.py:87
 msgid "Missing \"upload\" key in multipart file data."
 msgstr ""
 
-#: src/olympia/signing/views.py:96
+#: src/olympia/signing/views.py:101
 msgid "Version does not match the manifest file."
 msgstr ""
 
-#: src/olympia/signing/views.py:100
+#: src/olympia/signing/views.py:105
 msgid "Version already exists."
 msgstr ""
 
-#: src/olympia/signing/views.py:136
+#: src/olympia/signing/views.py:141
 msgid "No uploaded file for that addon and version."
 msgstr ""
 
@@ -11065,89 +10907,89 @@ msgstr ""
 msgid "Statistics Dashboard :: Add-ons for {0}"
 msgstr ""
 
-#: src/olympia/stats/templates/stats/stats.html:30
-msgid "Controls:"
-msgstr ""
-
-#: src/olympia/stats/templates/stats/stats.html:33
-msgid "reset zoom"
-msgstr ""
-
-#: src/olympia/stats/templates/stats/stats.html:40
-msgid "Group by:"
-msgstr ""
-
-#: src/olympia/stats/templates/stats/stats.html:42
-msgid "day"
-msgstr ""
-
-#: src/olympia/stats/templates/stats/stats.html:45
-msgid "week"
-msgstr ""
-
-#: src/olympia/stats/templates/stats/stats.html:48
-msgid "month"
-msgstr ""
-
-#: src/olympia/stats/templates/stats/stats.html:54
-msgid "For last:"
-msgstr ""
-
-#: src/olympia/stats/templates/stats/stats.html:57
-msgid "7 days"
-msgstr ""
-
-#: src/olympia/stats/templates/stats/stats.html:60
-msgid "30 days"
-msgstr ""
-
-#: src/olympia/stats/templates/stats/stats.html:63
-msgid "90 days"
-msgstr ""
-
-#: src/olympia/stats/templates/stats/stats.html:66
-msgid "365 days"
-msgstr ""
-
-#: src/olympia/stats/templates/stats/stats.html:69
-msgid "Custom..."
-msgstr ""
-
 #. {0} is an add-on name
-#: src/olympia/stats/templates/stats/stats.html:88 src/olympia/stats/templates/stats/stats.html:91
+#: src/olympia/stats/templates/stats/stats.html:44 src/olympia/stats/templates/stats/stats.html:47
 msgid "Statistics for {0}"
 msgstr ""
 
-#: src/olympia/stats/templates/stats/stats.html:94
+#: src/olympia/stats/templates/stats/stats.html:50
 msgid "Statistics Dashboard"
 msgstr ""
 
-#: src/olympia/stats/templates/stats/stats.html:104
+#: src/olympia/stats/templates/stats/stats.html:57
+msgid "Controls:"
+msgstr ""
+
+#: src/olympia/stats/templates/stats/stats.html:60
+msgid "reset zoom"
+msgstr ""
+
+#: src/olympia/stats/templates/stats/stats.html:67
+msgid "Group by:"
+msgstr ""
+
+#: src/olympia/stats/templates/stats/stats.html:69
+msgid "day"
+msgstr ""
+
+#: src/olympia/stats/templates/stats/stats.html:72
+msgid "week"
+msgstr ""
+
+#: src/olympia/stats/templates/stats/stats.html:75
+msgid "month"
+msgstr ""
+
+#: src/olympia/stats/templates/stats/stats.html:81
+msgid "For last:"
+msgstr ""
+
+#: src/olympia/stats/templates/stats/stats.html:84
+msgid "7 days"
+msgstr ""
+
+#: src/olympia/stats/templates/stats/stats.html:87
+msgid "30 days"
+msgstr ""
+
+#: src/olympia/stats/templates/stats/stats.html:90
+msgid "90 days"
+msgstr ""
+
+#: src/olympia/stats/templates/stats/stats.html:93
+msgid "365 days"
+msgstr ""
+
+#: src/olympia/stats/templates/stats/stats.html:96
+msgid "Custom..."
+msgstr ""
+
+#: src/olympia/stats/templates/stats/stats.html:106
 msgid "Statistics processing is currently disabled, so recent data is unavailable. The statistics are still being collected and this page will be updated soon with the missing data."
 msgstr ""
 
-#: src/olympia/stats/templates/stats/stats.html:110
+#: src/olympia/stats/templates/stats/stats.html:112
 msgid "Loading the latest data&hellip;"
 msgstr ""
 
-#: src/olympia/stats/templates/stats/stats.html:142 src/olympia/stats/templates/stats/reports/overview.html:25 src/olympia/stats/templates/stats/reports/overview.html:37
+#: src/olympia/stats/templates/stats/stats.html:144 src/olympia/stats/templates/stats/reports/overview.html:25 src/olympia/stats/templates/stats/reports/overview.html:37
 #: src/olympia/stats/templates/stats/reports/overview.html:49
 msgid "No data available."
 msgstr ""
 
-#: src/olympia/stats/templates/stats/stats.html:177
+#: src/olympia/stats/templates/stats/stats.html:179
 msgid "This dashboard is currently <b>public</b>."
 msgstr ""
 
-#: src/olympia/stats/templates/stats/stats.html:179
+#: src/olympia/stats/templates/stats/stats.html:181
 msgid "Contribution stats are currently <b>private</b>."
 msgstr ""
 
-#: src/olympia/stats/templates/stats/stats.html:182
+#: src/olympia/stats/templates/stats/stats.html:184
 msgid "This dashboard is currently <b>private</b>."
 msgstr ""
 
-#: src/olympia/stats/templates/stats/stats.html:185
+#: src/olympia/stats/templates/stats/stats.html:187
 msgid "Change settings."
 msgstr ""
 
@@ -11299,15 +11141,6 @@ msgstr ""
 msgid "Application versions by Date"
 msgstr ""
 
-#: src/olympia/tags/templates/tags/top_cloud.html:4
-msgid "Top {0} Tags"
-msgstr ""
-
-#. {0} is the current application name
-#: src/olympia/tags/templates/tags/top_cloud.html:14
-msgid "{0} Top Tags"
-msgstr ""
-
 #: src/olympia/templates/amo_footer.html:6 src/olympia/templates/includes/lang_switcher.html:2
 msgid "Other languages"
 msgstr ""
@@ -11316,11 +11149,11 @@ msgstr ""
 msgid "Mozilla Add-ons"
 msgstr ""
 
-#: src/olympia/templates/base.html:91 src/olympia/templates/impala/base.html:81
+#: src/olympia/templates/base.html:89 src/olympia/templates/impala/base.html:78
 msgid "Find add-ons for other applications"
 msgstr ""
 
-#: src/olympia/templates/base.html:92 src/olympia/templates/impala/base.html:81
+#: src/olympia/templates/base.html:90 src/olympia/templates/impala/base.html:78
 msgid "Other Applications"
 msgstr ""
 
@@ -11345,7 +11178,7 @@ msgid "View Mobile Site"
 msgstr ""
 
 #: src/olympia/templates/copyright.html:7
-msgid "Site Status "
+msgid "Site Status"
 msgstr ""
 
 #: src/olympia/templates/footer.html:3
@@ -11445,35 +11278,35 @@ msgstr ""
 msgid "<a href=\"%(reg)s\">Register</a> or <a href=\"%(login)s\">Log in</a>"
 msgstr ""
 
-#: src/olympia/templates/impala/base.html:126
+#: src/olympia/templates/impala/base.html:123
 #, python-format
 msgid "To try the thousands of add-ons available here, download <a href=\"%(url)s\">Mozilla Firefox</a>, a fast, free way to surf the Web!"
 msgstr ""
 
-#: src/olympia/templates/impala/base.html:138
+#: src/olympia/templates/impala/base.html:135
 #, python-format
 msgid "Add-ons is switching to Firefox Accounts for login. <a href=\"%(url)s\" class=\"fxa-login\">Sign in now to transfer your account.</a>"
 msgstr ""
 
 #. {0} is an application, such as Firefox.
-#: src/olympia/templates/impala/base.html:148
+#: src/olympia/templates/impala/base.html:145
 msgid "Welcome to {0} Add-ons."
 msgstr ""
 
-#: src/olympia/templates/impala/base.html:151
+#: src/olympia/templates/impala/base.html:148
 msgid "Choose from thousands of extra features and styles to make Firefox your own."
 msgstr ""
 
-#: src/olympia/templates/impala/base.html:156
+#: src/olympia/templates/impala/base.html:153
 #, python-format
 msgid "Add extra features and styles to make %(app)s your own."
 msgstr ""
 
-#: src/olympia/templates/impala/base.html:164
+#: src/olympia/templates/impala/base.html:161
 msgid "On the go?"
 msgstr ""
 
-#: src/olympia/templates/impala/base.html:166
+#: src/olympia/templates/impala/base.html:163
 msgid "Check out our <a class=\"mobile-link\" href=\"#\">Mobile Add-ons site</a>."
 msgstr ""
 
@@ -11697,19 +11530,19 @@ msgstr ""
 
 #. L10n: {id} will be something like "13ad6a", just a random number
 #. to differentiate this user from other anonymous users.
-#: src/olympia/users/models.py:353
+#: src/olympia/users/models.py:362
 msgid "Anonymous user {id}"
 msgstr ""
 
-#: src/olympia/users/models.py:410
+#: src/olympia/users/models.py:419
 msgid "Your account has been restricted"
 msgstr ""
 
-#: src/olympia/users/models.py:480
+#: src/olympia/users/models.py:489
 msgid "Please confirm your email address"
 msgstr ""
 
-#: src/olympia/users/models.py:506
+#: src/olympia/users/models.py:515
 msgid "My Mobile Add-ons"
 msgstr ""
 
@@ -11986,7 +11819,7 @@ msgstr ""
 
 #: src/olympia/users/templates/users/edit.html:70
 #, python-format
-msgid "Change your password.  If you forgot your password, you can <a href=\"%(reset_url)s\">use the reset form</a>."
+msgid "Change your password. If you forgot your password, you can <a href=\"%(reset_url)s\">use the reset form</a>."
 msgstr ""
 
 #: src/olympia/users/templates/users/edit.html:76
@@ -12006,7 +11839,7 @@ msgid "Profile"
 msgstr ""
 
 #: src/olympia/users/templates/users/edit.html:100
-msgid "Give us a bit more information about yourself.  All these fields are optional, but they'll help other users get to know you better."
+msgid "Give us a bit more information about yourself. All these fields are optional, but they'll help other users get to know you better."
 msgstr ""
 
 #: src/olympia/users/templates/users/edit.html:124
@@ -12222,7 +12055,7 @@ msgid "Confirm password"
 msgstr ""
 
 #: src/olympia/users/templates/users/pwreset_confirm.html:47
-msgid "The password reset link was invalid, possibly because it has already been used.  Please request a new password reset."
+msgid "The password reset link was invalid, possibly because it has already been used. Please request a new password reset."
 msgstr ""
 
 #: src/olympia/users/templates/users/pwreset_request.html:15
@@ -12408,7 +12241,7 @@ msgstr ""
 
 #: src/olympia/users/templates/users/unsubscribe.html:30
 #, python-format
-msgid "Unfortunately, we weren't able to unsubscribe you.  The link you clicked is invalid. However, you can unsubscribe still unsubscribe on your <a href=\"%(edit_url)s\">edit profile page</a>."
+msgid "Unfortunately, we weren't able to unsubscribe you. The link you clicked is invalid. However, you can unsubscribe still unsubscribe on your <a href=\"%(edit_url)s\">edit profile page</a>."
 msgstr ""
 
 #: src/olympia/users/templates/users/vcard.html:2
@@ -12462,15 +12295,15 @@ msgstr ""
 msgid "Version History with Changelogs"
 msgstr ""
 
-#: src/olympia/versions/models.py:314
+#: src/olympia/versions/models.py:313
 msgid "Add-on uses binary components."
 msgstr ""
 
-#: src/olympia/versions/models.py:317
+#: src/olympia/versions/models.py:316
 msgid "Add-on has opted into strict compatibility checking."
 msgstr ""
 
-#: src/olympia/versions/models.py:715
+#: src/olympia/versions/models.py:711
 msgid "{app} {min} and later"
 msgstr ""
 
@@ -12545,4 +12378,8 @@ msgstr ""
 
 #: src/olympia/zadmin/forms.py:105
 msgid "Log emails instead of sending"
+msgstr ""
+
+#: src/olympia/zadmin/forms.py:215
+msgid "Deleted versions can`t be changed."
 msgstr ""

--- a/locale/ml/LC_MESSAGES/djangojs.po
+++ b/locale/ml/LC_MESSAGES/djangojs.po
@@ -1,1216 +1,1236 @@
-
 #, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2016-02-24 21:23+0000\n"
+"POT-Creation-Date: 2016-04-18 15:47+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
+"Language: \n"
 "MIME-Version: 1.0\n"
-"Content-Type: text/plain; charset=utf-8\n"
+"Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Generated-By: Babel 2.2.0\n"
 
-#: static/js/common/ratingwidget.js:31
+#: static/js/common-all.js:1426 static/js/impala-all.js:1511 static/js/zamboni/discovery-all.js:12598 static/js/zamboni/init.js:28 static/js/zamboni/mobile-all.js:14945
+msgid "This feature is temporarily disabled while we perform website maintenance. Please check back a little later."
+msgstr ""
+
+#. L10n: {0} is an app name like Firefox.
+#: static/js/common-all.js:1837 static/js/impala-all.js:1922 static/js/zamboni/buttons.js:73 static/js/zamboni/discovery-all.js:13108
+msgid "Accept and Install"
+msgstr ""
+
+#: static/js/common-all.js:1837 static/js/impala-all.js:1922 static/js/zamboni/buttons.js:73 static/js/zamboni/discovery-all.js:13108
+msgid "Add to {0}"
+msgstr ""
+
+#: static/js/common-all.js:1842 static/js/impala-all.js:1927 static/js/zamboni/buttons.js:78 static/js/zamboni/discovery-all.js:13113
+msgid "Download Now"
+msgstr ""
+
+#: static/js/common-all.js:1883 static/js/impala-all.js:1968 static/js/zamboni/buttons.js:119 static/js/zamboni/discovery-all.js:13154
+msgid "Add-on has not been updated to support default-to-compatible."
+msgstr ""
+
+#: static/js/common-all.js:1888 static/js/impala-all.js:1973 static/js/zamboni/buttons.js:124 static/js/zamboni/discovery-all.js:13159
+msgid "You need to be using Firefox 10.0 or higher."
+msgstr ""
+
+#: static/js/common-all.js:1900 static/js/impala-all.js:1985 static/js/zamboni/buttons.js:136 static/js/zamboni/discovery-all.js:13171
+msgid "Mozilla has marked this version as incompatible with your Firefox version."
+msgstr ""
+
+#. L10n: {0} is an platform like Windows or Linux.
+#: static/js/common-all.js:1981 static/js/impala-all.js:2066 static/js/zamboni/buttons.js:217 static/js/zamboni/discovery-all.js:13252
+msgid "Install for {0} anyway"
+msgstr ""
+
+#: static/js/common-all.js:1981 static/js/impala-all.js:2066 static/js/zamboni/buttons.js:217 static/js/zamboni/discovery-all.js:13252
+msgid "Download for {0} anyway"
+msgstr ""
+
+#: static/js/common-all.js:2038 static/js/impala-all.js:2123 static/js/zamboni/buttons.js:274 static/js/zamboni/discovery-all.js:13309
+msgid "Not available for your platform"
+msgstr ""
+
+#. L10n: {0} is an app name, {1} is the app version.
+#: static/js/common-all.js:2049 static/js/common-all.js:2086 static/js/impala-all.js:2134 static/js/impala-all.js:2171 static/js/zamboni/buttons.js:286 static/js/zamboni/buttons.js:324
+#: static/js/zamboni/discovery-all.js:13320 static/js/zamboni/discovery-all.js:13357
+msgid "Not available for {0} {1}"
+msgstr ""
+
+#: static/js/common-all.js:2112 static/js/impala-all.js:2197 static/js/zamboni/buttons.js:351 static/js/zamboni/discovery-all.js:13383
+msgid "Works with {app} {min} - {max}"
+msgstr ""
+
+#: static/js/common-all.js:2114 static/js/impala-all.js:2199 static/js/zamboni/buttons.js:353 static/js/zamboni/discovery-all.js:13385
+msgid "View other versions"
+msgstr ""
+
+#: static/js/common-all.js:2162 static/js/impala-all.js:2247 static/js/zamboni/buttons.js:401 static/js/zamboni/discovery-all.js:13433
+msgid "Only with Firefox — Get Firefox Now!"
+msgstr ""
+
+#: static/js/common-all.js:2278 static/js/impala-all.js:2363 static/js/zamboni/buttons.js:517 static/js/zamboni/discovery-all.js:13549 static/js/zamboni/mobile-all.js:15177
+#: static/js/zamboni/mobile/buttons.js:43
+msgid "Sorry, you need a Mozilla-based browser (such as Firefox) to install a search plugin."
+msgstr ""
+
+#: static/js/common-all.js:9088 static/js/impala-all.js:9649 static/js/zamboni/global.js:410
+msgid "Loading..."
+msgstr ""
+
+#. L10n: {0} is the number of characters left.
+#: static/js/common-all.js:9152 static/js/impala-all.js:9713 static/js/zamboni/global.js:474
+msgid "<b>{0}</b> character left."
+msgid_plural "<b>{0}</b> characters left."
+msgstr[0] ""
+msgstr[1] ""
+
+#: static/js/common-all.js:9589 static/js/common-min.js:6 static/js/impala-all.js:10052 static/js/impala-min.js:6 static/js/common/ratingwidget.js:31 static/js/zamboni/mobile-all.js:16123
+#: static/js/zamboni/mobile-min.js:6
 msgid "{0} star"
 msgid_plural "{0} stars"
 msgstr[0] ""
 msgstr[1] ""
 
-#: static/js/common/upload-addon.js:41 static/js/common/upload-image.js:128
+#: static/js/common-all.js:9676 static/js/common-min.js:6 static/js/impala-all.js:10139 static/js/impala-min.js:6 static/js/zamboni/l10n.js:45
+msgid "Remove this localization"
+msgstr ""
+
+#: static/js/common-all.js:10193 static/js/common-min.js:6 static/js/impala-all.js:10674 static/js/impala-min.js:6 static/js/zamboni/discovery-all.js:13678
+msgid "close"
+msgstr ""
+
+#: static/js/common-all.js:10860 static/js/common-min.js:6 static/js/impala-all.js:11481 static/js/impala-min.js:6 static/js/impala/reviews.js:23 static/js/zamboni/reviews.js:18
+msgid "Flagged for review"
+msgstr ""
+
+#: static/js/common-all.js:10876 static/js/common-min.js:6 static/js/impala-all.js:11498 static/js/impala-min.js:6 static/js/impala/reviews.js:40 static/js/zamboni/reviews.js:34
+msgid "Your input is required"
+msgstr ""
+
+#: static/js/common-all.js:10945 static/js/common-min.js:6 static/js/impala-all.js:11610 static/js/impala-min.js:7 static/js/impala/reviews.js:152 static/js/zamboni/reviews.js:103
+msgid "Marked for deletion"
+msgstr ""
+
+#: static/js/common-all.js:11573 static/js/common-min.js:7 static/js/impala-all.js:13809 static/js/impala-min.js:8 static/js/zamboni/collections.js:229
+msgid "Adding to Favorites&hellip;"
+msgstr ""
+
+#: static/js/common-all.js:11576 static/js/common-min.js:7 static/js/impala-all.js:13812 static/js/impala-min.js:8 static/js/zamboni/collections.js:232
+msgid "Removing Favorite&hellip;"
+msgstr ""
+
+#: static/js/common-all.js:11579 static/js/common-min.js:7 static/js/impala-all.js:13815 static/js/impala-min.js:8 static/js/zamboni/collections.js:235
+msgid "Add to Favorites"
+msgstr ""
+
+#: static/js/common-all.js:11582 static/js/common-min.js:7 static/js/impala-all.js:13818 static/js/impala-min.js:8 static/js/zamboni/collections.js:238
+msgid "Remove from Favorites"
+msgstr ""
+
+#: static/js/common-all.js:11647 static/js/common-min.js:7 static/js/impala-all.js:13883 static/js/impala-min.js:8 static/js/zamboni/collections.js:303
+msgid "Pending"
+msgstr ""
+
+#: static/js/common-all.js:11648 static/js/common-min.js:7 static/js/impala-all.js:13884 static/js/impala-min.js:8 static/js/zamboni/collections.js:304
+msgid "Add a comment"
+msgstr ""
+
+#: static/js/common-all.js:11648 static/js/common-min.js:7 static/js/impala-all.js:13884 static/js/impala-min.js:8 static/js/zamboni/collections.js:304
+msgid "Comment"
+msgstr ""
+
+#: static/js/common-all.js:11649 static/js/common-min.js:7 static/js/impala-all.js:13885 static/js/impala-min.js:8 static/js/zamboni/collections.js:305
+msgid "Remove this add-on from the collection"
+msgstr ""
+
+#: static/js/common-all.js:11649 static/js/common-all.js:11678 static/js/common-min.js:7 static/js/impala-all.js:13885 static/js/impala-all.js:13914 static/js/impala-min.js:8
+#: static/js/zamboni/collections.js:305 static/js/zamboni/collections.js:334
+msgid "Remove"
+msgstr ""
+
+#: static/js/common-all.js:11678 static/js/common-min.js:7 static/js/impala-all.js:13914 static/js/impala-min.js:8 static/js/zamboni/collections.js:334
+msgid "Remove this user as a contributor"
+msgstr ""
+
+#: static/js/common-all.js:11690 static/js/common-min.js:7 static/js/impala-all.js:13926 static/js/impala-min.js:8 static/js/zamboni/collections.js:346
+msgid "An email address is required."
+msgstr ""
+
+#: static/js/common-all.js:11708 static/js/common-min.js:7 static/js/impala-all.js:13944 static/js/impala-min.js:8 static/js/zamboni/collections.js:364
+msgid "You cannot add yourself as a contributor."
+msgstr ""
+
+#: static/js/common-all.js:11710 static/js/common-min.js:7 static/js/impala-all.js:13946 static/js/impala-min.js:8 static/js/zamboni/collections.js:366
+msgid "You have already added that user."
+msgstr ""
+
+#: static/js/common-all.js:11917 static/js/common-min.js:7 static/js/impala-all.js:14153 static/js/impala-min.js:8 static/js/zamboni/collections.js:573
+msgid "Add to favorites"
+msgstr ""
+
+#: static/js/common-all.js:11921 static/js/common-min.js:7 static/js/impala-all.js:14157 static/js/impala-min.js:8 static/js/zamboni/collections.js:577
+msgid "Remove from favorites"
+msgstr ""
+
+#: static/js/common-all.js:11939 static/js/common-min.js:7 static/js/impala-all.js:14175 static/js/impala-all.js:14233 static/js/impala-min.js:8 static/js/impala/collections.js:10
+#: static/js/zamboni/collections.js:595
+msgid "Follow this Collection"
+msgstr ""
+
+#: static/js/common-all.js:11948 static/js/common-min.js:7 static/js/impala-all.js:14184 static/js/impala-min.js:8 static/js/zamboni/collections.js:604
+msgid "Stop following"
+msgstr ""
+
+#: static/js/common-all.js:12096 static/js/common-min.js:7 static/js/zamboni/password-strength.js:20
+msgid "Password strength:"
+msgstr ""
+
+#: static/js/common-all.js:12102 static/js/common-min.js:7 static/js/zamboni/password-strength.js:26
+msgid "At least {0} character left."
+msgid_plural "At least {0} characters left."
+msgstr[0] ""
+msgstr[1] ""
+
+#: static/js/common-all.js:12286 static/js/common-min.js:7 static/js/impala-all.js:14632 static/js/impala-min.js:8 static/js/impala/suggestions.js:39
+msgid "Search themes for <b>{0}</b>"
+msgstr ""
+
+#: static/js/common-all.js:12288 static/js/common-min.js:7 static/js/impala-all.js:14634 static/js/impala-min.js:8 static/js/impala/suggestions.js:41
+msgid "Search apps for <b>{0}</b>"
+msgstr ""
+
+#: static/js/common-all.js:12290 static/js/common-min.js:7 static/js/impala-all.js:14636 static/js/impala-min.js:8 static/js/impala/suggestions.js:43
+msgid "Search add-ons for <b>{0}</b>"
+msgstr ""
+
+#: static/js/common-all.js:12521 static/js/common-min.js:7 static/js/impala-all.js:14867 static/js/impala-min.js:8 static/js/impala/site_suggestions.js:46
+msgid "Category"
+msgstr ""
+
+#. L10n: {0} is an app name.
+#: static/js/impala-all.js:11632 static/js/impala-min.js:7 static/js/impala/listing.js:11 static/js/zamboni/themes.js:13
+msgid "This theme is incompatible with your version of {0}"
+msgstr ""
+
+#: static/js/impala-all.js:12146 static/js/impala-all.js:14331 static/js/impala-min.js:7 static/js/impala-min.js:8 static/js/common/upload-image.js:97 static/js/impala/users.js:51
+#: static/js/zamboni/devhub-all.js:894 static/js/zamboni/devhub-min.js:1
+msgid "Images must be either PNG or JPG."
+msgstr ""
+
+#: static/js/impala-all.js:12150 static/js/impala-min.js:7 static/js/common/upload-image.js:101 static/js/zamboni/devhub-all.js:898 static/js/zamboni/devhub-min.js:1
+msgid "Videos must be in WebM."
+msgstr ""
+
+#: static/js/impala-all.js:12177 static/js/impala-min.js:7 static/js/common/upload-addon.js:41 static/js/common/upload-image.js:128 static/js/zamboni/devhub-all.js:272
+#: static/js/zamboni/devhub-all.js:925 static/js/zamboni/devhub-min.js:1
 msgid "There was a problem contacting the server."
 msgstr ""
 
-#: static/js/common/upload-addon.js:69
+#: static/js/impala-all.js:13298 static/js/impala-min.js:7 static/js/impala/persona_creation.js:60
+msgid "All Rights Reserved"
+msgstr ""
+
+#: static/js/impala-all.js:13302 static/js/impala-min.js:7 static/js/impala/persona_creation.js:64
+msgid "Creative Commons Attribution 3.0"
+msgstr ""
+
+#: static/js/impala-all.js:13307 static/js/impala-min.js:7 static/js/impala/persona_creation.js:69
+msgid "Creative Commons Attribution-NonCommercial 3.0"
+msgstr ""
+
+#: static/js/impala-all.js:13312 static/js/impala-min.js:7 static/js/impala/persona_creation.js:74
+msgid "Creative Commons Attribution-NonCommercial-NoDerivs 3.0"
+msgstr ""
+
+#: static/js/impala-all.js:13317 static/js/impala-min.js:7 static/js/impala/persona_creation.js:79
+msgid "Creative Commons Attribution-NonCommercial-Share Alike 3.0"
+msgstr ""
+
+#: static/js/impala-all.js:13322 static/js/impala-min.js:7 static/js/impala/persona_creation.js:84
+msgid "Creative Commons Attribution-NoDerivs 3.0"
+msgstr ""
+
+#: static/js/impala-all.js:13327 static/js/impala-min.js:7 static/js/impala/persona_creation.js:89
+msgid "Creative Commons Attribution-ShareAlike 3.0"
+msgstr ""
+
+#: static/js/impala-all.js:13530 static/js/impala-min.js:7 static/js/impala/persona_creation.js:292
+msgid "Your Theme's Name"
+msgstr ""
+
+#: static/js/impala-all.js:14242 static/js/impala-min.js:8 static/js/impala/collections.js:19
+msgid "Stop Following"
+msgstr ""
+
+#: static/js/impala-all.js:14243 static/js/impala-min.js:8 static/js/impala/collections.js:20
+msgid "Following"
+msgstr ""
+
+#: static/js/impala-all.js:14313 static/js/impala-min.js:8 static/js/impala/users.js:33
+msgid "use original"
+msgstr ""
+
+#: static/js/impala-all.js:14523 static/js/impala-min.js:8 static/js/impala/search.js:114
+msgid "Updating results&hellip;"
+msgstr ""
+
+#: static/js/common/upload-addon.js:69 static/js/zamboni/devhub-all.js:300 static/js/zamboni/devhub-min.js:1
 msgid "Select a file..."
 msgstr ""
 
-#: static/js/common/upload-addon.js:70
+#: static/js/common/upload-addon.js:70 static/js/zamboni/devhub-all.js:301 static/js/zamboni/devhub-min.js:1
 msgid "Your add-on should end with .xpi, .jar or .xml"
 msgstr ""
 
 #. L10n: {0} is the percent of the file that has been uploaded.
-#: static/js/common/upload-addon.js:104
+#: static/js/common/upload-addon.js:104 static/js/zamboni/devhub-all.js:335 static/js/zamboni/devhub-min.js:1
 #, python-format
 msgid "{0}% complete"
 msgstr ""
 
 #. L10n: "{bytes uploaded} of {total filesize}".
-#: static/js/common/upload-addon.js:107
+#: static/js/common/upload-addon.js:107 static/js/zamboni/devhub-all.js:338 static/js/zamboni/devhub-min.js:1
 msgid "{0} of {1}"
 msgstr ""
 
-#: static/js/common/upload-addon.js:140
+#: static/js/common/upload-addon.js:140 static/js/zamboni/devhub-all.js:371 static/js/zamboni/devhub-min.js:1
 msgid "Cancel"
 msgstr ""
 
-#: static/js/common/upload-addon.js:162
+#: static/js/common/upload-addon.js:162 static/js/zamboni/devhub-all.js:393 static/js/zamboni/devhub-min.js:1
 msgid "Uploading {0}"
 msgstr ""
 
-#: static/js/common/upload-addon.js:189
+#: static/js/common/upload-addon.js:189 static/js/zamboni/devhub-all.js:420 static/js/zamboni/devhub-min.js:1
 msgid "Error with {0}"
 msgstr ""
 
-#: static/js/common/upload-addon.js:194
+#: static/js/common/upload-addon.js:194 static/js/zamboni/devhub-all.js:425 static/js/zamboni/devhub-min.js:1
 msgid "Your add-on failed validation with {0} error."
 msgid_plural "Your add-on failed validation with {0} errors."
 msgstr[0] ""
 msgstr[1] ""
 
-#: static/js/common/upload-addon.js:208
+#: static/js/common/upload-addon.js:208 static/js/zamboni/devhub-all.js:439 static/js/zamboni/devhub-min.js:1
 msgid "&hellip;and {0} more"
 msgid_plural "&hellip;and {0} more"
 msgstr[0] ""
 msgstr[1] ""
 
-#: static/js/common/upload-addon.js:222 static/js/common/upload-addon.js:512
+#: static/js/common/upload-addon.js:222 static/js/common/upload-addon.js:497 static/js/zamboni/devhub-all.js:453 static/js/zamboni/devhub-all.js:743 static/js/zamboni/devhub-min.js:1
 msgid "See full validation report"
 msgstr ""
 
-#: static/js/common/upload-addon.js:234
+#: static/js/common/upload-addon.js:234 static/js/zamboni/devhub-all.js:465 static/js/zamboni/devhub-min.js:1
 msgid "Validating {0}"
 msgstr ""
 
 #. L10n: first argument is an HTTP status code
-#: static/js/common/upload-addon.js:273
+#: static/js/common/upload-addon.js:273 static/js/zamboni/devhub-all.js:504 static/js/zamboni/devhub-min.js:1
 msgid "Received an empty response from the server; status: {0}"
 msgstr ""
 
-#: static/js/common/upload-addon.js:373
+#: static/js/common/upload-addon.js:370 static/js/zamboni/devhub-all.js:604 static/js/zamboni/devhub-min.js:1
 msgid "Unexpected server error while validating."
 msgstr ""
 
-#: static/js/common/upload-addon.js:412
+#: static/js/common/upload-addon.js:409 static/js/zamboni/devhub-all.js:643 static/js/zamboni/devhub-min.js:1
 msgid "Finished validating {0}"
 msgstr ""
 
-#: static/js/common/upload-addon.js:418
+#: static/js/common/upload-addon.js:415 static/js/zamboni/devhub-all.js:649 static/js/zamboni/devhub-min.js:1
 msgid "Your add-on validation timed out, it will be manually reviewed."
 msgstr ""
 
-#: static/js/common/upload-addon.js:421
+#: static/js/common/upload-addon.js:418 static/js/zamboni/devhub-all.js:652 static/js/zamboni/devhub-min.js:1
 msgid "Your add-on was validated with no errors and {0} warning."
 msgid_plural "Your add-on was validated with no errors and {0} warnings."
 msgstr[0] ""
 msgstr[1] ""
 
-#: static/js/common/upload-addon.js:426
+#: static/js/common/upload-addon.js:423 static/js/zamboni/devhub-all.js:657 static/js/zamboni/devhub-min.js:1
 msgid "Your add-on was validated with no errors and {0} message."
 msgid_plural "Your add-on was validated with no errors and {0} messages."
 msgstr[0] ""
 msgstr[1] ""
 
-#: static/js/common/upload-addon.js:431
+#: static/js/common/upload-addon.js:428 static/js/zamboni/devhub-all.js:662 static/js/zamboni/devhub-min.js:1
 msgid "Your add-on was validated with no errors or warnings."
 msgstr ""
 
-#: static/js/common/upload-addon.js:446
+#: static/js/common/upload-addon.js:443 static/js/zamboni/devhub-all.js:677 static/js/zamboni/devhub-min.js:1
 msgid "Your submission will be automatically signed."
 msgstr ""
 
-#: static/js/common/upload-addon.js:465
+#: static/js/common/upload-addon.js:450 static/js/zamboni/devhub-all.js:696 static/js/zamboni/devhub-min.js:1
 msgid "Include detailed version notes (this can be done in the next step)."
 msgstr ""
 
-#: static/js/common/upload-addon.js:466
+#: static/js/common/upload-addon.js:451 static/js/zamboni/devhub-all.js:697 static/js/zamboni/devhub-min.js:1
 msgid "If your add-on requires an account to a website in order to be fully tested, include a test username and password in the Notes to Reviewer (this can be done in the next step)."
 msgstr ""
 
-#: static/js/common/upload-addon.js:467
+#: static/js/common/upload-addon.js:452 static/js/zamboni/devhub-all.js:698 static/js/zamboni/devhub-min.js:1
 msgid "If your add-on is intended for a limited audience you should choose Preliminary Review instead of Full Review."
 msgstr ""
 
-#: static/js/common/upload-addon.js:480
+#: static/js/common/upload-addon.js:465 static/js/zamboni/devhub-all.js:711 static/js/zamboni/devhub-min.js:1
 msgid "Add-on submission checklist"
 msgstr ""
 
-#: static/js/common/upload-addon.js:481
+#: static/js/common/upload-addon.js:466 static/js/zamboni/devhub-all.js:712 static/js/zamboni/devhub-min.js:1
 msgid "Please verify the following points before finalizing your submission. This will minimize delays or misunderstanding during the review process:"
 msgstr ""
 
-#: static/js/common/upload-addon.js:483
+#: static/js/common/upload-addon.js:468 static/js/zamboni/devhub-all.js:714 static/js/zamboni/devhub-min.js:1
 msgid ""
 "Compiled binaries, as well as minified or obfuscated scripts (excluding known libraries) need to have their sources submitted separately for review. Make sure that you use the source code upload "
 "field to avoid having your submission rejected."
 msgstr ""
 
-#: static/js/common/upload-addon.js:501
+#: static/js/common/upload-addon.js:486 static/js/zamboni/devhub-all.js:732 static/js/zamboni/devhub-min.js:1
 msgid "The validation process found these issues that can lead to rejections:"
 msgstr ""
 
-#: static/js/common/upload-addon.js:518
+#: static/js/common/upload-addon.js:503 static/js/zamboni/devhub-all.js:749 static/js/zamboni/devhub-min.js:1
 msgid "If you are unfamiliar with the add-ons review process, you can read about it here."
 msgstr ""
 
-#: static/js/common/upload-addon.js:555
+#: static/js/common/upload-addon.js:540 static/js/zamboni/devhub-all.js:786 static/js/zamboni/devhub-min.js:1
 msgid "Sorry, no supported platform has been found."
 msgstr ""
 
-#: static/js/common/upload-base.js:57
+#: static/js/common/upload-base.js:57 static/js/zamboni/devhub-all.js:187 static/js/zamboni/devhub-min.js:1
 msgid "The filetype you uploaded isn't recognized."
 msgstr ""
 
-#: static/js/common/upload-base.js:79
+#: static/js/common/upload-base.js:79 static/js/zamboni/devhub-all.js:209 static/js/zamboni/devhub-min.js:1
 msgid "You cancelled the upload."
 msgstr ""
 
-#: static/js/common/upload-image.js:97 static/js/impala/users.js:51
-msgid "Images must be either PNG or JPG."
-msgstr ""
-
-#: static/js/common/upload-image.js:101
-msgid "Videos must be in WebM."
-msgstr ""
-
-#: static/js/impala/collections.js:10 static/js/zamboni/collections.js:595
-msgid "Follow this Collection"
-msgstr ""
-
-#: static/js/impala/collections.js:19
-msgid "Stop Following"
-msgstr ""
-
-#: static/js/impala/collections.js:20
-msgid "Following"
-msgstr ""
-
-#. L10n: {0} is an app name.
-#: static/js/impala/listing.js:11 static/js/zamboni/themes.js:13
-msgid "This theme is incompatible with your version of {0}"
-msgstr ""
-
-#: static/js/impala/persona_creation.js:60
-msgid "All Rights Reserved"
-msgstr ""
-
-#: static/js/impala/persona_creation.js:64
-msgid "Creative Commons Attribution 3.0"
-msgstr ""
-
-#: static/js/impala/persona_creation.js:69
-msgid "Creative Commons Attribution-NonCommercial 3.0"
-msgstr ""
-
-#: static/js/impala/persona_creation.js:74
-msgid "Creative Commons Attribution-NonCommercial-NoDerivs 3.0"
-msgstr ""
-
-#: static/js/impala/persona_creation.js:79
-msgid "Creative Commons Attribution-NonCommercial-Share Alike 3.0"
-msgstr ""
-
-#: static/js/impala/persona_creation.js:84
-msgid "Creative Commons Attribution-NoDerivs 3.0"
-msgstr ""
-
-#: static/js/impala/persona_creation.js:89
-msgid "Creative Commons Attribution-ShareAlike 3.0"
-msgstr ""
-
-#: static/js/impala/persona_creation.js:292
-msgid "Your Theme's Name"
-msgstr ""
-
-#: static/js/impala/reviews.js:23 static/js/zamboni/reviews.js:18
-msgid "Flagged for review"
-msgstr ""
-
-#: static/js/impala/reviews.js:40 static/js/zamboni/reviews.js:34
-msgid "Your input is required"
-msgstr ""
-
-#: static/js/impala/reviews.js:152 static/js/zamboni/reviews.js:103
-msgid "Marked for deletion"
-msgstr ""
-
-#: static/js/impala/search.js:114
-msgid "Updating results&hellip;"
-msgstr ""
-
-#: static/js/impala/site_suggestions.js:46
-msgid "Category"
-msgstr ""
-
-#: static/js/impala/suggestions.js:39
-msgid "Search themes for <b>{0}</b>"
-msgstr ""
-
-#: static/js/impala/suggestions.js:41
-msgid "Search apps for <b>{0}</b>"
-msgstr ""
-
-#: static/js/impala/suggestions.js:43
-msgid "Search add-ons for <b>{0}</b>"
-msgstr ""
-
-#: static/js/impala/users.js:33
-msgid "use original"
-msgstr ""
-
-#: static/js/impala/stats/chart.js:267
+#: static/js/impala/stats/chart.js:267 static/js/zamboni/stats-all.js:16898 static/js/zamboni/stats-min.js:5
 msgid "Week of {0}"
 msgstr ""
 
-#: static/js/impala/stats/chart.js:269
+#: static/js/impala/stats/chart.js:269 static/js/zamboni/stats-all.js:16900 static/js/zamboni/stats-min.js:5
 msgid " downloads"
 msgstr ""
 
-#: static/js/impala/stats/chart.js:270
+#: static/js/impala/stats/chart.js:270 static/js/zamboni/stats-all.js:16901 static/js/zamboni/stats-min.js:5
 msgid "{0} users"
 msgstr ""
 
-#: static/js/impala/stats/chart.js:271
+#: static/js/impala/stats/chart.js:271 static/js/zamboni/stats-all.js:16902 static/js/zamboni/stats-min.js:5
 msgid "{0} add-ons"
 msgstr ""
 
-#: static/js/impala/stats/chart.js:272
+#: static/js/impala/stats/chart.js:272 static/js/zamboni/stats-all.js:16903 static/js/zamboni/stats-min.js:5
 msgid "{0} collections"
 msgstr ""
 
-#: static/js/impala/stats/chart.js:273
+#: static/js/impala/stats/chart.js:273 static/js/zamboni/stats-all.js:16904 static/js/zamboni/stats-min.js:5
 msgid "{0} reviews"
 msgstr ""
 
-#: static/js/impala/stats/chart.js:275
+#: static/js/impala/stats/chart.js:275 static/js/zamboni/stats-all.js:16906 static/js/zamboni/stats-min.js:5
 msgid "{0} sales"
 msgstr ""
 
-#: static/js/impala/stats/chart.js:276
+#: static/js/impala/stats/chart.js:276 static/js/zamboni/stats-all.js:16907 static/js/zamboni/stats-min.js:5
 msgid "{0} refunds"
 msgstr ""
 
-#: static/js/impala/stats/chart.js:277
+#: static/js/impala/stats/chart.js:277 static/js/zamboni/stats-all.js:16908 static/js/zamboni/stats-min.js:5
 msgid "{0} installs"
 msgstr ""
 
-#: static/js/impala/stats/chart.js:369 static/js/impala/stats/csv_keys.js:3 static/js/impala/stats/csv_keys.js:109
+#: static/js/impala/stats/chart.js:369 static/js/impala/stats/csv_keys.js:3 static/js/impala/stats/csv_keys.js:109 static/js/zamboni/stats-all.js:15284 static/js/zamboni/stats-all.js:15390
+#: static/js/zamboni/stats-all.js:17000 static/js/zamboni/stats-min.js:4 static/js/zamboni/stats-min.js:5
 msgid "Downloads"
 msgstr ""
 
-#: static/js/impala/stats/chart.js:379 static/js/impala/stats/csv_keys.js:6 static/js/impala/stats/csv_keys.js:110
+#: static/js/impala/stats/chart.js:379 static/js/impala/stats/csv_keys.js:6 static/js/impala/stats/csv_keys.js:110 static/js/zamboni/stats-all.js:15287 static/js/zamboni/stats-all.js:15391
+#: static/js/zamboni/stats-all.js:17010 static/js/zamboni/stats-min.js:4 static/js/zamboni/stats-min.js:5
 msgid "Daily Users"
 msgstr ""
 
-#: static/js/impala/stats/chart.js:410
+#: static/js/impala/stats/chart.js:410 static/js/zamboni/stats-all.js:17041 static/js/zamboni/stats-min.js:5
 msgid "Amount, in USD"
 msgstr ""
 
-#: static/js/impala/stats/chart.js:421 static/js/impala/stats/csv_keys.js:104
+#: static/js/impala/stats/chart.js:421 static/js/impala/stats/csv_keys.js:104 static/js/zamboni/stats-all.js:15385 static/js/zamboni/stats-all.js:17052 static/js/zamboni/stats-min.js:5
 msgid "Number of Contributions"
 msgstr ""
 
-#: static/js/impala/stats/chart.js:447
+#: static/js/impala/stats/chart.js:447 static/js/zamboni/stats-all.js:17078 static/js/zamboni/stats-min.js:5
 msgid "More Info..."
 msgstr ""
 
 #. L10n: {0} is an ISO-formatted date.
-#: static/js/impala/stats/chart.js:451
+#: static/js/impala/stats/chart.js:451 static/js/zamboni/stats-all.js:17082 static/js/zamboni/stats-min.js:5
 msgid "Details for {0}"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:9
+#: static/js/impala/stats/csv_keys.js:9 static/js/zamboni/stats-all.js:15290 static/js/zamboni/stats-min.js:4
 msgid "Collections Created"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:12
+#: static/js/impala/stats/csv_keys.js:12 static/js/zamboni/stats-all.js:15293 static/js/zamboni/stats-min.js:4
 msgid "Add-ons in Use"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:15
+#: static/js/impala/stats/csv_keys.js:15 static/js/zamboni/stats-all.js:15296 static/js/zamboni/stats-min.js:4
 msgid "Add-ons Created"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:18
+#: static/js/impala/stats/csv_keys.js:18 static/js/zamboni/stats-all.js:15299 static/js/zamboni/stats-min.js:4
 msgid "Add-ons Downloaded"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:21
+#: static/js/impala/stats/csv_keys.js:21 static/js/zamboni/stats-all.js:15302 static/js/zamboni/stats-min.js:4
 msgid "Add-ons Updated"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:24
+#: static/js/impala/stats/csv_keys.js:24 static/js/zamboni/stats-all.js:15305 static/js/zamboni/stats-min.js:4
 msgid "Reviews Written"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:27
+#: static/js/impala/stats/csv_keys.js:27 static/js/zamboni/stats-all.js:15308 static/js/zamboni/stats-min.js:4
 msgid "User Signups"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:30
+#: static/js/impala/stats/csv_keys.js:30 static/js/zamboni/stats-all.js:15311 static/js/zamboni/stats-min.js:4
 msgid "Subscribers"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:33
+#: static/js/impala/stats/csv_keys.js:33 static/js/zamboni/stats-all.js:15314 static/js/zamboni/stats-min.js:4
 msgid "Ratings"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:36 static/js/impala/stats/csv_keys.js:114
+#: static/js/impala/stats/csv_keys.js:36 static/js/impala/stats/csv_keys.js:114 static/js/zamboni/stats-all.js:15317 static/js/zamboni/stats-all.js:15395 static/js/zamboni/stats-min.js:4
+#: static/js/zamboni/stats-min.js:5
 msgid "Sales"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:39 static/js/impala/stats/csv_keys.js:113
+#: static/js/impala/stats/csv_keys.js:39 static/js/impala/stats/csv_keys.js:113 static/js/zamboni/stats-all.js:15320 static/js/zamboni/stats-all.js:15394 static/js/zamboni/stats-min.js:4
+#: static/js/zamboni/stats-min.js:5
 msgid "Installs"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:42
+#: static/js/impala/stats/csv_keys.js:42 static/js/zamboni/stats-all.js:15323 static/js/zamboni/stats-min.js:4
 msgid "Unknown"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:43
+#: static/js/impala/stats/csv_keys.js:43 static/js/zamboni/stats-all.js:15324 static/js/zamboni/stats-min.js:4
 msgid "Add-ons Manager"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:44
+#: static/js/impala/stats/csv_keys.js:44 static/js/zamboni/stats-all.js:15325 static/js/zamboni/stats-min.js:4
 msgid "Add-ons Manager Promo"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:45
+#: static/js/impala/stats/csv_keys.js:45 static/js/zamboni/stats-all.js:15326 static/js/zamboni/stats-min.js:4
 msgid "Add-ons Manager Featured"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:46
+#: static/js/impala/stats/csv_keys.js:46 static/js/zamboni/stats-all.js:15327 static/js/zamboni/stats-min.js:4
 msgid "Add-ons Manager Learn More"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:47
+#: static/js/impala/stats/csv_keys.js:47 static/js/zamboni/stats-all.js:15328 static/js/zamboni/stats-min.js:4
 msgid "Search Suggestions"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:48
+#: static/js/impala/stats/csv_keys.js:48 static/js/zamboni/stats-all.js:15329 static/js/zamboni/stats-min.js:4
 msgid "Search Results"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:49 static/js/impala/stats/csv_keys.js:50 static/js/impala/stats/csv_keys.js:51
+#: static/js/impala/stats/csv_keys.js:49 static/js/impala/stats/csv_keys.js:50 static/js/impala/stats/csv_keys.js:51 static/js/zamboni/stats-all.js:15330 static/js/zamboni/stats-all.js:15331
+#: static/js/zamboni/stats-all.js:15332 static/js/zamboni/stats-min.js:4
 msgid "Homepage Promo"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:52 static/js/impala/stats/csv_keys.js:53
+#: static/js/impala/stats/csv_keys.js:52 static/js/impala/stats/csv_keys.js:53 static/js/zamboni/stats-all.js:15333 static/js/zamboni/stats-all.js:15334 static/js/zamboni/stats-min.js:4
 msgid "Homepage Featured"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:54 static/js/impala/stats/csv_keys.js:55
+#: static/js/impala/stats/csv_keys.js:54 static/js/impala/stats/csv_keys.js:55 static/js/zamboni/stats-all.js:15335 static/js/zamboni/stats-all.js:15336 static/js/zamboni/stats-min.js:4
 msgid "Homepage Up and Coming"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:56
+#: static/js/impala/stats/csv_keys.js:56 static/js/zamboni/stats-all.js:15337 static/js/zamboni/stats-min.js:4
 msgid "Homepage Most Popular"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:57 static/js/impala/stats/csv_keys.js:59
+#: static/js/impala/stats/csv_keys.js:57 static/js/impala/stats/csv_keys.js:59 static/js/zamboni/stats-all.js:15338 static/js/zamboni/stats-all.js:15340 static/js/zamboni/stats-min.js:4
 msgid "Detail Page"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:58 static/js/impala/stats/csv_keys.js:60
+#: static/js/impala/stats/csv_keys.js:58 static/js/impala/stats/csv_keys.js:60 static/js/zamboni/stats-all.js:15339 static/js/zamboni/stats-all.js:15341 static/js/zamboni/stats-min.js:4
 msgid "Detail Page (bottom)"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:61
+#: static/js/impala/stats/csv_keys.js:61 static/js/zamboni/stats-all.js:15342 static/js/zamboni/stats-min.js:4
 msgid "Detail Page (Development Channel)"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:62 static/js/impala/stats/csv_keys.js:63 static/js/impala/stats/csv_keys.js:64
+#: static/js/impala/stats/csv_keys.js:62 static/js/impala/stats/csv_keys.js:63 static/js/impala/stats/csv_keys.js:64 static/js/zamboni/stats-all.js:15343 static/js/zamboni/stats-all.js:15344
+#: static/js/zamboni/stats-all.js:15345 static/js/zamboni/stats-min.js:4
 msgid "Often Used With"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:65 static/js/impala/stats/csv_keys.js:66
+#: static/js/impala/stats/csv_keys.js:65 static/js/impala/stats/csv_keys.js:66 static/js/zamboni/stats-all.js:15346 static/js/zamboni/stats-all.js:15347 static/js/zamboni/stats-min.js:4
 msgid "Others By Author"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:67 static/js/impala/stats/csv_keys.js:68
+#: static/js/impala/stats/csv_keys.js:67 static/js/impala/stats/csv_keys.js:68 static/js/zamboni/stats-all.js:15348 static/js/zamboni/stats-all.js:15349 static/js/zamboni/stats-min.js:4
 msgid "Dependencies"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:69 static/js/impala/stats/csv_keys.js:70
+#: static/js/impala/stats/csv_keys.js:69 static/js/impala/stats/csv_keys.js:70 static/js/zamboni/stats-all.js:15350 static/js/zamboni/stats-all.js:15351 static/js/zamboni/stats-min.js:4
 msgid "Upsell"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:71
+#: static/js/impala/stats/csv_keys.js:71 static/js/zamboni/stats-all.js:15352 static/js/zamboni/stats-min.js:4
 msgid "Meet the Developer"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:72
+#: static/js/impala/stats/csv_keys.js:72 static/js/zamboni/stats-all.js:15353 static/js/zamboni/stats-min.js:4
 msgid "User Profile"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:73
+#: static/js/impala/stats/csv_keys.js:73 static/js/zamboni/stats-all.js:15354 static/js/zamboni/stats-min.js:4
 msgid "Version History"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:75
+#: static/js/impala/stats/csv_keys.js:75 static/js/zamboni/stats-all.js:15356 static/js/zamboni/stats-min.js:4
 msgid "Sharing"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:76
+#: static/js/impala/stats/csv_keys.js:76 static/js/zamboni/stats-all.js:15357 static/js/zamboni/stats-min.js:4
 msgid "Category Pages"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:77
+#: static/js/impala/stats/csv_keys.js:77 static/js/zamboni/stats-all.js:15358 static/js/zamboni/stats-min.js:4
 msgid "Collections"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:78 static/js/impala/stats/csv_keys.js:79
+#: static/js/impala/stats/csv_keys.js:78 static/js/impala/stats/csv_keys.js:79 static/js/zamboni/stats-all.js:15359 static/js/zamboni/stats-all.js:15360 static/js/zamboni/stats-min.js:4
 msgid "Category Landing Featured Carousel"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:80 static/js/impala/stats/csv_keys.js:81
+#: static/js/impala/stats/csv_keys.js:80 static/js/impala/stats/csv_keys.js:81 static/js/zamboni/stats-all.js:15361 static/js/zamboni/stats-all.js:15362 static/js/zamboni/stats-min.js:4
 msgid "Category Landing Top Rated"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:82 static/js/impala/stats/csv_keys.js:83
+#: static/js/impala/stats/csv_keys.js:82 static/js/impala/stats/csv_keys.js:83 static/js/zamboni/stats-all.js:15363 static/js/zamboni/stats-all.js:15364 static/js/zamboni/stats-min.js:5
 msgid "Category Landing Most Popular"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:84 static/js/impala/stats/csv_keys.js:85
+#: static/js/impala/stats/csv_keys.js:84 static/js/impala/stats/csv_keys.js:85 static/js/zamboni/stats-all.js:15365 static/js/zamboni/stats-all.js:15366 static/js/zamboni/stats-min.js:5
 msgid "Category Landing Recently Added"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:86 static/js/impala/stats/csv_keys.js:87
+#: static/js/impala/stats/csv_keys.js:86 static/js/impala/stats/csv_keys.js:87 static/js/zamboni/stats-all.js:15367 static/js/zamboni/stats-all.js:15368 static/js/zamboni/stats-min.js:5
 msgid "Browse Listing Featured Sort"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:88 static/js/impala/stats/csv_keys.js:89
+#: static/js/impala/stats/csv_keys.js:88 static/js/impala/stats/csv_keys.js:89 static/js/zamboni/stats-all.js:15369 static/js/zamboni/stats-all.js:15370 static/js/zamboni/stats-min.js:5
 msgid "Browse Listing Users Sort"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:90 static/js/impala/stats/csv_keys.js:91
+#: static/js/impala/stats/csv_keys.js:90 static/js/impala/stats/csv_keys.js:91 static/js/zamboni/stats-all.js:15371 static/js/zamboni/stats-all.js:15372 static/js/zamboni/stats-min.js:5
 msgid "Browse Listing Rating Sort"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:92 static/js/impala/stats/csv_keys.js:93
+#: static/js/impala/stats/csv_keys.js:92 static/js/impala/stats/csv_keys.js:93 static/js/zamboni/stats-all.js:15373 static/js/zamboni/stats-all.js:15374 static/js/zamboni/stats-min.js:5
 msgid "Browse Listing Created Sort"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:94 static/js/impala/stats/csv_keys.js:95
+#: static/js/impala/stats/csv_keys.js:94 static/js/impala/stats/csv_keys.js:95 static/js/zamboni/stats-all.js:15375 static/js/zamboni/stats-all.js:15376 static/js/zamboni/stats-min.js:5
 msgid "Browse Listing Name Sort"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:96 static/js/impala/stats/csv_keys.js:97
+#: static/js/impala/stats/csv_keys.js:96 static/js/impala/stats/csv_keys.js:97 static/js/zamboni/stats-all.js:15377 static/js/zamboni/stats-all.js:15378 static/js/zamboni/stats-min.js:5
 msgid "Browse Listing Popular Sort"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:98 static/js/impala/stats/csv_keys.js:99
+#: static/js/impala/stats/csv_keys.js:98 static/js/impala/stats/csv_keys.js:99 static/js/zamboni/stats-all.js:15379 static/js/zamboni/stats-all.js:15380 static/js/zamboni/stats-min.js:5
 msgid "Browse Listing Updated Sort"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:100 static/js/impala/stats/csv_keys.js:101
+#: static/js/impala/stats/csv_keys.js:100 static/js/impala/stats/csv_keys.js:101 static/js/zamboni/stats-all.js:15381 static/js/zamboni/stats-all.js:15382 static/js/zamboni/stats-min.js:5
 msgid "Browse Listing Up and Coming Sort"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:105
+#: static/js/impala/stats/csv_keys.js:105 static/js/zamboni/stats-all.js:15386 static/js/zamboni/stats-min.js:5
 msgid "Total Amount Contributed"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:106
+#: static/js/impala/stats/csv_keys.js:106 static/js/zamboni/stats-all.js:15387 static/js/zamboni/stats-min.js:5
 msgid "Average Contribution"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:115
+#: static/js/impala/stats/csv_keys.js:115 static/js/zamboni/stats-all.js:15396 static/js/zamboni/stats-min.js:5
 msgid "Usage"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:118
+#: static/js/impala/stats/csv_keys.js:118 static/js/zamboni/stats-all.js:15399 static/js/zamboni/stats-min.js:5
 msgid "Firefox"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:119
+#: static/js/impala/stats/csv_keys.js:119 static/js/zamboni/stats-all.js:15400 static/js/zamboni/stats-min.js:5
 msgid "Mozilla"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:120
+#: static/js/impala/stats/csv_keys.js:120 static/js/zamboni/stats-all.js:15401 static/js/zamboni/stats-min.js:5
 msgid "Thunderbird"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:121
+#: static/js/impala/stats/csv_keys.js:121 static/js/zamboni/stats-all.js:15402 static/js/zamboni/stats-min.js:5
 msgid "Sunbird"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:122
+#: static/js/impala/stats/csv_keys.js:122 static/js/zamboni/stats-all.js:15403 static/js/zamboni/stats-min.js:5
 msgid "SeaMonkey"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:123
+#: static/js/impala/stats/csv_keys.js:123 static/js/zamboni/stats-all.js:15404 static/js/zamboni/stats-min.js:5
 msgid "Fennec"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:124
+#: static/js/impala/stats/csv_keys.js:124 static/js/zamboni/stats-all.js:15405 static/js/zamboni/stats-min.js:5
 msgid "Android"
 msgstr ""
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:129
+#: static/js/impala/stats/csv_keys.js:129 static/js/zamboni/stats-all.js:15410 static/js/zamboni/stats-min.js:5
 msgid "Downloads and Daily Users, last {0} days"
 msgstr ""
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:131
+#: static/js/impala/stats/csv_keys.js:131 static/js/zamboni/stats-all.js:15412 static/js/zamboni/stats-min.js:5
 msgid "Downloads and Daily Users from {0} to {1}"
 msgstr ""
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:135
+#: static/js/impala/stats/csv_keys.js:135 static/js/zamboni/stats-all.js:15416 static/js/zamboni/stats-min.js:5
 msgid "Installs and Daily Users, last {0} days"
 msgstr ""
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:137
+#: static/js/impala/stats/csv_keys.js:137 static/js/zamboni/stats-all.js:15418 static/js/zamboni/stats-min.js:5
 msgid "Installs and Daily Users from {0} to {1}"
 msgstr ""
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:141
+#: static/js/impala/stats/csv_keys.js:141 static/js/zamboni/stats-all.js:15422 static/js/zamboni/stats-min.js:5
 msgid "Downloads, last {0} days"
 msgstr ""
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:143
+#: static/js/impala/stats/csv_keys.js:143 static/js/zamboni/stats-all.js:15424 static/js/zamboni/stats-min.js:5
 msgid "Downloads from {0} to {1}"
 msgstr ""
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:147
+#: static/js/impala/stats/csv_keys.js:147 static/js/zamboni/stats-all.js:15428 static/js/zamboni/stats-min.js:5
 msgid "Daily Users, last {0} days"
 msgstr ""
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:149
+#: static/js/impala/stats/csv_keys.js:149 static/js/zamboni/stats-all.js:15430 static/js/zamboni/stats-min.js:5
 msgid "Daily Users from {0} to {1}"
 msgstr ""
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:153
+#: static/js/impala/stats/csv_keys.js:153 static/js/zamboni/stats-all.js:15434 static/js/zamboni/stats-min.js:5
 msgid "Applications, last {0} days"
 msgstr ""
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:155
+#: static/js/impala/stats/csv_keys.js:155 static/js/zamboni/stats-all.js:15436 static/js/zamboni/stats-min.js:5
 msgid "Applications from {0} to {1}"
 msgstr ""
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:159
+#: static/js/impala/stats/csv_keys.js:159 static/js/zamboni/stats-all.js:15440 static/js/zamboni/stats-min.js:5
 msgid "Platforms, last {0} days"
 msgstr ""
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:161
+#: static/js/impala/stats/csv_keys.js:161 static/js/zamboni/stats-all.js:15442 static/js/zamboni/stats-min.js:5
 msgid "Platforms from {0} to {1}"
 msgstr ""
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:165
+#: static/js/impala/stats/csv_keys.js:165 static/js/zamboni/stats-all.js:15446 static/js/zamboni/stats-min.js:5
 msgid "Languages, last {0} days"
 msgstr ""
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:167
+#: static/js/impala/stats/csv_keys.js:167 static/js/zamboni/stats-all.js:15448 static/js/zamboni/stats-min.js:5
 msgid "Languages from {0} to {1}"
 msgstr ""
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:171
+#: static/js/impala/stats/csv_keys.js:171 static/js/zamboni/stats-all.js:15452 static/js/zamboni/stats-min.js:5
 msgid "Add-on Versions, last {0} days"
 msgstr ""
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:173
+#: static/js/impala/stats/csv_keys.js:173 static/js/zamboni/stats-all.js:15454 static/js/zamboni/stats-min.js:5
 msgid "Add-on Versions from {0} to {1}"
 msgstr ""
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:177
+#: static/js/impala/stats/csv_keys.js:177 static/js/zamboni/stats-all.js:15458 static/js/zamboni/stats-min.js:5
 msgid "Add-on Status, last {0} days"
 msgstr ""
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:179
+#: static/js/impala/stats/csv_keys.js:179 static/js/zamboni/stats-all.js:15460 static/js/zamboni/stats-min.js:5
 msgid "Add-on Status from {0} to {1}"
 msgstr ""
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:183
+#: static/js/impala/stats/csv_keys.js:183 static/js/zamboni/stats-all.js:15464 static/js/zamboni/stats-min.js:5
 msgid "Download Sources, last {0} days"
 msgstr ""
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:185
+#: static/js/impala/stats/csv_keys.js:185 static/js/zamboni/stats-all.js:15466 static/js/zamboni/stats-min.js:5
 msgid "Download Sources from {0} to {1}"
 msgstr ""
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:189
+#: static/js/impala/stats/csv_keys.js:189 static/js/zamboni/stats-all.js:15470 static/js/zamboni/stats-min.js:5
 msgid "Contributions, last {0} days"
 msgstr ""
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:191
+#: static/js/impala/stats/csv_keys.js:191 static/js/zamboni/stats-all.js:15472 static/js/zamboni/stats-min.js:5
 msgid "Contributions from {0} to {1}"
 msgstr ""
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:195
+#: static/js/impala/stats/csv_keys.js:195 static/js/zamboni/stats-all.js:15476 static/js/zamboni/stats-min.js:5
 msgid "Site Metrics, last {0} days"
 msgstr ""
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:197
+#: static/js/impala/stats/csv_keys.js:197 static/js/zamboni/stats-all.js:15478 static/js/zamboni/stats-min.js:5
 msgid "Site Metrics from {0} to {1}"
 msgstr ""
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:201
+#: static/js/impala/stats/csv_keys.js:201 static/js/zamboni/stats-all.js:15482 static/js/zamboni/stats-min.js:5
 msgid "Add-ons in Use, last {0} days"
 msgstr ""
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:203
+#: static/js/impala/stats/csv_keys.js:203 static/js/zamboni/stats-all.js:15484 static/js/zamboni/stats-min.js:5
 msgid "Add-ons in Use from {0} to {1}"
 msgstr ""
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:207
+#: static/js/impala/stats/csv_keys.js:207 static/js/zamboni/stats-all.js:15488 static/js/zamboni/stats-min.js:5
 msgid "Add-ons Downloaded, last {0} days"
 msgstr ""
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:209
+#: static/js/impala/stats/csv_keys.js:209 static/js/zamboni/stats-all.js:15490 static/js/zamboni/stats-min.js:5
 msgid "Add-ons Downloaded from {0} to {1}"
 msgstr ""
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:213
+#: static/js/impala/stats/csv_keys.js:213 static/js/zamboni/stats-all.js:15494 static/js/zamboni/stats-min.js:5
 msgid "Add-ons Created, last {0} days"
 msgstr ""
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:215
+#: static/js/impala/stats/csv_keys.js:215 static/js/zamboni/stats-all.js:15496 static/js/zamboni/stats-min.js:5
 msgid "Add-ons Created from {0} to {1}"
 msgstr ""
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:219
+#: static/js/impala/stats/csv_keys.js:219 static/js/zamboni/stats-all.js:15500 static/js/zamboni/stats-min.js:5
 msgid "Add-ons Updated, last {0} days"
 msgstr ""
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:221
+#: static/js/impala/stats/csv_keys.js:221 static/js/zamboni/stats-all.js:15502 static/js/zamboni/stats-min.js:5
 msgid "Add-ons Updated from {0} to {1}"
 msgstr ""
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:225
+#: static/js/impala/stats/csv_keys.js:225 static/js/zamboni/stats-all.js:15506 static/js/zamboni/stats-min.js:5
 msgid "Reviews Written, last {0} days"
 msgstr ""
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:227
+#: static/js/impala/stats/csv_keys.js:227 static/js/zamboni/stats-all.js:15508 static/js/zamboni/stats-min.js:5
 msgid "Reviews Written from {0} to {1}"
 msgstr ""
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:231
+#: static/js/impala/stats/csv_keys.js:231 static/js/zamboni/stats-all.js:15512 static/js/zamboni/stats-min.js:5
 msgid "User Signups, last {0} days"
 msgstr ""
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:233
+#: static/js/impala/stats/csv_keys.js:233 static/js/zamboni/stats-all.js:15514 static/js/zamboni/stats-min.js:5
 msgid "User Signups from {0} to {1}"
 msgstr ""
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:237
+#: static/js/impala/stats/csv_keys.js:237 static/js/zamboni/stats-all.js:15518 static/js/zamboni/stats-min.js:5
 msgid "Collections Created, last {0} days"
 msgstr ""
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:239
+#: static/js/impala/stats/csv_keys.js:239 static/js/zamboni/stats-all.js:15520 static/js/zamboni/stats-min.js:5
 msgid "Collections Created from {0} to {1}"
 msgstr ""
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:243
+#: static/js/impala/stats/csv_keys.js:243 static/js/zamboni/stats-all.js:15524 static/js/zamboni/stats-min.js:5
 msgid "Subscribers, last {0} days"
 msgstr ""
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:245
+#: static/js/impala/stats/csv_keys.js:245 static/js/zamboni/stats-all.js:15526 static/js/zamboni/stats-min.js:5
 msgid "Subscribers from {0} to {1}"
 msgstr ""
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:249
+#: static/js/impala/stats/csv_keys.js:249 static/js/zamboni/stats-all.js:15530 static/js/zamboni/stats-min.js:5
 msgid "Ratings, last {0} days"
 msgstr ""
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:251
+#: static/js/impala/stats/csv_keys.js:251 static/js/zamboni/stats-all.js:15532 static/js/zamboni/stats-min.js:5
 msgid "Ratings from {0} to {1}"
 msgstr ""
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:255
+#: static/js/impala/stats/csv_keys.js:255 static/js/zamboni/stats-all.js:15536 static/js/zamboni/stats-min.js:5
 msgid "Sales, last {0} days"
 msgstr ""
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:257
+#: static/js/impala/stats/csv_keys.js:257 static/js/zamboni/stats-all.js:15538 static/js/zamboni/stats-min.js:5
 msgid "Sales from {0} to {1}"
 msgstr ""
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:261
+#: static/js/impala/stats/csv_keys.js:261 static/js/zamboni/stats-all.js:15542 static/js/zamboni/stats-min.js:5
 msgid "Installs, last {0} days"
 msgstr ""
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:263
+#: static/js/impala/stats/csv_keys.js:263 static/js/zamboni/stats-all.js:15544 static/js/zamboni/stats-min.js:5
 msgid "Installs from {0} to {1}"
 msgstr ""
 
 #. L10n: {0} and {1} are integers.
-#: static/js/impala/stats/csv_keys.js:269
+#: static/js/impala/stats/csv_keys.js:269 static/js/zamboni/stats-all.js:15550 static/js/zamboni/stats-min.js:5
 msgid "<b>{0}</b> in last {1} days"
 msgstr ""
 
 #. L10n: {0} is an integer and {1} and {2} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:271 static/js/impala/stats/csv_keys.js:277
+#: static/js/impala/stats/csv_keys.js:271 static/js/impala/stats/csv_keys.js:277 static/js/zamboni/stats-all.js:15552 static/js/zamboni/stats-all.js:15558 static/js/zamboni/stats-min.js:5
 msgid "<b>{0}</b> from {1} to {2}"
 msgstr ""
 
 #. L10n: {0} and {1} are integers.
-#: static/js/impala/stats/csv_keys.js:275
+#: static/js/impala/stats/csv_keys.js:275 static/js/zamboni/stats-all.js:15556 static/js/zamboni/stats-min.js:5
 msgid "<b>{0}</b> average in last {1} days"
 msgstr ""
 
-#: static/js/impala/stats/overview.js:19
+#: static/js/impala/stats/overview.js:19 static/js/zamboni/stats-all.js:16469 static/js/zamboni/stats-min.js:5
 msgid "No data available."
 msgstr ""
 
-#: static/js/impala/stats/table.js:74
+#: static/js/impala/stats/table.js:74 static/js/zamboni/stats-all.js:17209 static/js/zamboni/stats-min.js:5
 msgid "Date"
 msgstr ""
 
-#: static/js/impala/stats/topchart.js:96
+#: static/js/impala/stats/topchart.js:96 static/js/zamboni/stats-all.js:16600 static/js/zamboni/stats-min.js:5
 msgid "Other"
 msgstr ""
 
-#: static/js/zamboni/admin_validation.js:24 static/js/zamboni/devhub.js:1229 static/js/zamboni/editors.js:295
+#: static/js/zamboni/admin-all.js:180 static/js/zamboni/admin-min.js:1 static/js/zamboni/admin_validation.js:24 static/js/zamboni/devhub-all.js:2408 static/js/zamboni/devhub-min.js:2
+#: static/js/zamboni/devhub.js:1229 static/js/zamboni/editors-all.js:15576 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:295
 msgid "Select an application first"
 msgstr ""
 
-#: static/js/zamboni/admin_validation.js:51
+#: static/js/zamboni/admin-all.js:207 static/js/zamboni/admin-min.js:1 static/js/zamboni/admin_validation.js:51
 msgid "Set {0} add-on to a max version of {1} and email the author."
 msgid_plural "Set {0} add-ons to a max version of {1} and email the authors."
 msgstr[0] ""
 msgstr[1] ""
 
-#: static/js/zamboni/admin_validation.js:54
+#: static/js/zamboni/admin-all.js:210 static/js/zamboni/admin-min.js:1 static/js/zamboni/admin_validation.js:54
 msgid "Email author of {2} add-on which failed validation."
 msgid_plural "Email authors of {2} add-ons which failed validation."
 msgstr[0] ""
 msgstr[1] ""
 
-#. L10n: {0} is an app name like Firefox.
-#: static/js/zamboni/buttons.js:66
-msgid "Accept and Install"
-msgstr ""
-
-#: static/js/zamboni/buttons.js:66
-msgid "Add to {0}"
-msgstr ""
-
-#: static/js/zamboni/buttons.js:71
-msgid "Download Now"
-msgstr ""
-
-#: static/js/zamboni/buttons.js:112
-msgid "Add-on has not been updated to support default-to-compatible."
-msgstr ""
-
-#: static/js/zamboni/buttons.js:117
-msgid "You need to be using Firefox 10.0 or higher."
-msgstr ""
-
-#: static/js/zamboni/buttons.js:129
-msgid "Mozilla has marked this version as incompatible with your Firefox version."
-msgstr ""
-
-#. L10n: {0} is an platform like Windows or Linux.
-#: static/js/zamboni/buttons.js:210
-msgid "Install for {0} anyway"
-msgstr ""
-
-#: static/js/zamboni/buttons.js:210
-msgid "Download for {0} anyway"
-msgstr ""
-
-#: static/js/zamboni/buttons.js:267
-msgid "Not available for your platform"
-msgstr ""
-
-#. L10n: {0} is an app name, {1} is the app version.
-#: static/js/zamboni/buttons.js:278 static/js/zamboni/buttons.js:315
-msgid "Not available for {0} {1}"
-msgstr ""
-
-#: static/js/zamboni/buttons.js:341
-msgid "Works with {app} {min} - {max}"
-msgstr ""
-
-#: static/js/zamboni/buttons.js:343
-msgid "View other versions"
-msgstr ""
-
-#: static/js/zamboni/buttons.js:391
-msgid "Only with Firefox — Get Firefox Now!"
-msgstr ""
-
-#: static/js/zamboni/buttons.js:507 static/js/zamboni/mobile/buttons.js:43
-msgid "Sorry, you need a Mozilla-based browser (such as Firefox) to install a search plugin."
-msgstr ""
-
-#: static/js/zamboni/collections.js:229
-msgid "Adding to Favorites&hellip;"
-msgstr ""
-
-#: static/js/zamboni/collections.js:232
-msgid "Removing Favorite&hellip;"
-msgstr ""
-
-#: static/js/zamboni/collections.js:235
-msgid "Add to Favorites"
-msgstr ""
-
-#: static/js/zamboni/collections.js:238
-msgid "Remove from Favorites"
-msgstr ""
-
-#: static/js/zamboni/collections.js:303
-msgid "Pending"
-msgstr ""
-
-#: static/js/zamboni/collections.js:304
-msgid "Add a comment"
-msgstr ""
-
-#: static/js/zamboni/collections.js:304
-msgid "Comment"
-msgstr ""
-
-#: static/js/zamboni/collections.js:305
-msgid "Remove this add-on from the collection"
-msgstr ""
-
-#: static/js/zamboni/collections.js:305 static/js/zamboni/collections.js:334
-msgid "Remove"
-msgstr ""
-
-#: static/js/zamboni/collections.js:334
-msgid "Remove this user as a contributor"
-msgstr ""
-
-#: static/js/zamboni/collections.js:346
-msgid "An email address is required."
-msgstr ""
-
-#: static/js/zamboni/collections.js:364
-msgid "You cannot add yourself as a contributor."
-msgstr ""
-
-#: static/js/zamboni/collections.js:366
-msgid "You have already added that user."
-msgstr ""
-
-#: static/js/zamboni/collections.js:573
-msgid "Add to favorites"
-msgstr ""
-
-#: static/js/zamboni/collections.js:577
-msgid "Remove from favorites"
-msgstr ""
-
-#: static/js/zamboni/collections.js:604
-msgid "Stop following"
-msgstr ""
-
-#: static/js/zamboni/devhub.js:110
+#: static/js/zamboni/devhub-all.js:1289 static/js/zamboni/devhub-min.js:1 static/js/zamboni/devhub.js:110
 msgid "Your browser does not support the video tag"
 msgstr ""
 
-#: static/js/zamboni/devhub.js:371
+#: static/js/zamboni/devhub-all.js:1550 static/js/zamboni/devhub-min.js:1 static/js/zamboni/devhub.js:371
 msgid "Changes Saved"
 msgstr ""
 
-#: static/js/zamboni/devhub.js:387
+#: static/js/zamboni/devhub-all.js:1566 static/js/zamboni/devhub-min.js:1 static/js/zamboni/devhub.js:387
 msgid "Enter a new author's email address"
 msgstr ""
 
-#: static/js/zamboni/devhub.js:536
+#: static/js/zamboni/devhub-all.js:1715 static/js/zamboni/devhub-min.js:1 static/js/zamboni/devhub.js:536
 msgid "There was an error uploading your file."
 msgstr ""
 
-#: static/js/zamboni/devhub.js:681
+#: static/js/zamboni/devhub-all.js:1860 static/js/zamboni/devhub-min.js:1 static/js/zamboni/devhub.js:681
 msgid "{files} file"
 msgid_plural "{files} files"
 msgstr[0] ""
 msgstr[1] ""
 
-#: static/js/zamboni/devhub.js:684
+#: static/js/zamboni/devhub-all.js:1863 static/js/zamboni/devhub-min.js:1 static/js/zamboni/devhub.js:684
 msgid "{reviews} user review"
 msgid_plural "{reviews} user reviews"
 msgstr[0] ""
 msgstr[1] ""
 
-#: static/js/zamboni/devhub.js:796
+#: static/js/zamboni/devhub-all.js:1975 static/js/zamboni/devhub-min.js:2 static/js/zamboni/devhub.js:796
 msgid "Learn more"
 msgstr ""
 
-#: static/js/zamboni/devhub.js:800
+#: static/js/zamboni/devhub-all.js:1979 static/js/zamboni/devhub-min.js:2 static/js/zamboni/devhub.js:800
 msgid "Example"
 msgstr ""
 
-#: static/js/zamboni/devhub.js:1130
+#: static/js/zamboni/devhub-all.js:2309 static/js/zamboni/devhub-min.js:2 static/js/zamboni/devhub.js:1130
 msgid "Image changes being processed"
 msgstr ""
 
-#: static/js/zamboni/devhub.js:1280
+#: static/js/zamboni/devhub-all.js:2459 static/js/zamboni/devhub-min.js:2 static/js/zamboni/devhub.js:1280
 msgid "Must be a valid e-mail address."
+msgstr ""
+
+#: static/js/zamboni/devhub-all.js:2613 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:80
+msgid "All tests passed successfully."
+msgstr ""
+
+#: static/js/zamboni/devhub-all.js:2616 static/js/zamboni/devhub-all.js:3011 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:83 static/js/zamboni/validator.js:478
+msgid "These tests were not run."
+msgstr ""
+
+#: static/js/zamboni/devhub-all.js:2664 static/js/zamboni/devhub-all.js:2677 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:131 static/js/zamboni/validator.js:144
+msgid "Tests"
+msgstr ""
+
+#: static/js/zamboni/devhub-all.js:2779 static/js/zamboni/devhub-all.js:3108 static/js/zamboni/devhub-all.js:3127 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:246
+#: static/js/zamboni/validator.js:575 static/js/zamboni/validator.js:594
+msgid "Error"
+msgstr ""
+
+#: static/js/zamboni/devhub-all.js:2780 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:247
+msgid "Warning"
+msgstr ""
+
+#: static/js/zamboni/devhub-all.js:2794 static/js/zamboni/devhub-min.js:2 static/js/zamboni/files-all.js:5657 static/js/zamboni/files-min.js:3 static/js/zamboni/files.js:411
+#: static/js/zamboni/validator.js:261
+msgid "Ignore this message in future updates"
+msgstr ""
+
+#: static/js/zamboni/devhub-all.js:2817 static/js/zamboni/devhub-min.js:2 static/js/zamboni/files-all.js:5663 static/js/zamboni/files-min.js:3 static/js/zamboni/files.js:417
+#: static/js/zamboni/validator.js:284
+msgid "Severity for automated signing:"
+msgstr ""
+
+#: static/js/zamboni/devhub-all.js:2832 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:299
+msgid "Suggestions for passing automated signing:"
+msgstr ""
+
+#: static/js/zamboni/devhub-all.js:2920 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:387
+msgid "Compatibility Tests"
+msgstr ""
+
+#: static/js/zamboni/devhub-all.js:2999 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:466
+msgid "Add-on failed validation."
+msgstr ""
+
+#: static/js/zamboni/devhub-all.js:3001 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:468
+msgid "Add-on passed validation."
+msgstr ""
+
+#: static/js/zamboni/devhub-all.js:3014 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:481
+msgid "{0} error"
+msgid_plural "{0} errors"
+msgstr[0] ""
+msgstr[1] ""
+
+#: static/js/zamboni/devhub-all.js:3016 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:483
+msgid "{0} warning"
+msgid_plural "{0} warnings"
+msgstr[0] ""
+msgstr[1] ""
+
+#: static/js/zamboni/devhub-all.js:3018 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:485
+msgid "{0} notice"
+msgid_plural "{0} notices"
+msgstr[0] ""
+msgstr[1] ""
+
+#: static/js/zamboni/devhub-all.js:3110 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:577
+msgid "Validation task could not complete or completed with errors"
+msgstr ""
+
+#: static/js/zamboni/devhub-all.js:3128 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:595
+msgid "Internal server error"
 msgstr ""
 
 #: static/js/zamboni/devhub_search.js:8
 msgid "No results found."
 msgstr ""
 
-#: static/js/zamboni/editors.js:121
+#: static/js/zamboni/editors-all.js:15402 static/js/zamboni/editors-min.js:4 static/js/zamboni/editors.js:121
 msgid "{name} was viewing this page first."
 msgstr ""
 
-#: static/js/zamboni/editors.js:171
+#: static/js/zamboni/editors-all.js:15452 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:171
 msgid "Receipt checked by app."
 msgstr ""
 
-#: static/js/zamboni/editors.js:173
+#: static/js/zamboni/editors-all.js:15454 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:173
 msgid "Receipt was not checked by app."
 msgstr ""
 
-#: static/js/zamboni/editors.js:244
+#: static/js/zamboni/editors-all.js:15525 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:244
 msgid "{name} was viewing this add-on first."
 msgstr ""
 
-#: static/js/zamboni/editors.js:255
+#: static/js/zamboni/editors-all.js:15536 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:255
 msgid "Loading&hellip;"
 msgstr ""
 
-#: static/js/zamboni/editors.js:260
+#: static/js/zamboni/editors-all.js:15541 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:260
 msgid "Version Notes"
 msgstr ""
 
-#: static/js/zamboni/editors.js:265
+#: static/js/zamboni/editors-all.js:15546 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:265
 msgid "Notes for Reviewers"
 msgstr ""
 
-#: static/js/zamboni/editors.js:270
+#: static/js/zamboni/editors-all.js:15551 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:270
 msgid "No version notes found"
 msgstr ""
 
-#: static/js/zamboni/editors.js:330
+#: static/js/zamboni/editors-all.js:15611 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:330
 msgid "Average Reviews"
 msgstr ""
 
-#: static/js/zamboni/editors.js:386
+#: static/js/zamboni/editors-all.js:15667 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:386
 msgid "Number of Reviews"
 msgstr ""
 
-#: static/js/zamboni/editors.js:445
+#: static/js/zamboni/editors-all.js:15726 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:445
 msgid "Error loading translation"
 msgstr ""
 
-#: static/js/zamboni/files.js:411 static/js/zamboni/validator.js:261
-msgid "Ignore this message in future updates"
-msgstr ""
-
-#: static/js/zamboni/files.js:417 static/js/zamboni/validator.js:284
-msgid "Severity for automated signing:"
-msgstr ""
-
-#: static/js/zamboni/global.js:410
-msgid "Loading..."
-msgstr ""
-
-#. L10n: {0} is the number of characters left.
-#: static/js/zamboni/global.js:474
-msgid "<b>{0}</b> character left."
-msgid_plural "<b>{0}</b> characters left."
-msgstr[0] ""
-msgstr[1] ""
-
-#: static/js/zamboni/init.js:28
-msgid "This feature is temporarily disabled while we perform website maintenance. Please check back a little later."
-msgstr ""
-
-#: static/js/zamboni/l10n.js:45
-msgid "Remove this localization"
-msgstr ""
-
-#: static/js/zamboni/password-strength.js:20
-msgid "Password strength:"
-msgstr ""
-
-#: static/js/zamboni/password-strength.js:26
-msgid "At least {0} character left."
-msgid_plural "At least {0} characters left."
-msgstr[0] ""
-msgstr[1] ""
-
-#: static/js/zamboni/themes_review.js:176
-msgid "Requested Info"
-msgstr ""
-
-#: static/js/zamboni/themes_review.js:177
-msgid "Flagged"
-msgstr ""
-
-#: static/js/zamboni/themes_review.js:178
-msgid "Duplicate"
-msgstr ""
-
-#: static/js/zamboni/themes_review.js:179
-msgid "Rejected"
-msgstr ""
-
-#: static/js/zamboni/themes_review.js:180
-msgid "Approved"
-msgstr ""
-
-#: static/js/zamboni/themes_review.js:424
-msgid "No results found"
-msgstr ""
-
-#: static/js/zamboni/themes_review_templates.js:31
+#: static/js/zamboni/editors-all.js:15975 static/js/zamboni/editors-min.js:5 static/js/zamboni/themes_review_templates.js:31
 msgid "Theme"
 msgstr ""
 
-#: static/js/zamboni/themes_review_templates.js:33
+#: static/js/zamboni/editors-all.js:15977 static/js/zamboni/editors-min.js:5 static/js/zamboni/themes_review_templates.js:33
 msgid "Reviewer"
 msgstr ""
 
-#: static/js/zamboni/themes_review_templates.js:35
+#: static/js/zamboni/editors-all.js:15979 static/js/zamboni/editors-min.js:5 static/js/zamboni/themes_review_templates.js:35
 msgid "Status"
 msgstr ""
 
-#: static/js/zamboni/validator.js:80
-msgid "All tests passed successfully."
+#: static/js/zamboni/editors-all.js:16196 static/js/zamboni/editors-min.js:5 static/js/zamboni/themes_review.js:176
+msgid "Requested Info"
 msgstr ""
 
-#: static/js/zamboni/validator.js:83 static/js/zamboni/validator.js:478
-msgid "These tests were not run."
+#: static/js/zamboni/editors-all.js:16197 static/js/zamboni/editors-min.js:5 static/js/zamboni/themes_review.js:177
+msgid "Flagged"
 msgstr ""
 
-#: static/js/zamboni/validator.js:131 static/js/zamboni/validator.js:144
-msgid "Tests"
+#: static/js/zamboni/editors-all.js:16198 static/js/zamboni/editors-min.js:5 static/js/zamboni/themes_review.js:178
+msgid "Duplicate"
 msgstr ""
 
-#: static/js/zamboni/validator.js:246 static/js/zamboni/validator.js:575 static/js/zamboni/validator.js:594
-msgid "Error"
+#: static/js/zamboni/editors-all.js:16199 static/js/zamboni/editors-min.js:5 static/js/zamboni/themes_review.js:179
+msgid "Rejected"
 msgstr ""
 
-#: static/js/zamboni/validator.js:247
-msgid "Warning"
+#: static/js/zamboni/editors-all.js:16200 static/js/zamboni/editors-min.js:5 static/js/zamboni/themes_review.js:180
+msgid "Approved"
 msgstr ""
 
-#: static/js/zamboni/validator.js:299
-msgid "Suggestions for passing automated signing:"
+#: static/js/zamboni/editors-all.js:16444 static/js/zamboni/editors-min.js:5 static/js/zamboni/themes_review.js:424
+msgid "No results found"
 msgstr ""
 
-#: static/js/zamboni/validator.js:387
-msgid "Compatibility Tests"
-msgstr ""
-
-#: static/js/zamboni/validator.js:466
-msgid "Add-on failed validation."
-msgstr ""
-
-#: static/js/zamboni/validator.js:468
-msgid "Add-on passed validation."
-msgstr ""
-
-#: static/js/zamboni/validator.js:481
-msgid "{0} error"
-msgid_plural "{0} errors"
-msgstr[0] ""
-msgstr[1] ""
-
-#: static/js/zamboni/validator.js:483
-msgid "{0} warning"
-msgid_plural "{0} warnings"
-msgstr[0] ""
-msgstr[1] ""
-
-#: static/js/zamboni/validator.js:485
-msgid "{0} notice"
-msgid_plural "{0} notices"
-msgstr[0] ""
-msgstr[1] ""
-
-#: static/js/zamboni/validator.js:577
-msgid "Validation task could not complete or completed with errors"
-msgstr ""
-
-#: static/js/zamboni/validator.js:595
-msgid "Internal server error"
-msgstr ""
-
-#: static/js/zamboni/mobile/buttons.js:52
+#: static/js/zamboni/mobile-all.js:15186 static/js/zamboni/mobile/buttons.js:52
 msgid "Not Updated for {0} {1}"
 msgstr ""
 
-#: static/js/zamboni/mobile/buttons.js:53
+#: static/js/zamboni/mobile-all.js:15187 static/js/zamboni/mobile/buttons.js:53
 msgid "Requires Newer Version of {0}"
 msgstr ""
 
-#: static/js/zamboni/mobile/buttons.js:54
+#: static/js/zamboni/mobile-all.js:15188 static/js/zamboni/mobile/buttons.js:54
 msgid "Unreviewed"
 msgstr ""
 
-#: static/js/zamboni/mobile/buttons.js:55
+#: static/js/zamboni/mobile-all.js:15189 static/js/zamboni/mobile/buttons.js:55
 msgid "Experimental <span>(Learn More)</span>"
 msgstr ""
 
-#: static/js/zamboni/mobile/buttons.js:56 static/js/zamboni/mobile/buttons.js:57
+#: static/js/zamboni/mobile-all.js:15190 static/js/zamboni/mobile-all.js:15191 static/js/zamboni/mobile/buttons.js:56 static/js/zamboni/mobile/buttons.js:57
 msgid "Not Available for {0}"
 msgstr ""
 
-#: static/js/zamboni/mobile/buttons.js:58
+#: static/js/zamboni/mobile-all.js:15192 static/js/zamboni/mobile/buttons.js:58
 msgid "Experimental"
 msgstr ""
 
-#: static/js/zamboni/mobile/buttons.js:59
+#: static/js/zamboni/mobile-all.js:15193 static/js/zamboni/mobile/buttons.js:59
 msgid "Themes Require Newer Version of {0}"
 msgstr ""
 
-#: static/js/zamboni/mobile/buttons.js:60
+#: static/js/zamboni/mobile-all.js:15194 static/js/zamboni/mobile/buttons.js:60
 msgid "Themes Require {0}"
 msgstr ""
 
-#: static/js/zamboni/mobile/buttons.js:105
+#: static/js/zamboni/mobile-all.js:15239 static/js/zamboni/mobile/buttons.js:105
 msgid "Installing..."
 msgstr ""
 
-#: static/js/zamboni/mobile/buttons.js:125
+#: static/js/zamboni/mobile-all.js:15259 static/js/zamboni/mobile/buttons.js:125
 msgid "This add-on has been preliminarily reviewed by Mozilla."
 msgstr ""
 
-#: static/js/zamboni/mobile/buttons.js:250
+#: static/js/zamboni/mobile-all.js:15384 static/js/zamboni/mobile/buttons.js:250
 msgid "Keep it"
 msgstr ""
 
-#: static/js/zamboni/mobile/general.js:344
+#: static/js/zamboni/mobile-all.js:16049 static/js/zamboni/mobile-min.js:6 static/js/zamboni/mobile/general.js:344
 msgid "You're trying it on!"
 msgstr ""
 
-#: static/js/zamboni/mobile/general.js:356
+#: static/js/zamboni/mobile-all.js:16061 static/js/zamboni/mobile-min.js:6 static/js/zamboni/mobile/general.js:356
 msgid "Added to Firefox"
 msgstr ""
-

--- a/locale/mn/LC_MESSAGES/django.po
+++ b/locale/mn/LC_MESSAGES/django.po
@@ -6,69 +6,70 @@ msgid ""
 msgstr ""
 "Project-Id-Version: REMORA 0.1\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2016-02-24 21:23+0000\n"
+"POT-Creation-Date: 2016-04-18 15:47+0000\n"
 "PO-Revision-Date: 2013-11-28 12:53+0000\n"
 "Last-Translator: Anonymous Pootle User\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
+"Language: \n"
 "MIME-Version: 1.0\n"
-"Content-Type: text/plain; charset=utf-8\n"
+"Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Generated-By: Babel 2.2.0\n"
 
-#: src/olympia/accounts/views.py:52
+#: src/olympia/accounts/views.py:54
 msgid "Your log in attempt could not be parsed. Please try again."
 msgstr ""
 
-#: src/olympia/accounts/views.py:54
+#: src/olympia/accounts/views.py:56
 msgid "Your Firefox Account could not be found. Please try again."
 msgstr ""
 
-#: src/olympia/accounts/views.py:55
+#: src/olympia/accounts/views.py:57
 msgid "You could not be logged in. Please try again."
 msgstr ""
 
-#: src/olympia/accounts/views.py:57
+#: src/olympia/accounts/views.py:59
 msgid "Your account has already been migrated to Firefox Accounts."
 msgstr ""
 
-#: src/olympia/accounts/views.py:59
+#: src/olympia/accounts/views.py:61
 msgid "Your Firefox Account already exists on this site."
 msgstr ""
 
-#: src/olympia/accounts/views.py:108
+#: src/olympia/accounts/views.py:110
 msgid "Great job!"
 msgstr ""
 
-#: src/olympia/accounts/views.py:109
+#: src/olympia/accounts/views.py:111
 msgid "You can now log in to Add-ons with your Firefox Account."
 msgstr ""
 
-#: src/olympia/accounts/views.py:121
+#: src/olympia/accounts/views.py:123
 msgid "Need help?"
 msgstr ""
 
-#: src/olympia/addons/buttons.py:180
+#: src/olympia/addons/buttons.py:177
 msgid "Download Now"
 msgstr ""
 
-#: src/olympia/addons/buttons.py:182
+#: src/olympia/addons/buttons.py:179
 msgid "Download"
 msgstr ""
 
 #. L10n: please keep &nbsp; in the string so &rarr; does not wrap.
-#: src/olympia/addons/buttons.py:186
+#: src/olympia/addons/buttons.py:183
 msgid "Continue to Download&nbsp;&rarr;"
 msgstr ""
 
-#: src/olympia/addons/buttons.py:202 src/olympia/addons/helpers.py:35 src/olympia/addons/views.py:319 src/olympia/addons/templates/addons/impala/details.html:114
+#: src/olympia/addons/buttons.py:199 src/olympia/addons/helpers.py:35 src/olympia/addons/views.py:333 src/olympia/addons/templates/addons/impala/details.html:111
 #: src/olympia/addons/templates/addons/impala/listing/items.html:17 src/olympia/addons/templates/addons/mobile/home.html:40 src/olympia/amo/templates/amo/side_nav.html:6
-#: src/olympia/amo/templates/amo/side_nav.html:10 src/olympia/amo/templates/amo/site_nav.html:2 src/olympia/amo/templates/amo/site_nav.html:55 src/olympia/bandwagon/views.py:95
-#: src/olympia/browse/views.py:54 src/olympia/browse/views.py:68 src/olympia/browse/views.py:235 src/olympia/browse/templates/browse/impala/category_landing.html:22
+#: src/olympia/amo/templates/amo/side_nav.html:10 src/olympia/amo/templates/amo/site_nav.html:2 src/olympia/amo/templates/amo/site_nav.html:53 src/olympia/bandwagon/views.py:95
+#: src/olympia/browse/views.py:54 src/olympia/browse/views.py:68 src/olympia/browse/views.py:202 src/olympia/browse/templates/browse/impala/category_landing.html:22
 #: src/olympia/browse/templates/browse/personas/mobile/category_landing.html:26
 msgid "Featured"
 msgstr ""
 
-#: src/olympia/addons/buttons.py:221
+#: src/olympia/addons/buttons.py:218
 msgid "Add to {0}"
 msgstr ""
 
@@ -116,39 +117,39 @@ msgid_plural "All tags must be at least {0} characters."
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/olympia/addons/forms.py:234
+#: src/olympia/addons/forms.py:238
 msgid "Categories cannot be changed while your add-on is featured for this application."
 msgstr ""
 
 #. L10n: {0} is the number of categories.
-#: src/olympia/addons/forms.py:238
+#: src/olympia/addons/forms.py:242
 msgid "You can have only {0} category."
 msgid_plural "You can have only {0} categories."
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/olympia/addons/forms.py:246
+#: src/olympia/addons/forms.py:250
 msgid "The miscellaneous category cannot be combined with additional categories."
 msgstr ""
 
-#: src/olympia/addons/forms.py:369
+#: src/olympia/addons/forms.py:374
 #, python-format
 msgid "Before changing your default locale you must have a name, summary, and description in that locale. You are missing %s."
 msgstr ""
 
-#: src/olympia/addons/forms.py:484 src/olympia/addons/forms.py:575
+#: src/olympia/addons/forms.py:455 src/olympia/addons/forms.py:546
 msgid "A license must be selected."
 msgstr ""
 
-#: src/olympia/addons/forms.py:556
+#: src/olympia/addons/forms.py:527
 msgid "Give Your Theme a Name."
 msgstr ""
 
-#: src/olympia/addons/forms.py:562 src/olympia/devhub/templates/devhub/personas/submit.html:53
+#: src/olympia/addons/forms.py:533 src/olympia/devhub/templates/devhub/personas/submit.html:53
 msgid "Describe your Theme."
 msgstr ""
 
-#: src/olympia/addons/forms.py:704
+#: src/olympia/addons/forms.py:675
 msgid "Enter a new author's email address"
 msgstr ""
 
@@ -156,43 +157,43 @@ msgstr ""
 msgid "Not Reviewed"
 msgstr ""
 
-#: src/olympia/addons/models.py:301
+#: src/olympia/addons/models.py:298
 #, fuzzy
 msgid "Users have the option of contributing more or less than this amount."
 msgstr "Users have the option of contributing more or less than this amount."
 
-#: src/olympia/addons/models.py:309
-msgid "Users will always be asked in the Add-ons Manager (Firefox 4 and above)"
+#: src/olympia/addons/models.py:306
+msgid "Users will always be asked in the Add-ons Manager (Firefox 4 and above). Only applies to desktop."
 msgstr ""
 
 # Column name in a table.
-#: src/olympia/addons/models.py:1804 src/olympia/addons/templates/addons/details_box.html:55 src/olympia/devhub/templates/devhub/index.html:92
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:102
+#: src/olympia/addons/models.py:1802 src/olympia/addons/templates/addons/details_box.html:55 src/olympia/devhub/templates/devhub/index.html:92
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:89
 #, fuzzy
 msgid "Listed"
 msgstr "Listed"
 
-#: src/olympia/addons/views.py:320 src/olympia/browse/templates/browse/personas/mobile/category_landing.html:27
+#: src/olympia/addons/views.py:334 src/olympia/browse/templates/browse/personas/mobile/category_landing.html:27
 msgid "Popular"
 msgstr ""
 
-#: src/olympia/addons/views.py:321 src/olympia/browse/views.py:238 src/olympia/browse/views.py:280 src/olympia/browse/views.py:482
+#: src/olympia/addons/views.py:335 src/olympia/browse/views.py:205 src/olympia/browse/views.py:247 src/olympia/browse/views.py:449
 #, fuzzy
 msgid "Recently Added"
 msgstr "Recently Added"
 
-#: src/olympia/addons/views.py:322 src/olympia/bandwagon/views.py:99 src/olympia/browse/views.py:60 src/olympia/browse/views.py:71 src/olympia/search/forms.py:16 src/olympia/search/forms.py:91
+#: src/olympia/addons/views.py:336 src/olympia/bandwagon/views.py:99 src/olympia/browse/views.py:60 src/olympia/browse/views.py:71 src/olympia/search/forms.py:16 src/olympia/search/forms.py:91
 msgid "Recently Updated"
 msgstr ""
 
 # %1 is an add-on name.
 #. l10n: {0} is the addon name
-#: src/olympia/addons/views.py:520
+#: src/olympia/addons/views.py:534
 #, fuzzy
 msgid "Contribution for {0}"
 msgstr "Contribution for {0}"
 
-#: src/olympia/addons/views.py:613
+#: src/olympia/addons/views.py:627
 msgid "Abuse reported."
 msgstr ""
 
@@ -264,9 +265,9 @@ msgstr "Contribute"
 #: src/olympia/devhub/templates/devhub/addons/ajax_compat_update.html:36 src/olympia/devhub/templates/devhub/addons/profile.html:44 src/olympia/devhub/templates/devhub/addons/edit/admin.html:101
 #: src/olympia/devhub/templates/devhub/addons/edit/basic.html:152 src/olympia/devhub/templates/devhub/addons/edit/details.html:85 src/olympia/devhub/templates/devhub/addons/edit/support.html:67
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:166 src/olympia/devhub/templates/devhub/addons/forms_shared/media.html:149
-#: src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:44 src/olympia/devhub/templates/devhub/versions/add_file_modal.html:78 src/olympia/devhub/templates/devhub/versions/edit.html:139
-#: src/olympia/devhub/templates/devhub/versions/list.html:242 src/olympia/devhub/templates/devhub/versions/list.html:276 src/olympia/devhub/templates/devhub/versions/list.html:317
-#: src/olympia/devhub/templates/devhub/versions/list.html:351 src/olympia/reviews/templates/reviews/edit_review.html:16 src/olympia/translations/templates/translations/trans-menu.html:50
+#: src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:43 src/olympia/devhub/templates/devhub/versions/add_file_modal.html:58 src/olympia/devhub/templates/devhub/versions/edit.html:139
+#: src/olympia/devhub/templates/devhub/versions/list.html:239 src/olympia/devhub/templates/devhub/versions/list.html:281 src/olympia/devhub/templates/devhub/versions/list.html:315
+#: src/olympia/devhub/templates/devhub/versions/list.html:349 src/olympia/reviews/templates/reviews/edit_review.html:16 src/olympia/translations/templates/translations/trans-menu.html:50
 #: src/olympia/translations/templates/translations/trans-menu.html:62
 #, fuzzy
 msgid "or"
@@ -379,7 +380,7 @@ msgid "Add-on Information for {0}"
 msgstr ""
 
 #: src/olympia/addons/templates/addons/details_box.html:30 src/olympia/addons/templates/addons/persona_detail_table.html:3 src/olympia/addons/templates/addons/mobile/details.html:63
-#: src/olympia/addons/templates/addons/mobile/persona_detail_table.html:7 src/olympia/browse/views.py:459 src/olympia/devhub/views.py:75
+#: src/olympia/addons/templates/addons/mobile/persona_detail_table.html:7 src/olympia/browse/views.py:426 src/olympia/devhub/views.py:73
 #, fuzzy
 msgid "Updated"
 msgstr "Updated"
@@ -400,11 +401,11 @@ msgstr "Works with"
 msgid "Visibility"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/details_box.html:57 src/olympia/devhub/templates/devhub/index.html:94 src/olympia/devhub/templates/devhub/includes/addon_details.html:104
+#: src/olympia/addons/templates/addons/details_box.html:57 src/olympia/devhub/templates/devhub/index.html:94 src/olympia/devhub/templates/devhub/includes/addon_details.html:91
 msgid "Hidden"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/details_box.html:59 src/olympia/devhub/templates/devhub/index.html:96 src/olympia/devhub/templates/devhub/includes/addon_details.html:106
+#: src/olympia/addons/templates/addons/details_box.html:59 src/olympia/devhub/templates/devhub/index.html:96 src/olympia/devhub/templates/devhub/includes/addon_details.html:93
 msgid "Unlisted"
 msgstr ""
 
@@ -413,14 +414,14 @@ msgid "Required Add-ons"
 msgstr ""
 
 # 100%
-#: src/olympia/addons/templates/addons/details_box.html:81 src/olympia/addons/templates/addons/persona_detail_table.html:15 src/olympia/browse/views.py:462 src/olympia/devhub/views.py:78
-#: src/olympia/devhub/views.py:85 src/olympia/discovery/templates/discovery/addons/detail.html:57 src/olympia/reviews/forms.py:62 src/olympia/reviews/templates/reviews/add.html:57
+#: src/olympia/addons/templates/addons/details_box.html:81 src/olympia/addons/templates/addons/persona_detail_table.html:15 src/olympia/browse/views.py:429 src/olympia/devhub/views.py:76
+#: src/olympia/devhub/views.py:83 src/olympia/discovery/templates/discovery/addons/detail.html:57 src/olympia/reviews/forms.py:62 src/olympia/reviews/templates/reviews/add.html:57
 #: src/olympia/reviews/templates/reviews/mobile/review_list.html:18
 msgid "Rating"
 msgstr "Үнэлгээгээр нь"
 
 # 100%
-#: src/olympia/addons/templates/addons/details_box.html:85 src/olympia/browse/views.py:461 src/olympia/devhub/views.py:77 src/olympia/devhub/views.py:84
+#: src/olympia/addons/templates/addons/details_box.html:85 src/olympia/browse/views.py:428 src/olympia/devhub/views.py:75 src/olympia/devhub/views.py:82
 #: src/olympia/stats/templates/stats/addon_report_menu.html:8 src/olympia/stats/templates/stats/collection_report_menu.html:18
 msgid "Downloads"
 msgstr "Татаж авалт"
@@ -440,7 +441,7 @@ msgstr ""
 
 #. The Privacy Policy for this add-on.
 #: src/olympia/addons/templates/addons/details_box.html:121 src/olympia/addons/templates/addons/privacy.html:19 src/olympia/addons/templates/addons/privacy.html:23
-#: src/olympia/addons/templates/addons/impala/button.html:43 src/olympia/addons/templates/addons/impala/details.html:307 src/olympia/devhub/templates/devhub/includes/policy_form.html:20
+#: src/olympia/addons/templates/addons/impala/button.html:43 src/olympia/addons/templates/addons/impala/details.html:312 src/olympia/devhub/templates/devhub/includes/policy_form.html:23
 #: src/olympia/templates/mobile/base_addons.html:87
 msgid "Privacy Policy"
 msgstr ""
@@ -467,7 +468,7 @@ msgstr "Image Gallery"
 msgid "Developer Comments"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/details_box.html:199 src/olympia/addons/templates/addons/impala/details.html:259
+#: src/olympia/addons/templates/addons/details_box.html:199 src/olympia/addons/templates/addons/impala/details.html:264
 msgid "Development Channel"
 msgstr ""
 
@@ -487,7 +488,7 @@ msgid ""
 "developer. To stop receiving development updates, reinstall the default version from the link above."
 msgstr ""
 
-#: src/olympia/addons/templates/addons/details_box.html:220 src/olympia/addons/templates/addons/impala/details.html:278
+#: src/olympia/addons/templates/addons/details_box.html:220 src/olympia/addons/templates/addons/impala/details.html:283
 msgid "Version {0}:"
 msgstr ""
 
@@ -506,7 +507,7 @@ msgid "End-User License Agreement for {0}"
 msgstr ""
 
 #: src/olympia/addons/templates/addons/eula.html:17 src/olympia/addons/templates/addons/eula.html:21 src/olympia/addons/templates/addons/impala/button.html:48
-#: src/olympia/addons/templates/addons/impala/details.html:316 src/olympia/devhub/templates/devhub/includes/policy_form.html:3 src/olympia/discovery/templates/discovery/addons/eula.html:11
+#: src/olympia/addons/templates/addons/impala/details.html:321 src/olympia/devhub/templates/devhub/includes/policy_form.html:3 src/olympia/discovery/templates/discovery/addons/eula.html:11
 #, fuzzy
 msgid "End-User License Agreement"
 msgstr "End-User License Agreement"
@@ -526,7 +527,7 @@ msgstr ""
 msgid "Add-ons for {0}"
 msgstr "{0} нэмэгдлүүд"
 
-#: src/olympia/addons/templates/addons/home.html:10 src/olympia/addons/templates/addons/home.html:51 src/olympia/browse/templates/browse/impala/base_listing.html:11
+#: src/olympia/addons/templates/addons/home.html:10 src/olympia/addons/templates/addons/home.html:53 src/olympia/browse/templates/browse/impala/base_listing.html:11
 msgid "Featured Extensions"
 msgstr ""
 
@@ -534,29 +535,29 @@ msgstr ""
 msgid "Popular Extensions"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/home.html:42 src/olympia/amo/templates/amo/side_nav.html:3 src/olympia/amo/templates/amo/side_nav.html:11 src/olympia/amo/templates/amo/site_nav.html:3
-#: src/olympia/amo/templates/amo/site_nav.html:25 src/olympia/browse/views.py:236 src/olympia/browse/views.py:281 src/olympia/browse/views.py:481
+#: src/olympia/addons/templates/addons/home.html:44 src/olympia/amo/templates/amo/side_nav.html:3 src/olympia/amo/templates/amo/side_nav.html:11 src/olympia/amo/templates/amo/site_nav.html:3
+#: src/olympia/amo/templates/amo/site_nav.html:25 src/olympia/browse/views.py:203 src/olympia/browse/views.py:248 src/olympia/browse/views.py:448
 msgid "Most Popular"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/home.html:43
+#: src/olympia/addons/templates/addons/home.html:45
 msgid "All »"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/home.html:52 src/olympia/addons/templates/addons/home.html:61 src/olympia/addons/templates/addons/home.html:70 src/olympia/addons/templates/addons/home.html:78
+#: src/olympia/addons/templates/addons/home.html:54 src/olympia/addons/templates/addons/home.html:63 src/olympia/addons/templates/addons/home.html:72 src/olympia/addons/templates/addons/home.html:80
 #: src/olympia/browse/templates/browse/impala/category_landing.html:36
 msgid "See all »"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/home.html:60
+#: src/olympia/addons/templates/addons/home.html:62
 msgid "Up &amp; Coming Extensions"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/home.html:69 src/olympia/browse/templates/browse/personas/category_landing.html:61 src/olympia/discovery/templates/discovery/pane.html:74
+#: src/olympia/addons/templates/addons/home.html:71 src/olympia/browse/templates/browse/personas/category_landing.html:61 src/olympia/discovery/templates/discovery/pane.html:74
 msgid "Featured Themes"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/home.html:77 src/olympia/bandwagon/templates/bandwagon/impala/collection_listing.html:5
+#: src/olympia/addons/templates/addons/home.html:79 src/olympia/bandwagon/templates/bandwagon/impala/collection_listing.html:5
 msgid "Featured Collections"
 msgstr ""
 
@@ -574,7 +575,7 @@ msgid "Updated {0}"
 msgstr ""
 
 #. {0} is a date.
-#: src/olympia/addons/templates/addons/macros.html:10 src/olympia/addons/templates/addons/macros.html:69 src/olympia/addons/templates/addons/persona_preview.html:21
+#: src/olympia/addons/templates/addons/macros.html:10 src/olympia/addons/templates/addons/macros.html:69 src/olympia/addons/templates/addons/persona_preview.html:22
 #: src/olympia/addons/templates/addons/listing/items_mobile.html:44 src/olympia/addons/templates/addons/listing/macros.html:39
 #: src/olympia/bandwagon/templates/bandwagon/collection_listing_items.html:37 src/olympia/bandwagon/templates/bandwagon/impala/collection_listing_items.html:37
 msgid "Added {0}"
@@ -595,15 +596,14 @@ msgstr[0] ""
 msgstr[1] ""
 
 #. {0} is the number of downloads.
-#: src/olympia/addons/templates/addons/macros.html:53 src/olympia/addons/templates/addons/impala/details.html:61
+#: src/olympia/addons/templates/addons/macros.html:53 src/olympia/addons/templates/addons/impala/details.html:59
 msgid "{0} weekly download"
 msgid_plural "{0} weekly downloads"
 msgstr[0] ""
 msgstr[1] ""
 
 #. {0} is the number of users.
-#: src/olympia/addons/templates/addons/macros.html:61 src/olympia/addons/templates/addons/impala/details.html:54 src/olympia/compat/templates/compat/index.html:71
-#: src/olympia/zadmin/templates/zadmin/compat.html:67
+#: src/olympia/addons/templates/addons/macros.html:61 src/olympia/addons/templates/addons/impala/details.html:52 src/olympia/zadmin/templates/zadmin/compat.html:67
 msgid "{0} user"
 msgid_plural "{0} users"
 msgstr[0] ""
@@ -621,7 +621,7 @@ msgstr ""
 msgid "Return to the addon."
 msgstr ""
 
-#: src/olympia/addons/templates/addons/persona_detail.html:17 src/olympia/addons/templates/addons/impala/details.html:106 src/olympia/addons/templates/addons/mobile/details.html:23
+#: src/olympia/addons/templates/addons/persona_detail.html:17 src/olympia/addons/templates/addons/impala/details.html:103 src/olympia/addons/templates/addons/mobile/details.html:23
 #: src/olympia/addons/templates/addons/mobile/persona_detail.html:21 src/olympia/discovery/templates/discovery/addons/base.html:27 src/olympia/editors/templates/editors/review.html:31
 msgid "by"
 msgstr "зохиогч"
@@ -666,34 +666,35 @@ msgstr ""
 msgid "License"
 msgstr "License"
 
-#: src/olympia/addons/templates/addons/persona_preview.html:12 src/olympia/constants/base.py:48
+#: src/olympia/addons/templates/addons/persona_preview.html:13 src/olympia/constants/base.py:48
 msgid "Awaiting Review"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/persona_preview.html:14 src/olympia/amo/log.py:180 src/olympia/constants/base.py:42 src/olympia/editors/helpers.py:62
+#: src/olympia/addons/templates/addons/persona_preview.html:15 src/olympia/amo/log.py:180 src/olympia/constants/base.py:42 src/olympia/editors/helpers.py:62
 msgid "Rejected"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/persona_preview.html:16 src/olympia/amo/log.py:159
+#: src/olympia/addons/templates/addons/persona_preview.html:17 src/olympia/amo/log.py:159
 msgid "Approved"
 msgstr ""
 
 #. {0} is the number of users.
-#: src/olympia/addons/templates/addons/persona_preview.html:26 src/olympia/addons/templates/addons/listing/items_mobile.html:36 src/olympia/addons/templates/addons/listing/macros.html:31
+#: src/olympia/addons/templates/addons/persona_preview.html:27 src/olympia/addons/templates/addons/listing/items_mobile.html:36 src/olympia/addons/templates/addons/listing/macros.html:31
 msgid "<strong>{0}</strong> user"
 msgid_plural "<strong>{0}</strong> users"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/olympia/addons/templates/addons/persona_preview.html:40
+#: src/olympia/addons/templates/addons/persona_preview.html:41
 msgid "Hover to Preview"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/persona_preview.html:46 src/olympia/addons/templates/addons/persona_preview.html:48 src/olympia/reviews/templates/reviews/add.html:15
+#: src/olympia/addons/templates/addons/persona_preview.html:47 src/olympia/addons/templates/addons/persona_preview.html:49 src/olympia/addons/templates/addons/persona_preview.html:97
+#: src/olympia/reviews/templates/reviews/add.html:15
 msgid "Add"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/persona_preview.html:57 src/olympia/bandwagon/templates/bandwagon/ajax_new.html:16 src/olympia/bandwagon/templates/bandwagon/edit.html:19
+#: src/olympia/addons/templates/addons/persona_preview.html:58 src/olympia/bandwagon/templates/bandwagon/ajax_new.html:16 src/olympia/bandwagon/templates/bandwagon/edit.html:19
 #: src/olympia/bandwagon/templates/bandwagon/includes/addedit.html:19 src/olympia/devhub/templates/devhub/addons/edit/admin.html:13 src/olympia/devhub/templates/devhub/addons/edit/basic.html:10
 #: src/olympia/devhub/templates/devhub/addons/edit/details.html:8 src/olympia/devhub/templates/devhub/addons/edit/media.html:6 src/olympia/devhub/templates/devhub/addons/edit/support.html:8
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:9 src/olympia/devhub/templates/devhub/addons/submit/describe.html:29 src/olympia/editors/templates/editors/review.html:257
@@ -702,21 +703,21 @@ msgstr ""
 
 #. For datetime formatting, see the table on
 #. http://docs.python.org/library/datetime.html#strftime-and-strptime-behavior
-#: src/olympia/addons/templates/addons/persona_preview.html:66
+#: src/olympia/addons/templates/addons/persona_preview.html:67
 #, python-format
 msgid "%%Y-%%m-%%d"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/persona_preview.html:67
+#: src/olympia/addons/templates/addons/persona_preview.html:68
 msgid "by {0} on {1}"
 msgstr "{1}-ны өдөр {0}-р"
 
-#: src/olympia/addons/templates/addons/persona_preview.html:75 src/olympia/reviews/helpers.py:17 src/olympia/reviews/templates/reviews/review_list.html:63
+#: src/olympia/addons/templates/addons/persona_preview.html:76 src/olympia/reviews/helpers.py:17 src/olympia/reviews/templates/reviews/review_list.html:63
 #: src/olympia/reviews/templates/reviews/reviews_link.html:21 src/olympia/reviews/templates/reviews/impala/reviews_link.html:16
 msgid "Not yet rated"
 msgstr "Одоогоор үнэлгээ аваагүй"
 
-#: src/olympia/addons/templates/addons/persona_preview.html:78
+#: src/olympia/addons/templates/addons/persona_preview.html:79
 msgid "<b>{0}</b> users"
 msgstr ""
 
@@ -729,7 +730,7 @@ msgid "Learn more about Firefox"
 msgstr ""
 
 #: src/olympia/addons/templates/addons/popups.html:22
-msgid "or <b><a class=\"installer\" href=\"{url}\">download anyway</a></b>"
+msgid "or <b><a class=\"button installer\" href=\"{url}\">download anyway</a></b>"
 msgstr ""
 
 #: src/olympia/addons/templates/addons/popups.html:26
@@ -828,7 +829,7 @@ msgid ""
 msgstr ""
 
 #: src/olympia/addons/templates/addons/report_abuse.html:6 src/olympia/addons/templates/addons/report_abuse_full.html:10 src/olympia/addons/templates/addons/impala/details-more.html:23
-#: src/olympia/addons/templates/addons/impala/details.html:328
+#: src/olympia/addons/templates/addons/impala/details.html:333
 msgid "Report Abuse"
 msgstr ""
 
@@ -847,9 +848,9 @@ msgstr ""
 #: src/olympia/devhub/templates/devhub/addons/ajax_compat_update.html:36 src/olympia/devhub/templates/devhub/addons/profile.html:44 src/olympia/devhub/templates/devhub/addons/edit/admin.html:104
 #: src/olympia/devhub/templates/devhub/addons/edit/basic.html:155 src/olympia/devhub/templates/devhub/addons/edit/details.html:88 src/olympia/devhub/templates/devhub/addons/edit/support.html:70
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:169 src/olympia/devhub/templates/devhub/addons/forms_shared/media.html:152
-#: src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:44 src/olympia/devhub/templates/devhub/personas/edit.html:222 src/olympia/devhub/templates/devhub/versions/add_file_modal.html:79
-#: src/olympia/devhub/templates/devhub/versions/edit.html:140 src/olympia/devhub/templates/devhub/versions/list.html:208 src/olympia/devhub/templates/devhub/versions/list.html:242
-#: src/olympia/devhub/templates/devhub/versions/list.html:276 src/olympia/devhub/templates/devhub/versions/list.html:317 src/olympia/reviews/templates/reviews/edit_review.html:16
+#: src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:43 src/olympia/devhub/templates/devhub/personas/edit.html:222 src/olympia/devhub/templates/devhub/versions/add_file_modal.html:59
+#: src/olympia/devhub/templates/devhub/versions/edit.html:140 src/olympia/devhub/templates/devhub/versions/list.html:208 src/olympia/devhub/templates/devhub/versions/list.html:239
+#: src/olympia/devhub/templates/devhub/versions/list.html:281 src/olympia/devhub/templates/devhub/versions/list.html:315 src/olympia/reviews/templates/reviews/edit_review.html:16
 #: src/olympia/translations/templates/translations/trans-menu.html:50 src/olympia/translations/templates/translations/trans-menu.html:62 src/olympia/zadmin/templates/zadmin/validation.html:105
 msgid "Cancel"
 msgstr ""
@@ -897,7 +898,7 @@ msgstr ""
 msgid "Review Guidelines"
 msgstr "Review Guidelines"
 
-#: src/olympia/addons/templates/addons/review_list_box.html:5 src/olympia/addons/templates/addons/impala/details-more.html:27 src/olympia/editors/helpers.py:921
+#: src/olympia/addons/templates/addons/review_list_box.html:5 src/olympia/addons/templates/addons/impala/details-more.html:27 src/olympia/editors/helpers.py:1001
 #: src/olympia/reviews/templates/reviews/add.html:14 src/olympia/reviews/templates/reviews/reply.html:14 src/olympia/reviews/templates/reviews/review_list.html:19
 #: src/olympia/reviews/templates/reviews/mobile/review_list.html:26
 msgid "Reviews"
@@ -988,31 +989,31 @@ msgid_plural "Other add-ons by these authors"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/olympia/addons/templates/addons/impala/details.html:41
+#: src/olympia/addons/templates/addons/impala/details.html:39
 #, python-format
 msgid "<span itemprop=\"ratingCount\">%(num)s</span> user review"
 msgid_plural "<span itemprop=\"ratingCount\">%(num)s</span> user reviews"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/olympia/addons/templates/addons/impala/details.html:69
+#: src/olympia/addons/templates/addons/impala/details.html:66
 msgid "View statistics"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/impala/details.html:84
+#: src/olympia/addons/templates/addons/impala/details.html:81
 msgid "Manage"
 msgstr ""
 
 #. {0} is an add-on name.
-#: src/olympia/addons/templates/addons/impala/details.html:96
+#: src/olympia/addons/templates/addons/impala/details.html:93
 msgid "Icon of {0}"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/impala/details.html:103 src/olympia/addons/templates/addons/impala/listing/items.html:14
+#: src/olympia/addons/templates/addons/impala/details.html:100 src/olympia/addons/templates/addons/impala/listing/items.html:14
 msgid "No Restart"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/impala/details.html:127
+#: src/olympia/addons/templates/addons/impala/details.html:124
 #, python-format
 msgid "Meet the Developer: <a href=\"%(url)s\">%(name)s</a>"
 msgid_plural "<a href=\"%(url)s\">Meet the Developers</a>"
@@ -1020,90 +1021,90 @@ msgstr[0] ""
 msgstr[1] ""
 
 # {0} is an add-on name.
-#: src/olympia/addons/templates/addons/impala/details.html:137
+#: src/olympia/addons/templates/addons/impala/details.html:134
 #, fuzzy
 msgid "Learn why {0} was created and find out what's next for this add-on."
 msgstr "Learn why {0} was created and find out what's next for this add-on."
 
 #. {0} is an index.
-#: src/olympia/addons/templates/addons/impala/details.html:156
+#: src/olympia/addons/templates/addons/impala/details.html:161
 msgid "Add-on screenshot #{0}"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/impala/details.html:182
+#: src/olympia/addons/templates/addons/impala/details.html:187
 msgid "Add-on home page"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/impala/details.html:185
+#: src/olympia/addons/templates/addons/impala/details.html:190
 msgid "Support site"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/impala/details.html:189
+#: src/olympia/addons/templates/addons/impala/details.html:194
 msgid "Support E-mail"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/impala/details.html:194 src/olympia/devhub/models.py:378 src/olympia/devhub/templates/devhub/versions/list.html:12
+#: src/olympia/addons/templates/addons/impala/details.html:199 src/olympia/devhub/models.py:378 src/olympia/devhub/templates/devhub/versions/list.html:12
 #: src/olympia/versions/templates/versions/version.html:6 src/olympia/versions/templates/versions/mobile/version.html:6
 msgid "Version {0}"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/impala/details.html:194
+#: src/olympia/addons/templates/addons/impala/details.html:199
 msgid "Info"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/impala/details.html:195 src/olympia/devhub/templates/devhub/includes/addon_details.html:129
+#: src/olympia/addons/templates/addons/impala/details.html:200 src/olympia/devhub/templates/devhub/includes/addon_details.html:116
 msgid "Last Updated:"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/impala/details.html:200
+#: src/olympia/addons/templates/addons/impala/details.html:205
 #, python-format
 msgid "Released under <a target=\"_blank\" href=\"%(url)s\">%(name)s</a>"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/impala/details.html:201 src/olympia/addons/templates/addons/impala/details.html:206 src/olympia/amo/helpers.py:398 src/olympia/devhub/forms.py:142
+#: src/olympia/addons/templates/addons/impala/details.html:206 src/olympia/addons/templates/addons/impala/details.html:211 src/olympia/amo/helpers.py:398 src/olympia/devhub/forms.py:142
 #: src/olympia/devhub/forms.py:173 src/olympia/versions/templates/versions/version.html:40 src/olympia/versions/templates/versions/version.html:45
 #, fuzzy
 msgid "Custom License"
 msgstr "Custom License"
 
-#: src/olympia/addons/templates/addons/impala/details.html:205
+#: src/olympia/addons/templates/addons/impala/details.html:210
 #, python-format
 msgid "Released under <a href=\"%(url)s\">%(name)s</a>"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/impala/details.html:217
+#: src/olympia/addons/templates/addons/impala/details.html:222
 msgid "About this Add-on"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/impala/details.html:233
+#: src/olympia/addons/templates/addons/impala/details.html:238
 msgid "Developer’s Comments"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/impala/details.html:243
+#: src/olympia/addons/templates/addons/impala/details.html:248
 msgid "Version Information"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/impala/details.html:250
+#: src/olympia/addons/templates/addons/impala/details.html:255
 msgid "See complete version history"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/impala/details.html:262
+#: src/olympia/addons/templates/addons/impala/details.html:267
 msgid ""
 "The Development Channel lets you test an experimental new version of this add-on before it's released to the general public. Once you install the development version, you will continue to get "
 "updates from this channel. To stop receiving development updates, reinstall the default version from the link above."
 msgstr ""
 
-#: src/olympia/addons/templates/addons/impala/details.html:272
+#: src/olympia/addons/templates/addons/impala/details.html:277
 msgid "<strong>Caution:</strong> Development versions of this add-on have not been reviewed by Mozilla."
 msgstr ""
 
-#: src/olympia/addons/templates/addons/impala/details.html:287
+#: src/olympia/addons/templates/addons/impala/details.html:292
 msgid "See complete development channel history"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/impala/details.html:306 src/olympia/addons/templates/addons/impala/details.html:315 src/olympia/addons/templates/addons/impala/details.html:327
+#: src/olympia/addons/templates/addons/impala/details.html:311 src/olympia/addons/templates/addons/impala/details.html:320 src/olympia/addons/templates/addons/impala/details.html:332
 #: src/olympia/addons/templates/addons/impala/review_add_box.html:4 src/olympia/stats/templates/stats/popup.html:2 src/olympia/stats/templates/stats/popup.html:8
-#: src/olympia/stats/templates/stats/stats.html:202 src/olympia/users/templates/users/profile.html:119
+#: src/olympia/stats/templates/stats/stats.html:204 src/olympia/users/templates/users/profile.html:119
 msgid "close"
 msgstr ""
 
@@ -1167,15 +1168,11 @@ msgstr ""
 msgid "Source Code License"
 msgstr "Source Code License"
 
-#: src/olympia/addons/templates/addons/impala/persona_grid.html:16 src/olympia/addons/templates/addons/impala/toplist.html:6
-msgid "{0} users"
-msgstr ""
-
 #: src/olympia/addons/templates/addons/impala/review_list_box.html:19 src/olympia/reviews/templates/reviews/review.html:40
 msgid "permalink"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/impala/review_list_box.html:23 src/olympia/editors/templates/editors/queue.html:98 src/olympia/reviews/templates/reviews/review.html:44
+#: src/olympia/addons/templates/addons/impala/review_list_box.html:23 src/olympia/editors/templates/editors/queue.html:104 src/olympia/reviews/templates/reviews/review.html:44
 msgid "translate"
 msgstr ""
 
@@ -1194,6 +1191,10 @@ msgstr ""
 msgid "Be the first!"
 msgstr ""
 
+#: src/olympia/addons/templates/addons/impala/toplist.html:6
+msgid "{0} users"
+msgstr ""
+
 #: src/olympia/addons/templates/addons/impala/listing/sorter.html:14 src/olympia/devhub/templates/devhub/addons/listing/item_actions.html:49
 msgid "More"
 msgstr ""
@@ -1206,7 +1207,7 @@ msgstr ""
 msgid "My Add-ons"
 msgstr "Миний нэмэгдлүүд"
 
-#: src/olympia/addons/templates/addons/includes/dashboard_tabs.html:6 src/olympia/amo/context_processors.py:51
+#: src/olympia/addons/templates/addons/includes/dashboard_tabs.html:6 src/olympia/amo/context_processors.py:50
 msgid "My Themes"
 msgstr ""
 
@@ -1261,7 +1262,7 @@ msgstr ""
 msgid "Weekly Downloads"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/mobile/details.html:99 src/olympia/compat/templates/compat/reporter_detail.html:46 src/olympia/devhub/forms.py:787
+#: src/olympia/addons/templates/addons/mobile/details.html:99 src/olympia/compat/templates/compat/reporter_detail.html:46 src/olympia/devhub/forms.py:788
 #: src/olympia/devhub/templates/devhub/versions/list.html:163
 #, fuzzy
 msgid "Version"
@@ -1348,7 +1349,7 @@ msgstr ""
 #: src/olympia/browse/templates/browse/personas/category_landing.html:21 src/olympia/browse/templates/browse/personas/category_landing.html:23
 #: src/olympia/browse/templates/browse/personas/category_landing.html:38 src/olympia/browse/templates/browse/personas/grid.html:7 src/olympia/browse/templates/browse/personas/grid.html:11
 #: src/olympia/browse/templates/browse/personas/mobile/base.html:7 src/olympia/browse/templates/browse/personas/mobile/category_landing.html:19 src/olympia/constants/base.py:180
-#: src/olympia/devhub/templates/devhub/personas/submit.html:13 src/olympia/editors/helpers.py:105 src/olympia/editors/templates/editors/base.html:26
+#: src/olympia/devhub/templates/devhub/personas/submit.html:13 src/olympia/editors/helpers.py:107 src/olympia/editors/templates/editors/base.html:26
 #: src/olympia/editors/templates/editors/performance.html:73 src/olympia/search/templates/search/personas.html:39 src/olympia/templates/menu_links.html:9
 msgid "Themes"
 msgstr ""
@@ -1370,7 +1371,7 @@ msgid "Highest Rated"
 msgstr ""
 
 # 100%
-#: src/olympia/addons/templates/addons/mobile/home.html:74 src/olympia/amo/templates/amo/side_nav.html:5 src/olympia/amo/templates/amo/site_nav.html:27 src/olympia/amo/templates/amo/site_nav.html:57
+#: src/olympia/addons/templates/addons/mobile/home.html:74 src/olympia/amo/templates/amo/side_nav.html:5 src/olympia/amo/templates/amo/site_nav.html:27 src/olympia/amo/templates/amo/site_nav.html:55
 #: src/olympia/bandwagon/views.py:97 src/olympia/browse/views.py:57 src/olympia/browse/views.py:67 src/olympia/browse/templates/browse/personas/mobile/category_landing.html:65
 #: src/olympia/search/forms.py:15 src/olympia/search/forms.py:87
 msgid "Newest"
@@ -1384,94 +1385,94 @@ msgstr ""
 msgid "Theme Info &raquo;"
 msgstr ""
 
-#: src/olympia/amo/context_processors.py:39 src/olympia/devhub/templates/devhub/nav.html:43
+#: src/olympia/amo/context_processors.py:37 src/olympia/devhub/templates/devhub/nav.html:43
 #, fuzzy
 msgid "Tools"
 msgstr "Tools"
 
-#: src/olympia/amo/context_processors.py:48 src/olympia/discovery/templates/discovery/pane_account.html:8 src/olympia/users/templates/users/includes/navigation.html:2
+#: src/olympia/amo/context_processors.py:47 src/olympia/discovery/templates/discovery/pane_account.html:8 src/olympia/users/templates/users/includes/navigation.html:2
 msgid "My Profile"
 msgstr ""
 
-#: src/olympia/amo/context_processors.py:54 src/olympia/users/templates/users/edit.html:5 src/olympia/users/templates/users/includes/navigation.html:3
+#: src/olympia/amo/context_processors.py:53 src/olympia/users/templates/users/edit.html:5 src/olympia/users/templates/users/includes/navigation.html:3
 msgid "Account Settings"
 msgstr ""
 
-#: src/olympia/amo/context_processors.py:57 src/olympia/discovery/templates/discovery/pane_account.html:11 src/olympia/users/templates/users/profile.html:83
+#: src/olympia/amo/context_processors.py:56 src/olympia/discovery/templates/discovery/pane_account.html:11 src/olympia/users/templates/users/profile.html:83
 #: src/olympia/users/templates/users/includes/navigation.html:4
 #, fuzzy
 msgid "My Collections"
 msgstr "My Collections"
 
-#: src/olympia/amo/context_processors.py:62 src/olympia/discovery/templates/discovery/pane_account.html:10 src/olympia/users/templates/users/includes/navigation.html:7
+#: src/olympia/amo/context_processors.py:61 src/olympia/discovery/templates/discovery/pane_account.html:10 src/olympia/users/templates/users/includes/navigation.html:7
 #, fuzzy
 msgid "My Favorites"
 msgstr "My Favorites"
 
-#: src/olympia/amo/context_processors.py:67 src/olympia/discovery/templates/discovery/pane_account.html:13 src/olympia/templates/impala/user_login.html:14
+#: src/olympia/amo/context_processors.py:66 src/olympia/discovery/templates/discovery/pane_account.html:13 src/olympia/templates/impala/user_login.html:14
 #: src/olympia/templates/mobile/header_auth.html:5
 msgid "Log out"
 msgstr "Гарах"
 
-#: src/olympia/amo/context_processors.py:72 src/olympia/devhub/templates/devhub/addons/dashboard.html:4
+#: src/olympia/amo/context_processors.py:71 src/olympia/devhub/templates/devhub/addons/dashboard.html:4
 msgid "Manage My Submissions"
 msgstr ""
 
-#: src/olympia/amo/context_processors.py:75 src/olympia/devhub/templates/devhub/nav.html:27 src/olympia/devhub/templates/devhub/addons/dashboard.html:25
+#: src/olympia/amo/context_processors.py:74 src/olympia/devhub/templates/devhub/nav.html:27 src/olympia/devhub/templates/devhub/addons/dashboard.html:25
 #: src/olympia/devhub/templates/devhub/addons/submit/base.html:4
 msgid "Submit a New Add-on"
 msgstr ""
 
-#: src/olympia/amo/context_processors.py:77 src/olympia/browse/templates/browse/personas/base.html:50 src/olympia/devhub/templates/devhub/index.html:24
+#: src/olympia/amo/context_processors.py:76 src/olympia/browse/templates/browse/personas/base.html:50 src/olympia/devhub/templates/devhub/index.html:24
 #: src/olympia/devhub/templates/devhub/addons/dashboard.html:29
 msgid "Submit a New Theme"
 msgstr ""
 
-#: src/olympia/amo/context_processors.py:79 src/olympia/amo/templates/amo/site_nav.html:87 src/olympia/devhub/helpers.py:36 src/olympia/devhub/helpers.py:68 src/olympia/devhub/helpers.py:102
+#: src/olympia/amo/context_processors.py:78 src/olympia/amo/templates/amo/site_nav.html:85 src/olympia/devhub/helpers.py:36 src/olympia/devhub/helpers.py:68 src/olympia/devhub/helpers.py:102
 #: src/olympia/templates/footer.html:6 src/olympia/templates/menu_links.html:14
 msgid "Developer Hub"
 msgstr ""
 
-#: src/olympia/amo/context_processors.py:83 src/olympia/devhub/views.py:1792
+#: src/olympia/amo/context_processors.py:81 src/olympia/devhub/views.py:1796
 msgid "Manage API Keys"
 msgstr ""
 
-#: src/olympia/amo/context_processors.py:88 src/olympia/editors/helpers.py:82 src/olympia/editors/helpers.py:102 src/olympia/editors/templates/editors/base.html:10
+#: src/olympia/amo/context_processors.py:86 src/olympia/editors/helpers.py:84 src/olympia/editors/helpers.py:104 src/olympia/editors/templates/editors/base.html:10
 msgid "Editor Tools"
 msgstr ""
 
-#: src/olympia/amo/context_processors.py:92
+#: src/olympia/amo/context_processors.py:90
 msgid "Admin Tools"
 msgstr ""
 
-#: src/olympia/amo/fields.py:15
+#: src/olympia/amo/fields.py:20
 msgid "Incorrect, please try again."
 msgstr ""
 
-#: src/olympia/amo/fields.py:16
+#: src/olympia/amo/fields.py:21
 msgid "Error verifying input, please try again."
 msgstr ""
 
-#: src/olympia/amo/fields.py:32
+#: src/olympia/amo/fields.py:37
 msgid "This must be a valid hex color code, such as #000000."
 msgstr ""
 
-#: src/olympia/amo/fields.py:58
+#: src/olympia/amo/fields.py:63
 msgid "Enter at least one value."
 msgstr ""
 
-#: src/olympia/amo/helpers.py:162 src/olympia/amo/templates/amo/site_nav.html:61 src/olympia/bandwagon/templates/bandwagon/add.html:9
+#: src/olympia/amo/helpers.py:162 src/olympia/amo/templates/amo/site_nav.html:59 src/olympia/bandwagon/templates/bandwagon/add.html:9
 #: src/olympia/bandwagon/templates/bandwagon/collection_detail.html:15 src/olympia/bandwagon/templates/bandwagon/delete.html:9 src/olympia/bandwagon/templates/bandwagon/edit.html:15
 #: src/olympia/bandwagon/templates/bandwagon/user_listing.html:18 src/olympia/bandwagon/templates/bandwagon/user_listing.html:21
 #: src/olympia/bandwagon/templates/bandwagon/impala/collection_listing.html:12 src/olympia/bandwagon/templates/bandwagon/impala/collection_listing.html:20
 #: src/olympia/bandwagon/templates/bandwagon/impala/collection_listing.html:24 src/olympia/bandwagon/templates/bandwagon/impala/collection_sidebar.html:3
 #: src/olympia/bandwagon/templates/bandwagon/includes/collection_sidebar.html:2 src/olympia/bandwagon/templates/bandwagon/mobile/collection_listing.html:3
-#: src/olympia/stats/templates/stats/stats.html:77 src/olympia/templates/menu_links.html:12
+#: src/olympia/stats/templates/stats/stats.html:33 src/olympia/templates/menu_links.html:12
 #, fuzzy
 msgid "Collections"
 msgstr "Collections"
 
-#: src/olympia/amo/helpers.py:171 src/olympia/amo/templates/amo/site_nav.html:85 src/olympia/browse/templates/browse/language_tools.html:3
+#: src/olympia/amo/helpers.py:171 src/olympia/amo/templates/amo/site_nav.html:83 src/olympia/browse/templates/browse/language_tools.html:3
 msgid "Dictionaries & Language Packs"
 msgstr ""
 
@@ -1623,8 +1624,8 @@ msgstr ""
 msgid "Comment on {addon} {version}."
 msgstr ""
 
-#: src/olympia/amo/log.py:236 src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:19 src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:47
-#: src/olympia/editors/helpers.py:511 src/olympia/editors/templates/editors/themes/history_table.html:11
+#: src/olympia/amo/log.py:236 src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:17 src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:45
+#: src/olympia/editors/helpers.py:584 src/olympia/editors/templates/editors/themes/history_table.html:11
 msgid "Comment"
 msgstr ""
 
@@ -1948,7 +1949,7 @@ msgstr "Prev"
 #: src/olympia/amo/templates/amo/mobile/paginator.html:14 src/olympia/amo/templates/amo/mobile/paginator.html:16 src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:51
 #: src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:65 src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:78
 #: src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:91 src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:104
-#: src/olympia/discovery/templates/discovery/pane.html:45 src/olympia/discovery/templates/discovery/addons/detail.html:39 src/olympia/stats/templates/stats/stats.html:167
+#: src/olympia/discovery/templates/discovery/pane.html:45 src/olympia/discovery/templates/discovery/addons/detail.html:39 src/olympia/stats/templates/stats/stats.html:169
 #, fuzzy
 msgid "Next"
 msgstr "Next"
@@ -1982,7 +1983,7 @@ msgid ""
 msgstr ""
 
 #: src/olympia/amo/templates/amo/side_nav.html:4 src/olympia/amo/templates/amo/side_nav.html:12 src/olympia/amo/templates/amo/site_nav.html:4 src/olympia/amo/templates/amo/site_nav.html:26
-#: src/olympia/browse/views.py:56 src/olympia/browse/views.py:66 src/olympia/browse/views.py:237 src/olympia/browse/views.py:282 src/olympia/search/forms.py:86
+#: src/olympia/browse/views.py:56 src/olympia/browse/views.py:66 src/olympia/browse/views.py:204 src/olympia/browse/views.py:249 src/olympia/search/forms.py:86
 #, fuzzy
 msgid "Top Rated"
 msgstr "Top Rated"
@@ -1998,38 +1999,38 @@ msgstr ""
 msgid "Extensions"
 msgstr "Өргөтгөлүүд"
 
-#: src/olympia/amo/templates/amo/site_nav.html:45
+#: src/olympia/amo/templates/amo/site_nav.html:44
 msgid "Want more customization? Try <b>Complete Themes</b>"
 msgstr ""
 
-#: src/olympia/amo/templates/amo/site_nav.html:56 src/olympia/bandwagon/views.py:96
+#: src/olympia/amo/templates/amo/site_nav.html:54 src/olympia/bandwagon/views.py:96
 msgid "Most Followers"
 msgstr ""
 
-#: src/olympia/amo/templates/amo/site_nav.html:68 src/olympia/bandwagon/templates/bandwagon/impala/collection_sidebar.html:16
+#: src/olympia/amo/templates/amo/site_nav.html:66 src/olympia/bandwagon/templates/bandwagon/impala/collection_sidebar.html:16
 #: src/olympia/bandwagon/templates/bandwagon/includes/collection_sidebar.html:18
 msgid "Collections I've Made"
 msgstr ""
 
-#: src/olympia/amo/templates/amo/site_nav.html:70 src/olympia/bandwagon/templates/bandwagon/user_listing.html:4 src/olympia/bandwagon/templates/bandwagon/impala/collection_sidebar.html:13
+#: src/olympia/amo/templates/amo/site_nav.html:68 src/olympia/bandwagon/templates/bandwagon/user_listing.html:4 src/olympia/bandwagon/templates/bandwagon/impala/collection_sidebar.html:13
 #: src/olympia/bandwagon/templates/bandwagon/includes/collection_sidebar.html:15
 msgid "Collections I'm Following"
 msgstr ""
 
-#: src/olympia/amo/templates/amo/site_nav.html:73 src/olympia/bandwagon/templates/bandwagon/impala/collection_sidebar.html:18
-#: src/olympia/bandwagon/templates/bandwagon/includes/collection_sidebar.html:20 src/olympia/users/models.py:512
+#: src/olympia/amo/templates/amo/site_nav.html:71 src/olympia/bandwagon/templates/bandwagon/impala/collection_sidebar.html:18
+#: src/olympia/bandwagon/templates/bandwagon/includes/collection_sidebar.html:20 src/olympia/users/models.py:521
 msgid "My Favorite Add-ons"
 msgstr ""
 
-#: src/olympia/amo/templates/amo/site_nav.html:78
+#: src/olympia/amo/templates/amo/site_nav.html:76
 msgid "More&hellip;"
 msgstr ""
 
-#: src/olympia/amo/templates/amo/site_nav.html:82
+#: src/olympia/amo/templates/amo/site_nav.html:80
 msgid "Add-ons for Mobile"
 msgstr ""
 
-#: src/olympia/amo/templates/amo/site_nav.html:86 src/olympia/browse/feeds.py:207 src/olympia/browse/templates/browse/search_tools.html:3 src/olympia/constants/base.py:176
+#: src/olympia/amo/templates/amo/site_nav.html:84 src/olympia/browse/feeds.py:207 src/olympia/browse/templates/browse/search_tools.html:3 src/olympia/constants/base.py:176
 #: src/olympia/templates/menu_links.html:10
 msgid "Search Tools"
 msgstr ""
@@ -2045,7 +2046,7 @@ msgid "Jump to first page"
 msgstr ""
 
 #: src/olympia/amo/templates/amo/impala/paginator.html:22 src/olympia/amo/templates/amo/mobile/impala_paginator.html:12 src/olympia/discovery/templates/discovery/pane.html:44
-#: src/olympia/discovery/templates/discovery/addons/detail.html:38 src/olympia/stats/templates/stats/stats.html:164
+#: src/olympia/discovery/templates/discovery/addons/detail.html:38 src/olympia/stats/templates/stats/stats.html:166
 msgid "Previous"
 msgstr ""
 
@@ -2068,30 +2069,49 @@ msgid_plural "Page {n}"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/olympia/amo/templates/services/install.html:38
-#, python-format
-msgid "If you are not prompted to install %(addon_name)s in a moment, please <a href=\"%(addon_xpi)s\">click here</a>."
-msgstr ""
-
-#: src/olympia/amo/tests/test_messages.py:57 src/olympia/amo/tests/test_messages.py:58 src/olympia/reviews/forms.py:25 src/olympia/reviews/forms.py:50 src/olympia/reviews/templates/reviews/add.html:56
+#: src/olympia/amo/tests/test_messages.py:56 src/olympia/amo/tests/test_messages.py:57 src/olympia/reviews/forms.py:25 src/olympia/reviews/forms.py:50 src/olympia/reviews/templates/reviews/add.html:56
 #: src/olympia/reviews/templates/reviews/reply.html:30
 msgid "Title"
 msgstr ""
 
-#: src/olympia/amo/tests/test_messages.py:57 src/olympia/amo/tests/test_messages.py:58
+#: src/olympia/amo/tests/test_messages.py:56 src/olympia/amo/tests/test_messages.py:57
 msgid "Body"
 msgstr ""
 
-#: src/olympia/amo/tests/test_messages.py:59
+#: src/olympia/amo/tests/test_messages.py:58
 msgid "Another Title"
 msgstr ""
 
-#: src/olympia/amo/tests/test_messages.py:59
+#: src/olympia/amo/tests/test_messages.py:58
 msgid "Another Body"
 msgstr ""
 
-#: src/olympia/api/views.py:255
-msgid "Not implemented yet."
+#: src/olympia/api/authentication.py:76
+msgid "Signature has expired."
+msgstr ""
+
+#: src/olympia/api/authentication.py:79
+msgid "Error decoding signature."
+msgstr ""
+
+#: src/olympia/api/authentication.py:82
+msgid "Invalid JWT Token."
+msgstr ""
+
+#: src/olympia/api/authentication.py:130
+msgid "Invalid Authorization header. No credentials provided."
+msgstr ""
+
+#: src/olympia/api/authentication.py:133
+msgid "Invalid Authorization header. Credentials string should not contain spaces."
+msgstr ""
+
+#: src/olympia/api/fields.py:29
+msgid "The field must have a length of at least {num} characters."
+msgstr ""
+
+#: src/olympia/api/fields.py:31
+msgid "The language code {lang_code} is invalid."
 msgstr ""
 
 #: src/olympia/applications/views.py:39 src/olympia/applications/templates/applications/appversions.html:3
@@ -2111,7 +2131,7 @@ msgstr "Програмын хүчинтэй хувилбар"
 msgid "Add-ons submitted to Mozilla Add-ons must have a manifest file with at least one of the below applications supported. Only the versions listed below are allowed for these applications."
 msgstr ""
 
-#: src/olympia/applications/templates/applications/appversions.html:25
+#: src/olympia/applications/templates/applications/appversions.html:25 src/olympia/editors/helpers.py:361
 msgid "GUID"
 msgstr "GUID"
 
@@ -2230,8 +2250,8 @@ msgstr ""
 msgid "Remove from favorites"
 msgstr ""
 
-#: src/olympia/bandwagon/views.py:98 src/olympia/bandwagon/views.py:191 src/olympia/browse/views.py:58 src/olympia/browse/views.py:69 src/olympia/browse/views.py:458 src/olympia/devhub/views.py:74
-#: src/olympia/devhub/views.py:82 src/olympia/devhub/templates/devhub/addons/edit/basic.html:20 src/olympia/editors/templates/editors/leaderboard.html:24
+#: src/olympia/bandwagon/views.py:98 src/olympia/bandwagon/views.py:191 src/olympia/browse/views.py:58 src/olympia/browse/views.py:69 src/olympia/browse/views.py:425 src/olympia/devhub/views.py:72
+#: src/olympia/devhub/views.py:80 src/olympia/devhub/templates/devhub/addons/edit/basic.html:20 src/olympia/editors/templates/editors/leaderboard.html:24
 #: src/olympia/editors/templates/editors/themes/queue_list.html:48 src/olympia/search/forms.py:17 src/olympia/search/forms.py:89 src/olympia/users/templates/users/vcard.html:5
 msgid "Name"
 msgstr ""
@@ -2240,7 +2260,7 @@ msgstr ""
 msgid "Recently Popular"
 msgstr ""
 
-#: src/olympia/bandwagon/views.py:189 src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:18
+#: src/olympia/bandwagon/views.py:189 src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:16
 msgid "Added"
 msgstr ""
 
@@ -2255,7 +2275,7 @@ msgstr ""
 
 #: src/olympia/bandwagon/views.py:316
 #, python-format
-msgid "Your new collection is shown below. You can <ahref=\"%(url)s\">edit additional settings</a> if you'dlike."
+msgid "Your new collection is shown below. You can <a href=\"%(url)s\">edit additional settings</a> if you'd like."
 msgstr ""
 
 #: src/olympia/bandwagon/views.py:322
@@ -2385,8 +2405,8 @@ msgstr[0] ""
 msgstr[1] ""
 
 # 100%
-#: src/olympia/bandwagon/templates/bandwagon/collection_detail.html:125 src/olympia/compat/templates/compat/index.html:25 src/olympia/compat/templates/compat/reporter_detail.html:29
-#: src/olympia/files/templates/files/viewer.html:29 src/olympia/templates/amo_footer.html:17 src/olympia/templates/includes/lang_switcher.html:10
+#: src/olympia/bandwagon/templates/bandwagon/collection_detail.html:125 src/olympia/compat/templates/compat/reporter_detail.html:29 src/olympia/files/templates/files/viewer.html:29
+#: src/olympia/templates/amo_footer.html:17 src/olympia/templates/includes/lang_switcher.html:10
 msgid "Go"
 msgstr "Илгээх"
 
@@ -2557,7 +2577,7 @@ msgid "Remove this user as a contributor"
 msgstr ""
 
 #: src/olympia/bandwagon/templates/bandwagon/edit_contributors.html:18 src/olympia/bandwagon/templates/bandwagon/edit_contributors.html:43
-#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:20 src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:48
+#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:18 src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:46
 #: src/olympia/devhub/templates/devhub/addons/ajax_compat_update.html:19
 msgid "Remove"
 msgstr ""
@@ -2608,7 +2628,7 @@ msgid "<b>Warning:</b> By changing the owner of this collection, you will no lon
 msgstr ""
 
 #: src/olympia/bandwagon/templates/bandwagon/edit_contributors.html:83 src/olympia/devhub/templates/devhub/addons/forms_shared/media.html:157
-#: src/olympia/devhub/templates/devhub/addons/submit/describe.html:69 src/olympia/devhub/templates/devhub/addons/submit/license.html:60 src/olympia/devhub/templates/devhub/addons/submit/upload.html:78
+#: src/olympia/devhub/templates/devhub/addons/submit/describe.html:69 src/olympia/devhub/templates/devhub/addons/submit/license.html:60 src/olympia/devhub/templates/devhub/addons/submit/upload.html:70
 #: src/olympia/devhub/templates/devhub/payments/tier.html:17 src/olympia/editors/templates/editors/themes/themes.html:111 src/olympia/editors/templates/editors/themes/themes.html:128
 #: src/olympia/editors/templates/editors/themes/themes.html:134 src/olympia/editors/templates/editors/themes/themes.html:141 src/olympia/users/templates/users/fxa_migration_prompt_content.html:10
 #: src/olympia/users/templates/users/login_form.html:42 src/olympia/users/templates/users/mobile/login.html:57
@@ -2693,32 +2713,32 @@ msgid "Add-ons in Your Collection"
 msgstr ""
 
 #: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:4
-msgid ""
-"To include an add-on in this collection, enter its name in the box below and hit enter.  You can also use the <strong>Add to Collection</strong> links throughout the site to include add-ons later."
+msgid "To include an add-on in this collection, enter its name in the box below and hit enter."
 msgstr ""
 
-#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:17 src/olympia/constants/base.py:400 src/olympia/devhub/templates/devhub/addons/activity.html:62
+#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:15 src/olympia/constants/base.py:400 src/olympia/devhub/templates/devhub/addons/activity.html:62
+#: src/olympia/editors/helpers.py:273 src/olympia/editors/helpers.py:360
 msgid "Add-on"
 msgstr ""
 
-#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:26
+#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:24
 msgid "Enter the name of the add-on to include"
 msgstr ""
 
-#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:28
+#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:26
 #, fuzzy
 msgid "Add to Collection"
 msgstr "Add to Collection"
 
-#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:45 src/olympia/editors/helpers.py:936 src/olympia/editors/helpers.py:956
+#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:43 src/olympia/editors/helpers.py:1016 src/olympia/editors/helpers.py:1036
 msgid "Pending"
 msgstr ""
 
-#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:47
+#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:45
 msgid "Add a comment"
 msgstr ""
 
-#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:48
+#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:46
 msgid "Remove this add-on from the collection"
 msgstr ""
 
@@ -2825,12 +2845,12 @@ msgstr ""
 msgid "Most Users"
 msgstr ""
 
-#: src/olympia/browse/views.py:61 src/olympia/browse/views.py:72 src/olympia/browse/views.py:279 src/olympia/browse/templates/browse/personas/mobile/category_landing.html:63
+#: src/olympia/browse/views.py:61 src/olympia/browse/views.py:72 src/olympia/browse/views.py:246 src/olympia/browse/templates/browse/personas/mobile/category_landing.html:63
 #: src/olympia/discovery/templates/discovery/pane.html:67 src/olympia/search/forms.py:92
 msgid "Up & Coming"
 msgstr ""
 
-#: src/olympia/browse/views.py:460 src/olympia/devhub/views.py:76 src/olympia/devhub/views.py:83 src/olympia/discovery/templates/discovery/addons/detail.html:66
+#: src/olympia/browse/views.py:427 src/olympia/devhub/views.py:74 src/olympia/devhub/views.py:81 src/olympia/discovery/templates/discovery/addons/detail.html:66
 #, fuzzy
 msgid "Created"
 msgstr "Created"
@@ -3019,8 +3039,8 @@ msgid_plural "See all %(cnt)s extensions in %(name)s &raquo;"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/olympia/browse/templates/browse/mobile/extensions.html:13 src/olympia/compat/templates/compat/index.html:82 src/olympia/devhub/templates/devhub/devhub_search.html:24
-#: src/olympia/devhub/templates/devhub/addons/activity.html:47 src/olympia/search/templates/search/no_results.html:4 src/olympia/search/templates/search/mobile/results.html:36
+#: src/olympia/browse/templates/browse/mobile/extensions.html:13 src/olympia/devhub/templates/devhub/devhub_search.html:24 src/olympia/devhub/templates/devhub/addons/activity.html:47
+#: src/olympia/search/templates/search/no_results.html:4 src/olympia/search/templates/search/mobile/results.html:36
 msgid "No results found."
 msgstr "Ямар ч үр дүн олдсонгүй."
 
@@ -3105,7 +3125,7 @@ msgstr ""
 msgid "All"
 msgstr ""
 
-#: src/olympia/compat/forms.py:22 src/olympia/search/views.py:525
+#: src/olympia/compat/forms.py:22 src/olympia/editors/templates/editors/base.html:69 src/olympia/search/views.py:518
 msgid "All Add-ons"
 msgstr ""
 
@@ -3115,54 +3135,6 @@ msgstr ""
 
 #: src/olympia/compat/forms.py:24
 msgid "Non-binary"
-msgstr ""
-
-#. Review points sources other than add-ons and themes.
-#: src/olympia/compat/views.py:87 src/olympia/constants/base.py:388 src/olympia/devhub/forms.py:162 src/olympia/editors/templates/editors/performance.html:75
-#, fuzzy
-msgid "Other"
-msgstr "Other"
-
-#: src/olympia/compat/templates/compat/index.html:4
-msgid "Add-on Compatibility Report for {app} {version}"
-msgstr ""
-
-#: src/olympia/compat/templates/compat/index.html:11
-msgid "{app} {version} Compatibility"
-msgstr ""
-
-#: src/olympia/compat/templates/compat/index.html:17
-#, python-format
-msgid "Top 95%% compatible with previous version"
-msgstr ""
-
-#: src/olympia/compat/templates/compat/index.html:18
-#, python-format
-msgid "Top 95%% of all add-ons"
-msgstr ""
-
-#: src/olympia/compat/templates/compat/index.html:19
-msgid "All active add-ons"
-msgstr ""
-
-#: src/olympia/compat/templates/compat/index.html:23 src/olympia/constants/base.py:401
-msgid "App"
-msgstr ""
-
-#: src/olympia/compat/templates/compat/index.html:55
-msgid "Details for add-ons compatible with previous version:"
-msgstr ""
-
-#: src/olympia/compat/templates/compat/index.html:57
-msgid "Show all versions"
-msgstr ""
-
-#: src/olympia/compat/templates/compat/index.html:59
-msgid "Details for add-ons compatible with all versions:"
-msgstr ""
-
-#: src/olympia/compat/templates/compat/index.html:61
-msgid "Show previous version only"
 msgstr ""
 
 #: src/olympia/compat/templates/compat/reporter.html:3
@@ -3216,8 +3188,8 @@ msgstr ""
 msgid "Report Type"
 msgstr ""
 
-#: src/olympia/compat/templates/compat/reporter_detail.html:47 src/olympia/devhub/forms.py:784 src/olympia/devhub/templates/devhub/addons/ajax_compat_update.html:17 src/olympia/editors/forms.py:108
-#: src/olympia/zadmin/forms.py:45
+#: src/olympia/compat/templates/compat/reporter_detail.html:47 src/olympia/devhub/forms.py:785 src/olympia/devhub/templates/devhub/addons/ajax_compat_update.html:17 src/olympia/editors/forms.py:108
+#: src/olympia/editors/forms.py:248 src/olympia/zadmin/forms.py:45
 msgid "Application"
 msgstr ""
 
@@ -3306,7 +3278,8 @@ msgstr ""
 msgid "Preliminarily Reviewed and Awaiting Full Review"
 msgstr ""
 
-#: src/olympia/constants/base.py:33 src/olympia/editors/helpers.py:924 src/olympia/editors/templates/editors/themes/history_table.html:34
+#: src/olympia/constants/base.py:33 src/olympia/editors/forms.py:258 src/olympia/editors/helpers.py:73 src/olympia/editors/helpers.py:1004
+#: src/olympia/editors/templates/editors/themes/history_table.html:34
 msgid "Deleted"
 msgstr ""
 
@@ -3408,6 +3381,12 @@ msgstr ""
 msgid "Ask before users can download this add-on"
 msgstr ""
 
+#. Review points sources other than add-ons and themes.
+#: src/olympia/constants/base.py:388 src/olympia/devhub/forms.py:162 src/olympia/editors/templates/editors/performance.html:75
+#, fuzzy
+msgid "Other"
+msgstr "Other"
+
 #: src/olympia/constants/base.py:389
 msgid "Exception"
 msgstr ""
@@ -3418,6 +3397,10 @@ msgstr ""
 
 #: src/olympia/constants/base.py:391
 msgid "Change"
+msgstr ""
+
+#: src/olympia/constants/base.py:401
+msgid "App"
 msgstr ""
 
 #: src/olympia/constants/base.py:402
@@ -3568,7 +3551,7 @@ msgstr ""
 msgid "Duplicate"
 msgstr ""
 
-#: src/olympia/constants/editors.py:17 src/olympia/editors/helpers.py:502 src/olympia/editors/templates/editors/themes/queue.html:71 src/olympia/editors/templates/editors/themes/themes.html:94
+#: src/olympia/constants/editors.py:17 src/olympia/editors/helpers.py:575 src/olympia/editors/templates/editors/themes/queue.html:71 src/olympia/editors/templates/editors/themes/themes.html:94
 msgid "Reject"
 msgstr ""
 
@@ -3668,7 +3651,7 @@ msgstr ""
 msgid "Android"
 msgstr ""
 
-#: src/olympia/core/apps.py:19
+#: src/olympia/core/apps.py:21
 msgid "Core"
 msgstr ""
 
@@ -3803,7 +3786,7 @@ msgid "Submit my add-on for manual review."
 msgstr ""
 
 #: src/olympia/devhub/forms.py:537
-msgid "Do not list my add-on on this site (beta)"
+msgid "Do not list my add-on on this site"
 msgstr ""
 
 #: src/olympia/devhub/forms.py:538
@@ -3836,46 +3819,46 @@ msgstr ""
 
 #: src/olympia/devhub/forms.py:592
 #, python-format
-msgid "Version %s already exists"
+msgid "Version %s already exists, or was uploaded before."
 msgstr ""
 
-#: src/olympia/devhub/forms.py:604
+#: src/olympia/devhub/forms.py:605
 msgid "Select a valid choice. That choice is not one of the available choices."
 msgstr ""
 
-#: src/olympia/devhub/forms.py:610
+#: src/olympia/devhub/forms.py:611
 msgid "A file with a version ending with a|alpha|b|beta and an optional number is detected as beta."
 msgstr ""
 
-#: src/olympia/devhub/forms.py:633
+#: src/olympia/devhub/forms.py:634
 msgid "You cannot upload any more files for this version."
 msgstr ""
 
-#: src/olympia/devhub/forms.py:639
+#: src/olympia/devhub/forms.py:640
 msgid "Version doesn't match"
 msgstr ""
 
-#: src/olympia/devhub/forms.py:668
+#: src/olympia/devhub/forms.py:669
 msgid "You cannot delete a file once the review process has started.  You must delete the whole version."
 msgstr ""
 
-#: src/olympia/devhub/forms.py:688
+#: src/olympia/devhub/forms.py:689
 msgid "The platform All cannot be combined with specific platforms."
 msgstr ""
 
-#: src/olympia/devhub/forms.py:693
+#: src/olympia/devhub/forms.py:694
 msgid "A platform can only be chosen once."
 msgstr ""
 
-#: src/olympia/devhub/forms.py:706
+#: src/olympia/devhub/forms.py:707
 msgid "A review type must be selected."
 msgstr ""
 
-#: src/olympia/devhub/forms.py:788 src/olympia/editors/forms.py:114 src/olympia/zadmin/forms.py:49 src/olympia/zadmin/forms.py:52
+#: src/olympia/devhub/forms.py:789 src/olympia/editors/forms.py:114 src/olympia/editors/forms.py:254 src/olympia/zadmin/forms.py:49 src/olympia/zadmin/forms.py:52
 msgid "Select an application first"
 msgstr ""
 
-#: src/olympia/devhub/forms.py:840
+#: src/olympia/devhub/forms.py:841
 msgid "There cannot be more than 3 required add-ons."
 msgstr ""
 
@@ -3914,76 +3897,76 @@ msgstr[1] "{0} warnings"
 msgid "Review"
 msgstr "Review"
 
-#: src/olympia/devhub/tasks.py:551
+#: src/olympia/devhub/tasks.py:583
 #, python-format
 msgid "%s responded with %s (%s)."
 msgstr ""
 
-#: src/olympia/devhub/tasks.py:555
+#: src/olympia/devhub/tasks.py:587
 #, python-format
 msgid "Connection to \"%s\" timed out."
 msgstr ""
 
-#: src/olympia/devhub/tasks.py:557
+#: src/olympia/devhub/tasks.py:589
 #, python-format
 msgid "Could not contact host at \"%s\"."
 msgstr ""
 
-#: src/olympia/devhub/utils.py:104
+#: src/olympia/devhub/utils.py:105
 #, python-format
 msgid "Validation generated too many errors/warnings so %s messages were truncated. After addressing the visible messages, you'll be able to see the others."
 msgstr ""
 
-#: src/olympia/devhub/views.py:183
+#: src/olympia/devhub/views.py:181
 msgid "All My Add-ons"
 msgstr ""
 
-#: src/olympia/devhub/views.py:210
+#: src/olympia/devhub/views.py:208
 msgid "All Activity"
 msgstr ""
 
-#: src/olympia/devhub/views.py:211
+#: src/olympia/devhub/views.py:209
 msgid "Add-on Updates"
 msgstr ""
 
-#: src/olympia/devhub/views.py:212
+#: src/olympia/devhub/views.py:210
 msgid "Add-on Status"
 msgstr ""
 
-#: src/olympia/devhub/views.py:213
+#: src/olympia/devhub/views.py:211
 msgid "User Collections"
 msgstr ""
 
-#: src/olympia/devhub/views.py:214 src/olympia/devhub/templates/devhub/docs/policies-maintenance.html:68 src/olympia/pages/templates/pages/dev_faq.html:38
+#: src/olympia/devhub/views.py:212 src/olympia/devhub/templates/devhub/docs/policies-maintenance.html:68 src/olympia/pages/templates/pages/dev_faq.html:38
 #: src/olympia/pages/templates/pages/dev_faq.html:484
 msgid "User Reviews"
 msgstr ""
 
-#: src/olympia/devhub/views.py:327 src/olympia/devhub/views.py:331 src/olympia/devhub/views.py:484 src/olympia/devhub/views.py:513 src/olympia/devhub/views.py:564 src/olympia/devhub/views.py:1150
+#: src/olympia/devhub/views.py:325 src/olympia/devhub/views.py:329 src/olympia/devhub/views.py:484 src/olympia/devhub/views.py:513 src/olympia/devhub/views.py:564 src/olympia/devhub/views.py:1156
 msgid "Changes successfully saved."
 msgstr ""
 
-#: src/olympia/devhub/views.py:334 src/olympia/devhub/views.py:1631
+#: src/olympia/devhub/views.py:332 src/olympia/devhub/views.py:1637
 msgid "Please check the form for errors."
 msgstr ""
 
-#: src/olympia/devhub/views.py:346
+#: src/olympia/devhub/views.py:344
 msgid "Add-on cannot be deleted. Disable this add-on instead."
 msgstr ""
 
-#: src/olympia/devhub/views.py:356
+#: src/olympia/devhub/views.py:354
 msgid "Theme deleted."
 msgstr ""
 
-#: src/olympia/devhub/views.py:356
+#: src/olympia/devhub/views.py:354
 msgid "Add-on deleted."
 msgstr ""
 
-#: src/olympia/devhub/views.py:362
+#: src/olympia/devhub/views.py:360
 msgid "URL name was incorrect. Theme was not deleted."
 msgstr ""
 
-#: src/olympia/devhub/views.py:367
+#: src/olympia/devhub/views.py:365
 msgid "URL name was incorrect. Add-on was not deleted."
 msgstr ""
 
@@ -4011,7 +3994,7 @@ msgstr ""
 msgid "Check Add-on Compatibility"
 msgstr ""
 
-#: src/olympia/devhub/views.py:808 src/olympia/signing/views.py:90
+#: src/olympia/devhub/views.py:808 src/olympia/signing/views.py:95
 msgid "You cannot submit this type of add-on"
 msgstr ""
 
@@ -4041,33 +4024,33 @@ msgstr ""
 msgid "There was an error uploading your preview."
 msgstr ""
 
-#: src/olympia/devhub/views.py:1189
+#: src/olympia/devhub/views.py:1195
 #, python-format
 msgid "Version %s disabled."
 msgstr ""
 
-#: src/olympia/devhub/views.py:1193
+#: src/olympia/devhub/views.py:1199
 #, python-format
 msgid "Version %s deleted."
 msgstr ""
 
-#: src/olympia/devhub/views.py:1203
+#: src/olympia/devhub/views.py:1209
 msgid "This upload has failed validation, and may lack complete validation results. Please take due care when reviewing it."
 msgstr ""
 
-#: src/olympia/devhub/views.py:1677
+#: src/olympia/devhub/views.py:1683
 msgid "Preliminary Review Requested."
 msgstr ""
 
-#: src/olympia/devhub/views.py:1678
+#: src/olympia/devhub/views.py:1684
 msgid "Full Review Requested."
 msgstr ""
 
-#: src/olympia/devhub/views.py:1779
+#: src/olympia/devhub/views.py:1783
 msgid "Your old credentials were revoked and are no longer valid. Be sure to update all API clients with the new credentials."
 msgstr ""
 
-#: src/olympia/devhub/views.py:1797
+#: src/olympia/devhub/views.py:1801
 msgid "New API key created"
 msgstr ""
 
@@ -4097,7 +4080,7 @@ msgstr ""
 msgid "{0} :: Search"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/devhub_search.html:6 src/olympia/devhub/templates/devhub/search.html:8 src/olympia/editors/forms.py:435 src/olympia/editors/forms.py:437
+#: src/olympia/devhub/templates/devhub/devhub_search.html:6 src/olympia/devhub/templates/devhub/search.html:8 src/olympia/editors/forms.py:534 src/olympia/editors/forms.py:536
 #: src/olympia/editors/templates/editors/queue.html:27 src/olympia/editors/templates/editors/themes/queue_list.html:14 src/olympia/search/templates/search/collections.html:17
 #: src/olympia/search/templates/search/personas.html:18 src/olympia/search/templates/search/results.html:18 src/olympia/search/templates/search/mobile/results.html:8
 #: src/olympia/templates/search.html:14 src/olympia/templates/impala/search.html:18
@@ -4158,12 +4141,12 @@ msgstr ""
 msgid "Start Making Add-ons"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/index.html:86 src/olympia/devhub/templates/devhub/addons/listing/items.html:25 src/olympia/devhub/templates/devhub/includes/addon_details.html:15
+#: src/olympia/devhub/templates/devhub/index.html:86 src/olympia/devhub/templates/devhub/addons/listing/items.html:25 src/olympia/devhub/templates/devhub/includes/addon_details.html:20
 #: src/olympia/devhub/templates/devhub/personas/edit.html:43
 msgid "Status:"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/index.html:90 src/olympia/devhub/templates/devhub/includes/addon_details.html:100
+#: src/olympia/devhub/templates/devhub/index.html:90 src/olympia/devhub/templates/devhub/includes/addon_details.html:87
 msgid "Visibility:"
 msgstr ""
 
@@ -4171,11 +4154,11 @@ msgstr ""
 msgid "Latest Version:"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/index.html:109 src/olympia/devhub/templates/devhub/includes/addon_details.html:145 src/olympia/devhub/templates/devhub/personas/edit.html:49
+#: src/olympia/devhub/templates/devhub/index.html:109 src/olympia/devhub/templates/devhub/includes/addon_details.html:131 src/olympia/devhub/templates/devhub/personas/edit.html:49
 msgid "Queue Position:"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/index.html:110 src/olympia/devhub/templates/devhub/includes/addon_details.html:146 src/olympia/devhub/templates/devhub/personas/edit.html:50
+#: src/olympia/devhub/templates/devhub/index.html:110 src/olympia/devhub/templates/devhub/includes/addon_details.html:132 src/olympia/devhub/templates/devhub/personas/edit.html:50
 #, python-format
 msgid "%(position)s of %(total)s"
 msgstr ""
@@ -4277,16 +4260,6 @@ msgstr ""
 msgid "Do you want your add-on to be distributed on this site?"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/validate_addon.html:49 src/olympia/devhub/templates/devhub/addons/submit/upload.html:30 src/olympia/devhub/templates/devhub/versions/add_file_modal.html:14
-#: src/olympia/devhub/templates/devhub/versions/add_file_modal.html:53 src/olympia/devhub/templates/devhub/versions/list.html:298
-msgid "Warning:"
-msgstr ""
-
-#: src/olympia/devhub/templates/devhub/validate_addon.html:50 src/olympia/devhub/templates/devhub/addons/submit/upload.html:31
-#, python-format
-msgid "Submission of unlisted add-ons for signing is currently in an open beta. Please <a href=\"%(url)s\" target=\"_blank\">report any bugs</a> that you encounter."
-msgstr ""
-
 #. first parameter is a filename like lorem-ipsum-1.0.2.xpi
 #: src/olympia/devhub/templates/devhub/validation.html:5
 msgid "Validation Results for {0}"
@@ -4361,7 +4334,7 @@ msgstr ""
 msgid "Update Compatibility"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/addons/ajax_compat_update.html:4
+#: src/olympia/devhub/templates/devhub/addons/ajax_compat_update.html:4 src/olympia/devhub/templates/devhub/versions/edit.html:45
 msgid "Adjusting application information here will allow users to install your add-on even if the install manifest in the package indicates that the add-on is incompatible."
 msgstr ""
 
@@ -4373,9 +4346,9 @@ msgstr ""
 msgid "Add Another Application&hellip;"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/addons/ajax_compat_update.html:38 src/olympia/devhub/templates/devhub/addons/owner.html:86 src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:46
-#: src/olympia/devhub/templates/devhub/versions/list.html:351 src/olympia/devhub/templates/devhub/versions/list.html:353 src/olympia/templates/impala/base.html:132
-#: src/olympia/templates/impala/base.html:143 src/olympia/templates/impala/base.html:161 src/olympia/templates/impala/base.html:171
+#: src/olympia/devhub/templates/devhub/addons/ajax_compat_update.html:38 src/olympia/devhub/templates/devhub/addons/owner.html:86 src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:45
+#: src/olympia/devhub/templates/devhub/versions/list.html:349 src/olympia/devhub/templates/devhub/versions/list.html:351 src/olympia/templates/impala/base.html:129
+#: src/olympia/templates/impala/base.html:140 src/olympia/templates/impala/base.html:158 src/olympia/templates/impala/base.html:168
 msgid "Close"
 msgstr ""
 
@@ -4409,7 +4382,7 @@ msgstr ""
 msgid "Manage Authors & License"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/addons/owner.html:29 src/olympia/editors/templates/editors/review.html:270
+#: src/olympia/devhub/templates/devhub/addons/owner.html:29 src/olympia/editors/helpers.py:362 src/olympia/editors/templates/editors/review.html:270
 #, fuzzy
 msgid "Authors"
 msgstr "Authors"
@@ -4481,17 +4454,11 @@ msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/basic.html:52
 msgid ""
-"A short explanation of your add-on's basic\n"
-"                          functionality that is displayed in search and browse\n"
-"                          listings, as well as at the top of your add-on's\n"
-"                          details page. It is only relevant for listed add-ons."
+"A short explanation of your add-on's basic functionality that is displayed in search and browse listings, as well as at the top of your add-on's details page. It is only relevant for listed add-ons."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/basic.html:73
-msgid ""
-"Categories are the primary way users browse through add-ons.\n"
-"                        Choose any that fit your add-on's functionality for the most\n"
-"                        exposure. It is only relevant for listed add-ons."
+msgid "Categories are the primary way users browse through add-ons. Choose any that fit your add-on's functionality for the most exposure. It is only relevant for listed add-ons."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/basic.html:90
@@ -4501,11 +4468,7 @@ msgid ""
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/basic.html:119
-msgid ""
-"Tags help users find your add-on and should be short\n"
-"                        descriptors such as tabs, toolbar, or twitter.  You\n"
-"                        may have a maximum of {0} tags. It is only relevant\n"
-"                        for listed add-ons."
+msgid "Tags help users find your add-on and should be short descriptors such as tabs, toolbar, or twitter. You may have a maximum of {0} tags. It is only relevant for listed add-ons."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/basic.html:129 src/olympia/devhub/templates/devhub/personas/edit.html:97 src/olympia/devhub/templates/devhub/personas/submit.html:46
@@ -4533,11 +4496,7 @@ msgid "Add-on Details for {0}"
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/details.html:22
-msgid ""
-"A longer explanation of features,\n"
-"                          functionality, and other relevant information. This\n"
-"                          field is only displayed on the add-on's details\n"
-"                          page. It is only relevant for listed add-ons."
+msgid "A longer explanation of features, functionality, and other relevant information. This field is only displayed on the add-on's details page. It is only relevant for listed add-ons."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/details.html:44 src/olympia/translations/templates/translations/trans-menu.html:13
@@ -4546,10 +4505,7 @@ msgid "Default Locale"
 msgstr "Default Locale"
 
 #: src/olympia/devhub/templates/devhub/addons/edit/details.html:45
-msgid ""
-"Information about your add-on is displayed in this locale\n"
-"                        unless you override it with a locale-specific translation.\n"
-"                        It is only relevant for listed add-ons."
+msgid "Information about your add-on is displayed in this locale unless you override it with a locale-specific translation. It is only relevant for listed add-ons."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/details.html:61 src/olympia/users/forms.py:311 src/olympia/users/templates/users/edit.html:122 src/olympia/users/templates/users/register.html:57
@@ -4559,10 +4515,8 @@ msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/details.html:63
 msgid ""
-"If your add-on has another homepage, enter its\n"
-"                          address here. If your website is localized into other\n"
-"                          languages multiple translations of this field can be\n"
-"                          added. It is only relevant for listed add-ons."
+"If your add-on has another homepage, enter its address here. If your website is localized into other languages multiple translations of this field can be added. It is only relevant for listed add-"
+"ons."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/media.html:3
@@ -4580,19 +4534,14 @@ msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/support.html:22
 msgid ""
-"If you wish to display an e-mail address for support\n"
-"                          inquiries, enter it here. If you have different\n"
-"                          addresses for each language multiple translations of\n"
-"                          this field can be added. It is only relevant for\n"
-"                          listed add-ons."
+"If you wish to display an e-mail address for support inquiries, enter it here. If you have different addresses for each language multiple translations of this field can be added. It is only "
+"relevant for listed add-ons."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/support.html:45
 msgid ""
-"If your add-on has a support website or forum, enter\n"
-"                          its address here. If your website is localized into\n"
-"                          other languages, multiple translations of this field can\n"
-"                          be added. It is only relevant for listed add-ons."
+"If your add-on has a support website or forum, enter its address here. If your website is localized into other languages, multiple translations of this field can be added. It is only relevant for "
+"listed add-ons."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:6
@@ -4606,11 +4555,8 @@ msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:23
 msgid ""
-"Any information end users may want to know that isn't\n"
-"                          necessarily applicable to the add-on summary or description.\n"
-"                          Common uses include listing known major bugs, information on\n"
-"                          how to report bugs, anticipated release date of a new version,\n"
-"                          etc. It is only relevant for listed add-ons."
+"Any information end users may want to know that isn't necessarily applicable to the add-on summary or description. Common uses include listing known major bugs, information on how to report bugs, "
+"anticipated release date of a new version, etc. It is only relevant for listed add-ons."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:46
@@ -4622,9 +4568,7 @@ msgid "Add-on Flags"
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:69
-msgid ""
-"These flags are used to classify add-ons. It is only\n"
-"                        relevant for listed add-ons."
+msgid "These flags are used to classify add-ons. It is only relevant for listed add-ons."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:74
@@ -4640,9 +4584,7 @@ msgid "View Source?"
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:90
-msgid ""
-"Whether the source of your add-on can be displayed in our\n"
-"                        online viewer. It is only relevant for listed add-ons."
+msgid "Whether the source of your add-on can be displayed in our online viewer. It is only relevant for listed add-ons."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:94
@@ -4658,10 +4600,7 @@ msgid "Public Stats?"
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:102
-msgid ""
-"Whether the download and usage stats of your add-on can\n"
-"                        be displayed in our online viewer.\n"
-"                        It is only relevant for listed add-ons."
+msgid "Whether the download and usage stats of your add-on can be displayed in our online viewer. It is only relevant for listed add-ons."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:107
@@ -4677,10 +4616,7 @@ msgid "Upgrade SDK?"
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:116
-msgid ""
-"If selected, we will try to automatically upgrade your\n"
-"                        add-on when a new version of the SDK is released.\n"
-"                        It is only relevant for listed add-ons."
+msgid "If selected, we will try to automatically upgrade your add-on when a new version of the SDK is released. It is only relevant for listed add-ons."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:121
@@ -4731,10 +4667,8 @@ msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/forms_shared/media.html:16
 msgid ""
-"Upload an icon for your add-on or choose from one of ours. The\n"
-"                      icon is displayed nearly everywhere your add-on is. Uploaded images\n"
-"                      must be one of the following image types: .png, .jpg.\n"
-"                      It is only relevant for listed add-ons."
+"Upload an icon for your add-on or choose from one of ours. The icon is displayed nearly everywhere your add-on is. Uploaded images must be one of the following image types: .png, .jpg. It is only "
+"relevant for listed add-ons."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/forms_shared/media.html:25
@@ -4747,9 +4681,7 @@ msgid "32x32px"
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/forms_shared/media.html:39
-msgid ""
-"Used in listings of add-ons, like search results\n"
-"                            and featured add-ons."
+msgid "Used in listings of add-ons, like search results and featured add-ons."
 msgstr ""
 
 #. The size of the icon
@@ -4844,16 +4776,14 @@ msgid "Deleting your add-on will permanently remove it from the site and prevent
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:24
-msgid ""
-"Enter the following text confirm your decision:\n"
-"           {slug}"
+msgid "Enter the following text confirm your decision: {slug}"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:34
+#: src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:33
 msgid "Please tell us why you are deleting your theme:"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:36
+#: src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:35
 msgid "Please tell us why you are deleting your add-on:"
 msgstr ""
 
@@ -4891,8 +4821,8 @@ msgstr "New Version"
 msgid "Daily statistics on downloads and users."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/addons/listing/item_actions.html:45 src/olympia/stats/templates/stats/stats.html:75 src/olympia/stats/templates/stats/stats.html:79
-#: src/olympia/stats/templates/stats/stats.html:81
+#: src/olympia/devhub/templates/devhub/addons/listing/item_actions.html:45 src/olympia/stats/templates/stats/stats.html:31 src/olympia/stats/templates/stats/stats.html:35
+#: src/olympia/stats/templates/stats/stats.html:37
 #, fuzzy
 msgid "Statistics"
 msgstr "Statistics"
@@ -5013,10 +4943,7 @@ msgid "Your add-on has been submitted to the Full Review queue."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/submit/done.html:18
-msgid ""
-"You'll receive an email once it has been reviewed by an editor. In\n"
-"          the meantime, you and your friends can install it directly from its\n"
-"          details page:"
+msgid "You'll receive an email once it has been reviewed by an editor. In the meantime, you and your friends can install it directly from its details page:"
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/submit/done.html:27 src/olympia/devhub/templates/devhub/addons/submit/done.html:77 src/olympia/devhub/templates/devhub/personas/submit_done.html:16
@@ -5222,11 +5149,11 @@ msgstr ""
 msgid "Use the fields below to upload your add-on package and select any platform restrictions. After upload, a series of automated validation tests will be run on your file."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/addons/submit/upload.html:59 src/olympia/devhub/templates/devhub/versions/add_file_modal.html:39
+#: src/olympia/devhub/templates/devhub/addons/submit/upload.html:51 src/olympia/devhub/templates/devhub/versions/add_file_modal.html:28
 msgid "Which platforms is this file compatible with?"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/addons/submit/upload.html:67 src/olympia/devhub/templates/devhub/versions/add_file_modal.html:65
+#: src/olympia/devhub/templates/devhub/addons/submit/upload.html:59 src/olympia/devhub/templates/devhub/versions/add_file_modal.html:45
 msgid "Administrative overrides"
 msgstr ""
 
@@ -5336,8 +5263,8 @@ msgstr ""
 
 #: src/olympia/devhub/templates/devhub/docs/policies-contact.html:44
 msgid ""
-"If you've found a problem with the site, we'd love to fix it. Please <a href=\"https://github.com/mozilla/olympia/issues\">file a bug report</a> in GitHub, including the location of the problem and "
-"how you encountered it."
+"If you've found a problem with the site, we'd love to fix it. Please <a href=\"https://github.com/mozilla/addons/issues/new\">file a bug report</a> in GitHub, including the location of the problem "
+"and how you encountered it."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/docs/policies-maintenance.html:3 src/olympia/devhub/templates/devhub/docs/policies-maintenance.html:7
@@ -5904,7 +5831,7 @@ msgstr ""
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:282
 msgid ""
-"Add-ons that store or otherwise handle browsing data must support <a href=\"https://developer.mozilla.org/En/Supporting_private_browsing_mode\">Private Browsing Mode</a>.  During a Private Browsing "
+"Add-ons that store or otherwise handle browsing data must support <a href=\"https://developer.mozilla.org/En/Supporting_private_browsing_mode\">Private Browsing Mode</a>. During a Private Browsing "
 "session, no browsing data can be written to disk, and all of this data must be cleared when Firefox quits or the Private Browsing session ends."
 msgstr ""
 
@@ -6069,129 +5996,95 @@ msgstr ""
 msgid "How to get in touch with us regarding these policies or your add-on."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:6
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:10
 msgid "You have disabled this add-on"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:20
-msgid ""
-"Your add-on's listing is disabled and is not showing\n"
-"                             anywhere in our gallery or update service."
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:24
+msgid "Your add-on's listing is disabled and is not showing anywhere in our gallery or update service."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:25
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:27
 msgid "Please complete your add-on."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:29
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:30
 msgid "You will receive an email when the review is complete."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:34
-msgid ""
-"You will receive an email when the review is complete. Until\n"
-"                             then, your add-on is not listed in our gallery but can be\n"
-"                             accessed directly from its details page."
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:33
+msgid "You will receive an email when the review is complete. Until then, your add-on is not listed in our gallery but can be accessed directly from its details page."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:38 src/olympia/devhub/templates/devhub/includes/addon_details.html:48
-msgid ""
-"You will receive an email when the review is\n"
-"                             complete and your add-on is signed."
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:37 src/olympia/devhub/templates/devhub/includes/addon_details.html:45
+msgid "You will receive an email when the review is complete and your add-on is signed."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:44
-msgid ""
-"You will receive an email when the review is complete. Until\n"
-"                             then, your add-on is not listed in our gallery but can be\n"
-"                             accessed directly from its details page. "
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:41
+msgid "You will receive an email when the review is complete. Until then, your add-on is not listed in our gallery but can be accessed directly from its details page. "
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:54
-msgid ""
-"Your add-on is displayed in our gallery and users are\n"
-"                             receiving automatic updates."
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:49
+msgid "Your add-on is displayed in our gallery and users are receiving automatic updates."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:57
-msgid ""
-"Your add-on has been signed and can be bundled with an\n"
-"                             application installer."
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:52
+msgid "Your add-on has been signed and can be bundled with an application installer."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:63
-msgid ""
-"Your add-on was disabled by a site administrator and is no\n"
-"                             longer shown in our gallery. If you have any questions,\n"
-"                             please email amo-admins@mozilla.org."
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:56
+msgid "Your add-on was disabled by a site administrator and is no longer shown in our gallery. If you have any questions, please email amo-admins@mozilla.org."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:70
-msgid ""
-"Your add-on is displayed in our gallery as experimental\n"
-"                             and users are receiving automatic updates. Some features\n"
-"                             are unavailable to your add-on."
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:62
+msgid "Your add-on is displayed in our gallery as experimental and users are receiving automatic updates. Some features are unavailable to your add-on."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:74
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:66
 msgid "Your add-on has been signed."
 msgstr ""
 
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:69
+msgid ""
+"You will receive an email when the full review is complete. Until then, your add-on is displayed in our gallery as experimental and users are receiving automatic updates. Some features are "
+"unavailable to your add-on."
+msgstr ""
+
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:74
+msgid "You will receive an email when the full review is complete, making you able to bundle your add-on with an application installer."
+msgstr ""
+
 #: src/olympia/devhub/templates/devhub/includes/addon_details.html:79
-msgid ""
-"You will receive an email when the full review is complete.\n"
-"                             Until then, your add-on is displayed in our gallery as\n"
-"                             experimental and users are receiving automatic updates.\n"
-"                             Some features are unavailable to your add-on."
+msgid "All add-ons hosted in our gallery must now be reviewed by an editor. If you wish to continue hosting your add-on, please click to select a review process."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:84
-msgid ""
-"You will receive an email when the full review is\n"
-"                             complete, making you able to bundle your add-on with an\n"
-"                             application installer."
-msgstr ""
-
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:91
-msgid ""
-"All add-ons hosted in our gallery must now be reviewed by an\n"
-"                             editor. If you wish to continue hosting your add-on, please\n"
-"                             click to select a review process."
-msgstr ""
-
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:113
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:100
 msgid "Current Version:"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:115
-msgid ""
-"This is the version of your add-on that will\n"
-"                                           be installed if someone clicks the Install\n"
-"                                           button on addons.mozilla.org. It is only\n"
-"                                           relevant for listed add-ons."
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:102
+msgid "This is the version of your add-on that will be installed if someone clicks the Install button on addons.mozilla.org. It is only relevant for listed add-ons."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:123
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:110
 msgid "Created:"
 msgstr ""
 
 #. {0} is a date. dennis-ignore: E201
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:125 src/olympia/devhub/templates/devhub/includes/addon_details.html:131
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:112 src/olympia/devhub/templates/devhub/includes/addon_details.html:118
 #, python-format
 msgid "%%b %%e, %%Y"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:136
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:123
 msgid "Next Version:"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:138
-msgid ""
-"This is the newest uploaded version, however\n"
-"                                           it isn’t live on the site yet."
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:125
+msgid "This is the newest uploaded version, however it isn’t live on the site yet."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:144 src/olympia/devhub/templates/devhub/versions/list.html:30
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:130 src/olympia/devhub/templates/devhub/versions/list.html:30
 msgid "Queues are not reviewed strictly in order"
 msgstr ""
 
@@ -6259,9 +6152,7 @@ msgid "View the blog &#9658;"
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/includes/license_form.html:6
-msgid ""
-"Please choose a license appropriate for the rights you grant on your source code.\n"
-"                  It is only relevant for listed add-ons."
+msgid "Please choose a license appropriate for the rights you grant on your source code. It is only relevant for listed add-ons."
 msgstr ""
 
 #. {0} is a list of HTML tags.
@@ -6288,14 +6179,11 @@ msgstr[1] ""
 #: src/olympia/devhub/templates/devhub/includes/policy_form.html:4
 msgid ""
 "Users will be required to accept the following End-User License Agreement (EULA) prior to installing your add-on. The presence of a EULA significantly affects the number of downloads an add-on "
-"receives. Please note that a EULA is not the same as a code license, such as the GPL or MPL.\n"
-"                It is only relevant for listed add-ons."
+"receives. Please note that a EULA is not the same as a code license, such as the GPL or MPL.It is only relevant for listed add-ons."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/policy_form.html:21
-msgid ""
-"If your add-on transmits any data from the user's computer, a privacy policy is required that explains what data is sent and how it is used.\n"
-"                It is only relevant for listed add-ons."
+#: src/olympia/devhub/templates/devhub/includes/policy_form.html:24
+msgid "If your add-on transmits any data from the user's computer, a privacy policy is required that explains what data is sent and how it is used. It is only relevant for listed add-ons."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/includes/source_form_field.html:2
@@ -6464,12 +6352,8 @@ msgstr ""
 msgid "Add some tags to describe your Theme."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/personas/edit.html:106
-msgid ""
-"A short explanation of your theme's\n"
-"                                basic functionality that is displayed in\n"
-"                                search and browse listings, as well as at\n"
-"                                the top of your theme's details page."
+#: src/olympia/devhub/templates/devhub/personas/edit.html:106 src/olympia/devhub/templates/devhub/personas/submit.html:54
+msgid "A short explanation of your theme's basic functionality that is displayed in search and browse listings, as well as at the top of your theme's details page."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/personas/edit.html:122 src/olympia/devhub/templates/devhub/personas/submit.html:68
@@ -6539,7 +6423,7 @@ msgid "Upon upload and form submission, the AMO Team will review your updated de
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/personas/edit.html:241
-msgid "Your previously resubmitted design,  which is under pending review."
+msgid "Your previously resubmitted design, which is under pending review."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/personas/edit.html:245
@@ -6606,14 +6490,6 @@ msgstr ""
 
 #: src/olympia/devhub/templates/devhub/personas/submit.html:33
 msgid "Give your Theme a name."
-msgstr ""
-
-#: src/olympia/devhub/templates/devhub/personas/submit.html:54
-msgid ""
-"A short explanation of your theme's\n"
-"                                      basic functionality that is displayed in\n"
-"                                      search and browse listings, as well as at\n"
-"                                      the top of your theme's details page."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/personas/submit.html:198
@@ -6690,30 +6566,16 @@ msgstr ""
 msgid "Files added to reviewed versions must be reviewed before they will be available for download."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/add_file_modal.html:15
-#, python-format
-msgid ""
-"Submission of updates to unlisted add-ons for signing is currently in an open beta. Manual review may still be required for a large number of add-ons. Please <a href=\"%(url)s\" target=\"_blank"
-"\">report any bugs</a> that you encounter."
-msgstr ""
-
-#: src/olympia/devhub/templates/devhub/versions/add_file_modal.html:35
+#: src/olympia/devhub/templates/devhub/versions/add_file_modal.html:24
 msgid "Select the target platform for this file."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/add_file_modal.html:46
+#: src/olympia/devhub/templates/devhub/versions/add_file_modal.html:35
 msgid "Which review type would you like to nominate for?"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/add_file_modal.html:51
+#: src/olympia/devhub/templates/devhub/versions/add_file_modal.html:40
 msgid "Only publish this version to my beta channel."
-msgstr ""
-
-#: src/olympia/devhub/templates/devhub/versions/add_file_modal.html:54
-#, python-format
-msgid ""
-"The behavior of the beta channel has changed to accommodate <a href=\"%(addon_signing_url)s\" target=\"_blank\">mandatory add-on signing</a>. The new process is currently in an open beta, and may "
-"change significantly in the near future. Please <a href=\"%(issues_url)s\" target=\"_blank\">report any bugs</a> that you encounter."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/versions/edit.html:5
@@ -6739,19 +6601,10 @@ msgstr ""
 msgid "Upload Another File"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/edit.html:45
-msgid ""
-"Adjusting application information here will allow users to install your\n"
-"                          add-on even if the install manifest in the package indicates that the\n"
-"                          add-on is incompatible."
-msgstr ""
-
 #: src/olympia/devhub/templates/devhub/versions/edit.html:74
 msgid ""
-"Information about changes in this release, new features,\n"
-"                              known bugs, and other useful information specific to this\n"
-"                              release/version. This information is also shown in the\n"
-"                              Add-ons Manager when updating."
+"Information about changes in this release, new features, known bugs, and other useful information specific to this release/version. This information is also shown in the Add-ons Manager when "
+"updating."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/versions/edit.html:99
@@ -6763,10 +6616,7 @@ msgid "Notes for Reviewers"
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/versions/edit.html:114
-msgid ""
-"Optionally, enter any information that may be useful\n"
-"                              to the Editor reviewing this add-on, such as test\n"
-"                              account information."
+msgid "Optionally, enter any information that may be useful to the Editor reviewing this add-on, such as test account information."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/versions/edit.html:127
@@ -6844,7 +6694,7 @@ msgstr ""
 msgid "Request Preliminary Review"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:80 src/olympia/devhub/templates/devhub/versions/list.html:327 src/olympia/devhub/templates/devhub/versions/list.html:350
+#: src/olympia/devhub/templates/devhub/versions/list.html:80 src/olympia/devhub/templates/devhub/versions/list.html:325 src/olympia/devhub/templates/devhub/versions/list.html:348
 msgid "Cancel Review Request"
 msgstr ""
 
@@ -6873,7 +6723,7 @@ msgid "Unlisted:"
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/versions/list.html:114
-msgid "Not distributed on {0}. Developers will upload new versions for signing and distribute the add-ons on their own. (beta)"
+msgid "Not distributed on {0}. Developers will upload new versions for signing and distribute the add-ons on their own."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/versions/list.html:122
@@ -6938,81 +6788,73 @@ msgid "<strong>Important:</strong> Once a version has been deleted, you may not 
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/versions/list.html:230
-msgid ""
-"Deleting a version which has already been reviewed\n"
-"               may also cause a significant delay in the review of\n"
-"               your next update."
-msgstr ""
-
-#: src/olympia/devhub/templates/devhub/versions/list.html:233
 msgid "Are you sure you wish to delete this version?"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:238
+#: src/olympia/devhub/templates/devhub/versions/list.html:235
 msgid "Delete Version"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:240
+#: src/olympia/devhub/templates/devhub/versions/list.html:237
 msgid "Disable Version"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:247
+#: src/olympia/devhub/templates/devhub/versions/list.html:244
 msgid "Add a new Version"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:249
+#: src/olympia/devhub/templates/devhub/versions/list.html:246
 msgid "Add Version"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:256 src/olympia/devhub/templates/devhub/versions/list.html:274
+#: src/olympia/devhub/templates/devhub/versions/list.html:253 src/olympia/devhub/templates/devhub/versions/list.html:279
 msgid "Hide Add-on"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:259
+#: src/olympia/devhub/templates/devhub/versions/list.html:256
 msgid "Hiding your add-on will prevent it from appearing anywhere in our gallery and will stop users from receiving automatic updates."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:265
+#: src/olympia/devhub/templates/devhub/versions/list.html:263
+msgid "The files awaiting review will be disabled and you will need to upload new versions."
+msgstr ""
+
+#: src/olympia/devhub/templates/devhub/versions/list.html:270
 msgid "Are you sure you wish to hide your add-on?"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:286 src/olympia/devhub/templates/devhub/versions/list.html:315
+#: src/olympia/devhub/templates/devhub/versions/list.html:291 src/olympia/devhub/templates/devhub/versions/list.html:313
 msgid "Unlist Add-on"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:289
+#: src/olympia/devhub/templates/devhub/versions/list.html:294
 #, python-format
 msgid ""
 "Unlisting your add-on will make it (and each of its versions/files) invisible on this website. It won't show up in searches, won't have a public facing page, and won't be updated automatically for "
-"current users.  It is recommended for unlisted add-ons to provide a custom <a href=\"%(update_url)s\" target=\"_blank\">updateURL</a> in their manifest file for automatic updates."
+"current users. It is recommended for unlisted add-ons to provide a custom <a href=\"%(update_url)s\" target=\"_blank\">updateURL</a> in their manifest file for automatic updates."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:299
-#, python-format
-msgid "Switching add-ons to unlisted is currently in an open beta. Please <a href=\"%(url)s\" target=\"_blank\">report any bugs</a> that you encounter."
-msgstr ""
-
-#: src/olympia/devhub/templates/devhub/versions/list.html:305
+#: src/olympia/devhub/templates/devhub/versions/list.html:303
 msgid "Unlisting an add-on is irreversible!"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:305
+#: src/olympia/devhub/templates/devhub/versions/list.html:303
 msgid "An unlisted add-on cannot be switched to be listed."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:307
+#: src/olympia/devhub/templates/devhub/versions/list.html:305
 msgid "Are you sure you wish to unlist your add-on?"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:330
+#: src/olympia/devhub/templates/devhub/versions/list.html:328
 msgid "Canceling your review request will leave your add-on as preliminarily reviewed."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:335
+#: src/olympia/devhub/templates/devhub/versions/list.html:333
 msgid "Canceling your review request will mark your add-on incomplete. If you do not complete your add-on after several days by re-requesting review, it will be deleted."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:343
+#: src/olympia/devhub/templates/devhub/versions/list.html:341
 msgid "Are you sure you wish to cancel your review request?"
 msgstr ""
 
@@ -7354,22 +7196,22 @@ msgstr ""
 msgid "Search by add-on name / author email"
 msgstr ""
 
-#: src/olympia/editors/forms.py:103
+#: src/olympia/editors/forms.py:103 src/olympia/editors/forms.py:244 src/olympia/editors/forms.py:257
 #, fuzzy
 msgid "yes"
 msgstr "yes"
 
-#: src/olympia/editors/forms.py:104
+#: src/olympia/editors/forms.py:104 src/olympia/editors/forms.py:244 src/olympia/editors/forms.py:257
 #, fuzzy
 msgid "no"
 msgstr "no"
 
-#: src/olympia/editors/forms.py:105
+#: src/olympia/editors/forms.py:105 src/olympia/editors/forms.py:245
 #, fuzzy
 msgid "Admin Flag"
 msgstr "Admin Flag"
 
-#: src/olympia/editors/forms.py:113
+#: src/olympia/editors/forms.py:113 src/olympia/editors/forms.py:253
 #, fuzzy
 msgid "Max. Version"
 msgstr "Max. Version"
@@ -7383,57 +7225,61 @@ msgstr ""
 msgid "Add-on Types"
 msgstr "Add-on Types"
 
-#: src/olympia/editors/forms.py:126 src/olympia/editors/helpers.py:267
+#: src/olympia/editors/forms.py:126 src/olympia/editors/helpers.py:279
 #, fuzzy
 msgid "Platforms"
 msgstr "Platforms"
 
+#: src/olympia/editors/forms.py:237
+msgid "Search by add-on name / author email / guid"
+msgstr ""
+
 #. L10n: 0 = platform, 1 = filename, 2 = status message
-#: src/olympia/editors/forms.py:238
+#: src/olympia/editors/forms.py:342
 #, python-format
 msgid "<strong>%s</strong> &middot; %s &middot; %s"
 msgstr ""
 
-#: src/olympia/editors/forms.py:252
+#: src/olympia/editors/forms.py:356
 msgid "Comments:"
 msgstr "Тайлбар:"
 
-#: src/olympia/editors/forms.py:256
+#: src/olympia/editors/forms.py:360
 msgid "Operating systems:"
 msgstr ""
 
-#: src/olympia/editors/forms.py:258
+#: src/olympia/editors/forms.py:362
 msgid "Applications:"
 msgstr "Програмууд:"
 
-#: src/olympia/editors/forms.py:260
+#: src/olympia/editors/forms.py:364
 #, fuzzy
 msgid "Notify me the next time this add-on is updated. (Subsequent updates will not generate an email)"
 msgstr "Notify me the next time this add-on is updated. (Subsequent updates will not generate an email)"
 
-#: src/olympia/editors/forms.py:265
+#: src/olympia/editors/forms.py:369
 msgid "Clear Admin Review Flag"
 msgstr ""
 
-#: src/olympia/editors/forms.py:267
+#: src/olympia/editors/forms.py:371
 msgid "Clear more info requested flag"
 msgstr ""
 
-#: src/olympia/editors/forms.py:281
+#: src/olympia/editors/forms.py:385
 msgid "Choose a canned response..."
 msgstr ""
 
 #. L10n: Description of what can be searched for.
-#: src/olympia/editors/forms.py:324
+#: src/olympia/editors/forms.py:423
 msgid "theme name"
 msgstr ""
 
-#: src/olympia/editors/forms.py:350
+#: src/olympia/editors/forms.py:449
 msgid "Someone else is reviewing this theme."
 msgstr ""
 
 #. L10n: Description of what can be searched for.
-#: src/olympia/editors/forms.py:447
+#: src/olympia/editors/forms.py:546
 msgid "app, reviewer, or comment"
 msgstr ""
 
@@ -7449,194 +7295,212 @@ msgstr ""
 msgid "Rejected or Unreviewed"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:123 src/olympia/editors/helpers.py:136
+#: src/olympia/editors/helpers.py:125 src/olympia/editors/helpers.py:138
 msgid "Queue"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:124 src/olympia/editors/templates/editors/base.html:50 src/olympia/editors/templates/editors/base.html:65
+#: src/olympia/editors/helpers.py:126 src/olympia/editors/templates/editors/base.html:50 src/olympia/editors/templates/editors/base.html:65
 msgid "Pending Updates"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:125 src/olympia/editors/templates/editors/base.html:48 src/olympia/editors/templates/editors/base.html:63
+#: src/olympia/editors/helpers.py:127 src/olympia/editors/templates/editors/base.html:48 src/olympia/editors/templates/editors/base.html:63
 msgid "Full Reviews"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:126 src/olympia/editors/templates/editors/base.html:52 src/olympia/editors/templates/editors/base.html:67
+#: src/olympia/editors/helpers.py:128 src/olympia/editors/templates/editors/base.html:52 src/olympia/editors/templates/editors/base.html:67
 msgid "Preliminary Reviews"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:127 src/olympia/editors/templates/editors/base.html:54
+#: src/olympia/editors/helpers.py:129 src/olympia/editors/templates/editors/base.html:54
 msgid "Moderated Reviews"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:128 src/olympia/editors/templates/editors/base.html:46
+#: src/olympia/editors/helpers.py:130 src/olympia/editors/templates/editors/base.html:46
 msgid "Fast Track"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:130
+#: src/olympia/editors/helpers.py:132
 msgid "Pending Themes"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:131 src/olympia/editors/templates/editors/themes/queue.html:4
+#: src/olympia/editors/helpers.py:133 src/olympia/editors/templates/editors/themes/queue.html:4
 msgid "Flagged Themes"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:132
+#: src/olympia/editors/helpers.py:134
 msgid "Update Themes"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:137
+#: src/olympia/editors/helpers.py:139
 msgid "Unlisted Pending Updates"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:138
+#: src/olympia/editors/helpers.py:140
 msgid "Unlisted Full Reviews"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:139
+#: src/olympia/editors/helpers.py:141
 msgid "Unlisted Preliminary Reviews"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:170
+#: src/olympia/editors/helpers.py:142
+msgid "Unlisted All Add-ons"
+msgstr ""
+
+#: src/olympia/editors/helpers.py:173
 msgid "Fast Track ({0})"
 msgid_plural "Fast Track ({0})"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/olympia/editors/helpers.py:175
+#: src/olympia/editors/helpers.py:178
 msgid "Full Review ({0})"
 msgid_plural "Full Reviews ({0})"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/olympia/editors/helpers.py:180
+#: src/olympia/editors/helpers.py:183
 msgid "Pending Update ({0})"
 msgid_plural "Pending Updates ({0})"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/olympia/editors/helpers.py:185
+#: src/olympia/editors/helpers.py:188
 msgid "Preliminary Review ({0})"
 msgid_plural "Preliminary Reviews ({0})"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/olympia/editors/helpers.py:190
+#: src/olympia/editors/helpers.py:193
 msgid "Moderated Review ({0})"
 msgid_plural "Moderated Reviews ({0})"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/olympia/editors/helpers.py:196
+#: src/olympia/editors/helpers.py:199
 msgid "Unlisted Full Review ({0})"
 msgid_plural "Unlisted Full Reviews ({0})"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/olympia/editors/helpers.py:201
+#: src/olympia/editors/helpers.py:204
 msgid "Unlisted Pending Update ({0})"
 msgid_plural "Unlisted Pending Updates ({0})"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/olympia/editors/helpers.py:206
+#: src/olympia/editors/helpers.py:209
 msgid "Unlisted Preliminary Review ({0})"
 msgid_plural "Unlisted Preliminary Reviews ({0})"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/olympia/editors/helpers.py:261
-msgid "Addon"
-msgstr ""
+#: src/olympia/editors/helpers.py:214
+msgid "Unlisted All Add-ons ({0})"
+msgid_plural "Unlisted All Add-ons ({0})"
+msgstr[0] ""
+msgstr[1] ""
 
-#: src/olympia/editors/helpers.py:262
+#: src/olympia/editors/helpers.py:274
 msgid "Type"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:263
+#: src/olympia/editors/helpers.py:275
 msgid "Waiting Time"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:264 src/olympia/editors/templates/editors/review.html:285
+#: src/olympia/editors/helpers.py:276 src/olympia/editors/templates/editors/review.html:285
 #, fuzzy
 msgid "Flags"
 msgstr "Flags"
 
-#: src/olympia/editors/helpers.py:265
+#: src/olympia/editors/helpers.py:277
 msgid "Applications"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:270
+#: src/olympia/editors/helpers.py:282
 msgid "Additional"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:285
+#: src/olympia/editors/helpers.py:302
 msgid "Site Specific"
 msgstr "Тусгай хуудсанд зориулсан"
 
-#: src/olympia/editors/helpers.py:287
+#: src/olympia/editors/helpers.py:304
 msgid "Requires External Software"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:289
+#: src/olympia/editors/helpers.py:306
 msgid "Binary Components"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:313
+#: src/olympia/editors/helpers.py:339
 msgid "moments ago"
 msgstr ""
 
 #. L10n: first argument is number of minutes
-#: src/olympia/editors/helpers.py:316
+#: src/olympia/editors/helpers.py:342
 msgid "{0} minute"
 msgid_plural "{0} minutes"
 msgstr[0] ""
 msgstr[1] ""
 
 #. L10n: first argument is number of hours
-#: src/olympia/editors/helpers.py:320
+#: src/olympia/editors/helpers.py:346
 msgid "{0} hour"
 msgid_plural "{0} hours"
 msgstr[0] ""
 msgstr[1] ""
 
 #. L10n: first argument is number of days
-#: src/olympia/editors/helpers.py:324
+#: src/olympia/editors/helpers.py:350
 msgid "{0} day"
 msgid_plural "{0} days"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/olympia/editors/helpers.py:488
+#: src/olympia/editors/helpers.py:364
+msgid "Last Review"
+msgstr ""
+
+#: src/olympia/editors/helpers.py:366
+msgid "Last Update"
+msgstr ""
+
+#: src/olympia/editors/helpers.py:387
+msgid "No Reviews"
+msgstr ""
+
+#: src/olympia/editors/helpers.py:561
 msgid "Push to public"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:490
+#: src/olympia/editors/helpers.py:563
 msgid "Grant full review"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:505
+#: src/olympia/editors/helpers.py:578
 msgid "Request more information"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:508
+#: src/olympia/editors/helpers.py:581
 msgid "Request super-review"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:519
+#: src/olympia/editors/helpers.py:592
 msgid "Grant preliminary review"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:520
+#: src/olympia/editors/helpers.py:593
 msgid "This will mark the files as preliminarily reviewed."
 msgstr ""
 
-#: src/olympia/editors/helpers.py:522
+#: src/olympia/editors/helpers.py:595
 #, fuzzy
 msgid "Use this form to request more information from the author. They will receive an email and be able to answer here. You will be notified by email when they reply."
 msgstr "Use this form to request more information from the author. They will receive an email and be able to answer here. You will be notified by email when they reply."
 
-#: src/olympia/editors/helpers.py:526
+#: src/olympia/editors/helpers.py:599
 msgid ""
 "If you have concerns about this add-on's security, copyright issues, or other concerns that an administrator should look into, enter your comments in the area below. They will be sent to "
 "administrators, not the author."
@@ -7644,55 +7508,55 @@ msgstr ""
 "Хэрэв та энэ нэмэгдлийн нууцлал юмуу эсвэл зохиогчийн эрхтэй холбоотой зүйлүүд эсвэл администратор харах хэрэгтэй зүйлс байгаа гэж бодож байгаа бол дараах талбарт бичээрэй. Тэр нь зохиогч уруу биш "
 "администратор луу илгээгдэх болно."
 
-#: src/olympia/editors/helpers.py:532
+#: src/olympia/editors/helpers.py:605
 msgid "This will reject the add-on and remove it from the review queue."
 msgstr ""
 
-#: src/olympia/editors/helpers.py:534
-msgid "Make a comment on this version.  The author won't be able to see this."
+#: src/olympia/editors/helpers.py:607
+msgid "Make a comment on this version. The author won't be able to see this."
 msgstr ""
 
-#: src/olympia/editors/helpers.py:538
+#: src/olympia/editors/helpers.py:611
 msgid "This will reject the files and remove them from the review queue."
 msgstr ""
 
-#: src/olympia/editors/helpers.py:542
+#: src/olympia/editors/helpers.py:615
 msgid "This will mark the add-on as preliminarily reviewed. Future versions will undergo preliminary review."
 msgstr ""
 
-#: src/olympia/editors/helpers.py:547
+#: src/olympia/editors/helpers.py:620
 msgid "This will mark the files as preliminarily reviewed. Future versions will undergo preliminary review."
 msgstr ""
 
-#: src/olympia/editors/helpers.py:552
+#: src/olympia/editors/helpers.py:625
 msgid "Retain preliminary review"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:553
+#: src/olympia/editors/helpers.py:626
 msgid "This will retain the add-on as preliminarily reviewed. Future versions will undergo preliminary review."
 msgstr ""
 
-#: src/olympia/editors/helpers.py:558
+#: src/olympia/editors/helpers.py:631
 msgid "This will approve a sandboxed version of a public add-on to appear on the public side."
 msgstr "Энэ нь нийтийн түр байрлуулах хайрцагт буй нэмэгдлийн хувилбарыг нийтийн хуудсанд харуулагдах эрх өгдөг."
 
-#: src/olympia/editors/helpers.py:561
+#: src/olympia/editors/helpers.py:634
 msgid "This will reject a version of a public add-on and remove it from the queue."
 msgstr ""
 
-#: src/olympia/editors/helpers.py:564
+#: src/olympia/editors/helpers.py:637
 msgid "This will mark the add-on and its most recent version and files as public. Future versions will go into the sandbox until they are reviewed by an editor."
 msgstr "Энэ нь нэмэгдэл болон түүний хамгийн сүүлийн хувилбар ба файлуудыг олон нийтийн хуудсанд тэмдэглэдэг. Дараагийн хувилбарууд нь завсарлагчаар хянагдах хүртэл түр хайрцагт байрлах болно."
 
-#: src/olympia/editors/helpers.py:637
+#: src/olympia/editors/helpers.py:714
 msgid "add-on"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:940 src/olympia/editors/helpers.py:960
+#: src/olympia/editors/helpers.py:1020 src/olympia/editors/helpers.py:1040
 msgid "Flagged"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:944 src/olympia/editors/helpers.py:963
+#: src/olympia/editors/helpers.py:1024 src/olympia/editors/helpers.py:1043
 msgid "Updates"
 msgstr ""
 
@@ -7744,56 +7608,56 @@ msgstr ""
 msgid "A question about your Theme submission"
 msgstr ""
 
-#: src/olympia/editors/views.py:144
+#: src/olympia/editors/views.py:146
 msgid "New Add-ons (Under 5 days)"
 msgstr ""
 
-#: src/olympia/editors/views.py:145
+#: src/olympia/editors/views.py:147
 msgid "Passable (5 to 10 days)"
 msgstr ""
 
-#: src/olympia/editors/views.py:146
+#: src/olympia/editors/views.py:148
 msgid "Overdue (Over 10 days)"
 msgstr ""
 
-#: src/olympia/editors/views.py:532
+#: src/olympia/editors/views.py:539
 msgid "An unknown error occurred"
 msgstr ""
 
-#: src/olympia/editors/views.py:587
+#: src/olympia/editors/views.py:592
 msgid "Self-reviews are not allowed."
 msgstr "Өөрсдөө үнэлж дүгнэх хориотой."
 
-#: src/olympia/editors/views.py:609
+#: src/olympia/editors/views.py:613
 msgid "Review successfully processed."
 msgstr "Хянах дүгнэлт амжилттай гүйцэтгэгдлээ."
 
-#: src/olympia/editors/views.py:807
+#: src/olympia/editors/views.py:812
 msgid "was approved"
 msgstr ""
 
-#: src/olympia/editors/views.py:808
+#: src/olympia/editors/views.py:813
 msgid "given preliminary review"
 msgstr ""
 
-#: src/olympia/editors/views.py:809
+#: src/olympia/editors/views.py:814
 msgid "rejected"
 msgstr ""
 
-#: src/olympia/editors/views.py:810
+#: src/olympia/editors/views.py:815
 msgctxt "editors_review_history_nominated_adminreview"
 msgid "escalated"
 msgstr ""
 
-#: src/olympia/editors/views.py:812
+#: src/olympia/editors/views.py:817
 msgid "needs more information"
 msgstr ""
 
-#: src/olympia/editors/views.py:813
+#: src/olympia/editors/views.py:818
 msgid "needs super review"
 msgstr ""
 
-#: src/olympia/editors/views.py:814
+#: src/olympia/editors/views.py:819
 msgid "commented"
 msgstr ""
 
@@ -7838,29 +7702,29 @@ msgstr ""
 msgid "Unlisted Queues"
 msgstr ""
 
-#: src/olympia/editors/templates/editors/base.html:72 src/olympia/editors/templates/editors/performance.html:6
+#: src/olympia/editors/templates/editors/base.html:74 src/olympia/editors/templates/editors/performance.html:6
 #, fuzzy
 msgid "Performance"
 msgstr "Performance"
 
-#: src/olympia/editors/templates/editors/base.html:75 src/olympia/editors/templates/editors/themes/base.html:19 src/olympia/editors/templates/editors/themes/base.html:38
+#: src/olympia/editors/templates/editors/base.html:77 src/olympia/editors/templates/editors/themes/base.html:19 src/olympia/editors/templates/editors/themes/base.html:38
 msgid "Logs"
 msgstr ""
 
-#: src/olympia/editors/templates/editors/base.html:78 src/olympia/editors/templates/editors/reviewlog.html:4 src/olympia/editors/templates/editors/reviewlog.html:27
+#: src/olympia/editors/templates/editors/base.html:80 src/olympia/editors/templates/editors/reviewlog.html:4 src/olympia/editors/templates/editors/reviewlog.html:27
 msgid "Add-on Review Log"
 msgstr ""
 
-#: src/olympia/editors/templates/editors/base.html:80 src/olympia/editors/templates/editors/eventlog.html:4 src/olympia/editors/templates/editors/eventlog.html:8
+#: src/olympia/editors/templates/editors/base.html:82 src/olympia/editors/templates/editors/eventlog.html:4 src/olympia/editors/templates/editors/eventlog.html:8
 #: src/olympia/editors/templates/editors/eventlog_detail.html:4
 msgid "Moderated Review Log"
 msgstr ""
 
-#: src/olympia/editors/templates/editors/base.html:82 src/olympia/editors/templates/editors/beta_signed_log.html:4 src/olympia/editors/templates/editors/beta_signed_log.html:8
+#: src/olympia/editors/templates/editors/base.html:84 src/olympia/editors/templates/editors/beta_signed_log.html:4 src/olympia/editors/templates/editors/beta_signed_log.html:8
 msgid "Signed Beta Files Log"
 msgstr ""
 
-#: src/olympia/editors/templates/editors/base.html:87 src/olympia/editors/templates/editors/includes/daily-message.html:4
+#: src/olympia/editors/templates/editors/base.html:89 src/olympia/editors/templates/editors/includes/daily-message.html:4
 msgid "Announcement"
 msgstr ""
 
@@ -8082,46 +7946,46 @@ msgstr ""
 msgid "clear search"
 msgstr ""
 
-#: src/olympia/editors/templates/editors/queue.html:72 src/olympia/editors/templates/editors/queue.html:122
+#: src/olympia/editors/templates/editors/queue.html:78 src/olympia/editors/templates/editors/queue.html:128
 msgid "Process Reviews"
 msgstr "Хянаж дүгнэлт хийх"
 
-#: src/olympia/editors/templates/editors/queue.html:80
+#: src/olympia/editors/templates/editors/queue.html:86
 msgid "Moderation actions:"
 msgstr ""
 
-#: src/olympia/editors/templates/editors/queue.html:90
+#: src/olympia/editors/templates/editors/queue.html:96
 #, python-format
 msgid "by %(user)s on %(date)s %(stars)s (%(locale)s)"
 msgstr ""
 
-#: src/olympia/editors/templates/editors/queue.html:106
+#: src/olympia/editors/templates/editors/queue.html:112
 #, python-format
 msgid "<strong>%(reason)s</strong> <span class=\"light\">Flagged by %(user)s on %(date)s</span>"
 msgstr ""
 
-#: src/olympia/editors/templates/editors/queue.html:119
-msgid "All reviews have been moderated.  Good work!"
+#: src/olympia/editors/templates/editors/queue.html:125
+msgid "All reviews have been moderated. Good work!"
 msgstr ""
 
-#: src/olympia/editors/templates/editors/queue.html:161
+#: src/olympia/editors/templates/editors/queue.html:167
 msgid "Version Notes / Notes for Reviewer"
 msgstr ""
 
 # %1 is the queue mode
-#: src/olympia/editors/templates/editors/queue.html:169
+#: src/olympia/editors/templates/editors/queue.html:175
 msgid "There are currently no add-ons of this type to review."
 msgstr "Дүгнэлт хийгдэхээр доторх нэмэгдлүүд байхгүй байна."
 
-#: src/olympia/editors/templates/editors/queue.html:181 src/olympia/editors/templates/editors/themes/queue_list.html:85
+#: src/olympia/editors/templates/editors/queue.html:187 src/olympia/editors/templates/editors/themes/queue_list.html:85
 msgid "Helpful Links:"
 msgstr ""
 
-#: src/olympia/editors/templates/editors/queue.html:182
+#: src/olympia/editors/templates/editors/queue.html:188
 msgid "Add-on Policy"
 msgstr "Нэмэгдлийн журам"
 
-#: src/olympia/editors/templates/editors/queue.html:184
+#: src/olympia/editors/templates/editors/queue.html:190
 msgid "Editors' Guide"
 msgstr "Засварлагчийн заавар"
 
@@ -8184,10 +8048,7 @@ msgid "<strong>Warning!</strong> Another user was viewing this page before you."
 msgstr ""
 
 #: src/olympia/editors/templates/editors/review.html:237
-msgid ""
-"The whiteboard is the place to exchange information relevant to\n"
-"               this addon (whatever the version), between the developer and the\n"
-"               editor. This is visible and editable by both."
+msgid "The whiteboard is the place to exchange information relevant to this addon (whatever the version), between the developer and the editor. This is visible and editable by both."
 msgstr ""
 
 #: src/olympia/editors/templates/editors/review.html:241
@@ -8461,7 +8322,7 @@ msgstr ""
 msgid "Describe your reason for flagging"
 msgstr ""
 
-#: src/olympia/files/forms.py:88
+#: src/olympia/files/forms.py:90
 msgid "Cannot diff a version against itself"
 msgstr ""
 
@@ -8496,51 +8357,51 @@ msgstr ""
 msgid "There was an error accessing file %s."
 msgstr ""
 
-#: src/olympia/files/utils.py:343
+#: src/olympia/files/utils.py:340
 msgid "Could not parse uploaded file."
 msgstr ""
 
-#: src/olympia/files/utils.py:380
+#: src/olympia/files/utils.py:377
 msgid "Invalid file name in archive: {0}"
 msgstr ""
 
-#: src/olympia/files/utils.py:388
+#: src/olympia/files/utils.py:385
 msgid "File exceeding size limit in archive: {0}"
 msgstr ""
 
-#: src/olympia/files/utils.py:439
+#: src/olympia/files/utils.py:436
 msgid "Invalid archive."
 msgstr ""
 
-#: src/olympia/files/utils.py:529 src/olympia/files/utils.py:532
+#: src/olympia/files/utils.py:526 src/olympia/files/utils.py:529
 msgid "Could not parse the manifest file."
 msgstr ""
 
-#: src/olympia/files/utils.py:551
+#: src/olympia/files/utils.py:548
 msgid "Could not find an add-on ID."
 msgstr ""
 
-#: src/olympia/files/utils.py:554
+#: src/olympia/files/utils.py:551
 msgid "Add-on ID must be 64 characters or less."
 msgstr ""
 
-#: src/olympia/files/utils.py:556
+#: src/olympia/files/utils.py:553
 msgid "Add-on ID doesn't match add-on."
 msgstr ""
 
-#: src/olympia/files/utils.py:564
+#: src/olympia/files/utils.py:561
 msgid "Duplicate add-on ID found."
 msgstr ""
 
-#: src/olympia/files/utils.py:567
+#: src/olympia/files/utils.py:564
 msgid "Version numbers should have fewer than 32 characters."
 msgstr ""
 
-#: src/olympia/files/utils.py:570
+#: src/olympia/files/utils.py:567
 msgid "Version numbers should only contain letters, numbers, and these punctuation characters: +*.-_."
 msgstr ""
 
-#: src/olympia/files/utils.py:587
+#: src/olympia/files/utils.py:584
 msgid "<em:type> doesn't match add-on"
 msgstr ""
 
@@ -8643,6 +8504,10 @@ msgstr ""
 
 #: src/olympia/files/templates/files/viewer.html:134
 msgid "Fetching file."
+msgstr ""
+
+#: src/olympia/legacy_api/views.py:255
+msgid "Not implemented yet."
 msgstr ""
 
 #: src/olympia/lib/constants.py:6
@@ -9301,10 +9166,6 @@ msgstr ""
 msgid "Zimbabwe Dollar"
 msgstr ""
 
-#: src/olympia/lib/video/ffmpeg.py:112 src/olympia/lib/video/totem.py:81
-msgid "Videos must be in WebM."
-msgstr ""
-
 #: src/olympia/pages/templates/pages/about.lhtml:3 src/olympia/pages/templates/pages/about.lhtml:10
 msgid "About Mozilla Add-ons"
 msgstr ""
@@ -9316,7 +9177,7 @@ msgstr ""
 #: src/olympia/pages/templates/pages/about.lhtml:13
 msgid ""
 "addons.mozilla.org, commonly known as \"AMO\", is Mozilla's official site for add-ons to Mozilla software, such as Firefox, Thunderbird, and SeaMonkey. Add-ons let you add new features and change "
-"the way your browser or application works.  Take a look around and explore the thousands of ways to customize the way you do things online."
+"the way your browser or application works. Take a look around and explore the thousands of ways to customize the way you do things online."
 msgstr ""
 
 #: src/olympia/pages/templates/pages/about.lhtml:19
@@ -9661,7 +9522,7 @@ msgstr ""
 msgid ""
 "Yes. It's possible, but some of the functionality provided by these libraries are available through XPCOM, XUL, and JavaScript. In addition, authors should take care if libraries modify primitive "
 "object prototypes (String.prototype, Date.prototype, etc.) and/or define global functions (eg. the $ function). These are prone to cause conflict with other add-ons, in particular if different add-"
-"ons use different versions of libraries and so on. Developers need to be very, very careful with using them.  Mozilla does not offer documentation on using them to build add-ons."
+"ons use different versions of libraries and so on. Developers need to be very, very careful with using them. Mozilla does not offer documentation on using them to build add-ons."
 msgstr ""
 
 #: src/olympia/pages/templates/pages/dev_faq.html:165
@@ -9775,8 +9636,8 @@ msgstr ""
 #, python-format
 msgid ""
 "Yes. Many developers choose to host their own add-ons. Choosing to host your add-on on <a href=\"%(amo_url)s\">Mozilla's add-on site</a>, though, allows for much greater exposure to your add-on due "
-"to the large volume of visitors to the site.  <a href=\"%(md_url)s\">mozdev.org</a> offers free project hosting for Mozilla applications and extensions providing developers with tools to help "
-"manage source code, version control, bug tracking and documentation."
+"to the large volume of visitors to the site. <a href=\"%(md_url)s\">mozdev.org</a> offers free project hosting for Mozilla applications and extensions providing developers with tools to help manage "
+"source code, version control, bug tracking and documentation."
 msgstr ""
 
 #: src/olympia/pages/templates/pages/dev_faq.html:277
@@ -9824,7 +9685,7 @@ msgstr ""
 #: src/olympia/pages/templates/pages/dev_faq.html:314
 #, python-format
 msgid ""
-"Yes. Mozilla's <a href=\"%(p_url)s\">Add-on Policy</a> describes what is an acceptable submission. This policy is subject to change without notice.  In addition, the AMO editorial team uses the <a "
+"Yes. Mozilla's <a href=\"%(p_url)s\">Add-on Policy</a> describes what is an acceptable submission. This policy is subject to change without notice. In addition, the AMO editorial team uses the <a "
 "href=\"%(g_url)s\">Editors Reviewing Guide</a> to ensure that your add-on meets specific guidelines for functionality and security."
 msgstr ""
 
@@ -9941,7 +9802,7 @@ msgstr ""
 #: src/olympia/pages/templates/pages/dev_faq.html:434
 #, python-format
 msgid ""
-"This is why it's very important to read the <a href=\"%(g_url)s\">Editors Reviewing Guide</a> to ensure that your add-on is setup as expected.  It's also a good idea to read the blog post, <a href="
+"This is why it's very important to read the <a href=\"%(g_url)s\">Editors Reviewing Guide</a> to ensure that your add-on is setup as expected. It's also a good idea to read the blog post, <a href="
 "\"%(blog_url)s\">Successfully Getting your Add-on Reviewed</a> which provides excellent insight into ensuring a smooth review of your add-on."
 msgstr ""
 
@@ -10051,7 +9912,7 @@ msgstr ""
 
 #: src/olympia/pages/templates/pages/dev_faq.html:572
 msgid ""
-"Free Software Foundation provides short summaries of the key open source licenses, including whether the license qualifies as a free software license or a copyleft license.  Also includes a "
+"Free Software Foundation provides short summaries of the key open source licenses, including whether the license qualifies as a free software license or a copyleft license. Also includes a "
 "discussion of what constitutes a free software license or a copyleft license (e.g., a Copyleft license is a general method for making a program or other work free, and requiring all modified and "
 "extended versions of the program to be free as well.)"
 msgstr ""
@@ -10229,19 +10090,13 @@ msgid "Add-on Gallery"
 msgstr ""
 
 #: src/olympia/pages/templates/pages/faq.html:171
-msgid ""
-"How do I choose between add-ons that seem to do the same\n"
-"    thing?"
+msgid "How do I choose between add-ons that seem to do the same thing?"
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:173
+#: src/olympia/pages/templates/pages/faq.html:172
 msgid ""
-"There are often several add-ons that have similar features. To\n"
-"    figure out which is right for you, read the entire description of the\n"
-"    add-on and view its screenshots. If there are still several in the running,\n"
-"    read through the add-on's ratings, user reviews, and statistics to see\n"
-"    which is most liked by other users. Remember that you can also just try\n"
-"    out both and see which you like better."
+"There are often several add-ons that have similar features. To figure out which is right for you, read the entire description of the add-on and view its screenshots. If there are still several in "
+"the running, read through the add-on's ratings, user reviews, and statistics to see which is most liked by other users. Remember that you can also just try out both and see which you like better."
 msgstr ""
 
 #: src/olympia/pages/templates/pages/faq.html:180
@@ -10282,80 +10137,67 @@ msgid "How much do add-ons cost to purchase?"
 msgstr ""
 
 #: src/olympia/pages/templates/pages/faq.html:207
-msgid ""
-"Add-ons hosted in our gallery are free unless clearly marked\n"
-"    otherwise."
+msgid "Add-ons hosted in our gallery are free unless clearly marked otherwise."
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:210
+#: src/olympia/pages/templates/pages/faq.html:209
 msgid "What does it mean when an add-on asks for contributions?"
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:211
+#: src/olympia/pages/templates/pages/faq.html:210
 msgid ""
-"Some add-on authors request users who enjoy an add-on to\n"
-"        contribute to its development by making a monetary contribution. These\n"
-"        contributions go directly to the developer unless a third party is\n"
-"        indicated, such as the non-profit Mozilla Foundation."
+"Some add-on authors request users who enjoy an add-on to contribute to its development by making a monetary contribution. These contributions go directly to the developer unless a third party is "
+"indicated, such as the non-profit Mozilla Foundation."
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:216
+#: src/olympia/pages/templates/pages/faq.html:215
 msgid "What are beta add-ons?"
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:218
+#: src/olympia/pages/templates/pages/faq.html:217
 msgid ""
-"Beta add-ons are unreviewed versions which represent the\n"
-"        latest work of an add-on author. While different authors have different\n"
-"        standards for beta code quality, you should assume that these add-ons\n"
-"        are less stable than the general add-on releases."
+"Beta add-ons are unreviewed versions which represent the latest work of an add-on author. While different authors have different standards for beta code quality, you should assume that these add-"
+"ons are less stable than the general add-on releases."
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:222
+#: src/olympia/pages/templates/pages/faq.html:221
 msgid ""
 "Please note that when you install an add-on from the \"Beta Version\" section of an add-on's listing, you will continue to receive updates for that add-on as they become available. Like the initial "
 "version you installed, all beta releases are unreviewed by Mozilla and may harm your computer."
 msgstr ""
 
+#: src/olympia/pages/templates/pages/faq.html:228
+msgid "What does it mean when an add-on is flagged as slow?"
+msgstr ""
+
 #: src/olympia/pages/templates/pages/faq.html:229
-msgid ""
-"What does it mean when an add-on is flagged as\n"
-"    slow?"
+msgid "Most add-ons load code and resources at the same time Firefox is starting up. In most cases the impact in start-up time is minimal, but some add-ons can cause a noticeable slowdown."
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:231
-msgid ""
-"Most add-ons load code and resources at the same time Firefox\n"
-"        is starting up. In most cases the impact in start-up time is minimal,\n"
-"        but some add-ons can cause a noticeable slowdown."
-msgstr ""
-
-#: src/olympia/pages/templates/pages/faq.html:236
+#: src/olympia/pages/templates/pages/faq.html:234
 msgid "How do I report an inappropriate or spam user review?"
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:237
+#: src/olympia/pages/templates/pages/faq.html:235
 msgid ""
-"To report a user review of an add-on, log in with your account\n"
-"    and visit the add-on's reviews page. Find the review you wish to report,\n"
-"    click \"Report this review\" and select a reason. Our editorial team will\n"
-"    investigate the review and take appropriate action."
+"To report a user review of an add-on, log in with your account and visit the add-on's reviews page. Find the review you wish to report, click \"Report this review\" and select a reason. Our "
+"editorial team will investigate the review and take appropriate action."
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:242
+#: src/olympia/pages/templates/pages/faq.html:240
 msgid "How do I report a bug or contact the Mozilla Add-ons team?"
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:243
+#: src/olympia/pages/templates/pages/faq.html:241
 #, python-format
 msgid "Please visit our <a href=\"%(contact_url)s\">Contact page</a>."
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:246
+#: src/olympia/pages/templates/pages/faq.html:244
 msgid "What is a Source Code License?"
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:247
+#: src/olympia/pages/templates/pages/faq.html:245
 #, python-format
 msgid ""
 "The source code used to create an add-on is an exclusive copyright of the add-on author, unless otherwise declared in a source code license. Many add-ons on this site have <a href=\"%(url)s\" lang="
@@ -10363,60 +10205,60 @@ msgid ""
 "the GPL or BSD licenses instead of making up their own."
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:256
+#: src/olympia/pages/templates/pages/faq.html:254
 #, python-format
 msgid "Firefox and other Mozilla software are <a href=\"%(url)s\">open source</a>."
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:264
+#: src/olympia/pages/templates/pages/faq.html:262
 msgid "Collections and Favorites"
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:267
+#: src/olympia/pages/templates/pages/faq.html:265
 msgid "What is a collection?"
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:268
+#: src/olympia/pages/templates/pages/faq.html:266
 msgid "Collections are groups of related add-ons created by users to share."
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:270
+#: src/olympia/pages/templates/pages/faq.html:268
 msgid "What is the My Favorites collection?"
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:271
+#: src/olympia/pages/templates/pages/faq.html:269
 msgid "Favorite add-ons are add-ons that you have bookmarked to easily get back to later. You can add an add-on to your favorites collection by clicking \"Add to favorites\" on its details page."
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:275 src/olympia/templates/menu_links.html:13 src/olympia/templates/impala/header_title.html:17
+#: src/olympia/pages/templates/pages/faq.html:273 src/olympia/templates/menu_links.html:13 src/olympia/templates/impala/header_title.html:17
 msgid "Mobile Add-ons"
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:278
+#: src/olympia/pages/templates/pages/faq.html:276
 msgid "What are mobile add-ons?"
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:279
+#: src/olympia/pages/templates/pages/faq.html:277
 #, python-format
 msgid ""
 "Mobile add-ons work with <a href=\"%(mobile_url)s\">Firefox for Mobile</a> and add or modify functionality just like desktop add-ons. You can find add-ons that work with Firefox for Mobile in our "
 "<a href=\"%(gallery_url)s\">gallery</a>."
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:288
+#: src/olympia/pages/templates/pages/faq.html:286
 msgid "Developer Topics"
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:289
+#: src/olympia/pages/templates/pages/faq.html:287
 #, python-format
 msgid "Please see our <a href=\"%(faq_url)s\">Developer FAQ</a> and <a href=\"%(hub_url)s\">Developer Hub</a> for answers to add-on developer-related questions."
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:294
+#: src/olympia/pages/templates/pages/faq.html:292
 msgid "Still have questions?"
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:295
+#: src/olympia/pages/templates/pages/faq.html:293
 #, python-format
 msgid "For general Firefox support, visit our <a href=\"%(sumo_url)s\">support website</a>. For general add-on and website questions, visit our <a href=\"%(forum_url)s\">forum</a>."
 msgstr ""
@@ -10554,7 +10396,7 @@ msgstr ""
 
 #: src/olympia/pages/templates/pages/sunbird.html:29
 msgid ""
-"Development on the Sunbird project has halted and its final release was on March 30, 2010.  We've been proud to host Sunbird add-ons on this site but as the project is no longer maintained we have "
+"Development on the Sunbird project has halted and its final release was on March 30, 2010. We've been proud to host Sunbird add-ons on this site but as the project is no longer maintained we have "
 "disabled our support for the add-ons."
 msgstr ""
 
@@ -10634,7 +10476,7 @@ msgstr ""
 #, python-format
 msgid ""
 "<h2>Keep these tips in mind:</h2> <ul> <li> Write like you're telling a friend about your experience with the add-on. Give specifics and helpful details, such as what features you liked and/or "
-"disliked, how easy to use it is, and any disadvantages it has.  Avoid generic language such as calling it \"Great\" or \"Bad\" unless you can give reasons why you believe this is so. </li> <li> "
+"disliked, how easy to use it is, and any disadvantages it has. Avoid generic language such as calling it \"Great\" or \"Bad\" unless you can give reasons why you believe this is so. </li> <li> "
 "Please do not post bug reports in reviews. We do not make your email address available to add-on developers and they may need to contact you to help resolve your issue. See the <a href=\"%(support)s"
 "\">support section</a> to find out where to get assistance for this add-on. </li> <li>Please keep reviews clean, avoid the use of improper language and do not post any personal information. </li> </"
 "ul> <p>Please read the <a href=\"%(guide)s\" target=\"_blank\">Review Guidelines</a> for more detail about user add-on reviews.</p>"
@@ -10894,16 +10736,16 @@ msgstr ""
 
 #. L10n: {0} is an application, such as Firefox. This means "any version of
 #. Firefox."
-#: src/olympia/search/views.py:554
+#: src/olympia/search/views.py:547
 msgid "Any {0}"
 msgstr ""
 
 #. L10n: "All Systems" means show everything regardless of platform.
-#: src/olympia/search/views.py:589
+#: src/olympia/search/views.py:582
 msgid "All Systems"
 msgstr ""
 
-#: src/olympia/search/views.py:600
+#: src/olympia/search/views.py:593
 msgid "All Tags"
 msgstr ""
 
@@ -11081,31 +10923,31 @@ msgstr "Share this Add-on"
 msgid "Share this Collection"
 msgstr "Create Collection"
 
-#: src/olympia/signing/views.py:30 src/olympia/templates/base.html:75 src/olympia/templates/impala/base.html:115
+#: src/olympia/signing/views.py:33 src/olympia/templates/base.html:71 src/olympia/templates/impala/base.html:112
 msgid "Some features are temporarily disabled while we perform website maintenance. We'll be back to full capacity shortly."
 msgstr ""
 
-#: src/olympia/signing/views.py:53
+#: src/olympia/signing/views.py:56
 msgid "Could not find add-on with id \"{}\"."
 msgstr ""
 
-#: src/olympia/signing/views.py:67
+#: src/olympia/signing/views.py:70
 msgid "You do not own this addon."
 msgstr ""
 
-#: src/olympia/signing/views.py:82
+#: src/olympia/signing/views.py:87
 msgid "Missing \"upload\" key in multipart file data."
 msgstr ""
 
-#: src/olympia/signing/views.py:96
+#: src/olympia/signing/views.py:101
 msgid "Version does not match the manifest file."
 msgstr ""
 
-#: src/olympia/signing/views.py:100
+#: src/olympia/signing/views.py:105
 msgid "Version already exists."
 msgstr ""
 
-#: src/olympia/signing/views.py:136
+#: src/olympia/signing/views.py:141
 msgid "No uploaded file for that addon and version."
 msgstr ""
 
@@ -11218,89 +11060,89 @@ msgstr ""
 msgid "Statistics Dashboard :: Add-ons for {0}"
 msgstr ""
 
-#: src/olympia/stats/templates/stats/stats.html:30
-msgid "Controls:"
-msgstr ""
-
-#: src/olympia/stats/templates/stats/stats.html:33
-msgid "reset zoom"
-msgstr ""
-
-#: src/olympia/stats/templates/stats/stats.html:40
-msgid "Group by:"
-msgstr ""
-
-#: src/olympia/stats/templates/stats/stats.html:42
-msgid "day"
-msgstr ""
-
-#: src/olympia/stats/templates/stats/stats.html:45
-msgid "week"
-msgstr ""
-
-#: src/olympia/stats/templates/stats/stats.html:48
-msgid "month"
-msgstr ""
-
-#: src/olympia/stats/templates/stats/stats.html:54
-msgid "For last:"
-msgstr ""
-
-#: src/olympia/stats/templates/stats/stats.html:57
-msgid "7 days"
-msgstr ""
-
-#: src/olympia/stats/templates/stats/stats.html:60
-msgid "30 days"
-msgstr ""
-
-#: src/olympia/stats/templates/stats/stats.html:63
-msgid "90 days"
-msgstr ""
-
-#: src/olympia/stats/templates/stats/stats.html:66
-msgid "365 days"
-msgstr ""
-
-#: src/olympia/stats/templates/stats/stats.html:69
-msgid "Custom..."
-msgstr ""
-
 #. {0} is an add-on name
-#: src/olympia/stats/templates/stats/stats.html:88 src/olympia/stats/templates/stats/stats.html:91
+#: src/olympia/stats/templates/stats/stats.html:44 src/olympia/stats/templates/stats/stats.html:47
 msgid "Statistics for {0}"
 msgstr "{0}-н судалгааны үзүүлэлт"
 
-#: src/olympia/stats/templates/stats/stats.html:94
+#: src/olympia/stats/templates/stats/stats.html:50
 msgid "Statistics Dashboard"
 msgstr ""
 
-#: src/olympia/stats/templates/stats/stats.html:104
+#: src/olympia/stats/templates/stats/stats.html:57
+msgid "Controls:"
+msgstr ""
+
+#: src/olympia/stats/templates/stats/stats.html:60
+msgid "reset zoom"
+msgstr ""
+
+#: src/olympia/stats/templates/stats/stats.html:67
+msgid "Group by:"
+msgstr ""
+
+#: src/olympia/stats/templates/stats/stats.html:69
+msgid "day"
+msgstr ""
+
+#: src/olympia/stats/templates/stats/stats.html:72
+msgid "week"
+msgstr ""
+
+#: src/olympia/stats/templates/stats/stats.html:75
+msgid "month"
+msgstr ""
+
+#: src/olympia/stats/templates/stats/stats.html:81
+msgid "For last:"
+msgstr ""
+
+#: src/olympia/stats/templates/stats/stats.html:84
+msgid "7 days"
+msgstr ""
+
+#: src/olympia/stats/templates/stats/stats.html:87
+msgid "30 days"
+msgstr ""
+
+#: src/olympia/stats/templates/stats/stats.html:90
+msgid "90 days"
+msgstr ""
+
+#: src/olympia/stats/templates/stats/stats.html:93
+msgid "365 days"
+msgstr ""
+
+#: src/olympia/stats/templates/stats/stats.html:96
+msgid "Custom..."
+msgstr ""
+
+#: src/olympia/stats/templates/stats/stats.html:106
 msgid "Statistics processing is currently disabled, so recent data is unavailable. The statistics are still being collected and this page will be updated soon with the missing data."
 msgstr ""
 
-#: src/olympia/stats/templates/stats/stats.html:110
+#: src/olympia/stats/templates/stats/stats.html:112
 msgid "Loading the latest data&hellip;"
 msgstr ""
 
-#: src/olympia/stats/templates/stats/stats.html:142 src/olympia/stats/templates/stats/reports/overview.html:25 src/olympia/stats/templates/stats/reports/overview.html:37
+#: src/olympia/stats/templates/stats/stats.html:144 src/olympia/stats/templates/stats/reports/overview.html:25 src/olympia/stats/templates/stats/reports/overview.html:37
 #: src/olympia/stats/templates/stats/reports/overview.html:49
 msgid "No data available."
 msgstr ""
 
-#: src/olympia/stats/templates/stats/stats.html:177
+#: src/olympia/stats/templates/stats/stats.html:179
 msgid "This dashboard is currently <b>public</b>."
 msgstr ""
 
-#: src/olympia/stats/templates/stats/stats.html:179
+#: src/olympia/stats/templates/stats/stats.html:181
 msgid "Contribution stats are currently <b>private</b>."
 msgstr ""
 
-#: src/olympia/stats/templates/stats/stats.html:182
+#: src/olympia/stats/templates/stats/stats.html:184
 msgid "This dashboard is currently <b>private</b>."
 msgstr ""
 
-#: src/olympia/stats/templates/stats/stats.html:185
+#: src/olympia/stats/templates/stats/stats.html:187
 msgid "Change settings."
 msgstr ""
 
@@ -11452,17 +11294,6 @@ msgstr ""
 msgid "Application versions by Date"
 msgstr ""
 
-# {0} is a number
-#: src/olympia/tags/templates/tags/top_cloud.html:4
-#, fuzzy
-msgid "Top {0} Tags"
-msgstr "Top {0} Tags"
-
-#. {0} is the current application name
-#: src/olympia/tags/templates/tags/top_cloud.html:14
-msgid "{0} Top Tags"
-msgstr ""
-
 #: src/olympia/templates/amo_footer.html:6 src/olympia/templates/includes/lang_switcher.html:2
 msgid "Other languages"
 msgstr ""
@@ -11471,12 +11302,12 @@ msgstr ""
 msgid "Mozilla Add-ons"
 msgstr ""
 
-#: src/olympia/templates/base.html:91 src/olympia/templates/impala/base.html:81
+#: src/olympia/templates/base.html:89 src/olympia/templates/impala/base.html:78
 #, fuzzy
 msgid "Find add-ons for other applications"
 msgstr "Find add-ons for other applications"
 
-#: src/olympia/templates/base.html:92 src/olympia/templates/impala/base.html:81
+#: src/olympia/templates/base.html:90 src/olympia/templates/impala/base.html:78
 msgid "Other Applications"
 msgstr "Бусад програмууд"
 
@@ -11501,7 +11332,7 @@ msgid "View Mobile Site"
 msgstr ""
 
 #: src/olympia/templates/copyright.html:7
-msgid "Site Status "
+msgid "Site Status"
 msgstr ""
 
 #: src/olympia/templates/footer.html:3
@@ -11605,35 +11436,35 @@ msgstr ""
 msgid "<a href=\"%(reg)s\">Register</a> or <a href=\"%(login)s\">Log in</a>"
 msgstr ""
 
-#: src/olympia/templates/impala/base.html:126
+#: src/olympia/templates/impala/base.html:123
 #, python-format
 msgid "To try the thousands of add-ons available here, download <a href=\"%(url)s\">Mozilla Firefox</a>, a fast, free way to surf the Web!"
 msgstr ""
 
-#: src/olympia/templates/impala/base.html:138
+#: src/olympia/templates/impala/base.html:135
 #, python-format
 msgid "Add-ons is switching to Firefox Accounts for login. <a href=\"%(url)s\" class=\"fxa-login\">Sign in now to transfer your account.</a>"
 msgstr ""
 
 #. {0} is an application, such as Firefox.
-#: src/olympia/templates/impala/base.html:148
+#: src/olympia/templates/impala/base.html:145
 msgid "Welcome to {0} Add-ons."
 msgstr ""
 
-#: src/olympia/templates/impala/base.html:151
+#: src/olympia/templates/impala/base.html:148
 msgid "Choose from thousands of extra features and styles to make Firefox your own."
 msgstr ""
 
-#: src/olympia/templates/impala/base.html:156
+#: src/olympia/templates/impala/base.html:153
 #, python-format
 msgid "Add extra features and styles to make %(app)s your own."
 msgstr ""
 
-#: src/olympia/templates/impala/base.html:164
+#: src/olympia/templates/impala/base.html:161
 msgid "On the go?"
 msgstr ""
 
-#: src/olympia/templates/impala/base.html:166
+#: src/olympia/templates/impala/base.html:163
 msgid "Check out our <a class=\"mobile-link\" href=\"#\">Mobile Add-ons site</a>."
 msgstr ""
 
@@ -11857,19 +11688,19 @@ msgstr ""
 
 #. L10n: {id} will be something like "13ad6a", just a random number
 #. to differentiate this user from other anonymous users.
-#: src/olympia/users/models.py:353
+#: src/olympia/users/models.py:362
 msgid "Anonymous user {id}"
 msgstr ""
 
-#: src/olympia/users/models.py:410
+#: src/olympia/users/models.py:419
 msgid "Your account has been restricted"
 msgstr ""
 
-#: src/olympia/users/models.py:480
+#: src/olympia/users/models.py:489
 msgid "Please confirm your email address"
 msgstr ""
 
-#: src/olympia/users/models.py:506
+#: src/olympia/users/models.py:515
 msgid "My Mobile Add-ons"
 msgstr ""
 
@@ -12150,7 +11981,7 @@ msgstr "Нууц үг"
 
 #: src/olympia/users/templates/users/edit.html:70
 #, python-format
-msgid "Change your password.  If you forgot your password, you can <a href=\"%(reset_url)s\">use the reset form</a>."
+msgid "Change your password. If you forgot your password, you can <a href=\"%(reset_url)s\">use the reset form</a>."
 msgstr ""
 
 #: src/olympia/users/templates/users/edit.html:76
@@ -12170,7 +12001,7 @@ msgid "Profile"
 msgstr ""
 
 #: src/olympia/users/templates/users/edit.html:100
-msgid "Give us a bit more information about yourself.  All these fields are optional, but they'll help other users get to know you better."
+msgid "Give us a bit more information about yourself. All these fields are optional, but they'll help other users get to know you better."
 msgstr ""
 
 #: src/olympia/users/templates/users/edit.html:124
@@ -12399,7 +12230,7 @@ msgid "Confirm password"
 msgstr "Нууц үгийг дахин оруул"
 
 #: src/olympia/users/templates/users/pwreset_confirm.html:47
-msgid "The password reset link was invalid, possibly because it has already been used.  Please request a new password reset."
+msgid "The password reset link was invalid, possibly because it has already been used. Please request a new password reset."
 msgstr ""
 
 #: src/olympia/users/templates/users/pwreset_request.html:15
@@ -12585,7 +12416,7 @@ msgstr ""
 
 #: src/olympia/users/templates/users/unsubscribe.html:30
 #, python-format
-msgid "Unfortunately, we weren't able to unsubscribe you.  The link you clicked is invalid. However, you can unsubscribe still unsubscribe on your <a href=\"%(edit_url)s\">edit profile page</a>."
+msgid "Unfortunately, we weren't able to unsubscribe you. The link you clicked is invalid. However, you can unsubscribe still unsubscribe on your <a href=\"%(edit_url)s\">edit profile page</a>."
 msgstr ""
 
 #: src/olympia/users/templates/users/vcard.html:2
@@ -12641,15 +12472,15 @@ msgstr ""
 msgid "Version History with Changelogs"
 msgstr "Өөрчлөлтийн бүртгэл агуулсан хувилбарын түүх"
 
-#: src/olympia/versions/models.py:314
+#: src/olympia/versions/models.py:313
 msgid "Add-on uses binary components."
 msgstr ""
 
-#: src/olympia/versions/models.py:317
+#: src/olympia/versions/models.py:316
 msgid "Add-on has opted into strict compatibility checking."
 msgstr ""
 
-#: src/olympia/versions/models.py:715
+#: src/olympia/versions/models.py:711
 msgid "{app} {min} and later"
 msgstr ""
 
@@ -12726,4 +12557,8 @@ msgstr ""
 
 #: src/olympia/zadmin/forms.py:105
 msgid "Log emails instead of sending"
+msgstr ""
+
+#: src/olympia/zadmin/forms.py:215
+msgid "Deleted versions can`t be changed."
 msgstr ""

--- a/locale/mn/LC_MESSAGES/djangojs.po
+++ b/locale/mn/LC_MESSAGES/djangojs.po
@@ -1,1215 +1,1235 @@
-
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2016-02-24 21:23+0000\n"
+"POT-Creation-Date: 2016-04-18 15:47+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
+"Language: \n"
 "MIME-Version: 1.0\n"
-"Content-Type: text/plain; charset=utf-8\n"
+"Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Generated-By: Babel 2.2.0\n"
 
-#: static/js/common/ratingwidget.js:31
+#: static/js/common-all.js:1426 static/js/impala-all.js:1511 static/js/zamboni/discovery-all.js:12598 static/js/zamboni/init.js:28 static/js/zamboni/mobile-all.js:14945
+msgid "This feature is temporarily disabled while we perform website maintenance. Please check back a little later."
+msgstr ""
+
+#. L10n: {0} is an app name like Firefox.
+#: static/js/common-all.js:1837 static/js/impala-all.js:1922 static/js/zamboni/buttons.js:73 static/js/zamboni/discovery-all.js:13108
+msgid "Accept and Install"
+msgstr ""
+
+#: static/js/common-all.js:1837 static/js/impala-all.js:1922 static/js/zamboni/buttons.js:73 static/js/zamboni/discovery-all.js:13108
+msgid "Add to {0}"
+msgstr ""
+
+#: static/js/common-all.js:1842 static/js/impala-all.js:1927 static/js/zamboni/buttons.js:78 static/js/zamboni/discovery-all.js:13113
+msgid "Download Now"
+msgstr ""
+
+#: static/js/common-all.js:1883 static/js/impala-all.js:1968 static/js/zamboni/buttons.js:119 static/js/zamboni/discovery-all.js:13154
+msgid "Add-on has not been updated to support default-to-compatible."
+msgstr ""
+
+#: static/js/common-all.js:1888 static/js/impala-all.js:1973 static/js/zamboni/buttons.js:124 static/js/zamboni/discovery-all.js:13159
+msgid "You need to be using Firefox 10.0 or higher."
+msgstr ""
+
+#: static/js/common-all.js:1900 static/js/impala-all.js:1985 static/js/zamboni/buttons.js:136 static/js/zamboni/discovery-all.js:13171
+msgid "Mozilla has marked this version as incompatible with your Firefox version."
+msgstr ""
+
+#. L10n: {0} is an platform like Windows or Linux.
+#: static/js/common-all.js:1981 static/js/impala-all.js:2066 static/js/zamboni/buttons.js:217 static/js/zamboni/discovery-all.js:13252
+msgid "Install for {0} anyway"
+msgstr ""
+
+#: static/js/common-all.js:1981 static/js/impala-all.js:2066 static/js/zamboni/buttons.js:217 static/js/zamboni/discovery-all.js:13252
+msgid "Download for {0} anyway"
+msgstr ""
+
+#: static/js/common-all.js:2038 static/js/impala-all.js:2123 static/js/zamboni/buttons.js:274 static/js/zamboni/discovery-all.js:13309
+msgid "Not available for your platform"
+msgstr ""
+
+#. L10n: {0} is an app name, {1} is the app version.
+#: static/js/common-all.js:2049 static/js/common-all.js:2086 static/js/impala-all.js:2134 static/js/impala-all.js:2171 static/js/zamboni/buttons.js:286 static/js/zamboni/buttons.js:324
+#: static/js/zamboni/discovery-all.js:13320 static/js/zamboni/discovery-all.js:13357
+msgid "Not available for {0} {1}"
+msgstr ""
+
+#: static/js/common-all.js:2112 static/js/impala-all.js:2197 static/js/zamboni/buttons.js:351 static/js/zamboni/discovery-all.js:13383
+msgid "Works with {app} {min} - {max}"
+msgstr ""
+
+#: static/js/common-all.js:2114 static/js/impala-all.js:2199 static/js/zamboni/buttons.js:353 static/js/zamboni/discovery-all.js:13385
+msgid "View other versions"
+msgstr ""
+
+#: static/js/common-all.js:2162 static/js/impala-all.js:2247 static/js/zamboni/buttons.js:401 static/js/zamboni/discovery-all.js:13433
+msgid "Only with Firefox — Get Firefox Now!"
+msgstr ""
+
+#: static/js/common-all.js:2278 static/js/impala-all.js:2363 static/js/zamboni/buttons.js:517 static/js/zamboni/discovery-all.js:13549 static/js/zamboni/mobile-all.js:15177
+#: static/js/zamboni/mobile/buttons.js:43
+msgid "Sorry, you need a Mozilla-based browser (such as Firefox) to install a search plugin."
+msgstr ""
+
+#: static/js/common-all.js:9088 static/js/impala-all.js:9649 static/js/zamboni/global.js:410
+msgid "Loading..."
+msgstr ""
+
+#. L10n: {0} is the number of characters left.
+#: static/js/common-all.js:9152 static/js/impala-all.js:9713 static/js/zamboni/global.js:474
+msgid "<b>{0}</b> character left."
+msgid_plural "<b>{0}</b> characters left."
+msgstr[0] ""
+msgstr[1] ""
+
+#: static/js/common-all.js:9589 static/js/common-min.js:6 static/js/impala-all.js:10052 static/js/impala-min.js:6 static/js/common/ratingwidget.js:31 static/js/zamboni/mobile-all.js:16123
+#: static/js/zamboni/mobile-min.js:6
 msgid "{0} star"
 msgid_plural "{0} stars"
 msgstr[0] ""
 msgstr[1] ""
 
-#: static/js/common/upload-addon.js:41 static/js/common/upload-image.js:128
+#: static/js/common-all.js:9676 static/js/common-min.js:6 static/js/impala-all.js:10139 static/js/impala-min.js:6 static/js/zamboni/l10n.js:45
+msgid "Remove this localization"
+msgstr ""
+
+#: static/js/common-all.js:10193 static/js/common-min.js:6 static/js/impala-all.js:10674 static/js/impala-min.js:6 static/js/zamboni/discovery-all.js:13678
+msgid "close"
+msgstr ""
+
+#: static/js/common-all.js:10860 static/js/common-min.js:6 static/js/impala-all.js:11481 static/js/impala-min.js:6 static/js/impala/reviews.js:23 static/js/zamboni/reviews.js:18
+msgid "Flagged for review"
+msgstr ""
+
+#: static/js/common-all.js:10876 static/js/common-min.js:6 static/js/impala-all.js:11498 static/js/impala-min.js:6 static/js/impala/reviews.js:40 static/js/zamboni/reviews.js:34
+msgid "Your input is required"
+msgstr ""
+
+#: static/js/common-all.js:10945 static/js/common-min.js:6 static/js/impala-all.js:11610 static/js/impala-min.js:7 static/js/impala/reviews.js:152 static/js/zamboni/reviews.js:103
+msgid "Marked for deletion"
+msgstr ""
+
+#: static/js/common-all.js:11573 static/js/common-min.js:7 static/js/impala-all.js:13809 static/js/impala-min.js:8 static/js/zamboni/collections.js:229
+msgid "Adding to Favorites&hellip;"
+msgstr ""
+
+#: static/js/common-all.js:11576 static/js/common-min.js:7 static/js/impala-all.js:13812 static/js/impala-min.js:8 static/js/zamboni/collections.js:232
+msgid "Removing Favorite&hellip;"
+msgstr ""
+
+#: static/js/common-all.js:11579 static/js/common-min.js:7 static/js/impala-all.js:13815 static/js/impala-min.js:8 static/js/zamboni/collections.js:235
+msgid "Add to Favorites"
+msgstr ""
+
+#: static/js/common-all.js:11582 static/js/common-min.js:7 static/js/impala-all.js:13818 static/js/impala-min.js:8 static/js/zamboni/collections.js:238
+msgid "Remove from Favorites"
+msgstr ""
+
+#: static/js/common-all.js:11647 static/js/common-min.js:7 static/js/impala-all.js:13883 static/js/impala-min.js:8 static/js/zamboni/collections.js:303
+msgid "Pending"
+msgstr ""
+
+#: static/js/common-all.js:11648 static/js/common-min.js:7 static/js/impala-all.js:13884 static/js/impala-min.js:8 static/js/zamboni/collections.js:304
+msgid "Add a comment"
+msgstr ""
+
+#: static/js/common-all.js:11648 static/js/common-min.js:7 static/js/impala-all.js:13884 static/js/impala-min.js:8 static/js/zamboni/collections.js:304
+msgid "Comment"
+msgstr ""
+
+#: static/js/common-all.js:11649 static/js/common-min.js:7 static/js/impala-all.js:13885 static/js/impala-min.js:8 static/js/zamboni/collections.js:305
+msgid "Remove this add-on from the collection"
+msgstr ""
+
+#: static/js/common-all.js:11649 static/js/common-all.js:11678 static/js/common-min.js:7 static/js/impala-all.js:13885 static/js/impala-all.js:13914 static/js/impala-min.js:8
+#: static/js/zamboni/collections.js:305 static/js/zamboni/collections.js:334
+msgid "Remove"
+msgstr ""
+
+#: static/js/common-all.js:11678 static/js/common-min.js:7 static/js/impala-all.js:13914 static/js/impala-min.js:8 static/js/zamboni/collections.js:334
+msgid "Remove this user as a contributor"
+msgstr ""
+
+#: static/js/common-all.js:11690 static/js/common-min.js:7 static/js/impala-all.js:13926 static/js/impala-min.js:8 static/js/zamboni/collections.js:346
+msgid "An email address is required."
+msgstr ""
+
+#: static/js/common-all.js:11708 static/js/common-min.js:7 static/js/impala-all.js:13944 static/js/impala-min.js:8 static/js/zamboni/collections.js:364
+msgid "You cannot add yourself as a contributor."
+msgstr ""
+
+#: static/js/common-all.js:11710 static/js/common-min.js:7 static/js/impala-all.js:13946 static/js/impala-min.js:8 static/js/zamboni/collections.js:366
+msgid "You have already added that user."
+msgstr ""
+
+#: static/js/common-all.js:11917 static/js/common-min.js:7 static/js/impala-all.js:14153 static/js/impala-min.js:8 static/js/zamboni/collections.js:573
+msgid "Add to favorites"
+msgstr ""
+
+#: static/js/common-all.js:11921 static/js/common-min.js:7 static/js/impala-all.js:14157 static/js/impala-min.js:8 static/js/zamboni/collections.js:577
+msgid "Remove from favorites"
+msgstr ""
+
+#: static/js/common-all.js:11939 static/js/common-min.js:7 static/js/impala-all.js:14175 static/js/impala-all.js:14233 static/js/impala-min.js:8 static/js/impala/collections.js:10
+#: static/js/zamboni/collections.js:595
+msgid "Follow this Collection"
+msgstr ""
+
+#: static/js/common-all.js:11948 static/js/common-min.js:7 static/js/impala-all.js:14184 static/js/impala-min.js:8 static/js/zamboni/collections.js:604
+msgid "Stop following"
+msgstr ""
+
+#: static/js/common-all.js:12096 static/js/common-min.js:7 static/js/zamboni/password-strength.js:20
+msgid "Password strength:"
+msgstr ""
+
+#: static/js/common-all.js:12102 static/js/common-min.js:7 static/js/zamboni/password-strength.js:26
+msgid "At least {0} character left."
+msgid_plural "At least {0} characters left."
+msgstr[0] ""
+msgstr[1] ""
+
+#: static/js/common-all.js:12286 static/js/common-min.js:7 static/js/impala-all.js:14632 static/js/impala-min.js:8 static/js/impala/suggestions.js:39
+msgid "Search themes for <b>{0}</b>"
+msgstr ""
+
+#: static/js/common-all.js:12288 static/js/common-min.js:7 static/js/impala-all.js:14634 static/js/impala-min.js:8 static/js/impala/suggestions.js:41
+msgid "Search apps for <b>{0}</b>"
+msgstr ""
+
+#: static/js/common-all.js:12290 static/js/common-min.js:7 static/js/impala-all.js:14636 static/js/impala-min.js:8 static/js/impala/suggestions.js:43
+msgid "Search add-ons for <b>{0}</b>"
+msgstr ""
+
+#: static/js/common-all.js:12521 static/js/common-min.js:7 static/js/impala-all.js:14867 static/js/impala-min.js:8 static/js/impala/site_suggestions.js:46
+msgid "Category"
+msgstr ""
+
+#. L10n: {0} is an app name.
+#: static/js/impala-all.js:11632 static/js/impala-min.js:7 static/js/impala/listing.js:11 static/js/zamboni/themes.js:13
+msgid "This theme is incompatible with your version of {0}"
+msgstr ""
+
+#: static/js/impala-all.js:12146 static/js/impala-all.js:14331 static/js/impala-min.js:7 static/js/impala-min.js:8 static/js/common/upload-image.js:97 static/js/impala/users.js:51
+#: static/js/zamboni/devhub-all.js:894 static/js/zamboni/devhub-min.js:1
+msgid "Images must be either PNG or JPG."
+msgstr ""
+
+#: static/js/impala-all.js:12150 static/js/impala-min.js:7 static/js/common/upload-image.js:101 static/js/zamboni/devhub-all.js:898 static/js/zamboni/devhub-min.js:1
+msgid "Videos must be in WebM."
+msgstr ""
+
+#: static/js/impala-all.js:12177 static/js/impala-min.js:7 static/js/common/upload-addon.js:41 static/js/common/upload-image.js:128 static/js/zamboni/devhub-all.js:272
+#: static/js/zamboni/devhub-all.js:925 static/js/zamboni/devhub-min.js:1
 msgid "There was a problem contacting the server."
 msgstr ""
 
-#: static/js/common/upload-addon.js:69
+#: static/js/impala-all.js:13298 static/js/impala-min.js:7 static/js/impala/persona_creation.js:60
+msgid "All Rights Reserved"
+msgstr ""
+
+#: static/js/impala-all.js:13302 static/js/impala-min.js:7 static/js/impala/persona_creation.js:64
+msgid "Creative Commons Attribution 3.0"
+msgstr ""
+
+#: static/js/impala-all.js:13307 static/js/impala-min.js:7 static/js/impala/persona_creation.js:69
+msgid "Creative Commons Attribution-NonCommercial 3.0"
+msgstr ""
+
+#: static/js/impala-all.js:13312 static/js/impala-min.js:7 static/js/impala/persona_creation.js:74
+msgid "Creative Commons Attribution-NonCommercial-NoDerivs 3.0"
+msgstr ""
+
+#: static/js/impala-all.js:13317 static/js/impala-min.js:7 static/js/impala/persona_creation.js:79
+msgid "Creative Commons Attribution-NonCommercial-Share Alike 3.0"
+msgstr ""
+
+#: static/js/impala-all.js:13322 static/js/impala-min.js:7 static/js/impala/persona_creation.js:84
+msgid "Creative Commons Attribution-NoDerivs 3.0"
+msgstr ""
+
+#: static/js/impala-all.js:13327 static/js/impala-min.js:7 static/js/impala/persona_creation.js:89
+msgid "Creative Commons Attribution-ShareAlike 3.0"
+msgstr ""
+
+#: static/js/impala-all.js:13530 static/js/impala-min.js:7 static/js/impala/persona_creation.js:292
+msgid "Your Theme's Name"
+msgstr ""
+
+#: static/js/impala-all.js:14242 static/js/impala-min.js:8 static/js/impala/collections.js:19
+msgid "Stop Following"
+msgstr ""
+
+#: static/js/impala-all.js:14243 static/js/impala-min.js:8 static/js/impala/collections.js:20
+msgid "Following"
+msgstr ""
+
+#: static/js/impala-all.js:14313 static/js/impala-min.js:8 static/js/impala/users.js:33
+msgid "use original"
+msgstr ""
+
+#: static/js/impala-all.js:14523 static/js/impala-min.js:8 static/js/impala/search.js:114
+msgid "Updating results&hellip;"
+msgstr ""
+
+#: static/js/common/upload-addon.js:69 static/js/zamboni/devhub-all.js:300 static/js/zamboni/devhub-min.js:1
 msgid "Select a file..."
 msgstr ""
 
-#: static/js/common/upload-addon.js:70
+#: static/js/common/upload-addon.js:70 static/js/zamboni/devhub-all.js:301 static/js/zamboni/devhub-min.js:1
 msgid "Your add-on should end with .xpi, .jar or .xml"
 msgstr ""
 
 #. L10n: {0} is the percent of the file that has been uploaded.
-#: static/js/common/upload-addon.js:104
+#: static/js/common/upload-addon.js:104 static/js/zamboni/devhub-all.js:335 static/js/zamboni/devhub-min.js:1
 #, python-format
 msgid "{0}% complete"
 msgstr ""
 
 #. L10n: "{bytes uploaded} of {total filesize}".
-#: static/js/common/upload-addon.js:107
+#: static/js/common/upload-addon.js:107 static/js/zamboni/devhub-all.js:338 static/js/zamboni/devhub-min.js:1
 msgid "{0} of {1}"
 msgstr ""
 
-#: static/js/common/upload-addon.js:140
+#: static/js/common/upload-addon.js:140 static/js/zamboni/devhub-all.js:371 static/js/zamboni/devhub-min.js:1
 msgid "Cancel"
 msgstr ""
 
-#: static/js/common/upload-addon.js:162
+#: static/js/common/upload-addon.js:162 static/js/zamboni/devhub-all.js:393 static/js/zamboni/devhub-min.js:1
 msgid "Uploading {0}"
 msgstr ""
 
-#: static/js/common/upload-addon.js:189
+#: static/js/common/upload-addon.js:189 static/js/zamboni/devhub-all.js:420 static/js/zamboni/devhub-min.js:1
 msgid "Error with {0}"
 msgstr ""
 
-#: static/js/common/upload-addon.js:194
+#: static/js/common/upload-addon.js:194 static/js/zamboni/devhub-all.js:425 static/js/zamboni/devhub-min.js:1
 msgid "Your add-on failed validation with {0} error."
 msgid_plural "Your add-on failed validation with {0} errors."
 msgstr[0] ""
 msgstr[1] ""
 
-#: static/js/common/upload-addon.js:208
+#: static/js/common/upload-addon.js:208 static/js/zamboni/devhub-all.js:439 static/js/zamboni/devhub-min.js:1
 msgid "&hellip;and {0} more"
 msgid_plural "&hellip;and {0} more"
 msgstr[0] ""
 msgstr[1] ""
 
-#: static/js/common/upload-addon.js:222 static/js/common/upload-addon.js:512
+#: static/js/common/upload-addon.js:222 static/js/common/upload-addon.js:497 static/js/zamboni/devhub-all.js:453 static/js/zamboni/devhub-all.js:743 static/js/zamboni/devhub-min.js:1
 msgid "See full validation report"
 msgstr ""
 
-#: static/js/common/upload-addon.js:234
+#: static/js/common/upload-addon.js:234 static/js/zamboni/devhub-all.js:465 static/js/zamboni/devhub-min.js:1
 msgid "Validating {0}"
 msgstr ""
 
 #. L10n: first argument is an HTTP status code
-#: static/js/common/upload-addon.js:273
+#: static/js/common/upload-addon.js:273 static/js/zamboni/devhub-all.js:504 static/js/zamboni/devhub-min.js:1
 msgid "Received an empty response from the server; status: {0}"
 msgstr ""
 
-#: static/js/common/upload-addon.js:373
+#: static/js/common/upload-addon.js:370 static/js/zamboni/devhub-all.js:604 static/js/zamboni/devhub-min.js:1
 msgid "Unexpected server error while validating."
 msgstr ""
 
-#: static/js/common/upload-addon.js:412
+#: static/js/common/upload-addon.js:409 static/js/zamboni/devhub-all.js:643 static/js/zamboni/devhub-min.js:1
 msgid "Finished validating {0}"
 msgstr ""
 
-#: static/js/common/upload-addon.js:418
+#: static/js/common/upload-addon.js:415 static/js/zamboni/devhub-all.js:649 static/js/zamboni/devhub-min.js:1
 msgid "Your add-on validation timed out, it will be manually reviewed."
 msgstr ""
 
-#: static/js/common/upload-addon.js:421
+#: static/js/common/upload-addon.js:418 static/js/zamboni/devhub-all.js:652 static/js/zamboni/devhub-min.js:1
 msgid "Your add-on was validated with no errors and {0} warning."
 msgid_plural "Your add-on was validated with no errors and {0} warnings."
 msgstr[0] ""
 msgstr[1] ""
 
-#: static/js/common/upload-addon.js:426
+#: static/js/common/upload-addon.js:423 static/js/zamboni/devhub-all.js:657 static/js/zamboni/devhub-min.js:1
 msgid "Your add-on was validated with no errors and {0} message."
 msgid_plural "Your add-on was validated with no errors and {0} messages."
 msgstr[0] ""
 msgstr[1] ""
 
-#: static/js/common/upload-addon.js:431
+#: static/js/common/upload-addon.js:428 static/js/zamboni/devhub-all.js:662 static/js/zamboni/devhub-min.js:1
 msgid "Your add-on was validated with no errors or warnings."
 msgstr ""
 
-#: static/js/common/upload-addon.js:446
+#: static/js/common/upload-addon.js:443 static/js/zamboni/devhub-all.js:677 static/js/zamboni/devhub-min.js:1
 msgid "Your submission will be automatically signed."
 msgstr ""
 
-#: static/js/common/upload-addon.js:465
+#: static/js/common/upload-addon.js:450 static/js/zamboni/devhub-all.js:696 static/js/zamboni/devhub-min.js:1
 msgid "Include detailed version notes (this can be done in the next step)."
 msgstr ""
 
-#: static/js/common/upload-addon.js:466
+#: static/js/common/upload-addon.js:451 static/js/zamboni/devhub-all.js:697 static/js/zamboni/devhub-min.js:1
 msgid "If your add-on requires an account to a website in order to be fully tested, include a test username and password in the Notes to Reviewer (this can be done in the next step)."
 msgstr ""
 
-#: static/js/common/upload-addon.js:467
+#: static/js/common/upload-addon.js:452 static/js/zamboni/devhub-all.js:698 static/js/zamboni/devhub-min.js:1
 msgid "If your add-on is intended for a limited audience you should choose Preliminary Review instead of Full Review."
 msgstr ""
 
-#: static/js/common/upload-addon.js:480
+#: static/js/common/upload-addon.js:465 static/js/zamboni/devhub-all.js:711 static/js/zamboni/devhub-min.js:1
 msgid "Add-on submission checklist"
 msgstr ""
 
-#: static/js/common/upload-addon.js:481
+#: static/js/common/upload-addon.js:466 static/js/zamboni/devhub-all.js:712 static/js/zamboni/devhub-min.js:1
 msgid "Please verify the following points before finalizing your submission. This will minimize delays or misunderstanding during the review process:"
 msgstr ""
 
-#: static/js/common/upload-addon.js:483
+#: static/js/common/upload-addon.js:468 static/js/zamboni/devhub-all.js:714 static/js/zamboni/devhub-min.js:1
 msgid ""
 "Compiled binaries, as well as minified or obfuscated scripts (excluding known libraries) need to have their sources submitted separately for review. Make sure that you use the source code upload "
 "field to avoid having your submission rejected."
 msgstr ""
 
-#: static/js/common/upload-addon.js:501
+#: static/js/common/upload-addon.js:486 static/js/zamboni/devhub-all.js:732 static/js/zamboni/devhub-min.js:1
 msgid "The validation process found these issues that can lead to rejections:"
 msgstr ""
 
-#: static/js/common/upload-addon.js:518
+#: static/js/common/upload-addon.js:503 static/js/zamboni/devhub-all.js:749 static/js/zamboni/devhub-min.js:1
 msgid "If you are unfamiliar with the add-ons review process, you can read about it here."
 msgstr ""
 
-#: static/js/common/upload-addon.js:555
+#: static/js/common/upload-addon.js:540 static/js/zamboni/devhub-all.js:786 static/js/zamboni/devhub-min.js:1
 msgid "Sorry, no supported platform has been found."
 msgstr ""
 
-#: static/js/common/upload-base.js:57
+#: static/js/common/upload-base.js:57 static/js/zamboni/devhub-all.js:187 static/js/zamboni/devhub-min.js:1
 msgid "The filetype you uploaded isn't recognized."
 msgstr ""
 
-#: static/js/common/upload-base.js:79
+#: static/js/common/upload-base.js:79 static/js/zamboni/devhub-all.js:209 static/js/zamboni/devhub-min.js:1
 msgid "You cancelled the upload."
 msgstr ""
 
-#: static/js/common/upload-image.js:97 static/js/impala/users.js:51
-msgid "Images must be either PNG or JPG."
-msgstr ""
-
-#: static/js/common/upload-image.js:101
-msgid "Videos must be in WebM."
-msgstr ""
-
-#: static/js/impala/collections.js:10 static/js/zamboni/collections.js:595
-msgid "Follow this Collection"
-msgstr ""
-
-#: static/js/impala/collections.js:19
-msgid "Stop Following"
-msgstr ""
-
-#: static/js/impala/collections.js:20
-msgid "Following"
-msgstr ""
-
-#. L10n: {0} is an app name.
-#: static/js/impala/listing.js:11 static/js/zamboni/themes.js:13
-msgid "This theme is incompatible with your version of {0}"
-msgstr ""
-
-#: static/js/impala/persona_creation.js:60
-msgid "All Rights Reserved"
-msgstr ""
-
-#: static/js/impala/persona_creation.js:64
-msgid "Creative Commons Attribution 3.0"
-msgstr ""
-
-#: static/js/impala/persona_creation.js:69
-msgid "Creative Commons Attribution-NonCommercial 3.0"
-msgstr ""
-
-#: static/js/impala/persona_creation.js:74
-msgid "Creative Commons Attribution-NonCommercial-NoDerivs 3.0"
-msgstr ""
-
-#: static/js/impala/persona_creation.js:79
-msgid "Creative Commons Attribution-NonCommercial-Share Alike 3.0"
-msgstr ""
-
-#: static/js/impala/persona_creation.js:84
-msgid "Creative Commons Attribution-NoDerivs 3.0"
-msgstr ""
-
-#: static/js/impala/persona_creation.js:89
-msgid "Creative Commons Attribution-ShareAlike 3.0"
-msgstr ""
-
-#: static/js/impala/persona_creation.js:292
-msgid "Your Theme's Name"
-msgstr ""
-
-#: static/js/impala/reviews.js:23 static/js/zamboni/reviews.js:18
-msgid "Flagged for review"
-msgstr ""
-
-#: static/js/impala/reviews.js:40 static/js/zamboni/reviews.js:34
-msgid "Your input is required"
-msgstr ""
-
-#: static/js/impala/reviews.js:152 static/js/zamboni/reviews.js:103
-msgid "Marked for deletion"
-msgstr ""
-
-#: static/js/impala/search.js:114
-msgid "Updating results&hellip;"
-msgstr ""
-
-#: static/js/impala/site_suggestions.js:46
-msgid "Category"
-msgstr ""
-
-#: static/js/impala/suggestions.js:39
-msgid "Search themes for <b>{0}</b>"
-msgstr ""
-
-#: static/js/impala/suggestions.js:41
-msgid "Search apps for <b>{0}</b>"
-msgstr ""
-
-#: static/js/impala/suggestions.js:43
-msgid "Search add-ons for <b>{0}</b>"
-msgstr ""
-
-#: static/js/impala/users.js:33
-msgid "use original"
-msgstr ""
-
-#: static/js/impala/stats/chart.js:267
+#: static/js/impala/stats/chart.js:267 static/js/zamboni/stats-all.js:16898 static/js/zamboni/stats-min.js:5
 msgid "Week of {0}"
 msgstr ""
 
-#: static/js/impala/stats/chart.js:269
+#: static/js/impala/stats/chart.js:269 static/js/zamboni/stats-all.js:16900 static/js/zamboni/stats-min.js:5
 msgid " downloads"
 msgstr ""
 
-#: static/js/impala/stats/chart.js:270
+#: static/js/impala/stats/chart.js:270 static/js/zamboni/stats-all.js:16901 static/js/zamboni/stats-min.js:5
 msgid "{0} users"
 msgstr ""
 
-#: static/js/impala/stats/chart.js:271
+#: static/js/impala/stats/chart.js:271 static/js/zamboni/stats-all.js:16902 static/js/zamboni/stats-min.js:5
 msgid "{0} add-ons"
 msgstr ""
 
-#: static/js/impala/stats/chart.js:272
+#: static/js/impala/stats/chart.js:272 static/js/zamboni/stats-all.js:16903 static/js/zamboni/stats-min.js:5
 msgid "{0} collections"
 msgstr ""
 
-#: static/js/impala/stats/chart.js:273
+#: static/js/impala/stats/chart.js:273 static/js/zamboni/stats-all.js:16904 static/js/zamboni/stats-min.js:5
 msgid "{0} reviews"
 msgstr ""
 
-#: static/js/impala/stats/chart.js:275
+#: static/js/impala/stats/chart.js:275 static/js/zamboni/stats-all.js:16906 static/js/zamboni/stats-min.js:5
 msgid "{0} sales"
 msgstr ""
 
-#: static/js/impala/stats/chart.js:276
+#: static/js/impala/stats/chart.js:276 static/js/zamboni/stats-all.js:16907 static/js/zamboni/stats-min.js:5
 msgid "{0} refunds"
 msgstr ""
 
-#: static/js/impala/stats/chart.js:277
+#: static/js/impala/stats/chart.js:277 static/js/zamboni/stats-all.js:16908 static/js/zamboni/stats-min.js:5
 msgid "{0} installs"
 msgstr ""
 
-#: static/js/impala/stats/chart.js:369 static/js/impala/stats/csv_keys.js:3 static/js/impala/stats/csv_keys.js:109
+#: static/js/impala/stats/chart.js:369 static/js/impala/stats/csv_keys.js:3 static/js/impala/stats/csv_keys.js:109 static/js/zamboni/stats-all.js:15284 static/js/zamboni/stats-all.js:15390
+#: static/js/zamboni/stats-all.js:17000 static/js/zamboni/stats-min.js:4 static/js/zamboni/stats-min.js:5
 msgid "Downloads"
 msgstr ""
 
-#: static/js/impala/stats/chart.js:379 static/js/impala/stats/csv_keys.js:6 static/js/impala/stats/csv_keys.js:110
+#: static/js/impala/stats/chart.js:379 static/js/impala/stats/csv_keys.js:6 static/js/impala/stats/csv_keys.js:110 static/js/zamboni/stats-all.js:15287 static/js/zamboni/stats-all.js:15391
+#: static/js/zamboni/stats-all.js:17010 static/js/zamboni/stats-min.js:4 static/js/zamboni/stats-min.js:5
 msgid "Daily Users"
 msgstr ""
 
-#: static/js/impala/stats/chart.js:410
+#: static/js/impala/stats/chart.js:410 static/js/zamboni/stats-all.js:17041 static/js/zamboni/stats-min.js:5
 msgid "Amount, in USD"
 msgstr ""
 
-#: static/js/impala/stats/chart.js:421 static/js/impala/stats/csv_keys.js:104
+#: static/js/impala/stats/chart.js:421 static/js/impala/stats/csv_keys.js:104 static/js/zamboni/stats-all.js:15385 static/js/zamboni/stats-all.js:17052 static/js/zamboni/stats-min.js:5
 msgid "Number of Contributions"
 msgstr ""
 
-#: static/js/impala/stats/chart.js:447
+#: static/js/impala/stats/chart.js:447 static/js/zamboni/stats-all.js:17078 static/js/zamboni/stats-min.js:5
 msgid "More Info..."
 msgstr ""
 
 #. L10n: {0} is an ISO-formatted date.
-#: static/js/impala/stats/chart.js:451
+#: static/js/impala/stats/chart.js:451 static/js/zamboni/stats-all.js:17082 static/js/zamboni/stats-min.js:5
 msgid "Details for {0}"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:9
+#: static/js/impala/stats/csv_keys.js:9 static/js/zamboni/stats-all.js:15290 static/js/zamboni/stats-min.js:4
 msgid "Collections Created"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:12
+#: static/js/impala/stats/csv_keys.js:12 static/js/zamboni/stats-all.js:15293 static/js/zamboni/stats-min.js:4
 msgid "Add-ons in Use"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:15
+#: static/js/impala/stats/csv_keys.js:15 static/js/zamboni/stats-all.js:15296 static/js/zamboni/stats-min.js:4
 msgid "Add-ons Created"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:18
+#: static/js/impala/stats/csv_keys.js:18 static/js/zamboni/stats-all.js:15299 static/js/zamboni/stats-min.js:4
 msgid "Add-ons Downloaded"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:21
+#: static/js/impala/stats/csv_keys.js:21 static/js/zamboni/stats-all.js:15302 static/js/zamboni/stats-min.js:4
 msgid "Add-ons Updated"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:24
+#: static/js/impala/stats/csv_keys.js:24 static/js/zamboni/stats-all.js:15305 static/js/zamboni/stats-min.js:4
 msgid "Reviews Written"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:27
+#: static/js/impala/stats/csv_keys.js:27 static/js/zamboni/stats-all.js:15308 static/js/zamboni/stats-min.js:4
 msgid "User Signups"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:30
+#: static/js/impala/stats/csv_keys.js:30 static/js/zamboni/stats-all.js:15311 static/js/zamboni/stats-min.js:4
 msgid "Subscribers"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:33
+#: static/js/impala/stats/csv_keys.js:33 static/js/zamboni/stats-all.js:15314 static/js/zamboni/stats-min.js:4
 msgid "Ratings"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:36 static/js/impala/stats/csv_keys.js:114
+#: static/js/impala/stats/csv_keys.js:36 static/js/impala/stats/csv_keys.js:114 static/js/zamboni/stats-all.js:15317 static/js/zamboni/stats-all.js:15395 static/js/zamboni/stats-min.js:4
+#: static/js/zamboni/stats-min.js:5
 msgid "Sales"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:39 static/js/impala/stats/csv_keys.js:113
+#: static/js/impala/stats/csv_keys.js:39 static/js/impala/stats/csv_keys.js:113 static/js/zamboni/stats-all.js:15320 static/js/zamboni/stats-all.js:15394 static/js/zamboni/stats-min.js:4
+#: static/js/zamboni/stats-min.js:5
 msgid "Installs"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:42
+#: static/js/impala/stats/csv_keys.js:42 static/js/zamboni/stats-all.js:15323 static/js/zamboni/stats-min.js:4
 msgid "Unknown"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:43
+#: static/js/impala/stats/csv_keys.js:43 static/js/zamboni/stats-all.js:15324 static/js/zamboni/stats-min.js:4
 msgid "Add-ons Manager"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:44
+#: static/js/impala/stats/csv_keys.js:44 static/js/zamboni/stats-all.js:15325 static/js/zamboni/stats-min.js:4
 msgid "Add-ons Manager Promo"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:45
+#: static/js/impala/stats/csv_keys.js:45 static/js/zamboni/stats-all.js:15326 static/js/zamboni/stats-min.js:4
 msgid "Add-ons Manager Featured"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:46
+#: static/js/impala/stats/csv_keys.js:46 static/js/zamboni/stats-all.js:15327 static/js/zamboni/stats-min.js:4
 msgid "Add-ons Manager Learn More"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:47
+#: static/js/impala/stats/csv_keys.js:47 static/js/zamboni/stats-all.js:15328 static/js/zamboni/stats-min.js:4
 msgid "Search Suggestions"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:48
+#: static/js/impala/stats/csv_keys.js:48 static/js/zamboni/stats-all.js:15329 static/js/zamboni/stats-min.js:4
 msgid "Search Results"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:49 static/js/impala/stats/csv_keys.js:50 static/js/impala/stats/csv_keys.js:51
+#: static/js/impala/stats/csv_keys.js:49 static/js/impala/stats/csv_keys.js:50 static/js/impala/stats/csv_keys.js:51 static/js/zamboni/stats-all.js:15330 static/js/zamboni/stats-all.js:15331
+#: static/js/zamboni/stats-all.js:15332 static/js/zamboni/stats-min.js:4
 msgid "Homepage Promo"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:52 static/js/impala/stats/csv_keys.js:53
+#: static/js/impala/stats/csv_keys.js:52 static/js/impala/stats/csv_keys.js:53 static/js/zamboni/stats-all.js:15333 static/js/zamboni/stats-all.js:15334 static/js/zamboni/stats-min.js:4
 msgid "Homepage Featured"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:54 static/js/impala/stats/csv_keys.js:55
+#: static/js/impala/stats/csv_keys.js:54 static/js/impala/stats/csv_keys.js:55 static/js/zamboni/stats-all.js:15335 static/js/zamboni/stats-all.js:15336 static/js/zamboni/stats-min.js:4
 msgid "Homepage Up and Coming"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:56
+#: static/js/impala/stats/csv_keys.js:56 static/js/zamboni/stats-all.js:15337 static/js/zamboni/stats-min.js:4
 msgid "Homepage Most Popular"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:57 static/js/impala/stats/csv_keys.js:59
+#: static/js/impala/stats/csv_keys.js:57 static/js/impala/stats/csv_keys.js:59 static/js/zamboni/stats-all.js:15338 static/js/zamboni/stats-all.js:15340 static/js/zamboni/stats-min.js:4
 msgid "Detail Page"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:58 static/js/impala/stats/csv_keys.js:60
+#: static/js/impala/stats/csv_keys.js:58 static/js/impala/stats/csv_keys.js:60 static/js/zamboni/stats-all.js:15339 static/js/zamboni/stats-all.js:15341 static/js/zamboni/stats-min.js:4
 msgid "Detail Page (bottom)"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:61
+#: static/js/impala/stats/csv_keys.js:61 static/js/zamboni/stats-all.js:15342 static/js/zamboni/stats-min.js:4
 msgid "Detail Page (Development Channel)"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:62 static/js/impala/stats/csv_keys.js:63 static/js/impala/stats/csv_keys.js:64
+#: static/js/impala/stats/csv_keys.js:62 static/js/impala/stats/csv_keys.js:63 static/js/impala/stats/csv_keys.js:64 static/js/zamboni/stats-all.js:15343 static/js/zamboni/stats-all.js:15344
+#: static/js/zamboni/stats-all.js:15345 static/js/zamboni/stats-min.js:4
 msgid "Often Used With"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:65 static/js/impala/stats/csv_keys.js:66
+#: static/js/impala/stats/csv_keys.js:65 static/js/impala/stats/csv_keys.js:66 static/js/zamboni/stats-all.js:15346 static/js/zamboni/stats-all.js:15347 static/js/zamboni/stats-min.js:4
 msgid "Others By Author"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:67 static/js/impala/stats/csv_keys.js:68
+#: static/js/impala/stats/csv_keys.js:67 static/js/impala/stats/csv_keys.js:68 static/js/zamboni/stats-all.js:15348 static/js/zamboni/stats-all.js:15349 static/js/zamboni/stats-min.js:4
 msgid "Dependencies"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:69 static/js/impala/stats/csv_keys.js:70
+#: static/js/impala/stats/csv_keys.js:69 static/js/impala/stats/csv_keys.js:70 static/js/zamboni/stats-all.js:15350 static/js/zamboni/stats-all.js:15351 static/js/zamboni/stats-min.js:4
 msgid "Upsell"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:71
+#: static/js/impala/stats/csv_keys.js:71 static/js/zamboni/stats-all.js:15352 static/js/zamboni/stats-min.js:4
 msgid "Meet the Developer"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:72
+#: static/js/impala/stats/csv_keys.js:72 static/js/zamboni/stats-all.js:15353 static/js/zamboni/stats-min.js:4
 msgid "User Profile"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:73
+#: static/js/impala/stats/csv_keys.js:73 static/js/zamboni/stats-all.js:15354 static/js/zamboni/stats-min.js:4
 msgid "Version History"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:75
+#: static/js/impala/stats/csv_keys.js:75 static/js/zamboni/stats-all.js:15356 static/js/zamboni/stats-min.js:4
 msgid "Sharing"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:76
+#: static/js/impala/stats/csv_keys.js:76 static/js/zamboni/stats-all.js:15357 static/js/zamboni/stats-min.js:4
 msgid "Category Pages"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:77
+#: static/js/impala/stats/csv_keys.js:77 static/js/zamboni/stats-all.js:15358 static/js/zamboni/stats-min.js:4
 msgid "Collections"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:78 static/js/impala/stats/csv_keys.js:79
+#: static/js/impala/stats/csv_keys.js:78 static/js/impala/stats/csv_keys.js:79 static/js/zamboni/stats-all.js:15359 static/js/zamboni/stats-all.js:15360 static/js/zamboni/stats-min.js:4
 msgid "Category Landing Featured Carousel"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:80 static/js/impala/stats/csv_keys.js:81
+#: static/js/impala/stats/csv_keys.js:80 static/js/impala/stats/csv_keys.js:81 static/js/zamboni/stats-all.js:15361 static/js/zamboni/stats-all.js:15362 static/js/zamboni/stats-min.js:4
 msgid "Category Landing Top Rated"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:82 static/js/impala/stats/csv_keys.js:83
+#: static/js/impala/stats/csv_keys.js:82 static/js/impala/stats/csv_keys.js:83 static/js/zamboni/stats-all.js:15363 static/js/zamboni/stats-all.js:15364 static/js/zamboni/stats-min.js:5
 msgid "Category Landing Most Popular"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:84 static/js/impala/stats/csv_keys.js:85
+#: static/js/impala/stats/csv_keys.js:84 static/js/impala/stats/csv_keys.js:85 static/js/zamboni/stats-all.js:15365 static/js/zamboni/stats-all.js:15366 static/js/zamboni/stats-min.js:5
 msgid "Category Landing Recently Added"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:86 static/js/impala/stats/csv_keys.js:87
+#: static/js/impala/stats/csv_keys.js:86 static/js/impala/stats/csv_keys.js:87 static/js/zamboni/stats-all.js:15367 static/js/zamboni/stats-all.js:15368 static/js/zamboni/stats-min.js:5
 msgid "Browse Listing Featured Sort"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:88 static/js/impala/stats/csv_keys.js:89
+#: static/js/impala/stats/csv_keys.js:88 static/js/impala/stats/csv_keys.js:89 static/js/zamboni/stats-all.js:15369 static/js/zamboni/stats-all.js:15370 static/js/zamboni/stats-min.js:5
 msgid "Browse Listing Users Sort"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:90 static/js/impala/stats/csv_keys.js:91
+#: static/js/impala/stats/csv_keys.js:90 static/js/impala/stats/csv_keys.js:91 static/js/zamboni/stats-all.js:15371 static/js/zamboni/stats-all.js:15372 static/js/zamboni/stats-min.js:5
 msgid "Browse Listing Rating Sort"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:92 static/js/impala/stats/csv_keys.js:93
+#: static/js/impala/stats/csv_keys.js:92 static/js/impala/stats/csv_keys.js:93 static/js/zamboni/stats-all.js:15373 static/js/zamboni/stats-all.js:15374 static/js/zamboni/stats-min.js:5
 msgid "Browse Listing Created Sort"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:94 static/js/impala/stats/csv_keys.js:95
+#: static/js/impala/stats/csv_keys.js:94 static/js/impala/stats/csv_keys.js:95 static/js/zamboni/stats-all.js:15375 static/js/zamboni/stats-all.js:15376 static/js/zamboni/stats-min.js:5
 msgid "Browse Listing Name Sort"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:96 static/js/impala/stats/csv_keys.js:97
+#: static/js/impala/stats/csv_keys.js:96 static/js/impala/stats/csv_keys.js:97 static/js/zamboni/stats-all.js:15377 static/js/zamboni/stats-all.js:15378 static/js/zamboni/stats-min.js:5
 msgid "Browse Listing Popular Sort"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:98 static/js/impala/stats/csv_keys.js:99
+#: static/js/impala/stats/csv_keys.js:98 static/js/impala/stats/csv_keys.js:99 static/js/zamboni/stats-all.js:15379 static/js/zamboni/stats-all.js:15380 static/js/zamboni/stats-min.js:5
 msgid "Browse Listing Updated Sort"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:100 static/js/impala/stats/csv_keys.js:101
+#: static/js/impala/stats/csv_keys.js:100 static/js/impala/stats/csv_keys.js:101 static/js/zamboni/stats-all.js:15381 static/js/zamboni/stats-all.js:15382 static/js/zamboni/stats-min.js:5
 msgid "Browse Listing Up and Coming Sort"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:105
+#: static/js/impala/stats/csv_keys.js:105 static/js/zamboni/stats-all.js:15386 static/js/zamboni/stats-min.js:5
 msgid "Total Amount Contributed"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:106
+#: static/js/impala/stats/csv_keys.js:106 static/js/zamboni/stats-all.js:15387 static/js/zamboni/stats-min.js:5
 msgid "Average Contribution"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:115
+#: static/js/impala/stats/csv_keys.js:115 static/js/zamboni/stats-all.js:15396 static/js/zamboni/stats-min.js:5
 msgid "Usage"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:118
+#: static/js/impala/stats/csv_keys.js:118 static/js/zamboni/stats-all.js:15399 static/js/zamboni/stats-min.js:5
 msgid "Firefox"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:119
+#: static/js/impala/stats/csv_keys.js:119 static/js/zamboni/stats-all.js:15400 static/js/zamboni/stats-min.js:5
 msgid "Mozilla"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:120
+#: static/js/impala/stats/csv_keys.js:120 static/js/zamboni/stats-all.js:15401 static/js/zamboni/stats-min.js:5
 msgid "Thunderbird"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:121
+#: static/js/impala/stats/csv_keys.js:121 static/js/zamboni/stats-all.js:15402 static/js/zamboni/stats-min.js:5
 msgid "Sunbird"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:122
+#: static/js/impala/stats/csv_keys.js:122 static/js/zamboni/stats-all.js:15403 static/js/zamboni/stats-min.js:5
 msgid "SeaMonkey"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:123
+#: static/js/impala/stats/csv_keys.js:123 static/js/zamboni/stats-all.js:15404 static/js/zamboni/stats-min.js:5
 msgid "Fennec"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:124
+#: static/js/impala/stats/csv_keys.js:124 static/js/zamboni/stats-all.js:15405 static/js/zamboni/stats-min.js:5
 msgid "Android"
 msgstr ""
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:129
+#: static/js/impala/stats/csv_keys.js:129 static/js/zamboni/stats-all.js:15410 static/js/zamboni/stats-min.js:5
 msgid "Downloads and Daily Users, last {0} days"
 msgstr ""
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:131
+#: static/js/impala/stats/csv_keys.js:131 static/js/zamboni/stats-all.js:15412 static/js/zamboni/stats-min.js:5
 msgid "Downloads and Daily Users from {0} to {1}"
 msgstr ""
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:135
+#: static/js/impala/stats/csv_keys.js:135 static/js/zamboni/stats-all.js:15416 static/js/zamboni/stats-min.js:5
 msgid "Installs and Daily Users, last {0} days"
 msgstr ""
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:137
+#: static/js/impala/stats/csv_keys.js:137 static/js/zamboni/stats-all.js:15418 static/js/zamboni/stats-min.js:5
 msgid "Installs and Daily Users from {0} to {1}"
 msgstr ""
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:141
+#: static/js/impala/stats/csv_keys.js:141 static/js/zamboni/stats-all.js:15422 static/js/zamboni/stats-min.js:5
 msgid "Downloads, last {0} days"
 msgstr ""
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:143
+#: static/js/impala/stats/csv_keys.js:143 static/js/zamboni/stats-all.js:15424 static/js/zamboni/stats-min.js:5
 msgid "Downloads from {0} to {1}"
 msgstr ""
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:147
+#: static/js/impala/stats/csv_keys.js:147 static/js/zamboni/stats-all.js:15428 static/js/zamboni/stats-min.js:5
 msgid "Daily Users, last {0} days"
 msgstr ""
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:149
+#: static/js/impala/stats/csv_keys.js:149 static/js/zamboni/stats-all.js:15430 static/js/zamboni/stats-min.js:5
 msgid "Daily Users from {0} to {1}"
 msgstr ""
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:153
+#: static/js/impala/stats/csv_keys.js:153 static/js/zamboni/stats-all.js:15434 static/js/zamboni/stats-min.js:5
 msgid "Applications, last {0} days"
 msgstr ""
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:155
+#: static/js/impala/stats/csv_keys.js:155 static/js/zamboni/stats-all.js:15436 static/js/zamboni/stats-min.js:5
 msgid "Applications from {0} to {1}"
 msgstr ""
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:159
+#: static/js/impala/stats/csv_keys.js:159 static/js/zamboni/stats-all.js:15440 static/js/zamboni/stats-min.js:5
 msgid "Platforms, last {0} days"
 msgstr ""
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:161
+#: static/js/impala/stats/csv_keys.js:161 static/js/zamboni/stats-all.js:15442 static/js/zamboni/stats-min.js:5
 msgid "Platforms from {0} to {1}"
 msgstr ""
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:165
+#: static/js/impala/stats/csv_keys.js:165 static/js/zamboni/stats-all.js:15446 static/js/zamboni/stats-min.js:5
 msgid "Languages, last {0} days"
 msgstr ""
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:167
+#: static/js/impala/stats/csv_keys.js:167 static/js/zamboni/stats-all.js:15448 static/js/zamboni/stats-min.js:5
 msgid "Languages from {0} to {1}"
 msgstr ""
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:171
+#: static/js/impala/stats/csv_keys.js:171 static/js/zamboni/stats-all.js:15452 static/js/zamboni/stats-min.js:5
 msgid "Add-on Versions, last {0} days"
 msgstr ""
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:173
+#: static/js/impala/stats/csv_keys.js:173 static/js/zamboni/stats-all.js:15454 static/js/zamboni/stats-min.js:5
 msgid "Add-on Versions from {0} to {1}"
 msgstr ""
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:177
+#: static/js/impala/stats/csv_keys.js:177 static/js/zamboni/stats-all.js:15458 static/js/zamboni/stats-min.js:5
 msgid "Add-on Status, last {0} days"
 msgstr ""
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:179
+#: static/js/impala/stats/csv_keys.js:179 static/js/zamboni/stats-all.js:15460 static/js/zamboni/stats-min.js:5
 msgid "Add-on Status from {0} to {1}"
 msgstr ""
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:183
+#: static/js/impala/stats/csv_keys.js:183 static/js/zamboni/stats-all.js:15464 static/js/zamboni/stats-min.js:5
 msgid "Download Sources, last {0} days"
 msgstr ""
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:185
+#: static/js/impala/stats/csv_keys.js:185 static/js/zamboni/stats-all.js:15466 static/js/zamboni/stats-min.js:5
 msgid "Download Sources from {0} to {1}"
 msgstr ""
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:189
+#: static/js/impala/stats/csv_keys.js:189 static/js/zamboni/stats-all.js:15470 static/js/zamboni/stats-min.js:5
 msgid "Contributions, last {0} days"
 msgstr ""
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:191
+#: static/js/impala/stats/csv_keys.js:191 static/js/zamboni/stats-all.js:15472 static/js/zamboni/stats-min.js:5
 msgid "Contributions from {0} to {1}"
 msgstr ""
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:195
+#: static/js/impala/stats/csv_keys.js:195 static/js/zamboni/stats-all.js:15476 static/js/zamboni/stats-min.js:5
 msgid "Site Metrics, last {0} days"
 msgstr ""
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:197
+#: static/js/impala/stats/csv_keys.js:197 static/js/zamboni/stats-all.js:15478 static/js/zamboni/stats-min.js:5
 msgid "Site Metrics from {0} to {1}"
 msgstr ""
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:201
+#: static/js/impala/stats/csv_keys.js:201 static/js/zamboni/stats-all.js:15482 static/js/zamboni/stats-min.js:5
 msgid "Add-ons in Use, last {0} days"
 msgstr ""
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:203
+#: static/js/impala/stats/csv_keys.js:203 static/js/zamboni/stats-all.js:15484 static/js/zamboni/stats-min.js:5
 msgid "Add-ons in Use from {0} to {1}"
 msgstr ""
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:207
+#: static/js/impala/stats/csv_keys.js:207 static/js/zamboni/stats-all.js:15488 static/js/zamboni/stats-min.js:5
 msgid "Add-ons Downloaded, last {0} days"
 msgstr ""
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:209
+#: static/js/impala/stats/csv_keys.js:209 static/js/zamboni/stats-all.js:15490 static/js/zamboni/stats-min.js:5
 msgid "Add-ons Downloaded from {0} to {1}"
 msgstr ""
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:213
+#: static/js/impala/stats/csv_keys.js:213 static/js/zamboni/stats-all.js:15494 static/js/zamboni/stats-min.js:5
 msgid "Add-ons Created, last {0} days"
 msgstr ""
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:215
+#: static/js/impala/stats/csv_keys.js:215 static/js/zamboni/stats-all.js:15496 static/js/zamboni/stats-min.js:5
 msgid "Add-ons Created from {0} to {1}"
 msgstr ""
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:219
+#: static/js/impala/stats/csv_keys.js:219 static/js/zamboni/stats-all.js:15500 static/js/zamboni/stats-min.js:5
 msgid "Add-ons Updated, last {0} days"
 msgstr ""
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:221
+#: static/js/impala/stats/csv_keys.js:221 static/js/zamboni/stats-all.js:15502 static/js/zamboni/stats-min.js:5
 msgid "Add-ons Updated from {0} to {1}"
 msgstr ""
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:225
+#: static/js/impala/stats/csv_keys.js:225 static/js/zamboni/stats-all.js:15506 static/js/zamboni/stats-min.js:5
 msgid "Reviews Written, last {0} days"
 msgstr ""
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:227
+#: static/js/impala/stats/csv_keys.js:227 static/js/zamboni/stats-all.js:15508 static/js/zamboni/stats-min.js:5
 msgid "Reviews Written from {0} to {1}"
 msgstr ""
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:231
+#: static/js/impala/stats/csv_keys.js:231 static/js/zamboni/stats-all.js:15512 static/js/zamboni/stats-min.js:5
 msgid "User Signups, last {0} days"
 msgstr ""
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:233
+#: static/js/impala/stats/csv_keys.js:233 static/js/zamboni/stats-all.js:15514 static/js/zamboni/stats-min.js:5
 msgid "User Signups from {0} to {1}"
 msgstr ""
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:237
+#: static/js/impala/stats/csv_keys.js:237 static/js/zamboni/stats-all.js:15518 static/js/zamboni/stats-min.js:5
 msgid "Collections Created, last {0} days"
 msgstr ""
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:239
+#: static/js/impala/stats/csv_keys.js:239 static/js/zamboni/stats-all.js:15520 static/js/zamboni/stats-min.js:5
 msgid "Collections Created from {0} to {1}"
 msgstr ""
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:243
+#: static/js/impala/stats/csv_keys.js:243 static/js/zamboni/stats-all.js:15524 static/js/zamboni/stats-min.js:5
 msgid "Subscribers, last {0} days"
 msgstr ""
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:245
+#: static/js/impala/stats/csv_keys.js:245 static/js/zamboni/stats-all.js:15526 static/js/zamboni/stats-min.js:5
 msgid "Subscribers from {0} to {1}"
 msgstr ""
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:249
+#: static/js/impala/stats/csv_keys.js:249 static/js/zamboni/stats-all.js:15530 static/js/zamboni/stats-min.js:5
 msgid "Ratings, last {0} days"
 msgstr ""
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:251
+#: static/js/impala/stats/csv_keys.js:251 static/js/zamboni/stats-all.js:15532 static/js/zamboni/stats-min.js:5
 msgid "Ratings from {0} to {1}"
 msgstr ""
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:255
+#: static/js/impala/stats/csv_keys.js:255 static/js/zamboni/stats-all.js:15536 static/js/zamboni/stats-min.js:5
 msgid "Sales, last {0} days"
 msgstr ""
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:257
+#: static/js/impala/stats/csv_keys.js:257 static/js/zamboni/stats-all.js:15538 static/js/zamboni/stats-min.js:5
 msgid "Sales from {0} to {1}"
 msgstr ""
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:261
+#: static/js/impala/stats/csv_keys.js:261 static/js/zamboni/stats-all.js:15542 static/js/zamboni/stats-min.js:5
 msgid "Installs, last {0} days"
 msgstr ""
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:263
+#: static/js/impala/stats/csv_keys.js:263 static/js/zamboni/stats-all.js:15544 static/js/zamboni/stats-min.js:5
 msgid "Installs from {0} to {1}"
 msgstr ""
 
 #. L10n: {0} and {1} are integers.
-#: static/js/impala/stats/csv_keys.js:269
+#: static/js/impala/stats/csv_keys.js:269 static/js/zamboni/stats-all.js:15550 static/js/zamboni/stats-min.js:5
 msgid "<b>{0}</b> in last {1} days"
 msgstr ""
 
 #. L10n: {0} is an integer and {1} and {2} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:271 static/js/impala/stats/csv_keys.js:277
+#: static/js/impala/stats/csv_keys.js:271 static/js/impala/stats/csv_keys.js:277 static/js/zamboni/stats-all.js:15552 static/js/zamboni/stats-all.js:15558 static/js/zamboni/stats-min.js:5
 msgid "<b>{0}</b> from {1} to {2}"
 msgstr ""
 
 #. L10n: {0} and {1} are integers.
-#: static/js/impala/stats/csv_keys.js:275
+#: static/js/impala/stats/csv_keys.js:275 static/js/zamboni/stats-all.js:15556 static/js/zamboni/stats-min.js:5
 msgid "<b>{0}</b> average in last {1} days"
 msgstr ""
 
-#: static/js/impala/stats/overview.js:19
+#: static/js/impala/stats/overview.js:19 static/js/zamboni/stats-all.js:16469 static/js/zamboni/stats-min.js:5
 msgid "No data available."
 msgstr ""
 
-#: static/js/impala/stats/table.js:74
+#: static/js/impala/stats/table.js:74 static/js/zamboni/stats-all.js:17209 static/js/zamboni/stats-min.js:5
 msgid "Date"
 msgstr ""
 
-#: static/js/impala/stats/topchart.js:96
+#: static/js/impala/stats/topchart.js:96 static/js/zamboni/stats-all.js:16600 static/js/zamboni/stats-min.js:5
 msgid "Other"
 msgstr ""
 
-#: static/js/zamboni/admin_validation.js:24 static/js/zamboni/devhub.js:1229 static/js/zamboni/editors.js:295
+#: static/js/zamboni/admin-all.js:180 static/js/zamboni/admin-min.js:1 static/js/zamboni/admin_validation.js:24 static/js/zamboni/devhub-all.js:2408 static/js/zamboni/devhub-min.js:2
+#: static/js/zamboni/devhub.js:1229 static/js/zamboni/editors-all.js:15576 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:295
 msgid "Select an application first"
 msgstr ""
 
-#: static/js/zamboni/admin_validation.js:51
+#: static/js/zamboni/admin-all.js:207 static/js/zamboni/admin-min.js:1 static/js/zamboni/admin_validation.js:51
 msgid "Set {0} add-on to a max version of {1} and email the author."
 msgid_plural "Set {0} add-ons to a max version of {1} and email the authors."
 msgstr[0] ""
 msgstr[1] ""
 
-#: static/js/zamboni/admin_validation.js:54
+#: static/js/zamboni/admin-all.js:210 static/js/zamboni/admin-min.js:1 static/js/zamboni/admin_validation.js:54
 msgid "Email author of {2} add-on which failed validation."
 msgid_plural "Email authors of {2} add-ons which failed validation."
 msgstr[0] ""
 msgstr[1] ""
 
-#. L10n: {0} is an app name like Firefox.
-#: static/js/zamboni/buttons.js:66
-msgid "Accept and Install"
-msgstr ""
-
-#: static/js/zamboni/buttons.js:66
-msgid "Add to {0}"
-msgstr ""
-
-#: static/js/zamboni/buttons.js:71
-msgid "Download Now"
-msgstr ""
-
-#: static/js/zamboni/buttons.js:112
-msgid "Add-on has not been updated to support default-to-compatible."
-msgstr ""
-
-#: static/js/zamboni/buttons.js:117
-msgid "You need to be using Firefox 10.0 or higher."
-msgstr ""
-
-#: static/js/zamboni/buttons.js:129
-msgid "Mozilla has marked this version as incompatible with your Firefox version."
-msgstr ""
-
-#. L10n: {0} is an platform like Windows or Linux.
-#: static/js/zamboni/buttons.js:210
-msgid "Install for {0} anyway"
-msgstr ""
-
-#: static/js/zamboni/buttons.js:210
-msgid "Download for {0} anyway"
-msgstr ""
-
-#: static/js/zamboni/buttons.js:267
-msgid "Not available for your platform"
-msgstr ""
-
-#. L10n: {0} is an app name, {1} is the app version.
-#: static/js/zamboni/buttons.js:278 static/js/zamboni/buttons.js:315
-msgid "Not available for {0} {1}"
-msgstr ""
-
-#: static/js/zamboni/buttons.js:341
-msgid "Works with {app} {min} - {max}"
-msgstr ""
-
-#: static/js/zamboni/buttons.js:343
-msgid "View other versions"
-msgstr ""
-
-#: static/js/zamboni/buttons.js:391
-msgid "Only with Firefox — Get Firefox Now!"
-msgstr ""
-
-#: static/js/zamboni/buttons.js:507 static/js/zamboni/mobile/buttons.js:43
-msgid "Sorry, you need a Mozilla-based browser (such as Firefox) to install a search plugin."
-msgstr ""
-
-#: static/js/zamboni/collections.js:229
-msgid "Adding to Favorites&hellip;"
-msgstr ""
-
-#: static/js/zamboni/collections.js:232
-msgid "Removing Favorite&hellip;"
-msgstr ""
-
-#: static/js/zamboni/collections.js:235
-msgid "Add to Favorites"
-msgstr ""
-
-#: static/js/zamboni/collections.js:238
-msgid "Remove from Favorites"
-msgstr ""
-
-#: static/js/zamboni/collections.js:303
-msgid "Pending"
-msgstr ""
-
-#: static/js/zamboni/collections.js:304
-msgid "Add a comment"
-msgstr ""
-
-#: static/js/zamboni/collections.js:304
-msgid "Comment"
-msgstr ""
-
-#: static/js/zamboni/collections.js:305
-msgid "Remove this add-on from the collection"
-msgstr ""
-
-#: static/js/zamboni/collections.js:305 static/js/zamboni/collections.js:334
-msgid "Remove"
-msgstr ""
-
-#: static/js/zamboni/collections.js:334
-msgid "Remove this user as a contributor"
-msgstr ""
-
-#: static/js/zamboni/collections.js:346
-msgid "An email address is required."
-msgstr ""
-
-#: static/js/zamboni/collections.js:364
-msgid "You cannot add yourself as a contributor."
-msgstr ""
-
-#: static/js/zamboni/collections.js:366
-msgid "You have already added that user."
-msgstr ""
-
-#: static/js/zamboni/collections.js:573
-msgid "Add to favorites"
-msgstr ""
-
-#: static/js/zamboni/collections.js:577
-msgid "Remove from favorites"
-msgstr ""
-
-#: static/js/zamboni/collections.js:604
-msgid "Stop following"
-msgstr ""
-
-#: static/js/zamboni/devhub.js:110
+#: static/js/zamboni/devhub-all.js:1289 static/js/zamboni/devhub-min.js:1 static/js/zamboni/devhub.js:110
 msgid "Your browser does not support the video tag"
 msgstr ""
 
-#: static/js/zamboni/devhub.js:371
+#: static/js/zamboni/devhub-all.js:1550 static/js/zamboni/devhub-min.js:1 static/js/zamboni/devhub.js:371
 msgid "Changes Saved"
 msgstr ""
 
-#: static/js/zamboni/devhub.js:387
+#: static/js/zamboni/devhub-all.js:1566 static/js/zamboni/devhub-min.js:1 static/js/zamboni/devhub.js:387
 msgid "Enter a new author's email address"
 msgstr ""
 
-#: static/js/zamboni/devhub.js:536
+#: static/js/zamboni/devhub-all.js:1715 static/js/zamboni/devhub-min.js:1 static/js/zamboni/devhub.js:536
 msgid "There was an error uploading your file."
 msgstr ""
 
-#: static/js/zamboni/devhub.js:681
+#: static/js/zamboni/devhub-all.js:1860 static/js/zamboni/devhub-min.js:1 static/js/zamboni/devhub.js:681
 msgid "{files} file"
 msgid_plural "{files} files"
 msgstr[0] ""
 msgstr[1] ""
 
-#: static/js/zamboni/devhub.js:684
+#: static/js/zamboni/devhub-all.js:1863 static/js/zamboni/devhub-min.js:1 static/js/zamboni/devhub.js:684
 msgid "{reviews} user review"
 msgid_plural "{reviews} user reviews"
 msgstr[0] ""
 msgstr[1] ""
 
-#: static/js/zamboni/devhub.js:796
+#: static/js/zamboni/devhub-all.js:1975 static/js/zamboni/devhub-min.js:2 static/js/zamboni/devhub.js:796
 msgid "Learn more"
 msgstr ""
 
-#: static/js/zamboni/devhub.js:800
+#: static/js/zamboni/devhub-all.js:1979 static/js/zamboni/devhub-min.js:2 static/js/zamboni/devhub.js:800
 msgid "Example"
 msgstr ""
 
-#: static/js/zamboni/devhub.js:1130
+#: static/js/zamboni/devhub-all.js:2309 static/js/zamboni/devhub-min.js:2 static/js/zamboni/devhub.js:1130
 msgid "Image changes being processed"
 msgstr ""
 
-#: static/js/zamboni/devhub.js:1280
+#: static/js/zamboni/devhub-all.js:2459 static/js/zamboni/devhub-min.js:2 static/js/zamboni/devhub.js:1280
 msgid "Must be a valid e-mail address."
+msgstr ""
+
+#: static/js/zamboni/devhub-all.js:2613 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:80
+msgid "All tests passed successfully."
+msgstr ""
+
+#: static/js/zamboni/devhub-all.js:2616 static/js/zamboni/devhub-all.js:3011 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:83 static/js/zamboni/validator.js:478
+msgid "These tests were not run."
+msgstr ""
+
+#: static/js/zamboni/devhub-all.js:2664 static/js/zamboni/devhub-all.js:2677 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:131 static/js/zamboni/validator.js:144
+msgid "Tests"
+msgstr ""
+
+#: static/js/zamboni/devhub-all.js:2779 static/js/zamboni/devhub-all.js:3108 static/js/zamboni/devhub-all.js:3127 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:246
+#: static/js/zamboni/validator.js:575 static/js/zamboni/validator.js:594
+msgid "Error"
+msgstr ""
+
+#: static/js/zamboni/devhub-all.js:2780 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:247
+msgid "Warning"
+msgstr ""
+
+#: static/js/zamboni/devhub-all.js:2794 static/js/zamboni/devhub-min.js:2 static/js/zamboni/files-all.js:5657 static/js/zamboni/files-min.js:3 static/js/zamboni/files.js:411
+#: static/js/zamboni/validator.js:261
+msgid "Ignore this message in future updates"
+msgstr ""
+
+#: static/js/zamboni/devhub-all.js:2817 static/js/zamboni/devhub-min.js:2 static/js/zamboni/files-all.js:5663 static/js/zamboni/files-min.js:3 static/js/zamboni/files.js:417
+#: static/js/zamboni/validator.js:284
+msgid "Severity for automated signing:"
+msgstr ""
+
+#: static/js/zamboni/devhub-all.js:2832 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:299
+msgid "Suggestions for passing automated signing:"
+msgstr ""
+
+#: static/js/zamboni/devhub-all.js:2920 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:387
+msgid "Compatibility Tests"
+msgstr ""
+
+#: static/js/zamboni/devhub-all.js:2999 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:466
+msgid "Add-on failed validation."
+msgstr ""
+
+#: static/js/zamboni/devhub-all.js:3001 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:468
+msgid "Add-on passed validation."
+msgstr ""
+
+#: static/js/zamboni/devhub-all.js:3014 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:481
+msgid "{0} error"
+msgid_plural "{0} errors"
+msgstr[0] ""
+msgstr[1] ""
+
+#: static/js/zamboni/devhub-all.js:3016 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:483
+msgid "{0} warning"
+msgid_plural "{0} warnings"
+msgstr[0] ""
+msgstr[1] ""
+
+#: static/js/zamboni/devhub-all.js:3018 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:485
+msgid "{0} notice"
+msgid_plural "{0} notices"
+msgstr[0] ""
+msgstr[1] ""
+
+#: static/js/zamboni/devhub-all.js:3110 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:577
+msgid "Validation task could not complete or completed with errors"
+msgstr ""
+
+#: static/js/zamboni/devhub-all.js:3128 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:595
+msgid "Internal server error"
 msgstr ""
 
 #: static/js/zamboni/devhub_search.js:8
 msgid "No results found."
 msgstr ""
 
-#: static/js/zamboni/editors.js:121
+#: static/js/zamboni/editors-all.js:15402 static/js/zamboni/editors-min.js:4 static/js/zamboni/editors.js:121
 msgid "{name} was viewing this page first."
 msgstr ""
 
-#: static/js/zamboni/editors.js:171
+#: static/js/zamboni/editors-all.js:15452 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:171
 msgid "Receipt checked by app."
 msgstr ""
 
-#: static/js/zamboni/editors.js:173
+#: static/js/zamboni/editors-all.js:15454 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:173
 msgid "Receipt was not checked by app."
 msgstr ""
 
-#: static/js/zamboni/editors.js:244
+#: static/js/zamboni/editors-all.js:15525 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:244
 msgid "{name} was viewing this add-on first."
 msgstr ""
 
-#: static/js/zamboni/editors.js:255
+#: static/js/zamboni/editors-all.js:15536 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:255
 msgid "Loading&hellip;"
 msgstr ""
 
-#: static/js/zamboni/editors.js:260
+#: static/js/zamboni/editors-all.js:15541 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:260
 msgid "Version Notes"
 msgstr ""
 
-#: static/js/zamboni/editors.js:265
+#: static/js/zamboni/editors-all.js:15546 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:265
 msgid "Notes for Reviewers"
 msgstr ""
 
-#: static/js/zamboni/editors.js:270
+#: static/js/zamboni/editors-all.js:15551 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:270
 msgid "No version notes found"
 msgstr ""
 
-#: static/js/zamboni/editors.js:330
+#: static/js/zamboni/editors-all.js:15611 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:330
 msgid "Average Reviews"
 msgstr ""
 
-#: static/js/zamboni/editors.js:386
+#: static/js/zamboni/editors-all.js:15667 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:386
 msgid "Number of Reviews"
 msgstr ""
 
-#: static/js/zamboni/editors.js:445
+#: static/js/zamboni/editors-all.js:15726 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:445
 msgid "Error loading translation"
 msgstr ""
 
-#: static/js/zamboni/files.js:411 static/js/zamboni/validator.js:261
-msgid "Ignore this message in future updates"
-msgstr ""
-
-#: static/js/zamboni/files.js:417 static/js/zamboni/validator.js:284
-msgid "Severity for automated signing:"
-msgstr ""
-
-#: static/js/zamboni/global.js:410
-msgid "Loading..."
-msgstr ""
-
-#. L10n: {0} is the number of characters left.
-#: static/js/zamboni/global.js:474
-msgid "<b>{0}</b> character left."
-msgid_plural "<b>{0}</b> characters left."
-msgstr[0] ""
-msgstr[1] ""
-
-#: static/js/zamboni/init.js:28
-msgid "This feature is temporarily disabled while we perform website maintenance. Please check back a little later."
-msgstr ""
-
-#: static/js/zamboni/l10n.js:45
-msgid "Remove this localization"
-msgstr ""
-
-#: static/js/zamboni/password-strength.js:20
-msgid "Password strength:"
-msgstr ""
-
-#: static/js/zamboni/password-strength.js:26
-msgid "At least {0} character left."
-msgid_plural "At least {0} characters left."
-msgstr[0] ""
-msgstr[1] ""
-
-#: static/js/zamboni/themes_review.js:176
-msgid "Requested Info"
-msgstr ""
-
-#: static/js/zamboni/themes_review.js:177
-msgid "Flagged"
-msgstr ""
-
-#: static/js/zamboni/themes_review.js:178
-msgid "Duplicate"
-msgstr ""
-
-#: static/js/zamboni/themes_review.js:179
-msgid "Rejected"
-msgstr ""
-
-#: static/js/zamboni/themes_review.js:180
-msgid "Approved"
-msgstr ""
-
-#: static/js/zamboni/themes_review.js:424
-msgid "No results found"
-msgstr ""
-
-#: static/js/zamboni/themes_review_templates.js:31
+#: static/js/zamboni/editors-all.js:15975 static/js/zamboni/editors-min.js:5 static/js/zamboni/themes_review_templates.js:31
 msgid "Theme"
 msgstr ""
 
-#: static/js/zamboni/themes_review_templates.js:33
+#: static/js/zamboni/editors-all.js:15977 static/js/zamboni/editors-min.js:5 static/js/zamboni/themes_review_templates.js:33
 msgid "Reviewer"
 msgstr ""
 
-#: static/js/zamboni/themes_review_templates.js:35
+#: static/js/zamboni/editors-all.js:15979 static/js/zamboni/editors-min.js:5 static/js/zamboni/themes_review_templates.js:35
 msgid "Status"
 msgstr ""
 
-#: static/js/zamboni/validator.js:80
-msgid "All tests passed successfully."
+#: static/js/zamboni/editors-all.js:16196 static/js/zamboni/editors-min.js:5 static/js/zamboni/themes_review.js:176
+msgid "Requested Info"
 msgstr ""
 
-#: static/js/zamboni/validator.js:83 static/js/zamboni/validator.js:478
-msgid "These tests were not run."
+#: static/js/zamboni/editors-all.js:16197 static/js/zamboni/editors-min.js:5 static/js/zamboni/themes_review.js:177
+msgid "Flagged"
 msgstr ""
 
-#: static/js/zamboni/validator.js:131 static/js/zamboni/validator.js:144
-msgid "Tests"
+#: static/js/zamboni/editors-all.js:16198 static/js/zamboni/editors-min.js:5 static/js/zamboni/themes_review.js:178
+msgid "Duplicate"
 msgstr ""
 
-#: static/js/zamboni/validator.js:246 static/js/zamboni/validator.js:575 static/js/zamboni/validator.js:594
-msgid "Error"
+#: static/js/zamboni/editors-all.js:16199 static/js/zamboni/editors-min.js:5 static/js/zamboni/themes_review.js:179
+msgid "Rejected"
 msgstr ""
 
-#: static/js/zamboni/validator.js:247
-msgid "Warning"
+#: static/js/zamboni/editors-all.js:16200 static/js/zamboni/editors-min.js:5 static/js/zamboni/themes_review.js:180
+msgid "Approved"
 msgstr ""
 
-#: static/js/zamboni/validator.js:299
-msgid "Suggestions for passing automated signing:"
+#: static/js/zamboni/editors-all.js:16444 static/js/zamboni/editors-min.js:5 static/js/zamboni/themes_review.js:424
+msgid "No results found"
 msgstr ""
 
-#: static/js/zamboni/validator.js:387
-msgid "Compatibility Tests"
-msgstr ""
-
-#: static/js/zamboni/validator.js:466
-msgid "Add-on failed validation."
-msgstr ""
-
-#: static/js/zamboni/validator.js:468
-msgid "Add-on passed validation."
-msgstr ""
-
-#: static/js/zamboni/validator.js:481
-msgid "{0} error"
-msgid_plural "{0} errors"
-msgstr[0] ""
-msgstr[1] ""
-
-#: static/js/zamboni/validator.js:483
-msgid "{0} warning"
-msgid_plural "{0} warnings"
-msgstr[0] ""
-msgstr[1] ""
-
-#: static/js/zamboni/validator.js:485
-msgid "{0} notice"
-msgid_plural "{0} notices"
-msgstr[0] ""
-msgstr[1] ""
-
-#: static/js/zamboni/validator.js:577
-msgid "Validation task could not complete or completed with errors"
-msgstr ""
-
-#: static/js/zamboni/validator.js:595
-msgid "Internal server error"
-msgstr ""
-
-#: static/js/zamboni/mobile/buttons.js:52
+#: static/js/zamboni/mobile-all.js:15186 static/js/zamboni/mobile/buttons.js:52
 msgid "Not Updated for {0} {1}"
 msgstr ""
 
-#: static/js/zamboni/mobile/buttons.js:53
+#: static/js/zamboni/mobile-all.js:15187 static/js/zamboni/mobile/buttons.js:53
 msgid "Requires Newer Version of {0}"
 msgstr ""
 
-#: static/js/zamboni/mobile/buttons.js:54
+#: static/js/zamboni/mobile-all.js:15188 static/js/zamboni/mobile/buttons.js:54
 msgid "Unreviewed"
 msgstr ""
 
-#: static/js/zamboni/mobile/buttons.js:55
+#: static/js/zamboni/mobile-all.js:15189 static/js/zamboni/mobile/buttons.js:55
 msgid "Experimental <span>(Learn More)</span>"
 msgstr ""
 
-#: static/js/zamboni/mobile/buttons.js:56 static/js/zamboni/mobile/buttons.js:57
+#: static/js/zamboni/mobile-all.js:15190 static/js/zamboni/mobile-all.js:15191 static/js/zamboni/mobile/buttons.js:56 static/js/zamboni/mobile/buttons.js:57
 msgid "Not Available for {0}"
 msgstr ""
 
-#: static/js/zamboni/mobile/buttons.js:58
+#: static/js/zamboni/mobile-all.js:15192 static/js/zamboni/mobile/buttons.js:58
 msgid "Experimental"
 msgstr ""
 
-#: static/js/zamboni/mobile/buttons.js:59
+#: static/js/zamboni/mobile-all.js:15193 static/js/zamboni/mobile/buttons.js:59
 msgid "Themes Require Newer Version of {0}"
 msgstr ""
 
-#: static/js/zamboni/mobile/buttons.js:60
+#: static/js/zamboni/mobile-all.js:15194 static/js/zamboni/mobile/buttons.js:60
 msgid "Themes Require {0}"
 msgstr ""
 
-#: static/js/zamboni/mobile/buttons.js:105
+#: static/js/zamboni/mobile-all.js:15239 static/js/zamboni/mobile/buttons.js:105
 msgid "Installing..."
 msgstr ""
 
-#: static/js/zamboni/mobile/buttons.js:125
+#: static/js/zamboni/mobile-all.js:15259 static/js/zamboni/mobile/buttons.js:125
 msgid "This add-on has been preliminarily reviewed by Mozilla."
 msgstr ""
 
-#: static/js/zamboni/mobile/buttons.js:250
+#: static/js/zamboni/mobile-all.js:15384 static/js/zamboni/mobile/buttons.js:250
 msgid "Keep it"
 msgstr ""
 
-#: static/js/zamboni/mobile/general.js:344
+#: static/js/zamboni/mobile-all.js:16049 static/js/zamboni/mobile-min.js:6 static/js/zamboni/mobile/general.js:344
 msgid "You're trying it on!"
 msgstr ""
 
-#: static/js/zamboni/mobile/general.js:356
+#: static/js/zamboni/mobile-all.js:16061 static/js/zamboni/mobile-min.js:6 static/js/zamboni/mobile/general.js:356
 msgid "Added to Firefox"
 msgstr ""
-

--- a/locale/ms/LC_MESSAGES/django.po
+++ b/locale/ms/LC_MESSAGES/django.po
@@ -3,69 +3,70 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2016-02-24 21:23+0000\n"
+"POT-Creation-Date: 2016-04-18 15:47+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
+"Language: \n"
 "MIME-Version: 1.0\n"
-"Content-Type: text/plain; charset=utf-8\n"
+"Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Generated-By: Babel 2.2.0\n"
 
-#: src/olympia/accounts/views.py:52
+#: src/olympia/accounts/views.py:54
 msgid "Your log in attempt could not be parsed. Please try again."
 msgstr ""
 
-#: src/olympia/accounts/views.py:54
+#: src/olympia/accounts/views.py:56
 msgid "Your Firefox Account could not be found. Please try again."
 msgstr ""
 
-#: src/olympia/accounts/views.py:55
+#: src/olympia/accounts/views.py:57
 msgid "You could not be logged in. Please try again."
 msgstr ""
 
-#: src/olympia/accounts/views.py:57
+#: src/olympia/accounts/views.py:59
 msgid "Your account has already been migrated to Firefox Accounts."
 msgstr ""
 
-#: src/olympia/accounts/views.py:59
+#: src/olympia/accounts/views.py:61
 msgid "Your Firefox Account already exists on this site."
 msgstr ""
 
-#: src/olympia/accounts/views.py:108
+#: src/olympia/accounts/views.py:110
 msgid "Great job!"
 msgstr ""
 
-#: src/olympia/accounts/views.py:109
+#: src/olympia/accounts/views.py:111
 msgid "You can now log in to Add-ons with your Firefox Account."
 msgstr ""
 
-#: src/olympia/accounts/views.py:121
+#: src/olympia/accounts/views.py:123
 msgid "Need help?"
 msgstr ""
 
-#: src/olympia/addons/buttons.py:180
+#: src/olympia/addons/buttons.py:177
 msgid "Download Now"
 msgstr ""
 
-#: src/olympia/addons/buttons.py:182
+#: src/olympia/addons/buttons.py:179
 msgid "Download"
 msgstr ""
 
 #. L10n: please keep &nbsp; in the string so &rarr; does not wrap.
-#: src/olympia/addons/buttons.py:186
+#: src/olympia/addons/buttons.py:183
 msgid "Continue to Download&nbsp;&rarr;"
 msgstr ""
 
-#: src/olympia/addons/buttons.py:202 src/olympia/addons/helpers.py:35 src/olympia/addons/views.py:319 src/olympia/addons/templates/addons/impala/details.html:114
+#: src/olympia/addons/buttons.py:199 src/olympia/addons/helpers.py:35 src/olympia/addons/views.py:333 src/olympia/addons/templates/addons/impala/details.html:111
 #: src/olympia/addons/templates/addons/impala/listing/items.html:17 src/olympia/addons/templates/addons/mobile/home.html:40 src/olympia/amo/templates/amo/side_nav.html:6
-#: src/olympia/amo/templates/amo/side_nav.html:10 src/olympia/amo/templates/amo/site_nav.html:2 src/olympia/amo/templates/amo/site_nav.html:55 src/olympia/bandwagon/views.py:95
-#: src/olympia/browse/views.py:54 src/olympia/browse/views.py:68 src/olympia/browse/views.py:235 src/olympia/browse/templates/browse/impala/category_landing.html:22
+#: src/olympia/amo/templates/amo/side_nav.html:10 src/olympia/amo/templates/amo/site_nav.html:2 src/olympia/amo/templates/amo/site_nav.html:53 src/olympia/bandwagon/views.py:95
+#: src/olympia/browse/views.py:54 src/olympia/browse/views.py:68 src/olympia/browse/views.py:202 src/olympia/browse/templates/browse/impala/category_landing.html:22
 #: src/olympia/browse/templates/browse/personas/mobile/category_landing.html:26
 msgid "Featured"
 msgstr ""
 
-#: src/olympia/addons/buttons.py:221
+#: src/olympia/addons/buttons.py:218
 msgid "Add to {0}"
 msgstr ""
 
@@ -113,39 +114,39 @@ msgid_plural "All tags must be at least {0} characters."
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/olympia/addons/forms.py:234
+#: src/olympia/addons/forms.py:238
 msgid "Categories cannot be changed while your add-on is featured for this application."
 msgstr ""
 
 #. L10n: {0} is the number of categories.
-#: src/olympia/addons/forms.py:238
+#: src/olympia/addons/forms.py:242
 msgid "You can have only {0} category."
 msgid_plural "You can have only {0} categories."
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/olympia/addons/forms.py:246
+#: src/olympia/addons/forms.py:250
 msgid "The miscellaneous category cannot be combined with additional categories."
 msgstr ""
 
-#: src/olympia/addons/forms.py:369
+#: src/olympia/addons/forms.py:374
 #, python-format
 msgid "Before changing your default locale you must have a name, summary, and description in that locale. You are missing %s."
 msgstr ""
 
-#: src/olympia/addons/forms.py:484 src/olympia/addons/forms.py:575
+#: src/olympia/addons/forms.py:455 src/olympia/addons/forms.py:546
 msgid "A license must be selected."
 msgstr ""
 
-#: src/olympia/addons/forms.py:556
+#: src/olympia/addons/forms.py:527
 msgid "Give Your Theme a Name."
 msgstr ""
 
-#: src/olympia/addons/forms.py:562 src/olympia/devhub/templates/devhub/personas/submit.html:53
+#: src/olympia/addons/forms.py:533 src/olympia/devhub/templates/devhub/personas/submit.html:53
 msgid "Describe your Theme."
 msgstr ""
 
-#: src/olympia/addons/forms.py:704
+#: src/olympia/addons/forms.py:675
 msgid "Enter a new author's email address"
 msgstr ""
 
@@ -153,37 +154,37 @@ msgstr ""
 msgid "Not Reviewed"
 msgstr ""
 
-#: src/olympia/addons/models.py:301
+#: src/olympia/addons/models.py:298
 msgid "Users have the option of contributing more or less than this amount."
 msgstr ""
 
-#: src/olympia/addons/models.py:309
-msgid "Users will always be asked in the Add-ons Manager (Firefox 4 and above)"
+#: src/olympia/addons/models.py:306
+msgid "Users will always be asked in the Add-ons Manager (Firefox 4 and above). Only applies to desktop."
 msgstr ""
 
-#: src/olympia/addons/models.py:1804 src/olympia/addons/templates/addons/details_box.html:55 src/olympia/devhub/templates/devhub/index.html:92
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:102
+#: src/olympia/addons/models.py:1802 src/olympia/addons/templates/addons/details_box.html:55 src/olympia/devhub/templates/devhub/index.html:92
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:89
 msgid "Listed"
 msgstr ""
 
-#: src/olympia/addons/views.py:320 src/olympia/browse/templates/browse/personas/mobile/category_landing.html:27
+#: src/olympia/addons/views.py:334 src/olympia/browse/templates/browse/personas/mobile/category_landing.html:27
 msgid "Popular"
 msgstr ""
 
-#: src/olympia/addons/views.py:321 src/olympia/browse/views.py:238 src/olympia/browse/views.py:280 src/olympia/browse/views.py:482
+#: src/olympia/addons/views.py:335 src/olympia/browse/views.py:205 src/olympia/browse/views.py:247 src/olympia/browse/views.py:449
 msgid "Recently Added"
 msgstr ""
 
-#: src/olympia/addons/views.py:322 src/olympia/bandwagon/views.py:99 src/olympia/browse/views.py:60 src/olympia/browse/views.py:71 src/olympia/search/forms.py:16 src/olympia/search/forms.py:91
+#: src/olympia/addons/views.py:336 src/olympia/bandwagon/views.py:99 src/olympia/browse/views.py:60 src/olympia/browse/views.py:71 src/olympia/search/forms.py:16 src/olympia/search/forms.py:91
 msgid "Recently Updated"
 msgstr ""
 
 #. l10n: {0} is the addon name
-#: src/olympia/addons/views.py:520
+#: src/olympia/addons/views.py:534
 msgid "Contribution for {0}"
 msgstr ""
 
-#: src/olympia/addons/views.py:613
+#: src/olympia/addons/views.py:627
 msgid "Abuse reported."
 msgstr ""
 
@@ -250,9 +251,9 @@ msgstr ""
 #: src/olympia/devhub/templates/devhub/addons/ajax_compat_update.html:36 src/olympia/devhub/templates/devhub/addons/profile.html:44 src/olympia/devhub/templates/devhub/addons/edit/admin.html:101
 #: src/olympia/devhub/templates/devhub/addons/edit/basic.html:152 src/olympia/devhub/templates/devhub/addons/edit/details.html:85 src/olympia/devhub/templates/devhub/addons/edit/support.html:67
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:166 src/olympia/devhub/templates/devhub/addons/forms_shared/media.html:149
-#: src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:44 src/olympia/devhub/templates/devhub/versions/add_file_modal.html:78 src/olympia/devhub/templates/devhub/versions/edit.html:139
-#: src/olympia/devhub/templates/devhub/versions/list.html:242 src/olympia/devhub/templates/devhub/versions/list.html:276 src/olympia/devhub/templates/devhub/versions/list.html:317
-#: src/olympia/devhub/templates/devhub/versions/list.html:351 src/olympia/reviews/templates/reviews/edit_review.html:16 src/olympia/translations/templates/translations/trans-menu.html:50
+#: src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:43 src/olympia/devhub/templates/devhub/versions/add_file_modal.html:58 src/olympia/devhub/templates/devhub/versions/edit.html:139
+#: src/olympia/devhub/templates/devhub/versions/list.html:239 src/olympia/devhub/templates/devhub/versions/list.html:281 src/olympia/devhub/templates/devhub/versions/list.html:315
+#: src/olympia/devhub/templates/devhub/versions/list.html:349 src/olympia/reviews/templates/reviews/edit_review.html:16 src/olympia/translations/templates/translations/trans-menu.html:50
 #: src/olympia/translations/templates/translations/trans-menu.html:62
 msgid "or"
 msgstr ""
@@ -363,7 +364,7 @@ msgid "Add-on Information for {0}"
 msgstr ""
 
 #: src/olympia/addons/templates/addons/details_box.html:30 src/olympia/addons/templates/addons/persona_detail_table.html:3 src/olympia/addons/templates/addons/mobile/details.html:63
-#: src/olympia/addons/templates/addons/mobile/persona_detail_table.html:7 src/olympia/browse/views.py:459 src/olympia/devhub/views.py:75
+#: src/olympia/addons/templates/addons/mobile/persona_detail_table.html:7 src/olympia/browse/views.py:426 src/olympia/devhub/views.py:73
 msgid "Updated"
 msgstr ""
 
@@ -382,11 +383,11 @@ msgstr ""
 msgid "Visibility"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/details_box.html:57 src/olympia/devhub/templates/devhub/index.html:94 src/olympia/devhub/templates/devhub/includes/addon_details.html:104
+#: src/olympia/addons/templates/addons/details_box.html:57 src/olympia/devhub/templates/devhub/index.html:94 src/olympia/devhub/templates/devhub/includes/addon_details.html:91
 msgid "Hidden"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/details_box.html:59 src/olympia/devhub/templates/devhub/index.html:96 src/olympia/devhub/templates/devhub/includes/addon_details.html:106
+#: src/olympia/addons/templates/addons/details_box.html:59 src/olympia/devhub/templates/devhub/index.html:96 src/olympia/devhub/templates/devhub/includes/addon_details.html:93
 msgid "Unlisted"
 msgstr ""
 
@@ -394,13 +395,13 @@ msgstr ""
 msgid "Required Add-ons"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/details_box.html:81 src/olympia/addons/templates/addons/persona_detail_table.html:15 src/olympia/browse/views.py:462 src/olympia/devhub/views.py:78
-#: src/olympia/devhub/views.py:85 src/olympia/discovery/templates/discovery/addons/detail.html:57 src/olympia/reviews/forms.py:62 src/olympia/reviews/templates/reviews/add.html:57
+#: src/olympia/addons/templates/addons/details_box.html:81 src/olympia/addons/templates/addons/persona_detail_table.html:15 src/olympia/browse/views.py:429 src/olympia/devhub/views.py:76
+#: src/olympia/devhub/views.py:83 src/olympia/discovery/templates/discovery/addons/detail.html:57 src/olympia/reviews/forms.py:62 src/olympia/reviews/templates/reviews/add.html:57
 #: src/olympia/reviews/templates/reviews/mobile/review_list.html:18
 msgid "Rating"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/details_box.html:85 src/olympia/browse/views.py:461 src/olympia/devhub/views.py:77 src/olympia/devhub/views.py:84
+#: src/olympia/addons/templates/addons/details_box.html:85 src/olympia/browse/views.py:428 src/olympia/devhub/views.py:75 src/olympia/devhub/views.py:82
 #: src/olympia/stats/templates/stats/addon_report_menu.html:8 src/olympia/stats/templates/stats/collection_report_menu.html:18
 msgid "Downloads"
 msgstr ""
@@ -420,7 +421,7 @@ msgstr ""
 
 #. The Privacy Policy for this add-on.
 #: src/olympia/addons/templates/addons/details_box.html:121 src/olympia/addons/templates/addons/privacy.html:19 src/olympia/addons/templates/addons/privacy.html:23
-#: src/olympia/addons/templates/addons/impala/button.html:43 src/olympia/addons/templates/addons/impala/details.html:307 src/olympia/devhub/templates/devhub/includes/policy_form.html:20
+#: src/olympia/addons/templates/addons/impala/button.html:43 src/olympia/addons/templates/addons/impala/details.html:312 src/olympia/devhub/templates/devhub/includes/policy_form.html:23
 #: src/olympia/templates/mobile/base_addons.html:87
 msgid "Privacy Policy"
 msgstr ""
@@ -445,7 +446,7 @@ msgstr ""
 msgid "Developer Comments"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/details_box.html:199 src/olympia/addons/templates/addons/impala/details.html:259
+#: src/olympia/addons/templates/addons/details_box.html:199 src/olympia/addons/templates/addons/impala/details.html:264
 msgid "Development Channel"
 msgstr ""
 
@@ -465,7 +466,7 @@ msgid ""
 "developer. To stop receiving development updates, reinstall the default version from the link above."
 msgstr ""
 
-#: src/olympia/addons/templates/addons/details_box.html:220 src/olympia/addons/templates/addons/impala/details.html:278
+#: src/olympia/addons/templates/addons/details_box.html:220 src/olympia/addons/templates/addons/impala/details.html:283
 msgid "Version {0}:"
 msgstr ""
 
@@ -484,7 +485,7 @@ msgid "End-User License Agreement for {0}"
 msgstr ""
 
 #: src/olympia/addons/templates/addons/eula.html:17 src/olympia/addons/templates/addons/eula.html:21 src/olympia/addons/templates/addons/impala/button.html:48
-#: src/olympia/addons/templates/addons/impala/details.html:316 src/olympia/devhub/templates/devhub/includes/policy_form.html:3 src/olympia/discovery/templates/discovery/addons/eula.html:11
+#: src/olympia/addons/templates/addons/impala/details.html:321 src/olympia/devhub/templates/devhub/includes/policy_form.html:3 src/olympia/discovery/templates/discovery/addons/eula.html:11
 msgid "End-User License Agreement"
 msgstr ""
 
@@ -501,7 +502,7 @@ msgstr ""
 msgid "Add-ons for {0}"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/home.html:10 src/olympia/addons/templates/addons/home.html:51 src/olympia/browse/templates/browse/impala/base_listing.html:11
+#: src/olympia/addons/templates/addons/home.html:10 src/olympia/addons/templates/addons/home.html:53 src/olympia/browse/templates/browse/impala/base_listing.html:11
 msgid "Featured Extensions"
 msgstr ""
 
@@ -509,29 +510,29 @@ msgstr ""
 msgid "Popular Extensions"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/home.html:42 src/olympia/amo/templates/amo/side_nav.html:3 src/olympia/amo/templates/amo/side_nav.html:11 src/olympia/amo/templates/amo/site_nav.html:3
-#: src/olympia/amo/templates/amo/site_nav.html:25 src/olympia/browse/views.py:236 src/olympia/browse/views.py:281 src/olympia/browse/views.py:481
+#: src/olympia/addons/templates/addons/home.html:44 src/olympia/amo/templates/amo/side_nav.html:3 src/olympia/amo/templates/amo/side_nav.html:11 src/olympia/amo/templates/amo/site_nav.html:3
+#: src/olympia/amo/templates/amo/site_nav.html:25 src/olympia/browse/views.py:203 src/olympia/browse/views.py:248 src/olympia/browse/views.py:448
 msgid "Most Popular"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/home.html:43
+#: src/olympia/addons/templates/addons/home.html:45
 msgid "All »"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/home.html:52 src/olympia/addons/templates/addons/home.html:61 src/olympia/addons/templates/addons/home.html:70 src/olympia/addons/templates/addons/home.html:78
+#: src/olympia/addons/templates/addons/home.html:54 src/olympia/addons/templates/addons/home.html:63 src/olympia/addons/templates/addons/home.html:72 src/olympia/addons/templates/addons/home.html:80
 #: src/olympia/browse/templates/browse/impala/category_landing.html:36
 msgid "See all »"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/home.html:60
+#: src/olympia/addons/templates/addons/home.html:62
 msgid "Up &amp; Coming Extensions"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/home.html:69 src/olympia/browse/templates/browse/personas/category_landing.html:61 src/olympia/discovery/templates/discovery/pane.html:74
+#: src/olympia/addons/templates/addons/home.html:71 src/olympia/browse/templates/browse/personas/category_landing.html:61 src/olympia/discovery/templates/discovery/pane.html:74
 msgid "Featured Themes"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/home.html:77 src/olympia/bandwagon/templates/bandwagon/impala/collection_listing.html:5
+#: src/olympia/addons/templates/addons/home.html:79 src/olympia/bandwagon/templates/bandwagon/impala/collection_listing.html:5
 msgid "Featured Collections"
 msgstr ""
 
@@ -549,7 +550,7 @@ msgid "Updated {0}"
 msgstr ""
 
 #. {0} is a date.
-#: src/olympia/addons/templates/addons/macros.html:10 src/olympia/addons/templates/addons/macros.html:69 src/olympia/addons/templates/addons/persona_preview.html:21
+#: src/olympia/addons/templates/addons/macros.html:10 src/olympia/addons/templates/addons/macros.html:69 src/olympia/addons/templates/addons/persona_preview.html:22
 #: src/olympia/addons/templates/addons/listing/items_mobile.html:44 src/olympia/addons/templates/addons/listing/macros.html:39
 #: src/olympia/bandwagon/templates/bandwagon/collection_listing_items.html:37 src/olympia/bandwagon/templates/bandwagon/impala/collection_listing_items.html:37
 msgid "Added {0}"
@@ -570,15 +571,14 @@ msgstr[0] ""
 msgstr[1] ""
 
 #. {0} is the number of downloads.
-#: src/olympia/addons/templates/addons/macros.html:53 src/olympia/addons/templates/addons/impala/details.html:61
+#: src/olympia/addons/templates/addons/macros.html:53 src/olympia/addons/templates/addons/impala/details.html:59
 msgid "{0} weekly download"
 msgid_plural "{0} weekly downloads"
 msgstr[0] ""
 msgstr[1] ""
 
 #. {0} is the number of users.
-#: src/olympia/addons/templates/addons/macros.html:61 src/olympia/addons/templates/addons/impala/details.html:54 src/olympia/compat/templates/compat/index.html:71
-#: src/olympia/zadmin/templates/zadmin/compat.html:67
+#: src/olympia/addons/templates/addons/macros.html:61 src/olympia/addons/templates/addons/impala/details.html:52 src/olympia/zadmin/templates/zadmin/compat.html:67
 msgid "{0} user"
 msgid_plural "{0} users"
 msgstr[0] ""
@@ -596,7 +596,7 @@ msgstr ""
 msgid "Return to the addon."
 msgstr ""
 
-#: src/olympia/addons/templates/addons/persona_detail.html:17 src/olympia/addons/templates/addons/impala/details.html:106 src/olympia/addons/templates/addons/mobile/details.html:23
+#: src/olympia/addons/templates/addons/persona_detail.html:17 src/olympia/addons/templates/addons/impala/details.html:103 src/olympia/addons/templates/addons/mobile/details.html:23
 #: src/olympia/addons/templates/addons/mobile/persona_detail.html:21 src/olympia/discovery/templates/discovery/addons/base.html:27 src/olympia/editors/templates/editors/review.html:31
 msgid "by"
 msgstr ""
@@ -640,34 +640,35 @@ msgstr ""
 msgid "License"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/persona_preview.html:12 src/olympia/constants/base.py:48
+#: src/olympia/addons/templates/addons/persona_preview.html:13 src/olympia/constants/base.py:48
 msgid "Awaiting Review"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/persona_preview.html:14 src/olympia/amo/log.py:180 src/olympia/constants/base.py:42 src/olympia/editors/helpers.py:62
+#: src/olympia/addons/templates/addons/persona_preview.html:15 src/olympia/amo/log.py:180 src/olympia/constants/base.py:42 src/olympia/editors/helpers.py:62
 msgid "Rejected"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/persona_preview.html:16 src/olympia/amo/log.py:159
+#: src/olympia/addons/templates/addons/persona_preview.html:17 src/olympia/amo/log.py:159
 msgid "Approved"
 msgstr ""
 
 #. {0} is the number of users.
-#: src/olympia/addons/templates/addons/persona_preview.html:26 src/olympia/addons/templates/addons/listing/items_mobile.html:36 src/olympia/addons/templates/addons/listing/macros.html:31
+#: src/olympia/addons/templates/addons/persona_preview.html:27 src/olympia/addons/templates/addons/listing/items_mobile.html:36 src/olympia/addons/templates/addons/listing/macros.html:31
 msgid "<strong>{0}</strong> user"
 msgid_plural "<strong>{0}</strong> users"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/olympia/addons/templates/addons/persona_preview.html:40
+#: src/olympia/addons/templates/addons/persona_preview.html:41
 msgid "Hover to Preview"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/persona_preview.html:46 src/olympia/addons/templates/addons/persona_preview.html:48 src/olympia/reviews/templates/reviews/add.html:15
+#: src/olympia/addons/templates/addons/persona_preview.html:47 src/olympia/addons/templates/addons/persona_preview.html:49 src/olympia/addons/templates/addons/persona_preview.html:97
+#: src/olympia/reviews/templates/reviews/add.html:15
 msgid "Add"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/persona_preview.html:57 src/olympia/bandwagon/templates/bandwagon/ajax_new.html:16 src/olympia/bandwagon/templates/bandwagon/edit.html:19
+#: src/olympia/addons/templates/addons/persona_preview.html:58 src/olympia/bandwagon/templates/bandwagon/ajax_new.html:16 src/olympia/bandwagon/templates/bandwagon/edit.html:19
 #: src/olympia/bandwagon/templates/bandwagon/includes/addedit.html:19 src/olympia/devhub/templates/devhub/addons/edit/admin.html:13 src/olympia/devhub/templates/devhub/addons/edit/basic.html:10
 #: src/olympia/devhub/templates/devhub/addons/edit/details.html:8 src/olympia/devhub/templates/devhub/addons/edit/media.html:6 src/olympia/devhub/templates/devhub/addons/edit/support.html:8
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:9 src/olympia/devhub/templates/devhub/addons/submit/describe.html:29 src/olympia/editors/templates/editors/review.html:257
@@ -676,21 +677,21 @@ msgstr ""
 
 #. For datetime formatting, see the table on
 #. http://docs.python.org/library/datetime.html#strftime-and-strptime-behavior
-#: src/olympia/addons/templates/addons/persona_preview.html:66
+#: src/olympia/addons/templates/addons/persona_preview.html:67
 #, python-format
 msgid "%%Y-%%m-%%d"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/persona_preview.html:67
+#: src/olympia/addons/templates/addons/persona_preview.html:68
 msgid "by {0} on {1}"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/persona_preview.html:75 src/olympia/reviews/helpers.py:17 src/olympia/reviews/templates/reviews/review_list.html:63
+#: src/olympia/addons/templates/addons/persona_preview.html:76 src/olympia/reviews/helpers.py:17 src/olympia/reviews/templates/reviews/review_list.html:63
 #: src/olympia/reviews/templates/reviews/reviews_link.html:21 src/olympia/reviews/templates/reviews/impala/reviews_link.html:16
 msgid "Not yet rated"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/persona_preview.html:78
+#: src/olympia/addons/templates/addons/persona_preview.html:79
 msgid "<b>{0}</b> users"
 msgstr ""
 
@@ -703,7 +704,7 @@ msgid "Learn more about Firefox"
 msgstr ""
 
 #: src/olympia/addons/templates/addons/popups.html:22
-msgid "or <b><a class=\"installer\" href=\"{url}\">download anyway</a></b>"
+msgid "or <b><a class=\"button installer\" href=\"{url}\">download anyway</a></b>"
 msgstr ""
 
 #: src/olympia/addons/templates/addons/popups.html:26
@@ -802,7 +803,7 @@ msgid ""
 msgstr ""
 
 #: src/olympia/addons/templates/addons/report_abuse.html:6 src/olympia/addons/templates/addons/report_abuse_full.html:10 src/olympia/addons/templates/addons/impala/details-more.html:23
-#: src/olympia/addons/templates/addons/impala/details.html:328
+#: src/olympia/addons/templates/addons/impala/details.html:333
 msgid "Report Abuse"
 msgstr ""
 
@@ -821,9 +822,9 @@ msgstr ""
 #: src/olympia/devhub/templates/devhub/addons/ajax_compat_update.html:36 src/olympia/devhub/templates/devhub/addons/profile.html:44 src/olympia/devhub/templates/devhub/addons/edit/admin.html:104
 #: src/olympia/devhub/templates/devhub/addons/edit/basic.html:155 src/olympia/devhub/templates/devhub/addons/edit/details.html:88 src/olympia/devhub/templates/devhub/addons/edit/support.html:70
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:169 src/olympia/devhub/templates/devhub/addons/forms_shared/media.html:152
-#: src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:44 src/olympia/devhub/templates/devhub/personas/edit.html:222 src/olympia/devhub/templates/devhub/versions/add_file_modal.html:79
-#: src/olympia/devhub/templates/devhub/versions/edit.html:140 src/olympia/devhub/templates/devhub/versions/list.html:208 src/olympia/devhub/templates/devhub/versions/list.html:242
-#: src/olympia/devhub/templates/devhub/versions/list.html:276 src/olympia/devhub/templates/devhub/versions/list.html:317 src/olympia/reviews/templates/reviews/edit_review.html:16
+#: src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:43 src/olympia/devhub/templates/devhub/personas/edit.html:222 src/olympia/devhub/templates/devhub/versions/add_file_modal.html:59
+#: src/olympia/devhub/templates/devhub/versions/edit.html:140 src/olympia/devhub/templates/devhub/versions/list.html:208 src/olympia/devhub/templates/devhub/versions/list.html:239
+#: src/olympia/devhub/templates/devhub/versions/list.html:281 src/olympia/devhub/templates/devhub/versions/list.html:315 src/olympia/reviews/templates/reviews/edit_review.html:16
 #: src/olympia/translations/templates/translations/trans-menu.html:50 src/olympia/translations/templates/translations/trans-menu.html:62 src/olympia/zadmin/templates/zadmin/validation.html:105
 msgid "Cancel"
 msgstr ""
@@ -868,7 +869,7 @@ msgstr ""
 msgid "Review Guidelines"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/review_list_box.html:5 src/olympia/addons/templates/addons/impala/details-more.html:27 src/olympia/editors/helpers.py:921
+#: src/olympia/addons/templates/addons/review_list_box.html:5 src/olympia/addons/templates/addons/impala/details-more.html:27 src/olympia/editors/helpers.py:1001
 #: src/olympia/reviews/templates/reviews/add.html:14 src/olympia/reviews/templates/reviews/reply.html:14 src/olympia/reviews/templates/reviews/review_list.html:19
 #: src/olympia/reviews/templates/reviews/mobile/review_list.html:26
 msgid "Reviews"
@@ -959,119 +960,119 @@ msgid_plural "Other add-ons by these authors"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/olympia/addons/templates/addons/impala/details.html:41
+#: src/olympia/addons/templates/addons/impala/details.html:39
 #, python-format
 msgid "<span itemprop=\"ratingCount\">%(num)s</span> user review"
 msgid_plural "<span itemprop=\"ratingCount\">%(num)s</span> user reviews"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/olympia/addons/templates/addons/impala/details.html:69
+#: src/olympia/addons/templates/addons/impala/details.html:66
 msgid "View statistics"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/impala/details.html:84
+#: src/olympia/addons/templates/addons/impala/details.html:81
 msgid "Manage"
 msgstr ""
 
 #. {0} is an add-on name.
-#: src/olympia/addons/templates/addons/impala/details.html:96
+#: src/olympia/addons/templates/addons/impala/details.html:93
 msgid "Icon of {0}"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/impala/details.html:103 src/olympia/addons/templates/addons/impala/listing/items.html:14
+#: src/olympia/addons/templates/addons/impala/details.html:100 src/olympia/addons/templates/addons/impala/listing/items.html:14
 msgid "No Restart"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/impala/details.html:127
+#: src/olympia/addons/templates/addons/impala/details.html:124
 #, python-format
 msgid "Meet the Developer: <a href=\"%(url)s\">%(name)s</a>"
 msgid_plural "<a href=\"%(url)s\">Meet the Developers</a>"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/olympia/addons/templates/addons/impala/details.html:137
+#: src/olympia/addons/templates/addons/impala/details.html:134
 msgid "Learn why {0} was created and find out what's next for this add-on."
 msgstr ""
 
 #. {0} is an index.
-#: src/olympia/addons/templates/addons/impala/details.html:156
+#: src/olympia/addons/templates/addons/impala/details.html:161
 msgid "Add-on screenshot #{0}"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/impala/details.html:182
+#: src/olympia/addons/templates/addons/impala/details.html:187
 msgid "Add-on home page"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/impala/details.html:185
+#: src/olympia/addons/templates/addons/impala/details.html:190
 msgid "Support site"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/impala/details.html:189
+#: src/olympia/addons/templates/addons/impala/details.html:194
 msgid "Support E-mail"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/impala/details.html:194 src/olympia/devhub/models.py:378 src/olympia/devhub/templates/devhub/versions/list.html:12
+#: src/olympia/addons/templates/addons/impala/details.html:199 src/olympia/devhub/models.py:378 src/olympia/devhub/templates/devhub/versions/list.html:12
 #: src/olympia/versions/templates/versions/version.html:6 src/olympia/versions/templates/versions/mobile/version.html:6
 msgid "Version {0}"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/impala/details.html:194
+#: src/olympia/addons/templates/addons/impala/details.html:199
 msgid "Info"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/impala/details.html:195 src/olympia/devhub/templates/devhub/includes/addon_details.html:129
+#: src/olympia/addons/templates/addons/impala/details.html:200 src/olympia/devhub/templates/devhub/includes/addon_details.html:116
 msgid "Last Updated:"
-msgstr ""
-
-#: src/olympia/addons/templates/addons/impala/details.html:200
-#, python-format
-msgid "Released under <a target=\"_blank\" href=\"%(url)s\">%(name)s</a>"
-msgstr ""
-
-#: src/olympia/addons/templates/addons/impala/details.html:201 src/olympia/addons/templates/addons/impala/details.html:206 src/olympia/amo/helpers.py:398 src/olympia/devhub/forms.py:142
-#: src/olympia/devhub/forms.py:173 src/olympia/versions/templates/versions/version.html:40 src/olympia/versions/templates/versions/version.html:45
-msgid "Custom License"
 msgstr ""
 
 #: src/olympia/addons/templates/addons/impala/details.html:205
 #, python-format
+msgid "Released under <a target=\"_blank\" href=\"%(url)s\">%(name)s</a>"
+msgstr ""
+
+#: src/olympia/addons/templates/addons/impala/details.html:206 src/olympia/addons/templates/addons/impala/details.html:211 src/olympia/amo/helpers.py:398 src/olympia/devhub/forms.py:142
+#: src/olympia/devhub/forms.py:173 src/olympia/versions/templates/versions/version.html:40 src/olympia/versions/templates/versions/version.html:45
+msgid "Custom License"
+msgstr ""
+
+#: src/olympia/addons/templates/addons/impala/details.html:210
+#, python-format
 msgid "Released under <a href=\"%(url)s\">%(name)s</a>"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/impala/details.html:217
+#: src/olympia/addons/templates/addons/impala/details.html:222
 msgid "About this Add-on"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/impala/details.html:233
+#: src/olympia/addons/templates/addons/impala/details.html:238
 msgid "Developer’s Comments"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/impala/details.html:243
+#: src/olympia/addons/templates/addons/impala/details.html:248
 msgid "Version Information"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/impala/details.html:250
+#: src/olympia/addons/templates/addons/impala/details.html:255
 msgid "See complete version history"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/impala/details.html:262
+#: src/olympia/addons/templates/addons/impala/details.html:267
 msgid ""
 "The Development Channel lets you test an experimental new version of this add-on before it's released to the general public. Once you install the development version, you will continue to get "
 "updates from this channel. To stop receiving development updates, reinstall the default version from the link above."
 msgstr ""
 
-#: src/olympia/addons/templates/addons/impala/details.html:272
+#: src/olympia/addons/templates/addons/impala/details.html:277
 msgid "<strong>Caution:</strong> Development versions of this add-on have not been reviewed by Mozilla."
 msgstr ""
 
-#: src/olympia/addons/templates/addons/impala/details.html:287
+#: src/olympia/addons/templates/addons/impala/details.html:292
 msgid "See complete development channel history"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/impala/details.html:306 src/olympia/addons/templates/addons/impala/details.html:315 src/olympia/addons/templates/addons/impala/details.html:327
+#: src/olympia/addons/templates/addons/impala/details.html:311 src/olympia/addons/templates/addons/impala/details.html:320 src/olympia/addons/templates/addons/impala/details.html:332
 #: src/olympia/addons/templates/addons/impala/review_add_box.html:4 src/olympia/stats/templates/stats/popup.html:2 src/olympia/stats/templates/stats/popup.html:8
-#: src/olympia/stats/templates/stats/stats.html:202 src/olympia/users/templates/users/profile.html:119
+#: src/olympia/stats/templates/stats/stats.html:204 src/olympia/users/templates/users/profile.html:119
 msgid "close"
 msgstr ""
 
@@ -1127,15 +1128,11 @@ msgstr ""
 msgid "Source Code License"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/impala/persona_grid.html:16 src/olympia/addons/templates/addons/impala/toplist.html:6
-msgid "{0} users"
-msgstr ""
-
 #: src/olympia/addons/templates/addons/impala/review_list_box.html:19 src/olympia/reviews/templates/reviews/review.html:40
 msgid "permalink"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/impala/review_list_box.html:23 src/olympia/editors/templates/editors/queue.html:98 src/olympia/reviews/templates/reviews/review.html:44
+#: src/olympia/addons/templates/addons/impala/review_list_box.html:23 src/olympia/editors/templates/editors/queue.html:104 src/olympia/reviews/templates/reviews/review.html:44
 msgid "translate"
 msgstr ""
 
@@ -1154,6 +1151,10 @@ msgstr ""
 msgid "Be the first!"
 msgstr ""
 
+#: src/olympia/addons/templates/addons/impala/toplist.html:6
+msgid "{0} users"
+msgstr ""
+
 #: src/olympia/addons/templates/addons/impala/listing/sorter.html:14 src/olympia/devhub/templates/devhub/addons/listing/item_actions.html:49
 msgid "More"
 msgstr ""
@@ -1166,7 +1167,7 @@ msgstr ""
 msgid "My Add-ons"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/includes/dashboard_tabs.html:6 src/olympia/amo/context_processors.py:51
+#: src/olympia/addons/templates/addons/includes/dashboard_tabs.html:6 src/olympia/amo/context_processors.py:50
 msgid "My Themes"
 msgstr ""
 
@@ -1221,7 +1222,7 @@ msgstr ""
 msgid "Weekly Downloads"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/mobile/details.html:99 src/olympia/compat/templates/compat/reporter_detail.html:46 src/olympia/devhub/forms.py:787
+#: src/olympia/addons/templates/addons/mobile/details.html:99 src/olympia/compat/templates/compat/reporter_detail.html:46 src/olympia/devhub/forms.py:788
 #: src/olympia/devhub/templates/devhub/versions/list.html:163
 msgid "Version"
 msgstr ""
@@ -1305,7 +1306,7 @@ msgstr ""
 #: src/olympia/browse/templates/browse/personas/category_landing.html:21 src/olympia/browse/templates/browse/personas/category_landing.html:23
 #: src/olympia/browse/templates/browse/personas/category_landing.html:38 src/olympia/browse/templates/browse/personas/grid.html:7 src/olympia/browse/templates/browse/personas/grid.html:11
 #: src/olympia/browse/templates/browse/personas/mobile/base.html:7 src/olympia/browse/templates/browse/personas/mobile/category_landing.html:19 src/olympia/constants/base.py:180
-#: src/olympia/devhub/templates/devhub/personas/submit.html:13 src/olympia/editors/helpers.py:105 src/olympia/editors/templates/editors/base.html:26
+#: src/olympia/devhub/templates/devhub/personas/submit.html:13 src/olympia/editors/helpers.py:107 src/olympia/editors/templates/editors/base.html:26
 #: src/olympia/editors/templates/editors/performance.html:73 src/olympia/search/templates/search/personas.html:39 src/olympia/templates/menu_links.html:9
 msgid "Themes"
 msgstr ""
@@ -1326,7 +1327,7 @@ msgstr ""
 msgid "Highest Rated"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/mobile/home.html:74 src/olympia/amo/templates/amo/side_nav.html:5 src/olympia/amo/templates/amo/site_nav.html:27 src/olympia/amo/templates/amo/site_nav.html:57
+#: src/olympia/addons/templates/addons/mobile/home.html:74 src/olympia/amo/templates/amo/side_nav.html:5 src/olympia/amo/templates/amo/site_nav.html:27 src/olympia/amo/templates/amo/site_nav.html:55
 #: src/olympia/bandwagon/views.py:97 src/olympia/browse/views.py:57 src/olympia/browse/views.py:67 src/olympia/browse/templates/browse/personas/mobile/category_landing.html:65
 #: src/olympia/search/forms.py:15 src/olympia/search/forms.py:87
 msgid "Newest"
@@ -1340,90 +1341,90 @@ msgstr ""
 msgid "Theme Info &raquo;"
 msgstr ""
 
-#: src/olympia/amo/context_processors.py:39 src/olympia/devhub/templates/devhub/nav.html:43
+#: src/olympia/amo/context_processors.py:37 src/olympia/devhub/templates/devhub/nav.html:43
 msgid "Tools"
 msgstr ""
 
-#: src/olympia/amo/context_processors.py:48 src/olympia/discovery/templates/discovery/pane_account.html:8 src/olympia/users/templates/users/includes/navigation.html:2
+#: src/olympia/amo/context_processors.py:47 src/olympia/discovery/templates/discovery/pane_account.html:8 src/olympia/users/templates/users/includes/navigation.html:2
 msgid "My Profile"
 msgstr ""
 
-#: src/olympia/amo/context_processors.py:54 src/olympia/users/templates/users/edit.html:5 src/olympia/users/templates/users/includes/navigation.html:3
+#: src/olympia/amo/context_processors.py:53 src/olympia/users/templates/users/edit.html:5 src/olympia/users/templates/users/includes/navigation.html:3
 msgid "Account Settings"
 msgstr ""
 
-#: src/olympia/amo/context_processors.py:57 src/olympia/discovery/templates/discovery/pane_account.html:11 src/olympia/users/templates/users/profile.html:83
+#: src/olympia/amo/context_processors.py:56 src/olympia/discovery/templates/discovery/pane_account.html:11 src/olympia/users/templates/users/profile.html:83
 #: src/olympia/users/templates/users/includes/navigation.html:4
 msgid "My Collections"
 msgstr ""
 
-#: src/olympia/amo/context_processors.py:62 src/olympia/discovery/templates/discovery/pane_account.html:10 src/olympia/users/templates/users/includes/navigation.html:7
+#: src/olympia/amo/context_processors.py:61 src/olympia/discovery/templates/discovery/pane_account.html:10 src/olympia/users/templates/users/includes/navigation.html:7
 msgid "My Favorites"
 msgstr ""
 
-#: src/olympia/amo/context_processors.py:67 src/olympia/discovery/templates/discovery/pane_account.html:13 src/olympia/templates/impala/user_login.html:14
+#: src/olympia/amo/context_processors.py:66 src/olympia/discovery/templates/discovery/pane_account.html:13 src/olympia/templates/impala/user_login.html:14
 #: src/olympia/templates/mobile/header_auth.html:5
 msgid "Log out"
 msgstr ""
 
-#: src/olympia/amo/context_processors.py:72 src/olympia/devhub/templates/devhub/addons/dashboard.html:4
+#: src/olympia/amo/context_processors.py:71 src/olympia/devhub/templates/devhub/addons/dashboard.html:4
 msgid "Manage My Submissions"
 msgstr ""
 
-#: src/olympia/amo/context_processors.py:75 src/olympia/devhub/templates/devhub/nav.html:27 src/olympia/devhub/templates/devhub/addons/dashboard.html:25
+#: src/olympia/amo/context_processors.py:74 src/olympia/devhub/templates/devhub/nav.html:27 src/olympia/devhub/templates/devhub/addons/dashboard.html:25
 #: src/olympia/devhub/templates/devhub/addons/submit/base.html:4
 msgid "Submit a New Add-on"
 msgstr ""
 
-#: src/olympia/amo/context_processors.py:77 src/olympia/browse/templates/browse/personas/base.html:50 src/olympia/devhub/templates/devhub/index.html:24
+#: src/olympia/amo/context_processors.py:76 src/olympia/browse/templates/browse/personas/base.html:50 src/olympia/devhub/templates/devhub/index.html:24
 #: src/olympia/devhub/templates/devhub/addons/dashboard.html:29
 msgid "Submit a New Theme"
 msgstr ""
 
-#: src/olympia/amo/context_processors.py:79 src/olympia/amo/templates/amo/site_nav.html:87 src/olympia/devhub/helpers.py:36 src/olympia/devhub/helpers.py:68 src/olympia/devhub/helpers.py:102
+#: src/olympia/amo/context_processors.py:78 src/olympia/amo/templates/amo/site_nav.html:85 src/olympia/devhub/helpers.py:36 src/olympia/devhub/helpers.py:68 src/olympia/devhub/helpers.py:102
 #: src/olympia/templates/footer.html:6 src/olympia/templates/menu_links.html:14
 msgid "Developer Hub"
 msgstr ""
 
-#: src/olympia/amo/context_processors.py:83 src/olympia/devhub/views.py:1792
+#: src/olympia/amo/context_processors.py:81 src/olympia/devhub/views.py:1796
 msgid "Manage API Keys"
 msgstr ""
 
-#: src/olympia/amo/context_processors.py:88 src/olympia/editors/helpers.py:82 src/olympia/editors/helpers.py:102 src/olympia/editors/templates/editors/base.html:10
+#: src/olympia/amo/context_processors.py:86 src/olympia/editors/helpers.py:84 src/olympia/editors/helpers.py:104 src/olympia/editors/templates/editors/base.html:10
 msgid "Editor Tools"
 msgstr ""
 
-#: src/olympia/amo/context_processors.py:92
+#: src/olympia/amo/context_processors.py:90
 msgid "Admin Tools"
 msgstr ""
 
-#: src/olympia/amo/fields.py:15
+#: src/olympia/amo/fields.py:20
 msgid "Incorrect, please try again."
 msgstr ""
 
-#: src/olympia/amo/fields.py:16
+#: src/olympia/amo/fields.py:21
 msgid "Error verifying input, please try again."
 msgstr ""
 
-#: src/olympia/amo/fields.py:32
+#: src/olympia/amo/fields.py:37
 msgid "This must be a valid hex color code, such as #000000."
 msgstr ""
 
-#: src/olympia/amo/fields.py:58
+#: src/olympia/amo/fields.py:63
 msgid "Enter at least one value."
 msgstr ""
 
-#: src/olympia/amo/helpers.py:162 src/olympia/amo/templates/amo/site_nav.html:61 src/olympia/bandwagon/templates/bandwagon/add.html:9
+#: src/olympia/amo/helpers.py:162 src/olympia/amo/templates/amo/site_nav.html:59 src/olympia/bandwagon/templates/bandwagon/add.html:9
 #: src/olympia/bandwagon/templates/bandwagon/collection_detail.html:15 src/olympia/bandwagon/templates/bandwagon/delete.html:9 src/olympia/bandwagon/templates/bandwagon/edit.html:15
 #: src/olympia/bandwagon/templates/bandwagon/user_listing.html:18 src/olympia/bandwagon/templates/bandwagon/user_listing.html:21
 #: src/olympia/bandwagon/templates/bandwagon/impala/collection_listing.html:12 src/olympia/bandwagon/templates/bandwagon/impala/collection_listing.html:20
 #: src/olympia/bandwagon/templates/bandwagon/impala/collection_listing.html:24 src/olympia/bandwagon/templates/bandwagon/impala/collection_sidebar.html:3
 #: src/olympia/bandwagon/templates/bandwagon/includes/collection_sidebar.html:2 src/olympia/bandwagon/templates/bandwagon/mobile/collection_listing.html:3
-#: src/olympia/stats/templates/stats/stats.html:77 src/olympia/templates/menu_links.html:12
+#: src/olympia/stats/templates/stats/stats.html:33 src/olympia/templates/menu_links.html:12
 msgid "Collections"
 msgstr ""
 
-#: src/olympia/amo/helpers.py:171 src/olympia/amo/templates/amo/site_nav.html:85 src/olympia/browse/templates/browse/language_tools.html:3
+#: src/olympia/amo/helpers.py:171 src/olympia/amo/templates/amo/site_nav.html:83 src/olympia/browse/templates/browse/language_tools.html:3
 msgid "Dictionaries & Language Packs"
 msgstr ""
 
@@ -1575,8 +1576,8 @@ msgstr ""
 msgid "Comment on {addon} {version}."
 msgstr ""
 
-#: src/olympia/amo/log.py:236 src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:19 src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:47
-#: src/olympia/editors/helpers.py:511 src/olympia/editors/templates/editors/themes/history_table.html:11
+#: src/olympia/amo/log.py:236 src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:17 src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:45
+#: src/olympia/editors/helpers.py:584 src/olympia/editors/templates/editors/themes/history_table.html:11
 msgid "Comment"
 msgstr ""
 
@@ -1899,7 +1900,7 @@ msgstr ""
 #: src/olympia/amo/templates/amo/mobile/paginator.html:14 src/olympia/amo/templates/amo/mobile/paginator.html:16 src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:51
 #: src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:65 src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:78
 #: src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:91 src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:104
-#: src/olympia/discovery/templates/discovery/pane.html:45 src/olympia/discovery/templates/discovery/addons/detail.html:39 src/olympia/stats/templates/stats/stats.html:167
+#: src/olympia/discovery/templates/discovery/pane.html:45 src/olympia/discovery/templates/discovery/addons/detail.html:39 src/olympia/stats/templates/stats/stats.html:169
 msgid "Next"
 msgstr ""
 
@@ -1931,7 +1932,7 @@ msgid ""
 msgstr ""
 
 #: src/olympia/amo/templates/amo/side_nav.html:4 src/olympia/amo/templates/amo/side_nav.html:12 src/olympia/amo/templates/amo/site_nav.html:4 src/olympia/amo/templates/amo/site_nav.html:26
-#: src/olympia/browse/views.py:56 src/olympia/browse/views.py:66 src/olympia/browse/views.py:237 src/olympia/browse/views.py:282 src/olympia/search/forms.py:86
+#: src/olympia/browse/views.py:56 src/olympia/browse/views.py:66 src/olympia/browse/views.py:204 src/olympia/browse/views.py:249 src/olympia/search/forms.py:86
 msgid "Top Rated"
 msgstr ""
 
@@ -1945,38 +1946,38 @@ msgstr ""
 msgid "Extensions"
 msgstr ""
 
-#: src/olympia/amo/templates/amo/site_nav.html:45
+#: src/olympia/amo/templates/amo/site_nav.html:44
 msgid "Want more customization? Try <b>Complete Themes</b>"
 msgstr ""
 
-#: src/olympia/amo/templates/amo/site_nav.html:56 src/olympia/bandwagon/views.py:96
+#: src/olympia/amo/templates/amo/site_nav.html:54 src/olympia/bandwagon/views.py:96
 msgid "Most Followers"
 msgstr ""
 
-#: src/olympia/amo/templates/amo/site_nav.html:68 src/olympia/bandwagon/templates/bandwagon/impala/collection_sidebar.html:16
+#: src/olympia/amo/templates/amo/site_nav.html:66 src/olympia/bandwagon/templates/bandwagon/impala/collection_sidebar.html:16
 #: src/olympia/bandwagon/templates/bandwagon/includes/collection_sidebar.html:18
 msgid "Collections I've Made"
 msgstr ""
 
-#: src/olympia/amo/templates/amo/site_nav.html:70 src/olympia/bandwagon/templates/bandwagon/user_listing.html:4 src/olympia/bandwagon/templates/bandwagon/impala/collection_sidebar.html:13
+#: src/olympia/amo/templates/amo/site_nav.html:68 src/olympia/bandwagon/templates/bandwagon/user_listing.html:4 src/olympia/bandwagon/templates/bandwagon/impala/collection_sidebar.html:13
 #: src/olympia/bandwagon/templates/bandwagon/includes/collection_sidebar.html:15
 msgid "Collections I'm Following"
 msgstr ""
 
-#: src/olympia/amo/templates/amo/site_nav.html:73 src/olympia/bandwagon/templates/bandwagon/impala/collection_sidebar.html:18
-#: src/olympia/bandwagon/templates/bandwagon/includes/collection_sidebar.html:20 src/olympia/users/models.py:512
+#: src/olympia/amo/templates/amo/site_nav.html:71 src/olympia/bandwagon/templates/bandwagon/impala/collection_sidebar.html:18
+#: src/olympia/bandwagon/templates/bandwagon/includes/collection_sidebar.html:20 src/olympia/users/models.py:521
 msgid "My Favorite Add-ons"
 msgstr ""
 
-#: src/olympia/amo/templates/amo/site_nav.html:78
+#: src/olympia/amo/templates/amo/site_nav.html:76
 msgid "More&hellip;"
 msgstr ""
 
-#: src/olympia/amo/templates/amo/site_nav.html:82
+#: src/olympia/amo/templates/amo/site_nav.html:80
 msgid "Add-ons for Mobile"
 msgstr ""
 
-#: src/olympia/amo/templates/amo/site_nav.html:86 src/olympia/browse/feeds.py:207 src/olympia/browse/templates/browse/search_tools.html:3 src/olympia/constants/base.py:176
+#: src/olympia/amo/templates/amo/site_nav.html:84 src/olympia/browse/feeds.py:207 src/olympia/browse/templates/browse/search_tools.html:3 src/olympia/constants/base.py:176
 #: src/olympia/templates/menu_links.html:10
 msgid "Search Tools"
 msgstr ""
@@ -1992,7 +1993,7 @@ msgid "Jump to first page"
 msgstr ""
 
 #: src/olympia/amo/templates/amo/impala/paginator.html:22 src/olympia/amo/templates/amo/mobile/impala_paginator.html:12 src/olympia/discovery/templates/discovery/pane.html:44
-#: src/olympia/discovery/templates/discovery/addons/detail.html:38 src/olympia/stats/templates/stats/stats.html:164
+#: src/olympia/discovery/templates/discovery/addons/detail.html:38 src/olympia/stats/templates/stats/stats.html:166
 msgid "Previous"
 msgstr ""
 
@@ -2015,30 +2016,49 @@ msgid_plural "Page {n}"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/olympia/amo/templates/services/install.html:38
-#, python-format
-msgid "If you are not prompted to install %(addon_name)s in a moment, please <a href=\"%(addon_xpi)s\">click here</a>."
-msgstr ""
-
-#: src/olympia/amo/tests/test_messages.py:57 src/olympia/amo/tests/test_messages.py:58 src/olympia/reviews/forms.py:25 src/olympia/reviews/forms.py:50 src/olympia/reviews/templates/reviews/add.html:56
+#: src/olympia/amo/tests/test_messages.py:56 src/olympia/amo/tests/test_messages.py:57 src/olympia/reviews/forms.py:25 src/olympia/reviews/forms.py:50 src/olympia/reviews/templates/reviews/add.html:56
 #: src/olympia/reviews/templates/reviews/reply.html:30
 msgid "Title"
 msgstr ""
 
-#: src/olympia/amo/tests/test_messages.py:57 src/olympia/amo/tests/test_messages.py:58
+#: src/olympia/amo/tests/test_messages.py:56 src/olympia/amo/tests/test_messages.py:57
 msgid "Body"
 msgstr ""
 
-#: src/olympia/amo/tests/test_messages.py:59
+#: src/olympia/amo/tests/test_messages.py:58
 msgid "Another Title"
 msgstr ""
 
-#: src/olympia/amo/tests/test_messages.py:59
+#: src/olympia/amo/tests/test_messages.py:58
 msgid "Another Body"
 msgstr ""
 
-#: src/olympia/api/views.py:255
-msgid "Not implemented yet."
+#: src/olympia/api/authentication.py:76
+msgid "Signature has expired."
+msgstr ""
+
+#: src/olympia/api/authentication.py:79
+msgid "Error decoding signature."
+msgstr ""
+
+#: src/olympia/api/authentication.py:82
+msgid "Invalid JWT Token."
+msgstr ""
+
+#: src/olympia/api/authentication.py:130
+msgid "Invalid Authorization header. No credentials provided."
+msgstr ""
+
+#: src/olympia/api/authentication.py:133
+msgid "Invalid Authorization header. Credentials string should not contain spaces."
+msgstr ""
+
+#: src/olympia/api/fields.py:29
+msgid "The field must have a length of at least {num} characters."
+msgstr ""
+
+#: src/olympia/api/fields.py:31
+msgid "The language code {lang_code} is invalid."
 msgstr ""
 
 #: src/olympia/applications/views.py:39 src/olympia/applications/templates/applications/appversions.html:3
@@ -2057,7 +2077,7 @@ msgstr ""
 msgid "Add-ons submitted to Mozilla Add-ons must have a manifest file with at least one of the below applications supported. Only the versions listed below are allowed for these applications."
 msgstr ""
 
-#: src/olympia/applications/templates/applications/appversions.html:25
+#: src/olympia/applications/templates/applications/appversions.html:25 src/olympia/editors/helpers.py:361
 msgid "GUID"
 msgstr ""
 
@@ -2171,8 +2191,8 @@ msgstr ""
 msgid "Remove from favorites"
 msgstr ""
 
-#: src/olympia/bandwagon/views.py:98 src/olympia/bandwagon/views.py:191 src/olympia/browse/views.py:58 src/olympia/browse/views.py:69 src/olympia/browse/views.py:458 src/olympia/devhub/views.py:74
-#: src/olympia/devhub/views.py:82 src/olympia/devhub/templates/devhub/addons/edit/basic.html:20 src/olympia/editors/templates/editors/leaderboard.html:24
+#: src/olympia/bandwagon/views.py:98 src/olympia/bandwagon/views.py:191 src/olympia/browse/views.py:58 src/olympia/browse/views.py:69 src/olympia/browse/views.py:425 src/olympia/devhub/views.py:72
+#: src/olympia/devhub/views.py:80 src/olympia/devhub/templates/devhub/addons/edit/basic.html:20 src/olympia/editors/templates/editors/leaderboard.html:24
 #: src/olympia/editors/templates/editors/themes/queue_list.html:48 src/olympia/search/forms.py:17 src/olympia/search/forms.py:89 src/olympia/users/templates/users/vcard.html:5
 msgid "Name"
 msgstr ""
@@ -2181,7 +2201,7 @@ msgstr ""
 msgid "Recently Popular"
 msgstr ""
 
-#: src/olympia/bandwagon/views.py:189 src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:18
+#: src/olympia/bandwagon/views.py:189 src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:16
 msgid "Added"
 msgstr ""
 
@@ -2195,7 +2215,7 @@ msgstr ""
 
 #: src/olympia/bandwagon/views.py:316
 #, python-format
-msgid "Your new collection is shown below. You can <ahref=\"%(url)s\">edit additional settings</a> if you'dlike."
+msgid "Your new collection is shown below. You can <a href=\"%(url)s\">edit additional settings</a> if you'd like."
 msgstr ""
 
 #: src/olympia/bandwagon/views.py:322
@@ -2323,8 +2343,8 @@ msgid_plural "%(num)s Add-ons in this Collection"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/olympia/bandwagon/templates/bandwagon/collection_detail.html:125 src/olympia/compat/templates/compat/index.html:25 src/olympia/compat/templates/compat/reporter_detail.html:29
-#: src/olympia/files/templates/files/viewer.html:29 src/olympia/templates/amo_footer.html:17 src/olympia/templates/includes/lang_switcher.html:10
+#: src/olympia/bandwagon/templates/bandwagon/collection_detail.html:125 src/olympia/compat/templates/compat/reporter_detail.html:29 src/olympia/files/templates/files/viewer.html:29
+#: src/olympia/templates/amo_footer.html:17 src/olympia/templates/includes/lang_switcher.html:10
 msgid "Go"
 msgstr ""
 
@@ -2491,7 +2511,7 @@ msgid "Remove this user as a contributor"
 msgstr ""
 
 #: src/olympia/bandwagon/templates/bandwagon/edit_contributors.html:18 src/olympia/bandwagon/templates/bandwagon/edit_contributors.html:43
-#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:20 src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:48
+#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:18 src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:46
 #: src/olympia/devhub/templates/devhub/addons/ajax_compat_update.html:19
 msgid "Remove"
 msgstr ""
@@ -2539,7 +2559,7 @@ msgid "<b>Warning:</b> By changing the owner of this collection, you will no lon
 msgstr ""
 
 #: src/olympia/bandwagon/templates/bandwagon/edit_contributors.html:83 src/olympia/devhub/templates/devhub/addons/forms_shared/media.html:157
-#: src/olympia/devhub/templates/devhub/addons/submit/describe.html:69 src/olympia/devhub/templates/devhub/addons/submit/license.html:60 src/olympia/devhub/templates/devhub/addons/submit/upload.html:78
+#: src/olympia/devhub/templates/devhub/addons/submit/describe.html:69 src/olympia/devhub/templates/devhub/addons/submit/license.html:60 src/olympia/devhub/templates/devhub/addons/submit/upload.html:70
 #: src/olympia/devhub/templates/devhub/payments/tier.html:17 src/olympia/editors/templates/editors/themes/themes.html:111 src/olympia/editors/templates/editors/themes/themes.html:128
 #: src/olympia/editors/templates/editors/themes/themes.html:134 src/olympia/editors/templates/editors/themes/themes.html:141 src/olympia/users/templates/users/fxa_migration_prompt_content.html:10
 #: src/olympia/users/templates/users/login_form.html:42 src/olympia/users/templates/users/mobile/login.html:57
@@ -2622,31 +2642,31 @@ msgid "Add-ons in Your Collection"
 msgstr ""
 
 #: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:4
-msgid ""
-"To include an add-on in this collection, enter its name in the box below and hit enter.  You can also use the <strong>Add to Collection</strong> links throughout the site to include add-ons later."
+msgid "To include an add-on in this collection, enter its name in the box below and hit enter."
 msgstr ""
 
-#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:17 src/olympia/constants/base.py:400 src/olympia/devhub/templates/devhub/addons/activity.html:62
+#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:15 src/olympia/constants/base.py:400 src/olympia/devhub/templates/devhub/addons/activity.html:62
+#: src/olympia/editors/helpers.py:273 src/olympia/editors/helpers.py:360
 msgid "Add-on"
 msgstr ""
 
-#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:26
+#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:24
 msgid "Enter the name of the add-on to include"
 msgstr ""
 
-#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:28
+#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:26
 msgid "Add to Collection"
 msgstr ""
 
-#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:45 src/olympia/editors/helpers.py:936 src/olympia/editors/helpers.py:956
+#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:43 src/olympia/editors/helpers.py:1016 src/olympia/editors/helpers.py:1036
 msgid "Pending"
 msgstr ""
 
-#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:47
+#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:45
 msgid "Add a comment"
 msgstr ""
 
-#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:48
+#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:46
 msgid "Remove this add-on from the collection"
 msgstr ""
 
@@ -2753,12 +2773,12 @@ msgstr ""
 msgid "Most Users"
 msgstr ""
 
-#: src/olympia/browse/views.py:61 src/olympia/browse/views.py:72 src/olympia/browse/views.py:279 src/olympia/browse/templates/browse/personas/mobile/category_landing.html:63
+#: src/olympia/browse/views.py:61 src/olympia/browse/views.py:72 src/olympia/browse/views.py:246 src/olympia/browse/templates/browse/personas/mobile/category_landing.html:63
 #: src/olympia/discovery/templates/discovery/pane.html:67 src/olympia/search/forms.py:92
 msgid "Up & Coming"
 msgstr ""
 
-#: src/olympia/browse/views.py:460 src/olympia/devhub/views.py:76 src/olympia/devhub/views.py:83 src/olympia/discovery/templates/discovery/addons/detail.html:66
+#: src/olympia/browse/views.py:427 src/olympia/devhub/views.py:74 src/olympia/devhub/views.py:81 src/olympia/discovery/templates/discovery/addons/detail.html:66
 msgid "Created"
 msgstr ""
 
@@ -2946,8 +2966,8 @@ msgid_plural "See all %(cnt)s extensions in %(name)s &raquo;"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/olympia/browse/templates/browse/mobile/extensions.html:13 src/olympia/compat/templates/compat/index.html:82 src/olympia/devhub/templates/devhub/devhub_search.html:24
-#: src/olympia/devhub/templates/devhub/addons/activity.html:47 src/olympia/search/templates/search/no_results.html:4 src/olympia/search/templates/search/mobile/results.html:36
+#: src/olympia/browse/templates/browse/mobile/extensions.html:13 src/olympia/devhub/templates/devhub/devhub_search.html:24 src/olympia/devhub/templates/devhub/addons/activity.html:47
+#: src/olympia/search/templates/search/no_results.html:4 src/olympia/search/templates/search/mobile/results.html:36
 msgid "No results found."
 msgstr ""
 
@@ -3032,7 +3052,7 @@ msgstr ""
 msgid "All"
 msgstr ""
 
-#: src/olympia/compat/forms.py:22 src/olympia/search/views.py:525
+#: src/olympia/compat/forms.py:22 src/olympia/editors/templates/editors/base.html:69 src/olympia/search/views.py:518
 msgid "All Add-ons"
 msgstr ""
 
@@ -3042,53 +3062,6 @@ msgstr ""
 
 #: src/olympia/compat/forms.py:24
 msgid "Non-binary"
-msgstr ""
-
-#. Review points sources other than add-ons and themes.
-#: src/olympia/compat/views.py:87 src/olympia/constants/base.py:388 src/olympia/devhub/forms.py:162 src/olympia/editors/templates/editors/performance.html:75
-msgid "Other"
-msgstr ""
-
-#: src/olympia/compat/templates/compat/index.html:4
-msgid "Add-on Compatibility Report for {app} {version}"
-msgstr ""
-
-#: src/olympia/compat/templates/compat/index.html:11
-msgid "{app} {version} Compatibility"
-msgstr ""
-
-#: src/olympia/compat/templates/compat/index.html:17
-#, python-format
-msgid "Top 95%% compatible with previous version"
-msgstr ""
-
-#: src/olympia/compat/templates/compat/index.html:18
-#, python-format
-msgid "Top 95%% of all add-ons"
-msgstr ""
-
-#: src/olympia/compat/templates/compat/index.html:19
-msgid "All active add-ons"
-msgstr ""
-
-#: src/olympia/compat/templates/compat/index.html:23 src/olympia/constants/base.py:401
-msgid "App"
-msgstr ""
-
-#: src/olympia/compat/templates/compat/index.html:55
-msgid "Details for add-ons compatible with previous version:"
-msgstr ""
-
-#: src/olympia/compat/templates/compat/index.html:57
-msgid "Show all versions"
-msgstr ""
-
-#: src/olympia/compat/templates/compat/index.html:59
-msgid "Details for add-ons compatible with all versions:"
-msgstr ""
-
-#: src/olympia/compat/templates/compat/index.html:61
-msgid "Show previous version only"
 msgstr ""
 
 #: src/olympia/compat/templates/compat/reporter.html:3
@@ -3142,8 +3115,8 @@ msgstr ""
 msgid "Report Type"
 msgstr ""
 
-#: src/olympia/compat/templates/compat/reporter_detail.html:47 src/olympia/devhub/forms.py:784 src/olympia/devhub/templates/devhub/addons/ajax_compat_update.html:17 src/olympia/editors/forms.py:108
-#: src/olympia/zadmin/forms.py:45
+#: src/olympia/compat/templates/compat/reporter_detail.html:47 src/olympia/devhub/forms.py:785 src/olympia/devhub/templates/devhub/addons/ajax_compat_update.html:17 src/olympia/editors/forms.py:108
+#: src/olympia/editors/forms.py:248 src/olympia/zadmin/forms.py:45
 msgid "Application"
 msgstr ""
 
@@ -3231,7 +3204,8 @@ msgstr ""
 msgid "Preliminarily Reviewed and Awaiting Full Review"
 msgstr ""
 
-#: src/olympia/constants/base.py:33 src/olympia/editors/helpers.py:924 src/olympia/editors/templates/editors/themes/history_table.html:34
+#: src/olympia/constants/base.py:33 src/olympia/editors/forms.py:258 src/olympia/editors/helpers.py:73 src/olympia/editors/helpers.py:1004
+#: src/olympia/editors/templates/editors/themes/history_table.html:34
 msgid "Deleted"
 msgstr ""
 
@@ -3328,6 +3302,11 @@ msgstr ""
 msgid "Ask before users can download this add-on"
 msgstr ""
 
+#. Review points sources other than add-ons and themes.
+#: src/olympia/constants/base.py:388 src/olympia/devhub/forms.py:162 src/olympia/editors/templates/editors/performance.html:75
+msgid "Other"
+msgstr ""
+
 #: src/olympia/constants/base.py:389
 msgid "Exception"
 msgstr ""
@@ -3338,6 +3317,10 @@ msgstr ""
 
 #: src/olympia/constants/base.py:391
 msgid "Change"
+msgstr ""
+
+#: src/olympia/constants/base.py:401
+msgid "App"
 msgstr ""
 
 #: src/olympia/constants/base.py:402
@@ -3488,7 +3471,7 @@ msgstr ""
 msgid "Duplicate"
 msgstr ""
 
-#: src/olympia/constants/editors.py:17 src/olympia/editors/helpers.py:502 src/olympia/editors/templates/editors/themes/queue.html:71 src/olympia/editors/templates/editors/themes/themes.html:94
+#: src/olympia/constants/editors.py:17 src/olympia/editors/helpers.py:575 src/olympia/editors/templates/editors/themes/queue.html:71 src/olympia/editors/templates/editors/themes/themes.html:94
 msgid "Reject"
 msgstr ""
 
@@ -3588,7 +3571,7 @@ msgstr ""
 msgid "Android"
 msgstr ""
 
-#: src/olympia/core/apps.py:19
+#: src/olympia/core/apps.py:21
 msgid "Core"
 msgstr ""
 
@@ -3722,7 +3705,7 @@ msgid "Submit my add-on for manual review."
 msgstr ""
 
 #: src/olympia/devhub/forms.py:537
-msgid "Do not list my add-on on this site (beta)"
+msgid "Do not list my add-on on this site"
 msgstr ""
 
 #: src/olympia/devhub/forms.py:538
@@ -3755,46 +3738,46 @@ msgstr ""
 
 #: src/olympia/devhub/forms.py:592
 #, python-format
-msgid "Version %s already exists"
+msgid "Version %s already exists, or was uploaded before."
 msgstr ""
 
-#: src/olympia/devhub/forms.py:604
+#: src/olympia/devhub/forms.py:605
 msgid "Select a valid choice. That choice is not one of the available choices."
 msgstr ""
 
-#: src/olympia/devhub/forms.py:610
+#: src/olympia/devhub/forms.py:611
 msgid "A file with a version ending with a|alpha|b|beta and an optional number is detected as beta."
 msgstr ""
 
-#: src/olympia/devhub/forms.py:633
+#: src/olympia/devhub/forms.py:634
 msgid "You cannot upload any more files for this version."
 msgstr ""
 
-#: src/olympia/devhub/forms.py:639
+#: src/olympia/devhub/forms.py:640
 msgid "Version doesn't match"
 msgstr ""
 
-#: src/olympia/devhub/forms.py:668
+#: src/olympia/devhub/forms.py:669
 msgid "You cannot delete a file once the review process has started.  You must delete the whole version."
 msgstr ""
 
-#: src/olympia/devhub/forms.py:688
+#: src/olympia/devhub/forms.py:689
 msgid "The platform All cannot be combined with specific platforms."
 msgstr ""
 
-#: src/olympia/devhub/forms.py:693
+#: src/olympia/devhub/forms.py:694
 msgid "A platform can only be chosen once."
 msgstr ""
 
-#: src/olympia/devhub/forms.py:706
+#: src/olympia/devhub/forms.py:707
 msgid "A review type must be selected."
 msgstr ""
 
-#: src/olympia/devhub/forms.py:788 src/olympia/editors/forms.py:114 src/olympia/zadmin/forms.py:49 src/olympia/zadmin/forms.py:52
+#: src/olympia/devhub/forms.py:789 src/olympia/editors/forms.py:114 src/olympia/editors/forms.py:254 src/olympia/zadmin/forms.py:49 src/olympia/zadmin/forms.py:52
 msgid "Select an application first"
 msgstr ""
 
-#: src/olympia/devhub/forms.py:840
+#: src/olympia/devhub/forms.py:841
 msgid "There cannot be more than 3 required add-ons."
 msgstr ""
 
@@ -3828,76 +3811,76 @@ msgstr[1] ""
 msgid "Review"
 msgstr ""
 
-#: src/olympia/devhub/tasks.py:551
+#: src/olympia/devhub/tasks.py:583
 #, python-format
 msgid "%s responded with %s (%s)."
 msgstr ""
 
-#: src/olympia/devhub/tasks.py:555
+#: src/olympia/devhub/tasks.py:587
 #, python-format
 msgid "Connection to \"%s\" timed out."
 msgstr ""
 
-#: src/olympia/devhub/tasks.py:557
+#: src/olympia/devhub/tasks.py:589
 #, python-format
 msgid "Could not contact host at \"%s\"."
 msgstr ""
 
-#: src/olympia/devhub/utils.py:104
+#: src/olympia/devhub/utils.py:105
 #, python-format
 msgid "Validation generated too many errors/warnings so %s messages were truncated. After addressing the visible messages, you'll be able to see the others."
 msgstr ""
 
-#: src/olympia/devhub/views.py:183
+#: src/olympia/devhub/views.py:181
 msgid "All My Add-ons"
 msgstr ""
 
-#: src/olympia/devhub/views.py:210
+#: src/olympia/devhub/views.py:208
 msgid "All Activity"
 msgstr ""
 
-#: src/olympia/devhub/views.py:211
+#: src/olympia/devhub/views.py:209
 msgid "Add-on Updates"
 msgstr ""
 
-#: src/olympia/devhub/views.py:212
+#: src/olympia/devhub/views.py:210
 msgid "Add-on Status"
 msgstr ""
 
-#: src/olympia/devhub/views.py:213
+#: src/olympia/devhub/views.py:211
 msgid "User Collections"
 msgstr ""
 
-#: src/olympia/devhub/views.py:214 src/olympia/devhub/templates/devhub/docs/policies-maintenance.html:68 src/olympia/pages/templates/pages/dev_faq.html:38
+#: src/olympia/devhub/views.py:212 src/olympia/devhub/templates/devhub/docs/policies-maintenance.html:68 src/olympia/pages/templates/pages/dev_faq.html:38
 #: src/olympia/pages/templates/pages/dev_faq.html:484
 msgid "User Reviews"
 msgstr ""
 
-#: src/olympia/devhub/views.py:327 src/olympia/devhub/views.py:331 src/olympia/devhub/views.py:484 src/olympia/devhub/views.py:513 src/olympia/devhub/views.py:564 src/olympia/devhub/views.py:1150
+#: src/olympia/devhub/views.py:325 src/olympia/devhub/views.py:329 src/olympia/devhub/views.py:484 src/olympia/devhub/views.py:513 src/olympia/devhub/views.py:564 src/olympia/devhub/views.py:1156
 msgid "Changes successfully saved."
 msgstr ""
 
-#: src/olympia/devhub/views.py:334 src/olympia/devhub/views.py:1631
+#: src/olympia/devhub/views.py:332 src/olympia/devhub/views.py:1637
 msgid "Please check the form for errors."
 msgstr ""
 
-#: src/olympia/devhub/views.py:346
+#: src/olympia/devhub/views.py:344
 msgid "Add-on cannot be deleted. Disable this add-on instead."
 msgstr ""
 
-#: src/olympia/devhub/views.py:356
+#: src/olympia/devhub/views.py:354
 msgid "Theme deleted."
 msgstr ""
 
-#: src/olympia/devhub/views.py:356
+#: src/olympia/devhub/views.py:354
 msgid "Add-on deleted."
 msgstr ""
 
-#: src/olympia/devhub/views.py:362
+#: src/olympia/devhub/views.py:360
 msgid "URL name was incorrect. Theme was not deleted."
 msgstr ""
 
-#: src/olympia/devhub/views.py:367
+#: src/olympia/devhub/views.py:365
 msgid "URL name was incorrect. Add-on was not deleted."
 msgstr ""
 
@@ -3925,7 +3908,7 @@ msgstr ""
 msgid "Check Add-on Compatibility"
 msgstr ""
 
-#: src/olympia/devhub/views.py:808 src/olympia/signing/views.py:90
+#: src/olympia/devhub/views.py:808 src/olympia/signing/views.py:95
 msgid "You cannot submit this type of add-on"
 msgstr ""
 
@@ -3955,33 +3938,33 @@ msgstr ""
 msgid "There was an error uploading your preview."
 msgstr ""
 
-#: src/olympia/devhub/views.py:1189
+#: src/olympia/devhub/views.py:1195
 #, python-format
 msgid "Version %s disabled."
 msgstr ""
 
-#: src/olympia/devhub/views.py:1193
+#: src/olympia/devhub/views.py:1199
 #, python-format
 msgid "Version %s deleted."
 msgstr ""
 
-#: src/olympia/devhub/views.py:1203
+#: src/olympia/devhub/views.py:1209
 msgid "This upload has failed validation, and may lack complete validation results. Please take due care when reviewing it."
 msgstr ""
 
-#: src/olympia/devhub/views.py:1677
+#: src/olympia/devhub/views.py:1683
 msgid "Preliminary Review Requested."
 msgstr ""
 
-#: src/olympia/devhub/views.py:1678
+#: src/olympia/devhub/views.py:1684
 msgid "Full Review Requested."
 msgstr ""
 
-#: src/olympia/devhub/views.py:1779
+#: src/olympia/devhub/views.py:1783
 msgid "Your old credentials were revoked and are no longer valid. Be sure to update all API clients with the new credentials."
 msgstr ""
 
-#: src/olympia/devhub/views.py:1797
+#: src/olympia/devhub/views.py:1801
 msgid "New API key created"
 msgstr ""
 
@@ -4011,7 +3994,7 @@ msgstr ""
 msgid "{0} :: Search"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/devhub_search.html:6 src/olympia/devhub/templates/devhub/search.html:8 src/olympia/editors/forms.py:435 src/olympia/editors/forms.py:437
+#: src/olympia/devhub/templates/devhub/devhub_search.html:6 src/olympia/devhub/templates/devhub/search.html:8 src/olympia/editors/forms.py:534 src/olympia/editors/forms.py:536
 #: src/olympia/editors/templates/editors/queue.html:27 src/olympia/editors/templates/editors/themes/queue_list.html:14 src/olympia/search/templates/search/collections.html:17
 #: src/olympia/search/templates/search/personas.html:18 src/olympia/search/templates/search/results.html:18 src/olympia/search/templates/search/mobile/results.html:8
 #: src/olympia/templates/search.html:14 src/olympia/templates/impala/search.html:18
@@ -4071,12 +4054,12 @@ msgstr ""
 msgid "Start Making Add-ons"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/index.html:86 src/olympia/devhub/templates/devhub/addons/listing/items.html:25 src/olympia/devhub/templates/devhub/includes/addon_details.html:15
+#: src/olympia/devhub/templates/devhub/index.html:86 src/olympia/devhub/templates/devhub/addons/listing/items.html:25 src/olympia/devhub/templates/devhub/includes/addon_details.html:20
 #: src/olympia/devhub/templates/devhub/personas/edit.html:43
 msgid "Status:"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/index.html:90 src/olympia/devhub/templates/devhub/includes/addon_details.html:100
+#: src/olympia/devhub/templates/devhub/index.html:90 src/olympia/devhub/templates/devhub/includes/addon_details.html:87
 msgid "Visibility:"
 msgstr ""
 
@@ -4084,11 +4067,11 @@ msgstr ""
 msgid "Latest Version:"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/index.html:109 src/olympia/devhub/templates/devhub/includes/addon_details.html:145 src/olympia/devhub/templates/devhub/personas/edit.html:49
+#: src/olympia/devhub/templates/devhub/index.html:109 src/olympia/devhub/templates/devhub/includes/addon_details.html:131 src/olympia/devhub/templates/devhub/personas/edit.html:49
 msgid "Queue Position:"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/index.html:110 src/olympia/devhub/templates/devhub/includes/addon_details.html:146 src/olympia/devhub/templates/devhub/personas/edit.html:50
+#: src/olympia/devhub/templates/devhub/index.html:110 src/olympia/devhub/templates/devhub/includes/addon_details.html:132 src/olympia/devhub/templates/devhub/personas/edit.html:50
 #, python-format
 msgid "%(position)s of %(total)s"
 msgstr ""
@@ -4190,16 +4173,6 @@ msgstr ""
 msgid "Do you want your add-on to be distributed on this site?"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/validate_addon.html:49 src/olympia/devhub/templates/devhub/addons/submit/upload.html:30 src/olympia/devhub/templates/devhub/versions/add_file_modal.html:14
-#: src/olympia/devhub/templates/devhub/versions/add_file_modal.html:53 src/olympia/devhub/templates/devhub/versions/list.html:298
-msgid "Warning:"
-msgstr ""
-
-#: src/olympia/devhub/templates/devhub/validate_addon.html:50 src/olympia/devhub/templates/devhub/addons/submit/upload.html:31
-#, python-format
-msgid "Submission of unlisted add-ons for signing is currently in an open beta. Please <a href=\"%(url)s\" target=\"_blank\">report any bugs</a> that you encounter."
-msgstr ""
-
 #. first parameter is a filename like lorem-ipsum-1.0.2.xpi
 #: src/olympia/devhub/templates/devhub/validation.html:5
 msgid "Validation Results for {0}"
@@ -4274,7 +4247,7 @@ msgstr ""
 msgid "Update Compatibility"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/addons/ajax_compat_update.html:4
+#: src/olympia/devhub/templates/devhub/addons/ajax_compat_update.html:4 src/olympia/devhub/templates/devhub/versions/edit.html:45
 msgid "Adjusting application information here will allow users to install your add-on even if the install manifest in the package indicates that the add-on is incompatible."
 msgstr ""
 
@@ -4286,9 +4259,9 @@ msgstr ""
 msgid "Add Another Application&hellip;"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/addons/ajax_compat_update.html:38 src/olympia/devhub/templates/devhub/addons/owner.html:86 src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:46
-#: src/olympia/devhub/templates/devhub/versions/list.html:351 src/olympia/devhub/templates/devhub/versions/list.html:353 src/olympia/templates/impala/base.html:132
-#: src/olympia/templates/impala/base.html:143 src/olympia/templates/impala/base.html:161 src/olympia/templates/impala/base.html:171
+#: src/olympia/devhub/templates/devhub/addons/ajax_compat_update.html:38 src/olympia/devhub/templates/devhub/addons/owner.html:86 src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:45
+#: src/olympia/devhub/templates/devhub/versions/list.html:349 src/olympia/devhub/templates/devhub/versions/list.html:351 src/olympia/templates/impala/base.html:129
+#: src/olympia/templates/impala/base.html:140 src/olympia/templates/impala/base.html:158 src/olympia/templates/impala/base.html:168
 msgid "Close"
 msgstr ""
 
@@ -4322,7 +4295,7 @@ msgstr ""
 msgid "Manage Authors & License"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/addons/owner.html:29 src/olympia/editors/templates/editors/review.html:270
+#: src/olympia/devhub/templates/devhub/addons/owner.html:29 src/olympia/editors/helpers.py:362 src/olympia/editors/templates/editors/review.html:270
 msgid "Authors"
 msgstr ""
 
@@ -4391,17 +4364,11 @@ msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/basic.html:52
 msgid ""
-"A short explanation of your add-on's basic\n"
-"                          functionality that is displayed in search and browse\n"
-"                          listings, as well as at the top of your add-on's\n"
-"                          details page. It is only relevant for listed add-ons."
+"A short explanation of your add-on's basic functionality that is displayed in search and browse listings, as well as at the top of your add-on's details page. It is only relevant for listed add-ons."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/basic.html:73
-msgid ""
-"Categories are the primary way users browse through add-ons.\n"
-"                        Choose any that fit your add-on's functionality for the most\n"
-"                        exposure. It is only relevant for listed add-ons."
+msgid "Categories are the primary way users browse through add-ons. Choose any that fit your add-on's functionality for the most exposure. It is only relevant for listed add-ons."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/basic.html:90
@@ -4411,11 +4378,7 @@ msgid ""
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/basic.html:119
-msgid ""
-"Tags help users find your add-on and should be short\n"
-"                        descriptors such as tabs, toolbar, or twitter.  You\n"
-"                        may have a maximum of {0} tags. It is only relevant\n"
-"                        for listed add-ons."
+msgid "Tags help users find your add-on and should be short descriptors such as tabs, toolbar, or twitter. You may have a maximum of {0} tags. It is only relevant for listed add-ons."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/basic.html:129 src/olympia/devhub/templates/devhub/personas/edit.html:97 src/olympia/devhub/templates/devhub/personas/submit.html:46
@@ -4443,11 +4406,7 @@ msgid "Add-on Details for {0}"
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/details.html:22
-msgid ""
-"A longer explanation of features,\n"
-"                          functionality, and other relevant information. This\n"
-"                          field is only displayed on the add-on's details\n"
-"                          page. It is only relevant for listed add-ons."
+msgid "A longer explanation of features, functionality, and other relevant information. This field is only displayed on the add-on's details page. It is only relevant for listed add-ons."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/details.html:44 src/olympia/translations/templates/translations/trans-menu.html:13
@@ -4455,10 +4414,7 @@ msgid "Default Locale"
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/details.html:45
-msgid ""
-"Information about your add-on is displayed in this locale\n"
-"                        unless you override it with a locale-specific translation.\n"
-"                        It is only relevant for listed add-ons."
+msgid "Information about your add-on is displayed in this locale unless you override it with a locale-specific translation. It is only relevant for listed add-ons."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/details.html:61 src/olympia/users/forms.py:311 src/olympia/users/templates/users/edit.html:122 src/olympia/users/templates/users/register.html:57
@@ -4468,10 +4424,8 @@ msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/details.html:63
 msgid ""
-"If your add-on has another homepage, enter its\n"
-"                          address here. If your website is localized into other\n"
-"                          languages multiple translations of this field can be\n"
-"                          added. It is only relevant for listed add-ons."
+"If your add-on has another homepage, enter its address here. If your website is localized into other languages multiple translations of this field can be added. It is only relevant for listed add-"
+"ons."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/media.html:3
@@ -4489,19 +4443,14 @@ msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/support.html:22
 msgid ""
-"If you wish to display an e-mail address for support\n"
-"                          inquiries, enter it here. If you have different\n"
-"                          addresses for each language multiple translations of\n"
-"                          this field can be added. It is only relevant for\n"
-"                          listed add-ons."
+"If you wish to display an e-mail address for support inquiries, enter it here. If you have different addresses for each language multiple translations of this field can be added. It is only "
+"relevant for listed add-ons."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/support.html:45
 msgid ""
-"If your add-on has a support website or forum, enter\n"
-"                          its address here. If your website is localized into\n"
-"                          other languages, multiple translations of this field can\n"
-"                          be added. It is only relevant for listed add-ons."
+"If your add-on has a support website or forum, enter its address here. If your website is localized into other languages, multiple translations of this field can be added. It is only relevant for "
+"listed add-ons."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:6
@@ -4515,11 +4464,8 @@ msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:23
 msgid ""
-"Any information end users may want to know that isn't\n"
-"                          necessarily applicable to the add-on summary or description.\n"
-"                          Common uses include listing known major bugs, information on\n"
-"                          how to report bugs, anticipated release date of a new version,\n"
-"                          etc. It is only relevant for listed add-ons."
+"Any information end users may want to know that isn't necessarily applicable to the add-on summary or description. Common uses include listing known major bugs, information on how to report bugs, "
+"anticipated release date of a new version, etc. It is only relevant for listed add-ons."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:46
@@ -4531,9 +4477,7 @@ msgid "Add-on Flags"
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:69
-msgid ""
-"These flags are used to classify add-ons. It is only\n"
-"                        relevant for listed add-ons."
+msgid "These flags are used to classify add-ons. It is only relevant for listed add-ons."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:74
@@ -4549,9 +4493,7 @@ msgid "View Source?"
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:90
-msgid ""
-"Whether the source of your add-on can be displayed in our\n"
-"                        online viewer. It is only relevant for listed add-ons."
+msgid "Whether the source of your add-on can be displayed in our online viewer. It is only relevant for listed add-ons."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:94
@@ -4567,10 +4509,7 @@ msgid "Public Stats?"
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:102
-msgid ""
-"Whether the download and usage stats of your add-on can\n"
-"                        be displayed in our online viewer.\n"
-"                        It is only relevant for listed add-ons."
+msgid "Whether the download and usage stats of your add-on can be displayed in our online viewer. It is only relevant for listed add-ons."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:107
@@ -4586,10 +4525,7 @@ msgid "Upgrade SDK?"
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:116
-msgid ""
-"If selected, we will try to automatically upgrade your\n"
-"                        add-on when a new version of the SDK is released.\n"
-"                        It is only relevant for listed add-ons."
+msgid "If selected, we will try to automatically upgrade your add-on when a new version of the SDK is released. It is only relevant for listed add-ons."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:121
@@ -4640,10 +4576,8 @@ msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/forms_shared/media.html:16
 msgid ""
-"Upload an icon for your add-on or choose from one of ours. The\n"
-"                      icon is displayed nearly everywhere your add-on is. Uploaded images\n"
-"                      must be one of the following image types: .png, .jpg.\n"
-"                      It is only relevant for listed add-ons."
+"Upload an icon for your add-on or choose from one of ours. The icon is displayed nearly everywhere your add-on is. Uploaded images must be one of the following image types: .png, .jpg. It is only "
+"relevant for listed add-ons."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/forms_shared/media.html:25
@@ -4656,9 +4590,7 @@ msgid "32x32px"
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/forms_shared/media.html:39
-msgid ""
-"Used in listings of add-ons, like search results\n"
-"                            and featured add-ons."
+msgid "Used in listings of add-ons, like search results and featured add-ons."
 msgstr ""
 
 #. The size of the icon
@@ -4753,16 +4685,14 @@ msgid "Deleting your add-on will permanently remove it from the site and prevent
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:24
-msgid ""
-"Enter the following text confirm your decision:\n"
-"           {slug}"
+msgid "Enter the following text confirm your decision: {slug}"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:34
+#: src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:33
 msgid "Please tell us why you are deleting your theme:"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:36
+#: src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:35
 msgid "Please tell us why you are deleting your add-on:"
 msgstr ""
 
@@ -4799,8 +4729,8 @@ msgstr ""
 msgid "Daily statistics on downloads and users."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/addons/listing/item_actions.html:45 src/olympia/stats/templates/stats/stats.html:75 src/olympia/stats/templates/stats/stats.html:79
-#: src/olympia/stats/templates/stats/stats.html:81
+#: src/olympia/devhub/templates/devhub/addons/listing/item_actions.html:45 src/olympia/stats/templates/stats/stats.html:31 src/olympia/stats/templates/stats/stats.html:35
+#: src/olympia/stats/templates/stats/stats.html:37
 msgid "Statistics"
 msgstr ""
 
@@ -4919,10 +4849,7 @@ msgid "Your add-on has been submitted to the Full Review queue."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/submit/done.html:18
-msgid ""
-"You'll receive an email once it has been reviewed by an editor. In\n"
-"          the meantime, you and your friends can install it directly from its\n"
-"          details page:"
+msgid "You'll receive an email once it has been reviewed by an editor. In the meantime, you and your friends can install it directly from its details page:"
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/submit/done.html:27 src/olympia/devhub/templates/devhub/addons/submit/done.html:77 src/olympia/devhub/templates/devhub/personas/submit_done.html:16
@@ -5128,11 +5055,11 @@ msgstr ""
 msgid "Use the fields below to upload your add-on package and select any platform restrictions. After upload, a series of automated validation tests will be run on your file."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/addons/submit/upload.html:59 src/olympia/devhub/templates/devhub/versions/add_file_modal.html:39
+#: src/olympia/devhub/templates/devhub/addons/submit/upload.html:51 src/olympia/devhub/templates/devhub/versions/add_file_modal.html:28
 msgid "Which platforms is this file compatible with?"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/addons/submit/upload.html:67 src/olympia/devhub/templates/devhub/versions/add_file_modal.html:65
+#: src/olympia/devhub/templates/devhub/addons/submit/upload.html:59 src/olympia/devhub/templates/devhub/versions/add_file_modal.html:45
 msgid "Administrative overrides"
 msgstr ""
 
@@ -5242,8 +5169,8 @@ msgstr ""
 
 #: src/olympia/devhub/templates/devhub/docs/policies-contact.html:44
 msgid ""
-"If you've found a problem with the site, we'd love to fix it. Please <a href=\"https://github.com/mozilla/olympia/issues\">file a bug report</a> in GitHub, including the location of the problem and "
-"how you encountered it."
+"If you've found a problem with the site, we'd love to fix it. Please <a href=\"https://github.com/mozilla/addons/issues/new\">file a bug report</a> in GitHub, including the location of the problem "
+"and how you encountered it."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/docs/policies-maintenance.html:3 src/olympia/devhub/templates/devhub/docs/policies-maintenance.html:7
@@ -5810,7 +5737,7 @@ msgstr ""
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:282
 msgid ""
-"Add-ons that store or otherwise handle browsing data must support <a href=\"https://developer.mozilla.org/En/Supporting_private_browsing_mode\">Private Browsing Mode</a>.  During a Private Browsing "
+"Add-ons that store or otherwise handle browsing data must support <a href=\"https://developer.mozilla.org/En/Supporting_private_browsing_mode\">Private Browsing Mode</a>. During a Private Browsing "
 "session, no browsing data can be written to disk, and all of this data must be cleared when Firefox quits or the Private Browsing session ends."
 msgstr ""
 
@@ -5975,129 +5902,95 @@ msgstr ""
 msgid "How to get in touch with us regarding these policies or your add-on."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:6
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:10
 msgid "You have disabled this add-on"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:20
-msgid ""
-"Your add-on's listing is disabled and is not showing\n"
-"                             anywhere in our gallery or update service."
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:24
+msgid "Your add-on's listing is disabled and is not showing anywhere in our gallery or update service."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:25
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:27
 msgid "Please complete your add-on."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:29
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:30
 msgid "You will receive an email when the review is complete."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:34
-msgid ""
-"You will receive an email when the review is complete. Until\n"
-"                             then, your add-on is not listed in our gallery but can be\n"
-"                             accessed directly from its details page."
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:33
+msgid "You will receive an email when the review is complete. Until then, your add-on is not listed in our gallery but can be accessed directly from its details page."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:38 src/olympia/devhub/templates/devhub/includes/addon_details.html:48
-msgid ""
-"You will receive an email when the review is\n"
-"                             complete and your add-on is signed."
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:37 src/olympia/devhub/templates/devhub/includes/addon_details.html:45
+msgid "You will receive an email when the review is complete and your add-on is signed."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:44
-msgid ""
-"You will receive an email when the review is complete. Until\n"
-"                             then, your add-on is not listed in our gallery but can be\n"
-"                             accessed directly from its details page. "
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:41
+msgid "You will receive an email when the review is complete. Until then, your add-on is not listed in our gallery but can be accessed directly from its details page. "
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:54
-msgid ""
-"Your add-on is displayed in our gallery and users are\n"
-"                             receiving automatic updates."
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:49
+msgid "Your add-on is displayed in our gallery and users are receiving automatic updates."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:57
-msgid ""
-"Your add-on has been signed and can be bundled with an\n"
-"                             application installer."
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:52
+msgid "Your add-on has been signed and can be bundled with an application installer."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:63
-msgid ""
-"Your add-on was disabled by a site administrator and is no\n"
-"                             longer shown in our gallery. If you have any questions,\n"
-"                             please email amo-admins@mozilla.org."
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:56
+msgid "Your add-on was disabled by a site administrator and is no longer shown in our gallery. If you have any questions, please email amo-admins@mozilla.org."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:70
-msgid ""
-"Your add-on is displayed in our gallery as experimental\n"
-"                             and users are receiving automatic updates. Some features\n"
-"                             are unavailable to your add-on."
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:62
+msgid "Your add-on is displayed in our gallery as experimental and users are receiving automatic updates. Some features are unavailable to your add-on."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:74
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:66
 msgid "Your add-on has been signed."
 msgstr ""
 
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:69
+msgid ""
+"You will receive an email when the full review is complete. Until then, your add-on is displayed in our gallery as experimental and users are receiving automatic updates. Some features are "
+"unavailable to your add-on."
+msgstr ""
+
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:74
+msgid "You will receive an email when the full review is complete, making you able to bundle your add-on with an application installer."
+msgstr ""
+
 #: src/olympia/devhub/templates/devhub/includes/addon_details.html:79
-msgid ""
-"You will receive an email when the full review is complete.\n"
-"                             Until then, your add-on is displayed in our gallery as\n"
-"                             experimental and users are receiving automatic updates.\n"
-"                             Some features are unavailable to your add-on."
+msgid "All add-ons hosted in our gallery must now be reviewed by an editor. If you wish to continue hosting your add-on, please click to select a review process."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:84
-msgid ""
-"You will receive an email when the full review is\n"
-"                             complete, making you able to bundle your add-on with an\n"
-"                             application installer."
-msgstr ""
-
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:91
-msgid ""
-"All add-ons hosted in our gallery must now be reviewed by an\n"
-"                             editor. If you wish to continue hosting your add-on, please\n"
-"                             click to select a review process."
-msgstr ""
-
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:113
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:100
 msgid "Current Version:"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:115
-msgid ""
-"This is the version of your add-on that will\n"
-"                                           be installed if someone clicks the Install\n"
-"                                           button on addons.mozilla.org. It is only\n"
-"                                           relevant for listed add-ons."
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:102
+msgid "This is the version of your add-on that will be installed if someone clicks the Install button on addons.mozilla.org. It is only relevant for listed add-ons."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:123
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:110
 msgid "Created:"
 msgstr ""
 
 #. {0} is a date. dennis-ignore: E201
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:125 src/olympia/devhub/templates/devhub/includes/addon_details.html:131
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:112 src/olympia/devhub/templates/devhub/includes/addon_details.html:118
 #, python-format
 msgid "%%b %%e, %%Y"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:136
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:123
 msgid "Next Version:"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:138
-msgid ""
-"This is the newest uploaded version, however\n"
-"                                           it isn’t live on the site yet."
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:125
+msgid "This is the newest uploaded version, however it isn’t live on the site yet."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:144 src/olympia/devhub/templates/devhub/versions/list.html:30
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:130 src/olympia/devhub/templates/devhub/versions/list.html:30
 msgid "Queues are not reviewed strictly in order"
 msgstr ""
 
@@ -6165,9 +6058,7 @@ msgid "View the blog &#9658;"
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/includes/license_form.html:6
-msgid ""
-"Please choose a license appropriate for the rights you grant on your source code.\n"
-"                  It is only relevant for listed add-ons."
+msgid "Please choose a license appropriate for the rights you grant on your source code. It is only relevant for listed add-ons."
 msgstr ""
 
 #. {0} is a list of HTML tags.
@@ -6194,14 +6085,11 @@ msgstr[1] ""
 #: src/olympia/devhub/templates/devhub/includes/policy_form.html:4
 msgid ""
 "Users will be required to accept the following End-User License Agreement (EULA) prior to installing your add-on. The presence of a EULA significantly affects the number of downloads an add-on "
-"receives. Please note that a EULA is not the same as a code license, such as the GPL or MPL.\n"
-"                It is only relevant for listed add-ons."
+"receives. Please note that a EULA is not the same as a code license, such as the GPL or MPL.It is only relevant for listed add-ons."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/policy_form.html:21
-msgid ""
-"If your add-on transmits any data from the user's computer, a privacy policy is required that explains what data is sent and how it is used.\n"
-"                It is only relevant for listed add-ons."
+#: src/olympia/devhub/templates/devhub/includes/policy_form.html:24
+msgid "If your add-on transmits any data from the user's computer, a privacy policy is required that explains what data is sent and how it is used. It is only relevant for listed add-ons."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/includes/source_form_field.html:2
@@ -6369,12 +6257,8 @@ msgstr ""
 msgid "Add some tags to describe your Theme."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/personas/edit.html:106
-msgid ""
-"A short explanation of your theme's\n"
-"                                basic functionality that is displayed in\n"
-"                                search and browse listings, as well as at\n"
-"                                the top of your theme's details page."
+#: src/olympia/devhub/templates/devhub/personas/edit.html:106 src/olympia/devhub/templates/devhub/personas/submit.html:54
+msgid "A short explanation of your theme's basic functionality that is displayed in search and browse listings, as well as at the top of your theme's details page."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/personas/edit.html:122 src/olympia/devhub/templates/devhub/personas/submit.html:68
@@ -6444,7 +6328,7 @@ msgid "Upon upload and form submission, the AMO Team will review your updated de
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/personas/edit.html:241
-msgid "Your previously resubmitted design,  which is under pending review."
+msgid "Your previously resubmitted design, which is under pending review."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/personas/edit.html:245
@@ -6511,14 +6395,6 @@ msgstr ""
 
 #: src/olympia/devhub/templates/devhub/personas/submit.html:33
 msgid "Give your Theme a name."
-msgstr ""
-
-#: src/olympia/devhub/templates/devhub/personas/submit.html:54
-msgid ""
-"A short explanation of your theme's\n"
-"                                      basic functionality that is displayed in\n"
-"                                      search and browse listings, as well as at\n"
-"                                      the top of your theme's details page."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/personas/submit.html:198
@@ -6595,30 +6471,16 @@ msgstr ""
 msgid "Files added to reviewed versions must be reviewed before they will be available for download."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/add_file_modal.html:15
-#, python-format
-msgid ""
-"Submission of updates to unlisted add-ons for signing is currently in an open beta. Manual review may still be required for a large number of add-ons. Please <a href=\"%(url)s\" target=\"_blank"
-"\">report any bugs</a> that you encounter."
-msgstr ""
-
-#: src/olympia/devhub/templates/devhub/versions/add_file_modal.html:35
+#: src/olympia/devhub/templates/devhub/versions/add_file_modal.html:24
 msgid "Select the target platform for this file."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/add_file_modal.html:46
+#: src/olympia/devhub/templates/devhub/versions/add_file_modal.html:35
 msgid "Which review type would you like to nominate for?"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/add_file_modal.html:51
+#: src/olympia/devhub/templates/devhub/versions/add_file_modal.html:40
 msgid "Only publish this version to my beta channel."
-msgstr ""
-
-#: src/olympia/devhub/templates/devhub/versions/add_file_modal.html:54
-#, python-format
-msgid ""
-"The behavior of the beta channel has changed to accommodate <a href=\"%(addon_signing_url)s\" target=\"_blank\">mandatory add-on signing</a>. The new process is currently in an open beta, and may "
-"change significantly in the near future. Please <a href=\"%(issues_url)s\" target=\"_blank\">report any bugs</a> that you encounter."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/versions/edit.html:5
@@ -6642,19 +6504,10 @@ msgstr ""
 msgid "Upload Another File"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/edit.html:45
-msgid ""
-"Adjusting application information here will allow users to install your\n"
-"                          add-on even if the install manifest in the package indicates that the\n"
-"                          add-on is incompatible."
-msgstr ""
-
 #: src/olympia/devhub/templates/devhub/versions/edit.html:74
 msgid ""
-"Information about changes in this release, new features,\n"
-"                              known bugs, and other useful information specific to this\n"
-"                              release/version. This information is also shown in the\n"
-"                              Add-ons Manager when updating."
+"Information about changes in this release, new features, known bugs, and other useful information specific to this release/version. This information is also shown in the Add-ons Manager when "
+"updating."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/versions/edit.html:99
@@ -6666,10 +6519,7 @@ msgid "Notes for Reviewers"
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/versions/edit.html:114
-msgid ""
-"Optionally, enter any information that may be useful\n"
-"                              to the Editor reviewing this add-on, such as test\n"
-"                              account information."
+msgid "Optionally, enter any information that may be useful to the Editor reviewing this add-on, such as test account information."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/versions/edit.html:127
@@ -6747,7 +6597,7 @@ msgstr ""
 msgid "Request Preliminary Review"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:80 src/olympia/devhub/templates/devhub/versions/list.html:327 src/olympia/devhub/templates/devhub/versions/list.html:350
+#: src/olympia/devhub/templates/devhub/versions/list.html:80 src/olympia/devhub/templates/devhub/versions/list.html:325 src/olympia/devhub/templates/devhub/versions/list.html:348
 msgid "Cancel Review Request"
 msgstr ""
 
@@ -6776,7 +6626,7 @@ msgid "Unlisted:"
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/versions/list.html:114
-msgid "Not distributed on {0}. Developers will upload new versions for signing and distribute the add-ons on their own. (beta)"
+msgid "Not distributed on {0}. Developers will upload new versions for signing and distribute the add-ons on their own."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/versions/list.html:122
@@ -6839,81 +6689,73 @@ msgid "<strong>Important:</strong> Once a version has been deleted, you may not 
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/versions/list.html:230
-msgid ""
-"Deleting a version which has already been reviewed\n"
-"               may also cause a significant delay in the review of\n"
-"               your next update."
-msgstr ""
-
-#: src/olympia/devhub/templates/devhub/versions/list.html:233
 msgid "Are you sure you wish to delete this version?"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:238
+#: src/olympia/devhub/templates/devhub/versions/list.html:235
 msgid "Delete Version"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:240
+#: src/olympia/devhub/templates/devhub/versions/list.html:237
 msgid "Disable Version"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:247
+#: src/olympia/devhub/templates/devhub/versions/list.html:244
 msgid "Add a new Version"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:249
+#: src/olympia/devhub/templates/devhub/versions/list.html:246
 msgid "Add Version"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:256 src/olympia/devhub/templates/devhub/versions/list.html:274
+#: src/olympia/devhub/templates/devhub/versions/list.html:253 src/olympia/devhub/templates/devhub/versions/list.html:279
 msgid "Hide Add-on"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:259
+#: src/olympia/devhub/templates/devhub/versions/list.html:256
 msgid "Hiding your add-on will prevent it from appearing anywhere in our gallery and will stop users from receiving automatic updates."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:265
+#: src/olympia/devhub/templates/devhub/versions/list.html:263
+msgid "The files awaiting review will be disabled and you will need to upload new versions."
+msgstr ""
+
+#: src/olympia/devhub/templates/devhub/versions/list.html:270
 msgid "Are you sure you wish to hide your add-on?"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:286 src/olympia/devhub/templates/devhub/versions/list.html:315
+#: src/olympia/devhub/templates/devhub/versions/list.html:291 src/olympia/devhub/templates/devhub/versions/list.html:313
 msgid "Unlist Add-on"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:289
+#: src/olympia/devhub/templates/devhub/versions/list.html:294
 #, python-format
 msgid ""
 "Unlisting your add-on will make it (and each of its versions/files) invisible on this website. It won't show up in searches, won't have a public facing page, and won't be updated automatically for "
-"current users.  It is recommended for unlisted add-ons to provide a custom <a href=\"%(update_url)s\" target=\"_blank\">updateURL</a> in their manifest file for automatic updates."
+"current users. It is recommended for unlisted add-ons to provide a custom <a href=\"%(update_url)s\" target=\"_blank\">updateURL</a> in their manifest file for automatic updates."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:299
-#, python-format
-msgid "Switching add-ons to unlisted is currently in an open beta. Please <a href=\"%(url)s\" target=\"_blank\">report any bugs</a> that you encounter."
-msgstr ""
-
-#: src/olympia/devhub/templates/devhub/versions/list.html:305
+#: src/olympia/devhub/templates/devhub/versions/list.html:303
 msgid "Unlisting an add-on is irreversible!"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:305
+#: src/olympia/devhub/templates/devhub/versions/list.html:303
 msgid "An unlisted add-on cannot be switched to be listed."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:307
+#: src/olympia/devhub/templates/devhub/versions/list.html:305
 msgid "Are you sure you wish to unlist your add-on?"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:330
+#: src/olympia/devhub/templates/devhub/versions/list.html:328
 msgid "Canceling your review request will leave your add-on as preliminarily reviewed."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:335
+#: src/olympia/devhub/templates/devhub/versions/list.html:333
 msgid "Canceling your review request will mark your add-on incomplete. If you do not complete your add-on after several days by re-requesting review, it will be deleted."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:343
+#: src/olympia/devhub/templates/devhub/versions/list.html:341
 msgid "Are you sure you wish to cancel your review request?"
 msgstr ""
 
@@ -7252,19 +7094,19 @@ msgstr ""
 msgid "Search by add-on name / author email"
 msgstr ""
 
-#: src/olympia/editors/forms.py:103
+#: src/olympia/editors/forms.py:103 src/olympia/editors/forms.py:244 src/olympia/editors/forms.py:257
 msgid "yes"
 msgstr ""
 
-#: src/olympia/editors/forms.py:104
+#: src/olympia/editors/forms.py:104 src/olympia/editors/forms.py:244 src/olympia/editors/forms.py:257
 msgid "no"
 msgstr ""
 
-#: src/olympia/editors/forms.py:105
+#: src/olympia/editors/forms.py:105 src/olympia/editors/forms.py:245
 msgid "Admin Flag"
 msgstr ""
 
-#: src/olympia/editors/forms.py:113
+#: src/olympia/editors/forms.py:113 src/olympia/editors/forms.py:253
 msgid "Max. Version"
 msgstr ""
 
@@ -7276,55 +7118,59 @@ msgstr ""
 msgid "Add-on Types"
 msgstr ""
 
-#: src/olympia/editors/forms.py:126 src/olympia/editors/helpers.py:267
+#: src/olympia/editors/forms.py:126 src/olympia/editors/helpers.py:279
 msgid "Platforms"
 msgstr ""
 
+#: src/olympia/editors/forms.py:237
+msgid "Search by add-on name / author email / guid"
+msgstr ""
+
 #. L10n: 0 = platform, 1 = filename, 2 = status message
-#: src/olympia/editors/forms.py:238
+#: src/olympia/editors/forms.py:342
 #, python-format
 msgid "<strong>%s</strong> &middot; %s &middot; %s"
 msgstr ""
 
-#: src/olympia/editors/forms.py:252
+#: src/olympia/editors/forms.py:356
 msgid "Comments:"
 msgstr ""
 
-#: src/olympia/editors/forms.py:256
+#: src/olympia/editors/forms.py:360
 msgid "Operating systems:"
 msgstr ""
 
-#: src/olympia/editors/forms.py:258
+#: src/olympia/editors/forms.py:362
 msgid "Applications:"
 msgstr ""
 
-#: src/olympia/editors/forms.py:260
+#: src/olympia/editors/forms.py:364
 msgid "Notify me the next time this add-on is updated. (Subsequent updates will not generate an email)"
 msgstr ""
 
-#: src/olympia/editors/forms.py:265
+#: src/olympia/editors/forms.py:369
 msgid "Clear Admin Review Flag"
 msgstr ""
 
-#: src/olympia/editors/forms.py:267
+#: src/olympia/editors/forms.py:371
 msgid "Clear more info requested flag"
 msgstr ""
 
-#: src/olympia/editors/forms.py:281
+#: src/olympia/editors/forms.py:385
 msgid "Choose a canned response..."
 msgstr ""
 
 #. L10n: Description of what can be searched for.
-#: src/olympia/editors/forms.py:324
+#: src/olympia/editors/forms.py:423
 msgid "theme name"
 msgstr ""
 
-#: src/olympia/editors/forms.py:350
+#: src/olympia/editors/forms.py:449
 msgid "Someone else is reviewing this theme."
 msgstr ""
 
 #. L10n: Description of what can be searched for.
-#: src/olympia/editors/forms.py:447
+#: src/olympia/editors/forms.py:546
 msgid "app, reviewer, or comment"
 msgstr ""
 
@@ -7340,246 +7186,264 @@ msgstr ""
 msgid "Rejected or Unreviewed"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:123 src/olympia/editors/helpers.py:136
+#: src/olympia/editors/helpers.py:125 src/olympia/editors/helpers.py:138
 msgid "Queue"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:124 src/olympia/editors/templates/editors/base.html:50 src/olympia/editors/templates/editors/base.html:65
+#: src/olympia/editors/helpers.py:126 src/olympia/editors/templates/editors/base.html:50 src/olympia/editors/templates/editors/base.html:65
 msgid "Pending Updates"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:125 src/olympia/editors/templates/editors/base.html:48 src/olympia/editors/templates/editors/base.html:63
+#: src/olympia/editors/helpers.py:127 src/olympia/editors/templates/editors/base.html:48 src/olympia/editors/templates/editors/base.html:63
 msgid "Full Reviews"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:126 src/olympia/editors/templates/editors/base.html:52 src/olympia/editors/templates/editors/base.html:67
+#: src/olympia/editors/helpers.py:128 src/olympia/editors/templates/editors/base.html:52 src/olympia/editors/templates/editors/base.html:67
 msgid "Preliminary Reviews"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:127 src/olympia/editors/templates/editors/base.html:54
+#: src/olympia/editors/helpers.py:129 src/olympia/editors/templates/editors/base.html:54
 msgid "Moderated Reviews"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:128 src/olympia/editors/templates/editors/base.html:46
+#: src/olympia/editors/helpers.py:130 src/olympia/editors/templates/editors/base.html:46
 msgid "Fast Track"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:130
+#: src/olympia/editors/helpers.py:132
 msgid "Pending Themes"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:131 src/olympia/editors/templates/editors/themes/queue.html:4
+#: src/olympia/editors/helpers.py:133 src/olympia/editors/templates/editors/themes/queue.html:4
 msgid "Flagged Themes"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:132
+#: src/olympia/editors/helpers.py:134
 msgid "Update Themes"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:137
+#: src/olympia/editors/helpers.py:139
 msgid "Unlisted Pending Updates"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:138
+#: src/olympia/editors/helpers.py:140
 msgid "Unlisted Full Reviews"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:139
+#: src/olympia/editors/helpers.py:141
 msgid "Unlisted Preliminary Reviews"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:170
+#: src/olympia/editors/helpers.py:142
+msgid "Unlisted All Add-ons"
+msgstr ""
+
+#: src/olympia/editors/helpers.py:173
 msgid "Fast Track ({0})"
 msgid_plural "Fast Track ({0})"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/olympia/editors/helpers.py:175
+#: src/olympia/editors/helpers.py:178
 msgid "Full Review ({0})"
 msgid_plural "Full Reviews ({0})"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/olympia/editors/helpers.py:180
+#: src/olympia/editors/helpers.py:183
 msgid "Pending Update ({0})"
 msgid_plural "Pending Updates ({0})"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/olympia/editors/helpers.py:185
+#: src/olympia/editors/helpers.py:188
 msgid "Preliminary Review ({0})"
 msgid_plural "Preliminary Reviews ({0})"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/olympia/editors/helpers.py:190
+#: src/olympia/editors/helpers.py:193
 msgid "Moderated Review ({0})"
 msgid_plural "Moderated Reviews ({0})"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/olympia/editors/helpers.py:196
+#: src/olympia/editors/helpers.py:199
 msgid "Unlisted Full Review ({0})"
 msgid_plural "Unlisted Full Reviews ({0})"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/olympia/editors/helpers.py:201
+#: src/olympia/editors/helpers.py:204
 msgid "Unlisted Pending Update ({0})"
 msgid_plural "Unlisted Pending Updates ({0})"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/olympia/editors/helpers.py:206
+#: src/olympia/editors/helpers.py:209
 msgid "Unlisted Preliminary Review ({0})"
 msgid_plural "Unlisted Preliminary Reviews ({0})"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/olympia/editors/helpers.py:261
-msgid "Addon"
-msgstr ""
+#: src/olympia/editors/helpers.py:214
+msgid "Unlisted All Add-ons ({0})"
+msgid_plural "Unlisted All Add-ons ({0})"
+msgstr[0] ""
+msgstr[1] ""
 
-#: src/olympia/editors/helpers.py:262
+#: src/olympia/editors/helpers.py:274
 msgid "Type"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:263
+#: src/olympia/editors/helpers.py:275
 msgid "Waiting Time"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:264 src/olympia/editors/templates/editors/review.html:285
+#: src/olympia/editors/helpers.py:276 src/olympia/editors/templates/editors/review.html:285
 msgid "Flags"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:265
+#: src/olympia/editors/helpers.py:277
 msgid "Applications"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:270
+#: src/olympia/editors/helpers.py:282
 msgid "Additional"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:285
+#: src/olympia/editors/helpers.py:302
 msgid "Site Specific"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:287
+#: src/olympia/editors/helpers.py:304
 msgid "Requires External Software"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:289
+#: src/olympia/editors/helpers.py:306
 msgid "Binary Components"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:313
+#: src/olympia/editors/helpers.py:339
 msgid "moments ago"
 msgstr ""
 
 #. L10n: first argument is number of minutes
-#: src/olympia/editors/helpers.py:316
+#: src/olympia/editors/helpers.py:342
 msgid "{0} minute"
 msgid_plural "{0} minutes"
 msgstr[0] ""
 msgstr[1] ""
 
 #. L10n: first argument is number of hours
-#: src/olympia/editors/helpers.py:320
+#: src/olympia/editors/helpers.py:346
 msgid "{0} hour"
 msgid_plural "{0} hours"
 msgstr[0] ""
 msgstr[1] ""
 
 #. L10n: first argument is number of days
-#: src/olympia/editors/helpers.py:324
+#: src/olympia/editors/helpers.py:350
 msgid "{0} day"
 msgid_plural "{0} days"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/olympia/editors/helpers.py:488
+#: src/olympia/editors/helpers.py:364
+msgid "Last Review"
+msgstr ""
+
+#: src/olympia/editors/helpers.py:366
+msgid "Last Update"
+msgstr ""
+
+#: src/olympia/editors/helpers.py:387
+msgid "No Reviews"
+msgstr ""
+
+#: src/olympia/editors/helpers.py:561
 msgid "Push to public"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:490
+#: src/olympia/editors/helpers.py:563
 msgid "Grant full review"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:505
+#: src/olympia/editors/helpers.py:578
 msgid "Request more information"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:508
+#: src/olympia/editors/helpers.py:581
 msgid "Request super-review"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:519
+#: src/olympia/editors/helpers.py:592
 msgid "Grant preliminary review"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:520
+#: src/olympia/editors/helpers.py:593
 msgid "This will mark the files as preliminarily reviewed."
 msgstr ""
 
-#: src/olympia/editors/helpers.py:522
+#: src/olympia/editors/helpers.py:595
 msgid "Use this form to request more information from the author. They will receive an email and be able to answer here. You will be notified by email when they reply."
 msgstr ""
 
-#: src/olympia/editors/helpers.py:526
+#: src/olympia/editors/helpers.py:599
 msgid ""
 "If you have concerns about this add-on's security, copyright issues, or other concerns that an administrator should look into, enter your comments in the area below. They will be sent to "
 "administrators, not the author."
 msgstr ""
 
-#: src/olympia/editors/helpers.py:532
+#: src/olympia/editors/helpers.py:605
 msgid "This will reject the add-on and remove it from the review queue."
 msgstr ""
 
-#: src/olympia/editors/helpers.py:534
-msgid "Make a comment on this version.  The author won't be able to see this."
+#: src/olympia/editors/helpers.py:607
+msgid "Make a comment on this version. The author won't be able to see this."
 msgstr ""
 
-#: src/olympia/editors/helpers.py:538
+#: src/olympia/editors/helpers.py:611
 msgid "This will reject the files and remove them from the review queue."
 msgstr ""
 
-#: src/olympia/editors/helpers.py:542
+#: src/olympia/editors/helpers.py:615
 msgid "This will mark the add-on as preliminarily reviewed. Future versions will undergo preliminary review."
 msgstr ""
 
-#: src/olympia/editors/helpers.py:547
+#: src/olympia/editors/helpers.py:620
 msgid "This will mark the files as preliminarily reviewed. Future versions will undergo preliminary review."
 msgstr ""
 
-#: src/olympia/editors/helpers.py:552
+#: src/olympia/editors/helpers.py:625
 msgid "Retain preliminary review"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:553
+#: src/olympia/editors/helpers.py:626
 msgid "This will retain the add-on as preliminarily reviewed. Future versions will undergo preliminary review."
 msgstr ""
 
-#: src/olympia/editors/helpers.py:558
+#: src/olympia/editors/helpers.py:631
 msgid "This will approve a sandboxed version of a public add-on to appear on the public side."
 msgstr ""
 
-#: src/olympia/editors/helpers.py:561
+#: src/olympia/editors/helpers.py:634
 msgid "This will reject a version of a public add-on and remove it from the queue."
 msgstr ""
 
-#: src/olympia/editors/helpers.py:564
+#: src/olympia/editors/helpers.py:637
 msgid "This will mark the add-on and its most recent version and files as public. Future versions will go into the sandbox until they are reviewed by an editor."
 msgstr ""
 
-#: src/olympia/editors/helpers.py:637
+#: src/olympia/editors/helpers.py:714
 msgid "add-on"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:940 src/olympia/editors/helpers.py:960
+#: src/olympia/editors/helpers.py:1020 src/olympia/editors/helpers.py:1040
 msgid "Flagged"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:944 src/olympia/editors/helpers.py:963
+#: src/olympia/editors/helpers.py:1024 src/olympia/editors/helpers.py:1043
 msgid "Updates"
 msgstr ""
 
@@ -7631,56 +7495,56 @@ msgstr ""
 msgid "A question about your Theme submission"
 msgstr ""
 
-#: src/olympia/editors/views.py:144
+#: src/olympia/editors/views.py:146
 msgid "New Add-ons (Under 5 days)"
 msgstr ""
 
-#: src/olympia/editors/views.py:145
+#: src/olympia/editors/views.py:147
 msgid "Passable (5 to 10 days)"
 msgstr ""
 
-#: src/olympia/editors/views.py:146
+#: src/olympia/editors/views.py:148
 msgid "Overdue (Over 10 days)"
 msgstr ""
 
-#: src/olympia/editors/views.py:532
+#: src/olympia/editors/views.py:539
 msgid "An unknown error occurred"
 msgstr ""
 
-#: src/olympia/editors/views.py:587
+#: src/olympia/editors/views.py:592
 msgid "Self-reviews are not allowed."
 msgstr ""
 
-#: src/olympia/editors/views.py:609
+#: src/olympia/editors/views.py:613
 msgid "Review successfully processed."
 msgstr ""
 
-#: src/olympia/editors/views.py:807
+#: src/olympia/editors/views.py:812
 msgid "was approved"
 msgstr ""
 
-#: src/olympia/editors/views.py:808
+#: src/olympia/editors/views.py:813
 msgid "given preliminary review"
 msgstr ""
 
-#: src/olympia/editors/views.py:809
+#: src/olympia/editors/views.py:814
 msgid "rejected"
 msgstr ""
 
-#: src/olympia/editors/views.py:810
+#: src/olympia/editors/views.py:815
 msgctxt "editors_review_history_nominated_adminreview"
 msgid "escalated"
 msgstr ""
 
-#: src/olympia/editors/views.py:812
+#: src/olympia/editors/views.py:817
 msgid "needs more information"
 msgstr ""
 
-#: src/olympia/editors/views.py:813
+#: src/olympia/editors/views.py:818
 msgid "needs super review"
 msgstr ""
 
-#: src/olympia/editors/views.py:814
+#: src/olympia/editors/views.py:819
 msgid "commented"
 msgstr ""
 
@@ -7725,28 +7589,28 @@ msgstr ""
 msgid "Unlisted Queues"
 msgstr ""
 
-#: src/olympia/editors/templates/editors/base.html:72 src/olympia/editors/templates/editors/performance.html:6
+#: src/olympia/editors/templates/editors/base.html:74 src/olympia/editors/templates/editors/performance.html:6
 msgid "Performance"
 msgstr ""
 
-#: src/olympia/editors/templates/editors/base.html:75 src/olympia/editors/templates/editors/themes/base.html:19 src/olympia/editors/templates/editors/themes/base.html:38
+#: src/olympia/editors/templates/editors/base.html:77 src/olympia/editors/templates/editors/themes/base.html:19 src/olympia/editors/templates/editors/themes/base.html:38
 msgid "Logs"
 msgstr ""
 
-#: src/olympia/editors/templates/editors/base.html:78 src/olympia/editors/templates/editors/reviewlog.html:4 src/olympia/editors/templates/editors/reviewlog.html:27
+#: src/olympia/editors/templates/editors/base.html:80 src/olympia/editors/templates/editors/reviewlog.html:4 src/olympia/editors/templates/editors/reviewlog.html:27
 msgid "Add-on Review Log"
 msgstr ""
 
-#: src/olympia/editors/templates/editors/base.html:80 src/olympia/editors/templates/editors/eventlog.html:4 src/olympia/editors/templates/editors/eventlog.html:8
+#: src/olympia/editors/templates/editors/base.html:82 src/olympia/editors/templates/editors/eventlog.html:4 src/olympia/editors/templates/editors/eventlog.html:8
 #: src/olympia/editors/templates/editors/eventlog_detail.html:4
 msgid "Moderated Review Log"
 msgstr ""
 
-#: src/olympia/editors/templates/editors/base.html:82 src/olympia/editors/templates/editors/beta_signed_log.html:4 src/olympia/editors/templates/editors/beta_signed_log.html:8
+#: src/olympia/editors/templates/editors/base.html:84 src/olympia/editors/templates/editors/beta_signed_log.html:4 src/olympia/editors/templates/editors/beta_signed_log.html:8
 msgid "Signed Beta Files Log"
 msgstr ""
 
-#: src/olympia/editors/templates/editors/base.html:87 src/olympia/editors/templates/editors/includes/daily-message.html:4
+#: src/olympia/editors/templates/editors/base.html:89 src/olympia/editors/templates/editors/includes/daily-message.html:4
 msgid "Announcement"
 msgstr ""
 
@@ -7967,45 +7831,45 @@ msgstr ""
 msgid "clear search"
 msgstr ""
 
-#: src/olympia/editors/templates/editors/queue.html:72 src/olympia/editors/templates/editors/queue.html:122
+#: src/olympia/editors/templates/editors/queue.html:78 src/olympia/editors/templates/editors/queue.html:128
 msgid "Process Reviews"
 msgstr ""
 
-#: src/olympia/editors/templates/editors/queue.html:80
+#: src/olympia/editors/templates/editors/queue.html:86
 msgid "Moderation actions:"
 msgstr ""
 
-#: src/olympia/editors/templates/editors/queue.html:90
+#: src/olympia/editors/templates/editors/queue.html:96
 #, python-format
 msgid "by %(user)s on %(date)s %(stars)s (%(locale)s)"
 msgstr ""
 
-#: src/olympia/editors/templates/editors/queue.html:106
+#: src/olympia/editors/templates/editors/queue.html:112
 #, python-format
 msgid "<strong>%(reason)s</strong> <span class=\"light\">Flagged by %(user)s on %(date)s</span>"
 msgstr ""
 
-#: src/olympia/editors/templates/editors/queue.html:119
-msgid "All reviews have been moderated.  Good work!"
+#: src/olympia/editors/templates/editors/queue.html:125
+msgid "All reviews have been moderated. Good work!"
 msgstr ""
 
-#: src/olympia/editors/templates/editors/queue.html:161
+#: src/olympia/editors/templates/editors/queue.html:167
 msgid "Version Notes / Notes for Reviewer"
 msgstr ""
 
-#: src/olympia/editors/templates/editors/queue.html:169
+#: src/olympia/editors/templates/editors/queue.html:175
 msgid "There are currently no add-ons of this type to review."
 msgstr ""
 
-#: src/olympia/editors/templates/editors/queue.html:181 src/olympia/editors/templates/editors/themes/queue_list.html:85
+#: src/olympia/editors/templates/editors/queue.html:187 src/olympia/editors/templates/editors/themes/queue_list.html:85
 msgid "Helpful Links:"
 msgstr ""
 
-#: src/olympia/editors/templates/editors/queue.html:182
+#: src/olympia/editors/templates/editors/queue.html:188
 msgid "Add-on Policy"
 msgstr ""
 
-#: src/olympia/editors/templates/editors/queue.html:184
+#: src/olympia/editors/templates/editors/queue.html:190
 msgid "Editors' Guide"
 msgstr ""
 
@@ -8068,10 +7932,7 @@ msgid "<strong>Warning!</strong> Another user was viewing this page before you."
 msgstr ""
 
 #: src/olympia/editors/templates/editors/review.html:237
-msgid ""
-"The whiteboard is the place to exchange information relevant to\n"
-"               this addon (whatever the version), between the developer and the\n"
-"               editor. This is visible and editable by both."
+msgid "The whiteboard is the place to exchange information relevant to this addon (whatever the version), between the developer and the editor. This is visible and editable by both."
 msgstr ""
 
 #: src/olympia/editors/templates/editors/review.html:241
@@ -8345,7 +8206,7 @@ msgstr ""
 msgid "Describe your reason for flagging"
 msgstr ""
 
-#: src/olympia/files/forms.py:88
+#: src/olympia/files/forms.py:90
 msgid "Cannot diff a version against itself"
 msgstr ""
 
@@ -8380,51 +8241,51 @@ msgstr ""
 msgid "There was an error accessing file %s."
 msgstr ""
 
-#: src/olympia/files/utils.py:343
+#: src/olympia/files/utils.py:340
 msgid "Could not parse uploaded file."
 msgstr ""
 
-#: src/olympia/files/utils.py:380
+#: src/olympia/files/utils.py:377
 msgid "Invalid file name in archive: {0}"
 msgstr ""
 
-#: src/olympia/files/utils.py:388
+#: src/olympia/files/utils.py:385
 msgid "File exceeding size limit in archive: {0}"
 msgstr ""
 
-#: src/olympia/files/utils.py:439
+#: src/olympia/files/utils.py:436
 msgid "Invalid archive."
 msgstr ""
 
-#: src/olympia/files/utils.py:529 src/olympia/files/utils.py:532
+#: src/olympia/files/utils.py:526 src/olympia/files/utils.py:529
 msgid "Could not parse the manifest file."
 msgstr ""
 
-#: src/olympia/files/utils.py:551
+#: src/olympia/files/utils.py:548
 msgid "Could not find an add-on ID."
 msgstr ""
 
-#: src/olympia/files/utils.py:554
+#: src/olympia/files/utils.py:551
 msgid "Add-on ID must be 64 characters or less."
 msgstr ""
 
-#: src/olympia/files/utils.py:556
+#: src/olympia/files/utils.py:553
 msgid "Add-on ID doesn't match add-on."
 msgstr ""
 
-#: src/olympia/files/utils.py:564
+#: src/olympia/files/utils.py:561
 msgid "Duplicate add-on ID found."
 msgstr ""
 
-#: src/olympia/files/utils.py:567
+#: src/olympia/files/utils.py:564
 msgid "Version numbers should have fewer than 32 characters."
 msgstr ""
 
-#: src/olympia/files/utils.py:570
+#: src/olympia/files/utils.py:567
 msgid "Version numbers should only contain letters, numbers, and these punctuation characters: +*.-_."
 msgstr ""
 
-#: src/olympia/files/utils.py:587
+#: src/olympia/files/utils.py:584
 msgid "<em:type> doesn't match add-on"
 msgstr ""
 
@@ -8523,6 +8384,10 @@ msgstr ""
 
 #: src/olympia/files/templates/files/viewer.html:134
 msgid "Fetching file."
+msgstr ""
+
+#: src/olympia/legacy_api/views.py:255
+msgid "Not implemented yet."
 msgstr ""
 
 #: src/olympia/lib/constants.py:6
@@ -9181,10 +9046,6 @@ msgstr ""
 msgid "Zimbabwe Dollar"
 msgstr ""
 
-#: src/olympia/lib/video/ffmpeg.py:112 src/olympia/lib/video/totem.py:81
-msgid "Videos must be in WebM."
-msgstr ""
-
 #: src/olympia/pages/templates/pages/about.lhtml:3 src/olympia/pages/templates/pages/about.lhtml:10
 msgid "About Mozilla Add-ons"
 msgstr ""
@@ -9196,7 +9057,7 @@ msgstr ""
 #: src/olympia/pages/templates/pages/about.lhtml:13
 msgid ""
 "addons.mozilla.org, commonly known as \"AMO\", is Mozilla's official site for add-ons to Mozilla software, such as Firefox, Thunderbird, and SeaMonkey. Add-ons let you add new features and change "
-"the way your browser or application works.  Take a look around and explore the thousands of ways to customize the way you do things online."
+"the way your browser or application works. Take a look around and explore the thousands of ways to customize the way you do things online."
 msgstr ""
 
 #: src/olympia/pages/templates/pages/about.lhtml:19
@@ -9541,7 +9402,7 @@ msgstr ""
 msgid ""
 "Yes. It's possible, but some of the functionality provided by these libraries are available through XPCOM, XUL, and JavaScript. In addition, authors should take care if libraries modify primitive "
 "object prototypes (String.prototype, Date.prototype, etc.) and/or define global functions (eg. the $ function). These are prone to cause conflict with other add-ons, in particular if different add-"
-"ons use different versions of libraries and so on. Developers need to be very, very careful with using them.  Mozilla does not offer documentation on using them to build add-ons."
+"ons use different versions of libraries and so on. Developers need to be very, very careful with using them. Mozilla does not offer documentation on using them to build add-ons."
 msgstr ""
 
 #: src/olympia/pages/templates/pages/dev_faq.html:165
@@ -9655,8 +9516,8 @@ msgstr ""
 #, python-format
 msgid ""
 "Yes. Many developers choose to host their own add-ons. Choosing to host your add-on on <a href=\"%(amo_url)s\">Mozilla's add-on site</a>, though, allows for much greater exposure to your add-on due "
-"to the large volume of visitors to the site.  <a href=\"%(md_url)s\">mozdev.org</a> offers free project hosting for Mozilla applications and extensions providing developers with tools to help "
-"manage source code, version control, bug tracking and documentation."
+"to the large volume of visitors to the site. <a href=\"%(md_url)s\">mozdev.org</a> offers free project hosting for Mozilla applications and extensions providing developers with tools to help manage "
+"source code, version control, bug tracking and documentation."
 msgstr ""
 
 #: src/olympia/pages/templates/pages/dev_faq.html:277
@@ -9704,7 +9565,7 @@ msgstr ""
 #: src/olympia/pages/templates/pages/dev_faq.html:314
 #, python-format
 msgid ""
-"Yes. Mozilla's <a href=\"%(p_url)s\">Add-on Policy</a> describes what is an acceptable submission. This policy is subject to change without notice.  In addition, the AMO editorial team uses the <a "
+"Yes. Mozilla's <a href=\"%(p_url)s\">Add-on Policy</a> describes what is an acceptable submission. This policy is subject to change without notice. In addition, the AMO editorial team uses the <a "
 "href=\"%(g_url)s\">Editors Reviewing Guide</a> to ensure that your add-on meets specific guidelines for functionality and security."
 msgstr ""
 
@@ -9821,7 +9682,7 @@ msgstr ""
 #: src/olympia/pages/templates/pages/dev_faq.html:434
 #, python-format
 msgid ""
-"This is why it's very important to read the <a href=\"%(g_url)s\">Editors Reviewing Guide</a> to ensure that your add-on is setup as expected.  It's also a good idea to read the blog post, <a href="
+"This is why it's very important to read the <a href=\"%(g_url)s\">Editors Reviewing Guide</a> to ensure that your add-on is setup as expected. It's also a good idea to read the blog post, <a href="
 "\"%(blog_url)s\">Successfully Getting your Add-on Reviewed</a> which provides excellent insight into ensuring a smooth review of your add-on."
 msgstr ""
 
@@ -9928,7 +9789,7 @@ msgstr ""
 
 #: src/olympia/pages/templates/pages/dev_faq.html:572
 msgid ""
-"Free Software Foundation provides short summaries of the key open source licenses, including whether the license qualifies as a free software license or a copyleft license.  Also includes a "
+"Free Software Foundation provides short summaries of the key open source licenses, including whether the license qualifies as a free software license or a copyleft license. Also includes a "
 "discussion of what constitutes a free software license or a copyleft license (e.g., a Copyleft license is a general method for making a program or other work free, and requiring all modified and "
 "extended versions of the program to be free as well.)"
 msgstr ""
@@ -10106,19 +9967,13 @@ msgid "Add-on Gallery"
 msgstr ""
 
 #: src/olympia/pages/templates/pages/faq.html:171
-msgid ""
-"How do I choose between add-ons that seem to do the same\n"
-"    thing?"
+msgid "How do I choose between add-ons that seem to do the same thing?"
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:173
+#: src/olympia/pages/templates/pages/faq.html:172
 msgid ""
-"There are often several add-ons that have similar features. To\n"
-"    figure out which is right for you, read the entire description of the\n"
-"    add-on and view its screenshots. If there are still several in the running,\n"
-"    read through the add-on's ratings, user reviews, and statistics to see\n"
-"    which is most liked by other users. Remember that you can also just try\n"
-"    out both and see which you like better."
+"There are often several add-ons that have similar features. To figure out which is right for you, read the entire description of the add-on and view its screenshots. If there are still several in "
+"the running, read through the add-on's ratings, user reviews, and statistics to see which is most liked by other users. Remember that you can also just try out both and see which you like better."
 msgstr ""
 
 #: src/olympia/pages/templates/pages/faq.html:180
@@ -10159,80 +10014,67 @@ msgid "How much do add-ons cost to purchase?"
 msgstr ""
 
 #: src/olympia/pages/templates/pages/faq.html:207
-msgid ""
-"Add-ons hosted in our gallery are free unless clearly marked\n"
-"    otherwise."
+msgid "Add-ons hosted in our gallery are free unless clearly marked otherwise."
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:210
+#: src/olympia/pages/templates/pages/faq.html:209
 msgid "What does it mean when an add-on asks for contributions?"
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:211
+#: src/olympia/pages/templates/pages/faq.html:210
 msgid ""
-"Some add-on authors request users who enjoy an add-on to\n"
-"        contribute to its development by making a monetary contribution. These\n"
-"        contributions go directly to the developer unless a third party is\n"
-"        indicated, such as the non-profit Mozilla Foundation."
+"Some add-on authors request users who enjoy an add-on to contribute to its development by making a monetary contribution. These contributions go directly to the developer unless a third party is "
+"indicated, such as the non-profit Mozilla Foundation."
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:216
+#: src/olympia/pages/templates/pages/faq.html:215
 msgid "What are beta add-ons?"
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:218
+#: src/olympia/pages/templates/pages/faq.html:217
 msgid ""
-"Beta add-ons are unreviewed versions which represent the\n"
-"        latest work of an add-on author. While different authors have different\n"
-"        standards for beta code quality, you should assume that these add-ons\n"
-"        are less stable than the general add-on releases."
+"Beta add-ons are unreviewed versions which represent the latest work of an add-on author. While different authors have different standards for beta code quality, you should assume that these add-"
+"ons are less stable than the general add-on releases."
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:222
+#: src/olympia/pages/templates/pages/faq.html:221
 msgid ""
 "Please note that when you install an add-on from the \"Beta Version\" section of an add-on's listing, you will continue to receive updates for that add-on as they become available. Like the initial "
 "version you installed, all beta releases are unreviewed by Mozilla and may harm your computer."
 msgstr ""
 
+#: src/olympia/pages/templates/pages/faq.html:228
+msgid "What does it mean when an add-on is flagged as slow?"
+msgstr ""
+
 #: src/olympia/pages/templates/pages/faq.html:229
-msgid ""
-"What does it mean when an add-on is flagged as\n"
-"    slow?"
+msgid "Most add-ons load code and resources at the same time Firefox is starting up. In most cases the impact in start-up time is minimal, but some add-ons can cause a noticeable slowdown."
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:231
-msgid ""
-"Most add-ons load code and resources at the same time Firefox\n"
-"        is starting up. In most cases the impact in start-up time is minimal,\n"
-"        but some add-ons can cause a noticeable slowdown."
-msgstr ""
-
-#: src/olympia/pages/templates/pages/faq.html:236
+#: src/olympia/pages/templates/pages/faq.html:234
 msgid "How do I report an inappropriate or spam user review?"
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:237
+#: src/olympia/pages/templates/pages/faq.html:235
 msgid ""
-"To report a user review of an add-on, log in with your account\n"
-"    and visit the add-on's reviews page. Find the review you wish to report,\n"
-"    click \"Report this review\" and select a reason. Our editorial team will\n"
-"    investigate the review and take appropriate action."
+"To report a user review of an add-on, log in with your account and visit the add-on's reviews page. Find the review you wish to report, click \"Report this review\" and select a reason. Our "
+"editorial team will investigate the review and take appropriate action."
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:242
+#: src/olympia/pages/templates/pages/faq.html:240
 msgid "How do I report a bug or contact the Mozilla Add-ons team?"
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:243
+#: src/olympia/pages/templates/pages/faq.html:241
 #, python-format
 msgid "Please visit our <a href=\"%(contact_url)s\">Contact page</a>."
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:246
+#: src/olympia/pages/templates/pages/faq.html:244
 msgid "What is a Source Code License?"
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:247
+#: src/olympia/pages/templates/pages/faq.html:245
 #, python-format
 msgid ""
 "The source code used to create an add-on is an exclusive copyright of the add-on author, unless otherwise declared in a source code license. Many add-ons on this site have <a href=\"%(url)s\" lang="
@@ -10240,60 +10082,60 @@ msgid ""
 "the GPL or BSD licenses instead of making up their own."
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:256
+#: src/olympia/pages/templates/pages/faq.html:254
 #, python-format
 msgid "Firefox and other Mozilla software are <a href=\"%(url)s\">open source</a>."
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:264
+#: src/olympia/pages/templates/pages/faq.html:262
 msgid "Collections and Favorites"
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:267
+#: src/olympia/pages/templates/pages/faq.html:265
 msgid "What is a collection?"
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:268
+#: src/olympia/pages/templates/pages/faq.html:266
 msgid "Collections are groups of related add-ons created by users to share."
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:270
+#: src/olympia/pages/templates/pages/faq.html:268
 msgid "What is the My Favorites collection?"
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:271
+#: src/olympia/pages/templates/pages/faq.html:269
 msgid "Favorite add-ons are add-ons that you have bookmarked to easily get back to later. You can add an add-on to your favorites collection by clicking \"Add to favorites\" on its details page."
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:275 src/olympia/templates/menu_links.html:13 src/olympia/templates/impala/header_title.html:17
+#: src/olympia/pages/templates/pages/faq.html:273 src/olympia/templates/menu_links.html:13 src/olympia/templates/impala/header_title.html:17
 msgid "Mobile Add-ons"
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:278
+#: src/olympia/pages/templates/pages/faq.html:276
 msgid "What are mobile add-ons?"
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:279
+#: src/olympia/pages/templates/pages/faq.html:277
 #, python-format
 msgid ""
 "Mobile add-ons work with <a href=\"%(mobile_url)s\">Firefox for Mobile</a> and add or modify functionality just like desktop add-ons. You can find add-ons that work with Firefox for Mobile in our "
 "<a href=\"%(gallery_url)s\">gallery</a>."
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:288
+#: src/olympia/pages/templates/pages/faq.html:286
 msgid "Developer Topics"
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:289
+#: src/olympia/pages/templates/pages/faq.html:287
 #, python-format
 msgid "Please see our <a href=\"%(faq_url)s\">Developer FAQ</a> and <a href=\"%(hub_url)s\">Developer Hub</a> for answers to add-on developer-related questions."
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:294
+#: src/olympia/pages/templates/pages/faq.html:292
 msgid "Still have questions?"
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:295
+#: src/olympia/pages/templates/pages/faq.html:293
 #, python-format
 msgid "For general Firefox support, visit our <a href=\"%(sumo_url)s\">support website</a>. For general add-on and website questions, visit our <a href=\"%(forum_url)s\">forum</a>."
 msgstr ""
@@ -10431,7 +10273,7 @@ msgstr ""
 
 #: src/olympia/pages/templates/pages/sunbird.html:29
 msgid ""
-"Development on the Sunbird project has halted and its final release was on March 30, 2010.  We've been proud to host Sunbird add-ons on this site but as the project is no longer maintained we have "
+"Development on the Sunbird project has halted and its final release was on March 30, 2010. We've been proud to host Sunbird add-ons on this site but as the project is no longer maintained we have "
 "disabled our support for the add-ons."
 msgstr ""
 
@@ -10509,7 +10351,7 @@ msgstr ""
 #, python-format
 msgid ""
 "<h2>Keep these tips in mind:</h2> <ul> <li> Write like you're telling a friend about your experience with the add-on. Give specifics and helpful details, such as what features you liked and/or "
-"disliked, how easy to use it is, and any disadvantages it has.  Avoid generic language such as calling it \"Great\" or \"Bad\" unless you can give reasons why you believe this is so. </li> <li> "
+"disliked, how easy to use it is, and any disadvantages it has. Avoid generic language such as calling it \"Great\" or \"Bad\" unless you can give reasons why you believe this is so. </li> <li> "
 "Please do not post bug reports in reviews. We do not make your email address available to add-on developers and they may need to contact you to help resolve your issue. See the <a href=\"%(support)s"
 "\">support section</a> to find out where to get assistance for this add-on. </li> <li>Please keep reviews clean, avoid the use of improper language and do not post any personal information. </li> </"
 "ul> <p>Please read the <a href=\"%(guide)s\" target=\"_blank\">Review Guidelines</a> for more detail about user add-on reviews.</p>"
@@ -10745,16 +10587,16 @@ msgstr ""
 
 #. L10n: {0} is an application, such as Firefox. This means "any version of
 #. Firefox."
-#: src/olympia/search/views.py:554
+#: src/olympia/search/views.py:547
 msgid "Any {0}"
 msgstr ""
 
 #. L10n: "All Systems" means show everything regardless of platform.
-#: src/olympia/search/views.py:589
+#: src/olympia/search/views.py:582
 msgid "All Systems"
 msgstr ""
 
-#: src/olympia/search/views.py:600
+#: src/olympia/search/views.py:593
 msgid "All Tags"
 msgstr ""
 
@@ -10928,31 +10770,31 @@ msgstr ""
 msgid "Share this Collection"
 msgstr ""
 
-#: src/olympia/signing/views.py:30 src/olympia/templates/base.html:75 src/olympia/templates/impala/base.html:115
+#: src/olympia/signing/views.py:33 src/olympia/templates/base.html:71 src/olympia/templates/impala/base.html:112
 msgid "Some features are temporarily disabled while we perform website maintenance. We'll be back to full capacity shortly."
 msgstr ""
 
-#: src/olympia/signing/views.py:53
+#: src/olympia/signing/views.py:56
 msgid "Could not find add-on with id \"{}\"."
 msgstr ""
 
-#: src/olympia/signing/views.py:67
+#: src/olympia/signing/views.py:70
 msgid "You do not own this addon."
 msgstr ""
 
-#: src/olympia/signing/views.py:82
+#: src/olympia/signing/views.py:87
 msgid "Missing \"upload\" key in multipart file data."
 msgstr ""
 
-#: src/olympia/signing/views.py:96
+#: src/olympia/signing/views.py:101
 msgid "Version does not match the manifest file."
 msgstr ""
 
-#: src/olympia/signing/views.py:100
+#: src/olympia/signing/views.py:105
 msgid "Version already exists."
 msgstr ""
 
-#: src/olympia/signing/views.py:136
+#: src/olympia/signing/views.py:141
 msgid "No uploaded file for that addon and version."
 msgstr ""
 
@@ -11065,89 +10907,89 @@ msgstr ""
 msgid "Statistics Dashboard :: Add-ons for {0}"
 msgstr ""
 
-#: src/olympia/stats/templates/stats/stats.html:30
-msgid "Controls:"
-msgstr ""
-
-#: src/olympia/stats/templates/stats/stats.html:33
-msgid "reset zoom"
-msgstr ""
-
-#: src/olympia/stats/templates/stats/stats.html:40
-msgid "Group by:"
-msgstr ""
-
-#: src/olympia/stats/templates/stats/stats.html:42
-msgid "day"
-msgstr ""
-
-#: src/olympia/stats/templates/stats/stats.html:45
-msgid "week"
-msgstr ""
-
-#: src/olympia/stats/templates/stats/stats.html:48
-msgid "month"
-msgstr ""
-
-#: src/olympia/stats/templates/stats/stats.html:54
-msgid "For last:"
-msgstr ""
-
-#: src/olympia/stats/templates/stats/stats.html:57
-msgid "7 days"
-msgstr ""
-
-#: src/olympia/stats/templates/stats/stats.html:60
-msgid "30 days"
-msgstr ""
-
-#: src/olympia/stats/templates/stats/stats.html:63
-msgid "90 days"
-msgstr ""
-
-#: src/olympia/stats/templates/stats/stats.html:66
-msgid "365 days"
-msgstr ""
-
-#: src/olympia/stats/templates/stats/stats.html:69
-msgid "Custom..."
-msgstr ""
-
 #. {0} is an add-on name
-#: src/olympia/stats/templates/stats/stats.html:88 src/olympia/stats/templates/stats/stats.html:91
+#: src/olympia/stats/templates/stats/stats.html:44 src/olympia/stats/templates/stats/stats.html:47
 msgid "Statistics for {0}"
 msgstr ""
 
-#: src/olympia/stats/templates/stats/stats.html:94
+#: src/olympia/stats/templates/stats/stats.html:50
 msgid "Statistics Dashboard"
 msgstr ""
 
-#: src/olympia/stats/templates/stats/stats.html:104
+#: src/olympia/stats/templates/stats/stats.html:57
+msgid "Controls:"
+msgstr ""
+
+#: src/olympia/stats/templates/stats/stats.html:60
+msgid "reset zoom"
+msgstr ""
+
+#: src/olympia/stats/templates/stats/stats.html:67
+msgid "Group by:"
+msgstr ""
+
+#: src/olympia/stats/templates/stats/stats.html:69
+msgid "day"
+msgstr ""
+
+#: src/olympia/stats/templates/stats/stats.html:72
+msgid "week"
+msgstr ""
+
+#: src/olympia/stats/templates/stats/stats.html:75
+msgid "month"
+msgstr ""
+
+#: src/olympia/stats/templates/stats/stats.html:81
+msgid "For last:"
+msgstr ""
+
+#: src/olympia/stats/templates/stats/stats.html:84
+msgid "7 days"
+msgstr ""
+
+#: src/olympia/stats/templates/stats/stats.html:87
+msgid "30 days"
+msgstr ""
+
+#: src/olympia/stats/templates/stats/stats.html:90
+msgid "90 days"
+msgstr ""
+
+#: src/olympia/stats/templates/stats/stats.html:93
+msgid "365 days"
+msgstr ""
+
+#: src/olympia/stats/templates/stats/stats.html:96
+msgid "Custom..."
+msgstr ""
+
+#: src/olympia/stats/templates/stats/stats.html:106
 msgid "Statistics processing is currently disabled, so recent data is unavailable. The statistics are still being collected and this page will be updated soon with the missing data."
 msgstr ""
 
-#: src/olympia/stats/templates/stats/stats.html:110
+#: src/olympia/stats/templates/stats/stats.html:112
 msgid "Loading the latest data&hellip;"
 msgstr ""
 
-#: src/olympia/stats/templates/stats/stats.html:142 src/olympia/stats/templates/stats/reports/overview.html:25 src/olympia/stats/templates/stats/reports/overview.html:37
+#: src/olympia/stats/templates/stats/stats.html:144 src/olympia/stats/templates/stats/reports/overview.html:25 src/olympia/stats/templates/stats/reports/overview.html:37
 #: src/olympia/stats/templates/stats/reports/overview.html:49
 msgid "No data available."
 msgstr ""
 
-#: src/olympia/stats/templates/stats/stats.html:177
+#: src/olympia/stats/templates/stats/stats.html:179
 msgid "This dashboard is currently <b>public</b>."
 msgstr ""
 
-#: src/olympia/stats/templates/stats/stats.html:179
+#: src/olympia/stats/templates/stats/stats.html:181
 msgid "Contribution stats are currently <b>private</b>."
 msgstr ""
 
-#: src/olympia/stats/templates/stats/stats.html:182
+#: src/olympia/stats/templates/stats/stats.html:184
 msgid "This dashboard is currently <b>private</b>."
 msgstr ""
 
-#: src/olympia/stats/templates/stats/stats.html:185
+#: src/olympia/stats/templates/stats/stats.html:187
 msgid "Change settings."
 msgstr ""
 
@@ -11299,15 +11141,6 @@ msgstr ""
 msgid "Application versions by Date"
 msgstr ""
 
-#: src/olympia/tags/templates/tags/top_cloud.html:4
-msgid "Top {0} Tags"
-msgstr ""
-
-#. {0} is the current application name
-#: src/olympia/tags/templates/tags/top_cloud.html:14
-msgid "{0} Top Tags"
-msgstr ""
-
 #: src/olympia/templates/amo_footer.html:6 src/olympia/templates/includes/lang_switcher.html:2
 msgid "Other languages"
 msgstr ""
@@ -11316,11 +11149,11 @@ msgstr ""
 msgid "Mozilla Add-ons"
 msgstr ""
 
-#: src/olympia/templates/base.html:91 src/olympia/templates/impala/base.html:81
+#: src/olympia/templates/base.html:89 src/olympia/templates/impala/base.html:78
 msgid "Find add-ons for other applications"
 msgstr ""
 
-#: src/olympia/templates/base.html:92 src/olympia/templates/impala/base.html:81
+#: src/olympia/templates/base.html:90 src/olympia/templates/impala/base.html:78
 msgid "Other Applications"
 msgstr ""
 
@@ -11345,7 +11178,7 @@ msgid "View Mobile Site"
 msgstr ""
 
 #: src/olympia/templates/copyright.html:7
-msgid "Site Status "
+msgid "Site Status"
 msgstr ""
 
 #: src/olympia/templates/footer.html:3
@@ -11445,35 +11278,35 @@ msgstr ""
 msgid "<a href=\"%(reg)s\">Register</a> or <a href=\"%(login)s\">Log in</a>"
 msgstr ""
 
-#: src/olympia/templates/impala/base.html:126
+#: src/olympia/templates/impala/base.html:123
 #, python-format
 msgid "To try the thousands of add-ons available here, download <a href=\"%(url)s\">Mozilla Firefox</a>, a fast, free way to surf the Web!"
 msgstr ""
 
-#: src/olympia/templates/impala/base.html:138
+#: src/olympia/templates/impala/base.html:135
 #, python-format
 msgid "Add-ons is switching to Firefox Accounts for login. <a href=\"%(url)s\" class=\"fxa-login\">Sign in now to transfer your account.</a>"
 msgstr ""
 
 #. {0} is an application, such as Firefox.
-#: src/olympia/templates/impala/base.html:148
+#: src/olympia/templates/impala/base.html:145
 msgid "Welcome to {0} Add-ons."
 msgstr ""
 
-#: src/olympia/templates/impala/base.html:151
+#: src/olympia/templates/impala/base.html:148
 msgid "Choose from thousands of extra features and styles to make Firefox your own."
 msgstr ""
 
-#: src/olympia/templates/impala/base.html:156
+#: src/olympia/templates/impala/base.html:153
 #, python-format
 msgid "Add extra features and styles to make %(app)s your own."
 msgstr ""
 
-#: src/olympia/templates/impala/base.html:164
+#: src/olympia/templates/impala/base.html:161
 msgid "On the go?"
 msgstr ""
 
-#: src/olympia/templates/impala/base.html:166
+#: src/olympia/templates/impala/base.html:163
 msgid "Check out our <a class=\"mobile-link\" href=\"#\">Mobile Add-ons site</a>."
 msgstr ""
 
@@ -11697,19 +11530,19 @@ msgstr ""
 
 #. L10n: {id} will be something like "13ad6a", just a random number
 #. to differentiate this user from other anonymous users.
-#: src/olympia/users/models.py:353
+#: src/olympia/users/models.py:362
 msgid "Anonymous user {id}"
 msgstr ""
 
-#: src/olympia/users/models.py:410
+#: src/olympia/users/models.py:419
 msgid "Your account has been restricted"
 msgstr ""
 
-#: src/olympia/users/models.py:480
+#: src/olympia/users/models.py:489
 msgid "Please confirm your email address"
 msgstr ""
 
-#: src/olympia/users/models.py:506
+#: src/olympia/users/models.py:515
 msgid "My Mobile Add-ons"
 msgstr ""
 
@@ -11986,7 +11819,7 @@ msgstr ""
 
 #: src/olympia/users/templates/users/edit.html:70
 #, python-format
-msgid "Change your password.  If you forgot your password, you can <a href=\"%(reset_url)s\">use the reset form</a>."
+msgid "Change your password. If you forgot your password, you can <a href=\"%(reset_url)s\">use the reset form</a>."
 msgstr ""
 
 #: src/olympia/users/templates/users/edit.html:76
@@ -12006,7 +11839,7 @@ msgid "Profile"
 msgstr ""
 
 #: src/olympia/users/templates/users/edit.html:100
-msgid "Give us a bit more information about yourself.  All these fields are optional, but they'll help other users get to know you better."
+msgid "Give us a bit more information about yourself. All these fields are optional, but they'll help other users get to know you better."
 msgstr ""
 
 #: src/olympia/users/templates/users/edit.html:124
@@ -12222,7 +12055,7 @@ msgid "Confirm password"
 msgstr ""
 
 #: src/olympia/users/templates/users/pwreset_confirm.html:47
-msgid "The password reset link was invalid, possibly because it has already been used.  Please request a new password reset."
+msgid "The password reset link was invalid, possibly because it has already been used. Please request a new password reset."
 msgstr ""
 
 #: src/olympia/users/templates/users/pwreset_request.html:15
@@ -12408,7 +12241,7 @@ msgstr ""
 
 #: src/olympia/users/templates/users/unsubscribe.html:30
 #, python-format
-msgid "Unfortunately, we weren't able to unsubscribe you.  The link you clicked is invalid. However, you can unsubscribe still unsubscribe on your <a href=\"%(edit_url)s\">edit profile page</a>."
+msgid "Unfortunately, we weren't able to unsubscribe you. The link you clicked is invalid. However, you can unsubscribe still unsubscribe on your <a href=\"%(edit_url)s\">edit profile page</a>."
 msgstr ""
 
 #: src/olympia/users/templates/users/vcard.html:2
@@ -12462,15 +12295,15 @@ msgstr ""
 msgid "Version History with Changelogs"
 msgstr ""
 
-#: src/olympia/versions/models.py:314
+#: src/olympia/versions/models.py:313
 msgid "Add-on uses binary components."
 msgstr ""
 
-#: src/olympia/versions/models.py:317
+#: src/olympia/versions/models.py:316
 msgid "Add-on has opted into strict compatibility checking."
 msgstr ""
 
-#: src/olympia/versions/models.py:715
+#: src/olympia/versions/models.py:711
 msgid "{app} {min} and later"
 msgstr ""
 
@@ -12545,4 +12378,8 @@ msgstr ""
 
 #: src/olympia/zadmin/forms.py:105
 msgid "Log emails instead of sending"
+msgstr ""
+
+#: src/olympia/zadmin/forms.py:215
+msgid "Deleted versions can`t be changed."
 msgstr ""

--- a/locale/ms/LC_MESSAGES/djangojs.po
+++ b/locale/ms/LC_MESSAGES/djangojs.po
@@ -1,1216 +1,1236 @@
-
 #, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2016-02-24 21:23+0000\n"
+"POT-Creation-Date: 2016-04-18 15:47+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
+"Language: \n"
 "MIME-Version: 1.0\n"
-"Content-Type: text/plain; charset=utf-8\n"
+"Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Generated-By: Babel 2.2.0\n"
 
-#: static/js/common/ratingwidget.js:31
+#: static/js/common-all.js:1426 static/js/impala-all.js:1511 static/js/zamboni/discovery-all.js:12598 static/js/zamboni/init.js:28 static/js/zamboni/mobile-all.js:14945
+msgid "This feature is temporarily disabled while we perform website maintenance. Please check back a little later."
+msgstr ""
+
+#. L10n: {0} is an app name like Firefox.
+#: static/js/common-all.js:1837 static/js/impala-all.js:1922 static/js/zamboni/buttons.js:73 static/js/zamboni/discovery-all.js:13108
+msgid "Accept and Install"
+msgstr ""
+
+#: static/js/common-all.js:1837 static/js/impala-all.js:1922 static/js/zamboni/buttons.js:73 static/js/zamboni/discovery-all.js:13108
+msgid "Add to {0}"
+msgstr ""
+
+#: static/js/common-all.js:1842 static/js/impala-all.js:1927 static/js/zamboni/buttons.js:78 static/js/zamboni/discovery-all.js:13113
+msgid "Download Now"
+msgstr ""
+
+#: static/js/common-all.js:1883 static/js/impala-all.js:1968 static/js/zamboni/buttons.js:119 static/js/zamboni/discovery-all.js:13154
+msgid "Add-on has not been updated to support default-to-compatible."
+msgstr ""
+
+#: static/js/common-all.js:1888 static/js/impala-all.js:1973 static/js/zamboni/buttons.js:124 static/js/zamboni/discovery-all.js:13159
+msgid "You need to be using Firefox 10.0 or higher."
+msgstr ""
+
+#: static/js/common-all.js:1900 static/js/impala-all.js:1985 static/js/zamboni/buttons.js:136 static/js/zamboni/discovery-all.js:13171
+msgid "Mozilla has marked this version as incompatible with your Firefox version."
+msgstr ""
+
+#. L10n: {0} is an platform like Windows or Linux.
+#: static/js/common-all.js:1981 static/js/impala-all.js:2066 static/js/zamboni/buttons.js:217 static/js/zamboni/discovery-all.js:13252
+msgid "Install for {0} anyway"
+msgstr ""
+
+#: static/js/common-all.js:1981 static/js/impala-all.js:2066 static/js/zamboni/buttons.js:217 static/js/zamboni/discovery-all.js:13252
+msgid "Download for {0} anyway"
+msgstr ""
+
+#: static/js/common-all.js:2038 static/js/impala-all.js:2123 static/js/zamboni/buttons.js:274 static/js/zamboni/discovery-all.js:13309
+msgid "Not available for your platform"
+msgstr ""
+
+#. L10n: {0} is an app name, {1} is the app version.
+#: static/js/common-all.js:2049 static/js/common-all.js:2086 static/js/impala-all.js:2134 static/js/impala-all.js:2171 static/js/zamboni/buttons.js:286 static/js/zamboni/buttons.js:324
+#: static/js/zamboni/discovery-all.js:13320 static/js/zamboni/discovery-all.js:13357
+msgid "Not available for {0} {1}"
+msgstr ""
+
+#: static/js/common-all.js:2112 static/js/impala-all.js:2197 static/js/zamboni/buttons.js:351 static/js/zamboni/discovery-all.js:13383
+msgid "Works with {app} {min} - {max}"
+msgstr ""
+
+#: static/js/common-all.js:2114 static/js/impala-all.js:2199 static/js/zamboni/buttons.js:353 static/js/zamboni/discovery-all.js:13385
+msgid "View other versions"
+msgstr ""
+
+#: static/js/common-all.js:2162 static/js/impala-all.js:2247 static/js/zamboni/buttons.js:401 static/js/zamboni/discovery-all.js:13433
+msgid "Only with Firefox — Get Firefox Now!"
+msgstr ""
+
+#: static/js/common-all.js:2278 static/js/impala-all.js:2363 static/js/zamboni/buttons.js:517 static/js/zamboni/discovery-all.js:13549 static/js/zamboni/mobile-all.js:15177
+#: static/js/zamboni/mobile/buttons.js:43
+msgid "Sorry, you need a Mozilla-based browser (such as Firefox) to install a search plugin."
+msgstr ""
+
+#: static/js/common-all.js:9088 static/js/impala-all.js:9649 static/js/zamboni/global.js:410
+msgid "Loading..."
+msgstr ""
+
+#. L10n: {0} is the number of characters left.
+#: static/js/common-all.js:9152 static/js/impala-all.js:9713 static/js/zamboni/global.js:474
+msgid "<b>{0}</b> character left."
+msgid_plural "<b>{0}</b> characters left."
+msgstr[0] ""
+msgstr[1] ""
+
+#: static/js/common-all.js:9589 static/js/common-min.js:6 static/js/impala-all.js:10052 static/js/impala-min.js:6 static/js/common/ratingwidget.js:31 static/js/zamboni/mobile-all.js:16123
+#: static/js/zamboni/mobile-min.js:6
 msgid "{0} star"
 msgid_plural "{0} stars"
 msgstr[0] ""
 msgstr[1] ""
 
-#: static/js/common/upload-addon.js:41 static/js/common/upload-image.js:128
+#: static/js/common-all.js:9676 static/js/common-min.js:6 static/js/impala-all.js:10139 static/js/impala-min.js:6 static/js/zamboni/l10n.js:45
+msgid "Remove this localization"
+msgstr ""
+
+#: static/js/common-all.js:10193 static/js/common-min.js:6 static/js/impala-all.js:10674 static/js/impala-min.js:6 static/js/zamboni/discovery-all.js:13678
+msgid "close"
+msgstr ""
+
+#: static/js/common-all.js:10860 static/js/common-min.js:6 static/js/impala-all.js:11481 static/js/impala-min.js:6 static/js/impala/reviews.js:23 static/js/zamboni/reviews.js:18
+msgid "Flagged for review"
+msgstr ""
+
+#: static/js/common-all.js:10876 static/js/common-min.js:6 static/js/impala-all.js:11498 static/js/impala-min.js:6 static/js/impala/reviews.js:40 static/js/zamboni/reviews.js:34
+msgid "Your input is required"
+msgstr ""
+
+#: static/js/common-all.js:10945 static/js/common-min.js:6 static/js/impala-all.js:11610 static/js/impala-min.js:7 static/js/impala/reviews.js:152 static/js/zamboni/reviews.js:103
+msgid "Marked for deletion"
+msgstr ""
+
+#: static/js/common-all.js:11573 static/js/common-min.js:7 static/js/impala-all.js:13809 static/js/impala-min.js:8 static/js/zamboni/collections.js:229
+msgid "Adding to Favorites&hellip;"
+msgstr ""
+
+#: static/js/common-all.js:11576 static/js/common-min.js:7 static/js/impala-all.js:13812 static/js/impala-min.js:8 static/js/zamboni/collections.js:232
+msgid "Removing Favorite&hellip;"
+msgstr ""
+
+#: static/js/common-all.js:11579 static/js/common-min.js:7 static/js/impala-all.js:13815 static/js/impala-min.js:8 static/js/zamboni/collections.js:235
+msgid "Add to Favorites"
+msgstr ""
+
+#: static/js/common-all.js:11582 static/js/common-min.js:7 static/js/impala-all.js:13818 static/js/impala-min.js:8 static/js/zamboni/collections.js:238
+msgid "Remove from Favorites"
+msgstr ""
+
+#: static/js/common-all.js:11647 static/js/common-min.js:7 static/js/impala-all.js:13883 static/js/impala-min.js:8 static/js/zamboni/collections.js:303
+msgid "Pending"
+msgstr ""
+
+#: static/js/common-all.js:11648 static/js/common-min.js:7 static/js/impala-all.js:13884 static/js/impala-min.js:8 static/js/zamboni/collections.js:304
+msgid "Add a comment"
+msgstr ""
+
+#: static/js/common-all.js:11648 static/js/common-min.js:7 static/js/impala-all.js:13884 static/js/impala-min.js:8 static/js/zamboni/collections.js:304
+msgid "Comment"
+msgstr ""
+
+#: static/js/common-all.js:11649 static/js/common-min.js:7 static/js/impala-all.js:13885 static/js/impala-min.js:8 static/js/zamboni/collections.js:305
+msgid "Remove this add-on from the collection"
+msgstr ""
+
+#: static/js/common-all.js:11649 static/js/common-all.js:11678 static/js/common-min.js:7 static/js/impala-all.js:13885 static/js/impala-all.js:13914 static/js/impala-min.js:8
+#: static/js/zamboni/collections.js:305 static/js/zamboni/collections.js:334
+msgid "Remove"
+msgstr ""
+
+#: static/js/common-all.js:11678 static/js/common-min.js:7 static/js/impala-all.js:13914 static/js/impala-min.js:8 static/js/zamboni/collections.js:334
+msgid "Remove this user as a contributor"
+msgstr ""
+
+#: static/js/common-all.js:11690 static/js/common-min.js:7 static/js/impala-all.js:13926 static/js/impala-min.js:8 static/js/zamboni/collections.js:346
+msgid "An email address is required."
+msgstr ""
+
+#: static/js/common-all.js:11708 static/js/common-min.js:7 static/js/impala-all.js:13944 static/js/impala-min.js:8 static/js/zamboni/collections.js:364
+msgid "You cannot add yourself as a contributor."
+msgstr ""
+
+#: static/js/common-all.js:11710 static/js/common-min.js:7 static/js/impala-all.js:13946 static/js/impala-min.js:8 static/js/zamboni/collections.js:366
+msgid "You have already added that user."
+msgstr ""
+
+#: static/js/common-all.js:11917 static/js/common-min.js:7 static/js/impala-all.js:14153 static/js/impala-min.js:8 static/js/zamboni/collections.js:573
+msgid "Add to favorites"
+msgstr ""
+
+#: static/js/common-all.js:11921 static/js/common-min.js:7 static/js/impala-all.js:14157 static/js/impala-min.js:8 static/js/zamboni/collections.js:577
+msgid "Remove from favorites"
+msgstr ""
+
+#: static/js/common-all.js:11939 static/js/common-min.js:7 static/js/impala-all.js:14175 static/js/impala-all.js:14233 static/js/impala-min.js:8 static/js/impala/collections.js:10
+#: static/js/zamboni/collections.js:595
+msgid "Follow this Collection"
+msgstr ""
+
+#: static/js/common-all.js:11948 static/js/common-min.js:7 static/js/impala-all.js:14184 static/js/impala-min.js:8 static/js/zamboni/collections.js:604
+msgid "Stop following"
+msgstr ""
+
+#: static/js/common-all.js:12096 static/js/common-min.js:7 static/js/zamboni/password-strength.js:20
+msgid "Password strength:"
+msgstr ""
+
+#: static/js/common-all.js:12102 static/js/common-min.js:7 static/js/zamboni/password-strength.js:26
+msgid "At least {0} character left."
+msgid_plural "At least {0} characters left."
+msgstr[0] ""
+msgstr[1] ""
+
+#: static/js/common-all.js:12286 static/js/common-min.js:7 static/js/impala-all.js:14632 static/js/impala-min.js:8 static/js/impala/suggestions.js:39
+msgid "Search themes for <b>{0}</b>"
+msgstr ""
+
+#: static/js/common-all.js:12288 static/js/common-min.js:7 static/js/impala-all.js:14634 static/js/impala-min.js:8 static/js/impala/suggestions.js:41
+msgid "Search apps for <b>{0}</b>"
+msgstr ""
+
+#: static/js/common-all.js:12290 static/js/common-min.js:7 static/js/impala-all.js:14636 static/js/impala-min.js:8 static/js/impala/suggestions.js:43
+msgid "Search add-ons for <b>{0}</b>"
+msgstr ""
+
+#: static/js/common-all.js:12521 static/js/common-min.js:7 static/js/impala-all.js:14867 static/js/impala-min.js:8 static/js/impala/site_suggestions.js:46
+msgid "Category"
+msgstr ""
+
+#. L10n: {0} is an app name.
+#: static/js/impala-all.js:11632 static/js/impala-min.js:7 static/js/impala/listing.js:11 static/js/zamboni/themes.js:13
+msgid "This theme is incompatible with your version of {0}"
+msgstr ""
+
+#: static/js/impala-all.js:12146 static/js/impala-all.js:14331 static/js/impala-min.js:7 static/js/impala-min.js:8 static/js/common/upload-image.js:97 static/js/impala/users.js:51
+#: static/js/zamboni/devhub-all.js:894 static/js/zamboni/devhub-min.js:1
+msgid "Images must be either PNG or JPG."
+msgstr ""
+
+#: static/js/impala-all.js:12150 static/js/impala-min.js:7 static/js/common/upload-image.js:101 static/js/zamboni/devhub-all.js:898 static/js/zamboni/devhub-min.js:1
+msgid "Videos must be in WebM."
+msgstr ""
+
+#: static/js/impala-all.js:12177 static/js/impala-min.js:7 static/js/common/upload-addon.js:41 static/js/common/upload-image.js:128 static/js/zamboni/devhub-all.js:272
+#: static/js/zamboni/devhub-all.js:925 static/js/zamboni/devhub-min.js:1
 msgid "There was a problem contacting the server."
 msgstr ""
 
-#: static/js/common/upload-addon.js:69
+#: static/js/impala-all.js:13298 static/js/impala-min.js:7 static/js/impala/persona_creation.js:60
+msgid "All Rights Reserved"
+msgstr ""
+
+#: static/js/impala-all.js:13302 static/js/impala-min.js:7 static/js/impala/persona_creation.js:64
+msgid "Creative Commons Attribution 3.0"
+msgstr ""
+
+#: static/js/impala-all.js:13307 static/js/impala-min.js:7 static/js/impala/persona_creation.js:69
+msgid "Creative Commons Attribution-NonCommercial 3.0"
+msgstr ""
+
+#: static/js/impala-all.js:13312 static/js/impala-min.js:7 static/js/impala/persona_creation.js:74
+msgid "Creative Commons Attribution-NonCommercial-NoDerivs 3.0"
+msgstr ""
+
+#: static/js/impala-all.js:13317 static/js/impala-min.js:7 static/js/impala/persona_creation.js:79
+msgid "Creative Commons Attribution-NonCommercial-Share Alike 3.0"
+msgstr ""
+
+#: static/js/impala-all.js:13322 static/js/impala-min.js:7 static/js/impala/persona_creation.js:84
+msgid "Creative Commons Attribution-NoDerivs 3.0"
+msgstr ""
+
+#: static/js/impala-all.js:13327 static/js/impala-min.js:7 static/js/impala/persona_creation.js:89
+msgid "Creative Commons Attribution-ShareAlike 3.0"
+msgstr ""
+
+#: static/js/impala-all.js:13530 static/js/impala-min.js:7 static/js/impala/persona_creation.js:292
+msgid "Your Theme's Name"
+msgstr ""
+
+#: static/js/impala-all.js:14242 static/js/impala-min.js:8 static/js/impala/collections.js:19
+msgid "Stop Following"
+msgstr ""
+
+#: static/js/impala-all.js:14243 static/js/impala-min.js:8 static/js/impala/collections.js:20
+msgid "Following"
+msgstr ""
+
+#: static/js/impala-all.js:14313 static/js/impala-min.js:8 static/js/impala/users.js:33
+msgid "use original"
+msgstr ""
+
+#: static/js/impala-all.js:14523 static/js/impala-min.js:8 static/js/impala/search.js:114
+msgid "Updating results&hellip;"
+msgstr ""
+
+#: static/js/common/upload-addon.js:69 static/js/zamboni/devhub-all.js:300 static/js/zamboni/devhub-min.js:1
 msgid "Select a file..."
 msgstr ""
 
-#: static/js/common/upload-addon.js:70
+#: static/js/common/upload-addon.js:70 static/js/zamboni/devhub-all.js:301 static/js/zamboni/devhub-min.js:1
 msgid "Your add-on should end with .xpi, .jar or .xml"
 msgstr ""
 
 #. L10n: {0} is the percent of the file that has been uploaded.
-#: static/js/common/upload-addon.js:104
+#: static/js/common/upload-addon.js:104 static/js/zamboni/devhub-all.js:335 static/js/zamboni/devhub-min.js:1
 #, python-format
 msgid "{0}% complete"
 msgstr ""
 
 #. L10n: "{bytes uploaded} of {total filesize}".
-#: static/js/common/upload-addon.js:107
+#: static/js/common/upload-addon.js:107 static/js/zamboni/devhub-all.js:338 static/js/zamboni/devhub-min.js:1
 msgid "{0} of {1}"
 msgstr ""
 
-#: static/js/common/upload-addon.js:140
+#: static/js/common/upload-addon.js:140 static/js/zamboni/devhub-all.js:371 static/js/zamboni/devhub-min.js:1
 msgid "Cancel"
 msgstr ""
 
-#: static/js/common/upload-addon.js:162
+#: static/js/common/upload-addon.js:162 static/js/zamboni/devhub-all.js:393 static/js/zamboni/devhub-min.js:1
 msgid "Uploading {0}"
 msgstr ""
 
-#: static/js/common/upload-addon.js:189
+#: static/js/common/upload-addon.js:189 static/js/zamboni/devhub-all.js:420 static/js/zamboni/devhub-min.js:1
 msgid "Error with {0}"
 msgstr ""
 
-#: static/js/common/upload-addon.js:194
+#: static/js/common/upload-addon.js:194 static/js/zamboni/devhub-all.js:425 static/js/zamboni/devhub-min.js:1
 msgid "Your add-on failed validation with {0} error."
 msgid_plural "Your add-on failed validation with {0} errors."
 msgstr[0] ""
 msgstr[1] ""
 
-#: static/js/common/upload-addon.js:208
+#: static/js/common/upload-addon.js:208 static/js/zamboni/devhub-all.js:439 static/js/zamboni/devhub-min.js:1
 msgid "&hellip;and {0} more"
 msgid_plural "&hellip;and {0} more"
 msgstr[0] ""
 msgstr[1] ""
 
-#: static/js/common/upload-addon.js:222 static/js/common/upload-addon.js:512
+#: static/js/common/upload-addon.js:222 static/js/common/upload-addon.js:497 static/js/zamboni/devhub-all.js:453 static/js/zamboni/devhub-all.js:743 static/js/zamboni/devhub-min.js:1
 msgid "See full validation report"
 msgstr ""
 
-#: static/js/common/upload-addon.js:234
+#: static/js/common/upload-addon.js:234 static/js/zamboni/devhub-all.js:465 static/js/zamboni/devhub-min.js:1
 msgid "Validating {0}"
 msgstr ""
 
 #. L10n: first argument is an HTTP status code
-#: static/js/common/upload-addon.js:273
+#: static/js/common/upload-addon.js:273 static/js/zamboni/devhub-all.js:504 static/js/zamboni/devhub-min.js:1
 msgid "Received an empty response from the server; status: {0}"
 msgstr ""
 
-#: static/js/common/upload-addon.js:373
+#: static/js/common/upload-addon.js:370 static/js/zamboni/devhub-all.js:604 static/js/zamboni/devhub-min.js:1
 msgid "Unexpected server error while validating."
 msgstr ""
 
-#: static/js/common/upload-addon.js:412
+#: static/js/common/upload-addon.js:409 static/js/zamboni/devhub-all.js:643 static/js/zamboni/devhub-min.js:1
 msgid "Finished validating {0}"
 msgstr ""
 
-#: static/js/common/upload-addon.js:418
+#: static/js/common/upload-addon.js:415 static/js/zamboni/devhub-all.js:649 static/js/zamboni/devhub-min.js:1
 msgid "Your add-on validation timed out, it will be manually reviewed."
 msgstr ""
 
-#: static/js/common/upload-addon.js:421
+#: static/js/common/upload-addon.js:418 static/js/zamboni/devhub-all.js:652 static/js/zamboni/devhub-min.js:1
 msgid "Your add-on was validated with no errors and {0} warning."
 msgid_plural "Your add-on was validated with no errors and {0} warnings."
 msgstr[0] ""
 msgstr[1] ""
 
-#: static/js/common/upload-addon.js:426
+#: static/js/common/upload-addon.js:423 static/js/zamboni/devhub-all.js:657 static/js/zamboni/devhub-min.js:1
 msgid "Your add-on was validated with no errors and {0} message."
 msgid_plural "Your add-on was validated with no errors and {0} messages."
 msgstr[0] ""
 msgstr[1] ""
 
-#: static/js/common/upload-addon.js:431
+#: static/js/common/upload-addon.js:428 static/js/zamboni/devhub-all.js:662 static/js/zamboni/devhub-min.js:1
 msgid "Your add-on was validated with no errors or warnings."
 msgstr ""
 
-#: static/js/common/upload-addon.js:446
+#: static/js/common/upload-addon.js:443 static/js/zamboni/devhub-all.js:677 static/js/zamboni/devhub-min.js:1
 msgid "Your submission will be automatically signed."
 msgstr ""
 
-#: static/js/common/upload-addon.js:465
+#: static/js/common/upload-addon.js:450 static/js/zamboni/devhub-all.js:696 static/js/zamboni/devhub-min.js:1
 msgid "Include detailed version notes (this can be done in the next step)."
 msgstr ""
 
-#: static/js/common/upload-addon.js:466
+#: static/js/common/upload-addon.js:451 static/js/zamboni/devhub-all.js:697 static/js/zamboni/devhub-min.js:1
 msgid "If your add-on requires an account to a website in order to be fully tested, include a test username and password in the Notes to Reviewer (this can be done in the next step)."
 msgstr ""
 
-#: static/js/common/upload-addon.js:467
+#: static/js/common/upload-addon.js:452 static/js/zamboni/devhub-all.js:698 static/js/zamboni/devhub-min.js:1
 msgid "If your add-on is intended for a limited audience you should choose Preliminary Review instead of Full Review."
 msgstr ""
 
-#: static/js/common/upload-addon.js:480
+#: static/js/common/upload-addon.js:465 static/js/zamboni/devhub-all.js:711 static/js/zamboni/devhub-min.js:1
 msgid "Add-on submission checklist"
 msgstr ""
 
-#: static/js/common/upload-addon.js:481
+#: static/js/common/upload-addon.js:466 static/js/zamboni/devhub-all.js:712 static/js/zamboni/devhub-min.js:1
 msgid "Please verify the following points before finalizing your submission. This will minimize delays or misunderstanding during the review process:"
 msgstr ""
 
-#: static/js/common/upload-addon.js:483
+#: static/js/common/upload-addon.js:468 static/js/zamboni/devhub-all.js:714 static/js/zamboni/devhub-min.js:1
 msgid ""
 "Compiled binaries, as well as minified or obfuscated scripts (excluding known libraries) need to have their sources submitted separately for review. Make sure that you use the source code upload "
 "field to avoid having your submission rejected."
 msgstr ""
 
-#: static/js/common/upload-addon.js:501
+#: static/js/common/upload-addon.js:486 static/js/zamboni/devhub-all.js:732 static/js/zamboni/devhub-min.js:1
 msgid "The validation process found these issues that can lead to rejections:"
 msgstr ""
 
-#: static/js/common/upload-addon.js:518
+#: static/js/common/upload-addon.js:503 static/js/zamboni/devhub-all.js:749 static/js/zamboni/devhub-min.js:1
 msgid "If you are unfamiliar with the add-ons review process, you can read about it here."
 msgstr ""
 
-#: static/js/common/upload-addon.js:555
+#: static/js/common/upload-addon.js:540 static/js/zamboni/devhub-all.js:786 static/js/zamboni/devhub-min.js:1
 msgid "Sorry, no supported platform has been found."
 msgstr ""
 
-#: static/js/common/upload-base.js:57
+#: static/js/common/upload-base.js:57 static/js/zamboni/devhub-all.js:187 static/js/zamboni/devhub-min.js:1
 msgid "The filetype you uploaded isn't recognized."
 msgstr ""
 
-#: static/js/common/upload-base.js:79
+#: static/js/common/upload-base.js:79 static/js/zamboni/devhub-all.js:209 static/js/zamboni/devhub-min.js:1
 msgid "You cancelled the upload."
 msgstr ""
 
-#: static/js/common/upload-image.js:97 static/js/impala/users.js:51
-msgid "Images must be either PNG or JPG."
-msgstr ""
-
-#: static/js/common/upload-image.js:101
-msgid "Videos must be in WebM."
-msgstr ""
-
-#: static/js/impala/collections.js:10 static/js/zamboni/collections.js:595
-msgid "Follow this Collection"
-msgstr ""
-
-#: static/js/impala/collections.js:19
-msgid "Stop Following"
-msgstr ""
-
-#: static/js/impala/collections.js:20
-msgid "Following"
-msgstr ""
-
-#. L10n: {0} is an app name.
-#: static/js/impala/listing.js:11 static/js/zamboni/themes.js:13
-msgid "This theme is incompatible with your version of {0}"
-msgstr ""
-
-#: static/js/impala/persona_creation.js:60
-msgid "All Rights Reserved"
-msgstr ""
-
-#: static/js/impala/persona_creation.js:64
-msgid "Creative Commons Attribution 3.0"
-msgstr ""
-
-#: static/js/impala/persona_creation.js:69
-msgid "Creative Commons Attribution-NonCommercial 3.0"
-msgstr ""
-
-#: static/js/impala/persona_creation.js:74
-msgid "Creative Commons Attribution-NonCommercial-NoDerivs 3.0"
-msgstr ""
-
-#: static/js/impala/persona_creation.js:79
-msgid "Creative Commons Attribution-NonCommercial-Share Alike 3.0"
-msgstr ""
-
-#: static/js/impala/persona_creation.js:84
-msgid "Creative Commons Attribution-NoDerivs 3.0"
-msgstr ""
-
-#: static/js/impala/persona_creation.js:89
-msgid "Creative Commons Attribution-ShareAlike 3.0"
-msgstr ""
-
-#: static/js/impala/persona_creation.js:292
-msgid "Your Theme's Name"
-msgstr ""
-
-#: static/js/impala/reviews.js:23 static/js/zamboni/reviews.js:18
-msgid "Flagged for review"
-msgstr ""
-
-#: static/js/impala/reviews.js:40 static/js/zamboni/reviews.js:34
-msgid "Your input is required"
-msgstr ""
-
-#: static/js/impala/reviews.js:152 static/js/zamboni/reviews.js:103
-msgid "Marked for deletion"
-msgstr ""
-
-#: static/js/impala/search.js:114
-msgid "Updating results&hellip;"
-msgstr ""
-
-#: static/js/impala/site_suggestions.js:46
-msgid "Category"
-msgstr ""
-
-#: static/js/impala/suggestions.js:39
-msgid "Search themes for <b>{0}</b>"
-msgstr ""
-
-#: static/js/impala/suggestions.js:41
-msgid "Search apps for <b>{0}</b>"
-msgstr ""
-
-#: static/js/impala/suggestions.js:43
-msgid "Search add-ons for <b>{0}</b>"
-msgstr ""
-
-#: static/js/impala/users.js:33
-msgid "use original"
-msgstr ""
-
-#: static/js/impala/stats/chart.js:267
+#: static/js/impala/stats/chart.js:267 static/js/zamboni/stats-all.js:16898 static/js/zamboni/stats-min.js:5
 msgid "Week of {0}"
 msgstr ""
 
-#: static/js/impala/stats/chart.js:269
+#: static/js/impala/stats/chart.js:269 static/js/zamboni/stats-all.js:16900 static/js/zamboni/stats-min.js:5
 msgid " downloads"
 msgstr ""
 
-#: static/js/impala/stats/chart.js:270
+#: static/js/impala/stats/chart.js:270 static/js/zamboni/stats-all.js:16901 static/js/zamboni/stats-min.js:5
 msgid "{0} users"
 msgstr ""
 
-#: static/js/impala/stats/chart.js:271
+#: static/js/impala/stats/chart.js:271 static/js/zamboni/stats-all.js:16902 static/js/zamboni/stats-min.js:5
 msgid "{0} add-ons"
 msgstr ""
 
-#: static/js/impala/stats/chart.js:272
+#: static/js/impala/stats/chart.js:272 static/js/zamboni/stats-all.js:16903 static/js/zamboni/stats-min.js:5
 msgid "{0} collections"
 msgstr ""
 
-#: static/js/impala/stats/chart.js:273
+#: static/js/impala/stats/chart.js:273 static/js/zamboni/stats-all.js:16904 static/js/zamboni/stats-min.js:5
 msgid "{0} reviews"
 msgstr ""
 
-#: static/js/impala/stats/chart.js:275
+#: static/js/impala/stats/chart.js:275 static/js/zamboni/stats-all.js:16906 static/js/zamboni/stats-min.js:5
 msgid "{0} sales"
 msgstr ""
 
-#: static/js/impala/stats/chart.js:276
+#: static/js/impala/stats/chart.js:276 static/js/zamboni/stats-all.js:16907 static/js/zamboni/stats-min.js:5
 msgid "{0} refunds"
 msgstr ""
 
-#: static/js/impala/stats/chart.js:277
+#: static/js/impala/stats/chart.js:277 static/js/zamboni/stats-all.js:16908 static/js/zamboni/stats-min.js:5
 msgid "{0} installs"
 msgstr ""
 
-#: static/js/impala/stats/chart.js:369 static/js/impala/stats/csv_keys.js:3 static/js/impala/stats/csv_keys.js:109
+#: static/js/impala/stats/chart.js:369 static/js/impala/stats/csv_keys.js:3 static/js/impala/stats/csv_keys.js:109 static/js/zamboni/stats-all.js:15284 static/js/zamboni/stats-all.js:15390
+#: static/js/zamboni/stats-all.js:17000 static/js/zamboni/stats-min.js:4 static/js/zamboni/stats-min.js:5
 msgid "Downloads"
 msgstr ""
 
-#: static/js/impala/stats/chart.js:379 static/js/impala/stats/csv_keys.js:6 static/js/impala/stats/csv_keys.js:110
+#: static/js/impala/stats/chart.js:379 static/js/impala/stats/csv_keys.js:6 static/js/impala/stats/csv_keys.js:110 static/js/zamboni/stats-all.js:15287 static/js/zamboni/stats-all.js:15391
+#: static/js/zamboni/stats-all.js:17010 static/js/zamboni/stats-min.js:4 static/js/zamboni/stats-min.js:5
 msgid "Daily Users"
 msgstr ""
 
-#: static/js/impala/stats/chart.js:410
+#: static/js/impala/stats/chart.js:410 static/js/zamboni/stats-all.js:17041 static/js/zamboni/stats-min.js:5
 msgid "Amount, in USD"
 msgstr ""
 
-#: static/js/impala/stats/chart.js:421 static/js/impala/stats/csv_keys.js:104
+#: static/js/impala/stats/chart.js:421 static/js/impala/stats/csv_keys.js:104 static/js/zamboni/stats-all.js:15385 static/js/zamboni/stats-all.js:17052 static/js/zamboni/stats-min.js:5
 msgid "Number of Contributions"
 msgstr ""
 
-#: static/js/impala/stats/chart.js:447
+#: static/js/impala/stats/chart.js:447 static/js/zamboni/stats-all.js:17078 static/js/zamboni/stats-min.js:5
 msgid "More Info..."
 msgstr ""
 
 #. L10n: {0} is an ISO-formatted date.
-#: static/js/impala/stats/chart.js:451
+#: static/js/impala/stats/chart.js:451 static/js/zamboni/stats-all.js:17082 static/js/zamboni/stats-min.js:5
 msgid "Details for {0}"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:9
+#: static/js/impala/stats/csv_keys.js:9 static/js/zamboni/stats-all.js:15290 static/js/zamboni/stats-min.js:4
 msgid "Collections Created"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:12
+#: static/js/impala/stats/csv_keys.js:12 static/js/zamboni/stats-all.js:15293 static/js/zamboni/stats-min.js:4
 msgid "Add-ons in Use"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:15
+#: static/js/impala/stats/csv_keys.js:15 static/js/zamboni/stats-all.js:15296 static/js/zamboni/stats-min.js:4
 msgid "Add-ons Created"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:18
+#: static/js/impala/stats/csv_keys.js:18 static/js/zamboni/stats-all.js:15299 static/js/zamboni/stats-min.js:4
 msgid "Add-ons Downloaded"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:21
+#: static/js/impala/stats/csv_keys.js:21 static/js/zamboni/stats-all.js:15302 static/js/zamboni/stats-min.js:4
 msgid "Add-ons Updated"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:24
+#: static/js/impala/stats/csv_keys.js:24 static/js/zamboni/stats-all.js:15305 static/js/zamboni/stats-min.js:4
 msgid "Reviews Written"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:27
+#: static/js/impala/stats/csv_keys.js:27 static/js/zamboni/stats-all.js:15308 static/js/zamboni/stats-min.js:4
 msgid "User Signups"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:30
+#: static/js/impala/stats/csv_keys.js:30 static/js/zamboni/stats-all.js:15311 static/js/zamboni/stats-min.js:4
 msgid "Subscribers"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:33
+#: static/js/impala/stats/csv_keys.js:33 static/js/zamboni/stats-all.js:15314 static/js/zamboni/stats-min.js:4
 msgid "Ratings"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:36 static/js/impala/stats/csv_keys.js:114
+#: static/js/impala/stats/csv_keys.js:36 static/js/impala/stats/csv_keys.js:114 static/js/zamboni/stats-all.js:15317 static/js/zamboni/stats-all.js:15395 static/js/zamboni/stats-min.js:4
+#: static/js/zamboni/stats-min.js:5
 msgid "Sales"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:39 static/js/impala/stats/csv_keys.js:113
+#: static/js/impala/stats/csv_keys.js:39 static/js/impala/stats/csv_keys.js:113 static/js/zamboni/stats-all.js:15320 static/js/zamboni/stats-all.js:15394 static/js/zamboni/stats-min.js:4
+#: static/js/zamboni/stats-min.js:5
 msgid "Installs"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:42
+#: static/js/impala/stats/csv_keys.js:42 static/js/zamboni/stats-all.js:15323 static/js/zamboni/stats-min.js:4
 msgid "Unknown"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:43
+#: static/js/impala/stats/csv_keys.js:43 static/js/zamboni/stats-all.js:15324 static/js/zamboni/stats-min.js:4
 msgid "Add-ons Manager"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:44
+#: static/js/impala/stats/csv_keys.js:44 static/js/zamboni/stats-all.js:15325 static/js/zamboni/stats-min.js:4
 msgid "Add-ons Manager Promo"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:45
+#: static/js/impala/stats/csv_keys.js:45 static/js/zamboni/stats-all.js:15326 static/js/zamboni/stats-min.js:4
 msgid "Add-ons Manager Featured"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:46
+#: static/js/impala/stats/csv_keys.js:46 static/js/zamboni/stats-all.js:15327 static/js/zamboni/stats-min.js:4
 msgid "Add-ons Manager Learn More"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:47
+#: static/js/impala/stats/csv_keys.js:47 static/js/zamboni/stats-all.js:15328 static/js/zamboni/stats-min.js:4
 msgid "Search Suggestions"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:48
+#: static/js/impala/stats/csv_keys.js:48 static/js/zamboni/stats-all.js:15329 static/js/zamboni/stats-min.js:4
 msgid "Search Results"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:49 static/js/impala/stats/csv_keys.js:50 static/js/impala/stats/csv_keys.js:51
+#: static/js/impala/stats/csv_keys.js:49 static/js/impala/stats/csv_keys.js:50 static/js/impala/stats/csv_keys.js:51 static/js/zamboni/stats-all.js:15330 static/js/zamboni/stats-all.js:15331
+#: static/js/zamboni/stats-all.js:15332 static/js/zamboni/stats-min.js:4
 msgid "Homepage Promo"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:52 static/js/impala/stats/csv_keys.js:53
+#: static/js/impala/stats/csv_keys.js:52 static/js/impala/stats/csv_keys.js:53 static/js/zamboni/stats-all.js:15333 static/js/zamboni/stats-all.js:15334 static/js/zamboni/stats-min.js:4
 msgid "Homepage Featured"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:54 static/js/impala/stats/csv_keys.js:55
+#: static/js/impala/stats/csv_keys.js:54 static/js/impala/stats/csv_keys.js:55 static/js/zamboni/stats-all.js:15335 static/js/zamboni/stats-all.js:15336 static/js/zamboni/stats-min.js:4
 msgid "Homepage Up and Coming"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:56
+#: static/js/impala/stats/csv_keys.js:56 static/js/zamboni/stats-all.js:15337 static/js/zamboni/stats-min.js:4
 msgid "Homepage Most Popular"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:57 static/js/impala/stats/csv_keys.js:59
+#: static/js/impala/stats/csv_keys.js:57 static/js/impala/stats/csv_keys.js:59 static/js/zamboni/stats-all.js:15338 static/js/zamboni/stats-all.js:15340 static/js/zamboni/stats-min.js:4
 msgid "Detail Page"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:58 static/js/impala/stats/csv_keys.js:60
+#: static/js/impala/stats/csv_keys.js:58 static/js/impala/stats/csv_keys.js:60 static/js/zamboni/stats-all.js:15339 static/js/zamboni/stats-all.js:15341 static/js/zamboni/stats-min.js:4
 msgid "Detail Page (bottom)"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:61
+#: static/js/impala/stats/csv_keys.js:61 static/js/zamboni/stats-all.js:15342 static/js/zamboni/stats-min.js:4
 msgid "Detail Page (Development Channel)"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:62 static/js/impala/stats/csv_keys.js:63 static/js/impala/stats/csv_keys.js:64
+#: static/js/impala/stats/csv_keys.js:62 static/js/impala/stats/csv_keys.js:63 static/js/impala/stats/csv_keys.js:64 static/js/zamboni/stats-all.js:15343 static/js/zamboni/stats-all.js:15344
+#: static/js/zamboni/stats-all.js:15345 static/js/zamboni/stats-min.js:4
 msgid "Often Used With"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:65 static/js/impala/stats/csv_keys.js:66
+#: static/js/impala/stats/csv_keys.js:65 static/js/impala/stats/csv_keys.js:66 static/js/zamboni/stats-all.js:15346 static/js/zamboni/stats-all.js:15347 static/js/zamboni/stats-min.js:4
 msgid "Others By Author"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:67 static/js/impala/stats/csv_keys.js:68
+#: static/js/impala/stats/csv_keys.js:67 static/js/impala/stats/csv_keys.js:68 static/js/zamboni/stats-all.js:15348 static/js/zamboni/stats-all.js:15349 static/js/zamboni/stats-min.js:4
 msgid "Dependencies"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:69 static/js/impala/stats/csv_keys.js:70
+#: static/js/impala/stats/csv_keys.js:69 static/js/impala/stats/csv_keys.js:70 static/js/zamboni/stats-all.js:15350 static/js/zamboni/stats-all.js:15351 static/js/zamboni/stats-min.js:4
 msgid "Upsell"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:71
+#: static/js/impala/stats/csv_keys.js:71 static/js/zamboni/stats-all.js:15352 static/js/zamboni/stats-min.js:4
 msgid "Meet the Developer"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:72
+#: static/js/impala/stats/csv_keys.js:72 static/js/zamboni/stats-all.js:15353 static/js/zamboni/stats-min.js:4
 msgid "User Profile"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:73
+#: static/js/impala/stats/csv_keys.js:73 static/js/zamboni/stats-all.js:15354 static/js/zamboni/stats-min.js:4
 msgid "Version History"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:75
+#: static/js/impala/stats/csv_keys.js:75 static/js/zamboni/stats-all.js:15356 static/js/zamboni/stats-min.js:4
 msgid "Sharing"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:76
+#: static/js/impala/stats/csv_keys.js:76 static/js/zamboni/stats-all.js:15357 static/js/zamboni/stats-min.js:4
 msgid "Category Pages"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:77
+#: static/js/impala/stats/csv_keys.js:77 static/js/zamboni/stats-all.js:15358 static/js/zamboni/stats-min.js:4
 msgid "Collections"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:78 static/js/impala/stats/csv_keys.js:79
+#: static/js/impala/stats/csv_keys.js:78 static/js/impala/stats/csv_keys.js:79 static/js/zamboni/stats-all.js:15359 static/js/zamboni/stats-all.js:15360 static/js/zamboni/stats-min.js:4
 msgid "Category Landing Featured Carousel"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:80 static/js/impala/stats/csv_keys.js:81
+#: static/js/impala/stats/csv_keys.js:80 static/js/impala/stats/csv_keys.js:81 static/js/zamboni/stats-all.js:15361 static/js/zamboni/stats-all.js:15362 static/js/zamboni/stats-min.js:4
 msgid "Category Landing Top Rated"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:82 static/js/impala/stats/csv_keys.js:83
+#: static/js/impala/stats/csv_keys.js:82 static/js/impala/stats/csv_keys.js:83 static/js/zamboni/stats-all.js:15363 static/js/zamboni/stats-all.js:15364 static/js/zamboni/stats-min.js:5
 msgid "Category Landing Most Popular"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:84 static/js/impala/stats/csv_keys.js:85
+#: static/js/impala/stats/csv_keys.js:84 static/js/impala/stats/csv_keys.js:85 static/js/zamboni/stats-all.js:15365 static/js/zamboni/stats-all.js:15366 static/js/zamboni/stats-min.js:5
 msgid "Category Landing Recently Added"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:86 static/js/impala/stats/csv_keys.js:87
+#: static/js/impala/stats/csv_keys.js:86 static/js/impala/stats/csv_keys.js:87 static/js/zamboni/stats-all.js:15367 static/js/zamboni/stats-all.js:15368 static/js/zamboni/stats-min.js:5
 msgid "Browse Listing Featured Sort"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:88 static/js/impala/stats/csv_keys.js:89
+#: static/js/impala/stats/csv_keys.js:88 static/js/impala/stats/csv_keys.js:89 static/js/zamboni/stats-all.js:15369 static/js/zamboni/stats-all.js:15370 static/js/zamboni/stats-min.js:5
 msgid "Browse Listing Users Sort"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:90 static/js/impala/stats/csv_keys.js:91
+#: static/js/impala/stats/csv_keys.js:90 static/js/impala/stats/csv_keys.js:91 static/js/zamboni/stats-all.js:15371 static/js/zamboni/stats-all.js:15372 static/js/zamboni/stats-min.js:5
 msgid "Browse Listing Rating Sort"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:92 static/js/impala/stats/csv_keys.js:93
+#: static/js/impala/stats/csv_keys.js:92 static/js/impala/stats/csv_keys.js:93 static/js/zamboni/stats-all.js:15373 static/js/zamboni/stats-all.js:15374 static/js/zamboni/stats-min.js:5
 msgid "Browse Listing Created Sort"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:94 static/js/impala/stats/csv_keys.js:95
+#: static/js/impala/stats/csv_keys.js:94 static/js/impala/stats/csv_keys.js:95 static/js/zamboni/stats-all.js:15375 static/js/zamboni/stats-all.js:15376 static/js/zamboni/stats-min.js:5
 msgid "Browse Listing Name Sort"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:96 static/js/impala/stats/csv_keys.js:97
+#: static/js/impala/stats/csv_keys.js:96 static/js/impala/stats/csv_keys.js:97 static/js/zamboni/stats-all.js:15377 static/js/zamboni/stats-all.js:15378 static/js/zamboni/stats-min.js:5
 msgid "Browse Listing Popular Sort"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:98 static/js/impala/stats/csv_keys.js:99
+#: static/js/impala/stats/csv_keys.js:98 static/js/impala/stats/csv_keys.js:99 static/js/zamboni/stats-all.js:15379 static/js/zamboni/stats-all.js:15380 static/js/zamboni/stats-min.js:5
 msgid "Browse Listing Updated Sort"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:100 static/js/impala/stats/csv_keys.js:101
+#: static/js/impala/stats/csv_keys.js:100 static/js/impala/stats/csv_keys.js:101 static/js/zamboni/stats-all.js:15381 static/js/zamboni/stats-all.js:15382 static/js/zamboni/stats-min.js:5
 msgid "Browse Listing Up and Coming Sort"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:105
+#: static/js/impala/stats/csv_keys.js:105 static/js/zamboni/stats-all.js:15386 static/js/zamboni/stats-min.js:5
 msgid "Total Amount Contributed"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:106
+#: static/js/impala/stats/csv_keys.js:106 static/js/zamboni/stats-all.js:15387 static/js/zamboni/stats-min.js:5
 msgid "Average Contribution"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:115
+#: static/js/impala/stats/csv_keys.js:115 static/js/zamboni/stats-all.js:15396 static/js/zamboni/stats-min.js:5
 msgid "Usage"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:118
+#: static/js/impala/stats/csv_keys.js:118 static/js/zamboni/stats-all.js:15399 static/js/zamboni/stats-min.js:5
 msgid "Firefox"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:119
+#: static/js/impala/stats/csv_keys.js:119 static/js/zamboni/stats-all.js:15400 static/js/zamboni/stats-min.js:5
 msgid "Mozilla"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:120
+#: static/js/impala/stats/csv_keys.js:120 static/js/zamboni/stats-all.js:15401 static/js/zamboni/stats-min.js:5
 msgid "Thunderbird"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:121
+#: static/js/impala/stats/csv_keys.js:121 static/js/zamboni/stats-all.js:15402 static/js/zamboni/stats-min.js:5
 msgid "Sunbird"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:122
+#: static/js/impala/stats/csv_keys.js:122 static/js/zamboni/stats-all.js:15403 static/js/zamboni/stats-min.js:5
 msgid "SeaMonkey"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:123
+#: static/js/impala/stats/csv_keys.js:123 static/js/zamboni/stats-all.js:15404 static/js/zamboni/stats-min.js:5
 msgid "Fennec"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:124
+#: static/js/impala/stats/csv_keys.js:124 static/js/zamboni/stats-all.js:15405 static/js/zamboni/stats-min.js:5
 msgid "Android"
 msgstr ""
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:129
+#: static/js/impala/stats/csv_keys.js:129 static/js/zamboni/stats-all.js:15410 static/js/zamboni/stats-min.js:5
 msgid "Downloads and Daily Users, last {0} days"
 msgstr ""
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:131
+#: static/js/impala/stats/csv_keys.js:131 static/js/zamboni/stats-all.js:15412 static/js/zamboni/stats-min.js:5
 msgid "Downloads and Daily Users from {0} to {1}"
 msgstr ""
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:135
+#: static/js/impala/stats/csv_keys.js:135 static/js/zamboni/stats-all.js:15416 static/js/zamboni/stats-min.js:5
 msgid "Installs and Daily Users, last {0} days"
 msgstr ""
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:137
+#: static/js/impala/stats/csv_keys.js:137 static/js/zamboni/stats-all.js:15418 static/js/zamboni/stats-min.js:5
 msgid "Installs and Daily Users from {0} to {1}"
 msgstr ""
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:141
+#: static/js/impala/stats/csv_keys.js:141 static/js/zamboni/stats-all.js:15422 static/js/zamboni/stats-min.js:5
 msgid "Downloads, last {0} days"
 msgstr ""
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:143
+#: static/js/impala/stats/csv_keys.js:143 static/js/zamboni/stats-all.js:15424 static/js/zamboni/stats-min.js:5
 msgid "Downloads from {0} to {1}"
 msgstr ""
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:147
+#: static/js/impala/stats/csv_keys.js:147 static/js/zamboni/stats-all.js:15428 static/js/zamboni/stats-min.js:5
 msgid "Daily Users, last {0} days"
 msgstr ""
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:149
+#: static/js/impala/stats/csv_keys.js:149 static/js/zamboni/stats-all.js:15430 static/js/zamboni/stats-min.js:5
 msgid "Daily Users from {0} to {1}"
 msgstr ""
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:153
+#: static/js/impala/stats/csv_keys.js:153 static/js/zamboni/stats-all.js:15434 static/js/zamboni/stats-min.js:5
 msgid "Applications, last {0} days"
 msgstr ""
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:155
+#: static/js/impala/stats/csv_keys.js:155 static/js/zamboni/stats-all.js:15436 static/js/zamboni/stats-min.js:5
 msgid "Applications from {0} to {1}"
 msgstr ""
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:159
+#: static/js/impala/stats/csv_keys.js:159 static/js/zamboni/stats-all.js:15440 static/js/zamboni/stats-min.js:5
 msgid "Platforms, last {0} days"
 msgstr ""
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:161
+#: static/js/impala/stats/csv_keys.js:161 static/js/zamboni/stats-all.js:15442 static/js/zamboni/stats-min.js:5
 msgid "Platforms from {0} to {1}"
 msgstr ""
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:165
+#: static/js/impala/stats/csv_keys.js:165 static/js/zamboni/stats-all.js:15446 static/js/zamboni/stats-min.js:5
 msgid "Languages, last {0} days"
 msgstr ""
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:167
+#: static/js/impala/stats/csv_keys.js:167 static/js/zamboni/stats-all.js:15448 static/js/zamboni/stats-min.js:5
 msgid "Languages from {0} to {1}"
 msgstr ""
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:171
+#: static/js/impala/stats/csv_keys.js:171 static/js/zamboni/stats-all.js:15452 static/js/zamboni/stats-min.js:5
 msgid "Add-on Versions, last {0} days"
 msgstr ""
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:173
+#: static/js/impala/stats/csv_keys.js:173 static/js/zamboni/stats-all.js:15454 static/js/zamboni/stats-min.js:5
 msgid "Add-on Versions from {0} to {1}"
 msgstr ""
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:177
+#: static/js/impala/stats/csv_keys.js:177 static/js/zamboni/stats-all.js:15458 static/js/zamboni/stats-min.js:5
 msgid "Add-on Status, last {0} days"
 msgstr ""
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:179
+#: static/js/impala/stats/csv_keys.js:179 static/js/zamboni/stats-all.js:15460 static/js/zamboni/stats-min.js:5
 msgid "Add-on Status from {0} to {1}"
 msgstr ""
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:183
+#: static/js/impala/stats/csv_keys.js:183 static/js/zamboni/stats-all.js:15464 static/js/zamboni/stats-min.js:5
 msgid "Download Sources, last {0} days"
 msgstr ""
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:185
+#: static/js/impala/stats/csv_keys.js:185 static/js/zamboni/stats-all.js:15466 static/js/zamboni/stats-min.js:5
 msgid "Download Sources from {0} to {1}"
 msgstr ""
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:189
+#: static/js/impala/stats/csv_keys.js:189 static/js/zamboni/stats-all.js:15470 static/js/zamboni/stats-min.js:5
 msgid "Contributions, last {0} days"
 msgstr ""
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:191
+#: static/js/impala/stats/csv_keys.js:191 static/js/zamboni/stats-all.js:15472 static/js/zamboni/stats-min.js:5
 msgid "Contributions from {0} to {1}"
 msgstr ""
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:195
+#: static/js/impala/stats/csv_keys.js:195 static/js/zamboni/stats-all.js:15476 static/js/zamboni/stats-min.js:5
 msgid "Site Metrics, last {0} days"
 msgstr ""
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:197
+#: static/js/impala/stats/csv_keys.js:197 static/js/zamboni/stats-all.js:15478 static/js/zamboni/stats-min.js:5
 msgid "Site Metrics from {0} to {1}"
 msgstr ""
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:201
+#: static/js/impala/stats/csv_keys.js:201 static/js/zamboni/stats-all.js:15482 static/js/zamboni/stats-min.js:5
 msgid "Add-ons in Use, last {0} days"
 msgstr ""
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:203
+#: static/js/impala/stats/csv_keys.js:203 static/js/zamboni/stats-all.js:15484 static/js/zamboni/stats-min.js:5
 msgid "Add-ons in Use from {0} to {1}"
 msgstr ""
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:207
+#: static/js/impala/stats/csv_keys.js:207 static/js/zamboni/stats-all.js:15488 static/js/zamboni/stats-min.js:5
 msgid "Add-ons Downloaded, last {0} days"
 msgstr ""
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:209
+#: static/js/impala/stats/csv_keys.js:209 static/js/zamboni/stats-all.js:15490 static/js/zamboni/stats-min.js:5
 msgid "Add-ons Downloaded from {0} to {1}"
 msgstr ""
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:213
+#: static/js/impala/stats/csv_keys.js:213 static/js/zamboni/stats-all.js:15494 static/js/zamboni/stats-min.js:5
 msgid "Add-ons Created, last {0} days"
 msgstr ""
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:215
+#: static/js/impala/stats/csv_keys.js:215 static/js/zamboni/stats-all.js:15496 static/js/zamboni/stats-min.js:5
 msgid "Add-ons Created from {0} to {1}"
 msgstr ""
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:219
+#: static/js/impala/stats/csv_keys.js:219 static/js/zamboni/stats-all.js:15500 static/js/zamboni/stats-min.js:5
 msgid "Add-ons Updated, last {0} days"
 msgstr ""
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:221
+#: static/js/impala/stats/csv_keys.js:221 static/js/zamboni/stats-all.js:15502 static/js/zamboni/stats-min.js:5
 msgid "Add-ons Updated from {0} to {1}"
 msgstr ""
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:225
+#: static/js/impala/stats/csv_keys.js:225 static/js/zamboni/stats-all.js:15506 static/js/zamboni/stats-min.js:5
 msgid "Reviews Written, last {0} days"
 msgstr ""
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:227
+#: static/js/impala/stats/csv_keys.js:227 static/js/zamboni/stats-all.js:15508 static/js/zamboni/stats-min.js:5
 msgid "Reviews Written from {0} to {1}"
 msgstr ""
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:231
+#: static/js/impala/stats/csv_keys.js:231 static/js/zamboni/stats-all.js:15512 static/js/zamboni/stats-min.js:5
 msgid "User Signups, last {0} days"
 msgstr ""
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:233
+#: static/js/impala/stats/csv_keys.js:233 static/js/zamboni/stats-all.js:15514 static/js/zamboni/stats-min.js:5
 msgid "User Signups from {0} to {1}"
 msgstr ""
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:237
+#: static/js/impala/stats/csv_keys.js:237 static/js/zamboni/stats-all.js:15518 static/js/zamboni/stats-min.js:5
 msgid "Collections Created, last {0} days"
 msgstr ""
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:239
+#: static/js/impala/stats/csv_keys.js:239 static/js/zamboni/stats-all.js:15520 static/js/zamboni/stats-min.js:5
 msgid "Collections Created from {0} to {1}"
 msgstr ""
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:243
+#: static/js/impala/stats/csv_keys.js:243 static/js/zamboni/stats-all.js:15524 static/js/zamboni/stats-min.js:5
 msgid "Subscribers, last {0} days"
 msgstr ""
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:245
+#: static/js/impala/stats/csv_keys.js:245 static/js/zamboni/stats-all.js:15526 static/js/zamboni/stats-min.js:5
 msgid "Subscribers from {0} to {1}"
 msgstr ""
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:249
+#: static/js/impala/stats/csv_keys.js:249 static/js/zamboni/stats-all.js:15530 static/js/zamboni/stats-min.js:5
 msgid "Ratings, last {0} days"
 msgstr ""
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:251
+#: static/js/impala/stats/csv_keys.js:251 static/js/zamboni/stats-all.js:15532 static/js/zamboni/stats-min.js:5
 msgid "Ratings from {0} to {1}"
 msgstr ""
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:255
+#: static/js/impala/stats/csv_keys.js:255 static/js/zamboni/stats-all.js:15536 static/js/zamboni/stats-min.js:5
 msgid "Sales, last {0} days"
 msgstr ""
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:257
+#: static/js/impala/stats/csv_keys.js:257 static/js/zamboni/stats-all.js:15538 static/js/zamboni/stats-min.js:5
 msgid "Sales from {0} to {1}"
 msgstr ""
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:261
+#: static/js/impala/stats/csv_keys.js:261 static/js/zamboni/stats-all.js:15542 static/js/zamboni/stats-min.js:5
 msgid "Installs, last {0} days"
 msgstr ""
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:263
+#: static/js/impala/stats/csv_keys.js:263 static/js/zamboni/stats-all.js:15544 static/js/zamboni/stats-min.js:5
 msgid "Installs from {0} to {1}"
 msgstr ""
 
 #. L10n: {0} and {1} are integers.
-#: static/js/impala/stats/csv_keys.js:269
+#: static/js/impala/stats/csv_keys.js:269 static/js/zamboni/stats-all.js:15550 static/js/zamboni/stats-min.js:5
 msgid "<b>{0}</b> in last {1} days"
 msgstr ""
 
 #. L10n: {0} is an integer and {1} and {2} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:271 static/js/impala/stats/csv_keys.js:277
+#: static/js/impala/stats/csv_keys.js:271 static/js/impala/stats/csv_keys.js:277 static/js/zamboni/stats-all.js:15552 static/js/zamboni/stats-all.js:15558 static/js/zamboni/stats-min.js:5
 msgid "<b>{0}</b> from {1} to {2}"
 msgstr ""
 
 #. L10n: {0} and {1} are integers.
-#: static/js/impala/stats/csv_keys.js:275
+#: static/js/impala/stats/csv_keys.js:275 static/js/zamboni/stats-all.js:15556 static/js/zamboni/stats-min.js:5
 msgid "<b>{0}</b> average in last {1} days"
 msgstr ""
 
-#: static/js/impala/stats/overview.js:19
+#: static/js/impala/stats/overview.js:19 static/js/zamboni/stats-all.js:16469 static/js/zamboni/stats-min.js:5
 msgid "No data available."
 msgstr ""
 
-#: static/js/impala/stats/table.js:74
+#: static/js/impala/stats/table.js:74 static/js/zamboni/stats-all.js:17209 static/js/zamboni/stats-min.js:5
 msgid "Date"
 msgstr ""
 
-#: static/js/impala/stats/topchart.js:96
+#: static/js/impala/stats/topchart.js:96 static/js/zamboni/stats-all.js:16600 static/js/zamboni/stats-min.js:5
 msgid "Other"
 msgstr ""
 
-#: static/js/zamboni/admin_validation.js:24 static/js/zamboni/devhub.js:1229 static/js/zamboni/editors.js:295
+#: static/js/zamboni/admin-all.js:180 static/js/zamboni/admin-min.js:1 static/js/zamboni/admin_validation.js:24 static/js/zamboni/devhub-all.js:2408 static/js/zamboni/devhub-min.js:2
+#: static/js/zamboni/devhub.js:1229 static/js/zamboni/editors-all.js:15576 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:295
 msgid "Select an application first"
 msgstr ""
 
-#: static/js/zamboni/admin_validation.js:51
+#: static/js/zamboni/admin-all.js:207 static/js/zamboni/admin-min.js:1 static/js/zamboni/admin_validation.js:51
 msgid "Set {0} add-on to a max version of {1} and email the author."
 msgid_plural "Set {0} add-ons to a max version of {1} and email the authors."
 msgstr[0] ""
 msgstr[1] ""
 
-#: static/js/zamboni/admin_validation.js:54
+#: static/js/zamboni/admin-all.js:210 static/js/zamboni/admin-min.js:1 static/js/zamboni/admin_validation.js:54
 msgid "Email author of {2} add-on which failed validation."
 msgid_plural "Email authors of {2} add-ons which failed validation."
 msgstr[0] ""
 msgstr[1] ""
 
-#. L10n: {0} is an app name like Firefox.
-#: static/js/zamboni/buttons.js:66
-msgid "Accept and Install"
-msgstr ""
-
-#: static/js/zamboni/buttons.js:66
-msgid "Add to {0}"
-msgstr ""
-
-#: static/js/zamboni/buttons.js:71
-msgid "Download Now"
-msgstr ""
-
-#: static/js/zamboni/buttons.js:112
-msgid "Add-on has not been updated to support default-to-compatible."
-msgstr ""
-
-#: static/js/zamboni/buttons.js:117
-msgid "You need to be using Firefox 10.0 or higher."
-msgstr ""
-
-#: static/js/zamboni/buttons.js:129
-msgid "Mozilla has marked this version as incompatible with your Firefox version."
-msgstr ""
-
-#. L10n: {0} is an platform like Windows or Linux.
-#: static/js/zamboni/buttons.js:210
-msgid "Install for {0} anyway"
-msgstr ""
-
-#: static/js/zamboni/buttons.js:210
-msgid "Download for {0} anyway"
-msgstr ""
-
-#: static/js/zamboni/buttons.js:267
-msgid "Not available for your platform"
-msgstr ""
-
-#. L10n: {0} is an app name, {1} is the app version.
-#: static/js/zamboni/buttons.js:278 static/js/zamboni/buttons.js:315
-msgid "Not available for {0} {1}"
-msgstr ""
-
-#: static/js/zamboni/buttons.js:341
-msgid "Works with {app} {min} - {max}"
-msgstr ""
-
-#: static/js/zamboni/buttons.js:343
-msgid "View other versions"
-msgstr ""
-
-#: static/js/zamboni/buttons.js:391
-msgid "Only with Firefox — Get Firefox Now!"
-msgstr ""
-
-#: static/js/zamboni/buttons.js:507 static/js/zamboni/mobile/buttons.js:43
-msgid "Sorry, you need a Mozilla-based browser (such as Firefox) to install a search plugin."
-msgstr ""
-
-#: static/js/zamboni/collections.js:229
-msgid "Adding to Favorites&hellip;"
-msgstr ""
-
-#: static/js/zamboni/collections.js:232
-msgid "Removing Favorite&hellip;"
-msgstr ""
-
-#: static/js/zamboni/collections.js:235
-msgid "Add to Favorites"
-msgstr ""
-
-#: static/js/zamboni/collections.js:238
-msgid "Remove from Favorites"
-msgstr ""
-
-#: static/js/zamboni/collections.js:303
-msgid "Pending"
-msgstr ""
-
-#: static/js/zamboni/collections.js:304
-msgid "Add a comment"
-msgstr ""
-
-#: static/js/zamboni/collections.js:304
-msgid "Comment"
-msgstr ""
-
-#: static/js/zamboni/collections.js:305
-msgid "Remove this add-on from the collection"
-msgstr ""
-
-#: static/js/zamboni/collections.js:305 static/js/zamboni/collections.js:334
-msgid "Remove"
-msgstr ""
-
-#: static/js/zamboni/collections.js:334
-msgid "Remove this user as a contributor"
-msgstr ""
-
-#: static/js/zamboni/collections.js:346
-msgid "An email address is required."
-msgstr ""
-
-#: static/js/zamboni/collections.js:364
-msgid "You cannot add yourself as a contributor."
-msgstr ""
-
-#: static/js/zamboni/collections.js:366
-msgid "You have already added that user."
-msgstr ""
-
-#: static/js/zamboni/collections.js:573
-msgid "Add to favorites"
-msgstr ""
-
-#: static/js/zamboni/collections.js:577
-msgid "Remove from favorites"
-msgstr ""
-
-#: static/js/zamboni/collections.js:604
-msgid "Stop following"
-msgstr ""
-
-#: static/js/zamboni/devhub.js:110
+#: static/js/zamboni/devhub-all.js:1289 static/js/zamboni/devhub-min.js:1 static/js/zamboni/devhub.js:110
 msgid "Your browser does not support the video tag"
 msgstr ""
 
-#: static/js/zamboni/devhub.js:371
+#: static/js/zamboni/devhub-all.js:1550 static/js/zamboni/devhub-min.js:1 static/js/zamboni/devhub.js:371
 msgid "Changes Saved"
 msgstr ""
 
-#: static/js/zamboni/devhub.js:387
+#: static/js/zamboni/devhub-all.js:1566 static/js/zamboni/devhub-min.js:1 static/js/zamboni/devhub.js:387
 msgid "Enter a new author's email address"
 msgstr ""
 
-#: static/js/zamboni/devhub.js:536
+#: static/js/zamboni/devhub-all.js:1715 static/js/zamboni/devhub-min.js:1 static/js/zamboni/devhub.js:536
 msgid "There was an error uploading your file."
 msgstr ""
 
-#: static/js/zamboni/devhub.js:681
+#: static/js/zamboni/devhub-all.js:1860 static/js/zamboni/devhub-min.js:1 static/js/zamboni/devhub.js:681
 msgid "{files} file"
 msgid_plural "{files} files"
 msgstr[0] ""
 msgstr[1] ""
 
-#: static/js/zamboni/devhub.js:684
+#: static/js/zamboni/devhub-all.js:1863 static/js/zamboni/devhub-min.js:1 static/js/zamboni/devhub.js:684
 msgid "{reviews} user review"
 msgid_plural "{reviews} user reviews"
 msgstr[0] ""
 msgstr[1] ""
 
-#: static/js/zamboni/devhub.js:796
+#: static/js/zamboni/devhub-all.js:1975 static/js/zamboni/devhub-min.js:2 static/js/zamboni/devhub.js:796
 msgid "Learn more"
 msgstr ""
 
-#: static/js/zamboni/devhub.js:800
+#: static/js/zamboni/devhub-all.js:1979 static/js/zamboni/devhub-min.js:2 static/js/zamboni/devhub.js:800
 msgid "Example"
 msgstr ""
 
-#: static/js/zamboni/devhub.js:1130
+#: static/js/zamboni/devhub-all.js:2309 static/js/zamboni/devhub-min.js:2 static/js/zamboni/devhub.js:1130
 msgid "Image changes being processed"
 msgstr ""
 
-#: static/js/zamboni/devhub.js:1280
+#: static/js/zamboni/devhub-all.js:2459 static/js/zamboni/devhub-min.js:2 static/js/zamboni/devhub.js:1280
 msgid "Must be a valid e-mail address."
+msgstr ""
+
+#: static/js/zamboni/devhub-all.js:2613 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:80
+msgid "All tests passed successfully."
+msgstr ""
+
+#: static/js/zamboni/devhub-all.js:2616 static/js/zamboni/devhub-all.js:3011 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:83 static/js/zamboni/validator.js:478
+msgid "These tests were not run."
+msgstr ""
+
+#: static/js/zamboni/devhub-all.js:2664 static/js/zamboni/devhub-all.js:2677 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:131 static/js/zamboni/validator.js:144
+msgid "Tests"
+msgstr ""
+
+#: static/js/zamboni/devhub-all.js:2779 static/js/zamboni/devhub-all.js:3108 static/js/zamboni/devhub-all.js:3127 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:246
+#: static/js/zamboni/validator.js:575 static/js/zamboni/validator.js:594
+msgid "Error"
+msgstr ""
+
+#: static/js/zamboni/devhub-all.js:2780 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:247
+msgid "Warning"
+msgstr ""
+
+#: static/js/zamboni/devhub-all.js:2794 static/js/zamboni/devhub-min.js:2 static/js/zamboni/files-all.js:5657 static/js/zamboni/files-min.js:3 static/js/zamboni/files.js:411
+#: static/js/zamboni/validator.js:261
+msgid "Ignore this message in future updates"
+msgstr ""
+
+#: static/js/zamboni/devhub-all.js:2817 static/js/zamboni/devhub-min.js:2 static/js/zamboni/files-all.js:5663 static/js/zamboni/files-min.js:3 static/js/zamboni/files.js:417
+#: static/js/zamboni/validator.js:284
+msgid "Severity for automated signing:"
+msgstr ""
+
+#: static/js/zamboni/devhub-all.js:2832 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:299
+msgid "Suggestions for passing automated signing:"
+msgstr ""
+
+#: static/js/zamboni/devhub-all.js:2920 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:387
+msgid "Compatibility Tests"
+msgstr ""
+
+#: static/js/zamboni/devhub-all.js:2999 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:466
+msgid "Add-on failed validation."
+msgstr ""
+
+#: static/js/zamboni/devhub-all.js:3001 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:468
+msgid "Add-on passed validation."
+msgstr ""
+
+#: static/js/zamboni/devhub-all.js:3014 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:481
+msgid "{0} error"
+msgid_plural "{0} errors"
+msgstr[0] ""
+msgstr[1] ""
+
+#: static/js/zamboni/devhub-all.js:3016 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:483
+msgid "{0} warning"
+msgid_plural "{0} warnings"
+msgstr[0] ""
+msgstr[1] ""
+
+#: static/js/zamboni/devhub-all.js:3018 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:485
+msgid "{0} notice"
+msgid_plural "{0} notices"
+msgstr[0] ""
+msgstr[1] ""
+
+#: static/js/zamboni/devhub-all.js:3110 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:577
+msgid "Validation task could not complete or completed with errors"
+msgstr ""
+
+#: static/js/zamboni/devhub-all.js:3128 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:595
+msgid "Internal server error"
 msgstr ""
 
 #: static/js/zamboni/devhub_search.js:8
 msgid "No results found."
 msgstr ""
 
-#: static/js/zamboni/editors.js:121
+#: static/js/zamboni/editors-all.js:15402 static/js/zamboni/editors-min.js:4 static/js/zamboni/editors.js:121
 msgid "{name} was viewing this page first."
 msgstr ""
 
-#: static/js/zamboni/editors.js:171
+#: static/js/zamboni/editors-all.js:15452 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:171
 msgid "Receipt checked by app."
 msgstr ""
 
-#: static/js/zamboni/editors.js:173
+#: static/js/zamboni/editors-all.js:15454 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:173
 msgid "Receipt was not checked by app."
 msgstr ""
 
-#: static/js/zamboni/editors.js:244
+#: static/js/zamboni/editors-all.js:15525 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:244
 msgid "{name} was viewing this add-on first."
 msgstr ""
 
-#: static/js/zamboni/editors.js:255
+#: static/js/zamboni/editors-all.js:15536 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:255
 msgid "Loading&hellip;"
 msgstr ""
 
-#: static/js/zamboni/editors.js:260
+#: static/js/zamboni/editors-all.js:15541 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:260
 msgid "Version Notes"
 msgstr ""
 
-#: static/js/zamboni/editors.js:265
+#: static/js/zamboni/editors-all.js:15546 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:265
 msgid "Notes for Reviewers"
 msgstr ""
 
-#: static/js/zamboni/editors.js:270
+#: static/js/zamboni/editors-all.js:15551 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:270
 msgid "No version notes found"
 msgstr ""
 
-#: static/js/zamboni/editors.js:330
+#: static/js/zamboni/editors-all.js:15611 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:330
 msgid "Average Reviews"
 msgstr ""
 
-#: static/js/zamboni/editors.js:386
+#: static/js/zamboni/editors-all.js:15667 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:386
 msgid "Number of Reviews"
 msgstr ""
 
-#: static/js/zamboni/editors.js:445
+#: static/js/zamboni/editors-all.js:15726 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:445
 msgid "Error loading translation"
 msgstr ""
 
-#: static/js/zamboni/files.js:411 static/js/zamboni/validator.js:261
-msgid "Ignore this message in future updates"
-msgstr ""
-
-#: static/js/zamboni/files.js:417 static/js/zamboni/validator.js:284
-msgid "Severity for automated signing:"
-msgstr ""
-
-#: static/js/zamboni/global.js:410
-msgid "Loading..."
-msgstr ""
-
-#. L10n: {0} is the number of characters left.
-#: static/js/zamboni/global.js:474
-msgid "<b>{0}</b> character left."
-msgid_plural "<b>{0}</b> characters left."
-msgstr[0] ""
-msgstr[1] ""
-
-#: static/js/zamboni/init.js:28
-msgid "This feature is temporarily disabled while we perform website maintenance. Please check back a little later."
-msgstr ""
-
-#: static/js/zamboni/l10n.js:45
-msgid "Remove this localization"
-msgstr ""
-
-#: static/js/zamboni/password-strength.js:20
-msgid "Password strength:"
-msgstr ""
-
-#: static/js/zamboni/password-strength.js:26
-msgid "At least {0} character left."
-msgid_plural "At least {0} characters left."
-msgstr[0] ""
-msgstr[1] ""
-
-#: static/js/zamboni/themes_review.js:176
-msgid "Requested Info"
-msgstr ""
-
-#: static/js/zamboni/themes_review.js:177
-msgid "Flagged"
-msgstr ""
-
-#: static/js/zamboni/themes_review.js:178
-msgid "Duplicate"
-msgstr ""
-
-#: static/js/zamboni/themes_review.js:179
-msgid "Rejected"
-msgstr ""
-
-#: static/js/zamboni/themes_review.js:180
-msgid "Approved"
-msgstr ""
-
-#: static/js/zamboni/themes_review.js:424
-msgid "No results found"
-msgstr ""
-
-#: static/js/zamboni/themes_review_templates.js:31
+#: static/js/zamboni/editors-all.js:15975 static/js/zamboni/editors-min.js:5 static/js/zamboni/themes_review_templates.js:31
 msgid "Theme"
 msgstr ""
 
-#: static/js/zamboni/themes_review_templates.js:33
+#: static/js/zamboni/editors-all.js:15977 static/js/zamboni/editors-min.js:5 static/js/zamboni/themes_review_templates.js:33
 msgid "Reviewer"
 msgstr ""
 
-#: static/js/zamboni/themes_review_templates.js:35
+#: static/js/zamboni/editors-all.js:15979 static/js/zamboni/editors-min.js:5 static/js/zamboni/themes_review_templates.js:35
 msgid "Status"
 msgstr ""
 
-#: static/js/zamboni/validator.js:80
-msgid "All tests passed successfully."
+#: static/js/zamboni/editors-all.js:16196 static/js/zamboni/editors-min.js:5 static/js/zamboni/themes_review.js:176
+msgid "Requested Info"
 msgstr ""
 
-#: static/js/zamboni/validator.js:83 static/js/zamboni/validator.js:478
-msgid "These tests were not run."
+#: static/js/zamboni/editors-all.js:16197 static/js/zamboni/editors-min.js:5 static/js/zamboni/themes_review.js:177
+msgid "Flagged"
 msgstr ""
 
-#: static/js/zamboni/validator.js:131 static/js/zamboni/validator.js:144
-msgid "Tests"
+#: static/js/zamboni/editors-all.js:16198 static/js/zamboni/editors-min.js:5 static/js/zamboni/themes_review.js:178
+msgid "Duplicate"
 msgstr ""
 
-#: static/js/zamboni/validator.js:246 static/js/zamboni/validator.js:575 static/js/zamboni/validator.js:594
-msgid "Error"
+#: static/js/zamboni/editors-all.js:16199 static/js/zamboni/editors-min.js:5 static/js/zamboni/themes_review.js:179
+msgid "Rejected"
 msgstr ""
 
-#: static/js/zamboni/validator.js:247
-msgid "Warning"
+#: static/js/zamboni/editors-all.js:16200 static/js/zamboni/editors-min.js:5 static/js/zamboni/themes_review.js:180
+msgid "Approved"
 msgstr ""
 
-#: static/js/zamboni/validator.js:299
-msgid "Suggestions for passing automated signing:"
+#: static/js/zamboni/editors-all.js:16444 static/js/zamboni/editors-min.js:5 static/js/zamboni/themes_review.js:424
+msgid "No results found"
 msgstr ""
 
-#: static/js/zamboni/validator.js:387
-msgid "Compatibility Tests"
-msgstr ""
-
-#: static/js/zamboni/validator.js:466
-msgid "Add-on failed validation."
-msgstr ""
-
-#: static/js/zamboni/validator.js:468
-msgid "Add-on passed validation."
-msgstr ""
-
-#: static/js/zamboni/validator.js:481
-msgid "{0} error"
-msgid_plural "{0} errors"
-msgstr[0] ""
-msgstr[1] ""
-
-#: static/js/zamboni/validator.js:483
-msgid "{0} warning"
-msgid_plural "{0} warnings"
-msgstr[0] ""
-msgstr[1] ""
-
-#: static/js/zamboni/validator.js:485
-msgid "{0} notice"
-msgid_plural "{0} notices"
-msgstr[0] ""
-msgstr[1] ""
-
-#: static/js/zamboni/validator.js:577
-msgid "Validation task could not complete or completed with errors"
-msgstr ""
-
-#: static/js/zamboni/validator.js:595
-msgid "Internal server error"
-msgstr ""
-
-#: static/js/zamboni/mobile/buttons.js:52
+#: static/js/zamboni/mobile-all.js:15186 static/js/zamboni/mobile/buttons.js:52
 msgid "Not Updated for {0} {1}"
 msgstr ""
 
-#: static/js/zamboni/mobile/buttons.js:53
+#: static/js/zamboni/mobile-all.js:15187 static/js/zamboni/mobile/buttons.js:53
 msgid "Requires Newer Version of {0}"
 msgstr ""
 
-#: static/js/zamboni/mobile/buttons.js:54
+#: static/js/zamboni/mobile-all.js:15188 static/js/zamboni/mobile/buttons.js:54
 msgid "Unreviewed"
 msgstr ""
 
-#: static/js/zamboni/mobile/buttons.js:55
+#: static/js/zamboni/mobile-all.js:15189 static/js/zamboni/mobile/buttons.js:55
 msgid "Experimental <span>(Learn More)</span>"
 msgstr ""
 
-#: static/js/zamboni/mobile/buttons.js:56 static/js/zamboni/mobile/buttons.js:57
+#: static/js/zamboni/mobile-all.js:15190 static/js/zamboni/mobile-all.js:15191 static/js/zamboni/mobile/buttons.js:56 static/js/zamboni/mobile/buttons.js:57
 msgid "Not Available for {0}"
 msgstr ""
 
-#: static/js/zamboni/mobile/buttons.js:58
+#: static/js/zamboni/mobile-all.js:15192 static/js/zamboni/mobile/buttons.js:58
 msgid "Experimental"
 msgstr ""
 
-#: static/js/zamboni/mobile/buttons.js:59
+#: static/js/zamboni/mobile-all.js:15193 static/js/zamboni/mobile/buttons.js:59
 msgid "Themes Require Newer Version of {0}"
 msgstr ""
 
-#: static/js/zamboni/mobile/buttons.js:60
+#: static/js/zamboni/mobile-all.js:15194 static/js/zamboni/mobile/buttons.js:60
 msgid "Themes Require {0}"
 msgstr ""
 
-#: static/js/zamboni/mobile/buttons.js:105
+#: static/js/zamboni/mobile-all.js:15239 static/js/zamboni/mobile/buttons.js:105
 msgid "Installing..."
 msgstr ""
 
-#: static/js/zamboni/mobile/buttons.js:125
+#: static/js/zamboni/mobile-all.js:15259 static/js/zamboni/mobile/buttons.js:125
 msgid "This add-on has been preliminarily reviewed by Mozilla."
 msgstr ""
 
-#: static/js/zamboni/mobile/buttons.js:250
+#: static/js/zamboni/mobile-all.js:15384 static/js/zamboni/mobile/buttons.js:250
 msgid "Keep it"
 msgstr ""
 
-#: static/js/zamboni/mobile/general.js:344
+#: static/js/zamboni/mobile-all.js:16049 static/js/zamboni/mobile-min.js:6 static/js/zamboni/mobile/general.js:344
 msgid "You're trying it on!"
 msgstr ""
 
-#: static/js/zamboni/mobile/general.js:356
+#: static/js/zamboni/mobile-all.js:16061 static/js/zamboni/mobile-min.js:6 static/js/zamboni/mobile/general.js:356
 msgid "Added to Firefox"
 msgstr ""
-

--- a/locale/my/LC_MESSAGES/django.po
+++ b/locale/my/LC_MESSAGES/django.po
@@ -3,69 +3,70 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2016-02-24 21:23+0000\n"
+"POT-Creation-Date: 2016-04-18 15:47+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
+"Language: \n"
 "MIME-Version: 1.0\n"
-"Content-Type: text/plain; charset=utf-8\n"
+"Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Generated-By: Babel 2.2.0\n"
 
-#: src/olympia/accounts/views.py:52
+#: src/olympia/accounts/views.py:54
 msgid "Your log in attempt could not be parsed. Please try again."
 msgstr ""
 
-#: src/olympia/accounts/views.py:54
+#: src/olympia/accounts/views.py:56
 msgid "Your Firefox Account could not be found. Please try again."
 msgstr ""
 
-#: src/olympia/accounts/views.py:55
+#: src/olympia/accounts/views.py:57
 msgid "You could not be logged in. Please try again."
 msgstr ""
 
-#: src/olympia/accounts/views.py:57
+#: src/olympia/accounts/views.py:59
 msgid "Your account has already been migrated to Firefox Accounts."
 msgstr ""
 
-#: src/olympia/accounts/views.py:59
+#: src/olympia/accounts/views.py:61
 msgid "Your Firefox Account already exists on this site."
 msgstr ""
 
-#: src/olympia/accounts/views.py:108
+#: src/olympia/accounts/views.py:110
 msgid "Great job!"
 msgstr ""
 
-#: src/olympia/accounts/views.py:109
+#: src/olympia/accounts/views.py:111
 msgid "You can now log in to Add-ons with your Firefox Account."
 msgstr ""
 
-#: src/olympia/accounts/views.py:121
+#: src/olympia/accounts/views.py:123
 msgid "Need help?"
 msgstr ""
 
-#: src/olympia/addons/buttons.py:180
+#: src/olympia/addons/buttons.py:177
 msgid "Download Now"
 msgstr ""
 
-#: src/olympia/addons/buttons.py:182
+#: src/olympia/addons/buttons.py:179
 msgid "Download"
 msgstr ""
 
 #. L10n: please keep &nbsp; in the string so &rarr; does not wrap.
-#: src/olympia/addons/buttons.py:186
+#: src/olympia/addons/buttons.py:183
 msgid "Continue to Download&nbsp;&rarr;"
 msgstr ""
 
-#: src/olympia/addons/buttons.py:202 src/olympia/addons/helpers.py:35 src/olympia/addons/views.py:319 src/olympia/addons/templates/addons/impala/details.html:114
+#: src/olympia/addons/buttons.py:199 src/olympia/addons/helpers.py:35 src/olympia/addons/views.py:333 src/olympia/addons/templates/addons/impala/details.html:111
 #: src/olympia/addons/templates/addons/impala/listing/items.html:17 src/olympia/addons/templates/addons/mobile/home.html:40 src/olympia/amo/templates/amo/side_nav.html:6
-#: src/olympia/amo/templates/amo/side_nav.html:10 src/olympia/amo/templates/amo/site_nav.html:2 src/olympia/amo/templates/amo/site_nav.html:55 src/olympia/bandwagon/views.py:95
-#: src/olympia/browse/views.py:54 src/olympia/browse/views.py:68 src/olympia/browse/views.py:235 src/olympia/browse/templates/browse/impala/category_landing.html:22
+#: src/olympia/amo/templates/amo/side_nav.html:10 src/olympia/amo/templates/amo/site_nav.html:2 src/olympia/amo/templates/amo/site_nav.html:53 src/olympia/bandwagon/views.py:95
+#: src/olympia/browse/views.py:54 src/olympia/browse/views.py:68 src/olympia/browse/views.py:202 src/olympia/browse/templates/browse/impala/category_landing.html:22
 #: src/olympia/browse/templates/browse/personas/mobile/category_landing.html:26
 msgid "Featured"
 msgstr ""
 
-#: src/olympia/addons/buttons.py:221
+#: src/olympia/addons/buttons.py:218
 msgid "Add to {0}"
 msgstr ""
 
@@ -87,17 +88,20 @@ msgstr ""
 msgid "Invalid tag: {0}"
 msgid_plural "Invalid tags: {0}"
 msgstr[0] ""
+msgstr[1] ""
 
 #. L10n: {0} is a single tag or a comma-separated list of tags.
 #: src/olympia/addons/forms.py:103
 msgid "\"{0}\" is a reserved tag and cannot be used."
 msgid_plural "\"{0}\" are reserved tags and cannot be used."
 msgstr[0] ""
+msgstr[1] ""
 
 #: src/olympia/addons/forms.py:111
 msgid "You have {0} too many tags."
 msgid_plural "You have {0} too many tags."
 msgstr[0] ""
+msgstr[1] ""
 
 #: src/olympia/addons/forms.py:117
 #, python-format
@@ -108,39 +112,41 @@ msgstr ""
 msgid "All tags must be at least {0} character."
 msgid_plural "All tags must be at least {0} characters."
 msgstr[0] ""
+msgstr[1] ""
 
-#: src/olympia/addons/forms.py:234
+#: src/olympia/addons/forms.py:238
 msgid "Categories cannot be changed while your add-on is featured for this application."
 msgstr ""
 
 #. L10n: {0} is the number of categories.
-#: src/olympia/addons/forms.py:238
+#: src/olympia/addons/forms.py:242
 msgid "You can have only {0} category."
 msgid_plural "You can have only {0} categories."
 msgstr[0] ""
+msgstr[1] ""
 
-#: src/olympia/addons/forms.py:246
+#: src/olympia/addons/forms.py:250
 msgid "The miscellaneous category cannot be combined with additional categories."
 msgstr ""
 
-#: src/olympia/addons/forms.py:369
+#: src/olympia/addons/forms.py:374
 #, python-format
 msgid "Before changing your default locale you must have a name, summary, and description in that locale. You are missing %s."
 msgstr ""
 
-#: src/olympia/addons/forms.py:484 src/olympia/addons/forms.py:575
+#: src/olympia/addons/forms.py:455 src/olympia/addons/forms.py:546
 msgid "A license must be selected."
 msgstr ""
 
-#: src/olympia/addons/forms.py:556
+#: src/olympia/addons/forms.py:527
 msgid "Give Your Theme a Name."
 msgstr ""
 
-#: src/olympia/addons/forms.py:562 src/olympia/devhub/templates/devhub/personas/submit.html:53
+#: src/olympia/addons/forms.py:533 src/olympia/devhub/templates/devhub/personas/submit.html:53
 msgid "Describe your Theme."
 msgstr ""
 
-#: src/olympia/addons/forms.py:704
+#: src/olympia/addons/forms.py:675
 msgid "Enter a new author's email address"
 msgstr ""
 
@@ -148,37 +154,37 @@ msgstr ""
 msgid "Not Reviewed"
 msgstr ""
 
-#: src/olympia/addons/models.py:301
+#: src/olympia/addons/models.py:298
 msgid "Users have the option of contributing more or less than this amount."
 msgstr ""
 
-#: src/olympia/addons/models.py:309
-msgid "Users will always be asked in the Add-ons Manager (Firefox 4 and above)"
+#: src/olympia/addons/models.py:306
+msgid "Users will always be asked in the Add-ons Manager (Firefox 4 and above). Only applies to desktop."
 msgstr ""
 
-#: src/olympia/addons/models.py:1804 src/olympia/addons/templates/addons/details_box.html:55 src/olympia/devhub/templates/devhub/index.html:92
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:102
+#: src/olympia/addons/models.py:1802 src/olympia/addons/templates/addons/details_box.html:55 src/olympia/devhub/templates/devhub/index.html:92
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:89
 msgid "Listed"
 msgstr ""
 
-#: src/olympia/addons/views.py:320 src/olympia/browse/templates/browse/personas/mobile/category_landing.html:27
+#: src/olympia/addons/views.py:334 src/olympia/browse/templates/browse/personas/mobile/category_landing.html:27
 msgid "Popular"
 msgstr ""
 
-#: src/olympia/addons/views.py:321 src/olympia/browse/views.py:238 src/olympia/browse/views.py:280 src/olympia/browse/views.py:482
+#: src/olympia/addons/views.py:335 src/olympia/browse/views.py:205 src/olympia/browse/views.py:247 src/olympia/browse/views.py:449
 msgid "Recently Added"
 msgstr ""
 
-#: src/olympia/addons/views.py:322 src/olympia/bandwagon/views.py:99 src/olympia/browse/views.py:60 src/olympia/browse/views.py:71 src/olympia/search/forms.py:16 src/olympia/search/forms.py:91
+#: src/olympia/addons/views.py:336 src/olympia/bandwagon/views.py:99 src/olympia/browse/views.py:60 src/olympia/browse/views.py:71 src/olympia/search/forms.py:16 src/olympia/search/forms.py:91
 msgid "Recently Updated"
 msgstr ""
 
 #. l10n: {0} is the addon name
-#: src/olympia/addons/views.py:520
+#: src/olympia/addons/views.py:534
 msgid "Contribution for {0}"
 msgstr ""
 
-#: src/olympia/addons/views.py:613
+#: src/olympia/addons/views.py:627
 msgid "Abuse reported."
 msgstr ""
 
@@ -245,9 +251,9 @@ msgstr ""
 #: src/olympia/devhub/templates/devhub/addons/ajax_compat_update.html:36 src/olympia/devhub/templates/devhub/addons/profile.html:44 src/olympia/devhub/templates/devhub/addons/edit/admin.html:101
 #: src/olympia/devhub/templates/devhub/addons/edit/basic.html:152 src/olympia/devhub/templates/devhub/addons/edit/details.html:85 src/olympia/devhub/templates/devhub/addons/edit/support.html:67
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:166 src/olympia/devhub/templates/devhub/addons/forms_shared/media.html:149
-#: src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:44 src/olympia/devhub/templates/devhub/versions/add_file_modal.html:78 src/olympia/devhub/templates/devhub/versions/edit.html:139
-#: src/olympia/devhub/templates/devhub/versions/list.html:242 src/olympia/devhub/templates/devhub/versions/list.html:276 src/olympia/devhub/templates/devhub/versions/list.html:317
-#: src/olympia/devhub/templates/devhub/versions/list.html:351 src/olympia/reviews/templates/reviews/edit_review.html:16 src/olympia/translations/templates/translations/trans-menu.html:50
+#: src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:43 src/olympia/devhub/templates/devhub/versions/add_file_modal.html:58 src/olympia/devhub/templates/devhub/versions/edit.html:139
+#: src/olympia/devhub/templates/devhub/versions/list.html:239 src/olympia/devhub/templates/devhub/versions/list.html:281 src/olympia/devhub/templates/devhub/versions/list.html:315
+#: src/olympia/devhub/templates/devhub/versions/list.html:349 src/olympia/reviews/templates/reviews/edit_review.html:16 src/olympia/translations/templates/translations/trans-menu.html:50
 #: src/olympia/translations/templates/translations/trans-menu.html:62
 msgid "or"
 msgstr ""
@@ -358,7 +364,7 @@ msgid "Add-on Information for {0}"
 msgstr ""
 
 #: src/olympia/addons/templates/addons/details_box.html:30 src/olympia/addons/templates/addons/persona_detail_table.html:3 src/olympia/addons/templates/addons/mobile/details.html:63
-#: src/olympia/addons/templates/addons/mobile/persona_detail_table.html:7 src/olympia/browse/views.py:459 src/olympia/devhub/views.py:75
+#: src/olympia/addons/templates/addons/mobile/persona_detail_table.html:7 src/olympia/browse/views.py:426 src/olympia/devhub/views.py:73
 msgid "Updated"
 msgstr ""
 
@@ -377,11 +383,11 @@ msgstr ""
 msgid "Visibility"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/details_box.html:57 src/olympia/devhub/templates/devhub/index.html:94 src/olympia/devhub/templates/devhub/includes/addon_details.html:104
+#: src/olympia/addons/templates/addons/details_box.html:57 src/olympia/devhub/templates/devhub/index.html:94 src/olympia/devhub/templates/devhub/includes/addon_details.html:91
 msgid "Hidden"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/details_box.html:59 src/olympia/devhub/templates/devhub/index.html:96 src/olympia/devhub/templates/devhub/includes/addon_details.html:106
+#: src/olympia/addons/templates/addons/details_box.html:59 src/olympia/devhub/templates/devhub/index.html:96 src/olympia/devhub/templates/devhub/includes/addon_details.html:93
 msgid "Unlisted"
 msgstr ""
 
@@ -389,13 +395,13 @@ msgstr ""
 msgid "Required Add-ons"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/details_box.html:81 src/olympia/addons/templates/addons/persona_detail_table.html:15 src/olympia/browse/views.py:462 src/olympia/devhub/views.py:78
-#: src/olympia/devhub/views.py:85 src/olympia/discovery/templates/discovery/addons/detail.html:57 src/olympia/reviews/forms.py:62 src/olympia/reviews/templates/reviews/add.html:57
+#: src/olympia/addons/templates/addons/details_box.html:81 src/olympia/addons/templates/addons/persona_detail_table.html:15 src/olympia/browse/views.py:429 src/olympia/devhub/views.py:76
+#: src/olympia/devhub/views.py:83 src/olympia/discovery/templates/discovery/addons/detail.html:57 src/olympia/reviews/forms.py:62 src/olympia/reviews/templates/reviews/add.html:57
 #: src/olympia/reviews/templates/reviews/mobile/review_list.html:18
 msgid "Rating"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/details_box.html:85 src/olympia/browse/views.py:461 src/olympia/devhub/views.py:77 src/olympia/devhub/views.py:84
+#: src/olympia/addons/templates/addons/details_box.html:85 src/olympia/browse/views.py:428 src/olympia/devhub/views.py:75 src/olympia/devhub/views.py:82
 #: src/olympia/stats/templates/stats/addon_report_menu.html:8 src/olympia/stats/templates/stats/collection_report_menu.html:18
 msgid "Downloads"
 msgstr ""
@@ -415,7 +421,7 @@ msgstr ""
 
 #. The Privacy Policy for this add-on.
 #: src/olympia/addons/templates/addons/details_box.html:121 src/olympia/addons/templates/addons/privacy.html:19 src/olympia/addons/templates/addons/privacy.html:23
-#: src/olympia/addons/templates/addons/impala/button.html:43 src/olympia/addons/templates/addons/impala/details.html:307 src/olympia/devhub/templates/devhub/includes/policy_form.html:20
+#: src/olympia/addons/templates/addons/impala/button.html:43 src/olympia/addons/templates/addons/impala/details.html:312 src/olympia/devhub/templates/devhub/includes/policy_form.html:23
 #: src/olympia/templates/mobile/base_addons.html:87
 msgid "Privacy Policy"
 msgstr ""
@@ -440,7 +446,7 @@ msgstr ""
 msgid "Developer Comments"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/details_box.html:199 src/olympia/addons/templates/addons/impala/details.html:259
+#: src/olympia/addons/templates/addons/details_box.html:199 src/olympia/addons/templates/addons/impala/details.html:264
 msgid "Development Channel"
 msgstr ""
 
@@ -460,7 +466,7 @@ msgid ""
 "developer. To stop receiving development updates, reinstall the default version from the link above."
 msgstr ""
 
-#: src/olympia/addons/templates/addons/details_box.html:220 src/olympia/addons/templates/addons/impala/details.html:278
+#: src/olympia/addons/templates/addons/details_box.html:220 src/olympia/addons/templates/addons/impala/details.html:283
 msgid "Version {0}:"
 msgstr ""
 
@@ -479,7 +485,7 @@ msgid "End-User License Agreement for {0}"
 msgstr ""
 
 #: src/olympia/addons/templates/addons/eula.html:17 src/olympia/addons/templates/addons/eula.html:21 src/olympia/addons/templates/addons/impala/button.html:48
-#: src/olympia/addons/templates/addons/impala/details.html:316 src/olympia/devhub/templates/devhub/includes/policy_form.html:3 src/olympia/discovery/templates/discovery/addons/eula.html:11
+#: src/olympia/addons/templates/addons/impala/details.html:321 src/olympia/devhub/templates/devhub/includes/policy_form.html:3 src/olympia/discovery/templates/discovery/addons/eula.html:11
 msgid "End-User License Agreement"
 msgstr ""
 
@@ -496,7 +502,7 @@ msgstr ""
 msgid "Add-ons for {0}"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/home.html:10 src/olympia/addons/templates/addons/home.html:51 src/olympia/browse/templates/browse/impala/base_listing.html:11
+#: src/olympia/addons/templates/addons/home.html:10 src/olympia/addons/templates/addons/home.html:53 src/olympia/browse/templates/browse/impala/base_listing.html:11
 msgid "Featured Extensions"
 msgstr ""
 
@@ -504,29 +510,29 @@ msgstr ""
 msgid "Popular Extensions"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/home.html:42 src/olympia/amo/templates/amo/side_nav.html:3 src/olympia/amo/templates/amo/side_nav.html:11 src/olympia/amo/templates/amo/site_nav.html:3
-#: src/olympia/amo/templates/amo/site_nav.html:25 src/olympia/browse/views.py:236 src/olympia/browse/views.py:281 src/olympia/browse/views.py:481
+#: src/olympia/addons/templates/addons/home.html:44 src/olympia/amo/templates/amo/side_nav.html:3 src/olympia/amo/templates/amo/side_nav.html:11 src/olympia/amo/templates/amo/site_nav.html:3
+#: src/olympia/amo/templates/amo/site_nav.html:25 src/olympia/browse/views.py:203 src/olympia/browse/views.py:248 src/olympia/browse/views.py:448
 msgid "Most Popular"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/home.html:43
+#: src/olympia/addons/templates/addons/home.html:45
 msgid "All »"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/home.html:52 src/olympia/addons/templates/addons/home.html:61 src/olympia/addons/templates/addons/home.html:70 src/olympia/addons/templates/addons/home.html:78
+#: src/olympia/addons/templates/addons/home.html:54 src/olympia/addons/templates/addons/home.html:63 src/olympia/addons/templates/addons/home.html:72 src/olympia/addons/templates/addons/home.html:80
 #: src/olympia/browse/templates/browse/impala/category_landing.html:36
 msgid "See all »"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/home.html:60
+#: src/olympia/addons/templates/addons/home.html:62
 msgid "Up &amp; Coming Extensions"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/home.html:69 src/olympia/browse/templates/browse/personas/category_landing.html:61 src/olympia/discovery/templates/discovery/pane.html:74
+#: src/olympia/addons/templates/addons/home.html:71 src/olympia/browse/templates/browse/personas/category_landing.html:61 src/olympia/discovery/templates/discovery/pane.html:74
 msgid "Featured Themes"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/home.html:77 src/olympia/bandwagon/templates/bandwagon/impala/collection_listing.html:5
+#: src/olympia/addons/templates/addons/home.html:79 src/olympia/bandwagon/templates/bandwagon/impala/collection_listing.html:5
 msgid "Featured Collections"
 msgstr ""
 
@@ -544,7 +550,7 @@ msgid "Updated {0}"
 msgstr ""
 
 #. {0} is a date.
-#: src/olympia/addons/templates/addons/macros.html:10 src/olympia/addons/templates/addons/macros.html:69 src/olympia/addons/templates/addons/persona_preview.html:21
+#: src/olympia/addons/templates/addons/macros.html:10 src/olympia/addons/templates/addons/macros.html:69 src/olympia/addons/templates/addons/persona_preview.html:22
 #: src/olympia/addons/templates/addons/listing/items_mobile.html:44 src/olympia/addons/templates/addons/listing/macros.html:39
 #: src/olympia/bandwagon/templates/bandwagon/collection_listing_items.html:37 src/olympia/bandwagon/templates/bandwagon/impala/collection_listing_items.html:37
 msgid "Added {0}"
@@ -555,25 +561,28 @@ msgstr ""
 msgid "%(num)s weekly download"
 msgid_plural "%(num)s weekly downloads"
 msgstr[0] ""
+msgstr[1] ""
 
 #: src/olympia/addons/templates/addons/macros.html:28
 #, python-format
 msgid "%(num)s user"
 msgid_plural "%(num)s users"
 msgstr[0] ""
+msgstr[1] ""
 
 #. {0} is the number of downloads.
-#: src/olympia/addons/templates/addons/macros.html:53 src/olympia/addons/templates/addons/impala/details.html:61
+#: src/olympia/addons/templates/addons/macros.html:53 src/olympia/addons/templates/addons/impala/details.html:59
 msgid "{0} weekly download"
 msgid_plural "{0} weekly downloads"
 msgstr[0] ""
+msgstr[1] ""
 
 #. {0} is the number of users.
-#: src/olympia/addons/templates/addons/macros.html:61 src/olympia/addons/templates/addons/impala/details.html:54 src/olympia/compat/templates/compat/index.html:71
-#: src/olympia/zadmin/templates/zadmin/compat.html:67
+#: src/olympia/addons/templates/addons/macros.html:61 src/olympia/addons/templates/addons/impala/details.html:52 src/olympia/zadmin/templates/zadmin/compat.html:67
 msgid "{0} user"
 msgid_plural "{0} users"
 msgstr[0] ""
+msgstr[1] ""
 
 #: src/olympia/addons/templates/addons/paypal_result.html:12
 msgid "Payment cancelled"
@@ -587,7 +596,7 @@ msgstr ""
 msgid "Return to the addon."
 msgstr ""
 
-#: src/olympia/addons/templates/addons/persona_detail.html:17 src/olympia/addons/templates/addons/impala/details.html:106 src/olympia/addons/templates/addons/mobile/details.html:23
+#: src/olympia/addons/templates/addons/persona_detail.html:17 src/olympia/addons/templates/addons/impala/details.html:103 src/olympia/addons/templates/addons/mobile/details.html:23
 #: src/olympia/addons/templates/addons/mobile/persona_detail.html:21 src/olympia/discovery/templates/discovery/addons/base.html:27 src/olympia/editors/templates/editors/review.html:31
 msgid "by"
 msgstr ""
@@ -631,33 +640,35 @@ msgstr ""
 msgid "License"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/persona_preview.html:12 src/olympia/constants/base.py:48
+#: src/olympia/addons/templates/addons/persona_preview.html:13 src/olympia/constants/base.py:48
 msgid "Awaiting Review"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/persona_preview.html:14 src/olympia/amo/log.py:180 src/olympia/constants/base.py:42 src/olympia/editors/helpers.py:62
+#: src/olympia/addons/templates/addons/persona_preview.html:15 src/olympia/amo/log.py:180 src/olympia/constants/base.py:42 src/olympia/editors/helpers.py:62
 msgid "Rejected"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/persona_preview.html:16 src/olympia/amo/log.py:159
+#: src/olympia/addons/templates/addons/persona_preview.html:17 src/olympia/amo/log.py:159
 msgid "Approved"
 msgstr ""
 
 #. {0} is the number of users.
-#: src/olympia/addons/templates/addons/persona_preview.html:26 src/olympia/addons/templates/addons/listing/items_mobile.html:36 src/olympia/addons/templates/addons/listing/macros.html:31
+#: src/olympia/addons/templates/addons/persona_preview.html:27 src/olympia/addons/templates/addons/listing/items_mobile.html:36 src/olympia/addons/templates/addons/listing/macros.html:31
 msgid "<strong>{0}</strong> user"
 msgid_plural "<strong>{0}</strong> users"
 msgstr[0] ""
+msgstr[1] ""
 
-#: src/olympia/addons/templates/addons/persona_preview.html:40
+#: src/olympia/addons/templates/addons/persona_preview.html:41
 msgid "Hover to Preview"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/persona_preview.html:46 src/olympia/addons/templates/addons/persona_preview.html:48 src/olympia/reviews/templates/reviews/add.html:15
+#: src/olympia/addons/templates/addons/persona_preview.html:47 src/olympia/addons/templates/addons/persona_preview.html:49 src/olympia/addons/templates/addons/persona_preview.html:97
+#: src/olympia/reviews/templates/reviews/add.html:15
 msgid "Add"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/persona_preview.html:57 src/olympia/bandwagon/templates/bandwagon/ajax_new.html:16 src/olympia/bandwagon/templates/bandwagon/edit.html:19
+#: src/olympia/addons/templates/addons/persona_preview.html:58 src/olympia/bandwagon/templates/bandwagon/ajax_new.html:16 src/olympia/bandwagon/templates/bandwagon/edit.html:19
 #: src/olympia/bandwagon/templates/bandwagon/includes/addedit.html:19 src/olympia/devhub/templates/devhub/addons/edit/admin.html:13 src/olympia/devhub/templates/devhub/addons/edit/basic.html:10
 #: src/olympia/devhub/templates/devhub/addons/edit/details.html:8 src/olympia/devhub/templates/devhub/addons/edit/media.html:6 src/olympia/devhub/templates/devhub/addons/edit/support.html:8
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:9 src/olympia/devhub/templates/devhub/addons/submit/describe.html:29 src/olympia/editors/templates/editors/review.html:257
@@ -666,21 +677,21 @@ msgstr ""
 
 #. For datetime formatting, see the table on
 #. http://docs.python.org/library/datetime.html#strftime-and-strptime-behavior
-#: src/olympia/addons/templates/addons/persona_preview.html:66
+#: src/olympia/addons/templates/addons/persona_preview.html:67
 #, python-format
 msgid "%%Y-%%m-%%d"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/persona_preview.html:67
+#: src/olympia/addons/templates/addons/persona_preview.html:68
 msgid "by {0} on {1}"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/persona_preview.html:75 src/olympia/reviews/helpers.py:17 src/olympia/reviews/templates/reviews/review_list.html:63
+#: src/olympia/addons/templates/addons/persona_preview.html:76 src/olympia/reviews/helpers.py:17 src/olympia/reviews/templates/reviews/review_list.html:63
 #: src/olympia/reviews/templates/reviews/reviews_link.html:21 src/olympia/reviews/templates/reviews/impala/reviews_link.html:16
 msgid "Not yet rated"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/persona_preview.html:78
+#: src/olympia/addons/templates/addons/persona_preview.html:79
 msgid "<b>{0}</b> users"
 msgstr ""
 
@@ -693,7 +704,7 @@ msgid "Learn more about Firefox"
 msgstr ""
 
 #: src/olympia/addons/templates/addons/popups.html:22
-msgid "or <b><a class=\"installer\" href=\"{url}\">download anyway</a></b>"
+msgid "or <b><a class=\"button installer\" href=\"{url}\">download anyway</a></b>"
 msgstr ""
 
 #: src/olympia/addons/templates/addons/popups.html:26
@@ -792,7 +803,7 @@ msgid ""
 msgstr ""
 
 #: src/olympia/addons/templates/addons/report_abuse.html:6 src/olympia/addons/templates/addons/report_abuse_full.html:10 src/olympia/addons/templates/addons/impala/details-more.html:23
-#: src/olympia/addons/templates/addons/impala/details.html:328
+#: src/olympia/addons/templates/addons/impala/details.html:333
 msgid "Report Abuse"
 msgstr ""
 
@@ -811,9 +822,9 @@ msgstr ""
 #: src/olympia/devhub/templates/devhub/addons/ajax_compat_update.html:36 src/olympia/devhub/templates/devhub/addons/profile.html:44 src/olympia/devhub/templates/devhub/addons/edit/admin.html:104
 #: src/olympia/devhub/templates/devhub/addons/edit/basic.html:155 src/olympia/devhub/templates/devhub/addons/edit/details.html:88 src/olympia/devhub/templates/devhub/addons/edit/support.html:70
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:169 src/olympia/devhub/templates/devhub/addons/forms_shared/media.html:152
-#: src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:44 src/olympia/devhub/templates/devhub/personas/edit.html:222 src/olympia/devhub/templates/devhub/versions/add_file_modal.html:79
-#: src/olympia/devhub/templates/devhub/versions/edit.html:140 src/olympia/devhub/templates/devhub/versions/list.html:208 src/olympia/devhub/templates/devhub/versions/list.html:242
-#: src/olympia/devhub/templates/devhub/versions/list.html:276 src/olympia/devhub/templates/devhub/versions/list.html:317 src/olympia/reviews/templates/reviews/edit_review.html:16
+#: src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:43 src/olympia/devhub/templates/devhub/personas/edit.html:222 src/olympia/devhub/templates/devhub/versions/add_file_modal.html:59
+#: src/olympia/devhub/templates/devhub/versions/edit.html:140 src/olympia/devhub/templates/devhub/versions/list.html:208 src/olympia/devhub/templates/devhub/versions/list.html:239
+#: src/olympia/devhub/templates/devhub/versions/list.html:281 src/olympia/devhub/templates/devhub/versions/list.html:315 src/olympia/reviews/templates/reviews/edit_review.html:16
 #: src/olympia/translations/templates/translations/trans-menu.html:50 src/olympia/translations/templates/translations/trans-menu.html:62 src/olympia/zadmin/templates/zadmin/validation.html:105
 msgid "Cancel"
 msgstr ""
@@ -858,7 +869,7 @@ msgstr ""
 msgid "Review Guidelines"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/review_list_box.html:5 src/olympia/addons/templates/addons/impala/details-more.html:27 src/olympia/editors/helpers.py:921
+#: src/olympia/addons/templates/addons/review_list_box.html:5 src/olympia/addons/templates/addons/impala/details-more.html:27 src/olympia/editors/helpers.py:1001
 #: src/olympia/reviews/templates/reviews/add.html:14 src/olympia/reviews/templates/reviews/reply.html:14 src/olympia/reviews/templates/reviews/review_list.html:19
 #: src/olympia/reviews/templates/reviews/mobile/review_list.html:26
 msgid "Reviews"
@@ -878,6 +889,7 @@ msgstr ""
 msgid "See all reviews of this add-on"
 msgid_plural "See all %(cnt)s reviews of this add-on"
 msgstr[0] ""
+msgstr[1] ""
 
 #: src/olympia/addons/templates/addons/tags_box.html:3 src/olympia/devhub/templates/devhub/addons/edit/basic.html:118
 msgid "Tags"
@@ -946,118 +958,121 @@ msgstr ""
 msgid "Other add-ons by %(author)s"
 msgid_plural "Other add-ons by these authors"
 msgstr[0] ""
+msgstr[1] ""
 
-#: src/olympia/addons/templates/addons/impala/details.html:41
+#: src/olympia/addons/templates/addons/impala/details.html:39
 #, python-format
 msgid "<span itemprop=\"ratingCount\">%(num)s</span> user review"
 msgid_plural "<span itemprop=\"ratingCount\">%(num)s</span> user reviews"
 msgstr[0] ""
+msgstr[1] ""
 
-#: src/olympia/addons/templates/addons/impala/details.html:69
+#: src/olympia/addons/templates/addons/impala/details.html:66
 msgid "View statistics"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/impala/details.html:84
+#: src/olympia/addons/templates/addons/impala/details.html:81
 msgid "Manage"
 msgstr ""
 
 #. {0} is an add-on name.
-#: src/olympia/addons/templates/addons/impala/details.html:96
+#: src/olympia/addons/templates/addons/impala/details.html:93
 msgid "Icon of {0}"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/impala/details.html:103 src/olympia/addons/templates/addons/impala/listing/items.html:14
+#: src/olympia/addons/templates/addons/impala/details.html:100 src/olympia/addons/templates/addons/impala/listing/items.html:14
 msgid "No Restart"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/impala/details.html:127
+#: src/olympia/addons/templates/addons/impala/details.html:124
 #, python-format
 msgid "Meet the Developer: <a href=\"%(url)s\">%(name)s</a>"
 msgid_plural "<a href=\"%(url)s\">Meet the Developers</a>"
 msgstr[0] ""
+msgstr[1] ""
 
-#: src/olympia/addons/templates/addons/impala/details.html:137
+#: src/olympia/addons/templates/addons/impala/details.html:134
 msgid "Learn why {0} was created and find out what's next for this add-on."
 msgstr ""
 
 #. {0} is an index.
-#: src/olympia/addons/templates/addons/impala/details.html:156
+#: src/olympia/addons/templates/addons/impala/details.html:161
 msgid "Add-on screenshot #{0}"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/impala/details.html:182
+#: src/olympia/addons/templates/addons/impala/details.html:187
 msgid "Add-on home page"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/impala/details.html:185
+#: src/olympia/addons/templates/addons/impala/details.html:190
 msgid "Support site"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/impala/details.html:189
+#: src/olympia/addons/templates/addons/impala/details.html:194
 msgid "Support E-mail"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/impala/details.html:194 src/olympia/devhub/models.py:378 src/olympia/devhub/templates/devhub/versions/list.html:12
+#: src/olympia/addons/templates/addons/impala/details.html:199 src/olympia/devhub/models.py:378 src/olympia/devhub/templates/devhub/versions/list.html:12
 #: src/olympia/versions/templates/versions/version.html:6 src/olympia/versions/templates/versions/mobile/version.html:6
 msgid "Version {0}"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/impala/details.html:194
+#: src/olympia/addons/templates/addons/impala/details.html:199
 msgid "Info"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/impala/details.html:195 src/olympia/devhub/templates/devhub/includes/addon_details.html:129
+#: src/olympia/addons/templates/addons/impala/details.html:200 src/olympia/devhub/templates/devhub/includes/addon_details.html:116
 msgid "Last Updated:"
-msgstr ""
-
-#: src/olympia/addons/templates/addons/impala/details.html:200
-#, python-format
-msgid "Released under <a target=\"_blank\" href=\"%(url)s\">%(name)s</a>"
-msgstr ""
-
-#: src/olympia/addons/templates/addons/impala/details.html:201 src/olympia/addons/templates/addons/impala/details.html:206 src/olympia/amo/helpers.py:398 src/olympia/devhub/forms.py:142
-#: src/olympia/devhub/forms.py:173 src/olympia/versions/templates/versions/version.html:40 src/olympia/versions/templates/versions/version.html:45
-msgid "Custom License"
 msgstr ""
 
 #: src/olympia/addons/templates/addons/impala/details.html:205
 #, python-format
+msgid "Released under <a target=\"_blank\" href=\"%(url)s\">%(name)s</a>"
+msgstr ""
+
+#: src/olympia/addons/templates/addons/impala/details.html:206 src/olympia/addons/templates/addons/impala/details.html:211 src/olympia/amo/helpers.py:398 src/olympia/devhub/forms.py:142
+#: src/olympia/devhub/forms.py:173 src/olympia/versions/templates/versions/version.html:40 src/olympia/versions/templates/versions/version.html:45
+msgid "Custom License"
+msgstr ""
+
+#: src/olympia/addons/templates/addons/impala/details.html:210
+#, python-format
 msgid "Released under <a href=\"%(url)s\">%(name)s</a>"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/impala/details.html:217
+#: src/olympia/addons/templates/addons/impala/details.html:222
 msgid "About this Add-on"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/impala/details.html:233
+#: src/olympia/addons/templates/addons/impala/details.html:238
 msgid "Developer’s Comments"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/impala/details.html:243
+#: src/olympia/addons/templates/addons/impala/details.html:248
 msgid "Version Information"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/impala/details.html:250
+#: src/olympia/addons/templates/addons/impala/details.html:255
 msgid "See complete version history"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/impala/details.html:262
+#: src/olympia/addons/templates/addons/impala/details.html:267
 msgid ""
 "The Development Channel lets you test an experimental new version of this add-on before it's released to the general public. Once you install the development version, you will continue to get "
 "updates from this channel. To stop receiving development updates, reinstall the default version from the link above."
 msgstr ""
 
-#: src/olympia/addons/templates/addons/impala/details.html:272
+#: src/olympia/addons/templates/addons/impala/details.html:277
 msgid "<strong>Caution:</strong> Development versions of this add-on have not been reviewed by Mozilla."
 msgstr ""
 
-#: src/olympia/addons/templates/addons/impala/details.html:287
+#: src/olympia/addons/templates/addons/impala/details.html:292
 msgid "See complete development channel history"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/impala/details.html:306 src/olympia/addons/templates/addons/impala/details.html:315 src/olympia/addons/templates/addons/impala/details.html:327
+#: src/olympia/addons/templates/addons/impala/details.html:311 src/olympia/addons/templates/addons/impala/details.html:320 src/olympia/addons/templates/addons/impala/details.html:332
 #: src/olympia/addons/templates/addons/impala/review_add_box.html:4 src/olympia/stats/templates/stats/popup.html:2 src/olympia/stats/templates/stats/popup.html:8
-#: src/olympia/stats/templates/stats/stats.html:202 src/olympia/users/templates/users/profile.html:119
+#: src/olympia/stats/templates/stats/stats.html:204 src/olympia/users/templates/users/profile.html:119
 msgid "close"
 msgstr ""
 
@@ -1087,6 +1102,7 @@ msgstr ""
 msgid "About the Developer"
 msgid_plural "About the Developers"
 msgstr[0] ""
+msgstr[1] ""
 
 #: src/olympia/addons/templates/addons/impala/developers.html:96 src/olympia/users/templates/users/edit.html:130 src/olympia/users/templates/users/profile.html:26
 msgid "No Photo"
@@ -1112,15 +1128,11 @@ msgstr ""
 msgid "Source Code License"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/impala/persona_grid.html:16 src/olympia/addons/templates/addons/impala/toplist.html:6
-msgid "{0} users"
-msgstr ""
-
 #: src/olympia/addons/templates/addons/impala/review_list_box.html:19 src/olympia/reviews/templates/reviews/review.html:40
 msgid "permalink"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/impala/review_list_box.html:23 src/olympia/editors/templates/editors/queue.html:98 src/olympia/reviews/templates/reviews/review.html:44
+#: src/olympia/addons/templates/addons/impala/review_list_box.html:23 src/olympia/editors/templates/editors/queue.html:104 src/olympia/reviews/templates/reviews/review.html:44
 msgid "translate"
 msgstr ""
 
@@ -1129,6 +1141,7 @@ msgstr ""
 msgid "See all user reviews"
 msgid_plural "See all %(cnt)s user reviews"
 msgstr[0] ""
+msgstr[1] ""
 
 #: src/olympia/addons/templates/addons/impala/review_list_box.html:47 src/olympia/reviews/templates/reviews/review_list.html:84
 msgid "This add-on has not yet been reviewed."
@@ -1136,6 +1149,10 @@ msgstr ""
 
 #: src/olympia/addons/templates/addons/impala/review_list_box.html:50
 msgid "Be the first!"
+msgstr ""
+
+#: src/olympia/addons/templates/addons/impala/toplist.html:6
+msgid "{0} users"
 msgstr ""
 
 #: src/olympia/addons/templates/addons/impala/listing/sorter.html:14 src/olympia/devhub/templates/devhub/addons/listing/item_actions.html:49
@@ -1150,7 +1167,7 @@ msgstr ""
 msgid "My Add-ons"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/includes/dashboard_tabs.html:6 src/olympia/amo/context_processors.py:51
+#: src/olympia/addons/templates/addons/includes/dashboard_tabs.html:6 src/olympia/amo/context_processors.py:50
 msgid "My Themes"
 msgstr ""
 
@@ -1191,6 +1208,7 @@ msgstr ""
 msgid "<strong>{0}</strong> weekly download"
 msgid_plural "<strong>{0}</strong> weekly downloads"
 msgstr[0] ""
+msgstr[1] ""
 
 #: src/olympia/addons/templates/addons/mobile/details.html:32
 msgid "Read More"
@@ -1204,7 +1222,7 @@ msgstr ""
 msgid "Weekly Downloads"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/mobile/details.html:99 src/olympia/compat/templates/compat/reporter_detail.html:46 src/olympia/devhub/forms.py:787
+#: src/olympia/addons/templates/addons/mobile/details.html:99 src/olympia/compat/templates/compat/reporter_detail.html:46 src/olympia/devhub/forms.py:788
 #: src/olympia/devhub/templates/devhub/versions/list.html:163
 msgid "Version"
 msgstr ""
@@ -1288,7 +1306,7 @@ msgstr ""
 #: src/olympia/browse/templates/browse/personas/category_landing.html:21 src/olympia/browse/templates/browse/personas/category_landing.html:23
 #: src/olympia/browse/templates/browse/personas/category_landing.html:38 src/olympia/browse/templates/browse/personas/grid.html:7 src/olympia/browse/templates/browse/personas/grid.html:11
 #: src/olympia/browse/templates/browse/personas/mobile/base.html:7 src/olympia/browse/templates/browse/personas/mobile/category_landing.html:19 src/olympia/constants/base.py:180
-#: src/olympia/devhub/templates/devhub/personas/submit.html:13 src/olympia/editors/helpers.py:105 src/olympia/editors/templates/editors/base.html:26
+#: src/olympia/devhub/templates/devhub/personas/submit.html:13 src/olympia/editors/helpers.py:107 src/olympia/editors/templates/editors/base.html:26
 #: src/olympia/editors/templates/editors/performance.html:73 src/olympia/search/templates/search/personas.html:39 src/olympia/templates/menu_links.html:9
 msgid "Themes"
 msgstr ""
@@ -1309,7 +1327,7 @@ msgstr ""
 msgid "Highest Rated"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/mobile/home.html:74 src/olympia/amo/templates/amo/side_nav.html:5 src/olympia/amo/templates/amo/site_nav.html:27 src/olympia/amo/templates/amo/site_nav.html:57
+#: src/olympia/addons/templates/addons/mobile/home.html:74 src/olympia/amo/templates/amo/side_nav.html:5 src/olympia/amo/templates/amo/site_nav.html:27 src/olympia/amo/templates/amo/site_nav.html:55
 #: src/olympia/bandwagon/views.py:97 src/olympia/browse/views.py:57 src/olympia/browse/views.py:67 src/olympia/browse/templates/browse/personas/mobile/category_landing.html:65
 #: src/olympia/search/forms.py:15 src/olympia/search/forms.py:87
 msgid "Newest"
@@ -1323,90 +1341,90 @@ msgstr ""
 msgid "Theme Info &raquo;"
 msgstr ""
 
-#: src/olympia/amo/context_processors.py:39 src/olympia/devhub/templates/devhub/nav.html:43
+#: src/olympia/amo/context_processors.py:37 src/olympia/devhub/templates/devhub/nav.html:43
 msgid "Tools"
 msgstr ""
 
-#: src/olympia/amo/context_processors.py:48 src/olympia/discovery/templates/discovery/pane_account.html:8 src/olympia/users/templates/users/includes/navigation.html:2
+#: src/olympia/amo/context_processors.py:47 src/olympia/discovery/templates/discovery/pane_account.html:8 src/olympia/users/templates/users/includes/navigation.html:2
 msgid "My Profile"
 msgstr ""
 
-#: src/olympia/amo/context_processors.py:54 src/olympia/users/templates/users/edit.html:5 src/olympia/users/templates/users/includes/navigation.html:3
+#: src/olympia/amo/context_processors.py:53 src/olympia/users/templates/users/edit.html:5 src/olympia/users/templates/users/includes/navigation.html:3
 msgid "Account Settings"
 msgstr ""
 
-#: src/olympia/amo/context_processors.py:57 src/olympia/discovery/templates/discovery/pane_account.html:11 src/olympia/users/templates/users/profile.html:83
+#: src/olympia/amo/context_processors.py:56 src/olympia/discovery/templates/discovery/pane_account.html:11 src/olympia/users/templates/users/profile.html:83
 #: src/olympia/users/templates/users/includes/navigation.html:4
 msgid "My Collections"
 msgstr ""
 
-#: src/olympia/amo/context_processors.py:62 src/olympia/discovery/templates/discovery/pane_account.html:10 src/olympia/users/templates/users/includes/navigation.html:7
+#: src/olympia/amo/context_processors.py:61 src/olympia/discovery/templates/discovery/pane_account.html:10 src/olympia/users/templates/users/includes/navigation.html:7
 msgid "My Favorites"
 msgstr ""
 
-#: src/olympia/amo/context_processors.py:67 src/olympia/discovery/templates/discovery/pane_account.html:13 src/olympia/templates/impala/user_login.html:14
+#: src/olympia/amo/context_processors.py:66 src/olympia/discovery/templates/discovery/pane_account.html:13 src/olympia/templates/impala/user_login.html:14
 #: src/olympia/templates/mobile/header_auth.html:5
 msgid "Log out"
 msgstr ""
 
-#: src/olympia/amo/context_processors.py:72 src/olympia/devhub/templates/devhub/addons/dashboard.html:4
+#: src/olympia/amo/context_processors.py:71 src/olympia/devhub/templates/devhub/addons/dashboard.html:4
 msgid "Manage My Submissions"
 msgstr ""
 
-#: src/olympia/amo/context_processors.py:75 src/olympia/devhub/templates/devhub/nav.html:27 src/olympia/devhub/templates/devhub/addons/dashboard.html:25
+#: src/olympia/amo/context_processors.py:74 src/olympia/devhub/templates/devhub/nav.html:27 src/olympia/devhub/templates/devhub/addons/dashboard.html:25
 #: src/olympia/devhub/templates/devhub/addons/submit/base.html:4
 msgid "Submit a New Add-on"
 msgstr ""
 
-#: src/olympia/amo/context_processors.py:77 src/olympia/browse/templates/browse/personas/base.html:50 src/olympia/devhub/templates/devhub/index.html:24
+#: src/olympia/amo/context_processors.py:76 src/olympia/browse/templates/browse/personas/base.html:50 src/olympia/devhub/templates/devhub/index.html:24
 #: src/olympia/devhub/templates/devhub/addons/dashboard.html:29
 msgid "Submit a New Theme"
 msgstr ""
 
-#: src/olympia/amo/context_processors.py:79 src/olympia/amo/templates/amo/site_nav.html:87 src/olympia/devhub/helpers.py:36 src/olympia/devhub/helpers.py:68 src/olympia/devhub/helpers.py:102
+#: src/olympia/amo/context_processors.py:78 src/olympia/amo/templates/amo/site_nav.html:85 src/olympia/devhub/helpers.py:36 src/olympia/devhub/helpers.py:68 src/olympia/devhub/helpers.py:102
 #: src/olympia/templates/footer.html:6 src/olympia/templates/menu_links.html:14
 msgid "Developer Hub"
 msgstr ""
 
-#: src/olympia/amo/context_processors.py:83 src/olympia/devhub/views.py:1792
+#: src/olympia/amo/context_processors.py:81 src/olympia/devhub/views.py:1796
 msgid "Manage API Keys"
 msgstr ""
 
-#: src/olympia/amo/context_processors.py:88 src/olympia/editors/helpers.py:82 src/olympia/editors/helpers.py:102 src/olympia/editors/templates/editors/base.html:10
+#: src/olympia/amo/context_processors.py:86 src/olympia/editors/helpers.py:84 src/olympia/editors/helpers.py:104 src/olympia/editors/templates/editors/base.html:10
 msgid "Editor Tools"
 msgstr ""
 
-#: src/olympia/amo/context_processors.py:92
+#: src/olympia/amo/context_processors.py:90
 msgid "Admin Tools"
 msgstr ""
 
-#: src/olympia/amo/fields.py:15
+#: src/olympia/amo/fields.py:20
 msgid "Incorrect, please try again."
 msgstr ""
 
-#: src/olympia/amo/fields.py:16
+#: src/olympia/amo/fields.py:21
 msgid "Error verifying input, please try again."
 msgstr ""
 
-#: src/olympia/amo/fields.py:32
+#: src/olympia/amo/fields.py:37
 msgid "This must be a valid hex color code, such as #000000."
 msgstr ""
 
-#: src/olympia/amo/fields.py:58
+#: src/olympia/amo/fields.py:63
 msgid "Enter at least one value."
 msgstr ""
 
-#: src/olympia/amo/helpers.py:162 src/olympia/amo/templates/amo/site_nav.html:61 src/olympia/bandwagon/templates/bandwagon/add.html:9
+#: src/olympia/amo/helpers.py:162 src/olympia/amo/templates/amo/site_nav.html:59 src/olympia/bandwagon/templates/bandwagon/add.html:9
 #: src/olympia/bandwagon/templates/bandwagon/collection_detail.html:15 src/olympia/bandwagon/templates/bandwagon/delete.html:9 src/olympia/bandwagon/templates/bandwagon/edit.html:15
 #: src/olympia/bandwagon/templates/bandwagon/user_listing.html:18 src/olympia/bandwagon/templates/bandwagon/user_listing.html:21
 #: src/olympia/bandwagon/templates/bandwagon/impala/collection_listing.html:12 src/olympia/bandwagon/templates/bandwagon/impala/collection_listing.html:20
 #: src/olympia/bandwagon/templates/bandwagon/impala/collection_listing.html:24 src/olympia/bandwagon/templates/bandwagon/impala/collection_sidebar.html:3
 #: src/olympia/bandwagon/templates/bandwagon/includes/collection_sidebar.html:2 src/olympia/bandwagon/templates/bandwagon/mobile/collection_listing.html:3
-#: src/olympia/stats/templates/stats/stats.html:77 src/olympia/templates/menu_links.html:12
+#: src/olympia/stats/templates/stats/stats.html:33 src/olympia/templates/menu_links.html:12
 msgid "Collections"
 msgstr ""
 
-#: src/olympia/amo/helpers.py:171 src/olympia/amo/templates/amo/site_nav.html:85 src/olympia/browse/templates/browse/language_tools.html:3
+#: src/olympia/amo/helpers.py:171 src/olympia/amo/templates/amo/site_nav.html:83 src/olympia/browse/templates/browse/language_tools.html:3
 msgid "Dictionaries & Language Packs"
 msgstr ""
 
@@ -1558,8 +1576,8 @@ msgstr ""
 msgid "Comment on {addon} {version}."
 msgstr ""
 
-#: src/olympia/amo/log.py:236 src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:19 src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:47
-#: src/olympia/editors/helpers.py:511 src/olympia/editors/templates/editors/themes/history_table.html:11
+#: src/olympia/amo/log.py:236 src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:17 src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:45
+#: src/olympia/editors/helpers.py:584 src/olympia/editors/templates/editors/themes/history_table.html:11
 msgid "Comment"
 msgstr ""
 
@@ -1882,7 +1900,7 @@ msgstr ""
 #: src/olympia/amo/templates/amo/mobile/paginator.html:14 src/olympia/amo/templates/amo/mobile/paginator.html:16 src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:51
 #: src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:65 src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:78
 #: src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:91 src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:104
-#: src/olympia/discovery/templates/discovery/pane.html:45 src/olympia/discovery/templates/discovery/addons/detail.html:39 src/olympia/stats/templates/stats/stats.html:167
+#: src/olympia/discovery/templates/discovery/pane.html:45 src/olympia/discovery/templates/discovery/addons/detail.html:39 src/olympia/stats/templates/stats/stats.html:169
 msgid "Next"
 msgstr ""
 
@@ -1914,7 +1932,7 @@ msgid ""
 msgstr ""
 
 #: src/olympia/amo/templates/amo/side_nav.html:4 src/olympia/amo/templates/amo/side_nav.html:12 src/olympia/amo/templates/amo/site_nav.html:4 src/olympia/amo/templates/amo/site_nav.html:26
-#: src/olympia/browse/views.py:56 src/olympia/browse/views.py:66 src/olympia/browse/views.py:237 src/olympia/browse/views.py:282 src/olympia/search/forms.py:86
+#: src/olympia/browse/views.py:56 src/olympia/browse/views.py:66 src/olympia/browse/views.py:204 src/olympia/browse/views.py:249 src/olympia/search/forms.py:86
 msgid "Top Rated"
 msgstr ""
 
@@ -1928,38 +1946,38 @@ msgstr ""
 msgid "Extensions"
 msgstr ""
 
-#: src/olympia/amo/templates/amo/site_nav.html:45
+#: src/olympia/amo/templates/amo/site_nav.html:44
 msgid "Want more customization? Try <b>Complete Themes</b>"
 msgstr ""
 
-#: src/olympia/amo/templates/amo/site_nav.html:56 src/olympia/bandwagon/views.py:96
+#: src/olympia/amo/templates/amo/site_nav.html:54 src/olympia/bandwagon/views.py:96
 msgid "Most Followers"
 msgstr ""
 
-#: src/olympia/amo/templates/amo/site_nav.html:68 src/olympia/bandwagon/templates/bandwagon/impala/collection_sidebar.html:16
+#: src/olympia/amo/templates/amo/site_nav.html:66 src/olympia/bandwagon/templates/bandwagon/impala/collection_sidebar.html:16
 #: src/olympia/bandwagon/templates/bandwagon/includes/collection_sidebar.html:18
 msgid "Collections I've Made"
 msgstr ""
 
-#: src/olympia/amo/templates/amo/site_nav.html:70 src/olympia/bandwagon/templates/bandwagon/user_listing.html:4 src/olympia/bandwagon/templates/bandwagon/impala/collection_sidebar.html:13
+#: src/olympia/amo/templates/amo/site_nav.html:68 src/olympia/bandwagon/templates/bandwagon/user_listing.html:4 src/olympia/bandwagon/templates/bandwagon/impala/collection_sidebar.html:13
 #: src/olympia/bandwagon/templates/bandwagon/includes/collection_sidebar.html:15
 msgid "Collections I'm Following"
 msgstr ""
 
-#: src/olympia/amo/templates/amo/site_nav.html:73 src/olympia/bandwagon/templates/bandwagon/impala/collection_sidebar.html:18
-#: src/olympia/bandwagon/templates/bandwagon/includes/collection_sidebar.html:20 src/olympia/users/models.py:512
+#: src/olympia/amo/templates/amo/site_nav.html:71 src/olympia/bandwagon/templates/bandwagon/impala/collection_sidebar.html:18
+#: src/olympia/bandwagon/templates/bandwagon/includes/collection_sidebar.html:20 src/olympia/users/models.py:521
 msgid "My Favorite Add-ons"
 msgstr ""
 
-#: src/olympia/amo/templates/amo/site_nav.html:78
+#: src/olympia/amo/templates/amo/site_nav.html:76
 msgid "More&hellip;"
 msgstr ""
 
-#: src/olympia/amo/templates/amo/site_nav.html:82
+#: src/olympia/amo/templates/amo/site_nav.html:80
 msgid "Add-ons for Mobile"
 msgstr ""
 
-#: src/olympia/amo/templates/amo/site_nav.html:86 src/olympia/browse/feeds.py:207 src/olympia/browse/templates/browse/search_tools.html:3 src/olympia/constants/base.py:176
+#: src/olympia/amo/templates/amo/site_nav.html:84 src/olympia/browse/feeds.py:207 src/olympia/browse/templates/browse/search_tools.html:3 src/olympia/constants/base.py:176
 #: src/olympia/templates/menu_links.html:10
 msgid "Search Tools"
 msgstr ""
@@ -1975,7 +1993,7 @@ msgid "Jump to first page"
 msgstr ""
 
 #: src/olympia/amo/templates/amo/impala/paginator.html:22 src/olympia/amo/templates/amo/mobile/impala_paginator.html:12 src/olympia/discovery/templates/discovery/pane.html:44
-#: src/olympia/discovery/templates/discovery/addons/detail.html:38 src/olympia/stats/templates/stats/stats.html:164
+#: src/olympia/discovery/templates/discovery/addons/detail.html:38 src/olympia/stats/templates/stats/stats.html:166
 msgid "Previous"
 msgstr ""
 
@@ -1996,31 +2014,51 @@ msgstr ""
 msgid "Page {n}"
 msgid_plural "Page {n}"
 msgstr[0] ""
+msgstr[1] ""
 
-#: src/olympia/amo/templates/services/install.html:38
-#, python-format
-msgid "If you are not prompted to install %(addon_name)s in a moment, please <a href=\"%(addon_xpi)s\">click here</a>."
-msgstr ""
-
-#: src/olympia/amo/tests/test_messages.py:57 src/olympia/amo/tests/test_messages.py:58 src/olympia/reviews/forms.py:25 src/olympia/reviews/forms.py:50 src/olympia/reviews/templates/reviews/add.html:56
+#: src/olympia/amo/tests/test_messages.py:56 src/olympia/amo/tests/test_messages.py:57 src/olympia/reviews/forms.py:25 src/olympia/reviews/forms.py:50 src/olympia/reviews/templates/reviews/add.html:56
 #: src/olympia/reviews/templates/reviews/reply.html:30
 msgid "Title"
 msgstr ""
 
-#: src/olympia/amo/tests/test_messages.py:57 src/olympia/amo/tests/test_messages.py:58
+#: src/olympia/amo/tests/test_messages.py:56 src/olympia/amo/tests/test_messages.py:57
 msgid "Body"
 msgstr ""
 
-#: src/olympia/amo/tests/test_messages.py:59
+#: src/olympia/amo/tests/test_messages.py:58
 msgid "Another Title"
 msgstr ""
 
-#: src/olympia/amo/tests/test_messages.py:59
+#: src/olympia/amo/tests/test_messages.py:58
 msgid "Another Body"
 msgstr ""
 
-#: src/olympia/api/views.py:255
-msgid "Not implemented yet."
+#: src/olympia/api/authentication.py:76
+msgid "Signature has expired."
+msgstr ""
+
+#: src/olympia/api/authentication.py:79
+msgid "Error decoding signature."
+msgstr ""
+
+#: src/olympia/api/authentication.py:82
+msgid "Invalid JWT Token."
+msgstr ""
+
+#: src/olympia/api/authentication.py:130
+msgid "Invalid Authorization header. No credentials provided."
+msgstr ""
+
+#: src/olympia/api/authentication.py:133
+msgid "Invalid Authorization header. Credentials string should not contain spaces."
+msgstr ""
+
+#: src/olympia/api/fields.py:29
+msgid "The field must have a length of at least {num} characters."
+msgstr ""
+
+#: src/olympia/api/fields.py:31
+msgid "The language code {lang_code} is invalid."
 msgstr ""
 
 #: src/olympia/applications/views.py:39 src/olympia/applications/templates/applications/appversions.html:3
@@ -2039,7 +2077,7 @@ msgstr ""
 msgid "Add-ons submitted to Mozilla Add-ons must have a manifest file with at least one of the below applications supported. Only the versions listed below are allowed for these applications."
 msgstr ""
 
-#: src/olympia/applications/templates/applications/appversions.html:25
+#: src/olympia/applications/templates/applications/appversions.html:25 src/olympia/editors/helpers.py:361
 msgid "GUID"
 msgstr ""
 
@@ -2153,8 +2191,8 @@ msgstr ""
 msgid "Remove from favorites"
 msgstr ""
 
-#: src/olympia/bandwagon/views.py:98 src/olympia/bandwagon/views.py:191 src/olympia/browse/views.py:58 src/olympia/browse/views.py:69 src/olympia/browse/views.py:458 src/olympia/devhub/views.py:74
-#: src/olympia/devhub/views.py:82 src/olympia/devhub/templates/devhub/addons/edit/basic.html:20 src/olympia/editors/templates/editors/leaderboard.html:24
+#: src/olympia/bandwagon/views.py:98 src/olympia/bandwagon/views.py:191 src/olympia/browse/views.py:58 src/olympia/browse/views.py:69 src/olympia/browse/views.py:425 src/olympia/devhub/views.py:72
+#: src/olympia/devhub/views.py:80 src/olympia/devhub/templates/devhub/addons/edit/basic.html:20 src/olympia/editors/templates/editors/leaderboard.html:24
 #: src/olympia/editors/templates/editors/themes/queue_list.html:48 src/olympia/search/forms.py:17 src/olympia/search/forms.py:89 src/olympia/users/templates/users/vcard.html:5
 msgid "Name"
 msgstr ""
@@ -2163,7 +2201,7 @@ msgstr ""
 msgid "Recently Popular"
 msgstr ""
 
-#: src/olympia/bandwagon/views.py:189 src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:18
+#: src/olympia/bandwagon/views.py:189 src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:16
 msgid "Added"
 msgstr ""
 
@@ -2177,7 +2215,7 @@ msgstr ""
 
 #: src/olympia/bandwagon/views.py:316
 #, python-format
-msgid "Your new collection is shown below. You can <ahref=\"%(url)s\">edit additional settings</a> if you'dlike."
+msgid "Your new collection is shown below. You can <a href=\"%(url)s\">edit additional settings</a> if you'd like."
 msgstr ""
 
 #: src/olympia/bandwagon/views.py:322
@@ -2257,6 +2295,7 @@ msgstr ""
 msgid "<span>%(num)s</span> follower"
 msgid_plural "<span>%(num)s</span> followers"
 msgstr[0] ""
+msgstr[1] ""
 
 #: src/olympia/bandwagon/templates/bandwagon/collection_detail.html:54
 msgid "About this Collection"
@@ -2295,15 +2334,17 @@ msgstr ""
 msgid "%(num)s Theme in this Collection"
 msgid_plural "%(num)s Themes in this Collection"
 msgstr[0] ""
+msgstr[1] ""
 
 #: src/olympia/bandwagon/templates/bandwagon/collection_detail.html:111
 #, python-format
 msgid "%(num)s Add-on in this Collection"
 msgid_plural "%(num)s Add-ons in this Collection"
 msgstr[0] ""
+msgstr[1] ""
 
-#: src/olympia/bandwagon/templates/bandwagon/collection_detail.html:125 src/olympia/compat/templates/compat/index.html:25 src/olympia/compat/templates/compat/reporter_detail.html:29
-#: src/olympia/files/templates/files/viewer.html:29 src/olympia/templates/amo_footer.html:17 src/olympia/templates/includes/lang_switcher.html:10
+#: src/olympia/bandwagon/templates/bandwagon/collection_detail.html:125 src/olympia/compat/templates/compat/reporter_detail.html:29 src/olympia/files/templates/files/viewer.html:29
+#: src/olympia/templates/amo_footer.html:17 src/olympia/templates/includes/lang_switcher.html:10
 msgid "Go"
 msgstr ""
 
@@ -2348,12 +2389,14 @@ msgstr ""
 msgid "<span>%(addons)s</span> add-on"
 msgid_plural "<span>%(addons)s</span> add-ons"
 msgstr[0] ""
+msgstr[1] ""
 
 #: src/olympia/bandwagon/templates/bandwagon/collection_grid.html:32
 #, python-format
 msgid "<span>%(followers)s</span> follower"
 msgid_plural "<span>%(followers)s</span> followers"
 msgstr[0] ""
+msgstr[1] ""
 
 #. People "follow" collections to get notified of updates.                    Like
 #. Twitter followers.
@@ -2364,6 +2407,7 @@ msgstr[0] ""
 msgid "%(num)s weekly follower"
 msgid_plural "%(num)s weekly followers"
 msgstr[0] ""
+msgstr[1] ""
 
 #. People "follow" collections to get notified of updates.                    Like
 #. Twitter followers.
@@ -2372,6 +2416,7 @@ msgstr[0] ""
 msgid "%(num)s monthly follower"
 msgid_plural "%(num)s monthly followers"
 msgstr[0] ""
+msgstr[1] ""
 
 #. People "follow" collections to get notified of updates.                    Like
 #. Twitter followers.
@@ -2382,6 +2427,7 @@ msgstr[0] ""
 msgid "%(num)s follower"
 msgid_plural "%(num)s followers"
 msgstr[0] ""
+msgstr[1] ""
 
 #: src/olympia/bandwagon/templates/bandwagon/collection_listing_items.html:56 src/olympia/bandwagon/templates/bandwagon/impala/collection_listing_items.html:9
 #: src/olympia/devhub/templates/devhub/personas/edit.html:27
@@ -2465,7 +2511,7 @@ msgid "Remove this user as a contributor"
 msgstr ""
 
 #: src/olympia/bandwagon/templates/bandwagon/edit_contributors.html:18 src/olympia/bandwagon/templates/bandwagon/edit_contributors.html:43
-#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:20 src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:48
+#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:18 src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:46
 #: src/olympia/devhub/templates/devhub/addons/ajax_compat_update.html:19
 msgid "Remove"
 msgstr ""
@@ -2513,7 +2559,7 @@ msgid "<b>Warning:</b> By changing the owner of this collection, you will no lon
 msgstr ""
 
 #: src/olympia/bandwagon/templates/bandwagon/edit_contributors.html:83 src/olympia/devhub/templates/devhub/addons/forms_shared/media.html:157
-#: src/olympia/devhub/templates/devhub/addons/submit/describe.html:69 src/olympia/devhub/templates/devhub/addons/submit/license.html:60 src/olympia/devhub/templates/devhub/addons/submit/upload.html:78
+#: src/olympia/devhub/templates/devhub/addons/submit/describe.html:69 src/olympia/devhub/templates/devhub/addons/submit/license.html:60 src/olympia/devhub/templates/devhub/addons/submit/upload.html:70
 #: src/olympia/devhub/templates/devhub/payments/tier.html:17 src/olympia/editors/templates/editors/themes/themes.html:111 src/olympia/editors/templates/editors/themes/themes.html:128
 #: src/olympia/editors/templates/editors/themes/themes.html:134 src/olympia/editors/templates/editors/themes/themes.html:141 src/olympia/users/templates/users/fxa_migration_prompt_content.html:10
 #: src/olympia/users/templates/users/login_form.html:42 src/olympia/users/templates/users/mobile/login.html:57
@@ -2596,31 +2642,31 @@ msgid "Add-ons in Your Collection"
 msgstr ""
 
 #: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:4
-msgid ""
-"To include an add-on in this collection, enter its name in the box below and hit enter.  You can also use the <strong>Add to Collection</strong> links throughout the site to include add-ons later."
+msgid "To include an add-on in this collection, enter its name in the box below and hit enter."
 msgstr ""
 
-#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:17 src/olympia/constants/base.py:400 src/olympia/devhub/templates/devhub/addons/activity.html:62
+#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:15 src/olympia/constants/base.py:400 src/olympia/devhub/templates/devhub/addons/activity.html:62
+#: src/olympia/editors/helpers.py:273 src/olympia/editors/helpers.py:360
 msgid "Add-on"
 msgstr ""
 
-#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:26
+#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:24
 msgid "Enter the name of the add-on to include"
 msgstr ""
 
-#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:28
+#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:26
 msgid "Add to Collection"
 msgstr ""
 
-#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:45 src/olympia/editors/helpers.py:936 src/olympia/editors/helpers.py:956
+#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:43 src/olympia/editors/helpers.py:1016 src/olympia/editors/helpers.py:1036
 msgid "Pending"
 msgstr ""
 
-#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:47
+#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:45
 msgid "Add a comment"
 msgstr ""
 
-#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:48
+#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:46
 msgid "Remove this add-on from the collection"
 msgstr ""
 
@@ -2727,12 +2773,12 @@ msgstr ""
 msgid "Most Users"
 msgstr ""
 
-#: src/olympia/browse/views.py:61 src/olympia/browse/views.py:72 src/olympia/browse/views.py:279 src/olympia/browse/templates/browse/personas/mobile/category_landing.html:63
+#: src/olympia/browse/views.py:61 src/olympia/browse/views.py:72 src/olympia/browse/views.py:246 src/olympia/browse/templates/browse/personas/mobile/category_landing.html:63
 #: src/olympia/discovery/templates/discovery/pane.html:67 src/olympia/search/forms.py:92
 msgid "Up & Coming"
 msgstr ""
 
-#: src/olympia/browse/views.py:460 src/olympia/devhub/views.py:76 src/olympia/devhub/views.py:83 src/olympia/discovery/templates/discovery/addons/detail.html:66
+#: src/olympia/browse/views.py:427 src/olympia/devhub/views.py:74 src/olympia/devhub/views.py:81 src/olympia/discovery/templates/discovery/addons/detail.html:66
 msgid "Created"
 msgstr ""
 
@@ -2812,6 +2858,7 @@ msgstr ""
 msgid "<b>{0}</b> add-on"
 msgid_plural "<b>{0}</b> add-ons"
 msgstr[0] ""
+msgstr[1] ""
 
 #: src/olympia/browse/templates/browse/search_tools.html:61
 msgid "Search Extensions"
@@ -2917,9 +2964,10 @@ msgstr ""
 msgid "See the %(cnt)s extension in %(name)s &raquo;"
 msgid_plural "See all %(cnt)s extensions in %(name)s &raquo;"
 msgstr[0] ""
+msgstr[1] ""
 
-#: src/olympia/browse/templates/browse/mobile/extensions.html:13 src/olympia/compat/templates/compat/index.html:82 src/olympia/devhub/templates/devhub/devhub_search.html:24
-#: src/olympia/devhub/templates/devhub/addons/activity.html:47 src/olympia/search/templates/search/no_results.html:4 src/olympia/search/templates/search/mobile/results.html:36
+#: src/olympia/browse/templates/browse/mobile/extensions.html:13 src/olympia/devhub/templates/devhub/devhub_search.html:24 src/olympia/devhub/templates/devhub/addons/activity.html:47
+#: src/olympia/search/templates/search/no_results.html:4 src/olympia/search/templates/search/mobile/results.html:36
 msgid "No results found."
 msgstr ""
 
@@ -3004,7 +3052,7 @@ msgstr ""
 msgid "All"
 msgstr ""
 
-#: src/olympia/compat/forms.py:22 src/olympia/search/views.py:525
+#: src/olympia/compat/forms.py:22 src/olympia/editors/templates/editors/base.html:69 src/olympia/search/views.py:518
 msgid "All Add-ons"
 msgstr ""
 
@@ -3014,53 +3062,6 @@ msgstr ""
 
 #: src/olympia/compat/forms.py:24
 msgid "Non-binary"
-msgstr ""
-
-#. Review points sources other than add-ons and themes.
-#: src/olympia/compat/views.py:87 src/olympia/constants/base.py:388 src/olympia/devhub/forms.py:162 src/olympia/editors/templates/editors/performance.html:75
-msgid "Other"
-msgstr ""
-
-#: src/olympia/compat/templates/compat/index.html:4
-msgid "Add-on Compatibility Report for {app} {version}"
-msgstr ""
-
-#: src/olympia/compat/templates/compat/index.html:11
-msgid "{app} {version} Compatibility"
-msgstr ""
-
-#: src/olympia/compat/templates/compat/index.html:17
-#, python-format
-msgid "Top 95%% compatible with previous version"
-msgstr ""
-
-#: src/olympia/compat/templates/compat/index.html:18
-#, python-format
-msgid "Top 95%% of all add-ons"
-msgstr ""
-
-#: src/olympia/compat/templates/compat/index.html:19
-msgid "All active add-ons"
-msgstr ""
-
-#: src/olympia/compat/templates/compat/index.html:23 src/olympia/constants/base.py:401
-msgid "App"
-msgstr ""
-
-#: src/olympia/compat/templates/compat/index.html:55
-msgid "Details for add-ons compatible with previous version:"
-msgstr ""
-
-#: src/olympia/compat/templates/compat/index.html:57
-msgid "Show all versions"
-msgstr ""
-
-#: src/olympia/compat/templates/compat/index.html:59
-msgid "Details for add-ons compatible with all versions:"
-msgstr ""
-
-#: src/olympia/compat/templates/compat/index.html:61
-msgid "Show previous version only"
 msgstr ""
 
 #: src/olympia/compat/templates/compat/reporter.html:3
@@ -3094,11 +3095,13 @@ msgstr ""
 msgid "{0} success report"
 msgid_plural "{0} success reports"
 msgstr[0] ""
+msgstr[1] ""
 
 #: src/olympia/compat/templates/compat/reporter_detail.html:17
 msgid "{0} problem report"
 msgid_plural "{0} problem reports"
 msgstr[0] ""
+msgstr[1] ""
 
 #: src/olympia/compat/templates/compat/reporter_detail.html:21 src/olympia/users/templates/users/profile.html:70
 msgid "View all"
@@ -3112,8 +3115,8 @@ msgstr ""
 msgid "Report Type"
 msgstr ""
 
-#: src/olympia/compat/templates/compat/reporter_detail.html:47 src/olympia/devhub/forms.py:784 src/olympia/devhub/templates/devhub/addons/ajax_compat_update.html:17 src/olympia/editors/forms.py:108
-#: src/olympia/zadmin/forms.py:45
+#: src/olympia/compat/templates/compat/reporter_detail.html:47 src/olympia/devhub/forms.py:785 src/olympia/devhub/templates/devhub/addons/ajax_compat_update.html:17 src/olympia/editors/forms.py:108
+#: src/olympia/editors/forms.py:248 src/olympia/zadmin/forms.py:45
 msgid "Application"
 msgstr ""
 
@@ -3201,7 +3204,8 @@ msgstr ""
 msgid "Preliminarily Reviewed and Awaiting Full Review"
 msgstr ""
 
-#: src/olympia/constants/base.py:33 src/olympia/editors/helpers.py:924 src/olympia/editors/templates/editors/themes/history_table.html:34
+#: src/olympia/constants/base.py:33 src/olympia/editors/forms.py:258 src/olympia/editors/helpers.py:73 src/olympia/editors/helpers.py:1004
+#: src/olympia/editors/templates/editors/themes/history_table.html:34
 msgid "Deleted"
 msgstr ""
 
@@ -3298,6 +3302,11 @@ msgstr ""
 msgid "Ask before users can download this add-on"
 msgstr ""
 
+#. Review points sources other than add-ons and themes.
+#: src/olympia/constants/base.py:388 src/olympia/devhub/forms.py:162 src/olympia/editors/templates/editors/performance.html:75
+msgid "Other"
+msgstr ""
+
 #: src/olympia/constants/base.py:389
 msgid "Exception"
 msgstr ""
@@ -3308,6 +3317,10 @@ msgstr ""
 
 #: src/olympia/constants/base.py:391
 msgid "Change"
+msgstr ""
+
+#: src/olympia/constants/base.py:401
+msgid "App"
 msgstr ""
 
 #: src/olympia/constants/base.py:402
@@ -3458,7 +3471,7 @@ msgstr ""
 msgid "Duplicate"
 msgstr ""
 
-#: src/olympia/constants/editors.py:17 src/olympia/editors/helpers.py:502 src/olympia/editors/templates/editors/themes/queue.html:71 src/olympia/editors/templates/editors/themes/themes.html:94
+#: src/olympia/constants/editors.py:17 src/olympia/editors/helpers.py:575 src/olympia/editors/templates/editors/themes/queue.html:71 src/olympia/editors/templates/editors/themes/themes.html:94
 msgid "Reject"
 msgstr ""
 
@@ -3558,7 +3571,7 @@ msgstr ""
 msgid "Android"
 msgstr ""
 
-#: src/olympia/core/apps.py:19
+#: src/olympia/core/apps.py:21
 msgid "Core"
 msgstr ""
 
@@ -3692,7 +3705,7 @@ msgid "Submit my add-on for manual review."
 msgstr ""
 
 #: src/olympia/devhub/forms.py:537
-msgid "Do not list my add-on on this site (beta)"
+msgid "Do not list my add-on on this site"
 msgstr ""
 
 #: src/olympia/devhub/forms.py:538
@@ -3725,46 +3738,46 @@ msgstr ""
 
 #: src/olympia/devhub/forms.py:592
 #, python-format
-msgid "Version %s already exists"
+msgid "Version %s already exists, or was uploaded before."
 msgstr ""
 
-#: src/olympia/devhub/forms.py:604
+#: src/olympia/devhub/forms.py:605
 msgid "Select a valid choice. That choice is not one of the available choices."
 msgstr ""
 
-#: src/olympia/devhub/forms.py:610
+#: src/olympia/devhub/forms.py:611
 msgid "A file with a version ending with a|alpha|b|beta and an optional number is detected as beta."
 msgstr ""
 
-#: src/olympia/devhub/forms.py:633
+#: src/olympia/devhub/forms.py:634
 msgid "You cannot upload any more files for this version."
 msgstr ""
 
-#: src/olympia/devhub/forms.py:639
+#: src/olympia/devhub/forms.py:640
 msgid "Version doesn't match"
 msgstr ""
 
-#: src/olympia/devhub/forms.py:668
+#: src/olympia/devhub/forms.py:669
 msgid "You cannot delete a file once the review process has started.  You must delete the whole version."
 msgstr ""
 
-#: src/olympia/devhub/forms.py:688
+#: src/olympia/devhub/forms.py:689
 msgid "The platform All cannot be combined with specific platforms."
 msgstr ""
 
-#: src/olympia/devhub/forms.py:693
+#: src/olympia/devhub/forms.py:694
 msgid "A platform can only be chosen once."
 msgstr ""
 
-#: src/olympia/devhub/forms.py:706
+#: src/olympia/devhub/forms.py:707
 msgid "A review type must be selected."
 msgstr ""
 
-#: src/olympia/devhub/forms.py:788 src/olympia/editors/forms.py:114 src/olympia/zadmin/forms.py:49 src/olympia/zadmin/forms.py:52
+#: src/olympia/devhub/forms.py:789 src/olympia/editors/forms.py:114 src/olympia/editors/forms.py:254 src/olympia/zadmin/forms.py:49 src/olympia/zadmin/forms.py:52
 msgid "Select an application first"
 msgstr ""
 
-#: src/olympia/devhub/forms.py:840
+#: src/olympia/devhub/forms.py:841
 msgid "There cannot be more than 3 required add-ons."
 msgstr ""
 
@@ -3785,87 +3798,89 @@ msgstr ""
 msgid "{0} error"
 msgid_plural "{0} errors"
 msgstr[0] ""
+msgstr[1] ""
 
 #. L10n: first parameter is the number of warnings
 #: src/olympia/devhub/helpers.py:203
 msgid "{0} warning"
 msgid_plural "{0} warnings"
 msgstr[0] ""
+msgstr[1] ""
 
 #: src/olympia/devhub/models.py:375 src/olympia/reviews/templates/reviews/add.html:58
 msgid "Review"
 msgstr ""
 
-#: src/olympia/devhub/tasks.py:551
+#: src/olympia/devhub/tasks.py:583
 #, python-format
 msgid "%s responded with %s (%s)."
 msgstr ""
 
-#: src/olympia/devhub/tasks.py:555
+#: src/olympia/devhub/tasks.py:587
 #, python-format
 msgid "Connection to \"%s\" timed out."
 msgstr ""
 
-#: src/olympia/devhub/tasks.py:557
+#: src/olympia/devhub/tasks.py:589
 #, python-format
 msgid "Could not contact host at \"%s\"."
 msgstr ""
 
-#: src/olympia/devhub/utils.py:104
+#: src/olympia/devhub/utils.py:105
 #, python-format
 msgid "Validation generated too many errors/warnings so %s messages were truncated. After addressing the visible messages, you'll be able to see the others."
 msgstr ""
 
-#: src/olympia/devhub/views.py:183
+#: src/olympia/devhub/views.py:181
 msgid "All My Add-ons"
 msgstr ""
 
-#: src/olympia/devhub/views.py:210
+#: src/olympia/devhub/views.py:208
 msgid "All Activity"
 msgstr ""
 
-#: src/olympia/devhub/views.py:211
+#: src/olympia/devhub/views.py:209
 msgid "Add-on Updates"
 msgstr ""
 
-#: src/olympia/devhub/views.py:212
+#: src/olympia/devhub/views.py:210
 msgid "Add-on Status"
 msgstr ""
 
-#: src/olympia/devhub/views.py:213
+#: src/olympia/devhub/views.py:211
 msgid "User Collections"
 msgstr ""
 
-#: src/olympia/devhub/views.py:214 src/olympia/devhub/templates/devhub/docs/policies-maintenance.html:68 src/olympia/pages/templates/pages/dev_faq.html:38
+#: src/olympia/devhub/views.py:212 src/olympia/devhub/templates/devhub/docs/policies-maintenance.html:68 src/olympia/pages/templates/pages/dev_faq.html:38
 #: src/olympia/pages/templates/pages/dev_faq.html:484
 msgid "User Reviews"
 msgstr ""
 
-#: src/olympia/devhub/views.py:327 src/olympia/devhub/views.py:331 src/olympia/devhub/views.py:484 src/olympia/devhub/views.py:513 src/olympia/devhub/views.py:564 src/olympia/devhub/views.py:1150
+#: src/olympia/devhub/views.py:325 src/olympia/devhub/views.py:329 src/olympia/devhub/views.py:484 src/olympia/devhub/views.py:513 src/olympia/devhub/views.py:564 src/olympia/devhub/views.py:1156
 msgid "Changes successfully saved."
 msgstr ""
 
-#: src/olympia/devhub/views.py:334 src/olympia/devhub/views.py:1631
+#: src/olympia/devhub/views.py:332 src/olympia/devhub/views.py:1637
 msgid "Please check the form for errors."
 msgstr ""
 
-#: src/olympia/devhub/views.py:346
+#: src/olympia/devhub/views.py:344
 msgid "Add-on cannot be deleted. Disable this add-on instead."
 msgstr ""
 
-#: src/olympia/devhub/views.py:356
+#: src/olympia/devhub/views.py:354
 msgid "Theme deleted."
 msgstr ""
 
-#: src/olympia/devhub/views.py:356
+#: src/olympia/devhub/views.py:354
 msgid "Add-on deleted."
 msgstr ""
 
-#: src/olympia/devhub/views.py:362
+#: src/olympia/devhub/views.py:360
 msgid "URL name was incorrect. Theme was not deleted."
 msgstr ""
 
-#: src/olympia/devhub/views.py:367
+#: src/olympia/devhub/views.py:365
 msgid "URL name was incorrect. Add-on was not deleted."
 msgstr ""
 
@@ -3893,7 +3908,7 @@ msgstr ""
 msgid "Check Add-on Compatibility"
 msgstr ""
 
-#: src/olympia/devhub/views.py:808 src/olympia/signing/views.py:90
+#: src/olympia/devhub/views.py:808 src/olympia/signing/views.py:95
 msgid "You cannot submit this type of add-on"
 msgstr ""
 
@@ -3923,33 +3938,33 @@ msgstr ""
 msgid "There was an error uploading your preview."
 msgstr ""
 
-#: src/olympia/devhub/views.py:1189
+#: src/olympia/devhub/views.py:1195
 #, python-format
 msgid "Version %s disabled."
 msgstr ""
 
-#: src/olympia/devhub/views.py:1193
+#: src/olympia/devhub/views.py:1199
 #, python-format
 msgid "Version %s deleted."
 msgstr ""
 
-#: src/olympia/devhub/views.py:1203
+#: src/olympia/devhub/views.py:1209
 msgid "This upload has failed validation, and may lack complete validation results. Please take due care when reviewing it."
 msgstr ""
 
-#: src/olympia/devhub/views.py:1677
+#: src/olympia/devhub/views.py:1683
 msgid "Preliminary Review Requested."
 msgstr ""
 
-#: src/olympia/devhub/views.py:1678
+#: src/olympia/devhub/views.py:1684
 msgid "Full Review Requested."
 msgstr ""
 
-#: src/olympia/devhub/views.py:1779
+#: src/olympia/devhub/views.py:1783
 msgid "Your old credentials were revoked and are no longer valid. Be sure to update all API clients with the new credentials."
 msgstr ""
 
-#: src/olympia/devhub/views.py:1797
+#: src/olympia/devhub/views.py:1801
 msgid "New API key created"
 msgstr ""
 
@@ -3979,7 +3994,7 @@ msgstr ""
 msgid "{0} :: Search"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/devhub_search.html:6 src/olympia/devhub/templates/devhub/search.html:8 src/olympia/editors/forms.py:435 src/olympia/editors/forms.py:437
+#: src/olympia/devhub/templates/devhub/devhub_search.html:6 src/olympia/devhub/templates/devhub/search.html:8 src/olympia/editors/forms.py:534 src/olympia/editors/forms.py:536
 #: src/olympia/editors/templates/editors/queue.html:27 src/olympia/editors/templates/editors/themes/queue_list.html:14 src/olympia/search/templates/search/collections.html:17
 #: src/olympia/search/templates/search/personas.html:18 src/olympia/search/templates/search/results.html:18 src/olympia/search/templates/search/mobile/results.html:8
 #: src/olympia/templates/search.html:14 src/olympia/templates/impala/search.html:18
@@ -4039,12 +4054,12 @@ msgstr ""
 msgid "Start Making Add-ons"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/index.html:86 src/olympia/devhub/templates/devhub/addons/listing/items.html:25 src/olympia/devhub/templates/devhub/includes/addon_details.html:15
+#: src/olympia/devhub/templates/devhub/index.html:86 src/olympia/devhub/templates/devhub/addons/listing/items.html:25 src/olympia/devhub/templates/devhub/includes/addon_details.html:20
 #: src/olympia/devhub/templates/devhub/personas/edit.html:43
 msgid "Status:"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/index.html:90 src/olympia/devhub/templates/devhub/includes/addon_details.html:100
+#: src/olympia/devhub/templates/devhub/index.html:90 src/olympia/devhub/templates/devhub/includes/addon_details.html:87
 msgid "Visibility:"
 msgstr ""
 
@@ -4052,11 +4067,11 @@ msgstr ""
 msgid "Latest Version:"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/index.html:109 src/olympia/devhub/templates/devhub/includes/addon_details.html:145 src/olympia/devhub/templates/devhub/personas/edit.html:49
+#: src/olympia/devhub/templates/devhub/index.html:109 src/olympia/devhub/templates/devhub/includes/addon_details.html:131 src/olympia/devhub/templates/devhub/personas/edit.html:49
 msgid "Queue Position:"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/index.html:110 src/olympia/devhub/templates/devhub/includes/addon_details.html:146 src/olympia/devhub/templates/devhub/personas/edit.html:50
+#: src/olympia/devhub/templates/devhub/index.html:110 src/olympia/devhub/templates/devhub/includes/addon_details.html:132 src/olympia/devhub/templates/devhub/personas/edit.html:50
 #, python-format
 msgid "%(position)s of %(total)s"
 msgstr ""
@@ -4158,16 +4173,6 @@ msgstr ""
 msgid "Do you want your add-on to be distributed on this site?"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/validate_addon.html:49 src/olympia/devhub/templates/devhub/addons/submit/upload.html:30 src/olympia/devhub/templates/devhub/versions/add_file_modal.html:14
-#: src/olympia/devhub/templates/devhub/versions/add_file_modal.html:53 src/olympia/devhub/templates/devhub/versions/list.html:298
-msgid "Warning:"
-msgstr ""
-
-#: src/olympia/devhub/templates/devhub/validate_addon.html:50 src/olympia/devhub/templates/devhub/addons/submit/upload.html:31
-#, python-format
-msgid "Submission of unlisted add-ons for signing is currently in an open beta. Please <a href=\"%(url)s\" target=\"_blank\">report any bugs</a> that you encounter."
-msgstr ""
-
 #. first parameter is a filename like lorem-ipsum-1.0.2.xpi
 #: src/olympia/devhub/templates/devhub/validation.html:5
 msgid "Validation Results for {0}"
@@ -4242,7 +4247,7 @@ msgstr ""
 msgid "Update Compatibility"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/addons/ajax_compat_update.html:4
+#: src/olympia/devhub/templates/devhub/addons/ajax_compat_update.html:4 src/olympia/devhub/templates/devhub/versions/edit.html:45
 msgid "Adjusting application information here will allow users to install your add-on even if the install manifest in the package indicates that the add-on is incompatible."
 msgstr ""
 
@@ -4254,9 +4259,9 @@ msgstr ""
 msgid "Add Another Application&hellip;"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/addons/ajax_compat_update.html:38 src/olympia/devhub/templates/devhub/addons/owner.html:86 src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:46
-#: src/olympia/devhub/templates/devhub/versions/list.html:351 src/olympia/devhub/templates/devhub/versions/list.html:353 src/olympia/templates/impala/base.html:132
-#: src/olympia/templates/impala/base.html:143 src/olympia/templates/impala/base.html:161 src/olympia/templates/impala/base.html:171
+#: src/olympia/devhub/templates/devhub/addons/ajax_compat_update.html:38 src/olympia/devhub/templates/devhub/addons/owner.html:86 src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:45
+#: src/olympia/devhub/templates/devhub/versions/list.html:349 src/olympia/devhub/templates/devhub/versions/list.html:351 src/olympia/templates/impala/base.html:129
+#: src/olympia/templates/impala/base.html:140 src/olympia/templates/impala/base.html:158 src/olympia/templates/impala/base.html:168
 msgid "Close"
 msgstr ""
 
@@ -4274,6 +4279,7 @@ msgstr ""
 msgid "<b>{0}</b> theme"
 msgid_plural "<b>{0}</b> themes"
 msgstr[0] ""
+msgstr[1] ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit.html:3 src/olympia/devhub/templates/devhub/addons/listing/item_actions.html:25
 #: src/olympia/devhub/templates/devhub/addons/listing/item_actions_theme.html:7 src/olympia/devhub/templates/devhub/includes/addons_edit_nav.html:2
@@ -4289,7 +4295,7 @@ msgstr ""
 msgid "Manage Authors & License"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/addons/owner.html:29 src/olympia/editors/templates/editors/review.html:270
+#: src/olympia/devhub/templates/devhub/addons/owner.html:29 src/olympia/editors/helpers.py:362 src/olympia/editors/templates/editors/review.html:270
 msgid "Authors"
 msgstr ""
 
@@ -4358,17 +4364,11 @@ msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/basic.html:52
 msgid ""
-"A short explanation of your add-on's basic\n"
-"                          functionality that is displayed in search and browse\n"
-"                          listings, as well as at the top of your add-on's\n"
-"                          details page. It is only relevant for listed add-ons."
+"A short explanation of your add-on's basic functionality that is displayed in search and browse listings, as well as at the top of your add-on's details page. It is only relevant for listed add-ons."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/basic.html:73
-msgid ""
-"Categories are the primary way users browse through add-ons.\n"
-"                        Choose any that fit your add-on's functionality for the most\n"
-"                        exposure. It is only relevant for listed add-ons."
+msgid "Categories are the primary way users browse through add-ons. Choose any that fit your add-on's functionality for the most exposure. It is only relevant for listed add-ons."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/basic.html:90
@@ -4378,17 +4378,14 @@ msgid ""
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/basic.html:119
-msgid ""
-"Tags help users find your add-on and should be short\n"
-"                        descriptors such as tabs, toolbar, or twitter.  You\n"
-"                        may have a maximum of {0} tags. It is only relevant\n"
-"                        for listed add-ons."
+msgid "Tags help users find your add-on and should be short descriptors such as tabs, toolbar, or twitter. You may have a maximum of {0} tags. It is only relevant for listed add-ons."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/basic.html:129 src/olympia/devhub/templates/devhub/personas/edit.html:97 src/olympia/devhub/templates/devhub/personas/submit.html:46
 msgid "Comma-separated, minimum of {0} character."
 msgid_plural "Comma-separated, minimum of {0} characters."
 msgstr[0] ""
+msgstr[1] ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/basic.html:132 src/olympia/devhub/templates/devhub/personas/edit.html:100 src/olympia/devhub/templates/devhub/personas/submit.html:49
 msgid "Example: dark, cinema, noir. Limit 20."
@@ -4398,6 +4395,7 @@ msgstr ""
 msgid "Reserved tag:"
 msgid_plural "Reserved tags:"
 msgstr[0] ""
+msgstr[1] ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/details.html:5
 msgid "Add-on Details"
@@ -4408,11 +4406,7 @@ msgid "Add-on Details for {0}"
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/details.html:22
-msgid ""
-"A longer explanation of features,\n"
-"                          functionality, and other relevant information. This\n"
-"                          field is only displayed on the add-on's details\n"
-"                          page. It is only relevant for listed add-ons."
+msgid "A longer explanation of features, functionality, and other relevant information. This field is only displayed on the add-on's details page. It is only relevant for listed add-ons."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/details.html:44 src/olympia/translations/templates/translations/trans-menu.html:13
@@ -4420,10 +4414,7 @@ msgid "Default Locale"
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/details.html:45
-msgid ""
-"Information about your add-on is displayed in this locale\n"
-"                        unless you override it with a locale-specific translation.\n"
-"                        It is only relevant for listed add-ons."
+msgid "Information about your add-on is displayed in this locale unless you override it with a locale-specific translation. It is only relevant for listed add-ons."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/details.html:61 src/olympia/users/forms.py:311 src/olympia/users/templates/users/edit.html:122 src/olympia/users/templates/users/register.html:57
@@ -4433,10 +4424,8 @@ msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/details.html:63
 msgid ""
-"If your add-on has another homepage, enter its\n"
-"                          address here. If your website is localized into other\n"
-"                          languages multiple translations of this field can be\n"
-"                          added. It is only relevant for listed add-ons."
+"If your add-on has another homepage, enter its address here. If your website is localized into other languages multiple translations of this field can be added. It is only relevant for listed add-"
+"ons."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/media.html:3
@@ -4454,19 +4443,14 @@ msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/support.html:22
 msgid ""
-"If you wish to display an e-mail address for support\n"
-"                          inquiries, enter it here. If you have different\n"
-"                          addresses for each language multiple translations of\n"
-"                          this field can be added. It is only relevant for\n"
-"                          listed add-ons."
+"If you wish to display an e-mail address for support inquiries, enter it here. If you have different addresses for each language multiple translations of this field can be added. It is only "
+"relevant for listed add-ons."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/support.html:45
 msgid ""
-"If your add-on has a support website or forum, enter\n"
-"                          its address here. If your website is localized into\n"
-"                          other languages, multiple translations of this field can\n"
-"                          be added. It is only relevant for listed add-ons."
+"If your add-on has a support website or forum, enter its address here. If your website is localized into other languages, multiple translations of this field can be added. It is only relevant for "
+"listed add-ons."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:6
@@ -4480,11 +4464,8 @@ msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:23
 msgid ""
-"Any information end users may want to know that isn't\n"
-"                          necessarily applicable to the add-on summary or description.\n"
-"                          Common uses include listing known major bugs, information on\n"
-"                          how to report bugs, anticipated release date of a new version,\n"
-"                          etc. It is only relevant for listed add-ons."
+"Any information end users may want to know that isn't necessarily applicable to the add-on summary or description. Common uses include listing known major bugs, information on how to report bugs, "
+"anticipated release date of a new version, etc. It is only relevant for listed add-ons."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:46
@@ -4496,9 +4477,7 @@ msgid "Add-on Flags"
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:69
-msgid ""
-"These flags are used to classify add-ons. It is only\n"
-"                        relevant for listed add-ons."
+msgid "These flags are used to classify add-ons. It is only relevant for listed add-ons."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:74
@@ -4514,9 +4493,7 @@ msgid "View Source?"
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:90
-msgid ""
-"Whether the source of your add-on can be displayed in our\n"
-"                        online viewer. It is only relevant for listed add-ons."
+msgid "Whether the source of your add-on can be displayed in our online viewer. It is only relevant for listed add-ons."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:94
@@ -4532,10 +4509,7 @@ msgid "Public Stats?"
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:102
-msgid ""
-"Whether the download and usage stats of your add-on can\n"
-"                        be displayed in our online viewer.\n"
-"                        It is only relevant for listed add-ons."
+msgid "Whether the download and usage stats of your add-on can be displayed in our online viewer. It is only relevant for listed add-ons."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:107
@@ -4551,10 +4525,7 @@ msgid "Upgrade SDK?"
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:116
-msgid ""
-"If selected, we will try to automatically upgrade your\n"
-"                        add-on when a new version of the SDK is released.\n"
-"                        It is only relevant for listed add-ons."
+msgid "If selected, we will try to automatically upgrade your add-on when a new version of the SDK is released. It is only relevant for listed add-ons."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:121
@@ -4605,10 +4576,8 @@ msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/forms_shared/media.html:16
 msgid ""
-"Upload an icon for your add-on or choose from one of ours. The\n"
-"                      icon is displayed nearly everywhere your add-on is. Uploaded images\n"
-"                      must be one of the following image types: .png, .jpg.\n"
-"                      It is only relevant for listed add-ons."
+"Upload an icon for your add-on or choose from one of ours. The icon is displayed nearly everywhere your add-on is. Uploaded images must be one of the following image types: .png, .jpg. It is only "
+"relevant for listed add-ons."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/forms_shared/media.html:25
@@ -4621,9 +4590,7 @@ msgid "32x32px"
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/forms_shared/media.html:39
-msgid ""
-"Used in listings of add-ons, like search results\n"
-"                            and featured add-ons."
+msgid "Used in listings of add-ons, like search results and featured add-ons."
 msgstr ""
 
 #. The size of the icon
@@ -4718,16 +4685,14 @@ msgid "Deleting your add-on will permanently remove it from the site and prevent
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:24
-msgid ""
-"Enter the following text confirm your decision:\n"
-"           {slug}"
+msgid "Enter the following text confirm your decision: {slug}"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:34
+#: src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:33
 msgid "Please tell us why you are deleting your theme:"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:36
+#: src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:35
 msgid "Please tell us why you are deleting your add-on:"
 msgstr ""
 
@@ -4764,8 +4729,8 @@ msgstr ""
 msgid "Daily statistics on downloads and users."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/addons/listing/item_actions.html:45 src/olympia/stats/templates/stats/stats.html:75 src/olympia/stats/templates/stats/stats.html:79
-#: src/olympia/stats/templates/stats/stats.html:81
+#: src/olympia/devhub/templates/devhub/addons/listing/item_actions.html:45 src/olympia/stats/templates/stats/stats.html:31 src/olympia/stats/templates/stats/stats.html:35
+#: src/olympia/stats/templates/stats/stats.html:37
 msgid "Statistics"
 msgstr ""
 
@@ -4825,6 +4790,7 @@ msgstr ""
 msgid "<strong>{0}</strong> active user"
 msgid_plural "<strong>{0}</strong> active users"
 msgstr[0] ""
+msgstr[1] ""
 
 #: src/olympia/devhub/templates/devhub/addons/submit/base.html:11
 msgid "Submit Add-on"
@@ -4883,10 +4849,7 @@ msgid "Your add-on has been submitted to the Full Review queue."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/submit/done.html:18
-msgid ""
-"You'll receive an email once it has been reviewed by an editor. In\n"
-"          the meantime, you and your friends can install it directly from its\n"
-"          details page:"
+msgid "You'll receive an email once it has been reviewed by an editor. In the meantime, you and your friends can install it directly from its details page:"
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/submit/done.html:27 src/olympia/devhub/templates/devhub/addons/submit/done.html:77 src/olympia/devhub/templates/devhub/personas/submit_done.html:16
@@ -5092,11 +5055,11 @@ msgstr ""
 msgid "Use the fields below to upload your add-on package and select any platform restrictions. After upload, a series of automated validation tests will be run on your file."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/addons/submit/upload.html:59 src/olympia/devhub/templates/devhub/versions/add_file_modal.html:39
+#: src/olympia/devhub/templates/devhub/addons/submit/upload.html:51 src/olympia/devhub/templates/devhub/versions/add_file_modal.html:28
 msgid "Which platforms is this file compatible with?"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/addons/submit/upload.html:67 src/olympia/devhub/templates/devhub/versions/add_file_modal.html:65
+#: src/olympia/devhub/templates/devhub/addons/submit/upload.html:59 src/olympia/devhub/templates/devhub/versions/add_file_modal.html:45
 msgid "Administrative overrides"
 msgstr ""
 
@@ -5206,8 +5169,8 @@ msgstr ""
 
 #: src/olympia/devhub/templates/devhub/docs/policies-contact.html:44
 msgid ""
-"If you've found a problem with the site, we'd love to fix it. Please <a href=\"https://github.com/mozilla/olympia/issues\">file a bug report</a> in GitHub, including the location of the problem and "
-"how you encountered it."
+"If you've found a problem with the site, we'd love to fix it. Please <a href=\"https://github.com/mozilla/addons/issues/new\">file a bug report</a> in GitHub, including the location of the problem "
+"and how you encountered it."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/docs/policies-maintenance.html:3 src/olympia/devhub/templates/devhub/docs/policies-maintenance.html:7
@@ -5774,7 +5737,7 @@ msgstr ""
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:282
 msgid ""
-"Add-ons that store or otherwise handle browsing data must support <a href=\"https://developer.mozilla.org/En/Supporting_private_browsing_mode\">Private Browsing Mode</a>.  During a Private Browsing "
+"Add-ons that store or otherwise handle browsing data must support <a href=\"https://developer.mozilla.org/En/Supporting_private_browsing_mode\">Private Browsing Mode</a>. During a Private Browsing "
 "session, no browsing data can be written to disk, and all of this data must be cleared when Firefox quits or the Private Browsing session ends."
 msgstr ""
 
@@ -5939,129 +5902,95 @@ msgstr ""
 msgid "How to get in touch with us regarding these policies or your add-on."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:6
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:10
 msgid "You have disabled this add-on"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:20
-msgid ""
-"Your add-on's listing is disabled and is not showing\n"
-"                             anywhere in our gallery or update service."
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:24
+msgid "Your add-on's listing is disabled and is not showing anywhere in our gallery or update service."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:25
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:27
 msgid "Please complete your add-on."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:29
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:30
 msgid "You will receive an email when the review is complete."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:34
-msgid ""
-"You will receive an email when the review is complete. Until\n"
-"                             then, your add-on is not listed in our gallery but can be\n"
-"                             accessed directly from its details page."
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:33
+msgid "You will receive an email when the review is complete. Until then, your add-on is not listed in our gallery but can be accessed directly from its details page."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:38 src/olympia/devhub/templates/devhub/includes/addon_details.html:48
-msgid ""
-"You will receive an email when the review is\n"
-"                             complete and your add-on is signed."
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:37 src/olympia/devhub/templates/devhub/includes/addon_details.html:45
+msgid "You will receive an email when the review is complete and your add-on is signed."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:44
-msgid ""
-"You will receive an email when the review is complete. Until\n"
-"                             then, your add-on is not listed in our gallery but can be\n"
-"                             accessed directly from its details page. "
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:41
+msgid "You will receive an email when the review is complete. Until then, your add-on is not listed in our gallery but can be accessed directly from its details page. "
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:54
-msgid ""
-"Your add-on is displayed in our gallery and users are\n"
-"                             receiving automatic updates."
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:49
+msgid "Your add-on is displayed in our gallery and users are receiving automatic updates."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:57
-msgid ""
-"Your add-on has been signed and can be bundled with an\n"
-"                             application installer."
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:52
+msgid "Your add-on has been signed and can be bundled with an application installer."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:63
-msgid ""
-"Your add-on was disabled by a site administrator and is no\n"
-"                             longer shown in our gallery. If you have any questions,\n"
-"                             please email amo-admins@mozilla.org."
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:56
+msgid "Your add-on was disabled by a site administrator and is no longer shown in our gallery. If you have any questions, please email amo-admins@mozilla.org."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:70
-msgid ""
-"Your add-on is displayed in our gallery as experimental\n"
-"                             and users are receiving automatic updates. Some features\n"
-"                             are unavailable to your add-on."
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:62
+msgid "Your add-on is displayed in our gallery as experimental and users are receiving automatic updates. Some features are unavailable to your add-on."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:74
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:66
 msgid "Your add-on has been signed."
 msgstr ""
 
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:69
+msgid ""
+"You will receive an email when the full review is complete. Until then, your add-on is displayed in our gallery as experimental and users are receiving automatic updates. Some features are "
+"unavailable to your add-on."
+msgstr ""
+
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:74
+msgid "You will receive an email when the full review is complete, making you able to bundle your add-on with an application installer."
+msgstr ""
+
 #: src/olympia/devhub/templates/devhub/includes/addon_details.html:79
-msgid ""
-"You will receive an email when the full review is complete.\n"
-"                             Until then, your add-on is displayed in our gallery as\n"
-"                             experimental and users are receiving automatic updates.\n"
-"                             Some features are unavailable to your add-on."
+msgid "All add-ons hosted in our gallery must now be reviewed by an editor. If you wish to continue hosting your add-on, please click to select a review process."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:84
-msgid ""
-"You will receive an email when the full review is\n"
-"                             complete, making you able to bundle your add-on with an\n"
-"                             application installer."
-msgstr ""
-
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:91
-msgid ""
-"All add-ons hosted in our gallery must now be reviewed by an\n"
-"                             editor. If you wish to continue hosting your add-on, please\n"
-"                             click to select a review process."
-msgstr ""
-
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:113
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:100
 msgid "Current Version:"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:115
-msgid ""
-"This is the version of your add-on that will\n"
-"                                           be installed if someone clicks the Install\n"
-"                                           button on addons.mozilla.org. It is only\n"
-"                                           relevant for listed add-ons."
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:102
+msgid "This is the version of your add-on that will be installed if someone clicks the Install button on addons.mozilla.org. It is only relevant for listed add-ons."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:123
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:110
 msgid "Created:"
 msgstr ""
 
 #. {0} is a date. dennis-ignore: E201
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:125 src/olympia/devhub/templates/devhub/includes/addon_details.html:131
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:112 src/olympia/devhub/templates/devhub/includes/addon_details.html:118
 #, python-format
 msgid "%%b %%e, %%Y"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:136
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:123
 msgid "Next Version:"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:138
-msgid ""
-"This is the newest uploaded version, however\n"
-"                                           it isn’t live on the site yet."
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:125
+msgid "This is the newest uploaded version, however it isn’t live on the site yet."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:144 src/olympia/devhub/templates/devhub/versions/list.html:30
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:130 src/olympia/devhub/templates/devhub/versions/list.html:30
 msgid "Queues are not reviewed strictly in order"
 msgstr ""
 
@@ -6129,9 +6058,7 @@ msgid "View the blog &#9658;"
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/includes/license_form.html:6
-msgid ""
-"Please choose a license appropriate for the rights you grant on your source code.\n"
-"                  It is only relevant for listed add-ons."
+msgid "Please choose a license appropriate for the rights you grant on your source code. It is only relevant for listed add-ons."
 msgstr ""
 
 #. {0} is a list of HTML tags.
@@ -6153,18 +6080,16 @@ msgstr ""
 msgid "Select <b>up to {0}</b> {1} category for this add-on:"
 msgid_plural "Select <b>up to {0}</b> {1} categories for this add-on:"
 msgstr[0] ""
+msgstr[1] ""
 
 #: src/olympia/devhub/templates/devhub/includes/policy_form.html:4
 msgid ""
 "Users will be required to accept the following End-User License Agreement (EULA) prior to installing your add-on. The presence of a EULA significantly affects the number of downloads an add-on "
-"receives. Please note that a EULA is not the same as a code license, such as the GPL or MPL.\n"
-"                It is only relevant for listed add-ons."
+"receives. Please note that a EULA is not the same as a code license, such as the GPL or MPL.It is only relevant for listed add-ons."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/policy_form.html:21
-msgid ""
-"If your add-on transmits any data from the user's computer, a privacy policy is required that explains what data is sent and how it is used.\n"
-"                It is only relevant for listed add-ons."
+#: src/olympia/devhub/templates/devhub/includes/policy_form.html:24
+msgid "If your add-on transmits any data from the user's computer, a privacy policy is required that explains what data is sent and how it is used. It is only relevant for listed add-ons."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/includes/source_form_field.html:2
@@ -6332,12 +6257,8 @@ msgstr ""
 msgid "Add some tags to describe your Theme."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/personas/edit.html:106
-msgid ""
-"A short explanation of your theme's\n"
-"                                basic functionality that is displayed in\n"
-"                                search and browse listings, as well as at\n"
-"                                the top of your theme's details page."
+#: src/olympia/devhub/templates/devhub/personas/edit.html:106 src/olympia/devhub/templates/devhub/personas/submit.html:54
+msgid "A short explanation of your theme's basic functionality that is displayed in search and browse listings, as well as at the top of your theme's details page."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/personas/edit.html:122 src/olympia/devhub/templates/devhub/personas/submit.html:68
@@ -6407,7 +6328,7 @@ msgid "Upon upload and form submission, the AMO Team will review your updated de
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/personas/edit.html:241
-msgid "Your previously resubmitted design,  which is under pending review."
+msgid "Your previously resubmitted design, which is under pending review."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/personas/edit.html:245
@@ -6474,14 +6395,6 @@ msgstr ""
 
 #: src/olympia/devhub/templates/devhub/personas/submit.html:33
 msgid "Give your Theme a name."
-msgstr ""
-
-#: src/olympia/devhub/templates/devhub/personas/submit.html:54
-msgid ""
-"A short explanation of your theme's\n"
-"                                      basic functionality that is displayed in\n"
-"                                      search and browse listings, as well as at\n"
-"                                      the top of your theme's details page."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/personas/submit.html:198
@@ -6558,30 +6471,16 @@ msgstr ""
 msgid "Files added to reviewed versions must be reviewed before they will be available for download."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/add_file_modal.html:15
-#, python-format
-msgid ""
-"Submission of updates to unlisted add-ons for signing is currently in an open beta. Manual review may still be required for a large number of add-ons. Please <a href=\"%(url)s\" target=\"_blank"
-"\">report any bugs</a> that you encounter."
-msgstr ""
-
-#: src/olympia/devhub/templates/devhub/versions/add_file_modal.html:35
+#: src/olympia/devhub/templates/devhub/versions/add_file_modal.html:24
 msgid "Select the target platform for this file."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/add_file_modal.html:46
+#: src/olympia/devhub/templates/devhub/versions/add_file_modal.html:35
 msgid "Which review type would you like to nominate for?"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/add_file_modal.html:51
+#: src/olympia/devhub/templates/devhub/versions/add_file_modal.html:40
 msgid "Only publish this version to my beta channel."
-msgstr ""
-
-#: src/olympia/devhub/templates/devhub/versions/add_file_modal.html:54
-#, python-format
-msgid ""
-"The behavior of the beta channel has changed to accommodate <a href=\"%(addon_signing_url)s\" target=\"_blank\">mandatory add-on signing</a>. The new process is currently in an open beta, and may "
-"change significantly in the near future. Please <a href=\"%(issues_url)s\" target=\"_blank\">report any bugs</a> that you encounter."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/versions/edit.html:5
@@ -6605,19 +6504,10 @@ msgstr ""
 msgid "Upload Another File"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/edit.html:45
-msgid ""
-"Adjusting application information here will allow users to install your\n"
-"                          add-on even if the install manifest in the package indicates that the\n"
-"                          add-on is incompatible."
-msgstr ""
-
 #: src/olympia/devhub/templates/devhub/versions/edit.html:74
 msgid ""
-"Information about changes in this release, new features,\n"
-"                              known bugs, and other useful information specific to this\n"
-"                              release/version. This information is also shown in the\n"
-"                              Add-ons Manager when updating."
+"Information about changes in this release, new features, known bugs, and other useful information specific to this release/version. This information is also shown in the Add-ons Manager when "
+"updating."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/versions/edit.html:99
@@ -6629,10 +6519,7 @@ msgid "Notes for Reviewers"
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/versions/edit.html:114
-msgid ""
-"Optionally, enter any information that may be useful\n"
-"                              to the Editor reviewing this add-on, such as test\n"
-"                              account information."
+msgid "Optionally, enter any information that may be useful to the Editor reviewing this add-on, such as test account information."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/versions/edit.html:127
@@ -6683,6 +6570,7 @@ msgstr ""
 msgid "{0} file"
 msgid_plural "{0} files"
 msgstr[0] ""
+msgstr[1] ""
 
 #: src/olympia/devhub/templates/devhub/versions/list.html:25
 msgid "0 files"
@@ -6709,7 +6597,7 @@ msgstr ""
 msgid "Request Preliminary Review"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:80 src/olympia/devhub/templates/devhub/versions/list.html:327 src/olympia/devhub/templates/devhub/versions/list.html:350
+#: src/olympia/devhub/templates/devhub/versions/list.html:80 src/olympia/devhub/templates/devhub/versions/list.html:325 src/olympia/devhub/templates/devhub/versions/list.html:348
 msgid "Cancel Review Request"
 msgstr ""
 
@@ -6738,7 +6626,7 @@ msgid "Unlisted:"
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/versions/list.html:114
-msgid "Not distributed on {0}. Developers will upload new versions for signing and distribute the add-ons on their own. (beta)"
+msgid "Not distributed on {0}. Developers will upload new versions for signing and distribute the add-ons on their own."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/versions/list.html:122
@@ -6801,81 +6689,73 @@ msgid "<strong>Important:</strong> Once a version has been deleted, you may not 
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/versions/list.html:230
-msgid ""
-"Deleting a version which has already been reviewed\n"
-"               may also cause a significant delay in the review of\n"
-"               your next update."
-msgstr ""
-
-#: src/olympia/devhub/templates/devhub/versions/list.html:233
 msgid "Are you sure you wish to delete this version?"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:238
+#: src/olympia/devhub/templates/devhub/versions/list.html:235
 msgid "Delete Version"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:240
+#: src/olympia/devhub/templates/devhub/versions/list.html:237
 msgid "Disable Version"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:247
+#: src/olympia/devhub/templates/devhub/versions/list.html:244
 msgid "Add a new Version"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:249
+#: src/olympia/devhub/templates/devhub/versions/list.html:246
 msgid "Add Version"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:256 src/olympia/devhub/templates/devhub/versions/list.html:274
+#: src/olympia/devhub/templates/devhub/versions/list.html:253 src/olympia/devhub/templates/devhub/versions/list.html:279
 msgid "Hide Add-on"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:259
+#: src/olympia/devhub/templates/devhub/versions/list.html:256
 msgid "Hiding your add-on will prevent it from appearing anywhere in our gallery and will stop users from receiving automatic updates."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:265
+#: src/olympia/devhub/templates/devhub/versions/list.html:263
+msgid "The files awaiting review will be disabled and you will need to upload new versions."
+msgstr ""
+
+#: src/olympia/devhub/templates/devhub/versions/list.html:270
 msgid "Are you sure you wish to hide your add-on?"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:286 src/olympia/devhub/templates/devhub/versions/list.html:315
+#: src/olympia/devhub/templates/devhub/versions/list.html:291 src/olympia/devhub/templates/devhub/versions/list.html:313
 msgid "Unlist Add-on"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:289
+#: src/olympia/devhub/templates/devhub/versions/list.html:294
 #, python-format
 msgid ""
 "Unlisting your add-on will make it (and each of its versions/files) invisible on this website. It won't show up in searches, won't have a public facing page, and won't be updated automatically for "
-"current users.  It is recommended for unlisted add-ons to provide a custom <a href=\"%(update_url)s\" target=\"_blank\">updateURL</a> in their manifest file for automatic updates."
+"current users. It is recommended for unlisted add-ons to provide a custom <a href=\"%(update_url)s\" target=\"_blank\">updateURL</a> in their manifest file for automatic updates."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:299
-#, python-format
-msgid "Switching add-ons to unlisted is currently in an open beta. Please <a href=\"%(url)s\" target=\"_blank\">report any bugs</a> that you encounter."
-msgstr ""
-
-#: src/olympia/devhub/templates/devhub/versions/list.html:305
+#: src/olympia/devhub/templates/devhub/versions/list.html:303
 msgid "Unlisting an add-on is irreversible!"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:305
+#: src/olympia/devhub/templates/devhub/versions/list.html:303
 msgid "An unlisted add-on cannot be switched to be listed."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:307
+#: src/olympia/devhub/templates/devhub/versions/list.html:305
 msgid "Are you sure you wish to unlist your add-on?"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:330
+#: src/olympia/devhub/templates/devhub/versions/list.html:328
 msgid "Canceling your review request will leave your add-on as preliminarily reviewed."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:335
+#: src/olympia/devhub/templates/devhub/versions/list.html:333
 msgid "Canceling your review request will mark your add-on incomplete. If you do not complete your add-on after several days by re-requesting review, it will be deleted."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:343
+#: src/olympia/devhub/templates/devhub/versions/list.html:341
 msgid "Are you sure you wish to cancel your review request?"
 msgstr ""
 
@@ -7214,19 +7094,19 @@ msgstr ""
 msgid "Search by add-on name / author email"
 msgstr ""
 
-#: src/olympia/editors/forms.py:103
+#: src/olympia/editors/forms.py:103 src/olympia/editors/forms.py:244 src/olympia/editors/forms.py:257
 msgid "yes"
 msgstr ""
 
-#: src/olympia/editors/forms.py:104
+#: src/olympia/editors/forms.py:104 src/olympia/editors/forms.py:244 src/olympia/editors/forms.py:257
 msgid "no"
 msgstr ""
 
-#: src/olympia/editors/forms.py:105
+#: src/olympia/editors/forms.py:105 src/olympia/editors/forms.py:245
 msgid "Admin Flag"
 msgstr ""
 
-#: src/olympia/editors/forms.py:113
+#: src/olympia/editors/forms.py:113 src/olympia/editors/forms.py:253
 msgid "Max. Version"
 msgstr ""
 
@@ -7238,55 +7118,59 @@ msgstr ""
 msgid "Add-on Types"
 msgstr ""
 
-#: src/olympia/editors/forms.py:126 src/olympia/editors/helpers.py:267
+#: src/olympia/editors/forms.py:126 src/olympia/editors/helpers.py:279
 msgid "Platforms"
 msgstr ""
 
+#: src/olympia/editors/forms.py:237
+msgid "Search by add-on name / author email / guid"
+msgstr ""
+
 #. L10n: 0 = platform, 1 = filename, 2 = status message
-#: src/olympia/editors/forms.py:238
+#: src/olympia/editors/forms.py:342
 #, python-format
 msgid "<strong>%s</strong> &middot; %s &middot; %s"
 msgstr ""
 
-#: src/olympia/editors/forms.py:252
+#: src/olympia/editors/forms.py:356
 msgid "Comments:"
 msgstr ""
 
-#: src/olympia/editors/forms.py:256
+#: src/olympia/editors/forms.py:360
 msgid "Operating systems:"
 msgstr ""
 
-#: src/olympia/editors/forms.py:258
+#: src/olympia/editors/forms.py:362
 msgid "Applications:"
 msgstr ""
 
-#: src/olympia/editors/forms.py:260
+#: src/olympia/editors/forms.py:364
 msgid "Notify me the next time this add-on is updated. (Subsequent updates will not generate an email)"
 msgstr ""
 
-#: src/olympia/editors/forms.py:265
+#: src/olympia/editors/forms.py:369
 msgid "Clear Admin Review Flag"
 msgstr ""
 
-#: src/olympia/editors/forms.py:267
+#: src/olympia/editors/forms.py:371
 msgid "Clear more info requested flag"
 msgstr ""
 
-#: src/olympia/editors/forms.py:281
+#: src/olympia/editors/forms.py:385
 msgid "Choose a canned response..."
 msgstr ""
 
 #. L10n: Description of what can be searched for.
-#: src/olympia/editors/forms.py:324
+#: src/olympia/editors/forms.py:423
 msgid "theme name"
 msgstr ""
 
-#: src/olympia/editors/forms.py:350
+#: src/olympia/editors/forms.py:449
 msgid "Someone else is reviewing this theme."
 msgstr ""
 
 #. L10n: Description of what can be searched for.
-#: src/olympia/editors/forms.py:447
+#: src/olympia/editors/forms.py:546
 msgid "app, reviewer, or comment"
 msgstr ""
 
@@ -7302,235 +7186,264 @@ msgstr ""
 msgid "Rejected or Unreviewed"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:123 src/olympia/editors/helpers.py:136
+#: src/olympia/editors/helpers.py:125 src/olympia/editors/helpers.py:138
 msgid "Queue"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:124 src/olympia/editors/templates/editors/base.html:50 src/olympia/editors/templates/editors/base.html:65
+#: src/olympia/editors/helpers.py:126 src/olympia/editors/templates/editors/base.html:50 src/olympia/editors/templates/editors/base.html:65
 msgid "Pending Updates"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:125 src/olympia/editors/templates/editors/base.html:48 src/olympia/editors/templates/editors/base.html:63
+#: src/olympia/editors/helpers.py:127 src/olympia/editors/templates/editors/base.html:48 src/olympia/editors/templates/editors/base.html:63
 msgid "Full Reviews"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:126 src/olympia/editors/templates/editors/base.html:52 src/olympia/editors/templates/editors/base.html:67
+#: src/olympia/editors/helpers.py:128 src/olympia/editors/templates/editors/base.html:52 src/olympia/editors/templates/editors/base.html:67
 msgid "Preliminary Reviews"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:127 src/olympia/editors/templates/editors/base.html:54
+#: src/olympia/editors/helpers.py:129 src/olympia/editors/templates/editors/base.html:54
 msgid "Moderated Reviews"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:128 src/olympia/editors/templates/editors/base.html:46
+#: src/olympia/editors/helpers.py:130 src/olympia/editors/templates/editors/base.html:46
 msgid "Fast Track"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:130
+#: src/olympia/editors/helpers.py:132
 msgid "Pending Themes"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:131 src/olympia/editors/templates/editors/themes/queue.html:4
+#: src/olympia/editors/helpers.py:133 src/olympia/editors/templates/editors/themes/queue.html:4
 msgid "Flagged Themes"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:132
+#: src/olympia/editors/helpers.py:134
 msgid "Update Themes"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:137
+#: src/olympia/editors/helpers.py:139
 msgid "Unlisted Pending Updates"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:138
+#: src/olympia/editors/helpers.py:140
 msgid "Unlisted Full Reviews"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:139
+#: src/olympia/editors/helpers.py:141
 msgid "Unlisted Preliminary Reviews"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:170
+#: src/olympia/editors/helpers.py:142
+msgid "Unlisted All Add-ons"
+msgstr ""
+
+#: src/olympia/editors/helpers.py:173
 msgid "Fast Track ({0})"
 msgid_plural "Fast Track ({0})"
 msgstr[0] ""
+msgstr[1] ""
 
-#: src/olympia/editors/helpers.py:175
+#: src/olympia/editors/helpers.py:178
 msgid "Full Review ({0})"
 msgid_plural "Full Reviews ({0})"
 msgstr[0] ""
+msgstr[1] ""
 
-#: src/olympia/editors/helpers.py:180
+#: src/olympia/editors/helpers.py:183
 msgid "Pending Update ({0})"
 msgid_plural "Pending Updates ({0})"
 msgstr[0] ""
+msgstr[1] ""
 
-#: src/olympia/editors/helpers.py:185
+#: src/olympia/editors/helpers.py:188
 msgid "Preliminary Review ({0})"
 msgid_plural "Preliminary Reviews ({0})"
 msgstr[0] ""
+msgstr[1] ""
 
-#: src/olympia/editors/helpers.py:190
+#: src/olympia/editors/helpers.py:193
 msgid "Moderated Review ({0})"
 msgid_plural "Moderated Reviews ({0})"
 msgstr[0] ""
+msgstr[1] ""
 
-#: src/olympia/editors/helpers.py:196
+#: src/olympia/editors/helpers.py:199
 msgid "Unlisted Full Review ({0})"
 msgid_plural "Unlisted Full Reviews ({0})"
 msgstr[0] ""
+msgstr[1] ""
 
-#: src/olympia/editors/helpers.py:201
+#: src/olympia/editors/helpers.py:204
 msgid "Unlisted Pending Update ({0})"
 msgid_plural "Unlisted Pending Updates ({0})"
 msgstr[0] ""
+msgstr[1] ""
 
-#: src/olympia/editors/helpers.py:206
+#: src/olympia/editors/helpers.py:209
 msgid "Unlisted Preliminary Review ({0})"
 msgid_plural "Unlisted Preliminary Reviews ({0})"
 msgstr[0] ""
+msgstr[1] ""
 
-#: src/olympia/editors/helpers.py:261
-msgid "Addon"
-msgstr ""
+#: src/olympia/editors/helpers.py:214
+msgid "Unlisted All Add-ons ({0})"
+msgid_plural "Unlisted All Add-ons ({0})"
+msgstr[0] ""
+msgstr[1] ""
 
-#: src/olympia/editors/helpers.py:262
+#: src/olympia/editors/helpers.py:274
 msgid "Type"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:263
+#: src/olympia/editors/helpers.py:275
 msgid "Waiting Time"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:264 src/olympia/editors/templates/editors/review.html:285
+#: src/olympia/editors/helpers.py:276 src/olympia/editors/templates/editors/review.html:285
 msgid "Flags"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:265
+#: src/olympia/editors/helpers.py:277
 msgid "Applications"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:270
+#: src/olympia/editors/helpers.py:282
 msgid "Additional"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:285
+#: src/olympia/editors/helpers.py:302
 msgid "Site Specific"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:287
+#: src/olympia/editors/helpers.py:304
 msgid "Requires External Software"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:289
+#: src/olympia/editors/helpers.py:306
 msgid "Binary Components"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:313
+#: src/olympia/editors/helpers.py:339
 msgid "moments ago"
 msgstr ""
 
 #. L10n: first argument is number of minutes
-#: src/olympia/editors/helpers.py:316
+#: src/olympia/editors/helpers.py:342
 msgid "{0} minute"
 msgid_plural "{0} minutes"
 msgstr[0] ""
+msgstr[1] ""
 
 #. L10n: first argument is number of hours
-#: src/olympia/editors/helpers.py:320
+#: src/olympia/editors/helpers.py:346
 msgid "{0} hour"
 msgid_plural "{0} hours"
 msgstr[0] ""
+msgstr[1] ""
 
 #. L10n: first argument is number of days
-#: src/olympia/editors/helpers.py:324
+#: src/olympia/editors/helpers.py:350
 msgid "{0} day"
 msgid_plural "{0} days"
 msgstr[0] ""
+msgstr[1] ""
 
-#: src/olympia/editors/helpers.py:488
+#: src/olympia/editors/helpers.py:364
+msgid "Last Review"
+msgstr ""
+
+#: src/olympia/editors/helpers.py:366
+msgid "Last Update"
+msgstr ""
+
+#: src/olympia/editors/helpers.py:387
+msgid "No Reviews"
+msgstr ""
+
+#: src/olympia/editors/helpers.py:561
 msgid "Push to public"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:490
+#: src/olympia/editors/helpers.py:563
 msgid "Grant full review"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:505
+#: src/olympia/editors/helpers.py:578
 msgid "Request more information"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:508
+#: src/olympia/editors/helpers.py:581
 msgid "Request super-review"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:519
+#: src/olympia/editors/helpers.py:592
 msgid "Grant preliminary review"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:520
+#: src/olympia/editors/helpers.py:593
 msgid "This will mark the files as preliminarily reviewed."
 msgstr ""
 
-#: src/olympia/editors/helpers.py:522
+#: src/olympia/editors/helpers.py:595
 msgid "Use this form to request more information from the author. They will receive an email and be able to answer here. You will be notified by email when they reply."
 msgstr ""
 
-#: src/olympia/editors/helpers.py:526
+#: src/olympia/editors/helpers.py:599
 msgid ""
 "If you have concerns about this add-on's security, copyright issues, or other concerns that an administrator should look into, enter your comments in the area below. They will be sent to "
 "administrators, not the author."
 msgstr ""
 
-#: src/olympia/editors/helpers.py:532
+#: src/olympia/editors/helpers.py:605
 msgid "This will reject the add-on and remove it from the review queue."
 msgstr ""
 
-#: src/olympia/editors/helpers.py:534
-msgid "Make a comment on this version.  The author won't be able to see this."
+#: src/olympia/editors/helpers.py:607
+msgid "Make a comment on this version. The author won't be able to see this."
 msgstr ""
 
-#: src/olympia/editors/helpers.py:538
+#: src/olympia/editors/helpers.py:611
 msgid "This will reject the files and remove them from the review queue."
 msgstr ""
 
-#: src/olympia/editors/helpers.py:542
+#: src/olympia/editors/helpers.py:615
 msgid "This will mark the add-on as preliminarily reviewed. Future versions will undergo preliminary review."
 msgstr ""
 
-#: src/olympia/editors/helpers.py:547
+#: src/olympia/editors/helpers.py:620
 msgid "This will mark the files as preliminarily reviewed. Future versions will undergo preliminary review."
 msgstr ""
 
-#: src/olympia/editors/helpers.py:552
+#: src/olympia/editors/helpers.py:625
 msgid "Retain preliminary review"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:553
+#: src/olympia/editors/helpers.py:626
 msgid "This will retain the add-on as preliminarily reviewed. Future versions will undergo preliminary review."
 msgstr ""
 
-#: src/olympia/editors/helpers.py:558
+#: src/olympia/editors/helpers.py:631
 msgid "This will approve a sandboxed version of a public add-on to appear on the public side."
 msgstr ""
 
-#: src/olympia/editors/helpers.py:561
+#: src/olympia/editors/helpers.py:634
 msgid "This will reject a version of a public add-on and remove it from the queue."
 msgstr ""
 
-#: src/olympia/editors/helpers.py:564
+#: src/olympia/editors/helpers.py:637
 msgid "This will mark the add-on and its most recent version and files as public. Future versions will go into the sandbox until they are reviewed by an editor."
 msgstr ""
 
-#: src/olympia/editors/helpers.py:637
+#: src/olympia/editors/helpers.py:714
 msgid "add-on"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:940 src/olympia/editors/helpers.py:960
+#: src/olympia/editors/helpers.py:1020 src/olympia/editors/helpers.py:1040
 msgid "Flagged"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:944 src/olympia/editors/helpers.py:963
+#: src/olympia/editors/helpers.py:1024 src/olympia/editors/helpers.py:1043
 msgid "Updates"
 msgstr ""
 
@@ -7582,56 +7495,56 @@ msgstr ""
 msgid "A question about your Theme submission"
 msgstr ""
 
-#: src/olympia/editors/views.py:144
+#: src/olympia/editors/views.py:146
 msgid "New Add-ons (Under 5 days)"
 msgstr ""
 
-#: src/olympia/editors/views.py:145
+#: src/olympia/editors/views.py:147
 msgid "Passable (5 to 10 days)"
 msgstr ""
 
-#: src/olympia/editors/views.py:146
+#: src/olympia/editors/views.py:148
 msgid "Overdue (Over 10 days)"
 msgstr ""
 
-#: src/olympia/editors/views.py:532
+#: src/olympia/editors/views.py:539
 msgid "An unknown error occurred"
 msgstr ""
 
-#: src/olympia/editors/views.py:587
+#: src/olympia/editors/views.py:592
 msgid "Self-reviews are not allowed."
 msgstr ""
 
-#: src/olympia/editors/views.py:609
+#: src/olympia/editors/views.py:613
 msgid "Review successfully processed."
 msgstr ""
 
-#: src/olympia/editors/views.py:807
+#: src/olympia/editors/views.py:812
 msgid "was approved"
 msgstr ""
 
-#: src/olympia/editors/views.py:808
+#: src/olympia/editors/views.py:813
 msgid "given preliminary review"
 msgstr ""
 
-#: src/olympia/editors/views.py:809
+#: src/olympia/editors/views.py:814
 msgid "rejected"
 msgstr ""
 
-#: src/olympia/editors/views.py:810
+#: src/olympia/editors/views.py:815
 msgctxt "editors_review_history_nominated_adminreview"
 msgid "escalated"
 msgstr ""
 
-#: src/olympia/editors/views.py:812
+#: src/olympia/editors/views.py:817
 msgid "needs more information"
 msgstr ""
 
-#: src/olympia/editors/views.py:813
+#: src/olympia/editors/views.py:818
 msgid "needs super review"
 msgstr ""
 
-#: src/olympia/editors/views.py:814
+#: src/olympia/editors/views.py:819
 msgid "commented"
 msgstr ""
 
@@ -7639,6 +7552,7 @@ msgstr ""
 msgid "{0} theme review successfully processed (+{1} points, {2} total)."
 msgid_plural "{0} theme reviews successfully processed (+{1} points, {2} total)."
 msgstr[0] ""
+msgstr[1] ""
 
 #: src/olympia/editors/views_themes.py:341
 msgid "Your theme locks have successfully been released. Other reviewers may now review those released themes. You may have to refresh the page to see the changes reflected in the table below."
@@ -7675,28 +7589,28 @@ msgstr ""
 msgid "Unlisted Queues"
 msgstr ""
 
-#: src/olympia/editors/templates/editors/base.html:72 src/olympia/editors/templates/editors/performance.html:6
+#: src/olympia/editors/templates/editors/base.html:74 src/olympia/editors/templates/editors/performance.html:6
 msgid "Performance"
 msgstr ""
 
-#: src/olympia/editors/templates/editors/base.html:75 src/olympia/editors/templates/editors/themes/base.html:19 src/olympia/editors/templates/editors/themes/base.html:38
+#: src/olympia/editors/templates/editors/base.html:77 src/olympia/editors/templates/editors/themes/base.html:19 src/olympia/editors/templates/editors/themes/base.html:38
 msgid "Logs"
 msgstr ""
 
-#: src/olympia/editors/templates/editors/base.html:78 src/olympia/editors/templates/editors/reviewlog.html:4 src/olympia/editors/templates/editors/reviewlog.html:27
+#: src/olympia/editors/templates/editors/base.html:80 src/olympia/editors/templates/editors/reviewlog.html:4 src/olympia/editors/templates/editors/reviewlog.html:27
 msgid "Add-on Review Log"
 msgstr ""
 
-#: src/olympia/editors/templates/editors/base.html:80 src/olympia/editors/templates/editors/eventlog.html:4 src/olympia/editors/templates/editors/eventlog.html:8
+#: src/olympia/editors/templates/editors/base.html:82 src/olympia/editors/templates/editors/eventlog.html:4 src/olympia/editors/templates/editors/eventlog.html:8
 #: src/olympia/editors/templates/editors/eventlog_detail.html:4
 msgid "Moderated Review Log"
 msgstr ""
 
-#: src/olympia/editors/templates/editors/base.html:82 src/olympia/editors/templates/editors/beta_signed_log.html:4 src/olympia/editors/templates/editors/beta_signed_log.html:8
+#: src/olympia/editors/templates/editors/base.html:84 src/olympia/editors/templates/editors/beta_signed_log.html:4 src/olympia/editors/templates/editors/beta_signed_log.html:8
 msgid "Signed Beta Files Log"
 msgstr ""
 
-#: src/olympia/editors/templates/editors/base.html:87 src/olympia/editors/templates/editors/includes/daily-message.html:4
+#: src/olympia/editors/templates/editors/base.html:89 src/olympia/editors/templates/editors/includes/daily-message.html:4
 msgid "Announcement"
 msgstr ""
 
@@ -7755,16 +7669,19 @@ msgstr ""
 msgid "Full Review ({num})"
 msgid_plural "Full Reviews ({num})"
 msgstr[0] ""
+msgstr[1] ""
 
 #: src/olympia/editors/templates/editors/home.html:18
 msgid "Pending Update ({num})"
 msgid_plural "Pending Updates ({num})"
 msgstr[0] ""
+msgstr[1] ""
 
 #: src/olympia/editors/templates/editors/home.html:25
 msgid "Preliminary Review ({num})"
 msgid_plural "Preliminary Reviews ({num})"
 msgstr[0] ""
+msgstr[1] ""
 
 #: src/olympia/editors/templates/editors/home.html:36 src/olympia/editors/templates/editors/home.html:86
 msgid "Current waiting times:"
@@ -7774,6 +7691,7 @@ msgstr ""
 msgid "{0} add-on"
 msgid_plural "{0} add-ons"
 msgstr[0] ""
+msgstr[1] ""
 
 #: src/olympia/editors/templates/editors/home.html:45 src/olympia/editors/templates/editors/home.html:95
 #, python-format
@@ -7784,16 +7702,19 @@ msgstr ""
 msgid "Unlisted Full Review ({num})"
 msgid_plural "Unlisted Full Reviews ({num})"
 msgstr[0] ""
+msgstr[1] ""
 
 #: src/olympia/editors/templates/editors/home.html:68
 msgid "Unlisted Pending Update ({num})"
 msgid_plural "Unlisted Pending Updates ({num})"
 msgstr[0] ""
+msgstr[1] ""
 
 #: src/olympia/editors/templates/editors/home.html:75
 msgid "Unlisted Preliminary Review ({num})"
 msgid_plural "Unlisted Preliminary Reviews ({num})"
 msgstr[0] ""
+msgstr[1] ""
 
 #: src/olympia/editors/templates/editors/home.html:109 src/olympia/editors/templates/editors/performance.html:37 src/olympia/editors/templates/editors/themes/home.html:54
 msgid "Total Reviews"
@@ -7816,6 +7737,7 @@ msgstr ""
 msgid "Moderated Review ({num})"
 msgid_plural "Moderated Reviews ({num})"
 msgstr[0] ""
+msgstr[1] ""
 
 #: src/olympia/editors/templates/editors/leaderboard.html:3 src/olympia/editors/templates/editors/includes/reviewers_score_bar.html:56
 msgid "Reviewer Leaderboard"
@@ -7909,45 +7831,45 @@ msgstr ""
 msgid "clear search"
 msgstr ""
 
-#: src/olympia/editors/templates/editors/queue.html:72 src/olympia/editors/templates/editors/queue.html:122
+#: src/olympia/editors/templates/editors/queue.html:78 src/olympia/editors/templates/editors/queue.html:128
 msgid "Process Reviews"
 msgstr ""
 
-#: src/olympia/editors/templates/editors/queue.html:80
+#: src/olympia/editors/templates/editors/queue.html:86
 msgid "Moderation actions:"
 msgstr ""
 
-#: src/olympia/editors/templates/editors/queue.html:90
+#: src/olympia/editors/templates/editors/queue.html:96
 #, python-format
 msgid "by %(user)s on %(date)s %(stars)s (%(locale)s)"
 msgstr ""
 
-#: src/olympia/editors/templates/editors/queue.html:106
+#: src/olympia/editors/templates/editors/queue.html:112
 #, python-format
 msgid "<strong>%(reason)s</strong> <span class=\"light\">Flagged by %(user)s on %(date)s</span>"
 msgstr ""
 
-#: src/olympia/editors/templates/editors/queue.html:119
-msgid "All reviews have been moderated.  Good work!"
+#: src/olympia/editors/templates/editors/queue.html:125
+msgid "All reviews have been moderated. Good work!"
 msgstr ""
 
-#: src/olympia/editors/templates/editors/queue.html:161
+#: src/olympia/editors/templates/editors/queue.html:167
 msgid "Version Notes / Notes for Reviewer"
 msgstr ""
 
-#: src/olympia/editors/templates/editors/queue.html:169
+#: src/olympia/editors/templates/editors/queue.html:175
 msgid "There are currently no add-ons of this type to review."
 msgstr ""
 
-#: src/olympia/editors/templates/editors/queue.html:181 src/olympia/editors/templates/editors/themes/queue_list.html:85
+#: src/olympia/editors/templates/editors/queue.html:187 src/olympia/editors/templates/editors/themes/queue_list.html:85
 msgid "Helpful Links:"
 msgstr ""
 
-#: src/olympia/editors/templates/editors/queue.html:182
+#: src/olympia/editors/templates/editors/queue.html:188
 msgid "Add-on Policy"
 msgstr ""
 
-#: src/olympia/editors/templates/editors/queue.html:184
+#: src/olympia/editors/templates/editors/queue.html:190
 msgid "Editors' Guide"
 msgstr ""
 
@@ -8010,10 +7932,7 @@ msgid "<strong>Warning!</strong> Another user was viewing this page before you."
 msgstr ""
 
 #: src/olympia/editors/templates/editors/review.html:237
-msgid ""
-"The whiteboard is the place to exchange information relevant to\n"
-"               this addon (whatever the version), between the developer and the\n"
-"               editor. This is visible and editable by both."
+msgid "The whiteboard is the place to exchange information relevant to this addon (whatever the version), between the developer and the editor. This is visible and editable by both."
 msgstr ""
 
 #: src/olympia/editors/templates/editors/review.html:241
@@ -8156,16 +8075,19 @@ msgstr ""
 msgid "{num} Pending Theme Review"
 msgid_plural "{num} Pending Theme Reviews"
 msgstr[0] ""
+msgstr[1] ""
 
 #: src/olympia/editors/templates/editors/themes/home.html:27
 msgid "{num} Flagged Review"
 msgid_plural "{num} Flagged Reviews"
 msgstr[0] ""
+msgstr[1] ""
 
 #: src/olympia/editors/templates/editors/themes/home.html:34
 msgid "{num} Update"
 msgid_plural "{num} Updates"
 msgstr[0] ""
+msgstr[1] ""
 
 #: src/olympia/editors/templates/editors/themes/logs.html:4
 msgid "Theme Review Log"
@@ -8284,7 +8206,7 @@ msgstr ""
 msgid "Describe your reason for flagging"
 msgstr ""
 
-#: src/olympia/files/forms.py:88
+#: src/olympia/files/forms.py:90
 msgid "Cannot diff a version against itself"
 msgstr ""
 
@@ -8319,51 +8241,51 @@ msgstr ""
 msgid "There was an error accessing file %s."
 msgstr ""
 
-#: src/olympia/files/utils.py:343
+#: src/olympia/files/utils.py:340
 msgid "Could not parse uploaded file."
 msgstr ""
 
-#: src/olympia/files/utils.py:380
+#: src/olympia/files/utils.py:377
 msgid "Invalid file name in archive: {0}"
 msgstr ""
 
-#: src/olympia/files/utils.py:388
+#: src/olympia/files/utils.py:385
 msgid "File exceeding size limit in archive: {0}"
 msgstr ""
 
-#: src/olympia/files/utils.py:439
+#: src/olympia/files/utils.py:436
 msgid "Invalid archive."
 msgstr ""
 
-#: src/olympia/files/utils.py:529 src/olympia/files/utils.py:532
+#: src/olympia/files/utils.py:526 src/olympia/files/utils.py:529
 msgid "Could not parse the manifest file."
 msgstr ""
 
-#: src/olympia/files/utils.py:551
+#: src/olympia/files/utils.py:548
 msgid "Could not find an add-on ID."
 msgstr ""
 
-#: src/olympia/files/utils.py:554
+#: src/olympia/files/utils.py:551
 msgid "Add-on ID must be 64 characters or less."
 msgstr ""
 
-#: src/olympia/files/utils.py:556
+#: src/olympia/files/utils.py:553
 msgid "Add-on ID doesn't match add-on."
 msgstr ""
 
-#: src/olympia/files/utils.py:564
+#: src/olympia/files/utils.py:561
 msgid "Duplicate add-on ID found."
 msgstr ""
 
-#: src/olympia/files/utils.py:567
+#: src/olympia/files/utils.py:564
 msgid "Version numbers should have fewer than 32 characters."
 msgstr ""
 
-#: src/olympia/files/utils.py:570
+#: src/olympia/files/utils.py:567
 msgid "Version numbers should only contain letters, numbers, and these punctuation characters: +*.-_."
 msgstr ""
 
-#: src/olympia/files/utils.py:587
+#: src/olympia/files/utils.py:584
 msgid "<em:type> doesn't match add-on"
 msgstr ""
 
@@ -8462,6 +8384,10 @@ msgstr ""
 
 #: src/olympia/files/templates/files/viewer.html:134
 msgid "Fetching file."
+msgstr ""
+
+#: src/olympia/legacy_api/views.py:255
+msgid "Not implemented yet."
 msgstr ""
 
 #: src/olympia/lib/constants.py:6
@@ -9120,10 +9046,6 @@ msgstr ""
 msgid "Zimbabwe Dollar"
 msgstr ""
 
-#: src/olympia/lib/video/ffmpeg.py:112 src/olympia/lib/video/totem.py:81
-msgid "Videos must be in WebM."
-msgstr ""
-
 #: src/olympia/pages/templates/pages/about.lhtml:3 src/olympia/pages/templates/pages/about.lhtml:10
 msgid "About Mozilla Add-ons"
 msgstr ""
@@ -9135,7 +9057,7 @@ msgstr ""
 #: src/olympia/pages/templates/pages/about.lhtml:13
 msgid ""
 "addons.mozilla.org, commonly known as \"AMO\", is Mozilla's official site for add-ons to Mozilla software, such as Firefox, Thunderbird, and SeaMonkey. Add-ons let you add new features and change "
-"the way your browser or application works.  Take a look around and explore the thousands of ways to customize the way you do things online."
+"the way your browser or application works. Take a look around and explore the thousands of ways to customize the way you do things online."
 msgstr ""
 
 #: src/olympia/pages/templates/pages/about.lhtml:19
@@ -9480,7 +9402,7 @@ msgstr ""
 msgid ""
 "Yes. It's possible, but some of the functionality provided by these libraries are available through XPCOM, XUL, and JavaScript. In addition, authors should take care if libraries modify primitive "
 "object prototypes (String.prototype, Date.prototype, etc.) and/or define global functions (eg. the $ function). These are prone to cause conflict with other add-ons, in particular if different add-"
-"ons use different versions of libraries and so on. Developers need to be very, very careful with using them.  Mozilla does not offer documentation on using them to build add-ons."
+"ons use different versions of libraries and so on. Developers need to be very, very careful with using them. Mozilla does not offer documentation on using them to build add-ons."
 msgstr ""
 
 #: src/olympia/pages/templates/pages/dev_faq.html:165
@@ -9594,8 +9516,8 @@ msgstr ""
 #, python-format
 msgid ""
 "Yes. Many developers choose to host their own add-ons. Choosing to host your add-on on <a href=\"%(amo_url)s\">Mozilla's add-on site</a>, though, allows for much greater exposure to your add-on due "
-"to the large volume of visitors to the site.  <a href=\"%(md_url)s\">mozdev.org</a> offers free project hosting for Mozilla applications and extensions providing developers with tools to help "
-"manage source code, version control, bug tracking and documentation."
+"to the large volume of visitors to the site. <a href=\"%(md_url)s\">mozdev.org</a> offers free project hosting for Mozilla applications and extensions providing developers with tools to help manage "
+"source code, version control, bug tracking and documentation."
 msgstr ""
 
 #: src/olympia/pages/templates/pages/dev_faq.html:277
@@ -9643,7 +9565,7 @@ msgstr ""
 #: src/olympia/pages/templates/pages/dev_faq.html:314
 #, python-format
 msgid ""
-"Yes. Mozilla's <a href=\"%(p_url)s\">Add-on Policy</a> describes what is an acceptable submission. This policy is subject to change without notice.  In addition, the AMO editorial team uses the <a "
+"Yes. Mozilla's <a href=\"%(p_url)s\">Add-on Policy</a> describes what is an acceptable submission. This policy is subject to change without notice. In addition, the AMO editorial team uses the <a "
 "href=\"%(g_url)s\">Editors Reviewing Guide</a> to ensure that your add-on meets specific guidelines for functionality and security."
 msgstr ""
 
@@ -9760,7 +9682,7 @@ msgstr ""
 #: src/olympia/pages/templates/pages/dev_faq.html:434
 #, python-format
 msgid ""
-"This is why it's very important to read the <a href=\"%(g_url)s\">Editors Reviewing Guide</a> to ensure that your add-on is setup as expected.  It's also a good idea to read the blog post, <a href="
+"This is why it's very important to read the <a href=\"%(g_url)s\">Editors Reviewing Guide</a> to ensure that your add-on is setup as expected. It's also a good idea to read the blog post, <a href="
 "\"%(blog_url)s\">Successfully Getting your Add-on Reviewed</a> which provides excellent insight into ensuring a smooth review of your add-on."
 msgstr ""
 
@@ -9867,7 +9789,7 @@ msgstr ""
 
 #: src/olympia/pages/templates/pages/dev_faq.html:572
 msgid ""
-"Free Software Foundation provides short summaries of the key open source licenses, including whether the license qualifies as a free software license or a copyleft license.  Also includes a "
+"Free Software Foundation provides short summaries of the key open source licenses, including whether the license qualifies as a free software license or a copyleft license. Also includes a "
 "discussion of what constitutes a free software license or a copyleft license (e.g., a Copyleft license is a general method for making a program or other work free, and requiring all modified and "
 "extended versions of the program to be free as well.)"
 msgstr ""
@@ -10045,19 +9967,13 @@ msgid "Add-on Gallery"
 msgstr ""
 
 #: src/olympia/pages/templates/pages/faq.html:171
-msgid ""
-"How do I choose between add-ons that seem to do the same\n"
-"    thing?"
+msgid "How do I choose between add-ons that seem to do the same thing?"
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:173
+#: src/olympia/pages/templates/pages/faq.html:172
 msgid ""
-"There are often several add-ons that have similar features. To\n"
-"    figure out which is right for you, read the entire description of the\n"
-"    add-on and view its screenshots. If there are still several in the running,\n"
-"    read through the add-on's ratings, user reviews, and statistics to see\n"
-"    which is most liked by other users. Remember that you can also just try\n"
-"    out both and see which you like better."
+"There are often several add-ons that have similar features. To figure out which is right for you, read the entire description of the add-on and view its screenshots. If there are still several in "
+"the running, read through the add-on's ratings, user reviews, and statistics to see which is most liked by other users. Remember that you can also just try out both and see which you like better."
 msgstr ""
 
 #: src/olympia/pages/templates/pages/faq.html:180
@@ -10098,80 +10014,67 @@ msgid "How much do add-ons cost to purchase?"
 msgstr ""
 
 #: src/olympia/pages/templates/pages/faq.html:207
-msgid ""
-"Add-ons hosted in our gallery are free unless clearly marked\n"
-"    otherwise."
+msgid "Add-ons hosted in our gallery are free unless clearly marked otherwise."
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:210
+#: src/olympia/pages/templates/pages/faq.html:209
 msgid "What does it mean when an add-on asks for contributions?"
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:211
+#: src/olympia/pages/templates/pages/faq.html:210
 msgid ""
-"Some add-on authors request users who enjoy an add-on to\n"
-"        contribute to its development by making a monetary contribution. These\n"
-"        contributions go directly to the developer unless a third party is\n"
-"        indicated, such as the non-profit Mozilla Foundation."
+"Some add-on authors request users who enjoy an add-on to contribute to its development by making a monetary contribution. These contributions go directly to the developer unless a third party is "
+"indicated, such as the non-profit Mozilla Foundation."
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:216
+#: src/olympia/pages/templates/pages/faq.html:215
 msgid "What are beta add-ons?"
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:218
+#: src/olympia/pages/templates/pages/faq.html:217
 msgid ""
-"Beta add-ons are unreviewed versions which represent the\n"
-"        latest work of an add-on author. While different authors have different\n"
-"        standards for beta code quality, you should assume that these add-ons\n"
-"        are less stable than the general add-on releases."
+"Beta add-ons are unreviewed versions which represent the latest work of an add-on author. While different authors have different standards for beta code quality, you should assume that these add-"
+"ons are less stable than the general add-on releases."
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:222
+#: src/olympia/pages/templates/pages/faq.html:221
 msgid ""
 "Please note that when you install an add-on from the \"Beta Version\" section of an add-on's listing, you will continue to receive updates for that add-on as they become available. Like the initial "
 "version you installed, all beta releases are unreviewed by Mozilla and may harm your computer."
 msgstr ""
 
+#: src/olympia/pages/templates/pages/faq.html:228
+msgid "What does it mean when an add-on is flagged as slow?"
+msgstr ""
+
 #: src/olympia/pages/templates/pages/faq.html:229
-msgid ""
-"What does it mean when an add-on is flagged as\n"
-"    slow?"
+msgid "Most add-ons load code and resources at the same time Firefox is starting up. In most cases the impact in start-up time is minimal, but some add-ons can cause a noticeable slowdown."
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:231
-msgid ""
-"Most add-ons load code and resources at the same time Firefox\n"
-"        is starting up. In most cases the impact in start-up time is minimal,\n"
-"        but some add-ons can cause a noticeable slowdown."
-msgstr ""
-
-#: src/olympia/pages/templates/pages/faq.html:236
+#: src/olympia/pages/templates/pages/faq.html:234
 msgid "How do I report an inappropriate or spam user review?"
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:237
+#: src/olympia/pages/templates/pages/faq.html:235
 msgid ""
-"To report a user review of an add-on, log in with your account\n"
-"    and visit the add-on's reviews page. Find the review you wish to report,\n"
-"    click \"Report this review\" and select a reason. Our editorial team will\n"
-"    investigate the review and take appropriate action."
+"To report a user review of an add-on, log in with your account and visit the add-on's reviews page. Find the review you wish to report, click \"Report this review\" and select a reason. Our "
+"editorial team will investigate the review and take appropriate action."
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:242
+#: src/olympia/pages/templates/pages/faq.html:240
 msgid "How do I report a bug or contact the Mozilla Add-ons team?"
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:243
+#: src/olympia/pages/templates/pages/faq.html:241
 #, python-format
 msgid "Please visit our <a href=\"%(contact_url)s\">Contact page</a>."
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:246
+#: src/olympia/pages/templates/pages/faq.html:244
 msgid "What is a Source Code License?"
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:247
+#: src/olympia/pages/templates/pages/faq.html:245
 #, python-format
 msgid ""
 "The source code used to create an add-on is an exclusive copyright of the add-on author, unless otherwise declared in a source code license. Many add-ons on this site have <a href=\"%(url)s\" lang="
@@ -10179,60 +10082,60 @@ msgid ""
 "the GPL or BSD licenses instead of making up their own."
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:256
+#: src/olympia/pages/templates/pages/faq.html:254
 #, python-format
 msgid "Firefox and other Mozilla software are <a href=\"%(url)s\">open source</a>."
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:264
+#: src/olympia/pages/templates/pages/faq.html:262
 msgid "Collections and Favorites"
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:267
+#: src/olympia/pages/templates/pages/faq.html:265
 msgid "What is a collection?"
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:268
+#: src/olympia/pages/templates/pages/faq.html:266
 msgid "Collections are groups of related add-ons created by users to share."
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:270
+#: src/olympia/pages/templates/pages/faq.html:268
 msgid "What is the My Favorites collection?"
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:271
+#: src/olympia/pages/templates/pages/faq.html:269
 msgid "Favorite add-ons are add-ons that you have bookmarked to easily get back to later. You can add an add-on to your favorites collection by clicking \"Add to favorites\" on its details page."
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:275 src/olympia/templates/menu_links.html:13 src/olympia/templates/impala/header_title.html:17
+#: src/olympia/pages/templates/pages/faq.html:273 src/olympia/templates/menu_links.html:13 src/olympia/templates/impala/header_title.html:17
 msgid "Mobile Add-ons"
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:278
+#: src/olympia/pages/templates/pages/faq.html:276
 msgid "What are mobile add-ons?"
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:279
+#: src/olympia/pages/templates/pages/faq.html:277
 #, python-format
 msgid ""
 "Mobile add-ons work with <a href=\"%(mobile_url)s\">Firefox for Mobile</a> and add or modify functionality just like desktop add-ons. You can find add-ons that work with Firefox for Mobile in our "
 "<a href=\"%(gallery_url)s\">gallery</a>."
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:288
+#: src/olympia/pages/templates/pages/faq.html:286
 msgid "Developer Topics"
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:289
+#: src/olympia/pages/templates/pages/faq.html:287
 #, python-format
 msgid "Please see our <a href=\"%(faq_url)s\">Developer FAQ</a> and <a href=\"%(hub_url)s\">Developer Hub</a> for answers to add-on developer-related questions."
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:294
+#: src/olympia/pages/templates/pages/faq.html:292
 msgid "Still have questions?"
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:295
+#: src/olympia/pages/templates/pages/faq.html:293
 #, python-format
 msgid "For general Firefox support, visit our <a href=\"%(sumo_url)s\">support website</a>. For general add-on and website questions, visit our <a href=\"%(forum_url)s\">forum</a>."
 msgstr ""
@@ -10370,7 +10273,7 @@ msgstr ""
 
 #: src/olympia/pages/templates/pages/sunbird.html:29
 msgid ""
-"Development on the Sunbird project has halted and its final release was on March 30, 2010.  We've been proud to host Sunbird add-ons on this site but as the project is no longer maintained we have "
+"Development on the Sunbird project has halted and its final release was on March 30, 2010. We've been proud to host Sunbird add-ons on this site but as the project is no longer maintained we have "
 "disabled our support for the add-ons."
 msgstr ""
 
@@ -10448,7 +10351,7 @@ msgstr ""
 #, python-format
 msgid ""
 "<h2>Keep these tips in mind:</h2> <ul> <li> Write like you're telling a friend about your experience with the add-on. Give specifics and helpful details, such as what features you liked and/or "
-"disliked, how easy to use it is, and any disadvantages it has.  Avoid generic language such as calling it \"Great\" or \"Bad\" unless you can give reasons why you believe this is so. </li> <li> "
+"disliked, how easy to use it is, and any disadvantages it has. Avoid generic language such as calling it \"Great\" or \"Bad\" unless you can give reasons why you believe this is so. </li> <li> "
 "Please do not post bug reports in reviews. We do not make your email address available to add-on developers and they may need to contact you to help resolve your issue. See the <a href=\"%(support)s"
 "\">support section</a> to find out where to get assistance for this add-on. </li> <li>Please keep reviews clean, avoid the use of improper language and do not post any personal information. </li> </"
 "ul> <p>Please read the <a href=\"%(guide)s\" target=\"_blank\">Review Guidelines</a> for more detail about user add-on reviews.</p>"
@@ -10495,6 +10398,7 @@ msgstr ""
 msgid "This user has a <a href=\"%(user_review_url)s\">previous review</a> of this add-on."
 msgid_plural "This user has <a href=\"%(user_review_url)s\">%(cnt)s previous reviews</a> of this add-on."
 msgstr[0] ""
+msgstr[1] ""
 
 #: src/olympia/reviews/templates/reviews/review.html:62
 #, python-format
@@ -10540,6 +10444,7 @@ msgstr ""
 msgid "<b>{0}</b> review for this add-on"
 msgid_plural "<b>{0}</b> reviews for this add-on"
 msgstr[0] ""
+msgstr[1] ""
 
 #. {0} is a developer's name.
 #: src/olympia/reviews/templates/reviews/review_list.html:33
@@ -10551,6 +10456,7 @@ msgstr ""
 msgid "Review for %(addon)s by %(user)s"
 msgid_plural "Reviews for %(addon)s by %(user)s"
 msgstr[0] ""
+msgstr[1] ""
 
 #: src/olympia/reviews/templates/reviews/review_list.html:42
 msgid "No reviews found."
@@ -10573,6 +10479,7 @@ msgstr ""
 msgid "{num} review"
 msgid_plural "{num} reviews"
 msgstr[0] ""
+msgstr[1] ""
 
 #: src/olympia/reviews/templates/reviews/impala/reviews_rating.html:1
 msgid "Rated {0} out of 5 stars"
@@ -10599,6 +10506,7 @@ msgstr ""
 msgid "Average from {0} Rating"
 msgid_plural "Average from {0} Ratings"
 msgstr[0] ""
+msgstr[1] ""
 
 #: src/olympia/reviews/templates/reviews/mobile/review_list.html:34
 #, python-format
@@ -10614,6 +10522,7 @@ msgstr ""
 msgid "See All Reviews"
 msgid_plural "See All %(cnt)s Reviews"
 msgstr[0] ""
+msgstr[1] ""
 
 #: src/olympia/search/forms.py:11
 msgid "Most popular this week"
@@ -10678,16 +10587,16 @@ msgstr ""
 
 #. L10n: {0} is an application, such as Firefox. This means "any version of
 #. Firefox."
-#: src/olympia/search/views.py:554
+#: src/olympia/search/views.py:547
 msgid "Any {0}"
 msgstr ""
 
 #. L10n: "All Systems" means show everything regardless of platform.
-#: src/olympia/search/views.py:589
+#: src/olympia/search/views.py:582
 msgid "All Systems"
 msgstr ""
 
-#: src/olympia/search/views.py:600
+#: src/olympia/search/views.py:593
 msgid "All Tags"
 msgstr ""
 
@@ -10731,6 +10640,7 @@ msgstr ""
 msgid "<b>{0}</b> matching result"
 msgid_plural "<b>{0}</b> matching results"
 msgstr[0] ""
+msgstr[1] ""
 
 #: src/olympia/search/templates/search/results.html:67
 msgid "Filter Results"
@@ -10752,6 +10662,7 @@ msgstr ""
 msgid "{0} post"
 msgid_plural "{0} posts"
 msgstr[0] ""
+msgstr[1] ""
 
 #: src/olympia/sharing/__init__.py:20
 msgid "Post to Facebook"
@@ -10761,6 +10672,7 @@ msgstr ""
 msgid "{0} Like"
 msgid_plural "{0} Likes"
 msgstr[0] ""
+msgstr[1] ""
 
 #: src/olympia/sharing/__init__.py:30
 msgid "Tweet on Twitter"
@@ -10770,6 +10682,7 @@ msgstr ""
 msgid "{0} tweet"
 msgid_plural "{0} tweets"
 msgstr[0] ""
+msgstr[1] ""
 
 #: src/olympia/sharing/__init__.py:40
 msgid "Share on g+"
@@ -10803,6 +10716,7 @@ msgstr ""
 msgid "{0} post on localservice1"
 msgid_plural "{0} posts on localservice1"
 msgstr[0] ""
+msgstr[1] ""
 
 #. L10n: Only change if you have reason! wiki.mozilla.org/AMO:Localizers
 #: src/olympia/sharing/__init__.py:76
@@ -10824,6 +10738,7 @@ msgstr ""
 msgid "{0} post on localservice2"
 msgid_plural "{0} posts on localservice2"
 msgstr[0] ""
+msgstr[1] ""
 
 #. L10n: Only change if you have reason! wiki.mozilla.org/AMO:Localizers
 #: src/olympia/sharing/__init__.py:91
@@ -10845,6 +10760,7 @@ msgstr ""
 msgid "{0} post on localservice3"
 msgid_plural "{0} posts on localservice3"
 msgstr[0] ""
+msgstr[1] ""
 
 #: src/olympia/sharing/templates/sharing/sharing_widget.html:2
 msgid "Share this Add-on"
@@ -10854,31 +10770,31 @@ msgstr ""
 msgid "Share this Collection"
 msgstr ""
 
-#: src/olympia/signing/views.py:30 src/olympia/templates/base.html:75 src/olympia/templates/impala/base.html:115
+#: src/olympia/signing/views.py:33 src/olympia/templates/base.html:71 src/olympia/templates/impala/base.html:112
 msgid "Some features are temporarily disabled while we perform website maintenance. We'll be back to full capacity shortly."
 msgstr ""
 
-#: src/olympia/signing/views.py:53
+#: src/olympia/signing/views.py:56
 msgid "Could not find add-on with id \"{}\"."
 msgstr ""
 
-#: src/olympia/signing/views.py:67
+#: src/olympia/signing/views.py:70
 msgid "You do not own this addon."
 msgstr ""
 
-#: src/olympia/signing/views.py:82
+#: src/olympia/signing/views.py:87
 msgid "Missing \"upload\" key in multipart file data."
 msgstr ""
 
-#: src/olympia/signing/views.py:96
+#: src/olympia/signing/views.py:101
 msgid "Version does not match the manifest file."
 msgstr ""
 
-#: src/olympia/signing/views.py:100
+#: src/olympia/signing/views.py:105
 msgid "Version already exists."
 msgstr ""
 
-#: src/olympia/signing/views.py:136
+#: src/olympia/signing/views.py:141
 msgid "No uploaded file for that addon and version."
 msgstr ""
 
@@ -10991,89 +10907,89 @@ msgstr ""
 msgid "Statistics Dashboard :: Add-ons for {0}"
 msgstr ""
 
-#: src/olympia/stats/templates/stats/stats.html:30
-msgid "Controls:"
-msgstr ""
-
-#: src/olympia/stats/templates/stats/stats.html:33
-msgid "reset zoom"
-msgstr ""
-
-#: src/olympia/stats/templates/stats/stats.html:40
-msgid "Group by:"
-msgstr ""
-
-#: src/olympia/stats/templates/stats/stats.html:42
-msgid "day"
-msgstr ""
-
-#: src/olympia/stats/templates/stats/stats.html:45
-msgid "week"
-msgstr ""
-
-#: src/olympia/stats/templates/stats/stats.html:48
-msgid "month"
-msgstr ""
-
-#: src/olympia/stats/templates/stats/stats.html:54
-msgid "For last:"
-msgstr ""
-
-#: src/olympia/stats/templates/stats/stats.html:57
-msgid "7 days"
-msgstr ""
-
-#: src/olympia/stats/templates/stats/stats.html:60
-msgid "30 days"
-msgstr ""
-
-#: src/olympia/stats/templates/stats/stats.html:63
-msgid "90 days"
-msgstr ""
-
-#: src/olympia/stats/templates/stats/stats.html:66
-msgid "365 days"
-msgstr ""
-
-#: src/olympia/stats/templates/stats/stats.html:69
-msgid "Custom..."
-msgstr ""
-
 #. {0} is an add-on name
-#: src/olympia/stats/templates/stats/stats.html:88 src/olympia/stats/templates/stats/stats.html:91
+#: src/olympia/stats/templates/stats/stats.html:44 src/olympia/stats/templates/stats/stats.html:47
 msgid "Statistics for {0}"
 msgstr ""
 
-#: src/olympia/stats/templates/stats/stats.html:94
+#: src/olympia/stats/templates/stats/stats.html:50
 msgid "Statistics Dashboard"
 msgstr ""
 
-#: src/olympia/stats/templates/stats/stats.html:104
+#: src/olympia/stats/templates/stats/stats.html:57
+msgid "Controls:"
+msgstr ""
+
+#: src/olympia/stats/templates/stats/stats.html:60
+msgid "reset zoom"
+msgstr ""
+
+#: src/olympia/stats/templates/stats/stats.html:67
+msgid "Group by:"
+msgstr ""
+
+#: src/olympia/stats/templates/stats/stats.html:69
+msgid "day"
+msgstr ""
+
+#: src/olympia/stats/templates/stats/stats.html:72
+msgid "week"
+msgstr ""
+
+#: src/olympia/stats/templates/stats/stats.html:75
+msgid "month"
+msgstr ""
+
+#: src/olympia/stats/templates/stats/stats.html:81
+msgid "For last:"
+msgstr ""
+
+#: src/olympia/stats/templates/stats/stats.html:84
+msgid "7 days"
+msgstr ""
+
+#: src/olympia/stats/templates/stats/stats.html:87
+msgid "30 days"
+msgstr ""
+
+#: src/olympia/stats/templates/stats/stats.html:90
+msgid "90 days"
+msgstr ""
+
+#: src/olympia/stats/templates/stats/stats.html:93
+msgid "365 days"
+msgstr ""
+
+#: src/olympia/stats/templates/stats/stats.html:96
+msgid "Custom..."
+msgstr ""
+
+#: src/olympia/stats/templates/stats/stats.html:106
 msgid "Statistics processing is currently disabled, so recent data is unavailable. The statistics are still being collected and this page will be updated soon with the missing data."
 msgstr ""
 
-#: src/olympia/stats/templates/stats/stats.html:110
+#: src/olympia/stats/templates/stats/stats.html:112
 msgid "Loading the latest data&hellip;"
 msgstr ""
 
-#: src/olympia/stats/templates/stats/stats.html:142 src/olympia/stats/templates/stats/reports/overview.html:25 src/olympia/stats/templates/stats/reports/overview.html:37
+#: src/olympia/stats/templates/stats/stats.html:144 src/olympia/stats/templates/stats/reports/overview.html:25 src/olympia/stats/templates/stats/reports/overview.html:37
 #: src/olympia/stats/templates/stats/reports/overview.html:49
 msgid "No data available."
 msgstr ""
 
-#: src/olympia/stats/templates/stats/stats.html:177
+#: src/olympia/stats/templates/stats/stats.html:179
 msgid "This dashboard is currently <b>public</b>."
 msgstr ""
 
-#: src/olympia/stats/templates/stats/stats.html:179
+#: src/olympia/stats/templates/stats/stats.html:181
 msgid "Contribution stats are currently <b>private</b>."
 msgstr ""
 
-#: src/olympia/stats/templates/stats/stats.html:182
+#: src/olympia/stats/templates/stats/stats.html:184
 msgid "This dashboard is currently <b>private</b>."
 msgstr ""
 
-#: src/olympia/stats/templates/stats/stats.html:185
+#: src/olympia/stats/templates/stats/stats.html:187
 msgid "Change settings."
 msgstr ""
 
@@ -11225,15 +11141,6 @@ msgstr ""
 msgid "Application versions by Date"
 msgstr ""
 
-#: src/olympia/tags/templates/tags/top_cloud.html:4
-msgid "Top {0} Tags"
-msgstr ""
-
-#. {0} is the current application name
-#: src/olympia/tags/templates/tags/top_cloud.html:14
-msgid "{0} Top Tags"
-msgstr ""
-
 #: src/olympia/templates/amo_footer.html:6 src/olympia/templates/includes/lang_switcher.html:2
 msgid "Other languages"
 msgstr ""
@@ -11242,11 +11149,11 @@ msgstr ""
 msgid "Mozilla Add-ons"
 msgstr ""
 
-#: src/olympia/templates/base.html:91 src/olympia/templates/impala/base.html:81
+#: src/olympia/templates/base.html:89 src/olympia/templates/impala/base.html:78
 msgid "Find add-ons for other applications"
 msgstr ""
 
-#: src/olympia/templates/base.html:92 src/olympia/templates/impala/base.html:81
+#: src/olympia/templates/base.html:90 src/olympia/templates/impala/base.html:78
 msgid "Other Applications"
 msgstr ""
 
@@ -11271,7 +11178,7 @@ msgid "View Mobile Site"
 msgstr ""
 
 #: src/olympia/templates/copyright.html:7
-msgid "Site Status "
+msgid "Site Status"
 msgstr ""
 
 #: src/olympia/templates/footer.html:3
@@ -11371,35 +11278,35 @@ msgstr ""
 msgid "<a href=\"%(reg)s\">Register</a> or <a href=\"%(login)s\">Log in</a>"
 msgstr ""
 
-#: src/olympia/templates/impala/base.html:126
+#: src/olympia/templates/impala/base.html:123
 #, python-format
 msgid "To try the thousands of add-ons available here, download <a href=\"%(url)s\">Mozilla Firefox</a>, a fast, free way to surf the Web!"
 msgstr ""
 
-#: src/olympia/templates/impala/base.html:138
+#: src/olympia/templates/impala/base.html:135
 #, python-format
 msgid "Add-ons is switching to Firefox Accounts for login. <a href=\"%(url)s\" class=\"fxa-login\">Sign in now to transfer your account.</a>"
 msgstr ""
 
 #. {0} is an application, such as Firefox.
-#: src/olympia/templates/impala/base.html:148
+#: src/olympia/templates/impala/base.html:145
 msgid "Welcome to {0} Add-ons."
 msgstr ""
 
-#: src/olympia/templates/impala/base.html:151
+#: src/olympia/templates/impala/base.html:148
 msgid "Choose from thousands of extra features and styles to make Firefox your own."
 msgstr ""
 
-#: src/olympia/templates/impala/base.html:156
+#: src/olympia/templates/impala/base.html:153
 #, python-format
 msgid "Add extra features and styles to make %(app)s your own."
 msgstr ""
 
-#: src/olympia/templates/impala/base.html:164
+#: src/olympia/templates/impala/base.html:161
 msgid "On the go?"
 msgstr ""
 
-#: src/olympia/templates/impala/base.html:166
+#: src/olympia/templates/impala/base.html:163
 msgid "Check out our <a class=\"mobile-link\" href=\"#\">Mobile Add-ons site</a>."
 msgstr ""
 
@@ -11623,19 +11530,19 @@ msgstr ""
 
 #. L10n: {id} will be something like "13ad6a", just a random number
 #. to differentiate this user from other anonymous users.
-#: src/olympia/users/models.py:353
+#: src/olympia/users/models.py:362
 msgid "Anonymous user {id}"
 msgstr ""
 
-#: src/olympia/users/models.py:410
+#: src/olympia/users/models.py:419
 msgid "Your account has been restricted"
 msgstr ""
 
-#: src/olympia/users/models.py:480
+#: src/olympia/users/models.py:489
 msgid "Please confirm your email address"
 msgstr ""
 
-#: src/olympia/users/models.py:506
+#: src/olympia/users/models.py:515
 msgid "My Mobile Add-ons"
 msgstr ""
 
@@ -11912,7 +11819,7 @@ msgstr ""
 
 #: src/olympia/users/templates/users/edit.html:70
 #, python-format
-msgid "Change your password.  If you forgot your password, you can <a href=\"%(reset_url)s\">use the reset form</a>."
+msgid "Change your password. If you forgot your password, you can <a href=\"%(reset_url)s\">use the reset form</a>."
 msgstr ""
 
 #: src/olympia/users/templates/users/edit.html:76
@@ -11932,7 +11839,7 @@ msgid "Profile"
 msgstr ""
 
 #: src/olympia/users/templates/users/edit.html:100
-msgid "Give us a bit more information about yourself.  All these fields are optional, but they'll help other users get to know you better."
+msgid "Give us a bit more information about yourself. All these fields are optional, but they'll help other users get to know you better."
 msgstr ""
 
 #: src/olympia/users/templates/users/edit.html:124
@@ -12148,7 +12055,7 @@ msgid "Confirm password"
 msgstr ""
 
 #: src/olympia/users/templates/users/pwreset_confirm.html:47
-msgid "The password reset link was invalid, possibly because it has already been used.  Please request a new password reset."
+msgid "The password reset link was invalid, possibly because it has already been used. Please request a new password reset."
 msgstr ""
 
 #: src/olympia/users/templates/users/pwreset_request.html:15
@@ -12334,7 +12241,7 @@ msgstr ""
 
 #: src/olympia/users/templates/users/unsubscribe.html:30
 #, python-format
-msgid "Unfortunately, we weren't able to unsubscribe you.  The link you clicked is invalid. However, you can unsubscribe still unsubscribe on your <a href=\"%(edit_url)s\">edit profile page</a>."
+msgid "Unfortunately, we weren't able to unsubscribe you. The link you clicked is invalid. However, you can unsubscribe still unsubscribe on your <a href=\"%(edit_url)s\">edit profile page</a>."
 msgstr ""
 
 #: src/olympia/users/templates/users/vcard.html:2
@@ -12366,12 +12273,14 @@ msgstr ""
 msgid "%(num)s theme"
 msgid_plural "%(num)s themes"
 msgstr[0] ""
+msgstr[1] ""
 
 #: src/olympia/users/templates/users/vcard.html:62
 #, python-format
 msgid "%(num)s add-on"
 msgid_plural "%(num)s add-ons"
 msgstr[0] ""
+msgstr[1] ""
 
 #: src/olympia/users/templates/users/vcard.html:75
 msgid "Average rating of developer's add-ons"
@@ -12386,15 +12295,15 @@ msgstr ""
 msgid "Version History with Changelogs"
 msgstr ""
 
-#: src/olympia/versions/models.py:314
+#: src/olympia/versions/models.py:313
 msgid "Add-on uses binary components."
 msgstr ""
 
-#: src/olympia/versions/models.py:317
+#: src/olympia/versions/models.py:316
 msgid "Add-on has opted into strict compatibility checking."
 msgstr ""
 
-#: src/olympia/versions/models.py:715
+#: src/olympia/versions/models.py:711
 msgid "{app} {min} and later"
 msgstr ""
 
@@ -12431,6 +12340,7 @@ msgstr ""
 msgid "<b>{0}</b> version"
 msgid_plural "<b>{0}</b> versions"
 msgstr[0] ""
+msgstr[1] ""
 
 #: src/olympia/versions/templates/versions/version_list.html:35 src/olympia/versions/templates/versions/mobile/version_list.html:14
 msgid "Be careful with old versions!"
@@ -12468,4 +12378,8 @@ msgstr ""
 
 #: src/olympia/zadmin/forms.py:105
 msgid "Log emails instead of sending"
+msgstr ""
+
+#: src/olympia/zadmin/forms.py:215
+msgid "Deleted versions can`t be changed."
 msgstr ""

--- a/locale/my/LC_MESSAGES/djangojs.po
+++ b/locale/my/LC_MESSAGES/djangojs.po
@@ -1,1202 +1,1236 @@
-
 #, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2016-02-24 21:23+0000\n"
+"POT-Creation-Date: 2016-04-18 15:47+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
+"Language: \n"
 "MIME-Version: 1.0\n"
-"Content-Type: text/plain; charset=utf-8\n"
+"Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Generated-By: Babel 2.2.0\n"
 
-#: static/js/common/ratingwidget.js:31
+#: static/js/common-all.js:1426 static/js/impala-all.js:1511 static/js/zamboni/discovery-all.js:12598 static/js/zamboni/init.js:28 static/js/zamboni/mobile-all.js:14945
+msgid "This feature is temporarily disabled while we perform website maintenance. Please check back a little later."
+msgstr ""
+
+#. L10n: {0} is an app name like Firefox.
+#: static/js/common-all.js:1837 static/js/impala-all.js:1922 static/js/zamboni/buttons.js:73 static/js/zamboni/discovery-all.js:13108
+msgid "Accept and Install"
+msgstr ""
+
+#: static/js/common-all.js:1837 static/js/impala-all.js:1922 static/js/zamboni/buttons.js:73 static/js/zamboni/discovery-all.js:13108
+msgid "Add to {0}"
+msgstr ""
+
+#: static/js/common-all.js:1842 static/js/impala-all.js:1927 static/js/zamboni/buttons.js:78 static/js/zamboni/discovery-all.js:13113
+msgid "Download Now"
+msgstr ""
+
+#: static/js/common-all.js:1883 static/js/impala-all.js:1968 static/js/zamboni/buttons.js:119 static/js/zamboni/discovery-all.js:13154
+msgid "Add-on has not been updated to support default-to-compatible."
+msgstr ""
+
+#: static/js/common-all.js:1888 static/js/impala-all.js:1973 static/js/zamboni/buttons.js:124 static/js/zamboni/discovery-all.js:13159
+msgid "You need to be using Firefox 10.0 or higher."
+msgstr ""
+
+#: static/js/common-all.js:1900 static/js/impala-all.js:1985 static/js/zamboni/buttons.js:136 static/js/zamboni/discovery-all.js:13171
+msgid "Mozilla has marked this version as incompatible with your Firefox version."
+msgstr ""
+
+#. L10n: {0} is an platform like Windows or Linux.
+#: static/js/common-all.js:1981 static/js/impala-all.js:2066 static/js/zamboni/buttons.js:217 static/js/zamboni/discovery-all.js:13252
+msgid "Install for {0} anyway"
+msgstr ""
+
+#: static/js/common-all.js:1981 static/js/impala-all.js:2066 static/js/zamboni/buttons.js:217 static/js/zamboni/discovery-all.js:13252
+msgid "Download for {0} anyway"
+msgstr ""
+
+#: static/js/common-all.js:2038 static/js/impala-all.js:2123 static/js/zamboni/buttons.js:274 static/js/zamboni/discovery-all.js:13309
+msgid "Not available for your platform"
+msgstr ""
+
+#. L10n: {0} is an app name, {1} is the app version.
+#: static/js/common-all.js:2049 static/js/common-all.js:2086 static/js/impala-all.js:2134 static/js/impala-all.js:2171 static/js/zamboni/buttons.js:286 static/js/zamboni/buttons.js:324
+#: static/js/zamboni/discovery-all.js:13320 static/js/zamboni/discovery-all.js:13357
+msgid "Not available for {0} {1}"
+msgstr ""
+
+#: static/js/common-all.js:2112 static/js/impala-all.js:2197 static/js/zamboni/buttons.js:351 static/js/zamboni/discovery-all.js:13383
+msgid "Works with {app} {min} - {max}"
+msgstr ""
+
+#: static/js/common-all.js:2114 static/js/impala-all.js:2199 static/js/zamboni/buttons.js:353 static/js/zamboni/discovery-all.js:13385
+msgid "View other versions"
+msgstr ""
+
+#: static/js/common-all.js:2162 static/js/impala-all.js:2247 static/js/zamboni/buttons.js:401 static/js/zamboni/discovery-all.js:13433
+msgid "Only with Firefox — Get Firefox Now!"
+msgstr ""
+
+#: static/js/common-all.js:2278 static/js/impala-all.js:2363 static/js/zamboni/buttons.js:517 static/js/zamboni/discovery-all.js:13549 static/js/zamboni/mobile-all.js:15177
+#: static/js/zamboni/mobile/buttons.js:43
+msgid "Sorry, you need a Mozilla-based browser (such as Firefox) to install a search plugin."
+msgstr ""
+
+#: static/js/common-all.js:9088 static/js/impala-all.js:9649 static/js/zamboni/global.js:410
+msgid "Loading..."
+msgstr ""
+
+#. L10n: {0} is the number of characters left.
+#: static/js/common-all.js:9152 static/js/impala-all.js:9713 static/js/zamboni/global.js:474
+msgid "<b>{0}</b> character left."
+msgid_plural "<b>{0}</b> characters left."
+msgstr[0] ""
+msgstr[1] ""
+
+#: static/js/common-all.js:9589 static/js/common-min.js:6 static/js/impala-all.js:10052 static/js/impala-min.js:6 static/js/common/ratingwidget.js:31 static/js/zamboni/mobile-all.js:16123
+#: static/js/zamboni/mobile-min.js:6
 msgid "{0} star"
 msgid_plural "{0} stars"
 msgstr[0] ""
+msgstr[1] ""
 
-#: static/js/common/upload-addon.js:41 static/js/common/upload-image.js:128
+#: static/js/common-all.js:9676 static/js/common-min.js:6 static/js/impala-all.js:10139 static/js/impala-min.js:6 static/js/zamboni/l10n.js:45
+msgid "Remove this localization"
+msgstr ""
+
+#: static/js/common-all.js:10193 static/js/common-min.js:6 static/js/impala-all.js:10674 static/js/impala-min.js:6 static/js/zamboni/discovery-all.js:13678
+msgid "close"
+msgstr ""
+
+#: static/js/common-all.js:10860 static/js/common-min.js:6 static/js/impala-all.js:11481 static/js/impala-min.js:6 static/js/impala/reviews.js:23 static/js/zamboni/reviews.js:18
+msgid "Flagged for review"
+msgstr ""
+
+#: static/js/common-all.js:10876 static/js/common-min.js:6 static/js/impala-all.js:11498 static/js/impala-min.js:6 static/js/impala/reviews.js:40 static/js/zamboni/reviews.js:34
+msgid "Your input is required"
+msgstr ""
+
+#: static/js/common-all.js:10945 static/js/common-min.js:6 static/js/impala-all.js:11610 static/js/impala-min.js:7 static/js/impala/reviews.js:152 static/js/zamboni/reviews.js:103
+msgid "Marked for deletion"
+msgstr ""
+
+#: static/js/common-all.js:11573 static/js/common-min.js:7 static/js/impala-all.js:13809 static/js/impala-min.js:8 static/js/zamboni/collections.js:229
+msgid "Adding to Favorites&hellip;"
+msgstr ""
+
+#: static/js/common-all.js:11576 static/js/common-min.js:7 static/js/impala-all.js:13812 static/js/impala-min.js:8 static/js/zamboni/collections.js:232
+msgid "Removing Favorite&hellip;"
+msgstr ""
+
+#: static/js/common-all.js:11579 static/js/common-min.js:7 static/js/impala-all.js:13815 static/js/impala-min.js:8 static/js/zamboni/collections.js:235
+msgid "Add to Favorites"
+msgstr ""
+
+#: static/js/common-all.js:11582 static/js/common-min.js:7 static/js/impala-all.js:13818 static/js/impala-min.js:8 static/js/zamboni/collections.js:238
+msgid "Remove from Favorites"
+msgstr ""
+
+#: static/js/common-all.js:11647 static/js/common-min.js:7 static/js/impala-all.js:13883 static/js/impala-min.js:8 static/js/zamboni/collections.js:303
+msgid "Pending"
+msgstr ""
+
+#: static/js/common-all.js:11648 static/js/common-min.js:7 static/js/impala-all.js:13884 static/js/impala-min.js:8 static/js/zamboni/collections.js:304
+msgid "Add a comment"
+msgstr ""
+
+#: static/js/common-all.js:11648 static/js/common-min.js:7 static/js/impala-all.js:13884 static/js/impala-min.js:8 static/js/zamboni/collections.js:304
+msgid "Comment"
+msgstr ""
+
+#: static/js/common-all.js:11649 static/js/common-min.js:7 static/js/impala-all.js:13885 static/js/impala-min.js:8 static/js/zamboni/collections.js:305
+msgid "Remove this add-on from the collection"
+msgstr ""
+
+#: static/js/common-all.js:11649 static/js/common-all.js:11678 static/js/common-min.js:7 static/js/impala-all.js:13885 static/js/impala-all.js:13914 static/js/impala-min.js:8
+#: static/js/zamboni/collections.js:305 static/js/zamboni/collections.js:334
+msgid "Remove"
+msgstr ""
+
+#: static/js/common-all.js:11678 static/js/common-min.js:7 static/js/impala-all.js:13914 static/js/impala-min.js:8 static/js/zamboni/collections.js:334
+msgid "Remove this user as a contributor"
+msgstr ""
+
+#: static/js/common-all.js:11690 static/js/common-min.js:7 static/js/impala-all.js:13926 static/js/impala-min.js:8 static/js/zamboni/collections.js:346
+msgid "An email address is required."
+msgstr ""
+
+#: static/js/common-all.js:11708 static/js/common-min.js:7 static/js/impala-all.js:13944 static/js/impala-min.js:8 static/js/zamboni/collections.js:364
+msgid "You cannot add yourself as a contributor."
+msgstr ""
+
+#: static/js/common-all.js:11710 static/js/common-min.js:7 static/js/impala-all.js:13946 static/js/impala-min.js:8 static/js/zamboni/collections.js:366
+msgid "You have already added that user."
+msgstr ""
+
+#: static/js/common-all.js:11917 static/js/common-min.js:7 static/js/impala-all.js:14153 static/js/impala-min.js:8 static/js/zamboni/collections.js:573
+msgid "Add to favorites"
+msgstr ""
+
+#: static/js/common-all.js:11921 static/js/common-min.js:7 static/js/impala-all.js:14157 static/js/impala-min.js:8 static/js/zamboni/collections.js:577
+msgid "Remove from favorites"
+msgstr ""
+
+#: static/js/common-all.js:11939 static/js/common-min.js:7 static/js/impala-all.js:14175 static/js/impala-all.js:14233 static/js/impala-min.js:8 static/js/impala/collections.js:10
+#: static/js/zamboni/collections.js:595
+msgid "Follow this Collection"
+msgstr ""
+
+#: static/js/common-all.js:11948 static/js/common-min.js:7 static/js/impala-all.js:14184 static/js/impala-min.js:8 static/js/zamboni/collections.js:604
+msgid "Stop following"
+msgstr ""
+
+#: static/js/common-all.js:12096 static/js/common-min.js:7 static/js/zamboni/password-strength.js:20
+msgid "Password strength:"
+msgstr ""
+
+#: static/js/common-all.js:12102 static/js/common-min.js:7 static/js/zamboni/password-strength.js:26
+msgid "At least {0} character left."
+msgid_plural "At least {0} characters left."
+msgstr[0] ""
+msgstr[1] ""
+
+#: static/js/common-all.js:12286 static/js/common-min.js:7 static/js/impala-all.js:14632 static/js/impala-min.js:8 static/js/impala/suggestions.js:39
+msgid "Search themes for <b>{0}</b>"
+msgstr ""
+
+#: static/js/common-all.js:12288 static/js/common-min.js:7 static/js/impala-all.js:14634 static/js/impala-min.js:8 static/js/impala/suggestions.js:41
+msgid "Search apps for <b>{0}</b>"
+msgstr ""
+
+#: static/js/common-all.js:12290 static/js/common-min.js:7 static/js/impala-all.js:14636 static/js/impala-min.js:8 static/js/impala/suggestions.js:43
+msgid "Search add-ons for <b>{0}</b>"
+msgstr ""
+
+#: static/js/common-all.js:12521 static/js/common-min.js:7 static/js/impala-all.js:14867 static/js/impala-min.js:8 static/js/impala/site_suggestions.js:46
+msgid "Category"
+msgstr ""
+
+#. L10n: {0} is an app name.
+#: static/js/impala-all.js:11632 static/js/impala-min.js:7 static/js/impala/listing.js:11 static/js/zamboni/themes.js:13
+msgid "This theme is incompatible with your version of {0}"
+msgstr ""
+
+#: static/js/impala-all.js:12146 static/js/impala-all.js:14331 static/js/impala-min.js:7 static/js/impala-min.js:8 static/js/common/upload-image.js:97 static/js/impala/users.js:51
+#: static/js/zamboni/devhub-all.js:894 static/js/zamboni/devhub-min.js:1
+msgid "Images must be either PNG or JPG."
+msgstr ""
+
+#: static/js/impala-all.js:12150 static/js/impala-min.js:7 static/js/common/upload-image.js:101 static/js/zamboni/devhub-all.js:898 static/js/zamboni/devhub-min.js:1
+msgid "Videos must be in WebM."
+msgstr ""
+
+#: static/js/impala-all.js:12177 static/js/impala-min.js:7 static/js/common/upload-addon.js:41 static/js/common/upload-image.js:128 static/js/zamboni/devhub-all.js:272
+#: static/js/zamboni/devhub-all.js:925 static/js/zamboni/devhub-min.js:1
 msgid "There was a problem contacting the server."
 msgstr ""
 
-#: static/js/common/upload-addon.js:69
+#: static/js/impala-all.js:13298 static/js/impala-min.js:7 static/js/impala/persona_creation.js:60
+msgid "All Rights Reserved"
+msgstr ""
+
+#: static/js/impala-all.js:13302 static/js/impala-min.js:7 static/js/impala/persona_creation.js:64
+msgid "Creative Commons Attribution 3.0"
+msgstr ""
+
+#: static/js/impala-all.js:13307 static/js/impala-min.js:7 static/js/impala/persona_creation.js:69
+msgid "Creative Commons Attribution-NonCommercial 3.0"
+msgstr ""
+
+#: static/js/impala-all.js:13312 static/js/impala-min.js:7 static/js/impala/persona_creation.js:74
+msgid "Creative Commons Attribution-NonCommercial-NoDerivs 3.0"
+msgstr ""
+
+#: static/js/impala-all.js:13317 static/js/impala-min.js:7 static/js/impala/persona_creation.js:79
+msgid "Creative Commons Attribution-NonCommercial-Share Alike 3.0"
+msgstr ""
+
+#: static/js/impala-all.js:13322 static/js/impala-min.js:7 static/js/impala/persona_creation.js:84
+msgid "Creative Commons Attribution-NoDerivs 3.0"
+msgstr ""
+
+#: static/js/impala-all.js:13327 static/js/impala-min.js:7 static/js/impala/persona_creation.js:89
+msgid "Creative Commons Attribution-ShareAlike 3.0"
+msgstr ""
+
+#: static/js/impala-all.js:13530 static/js/impala-min.js:7 static/js/impala/persona_creation.js:292
+msgid "Your Theme's Name"
+msgstr ""
+
+#: static/js/impala-all.js:14242 static/js/impala-min.js:8 static/js/impala/collections.js:19
+msgid "Stop Following"
+msgstr ""
+
+#: static/js/impala-all.js:14243 static/js/impala-min.js:8 static/js/impala/collections.js:20
+msgid "Following"
+msgstr ""
+
+#: static/js/impala-all.js:14313 static/js/impala-min.js:8 static/js/impala/users.js:33
+msgid "use original"
+msgstr ""
+
+#: static/js/impala-all.js:14523 static/js/impala-min.js:8 static/js/impala/search.js:114
+msgid "Updating results&hellip;"
+msgstr ""
+
+#: static/js/common/upload-addon.js:69 static/js/zamboni/devhub-all.js:300 static/js/zamboni/devhub-min.js:1
 msgid "Select a file..."
 msgstr ""
 
-#: static/js/common/upload-addon.js:70
+#: static/js/common/upload-addon.js:70 static/js/zamboni/devhub-all.js:301 static/js/zamboni/devhub-min.js:1
 msgid "Your add-on should end with .xpi, .jar or .xml"
 msgstr ""
 
 #. L10n: {0} is the percent of the file that has been uploaded.
-#: static/js/common/upload-addon.js:104
+#: static/js/common/upload-addon.js:104 static/js/zamboni/devhub-all.js:335 static/js/zamboni/devhub-min.js:1
 #, python-format
 msgid "{0}% complete"
 msgstr ""
 
 #. L10n: "{bytes uploaded} of {total filesize}".
-#: static/js/common/upload-addon.js:107
+#: static/js/common/upload-addon.js:107 static/js/zamboni/devhub-all.js:338 static/js/zamboni/devhub-min.js:1
 msgid "{0} of {1}"
 msgstr ""
 
-#: static/js/common/upload-addon.js:140
+#: static/js/common/upload-addon.js:140 static/js/zamboni/devhub-all.js:371 static/js/zamboni/devhub-min.js:1
 msgid "Cancel"
 msgstr ""
 
-#: static/js/common/upload-addon.js:162
+#: static/js/common/upload-addon.js:162 static/js/zamboni/devhub-all.js:393 static/js/zamboni/devhub-min.js:1
 msgid "Uploading {0}"
 msgstr ""
 
-#: static/js/common/upload-addon.js:189
+#: static/js/common/upload-addon.js:189 static/js/zamboni/devhub-all.js:420 static/js/zamboni/devhub-min.js:1
 msgid "Error with {0}"
 msgstr ""
 
-#: static/js/common/upload-addon.js:194
+#: static/js/common/upload-addon.js:194 static/js/zamboni/devhub-all.js:425 static/js/zamboni/devhub-min.js:1
 msgid "Your add-on failed validation with {0} error."
 msgid_plural "Your add-on failed validation with {0} errors."
 msgstr[0] ""
+msgstr[1] ""
 
-#: static/js/common/upload-addon.js:208
+#: static/js/common/upload-addon.js:208 static/js/zamboni/devhub-all.js:439 static/js/zamboni/devhub-min.js:1
 msgid "&hellip;and {0} more"
 msgid_plural "&hellip;and {0} more"
 msgstr[0] ""
+msgstr[1] ""
 
-#: static/js/common/upload-addon.js:222 static/js/common/upload-addon.js:512
+#: static/js/common/upload-addon.js:222 static/js/common/upload-addon.js:497 static/js/zamboni/devhub-all.js:453 static/js/zamboni/devhub-all.js:743 static/js/zamboni/devhub-min.js:1
 msgid "See full validation report"
 msgstr ""
 
-#: static/js/common/upload-addon.js:234
+#: static/js/common/upload-addon.js:234 static/js/zamboni/devhub-all.js:465 static/js/zamboni/devhub-min.js:1
 msgid "Validating {0}"
 msgstr ""
 
 #. L10n: first argument is an HTTP status code
-#: static/js/common/upload-addon.js:273
+#: static/js/common/upload-addon.js:273 static/js/zamboni/devhub-all.js:504 static/js/zamboni/devhub-min.js:1
 msgid "Received an empty response from the server; status: {0}"
 msgstr ""
 
-#: static/js/common/upload-addon.js:373
+#: static/js/common/upload-addon.js:370 static/js/zamboni/devhub-all.js:604 static/js/zamboni/devhub-min.js:1
 msgid "Unexpected server error while validating."
 msgstr ""
 
-#: static/js/common/upload-addon.js:412
+#: static/js/common/upload-addon.js:409 static/js/zamboni/devhub-all.js:643 static/js/zamboni/devhub-min.js:1
 msgid "Finished validating {0}"
 msgstr ""
 
-#: static/js/common/upload-addon.js:418
+#: static/js/common/upload-addon.js:415 static/js/zamboni/devhub-all.js:649 static/js/zamboni/devhub-min.js:1
 msgid "Your add-on validation timed out, it will be manually reviewed."
 msgstr ""
 
-#: static/js/common/upload-addon.js:421
+#: static/js/common/upload-addon.js:418 static/js/zamboni/devhub-all.js:652 static/js/zamboni/devhub-min.js:1
 msgid "Your add-on was validated with no errors and {0} warning."
 msgid_plural "Your add-on was validated with no errors and {0} warnings."
 msgstr[0] ""
+msgstr[1] ""
 
-#: static/js/common/upload-addon.js:426
+#: static/js/common/upload-addon.js:423 static/js/zamboni/devhub-all.js:657 static/js/zamboni/devhub-min.js:1
 msgid "Your add-on was validated with no errors and {0} message."
 msgid_plural "Your add-on was validated with no errors and {0} messages."
 msgstr[0] ""
+msgstr[1] ""
 
-#: static/js/common/upload-addon.js:431
+#: static/js/common/upload-addon.js:428 static/js/zamboni/devhub-all.js:662 static/js/zamboni/devhub-min.js:1
 msgid "Your add-on was validated with no errors or warnings."
 msgstr ""
 
-#: static/js/common/upload-addon.js:446
+#: static/js/common/upload-addon.js:443 static/js/zamboni/devhub-all.js:677 static/js/zamboni/devhub-min.js:1
 msgid "Your submission will be automatically signed."
 msgstr ""
 
-#: static/js/common/upload-addon.js:465
+#: static/js/common/upload-addon.js:450 static/js/zamboni/devhub-all.js:696 static/js/zamboni/devhub-min.js:1
 msgid "Include detailed version notes (this can be done in the next step)."
 msgstr ""
 
-#: static/js/common/upload-addon.js:466
+#: static/js/common/upload-addon.js:451 static/js/zamboni/devhub-all.js:697 static/js/zamboni/devhub-min.js:1
 msgid "If your add-on requires an account to a website in order to be fully tested, include a test username and password in the Notes to Reviewer (this can be done in the next step)."
 msgstr ""
 
-#: static/js/common/upload-addon.js:467
+#: static/js/common/upload-addon.js:452 static/js/zamboni/devhub-all.js:698 static/js/zamboni/devhub-min.js:1
 msgid "If your add-on is intended for a limited audience you should choose Preliminary Review instead of Full Review."
 msgstr ""
 
-#: static/js/common/upload-addon.js:480
+#: static/js/common/upload-addon.js:465 static/js/zamboni/devhub-all.js:711 static/js/zamboni/devhub-min.js:1
 msgid "Add-on submission checklist"
 msgstr ""
 
-#: static/js/common/upload-addon.js:481
+#: static/js/common/upload-addon.js:466 static/js/zamboni/devhub-all.js:712 static/js/zamboni/devhub-min.js:1
 msgid "Please verify the following points before finalizing your submission. This will minimize delays or misunderstanding during the review process:"
 msgstr ""
 
-#: static/js/common/upload-addon.js:483
+#: static/js/common/upload-addon.js:468 static/js/zamboni/devhub-all.js:714 static/js/zamboni/devhub-min.js:1
 msgid ""
 "Compiled binaries, as well as minified or obfuscated scripts (excluding known libraries) need to have their sources submitted separately for review. Make sure that you use the source code upload "
 "field to avoid having your submission rejected."
 msgstr ""
 
-#: static/js/common/upload-addon.js:501
+#: static/js/common/upload-addon.js:486 static/js/zamboni/devhub-all.js:732 static/js/zamboni/devhub-min.js:1
 msgid "The validation process found these issues that can lead to rejections:"
 msgstr ""
 
-#: static/js/common/upload-addon.js:518
+#: static/js/common/upload-addon.js:503 static/js/zamboni/devhub-all.js:749 static/js/zamboni/devhub-min.js:1
 msgid "If you are unfamiliar with the add-ons review process, you can read about it here."
 msgstr ""
 
-#: static/js/common/upload-addon.js:555
+#: static/js/common/upload-addon.js:540 static/js/zamboni/devhub-all.js:786 static/js/zamboni/devhub-min.js:1
 msgid "Sorry, no supported platform has been found."
 msgstr ""
 
-#: static/js/common/upload-base.js:57
+#: static/js/common/upload-base.js:57 static/js/zamboni/devhub-all.js:187 static/js/zamboni/devhub-min.js:1
 msgid "The filetype you uploaded isn't recognized."
 msgstr ""
 
-#: static/js/common/upload-base.js:79
+#: static/js/common/upload-base.js:79 static/js/zamboni/devhub-all.js:209 static/js/zamboni/devhub-min.js:1
 msgid "You cancelled the upload."
 msgstr ""
 
-#: static/js/common/upload-image.js:97 static/js/impala/users.js:51
-msgid "Images must be either PNG or JPG."
-msgstr ""
-
-#: static/js/common/upload-image.js:101
-msgid "Videos must be in WebM."
-msgstr ""
-
-#: static/js/impala/collections.js:10 static/js/zamboni/collections.js:595
-msgid "Follow this Collection"
-msgstr ""
-
-#: static/js/impala/collections.js:19
-msgid "Stop Following"
-msgstr ""
-
-#: static/js/impala/collections.js:20
-msgid "Following"
-msgstr ""
-
-#. L10n: {0} is an app name.
-#: static/js/impala/listing.js:11 static/js/zamboni/themes.js:13
-msgid "This theme is incompatible with your version of {0}"
-msgstr ""
-
-#: static/js/impala/persona_creation.js:60
-msgid "All Rights Reserved"
-msgstr ""
-
-#: static/js/impala/persona_creation.js:64
-msgid "Creative Commons Attribution 3.0"
-msgstr ""
-
-#: static/js/impala/persona_creation.js:69
-msgid "Creative Commons Attribution-NonCommercial 3.0"
-msgstr ""
-
-#: static/js/impala/persona_creation.js:74
-msgid "Creative Commons Attribution-NonCommercial-NoDerivs 3.0"
-msgstr ""
-
-#: static/js/impala/persona_creation.js:79
-msgid "Creative Commons Attribution-NonCommercial-Share Alike 3.0"
-msgstr ""
-
-#: static/js/impala/persona_creation.js:84
-msgid "Creative Commons Attribution-NoDerivs 3.0"
-msgstr ""
-
-#: static/js/impala/persona_creation.js:89
-msgid "Creative Commons Attribution-ShareAlike 3.0"
-msgstr ""
-
-#: static/js/impala/persona_creation.js:292
-msgid "Your Theme's Name"
-msgstr ""
-
-#: static/js/impala/reviews.js:23 static/js/zamboni/reviews.js:18
-msgid "Flagged for review"
-msgstr ""
-
-#: static/js/impala/reviews.js:40 static/js/zamboni/reviews.js:34
-msgid "Your input is required"
-msgstr ""
-
-#: static/js/impala/reviews.js:152 static/js/zamboni/reviews.js:103
-msgid "Marked for deletion"
-msgstr ""
-
-#: static/js/impala/search.js:114
-msgid "Updating results&hellip;"
-msgstr ""
-
-#: static/js/impala/site_suggestions.js:46
-msgid "Category"
-msgstr ""
-
-#: static/js/impala/suggestions.js:39
-msgid "Search themes for <b>{0}</b>"
-msgstr ""
-
-#: static/js/impala/suggestions.js:41
-msgid "Search apps for <b>{0}</b>"
-msgstr ""
-
-#: static/js/impala/suggestions.js:43
-msgid "Search add-ons for <b>{0}</b>"
-msgstr ""
-
-#: static/js/impala/users.js:33
-msgid "use original"
-msgstr ""
-
-#: static/js/impala/stats/chart.js:267
+#: static/js/impala/stats/chart.js:267 static/js/zamboni/stats-all.js:16898 static/js/zamboni/stats-min.js:5
 msgid "Week of {0}"
 msgstr ""
 
-#: static/js/impala/stats/chart.js:269
+#: static/js/impala/stats/chart.js:269 static/js/zamboni/stats-all.js:16900 static/js/zamboni/stats-min.js:5
 msgid " downloads"
 msgstr ""
 
-#: static/js/impala/stats/chart.js:270
+#: static/js/impala/stats/chart.js:270 static/js/zamboni/stats-all.js:16901 static/js/zamboni/stats-min.js:5
 msgid "{0} users"
 msgstr ""
 
-#: static/js/impala/stats/chart.js:271
+#: static/js/impala/stats/chart.js:271 static/js/zamboni/stats-all.js:16902 static/js/zamboni/stats-min.js:5
 msgid "{0} add-ons"
 msgstr ""
 
-#: static/js/impala/stats/chart.js:272
+#: static/js/impala/stats/chart.js:272 static/js/zamboni/stats-all.js:16903 static/js/zamboni/stats-min.js:5
 msgid "{0} collections"
 msgstr ""
 
-#: static/js/impala/stats/chart.js:273
+#: static/js/impala/stats/chart.js:273 static/js/zamboni/stats-all.js:16904 static/js/zamboni/stats-min.js:5
 msgid "{0} reviews"
 msgstr ""
 
-#: static/js/impala/stats/chart.js:275
+#: static/js/impala/stats/chart.js:275 static/js/zamboni/stats-all.js:16906 static/js/zamboni/stats-min.js:5
 msgid "{0} sales"
 msgstr ""
 
-#: static/js/impala/stats/chart.js:276
+#: static/js/impala/stats/chart.js:276 static/js/zamboni/stats-all.js:16907 static/js/zamboni/stats-min.js:5
 msgid "{0} refunds"
 msgstr ""
 
-#: static/js/impala/stats/chart.js:277
+#: static/js/impala/stats/chart.js:277 static/js/zamboni/stats-all.js:16908 static/js/zamboni/stats-min.js:5
 msgid "{0} installs"
 msgstr ""
 
-#: static/js/impala/stats/chart.js:369 static/js/impala/stats/csv_keys.js:3 static/js/impala/stats/csv_keys.js:109
+#: static/js/impala/stats/chart.js:369 static/js/impala/stats/csv_keys.js:3 static/js/impala/stats/csv_keys.js:109 static/js/zamboni/stats-all.js:15284 static/js/zamboni/stats-all.js:15390
+#: static/js/zamboni/stats-all.js:17000 static/js/zamboni/stats-min.js:4 static/js/zamboni/stats-min.js:5
 msgid "Downloads"
 msgstr ""
 
-#: static/js/impala/stats/chart.js:379 static/js/impala/stats/csv_keys.js:6 static/js/impala/stats/csv_keys.js:110
+#: static/js/impala/stats/chart.js:379 static/js/impala/stats/csv_keys.js:6 static/js/impala/stats/csv_keys.js:110 static/js/zamboni/stats-all.js:15287 static/js/zamboni/stats-all.js:15391
+#: static/js/zamboni/stats-all.js:17010 static/js/zamboni/stats-min.js:4 static/js/zamboni/stats-min.js:5
 msgid "Daily Users"
 msgstr ""
 
-#: static/js/impala/stats/chart.js:410
+#: static/js/impala/stats/chart.js:410 static/js/zamboni/stats-all.js:17041 static/js/zamboni/stats-min.js:5
 msgid "Amount, in USD"
 msgstr ""
 
-#: static/js/impala/stats/chart.js:421 static/js/impala/stats/csv_keys.js:104
+#: static/js/impala/stats/chart.js:421 static/js/impala/stats/csv_keys.js:104 static/js/zamboni/stats-all.js:15385 static/js/zamboni/stats-all.js:17052 static/js/zamboni/stats-min.js:5
 msgid "Number of Contributions"
 msgstr ""
 
-#: static/js/impala/stats/chart.js:447
+#: static/js/impala/stats/chart.js:447 static/js/zamboni/stats-all.js:17078 static/js/zamboni/stats-min.js:5
 msgid "More Info..."
 msgstr ""
 
 #. L10n: {0} is an ISO-formatted date.
-#: static/js/impala/stats/chart.js:451
+#: static/js/impala/stats/chart.js:451 static/js/zamboni/stats-all.js:17082 static/js/zamboni/stats-min.js:5
 msgid "Details for {0}"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:9
+#: static/js/impala/stats/csv_keys.js:9 static/js/zamboni/stats-all.js:15290 static/js/zamboni/stats-min.js:4
 msgid "Collections Created"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:12
+#: static/js/impala/stats/csv_keys.js:12 static/js/zamboni/stats-all.js:15293 static/js/zamboni/stats-min.js:4
 msgid "Add-ons in Use"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:15
+#: static/js/impala/stats/csv_keys.js:15 static/js/zamboni/stats-all.js:15296 static/js/zamboni/stats-min.js:4
 msgid "Add-ons Created"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:18
+#: static/js/impala/stats/csv_keys.js:18 static/js/zamboni/stats-all.js:15299 static/js/zamboni/stats-min.js:4
 msgid "Add-ons Downloaded"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:21
+#: static/js/impala/stats/csv_keys.js:21 static/js/zamboni/stats-all.js:15302 static/js/zamboni/stats-min.js:4
 msgid "Add-ons Updated"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:24
+#: static/js/impala/stats/csv_keys.js:24 static/js/zamboni/stats-all.js:15305 static/js/zamboni/stats-min.js:4
 msgid "Reviews Written"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:27
+#: static/js/impala/stats/csv_keys.js:27 static/js/zamboni/stats-all.js:15308 static/js/zamboni/stats-min.js:4
 msgid "User Signups"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:30
+#: static/js/impala/stats/csv_keys.js:30 static/js/zamboni/stats-all.js:15311 static/js/zamboni/stats-min.js:4
 msgid "Subscribers"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:33
+#: static/js/impala/stats/csv_keys.js:33 static/js/zamboni/stats-all.js:15314 static/js/zamboni/stats-min.js:4
 msgid "Ratings"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:36 static/js/impala/stats/csv_keys.js:114
+#: static/js/impala/stats/csv_keys.js:36 static/js/impala/stats/csv_keys.js:114 static/js/zamboni/stats-all.js:15317 static/js/zamboni/stats-all.js:15395 static/js/zamboni/stats-min.js:4
+#: static/js/zamboni/stats-min.js:5
 msgid "Sales"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:39 static/js/impala/stats/csv_keys.js:113
+#: static/js/impala/stats/csv_keys.js:39 static/js/impala/stats/csv_keys.js:113 static/js/zamboni/stats-all.js:15320 static/js/zamboni/stats-all.js:15394 static/js/zamboni/stats-min.js:4
+#: static/js/zamboni/stats-min.js:5
 msgid "Installs"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:42
+#: static/js/impala/stats/csv_keys.js:42 static/js/zamboni/stats-all.js:15323 static/js/zamboni/stats-min.js:4
 msgid "Unknown"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:43
+#: static/js/impala/stats/csv_keys.js:43 static/js/zamboni/stats-all.js:15324 static/js/zamboni/stats-min.js:4
 msgid "Add-ons Manager"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:44
+#: static/js/impala/stats/csv_keys.js:44 static/js/zamboni/stats-all.js:15325 static/js/zamboni/stats-min.js:4
 msgid "Add-ons Manager Promo"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:45
+#: static/js/impala/stats/csv_keys.js:45 static/js/zamboni/stats-all.js:15326 static/js/zamboni/stats-min.js:4
 msgid "Add-ons Manager Featured"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:46
+#: static/js/impala/stats/csv_keys.js:46 static/js/zamboni/stats-all.js:15327 static/js/zamboni/stats-min.js:4
 msgid "Add-ons Manager Learn More"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:47
+#: static/js/impala/stats/csv_keys.js:47 static/js/zamboni/stats-all.js:15328 static/js/zamboni/stats-min.js:4
 msgid "Search Suggestions"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:48
+#: static/js/impala/stats/csv_keys.js:48 static/js/zamboni/stats-all.js:15329 static/js/zamboni/stats-min.js:4
 msgid "Search Results"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:49 static/js/impala/stats/csv_keys.js:50 static/js/impala/stats/csv_keys.js:51
+#: static/js/impala/stats/csv_keys.js:49 static/js/impala/stats/csv_keys.js:50 static/js/impala/stats/csv_keys.js:51 static/js/zamboni/stats-all.js:15330 static/js/zamboni/stats-all.js:15331
+#: static/js/zamboni/stats-all.js:15332 static/js/zamboni/stats-min.js:4
 msgid "Homepage Promo"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:52 static/js/impala/stats/csv_keys.js:53
+#: static/js/impala/stats/csv_keys.js:52 static/js/impala/stats/csv_keys.js:53 static/js/zamboni/stats-all.js:15333 static/js/zamboni/stats-all.js:15334 static/js/zamboni/stats-min.js:4
 msgid "Homepage Featured"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:54 static/js/impala/stats/csv_keys.js:55
+#: static/js/impala/stats/csv_keys.js:54 static/js/impala/stats/csv_keys.js:55 static/js/zamboni/stats-all.js:15335 static/js/zamboni/stats-all.js:15336 static/js/zamboni/stats-min.js:4
 msgid "Homepage Up and Coming"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:56
+#: static/js/impala/stats/csv_keys.js:56 static/js/zamboni/stats-all.js:15337 static/js/zamboni/stats-min.js:4
 msgid "Homepage Most Popular"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:57 static/js/impala/stats/csv_keys.js:59
+#: static/js/impala/stats/csv_keys.js:57 static/js/impala/stats/csv_keys.js:59 static/js/zamboni/stats-all.js:15338 static/js/zamboni/stats-all.js:15340 static/js/zamboni/stats-min.js:4
 msgid "Detail Page"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:58 static/js/impala/stats/csv_keys.js:60
+#: static/js/impala/stats/csv_keys.js:58 static/js/impala/stats/csv_keys.js:60 static/js/zamboni/stats-all.js:15339 static/js/zamboni/stats-all.js:15341 static/js/zamboni/stats-min.js:4
 msgid "Detail Page (bottom)"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:61
+#: static/js/impala/stats/csv_keys.js:61 static/js/zamboni/stats-all.js:15342 static/js/zamboni/stats-min.js:4
 msgid "Detail Page (Development Channel)"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:62 static/js/impala/stats/csv_keys.js:63 static/js/impala/stats/csv_keys.js:64
+#: static/js/impala/stats/csv_keys.js:62 static/js/impala/stats/csv_keys.js:63 static/js/impala/stats/csv_keys.js:64 static/js/zamboni/stats-all.js:15343 static/js/zamboni/stats-all.js:15344
+#: static/js/zamboni/stats-all.js:15345 static/js/zamboni/stats-min.js:4
 msgid "Often Used With"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:65 static/js/impala/stats/csv_keys.js:66
+#: static/js/impala/stats/csv_keys.js:65 static/js/impala/stats/csv_keys.js:66 static/js/zamboni/stats-all.js:15346 static/js/zamboni/stats-all.js:15347 static/js/zamboni/stats-min.js:4
 msgid "Others By Author"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:67 static/js/impala/stats/csv_keys.js:68
+#: static/js/impala/stats/csv_keys.js:67 static/js/impala/stats/csv_keys.js:68 static/js/zamboni/stats-all.js:15348 static/js/zamboni/stats-all.js:15349 static/js/zamboni/stats-min.js:4
 msgid "Dependencies"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:69 static/js/impala/stats/csv_keys.js:70
+#: static/js/impala/stats/csv_keys.js:69 static/js/impala/stats/csv_keys.js:70 static/js/zamboni/stats-all.js:15350 static/js/zamboni/stats-all.js:15351 static/js/zamboni/stats-min.js:4
 msgid "Upsell"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:71
+#: static/js/impala/stats/csv_keys.js:71 static/js/zamboni/stats-all.js:15352 static/js/zamboni/stats-min.js:4
 msgid "Meet the Developer"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:72
+#: static/js/impala/stats/csv_keys.js:72 static/js/zamboni/stats-all.js:15353 static/js/zamboni/stats-min.js:4
 msgid "User Profile"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:73
+#: static/js/impala/stats/csv_keys.js:73 static/js/zamboni/stats-all.js:15354 static/js/zamboni/stats-min.js:4
 msgid "Version History"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:75
+#: static/js/impala/stats/csv_keys.js:75 static/js/zamboni/stats-all.js:15356 static/js/zamboni/stats-min.js:4
 msgid "Sharing"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:76
+#: static/js/impala/stats/csv_keys.js:76 static/js/zamboni/stats-all.js:15357 static/js/zamboni/stats-min.js:4
 msgid "Category Pages"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:77
+#: static/js/impala/stats/csv_keys.js:77 static/js/zamboni/stats-all.js:15358 static/js/zamboni/stats-min.js:4
 msgid "Collections"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:78 static/js/impala/stats/csv_keys.js:79
+#: static/js/impala/stats/csv_keys.js:78 static/js/impala/stats/csv_keys.js:79 static/js/zamboni/stats-all.js:15359 static/js/zamboni/stats-all.js:15360 static/js/zamboni/stats-min.js:4
 msgid "Category Landing Featured Carousel"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:80 static/js/impala/stats/csv_keys.js:81
+#: static/js/impala/stats/csv_keys.js:80 static/js/impala/stats/csv_keys.js:81 static/js/zamboni/stats-all.js:15361 static/js/zamboni/stats-all.js:15362 static/js/zamboni/stats-min.js:4
 msgid "Category Landing Top Rated"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:82 static/js/impala/stats/csv_keys.js:83
+#: static/js/impala/stats/csv_keys.js:82 static/js/impala/stats/csv_keys.js:83 static/js/zamboni/stats-all.js:15363 static/js/zamboni/stats-all.js:15364 static/js/zamboni/stats-min.js:5
 msgid "Category Landing Most Popular"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:84 static/js/impala/stats/csv_keys.js:85
+#: static/js/impala/stats/csv_keys.js:84 static/js/impala/stats/csv_keys.js:85 static/js/zamboni/stats-all.js:15365 static/js/zamboni/stats-all.js:15366 static/js/zamboni/stats-min.js:5
 msgid "Category Landing Recently Added"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:86 static/js/impala/stats/csv_keys.js:87
+#: static/js/impala/stats/csv_keys.js:86 static/js/impala/stats/csv_keys.js:87 static/js/zamboni/stats-all.js:15367 static/js/zamboni/stats-all.js:15368 static/js/zamboni/stats-min.js:5
 msgid "Browse Listing Featured Sort"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:88 static/js/impala/stats/csv_keys.js:89
+#: static/js/impala/stats/csv_keys.js:88 static/js/impala/stats/csv_keys.js:89 static/js/zamboni/stats-all.js:15369 static/js/zamboni/stats-all.js:15370 static/js/zamboni/stats-min.js:5
 msgid "Browse Listing Users Sort"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:90 static/js/impala/stats/csv_keys.js:91
+#: static/js/impala/stats/csv_keys.js:90 static/js/impala/stats/csv_keys.js:91 static/js/zamboni/stats-all.js:15371 static/js/zamboni/stats-all.js:15372 static/js/zamboni/stats-min.js:5
 msgid "Browse Listing Rating Sort"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:92 static/js/impala/stats/csv_keys.js:93
+#: static/js/impala/stats/csv_keys.js:92 static/js/impala/stats/csv_keys.js:93 static/js/zamboni/stats-all.js:15373 static/js/zamboni/stats-all.js:15374 static/js/zamboni/stats-min.js:5
 msgid "Browse Listing Created Sort"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:94 static/js/impala/stats/csv_keys.js:95
+#: static/js/impala/stats/csv_keys.js:94 static/js/impala/stats/csv_keys.js:95 static/js/zamboni/stats-all.js:15375 static/js/zamboni/stats-all.js:15376 static/js/zamboni/stats-min.js:5
 msgid "Browse Listing Name Sort"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:96 static/js/impala/stats/csv_keys.js:97
+#: static/js/impala/stats/csv_keys.js:96 static/js/impala/stats/csv_keys.js:97 static/js/zamboni/stats-all.js:15377 static/js/zamboni/stats-all.js:15378 static/js/zamboni/stats-min.js:5
 msgid "Browse Listing Popular Sort"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:98 static/js/impala/stats/csv_keys.js:99
+#: static/js/impala/stats/csv_keys.js:98 static/js/impala/stats/csv_keys.js:99 static/js/zamboni/stats-all.js:15379 static/js/zamboni/stats-all.js:15380 static/js/zamboni/stats-min.js:5
 msgid "Browse Listing Updated Sort"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:100 static/js/impala/stats/csv_keys.js:101
+#: static/js/impala/stats/csv_keys.js:100 static/js/impala/stats/csv_keys.js:101 static/js/zamboni/stats-all.js:15381 static/js/zamboni/stats-all.js:15382 static/js/zamboni/stats-min.js:5
 msgid "Browse Listing Up and Coming Sort"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:105
+#: static/js/impala/stats/csv_keys.js:105 static/js/zamboni/stats-all.js:15386 static/js/zamboni/stats-min.js:5
 msgid "Total Amount Contributed"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:106
+#: static/js/impala/stats/csv_keys.js:106 static/js/zamboni/stats-all.js:15387 static/js/zamboni/stats-min.js:5
 msgid "Average Contribution"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:115
+#: static/js/impala/stats/csv_keys.js:115 static/js/zamboni/stats-all.js:15396 static/js/zamboni/stats-min.js:5
 msgid "Usage"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:118
+#: static/js/impala/stats/csv_keys.js:118 static/js/zamboni/stats-all.js:15399 static/js/zamboni/stats-min.js:5
 msgid "Firefox"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:119
+#: static/js/impala/stats/csv_keys.js:119 static/js/zamboni/stats-all.js:15400 static/js/zamboni/stats-min.js:5
 msgid "Mozilla"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:120
+#: static/js/impala/stats/csv_keys.js:120 static/js/zamboni/stats-all.js:15401 static/js/zamboni/stats-min.js:5
 msgid "Thunderbird"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:121
+#: static/js/impala/stats/csv_keys.js:121 static/js/zamboni/stats-all.js:15402 static/js/zamboni/stats-min.js:5
 msgid "Sunbird"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:122
+#: static/js/impala/stats/csv_keys.js:122 static/js/zamboni/stats-all.js:15403 static/js/zamboni/stats-min.js:5
 msgid "SeaMonkey"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:123
+#: static/js/impala/stats/csv_keys.js:123 static/js/zamboni/stats-all.js:15404 static/js/zamboni/stats-min.js:5
 msgid "Fennec"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:124
+#: static/js/impala/stats/csv_keys.js:124 static/js/zamboni/stats-all.js:15405 static/js/zamboni/stats-min.js:5
 msgid "Android"
 msgstr ""
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:129
+#: static/js/impala/stats/csv_keys.js:129 static/js/zamboni/stats-all.js:15410 static/js/zamboni/stats-min.js:5
 msgid "Downloads and Daily Users, last {0} days"
 msgstr ""
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:131
+#: static/js/impala/stats/csv_keys.js:131 static/js/zamboni/stats-all.js:15412 static/js/zamboni/stats-min.js:5
 msgid "Downloads and Daily Users from {0} to {1}"
 msgstr ""
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:135
+#: static/js/impala/stats/csv_keys.js:135 static/js/zamboni/stats-all.js:15416 static/js/zamboni/stats-min.js:5
 msgid "Installs and Daily Users, last {0} days"
 msgstr ""
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:137
+#: static/js/impala/stats/csv_keys.js:137 static/js/zamboni/stats-all.js:15418 static/js/zamboni/stats-min.js:5
 msgid "Installs and Daily Users from {0} to {1}"
 msgstr ""
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:141
+#: static/js/impala/stats/csv_keys.js:141 static/js/zamboni/stats-all.js:15422 static/js/zamboni/stats-min.js:5
 msgid "Downloads, last {0} days"
 msgstr ""
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:143
+#: static/js/impala/stats/csv_keys.js:143 static/js/zamboni/stats-all.js:15424 static/js/zamboni/stats-min.js:5
 msgid "Downloads from {0} to {1}"
 msgstr ""
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:147
+#: static/js/impala/stats/csv_keys.js:147 static/js/zamboni/stats-all.js:15428 static/js/zamboni/stats-min.js:5
 msgid "Daily Users, last {0} days"
 msgstr ""
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:149
+#: static/js/impala/stats/csv_keys.js:149 static/js/zamboni/stats-all.js:15430 static/js/zamboni/stats-min.js:5
 msgid "Daily Users from {0} to {1}"
 msgstr ""
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:153
+#: static/js/impala/stats/csv_keys.js:153 static/js/zamboni/stats-all.js:15434 static/js/zamboni/stats-min.js:5
 msgid "Applications, last {0} days"
 msgstr ""
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:155
+#: static/js/impala/stats/csv_keys.js:155 static/js/zamboni/stats-all.js:15436 static/js/zamboni/stats-min.js:5
 msgid "Applications from {0} to {1}"
 msgstr ""
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:159
+#: static/js/impala/stats/csv_keys.js:159 static/js/zamboni/stats-all.js:15440 static/js/zamboni/stats-min.js:5
 msgid "Platforms, last {0} days"
 msgstr ""
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:161
+#: static/js/impala/stats/csv_keys.js:161 static/js/zamboni/stats-all.js:15442 static/js/zamboni/stats-min.js:5
 msgid "Platforms from {0} to {1}"
 msgstr ""
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:165
+#: static/js/impala/stats/csv_keys.js:165 static/js/zamboni/stats-all.js:15446 static/js/zamboni/stats-min.js:5
 msgid "Languages, last {0} days"
 msgstr ""
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:167
+#: static/js/impala/stats/csv_keys.js:167 static/js/zamboni/stats-all.js:15448 static/js/zamboni/stats-min.js:5
 msgid "Languages from {0} to {1}"
 msgstr ""
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:171
+#: static/js/impala/stats/csv_keys.js:171 static/js/zamboni/stats-all.js:15452 static/js/zamboni/stats-min.js:5
 msgid "Add-on Versions, last {0} days"
 msgstr ""
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:173
+#: static/js/impala/stats/csv_keys.js:173 static/js/zamboni/stats-all.js:15454 static/js/zamboni/stats-min.js:5
 msgid "Add-on Versions from {0} to {1}"
 msgstr ""
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:177
+#: static/js/impala/stats/csv_keys.js:177 static/js/zamboni/stats-all.js:15458 static/js/zamboni/stats-min.js:5
 msgid "Add-on Status, last {0} days"
 msgstr ""
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:179
+#: static/js/impala/stats/csv_keys.js:179 static/js/zamboni/stats-all.js:15460 static/js/zamboni/stats-min.js:5
 msgid "Add-on Status from {0} to {1}"
 msgstr ""
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:183
+#: static/js/impala/stats/csv_keys.js:183 static/js/zamboni/stats-all.js:15464 static/js/zamboni/stats-min.js:5
 msgid "Download Sources, last {0} days"
 msgstr ""
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:185
+#: static/js/impala/stats/csv_keys.js:185 static/js/zamboni/stats-all.js:15466 static/js/zamboni/stats-min.js:5
 msgid "Download Sources from {0} to {1}"
 msgstr ""
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:189
+#: static/js/impala/stats/csv_keys.js:189 static/js/zamboni/stats-all.js:15470 static/js/zamboni/stats-min.js:5
 msgid "Contributions, last {0} days"
 msgstr ""
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:191
+#: static/js/impala/stats/csv_keys.js:191 static/js/zamboni/stats-all.js:15472 static/js/zamboni/stats-min.js:5
 msgid "Contributions from {0} to {1}"
 msgstr ""
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:195
+#: static/js/impala/stats/csv_keys.js:195 static/js/zamboni/stats-all.js:15476 static/js/zamboni/stats-min.js:5
 msgid "Site Metrics, last {0} days"
 msgstr ""
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:197
+#: static/js/impala/stats/csv_keys.js:197 static/js/zamboni/stats-all.js:15478 static/js/zamboni/stats-min.js:5
 msgid "Site Metrics from {0} to {1}"
 msgstr ""
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:201
+#: static/js/impala/stats/csv_keys.js:201 static/js/zamboni/stats-all.js:15482 static/js/zamboni/stats-min.js:5
 msgid "Add-ons in Use, last {0} days"
 msgstr ""
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:203
+#: static/js/impala/stats/csv_keys.js:203 static/js/zamboni/stats-all.js:15484 static/js/zamboni/stats-min.js:5
 msgid "Add-ons in Use from {0} to {1}"
 msgstr ""
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:207
+#: static/js/impala/stats/csv_keys.js:207 static/js/zamboni/stats-all.js:15488 static/js/zamboni/stats-min.js:5
 msgid "Add-ons Downloaded, last {0} days"
 msgstr ""
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:209
+#: static/js/impala/stats/csv_keys.js:209 static/js/zamboni/stats-all.js:15490 static/js/zamboni/stats-min.js:5
 msgid "Add-ons Downloaded from {0} to {1}"
 msgstr ""
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:213
+#: static/js/impala/stats/csv_keys.js:213 static/js/zamboni/stats-all.js:15494 static/js/zamboni/stats-min.js:5
 msgid "Add-ons Created, last {0} days"
 msgstr ""
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:215
+#: static/js/impala/stats/csv_keys.js:215 static/js/zamboni/stats-all.js:15496 static/js/zamboni/stats-min.js:5
 msgid "Add-ons Created from {0} to {1}"
 msgstr ""
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:219
+#: static/js/impala/stats/csv_keys.js:219 static/js/zamboni/stats-all.js:15500 static/js/zamboni/stats-min.js:5
 msgid "Add-ons Updated, last {0} days"
 msgstr ""
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:221
+#: static/js/impala/stats/csv_keys.js:221 static/js/zamboni/stats-all.js:15502 static/js/zamboni/stats-min.js:5
 msgid "Add-ons Updated from {0} to {1}"
 msgstr ""
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:225
+#: static/js/impala/stats/csv_keys.js:225 static/js/zamboni/stats-all.js:15506 static/js/zamboni/stats-min.js:5
 msgid "Reviews Written, last {0} days"
 msgstr ""
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:227
+#: static/js/impala/stats/csv_keys.js:227 static/js/zamboni/stats-all.js:15508 static/js/zamboni/stats-min.js:5
 msgid "Reviews Written from {0} to {1}"
 msgstr ""
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:231
+#: static/js/impala/stats/csv_keys.js:231 static/js/zamboni/stats-all.js:15512 static/js/zamboni/stats-min.js:5
 msgid "User Signups, last {0} days"
 msgstr ""
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:233
+#: static/js/impala/stats/csv_keys.js:233 static/js/zamboni/stats-all.js:15514 static/js/zamboni/stats-min.js:5
 msgid "User Signups from {0} to {1}"
 msgstr ""
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:237
+#: static/js/impala/stats/csv_keys.js:237 static/js/zamboni/stats-all.js:15518 static/js/zamboni/stats-min.js:5
 msgid "Collections Created, last {0} days"
 msgstr ""
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:239
+#: static/js/impala/stats/csv_keys.js:239 static/js/zamboni/stats-all.js:15520 static/js/zamboni/stats-min.js:5
 msgid "Collections Created from {0} to {1}"
 msgstr ""
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:243
+#: static/js/impala/stats/csv_keys.js:243 static/js/zamboni/stats-all.js:15524 static/js/zamboni/stats-min.js:5
 msgid "Subscribers, last {0} days"
 msgstr ""
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:245
+#: static/js/impala/stats/csv_keys.js:245 static/js/zamboni/stats-all.js:15526 static/js/zamboni/stats-min.js:5
 msgid "Subscribers from {0} to {1}"
 msgstr ""
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:249
+#: static/js/impala/stats/csv_keys.js:249 static/js/zamboni/stats-all.js:15530 static/js/zamboni/stats-min.js:5
 msgid "Ratings, last {0} days"
 msgstr ""
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:251
+#: static/js/impala/stats/csv_keys.js:251 static/js/zamboni/stats-all.js:15532 static/js/zamboni/stats-min.js:5
 msgid "Ratings from {0} to {1}"
 msgstr ""
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:255
+#: static/js/impala/stats/csv_keys.js:255 static/js/zamboni/stats-all.js:15536 static/js/zamboni/stats-min.js:5
 msgid "Sales, last {0} days"
 msgstr ""
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:257
+#: static/js/impala/stats/csv_keys.js:257 static/js/zamboni/stats-all.js:15538 static/js/zamboni/stats-min.js:5
 msgid "Sales from {0} to {1}"
 msgstr ""
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:261
+#: static/js/impala/stats/csv_keys.js:261 static/js/zamboni/stats-all.js:15542 static/js/zamboni/stats-min.js:5
 msgid "Installs, last {0} days"
 msgstr ""
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:263
+#: static/js/impala/stats/csv_keys.js:263 static/js/zamboni/stats-all.js:15544 static/js/zamboni/stats-min.js:5
 msgid "Installs from {0} to {1}"
 msgstr ""
 
 #. L10n: {0} and {1} are integers.
-#: static/js/impala/stats/csv_keys.js:269
+#: static/js/impala/stats/csv_keys.js:269 static/js/zamboni/stats-all.js:15550 static/js/zamboni/stats-min.js:5
 msgid "<b>{0}</b> in last {1} days"
 msgstr ""
 
 #. L10n: {0} is an integer and {1} and {2} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:271 static/js/impala/stats/csv_keys.js:277
+#: static/js/impala/stats/csv_keys.js:271 static/js/impala/stats/csv_keys.js:277 static/js/zamboni/stats-all.js:15552 static/js/zamboni/stats-all.js:15558 static/js/zamboni/stats-min.js:5
 msgid "<b>{0}</b> from {1} to {2}"
 msgstr ""
 
 #. L10n: {0} and {1} are integers.
-#: static/js/impala/stats/csv_keys.js:275
+#: static/js/impala/stats/csv_keys.js:275 static/js/zamboni/stats-all.js:15556 static/js/zamboni/stats-min.js:5
 msgid "<b>{0}</b> average in last {1} days"
 msgstr ""
 
-#: static/js/impala/stats/overview.js:19
+#: static/js/impala/stats/overview.js:19 static/js/zamboni/stats-all.js:16469 static/js/zamboni/stats-min.js:5
 msgid "No data available."
 msgstr ""
 
-#: static/js/impala/stats/table.js:74
+#: static/js/impala/stats/table.js:74 static/js/zamboni/stats-all.js:17209 static/js/zamboni/stats-min.js:5
 msgid "Date"
 msgstr ""
 
-#: static/js/impala/stats/topchart.js:96
+#: static/js/impala/stats/topchart.js:96 static/js/zamboni/stats-all.js:16600 static/js/zamboni/stats-min.js:5
 msgid "Other"
 msgstr ""
 
-#: static/js/zamboni/admin_validation.js:24 static/js/zamboni/devhub.js:1229 static/js/zamboni/editors.js:295
+#: static/js/zamboni/admin-all.js:180 static/js/zamboni/admin-min.js:1 static/js/zamboni/admin_validation.js:24 static/js/zamboni/devhub-all.js:2408 static/js/zamboni/devhub-min.js:2
+#: static/js/zamboni/devhub.js:1229 static/js/zamboni/editors-all.js:15576 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:295
 msgid "Select an application first"
 msgstr ""
 
-#: static/js/zamboni/admin_validation.js:51
+#: static/js/zamboni/admin-all.js:207 static/js/zamboni/admin-min.js:1 static/js/zamboni/admin_validation.js:51
 msgid "Set {0} add-on to a max version of {1} and email the author."
 msgid_plural "Set {0} add-ons to a max version of {1} and email the authors."
 msgstr[0] ""
+msgstr[1] ""
 
-#: static/js/zamboni/admin_validation.js:54
+#: static/js/zamboni/admin-all.js:210 static/js/zamboni/admin-min.js:1 static/js/zamboni/admin_validation.js:54
 msgid "Email author of {2} add-on which failed validation."
 msgid_plural "Email authors of {2} add-ons which failed validation."
 msgstr[0] ""
+msgstr[1] ""
 
-#. L10n: {0} is an app name like Firefox.
-#: static/js/zamboni/buttons.js:66
-msgid "Accept and Install"
-msgstr ""
-
-#: static/js/zamboni/buttons.js:66
-msgid "Add to {0}"
-msgstr ""
-
-#: static/js/zamboni/buttons.js:71
-msgid "Download Now"
-msgstr ""
-
-#: static/js/zamboni/buttons.js:112
-msgid "Add-on has not been updated to support default-to-compatible."
-msgstr ""
-
-#: static/js/zamboni/buttons.js:117
-msgid "You need to be using Firefox 10.0 or higher."
-msgstr ""
-
-#: static/js/zamboni/buttons.js:129
-msgid "Mozilla has marked this version as incompatible with your Firefox version."
-msgstr ""
-
-#. L10n: {0} is an platform like Windows or Linux.
-#: static/js/zamboni/buttons.js:210
-msgid "Install for {0} anyway"
-msgstr ""
-
-#: static/js/zamboni/buttons.js:210
-msgid "Download for {0} anyway"
-msgstr ""
-
-#: static/js/zamboni/buttons.js:267
-msgid "Not available for your platform"
-msgstr ""
-
-#. L10n: {0} is an app name, {1} is the app version.
-#: static/js/zamboni/buttons.js:278 static/js/zamboni/buttons.js:315
-msgid "Not available for {0} {1}"
-msgstr ""
-
-#: static/js/zamboni/buttons.js:341
-msgid "Works with {app} {min} - {max}"
-msgstr ""
-
-#: static/js/zamboni/buttons.js:343
-msgid "View other versions"
-msgstr ""
-
-#: static/js/zamboni/buttons.js:391
-msgid "Only with Firefox — Get Firefox Now!"
-msgstr ""
-
-#: static/js/zamboni/buttons.js:507 static/js/zamboni/mobile/buttons.js:43
-msgid "Sorry, you need a Mozilla-based browser (such as Firefox) to install a search plugin."
-msgstr ""
-
-#: static/js/zamboni/collections.js:229
-msgid "Adding to Favorites&hellip;"
-msgstr ""
-
-#: static/js/zamboni/collections.js:232
-msgid "Removing Favorite&hellip;"
-msgstr ""
-
-#: static/js/zamboni/collections.js:235
-msgid "Add to Favorites"
-msgstr ""
-
-#: static/js/zamboni/collections.js:238
-msgid "Remove from Favorites"
-msgstr ""
-
-#: static/js/zamboni/collections.js:303
-msgid "Pending"
-msgstr ""
-
-#: static/js/zamboni/collections.js:304
-msgid "Add a comment"
-msgstr ""
-
-#: static/js/zamboni/collections.js:304
-msgid "Comment"
-msgstr ""
-
-#: static/js/zamboni/collections.js:305
-msgid "Remove this add-on from the collection"
-msgstr ""
-
-#: static/js/zamboni/collections.js:305 static/js/zamboni/collections.js:334
-msgid "Remove"
-msgstr ""
-
-#: static/js/zamboni/collections.js:334
-msgid "Remove this user as a contributor"
-msgstr ""
-
-#: static/js/zamboni/collections.js:346
-msgid "An email address is required."
-msgstr ""
-
-#: static/js/zamboni/collections.js:364
-msgid "You cannot add yourself as a contributor."
-msgstr ""
-
-#: static/js/zamboni/collections.js:366
-msgid "You have already added that user."
-msgstr ""
-
-#: static/js/zamboni/collections.js:573
-msgid "Add to favorites"
-msgstr ""
-
-#: static/js/zamboni/collections.js:577
-msgid "Remove from favorites"
-msgstr ""
-
-#: static/js/zamboni/collections.js:604
-msgid "Stop following"
-msgstr ""
-
-#: static/js/zamboni/devhub.js:110
+#: static/js/zamboni/devhub-all.js:1289 static/js/zamboni/devhub-min.js:1 static/js/zamboni/devhub.js:110
 msgid "Your browser does not support the video tag"
 msgstr ""
 
-#: static/js/zamboni/devhub.js:371
+#: static/js/zamboni/devhub-all.js:1550 static/js/zamboni/devhub-min.js:1 static/js/zamboni/devhub.js:371
 msgid "Changes Saved"
 msgstr ""
 
-#: static/js/zamboni/devhub.js:387
+#: static/js/zamboni/devhub-all.js:1566 static/js/zamboni/devhub-min.js:1 static/js/zamboni/devhub.js:387
 msgid "Enter a new author's email address"
 msgstr ""
 
-#: static/js/zamboni/devhub.js:536
+#: static/js/zamboni/devhub-all.js:1715 static/js/zamboni/devhub-min.js:1 static/js/zamboni/devhub.js:536
 msgid "There was an error uploading your file."
 msgstr ""
 
-#: static/js/zamboni/devhub.js:681
+#: static/js/zamboni/devhub-all.js:1860 static/js/zamboni/devhub-min.js:1 static/js/zamboni/devhub.js:681
 msgid "{files} file"
 msgid_plural "{files} files"
 msgstr[0] ""
+msgstr[1] ""
 
-#: static/js/zamboni/devhub.js:684
+#: static/js/zamboni/devhub-all.js:1863 static/js/zamboni/devhub-min.js:1 static/js/zamboni/devhub.js:684
 msgid "{reviews} user review"
 msgid_plural "{reviews} user reviews"
 msgstr[0] ""
+msgstr[1] ""
 
-#: static/js/zamboni/devhub.js:796
+#: static/js/zamboni/devhub-all.js:1975 static/js/zamboni/devhub-min.js:2 static/js/zamboni/devhub.js:796
 msgid "Learn more"
 msgstr ""
 
-#: static/js/zamboni/devhub.js:800
+#: static/js/zamboni/devhub-all.js:1979 static/js/zamboni/devhub-min.js:2 static/js/zamboni/devhub.js:800
 msgid "Example"
 msgstr ""
 
-#: static/js/zamboni/devhub.js:1130
+#: static/js/zamboni/devhub-all.js:2309 static/js/zamboni/devhub-min.js:2 static/js/zamboni/devhub.js:1130
 msgid "Image changes being processed"
 msgstr ""
 
-#: static/js/zamboni/devhub.js:1280
+#: static/js/zamboni/devhub-all.js:2459 static/js/zamboni/devhub-min.js:2 static/js/zamboni/devhub.js:1280
 msgid "Must be a valid e-mail address."
+msgstr ""
+
+#: static/js/zamboni/devhub-all.js:2613 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:80
+msgid "All tests passed successfully."
+msgstr ""
+
+#: static/js/zamboni/devhub-all.js:2616 static/js/zamboni/devhub-all.js:3011 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:83 static/js/zamboni/validator.js:478
+msgid "These tests were not run."
+msgstr ""
+
+#: static/js/zamboni/devhub-all.js:2664 static/js/zamboni/devhub-all.js:2677 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:131 static/js/zamboni/validator.js:144
+msgid "Tests"
+msgstr ""
+
+#: static/js/zamboni/devhub-all.js:2779 static/js/zamboni/devhub-all.js:3108 static/js/zamboni/devhub-all.js:3127 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:246
+#: static/js/zamboni/validator.js:575 static/js/zamboni/validator.js:594
+msgid "Error"
+msgstr ""
+
+#: static/js/zamboni/devhub-all.js:2780 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:247
+msgid "Warning"
+msgstr ""
+
+#: static/js/zamboni/devhub-all.js:2794 static/js/zamboni/devhub-min.js:2 static/js/zamboni/files-all.js:5657 static/js/zamboni/files-min.js:3 static/js/zamboni/files.js:411
+#: static/js/zamboni/validator.js:261
+msgid "Ignore this message in future updates"
+msgstr ""
+
+#: static/js/zamboni/devhub-all.js:2817 static/js/zamboni/devhub-min.js:2 static/js/zamboni/files-all.js:5663 static/js/zamboni/files-min.js:3 static/js/zamboni/files.js:417
+#: static/js/zamboni/validator.js:284
+msgid "Severity for automated signing:"
+msgstr ""
+
+#: static/js/zamboni/devhub-all.js:2832 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:299
+msgid "Suggestions for passing automated signing:"
+msgstr ""
+
+#: static/js/zamboni/devhub-all.js:2920 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:387
+msgid "Compatibility Tests"
+msgstr ""
+
+#: static/js/zamboni/devhub-all.js:2999 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:466
+msgid "Add-on failed validation."
+msgstr ""
+
+#: static/js/zamboni/devhub-all.js:3001 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:468
+msgid "Add-on passed validation."
+msgstr ""
+
+#: static/js/zamboni/devhub-all.js:3014 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:481
+msgid "{0} error"
+msgid_plural "{0} errors"
+msgstr[0] ""
+msgstr[1] ""
+
+#: static/js/zamboni/devhub-all.js:3016 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:483
+msgid "{0} warning"
+msgid_plural "{0} warnings"
+msgstr[0] ""
+msgstr[1] ""
+
+#: static/js/zamboni/devhub-all.js:3018 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:485
+msgid "{0} notice"
+msgid_plural "{0} notices"
+msgstr[0] ""
+msgstr[1] ""
+
+#: static/js/zamboni/devhub-all.js:3110 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:577
+msgid "Validation task could not complete or completed with errors"
+msgstr ""
+
+#: static/js/zamboni/devhub-all.js:3128 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:595
+msgid "Internal server error"
 msgstr ""
 
 #: static/js/zamboni/devhub_search.js:8
 msgid "No results found."
 msgstr ""
 
-#: static/js/zamboni/editors.js:121
+#: static/js/zamboni/editors-all.js:15402 static/js/zamboni/editors-min.js:4 static/js/zamboni/editors.js:121
 msgid "{name} was viewing this page first."
 msgstr ""
 
-#: static/js/zamboni/editors.js:171
+#: static/js/zamboni/editors-all.js:15452 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:171
 msgid "Receipt checked by app."
 msgstr ""
 
-#: static/js/zamboni/editors.js:173
+#: static/js/zamboni/editors-all.js:15454 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:173
 msgid "Receipt was not checked by app."
 msgstr ""
 
-#: static/js/zamboni/editors.js:244
+#: static/js/zamboni/editors-all.js:15525 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:244
 msgid "{name} was viewing this add-on first."
 msgstr ""
 
-#: static/js/zamboni/editors.js:255
+#: static/js/zamboni/editors-all.js:15536 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:255
 msgid "Loading&hellip;"
 msgstr ""
 
-#: static/js/zamboni/editors.js:260
+#: static/js/zamboni/editors-all.js:15541 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:260
 msgid "Version Notes"
 msgstr ""
 
-#: static/js/zamboni/editors.js:265
+#: static/js/zamboni/editors-all.js:15546 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:265
 msgid "Notes for Reviewers"
 msgstr ""
 
-#: static/js/zamboni/editors.js:270
+#: static/js/zamboni/editors-all.js:15551 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:270
 msgid "No version notes found"
 msgstr ""
 
-#: static/js/zamboni/editors.js:330
+#: static/js/zamboni/editors-all.js:15611 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:330
 msgid "Average Reviews"
 msgstr ""
 
-#: static/js/zamboni/editors.js:386
+#: static/js/zamboni/editors-all.js:15667 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:386
 msgid "Number of Reviews"
 msgstr ""
 
-#: static/js/zamboni/editors.js:445
+#: static/js/zamboni/editors-all.js:15726 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:445
 msgid "Error loading translation"
 msgstr ""
 
-#: static/js/zamboni/files.js:411 static/js/zamboni/validator.js:261
-msgid "Ignore this message in future updates"
-msgstr ""
-
-#: static/js/zamboni/files.js:417 static/js/zamboni/validator.js:284
-msgid "Severity for automated signing:"
-msgstr ""
-
-#: static/js/zamboni/global.js:410
-msgid "Loading..."
-msgstr ""
-
-#. L10n: {0} is the number of characters left.
-#: static/js/zamboni/global.js:474
-msgid "<b>{0}</b> character left."
-msgid_plural "<b>{0}</b> characters left."
-msgstr[0] ""
-
-#: static/js/zamboni/init.js:28
-msgid "This feature is temporarily disabled while we perform website maintenance. Please check back a little later."
-msgstr ""
-
-#: static/js/zamboni/l10n.js:45
-msgid "Remove this localization"
-msgstr ""
-
-#: static/js/zamboni/password-strength.js:20
-msgid "Password strength:"
-msgstr ""
-
-#: static/js/zamboni/password-strength.js:26
-msgid "At least {0} character left."
-msgid_plural "At least {0} characters left."
-msgstr[0] ""
-
-#: static/js/zamboni/themes_review.js:176
-msgid "Requested Info"
-msgstr ""
-
-#: static/js/zamboni/themes_review.js:177
-msgid "Flagged"
-msgstr ""
-
-#: static/js/zamboni/themes_review.js:178
-msgid "Duplicate"
-msgstr ""
-
-#: static/js/zamboni/themes_review.js:179
-msgid "Rejected"
-msgstr ""
-
-#: static/js/zamboni/themes_review.js:180
-msgid "Approved"
-msgstr ""
-
-#: static/js/zamboni/themes_review.js:424
-msgid "No results found"
-msgstr ""
-
-#: static/js/zamboni/themes_review_templates.js:31
+#: static/js/zamboni/editors-all.js:15975 static/js/zamboni/editors-min.js:5 static/js/zamboni/themes_review_templates.js:31
 msgid "Theme"
 msgstr ""
 
-#: static/js/zamboni/themes_review_templates.js:33
+#: static/js/zamboni/editors-all.js:15977 static/js/zamboni/editors-min.js:5 static/js/zamboni/themes_review_templates.js:33
 msgid "Reviewer"
 msgstr ""
 
-#: static/js/zamboni/themes_review_templates.js:35
+#: static/js/zamboni/editors-all.js:15979 static/js/zamboni/editors-min.js:5 static/js/zamboni/themes_review_templates.js:35
 msgid "Status"
 msgstr ""
 
-#: static/js/zamboni/validator.js:80
-msgid "All tests passed successfully."
+#: static/js/zamboni/editors-all.js:16196 static/js/zamboni/editors-min.js:5 static/js/zamboni/themes_review.js:176
+msgid "Requested Info"
 msgstr ""
 
-#: static/js/zamboni/validator.js:83 static/js/zamboni/validator.js:478
-msgid "These tests were not run."
+#: static/js/zamboni/editors-all.js:16197 static/js/zamboni/editors-min.js:5 static/js/zamboni/themes_review.js:177
+msgid "Flagged"
 msgstr ""
 
-#: static/js/zamboni/validator.js:131 static/js/zamboni/validator.js:144
-msgid "Tests"
+#: static/js/zamboni/editors-all.js:16198 static/js/zamboni/editors-min.js:5 static/js/zamboni/themes_review.js:178
+msgid "Duplicate"
 msgstr ""
 
-#: static/js/zamboni/validator.js:246 static/js/zamboni/validator.js:575 static/js/zamboni/validator.js:594
-msgid "Error"
+#: static/js/zamboni/editors-all.js:16199 static/js/zamboni/editors-min.js:5 static/js/zamboni/themes_review.js:179
+msgid "Rejected"
 msgstr ""
 
-#: static/js/zamboni/validator.js:247
-msgid "Warning"
+#: static/js/zamboni/editors-all.js:16200 static/js/zamboni/editors-min.js:5 static/js/zamboni/themes_review.js:180
+msgid "Approved"
 msgstr ""
 
-#: static/js/zamboni/validator.js:299
-msgid "Suggestions for passing automated signing:"
+#: static/js/zamboni/editors-all.js:16444 static/js/zamboni/editors-min.js:5 static/js/zamboni/themes_review.js:424
+msgid "No results found"
 msgstr ""
 
-#: static/js/zamboni/validator.js:387
-msgid "Compatibility Tests"
-msgstr ""
-
-#: static/js/zamboni/validator.js:466
-msgid "Add-on failed validation."
-msgstr ""
-
-#: static/js/zamboni/validator.js:468
-msgid "Add-on passed validation."
-msgstr ""
-
-#: static/js/zamboni/validator.js:481
-msgid "{0} error"
-msgid_plural "{0} errors"
-msgstr[0] ""
-
-#: static/js/zamboni/validator.js:483
-msgid "{0} warning"
-msgid_plural "{0} warnings"
-msgstr[0] ""
-
-#: static/js/zamboni/validator.js:485
-msgid "{0} notice"
-msgid_plural "{0} notices"
-msgstr[0] ""
-
-#: static/js/zamboni/validator.js:577
-msgid "Validation task could not complete or completed with errors"
-msgstr ""
-
-#: static/js/zamboni/validator.js:595
-msgid "Internal server error"
-msgstr ""
-
-#: static/js/zamboni/mobile/buttons.js:52
+#: static/js/zamboni/mobile-all.js:15186 static/js/zamboni/mobile/buttons.js:52
 msgid "Not Updated for {0} {1}"
 msgstr ""
 
-#: static/js/zamboni/mobile/buttons.js:53
+#: static/js/zamboni/mobile-all.js:15187 static/js/zamboni/mobile/buttons.js:53
 msgid "Requires Newer Version of {0}"
 msgstr ""
 
-#: static/js/zamboni/mobile/buttons.js:54
+#: static/js/zamboni/mobile-all.js:15188 static/js/zamboni/mobile/buttons.js:54
 msgid "Unreviewed"
 msgstr ""
 
-#: static/js/zamboni/mobile/buttons.js:55
+#: static/js/zamboni/mobile-all.js:15189 static/js/zamboni/mobile/buttons.js:55
 msgid "Experimental <span>(Learn More)</span>"
 msgstr ""
 
-#: static/js/zamboni/mobile/buttons.js:56 static/js/zamboni/mobile/buttons.js:57
+#: static/js/zamboni/mobile-all.js:15190 static/js/zamboni/mobile-all.js:15191 static/js/zamboni/mobile/buttons.js:56 static/js/zamboni/mobile/buttons.js:57
 msgid "Not Available for {0}"
 msgstr ""
 
-#: static/js/zamboni/mobile/buttons.js:58
+#: static/js/zamboni/mobile-all.js:15192 static/js/zamboni/mobile/buttons.js:58
 msgid "Experimental"
 msgstr ""
 
-#: static/js/zamboni/mobile/buttons.js:59
+#: static/js/zamboni/mobile-all.js:15193 static/js/zamboni/mobile/buttons.js:59
 msgid "Themes Require Newer Version of {0}"
 msgstr ""
 
-#: static/js/zamboni/mobile/buttons.js:60
+#: static/js/zamboni/mobile-all.js:15194 static/js/zamboni/mobile/buttons.js:60
 msgid "Themes Require {0}"
 msgstr ""
 
-#: static/js/zamboni/mobile/buttons.js:105
+#: static/js/zamboni/mobile-all.js:15239 static/js/zamboni/mobile/buttons.js:105
 msgid "Installing..."
 msgstr ""
 
-#: static/js/zamboni/mobile/buttons.js:125
+#: static/js/zamboni/mobile-all.js:15259 static/js/zamboni/mobile/buttons.js:125
 msgid "This add-on has been preliminarily reviewed by Mozilla."
 msgstr ""
 
-#: static/js/zamboni/mobile/buttons.js:250
+#: static/js/zamboni/mobile-all.js:15384 static/js/zamboni/mobile/buttons.js:250
 msgid "Keep it"
 msgstr ""
 
-#: static/js/zamboni/mobile/general.js:344
+#: static/js/zamboni/mobile-all.js:16049 static/js/zamboni/mobile-min.js:6 static/js/zamboni/mobile/general.js:344
 msgid "You're trying it on!"
 msgstr ""
 
-#: static/js/zamboni/mobile/general.js:356
+#: static/js/zamboni/mobile-all.js:16061 static/js/zamboni/mobile-min.js:6 static/js/zamboni/mobile/general.js:356
 msgid "Added to Firefox"
 msgstr ""
-

--- a/locale/nb_NO/LC_MESSAGES/django.po
+++ b/locale/nb_NO/LC_MESSAGES/django.po
@@ -2,69 +2,70 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2016-02-24 21:23+0000\n"
+"POT-Creation-Date: 2016-04-18 15:47+0000\n"
 "PO-Revision-Date: 2015-01-24 23:49+0000\n"
 "Last-Translator: Håvar <havar@firefox.no>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
+"Language: \n"
 "MIME-Version: 1.0\n"
-"Content-Type: text/plain; charset=utf-8\n"
+"Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Generated-By: Babel 2.2.0\n"
 
-#: src/olympia/accounts/views.py:52
+#: src/olympia/accounts/views.py:54
 msgid "Your log in attempt could not be parsed. Please try again."
 msgstr ""
 
-#: src/olympia/accounts/views.py:54
+#: src/olympia/accounts/views.py:56
 msgid "Your Firefox Account could not be found. Please try again."
 msgstr ""
 
-#: src/olympia/accounts/views.py:55
+#: src/olympia/accounts/views.py:57
 msgid "You could not be logged in. Please try again."
 msgstr ""
 
-#: src/olympia/accounts/views.py:57
+#: src/olympia/accounts/views.py:59
 msgid "Your account has already been migrated to Firefox Accounts."
 msgstr ""
 
-#: src/olympia/accounts/views.py:59
+#: src/olympia/accounts/views.py:61
 msgid "Your Firefox Account already exists on this site."
 msgstr ""
 
-#: src/olympia/accounts/views.py:108
+#: src/olympia/accounts/views.py:110
 msgid "Great job!"
 msgstr ""
 
-#: src/olympia/accounts/views.py:109
+#: src/olympia/accounts/views.py:111
 msgid "You can now log in to Add-ons with your Firefox Account."
 msgstr ""
 
-#: src/olympia/accounts/views.py:121
+#: src/olympia/accounts/views.py:123
 msgid "Need help?"
 msgstr ""
 
-#: src/olympia/addons/buttons.py:180
+#: src/olympia/addons/buttons.py:177
 msgid "Download Now"
 msgstr "Last ned nå"
 
-#: src/olympia/addons/buttons.py:182
+#: src/olympia/addons/buttons.py:179
 msgid "Download"
 msgstr "Last ned"
 
 #. L10n: please keep &nbsp; in the string so &rarr; does not wrap.
-#: src/olympia/addons/buttons.py:186
+#: src/olympia/addons/buttons.py:183
 msgid "Continue to Download&nbsp;&rarr;"
 msgstr "Fortsett til nedlasting&nbsp;&rarr;"
 
-#: src/olympia/addons/buttons.py:202 src/olympia/addons/helpers.py:35 src/olympia/addons/views.py:319 src/olympia/addons/templates/addons/impala/details.html:114
+#: src/olympia/addons/buttons.py:199 src/olympia/addons/helpers.py:35 src/olympia/addons/views.py:333 src/olympia/addons/templates/addons/impala/details.html:111
 #: src/olympia/addons/templates/addons/impala/listing/items.html:17 src/olympia/addons/templates/addons/mobile/home.html:40 src/olympia/amo/templates/amo/side_nav.html:6
-#: src/olympia/amo/templates/amo/side_nav.html:10 src/olympia/amo/templates/amo/site_nav.html:2 src/olympia/amo/templates/amo/site_nav.html:55 src/olympia/bandwagon/views.py:95
-#: src/olympia/browse/views.py:54 src/olympia/browse/views.py:68 src/olympia/browse/views.py:235 src/olympia/browse/templates/browse/impala/category_landing.html:22
+#: src/olympia/amo/templates/amo/side_nav.html:10 src/olympia/amo/templates/amo/site_nav.html:2 src/olympia/amo/templates/amo/site_nav.html:53 src/olympia/bandwagon/views.py:95
+#: src/olympia/browse/views.py:54 src/olympia/browse/views.py:68 src/olympia/browse/views.py:202 src/olympia/browse/templates/browse/impala/category_landing.html:22
 #: src/olympia/browse/templates/browse/personas/mobile/category_landing.html:26
 msgid "Featured"
 msgstr "Fremhevet"
 
-#: src/olympia/addons/buttons.py:221
+#: src/olympia/addons/buttons.py:218
 msgid "Add to {0}"
 msgstr "Legg til i {0}"
 
@@ -112,39 +113,39 @@ msgid_plural "All tags must be at least {0} characters."
 msgstr[0] "Alle tagger må være minst {0} tegn."
 msgstr[1] "Alle tagger må være minst {0} tegn."
 
-#: src/olympia/addons/forms.py:234
+#: src/olympia/addons/forms.py:238
 msgid "Categories cannot be changed while your add-on is featured for this application."
 msgstr "Kategorier kan ikke endres mens utvidelsen er fremhevet for denne applikasjonen."
 
 #. L10n: {0} is the number of categories.
-#: src/olympia/addons/forms.py:238
+#: src/olympia/addons/forms.py:242
 msgid "You can have only {0} category."
 msgid_plural "You can have only {0} categories."
 msgstr[0] "Du kan bare ha {0} kategori."
 msgstr[1] "Du kan bare ha {0} kategorier."
 
-#: src/olympia/addons/forms.py:246
+#: src/olympia/addons/forms.py:250
 msgid "The miscellaneous category cannot be combined with additional categories."
 msgstr "Diverse-kategorien kan ikke kombineres med andre kategorier."
 
-#: src/olympia/addons/forms.py:369
+#: src/olympia/addons/forms.py:374
 #, python-format
 msgid "Before changing your default locale you must have a name, summary, and description in that locale. You are missing %s."
 msgstr "Bør du endrer standard språk må du oppgi et navn, oppsummering og beskrivelse på det språket. Du mangler %s."
 
-#: src/olympia/addons/forms.py:484 src/olympia/addons/forms.py:575
+#: src/olympia/addons/forms.py:455 src/olympia/addons/forms.py:546
 msgid "A license must be selected."
 msgstr "En lisens må velges."
 
-#: src/olympia/addons/forms.py:556
+#: src/olympia/addons/forms.py:527
 msgid "Give Your Theme a Name."
 msgstr "Gi temaet et navn."
 
-#: src/olympia/addons/forms.py:562 src/olympia/devhub/templates/devhub/personas/submit.html:53
+#: src/olympia/addons/forms.py:533 src/olympia/devhub/templates/devhub/personas/submit.html:53
 msgid "Describe your Theme."
 msgstr "Beskriv temaet."
 
-#: src/olympia/addons/forms.py:704
+#: src/olympia/addons/forms.py:675
 msgid "Enter a new author's email address"
 msgstr "Skriv inn forfatterens e-postadresse"
 
@@ -152,37 +153,37 @@ msgstr "Skriv inn forfatterens e-postadresse"
 msgid "Not Reviewed"
 msgstr "Ingen anmeldelser"
 
-#: src/olympia/addons/models.py:301
+#: src/olympia/addons/models.py:298
 msgid "Users have the option of contributing more or less than this amount."
 msgstr "Brukere har valget om å bidra mer eller mindre enn dette beløpet."
 
-#: src/olympia/addons/models.py:309
-msgid "Users will always be asked in the Add-ons Manager (Firefox 4 and above)"
-msgstr "Brukere vil alltid spørres i Utvidelsesbehandling (Firefox 4 og nyere)"
+#: src/olympia/addons/models.py:306
+msgid "Users will always be asked in the Add-ons Manager (Firefox 4 and above). Only applies to desktop."
+msgstr ""
 
-#: src/olympia/addons/models.py:1804 src/olympia/addons/templates/addons/details_box.html:55 src/olympia/devhub/templates/devhub/index.html:92
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:102
+#: src/olympia/addons/models.py:1802 src/olympia/addons/templates/addons/details_box.html:55 src/olympia/devhub/templates/devhub/index.html:92
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:89
 msgid "Listed"
 msgstr "Listet"
 
-#: src/olympia/addons/views.py:320 src/olympia/browse/templates/browse/personas/mobile/category_landing.html:27
+#: src/olympia/addons/views.py:334 src/olympia/browse/templates/browse/personas/mobile/category_landing.html:27
 msgid "Popular"
 msgstr "Populær"
 
-#: src/olympia/addons/views.py:321 src/olympia/browse/views.py:238 src/olympia/browse/views.py:280 src/olympia/browse/views.py:482
+#: src/olympia/addons/views.py:335 src/olympia/browse/views.py:205 src/olympia/browse/views.py:247 src/olympia/browse/views.py:449
 msgid "Recently Added"
 msgstr "Nylig lagt til"
 
-#: src/olympia/addons/views.py:322 src/olympia/bandwagon/views.py:99 src/olympia/browse/views.py:60 src/olympia/browse/views.py:71 src/olympia/search/forms.py:16 src/olympia/search/forms.py:91
+#: src/olympia/addons/views.py:336 src/olympia/bandwagon/views.py:99 src/olympia/browse/views.py:60 src/olympia/browse/views.py:71 src/olympia/search/forms.py:16 src/olympia/search/forms.py:91
 msgid "Recently Updated"
 msgstr "Nylig oppdatert"
 
 #. l10n: {0} is the addon name
-#: src/olympia/addons/views.py:520
+#: src/olympia/addons/views.py:534
 msgid "Contribution for {0}"
 msgstr "Bidrag til {0}"
 
-#: src/olympia/addons/views.py:613
+#: src/olympia/addons/views.py:627
 msgid "Abuse reported."
 msgstr "Misbruk rapportert."
 
@@ -249,9 +250,9 @@ msgstr "Bidra"
 #: src/olympia/devhub/templates/devhub/addons/ajax_compat_update.html:36 src/olympia/devhub/templates/devhub/addons/profile.html:44 src/olympia/devhub/templates/devhub/addons/edit/admin.html:101
 #: src/olympia/devhub/templates/devhub/addons/edit/basic.html:152 src/olympia/devhub/templates/devhub/addons/edit/details.html:85 src/olympia/devhub/templates/devhub/addons/edit/support.html:67
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:166 src/olympia/devhub/templates/devhub/addons/forms_shared/media.html:149
-#: src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:44 src/olympia/devhub/templates/devhub/versions/add_file_modal.html:78 src/olympia/devhub/templates/devhub/versions/edit.html:139
-#: src/olympia/devhub/templates/devhub/versions/list.html:242 src/olympia/devhub/templates/devhub/versions/list.html:276 src/olympia/devhub/templates/devhub/versions/list.html:317
-#: src/olympia/devhub/templates/devhub/versions/list.html:351 src/olympia/reviews/templates/reviews/edit_review.html:16 src/olympia/translations/templates/translations/trans-menu.html:50
+#: src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:43 src/olympia/devhub/templates/devhub/versions/add_file_modal.html:58 src/olympia/devhub/templates/devhub/versions/edit.html:139
+#: src/olympia/devhub/templates/devhub/versions/list.html:239 src/olympia/devhub/templates/devhub/versions/list.html:281 src/olympia/devhub/templates/devhub/versions/list.html:315
+#: src/olympia/devhub/templates/devhub/versions/list.html:349 src/olympia/reviews/templates/reviews/edit_review.html:16 src/olympia/translations/templates/translations/trans-menu.html:50
 #: src/olympia/translations/templates/translations/trans-menu.html:62
 msgid "or"
 msgstr "eller"
@@ -362,7 +363,7 @@ msgid "Add-on Information for {0}"
 msgstr "Utvidelsesinformasjon for {0}"
 
 #: src/olympia/addons/templates/addons/details_box.html:30 src/olympia/addons/templates/addons/persona_detail_table.html:3 src/olympia/addons/templates/addons/mobile/details.html:63
-#: src/olympia/addons/templates/addons/mobile/persona_detail_table.html:7 src/olympia/browse/views.py:459 src/olympia/devhub/views.py:75
+#: src/olympia/addons/templates/addons/mobile/persona_detail_table.html:7 src/olympia/browse/views.py:426 src/olympia/devhub/views.py:73
 msgid "Updated"
 msgstr "Oppdatert"
 
@@ -381,11 +382,11 @@ msgstr "Virker med"
 msgid "Visibility"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/details_box.html:57 src/olympia/devhub/templates/devhub/index.html:94 src/olympia/devhub/templates/devhub/includes/addon_details.html:104
+#: src/olympia/addons/templates/addons/details_box.html:57 src/olympia/devhub/templates/devhub/index.html:94 src/olympia/devhub/templates/devhub/includes/addon_details.html:91
 msgid "Hidden"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/details_box.html:59 src/olympia/devhub/templates/devhub/index.html:96 src/olympia/devhub/templates/devhub/includes/addon_details.html:106
+#: src/olympia/addons/templates/addons/details_box.html:59 src/olympia/devhub/templates/devhub/index.html:96 src/olympia/devhub/templates/devhub/includes/addon_details.html:93
 msgid "Unlisted"
 msgstr ""
 
@@ -393,13 +394,13 @@ msgstr ""
 msgid "Required Add-ons"
 msgstr "Påkrevde utvidelser"
 
-#: src/olympia/addons/templates/addons/details_box.html:81 src/olympia/addons/templates/addons/persona_detail_table.html:15 src/olympia/browse/views.py:462 src/olympia/devhub/views.py:78
-#: src/olympia/devhub/views.py:85 src/olympia/discovery/templates/discovery/addons/detail.html:57 src/olympia/reviews/forms.py:62 src/olympia/reviews/templates/reviews/add.html:57
+#: src/olympia/addons/templates/addons/details_box.html:81 src/olympia/addons/templates/addons/persona_detail_table.html:15 src/olympia/browse/views.py:429 src/olympia/devhub/views.py:76
+#: src/olympia/devhub/views.py:83 src/olympia/discovery/templates/discovery/addons/detail.html:57 src/olympia/reviews/forms.py:62 src/olympia/reviews/templates/reviews/add.html:57
 #: src/olympia/reviews/templates/reviews/mobile/review_list.html:18
 msgid "Rating"
 msgstr "Rangering"
 
-#: src/olympia/addons/templates/addons/details_box.html:85 src/olympia/browse/views.py:461 src/olympia/devhub/views.py:77 src/olympia/devhub/views.py:84
+#: src/olympia/addons/templates/addons/details_box.html:85 src/olympia/browse/views.py:428 src/olympia/devhub/views.py:75 src/olympia/devhub/views.py:82
 #: src/olympia/stats/templates/stats/addon_report_menu.html:8 src/olympia/stats/templates/stats/collection_report_menu.html:18
 msgid "Downloads"
 msgstr "Nedlastinger"
@@ -419,7 +420,7 @@ msgstr "Misbruksrapporter"
 
 #. The Privacy Policy for this add-on.
 #: src/olympia/addons/templates/addons/details_box.html:121 src/olympia/addons/templates/addons/privacy.html:19 src/olympia/addons/templates/addons/privacy.html:23
-#: src/olympia/addons/templates/addons/impala/button.html:43 src/olympia/addons/templates/addons/impala/details.html:307 src/olympia/devhub/templates/devhub/includes/policy_form.html:20
+#: src/olympia/addons/templates/addons/impala/button.html:43 src/olympia/addons/templates/addons/impala/details.html:312 src/olympia/devhub/templates/devhub/includes/policy_form.html:23
 #: src/olympia/templates/mobile/base_addons.html:87
 msgid "Privacy Policy"
 msgstr "Personvernbestemmelser"
@@ -444,7 +445,7 @@ msgstr "Bildegalleri"
 msgid "Developer Comments"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/details_box.html:199 src/olympia/addons/templates/addons/impala/details.html:259
+#: src/olympia/addons/templates/addons/details_box.html:199 src/olympia/addons/templates/addons/impala/details.html:264
 msgid "Development Channel"
 msgstr "Utviklingskanal"
 
@@ -468,13 +469,13 @@ msgstr ""
 "<strong>Advarsel:</strong> Utviklingsversjoner av denne utvidelsen er ikke gjennomgått av Mozilla. Så snart du installerer en utviklingsversjon vil du fortsette å motta oppdateringer fra denne "
 "utvikleren. For å slutte motta utviklingsoppdateringer, reinstaller standardversjonen fra lenken ovenfor."
 
-#: src/olympia/addons/templates/addons/details_box.html:220 src/olympia/addons/templates/addons/impala/details.html:278
+#: src/olympia/addons/templates/addons/details_box.html:220 src/olympia/addons/templates/addons/impala/details.html:283
 msgid "Version {0}:"
 msgstr "Versjon {0}:"
 
 #: src/olympia/addons/templates/addons/details_box.html:234
-msgid "Nothing to see here! The developer did not include any details."
-msgstr "Ingenting å se her! Utvikleren tok ikke med noen detaljer."
+msgid "Nothing to see here!  The developer did not include any details."
+msgstr ""
 
 #: src/olympia/addons/templates/addons/details_box.html:251 src/olympia/devhub/templates/devhub/versions/edit.html:73 src/olympia/editors/templates/editors/review.html:98
 msgid "Version Notes"
@@ -487,7 +488,7 @@ msgid "End-User License Agreement for {0}"
 msgstr "Sluttbrukerlisens for {0}"
 
 #: src/olympia/addons/templates/addons/eula.html:17 src/olympia/addons/templates/addons/eula.html:21 src/olympia/addons/templates/addons/impala/button.html:48
-#: src/olympia/addons/templates/addons/impala/details.html:316 src/olympia/devhub/templates/devhub/includes/policy_form.html:3 src/olympia/discovery/templates/discovery/addons/eula.html:11
+#: src/olympia/addons/templates/addons/impala/details.html:321 src/olympia/devhub/templates/devhub/includes/policy_form.html:3 src/olympia/discovery/templates/discovery/addons/eula.html:11
 msgid "End-User License Agreement"
 msgstr "Sluttbrukerlisens"
 
@@ -504,7 +505,7 @@ msgstr "Tilbake til {0} ..."
 msgid "Add-ons for {0}"
 msgstr "Utvidelser for {0}"
 
-#: src/olympia/addons/templates/addons/home.html:10 src/olympia/addons/templates/addons/home.html:51 src/olympia/browse/templates/browse/impala/base_listing.html:11
+#: src/olympia/addons/templates/addons/home.html:10 src/olympia/addons/templates/addons/home.html:53 src/olympia/browse/templates/browse/impala/base_listing.html:11
 msgid "Featured Extensions"
 msgstr "Fremhevede utvidelser"
 
@@ -512,29 +513,29 @@ msgstr "Fremhevede utvidelser"
 msgid "Popular Extensions"
 msgstr "Populære utvidelser"
 
-#: src/olympia/addons/templates/addons/home.html:42 src/olympia/amo/templates/amo/side_nav.html:3 src/olympia/amo/templates/amo/side_nav.html:11 src/olympia/amo/templates/amo/site_nav.html:3
-#: src/olympia/amo/templates/amo/site_nav.html:25 src/olympia/browse/views.py:236 src/olympia/browse/views.py:281 src/olympia/browse/views.py:481
+#: src/olympia/addons/templates/addons/home.html:44 src/olympia/amo/templates/amo/side_nav.html:3 src/olympia/amo/templates/amo/side_nav.html:11 src/olympia/amo/templates/amo/site_nav.html:3
+#: src/olympia/amo/templates/amo/site_nav.html:25 src/olympia/browse/views.py:203 src/olympia/browse/views.py:248 src/olympia/browse/views.py:448
 msgid "Most Popular"
 msgstr "Mest populære"
 
-#: src/olympia/addons/templates/addons/home.html:43
+#: src/olympia/addons/templates/addons/home.html:45
 msgid "All »"
 msgstr "Alle »"
 
-#: src/olympia/addons/templates/addons/home.html:52 src/olympia/addons/templates/addons/home.html:61 src/olympia/addons/templates/addons/home.html:70 src/olympia/addons/templates/addons/home.html:78
+#: src/olympia/addons/templates/addons/home.html:54 src/olympia/addons/templates/addons/home.html:63 src/olympia/addons/templates/addons/home.html:72 src/olympia/addons/templates/addons/home.html:80
 #: src/olympia/browse/templates/browse/impala/category_landing.html:36
 msgid "See all »"
 msgstr "Se alle »"
 
-#: src/olympia/addons/templates/addons/home.html:60
+#: src/olympia/addons/templates/addons/home.html:62
 msgid "Up &amp; Coming Extensions"
 msgstr "Fremgangsrike utvidelser"
 
-#: src/olympia/addons/templates/addons/home.html:69 src/olympia/browse/templates/browse/personas/category_landing.html:61 src/olympia/discovery/templates/discovery/pane.html:74
+#: src/olympia/addons/templates/addons/home.html:71 src/olympia/browse/templates/browse/personas/category_landing.html:61 src/olympia/discovery/templates/discovery/pane.html:74
 msgid "Featured Themes"
 msgstr "Fremhevede temaer"
 
-#: src/olympia/addons/templates/addons/home.html:77 src/olympia/bandwagon/templates/bandwagon/impala/collection_listing.html:5
+#: src/olympia/addons/templates/addons/home.html:79 src/olympia/bandwagon/templates/bandwagon/impala/collection_listing.html:5
 msgid "Featured Collections"
 msgstr "Fremhevede samlinger"
 
@@ -552,7 +553,7 @@ msgid "Updated {0}"
 msgstr "Oppdatert {0}"
 
 #. {0} is a date.
-#: src/olympia/addons/templates/addons/macros.html:10 src/olympia/addons/templates/addons/macros.html:69 src/olympia/addons/templates/addons/persona_preview.html:21
+#: src/olympia/addons/templates/addons/macros.html:10 src/olympia/addons/templates/addons/macros.html:69 src/olympia/addons/templates/addons/persona_preview.html:22
 #: src/olympia/addons/templates/addons/listing/items_mobile.html:44 src/olympia/addons/templates/addons/listing/macros.html:39
 #: src/olympia/bandwagon/templates/bandwagon/collection_listing_items.html:37 src/olympia/bandwagon/templates/bandwagon/impala/collection_listing_items.html:37
 msgid "Added {0}"
@@ -573,15 +574,14 @@ msgstr[0] "%(num)s bruker"
 msgstr[1] "%(num)s brukere"
 
 #. {0} is the number of downloads.
-#: src/olympia/addons/templates/addons/macros.html:53 src/olympia/addons/templates/addons/impala/details.html:61
+#: src/olympia/addons/templates/addons/macros.html:53 src/olympia/addons/templates/addons/impala/details.html:59
 msgid "{0} weekly download"
 msgid_plural "{0} weekly downloads"
 msgstr[0] "{0} ukentlig nedlasting"
 msgstr[1] "{0} ukentlige nedlastinger"
 
 #. {0} is the number of users.
-#: src/olympia/addons/templates/addons/macros.html:61 src/olympia/addons/templates/addons/impala/details.html:54 src/olympia/compat/templates/compat/index.html:71
-#: src/olympia/zadmin/templates/zadmin/compat.html:67
+#: src/olympia/addons/templates/addons/macros.html:61 src/olympia/addons/templates/addons/impala/details.html:52 src/olympia/zadmin/templates/zadmin/compat.html:67
 msgid "{0} user"
 msgid_plural "{0} users"
 msgstr[0] "{0} bruker"
@@ -599,7 +599,7 @@ msgstr "Betaling fullført"
 msgid "Return to the addon."
 msgstr "Tilbake til utvidelsen."
 
-#: src/olympia/addons/templates/addons/persona_detail.html:17 src/olympia/addons/templates/addons/impala/details.html:106 src/olympia/addons/templates/addons/mobile/details.html:23
+#: src/olympia/addons/templates/addons/persona_detail.html:17 src/olympia/addons/templates/addons/impala/details.html:103 src/olympia/addons/templates/addons/mobile/details.html:23
 #: src/olympia/addons/templates/addons/mobile/persona_detail.html:21 src/olympia/discovery/templates/discovery/addons/base.html:27 src/olympia/editors/templates/editors/review.html:31
 msgid "by"
 msgstr "av"
@@ -643,34 +643,35 @@ msgstr "Daglige brukere"
 msgid "License"
 msgstr "Lisens"
 
-#: src/olympia/addons/templates/addons/persona_preview.html:12 src/olympia/constants/base.py:48
+#: src/olympia/addons/templates/addons/persona_preview.html:13 src/olympia/constants/base.py:48
 msgid "Awaiting Review"
 msgstr "Venter på gjennomgang"
 
-#: src/olympia/addons/templates/addons/persona_preview.html:14 src/olympia/amo/log.py:180 src/olympia/constants/base.py:42 src/olympia/editors/helpers.py:62
+#: src/olympia/addons/templates/addons/persona_preview.html:15 src/olympia/amo/log.py:180 src/olympia/constants/base.py:42 src/olympia/editors/helpers.py:62
 msgid "Rejected"
 msgstr "Avvist"
 
-#: src/olympia/addons/templates/addons/persona_preview.html:16 src/olympia/amo/log.py:159
+#: src/olympia/addons/templates/addons/persona_preview.html:17 src/olympia/amo/log.py:159
 msgid "Approved"
 msgstr "Godkjent"
 
 #. {0} is the number of users.
-#: src/olympia/addons/templates/addons/persona_preview.html:26 src/olympia/addons/templates/addons/listing/items_mobile.html:36 src/olympia/addons/templates/addons/listing/macros.html:31
+#: src/olympia/addons/templates/addons/persona_preview.html:27 src/olympia/addons/templates/addons/listing/items_mobile.html:36 src/olympia/addons/templates/addons/listing/macros.html:31
 msgid "<strong>{0}</strong> user"
 msgid_plural "<strong>{0}</strong> users"
 msgstr[0] "<strong>{0}</strong> bruker"
 msgstr[1] "<strong>{0}</strong> brukere"
 
-#: src/olympia/addons/templates/addons/persona_preview.html:40
+#: src/olympia/addons/templates/addons/persona_preview.html:41
 msgid "Hover to Preview"
 msgstr "Flytt pekeren over for å forhåndsvise"
 
-#: src/olympia/addons/templates/addons/persona_preview.html:46 src/olympia/addons/templates/addons/persona_preview.html:48 src/olympia/reviews/templates/reviews/add.html:15
+#: src/olympia/addons/templates/addons/persona_preview.html:47 src/olympia/addons/templates/addons/persona_preview.html:49 src/olympia/addons/templates/addons/persona_preview.html:97
+#: src/olympia/reviews/templates/reviews/add.html:15
 msgid "Add"
 msgstr "Legg til"
 
-#: src/olympia/addons/templates/addons/persona_preview.html:57 src/olympia/bandwagon/templates/bandwagon/ajax_new.html:16 src/olympia/bandwagon/templates/bandwagon/edit.html:19
+#: src/olympia/addons/templates/addons/persona_preview.html:58 src/olympia/bandwagon/templates/bandwagon/ajax_new.html:16 src/olympia/bandwagon/templates/bandwagon/edit.html:19
 #: src/olympia/bandwagon/templates/bandwagon/includes/addedit.html:19 src/olympia/devhub/templates/devhub/addons/edit/admin.html:13 src/olympia/devhub/templates/devhub/addons/edit/basic.html:10
 #: src/olympia/devhub/templates/devhub/addons/edit/details.html:8 src/olympia/devhub/templates/devhub/addons/edit/media.html:6 src/olympia/devhub/templates/devhub/addons/edit/support.html:8
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:9 src/olympia/devhub/templates/devhub/addons/submit/describe.html:29 src/olympia/editors/templates/editors/review.html:257
@@ -679,21 +680,21 @@ msgstr "Rediger"
 
 #. For datetime formatting, see the table on
 #. http://docs.python.org/library/datetime.html#strftime-and-strptime-behavior
-#: src/olympia/addons/templates/addons/persona_preview.html:66
+#: src/olympia/addons/templates/addons/persona_preview.html:67
 #, python-format
 msgid "%%Y-%%m-%%d"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/persona_preview.html:67
+#: src/olympia/addons/templates/addons/persona_preview.html:68
 msgid "by {0} on {1}"
 msgstr "av {0} på {1}"
 
-#: src/olympia/addons/templates/addons/persona_preview.html:75 src/olympia/reviews/helpers.py:17 src/olympia/reviews/templates/reviews/review_list.html:63
+#: src/olympia/addons/templates/addons/persona_preview.html:76 src/olympia/reviews/helpers.py:17 src/olympia/reviews/templates/reviews/review_list.html:63
 #: src/olympia/reviews/templates/reviews/reviews_link.html:21 src/olympia/reviews/templates/reviews/impala/reviews_link.html:16
 msgid "Not yet rated"
 msgstr "Ikke rangert ennå"
 
-#: src/olympia/addons/templates/addons/persona_preview.html:78
+#: src/olympia/addons/templates/addons/persona_preview.html:79
 msgid "<b>{0}</b> users"
 msgstr "<b>{0}</b> brukere"
 
@@ -706,8 +707,8 @@ msgid "Learn more about Firefox"
 msgstr "Les mer om Firefox"
 
 #: src/olympia/addons/templates/addons/popups.html:22
-msgid "or <b><a class=\"installer\" href=\"{url}\">download anyway</a></b>"
-msgstr "eller <b><a class=\"installer\" href=\"{url}\">last ned likevel</a></b>"
+msgid "or <b><a class=\"button installer\" href=\"{url}\">download anyway</a></b>"
+msgstr ""
 
 #: src/olympia/addons/templates/addons/popups.html:26
 msgid ""
@@ -800,11 +801,14 @@ msgid "QR code for add-on"
 msgstr "QR-kode for utvidelse"
 
 #: src/olympia/addons/templates/addons/qr_code.html:6
-msgid "Want {0} on your mobile Firefox? Scan this QR code to install directly to your phone. (You'll need a QR reader. Search your phone's marketplace if don't have one.)"
-msgstr "Ønsker du å ha {0} på din mobile Firefox? Skann denne QR-koden for å installere direkte på telefonen. (Du trenger en QR-leser. Søk på telefonens markedsplass dersom du ikke har en.)"
+msgid ""
+"Want {0} on your mobile Firefox?  Scan this QR code to install directly\n"
+"  to your phone.  (You'll need a QR reader.  Search your phone's marketplace if\n"
+"  don't have one.)"
+msgstr ""
 
 #: src/olympia/addons/templates/addons/report_abuse.html:6 src/olympia/addons/templates/addons/report_abuse_full.html:10 src/olympia/addons/templates/addons/impala/details-more.html:23
-#: src/olympia/addons/templates/addons/impala/details.html:328
+#: src/olympia/addons/templates/addons/impala/details.html:333
 msgid "Report Abuse"
 msgstr "Rapporter misbruk"
 
@@ -825,9 +829,9 @@ msgstr "Send rapport"
 #: src/olympia/devhub/templates/devhub/addons/ajax_compat_update.html:36 src/olympia/devhub/templates/devhub/addons/profile.html:44 src/olympia/devhub/templates/devhub/addons/edit/admin.html:104
 #: src/olympia/devhub/templates/devhub/addons/edit/basic.html:155 src/olympia/devhub/templates/devhub/addons/edit/details.html:88 src/olympia/devhub/templates/devhub/addons/edit/support.html:70
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:169 src/olympia/devhub/templates/devhub/addons/forms_shared/media.html:152
-#: src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:44 src/olympia/devhub/templates/devhub/personas/edit.html:222 src/olympia/devhub/templates/devhub/versions/add_file_modal.html:79
-#: src/olympia/devhub/templates/devhub/versions/edit.html:140 src/olympia/devhub/templates/devhub/versions/list.html:208 src/olympia/devhub/templates/devhub/versions/list.html:242
-#: src/olympia/devhub/templates/devhub/versions/list.html:276 src/olympia/devhub/templates/devhub/versions/list.html:317 src/olympia/reviews/templates/reviews/edit_review.html:16
+#: src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:43 src/olympia/devhub/templates/devhub/personas/edit.html:222 src/olympia/devhub/templates/devhub/versions/add_file_modal.html:59
+#: src/olympia/devhub/templates/devhub/versions/edit.html:140 src/olympia/devhub/templates/devhub/versions/list.html:208 src/olympia/devhub/templates/devhub/versions/list.html:239
+#: src/olympia/devhub/templates/devhub/versions/list.html:281 src/olympia/devhub/templates/devhub/versions/list.html:315 src/olympia/reviews/templates/reviews/edit_review.html:16
 #: src/olympia/translations/templates/translations/trans-menu.html:50 src/olympia/translations/templates/translations/trans-menu.html:62 src/olympia/zadmin/templates/zadmin/validation.html:105
 msgid "Cancel"
 msgstr "Avbryt"
@@ -872,7 +876,7 @@ msgstr "Se <a href=\"%(support)s\">brukerstøtte-seksjonen</a> for å finne ut h
 msgid "Review Guidelines"
 msgstr "Retningslinjer for anmeldelser"
 
-#: src/olympia/addons/templates/addons/review_list_box.html:5 src/olympia/addons/templates/addons/impala/details-more.html:27 src/olympia/editors/helpers.py:921
+#: src/olympia/addons/templates/addons/review_list_box.html:5 src/olympia/addons/templates/addons/impala/details-more.html:27 src/olympia/editors/helpers.py:1001
 #: src/olympia/reviews/templates/reviews/add.html:14 src/olympia/reviews/templates/reviews/reply.html:14 src/olympia/reviews/templates/reviews/review_list.html:19
 #: src/olympia/reviews/templates/reviews/mobile/review_list.html:26
 msgid "Reviews"
@@ -963,103 +967,103 @@ msgid_plural "Other add-ons by these authors"
 msgstr[0] "Andre utvidelser av %(author)s"
 msgstr[1] "Andre utvidelser av disse forfatterne"
 
-#: src/olympia/addons/templates/addons/impala/details.html:41
+#: src/olympia/addons/templates/addons/impala/details.html:39
 #, python-format
 msgid "<span itemprop=\"ratingCount\">%(num)s</span> user review"
 msgid_plural "<span itemprop=\"ratingCount\">%(num)s</span> user reviews"
 msgstr[0] "<span itemprop=\"ratingCount\">%(num)s</span> brukeranmeldelse"
 msgstr[1] "<span itemprop=\"ratingCount\">%(num)s</span> brukeranmeldelser"
 
-#: src/olympia/addons/templates/addons/impala/details.html:69
+#: src/olympia/addons/templates/addons/impala/details.html:66
 msgid "View statistics"
 msgstr "Vis statistikk"
 
-#: src/olympia/addons/templates/addons/impala/details.html:84
+#: src/olympia/addons/templates/addons/impala/details.html:81
 msgid "Manage"
 msgstr "Behandle"
 
 #. {0} is an add-on name.
-#: src/olympia/addons/templates/addons/impala/details.html:96
+#: src/olympia/addons/templates/addons/impala/details.html:93
 msgid "Icon of {0}"
 msgstr "Ikonet til {0}"
 
-#: src/olympia/addons/templates/addons/impala/details.html:103 src/olympia/addons/templates/addons/impala/listing/items.html:14
+#: src/olympia/addons/templates/addons/impala/details.html:100 src/olympia/addons/templates/addons/impala/listing/items.html:14
 msgid "No Restart"
 msgstr "Ingen omstart"
 
-#: src/olympia/addons/templates/addons/impala/details.html:127
+#: src/olympia/addons/templates/addons/impala/details.html:124
 #, fuzzy, python-format
 msgid "Meet the Developer: <a href=\"%(url)s\">%(name)s</a>"
 msgid_plural "<a href=\"%(url)s\">Meet the Developers</a>"
 msgstr[0] "Møt utvikleren: <a href=\"%(url)s\">%(name)s</a>"
 msgstr[1] "<a href=\"%(url)s\">Møt utviklerne</a>"
 
-#: src/olympia/addons/templates/addons/impala/details.html:137
+#: src/olympia/addons/templates/addons/impala/details.html:134
 msgid "Learn why {0} was created and find out what's next for this add-on."
 msgstr "Les om hvorfor {0} ble laget og finn ut hva som venter for denne utvidelsen."
 
 #. {0} is an index.
-#: src/olympia/addons/templates/addons/impala/details.html:156
+#: src/olympia/addons/templates/addons/impala/details.html:161
 msgid "Add-on screenshot #{0}"
 msgstr "Skjermbilde #{0} av utvidelse"
 
-#: src/olympia/addons/templates/addons/impala/details.html:182
+#: src/olympia/addons/templates/addons/impala/details.html:187
 msgid "Add-on home page"
 msgstr "Hjemmeside for utvidelsen"
 
-#: src/olympia/addons/templates/addons/impala/details.html:185
+#: src/olympia/addons/templates/addons/impala/details.html:190
 msgid "Support site"
 msgstr "Brukerstøttenettsted"
 
-#: src/olympia/addons/templates/addons/impala/details.html:189
+#: src/olympia/addons/templates/addons/impala/details.html:194
 msgid "Support E-mail"
 msgstr "E-postadresse for brukerstøtte"
 
-#: src/olympia/addons/templates/addons/impala/details.html:194 src/olympia/devhub/models.py:378 src/olympia/devhub/templates/devhub/versions/list.html:12
+#: src/olympia/addons/templates/addons/impala/details.html:199 src/olympia/devhub/models.py:378 src/olympia/devhub/templates/devhub/versions/list.html:12
 #: src/olympia/versions/templates/versions/version.html:6 src/olympia/versions/templates/versions/mobile/version.html:6
 msgid "Version {0}"
 msgstr "Versjon {0}"
 
-#: src/olympia/addons/templates/addons/impala/details.html:194
+#: src/olympia/addons/templates/addons/impala/details.html:199
 msgid "Info"
 msgstr "Info"
 
-#: src/olympia/addons/templates/addons/impala/details.html:195 src/olympia/devhub/templates/devhub/includes/addon_details.html:129
+#: src/olympia/addons/templates/addons/impala/details.html:200 src/olympia/devhub/templates/devhub/includes/addon_details.html:116
 msgid "Last Updated:"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/impala/details.html:200
+#: src/olympia/addons/templates/addons/impala/details.html:205
 #, python-format
 msgid "Released under <a target=\"_blank\" href=\"%(url)s\">%(name)s</a>"
 msgstr "Utgitt under <a target=\"_blank\" href=\"%(url)s\">%(name)s</a>"
 
-#: src/olympia/addons/templates/addons/impala/details.html:201 src/olympia/addons/templates/addons/impala/details.html:206 src/olympia/amo/helpers.py:398 src/olympia/devhub/forms.py:142
+#: src/olympia/addons/templates/addons/impala/details.html:206 src/olympia/addons/templates/addons/impala/details.html:211 src/olympia/amo/helpers.py:398 src/olympia/devhub/forms.py:142
 #: src/olympia/devhub/forms.py:173 src/olympia/versions/templates/versions/version.html:40 src/olympia/versions/templates/versions/version.html:45
 msgid "Custom License"
 msgstr "Egen lisens"
 
-#: src/olympia/addons/templates/addons/impala/details.html:205
+#: src/olympia/addons/templates/addons/impala/details.html:210
 #, python-format
 msgid "Released under <a href=\"%(url)s\">%(name)s</a>"
 msgstr "Utgitt under <a href=\"%(url)s\">%(name)s</a>"
 
-#: src/olympia/addons/templates/addons/impala/details.html:217
+#: src/olympia/addons/templates/addons/impala/details.html:222
 msgid "About this Add-on"
 msgstr "Om denne utvidelsen"
 
-#: src/olympia/addons/templates/addons/impala/details.html:233
+#: src/olympia/addons/templates/addons/impala/details.html:238
 msgid "Developer’s Comments"
 msgstr "Utviklerens kommentarer"
 
-#: src/olympia/addons/templates/addons/impala/details.html:243
+#: src/olympia/addons/templates/addons/impala/details.html:248
 msgid "Version Information"
 msgstr "Versjonsinformasjon"
 
-#: src/olympia/addons/templates/addons/impala/details.html:250
+#: src/olympia/addons/templates/addons/impala/details.html:255
 msgid "See complete version history"
 msgstr "Se komplett versjonshistorikk"
 
-#: src/olympia/addons/templates/addons/impala/details.html:262
+#: src/olympia/addons/templates/addons/impala/details.html:267
 msgid ""
 "The Development Channel lets you test an experimental new version of this add-on before it's released to the general public. Once you install the development version, you will continue to get "
 "updates from this channel. To stop receiving development updates, reinstall the default version from the link above."
@@ -1067,17 +1071,17 @@ msgstr ""
 "Utviklingskanalen lar deg teste en eksperimentell versjon av denne utvidelsen før den utgis til offentligheten. Etter du installerer en utviklingsversjon vil du fortsette å motta oppdateringer fra "
 "denne kanalen. For å slutte motta utviklingsoppdateringer må du reinstallere standardversjonen fra lenken ovenfor."
 
-#: src/olympia/addons/templates/addons/impala/details.html:272
+#: src/olympia/addons/templates/addons/impala/details.html:277
 msgid "<strong>Caution:</strong> Development versions of this add-on have not been reviewed by Mozilla."
 msgstr ""
 
-#: src/olympia/addons/templates/addons/impala/details.html:287
+#: src/olympia/addons/templates/addons/impala/details.html:292
 msgid "See complete development channel history"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/impala/details.html:306 src/olympia/addons/templates/addons/impala/details.html:315 src/olympia/addons/templates/addons/impala/details.html:327
+#: src/olympia/addons/templates/addons/impala/details.html:311 src/olympia/addons/templates/addons/impala/details.html:320 src/olympia/addons/templates/addons/impala/details.html:332
 #: src/olympia/addons/templates/addons/impala/review_add_box.html:4 src/olympia/stats/templates/stats/popup.html:2 src/olympia/stats/templates/stats/popup.html:8
-#: src/olympia/stats/templates/stats/stats.html:202 src/olympia/users/templates/users/profile.html:119
+#: src/olympia/stats/templates/stats/stats.html:204 src/olympia/users/templates/users/profile.html:119
 msgid "close"
 msgstr "lukk"
 
@@ -1133,15 +1137,11 @@ msgstr "Kildekodelisens for {addon}"
 msgid "Source Code License"
 msgstr "Kildekodelisens"
 
-#: src/olympia/addons/templates/addons/impala/persona_grid.html:16 src/olympia/addons/templates/addons/impala/toplist.html:6
-msgid "{0} users"
-msgstr "{0} brukere"
-
 #: src/olympia/addons/templates/addons/impala/review_list_box.html:19 src/olympia/reviews/templates/reviews/review.html:40
 msgid "permalink"
 msgstr "permalenke"
 
-#: src/olympia/addons/templates/addons/impala/review_list_box.html:23 src/olympia/editors/templates/editors/queue.html:98 src/olympia/reviews/templates/reviews/review.html:44
+#: src/olympia/addons/templates/addons/impala/review_list_box.html:23 src/olympia/editors/templates/editors/queue.html:104 src/olympia/reviews/templates/reviews/review.html:44
 msgid "translate"
 msgstr "oversett"
 
@@ -1160,6 +1160,10 @@ msgstr "Denne utvidelsen har ennå ikke blitt anmeldt."
 msgid "Be the first!"
 msgstr "Vær først!"
 
+#: src/olympia/addons/templates/addons/impala/toplist.html:6
+msgid "{0} users"
+msgstr "{0} brukere"
+
 #: src/olympia/addons/templates/addons/impala/listing/sorter.html:14 src/olympia/devhub/templates/devhub/addons/listing/item_actions.html:49
 msgid "More"
 msgstr "Mer"
@@ -1172,7 +1176,7 @@ msgstr "Legg til i samling"
 msgid "My Add-ons"
 msgstr "Mine utvidelser"
 
-#: src/olympia/addons/templates/addons/includes/dashboard_tabs.html:6 src/olympia/amo/context_processors.py:51
+#: src/olympia/addons/templates/addons/includes/dashboard_tabs.html:6 src/olympia/amo/context_processors.py:50
 msgid "My Themes"
 msgstr "Mine temaer"
 
@@ -1227,7 +1231,7 @@ msgstr "Brukere"
 msgid "Weekly Downloads"
 msgstr "Ukentlige nedlastinger"
 
-#: src/olympia/addons/templates/addons/mobile/details.html:99 src/olympia/compat/templates/compat/reporter_detail.html:46 src/olympia/devhub/forms.py:787
+#: src/olympia/addons/templates/addons/mobile/details.html:99 src/olympia/compat/templates/compat/reporter_detail.html:46 src/olympia/devhub/forms.py:788
 #: src/olympia/devhub/templates/devhub/versions/list.html:163
 msgid "Version"
 msgstr "Versjon"
@@ -1313,7 +1317,7 @@ msgstr ""
 #: src/olympia/browse/templates/browse/personas/category_landing.html:21 src/olympia/browse/templates/browse/personas/category_landing.html:23
 #: src/olympia/browse/templates/browse/personas/category_landing.html:38 src/olympia/browse/templates/browse/personas/grid.html:7 src/olympia/browse/templates/browse/personas/grid.html:11
 #: src/olympia/browse/templates/browse/personas/mobile/base.html:7 src/olympia/browse/templates/browse/personas/mobile/category_landing.html:19 src/olympia/constants/base.py:180
-#: src/olympia/devhub/templates/devhub/personas/submit.html:13 src/olympia/editors/helpers.py:105 src/olympia/editors/templates/editors/base.html:26
+#: src/olympia/devhub/templates/devhub/personas/submit.html:13 src/olympia/editors/helpers.py:107 src/olympia/editors/templates/editors/base.html:26
 #: src/olympia/editors/templates/editors/performance.html:73 src/olympia/search/templates/search/personas.html:39 src/olympia/templates/menu_links.html:9
 msgid "Themes"
 msgstr "Temaer"
@@ -1334,7 +1338,7 @@ msgstr "Flere utvidelser"
 msgid "Highest Rated"
 msgstr "Høyest rangerte"
 
-#: src/olympia/addons/templates/addons/mobile/home.html:74 src/olympia/amo/templates/amo/side_nav.html:5 src/olympia/amo/templates/amo/site_nav.html:27 src/olympia/amo/templates/amo/site_nav.html:57
+#: src/olympia/addons/templates/addons/mobile/home.html:74 src/olympia/amo/templates/amo/side_nav.html:5 src/olympia/amo/templates/amo/site_nav.html:27 src/olympia/amo/templates/amo/site_nav.html:55
 #: src/olympia/bandwagon/views.py:97 src/olympia/browse/views.py:57 src/olympia/browse/views.py:67 src/olympia/browse/templates/browse/personas/mobile/category_landing.html:65
 #: src/olympia/search/forms.py:15 src/olympia/search/forms.py:87
 msgid "Newest"
@@ -1348,90 +1352,90 @@ msgstr "Prøv den på!"
 msgid "Theme Info &raquo;"
 msgstr "Temainfo &raquo;"
 
-#: src/olympia/amo/context_processors.py:39 src/olympia/devhub/templates/devhub/nav.html:43
+#: src/olympia/amo/context_processors.py:37 src/olympia/devhub/templates/devhub/nav.html:43
 msgid "Tools"
 msgstr "Verktøy"
 
-#: src/olympia/amo/context_processors.py:48 src/olympia/discovery/templates/discovery/pane_account.html:8 src/olympia/users/templates/users/includes/navigation.html:2
+#: src/olympia/amo/context_processors.py:47 src/olympia/discovery/templates/discovery/pane_account.html:8 src/olympia/users/templates/users/includes/navigation.html:2
 msgid "My Profile"
 msgstr "Min profil"
 
-#: src/olympia/amo/context_processors.py:54 src/olympia/users/templates/users/edit.html:5 src/olympia/users/templates/users/includes/navigation.html:3
+#: src/olympia/amo/context_processors.py:53 src/olympia/users/templates/users/edit.html:5 src/olympia/users/templates/users/includes/navigation.html:3
 msgid "Account Settings"
 msgstr "Kontoinnstillinger"
 
-#: src/olympia/amo/context_processors.py:57 src/olympia/discovery/templates/discovery/pane_account.html:11 src/olympia/users/templates/users/profile.html:83
+#: src/olympia/amo/context_processors.py:56 src/olympia/discovery/templates/discovery/pane_account.html:11 src/olympia/users/templates/users/profile.html:83
 #: src/olympia/users/templates/users/includes/navigation.html:4
 msgid "My Collections"
 msgstr "Mine samlinger"
 
-#: src/olympia/amo/context_processors.py:62 src/olympia/discovery/templates/discovery/pane_account.html:10 src/olympia/users/templates/users/includes/navigation.html:7
+#: src/olympia/amo/context_processors.py:61 src/olympia/discovery/templates/discovery/pane_account.html:10 src/olympia/users/templates/users/includes/navigation.html:7
 msgid "My Favorites"
 msgstr "Mine favoritter"
 
-#: src/olympia/amo/context_processors.py:67 src/olympia/discovery/templates/discovery/pane_account.html:13 src/olympia/templates/impala/user_login.html:14
+#: src/olympia/amo/context_processors.py:66 src/olympia/discovery/templates/discovery/pane_account.html:13 src/olympia/templates/impala/user_login.html:14
 #: src/olympia/templates/mobile/header_auth.html:5
 msgid "Log out"
 msgstr "Logg ut"
 
-#: src/olympia/amo/context_processors.py:72 src/olympia/devhub/templates/devhub/addons/dashboard.html:4
+#: src/olympia/amo/context_processors.py:71 src/olympia/devhub/templates/devhub/addons/dashboard.html:4
 msgid "Manage My Submissions"
 msgstr "Behandle mine innsendinger"
 
-#: src/olympia/amo/context_processors.py:75 src/olympia/devhub/templates/devhub/nav.html:27 src/olympia/devhub/templates/devhub/addons/dashboard.html:25
+#: src/olympia/amo/context_processors.py:74 src/olympia/devhub/templates/devhub/nav.html:27 src/olympia/devhub/templates/devhub/addons/dashboard.html:25
 #: src/olympia/devhub/templates/devhub/addons/submit/base.html:4
 msgid "Submit a New Add-on"
 msgstr "Send inn ny utvidelse"
 
-#: src/olympia/amo/context_processors.py:77 src/olympia/browse/templates/browse/personas/base.html:50 src/olympia/devhub/templates/devhub/index.html:24
+#: src/olympia/amo/context_processors.py:76 src/olympia/browse/templates/browse/personas/base.html:50 src/olympia/devhub/templates/devhub/index.html:24
 #: src/olympia/devhub/templates/devhub/addons/dashboard.html:29
 msgid "Submit a New Theme"
 msgstr "Send inn nytt tema"
 
-#: src/olympia/amo/context_processors.py:79 src/olympia/amo/templates/amo/site_nav.html:87 src/olympia/devhub/helpers.py:36 src/olympia/devhub/helpers.py:68 src/olympia/devhub/helpers.py:102
+#: src/olympia/amo/context_processors.py:78 src/olympia/amo/templates/amo/site_nav.html:85 src/olympia/devhub/helpers.py:36 src/olympia/devhub/helpers.py:68 src/olympia/devhub/helpers.py:102
 #: src/olympia/templates/footer.html:6 src/olympia/templates/menu_links.html:14
 msgid "Developer Hub"
 msgstr "Utviklerhubb"
 
-#: src/olympia/amo/context_processors.py:83 src/olympia/devhub/views.py:1792
+#: src/olympia/amo/context_processors.py:81 src/olympia/devhub/views.py:1796
 msgid "Manage API Keys"
 msgstr ""
 
-#: src/olympia/amo/context_processors.py:88 src/olympia/editors/helpers.py:82 src/olympia/editors/helpers.py:102 src/olympia/editors/templates/editors/base.html:10
+#: src/olympia/amo/context_processors.py:86 src/olympia/editors/helpers.py:84 src/olympia/editors/helpers.py:104 src/olympia/editors/templates/editors/base.html:10
 msgid "Editor Tools"
 msgstr "Redigeringsverktøy"
 
-#: src/olympia/amo/context_processors.py:92
+#: src/olympia/amo/context_processors.py:90
 msgid "Admin Tools"
 msgstr "Adminverktøy"
 
-#: src/olympia/amo/fields.py:15
+#: src/olympia/amo/fields.py:20
 msgid "Incorrect, please try again."
 msgstr ""
 
-#: src/olympia/amo/fields.py:16
+#: src/olympia/amo/fields.py:21
 msgid "Error verifying input, please try again."
 msgstr ""
 
-#: src/olympia/amo/fields.py:32
+#: src/olympia/amo/fields.py:37
 msgid "This must be a valid hex color code, such as #000000."
 msgstr "Dette må være en gyldig hex-fargekode, som for eksempel #000000."
 
-#: src/olympia/amo/fields.py:58
+#: src/olympia/amo/fields.py:63
 msgid "Enter at least one value."
 msgstr "Skriv inn minst en verdi."
 
-#: src/olympia/amo/helpers.py:162 src/olympia/amo/templates/amo/site_nav.html:61 src/olympia/bandwagon/templates/bandwagon/add.html:9
+#: src/olympia/amo/helpers.py:162 src/olympia/amo/templates/amo/site_nav.html:59 src/olympia/bandwagon/templates/bandwagon/add.html:9
 #: src/olympia/bandwagon/templates/bandwagon/collection_detail.html:15 src/olympia/bandwagon/templates/bandwagon/delete.html:9 src/olympia/bandwagon/templates/bandwagon/edit.html:15
 #: src/olympia/bandwagon/templates/bandwagon/user_listing.html:18 src/olympia/bandwagon/templates/bandwagon/user_listing.html:21
 #: src/olympia/bandwagon/templates/bandwagon/impala/collection_listing.html:12 src/olympia/bandwagon/templates/bandwagon/impala/collection_listing.html:20
 #: src/olympia/bandwagon/templates/bandwagon/impala/collection_listing.html:24 src/olympia/bandwagon/templates/bandwagon/impala/collection_sidebar.html:3
 #: src/olympia/bandwagon/templates/bandwagon/includes/collection_sidebar.html:2 src/olympia/bandwagon/templates/bandwagon/mobile/collection_listing.html:3
-#: src/olympia/stats/templates/stats/stats.html:77 src/olympia/templates/menu_links.html:12
+#: src/olympia/stats/templates/stats/stats.html:33 src/olympia/templates/menu_links.html:12
 msgid "Collections"
 msgstr "Samlinger"
 
-#: src/olympia/amo/helpers.py:171 src/olympia/amo/templates/amo/site_nav.html:85 src/olympia/browse/templates/browse/language_tools.html:3
+#: src/olympia/amo/helpers.py:171 src/olympia/amo/templates/amo/site_nav.html:83 src/olympia/browse/templates/browse/language_tools.html:3
 msgid "Dictionaries & Language Packs"
 msgstr "Ordbøker og språkpakker"
 
@@ -1583,8 +1587,8 @@ msgstr "Superreview er forespurt"
 msgid "Comment on {addon} {version}."
 msgstr "Kommentar på {addon} {version}."
 
-#: src/olympia/amo/log.py:236 src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:19 src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:47
-#: src/olympia/editors/helpers.py:511 src/olympia/editors/templates/editors/themes/history_table.html:11
+#: src/olympia/amo/log.py:236 src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:17 src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:45
+#: src/olympia/editors/helpers.py:584 src/olympia/editors/templates/editors/themes/history_table.html:11
 msgid "Comment"
 msgstr "Kommentar"
 
@@ -1737,8 +1741,8 @@ msgid "Reviewer escalation"
 msgstr "Redaktør-eskalering"
 
 #: src/olympia/amo/log.py:442
-msgid "Video removed from {addon} because of a problem with the video."
-msgstr "Video fjernet fra {addon} på grunn av et problem med videoen."
+msgid "Video removed from {addon} because of a problem with the video. "
+msgstr ""
 
 #: src/olympia/amo/log.py:444
 msgid "Video removed"
@@ -1890,8 +1894,8 @@ msgstr "Oops"
 
 #: src/olympia/amo/templates/amo/500.html:6
 #, python-format
-msgid "<h1>Oops! We had an error.</h1> <p>We'll get to fixing that soon.</p> <p> You can try refreshing the page, or head back to the <a href=\"%(home)s\">Add-ons homepage</a>. </p>"
-msgstr "<h1>Oops! En feil oppstod.</h1> <p>Vi vil starte å rette den snart.</p> <p> Du kan prøve å oppdatere siden, eller gå tilbake til <a href=\"%(home)s\">hjemmesiden for utvidelser</a>. </p>"
+msgid "<h1>Oops!  We had an error.</h1> <p>We'll get to fixing that soon.</p> <p> You can try refreshing the page, or head back to the <a href=\"%(home)s\">Add-ons homepage</a>. </p>"
+msgstr ""
 
 #: src/olympia/amo/templates/amo/license_link.html:10
 msgid "Some rights reserved"
@@ -1913,7 +1917,7 @@ msgstr "Forrige"
 #: src/olympia/amo/templates/amo/mobile/paginator.html:14 src/olympia/amo/templates/amo/mobile/paginator.html:16 src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:51
 #: src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:65 src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:78
 #: src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:91 src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:104
-#: src/olympia/discovery/templates/discovery/pane.html:45 src/olympia/discovery/templates/discovery/addons/detail.html:39 src/olympia/stats/templates/stats/stats.html:167
+#: src/olympia/discovery/templates/discovery/pane.html:45 src/olympia/discovery/templates/discovery/addons/detail.html:39 src/olympia/stats/templates/stats/stats.html:169
 msgid "Next"
 msgstr "Neste"
 
@@ -1945,7 +1949,7 @@ msgid ""
 msgstr ""
 
 #: src/olympia/amo/templates/amo/side_nav.html:4 src/olympia/amo/templates/amo/side_nav.html:12 src/olympia/amo/templates/amo/site_nav.html:4 src/olympia/amo/templates/amo/site_nav.html:26
-#: src/olympia/browse/views.py:56 src/olympia/browse/views.py:66 src/olympia/browse/views.py:237 src/olympia/browse/views.py:282 src/olympia/search/forms.py:86
+#: src/olympia/browse/views.py:56 src/olympia/browse/views.py:66 src/olympia/browse/views.py:204 src/olympia/browse/views.py:249 src/olympia/search/forms.py:86
 msgid "Top Rated"
 msgstr "Topprangert"
 
@@ -1959,38 +1963,38 @@ msgstr "Utforsk"
 msgid "Extensions"
 msgstr "Utvidelser"
 
-#: src/olympia/amo/templates/amo/site_nav.html:45
+#: src/olympia/amo/templates/amo/site_nav.html:44
 msgid "Want more customization? Try <b>Complete Themes</b>"
 msgstr ""
 
-#: src/olympia/amo/templates/amo/site_nav.html:56 src/olympia/bandwagon/views.py:96
+#: src/olympia/amo/templates/amo/site_nav.html:54 src/olympia/bandwagon/views.py:96
 msgid "Most Followers"
 msgstr "Flest følgere"
 
-#: src/olympia/amo/templates/amo/site_nav.html:68 src/olympia/bandwagon/templates/bandwagon/impala/collection_sidebar.html:16
+#: src/olympia/amo/templates/amo/site_nav.html:66 src/olympia/bandwagon/templates/bandwagon/impala/collection_sidebar.html:16
 #: src/olympia/bandwagon/templates/bandwagon/includes/collection_sidebar.html:18
 msgid "Collections I've Made"
 msgstr "Samlinger jeg har laget"
 
-#: src/olympia/amo/templates/amo/site_nav.html:70 src/olympia/bandwagon/templates/bandwagon/user_listing.html:4 src/olympia/bandwagon/templates/bandwagon/impala/collection_sidebar.html:13
+#: src/olympia/amo/templates/amo/site_nav.html:68 src/olympia/bandwagon/templates/bandwagon/user_listing.html:4 src/olympia/bandwagon/templates/bandwagon/impala/collection_sidebar.html:13
 #: src/olympia/bandwagon/templates/bandwagon/includes/collection_sidebar.html:15
 msgid "Collections I'm Following"
 msgstr "Samlinger jeg følger"
 
-#: src/olympia/amo/templates/amo/site_nav.html:73 src/olympia/bandwagon/templates/bandwagon/impala/collection_sidebar.html:18
-#: src/olympia/bandwagon/templates/bandwagon/includes/collection_sidebar.html:20 src/olympia/users/models.py:512
+#: src/olympia/amo/templates/amo/site_nav.html:71 src/olympia/bandwagon/templates/bandwagon/impala/collection_sidebar.html:18
+#: src/olympia/bandwagon/templates/bandwagon/includes/collection_sidebar.html:20 src/olympia/users/models.py:521
 msgid "My Favorite Add-ons"
 msgstr "Mine favorittutvidelser"
 
-#: src/olympia/amo/templates/amo/site_nav.html:78
+#: src/olympia/amo/templates/amo/site_nav.html:76
 msgid "More&hellip;"
 msgstr "Mer &hellip;"
 
-#: src/olympia/amo/templates/amo/site_nav.html:82
+#: src/olympia/amo/templates/amo/site_nav.html:80
 msgid "Add-ons for Mobile"
 msgstr "Utvidelser for mobil"
 
-#: src/olympia/amo/templates/amo/site_nav.html:86 src/olympia/browse/feeds.py:207 src/olympia/browse/templates/browse/search_tools.html:3 src/olympia/constants/base.py:176
+#: src/olympia/amo/templates/amo/site_nav.html:84 src/olympia/browse/feeds.py:207 src/olympia/browse/templates/browse/search_tools.html:3 src/olympia/constants/base.py:176
 #: src/olympia/templates/menu_links.html:10
 msgid "Search Tools"
 msgstr "Søkeverktøy"
@@ -2006,7 +2010,7 @@ msgid "Jump to first page"
 msgstr "Hopp til første side"
 
 #: src/olympia/amo/templates/amo/impala/paginator.html:22 src/olympia/amo/templates/amo/mobile/impala_paginator.html:12 src/olympia/discovery/templates/discovery/pane.html:44
-#: src/olympia/discovery/templates/discovery/addons/detail.html:38 src/olympia/stats/templates/stats/stats.html:164
+#: src/olympia/discovery/templates/discovery/addons/detail.html:38 src/olympia/stats/templates/stats/stats.html:166
 msgid "Previous"
 msgstr "Forrige"
 
@@ -2029,31 +2033,50 @@ msgid_plural "Page {n}"
 msgstr[0] "Side {n}"
 msgstr[1] "Side {n}"
 
-#: src/olympia/amo/templates/services/install.html:38
-#, python-format
-msgid "If you are not prompted to install %(addon_name)s in a moment, please <a href=\"%(addon_xpi)s\">click here</a>."
-msgstr "Dersom du ikke får spørsmål om å installere %(addon_name)s om et øyeblikk, <a href=\"%(addon_xpi)s\">trykk her</a>."
-
-#: src/olympia/amo/tests/test_messages.py:57 src/olympia/amo/tests/test_messages.py:58 src/olympia/reviews/forms.py:25 src/olympia/reviews/forms.py:50 src/olympia/reviews/templates/reviews/add.html:56
+#: src/olympia/amo/tests/test_messages.py:56 src/olympia/amo/tests/test_messages.py:57 src/olympia/reviews/forms.py:25 src/olympia/reviews/forms.py:50 src/olympia/reviews/templates/reviews/add.html:56
 #: src/olympia/reviews/templates/reviews/reply.html:30
 msgid "Title"
 msgstr "Tittel"
 
-#: src/olympia/amo/tests/test_messages.py:57 src/olympia/amo/tests/test_messages.py:58
+#: src/olympia/amo/tests/test_messages.py:56 src/olympia/amo/tests/test_messages.py:57
 msgid "Body"
 msgstr "Innhold"
 
-#: src/olympia/amo/tests/test_messages.py:59
+#: src/olympia/amo/tests/test_messages.py:58
 msgid "Another Title"
 msgstr "Annen tittel"
 
-#: src/olympia/amo/tests/test_messages.py:59
+#: src/olympia/amo/tests/test_messages.py:58
 msgid "Another Body"
 msgstr "Annet innhold"
 
-#: src/olympia/api/views.py:255
-msgid "Not implemented yet."
-msgstr "Ikke implementert ennå."
+#: src/olympia/api/authentication.py:76
+msgid "Signature has expired."
+msgstr ""
+
+#: src/olympia/api/authentication.py:79
+msgid "Error decoding signature."
+msgstr ""
+
+#: src/olympia/api/authentication.py:82
+msgid "Invalid JWT Token."
+msgstr ""
+
+#: src/olympia/api/authentication.py:130
+msgid "Invalid Authorization header. No credentials provided."
+msgstr ""
+
+#: src/olympia/api/authentication.py:133
+msgid "Invalid Authorization header. Credentials string should not contain spaces."
+msgstr ""
+
+#: src/olympia/api/fields.py:29
+msgid "The field must have a length of at least {num} characters."
+msgstr ""
+
+#: src/olympia/api/fields.py:31
+msgid "The language code {lang_code} is invalid."
+msgstr ""
 
 #: src/olympia/applications/views.py:39 src/olympia/applications/templates/applications/appversions.html:3
 msgid "Application Versions"
@@ -2071,7 +2094,7 @@ msgstr "Gyldige programversjoner"
 msgid "Add-ons submitted to Mozilla Add-ons must have a manifest file with at least one of the below applications supported. Only the versions listed below are allowed for these applications."
 msgstr ""
 
-#: src/olympia/applications/templates/applications/appversions.html:25
+#: src/olympia/applications/templates/applications/appversions.html:25 src/olympia/editors/helpers.py:361
 msgid "GUID"
 msgstr "GUID"
 
@@ -2185,8 +2208,8 @@ msgstr "Favoritt"
 msgid "Remove from favorites"
 msgstr "Fjern fra favoritter"
 
-#: src/olympia/bandwagon/views.py:98 src/olympia/bandwagon/views.py:191 src/olympia/browse/views.py:58 src/olympia/browse/views.py:69 src/olympia/browse/views.py:458 src/olympia/devhub/views.py:74
-#: src/olympia/devhub/views.py:82 src/olympia/devhub/templates/devhub/addons/edit/basic.html:20 src/olympia/editors/templates/editors/leaderboard.html:24
+#: src/olympia/bandwagon/views.py:98 src/olympia/bandwagon/views.py:191 src/olympia/browse/views.py:58 src/olympia/browse/views.py:69 src/olympia/browse/views.py:425 src/olympia/devhub/views.py:72
+#: src/olympia/devhub/views.py:80 src/olympia/devhub/templates/devhub/addons/edit/basic.html:20 src/olympia/editors/templates/editors/leaderboard.html:24
 #: src/olympia/editors/templates/editors/themes/queue_list.html:48 src/olympia/search/forms.py:17 src/olympia/search/forms.py:89 src/olympia/users/templates/users/vcard.html:5
 msgid "Name"
 msgstr "Navn"
@@ -2195,7 +2218,7 @@ msgstr "Navn"
 msgid "Recently Popular"
 msgstr "Populære i det siste"
 
-#: src/olympia/bandwagon/views.py:189 src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:18
+#: src/olympia/bandwagon/views.py:189 src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:16
 msgid "Added"
 msgstr "Lagt til"
 
@@ -2209,7 +2232,7 @@ msgstr "Samling opprettet!"
 
 #: src/olympia/bandwagon/views.py:316
 #, python-format
-msgid "Your new collection is shown below. You can <ahref=\"%(url)s\">edit additional settings</a> if you'dlike."
+msgid "Your new collection is shown below. You can <a href=\"%(url)s\">edit additional settings</a> if you'd like."
 msgstr ""
 
 #: src/olympia/bandwagon/views.py:322
@@ -2337,8 +2360,8 @@ msgid_plural "%(num)s Add-ons in this Collection"
 msgstr[0] "%(num)s utvidelse i denne samlingen"
 msgstr[1] "%(num)s utvidelser i denne samlingen"
 
-#: src/olympia/bandwagon/templates/bandwagon/collection_detail.html:125 src/olympia/compat/templates/compat/index.html:25 src/olympia/compat/templates/compat/reporter_detail.html:29
-#: src/olympia/files/templates/files/viewer.html:29 src/olympia/templates/amo_footer.html:17 src/olympia/templates/includes/lang_switcher.html:10
+#: src/olympia/bandwagon/templates/bandwagon/collection_detail.html:125 src/olympia/compat/templates/compat/reporter_detail.html:29 src/olympia/files/templates/files/viewer.html:29
+#: src/olympia/templates/amo_footer.html:17 src/olympia/templates/includes/lang_switcher.html:10
 msgid "Go"
 msgstr "Gå"
 
@@ -2372,11 +2395,9 @@ msgstr ""
 
 #: src/olympia/bandwagon/templates/bandwagon/collection_detail.html:186
 msgid ""
-"Add-ons that you mark as favorites using the <b>Add to Favorites</b> feature appear below. This collection is currently <b>private</b>, which means only you can see it. If you would like everyone "
+"Add-ons that you mark as favorites using the <b>Add to Favorites</b> feature appear below. This collection is currently <b>private</b>, which means only you can see it.  If you would like everyone "
 "to be able to see your favorites, click the button below to make it public."
 msgstr ""
-"Utvidelser som du markerer som favoritter med <b>Legg til i favoritter</b> vises nedenfor. Denne samlingen er akkurat nå <b>privat</b>, som betyr at bare du kan se den. Dersom du ønsker at alle "
-"skal kunne se dine favoritter, trykk på knappen nedenfor for å gjøre den offentlig."
 
 #: src/olympia/bandwagon/templates/bandwagon/collection_detail.html:196
 msgid "My favorite add-ons"
@@ -2509,7 +2530,7 @@ msgid "Remove this user as a contributor"
 msgstr "Fjern denne brukeren som bidragsyter"
 
 #: src/olympia/bandwagon/templates/bandwagon/edit_contributors.html:18 src/olympia/bandwagon/templates/bandwagon/edit_contributors.html:43
-#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:20 src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:48
+#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:18 src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:46
 #: src/olympia/devhub/templates/devhub/addons/ajax_compat_update.html:19
 msgid "Remove"
 msgstr "Fjern"
@@ -2520,11 +2541,9 @@ msgstr "Bidragsytere til samlingen"
 
 #: src/olympia/bandwagon/templates/bandwagon/edit_contributors.html:26
 msgid ""
-"You can add multiple contributors to this collection. A contributor can add and remove add-ons from this collection, but cannot change its name or description. To add a contributor, enter their "
+"You can add multiple contributors to this collection.  A contributor can add and remove add-ons from this collection, but cannot change its name or description.  To add a contributor, enter their "
 "email in the box below. Contributors must have a Mozilla Add-ons account."
 msgstr ""
-"Du kan legge til flere bidragsytere til denne samlingen. En bidragsyter kan legge til og fjerne utvidelser til samlingen, men kan ikke endre navnet eller beskrivelsen. For å legge inn en "
-"bidragsyter, skriv inn e-postadressen deres i boksen nedenfor. Bidragsytere må ha en konto på Mozilla Add-ons."
 
 #: src/olympia/bandwagon/templates/bandwagon/edit_contributors.html:40
 msgid "User"
@@ -2559,7 +2578,7 @@ msgid "<b>Warning:</b> By changing the owner of this collection, you will no lon
 msgstr "<b>Advarsel</b>: Ved å endre eieren til denne samlingen vil du ikke lenger være i stand til å redigere den. Du vil bare kunne legge til og fjerne utvidelser fra den."
 
 #: src/olympia/bandwagon/templates/bandwagon/edit_contributors.html:83 src/olympia/devhub/templates/devhub/addons/forms_shared/media.html:157
-#: src/olympia/devhub/templates/devhub/addons/submit/describe.html:69 src/olympia/devhub/templates/devhub/addons/submit/license.html:60 src/olympia/devhub/templates/devhub/addons/submit/upload.html:78
+#: src/olympia/devhub/templates/devhub/addons/submit/describe.html:69 src/olympia/devhub/templates/devhub/addons/submit/license.html:60 src/olympia/devhub/templates/devhub/addons/submit/upload.html:70
 #: src/olympia/devhub/templates/devhub/payments/tier.html:17 src/olympia/editors/templates/editors/themes/themes.html:111 src/olympia/editors/templates/editors/themes/themes.html:128
 #: src/olympia/editors/templates/editors/themes/themes.html:134 src/olympia/editors/templates/editors/themes/themes.html:141 src/olympia/users/templates/users/fxa_migration_prompt_content.html:10
 #: src/olympia/users/templates/users/login_form.html:42 src/olympia/users/templates/users/mobile/login.html:57
@@ -2630,45 +2649,43 @@ msgid "Reset"
 msgstr "Tilbakestill"
 
 #: src/olympia/bandwagon/templates/bandwagon/includes/addedit.html:53
-msgid "PNG and JPG supported. Image will be resized to 32x32."
-msgstr "PNG og JPG er støttet. Bilde vil endres størrelse til 32x32."
+msgid "PNG and JPG supported.  Image will be resized to 32x32."
+msgstr ""
 
 #: src/olympia/bandwagon/templates/bandwagon/includes/addedit_errors.html:3
-msgid "There are errors in this form. Please correct them below."
-msgstr "Der er feil i skjemaet. Rett opp de først."
+msgid "There are errors in this form.  Please correct them below."
+msgstr ""
 
 #: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:2
 msgid "Add-ons in Your Collection"
 msgstr "Utvidelser i samlingen din"
 
 #: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:4
-msgid ""
-"To include an add-on in this collection, enter its name in the box below and hit enter. You can also use the <strong>Add to Collection</strong> links throughout the site to include add-ons later."
+msgid "To include an add-on in this collection, enter its name in the box below and hit enter."
 msgstr ""
-"For å ta med en utvidelse i denne samlingen, skriv inn navnet i boksen nedenfor og trykk enter. Du kan også bruke <strong>Legg til i samling</strong>-lenkene på dette nettstedet for å legge til "
-"utvidelser senere."
 
-#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:17 src/olympia/constants/base.py:400 src/olympia/devhub/templates/devhub/addons/activity.html:62
+#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:15 src/olympia/constants/base.py:400 src/olympia/devhub/templates/devhub/addons/activity.html:62
+#: src/olympia/editors/helpers.py:273 src/olympia/editors/helpers.py:360
 msgid "Add-on"
 msgstr "Utvidelse"
 
-#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:26
+#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:24
 msgid "Enter the name of the add-on to include"
 msgstr "Skriv inn navnet på utvidelsen du vil ta med"
 
-#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:28
+#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:26
 msgid "Add to Collection"
 msgstr "Legg til i samling"
 
-#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:45 src/olympia/editors/helpers.py:936 src/olympia/editors/helpers.py:956
+#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:43 src/olympia/editors/helpers.py:1016 src/olympia/editors/helpers.py:1036
 msgid "Pending"
 msgstr "Venter behandling"
 
-#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:47
+#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:45
 msgid "Add a comment"
 msgstr "Legg til kommentar"
 
-#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:48
+#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:46
 msgid "Remove this add-on from the collection"
 msgstr "Fjern denne utvidelsen fra denne samlingen"
 
@@ -2717,10 +2734,8 @@ msgstr "Den problematiske utvidelsen eller programtillegget vil automatisk slås
 #, python-format
 msgid ""
 "When Mozilla becomes aware of add-ons, plugins, or other third-party software that seriously compromises %(app)s security, stability, or performance and meets <a href=\"%(criteria)s\">certain "
-"criteria</a>, the software may be blocked from general use. For more information, please read <a href=\"%(support)s\">this support article</a>."
+"criteria</a>, the software may be blocked from general use.  For more information, please read <a href=\"%(support)s\">this support article</a>."
 msgstr ""
-"Når Mozilla blir kjent med utvidelser, programtillegg eller annen tredjeparts programvare som kompromitterer %(app)s sin sikkerhet, stabilitet eller ytelse, og samtidig er innenfor <a href="
-"\"%(criteria)s\">forskjellige kriterier</a>, kan programmet bli blokkert fra generell bruk. For mer informasjon om dette, les <a href=\"%(support)s\">brukerstøtteartikkelen</a>."
 
 #: src/olympia/blocklist/templates/blocklist/blocked_detail.html:44
 #, python-format
@@ -2777,12 +2792,12 @@ msgstr "Søkeverktøy"
 msgid "Most Users"
 msgstr "Flest brukere"
 
-#: src/olympia/browse/views.py:61 src/olympia/browse/views.py:72 src/olympia/browse/views.py:279 src/olympia/browse/templates/browse/personas/mobile/category_landing.html:63
+#: src/olympia/browse/views.py:61 src/olympia/browse/views.py:72 src/olympia/browse/views.py:246 src/olympia/browse/templates/browse/personas/mobile/category_landing.html:63
 #: src/olympia/discovery/templates/discovery/pane.html:67 src/olympia/search/forms.py:92
 msgid "Up & Coming"
 msgstr "Fremgangsrike"
 
-#: src/olympia/browse/views.py:460 src/olympia/devhub/views.py:76 src/olympia/devhub/views.py:83 src/olympia/discovery/templates/discovery/addons/detail.html:66
+#: src/olympia/browse/views.py:427 src/olympia/devhub/views.py:74 src/olympia/devhub/views.py:81 src/olympia/discovery/templates/discovery/addons/detail.html:66
 msgid "Created"
 msgstr "Opprettet"
 
@@ -2970,8 +2985,8 @@ msgid_plural "See all %(cnt)s extensions in %(name)s &raquo;"
 msgstr[0] "Se %(cnt)s utvidelse i %(name)s &raquo;"
 msgstr[1] "Se alle %(cnt)s utvidelser i %(name)s &raquo;"
 
-#: src/olympia/browse/templates/browse/mobile/extensions.html:13 src/olympia/compat/templates/compat/index.html:82 src/olympia/devhub/templates/devhub/devhub_search.html:24
-#: src/olympia/devhub/templates/devhub/addons/activity.html:47 src/olympia/search/templates/search/no_results.html:4 src/olympia/search/templates/search/mobile/results.html:36
+#: src/olympia/browse/templates/browse/mobile/extensions.html:13 src/olympia/devhub/templates/devhub/devhub_search.html:24 src/olympia/devhub/templates/devhub/addons/activity.html:47
+#: src/olympia/search/templates/search/no_results.html:4 src/olympia/search/templates/search/mobile/results.html:36
 msgid "No results found."
 msgstr "Ingen resultater."
 
@@ -3056,7 +3071,7 @@ msgstr "&laquo; alle temaer"
 msgid "All"
 msgstr "Alle"
 
-#: src/olympia/compat/forms.py:22 src/olympia/search/views.py:525
+#: src/olympia/compat/forms.py:22 src/olympia/editors/templates/editors/base.html:69 src/olympia/search/views.py:518
 msgid "All Add-ons"
 msgstr "Alle utvidelser"
 
@@ -3067,53 +3082,6 @@ msgstr "Binær"
 #: src/olympia/compat/forms.py:24
 msgid "Non-binary"
 msgstr "Ikke-binær"
-
-#. Review points sources other than add-ons and themes.
-#: src/olympia/compat/views.py:87 src/olympia/constants/base.py:388 src/olympia/devhub/forms.py:162 src/olympia/editors/templates/editors/performance.html:75
-msgid "Other"
-msgstr "Annet"
-
-#: src/olympia/compat/templates/compat/index.html:4
-msgid "Add-on Compatibility Report for {app} {version}"
-msgstr "Utvidelseskompatibilitetsrapport for {app} {version}"
-
-#: src/olympia/compat/templates/compat/index.html:11
-msgid "{app} {version} Compatibility"
-msgstr "{app} {version} kompatibilitet"
-
-#: src/olympia/compat/templates/compat/index.html:17
-#, python-format
-msgid "Top 95%% compatible with previous version"
-msgstr ""
-
-#: src/olympia/compat/templates/compat/index.html:18
-#, python-format
-msgid "Top 95%% of all add-ons"
-msgstr ""
-
-#: src/olympia/compat/templates/compat/index.html:19
-msgid "All active add-ons"
-msgstr "Alle aktive utvidelser"
-
-#: src/olympia/compat/templates/compat/index.html:23 src/olympia/constants/base.py:401
-msgid "App"
-msgstr "App"
-
-#: src/olympia/compat/templates/compat/index.html:55
-msgid "Details for add-ons compatible with previous version:"
-msgstr "Detaljer for utvidelser som er kompatible med forrige versjon:"
-
-#: src/olympia/compat/templates/compat/index.html:57
-msgid "Show all versions"
-msgstr "Vis alle versjoner"
-
-#: src/olympia/compat/templates/compat/index.html:59
-msgid "Details for add-ons compatible with all versions:"
-msgstr "Detaljer for utvidelser som er kompatible med alle versjoner:"
-
-#: src/olympia/compat/templates/compat/index.html:61
-msgid "Show previous version only"
-msgstr "Vis kun forrige versjon"
 
 #: src/olympia/compat/templates/compat/reporter.html:3
 msgid "Add-on Compatibility Reports"
@@ -3168,8 +3136,8 @@ msgstr "Filtrer etter program"
 msgid "Report Type"
 msgstr "Rapporttype"
 
-#: src/olympia/compat/templates/compat/reporter_detail.html:47 src/olympia/devhub/forms.py:784 src/olympia/devhub/templates/devhub/addons/ajax_compat_update.html:17 src/olympia/editors/forms.py:108
-#: src/olympia/zadmin/forms.py:45
+#: src/olympia/compat/templates/compat/reporter_detail.html:47 src/olympia/devhub/forms.py:785 src/olympia/devhub/templates/devhub/addons/ajax_compat_update.html:17 src/olympia/editors/forms.py:108
+#: src/olympia/editors/forms.py:248 src/olympia/zadmin/forms.py:45
 msgid "Application"
 msgstr "Program"
 
@@ -3257,7 +3225,8 @@ msgstr "Foreløpig gjennomgått"
 msgid "Preliminarily Reviewed and Awaiting Full Review"
 msgstr "Foreløpig gjennomgått og venter på full gjennomgang"
 
-#: src/olympia/constants/base.py:33 src/olympia/editors/helpers.py:924 src/olympia/editors/templates/editors/themes/history_table.html:34
+#: src/olympia/constants/base.py:33 src/olympia/editors/forms.py:258 src/olympia/editors/helpers.py:73 src/olympia/editors/helpers.py:1004
+#: src/olympia/editors/templates/editors/themes/history_table.html:34
 msgid "Deleted"
 msgstr "Slettet"
 
@@ -3354,6 +3323,11 @@ msgstr "Spør etter brukere starter å laste ned denne utvidelsen"
 msgid "Ask before users can download this add-on"
 msgstr "Spør før brukere kan laste ned denne utvidelsen"
 
+#. Review points sources other than add-ons and themes.
+#: src/olympia/constants/base.py:388 src/olympia/devhub/forms.py:162 src/olympia/editors/templates/editors/performance.html:75
+msgid "Other"
+msgstr "Annet"
+
 #: src/olympia/constants/base.py:389
 msgid "Exception"
 msgstr "Unntak"
@@ -3365,6 +3339,10 @@ msgstr "Utgivelse"
 #: src/olympia/constants/base.py:391
 msgid "Change"
 msgstr "Endre"
+
+#: src/olympia/constants/base.py:401
+msgid "App"
+msgstr "App"
 
 #: src/olympia/constants/base.py:402
 msgid "Persona"
@@ -3514,7 +3492,7 @@ msgstr ""
 msgid "Duplicate"
 msgstr ""
 
-#: src/olympia/constants/editors.py:17 src/olympia/editors/helpers.py:502 src/olympia/editors/templates/editors/themes/queue.html:71 src/olympia/editors/templates/editors/themes/themes.html:94
+#: src/olympia/constants/editors.py:17 src/olympia/editors/helpers.py:575 src/olympia/editors/templates/editors/themes/queue.html:71 src/olympia/editors/templates/editors/themes/themes.html:94
 msgid "Reject"
 msgstr ""
 
@@ -3615,7 +3593,7 @@ msgstr "Solaris"
 msgid "Android"
 msgstr "Android"
 
-#: src/olympia/core/apps.py:19
+#: src/olympia/core/apps.py:21
 msgid "Core"
 msgstr ""
 
@@ -3749,7 +3727,7 @@ msgid "Submit my add-on for manual review."
 msgstr ""
 
 #: src/olympia/devhub/forms.py:537
-msgid "Do not list my add-on on this site (beta)"
+msgid "Do not list my add-on on this site"
 msgstr ""
 
 #: src/olympia/devhub/forms.py:538
@@ -3782,46 +3760,46 @@ msgstr ""
 
 #: src/olympia/devhub/forms.py:592
 #, python-format
-msgid "Version %s already exists"
-msgstr "Versjon %s finnes allerede"
+msgid "Version %s already exists, or was uploaded before."
+msgstr ""
 
-#: src/olympia/devhub/forms.py:604
+#: src/olympia/devhub/forms.py:605
 msgid "Select a valid choice. That choice is not one of the available choices."
 msgstr ""
 
-#: src/olympia/devhub/forms.py:610
+#: src/olympia/devhub/forms.py:611
 msgid "A file with a version ending with a|alpha|b|beta and an optional number is detected as beta."
 msgstr ""
 
-#: src/olympia/devhub/forms.py:633
+#: src/olympia/devhub/forms.py:634
 msgid "You cannot upload any more files for this version."
 msgstr "Du kan ikke laste opp flere filer for denne versjonen."
 
-#: src/olympia/devhub/forms.py:639
+#: src/olympia/devhub/forms.py:640
 msgid "Version doesn't match"
 msgstr "Versjon stemmer ikke"
 
-#: src/olympia/devhub/forms.py:668
-msgid "You cannot delete a file once the review process has started. You must delete the whole version."
-msgstr "Du kan ikke slette en fil når gjennomgangsprosessen har startet. Du må slette hele versjonen."
+#: src/olympia/devhub/forms.py:669
+msgid "You cannot delete a file once the review process has started.  You must delete the whole version."
+msgstr ""
 
-#: src/olympia/devhub/forms.py:688
+#: src/olympia/devhub/forms.py:689
 msgid "The platform All cannot be combined with specific platforms."
 msgstr "Plattformen \"Alle\" kan ikke kombineres med spesifikke plattformer."
 
-#: src/olympia/devhub/forms.py:693
+#: src/olympia/devhub/forms.py:694
 msgid "A platform can only be chosen once."
 msgstr "En plattform kan bare velges én gang."
 
-#: src/olympia/devhub/forms.py:706
+#: src/olympia/devhub/forms.py:707
 msgid "A review type must be selected."
 msgstr "En omtaletype må være valgt."
 
-#: src/olympia/devhub/forms.py:788 src/olympia/editors/forms.py:114 src/olympia/zadmin/forms.py:49 src/olympia/zadmin/forms.py:52
+#: src/olympia/devhub/forms.py:789 src/olympia/editors/forms.py:114 src/olympia/editors/forms.py:254 src/olympia/zadmin/forms.py:49 src/olympia/zadmin/forms.py:52
 msgid "Select an application first"
 msgstr ""
 
-#: src/olympia/devhub/forms.py:840
+#: src/olympia/devhub/forms.py:841
 msgid "There cannot be more than 3 required add-ons."
 msgstr ""
 
@@ -3855,76 +3833,76 @@ msgstr[1] ""
 msgid "Review"
 msgstr ""
 
-#: src/olympia/devhub/tasks.py:551
+#: src/olympia/devhub/tasks.py:583
 #, python-format
 msgid "%s responded with %s (%s)."
 msgstr ""
 
-#: src/olympia/devhub/tasks.py:555
+#: src/olympia/devhub/tasks.py:587
 #, python-format
 msgid "Connection to \"%s\" timed out."
 msgstr ""
 
-#: src/olympia/devhub/tasks.py:557
+#: src/olympia/devhub/tasks.py:589
 #, python-format
 msgid "Could not contact host at \"%s\"."
 msgstr ""
 
-#: src/olympia/devhub/utils.py:104
+#: src/olympia/devhub/utils.py:105
 #, python-format
 msgid "Validation generated too many errors/warnings so %s messages were truncated. After addressing the visible messages, you'll be able to see the others."
 msgstr ""
 
-#: src/olympia/devhub/views.py:183
+#: src/olympia/devhub/views.py:181
 msgid "All My Add-ons"
 msgstr ""
 
-#: src/olympia/devhub/views.py:210
+#: src/olympia/devhub/views.py:208
 msgid "All Activity"
 msgstr ""
 
-#: src/olympia/devhub/views.py:211
+#: src/olympia/devhub/views.py:209
 msgid "Add-on Updates"
 msgstr ""
 
-#: src/olympia/devhub/views.py:212
+#: src/olympia/devhub/views.py:210
 msgid "Add-on Status"
 msgstr ""
 
-#: src/olympia/devhub/views.py:213
+#: src/olympia/devhub/views.py:211
 msgid "User Collections"
 msgstr ""
 
-#: src/olympia/devhub/views.py:214 src/olympia/devhub/templates/devhub/docs/policies-maintenance.html:68 src/olympia/pages/templates/pages/dev_faq.html:38
+#: src/olympia/devhub/views.py:212 src/olympia/devhub/templates/devhub/docs/policies-maintenance.html:68 src/olympia/pages/templates/pages/dev_faq.html:38
 #: src/olympia/pages/templates/pages/dev_faq.html:484
 msgid "User Reviews"
 msgstr ""
 
-#: src/olympia/devhub/views.py:327 src/olympia/devhub/views.py:331 src/olympia/devhub/views.py:484 src/olympia/devhub/views.py:513 src/olympia/devhub/views.py:564 src/olympia/devhub/views.py:1150
+#: src/olympia/devhub/views.py:325 src/olympia/devhub/views.py:329 src/olympia/devhub/views.py:484 src/olympia/devhub/views.py:513 src/olympia/devhub/views.py:564 src/olympia/devhub/views.py:1156
 msgid "Changes successfully saved."
 msgstr ""
 
-#: src/olympia/devhub/views.py:334 src/olympia/devhub/views.py:1631
+#: src/olympia/devhub/views.py:332 src/olympia/devhub/views.py:1637
 msgid "Please check the form for errors."
 msgstr ""
 
-#: src/olympia/devhub/views.py:346
+#: src/olympia/devhub/views.py:344
 msgid "Add-on cannot be deleted. Disable this add-on instead."
 msgstr ""
 
-#: src/olympia/devhub/views.py:356
+#: src/olympia/devhub/views.py:354
 msgid "Theme deleted."
 msgstr ""
 
-#: src/olympia/devhub/views.py:356
+#: src/olympia/devhub/views.py:354
 msgid "Add-on deleted."
 msgstr ""
 
-#: src/olympia/devhub/views.py:362
+#: src/olympia/devhub/views.py:360
 msgid "URL name was incorrect. Theme was not deleted."
 msgstr ""
 
-#: src/olympia/devhub/views.py:367
+#: src/olympia/devhub/views.py:365
 msgid "URL name was incorrect. Add-on was not deleted."
 msgstr ""
 
@@ -3952,7 +3930,7 @@ msgstr ""
 msgid "Check Add-on Compatibility"
 msgstr ""
 
-#: src/olympia/devhub/views.py:808 src/olympia/signing/views.py:90
+#: src/olympia/devhub/views.py:808 src/olympia/signing/views.py:95
 msgid "You cannot submit this type of add-on"
 msgstr ""
 
@@ -3982,33 +3960,33 @@ msgstr ""
 msgid "There was an error uploading your preview."
 msgstr ""
 
-#: src/olympia/devhub/views.py:1189
+#: src/olympia/devhub/views.py:1195
 #, python-format
 msgid "Version %s disabled."
 msgstr ""
 
-#: src/olympia/devhub/views.py:1193
+#: src/olympia/devhub/views.py:1199
 #, python-format
 msgid "Version %s deleted."
 msgstr ""
 
-#: src/olympia/devhub/views.py:1203
+#: src/olympia/devhub/views.py:1209
 msgid "This upload has failed validation, and may lack complete validation results. Please take due care when reviewing it."
 msgstr ""
 
-#: src/olympia/devhub/views.py:1677
+#: src/olympia/devhub/views.py:1683
 msgid "Preliminary Review Requested."
 msgstr ""
 
-#: src/olympia/devhub/views.py:1678
+#: src/olympia/devhub/views.py:1684
 msgid "Full Review Requested."
 msgstr ""
 
-#: src/olympia/devhub/views.py:1779
+#: src/olympia/devhub/views.py:1783
 msgid "Your old credentials were revoked and are no longer valid. Be sure to update all API clients with the new credentials."
 msgstr ""
 
-#: src/olympia/devhub/views.py:1797
+#: src/olympia/devhub/views.py:1801
 msgid "New API key created"
 msgstr ""
 
@@ -4038,7 +4016,7 @@ msgstr ""
 msgid "{0} :: Search"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/devhub_search.html:6 src/olympia/devhub/templates/devhub/search.html:8 src/olympia/editors/forms.py:435 src/olympia/editors/forms.py:437
+#: src/olympia/devhub/templates/devhub/devhub_search.html:6 src/olympia/devhub/templates/devhub/search.html:8 src/olympia/editors/forms.py:534 src/olympia/editors/forms.py:536
 #: src/olympia/editors/templates/editors/queue.html:27 src/olympia/editors/templates/editors/themes/queue_list.html:14 src/olympia/search/templates/search/collections.html:17
 #: src/olympia/search/templates/search/personas.html:18 src/olympia/search/templates/search/results.html:18 src/olympia/search/templates/search/mobile/results.html:8
 #: src/olympia/templates/search.html:14 src/olympia/templates/impala/search.html:18
@@ -4098,12 +4076,12 @@ msgstr ""
 msgid "Start Making Add-ons"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/index.html:86 src/olympia/devhub/templates/devhub/addons/listing/items.html:25 src/olympia/devhub/templates/devhub/includes/addon_details.html:15
+#: src/olympia/devhub/templates/devhub/index.html:86 src/olympia/devhub/templates/devhub/addons/listing/items.html:25 src/olympia/devhub/templates/devhub/includes/addon_details.html:20
 #: src/olympia/devhub/templates/devhub/personas/edit.html:43
 msgid "Status:"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/index.html:90 src/olympia/devhub/templates/devhub/includes/addon_details.html:100
+#: src/olympia/devhub/templates/devhub/index.html:90 src/olympia/devhub/templates/devhub/includes/addon_details.html:87
 msgid "Visibility:"
 msgstr ""
 
@@ -4111,11 +4089,11 @@ msgstr ""
 msgid "Latest Version:"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/index.html:109 src/olympia/devhub/templates/devhub/includes/addon_details.html:145 src/olympia/devhub/templates/devhub/personas/edit.html:49
+#: src/olympia/devhub/templates/devhub/index.html:109 src/olympia/devhub/templates/devhub/includes/addon_details.html:131 src/olympia/devhub/templates/devhub/personas/edit.html:49
 msgid "Queue Position:"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/index.html:110 src/olympia/devhub/templates/devhub/includes/addon_details.html:146 src/olympia/devhub/templates/devhub/personas/edit.html:50
+#: src/olympia/devhub/templates/devhub/index.html:110 src/olympia/devhub/templates/devhub/includes/addon_details.html:132 src/olympia/devhub/templates/devhub/personas/edit.html:50
 #, python-format
 msgid "%(position)s of %(total)s"
 msgstr ""
@@ -4217,16 +4195,6 @@ msgstr ""
 msgid "Do you want your add-on to be distributed on this site?"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/validate_addon.html:49 src/olympia/devhub/templates/devhub/addons/submit/upload.html:30 src/olympia/devhub/templates/devhub/versions/add_file_modal.html:14
-#: src/olympia/devhub/templates/devhub/versions/add_file_modal.html:53 src/olympia/devhub/templates/devhub/versions/list.html:298
-msgid "Warning:"
-msgstr ""
-
-#: src/olympia/devhub/templates/devhub/validate_addon.html:50 src/olympia/devhub/templates/devhub/addons/submit/upload.html:31
-#, python-format
-msgid "Submission of unlisted add-ons for signing is currently in an open beta. Please <a href=\"%(url)s\" target=\"_blank\">report any bugs</a> that you encounter."
-msgstr ""
-
 #. first parameter is a filename like lorem-ipsum-1.0.2.xpi
 #: src/olympia/devhub/templates/devhub/validation.html:5
 msgid "Validation Results for {0}"
@@ -4301,7 +4269,7 @@ msgstr ""
 msgid "Update Compatibility"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/addons/ajax_compat_update.html:4
+#: src/olympia/devhub/templates/devhub/addons/ajax_compat_update.html:4 src/olympia/devhub/templates/devhub/versions/edit.html:45
 msgid "Adjusting application information here will allow users to install your add-on even if the install manifest in the package indicates that the add-on is incompatible."
 msgstr ""
 
@@ -4313,9 +4281,9 @@ msgstr ""
 msgid "Add Another Application&hellip;"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/addons/ajax_compat_update.html:38 src/olympia/devhub/templates/devhub/addons/owner.html:86 src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:46
-#: src/olympia/devhub/templates/devhub/versions/list.html:351 src/olympia/devhub/templates/devhub/versions/list.html:353 src/olympia/templates/impala/base.html:132
-#: src/olympia/templates/impala/base.html:143 src/olympia/templates/impala/base.html:161 src/olympia/templates/impala/base.html:171
+#: src/olympia/devhub/templates/devhub/addons/ajax_compat_update.html:38 src/olympia/devhub/templates/devhub/addons/owner.html:86 src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:45
+#: src/olympia/devhub/templates/devhub/versions/list.html:349 src/olympia/devhub/templates/devhub/versions/list.html:351 src/olympia/templates/impala/base.html:129
+#: src/olympia/templates/impala/base.html:140 src/olympia/templates/impala/base.html:158 src/olympia/templates/impala/base.html:168
 msgid "Close"
 msgstr ""
 
@@ -4349,7 +4317,7 @@ msgstr ""
 msgid "Manage Authors & License"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/addons/owner.html:29 src/olympia/editors/templates/editors/review.html:270
+#: src/olympia/devhub/templates/devhub/addons/owner.html:29 src/olympia/editors/helpers.py:362 src/olympia/editors/templates/editors/review.html:270
 msgid "Authors"
 msgstr ""
 
@@ -4418,17 +4386,11 @@ msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/basic.html:52
 msgid ""
-"A short explanation of your add-on's basic\n"
-"                          functionality that is displayed in search and browse\n"
-"                          listings, as well as at the top of your add-on's\n"
-"                          details page. It is only relevant for listed add-ons."
+"A short explanation of your add-on's basic functionality that is displayed in search and browse listings, as well as at the top of your add-on's details page. It is only relevant for listed add-ons."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/basic.html:73
-msgid ""
-"Categories are the primary way users browse through add-ons.\n"
-"                        Choose any that fit your add-on's functionality for the most\n"
-"                        exposure. It is only relevant for listed add-ons."
+msgid "Categories are the primary way users browse through add-ons. Choose any that fit your add-on's functionality for the most exposure. It is only relevant for listed add-ons."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/basic.html:90
@@ -4438,11 +4400,7 @@ msgid ""
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/basic.html:119
-msgid ""
-"Tags help users find your add-on and should be short\n"
-"                        descriptors such as tabs, toolbar, or twitter.  You\n"
-"                        may have a maximum of {0} tags. It is only relevant\n"
-"                        for listed add-ons."
+msgid "Tags help users find your add-on and should be short descriptors such as tabs, toolbar, or twitter. You may have a maximum of {0} tags. It is only relevant for listed add-ons."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/basic.html:129 src/olympia/devhub/templates/devhub/personas/edit.html:97 src/olympia/devhub/templates/devhub/personas/submit.html:46
@@ -4470,11 +4428,7 @@ msgid "Add-on Details for {0}"
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/details.html:22
-msgid ""
-"A longer explanation of features,\n"
-"                          functionality, and other relevant information. This\n"
-"                          field is only displayed on the add-on's details\n"
-"                          page. It is only relevant for listed add-ons."
+msgid "A longer explanation of features, functionality, and other relevant information. This field is only displayed on the add-on's details page. It is only relevant for listed add-ons."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/details.html:44 src/olympia/translations/templates/translations/trans-menu.html:13
@@ -4482,10 +4436,7 @@ msgid "Default Locale"
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/details.html:45
-msgid ""
-"Information about your add-on is displayed in this locale\n"
-"                        unless you override it with a locale-specific translation.\n"
-"                        It is only relevant for listed add-ons."
+msgid "Information about your add-on is displayed in this locale unless you override it with a locale-specific translation. It is only relevant for listed add-ons."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/details.html:61 src/olympia/users/forms.py:311 src/olympia/users/templates/users/edit.html:122 src/olympia/users/templates/users/register.html:57
@@ -4495,10 +4446,8 @@ msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/details.html:63
 msgid ""
-"If your add-on has another homepage, enter its\n"
-"                          address here. If your website is localized into other\n"
-"                          languages multiple translations of this field can be\n"
-"                          added. It is only relevant for listed add-ons."
+"If your add-on has another homepage, enter its address here. If your website is localized into other languages multiple translations of this field can be added. It is only relevant for listed add-"
+"ons."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/media.html:3
@@ -4516,19 +4465,14 @@ msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/support.html:22
 msgid ""
-"If you wish to display an e-mail address for support\n"
-"                          inquiries, enter it here. If you have different\n"
-"                          addresses for each language multiple translations of\n"
-"                          this field can be added. It is only relevant for\n"
-"                          listed add-ons."
+"If you wish to display an e-mail address for support inquiries, enter it here. If you have different addresses for each language multiple translations of this field can be added. It is only "
+"relevant for listed add-ons."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/support.html:45
 msgid ""
-"If your add-on has a support website or forum, enter\n"
-"                          its address here. If your website is localized into\n"
-"                          other languages, multiple translations of this field can\n"
-"                          be added. It is only relevant for listed add-ons."
+"If your add-on has a support website or forum, enter its address here. If your website is localized into other languages, multiple translations of this field can be added. It is only relevant for "
+"listed add-ons."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:6
@@ -4542,11 +4486,8 @@ msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:23
 msgid ""
-"Any information end users may want to know that isn't\n"
-"                          necessarily applicable to the add-on summary or description.\n"
-"                          Common uses include listing known major bugs, information on\n"
-"                          how to report bugs, anticipated release date of a new version,\n"
-"                          etc. It is only relevant for listed add-ons."
+"Any information end users may want to know that isn't necessarily applicable to the add-on summary or description. Common uses include listing known major bugs, information on how to report bugs, "
+"anticipated release date of a new version, etc. It is only relevant for listed add-ons."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:46
@@ -4558,9 +4499,7 @@ msgid "Add-on Flags"
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:69
-msgid ""
-"These flags are used to classify add-ons. It is only\n"
-"                        relevant for listed add-ons."
+msgid "These flags are used to classify add-ons. It is only relevant for listed add-ons."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:74
@@ -4576,9 +4515,7 @@ msgid "View Source?"
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:90
-msgid ""
-"Whether the source of your add-on can be displayed in our\n"
-"                        online viewer. It is only relevant for listed add-ons."
+msgid "Whether the source of your add-on can be displayed in our online viewer. It is only relevant for listed add-ons."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:94
@@ -4594,10 +4531,7 @@ msgid "Public Stats?"
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:102
-msgid ""
-"Whether the download and usage stats of your add-on can\n"
-"                        be displayed in our online viewer.\n"
-"                        It is only relevant for listed add-ons."
+msgid "Whether the download and usage stats of your add-on can be displayed in our online viewer. It is only relevant for listed add-ons."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:107
@@ -4613,10 +4547,7 @@ msgid "Upgrade SDK?"
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:116
-msgid ""
-"If selected, we will try to automatically upgrade your\n"
-"                        add-on when a new version of the SDK is released.\n"
-"                        It is only relevant for listed add-ons."
+msgid "If selected, we will try to automatically upgrade your add-on when a new version of the SDK is released. It is only relevant for listed add-ons."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:121
@@ -4667,10 +4598,8 @@ msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/forms_shared/media.html:16
 msgid ""
-"Upload an icon for your add-on or choose from one of ours. The\n"
-"                      icon is displayed nearly everywhere your add-on is. Uploaded images\n"
-"                      must be one of the following image types: .png, .jpg.\n"
-"                      It is only relevant for listed add-ons."
+"Upload an icon for your add-on or choose from one of ours. The icon is displayed nearly everywhere your add-on is. Uploaded images must be one of the following image types: .png, .jpg. It is only "
+"relevant for listed add-ons."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/forms_shared/media.html:25
@@ -4683,9 +4612,7 @@ msgid "32x32px"
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/forms_shared/media.html:39
-msgid ""
-"Used in listings of add-ons, like search results\n"
-"                            and featured add-ons."
+msgid "Used in listings of add-ons, like search results and featured add-ons."
 msgstr ""
 
 #. The size of the icon
@@ -4780,16 +4707,14 @@ msgid "Deleting your add-on will permanently remove it from the site and prevent
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:24
-msgid ""
-"Enter the following text confirm your decision:\n"
-"           {slug}"
+msgid "Enter the following text confirm your decision: {slug}"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:34
+#: src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:33
 msgid "Please tell us why you are deleting your theme:"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:36
+#: src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:35
 msgid "Please tell us why you are deleting your add-on:"
 msgstr ""
 
@@ -4826,8 +4751,8 @@ msgstr ""
 msgid "Daily statistics on downloads and users."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/addons/listing/item_actions.html:45 src/olympia/stats/templates/stats/stats.html:75 src/olympia/stats/templates/stats/stats.html:79
-#: src/olympia/stats/templates/stats/stats.html:81
+#: src/olympia/devhub/templates/devhub/addons/listing/item_actions.html:45 src/olympia/stats/templates/stats/stats.html:31 src/olympia/stats/templates/stats/stats.html:35
+#: src/olympia/stats/templates/stats/stats.html:37
 msgid "Statistics"
 msgstr "Statistikk"
 
@@ -4946,10 +4871,7 @@ msgid "Your add-on has been submitted to the Full Review queue."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/submit/done.html:18
-msgid ""
-"You'll receive an email once it has been reviewed by an editor. In\n"
-"          the meantime, you and your friends can install it directly from its\n"
-"          details page:"
+msgid "You'll receive an email once it has been reviewed by an editor. In the meantime, you and your friends can install it directly from its details page:"
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/submit/done.html:27 src/olympia/devhub/templates/devhub/addons/submit/done.html:77 src/olympia/devhub/templates/devhub/personas/submit_done.html:16
@@ -5155,11 +5077,11 @@ msgstr ""
 msgid "Use the fields below to upload your add-on package and select any platform restrictions. After upload, a series of automated validation tests will be run on your file."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/addons/submit/upload.html:59 src/olympia/devhub/templates/devhub/versions/add_file_modal.html:39
+#: src/olympia/devhub/templates/devhub/addons/submit/upload.html:51 src/olympia/devhub/templates/devhub/versions/add_file_modal.html:28
 msgid "Which platforms is this file compatible with?"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/addons/submit/upload.html:67 src/olympia/devhub/templates/devhub/versions/add_file_modal.html:65
+#: src/olympia/devhub/templates/devhub/addons/submit/upload.html:59 src/olympia/devhub/templates/devhub/versions/add_file_modal.html:45
 msgid "Administrative overrides"
 msgstr ""
 
@@ -5269,8 +5191,8 @@ msgstr ""
 
 #: src/olympia/devhub/templates/devhub/docs/policies-contact.html:44
 msgid ""
-"If you've found a problem with the site, we'd love to fix it. Please <a href=\"https://github.com/mozilla/olympia/issues\">file a bug report</a> in GitHub, including the location of the problem and "
-"how you encountered it."
+"If you've found a problem with the site, we'd love to fix it. Please <a href=\"https://github.com/mozilla/addons/issues/new\">file a bug report</a> in GitHub, including the location of the problem "
+"and how you encountered it."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/docs/policies-maintenance.html:3 src/olympia/devhub/templates/devhub/docs/policies-maintenance.html:7
@@ -5837,7 +5759,7 @@ msgstr ""
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:282
 msgid ""
-"Add-ons that store or otherwise handle browsing data must support <a href=\"https://developer.mozilla.org/En/Supporting_private_browsing_mode\">Private Browsing Mode</a>.  During a Private Browsing "
+"Add-ons that store or otherwise handle browsing data must support <a href=\"https://developer.mozilla.org/En/Supporting_private_browsing_mode\">Private Browsing Mode</a>. During a Private Browsing "
 "session, no browsing data can be written to disk, and all of this data must be cleared when Firefox quits or the Private Browsing session ends."
 msgstr ""
 
@@ -6002,129 +5924,95 @@ msgstr ""
 msgid "How to get in touch with us regarding these policies or your add-on."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:6
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:10
 msgid "You have disabled this add-on"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:20
-msgid ""
-"Your add-on's listing is disabled and is not showing\n"
-"                             anywhere in our gallery or update service."
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:24
+msgid "Your add-on's listing is disabled and is not showing anywhere in our gallery or update service."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:25
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:27
 msgid "Please complete your add-on."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:29
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:30
 msgid "You will receive an email when the review is complete."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:34
-msgid ""
-"You will receive an email when the review is complete. Until\n"
-"                             then, your add-on is not listed in our gallery but can be\n"
-"                             accessed directly from its details page."
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:33
+msgid "You will receive an email when the review is complete. Until then, your add-on is not listed in our gallery but can be accessed directly from its details page."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:38 src/olympia/devhub/templates/devhub/includes/addon_details.html:48
-msgid ""
-"You will receive an email when the review is\n"
-"                             complete and your add-on is signed."
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:37 src/olympia/devhub/templates/devhub/includes/addon_details.html:45
+msgid "You will receive an email when the review is complete and your add-on is signed."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:44
-msgid ""
-"You will receive an email when the review is complete. Until\n"
-"                             then, your add-on is not listed in our gallery but can be\n"
-"                             accessed directly from its details page. "
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:41
+msgid "You will receive an email when the review is complete. Until then, your add-on is not listed in our gallery but can be accessed directly from its details page. "
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:54
-msgid ""
-"Your add-on is displayed in our gallery and users are\n"
-"                             receiving automatic updates."
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:49
+msgid "Your add-on is displayed in our gallery and users are receiving automatic updates."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:57
-msgid ""
-"Your add-on has been signed and can be bundled with an\n"
-"                             application installer."
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:52
+msgid "Your add-on has been signed and can be bundled with an application installer."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:63
-msgid ""
-"Your add-on was disabled by a site administrator and is no\n"
-"                             longer shown in our gallery. If you have any questions,\n"
-"                             please email amo-admins@mozilla.org."
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:56
+msgid "Your add-on was disabled by a site administrator and is no longer shown in our gallery. If you have any questions, please email amo-admins@mozilla.org."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:70
-msgid ""
-"Your add-on is displayed in our gallery as experimental\n"
-"                             and users are receiving automatic updates. Some features\n"
-"                             are unavailable to your add-on."
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:62
+msgid "Your add-on is displayed in our gallery as experimental and users are receiving automatic updates. Some features are unavailable to your add-on."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:74
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:66
 msgid "Your add-on has been signed."
 msgstr ""
 
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:69
+msgid ""
+"You will receive an email when the full review is complete. Until then, your add-on is displayed in our gallery as experimental and users are receiving automatic updates. Some features are "
+"unavailable to your add-on."
+msgstr ""
+
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:74
+msgid "You will receive an email when the full review is complete, making you able to bundle your add-on with an application installer."
+msgstr ""
+
 #: src/olympia/devhub/templates/devhub/includes/addon_details.html:79
-msgid ""
-"You will receive an email when the full review is complete.\n"
-"                             Until then, your add-on is displayed in our gallery as\n"
-"                             experimental and users are receiving automatic updates.\n"
-"                             Some features are unavailable to your add-on."
+msgid "All add-ons hosted in our gallery must now be reviewed by an editor. If you wish to continue hosting your add-on, please click to select a review process."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:84
-msgid ""
-"You will receive an email when the full review is\n"
-"                             complete, making you able to bundle your add-on with an\n"
-"                             application installer."
-msgstr ""
-
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:91
-msgid ""
-"All add-ons hosted in our gallery must now be reviewed by an\n"
-"                             editor. If you wish to continue hosting your add-on, please\n"
-"                             click to select a review process."
-msgstr ""
-
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:113
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:100
 msgid "Current Version:"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:115
-msgid ""
-"This is the version of your add-on that will\n"
-"                                           be installed if someone clicks the Install\n"
-"                                           button on addons.mozilla.org. It is only\n"
-"                                           relevant for listed add-ons."
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:102
+msgid "This is the version of your add-on that will be installed if someone clicks the Install button on addons.mozilla.org. It is only relevant for listed add-ons."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:123
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:110
 msgid "Created:"
 msgstr ""
 
 #. {0} is a date. dennis-ignore: E201
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:125 src/olympia/devhub/templates/devhub/includes/addon_details.html:131
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:112 src/olympia/devhub/templates/devhub/includes/addon_details.html:118
 #, python-format
 msgid "%%b %%e, %%Y"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:136
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:123
 msgid "Next Version:"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:138
-msgid ""
-"This is the newest uploaded version, however\n"
-"                                           it isn’t live on the site yet."
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:125
+msgid "This is the newest uploaded version, however it isn’t live on the site yet."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:144 src/olympia/devhub/templates/devhub/versions/list.html:30
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:130 src/olympia/devhub/templates/devhub/versions/list.html:30
 msgid "Queues are not reviewed strictly in order"
 msgstr ""
 
@@ -6192,9 +6080,7 @@ msgid "View the blog &#9658;"
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/includes/license_form.html:6
-msgid ""
-"Please choose a license appropriate for the rights you grant on your source code.\n"
-"                  It is only relevant for listed add-ons."
+msgid "Please choose a license appropriate for the rights you grant on your source code. It is only relevant for listed add-ons."
 msgstr ""
 
 #. {0} is a list of HTML tags.
@@ -6221,14 +6107,11 @@ msgstr[1] ""
 #: src/olympia/devhub/templates/devhub/includes/policy_form.html:4
 msgid ""
 "Users will be required to accept the following End-User License Agreement (EULA) prior to installing your add-on. The presence of a EULA significantly affects the number of downloads an add-on "
-"receives. Please note that a EULA is not the same as a code license, such as the GPL or MPL.\n"
-"                It is only relevant for listed add-ons."
+"receives. Please note that a EULA is not the same as a code license, such as the GPL or MPL.It is only relevant for listed add-ons."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/policy_form.html:21
-msgid ""
-"If your add-on transmits any data from the user's computer, a privacy policy is required that explains what data is sent and how it is used.\n"
-"                It is only relevant for listed add-ons."
+#: src/olympia/devhub/templates/devhub/includes/policy_form.html:24
+msgid "If your add-on transmits any data from the user's computer, a privacy policy is required that explains what data is sent and how it is used. It is only relevant for listed add-ons."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/includes/source_form_field.html:2
@@ -6396,12 +6279,8 @@ msgstr ""
 msgid "Add some tags to describe your Theme."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/personas/edit.html:106
-msgid ""
-"A short explanation of your theme's\n"
-"                                basic functionality that is displayed in\n"
-"                                search and browse listings, as well as at\n"
-"                                the top of your theme's details page."
+#: src/olympia/devhub/templates/devhub/personas/edit.html:106 src/olympia/devhub/templates/devhub/personas/submit.html:54
+msgid "A short explanation of your theme's basic functionality that is displayed in search and browse listings, as well as at the top of your theme's details page."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/personas/edit.html:122 src/olympia/devhub/templates/devhub/personas/submit.html:68
@@ -6471,7 +6350,7 @@ msgid "Upon upload and form submission, the AMO Team will review your updated de
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/personas/edit.html:241
-msgid "Your previously resubmitted design,  which is under pending review."
+msgid "Your previously resubmitted design, which is under pending review."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/personas/edit.html:245
@@ -6538,14 +6417,6 @@ msgstr ""
 
 #: src/olympia/devhub/templates/devhub/personas/submit.html:33
 msgid "Give your Theme a name."
-msgstr ""
-
-#: src/olympia/devhub/templates/devhub/personas/submit.html:54
-msgid ""
-"A short explanation of your theme's\n"
-"                                      basic functionality that is displayed in\n"
-"                                      search and browse listings, as well as at\n"
-"                                      the top of your theme's details page."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/personas/submit.html:198
@@ -6622,30 +6493,16 @@ msgstr ""
 msgid "Files added to reviewed versions must be reviewed before they will be available for download."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/add_file_modal.html:15
-#, python-format
-msgid ""
-"Submission of updates to unlisted add-ons for signing is currently in an open beta. Manual review may still be required for a large number of add-ons. Please <a href=\"%(url)s\" target=\"_blank"
-"\">report any bugs</a> that you encounter."
-msgstr ""
-
-#: src/olympia/devhub/templates/devhub/versions/add_file_modal.html:35
+#: src/olympia/devhub/templates/devhub/versions/add_file_modal.html:24
 msgid "Select the target platform for this file."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/add_file_modal.html:46
+#: src/olympia/devhub/templates/devhub/versions/add_file_modal.html:35
 msgid "Which review type would you like to nominate for?"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/add_file_modal.html:51
+#: src/olympia/devhub/templates/devhub/versions/add_file_modal.html:40
 msgid "Only publish this version to my beta channel."
-msgstr ""
-
-#: src/olympia/devhub/templates/devhub/versions/add_file_modal.html:54
-#, python-format
-msgid ""
-"The behavior of the beta channel has changed to accommodate <a href=\"%(addon_signing_url)s\" target=\"_blank\">mandatory add-on signing</a>. The new process is currently in an open beta, and may "
-"change significantly in the near future. Please <a href=\"%(issues_url)s\" target=\"_blank\">report any bugs</a> that you encounter."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/versions/edit.html:5
@@ -6669,19 +6526,10 @@ msgstr ""
 msgid "Upload Another File"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/edit.html:45
-msgid ""
-"Adjusting application information here will allow users to install your\n"
-"                          add-on even if the install manifest in the package indicates that the\n"
-"                          add-on is incompatible."
-msgstr ""
-
 #: src/olympia/devhub/templates/devhub/versions/edit.html:74
 msgid ""
-"Information about changes in this release, new features,\n"
-"                              known bugs, and other useful information specific to this\n"
-"                              release/version. This information is also shown in the\n"
-"                              Add-ons Manager when updating."
+"Information about changes in this release, new features, known bugs, and other useful information specific to this release/version. This information is also shown in the Add-ons Manager when "
+"updating."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/versions/edit.html:99
@@ -6693,10 +6541,7 @@ msgid "Notes for Reviewers"
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/versions/edit.html:114
-msgid ""
-"Optionally, enter any information that may be useful\n"
-"                              to the Editor reviewing this add-on, such as test\n"
-"                              account information."
+msgid "Optionally, enter any information that may be useful to the Editor reviewing this add-on, such as test account information."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/versions/edit.html:127
@@ -6774,7 +6619,7 @@ msgstr ""
 msgid "Request Preliminary Review"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:80 src/olympia/devhub/templates/devhub/versions/list.html:327 src/olympia/devhub/templates/devhub/versions/list.html:350
+#: src/olympia/devhub/templates/devhub/versions/list.html:80 src/olympia/devhub/templates/devhub/versions/list.html:325 src/olympia/devhub/templates/devhub/versions/list.html:348
 msgid "Cancel Review Request"
 msgstr ""
 
@@ -6803,7 +6648,7 @@ msgid "Unlisted:"
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/versions/list.html:114
-msgid "Not distributed on {0}. Developers will upload new versions for signing and distribute the add-ons on their own. (beta)"
+msgid "Not distributed on {0}. Developers will upload new versions for signing and distribute the add-ons on their own."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/versions/list.html:122
@@ -6866,81 +6711,73 @@ msgid "<strong>Important:</strong> Once a version has been deleted, you may not 
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/versions/list.html:230
-msgid ""
-"Deleting a version which has already been reviewed\n"
-"               may also cause a significant delay in the review of\n"
-"               your next update."
-msgstr ""
-
-#: src/olympia/devhub/templates/devhub/versions/list.html:233
 msgid "Are you sure you wish to delete this version?"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:238
+#: src/olympia/devhub/templates/devhub/versions/list.html:235
 msgid "Delete Version"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:240
+#: src/olympia/devhub/templates/devhub/versions/list.html:237
 msgid "Disable Version"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:247
+#: src/olympia/devhub/templates/devhub/versions/list.html:244
 msgid "Add a new Version"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:249
+#: src/olympia/devhub/templates/devhub/versions/list.html:246
 msgid "Add Version"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:256 src/olympia/devhub/templates/devhub/versions/list.html:274
+#: src/olympia/devhub/templates/devhub/versions/list.html:253 src/olympia/devhub/templates/devhub/versions/list.html:279
 msgid "Hide Add-on"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:259
+#: src/olympia/devhub/templates/devhub/versions/list.html:256
 msgid "Hiding your add-on will prevent it from appearing anywhere in our gallery and will stop users from receiving automatic updates."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:265
+#: src/olympia/devhub/templates/devhub/versions/list.html:263
+msgid "The files awaiting review will be disabled and you will need to upload new versions."
+msgstr ""
+
+#: src/olympia/devhub/templates/devhub/versions/list.html:270
 msgid "Are you sure you wish to hide your add-on?"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:286 src/olympia/devhub/templates/devhub/versions/list.html:315
+#: src/olympia/devhub/templates/devhub/versions/list.html:291 src/olympia/devhub/templates/devhub/versions/list.html:313
 msgid "Unlist Add-on"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:289
+#: src/olympia/devhub/templates/devhub/versions/list.html:294
 #, python-format
 msgid ""
 "Unlisting your add-on will make it (and each of its versions/files) invisible on this website. It won't show up in searches, won't have a public facing page, and won't be updated automatically for "
-"current users.  It is recommended for unlisted add-ons to provide a custom <a href=\"%(update_url)s\" target=\"_blank\">updateURL</a> in their manifest file for automatic updates."
+"current users. It is recommended for unlisted add-ons to provide a custom <a href=\"%(update_url)s\" target=\"_blank\">updateURL</a> in their manifest file for automatic updates."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:299
-#, python-format
-msgid "Switching add-ons to unlisted is currently in an open beta. Please <a href=\"%(url)s\" target=\"_blank\">report any bugs</a> that you encounter."
-msgstr ""
-
-#: src/olympia/devhub/templates/devhub/versions/list.html:305
+#: src/olympia/devhub/templates/devhub/versions/list.html:303
 msgid "Unlisting an add-on is irreversible!"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:305
+#: src/olympia/devhub/templates/devhub/versions/list.html:303
 msgid "An unlisted add-on cannot be switched to be listed."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:307
+#: src/olympia/devhub/templates/devhub/versions/list.html:305
 msgid "Are you sure you wish to unlist your add-on?"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:330
+#: src/olympia/devhub/templates/devhub/versions/list.html:328
 msgid "Canceling your review request will leave your add-on as preliminarily reviewed."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:335
+#: src/olympia/devhub/templates/devhub/versions/list.html:333
 msgid "Canceling your review request will mark your add-on incomplete. If you do not complete your add-on after several days by re-requesting review, it will be deleted."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:343
+#: src/olympia/devhub/templates/devhub/versions/list.html:341
 msgid "Are you sure you wish to cancel your review request?"
 msgstr ""
 
@@ -7279,19 +7116,19 @@ msgstr ""
 msgid "Search by add-on name / author email"
 msgstr ""
 
-#: src/olympia/editors/forms.py:103
+#: src/olympia/editors/forms.py:103 src/olympia/editors/forms.py:244 src/olympia/editors/forms.py:257
 msgid "yes"
 msgstr ""
 
-#: src/olympia/editors/forms.py:104
+#: src/olympia/editors/forms.py:104 src/olympia/editors/forms.py:244 src/olympia/editors/forms.py:257
 msgid "no"
 msgstr ""
 
-#: src/olympia/editors/forms.py:105
+#: src/olympia/editors/forms.py:105 src/olympia/editors/forms.py:245
 msgid "Admin Flag"
 msgstr ""
 
-#: src/olympia/editors/forms.py:113
+#: src/olympia/editors/forms.py:113 src/olympia/editors/forms.py:253
 msgid "Max. Version"
 msgstr ""
 
@@ -7303,55 +7140,59 @@ msgstr ""
 msgid "Add-on Types"
 msgstr ""
 
-#: src/olympia/editors/forms.py:126 src/olympia/editors/helpers.py:267
+#: src/olympia/editors/forms.py:126 src/olympia/editors/helpers.py:279
 msgid "Platforms"
 msgstr ""
 
+#: src/olympia/editors/forms.py:237
+msgid "Search by add-on name / author email / guid"
+msgstr ""
+
 #. L10n: 0 = platform, 1 = filename, 2 = status message
-#: src/olympia/editors/forms.py:238
+#: src/olympia/editors/forms.py:342
 #, python-format
 msgid "<strong>%s</strong> &middot; %s &middot; %s"
 msgstr ""
 
-#: src/olympia/editors/forms.py:252
+#: src/olympia/editors/forms.py:356
 msgid "Comments:"
 msgstr ""
 
-#: src/olympia/editors/forms.py:256
+#: src/olympia/editors/forms.py:360
 msgid "Operating systems:"
 msgstr ""
 
-#: src/olympia/editors/forms.py:258
+#: src/olympia/editors/forms.py:362
 msgid "Applications:"
 msgstr ""
 
-#: src/olympia/editors/forms.py:260
+#: src/olympia/editors/forms.py:364
 msgid "Notify me the next time this add-on is updated. (Subsequent updates will not generate an email)"
 msgstr ""
 
-#: src/olympia/editors/forms.py:265
+#: src/olympia/editors/forms.py:369
 msgid "Clear Admin Review Flag"
 msgstr ""
 
-#: src/olympia/editors/forms.py:267
+#: src/olympia/editors/forms.py:371
 msgid "Clear more info requested flag"
 msgstr ""
 
-#: src/olympia/editors/forms.py:281
+#: src/olympia/editors/forms.py:385
 msgid "Choose a canned response..."
 msgstr ""
 
 #. L10n: Description of what can be searched for.
-#: src/olympia/editors/forms.py:324
+#: src/olympia/editors/forms.py:423
 msgid "theme name"
 msgstr ""
 
-#: src/olympia/editors/forms.py:350
+#: src/olympia/editors/forms.py:449
 msgid "Someone else is reviewing this theme."
 msgstr ""
 
 #. L10n: Description of what can be searched for.
-#: src/olympia/editors/forms.py:447
+#: src/olympia/editors/forms.py:546
 msgid "app, reviewer, or comment"
 msgstr ""
 
@@ -7367,246 +7208,264 @@ msgstr ""
 msgid "Rejected or Unreviewed"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:123 src/olympia/editors/helpers.py:136
+#: src/olympia/editors/helpers.py:125 src/olympia/editors/helpers.py:138
 msgid "Queue"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:124 src/olympia/editors/templates/editors/base.html:50 src/olympia/editors/templates/editors/base.html:65
+#: src/olympia/editors/helpers.py:126 src/olympia/editors/templates/editors/base.html:50 src/olympia/editors/templates/editors/base.html:65
 msgid "Pending Updates"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:125 src/olympia/editors/templates/editors/base.html:48 src/olympia/editors/templates/editors/base.html:63
+#: src/olympia/editors/helpers.py:127 src/olympia/editors/templates/editors/base.html:48 src/olympia/editors/templates/editors/base.html:63
 msgid "Full Reviews"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:126 src/olympia/editors/templates/editors/base.html:52 src/olympia/editors/templates/editors/base.html:67
+#: src/olympia/editors/helpers.py:128 src/olympia/editors/templates/editors/base.html:52 src/olympia/editors/templates/editors/base.html:67
 msgid "Preliminary Reviews"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:127 src/olympia/editors/templates/editors/base.html:54
+#: src/olympia/editors/helpers.py:129 src/olympia/editors/templates/editors/base.html:54
 msgid "Moderated Reviews"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:128 src/olympia/editors/templates/editors/base.html:46
+#: src/olympia/editors/helpers.py:130 src/olympia/editors/templates/editors/base.html:46
 msgid "Fast Track"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:130
+#: src/olympia/editors/helpers.py:132
 msgid "Pending Themes"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:131 src/olympia/editors/templates/editors/themes/queue.html:4
+#: src/olympia/editors/helpers.py:133 src/olympia/editors/templates/editors/themes/queue.html:4
 msgid "Flagged Themes"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:132
+#: src/olympia/editors/helpers.py:134
 msgid "Update Themes"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:137
+#: src/olympia/editors/helpers.py:139
 msgid "Unlisted Pending Updates"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:138
+#: src/olympia/editors/helpers.py:140
 msgid "Unlisted Full Reviews"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:139
+#: src/olympia/editors/helpers.py:141
 msgid "Unlisted Preliminary Reviews"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:170
+#: src/olympia/editors/helpers.py:142
+msgid "Unlisted All Add-ons"
+msgstr ""
+
+#: src/olympia/editors/helpers.py:173
 msgid "Fast Track ({0})"
 msgid_plural "Fast Track ({0})"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/olympia/editors/helpers.py:175
+#: src/olympia/editors/helpers.py:178
 msgid "Full Review ({0})"
 msgid_plural "Full Reviews ({0})"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/olympia/editors/helpers.py:180
+#: src/olympia/editors/helpers.py:183
 msgid "Pending Update ({0})"
 msgid_plural "Pending Updates ({0})"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/olympia/editors/helpers.py:185
+#: src/olympia/editors/helpers.py:188
 msgid "Preliminary Review ({0})"
 msgid_plural "Preliminary Reviews ({0})"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/olympia/editors/helpers.py:190
+#: src/olympia/editors/helpers.py:193
 msgid "Moderated Review ({0})"
 msgid_plural "Moderated Reviews ({0})"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/olympia/editors/helpers.py:196
+#: src/olympia/editors/helpers.py:199
 msgid "Unlisted Full Review ({0})"
 msgid_plural "Unlisted Full Reviews ({0})"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/olympia/editors/helpers.py:201
+#: src/olympia/editors/helpers.py:204
 msgid "Unlisted Pending Update ({0})"
 msgid_plural "Unlisted Pending Updates ({0})"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/olympia/editors/helpers.py:206
+#: src/olympia/editors/helpers.py:209
 msgid "Unlisted Preliminary Review ({0})"
 msgid_plural "Unlisted Preliminary Reviews ({0})"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/olympia/editors/helpers.py:261
-msgid "Addon"
-msgstr ""
+#: src/olympia/editors/helpers.py:214
+msgid "Unlisted All Add-ons ({0})"
+msgid_plural "Unlisted All Add-ons ({0})"
+msgstr[0] ""
+msgstr[1] ""
 
-#: src/olympia/editors/helpers.py:262
+#: src/olympia/editors/helpers.py:274
 msgid "Type"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:263
+#: src/olympia/editors/helpers.py:275
 msgid "Waiting Time"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:264 src/olympia/editors/templates/editors/review.html:285
+#: src/olympia/editors/helpers.py:276 src/olympia/editors/templates/editors/review.html:285
 msgid "Flags"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:265
+#: src/olympia/editors/helpers.py:277
 msgid "Applications"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:270
+#: src/olympia/editors/helpers.py:282
 msgid "Additional"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:285
+#: src/olympia/editors/helpers.py:302
 msgid "Site Specific"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:287
+#: src/olympia/editors/helpers.py:304
 msgid "Requires External Software"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:289
+#: src/olympia/editors/helpers.py:306
 msgid "Binary Components"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:313
+#: src/olympia/editors/helpers.py:339
 msgid "moments ago"
 msgstr ""
 
 #. L10n: first argument is number of minutes
-#: src/olympia/editors/helpers.py:316
+#: src/olympia/editors/helpers.py:342
 msgid "{0} minute"
 msgid_plural "{0} minutes"
 msgstr[0] ""
 msgstr[1] ""
 
 #. L10n: first argument is number of hours
-#: src/olympia/editors/helpers.py:320
+#: src/olympia/editors/helpers.py:346
 msgid "{0} hour"
 msgid_plural "{0} hours"
 msgstr[0] ""
 msgstr[1] ""
 
 #. L10n: first argument is number of days
-#: src/olympia/editors/helpers.py:324
+#: src/olympia/editors/helpers.py:350
 msgid "{0} day"
 msgid_plural "{0} days"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/olympia/editors/helpers.py:488
+#: src/olympia/editors/helpers.py:364
+msgid "Last Review"
+msgstr ""
+
+#: src/olympia/editors/helpers.py:366
+msgid "Last Update"
+msgstr ""
+
+#: src/olympia/editors/helpers.py:387
+msgid "No Reviews"
+msgstr ""
+
+#: src/olympia/editors/helpers.py:561
 msgid "Push to public"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:490
+#: src/olympia/editors/helpers.py:563
 msgid "Grant full review"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:505
+#: src/olympia/editors/helpers.py:578
 msgid "Request more information"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:508
+#: src/olympia/editors/helpers.py:581
 msgid "Request super-review"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:519
+#: src/olympia/editors/helpers.py:592
 msgid "Grant preliminary review"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:520
+#: src/olympia/editors/helpers.py:593
 msgid "This will mark the files as preliminarily reviewed."
 msgstr ""
 
-#: src/olympia/editors/helpers.py:522
+#: src/olympia/editors/helpers.py:595
 msgid "Use this form to request more information from the author. They will receive an email and be able to answer here. You will be notified by email when they reply."
 msgstr ""
 
-#: src/olympia/editors/helpers.py:526
+#: src/olympia/editors/helpers.py:599
 msgid ""
 "If you have concerns about this add-on's security, copyright issues, or other concerns that an administrator should look into, enter your comments in the area below. They will be sent to "
 "administrators, not the author."
 msgstr ""
 
-#: src/olympia/editors/helpers.py:532
+#: src/olympia/editors/helpers.py:605
 msgid "This will reject the add-on and remove it from the review queue."
 msgstr ""
 
-#: src/olympia/editors/helpers.py:534
-msgid "Make a comment on this version.  The author won't be able to see this."
+#: src/olympia/editors/helpers.py:607
+msgid "Make a comment on this version. The author won't be able to see this."
 msgstr ""
 
-#: src/olympia/editors/helpers.py:538
+#: src/olympia/editors/helpers.py:611
 msgid "This will reject the files and remove them from the review queue."
 msgstr ""
 
-#: src/olympia/editors/helpers.py:542
+#: src/olympia/editors/helpers.py:615
 msgid "This will mark the add-on as preliminarily reviewed. Future versions will undergo preliminary review."
 msgstr ""
 
-#: src/olympia/editors/helpers.py:547
+#: src/olympia/editors/helpers.py:620
 msgid "This will mark the files as preliminarily reviewed. Future versions will undergo preliminary review."
 msgstr ""
 
-#: src/olympia/editors/helpers.py:552
+#: src/olympia/editors/helpers.py:625
 msgid "Retain preliminary review"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:553
+#: src/olympia/editors/helpers.py:626
 msgid "This will retain the add-on as preliminarily reviewed. Future versions will undergo preliminary review."
 msgstr ""
 
-#: src/olympia/editors/helpers.py:558
+#: src/olympia/editors/helpers.py:631
 msgid "This will approve a sandboxed version of a public add-on to appear on the public side."
 msgstr ""
 
-#: src/olympia/editors/helpers.py:561
+#: src/olympia/editors/helpers.py:634
 msgid "This will reject a version of a public add-on and remove it from the queue."
 msgstr ""
 
-#: src/olympia/editors/helpers.py:564
+#: src/olympia/editors/helpers.py:637
 msgid "This will mark the add-on and its most recent version and files as public. Future versions will go into the sandbox until they are reviewed by an editor."
 msgstr ""
 
-#: src/olympia/editors/helpers.py:637
+#: src/olympia/editors/helpers.py:714
 msgid "add-on"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:940 src/olympia/editors/helpers.py:960
+#: src/olympia/editors/helpers.py:1020 src/olympia/editors/helpers.py:1040
 msgid "Flagged"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:944 src/olympia/editors/helpers.py:963
+#: src/olympia/editors/helpers.py:1024 src/olympia/editors/helpers.py:1043
 msgid "Updates"
 msgstr ""
 
@@ -7658,56 +7517,56 @@ msgstr ""
 msgid "A question about your Theme submission"
 msgstr ""
 
-#: src/olympia/editors/views.py:144
+#: src/olympia/editors/views.py:146
 msgid "New Add-ons (Under 5 days)"
 msgstr ""
 
-#: src/olympia/editors/views.py:145
+#: src/olympia/editors/views.py:147
 msgid "Passable (5 to 10 days)"
 msgstr ""
 
-#: src/olympia/editors/views.py:146
+#: src/olympia/editors/views.py:148
 msgid "Overdue (Over 10 days)"
 msgstr ""
 
-#: src/olympia/editors/views.py:532
+#: src/olympia/editors/views.py:539
 msgid "An unknown error occurred"
 msgstr ""
 
-#: src/olympia/editors/views.py:587
+#: src/olympia/editors/views.py:592
 msgid "Self-reviews are not allowed."
 msgstr ""
 
-#: src/olympia/editors/views.py:609
+#: src/olympia/editors/views.py:613
 msgid "Review successfully processed."
 msgstr ""
 
-#: src/olympia/editors/views.py:807
+#: src/olympia/editors/views.py:812
 msgid "was approved"
 msgstr ""
 
-#: src/olympia/editors/views.py:808
+#: src/olympia/editors/views.py:813
 msgid "given preliminary review"
 msgstr ""
 
-#: src/olympia/editors/views.py:809
+#: src/olympia/editors/views.py:814
 msgid "rejected"
 msgstr ""
 
-#: src/olympia/editors/views.py:810
+#: src/olympia/editors/views.py:815
 msgctxt "editors_review_history_nominated_adminreview"
 msgid "escalated"
 msgstr ""
 
-#: src/olympia/editors/views.py:812
+#: src/olympia/editors/views.py:817
 msgid "needs more information"
 msgstr ""
 
-#: src/olympia/editors/views.py:813
+#: src/olympia/editors/views.py:818
 msgid "needs super review"
 msgstr ""
 
-#: src/olympia/editors/views.py:814
+#: src/olympia/editors/views.py:819
 msgid "commented"
 msgstr ""
 
@@ -7752,28 +7611,28 @@ msgstr ""
 msgid "Unlisted Queues"
 msgstr ""
 
-#: src/olympia/editors/templates/editors/base.html:72 src/olympia/editors/templates/editors/performance.html:6
+#: src/olympia/editors/templates/editors/base.html:74 src/olympia/editors/templates/editors/performance.html:6
 msgid "Performance"
 msgstr ""
 
-#: src/olympia/editors/templates/editors/base.html:75 src/olympia/editors/templates/editors/themes/base.html:19 src/olympia/editors/templates/editors/themes/base.html:38
+#: src/olympia/editors/templates/editors/base.html:77 src/olympia/editors/templates/editors/themes/base.html:19 src/olympia/editors/templates/editors/themes/base.html:38
 msgid "Logs"
 msgstr ""
 
-#: src/olympia/editors/templates/editors/base.html:78 src/olympia/editors/templates/editors/reviewlog.html:4 src/olympia/editors/templates/editors/reviewlog.html:27
+#: src/olympia/editors/templates/editors/base.html:80 src/olympia/editors/templates/editors/reviewlog.html:4 src/olympia/editors/templates/editors/reviewlog.html:27
 msgid "Add-on Review Log"
 msgstr ""
 
-#: src/olympia/editors/templates/editors/base.html:80 src/olympia/editors/templates/editors/eventlog.html:4 src/olympia/editors/templates/editors/eventlog.html:8
+#: src/olympia/editors/templates/editors/base.html:82 src/olympia/editors/templates/editors/eventlog.html:4 src/olympia/editors/templates/editors/eventlog.html:8
 #: src/olympia/editors/templates/editors/eventlog_detail.html:4
 msgid "Moderated Review Log"
 msgstr ""
 
-#: src/olympia/editors/templates/editors/base.html:82 src/olympia/editors/templates/editors/beta_signed_log.html:4 src/olympia/editors/templates/editors/beta_signed_log.html:8
+#: src/olympia/editors/templates/editors/base.html:84 src/olympia/editors/templates/editors/beta_signed_log.html:4 src/olympia/editors/templates/editors/beta_signed_log.html:8
 msgid "Signed Beta Files Log"
 msgstr ""
 
-#: src/olympia/editors/templates/editors/base.html:87 src/olympia/editors/templates/editors/includes/daily-message.html:4
+#: src/olympia/editors/templates/editors/base.html:89 src/olympia/editors/templates/editors/includes/daily-message.html:4
 msgid "Announcement"
 msgstr ""
 
@@ -7994,45 +7853,45 @@ msgstr ""
 msgid "clear search"
 msgstr ""
 
-#: src/olympia/editors/templates/editors/queue.html:72 src/olympia/editors/templates/editors/queue.html:122
+#: src/olympia/editors/templates/editors/queue.html:78 src/olympia/editors/templates/editors/queue.html:128
 msgid "Process Reviews"
 msgstr ""
 
-#: src/olympia/editors/templates/editors/queue.html:80
+#: src/olympia/editors/templates/editors/queue.html:86
 msgid "Moderation actions:"
 msgstr ""
 
-#: src/olympia/editors/templates/editors/queue.html:90
+#: src/olympia/editors/templates/editors/queue.html:96
 #, python-format
 msgid "by %(user)s on %(date)s %(stars)s (%(locale)s)"
 msgstr ""
 
-#: src/olympia/editors/templates/editors/queue.html:106
+#: src/olympia/editors/templates/editors/queue.html:112
 #, python-format
 msgid "<strong>%(reason)s</strong> <span class=\"light\">Flagged by %(user)s on %(date)s</span>"
 msgstr ""
 
-#: src/olympia/editors/templates/editors/queue.html:119
-msgid "All reviews have been moderated.  Good work!"
+#: src/olympia/editors/templates/editors/queue.html:125
+msgid "All reviews have been moderated. Good work!"
 msgstr ""
 
-#: src/olympia/editors/templates/editors/queue.html:161
+#: src/olympia/editors/templates/editors/queue.html:167
 msgid "Version Notes / Notes for Reviewer"
 msgstr ""
 
-#: src/olympia/editors/templates/editors/queue.html:169
+#: src/olympia/editors/templates/editors/queue.html:175
 msgid "There are currently no add-ons of this type to review."
 msgstr ""
 
-#: src/olympia/editors/templates/editors/queue.html:181 src/olympia/editors/templates/editors/themes/queue_list.html:85
+#: src/olympia/editors/templates/editors/queue.html:187 src/olympia/editors/templates/editors/themes/queue_list.html:85
 msgid "Helpful Links:"
 msgstr ""
 
-#: src/olympia/editors/templates/editors/queue.html:182
+#: src/olympia/editors/templates/editors/queue.html:188
 msgid "Add-on Policy"
 msgstr ""
 
-#: src/olympia/editors/templates/editors/queue.html:184
+#: src/olympia/editors/templates/editors/queue.html:190
 msgid "Editors' Guide"
 msgstr ""
 
@@ -8095,10 +7954,7 @@ msgid "<strong>Warning!</strong> Another user was viewing this page before you."
 msgstr ""
 
 #: src/olympia/editors/templates/editors/review.html:237
-msgid ""
-"The whiteboard is the place to exchange information relevant to\n"
-"               this addon (whatever the version), between the developer and the\n"
-"               editor. This is visible and editable by both."
+msgid "The whiteboard is the place to exchange information relevant to this addon (whatever the version), between the developer and the editor. This is visible and editable by both."
 msgstr ""
 
 #: src/olympia/editors/templates/editors/review.html:241
@@ -8372,7 +8228,7 @@ msgstr ""
 msgid "Describe your reason for flagging"
 msgstr ""
 
-#: src/olympia/files/forms.py:88
+#: src/olympia/files/forms.py:90
 msgid "Cannot diff a version against itself"
 msgstr ""
 
@@ -8407,51 +8263,51 @@ msgstr ""
 msgid "There was an error accessing file %s."
 msgstr ""
 
-#: src/olympia/files/utils.py:343
+#: src/olympia/files/utils.py:340
 msgid "Could not parse uploaded file."
 msgstr ""
 
-#: src/olympia/files/utils.py:380
+#: src/olympia/files/utils.py:377
 msgid "Invalid file name in archive: {0}"
 msgstr ""
 
-#: src/olympia/files/utils.py:388
+#: src/olympia/files/utils.py:385
 msgid "File exceeding size limit in archive: {0}"
 msgstr ""
 
-#: src/olympia/files/utils.py:439
+#: src/olympia/files/utils.py:436
 msgid "Invalid archive."
 msgstr ""
 
-#: src/olympia/files/utils.py:529 src/olympia/files/utils.py:532
+#: src/olympia/files/utils.py:526 src/olympia/files/utils.py:529
 msgid "Could not parse the manifest file."
 msgstr ""
 
-#: src/olympia/files/utils.py:551
+#: src/olympia/files/utils.py:548
 msgid "Could not find an add-on ID."
 msgstr ""
 
-#: src/olympia/files/utils.py:554
+#: src/olympia/files/utils.py:551
 msgid "Add-on ID must be 64 characters or less."
 msgstr ""
 
-#: src/olympia/files/utils.py:556
+#: src/olympia/files/utils.py:553
 msgid "Add-on ID doesn't match add-on."
 msgstr ""
 
-#: src/olympia/files/utils.py:564
+#: src/olympia/files/utils.py:561
 msgid "Duplicate add-on ID found."
 msgstr ""
 
-#: src/olympia/files/utils.py:567
+#: src/olympia/files/utils.py:564
 msgid "Version numbers should have fewer than 32 characters."
 msgstr ""
 
-#: src/olympia/files/utils.py:570
+#: src/olympia/files/utils.py:567
 msgid "Version numbers should only contain letters, numbers, and these punctuation characters: +*.-_."
 msgstr ""
 
-#: src/olympia/files/utils.py:587
+#: src/olympia/files/utils.py:584
 msgid "<em:type> doesn't match add-on"
 msgstr ""
 
@@ -8551,6 +8407,10 @@ msgstr ""
 #: src/olympia/files/templates/files/viewer.html:134
 msgid "Fetching file."
 msgstr ""
+
+#: src/olympia/legacy_api/views.py:255
+msgid "Not implemented yet."
+msgstr "Ikke implementert ennå."
 
 #: src/olympia/lib/constants.py:6
 msgid "United Arab Emirates Dirham"
@@ -9208,10 +9068,6 @@ msgstr ""
 msgid "Zimbabwe Dollar"
 msgstr ""
 
-#: src/olympia/lib/video/ffmpeg.py:112 src/olympia/lib/video/totem.py:81
-msgid "Videos must be in WebM."
-msgstr ""
-
 #: src/olympia/pages/templates/pages/about.lhtml:3 src/olympia/pages/templates/pages/about.lhtml:10
 msgid "About Mozilla Add-ons"
 msgstr ""
@@ -9223,7 +9079,7 @@ msgstr ""
 #: src/olympia/pages/templates/pages/about.lhtml:13
 msgid ""
 "addons.mozilla.org, commonly known as \"AMO\", is Mozilla's official site for add-ons to Mozilla software, such as Firefox, Thunderbird, and SeaMonkey. Add-ons let you add new features and change "
-"the way your browser or application works.  Take a look around and explore the thousands of ways to customize the way you do things online."
+"the way your browser or application works. Take a look around and explore the thousands of ways to customize the way you do things online."
 msgstr ""
 
 #: src/olympia/pages/templates/pages/about.lhtml:19
@@ -9568,7 +9424,7 @@ msgstr ""
 msgid ""
 "Yes. It's possible, but some of the functionality provided by these libraries are available through XPCOM, XUL, and JavaScript. In addition, authors should take care if libraries modify primitive "
 "object prototypes (String.prototype, Date.prototype, etc.) and/or define global functions (eg. the $ function). These are prone to cause conflict with other add-ons, in particular if different add-"
-"ons use different versions of libraries and so on. Developers need to be very, very careful with using them.  Mozilla does not offer documentation on using them to build add-ons."
+"ons use different versions of libraries and so on. Developers need to be very, very careful with using them. Mozilla does not offer documentation on using them to build add-ons."
 msgstr ""
 
 #: src/olympia/pages/templates/pages/dev_faq.html:165
@@ -9682,8 +9538,8 @@ msgstr ""
 #, python-format
 msgid ""
 "Yes. Many developers choose to host their own add-ons. Choosing to host your add-on on <a href=\"%(amo_url)s\">Mozilla's add-on site</a>, though, allows for much greater exposure to your add-on due "
-"to the large volume of visitors to the site.  <a href=\"%(md_url)s\">mozdev.org</a> offers free project hosting for Mozilla applications and extensions providing developers with tools to help "
-"manage source code, version control, bug tracking and documentation."
+"to the large volume of visitors to the site. <a href=\"%(md_url)s\">mozdev.org</a> offers free project hosting for Mozilla applications and extensions providing developers with tools to help manage "
+"source code, version control, bug tracking and documentation."
 msgstr ""
 
 #: src/olympia/pages/templates/pages/dev_faq.html:277
@@ -9731,7 +9587,7 @@ msgstr ""
 #: src/olympia/pages/templates/pages/dev_faq.html:314
 #, python-format
 msgid ""
-"Yes. Mozilla's <a href=\"%(p_url)s\">Add-on Policy</a> describes what is an acceptable submission. This policy is subject to change without notice.  In addition, the AMO editorial team uses the <a "
+"Yes. Mozilla's <a href=\"%(p_url)s\">Add-on Policy</a> describes what is an acceptable submission. This policy is subject to change without notice. In addition, the AMO editorial team uses the <a "
 "href=\"%(g_url)s\">Editors Reviewing Guide</a> to ensure that your add-on meets specific guidelines for functionality and security."
 msgstr ""
 
@@ -9848,7 +9704,7 @@ msgstr ""
 #: src/olympia/pages/templates/pages/dev_faq.html:434
 #, python-format
 msgid ""
-"This is why it's very important to read the <a href=\"%(g_url)s\">Editors Reviewing Guide</a> to ensure that your add-on is setup as expected.  It's also a good idea to read the blog post, <a href="
+"This is why it's very important to read the <a href=\"%(g_url)s\">Editors Reviewing Guide</a> to ensure that your add-on is setup as expected. It's also a good idea to read the blog post, <a href="
 "\"%(blog_url)s\">Successfully Getting your Add-on Reviewed</a> which provides excellent insight into ensuring a smooth review of your add-on."
 msgstr ""
 
@@ -9955,7 +9811,7 @@ msgstr ""
 
 #: src/olympia/pages/templates/pages/dev_faq.html:572
 msgid ""
-"Free Software Foundation provides short summaries of the key open source licenses, including whether the license qualifies as a free software license or a copyleft license.  Also includes a "
+"Free Software Foundation provides short summaries of the key open source licenses, including whether the license qualifies as a free software license or a copyleft license. Also includes a "
 "discussion of what constitutes a free software license or a copyleft license (e.g., a Copyleft license is a general method for making a program or other work free, and requiring all modified and "
 "extended versions of the program to be free as well.)"
 msgstr ""
@@ -10133,19 +9989,13 @@ msgid "Add-on Gallery"
 msgstr ""
 
 #: src/olympia/pages/templates/pages/faq.html:171
-msgid ""
-"How do I choose between add-ons that seem to do the same\n"
-"    thing?"
+msgid "How do I choose between add-ons that seem to do the same thing?"
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:173
+#: src/olympia/pages/templates/pages/faq.html:172
 msgid ""
-"There are often several add-ons that have similar features. To\n"
-"    figure out which is right for you, read the entire description of the\n"
-"    add-on and view its screenshots. If there are still several in the running,\n"
-"    read through the add-on's ratings, user reviews, and statistics to see\n"
-"    which is most liked by other users. Remember that you can also just try\n"
-"    out both and see which you like better."
+"There are often several add-ons that have similar features. To figure out which is right for you, read the entire description of the add-on and view its screenshots. If there are still several in "
+"the running, read through the add-on's ratings, user reviews, and statistics to see which is most liked by other users. Remember that you can also just try out both and see which you like better."
 msgstr ""
 
 #: src/olympia/pages/templates/pages/faq.html:180
@@ -10186,80 +10036,67 @@ msgid "How much do add-ons cost to purchase?"
 msgstr ""
 
 #: src/olympia/pages/templates/pages/faq.html:207
-msgid ""
-"Add-ons hosted in our gallery are free unless clearly marked\n"
-"    otherwise."
+msgid "Add-ons hosted in our gallery are free unless clearly marked otherwise."
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:210
+#: src/olympia/pages/templates/pages/faq.html:209
 msgid "What does it mean when an add-on asks for contributions?"
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:211
+#: src/olympia/pages/templates/pages/faq.html:210
 msgid ""
-"Some add-on authors request users who enjoy an add-on to\n"
-"        contribute to its development by making a monetary contribution. These\n"
-"        contributions go directly to the developer unless a third party is\n"
-"        indicated, such as the non-profit Mozilla Foundation."
+"Some add-on authors request users who enjoy an add-on to contribute to its development by making a monetary contribution. These contributions go directly to the developer unless a third party is "
+"indicated, such as the non-profit Mozilla Foundation."
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:216
+#: src/olympia/pages/templates/pages/faq.html:215
 msgid "What are beta add-ons?"
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:218
+#: src/olympia/pages/templates/pages/faq.html:217
 msgid ""
-"Beta add-ons are unreviewed versions which represent the\n"
-"        latest work of an add-on author. While different authors have different\n"
-"        standards for beta code quality, you should assume that these add-ons\n"
-"        are less stable than the general add-on releases."
+"Beta add-ons are unreviewed versions which represent the latest work of an add-on author. While different authors have different standards for beta code quality, you should assume that these add-"
+"ons are less stable than the general add-on releases."
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:222
+#: src/olympia/pages/templates/pages/faq.html:221
 msgid ""
 "Please note that when you install an add-on from the \"Beta Version\" section of an add-on's listing, you will continue to receive updates for that add-on as they become available. Like the initial "
 "version you installed, all beta releases are unreviewed by Mozilla and may harm your computer."
 msgstr ""
 
+#: src/olympia/pages/templates/pages/faq.html:228
+msgid "What does it mean when an add-on is flagged as slow?"
+msgstr ""
+
 #: src/olympia/pages/templates/pages/faq.html:229
-msgid ""
-"What does it mean when an add-on is flagged as\n"
-"    slow?"
+msgid "Most add-ons load code and resources at the same time Firefox is starting up. In most cases the impact in start-up time is minimal, but some add-ons can cause a noticeable slowdown."
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:231
-msgid ""
-"Most add-ons load code and resources at the same time Firefox\n"
-"        is starting up. In most cases the impact in start-up time is minimal,\n"
-"        but some add-ons can cause a noticeable slowdown."
-msgstr ""
-
-#: src/olympia/pages/templates/pages/faq.html:236
+#: src/olympia/pages/templates/pages/faq.html:234
 msgid "How do I report an inappropriate or spam user review?"
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:237
+#: src/olympia/pages/templates/pages/faq.html:235
 msgid ""
-"To report a user review of an add-on, log in with your account\n"
-"    and visit the add-on's reviews page. Find the review you wish to report,\n"
-"    click \"Report this review\" and select a reason. Our editorial team will\n"
-"    investigate the review and take appropriate action."
+"To report a user review of an add-on, log in with your account and visit the add-on's reviews page. Find the review you wish to report, click \"Report this review\" and select a reason. Our "
+"editorial team will investigate the review and take appropriate action."
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:242
+#: src/olympia/pages/templates/pages/faq.html:240
 msgid "How do I report a bug or contact the Mozilla Add-ons team?"
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:243
+#: src/olympia/pages/templates/pages/faq.html:241
 #, python-format
 msgid "Please visit our <a href=\"%(contact_url)s\">Contact page</a>."
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:246
+#: src/olympia/pages/templates/pages/faq.html:244
 msgid "What is a Source Code License?"
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:247
+#: src/olympia/pages/templates/pages/faq.html:245
 #, python-format
 msgid ""
 "The source code used to create an add-on is an exclusive copyright of the add-on author, unless otherwise declared in a source code license. Many add-ons on this site have <a href=\"%(url)s\" lang="
@@ -10267,60 +10104,60 @@ msgid ""
 "the GPL or BSD licenses instead of making up their own."
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:256
+#: src/olympia/pages/templates/pages/faq.html:254
 #, python-format
 msgid "Firefox and other Mozilla software are <a href=\"%(url)s\">open source</a>."
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:264
+#: src/olympia/pages/templates/pages/faq.html:262
 msgid "Collections and Favorites"
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:267
+#: src/olympia/pages/templates/pages/faq.html:265
 msgid "What is a collection?"
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:268
+#: src/olympia/pages/templates/pages/faq.html:266
 msgid "Collections are groups of related add-ons created by users to share."
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:270
+#: src/olympia/pages/templates/pages/faq.html:268
 msgid "What is the My Favorites collection?"
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:271
+#: src/olympia/pages/templates/pages/faq.html:269
 msgid "Favorite add-ons are add-ons that you have bookmarked to easily get back to later. You can add an add-on to your favorites collection by clicking \"Add to favorites\" on its details page."
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:275 src/olympia/templates/menu_links.html:13 src/olympia/templates/impala/header_title.html:17
+#: src/olympia/pages/templates/pages/faq.html:273 src/olympia/templates/menu_links.html:13 src/olympia/templates/impala/header_title.html:17
 msgid "Mobile Add-ons"
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:278
+#: src/olympia/pages/templates/pages/faq.html:276
 msgid "What are mobile add-ons?"
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:279
+#: src/olympia/pages/templates/pages/faq.html:277
 #, python-format
 msgid ""
 "Mobile add-ons work with <a href=\"%(mobile_url)s\">Firefox for Mobile</a> and add or modify functionality just like desktop add-ons. You can find add-ons that work with Firefox for Mobile in our "
 "<a href=\"%(gallery_url)s\">gallery</a>."
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:288
+#: src/olympia/pages/templates/pages/faq.html:286
 msgid "Developer Topics"
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:289
+#: src/olympia/pages/templates/pages/faq.html:287
 #, python-format
 msgid "Please see our <a href=\"%(faq_url)s\">Developer FAQ</a> and <a href=\"%(hub_url)s\">Developer Hub</a> for answers to add-on developer-related questions."
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:294
+#: src/olympia/pages/templates/pages/faq.html:292
 msgid "Still have questions?"
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:295
+#: src/olympia/pages/templates/pages/faq.html:293
 #, python-format
 msgid "For general Firefox support, visit our <a href=\"%(sumo_url)s\">support website</a>. For general add-on and website questions, visit our <a href=\"%(forum_url)s\">forum</a>."
 msgstr ""
@@ -10458,7 +10295,7 @@ msgstr ""
 
 #: src/olympia/pages/templates/pages/sunbird.html:29
 msgid ""
-"Development on the Sunbird project has halted and its final release was on March 30, 2010.  We've been proud to host Sunbird add-ons on this site but as the project is no longer maintained we have "
+"Development on the Sunbird project has halted and its final release was on March 30, 2010. We've been proud to host Sunbird add-ons on this site but as the project is no longer maintained we have "
 "disabled our support for the add-ons."
 msgstr ""
 
@@ -10536,7 +10373,7 @@ msgstr ""
 #, python-format
 msgid ""
 "<h2>Keep these tips in mind:</h2> <ul> <li> Write like you're telling a friend about your experience with the add-on. Give specifics and helpful details, such as what features you liked and/or "
-"disliked, how easy to use it is, and any disadvantages it has.  Avoid generic language such as calling it \"Great\" or \"Bad\" unless you can give reasons why you believe this is so. </li> <li> "
+"disliked, how easy to use it is, and any disadvantages it has. Avoid generic language such as calling it \"Great\" or \"Bad\" unless you can give reasons why you believe this is so. </li> <li> "
 "Please do not post bug reports in reviews. We do not make your email address available to add-on developers and they may need to contact you to help resolve your issue. See the <a href=\"%(support)s"
 "\">support section</a> to find out where to get assistance for this add-on. </li> <li>Please keep reviews clean, avoid the use of improper language and do not post any personal information. </li> </"
 "ul> <p>Please read the <a href=\"%(guide)s\" target=\"_blank\">Review Guidelines</a> for more detail about user add-on reviews.</p>"
@@ -10772,16 +10609,16 @@ msgstr ""
 
 #. L10n: {0} is an application, such as Firefox. This means "any version of
 #. Firefox."
-#: src/olympia/search/views.py:554
+#: src/olympia/search/views.py:547
 msgid "Any {0}"
 msgstr ""
 
 #. L10n: "All Systems" means show everything regardless of platform.
-#: src/olympia/search/views.py:589
+#: src/olympia/search/views.py:582
 msgid "All Systems"
 msgstr ""
 
-#: src/olympia/search/views.py:600
+#: src/olympia/search/views.py:593
 msgid "All Tags"
 msgstr ""
 
@@ -10955,31 +10792,31 @@ msgstr ""
 msgid "Share this Collection"
 msgstr ""
 
-#: src/olympia/signing/views.py:30 src/olympia/templates/base.html:75 src/olympia/templates/impala/base.html:115
+#: src/olympia/signing/views.py:33 src/olympia/templates/base.html:71 src/olympia/templates/impala/base.html:112
 msgid "Some features are temporarily disabled while we perform website maintenance. We'll be back to full capacity shortly."
 msgstr ""
 
-#: src/olympia/signing/views.py:53
+#: src/olympia/signing/views.py:56
 msgid "Could not find add-on with id \"{}\"."
 msgstr ""
 
-#: src/olympia/signing/views.py:67
+#: src/olympia/signing/views.py:70
 msgid "You do not own this addon."
 msgstr ""
 
-#: src/olympia/signing/views.py:82
+#: src/olympia/signing/views.py:87
 msgid "Missing \"upload\" key in multipart file data."
 msgstr ""
 
-#: src/olympia/signing/views.py:96
+#: src/olympia/signing/views.py:101
 msgid "Version does not match the manifest file."
 msgstr ""
 
-#: src/olympia/signing/views.py:100
+#: src/olympia/signing/views.py:105
 msgid "Version already exists."
 msgstr ""
 
-#: src/olympia/signing/views.py:136
+#: src/olympia/signing/views.py:141
 msgid "No uploaded file for that addon and version."
 msgstr ""
 
@@ -11092,89 +10929,89 @@ msgstr ""
 msgid "Statistics Dashboard :: Add-ons for {0}"
 msgstr ""
 
-#: src/olympia/stats/templates/stats/stats.html:30
-msgid "Controls:"
-msgstr ""
-
-#: src/olympia/stats/templates/stats/stats.html:33
-msgid "reset zoom"
-msgstr ""
-
-#: src/olympia/stats/templates/stats/stats.html:40
-msgid "Group by:"
-msgstr ""
-
-#: src/olympia/stats/templates/stats/stats.html:42
-msgid "day"
-msgstr ""
-
-#: src/olympia/stats/templates/stats/stats.html:45
-msgid "week"
-msgstr ""
-
-#: src/olympia/stats/templates/stats/stats.html:48
-msgid "month"
-msgstr ""
-
-#: src/olympia/stats/templates/stats/stats.html:54
-msgid "For last:"
-msgstr ""
-
-#: src/olympia/stats/templates/stats/stats.html:57
-msgid "7 days"
-msgstr ""
-
-#: src/olympia/stats/templates/stats/stats.html:60
-msgid "30 days"
-msgstr ""
-
-#: src/olympia/stats/templates/stats/stats.html:63
-msgid "90 days"
-msgstr ""
-
-#: src/olympia/stats/templates/stats/stats.html:66
-msgid "365 days"
-msgstr ""
-
-#: src/olympia/stats/templates/stats/stats.html:69
-msgid "Custom..."
-msgstr ""
-
 #. {0} is an add-on name
-#: src/olympia/stats/templates/stats/stats.html:88 src/olympia/stats/templates/stats/stats.html:91
+#: src/olympia/stats/templates/stats/stats.html:44 src/olympia/stats/templates/stats/stats.html:47
 msgid "Statistics for {0}"
 msgstr ""
 
-#: src/olympia/stats/templates/stats/stats.html:94
+#: src/olympia/stats/templates/stats/stats.html:50
 msgid "Statistics Dashboard"
 msgstr ""
 
-#: src/olympia/stats/templates/stats/stats.html:104
+#: src/olympia/stats/templates/stats/stats.html:57
+msgid "Controls:"
+msgstr ""
+
+#: src/olympia/stats/templates/stats/stats.html:60
+msgid "reset zoom"
+msgstr ""
+
+#: src/olympia/stats/templates/stats/stats.html:67
+msgid "Group by:"
+msgstr ""
+
+#: src/olympia/stats/templates/stats/stats.html:69
+msgid "day"
+msgstr ""
+
+#: src/olympia/stats/templates/stats/stats.html:72
+msgid "week"
+msgstr ""
+
+#: src/olympia/stats/templates/stats/stats.html:75
+msgid "month"
+msgstr ""
+
+#: src/olympia/stats/templates/stats/stats.html:81
+msgid "For last:"
+msgstr ""
+
+#: src/olympia/stats/templates/stats/stats.html:84
+msgid "7 days"
+msgstr ""
+
+#: src/olympia/stats/templates/stats/stats.html:87
+msgid "30 days"
+msgstr ""
+
+#: src/olympia/stats/templates/stats/stats.html:90
+msgid "90 days"
+msgstr ""
+
+#: src/olympia/stats/templates/stats/stats.html:93
+msgid "365 days"
+msgstr ""
+
+#: src/olympia/stats/templates/stats/stats.html:96
+msgid "Custom..."
+msgstr ""
+
+#: src/olympia/stats/templates/stats/stats.html:106
 msgid "Statistics processing is currently disabled, so recent data is unavailable. The statistics are still being collected and this page will be updated soon with the missing data."
 msgstr ""
 
-#: src/olympia/stats/templates/stats/stats.html:110
+#: src/olympia/stats/templates/stats/stats.html:112
 msgid "Loading the latest data&hellip;"
 msgstr ""
 
-#: src/olympia/stats/templates/stats/stats.html:142 src/olympia/stats/templates/stats/reports/overview.html:25 src/olympia/stats/templates/stats/reports/overview.html:37
+#: src/olympia/stats/templates/stats/stats.html:144 src/olympia/stats/templates/stats/reports/overview.html:25 src/olympia/stats/templates/stats/reports/overview.html:37
 #: src/olympia/stats/templates/stats/reports/overview.html:49
 msgid "No data available."
 msgstr ""
 
-#: src/olympia/stats/templates/stats/stats.html:177
+#: src/olympia/stats/templates/stats/stats.html:179
 msgid "This dashboard is currently <b>public</b>."
 msgstr ""
 
-#: src/olympia/stats/templates/stats/stats.html:179
+#: src/olympia/stats/templates/stats/stats.html:181
 msgid "Contribution stats are currently <b>private</b>."
 msgstr ""
 
-#: src/olympia/stats/templates/stats/stats.html:182
+#: src/olympia/stats/templates/stats/stats.html:184
 msgid "This dashboard is currently <b>private</b>."
 msgstr ""
 
-#: src/olympia/stats/templates/stats/stats.html:185
+#: src/olympia/stats/templates/stats/stats.html:187
 msgid "Change settings."
 msgstr ""
 
@@ -11326,15 +11163,6 @@ msgstr ""
 msgid "Application versions by Date"
 msgstr ""
 
-#: src/olympia/tags/templates/tags/top_cloud.html:4
-msgid "Top {0} Tags"
-msgstr ""
-
-#. {0} is the current application name
-#: src/olympia/tags/templates/tags/top_cloud.html:14
-msgid "{0} Top Tags"
-msgstr ""
-
 #: src/olympia/templates/amo_footer.html:6 src/olympia/templates/includes/lang_switcher.html:2
 msgid "Other languages"
 msgstr ""
@@ -11343,11 +11171,11 @@ msgstr ""
 msgid "Mozilla Add-ons"
 msgstr ""
 
-#: src/olympia/templates/base.html:91 src/olympia/templates/impala/base.html:81
+#: src/olympia/templates/base.html:89 src/olympia/templates/impala/base.html:78
 msgid "Find add-ons for other applications"
 msgstr ""
 
-#: src/olympia/templates/base.html:92 src/olympia/templates/impala/base.html:81
+#: src/olympia/templates/base.html:90 src/olympia/templates/impala/base.html:78
 msgid "Other Applications"
 msgstr ""
 
@@ -11372,7 +11200,7 @@ msgid "View Mobile Site"
 msgstr ""
 
 #: src/olympia/templates/copyright.html:7
-msgid "Site Status "
+msgid "Site Status"
 msgstr ""
 
 #: src/olympia/templates/footer.html:3
@@ -11472,35 +11300,35 @@ msgstr ""
 msgid "<a href=\"%(reg)s\">Register</a> or <a href=\"%(login)s\">Log in</a>"
 msgstr ""
 
-#: src/olympia/templates/impala/base.html:126
+#: src/olympia/templates/impala/base.html:123
 #, python-format
 msgid "To try the thousands of add-ons available here, download <a href=\"%(url)s\">Mozilla Firefox</a>, a fast, free way to surf the Web!"
 msgstr ""
 
-#: src/olympia/templates/impala/base.html:138
+#: src/olympia/templates/impala/base.html:135
 #, python-format
 msgid "Add-ons is switching to Firefox Accounts for login. <a href=\"%(url)s\" class=\"fxa-login\">Sign in now to transfer your account.</a>"
 msgstr ""
 
 #. {0} is an application, such as Firefox.
-#: src/olympia/templates/impala/base.html:148
+#: src/olympia/templates/impala/base.html:145
 msgid "Welcome to {0} Add-ons."
 msgstr ""
 
-#: src/olympia/templates/impala/base.html:151
+#: src/olympia/templates/impala/base.html:148
 msgid "Choose from thousands of extra features and styles to make Firefox your own."
 msgstr ""
 
-#: src/olympia/templates/impala/base.html:156
+#: src/olympia/templates/impala/base.html:153
 #, python-format
 msgid "Add extra features and styles to make %(app)s your own."
 msgstr ""
 
-#: src/olympia/templates/impala/base.html:164
+#: src/olympia/templates/impala/base.html:161
 msgid "On the go?"
 msgstr ""
 
-#: src/olympia/templates/impala/base.html:166
+#: src/olympia/templates/impala/base.html:163
 msgid "Check out our <a class=\"mobile-link\" href=\"#\">Mobile Add-ons site</a>."
 msgstr ""
 
@@ -11724,19 +11552,19 @@ msgstr ""
 
 #. L10n: {id} will be something like "13ad6a", just a random number
 #. to differentiate this user from other anonymous users.
-#: src/olympia/users/models.py:353
+#: src/olympia/users/models.py:362
 msgid "Anonymous user {id}"
 msgstr ""
 
-#: src/olympia/users/models.py:410
+#: src/olympia/users/models.py:419
 msgid "Your account has been restricted"
 msgstr ""
 
-#: src/olympia/users/models.py:480
+#: src/olympia/users/models.py:489
 msgid "Please confirm your email address"
 msgstr ""
 
-#: src/olympia/users/models.py:506
+#: src/olympia/users/models.py:515
 msgid "My Mobile Add-ons"
 msgstr ""
 
@@ -12013,7 +11841,7 @@ msgstr ""
 
 #: src/olympia/users/templates/users/edit.html:70
 #, python-format
-msgid "Change your password.  If you forgot your password, you can <a href=\"%(reset_url)s\">use the reset form</a>."
+msgid "Change your password. If you forgot your password, you can <a href=\"%(reset_url)s\">use the reset form</a>."
 msgstr ""
 
 #: src/olympia/users/templates/users/edit.html:76
@@ -12033,7 +11861,7 @@ msgid "Profile"
 msgstr ""
 
 #: src/olympia/users/templates/users/edit.html:100
-msgid "Give us a bit more information about yourself.  All these fields are optional, but they'll help other users get to know you better."
+msgid "Give us a bit more information about yourself. All these fields are optional, but they'll help other users get to know you better."
 msgstr ""
 
 #: src/olympia/users/templates/users/edit.html:124
@@ -12249,7 +12077,7 @@ msgid "Confirm password"
 msgstr ""
 
 #: src/olympia/users/templates/users/pwreset_confirm.html:47
-msgid "The password reset link was invalid, possibly because it has already been used.  Please request a new password reset."
+msgid "The password reset link was invalid, possibly because it has already been used. Please request a new password reset."
 msgstr ""
 
 #: src/olympia/users/templates/users/pwreset_request.html:15
@@ -12435,7 +12263,7 @@ msgstr ""
 
 #: src/olympia/users/templates/users/unsubscribe.html:30
 #, python-format
-msgid "Unfortunately, we weren't able to unsubscribe you.  The link you clicked is invalid. However, you can unsubscribe still unsubscribe on your <a href=\"%(edit_url)s\">edit profile page</a>."
+msgid "Unfortunately, we weren't able to unsubscribe you. The link you clicked is invalid. However, you can unsubscribe still unsubscribe on your <a href=\"%(edit_url)s\">edit profile page</a>."
 msgstr ""
 
 #: src/olympia/users/templates/users/vcard.html:2
@@ -12489,15 +12317,15 @@ msgstr ""
 msgid "Version History with Changelogs"
 msgstr ""
 
-#: src/olympia/versions/models.py:314
+#: src/olympia/versions/models.py:313
 msgid "Add-on uses binary components."
 msgstr ""
 
-#: src/olympia/versions/models.py:317
+#: src/olympia/versions/models.py:316
 msgid "Add-on has opted into strict compatibility checking."
 msgstr ""
 
-#: src/olympia/versions/models.py:715
+#: src/olympia/versions/models.py:711
 msgid "{app} {min} and later"
 msgstr ""
 
@@ -12572,4 +12400,8 @@ msgstr ""
 
 #: src/olympia/zadmin/forms.py:105
 msgid "Log emails instead of sending"
+msgstr ""
+
+#: src/olympia/zadmin/forms.py:215
+msgid "Deleted versions can`t be changed."
 msgstr ""

--- a/locale/nb_NO/LC_MESSAGES/djangojs.po
+++ b/locale/nb_NO/LC_MESSAGES/djangojs.po
@@ -1,1215 +1,1235 @@
-
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2016-02-24 21:23+0000\n"
+"POT-Creation-Date: 2016-04-18 15:47+0000\n"
 "PO-Revision-Date: 2014-06-23 10:02+0000\n"
 "Last-Translator: Håvar <havar@firefox.no>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
+"Language: \n"
 "MIME-Version: 1.0\n"
-"Content-Type: text/plain; charset=utf-8\n"
+"Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Generated-By: Babel 2.2.0\n"
 
-#: static/js/common/ratingwidget.js:31
-msgid "{0} star"
-msgid_plural "{0} stars"
-msgstr[0] "{0} stjerne"
-msgstr[1] "{0} stjerner"
-
-#: static/js/common/upload-addon.js:41 static/js/common/upload-image.js:128
-msgid "There was a problem contacting the server."
-msgstr "Et problem oppstod ved forsøk på å kontakte serveren."
-
-#: static/js/common/upload-addon.js:69
-msgid "Select a file..."
-msgstr "Velg fil ..."
-
-#: static/js/common/upload-addon.js:70
-msgid "Your add-on should end with .xpi, .jar or .xml"
-msgstr "Utvidelsen må ende på .xpi, .jar eller .xml"
-
-#. L10n: {0} is the percent of the file that has been uploaded.
-#: static/js/common/upload-addon.js:104
-#, fuzzy, python-format
-msgid "{0}% complete"
-msgstr "{0} % fullført"
-
-#. L10n: "{bytes uploaded} of {total filesize}".
-#: static/js/common/upload-addon.js:107
-msgid "{0} of {1}"
-msgstr "{0} av {1}"
-
-#: static/js/common/upload-addon.js:140
-msgid "Cancel"
-msgstr "Avbryt"
-
-#: static/js/common/upload-addon.js:162
-msgid "Uploading {0}"
-msgstr "Laster opp {0}"
-
-#: static/js/common/upload-addon.js:189
-msgid "Error with {0}"
-msgstr "Feil med {0}"
-
-#: static/js/common/upload-addon.js:194
-msgid "Your add-on failed validation with {0} error."
-msgid_plural "Your add-on failed validation with {0} errors."
-msgstr[0] "Validering av utvidelsen gav {0} feil."
-msgstr[1] "Validering av utvidelsen gav {0} feil."
-
-#: static/js/common/upload-addon.js:208
-msgid "&hellip;and {0} more"
-msgid_plural "&hellip;and {0} more"
-msgstr[0] "&hellip;og {0} flere"
-msgstr[1] "&hellip;og {0} flere"
-
-#: static/js/common/upload-addon.js:222 static/js/common/upload-addon.js:512
-msgid "See full validation report"
-msgstr "Se fullstendig valideringsrapport"
-
-#: static/js/common/upload-addon.js:234
-msgid "Validating {0}"
-msgstr "Validerer {0}"
-
-#. L10n: first argument is an HTTP status code
-#: static/js/common/upload-addon.js:273
-msgid "Received an empty response from the server; status: {0}"
-msgstr "Mottok en tom respons fra serveren; status: {0}"
-
-#: static/js/common/upload-addon.js:373
-msgid "Unexpected server error while validating."
-msgstr "Uventet serverfeil ved validering."
-
-#: static/js/common/upload-addon.js:412
-msgid "Finished validating {0}"
-msgstr "Fullførte validering av {0}"
-
-#: static/js/common/upload-addon.js:418
-msgid "Your add-on validation timed out, it will be manually reviewed."
-msgstr ""
-
-#: static/js/common/upload-addon.js:421
-msgid "Your add-on was validated with no errors and {0} warning."
-msgid_plural "Your add-on was validated with no errors and {0} warnings."
-msgstr[0] ""
-msgstr[1] ""
-
-#: static/js/common/upload-addon.js:426
-msgid "Your add-on was validated with no errors and {0} message."
-msgid_plural "Your add-on was validated with no errors and {0} messages."
-msgstr[0] ""
-msgstr[1] ""
-
-#: static/js/common/upload-addon.js:431
-msgid "Your add-on was validated with no errors or warnings."
-msgstr ""
-
-#: static/js/common/upload-addon.js:446
-msgid "Your submission will be automatically signed."
-msgstr ""
-
-#: static/js/common/upload-addon.js:465
-msgid "Include detailed version notes (this can be done in the next step)."
-msgstr ""
-
-#: static/js/common/upload-addon.js:466
-msgid "If your add-on requires an account to a website in order to be fully tested, include a test username and password in the Notes to Reviewer (this can be done in the next step)."
-msgstr ""
-
-#: static/js/common/upload-addon.js:467
-msgid "If your add-on is intended for a limited audience you should choose Preliminary Review instead of Full Review."
-msgstr ""
-
-#: static/js/common/upload-addon.js:480
-msgid "Add-on submission checklist"
-msgstr ""
-
-#: static/js/common/upload-addon.js:481
-msgid "Please verify the following points before finalizing your submission. This will minimize delays or misunderstanding during the review process:"
-msgstr ""
-
-#: static/js/common/upload-addon.js:483
-msgid ""
-"Compiled binaries, as well as minified or obfuscated scripts (excluding known libraries) need to have their sources submitted separately for review. Make sure that you use the source code upload "
-"field to avoid having your submission rejected."
-msgstr ""
-
-#: static/js/common/upload-addon.js:501
-msgid "The validation process found these issues that can lead to rejections:"
-msgstr ""
-
-#: static/js/common/upload-addon.js:518
-msgid "If you are unfamiliar with the add-ons review process, you can read about it here."
-msgstr ""
-
-#: static/js/common/upload-addon.js:555
-msgid "Sorry, no supported platform has been found."
-msgstr "Beklager, ingen støttet plattform har blitt funnet."
-
-#: static/js/common/upload-base.js:57
-msgid "The filetype you uploaded isn't recognized."
-msgstr "Filtypen du lastet opp er ikke gjenkjent."
-
-#: static/js/common/upload-base.js:79
-msgid "You cancelled the upload."
-msgstr "Du avbrøt opplastingen."
-
-#: static/js/common/upload-image.js:97 static/js/impala/users.js:51
-msgid "Images must be either PNG or JPG."
-msgstr "Bilder må være enten PNG eller JPG."
-
-#: static/js/common/upload-image.js:101
-msgid "Videos must be in WebM."
-msgstr "Videoer må være i WebM."
-
-#: static/js/impala/collections.js:10 static/js/zamboni/collections.js:595
-msgid "Follow this Collection"
-msgstr "Følg denne samlingen"
-
-#: static/js/impala/collections.js:19
-msgid "Stop Following"
-msgstr "Stopp følging"
-
-#: static/js/impala/collections.js:20
-msgid "Following"
-msgstr "Følger"
-
-#. L10n: {0} is an app name.
-#: static/js/impala/listing.js:11 static/js/zamboni/themes.js:13
-msgid "This theme is incompatible with your version of {0}"
-msgstr "Dette temaet er inkompatibelt med din versjon av {0}"
-
-#: static/js/impala/persona_creation.js:60
-msgid "All Rights Reserved"
-msgstr "Med enerett"
-
-#: static/js/impala/persona_creation.js:64
-msgid "Creative Commons Attribution 3.0"
-msgstr "Creative Commons Attribution 3.0"
-
-#: static/js/impala/persona_creation.js:69
-msgid "Creative Commons Attribution-NonCommercial 3.0"
-msgstr "Creative Commons Attribution-NonCommercial 3.0"
-
-#: static/js/impala/persona_creation.js:74
-msgid "Creative Commons Attribution-NonCommercial-NoDerivs 3.0"
-msgstr "Creative Commons Attribution-NonCommercial-NoDerivs 3.0"
-
-#: static/js/impala/persona_creation.js:79
-msgid "Creative Commons Attribution-NonCommercial-Share Alike 3.0"
-msgstr "Creative Commons Attribution-NonCommercial-Share Alike 3.0"
-
-#: static/js/impala/persona_creation.js:84
-msgid "Creative Commons Attribution-NoDerivs 3.0"
-msgstr "Creative Commons Attribution-NoDerivs 3.0"
-
-#: static/js/impala/persona_creation.js:89
-msgid "Creative Commons Attribution-ShareAlike 3.0"
-msgstr "Creative Commons Attribution-ShareAlike 3.0"
-
-#: static/js/impala/persona_creation.js:292
-msgid "Your Theme's Name"
-msgstr "Navn på temaet"
-
-#: static/js/impala/reviews.js:23 static/js/zamboni/reviews.js:18
-msgid "Flagged for review"
-msgstr "Flagget for gjennomgang"
-
-#: static/js/impala/reviews.js:40 static/js/zamboni/reviews.js:34
-msgid "Your input is required"
-msgstr "Inndata er påkrevd"
-
-#: static/js/impala/reviews.js:152 static/js/zamboni/reviews.js:103
-msgid "Marked for deletion"
-msgstr "Markert for sletting"
-
-#: static/js/impala/search.js:114
-msgid "Updating results&hellip;"
-msgstr "Oppdaterer resultater &hellip;"
-
-#: static/js/impala/site_suggestions.js:46
-msgid "Category"
-msgstr "Kategori"
-
-#: static/js/impala/suggestions.js:39
-msgid "Search themes for <b>{0}</b>"
-msgstr "Søk i temaer etter <b>{0}</b>"
-
-#: static/js/impala/suggestions.js:41
-msgid "Search apps for <b>{0}</b>"
-msgstr "Søk i apps etter <b>{0}</b>"
-
-#: static/js/impala/suggestions.js:43
-msgid "Search add-ons for <b>{0}</b>"
-msgstr "Søk i utvidelser etter <b>{0}</b>"
-
-#: static/js/impala/users.js:33
-msgid "use original"
-msgstr "bruk original"
-
-#: static/js/impala/stats/chart.js:267
-msgid "Week of {0}"
-msgstr "Uke {0}"
-
-#: static/js/impala/stats/chart.js:269
-msgid " downloads"
-msgstr ""
-
-#: static/js/impala/stats/chart.js:270
-msgid "{0} users"
-msgstr "{0} brukere"
-
-#: static/js/impala/stats/chart.js:271
-msgid "{0} add-ons"
-msgstr "{0} utvidelser"
-
-#: static/js/impala/stats/chart.js:272
-msgid "{0} collections"
-msgstr "{0} samlinger"
-
-#: static/js/impala/stats/chart.js:273
-msgid "{0} reviews"
-msgstr "{0} anmeldelser"
-
-#: static/js/impala/stats/chart.js:275
-msgid "{0} sales"
-msgstr "{0} salg"
-
-#: static/js/impala/stats/chart.js:276
-msgid "{0} refunds"
-msgstr "{0} tilbakebetalinger"
-
-#: static/js/impala/stats/chart.js:277
-msgid "{0} installs"
-msgstr "{0} installeringer"
-
-#: static/js/impala/stats/chart.js:369 static/js/impala/stats/csv_keys.js:3 static/js/impala/stats/csv_keys.js:109
-msgid "Downloads"
-msgstr "Nedlastinger"
-
-#: static/js/impala/stats/chart.js:379 static/js/impala/stats/csv_keys.js:6 static/js/impala/stats/csv_keys.js:110
-msgid "Daily Users"
-msgstr "Daglige brukere"
-
-#: static/js/impala/stats/chart.js:410
-msgid "Amount, in USD"
-msgstr "Beløp, i USD"
-
-#: static/js/impala/stats/chart.js:421 static/js/impala/stats/csv_keys.js:104
-msgid "Number of Contributions"
-msgstr "Antall bidragsytere"
-
-#: static/js/impala/stats/chart.js:447
-msgid "More Info..."
-msgstr "Mer info ..."
-
-#. L10n: {0} is an ISO-formatted date.
-#: static/js/impala/stats/chart.js:451
-msgid "Details for {0}"
-msgstr "Detaljer for {0}"
-
-#: static/js/impala/stats/csv_keys.js:9
-msgid "Collections Created"
-msgstr "Samlinger opprettet"
-
-#: static/js/impala/stats/csv_keys.js:12
-msgid "Add-ons in Use"
-msgstr "Utvidelser i bruk"
-
-#: static/js/impala/stats/csv_keys.js:15
-msgid "Add-ons Created"
-msgstr "Utvidelser opprettet"
-
-#: static/js/impala/stats/csv_keys.js:18
-msgid "Add-ons Downloaded"
-msgstr "Utvidelser lastet ned"
-
-#: static/js/impala/stats/csv_keys.js:21
-msgid "Add-ons Updated"
-msgstr "Utvidelser oppdatert"
-
-#: static/js/impala/stats/csv_keys.js:24
-msgid "Reviews Written"
-msgstr "Anmeldelser skrevet"
-
-#: static/js/impala/stats/csv_keys.js:27
-msgid "User Signups"
-msgstr "Brukerregistreringer"
-
-#: static/js/impala/stats/csv_keys.js:30
-msgid "Subscribers"
-msgstr "Abonnementer"
-
-#: static/js/impala/stats/csv_keys.js:33
-msgid "Ratings"
-msgstr "Rangering"
-
-#: static/js/impala/stats/csv_keys.js:36 static/js/impala/stats/csv_keys.js:114
-msgid "Sales"
-msgstr "Salg"
-
-#: static/js/impala/stats/csv_keys.js:39 static/js/impala/stats/csv_keys.js:113
-msgid "Installs"
-msgstr "Installeringer"
-
-#: static/js/impala/stats/csv_keys.js:42
-msgid "Unknown"
-msgstr "Ukjent"
-
-#: static/js/impala/stats/csv_keys.js:43
-msgid "Add-ons Manager"
-msgstr "Utvidelsesbehandler"
-
-#: static/js/impala/stats/csv_keys.js:44
-msgid "Add-ons Manager Promo"
-msgstr ""
-
-#: static/js/impala/stats/csv_keys.js:45
-msgid "Add-ons Manager Featured"
-msgstr ""
-
-#: static/js/impala/stats/csv_keys.js:46
-msgid "Add-ons Manager Learn More"
-msgstr ""
-
-#: static/js/impala/stats/csv_keys.js:47
-msgid "Search Suggestions"
-msgstr ""
-
-#: static/js/impala/stats/csv_keys.js:48
-msgid "Search Results"
-msgstr "Søkeresultater"
-
-#: static/js/impala/stats/csv_keys.js:49 static/js/impala/stats/csv_keys.js:50 static/js/impala/stats/csv_keys.js:51
-msgid "Homepage Promo"
-msgstr "Hjemmeside-promo"
-
-#: static/js/impala/stats/csv_keys.js:52 static/js/impala/stats/csv_keys.js:53
-msgid "Homepage Featured"
-msgstr "Hjemmeside fremhevet"
-
-#: static/js/impala/stats/csv_keys.js:54 static/js/impala/stats/csv_keys.js:55
-msgid "Homepage Up and Coming"
-msgstr "Hjemmeside fremgangsrik"
-
-#: static/js/impala/stats/csv_keys.js:56
-msgid "Homepage Most Popular"
-msgstr "Hjemmeside mest populær"
-
-#: static/js/impala/stats/csv_keys.js:57 static/js/impala/stats/csv_keys.js:59
-msgid "Detail Page"
-msgstr "Detaljside"
-
-#: static/js/impala/stats/csv_keys.js:58 static/js/impala/stats/csv_keys.js:60
-msgid "Detail Page (bottom)"
-msgstr "Detaljside (bunn)"
-
-#: static/js/impala/stats/csv_keys.js:61
-msgid "Detail Page (Development Channel)"
-msgstr "Detaljside (utviklerkanal)"
-
-#: static/js/impala/stats/csv_keys.js:62 static/js/impala/stats/csv_keys.js:63 static/js/impala/stats/csv_keys.js:64
-msgid "Often Used With"
-msgstr "Ofte brukt sammen med"
-
-#: static/js/impala/stats/csv_keys.js:65 static/js/impala/stats/csv_keys.js:66
-msgid "Others By Author"
-msgstr "Andre av forfatteren"
-
-#: static/js/impala/stats/csv_keys.js:67 static/js/impala/stats/csv_keys.js:68
-msgid "Dependencies"
-msgstr "Avhengigheter"
-
-#: static/js/impala/stats/csv_keys.js:69 static/js/impala/stats/csv_keys.js:70
-msgid "Upsell"
-msgstr "Oppsalg"
-
-#: static/js/impala/stats/csv_keys.js:71
-msgid "Meet the Developer"
-msgstr ""
-
-#: static/js/impala/stats/csv_keys.js:72
-msgid "User Profile"
-msgstr ""
-
-#: static/js/impala/stats/csv_keys.js:73
-msgid "Version History"
-msgstr ""
-
-#: static/js/impala/stats/csv_keys.js:75
-msgid "Sharing"
-msgstr "Deler"
-
-#: static/js/impala/stats/csv_keys.js:76
-msgid "Category Pages"
-msgstr "Kategorisider"
-
-#: static/js/impala/stats/csv_keys.js:77
-msgid "Collections"
-msgstr "Samlinger"
-
-#: static/js/impala/stats/csv_keys.js:78 static/js/impala/stats/csv_keys.js:79
-msgid "Category Landing Featured Carousel"
-msgstr "Kategorilanding fremhevet karusell"
-
-#: static/js/impala/stats/csv_keys.js:80 static/js/impala/stats/csv_keys.js:81
-msgid "Category Landing Top Rated"
-msgstr "Kategorilanding topprangert"
-
-#: static/js/impala/stats/csv_keys.js:82 static/js/impala/stats/csv_keys.js:83
-msgid "Category Landing Most Popular"
-msgstr "Kategorilanding mest populær"
-
-#: static/js/impala/stats/csv_keys.js:84 static/js/impala/stats/csv_keys.js:85
-msgid "Category Landing Recently Added"
-msgstr "Kategorilanding nylig lagt til"
-
-#: static/js/impala/stats/csv_keys.js:86 static/js/impala/stats/csv_keys.js:87
-msgid "Browse Listing Featured Sort"
-msgstr "Listegjennomgang sortert etter fremhevet"
-
-#: static/js/impala/stats/csv_keys.js:88 static/js/impala/stats/csv_keys.js:89
-msgid "Browse Listing Users Sort"
-msgstr "Listegjennomgang sortert etter brukere"
-
-#: static/js/impala/stats/csv_keys.js:90 static/js/impala/stats/csv_keys.js:91
-msgid "Browse Listing Rating Sort"
-msgstr "Listegjennomgang sortert etter rangering"
-
-#: static/js/impala/stats/csv_keys.js:92 static/js/impala/stats/csv_keys.js:93
-msgid "Browse Listing Created Sort"
-msgstr "Listegjennomgang sortert etter opprettet"
-
-#: static/js/impala/stats/csv_keys.js:94 static/js/impala/stats/csv_keys.js:95
-msgid "Browse Listing Name Sort"
-msgstr "Listegjennomgang sortert etter navn"
-
-#: static/js/impala/stats/csv_keys.js:96 static/js/impala/stats/csv_keys.js:97
-msgid "Browse Listing Popular Sort"
-msgstr "Listegjennomgang sortert etter popularitet"
-
-#: static/js/impala/stats/csv_keys.js:98 static/js/impala/stats/csv_keys.js:99
-msgid "Browse Listing Updated Sort"
-msgstr "Listegjennomgang sortert etter oppdatert"
-
-#: static/js/impala/stats/csv_keys.js:100 static/js/impala/stats/csv_keys.js:101
-msgid "Browse Listing Up and Coming Sort"
-msgstr "Listegjennomgang sortert etter fremgangsrik"
-
-#: static/js/impala/stats/csv_keys.js:105
-msgid "Total Amount Contributed"
-msgstr "Totalt bidragsbeløp"
-
-#: static/js/impala/stats/csv_keys.js:106
-msgid "Average Contribution"
-msgstr "Gjennomsnittelig bidrag"
-
-#: static/js/impala/stats/csv_keys.js:115
-msgid "Usage"
-msgstr "Bruk"
-
-#: static/js/impala/stats/csv_keys.js:118
-msgid "Firefox"
-msgstr "Firefox"
-
-#: static/js/impala/stats/csv_keys.js:119
-msgid "Mozilla"
-msgstr "Mozilla"
-
-#: static/js/impala/stats/csv_keys.js:120
-msgid "Thunderbird"
-msgstr "Thunderbird"
-
-#: static/js/impala/stats/csv_keys.js:121
-msgid "Sunbird"
-msgstr "Sunbird"
-
-#: static/js/impala/stats/csv_keys.js:122
-msgid "SeaMonkey"
-msgstr "SeaMonkey"
-
-#: static/js/impala/stats/csv_keys.js:123
-msgid "Fennec"
-msgstr "Fennec"
-
-#: static/js/impala/stats/csv_keys.js:124
-msgid "Android"
-msgstr ""
-
-#. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:129
-msgid "Downloads and Daily Users, last {0} days"
-msgstr "Nedlastinger og daglige brukere, siste {0} dager"
-
-#. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:131
-msgid "Downloads and Daily Users from {0} to {1}"
-msgstr "Nedlastinger og daglige brukere fra {0} til {1}"
-
-#. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:135
-msgid "Installs and Daily Users, last {0} days"
-msgstr "Installeringer og daglige brukere, siste {0} dager"
-
-#. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:137
-msgid "Installs and Daily Users from {0} to {1}"
-msgstr "Installeringer og daglige brukere fra {0} til {1}"
-
-#. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:141
-msgid "Downloads, last {0} days"
-msgstr "Nedlastinger, siste {0} dager"
-
-#. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:143
-msgid "Downloads from {0} to {1}"
-msgstr "Nedlastinger fra {0} til {1}"
-
-#. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:147
-msgid "Daily Users, last {0} days"
-msgstr "Daglige brukere, siste {0} dager"
-
-#. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:149
-msgid "Daily Users from {0} to {1}"
-msgstr "Daglige brukere fra {0} til {1}"
-
-#. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:153
-msgid "Applications, last {0} days"
-msgstr "Programmer, siste {0} dager"
-
-#. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:155
-msgid "Applications from {0} to {1}"
-msgstr "Programmer fra {0} til {1}"
-
-#. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:159
-msgid "Platforms, last {0} days"
-msgstr "Plattformer, siste {0} dager"
-
-#. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:161
-msgid "Platforms from {0} to {1}"
-msgstr "Plattformer fra {0} til {1}"
-
-#. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:165
-msgid "Languages, last {0} days"
-msgstr "Språk, siste {0} dager"
-
-#. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:167
-msgid "Languages from {0} to {1}"
-msgstr "Språk fra {0} til {1}"
-
-#. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:171
-msgid "Add-on Versions, last {0} days"
-msgstr "Utvidelsesversjoner, siste {0} dager"
-
-#. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:173
-msgid "Add-on Versions from {0} to {1}"
-msgstr "Utvidelsesversjoner fra {0} til {1}"
-
-#. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:177
-msgid "Add-on Status, last {0} days"
-msgstr "Utvidelsesstatus, siste {0} dager"
-
-#. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:179
-msgid "Add-on Status from {0} to {1}"
-msgstr "Utvidelsesstatus fra {0} til {1}"
-
-#. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:183
-msgid "Download Sources, last {0} days"
-msgstr "Nedlastingskilder, siste {0} dager"
-
-#. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:185
-msgid "Download Sources from {0} to {1}"
-msgstr "Nedlastingskilder fra {0} til {1}"
-
-#. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:189
-msgid "Contributions, last {0} days"
-msgstr "Bidrag, siste {0} dager"
-
-#. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:191
-msgid "Contributions from {0} to {1}"
-msgstr "Bidrag fra {0} til {1}"
-
-#. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:195
-msgid "Site Metrics, last {0} days"
-msgstr "Nettstedsmetrikk, siste {0} dager"
-
-#. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:197
-msgid "Site Metrics from {0} to {1}"
-msgstr "Nettstedsmetrikk fra {0} til {1}"
-
-#. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:201
-msgid "Add-ons in Use, last {0} days"
-msgstr "Utvidelser i bruk, siste {0} dager"
-
-#. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:203
-msgid "Add-ons in Use from {0} to {1}"
-msgstr "Utvidelser i bruk fra {0} til {1}"
-
-#. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:207
-msgid "Add-ons Downloaded, last {0} days"
-msgstr "Utvidelser lastet ned, siste {0} dager"
-
-#. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:209
-msgid "Add-ons Downloaded from {0} to {1}"
-msgstr "Utvidelser lastet ned fra {0} til {1}"
-
-#. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:213
-msgid "Add-ons Created, last {0} days"
-msgstr "Utvidelser opprettet, siste {0} dager"
-
-#. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:215
-msgid "Add-ons Created from {0} to {1}"
-msgstr "Utvidelser opprettet fra {0} til {1}"
-
-#. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:219
-msgid "Add-ons Updated, last {0} days"
-msgstr "Utvidelser oppdatert, siste {0} dager"
-
-#. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:221
-msgid "Add-ons Updated from {0} to {1}"
-msgstr "Utvidelser oppdatert fra {0} til {1}"
-
-#. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:225
-msgid "Reviews Written, last {0} days"
-msgstr "Anmeldelser skrevet, siste {0} dager"
-
-#. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:227
-msgid "Reviews Written from {0} to {1}"
-msgstr "Anmeldelser skrevet fra {0} til {1}"
-
-#. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:231
-msgid "User Signups, last {0} days"
-msgstr "Brukerregistreringer, siste {0} dager"
-
-#. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:233
-msgid "User Signups from {0} to {1}"
-msgstr "Brukerregistreringer fra {0} til {1}"
-
-#. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:237
-msgid "Collections Created, last {0} days"
-msgstr "Samlinger opprettet, siste {0} dager"
-
-#. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:239
-msgid "Collections Created from {0} to {1}"
-msgstr "Samlinger opprettet fra {0} til {1}"
-
-#. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:243
-msgid "Subscribers, last {0} days"
-msgstr "Abonnementer, siste {0} dager"
-
-#. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:245
-msgid "Subscribers from {0} to {1}"
-msgstr "Abonnementer fra {0} til {1}"
-
-#. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:249
-msgid "Ratings, last {0} days"
-msgstr "Rangeringer, siste {0} dager"
-
-#. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:251
-msgid "Ratings from {0} to {1}"
-msgstr "Rangeringer fra {0} til {1}"
-
-#. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:255
-msgid "Sales, last {0} days"
-msgstr "Salg, siste {0} dager"
-
-#. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:257
-msgid "Sales from {0} to {1}"
-msgstr "Salg fra {0} til {1}"
-
-#. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:261
-msgid "Installs, last {0} days"
-msgstr "Installeringer, siste {0} dager"
-
-#. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:263
-msgid "Installs from {0} to {1}"
-msgstr "Installeringer fra {0} til {1}"
-
-#. L10n: {0} and {1} are integers.
-#: static/js/impala/stats/csv_keys.js:269
-msgid "<b>{0}</b> in last {1} days"
-msgstr "<b>{0}</b> de siste {1} dagene"
-
-#. L10n: {0} is an integer and {1} and {2} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:271 static/js/impala/stats/csv_keys.js:277
-msgid "<b>{0}</b> from {1} to {2}"
-msgstr "<b>{0}</b> fra {1} til {2}"
-
-#. L10n: {0} and {1} are integers.
-#: static/js/impala/stats/csv_keys.js:275
-msgid "<b>{0}</b> average in last {1} days"
-msgstr "<b>{0}</b> gjennomsnittelig de siste {1} dagene"
-
-#: static/js/impala/stats/overview.js:19
-msgid "No data available."
-msgstr "Ingen data tilgjengelig."
-
-#: static/js/impala/stats/table.js:74
-msgid "Date"
-msgstr "Dato"
-
-#: static/js/impala/stats/topchart.js:96
-msgid "Other"
-msgstr "Annet"
-
-#: static/js/zamboni/admin_validation.js:24 static/js/zamboni/devhub.js:1229 static/js/zamboni/editors.js:295
-msgid "Select an application first"
-msgstr "Velg en applikasjon først"
-
-#: static/js/zamboni/admin_validation.js:51
-msgid "Set {0} add-on to a max version of {1} and email the author."
-msgid_plural "Set {0} add-ons to a max version of {1} and email the authors."
-msgstr[0] "Sett {0} utvidelse til maksversjon {1} og send e-post til forfatteren."
-msgstr[1] "Sett {0} utvidelser til maksversjon {1} og send e-post til forfatterne."
-
-#: static/js/zamboni/admin_validation.js:54
-msgid "Email author of {2} add-on which failed validation."
-msgid_plural "Email authors of {2} add-ons which failed validation."
-msgstr[0] ""
-msgstr[1] ""
+#: static/js/common-all.js:1426 static/js/impala-all.js:1511 static/js/zamboni/discovery-all.js:12598 static/js/zamboni/init.js:28 static/js/zamboni/mobile-all.js:14945
+msgid "This feature is temporarily disabled while we perform website maintenance. Please check back a little later."
+msgstr "Denne funksjonen er midlertidig utilgjengelig mens vi utfører rutinemessig vedlikehold. Kom tilbake senere."
 
 #. L10n: {0} is an app name like Firefox.
-#: static/js/zamboni/buttons.js:66
+#: static/js/common-all.js:1837 static/js/impala-all.js:1922 static/js/zamboni/buttons.js:73 static/js/zamboni/discovery-all.js:13108
 msgid "Accept and Install"
 msgstr "Godta og installer"
 
-#: static/js/zamboni/buttons.js:66
+#: static/js/common-all.js:1837 static/js/impala-all.js:1922 static/js/zamboni/buttons.js:73 static/js/zamboni/discovery-all.js:13108
 msgid "Add to {0}"
 msgstr "Legg til {0}"
 
-#: static/js/zamboni/buttons.js:71
+#: static/js/common-all.js:1842 static/js/impala-all.js:1927 static/js/zamboni/buttons.js:78 static/js/zamboni/discovery-all.js:13113
 msgid "Download Now"
 msgstr "Last ned nå"
 
-#: static/js/zamboni/buttons.js:112
+#: static/js/common-all.js:1883 static/js/impala-all.js:1968 static/js/zamboni/buttons.js:119 static/js/zamboni/discovery-all.js:13154
 msgid "Add-on has not been updated to support default-to-compatible."
 msgstr "Utvidelsen har ikke blitt oppdatert til å støtte kompatibel-som-standard."
 
-#: static/js/zamboni/buttons.js:117
+#: static/js/common-all.js:1888 static/js/impala-all.js:1973 static/js/zamboni/buttons.js:124 static/js/zamboni/discovery-all.js:13159
 msgid "You need to be using Firefox 10.0 or higher."
 msgstr "Du må bruke Firefox 10.0 eller nyere."
 
-#: static/js/zamboni/buttons.js:129
+#: static/js/common-all.js:1900 static/js/impala-all.js:1985 static/js/zamboni/buttons.js:136 static/js/zamboni/discovery-all.js:13171
 msgid "Mozilla has marked this version as incompatible with your Firefox version."
 msgstr "Mozilla har markert denne versjonen som inkompatibel med din Firefox-versjon."
 
 #. L10n: {0} is an platform like Windows or Linux.
-#: static/js/zamboni/buttons.js:210
+#: static/js/common-all.js:1981 static/js/impala-all.js:2066 static/js/zamboni/buttons.js:217 static/js/zamboni/discovery-all.js:13252
 msgid "Install for {0} anyway"
 msgstr "Installer for {0} likevel"
 
-#: static/js/zamboni/buttons.js:210
+#: static/js/common-all.js:1981 static/js/impala-all.js:2066 static/js/zamboni/buttons.js:217 static/js/zamboni/discovery-all.js:13252
 msgid "Download for {0} anyway"
 msgstr "Last ned for {0} likevel"
 
-#: static/js/zamboni/buttons.js:267
+#: static/js/common-all.js:2038 static/js/impala-all.js:2123 static/js/zamboni/buttons.js:274 static/js/zamboni/discovery-all.js:13309
 msgid "Not available for your platform"
 msgstr "Ikke tilgjengelig for plattformen din"
 
 #. L10n: {0} is an app name, {1} is the app version.
-#: static/js/zamboni/buttons.js:278 static/js/zamboni/buttons.js:315
+#: static/js/common-all.js:2049 static/js/common-all.js:2086 static/js/impala-all.js:2134 static/js/impala-all.js:2171 static/js/zamboni/buttons.js:286 static/js/zamboni/buttons.js:324
+#: static/js/zamboni/discovery-all.js:13320 static/js/zamboni/discovery-all.js:13357
 msgid "Not available for {0} {1}"
 msgstr "Ikke tilgjengelig for {0} {1}"
 
-#: static/js/zamboni/buttons.js:341
+#: static/js/common-all.js:2112 static/js/impala-all.js:2197 static/js/zamboni/buttons.js:351 static/js/zamboni/discovery-all.js:13383
 msgid "Works with {app} {min} - {max}"
 msgstr "Virker med {app} {min} - {max}"
 
-#: static/js/zamboni/buttons.js:343
+#: static/js/common-all.js:2114 static/js/impala-all.js:2199 static/js/zamboni/buttons.js:353 static/js/zamboni/discovery-all.js:13385
 msgid "View other versions"
 msgstr "Vis andre versjoner"
 
-#: static/js/zamboni/buttons.js:391
+#: static/js/common-all.js:2162 static/js/impala-all.js:2247 static/js/zamboni/buttons.js:401 static/js/zamboni/discovery-all.js:13433
 msgid "Only with Firefox — Get Firefox Now!"
 msgstr ""
 
-#: static/js/zamboni/buttons.js:507 static/js/zamboni/mobile/buttons.js:43
+#: static/js/common-all.js:2278 static/js/impala-all.js:2363 static/js/zamboni/buttons.js:517 static/js/zamboni/discovery-all.js:13549 static/js/zamboni/mobile-all.js:15177
+#: static/js/zamboni/mobile/buttons.js:43
 msgid "Sorry, you need a Mozilla-based browser (such as Firefox) to install a search plugin."
 msgstr "Beklager, du trenger en Mozilla-basert nettleser (som Firefox) for å installere et søketillegg."
 
-#: static/js/zamboni/collections.js:229
-msgid "Adding to Favorites&hellip;"
-msgstr "Legg til i favoritter &hellip;"
-
-#: static/js/zamboni/collections.js:232
-msgid "Removing Favorite&hellip;"
-msgstr "Fjerner favoritt &hellip;"
-
-#: static/js/zamboni/collections.js:235
-msgid "Add to Favorites"
-msgstr "Legg til i favoritter"
-
-#: static/js/zamboni/collections.js:238
-msgid "Remove from Favorites"
-msgstr "Fjern fra favoritter"
-
-#: static/js/zamboni/collections.js:303
-msgid "Pending"
-msgstr "Under behandling"
-
-#: static/js/zamboni/collections.js:304
-msgid "Add a comment"
-msgstr "Legg til kommentar"
-
-#: static/js/zamboni/collections.js:304
-msgid "Comment"
-msgstr "Kommentar"
-
-#: static/js/zamboni/collections.js:305
-msgid "Remove this add-on from the collection"
-msgstr "Fjern denne utvidelsen fra samlingen"
-
-#: static/js/zamboni/collections.js:305 static/js/zamboni/collections.js:334
-msgid "Remove"
-msgstr "Fjern"
-
-#: static/js/zamboni/collections.js:334
-msgid "Remove this user as a contributor"
-msgstr "Fjern denne brukeren som bidragsyter"
-
-#: static/js/zamboni/collections.js:346
-msgid "An email address is required."
-msgstr "En e-postadresse er påkrevd."
-
-#: static/js/zamboni/collections.js:364
-msgid "You cannot add yourself as a contributor."
-msgstr "Du kan ikke legge til deg selv som bidragsyter."
-
-#: static/js/zamboni/collections.js:366
-msgid "You have already added that user."
-msgstr "Du har allerede lagt til denne brukeren."
-
-#: static/js/zamboni/collections.js:573
-msgid "Add to favorites"
-msgstr "Legg til i favoritter"
-
-#: static/js/zamboni/collections.js:577
-msgid "Remove from favorites"
-msgstr "Fjern fra favoritter"
-
-#: static/js/zamboni/collections.js:604
-msgid "Stop following"
-msgstr "Slutt å følge"
-
-#: static/js/zamboni/devhub.js:110
-msgid "Your browser does not support the video tag"
-msgstr "Nettleseren din støtter ikke video-taggen"
-
-#: static/js/zamboni/devhub.js:371
-msgid "Changes Saved"
-msgstr "Endringer lagret"
-
-#: static/js/zamboni/devhub.js:387
-msgid "Enter a new author's email address"
-msgstr "Skriv inn forfatterens nye e-postadresse"
-
-#: static/js/zamboni/devhub.js:536
-msgid "There was an error uploading your file."
-msgstr "En feil oppstod under opplasting av fil."
-
-#: static/js/zamboni/devhub.js:681
-msgid "{files} file"
-msgid_plural "{files} files"
-msgstr[0] "{files} fil"
-msgstr[1] "{files} filer"
-
-#: static/js/zamboni/devhub.js:684
-msgid "{reviews} user review"
-msgid_plural "{reviews} user reviews"
-msgstr[0] ""
-msgstr[1] ""
-
-#: static/js/zamboni/devhub.js:796
-msgid "Learn more"
-msgstr "Les mer"
-
-#: static/js/zamboni/devhub.js:800
-msgid "Example"
-msgstr "Eksempel"
-
-#: static/js/zamboni/devhub.js:1130
-msgid "Image changes being processed"
-msgstr "Endringer på bilde blir behandlet"
-
-#: static/js/zamboni/devhub.js:1280
-msgid "Must be a valid e-mail address."
-msgstr "Må være en gyldig e-postadresse"
-
-#: static/js/zamboni/devhub_search.js:8
-msgid "No results found."
-msgstr "Ingen resultater funnet."
-
-#: static/js/zamboni/editors.js:121
-msgid "{name} was viewing this page first."
-msgstr "{name} så på denne siden først."
-
-#: static/js/zamboni/editors.js:171
-msgid "Receipt checked by app."
-msgstr "Kvittering kontrollert av appen."
-
-#: static/js/zamboni/editors.js:173
-msgid "Receipt was not checked by app."
-msgstr "Kvittering ble ikke kontrollert av appen."
-
-#: static/js/zamboni/editors.js:244
-msgid "{name} was viewing this add-on first."
-msgstr "{name} så på denne utvidelsen først."
-
-#: static/js/zamboni/editors.js:255
-msgid "Loading&hellip;"
-msgstr "Laster &hellip;"
-
-#: static/js/zamboni/editors.js:260
-msgid "Version Notes"
-msgstr "Versjonnotat"
-
-#: static/js/zamboni/editors.js:265
-msgid "Notes for Reviewers"
-msgstr "Notat for redaktører"
-
-#: static/js/zamboni/editors.js:270
-msgid "No version notes found"
-msgstr "Versjonsnotat ikke funnet"
-
-#: static/js/zamboni/editors.js:330
-msgid "Average Reviews"
-msgstr ""
-
-#: static/js/zamboni/editors.js:386
-msgid "Number of Reviews"
-msgstr ""
-
-#: static/js/zamboni/editors.js:445
-msgid "Error loading translation"
-msgstr "Feil ved lasting av oversettelse"
-
-#: static/js/zamboni/files.js:411 static/js/zamboni/validator.js:261
-msgid "Ignore this message in future updates"
-msgstr ""
-
-#: static/js/zamboni/files.js:417 static/js/zamboni/validator.js:284
-msgid "Severity for automated signing:"
-msgstr ""
-
-#: static/js/zamboni/global.js:410
+#: static/js/common-all.js:9088 static/js/impala-all.js:9649 static/js/zamboni/global.js:410
 msgid "Loading..."
 msgstr "Laster ..."
 
 #. L10n: {0} is the number of characters left.
-#: static/js/zamboni/global.js:474
+#: static/js/common-all.js:9152 static/js/impala-all.js:9713 static/js/zamboni/global.js:474
 msgid "<b>{0}</b> character left."
 msgid_plural "<b>{0}</b> characters left."
 msgstr[0] "<b>{0}</b> tegn igjen."
 msgstr[1] "<b>{0}</b> tegn igjen."
 
-#: static/js/zamboni/init.js:28
-msgid "This feature is temporarily disabled while we perform website maintenance. Please check back a little later."
-msgstr "Denne funksjonen er midlertidig utilgjengelig mens vi utfører rutinemessig vedlikehold. Kom tilbake senere."
+#: static/js/common-all.js:9589 static/js/common-min.js:6 static/js/impala-all.js:10052 static/js/impala-min.js:6 static/js/common/ratingwidget.js:31 static/js/zamboni/mobile-all.js:16123
+#: static/js/zamboni/mobile-min.js:6
+msgid "{0} star"
+msgid_plural "{0} stars"
+msgstr[0] "{0} stjerne"
+msgstr[1] "{0} stjerner"
 
-#: static/js/zamboni/l10n.js:45
+#: static/js/common-all.js:9676 static/js/common-min.js:6 static/js/impala-all.js:10139 static/js/impala-min.js:6 static/js/zamboni/l10n.js:45
 msgid "Remove this localization"
 msgstr "Fjern denne oversettelsen"
 
-#: static/js/zamboni/password-strength.js:20
+#: static/js/common-all.js:10193 static/js/common-min.js:6 static/js/impala-all.js:10674 static/js/impala-min.js:6 static/js/zamboni/discovery-all.js:13678
+msgid "close"
+msgstr ""
+
+#: static/js/common-all.js:10860 static/js/common-min.js:6 static/js/impala-all.js:11481 static/js/impala-min.js:6 static/js/impala/reviews.js:23 static/js/zamboni/reviews.js:18
+msgid "Flagged for review"
+msgstr "Flagget for gjennomgang"
+
+#: static/js/common-all.js:10876 static/js/common-min.js:6 static/js/impala-all.js:11498 static/js/impala-min.js:6 static/js/impala/reviews.js:40 static/js/zamboni/reviews.js:34
+msgid "Your input is required"
+msgstr "Inndata er påkrevd"
+
+#: static/js/common-all.js:10945 static/js/common-min.js:6 static/js/impala-all.js:11610 static/js/impala-min.js:7 static/js/impala/reviews.js:152 static/js/zamboni/reviews.js:103
+msgid "Marked for deletion"
+msgstr "Markert for sletting"
+
+#: static/js/common-all.js:11573 static/js/common-min.js:7 static/js/impala-all.js:13809 static/js/impala-min.js:8 static/js/zamboni/collections.js:229
+msgid "Adding to Favorites&hellip;"
+msgstr "Legg til i favoritter &hellip;"
+
+#: static/js/common-all.js:11576 static/js/common-min.js:7 static/js/impala-all.js:13812 static/js/impala-min.js:8 static/js/zamboni/collections.js:232
+msgid "Removing Favorite&hellip;"
+msgstr "Fjerner favoritt &hellip;"
+
+#: static/js/common-all.js:11579 static/js/common-min.js:7 static/js/impala-all.js:13815 static/js/impala-min.js:8 static/js/zamboni/collections.js:235
+msgid "Add to Favorites"
+msgstr "Legg til i favoritter"
+
+#: static/js/common-all.js:11582 static/js/common-min.js:7 static/js/impala-all.js:13818 static/js/impala-min.js:8 static/js/zamboni/collections.js:238
+msgid "Remove from Favorites"
+msgstr "Fjern fra favoritter"
+
+#: static/js/common-all.js:11647 static/js/common-min.js:7 static/js/impala-all.js:13883 static/js/impala-min.js:8 static/js/zamboni/collections.js:303
+msgid "Pending"
+msgstr "Under behandling"
+
+#: static/js/common-all.js:11648 static/js/common-min.js:7 static/js/impala-all.js:13884 static/js/impala-min.js:8 static/js/zamboni/collections.js:304
+msgid "Add a comment"
+msgstr "Legg til kommentar"
+
+#: static/js/common-all.js:11648 static/js/common-min.js:7 static/js/impala-all.js:13884 static/js/impala-min.js:8 static/js/zamboni/collections.js:304
+msgid "Comment"
+msgstr "Kommentar"
+
+#: static/js/common-all.js:11649 static/js/common-min.js:7 static/js/impala-all.js:13885 static/js/impala-min.js:8 static/js/zamboni/collections.js:305
+msgid "Remove this add-on from the collection"
+msgstr "Fjern denne utvidelsen fra samlingen"
+
+#: static/js/common-all.js:11649 static/js/common-all.js:11678 static/js/common-min.js:7 static/js/impala-all.js:13885 static/js/impala-all.js:13914 static/js/impala-min.js:8
+#: static/js/zamboni/collections.js:305 static/js/zamboni/collections.js:334
+msgid "Remove"
+msgstr "Fjern"
+
+#: static/js/common-all.js:11678 static/js/common-min.js:7 static/js/impala-all.js:13914 static/js/impala-min.js:8 static/js/zamboni/collections.js:334
+msgid "Remove this user as a contributor"
+msgstr "Fjern denne brukeren som bidragsyter"
+
+#: static/js/common-all.js:11690 static/js/common-min.js:7 static/js/impala-all.js:13926 static/js/impala-min.js:8 static/js/zamboni/collections.js:346
+msgid "An email address is required."
+msgstr "En e-postadresse er påkrevd."
+
+#: static/js/common-all.js:11708 static/js/common-min.js:7 static/js/impala-all.js:13944 static/js/impala-min.js:8 static/js/zamboni/collections.js:364
+msgid "You cannot add yourself as a contributor."
+msgstr "Du kan ikke legge til deg selv som bidragsyter."
+
+#: static/js/common-all.js:11710 static/js/common-min.js:7 static/js/impala-all.js:13946 static/js/impala-min.js:8 static/js/zamboni/collections.js:366
+msgid "You have already added that user."
+msgstr "Du har allerede lagt til denne brukeren."
+
+#: static/js/common-all.js:11917 static/js/common-min.js:7 static/js/impala-all.js:14153 static/js/impala-min.js:8 static/js/zamboni/collections.js:573
+msgid "Add to favorites"
+msgstr "Legg til i favoritter"
+
+#: static/js/common-all.js:11921 static/js/common-min.js:7 static/js/impala-all.js:14157 static/js/impala-min.js:8 static/js/zamboni/collections.js:577
+msgid "Remove from favorites"
+msgstr "Fjern fra favoritter"
+
+#: static/js/common-all.js:11939 static/js/common-min.js:7 static/js/impala-all.js:14175 static/js/impala-all.js:14233 static/js/impala-min.js:8 static/js/impala/collections.js:10
+#: static/js/zamboni/collections.js:595
+msgid "Follow this Collection"
+msgstr "Følg denne samlingen"
+
+#: static/js/common-all.js:11948 static/js/common-min.js:7 static/js/impala-all.js:14184 static/js/impala-min.js:8 static/js/zamboni/collections.js:604
+msgid "Stop following"
+msgstr "Slutt å følge"
+
+#: static/js/common-all.js:12096 static/js/common-min.js:7 static/js/zamboni/password-strength.js:20
 msgid "Password strength:"
 msgstr "Passordstyrke:"
 
-#: static/js/zamboni/password-strength.js:26
+#: static/js/common-all.js:12102 static/js/common-min.js:7 static/js/zamboni/password-strength.js:26
 msgid "At least {0} character left."
 msgid_plural "At least {0} characters left."
 msgstr[0] "Minst {0} tegn igjen."
 msgstr[1] "Minst {0} tegn igjen."
 
-#: static/js/zamboni/themes_review.js:176
-msgid "Requested Info"
-msgstr "Forespurt info"
+#: static/js/common-all.js:12286 static/js/common-min.js:7 static/js/impala-all.js:14632 static/js/impala-min.js:8 static/js/impala/suggestions.js:39
+msgid "Search themes for <b>{0}</b>"
+msgstr "Søk i temaer etter <b>{0}</b>"
 
-#: static/js/zamboni/themes_review.js:177
-msgid "Flagged"
-msgstr "Flagget"
+#: static/js/common-all.js:12288 static/js/common-min.js:7 static/js/impala-all.js:14634 static/js/impala-min.js:8 static/js/impala/suggestions.js:41
+msgid "Search apps for <b>{0}</b>"
+msgstr "Søk i apps etter <b>{0}</b>"
 
-#: static/js/zamboni/themes_review.js:178
-msgid "Duplicate"
-msgstr "Duplikat"
+#: static/js/common-all.js:12290 static/js/common-min.js:7 static/js/impala-all.js:14636 static/js/impala-min.js:8 static/js/impala/suggestions.js:43
+msgid "Search add-ons for <b>{0}</b>"
+msgstr "Søk i utvidelser etter <b>{0}</b>"
 
-#: static/js/zamboni/themes_review.js:179
-msgid "Rejected"
-msgstr "Avvist"
+#: static/js/common-all.js:12521 static/js/common-min.js:7 static/js/impala-all.js:14867 static/js/impala-min.js:8 static/js/impala/site_suggestions.js:46
+msgid "Category"
+msgstr "Kategori"
 
-#: static/js/zamboni/themes_review.js:180
-msgid "Approved"
-msgstr "Godkjent"
+#. L10n: {0} is an app name.
+#: static/js/impala-all.js:11632 static/js/impala-min.js:7 static/js/impala/listing.js:11 static/js/zamboni/themes.js:13
+msgid "This theme is incompatible with your version of {0}"
+msgstr "Dette temaet er inkompatibelt med din versjon av {0}"
 
-#: static/js/zamboni/themes_review.js:424
-msgid "No results found"
+#: static/js/impala-all.js:12146 static/js/impala-all.js:14331 static/js/impala-min.js:7 static/js/impala-min.js:8 static/js/common/upload-image.js:97 static/js/impala/users.js:51
+#: static/js/zamboni/devhub-all.js:894 static/js/zamboni/devhub-min.js:1
+msgid "Images must be either PNG or JPG."
+msgstr "Bilder må være enten PNG eller JPG."
+
+#: static/js/impala-all.js:12150 static/js/impala-min.js:7 static/js/common/upload-image.js:101 static/js/zamboni/devhub-all.js:898 static/js/zamboni/devhub-min.js:1
+msgid "Videos must be in WebM."
+msgstr "Videoer må være i WebM."
+
+#: static/js/impala-all.js:12177 static/js/impala-min.js:7 static/js/common/upload-addon.js:41 static/js/common/upload-image.js:128 static/js/zamboni/devhub-all.js:272
+#: static/js/zamboni/devhub-all.js:925 static/js/zamboni/devhub-min.js:1
+msgid "There was a problem contacting the server."
+msgstr "Et problem oppstod ved forsøk på å kontakte serveren."
+
+#: static/js/impala-all.js:13298 static/js/impala-min.js:7 static/js/impala/persona_creation.js:60
+msgid "All Rights Reserved"
+msgstr "Med enerett"
+
+#: static/js/impala-all.js:13302 static/js/impala-min.js:7 static/js/impala/persona_creation.js:64
+msgid "Creative Commons Attribution 3.0"
+msgstr "Creative Commons Attribution 3.0"
+
+#: static/js/impala-all.js:13307 static/js/impala-min.js:7 static/js/impala/persona_creation.js:69
+msgid "Creative Commons Attribution-NonCommercial 3.0"
+msgstr "Creative Commons Attribution-NonCommercial 3.0"
+
+#: static/js/impala-all.js:13312 static/js/impala-min.js:7 static/js/impala/persona_creation.js:74
+msgid "Creative Commons Attribution-NonCommercial-NoDerivs 3.0"
+msgstr "Creative Commons Attribution-NonCommercial-NoDerivs 3.0"
+
+#: static/js/impala-all.js:13317 static/js/impala-min.js:7 static/js/impala/persona_creation.js:79
+msgid "Creative Commons Attribution-NonCommercial-Share Alike 3.0"
+msgstr "Creative Commons Attribution-NonCommercial-Share Alike 3.0"
+
+#: static/js/impala-all.js:13322 static/js/impala-min.js:7 static/js/impala/persona_creation.js:84
+msgid "Creative Commons Attribution-NoDerivs 3.0"
+msgstr "Creative Commons Attribution-NoDerivs 3.0"
+
+#: static/js/impala-all.js:13327 static/js/impala-min.js:7 static/js/impala/persona_creation.js:89
+msgid "Creative Commons Attribution-ShareAlike 3.0"
+msgstr "Creative Commons Attribution-ShareAlike 3.0"
+
+#: static/js/impala-all.js:13530 static/js/impala-min.js:7 static/js/impala/persona_creation.js:292
+msgid "Your Theme's Name"
+msgstr "Navn på temaet"
+
+#: static/js/impala-all.js:14242 static/js/impala-min.js:8 static/js/impala/collections.js:19
+msgid "Stop Following"
+msgstr "Stopp følging"
+
+#: static/js/impala-all.js:14243 static/js/impala-min.js:8 static/js/impala/collections.js:20
+msgid "Following"
+msgstr "Følger"
+
+#: static/js/impala-all.js:14313 static/js/impala-min.js:8 static/js/impala/users.js:33
+msgid "use original"
+msgstr "bruk original"
+
+#: static/js/impala-all.js:14523 static/js/impala-min.js:8 static/js/impala/search.js:114
+msgid "Updating results&hellip;"
+msgstr "Oppdaterer resultater &hellip;"
+
+#: static/js/common/upload-addon.js:69 static/js/zamboni/devhub-all.js:300 static/js/zamboni/devhub-min.js:1
+msgid "Select a file..."
+msgstr "Velg fil ..."
+
+#: static/js/common/upload-addon.js:70 static/js/zamboni/devhub-all.js:301 static/js/zamboni/devhub-min.js:1
+msgid "Your add-on should end with .xpi, .jar or .xml"
+msgstr "Utvidelsen må ende på .xpi, .jar eller .xml"
+
+#. L10n: {0} is the percent of the file that has been uploaded.
+#: static/js/common/upload-addon.js:104 static/js/zamboni/devhub-all.js:335 static/js/zamboni/devhub-min.js:1
+#, fuzzy, python-format
+msgid "{0}% complete"
+msgstr "{0} % fullført"
+
+#. L10n: "{bytes uploaded} of {total filesize}".
+#: static/js/common/upload-addon.js:107 static/js/zamboni/devhub-all.js:338 static/js/zamboni/devhub-min.js:1
+msgid "{0} of {1}"
+msgstr "{0} av {1}"
+
+#: static/js/common/upload-addon.js:140 static/js/zamboni/devhub-all.js:371 static/js/zamboni/devhub-min.js:1
+msgid "Cancel"
+msgstr "Avbryt"
+
+#: static/js/common/upload-addon.js:162 static/js/zamboni/devhub-all.js:393 static/js/zamboni/devhub-min.js:1
+msgid "Uploading {0}"
+msgstr "Laster opp {0}"
+
+#: static/js/common/upload-addon.js:189 static/js/zamboni/devhub-all.js:420 static/js/zamboni/devhub-min.js:1
+msgid "Error with {0}"
+msgstr "Feil med {0}"
+
+#: static/js/common/upload-addon.js:194 static/js/zamboni/devhub-all.js:425 static/js/zamboni/devhub-min.js:1
+msgid "Your add-on failed validation with {0} error."
+msgid_plural "Your add-on failed validation with {0} errors."
+msgstr[0] "Validering av utvidelsen gav {0} feil."
+msgstr[1] "Validering av utvidelsen gav {0} feil."
+
+#: static/js/common/upload-addon.js:208 static/js/zamboni/devhub-all.js:439 static/js/zamboni/devhub-min.js:1
+msgid "&hellip;and {0} more"
+msgid_plural "&hellip;and {0} more"
+msgstr[0] "&hellip;og {0} flere"
+msgstr[1] "&hellip;og {0} flere"
+
+#: static/js/common/upload-addon.js:222 static/js/common/upload-addon.js:497 static/js/zamboni/devhub-all.js:453 static/js/zamboni/devhub-all.js:743 static/js/zamboni/devhub-min.js:1
+msgid "See full validation report"
+msgstr "Se fullstendig valideringsrapport"
+
+#: static/js/common/upload-addon.js:234 static/js/zamboni/devhub-all.js:465 static/js/zamboni/devhub-min.js:1
+msgid "Validating {0}"
+msgstr "Validerer {0}"
+
+#. L10n: first argument is an HTTP status code
+#: static/js/common/upload-addon.js:273 static/js/zamboni/devhub-all.js:504 static/js/zamboni/devhub-min.js:1
+msgid "Received an empty response from the server; status: {0}"
+msgstr "Mottok en tom respons fra serveren; status: {0}"
+
+#: static/js/common/upload-addon.js:370 static/js/zamboni/devhub-all.js:604 static/js/zamboni/devhub-min.js:1
+msgid "Unexpected server error while validating."
+msgstr "Uventet serverfeil ved validering."
+
+#: static/js/common/upload-addon.js:409 static/js/zamboni/devhub-all.js:643 static/js/zamboni/devhub-min.js:1
+msgid "Finished validating {0}"
+msgstr "Fullførte validering av {0}"
+
+#: static/js/common/upload-addon.js:415 static/js/zamboni/devhub-all.js:649 static/js/zamboni/devhub-min.js:1
+msgid "Your add-on validation timed out, it will be manually reviewed."
 msgstr ""
 
-#: static/js/zamboni/themes_review_templates.js:31
-msgid "Theme"
+#: static/js/common/upload-addon.js:418 static/js/zamboni/devhub-all.js:652 static/js/zamboni/devhub-min.js:1
+msgid "Your add-on was validated with no errors and {0} warning."
+msgid_plural "Your add-on was validated with no errors and {0} warnings."
+msgstr[0] ""
+msgstr[1] ""
+
+#: static/js/common/upload-addon.js:423 static/js/zamboni/devhub-all.js:657 static/js/zamboni/devhub-min.js:1
+msgid "Your add-on was validated with no errors and {0} message."
+msgid_plural "Your add-on was validated with no errors and {0} messages."
+msgstr[0] ""
+msgstr[1] ""
+
+#: static/js/common/upload-addon.js:428 static/js/zamboni/devhub-all.js:662 static/js/zamboni/devhub-min.js:1
+msgid "Your add-on was validated with no errors or warnings."
 msgstr ""
 
-#: static/js/zamboni/themes_review_templates.js:33
-msgid "Reviewer"
+#: static/js/common/upload-addon.js:443 static/js/zamboni/devhub-all.js:677 static/js/zamboni/devhub-min.js:1
+msgid "Your submission will be automatically signed."
 msgstr ""
 
-#: static/js/zamboni/themes_review_templates.js:35
-msgid "Status"
+#: static/js/common/upload-addon.js:450 static/js/zamboni/devhub-all.js:696 static/js/zamboni/devhub-min.js:1
+msgid "Include detailed version notes (this can be done in the next step)."
 msgstr ""
 
-#: static/js/zamboni/validator.js:80
+#: static/js/common/upload-addon.js:451 static/js/zamboni/devhub-all.js:697 static/js/zamboni/devhub-min.js:1
+msgid "If your add-on requires an account to a website in order to be fully tested, include a test username and password in the Notes to Reviewer (this can be done in the next step)."
+msgstr ""
+
+#: static/js/common/upload-addon.js:452 static/js/zamboni/devhub-all.js:698 static/js/zamboni/devhub-min.js:1
+msgid "If your add-on is intended for a limited audience you should choose Preliminary Review instead of Full Review."
+msgstr ""
+
+#: static/js/common/upload-addon.js:465 static/js/zamboni/devhub-all.js:711 static/js/zamboni/devhub-min.js:1
+msgid "Add-on submission checklist"
+msgstr ""
+
+#: static/js/common/upload-addon.js:466 static/js/zamboni/devhub-all.js:712 static/js/zamboni/devhub-min.js:1
+msgid "Please verify the following points before finalizing your submission. This will minimize delays or misunderstanding during the review process:"
+msgstr ""
+
+#: static/js/common/upload-addon.js:468 static/js/zamboni/devhub-all.js:714 static/js/zamboni/devhub-min.js:1
+msgid ""
+"Compiled binaries, as well as minified or obfuscated scripts (excluding known libraries) need to have their sources submitted separately for review. Make sure that you use the source code upload "
+"field to avoid having your submission rejected."
+msgstr ""
+
+#: static/js/common/upload-addon.js:486 static/js/zamboni/devhub-all.js:732 static/js/zamboni/devhub-min.js:1
+msgid "The validation process found these issues that can lead to rejections:"
+msgstr ""
+
+#: static/js/common/upload-addon.js:503 static/js/zamboni/devhub-all.js:749 static/js/zamboni/devhub-min.js:1
+msgid "If you are unfamiliar with the add-ons review process, you can read about it here."
+msgstr ""
+
+#: static/js/common/upload-addon.js:540 static/js/zamboni/devhub-all.js:786 static/js/zamboni/devhub-min.js:1
+msgid "Sorry, no supported platform has been found."
+msgstr "Beklager, ingen støttet plattform har blitt funnet."
+
+#: static/js/common/upload-base.js:57 static/js/zamboni/devhub-all.js:187 static/js/zamboni/devhub-min.js:1
+msgid "The filetype you uploaded isn't recognized."
+msgstr "Filtypen du lastet opp er ikke gjenkjent."
+
+#: static/js/common/upload-base.js:79 static/js/zamboni/devhub-all.js:209 static/js/zamboni/devhub-min.js:1
+msgid "You cancelled the upload."
+msgstr "Du avbrøt opplastingen."
+
+#: static/js/impala/stats/chart.js:267 static/js/zamboni/stats-all.js:16898 static/js/zamboni/stats-min.js:5
+msgid "Week of {0}"
+msgstr "Uke {0}"
+
+#: static/js/impala/stats/chart.js:269 static/js/zamboni/stats-all.js:16900 static/js/zamboni/stats-min.js:5
+msgid " downloads"
+msgstr ""
+
+#: static/js/impala/stats/chart.js:270 static/js/zamboni/stats-all.js:16901 static/js/zamboni/stats-min.js:5
+msgid "{0} users"
+msgstr "{0} brukere"
+
+#: static/js/impala/stats/chart.js:271 static/js/zamboni/stats-all.js:16902 static/js/zamboni/stats-min.js:5
+msgid "{0} add-ons"
+msgstr "{0} utvidelser"
+
+#: static/js/impala/stats/chart.js:272 static/js/zamboni/stats-all.js:16903 static/js/zamboni/stats-min.js:5
+msgid "{0} collections"
+msgstr "{0} samlinger"
+
+#: static/js/impala/stats/chart.js:273 static/js/zamboni/stats-all.js:16904 static/js/zamboni/stats-min.js:5
+msgid "{0} reviews"
+msgstr "{0} anmeldelser"
+
+#: static/js/impala/stats/chart.js:275 static/js/zamboni/stats-all.js:16906 static/js/zamboni/stats-min.js:5
+msgid "{0} sales"
+msgstr "{0} salg"
+
+#: static/js/impala/stats/chart.js:276 static/js/zamboni/stats-all.js:16907 static/js/zamboni/stats-min.js:5
+msgid "{0} refunds"
+msgstr "{0} tilbakebetalinger"
+
+#: static/js/impala/stats/chart.js:277 static/js/zamboni/stats-all.js:16908 static/js/zamboni/stats-min.js:5
+msgid "{0} installs"
+msgstr "{0} installeringer"
+
+#: static/js/impala/stats/chart.js:369 static/js/impala/stats/csv_keys.js:3 static/js/impala/stats/csv_keys.js:109 static/js/zamboni/stats-all.js:15284 static/js/zamboni/stats-all.js:15390
+#: static/js/zamboni/stats-all.js:17000 static/js/zamboni/stats-min.js:4 static/js/zamboni/stats-min.js:5
+msgid "Downloads"
+msgstr "Nedlastinger"
+
+#: static/js/impala/stats/chart.js:379 static/js/impala/stats/csv_keys.js:6 static/js/impala/stats/csv_keys.js:110 static/js/zamboni/stats-all.js:15287 static/js/zamboni/stats-all.js:15391
+#: static/js/zamboni/stats-all.js:17010 static/js/zamboni/stats-min.js:4 static/js/zamboni/stats-min.js:5
+msgid "Daily Users"
+msgstr "Daglige brukere"
+
+#: static/js/impala/stats/chart.js:410 static/js/zamboni/stats-all.js:17041 static/js/zamboni/stats-min.js:5
+msgid "Amount, in USD"
+msgstr "Beløp, i USD"
+
+#: static/js/impala/stats/chart.js:421 static/js/impala/stats/csv_keys.js:104 static/js/zamboni/stats-all.js:15385 static/js/zamboni/stats-all.js:17052 static/js/zamboni/stats-min.js:5
+msgid "Number of Contributions"
+msgstr "Antall bidragsytere"
+
+#: static/js/impala/stats/chart.js:447 static/js/zamboni/stats-all.js:17078 static/js/zamboni/stats-min.js:5
+msgid "More Info..."
+msgstr "Mer info ..."
+
+#. L10n: {0} is an ISO-formatted date.
+#: static/js/impala/stats/chart.js:451 static/js/zamboni/stats-all.js:17082 static/js/zamboni/stats-min.js:5
+msgid "Details for {0}"
+msgstr "Detaljer for {0}"
+
+#: static/js/impala/stats/csv_keys.js:9 static/js/zamboni/stats-all.js:15290 static/js/zamboni/stats-min.js:4
+msgid "Collections Created"
+msgstr "Samlinger opprettet"
+
+#: static/js/impala/stats/csv_keys.js:12 static/js/zamboni/stats-all.js:15293 static/js/zamboni/stats-min.js:4
+msgid "Add-ons in Use"
+msgstr "Utvidelser i bruk"
+
+#: static/js/impala/stats/csv_keys.js:15 static/js/zamboni/stats-all.js:15296 static/js/zamboni/stats-min.js:4
+msgid "Add-ons Created"
+msgstr "Utvidelser opprettet"
+
+#: static/js/impala/stats/csv_keys.js:18 static/js/zamboni/stats-all.js:15299 static/js/zamboni/stats-min.js:4
+msgid "Add-ons Downloaded"
+msgstr "Utvidelser lastet ned"
+
+#: static/js/impala/stats/csv_keys.js:21 static/js/zamboni/stats-all.js:15302 static/js/zamboni/stats-min.js:4
+msgid "Add-ons Updated"
+msgstr "Utvidelser oppdatert"
+
+#: static/js/impala/stats/csv_keys.js:24 static/js/zamboni/stats-all.js:15305 static/js/zamboni/stats-min.js:4
+msgid "Reviews Written"
+msgstr "Anmeldelser skrevet"
+
+#: static/js/impala/stats/csv_keys.js:27 static/js/zamboni/stats-all.js:15308 static/js/zamboni/stats-min.js:4
+msgid "User Signups"
+msgstr "Brukerregistreringer"
+
+#: static/js/impala/stats/csv_keys.js:30 static/js/zamboni/stats-all.js:15311 static/js/zamboni/stats-min.js:4
+msgid "Subscribers"
+msgstr "Abonnementer"
+
+#: static/js/impala/stats/csv_keys.js:33 static/js/zamboni/stats-all.js:15314 static/js/zamboni/stats-min.js:4
+msgid "Ratings"
+msgstr "Rangering"
+
+#: static/js/impala/stats/csv_keys.js:36 static/js/impala/stats/csv_keys.js:114 static/js/zamboni/stats-all.js:15317 static/js/zamboni/stats-all.js:15395 static/js/zamboni/stats-min.js:4
+#: static/js/zamboni/stats-min.js:5
+msgid "Sales"
+msgstr "Salg"
+
+#: static/js/impala/stats/csv_keys.js:39 static/js/impala/stats/csv_keys.js:113 static/js/zamboni/stats-all.js:15320 static/js/zamboni/stats-all.js:15394 static/js/zamboni/stats-min.js:4
+#: static/js/zamboni/stats-min.js:5
+msgid "Installs"
+msgstr "Installeringer"
+
+#: static/js/impala/stats/csv_keys.js:42 static/js/zamboni/stats-all.js:15323 static/js/zamboni/stats-min.js:4
+msgid "Unknown"
+msgstr "Ukjent"
+
+#: static/js/impala/stats/csv_keys.js:43 static/js/zamboni/stats-all.js:15324 static/js/zamboni/stats-min.js:4
+msgid "Add-ons Manager"
+msgstr "Utvidelsesbehandler"
+
+#: static/js/impala/stats/csv_keys.js:44 static/js/zamboni/stats-all.js:15325 static/js/zamboni/stats-min.js:4
+msgid "Add-ons Manager Promo"
+msgstr ""
+
+#: static/js/impala/stats/csv_keys.js:45 static/js/zamboni/stats-all.js:15326 static/js/zamboni/stats-min.js:4
+msgid "Add-ons Manager Featured"
+msgstr ""
+
+#: static/js/impala/stats/csv_keys.js:46 static/js/zamboni/stats-all.js:15327 static/js/zamboni/stats-min.js:4
+msgid "Add-ons Manager Learn More"
+msgstr ""
+
+#: static/js/impala/stats/csv_keys.js:47 static/js/zamboni/stats-all.js:15328 static/js/zamboni/stats-min.js:4
+msgid "Search Suggestions"
+msgstr ""
+
+#: static/js/impala/stats/csv_keys.js:48 static/js/zamboni/stats-all.js:15329 static/js/zamboni/stats-min.js:4
+msgid "Search Results"
+msgstr "Søkeresultater"
+
+#: static/js/impala/stats/csv_keys.js:49 static/js/impala/stats/csv_keys.js:50 static/js/impala/stats/csv_keys.js:51 static/js/zamboni/stats-all.js:15330 static/js/zamboni/stats-all.js:15331
+#: static/js/zamboni/stats-all.js:15332 static/js/zamboni/stats-min.js:4
+msgid "Homepage Promo"
+msgstr "Hjemmeside-promo"
+
+#: static/js/impala/stats/csv_keys.js:52 static/js/impala/stats/csv_keys.js:53 static/js/zamboni/stats-all.js:15333 static/js/zamboni/stats-all.js:15334 static/js/zamboni/stats-min.js:4
+msgid "Homepage Featured"
+msgstr "Hjemmeside fremhevet"
+
+#: static/js/impala/stats/csv_keys.js:54 static/js/impala/stats/csv_keys.js:55 static/js/zamboni/stats-all.js:15335 static/js/zamboni/stats-all.js:15336 static/js/zamboni/stats-min.js:4
+msgid "Homepage Up and Coming"
+msgstr "Hjemmeside fremgangsrik"
+
+#: static/js/impala/stats/csv_keys.js:56 static/js/zamboni/stats-all.js:15337 static/js/zamboni/stats-min.js:4
+msgid "Homepage Most Popular"
+msgstr "Hjemmeside mest populær"
+
+#: static/js/impala/stats/csv_keys.js:57 static/js/impala/stats/csv_keys.js:59 static/js/zamboni/stats-all.js:15338 static/js/zamboni/stats-all.js:15340 static/js/zamboni/stats-min.js:4
+msgid "Detail Page"
+msgstr "Detaljside"
+
+#: static/js/impala/stats/csv_keys.js:58 static/js/impala/stats/csv_keys.js:60 static/js/zamboni/stats-all.js:15339 static/js/zamboni/stats-all.js:15341 static/js/zamboni/stats-min.js:4
+msgid "Detail Page (bottom)"
+msgstr "Detaljside (bunn)"
+
+#: static/js/impala/stats/csv_keys.js:61 static/js/zamboni/stats-all.js:15342 static/js/zamboni/stats-min.js:4
+msgid "Detail Page (Development Channel)"
+msgstr "Detaljside (utviklerkanal)"
+
+#: static/js/impala/stats/csv_keys.js:62 static/js/impala/stats/csv_keys.js:63 static/js/impala/stats/csv_keys.js:64 static/js/zamboni/stats-all.js:15343 static/js/zamboni/stats-all.js:15344
+#: static/js/zamboni/stats-all.js:15345 static/js/zamboni/stats-min.js:4
+msgid "Often Used With"
+msgstr "Ofte brukt sammen med"
+
+#: static/js/impala/stats/csv_keys.js:65 static/js/impala/stats/csv_keys.js:66 static/js/zamboni/stats-all.js:15346 static/js/zamboni/stats-all.js:15347 static/js/zamboni/stats-min.js:4
+msgid "Others By Author"
+msgstr "Andre av forfatteren"
+
+#: static/js/impala/stats/csv_keys.js:67 static/js/impala/stats/csv_keys.js:68 static/js/zamboni/stats-all.js:15348 static/js/zamboni/stats-all.js:15349 static/js/zamboni/stats-min.js:4
+msgid "Dependencies"
+msgstr "Avhengigheter"
+
+#: static/js/impala/stats/csv_keys.js:69 static/js/impala/stats/csv_keys.js:70 static/js/zamboni/stats-all.js:15350 static/js/zamboni/stats-all.js:15351 static/js/zamboni/stats-min.js:4
+msgid "Upsell"
+msgstr "Oppsalg"
+
+#: static/js/impala/stats/csv_keys.js:71 static/js/zamboni/stats-all.js:15352 static/js/zamboni/stats-min.js:4
+msgid "Meet the Developer"
+msgstr ""
+
+#: static/js/impala/stats/csv_keys.js:72 static/js/zamboni/stats-all.js:15353 static/js/zamboni/stats-min.js:4
+msgid "User Profile"
+msgstr ""
+
+#: static/js/impala/stats/csv_keys.js:73 static/js/zamboni/stats-all.js:15354 static/js/zamboni/stats-min.js:4
+msgid "Version History"
+msgstr ""
+
+#: static/js/impala/stats/csv_keys.js:75 static/js/zamboni/stats-all.js:15356 static/js/zamboni/stats-min.js:4
+msgid "Sharing"
+msgstr "Deler"
+
+#: static/js/impala/stats/csv_keys.js:76 static/js/zamboni/stats-all.js:15357 static/js/zamboni/stats-min.js:4
+msgid "Category Pages"
+msgstr "Kategorisider"
+
+#: static/js/impala/stats/csv_keys.js:77 static/js/zamboni/stats-all.js:15358 static/js/zamboni/stats-min.js:4
+msgid "Collections"
+msgstr "Samlinger"
+
+#: static/js/impala/stats/csv_keys.js:78 static/js/impala/stats/csv_keys.js:79 static/js/zamboni/stats-all.js:15359 static/js/zamboni/stats-all.js:15360 static/js/zamboni/stats-min.js:4
+msgid "Category Landing Featured Carousel"
+msgstr "Kategorilanding fremhevet karusell"
+
+#: static/js/impala/stats/csv_keys.js:80 static/js/impala/stats/csv_keys.js:81 static/js/zamboni/stats-all.js:15361 static/js/zamboni/stats-all.js:15362 static/js/zamboni/stats-min.js:4
+msgid "Category Landing Top Rated"
+msgstr "Kategorilanding topprangert"
+
+#: static/js/impala/stats/csv_keys.js:82 static/js/impala/stats/csv_keys.js:83 static/js/zamboni/stats-all.js:15363 static/js/zamboni/stats-all.js:15364 static/js/zamboni/stats-min.js:5
+msgid "Category Landing Most Popular"
+msgstr "Kategorilanding mest populær"
+
+#: static/js/impala/stats/csv_keys.js:84 static/js/impala/stats/csv_keys.js:85 static/js/zamboni/stats-all.js:15365 static/js/zamboni/stats-all.js:15366 static/js/zamboni/stats-min.js:5
+msgid "Category Landing Recently Added"
+msgstr "Kategorilanding nylig lagt til"
+
+#: static/js/impala/stats/csv_keys.js:86 static/js/impala/stats/csv_keys.js:87 static/js/zamboni/stats-all.js:15367 static/js/zamboni/stats-all.js:15368 static/js/zamboni/stats-min.js:5
+msgid "Browse Listing Featured Sort"
+msgstr "Listegjennomgang sortert etter fremhevet"
+
+#: static/js/impala/stats/csv_keys.js:88 static/js/impala/stats/csv_keys.js:89 static/js/zamboni/stats-all.js:15369 static/js/zamboni/stats-all.js:15370 static/js/zamboni/stats-min.js:5
+msgid "Browse Listing Users Sort"
+msgstr "Listegjennomgang sortert etter brukere"
+
+#: static/js/impala/stats/csv_keys.js:90 static/js/impala/stats/csv_keys.js:91 static/js/zamboni/stats-all.js:15371 static/js/zamboni/stats-all.js:15372 static/js/zamboni/stats-min.js:5
+msgid "Browse Listing Rating Sort"
+msgstr "Listegjennomgang sortert etter rangering"
+
+#: static/js/impala/stats/csv_keys.js:92 static/js/impala/stats/csv_keys.js:93 static/js/zamboni/stats-all.js:15373 static/js/zamboni/stats-all.js:15374 static/js/zamboni/stats-min.js:5
+msgid "Browse Listing Created Sort"
+msgstr "Listegjennomgang sortert etter opprettet"
+
+#: static/js/impala/stats/csv_keys.js:94 static/js/impala/stats/csv_keys.js:95 static/js/zamboni/stats-all.js:15375 static/js/zamboni/stats-all.js:15376 static/js/zamboni/stats-min.js:5
+msgid "Browse Listing Name Sort"
+msgstr "Listegjennomgang sortert etter navn"
+
+#: static/js/impala/stats/csv_keys.js:96 static/js/impala/stats/csv_keys.js:97 static/js/zamboni/stats-all.js:15377 static/js/zamboni/stats-all.js:15378 static/js/zamboni/stats-min.js:5
+msgid "Browse Listing Popular Sort"
+msgstr "Listegjennomgang sortert etter popularitet"
+
+#: static/js/impala/stats/csv_keys.js:98 static/js/impala/stats/csv_keys.js:99 static/js/zamboni/stats-all.js:15379 static/js/zamboni/stats-all.js:15380 static/js/zamboni/stats-min.js:5
+msgid "Browse Listing Updated Sort"
+msgstr "Listegjennomgang sortert etter oppdatert"
+
+#: static/js/impala/stats/csv_keys.js:100 static/js/impala/stats/csv_keys.js:101 static/js/zamboni/stats-all.js:15381 static/js/zamboni/stats-all.js:15382 static/js/zamboni/stats-min.js:5
+msgid "Browse Listing Up and Coming Sort"
+msgstr "Listegjennomgang sortert etter fremgangsrik"
+
+#: static/js/impala/stats/csv_keys.js:105 static/js/zamboni/stats-all.js:15386 static/js/zamboni/stats-min.js:5
+msgid "Total Amount Contributed"
+msgstr "Totalt bidragsbeløp"
+
+#: static/js/impala/stats/csv_keys.js:106 static/js/zamboni/stats-all.js:15387 static/js/zamboni/stats-min.js:5
+msgid "Average Contribution"
+msgstr "Gjennomsnittelig bidrag"
+
+#: static/js/impala/stats/csv_keys.js:115 static/js/zamboni/stats-all.js:15396 static/js/zamboni/stats-min.js:5
+msgid "Usage"
+msgstr "Bruk"
+
+#: static/js/impala/stats/csv_keys.js:118 static/js/zamboni/stats-all.js:15399 static/js/zamboni/stats-min.js:5
+msgid "Firefox"
+msgstr "Firefox"
+
+#: static/js/impala/stats/csv_keys.js:119 static/js/zamboni/stats-all.js:15400 static/js/zamboni/stats-min.js:5
+msgid "Mozilla"
+msgstr "Mozilla"
+
+#: static/js/impala/stats/csv_keys.js:120 static/js/zamboni/stats-all.js:15401 static/js/zamboni/stats-min.js:5
+msgid "Thunderbird"
+msgstr "Thunderbird"
+
+#: static/js/impala/stats/csv_keys.js:121 static/js/zamboni/stats-all.js:15402 static/js/zamboni/stats-min.js:5
+msgid "Sunbird"
+msgstr "Sunbird"
+
+#: static/js/impala/stats/csv_keys.js:122 static/js/zamboni/stats-all.js:15403 static/js/zamboni/stats-min.js:5
+msgid "SeaMonkey"
+msgstr "SeaMonkey"
+
+#: static/js/impala/stats/csv_keys.js:123 static/js/zamboni/stats-all.js:15404 static/js/zamboni/stats-min.js:5
+msgid "Fennec"
+msgstr "Fennec"
+
+#: static/js/impala/stats/csv_keys.js:124 static/js/zamboni/stats-all.js:15405 static/js/zamboni/stats-min.js:5
+msgid "Android"
+msgstr ""
+
+#. L10n: {0} is an integer.
+#: static/js/impala/stats/csv_keys.js:129 static/js/zamboni/stats-all.js:15410 static/js/zamboni/stats-min.js:5
+msgid "Downloads and Daily Users, last {0} days"
+msgstr "Nedlastinger og daglige brukere, siste {0} dager"
+
+#. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
+#: static/js/impala/stats/csv_keys.js:131 static/js/zamboni/stats-all.js:15412 static/js/zamboni/stats-min.js:5
+msgid "Downloads and Daily Users from {0} to {1}"
+msgstr "Nedlastinger og daglige brukere fra {0} til {1}"
+
+#. L10n: {0} is an integer.
+#: static/js/impala/stats/csv_keys.js:135 static/js/zamboni/stats-all.js:15416 static/js/zamboni/stats-min.js:5
+msgid "Installs and Daily Users, last {0} days"
+msgstr "Installeringer og daglige brukere, siste {0} dager"
+
+#. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
+#: static/js/impala/stats/csv_keys.js:137 static/js/zamboni/stats-all.js:15418 static/js/zamboni/stats-min.js:5
+msgid "Installs and Daily Users from {0} to {1}"
+msgstr "Installeringer og daglige brukere fra {0} til {1}"
+
+#. L10n: {0} is an integer.
+#: static/js/impala/stats/csv_keys.js:141 static/js/zamboni/stats-all.js:15422 static/js/zamboni/stats-min.js:5
+msgid "Downloads, last {0} days"
+msgstr "Nedlastinger, siste {0} dager"
+
+#. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
+#: static/js/impala/stats/csv_keys.js:143 static/js/zamboni/stats-all.js:15424 static/js/zamboni/stats-min.js:5
+msgid "Downloads from {0} to {1}"
+msgstr "Nedlastinger fra {0} til {1}"
+
+#. L10n: {0} is an integer.
+#: static/js/impala/stats/csv_keys.js:147 static/js/zamboni/stats-all.js:15428 static/js/zamboni/stats-min.js:5
+msgid "Daily Users, last {0} days"
+msgstr "Daglige brukere, siste {0} dager"
+
+#. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
+#: static/js/impala/stats/csv_keys.js:149 static/js/zamboni/stats-all.js:15430 static/js/zamboni/stats-min.js:5
+msgid "Daily Users from {0} to {1}"
+msgstr "Daglige brukere fra {0} til {1}"
+
+#. L10n: {0} is an integer.
+#: static/js/impala/stats/csv_keys.js:153 static/js/zamboni/stats-all.js:15434 static/js/zamboni/stats-min.js:5
+msgid "Applications, last {0} days"
+msgstr "Programmer, siste {0} dager"
+
+#. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
+#: static/js/impala/stats/csv_keys.js:155 static/js/zamboni/stats-all.js:15436 static/js/zamboni/stats-min.js:5
+msgid "Applications from {0} to {1}"
+msgstr "Programmer fra {0} til {1}"
+
+#. L10n: {0} is an integer.
+#: static/js/impala/stats/csv_keys.js:159 static/js/zamboni/stats-all.js:15440 static/js/zamboni/stats-min.js:5
+msgid "Platforms, last {0} days"
+msgstr "Plattformer, siste {0} dager"
+
+#. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
+#: static/js/impala/stats/csv_keys.js:161 static/js/zamboni/stats-all.js:15442 static/js/zamboni/stats-min.js:5
+msgid "Platforms from {0} to {1}"
+msgstr "Plattformer fra {0} til {1}"
+
+#. L10n: {0} is an integer.
+#: static/js/impala/stats/csv_keys.js:165 static/js/zamboni/stats-all.js:15446 static/js/zamboni/stats-min.js:5
+msgid "Languages, last {0} days"
+msgstr "Språk, siste {0} dager"
+
+#. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
+#: static/js/impala/stats/csv_keys.js:167 static/js/zamboni/stats-all.js:15448 static/js/zamboni/stats-min.js:5
+msgid "Languages from {0} to {1}"
+msgstr "Språk fra {0} til {1}"
+
+#. L10n: {0} is an integer.
+#: static/js/impala/stats/csv_keys.js:171 static/js/zamboni/stats-all.js:15452 static/js/zamboni/stats-min.js:5
+msgid "Add-on Versions, last {0} days"
+msgstr "Utvidelsesversjoner, siste {0} dager"
+
+#. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
+#: static/js/impala/stats/csv_keys.js:173 static/js/zamboni/stats-all.js:15454 static/js/zamboni/stats-min.js:5
+msgid "Add-on Versions from {0} to {1}"
+msgstr "Utvidelsesversjoner fra {0} til {1}"
+
+#. L10n: {0} is an integer.
+#: static/js/impala/stats/csv_keys.js:177 static/js/zamboni/stats-all.js:15458 static/js/zamboni/stats-min.js:5
+msgid "Add-on Status, last {0} days"
+msgstr "Utvidelsesstatus, siste {0} dager"
+
+#. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
+#: static/js/impala/stats/csv_keys.js:179 static/js/zamboni/stats-all.js:15460 static/js/zamboni/stats-min.js:5
+msgid "Add-on Status from {0} to {1}"
+msgstr "Utvidelsesstatus fra {0} til {1}"
+
+#. L10n: {0} is an integer.
+#: static/js/impala/stats/csv_keys.js:183 static/js/zamboni/stats-all.js:15464 static/js/zamboni/stats-min.js:5
+msgid "Download Sources, last {0} days"
+msgstr "Nedlastingskilder, siste {0} dager"
+
+#. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
+#: static/js/impala/stats/csv_keys.js:185 static/js/zamboni/stats-all.js:15466 static/js/zamboni/stats-min.js:5
+msgid "Download Sources from {0} to {1}"
+msgstr "Nedlastingskilder fra {0} til {1}"
+
+#. L10n: {0} is an integer.
+#: static/js/impala/stats/csv_keys.js:189 static/js/zamboni/stats-all.js:15470 static/js/zamboni/stats-min.js:5
+msgid "Contributions, last {0} days"
+msgstr "Bidrag, siste {0} dager"
+
+#. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
+#: static/js/impala/stats/csv_keys.js:191 static/js/zamboni/stats-all.js:15472 static/js/zamboni/stats-min.js:5
+msgid "Contributions from {0} to {1}"
+msgstr "Bidrag fra {0} til {1}"
+
+#. L10n: {0} is an integer.
+#: static/js/impala/stats/csv_keys.js:195 static/js/zamboni/stats-all.js:15476 static/js/zamboni/stats-min.js:5
+msgid "Site Metrics, last {0} days"
+msgstr "Nettstedsmetrikk, siste {0} dager"
+
+#. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
+#: static/js/impala/stats/csv_keys.js:197 static/js/zamboni/stats-all.js:15478 static/js/zamboni/stats-min.js:5
+msgid "Site Metrics from {0} to {1}"
+msgstr "Nettstedsmetrikk fra {0} til {1}"
+
+#. L10n: {0} is an integer.
+#: static/js/impala/stats/csv_keys.js:201 static/js/zamboni/stats-all.js:15482 static/js/zamboni/stats-min.js:5
+msgid "Add-ons in Use, last {0} days"
+msgstr "Utvidelser i bruk, siste {0} dager"
+
+#. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
+#: static/js/impala/stats/csv_keys.js:203 static/js/zamboni/stats-all.js:15484 static/js/zamboni/stats-min.js:5
+msgid "Add-ons in Use from {0} to {1}"
+msgstr "Utvidelser i bruk fra {0} til {1}"
+
+#. L10n: {0} is an integer.
+#: static/js/impala/stats/csv_keys.js:207 static/js/zamboni/stats-all.js:15488 static/js/zamboni/stats-min.js:5
+msgid "Add-ons Downloaded, last {0} days"
+msgstr "Utvidelser lastet ned, siste {0} dager"
+
+#. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
+#: static/js/impala/stats/csv_keys.js:209 static/js/zamboni/stats-all.js:15490 static/js/zamboni/stats-min.js:5
+msgid "Add-ons Downloaded from {0} to {1}"
+msgstr "Utvidelser lastet ned fra {0} til {1}"
+
+#. L10n: {0} is an integer.
+#: static/js/impala/stats/csv_keys.js:213 static/js/zamboni/stats-all.js:15494 static/js/zamboni/stats-min.js:5
+msgid "Add-ons Created, last {0} days"
+msgstr "Utvidelser opprettet, siste {0} dager"
+
+#. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
+#: static/js/impala/stats/csv_keys.js:215 static/js/zamboni/stats-all.js:15496 static/js/zamboni/stats-min.js:5
+msgid "Add-ons Created from {0} to {1}"
+msgstr "Utvidelser opprettet fra {0} til {1}"
+
+#. L10n: {0} is an integer.
+#: static/js/impala/stats/csv_keys.js:219 static/js/zamboni/stats-all.js:15500 static/js/zamboni/stats-min.js:5
+msgid "Add-ons Updated, last {0} days"
+msgstr "Utvidelser oppdatert, siste {0} dager"
+
+#. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
+#: static/js/impala/stats/csv_keys.js:221 static/js/zamboni/stats-all.js:15502 static/js/zamboni/stats-min.js:5
+msgid "Add-ons Updated from {0} to {1}"
+msgstr "Utvidelser oppdatert fra {0} til {1}"
+
+#. L10n: {0} is an integer.
+#: static/js/impala/stats/csv_keys.js:225 static/js/zamboni/stats-all.js:15506 static/js/zamboni/stats-min.js:5
+msgid "Reviews Written, last {0} days"
+msgstr "Anmeldelser skrevet, siste {0} dager"
+
+#. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
+#: static/js/impala/stats/csv_keys.js:227 static/js/zamboni/stats-all.js:15508 static/js/zamboni/stats-min.js:5
+msgid "Reviews Written from {0} to {1}"
+msgstr "Anmeldelser skrevet fra {0} til {1}"
+
+#. L10n: {0} is an integer.
+#: static/js/impala/stats/csv_keys.js:231 static/js/zamboni/stats-all.js:15512 static/js/zamboni/stats-min.js:5
+msgid "User Signups, last {0} days"
+msgstr "Brukerregistreringer, siste {0} dager"
+
+#. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
+#: static/js/impala/stats/csv_keys.js:233 static/js/zamboni/stats-all.js:15514 static/js/zamboni/stats-min.js:5
+msgid "User Signups from {0} to {1}"
+msgstr "Brukerregistreringer fra {0} til {1}"
+
+#. L10n: {0} is an integer.
+#: static/js/impala/stats/csv_keys.js:237 static/js/zamboni/stats-all.js:15518 static/js/zamboni/stats-min.js:5
+msgid "Collections Created, last {0} days"
+msgstr "Samlinger opprettet, siste {0} dager"
+
+#. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
+#: static/js/impala/stats/csv_keys.js:239 static/js/zamboni/stats-all.js:15520 static/js/zamboni/stats-min.js:5
+msgid "Collections Created from {0} to {1}"
+msgstr "Samlinger opprettet fra {0} til {1}"
+
+#. L10n: {0} is an integer.
+#: static/js/impala/stats/csv_keys.js:243 static/js/zamboni/stats-all.js:15524 static/js/zamboni/stats-min.js:5
+msgid "Subscribers, last {0} days"
+msgstr "Abonnementer, siste {0} dager"
+
+#. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
+#: static/js/impala/stats/csv_keys.js:245 static/js/zamboni/stats-all.js:15526 static/js/zamboni/stats-min.js:5
+msgid "Subscribers from {0} to {1}"
+msgstr "Abonnementer fra {0} til {1}"
+
+#. L10n: {0} is an integer.
+#: static/js/impala/stats/csv_keys.js:249 static/js/zamboni/stats-all.js:15530 static/js/zamboni/stats-min.js:5
+msgid "Ratings, last {0} days"
+msgstr "Rangeringer, siste {0} dager"
+
+#. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
+#: static/js/impala/stats/csv_keys.js:251 static/js/zamboni/stats-all.js:15532 static/js/zamboni/stats-min.js:5
+msgid "Ratings from {0} to {1}"
+msgstr "Rangeringer fra {0} til {1}"
+
+#. L10n: {0} is an integer.
+#: static/js/impala/stats/csv_keys.js:255 static/js/zamboni/stats-all.js:15536 static/js/zamboni/stats-min.js:5
+msgid "Sales, last {0} days"
+msgstr "Salg, siste {0} dager"
+
+#. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
+#: static/js/impala/stats/csv_keys.js:257 static/js/zamboni/stats-all.js:15538 static/js/zamboni/stats-min.js:5
+msgid "Sales from {0} to {1}"
+msgstr "Salg fra {0} til {1}"
+
+#. L10n: {0} is an integer.
+#: static/js/impala/stats/csv_keys.js:261 static/js/zamboni/stats-all.js:15542 static/js/zamboni/stats-min.js:5
+msgid "Installs, last {0} days"
+msgstr "Installeringer, siste {0} dager"
+
+#. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
+#: static/js/impala/stats/csv_keys.js:263 static/js/zamboni/stats-all.js:15544 static/js/zamboni/stats-min.js:5
+msgid "Installs from {0} to {1}"
+msgstr "Installeringer fra {0} til {1}"
+
+#. L10n: {0} and {1} are integers.
+#: static/js/impala/stats/csv_keys.js:269 static/js/zamboni/stats-all.js:15550 static/js/zamboni/stats-min.js:5
+msgid "<b>{0}</b> in last {1} days"
+msgstr "<b>{0}</b> de siste {1} dagene"
+
+#. L10n: {0} is an integer and {1} and {2} are dates in YYYY-MM-DD format.
+#: static/js/impala/stats/csv_keys.js:271 static/js/impala/stats/csv_keys.js:277 static/js/zamboni/stats-all.js:15552 static/js/zamboni/stats-all.js:15558 static/js/zamboni/stats-min.js:5
+msgid "<b>{0}</b> from {1} to {2}"
+msgstr "<b>{0}</b> fra {1} til {2}"
+
+#. L10n: {0} and {1} are integers.
+#: static/js/impala/stats/csv_keys.js:275 static/js/zamboni/stats-all.js:15556 static/js/zamboni/stats-min.js:5
+msgid "<b>{0}</b> average in last {1} days"
+msgstr "<b>{0}</b> gjennomsnittelig de siste {1} dagene"
+
+#: static/js/impala/stats/overview.js:19 static/js/zamboni/stats-all.js:16469 static/js/zamboni/stats-min.js:5
+msgid "No data available."
+msgstr "Ingen data tilgjengelig."
+
+#: static/js/impala/stats/table.js:74 static/js/zamboni/stats-all.js:17209 static/js/zamboni/stats-min.js:5
+msgid "Date"
+msgstr "Dato"
+
+#: static/js/impala/stats/topchart.js:96 static/js/zamboni/stats-all.js:16600 static/js/zamboni/stats-min.js:5
+msgid "Other"
+msgstr "Annet"
+
+#: static/js/zamboni/admin-all.js:180 static/js/zamboni/admin-min.js:1 static/js/zamboni/admin_validation.js:24 static/js/zamboni/devhub-all.js:2408 static/js/zamboni/devhub-min.js:2
+#: static/js/zamboni/devhub.js:1229 static/js/zamboni/editors-all.js:15576 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:295
+msgid "Select an application first"
+msgstr "Velg en applikasjon først"
+
+#: static/js/zamboni/admin-all.js:207 static/js/zamboni/admin-min.js:1 static/js/zamboni/admin_validation.js:51
+msgid "Set {0} add-on to a max version of {1} and email the author."
+msgid_plural "Set {0} add-ons to a max version of {1} and email the authors."
+msgstr[0] "Sett {0} utvidelse til maksversjon {1} og send e-post til forfatteren."
+msgstr[1] "Sett {0} utvidelser til maksversjon {1} og send e-post til forfatterne."
+
+#: static/js/zamboni/admin-all.js:210 static/js/zamboni/admin-min.js:1 static/js/zamboni/admin_validation.js:54
+msgid "Email author of {2} add-on which failed validation."
+msgid_plural "Email authors of {2} add-ons which failed validation."
+msgstr[0] ""
+msgstr[1] ""
+
+#: static/js/zamboni/devhub-all.js:1289 static/js/zamboni/devhub-min.js:1 static/js/zamboni/devhub.js:110
+msgid "Your browser does not support the video tag"
+msgstr "Nettleseren din støtter ikke video-taggen"
+
+#: static/js/zamboni/devhub-all.js:1550 static/js/zamboni/devhub-min.js:1 static/js/zamboni/devhub.js:371
+msgid "Changes Saved"
+msgstr "Endringer lagret"
+
+#: static/js/zamboni/devhub-all.js:1566 static/js/zamboni/devhub-min.js:1 static/js/zamboni/devhub.js:387
+msgid "Enter a new author's email address"
+msgstr "Skriv inn forfatterens nye e-postadresse"
+
+#: static/js/zamboni/devhub-all.js:1715 static/js/zamboni/devhub-min.js:1 static/js/zamboni/devhub.js:536
+msgid "There was an error uploading your file."
+msgstr "En feil oppstod under opplasting av fil."
+
+#: static/js/zamboni/devhub-all.js:1860 static/js/zamboni/devhub-min.js:1 static/js/zamboni/devhub.js:681
+msgid "{files} file"
+msgid_plural "{files} files"
+msgstr[0] "{files} fil"
+msgstr[1] "{files} filer"
+
+#: static/js/zamboni/devhub-all.js:1863 static/js/zamboni/devhub-min.js:1 static/js/zamboni/devhub.js:684
+msgid "{reviews} user review"
+msgid_plural "{reviews} user reviews"
+msgstr[0] ""
+msgstr[1] ""
+
+#: static/js/zamboni/devhub-all.js:1975 static/js/zamboni/devhub-min.js:2 static/js/zamboni/devhub.js:796
+msgid "Learn more"
+msgstr "Les mer"
+
+#: static/js/zamboni/devhub-all.js:1979 static/js/zamboni/devhub-min.js:2 static/js/zamboni/devhub.js:800
+msgid "Example"
+msgstr "Eksempel"
+
+#: static/js/zamboni/devhub-all.js:2309 static/js/zamboni/devhub-min.js:2 static/js/zamboni/devhub.js:1130
+msgid "Image changes being processed"
+msgstr "Endringer på bilde blir behandlet"
+
+#: static/js/zamboni/devhub-all.js:2459 static/js/zamboni/devhub-min.js:2 static/js/zamboni/devhub.js:1280
+msgid "Must be a valid e-mail address."
+msgstr "Må være en gyldig e-postadresse"
+
+#: static/js/zamboni/devhub-all.js:2613 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:80
 msgid "All tests passed successfully."
 msgstr "Alle tester fullført."
 
-#: static/js/zamboni/validator.js:83 static/js/zamboni/validator.js:478
+#: static/js/zamboni/devhub-all.js:2616 static/js/zamboni/devhub-all.js:3011 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:83 static/js/zamboni/validator.js:478
 msgid "These tests were not run."
 msgstr "Disse testene ble ikke kjørt."
 
-#: static/js/zamboni/validator.js:131 static/js/zamboni/validator.js:144
+#: static/js/zamboni/devhub-all.js:2664 static/js/zamboni/devhub-all.js:2677 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:131 static/js/zamboni/validator.js:144
 msgid "Tests"
 msgstr "Tester"
 
-#: static/js/zamboni/validator.js:246 static/js/zamboni/validator.js:575 static/js/zamboni/validator.js:594
+#: static/js/zamboni/devhub-all.js:2779 static/js/zamboni/devhub-all.js:3108 static/js/zamboni/devhub-all.js:3127 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:246
+#: static/js/zamboni/validator.js:575 static/js/zamboni/validator.js:594
 msgid "Error"
 msgstr "Feil"
 
-#: static/js/zamboni/validator.js:247
+#: static/js/zamboni/devhub-all.js:2780 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:247
 msgid "Warning"
 msgstr "Advarsel"
 
-#: static/js/zamboni/validator.js:299
+#: static/js/zamboni/devhub-all.js:2794 static/js/zamboni/devhub-min.js:2 static/js/zamboni/files-all.js:5657 static/js/zamboni/files-min.js:3 static/js/zamboni/files.js:411
+#: static/js/zamboni/validator.js:261
+msgid "Ignore this message in future updates"
+msgstr ""
+
+#: static/js/zamboni/devhub-all.js:2817 static/js/zamboni/devhub-min.js:2 static/js/zamboni/files-all.js:5663 static/js/zamboni/files-min.js:3 static/js/zamboni/files.js:417
+#: static/js/zamboni/validator.js:284
+msgid "Severity for automated signing:"
+msgstr ""
+
+#: static/js/zamboni/devhub-all.js:2832 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:299
 msgid "Suggestions for passing automated signing:"
 msgstr ""
 
-#: static/js/zamboni/validator.js:387
+#: static/js/zamboni/devhub-all.js:2920 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:387
 msgid "Compatibility Tests"
 msgstr "Kompatibilitetstester"
 
-#: static/js/zamboni/validator.js:466
+#: static/js/zamboni/devhub-all.js:2999 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:466
 msgid "Add-on failed validation."
 msgstr "Validering av utvidelse mislykket."
 
-#: static/js/zamboni/validator.js:468
+#: static/js/zamboni/devhub-all.js:3001 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:468
 msgid "Add-on passed validation."
 msgstr "Utvidelsevalidering fullført."
 
-#: static/js/zamboni/validator.js:481
+#: static/js/zamboni/devhub-all.js:3014 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:481
 msgid "{0} error"
 msgid_plural "{0} errors"
 msgstr[0] "{0} feil"
 msgstr[1] "{0} feil"
 
-#: static/js/zamboni/validator.js:483
+#: static/js/zamboni/devhub-all.js:3016 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:483
 msgid "{0} warning"
 msgid_plural "{0} warnings"
 msgstr[0] "{0} advarsel"
 msgstr[1] "{0} advarsler"
 
-#: static/js/zamboni/validator.js:485
+#: static/js/zamboni/devhub-all.js:3018 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:485
 msgid "{0} notice"
 msgid_plural "{0} notices"
 msgstr[0] ""
 msgstr[1] ""
 
-#: static/js/zamboni/validator.js:577
+#: static/js/zamboni/devhub-all.js:3110 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:577
 msgid "Validation task could not complete or completed with errors"
 msgstr "Valideringsoppgave kunne ikke fullføre, eller fullførte med feil"
 
-#: static/js/zamboni/validator.js:595
+#: static/js/zamboni/devhub-all.js:3128 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:595
 msgid "Internal server error"
 msgstr "Intern serverfeil"
 
-#: static/js/zamboni/mobile/buttons.js:52
+#: static/js/zamboni/devhub_search.js:8
+msgid "No results found."
+msgstr "Ingen resultater funnet."
+
+#: static/js/zamboni/editors-all.js:15402 static/js/zamboni/editors-min.js:4 static/js/zamboni/editors.js:121
+msgid "{name} was viewing this page first."
+msgstr "{name} så på denne siden først."
+
+#: static/js/zamboni/editors-all.js:15452 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:171
+msgid "Receipt checked by app."
+msgstr "Kvittering kontrollert av appen."
+
+#: static/js/zamboni/editors-all.js:15454 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:173
+msgid "Receipt was not checked by app."
+msgstr "Kvittering ble ikke kontrollert av appen."
+
+#: static/js/zamboni/editors-all.js:15525 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:244
+msgid "{name} was viewing this add-on first."
+msgstr "{name} så på denne utvidelsen først."
+
+#: static/js/zamboni/editors-all.js:15536 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:255
+msgid "Loading&hellip;"
+msgstr "Laster &hellip;"
+
+#: static/js/zamboni/editors-all.js:15541 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:260
+msgid "Version Notes"
+msgstr "Versjonnotat"
+
+#: static/js/zamboni/editors-all.js:15546 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:265
+msgid "Notes for Reviewers"
+msgstr "Notat for redaktører"
+
+#: static/js/zamboni/editors-all.js:15551 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:270
+msgid "No version notes found"
+msgstr "Versjonsnotat ikke funnet"
+
+#: static/js/zamboni/editors-all.js:15611 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:330
+msgid "Average Reviews"
+msgstr ""
+
+#: static/js/zamboni/editors-all.js:15667 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:386
+msgid "Number of Reviews"
+msgstr ""
+
+#: static/js/zamboni/editors-all.js:15726 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:445
+msgid "Error loading translation"
+msgstr "Feil ved lasting av oversettelse"
+
+#: static/js/zamboni/editors-all.js:15975 static/js/zamboni/editors-min.js:5 static/js/zamboni/themes_review_templates.js:31
+msgid "Theme"
+msgstr ""
+
+#: static/js/zamboni/editors-all.js:15977 static/js/zamboni/editors-min.js:5 static/js/zamboni/themes_review_templates.js:33
+msgid "Reviewer"
+msgstr ""
+
+#: static/js/zamboni/editors-all.js:15979 static/js/zamboni/editors-min.js:5 static/js/zamboni/themes_review_templates.js:35
+msgid "Status"
+msgstr ""
+
+#: static/js/zamboni/editors-all.js:16196 static/js/zamboni/editors-min.js:5 static/js/zamboni/themes_review.js:176
+msgid "Requested Info"
+msgstr "Forespurt info"
+
+#: static/js/zamboni/editors-all.js:16197 static/js/zamboni/editors-min.js:5 static/js/zamboni/themes_review.js:177
+msgid "Flagged"
+msgstr "Flagget"
+
+#: static/js/zamboni/editors-all.js:16198 static/js/zamboni/editors-min.js:5 static/js/zamboni/themes_review.js:178
+msgid "Duplicate"
+msgstr "Duplikat"
+
+#: static/js/zamboni/editors-all.js:16199 static/js/zamboni/editors-min.js:5 static/js/zamboni/themes_review.js:179
+msgid "Rejected"
+msgstr "Avvist"
+
+#: static/js/zamboni/editors-all.js:16200 static/js/zamboni/editors-min.js:5 static/js/zamboni/themes_review.js:180
+msgid "Approved"
+msgstr "Godkjent"
+
+#: static/js/zamboni/editors-all.js:16444 static/js/zamboni/editors-min.js:5 static/js/zamboni/themes_review.js:424
+msgid "No results found"
+msgstr ""
+
+#: static/js/zamboni/mobile-all.js:15186 static/js/zamboni/mobile/buttons.js:52
 msgid "Not Updated for {0} {1}"
 msgstr "Ikke oppdatert for {0} {1}"
 
-#: static/js/zamboni/mobile/buttons.js:53
+#: static/js/zamboni/mobile-all.js:15187 static/js/zamboni/mobile/buttons.js:53
 msgid "Requires Newer Version of {0}"
 msgstr "Krever en nyere versjon av {0}"
 
-#: static/js/zamboni/mobile/buttons.js:54
+#: static/js/zamboni/mobile-all.js:15188 static/js/zamboni/mobile/buttons.js:54
 msgid "Unreviewed"
 msgstr "Ingen anmeldelser"
 
-#: static/js/zamboni/mobile/buttons.js:55
+#: static/js/zamboni/mobile-all.js:15189 static/js/zamboni/mobile/buttons.js:55
 msgid "Experimental <span>(Learn More)</span>"
 msgstr "Eksperimentell <span>(Les mer)</span>"
 
-#: static/js/zamboni/mobile/buttons.js:56 static/js/zamboni/mobile/buttons.js:57
+#: static/js/zamboni/mobile-all.js:15190 static/js/zamboni/mobile-all.js:15191 static/js/zamboni/mobile/buttons.js:56 static/js/zamboni/mobile/buttons.js:57
 msgid "Not Available for {0}"
 msgstr "Ikke tilgjengelig for {0}"
 
-#: static/js/zamboni/mobile/buttons.js:58
+#: static/js/zamboni/mobile-all.js:15192 static/js/zamboni/mobile/buttons.js:58
 msgid "Experimental"
 msgstr "Eksperimentell"
 
-#: static/js/zamboni/mobile/buttons.js:59
+#: static/js/zamboni/mobile-all.js:15193 static/js/zamboni/mobile/buttons.js:59
 msgid "Themes Require Newer Version of {0}"
 msgstr "Temaer krever en nyere versjon av {0}"
 
-#: static/js/zamboni/mobile/buttons.js:60
+#: static/js/zamboni/mobile-all.js:15194 static/js/zamboni/mobile/buttons.js:60
 msgid "Themes Require {0}"
 msgstr "Temaer krever {0}"
 
-#: static/js/zamboni/mobile/buttons.js:105
+#: static/js/zamboni/mobile-all.js:15239 static/js/zamboni/mobile/buttons.js:105
 msgid "Installing..."
 msgstr "Installerer ..."
 
-#: static/js/zamboni/mobile/buttons.js:125
+#: static/js/zamboni/mobile-all.js:15259 static/js/zamboni/mobile/buttons.js:125
 msgid "This add-on has been preliminarily reviewed by Mozilla."
 msgstr "Denne utvidelsen er midlertidig kontrollert av Mozilla."
 
-#: static/js/zamboni/mobile/buttons.js:250
+#: static/js/zamboni/mobile-all.js:15384 static/js/zamboni/mobile/buttons.js:250
 msgid "Keep it"
 msgstr "Behold den"
 
-#: static/js/zamboni/mobile/general.js:344
+#: static/js/zamboni/mobile-all.js:16049 static/js/zamboni/mobile-min.js:6 static/js/zamboni/mobile/general.js:344
 msgid "You're trying it on!"
 msgstr "Du prøver den ut!"
 
-#: static/js/zamboni/mobile/general.js:356
+#: static/js/zamboni/mobile-all.js:16061 static/js/zamboni/mobile-min.js:6 static/js/zamboni/mobile/general.js:356
 msgid "Added to Firefox"
 msgstr "Lagt til i Firefox"
-

--- a/locale/ne_NP/LC_MESSAGES/django.po
+++ b/locale/ne_NP/LC_MESSAGES/django.po
@@ -3,69 +3,70 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2016-02-24 21:23+0000\n"
+"POT-Creation-Date: 2016-04-18 15:47+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
+"Language: \n"
 "MIME-Version: 1.0\n"
-"Content-Type: text/plain; charset=utf-8\n"
+"Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Generated-By: Babel 2.2.0\n"
 
-#: src/olympia/accounts/views.py:52
+#: src/olympia/accounts/views.py:54
 msgid "Your log in attempt could not be parsed. Please try again."
 msgstr ""
 
-#: src/olympia/accounts/views.py:54
+#: src/olympia/accounts/views.py:56
 msgid "Your Firefox Account could not be found. Please try again."
 msgstr ""
 
-#: src/olympia/accounts/views.py:55
+#: src/olympia/accounts/views.py:57
 msgid "You could not be logged in. Please try again."
 msgstr ""
 
-#: src/olympia/accounts/views.py:57
+#: src/olympia/accounts/views.py:59
 msgid "Your account has already been migrated to Firefox Accounts."
 msgstr ""
 
-#: src/olympia/accounts/views.py:59
+#: src/olympia/accounts/views.py:61
 msgid "Your Firefox Account already exists on this site."
 msgstr ""
 
-#: src/olympia/accounts/views.py:108
+#: src/olympia/accounts/views.py:110
 msgid "Great job!"
 msgstr ""
 
-#: src/olympia/accounts/views.py:109
+#: src/olympia/accounts/views.py:111
 msgid "You can now log in to Add-ons with your Firefox Account."
 msgstr ""
 
-#: src/olympia/accounts/views.py:121
+#: src/olympia/accounts/views.py:123
 msgid "Need help?"
 msgstr ""
 
-#: src/olympia/addons/buttons.py:180
+#: src/olympia/addons/buttons.py:177
 msgid "Download Now"
 msgstr ""
 
-#: src/olympia/addons/buttons.py:182
+#: src/olympia/addons/buttons.py:179
 msgid "Download"
 msgstr ""
 
 #. L10n: please keep &nbsp; in the string so &rarr; does not wrap.
-#: src/olympia/addons/buttons.py:186
+#: src/olympia/addons/buttons.py:183
 msgid "Continue to Download&nbsp;&rarr;"
 msgstr ""
 
-#: src/olympia/addons/buttons.py:202 src/olympia/addons/helpers.py:35 src/olympia/addons/views.py:319 src/olympia/addons/templates/addons/impala/details.html:114
+#: src/olympia/addons/buttons.py:199 src/olympia/addons/helpers.py:35 src/olympia/addons/views.py:333 src/olympia/addons/templates/addons/impala/details.html:111
 #: src/olympia/addons/templates/addons/impala/listing/items.html:17 src/olympia/addons/templates/addons/mobile/home.html:40 src/olympia/amo/templates/amo/side_nav.html:6
-#: src/olympia/amo/templates/amo/side_nav.html:10 src/olympia/amo/templates/amo/site_nav.html:2 src/olympia/amo/templates/amo/site_nav.html:55 src/olympia/bandwagon/views.py:95
-#: src/olympia/browse/views.py:54 src/olympia/browse/views.py:68 src/olympia/browse/views.py:235 src/olympia/browse/templates/browse/impala/category_landing.html:22
+#: src/olympia/amo/templates/amo/side_nav.html:10 src/olympia/amo/templates/amo/site_nav.html:2 src/olympia/amo/templates/amo/site_nav.html:53 src/olympia/bandwagon/views.py:95
+#: src/olympia/browse/views.py:54 src/olympia/browse/views.py:68 src/olympia/browse/views.py:202 src/olympia/browse/templates/browse/impala/category_landing.html:22
 #: src/olympia/browse/templates/browse/personas/mobile/category_landing.html:26
 msgid "Featured"
 msgstr ""
 
-#: src/olympia/addons/buttons.py:221
+#: src/olympia/addons/buttons.py:218
 msgid "Add to {0}"
 msgstr ""
 
@@ -113,39 +114,39 @@ msgid_plural "All tags must be at least {0} characters."
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/olympia/addons/forms.py:234
+#: src/olympia/addons/forms.py:238
 msgid "Categories cannot be changed while your add-on is featured for this application."
 msgstr ""
 
 #. L10n: {0} is the number of categories.
-#: src/olympia/addons/forms.py:238
+#: src/olympia/addons/forms.py:242
 msgid "You can have only {0} category."
 msgid_plural "You can have only {0} categories."
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/olympia/addons/forms.py:246
+#: src/olympia/addons/forms.py:250
 msgid "The miscellaneous category cannot be combined with additional categories."
 msgstr ""
 
-#: src/olympia/addons/forms.py:369
+#: src/olympia/addons/forms.py:374
 #, python-format
 msgid "Before changing your default locale you must have a name, summary, and description in that locale. You are missing %s."
 msgstr ""
 
-#: src/olympia/addons/forms.py:484 src/olympia/addons/forms.py:575
+#: src/olympia/addons/forms.py:455 src/olympia/addons/forms.py:546
 msgid "A license must be selected."
 msgstr ""
 
-#: src/olympia/addons/forms.py:556
+#: src/olympia/addons/forms.py:527
 msgid "Give Your Theme a Name."
 msgstr ""
 
-#: src/olympia/addons/forms.py:562 src/olympia/devhub/templates/devhub/personas/submit.html:53
+#: src/olympia/addons/forms.py:533 src/olympia/devhub/templates/devhub/personas/submit.html:53
 msgid "Describe your Theme."
 msgstr ""
 
-#: src/olympia/addons/forms.py:704
+#: src/olympia/addons/forms.py:675
 msgid "Enter a new author's email address"
 msgstr ""
 
@@ -153,37 +154,37 @@ msgstr ""
 msgid "Not Reviewed"
 msgstr ""
 
-#: src/olympia/addons/models.py:301
+#: src/olympia/addons/models.py:298
 msgid "Users have the option of contributing more or less than this amount."
 msgstr ""
 
-#: src/olympia/addons/models.py:309
-msgid "Users will always be asked in the Add-ons Manager (Firefox 4 and above)"
+#: src/olympia/addons/models.py:306
+msgid "Users will always be asked in the Add-ons Manager (Firefox 4 and above). Only applies to desktop."
 msgstr ""
 
-#: src/olympia/addons/models.py:1804 src/olympia/addons/templates/addons/details_box.html:55 src/olympia/devhub/templates/devhub/index.html:92
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:102
+#: src/olympia/addons/models.py:1802 src/olympia/addons/templates/addons/details_box.html:55 src/olympia/devhub/templates/devhub/index.html:92
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:89
 msgid "Listed"
 msgstr ""
 
-#: src/olympia/addons/views.py:320 src/olympia/browse/templates/browse/personas/mobile/category_landing.html:27
+#: src/olympia/addons/views.py:334 src/olympia/browse/templates/browse/personas/mobile/category_landing.html:27
 msgid "Popular"
 msgstr ""
 
-#: src/olympia/addons/views.py:321 src/olympia/browse/views.py:238 src/olympia/browse/views.py:280 src/olympia/browse/views.py:482
+#: src/olympia/addons/views.py:335 src/olympia/browse/views.py:205 src/olympia/browse/views.py:247 src/olympia/browse/views.py:449
 msgid "Recently Added"
 msgstr ""
 
-#: src/olympia/addons/views.py:322 src/olympia/bandwagon/views.py:99 src/olympia/browse/views.py:60 src/olympia/browse/views.py:71 src/olympia/search/forms.py:16 src/olympia/search/forms.py:91
+#: src/olympia/addons/views.py:336 src/olympia/bandwagon/views.py:99 src/olympia/browse/views.py:60 src/olympia/browse/views.py:71 src/olympia/search/forms.py:16 src/olympia/search/forms.py:91
 msgid "Recently Updated"
 msgstr ""
 
 #. l10n: {0} is the addon name
-#: src/olympia/addons/views.py:520
+#: src/olympia/addons/views.py:534
 msgid "Contribution for {0}"
 msgstr ""
 
-#: src/olympia/addons/views.py:613
+#: src/olympia/addons/views.py:627
 msgid "Abuse reported."
 msgstr ""
 
@@ -250,9 +251,9 @@ msgstr ""
 #: src/olympia/devhub/templates/devhub/addons/ajax_compat_update.html:36 src/olympia/devhub/templates/devhub/addons/profile.html:44 src/olympia/devhub/templates/devhub/addons/edit/admin.html:101
 #: src/olympia/devhub/templates/devhub/addons/edit/basic.html:152 src/olympia/devhub/templates/devhub/addons/edit/details.html:85 src/olympia/devhub/templates/devhub/addons/edit/support.html:67
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:166 src/olympia/devhub/templates/devhub/addons/forms_shared/media.html:149
-#: src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:44 src/olympia/devhub/templates/devhub/versions/add_file_modal.html:78 src/olympia/devhub/templates/devhub/versions/edit.html:139
-#: src/olympia/devhub/templates/devhub/versions/list.html:242 src/olympia/devhub/templates/devhub/versions/list.html:276 src/olympia/devhub/templates/devhub/versions/list.html:317
-#: src/olympia/devhub/templates/devhub/versions/list.html:351 src/olympia/reviews/templates/reviews/edit_review.html:16 src/olympia/translations/templates/translations/trans-menu.html:50
+#: src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:43 src/olympia/devhub/templates/devhub/versions/add_file_modal.html:58 src/olympia/devhub/templates/devhub/versions/edit.html:139
+#: src/olympia/devhub/templates/devhub/versions/list.html:239 src/olympia/devhub/templates/devhub/versions/list.html:281 src/olympia/devhub/templates/devhub/versions/list.html:315
+#: src/olympia/devhub/templates/devhub/versions/list.html:349 src/olympia/reviews/templates/reviews/edit_review.html:16 src/olympia/translations/templates/translations/trans-menu.html:50
 #: src/olympia/translations/templates/translations/trans-menu.html:62
 msgid "or"
 msgstr ""
@@ -363,7 +364,7 @@ msgid "Add-on Information for {0}"
 msgstr ""
 
 #: src/olympia/addons/templates/addons/details_box.html:30 src/olympia/addons/templates/addons/persona_detail_table.html:3 src/olympia/addons/templates/addons/mobile/details.html:63
-#: src/olympia/addons/templates/addons/mobile/persona_detail_table.html:7 src/olympia/browse/views.py:459 src/olympia/devhub/views.py:75
+#: src/olympia/addons/templates/addons/mobile/persona_detail_table.html:7 src/olympia/browse/views.py:426 src/olympia/devhub/views.py:73
 msgid "Updated"
 msgstr ""
 
@@ -382,11 +383,11 @@ msgstr ""
 msgid "Visibility"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/details_box.html:57 src/olympia/devhub/templates/devhub/index.html:94 src/olympia/devhub/templates/devhub/includes/addon_details.html:104
+#: src/olympia/addons/templates/addons/details_box.html:57 src/olympia/devhub/templates/devhub/index.html:94 src/olympia/devhub/templates/devhub/includes/addon_details.html:91
 msgid "Hidden"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/details_box.html:59 src/olympia/devhub/templates/devhub/index.html:96 src/olympia/devhub/templates/devhub/includes/addon_details.html:106
+#: src/olympia/addons/templates/addons/details_box.html:59 src/olympia/devhub/templates/devhub/index.html:96 src/olympia/devhub/templates/devhub/includes/addon_details.html:93
 msgid "Unlisted"
 msgstr ""
 
@@ -394,13 +395,13 @@ msgstr ""
 msgid "Required Add-ons"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/details_box.html:81 src/olympia/addons/templates/addons/persona_detail_table.html:15 src/olympia/browse/views.py:462 src/olympia/devhub/views.py:78
-#: src/olympia/devhub/views.py:85 src/olympia/discovery/templates/discovery/addons/detail.html:57 src/olympia/reviews/forms.py:62 src/olympia/reviews/templates/reviews/add.html:57
+#: src/olympia/addons/templates/addons/details_box.html:81 src/olympia/addons/templates/addons/persona_detail_table.html:15 src/olympia/browse/views.py:429 src/olympia/devhub/views.py:76
+#: src/olympia/devhub/views.py:83 src/olympia/discovery/templates/discovery/addons/detail.html:57 src/olympia/reviews/forms.py:62 src/olympia/reviews/templates/reviews/add.html:57
 #: src/olympia/reviews/templates/reviews/mobile/review_list.html:18
 msgid "Rating"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/details_box.html:85 src/olympia/browse/views.py:461 src/olympia/devhub/views.py:77 src/olympia/devhub/views.py:84
+#: src/olympia/addons/templates/addons/details_box.html:85 src/olympia/browse/views.py:428 src/olympia/devhub/views.py:75 src/olympia/devhub/views.py:82
 #: src/olympia/stats/templates/stats/addon_report_menu.html:8 src/olympia/stats/templates/stats/collection_report_menu.html:18
 msgid "Downloads"
 msgstr ""
@@ -420,7 +421,7 @@ msgstr ""
 
 #. The Privacy Policy for this add-on.
 #: src/olympia/addons/templates/addons/details_box.html:121 src/olympia/addons/templates/addons/privacy.html:19 src/olympia/addons/templates/addons/privacy.html:23
-#: src/olympia/addons/templates/addons/impala/button.html:43 src/olympia/addons/templates/addons/impala/details.html:307 src/olympia/devhub/templates/devhub/includes/policy_form.html:20
+#: src/olympia/addons/templates/addons/impala/button.html:43 src/olympia/addons/templates/addons/impala/details.html:312 src/olympia/devhub/templates/devhub/includes/policy_form.html:23
 #: src/olympia/templates/mobile/base_addons.html:87
 msgid "Privacy Policy"
 msgstr ""
@@ -445,7 +446,7 @@ msgstr ""
 msgid "Developer Comments"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/details_box.html:199 src/olympia/addons/templates/addons/impala/details.html:259
+#: src/olympia/addons/templates/addons/details_box.html:199 src/olympia/addons/templates/addons/impala/details.html:264
 msgid "Development Channel"
 msgstr ""
 
@@ -465,7 +466,7 @@ msgid ""
 "developer. To stop receiving development updates, reinstall the default version from the link above."
 msgstr ""
 
-#: src/olympia/addons/templates/addons/details_box.html:220 src/olympia/addons/templates/addons/impala/details.html:278
+#: src/olympia/addons/templates/addons/details_box.html:220 src/olympia/addons/templates/addons/impala/details.html:283
 msgid "Version {0}:"
 msgstr ""
 
@@ -484,7 +485,7 @@ msgid "End-User License Agreement for {0}"
 msgstr ""
 
 #: src/olympia/addons/templates/addons/eula.html:17 src/olympia/addons/templates/addons/eula.html:21 src/olympia/addons/templates/addons/impala/button.html:48
-#: src/olympia/addons/templates/addons/impala/details.html:316 src/olympia/devhub/templates/devhub/includes/policy_form.html:3 src/olympia/discovery/templates/discovery/addons/eula.html:11
+#: src/olympia/addons/templates/addons/impala/details.html:321 src/olympia/devhub/templates/devhub/includes/policy_form.html:3 src/olympia/discovery/templates/discovery/addons/eula.html:11
 msgid "End-User License Agreement"
 msgstr ""
 
@@ -501,7 +502,7 @@ msgstr ""
 msgid "Add-ons for {0}"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/home.html:10 src/olympia/addons/templates/addons/home.html:51 src/olympia/browse/templates/browse/impala/base_listing.html:11
+#: src/olympia/addons/templates/addons/home.html:10 src/olympia/addons/templates/addons/home.html:53 src/olympia/browse/templates/browse/impala/base_listing.html:11
 msgid "Featured Extensions"
 msgstr ""
 
@@ -509,29 +510,29 @@ msgstr ""
 msgid "Popular Extensions"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/home.html:42 src/olympia/amo/templates/amo/side_nav.html:3 src/olympia/amo/templates/amo/side_nav.html:11 src/olympia/amo/templates/amo/site_nav.html:3
-#: src/olympia/amo/templates/amo/site_nav.html:25 src/olympia/browse/views.py:236 src/olympia/browse/views.py:281 src/olympia/browse/views.py:481
+#: src/olympia/addons/templates/addons/home.html:44 src/olympia/amo/templates/amo/side_nav.html:3 src/olympia/amo/templates/amo/side_nav.html:11 src/olympia/amo/templates/amo/site_nav.html:3
+#: src/olympia/amo/templates/amo/site_nav.html:25 src/olympia/browse/views.py:203 src/olympia/browse/views.py:248 src/olympia/browse/views.py:448
 msgid "Most Popular"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/home.html:43
+#: src/olympia/addons/templates/addons/home.html:45
 msgid "All »"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/home.html:52 src/olympia/addons/templates/addons/home.html:61 src/olympia/addons/templates/addons/home.html:70 src/olympia/addons/templates/addons/home.html:78
+#: src/olympia/addons/templates/addons/home.html:54 src/olympia/addons/templates/addons/home.html:63 src/olympia/addons/templates/addons/home.html:72 src/olympia/addons/templates/addons/home.html:80
 #: src/olympia/browse/templates/browse/impala/category_landing.html:36
 msgid "See all »"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/home.html:60
+#: src/olympia/addons/templates/addons/home.html:62
 msgid "Up &amp; Coming Extensions"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/home.html:69 src/olympia/browse/templates/browse/personas/category_landing.html:61 src/olympia/discovery/templates/discovery/pane.html:74
+#: src/olympia/addons/templates/addons/home.html:71 src/olympia/browse/templates/browse/personas/category_landing.html:61 src/olympia/discovery/templates/discovery/pane.html:74
 msgid "Featured Themes"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/home.html:77 src/olympia/bandwagon/templates/bandwagon/impala/collection_listing.html:5
+#: src/olympia/addons/templates/addons/home.html:79 src/olympia/bandwagon/templates/bandwagon/impala/collection_listing.html:5
 msgid "Featured Collections"
 msgstr ""
 
@@ -549,7 +550,7 @@ msgid "Updated {0}"
 msgstr ""
 
 #. {0} is a date.
-#: src/olympia/addons/templates/addons/macros.html:10 src/olympia/addons/templates/addons/macros.html:69 src/olympia/addons/templates/addons/persona_preview.html:21
+#: src/olympia/addons/templates/addons/macros.html:10 src/olympia/addons/templates/addons/macros.html:69 src/olympia/addons/templates/addons/persona_preview.html:22
 #: src/olympia/addons/templates/addons/listing/items_mobile.html:44 src/olympia/addons/templates/addons/listing/macros.html:39
 #: src/olympia/bandwagon/templates/bandwagon/collection_listing_items.html:37 src/olympia/bandwagon/templates/bandwagon/impala/collection_listing_items.html:37
 msgid "Added {0}"
@@ -570,15 +571,14 @@ msgstr[0] ""
 msgstr[1] ""
 
 #. {0} is the number of downloads.
-#: src/olympia/addons/templates/addons/macros.html:53 src/olympia/addons/templates/addons/impala/details.html:61
+#: src/olympia/addons/templates/addons/macros.html:53 src/olympia/addons/templates/addons/impala/details.html:59
 msgid "{0} weekly download"
 msgid_plural "{0} weekly downloads"
 msgstr[0] ""
 msgstr[1] ""
 
 #. {0} is the number of users.
-#: src/olympia/addons/templates/addons/macros.html:61 src/olympia/addons/templates/addons/impala/details.html:54 src/olympia/compat/templates/compat/index.html:71
-#: src/olympia/zadmin/templates/zadmin/compat.html:67
+#: src/olympia/addons/templates/addons/macros.html:61 src/olympia/addons/templates/addons/impala/details.html:52 src/olympia/zadmin/templates/zadmin/compat.html:67
 msgid "{0} user"
 msgid_plural "{0} users"
 msgstr[0] ""
@@ -596,7 +596,7 @@ msgstr ""
 msgid "Return to the addon."
 msgstr ""
 
-#: src/olympia/addons/templates/addons/persona_detail.html:17 src/olympia/addons/templates/addons/impala/details.html:106 src/olympia/addons/templates/addons/mobile/details.html:23
+#: src/olympia/addons/templates/addons/persona_detail.html:17 src/olympia/addons/templates/addons/impala/details.html:103 src/olympia/addons/templates/addons/mobile/details.html:23
 #: src/olympia/addons/templates/addons/mobile/persona_detail.html:21 src/olympia/discovery/templates/discovery/addons/base.html:27 src/olympia/editors/templates/editors/review.html:31
 msgid "by"
 msgstr ""
@@ -640,34 +640,35 @@ msgstr ""
 msgid "License"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/persona_preview.html:12 src/olympia/constants/base.py:48
+#: src/olympia/addons/templates/addons/persona_preview.html:13 src/olympia/constants/base.py:48
 msgid "Awaiting Review"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/persona_preview.html:14 src/olympia/amo/log.py:180 src/olympia/constants/base.py:42 src/olympia/editors/helpers.py:62
+#: src/olympia/addons/templates/addons/persona_preview.html:15 src/olympia/amo/log.py:180 src/olympia/constants/base.py:42 src/olympia/editors/helpers.py:62
 msgid "Rejected"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/persona_preview.html:16 src/olympia/amo/log.py:159
+#: src/olympia/addons/templates/addons/persona_preview.html:17 src/olympia/amo/log.py:159
 msgid "Approved"
 msgstr ""
 
 #. {0} is the number of users.
-#: src/olympia/addons/templates/addons/persona_preview.html:26 src/olympia/addons/templates/addons/listing/items_mobile.html:36 src/olympia/addons/templates/addons/listing/macros.html:31
+#: src/olympia/addons/templates/addons/persona_preview.html:27 src/olympia/addons/templates/addons/listing/items_mobile.html:36 src/olympia/addons/templates/addons/listing/macros.html:31
 msgid "<strong>{0}</strong> user"
 msgid_plural "<strong>{0}</strong> users"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/olympia/addons/templates/addons/persona_preview.html:40
+#: src/olympia/addons/templates/addons/persona_preview.html:41
 msgid "Hover to Preview"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/persona_preview.html:46 src/olympia/addons/templates/addons/persona_preview.html:48 src/olympia/reviews/templates/reviews/add.html:15
+#: src/olympia/addons/templates/addons/persona_preview.html:47 src/olympia/addons/templates/addons/persona_preview.html:49 src/olympia/addons/templates/addons/persona_preview.html:97
+#: src/olympia/reviews/templates/reviews/add.html:15
 msgid "Add"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/persona_preview.html:57 src/olympia/bandwagon/templates/bandwagon/ajax_new.html:16 src/olympia/bandwagon/templates/bandwagon/edit.html:19
+#: src/olympia/addons/templates/addons/persona_preview.html:58 src/olympia/bandwagon/templates/bandwagon/ajax_new.html:16 src/olympia/bandwagon/templates/bandwagon/edit.html:19
 #: src/olympia/bandwagon/templates/bandwagon/includes/addedit.html:19 src/olympia/devhub/templates/devhub/addons/edit/admin.html:13 src/olympia/devhub/templates/devhub/addons/edit/basic.html:10
 #: src/olympia/devhub/templates/devhub/addons/edit/details.html:8 src/olympia/devhub/templates/devhub/addons/edit/media.html:6 src/olympia/devhub/templates/devhub/addons/edit/support.html:8
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:9 src/olympia/devhub/templates/devhub/addons/submit/describe.html:29 src/olympia/editors/templates/editors/review.html:257
@@ -676,21 +677,21 @@ msgstr ""
 
 #. For datetime formatting, see the table on
 #. http://docs.python.org/library/datetime.html#strftime-and-strptime-behavior
-#: src/olympia/addons/templates/addons/persona_preview.html:66
+#: src/olympia/addons/templates/addons/persona_preview.html:67
 #, python-format
 msgid "%%Y-%%m-%%d"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/persona_preview.html:67
+#: src/olympia/addons/templates/addons/persona_preview.html:68
 msgid "by {0} on {1}"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/persona_preview.html:75 src/olympia/reviews/helpers.py:17 src/olympia/reviews/templates/reviews/review_list.html:63
+#: src/olympia/addons/templates/addons/persona_preview.html:76 src/olympia/reviews/helpers.py:17 src/olympia/reviews/templates/reviews/review_list.html:63
 #: src/olympia/reviews/templates/reviews/reviews_link.html:21 src/olympia/reviews/templates/reviews/impala/reviews_link.html:16
 msgid "Not yet rated"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/persona_preview.html:78
+#: src/olympia/addons/templates/addons/persona_preview.html:79
 msgid "<b>{0}</b> users"
 msgstr ""
 
@@ -703,7 +704,7 @@ msgid "Learn more about Firefox"
 msgstr ""
 
 #: src/olympia/addons/templates/addons/popups.html:22
-msgid "or <b><a class=\"installer\" href=\"{url}\">download anyway</a></b>"
+msgid "or <b><a class=\"button installer\" href=\"{url}\">download anyway</a></b>"
 msgstr ""
 
 #: src/olympia/addons/templates/addons/popups.html:26
@@ -802,7 +803,7 @@ msgid ""
 msgstr ""
 
 #: src/olympia/addons/templates/addons/report_abuse.html:6 src/olympia/addons/templates/addons/report_abuse_full.html:10 src/olympia/addons/templates/addons/impala/details-more.html:23
-#: src/olympia/addons/templates/addons/impala/details.html:328
+#: src/olympia/addons/templates/addons/impala/details.html:333
 msgid "Report Abuse"
 msgstr ""
 
@@ -821,9 +822,9 @@ msgstr ""
 #: src/olympia/devhub/templates/devhub/addons/ajax_compat_update.html:36 src/olympia/devhub/templates/devhub/addons/profile.html:44 src/olympia/devhub/templates/devhub/addons/edit/admin.html:104
 #: src/olympia/devhub/templates/devhub/addons/edit/basic.html:155 src/olympia/devhub/templates/devhub/addons/edit/details.html:88 src/olympia/devhub/templates/devhub/addons/edit/support.html:70
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:169 src/olympia/devhub/templates/devhub/addons/forms_shared/media.html:152
-#: src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:44 src/olympia/devhub/templates/devhub/personas/edit.html:222 src/olympia/devhub/templates/devhub/versions/add_file_modal.html:79
-#: src/olympia/devhub/templates/devhub/versions/edit.html:140 src/olympia/devhub/templates/devhub/versions/list.html:208 src/olympia/devhub/templates/devhub/versions/list.html:242
-#: src/olympia/devhub/templates/devhub/versions/list.html:276 src/olympia/devhub/templates/devhub/versions/list.html:317 src/olympia/reviews/templates/reviews/edit_review.html:16
+#: src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:43 src/olympia/devhub/templates/devhub/personas/edit.html:222 src/olympia/devhub/templates/devhub/versions/add_file_modal.html:59
+#: src/olympia/devhub/templates/devhub/versions/edit.html:140 src/olympia/devhub/templates/devhub/versions/list.html:208 src/olympia/devhub/templates/devhub/versions/list.html:239
+#: src/olympia/devhub/templates/devhub/versions/list.html:281 src/olympia/devhub/templates/devhub/versions/list.html:315 src/olympia/reviews/templates/reviews/edit_review.html:16
 #: src/olympia/translations/templates/translations/trans-menu.html:50 src/olympia/translations/templates/translations/trans-menu.html:62 src/olympia/zadmin/templates/zadmin/validation.html:105
 msgid "Cancel"
 msgstr ""
@@ -868,7 +869,7 @@ msgstr ""
 msgid "Review Guidelines"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/review_list_box.html:5 src/olympia/addons/templates/addons/impala/details-more.html:27 src/olympia/editors/helpers.py:921
+#: src/olympia/addons/templates/addons/review_list_box.html:5 src/olympia/addons/templates/addons/impala/details-more.html:27 src/olympia/editors/helpers.py:1001
 #: src/olympia/reviews/templates/reviews/add.html:14 src/olympia/reviews/templates/reviews/reply.html:14 src/olympia/reviews/templates/reviews/review_list.html:19
 #: src/olympia/reviews/templates/reviews/mobile/review_list.html:26
 msgid "Reviews"
@@ -959,119 +960,119 @@ msgid_plural "Other add-ons by these authors"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/olympia/addons/templates/addons/impala/details.html:41
+#: src/olympia/addons/templates/addons/impala/details.html:39
 #, python-format
 msgid "<span itemprop=\"ratingCount\">%(num)s</span> user review"
 msgid_plural "<span itemprop=\"ratingCount\">%(num)s</span> user reviews"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/olympia/addons/templates/addons/impala/details.html:69
+#: src/olympia/addons/templates/addons/impala/details.html:66
 msgid "View statistics"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/impala/details.html:84
+#: src/olympia/addons/templates/addons/impala/details.html:81
 msgid "Manage"
 msgstr ""
 
 #. {0} is an add-on name.
-#: src/olympia/addons/templates/addons/impala/details.html:96
+#: src/olympia/addons/templates/addons/impala/details.html:93
 msgid "Icon of {0}"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/impala/details.html:103 src/olympia/addons/templates/addons/impala/listing/items.html:14
+#: src/olympia/addons/templates/addons/impala/details.html:100 src/olympia/addons/templates/addons/impala/listing/items.html:14
 msgid "No Restart"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/impala/details.html:127
+#: src/olympia/addons/templates/addons/impala/details.html:124
 #, python-format
 msgid "Meet the Developer: <a href=\"%(url)s\">%(name)s</a>"
 msgid_plural "<a href=\"%(url)s\">Meet the Developers</a>"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/olympia/addons/templates/addons/impala/details.html:137
+#: src/olympia/addons/templates/addons/impala/details.html:134
 msgid "Learn why {0} was created and find out what's next for this add-on."
 msgstr ""
 
 #. {0} is an index.
-#: src/olympia/addons/templates/addons/impala/details.html:156
+#: src/olympia/addons/templates/addons/impala/details.html:161
 msgid "Add-on screenshot #{0}"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/impala/details.html:182
+#: src/olympia/addons/templates/addons/impala/details.html:187
 msgid "Add-on home page"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/impala/details.html:185
+#: src/olympia/addons/templates/addons/impala/details.html:190
 msgid "Support site"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/impala/details.html:189
+#: src/olympia/addons/templates/addons/impala/details.html:194
 msgid "Support E-mail"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/impala/details.html:194 src/olympia/devhub/models.py:378 src/olympia/devhub/templates/devhub/versions/list.html:12
+#: src/olympia/addons/templates/addons/impala/details.html:199 src/olympia/devhub/models.py:378 src/olympia/devhub/templates/devhub/versions/list.html:12
 #: src/olympia/versions/templates/versions/version.html:6 src/olympia/versions/templates/versions/mobile/version.html:6
 msgid "Version {0}"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/impala/details.html:194
+#: src/olympia/addons/templates/addons/impala/details.html:199
 msgid "Info"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/impala/details.html:195 src/olympia/devhub/templates/devhub/includes/addon_details.html:129
+#: src/olympia/addons/templates/addons/impala/details.html:200 src/olympia/devhub/templates/devhub/includes/addon_details.html:116
 msgid "Last Updated:"
-msgstr ""
-
-#: src/olympia/addons/templates/addons/impala/details.html:200
-#, python-format
-msgid "Released under <a target=\"_blank\" href=\"%(url)s\">%(name)s</a>"
-msgstr ""
-
-#: src/olympia/addons/templates/addons/impala/details.html:201 src/olympia/addons/templates/addons/impala/details.html:206 src/olympia/amo/helpers.py:398 src/olympia/devhub/forms.py:142
-#: src/olympia/devhub/forms.py:173 src/olympia/versions/templates/versions/version.html:40 src/olympia/versions/templates/versions/version.html:45
-msgid "Custom License"
 msgstr ""
 
 #: src/olympia/addons/templates/addons/impala/details.html:205
 #, python-format
+msgid "Released under <a target=\"_blank\" href=\"%(url)s\">%(name)s</a>"
+msgstr ""
+
+#: src/olympia/addons/templates/addons/impala/details.html:206 src/olympia/addons/templates/addons/impala/details.html:211 src/olympia/amo/helpers.py:398 src/olympia/devhub/forms.py:142
+#: src/olympia/devhub/forms.py:173 src/olympia/versions/templates/versions/version.html:40 src/olympia/versions/templates/versions/version.html:45
+msgid "Custom License"
+msgstr ""
+
+#: src/olympia/addons/templates/addons/impala/details.html:210
+#, python-format
 msgid "Released under <a href=\"%(url)s\">%(name)s</a>"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/impala/details.html:217
+#: src/olympia/addons/templates/addons/impala/details.html:222
 msgid "About this Add-on"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/impala/details.html:233
+#: src/olympia/addons/templates/addons/impala/details.html:238
 msgid "Developer’s Comments"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/impala/details.html:243
+#: src/olympia/addons/templates/addons/impala/details.html:248
 msgid "Version Information"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/impala/details.html:250
+#: src/olympia/addons/templates/addons/impala/details.html:255
 msgid "See complete version history"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/impala/details.html:262
+#: src/olympia/addons/templates/addons/impala/details.html:267
 msgid ""
 "The Development Channel lets you test an experimental new version of this add-on before it's released to the general public. Once you install the development version, you will continue to get "
 "updates from this channel. To stop receiving development updates, reinstall the default version from the link above."
 msgstr ""
 
-#: src/olympia/addons/templates/addons/impala/details.html:272
+#: src/olympia/addons/templates/addons/impala/details.html:277
 msgid "<strong>Caution:</strong> Development versions of this add-on have not been reviewed by Mozilla."
 msgstr ""
 
-#: src/olympia/addons/templates/addons/impala/details.html:287
+#: src/olympia/addons/templates/addons/impala/details.html:292
 msgid "See complete development channel history"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/impala/details.html:306 src/olympia/addons/templates/addons/impala/details.html:315 src/olympia/addons/templates/addons/impala/details.html:327
+#: src/olympia/addons/templates/addons/impala/details.html:311 src/olympia/addons/templates/addons/impala/details.html:320 src/olympia/addons/templates/addons/impala/details.html:332
 #: src/olympia/addons/templates/addons/impala/review_add_box.html:4 src/olympia/stats/templates/stats/popup.html:2 src/olympia/stats/templates/stats/popup.html:8
-#: src/olympia/stats/templates/stats/stats.html:202 src/olympia/users/templates/users/profile.html:119
+#: src/olympia/stats/templates/stats/stats.html:204 src/olympia/users/templates/users/profile.html:119
 msgid "close"
 msgstr ""
 
@@ -1127,15 +1128,11 @@ msgstr ""
 msgid "Source Code License"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/impala/persona_grid.html:16 src/olympia/addons/templates/addons/impala/toplist.html:6
-msgid "{0} users"
-msgstr ""
-
 #: src/olympia/addons/templates/addons/impala/review_list_box.html:19 src/olympia/reviews/templates/reviews/review.html:40
 msgid "permalink"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/impala/review_list_box.html:23 src/olympia/editors/templates/editors/queue.html:98 src/olympia/reviews/templates/reviews/review.html:44
+#: src/olympia/addons/templates/addons/impala/review_list_box.html:23 src/olympia/editors/templates/editors/queue.html:104 src/olympia/reviews/templates/reviews/review.html:44
 msgid "translate"
 msgstr ""
 
@@ -1154,6 +1151,10 @@ msgstr ""
 msgid "Be the first!"
 msgstr ""
 
+#: src/olympia/addons/templates/addons/impala/toplist.html:6
+msgid "{0} users"
+msgstr ""
+
 #: src/olympia/addons/templates/addons/impala/listing/sorter.html:14 src/olympia/devhub/templates/devhub/addons/listing/item_actions.html:49
 msgid "More"
 msgstr ""
@@ -1166,7 +1167,7 @@ msgstr ""
 msgid "My Add-ons"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/includes/dashboard_tabs.html:6 src/olympia/amo/context_processors.py:51
+#: src/olympia/addons/templates/addons/includes/dashboard_tabs.html:6 src/olympia/amo/context_processors.py:50
 msgid "My Themes"
 msgstr ""
 
@@ -1221,7 +1222,7 @@ msgstr ""
 msgid "Weekly Downloads"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/mobile/details.html:99 src/olympia/compat/templates/compat/reporter_detail.html:46 src/olympia/devhub/forms.py:787
+#: src/olympia/addons/templates/addons/mobile/details.html:99 src/olympia/compat/templates/compat/reporter_detail.html:46 src/olympia/devhub/forms.py:788
 #: src/olympia/devhub/templates/devhub/versions/list.html:163
 msgid "Version"
 msgstr ""
@@ -1305,7 +1306,7 @@ msgstr ""
 #: src/olympia/browse/templates/browse/personas/category_landing.html:21 src/olympia/browse/templates/browse/personas/category_landing.html:23
 #: src/olympia/browse/templates/browse/personas/category_landing.html:38 src/olympia/browse/templates/browse/personas/grid.html:7 src/olympia/browse/templates/browse/personas/grid.html:11
 #: src/olympia/browse/templates/browse/personas/mobile/base.html:7 src/olympia/browse/templates/browse/personas/mobile/category_landing.html:19 src/olympia/constants/base.py:180
-#: src/olympia/devhub/templates/devhub/personas/submit.html:13 src/olympia/editors/helpers.py:105 src/olympia/editors/templates/editors/base.html:26
+#: src/olympia/devhub/templates/devhub/personas/submit.html:13 src/olympia/editors/helpers.py:107 src/olympia/editors/templates/editors/base.html:26
 #: src/olympia/editors/templates/editors/performance.html:73 src/olympia/search/templates/search/personas.html:39 src/olympia/templates/menu_links.html:9
 msgid "Themes"
 msgstr ""
@@ -1326,7 +1327,7 @@ msgstr ""
 msgid "Highest Rated"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/mobile/home.html:74 src/olympia/amo/templates/amo/side_nav.html:5 src/olympia/amo/templates/amo/site_nav.html:27 src/olympia/amo/templates/amo/site_nav.html:57
+#: src/olympia/addons/templates/addons/mobile/home.html:74 src/olympia/amo/templates/amo/side_nav.html:5 src/olympia/amo/templates/amo/site_nav.html:27 src/olympia/amo/templates/amo/site_nav.html:55
 #: src/olympia/bandwagon/views.py:97 src/olympia/browse/views.py:57 src/olympia/browse/views.py:67 src/olympia/browse/templates/browse/personas/mobile/category_landing.html:65
 #: src/olympia/search/forms.py:15 src/olympia/search/forms.py:87
 msgid "Newest"
@@ -1340,90 +1341,90 @@ msgstr ""
 msgid "Theme Info &raquo;"
 msgstr ""
 
-#: src/olympia/amo/context_processors.py:39 src/olympia/devhub/templates/devhub/nav.html:43
+#: src/olympia/amo/context_processors.py:37 src/olympia/devhub/templates/devhub/nav.html:43
 msgid "Tools"
 msgstr ""
 
-#: src/olympia/amo/context_processors.py:48 src/olympia/discovery/templates/discovery/pane_account.html:8 src/olympia/users/templates/users/includes/navigation.html:2
+#: src/olympia/amo/context_processors.py:47 src/olympia/discovery/templates/discovery/pane_account.html:8 src/olympia/users/templates/users/includes/navigation.html:2
 msgid "My Profile"
 msgstr ""
 
-#: src/olympia/amo/context_processors.py:54 src/olympia/users/templates/users/edit.html:5 src/olympia/users/templates/users/includes/navigation.html:3
+#: src/olympia/amo/context_processors.py:53 src/olympia/users/templates/users/edit.html:5 src/olympia/users/templates/users/includes/navigation.html:3
 msgid "Account Settings"
 msgstr ""
 
-#: src/olympia/amo/context_processors.py:57 src/olympia/discovery/templates/discovery/pane_account.html:11 src/olympia/users/templates/users/profile.html:83
+#: src/olympia/amo/context_processors.py:56 src/olympia/discovery/templates/discovery/pane_account.html:11 src/olympia/users/templates/users/profile.html:83
 #: src/olympia/users/templates/users/includes/navigation.html:4
 msgid "My Collections"
 msgstr ""
 
-#: src/olympia/amo/context_processors.py:62 src/olympia/discovery/templates/discovery/pane_account.html:10 src/olympia/users/templates/users/includes/navigation.html:7
+#: src/olympia/amo/context_processors.py:61 src/olympia/discovery/templates/discovery/pane_account.html:10 src/olympia/users/templates/users/includes/navigation.html:7
 msgid "My Favorites"
 msgstr ""
 
-#: src/olympia/amo/context_processors.py:67 src/olympia/discovery/templates/discovery/pane_account.html:13 src/olympia/templates/impala/user_login.html:14
+#: src/olympia/amo/context_processors.py:66 src/olympia/discovery/templates/discovery/pane_account.html:13 src/olympia/templates/impala/user_login.html:14
 #: src/olympia/templates/mobile/header_auth.html:5
 msgid "Log out"
 msgstr ""
 
-#: src/olympia/amo/context_processors.py:72 src/olympia/devhub/templates/devhub/addons/dashboard.html:4
+#: src/olympia/amo/context_processors.py:71 src/olympia/devhub/templates/devhub/addons/dashboard.html:4
 msgid "Manage My Submissions"
 msgstr ""
 
-#: src/olympia/amo/context_processors.py:75 src/olympia/devhub/templates/devhub/nav.html:27 src/olympia/devhub/templates/devhub/addons/dashboard.html:25
+#: src/olympia/amo/context_processors.py:74 src/olympia/devhub/templates/devhub/nav.html:27 src/olympia/devhub/templates/devhub/addons/dashboard.html:25
 #: src/olympia/devhub/templates/devhub/addons/submit/base.html:4
 msgid "Submit a New Add-on"
 msgstr ""
 
-#: src/olympia/amo/context_processors.py:77 src/olympia/browse/templates/browse/personas/base.html:50 src/olympia/devhub/templates/devhub/index.html:24
+#: src/olympia/amo/context_processors.py:76 src/olympia/browse/templates/browse/personas/base.html:50 src/olympia/devhub/templates/devhub/index.html:24
 #: src/olympia/devhub/templates/devhub/addons/dashboard.html:29
 msgid "Submit a New Theme"
 msgstr ""
 
-#: src/olympia/amo/context_processors.py:79 src/olympia/amo/templates/amo/site_nav.html:87 src/olympia/devhub/helpers.py:36 src/olympia/devhub/helpers.py:68 src/olympia/devhub/helpers.py:102
+#: src/olympia/amo/context_processors.py:78 src/olympia/amo/templates/amo/site_nav.html:85 src/olympia/devhub/helpers.py:36 src/olympia/devhub/helpers.py:68 src/olympia/devhub/helpers.py:102
 #: src/olympia/templates/footer.html:6 src/olympia/templates/menu_links.html:14
 msgid "Developer Hub"
 msgstr ""
 
-#: src/olympia/amo/context_processors.py:83 src/olympia/devhub/views.py:1792
+#: src/olympia/amo/context_processors.py:81 src/olympia/devhub/views.py:1796
 msgid "Manage API Keys"
 msgstr ""
 
-#: src/olympia/amo/context_processors.py:88 src/olympia/editors/helpers.py:82 src/olympia/editors/helpers.py:102 src/olympia/editors/templates/editors/base.html:10
+#: src/olympia/amo/context_processors.py:86 src/olympia/editors/helpers.py:84 src/olympia/editors/helpers.py:104 src/olympia/editors/templates/editors/base.html:10
 msgid "Editor Tools"
 msgstr ""
 
-#: src/olympia/amo/context_processors.py:92
+#: src/olympia/amo/context_processors.py:90
 msgid "Admin Tools"
 msgstr ""
 
-#: src/olympia/amo/fields.py:15
+#: src/olympia/amo/fields.py:20
 msgid "Incorrect, please try again."
 msgstr ""
 
-#: src/olympia/amo/fields.py:16
+#: src/olympia/amo/fields.py:21
 msgid "Error verifying input, please try again."
 msgstr ""
 
-#: src/olympia/amo/fields.py:32
+#: src/olympia/amo/fields.py:37
 msgid "This must be a valid hex color code, such as #000000."
 msgstr ""
 
-#: src/olympia/amo/fields.py:58
+#: src/olympia/amo/fields.py:63
 msgid "Enter at least one value."
 msgstr ""
 
-#: src/olympia/amo/helpers.py:162 src/olympia/amo/templates/amo/site_nav.html:61 src/olympia/bandwagon/templates/bandwagon/add.html:9
+#: src/olympia/amo/helpers.py:162 src/olympia/amo/templates/amo/site_nav.html:59 src/olympia/bandwagon/templates/bandwagon/add.html:9
 #: src/olympia/bandwagon/templates/bandwagon/collection_detail.html:15 src/olympia/bandwagon/templates/bandwagon/delete.html:9 src/olympia/bandwagon/templates/bandwagon/edit.html:15
 #: src/olympia/bandwagon/templates/bandwagon/user_listing.html:18 src/olympia/bandwagon/templates/bandwagon/user_listing.html:21
 #: src/olympia/bandwagon/templates/bandwagon/impala/collection_listing.html:12 src/olympia/bandwagon/templates/bandwagon/impala/collection_listing.html:20
 #: src/olympia/bandwagon/templates/bandwagon/impala/collection_listing.html:24 src/olympia/bandwagon/templates/bandwagon/impala/collection_sidebar.html:3
 #: src/olympia/bandwagon/templates/bandwagon/includes/collection_sidebar.html:2 src/olympia/bandwagon/templates/bandwagon/mobile/collection_listing.html:3
-#: src/olympia/stats/templates/stats/stats.html:77 src/olympia/templates/menu_links.html:12
+#: src/olympia/stats/templates/stats/stats.html:33 src/olympia/templates/menu_links.html:12
 msgid "Collections"
 msgstr ""
 
-#: src/olympia/amo/helpers.py:171 src/olympia/amo/templates/amo/site_nav.html:85 src/olympia/browse/templates/browse/language_tools.html:3
+#: src/olympia/amo/helpers.py:171 src/olympia/amo/templates/amo/site_nav.html:83 src/olympia/browse/templates/browse/language_tools.html:3
 msgid "Dictionaries & Language Packs"
 msgstr ""
 
@@ -1575,8 +1576,8 @@ msgstr ""
 msgid "Comment on {addon} {version}."
 msgstr ""
 
-#: src/olympia/amo/log.py:236 src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:19 src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:47
-#: src/olympia/editors/helpers.py:511 src/olympia/editors/templates/editors/themes/history_table.html:11
+#: src/olympia/amo/log.py:236 src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:17 src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:45
+#: src/olympia/editors/helpers.py:584 src/olympia/editors/templates/editors/themes/history_table.html:11
 msgid "Comment"
 msgstr ""
 
@@ -1899,7 +1900,7 @@ msgstr ""
 #: src/olympia/amo/templates/amo/mobile/paginator.html:14 src/olympia/amo/templates/amo/mobile/paginator.html:16 src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:51
 #: src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:65 src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:78
 #: src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:91 src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:104
-#: src/olympia/discovery/templates/discovery/pane.html:45 src/olympia/discovery/templates/discovery/addons/detail.html:39 src/olympia/stats/templates/stats/stats.html:167
+#: src/olympia/discovery/templates/discovery/pane.html:45 src/olympia/discovery/templates/discovery/addons/detail.html:39 src/olympia/stats/templates/stats/stats.html:169
 msgid "Next"
 msgstr ""
 
@@ -1931,7 +1932,7 @@ msgid ""
 msgstr ""
 
 #: src/olympia/amo/templates/amo/side_nav.html:4 src/olympia/amo/templates/amo/side_nav.html:12 src/olympia/amo/templates/amo/site_nav.html:4 src/olympia/amo/templates/amo/site_nav.html:26
-#: src/olympia/browse/views.py:56 src/olympia/browse/views.py:66 src/olympia/browse/views.py:237 src/olympia/browse/views.py:282 src/olympia/search/forms.py:86
+#: src/olympia/browse/views.py:56 src/olympia/browse/views.py:66 src/olympia/browse/views.py:204 src/olympia/browse/views.py:249 src/olympia/search/forms.py:86
 msgid "Top Rated"
 msgstr ""
 
@@ -1945,38 +1946,38 @@ msgstr ""
 msgid "Extensions"
 msgstr ""
 
-#: src/olympia/amo/templates/amo/site_nav.html:45
+#: src/olympia/amo/templates/amo/site_nav.html:44
 msgid "Want more customization? Try <b>Complete Themes</b>"
 msgstr ""
 
-#: src/olympia/amo/templates/amo/site_nav.html:56 src/olympia/bandwagon/views.py:96
+#: src/olympia/amo/templates/amo/site_nav.html:54 src/olympia/bandwagon/views.py:96
 msgid "Most Followers"
 msgstr ""
 
-#: src/olympia/amo/templates/amo/site_nav.html:68 src/olympia/bandwagon/templates/bandwagon/impala/collection_sidebar.html:16
+#: src/olympia/amo/templates/amo/site_nav.html:66 src/olympia/bandwagon/templates/bandwagon/impala/collection_sidebar.html:16
 #: src/olympia/bandwagon/templates/bandwagon/includes/collection_sidebar.html:18
 msgid "Collections I've Made"
 msgstr ""
 
-#: src/olympia/amo/templates/amo/site_nav.html:70 src/olympia/bandwagon/templates/bandwagon/user_listing.html:4 src/olympia/bandwagon/templates/bandwagon/impala/collection_sidebar.html:13
+#: src/olympia/amo/templates/amo/site_nav.html:68 src/olympia/bandwagon/templates/bandwagon/user_listing.html:4 src/olympia/bandwagon/templates/bandwagon/impala/collection_sidebar.html:13
 #: src/olympia/bandwagon/templates/bandwagon/includes/collection_sidebar.html:15
 msgid "Collections I'm Following"
 msgstr ""
 
-#: src/olympia/amo/templates/amo/site_nav.html:73 src/olympia/bandwagon/templates/bandwagon/impala/collection_sidebar.html:18
-#: src/olympia/bandwagon/templates/bandwagon/includes/collection_sidebar.html:20 src/olympia/users/models.py:512
+#: src/olympia/amo/templates/amo/site_nav.html:71 src/olympia/bandwagon/templates/bandwagon/impala/collection_sidebar.html:18
+#: src/olympia/bandwagon/templates/bandwagon/includes/collection_sidebar.html:20 src/olympia/users/models.py:521
 msgid "My Favorite Add-ons"
 msgstr ""
 
-#: src/olympia/amo/templates/amo/site_nav.html:78
+#: src/olympia/amo/templates/amo/site_nav.html:76
 msgid "More&hellip;"
 msgstr ""
 
-#: src/olympia/amo/templates/amo/site_nav.html:82
+#: src/olympia/amo/templates/amo/site_nav.html:80
 msgid "Add-ons for Mobile"
 msgstr ""
 
-#: src/olympia/amo/templates/amo/site_nav.html:86 src/olympia/browse/feeds.py:207 src/olympia/browse/templates/browse/search_tools.html:3 src/olympia/constants/base.py:176
+#: src/olympia/amo/templates/amo/site_nav.html:84 src/olympia/browse/feeds.py:207 src/olympia/browse/templates/browse/search_tools.html:3 src/olympia/constants/base.py:176
 #: src/olympia/templates/menu_links.html:10
 msgid "Search Tools"
 msgstr ""
@@ -1992,7 +1993,7 @@ msgid "Jump to first page"
 msgstr ""
 
 #: src/olympia/amo/templates/amo/impala/paginator.html:22 src/olympia/amo/templates/amo/mobile/impala_paginator.html:12 src/olympia/discovery/templates/discovery/pane.html:44
-#: src/olympia/discovery/templates/discovery/addons/detail.html:38 src/olympia/stats/templates/stats/stats.html:164
+#: src/olympia/discovery/templates/discovery/addons/detail.html:38 src/olympia/stats/templates/stats/stats.html:166
 msgid "Previous"
 msgstr ""
 
@@ -2015,30 +2016,49 @@ msgid_plural "Page {n}"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/olympia/amo/templates/services/install.html:38
-#, python-format
-msgid "If you are not prompted to install %(addon_name)s in a moment, please <a href=\"%(addon_xpi)s\">click here</a>."
-msgstr ""
-
-#: src/olympia/amo/tests/test_messages.py:57 src/olympia/amo/tests/test_messages.py:58 src/olympia/reviews/forms.py:25 src/olympia/reviews/forms.py:50 src/olympia/reviews/templates/reviews/add.html:56
+#: src/olympia/amo/tests/test_messages.py:56 src/olympia/amo/tests/test_messages.py:57 src/olympia/reviews/forms.py:25 src/olympia/reviews/forms.py:50 src/olympia/reviews/templates/reviews/add.html:56
 #: src/olympia/reviews/templates/reviews/reply.html:30
 msgid "Title"
 msgstr ""
 
-#: src/olympia/amo/tests/test_messages.py:57 src/olympia/amo/tests/test_messages.py:58
+#: src/olympia/amo/tests/test_messages.py:56 src/olympia/amo/tests/test_messages.py:57
 msgid "Body"
 msgstr ""
 
-#: src/olympia/amo/tests/test_messages.py:59
+#: src/olympia/amo/tests/test_messages.py:58
 msgid "Another Title"
 msgstr ""
 
-#: src/olympia/amo/tests/test_messages.py:59
+#: src/olympia/amo/tests/test_messages.py:58
 msgid "Another Body"
 msgstr ""
 
-#: src/olympia/api/views.py:255
-msgid "Not implemented yet."
+#: src/olympia/api/authentication.py:76
+msgid "Signature has expired."
+msgstr ""
+
+#: src/olympia/api/authentication.py:79
+msgid "Error decoding signature."
+msgstr ""
+
+#: src/olympia/api/authentication.py:82
+msgid "Invalid JWT Token."
+msgstr ""
+
+#: src/olympia/api/authentication.py:130
+msgid "Invalid Authorization header. No credentials provided."
+msgstr ""
+
+#: src/olympia/api/authentication.py:133
+msgid "Invalid Authorization header. Credentials string should not contain spaces."
+msgstr ""
+
+#: src/olympia/api/fields.py:29
+msgid "The field must have a length of at least {num} characters."
+msgstr ""
+
+#: src/olympia/api/fields.py:31
+msgid "The language code {lang_code} is invalid."
 msgstr ""
 
 #: src/olympia/applications/views.py:39 src/olympia/applications/templates/applications/appversions.html:3
@@ -2057,7 +2077,7 @@ msgstr ""
 msgid "Add-ons submitted to Mozilla Add-ons must have a manifest file with at least one of the below applications supported. Only the versions listed below are allowed for these applications."
 msgstr ""
 
-#: src/olympia/applications/templates/applications/appversions.html:25
+#: src/olympia/applications/templates/applications/appversions.html:25 src/olympia/editors/helpers.py:361
 msgid "GUID"
 msgstr ""
 
@@ -2171,8 +2191,8 @@ msgstr ""
 msgid "Remove from favorites"
 msgstr ""
 
-#: src/olympia/bandwagon/views.py:98 src/olympia/bandwagon/views.py:191 src/olympia/browse/views.py:58 src/olympia/browse/views.py:69 src/olympia/browse/views.py:458 src/olympia/devhub/views.py:74
-#: src/olympia/devhub/views.py:82 src/olympia/devhub/templates/devhub/addons/edit/basic.html:20 src/olympia/editors/templates/editors/leaderboard.html:24
+#: src/olympia/bandwagon/views.py:98 src/olympia/bandwagon/views.py:191 src/olympia/browse/views.py:58 src/olympia/browse/views.py:69 src/olympia/browse/views.py:425 src/olympia/devhub/views.py:72
+#: src/olympia/devhub/views.py:80 src/olympia/devhub/templates/devhub/addons/edit/basic.html:20 src/olympia/editors/templates/editors/leaderboard.html:24
 #: src/olympia/editors/templates/editors/themes/queue_list.html:48 src/olympia/search/forms.py:17 src/olympia/search/forms.py:89 src/olympia/users/templates/users/vcard.html:5
 msgid "Name"
 msgstr ""
@@ -2181,7 +2201,7 @@ msgstr ""
 msgid "Recently Popular"
 msgstr ""
 
-#: src/olympia/bandwagon/views.py:189 src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:18
+#: src/olympia/bandwagon/views.py:189 src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:16
 msgid "Added"
 msgstr ""
 
@@ -2195,7 +2215,7 @@ msgstr ""
 
 #: src/olympia/bandwagon/views.py:316
 #, python-format
-msgid "Your new collection is shown below. You can <ahref=\"%(url)s\">edit additional settings</a> if you'dlike."
+msgid "Your new collection is shown below. You can <a href=\"%(url)s\">edit additional settings</a> if you'd like."
 msgstr ""
 
 #: src/olympia/bandwagon/views.py:322
@@ -2323,8 +2343,8 @@ msgid_plural "%(num)s Add-ons in this Collection"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/olympia/bandwagon/templates/bandwagon/collection_detail.html:125 src/olympia/compat/templates/compat/index.html:25 src/olympia/compat/templates/compat/reporter_detail.html:29
-#: src/olympia/files/templates/files/viewer.html:29 src/olympia/templates/amo_footer.html:17 src/olympia/templates/includes/lang_switcher.html:10
+#: src/olympia/bandwagon/templates/bandwagon/collection_detail.html:125 src/olympia/compat/templates/compat/reporter_detail.html:29 src/olympia/files/templates/files/viewer.html:29
+#: src/olympia/templates/amo_footer.html:17 src/olympia/templates/includes/lang_switcher.html:10
 msgid "Go"
 msgstr ""
 
@@ -2491,7 +2511,7 @@ msgid "Remove this user as a contributor"
 msgstr ""
 
 #: src/olympia/bandwagon/templates/bandwagon/edit_contributors.html:18 src/olympia/bandwagon/templates/bandwagon/edit_contributors.html:43
-#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:20 src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:48
+#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:18 src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:46
 #: src/olympia/devhub/templates/devhub/addons/ajax_compat_update.html:19
 msgid "Remove"
 msgstr ""
@@ -2539,7 +2559,7 @@ msgid "<b>Warning:</b> By changing the owner of this collection, you will no lon
 msgstr ""
 
 #: src/olympia/bandwagon/templates/bandwagon/edit_contributors.html:83 src/olympia/devhub/templates/devhub/addons/forms_shared/media.html:157
-#: src/olympia/devhub/templates/devhub/addons/submit/describe.html:69 src/olympia/devhub/templates/devhub/addons/submit/license.html:60 src/olympia/devhub/templates/devhub/addons/submit/upload.html:78
+#: src/olympia/devhub/templates/devhub/addons/submit/describe.html:69 src/olympia/devhub/templates/devhub/addons/submit/license.html:60 src/olympia/devhub/templates/devhub/addons/submit/upload.html:70
 #: src/olympia/devhub/templates/devhub/payments/tier.html:17 src/olympia/editors/templates/editors/themes/themes.html:111 src/olympia/editors/templates/editors/themes/themes.html:128
 #: src/olympia/editors/templates/editors/themes/themes.html:134 src/olympia/editors/templates/editors/themes/themes.html:141 src/olympia/users/templates/users/fxa_migration_prompt_content.html:10
 #: src/olympia/users/templates/users/login_form.html:42 src/olympia/users/templates/users/mobile/login.html:57
@@ -2622,31 +2642,31 @@ msgid "Add-ons in Your Collection"
 msgstr ""
 
 #: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:4
-msgid ""
-"To include an add-on in this collection, enter its name in the box below and hit enter.  You can also use the <strong>Add to Collection</strong> links throughout the site to include add-ons later."
+msgid "To include an add-on in this collection, enter its name in the box below and hit enter."
 msgstr ""
 
-#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:17 src/olympia/constants/base.py:400 src/olympia/devhub/templates/devhub/addons/activity.html:62
+#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:15 src/olympia/constants/base.py:400 src/olympia/devhub/templates/devhub/addons/activity.html:62
+#: src/olympia/editors/helpers.py:273 src/olympia/editors/helpers.py:360
 msgid "Add-on"
 msgstr ""
 
-#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:26
+#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:24
 msgid "Enter the name of the add-on to include"
 msgstr ""
 
-#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:28
+#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:26
 msgid "Add to Collection"
 msgstr ""
 
-#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:45 src/olympia/editors/helpers.py:936 src/olympia/editors/helpers.py:956
+#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:43 src/olympia/editors/helpers.py:1016 src/olympia/editors/helpers.py:1036
 msgid "Pending"
 msgstr ""
 
-#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:47
+#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:45
 msgid "Add a comment"
 msgstr ""
 
-#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:48
+#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:46
 msgid "Remove this add-on from the collection"
 msgstr ""
 
@@ -2753,12 +2773,12 @@ msgstr ""
 msgid "Most Users"
 msgstr ""
 
-#: src/olympia/browse/views.py:61 src/olympia/browse/views.py:72 src/olympia/browse/views.py:279 src/olympia/browse/templates/browse/personas/mobile/category_landing.html:63
+#: src/olympia/browse/views.py:61 src/olympia/browse/views.py:72 src/olympia/browse/views.py:246 src/olympia/browse/templates/browse/personas/mobile/category_landing.html:63
 #: src/olympia/discovery/templates/discovery/pane.html:67 src/olympia/search/forms.py:92
 msgid "Up & Coming"
 msgstr ""
 
-#: src/olympia/browse/views.py:460 src/olympia/devhub/views.py:76 src/olympia/devhub/views.py:83 src/olympia/discovery/templates/discovery/addons/detail.html:66
+#: src/olympia/browse/views.py:427 src/olympia/devhub/views.py:74 src/olympia/devhub/views.py:81 src/olympia/discovery/templates/discovery/addons/detail.html:66
 msgid "Created"
 msgstr ""
 
@@ -2946,8 +2966,8 @@ msgid_plural "See all %(cnt)s extensions in %(name)s &raquo;"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/olympia/browse/templates/browse/mobile/extensions.html:13 src/olympia/compat/templates/compat/index.html:82 src/olympia/devhub/templates/devhub/devhub_search.html:24
-#: src/olympia/devhub/templates/devhub/addons/activity.html:47 src/olympia/search/templates/search/no_results.html:4 src/olympia/search/templates/search/mobile/results.html:36
+#: src/olympia/browse/templates/browse/mobile/extensions.html:13 src/olympia/devhub/templates/devhub/devhub_search.html:24 src/olympia/devhub/templates/devhub/addons/activity.html:47
+#: src/olympia/search/templates/search/no_results.html:4 src/olympia/search/templates/search/mobile/results.html:36
 msgid "No results found."
 msgstr ""
 
@@ -3032,7 +3052,7 @@ msgstr ""
 msgid "All"
 msgstr ""
 
-#: src/olympia/compat/forms.py:22 src/olympia/search/views.py:525
+#: src/olympia/compat/forms.py:22 src/olympia/editors/templates/editors/base.html:69 src/olympia/search/views.py:518
 msgid "All Add-ons"
 msgstr ""
 
@@ -3042,53 +3062,6 @@ msgstr ""
 
 #: src/olympia/compat/forms.py:24
 msgid "Non-binary"
-msgstr ""
-
-#. Review points sources other than add-ons and themes.
-#: src/olympia/compat/views.py:87 src/olympia/constants/base.py:388 src/olympia/devhub/forms.py:162 src/olympia/editors/templates/editors/performance.html:75
-msgid "Other"
-msgstr ""
-
-#: src/olympia/compat/templates/compat/index.html:4
-msgid "Add-on Compatibility Report for {app} {version}"
-msgstr ""
-
-#: src/olympia/compat/templates/compat/index.html:11
-msgid "{app} {version} Compatibility"
-msgstr ""
-
-#: src/olympia/compat/templates/compat/index.html:17
-#, python-format
-msgid "Top 95%% compatible with previous version"
-msgstr ""
-
-#: src/olympia/compat/templates/compat/index.html:18
-#, python-format
-msgid "Top 95%% of all add-ons"
-msgstr ""
-
-#: src/olympia/compat/templates/compat/index.html:19
-msgid "All active add-ons"
-msgstr ""
-
-#: src/olympia/compat/templates/compat/index.html:23 src/olympia/constants/base.py:401
-msgid "App"
-msgstr ""
-
-#: src/olympia/compat/templates/compat/index.html:55
-msgid "Details for add-ons compatible with previous version:"
-msgstr ""
-
-#: src/olympia/compat/templates/compat/index.html:57
-msgid "Show all versions"
-msgstr ""
-
-#: src/olympia/compat/templates/compat/index.html:59
-msgid "Details for add-ons compatible with all versions:"
-msgstr ""
-
-#: src/olympia/compat/templates/compat/index.html:61
-msgid "Show previous version only"
 msgstr ""
 
 #: src/olympia/compat/templates/compat/reporter.html:3
@@ -3142,8 +3115,8 @@ msgstr ""
 msgid "Report Type"
 msgstr ""
 
-#: src/olympia/compat/templates/compat/reporter_detail.html:47 src/olympia/devhub/forms.py:784 src/olympia/devhub/templates/devhub/addons/ajax_compat_update.html:17 src/olympia/editors/forms.py:108
-#: src/olympia/zadmin/forms.py:45
+#: src/olympia/compat/templates/compat/reporter_detail.html:47 src/olympia/devhub/forms.py:785 src/olympia/devhub/templates/devhub/addons/ajax_compat_update.html:17 src/olympia/editors/forms.py:108
+#: src/olympia/editors/forms.py:248 src/olympia/zadmin/forms.py:45
 msgid "Application"
 msgstr ""
 
@@ -3231,7 +3204,8 @@ msgstr ""
 msgid "Preliminarily Reviewed and Awaiting Full Review"
 msgstr ""
 
-#: src/olympia/constants/base.py:33 src/olympia/editors/helpers.py:924 src/olympia/editors/templates/editors/themes/history_table.html:34
+#: src/olympia/constants/base.py:33 src/olympia/editors/forms.py:258 src/olympia/editors/helpers.py:73 src/olympia/editors/helpers.py:1004
+#: src/olympia/editors/templates/editors/themes/history_table.html:34
 msgid "Deleted"
 msgstr ""
 
@@ -3328,6 +3302,11 @@ msgstr ""
 msgid "Ask before users can download this add-on"
 msgstr ""
 
+#. Review points sources other than add-ons and themes.
+#: src/olympia/constants/base.py:388 src/olympia/devhub/forms.py:162 src/olympia/editors/templates/editors/performance.html:75
+msgid "Other"
+msgstr ""
+
 #: src/olympia/constants/base.py:389
 msgid "Exception"
 msgstr ""
@@ -3338,6 +3317,10 @@ msgstr ""
 
 #: src/olympia/constants/base.py:391
 msgid "Change"
+msgstr ""
+
+#: src/olympia/constants/base.py:401
+msgid "App"
 msgstr ""
 
 #: src/olympia/constants/base.py:402
@@ -3488,7 +3471,7 @@ msgstr ""
 msgid "Duplicate"
 msgstr ""
 
-#: src/olympia/constants/editors.py:17 src/olympia/editors/helpers.py:502 src/olympia/editors/templates/editors/themes/queue.html:71 src/olympia/editors/templates/editors/themes/themes.html:94
+#: src/olympia/constants/editors.py:17 src/olympia/editors/helpers.py:575 src/olympia/editors/templates/editors/themes/queue.html:71 src/olympia/editors/templates/editors/themes/themes.html:94
 msgid "Reject"
 msgstr ""
 
@@ -3588,7 +3571,7 @@ msgstr ""
 msgid "Android"
 msgstr ""
 
-#: src/olympia/core/apps.py:19
+#: src/olympia/core/apps.py:21
 msgid "Core"
 msgstr ""
 
@@ -3722,7 +3705,7 @@ msgid "Submit my add-on for manual review."
 msgstr ""
 
 #: src/olympia/devhub/forms.py:537
-msgid "Do not list my add-on on this site (beta)"
+msgid "Do not list my add-on on this site"
 msgstr ""
 
 #: src/olympia/devhub/forms.py:538
@@ -3755,46 +3738,46 @@ msgstr ""
 
 #: src/olympia/devhub/forms.py:592
 #, python-format
-msgid "Version %s already exists"
+msgid "Version %s already exists, or was uploaded before."
 msgstr ""
 
-#: src/olympia/devhub/forms.py:604
+#: src/olympia/devhub/forms.py:605
 msgid "Select a valid choice. That choice is not one of the available choices."
 msgstr ""
 
-#: src/olympia/devhub/forms.py:610
+#: src/olympia/devhub/forms.py:611
 msgid "A file with a version ending with a|alpha|b|beta and an optional number is detected as beta."
 msgstr ""
 
-#: src/olympia/devhub/forms.py:633
+#: src/olympia/devhub/forms.py:634
 msgid "You cannot upload any more files for this version."
 msgstr ""
 
-#: src/olympia/devhub/forms.py:639
+#: src/olympia/devhub/forms.py:640
 msgid "Version doesn't match"
 msgstr ""
 
-#: src/olympia/devhub/forms.py:668
+#: src/olympia/devhub/forms.py:669
 msgid "You cannot delete a file once the review process has started.  You must delete the whole version."
 msgstr ""
 
-#: src/olympia/devhub/forms.py:688
+#: src/olympia/devhub/forms.py:689
 msgid "The platform All cannot be combined with specific platforms."
 msgstr ""
 
-#: src/olympia/devhub/forms.py:693
+#: src/olympia/devhub/forms.py:694
 msgid "A platform can only be chosen once."
 msgstr ""
 
-#: src/olympia/devhub/forms.py:706
+#: src/olympia/devhub/forms.py:707
 msgid "A review type must be selected."
 msgstr ""
 
-#: src/olympia/devhub/forms.py:788 src/olympia/editors/forms.py:114 src/olympia/zadmin/forms.py:49 src/olympia/zadmin/forms.py:52
+#: src/olympia/devhub/forms.py:789 src/olympia/editors/forms.py:114 src/olympia/editors/forms.py:254 src/olympia/zadmin/forms.py:49 src/olympia/zadmin/forms.py:52
 msgid "Select an application first"
 msgstr ""
 
-#: src/olympia/devhub/forms.py:840
+#: src/olympia/devhub/forms.py:841
 msgid "There cannot be more than 3 required add-ons."
 msgstr ""
 
@@ -3828,76 +3811,76 @@ msgstr[1] ""
 msgid "Review"
 msgstr ""
 
-#: src/olympia/devhub/tasks.py:551
+#: src/olympia/devhub/tasks.py:583
 #, python-format
 msgid "%s responded with %s (%s)."
 msgstr ""
 
-#: src/olympia/devhub/tasks.py:555
+#: src/olympia/devhub/tasks.py:587
 #, python-format
 msgid "Connection to \"%s\" timed out."
 msgstr ""
 
-#: src/olympia/devhub/tasks.py:557
+#: src/olympia/devhub/tasks.py:589
 #, python-format
 msgid "Could not contact host at \"%s\"."
 msgstr ""
 
-#: src/olympia/devhub/utils.py:104
+#: src/olympia/devhub/utils.py:105
 #, python-format
 msgid "Validation generated too many errors/warnings so %s messages were truncated. After addressing the visible messages, you'll be able to see the others."
 msgstr ""
 
-#: src/olympia/devhub/views.py:183
+#: src/olympia/devhub/views.py:181
 msgid "All My Add-ons"
 msgstr ""
 
-#: src/olympia/devhub/views.py:210
+#: src/olympia/devhub/views.py:208
 msgid "All Activity"
 msgstr ""
 
-#: src/olympia/devhub/views.py:211
+#: src/olympia/devhub/views.py:209
 msgid "Add-on Updates"
 msgstr ""
 
-#: src/olympia/devhub/views.py:212
+#: src/olympia/devhub/views.py:210
 msgid "Add-on Status"
 msgstr ""
 
-#: src/olympia/devhub/views.py:213
+#: src/olympia/devhub/views.py:211
 msgid "User Collections"
 msgstr ""
 
-#: src/olympia/devhub/views.py:214 src/olympia/devhub/templates/devhub/docs/policies-maintenance.html:68 src/olympia/pages/templates/pages/dev_faq.html:38
+#: src/olympia/devhub/views.py:212 src/olympia/devhub/templates/devhub/docs/policies-maintenance.html:68 src/olympia/pages/templates/pages/dev_faq.html:38
 #: src/olympia/pages/templates/pages/dev_faq.html:484
 msgid "User Reviews"
 msgstr ""
 
-#: src/olympia/devhub/views.py:327 src/olympia/devhub/views.py:331 src/olympia/devhub/views.py:484 src/olympia/devhub/views.py:513 src/olympia/devhub/views.py:564 src/olympia/devhub/views.py:1150
+#: src/olympia/devhub/views.py:325 src/olympia/devhub/views.py:329 src/olympia/devhub/views.py:484 src/olympia/devhub/views.py:513 src/olympia/devhub/views.py:564 src/olympia/devhub/views.py:1156
 msgid "Changes successfully saved."
 msgstr ""
 
-#: src/olympia/devhub/views.py:334 src/olympia/devhub/views.py:1631
+#: src/olympia/devhub/views.py:332 src/olympia/devhub/views.py:1637
 msgid "Please check the form for errors."
 msgstr ""
 
-#: src/olympia/devhub/views.py:346
+#: src/olympia/devhub/views.py:344
 msgid "Add-on cannot be deleted. Disable this add-on instead."
 msgstr ""
 
-#: src/olympia/devhub/views.py:356
+#: src/olympia/devhub/views.py:354
 msgid "Theme deleted."
 msgstr ""
 
-#: src/olympia/devhub/views.py:356
+#: src/olympia/devhub/views.py:354
 msgid "Add-on deleted."
 msgstr ""
 
-#: src/olympia/devhub/views.py:362
+#: src/olympia/devhub/views.py:360
 msgid "URL name was incorrect. Theme was not deleted."
 msgstr ""
 
-#: src/olympia/devhub/views.py:367
+#: src/olympia/devhub/views.py:365
 msgid "URL name was incorrect. Add-on was not deleted."
 msgstr ""
 
@@ -3925,7 +3908,7 @@ msgstr ""
 msgid "Check Add-on Compatibility"
 msgstr ""
 
-#: src/olympia/devhub/views.py:808 src/olympia/signing/views.py:90
+#: src/olympia/devhub/views.py:808 src/olympia/signing/views.py:95
 msgid "You cannot submit this type of add-on"
 msgstr ""
 
@@ -3955,33 +3938,33 @@ msgstr ""
 msgid "There was an error uploading your preview."
 msgstr ""
 
-#: src/olympia/devhub/views.py:1189
+#: src/olympia/devhub/views.py:1195
 #, python-format
 msgid "Version %s disabled."
 msgstr ""
 
-#: src/olympia/devhub/views.py:1193
+#: src/olympia/devhub/views.py:1199
 #, python-format
 msgid "Version %s deleted."
 msgstr ""
 
-#: src/olympia/devhub/views.py:1203
+#: src/olympia/devhub/views.py:1209
 msgid "This upload has failed validation, and may lack complete validation results. Please take due care when reviewing it."
 msgstr ""
 
-#: src/olympia/devhub/views.py:1677
+#: src/olympia/devhub/views.py:1683
 msgid "Preliminary Review Requested."
 msgstr ""
 
-#: src/olympia/devhub/views.py:1678
+#: src/olympia/devhub/views.py:1684
 msgid "Full Review Requested."
 msgstr ""
 
-#: src/olympia/devhub/views.py:1779
+#: src/olympia/devhub/views.py:1783
 msgid "Your old credentials were revoked and are no longer valid. Be sure to update all API clients with the new credentials."
 msgstr ""
 
-#: src/olympia/devhub/views.py:1797
+#: src/olympia/devhub/views.py:1801
 msgid "New API key created"
 msgstr ""
 
@@ -4011,7 +3994,7 @@ msgstr ""
 msgid "{0} :: Search"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/devhub_search.html:6 src/olympia/devhub/templates/devhub/search.html:8 src/olympia/editors/forms.py:435 src/olympia/editors/forms.py:437
+#: src/olympia/devhub/templates/devhub/devhub_search.html:6 src/olympia/devhub/templates/devhub/search.html:8 src/olympia/editors/forms.py:534 src/olympia/editors/forms.py:536
 #: src/olympia/editors/templates/editors/queue.html:27 src/olympia/editors/templates/editors/themes/queue_list.html:14 src/olympia/search/templates/search/collections.html:17
 #: src/olympia/search/templates/search/personas.html:18 src/olympia/search/templates/search/results.html:18 src/olympia/search/templates/search/mobile/results.html:8
 #: src/olympia/templates/search.html:14 src/olympia/templates/impala/search.html:18
@@ -4071,12 +4054,12 @@ msgstr ""
 msgid "Start Making Add-ons"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/index.html:86 src/olympia/devhub/templates/devhub/addons/listing/items.html:25 src/olympia/devhub/templates/devhub/includes/addon_details.html:15
+#: src/olympia/devhub/templates/devhub/index.html:86 src/olympia/devhub/templates/devhub/addons/listing/items.html:25 src/olympia/devhub/templates/devhub/includes/addon_details.html:20
 #: src/olympia/devhub/templates/devhub/personas/edit.html:43
 msgid "Status:"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/index.html:90 src/olympia/devhub/templates/devhub/includes/addon_details.html:100
+#: src/olympia/devhub/templates/devhub/index.html:90 src/olympia/devhub/templates/devhub/includes/addon_details.html:87
 msgid "Visibility:"
 msgstr ""
 
@@ -4084,11 +4067,11 @@ msgstr ""
 msgid "Latest Version:"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/index.html:109 src/olympia/devhub/templates/devhub/includes/addon_details.html:145 src/olympia/devhub/templates/devhub/personas/edit.html:49
+#: src/olympia/devhub/templates/devhub/index.html:109 src/olympia/devhub/templates/devhub/includes/addon_details.html:131 src/olympia/devhub/templates/devhub/personas/edit.html:49
 msgid "Queue Position:"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/index.html:110 src/olympia/devhub/templates/devhub/includes/addon_details.html:146 src/olympia/devhub/templates/devhub/personas/edit.html:50
+#: src/olympia/devhub/templates/devhub/index.html:110 src/olympia/devhub/templates/devhub/includes/addon_details.html:132 src/olympia/devhub/templates/devhub/personas/edit.html:50
 #, python-format
 msgid "%(position)s of %(total)s"
 msgstr ""
@@ -4190,16 +4173,6 @@ msgstr ""
 msgid "Do you want your add-on to be distributed on this site?"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/validate_addon.html:49 src/olympia/devhub/templates/devhub/addons/submit/upload.html:30 src/olympia/devhub/templates/devhub/versions/add_file_modal.html:14
-#: src/olympia/devhub/templates/devhub/versions/add_file_modal.html:53 src/olympia/devhub/templates/devhub/versions/list.html:298
-msgid "Warning:"
-msgstr ""
-
-#: src/olympia/devhub/templates/devhub/validate_addon.html:50 src/olympia/devhub/templates/devhub/addons/submit/upload.html:31
-#, python-format
-msgid "Submission of unlisted add-ons for signing is currently in an open beta. Please <a href=\"%(url)s\" target=\"_blank\">report any bugs</a> that you encounter."
-msgstr ""
-
 #. first parameter is a filename like lorem-ipsum-1.0.2.xpi
 #: src/olympia/devhub/templates/devhub/validation.html:5
 msgid "Validation Results for {0}"
@@ -4274,7 +4247,7 @@ msgstr ""
 msgid "Update Compatibility"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/addons/ajax_compat_update.html:4
+#: src/olympia/devhub/templates/devhub/addons/ajax_compat_update.html:4 src/olympia/devhub/templates/devhub/versions/edit.html:45
 msgid "Adjusting application information here will allow users to install your add-on even if the install manifest in the package indicates that the add-on is incompatible."
 msgstr ""
 
@@ -4286,9 +4259,9 @@ msgstr ""
 msgid "Add Another Application&hellip;"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/addons/ajax_compat_update.html:38 src/olympia/devhub/templates/devhub/addons/owner.html:86 src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:46
-#: src/olympia/devhub/templates/devhub/versions/list.html:351 src/olympia/devhub/templates/devhub/versions/list.html:353 src/olympia/templates/impala/base.html:132
-#: src/olympia/templates/impala/base.html:143 src/olympia/templates/impala/base.html:161 src/olympia/templates/impala/base.html:171
+#: src/olympia/devhub/templates/devhub/addons/ajax_compat_update.html:38 src/olympia/devhub/templates/devhub/addons/owner.html:86 src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:45
+#: src/olympia/devhub/templates/devhub/versions/list.html:349 src/olympia/devhub/templates/devhub/versions/list.html:351 src/olympia/templates/impala/base.html:129
+#: src/olympia/templates/impala/base.html:140 src/olympia/templates/impala/base.html:158 src/olympia/templates/impala/base.html:168
 msgid "Close"
 msgstr ""
 
@@ -4322,7 +4295,7 @@ msgstr ""
 msgid "Manage Authors & License"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/addons/owner.html:29 src/olympia/editors/templates/editors/review.html:270
+#: src/olympia/devhub/templates/devhub/addons/owner.html:29 src/olympia/editors/helpers.py:362 src/olympia/editors/templates/editors/review.html:270
 msgid "Authors"
 msgstr ""
 
@@ -4391,17 +4364,11 @@ msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/basic.html:52
 msgid ""
-"A short explanation of your add-on's basic\n"
-"                          functionality that is displayed in search and browse\n"
-"                          listings, as well as at the top of your add-on's\n"
-"                          details page. It is only relevant for listed add-ons."
+"A short explanation of your add-on's basic functionality that is displayed in search and browse listings, as well as at the top of your add-on's details page. It is only relevant for listed add-ons."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/basic.html:73
-msgid ""
-"Categories are the primary way users browse through add-ons.\n"
-"                        Choose any that fit your add-on's functionality for the most\n"
-"                        exposure. It is only relevant for listed add-ons."
+msgid "Categories are the primary way users browse through add-ons. Choose any that fit your add-on's functionality for the most exposure. It is only relevant for listed add-ons."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/basic.html:90
@@ -4411,11 +4378,7 @@ msgid ""
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/basic.html:119
-msgid ""
-"Tags help users find your add-on and should be short\n"
-"                        descriptors such as tabs, toolbar, or twitter.  You\n"
-"                        may have a maximum of {0} tags. It is only relevant\n"
-"                        for listed add-ons."
+msgid "Tags help users find your add-on and should be short descriptors such as tabs, toolbar, or twitter. You may have a maximum of {0} tags. It is only relevant for listed add-ons."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/basic.html:129 src/olympia/devhub/templates/devhub/personas/edit.html:97 src/olympia/devhub/templates/devhub/personas/submit.html:46
@@ -4443,11 +4406,7 @@ msgid "Add-on Details for {0}"
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/details.html:22
-msgid ""
-"A longer explanation of features,\n"
-"                          functionality, and other relevant information. This\n"
-"                          field is only displayed on the add-on's details\n"
-"                          page. It is only relevant for listed add-ons."
+msgid "A longer explanation of features, functionality, and other relevant information. This field is only displayed on the add-on's details page. It is only relevant for listed add-ons."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/details.html:44 src/olympia/translations/templates/translations/trans-menu.html:13
@@ -4455,10 +4414,7 @@ msgid "Default Locale"
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/details.html:45
-msgid ""
-"Information about your add-on is displayed in this locale\n"
-"                        unless you override it with a locale-specific translation.\n"
-"                        It is only relevant for listed add-ons."
+msgid "Information about your add-on is displayed in this locale unless you override it with a locale-specific translation. It is only relevant for listed add-ons."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/details.html:61 src/olympia/users/forms.py:311 src/olympia/users/templates/users/edit.html:122 src/olympia/users/templates/users/register.html:57
@@ -4468,10 +4424,8 @@ msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/details.html:63
 msgid ""
-"If your add-on has another homepage, enter its\n"
-"                          address here. If your website is localized into other\n"
-"                          languages multiple translations of this field can be\n"
-"                          added. It is only relevant for listed add-ons."
+"If your add-on has another homepage, enter its address here. If your website is localized into other languages multiple translations of this field can be added. It is only relevant for listed add-"
+"ons."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/media.html:3
@@ -4489,19 +4443,14 @@ msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/support.html:22
 msgid ""
-"If you wish to display an e-mail address for support\n"
-"                          inquiries, enter it here. If you have different\n"
-"                          addresses for each language multiple translations of\n"
-"                          this field can be added. It is only relevant for\n"
-"                          listed add-ons."
+"If you wish to display an e-mail address for support inquiries, enter it here. If you have different addresses for each language multiple translations of this field can be added. It is only "
+"relevant for listed add-ons."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/support.html:45
 msgid ""
-"If your add-on has a support website or forum, enter\n"
-"                          its address here. If your website is localized into\n"
-"                          other languages, multiple translations of this field can\n"
-"                          be added. It is only relevant for listed add-ons."
+"If your add-on has a support website or forum, enter its address here. If your website is localized into other languages, multiple translations of this field can be added. It is only relevant for "
+"listed add-ons."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:6
@@ -4515,11 +4464,8 @@ msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:23
 msgid ""
-"Any information end users may want to know that isn't\n"
-"                          necessarily applicable to the add-on summary or description.\n"
-"                          Common uses include listing known major bugs, information on\n"
-"                          how to report bugs, anticipated release date of a new version,\n"
-"                          etc. It is only relevant for listed add-ons."
+"Any information end users may want to know that isn't necessarily applicable to the add-on summary or description. Common uses include listing known major bugs, information on how to report bugs, "
+"anticipated release date of a new version, etc. It is only relevant for listed add-ons."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:46
@@ -4531,9 +4477,7 @@ msgid "Add-on Flags"
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:69
-msgid ""
-"These flags are used to classify add-ons. It is only\n"
-"                        relevant for listed add-ons."
+msgid "These flags are used to classify add-ons. It is only relevant for listed add-ons."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:74
@@ -4549,9 +4493,7 @@ msgid "View Source?"
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:90
-msgid ""
-"Whether the source of your add-on can be displayed in our\n"
-"                        online viewer. It is only relevant for listed add-ons."
+msgid "Whether the source of your add-on can be displayed in our online viewer. It is only relevant for listed add-ons."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:94
@@ -4567,10 +4509,7 @@ msgid "Public Stats?"
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:102
-msgid ""
-"Whether the download and usage stats of your add-on can\n"
-"                        be displayed in our online viewer.\n"
-"                        It is only relevant for listed add-ons."
+msgid "Whether the download and usage stats of your add-on can be displayed in our online viewer. It is only relevant for listed add-ons."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:107
@@ -4586,10 +4525,7 @@ msgid "Upgrade SDK?"
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:116
-msgid ""
-"If selected, we will try to automatically upgrade your\n"
-"                        add-on when a new version of the SDK is released.\n"
-"                        It is only relevant for listed add-ons."
+msgid "If selected, we will try to automatically upgrade your add-on when a new version of the SDK is released. It is only relevant for listed add-ons."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:121
@@ -4640,10 +4576,8 @@ msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/forms_shared/media.html:16
 msgid ""
-"Upload an icon for your add-on or choose from one of ours. The\n"
-"                      icon is displayed nearly everywhere your add-on is. Uploaded images\n"
-"                      must be one of the following image types: .png, .jpg.\n"
-"                      It is only relevant for listed add-ons."
+"Upload an icon for your add-on or choose from one of ours. The icon is displayed nearly everywhere your add-on is. Uploaded images must be one of the following image types: .png, .jpg. It is only "
+"relevant for listed add-ons."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/forms_shared/media.html:25
@@ -4656,9 +4590,7 @@ msgid "32x32px"
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/forms_shared/media.html:39
-msgid ""
-"Used in listings of add-ons, like search results\n"
-"                            and featured add-ons."
+msgid "Used in listings of add-ons, like search results and featured add-ons."
 msgstr ""
 
 #. The size of the icon
@@ -4753,16 +4685,14 @@ msgid "Deleting your add-on will permanently remove it from the site and prevent
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:24
-msgid ""
-"Enter the following text confirm your decision:\n"
-"           {slug}"
+msgid "Enter the following text confirm your decision: {slug}"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:34
+#: src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:33
 msgid "Please tell us why you are deleting your theme:"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:36
+#: src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:35
 msgid "Please tell us why you are deleting your add-on:"
 msgstr ""
 
@@ -4799,8 +4729,8 @@ msgstr ""
 msgid "Daily statistics on downloads and users."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/addons/listing/item_actions.html:45 src/olympia/stats/templates/stats/stats.html:75 src/olympia/stats/templates/stats/stats.html:79
-#: src/olympia/stats/templates/stats/stats.html:81
+#: src/olympia/devhub/templates/devhub/addons/listing/item_actions.html:45 src/olympia/stats/templates/stats/stats.html:31 src/olympia/stats/templates/stats/stats.html:35
+#: src/olympia/stats/templates/stats/stats.html:37
 msgid "Statistics"
 msgstr ""
 
@@ -4919,10 +4849,7 @@ msgid "Your add-on has been submitted to the Full Review queue."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/submit/done.html:18
-msgid ""
-"You'll receive an email once it has been reviewed by an editor. In\n"
-"          the meantime, you and your friends can install it directly from its\n"
-"          details page:"
+msgid "You'll receive an email once it has been reviewed by an editor. In the meantime, you and your friends can install it directly from its details page:"
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/submit/done.html:27 src/olympia/devhub/templates/devhub/addons/submit/done.html:77 src/olympia/devhub/templates/devhub/personas/submit_done.html:16
@@ -5128,11 +5055,11 @@ msgstr ""
 msgid "Use the fields below to upload your add-on package and select any platform restrictions. After upload, a series of automated validation tests will be run on your file."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/addons/submit/upload.html:59 src/olympia/devhub/templates/devhub/versions/add_file_modal.html:39
+#: src/olympia/devhub/templates/devhub/addons/submit/upload.html:51 src/olympia/devhub/templates/devhub/versions/add_file_modal.html:28
 msgid "Which platforms is this file compatible with?"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/addons/submit/upload.html:67 src/olympia/devhub/templates/devhub/versions/add_file_modal.html:65
+#: src/olympia/devhub/templates/devhub/addons/submit/upload.html:59 src/olympia/devhub/templates/devhub/versions/add_file_modal.html:45
 msgid "Administrative overrides"
 msgstr ""
 
@@ -5242,8 +5169,8 @@ msgstr ""
 
 #: src/olympia/devhub/templates/devhub/docs/policies-contact.html:44
 msgid ""
-"If you've found a problem with the site, we'd love to fix it. Please <a href=\"https://github.com/mozilla/olympia/issues\">file a bug report</a> in GitHub, including the location of the problem and "
-"how you encountered it."
+"If you've found a problem with the site, we'd love to fix it. Please <a href=\"https://github.com/mozilla/addons/issues/new\">file a bug report</a> in GitHub, including the location of the problem "
+"and how you encountered it."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/docs/policies-maintenance.html:3 src/olympia/devhub/templates/devhub/docs/policies-maintenance.html:7
@@ -5810,7 +5737,7 @@ msgstr ""
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:282
 msgid ""
-"Add-ons that store or otherwise handle browsing data must support <a href=\"https://developer.mozilla.org/En/Supporting_private_browsing_mode\">Private Browsing Mode</a>.  During a Private Browsing "
+"Add-ons that store or otherwise handle browsing data must support <a href=\"https://developer.mozilla.org/En/Supporting_private_browsing_mode\">Private Browsing Mode</a>. During a Private Browsing "
 "session, no browsing data can be written to disk, and all of this data must be cleared when Firefox quits or the Private Browsing session ends."
 msgstr ""
 
@@ -5975,129 +5902,95 @@ msgstr ""
 msgid "How to get in touch with us regarding these policies or your add-on."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:6
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:10
 msgid "You have disabled this add-on"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:20
-msgid ""
-"Your add-on's listing is disabled and is not showing\n"
-"                             anywhere in our gallery or update service."
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:24
+msgid "Your add-on's listing is disabled and is not showing anywhere in our gallery or update service."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:25
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:27
 msgid "Please complete your add-on."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:29
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:30
 msgid "You will receive an email when the review is complete."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:34
-msgid ""
-"You will receive an email when the review is complete. Until\n"
-"                             then, your add-on is not listed in our gallery but can be\n"
-"                             accessed directly from its details page."
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:33
+msgid "You will receive an email when the review is complete. Until then, your add-on is not listed in our gallery but can be accessed directly from its details page."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:38 src/olympia/devhub/templates/devhub/includes/addon_details.html:48
-msgid ""
-"You will receive an email when the review is\n"
-"                             complete and your add-on is signed."
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:37 src/olympia/devhub/templates/devhub/includes/addon_details.html:45
+msgid "You will receive an email when the review is complete and your add-on is signed."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:44
-msgid ""
-"You will receive an email when the review is complete. Until\n"
-"                             then, your add-on is not listed in our gallery but can be\n"
-"                             accessed directly from its details page. "
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:41
+msgid "You will receive an email when the review is complete. Until then, your add-on is not listed in our gallery but can be accessed directly from its details page. "
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:54
-msgid ""
-"Your add-on is displayed in our gallery and users are\n"
-"                             receiving automatic updates."
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:49
+msgid "Your add-on is displayed in our gallery and users are receiving automatic updates."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:57
-msgid ""
-"Your add-on has been signed and can be bundled with an\n"
-"                             application installer."
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:52
+msgid "Your add-on has been signed and can be bundled with an application installer."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:63
-msgid ""
-"Your add-on was disabled by a site administrator and is no\n"
-"                             longer shown in our gallery. If you have any questions,\n"
-"                             please email amo-admins@mozilla.org."
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:56
+msgid "Your add-on was disabled by a site administrator and is no longer shown in our gallery. If you have any questions, please email amo-admins@mozilla.org."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:70
-msgid ""
-"Your add-on is displayed in our gallery as experimental\n"
-"                             and users are receiving automatic updates. Some features\n"
-"                             are unavailable to your add-on."
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:62
+msgid "Your add-on is displayed in our gallery as experimental and users are receiving automatic updates. Some features are unavailable to your add-on."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:74
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:66
 msgid "Your add-on has been signed."
 msgstr ""
 
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:69
+msgid ""
+"You will receive an email when the full review is complete. Until then, your add-on is displayed in our gallery as experimental and users are receiving automatic updates. Some features are "
+"unavailable to your add-on."
+msgstr ""
+
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:74
+msgid "You will receive an email when the full review is complete, making you able to bundle your add-on with an application installer."
+msgstr ""
+
 #: src/olympia/devhub/templates/devhub/includes/addon_details.html:79
-msgid ""
-"You will receive an email when the full review is complete.\n"
-"                             Until then, your add-on is displayed in our gallery as\n"
-"                             experimental and users are receiving automatic updates.\n"
-"                             Some features are unavailable to your add-on."
+msgid "All add-ons hosted in our gallery must now be reviewed by an editor. If you wish to continue hosting your add-on, please click to select a review process."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:84
-msgid ""
-"You will receive an email when the full review is\n"
-"                             complete, making you able to bundle your add-on with an\n"
-"                             application installer."
-msgstr ""
-
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:91
-msgid ""
-"All add-ons hosted in our gallery must now be reviewed by an\n"
-"                             editor. If you wish to continue hosting your add-on, please\n"
-"                             click to select a review process."
-msgstr ""
-
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:113
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:100
 msgid "Current Version:"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:115
-msgid ""
-"This is the version of your add-on that will\n"
-"                                           be installed if someone clicks the Install\n"
-"                                           button on addons.mozilla.org. It is only\n"
-"                                           relevant for listed add-ons."
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:102
+msgid "This is the version of your add-on that will be installed if someone clicks the Install button on addons.mozilla.org. It is only relevant for listed add-ons."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:123
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:110
 msgid "Created:"
 msgstr ""
 
 #. {0} is a date. dennis-ignore: E201
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:125 src/olympia/devhub/templates/devhub/includes/addon_details.html:131
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:112 src/olympia/devhub/templates/devhub/includes/addon_details.html:118
 #, python-format
 msgid "%%b %%e, %%Y"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:136
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:123
 msgid "Next Version:"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:138
-msgid ""
-"This is the newest uploaded version, however\n"
-"                                           it isn’t live on the site yet."
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:125
+msgid "This is the newest uploaded version, however it isn’t live on the site yet."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:144 src/olympia/devhub/templates/devhub/versions/list.html:30
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:130 src/olympia/devhub/templates/devhub/versions/list.html:30
 msgid "Queues are not reviewed strictly in order"
 msgstr ""
 
@@ -6165,9 +6058,7 @@ msgid "View the blog &#9658;"
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/includes/license_form.html:6
-msgid ""
-"Please choose a license appropriate for the rights you grant on your source code.\n"
-"                  It is only relevant for listed add-ons."
+msgid "Please choose a license appropriate for the rights you grant on your source code. It is only relevant for listed add-ons."
 msgstr ""
 
 #. {0} is a list of HTML tags.
@@ -6194,14 +6085,11 @@ msgstr[1] ""
 #: src/olympia/devhub/templates/devhub/includes/policy_form.html:4
 msgid ""
 "Users will be required to accept the following End-User License Agreement (EULA) prior to installing your add-on. The presence of a EULA significantly affects the number of downloads an add-on "
-"receives. Please note that a EULA is not the same as a code license, such as the GPL or MPL.\n"
-"                It is only relevant for listed add-ons."
+"receives. Please note that a EULA is not the same as a code license, such as the GPL or MPL.It is only relevant for listed add-ons."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/policy_form.html:21
-msgid ""
-"If your add-on transmits any data from the user's computer, a privacy policy is required that explains what data is sent and how it is used.\n"
-"                It is only relevant for listed add-ons."
+#: src/olympia/devhub/templates/devhub/includes/policy_form.html:24
+msgid "If your add-on transmits any data from the user's computer, a privacy policy is required that explains what data is sent and how it is used. It is only relevant for listed add-ons."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/includes/source_form_field.html:2
@@ -6369,12 +6257,8 @@ msgstr ""
 msgid "Add some tags to describe your Theme."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/personas/edit.html:106
-msgid ""
-"A short explanation of your theme's\n"
-"                                basic functionality that is displayed in\n"
-"                                search and browse listings, as well as at\n"
-"                                the top of your theme's details page."
+#: src/olympia/devhub/templates/devhub/personas/edit.html:106 src/olympia/devhub/templates/devhub/personas/submit.html:54
+msgid "A short explanation of your theme's basic functionality that is displayed in search and browse listings, as well as at the top of your theme's details page."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/personas/edit.html:122 src/olympia/devhub/templates/devhub/personas/submit.html:68
@@ -6444,7 +6328,7 @@ msgid "Upon upload and form submission, the AMO Team will review your updated de
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/personas/edit.html:241
-msgid "Your previously resubmitted design,  which is under pending review."
+msgid "Your previously resubmitted design, which is under pending review."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/personas/edit.html:245
@@ -6511,14 +6395,6 @@ msgstr ""
 
 #: src/olympia/devhub/templates/devhub/personas/submit.html:33
 msgid "Give your Theme a name."
-msgstr ""
-
-#: src/olympia/devhub/templates/devhub/personas/submit.html:54
-msgid ""
-"A short explanation of your theme's\n"
-"                                      basic functionality that is displayed in\n"
-"                                      search and browse listings, as well as at\n"
-"                                      the top of your theme's details page."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/personas/submit.html:198
@@ -6595,30 +6471,16 @@ msgstr ""
 msgid "Files added to reviewed versions must be reviewed before they will be available for download."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/add_file_modal.html:15
-#, python-format
-msgid ""
-"Submission of updates to unlisted add-ons for signing is currently in an open beta. Manual review may still be required for a large number of add-ons. Please <a href=\"%(url)s\" target=\"_blank"
-"\">report any bugs</a> that you encounter."
-msgstr ""
-
-#: src/olympia/devhub/templates/devhub/versions/add_file_modal.html:35
+#: src/olympia/devhub/templates/devhub/versions/add_file_modal.html:24
 msgid "Select the target platform for this file."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/add_file_modal.html:46
+#: src/olympia/devhub/templates/devhub/versions/add_file_modal.html:35
 msgid "Which review type would you like to nominate for?"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/add_file_modal.html:51
+#: src/olympia/devhub/templates/devhub/versions/add_file_modal.html:40
 msgid "Only publish this version to my beta channel."
-msgstr ""
-
-#: src/olympia/devhub/templates/devhub/versions/add_file_modal.html:54
-#, python-format
-msgid ""
-"The behavior of the beta channel has changed to accommodate <a href=\"%(addon_signing_url)s\" target=\"_blank\">mandatory add-on signing</a>. The new process is currently in an open beta, and may "
-"change significantly in the near future. Please <a href=\"%(issues_url)s\" target=\"_blank\">report any bugs</a> that you encounter."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/versions/edit.html:5
@@ -6642,19 +6504,10 @@ msgstr ""
 msgid "Upload Another File"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/edit.html:45
-msgid ""
-"Adjusting application information here will allow users to install your\n"
-"                          add-on even if the install manifest in the package indicates that the\n"
-"                          add-on is incompatible."
-msgstr ""
-
 #: src/olympia/devhub/templates/devhub/versions/edit.html:74
 msgid ""
-"Information about changes in this release, new features,\n"
-"                              known bugs, and other useful information specific to this\n"
-"                              release/version. This information is also shown in the\n"
-"                              Add-ons Manager when updating."
+"Information about changes in this release, new features, known bugs, and other useful information specific to this release/version. This information is also shown in the Add-ons Manager when "
+"updating."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/versions/edit.html:99
@@ -6666,10 +6519,7 @@ msgid "Notes for Reviewers"
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/versions/edit.html:114
-msgid ""
-"Optionally, enter any information that may be useful\n"
-"                              to the Editor reviewing this add-on, such as test\n"
-"                              account information."
+msgid "Optionally, enter any information that may be useful to the Editor reviewing this add-on, such as test account information."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/versions/edit.html:127
@@ -6747,7 +6597,7 @@ msgstr ""
 msgid "Request Preliminary Review"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:80 src/olympia/devhub/templates/devhub/versions/list.html:327 src/olympia/devhub/templates/devhub/versions/list.html:350
+#: src/olympia/devhub/templates/devhub/versions/list.html:80 src/olympia/devhub/templates/devhub/versions/list.html:325 src/olympia/devhub/templates/devhub/versions/list.html:348
 msgid "Cancel Review Request"
 msgstr ""
 
@@ -6776,7 +6626,7 @@ msgid "Unlisted:"
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/versions/list.html:114
-msgid "Not distributed on {0}. Developers will upload new versions for signing and distribute the add-ons on their own. (beta)"
+msgid "Not distributed on {0}. Developers will upload new versions for signing and distribute the add-ons on their own."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/versions/list.html:122
@@ -6839,81 +6689,73 @@ msgid "<strong>Important:</strong> Once a version has been deleted, you may not 
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/versions/list.html:230
-msgid ""
-"Deleting a version which has already been reviewed\n"
-"               may also cause a significant delay in the review of\n"
-"               your next update."
-msgstr ""
-
-#: src/olympia/devhub/templates/devhub/versions/list.html:233
 msgid "Are you sure you wish to delete this version?"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:238
+#: src/olympia/devhub/templates/devhub/versions/list.html:235
 msgid "Delete Version"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:240
+#: src/olympia/devhub/templates/devhub/versions/list.html:237
 msgid "Disable Version"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:247
+#: src/olympia/devhub/templates/devhub/versions/list.html:244
 msgid "Add a new Version"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:249
+#: src/olympia/devhub/templates/devhub/versions/list.html:246
 msgid "Add Version"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:256 src/olympia/devhub/templates/devhub/versions/list.html:274
+#: src/olympia/devhub/templates/devhub/versions/list.html:253 src/olympia/devhub/templates/devhub/versions/list.html:279
 msgid "Hide Add-on"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:259
+#: src/olympia/devhub/templates/devhub/versions/list.html:256
 msgid "Hiding your add-on will prevent it from appearing anywhere in our gallery and will stop users from receiving automatic updates."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:265
+#: src/olympia/devhub/templates/devhub/versions/list.html:263
+msgid "The files awaiting review will be disabled and you will need to upload new versions."
+msgstr ""
+
+#: src/olympia/devhub/templates/devhub/versions/list.html:270
 msgid "Are you sure you wish to hide your add-on?"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:286 src/olympia/devhub/templates/devhub/versions/list.html:315
+#: src/olympia/devhub/templates/devhub/versions/list.html:291 src/olympia/devhub/templates/devhub/versions/list.html:313
 msgid "Unlist Add-on"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:289
+#: src/olympia/devhub/templates/devhub/versions/list.html:294
 #, python-format
 msgid ""
 "Unlisting your add-on will make it (and each of its versions/files) invisible on this website. It won't show up in searches, won't have a public facing page, and won't be updated automatically for "
-"current users.  It is recommended for unlisted add-ons to provide a custom <a href=\"%(update_url)s\" target=\"_blank\">updateURL</a> in their manifest file for automatic updates."
+"current users. It is recommended for unlisted add-ons to provide a custom <a href=\"%(update_url)s\" target=\"_blank\">updateURL</a> in their manifest file for automatic updates."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:299
-#, python-format
-msgid "Switching add-ons to unlisted is currently in an open beta. Please <a href=\"%(url)s\" target=\"_blank\">report any bugs</a> that you encounter."
-msgstr ""
-
-#: src/olympia/devhub/templates/devhub/versions/list.html:305
+#: src/olympia/devhub/templates/devhub/versions/list.html:303
 msgid "Unlisting an add-on is irreversible!"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:305
+#: src/olympia/devhub/templates/devhub/versions/list.html:303
 msgid "An unlisted add-on cannot be switched to be listed."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:307
+#: src/olympia/devhub/templates/devhub/versions/list.html:305
 msgid "Are you sure you wish to unlist your add-on?"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:330
+#: src/olympia/devhub/templates/devhub/versions/list.html:328
 msgid "Canceling your review request will leave your add-on as preliminarily reviewed."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:335
+#: src/olympia/devhub/templates/devhub/versions/list.html:333
 msgid "Canceling your review request will mark your add-on incomplete. If you do not complete your add-on after several days by re-requesting review, it will be deleted."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:343
+#: src/olympia/devhub/templates/devhub/versions/list.html:341
 msgid "Are you sure you wish to cancel your review request?"
 msgstr ""
 
@@ -7252,19 +7094,19 @@ msgstr ""
 msgid "Search by add-on name / author email"
 msgstr ""
 
-#: src/olympia/editors/forms.py:103
+#: src/olympia/editors/forms.py:103 src/olympia/editors/forms.py:244 src/olympia/editors/forms.py:257
 msgid "yes"
 msgstr ""
 
-#: src/olympia/editors/forms.py:104
+#: src/olympia/editors/forms.py:104 src/olympia/editors/forms.py:244 src/olympia/editors/forms.py:257
 msgid "no"
 msgstr ""
 
-#: src/olympia/editors/forms.py:105
+#: src/olympia/editors/forms.py:105 src/olympia/editors/forms.py:245
 msgid "Admin Flag"
 msgstr ""
 
-#: src/olympia/editors/forms.py:113
+#: src/olympia/editors/forms.py:113 src/olympia/editors/forms.py:253
 msgid "Max. Version"
 msgstr ""
 
@@ -7276,55 +7118,59 @@ msgstr ""
 msgid "Add-on Types"
 msgstr ""
 
-#: src/olympia/editors/forms.py:126 src/olympia/editors/helpers.py:267
+#: src/olympia/editors/forms.py:126 src/olympia/editors/helpers.py:279
 msgid "Platforms"
 msgstr ""
 
+#: src/olympia/editors/forms.py:237
+msgid "Search by add-on name / author email / guid"
+msgstr ""
+
 #. L10n: 0 = platform, 1 = filename, 2 = status message
-#: src/olympia/editors/forms.py:238
+#: src/olympia/editors/forms.py:342
 #, python-format
 msgid "<strong>%s</strong> &middot; %s &middot; %s"
 msgstr ""
 
-#: src/olympia/editors/forms.py:252
+#: src/olympia/editors/forms.py:356
 msgid "Comments:"
 msgstr ""
 
-#: src/olympia/editors/forms.py:256
+#: src/olympia/editors/forms.py:360
 msgid "Operating systems:"
 msgstr ""
 
-#: src/olympia/editors/forms.py:258
+#: src/olympia/editors/forms.py:362
 msgid "Applications:"
 msgstr ""
 
-#: src/olympia/editors/forms.py:260
+#: src/olympia/editors/forms.py:364
 msgid "Notify me the next time this add-on is updated. (Subsequent updates will not generate an email)"
 msgstr ""
 
-#: src/olympia/editors/forms.py:265
+#: src/olympia/editors/forms.py:369
 msgid "Clear Admin Review Flag"
 msgstr ""
 
-#: src/olympia/editors/forms.py:267
+#: src/olympia/editors/forms.py:371
 msgid "Clear more info requested flag"
 msgstr ""
 
-#: src/olympia/editors/forms.py:281
+#: src/olympia/editors/forms.py:385
 msgid "Choose a canned response..."
 msgstr ""
 
 #. L10n: Description of what can be searched for.
-#: src/olympia/editors/forms.py:324
+#: src/olympia/editors/forms.py:423
 msgid "theme name"
 msgstr ""
 
-#: src/olympia/editors/forms.py:350
+#: src/olympia/editors/forms.py:449
 msgid "Someone else is reviewing this theme."
 msgstr ""
 
 #. L10n: Description of what can be searched for.
-#: src/olympia/editors/forms.py:447
+#: src/olympia/editors/forms.py:546
 msgid "app, reviewer, or comment"
 msgstr ""
 
@@ -7340,246 +7186,264 @@ msgstr ""
 msgid "Rejected or Unreviewed"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:123 src/olympia/editors/helpers.py:136
+#: src/olympia/editors/helpers.py:125 src/olympia/editors/helpers.py:138
 msgid "Queue"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:124 src/olympia/editors/templates/editors/base.html:50 src/olympia/editors/templates/editors/base.html:65
+#: src/olympia/editors/helpers.py:126 src/olympia/editors/templates/editors/base.html:50 src/olympia/editors/templates/editors/base.html:65
 msgid "Pending Updates"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:125 src/olympia/editors/templates/editors/base.html:48 src/olympia/editors/templates/editors/base.html:63
+#: src/olympia/editors/helpers.py:127 src/olympia/editors/templates/editors/base.html:48 src/olympia/editors/templates/editors/base.html:63
 msgid "Full Reviews"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:126 src/olympia/editors/templates/editors/base.html:52 src/olympia/editors/templates/editors/base.html:67
+#: src/olympia/editors/helpers.py:128 src/olympia/editors/templates/editors/base.html:52 src/olympia/editors/templates/editors/base.html:67
 msgid "Preliminary Reviews"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:127 src/olympia/editors/templates/editors/base.html:54
+#: src/olympia/editors/helpers.py:129 src/olympia/editors/templates/editors/base.html:54
 msgid "Moderated Reviews"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:128 src/olympia/editors/templates/editors/base.html:46
+#: src/olympia/editors/helpers.py:130 src/olympia/editors/templates/editors/base.html:46
 msgid "Fast Track"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:130
+#: src/olympia/editors/helpers.py:132
 msgid "Pending Themes"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:131 src/olympia/editors/templates/editors/themes/queue.html:4
+#: src/olympia/editors/helpers.py:133 src/olympia/editors/templates/editors/themes/queue.html:4
 msgid "Flagged Themes"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:132
+#: src/olympia/editors/helpers.py:134
 msgid "Update Themes"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:137
+#: src/olympia/editors/helpers.py:139
 msgid "Unlisted Pending Updates"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:138
+#: src/olympia/editors/helpers.py:140
 msgid "Unlisted Full Reviews"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:139
+#: src/olympia/editors/helpers.py:141
 msgid "Unlisted Preliminary Reviews"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:170
+#: src/olympia/editors/helpers.py:142
+msgid "Unlisted All Add-ons"
+msgstr ""
+
+#: src/olympia/editors/helpers.py:173
 msgid "Fast Track ({0})"
 msgid_plural "Fast Track ({0})"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/olympia/editors/helpers.py:175
+#: src/olympia/editors/helpers.py:178
 msgid "Full Review ({0})"
 msgid_plural "Full Reviews ({0})"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/olympia/editors/helpers.py:180
+#: src/olympia/editors/helpers.py:183
 msgid "Pending Update ({0})"
 msgid_plural "Pending Updates ({0})"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/olympia/editors/helpers.py:185
+#: src/olympia/editors/helpers.py:188
 msgid "Preliminary Review ({0})"
 msgid_plural "Preliminary Reviews ({0})"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/olympia/editors/helpers.py:190
+#: src/olympia/editors/helpers.py:193
 msgid "Moderated Review ({0})"
 msgid_plural "Moderated Reviews ({0})"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/olympia/editors/helpers.py:196
+#: src/olympia/editors/helpers.py:199
 msgid "Unlisted Full Review ({0})"
 msgid_plural "Unlisted Full Reviews ({0})"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/olympia/editors/helpers.py:201
+#: src/olympia/editors/helpers.py:204
 msgid "Unlisted Pending Update ({0})"
 msgid_plural "Unlisted Pending Updates ({0})"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/olympia/editors/helpers.py:206
+#: src/olympia/editors/helpers.py:209
 msgid "Unlisted Preliminary Review ({0})"
 msgid_plural "Unlisted Preliminary Reviews ({0})"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/olympia/editors/helpers.py:261
-msgid "Addon"
-msgstr ""
+#: src/olympia/editors/helpers.py:214
+msgid "Unlisted All Add-ons ({0})"
+msgid_plural "Unlisted All Add-ons ({0})"
+msgstr[0] ""
+msgstr[1] ""
 
-#: src/olympia/editors/helpers.py:262
+#: src/olympia/editors/helpers.py:274
 msgid "Type"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:263
+#: src/olympia/editors/helpers.py:275
 msgid "Waiting Time"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:264 src/olympia/editors/templates/editors/review.html:285
+#: src/olympia/editors/helpers.py:276 src/olympia/editors/templates/editors/review.html:285
 msgid "Flags"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:265
+#: src/olympia/editors/helpers.py:277
 msgid "Applications"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:270
+#: src/olympia/editors/helpers.py:282
 msgid "Additional"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:285
+#: src/olympia/editors/helpers.py:302
 msgid "Site Specific"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:287
+#: src/olympia/editors/helpers.py:304
 msgid "Requires External Software"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:289
+#: src/olympia/editors/helpers.py:306
 msgid "Binary Components"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:313
+#: src/olympia/editors/helpers.py:339
 msgid "moments ago"
 msgstr ""
 
 #. L10n: first argument is number of minutes
-#: src/olympia/editors/helpers.py:316
+#: src/olympia/editors/helpers.py:342
 msgid "{0} minute"
 msgid_plural "{0} minutes"
 msgstr[0] ""
 msgstr[1] ""
 
 #. L10n: first argument is number of hours
-#: src/olympia/editors/helpers.py:320
+#: src/olympia/editors/helpers.py:346
 msgid "{0} hour"
 msgid_plural "{0} hours"
 msgstr[0] ""
 msgstr[1] ""
 
 #. L10n: first argument is number of days
-#: src/olympia/editors/helpers.py:324
+#: src/olympia/editors/helpers.py:350
 msgid "{0} day"
 msgid_plural "{0} days"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/olympia/editors/helpers.py:488
+#: src/olympia/editors/helpers.py:364
+msgid "Last Review"
+msgstr ""
+
+#: src/olympia/editors/helpers.py:366
+msgid "Last Update"
+msgstr ""
+
+#: src/olympia/editors/helpers.py:387
+msgid "No Reviews"
+msgstr ""
+
+#: src/olympia/editors/helpers.py:561
 msgid "Push to public"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:490
+#: src/olympia/editors/helpers.py:563
 msgid "Grant full review"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:505
+#: src/olympia/editors/helpers.py:578
 msgid "Request more information"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:508
+#: src/olympia/editors/helpers.py:581
 msgid "Request super-review"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:519
+#: src/olympia/editors/helpers.py:592
 msgid "Grant preliminary review"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:520
+#: src/olympia/editors/helpers.py:593
 msgid "This will mark the files as preliminarily reviewed."
 msgstr ""
 
-#: src/olympia/editors/helpers.py:522
+#: src/olympia/editors/helpers.py:595
 msgid "Use this form to request more information from the author. They will receive an email and be able to answer here. You will be notified by email when they reply."
 msgstr ""
 
-#: src/olympia/editors/helpers.py:526
+#: src/olympia/editors/helpers.py:599
 msgid ""
 "If you have concerns about this add-on's security, copyright issues, or other concerns that an administrator should look into, enter your comments in the area below. They will be sent to "
 "administrators, not the author."
 msgstr ""
 
-#: src/olympia/editors/helpers.py:532
+#: src/olympia/editors/helpers.py:605
 msgid "This will reject the add-on and remove it from the review queue."
 msgstr ""
 
-#: src/olympia/editors/helpers.py:534
-msgid "Make a comment on this version.  The author won't be able to see this."
+#: src/olympia/editors/helpers.py:607
+msgid "Make a comment on this version. The author won't be able to see this."
 msgstr ""
 
-#: src/olympia/editors/helpers.py:538
+#: src/olympia/editors/helpers.py:611
 msgid "This will reject the files and remove them from the review queue."
 msgstr ""
 
-#: src/olympia/editors/helpers.py:542
+#: src/olympia/editors/helpers.py:615
 msgid "This will mark the add-on as preliminarily reviewed. Future versions will undergo preliminary review."
 msgstr ""
 
-#: src/olympia/editors/helpers.py:547
+#: src/olympia/editors/helpers.py:620
 msgid "This will mark the files as preliminarily reviewed. Future versions will undergo preliminary review."
 msgstr ""
 
-#: src/olympia/editors/helpers.py:552
+#: src/olympia/editors/helpers.py:625
 msgid "Retain preliminary review"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:553
+#: src/olympia/editors/helpers.py:626
 msgid "This will retain the add-on as preliminarily reviewed. Future versions will undergo preliminary review."
 msgstr ""
 
-#: src/olympia/editors/helpers.py:558
+#: src/olympia/editors/helpers.py:631
 msgid "This will approve a sandboxed version of a public add-on to appear on the public side."
 msgstr ""
 
-#: src/olympia/editors/helpers.py:561
+#: src/olympia/editors/helpers.py:634
 msgid "This will reject a version of a public add-on and remove it from the queue."
 msgstr ""
 
-#: src/olympia/editors/helpers.py:564
+#: src/olympia/editors/helpers.py:637
 msgid "This will mark the add-on and its most recent version and files as public. Future versions will go into the sandbox until they are reviewed by an editor."
 msgstr ""
 
-#: src/olympia/editors/helpers.py:637
+#: src/olympia/editors/helpers.py:714
 msgid "add-on"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:940 src/olympia/editors/helpers.py:960
+#: src/olympia/editors/helpers.py:1020 src/olympia/editors/helpers.py:1040
 msgid "Flagged"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:944 src/olympia/editors/helpers.py:963
+#: src/olympia/editors/helpers.py:1024 src/olympia/editors/helpers.py:1043
 msgid "Updates"
 msgstr ""
 
@@ -7631,56 +7495,56 @@ msgstr ""
 msgid "A question about your Theme submission"
 msgstr ""
 
-#: src/olympia/editors/views.py:144
+#: src/olympia/editors/views.py:146
 msgid "New Add-ons (Under 5 days)"
 msgstr ""
 
-#: src/olympia/editors/views.py:145
+#: src/olympia/editors/views.py:147
 msgid "Passable (5 to 10 days)"
 msgstr ""
 
-#: src/olympia/editors/views.py:146
+#: src/olympia/editors/views.py:148
 msgid "Overdue (Over 10 days)"
 msgstr ""
 
-#: src/olympia/editors/views.py:532
+#: src/olympia/editors/views.py:539
 msgid "An unknown error occurred"
 msgstr ""
 
-#: src/olympia/editors/views.py:587
+#: src/olympia/editors/views.py:592
 msgid "Self-reviews are not allowed."
 msgstr ""
 
-#: src/olympia/editors/views.py:609
+#: src/olympia/editors/views.py:613
 msgid "Review successfully processed."
 msgstr ""
 
-#: src/olympia/editors/views.py:807
+#: src/olympia/editors/views.py:812
 msgid "was approved"
 msgstr ""
 
-#: src/olympia/editors/views.py:808
+#: src/olympia/editors/views.py:813
 msgid "given preliminary review"
 msgstr ""
 
-#: src/olympia/editors/views.py:809
+#: src/olympia/editors/views.py:814
 msgid "rejected"
 msgstr ""
 
-#: src/olympia/editors/views.py:810
+#: src/olympia/editors/views.py:815
 msgctxt "editors_review_history_nominated_adminreview"
 msgid "escalated"
 msgstr ""
 
-#: src/olympia/editors/views.py:812
+#: src/olympia/editors/views.py:817
 msgid "needs more information"
 msgstr ""
 
-#: src/olympia/editors/views.py:813
+#: src/olympia/editors/views.py:818
 msgid "needs super review"
 msgstr ""
 
-#: src/olympia/editors/views.py:814
+#: src/olympia/editors/views.py:819
 msgid "commented"
 msgstr ""
 
@@ -7725,28 +7589,28 @@ msgstr ""
 msgid "Unlisted Queues"
 msgstr ""
 
-#: src/olympia/editors/templates/editors/base.html:72 src/olympia/editors/templates/editors/performance.html:6
+#: src/olympia/editors/templates/editors/base.html:74 src/olympia/editors/templates/editors/performance.html:6
 msgid "Performance"
 msgstr ""
 
-#: src/olympia/editors/templates/editors/base.html:75 src/olympia/editors/templates/editors/themes/base.html:19 src/olympia/editors/templates/editors/themes/base.html:38
+#: src/olympia/editors/templates/editors/base.html:77 src/olympia/editors/templates/editors/themes/base.html:19 src/olympia/editors/templates/editors/themes/base.html:38
 msgid "Logs"
 msgstr ""
 
-#: src/olympia/editors/templates/editors/base.html:78 src/olympia/editors/templates/editors/reviewlog.html:4 src/olympia/editors/templates/editors/reviewlog.html:27
+#: src/olympia/editors/templates/editors/base.html:80 src/olympia/editors/templates/editors/reviewlog.html:4 src/olympia/editors/templates/editors/reviewlog.html:27
 msgid "Add-on Review Log"
 msgstr ""
 
-#: src/olympia/editors/templates/editors/base.html:80 src/olympia/editors/templates/editors/eventlog.html:4 src/olympia/editors/templates/editors/eventlog.html:8
+#: src/olympia/editors/templates/editors/base.html:82 src/olympia/editors/templates/editors/eventlog.html:4 src/olympia/editors/templates/editors/eventlog.html:8
 #: src/olympia/editors/templates/editors/eventlog_detail.html:4
 msgid "Moderated Review Log"
 msgstr ""
 
-#: src/olympia/editors/templates/editors/base.html:82 src/olympia/editors/templates/editors/beta_signed_log.html:4 src/olympia/editors/templates/editors/beta_signed_log.html:8
+#: src/olympia/editors/templates/editors/base.html:84 src/olympia/editors/templates/editors/beta_signed_log.html:4 src/olympia/editors/templates/editors/beta_signed_log.html:8
 msgid "Signed Beta Files Log"
 msgstr ""
 
-#: src/olympia/editors/templates/editors/base.html:87 src/olympia/editors/templates/editors/includes/daily-message.html:4
+#: src/olympia/editors/templates/editors/base.html:89 src/olympia/editors/templates/editors/includes/daily-message.html:4
 msgid "Announcement"
 msgstr ""
 
@@ -7967,45 +7831,45 @@ msgstr ""
 msgid "clear search"
 msgstr ""
 
-#: src/olympia/editors/templates/editors/queue.html:72 src/olympia/editors/templates/editors/queue.html:122
+#: src/olympia/editors/templates/editors/queue.html:78 src/olympia/editors/templates/editors/queue.html:128
 msgid "Process Reviews"
 msgstr ""
 
-#: src/olympia/editors/templates/editors/queue.html:80
+#: src/olympia/editors/templates/editors/queue.html:86
 msgid "Moderation actions:"
 msgstr ""
 
-#: src/olympia/editors/templates/editors/queue.html:90
+#: src/olympia/editors/templates/editors/queue.html:96
 #, python-format
 msgid "by %(user)s on %(date)s %(stars)s (%(locale)s)"
 msgstr ""
 
-#: src/olympia/editors/templates/editors/queue.html:106
+#: src/olympia/editors/templates/editors/queue.html:112
 #, python-format
 msgid "<strong>%(reason)s</strong> <span class=\"light\">Flagged by %(user)s on %(date)s</span>"
 msgstr ""
 
-#: src/olympia/editors/templates/editors/queue.html:119
-msgid "All reviews have been moderated.  Good work!"
+#: src/olympia/editors/templates/editors/queue.html:125
+msgid "All reviews have been moderated. Good work!"
 msgstr ""
 
-#: src/olympia/editors/templates/editors/queue.html:161
+#: src/olympia/editors/templates/editors/queue.html:167
 msgid "Version Notes / Notes for Reviewer"
 msgstr ""
 
-#: src/olympia/editors/templates/editors/queue.html:169
+#: src/olympia/editors/templates/editors/queue.html:175
 msgid "There are currently no add-ons of this type to review."
 msgstr ""
 
-#: src/olympia/editors/templates/editors/queue.html:181 src/olympia/editors/templates/editors/themes/queue_list.html:85
+#: src/olympia/editors/templates/editors/queue.html:187 src/olympia/editors/templates/editors/themes/queue_list.html:85
 msgid "Helpful Links:"
 msgstr ""
 
-#: src/olympia/editors/templates/editors/queue.html:182
+#: src/olympia/editors/templates/editors/queue.html:188
 msgid "Add-on Policy"
 msgstr ""
 
-#: src/olympia/editors/templates/editors/queue.html:184
+#: src/olympia/editors/templates/editors/queue.html:190
 msgid "Editors' Guide"
 msgstr ""
 
@@ -8068,10 +7932,7 @@ msgid "<strong>Warning!</strong> Another user was viewing this page before you."
 msgstr ""
 
 #: src/olympia/editors/templates/editors/review.html:237
-msgid ""
-"The whiteboard is the place to exchange information relevant to\n"
-"               this addon (whatever the version), between the developer and the\n"
-"               editor. This is visible and editable by both."
+msgid "The whiteboard is the place to exchange information relevant to this addon (whatever the version), between the developer and the editor. This is visible and editable by both."
 msgstr ""
 
 #: src/olympia/editors/templates/editors/review.html:241
@@ -8345,7 +8206,7 @@ msgstr ""
 msgid "Describe your reason for flagging"
 msgstr ""
 
-#: src/olympia/files/forms.py:88
+#: src/olympia/files/forms.py:90
 msgid "Cannot diff a version against itself"
 msgstr ""
 
@@ -8380,51 +8241,51 @@ msgstr ""
 msgid "There was an error accessing file %s."
 msgstr ""
 
-#: src/olympia/files/utils.py:343
+#: src/olympia/files/utils.py:340
 msgid "Could not parse uploaded file."
 msgstr ""
 
-#: src/olympia/files/utils.py:380
+#: src/olympia/files/utils.py:377
 msgid "Invalid file name in archive: {0}"
 msgstr ""
 
-#: src/olympia/files/utils.py:388
+#: src/olympia/files/utils.py:385
 msgid "File exceeding size limit in archive: {0}"
 msgstr ""
 
-#: src/olympia/files/utils.py:439
+#: src/olympia/files/utils.py:436
 msgid "Invalid archive."
 msgstr ""
 
-#: src/olympia/files/utils.py:529 src/olympia/files/utils.py:532
+#: src/olympia/files/utils.py:526 src/olympia/files/utils.py:529
 msgid "Could not parse the manifest file."
 msgstr ""
 
-#: src/olympia/files/utils.py:551
+#: src/olympia/files/utils.py:548
 msgid "Could not find an add-on ID."
 msgstr ""
 
-#: src/olympia/files/utils.py:554
+#: src/olympia/files/utils.py:551
 msgid "Add-on ID must be 64 characters or less."
 msgstr ""
 
-#: src/olympia/files/utils.py:556
+#: src/olympia/files/utils.py:553
 msgid "Add-on ID doesn't match add-on."
 msgstr ""
 
-#: src/olympia/files/utils.py:564
+#: src/olympia/files/utils.py:561
 msgid "Duplicate add-on ID found."
 msgstr ""
 
-#: src/olympia/files/utils.py:567
+#: src/olympia/files/utils.py:564
 msgid "Version numbers should have fewer than 32 characters."
 msgstr ""
 
-#: src/olympia/files/utils.py:570
+#: src/olympia/files/utils.py:567
 msgid "Version numbers should only contain letters, numbers, and these punctuation characters: +*.-_."
 msgstr ""
 
-#: src/olympia/files/utils.py:587
+#: src/olympia/files/utils.py:584
 msgid "<em:type> doesn't match add-on"
 msgstr ""
 
@@ -8523,6 +8384,10 @@ msgstr ""
 
 #: src/olympia/files/templates/files/viewer.html:134
 msgid "Fetching file."
+msgstr ""
+
+#: src/olympia/legacy_api/views.py:255
+msgid "Not implemented yet."
 msgstr ""
 
 #: src/olympia/lib/constants.py:6
@@ -9181,10 +9046,6 @@ msgstr ""
 msgid "Zimbabwe Dollar"
 msgstr ""
 
-#: src/olympia/lib/video/ffmpeg.py:112 src/olympia/lib/video/totem.py:81
-msgid "Videos must be in WebM."
-msgstr ""
-
 #: src/olympia/pages/templates/pages/about.lhtml:3 src/olympia/pages/templates/pages/about.lhtml:10
 msgid "About Mozilla Add-ons"
 msgstr ""
@@ -9196,7 +9057,7 @@ msgstr ""
 #: src/olympia/pages/templates/pages/about.lhtml:13
 msgid ""
 "addons.mozilla.org, commonly known as \"AMO\", is Mozilla's official site for add-ons to Mozilla software, such as Firefox, Thunderbird, and SeaMonkey. Add-ons let you add new features and change "
-"the way your browser or application works.  Take a look around and explore the thousands of ways to customize the way you do things online."
+"the way your browser or application works. Take a look around and explore the thousands of ways to customize the way you do things online."
 msgstr ""
 
 #: src/olympia/pages/templates/pages/about.lhtml:19
@@ -9541,7 +9402,7 @@ msgstr ""
 msgid ""
 "Yes. It's possible, but some of the functionality provided by these libraries are available through XPCOM, XUL, and JavaScript. In addition, authors should take care if libraries modify primitive "
 "object prototypes (String.prototype, Date.prototype, etc.) and/or define global functions (eg. the $ function). These are prone to cause conflict with other add-ons, in particular if different add-"
-"ons use different versions of libraries and so on. Developers need to be very, very careful with using them.  Mozilla does not offer documentation on using them to build add-ons."
+"ons use different versions of libraries and so on. Developers need to be very, very careful with using them. Mozilla does not offer documentation on using them to build add-ons."
 msgstr ""
 
 #: src/olympia/pages/templates/pages/dev_faq.html:165
@@ -9655,8 +9516,8 @@ msgstr ""
 #, python-format
 msgid ""
 "Yes. Many developers choose to host their own add-ons. Choosing to host your add-on on <a href=\"%(amo_url)s\">Mozilla's add-on site</a>, though, allows for much greater exposure to your add-on due "
-"to the large volume of visitors to the site.  <a href=\"%(md_url)s\">mozdev.org</a> offers free project hosting for Mozilla applications and extensions providing developers with tools to help "
-"manage source code, version control, bug tracking and documentation."
+"to the large volume of visitors to the site. <a href=\"%(md_url)s\">mozdev.org</a> offers free project hosting for Mozilla applications and extensions providing developers with tools to help manage "
+"source code, version control, bug tracking and documentation."
 msgstr ""
 
 #: src/olympia/pages/templates/pages/dev_faq.html:277
@@ -9704,7 +9565,7 @@ msgstr ""
 #: src/olympia/pages/templates/pages/dev_faq.html:314
 #, python-format
 msgid ""
-"Yes. Mozilla's <a href=\"%(p_url)s\">Add-on Policy</a> describes what is an acceptable submission. This policy is subject to change without notice.  In addition, the AMO editorial team uses the <a "
+"Yes. Mozilla's <a href=\"%(p_url)s\">Add-on Policy</a> describes what is an acceptable submission. This policy is subject to change without notice. In addition, the AMO editorial team uses the <a "
 "href=\"%(g_url)s\">Editors Reviewing Guide</a> to ensure that your add-on meets specific guidelines for functionality and security."
 msgstr ""
 
@@ -9821,7 +9682,7 @@ msgstr ""
 #: src/olympia/pages/templates/pages/dev_faq.html:434
 #, python-format
 msgid ""
-"This is why it's very important to read the <a href=\"%(g_url)s\">Editors Reviewing Guide</a> to ensure that your add-on is setup as expected.  It's also a good idea to read the blog post, <a href="
+"This is why it's very important to read the <a href=\"%(g_url)s\">Editors Reviewing Guide</a> to ensure that your add-on is setup as expected. It's also a good idea to read the blog post, <a href="
 "\"%(blog_url)s\">Successfully Getting your Add-on Reviewed</a> which provides excellent insight into ensuring a smooth review of your add-on."
 msgstr ""
 
@@ -9928,7 +9789,7 @@ msgstr ""
 
 #: src/olympia/pages/templates/pages/dev_faq.html:572
 msgid ""
-"Free Software Foundation provides short summaries of the key open source licenses, including whether the license qualifies as a free software license or a copyleft license.  Also includes a "
+"Free Software Foundation provides short summaries of the key open source licenses, including whether the license qualifies as a free software license or a copyleft license. Also includes a "
 "discussion of what constitutes a free software license or a copyleft license (e.g., a Copyleft license is a general method for making a program or other work free, and requiring all modified and "
 "extended versions of the program to be free as well.)"
 msgstr ""
@@ -10106,19 +9967,13 @@ msgid "Add-on Gallery"
 msgstr ""
 
 #: src/olympia/pages/templates/pages/faq.html:171
-msgid ""
-"How do I choose between add-ons that seem to do the same\n"
-"    thing?"
+msgid "How do I choose between add-ons that seem to do the same thing?"
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:173
+#: src/olympia/pages/templates/pages/faq.html:172
 msgid ""
-"There are often several add-ons that have similar features. To\n"
-"    figure out which is right for you, read the entire description of the\n"
-"    add-on and view its screenshots. If there are still several in the running,\n"
-"    read through the add-on's ratings, user reviews, and statistics to see\n"
-"    which is most liked by other users. Remember that you can also just try\n"
-"    out both and see which you like better."
+"There are often several add-ons that have similar features. To figure out which is right for you, read the entire description of the add-on and view its screenshots. If there are still several in "
+"the running, read through the add-on's ratings, user reviews, and statistics to see which is most liked by other users. Remember that you can also just try out both and see which you like better."
 msgstr ""
 
 #: src/olympia/pages/templates/pages/faq.html:180
@@ -10159,80 +10014,67 @@ msgid "How much do add-ons cost to purchase?"
 msgstr ""
 
 #: src/olympia/pages/templates/pages/faq.html:207
-msgid ""
-"Add-ons hosted in our gallery are free unless clearly marked\n"
-"    otherwise."
+msgid "Add-ons hosted in our gallery are free unless clearly marked otherwise."
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:210
+#: src/olympia/pages/templates/pages/faq.html:209
 msgid "What does it mean when an add-on asks for contributions?"
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:211
+#: src/olympia/pages/templates/pages/faq.html:210
 msgid ""
-"Some add-on authors request users who enjoy an add-on to\n"
-"        contribute to its development by making a monetary contribution. These\n"
-"        contributions go directly to the developer unless a third party is\n"
-"        indicated, such as the non-profit Mozilla Foundation."
+"Some add-on authors request users who enjoy an add-on to contribute to its development by making a monetary contribution. These contributions go directly to the developer unless a third party is "
+"indicated, such as the non-profit Mozilla Foundation."
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:216
+#: src/olympia/pages/templates/pages/faq.html:215
 msgid "What are beta add-ons?"
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:218
+#: src/olympia/pages/templates/pages/faq.html:217
 msgid ""
-"Beta add-ons are unreviewed versions which represent the\n"
-"        latest work of an add-on author. While different authors have different\n"
-"        standards for beta code quality, you should assume that these add-ons\n"
-"        are less stable than the general add-on releases."
+"Beta add-ons are unreviewed versions which represent the latest work of an add-on author. While different authors have different standards for beta code quality, you should assume that these add-"
+"ons are less stable than the general add-on releases."
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:222
+#: src/olympia/pages/templates/pages/faq.html:221
 msgid ""
 "Please note that when you install an add-on from the \"Beta Version\" section of an add-on's listing, you will continue to receive updates for that add-on as they become available. Like the initial "
 "version you installed, all beta releases are unreviewed by Mozilla and may harm your computer."
 msgstr ""
 
+#: src/olympia/pages/templates/pages/faq.html:228
+msgid "What does it mean when an add-on is flagged as slow?"
+msgstr ""
+
 #: src/olympia/pages/templates/pages/faq.html:229
-msgid ""
-"What does it mean when an add-on is flagged as\n"
-"    slow?"
+msgid "Most add-ons load code and resources at the same time Firefox is starting up. In most cases the impact in start-up time is minimal, but some add-ons can cause a noticeable slowdown."
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:231
-msgid ""
-"Most add-ons load code and resources at the same time Firefox\n"
-"        is starting up. In most cases the impact in start-up time is minimal,\n"
-"        but some add-ons can cause a noticeable slowdown."
-msgstr ""
-
-#: src/olympia/pages/templates/pages/faq.html:236
+#: src/olympia/pages/templates/pages/faq.html:234
 msgid "How do I report an inappropriate or spam user review?"
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:237
+#: src/olympia/pages/templates/pages/faq.html:235
 msgid ""
-"To report a user review of an add-on, log in with your account\n"
-"    and visit the add-on's reviews page. Find the review you wish to report,\n"
-"    click \"Report this review\" and select a reason. Our editorial team will\n"
-"    investigate the review and take appropriate action."
+"To report a user review of an add-on, log in with your account and visit the add-on's reviews page. Find the review you wish to report, click \"Report this review\" and select a reason. Our "
+"editorial team will investigate the review and take appropriate action."
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:242
+#: src/olympia/pages/templates/pages/faq.html:240
 msgid "How do I report a bug or contact the Mozilla Add-ons team?"
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:243
+#: src/olympia/pages/templates/pages/faq.html:241
 #, python-format
 msgid "Please visit our <a href=\"%(contact_url)s\">Contact page</a>."
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:246
+#: src/olympia/pages/templates/pages/faq.html:244
 msgid "What is a Source Code License?"
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:247
+#: src/olympia/pages/templates/pages/faq.html:245
 #, python-format
 msgid ""
 "The source code used to create an add-on is an exclusive copyright of the add-on author, unless otherwise declared in a source code license. Many add-ons on this site have <a href=\"%(url)s\" lang="
@@ -10240,60 +10082,60 @@ msgid ""
 "the GPL or BSD licenses instead of making up their own."
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:256
+#: src/olympia/pages/templates/pages/faq.html:254
 #, python-format
 msgid "Firefox and other Mozilla software are <a href=\"%(url)s\">open source</a>."
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:264
+#: src/olympia/pages/templates/pages/faq.html:262
 msgid "Collections and Favorites"
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:267
+#: src/olympia/pages/templates/pages/faq.html:265
 msgid "What is a collection?"
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:268
+#: src/olympia/pages/templates/pages/faq.html:266
 msgid "Collections are groups of related add-ons created by users to share."
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:270
+#: src/olympia/pages/templates/pages/faq.html:268
 msgid "What is the My Favorites collection?"
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:271
+#: src/olympia/pages/templates/pages/faq.html:269
 msgid "Favorite add-ons are add-ons that you have bookmarked to easily get back to later. You can add an add-on to your favorites collection by clicking \"Add to favorites\" on its details page."
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:275 src/olympia/templates/menu_links.html:13 src/olympia/templates/impala/header_title.html:17
+#: src/olympia/pages/templates/pages/faq.html:273 src/olympia/templates/menu_links.html:13 src/olympia/templates/impala/header_title.html:17
 msgid "Mobile Add-ons"
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:278
+#: src/olympia/pages/templates/pages/faq.html:276
 msgid "What are mobile add-ons?"
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:279
+#: src/olympia/pages/templates/pages/faq.html:277
 #, python-format
 msgid ""
 "Mobile add-ons work with <a href=\"%(mobile_url)s\">Firefox for Mobile</a> and add or modify functionality just like desktop add-ons. You can find add-ons that work with Firefox for Mobile in our "
 "<a href=\"%(gallery_url)s\">gallery</a>."
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:288
+#: src/olympia/pages/templates/pages/faq.html:286
 msgid "Developer Topics"
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:289
+#: src/olympia/pages/templates/pages/faq.html:287
 #, python-format
 msgid "Please see our <a href=\"%(faq_url)s\">Developer FAQ</a> and <a href=\"%(hub_url)s\">Developer Hub</a> for answers to add-on developer-related questions."
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:294
+#: src/olympia/pages/templates/pages/faq.html:292
 msgid "Still have questions?"
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:295
+#: src/olympia/pages/templates/pages/faq.html:293
 #, python-format
 msgid "For general Firefox support, visit our <a href=\"%(sumo_url)s\">support website</a>. For general add-on and website questions, visit our <a href=\"%(forum_url)s\">forum</a>."
 msgstr ""
@@ -10431,7 +10273,7 @@ msgstr ""
 
 #: src/olympia/pages/templates/pages/sunbird.html:29
 msgid ""
-"Development on the Sunbird project has halted and its final release was on March 30, 2010.  We've been proud to host Sunbird add-ons on this site but as the project is no longer maintained we have "
+"Development on the Sunbird project has halted and its final release was on March 30, 2010. We've been proud to host Sunbird add-ons on this site but as the project is no longer maintained we have "
 "disabled our support for the add-ons."
 msgstr ""
 
@@ -10509,7 +10351,7 @@ msgstr ""
 #, python-format
 msgid ""
 "<h2>Keep these tips in mind:</h2> <ul> <li> Write like you're telling a friend about your experience with the add-on. Give specifics and helpful details, such as what features you liked and/or "
-"disliked, how easy to use it is, and any disadvantages it has.  Avoid generic language such as calling it \"Great\" or \"Bad\" unless you can give reasons why you believe this is so. </li> <li> "
+"disliked, how easy to use it is, and any disadvantages it has. Avoid generic language such as calling it \"Great\" or \"Bad\" unless you can give reasons why you believe this is so. </li> <li> "
 "Please do not post bug reports in reviews. We do not make your email address available to add-on developers and they may need to contact you to help resolve your issue. See the <a href=\"%(support)s"
 "\">support section</a> to find out where to get assistance for this add-on. </li> <li>Please keep reviews clean, avoid the use of improper language and do not post any personal information. </li> </"
 "ul> <p>Please read the <a href=\"%(guide)s\" target=\"_blank\">Review Guidelines</a> for more detail about user add-on reviews.</p>"
@@ -10745,16 +10587,16 @@ msgstr ""
 
 #. L10n: {0} is an application, such as Firefox. This means "any version of
 #. Firefox."
-#: src/olympia/search/views.py:554
+#: src/olympia/search/views.py:547
 msgid "Any {0}"
 msgstr ""
 
 #. L10n: "All Systems" means show everything regardless of platform.
-#: src/olympia/search/views.py:589
+#: src/olympia/search/views.py:582
 msgid "All Systems"
 msgstr ""
 
-#: src/olympia/search/views.py:600
+#: src/olympia/search/views.py:593
 msgid "All Tags"
 msgstr ""
 
@@ -10928,31 +10770,31 @@ msgstr ""
 msgid "Share this Collection"
 msgstr ""
 
-#: src/olympia/signing/views.py:30 src/olympia/templates/base.html:75 src/olympia/templates/impala/base.html:115
+#: src/olympia/signing/views.py:33 src/olympia/templates/base.html:71 src/olympia/templates/impala/base.html:112
 msgid "Some features are temporarily disabled while we perform website maintenance. We'll be back to full capacity shortly."
 msgstr ""
 
-#: src/olympia/signing/views.py:53
+#: src/olympia/signing/views.py:56
 msgid "Could not find add-on with id \"{}\"."
 msgstr ""
 
-#: src/olympia/signing/views.py:67
+#: src/olympia/signing/views.py:70
 msgid "You do not own this addon."
 msgstr ""
 
-#: src/olympia/signing/views.py:82
+#: src/olympia/signing/views.py:87
 msgid "Missing \"upload\" key in multipart file data."
 msgstr ""
 
-#: src/olympia/signing/views.py:96
+#: src/olympia/signing/views.py:101
 msgid "Version does not match the manifest file."
 msgstr ""
 
-#: src/olympia/signing/views.py:100
+#: src/olympia/signing/views.py:105
 msgid "Version already exists."
 msgstr ""
 
-#: src/olympia/signing/views.py:136
+#: src/olympia/signing/views.py:141
 msgid "No uploaded file for that addon and version."
 msgstr ""
 
@@ -11065,89 +10907,89 @@ msgstr ""
 msgid "Statistics Dashboard :: Add-ons for {0}"
 msgstr ""
 
-#: src/olympia/stats/templates/stats/stats.html:30
-msgid "Controls:"
-msgstr ""
-
-#: src/olympia/stats/templates/stats/stats.html:33
-msgid "reset zoom"
-msgstr ""
-
-#: src/olympia/stats/templates/stats/stats.html:40
-msgid "Group by:"
-msgstr ""
-
-#: src/olympia/stats/templates/stats/stats.html:42
-msgid "day"
-msgstr ""
-
-#: src/olympia/stats/templates/stats/stats.html:45
-msgid "week"
-msgstr ""
-
-#: src/olympia/stats/templates/stats/stats.html:48
-msgid "month"
-msgstr ""
-
-#: src/olympia/stats/templates/stats/stats.html:54
-msgid "For last:"
-msgstr ""
-
-#: src/olympia/stats/templates/stats/stats.html:57
-msgid "7 days"
-msgstr ""
-
-#: src/olympia/stats/templates/stats/stats.html:60
-msgid "30 days"
-msgstr ""
-
-#: src/olympia/stats/templates/stats/stats.html:63
-msgid "90 days"
-msgstr ""
-
-#: src/olympia/stats/templates/stats/stats.html:66
-msgid "365 days"
-msgstr ""
-
-#: src/olympia/stats/templates/stats/stats.html:69
-msgid "Custom..."
-msgstr ""
-
 #. {0} is an add-on name
-#: src/olympia/stats/templates/stats/stats.html:88 src/olympia/stats/templates/stats/stats.html:91
+#: src/olympia/stats/templates/stats/stats.html:44 src/olympia/stats/templates/stats/stats.html:47
 msgid "Statistics for {0}"
 msgstr ""
 
-#: src/olympia/stats/templates/stats/stats.html:94
+#: src/olympia/stats/templates/stats/stats.html:50
 msgid "Statistics Dashboard"
 msgstr ""
 
-#: src/olympia/stats/templates/stats/stats.html:104
+#: src/olympia/stats/templates/stats/stats.html:57
+msgid "Controls:"
+msgstr ""
+
+#: src/olympia/stats/templates/stats/stats.html:60
+msgid "reset zoom"
+msgstr ""
+
+#: src/olympia/stats/templates/stats/stats.html:67
+msgid "Group by:"
+msgstr ""
+
+#: src/olympia/stats/templates/stats/stats.html:69
+msgid "day"
+msgstr ""
+
+#: src/olympia/stats/templates/stats/stats.html:72
+msgid "week"
+msgstr ""
+
+#: src/olympia/stats/templates/stats/stats.html:75
+msgid "month"
+msgstr ""
+
+#: src/olympia/stats/templates/stats/stats.html:81
+msgid "For last:"
+msgstr ""
+
+#: src/olympia/stats/templates/stats/stats.html:84
+msgid "7 days"
+msgstr ""
+
+#: src/olympia/stats/templates/stats/stats.html:87
+msgid "30 days"
+msgstr ""
+
+#: src/olympia/stats/templates/stats/stats.html:90
+msgid "90 days"
+msgstr ""
+
+#: src/olympia/stats/templates/stats/stats.html:93
+msgid "365 days"
+msgstr ""
+
+#: src/olympia/stats/templates/stats/stats.html:96
+msgid "Custom..."
+msgstr ""
+
+#: src/olympia/stats/templates/stats/stats.html:106
 msgid "Statistics processing is currently disabled, so recent data is unavailable. The statistics are still being collected and this page will be updated soon with the missing data."
 msgstr ""
 
-#: src/olympia/stats/templates/stats/stats.html:110
+#: src/olympia/stats/templates/stats/stats.html:112
 msgid "Loading the latest data&hellip;"
 msgstr ""
 
-#: src/olympia/stats/templates/stats/stats.html:142 src/olympia/stats/templates/stats/reports/overview.html:25 src/olympia/stats/templates/stats/reports/overview.html:37
+#: src/olympia/stats/templates/stats/stats.html:144 src/olympia/stats/templates/stats/reports/overview.html:25 src/olympia/stats/templates/stats/reports/overview.html:37
 #: src/olympia/stats/templates/stats/reports/overview.html:49
 msgid "No data available."
 msgstr ""
 
-#: src/olympia/stats/templates/stats/stats.html:177
+#: src/olympia/stats/templates/stats/stats.html:179
 msgid "This dashboard is currently <b>public</b>."
 msgstr ""
 
-#: src/olympia/stats/templates/stats/stats.html:179
+#: src/olympia/stats/templates/stats/stats.html:181
 msgid "Contribution stats are currently <b>private</b>."
 msgstr ""
 
-#: src/olympia/stats/templates/stats/stats.html:182
+#: src/olympia/stats/templates/stats/stats.html:184
 msgid "This dashboard is currently <b>private</b>."
 msgstr ""
 
-#: src/olympia/stats/templates/stats/stats.html:185
+#: src/olympia/stats/templates/stats/stats.html:187
 msgid "Change settings."
 msgstr ""
 
@@ -11299,15 +11141,6 @@ msgstr ""
 msgid "Application versions by Date"
 msgstr ""
 
-#: src/olympia/tags/templates/tags/top_cloud.html:4
-msgid "Top {0} Tags"
-msgstr ""
-
-#. {0} is the current application name
-#: src/olympia/tags/templates/tags/top_cloud.html:14
-msgid "{0} Top Tags"
-msgstr ""
-
 #: src/olympia/templates/amo_footer.html:6 src/olympia/templates/includes/lang_switcher.html:2
 msgid "Other languages"
 msgstr ""
@@ -11316,11 +11149,11 @@ msgstr ""
 msgid "Mozilla Add-ons"
 msgstr ""
 
-#: src/olympia/templates/base.html:91 src/olympia/templates/impala/base.html:81
+#: src/olympia/templates/base.html:89 src/olympia/templates/impala/base.html:78
 msgid "Find add-ons for other applications"
 msgstr ""
 
-#: src/olympia/templates/base.html:92 src/olympia/templates/impala/base.html:81
+#: src/olympia/templates/base.html:90 src/olympia/templates/impala/base.html:78
 msgid "Other Applications"
 msgstr ""
 
@@ -11345,7 +11178,7 @@ msgid "View Mobile Site"
 msgstr ""
 
 #: src/olympia/templates/copyright.html:7
-msgid "Site Status "
+msgid "Site Status"
 msgstr ""
 
 #: src/olympia/templates/footer.html:3
@@ -11445,35 +11278,35 @@ msgstr ""
 msgid "<a href=\"%(reg)s\">Register</a> or <a href=\"%(login)s\">Log in</a>"
 msgstr ""
 
-#: src/olympia/templates/impala/base.html:126
+#: src/olympia/templates/impala/base.html:123
 #, python-format
 msgid "To try the thousands of add-ons available here, download <a href=\"%(url)s\">Mozilla Firefox</a>, a fast, free way to surf the Web!"
 msgstr ""
 
-#: src/olympia/templates/impala/base.html:138
+#: src/olympia/templates/impala/base.html:135
 #, python-format
 msgid "Add-ons is switching to Firefox Accounts for login. <a href=\"%(url)s\" class=\"fxa-login\">Sign in now to transfer your account.</a>"
 msgstr ""
 
 #. {0} is an application, such as Firefox.
-#: src/olympia/templates/impala/base.html:148
+#: src/olympia/templates/impala/base.html:145
 msgid "Welcome to {0} Add-ons."
 msgstr ""
 
-#: src/olympia/templates/impala/base.html:151
+#: src/olympia/templates/impala/base.html:148
 msgid "Choose from thousands of extra features and styles to make Firefox your own."
 msgstr ""
 
-#: src/olympia/templates/impala/base.html:156
+#: src/olympia/templates/impala/base.html:153
 #, python-format
 msgid "Add extra features and styles to make %(app)s your own."
 msgstr ""
 
-#: src/olympia/templates/impala/base.html:164
+#: src/olympia/templates/impala/base.html:161
 msgid "On the go?"
 msgstr ""
 
-#: src/olympia/templates/impala/base.html:166
+#: src/olympia/templates/impala/base.html:163
 msgid "Check out our <a class=\"mobile-link\" href=\"#\">Mobile Add-ons site</a>."
 msgstr ""
 
@@ -11697,19 +11530,19 @@ msgstr ""
 
 #. L10n: {id} will be something like "13ad6a", just a random number
 #. to differentiate this user from other anonymous users.
-#: src/olympia/users/models.py:353
+#: src/olympia/users/models.py:362
 msgid "Anonymous user {id}"
 msgstr ""
 
-#: src/olympia/users/models.py:410
+#: src/olympia/users/models.py:419
 msgid "Your account has been restricted"
 msgstr ""
 
-#: src/olympia/users/models.py:480
+#: src/olympia/users/models.py:489
 msgid "Please confirm your email address"
 msgstr ""
 
-#: src/olympia/users/models.py:506
+#: src/olympia/users/models.py:515
 msgid "My Mobile Add-ons"
 msgstr ""
 
@@ -11986,7 +11819,7 @@ msgstr ""
 
 #: src/olympia/users/templates/users/edit.html:70
 #, python-format
-msgid "Change your password.  If you forgot your password, you can <a href=\"%(reset_url)s\">use the reset form</a>."
+msgid "Change your password. If you forgot your password, you can <a href=\"%(reset_url)s\">use the reset form</a>."
 msgstr ""
 
 #: src/olympia/users/templates/users/edit.html:76
@@ -12006,7 +11839,7 @@ msgid "Profile"
 msgstr ""
 
 #: src/olympia/users/templates/users/edit.html:100
-msgid "Give us a bit more information about yourself.  All these fields are optional, but they'll help other users get to know you better."
+msgid "Give us a bit more information about yourself. All these fields are optional, but they'll help other users get to know you better."
 msgstr ""
 
 #: src/olympia/users/templates/users/edit.html:124
@@ -12222,7 +12055,7 @@ msgid "Confirm password"
 msgstr ""
 
 #: src/olympia/users/templates/users/pwreset_confirm.html:47
-msgid "The password reset link was invalid, possibly because it has already been used.  Please request a new password reset."
+msgid "The password reset link was invalid, possibly because it has already been used. Please request a new password reset."
 msgstr ""
 
 #: src/olympia/users/templates/users/pwreset_request.html:15
@@ -12408,7 +12241,7 @@ msgstr ""
 
 #: src/olympia/users/templates/users/unsubscribe.html:30
 #, python-format
-msgid "Unfortunately, we weren't able to unsubscribe you.  The link you clicked is invalid. However, you can unsubscribe still unsubscribe on your <a href=\"%(edit_url)s\">edit profile page</a>."
+msgid "Unfortunately, we weren't able to unsubscribe you. The link you clicked is invalid. However, you can unsubscribe still unsubscribe on your <a href=\"%(edit_url)s\">edit profile page</a>."
 msgstr ""
 
 #: src/olympia/users/templates/users/vcard.html:2
@@ -12462,15 +12295,15 @@ msgstr ""
 msgid "Version History with Changelogs"
 msgstr ""
 
-#: src/olympia/versions/models.py:314
+#: src/olympia/versions/models.py:313
 msgid "Add-on uses binary components."
 msgstr ""
 
-#: src/olympia/versions/models.py:317
+#: src/olympia/versions/models.py:316
 msgid "Add-on has opted into strict compatibility checking."
 msgstr ""
 
-#: src/olympia/versions/models.py:715
+#: src/olympia/versions/models.py:711
 msgid "{app} {min} and later"
 msgstr ""
 
@@ -12545,4 +12378,8 @@ msgstr ""
 
 #: src/olympia/zadmin/forms.py:105
 msgid "Log emails instead of sending"
+msgstr ""
+
+#: src/olympia/zadmin/forms.py:215
+msgid "Deleted versions can`t be changed."
 msgstr ""

--- a/locale/ne_NP/LC_MESSAGES/djangojs.po
+++ b/locale/ne_NP/LC_MESSAGES/djangojs.po
@@ -1,1216 +1,1236 @@
-
 #, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2016-02-24 21:23+0000\n"
+"POT-Creation-Date: 2016-04-18 15:47+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
+"Language: \n"
 "MIME-Version: 1.0\n"
-"Content-Type: text/plain; charset=utf-8\n"
+"Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Generated-By: Babel 2.2.0\n"
 
-#: static/js/common/ratingwidget.js:31
+#: static/js/common-all.js:1426 static/js/impala-all.js:1511 static/js/zamboni/discovery-all.js:12598 static/js/zamboni/init.js:28 static/js/zamboni/mobile-all.js:14945
+msgid "This feature is temporarily disabled while we perform website maintenance. Please check back a little later."
+msgstr ""
+
+#. L10n: {0} is an app name like Firefox.
+#: static/js/common-all.js:1837 static/js/impala-all.js:1922 static/js/zamboni/buttons.js:73 static/js/zamboni/discovery-all.js:13108
+msgid "Accept and Install"
+msgstr ""
+
+#: static/js/common-all.js:1837 static/js/impala-all.js:1922 static/js/zamboni/buttons.js:73 static/js/zamboni/discovery-all.js:13108
+msgid "Add to {0}"
+msgstr ""
+
+#: static/js/common-all.js:1842 static/js/impala-all.js:1927 static/js/zamboni/buttons.js:78 static/js/zamboni/discovery-all.js:13113
+msgid "Download Now"
+msgstr ""
+
+#: static/js/common-all.js:1883 static/js/impala-all.js:1968 static/js/zamboni/buttons.js:119 static/js/zamboni/discovery-all.js:13154
+msgid "Add-on has not been updated to support default-to-compatible."
+msgstr ""
+
+#: static/js/common-all.js:1888 static/js/impala-all.js:1973 static/js/zamboni/buttons.js:124 static/js/zamboni/discovery-all.js:13159
+msgid "You need to be using Firefox 10.0 or higher."
+msgstr ""
+
+#: static/js/common-all.js:1900 static/js/impala-all.js:1985 static/js/zamboni/buttons.js:136 static/js/zamboni/discovery-all.js:13171
+msgid "Mozilla has marked this version as incompatible with your Firefox version."
+msgstr ""
+
+#. L10n: {0} is an platform like Windows or Linux.
+#: static/js/common-all.js:1981 static/js/impala-all.js:2066 static/js/zamboni/buttons.js:217 static/js/zamboni/discovery-all.js:13252
+msgid "Install for {0} anyway"
+msgstr ""
+
+#: static/js/common-all.js:1981 static/js/impala-all.js:2066 static/js/zamboni/buttons.js:217 static/js/zamboni/discovery-all.js:13252
+msgid "Download for {0} anyway"
+msgstr ""
+
+#: static/js/common-all.js:2038 static/js/impala-all.js:2123 static/js/zamboni/buttons.js:274 static/js/zamboni/discovery-all.js:13309
+msgid "Not available for your platform"
+msgstr ""
+
+#. L10n: {0} is an app name, {1} is the app version.
+#: static/js/common-all.js:2049 static/js/common-all.js:2086 static/js/impala-all.js:2134 static/js/impala-all.js:2171 static/js/zamboni/buttons.js:286 static/js/zamboni/buttons.js:324
+#: static/js/zamboni/discovery-all.js:13320 static/js/zamboni/discovery-all.js:13357
+msgid "Not available for {0} {1}"
+msgstr ""
+
+#: static/js/common-all.js:2112 static/js/impala-all.js:2197 static/js/zamboni/buttons.js:351 static/js/zamboni/discovery-all.js:13383
+msgid "Works with {app} {min} - {max}"
+msgstr ""
+
+#: static/js/common-all.js:2114 static/js/impala-all.js:2199 static/js/zamboni/buttons.js:353 static/js/zamboni/discovery-all.js:13385
+msgid "View other versions"
+msgstr ""
+
+#: static/js/common-all.js:2162 static/js/impala-all.js:2247 static/js/zamboni/buttons.js:401 static/js/zamboni/discovery-all.js:13433
+msgid "Only with Firefox — Get Firefox Now!"
+msgstr ""
+
+#: static/js/common-all.js:2278 static/js/impala-all.js:2363 static/js/zamboni/buttons.js:517 static/js/zamboni/discovery-all.js:13549 static/js/zamboni/mobile-all.js:15177
+#: static/js/zamboni/mobile/buttons.js:43
+msgid "Sorry, you need a Mozilla-based browser (such as Firefox) to install a search plugin."
+msgstr ""
+
+#: static/js/common-all.js:9088 static/js/impala-all.js:9649 static/js/zamboni/global.js:410
+msgid "Loading..."
+msgstr ""
+
+#. L10n: {0} is the number of characters left.
+#: static/js/common-all.js:9152 static/js/impala-all.js:9713 static/js/zamboni/global.js:474
+msgid "<b>{0}</b> character left."
+msgid_plural "<b>{0}</b> characters left."
+msgstr[0] ""
+msgstr[1] ""
+
+#: static/js/common-all.js:9589 static/js/common-min.js:6 static/js/impala-all.js:10052 static/js/impala-min.js:6 static/js/common/ratingwidget.js:31 static/js/zamboni/mobile-all.js:16123
+#: static/js/zamboni/mobile-min.js:6
 msgid "{0} star"
 msgid_plural "{0} stars"
 msgstr[0] ""
 msgstr[1] ""
 
-#: static/js/common/upload-addon.js:41 static/js/common/upload-image.js:128
+#: static/js/common-all.js:9676 static/js/common-min.js:6 static/js/impala-all.js:10139 static/js/impala-min.js:6 static/js/zamboni/l10n.js:45
+msgid "Remove this localization"
+msgstr ""
+
+#: static/js/common-all.js:10193 static/js/common-min.js:6 static/js/impala-all.js:10674 static/js/impala-min.js:6 static/js/zamboni/discovery-all.js:13678
+msgid "close"
+msgstr ""
+
+#: static/js/common-all.js:10860 static/js/common-min.js:6 static/js/impala-all.js:11481 static/js/impala-min.js:6 static/js/impala/reviews.js:23 static/js/zamboni/reviews.js:18
+msgid "Flagged for review"
+msgstr ""
+
+#: static/js/common-all.js:10876 static/js/common-min.js:6 static/js/impala-all.js:11498 static/js/impala-min.js:6 static/js/impala/reviews.js:40 static/js/zamboni/reviews.js:34
+msgid "Your input is required"
+msgstr ""
+
+#: static/js/common-all.js:10945 static/js/common-min.js:6 static/js/impala-all.js:11610 static/js/impala-min.js:7 static/js/impala/reviews.js:152 static/js/zamboni/reviews.js:103
+msgid "Marked for deletion"
+msgstr ""
+
+#: static/js/common-all.js:11573 static/js/common-min.js:7 static/js/impala-all.js:13809 static/js/impala-min.js:8 static/js/zamboni/collections.js:229
+msgid "Adding to Favorites&hellip;"
+msgstr ""
+
+#: static/js/common-all.js:11576 static/js/common-min.js:7 static/js/impala-all.js:13812 static/js/impala-min.js:8 static/js/zamboni/collections.js:232
+msgid "Removing Favorite&hellip;"
+msgstr ""
+
+#: static/js/common-all.js:11579 static/js/common-min.js:7 static/js/impala-all.js:13815 static/js/impala-min.js:8 static/js/zamboni/collections.js:235
+msgid "Add to Favorites"
+msgstr ""
+
+#: static/js/common-all.js:11582 static/js/common-min.js:7 static/js/impala-all.js:13818 static/js/impala-min.js:8 static/js/zamboni/collections.js:238
+msgid "Remove from Favorites"
+msgstr ""
+
+#: static/js/common-all.js:11647 static/js/common-min.js:7 static/js/impala-all.js:13883 static/js/impala-min.js:8 static/js/zamboni/collections.js:303
+msgid "Pending"
+msgstr ""
+
+#: static/js/common-all.js:11648 static/js/common-min.js:7 static/js/impala-all.js:13884 static/js/impala-min.js:8 static/js/zamboni/collections.js:304
+msgid "Add a comment"
+msgstr ""
+
+#: static/js/common-all.js:11648 static/js/common-min.js:7 static/js/impala-all.js:13884 static/js/impala-min.js:8 static/js/zamboni/collections.js:304
+msgid "Comment"
+msgstr ""
+
+#: static/js/common-all.js:11649 static/js/common-min.js:7 static/js/impala-all.js:13885 static/js/impala-min.js:8 static/js/zamboni/collections.js:305
+msgid "Remove this add-on from the collection"
+msgstr ""
+
+#: static/js/common-all.js:11649 static/js/common-all.js:11678 static/js/common-min.js:7 static/js/impala-all.js:13885 static/js/impala-all.js:13914 static/js/impala-min.js:8
+#: static/js/zamboni/collections.js:305 static/js/zamboni/collections.js:334
+msgid "Remove"
+msgstr ""
+
+#: static/js/common-all.js:11678 static/js/common-min.js:7 static/js/impala-all.js:13914 static/js/impala-min.js:8 static/js/zamboni/collections.js:334
+msgid "Remove this user as a contributor"
+msgstr ""
+
+#: static/js/common-all.js:11690 static/js/common-min.js:7 static/js/impala-all.js:13926 static/js/impala-min.js:8 static/js/zamboni/collections.js:346
+msgid "An email address is required."
+msgstr ""
+
+#: static/js/common-all.js:11708 static/js/common-min.js:7 static/js/impala-all.js:13944 static/js/impala-min.js:8 static/js/zamboni/collections.js:364
+msgid "You cannot add yourself as a contributor."
+msgstr ""
+
+#: static/js/common-all.js:11710 static/js/common-min.js:7 static/js/impala-all.js:13946 static/js/impala-min.js:8 static/js/zamboni/collections.js:366
+msgid "You have already added that user."
+msgstr ""
+
+#: static/js/common-all.js:11917 static/js/common-min.js:7 static/js/impala-all.js:14153 static/js/impala-min.js:8 static/js/zamboni/collections.js:573
+msgid "Add to favorites"
+msgstr ""
+
+#: static/js/common-all.js:11921 static/js/common-min.js:7 static/js/impala-all.js:14157 static/js/impala-min.js:8 static/js/zamboni/collections.js:577
+msgid "Remove from favorites"
+msgstr ""
+
+#: static/js/common-all.js:11939 static/js/common-min.js:7 static/js/impala-all.js:14175 static/js/impala-all.js:14233 static/js/impala-min.js:8 static/js/impala/collections.js:10
+#: static/js/zamboni/collections.js:595
+msgid "Follow this Collection"
+msgstr ""
+
+#: static/js/common-all.js:11948 static/js/common-min.js:7 static/js/impala-all.js:14184 static/js/impala-min.js:8 static/js/zamboni/collections.js:604
+msgid "Stop following"
+msgstr ""
+
+#: static/js/common-all.js:12096 static/js/common-min.js:7 static/js/zamboni/password-strength.js:20
+msgid "Password strength:"
+msgstr ""
+
+#: static/js/common-all.js:12102 static/js/common-min.js:7 static/js/zamboni/password-strength.js:26
+msgid "At least {0} character left."
+msgid_plural "At least {0} characters left."
+msgstr[0] ""
+msgstr[1] ""
+
+#: static/js/common-all.js:12286 static/js/common-min.js:7 static/js/impala-all.js:14632 static/js/impala-min.js:8 static/js/impala/suggestions.js:39
+msgid "Search themes for <b>{0}</b>"
+msgstr ""
+
+#: static/js/common-all.js:12288 static/js/common-min.js:7 static/js/impala-all.js:14634 static/js/impala-min.js:8 static/js/impala/suggestions.js:41
+msgid "Search apps for <b>{0}</b>"
+msgstr ""
+
+#: static/js/common-all.js:12290 static/js/common-min.js:7 static/js/impala-all.js:14636 static/js/impala-min.js:8 static/js/impala/suggestions.js:43
+msgid "Search add-ons for <b>{0}</b>"
+msgstr ""
+
+#: static/js/common-all.js:12521 static/js/common-min.js:7 static/js/impala-all.js:14867 static/js/impala-min.js:8 static/js/impala/site_suggestions.js:46
+msgid "Category"
+msgstr ""
+
+#. L10n: {0} is an app name.
+#: static/js/impala-all.js:11632 static/js/impala-min.js:7 static/js/impala/listing.js:11 static/js/zamboni/themes.js:13
+msgid "This theme is incompatible with your version of {0}"
+msgstr ""
+
+#: static/js/impala-all.js:12146 static/js/impala-all.js:14331 static/js/impala-min.js:7 static/js/impala-min.js:8 static/js/common/upload-image.js:97 static/js/impala/users.js:51
+#: static/js/zamboni/devhub-all.js:894 static/js/zamboni/devhub-min.js:1
+msgid "Images must be either PNG or JPG."
+msgstr ""
+
+#: static/js/impala-all.js:12150 static/js/impala-min.js:7 static/js/common/upload-image.js:101 static/js/zamboni/devhub-all.js:898 static/js/zamboni/devhub-min.js:1
+msgid "Videos must be in WebM."
+msgstr ""
+
+#: static/js/impala-all.js:12177 static/js/impala-min.js:7 static/js/common/upload-addon.js:41 static/js/common/upload-image.js:128 static/js/zamboni/devhub-all.js:272
+#: static/js/zamboni/devhub-all.js:925 static/js/zamboni/devhub-min.js:1
 msgid "There was a problem contacting the server."
 msgstr ""
 
-#: static/js/common/upload-addon.js:69
+#: static/js/impala-all.js:13298 static/js/impala-min.js:7 static/js/impala/persona_creation.js:60
+msgid "All Rights Reserved"
+msgstr ""
+
+#: static/js/impala-all.js:13302 static/js/impala-min.js:7 static/js/impala/persona_creation.js:64
+msgid "Creative Commons Attribution 3.0"
+msgstr ""
+
+#: static/js/impala-all.js:13307 static/js/impala-min.js:7 static/js/impala/persona_creation.js:69
+msgid "Creative Commons Attribution-NonCommercial 3.0"
+msgstr ""
+
+#: static/js/impala-all.js:13312 static/js/impala-min.js:7 static/js/impala/persona_creation.js:74
+msgid "Creative Commons Attribution-NonCommercial-NoDerivs 3.0"
+msgstr ""
+
+#: static/js/impala-all.js:13317 static/js/impala-min.js:7 static/js/impala/persona_creation.js:79
+msgid "Creative Commons Attribution-NonCommercial-Share Alike 3.0"
+msgstr ""
+
+#: static/js/impala-all.js:13322 static/js/impala-min.js:7 static/js/impala/persona_creation.js:84
+msgid "Creative Commons Attribution-NoDerivs 3.0"
+msgstr ""
+
+#: static/js/impala-all.js:13327 static/js/impala-min.js:7 static/js/impala/persona_creation.js:89
+msgid "Creative Commons Attribution-ShareAlike 3.0"
+msgstr ""
+
+#: static/js/impala-all.js:13530 static/js/impala-min.js:7 static/js/impala/persona_creation.js:292
+msgid "Your Theme's Name"
+msgstr ""
+
+#: static/js/impala-all.js:14242 static/js/impala-min.js:8 static/js/impala/collections.js:19
+msgid "Stop Following"
+msgstr ""
+
+#: static/js/impala-all.js:14243 static/js/impala-min.js:8 static/js/impala/collections.js:20
+msgid "Following"
+msgstr ""
+
+#: static/js/impala-all.js:14313 static/js/impala-min.js:8 static/js/impala/users.js:33
+msgid "use original"
+msgstr ""
+
+#: static/js/impala-all.js:14523 static/js/impala-min.js:8 static/js/impala/search.js:114
+msgid "Updating results&hellip;"
+msgstr ""
+
+#: static/js/common/upload-addon.js:69 static/js/zamboni/devhub-all.js:300 static/js/zamboni/devhub-min.js:1
 msgid "Select a file..."
 msgstr ""
 
-#: static/js/common/upload-addon.js:70
+#: static/js/common/upload-addon.js:70 static/js/zamboni/devhub-all.js:301 static/js/zamboni/devhub-min.js:1
 msgid "Your add-on should end with .xpi, .jar or .xml"
 msgstr ""
 
 #. L10n: {0} is the percent of the file that has been uploaded.
-#: static/js/common/upload-addon.js:104
+#: static/js/common/upload-addon.js:104 static/js/zamboni/devhub-all.js:335 static/js/zamboni/devhub-min.js:1
 #, python-format
 msgid "{0}% complete"
 msgstr ""
 
 #. L10n: "{bytes uploaded} of {total filesize}".
-#: static/js/common/upload-addon.js:107
+#: static/js/common/upload-addon.js:107 static/js/zamboni/devhub-all.js:338 static/js/zamboni/devhub-min.js:1
 msgid "{0} of {1}"
 msgstr ""
 
-#: static/js/common/upload-addon.js:140
+#: static/js/common/upload-addon.js:140 static/js/zamboni/devhub-all.js:371 static/js/zamboni/devhub-min.js:1
 msgid "Cancel"
 msgstr ""
 
-#: static/js/common/upload-addon.js:162
+#: static/js/common/upload-addon.js:162 static/js/zamboni/devhub-all.js:393 static/js/zamboni/devhub-min.js:1
 msgid "Uploading {0}"
 msgstr ""
 
-#: static/js/common/upload-addon.js:189
+#: static/js/common/upload-addon.js:189 static/js/zamboni/devhub-all.js:420 static/js/zamboni/devhub-min.js:1
 msgid "Error with {0}"
 msgstr ""
 
-#: static/js/common/upload-addon.js:194
+#: static/js/common/upload-addon.js:194 static/js/zamboni/devhub-all.js:425 static/js/zamboni/devhub-min.js:1
 msgid "Your add-on failed validation with {0} error."
 msgid_plural "Your add-on failed validation with {0} errors."
 msgstr[0] ""
 msgstr[1] ""
 
-#: static/js/common/upload-addon.js:208
+#: static/js/common/upload-addon.js:208 static/js/zamboni/devhub-all.js:439 static/js/zamboni/devhub-min.js:1
 msgid "&hellip;and {0} more"
 msgid_plural "&hellip;and {0} more"
 msgstr[0] ""
 msgstr[1] ""
 
-#: static/js/common/upload-addon.js:222 static/js/common/upload-addon.js:512
+#: static/js/common/upload-addon.js:222 static/js/common/upload-addon.js:497 static/js/zamboni/devhub-all.js:453 static/js/zamboni/devhub-all.js:743 static/js/zamboni/devhub-min.js:1
 msgid "See full validation report"
 msgstr ""
 
-#: static/js/common/upload-addon.js:234
+#: static/js/common/upload-addon.js:234 static/js/zamboni/devhub-all.js:465 static/js/zamboni/devhub-min.js:1
 msgid "Validating {0}"
 msgstr ""
 
 #. L10n: first argument is an HTTP status code
-#: static/js/common/upload-addon.js:273
+#: static/js/common/upload-addon.js:273 static/js/zamboni/devhub-all.js:504 static/js/zamboni/devhub-min.js:1
 msgid "Received an empty response from the server; status: {0}"
 msgstr ""
 
-#: static/js/common/upload-addon.js:373
+#: static/js/common/upload-addon.js:370 static/js/zamboni/devhub-all.js:604 static/js/zamboni/devhub-min.js:1
 msgid "Unexpected server error while validating."
 msgstr ""
 
-#: static/js/common/upload-addon.js:412
+#: static/js/common/upload-addon.js:409 static/js/zamboni/devhub-all.js:643 static/js/zamboni/devhub-min.js:1
 msgid "Finished validating {0}"
 msgstr ""
 
-#: static/js/common/upload-addon.js:418
+#: static/js/common/upload-addon.js:415 static/js/zamboni/devhub-all.js:649 static/js/zamboni/devhub-min.js:1
 msgid "Your add-on validation timed out, it will be manually reviewed."
 msgstr ""
 
-#: static/js/common/upload-addon.js:421
+#: static/js/common/upload-addon.js:418 static/js/zamboni/devhub-all.js:652 static/js/zamboni/devhub-min.js:1
 msgid "Your add-on was validated with no errors and {0} warning."
 msgid_plural "Your add-on was validated with no errors and {0} warnings."
 msgstr[0] ""
 msgstr[1] ""
 
-#: static/js/common/upload-addon.js:426
+#: static/js/common/upload-addon.js:423 static/js/zamboni/devhub-all.js:657 static/js/zamboni/devhub-min.js:1
 msgid "Your add-on was validated with no errors and {0} message."
 msgid_plural "Your add-on was validated with no errors and {0} messages."
 msgstr[0] ""
 msgstr[1] ""
 
-#: static/js/common/upload-addon.js:431
+#: static/js/common/upload-addon.js:428 static/js/zamboni/devhub-all.js:662 static/js/zamboni/devhub-min.js:1
 msgid "Your add-on was validated with no errors or warnings."
 msgstr ""
 
-#: static/js/common/upload-addon.js:446
+#: static/js/common/upload-addon.js:443 static/js/zamboni/devhub-all.js:677 static/js/zamboni/devhub-min.js:1
 msgid "Your submission will be automatically signed."
 msgstr ""
 
-#: static/js/common/upload-addon.js:465
+#: static/js/common/upload-addon.js:450 static/js/zamboni/devhub-all.js:696 static/js/zamboni/devhub-min.js:1
 msgid "Include detailed version notes (this can be done in the next step)."
 msgstr ""
 
-#: static/js/common/upload-addon.js:466
+#: static/js/common/upload-addon.js:451 static/js/zamboni/devhub-all.js:697 static/js/zamboni/devhub-min.js:1
 msgid "If your add-on requires an account to a website in order to be fully tested, include a test username and password in the Notes to Reviewer (this can be done in the next step)."
 msgstr ""
 
-#: static/js/common/upload-addon.js:467
+#: static/js/common/upload-addon.js:452 static/js/zamboni/devhub-all.js:698 static/js/zamboni/devhub-min.js:1
 msgid "If your add-on is intended for a limited audience you should choose Preliminary Review instead of Full Review."
 msgstr ""
 
-#: static/js/common/upload-addon.js:480
+#: static/js/common/upload-addon.js:465 static/js/zamboni/devhub-all.js:711 static/js/zamboni/devhub-min.js:1
 msgid "Add-on submission checklist"
 msgstr ""
 
-#: static/js/common/upload-addon.js:481
+#: static/js/common/upload-addon.js:466 static/js/zamboni/devhub-all.js:712 static/js/zamboni/devhub-min.js:1
 msgid "Please verify the following points before finalizing your submission. This will minimize delays or misunderstanding during the review process:"
 msgstr ""
 
-#: static/js/common/upload-addon.js:483
+#: static/js/common/upload-addon.js:468 static/js/zamboni/devhub-all.js:714 static/js/zamboni/devhub-min.js:1
 msgid ""
 "Compiled binaries, as well as minified or obfuscated scripts (excluding known libraries) need to have their sources submitted separately for review. Make sure that you use the source code upload "
 "field to avoid having your submission rejected."
 msgstr ""
 
-#: static/js/common/upload-addon.js:501
+#: static/js/common/upload-addon.js:486 static/js/zamboni/devhub-all.js:732 static/js/zamboni/devhub-min.js:1
 msgid "The validation process found these issues that can lead to rejections:"
 msgstr ""
 
-#: static/js/common/upload-addon.js:518
+#: static/js/common/upload-addon.js:503 static/js/zamboni/devhub-all.js:749 static/js/zamboni/devhub-min.js:1
 msgid "If you are unfamiliar with the add-ons review process, you can read about it here."
 msgstr ""
 
-#: static/js/common/upload-addon.js:555
+#: static/js/common/upload-addon.js:540 static/js/zamboni/devhub-all.js:786 static/js/zamboni/devhub-min.js:1
 msgid "Sorry, no supported platform has been found."
 msgstr ""
 
-#: static/js/common/upload-base.js:57
+#: static/js/common/upload-base.js:57 static/js/zamboni/devhub-all.js:187 static/js/zamboni/devhub-min.js:1
 msgid "The filetype you uploaded isn't recognized."
 msgstr ""
 
-#: static/js/common/upload-base.js:79
+#: static/js/common/upload-base.js:79 static/js/zamboni/devhub-all.js:209 static/js/zamboni/devhub-min.js:1
 msgid "You cancelled the upload."
 msgstr ""
 
-#: static/js/common/upload-image.js:97 static/js/impala/users.js:51
-msgid "Images must be either PNG or JPG."
-msgstr ""
-
-#: static/js/common/upload-image.js:101
-msgid "Videos must be in WebM."
-msgstr ""
-
-#: static/js/impala/collections.js:10 static/js/zamboni/collections.js:595
-msgid "Follow this Collection"
-msgstr ""
-
-#: static/js/impala/collections.js:19
-msgid "Stop Following"
-msgstr ""
-
-#: static/js/impala/collections.js:20
-msgid "Following"
-msgstr ""
-
-#. L10n: {0} is an app name.
-#: static/js/impala/listing.js:11 static/js/zamboni/themes.js:13
-msgid "This theme is incompatible with your version of {0}"
-msgstr ""
-
-#: static/js/impala/persona_creation.js:60
-msgid "All Rights Reserved"
-msgstr ""
-
-#: static/js/impala/persona_creation.js:64
-msgid "Creative Commons Attribution 3.0"
-msgstr ""
-
-#: static/js/impala/persona_creation.js:69
-msgid "Creative Commons Attribution-NonCommercial 3.0"
-msgstr ""
-
-#: static/js/impala/persona_creation.js:74
-msgid "Creative Commons Attribution-NonCommercial-NoDerivs 3.0"
-msgstr ""
-
-#: static/js/impala/persona_creation.js:79
-msgid "Creative Commons Attribution-NonCommercial-Share Alike 3.0"
-msgstr ""
-
-#: static/js/impala/persona_creation.js:84
-msgid "Creative Commons Attribution-NoDerivs 3.0"
-msgstr ""
-
-#: static/js/impala/persona_creation.js:89
-msgid "Creative Commons Attribution-ShareAlike 3.0"
-msgstr ""
-
-#: static/js/impala/persona_creation.js:292
-msgid "Your Theme's Name"
-msgstr ""
-
-#: static/js/impala/reviews.js:23 static/js/zamboni/reviews.js:18
-msgid "Flagged for review"
-msgstr ""
-
-#: static/js/impala/reviews.js:40 static/js/zamboni/reviews.js:34
-msgid "Your input is required"
-msgstr ""
-
-#: static/js/impala/reviews.js:152 static/js/zamboni/reviews.js:103
-msgid "Marked for deletion"
-msgstr ""
-
-#: static/js/impala/search.js:114
-msgid "Updating results&hellip;"
-msgstr ""
-
-#: static/js/impala/site_suggestions.js:46
-msgid "Category"
-msgstr ""
-
-#: static/js/impala/suggestions.js:39
-msgid "Search themes for <b>{0}</b>"
-msgstr ""
-
-#: static/js/impala/suggestions.js:41
-msgid "Search apps for <b>{0}</b>"
-msgstr ""
-
-#: static/js/impala/suggestions.js:43
-msgid "Search add-ons for <b>{0}</b>"
-msgstr ""
-
-#: static/js/impala/users.js:33
-msgid "use original"
-msgstr ""
-
-#: static/js/impala/stats/chart.js:267
+#: static/js/impala/stats/chart.js:267 static/js/zamboni/stats-all.js:16898 static/js/zamboni/stats-min.js:5
 msgid "Week of {0}"
 msgstr ""
 
-#: static/js/impala/stats/chart.js:269
+#: static/js/impala/stats/chart.js:269 static/js/zamboni/stats-all.js:16900 static/js/zamboni/stats-min.js:5
 msgid " downloads"
 msgstr ""
 
-#: static/js/impala/stats/chart.js:270
+#: static/js/impala/stats/chart.js:270 static/js/zamboni/stats-all.js:16901 static/js/zamboni/stats-min.js:5
 msgid "{0} users"
 msgstr ""
 
-#: static/js/impala/stats/chart.js:271
+#: static/js/impala/stats/chart.js:271 static/js/zamboni/stats-all.js:16902 static/js/zamboni/stats-min.js:5
 msgid "{0} add-ons"
 msgstr ""
 
-#: static/js/impala/stats/chart.js:272
+#: static/js/impala/stats/chart.js:272 static/js/zamboni/stats-all.js:16903 static/js/zamboni/stats-min.js:5
 msgid "{0} collections"
 msgstr ""
 
-#: static/js/impala/stats/chart.js:273
+#: static/js/impala/stats/chart.js:273 static/js/zamboni/stats-all.js:16904 static/js/zamboni/stats-min.js:5
 msgid "{0} reviews"
 msgstr ""
 
-#: static/js/impala/stats/chart.js:275
+#: static/js/impala/stats/chart.js:275 static/js/zamboni/stats-all.js:16906 static/js/zamboni/stats-min.js:5
 msgid "{0} sales"
 msgstr ""
 
-#: static/js/impala/stats/chart.js:276
+#: static/js/impala/stats/chart.js:276 static/js/zamboni/stats-all.js:16907 static/js/zamboni/stats-min.js:5
 msgid "{0} refunds"
 msgstr ""
 
-#: static/js/impala/stats/chart.js:277
+#: static/js/impala/stats/chart.js:277 static/js/zamboni/stats-all.js:16908 static/js/zamboni/stats-min.js:5
 msgid "{0} installs"
 msgstr ""
 
-#: static/js/impala/stats/chart.js:369 static/js/impala/stats/csv_keys.js:3 static/js/impala/stats/csv_keys.js:109
+#: static/js/impala/stats/chart.js:369 static/js/impala/stats/csv_keys.js:3 static/js/impala/stats/csv_keys.js:109 static/js/zamboni/stats-all.js:15284 static/js/zamboni/stats-all.js:15390
+#: static/js/zamboni/stats-all.js:17000 static/js/zamboni/stats-min.js:4 static/js/zamboni/stats-min.js:5
 msgid "Downloads"
 msgstr ""
 
-#: static/js/impala/stats/chart.js:379 static/js/impala/stats/csv_keys.js:6 static/js/impala/stats/csv_keys.js:110
+#: static/js/impala/stats/chart.js:379 static/js/impala/stats/csv_keys.js:6 static/js/impala/stats/csv_keys.js:110 static/js/zamboni/stats-all.js:15287 static/js/zamboni/stats-all.js:15391
+#: static/js/zamboni/stats-all.js:17010 static/js/zamboni/stats-min.js:4 static/js/zamboni/stats-min.js:5
 msgid "Daily Users"
 msgstr ""
 
-#: static/js/impala/stats/chart.js:410
+#: static/js/impala/stats/chart.js:410 static/js/zamboni/stats-all.js:17041 static/js/zamboni/stats-min.js:5
 msgid "Amount, in USD"
 msgstr ""
 
-#: static/js/impala/stats/chart.js:421 static/js/impala/stats/csv_keys.js:104
+#: static/js/impala/stats/chart.js:421 static/js/impala/stats/csv_keys.js:104 static/js/zamboni/stats-all.js:15385 static/js/zamboni/stats-all.js:17052 static/js/zamboni/stats-min.js:5
 msgid "Number of Contributions"
 msgstr ""
 
-#: static/js/impala/stats/chart.js:447
+#: static/js/impala/stats/chart.js:447 static/js/zamboni/stats-all.js:17078 static/js/zamboni/stats-min.js:5
 msgid "More Info..."
 msgstr ""
 
 #. L10n: {0} is an ISO-formatted date.
-#: static/js/impala/stats/chart.js:451
+#: static/js/impala/stats/chart.js:451 static/js/zamboni/stats-all.js:17082 static/js/zamboni/stats-min.js:5
 msgid "Details for {0}"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:9
+#: static/js/impala/stats/csv_keys.js:9 static/js/zamboni/stats-all.js:15290 static/js/zamboni/stats-min.js:4
 msgid "Collections Created"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:12
+#: static/js/impala/stats/csv_keys.js:12 static/js/zamboni/stats-all.js:15293 static/js/zamboni/stats-min.js:4
 msgid "Add-ons in Use"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:15
+#: static/js/impala/stats/csv_keys.js:15 static/js/zamboni/stats-all.js:15296 static/js/zamboni/stats-min.js:4
 msgid "Add-ons Created"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:18
+#: static/js/impala/stats/csv_keys.js:18 static/js/zamboni/stats-all.js:15299 static/js/zamboni/stats-min.js:4
 msgid "Add-ons Downloaded"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:21
+#: static/js/impala/stats/csv_keys.js:21 static/js/zamboni/stats-all.js:15302 static/js/zamboni/stats-min.js:4
 msgid "Add-ons Updated"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:24
+#: static/js/impala/stats/csv_keys.js:24 static/js/zamboni/stats-all.js:15305 static/js/zamboni/stats-min.js:4
 msgid "Reviews Written"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:27
+#: static/js/impala/stats/csv_keys.js:27 static/js/zamboni/stats-all.js:15308 static/js/zamboni/stats-min.js:4
 msgid "User Signups"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:30
+#: static/js/impala/stats/csv_keys.js:30 static/js/zamboni/stats-all.js:15311 static/js/zamboni/stats-min.js:4
 msgid "Subscribers"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:33
+#: static/js/impala/stats/csv_keys.js:33 static/js/zamboni/stats-all.js:15314 static/js/zamboni/stats-min.js:4
 msgid "Ratings"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:36 static/js/impala/stats/csv_keys.js:114
+#: static/js/impala/stats/csv_keys.js:36 static/js/impala/stats/csv_keys.js:114 static/js/zamboni/stats-all.js:15317 static/js/zamboni/stats-all.js:15395 static/js/zamboni/stats-min.js:4
+#: static/js/zamboni/stats-min.js:5
 msgid "Sales"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:39 static/js/impala/stats/csv_keys.js:113
+#: static/js/impala/stats/csv_keys.js:39 static/js/impala/stats/csv_keys.js:113 static/js/zamboni/stats-all.js:15320 static/js/zamboni/stats-all.js:15394 static/js/zamboni/stats-min.js:4
+#: static/js/zamboni/stats-min.js:5
 msgid "Installs"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:42
+#: static/js/impala/stats/csv_keys.js:42 static/js/zamboni/stats-all.js:15323 static/js/zamboni/stats-min.js:4
 msgid "Unknown"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:43
+#: static/js/impala/stats/csv_keys.js:43 static/js/zamboni/stats-all.js:15324 static/js/zamboni/stats-min.js:4
 msgid "Add-ons Manager"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:44
+#: static/js/impala/stats/csv_keys.js:44 static/js/zamboni/stats-all.js:15325 static/js/zamboni/stats-min.js:4
 msgid "Add-ons Manager Promo"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:45
+#: static/js/impala/stats/csv_keys.js:45 static/js/zamboni/stats-all.js:15326 static/js/zamboni/stats-min.js:4
 msgid "Add-ons Manager Featured"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:46
+#: static/js/impala/stats/csv_keys.js:46 static/js/zamboni/stats-all.js:15327 static/js/zamboni/stats-min.js:4
 msgid "Add-ons Manager Learn More"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:47
+#: static/js/impala/stats/csv_keys.js:47 static/js/zamboni/stats-all.js:15328 static/js/zamboni/stats-min.js:4
 msgid "Search Suggestions"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:48
+#: static/js/impala/stats/csv_keys.js:48 static/js/zamboni/stats-all.js:15329 static/js/zamboni/stats-min.js:4
 msgid "Search Results"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:49 static/js/impala/stats/csv_keys.js:50 static/js/impala/stats/csv_keys.js:51
+#: static/js/impala/stats/csv_keys.js:49 static/js/impala/stats/csv_keys.js:50 static/js/impala/stats/csv_keys.js:51 static/js/zamboni/stats-all.js:15330 static/js/zamboni/stats-all.js:15331
+#: static/js/zamboni/stats-all.js:15332 static/js/zamboni/stats-min.js:4
 msgid "Homepage Promo"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:52 static/js/impala/stats/csv_keys.js:53
+#: static/js/impala/stats/csv_keys.js:52 static/js/impala/stats/csv_keys.js:53 static/js/zamboni/stats-all.js:15333 static/js/zamboni/stats-all.js:15334 static/js/zamboni/stats-min.js:4
 msgid "Homepage Featured"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:54 static/js/impala/stats/csv_keys.js:55
+#: static/js/impala/stats/csv_keys.js:54 static/js/impala/stats/csv_keys.js:55 static/js/zamboni/stats-all.js:15335 static/js/zamboni/stats-all.js:15336 static/js/zamboni/stats-min.js:4
 msgid "Homepage Up and Coming"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:56
+#: static/js/impala/stats/csv_keys.js:56 static/js/zamboni/stats-all.js:15337 static/js/zamboni/stats-min.js:4
 msgid "Homepage Most Popular"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:57 static/js/impala/stats/csv_keys.js:59
+#: static/js/impala/stats/csv_keys.js:57 static/js/impala/stats/csv_keys.js:59 static/js/zamboni/stats-all.js:15338 static/js/zamboni/stats-all.js:15340 static/js/zamboni/stats-min.js:4
 msgid "Detail Page"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:58 static/js/impala/stats/csv_keys.js:60
+#: static/js/impala/stats/csv_keys.js:58 static/js/impala/stats/csv_keys.js:60 static/js/zamboni/stats-all.js:15339 static/js/zamboni/stats-all.js:15341 static/js/zamboni/stats-min.js:4
 msgid "Detail Page (bottom)"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:61
+#: static/js/impala/stats/csv_keys.js:61 static/js/zamboni/stats-all.js:15342 static/js/zamboni/stats-min.js:4
 msgid "Detail Page (Development Channel)"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:62 static/js/impala/stats/csv_keys.js:63 static/js/impala/stats/csv_keys.js:64
+#: static/js/impala/stats/csv_keys.js:62 static/js/impala/stats/csv_keys.js:63 static/js/impala/stats/csv_keys.js:64 static/js/zamboni/stats-all.js:15343 static/js/zamboni/stats-all.js:15344
+#: static/js/zamboni/stats-all.js:15345 static/js/zamboni/stats-min.js:4
 msgid "Often Used With"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:65 static/js/impala/stats/csv_keys.js:66
+#: static/js/impala/stats/csv_keys.js:65 static/js/impala/stats/csv_keys.js:66 static/js/zamboni/stats-all.js:15346 static/js/zamboni/stats-all.js:15347 static/js/zamboni/stats-min.js:4
 msgid "Others By Author"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:67 static/js/impala/stats/csv_keys.js:68
+#: static/js/impala/stats/csv_keys.js:67 static/js/impala/stats/csv_keys.js:68 static/js/zamboni/stats-all.js:15348 static/js/zamboni/stats-all.js:15349 static/js/zamboni/stats-min.js:4
 msgid "Dependencies"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:69 static/js/impala/stats/csv_keys.js:70
+#: static/js/impala/stats/csv_keys.js:69 static/js/impala/stats/csv_keys.js:70 static/js/zamboni/stats-all.js:15350 static/js/zamboni/stats-all.js:15351 static/js/zamboni/stats-min.js:4
 msgid "Upsell"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:71
+#: static/js/impala/stats/csv_keys.js:71 static/js/zamboni/stats-all.js:15352 static/js/zamboni/stats-min.js:4
 msgid "Meet the Developer"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:72
+#: static/js/impala/stats/csv_keys.js:72 static/js/zamboni/stats-all.js:15353 static/js/zamboni/stats-min.js:4
 msgid "User Profile"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:73
+#: static/js/impala/stats/csv_keys.js:73 static/js/zamboni/stats-all.js:15354 static/js/zamboni/stats-min.js:4
 msgid "Version History"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:75
+#: static/js/impala/stats/csv_keys.js:75 static/js/zamboni/stats-all.js:15356 static/js/zamboni/stats-min.js:4
 msgid "Sharing"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:76
+#: static/js/impala/stats/csv_keys.js:76 static/js/zamboni/stats-all.js:15357 static/js/zamboni/stats-min.js:4
 msgid "Category Pages"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:77
+#: static/js/impala/stats/csv_keys.js:77 static/js/zamboni/stats-all.js:15358 static/js/zamboni/stats-min.js:4
 msgid "Collections"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:78 static/js/impala/stats/csv_keys.js:79
+#: static/js/impala/stats/csv_keys.js:78 static/js/impala/stats/csv_keys.js:79 static/js/zamboni/stats-all.js:15359 static/js/zamboni/stats-all.js:15360 static/js/zamboni/stats-min.js:4
 msgid "Category Landing Featured Carousel"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:80 static/js/impala/stats/csv_keys.js:81
+#: static/js/impala/stats/csv_keys.js:80 static/js/impala/stats/csv_keys.js:81 static/js/zamboni/stats-all.js:15361 static/js/zamboni/stats-all.js:15362 static/js/zamboni/stats-min.js:4
 msgid "Category Landing Top Rated"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:82 static/js/impala/stats/csv_keys.js:83
+#: static/js/impala/stats/csv_keys.js:82 static/js/impala/stats/csv_keys.js:83 static/js/zamboni/stats-all.js:15363 static/js/zamboni/stats-all.js:15364 static/js/zamboni/stats-min.js:5
 msgid "Category Landing Most Popular"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:84 static/js/impala/stats/csv_keys.js:85
+#: static/js/impala/stats/csv_keys.js:84 static/js/impala/stats/csv_keys.js:85 static/js/zamboni/stats-all.js:15365 static/js/zamboni/stats-all.js:15366 static/js/zamboni/stats-min.js:5
 msgid "Category Landing Recently Added"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:86 static/js/impala/stats/csv_keys.js:87
+#: static/js/impala/stats/csv_keys.js:86 static/js/impala/stats/csv_keys.js:87 static/js/zamboni/stats-all.js:15367 static/js/zamboni/stats-all.js:15368 static/js/zamboni/stats-min.js:5
 msgid "Browse Listing Featured Sort"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:88 static/js/impala/stats/csv_keys.js:89
+#: static/js/impala/stats/csv_keys.js:88 static/js/impala/stats/csv_keys.js:89 static/js/zamboni/stats-all.js:15369 static/js/zamboni/stats-all.js:15370 static/js/zamboni/stats-min.js:5
 msgid "Browse Listing Users Sort"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:90 static/js/impala/stats/csv_keys.js:91
+#: static/js/impala/stats/csv_keys.js:90 static/js/impala/stats/csv_keys.js:91 static/js/zamboni/stats-all.js:15371 static/js/zamboni/stats-all.js:15372 static/js/zamboni/stats-min.js:5
 msgid "Browse Listing Rating Sort"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:92 static/js/impala/stats/csv_keys.js:93
+#: static/js/impala/stats/csv_keys.js:92 static/js/impala/stats/csv_keys.js:93 static/js/zamboni/stats-all.js:15373 static/js/zamboni/stats-all.js:15374 static/js/zamboni/stats-min.js:5
 msgid "Browse Listing Created Sort"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:94 static/js/impala/stats/csv_keys.js:95
+#: static/js/impala/stats/csv_keys.js:94 static/js/impala/stats/csv_keys.js:95 static/js/zamboni/stats-all.js:15375 static/js/zamboni/stats-all.js:15376 static/js/zamboni/stats-min.js:5
 msgid "Browse Listing Name Sort"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:96 static/js/impala/stats/csv_keys.js:97
+#: static/js/impala/stats/csv_keys.js:96 static/js/impala/stats/csv_keys.js:97 static/js/zamboni/stats-all.js:15377 static/js/zamboni/stats-all.js:15378 static/js/zamboni/stats-min.js:5
 msgid "Browse Listing Popular Sort"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:98 static/js/impala/stats/csv_keys.js:99
+#: static/js/impala/stats/csv_keys.js:98 static/js/impala/stats/csv_keys.js:99 static/js/zamboni/stats-all.js:15379 static/js/zamboni/stats-all.js:15380 static/js/zamboni/stats-min.js:5
 msgid "Browse Listing Updated Sort"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:100 static/js/impala/stats/csv_keys.js:101
+#: static/js/impala/stats/csv_keys.js:100 static/js/impala/stats/csv_keys.js:101 static/js/zamboni/stats-all.js:15381 static/js/zamboni/stats-all.js:15382 static/js/zamboni/stats-min.js:5
 msgid "Browse Listing Up and Coming Sort"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:105
+#: static/js/impala/stats/csv_keys.js:105 static/js/zamboni/stats-all.js:15386 static/js/zamboni/stats-min.js:5
 msgid "Total Amount Contributed"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:106
+#: static/js/impala/stats/csv_keys.js:106 static/js/zamboni/stats-all.js:15387 static/js/zamboni/stats-min.js:5
 msgid "Average Contribution"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:115
+#: static/js/impala/stats/csv_keys.js:115 static/js/zamboni/stats-all.js:15396 static/js/zamboni/stats-min.js:5
 msgid "Usage"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:118
+#: static/js/impala/stats/csv_keys.js:118 static/js/zamboni/stats-all.js:15399 static/js/zamboni/stats-min.js:5
 msgid "Firefox"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:119
+#: static/js/impala/stats/csv_keys.js:119 static/js/zamboni/stats-all.js:15400 static/js/zamboni/stats-min.js:5
 msgid "Mozilla"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:120
+#: static/js/impala/stats/csv_keys.js:120 static/js/zamboni/stats-all.js:15401 static/js/zamboni/stats-min.js:5
 msgid "Thunderbird"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:121
+#: static/js/impala/stats/csv_keys.js:121 static/js/zamboni/stats-all.js:15402 static/js/zamboni/stats-min.js:5
 msgid "Sunbird"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:122
+#: static/js/impala/stats/csv_keys.js:122 static/js/zamboni/stats-all.js:15403 static/js/zamboni/stats-min.js:5
 msgid "SeaMonkey"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:123
+#: static/js/impala/stats/csv_keys.js:123 static/js/zamboni/stats-all.js:15404 static/js/zamboni/stats-min.js:5
 msgid "Fennec"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:124
+#: static/js/impala/stats/csv_keys.js:124 static/js/zamboni/stats-all.js:15405 static/js/zamboni/stats-min.js:5
 msgid "Android"
 msgstr ""
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:129
+#: static/js/impala/stats/csv_keys.js:129 static/js/zamboni/stats-all.js:15410 static/js/zamboni/stats-min.js:5
 msgid "Downloads and Daily Users, last {0} days"
 msgstr ""
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:131
+#: static/js/impala/stats/csv_keys.js:131 static/js/zamboni/stats-all.js:15412 static/js/zamboni/stats-min.js:5
 msgid "Downloads and Daily Users from {0} to {1}"
 msgstr ""
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:135
+#: static/js/impala/stats/csv_keys.js:135 static/js/zamboni/stats-all.js:15416 static/js/zamboni/stats-min.js:5
 msgid "Installs and Daily Users, last {0} days"
 msgstr ""
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:137
+#: static/js/impala/stats/csv_keys.js:137 static/js/zamboni/stats-all.js:15418 static/js/zamboni/stats-min.js:5
 msgid "Installs and Daily Users from {0} to {1}"
 msgstr ""
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:141
+#: static/js/impala/stats/csv_keys.js:141 static/js/zamboni/stats-all.js:15422 static/js/zamboni/stats-min.js:5
 msgid "Downloads, last {0} days"
 msgstr ""
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:143
+#: static/js/impala/stats/csv_keys.js:143 static/js/zamboni/stats-all.js:15424 static/js/zamboni/stats-min.js:5
 msgid "Downloads from {0} to {1}"
 msgstr ""
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:147
+#: static/js/impala/stats/csv_keys.js:147 static/js/zamboni/stats-all.js:15428 static/js/zamboni/stats-min.js:5
 msgid "Daily Users, last {0} days"
 msgstr ""
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:149
+#: static/js/impala/stats/csv_keys.js:149 static/js/zamboni/stats-all.js:15430 static/js/zamboni/stats-min.js:5
 msgid "Daily Users from {0} to {1}"
 msgstr ""
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:153
+#: static/js/impala/stats/csv_keys.js:153 static/js/zamboni/stats-all.js:15434 static/js/zamboni/stats-min.js:5
 msgid "Applications, last {0} days"
 msgstr ""
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:155
+#: static/js/impala/stats/csv_keys.js:155 static/js/zamboni/stats-all.js:15436 static/js/zamboni/stats-min.js:5
 msgid "Applications from {0} to {1}"
 msgstr ""
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:159
+#: static/js/impala/stats/csv_keys.js:159 static/js/zamboni/stats-all.js:15440 static/js/zamboni/stats-min.js:5
 msgid "Platforms, last {0} days"
 msgstr ""
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:161
+#: static/js/impala/stats/csv_keys.js:161 static/js/zamboni/stats-all.js:15442 static/js/zamboni/stats-min.js:5
 msgid "Platforms from {0} to {1}"
 msgstr ""
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:165
+#: static/js/impala/stats/csv_keys.js:165 static/js/zamboni/stats-all.js:15446 static/js/zamboni/stats-min.js:5
 msgid "Languages, last {0} days"
 msgstr ""
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:167
+#: static/js/impala/stats/csv_keys.js:167 static/js/zamboni/stats-all.js:15448 static/js/zamboni/stats-min.js:5
 msgid "Languages from {0} to {1}"
 msgstr ""
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:171
+#: static/js/impala/stats/csv_keys.js:171 static/js/zamboni/stats-all.js:15452 static/js/zamboni/stats-min.js:5
 msgid "Add-on Versions, last {0} days"
 msgstr ""
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:173
+#: static/js/impala/stats/csv_keys.js:173 static/js/zamboni/stats-all.js:15454 static/js/zamboni/stats-min.js:5
 msgid "Add-on Versions from {0} to {1}"
 msgstr ""
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:177
+#: static/js/impala/stats/csv_keys.js:177 static/js/zamboni/stats-all.js:15458 static/js/zamboni/stats-min.js:5
 msgid "Add-on Status, last {0} days"
 msgstr ""
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:179
+#: static/js/impala/stats/csv_keys.js:179 static/js/zamboni/stats-all.js:15460 static/js/zamboni/stats-min.js:5
 msgid "Add-on Status from {0} to {1}"
 msgstr ""
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:183
+#: static/js/impala/stats/csv_keys.js:183 static/js/zamboni/stats-all.js:15464 static/js/zamboni/stats-min.js:5
 msgid "Download Sources, last {0} days"
 msgstr ""
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:185
+#: static/js/impala/stats/csv_keys.js:185 static/js/zamboni/stats-all.js:15466 static/js/zamboni/stats-min.js:5
 msgid "Download Sources from {0} to {1}"
 msgstr ""
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:189
+#: static/js/impala/stats/csv_keys.js:189 static/js/zamboni/stats-all.js:15470 static/js/zamboni/stats-min.js:5
 msgid "Contributions, last {0} days"
 msgstr ""
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:191
+#: static/js/impala/stats/csv_keys.js:191 static/js/zamboni/stats-all.js:15472 static/js/zamboni/stats-min.js:5
 msgid "Contributions from {0} to {1}"
 msgstr ""
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:195
+#: static/js/impala/stats/csv_keys.js:195 static/js/zamboni/stats-all.js:15476 static/js/zamboni/stats-min.js:5
 msgid "Site Metrics, last {0} days"
 msgstr ""
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:197
+#: static/js/impala/stats/csv_keys.js:197 static/js/zamboni/stats-all.js:15478 static/js/zamboni/stats-min.js:5
 msgid "Site Metrics from {0} to {1}"
 msgstr ""
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:201
+#: static/js/impala/stats/csv_keys.js:201 static/js/zamboni/stats-all.js:15482 static/js/zamboni/stats-min.js:5
 msgid "Add-ons in Use, last {0} days"
 msgstr ""
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:203
+#: static/js/impala/stats/csv_keys.js:203 static/js/zamboni/stats-all.js:15484 static/js/zamboni/stats-min.js:5
 msgid "Add-ons in Use from {0} to {1}"
 msgstr ""
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:207
+#: static/js/impala/stats/csv_keys.js:207 static/js/zamboni/stats-all.js:15488 static/js/zamboni/stats-min.js:5
 msgid "Add-ons Downloaded, last {0} days"
 msgstr ""
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:209
+#: static/js/impala/stats/csv_keys.js:209 static/js/zamboni/stats-all.js:15490 static/js/zamboni/stats-min.js:5
 msgid "Add-ons Downloaded from {0} to {1}"
 msgstr ""
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:213
+#: static/js/impala/stats/csv_keys.js:213 static/js/zamboni/stats-all.js:15494 static/js/zamboni/stats-min.js:5
 msgid "Add-ons Created, last {0} days"
 msgstr ""
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:215
+#: static/js/impala/stats/csv_keys.js:215 static/js/zamboni/stats-all.js:15496 static/js/zamboni/stats-min.js:5
 msgid "Add-ons Created from {0} to {1}"
 msgstr ""
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:219
+#: static/js/impala/stats/csv_keys.js:219 static/js/zamboni/stats-all.js:15500 static/js/zamboni/stats-min.js:5
 msgid "Add-ons Updated, last {0} days"
 msgstr ""
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:221
+#: static/js/impala/stats/csv_keys.js:221 static/js/zamboni/stats-all.js:15502 static/js/zamboni/stats-min.js:5
 msgid "Add-ons Updated from {0} to {1}"
 msgstr ""
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:225
+#: static/js/impala/stats/csv_keys.js:225 static/js/zamboni/stats-all.js:15506 static/js/zamboni/stats-min.js:5
 msgid "Reviews Written, last {0} days"
 msgstr ""
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:227
+#: static/js/impala/stats/csv_keys.js:227 static/js/zamboni/stats-all.js:15508 static/js/zamboni/stats-min.js:5
 msgid "Reviews Written from {0} to {1}"
 msgstr ""
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:231
+#: static/js/impala/stats/csv_keys.js:231 static/js/zamboni/stats-all.js:15512 static/js/zamboni/stats-min.js:5
 msgid "User Signups, last {0} days"
 msgstr ""
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:233
+#: static/js/impala/stats/csv_keys.js:233 static/js/zamboni/stats-all.js:15514 static/js/zamboni/stats-min.js:5
 msgid "User Signups from {0} to {1}"
 msgstr ""
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:237
+#: static/js/impala/stats/csv_keys.js:237 static/js/zamboni/stats-all.js:15518 static/js/zamboni/stats-min.js:5
 msgid "Collections Created, last {0} days"
 msgstr ""
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:239
+#: static/js/impala/stats/csv_keys.js:239 static/js/zamboni/stats-all.js:15520 static/js/zamboni/stats-min.js:5
 msgid "Collections Created from {0} to {1}"
 msgstr ""
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:243
+#: static/js/impala/stats/csv_keys.js:243 static/js/zamboni/stats-all.js:15524 static/js/zamboni/stats-min.js:5
 msgid "Subscribers, last {0} days"
 msgstr ""
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:245
+#: static/js/impala/stats/csv_keys.js:245 static/js/zamboni/stats-all.js:15526 static/js/zamboni/stats-min.js:5
 msgid "Subscribers from {0} to {1}"
 msgstr ""
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:249
+#: static/js/impala/stats/csv_keys.js:249 static/js/zamboni/stats-all.js:15530 static/js/zamboni/stats-min.js:5
 msgid "Ratings, last {0} days"
 msgstr ""
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:251
+#: static/js/impala/stats/csv_keys.js:251 static/js/zamboni/stats-all.js:15532 static/js/zamboni/stats-min.js:5
 msgid "Ratings from {0} to {1}"
 msgstr ""
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:255
+#: static/js/impala/stats/csv_keys.js:255 static/js/zamboni/stats-all.js:15536 static/js/zamboni/stats-min.js:5
 msgid "Sales, last {0} days"
 msgstr ""
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:257
+#: static/js/impala/stats/csv_keys.js:257 static/js/zamboni/stats-all.js:15538 static/js/zamboni/stats-min.js:5
 msgid "Sales from {0} to {1}"
 msgstr ""
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:261
+#: static/js/impala/stats/csv_keys.js:261 static/js/zamboni/stats-all.js:15542 static/js/zamboni/stats-min.js:5
 msgid "Installs, last {0} days"
 msgstr ""
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:263
+#: static/js/impala/stats/csv_keys.js:263 static/js/zamboni/stats-all.js:15544 static/js/zamboni/stats-min.js:5
 msgid "Installs from {0} to {1}"
 msgstr ""
 
 #. L10n: {0} and {1} are integers.
-#: static/js/impala/stats/csv_keys.js:269
+#: static/js/impala/stats/csv_keys.js:269 static/js/zamboni/stats-all.js:15550 static/js/zamboni/stats-min.js:5
 msgid "<b>{0}</b> in last {1} days"
 msgstr ""
 
 #. L10n: {0} is an integer and {1} and {2} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:271 static/js/impala/stats/csv_keys.js:277
+#: static/js/impala/stats/csv_keys.js:271 static/js/impala/stats/csv_keys.js:277 static/js/zamboni/stats-all.js:15552 static/js/zamboni/stats-all.js:15558 static/js/zamboni/stats-min.js:5
 msgid "<b>{0}</b> from {1} to {2}"
 msgstr ""
 
 #. L10n: {0} and {1} are integers.
-#: static/js/impala/stats/csv_keys.js:275
+#: static/js/impala/stats/csv_keys.js:275 static/js/zamboni/stats-all.js:15556 static/js/zamboni/stats-min.js:5
 msgid "<b>{0}</b> average in last {1} days"
 msgstr ""
 
-#: static/js/impala/stats/overview.js:19
+#: static/js/impala/stats/overview.js:19 static/js/zamboni/stats-all.js:16469 static/js/zamboni/stats-min.js:5
 msgid "No data available."
 msgstr ""
 
-#: static/js/impala/stats/table.js:74
+#: static/js/impala/stats/table.js:74 static/js/zamboni/stats-all.js:17209 static/js/zamboni/stats-min.js:5
 msgid "Date"
 msgstr ""
 
-#: static/js/impala/stats/topchart.js:96
+#: static/js/impala/stats/topchart.js:96 static/js/zamboni/stats-all.js:16600 static/js/zamboni/stats-min.js:5
 msgid "Other"
 msgstr ""
 
-#: static/js/zamboni/admin_validation.js:24 static/js/zamboni/devhub.js:1229 static/js/zamboni/editors.js:295
+#: static/js/zamboni/admin-all.js:180 static/js/zamboni/admin-min.js:1 static/js/zamboni/admin_validation.js:24 static/js/zamboni/devhub-all.js:2408 static/js/zamboni/devhub-min.js:2
+#: static/js/zamboni/devhub.js:1229 static/js/zamboni/editors-all.js:15576 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:295
 msgid "Select an application first"
 msgstr ""
 
-#: static/js/zamboni/admin_validation.js:51
+#: static/js/zamboni/admin-all.js:207 static/js/zamboni/admin-min.js:1 static/js/zamboni/admin_validation.js:51
 msgid "Set {0} add-on to a max version of {1} and email the author."
 msgid_plural "Set {0} add-ons to a max version of {1} and email the authors."
 msgstr[0] ""
 msgstr[1] ""
 
-#: static/js/zamboni/admin_validation.js:54
+#: static/js/zamboni/admin-all.js:210 static/js/zamboni/admin-min.js:1 static/js/zamboni/admin_validation.js:54
 msgid "Email author of {2} add-on which failed validation."
 msgid_plural "Email authors of {2} add-ons which failed validation."
 msgstr[0] ""
 msgstr[1] ""
 
-#. L10n: {0} is an app name like Firefox.
-#: static/js/zamboni/buttons.js:66
-msgid "Accept and Install"
-msgstr ""
-
-#: static/js/zamboni/buttons.js:66
-msgid "Add to {0}"
-msgstr ""
-
-#: static/js/zamboni/buttons.js:71
-msgid "Download Now"
-msgstr ""
-
-#: static/js/zamboni/buttons.js:112
-msgid "Add-on has not been updated to support default-to-compatible."
-msgstr ""
-
-#: static/js/zamboni/buttons.js:117
-msgid "You need to be using Firefox 10.0 or higher."
-msgstr ""
-
-#: static/js/zamboni/buttons.js:129
-msgid "Mozilla has marked this version as incompatible with your Firefox version."
-msgstr ""
-
-#. L10n: {0} is an platform like Windows or Linux.
-#: static/js/zamboni/buttons.js:210
-msgid "Install for {0} anyway"
-msgstr ""
-
-#: static/js/zamboni/buttons.js:210
-msgid "Download for {0} anyway"
-msgstr ""
-
-#: static/js/zamboni/buttons.js:267
-msgid "Not available for your platform"
-msgstr ""
-
-#. L10n: {0} is an app name, {1} is the app version.
-#: static/js/zamboni/buttons.js:278 static/js/zamboni/buttons.js:315
-msgid "Not available for {0} {1}"
-msgstr ""
-
-#: static/js/zamboni/buttons.js:341
-msgid "Works with {app} {min} - {max}"
-msgstr ""
-
-#: static/js/zamboni/buttons.js:343
-msgid "View other versions"
-msgstr ""
-
-#: static/js/zamboni/buttons.js:391
-msgid "Only with Firefox — Get Firefox Now!"
-msgstr ""
-
-#: static/js/zamboni/buttons.js:507 static/js/zamboni/mobile/buttons.js:43
-msgid "Sorry, you need a Mozilla-based browser (such as Firefox) to install a search plugin."
-msgstr ""
-
-#: static/js/zamboni/collections.js:229
-msgid "Adding to Favorites&hellip;"
-msgstr ""
-
-#: static/js/zamboni/collections.js:232
-msgid "Removing Favorite&hellip;"
-msgstr ""
-
-#: static/js/zamboni/collections.js:235
-msgid "Add to Favorites"
-msgstr ""
-
-#: static/js/zamboni/collections.js:238
-msgid "Remove from Favorites"
-msgstr ""
-
-#: static/js/zamboni/collections.js:303
-msgid "Pending"
-msgstr ""
-
-#: static/js/zamboni/collections.js:304
-msgid "Add a comment"
-msgstr ""
-
-#: static/js/zamboni/collections.js:304
-msgid "Comment"
-msgstr ""
-
-#: static/js/zamboni/collections.js:305
-msgid "Remove this add-on from the collection"
-msgstr ""
-
-#: static/js/zamboni/collections.js:305 static/js/zamboni/collections.js:334
-msgid "Remove"
-msgstr ""
-
-#: static/js/zamboni/collections.js:334
-msgid "Remove this user as a contributor"
-msgstr ""
-
-#: static/js/zamboni/collections.js:346
-msgid "An email address is required."
-msgstr ""
-
-#: static/js/zamboni/collections.js:364
-msgid "You cannot add yourself as a contributor."
-msgstr ""
-
-#: static/js/zamboni/collections.js:366
-msgid "You have already added that user."
-msgstr ""
-
-#: static/js/zamboni/collections.js:573
-msgid "Add to favorites"
-msgstr ""
-
-#: static/js/zamboni/collections.js:577
-msgid "Remove from favorites"
-msgstr ""
-
-#: static/js/zamboni/collections.js:604
-msgid "Stop following"
-msgstr ""
-
-#: static/js/zamboni/devhub.js:110
+#: static/js/zamboni/devhub-all.js:1289 static/js/zamboni/devhub-min.js:1 static/js/zamboni/devhub.js:110
 msgid "Your browser does not support the video tag"
 msgstr ""
 
-#: static/js/zamboni/devhub.js:371
+#: static/js/zamboni/devhub-all.js:1550 static/js/zamboni/devhub-min.js:1 static/js/zamboni/devhub.js:371
 msgid "Changes Saved"
 msgstr ""
 
-#: static/js/zamboni/devhub.js:387
+#: static/js/zamboni/devhub-all.js:1566 static/js/zamboni/devhub-min.js:1 static/js/zamboni/devhub.js:387
 msgid "Enter a new author's email address"
 msgstr ""
 
-#: static/js/zamboni/devhub.js:536
+#: static/js/zamboni/devhub-all.js:1715 static/js/zamboni/devhub-min.js:1 static/js/zamboni/devhub.js:536
 msgid "There was an error uploading your file."
 msgstr ""
 
-#: static/js/zamboni/devhub.js:681
+#: static/js/zamboni/devhub-all.js:1860 static/js/zamboni/devhub-min.js:1 static/js/zamboni/devhub.js:681
 msgid "{files} file"
 msgid_plural "{files} files"
 msgstr[0] ""
 msgstr[1] ""
 
-#: static/js/zamboni/devhub.js:684
+#: static/js/zamboni/devhub-all.js:1863 static/js/zamboni/devhub-min.js:1 static/js/zamboni/devhub.js:684
 msgid "{reviews} user review"
 msgid_plural "{reviews} user reviews"
 msgstr[0] ""
 msgstr[1] ""
 
-#: static/js/zamboni/devhub.js:796
+#: static/js/zamboni/devhub-all.js:1975 static/js/zamboni/devhub-min.js:2 static/js/zamboni/devhub.js:796
 msgid "Learn more"
 msgstr ""
 
-#: static/js/zamboni/devhub.js:800
+#: static/js/zamboni/devhub-all.js:1979 static/js/zamboni/devhub-min.js:2 static/js/zamboni/devhub.js:800
 msgid "Example"
 msgstr ""
 
-#: static/js/zamboni/devhub.js:1130
+#: static/js/zamboni/devhub-all.js:2309 static/js/zamboni/devhub-min.js:2 static/js/zamboni/devhub.js:1130
 msgid "Image changes being processed"
 msgstr ""
 
-#: static/js/zamboni/devhub.js:1280
+#: static/js/zamboni/devhub-all.js:2459 static/js/zamboni/devhub-min.js:2 static/js/zamboni/devhub.js:1280
 msgid "Must be a valid e-mail address."
+msgstr ""
+
+#: static/js/zamboni/devhub-all.js:2613 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:80
+msgid "All tests passed successfully."
+msgstr ""
+
+#: static/js/zamboni/devhub-all.js:2616 static/js/zamboni/devhub-all.js:3011 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:83 static/js/zamboni/validator.js:478
+msgid "These tests were not run."
+msgstr ""
+
+#: static/js/zamboni/devhub-all.js:2664 static/js/zamboni/devhub-all.js:2677 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:131 static/js/zamboni/validator.js:144
+msgid "Tests"
+msgstr ""
+
+#: static/js/zamboni/devhub-all.js:2779 static/js/zamboni/devhub-all.js:3108 static/js/zamboni/devhub-all.js:3127 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:246
+#: static/js/zamboni/validator.js:575 static/js/zamboni/validator.js:594
+msgid "Error"
+msgstr ""
+
+#: static/js/zamboni/devhub-all.js:2780 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:247
+msgid "Warning"
+msgstr ""
+
+#: static/js/zamboni/devhub-all.js:2794 static/js/zamboni/devhub-min.js:2 static/js/zamboni/files-all.js:5657 static/js/zamboni/files-min.js:3 static/js/zamboni/files.js:411
+#: static/js/zamboni/validator.js:261
+msgid "Ignore this message in future updates"
+msgstr ""
+
+#: static/js/zamboni/devhub-all.js:2817 static/js/zamboni/devhub-min.js:2 static/js/zamboni/files-all.js:5663 static/js/zamboni/files-min.js:3 static/js/zamboni/files.js:417
+#: static/js/zamboni/validator.js:284
+msgid "Severity for automated signing:"
+msgstr ""
+
+#: static/js/zamboni/devhub-all.js:2832 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:299
+msgid "Suggestions for passing automated signing:"
+msgstr ""
+
+#: static/js/zamboni/devhub-all.js:2920 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:387
+msgid "Compatibility Tests"
+msgstr ""
+
+#: static/js/zamboni/devhub-all.js:2999 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:466
+msgid "Add-on failed validation."
+msgstr ""
+
+#: static/js/zamboni/devhub-all.js:3001 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:468
+msgid "Add-on passed validation."
+msgstr ""
+
+#: static/js/zamboni/devhub-all.js:3014 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:481
+msgid "{0} error"
+msgid_plural "{0} errors"
+msgstr[0] ""
+msgstr[1] ""
+
+#: static/js/zamboni/devhub-all.js:3016 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:483
+msgid "{0} warning"
+msgid_plural "{0} warnings"
+msgstr[0] ""
+msgstr[1] ""
+
+#: static/js/zamboni/devhub-all.js:3018 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:485
+msgid "{0} notice"
+msgid_plural "{0} notices"
+msgstr[0] ""
+msgstr[1] ""
+
+#: static/js/zamboni/devhub-all.js:3110 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:577
+msgid "Validation task could not complete or completed with errors"
+msgstr ""
+
+#: static/js/zamboni/devhub-all.js:3128 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:595
+msgid "Internal server error"
 msgstr ""
 
 #: static/js/zamboni/devhub_search.js:8
 msgid "No results found."
 msgstr ""
 
-#: static/js/zamboni/editors.js:121
+#: static/js/zamboni/editors-all.js:15402 static/js/zamboni/editors-min.js:4 static/js/zamboni/editors.js:121
 msgid "{name} was viewing this page first."
 msgstr ""
 
-#: static/js/zamboni/editors.js:171
+#: static/js/zamboni/editors-all.js:15452 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:171
 msgid "Receipt checked by app."
 msgstr ""
 
-#: static/js/zamboni/editors.js:173
+#: static/js/zamboni/editors-all.js:15454 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:173
 msgid "Receipt was not checked by app."
 msgstr ""
 
-#: static/js/zamboni/editors.js:244
+#: static/js/zamboni/editors-all.js:15525 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:244
 msgid "{name} was viewing this add-on first."
 msgstr ""
 
-#: static/js/zamboni/editors.js:255
+#: static/js/zamboni/editors-all.js:15536 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:255
 msgid "Loading&hellip;"
 msgstr ""
 
-#: static/js/zamboni/editors.js:260
+#: static/js/zamboni/editors-all.js:15541 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:260
 msgid "Version Notes"
 msgstr ""
 
-#: static/js/zamboni/editors.js:265
+#: static/js/zamboni/editors-all.js:15546 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:265
 msgid "Notes for Reviewers"
 msgstr ""
 
-#: static/js/zamboni/editors.js:270
+#: static/js/zamboni/editors-all.js:15551 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:270
 msgid "No version notes found"
 msgstr ""
 
-#: static/js/zamboni/editors.js:330
+#: static/js/zamboni/editors-all.js:15611 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:330
 msgid "Average Reviews"
 msgstr ""
 
-#: static/js/zamboni/editors.js:386
+#: static/js/zamboni/editors-all.js:15667 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:386
 msgid "Number of Reviews"
 msgstr ""
 
-#: static/js/zamboni/editors.js:445
+#: static/js/zamboni/editors-all.js:15726 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:445
 msgid "Error loading translation"
 msgstr ""
 
-#: static/js/zamboni/files.js:411 static/js/zamboni/validator.js:261
-msgid "Ignore this message in future updates"
-msgstr ""
-
-#: static/js/zamboni/files.js:417 static/js/zamboni/validator.js:284
-msgid "Severity for automated signing:"
-msgstr ""
-
-#: static/js/zamboni/global.js:410
-msgid "Loading..."
-msgstr ""
-
-#. L10n: {0} is the number of characters left.
-#: static/js/zamboni/global.js:474
-msgid "<b>{0}</b> character left."
-msgid_plural "<b>{0}</b> characters left."
-msgstr[0] ""
-msgstr[1] ""
-
-#: static/js/zamboni/init.js:28
-msgid "This feature is temporarily disabled while we perform website maintenance. Please check back a little later."
-msgstr ""
-
-#: static/js/zamboni/l10n.js:45
-msgid "Remove this localization"
-msgstr ""
-
-#: static/js/zamboni/password-strength.js:20
-msgid "Password strength:"
-msgstr ""
-
-#: static/js/zamboni/password-strength.js:26
-msgid "At least {0} character left."
-msgid_plural "At least {0} characters left."
-msgstr[0] ""
-msgstr[1] ""
-
-#: static/js/zamboni/themes_review.js:176
-msgid "Requested Info"
-msgstr ""
-
-#: static/js/zamboni/themes_review.js:177
-msgid "Flagged"
-msgstr ""
-
-#: static/js/zamboni/themes_review.js:178
-msgid "Duplicate"
-msgstr ""
-
-#: static/js/zamboni/themes_review.js:179
-msgid "Rejected"
-msgstr ""
-
-#: static/js/zamboni/themes_review.js:180
-msgid "Approved"
-msgstr ""
-
-#: static/js/zamboni/themes_review.js:424
-msgid "No results found"
-msgstr ""
-
-#: static/js/zamboni/themes_review_templates.js:31
+#: static/js/zamboni/editors-all.js:15975 static/js/zamboni/editors-min.js:5 static/js/zamboni/themes_review_templates.js:31
 msgid "Theme"
 msgstr ""
 
-#: static/js/zamboni/themes_review_templates.js:33
+#: static/js/zamboni/editors-all.js:15977 static/js/zamboni/editors-min.js:5 static/js/zamboni/themes_review_templates.js:33
 msgid "Reviewer"
 msgstr ""
 
-#: static/js/zamboni/themes_review_templates.js:35
+#: static/js/zamboni/editors-all.js:15979 static/js/zamboni/editors-min.js:5 static/js/zamboni/themes_review_templates.js:35
 msgid "Status"
 msgstr ""
 
-#: static/js/zamboni/validator.js:80
-msgid "All tests passed successfully."
+#: static/js/zamboni/editors-all.js:16196 static/js/zamboni/editors-min.js:5 static/js/zamboni/themes_review.js:176
+msgid "Requested Info"
 msgstr ""
 
-#: static/js/zamboni/validator.js:83 static/js/zamboni/validator.js:478
-msgid "These tests were not run."
+#: static/js/zamboni/editors-all.js:16197 static/js/zamboni/editors-min.js:5 static/js/zamboni/themes_review.js:177
+msgid "Flagged"
 msgstr ""
 
-#: static/js/zamboni/validator.js:131 static/js/zamboni/validator.js:144
-msgid "Tests"
+#: static/js/zamboni/editors-all.js:16198 static/js/zamboni/editors-min.js:5 static/js/zamboni/themes_review.js:178
+msgid "Duplicate"
 msgstr ""
 
-#: static/js/zamboni/validator.js:246 static/js/zamboni/validator.js:575 static/js/zamboni/validator.js:594
-msgid "Error"
+#: static/js/zamboni/editors-all.js:16199 static/js/zamboni/editors-min.js:5 static/js/zamboni/themes_review.js:179
+msgid "Rejected"
 msgstr ""
 
-#: static/js/zamboni/validator.js:247
-msgid "Warning"
+#: static/js/zamboni/editors-all.js:16200 static/js/zamboni/editors-min.js:5 static/js/zamboni/themes_review.js:180
+msgid "Approved"
 msgstr ""
 
-#: static/js/zamboni/validator.js:299
-msgid "Suggestions for passing automated signing:"
+#: static/js/zamboni/editors-all.js:16444 static/js/zamboni/editors-min.js:5 static/js/zamboni/themes_review.js:424
+msgid "No results found"
 msgstr ""
 
-#: static/js/zamboni/validator.js:387
-msgid "Compatibility Tests"
-msgstr ""
-
-#: static/js/zamboni/validator.js:466
-msgid "Add-on failed validation."
-msgstr ""
-
-#: static/js/zamboni/validator.js:468
-msgid "Add-on passed validation."
-msgstr ""
-
-#: static/js/zamboni/validator.js:481
-msgid "{0} error"
-msgid_plural "{0} errors"
-msgstr[0] ""
-msgstr[1] ""
-
-#: static/js/zamboni/validator.js:483
-msgid "{0} warning"
-msgid_plural "{0} warnings"
-msgstr[0] ""
-msgstr[1] ""
-
-#: static/js/zamboni/validator.js:485
-msgid "{0} notice"
-msgid_plural "{0} notices"
-msgstr[0] ""
-msgstr[1] ""
-
-#: static/js/zamboni/validator.js:577
-msgid "Validation task could not complete or completed with errors"
-msgstr ""
-
-#: static/js/zamboni/validator.js:595
-msgid "Internal server error"
-msgstr ""
-
-#: static/js/zamboni/mobile/buttons.js:52
+#: static/js/zamboni/mobile-all.js:15186 static/js/zamboni/mobile/buttons.js:52
 msgid "Not Updated for {0} {1}"
 msgstr ""
 
-#: static/js/zamboni/mobile/buttons.js:53
+#: static/js/zamboni/mobile-all.js:15187 static/js/zamboni/mobile/buttons.js:53
 msgid "Requires Newer Version of {0}"
 msgstr ""
 
-#: static/js/zamboni/mobile/buttons.js:54
+#: static/js/zamboni/mobile-all.js:15188 static/js/zamboni/mobile/buttons.js:54
 msgid "Unreviewed"
 msgstr ""
 
-#: static/js/zamboni/mobile/buttons.js:55
+#: static/js/zamboni/mobile-all.js:15189 static/js/zamboni/mobile/buttons.js:55
 msgid "Experimental <span>(Learn More)</span>"
 msgstr ""
 
-#: static/js/zamboni/mobile/buttons.js:56 static/js/zamboni/mobile/buttons.js:57
+#: static/js/zamboni/mobile-all.js:15190 static/js/zamboni/mobile-all.js:15191 static/js/zamboni/mobile/buttons.js:56 static/js/zamboni/mobile/buttons.js:57
 msgid "Not Available for {0}"
 msgstr ""
 
-#: static/js/zamboni/mobile/buttons.js:58
+#: static/js/zamboni/mobile-all.js:15192 static/js/zamboni/mobile/buttons.js:58
 msgid "Experimental"
 msgstr ""
 
-#: static/js/zamboni/mobile/buttons.js:59
+#: static/js/zamboni/mobile-all.js:15193 static/js/zamboni/mobile/buttons.js:59
 msgid "Themes Require Newer Version of {0}"
 msgstr ""
 
-#: static/js/zamboni/mobile/buttons.js:60
+#: static/js/zamboni/mobile-all.js:15194 static/js/zamboni/mobile/buttons.js:60
 msgid "Themes Require {0}"
 msgstr ""
 
-#: static/js/zamboni/mobile/buttons.js:105
+#: static/js/zamboni/mobile-all.js:15239 static/js/zamboni/mobile/buttons.js:105
 msgid "Installing..."
 msgstr ""
 
-#: static/js/zamboni/mobile/buttons.js:125
+#: static/js/zamboni/mobile-all.js:15259 static/js/zamboni/mobile/buttons.js:125
 msgid "This add-on has been preliminarily reviewed by Mozilla."
 msgstr ""
 
-#: static/js/zamboni/mobile/buttons.js:250
+#: static/js/zamboni/mobile-all.js:15384 static/js/zamboni/mobile/buttons.js:250
 msgid "Keep it"
 msgstr ""
 
-#: static/js/zamboni/mobile/general.js:344
+#: static/js/zamboni/mobile-all.js:16049 static/js/zamboni/mobile-min.js:6 static/js/zamboni/mobile/general.js:344
 msgid "You're trying it on!"
 msgstr ""
 
-#: static/js/zamboni/mobile/general.js:356
+#: static/js/zamboni/mobile-all.js:16061 static/js/zamboni/mobile-min.js:6 static/js/zamboni/mobile/general.js:356
 msgid "Added to Firefox"
 msgstr ""
-

--- a/locale/nl/LC_MESSAGES/django.po
+++ b/locale/nl/LC_MESSAGES/django.po
@@ -6,69 +6,70 @@ msgid ""
 msgstr ""
 "Project-Id-Version: REMORA 0.1\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2016-02-24 21:23+0000\n"
+"POT-Creation-Date: 2016-04-18 15:47+0000\n"
 "PO-Revision-Date: 2016-02-26 10:14+0000\n"
 "Last-Translator: Mark Heijl <markh@babelzilla.org>\n"
 "Language-Team: DUTCH <LL@li.org>\n"
+"Language: \n"
 "MIME-Version: 1.0\n"
-"Content-Type: text/plain; charset=utf-8\n"
+"Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Generated-By: Babel 2.2.0\n"
 
-#: src/olympia/accounts/views.py:52
+#: src/olympia/accounts/views.py:54
 msgid "Your log in attempt could not be parsed. Please try again."
 msgstr "Uw aanmeldpoging kon niet worden verwerkt. Probeer het opnieuw."
 
-#: src/olympia/accounts/views.py:54
+#: src/olympia/accounts/views.py:56
 msgid "Your Firefox Account could not be found. Please try again."
 msgstr "Uw Firefox-account werd niet gevonden. Probeer het opnieuw."
 
-#: src/olympia/accounts/views.py:55
+#: src/olympia/accounts/views.py:57
 msgid "You could not be logged in. Please try again."
 msgstr "U kunt niet worden aangemeld. Probeer het opnieuw."
 
-#: src/olympia/accounts/views.py:57
+#: src/olympia/accounts/views.py:59
 msgid "Your account has already been migrated to Firefox Accounts."
 msgstr "Uw account is al gemigreerd naar Firefox Accounts."
 
-#: src/olympia/accounts/views.py:59
+#: src/olympia/accounts/views.py:61
 msgid "Your Firefox Account already exists on this site."
 msgstr "Uw Firefox-account bestaat al op deze website."
 
-#: src/olympia/accounts/views.py:108
+#: src/olympia/accounts/views.py:110
 msgid "Great job!"
 msgstr "Goed werk!"
 
-#: src/olympia/accounts/views.py:109
+#: src/olympia/accounts/views.py:111
 msgid "You can now log in to Add-ons with your Firefox Account."
 msgstr "U kunt zich nu aanmelden bij Add-ons met uw Firefox-account."
 
-#: src/olympia/accounts/views.py:121
+#: src/olympia/accounts/views.py:123
 msgid "Need help?"
 msgstr "Hulp nodig?"
 
-#: src/olympia/addons/buttons.py:180
+#: src/olympia/addons/buttons.py:177
 msgid "Download Now"
 msgstr "Nu downloaden"
 
-#: src/olympia/addons/buttons.py:182
+#: src/olympia/addons/buttons.py:179
 msgid "Download"
 msgstr "Downloaden"
 
 #. L10n: please keep &nbsp; in the string so &rarr; does not wrap.
-#: src/olympia/addons/buttons.py:186
+#: src/olympia/addons/buttons.py:183
 msgid "Continue to Download&nbsp;&rarr;"
 msgstr "Doorgaan naar download&nbsp;&rarr;"
 
-#: src/olympia/addons/buttons.py:202 src/olympia/addons/helpers.py:35 src/olympia/addons/views.py:319 src/olympia/addons/templates/addons/impala/details.html:114
+#: src/olympia/addons/buttons.py:199 src/olympia/addons/helpers.py:35 src/olympia/addons/views.py:333 src/olympia/addons/templates/addons/impala/details.html:111
 #: src/olympia/addons/templates/addons/impala/listing/items.html:17 src/olympia/addons/templates/addons/mobile/home.html:40 src/olympia/amo/templates/amo/side_nav.html:6
-#: src/olympia/amo/templates/amo/side_nav.html:10 src/olympia/amo/templates/amo/site_nav.html:2 src/olympia/amo/templates/amo/site_nav.html:55 src/olympia/bandwagon/views.py:95
-#: src/olympia/browse/views.py:54 src/olympia/browse/views.py:68 src/olympia/browse/views.py:235 src/olympia/browse/templates/browse/impala/category_landing.html:22
+#: src/olympia/amo/templates/amo/side_nav.html:10 src/olympia/amo/templates/amo/site_nav.html:2 src/olympia/amo/templates/amo/site_nav.html:53 src/olympia/bandwagon/views.py:95
+#: src/olympia/browse/views.py:54 src/olympia/browse/views.py:68 src/olympia/browse/views.py:202 src/olympia/browse/templates/browse/impala/category_landing.html:22
 #: src/olympia/browse/templates/browse/personas/mobile/category_landing.html:26
 msgid "Featured"
 msgstr "Aanbevolen"
 
-#: src/olympia/addons/buttons.py:221
+#: src/olympia/addons/buttons.py:218
 msgid "Add to {0}"
 msgstr "Toevoegen aan {0}"
 
@@ -116,39 +117,39 @@ msgid_plural "All tags must be at least {0} characters."
 msgstr[0] "Alle labels dienen uit ten minste {0} teken te bestaan."
 msgstr[1] "Alle labels dienen uit ten minste {0} tekens te bestaan."
 
-#: src/olympia/addons/forms.py:234
+#: src/olympia/addons/forms.py:238
 msgid "Categories cannot be changed while your add-on is featured for this application."
 msgstr "Categorieën kunnen niet worden gewijzigd als uw add-on voor deze toepassing wordt aanbevolen."
 
 #. L10n: {0} is the number of categories.
-#: src/olympia/addons/forms.py:238
+#: src/olympia/addons/forms.py:242
 msgid "You can have only {0} category."
 msgid_plural "You can have only {0} categories."
 msgstr[0] "U kunt slechts {0} categorie gebruiken."
 msgstr[1] "U kunt slechts {0} categorieën gebruiken."
 
-#: src/olympia/addons/forms.py:246
+#: src/olympia/addons/forms.py:250
 msgid "The miscellaneous category cannot be combined with additional categories."
 msgstr "De categorie diversen kan niet met extra categorieën worden gecombineerd."
 
-#: src/olympia/addons/forms.py:369
+#: src/olympia/addons/forms.py:374
 #, python-format
 msgid "Before changing your default locale you must have a name, summary, and description in that locale. You are missing %s."
 msgstr "Voordat u uw standaardlocale wijzigt dient u een naam, samenvatting en beschrijving voor die locale in te geven. Momenteel ontbreekt %s."
 
-#: src/olympia/addons/forms.py:484 src/olympia/addons/forms.py:575
+#: src/olympia/addons/forms.py:455 src/olympia/addons/forms.py:546
 msgid "A license must be selected."
 msgstr "U dient een licentie te selecteren."
 
-#: src/olympia/addons/forms.py:556
+#: src/olympia/addons/forms.py:527
 msgid "Give Your Theme a Name."
 msgstr "Geef uw thema een naam."
 
-#: src/olympia/addons/forms.py:562 src/olympia/devhub/templates/devhub/personas/submit.html:53
+#: src/olympia/addons/forms.py:533 src/olympia/devhub/templates/devhub/personas/submit.html:53
 msgid "Describe your Theme."
 msgstr "Beschrijf uw thema."
 
-#: src/olympia/addons/forms.py:704
+#: src/olympia/addons/forms.py:675
 msgid "Enter a new author's email address"
 msgstr "Voor het e-mailadres van een nieuwe schrijver toe"
 
@@ -156,39 +157,39 @@ msgstr "Voor het e-mailadres van een nieuwe schrijver toe"
 msgid "Not Reviewed"
 msgstr "Niet beoordeeld"
 
-#: src/olympia/addons/models.py:301
+#: src/olympia/addons/models.py:298
 msgid "Users have the option of contributing more or less than this amount."
 msgstr "Gebruikers hebben de keuze om meer of minder dan dit bedrag bij te dragen."
 
-#: src/olympia/addons/models.py:309
-msgid "Users will always be asked in the Add-ons Manager (Firefox 4 and above)"
-msgstr "Gebruikers wordt altijd gevraagd in de Add-onbeheerder (Firefox 4 en hoger)"
+#: src/olympia/addons/models.py:306
+msgid "Users will always be asked in the Add-ons Manager (Firefox 4 and above). Only applies to desktop."
+msgstr ""
 
 # Column name in a table.
-#: src/olympia/addons/models.py:1804 src/olympia/addons/templates/addons/details_box.html:55 src/olympia/devhub/templates/devhub/index.html:92
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:102
+#: src/olympia/addons/models.py:1802 src/olympia/addons/templates/addons/details_box.html:55 src/olympia/devhub/templates/devhub/index.html:92
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:89
 msgid "Listed"
 msgstr "Vermeld"
 
-#: src/olympia/addons/views.py:320 src/olympia/browse/templates/browse/personas/mobile/category_landing.html:27
+#: src/olympia/addons/views.py:334 src/olympia/browse/templates/browse/personas/mobile/category_landing.html:27
 msgid "Popular"
 msgstr "Populair"
 
-#: src/olympia/addons/views.py:321 src/olympia/browse/views.py:238 src/olympia/browse/views.py:280 src/olympia/browse/views.py:482
+#: src/olympia/addons/views.py:335 src/olympia/browse/views.py:205 src/olympia/browse/views.py:247 src/olympia/browse/views.py:449
 msgid "Recently Added"
 msgstr "Onlangs toegevoegd"
 
-#: src/olympia/addons/views.py:322 src/olympia/bandwagon/views.py:99 src/olympia/browse/views.py:60 src/olympia/browse/views.py:71 src/olympia/search/forms.py:16 src/olympia/search/forms.py:91
+#: src/olympia/addons/views.py:336 src/olympia/bandwagon/views.py:99 src/olympia/browse/views.py:60 src/olympia/browse/views.py:71 src/olympia/search/forms.py:16 src/olympia/search/forms.py:91
 msgid "Recently Updated"
 msgstr "Onlangs bijgewerkt"
 
 # %1 is an add-on name.
 #. l10n: {0} is the addon name
-#: src/olympia/addons/views.py:520
+#: src/olympia/addons/views.py:534
 msgid "Contribution for {0}"
 msgstr "Bijdrage voor {0}"
 
-#: src/olympia/addons/views.py:613
+#: src/olympia/addons/views.py:627
 msgid "Abuse reported."
 msgstr "Misbruik gemeld."
 
@@ -257,9 +258,9 @@ msgstr "Bijdragen"
 #: src/olympia/devhub/templates/devhub/addons/ajax_compat_update.html:36 src/olympia/devhub/templates/devhub/addons/profile.html:44 src/olympia/devhub/templates/devhub/addons/edit/admin.html:101
 #: src/olympia/devhub/templates/devhub/addons/edit/basic.html:152 src/olympia/devhub/templates/devhub/addons/edit/details.html:85 src/olympia/devhub/templates/devhub/addons/edit/support.html:67
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:166 src/olympia/devhub/templates/devhub/addons/forms_shared/media.html:149
-#: src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:44 src/olympia/devhub/templates/devhub/versions/add_file_modal.html:78 src/olympia/devhub/templates/devhub/versions/edit.html:139
-#: src/olympia/devhub/templates/devhub/versions/list.html:242 src/olympia/devhub/templates/devhub/versions/list.html:276 src/olympia/devhub/templates/devhub/versions/list.html:317
-#: src/olympia/devhub/templates/devhub/versions/list.html:351 src/olympia/reviews/templates/reviews/edit_review.html:16 src/olympia/translations/templates/translations/trans-menu.html:50
+#: src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:43 src/olympia/devhub/templates/devhub/versions/add_file_modal.html:58 src/olympia/devhub/templates/devhub/versions/edit.html:139
+#: src/olympia/devhub/templates/devhub/versions/list.html:239 src/olympia/devhub/templates/devhub/versions/list.html:281 src/olympia/devhub/templates/devhub/versions/list.html:315
+#: src/olympia/devhub/templates/devhub/versions/list.html:349 src/olympia/reviews/templates/reviews/edit_review.html:16 src/olympia/translations/templates/translations/trans-menu.html:50
 #: src/olympia/translations/templates/translations/trans-menu.html:62
 msgid "or"
 msgstr "of"
@@ -329,8 +330,7 @@ msgstr "Het bedrag dient een getal te zijn."
 msgid "A one-time suggested contribution of {0}"
 msgstr "Een voorgestelde eenmalige bijdrage van {0}"
 
-#. {0} is a currency symbol (e.g., $),                    {1} is an amount
-#. input
+#. {0} is a currency symbol (e.g., $),                    {1} is an amount input
 #. field
 #: src/olympia/addons/templates/addons/contributions_lightbox.html:64
 msgid "A one-time contribution of {0} {1}"
@@ -371,7 +371,7 @@ msgid "Add-on Information for {0}"
 msgstr "Add-on-informatie voor {0}"
 
 #: src/olympia/addons/templates/addons/details_box.html:30 src/olympia/addons/templates/addons/persona_detail_table.html:3 src/olympia/addons/templates/addons/mobile/details.html:63
-#: src/olympia/addons/templates/addons/mobile/persona_detail_table.html:7 src/olympia/browse/views.py:459 src/olympia/devhub/views.py:75
+#: src/olympia/addons/templates/addons/mobile/persona_detail_table.html:7 src/olympia/browse/views.py:426 src/olympia/devhub/views.py:73
 msgid "Updated"
 msgstr "Bijgewerkt"
 
@@ -390,11 +390,11 @@ msgstr "Werkt met"
 msgid "Visibility"
 msgstr "Zichtbaarheid"
 
-#: src/olympia/addons/templates/addons/details_box.html:57 src/olympia/devhub/templates/devhub/index.html:94 src/olympia/devhub/templates/devhub/includes/addon_details.html:104
+#: src/olympia/addons/templates/addons/details_box.html:57 src/olympia/devhub/templates/devhub/index.html:94 src/olympia/devhub/templates/devhub/includes/addon_details.html:91
 msgid "Hidden"
 msgstr "Verborgen"
 
-#: src/olympia/addons/templates/addons/details_box.html:59 src/olympia/devhub/templates/devhub/index.html:96 src/olympia/devhub/templates/devhub/includes/addon_details.html:106
+#: src/olympia/addons/templates/addons/details_box.html:59 src/olympia/devhub/templates/devhub/index.html:96 src/olympia/devhub/templates/devhub/includes/addon_details.html:93
 msgid "Unlisted"
 msgstr "Niet vermeld"
 
@@ -402,13 +402,13 @@ msgstr "Niet vermeld"
 msgid "Required Add-ons"
 msgstr "Vereiste add-ons"
 
-#: src/olympia/addons/templates/addons/details_box.html:81 src/olympia/addons/templates/addons/persona_detail_table.html:15 src/olympia/browse/views.py:462 src/olympia/devhub/views.py:78
-#: src/olympia/devhub/views.py:85 src/olympia/discovery/templates/discovery/addons/detail.html:57 src/olympia/reviews/forms.py:62 src/olympia/reviews/templates/reviews/add.html:57
+#: src/olympia/addons/templates/addons/details_box.html:81 src/olympia/addons/templates/addons/persona_detail_table.html:15 src/olympia/browse/views.py:429 src/olympia/devhub/views.py:76
+#: src/olympia/devhub/views.py:83 src/olympia/discovery/templates/discovery/addons/detail.html:57 src/olympia/reviews/forms.py:62 src/olympia/reviews/templates/reviews/add.html:57
 #: src/olympia/reviews/templates/reviews/mobile/review_list.html:18
 msgid "Rating"
 msgstr "Waardering"
 
-#: src/olympia/addons/templates/addons/details_box.html:85 src/olympia/browse/views.py:461 src/olympia/devhub/views.py:77 src/olympia/devhub/views.py:84
+#: src/olympia/addons/templates/addons/details_box.html:85 src/olympia/browse/views.py:428 src/olympia/devhub/views.py:75 src/olympia/devhub/views.py:82
 #: src/olympia/stats/templates/stats/addon_report_menu.html:8 src/olympia/stats/templates/stats/collection_report_menu.html:18
 msgid "Downloads"
 msgstr "Downloads"
@@ -428,7 +428,7 @@ msgstr "Misbruikmeldingen"
 
 #. The Privacy Policy for this add-on.
 #: src/olympia/addons/templates/addons/details_box.html:121 src/olympia/addons/templates/addons/privacy.html:19 src/olympia/addons/templates/addons/privacy.html:23
-#: src/olympia/addons/templates/addons/impala/button.html:43 src/olympia/addons/templates/addons/impala/details.html:307 src/olympia/devhub/templates/devhub/includes/policy_form.html:20
+#: src/olympia/addons/templates/addons/impala/button.html:43 src/olympia/addons/templates/addons/impala/details.html:312 src/olympia/devhub/templates/devhub/includes/policy_form.html:23
 #: src/olympia/templates/mobile/base_addons.html:87
 msgid "Privacy Policy"
 msgstr "Privacybeleid"
@@ -453,7 +453,7 @@ msgstr "Afbeeldingengalerij"
 msgid "Developer Comments"
 msgstr "Opmerkingen van de ontwikkelaar"
 
-#: src/olympia/addons/templates/addons/details_box.html:199 src/olympia/addons/templates/addons/impala/details.html:259
+#: src/olympia/addons/templates/addons/details_box.html:199 src/olympia/addons/templates/addons/impala/details.html:264
 msgid "Development Channel"
 msgstr "Ontwikkelingskanaal"
 
@@ -477,13 +477,13 @@ msgstr ""
 "<strong>Waarschuwing:</strong> ontwikkelversies van deze add-on zijn niet beoordeeld door Mozilla. Als u een ontwikkelversie installeert, ontvangt u voortaan ontwikkelingsupdates van deze "
 "ontwikkelaar. Om geen ontwikkelingsupdates meer te ontvangen dient u de standaardversie via bovenstaande koppeling te installeren."
 
-#: src/olympia/addons/templates/addons/details_box.html:220 src/olympia/addons/templates/addons/impala/details.html:278
+#: src/olympia/addons/templates/addons/details_box.html:220 src/olympia/addons/templates/addons/impala/details.html:283
 msgid "Version {0}:"
 msgstr "Versie {0}:"
 
 #: src/olympia/addons/templates/addons/details_box.html:234
 msgid "Nothing to see here!  The developer did not include any details."
-msgstr "Niets te zien hier!  De ontwikkelaar heeft geen details gegeven."
+msgstr ""
 
 #: src/olympia/addons/templates/addons/details_box.html:251 src/olympia/devhub/templates/devhub/versions/edit.html:73 src/olympia/editors/templates/editors/review.html:98
 msgid "Version Notes"
@@ -496,7 +496,7 @@ msgid "End-User License Agreement for {0}"
 msgstr "Eindgebruikerslicentieovereenkomst voor {0}"
 
 #: src/olympia/addons/templates/addons/eula.html:17 src/olympia/addons/templates/addons/eula.html:21 src/olympia/addons/templates/addons/impala/button.html:48
-#: src/olympia/addons/templates/addons/impala/details.html:316 src/olympia/devhub/templates/devhub/includes/policy_form.html:3 src/olympia/discovery/templates/discovery/addons/eula.html:11
+#: src/olympia/addons/templates/addons/impala/details.html:321 src/olympia/devhub/templates/devhub/includes/policy_form.html:3 src/olympia/discovery/templates/discovery/addons/eula.html:11
 msgid "End-User License Agreement"
 msgstr "Eindgebruikerslicentieovereenkomst"
 
@@ -516,7 +516,7 @@ msgstr "Terug naar {0}…"
 msgid "Add-ons for {0}"
 msgstr "Add-ons voor {0}"
 
-#: src/olympia/addons/templates/addons/home.html:10 src/olympia/addons/templates/addons/home.html:51 src/olympia/browse/templates/browse/impala/base_listing.html:11
+#: src/olympia/addons/templates/addons/home.html:10 src/olympia/addons/templates/addons/home.html:53 src/olympia/browse/templates/browse/impala/base_listing.html:11
 msgid "Featured Extensions"
 msgstr "Aanbevolen extensies"
 
@@ -524,29 +524,29 @@ msgstr "Aanbevolen extensies"
 msgid "Popular Extensions"
 msgstr "Populaire extensies"
 
-#: src/olympia/addons/templates/addons/home.html:42 src/olympia/amo/templates/amo/side_nav.html:3 src/olympia/amo/templates/amo/side_nav.html:11 src/olympia/amo/templates/amo/site_nav.html:3
-#: src/olympia/amo/templates/amo/site_nav.html:25 src/olympia/browse/views.py:236 src/olympia/browse/views.py:281 src/olympia/browse/views.py:481
+#: src/olympia/addons/templates/addons/home.html:44 src/olympia/amo/templates/amo/side_nav.html:3 src/olympia/amo/templates/amo/side_nav.html:11 src/olympia/amo/templates/amo/site_nav.html:3
+#: src/olympia/amo/templates/amo/site_nav.html:25 src/olympia/browse/views.py:203 src/olympia/browse/views.py:248 src/olympia/browse/views.py:448
 msgid "Most Popular"
 msgstr "Populairst"
 
-#: src/olympia/addons/templates/addons/home.html:43
+#: src/olympia/addons/templates/addons/home.html:45
 msgid "All »"
 msgstr "Alles »"
 
-#: src/olympia/addons/templates/addons/home.html:52 src/olympia/addons/templates/addons/home.html:61 src/olympia/addons/templates/addons/home.html:70 src/olympia/addons/templates/addons/home.html:78
+#: src/olympia/addons/templates/addons/home.html:54 src/olympia/addons/templates/addons/home.html:63 src/olympia/addons/templates/addons/home.html:72 src/olympia/addons/templates/addons/home.html:80
 #: src/olympia/browse/templates/browse/impala/category_landing.html:36
 msgid "See all »"
 msgstr "Alles bekijken »"
 
-#: src/olympia/addons/templates/addons/home.html:60
+#: src/olympia/addons/templates/addons/home.html:62
 msgid "Up &amp; Coming Extensions"
 msgstr "Aankomende extensies"
 
-#: src/olympia/addons/templates/addons/home.html:69 src/olympia/browse/templates/browse/personas/category_landing.html:61 src/olympia/discovery/templates/discovery/pane.html:74
+#: src/olympia/addons/templates/addons/home.html:71 src/olympia/browse/templates/browse/personas/category_landing.html:61 src/olympia/discovery/templates/discovery/pane.html:74
 msgid "Featured Themes"
 msgstr "Aanbevolen thema’s"
 
-#: src/olympia/addons/templates/addons/home.html:77 src/olympia/bandwagon/templates/bandwagon/impala/collection_listing.html:5
+#: src/olympia/addons/templates/addons/home.html:79 src/olympia/bandwagon/templates/bandwagon/impala/collection_listing.html:5
 msgid "Featured Collections"
 msgstr "Aanbevolen collecties"
 
@@ -564,7 +564,7 @@ msgid "Updated {0}"
 msgstr "Bijgewerkt op {0}"
 
 #. {0} is a date.
-#: src/olympia/addons/templates/addons/macros.html:10 src/olympia/addons/templates/addons/macros.html:69 src/olympia/addons/templates/addons/persona_preview.html:21
+#: src/olympia/addons/templates/addons/macros.html:10 src/olympia/addons/templates/addons/macros.html:69 src/olympia/addons/templates/addons/persona_preview.html:22
 #: src/olympia/addons/templates/addons/listing/items_mobile.html:44 src/olympia/addons/templates/addons/listing/macros.html:39
 #: src/olympia/bandwagon/templates/bandwagon/collection_listing_items.html:37 src/olympia/bandwagon/templates/bandwagon/impala/collection_listing_items.html:37
 msgid "Added {0}"
@@ -585,15 +585,14 @@ msgstr[0] "%(num)s gebruiker"
 msgstr[1] "%(num)s gebruikers"
 
 #. {0} is the number of downloads.
-#: src/olympia/addons/templates/addons/macros.html:53 src/olympia/addons/templates/addons/impala/details.html:61
+#: src/olympia/addons/templates/addons/macros.html:53 src/olympia/addons/templates/addons/impala/details.html:59
 msgid "{0} weekly download"
 msgid_plural "{0} weekly downloads"
 msgstr[0] "{0} download deze week"
 msgstr[1] "{0} downloads deze week"
 
 #. {0} is the number of users.
-#: src/olympia/addons/templates/addons/macros.html:61 src/olympia/addons/templates/addons/impala/details.html:54 src/olympia/compat/templates/compat/index.html:71
-#: src/olympia/zadmin/templates/zadmin/compat.html:67
+#: src/olympia/addons/templates/addons/macros.html:61 src/olympia/addons/templates/addons/impala/details.html:52 src/olympia/zadmin/templates/zadmin/compat.html:67
 msgid "{0} user"
 msgid_plural "{0} users"
 msgstr[0] "{0} gebruiker"
@@ -611,7 +610,7 @@ msgstr "Betaling voltooid"
 msgid "Return to the addon."
 msgstr "Terug naar de add-on."
 
-#: src/olympia/addons/templates/addons/persona_detail.html:17 src/olympia/addons/templates/addons/impala/details.html:106 src/olympia/addons/templates/addons/mobile/details.html:23
+#: src/olympia/addons/templates/addons/persona_detail.html:17 src/olympia/addons/templates/addons/impala/details.html:103 src/olympia/addons/templates/addons/mobile/details.html:23
 #: src/olympia/addons/templates/addons/mobile/persona_detail.html:21 src/olympia/discovery/templates/discovery/addons/base.html:27 src/olympia/editors/templates/editors/review.html:31
 msgid "by"
 msgstr "door"
@@ -655,34 +654,35 @@ msgstr "Dagelijkse gebruikers"
 msgid "License"
 msgstr "Licentie"
 
-#: src/olympia/addons/templates/addons/persona_preview.html:12 src/olympia/constants/base.py:48
+#: src/olympia/addons/templates/addons/persona_preview.html:13 src/olympia/constants/base.py:48
 msgid "Awaiting Review"
 msgstr "Wacht op beoordeling"
 
-#: src/olympia/addons/templates/addons/persona_preview.html:14 src/olympia/amo/log.py:180 src/olympia/constants/base.py:42 src/olympia/editors/helpers.py:62
+#: src/olympia/addons/templates/addons/persona_preview.html:15 src/olympia/amo/log.py:180 src/olympia/constants/base.py:42 src/olympia/editors/helpers.py:62
 msgid "Rejected"
 msgstr "Afgewezen"
 
-#: src/olympia/addons/templates/addons/persona_preview.html:16 src/olympia/amo/log.py:159
+#: src/olympia/addons/templates/addons/persona_preview.html:17 src/olympia/amo/log.py:159
 msgid "Approved"
 msgstr "Goedgekeurd"
 
 #. {0} is the number of users.
-#: src/olympia/addons/templates/addons/persona_preview.html:26 src/olympia/addons/templates/addons/listing/items_mobile.html:36 src/olympia/addons/templates/addons/listing/macros.html:31
+#: src/olympia/addons/templates/addons/persona_preview.html:27 src/olympia/addons/templates/addons/listing/items_mobile.html:36 src/olympia/addons/templates/addons/listing/macros.html:31
 msgid "<strong>{0}</strong> user"
 msgid_plural "<strong>{0}</strong> users"
 msgstr[0] "<strong>{0}</strong> gebruiker"
 msgstr[1] "<strong>{0}</strong> gebruikers"
 
-#: src/olympia/addons/templates/addons/persona_preview.html:40
+#: src/olympia/addons/templates/addons/persona_preview.html:41
 msgid "Hover to Preview"
 msgstr "Wijs aan voor voorbeeld"
 
-#: src/olympia/addons/templates/addons/persona_preview.html:46 src/olympia/addons/templates/addons/persona_preview.html:48 src/olympia/reviews/templates/reviews/add.html:15
+#: src/olympia/addons/templates/addons/persona_preview.html:47 src/olympia/addons/templates/addons/persona_preview.html:49 src/olympia/addons/templates/addons/persona_preview.html:97
+#: src/olympia/reviews/templates/reviews/add.html:15
 msgid "Add"
 msgstr "Toevoegen"
 
-#: src/olympia/addons/templates/addons/persona_preview.html:57 src/olympia/bandwagon/templates/bandwagon/ajax_new.html:16 src/olympia/bandwagon/templates/bandwagon/edit.html:19
+#: src/olympia/addons/templates/addons/persona_preview.html:58 src/olympia/bandwagon/templates/bandwagon/ajax_new.html:16 src/olympia/bandwagon/templates/bandwagon/edit.html:19
 #: src/olympia/bandwagon/templates/bandwagon/includes/addedit.html:19 src/olympia/devhub/templates/devhub/addons/edit/admin.html:13 src/olympia/devhub/templates/devhub/addons/edit/basic.html:10
 #: src/olympia/devhub/templates/devhub/addons/edit/details.html:8 src/olympia/devhub/templates/devhub/addons/edit/media.html:6 src/olympia/devhub/templates/devhub/addons/edit/support.html:8
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:9 src/olympia/devhub/templates/devhub/addons/submit/describe.html:29 src/olympia/editors/templates/editors/review.html:257
@@ -691,21 +691,21 @@ msgstr "Bewerken"
 
 #. For datetime formatting, see the table on
 #. http://docs.python.org/library/datetime.html#strftime-and-strptime-behavior
-#: src/olympia/addons/templates/addons/persona_preview.html:66
+#: src/olympia/addons/templates/addons/persona_preview.html:67
 #, python-format
 msgid "%%Y-%%m-%%d"
 msgstr "%%d-%%m-%%Y"
 
-#: src/olympia/addons/templates/addons/persona_preview.html:67
+#: src/olympia/addons/templates/addons/persona_preview.html:68
 msgid "by {0} on {1}"
 msgstr "door {0} op {1}"
 
-#: src/olympia/addons/templates/addons/persona_preview.html:75 src/olympia/reviews/helpers.py:17 src/olympia/reviews/templates/reviews/review_list.html:63
+#: src/olympia/addons/templates/addons/persona_preview.html:76 src/olympia/reviews/helpers.py:17 src/olympia/reviews/templates/reviews/review_list.html:63
 #: src/olympia/reviews/templates/reviews/reviews_link.html:21 src/olympia/reviews/templates/reviews/impala/reviews_link.html:16
 msgid "Not yet rated"
 msgstr "Nog niet gewaardeerd"
 
-#: src/olympia/addons/templates/addons/persona_preview.html:78
+#: src/olympia/addons/templates/addons/persona_preview.html:79
 msgid "<b>{0}</b> users"
 msgstr "<b>{0}</b> gebruikers"
 
@@ -718,8 +718,8 @@ msgid "Learn more about Firefox"
 msgstr "Meer over Firefox"
 
 #: src/olympia/addons/templates/addons/popups.html:22
-msgid "or <b><a class=\"installer\" href=\"{url}\">download anyway</a></b>"
-msgstr "of <b><a class=\"installer\" href=\"{url}\">download toch</a></b>"
+msgid "or <b><a class=\"button installer\" href=\"{url}\">download anyway</a></b>"
+msgstr ""
 
 #: src/olympia/addons/templates/addons/popups.html:26
 msgid ""
@@ -783,8 +783,6 @@ msgid ""
 "<strong>Caution:</strong> This add-on has not been reviewed by Mozilla and can't be installed on release versions of Firefox 43 and above.  Be careful when installing third-party software that "
 "might harm your computer."
 msgstr ""
-"<strong>Let op:</strong> Deze add-on is niet door Mozilla beoordeeld en kan niet worden geïnstalleerd op Firefox-versies 43 en hoger.  Wees voorzichtig bij het installeren van software van derden, "
-"die mogelijk schade aan uw computer kan toebrengen."
 
 #: src/olympia/addons/templates/addons/popups.html:120
 msgid "<strong>Please note:</strong> This add-on is not compatible with your operating system."
@@ -818,10 +816,10 @@ msgid ""
 "Want {0} on your mobile Firefox?  Scan this QR code to install directly\n"
 "  to your phone.  (You'll need a QR reader.  Search your phone's marketplace if\n"
 "  don't have one.)"
-msgstr "Wilt u {0} op uw mobiele Firefox? Scan deze QR-code en installeer rechtstreeks op uw telefoon. (U hebt een QR-lezer nodig.  Zoek op de marktplaats van uw telefoon als u deze niet heeft.)"
+msgstr ""
 
 #: src/olympia/addons/templates/addons/report_abuse.html:6 src/olympia/addons/templates/addons/report_abuse_full.html:10 src/olympia/addons/templates/addons/impala/details-more.html:23
-#: src/olympia/addons/templates/addons/impala/details.html:328
+#: src/olympia/addons/templates/addons/impala/details.html:333
 msgid "Report Abuse"
 msgstr "Misbruik melden"
 
@@ -842,9 +840,9 @@ msgstr "Rapport verzenden"
 #: src/olympia/devhub/templates/devhub/addons/ajax_compat_update.html:36 src/olympia/devhub/templates/devhub/addons/profile.html:44 src/olympia/devhub/templates/devhub/addons/edit/admin.html:104
 #: src/olympia/devhub/templates/devhub/addons/edit/basic.html:155 src/olympia/devhub/templates/devhub/addons/edit/details.html:88 src/olympia/devhub/templates/devhub/addons/edit/support.html:70
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:169 src/olympia/devhub/templates/devhub/addons/forms_shared/media.html:152
-#: src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:44 src/olympia/devhub/templates/devhub/personas/edit.html:222 src/olympia/devhub/templates/devhub/versions/add_file_modal.html:79
-#: src/olympia/devhub/templates/devhub/versions/edit.html:140 src/olympia/devhub/templates/devhub/versions/list.html:208 src/olympia/devhub/templates/devhub/versions/list.html:242
-#: src/olympia/devhub/templates/devhub/versions/list.html:276 src/olympia/devhub/templates/devhub/versions/list.html:317 src/olympia/reviews/templates/reviews/edit_review.html:16
+#: src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:43 src/olympia/devhub/templates/devhub/personas/edit.html:222 src/olympia/devhub/templates/devhub/versions/add_file_modal.html:59
+#: src/olympia/devhub/templates/devhub/versions/edit.html:140 src/olympia/devhub/templates/devhub/versions/list.html:208 src/olympia/devhub/templates/devhub/versions/list.html:239
+#: src/olympia/devhub/templates/devhub/versions/list.html:281 src/olympia/devhub/templates/devhub/versions/list.html:315 src/olympia/reviews/templates/reviews/edit_review.html:16
 #: src/olympia/translations/templates/translations/trans-menu.html:50 src/olympia/translations/templates/translations/trans-menu.html:62 src/olympia/zadmin/templates/zadmin/validation.html:105
 msgid "Cancel"
 msgstr "Annuleren"
@@ -891,7 +889,7 @@ msgstr "Kijk in de <a href=\"%(support)s\">ondersteuningssectie</a> waar u hulp 
 msgid "Review Guidelines"
 msgstr "Beoordelingsrichtlijnen"
 
-#: src/olympia/addons/templates/addons/review_list_box.html:5 src/olympia/addons/templates/addons/impala/details-more.html:27 src/olympia/editors/helpers.py:921
+#: src/olympia/addons/templates/addons/review_list_box.html:5 src/olympia/addons/templates/addons/impala/details-more.html:27 src/olympia/editors/helpers.py:1001
 #: src/olympia/reviews/templates/reviews/add.html:14 src/olympia/reviews/templates/reviews/reply.html:14 src/olympia/reviews/templates/reviews/review_list.html:19
 #: src/olympia/reviews/templates/reviews/mobile/review_list.html:26
 msgid "Reviews"
@@ -982,31 +980,31 @@ msgid_plural "Other add-ons by these authors"
 msgstr[0] "Overige add-ons door %(author)s"
 msgstr[1] "Overige add-ons door deze schrijvers"
 
-#: src/olympia/addons/templates/addons/impala/details.html:41
+#: src/olympia/addons/templates/addons/impala/details.html:39
 #, python-format
 msgid "<span itemprop=\"ratingCount\">%(num)s</span> user review"
 msgid_plural "<span itemprop=\"ratingCount\">%(num)s</span> user reviews"
 msgstr[0] "<span itemprop=\"ratingCount\">%(num)s</span> gebruikersbeoordeling"
 msgstr[1] "<span itemprop=\"ratingCount\">%(num)s</span> gebruikersbeoordelingen"
 
-#: src/olympia/addons/templates/addons/impala/details.html:69
+#: src/olympia/addons/templates/addons/impala/details.html:66
 msgid "View statistics"
 msgstr "Statistieken bekijken"
 
-#: src/olympia/addons/templates/addons/impala/details.html:84
+#: src/olympia/addons/templates/addons/impala/details.html:81
 msgid "Manage"
 msgstr "Beheren"
 
 #. {0} is an add-on name.
-#: src/olympia/addons/templates/addons/impala/details.html:96
+#: src/olympia/addons/templates/addons/impala/details.html:93
 msgid "Icon of {0}"
 msgstr "Pictogram van {0}"
 
-#: src/olympia/addons/templates/addons/impala/details.html:103 src/olympia/addons/templates/addons/impala/listing/items.html:14
+#: src/olympia/addons/templates/addons/impala/details.html:100 src/olympia/addons/templates/addons/impala/listing/items.html:14
 msgid "No Restart"
 msgstr "Geen herstart"
 
-#: src/olympia/addons/templates/addons/impala/details.html:127
+#: src/olympia/addons/templates/addons/impala/details.html:124
 #, python-format
 msgid "Meet the Developer: <a href=\"%(url)s\">%(name)s</a>"
 msgid_plural "<a href=\"%(url)s\">Meet the Developers</a>"
@@ -1014,72 +1012,72 @@ msgstr[0] "Maak kennis met de ontwikkelaar: <a href=\"%(url)s\">%(name)s</a>"
 msgstr[1] "<a href=\"%(url)s\">Maak kennis met de ontwikkelaars</a>"
 
 # {0} is an add-on name.
-#: src/olympia/addons/templates/addons/impala/details.html:137
+#: src/olympia/addons/templates/addons/impala/details.html:134
 msgid "Learn why {0} was created and find out what's next for this add-on."
 msgstr "Lees waarom {0} is gemaakt en ontdek wat de toekomst biedt voor deze add-on."
 
 #. {0} is an index.
-#: src/olympia/addons/templates/addons/impala/details.html:156
+#: src/olympia/addons/templates/addons/impala/details.html:161
 msgid "Add-on screenshot #{0}"
 msgstr "Schermafbeelding add-on nr. {0}"
 
-#: src/olympia/addons/templates/addons/impala/details.html:182
+#: src/olympia/addons/templates/addons/impala/details.html:187
 msgid "Add-on home page"
 msgstr "Add-on-startpagina"
 
-#: src/olympia/addons/templates/addons/impala/details.html:185
+#: src/olympia/addons/templates/addons/impala/details.html:190
 msgid "Support site"
 msgstr "Ondersteuningswebsite"
 
-#: src/olympia/addons/templates/addons/impala/details.html:189
+#: src/olympia/addons/templates/addons/impala/details.html:194
 msgid "Support E-mail"
 msgstr "E-mailadres voor ondersteuning"
 
-#: src/olympia/addons/templates/addons/impala/details.html:194 src/olympia/devhub/models.py:378 src/olympia/devhub/templates/devhub/versions/list.html:12
+#: src/olympia/addons/templates/addons/impala/details.html:199 src/olympia/devhub/models.py:378 src/olympia/devhub/templates/devhub/versions/list.html:12
 #: src/olympia/versions/templates/versions/version.html:6 src/olympia/versions/templates/versions/mobile/version.html:6
 msgid "Version {0}"
 msgstr "Versie {0}"
 
-#: src/olympia/addons/templates/addons/impala/details.html:194
+#: src/olympia/addons/templates/addons/impala/details.html:199
 msgid "Info"
 msgstr "Informatie"
 
-#: src/olympia/addons/templates/addons/impala/details.html:195 src/olympia/devhub/templates/devhub/includes/addon_details.html:129
+#: src/olympia/addons/templates/addons/impala/details.html:200 src/olympia/devhub/templates/devhub/includes/addon_details.html:116
 msgid "Last Updated:"
 msgstr "Laatst bijgewerkt:"
 
-#: src/olympia/addons/templates/addons/impala/details.html:200
+#: src/olympia/addons/templates/addons/impala/details.html:205
 #, python-format
 msgid "Released under <a target=\"_blank\" href=\"%(url)s\">%(name)s</a>"
 msgstr "Uitgegeven onder <a target=\"_blank\" href=\"%(url)s\">%(name)s</a>"
 
-#: src/olympia/addons/templates/addons/impala/details.html:201 src/olympia/addons/templates/addons/impala/details.html:206 src/olympia/amo/helpers.py:398 src/olympia/devhub/forms.py:142
+#: src/olympia/addons/templates/addons/impala/details.html:206 src/olympia/addons/templates/addons/impala/details.html:211 src/olympia/amo/helpers.py:398 src/olympia/devhub/forms.py:142
 #: src/olympia/devhub/forms.py:173 src/olympia/versions/templates/versions/version.html:40 src/olympia/versions/templates/versions/version.html:45
 msgid "Custom License"
 msgstr "Aangepaste licentie"
 
-#: src/olympia/addons/templates/addons/impala/details.html:205
+#: src/olympia/addons/templates/addons/impala/details.html:210
 #, python-format
 msgid "Released under <a href=\"%(url)s\">%(name)s</a>"
 msgstr "Uitgegeven onder <a href=\"%(url)s\">%(name)s</a>"
 
-#: src/olympia/addons/templates/addons/impala/details.html:217
+#: src/olympia/addons/templates/addons/impala/details.html:222
 msgid "About this Add-on"
 msgstr "Over deze add-on"
 
-#: src/olympia/addons/templates/addons/impala/details.html:233
+#: src/olympia/addons/templates/addons/impala/details.html:238
 msgid "Developer’s Comments"
 msgstr "Ontwikkelaarsopmerkingen"
 
-#: src/olympia/addons/templates/addons/impala/details.html:243
+#: src/olympia/addons/templates/addons/impala/details.html:248
 msgid "Version Information"
 msgstr "Versie-informatie"
 
-#: src/olympia/addons/templates/addons/impala/details.html:250
+#: src/olympia/addons/templates/addons/impala/details.html:255
 msgid "See complete version history"
 msgstr "Volledige versiegeschiedenis bekijken"
 
-#: src/olympia/addons/templates/addons/impala/details.html:262
+#: src/olympia/addons/templates/addons/impala/details.html:267
 msgid ""
 "The Development Channel lets you test an experimental new version of this add-on before it's released to the general public. Once you install the development version, you will continue to get "
 "updates from this channel. To stop receiving development updates, reinstall the default version from the link above."
@@ -1087,17 +1085,17 @@ msgstr ""
 "Via het Ontwikkelingskanaal kunt u een experimentele nieuwe versie van deze add-on testen voordat deze wordt vrijgegeven voor algemeen gebruik. Na installatie van de ontwikkelversie krijgt u "
 "voortaan updates via dit kanaal. Installeer de standaardversie via bovenstaande koppeling om geen ontwikkelupdates meer te ontvangen."
 
-#: src/olympia/addons/templates/addons/impala/details.html:272
+#: src/olympia/addons/templates/addons/impala/details.html:277
 msgid "<strong>Caution:</strong> Development versions of this add-on have not been reviewed by Mozilla."
 msgstr "<strong>Waarschuwing:</strong> ontwikkelversies van deze add-on zijn niet beoordeeld door Mozilla."
 
-#: src/olympia/addons/templates/addons/impala/details.html:287
+#: src/olympia/addons/templates/addons/impala/details.html:292
 msgid "See complete development channel history"
 msgstr "Volledige geschiedenis van ontwikkelingskanaal bekijken"
 
-#: src/olympia/addons/templates/addons/impala/details.html:306 src/olympia/addons/templates/addons/impala/details.html:315 src/olympia/addons/templates/addons/impala/details.html:327
+#: src/olympia/addons/templates/addons/impala/details.html:311 src/olympia/addons/templates/addons/impala/details.html:320 src/olympia/addons/templates/addons/impala/details.html:332
 #: src/olympia/addons/templates/addons/impala/review_add_box.html:4 src/olympia/stats/templates/stats/popup.html:2 src/olympia/stats/templates/stats/popup.html:8
-#: src/olympia/stats/templates/stats/stats.html:202 src/olympia/users/templates/users/profile.html:119
+#: src/olympia/stats/templates/stats/stats.html:204 src/olympia/users/templates/users/profile.html:119
 msgid "close"
 msgstr "sluiten"
 
@@ -1156,15 +1154,11 @@ msgstr "Broncodelicentie voor {addon}"
 msgid "Source Code License"
 msgstr "Broncodelicentie"
 
-#: src/olympia/addons/templates/addons/impala/persona_grid.html:16 src/olympia/addons/templates/addons/impala/toplist.html:6
-msgid "{0} users"
-msgstr "{0} gebruikers"
-
 #: src/olympia/addons/templates/addons/impala/review_list_box.html:19 src/olympia/reviews/templates/reviews/review.html:40
 msgid "permalink"
 msgstr "permalink"
 
-#: src/olympia/addons/templates/addons/impala/review_list_box.html:23 src/olympia/editors/templates/editors/queue.html:98 src/olympia/reviews/templates/reviews/review.html:44
+#: src/olympia/addons/templates/addons/impala/review_list_box.html:23 src/olympia/editors/templates/editors/queue.html:104 src/olympia/reviews/templates/reviews/review.html:44
 msgid "translate"
 msgstr "vertalen"
 
@@ -1183,6 +1177,10 @@ msgstr "Deze add-on is nog niet beoordeeld."
 msgid "Be the first!"
 msgstr "Wees de eerste!"
 
+#: src/olympia/addons/templates/addons/impala/toplist.html:6
+msgid "{0} users"
+msgstr "{0} gebruikers"
+
 #: src/olympia/addons/templates/addons/impala/listing/sorter.html:14 src/olympia/devhub/templates/devhub/addons/listing/item_actions.html:49
 msgid "More"
 msgstr "Meer"
@@ -1195,7 +1193,7 @@ msgstr "Toevoegen aan collectie"
 msgid "My Add-ons"
 msgstr "Mijn add-ons"
 
-#: src/olympia/addons/templates/addons/includes/dashboard_tabs.html:6 src/olympia/amo/context_processors.py:51
+#: src/olympia/addons/templates/addons/includes/dashboard_tabs.html:6 src/olympia/amo/context_processors.py:50
 msgid "My Themes"
 msgstr "Mijn thema’s"
 
@@ -1250,7 +1248,7 @@ msgstr "Gebruikers"
 msgid "Weekly Downloads"
 msgstr "Wekelijkse downloads"
 
-#: src/olympia/addons/templates/addons/mobile/details.html:99 src/olympia/compat/templates/compat/reporter_detail.html:46 src/olympia/devhub/forms.py:787
+#: src/olympia/addons/templates/addons/mobile/details.html:99 src/olympia/compat/templates/compat/reporter_detail.html:46 src/olympia/devhub/forms.py:788
 #: src/olympia/devhub/templates/devhub/versions/list.html:163
 msgid "Version"
 msgstr "Versie"
@@ -1337,7 +1335,7 @@ msgstr ""
 #: src/olympia/browse/templates/browse/personas/category_landing.html:21 src/olympia/browse/templates/browse/personas/category_landing.html:23
 #: src/olympia/browse/templates/browse/personas/category_landing.html:38 src/olympia/browse/templates/browse/personas/grid.html:7 src/olympia/browse/templates/browse/personas/grid.html:11
 #: src/olympia/browse/templates/browse/personas/mobile/base.html:7 src/olympia/browse/templates/browse/personas/mobile/category_landing.html:19 src/olympia/constants/base.py:180
-#: src/olympia/devhub/templates/devhub/personas/submit.html:13 src/olympia/editors/helpers.py:105 src/olympia/editors/templates/editors/base.html:26
+#: src/olympia/devhub/templates/devhub/personas/submit.html:13 src/olympia/editors/helpers.py:107 src/olympia/editors/templates/editors/base.html:26
 #: src/olympia/editors/templates/editors/performance.html:73 src/olympia/search/templates/search/personas.html:39 src/olympia/templates/menu_links.html:9
 msgid "Themes"
 msgstr "Thema’s"
@@ -1358,7 +1356,7 @@ msgstr "Meer add-ons"
 msgid "Highest Rated"
 msgstr "Best gewaardeerd"
 
-#: src/olympia/addons/templates/addons/mobile/home.html:74 src/olympia/amo/templates/amo/side_nav.html:5 src/olympia/amo/templates/amo/site_nav.html:27 src/olympia/amo/templates/amo/site_nav.html:57
+#: src/olympia/addons/templates/addons/mobile/home.html:74 src/olympia/amo/templates/amo/side_nav.html:5 src/olympia/amo/templates/amo/site_nav.html:27 src/olympia/amo/templates/amo/site_nav.html:55
 #: src/olympia/bandwagon/views.py:97 src/olympia/browse/views.py:57 src/olympia/browse/views.py:67 src/olympia/browse/templates/browse/personas/mobile/category_landing.html:65
 #: src/olympia/search/forms.py:15 src/olympia/search/forms.py:87
 msgid "Newest"
@@ -1372,90 +1370,90 @@ msgstr "Probeer deze!"
 msgid "Theme Info &raquo;"
 msgstr "Thema-informatie &raquo;"
 
-#: src/olympia/amo/context_processors.py:39 src/olympia/devhub/templates/devhub/nav.html:43
+#: src/olympia/amo/context_processors.py:37 src/olympia/devhub/templates/devhub/nav.html:43
 msgid "Tools"
 msgstr "Hulpmiddelen"
 
-#: src/olympia/amo/context_processors.py:48 src/olympia/discovery/templates/discovery/pane_account.html:8 src/olympia/users/templates/users/includes/navigation.html:2
+#: src/olympia/amo/context_processors.py:47 src/olympia/discovery/templates/discovery/pane_account.html:8 src/olympia/users/templates/users/includes/navigation.html:2
 msgid "My Profile"
 msgstr "Mijn profiel"
 
-#: src/olympia/amo/context_processors.py:54 src/olympia/users/templates/users/edit.html:5 src/olympia/users/templates/users/includes/navigation.html:3
+#: src/olympia/amo/context_processors.py:53 src/olympia/users/templates/users/edit.html:5 src/olympia/users/templates/users/includes/navigation.html:3
 msgid "Account Settings"
 msgstr "Accountinstellingen"
 
-#: src/olympia/amo/context_processors.py:57 src/olympia/discovery/templates/discovery/pane_account.html:11 src/olympia/users/templates/users/profile.html:83
+#: src/olympia/amo/context_processors.py:56 src/olympia/discovery/templates/discovery/pane_account.html:11 src/olympia/users/templates/users/profile.html:83
 #: src/olympia/users/templates/users/includes/navigation.html:4
 msgid "My Collections"
 msgstr "Mijn collecties"
 
-#: src/olympia/amo/context_processors.py:62 src/olympia/discovery/templates/discovery/pane_account.html:10 src/olympia/users/templates/users/includes/navigation.html:7
+#: src/olympia/amo/context_processors.py:61 src/olympia/discovery/templates/discovery/pane_account.html:10 src/olympia/users/templates/users/includes/navigation.html:7
 msgid "My Favorites"
 msgstr "Mijn favorieten"
 
-#: src/olympia/amo/context_processors.py:67 src/olympia/discovery/templates/discovery/pane_account.html:13 src/olympia/templates/impala/user_login.html:14
+#: src/olympia/amo/context_processors.py:66 src/olympia/discovery/templates/discovery/pane_account.html:13 src/olympia/templates/impala/user_login.html:14
 #: src/olympia/templates/mobile/header_auth.html:5
 msgid "Log out"
 msgstr "Afmelden"
 
-#: src/olympia/amo/context_processors.py:72 src/olympia/devhub/templates/devhub/addons/dashboard.html:4
+#: src/olympia/amo/context_processors.py:71 src/olympia/devhub/templates/devhub/addons/dashboard.html:4
 msgid "Manage My Submissions"
 msgstr "Mijn bijdragen beheren"
 
-#: src/olympia/amo/context_processors.py:75 src/olympia/devhub/templates/devhub/nav.html:27 src/olympia/devhub/templates/devhub/addons/dashboard.html:25
+#: src/olympia/amo/context_processors.py:74 src/olympia/devhub/templates/devhub/nav.html:27 src/olympia/devhub/templates/devhub/addons/dashboard.html:25
 #: src/olympia/devhub/templates/devhub/addons/submit/base.html:4
 msgid "Submit a New Add-on"
 msgstr "Een nieuwe add-on indienen"
 
-#: src/olympia/amo/context_processors.py:77 src/olympia/browse/templates/browse/personas/base.html:50 src/olympia/devhub/templates/devhub/index.html:24
+#: src/olympia/amo/context_processors.py:76 src/olympia/browse/templates/browse/personas/base.html:50 src/olympia/devhub/templates/devhub/index.html:24
 #: src/olympia/devhub/templates/devhub/addons/dashboard.html:29
 msgid "Submit a New Theme"
 msgstr "Een nieuw thema indienen"
 
-#: src/olympia/amo/context_processors.py:79 src/olympia/amo/templates/amo/site_nav.html:87 src/olympia/devhub/helpers.py:36 src/olympia/devhub/helpers.py:68 src/olympia/devhub/helpers.py:102
+#: src/olympia/amo/context_processors.py:78 src/olympia/amo/templates/amo/site_nav.html:85 src/olympia/devhub/helpers.py:36 src/olympia/devhub/helpers.py:68 src/olympia/devhub/helpers.py:102
 #: src/olympia/templates/footer.html:6 src/olympia/templates/menu_links.html:14
 msgid "Developer Hub"
 msgstr "Ontwikkelaarshub"
 
-#: src/olympia/amo/context_processors.py:83 src/olympia/devhub/views.py:1792
+#: src/olympia/amo/context_processors.py:81 src/olympia/devhub/views.py:1796
 msgid "Manage API Keys"
 msgstr "API-sleutels beheren"
 
-#: src/olympia/amo/context_processors.py:88 src/olympia/editors/helpers.py:82 src/olympia/editors/helpers.py:102 src/olympia/editors/templates/editors/base.html:10
+#: src/olympia/amo/context_processors.py:86 src/olympia/editors/helpers.py:84 src/olympia/editors/helpers.py:104 src/olympia/editors/templates/editors/base.html:10
 msgid "Editor Tools"
 msgstr "Editorhulpmiddelen"
 
-#: src/olympia/amo/context_processors.py:92
+#: src/olympia/amo/context_processors.py:90
 msgid "Admin Tools"
 msgstr "Beheerhulpmiddelen"
 
-#: src/olympia/amo/fields.py:15
+#: src/olympia/amo/fields.py:20
 msgid "Incorrect, please try again."
 msgstr "Onjuist, probeer het opnieuw."
 
-#: src/olympia/amo/fields.py:16
+#: src/olympia/amo/fields.py:21
 msgid "Error verifying input, please try again."
 msgstr "Fout bij controleren invoer, probeer het opnieuw."
 
-#: src/olympia/amo/fields.py:32
+#: src/olympia/amo/fields.py:37
 msgid "This must be a valid hex color code, such as #000000."
 msgstr "Dit dient een geldige hex-kleurcode te zijn, zoals #000000."
 
-#: src/olympia/amo/fields.py:58
+#: src/olympia/amo/fields.py:63
 msgid "Enter at least one value."
 msgstr "Voer ten minste één waarde in."
 
-#: src/olympia/amo/helpers.py:162 src/olympia/amo/templates/amo/site_nav.html:61 src/olympia/bandwagon/templates/bandwagon/add.html:9
+#: src/olympia/amo/helpers.py:162 src/olympia/amo/templates/amo/site_nav.html:59 src/olympia/bandwagon/templates/bandwagon/add.html:9
 #: src/olympia/bandwagon/templates/bandwagon/collection_detail.html:15 src/olympia/bandwagon/templates/bandwagon/delete.html:9 src/olympia/bandwagon/templates/bandwagon/edit.html:15
 #: src/olympia/bandwagon/templates/bandwagon/user_listing.html:18 src/olympia/bandwagon/templates/bandwagon/user_listing.html:21
 #: src/olympia/bandwagon/templates/bandwagon/impala/collection_listing.html:12 src/olympia/bandwagon/templates/bandwagon/impala/collection_listing.html:20
 #: src/olympia/bandwagon/templates/bandwagon/impala/collection_listing.html:24 src/olympia/bandwagon/templates/bandwagon/impala/collection_sidebar.html:3
 #: src/olympia/bandwagon/templates/bandwagon/includes/collection_sidebar.html:2 src/olympia/bandwagon/templates/bandwagon/mobile/collection_listing.html:3
-#: src/olympia/stats/templates/stats/stats.html:77 src/olympia/templates/menu_links.html:12
+#: src/olympia/stats/templates/stats/stats.html:33 src/olympia/templates/menu_links.html:12
 msgid "Collections"
 msgstr "Collecties"
 
-#: src/olympia/amo/helpers.py:171 src/olympia/amo/templates/amo/site_nav.html:85 src/olympia/browse/templates/browse/language_tools.html:3
+#: src/olympia/amo/helpers.py:171 src/olympia/amo/templates/amo/site_nav.html:83 src/olympia/browse/templates/browse/language_tools.html:3
 msgid "Dictionaries & Language Packs"
 msgstr "Woordenboeken en taalpakketten"
 
@@ -1607,8 +1605,8 @@ msgstr "Superbeoordeling aangevraagd"
 msgid "Comment on {addon} {version}."
 msgstr "Opmerking over {addon} {version}."
 
-#: src/olympia/amo/log.py:236 src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:19 src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:47
-#: src/olympia/editors/helpers.py:511 src/olympia/editors/templates/editors/themes/history_table.html:11
+#: src/olympia/amo/log.py:236 src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:17 src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:45
+#: src/olympia/editors/helpers.py:584 src/olympia/editors/templates/editors/themes/history_table.html:11
 msgid "Comment"
 msgstr "Opmerking"
 
@@ -1764,7 +1762,7 @@ msgstr "Escalatie door beoordelaar"
 
 #: src/olympia/amo/log.py:442
 msgid "Video removed from {addon} because of a problem with the video. "
-msgstr "Video van {addon} verwijderd vanwege een probleem met de video."
+msgstr ""
 
 #: src/olympia/amo/log.py:444
 msgid "Video removed"
@@ -1918,7 +1916,6 @@ msgstr "Oeps"
 #, python-format
 msgid "<h1>Oops!  We had an error.</h1> <p>We'll get to fixing that soon.</p> <p> You can try refreshing the page, or head back to the <a href=\"%(home)s\">Add-ons homepage</a>. </p>"
 msgstr ""
-"<h1>Oeps! Er is een fout opgetreden.</h1> <p>Dat zullen we snel repareren</p> <p>U kunt proberen de pagina te vernieuwen, of teruggaan naar de <a href=\"%(home)s\">startpagina van Add-ons</a>.</p>"
 
 #: src/olympia/amo/templates/amo/license_link.html:10
 msgid "Some rights reserved"
@@ -1940,7 +1937,7 @@ msgstr "Vorige"
 #: src/olympia/amo/templates/amo/mobile/paginator.html:14 src/olympia/amo/templates/amo/mobile/paginator.html:16 src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:51
 #: src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:65 src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:78
 #: src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:91 src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:104
-#: src/olympia/discovery/templates/discovery/pane.html:45 src/olympia/discovery/templates/discovery/addons/detail.html:39 src/olympia/stats/templates/stats/stats.html:167
+#: src/olympia/discovery/templates/discovery/pane.html:45 src/olympia/discovery/templates/discovery/addons/detail.html:39 src/olympia/stats/templates/stats/stats.html:169
 msgid "Next"
 msgstr "Volgende"
 
@@ -1974,7 +1971,7 @@ msgstr ""
 "\">andere woorden proberen</a> of <a href=\"#\" id=\"recaptcha_audio\">een ander soort captcha proberen</a>. </p>"
 
 #: src/olympia/amo/templates/amo/side_nav.html:4 src/olympia/amo/templates/amo/side_nav.html:12 src/olympia/amo/templates/amo/site_nav.html:4 src/olympia/amo/templates/amo/site_nav.html:26
-#: src/olympia/browse/views.py:56 src/olympia/browse/views.py:66 src/olympia/browse/views.py:237 src/olympia/browse/views.py:282 src/olympia/search/forms.py:86
+#: src/olympia/browse/views.py:56 src/olympia/browse/views.py:66 src/olympia/browse/views.py:204 src/olympia/browse/views.py:249 src/olympia/search/forms.py:86
 msgid "Top Rated"
 msgstr "Best beoordeeld"
 
@@ -1989,38 +1986,38 @@ msgstr "Verkennen"
 msgid "Extensions"
 msgstr "Extensies"
 
-#: src/olympia/amo/templates/amo/site_nav.html:45
+#: src/olympia/amo/templates/amo/site_nav.html:44
 msgid "Want more customization? Try <b>Complete Themes</b>"
 msgstr "Wilt u meer aanpassingen? Probeer <b>Volledige thema’s</b>"
 
-#: src/olympia/amo/templates/amo/site_nav.html:56 src/olympia/bandwagon/views.py:96
+#: src/olympia/amo/templates/amo/site_nav.html:54 src/olympia/bandwagon/views.py:96
 msgid "Most Followers"
 msgstr "Meeste volgers"
 
-#: src/olympia/amo/templates/amo/site_nav.html:68 src/olympia/bandwagon/templates/bandwagon/impala/collection_sidebar.html:16
+#: src/olympia/amo/templates/amo/site_nav.html:66 src/olympia/bandwagon/templates/bandwagon/impala/collection_sidebar.html:16
 #: src/olympia/bandwagon/templates/bandwagon/includes/collection_sidebar.html:18
 msgid "Collections I've Made"
 msgstr "Mijn collecties"
 
-#: src/olympia/amo/templates/amo/site_nav.html:70 src/olympia/bandwagon/templates/bandwagon/user_listing.html:4 src/olympia/bandwagon/templates/bandwagon/impala/collection_sidebar.html:13
+#: src/olympia/amo/templates/amo/site_nav.html:68 src/olympia/bandwagon/templates/bandwagon/user_listing.html:4 src/olympia/bandwagon/templates/bandwagon/impala/collection_sidebar.html:13
 #: src/olympia/bandwagon/templates/bandwagon/includes/collection_sidebar.html:15
 msgid "Collections I'm Following"
 msgstr "Door mij gevolgde collecties"
 
-#: src/olympia/amo/templates/amo/site_nav.html:73 src/olympia/bandwagon/templates/bandwagon/impala/collection_sidebar.html:18
-#: src/olympia/bandwagon/templates/bandwagon/includes/collection_sidebar.html:20 src/olympia/users/models.py:512
+#: src/olympia/amo/templates/amo/site_nav.html:71 src/olympia/bandwagon/templates/bandwagon/impala/collection_sidebar.html:18
+#: src/olympia/bandwagon/templates/bandwagon/includes/collection_sidebar.html:20 src/olympia/users/models.py:521
 msgid "My Favorite Add-ons"
 msgstr "Mijn favoriete add-ons"
 
-#: src/olympia/amo/templates/amo/site_nav.html:78
+#: src/olympia/amo/templates/amo/site_nav.html:76
 msgid "More&hellip;"
 msgstr "Meer…"
 
-#: src/olympia/amo/templates/amo/site_nav.html:82
+#: src/olympia/amo/templates/amo/site_nav.html:80
 msgid "Add-ons for Mobile"
 msgstr "Add-ons voor Mobiel"
 
-#: src/olympia/amo/templates/amo/site_nav.html:86 src/olympia/browse/feeds.py:207 src/olympia/browse/templates/browse/search_tools.html:3 src/olympia/constants/base.py:176
+#: src/olympia/amo/templates/amo/site_nav.html:84 src/olympia/browse/feeds.py:207 src/olympia/browse/templates/browse/search_tools.html:3 src/olympia/constants/base.py:176
 #: src/olympia/templates/menu_links.html:10
 msgid "Search Tools"
 msgstr "Zoekhulpmiddelen"
@@ -2036,7 +2033,7 @@ msgid "Jump to first page"
 msgstr "Naar eerste pagina"
 
 #: src/olympia/amo/templates/amo/impala/paginator.html:22 src/olympia/amo/templates/amo/mobile/impala_paginator.html:12 src/olympia/discovery/templates/discovery/pane.html:44
-#: src/olympia/discovery/templates/discovery/addons/detail.html:38 src/olympia/stats/templates/stats/stats.html:164
+#: src/olympia/discovery/templates/discovery/addons/detail.html:38 src/olympia/stats/templates/stats/stats.html:166
 msgid "Previous"
 msgstr "Vorige"
 
@@ -2046,7 +2043,7 @@ msgstr "Naar laatste pagina"
 
 #. First and second arguments are the result range (e.g., 1-20);
 #. third argument is the number of total results (e.g., 1,000).
-#. third
+#. First and second arguments are the result range (e.g., 1-20);              third
 #. argument is the number of total results (e.g., 1,000).
 #: src/olympia/amo/templates/amo/impala/paginator.html:36 src/olympia/amo/templates/amo/mobile/impala_paginator.html:38
 #, python-format
@@ -2059,31 +2056,50 @@ msgid_plural "Page {n}"
 msgstr[0] "Pagina {n}"
 msgstr[1] "Pagina {n}"
 
-#: src/olympia/amo/templates/services/install.html:38
-#, python-format
-msgid "If you are not prompted to install %(addon_name)s in a moment, please <a href=\"%(addon_xpi)s\">click here</a>."
-msgstr "Als u zo dadelijk niet wordt gevraagd om %(addon_name)s te installeren, <a href=\"%(addon_xpi)s\">klik dan hier</a>."
-
-#: src/olympia/amo/tests/test_messages.py:57 src/olympia/amo/tests/test_messages.py:58 src/olympia/reviews/forms.py:25 src/olympia/reviews/forms.py:50 src/olympia/reviews/templates/reviews/add.html:56
+#: src/olympia/amo/tests/test_messages.py:56 src/olympia/amo/tests/test_messages.py:57 src/olympia/reviews/forms.py:25 src/olympia/reviews/forms.py:50 src/olympia/reviews/templates/reviews/add.html:56
 #: src/olympia/reviews/templates/reviews/reply.html:30
 msgid "Title"
 msgstr "Titel"
 
-#: src/olympia/amo/tests/test_messages.py:57 src/olympia/amo/tests/test_messages.py:58
+#: src/olympia/amo/tests/test_messages.py:56 src/olympia/amo/tests/test_messages.py:57
 msgid "Body"
 msgstr "Bericht"
 
-#: src/olympia/amo/tests/test_messages.py:59
+#: src/olympia/amo/tests/test_messages.py:58
 msgid "Another Title"
 msgstr "Andere titel"
 
-#: src/olympia/amo/tests/test_messages.py:59
+#: src/olympia/amo/tests/test_messages.py:58
 msgid "Another Body"
 msgstr "Ander bericht"
 
-#: src/olympia/api/views.py:255
-msgid "Not implemented yet."
-msgstr "Nog niet geïmplementeerd."
+#: src/olympia/api/authentication.py:76
+msgid "Signature has expired."
+msgstr ""
+
+#: src/olympia/api/authentication.py:79
+msgid "Error decoding signature."
+msgstr ""
+
+#: src/olympia/api/authentication.py:82
+msgid "Invalid JWT Token."
+msgstr ""
+
+#: src/olympia/api/authentication.py:130
+msgid "Invalid Authorization header. No credentials provided."
+msgstr ""
+
+#: src/olympia/api/authentication.py:133
+msgid "Invalid Authorization header. Credentials string should not contain spaces."
+msgstr ""
+
+#: src/olympia/api/fields.py:29
+msgid "The field must have a length of at least {num} characters."
+msgstr ""
+
+#: src/olympia/api/fields.py:31
+msgid "The language code {lang_code} is invalid."
+msgstr ""
 
 #: src/olympia/applications/views.py:39 src/olympia/applications/templates/applications/appversions.html:3
 msgid "Application Versions"
@@ -2103,7 +2119,7 @@ msgstr ""
 "Bij Mozilla Add-ons ingediende add-ons dienen een manifest-bestand te bevatten dat ten minste één van de onderstaande toepassingen ondersteunt. Alleen de hieronder vermelde versies zijn voor deze "
 "toepassingen toegestaan."
 
-#: src/olympia/applications/templates/applications/appversions.html:25
+#: src/olympia/applications/templates/applications/appversions.html:25 src/olympia/editors/helpers.py:361
 msgid "GUID"
 msgstr "GUID"
 
@@ -2217,8 +2233,8 @@ msgstr "Favoriet"
 msgid "Remove from favorites"
 msgstr "Verwijderen uit favorieten"
 
-#: src/olympia/bandwagon/views.py:98 src/olympia/bandwagon/views.py:191 src/olympia/browse/views.py:58 src/olympia/browse/views.py:69 src/olympia/browse/views.py:458 src/olympia/devhub/views.py:74
-#: src/olympia/devhub/views.py:82 src/olympia/devhub/templates/devhub/addons/edit/basic.html:20 src/olympia/editors/templates/editors/leaderboard.html:24
+#: src/olympia/bandwagon/views.py:98 src/olympia/bandwagon/views.py:191 src/olympia/browse/views.py:58 src/olympia/browse/views.py:69 src/olympia/browse/views.py:425 src/olympia/devhub/views.py:72
+#: src/olympia/devhub/views.py:80 src/olympia/devhub/templates/devhub/addons/edit/basic.html:20 src/olympia/editors/templates/editors/leaderboard.html:24
 #: src/olympia/editors/templates/editors/themes/queue_list.html:48 src/olympia/search/forms.py:17 src/olympia/search/forms.py:89 src/olympia/users/templates/users/vcard.html:5
 msgid "Name"
 msgstr "Naam"
@@ -2227,7 +2243,7 @@ msgstr "Naam"
 msgid "Recently Popular"
 msgstr "Onlangs populair"
 
-#: src/olympia/bandwagon/views.py:189 src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:18
+#: src/olympia/bandwagon/views.py:189 src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:16
 msgid "Added"
 msgstr "Toegevoegd"
 
@@ -2241,8 +2257,8 @@ msgstr "Collectie aangemaakt!"
 
 #: src/olympia/bandwagon/views.py:316
 #, python-format
-msgid "Your new collection is shown below. You can <ahref=\"%(url)s\">edit additional settings</a> if you'dlike."
-msgstr "Uw nieuwe collectie wordt hieronder weergegeven. U kunt desgewenst <a href=\"%(url)s\">aanvullende instellingen bewerken</a>."
+msgid "Your new collection is shown below. You can <a href=\"%(url)s\">edit additional settings</a> if you'd like."
+msgstr ""
 
 #: src/olympia/bandwagon/views.py:322
 msgid "Collection updated!"
@@ -2369,8 +2385,8 @@ msgid_plural "%(num)s Add-ons in this Collection"
 msgstr[0] "%(num)s add-on in deze collectie"
 msgstr[1] "%(num)s add-ons in deze collectie"
 
-#: src/olympia/bandwagon/templates/bandwagon/collection_detail.html:125 src/olympia/compat/templates/compat/index.html:25 src/olympia/compat/templates/compat/reporter_detail.html:29
-#: src/olympia/files/templates/files/viewer.html:29 src/olympia/templates/amo_footer.html:17 src/olympia/templates/includes/lang_switcher.html:10
+#: src/olympia/bandwagon/templates/bandwagon/collection_detail.html:125 src/olympia/compat/templates/compat/reporter_detail.html:29 src/olympia/files/templates/files/viewer.html:29
+#: src/olympia/templates/amo_footer.html:17 src/olympia/templates/includes/lang_switcher.html:10
 msgid "Go"
 msgstr "Start"
 
@@ -2407,8 +2423,6 @@ msgid ""
 "Add-ons that you mark as favorites using the <b>Add to Favorites</b> feature appear below. This collection is currently <b>private</b>, which means only you can see it.  If you would like everyone "
 "to be able to see your favorites, click the button below to make it public."
 msgstr ""
-"Middels de functie <b>Aan Favorieten toevoegen</b> als favoriet gemarkeerde add-ons verschijnen hieronder. Deze collectie is momenteel <b>privé</b>, wat betekent dat alleen u hem kan zien. Als u "
-"wilt dat iedereen uw favorieten kan zien, klik dan op onderstaande knop om de collectie openbaar te maken."
 
 #: src/olympia/bandwagon/templates/bandwagon/collection_detail.html:196
 msgid "My favorite add-ons"
@@ -2428,9 +2442,9 @@ msgid_plural "<span>%(followers)s</span> followers"
 msgstr[0] "<span>%(followers)s</span> volger"
 msgstr[1] "<span>%(followers)s</span> volgers"
 
-#. People "follow" collections to get notified of updates.
-#. Like
+#. People "follow" collections to get notified of updates.                    Like
 #. Twitter followers.
+#. People "follow" collections to get notified of updates.
 #. Like Twitter followers.
 #: src/olympia/bandwagon/templates/bandwagon/collection_listing_items.html:10 src/olympia/bandwagon/templates/bandwagon/impala/collection_listing_items.html:18
 #, python-format
@@ -2439,8 +2453,7 @@ msgid_plural "%(num)s weekly followers"
 msgstr[0] "%(num)s wekelijkse volger"
 msgstr[1] "%(num)s wekelijkse volgers"
 
-#. People "follow" collections to get notified of updates.
-#. Like
+#. People "follow" collections to get notified of updates.                    Like
 #. Twitter followers.
 #: src/olympia/bandwagon/templates/bandwagon/collection_listing_items.html:18
 #, python-format
@@ -2449,9 +2462,9 @@ msgid_plural "%(num)s monthly followers"
 msgstr[0] "%(num)s maandelijkse volger"
 msgstr[1] "%(num)s maandelijkse volgers"
 
-#. People "follow" collections to get notified of updates.
-#. Like
+#. People "follow" collections to get notified of updates.                    Like
 #. Twitter followers.
+#. People "follow" collections to get notified of updates.
 #. Like Twitter followers.
 #: src/olympia/bandwagon/templates/bandwagon/collection_listing_items.html:26 src/olympia/bandwagon/templates/bandwagon/impala/collection_listing_items.html:26
 #, python-format
@@ -2543,7 +2556,7 @@ msgid "Remove this user as a contributor"
 msgstr "Deze gebruiker verwijderen als medewerker"
 
 #: src/olympia/bandwagon/templates/bandwagon/edit_contributors.html:18 src/olympia/bandwagon/templates/bandwagon/edit_contributors.html:43
-#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:20 src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:48
+#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:18 src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:46
 #: src/olympia/devhub/templates/devhub/addons/ajax_compat_update.html:19
 msgid "Remove"
 msgstr "Verwijderen"
@@ -2557,8 +2570,6 @@ msgid ""
 "You can add multiple contributors to this collection.  A contributor can add and remove add-ons from this collection, but cannot change its name or description.  To add a contributor, enter their "
 "email in the box below. Contributors must have a Mozilla Add-ons account."
 msgstr ""
-"U kunt meerdere medewerkers aan deze collectie toevoegen. Een medewerker kan add-ons toevoegen en verwijderen, maar kan de naam of de beschrijving van de collectie niet wijzigen. Voer om een "
-"medewerker toe te voegen diens e-mailadres in onderstaand veld in. Medewerkers dienen een Mozilla Add-ons-account te hebben."
 
 #: src/olympia/bandwagon/templates/bandwagon/edit_contributors.html:40
 msgid "User"
@@ -2594,7 +2605,7 @@ msgid "<b>Warning:</b> By changing the owner of this collection, you will no lon
 msgstr "<b>Waarschuwing:</b> door het wijzigen van de eigenaar van deze collectie kunt u deze niet meer bewerken. U kunt alleen nog add-ons eraan toevoegen en eruit verwijderen."
 
 #: src/olympia/bandwagon/templates/bandwagon/edit_contributors.html:83 src/olympia/devhub/templates/devhub/addons/forms_shared/media.html:157
-#: src/olympia/devhub/templates/devhub/addons/submit/describe.html:69 src/olympia/devhub/templates/devhub/addons/submit/license.html:60 src/olympia/devhub/templates/devhub/addons/submit/upload.html:78
+#: src/olympia/devhub/templates/devhub/addons/submit/describe.html:69 src/olympia/devhub/templates/devhub/addons/submit/license.html:60 src/olympia/devhub/templates/devhub/addons/submit/upload.html:70
 #: src/olympia/devhub/templates/devhub/payments/tier.html:17 src/olympia/editors/templates/editors/themes/themes.html:111 src/olympia/editors/templates/editors/themes/themes.html:128
 #: src/olympia/editors/templates/editors/themes/themes.html:134 src/olympia/editors/templates/editors/themes/themes.html:141 src/olympia/users/templates/users/fxa_migration_prompt_content.html:10
 #: src/olympia/users/templates/users/login_form.html:42 src/olympia/users/templates/users/mobile/login.html:57
@@ -2666,44 +2677,42 @@ msgstr "Opnieuw instellen"
 
 #: src/olympia/bandwagon/templates/bandwagon/includes/addedit.html:53
 msgid "PNG and JPG supported.  Image will be resized to 32x32."
-msgstr "PNG en JPG worden ondersteund. Afbeeldingsgrootte wordt bijgesteld tot 32x32."
+msgstr ""
 
 #: src/olympia/bandwagon/templates/bandwagon/includes/addedit_errors.html:3
 msgid "There are errors in this form.  Please correct them below."
-msgstr "Er zitten fouten in dit formulier. Corrigeer ze hieronder."
+msgstr ""
 
 #: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:2
 msgid "Add-ons in Your Collection"
 msgstr "Add-ons in uw collectie"
 
 #: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:4
-msgid ""
-"To include an add-on in this collection, enter its name in the box below and hit enter.  You can also use the <strong>Add to Collection</strong> links throughout the site to include add-ons later."
+msgid "To include an add-on in this collection, enter its name in the box below and hit enter."
 msgstr ""
-"Voer om een add-on in deze collectie op te nemen de naam in onderstaand veld in en druk op Enter. U kunt ook de koppelingen <strong>Aan collectie toevoegen</strong> op de website gebruiken om add-"
-"ons later toe te voegen."
 
-#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:17 src/olympia/constants/base.py:400 src/olympia/devhub/templates/devhub/addons/activity.html:62
+#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:15 src/olympia/constants/base.py:400 src/olympia/devhub/templates/devhub/addons/activity.html:62
+#: src/olympia/editors/helpers.py:273 src/olympia/editors/helpers.py:360
 msgid "Add-on"
 msgstr "Add-on"
 
-#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:26
+#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:24
 msgid "Enter the name of the add-on to include"
 msgstr "Voer de naam van de op te nemen add-on in"
 
-#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:28
+#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:26
 msgid "Add to Collection"
 msgstr "Toevoegen aan collectie"
 
-#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:45 src/olympia/editors/helpers.py:936 src/olympia/editors/helpers.py:956
+#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:43 src/olympia/editors/helpers.py:1016 src/olympia/editors/helpers.py:1036
 msgid "Pending"
 msgstr "In behandeling"
 
-#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:47
+#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:45
 msgid "Add a comment"
 msgstr "Opmerking toevoegen"
 
-#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:48
+#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:46
 msgid "Remove this add-on from the collection"
 msgstr "Deze add-on uit de collectie verwijderen"
 
@@ -2756,8 +2765,6 @@ msgid ""
 "When Mozilla becomes aware of add-ons, plugins, or other third-party software that seriously compromises %(app)s security, stability, or performance and meets <a href=\"%(criteria)s\">certain "
 "criteria</a>, the software may be blocked from general use.  For more information, please read <a href=\"%(support)s\">this support article</a>."
 msgstr ""
-"Wanneer Mozilla op de hoogte komt van add-ons, plug-ins of andere software van derden die een serieuze bedreiging vormen voor de veiligheid, stabiliteit of prestaties van %(app)s en voldoen aan <a "
-"href=\"%(criteria)s\">bepaalde criteria</a>, dan kan de software worden geblokkeerd voor algemeen gebruik. Lees voor meer informatie <a href=\"%(support)s\">dit ondersteuningsartikel</a>."
 
 #: src/olympia/blocklist/templates/blocklist/blocked_detail.html:44
 #, python-format
@@ -2814,12 +2821,12 @@ msgstr "Zoekhulpmiddelen"
 msgid "Most Users"
 msgstr "Meeste gebruikers"
 
-#: src/olympia/browse/views.py:61 src/olympia/browse/views.py:72 src/olympia/browse/views.py:279 src/olympia/browse/templates/browse/personas/mobile/category_landing.html:63
+#: src/olympia/browse/views.py:61 src/olympia/browse/views.py:72 src/olympia/browse/views.py:246 src/olympia/browse/templates/browse/personas/mobile/category_landing.html:63
 #: src/olympia/discovery/templates/discovery/pane.html:67 src/olympia/search/forms.py:92
 msgid "Up & Coming"
 msgstr "Aankomend"
 
-#: src/olympia/browse/views.py:460 src/olympia/devhub/views.py:76 src/olympia/devhub/views.py:83 src/olympia/discovery/templates/discovery/addons/detail.html:66
+#: src/olympia/browse/views.py:427 src/olympia/devhub/views.py:74 src/olympia/devhub/views.py:81 src/olympia/discovery/templates/discovery/addons/detail.html:66
 msgid "Created"
 msgstr "Aangemaakt"
 
@@ -3007,8 +3014,8 @@ msgid_plural "See all %(cnt)s extensions in %(name)s &raquo;"
 msgstr[0] "Bekijk %(cnt)s extensie in %(name)s &raquo;"
 msgstr[1] "Bekijk alle %(cnt)s extensies in %(name)s &raquo;"
 
-#: src/olympia/browse/templates/browse/mobile/extensions.html:13 src/olympia/compat/templates/compat/index.html:82 src/olympia/devhub/templates/devhub/devhub_search.html:24
-#: src/olympia/devhub/templates/devhub/addons/activity.html:47 src/olympia/search/templates/search/no_results.html:4 src/olympia/search/templates/search/mobile/results.html:36
+#: src/olympia/browse/templates/browse/mobile/extensions.html:13 src/olympia/devhub/templates/devhub/devhub_search.html:24 src/olympia/devhub/templates/devhub/addons/activity.html:47
+#: src/olympia/search/templates/search/no_results.html:4 src/olympia/search/templates/search/mobile/results.html:36
 msgid "No results found."
 msgstr "Geen resultaten gevonden."
 
@@ -3095,7 +3102,7 @@ msgstr "&laquo; Alle thema’s"
 msgid "All"
 msgstr "Alles"
 
-#: src/olympia/compat/forms.py:22 src/olympia/search/views.py:525
+#: src/olympia/compat/forms.py:22 src/olympia/editors/templates/editors/base.html:69 src/olympia/search/views.py:518
 msgid "All Add-ons"
 msgstr "Alle add-ons"
 
@@ -3106,53 +3113,6 @@ msgstr "Binair"
 #: src/olympia/compat/forms.py:24
 msgid "Non-binary"
 msgstr "Niet binair"
-
-#. Review points sources other than add-ons and themes.
-#: src/olympia/compat/views.py:87 src/olympia/constants/base.py:388 src/olympia/devhub/forms.py:162 src/olympia/editors/templates/editors/performance.html:75
-msgid "Other"
-msgstr "Overig"
-
-#: src/olympia/compat/templates/compat/index.html:4
-msgid "Add-on Compatibility Report for {app} {version}"
-msgstr "Add-on-compatibiliteitsrapport voor {app} {version}"
-
-#: src/olympia/compat/templates/compat/index.html:11
-msgid "{app} {version} Compatibility"
-msgstr "Compatibiliteit van {app} {version}"
-
-#: src/olympia/compat/templates/compat/index.html:17
-#, python-format
-msgid "Top 95%% compatible with previous version"
-msgstr "Top 95%% compatibel met vorige versie"
-
-#: src/olympia/compat/templates/compat/index.html:18
-#, python-format
-msgid "Top 95%% of all add-ons"
-msgstr "Top 95%% van alle add-ons"
-
-#: src/olympia/compat/templates/compat/index.html:19
-msgid "All active add-ons"
-msgstr "Alle actieve add-ons"
-
-#: src/olympia/compat/templates/compat/index.html:23 src/olympia/constants/base.py:401
-msgid "App"
-msgstr "App"
-
-#: src/olympia/compat/templates/compat/index.html:55
-msgid "Details for add-ons compatible with previous version:"
-msgstr "Details voor met de vorige versie compatibele add-ons:"
-
-#: src/olympia/compat/templates/compat/index.html:57
-msgid "Show all versions"
-msgstr "Alle versies weergeven"
-
-#: src/olympia/compat/templates/compat/index.html:59
-msgid "Details for add-ons compatible with all versions:"
-msgstr "Details voor met alle versies compatibele add-ons:"
-
-#: src/olympia/compat/templates/compat/index.html:61
-msgid "Show previous version only"
-msgstr "Alleen vorige versie weergeven"
 
 #: src/olympia/compat/templates/compat/reporter.html:3
 msgid "Add-on Compatibility Reports"
@@ -3207,8 +3167,8 @@ msgstr "Filteren op toepassing"
 msgid "Report Type"
 msgstr "Rapporttype"
 
-#: src/olympia/compat/templates/compat/reporter_detail.html:47 src/olympia/devhub/forms.py:784 src/olympia/devhub/templates/devhub/addons/ajax_compat_update.html:17 src/olympia/editors/forms.py:108
-#: src/olympia/zadmin/forms.py:45
+#: src/olympia/compat/templates/compat/reporter_detail.html:47 src/olympia/devhub/forms.py:785 src/olympia/devhub/templates/devhub/addons/ajax_compat_update.html:17 src/olympia/editors/forms.py:108
+#: src/olympia/editors/forms.py:248 src/olympia/zadmin/forms.py:45
 msgid "Application"
 msgstr "Toepassing"
 
@@ -3296,7 +3256,8 @@ msgstr "Voorlopig beoordeeld"
 msgid "Preliminarily Reviewed and Awaiting Full Review"
 msgstr "Voorlopig beoordeeld en wacht op volledige beoordeling"
 
-#: src/olympia/constants/base.py:33 src/olympia/editors/helpers.py:924 src/olympia/editors/templates/editors/themes/history_table.html:34
+#: src/olympia/constants/base.py:33 src/olympia/editors/forms.py:258 src/olympia/editors/helpers.py:73 src/olympia/editors/helpers.py:1004
+#: src/olympia/editors/templates/editors/themes/history_table.html:34
 msgid "Deleted"
 msgstr "Verwijderd"
 
@@ -3396,6 +3357,11 @@ msgstr "Vragen voordat gebruikers deze add-on downloaden"
 msgid "Ask before users can download this add-on"
 msgstr "Vragen voordat gebruikers deze add-on kunnen downloaden"
 
+#. Review points sources other than add-ons and themes.
+#: src/olympia/constants/base.py:388 src/olympia/devhub/forms.py:162 src/olympia/editors/templates/editors/performance.html:75
+msgid "Other"
+msgstr "Overig"
+
 #: src/olympia/constants/base.py:389
 msgid "Exception"
 msgstr "Uitzondering"
@@ -3407,6 +3373,10 @@ msgstr "Uitgave"
 #: src/olympia/constants/base.py:391
 msgid "Change"
 msgstr "Wijzigen"
+
+#: src/olympia/constants/base.py:401
+msgid "App"
+msgstr "App"
 
 #: src/olympia/constants/base.py:402
 msgid "Persona"
@@ -3558,7 +3528,7 @@ msgstr "Label"
 msgid "Duplicate"
 msgstr "Duplicaat"
 
-#: src/olympia/constants/editors.py:17 src/olympia/editors/helpers.py:502 src/olympia/editors/templates/editors/themes/queue.html:71 src/olympia/editors/templates/editors/themes/themes.html:94
+#: src/olympia/constants/editors.py:17 src/olympia/editors/helpers.py:575 src/olympia/editors/templates/editors/themes/queue.html:71 src/olympia/editors/templates/editors/themes/themes.html:94
 msgid "Reject"
 msgstr "Afwijzen"
 
@@ -3658,7 +3628,7 @@ msgstr "Solaris"
 msgid "Android"
 msgstr "Android"
 
-#: src/olympia/core/apps.py:19
+#: src/olympia/core/apps.py:21
 msgid "Core"
 msgstr "Kern"
 
@@ -3792,8 +3762,8 @@ msgid "Submit my add-on for manual review."
 msgstr "Mijn add-on voor beoordeling indienen."
 
 #: src/olympia/devhub/forms.py:537
-msgid "Do not list my add-on on this site (beta)"
-msgstr "Mijn add-on niet op deze website vermelden (bèta)"
+msgid "Do not list my add-on on this site"
+msgstr ""
 
 #: src/olympia/devhub/forms.py:538
 msgid "Check this option if you intend to distribute your add-on on your own and only need it to be signed by Mozilla."
@@ -3825,46 +3795,46 @@ msgstr "Een bestand met een versie die eindigt op a|alpha|b|beta|pre|rc en een o
 
 #: src/olympia/devhub/forms.py:592
 #, python-format
-msgid "Version %s already exists"
-msgstr "Versie %s bestaat al"
+msgid "Version %s already exists, or was uploaded before."
+msgstr ""
 
-#: src/olympia/devhub/forms.py:604
+#: src/olympia/devhub/forms.py:605
 msgid "Select a valid choice. That choice is not one of the available choices."
 msgstr "Selecteer een geldige keuze. Die keuze is niet beschikbaar."
 
-#: src/olympia/devhub/forms.py:610
+#: src/olympia/devhub/forms.py:611
 msgid "A file with a version ending with a|alpha|b|beta and an optional number is detected as beta."
 msgstr "Een bestand met een versie eindigend op a|alpha|b|beta en een optioneel nummer wordt als bèta gedetecteerd."
 
-#: src/olympia/devhub/forms.py:633
+#: src/olympia/devhub/forms.py:634
 msgid "You cannot upload any more files for this version."
 msgstr "U kunt geen bestanden meer uploaden voor deze versie."
 
-#: src/olympia/devhub/forms.py:639
+#: src/olympia/devhub/forms.py:640
 msgid "Version doesn't match"
 msgstr "Versie komt niet overeen"
 
-#: src/olympia/devhub/forms.py:668
+#: src/olympia/devhub/forms.py:669
 msgid "You cannot delete a file once the review process has started.  You must delete the whole version."
-msgstr "U kunt een bestand niet verwijderen als het beoordelingsproces is gestart. U dient de gehele versie te verwijderen."
+msgstr ""
 
-#: src/olympia/devhub/forms.py:688
+#: src/olympia/devhub/forms.py:689
 msgid "The platform All cannot be combined with specific platforms."
 msgstr "Het platform Alle kan niet met specifieke platformen worden gecombineerd."
 
-#: src/olympia/devhub/forms.py:693
+#: src/olympia/devhub/forms.py:694
 msgid "A platform can only be chosen once."
 msgstr "Een platform kan slechts één keer worden gekozen."
 
-#: src/olympia/devhub/forms.py:706
+#: src/olympia/devhub/forms.py:707
 msgid "A review type must be selected."
 msgstr "Er dient een beoordelingstype te worden geselecteerd."
 
-#: src/olympia/devhub/forms.py:788 src/olympia/editors/forms.py:114 src/olympia/zadmin/forms.py:49 src/olympia/zadmin/forms.py:52
+#: src/olympia/devhub/forms.py:789 src/olympia/editors/forms.py:114 src/olympia/editors/forms.py:254 src/olympia/zadmin/forms.py:49 src/olympia/zadmin/forms.py:52
 msgid "Select an application first"
 msgstr "Selecteer eerst een toepassing"
 
-#: src/olympia/devhub/forms.py:840
+#: src/olympia/devhub/forms.py:841
 msgid "There cannot be more than 3 required add-ons."
 msgstr "Er mogen niet meer dan 3 verplichte add-ons zijn."
 
@@ -3898,77 +3868,77 @@ msgstr[1] "{0} waarschuwingen"
 msgid "Review"
 msgstr "Beoordeling"
 
-#: src/olympia/devhub/tasks.py:551
+#: src/olympia/devhub/tasks.py:583
 #, python-format
 msgid "%s responded with %s (%s)."
 msgstr "%s heeft geantwoord met %s (%s)."
 
 # consistent w/ products (& verbindingen verlopen niet)
-#: src/olympia/devhub/tasks.py:555
+#: src/olympia/devhub/tasks.py:587
 #, python-format
 msgid "Connection to \"%s\" timed out."
 msgstr "Wachttijd voor verbinding met ‘%s’ verstreken."
 
-#: src/olympia/devhub/tasks.py:557
+#: src/olympia/devhub/tasks.py:589
 #, python-format
 msgid "Could not contact host at \"%s\"."
 msgstr "Kan geen verbinding maken met de host op ‘%s’."
 
-#: src/olympia/devhub/utils.py:104
+#: src/olympia/devhub/utils.py:105
 #, python-format
 msgid "Validation generated too many errors/warnings so %s messages were truncated. After addressing the visible messages, you'll be able to see the others."
 msgstr "De validatie leverde te veel fouten/waarschuwingen op, dus %s berichten zijn ingekort. Nadat de zichtbare berichten zijn geadresseerd kunt u de overige lezen."
 
-#: src/olympia/devhub/views.py:183
+#: src/olympia/devhub/views.py:181
 msgid "All My Add-ons"
 msgstr "Al mijn add-ons"
 
-#: src/olympia/devhub/views.py:210
+#: src/olympia/devhub/views.py:208
 msgid "All Activity"
 msgstr "Alle activiteit"
 
-#: src/olympia/devhub/views.py:211
+#: src/olympia/devhub/views.py:209
 msgid "Add-on Updates"
 msgstr "Add-on-updates"
 
-#: src/olympia/devhub/views.py:212
+#: src/olympia/devhub/views.py:210
 msgid "Add-on Status"
 msgstr "Add-on-status"
 
-#: src/olympia/devhub/views.py:213
+#: src/olympia/devhub/views.py:211
 msgid "User Collections"
 msgstr "Gebruikerscollecties"
 
-#: src/olympia/devhub/views.py:214 src/olympia/devhub/templates/devhub/docs/policies-maintenance.html:68 src/olympia/pages/templates/pages/dev_faq.html:38
+#: src/olympia/devhub/views.py:212 src/olympia/devhub/templates/devhub/docs/policies-maintenance.html:68 src/olympia/pages/templates/pages/dev_faq.html:38
 #: src/olympia/pages/templates/pages/dev_faq.html:484
 msgid "User Reviews"
 msgstr "Gebruikersbeoordelingen"
 
-#: src/olympia/devhub/views.py:327 src/olympia/devhub/views.py:331 src/olympia/devhub/views.py:484 src/olympia/devhub/views.py:513 src/olympia/devhub/views.py:564 src/olympia/devhub/views.py:1150
+#: src/olympia/devhub/views.py:325 src/olympia/devhub/views.py:329 src/olympia/devhub/views.py:484 src/olympia/devhub/views.py:513 src/olympia/devhub/views.py:564 src/olympia/devhub/views.py:1156
 msgid "Changes successfully saved."
 msgstr "Wijzigingen met succes opgeslagen."
 
-#: src/olympia/devhub/views.py:334 src/olympia/devhub/views.py:1631
+#: src/olympia/devhub/views.py:332 src/olympia/devhub/views.py:1637
 msgid "Please check the form for errors."
 msgstr "Controleer het formulier op fouten."
 
-#: src/olympia/devhub/views.py:346
+#: src/olympia/devhub/views.py:344
 msgid "Add-on cannot be deleted. Disable this add-on instead."
 msgstr "Add-on kan niet worden verwijderd. Schakel deze add-on uit."
 
-#: src/olympia/devhub/views.py:356
+#: src/olympia/devhub/views.py:354
 msgid "Theme deleted."
 msgstr "Thema verwijderd."
 
-#: src/olympia/devhub/views.py:356
+#: src/olympia/devhub/views.py:354
 msgid "Add-on deleted."
 msgstr "Add-on verwijderd."
 
-#: src/olympia/devhub/views.py:362
+#: src/olympia/devhub/views.py:360
 msgid "URL name was incorrect. Theme was not deleted."
 msgstr "URL-naam onjuist. Thema is niet verwijderd."
 
-#: src/olympia/devhub/views.py:367
+#: src/olympia/devhub/views.py:365
 msgid "URL name was incorrect. Add-on was not deleted."
 msgstr "URL-naam onjuist. Add-on is niet verwijderd."
 
@@ -3996,7 +3966,7 @@ msgstr "Add-on valideren"
 msgid "Check Add-on Compatibility"
 msgstr "Add-on-compatibiliteit controleren"
 
-#: src/olympia/devhub/views.py:808 src/olympia/signing/views.py:90
+#: src/olympia/devhub/views.py:808 src/olympia/signing/views.py:95
 msgid "You cannot submit this type of add-on"
 msgstr "U kunt dit type add-on niet indienen"
 
@@ -4026,33 +3996,33 @@ msgstr "Afbeeldingen dienen exact {0} pixels breed en {1} pixels hoog te zijn."
 msgid "There was an error uploading your preview."
 msgstr "Er is een fout opgetreden bij het uploaden van uw voorbeeld."
 
-#: src/olympia/devhub/views.py:1189
+#: src/olympia/devhub/views.py:1195
 #, python-format
 msgid "Version %s disabled."
 msgstr "Versie %s uitgeschakeld."
 
-#: src/olympia/devhub/views.py:1193
+#: src/olympia/devhub/views.py:1199
 #, python-format
 msgid "Version %s deleted."
 msgstr "Versie %s verwijderd."
 
-#: src/olympia/devhub/views.py:1203
+#: src/olympia/devhub/views.py:1209
 msgid "This upload has failed validation, and may lack complete validation results. Please take due care when reviewing it."
 msgstr "De validatie van deze upload is mislukt en er ontbreken mogelijk volledige validatieresultaten. Let goed op bij de beoordeling."
 
-#: src/olympia/devhub/views.py:1677
+#: src/olympia/devhub/views.py:1683
 msgid "Preliminary Review Requested."
 msgstr "Voorlopige beoordeling aangevraagd."
 
-#: src/olympia/devhub/views.py:1678
+#: src/olympia/devhub/views.py:1684
 msgid "Full Review Requested."
 msgstr "Volledige beoordeling aangevraagd."
 
-#: src/olympia/devhub/views.py:1779
+#: src/olympia/devhub/views.py:1783
 msgid "Your old credentials were revoked and are no longer valid. Be sure to update all API clients with the new credentials."
 msgstr "Uw oude referenties zijn ingetrokken en niet meer geldig. Zorg ervoor dat u alle API-clients bijwerkt met de nieuwe referenties."
 
-#: src/olympia/devhub/views.py:1797
+#: src/olympia/devhub/views.py:1801
 msgid "New API key created"
 msgstr "Nieuwe API-sleutel gemaakt"
 
@@ -4082,7 +4052,7 @@ msgstr "Terug naar add-ons"
 msgid "{0} :: Search"
 msgstr "{0} :: Zoeken"
 
-#: src/olympia/devhub/templates/devhub/devhub_search.html:6 src/olympia/devhub/templates/devhub/search.html:8 src/olympia/editors/forms.py:435 src/olympia/editors/forms.py:437
+#: src/olympia/devhub/templates/devhub/devhub_search.html:6 src/olympia/devhub/templates/devhub/search.html:8 src/olympia/editors/forms.py:534 src/olympia/editors/forms.py:536
 #: src/olympia/editors/templates/editors/queue.html:27 src/olympia/editors/templates/editors/themes/queue_list.html:14 src/olympia/search/templates/search/collections.html:17
 #: src/olympia/search/templates/search/personas.html:18 src/olympia/search/templates/search/results.html:18 src/olympia/search/templates/search/mobile/results.html:8
 #: src/olympia/templates/search.html:14 src/olympia/templates/impala/search.html:18
@@ -4145,12 +4115,12 @@ msgstr "Ga naar het <a href=\"https://developer.mozilla.org/Add-ons\">Mozilla De
 msgid "Start Making Add-ons"
 msgstr "Start met het maken van add-ons"
 
-#: src/olympia/devhub/templates/devhub/index.html:86 src/olympia/devhub/templates/devhub/addons/listing/items.html:25 src/olympia/devhub/templates/devhub/includes/addon_details.html:15
+#: src/olympia/devhub/templates/devhub/index.html:86 src/olympia/devhub/templates/devhub/addons/listing/items.html:25 src/olympia/devhub/templates/devhub/includes/addon_details.html:20
 #: src/olympia/devhub/templates/devhub/personas/edit.html:43
 msgid "Status:"
 msgstr "Status:"
 
-#: src/olympia/devhub/templates/devhub/index.html:90 src/olympia/devhub/templates/devhub/includes/addon_details.html:100
+#: src/olympia/devhub/templates/devhub/index.html:90 src/olympia/devhub/templates/devhub/includes/addon_details.html:87
 msgid "Visibility:"
 msgstr "Zichtbaarheid:"
 
@@ -4158,11 +4128,11 @@ msgstr "Zichtbaarheid:"
 msgid "Latest Version:"
 msgstr "Nieuwste versie:"
 
-#: src/olympia/devhub/templates/devhub/index.html:109 src/olympia/devhub/templates/devhub/includes/addon_details.html:145 src/olympia/devhub/templates/devhub/personas/edit.html:49
+#: src/olympia/devhub/templates/devhub/index.html:109 src/olympia/devhub/templates/devhub/includes/addon_details.html:131 src/olympia/devhub/templates/devhub/personas/edit.html:49
 msgid "Queue Position:"
 msgstr "Positie in wachtrij:"
 
-#: src/olympia/devhub/templates/devhub/index.html:110 src/olympia/devhub/templates/devhub/includes/addon_details.html:146 src/olympia/devhub/templates/devhub/personas/edit.html:50
+#: src/olympia/devhub/templates/devhub/index.html:110 src/olympia/devhub/templates/devhub/includes/addon_details.html:132 src/olympia/devhub/templates/devhub/personas/edit.html:50
 #, python-format
 msgid "%(position)s of %(total)s"
 msgstr "%(position)s van %(total)s"
@@ -4264,16 +4234,6 @@ msgstr "Na de upload wordt een aantal geautomatiseerde validatietests op uw best
 msgid "Do you want your add-on to be distributed on this site?"
 msgstr "Wilt u uw add-on op deze website laten verspreiden?"
 
-#: src/olympia/devhub/templates/devhub/validate_addon.html:49 src/olympia/devhub/templates/devhub/addons/submit/upload.html:30 src/olympia/devhub/templates/devhub/versions/add_file_modal.html:14
-#: src/olympia/devhub/templates/devhub/versions/add_file_modal.html:53 src/olympia/devhub/templates/devhub/versions/list.html:298
-msgid "Warning:"
-msgstr "Waarschuwing:"
-
-#: src/olympia/devhub/templates/devhub/validate_addon.html:50 src/olympia/devhub/templates/devhub/addons/submit/upload.html:31
-#, python-format
-msgid "Submission of unlisted add-ons for signing is currently in an open beta. Please <a href=\"%(url)s\" target=\"_blank\">report any bugs</a> that you encounter."
-msgstr "Indienen van niet-vermelde add-ons voor ondertekening bevindt zich momenteel in een open-bètafase. <a href=\"%(url)s\" target=\"_blank\">Meld eventuele bugs</a> die u tegenkomt."
-
 #. first parameter is a filename like lorem-ipsum-1.0.2.xpi
 #: src/olympia/devhub/templates/devhub/validation.html:5
 msgid "Validation Results for {0}"
@@ -4352,7 +4312,7 @@ msgstr "Compatibiliteit"
 msgid "Update Compatibility"
 msgstr "Compatibiliteit bijwerken"
 
-#: src/olympia/devhub/templates/devhub/addons/ajax_compat_update.html:4
+#: src/olympia/devhub/templates/devhub/addons/ajax_compat_update.html:4 src/olympia/devhub/templates/devhub/versions/edit.html:45
 msgid "Adjusting application information here will allow users to install your add-on even if the install manifest in the package indicates that the add-on is incompatible."
 msgstr "Door hier toepassingsinformatie aan te passen kunnen gebruikers uw add-on installeren, zelfs als het installatiemanifest in het pakket aangeeft dat de add-on niet compatibel is."
 
@@ -4364,9 +4324,9 @@ msgstr "Ondersteunde versies"
 msgid "Add Another Application&hellip;"
 msgstr "Nog een toepassing toevoegen…"
 
-#: src/olympia/devhub/templates/devhub/addons/ajax_compat_update.html:38 src/olympia/devhub/templates/devhub/addons/owner.html:86 src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:46
-#: src/olympia/devhub/templates/devhub/versions/list.html:351 src/olympia/devhub/templates/devhub/versions/list.html:353 src/olympia/templates/impala/base.html:132
-#: src/olympia/templates/impala/base.html:143 src/olympia/templates/impala/base.html:161 src/olympia/templates/impala/base.html:171
+#: src/olympia/devhub/templates/devhub/addons/ajax_compat_update.html:38 src/olympia/devhub/templates/devhub/addons/owner.html:86 src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:45
+#: src/olympia/devhub/templates/devhub/versions/list.html:349 src/olympia/devhub/templates/devhub/versions/list.html:351 src/olympia/templates/impala/base.html:129
+#: src/olympia/templates/impala/base.html:140 src/olympia/templates/impala/base.html:158 src/olympia/templates/impala/base.html:168
 msgid "Close"
 msgstr "Sluiten"
 
@@ -4400,7 +4360,7 @@ msgstr "Geen"
 msgid "Manage Authors & License"
 msgstr "Schrijvers en licentie beheren"
 
-#: src/olympia/devhub/templates/devhub/addons/owner.html:29 src/olympia/editors/templates/editors/review.html:270
+#: src/olympia/devhub/templates/devhub/addons/owner.html:29 src/olympia/editors/helpers.py:362 src/olympia/editors/templates/editors/review.html:270
 msgid "Authors"
 msgstr "Schrijvers"
 
@@ -4472,18 +4432,12 @@ msgstr "Samenvatting"
 
 #: src/olympia/devhub/templates/devhub/addons/edit/basic.html:52
 msgid ""
-"A short explanation of your add-on's basic\n"
-"                          functionality that is displayed in search and browse\n"
-"                          listings, as well as at the top of your add-on's\n"
-"                          details page. It is only relevant for listed add-ons."
+"A short explanation of your add-on's basic functionality that is displayed in search and browse listings, as well as at the top of your add-on's details page. It is only relevant for listed add-ons."
 msgstr ""
 "Een korte uitleg van de belangrijkste functies van uw add-on die wordt weergegeven in zoek- en bladerlijsten, evenals bovenaan de detailpagina van uw add-on. Alleen relevant voor vermelde add-ons."
 
 #: src/olympia/devhub/templates/devhub/addons/edit/basic.html:73
-msgid ""
-"Categories are the primary way users browse through add-ons.\n"
-"                        Choose any that fit your add-on's functionality for the most\n"
-"                        exposure. It is only relevant for listed add-ons."
+msgid "Categories are the primary way users browse through add-ons. Choose any that fit your add-on's functionality for the most exposure. It is only relevant for listed add-ons."
 msgstr ""
 "Categorieën zijn de voornaamste manier waarop gebruikers door add-ons bladeren. Kies er één die de functionaliteit van uw add-on in de meeste gevallen beschrijft. Alleen relevant voor vermelde add-"
 "ons."
@@ -4497,11 +4451,7 @@ msgstr ""
 "categorieën te wijzigen."
 
 #: src/olympia/devhub/templates/devhub/addons/edit/basic.html:119
-msgid ""
-"Tags help users find your add-on and should be short\n"
-"                        descriptors such as tabs, toolbar, or twitter.  You\n"
-"                        may have a maximum of {0} tags. It is only relevant\n"
-"                        for listed add-ons."
+msgid "Tags help users find your add-on and should be short descriptors such as tabs, toolbar, or twitter. You may have a maximum of {0} tags. It is only relevant for listed add-ons."
 msgstr ""
 "Labels helpen gebruikers om uw add-on te vinden en dienen korte beschrijvingen te zijn, zoals tabbladen, werkbalk of twitter. U kunt maximaal {0} labels gebruiken. Alleen relevant voor vermelde add-"
 "ons."
@@ -4531,11 +4481,7 @@ msgid "Add-on Details for {0}"
 msgstr "Add-ondetails voor {0}"
 
 #: src/olympia/devhub/templates/devhub/addons/edit/details.html:22
-msgid ""
-"A longer explanation of features,\n"
-"                          functionality, and other relevant information. This\n"
-"                          field is only displayed on the add-on's details\n"
-"                          page. It is only relevant for listed add-ons."
+msgid "A longer explanation of features, functionality, and other relevant information. This field is only displayed on the add-on's details page. It is only relevant for listed add-ons."
 msgstr "Een langere uitleg van functies, functionaliteit en overige relevante informatie. Dit veld wordt alleen op de detailpagina van de add-on weergegeven. Alleen relevant voor vermelde add-ons."
 
 #: src/olympia/devhub/templates/devhub/addons/edit/details.html:44 src/olympia/translations/templates/translations/trans-menu.html:13
@@ -4543,10 +4489,7 @@ msgid "Default Locale"
 msgstr "Standaardlocale"
 
 #: src/olympia/devhub/templates/devhub/addons/edit/details.html:45
-msgid ""
-"Information about your add-on is displayed in this locale\n"
-"                        unless you override it with a locale-specific translation.\n"
-"                        It is only relevant for listed add-ons."
+msgid "Information about your add-on is displayed in this locale unless you override it with a locale-specific translation. It is only relevant for listed add-ons."
 msgstr "Informatie over uw add-on wordt in deze taal weergegeven, tenzij u dit bijstelt met een locale-specifieke vertaling. Alleen relevant voor vermelde add-ons."
 
 #: src/olympia/devhub/templates/devhub/addons/edit/details.html:61 src/olympia/users/forms.py:311 src/olympia/users/templates/users/edit.html:122 src/olympia/users/templates/users/register.html:57
@@ -4556,10 +4499,8 @@ msgstr "Startpagina"
 
 #: src/olympia/devhub/templates/devhub/addons/edit/details.html:63
 msgid ""
-"If your add-on has another homepage, enter its\n"
-"                          address here. If your website is localized into other\n"
-"                          languages multiple translations of this field can be\n"
-"                          added. It is only relevant for listed add-ons."
+"If your add-on has another homepage, enter its address here. If your website is localized into other languages multiple translations of this field can be added. It is only relevant for listed add-"
+"ons."
 msgstr ""
 "Als uw add-on een andere startpagina heeft, voer dan hier het adres in. Als uw website naar andere talen is vertaald kunnen meerdere vertalingen van dit veld worden toegevoegd. Alleen relevant voor "
 "vermelde add-ons."
@@ -4579,21 +4520,16 @@ msgstr "Ondersteuningsinformatie voor {0}"
 
 #: src/olympia/devhub/templates/devhub/addons/edit/support.html:22
 msgid ""
-"If you wish to display an e-mail address for support\n"
-"                          inquiries, enter it here. If you have different\n"
-"                          addresses for each language multiple translations of\n"
-"                          this field can be added. It is only relevant for\n"
-"                          listed add-ons."
+"If you wish to display an e-mail address for support inquiries, enter it here. If you have different addresses for each language multiple translations of this field can be added. It is only "
+"relevant for listed add-ons."
 msgstr ""
 "Als u een e-mailadres voor ondersteuningsvragen wilt weergeven, voer het hier dan in. Als u verschillende adressen voor elke taal heeft kunnen meerdere vertalingen van dit veld worden toegevoegd. "
 "Alleen relevant voor vermelde add-ons."
 
 #: src/olympia/devhub/templates/devhub/addons/edit/support.html:45
 msgid ""
-"If your add-on has a support website or forum, enter\n"
-"                          its address here. If your website is localized into\n"
-"                          other languages, multiple translations of this field can\n"
-"                          be added. It is only relevant for listed add-ons."
+"If your add-on has a support website or forum, enter its address here. If your website is localized into other languages, multiple translations of this field can be added. It is only relevant for "
+"listed add-ons."
 msgstr ""
 "Als uw add-on een ondersteuningswebsite of -forum heeft, voer dan hier het adres in. Als uw website in andere talen is vertaald kunnen meerdere vertalingen van dit veld worden toegevoegd. Alleen "
 "relevant voor vermelde add-ons."
@@ -4609,11 +4545,8 @@ msgstr "Technische details voor {0}"
 
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:23
 msgid ""
-"Any information end users may want to know that isn't\n"
-"                          necessarily applicable to the add-on summary or description.\n"
-"                          Common uses include listing known major bugs, information on\n"
-"                          how to report bugs, anticipated release date of a new version,\n"
-"                          etc. It is only relevant for listed add-ons."
+"Any information end users may want to know that isn't necessarily applicable to the add-on summary or description. Common uses include listing known major bugs, information on how to report bugs, "
+"anticipated release date of a new version, etc. It is only relevant for listed add-ons."
 msgstr ""
 "Alle informatie waar gebruikers mogelijk in zijn geïnteresseerd die niet noodzakelijkerwijs van toepassing is op de samenvatting of beschrijving van de add-on. Wordt vaak gebruikt voor een lijst "
 "met bekende bugs, informatie over hoe bugs gemeld kunnen worden, de verwachte publicatiedatum van een nieuwe versie, enz. Alleen relevant voor vermelde add-ons."
@@ -4627,9 +4560,7 @@ msgid "Add-on Flags"
 msgstr "Add-onmarkeringen"
 
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:69
-msgid ""
-"These flags are used to classify add-ons. It is only\n"
-"                        relevant for listed add-ons."
+msgid "These flags are used to classify add-ons. It is only relevant for listed add-ons."
 msgstr "Deze labels worden gebruikt om add-ons te classificeren. Alleen relevant voor vermelde add-ons."
 
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:74
@@ -4645,9 +4576,7 @@ msgid "View Source?"
 msgstr "Bron bekijken?"
 
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:90
-msgid ""
-"Whether the source of your add-on can be displayed in our\n"
-"                        online viewer. It is only relevant for listed add-ons."
+msgid "Whether the source of your add-on can be displayed in our online viewer. It is only relevant for listed add-ons."
 msgstr "Of de broncode van uw add-on in onze online weergave kan worden weergegeven. Alleen relevant voor vermelde add-ons."
 
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:94
@@ -4663,10 +4592,7 @@ msgid "Public Stats?"
 msgstr "Publieke statistieken?"
 
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:102
-msgid ""
-"Whether the download and usage stats of your add-on can\n"
-"                        be displayed in our online viewer.\n"
-"                        It is only relevant for listed add-ons."
+msgid "Whether the download and usage stats of your add-on can be displayed in our online viewer. It is only relevant for listed add-ons."
 msgstr "Of de downlaod- en gebruiksstatistieken van uw add-on in onze online weergave mogen worden weergegeven. Alleen relevant voor vermelde add-ons."
 
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:107
@@ -4682,10 +4608,7 @@ msgid "Upgrade SDK?"
 msgstr "SDK upgraden?"
 
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:116
-msgid ""
-"If selected, we will try to automatically upgrade your\n"
-"                        add-on when a new version of the SDK is released.\n"
-"                        It is only relevant for listed add-ons."
+msgid "If selected, we will try to automatically upgrade your add-on when a new version of the SDK is released. It is only relevant for listed add-ons."
 msgstr "Indien geselecteerd proberen we uw add-on automatisch te upgraden als een nieuwe versie van de SDK wordt gepubliceerd. Alleen relevant voor vermelde add-ons."
 
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:121
@@ -4738,10 +4661,8 @@ msgstr "Add-onpictogram"
 
 #: src/olympia/devhub/templates/devhub/addons/forms_shared/media.html:16
 msgid ""
-"Upload an icon for your add-on or choose from one of ours. The\n"
-"                      icon is displayed nearly everywhere your add-on is. Uploaded images\n"
-"                      must be one of the following image types: .png, .jpg.\n"
-"                      It is only relevant for listed add-ons."
+"Upload an icon for your add-on or choose from one of ours. The icon is displayed nearly everywhere your add-on is. Uploaded images must be one of the following image types: .png, .jpg. It is only "
+"relevant for listed add-ons."
 msgstr ""
 "Upload een pictogram voor uw add-on of kies er één van ons. Het pictogram wordt vrijwel overal bij uw add-on weergegeven. Geüploade afbeeldingen dienen van het type .png of .jpg te zijn. Alleen "
 "relevant voor vermelde add-ons."
@@ -4756,9 +4677,7 @@ msgid "32x32px"
 msgstr "32x32px"
 
 #: src/olympia/devhub/templates/devhub/addons/forms_shared/media.html:39
-msgid ""
-"Used in listings of add-ons, like search results\n"
-"                            and featured add-ons."
+msgid "Used in listings of add-ons, like search results and featured add-ons."
 msgstr "Gebruikt in vermeldingen van add-ons, zoals zoekresultaten en aanbevolen add-ons."
 
 #. The size of the icon
@@ -4853,16 +4772,14 @@ msgid "Deleting your add-on will permanently remove it from the site and prevent
 msgstr "Door uw add-on te verwijderen wordt deze blijvend verwijderd van de website en kan de GUID niet meer door anderen worden ingediend."
 
 #: src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:24
-msgid ""
-"Enter the following text confirm your decision:\n"
-"           {slug}"
+msgid "Enter the following text confirm your decision: {slug}"
 msgstr "Voer de volgende tekst in om uw beslissing te bevestigen: {slug}"
 
-#: src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:34
+#: src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:33
 msgid "Please tell us why you are deleting your theme:"
 msgstr "Vertel ons waarom u uw thema verwijdert:"
 
-#: src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:36
+#: src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:35
 msgid "Please tell us why you are deleting your add-on:"
 msgstr "Vertel ons waarom u uw add-on verwijdert:"
 
@@ -4899,8 +4816,8 @@ msgstr "Nieuwe versie"
 msgid "Daily statistics on downloads and users."
 msgstr "Dagelijkse statistieken over downloads en gebruikers."
 
-#: src/olympia/devhub/templates/devhub/addons/listing/item_actions.html:45 src/olympia/stats/templates/stats/stats.html:75 src/olympia/stats/templates/stats/stats.html:79
-#: src/olympia/stats/templates/stats/stats.html:81
+#: src/olympia/devhub/templates/devhub/addons/listing/item_actions.html:45 src/olympia/stats/templates/stats/stats.html:31 src/olympia/stats/templates/stats/stats.html:35
+#: src/olympia/stats/templates/stats/stats.html:37
 msgid "Statistics"
 msgstr "Statistieken"
 
@@ -5019,10 +4936,7 @@ msgid "Your add-on has been submitted to the Full Review queue."
 msgstr "Uw add-on is ingediend bij de wachtrij voor Volledige beoordeling."
 
 #: src/olympia/devhub/templates/devhub/addons/submit/done.html:18
-msgid ""
-"You'll receive an email once it has been reviewed by an editor. In\n"
-"          the meantime, you and your friends can install it directly from its\n"
-"          details page:"
+msgid "You'll receive an email once it has been reviewed by an editor. In the meantime, you and your friends can install it directly from its details page:"
 msgstr "U ontvangt een e-mailbericht als deze is beoordeeld door een editor. Ondertussen kunnen u en uw vrienden de add-on rechtstreeks vanaf de detailpagina installeren:"
 
 #: src/olympia/devhub/templates/devhub/addons/submit/done.html:27 src/olympia/devhub/templates/devhub/addons/submit/done.html:77 src/olympia/devhub/templates/devhub/personas/submit_done.html:16
@@ -5232,11 +5146,11 @@ msgstr "Stap 2. Upload uw add-on"
 msgid "Use the fields below to upload your add-on package and select any platform restrictions. After upload, a series of automated validation tests will be run on your file."
 msgstr "Gebruik onderstaande velden om uw add-onpakket te uploaden en selecteer eventuele platformbeperkingen. Na de upload wordt een aantal geautomatiseerde validatietests op uw bestand uitgevoerd."
 
-#: src/olympia/devhub/templates/devhub/addons/submit/upload.html:59 src/olympia/devhub/templates/devhub/versions/add_file_modal.html:39
+#: src/olympia/devhub/templates/devhub/addons/submit/upload.html:51 src/olympia/devhub/templates/devhub/versions/add_file_modal.html:28
 msgid "Which platforms is this file compatible with?"
 msgstr "Met welke platformen is dit bestand compatibel?"
 
-#: src/olympia/devhub/templates/devhub/addons/submit/upload.html:67 src/olympia/devhub/templates/devhub/versions/add_file_modal.html:65
+#: src/olympia/devhub/templates/devhub/addons/submit/upload.html:59 src/olympia/devhub/templates/devhub/versions/add_file_modal.html:45
 msgid "Administrative overrides"
 msgstr "Negeerhandelingen van beheer"
 
@@ -5355,11 +5269,9 @@ msgstr "Websitefunctionaliteit & -ontwikkeling"
 
 #: src/olympia/devhub/templates/devhub/docs/policies-contact.html:44
 msgid ""
-"If you've found a problem with the site, we'd love to fix it. Please <a href=\"https://github.com/mozilla/olympia/issues\">file a bug report</a> in GitHub, including the location of the problem and "
-"how you encountered it."
+"If you've found a problem with the site, we'd love to fix it. Please <a href=\"https://github.com/mozilla/addons/issues/new\">file a bug report</a> in GitHub, including the location of the problem "
+"and how you encountered it."
 msgstr ""
-"Als u een probleem met de website hebt gevonden, zouden we dit graag verhelpen. <a href=\"https://github.com/mozilla/olympia/issues\">Meld een bug</a> in GitHub, inclusief de locatie van het "
-"probleem en hoe u het bent tegengekomen."
 
 #: src/olympia/devhub/templates/devhub/docs/policies-maintenance.html:3 src/olympia/devhub/templates/devhub/docs/policies-maintenance.html:7
 #: src/olympia/devhub/templates/devhub/docs/policies-maintenance.html:8
@@ -6026,7 +5938,7 @@ msgstr "Privénavigatiemodus"
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:282
 msgid ""
-"Add-ons that store or otherwise handle browsing data must support <a href=\"https://developer.mozilla.org/En/Supporting_private_browsing_mode\">Private Browsing Mode</a>.  During a Private Browsing "
+"Add-ons that store or otherwise handle browsing data must support <a href=\"https://developer.mozilla.org/En/Supporting_private_browsing_mode\">Private Browsing Mode</a>. During a Private Browsing "
 "session, no browsing data can be written to disk, and all of this data must be cleared when Firefox quits or the Private Browsing session ends."
 msgstr ""
 "Add-ons die navigatiegegevens opslaan of anderszins verwerken dienen <a href=\"https://developer.mozilla.org/En/Supporting_private_browsing_mode\">Privénavigatie</a> te ondersteunen. Tijdens een "
@@ -6243,131 +6155,97 @@ msgstr "Voorwaarden voor het indienen van uw werk bij onze website. Ontwikkelaar
 msgid "How to get in touch with us regarding these policies or your add-on."
 msgstr "Hoe u met ons contact kunt opnemen over dit beleid of uw add-on."
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:6
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:10
 msgid "You have disabled this add-on"
 msgstr "U hebt deze add-on uitgeschakeld"
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:20
-msgid ""
-"Your add-on's listing is disabled and is not showing\n"
-"                             anywhere in our gallery or update service."
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:24
+msgid "Your add-on's listing is disabled and is not showing anywhere in our gallery or update service."
 msgstr "De vermelding van uw add-on is uitgeschakeld en de add-on wordt niet in onze galerij of update-service weergegeven."
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:25
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:27
 msgid "Please complete your add-on."
 msgstr "Voltooi uw add-on."
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:29
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:30
 msgid "You will receive an email when the review is complete."
 msgstr "U ontvangt een e-mailbericht als de beoordeling is voltooid."
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:34
-msgid ""
-"You will receive an email when the review is complete. Until\n"
-"                             then, your add-on is not listed in our gallery but can be\n"
-"                             accessed directly from its details page."
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:33
+msgid "You will receive an email when the review is complete. Until then, your add-on is not listed in our gallery but can be accessed directly from its details page."
 msgstr "U ontvangt een e-mailbericht als de beoordeling is voltooid. Tot dat moment wordt uw add-on niet in onze galerij weergegeven maar kan wel rechtstreeks van de detailpagina worden benaderd."
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:38 src/olympia/devhub/templates/devhub/includes/addon_details.html:48
-msgid ""
-"You will receive an email when the review is\n"
-"                             complete and your add-on is signed."
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:37 src/olympia/devhub/templates/devhub/includes/addon_details.html:45
+msgid "You will receive an email when the review is complete and your add-on is signed."
 msgstr "U ontvangt een e-mailbericht als de beoordeling is voltooid en uw add-on is ondertekend."
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:44
-msgid ""
-"You will receive an email when the review is complete. Until\n"
-"                             then, your add-on is not listed in our gallery but can be\n"
-"                             accessed directly from its details page. "
-msgstr "U ontvangt een e-mailbericht als de beoordeling is voltooid. Tot dat moment wordt uw add-on niet in onze galerij weergegeven maar kan wel rechtstreeks van de detailpagina worden benaderd."
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:41
+msgid "You will receive an email when the review is complete. Until then, your add-on is not listed in our gallery but can be accessed directly from its details page. "
+msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:54
-msgid ""
-"Your add-on is displayed in our gallery and users are\n"
-"                             receiving automatic updates."
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:49
+msgid "Your add-on is displayed in our gallery and users are receiving automatic updates."
 msgstr "Uw add-on wordt weergegeven in onze galerij en gebruikers ontvangen automatische updates."
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:57
-msgid ""
-"Your add-on has been signed and can be bundled with an\n"
-"                             application installer."
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:52
+msgid "Your add-on has been signed and can be bundled with an application installer."
 msgstr "Uw add-on is ondertekend en kan worden gebundeld met een toepassingsinstallatie."
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:63
-msgid ""
-"Your add-on was disabled by a site administrator and is no\n"
-"                             longer shown in our gallery. If you have any questions,\n"
-"                             please email amo-admins@mozilla.org."
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:56
+msgid "Your add-on was disabled by a site administrator and is no longer shown in our gallery. If you have any questions, please email amo-admins@mozilla.org."
 msgstr "Uw add-on is uitgeschakeld door een websitebeheerder en wordt niet meer weergegeven in onze galerij. Als u vragen heeft, stuur ze dan naar amo-admins@mozilla.org."
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:70
-msgid ""
-"Your add-on is displayed in our gallery as experimental\n"
-"                             and users are receiving automatic updates. Some features\n"
-"                             are unavailable to your add-on."
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:62
+msgid "Your add-on is displayed in our gallery as experimental and users are receiving automatic updates. Some features are unavailable to your add-on."
 msgstr "Uw add-on wordt in onze galerij als experimenteel weergegeven en gebruikers ontvangen automatische updates. Sommige functies zijn voor uw add-on niet beschikbaar."
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:74
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:66
 msgid "Your add-on has been signed."
 msgstr "Uw add-on is ondertekend."
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:79
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:69
 msgid ""
-"You will receive an email when the full review is complete.\n"
-"                             Until then, your add-on is displayed in our gallery as\n"
-"                             experimental and users are receiving automatic updates.\n"
-"                             Some features are unavailable to your add-on."
+"You will receive an email when the full review is complete. Until then, your add-on is displayed in our gallery as experimental and users are receiving automatic updates. Some features are "
+"unavailable to your add-on."
 msgstr ""
 "U ontvangt een e-mailbericht wanneer de volledige beoordeling is voltooid. Tot dat moment wordt uw add-on als experimenteel in onze galerij weergegeven en ontvangen gebruikers automatische updates. "
 "Sommige functies zijn voor uw add-on niet beschikbaar."
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:84
-msgid ""
-"You will receive an email when the full review is\n"
-"                             complete, making you able to bundle your add-on with an\n"
-"                             application installer."
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:74
+msgid "You will receive an email when the full review is complete, making you able to bundle your add-on with an application installer."
 msgstr "U ontvangt een e-mailbericht wanneer de volledige beoordeling is voltooid, waarna u uw add-on kunt bundelen met een toepassingsinstallatie."
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:91
-msgid ""
-"All add-ons hosted in our gallery must now be reviewed by an\n"
-"                             editor. If you wish to continue hosting your add-on, please\n"
-"                             click to select a review process."
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:79
+msgid "All add-ons hosted in our gallery must now be reviewed by an editor. If you wish to continue hosting your add-on, please click to select a review process."
 msgstr "Alle add-ons in onze galerij dienen voortaan door een editor te worden beoordeeld. Als u uw add-on verder wilt laten hosten, klik dan om een beoordelingsproces te selecteren."
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:113
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:100
 msgid "Current Version:"
 msgstr "Huidige versie:"
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:115
-msgid ""
-"This is the version of your add-on that will\n"
-"                                           be installed if someone clicks the Install\n"
-"                                           button on addons.mozilla.org. It is only\n"
-"                                           relevant for listed add-ons."
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:102
+msgid "This is the version of your add-on that will be installed if someone clicks the Install button on addons.mozilla.org. It is only relevant for listed add-ons."
 msgstr "Dit is de versie van uw add-on die wordt geïnstalleerd als iemand op de knop Installeren klikt op addons.mozilla.org. Alleen relevant voor vermelde add-ons."
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:123
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:110
 msgid "Created:"
 msgstr "Gemaakt:"
 
 #. {0} is a date. dennis-ignore: E201
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:125 src/olympia/devhub/templates/devhub/includes/addon_details.html:131
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:112 src/olympia/devhub/templates/devhub/includes/addon_details.html:118
 #, python-format
 msgid "%%b %%e, %%Y"
 msgstr "%%d %%b %%Y"
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:136
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:123
 msgid "Next Version:"
 msgstr "Volgende versie:"
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:138
-msgid ""
-"This is the newest uploaded version, however\n"
-"                                           it isn’t live on the site yet."
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:125
+msgid "This is the newest uploaded version, however it isn’t live on the site yet."
 msgstr "Dit is de nieuwste geüploade versie, echter deze is op de website nog niet live."
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:144 src/olympia/devhub/templates/devhub/versions/list.html:30
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:130 src/olympia/devhub/templates/devhub/versions/list.html:30
 msgid "Queues are not reviewed strictly in order"
 msgstr "Wachtrijen worden niet op strikte volgorde beoordeeld"
 
@@ -6437,9 +6315,7 @@ msgid "View the blog &#9658;"
 msgstr "Lees de blog &#9658;"
 
 #: src/olympia/devhub/templates/devhub/includes/license_form.html:6
-msgid ""
-"Please choose a license appropriate for the rights you grant on your source code.\n"
-"                  It is only relevant for listed add-ons."
+msgid "Please choose a license appropriate for the rights you grant on your source code. It is only relevant for listed add-ons."
 msgstr "Kies een licentie die toepasselijk is voor de rechten die u op uw broncode wilt geven. Alleen relevant voor vermelde add-ons."
 
 #. {0} is a list of HTML tags.
@@ -6455,8 +6331,7 @@ msgstr "HTML gedeeltelijk ondersteund."
 msgid "Remove this application"
 msgstr "Deze toepassing verwijderen"
 
-#. {0} is the maximum number of add-on categories allowed.                {1}
-#. is
+#. {0} is the maximum number of add-on categories allowed.                {1} is
 #. the application name.
 #: src/olympia/devhub/templates/devhub/includes/macros.html:70
 msgid "Select <b>up to {0}</b> {1} category for this add-on:"
@@ -6467,16 +6342,11 @@ msgstr[1] "Selecteer <b>maximaal {0}</b> {1} categorieën voor deze add-on:"
 #: src/olympia/devhub/templates/devhub/includes/policy_form.html:4
 msgid ""
 "Users will be required to accept the following End-User License Agreement (EULA) prior to installing your add-on. The presence of a EULA significantly affects the number of downloads an add-on "
-"receives. Please note that a EULA is not the same as a code license, such as the GPL or MPL.\n"
-"                It is only relevant for listed add-ons."
+"receives. Please note that a EULA is not the same as a code license, such as the GPL or MPL.It is only relevant for listed add-ons."
 msgstr ""
-"Gebruikers zijn verplicht de volgende Gebruikersovereenkomst (EULA) te accepteren voordat ze uw add-on kunnen installeren.  De aanwezigheid van een EULA beïnvloedt het aantal downloads van een add-"
-"on significant. Merk op dat een EULA niet hetzelfde is als een codelicentie, zoals de GPL of MPL. Alleen relevant voor vermelde add-ons."
 
-#: src/olympia/devhub/templates/devhub/includes/policy_form.html:21
-msgid ""
-"If your add-on transmits any data from the user's computer, a privacy policy is required that explains what data is sent and how it is used.\n"
-"                It is only relevant for listed add-ons."
+#: src/olympia/devhub/templates/devhub/includes/policy_form.html:24
+msgid "If your add-on transmits any data from the user's computer, a privacy policy is required that explains what data is sent and how it is used. It is only relevant for listed add-ons."
 msgstr ""
 "Als uw add-on gegevens verzendt vanaf de computer van de gebruiker is een privacybeleid dat uitlegt welke gegevens worden verzonden en hoe deze worden gebruikt verplicht. Alleen relevant voor "
 "vermelde add-ons."
@@ -6648,12 +6518,8 @@ msgstr "Selecteer de categorie die het beste bij uw thema past."
 msgid "Add some tags to describe your Theme."
 msgstr "Voeg enkele labels toe die uw thema beschrijven."
 
-#: src/olympia/devhub/templates/devhub/personas/edit.html:106
-msgid ""
-"A short explanation of your theme's\n"
-"                                basic functionality that is displayed in\n"
-"                                search and browse listings, as well as at\n"
-"                                the top of your theme's details page."
+#: src/olympia/devhub/templates/devhub/personas/edit.html:106 src/olympia/devhub/templates/devhub/personas/submit.html:54
+msgid "A short explanation of your theme's basic functionality that is displayed in search and browse listings, as well as at the top of your theme's details page."
 msgstr "Een korte uitleg van de basisfuncties van uw thema die wordt weergegeven in zoek- en navigatielijsten, evenals bovenaan de detailpagina van uw thema."
 
 #: src/olympia/devhub/templates/devhub/personas/edit.html:122 src/olympia/devhub/templates/devhub/personas/submit.html:68
@@ -6723,7 +6589,7 @@ msgid "Upon upload and form submission, the AMO Team will review your updated de
 msgstr "Bij uploaden en indienen van het formulier beoordeelt het AMO-team uw bijgewerkte ontwerp. Ondertussen blijft uw huidige ontwerp beschikbaar."
 
 #: src/olympia/devhub/templates/devhub/personas/edit.html:241
-msgid "Your previously resubmitted design,  which is under pending review."
+msgid "Your previously resubmitted design, which is under pending review."
 msgstr "Uw eerder opnieuw ingediende ontwerp, dat momenteel op beoordeling wacht."
 
 #: src/olympia/devhub/templates/devhub/personas/edit.html:245
@@ -6791,14 +6657,6 @@ msgstr "Met achtergrondthema’s kunt u eenvoudig de uitstraling van uw Firefox 
 #: src/olympia/devhub/templates/devhub/personas/submit.html:33
 msgid "Give your Theme a name."
 msgstr "Geef uw thema een naam."
-
-#: src/olympia/devhub/templates/devhub/personas/submit.html:54
-msgid ""
-"A short explanation of your theme's\n"
-"                                      basic functionality that is displayed in\n"
-"                                      search and browse listings, as well as at\n"
-"                                      the top of your theme's details page."
-msgstr "Een korte uitleg van de basisfuncties van uw thema die wordt weergegeven in zoek- en navigatielijsten, evenals bovenaan de detailpagina van uw thema."
 
 #: src/olympia/devhub/templates/devhub/personas/submit.html:198
 #, python-format
@@ -6876,35 +6734,17 @@ msgstr "Andere footerafbeelding selecteren"
 msgid "Files added to reviewed versions must be reviewed before they will be available for download."
 msgstr "Bestanden die worden toegevoegd aan beoordeelde versies dienen te worden beoordeeld voordat ze kunnen worden gedownload."
 
-#: src/olympia/devhub/templates/devhub/versions/add_file_modal.html:15
-#, python-format
-msgid ""
-"Submission of updates to unlisted add-ons for signing is currently in an open beta. Manual review may still be required for a large number of add-ons. Please <a href=\"%(url)s\" target=\"_blank"
-"\">report any bugs</a> that you encounter."
-msgstr ""
-"Indienen van updates voor niet-vermelde add-ons voor ondertekening bevindt zich momenteel in een open-bètafase. Voor een groot aantal add-ons kan nog handmatige beoordeling nodig zijn. <a href="
-"\"%(url)s\" target=\"_blank\">Meld eventuele bugs</a> die u tegenkomt."
-
-#: src/olympia/devhub/templates/devhub/versions/add_file_modal.html:35
+#: src/olympia/devhub/templates/devhub/versions/add_file_modal.html:24
 msgid "Select the target platform for this file."
 msgstr "Selecteer het doelplatform voor dit bestand."
 
-#: src/olympia/devhub/templates/devhub/versions/add_file_modal.html:46
+#: src/olympia/devhub/templates/devhub/versions/add_file_modal.html:35
 msgid "Which review type would you like to nominate for?"
 msgstr "Voor welk beoordelingstype wilt u nomineren?"
 
-#: src/olympia/devhub/templates/devhub/versions/add_file_modal.html:51
+#: src/olympia/devhub/templates/devhub/versions/add_file_modal.html:40
 msgid "Only publish this version to my beta channel."
 msgstr "Alleen deze versie op mijn bètakanaal publiceren."
-
-#: src/olympia/devhub/templates/devhub/versions/add_file_modal.html:54
-#, python-format
-msgid ""
-"The behavior of the beta channel has changed to accommodate <a href=\"%(addon_signing_url)s\" target=\"_blank\">mandatory add-on signing</a>. The new process is currently in an open beta, and may "
-"change significantly in the near future. Please <a href=\"%(issues_url)s\" target=\"_blank\">report any bugs</a> that you encounter."
-msgstr ""
-"Om <a href=\"%(addon_signing_url)s\" target=\"_blank\">verplichte add-on-ondertekening</a> te verzorgen is het gedrag van het bètakanaal gewijzigd. Het nieuwe proces bevindt zich momenteel in een "
-"open-bètafase en kan in de nabije toekomst significant worden gewijzigd. <a href=\"%(issues_url)s\" target=\"_blank\">Meld eventuele bugs</a> die u tegenkomt."
 
 #: src/olympia/devhub/templates/devhub/versions/edit.html:5
 msgid "Manage Version {0}"
@@ -6928,19 +6768,10 @@ msgstr "Bestanden"
 msgid "Upload Another File"
 msgstr "Nog een bestand uploaden"
 
-#: src/olympia/devhub/templates/devhub/versions/edit.html:45
-msgid ""
-"Adjusting application information here will allow users to install your\n"
-"                          add-on even if the install manifest in the package indicates that the\n"
-"                          add-on is incompatible."
-msgstr "Door hier uw toepassingsinformatie bij te werken kunnen gebruikers uw add-on installeren, zelfs als het installatiemanifest in het pakket aangeeft dat de add-on niet compatibel is."
-
 #: src/olympia/devhub/templates/devhub/versions/edit.html:74
 msgid ""
-"Information about changes in this release, new features,\n"
-"                              known bugs, and other useful information specific to this\n"
-"                              release/version. This information is also shown in the\n"
-"                              Add-ons Manager when updating."
+"Information about changes in this release, new features, known bugs, and other useful information specific to this release/version. This information is also shown in the Add-ons Manager when "
+"updating."
 msgstr ""
 "Informatie over wijzigingen in deze versie, nieuwe functies, bekende bugs en andere nuttige informatie die specifiek is voor deze uitgave/versie. Deze informatie wordt ook weergegeven in de add-"
 "onbeheerder bij bijwerken."
@@ -6954,10 +6785,7 @@ msgid "Notes for Reviewers"
 msgstr "Opmerkingen voor beoordelaars"
 
 #: src/olympia/devhub/templates/devhub/versions/edit.html:114
-msgid ""
-"Optionally, enter any information that may be useful\n"
-"                              to the Editor reviewing this add-on, such as test\n"
-"                              account information."
+msgid "Optionally, enter any information that may be useful to the Editor reviewing this add-on, such as test account information."
 msgstr "Voer optioneel informatie in die nuttig zou kunnen zijn voor de editor die deze add-on beoordeelt, zoals informatie over een testaccount."
 
 #: src/olympia/devhub/templates/devhub/versions/edit.html:127
@@ -7035,7 +6863,7 @@ msgstr "Volledige beoordeling aanvragen"
 msgid "Request Preliminary Review"
 msgstr "Voorlopige beoordeling aanvragen"
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:80 src/olympia/devhub/templates/devhub/versions/list.html:327 src/olympia/devhub/templates/devhub/versions/list.html:350
+#: src/olympia/devhub/templates/devhub/versions/list.html:80 src/olympia/devhub/templates/devhub/versions/list.html:325 src/olympia/devhub/templates/devhub/versions/list.html:348
 msgid "Cancel Review Request"
 msgstr "Beoordelingsverzoek annuleren"
 
@@ -7064,8 +6892,8 @@ msgid "Unlisted:"
 msgstr "Niet vermeld:"
 
 #: src/olympia/devhub/templates/devhub/versions/list.html:114
-msgid "Not distributed on {0}. Developers will upload new versions for signing and distribute the add-ons on their own. (beta)"
-msgstr "Niet verspreid via {0}. Ontwikkelaar zullen nieuwe versies voor ondertekening uploaden en de add-ons zelf verspreiden. (bèta)"
+msgid "Not distributed on {0}. Developers will upload new versions for signing and distribute the add-ons on their own."
+msgstr ""
 
 #: src/olympia/devhub/templates/devhub/versions/list.html:122
 msgid "Current versions"
@@ -7132,86 +6960,78 @@ msgid "<strong>Important:</strong> Once a version has been deleted, you may not 
 msgstr "<strong>Belangrijk:</strong> als een versie eenmaal is verwijderd, kunt u geen nieuwe versie met hetzelfde versienummer uploaden."
 
 #: src/olympia/devhub/templates/devhub/versions/list.html:230
-msgid ""
-"Deleting a version which has already been reviewed\n"
-"               may also cause a significant delay in the review of\n"
-"               your next update."
-msgstr "Het verwijderen van een al beoordeelde versie kan ook een significante vertraging in de beoordeling van uw volgende update betekenen."
-
-#: src/olympia/devhub/templates/devhub/versions/list.html:233
 msgid "Are you sure you wish to delete this version?"
 msgstr "Weet u zeker dat u deze versie wilt verwijderen?"
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:238
+#: src/olympia/devhub/templates/devhub/versions/list.html:235
 msgid "Delete Version"
 msgstr "Versie verwijderen"
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:240
+#: src/olympia/devhub/templates/devhub/versions/list.html:237
 msgid "Disable Version"
 msgstr "Versie uitschakelen"
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:247
+#: src/olympia/devhub/templates/devhub/versions/list.html:244
 msgid "Add a new Version"
 msgstr "Een nieuwe versie toevoegen"
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:249
+#: src/olympia/devhub/templates/devhub/versions/list.html:246
 msgid "Add Version"
 msgstr "Versie toevoegen"
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:256 src/olympia/devhub/templates/devhub/versions/list.html:274
+#: src/olympia/devhub/templates/devhub/versions/list.html:253 src/olympia/devhub/templates/devhub/versions/list.html:279
 msgid "Hide Add-on"
 msgstr "Add-on verbergen"
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:259
+#: src/olympia/devhub/templates/devhub/versions/list.html:256
 msgid "Hiding your add-on will prevent it from appearing anywhere in our gallery and will stop users from receiving automatic updates."
 msgstr "Door uw add-on te verbergen wordt deze nergens in onze galerij weergegeven en ontvangen gebruikers geen automatische updates meer."
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:265
+#: src/olympia/devhub/templates/devhub/versions/list.html:263
+msgid "The files awaiting review will be disabled and you will need to upload new versions."
+msgstr ""
+
+#: src/olympia/devhub/templates/devhub/versions/list.html:270
 msgid "Are you sure you wish to hide your add-on?"
 msgstr "Weet u zeker dat u uw add-on wilt verbergen?"
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:286 src/olympia/devhub/templates/devhub/versions/list.html:315
+#: src/olympia/devhub/templates/devhub/versions/list.html:291 src/olympia/devhub/templates/devhub/versions/list.html:313
 msgid "Unlist Add-on"
 msgstr "Add-on niet meer vermelden"
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:289
+#: src/olympia/devhub/templates/devhub/versions/list.html:294
 #, python-format
 msgid ""
 "Unlisting your add-on will make it (and each of its versions/files) invisible on this website. It won't show up in searches, won't have a public facing page, and won't be updated automatically for "
-"current users.  It is recommended for unlisted add-ons to provide a custom <a href=\"%(update_url)s\" target=\"_blank\">updateURL</a> in their manifest file for automatic updates."
+"current users. It is recommended for unlisted add-ons to provide a custom <a href=\"%(update_url)s\" target=\"_blank\">updateURL</a> in their manifest file for automatic updates."
 msgstr ""
 "Door de vermelding van uw add-on te verwijderen wordt deze (en alle versies/bestanden) onzichtbaar op deze website. Hij wordt niet weergegeven in zoekresultaten, heeft geen publieke pagina en wordt "
 "niet automatisch bijgewerkt voor huidige gebruikers. Het wordt aanbevolen om bij niet-vermelde add-ons een aangepaste <a href=\"%(update_url)s\" target=\"_blank\">updateURL</a> in het manifest op "
 "te nemen voor automatische updates."
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:299
-#, python-format
-msgid "Switching add-ons to unlisted is currently in an open beta. Please <a href=\"%(url)s\" target=\"_blank\">report any bugs</a> that you encounter."
-msgstr "Omzetten van add-ons naar ‘niet vermeld’ bevindt zich momenteel in een open-bètafase. <a href=\"%(url)s\" target=\"_blank\">Meld eventuele bugs</a> die u tegenkomt."
-
-#: src/olympia/devhub/templates/devhub/versions/list.html:305
+#: src/olympia/devhub/templates/devhub/versions/list.html:303
 msgid "Unlisting an add-on is irreversible!"
 msgstr "Verwijderen van een add-onvermelding is onomkeerbaar!"
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:305
+#: src/olympia/devhub/templates/devhub/versions/list.html:303
 msgid "An unlisted add-on cannot be switched to be listed."
 msgstr "Een niet-vermelde add-on kan niet worden omgezet naar vermeld."
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:307
+#: src/olympia/devhub/templates/devhub/versions/list.html:305
 msgid "Are you sure you wish to unlist your add-on?"
 msgstr "Weet u zeker dat u uw add-on niet meer wilt vermelden?"
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:330
+#: src/olympia/devhub/templates/devhub/versions/list.html:328
 msgid "Canceling your review request will leave your add-on as preliminarily reviewed."
 msgstr "Door uw beoordelingsverzoek te annuleren blijft uw add-on voorlopig beoordeeld."
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:335
+#: src/olympia/devhub/templates/devhub/versions/list.html:333
 msgid "Canceling your review request will mark your add-on incomplete. If you do not complete your add-on after several days by re-requesting review, it will be deleted."
 msgstr ""
 "Door uw beoordelingsverzoek te annuleren wordt uw add-on als onvolledig gemarkeerd. Als u uw add-on niet binnen enkele dagen voltooit door opnieuw een beoordeling aan te vragen, wordt deze "
 "verwijderd."
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:343
+#: src/olympia/devhub/templates/devhub/versions/list.html:341
 msgid "Are you sure you wish to cancel your review request?"
 msgstr "Weet u zeker dat u uw beoordelingsverzoek wilt annuleren?"
 
@@ -7554,19 +7374,19 @@ msgstr "add-on, editor of opmerking"
 msgid "Search by add-on name / author email"
 msgstr "Zoeken op add-onnaam / e-mailadres schrijver"
 
-#: src/olympia/editors/forms.py:103
+#: src/olympia/editors/forms.py:103 src/olympia/editors/forms.py:244 src/olympia/editors/forms.py:257
 msgid "yes"
 msgstr "ja"
 
-#: src/olympia/editors/forms.py:104
+#: src/olympia/editors/forms.py:104 src/olympia/editors/forms.py:244 src/olympia/editors/forms.py:257
 msgid "no"
 msgstr "nee"
 
-#: src/olympia/editors/forms.py:105
+#: src/olympia/editors/forms.py:105 src/olympia/editors/forms.py:245
 msgid "Admin Flag"
 msgstr "Beheerderslabel"
 
-#: src/olympia/editors/forms.py:113
+#: src/olympia/editors/forms.py:113 src/olympia/editors/forms.py:253
 msgid "Max. Version"
 msgstr "Max. versie"
 
@@ -7578,55 +7398,59 @@ msgstr "Dagen sinds indiening"
 msgid "Add-on Types"
 msgstr "Add-ontypen"
 
-#: src/olympia/editors/forms.py:126 src/olympia/editors/helpers.py:267
+#: src/olympia/editors/forms.py:126 src/olympia/editors/helpers.py:279
 msgid "Platforms"
 msgstr "Platformen"
 
+#: src/olympia/editors/forms.py:237
+msgid "Search by add-on name / author email / guid"
+msgstr ""
+
 #. L10n: 0 = platform, 1 = filename, 2 = status message
-#: src/olympia/editors/forms.py:238
+#: src/olympia/editors/forms.py:342
 #, python-format
 msgid "<strong>%s</strong> &middot; %s &middot; %s"
 msgstr "<strong>%s</strong> &middot; %s &middot; %s"
 
-#: src/olympia/editors/forms.py:252
+#: src/olympia/editors/forms.py:356
 msgid "Comments:"
 msgstr "Opmerkingen:"
 
-#: src/olympia/editors/forms.py:256
+#: src/olympia/editors/forms.py:360
 msgid "Operating systems:"
 msgstr "Besturingssystemen:"
 
-#: src/olympia/editors/forms.py:258
+#: src/olympia/editors/forms.py:362
 msgid "Applications:"
 msgstr "Toepassingen:"
 
-#: src/olympia/editors/forms.py:260
+#: src/olympia/editors/forms.py:364
 msgid "Notify me the next time this add-on is updated. (Subsequent updates will not generate an email)"
 msgstr "Stuur mij een bericht als deze add-on de volgende keer wordt bijgewerkt. (Volgende updates genereren geen e-mailbericht)"
 
-#: src/olympia/editors/forms.py:265
+#: src/olympia/editors/forms.py:369
 msgid "Clear Admin Review Flag"
 msgstr "Beoordelingslabel voor beheerder wissen"
 
-#: src/olympia/editors/forms.py:267
+#: src/olympia/editors/forms.py:371
 msgid "Clear more info requested flag"
 msgstr "Label Meer informatie gevraagd wissen"
 
-#: src/olympia/editors/forms.py:281
+#: src/olympia/editors/forms.py:385
 msgid "Choose a canned response..."
 msgstr "Kies een voorgedefinieerd antwoord…"
 
 #. L10n: Description of what can be searched for.
-#: src/olympia/editors/forms.py:324
+#: src/olympia/editors/forms.py:423
 msgid "theme name"
 msgstr "themanaam"
 
-#: src/olympia/editors/forms.py:350
+#: src/olympia/editors/forms.py:449
 msgid "Someone else is reviewing this theme."
 msgstr "Iemand anders beoordeelt dit thema."
 
 #. L10n: Description of what can be searched for.
-#: src/olympia/editors/forms.py:447
+#: src/olympia/editors/forms.py:546
 msgid "app, reviewer, or comment"
 msgstr "app, beoordelaar of opmerking"
 
@@ -7642,193 +7466,211 @@ msgstr "Wacht op voorlopige beoordeling"
 msgid "Rejected or Unreviewed"
 msgstr "Afgewezen of niet beoordeeld"
 
-#: src/olympia/editors/helpers.py:123 src/olympia/editors/helpers.py:136
+#: src/olympia/editors/helpers.py:125 src/olympia/editors/helpers.py:138
 msgid "Queue"
 msgstr "Wachtrij"
 
-#: src/olympia/editors/helpers.py:124 src/olympia/editors/templates/editors/base.html:50 src/olympia/editors/templates/editors/base.html:65
+#: src/olympia/editors/helpers.py:126 src/olympia/editors/templates/editors/base.html:50 src/olympia/editors/templates/editors/base.html:65
 msgid "Pending Updates"
 msgstr "Wachtende updates"
 
-#: src/olympia/editors/helpers.py:125 src/olympia/editors/templates/editors/base.html:48 src/olympia/editors/templates/editors/base.html:63
+#: src/olympia/editors/helpers.py:127 src/olympia/editors/templates/editors/base.html:48 src/olympia/editors/templates/editors/base.html:63
 msgid "Full Reviews"
 msgstr "Volledige beoordelingen"
 
-#: src/olympia/editors/helpers.py:126 src/olympia/editors/templates/editors/base.html:52 src/olympia/editors/templates/editors/base.html:67
+#: src/olympia/editors/helpers.py:128 src/olympia/editors/templates/editors/base.html:52 src/olympia/editors/templates/editors/base.html:67
 msgid "Preliminary Reviews"
 msgstr "Voorlopige beoordelingen"
 
-#: src/olympia/editors/helpers.py:127 src/olympia/editors/templates/editors/base.html:54
+#: src/olympia/editors/helpers.py:129 src/olympia/editors/templates/editors/base.html:54
 msgid "Moderated Reviews"
 msgstr "Gemodereerde beoordelingen"
 
-#: src/olympia/editors/helpers.py:128 src/olympia/editors/templates/editors/base.html:46
+#: src/olympia/editors/helpers.py:130 src/olympia/editors/templates/editors/base.html:46
 msgid "Fast Track"
 msgstr "Kortste weg"
 
-#: src/olympia/editors/helpers.py:130
+#: src/olympia/editors/helpers.py:132
 msgid "Pending Themes"
 msgstr "Wachtende thema’s"
 
-#: src/olympia/editors/helpers.py:131 src/olympia/editors/templates/editors/themes/queue.html:4
+#: src/olympia/editors/helpers.py:133 src/olympia/editors/templates/editors/themes/queue.html:4
 msgid "Flagged Themes"
 msgstr "Gemarkeerde thema’s"
 
-#: src/olympia/editors/helpers.py:132
+#: src/olympia/editors/helpers.py:134
 msgid "Update Themes"
 msgstr "Thema’s bijwerken"
 
-#: src/olympia/editors/helpers.py:137
+#: src/olympia/editors/helpers.py:139
 msgid "Unlisted Pending Updates"
 msgstr "Niet-vermelde wachtende updates"
 
-#: src/olympia/editors/helpers.py:138
+#: src/olympia/editors/helpers.py:140
 msgid "Unlisted Full Reviews"
 msgstr "Niet-vermelde volledige beoordelingen"
 
-#: src/olympia/editors/helpers.py:139
+#: src/olympia/editors/helpers.py:141
 msgid "Unlisted Preliminary Reviews"
 msgstr "Niet-vermelde voorlopige beoordelingen"
 
-#: src/olympia/editors/helpers.py:170
+#: src/olympia/editors/helpers.py:142
+msgid "Unlisted All Add-ons"
+msgstr ""
+
+#: src/olympia/editors/helpers.py:173
 msgid "Fast Track ({0})"
 msgid_plural "Fast Track ({0})"
 msgstr[0] "Kortste weg ({0})"
 msgstr[1] "Kortste weg ({0})"
 
-#: src/olympia/editors/helpers.py:175
+#: src/olympia/editors/helpers.py:178
 msgid "Full Review ({0})"
 msgid_plural "Full Reviews ({0})"
 msgstr[0] "Volledige beoordeling ({0})"
 msgstr[1] "Volledige beoordelingen ({0})"
 
-#: src/olympia/editors/helpers.py:180
+#: src/olympia/editors/helpers.py:183
 msgid "Pending Update ({0})"
 msgid_plural "Pending Updates ({0})"
 msgstr[0] "Wacht op update ({0})"
 msgstr[1] "Wachten op updates ({0})"
 
-#: src/olympia/editors/helpers.py:185
+#: src/olympia/editors/helpers.py:188
 msgid "Preliminary Review ({0})"
 msgid_plural "Preliminary Reviews ({0})"
 msgstr[0] "Voorlopige beoordeling ({0})"
 msgstr[1] "Voorlopige beoordelingen ({0})"
 
-#: src/olympia/editors/helpers.py:190
+#: src/olympia/editors/helpers.py:193
 msgid "Moderated Review ({0})"
 msgid_plural "Moderated Reviews ({0})"
 msgstr[0] "Aangepaste beoordeling ({0})"
 msgstr[1] "Aangepaste beoordelingen ({0})"
 
-#: src/olympia/editors/helpers.py:196
+#: src/olympia/editors/helpers.py:199
 msgid "Unlisted Full Review ({0})"
 msgid_plural "Unlisted Full Reviews ({0})"
 msgstr[0] "Niet-vermelde volledige beoordeling ({0})"
 msgstr[1] "Niet-vermelde volledige beoordelingen ({0})"
 
-#: src/olympia/editors/helpers.py:201
+#: src/olympia/editors/helpers.py:204
 msgid "Unlisted Pending Update ({0})"
 msgid_plural "Unlisted Pending Updates ({0})"
 msgstr[0] "Niet-vermelde wachtende update ({0})"
 msgstr[1] "Niet-vermelde wachtende updates ({0})"
 
-#: src/olympia/editors/helpers.py:206
+#: src/olympia/editors/helpers.py:209
 msgid "Unlisted Preliminary Review ({0})"
 msgid_plural "Unlisted Preliminary Reviews ({0})"
 msgstr[0] "Niet-vermelde voorlopige beoordeling ({0})"
 msgstr[1] "Niet-vermelde voorlopige beoordelingen ({0})"
 
-#: src/olympia/editors/helpers.py:261
-msgid "Addon"
-msgstr "Add-on"
+#: src/olympia/editors/helpers.py:214
+msgid "Unlisted All Add-ons ({0})"
+msgid_plural "Unlisted All Add-ons ({0})"
+msgstr[0] ""
+msgstr[1] ""
 
-#: src/olympia/editors/helpers.py:262
+#: src/olympia/editors/helpers.py:274
 msgid "Type"
 msgstr "Type"
 
-#: src/olympia/editors/helpers.py:263
+#: src/olympia/editors/helpers.py:275
 msgid "Waiting Time"
 msgstr "Wachttijd"
 
-#: src/olympia/editors/helpers.py:264 src/olympia/editors/templates/editors/review.html:285
+#: src/olympia/editors/helpers.py:276 src/olympia/editors/templates/editors/review.html:285
 msgid "Flags"
 msgstr "Labels"
 
-#: src/olympia/editors/helpers.py:265
+#: src/olympia/editors/helpers.py:277
 msgid "Applications"
 msgstr "Toepassingen"
 
-#: src/olympia/editors/helpers.py:270
+#: src/olympia/editors/helpers.py:282
 msgid "Additional"
 msgstr "Aanvullend"
 
-#: src/olympia/editors/helpers.py:285
+#: src/olympia/editors/helpers.py:302
 msgid "Site Specific"
 msgstr "Website-specifiek"
 
-#: src/olympia/editors/helpers.py:287
+#: src/olympia/editors/helpers.py:304
 msgid "Requires External Software"
 msgstr "Vereist externe software"
 
-#: src/olympia/editors/helpers.py:289
+#: src/olympia/editors/helpers.py:306
 msgid "Binary Components"
 msgstr "Binaire componenten"
 
 # is this preceded by a number?
-#: src/olympia/editors/helpers.py:313
+#: src/olympia/editors/helpers.py:339
 msgid "moments ago"
 msgstr "kortgeleden"
 
 #. L10n: first argument is number of minutes
-#: src/olympia/editors/helpers.py:316
+#: src/olympia/editors/helpers.py:342
 msgid "{0} minute"
 msgid_plural "{0} minutes"
 msgstr[0] "{0} minuut"
 msgstr[1] "{0} minuten"
 
 #. L10n: first argument is number of hours
-#: src/olympia/editors/helpers.py:320
+#: src/olympia/editors/helpers.py:346
 msgid "{0} hour"
 msgid_plural "{0} hours"
 msgstr[0] "{0} uur"
 msgstr[1] "{0} uur"
 
 #. L10n: first argument is number of days
-#: src/olympia/editors/helpers.py:324
+#: src/olympia/editors/helpers.py:350
 msgid "{0} day"
 msgid_plural "{0} days"
 msgstr[0] "{0} dag"
 msgstr[1] "{0} dagen"
 
-#: src/olympia/editors/helpers.py:488
+#: src/olympia/editors/helpers.py:364
+msgid "Last Review"
+msgstr ""
+
+#: src/olympia/editors/helpers.py:366
+msgid "Last Update"
+msgstr ""
+
+#: src/olympia/editors/helpers.py:387
+msgid "No Reviews"
+msgstr ""
+
+#: src/olympia/editors/helpers.py:561
 msgid "Push to public"
 msgstr "Publiceren"
 
-#: src/olympia/editors/helpers.py:490
+#: src/olympia/editors/helpers.py:563
 msgid "Grant full review"
 msgstr "Volledige beoordeling toekennen"
 
-#: src/olympia/editors/helpers.py:505
+#: src/olympia/editors/helpers.py:578
 msgid "Request more information"
 msgstr "Meer informatie aanvragen"
 
-#: src/olympia/editors/helpers.py:508
+#: src/olympia/editors/helpers.py:581
 msgid "Request super-review"
 msgstr "Superbeoordeling aanvragen"
 
-#: src/olympia/editors/helpers.py:519
+#: src/olympia/editors/helpers.py:592
 msgid "Grant preliminary review"
 msgstr "Voorlopige beoordeling toekennen"
 
-#: src/olympia/editors/helpers.py:520
+#: src/olympia/editors/helpers.py:593
 msgid "This will mark the files as preliminarily reviewed."
 msgstr "Dit markeert de bestanden als voorlopig beoordeeld."
 
-#: src/olympia/editors/helpers.py:522
+#: src/olympia/editors/helpers.py:595
 msgid "Use this form to request more information from the author. They will receive an email and be able to answer here. You will be notified by email when they reply."
 msgstr "Gebruik dit formulier om meer informatie aan de schrijver te vragen. Deze ontvangt een e-mailbericht en kan vervolgens hier antwoorden. U krijgt een e-mailbericht als er antwoord is gegeven."
 
-#: src/olympia/editors/helpers.py:526
+#: src/olympia/editors/helpers.py:599
 msgid ""
 "If you have concerns about this add-on's security, copyright issues, or other concerns that an administrator should look into, enter your comments in the area below. They will be sent to "
 "administrators, not the author."
@@ -7836,55 +7678,55 @@ msgstr ""
 "Als u vraagtekens hebt bij de veiligheid, auteursrechtproblemen van deze add-on of andere zorgen hebt waar een beheerder naar zou moeten kijken, voer dan hieronder uw opmerkingen in. Deze worden "
 "naar de beheerders verstuurd, niet naar de schrijver."
 
-#: src/olympia/editors/helpers.py:532
+#: src/olympia/editors/helpers.py:605
 msgid "This will reject the add-on and remove it from the review queue."
 msgstr "Dit wijst de add-on af en verwijdert deze uit de beoordelingswachtrij."
 
-#: src/olympia/editors/helpers.py:534
-msgid "Make a comment on this version.  The author won't be able to see this."
+#: src/olympia/editors/helpers.py:607
+msgid "Make a comment on this version. The author won't be able to see this."
 msgstr "Lever commentaar op deze versie. De schrijver kan dit niet zien."
 
-#: src/olympia/editors/helpers.py:538
+#: src/olympia/editors/helpers.py:611
 msgid "This will reject the files and remove them from the review queue."
 msgstr "Dit wijst de bestanden af en verwijdert ze uit de beoordelingswachtrij."
 
-#: src/olympia/editors/helpers.py:542
+#: src/olympia/editors/helpers.py:615
 msgid "This will mark the add-on as preliminarily reviewed. Future versions will undergo preliminary review."
 msgstr "Dit markeert de add-on als voorlopig beoordeeld. Toekomstige versies zullen een voorlopige beoordeling ondergaan."
 
-#: src/olympia/editors/helpers.py:547
+#: src/olympia/editors/helpers.py:620
 msgid "This will mark the files as preliminarily reviewed. Future versions will undergo preliminary review."
 msgstr "Dit markeert de bestanden als voorlopig beoordeeld. Toekomstige versies zullen een voorlopige beoordeling ondergaan."
 
-#: src/olympia/editors/helpers.py:552
+#: src/olympia/editors/helpers.py:625
 msgid "Retain preliminary review"
 msgstr "Voorlopige beoordeling behouden"
 
-#: src/olympia/editors/helpers.py:553
+#: src/olympia/editors/helpers.py:626
 msgid "This will retain the add-on as preliminarily reviewed. Future versions will undergo preliminary review."
 msgstr "Dit houdt de add-on aan als voorlopig beoordeeld. Toekomstige versies zullen een voorlopige beoordeling ondergaan."
 
-#: src/olympia/editors/helpers.py:558
+#: src/olympia/editors/helpers.py:631
 msgid "This will approve a sandboxed version of a public add-on to appear on the public side."
 msgstr "Dit keurt een versie in de sandbox van een publieke add-on goed, zodat deze gepubliceerd wordt."
 
-#: src/olympia/editors/helpers.py:561
+#: src/olympia/editors/helpers.py:634
 msgid "This will reject a version of a public add-on and remove it from the queue."
 msgstr "Dit wijst een versie van een publieke add-on af en verwijdert deze uit de wachtrij."
 
-#: src/olympia/editors/helpers.py:564
+#: src/olympia/editors/helpers.py:637
 msgid "This will mark the add-on and its most recent version and files as public. Future versions will go into the sandbox until they are reviewed by an editor."
 msgstr "Dit markeert de add-on en de meest recente versie en bestanden als publiek. Toekomstige versies worden in de sandbox geplaatst tot ze zijn beoordeeld door een editor."
 
-#: src/olympia/editors/helpers.py:637
+#: src/olympia/editors/helpers.py:714
 msgid "add-on"
 msgstr "add-on"
 
-#: src/olympia/editors/helpers.py:940 src/olympia/editors/helpers.py:960
+#: src/olympia/editors/helpers.py:1020 src/olympia/editors/helpers.py:1040
 msgid "Flagged"
 msgstr "Gemarkeerd"
 
-#: src/olympia/editors/helpers.py:944 src/olympia/editors/helpers.py:963
+#: src/olympia/editors/helpers.py:1024 src/olympia/editors/helpers.py:1043
 msgid "Updates"
 msgstr "Updates"
 
@@ -7936,56 +7778,56 @@ msgstr "Ingediend thema gelabeld voor beoordeling"
 msgid "A question about your Theme submission"
 msgstr "Een vraag over uw ingediende thema"
 
-#: src/olympia/editors/views.py:144
+#: src/olympia/editors/views.py:146
 msgid "New Add-ons (Under 5 days)"
 msgstr "Nieuwe add-ons (minder dan 5 dagen)"
 
-#: src/olympia/editors/views.py:145
+#: src/olympia/editors/views.py:147
 msgid "Passable (5 to 10 days)"
 msgstr "Toelaatbaar (5 tot 10 dagen)"
 
-#: src/olympia/editors/views.py:146
+#: src/olympia/editors/views.py:148
 msgid "Overdue (Over 10 days)"
 msgstr "Verlaat (meer dan 10 dagen)"
 
-#: src/olympia/editors/views.py:532
+#: src/olympia/editors/views.py:539
 msgid "An unknown error occurred"
 msgstr "Er is een onbekende fout opgetreden"
 
-#: src/olympia/editors/views.py:587
+#: src/olympia/editors/views.py:592
 msgid "Self-reviews are not allowed."
 msgstr "Zelfbeoordelingen zijn niet toegestaan."
 
-#: src/olympia/editors/views.py:609
+#: src/olympia/editors/views.py:613
 msgid "Review successfully processed."
 msgstr "Beoordeling met succes verwerkt."
 
-#: src/olympia/editors/views.py:807
+#: src/olympia/editors/views.py:812
 msgid "was approved"
 msgstr "is goedgekeurd"
 
-#: src/olympia/editors/views.py:808
+#: src/olympia/editors/views.py:813
 msgid "given preliminary review"
 msgstr "is voorlopig beoordeeld"
 
-#: src/olympia/editors/views.py:809
+#: src/olympia/editors/views.py:814
 msgid "rejected"
 msgstr "is afgewezen"
 
-#: src/olympia/editors/views.py:810
+#: src/olympia/editors/views.py:815
 msgctxt "editors_review_history_nominated_adminreview"
 msgid "escalated"
 msgstr "is geëscaleerd"
 
-#: src/olympia/editors/views.py:812
+#: src/olympia/editors/views.py:817
 msgid "needs more information"
 msgstr "heeft meer informatie nodig"
 
-#: src/olympia/editors/views.py:813
+#: src/olympia/editors/views.py:818
 msgid "needs super review"
 msgstr "vereist superbeoordeling"
 
-#: src/olympia/editors/views.py:814
+#: src/olympia/editors/views.py:819
 msgid "commented"
 msgstr "met opmerking"
 
@@ -8032,28 +7874,28 @@ msgstr "Wachtrijen"
 msgid "Unlisted Queues"
 msgstr "Niet-vermelde wachtrijen"
 
-#: src/olympia/editors/templates/editors/base.html:72 src/olympia/editors/templates/editors/performance.html:6
+#: src/olympia/editors/templates/editors/base.html:74 src/olympia/editors/templates/editors/performance.html:6
 msgid "Performance"
 msgstr "Prestaties"
 
-#: src/olympia/editors/templates/editors/base.html:75 src/olympia/editors/templates/editors/themes/base.html:19 src/olympia/editors/templates/editors/themes/base.html:38
+#: src/olympia/editors/templates/editors/base.html:77 src/olympia/editors/templates/editors/themes/base.html:19 src/olympia/editors/templates/editors/themes/base.html:38
 msgid "Logs"
 msgstr "Logbestanden"
 
-#: src/olympia/editors/templates/editors/base.html:78 src/olympia/editors/templates/editors/reviewlog.html:4 src/olympia/editors/templates/editors/reviewlog.html:27
+#: src/olympia/editors/templates/editors/base.html:80 src/olympia/editors/templates/editors/reviewlog.html:4 src/olympia/editors/templates/editors/reviewlog.html:27
 msgid "Add-on Review Log"
 msgstr "Add-on-beoordelingslogboek"
 
-#: src/olympia/editors/templates/editors/base.html:80 src/olympia/editors/templates/editors/eventlog.html:4 src/olympia/editors/templates/editors/eventlog.html:8
+#: src/olympia/editors/templates/editors/base.html:82 src/olympia/editors/templates/editors/eventlog.html:4 src/olympia/editors/templates/editors/eventlog.html:8
 #: src/olympia/editors/templates/editors/eventlog_detail.html:4
 msgid "Moderated Review Log"
 msgstr "Gemodereerd beoordelingslogboek"
 
-#: src/olympia/editors/templates/editors/base.html:82 src/olympia/editors/templates/editors/beta_signed_log.html:4 src/olympia/editors/templates/editors/beta_signed_log.html:8
+#: src/olympia/editors/templates/editors/base.html:84 src/olympia/editors/templates/editors/beta_signed_log.html:4 src/olympia/editors/templates/editors/beta_signed_log.html:8
 msgid "Signed Beta Files Log"
 msgstr "Logboek van ondertekende bètabestanden"
 
-#: src/olympia/editors/templates/editors/base.html:87 src/olympia/editors/templates/editors/includes/daily-message.html:4
+#: src/olympia/editors/templates/editors/base.html:89 src/olympia/editors/templates/editors/includes/daily-message.html:4
 msgid "Announcement"
 msgstr "Mededeling"
 
@@ -8274,45 +8116,45 @@ msgstr "Geavanceerd zoeken"
 msgid "clear search"
 msgstr "zoekopdracht wissen"
 
-#: src/olympia/editors/templates/editors/queue.html:72 src/olympia/editors/templates/editors/queue.html:122
+#: src/olympia/editors/templates/editors/queue.html:78 src/olympia/editors/templates/editors/queue.html:128
 msgid "Process Reviews"
 msgstr "Beoordelingen verwerken"
 
-#: src/olympia/editors/templates/editors/queue.html:80
+#: src/olympia/editors/templates/editors/queue.html:86
 msgid "Moderation actions:"
 msgstr "Evaluatie-acties:"
 
-#: src/olympia/editors/templates/editors/queue.html:90
+#: src/olympia/editors/templates/editors/queue.html:96
 #, python-format
 msgid "by %(user)s on %(date)s %(stars)s (%(locale)s)"
 msgstr "door %(user)s op %(date)s %(stars)s (%(locale)s)"
 
-#: src/olympia/editors/templates/editors/queue.html:106
+#: src/olympia/editors/templates/editors/queue.html:112
 #, python-format
 msgid "<strong>%(reason)s</strong> <span class=\"light\">Flagged by %(user)s on %(date)s</span>"
 msgstr "<strong>%(reason)s</strong> <span class=\"light\">Gemarkeerd door %(user)s op %(date)s</span>"
 
-#: src/olympia/editors/templates/editors/queue.html:119
-msgid "All reviews have been moderated.  Good work!"
+#: src/olympia/editors/templates/editors/queue.html:125
+msgid "All reviews have been moderated. Good work!"
 msgstr "Alle beoordelingen zijn verwerkt. Goed werk!"
 
-#: src/olympia/editors/templates/editors/queue.html:161
+#: src/olympia/editors/templates/editors/queue.html:167
 msgid "Version Notes / Notes for Reviewer"
 msgstr "Versieopmerkingen / Opmerkingen voor beoordelaar"
 
-#: src/olympia/editors/templates/editors/queue.html:169
+#: src/olympia/editors/templates/editors/queue.html:175
 msgid "There are currently no add-ons of this type to review."
 msgstr "Er zijn momenteel geen add-ons van dit type te beoordelen."
 
-#: src/olympia/editors/templates/editors/queue.html:181 src/olympia/editors/templates/editors/themes/queue_list.html:85
+#: src/olympia/editors/templates/editors/queue.html:187 src/olympia/editors/templates/editors/themes/queue_list.html:85
 msgid "Helpful Links:"
 msgstr "Nuttige koppelingen:"
 
-#: src/olympia/editors/templates/editors/queue.html:182
+#: src/olympia/editors/templates/editors/queue.html:188
 msgid "Add-on Policy"
 msgstr "Add-onbeleid"
 
-#: src/olympia/editors/templates/editors/queue.html:184
+#: src/olympia/editors/templates/editors/queue.html:190
 msgid "Editors' Guide"
 msgstr "Gids voor editors"
 
@@ -8375,10 +8217,7 @@ msgid "<strong>Warning!</strong> Another user was viewing this page before you."
 msgstr "<strong>Waarschuwing!</strong> Een andere gebruiker heeft deze pagina vóór u bekeken."
 
 #: src/olympia/editors/templates/editors/review.html:237
-msgid ""
-"The whiteboard is the place to exchange information relevant to\n"
-"               this addon (whatever the version), between the developer and the\n"
-"               editor. This is visible and editable by both."
+msgid "The whiteboard is the place to exchange information relevant to this addon (whatever the version), between the developer and the editor. This is visible and editable by both."
 msgstr "Het schrijfbord is de plaats om voor deze add-on relevante informatie (ongeacht de versie) tussen de ontwikkelaar en de editor uit te wisselen. Dit is voor beiden zichtbaar en te bewerken."
 
 #: src/olympia/editors/templates/editors/review.html:241
@@ -8652,7 +8491,7 @@ msgstr "Een vraag aan de kunstenaar stellen"
 msgid "Describe your reason for flagging"
 msgstr "Beschrijf uw reden voor het label"
 
-#: src/olympia/files/forms.py:88
+#: src/olympia/files/forms.py:90
 msgid "Cannot diff a version against itself"
 msgstr "Kan geen diff van een versie tegen zichzelf maken"
 
@@ -8687,51 +8526,51 @@ msgstr "Er is een fout opgetreden bij het openen van het bestand %s. %s."
 msgid "There was an error accessing file %s."
 msgstr "Er is een fout opgetreden bij het openen van het bestand %s."
 
-#: src/olympia/files/utils.py:343
+#: src/olympia/files/utils.py:340
 msgid "Could not parse uploaded file."
 msgstr "Kan geüpload bestand niet uitpakken."
 
-#: src/olympia/files/utils.py:380
+#: src/olympia/files/utils.py:377
 msgid "Invalid file name in archive: {0}"
 msgstr "Ongeldige bestandsnaam in archief: {0}"
 
-#: src/olympia/files/utils.py:388
+#: src/olympia/files/utils.py:385
 msgid "File exceeding size limit in archive: {0}"
 msgstr "Te groot bestand in archief: {0}"
 
-#: src/olympia/files/utils.py:439
+#: src/olympia/files/utils.py:436
 msgid "Invalid archive."
 msgstr "Ongeldig archief."
 
-#: src/olympia/files/utils.py:529 src/olympia/files/utils.py:532
+#: src/olympia/files/utils.py:526 src/olympia/files/utils.py:529
 msgid "Could not parse the manifest file."
 msgstr "Kan het manifest-bestand niet verwerken."
 
-#: src/olympia/files/utils.py:551
+#: src/olympia/files/utils.py:548
 msgid "Could not find an add-on ID."
 msgstr "Kan add-on-ID niet vinden."
 
-#: src/olympia/files/utils.py:554
+#: src/olympia/files/utils.py:551
 msgid "Add-on ID must be 64 characters or less."
 msgstr "Add-on-ID dient uit maximaal 64 tekens te bestaan."
 
-#: src/olympia/files/utils.py:556
+#: src/olympia/files/utils.py:553
 msgid "Add-on ID doesn't match add-on."
 msgstr "Add-on-ID komt niet overeen met add-on."
 
-#: src/olympia/files/utils.py:564
+#: src/olympia/files/utils.py:561
 msgid "Duplicate add-on ID found."
 msgstr "Dubbele add-on-ID gevonden."
 
-#: src/olympia/files/utils.py:567
+#: src/olympia/files/utils.py:564
 msgid "Version numbers should have fewer than 32 characters."
 msgstr "Versienummers mogen uit niet meer dan 32 tekens bestaan."
 
-#: src/olympia/files/utils.py:570
+#: src/olympia/files/utils.py:567
 msgid "Version numbers should only contain letters, numbers, and these punctuation characters: +*.-_."
 msgstr "Versienummers mogen alleen letters, cijfers en deze interpunctietekens bevatten: +*.-_."
 
-#: src/olympia/files/utils.py:587
+#: src/olympia/files/utils.py:584
 msgid "<em:type> doesn't match add-on"
 msgstr "<em:type> komt niet overeen met add-on"
 
@@ -8831,6 +8670,10 @@ msgstr "Geen bestanden in geüpload bestand."
 #: src/olympia/files/templates/files/viewer.html:134
 msgid "Fetching file."
 msgstr "Bestand ophalen."
+
+#: src/olympia/legacy_api/views.py:255
+msgid "Not implemented yet."
+msgstr "Nog niet geïmplementeerd."
 
 #: src/olympia/lib/constants.py:6
 msgid "United Arab Emirates Dirham"
@@ -9488,10 +9331,6 @@ msgstr "Zambiaanse Kwacha"
 msgid "Zimbabwe Dollar"
 msgstr "Zimbabwaanse dollar"
 
-#: src/olympia/lib/video/ffmpeg.py:112 src/olympia/lib/video/totem.py:81
-msgid "Videos must be in WebM."
-msgstr "Video’s dienen in WebM te zijn."
-
 #: src/olympia/pages/templates/pages/about.lhtml:3 src/olympia/pages/templates/pages/about.lhtml:10
 msgid "About Mozilla Add-ons"
 msgstr "Over Mozilla Add-ons"
@@ -9503,7 +9342,7 @@ msgstr "Wat is deze website?"
 #: src/olympia/pages/templates/pages/about.lhtml:13
 msgid ""
 "addons.mozilla.org, commonly known as \"AMO\", is Mozilla's official site for add-ons to Mozilla software, such as Firefox, Thunderbird, and SeaMonkey. Add-ons let you add new features and change "
-"the way your browser or application works.  Take a look around and explore the thousands of ways to customize the way you do things online."
+"the way your browser or application works. Take a look around and explore the thousands of ways to customize the way you do things online."
 msgstr ""
 "addons.mozilla.org, ook wel bekend als “AMO”, is de officiële website van Mozilla voor add-ons voor Mozilla-software, zoals Firefox, Thunderbird en SeaMonkey. Met add-ons kunt uw nieuwe functies "
 "toevoegen en de wijze waarop uw browser of toepassing werkt wijzigen. Kijk eens rond en verken de duizenden manieren waarop u de manier waarop u dingen online doet kunt aanpassen."
@@ -9884,7 +9723,7 @@ msgstr "Kan ik een JavaScript-bibliotheek als jQuery, MooTools of Prototype gebr
 msgid ""
 "Yes. It's possible, but some of the functionality provided by these libraries are available through XPCOM, XUL, and JavaScript. In addition, authors should take care if libraries modify primitive "
 "object prototypes (String.prototype, Date.prototype, etc.) and/or define global functions (eg. the $ function). These are prone to cause conflict with other add-ons, in particular if different add-"
-"ons use different versions of libraries and so on. Developers need to be very, very careful with using them.  Mozilla does not offer documentation on using them to build add-ons."
+"ons use different versions of libraries and so on. Developers need to be very, very careful with using them. Mozilla does not offer documentation on using them to build add-ons."
 msgstr ""
 "Ja. Het is mogelijk, maar een deel van de door deze bibliotheken geboden functionaliteit is beschikbaar via XPCOM, XUL en JavaScript. Daarbij moeten schrijvers opletten of bibliothekenprimitieve "
 "objectprototypes (String.prototype, Date.prototype, enz.) wijzigen en/of globale functies (bijv. de $-functie) definiëren. Deze zijn gevoelig voor conflicten met andere add-ons, vooral als andere "
@@ -10012,8 +9851,8 @@ msgstr "Kan ik mijn eigen add-on hosten?"
 #, python-format
 msgid ""
 "Yes. Many developers choose to host their own add-ons. Choosing to host your add-on on <a href=\"%(amo_url)s\">Mozilla's add-on site</a>, though, allows for much greater exposure to your add-on due "
-"to the large volume of visitors to the site.  <a href=\"%(md_url)s\">mozdev.org</a> offers free project hosting for Mozilla applications and extensions providing developers with tools to help "
-"manage source code, version control, bug tracking and documentation."
+"to the large volume of visitors to the site. <a href=\"%(md_url)s\">mozdev.org</a> offers free project hosting for Mozilla applications and extensions providing developers with tools to help manage "
+"source code, version control, bug tracking and documentation."
 msgstr ""
 "Ja, Veel ontwikkelaars kiezen ervoor hun eigen add-ons te hosten. Door er echter voor te kiezen uw add-on op de <a href=\"%(amo_url)s\">add-onwebsite van Mozilla</a> te laten hosten krijgt uw add-"
 "on meer aandacht door het grote aantal websitebezoekers. <a href=\"%(md_url)s\">mozdev.org</a> biedt gratis projecthosting voor Mozilla-toepassingen en extensies, en biedt ontwikkelaar hulpmiddelen "
@@ -10068,7 +9907,7 @@ msgstr "Heeft Mozilla een beleid over wat een acceptabele bijdrage is?"
 #: src/olympia/pages/templates/pages/dev_faq.html:314
 #, python-format
 msgid ""
-"Yes. Mozilla's <a href=\"%(p_url)s\">Add-on Policy</a> describes what is an acceptable submission. This policy is subject to change without notice.  In addition, the AMO editorial team uses the <a "
+"Yes. Mozilla's <a href=\"%(p_url)s\">Add-on Policy</a> describes what is an acceptable submission. This policy is subject to change without notice. In addition, the AMO editorial team uses the <a "
 "href=\"%(g_url)s\">Editors Reviewing Guide</a> to ensure that your add-on meets specific guidelines for functionality and security."
 msgstr ""
 "Ja. Mozilla’s <a href=\"%(p_url)s\">Add-onbeleid</a> beschrijft wat een acceptabele inzending is. Dit beleid kan zonder bericht worden gewijzigd. Daarnaast gebruikt het editorteam van AMO de <a "
@@ -10200,7 +10039,7 @@ msgstr "het aantal ontdekte probleemgebieden"
 #: src/olympia/pages/templates/pages/dev_faq.html:434
 #, python-format
 msgid ""
-"This is why it's very important to read the <a href=\"%(g_url)s\">Editors Reviewing Guide</a> to ensure that your add-on is setup as expected.  It's also a good idea to read the blog post, <a href="
+"This is why it's very important to read the <a href=\"%(g_url)s\">Editors Reviewing Guide</a> to ensure that your add-on is setup as expected. It's also a good idea to read the blog post, <a href="
 "\"%(blog_url)s\">Successfully Getting your Add-on Reviewed</a> which provides excellent insight into ensuring a smooth review of your add-on."
 msgstr ""
 "Daarom is het zeer belangrijk om de <a href=\"%(g_url)s\">Beoordelingsgids voor editors</a> te lezen om ervoor te zorgen dat uw add-on is opgezet volgens de verwachtingen. Het is ook een goed idee "
@@ -10320,7 +10159,7 @@ msgstr ""
 
 #: src/olympia/pages/templates/pages/dev_faq.html:572
 msgid ""
-"Free Software Foundation provides short summaries of the key open source licenses, including whether the license qualifies as a free software license or a copyleft license.  Also includes a "
+"Free Software Foundation provides short summaries of the key open source licenses, including whether the license qualifies as a free software license or a copyleft license. Also includes a "
 "discussion of what constitutes a free software license or a copyleft license (e.g., a Copyleft license is a general method for making a program or other work free, and requiring all modified and "
 "extended versions of the program to be free as well.)"
 msgstr ""
@@ -10528,19 +10367,13 @@ msgid "Add-on Gallery"
 msgstr "Add-ongalerij"
 
 #: src/olympia/pages/templates/pages/faq.html:171
-msgid ""
-"How do I choose between add-ons that seem to do the same\n"
-"    thing?"
+msgid "How do I choose between add-ons that seem to do the same thing?"
 msgstr "Hoe kies ik tussen add-ons die hetzelfde lijken te doen?"
 
-#: src/olympia/pages/templates/pages/faq.html:173
+#: src/olympia/pages/templates/pages/faq.html:172
 msgid ""
-"There are often several add-ons that have similar features. To\n"
-"    figure out which is right for you, read the entire description of the\n"
-"    add-on and view its screenshots. If there are still several in the running,\n"
-"    read through the add-on's ratings, user reviews, and statistics to see\n"
-"    which is most liked by other users. Remember that you can also just try\n"
-"    out both and see which you like better."
+"There are often several add-ons that have similar features. To figure out which is right for you, read the entire description of the add-on and view its screenshots. If there are still several in "
+"the running, read through the add-on's ratings, user reviews, and statistics to see which is most liked by other users. Remember that you can also just try out both and see which you like better."
 msgstr ""
 "Er zijn vaak diverse add-ons met vergelijkbare functies. Lees om te ontdekken welke passend is voor u de volledige beschrijving van de add-on en bekijk de schermafdrukken. Als er dan nog steeds "
 "meerdere keuzemogelijkheden zijn, lees dan door de waarderingen van de add-ons, de gebruikersbeoordelingen en de statistieken om te ontdekken welke het meest in de smaak valt bij andere gebruikers. "
@@ -10591,40 +10424,34 @@ msgid "How much do add-ons cost to purchase?"
 msgstr "Hoe duur zijn add-ons in aanschaf?"
 
 #: src/olympia/pages/templates/pages/faq.html:207
-msgid ""
-"Add-ons hosted in our gallery are free unless clearly marked\n"
-"    otherwise."
+msgid "Add-ons hosted in our gallery are free unless clearly marked otherwise."
 msgstr "In onze galerij gehoste add-ons zijn gratis, tenzij duidelijk anderszins aangeduid."
 
-#: src/olympia/pages/templates/pages/faq.html:210
+#: src/olympia/pages/templates/pages/faq.html:209
 msgid "What does it mean when an add-on asks for contributions?"
 msgstr "Wat betekent het wanneer een add-on vraagt om een bijdrage?"
 
-#: src/olympia/pages/templates/pages/faq.html:211
+#: src/olympia/pages/templates/pages/faq.html:210
 msgid ""
-"Some add-on authors request users who enjoy an add-on to\n"
-"        contribute to its development by making a monetary contribution. These\n"
-"        contributions go directly to the developer unless a third party is\n"
-"        indicated, such as the non-profit Mozilla Foundation."
+"Some add-on authors request users who enjoy an add-on to contribute to its development by making a monetary contribution. These contributions go directly to the developer unless a third party is "
+"indicated, such as the non-profit Mozilla Foundation."
 msgstr ""
 "Sommige add-onschrijvers vragen tevreden gebruikers van een add-on om een geldelijke bijdrage aan de ontwikkeling. Deze bijdragen gaan rechtstreeks naar de ontwikkelaar, tenzij een derde partij "
 "wordt aangeduid, zoals de nonprofit Mozilla Foundation."
 
-#: src/olympia/pages/templates/pages/faq.html:216
+#: src/olympia/pages/templates/pages/faq.html:215
 msgid "What are beta add-ons?"
 msgstr "Wat zijn bèta-add-ons?"
 
-#: src/olympia/pages/templates/pages/faq.html:218
+#: src/olympia/pages/templates/pages/faq.html:217
 msgid ""
-"Beta add-ons are unreviewed versions which represent the\n"
-"        latest work of an add-on author. While different authors have different\n"
-"        standards for beta code quality, you should assume that these add-ons\n"
-"        are less stable than the general add-on releases."
+"Beta add-ons are unreviewed versions which represent the latest work of an add-on author. While different authors have different standards for beta code quality, you should assume that these add-"
+"ons are less stable than the general add-on releases."
 msgstr ""
 "Bèta-add-ons zijn niet beoordeelde versies die het laatste werk van een add-on-schrijver weergeven. Hoewel verschillende schrijvers verschillende normen hanteren voor de kwaliteit van bètacode, "
 "dient u aan te nemen dat deze add-ons minder stabiel zijn dan normale uitgegeven versies."
 
-#: src/olympia/pages/templates/pages/faq.html:222
+#: src/olympia/pages/templates/pages/faq.html:221
 msgid ""
 "Please note that when you install an add-on from the \"Beta Version\" section of an add-on's listing, you will continue to receive updates for that add-on as they become available. Like the initial "
 "version you installed, all beta releases are unreviewed by Mozilla and may harm your computer."
@@ -10632,49 +10459,42 @@ msgstr ""
 "Bedenk dat als u een add-on uit de sectie ‘bètaversie’ van een add-onpagina installeert, u updates voor die add-on zult blijven ontvangen zodra ze beschikbaar komen. Net als de oorspronkelijk "
 "geïnstalleerde versie zijn alle bètaversies niet door Mozilla beoordeeld en kunnen deze uw computer beschadigen."
 
-#: src/olympia/pages/templates/pages/faq.html:229
-msgid ""
-"What does it mean when an add-on is flagged as\n"
-"    slow?"
+#: src/olympia/pages/templates/pages/faq.html:228
+msgid "What does it mean when an add-on is flagged as slow?"
 msgstr "Wat betekent het als een add-on als langzaam is gemarkeerd?"
 
-#: src/olympia/pages/templates/pages/faq.html:231
-msgid ""
-"Most add-ons load code and resources at the same time Firefox\n"
-"        is starting up. In most cases the impact in start-up time is minimal,\n"
-"        but some add-ons can cause a noticeable slowdown."
+#: src/olympia/pages/templates/pages/faq.html:229
+msgid "Most add-ons load code and resources at the same time Firefox is starting up. In most cases the impact in start-up time is minimal, but some add-ons can cause a noticeable slowdown."
 msgstr ""
 "De meeste add-ons laden code en hulpbronnen tijdens het opstarten van Firefox. In de meeste gevallen is de invloed op de opstarttijd verwaarloosbaar, maar sommige add-ons kunnen een waarneembare "
 "vertraging veroorzaken."
 
-#: src/olympia/pages/templates/pages/faq.html:236
+#: src/olympia/pages/templates/pages/faq.html:234
 msgid "How do I report an inappropriate or spam user review?"
 msgstr "Hoe rapporteer ik een ongepaste gebruikersbeoordeling of een beoordeling met spam?"
 
-#: src/olympia/pages/templates/pages/faq.html:237
+#: src/olympia/pages/templates/pages/faq.html:235
 msgid ""
-"To report a user review of an add-on, log in with your account\n"
-"    and visit the add-on's reviews page. Find the review you wish to report,\n"
-"    click \"Report this review\" and select a reason. Our editorial team will\n"
-"    investigate the review and take appropriate action."
+"To report a user review of an add-on, log in with your account and visit the add-on's reviews page. Find the review you wish to report, click \"Report this review\" and select a reason. Our "
+"editorial team will investigate the review and take appropriate action."
 msgstr ""
 "Meld u aan met uw account en bezoek de beoordelingspagina van de add-on om een gebruikersbeoordeling van een add-on te melden. Zoek de beoordeling die u wilt melden, klik op ‘Deze beoordeling "
 "melden’ en selecteer een reden. Ons editorteam onderzoekt de beoordeling en neemt toepasselijke actie."
 
-#: src/olympia/pages/templates/pages/faq.html:242
+#: src/olympia/pages/templates/pages/faq.html:240
 msgid "How do I report a bug or contact the Mozilla Add-ons team?"
 msgstr "Hoe kan ik een fout melden of contact opnemen met het Mozilla Add-ons-team?"
 
-#: src/olympia/pages/templates/pages/faq.html:243
+#: src/olympia/pages/templates/pages/faq.html:241
 #, python-format
 msgid "Please visit our <a href=\"%(contact_url)s\">Contact page</a>."
 msgstr "Bezoek onze <a href=\"%(contact_url)s\">contactpagina</a>."
 
-#: src/olympia/pages/templates/pages/faq.html:246
+#: src/olympia/pages/templates/pages/faq.html:244
 msgid "What is a Source Code License?"
 msgstr "Wat is een broncodelicentie?"
 
-#: src/olympia/pages/templates/pages/faq.html:247
+#: src/olympia/pages/templates/pages/faq.html:245
 #, python-format
 msgid ""
 "The source code used to create an add-on is an exclusive copyright of the add-on author, unless otherwise declared in a source code license. Many add-ons on this site have <a href=\"%(url)s\" lang="
@@ -10685,42 +10505,42 @@ msgstr ""
 "website hebben <a href=\"%(url)s\" lang=\"nl\">opensourcelicenties</a> die de broncode beschikbaar stellen voor kopiëren en hergebruik onder voorwaarden zoals vastgesteld door de schrijver. De "
 "meeste schrijvers kiezen algemeen bekende opensourcelicenties zoals de GPL- of BSD-licenties in plaats van er zelf één te verzinnen."
 
-#: src/olympia/pages/templates/pages/faq.html:256
+#: src/olympia/pages/templates/pages/faq.html:254
 #, python-format
 msgid "Firefox and other Mozilla software are <a href=\"%(url)s\">open source</a>."
 msgstr "Firefox en andere Mozilla-software zijn <a href=\"%(url)s\">opensource</a>."
 
-#: src/olympia/pages/templates/pages/faq.html:264
+#: src/olympia/pages/templates/pages/faq.html:262
 msgid "Collections and Favorites"
 msgstr "Collecties en favorieten"
 
-#: src/olympia/pages/templates/pages/faq.html:267
+#: src/olympia/pages/templates/pages/faq.html:265
 msgid "What is a collection?"
 msgstr "Wat is een collectie?"
 
-#: src/olympia/pages/templates/pages/faq.html:268
+#: src/olympia/pages/templates/pages/faq.html:266
 msgid "Collections are groups of related add-ons created by users to share."
 msgstr "Collecties zijn groepen gerelateerde add-ons die door gebruikers worden gemaakt om te delen."
 
-#: src/olympia/pages/templates/pages/faq.html:270
+#: src/olympia/pages/templates/pages/faq.html:268
 msgid "What is the My Favorites collection?"
 msgstr "Wat is de collectie Mijn favorieten?"
 
-#: src/olympia/pages/templates/pages/faq.html:271
+#: src/olympia/pages/templates/pages/faq.html:269
 msgid "Favorite add-ons are add-ons that you have bookmarked to easily get back to later. You can add an add-on to your favorites collection by clicking \"Add to favorites\" on its details page."
 msgstr ""
 "Favoriete add-ons zijn add-ons die u hebt gemarkeerd om makkelijk later terug te vinden. U kunt een add-on aan uw favorietencollectie toevoegen door op ‘Toevoegen aan favorieten’ op de detailpagina "
 "ervan te klikken."
 
-#: src/olympia/pages/templates/pages/faq.html:275 src/olympia/templates/menu_links.html:13 src/olympia/templates/impala/header_title.html:17
+#: src/olympia/pages/templates/pages/faq.html:273 src/olympia/templates/menu_links.html:13 src/olympia/templates/impala/header_title.html:17
 msgid "Mobile Add-ons"
 msgstr "Add-ons voor Mobiel"
 
-#: src/olympia/pages/templates/pages/faq.html:278
+#: src/olympia/pages/templates/pages/faq.html:276
 msgid "What are mobile add-ons?"
 msgstr "Wat zijn mobiele add-ons?"
 
-#: src/olympia/pages/templates/pages/faq.html:279
+#: src/olympia/pages/templates/pages/faq.html:277
 #, python-format
 msgid ""
 "Mobile add-ons work with <a href=\"%(mobile_url)s\">Firefox for Mobile</a> and add or modify functionality just like desktop add-ons. You can find add-ons that work with Firefox for Mobile in our "
@@ -10729,21 +10549,21 @@ msgstr ""
 "Add-ons voor Mobiel werken met <a href=\"%(mobile_url)s\">Firefox voor Mobiel</a> en voegen functionaliteit toe of wijzigen deze, net als add-ons voor een desktop. U kunt add-ons die met Firefox "
 "voor Mobiel werken vinden in onze <a href=\"%(gallery_url)s\">galerij</a>."
 
-#: src/olympia/pages/templates/pages/faq.html:288
+#: src/olympia/pages/templates/pages/faq.html:286
 msgid "Developer Topics"
 msgstr "Ontwikkelaarsonderwerpen"
 
-#: src/olympia/pages/templates/pages/faq.html:289
+#: src/olympia/pages/templates/pages/faq.html:287
 #, python-format
 msgid "Please see our <a href=\"%(faq_url)s\">Developer FAQ</a> and <a href=\"%(hub_url)s\">Developer Hub</a> for answers to add-on developer-related questions."
 msgstr ""
 "Zie onze <a href=\"%(faq_url)s\">Veelgestelde vragen voor ontwikkelaars</a> en <a href=\"%(hub_url)s\">Ontwikkelaarshub</a> voor antwoorden op vragen met betrekking tot de ontwikkeling van add-ons."
 
-#: src/olympia/pages/templates/pages/faq.html:294
+#: src/olympia/pages/templates/pages/faq.html:292
 msgid "Still have questions?"
 msgstr "Nog steeds vragen?"
 
-#: src/olympia/pages/templates/pages/faq.html:295
+#: src/olympia/pages/templates/pages/faq.html:293
 #, python-format
 msgid "For general Firefox support, visit our <a href=\"%(sumo_url)s\">support website</a>. For general add-on and website questions, visit our <a href=\"%(forum_url)s\">forum</a>."
 msgstr ""
@@ -10892,7 +10712,7 @@ msgstr "Sunbird is met pensioen"
 
 #: src/olympia/pages/templates/pages/sunbird.html:29
 msgid ""
-"Development on the Sunbird project has halted and its final release was on March 30, 2010.  We've been proud to host Sunbird add-ons on this site but as the project is no longer maintained we have "
+"Development on the Sunbird project has halted and its final release was on March 30, 2010. We've been proud to host Sunbird add-ons on this site but as the project is no longer maintained we have "
 "disabled our support for the add-ons."
 msgstr ""
 "De ontwikkeling van het Sunbird-project is gestopt en de laatste versie dateert van 30 maart 2010. We zijn er trots op dat we op deze website add-ons voor Sunbird hebben mogen hosten, maar "
@@ -10972,7 +10792,7 @@ msgstr "Een beoordeling voor {0} toevoegen"
 #, python-format
 msgid ""
 "<h2>Keep these tips in mind:</h2> <ul> <li> Write like you're telling a friend about your experience with the add-on. Give specifics and helpful details, such as what features you liked and/or "
-"disliked, how easy to use it is, and any disadvantages it has.  Avoid generic language such as calling it \"Great\" or \"Bad\" unless you can give reasons why you believe this is so. </li> <li> "
+"disliked, how easy to use it is, and any disadvantages it has. Avoid generic language such as calling it \"Great\" or \"Bad\" unless you can give reasons why you believe this is so. </li> <li> "
 "Please do not post bug reports in reviews. We do not make your email address available to add-on developers and they may need to contact you to help resolve your issue. See the <a href=\"%(support)s"
 "\">support section</a> to find out where to get assistance for this add-on. </li> <li>Please keep reviews clean, avoid the use of improper language and do not post any personal information. </li> </"
 "ul> <p>Please read the <a href=\"%(guide)s\" target=\"_blank\">Review Guidelines</a> for more detail about user add-on reviews.</p>"
@@ -11229,16 +11049,16 @@ msgstr "{0}-add-ons"
 
 #. L10n: {0} is an application, such as Firefox. This means "any version of
 #. Firefox."
-#: src/olympia/search/views.py:554
+#: src/olympia/search/views.py:547
 msgid "Any {0}"
 msgstr "Alle {0}-versies"
 
 #. L10n: "All Systems" means show everything regardless of platform.
-#: src/olympia/search/views.py:589
+#: src/olympia/search/views.py:582
 msgid "All Systems"
 msgstr "Alle systemen"
 
-#: src/olympia/search/views.py:600
+#: src/olympia/search/views.py:593
 msgid "All Tags"
 msgstr "Alle labels"
 
@@ -11416,31 +11236,31 @@ msgstr "Deze add-on delen"
 msgid "Share this Collection"
 msgstr "Deze collectie delen"
 
-#: src/olympia/signing/views.py:30 src/olympia/templates/base.html:75 src/olympia/templates/impala/base.html:115
+#: src/olympia/signing/views.py:33 src/olympia/templates/base.html:71 src/olympia/templates/impala/base.html:112
 msgid "Some features are temporarily disabled while we perform website maintenance. We'll be back to full capacity shortly."
 msgstr "Enkele functies zijn tijdelijk uitgeschakeld vanwege onderhoud aan de website. Binnenkort zijn we weer volledig beschikbaar."
 
-#: src/olympia/signing/views.py:53
+#: src/olympia/signing/views.py:56
 msgid "Could not find add-on with id \"{}\"."
 msgstr "Kon geen add-on met id ‘{}’ vinden."
 
-#: src/olympia/signing/views.py:67
+#: src/olympia/signing/views.py:70
 msgid "You do not own this addon."
 msgstr "Deze add-on is niet van u."
 
-#: src/olympia/signing/views.py:82
+#: src/olympia/signing/views.py:87
 msgid "Missing \"upload\" key in multipart file data."
 msgstr "‘upload’-sleutel in multipart-bestandsgegevens ontbreekt."
 
-#: src/olympia/signing/views.py:96
+#: src/olympia/signing/views.py:101
 msgid "Version does not match the manifest file."
 msgstr "Versie komt niet overeen met het manifest-bestand."
 
-#: src/olympia/signing/views.py:100
+#: src/olympia/signing/views.py:105
 msgid "Version already exists."
 msgstr "Versie bestaat al."
 
-#: src/olympia/signing/views.py:136
+#: src/olympia/signing/views.py:141
 msgid "No uploaded file for that addon and version."
 msgstr "Geen geüpload bestand voor die add-on en versie."
 
@@ -11553,91 +11373,91 @@ msgstr "{0} :: Statistiekendashboard"
 msgid "Statistics Dashboard :: Add-ons for {0}"
 msgstr "Statistiekendashboard :: Add-ons voor {0}"
 
-#: src/olympia/stats/templates/stats/stats.html:30
-msgid "Controls:"
-msgstr "Besturing:"
-
-#: src/olympia/stats/templates/stats/stats.html:33
-msgid "reset zoom"
-msgstr "zoom herstellen"
-
-#: src/olympia/stats/templates/stats/stats.html:40
-msgid "Group by:"
-msgstr "Groeperen op:"
-
-#: src/olympia/stats/templates/stats/stats.html:42
-msgid "day"
-msgstr "dag"
-
-#: src/olympia/stats/templates/stats/stats.html:45
-msgid "week"
-msgstr "week"
-
-#: src/olympia/stats/templates/stats/stats.html:48
-msgid "month"
-msgstr "maand"
-
-#: src/olympia/stats/templates/stats/stats.html:54
-msgid "For last:"
-msgstr "Voor de afgelopen:"
-
-#: src/olympia/stats/templates/stats/stats.html:57
-msgid "7 days"
-msgstr "7 dagen"
-
-#: src/olympia/stats/templates/stats/stats.html:60
-msgid "30 days"
-msgstr "30 dagen"
-
-#: src/olympia/stats/templates/stats/stats.html:63
-msgid "90 days"
-msgstr "90 dagen"
-
-#: src/olympia/stats/templates/stats/stats.html:66
-msgid "365 days"
-msgstr "365 dagen"
-
-#: src/olympia/stats/templates/stats/stats.html:69
-msgid "Custom..."
-msgstr "Aangepast…"
-
 #. {0} is an add-on name
-#: src/olympia/stats/templates/stats/stats.html:88 src/olympia/stats/templates/stats/stats.html:91
+#: src/olympia/stats/templates/stats/stats.html:44 src/olympia/stats/templates/stats/stats.html:47
 msgid "Statistics for {0}"
 msgstr "Statistieken voor {0}"
 
-#: src/olympia/stats/templates/stats/stats.html:94
+#: src/olympia/stats/templates/stats/stats.html:50
 msgid "Statistics Dashboard"
 msgstr "Statistiekendashboard"
 
-#: src/olympia/stats/templates/stats/stats.html:104
+#: src/olympia/stats/templates/stats/stats.html:57
+msgid "Controls:"
+msgstr "Besturing:"
+
+#: src/olympia/stats/templates/stats/stats.html:60
+msgid "reset zoom"
+msgstr "zoom herstellen"
+
+#: src/olympia/stats/templates/stats/stats.html:67
+msgid "Group by:"
+msgstr "Groeperen op:"
+
+#: src/olympia/stats/templates/stats/stats.html:69
+msgid "day"
+msgstr "dag"
+
+#: src/olympia/stats/templates/stats/stats.html:72
+msgid "week"
+msgstr "week"
+
+#: src/olympia/stats/templates/stats/stats.html:75
+msgid "month"
+msgstr "maand"
+
+#: src/olympia/stats/templates/stats/stats.html:81
+msgid "For last:"
+msgstr "Voor de afgelopen:"
+
+#: src/olympia/stats/templates/stats/stats.html:84
+msgid "7 days"
+msgstr "7 dagen"
+
+#: src/olympia/stats/templates/stats/stats.html:87
+msgid "30 days"
+msgstr "30 dagen"
+
+#: src/olympia/stats/templates/stats/stats.html:90
+msgid "90 days"
+msgstr "90 dagen"
+
+#: src/olympia/stats/templates/stats/stats.html:93
+msgid "365 days"
+msgstr "365 dagen"
+
+#: src/olympia/stats/templates/stats/stats.html:96
+msgid "Custom..."
+msgstr "Aangepast…"
+
+#: src/olympia/stats/templates/stats/stats.html:106
 msgid "Statistics processing is currently disabled, so recent data is unavailable. The statistics are still being collected and this page will be updated soon with the missing data."
 msgstr ""
 "Het verwerken van statistieken is momenteel uitgeschakeld, dus er zijn geen recente gegevens beschikbaar. De statistieken worden nog steeds verzameld en deze pagina wordt binnenkort bijgewerkt met "
 "de ontbrekende gegevens."
 
-#: src/olympia/stats/templates/stats/stats.html:110
+#: src/olympia/stats/templates/stats/stats.html:112
 msgid "Loading the latest data&hellip;"
 msgstr "Laatste gegevens laden…"
 
-#: src/olympia/stats/templates/stats/stats.html:142 src/olympia/stats/templates/stats/reports/overview.html:25 src/olympia/stats/templates/stats/reports/overview.html:37
+#: src/olympia/stats/templates/stats/stats.html:144 src/olympia/stats/templates/stats/reports/overview.html:25 src/olympia/stats/templates/stats/reports/overview.html:37
 #: src/olympia/stats/templates/stats/reports/overview.html:49
 msgid "No data available."
 msgstr "Geen gegevens beschikbaar."
 
-#: src/olympia/stats/templates/stats/stats.html:177
+#: src/olympia/stats/templates/stats/stats.html:179
 msgid "This dashboard is currently <b>public</b>."
 msgstr "Dit dashboard is momenteel <b>publiek</b>."
 
-#: src/olympia/stats/templates/stats/stats.html:179
+#: src/olympia/stats/templates/stats/stats.html:181
 msgid "Contribution stats are currently <b>private</b>."
 msgstr "Bijdragestatistieken zijn momenteel <b>privé</b>."
 
-#: src/olympia/stats/templates/stats/stats.html:182
+#: src/olympia/stats/templates/stats/stats.html:184
 msgid "This dashboard is currently <b>private</b>."
 msgstr "Dit dashboard is momenteel <b>privé</b>."
 
-#: src/olympia/stats/templates/stats/stats.html:185
+#: src/olympia/stats/templates/stats/stats.html:187
 msgid "Change settings."
 msgstr "Instellingen wijzigen."
 
@@ -11803,15 +11623,6 @@ msgstr "Gebruikersregistraties op datum"
 msgid "Application versions by Date"
 msgstr "Toepassingsversies op datum"
 
-#: src/olympia/tags/templates/tags/top_cloud.html:4
-msgid "Top {0} Tags"
-msgstr "Top-{0}-labels"
-
-#. {0} is the current application name
-#: src/olympia/tags/templates/tags/top_cloud.html:14
-msgid "{0} Top Tags"
-msgstr "{0} toplabels"
-
 #: src/olympia/templates/amo_footer.html:6 src/olympia/templates/includes/lang_switcher.html:2
 msgid "Other languages"
 msgstr "Andere talen"
@@ -11820,11 +11631,11 @@ msgstr "Andere talen"
 msgid "Mozilla Add-ons"
 msgstr "Mozilla-add-ons"
 
-#: src/olympia/templates/base.html:91 src/olympia/templates/impala/base.html:81
+#: src/olympia/templates/base.html:89 src/olympia/templates/impala/base.html:78
 msgid "Find add-ons for other applications"
 msgstr "Add-ons voor andere toepassingen zoeken"
 
-#: src/olympia/templates/base.html:92 src/olympia/templates/impala/base.html:81
+#: src/olympia/templates/base.html:90 src/olympia/templates/impala/base.html:78
 msgid "Other Applications"
 msgstr "Andere toepassingen"
 
@@ -11849,7 +11660,7 @@ msgid "View Mobile Site"
 msgstr "Mobiel-website bekijken"
 
 #: src/olympia/templates/copyright.html:7
-msgid "Site Status "
+msgid "Site Status"
 msgstr "Websitestatus"
 
 #: src/olympia/templates/footer.html:3
@@ -11951,35 +11762,35 @@ msgstr "Welkom {0}"
 msgid "<a href=\"%(reg)s\">Register</a> or <a href=\"%(login)s\">Log in</a>"
 msgstr "<a href=\"%(reg)s\">Registreren</a> of <a href=\"%(login)s\">aanmelden</a>"
 
-#: src/olympia/templates/impala/base.html:126
+#: src/olympia/templates/impala/base.html:123
 #, python-format
 msgid "To try the thousands of add-ons available here, download <a href=\"%(url)s\">Mozilla Firefox</a>, a fast, free way to surf the Web!"
 msgstr "Download <a href=\"%(url)s\">Mozilla Firefox</a>, een snelle, gratis manier om op het Web te surfen, om de duizenden hier beschikbare add-ons te proberen!"
 
-#: src/olympia/templates/impala/base.html:138
+#: src/olympia/templates/impala/base.html:135
 #, python-format
 msgid "Add-ons is switching to Firefox Accounts for login. <a href=\"%(url)s\" class=\"fxa-login\">Sign in now to transfer your account.</a>"
 msgstr "Add-ons stapt voor het aanmeldproces over naar Firefox Accounts. <a href=\"%(url)s\" class=\"fxa-login\">Meld u nu aan om uw account over te zetten.</a>"
 
 #. {0} is an application, such as Firefox.
-#: src/olympia/templates/impala/base.html:148
+#: src/olympia/templates/impala/base.html:145
 msgid "Welcome to {0} Add-ons."
 msgstr "Welkom bij {0} Add-ons."
 
-#: src/olympia/templates/impala/base.html:151
+#: src/olympia/templates/impala/base.html:148
 msgid "Choose from thousands of extra features and styles to make Firefox your own."
 msgstr "Kies uit duizenden extra functies en stijlen om Firefox van u te maken."
 
-#: src/olympia/templates/impala/base.html:156
+#: src/olympia/templates/impala/base.html:153
 #, python-format
 msgid "Add extra features and styles to make %(app)s your own."
 msgstr "Voeg extra functies en stijlen toe om %(app)s helemaal van u te maken."
 
-#: src/olympia/templates/impala/base.html:164
+#: src/olympia/templates/impala/base.html:161
 msgid "On the go?"
 msgstr "Onderweg?"
 
-#: src/olympia/templates/impala/base.html:166
+#: src/olympia/templates/impala/base.html:163
 msgid "Check out our <a class=\"mobile-link\" href=\"#\">Mobile Add-ons site</a>."
 msgstr "Kijk eens op onze <a class=\"mobile-link\" href=\"#\">Mobiel-add-onswebsite</a>."
 
@@ -12205,19 +12016,19 @@ msgstr "Er is geen gebruiker met dat e-mailadres."
 
 #. L10n: {id} will be something like "13ad6a", just a random number
 #. to differentiate this user from other anonymous users.
-#: src/olympia/users/models.py:353
+#: src/olympia/users/models.py:362
 msgid "Anonymous user {id}"
 msgstr "Anonieme gebruiker {id}"
 
-#: src/olympia/users/models.py:410
+#: src/olympia/users/models.py:419
 msgid "Your account has been restricted"
 msgstr "Uw account is beperkt"
 
-#: src/olympia/users/models.py:480
+#: src/olympia/users/models.py:489
 msgid "Please confirm your email address"
 msgstr "Bevestig uw e-mailadres"
 
-#: src/olympia/users/models.py:506
+#: src/olympia/users/models.py:515
 msgid "My Mobile Add-ons"
 msgstr "Mijn Mobiel-add-ons"
 
@@ -12503,7 +12314,7 @@ msgstr "Wachtwoord"
 
 #: src/olympia/users/templates/users/edit.html:70
 #, python-format
-msgid "Change your password.  If you forgot your password, you can <a href=\"%(reset_url)s\">use the reset form</a>."
+msgid "Change your password. If you forgot your password, you can <a href=\"%(reset_url)s\">use the reset form</a>."
 msgstr "Wijzig uw wachtwoord. Als u uw wachtwoord bent vergeten, dan kunt u <a href=\"%(reset_url)s\">het formulier voor opnieuw instellen gebruiken</a>."
 
 #: src/olympia/users/templates/users/edit.html:76
@@ -12523,7 +12334,7 @@ msgid "Profile"
 msgstr "Profiel"
 
 #: src/olympia/users/templates/users/edit.html:100
-msgid "Give us a bit more information about yourself.  All these fields are optional, but they'll help other users get to know you better."
+msgid "Give us a bit more information about yourself. All these fields are optional, but they'll help other users get to know you better."
 msgstr "Geef ons wat meer informatie over uzelf. Al deze velden zijn optioneel, maar ze helpen andere gebruikers om u wat beter te leren kennen."
 
 #: src/olympia/users/templates/users/edit.html:124
@@ -12743,7 +12554,7 @@ msgid "Confirm password"
 msgstr "Wachtwoord bevestigen"
 
 #: src/olympia/users/templates/users/pwreset_confirm.html:47
-msgid "The password reset link was invalid, possibly because it has already been used.  Please request a new password reset."
+msgid "The password reset link was invalid, possibly because it has already been used. Please request a new password reset."
 msgstr "De koppeling voor opnieuw instellen van het wachtwoord was ongeldig, mogelijk omdat deze al eens is gebruikt. Vraag een nieuwe instelkoppeling aan."
 
 #: src/olympia/users/templates/users/pwreset_request.html:15
@@ -12934,7 +12745,7 @@ msgstr "We kunnen uw abonnement niet stopzetten"
 
 #: src/olympia/users/templates/users/unsubscribe.html:30
 #, python-format
-msgid "Unfortunately, we weren't able to unsubscribe you.  The link you clicked is invalid. However, you can unsubscribe still unsubscribe on your <a href=\"%(edit_url)s\">edit profile page</a>."
+msgid "Unfortunately, we weren't able to unsubscribe you. The link you clicked is invalid. However, you can unsubscribe still unsubscribe on your <a href=\"%(edit_url)s\">edit profile page</a>."
 msgstr "We kunnen u helaas niet afmelden. De door u aangeklikte koppeling is niet geldig. U kunt zich echter nog steeds afmelden op uw <a href=\"%(edit_url)s\">profielpagina</a>."
 
 #: src/olympia/users/templates/users/vcard.html:2
@@ -12988,15 +12799,15 @@ msgstr "%s-versiegeschiedenis"
 msgid "Version History with Changelogs"
 msgstr "Versiegeschiedenis met overzicht van wijzigingen"
 
-#: src/olympia/versions/models.py:314
+#: src/olympia/versions/models.py:313
 msgid "Add-on uses binary components."
 msgstr "Add-on gebruikt binaire componenten."
 
-#: src/olympia/versions/models.py:317
+#: src/olympia/versions/models.py:316
 msgid "Add-on has opted into strict compatibility checking."
 msgstr "Add-on heeft geopteerd voor strenge compatibiliteitscontrole."
 
-#: src/olympia/versions/models.py:715
+#: src/olympia/versions/models.py:711
 msgid "{app} {min} and later"
 msgstr "{app} {min} en hoger"
 
@@ -13073,3 +12884,7 @@ msgstr "E-mail bij voltooiing"
 #: src/olympia/zadmin/forms.py:105
 msgid "Log emails instead of sending"
 msgstr "E-mailberichten loggen in plaats van verzenden"
+
+#: src/olympia/zadmin/forms.py:215
+msgid "Deleted versions can`t be changed."
+msgstr ""

--- a/locale/nl/LC_MESSAGES/djangojs.po
+++ b/locale/nl/LC_MESSAGES/djangojs.po
@@ -3,136 +3,393 @@ msgid ""
 msgstr ""
 "Project-Id-Version:  \n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2016-02-24 21:23+0000\n"
+"POT-Creation-Date: 2016-04-18 15:47+0000\n"
 "PO-Revision-Date: 2015-12-15 21:55+0000\n"
 "Last-Translator: Mark Heijl <markh@babelzilla.org>\n"
 "Language-Team: DUTCH <LL@li.org>\n"
+"Language: \n"
 "MIME-Version: 1.0\n"
-"Content-Type: text/plain; charset=utf-8\n"
+"Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Generated-By: Babel 2.2.0\n"
 
-#: static/js/common/ratingwidget.js:31
+#: static/js/common-all.js:1426 static/js/impala-all.js:1511 static/js/zamboni/discovery-all.js:12598 static/js/zamboni/init.js:28 static/js/zamboni/mobile-all.js:14945
+msgid "This feature is temporarily disabled while we perform website maintenance. Please check back a little later."
+msgstr "Deze functie is tijdelijk uitgeschakeld vanwege onderhoud aan de website. Probeer het later nog eens."
+
+#. L10n: {0} is an app name like Firefox.
+#: static/js/common-all.js:1837 static/js/impala-all.js:1922 static/js/zamboni/buttons.js:73 static/js/zamboni/discovery-all.js:13108
+msgid "Accept and Install"
+msgstr "Accepteren en installeren"
+
+#: static/js/common-all.js:1837 static/js/impala-all.js:1922 static/js/zamboni/buttons.js:73 static/js/zamboni/discovery-all.js:13108
+msgid "Add to {0}"
+msgstr "Toevoegen aan {0}"
+
+#: static/js/common-all.js:1842 static/js/impala-all.js:1927 static/js/zamboni/buttons.js:78 static/js/zamboni/discovery-all.js:13113
+msgid "Download Now"
+msgstr "Nu downloaden"
+
+#: static/js/common-all.js:1883 static/js/impala-all.js:1968 static/js/zamboni/buttons.js:119 static/js/zamboni/discovery-all.js:13154
+msgid "Add-on has not been updated to support default-to-compatible."
+msgstr "Add-on is niet bijgewerkt om standaard-compatibel te ondersteunen."
+
+#: static/js/common-all.js:1888 static/js/impala-all.js:1973 static/js/zamboni/buttons.js:124 static/js/zamboni/discovery-all.js:13159
+msgid "You need to be using Firefox 10.0 or higher."
+msgstr "U dient Firefox 10.0 of hoger te gebruiken."
+
+#: static/js/common-all.js:1900 static/js/impala-all.js:1985 static/js/zamboni/buttons.js:136 static/js/zamboni/discovery-all.js:13171
+msgid "Mozilla has marked this version as incompatible with your Firefox version."
+msgstr "Mozilla heeft deze versie als niet-compatibel met uw Firefox-versie gemarkeerd."
+
+#. L10n: {0} is an platform like Windows or Linux.
+#: static/js/common-all.js:1981 static/js/impala-all.js:2066 static/js/zamboni/buttons.js:217 static/js/zamboni/discovery-all.js:13252
+msgid "Install for {0} anyway"
+msgstr "Toch installeren voor {0}"
+
+#: static/js/common-all.js:1981 static/js/impala-all.js:2066 static/js/zamboni/buttons.js:217 static/js/zamboni/discovery-all.js:13252
+msgid "Download for {0} anyway"
+msgstr "Toch downloaden voor {0}"
+
+#: static/js/common-all.js:2038 static/js/impala-all.js:2123 static/js/zamboni/buttons.js:274 static/js/zamboni/discovery-all.js:13309
+msgid "Not available for your platform"
+msgstr "Niet beschikbaar voor uw platform"
+
+#. L10n: {0} is an app name, {1} is the app version.
+#: static/js/common-all.js:2049 static/js/common-all.js:2086 static/js/impala-all.js:2134 static/js/impala-all.js:2171 static/js/zamboni/buttons.js:286 static/js/zamboni/buttons.js:324
+#: static/js/zamboni/discovery-all.js:13320 static/js/zamboni/discovery-all.js:13357
+msgid "Not available for {0} {1}"
+msgstr "Niet beschikbaar voor {0} {1}"
+
+#: static/js/common-all.js:2112 static/js/impala-all.js:2197 static/js/zamboni/buttons.js:351 static/js/zamboni/discovery-all.js:13383
+msgid "Works with {app} {min} - {max}"
+msgstr "Werkt met {app} {min} - {max}"
+
+#: static/js/common-all.js:2114 static/js/impala-all.js:2199 static/js/zamboni/buttons.js:353 static/js/zamboni/discovery-all.js:13385
+msgid "View other versions"
+msgstr "Overige versies bekijken"
+
+#: static/js/common-all.js:2162 static/js/impala-all.js:2247 static/js/zamboni/buttons.js:401 static/js/zamboni/discovery-all.js:13433
+msgid "Only with Firefox — Get Firefox Now!"
+msgstr "Alleen bij Firefox – Download Firefox nu!"
+
+#: static/js/common-all.js:2278 static/js/impala-all.js:2363 static/js/zamboni/buttons.js:517 static/js/zamboni/discovery-all.js:13549 static/js/zamboni/mobile-all.js:15177
+#: static/js/zamboni/mobile/buttons.js:43
+msgid "Sorry, you need a Mozilla-based browser (such as Firefox) to install a search plugin."
+msgstr "Sorry, u hebt een op Mozilla gebaseerde browser (zoals Firefox) nodig om een zoekplug-in te kunnen installeren."
+
+#: static/js/common-all.js:9088 static/js/impala-all.js:9649 static/js/zamboni/global.js:410
+msgid "Loading..."
+msgstr "Laden…"
+
+#. L10n: {0} is the number of characters left.
+#: static/js/common-all.js:9152 static/js/impala-all.js:9713 static/js/zamboni/global.js:474
+msgid "<b>{0}</b> character left."
+msgid_plural "<b>{0}</b> characters left."
+msgstr[0] "<b>{0}</b> teken resterend."
+msgstr[1] "<b>{0}</b> tekens resterend."
+
+#: static/js/common-all.js:9589 static/js/common-min.js:6 static/js/impala-all.js:10052 static/js/impala-min.js:6 static/js/common/ratingwidget.js:31 static/js/zamboni/mobile-all.js:16123
+#: static/js/zamboni/mobile-min.js:6
 msgid "{0} star"
 msgid_plural "{0} stars"
 msgstr[0] "{0} ster"
 msgstr[1] "{0} sterren"
 
-#: static/js/common/upload-addon.js:41 static/js/common/upload-image.js:128
+#: static/js/common-all.js:9676 static/js/common-min.js:6 static/js/impala-all.js:10139 static/js/impala-min.js:6 static/js/zamboni/l10n.js:45
+msgid "Remove this localization"
+msgstr "Deze vertaling verwijderen"
+
+#: static/js/common-all.js:10193 static/js/common-min.js:6 static/js/impala-all.js:10674 static/js/impala-min.js:6 static/js/zamboni/discovery-all.js:13678
+msgid "close"
+msgstr ""
+
+#: static/js/common-all.js:10860 static/js/common-min.js:6 static/js/impala-all.js:11481 static/js/impala-min.js:6 static/js/impala/reviews.js:23 static/js/zamboni/reviews.js:18
+msgid "Flagged for review"
+msgstr "Gemarkeerd voor beoordeling"
+
+#: static/js/common-all.js:10876 static/js/common-min.js:6 static/js/impala-all.js:11498 static/js/impala-min.js:6 static/js/impala/reviews.js:40 static/js/zamboni/reviews.js:34
+msgid "Your input is required"
+msgstr "Uw bijdrage is vereist"
+
+#: static/js/common-all.js:10945 static/js/common-min.js:6 static/js/impala-all.js:11610 static/js/impala-min.js:7 static/js/impala/reviews.js:152 static/js/zamboni/reviews.js:103
+msgid "Marked for deletion"
+msgstr "Gemarkeerd voor verwijdering"
+
+#: static/js/common-all.js:11573 static/js/common-min.js:7 static/js/impala-all.js:13809 static/js/impala-min.js:8 static/js/zamboni/collections.js:229
+msgid "Adding to Favorites&hellip;"
+msgstr "Wordt toegevoegd aan Favorieten…"
+
+#: static/js/common-all.js:11576 static/js/common-min.js:7 static/js/impala-all.js:13812 static/js/impala-min.js:8 static/js/zamboni/collections.js:232
+msgid "Removing Favorite&hellip;"
+msgstr "Favoriet wordt verwijderd…"
+
+#: static/js/common-all.js:11579 static/js/common-min.js:7 static/js/impala-all.js:13815 static/js/impala-min.js:8 static/js/zamboni/collections.js:235
+msgid "Add to Favorites"
+msgstr "Toevoegen aan Favorieten"
+
+#: static/js/common-all.js:11582 static/js/common-min.js:7 static/js/impala-all.js:13818 static/js/impala-min.js:8 static/js/zamboni/collections.js:238
+msgid "Remove from Favorites"
+msgstr "Verwijderen uit Favorieten"
+
+#: static/js/common-all.js:11647 static/js/common-min.js:7 static/js/impala-all.js:13883 static/js/impala-min.js:8 static/js/zamboni/collections.js:303
+msgid "Pending"
+msgstr "In behandeling"
+
+#: static/js/common-all.js:11648 static/js/common-min.js:7 static/js/impala-all.js:13884 static/js/impala-min.js:8 static/js/zamboni/collections.js:304
+msgid "Add a comment"
+msgstr "Opmerking toevoegen"
+
+#: static/js/common-all.js:11648 static/js/common-min.js:7 static/js/impala-all.js:13884 static/js/impala-min.js:8 static/js/zamboni/collections.js:304
+msgid "Comment"
+msgstr "Opmerking"
+
+#: static/js/common-all.js:11649 static/js/common-min.js:7 static/js/impala-all.js:13885 static/js/impala-min.js:8 static/js/zamboni/collections.js:305
+msgid "Remove this add-on from the collection"
+msgstr "Deze add-on uit de collectie verwijderen"
+
+#: static/js/common-all.js:11649 static/js/common-all.js:11678 static/js/common-min.js:7 static/js/impala-all.js:13885 static/js/impala-all.js:13914 static/js/impala-min.js:8
+#: static/js/zamboni/collections.js:305 static/js/zamboni/collections.js:334
+msgid "Remove"
+msgstr "Verwijderen"
+
+#: static/js/common-all.js:11678 static/js/common-min.js:7 static/js/impala-all.js:13914 static/js/impala-min.js:8 static/js/zamboni/collections.js:334
+msgid "Remove this user as a contributor"
+msgstr "Deze gebruiker als medewerker verwijderen"
+
+#: static/js/common-all.js:11690 static/js/common-min.js:7 static/js/impala-all.js:13926 static/js/impala-min.js:8 static/js/zamboni/collections.js:346
+msgid "An email address is required."
+msgstr "Een e-mailadres is verplicht."
+
+#: static/js/common-all.js:11708 static/js/common-min.js:7 static/js/impala-all.js:13944 static/js/impala-min.js:8 static/js/zamboni/collections.js:364
+msgid "You cannot add yourself as a contributor."
+msgstr "U kunt uzelf niet als medewerker toevoegen."
+
+#: static/js/common-all.js:11710 static/js/common-min.js:7 static/js/impala-all.js:13946 static/js/impala-min.js:8 static/js/zamboni/collections.js:366
+msgid "You have already added that user."
+msgstr "U hebt die gebruiker al toegevoegd."
+
+#: static/js/common-all.js:11917 static/js/common-min.js:7 static/js/impala-all.js:14153 static/js/impala-min.js:8 static/js/zamboni/collections.js:573
+msgid "Add to favorites"
+msgstr "Toevoegen aan favorieten"
+
+#: static/js/common-all.js:11921 static/js/common-min.js:7 static/js/impala-all.js:14157 static/js/impala-min.js:8 static/js/zamboni/collections.js:577
+msgid "Remove from favorites"
+msgstr "Verwijderen uit favorieten"
+
+#: static/js/common-all.js:11939 static/js/common-min.js:7 static/js/impala-all.js:14175 static/js/impala-all.js:14233 static/js/impala-min.js:8 static/js/impala/collections.js:10
+#: static/js/zamboni/collections.js:595
+msgid "Follow this Collection"
+msgstr "Deze collectie volgen"
+
+#: static/js/common-all.js:11948 static/js/common-min.js:7 static/js/impala-all.js:14184 static/js/impala-min.js:8 static/js/zamboni/collections.js:604
+msgid "Stop following"
+msgstr "Volgen stoppen"
+
+#: static/js/common-all.js:12096 static/js/common-min.js:7 static/js/zamboni/password-strength.js:20
+msgid "Password strength:"
+msgstr "Wachtwoordsterkte:"
+
+#: static/js/common-all.js:12102 static/js/common-min.js:7 static/js/zamboni/password-strength.js:26
+msgid "At least {0} character left."
+msgid_plural "At least {0} characters left."
+msgstr[0] "Ten minste {0} teken resterend."
+msgstr[1] "Ten minste {0} tekens resterend."
+
+#: static/js/common-all.js:12286 static/js/common-min.js:7 static/js/impala-all.js:14632 static/js/impala-min.js:8 static/js/impala/suggestions.js:39
+msgid "Search themes for <b>{0}</b>"
+msgstr "Thema’s zoeken op <b>{0}</b>"
+
+#: static/js/common-all.js:12288 static/js/common-min.js:7 static/js/impala-all.js:14634 static/js/impala-min.js:8 static/js/impala/suggestions.js:41
+msgid "Search apps for <b>{0}</b>"
+msgstr "Apps doorzoeken op <b>{0}</b>"
+
+#: static/js/common-all.js:12290 static/js/common-min.js:7 static/js/impala-all.js:14636 static/js/impala-min.js:8 static/js/impala/suggestions.js:43
+msgid "Search add-ons for <b>{0}</b>"
+msgstr "Add-ons doorzoeken op <b>{0}</b>"
+
+#: static/js/common-all.js:12521 static/js/common-min.js:7 static/js/impala-all.js:14867 static/js/impala-min.js:8 static/js/impala/site_suggestions.js:46
+msgid "Category"
+msgstr "Categorie"
+
+#. L10n: {0} is an app name.
+#: static/js/impala-all.js:11632 static/js/impala-min.js:7 static/js/impala/listing.js:11 static/js/zamboni/themes.js:13
+msgid "This theme is incompatible with your version of {0}"
+msgstr "Dit thema is niet compatibel met uw versie van {0}"
+
+#: static/js/impala-all.js:12146 static/js/impala-all.js:14331 static/js/impala-min.js:7 static/js/impala-min.js:8 static/js/common/upload-image.js:97 static/js/impala/users.js:51
+#: static/js/zamboni/devhub-all.js:894 static/js/zamboni/devhub-min.js:1
+msgid "Images must be either PNG or JPG."
+msgstr "Afbeeldingen dienen van het type PNG of JPG te zijn."
+
+#: static/js/impala-all.js:12150 static/js/impala-min.js:7 static/js/common/upload-image.js:101 static/js/zamboni/devhub-all.js:898 static/js/zamboni/devhub-min.js:1
+msgid "Videos must be in WebM."
+msgstr "Video’s dienen in WebM te zijn."
+
+#: static/js/impala-all.js:12177 static/js/impala-min.js:7 static/js/common/upload-addon.js:41 static/js/common/upload-image.js:128 static/js/zamboni/devhub-all.js:272
+#: static/js/zamboni/devhub-all.js:925 static/js/zamboni/devhub-min.js:1
 msgid "There was a problem contacting the server."
 msgstr "Er is een probleem opgetreden bij het verbinden met de server."
 
-#: static/js/common/upload-addon.js:69
+#: static/js/impala-all.js:13298 static/js/impala-min.js:7 static/js/impala/persona_creation.js:60
+msgid "All Rights Reserved"
+msgstr "Alle rechten voorbehouden"
+
+#: static/js/impala-all.js:13302 static/js/impala-min.js:7 static/js/impala/persona_creation.js:64
+msgid "Creative Commons Attribution 3.0"
+msgstr "Creative Commons Attribution 3.0"
+
+#: static/js/impala-all.js:13307 static/js/impala-min.js:7 static/js/impala/persona_creation.js:69
+msgid "Creative Commons Attribution-NonCommercial 3.0"
+msgstr "Creative Commons Attribution-NonCommercial 3.0"
+
+#: static/js/impala-all.js:13312 static/js/impala-min.js:7 static/js/impala/persona_creation.js:74
+msgid "Creative Commons Attribution-NonCommercial-NoDerivs 3.0"
+msgstr "Creative Commons Attribution-NonCommercial-NoDerivs 3.0"
+
+#: static/js/impala-all.js:13317 static/js/impala-min.js:7 static/js/impala/persona_creation.js:79
+msgid "Creative Commons Attribution-NonCommercial-Share Alike 3.0"
+msgstr "Creative Commons Attribution-NonCommercial-Share Alike 3.0"
+
+#: static/js/impala-all.js:13322 static/js/impala-min.js:7 static/js/impala/persona_creation.js:84
+msgid "Creative Commons Attribution-NoDerivs 3.0"
+msgstr "Creative Commons Attribution-NoDerivs 3.0"
+
+#: static/js/impala-all.js:13327 static/js/impala-min.js:7 static/js/impala/persona_creation.js:89
+msgid "Creative Commons Attribution-ShareAlike 3.0"
+msgstr "Creative Commons Attribution-ShareAlike 3.0"
+
+#: static/js/impala-all.js:13530 static/js/impala-min.js:7 static/js/impala/persona_creation.js:292
+msgid "Your Theme's Name"
+msgstr "De naam van uw thema"
+
+#: static/js/impala-all.js:14242 static/js/impala-min.js:8 static/js/impala/collections.js:19
+msgid "Stop Following"
+msgstr "Volgen stoppen"
+
+#: static/js/impala-all.js:14243 static/js/impala-min.js:8 static/js/impala/collections.js:20
+msgid "Following"
+msgstr "Wordt gevolgd"
+
+#: static/js/impala-all.js:14313 static/js/impala-min.js:8 static/js/impala/users.js:33
+msgid "use original"
+msgstr "oorspronkelijke gebruiken"
+
+#: static/js/impala-all.js:14523 static/js/impala-min.js:8 static/js/impala/search.js:114
+msgid "Updating results&hellip;"
+msgstr "Resultaten bijwerken…"
+
+#: static/js/common/upload-addon.js:69 static/js/zamboni/devhub-all.js:300 static/js/zamboni/devhub-min.js:1
 msgid "Select a file..."
 msgstr "Selecteer een bestand…"
 
-#: static/js/common/upload-addon.js:70
+#: static/js/common/upload-addon.js:70 static/js/zamboni/devhub-all.js:301 static/js/zamboni/devhub-min.js:1
 msgid "Your add-on should end with .xpi, .jar or .xml"
 msgstr "Uw add-on dient op .xpi, .jar of .xml te eindigen"
 
 #. L10n: {0} is the percent of the file that has been uploaded.
-#: static/js/common/upload-addon.js:104
+#: static/js/common/upload-addon.js:104 static/js/zamboni/devhub-all.js:335 static/js/zamboni/devhub-min.js:1
 #, python-format
 msgid "{0}% complete"
 msgstr "{0}% voltooid"
 
 #. L10n: "{bytes uploaded} of {total filesize}".
-#: static/js/common/upload-addon.js:107
+#: static/js/common/upload-addon.js:107 static/js/zamboni/devhub-all.js:338 static/js/zamboni/devhub-min.js:1
 msgid "{0} of {1}"
 msgstr "{0} van {1}"
 
-#: static/js/common/upload-addon.js:140
+#: static/js/common/upload-addon.js:140 static/js/zamboni/devhub-all.js:371 static/js/zamboni/devhub-min.js:1
 msgid "Cancel"
 msgstr "Annuleren"
 
-#: static/js/common/upload-addon.js:162
+#: static/js/common/upload-addon.js:162 static/js/zamboni/devhub-all.js:393 static/js/zamboni/devhub-min.js:1
 msgid "Uploading {0}"
 msgstr "Uploaden {0}"
 
-#: static/js/common/upload-addon.js:189
+#: static/js/common/upload-addon.js:189 static/js/zamboni/devhub-all.js:420 static/js/zamboni/devhub-min.js:1
 msgid "Error with {0}"
 msgstr "Fout met {0}"
 
-#: static/js/common/upload-addon.js:194
+#: static/js/common/upload-addon.js:194 static/js/zamboni/devhub-all.js:425 static/js/zamboni/devhub-min.js:1
 msgid "Your add-on failed validation with {0} error."
 msgid_plural "Your add-on failed validation with {0} errors."
 msgstr[0] "Uw add-on heeft de validatie niet doorstaan met {0} fout."
 msgstr[1] "Uw add-on heeft de validatie niet doorstaan met {0} fouten."
 
-#: static/js/common/upload-addon.js:208
+#: static/js/common/upload-addon.js:208 static/js/zamboni/devhub-all.js:439 static/js/zamboni/devhub-min.js:1
 msgid "&hellip;and {0} more"
 msgid_plural "&hellip;and {0} more"
 msgstr[0] "… en nog {0}"
 msgstr[1] "… en nog {0}"
 
-#: static/js/common/upload-addon.js:222 static/js/common/upload-addon.js:512
+#: static/js/common/upload-addon.js:222 static/js/common/upload-addon.js:497 static/js/zamboni/devhub-all.js:453 static/js/zamboni/devhub-all.js:743 static/js/zamboni/devhub-min.js:1
 msgid "See full validation report"
 msgstr "Volledig validatierapport bekijken"
 
-#: static/js/common/upload-addon.js:234
+#: static/js/common/upload-addon.js:234 static/js/zamboni/devhub-all.js:465 static/js/zamboni/devhub-min.js:1
 msgid "Validating {0}"
 msgstr "{0} wordt gevalideerd"
 
 #. L10n: first argument is an HTTP status code
-#: static/js/common/upload-addon.js:273
+#: static/js/common/upload-addon.js:273 static/js/zamboni/devhub-all.js:504 static/js/zamboni/devhub-min.js:1
 msgid "Received an empty response from the server; status: {0}"
 msgstr "Lege respons van server ontvangen; status: {0}"
 
-#: static/js/common/upload-addon.js:373
+#: static/js/common/upload-addon.js:370 static/js/zamboni/devhub-all.js:604 static/js/zamboni/devhub-min.js:1
 msgid "Unexpected server error while validating."
 msgstr "Onverwachte serverfout tijdens validatie."
 
-#: static/js/common/upload-addon.js:412
+#: static/js/common/upload-addon.js:409 static/js/zamboni/devhub-all.js:643 static/js/zamboni/devhub-min.js:1
 msgid "Finished validating {0}"
 msgstr "Validatie van {0} voltooid"
 
-#: static/js/common/upload-addon.js:418
+#: static/js/common/upload-addon.js:415 static/js/zamboni/devhub-all.js:649 static/js/zamboni/devhub-min.js:1
 msgid "Your add-on validation timed out, it will be manually reviewed."
 msgstr "De validatietijd voor uw add-on is verstreken, deze zal handmatig worden beoordeeld."
 
-#: static/js/common/upload-addon.js:421
+#: static/js/common/upload-addon.js:418 static/js/zamboni/devhub-all.js:652 static/js/zamboni/devhub-min.js:1
 msgid "Your add-on was validated with no errors and {0} warning."
 msgid_plural "Your add-on was validated with no errors and {0} warnings."
 msgstr[0] "Uw add-on is gevalideerd zonder fouten en met {0} waarschuwing."
 msgstr[1] "Uw add-on is gevalideerd zonder fouten en met {0} waarschuwingen."
 
-#: static/js/common/upload-addon.js:426
+#: static/js/common/upload-addon.js:423 static/js/zamboni/devhub-all.js:657 static/js/zamboni/devhub-min.js:1
 msgid "Your add-on was validated with no errors and {0} message."
 msgid_plural "Your add-on was validated with no errors and {0} messages."
 msgstr[0] "Uw add-on is gevalideerd zonder fouten en met {0} bericht."
 msgstr[1] "Uw add-on is gevalideerd zonder fouten en met {0} berichten."
 
-#: static/js/common/upload-addon.js:431
+#: static/js/common/upload-addon.js:428 static/js/zamboni/devhub-all.js:662 static/js/zamboni/devhub-min.js:1
 msgid "Your add-on was validated with no errors or warnings."
 msgstr "Uw add-on is gevalideerd zonder fouten of waarschuwingen."
 
-#: static/js/common/upload-addon.js:446
+#: static/js/common/upload-addon.js:443 static/js/zamboni/devhub-all.js:677 static/js/zamboni/devhub-min.js:1
 msgid "Your submission will be automatically signed."
 msgstr "Uw inzending zal automatisch worden ondertekend."
 
-#: static/js/common/upload-addon.js:465
+#: static/js/common/upload-addon.js:450 static/js/zamboni/devhub-all.js:696 static/js/zamboni/devhub-min.js:1
 msgid "Include detailed version notes (this can be done in the next step)."
 msgstr "Neem gedetailleerde versieopmerkingen op (dit kunt u in de volgende stap doen)."
 
-#: static/js/common/upload-addon.js:466
+#: static/js/common/upload-addon.js:451 static/js/zamboni/devhub-all.js:697 static/js/zamboni/devhub-min.js:1
 msgid "If your add-on requires an account to a website in order to be fully tested, include a test username and password in the Notes to Reviewer (this can be done in the next step)."
 msgstr ""
 "Als uw add-on een account bij een website vereist om volledig getest te kunnen worden, vermeld dan een testgebruikersnaam en wachtwoord in de Opmerkingen voor de beoordelaar (dit kunt u in de "
 "volgende stap doen)."
 
-#: static/js/common/upload-addon.js:467
+#: static/js/common/upload-addon.js:452 static/js/zamboni/devhub-all.js:698 static/js/zamboni/devhub-min.js:1
 msgid "If your add-on is intended for a limited audience you should choose Preliminary Review instead of Full Review."
 msgstr "Als uw add-on voor een beperkt publiek is bedoeld, dient u Voorlopige beoordeling in plaats van Volledige beoordeling te kiezen."
 
-#: static/js/common/upload-addon.js:480
+#: static/js/common/upload-addon.js:465 static/js/zamboni/devhub-all.js:711 static/js/zamboni/devhub-min.js:1
 msgid "Add-on submission checklist"
 msgstr "Checklist voor add-on-indiening"
 
-#: static/js/common/upload-addon.js:481
+#: static/js/common/upload-addon.js:466 static/js/zamboni/devhub-all.js:712 static/js/zamboni/devhub-min.js:1
 msgid "Please verify the following points before finalizing your submission. This will minimize delays or misunderstanding during the review process:"
 msgstr "Controleer de volgende punten voordat u uw inzending afrondt. Dit minimaliseert vertragingen of misvattingen tijdens het beoordelingsproces:"
 
-#: static/js/common/upload-addon.js:483
+#: static/js/common/upload-addon.js:468 static/js/zamboni/devhub-all.js:714 static/js/zamboni/devhub-min.js:1
 msgid ""
 "Compiled binaries, as well as minified or obfuscated scripts (excluding known libraries) need to have their sources submitted separately for review. Make sure that you use the source code upload "
 "field to avoid having your submission rejected."
@@ -140,1082 +397,846 @@ msgstr ""
 "Bronnen van gecompileerde binaire bestanden dienen, net als verkleinde of verborgen scripts (exclusief bekende bibliotheken), apart ter beoordeling te worden ingediend. Zorg ervoor dat u het "
 "uploadveld voor broncode gebruikt om te voorkomen dat uw inzending wordt afgewezen."
 
-#: static/js/common/upload-addon.js:501
+#: static/js/common/upload-addon.js:486 static/js/zamboni/devhub-all.js:732 static/js/zamboni/devhub-min.js:1
 msgid "The validation process found these issues that can lead to rejections:"
 msgstr "Het validatieproces heeft de volgende problemen die tot afwijzing zouden kunnen leiden gevonden:"
 
-#: static/js/common/upload-addon.js:518
+#: static/js/common/upload-addon.js:503 static/js/zamboni/devhub-all.js:749 static/js/zamboni/devhub-min.js:1
 msgid "If you are unfamiliar with the add-ons review process, you can read about it here."
 msgstr "Als u niet bekend bent met het add-onbeoordelingsproces, kunt u er hier meer over lezen."
 
-#: static/js/common/upload-addon.js:555
+#: static/js/common/upload-addon.js:540 static/js/zamboni/devhub-all.js:786 static/js/zamboni/devhub-min.js:1
 msgid "Sorry, no supported platform has been found."
 msgstr "Sorry, geen ondersteund platform gevonden."
 
-#: static/js/common/upload-base.js:57
+#: static/js/common/upload-base.js:57 static/js/zamboni/devhub-all.js:187 static/js/zamboni/devhub-min.js:1
 msgid "The filetype you uploaded isn't recognized."
 msgstr "Het door u geüploade bestandstype wordt niet herkend."
 
-#: static/js/common/upload-base.js:79
+#: static/js/common/upload-base.js:79 static/js/zamboni/devhub-all.js:209 static/js/zamboni/devhub-min.js:1
 msgid "You cancelled the upload."
 msgstr "U hebt de upload geannuleerd."
 
-#: static/js/common/upload-image.js:97 static/js/impala/users.js:51
-msgid "Images must be either PNG or JPG."
-msgstr "Afbeeldingen dienen van het type PNG of JPG te zijn."
-
-#: static/js/common/upload-image.js:101
-msgid "Videos must be in WebM."
-msgstr "Video’s dienen in WebM te zijn."
-
-#: static/js/impala/collections.js:10 static/js/zamboni/collections.js:595
-msgid "Follow this Collection"
-msgstr "Deze collectie volgen"
-
-#: static/js/impala/collections.js:19
-msgid "Stop Following"
-msgstr "Volgen stoppen"
-
-#: static/js/impala/collections.js:20
-msgid "Following"
-msgstr "Wordt gevolgd"
-
-#. L10n: {0} is an app name.
-#: static/js/impala/listing.js:11 static/js/zamboni/themes.js:13
-msgid "This theme is incompatible with your version of {0}"
-msgstr "Dit thema is niet compatibel met uw versie van {0}"
-
-#: static/js/impala/persona_creation.js:60
-msgid "All Rights Reserved"
-msgstr "Alle rechten voorbehouden"
-
-#: static/js/impala/persona_creation.js:64
-msgid "Creative Commons Attribution 3.0"
-msgstr "Creative Commons Attribution 3.0"
-
-#: static/js/impala/persona_creation.js:69
-msgid "Creative Commons Attribution-NonCommercial 3.0"
-msgstr "Creative Commons Attribution-NonCommercial 3.0"
-
-#: static/js/impala/persona_creation.js:74
-msgid "Creative Commons Attribution-NonCommercial-NoDerivs 3.0"
-msgstr "Creative Commons Attribution-NonCommercial-NoDerivs 3.0"
-
-#: static/js/impala/persona_creation.js:79
-msgid "Creative Commons Attribution-NonCommercial-Share Alike 3.0"
-msgstr "Creative Commons Attribution-NonCommercial-Share Alike 3.0"
-
-#: static/js/impala/persona_creation.js:84
-msgid "Creative Commons Attribution-NoDerivs 3.0"
-msgstr "Creative Commons Attribution-NoDerivs 3.0"
-
-#: static/js/impala/persona_creation.js:89
-msgid "Creative Commons Attribution-ShareAlike 3.0"
-msgstr "Creative Commons Attribution-ShareAlike 3.0"
-
-#: static/js/impala/persona_creation.js:292
-msgid "Your Theme's Name"
-msgstr "De naam van uw thema"
-
-#: static/js/impala/reviews.js:23 static/js/zamboni/reviews.js:18
-msgid "Flagged for review"
-msgstr "Gemarkeerd voor beoordeling"
-
-#: static/js/impala/reviews.js:40 static/js/zamboni/reviews.js:34
-msgid "Your input is required"
-msgstr "Uw bijdrage is vereist"
-
-#: static/js/impala/reviews.js:152 static/js/zamboni/reviews.js:103
-msgid "Marked for deletion"
-msgstr "Gemarkeerd voor verwijdering"
-
-#: static/js/impala/search.js:114
-msgid "Updating results&hellip;"
-msgstr "Resultaten bijwerken…"
-
-#: static/js/impala/site_suggestions.js:46
-msgid "Category"
-msgstr "Categorie"
-
-#: static/js/impala/suggestions.js:39
-msgid "Search themes for <b>{0}</b>"
-msgstr "Thema’s zoeken op <b>{0}</b>"
-
-#: static/js/impala/suggestions.js:41
-msgid "Search apps for <b>{0}</b>"
-msgstr "Apps doorzoeken op <b>{0}</b>"
-
-#: static/js/impala/suggestions.js:43
-msgid "Search add-ons for <b>{0}</b>"
-msgstr "Add-ons doorzoeken op <b>{0}</b>"
-
-#: static/js/impala/users.js:33
-msgid "use original"
-msgstr "oorspronkelijke gebruiken"
-
-#: static/js/impala/stats/chart.js:267
+#: static/js/impala/stats/chart.js:267 static/js/zamboni/stats-all.js:16898 static/js/zamboni/stats-min.js:5
 msgid "Week of {0}"
 msgstr "Week van {0}"
 
-#: static/js/impala/stats/chart.js:269
+#: static/js/impala/stats/chart.js:269 static/js/zamboni/stats-all.js:16900 static/js/zamboni/stats-min.js:5
 msgid " downloads"
-msgstr " downloads"
+msgstr ""
 
-#: static/js/impala/stats/chart.js:270
+#: static/js/impala/stats/chart.js:270 static/js/zamboni/stats-all.js:16901 static/js/zamboni/stats-min.js:5
 msgid "{0} users"
 msgstr "{0} gebruikers"
 
-#: static/js/impala/stats/chart.js:271
+#: static/js/impala/stats/chart.js:271 static/js/zamboni/stats-all.js:16902 static/js/zamboni/stats-min.js:5
 msgid "{0} add-ons"
 msgstr "{0} add-ons"
 
-#: static/js/impala/stats/chart.js:272
+#: static/js/impala/stats/chart.js:272 static/js/zamboni/stats-all.js:16903 static/js/zamboni/stats-min.js:5
 msgid "{0} collections"
 msgstr "{0} collecties"
 
-#: static/js/impala/stats/chart.js:273
+#: static/js/impala/stats/chart.js:273 static/js/zamboni/stats-all.js:16904 static/js/zamboni/stats-min.js:5
 msgid "{0} reviews"
 msgstr "{0} beoordelingen"
 
-#: static/js/impala/stats/chart.js:275
+#: static/js/impala/stats/chart.js:275 static/js/zamboni/stats-all.js:16906 static/js/zamboni/stats-min.js:5
 msgid "{0} sales"
 msgstr "{0} verkopen"
 
-#: static/js/impala/stats/chart.js:276
+#: static/js/impala/stats/chart.js:276 static/js/zamboni/stats-all.js:16907 static/js/zamboni/stats-min.js:5
 msgid "{0} refunds"
 msgstr "{0} restituties"
 
-#: static/js/impala/stats/chart.js:277
+#: static/js/impala/stats/chart.js:277 static/js/zamboni/stats-all.js:16908 static/js/zamboni/stats-min.js:5
 msgid "{0} installs"
 msgstr "{0} installaties"
 
-#: static/js/impala/stats/chart.js:369 static/js/impala/stats/csv_keys.js:3 static/js/impala/stats/csv_keys.js:109
+#: static/js/impala/stats/chart.js:369 static/js/impala/stats/csv_keys.js:3 static/js/impala/stats/csv_keys.js:109 static/js/zamboni/stats-all.js:15284 static/js/zamboni/stats-all.js:15390
+#: static/js/zamboni/stats-all.js:17000 static/js/zamboni/stats-min.js:4 static/js/zamboni/stats-min.js:5
 msgid "Downloads"
 msgstr "Downloads"
 
-#: static/js/impala/stats/chart.js:379 static/js/impala/stats/csv_keys.js:6 static/js/impala/stats/csv_keys.js:110
+#: static/js/impala/stats/chart.js:379 static/js/impala/stats/csv_keys.js:6 static/js/impala/stats/csv_keys.js:110 static/js/zamboni/stats-all.js:15287 static/js/zamboni/stats-all.js:15391
+#: static/js/zamboni/stats-all.js:17010 static/js/zamboni/stats-min.js:4 static/js/zamboni/stats-min.js:5
 msgid "Daily Users"
 msgstr "Dagelijkse gebruikers"
 
-#: static/js/impala/stats/chart.js:410
+#: static/js/impala/stats/chart.js:410 static/js/zamboni/stats-all.js:17041 static/js/zamboni/stats-min.js:5
 msgid "Amount, in USD"
 msgstr "Bedrag, in US$"
 
-#: static/js/impala/stats/chart.js:421 static/js/impala/stats/csv_keys.js:104
+#: static/js/impala/stats/chart.js:421 static/js/impala/stats/csv_keys.js:104 static/js/zamboni/stats-all.js:15385 static/js/zamboni/stats-all.js:17052 static/js/zamboni/stats-min.js:5
 msgid "Number of Contributions"
 msgstr "Aantal bijdragen"
 
-#: static/js/impala/stats/chart.js:447
+#: static/js/impala/stats/chart.js:447 static/js/zamboni/stats-all.js:17078 static/js/zamboni/stats-min.js:5
 msgid "More Info..."
 msgstr "Meer informatie…"
 
 #. L10n: {0} is an ISO-formatted date.
-#: static/js/impala/stats/chart.js:451
+#: static/js/impala/stats/chart.js:451 static/js/zamboni/stats-all.js:17082 static/js/zamboni/stats-min.js:5
 msgid "Details for {0}"
 msgstr "Details voor {0}"
 
-#: static/js/impala/stats/csv_keys.js:9
+#: static/js/impala/stats/csv_keys.js:9 static/js/zamboni/stats-all.js:15290 static/js/zamboni/stats-min.js:4
 msgid "Collections Created"
 msgstr "Gemaakte collecties"
 
-#: static/js/impala/stats/csv_keys.js:12
+#: static/js/impala/stats/csv_keys.js:12 static/js/zamboni/stats-all.js:15293 static/js/zamboni/stats-min.js:4
 msgid "Add-ons in Use"
 msgstr "Gebruikte add-ons"
 
-#: static/js/impala/stats/csv_keys.js:15
+#: static/js/impala/stats/csv_keys.js:15 static/js/zamboni/stats-all.js:15296 static/js/zamboni/stats-min.js:4
 msgid "Add-ons Created"
 msgstr "Gemaakte add-ons"
 
-#: static/js/impala/stats/csv_keys.js:18
+#: static/js/impala/stats/csv_keys.js:18 static/js/zamboni/stats-all.js:15299 static/js/zamboni/stats-min.js:4
 msgid "Add-ons Downloaded"
 msgstr "Gedownloade add-ons"
 
-#: static/js/impala/stats/csv_keys.js:21
+#: static/js/impala/stats/csv_keys.js:21 static/js/zamboni/stats-all.js:15302 static/js/zamboni/stats-min.js:4
 msgid "Add-ons Updated"
 msgstr "Bijgewerkte add-ons"
 
-#: static/js/impala/stats/csv_keys.js:24
+#: static/js/impala/stats/csv_keys.js:24 static/js/zamboni/stats-all.js:15305 static/js/zamboni/stats-min.js:4
 msgid "Reviews Written"
 msgstr "Geschreven beoordelingen"
 
-#: static/js/impala/stats/csv_keys.js:27
+#: static/js/impala/stats/csv_keys.js:27 static/js/zamboni/stats-all.js:15308 static/js/zamboni/stats-min.js:4
 msgid "User Signups"
 msgstr "Gebruikersregistraties"
 
-#: static/js/impala/stats/csv_keys.js:30
+#: static/js/impala/stats/csv_keys.js:30 static/js/zamboni/stats-all.js:15311 static/js/zamboni/stats-min.js:4
 msgid "Subscribers"
 msgstr "Abonnees"
 
-#: static/js/impala/stats/csv_keys.js:33
+#: static/js/impala/stats/csv_keys.js:33 static/js/zamboni/stats-all.js:15314 static/js/zamboni/stats-min.js:4
 msgid "Ratings"
 msgstr "Waarderingen"
 
-#: static/js/impala/stats/csv_keys.js:36 static/js/impala/stats/csv_keys.js:114
+#: static/js/impala/stats/csv_keys.js:36 static/js/impala/stats/csv_keys.js:114 static/js/zamboni/stats-all.js:15317 static/js/zamboni/stats-all.js:15395 static/js/zamboni/stats-min.js:4
+#: static/js/zamboni/stats-min.js:5
 msgid "Sales"
 msgstr "Verkopen"
 
-#: static/js/impala/stats/csv_keys.js:39 static/js/impala/stats/csv_keys.js:113
+#: static/js/impala/stats/csv_keys.js:39 static/js/impala/stats/csv_keys.js:113 static/js/zamboni/stats-all.js:15320 static/js/zamboni/stats-all.js:15394 static/js/zamboni/stats-min.js:4
+#: static/js/zamboni/stats-min.js:5
 msgid "Installs"
 msgstr "Installaties"
 
-#: static/js/impala/stats/csv_keys.js:42
+#: static/js/impala/stats/csv_keys.js:42 static/js/zamboni/stats-all.js:15323 static/js/zamboni/stats-min.js:4
 msgid "Unknown"
 msgstr "Onbekend"
 
-#: static/js/impala/stats/csv_keys.js:43
+#: static/js/impala/stats/csv_keys.js:43 static/js/zamboni/stats-all.js:15324 static/js/zamboni/stats-min.js:4
 msgid "Add-ons Manager"
 msgstr "Add-onbeheerder"
 
-#: static/js/impala/stats/csv_keys.js:44
+#: static/js/impala/stats/csv_keys.js:44 static/js/zamboni/stats-all.js:15325 static/js/zamboni/stats-min.js:4
 msgid "Add-ons Manager Promo"
 msgstr "Add-onbeheerder-promo"
 
-#: static/js/impala/stats/csv_keys.js:45
+#: static/js/impala/stats/csv_keys.js:45 static/js/zamboni/stats-all.js:15326 static/js/zamboni/stats-min.js:4
 msgid "Add-ons Manager Featured"
 msgstr "Aanbevolen in Add-onbeheerder"
 
-#: static/js/impala/stats/csv_keys.js:46
+#: static/js/impala/stats/csv_keys.js:46 static/js/zamboni/stats-all.js:15327 static/js/zamboni/stats-min.js:4
 msgid "Add-ons Manager Learn More"
 msgstr "Meer over de Add-onbeheerder"
 
-#: static/js/impala/stats/csv_keys.js:47
+#: static/js/impala/stats/csv_keys.js:47 static/js/zamboni/stats-all.js:15328 static/js/zamboni/stats-min.js:4
 msgid "Search Suggestions"
 msgstr "Zoeksuggesties"
 
-#: static/js/impala/stats/csv_keys.js:48
+#: static/js/impala/stats/csv_keys.js:48 static/js/zamboni/stats-all.js:15329 static/js/zamboni/stats-min.js:4
 msgid "Search Results"
 msgstr "Zoekresultaten"
 
-#: static/js/impala/stats/csv_keys.js:49 static/js/impala/stats/csv_keys.js:50 static/js/impala/stats/csv_keys.js:51
+#: static/js/impala/stats/csv_keys.js:49 static/js/impala/stats/csv_keys.js:50 static/js/impala/stats/csv_keys.js:51 static/js/zamboni/stats-all.js:15330 static/js/zamboni/stats-all.js:15331
+#: static/js/zamboni/stats-all.js:15332 static/js/zamboni/stats-min.js:4
 msgid "Homepage Promo"
 msgstr "Startpagina Promotie"
 
-#: static/js/impala/stats/csv_keys.js:52 static/js/impala/stats/csv_keys.js:53
+#: static/js/impala/stats/csv_keys.js:52 static/js/impala/stats/csv_keys.js:53 static/js/zamboni/stats-all.js:15333 static/js/zamboni/stats-all.js:15334 static/js/zamboni/stats-min.js:4
 msgid "Homepage Featured"
 msgstr "Startpagina Aanbevolen"
 
-#: static/js/impala/stats/csv_keys.js:54 static/js/impala/stats/csv_keys.js:55
+#: static/js/impala/stats/csv_keys.js:54 static/js/impala/stats/csv_keys.js:55 static/js/zamboni/stats-all.js:15335 static/js/zamboni/stats-all.js:15336 static/js/zamboni/stats-min.js:4
 msgid "Homepage Up and Coming"
 msgstr "Startpagina Aankomende"
 
-#: static/js/impala/stats/csv_keys.js:56
+#: static/js/impala/stats/csv_keys.js:56 static/js/zamboni/stats-all.js:15337 static/js/zamboni/stats-min.js:4
 msgid "Homepage Most Popular"
 msgstr "Startpagina Populairste"
 
-#: static/js/impala/stats/csv_keys.js:57 static/js/impala/stats/csv_keys.js:59
+#: static/js/impala/stats/csv_keys.js:57 static/js/impala/stats/csv_keys.js:59 static/js/zamboni/stats-all.js:15338 static/js/zamboni/stats-all.js:15340 static/js/zamboni/stats-min.js:4
 msgid "Detail Page"
 msgstr "Detailpagina"
 
-#: static/js/impala/stats/csv_keys.js:58 static/js/impala/stats/csv_keys.js:60
+#: static/js/impala/stats/csv_keys.js:58 static/js/impala/stats/csv_keys.js:60 static/js/zamboni/stats-all.js:15339 static/js/zamboni/stats-all.js:15341 static/js/zamboni/stats-min.js:4
 msgid "Detail Page (bottom)"
 msgstr "Detailpagina (onderzijde)"
 
-#: static/js/impala/stats/csv_keys.js:61
+#: static/js/impala/stats/csv_keys.js:61 static/js/zamboni/stats-all.js:15342 static/js/zamboni/stats-min.js:4
 msgid "Detail Page (Development Channel)"
 msgstr "Detailpagina (Ontwikkelingskanaal)"
 
-#: static/js/impala/stats/csv_keys.js:62 static/js/impala/stats/csv_keys.js:63 static/js/impala/stats/csv_keys.js:64
+#: static/js/impala/stats/csv_keys.js:62 static/js/impala/stats/csv_keys.js:63 static/js/impala/stats/csv_keys.js:64 static/js/zamboni/stats-all.js:15343 static/js/zamboni/stats-all.js:15344
+#: static/js/zamboni/stats-all.js:15345 static/js/zamboni/stats-min.js:4
 msgid "Often Used With"
 msgstr "Vaak gebruikt met"
 
-#: static/js/impala/stats/csv_keys.js:65 static/js/impala/stats/csv_keys.js:66
+#: static/js/impala/stats/csv_keys.js:65 static/js/impala/stats/csv_keys.js:66 static/js/zamboni/stats-all.js:15346 static/js/zamboni/stats-all.js:15347 static/js/zamboni/stats-min.js:4
 msgid "Others By Author"
 msgstr "Overige door schrijver"
 
-#: static/js/impala/stats/csv_keys.js:67 static/js/impala/stats/csv_keys.js:68
+#: static/js/impala/stats/csv_keys.js:67 static/js/impala/stats/csv_keys.js:68 static/js/zamboni/stats-all.js:15348 static/js/zamboni/stats-all.js:15349 static/js/zamboni/stats-min.js:4
 msgid "Dependencies"
 msgstr "Afhankelijkheden"
 
-#: static/js/impala/stats/csv_keys.js:69 static/js/impala/stats/csv_keys.js:70
+#: static/js/impala/stats/csv_keys.js:69 static/js/impala/stats/csv_keys.js:70 static/js/zamboni/stats-all.js:15350 static/js/zamboni/stats-all.js:15351 static/js/zamboni/stats-min.js:4
 msgid "Upsell"
 msgstr "Verkoop"
 
-#: static/js/impala/stats/csv_keys.js:71
+#: static/js/impala/stats/csv_keys.js:71 static/js/zamboni/stats-all.js:15352 static/js/zamboni/stats-min.js:4
 msgid "Meet the Developer"
 msgstr "Maak kennis met de ontwikkelaar"
 
-#: static/js/impala/stats/csv_keys.js:72
+#: static/js/impala/stats/csv_keys.js:72 static/js/zamboni/stats-all.js:15353 static/js/zamboni/stats-min.js:4
 msgid "User Profile"
 msgstr "Gebruikersprofiel"
 
-#: static/js/impala/stats/csv_keys.js:73
+#: static/js/impala/stats/csv_keys.js:73 static/js/zamboni/stats-all.js:15354 static/js/zamboni/stats-min.js:4
 msgid "Version History"
 msgstr "Versiegeschiedenis"
 
-#: static/js/impala/stats/csv_keys.js:75
+#: static/js/impala/stats/csv_keys.js:75 static/js/zamboni/stats-all.js:15356 static/js/zamboni/stats-min.js:4
 msgid "Sharing"
 msgstr "Delen"
 
-#: static/js/impala/stats/csv_keys.js:76
+#: static/js/impala/stats/csv_keys.js:76 static/js/zamboni/stats-all.js:15357 static/js/zamboni/stats-min.js:4
 msgid "Category Pages"
 msgstr "Categoriepagina’s"
 
-#: static/js/impala/stats/csv_keys.js:77
+#: static/js/impala/stats/csv_keys.js:77 static/js/zamboni/stats-all.js:15358 static/js/zamboni/stats-min.js:4
 msgid "Collections"
 msgstr "Collecties"
 
-#: static/js/impala/stats/csv_keys.js:78 static/js/impala/stats/csv_keys.js:79
+#: static/js/impala/stats/csv_keys.js:78 static/js/impala/stats/csv_keys.js:79 static/js/zamboni/stats-all.js:15359 static/js/zamboni/stats-all.js:15360 static/js/zamboni/stats-min.js:4
 msgid "Category Landing Featured Carousel"
 msgstr "Startpagina categorie Aanbevolen-carrousel"
 
-#: static/js/impala/stats/csv_keys.js:80 static/js/impala/stats/csv_keys.js:81
+#: static/js/impala/stats/csv_keys.js:80 static/js/impala/stats/csv_keys.js:81 static/js/zamboni/stats-all.js:15361 static/js/zamboni/stats-all.js:15362 static/js/zamboni/stats-min.js:4
 msgid "Category Landing Top Rated"
 msgstr "Startpagina categorie Best gewaardeerd"
 
-#: static/js/impala/stats/csv_keys.js:82 static/js/impala/stats/csv_keys.js:83
+#: static/js/impala/stats/csv_keys.js:82 static/js/impala/stats/csv_keys.js:83 static/js/zamboni/stats-all.js:15363 static/js/zamboni/stats-all.js:15364 static/js/zamboni/stats-min.js:5
 msgid "Category Landing Most Popular"
 msgstr "Startpagina categorie Populairst"
 
-#: static/js/impala/stats/csv_keys.js:84 static/js/impala/stats/csv_keys.js:85
+#: static/js/impala/stats/csv_keys.js:84 static/js/impala/stats/csv_keys.js:85 static/js/zamboni/stats-all.js:15365 static/js/zamboni/stats-all.js:15366 static/js/zamboni/stats-min.js:5
 msgid "Category Landing Recently Added"
 msgstr "Startpagina categorie Onlangs toegevoegd"
 
-#: static/js/impala/stats/csv_keys.js:86 static/js/impala/stats/csv_keys.js:87
+#: static/js/impala/stats/csv_keys.js:86 static/js/impala/stats/csv_keys.js:87 static/js/zamboni/stats-all.js:15367 static/js/zamboni/stats-all.js:15368 static/js/zamboni/stats-min.js:5
 msgid "Browse Listing Featured Sort"
 msgstr "Lijst doorbladeren gesorteerd op Aanbevolen"
 
-#: static/js/impala/stats/csv_keys.js:88 static/js/impala/stats/csv_keys.js:89
+#: static/js/impala/stats/csv_keys.js:88 static/js/impala/stats/csv_keys.js:89 static/js/zamboni/stats-all.js:15369 static/js/zamboni/stats-all.js:15370 static/js/zamboni/stats-min.js:5
 msgid "Browse Listing Users Sort"
 msgstr "Lijst doorbladeren gesorteerd op Gebruikers"
 
-#: static/js/impala/stats/csv_keys.js:90 static/js/impala/stats/csv_keys.js:91
+#: static/js/impala/stats/csv_keys.js:90 static/js/impala/stats/csv_keys.js:91 static/js/zamboni/stats-all.js:15371 static/js/zamboni/stats-all.js:15372 static/js/zamboni/stats-min.js:5
 msgid "Browse Listing Rating Sort"
 msgstr "Lijst doorbladeren gesorteerd op Waardering"
 
-#: static/js/impala/stats/csv_keys.js:92 static/js/impala/stats/csv_keys.js:93
+#: static/js/impala/stats/csv_keys.js:92 static/js/impala/stats/csv_keys.js:93 static/js/zamboni/stats-all.js:15373 static/js/zamboni/stats-all.js:15374 static/js/zamboni/stats-min.js:5
 msgid "Browse Listing Created Sort"
 msgstr "Lijst doorbladeren gesorteerd op Gemaakt"
 
-#: static/js/impala/stats/csv_keys.js:94 static/js/impala/stats/csv_keys.js:95
+#: static/js/impala/stats/csv_keys.js:94 static/js/impala/stats/csv_keys.js:95 static/js/zamboni/stats-all.js:15375 static/js/zamboni/stats-all.js:15376 static/js/zamboni/stats-min.js:5
 msgid "Browse Listing Name Sort"
 msgstr "Lijst doorbladeren gesorteerd op Naam"
 
-#: static/js/impala/stats/csv_keys.js:96 static/js/impala/stats/csv_keys.js:97
+#: static/js/impala/stats/csv_keys.js:96 static/js/impala/stats/csv_keys.js:97 static/js/zamboni/stats-all.js:15377 static/js/zamboni/stats-all.js:15378 static/js/zamboni/stats-min.js:5
 msgid "Browse Listing Popular Sort"
 msgstr "Lijst doorbladeren gesorteerd op Populair"
 
-#: static/js/impala/stats/csv_keys.js:98 static/js/impala/stats/csv_keys.js:99
+#: static/js/impala/stats/csv_keys.js:98 static/js/impala/stats/csv_keys.js:99 static/js/zamboni/stats-all.js:15379 static/js/zamboni/stats-all.js:15380 static/js/zamboni/stats-min.js:5
 msgid "Browse Listing Updated Sort"
 msgstr "Lijst doorbladeren gesorteerd op Bijgewerkt"
 
-#: static/js/impala/stats/csv_keys.js:100 static/js/impala/stats/csv_keys.js:101
+#: static/js/impala/stats/csv_keys.js:100 static/js/impala/stats/csv_keys.js:101 static/js/zamboni/stats-all.js:15381 static/js/zamboni/stats-all.js:15382 static/js/zamboni/stats-min.js:5
 msgid "Browse Listing Up and Coming Sort"
 msgstr "Lijst doorbladeren gesorteerd op Aankomend"
 
-#: static/js/impala/stats/csv_keys.js:105
+#: static/js/impala/stats/csv_keys.js:105 static/js/zamboni/stats-all.js:15386 static/js/zamboni/stats-min.js:5
 msgid "Total Amount Contributed"
 msgstr "Totaal bijgedragen bedrag"
 
-#: static/js/impala/stats/csv_keys.js:106
+#: static/js/impala/stats/csv_keys.js:106 static/js/zamboni/stats-all.js:15387 static/js/zamboni/stats-min.js:5
 msgid "Average Contribution"
 msgstr "Gemiddelde bijdrage"
 
-#: static/js/impala/stats/csv_keys.js:115
+#: static/js/impala/stats/csv_keys.js:115 static/js/zamboni/stats-all.js:15396 static/js/zamboni/stats-min.js:5
 msgid "Usage"
 msgstr "Gebruik"
 
-#: static/js/impala/stats/csv_keys.js:118
+#: static/js/impala/stats/csv_keys.js:118 static/js/zamboni/stats-all.js:15399 static/js/zamboni/stats-min.js:5
 msgid "Firefox"
 msgstr "Firefox"
 
-#: static/js/impala/stats/csv_keys.js:119
+#: static/js/impala/stats/csv_keys.js:119 static/js/zamboni/stats-all.js:15400 static/js/zamboni/stats-min.js:5
 msgid "Mozilla"
 msgstr "Mozilla"
 
-#: static/js/impala/stats/csv_keys.js:120
+#: static/js/impala/stats/csv_keys.js:120 static/js/zamboni/stats-all.js:15401 static/js/zamboni/stats-min.js:5
 msgid "Thunderbird"
 msgstr "Thunderbird"
 
-#: static/js/impala/stats/csv_keys.js:121
+#: static/js/impala/stats/csv_keys.js:121 static/js/zamboni/stats-all.js:15402 static/js/zamboni/stats-min.js:5
 msgid "Sunbird"
 msgstr "Sunbird"
 
-#: static/js/impala/stats/csv_keys.js:122
+#: static/js/impala/stats/csv_keys.js:122 static/js/zamboni/stats-all.js:15403 static/js/zamboni/stats-min.js:5
 msgid "SeaMonkey"
 msgstr "SeaMonkey"
 
-#: static/js/impala/stats/csv_keys.js:123
+#: static/js/impala/stats/csv_keys.js:123 static/js/zamboni/stats-all.js:15404 static/js/zamboni/stats-min.js:5
 msgid "Fennec"
 msgstr "Fennec"
 
-#: static/js/impala/stats/csv_keys.js:124
+#: static/js/impala/stats/csv_keys.js:124 static/js/zamboni/stats-all.js:15405 static/js/zamboni/stats-min.js:5
 msgid "Android"
 msgstr "Android"
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:129
+#: static/js/impala/stats/csv_keys.js:129 static/js/zamboni/stats-all.js:15410 static/js/zamboni/stats-min.js:5
 msgid "Downloads and Daily Users, last {0} days"
 msgstr "Downloads en dagelijkse gebruikers, laatste {0} dagen"
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:131
+#: static/js/impala/stats/csv_keys.js:131 static/js/zamboni/stats-all.js:15412 static/js/zamboni/stats-min.js:5
 msgid "Downloads and Daily Users from {0} to {1}"
 msgstr "Downloads en dagelijkse gebruikers van {0} tot {1}"
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:135
+#: static/js/impala/stats/csv_keys.js:135 static/js/zamboni/stats-all.js:15416 static/js/zamboni/stats-min.js:5
 msgid "Installs and Daily Users, last {0} days"
 msgstr "Installaties en dagelijkse gebruikers, laatste {0} dagen"
 
 # why not localize the date format?
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:137
+#: static/js/impala/stats/csv_keys.js:137 static/js/zamboni/stats-all.js:15418 static/js/zamboni/stats-min.js:5
 msgid "Installs and Daily Users from {0} to {1}"
 msgstr "Installaties en dagelijkse gebruikers van {0} tot {1}"
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:141
+#: static/js/impala/stats/csv_keys.js:141 static/js/zamboni/stats-all.js:15422 static/js/zamboni/stats-min.js:5
 msgid "Downloads, last {0} days"
 msgstr "Downloads, laatste {0} dagen"
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:143
+#: static/js/impala/stats/csv_keys.js:143 static/js/zamboni/stats-all.js:15424 static/js/zamboni/stats-min.js:5
 msgid "Downloads from {0} to {1}"
 msgstr "Downloads van {0} tot {1}"
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:147
+#: static/js/impala/stats/csv_keys.js:147 static/js/zamboni/stats-all.js:15428 static/js/zamboni/stats-min.js:5
 msgid "Daily Users, last {0} days"
 msgstr "Dagelijkse gebruikers, laatste {0} dagen"
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:149
+#: static/js/impala/stats/csv_keys.js:149 static/js/zamboni/stats-all.js:15430 static/js/zamboni/stats-min.js:5
 msgid "Daily Users from {0} to {1}"
 msgstr "Dagelijkse gebruikers van {0} tot {1}"
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:153
+#: static/js/impala/stats/csv_keys.js:153 static/js/zamboni/stats-all.js:15434 static/js/zamboni/stats-min.js:5
 msgid "Applications, last {0} days"
 msgstr "Toepassingen, laatste {0} dagen"
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:155
+#: static/js/impala/stats/csv_keys.js:155 static/js/zamboni/stats-all.js:15436 static/js/zamboni/stats-min.js:5
 msgid "Applications from {0} to {1}"
 msgstr "Toepassingen van {0} tot {1}"
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:159
+#: static/js/impala/stats/csv_keys.js:159 static/js/zamboni/stats-all.js:15440 static/js/zamboni/stats-min.js:5
 msgid "Platforms, last {0} days"
 msgstr "Platformen, laatste {0} dagen"
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:161
+#: static/js/impala/stats/csv_keys.js:161 static/js/zamboni/stats-all.js:15442 static/js/zamboni/stats-min.js:5
 msgid "Platforms from {0} to {1}"
 msgstr "Platformen van {0} tot {1}"
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:165
+#: static/js/impala/stats/csv_keys.js:165 static/js/zamboni/stats-all.js:15446 static/js/zamboni/stats-min.js:5
 msgid "Languages, last {0} days"
 msgstr "Talen, laatste {0} dagen"
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:167
+#: static/js/impala/stats/csv_keys.js:167 static/js/zamboni/stats-all.js:15448 static/js/zamboni/stats-min.js:5
 msgid "Languages from {0} to {1}"
 msgstr "Talen van {0} tot {1}"
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:171
+#: static/js/impala/stats/csv_keys.js:171 static/js/zamboni/stats-all.js:15452 static/js/zamboni/stats-min.js:5
 msgid "Add-on Versions, last {0} days"
 msgstr "Add-on-versies, laatste {0} dagen"
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:173
+#: static/js/impala/stats/csv_keys.js:173 static/js/zamboni/stats-all.js:15454 static/js/zamboni/stats-min.js:5
 msgid "Add-on Versions from {0} to {1}"
 msgstr "Add-on-versies van {0} tot {1}"
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:177
+#: static/js/impala/stats/csv_keys.js:177 static/js/zamboni/stats-all.js:15458 static/js/zamboni/stats-min.js:5
 msgid "Add-on Status, last {0} days"
 msgstr "Add-on-status, laatste {0} dagen"
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:179
+#: static/js/impala/stats/csv_keys.js:179 static/js/zamboni/stats-all.js:15460 static/js/zamboni/stats-min.js:5
 msgid "Add-on Status from {0} to {1}"
 msgstr "Add-on-status van {0} tot {1}"
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:183
+#: static/js/impala/stats/csv_keys.js:183 static/js/zamboni/stats-all.js:15464 static/js/zamboni/stats-min.js:5
 msgid "Download Sources, last {0} days"
 msgstr "Downloadbronnen, laatste {0} dagen"
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:185
+#: static/js/impala/stats/csv_keys.js:185 static/js/zamboni/stats-all.js:15466 static/js/zamboni/stats-min.js:5
 msgid "Download Sources from {0} to {1}"
 msgstr "Downloadbronnen van {0} tot {1}"
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:189
+#: static/js/impala/stats/csv_keys.js:189 static/js/zamboni/stats-all.js:15470 static/js/zamboni/stats-min.js:5
 msgid "Contributions, last {0} days"
 msgstr "Bijdragen, laatste {0} dagen"
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:191
+#: static/js/impala/stats/csv_keys.js:191 static/js/zamboni/stats-all.js:15472 static/js/zamboni/stats-min.js:5
 msgid "Contributions from {0} to {1}"
 msgstr "Bijdragen van {0} tot {1}"
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:195
+#: static/js/impala/stats/csv_keys.js:195 static/js/zamboni/stats-all.js:15476 static/js/zamboni/stats-min.js:5
 msgid "Site Metrics, last {0} days"
 msgstr "Websitegegevens, laatste {0} dagen"
 
 # why not localize the date format?
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:197
+#: static/js/impala/stats/csv_keys.js:197 static/js/zamboni/stats-all.js:15478 static/js/zamboni/stats-min.js:5
 msgid "Site Metrics from {0} to {1}"
 msgstr "Websitegegevens van {0} tot {1}"
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:201
+#: static/js/impala/stats/csv_keys.js:201 static/js/zamboni/stats-all.js:15482 static/js/zamboni/stats-min.js:5
 msgid "Add-ons in Use, last {0} days"
 msgstr "Gebruikte add-ons, laatste {0} dagen"
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:203
+#: static/js/impala/stats/csv_keys.js:203 static/js/zamboni/stats-all.js:15484 static/js/zamboni/stats-min.js:5
 msgid "Add-ons in Use from {0} to {1}"
 msgstr "Gebruikte add-ons van {0} tot {1}"
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:207
+#: static/js/impala/stats/csv_keys.js:207 static/js/zamboni/stats-all.js:15488 static/js/zamboni/stats-min.js:5
 msgid "Add-ons Downloaded, last {0} days"
 msgstr "Gedownloade add-ons, laatste {0} dagen"
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:209
+#: static/js/impala/stats/csv_keys.js:209 static/js/zamboni/stats-all.js:15490 static/js/zamboni/stats-min.js:5
 msgid "Add-ons Downloaded from {0} to {1}"
 msgstr "Gedownloade add-ons van {0} tot {1}"
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:213
+#: static/js/impala/stats/csv_keys.js:213 static/js/zamboni/stats-all.js:15494 static/js/zamboni/stats-min.js:5
 msgid "Add-ons Created, last {0} days"
 msgstr "Gemaakte add-ons, laatste {0} dagen"
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:215
+#: static/js/impala/stats/csv_keys.js:215 static/js/zamboni/stats-all.js:15496 static/js/zamboni/stats-min.js:5
 msgid "Add-ons Created from {0} to {1}"
 msgstr "Gemaakte add-ons van {0} tot {1}"
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:219
+#: static/js/impala/stats/csv_keys.js:219 static/js/zamboni/stats-all.js:15500 static/js/zamboni/stats-min.js:5
 msgid "Add-ons Updated, last {0} days"
 msgstr "Bijgewerkte add-ons, laatste {0} dagen"
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:221
+#: static/js/impala/stats/csv_keys.js:221 static/js/zamboni/stats-all.js:15502 static/js/zamboni/stats-min.js:5
 msgid "Add-ons Updated from {0} to {1}"
 msgstr "Bijgewerkte add-ons van {0} tot {1}"
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:225
+#: static/js/impala/stats/csv_keys.js:225 static/js/zamboni/stats-all.js:15506 static/js/zamboni/stats-min.js:5
 msgid "Reviews Written, last {0} days"
 msgstr "Geschreven beoordelingen, laatste {0} dagen"
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:227
+#: static/js/impala/stats/csv_keys.js:227 static/js/zamboni/stats-all.js:15508 static/js/zamboni/stats-min.js:5
 msgid "Reviews Written from {0} to {1}"
 msgstr "Geschreven beoordelingen van {0} tot {1}"
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:231
+#: static/js/impala/stats/csv_keys.js:231 static/js/zamboni/stats-all.js:15512 static/js/zamboni/stats-min.js:5
 msgid "User Signups, last {0} days"
 msgstr "Aanmeldingen, laatste {0} dagen"
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:233
+#: static/js/impala/stats/csv_keys.js:233 static/js/zamboni/stats-all.js:15514 static/js/zamboni/stats-min.js:5
 msgid "User Signups from {0} to {1}"
 msgstr "Aanmeldingen van {0} tot {1}"
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:237
+#: static/js/impala/stats/csv_keys.js:237 static/js/zamboni/stats-all.js:15518 static/js/zamboni/stats-min.js:5
 msgid "Collections Created, last {0} days"
 msgstr "Gemaakte collecties, laatste {0} dagen"
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:239
+#: static/js/impala/stats/csv_keys.js:239 static/js/zamboni/stats-all.js:15520 static/js/zamboni/stats-min.js:5
 msgid "Collections Created from {0} to {1}"
 msgstr "Gemaakte collecties van {0} tot {1}"
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:243
+#: static/js/impala/stats/csv_keys.js:243 static/js/zamboni/stats-all.js:15524 static/js/zamboni/stats-min.js:5
 msgid "Subscribers, last {0} days"
 msgstr "Abonnees, laatste {0} dagen"
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:245
+#: static/js/impala/stats/csv_keys.js:245 static/js/zamboni/stats-all.js:15526 static/js/zamboni/stats-min.js:5
 msgid "Subscribers from {0} to {1}"
 msgstr "Abonnees van {0} tot {1}"
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:249
+#: static/js/impala/stats/csv_keys.js:249 static/js/zamboni/stats-all.js:15530 static/js/zamboni/stats-min.js:5
 msgid "Ratings, last {0} days"
 msgstr "Waarderingen, laatste {0} dagen"
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:251
+#: static/js/impala/stats/csv_keys.js:251 static/js/zamboni/stats-all.js:15532 static/js/zamboni/stats-min.js:5
 msgid "Ratings from {0} to {1}"
 msgstr "Waarderingen van {0} tot {1}"
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:255
+#: static/js/impala/stats/csv_keys.js:255 static/js/zamboni/stats-all.js:15536 static/js/zamboni/stats-min.js:5
 msgid "Sales, last {0} days"
 msgstr "Verkopen, laatste {0} dagen"
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:257
+#: static/js/impala/stats/csv_keys.js:257 static/js/zamboni/stats-all.js:15538 static/js/zamboni/stats-min.js:5
 msgid "Sales from {0} to {1}"
 msgstr "Verkopen van {0} tot {1}"
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:261
+#: static/js/impala/stats/csv_keys.js:261 static/js/zamboni/stats-all.js:15542 static/js/zamboni/stats-min.js:5
 msgid "Installs, last {0} days"
 msgstr "Installaties, laatste {0} dagen"
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:263
+#: static/js/impala/stats/csv_keys.js:263 static/js/zamboni/stats-all.js:15544 static/js/zamboni/stats-min.js:5
 msgid "Installs from {0} to {1}"
 msgstr "Installaties van {0} tot {1}"
 
 #. L10n: {0} and {1} are integers.
-#: static/js/impala/stats/csv_keys.js:269
+#: static/js/impala/stats/csv_keys.js:269 static/js/zamboni/stats-all.js:15550 static/js/zamboni/stats-min.js:5
 msgid "<b>{0}</b> in last {1} days"
 msgstr "<b>{0}</b> in de laatste {1} dagen"
 
 #. L10n: {0} is an integer and {1} and {2} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:271 static/js/impala/stats/csv_keys.js:277
+#: static/js/impala/stats/csv_keys.js:271 static/js/impala/stats/csv_keys.js:277 static/js/zamboni/stats-all.js:15552 static/js/zamboni/stats-all.js:15558 static/js/zamboni/stats-min.js:5
 msgid "<b>{0}</b> from {1} to {2}"
 msgstr "<b>{0}</b> van {1} tot {2}"
 
 #. L10n: {0} and {1} are integers.
-#: static/js/impala/stats/csv_keys.js:275
+#: static/js/impala/stats/csv_keys.js:275 static/js/zamboni/stats-all.js:15556 static/js/zamboni/stats-min.js:5
 msgid "<b>{0}</b> average in last {1} days"
 msgstr "<b>{0}</b> gemiddeld in de laatste {1} dagen"
 
-#: static/js/impala/stats/overview.js:19
+#: static/js/impala/stats/overview.js:19 static/js/zamboni/stats-all.js:16469 static/js/zamboni/stats-min.js:5
 msgid "No data available."
 msgstr "Geen gegevens beschikbaar."
 
-#: static/js/impala/stats/table.js:74
+#: static/js/impala/stats/table.js:74 static/js/zamboni/stats-all.js:17209 static/js/zamboni/stats-min.js:5
 msgid "Date"
 msgstr "Datum"
 
-#: static/js/impala/stats/topchart.js:96
+#: static/js/impala/stats/topchart.js:96 static/js/zamboni/stats-all.js:16600 static/js/zamboni/stats-min.js:5
 msgid "Other"
 msgstr "Overig"
 
-#: static/js/zamboni/admin_validation.js:24 static/js/zamboni/devhub.js:1229 static/js/zamboni/editors.js:295
+#: static/js/zamboni/admin-all.js:180 static/js/zamboni/admin-min.js:1 static/js/zamboni/admin_validation.js:24 static/js/zamboni/devhub-all.js:2408 static/js/zamboni/devhub-min.js:2
+#: static/js/zamboni/devhub.js:1229 static/js/zamboni/editors-all.js:15576 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:295
 msgid "Select an application first"
 msgstr "Selecteer eerst een toepassing"
 
-#: static/js/zamboni/admin_validation.js:51
+#: static/js/zamboni/admin-all.js:207 static/js/zamboni/admin-min.js:1 static/js/zamboni/admin_validation.js:51
 msgid "Set {0} add-on to a max version of {1} and email the author."
 msgid_plural "Set {0} add-ons to a max version of {1} and email the authors."
 msgstr[0] "{0} add-on instellen op een maximumversie van {1} en een e-mailbericht naar de schrijver sturen."
 msgstr[1] "{0} add-ons instellen op een maximumversie van {1} en een e-mailbericht naar de schrijvers sturen."
 
-#: static/js/zamboni/admin_validation.js:54
+#: static/js/zamboni/admin-all.js:210 static/js/zamboni/admin-min.js:1 static/js/zamboni/admin_validation.js:54
 msgid "Email author of {2} add-on which failed validation."
 msgid_plural "Email authors of {2} add-ons which failed validation."
 msgstr[0] "E-mailbericht versturen naar schrijver van {2} add-on die de validatie niet heeft doorstaan."
 msgstr[1] "E-mailbericht versturen naar schrijver van {2} add-ons die de validatie niet heeft doorstaan."
 
-#. L10n: {0} is an app name like Firefox.
-#: static/js/zamboni/buttons.js:66
-msgid "Accept and Install"
-msgstr "Accepteren en installeren"
-
-#: static/js/zamboni/buttons.js:66
-msgid "Add to {0}"
-msgstr "Toevoegen aan {0}"
-
-#: static/js/zamboni/buttons.js:71
-msgid "Download Now"
-msgstr "Nu downloaden"
-
-#: static/js/zamboni/buttons.js:112
-msgid "Add-on has not been updated to support default-to-compatible."
-msgstr "Add-on is niet bijgewerkt om standaard-compatibel te ondersteunen."
-
-#: static/js/zamboni/buttons.js:117
-msgid "You need to be using Firefox 10.0 or higher."
-msgstr "U dient Firefox 10.0 of hoger te gebruiken."
-
-#: static/js/zamboni/buttons.js:129
-msgid "Mozilla has marked this version as incompatible with your Firefox version."
-msgstr "Mozilla heeft deze versie als niet-compatibel met uw Firefox-versie gemarkeerd."
-
-#. L10n: {0} is an platform like Windows or Linux.
-#: static/js/zamboni/buttons.js:210
-msgid "Install for {0} anyway"
-msgstr "Toch installeren voor {0}"
-
-#: static/js/zamboni/buttons.js:210
-msgid "Download for {0} anyway"
-msgstr "Toch downloaden voor {0}"
-
-#: static/js/zamboni/buttons.js:267
-msgid "Not available for your platform"
-msgstr "Niet beschikbaar voor uw platform"
-
-#. L10n: {0} is an app name, {1} is the app version.
-#: static/js/zamboni/buttons.js:278 static/js/zamboni/buttons.js:315
-msgid "Not available for {0} {1}"
-msgstr "Niet beschikbaar voor {0} {1}"
-
-#: static/js/zamboni/buttons.js:341
-msgid "Works with {app} {min} - {max}"
-msgstr "Werkt met {app} {min} - {max}"
-
-#: static/js/zamboni/buttons.js:343
-msgid "View other versions"
-msgstr "Overige versies bekijken"
-
-#: static/js/zamboni/buttons.js:391
-msgid "Only with Firefox — Get Firefox Now!"
-msgstr "Alleen bij Firefox – Download Firefox nu!"
-
-#: static/js/zamboni/buttons.js:507 static/js/zamboni/mobile/buttons.js:43
-msgid "Sorry, you need a Mozilla-based browser (such as Firefox) to install a search plugin."
-msgstr "Sorry, u hebt een op Mozilla gebaseerde browser (zoals Firefox) nodig om een zoekplug-in te kunnen installeren."
-
-#: static/js/zamboni/collections.js:229
-msgid "Adding to Favorites&hellip;"
-msgstr "Wordt toegevoegd aan Favorieten…"
-
-#: static/js/zamboni/collections.js:232
-msgid "Removing Favorite&hellip;"
-msgstr "Favoriet wordt verwijderd…"
-
-#: static/js/zamboni/collections.js:235
-msgid "Add to Favorites"
-msgstr "Toevoegen aan Favorieten"
-
-#: static/js/zamboni/collections.js:238
-msgid "Remove from Favorites"
-msgstr "Verwijderen uit Favorieten"
-
-#: static/js/zamboni/collections.js:303
-msgid "Pending"
-msgstr "In behandeling"
-
-#: static/js/zamboni/collections.js:304
-msgid "Add a comment"
-msgstr "Opmerking toevoegen"
-
-#: static/js/zamboni/collections.js:304
-msgid "Comment"
-msgstr "Opmerking"
-
-#: static/js/zamboni/collections.js:305
-msgid "Remove this add-on from the collection"
-msgstr "Deze add-on uit de collectie verwijderen"
-
-#: static/js/zamboni/collections.js:305 static/js/zamboni/collections.js:334
-msgid "Remove"
-msgstr "Verwijderen"
-
-#: static/js/zamboni/collections.js:334
-msgid "Remove this user as a contributor"
-msgstr "Deze gebruiker als medewerker verwijderen"
-
-#: static/js/zamboni/collections.js:346
-msgid "An email address is required."
-msgstr "Een e-mailadres is verplicht."
-
-#: static/js/zamboni/collections.js:364
-msgid "You cannot add yourself as a contributor."
-msgstr "U kunt uzelf niet als medewerker toevoegen."
-
-#: static/js/zamboni/collections.js:366
-msgid "You have already added that user."
-msgstr "U hebt die gebruiker al toegevoegd."
-
-#: static/js/zamboni/collections.js:573
-msgid "Add to favorites"
-msgstr "Toevoegen aan favorieten"
-
-#: static/js/zamboni/collections.js:577
-msgid "Remove from favorites"
-msgstr "Verwijderen uit favorieten"
-
-#: static/js/zamboni/collections.js:604
-msgid "Stop following"
-msgstr "Volgen stoppen"
-
-#: static/js/zamboni/devhub.js:110
+#: static/js/zamboni/devhub-all.js:1289 static/js/zamboni/devhub-min.js:1 static/js/zamboni/devhub.js:110
 msgid "Your browser does not support the video tag"
 msgstr "Uw browser ondersteunt het videolabel niet"
 
-#: static/js/zamboni/devhub.js:371
+#: static/js/zamboni/devhub-all.js:1550 static/js/zamboni/devhub-min.js:1 static/js/zamboni/devhub.js:371
 msgid "Changes Saved"
 msgstr "Wijzigingen opgeslagen"
 
-#: static/js/zamboni/devhub.js:387
+#: static/js/zamboni/devhub-all.js:1566 static/js/zamboni/devhub-min.js:1 static/js/zamboni/devhub.js:387
 msgid "Enter a new author's email address"
 msgstr "Voer een e-mailadres voor een nieuwe schrijver in"
 
-#: static/js/zamboni/devhub.js:536
+#: static/js/zamboni/devhub-all.js:1715 static/js/zamboni/devhub-min.js:1 static/js/zamboni/devhub.js:536
 msgid "There was an error uploading your file."
 msgstr "Er is een fout opgetreden tijdens het uploaden van uw bestand."
 
-#: static/js/zamboni/devhub.js:681
+#: static/js/zamboni/devhub-all.js:1860 static/js/zamboni/devhub-min.js:1 static/js/zamboni/devhub.js:681
 msgid "{files} file"
 msgid_plural "{files} files"
 msgstr[0] "{files} bestand"
 msgstr[1] "{files} bestanden"
 
-#: static/js/zamboni/devhub.js:684
+#: static/js/zamboni/devhub-all.js:1863 static/js/zamboni/devhub-min.js:1 static/js/zamboni/devhub.js:684
 msgid "{reviews} user review"
 msgid_plural "{reviews} user reviews"
 msgstr[0] "{reviews} gebruikersbeoordeling"
 msgstr[1] "{reviews} gebruikersbeoordelingen"
 
-#: static/js/zamboni/devhub.js:796
+#: static/js/zamboni/devhub-all.js:1975 static/js/zamboni/devhub-min.js:2 static/js/zamboni/devhub.js:796
 msgid "Learn more"
 msgstr "Meer info"
 
-#: static/js/zamboni/devhub.js:800
+#: static/js/zamboni/devhub-all.js:1979 static/js/zamboni/devhub-min.js:2 static/js/zamboni/devhub.js:800
 msgid "Example"
 msgstr "Voorbeeld"
 
-#: static/js/zamboni/devhub.js:1130
+#: static/js/zamboni/devhub-all.js:2309 static/js/zamboni/devhub-min.js:2 static/js/zamboni/devhub.js:1130
 msgid "Image changes being processed"
 msgstr "Afbeeldingswijzigingen worden verwerkt"
 
-#: static/js/zamboni/devhub.js:1280
+#: static/js/zamboni/devhub-all.js:2459 static/js/zamboni/devhub-min.js:2 static/js/zamboni/devhub.js:1280
 msgid "Must be a valid e-mail address."
 msgstr "Dient een geldig e-mailadres te zijn."
 
-#: static/js/zamboni/devhub_search.js:8
-msgid "No results found."
-msgstr "Geen resultaten."
-
-#: static/js/zamboni/editors.js:121
-msgid "{name} was viewing this page first."
-msgstr "{name} heeft eerst deze pagina bekeken."
-
-#: static/js/zamboni/editors.js:171
-msgid "Receipt checked by app."
-msgstr "Ontvangst gecontroleerd door app."
-
-#: static/js/zamboni/editors.js:173
-msgid "Receipt was not checked by app."
-msgstr "Ontvangst niet gecontroleerd door app."
-
-#: static/js/zamboni/editors.js:244
-msgid "{name} was viewing this add-on first."
-msgstr "{name} bekeek deze add-on eerst."
-
-#: static/js/zamboni/editors.js:255
-msgid "Loading&hellip;"
-msgstr "Laden…"
-
-#: static/js/zamboni/editors.js:260
-msgid "Version Notes"
-msgstr "Versieopmerkingen"
-
-#: static/js/zamboni/editors.js:265
-msgid "Notes for Reviewers"
-msgstr "Opmerkingen voor beoordelaars"
-
-#: static/js/zamboni/editors.js:270
-msgid "No version notes found"
-msgstr "Geen versieopmerkingen gevonden"
-
-#: static/js/zamboni/editors.js:330
-msgid "Average Reviews"
-msgstr "Gemiddelde beoordelingen"
-
-#: static/js/zamboni/editors.js:386
-msgid "Number of Reviews"
-msgstr "Aantal beoordelingen"
-
-#: static/js/zamboni/editors.js:445
-msgid "Error loading translation"
-msgstr "Fout bij laden vertaling"
-
-#: static/js/zamboni/files.js:411 static/js/zamboni/validator.js:261
-msgid "Ignore this message in future updates"
-msgstr "Dit bericht in toekomstige updates negeren"
-
-#: static/js/zamboni/files.js:417 static/js/zamboni/validator.js:284
-msgid "Severity for automated signing:"
-msgstr "Ernst voor automatische ondertekening:"
-
-#: static/js/zamboni/global.js:410
-msgid "Loading..."
-msgstr "Laden…"
-
-#. L10n: {0} is the number of characters left.
-#: static/js/zamboni/global.js:474
-msgid "<b>{0}</b> character left."
-msgid_plural "<b>{0}</b> characters left."
-msgstr[0] "<b>{0}</b> teken resterend."
-msgstr[1] "<b>{0}</b> tekens resterend."
-
-#: static/js/zamboni/init.js:28
-msgid "This feature is temporarily disabled while we perform website maintenance. Please check back a little later."
-msgstr "Deze functie is tijdelijk uitgeschakeld vanwege onderhoud aan de website. Probeer het later nog eens."
-
-#: static/js/zamboni/l10n.js:45
-msgid "Remove this localization"
-msgstr "Deze vertaling verwijderen"
-
-#: static/js/zamboni/password-strength.js:20
-msgid "Password strength:"
-msgstr "Wachtwoordsterkte:"
-
-#: static/js/zamboni/password-strength.js:26
-msgid "At least {0} character left."
-msgid_plural "At least {0} characters left."
-msgstr[0] "Ten minste {0} teken resterend."
-msgstr[1] "Ten minste {0} tekens resterend."
-
-#: static/js/zamboni/themes_review.js:176
-msgid "Requested Info"
-msgstr "Aangevraagde informatie"
-
-#: static/js/zamboni/themes_review.js:177
-msgid "Flagged"
-msgstr "Gelabeld"
-
-#: static/js/zamboni/themes_review.js:178
-msgid "Duplicate"
-msgstr "Duplicaat"
-
-#: static/js/zamboni/themes_review.js:179
-msgid "Rejected"
-msgstr "Afgewezen"
-
-#: static/js/zamboni/themes_review.js:180
-msgid "Approved"
-msgstr "Goedgekeurd"
-
-#: static/js/zamboni/themes_review.js:424
-msgid "No results found"
-msgstr "Geen resultaten gevonden"
-
-#: static/js/zamboni/themes_review_templates.js:31
-msgid "Theme"
-msgstr "Thema"
-
-#: static/js/zamboni/themes_review_templates.js:33
-msgid "Reviewer"
-msgstr "Beoordelaar"
-
-#: static/js/zamboni/themes_review_templates.js:35
-msgid "Status"
-msgstr "Status"
-
-#: static/js/zamboni/validator.js:80
+#: static/js/zamboni/devhub-all.js:2613 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:80
 msgid "All tests passed successfully."
 msgstr "Alle tests met succes doorstaan."
 
-#: static/js/zamboni/validator.js:83 static/js/zamboni/validator.js:478
+#: static/js/zamboni/devhub-all.js:2616 static/js/zamboni/devhub-all.js:3011 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:83 static/js/zamboni/validator.js:478
 msgid "These tests were not run."
 msgstr "Deze tests zijn niet uitgevoerd."
 
-#: static/js/zamboni/validator.js:131 static/js/zamboni/validator.js:144
+#: static/js/zamboni/devhub-all.js:2664 static/js/zamboni/devhub-all.js:2677 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:131 static/js/zamboni/validator.js:144
 msgid "Tests"
 msgstr "Tests"
 
-#: static/js/zamboni/validator.js:246 static/js/zamboni/validator.js:575 static/js/zamboni/validator.js:594
+#: static/js/zamboni/devhub-all.js:2779 static/js/zamboni/devhub-all.js:3108 static/js/zamboni/devhub-all.js:3127 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:246
+#: static/js/zamboni/validator.js:575 static/js/zamboni/validator.js:594
 msgid "Error"
 msgstr "Fout"
 
-#: static/js/zamboni/validator.js:247
+#: static/js/zamboni/devhub-all.js:2780 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:247
 msgid "Warning"
 msgstr "Waarschuwing"
 
-#: static/js/zamboni/validator.js:299
+#: static/js/zamboni/devhub-all.js:2794 static/js/zamboni/devhub-min.js:2 static/js/zamboni/files-all.js:5657 static/js/zamboni/files-min.js:3 static/js/zamboni/files.js:411
+#: static/js/zamboni/validator.js:261
+msgid "Ignore this message in future updates"
+msgstr "Dit bericht in toekomstige updates negeren"
+
+#: static/js/zamboni/devhub-all.js:2817 static/js/zamboni/devhub-min.js:2 static/js/zamboni/files-all.js:5663 static/js/zamboni/files-min.js:3 static/js/zamboni/files.js:417
+#: static/js/zamboni/validator.js:284
+msgid "Severity for automated signing:"
+msgstr "Ernst voor automatische ondertekening:"
+
+#: static/js/zamboni/devhub-all.js:2832 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:299
 msgid "Suggestions for passing automated signing:"
 msgstr "Suggesties voor doorstaan van automatische ondertekening:"
 
-#: static/js/zamboni/validator.js:387
+#: static/js/zamboni/devhub-all.js:2920 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:387
 msgid "Compatibility Tests"
 msgstr "Compatibiliteitstests"
 
-#: static/js/zamboni/validator.js:466
+#: static/js/zamboni/devhub-all.js:2999 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:466
 msgid "Add-on failed validation."
 msgstr "Add-on heeft validatie niet doorstaan."
 
-#: static/js/zamboni/validator.js:468
+#: static/js/zamboni/devhub-all.js:3001 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:468
 msgid "Add-on passed validation."
 msgstr "Add-on heeft validatie doorstaan."
 
-#: static/js/zamboni/validator.js:481
+#: static/js/zamboni/devhub-all.js:3014 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:481
 msgid "{0} error"
 msgid_plural "{0} errors"
 msgstr[0] "{0} fout"
 msgstr[1] "{0} fouten"
 
-#: static/js/zamboni/validator.js:483
+#: static/js/zamboni/devhub-all.js:3016 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:483
 msgid "{0} warning"
 msgid_plural "{0} warnings"
 msgstr[0] "{0} waarschuwing"
 msgstr[1] "{0} waarschuwingen"
 
-#: static/js/zamboni/validator.js:485
+#: static/js/zamboni/devhub-all.js:3018 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:485
 msgid "{0} notice"
 msgid_plural "{0} notices"
 msgstr[0] "{0} bericht"
 msgstr[1] "{0} berichten"
 
-#: static/js/zamboni/validator.js:577
+#: static/js/zamboni/devhub-all.js:3110 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:577
 msgid "Validation task could not complete or completed with errors"
 msgstr "Validatietaak kon niet worden voltooid of is voltooid met fouten"
 
-#: static/js/zamboni/validator.js:595
+#: static/js/zamboni/devhub-all.js:3128 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:595
 msgid "Internal server error"
 msgstr "Interne serverfout"
 
-#: static/js/zamboni/mobile/buttons.js:52
+#: static/js/zamboni/devhub_search.js:8
+msgid "No results found."
+msgstr "Geen resultaten."
+
+#: static/js/zamboni/editors-all.js:15402 static/js/zamboni/editors-min.js:4 static/js/zamboni/editors.js:121
+msgid "{name} was viewing this page first."
+msgstr "{name} heeft eerst deze pagina bekeken."
+
+#: static/js/zamboni/editors-all.js:15452 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:171
+msgid "Receipt checked by app."
+msgstr "Ontvangst gecontroleerd door app."
+
+#: static/js/zamboni/editors-all.js:15454 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:173
+msgid "Receipt was not checked by app."
+msgstr "Ontvangst niet gecontroleerd door app."
+
+#: static/js/zamboni/editors-all.js:15525 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:244
+msgid "{name} was viewing this add-on first."
+msgstr "{name} bekeek deze add-on eerst."
+
+#: static/js/zamboni/editors-all.js:15536 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:255
+msgid "Loading&hellip;"
+msgstr "Laden…"
+
+#: static/js/zamboni/editors-all.js:15541 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:260
+msgid "Version Notes"
+msgstr "Versieopmerkingen"
+
+#: static/js/zamboni/editors-all.js:15546 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:265
+msgid "Notes for Reviewers"
+msgstr "Opmerkingen voor beoordelaars"
+
+#: static/js/zamboni/editors-all.js:15551 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:270
+msgid "No version notes found"
+msgstr "Geen versieopmerkingen gevonden"
+
+#: static/js/zamboni/editors-all.js:15611 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:330
+msgid "Average Reviews"
+msgstr "Gemiddelde beoordelingen"
+
+#: static/js/zamboni/editors-all.js:15667 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:386
+msgid "Number of Reviews"
+msgstr "Aantal beoordelingen"
+
+#: static/js/zamboni/editors-all.js:15726 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:445
+msgid "Error loading translation"
+msgstr "Fout bij laden vertaling"
+
+#: static/js/zamboni/editors-all.js:15975 static/js/zamboni/editors-min.js:5 static/js/zamboni/themes_review_templates.js:31
+msgid "Theme"
+msgstr "Thema"
+
+#: static/js/zamboni/editors-all.js:15977 static/js/zamboni/editors-min.js:5 static/js/zamboni/themes_review_templates.js:33
+msgid "Reviewer"
+msgstr "Beoordelaar"
+
+#: static/js/zamboni/editors-all.js:15979 static/js/zamboni/editors-min.js:5 static/js/zamboni/themes_review_templates.js:35
+msgid "Status"
+msgstr "Status"
+
+#: static/js/zamboni/editors-all.js:16196 static/js/zamboni/editors-min.js:5 static/js/zamboni/themes_review.js:176
+msgid "Requested Info"
+msgstr "Aangevraagde informatie"
+
+#: static/js/zamboni/editors-all.js:16197 static/js/zamboni/editors-min.js:5 static/js/zamboni/themes_review.js:177
+msgid "Flagged"
+msgstr "Gelabeld"
+
+#: static/js/zamboni/editors-all.js:16198 static/js/zamboni/editors-min.js:5 static/js/zamboni/themes_review.js:178
+msgid "Duplicate"
+msgstr "Duplicaat"
+
+#: static/js/zamboni/editors-all.js:16199 static/js/zamboni/editors-min.js:5 static/js/zamboni/themes_review.js:179
+msgid "Rejected"
+msgstr "Afgewezen"
+
+#: static/js/zamboni/editors-all.js:16200 static/js/zamboni/editors-min.js:5 static/js/zamboni/themes_review.js:180
+msgid "Approved"
+msgstr "Goedgekeurd"
+
+#: static/js/zamboni/editors-all.js:16444 static/js/zamboni/editors-min.js:5 static/js/zamboni/themes_review.js:424
+msgid "No results found"
+msgstr "Geen resultaten gevonden"
+
+#: static/js/zamboni/mobile-all.js:15186 static/js/zamboni/mobile/buttons.js:52
 msgid "Not Updated for {0} {1}"
 msgstr "Niet bijgewerkt voor {0} {1}"
 
-#: static/js/zamboni/mobile/buttons.js:53
+#: static/js/zamboni/mobile-all.js:15187 static/js/zamboni/mobile/buttons.js:53
 msgid "Requires Newer Version of {0}"
 msgstr "Vereist een nieuwere versie van {0}"
 
-#: static/js/zamboni/mobile/buttons.js:54
+#: static/js/zamboni/mobile-all.js:15188 static/js/zamboni/mobile/buttons.js:54
 msgid "Unreviewed"
 msgstr "Niet beoordeeld"
 
-#: static/js/zamboni/mobile/buttons.js:55
+#: static/js/zamboni/mobile-all.js:15189 static/js/zamboni/mobile/buttons.js:55
 msgid "Experimental <span>(Learn More)</span>"
 msgstr "Experimenteel <span>(meer info)</span>"
 
-#: static/js/zamboni/mobile/buttons.js:56 static/js/zamboni/mobile/buttons.js:57
+#: static/js/zamboni/mobile-all.js:15190 static/js/zamboni/mobile-all.js:15191 static/js/zamboni/mobile/buttons.js:56 static/js/zamboni/mobile/buttons.js:57
 msgid "Not Available for {0}"
 msgstr "Niet beschikbaar voor {0}"
 
-#: static/js/zamboni/mobile/buttons.js:58
+#: static/js/zamboni/mobile-all.js:15192 static/js/zamboni/mobile/buttons.js:58
 msgid "Experimental"
 msgstr "Experimenteel"
 
-#: static/js/zamboni/mobile/buttons.js:59
+#: static/js/zamboni/mobile-all.js:15193 static/js/zamboni/mobile/buttons.js:59
 msgid "Themes Require Newer Version of {0}"
 msgstr "Thema’s vereisen een nieuwere versie van {0}"
 
-#: static/js/zamboni/mobile/buttons.js:60
+#: static/js/zamboni/mobile-all.js:15194 static/js/zamboni/mobile/buttons.js:60
 msgid "Themes Require {0}"
 msgstr "Thema’s vereisen {0}"
 
-#: static/js/zamboni/mobile/buttons.js:105
+#: static/js/zamboni/mobile-all.js:15239 static/js/zamboni/mobile/buttons.js:105
 msgid "Installing..."
 msgstr "Installeren…"
 
-#: static/js/zamboni/mobile/buttons.js:125
+#: static/js/zamboni/mobile-all.js:15259 static/js/zamboni/mobile/buttons.js:125
 msgid "This add-on has been preliminarily reviewed by Mozilla."
 msgstr "Deze add-on is voorlopig beoordeeld door Mozilla."
 
-#: static/js/zamboni/mobile/buttons.js:250
+#: static/js/zamboni/mobile-all.js:15384 static/js/zamboni/mobile/buttons.js:250
 msgid "Keep it"
 msgstr "Behouden"
 
-#: static/js/zamboni/mobile/general.js:344
+#: static/js/zamboni/mobile-all.js:16049 static/js/zamboni/mobile-min.js:6 static/js/zamboni/mobile/general.js:344
 msgid "You're trying it on!"
 msgstr "U past het nu!"
 
-#: static/js/zamboni/mobile/general.js:356
+#: static/js/zamboni/mobile-all.js:16061 static/js/zamboni/mobile-min.js:6 static/js/zamboni/mobile/general.js:356
 msgid "Added to Firefox"
 msgstr "Toegevoegd aan Firefox"
-

--- a/locale/or/LC_MESSAGES/django.po
+++ b/locale/or/LC_MESSAGES/django.po
@@ -3,69 +3,70 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2016-02-24 21:23+0000\n"
+"POT-Creation-Date: 2016-04-18 15:47+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
+"Language: \n"
 "MIME-Version: 1.0\n"
-"Content-Type: text/plain; charset=utf-8\n"
+"Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Generated-By: Babel 2.2.0\n"
 
-#: src/olympia/accounts/views.py:52
+#: src/olympia/accounts/views.py:54
 msgid "Your log in attempt could not be parsed. Please try again."
 msgstr ""
 
-#: src/olympia/accounts/views.py:54
+#: src/olympia/accounts/views.py:56
 msgid "Your Firefox Account could not be found. Please try again."
 msgstr ""
 
-#: src/olympia/accounts/views.py:55
+#: src/olympia/accounts/views.py:57
 msgid "You could not be logged in. Please try again."
 msgstr ""
 
-#: src/olympia/accounts/views.py:57
+#: src/olympia/accounts/views.py:59
 msgid "Your account has already been migrated to Firefox Accounts."
 msgstr ""
 
-#: src/olympia/accounts/views.py:59
+#: src/olympia/accounts/views.py:61
 msgid "Your Firefox Account already exists on this site."
 msgstr ""
 
-#: src/olympia/accounts/views.py:108
+#: src/olympia/accounts/views.py:110
 msgid "Great job!"
 msgstr ""
 
-#: src/olympia/accounts/views.py:109
+#: src/olympia/accounts/views.py:111
 msgid "You can now log in to Add-ons with your Firefox Account."
 msgstr ""
 
-#: src/olympia/accounts/views.py:121
+#: src/olympia/accounts/views.py:123
 msgid "Need help?"
 msgstr ""
 
-#: src/olympia/addons/buttons.py:180
+#: src/olympia/addons/buttons.py:177
 msgid "Download Now"
 msgstr ""
 
-#: src/olympia/addons/buttons.py:182
+#: src/olympia/addons/buttons.py:179
 msgid "Download"
 msgstr ""
 
 #. L10n: please keep &nbsp; in the string so &rarr; does not wrap.
-#: src/olympia/addons/buttons.py:186
+#: src/olympia/addons/buttons.py:183
 msgid "Continue to Download&nbsp;&rarr;"
 msgstr ""
 
-#: src/olympia/addons/buttons.py:202 src/olympia/addons/helpers.py:35 src/olympia/addons/views.py:319 src/olympia/addons/templates/addons/impala/details.html:114
+#: src/olympia/addons/buttons.py:199 src/olympia/addons/helpers.py:35 src/olympia/addons/views.py:333 src/olympia/addons/templates/addons/impala/details.html:111
 #: src/olympia/addons/templates/addons/impala/listing/items.html:17 src/olympia/addons/templates/addons/mobile/home.html:40 src/olympia/amo/templates/amo/side_nav.html:6
-#: src/olympia/amo/templates/amo/side_nav.html:10 src/olympia/amo/templates/amo/site_nav.html:2 src/olympia/amo/templates/amo/site_nav.html:55 src/olympia/bandwagon/views.py:95
-#: src/olympia/browse/views.py:54 src/olympia/browse/views.py:68 src/olympia/browse/views.py:235 src/olympia/browse/templates/browse/impala/category_landing.html:22
+#: src/olympia/amo/templates/amo/side_nav.html:10 src/olympia/amo/templates/amo/site_nav.html:2 src/olympia/amo/templates/amo/site_nav.html:53 src/olympia/bandwagon/views.py:95
+#: src/olympia/browse/views.py:54 src/olympia/browse/views.py:68 src/olympia/browse/views.py:202 src/olympia/browse/templates/browse/impala/category_landing.html:22
 #: src/olympia/browse/templates/browse/personas/mobile/category_landing.html:26
 msgid "Featured"
 msgstr ""
 
-#: src/olympia/addons/buttons.py:221
+#: src/olympia/addons/buttons.py:218
 msgid "Add to {0}"
 msgstr ""
 
@@ -113,39 +114,39 @@ msgid_plural "All tags must be at least {0} characters."
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/olympia/addons/forms.py:234
+#: src/olympia/addons/forms.py:238
 msgid "Categories cannot be changed while your add-on is featured for this application."
 msgstr ""
 
 #. L10n: {0} is the number of categories.
-#: src/olympia/addons/forms.py:238
+#: src/olympia/addons/forms.py:242
 msgid "You can have only {0} category."
 msgid_plural "You can have only {0} categories."
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/olympia/addons/forms.py:246
+#: src/olympia/addons/forms.py:250
 msgid "The miscellaneous category cannot be combined with additional categories."
 msgstr ""
 
-#: src/olympia/addons/forms.py:369
+#: src/olympia/addons/forms.py:374
 #, python-format
 msgid "Before changing your default locale you must have a name, summary, and description in that locale. You are missing %s."
 msgstr ""
 
-#: src/olympia/addons/forms.py:484 src/olympia/addons/forms.py:575
+#: src/olympia/addons/forms.py:455 src/olympia/addons/forms.py:546
 msgid "A license must be selected."
 msgstr ""
 
-#: src/olympia/addons/forms.py:556
+#: src/olympia/addons/forms.py:527
 msgid "Give Your Theme a Name."
 msgstr ""
 
-#: src/olympia/addons/forms.py:562 src/olympia/devhub/templates/devhub/personas/submit.html:53
+#: src/olympia/addons/forms.py:533 src/olympia/devhub/templates/devhub/personas/submit.html:53
 msgid "Describe your Theme."
 msgstr ""
 
-#: src/olympia/addons/forms.py:704
+#: src/olympia/addons/forms.py:675
 msgid "Enter a new author's email address"
 msgstr ""
 
@@ -153,37 +154,37 @@ msgstr ""
 msgid "Not Reviewed"
 msgstr ""
 
-#: src/olympia/addons/models.py:301
+#: src/olympia/addons/models.py:298
 msgid "Users have the option of contributing more or less than this amount."
 msgstr ""
 
-#: src/olympia/addons/models.py:309
-msgid "Users will always be asked in the Add-ons Manager (Firefox 4 and above)"
+#: src/olympia/addons/models.py:306
+msgid "Users will always be asked in the Add-ons Manager (Firefox 4 and above). Only applies to desktop."
 msgstr ""
 
-#: src/olympia/addons/models.py:1804 src/olympia/addons/templates/addons/details_box.html:55 src/olympia/devhub/templates/devhub/index.html:92
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:102
+#: src/olympia/addons/models.py:1802 src/olympia/addons/templates/addons/details_box.html:55 src/olympia/devhub/templates/devhub/index.html:92
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:89
 msgid "Listed"
 msgstr ""
 
-#: src/olympia/addons/views.py:320 src/olympia/browse/templates/browse/personas/mobile/category_landing.html:27
+#: src/olympia/addons/views.py:334 src/olympia/browse/templates/browse/personas/mobile/category_landing.html:27
 msgid "Popular"
 msgstr ""
 
-#: src/olympia/addons/views.py:321 src/olympia/browse/views.py:238 src/olympia/browse/views.py:280 src/olympia/browse/views.py:482
+#: src/olympia/addons/views.py:335 src/olympia/browse/views.py:205 src/olympia/browse/views.py:247 src/olympia/browse/views.py:449
 msgid "Recently Added"
 msgstr ""
 
-#: src/olympia/addons/views.py:322 src/olympia/bandwagon/views.py:99 src/olympia/browse/views.py:60 src/olympia/browse/views.py:71 src/olympia/search/forms.py:16 src/olympia/search/forms.py:91
+#: src/olympia/addons/views.py:336 src/olympia/bandwagon/views.py:99 src/olympia/browse/views.py:60 src/olympia/browse/views.py:71 src/olympia/search/forms.py:16 src/olympia/search/forms.py:91
 msgid "Recently Updated"
 msgstr ""
 
 #. l10n: {0} is the addon name
-#: src/olympia/addons/views.py:520
+#: src/olympia/addons/views.py:534
 msgid "Contribution for {0}"
 msgstr ""
 
-#: src/olympia/addons/views.py:613
+#: src/olympia/addons/views.py:627
 msgid "Abuse reported."
 msgstr ""
 
@@ -250,9 +251,9 @@ msgstr ""
 #: src/olympia/devhub/templates/devhub/addons/ajax_compat_update.html:36 src/olympia/devhub/templates/devhub/addons/profile.html:44 src/olympia/devhub/templates/devhub/addons/edit/admin.html:101
 #: src/olympia/devhub/templates/devhub/addons/edit/basic.html:152 src/olympia/devhub/templates/devhub/addons/edit/details.html:85 src/olympia/devhub/templates/devhub/addons/edit/support.html:67
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:166 src/olympia/devhub/templates/devhub/addons/forms_shared/media.html:149
-#: src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:44 src/olympia/devhub/templates/devhub/versions/add_file_modal.html:78 src/olympia/devhub/templates/devhub/versions/edit.html:139
-#: src/olympia/devhub/templates/devhub/versions/list.html:242 src/olympia/devhub/templates/devhub/versions/list.html:276 src/olympia/devhub/templates/devhub/versions/list.html:317
-#: src/olympia/devhub/templates/devhub/versions/list.html:351 src/olympia/reviews/templates/reviews/edit_review.html:16 src/olympia/translations/templates/translations/trans-menu.html:50
+#: src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:43 src/olympia/devhub/templates/devhub/versions/add_file_modal.html:58 src/olympia/devhub/templates/devhub/versions/edit.html:139
+#: src/olympia/devhub/templates/devhub/versions/list.html:239 src/olympia/devhub/templates/devhub/versions/list.html:281 src/olympia/devhub/templates/devhub/versions/list.html:315
+#: src/olympia/devhub/templates/devhub/versions/list.html:349 src/olympia/reviews/templates/reviews/edit_review.html:16 src/olympia/translations/templates/translations/trans-menu.html:50
 #: src/olympia/translations/templates/translations/trans-menu.html:62
 msgid "or"
 msgstr ""
@@ -363,7 +364,7 @@ msgid "Add-on Information for {0}"
 msgstr ""
 
 #: src/olympia/addons/templates/addons/details_box.html:30 src/olympia/addons/templates/addons/persona_detail_table.html:3 src/olympia/addons/templates/addons/mobile/details.html:63
-#: src/olympia/addons/templates/addons/mobile/persona_detail_table.html:7 src/olympia/browse/views.py:459 src/olympia/devhub/views.py:75
+#: src/olympia/addons/templates/addons/mobile/persona_detail_table.html:7 src/olympia/browse/views.py:426 src/olympia/devhub/views.py:73
 msgid "Updated"
 msgstr ""
 
@@ -382,11 +383,11 @@ msgstr ""
 msgid "Visibility"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/details_box.html:57 src/olympia/devhub/templates/devhub/index.html:94 src/olympia/devhub/templates/devhub/includes/addon_details.html:104
+#: src/olympia/addons/templates/addons/details_box.html:57 src/olympia/devhub/templates/devhub/index.html:94 src/olympia/devhub/templates/devhub/includes/addon_details.html:91
 msgid "Hidden"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/details_box.html:59 src/olympia/devhub/templates/devhub/index.html:96 src/olympia/devhub/templates/devhub/includes/addon_details.html:106
+#: src/olympia/addons/templates/addons/details_box.html:59 src/olympia/devhub/templates/devhub/index.html:96 src/olympia/devhub/templates/devhub/includes/addon_details.html:93
 msgid "Unlisted"
 msgstr ""
 
@@ -394,13 +395,13 @@ msgstr ""
 msgid "Required Add-ons"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/details_box.html:81 src/olympia/addons/templates/addons/persona_detail_table.html:15 src/olympia/browse/views.py:462 src/olympia/devhub/views.py:78
-#: src/olympia/devhub/views.py:85 src/olympia/discovery/templates/discovery/addons/detail.html:57 src/olympia/reviews/forms.py:62 src/olympia/reviews/templates/reviews/add.html:57
+#: src/olympia/addons/templates/addons/details_box.html:81 src/olympia/addons/templates/addons/persona_detail_table.html:15 src/olympia/browse/views.py:429 src/olympia/devhub/views.py:76
+#: src/olympia/devhub/views.py:83 src/olympia/discovery/templates/discovery/addons/detail.html:57 src/olympia/reviews/forms.py:62 src/olympia/reviews/templates/reviews/add.html:57
 #: src/olympia/reviews/templates/reviews/mobile/review_list.html:18
 msgid "Rating"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/details_box.html:85 src/olympia/browse/views.py:461 src/olympia/devhub/views.py:77 src/olympia/devhub/views.py:84
+#: src/olympia/addons/templates/addons/details_box.html:85 src/olympia/browse/views.py:428 src/olympia/devhub/views.py:75 src/olympia/devhub/views.py:82
 #: src/olympia/stats/templates/stats/addon_report_menu.html:8 src/olympia/stats/templates/stats/collection_report_menu.html:18
 msgid "Downloads"
 msgstr ""
@@ -420,7 +421,7 @@ msgstr ""
 
 #. The Privacy Policy for this add-on.
 #: src/olympia/addons/templates/addons/details_box.html:121 src/olympia/addons/templates/addons/privacy.html:19 src/olympia/addons/templates/addons/privacy.html:23
-#: src/olympia/addons/templates/addons/impala/button.html:43 src/olympia/addons/templates/addons/impala/details.html:307 src/olympia/devhub/templates/devhub/includes/policy_form.html:20
+#: src/olympia/addons/templates/addons/impala/button.html:43 src/olympia/addons/templates/addons/impala/details.html:312 src/olympia/devhub/templates/devhub/includes/policy_form.html:23
 #: src/olympia/templates/mobile/base_addons.html:87
 msgid "Privacy Policy"
 msgstr ""
@@ -445,7 +446,7 @@ msgstr ""
 msgid "Developer Comments"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/details_box.html:199 src/olympia/addons/templates/addons/impala/details.html:259
+#: src/olympia/addons/templates/addons/details_box.html:199 src/olympia/addons/templates/addons/impala/details.html:264
 msgid "Development Channel"
 msgstr ""
 
@@ -465,7 +466,7 @@ msgid ""
 "developer. To stop receiving development updates, reinstall the default version from the link above."
 msgstr ""
 
-#: src/olympia/addons/templates/addons/details_box.html:220 src/olympia/addons/templates/addons/impala/details.html:278
+#: src/olympia/addons/templates/addons/details_box.html:220 src/olympia/addons/templates/addons/impala/details.html:283
 msgid "Version {0}:"
 msgstr ""
 
@@ -484,7 +485,7 @@ msgid "End-User License Agreement for {0}"
 msgstr ""
 
 #: src/olympia/addons/templates/addons/eula.html:17 src/olympia/addons/templates/addons/eula.html:21 src/olympia/addons/templates/addons/impala/button.html:48
-#: src/olympia/addons/templates/addons/impala/details.html:316 src/olympia/devhub/templates/devhub/includes/policy_form.html:3 src/olympia/discovery/templates/discovery/addons/eula.html:11
+#: src/olympia/addons/templates/addons/impala/details.html:321 src/olympia/devhub/templates/devhub/includes/policy_form.html:3 src/olympia/discovery/templates/discovery/addons/eula.html:11
 msgid "End-User License Agreement"
 msgstr ""
 
@@ -501,7 +502,7 @@ msgstr ""
 msgid "Add-ons for {0}"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/home.html:10 src/olympia/addons/templates/addons/home.html:51 src/olympia/browse/templates/browse/impala/base_listing.html:11
+#: src/olympia/addons/templates/addons/home.html:10 src/olympia/addons/templates/addons/home.html:53 src/olympia/browse/templates/browse/impala/base_listing.html:11
 msgid "Featured Extensions"
 msgstr ""
 
@@ -509,29 +510,29 @@ msgstr ""
 msgid "Popular Extensions"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/home.html:42 src/olympia/amo/templates/amo/side_nav.html:3 src/olympia/amo/templates/amo/side_nav.html:11 src/olympia/amo/templates/amo/site_nav.html:3
-#: src/olympia/amo/templates/amo/site_nav.html:25 src/olympia/browse/views.py:236 src/olympia/browse/views.py:281 src/olympia/browse/views.py:481
+#: src/olympia/addons/templates/addons/home.html:44 src/olympia/amo/templates/amo/side_nav.html:3 src/olympia/amo/templates/amo/side_nav.html:11 src/olympia/amo/templates/amo/site_nav.html:3
+#: src/olympia/amo/templates/amo/site_nav.html:25 src/olympia/browse/views.py:203 src/olympia/browse/views.py:248 src/olympia/browse/views.py:448
 msgid "Most Popular"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/home.html:43
+#: src/olympia/addons/templates/addons/home.html:45
 msgid "All »"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/home.html:52 src/olympia/addons/templates/addons/home.html:61 src/olympia/addons/templates/addons/home.html:70 src/olympia/addons/templates/addons/home.html:78
+#: src/olympia/addons/templates/addons/home.html:54 src/olympia/addons/templates/addons/home.html:63 src/olympia/addons/templates/addons/home.html:72 src/olympia/addons/templates/addons/home.html:80
 #: src/olympia/browse/templates/browse/impala/category_landing.html:36
 msgid "See all »"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/home.html:60
+#: src/olympia/addons/templates/addons/home.html:62
 msgid "Up &amp; Coming Extensions"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/home.html:69 src/olympia/browse/templates/browse/personas/category_landing.html:61 src/olympia/discovery/templates/discovery/pane.html:74
+#: src/olympia/addons/templates/addons/home.html:71 src/olympia/browse/templates/browse/personas/category_landing.html:61 src/olympia/discovery/templates/discovery/pane.html:74
 msgid "Featured Themes"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/home.html:77 src/olympia/bandwagon/templates/bandwagon/impala/collection_listing.html:5
+#: src/olympia/addons/templates/addons/home.html:79 src/olympia/bandwagon/templates/bandwagon/impala/collection_listing.html:5
 msgid "Featured Collections"
 msgstr ""
 
@@ -549,7 +550,7 @@ msgid "Updated {0}"
 msgstr ""
 
 #. {0} is a date.
-#: src/olympia/addons/templates/addons/macros.html:10 src/olympia/addons/templates/addons/macros.html:69 src/olympia/addons/templates/addons/persona_preview.html:21
+#: src/olympia/addons/templates/addons/macros.html:10 src/olympia/addons/templates/addons/macros.html:69 src/olympia/addons/templates/addons/persona_preview.html:22
 #: src/olympia/addons/templates/addons/listing/items_mobile.html:44 src/olympia/addons/templates/addons/listing/macros.html:39
 #: src/olympia/bandwagon/templates/bandwagon/collection_listing_items.html:37 src/olympia/bandwagon/templates/bandwagon/impala/collection_listing_items.html:37
 msgid "Added {0}"
@@ -570,15 +571,14 @@ msgstr[0] ""
 msgstr[1] ""
 
 #. {0} is the number of downloads.
-#: src/olympia/addons/templates/addons/macros.html:53 src/olympia/addons/templates/addons/impala/details.html:61
+#: src/olympia/addons/templates/addons/macros.html:53 src/olympia/addons/templates/addons/impala/details.html:59
 msgid "{0} weekly download"
 msgid_plural "{0} weekly downloads"
 msgstr[0] ""
 msgstr[1] ""
 
 #. {0} is the number of users.
-#: src/olympia/addons/templates/addons/macros.html:61 src/olympia/addons/templates/addons/impala/details.html:54 src/olympia/compat/templates/compat/index.html:71
-#: src/olympia/zadmin/templates/zadmin/compat.html:67
+#: src/olympia/addons/templates/addons/macros.html:61 src/olympia/addons/templates/addons/impala/details.html:52 src/olympia/zadmin/templates/zadmin/compat.html:67
 msgid "{0} user"
 msgid_plural "{0} users"
 msgstr[0] ""
@@ -596,7 +596,7 @@ msgstr ""
 msgid "Return to the addon."
 msgstr ""
 
-#: src/olympia/addons/templates/addons/persona_detail.html:17 src/olympia/addons/templates/addons/impala/details.html:106 src/olympia/addons/templates/addons/mobile/details.html:23
+#: src/olympia/addons/templates/addons/persona_detail.html:17 src/olympia/addons/templates/addons/impala/details.html:103 src/olympia/addons/templates/addons/mobile/details.html:23
 #: src/olympia/addons/templates/addons/mobile/persona_detail.html:21 src/olympia/discovery/templates/discovery/addons/base.html:27 src/olympia/editors/templates/editors/review.html:31
 msgid "by"
 msgstr ""
@@ -640,34 +640,35 @@ msgstr ""
 msgid "License"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/persona_preview.html:12 src/olympia/constants/base.py:48
+#: src/olympia/addons/templates/addons/persona_preview.html:13 src/olympia/constants/base.py:48
 msgid "Awaiting Review"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/persona_preview.html:14 src/olympia/amo/log.py:180 src/olympia/constants/base.py:42 src/olympia/editors/helpers.py:62
+#: src/olympia/addons/templates/addons/persona_preview.html:15 src/olympia/amo/log.py:180 src/olympia/constants/base.py:42 src/olympia/editors/helpers.py:62
 msgid "Rejected"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/persona_preview.html:16 src/olympia/amo/log.py:159
+#: src/olympia/addons/templates/addons/persona_preview.html:17 src/olympia/amo/log.py:159
 msgid "Approved"
 msgstr ""
 
 #. {0} is the number of users.
-#: src/olympia/addons/templates/addons/persona_preview.html:26 src/olympia/addons/templates/addons/listing/items_mobile.html:36 src/olympia/addons/templates/addons/listing/macros.html:31
+#: src/olympia/addons/templates/addons/persona_preview.html:27 src/olympia/addons/templates/addons/listing/items_mobile.html:36 src/olympia/addons/templates/addons/listing/macros.html:31
 msgid "<strong>{0}</strong> user"
 msgid_plural "<strong>{0}</strong> users"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/olympia/addons/templates/addons/persona_preview.html:40
+#: src/olympia/addons/templates/addons/persona_preview.html:41
 msgid "Hover to Preview"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/persona_preview.html:46 src/olympia/addons/templates/addons/persona_preview.html:48 src/olympia/reviews/templates/reviews/add.html:15
+#: src/olympia/addons/templates/addons/persona_preview.html:47 src/olympia/addons/templates/addons/persona_preview.html:49 src/olympia/addons/templates/addons/persona_preview.html:97
+#: src/olympia/reviews/templates/reviews/add.html:15
 msgid "Add"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/persona_preview.html:57 src/olympia/bandwagon/templates/bandwagon/ajax_new.html:16 src/olympia/bandwagon/templates/bandwagon/edit.html:19
+#: src/olympia/addons/templates/addons/persona_preview.html:58 src/olympia/bandwagon/templates/bandwagon/ajax_new.html:16 src/olympia/bandwagon/templates/bandwagon/edit.html:19
 #: src/olympia/bandwagon/templates/bandwagon/includes/addedit.html:19 src/olympia/devhub/templates/devhub/addons/edit/admin.html:13 src/olympia/devhub/templates/devhub/addons/edit/basic.html:10
 #: src/olympia/devhub/templates/devhub/addons/edit/details.html:8 src/olympia/devhub/templates/devhub/addons/edit/media.html:6 src/olympia/devhub/templates/devhub/addons/edit/support.html:8
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:9 src/olympia/devhub/templates/devhub/addons/submit/describe.html:29 src/olympia/editors/templates/editors/review.html:257
@@ -676,21 +677,21 @@ msgstr ""
 
 #. For datetime formatting, see the table on
 #. http://docs.python.org/library/datetime.html#strftime-and-strptime-behavior
-#: src/olympia/addons/templates/addons/persona_preview.html:66
+#: src/olympia/addons/templates/addons/persona_preview.html:67
 #, python-format
 msgid "%%Y-%%m-%%d"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/persona_preview.html:67
+#: src/olympia/addons/templates/addons/persona_preview.html:68
 msgid "by {0} on {1}"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/persona_preview.html:75 src/olympia/reviews/helpers.py:17 src/olympia/reviews/templates/reviews/review_list.html:63
+#: src/olympia/addons/templates/addons/persona_preview.html:76 src/olympia/reviews/helpers.py:17 src/olympia/reviews/templates/reviews/review_list.html:63
 #: src/olympia/reviews/templates/reviews/reviews_link.html:21 src/olympia/reviews/templates/reviews/impala/reviews_link.html:16
 msgid "Not yet rated"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/persona_preview.html:78
+#: src/olympia/addons/templates/addons/persona_preview.html:79
 msgid "<b>{0}</b> users"
 msgstr ""
 
@@ -703,7 +704,7 @@ msgid "Learn more about Firefox"
 msgstr ""
 
 #: src/olympia/addons/templates/addons/popups.html:22
-msgid "or <b><a class=\"installer\" href=\"{url}\">download anyway</a></b>"
+msgid "or <b><a class=\"button installer\" href=\"{url}\">download anyway</a></b>"
 msgstr ""
 
 #: src/olympia/addons/templates/addons/popups.html:26
@@ -802,7 +803,7 @@ msgid ""
 msgstr ""
 
 #: src/olympia/addons/templates/addons/report_abuse.html:6 src/olympia/addons/templates/addons/report_abuse_full.html:10 src/olympia/addons/templates/addons/impala/details-more.html:23
-#: src/olympia/addons/templates/addons/impala/details.html:328
+#: src/olympia/addons/templates/addons/impala/details.html:333
 msgid "Report Abuse"
 msgstr ""
 
@@ -821,9 +822,9 @@ msgstr ""
 #: src/olympia/devhub/templates/devhub/addons/ajax_compat_update.html:36 src/olympia/devhub/templates/devhub/addons/profile.html:44 src/olympia/devhub/templates/devhub/addons/edit/admin.html:104
 #: src/olympia/devhub/templates/devhub/addons/edit/basic.html:155 src/olympia/devhub/templates/devhub/addons/edit/details.html:88 src/olympia/devhub/templates/devhub/addons/edit/support.html:70
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:169 src/olympia/devhub/templates/devhub/addons/forms_shared/media.html:152
-#: src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:44 src/olympia/devhub/templates/devhub/personas/edit.html:222 src/olympia/devhub/templates/devhub/versions/add_file_modal.html:79
-#: src/olympia/devhub/templates/devhub/versions/edit.html:140 src/olympia/devhub/templates/devhub/versions/list.html:208 src/olympia/devhub/templates/devhub/versions/list.html:242
-#: src/olympia/devhub/templates/devhub/versions/list.html:276 src/olympia/devhub/templates/devhub/versions/list.html:317 src/olympia/reviews/templates/reviews/edit_review.html:16
+#: src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:43 src/olympia/devhub/templates/devhub/personas/edit.html:222 src/olympia/devhub/templates/devhub/versions/add_file_modal.html:59
+#: src/olympia/devhub/templates/devhub/versions/edit.html:140 src/olympia/devhub/templates/devhub/versions/list.html:208 src/olympia/devhub/templates/devhub/versions/list.html:239
+#: src/olympia/devhub/templates/devhub/versions/list.html:281 src/olympia/devhub/templates/devhub/versions/list.html:315 src/olympia/reviews/templates/reviews/edit_review.html:16
 #: src/olympia/translations/templates/translations/trans-menu.html:50 src/olympia/translations/templates/translations/trans-menu.html:62 src/olympia/zadmin/templates/zadmin/validation.html:105
 msgid "Cancel"
 msgstr ""
@@ -868,7 +869,7 @@ msgstr ""
 msgid "Review Guidelines"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/review_list_box.html:5 src/olympia/addons/templates/addons/impala/details-more.html:27 src/olympia/editors/helpers.py:921
+#: src/olympia/addons/templates/addons/review_list_box.html:5 src/olympia/addons/templates/addons/impala/details-more.html:27 src/olympia/editors/helpers.py:1001
 #: src/olympia/reviews/templates/reviews/add.html:14 src/olympia/reviews/templates/reviews/reply.html:14 src/olympia/reviews/templates/reviews/review_list.html:19
 #: src/olympia/reviews/templates/reviews/mobile/review_list.html:26
 msgid "Reviews"
@@ -959,119 +960,119 @@ msgid_plural "Other add-ons by these authors"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/olympia/addons/templates/addons/impala/details.html:41
+#: src/olympia/addons/templates/addons/impala/details.html:39
 #, python-format
 msgid "<span itemprop=\"ratingCount\">%(num)s</span> user review"
 msgid_plural "<span itemprop=\"ratingCount\">%(num)s</span> user reviews"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/olympia/addons/templates/addons/impala/details.html:69
+#: src/olympia/addons/templates/addons/impala/details.html:66
 msgid "View statistics"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/impala/details.html:84
+#: src/olympia/addons/templates/addons/impala/details.html:81
 msgid "Manage"
 msgstr ""
 
 #. {0} is an add-on name.
-#: src/olympia/addons/templates/addons/impala/details.html:96
+#: src/olympia/addons/templates/addons/impala/details.html:93
 msgid "Icon of {0}"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/impala/details.html:103 src/olympia/addons/templates/addons/impala/listing/items.html:14
+#: src/olympia/addons/templates/addons/impala/details.html:100 src/olympia/addons/templates/addons/impala/listing/items.html:14
 msgid "No Restart"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/impala/details.html:127
+#: src/olympia/addons/templates/addons/impala/details.html:124
 #, python-format
 msgid "Meet the Developer: <a href=\"%(url)s\">%(name)s</a>"
 msgid_plural "<a href=\"%(url)s\">Meet the Developers</a>"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/olympia/addons/templates/addons/impala/details.html:137
+#: src/olympia/addons/templates/addons/impala/details.html:134
 msgid "Learn why {0} was created and find out what's next for this add-on."
 msgstr ""
 
 #. {0} is an index.
-#: src/olympia/addons/templates/addons/impala/details.html:156
+#: src/olympia/addons/templates/addons/impala/details.html:161
 msgid "Add-on screenshot #{0}"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/impala/details.html:182
+#: src/olympia/addons/templates/addons/impala/details.html:187
 msgid "Add-on home page"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/impala/details.html:185
+#: src/olympia/addons/templates/addons/impala/details.html:190
 msgid "Support site"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/impala/details.html:189
+#: src/olympia/addons/templates/addons/impala/details.html:194
 msgid "Support E-mail"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/impala/details.html:194 src/olympia/devhub/models.py:378 src/olympia/devhub/templates/devhub/versions/list.html:12
+#: src/olympia/addons/templates/addons/impala/details.html:199 src/olympia/devhub/models.py:378 src/olympia/devhub/templates/devhub/versions/list.html:12
 #: src/olympia/versions/templates/versions/version.html:6 src/olympia/versions/templates/versions/mobile/version.html:6
 msgid "Version {0}"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/impala/details.html:194
+#: src/olympia/addons/templates/addons/impala/details.html:199
 msgid "Info"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/impala/details.html:195 src/olympia/devhub/templates/devhub/includes/addon_details.html:129
+#: src/olympia/addons/templates/addons/impala/details.html:200 src/olympia/devhub/templates/devhub/includes/addon_details.html:116
 msgid "Last Updated:"
-msgstr ""
-
-#: src/olympia/addons/templates/addons/impala/details.html:200
-#, python-format
-msgid "Released under <a target=\"_blank\" href=\"%(url)s\">%(name)s</a>"
-msgstr ""
-
-#: src/olympia/addons/templates/addons/impala/details.html:201 src/olympia/addons/templates/addons/impala/details.html:206 src/olympia/amo/helpers.py:398 src/olympia/devhub/forms.py:142
-#: src/olympia/devhub/forms.py:173 src/olympia/versions/templates/versions/version.html:40 src/olympia/versions/templates/versions/version.html:45
-msgid "Custom License"
 msgstr ""
 
 #: src/olympia/addons/templates/addons/impala/details.html:205
 #, python-format
+msgid "Released under <a target=\"_blank\" href=\"%(url)s\">%(name)s</a>"
+msgstr ""
+
+#: src/olympia/addons/templates/addons/impala/details.html:206 src/olympia/addons/templates/addons/impala/details.html:211 src/olympia/amo/helpers.py:398 src/olympia/devhub/forms.py:142
+#: src/olympia/devhub/forms.py:173 src/olympia/versions/templates/versions/version.html:40 src/olympia/versions/templates/versions/version.html:45
+msgid "Custom License"
+msgstr ""
+
+#: src/olympia/addons/templates/addons/impala/details.html:210
+#, python-format
 msgid "Released under <a href=\"%(url)s\">%(name)s</a>"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/impala/details.html:217
+#: src/olympia/addons/templates/addons/impala/details.html:222
 msgid "About this Add-on"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/impala/details.html:233
+#: src/olympia/addons/templates/addons/impala/details.html:238
 msgid "Developer’s Comments"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/impala/details.html:243
+#: src/olympia/addons/templates/addons/impala/details.html:248
 msgid "Version Information"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/impala/details.html:250
+#: src/olympia/addons/templates/addons/impala/details.html:255
 msgid "See complete version history"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/impala/details.html:262
+#: src/olympia/addons/templates/addons/impala/details.html:267
 msgid ""
 "The Development Channel lets you test an experimental new version of this add-on before it's released to the general public. Once you install the development version, you will continue to get "
 "updates from this channel. To stop receiving development updates, reinstall the default version from the link above."
 msgstr ""
 
-#: src/olympia/addons/templates/addons/impala/details.html:272
+#: src/olympia/addons/templates/addons/impala/details.html:277
 msgid "<strong>Caution:</strong> Development versions of this add-on have not been reviewed by Mozilla."
 msgstr ""
 
-#: src/olympia/addons/templates/addons/impala/details.html:287
+#: src/olympia/addons/templates/addons/impala/details.html:292
 msgid "See complete development channel history"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/impala/details.html:306 src/olympia/addons/templates/addons/impala/details.html:315 src/olympia/addons/templates/addons/impala/details.html:327
+#: src/olympia/addons/templates/addons/impala/details.html:311 src/olympia/addons/templates/addons/impala/details.html:320 src/olympia/addons/templates/addons/impala/details.html:332
 #: src/olympia/addons/templates/addons/impala/review_add_box.html:4 src/olympia/stats/templates/stats/popup.html:2 src/olympia/stats/templates/stats/popup.html:8
-#: src/olympia/stats/templates/stats/stats.html:202 src/olympia/users/templates/users/profile.html:119
+#: src/olympia/stats/templates/stats/stats.html:204 src/olympia/users/templates/users/profile.html:119
 msgid "close"
 msgstr ""
 
@@ -1127,15 +1128,11 @@ msgstr ""
 msgid "Source Code License"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/impala/persona_grid.html:16 src/olympia/addons/templates/addons/impala/toplist.html:6
-msgid "{0} users"
-msgstr ""
-
 #: src/olympia/addons/templates/addons/impala/review_list_box.html:19 src/olympia/reviews/templates/reviews/review.html:40
 msgid "permalink"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/impala/review_list_box.html:23 src/olympia/editors/templates/editors/queue.html:98 src/olympia/reviews/templates/reviews/review.html:44
+#: src/olympia/addons/templates/addons/impala/review_list_box.html:23 src/olympia/editors/templates/editors/queue.html:104 src/olympia/reviews/templates/reviews/review.html:44
 msgid "translate"
 msgstr ""
 
@@ -1154,6 +1151,10 @@ msgstr ""
 msgid "Be the first!"
 msgstr ""
 
+#: src/olympia/addons/templates/addons/impala/toplist.html:6
+msgid "{0} users"
+msgstr ""
+
 #: src/olympia/addons/templates/addons/impala/listing/sorter.html:14 src/olympia/devhub/templates/devhub/addons/listing/item_actions.html:49
 msgid "More"
 msgstr ""
@@ -1166,7 +1167,7 @@ msgstr ""
 msgid "My Add-ons"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/includes/dashboard_tabs.html:6 src/olympia/amo/context_processors.py:51
+#: src/olympia/addons/templates/addons/includes/dashboard_tabs.html:6 src/olympia/amo/context_processors.py:50
 msgid "My Themes"
 msgstr ""
 
@@ -1221,7 +1222,7 @@ msgstr ""
 msgid "Weekly Downloads"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/mobile/details.html:99 src/olympia/compat/templates/compat/reporter_detail.html:46 src/olympia/devhub/forms.py:787
+#: src/olympia/addons/templates/addons/mobile/details.html:99 src/olympia/compat/templates/compat/reporter_detail.html:46 src/olympia/devhub/forms.py:788
 #: src/olympia/devhub/templates/devhub/versions/list.html:163
 msgid "Version"
 msgstr ""
@@ -1305,7 +1306,7 @@ msgstr ""
 #: src/olympia/browse/templates/browse/personas/category_landing.html:21 src/olympia/browse/templates/browse/personas/category_landing.html:23
 #: src/olympia/browse/templates/browse/personas/category_landing.html:38 src/olympia/browse/templates/browse/personas/grid.html:7 src/olympia/browse/templates/browse/personas/grid.html:11
 #: src/olympia/browse/templates/browse/personas/mobile/base.html:7 src/olympia/browse/templates/browse/personas/mobile/category_landing.html:19 src/olympia/constants/base.py:180
-#: src/olympia/devhub/templates/devhub/personas/submit.html:13 src/olympia/editors/helpers.py:105 src/olympia/editors/templates/editors/base.html:26
+#: src/olympia/devhub/templates/devhub/personas/submit.html:13 src/olympia/editors/helpers.py:107 src/olympia/editors/templates/editors/base.html:26
 #: src/olympia/editors/templates/editors/performance.html:73 src/olympia/search/templates/search/personas.html:39 src/olympia/templates/menu_links.html:9
 msgid "Themes"
 msgstr ""
@@ -1326,7 +1327,7 @@ msgstr ""
 msgid "Highest Rated"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/mobile/home.html:74 src/olympia/amo/templates/amo/side_nav.html:5 src/olympia/amo/templates/amo/site_nav.html:27 src/olympia/amo/templates/amo/site_nav.html:57
+#: src/olympia/addons/templates/addons/mobile/home.html:74 src/olympia/amo/templates/amo/side_nav.html:5 src/olympia/amo/templates/amo/site_nav.html:27 src/olympia/amo/templates/amo/site_nav.html:55
 #: src/olympia/bandwagon/views.py:97 src/olympia/browse/views.py:57 src/olympia/browse/views.py:67 src/olympia/browse/templates/browse/personas/mobile/category_landing.html:65
 #: src/olympia/search/forms.py:15 src/olympia/search/forms.py:87
 msgid "Newest"
@@ -1340,90 +1341,90 @@ msgstr ""
 msgid "Theme Info &raquo;"
 msgstr ""
 
-#: src/olympia/amo/context_processors.py:39 src/olympia/devhub/templates/devhub/nav.html:43
+#: src/olympia/amo/context_processors.py:37 src/olympia/devhub/templates/devhub/nav.html:43
 msgid "Tools"
 msgstr ""
 
-#: src/olympia/amo/context_processors.py:48 src/olympia/discovery/templates/discovery/pane_account.html:8 src/olympia/users/templates/users/includes/navigation.html:2
+#: src/olympia/amo/context_processors.py:47 src/olympia/discovery/templates/discovery/pane_account.html:8 src/olympia/users/templates/users/includes/navigation.html:2
 msgid "My Profile"
 msgstr ""
 
-#: src/olympia/amo/context_processors.py:54 src/olympia/users/templates/users/edit.html:5 src/olympia/users/templates/users/includes/navigation.html:3
+#: src/olympia/amo/context_processors.py:53 src/olympia/users/templates/users/edit.html:5 src/olympia/users/templates/users/includes/navigation.html:3
 msgid "Account Settings"
 msgstr ""
 
-#: src/olympia/amo/context_processors.py:57 src/olympia/discovery/templates/discovery/pane_account.html:11 src/olympia/users/templates/users/profile.html:83
+#: src/olympia/amo/context_processors.py:56 src/olympia/discovery/templates/discovery/pane_account.html:11 src/olympia/users/templates/users/profile.html:83
 #: src/olympia/users/templates/users/includes/navigation.html:4
 msgid "My Collections"
 msgstr ""
 
-#: src/olympia/amo/context_processors.py:62 src/olympia/discovery/templates/discovery/pane_account.html:10 src/olympia/users/templates/users/includes/navigation.html:7
+#: src/olympia/amo/context_processors.py:61 src/olympia/discovery/templates/discovery/pane_account.html:10 src/olympia/users/templates/users/includes/navigation.html:7
 msgid "My Favorites"
 msgstr ""
 
-#: src/olympia/amo/context_processors.py:67 src/olympia/discovery/templates/discovery/pane_account.html:13 src/olympia/templates/impala/user_login.html:14
+#: src/olympia/amo/context_processors.py:66 src/olympia/discovery/templates/discovery/pane_account.html:13 src/olympia/templates/impala/user_login.html:14
 #: src/olympia/templates/mobile/header_auth.html:5
 msgid "Log out"
 msgstr ""
 
-#: src/olympia/amo/context_processors.py:72 src/olympia/devhub/templates/devhub/addons/dashboard.html:4
+#: src/olympia/amo/context_processors.py:71 src/olympia/devhub/templates/devhub/addons/dashboard.html:4
 msgid "Manage My Submissions"
 msgstr ""
 
-#: src/olympia/amo/context_processors.py:75 src/olympia/devhub/templates/devhub/nav.html:27 src/olympia/devhub/templates/devhub/addons/dashboard.html:25
+#: src/olympia/amo/context_processors.py:74 src/olympia/devhub/templates/devhub/nav.html:27 src/olympia/devhub/templates/devhub/addons/dashboard.html:25
 #: src/olympia/devhub/templates/devhub/addons/submit/base.html:4
 msgid "Submit a New Add-on"
 msgstr ""
 
-#: src/olympia/amo/context_processors.py:77 src/olympia/browse/templates/browse/personas/base.html:50 src/olympia/devhub/templates/devhub/index.html:24
+#: src/olympia/amo/context_processors.py:76 src/olympia/browse/templates/browse/personas/base.html:50 src/olympia/devhub/templates/devhub/index.html:24
 #: src/olympia/devhub/templates/devhub/addons/dashboard.html:29
 msgid "Submit a New Theme"
 msgstr ""
 
-#: src/olympia/amo/context_processors.py:79 src/olympia/amo/templates/amo/site_nav.html:87 src/olympia/devhub/helpers.py:36 src/olympia/devhub/helpers.py:68 src/olympia/devhub/helpers.py:102
+#: src/olympia/amo/context_processors.py:78 src/olympia/amo/templates/amo/site_nav.html:85 src/olympia/devhub/helpers.py:36 src/olympia/devhub/helpers.py:68 src/olympia/devhub/helpers.py:102
 #: src/olympia/templates/footer.html:6 src/olympia/templates/menu_links.html:14
 msgid "Developer Hub"
 msgstr ""
 
-#: src/olympia/amo/context_processors.py:83 src/olympia/devhub/views.py:1792
+#: src/olympia/amo/context_processors.py:81 src/olympia/devhub/views.py:1796
 msgid "Manage API Keys"
 msgstr ""
 
-#: src/olympia/amo/context_processors.py:88 src/olympia/editors/helpers.py:82 src/olympia/editors/helpers.py:102 src/olympia/editors/templates/editors/base.html:10
+#: src/olympia/amo/context_processors.py:86 src/olympia/editors/helpers.py:84 src/olympia/editors/helpers.py:104 src/olympia/editors/templates/editors/base.html:10
 msgid "Editor Tools"
 msgstr ""
 
-#: src/olympia/amo/context_processors.py:92
+#: src/olympia/amo/context_processors.py:90
 msgid "Admin Tools"
 msgstr ""
 
-#: src/olympia/amo/fields.py:15
+#: src/olympia/amo/fields.py:20
 msgid "Incorrect, please try again."
 msgstr ""
 
-#: src/olympia/amo/fields.py:16
+#: src/olympia/amo/fields.py:21
 msgid "Error verifying input, please try again."
 msgstr ""
 
-#: src/olympia/amo/fields.py:32
+#: src/olympia/amo/fields.py:37
 msgid "This must be a valid hex color code, such as #000000."
 msgstr ""
 
-#: src/olympia/amo/fields.py:58
+#: src/olympia/amo/fields.py:63
 msgid "Enter at least one value."
 msgstr ""
 
-#: src/olympia/amo/helpers.py:162 src/olympia/amo/templates/amo/site_nav.html:61 src/olympia/bandwagon/templates/bandwagon/add.html:9
+#: src/olympia/amo/helpers.py:162 src/olympia/amo/templates/amo/site_nav.html:59 src/olympia/bandwagon/templates/bandwagon/add.html:9
 #: src/olympia/bandwagon/templates/bandwagon/collection_detail.html:15 src/olympia/bandwagon/templates/bandwagon/delete.html:9 src/olympia/bandwagon/templates/bandwagon/edit.html:15
 #: src/olympia/bandwagon/templates/bandwagon/user_listing.html:18 src/olympia/bandwagon/templates/bandwagon/user_listing.html:21
 #: src/olympia/bandwagon/templates/bandwagon/impala/collection_listing.html:12 src/olympia/bandwagon/templates/bandwagon/impala/collection_listing.html:20
 #: src/olympia/bandwagon/templates/bandwagon/impala/collection_listing.html:24 src/olympia/bandwagon/templates/bandwagon/impala/collection_sidebar.html:3
 #: src/olympia/bandwagon/templates/bandwagon/includes/collection_sidebar.html:2 src/olympia/bandwagon/templates/bandwagon/mobile/collection_listing.html:3
-#: src/olympia/stats/templates/stats/stats.html:77 src/olympia/templates/menu_links.html:12
+#: src/olympia/stats/templates/stats/stats.html:33 src/olympia/templates/menu_links.html:12
 msgid "Collections"
 msgstr ""
 
-#: src/olympia/amo/helpers.py:171 src/olympia/amo/templates/amo/site_nav.html:85 src/olympia/browse/templates/browse/language_tools.html:3
+#: src/olympia/amo/helpers.py:171 src/olympia/amo/templates/amo/site_nav.html:83 src/olympia/browse/templates/browse/language_tools.html:3
 msgid "Dictionaries & Language Packs"
 msgstr ""
 
@@ -1575,8 +1576,8 @@ msgstr ""
 msgid "Comment on {addon} {version}."
 msgstr ""
 
-#: src/olympia/amo/log.py:236 src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:19 src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:47
-#: src/olympia/editors/helpers.py:511 src/olympia/editors/templates/editors/themes/history_table.html:11
+#: src/olympia/amo/log.py:236 src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:17 src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:45
+#: src/olympia/editors/helpers.py:584 src/olympia/editors/templates/editors/themes/history_table.html:11
 msgid "Comment"
 msgstr ""
 
@@ -1899,7 +1900,7 @@ msgstr ""
 #: src/olympia/amo/templates/amo/mobile/paginator.html:14 src/olympia/amo/templates/amo/mobile/paginator.html:16 src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:51
 #: src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:65 src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:78
 #: src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:91 src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:104
-#: src/olympia/discovery/templates/discovery/pane.html:45 src/olympia/discovery/templates/discovery/addons/detail.html:39 src/olympia/stats/templates/stats/stats.html:167
+#: src/olympia/discovery/templates/discovery/pane.html:45 src/olympia/discovery/templates/discovery/addons/detail.html:39 src/olympia/stats/templates/stats/stats.html:169
 msgid "Next"
 msgstr ""
 
@@ -1931,7 +1932,7 @@ msgid ""
 msgstr ""
 
 #: src/olympia/amo/templates/amo/side_nav.html:4 src/olympia/amo/templates/amo/side_nav.html:12 src/olympia/amo/templates/amo/site_nav.html:4 src/olympia/amo/templates/amo/site_nav.html:26
-#: src/olympia/browse/views.py:56 src/olympia/browse/views.py:66 src/olympia/browse/views.py:237 src/olympia/browse/views.py:282 src/olympia/search/forms.py:86
+#: src/olympia/browse/views.py:56 src/olympia/browse/views.py:66 src/olympia/browse/views.py:204 src/olympia/browse/views.py:249 src/olympia/search/forms.py:86
 msgid "Top Rated"
 msgstr ""
 
@@ -1945,38 +1946,38 @@ msgstr ""
 msgid "Extensions"
 msgstr ""
 
-#: src/olympia/amo/templates/amo/site_nav.html:45
+#: src/olympia/amo/templates/amo/site_nav.html:44
 msgid "Want more customization? Try <b>Complete Themes</b>"
 msgstr ""
 
-#: src/olympia/amo/templates/amo/site_nav.html:56 src/olympia/bandwagon/views.py:96
+#: src/olympia/amo/templates/amo/site_nav.html:54 src/olympia/bandwagon/views.py:96
 msgid "Most Followers"
 msgstr ""
 
-#: src/olympia/amo/templates/amo/site_nav.html:68 src/olympia/bandwagon/templates/bandwagon/impala/collection_sidebar.html:16
+#: src/olympia/amo/templates/amo/site_nav.html:66 src/olympia/bandwagon/templates/bandwagon/impala/collection_sidebar.html:16
 #: src/olympia/bandwagon/templates/bandwagon/includes/collection_sidebar.html:18
 msgid "Collections I've Made"
 msgstr ""
 
-#: src/olympia/amo/templates/amo/site_nav.html:70 src/olympia/bandwagon/templates/bandwagon/user_listing.html:4 src/olympia/bandwagon/templates/bandwagon/impala/collection_sidebar.html:13
+#: src/olympia/amo/templates/amo/site_nav.html:68 src/olympia/bandwagon/templates/bandwagon/user_listing.html:4 src/olympia/bandwagon/templates/bandwagon/impala/collection_sidebar.html:13
 #: src/olympia/bandwagon/templates/bandwagon/includes/collection_sidebar.html:15
 msgid "Collections I'm Following"
 msgstr ""
 
-#: src/olympia/amo/templates/amo/site_nav.html:73 src/olympia/bandwagon/templates/bandwagon/impala/collection_sidebar.html:18
-#: src/olympia/bandwagon/templates/bandwagon/includes/collection_sidebar.html:20 src/olympia/users/models.py:512
+#: src/olympia/amo/templates/amo/site_nav.html:71 src/olympia/bandwagon/templates/bandwagon/impala/collection_sidebar.html:18
+#: src/olympia/bandwagon/templates/bandwagon/includes/collection_sidebar.html:20 src/olympia/users/models.py:521
 msgid "My Favorite Add-ons"
 msgstr ""
 
-#: src/olympia/amo/templates/amo/site_nav.html:78
+#: src/olympia/amo/templates/amo/site_nav.html:76
 msgid "More&hellip;"
 msgstr ""
 
-#: src/olympia/amo/templates/amo/site_nav.html:82
+#: src/olympia/amo/templates/amo/site_nav.html:80
 msgid "Add-ons for Mobile"
 msgstr ""
 
-#: src/olympia/amo/templates/amo/site_nav.html:86 src/olympia/browse/feeds.py:207 src/olympia/browse/templates/browse/search_tools.html:3 src/olympia/constants/base.py:176
+#: src/olympia/amo/templates/amo/site_nav.html:84 src/olympia/browse/feeds.py:207 src/olympia/browse/templates/browse/search_tools.html:3 src/olympia/constants/base.py:176
 #: src/olympia/templates/menu_links.html:10
 msgid "Search Tools"
 msgstr ""
@@ -1992,7 +1993,7 @@ msgid "Jump to first page"
 msgstr ""
 
 #: src/olympia/amo/templates/amo/impala/paginator.html:22 src/olympia/amo/templates/amo/mobile/impala_paginator.html:12 src/olympia/discovery/templates/discovery/pane.html:44
-#: src/olympia/discovery/templates/discovery/addons/detail.html:38 src/olympia/stats/templates/stats/stats.html:164
+#: src/olympia/discovery/templates/discovery/addons/detail.html:38 src/olympia/stats/templates/stats/stats.html:166
 msgid "Previous"
 msgstr ""
 
@@ -2015,30 +2016,49 @@ msgid_plural "Page {n}"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/olympia/amo/templates/services/install.html:38
-#, python-format
-msgid "If you are not prompted to install %(addon_name)s in a moment, please <a href=\"%(addon_xpi)s\">click here</a>."
-msgstr ""
-
-#: src/olympia/amo/tests/test_messages.py:57 src/olympia/amo/tests/test_messages.py:58 src/olympia/reviews/forms.py:25 src/olympia/reviews/forms.py:50 src/olympia/reviews/templates/reviews/add.html:56
+#: src/olympia/amo/tests/test_messages.py:56 src/olympia/amo/tests/test_messages.py:57 src/olympia/reviews/forms.py:25 src/olympia/reviews/forms.py:50 src/olympia/reviews/templates/reviews/add.html:56
 #: src/olympia/reviews/templates/reviews/reply.html:30
 msgid "Title"
 msgstr ""
 
-#: src/olympia/amo/tests/test_messages.py:57 src/olympia/amo/tests/test_messages.py:58
+#: src/olympia/amo/tests/test_messages.py:56 src/olympia/amo/tests/test_messages.py:57
 msgid "Body"
 msgstr ""
 
-#: src/olympia/amo/tests/test_messages.py:59
+#: src/olympia/amo/tests/test_messages.py:58
 msgid "Another Title"
 msgstr ""
 
-#: src/olympia/amo/tests/test_messages.py:59
+#: src/olympia/amo/tests/test_messages.py:58
 msgid "Another Body"
 msgstr ""
 
-#: src/olympia/api/views.py:255
-msgid "Not implemented yet."
+#: src/olympia/api/authentication.py:76
+msgid "Signature has expired."
+msgstr ""
+
+#: src/olympia/api/authentication.py:79
+msgid "Error decoding signature."
+msgstr ""
+
+#: src/olympia/api/authentication.py:82
+msgid "Invalid JWT Token."
+msgstr ""
+
+#: src/olympia/api/authentication.py:130
+msgid "Invalid Authorization header. No credentials provided."
+msgstr ""
+
+#: src/olympia/api/authentication.py:133
+msgid "Invalid Authorization header. Credentials string should not contain spaces."
+msgstr ""
+
+#: src/olympia/api/fields.py:29
+msgid "The field must have a length of at least {num} characters."
+msgstr ""
+
+#: src/olympia/api/fields.py:31
+msgid "The language code {lang_code} is invalid."
 msgstr ""
 
 #: src/olympia/applications/views.py:39 src/olympia/applications/templates/applications/appversions.html:3
@@ -2057,7 +2077,7 @@ msgstr ""
 msgid "Add-ons submitted to Mozilla Add-ons must have a manifest file with at least one of the below applications supported. Only the versions listed below are allowed for these applications."
 msgstr ""
 
-#: src/olympia/applications/templates/applications/appversions.html:25
+#: src/olympia/applications/templates/applications/appversions.html:25 src/olympia/editors/helpers.py:361
 msgid "GUID"
 msgstr ""
 
@@ -2171,8 +2191,8 @@ msgstr ""
 msgid "Remove from favorites"
 msgstr ""
 
-#: src/olympia/bandwagon/views.py:98 src/olympia/bandwagon/views.py:191 src/olympia/browse/views.py:58 src/olympia/browse/views.py:69 src/olympia/browse/views.py:458 src/olympia/devhub/views.py:74
-#: src/olympia/devhub/views.py:82 src/olympia/devhub/templates/devhub/addons/edit/basic.html:20 src/olympia/editors/templates/editors/leaderboard.html:24
+#: src/olympia/bandwagon/views.py:98 src/olympia/bandwagon/views.py:191 src/olympia/browse/views.py:58 src/olympia/browse/views.py:69 src/olympia/browse/views.py:425 src/olympia/devhub/views.py:72
+#: src/olympia/devhub/views.py:80 src/olympia/devhub/templates/devhub/addons/edit/basic.html:20 src/olympia/editors/templates/editors/leaderboard.html:24
 #: src/olympia/editors/templates/editors/themes/queue_list.html:48 src/olympia/search/forms.py:17 src/olympia/search/forms.py:89 src/olympia/users/templates/users/vcard.html:5
 msgid "Name"
 msgstr ""
@@ -2181,7 +2201,7 @@ msgstr ""
 msgid "Recently Popular"
 msgstr ""
 
-#: src/olympia/bandwagon/views.py:189 src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:18
+#: src/olympia/bandwagon/views.py:189 src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:16
 msgid "Added"
 msgstr ""
 
@@ -2195,7 +2215,7 @@ msgstr ""
 
 #: src/olympia/bandwagon/views.py:316
 #, python-format
-msgid "Your new collection is shown below. You can <ahref=\"%(url)s\">edit additional settings</a> if you'dlike."
+msgid "Your new collection is shown below. You can <a href=\"%(url)s\">edit additional settings</a> if you'd like."
 msgstr ""
 
 #: src/olympia/bandwagon/views.py:322
@@ -2323,8 +2343,8 @@ msgid_plural "%(num)s Add-ons in this Collection"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/olympia/bandwagon/templates/bandwagon/collection_detail.html:125 src/olympia/compat/templates/compat/index.html:25 src/olympia/compat/templates/compat/reporter_detail.html:29
-#: src/olympia/files/templates/files/viewer.html:29 src/olympia/templates/amo_footer.html:17 src/olympia/templates/includes/lang_switcher.html:10
+#: src/olympia/bandwagon/templates/bandwagon/collection_detail.html:125 src/olympia/compat/templates/compat/reporter_detail.html:29 src/olympia/files/templates/files/viewer.html:29
+#: src/olympia/templates/amo_footer.html:17 src/olympia/templates/includes/lang_switcher.html:10
 msgid "Go"
 msgstr ""
 
@@ -2491,7 +2511,7 @@ msgid "Remove this user as a contributor"
 msgstr ""
 
 #: src/olympia/bandwagon/templates/bandwagon/edit_contributors.html:18 src/olympia/bandwagon/templates/bandwagon/edit_contributors.html:43
-#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:20 src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:48
+#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:18 src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:46
 #: src/olympia/devhub/templates/devhub/addons/ajax_compat_update.html:19
 msgid "Remove"
 msgstr ""
@@ -2539,7 +2559,7 @@ msgid "<b>Warning:</b> By changing the owner of this collection, you will no lon
 msgstr ""
 
 #: src/olympia/bandwagon/templates/bandwagon/edit_contributors.html:83 src/olympia/devhub/templates/devhub/addons/forms_shared/media.html:157
-#: src/olympia/devhub/templates/devhub/addons/submit/describe.html:69 src/olympia/devhub/templates/devhub/addons/submit/license.html:60 src/olympia/devhub/templates/devhub/addons/submit/upload.html:78
+#: src/olympia/devhub/templates/devhub/addons/submit/describe.html:69 src/olympia/devhub/templates/devhub/addons/submit/license.html:60 src/olympia/devhub/templates/devhub/addons/submit/upload.html:70
 #: src/olympia/devhub/templates/devhub/payments/tier.html:17 src/olympia/editors/templates/editors/themes/themes.html:111 src/olympia/editors/templates/editors/themes/themes.html:128
 #: src/olympia/editors/templates/editors/themes/themes.html:134 src/olympia/editors/templates/editors/themes/themes.html:141 src/olympia/users/templates/users/fxa_migration_prompt_content.html:10
 #: src/olympia/users/templates/users/login_form.html:42 src/olympia/users/templates/users/mobile/login.html:57
@@ -2622,31 +2642,31 @@ msgid "Add-ons in Your Collection"
 msgstr ""
 
 #: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:4
-msgid ""
-"To include an add-on in this collection, enter its name in the box below and hit enter.  You can also use the <strong>Add to Collection</strong> links throughout the site to include add-ons later."
+msgid "To include an add-on in this collection, enter its name in the box below and hit enter."
 msgstr ""
 
-#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:17 src/olympia/constants/base.py:400 src/olympia/devhub/templates/devhub/addons/activity.html:62
+#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:15 src/olympia/constants/base.py:400 src/olympia/devhub/templates/devhub/addons/activity.html:62
+#: src/olympia/editors/helpers.py:273 src/olympia/editors/helpers.py:360
 msgid "Add-on"
 msgstr ""
 
-#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:26
+#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:24
 msgid "Enter the name of the add-on to include"
 msgstr ""
 
-#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:28
+#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:26
 msgid "Add to Collection"
 msgstr ""
 
-#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:45 src/olympia/editors/helpers.py:936 src/olympia/editors/helpers.py:956
+#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:43 src/olympia/editors/helpers.py:1016 src/olympia/editors/helpers.py:1036
 msgid "Pending"
 msgstr ""
 
-#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:47
+#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:45
 msgid "Add a comment"
 msgstr ""
 
-#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:48
+#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:46
 msgid "Remove this add-on from the collection"
 msgstr ""
 
@@ -2753,12 +2773,12 @@ msgstr ""
 msgid "Most Users"
 msgstr ""
 
-#: src/olympia/browse/views.py:61 src/olympia/browse/views.py:72 src/olympia/browse/views.py:279 src/olympia/browse/templates/browse/personas/mobile/category_landing.html:63
+#: src/olympia/browse/views.py:61 src/olympia/browse/views.py:72 src/olympia/browse/views.py:246 src/olympia/browse/templates/browse/personas/mobile/category_landing.html:63
 #: src/olympia/discovery/templates/discovery/pane.html:67 src/olympia/search/forms.py:92
 msgid "Up & Coming"
 msgstr ""
 
-#: src/olympia/browse/views.py:460 src/olympia/devhub/views.py:76 src/olympia/devhub/views.py:83 src/olympia/discovery/templates/discovery/addons/detail.html:66
+#: src/olympia/browse/views.py:427 src/olympia/devhub/views.py:74 src/olympia/devhub/views.py:81 src/olympia/discovery/templates/discovery/addons/detail.html:66
 msgid "Created"
 msgstr ""
 
@@ -2946,8 +2966,8 @@ msgid_plural "See all %(cnt)s extensions in %(name)s &raquo;"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/olympia/browse/templates/browse/mobile/extensions.html:13 src/olympia/compat/templates/compat/index.html:82 src/olympia/devhub/templates/devhub/devhub_search.html:24
-#: src/olympia/devhub/templates/devhub/addons/activity.html:47 src/olympia/search/templates/search/no_results.html:4 src/olympia/search/templates/search/mobile/results.html:36
+#: src/olympia/browse/templates/browse/mobile/extensions.html:13 src/olympia/devhub/templates/devhub/devhub_search.html:24 src/olympia/devhub/templates/devhub/addons/activity.html:47
+#: src/olympia/search/templates/search/no_results.html:4 src/olympia/search/templates/search/mobile/results.html:36
 msgid "No results found."
 msgstr ""
 
@@ -3032,7 +3052,7 @@ msgstr ""
 msgid "All"
 msgstr ""
 
-#: src/olympia/compat/forms.py:22 src/olympia/search/views.py:525
+#: src/olympia/compat/forms.py:22 src/olympia/editors/templates/editors/base.html:69 src/olympia/search/views.py:518
 msgid "All Add-ons"
 msgstr ""
 
@@ -3042,53 +3062,6 @@ msgstr ""
 
 #: src/olympia/compat/forms.py:24
 msgid "Non-binary"
-msgstr ""
-
-#. Review points sources other than add-ons and themes.
-#: src/olympia/compat/views.py:87 src/olympia/constants/base.py:388 src/olympia/devhub/forms.py:162 src/olympia/editors/templates/editors/performance.html:75
-msgid "Other"
-msgstr ""
-
-#: src/olympia/compat/templates/compat/index.html:4
-msgid "Add-on Compatibility Report for {app} {version}"
-msgstr ""
-
-#: src/olympia/compat/templates/compat/index.html:11
-msgid "{app} {version} Compatibility"
-msgstr ""
-
-#: src/olympia/compat/templates/compat/index.html:17
-#, python-format
-msgid "Top 95%% compatible with previous version"
-msgstr ""
-
-#: src/olympia/compat/templates/compat/index.html:18
-#, python-format
-msgid "Top 95%% of all add-ons"
-msgstr ""
-
-#: src/olympia/compat/templates/compat/index.html:19
-msgid "All active add-ons"
-msgstr ""
-
-#: src/olympia/compat/templates/compat/index.html:23 src/olympia/constants/base.py:401
-msgid "App"
-msgstr ""
-
-#: src/olympia/compat/templates/compat/index.html:55
-msgid "Details for add-ons compatible with previous version:"
-msgstr ""
-
-#: src/olympia/compat/templates/compat/index.html:57
-msgid "Show all versions"
-msgstr ""
-
-#: src/olympia/compat/templates/compat/index.html:59
-msgid "Details for add-ons compatible with all versions:"
-msgstr ""
-
-#: src/olympia/compat/templates/compat/index.html:61
-msgid "Show previous version only"
 msgstr ""
 
 #: src/olympia/compat/templates/compat/reporter.html:3
@@ -3142,8 +3115,8 @@ msgstr ""
 msgid "Report Type"
 msgstr ""
 
-#: src/olympia/compat/templates/compat/reporter_detail.html:47 src/olympia/devhub/forms.py:784 src/olympia/devhub/templates/devhub/addons/ajax_compat_update.html:17 src/olympia/editors/forms.py:108
-#: src/olympia/zadmin/forms.py:45
+#: src/olympia/compat/templates/compat/reporter_detail.html:47 src/olympia/devhub/forms.py:785 src/olympia/devhub/templates/devhub/addons/ajax_compat_update.html:17 src/olympia/editors/forms.py:108
+#: src/olympia/editors/forms.py:248 src/olympia/zadmin/forms.py:45
 msgid "Application"
 msgstr ""
 
@@ -3231,7 +3204,8 @@ msgstr ""
 msgid "Preliminarily Reviewed and Awaiting Full Review"
 msgstr ""
 
-#: src/olympia/constants/base.py:33 src/olympia/editors/helpers.py:924 src/olympia/editors/templates/editors/themes/history_table.html:34
+#: src/olympia/constants/base.py:33 src/olympia/editors/forms.py:258 src/olympia/editors/helpers.py:73 src/olympia/editors/helpers.py:1004
+#: src/olympia/editors/templates/editors/themes/history_table.html:34
 msgid "Deleted"
 msgstr ""
 
@@ -3328,6 +3302,11 @@ msgstr ""
 msgid "Ask before users can download this add-on"
 msgstr ""
 
+#. Review points sources other than add-ons and themes.
+#: src/olympia/constants/base.py:388 src/olympia/devhub/forms.py:162 src/olympia/editors/templates/editors/performance.html:75
+msgid "Other"
+msgstr ""
+
 #: src/olympia/constants/base.py:389
 msgid "Exception"
 msgstr ""
@@ -3338,6 +3317,10 @@ msgstr ""
 
 #: src/olympia/constants/base.py:391
 msgid "Change"
+msgstr ""
+
+#: src/olympia/constants/base.py:401
+msgid "App"
 msgstr ""
 
 #: src/olympia/constants/base.py:402
@@ -3488,7 +3471,7 @@ msgstr ""
 msgid "Duplicate"
 msgstr ""
 
-#: src/olympia/constants/editors.py:17 src/olympia/editors/helpers.py:502 src/olympia/editors/templates/editors/themes/queue.html:71 src/olympia/editors/templates/editors/themes/themes.html:94
+#: src/olympia/constants/editors.py:17 src/olympia/editors/helpers.py:575 src/olympia/editors/templates/editors/themes/queue.html:71 src/olympia/editors/templates/editors/themes/themes.html:94
 msgid "Reject"
 msgstr ""
 
@@ -3588,7 +3571,7 @@ msgstr ""
 msgid "Android"
 msgstr ""
 
-#: src/olympia/core/apps.py:19
+#: src/olympia/core/apps.py:21
 msgid "Core"
 msgstr ""
 
@@ -3722,7 +3705,7 @@ msgid "Submit my add-on for manual review."
 msgstr ""
 
 #: src/olympia/devhub/forms.py:537
-msgid "Do not list my add-on on this site (beta)"
+msgid "Do not list my add-on on this site"
 msgstr ""
 
 #: src/olympia/devhub/forms.py:538
@@ -3755,46 +3738,46 @@ msgstr ""
 
 #: src/olympia/devhub/forms.py:592
 #, python-format
-msgid "Version %s already exists"
+msgid "Version %s already exists, or was uploaded before."
 msgstr ""
 
-#: src/olympia/devhub/forms.py:604
+#: src/olympia/devhub/forms.py:605
 msgid "Select a valid choice. That choice is not one of the available choices."
 msgstr ""
 
-#: src/olympia/devhub/forms.py:610
+#: src/olympia/devhub/forms.py:611
 msgid "A file with a version ending with a|alpha|b|beta and an optional number is detected as beta."
 msgstr ""
 
-#: src/olympia/devhub/forms.py:633
+#: src/olympia/devhub/forms.py:634
 msgid "You cannot upload any more files for this version."
 msgstr ""
 
-#: src/olympia/devhub/forms.py:639
+#: src/olympia/devhub/forms.py:640
 msgid "Version doesn't match"
 msgstr ""
 
-#: src/olympia/devhub/forms.py:668
+#: src/olympia/devhub/forms.py:669
 msgid "You cannot delete a file once the review process has started.  You must delete the whole version."
 msgstr ""
 
-#: src/olympia/devhub/forms.py:688
+#: src/olympia/devhub/forms.py:689
 msgid "The platform All cannot be combined with specific platforms."
 msgstr ""
 
-#: src/olympia/devhub/forms.py:693
+#: src/olympia/devhub/forms.py:694
 msgid "A platform can only be chosen once."
 msgstr ""
 
-#: src/olympia/devhub/forms.py:706
+#: src/olympia/devhub/forms.py:707
 msgid "A review type must be selected."
 msgstr ""
 
-#: src/olympia/devhub/forms.py:788 src/olympia/editors/forms.py:114 src/olympia/zadmin/forms.py:49 src/olympia/zadmin/forms.py:52
+#: src/olympia/devhub/forms.py:789 src/olympia/editors/forms.py:114 src/olympia/editors/forms.py:254 src/olympia/zadmin/forms.py:49 src/olympia/zadmin/forms.py:52
 msgid "Select an application first"
 msgstr ""
 
-#: src/olympia/devhub/forms.py:840
+#: src/olympia/devhub/forms.py:841
 msgid "There cannot be more than 3 required add-ons."
 msgstr ""
 
@@ -3828,76 +3811,76 @@ msgstr[1] ""
 msgid "Review"
 msgstr ""
 
-#: src/olympia/devhub/tasks.py:551
+#: src/olympia/devhub/tasks.py:583
 #, python-format
 msgid "%s responded with %s (%s)."
 msgstr ""
 
-#: src/olympia/devhub/tasks.py:555
+#: src/olympia/devhub/tasks.py:587
 #, python-format
 msgid "Connection to \"%s\" timed out."
 msgstr ""
 
-#: src/olympia/devhub/tasks.py:557
+#: src/olympia/devhub/tasks.py:589
 #, python-format
 msgid "Could not contact host at \"%s\"."
 msgstr ""
 
-#: src/olympia/devhub/utils.py:104
+#: src/olympia/devhub/utils.py:105
 #, python-format
 msgid "Validation generated too many errors/warnings so %s messages were truncated. After addressing the visible messages, you'll be able to see the others."
 msgstr ""
 
-#: src/olympia/devhub/views.py:183
+#: src/olympia/devhub/views.py:181
 msgid "All My Add-ons"
 msgstr ""
 
-#: src/olympia/devhub/views.py:210
+#: src/olympia/devhub/views.py:208
 msgid "All Activity"
 msgstr ""
 
-#: src/olympia/devhub/views.py:211
+#: src/olympia/devhub/views.py:209
 msgid "Add-on Updates"
 msgstr ""
 
-#: src/olympia/devhub/views.py:212
+#: src/olympia/devhub/views.py:210
 msgid "Add-on Status"
 msgstr ""
 
-#: src/olympia/devhub/views.py:213
+#: src/olympia/devhub/views.py:211
 msgid "User Collections"
 msgstr ""
 
-#: src/olympia/devhub/views.py:214 src/olympia/devhub/templates/devhub/docs/policies-maintenance.html:68 src/olympia/pages/templates/pages/dev_faq.html:38
+#: src/olympia/devhub/views.py:212 src/olympia/devhub/templates/devhub/docs/policies-maintenance.html:68 src/olympia/pages/templates/pages/dev_faq.html:38
 #: src/olympia/pages/templates/pages/dev_faq.html:484
 msgid "User Reviews"
 msgstr ""
 
-#: src/olympia/devhub/views.py:327 src/olympia/devhub/views.py:331 src/olympia/devhub/views.py:484 src/olympia/devhub/views.py:513 src/olympia/devhub/views.py:564 src/olympia/devhub/views.py:1150
+#: src/olympia/devhub/views.py:325 src/olympia/devhub/views.py:329 src/olympia/devhub/views.py:484 src/olympia/devhub/views.py:513 src/olympia/devhub/views.py:564 src/olympia/devhub/views.py:1156
 msgid "Changes successfully saved."
 msgstr ""
 
-#: src/olympia/devhub/views.py:334 src/olympia/devhub/views.py:1631
+#: src/olympia/devhub/views.py:332 src/olympia/devhub/views.py:1637
 msgid "Please check the form for errors."
 msgstr ""
 
-#: src/olympia/devhub/views.py:346
+#: src/olympia/devhub/views.py:344
 msgid "Add-on cannot be deleted. Disable this add-on instead."
 msgstr ""
 
-#: src/olympia/devhub/views.py:356
+#: src/olympia/devhub/views.py:354
 msgid "Theme deleted."
 msgstr ""
 
-#: src/olympia/devhub/views.py:356
+#: src/olympia/devhub/views.py:354
 msgid "Add-on deleted."
 msgstr ""
 
-#: src/olympia/devhub/views.py:362
+#: src/olympia/devhub/views.py:360
 msgid "URL name was incorrect. Theme was not deleted."
 msgstr ""
 
-#: src/olympia/devhub/views.py:367
+#: src/olympia/devhub/views.py:365
 msgid "URL name was incorrect. Add-on was not deleted."
 msgstr ""
 
@@ -3925,7 +3908,7 @@ msgstr ""
 msgid "Check Add-on Compatibility"
 msgstr ""
 
-#: src/olympia/devhub/views.py:808 src/olympia/signing/views.py:90
+#: src/olympia/devhub/views.py:808 src/olympia/signing/views.py:95
 msgid "You cannot submit this type of add-on"
 msgstr ""
 
@@ -3955,33 +3938,33 @@ msgstr ""
 msgid "There was an error uploading your preview."
 msgstr ""
 
-#: src/olympia/devhub/views.py:1189
+#: src/olympia/devhub/views.py:1195
 #, python-format
 msgid "Version %s disabled."
 msgstr ""
 
-#: src/olympia/devhub/views.py:1193
+#: src/olympia/devhub/views.py:1199
 #, python-format
 msgid "Version %s deleted."
 msgstr ""
 
-#: src/olympia/devhub/views.py:1203
+#: src/olympia/devhub/views.py:1209
 msgid "This upload has failed validation, and may lack complete validation results. Please take due care when reviewing it."
 msgstr ""
 
-#: src/olympia/devhub/views.py:1677
+#: src/olympia/devhub/views.py:1683
 msgid "Preliminary Review Requested."
 msgstr ""
 
-#: src/olympia/devhub/views.py:1678
+#: src/olympia/devhub/views.py:1684
 msgid "Full Review Requested."
 msgstr ""
 
-#: src/olympia/devhub/views.py:1779
+#: src/olympia/devhub/views.py:1783
 msgid "Your old credentials were revoked and are no longer valid. Be sure to update all API clients with the new credentials."
 msgstr ""
 
-#: src/olympia/devhub/views.py:1797
+#: src/olympia/devhub/views.py:1801
 msgid "New API key created"
 msgstr ""
 
@@ -4011,7 +3994,7 @@ msgstr ""
 msgid "{0} :: Search"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/devhub_search.html:6 src/olympia/devhub/templates/devhub/search.html:8 src/olympia/editors/forms.py:435 src/olympia/editors/forms.py:437
+#: src/olympia/devhub/templates/devhub/devhub_search.html:6 src/olympia/devhub/templates/devhub/search.html:8 src/olympia/editors/forms.py:534 src/olympia/editors/forms.py:536
 #: src/olympia/editors/templates/editors/queue.html:27 src/olympia/editors/templates/editors/themes/queue_list.html:14 src/olympia/search/templates/search/collections.html:17
 #: src/olympia/search/templates/search/personas.html:18 src/olympia/search/templates/search/results.html:18 src/olympia/search/templates/search/mobile/results.html:8
 #: src/olympia/templates/search.html:14 src/olympia/templates/impala/search.html:18
@@ -4071,12 +4054,12 @@ msgstr ""
 msgid "Start Making Add-ons"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/index.html:86 src/olympia/devhub/templates/devhub/addons/listing/items.html:25 src/olympia/devhub/templates/devhub/includes/addon_details.html:15
+#: src/olympia/devhub/templates/devhub/index.html:86 src/olympia/devhub/templates/devhub/addons/listing/items.html:25 src/olympia/devhub/templates/devhub/includes/addon_details.html:20
 #: src/olympia/devhub/templates/devhub/personas/edit.html:43
 msgid "Status:"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/index.html:90 src/olympia/devhub/templates/devhub/includes/addon_details.html:100
+#: src/olympia/devhub/templates/devhub/index.html:90 src/olympia/devhub/templates/devhub/includes/addon_details.html:87
 msgid "Visibility:"
 msgstr ""
 
@@ -4084,11 +4067,11 @@ msgstr ""
 msgid "Latest Version:"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/index.html:109 src/olympia/devhub/templates/devhub/includes/addon_details.html:145 src/olympia/devhub/templates/devhub/personas/edit.html:49
+#: src/olympia/devhub/templates/devhub/index.html:109 src/olympia/devhub/templates/devhub/includes/addon_details.html:131 src/olympia/devhub/templates/devhub/personas/edit.html:49
 msgid "Queue Position:"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/index.html:110 src/olympia/devhub/templates/devhub/includes/addon_details.html:146 src/olympia/devhub/templates/devhub/personas/edit.html:50
+#: src/olympia/devhub/templates/devhub/index.html:110 src/olympia/devhub/templates/devhub/includes/addon_details.html:132 src/olympia/devhub/templates/devhub/personas/edit.html:50
 #, python-format
 msgid "%(position)s of %(total)s"
 msgstr ""
@@ -4190,16 +4173,6 @@ msgstr ""
 msgid "Do you want your add-on to be distributed on this site?"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/validate_addon.html:49 src/olympia/devhub/templates/devhub/addons/submit/upload.html:30 src/olympia/devhub/templates/devhub/versions/add_file_modal.html:14
-#: src/olympia/devhub/templates/devhub/versions/add_file_modal.html:53 src/olympia/devhub/templates/devhub/versions/list.html:298
-msgid "Warning:"
-msgstr ""
-
-#: src/olympia/devhub/templates/devhub/validate_addon.html:50 src/olympia/devhub/templates/devhub/addons/submit/upload.html:31
-#, python-format
-msgid "Submission of unlisted add-ons for signing is currently in an open beta. Please <a href=\"%(url)s\" target=\"_blank\">report any bugs</a> that you encounter."
-msgstr ""
-
 #. first parameter is a filename like lorem-ipsum-1.0.2.xpi
 #: src/olympia/devhub/templates/devhub/validation.html:5
 msgid "Validation Results for {0}"
@@ -4274,7 +4247,7 @@ msgstr ""
 msgid "Update Compatibility"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/addons/ajax_compat_update.html:4
+#: src/olympia/devhub/templates/devhub/addons/ajax_compat_update.html:4 src/olympia/devhub/templates/devhub/versions/edit.html:45
 msgid "Adjusting application information here will allow users to install your add-on even if the install manifest in the package indicates that the add-on is incompatible."
 msgstr ""
 
@@ -4286,9 +4259,9 @@ msgstr ""
 msgid "Add Another Application&hellip;"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/addons/ajax_compat_update.html:38 src/olympia/devhub/templates/devhub/addons/owner.html:86 src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:46
-#: src/olympia/devhub/templates/devhub/versions/list.html:351 src/olympia/devhub/templates/devhub/versions/list.html:353 src/olympia/templates/impala/base.html:132
-#: src/olympia/templates/impala/base.html:143 src/olympia/templates/impala/base.html:161 src/olympia/templates/impala/base.html:171
+#: src/olympia/devhub/templates/devhub/addons/ajax_compat_update.html:38 src/olympia/devhub/templates/devhub/addons/owner.html:86 src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:45
+#: src/olympia/devhub/templates/devhub/versions/list.html:349 src/olympia/devhub/templates/devhub/versions/list.html:351 src/olympia/templates/impala/base.html:129
+#: src/olympia/templates/impala/base.html:140 src/olympia/templates/impala/base.html:158 src/olympia/templates/impala/base.html:168
 msgid "Close"
 msgstr ""
 
@@ -4322,7 +4295,7 @@ msgstr ""
 msgid "Manage Authors & License"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/addons/owner.html:29 src/olympia/editors/templates/editors/review.html:270
+#: src/olympia/devhub/templates/devhub/addons/owner.html:29 src/olympia/editors/helpers.py:362 src/olympia/editors/templates/editors/review.html:270
 msgid "Authors"
 msgstr ""
 
@@ -4391,17 +4364,11 @@ msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/basic.html:52
 msgid ""
-"A short explanation of your add-on's basic\n"
-"                          functionality that is displayed in search and browse\n"
-"                          listings, as well as at the top of your add-on's\n"
-"                          details page. It is only relevant for listed add-ons."
+"A short explanation of your add-on's basic functionality that is displayed in search and browse listings, as well as at the top of your add-on's details page. It is only relevant for listed add-ons."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/basic.html:73
-msgid ""
-"Categories are the primary way users browse through add-ons.\n"
-"                        Choose any that fit your add-on's functionality for the most\n"
-"                        exposure. It is only relevant for listed add-ons."
+msgid "Categories are the primary way users browse through add-ons. Choose any that fit your add-on's functionality for the most exposure. It is only relevant for listed add-ons."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/basic.html:90
@@ -4411,11 +4378,7 @@ msgid ""
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/basic.html:119
-msgid ""
-"Tags help users find your add-on and should be short\n"
-"                        descriptors such as tabs, toolbar, or twitter.  You\n"
-"                        may have a maximum of {0} tags. It is only relevant\n"
-"                        for listed add-ons."
+msgid "Tags help users find your add-on and should be short descriptors such as tabs, toolbar, or twitter. You may have a maximum of {0} tags. It is only relevant for listed add-ons."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/basic.html:129 src/olympia/devhub/templates/devhub/personas/edit.html:97 src/olympia/devhub/templates/devhub/personas/submit.html:46
@@ -4443,11 +4406,7 @@ msgid "Add-on Details for {0}"
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/details.html:22
-msgid ""
-"A longer explanation of features,\n"
-"                          functionality, and other relevant information. This\n"
-"                          field is only displayed on the add-on's details\n"
-"                          page. It is only relevant for listed add-ons."
+msgid "A longer explanation of features, functionality, and other relevant information. This field is only displayed on the add-on's details page. It is only relevant for listed add-ons."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/details.html:44 src/olympia/translations/templates/translations/trans-menu.html:13
@@ -4455,10 +4414,7 @@ msgid "Default Locale"
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/details.html:45
-msgid ""
-"Information about your add-on is displayed in this locale\n"
-"                        unless you override it with a locale-specific translation.\n"
-"                        It is only relevant for listed add-ons."
+msgid "Information about your add-on is displayed in this locale unless you override it with a locale-specific translation. It is only relevant for listed add-ons."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/details.html:61 src/olympia/users/forms.py:311 src/olympia/users/templates/users/edit.html:122 src/olympia/users/templates/users/register.html:57
@@ -4468,10 +4424,8 @@ msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/details.html:63
 msgid ""
-"If your add-on has another homepage, enter its\n"
-"                          address here. If your website is localized into other\n"
-"                          languages multiple translations of this field can be\n"
-"                          added. It is only relevant for listed add-ons."
+"If your add-on has another homepage, enter its address here. If your website is localized into other languages multiple translations of this field can be added. It is only relevant for listed add-"
+"ons."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/media.html:3
@@ -4489,19 +4443,14 @@ msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/support.html:22
 msgid ""
-"If you wish to display an e-mail address for support\n"
-"                          inquiries, enter it here. If you have different\n"
-"                          addresses for each language multiple translations of\n"
-"                          this field can be added. It is only relevant for\n"
-"                          listed add-ons."
+"If you wish to display an e-mail address for support inquiries, enter it here. If you have different addresses for each language multiple translations of this field can be added. It is only "
+"relevant for listed add-ons."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/support.html:45
 msgid ""
-"If your add-on has a support website or forum, enter\n"
-"                          its address here. If your website is localized into\n"
-"                          other languages, multiple translations of this field can\n"
-"                          be added. It is only relevant for listed add-ons."
+"If your add-on has a support website or forum, enter its address here. If your website is localized into other languages, multiple translations of this field can be added. It is only relevant for "
+"listed add-ons."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:6
@@ -4515,11 +4464,8 @@ msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:23
 msgid ""
-"Any information end users may want to know that isn't\n"
-"                          necessarily applicable to the add-on summary or description.\n"
-"                          Common uses include listing known major bugs, information on\n"
-"                          how to report bugs, anticipated release date of a new version,\n"
-"                          etc. It is only relevant for listed add-ons."
+"Any information end users may want to know that isn't necessarily applicable to the add-on summary or description. Common uses include listing known major bugs, information on how to report bugs, "
+"anticipated release date of a new version, etc. It is only relevant for listed add-ons."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:46
@@ -4531,9 +4477,7 @@ msgid "Add-on Flags"
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:69
-msgid ""
-"These flags are used to classify add-ons. It is only\n"
-"                        relevant for listed add-ons."
+msgid "These flags are used to classify add-ons. It is only relevant for listed add-ons."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:74
@@ -4549,9 +4493,7 @@ msgid "View Source?"
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:90
-msgid ""
-"Whether the source of your add-on can be displayed in our\n"
-"                        online viewer. It is only relevant for listed add-ons."
+msgid "Whether the source of your add-on can be displayed in our online viewer. It is only relevant for listed add-ons."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:94
@@ -4567,10 +4509,7 @@ msgid "Public Stats?"
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:102
-msgid ""
-"Whether the download and usage stats of your add-on can\n"
-"                        be displayed in our online viewer.\n"
-"                        It is only relevant for listed add-ons."
+msgid "Whether the download and usage stats of your add-on can be displayed in our online viewer. It is only relevant for listed add-ons."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:107
@@ -4586,10 +4525,7 @@ msgid "Upgrade SDK?"
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:116
-msgid ""
-"If selected, we will try to automatically upgrade your\n"
-"                        add-on when a new version of the SDK is released.\n"
-"                        It is only relevant for listed add-ons."
+msgid "If selected, we will try to automatically upgrade your add-on when a new version of the SDK is released. It is only relevant for listed add-ons."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:121
@@ -4640,10 +4576,8 @@ msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/forms_shared/media.html:16
 msgid ""
-"Upload an icon for your add-on or choose from one of ours. The\n"
-"                      icon is displayed nearly everywhere your add-on is. Uploaded images\n"
-"                      must be one of the following image types: .png, .jpg.\n"
-"                      It is only relevant for listed add-ons."
+"Upload an icon for your add-on or choose from one of ours. The icon is displayed nearly everywhere your add-on is. Uploaded images must be one of the following image types: .png, .jpg. It is only "
+"relevant for listed add-ons."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/forms_shared/media.html:25
@@ -4656,9 +4590,7 @@ msgid "32x32px"
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/forms_shared/media.html:39
-msgid ""
-"Used in listings of add-ons, like search results\n"
-"                            and featured add-ons."
+msgid "Used in listings of add-ons, like search results and featured add-ons."
 msgstr ""
 
 #. The size of the icon
@@ -4753,16 +4685,14 @@ msgid "Deleting your add-on will permanently remove it from the site and prevent
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:24
-msgid ""
-"Enter the following text confirm your decision:\n"
-"           {slug}"
+msgid "Enter the following text confirm your decision: {slug}"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:34
+#: src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:33
 msgid "Please tell us why you are deleting your theme:"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:36
+#: src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:35
 msgid "Please tell us why you are deleting your add-on:"
 msgstr ""
 
@@ -4799,8 +4729,8 @@ msgstr ""
 msgid "Daily statistics on downloads and users."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/addons/listing/item_actions.html:45 src/olympia/stats/templates/stats/stats.html:75 src/olympia/stats/templates/stats/stats.html:79
-#: src/olympia/stats/templates/stats/stats.html:81
+#: src/olympia/devhub/templates/devhub/addons/listing/item_actions.html:45 src/olympia/stats/templates/stats/stats.html:31 src/olympia/stats/templates/stats/stats.html:35
+#: src/olympia/stats/templates/stats/stats.html:37
 msgid "Statistics"
 msgstr ""
 
@@ -4919,10 +4849,7 @@ msgid "Your add-on has been submitted to the Full Review queue."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/submit/done.html:18
-msgid ""
-"You'll receive an email once it has been reviewed by an editor. In\n"
-"          the meantime, you and your friends can install it directly from its\n"
-"          details page:"
+msgid "You'll receive an email once it has been reviewed by an editor. In the meantime, you and your friends can install it directly from its details page:"
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/submit/done.html:27 src/olympia/devhub/templates/devhub/addons/submit/done.html:77 src/olympia/devhub/templates/devhub/personas/submit_done.html:16
@@ -5128,11 +5055,11 @@ msgstr ""
 msgid "Use the fields below to upload your add-on package and select any platform restrictions. After upload, a series of automated validation tests will be run on your file."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/addons/submit/upload.html:59 src/olympia/devhub/templates/devhub/versions/add_file_modal.html:39
+#: src/olympia/devhub/templates/devhub/addons/submit/upload.html:51 src/olympia/devhub/templates/devhub/versions/add_file_modal.html:28
 msgid "Which platforms is this file compatible with?"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/addons/submit/upload.html:67 src/olympia/devhub/templates/devhub/versions/add_file_modal.html:65
+#: src/olympia/devhub/templates/devhub/addons/submit/upload.html:59 src/olympia/devhub/templates/devhub/versions/add_file_modal.html:45
 msgid "Administrative overrides"
 msgstr ""
 
@@ -5242,8 +5169,8 @@ msgstr ""
 
 #: src/olympia/devhub/templates/devhub/docs/policies-contact.html:44
 msgid ""
-"If you've found a problem with the site, we'd love to fix it. Please <a href=\"https://github.com/mozilla/olympia/issues\">file a bug report</a> in GitHub, including the location of the problem and "
-"how you encountered it."
+"If you've found a problem with the site, we'd love to fix it. Please <a href=\"https://github.com/mozilla/addons/issues/new\">file a bug report</a> in GitHub, including the location of the problem "
+"and how you encountered it."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/docs/policies-maintenance.html:3 src/olympia/devhub/templates/devhub/docs/policies-maintenance.html:7
@@ -5810,7 +5737,7 @@ msgstr ""
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:282
 msgid ""
-"Add-ons that store or otherwise handle browsing data must support <a href=\"https://developer.mozilla.org/En/Supporting_private_browsing_mode\">Private Browsing Mode</a>.  During a Private Browsing "
+"Add-ons that store or otherwise handle browsing data must support <a href=\"https://developer.mozilla.org/En/Supporting_private_browsing_mode\">Private Browsing Mode</a>. During a Private Browsing "
 "session, no browsing data can be written to disk, and all of this data must be cleared when Firefox quits or the Private Browsing session ends."
 msgstr ""
 
@@ -5975,129 +5902,95 @@ msgstr ""
 msgid "How to get in touch with us regarding these policies or your add-on."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:6
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:10
 msgid "You have disabled this add-on"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:20
-msgid ""
-"Your add-on's listing is disabled and is not showing\n"
-"                             anywhere in our gallery or update service."
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:24
+msgid "Your add-on's listing is disabled and is not showing anywhere in our gallery or update service."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:25
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:27
 msgid "Please complete your add-on."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:29
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:30
 msgid "You will receive an email when the review is complete."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:34
-msgid ""
-"You will receive an email when the review is complete. Until\n"
-"                             then, your add-on is not listed in our gallery but can be\n"
-"                             accessed directly from its details page."
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:33
+msgid "You will receive an email when the review is complete. Until then, your add-on is not listed in our gallery but can be accessed directly from its details page."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:38 src/olympia/devhub/templates/devhub/includes/addon_details.html:48
-msgid ""
-"You will receive an email when the review is\n"
-"                             complete and your add-on is signed."
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:37 src/olympia/devhub/templates/devhub/includes/addon_details.html:45
+msgid "You will receive an email when the review is complete and your add-on is signed."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:44
-msgid ""
-"You will receive an email when the review is complete. Until\n"
-"                             then, your add-on is not listed in our gallery but can be\n"
-"                             accessed directly from its details page. "
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:41
+msgid "You will receive an email when the review is complete. Until then, your add-on is not listed in our gallery but can be accessed directly from its details page. "
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:54
-msgid ""
-"Your add-on is displayed in our gallery and users are\n"
-"                             receiving automatic updates."
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:49
+msgid "Your add-on is displayed in our gallery and users are receiving automatic updates."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:57
-msgid ""
-"Your add-on has been signed and can be bundled with an\n"
-"                             application installer."
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:52
+msgid "Your add-on has been signed and can be bundled with an application installer."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:63
-msgid ""
-"Your add-on was disabled by a site administrator and is no\n"
-"                             longer shown in our gallery. If you have any questions,\n"
-"                             please email amo-admins@mozilla.org."
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:56
+msgid "Your add-on was disabled by a site administrator and is no longer shown in our gallery. If you have any questions, please email amo-admins@mozilla.org."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:70
-msgid ""
-"Your add-on is displayed in our gallery as experimental\n"
-"                             and users are receiving automatic updates. Some features\n"
-"                             are unavailable to your add-on."
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:62
+msgid "Your add-on is displayed in our gallery as experimental and users are receiving automatic updates. Some features are unavailable to your add-on."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:74
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:66
 msgid "Your add-on has been signed."
 msgstr ""
 
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:69
+msgid ""
+"You will receive an email when the full review is complete. Until then, your add-on is displayed in our gallery as experimental and users are receiving automatic updates. Some features are "
+"unavailable to your add-on."
+msgstr ""
+
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:74
+msgid "You will receive an email when the full review is complete, making you able to bundle your add-on with an application installer."
+msgstr ""
+
 #: src/olympia/devhub/templates/devhub/includes/addon_details.html:79
-msgid ""
-"You will receive an email when the full review is complete.\n"
-"                             Until then, your add-on is displayed in our gallery as\n"
-"                             experimental and users are receiving automatic updates.\n"
-"                             Some features are unavailable to your add-on."
+msgid "All add-ons hosted in our gallery must now be reviewed by an editor. If you wish to continue hosting your add-on, please click to select a review process."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:84
-msgid ""
-"You will receive an email when the full review is\n"
-"                             complete, making you able to bundle your add-on with an\n"
-"                             application installer."
-msgstr ""
-
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:91
-msgid ""
-"All add-ons hosted in our gallery must now be reviewed by an\n"
-"                             editor. If you wish to continue hosting your add-on, please\n"
-"                             click to select a review process."
-msgstr ""
-
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:113
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:100
 msgid "Current Version:"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:115
-msgid ""
-"This is the version of your add-on that will\n"
-"                                           be installed if someone clicks the Install\n"
-"                                           button on addons.mozilla.org. It is only\n"
-"                                           relevant for listed add-ons."
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:102
+msgid "This is the version of your add-on that will be installed if someone clicks the Install button on addons.mozilla.org. It is only relevant for listed add-ons."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:123
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:110
 msgid "Created:"
 msgstr ""
 
 #. {0} is a date. dennis-ignore: E201
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:125 src/olympia/devhub/templates/devhub/includes/addon_details.html:131
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:112 src/olympia/devhub/templates/devhub/includes/addon_details.html:118
 #, python-format
 msgid "%%b %%e, %%Y"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:136
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:123
 msgid "Next Version:"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:138
-msgid ""
-"This is the newest uploaded version, however\n"
-"                                           it isn’t live on the site yet."
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:125
+msgid "This is the newest uploaded version, however it isn’t live on the site yet."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:144 src/olympia/devhub/templates/devhub/versions/list.html:30
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:130 src/olympia/devhub/templates/devhub/versions/list.html:30
 msgid "Queues are not reviewed strictly in order"
 msgstr ""
 
@@ -6165,9 +6058,7 @@ msgid "View the blog &#9658;"
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/includes/license_form.html:6
-msgid ""
-"Please choose a license appropriate for the rights you grant on your source code.\n"
-"                  It is only relevant for listed add-ons."
+msgid "Please choose a license appropriate for the rights you grant on your source code. It is only relevant for listed add-ons."
 msgstr ""
 
 #. {0} is a list of HTML tags.
@@ -6194,14 +6085,11 @@ msgstr[1] ""
 #: src/olympia/devhub/templates/devhub/includes/policy_form.html:4
 msgid ""
 "Users will be required to accept the following End-User License Agreement (EULA) prior to installing your add-on. The presence of a EULA significantly affects the number of downloads an add-on "
-"receives. Please note that a EULA is not the same as a code license, such as the GPL or MPL.\n"
-"                It is only relevant for listed add-ons."
+"receives. Please note that a EULA is not the same as a code license, such as the GPL or MPL.It is only relevant for listed add-ons."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/policy_form.html:21
-msgid ""
-"If your add-on transmits any data from the user's computer, a privacy policy is required that explains what data is sent and how it is used.\n"
-"                It is only relevant for listed add-ons."
+#: src/olympia/devhub/templates/devhub/includes/policy_form.html:24
+msgid "If your add-on transmits any data from the user's computer, a privacy policy is required that explains what data is sent and how it is used. It is only relevant for listed add-ons."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/includes/source_form_field.html:2
@@ -6369,12 +6257,8 @@ msgstr ""
 msgid "Add some tags to describe your Theme."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/personas/edit.html:106
-msgid ""
-"A short explanation of your theme's\n"
-"                                basic functionality that is displayed in\n"
-"                                search and browse listings, as well as at\n"
-"                                the top of your theme's details page."
+#: src/olympia/devhub/templates/devhub/personas/edit.html:106 src/olympia/devhub/templates/devhub/personas/submit.html:54
+msgid "A short explanation of your theme's basic functionality that is displayed in search and browse listings, as well as at the top of your theme's details page."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/personas/edit.html:122 src/olympia/devhub/templates/devhub/personas/submit.html:68
@@ -6444,7 +6328,7 @@ msgid "Upon upload and form submission, the AMO Team will review your updated de
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/personas/edit.html:241
-msgid "Your previously resubmitted design,  which is under pending review."
+msgid "Your previously resubmitted design, which is under pending review."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/personas/edit.html:245
@@ -6511,14 +6395,6 @@ msgstr ""
 
 #: src/olympia/devhub/templates/devhub/personas/submit.html:33
 msgid "Give your Theme a name."
-msgstr ""
-
-#: src/olympia/devhub/templates/devhub/personas/submit.html:54
-msgid ""
-"A short explanation of your theme's\n"
-"                                      basic functionality that is displayed in\n"
-"                                      search and browse listings, as well as at\n"
-"                                      the top of your theme's details page."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/personas/submit.html:198
@@ -6595,30 +6471,16 @@ msgstr ""
 msgid "Files added to reviewed versions must be reviewed before they will be available for download."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/add_file_modal.html:15
-#, python-format
-msgid ""
-"Submission of updates to unlisted add-ons for signing is currently in an open beta. Manual review may still be required for a large number of add-ons. Please <a href=\"%(url)s\" target=\"_blank"
-"\">report any bugs</a> that you encounter."
-msgstr ""
-
-#: src/olympia/devhub/templates/devhub/versions/add_file_modal.html:35
+#: src/olympia/devhub/templates/devhub/versions/add_file_modal.html:24
 msgid "Select the target platform for this file."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/add_file_modal.html:46
+#: src/olympia/devhub/templates/devhub/versions/add_file_modal.html:35
 msgid "Which review type would you like to nominate for?"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/add_file_modal.html:51
+#: src/olympia/devhub/templates/devhub/versions/add_file_modal.html:40
 msgid "Only publish this version to my beta channel."
-msgstr ""
-
-#: src/olympia/devhub/templates/devhub/versions/add_file_modal.html:54
-#, python-format
-msgid ""
-"The behavior of the beta channel has changed to accommodate <a href=\"%(addon_signing_url)s\" target=\"_blank\">mandatory add-on signing</a>. The new process is currently in an open beta, and may "
-"change significantly in the near future. Please <a href=\"%(issues_url)s\" target=\"_blank\">report any bugs</a> that you encounter."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/versions/edit.html:5
@@ -6642,19 +6504,10 @@ msgstr ""
 msgid "Upload Another File"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/edit.html:45
-msgid ""
-"Adjusting application information here will allow users to install your\n"
-"                          add-on even if the install manifest in the package indicates that the\n"
-"                          add-on is incompatible."
-msgstr ""
-
 #: src/olympia/devhub/templates/devhub/versions/edit.html:74
 msgid ""
-"Information about changes in this release, new features,\n"
-"                              known bugs, and other useful information specific to this\n"
-"                              release/version. This information is also shown in the\n"
-"                              Add-ons Manager when updating."
+"Information about changes in this release, new features, known bugs, and other useful information specific to this release/version. This information is also shown in the Add-ons Manager when "
+"updating."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/versions/edit.html:99
@@ -6666,10 +6519,7 @@ msgid "Notes for Reviewers"
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/versions/edit.html:114
-msgid ""
-"Optionally, enter any information that may be useful\n"
-"                              to the Editor reviewing this add-on, such as test\n"
-"                              account information."
+msgid "Optionally, enter any information that may be useful to the Editor reviewing this add-on, such as test account information."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/versions/edit.html:127
@@ -6747,7 +6597,7 @@ msgstr ""
 msgid "Request Preliminary Review"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:80 src/olympia/devhub/templates/devhub/versions/list.html:327 src/olympia/devhub/templates/devhub/versions/list.html:350
+#: src/olympia/devhub/templates/devhub/versions/list.html:80 src/olympia/devhub/templates/devhub/versions/list.html:325 src/olympia/devhub/templates/devhub/versions/list.html:348
 msgid "Cancel Review Request"
 msgstr ""
 
@@ -6776,7 +6626,7 @@ msgid "Unlisted:"
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/versions/list.html:114
-msgid "Not distributed on {0}. Developers will upload new versions for signing and distribute the add-ons on their own. (beta)"
+msgid "Not distributed on {0}. Developers will upload new versions for signing and distribute the add-ons on their own."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/versions/list.html:122
@@ -6839,81 +6689,73 @@ msgid "<strong>Important:</strong> Once a version has been deleted, you may not 
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/versions/list.html:230
-msgid ""
-"Deleting a version which has already been reviewed\n"
-"               may also cause a significant delay in the review of\n"
-"               your next update."
-msgstr ""
-
-#: src/olympia/devhub/templates/devhub/versions/list.html:233
 msgid "Are you sure you wish to delete this version?"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:238
+#: src/olympia/devhub/templates/devhub/versions/list.html:235
 msgid "Delete Version"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:240
+#: src/olympia/devhub/templates/devhub/versions/list.html:237
 msgid "Disable Version"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:247
+#: src/olympia/devhub/templates/devhub/versions/list.html:244
 msgid "Add a new Version"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:249
+#: src/olympia/devhub/templates/devhub/versions/list.html:246
 msgid "Add Version"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:256 src/olympia/devhub/templates/devhub/versions/list.html:274
+#: src/olympia/devhub/templates/devhub/versions/list.html:253 src/olympia/devhub/templates/devhub/versions/list.html:279
 msgid "Hide Add-on"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:259
+#: src/olympia/devhub/templates/devhub/versions/list.html:256
 msgid "Hiding your add-on will prevent it from appearing anywhere in our gallery and will stop users from receiving automatic updates."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:265
+#: src/olympia/devhub/templates/devhub/versions/list.html:263
+msgid "The files awaiting review will be disabled and you will need to upload new versions."
+msgstr ""
+
+#: src/olympia/devhub/templates/devhub/versions/list.html:270
 msgid "Are you sure you wish to hide your add-on?"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:286 src/olympia/devhub/templates/devhub/versions/list.html:315
+#: src/olympia/devhub/templates/devhub/versions/list.html:291 src/olympia/devhub/templates/devhub/versions/list.html:313
 msgid "Unlist Add-on"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:289
+#: src/olympia/devhub/templates/devhub/versions/list.html:294
 #, python-format
 msgid ""
 "Unlisting your add-on will make it (and each of its versions/files) invisible on this website. It won't show up in searches, won't have a public facing page, and won't be updated automatically for "
-"current users.  It is recommended for unlisted add-ons to provide a custom <a href=\"%(update_url)s\" target=\"_blank\">updateURL</a> in their manifest file for automatic updates."
+"current users. It is recommended for unlisted add-ons to provide a custom <a href=\"%(update_url)s\" target=\"_blank\">updateURL</a> in their manifest file for automatic updates."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:299
-#, python-format
-msgid "Switching add-ons to unlisted is currently in an open beta. Please <a href=\"%(url)s\" target=\"_blank\">report any bugs</a> that you encounter."
-msgstr ""
-
-#: src/olympia/devhub/templates/devhub/versions/list.html:305
+#: src/olympia/devhub/templates/devhub/versions/list.html:303
 msgid "Unlisting an add-on is irreversible!"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:305
+#: src/olympia/devhub/templates/devhub/versions/list.html:303
 msgid "An unlisted add-on cannot be switched to be listed."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:307
+#: src/olympia/devhub/templates/devhub/versions/list.html:305
 msgid "Are you sure you wish to unlist your add-on?"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:330
+#: src/olympia/devhub/templates/devhub/versions/list.html:328
 msgid "Canceling your review request will leave your add-on as preliminarily reviewed."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:335
+#: src/olympia/devhub/templates/devhub/versions/list.html:333
 msgid "Canceling your review request will mark your add-on incomplete. If you do not complete your add-on after several days by re-requesting review, it will be deleted."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:343
+#: src/olympia/devhub/templates/devhub/versions/list.html:341
 msgid "Are you sure you wish to cancel your review request?"
 msgstr ""
 
@@ -7252,19 +7094,19 @@ msgstr ""
 msgid "Search by add-on name / author email"
 msgstr ""
 
-#: src/olympia/editors/forms.py:103
+#: src/olympia/editors/forms.py:103 src/olympia/editors/forms.py:244 src/olympia/editors/forms.py:257
 msgid "yes"
 msgstr ""
 
-#: src/olympia/editors/forms.py:104
+#: src/olympia/editors/forms.py:104 src/olympia/editors/forms.py:244 src/olympia/editors/forms.py:257
 msgid "no"
 msgstr ""
 
-#: src/olympia/editors/forms.py:105
+#: src/olympia/editors/forms.py:105 src/olympia/editors/forms.py:245
 msgid "Admin Flag"
 msgstr ""
 
-#: src/olympia/editors/forms.py:113
+#: src/olympia/editors/forms.py:113 src/olympia/editors/forms.py:253
 msgid "Max. Version"
 msgstr ""
 
@@ -7276,55 +7118,59 @@ msgstr ""
 msgid "Add-on Types"
 msgstr ""
 
-#: src/olympia/editors/forms.py:126 src/olympia/editors/helpers.py:267
+#: src/olympia/editors/forms.py:126 src/olympia/editors/helpers.py:279
 msgid "Platforms"
 msgstr ""
 
+#: src/olympia/editors/forms.py:237
+msgid "Search by add-on name / author email / guid"
+msgstr ""
+
 #. L10n: 0 = platform, 1 = filename, 2 = status message
-#: src/olympia/editors/forms.py:238
+#: src/olympia/editors/forms.py:342
 #, python-format
 msgid "<strong>%s</strong> &middot; %s &middot; %s"
 msgstr ""
 
-#: src/olympia/editors/forms.py:252
+#: src/olympia/editors/forms.py:356
 msgid "Comments:"
 msgstr ""
 
-#: src/olympia/editors/forms.py:256
+#: src/olympia/editors/forms.py:360
 msgid "Operating systems:"
 msgstr ""
 
-#: src/olympia/editors/forms.py:258
+#: src/olympia/editors/forms.py:362
 msgid "Applications:"
 msgstr ""
 
-#: src/olympia/editors/forms.py:260
+#: src/olympia/editors/forms.py:364
 msgid "Notify me the next time this add-on is updated. (Subsequent updates will not generate an email)"
 msgstr ""
 
-#: src/olympia/editors/forms.py:265
+#: src/olympia/editors/forms.py:369
 msgid "Clear Admin Review Flag"
 msgstr ""
 
-#: src/olympia/editors/forms.py:267
+#: src/olympia/editors/forms.py:371
 msgid "Clear more info requested flag"
 msgstr ""
 
-#: src/olympia/editors/forms.py:281
+#: src/olympia/editors/forms.py:385
 msgid "Choose a canned response..."
 msgstr ""
 
 #. L10n: Description of what can be searched for.
-#: src/olympia/editors/forms.py:324
+#: src/olympia/editors/forms.py:423
 msgid "theme name"
 msgstr ""
 
-#: src/olympia/editors/forms.py:350
+#: src/olympia/editors/forms.py:449
 msgid "Someone else is reviewing this theme."
 msgstr ""
 
 #. L10n: Description of what can be searched for.
-#: src/olympia/editors/forms.py:447
+#: src/olympia/editors/forms.py:546
 msgid "app, reviewer, or comment"
 msgstr ""
 
@@ -7340,246 +7186,264 @@ msgstr ""
 msgid "Rejected or Unreviewed"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:123 src/olympia/editors/helpers.py:136
+#: src/olympia/editors/helpers.py:125 src/olympia/editors/helpers.py:138
 msgid "Queue"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:124 src/olympia/editors/templates/editors/base.html:50 src/olympia/editors/templates/editors/base.html:65
+#: src/olympia/editors/helpers.py:126 src/olympia/editors/templates/editors/base.html:50 src/olympia/editors/templates/editors/base.html:65
 msgid "Pending Updates"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:125 src/olympia/editors/templates/editors/base.html:48 src/olympia/editors/templates/editors/base.html:63
+#: src/olympia/editors/helpers.py:127 src/olympia/editors/templates/editors/base.html:48 src/olympia/editors/templates/editors/base.html:63
 msgid "Full Reviews"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:126 src/olympia/editors/templates/editors/base.html:52 src/olympia/editors/templates/editors/base.html:67
+#: src/olympia/editors/helpers.py:128 src/olympia/editors/templates/editors/base.html:52 src/olympia/editors/templates/editors/base.html:67
 msgid "Preliminary Reviews"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:127 src/olympia/editors/templates/editors/base.html:54
+#: src/olympia/editors/helpers.py:129 src/olympia/editors/templates/editors/base.html:54
 msgid "Moderated Reviews"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:128 src/olympia/editors/templates/editors/base.html:46
+#: src/olympia/editors/helpers.py:130 src/olympia/editors/templates/editors/base.html:46
 msgid "Fast Track"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:130
+#: src/olympia/editors/helpers.py:132
 msgid "Pending Themes"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:131 src/olympia/editors/templates/editors/themes/queue.html:4
+#: src/olympia/editors/helpers.py:133 src/olympia/editors/templates/editors/themes/queue.html:4
 msgid "Flagged Themes"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:132
+#: src/olympia/editors/helpers.py:134
 msgid "Update Themes"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:137
+#: src/olympia/editors/helpers.py:139
 msgid "Unlisted Pending Updates"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:138
+#: src/olympia/editors/helpers.py:140
 msgid "Unlisted Full Reviews"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:139
+#: src/olympia/editors/helpers.py:141
 msgid "Unlisted Preliminary Reviews"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:170
+#: src/olympia/editors/helpers.py:142
+msgid "Unlisted All Add-ons"
+msgstr ""
+
+#: src/olympia/editors/helpers.py:173
 msgid "Fast Track ({0})"
 msgid_plural "Fast Track ({0})"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/olympia/editors/helpers.py:175
+#: src/olympia/editors/helpers.py:178
 msgid "Full Review ({0})"
 msgid_plural "Full Reviews ({0})"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/olympia/editors/helpers.py:180
+#: src/olympia/editors/helpers.py:183
 msgid "Pending Update ({0})"
 msgid_plural "Pending Updates ({0})"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/olympia/editors/helpers.py:185
+#: src/olympia/editors/helpers.py:188
 msgid "Preliminary Review ({0})"
 msgid_plural "Preliminary Reviews ({0})"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/olympia/editors/helpers.py:190
+#: src/olympia/editors/helpers.py:193
 msgid "Moderated Review ({0})"
 msgid_plural "Moderated Reviews ({0})"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/olympia/editors/helpers.py:196
+#: src/olympia/editors/helpers.py:199
 msgid "Unlisted Full Review ({0})"
 msgid_plural "Unlisted Full Reviews ({0})"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/olympia/editors/helpers.py:201
+#: src/olympia/editors/helpers.py:204
 msgid "Unlisted Pending Update ({0})"
 msgid_plural "Unlisted Pending Updates ({0})"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/olympia/editors/helpers.py:206
+#: src/olympia/editors/helpers.py:209
 msgid "Unlisted Preliminary Review ({0})"
 msgid_plural "Unlisted Preliminary Reviews ({0})"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/olympia/editors/helpers.py:261
-msgid "Addon"
-msgstr ""
+#: src/olympia/editors/helpers.py:214
+msgid "Unlisted All Add-ons ({0})"
+msgid_plural "Unlisted All Add-ons ({0})"
+msgstr[0] ""
+msgstr[1] ""
 
-#: src/olympia/editors/helpers.py:262
+#: src/olympia/editors/helpers.py:274
 msgid "Type"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:263
+#: src/olympia/editors/helpers.py:275
 msgid "Waiting Time"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:264 src/olympia/editors/templates/editors/review.html:285
+#: src/olympia/editors/helpers.py:276 src/olympia/editors/templates/editors/review.html:285
 msgid "Flags"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:265
+#: src/olympia/editors/helpers.py:277
 msgid "Applications"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:270
+#: src/olympia/editors/helpers.py:282
 msgid "Additional"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:285
+#: src/olympia/editors/helpers.py:302
 msgid "Site Specific"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:287
+#: src/olympia/editors/helpers.py:304
 msgid "Requires External Software"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:289
+#: src/olympia/editors/helpers.py:306
 msgid "Binary Components"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:313
+#: src/olympia/editors/helpers.py:339
 msgid "moments ago"
 msgstr ""
 
 #. L10n: first argument is number of minutes
-#: src/olympia/editors/helpers.py:316
+#: src/olympia/editors/helpers.py:342
 msgid "{0} minute"
 msgid_plural "{0} minutes"
 msgstr[0] ""
 msgstr[1] ""
 
 #. L10n: first argument is number of hours
-#: src/olympia/editors/helpers.py:320
+#: src/olympia/editors/helpers.py:346
 msgid "{0} hour"
 msgid_plural "{0} hours"
 msgstr[0] ""
 msgstr[1] ""
 
 #. L10n: first argument is number of days
-#: src/olympia/editors/helpers.py:324
+#: src/olympia/editors/helpers.py:350
 msgid "{0} day"
 msgid_plural "{0} days"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/olympia/editors/helpers.py:488
+#: src/olympia/editors/helpers.py:364
+msgid "Last Review"
+msgstr ""
+
+#: src/olympia/editors/helpers.py:366
+msgid "Last Update"
+msgstr ""
+
+#: src/olympia/editors/helpers.py:387
+msgid "No Reviews"
+msgstr ""
+
+#: src/olympia/editors/helpers.py:561
 msgid "Push to public"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:490
+#: src/olympia/editors/helpers.py:563
 msgid "Grant full review"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:505
+#: src/olympia/editors/helpers.py:578
 msgid "Request more information"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:508
+#: src/olympia/editors/helpers.py:581
 msgid "Request super-review"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:519
+#: src/olympia/editors/helpers.py:592
 msgid "Grant preliminary review"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:520
+#: src/olympia/editors/helpers.py:593
 msgid "This will mark the files as preliminarily reviewed."
 msgstr ""
 
-#: src/olympia/editors/helpers.py:522
+#: src/olympia/editors/helpers.py:595
 msgid "Use this form to request more information from the author. They will receive an email and be able to answer here. You will be notified by email when they reply."
 msgstr ""
 
-#: src/olympia/editors/helpers.py:526
+#: src/olympia/editors/helpers.py:599
 msgid ""
 "If you have concerns about this add-on's security, copyright issues, or other concerns that an administrator should look into, enter your comments in the area below. They will be sent to "
 "administrators, not the author."
 msgstr ""
 
-#: src/olympia/editors/helpers.py:532
+#: src/olympia/editors/helpers.py:605
 msgid "This will reject the add-on and remove it from the review queue."
 msgstr ""
 
-#: src/olympia/editors/helpers.py:534
-msgid "Make a comment on this version.  The author won't be able to see this."
+#: src/olympia/editors/helpers.py:607
+msgid "Make a comment on this version. The author won't be able to see this."
 msgstr ""
 
-#: src/olympia/editors/helpers.py:538
+#: src/olympia/editors/helpers.py:611
 msgid "This will reject the files and remove them from the review queue."
 msgstr ""
 
-#: src/olympia/editors/helpers.py:542
+#: src/olympia/editors/helpers.py:615
 msgid "This will mark the add-on as preliminarily reviewed. Future versions will undergo preliminary review."
 msgstr ""
 
-#: src/olympia/editors/helpers.py:547
+#: src/olympia/editors/helpers.py:620
 msgid "This will mark the files as preliminarily reviewed. Future versions will undergo preliminary review."
 msgstr ""
 
-#: src/olympia/editors/helpers.py:552
+#: src/olympia/editors/helpers.py:625
 msgid "Retain preliminary review"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:553
+#: src/olympia/editors/helpers.py:626
 msgid "This will retain the add-on as preliminarily reviewed. Future versions will undergo preliminary review."
 msgstr ""
 
-#: src/olympia/editors/helpers.py:558
+#: src/olympia/editors/helpers.py:631
 msgid "This will approve a sandboxed version of a public add-on to appear on the public side."
 msgstr ""
 
-#: src/olympia/editors/helpers.py:561
+#: src/olympia/editors/helpers.py:634
 msgid "This will reject a version of a public add-on and remove it from the queue."
 msgstr ""
 
-#: src/olympia/editors/helpers.py:564
+#: src/olympia/editors/helpers.py:637
 msgid "This will mark the add-on and its most recent version and files as public. Future versions will go into the sandbox until they are reviewed by an editor."
 msgstr ""
 
-#: src/olympia/editors/helpers.py:637
+#: src/olympia/editors/helpers.py:714
 msgid "add-on"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:940 src/olympia/editors/helpers.py:960
+#: src/olympia/editors/helpers.py:1020 src/olympia/editors/helpers.py:1040
 msgid "Flagged"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:944 src/olympia/editors/helpers.py:963
+#: src/olympia/editors/helpers.py:1024 src/olympia/editors/helpers.py:1043
 msgid "Updates"
 msgstr ""
 
@@ -7631,56 +7495,56 @@ msgstr ""
 msgid "A question about your Theme submission"
 msgstr ""
 
-#: src/olympia/editors/views.py:144
+#: src/olympia/editors/views.py:146
 msgid "New Add-ons (Under 5 days)"
 msgstr ""
 
-#: src/olympia/editors/views.py:145
+#: src/olympia/editors/views.py:147
 msgid "Passable (5 to 10 days)"
 msgstr ""
 
-#: src/olympia/editors/views.py:146
+#: src/olympia/editors/views.py:148
 msgid "Overdue (Over 10 days)"
 msgstr ""
 
-#: src/olympia/editors/views.py:532
+#: src/olympia/editors/views.py:539
 msgid "An unknown error occurred"
 msgstr ""
 
-#: src/olympia/editors/views.py:587
+#: src/olympia/editors/views.py:592
 msgid "Self-reviews are not allowed."
 msgstr ""
 
-#: src/olympia/editors/views.py:609
+#: src/olympia/editors/views.py:613
 msgid "Review successfully processed."
 msgstr ""
 
-#: src/olympia/editors/views.py:807
+#: src/olympia/editors/views.py:812
 msgid "was approved"
 msgstr ""
 
-#: src/olympia/editors/views.py:808
+#: src/olympia/editors/views.py:813
 msgid "given preliminary review"
 msgstr ""
 
-#: src/olympia/editors/views.py:809
+#: src/olympia/editors/views.py:814
 msgid "rejected"
 msgstr ""
 
-#: src/olympia/editors/views.py:810
+#: src/olympia/editors/views.py:815
 msgctxt "editors_review_history_nominated_adminreview"
 msgid "escalated"
 msgstr ""
 
-#: src/olympia/editors/views.py:812
+#: src/olympia/editors/views.py:817
 msgid "needs more information"
 msgstr ""
 
-#: src/olympia/editors/views.py:813
+#: src/olympia/editors/views.py:818
 msgid "needs super review"
 msgstr ""
 
-#: src/olympia/editors/views.py:814
+#: src/olympia/editors/views.py:819
 msgid "commented"
 msgstr ""
 
@@ -7725,28 +7589,28 @@ msgstr ""
 msgid "Unlisted Queues"
 msgstr ""
 
-#: src/olympia/editors/templates/editors/base.html:72 src/olympia/editors/templates/editors/performance.html:6
+#: src/olympia/editors/templates/editors/base.html:74 src/olympia/editors/templates/editors/performance.html:6
 msgid "Performance"
 msgstr ""
 
-#: src/olympia/editors/templates/editors/base.html:75 src/olympia/editors/templates/editors/themes/base.html:19 src/olympia/editors/templates/editors/themes/base.html:38
+#: src/olympia/editors/templates/editors/base.html:77 src/olympia/editors/templates/editors/themes/base.html:19 src/olympia/editors/templates/editors/themes/base.html:38
 msgid "Logs"
 msgstr ""
 
-#: src/olympia/editors/templates/editors/base.html:78 src/olympia/editors/templates/editors/reviewlog.html:4 src/olympia/editors/templates/editors/reviewlog.html:27
+#: src/olympia/editors/templates/editors/base.html:80 src/olympia/editors/templates/editors/reviewlog.html:4 src/olympia/editors/templates/editors/reviewlog.html:27
 msgid "Add-on Review Log"
 msgstr ""
 
-#: src/olympia/editors/templates/editors/base.html:80 src/olympia/editors/templates/editors/eventlog.html:4 src/olympia/editors/templates/editors/eventlog.html:8
+#: src/olympia/editors/templates/editors/base.html:82 src/olympia/editors/templates/editors/eventlog.html:4 src/olympia/editors/templates/editors/eventlog.html:8
 #: src/olympia/editors/templates/editors/eventlog_detail.html:4
 msgid "Moderated Review Log"
 msgstr ""
 
-#: src/olympia/editors/templates/editors/base.html:82 src/olympia/editors/templates/editors/beta_signed_log.html:4 src/olympia/editors/templates/editors/beta_signed_log.html:8
+#: src/olympia/editors/templates/editors/base.html:84 src/olympia/editors/templates/editors/beta_signed_log.html:4 src/olympia/editors/templates/editors/beta_signed_log.html:8
 msgid "Signed Beta Files Log"
 msgstr ""
 
-#: src/olympia/editors/templates/editors/base.html:87 src/olympia/editors/templates/editors/includes/daily-message.html:4
+#: src/olympia/editors/templates/editors/base.html:89 src/olympia/editors/templates/editors/includes/daily-message.html:4
 msgid "Announcement"
 msgstr ""
 
@@ -7967,45 +7831,45 @@ msgstr ""
 msgid "clear search"
 msgstr ""
 
-#: src/olympia/editors/templates/editors/queue.html:72 src/olympia/editors/templates/editors/queue.html:122
+#: src/olympia/editors/templates/editors/queue.html:78 src/olympia/editors/templates/editors/queue.html:128
 msgid "Process Reviews"
 msgstr ""
 
-#: src/olympia/editors/templates/editors/queue.html:80
+#: src/olympia/editors/templates/editors/queue.html:86
 msgid "Moderation actions:"
 msgstr ""
 
-#: src/olympia/editors/templates/editors/queue.html:90
+#: src/olympia/editors/templates/editors/queue.html:96
 #, python-format
 msgid "by %(user)s on %(date)s %(stars)s (%(locale)s)"
 msgstr ""
 
-#: src/olympia/editors/templates/editors/queue.html:106
+#: src/olympia/editors/templates/editors/queue.html:112
 #, python-format
 msgid "<strong>%(reason)s</strong> <span class=\"light\">Flagged by %(user)s on %(date)s</span>"
 msgstr ""
 
-#: src/olympia/editors/templates/editors/queue.html:119
-msgid "All reviews have been moderated.  Good work!"
+#: src/olympia/editors/templates/editors/queue.html:125
+msgid "All reviews have been moderated. Good work!"
 msgstr ""
 
-#: src/olympia/editors/templates/editors/queue.html:161
+#: src/olympia/editors/templates/editors/queue.html:167
 msgid "Version Notes / Notes for Reviewer"
 msgstr ""
 
-#: src/olympia/editors/templates/editors/queue.html:169
+#: src/olympia/editors/templates/editors/queue.html:175
 msgid "There are currently no add-ons of this type to review."
 msgstr ""
 
-#: src/olympia/editors/templates/editors/queue.html:181 src/olympia/editors/templates/editors/themes/queue_list.html:85
+#: src/olympia/editors/templates/editors/queue.html:187 src/olympia/editors/templates/editors/themes/queue_list.html:85
 msgid "Helpful Links:"
 msgstr ""
 
-#: src/olympia/editors/templates/editors/queue.html:182
+#: src/olympia/editors/templates/editors/queue.html:188
 msgid "Add-on Policy"
 msgstr ""
 
-#: src/olympia/editors/templates/editors/queue.html:184
+#: src/olympia/editors/templates/editors/queue.html:190
 msgid "Editors' Guide"
 msgstr ""
 
@@ -8068,10 +7932,7 @@ msgid "<strong>Warning!</strong> Another user was viewing this page before you."
 msgstr ""
 
 #: src/olympia/editors/templates/editors/review.html:237
-msgid ""
-"The whiteboard is the place to exchange information relevant to\n"
-"               this addon (whatever the version), between the developer and the\n"
-"               editor. This is visible and editable by both."
+msgid "The whiteboard is the place to exchange information relevant to this addon (whatever the version), between the developer and the editor. This is visible and editable by both."
 msgstr ""
 
 #: src/olympia/editors/templates/editors/review.html:241
@@ -8345,7 +8206,7 @@ msgstr ""
 msgid "Describe your reason for flagging"
 msgstr ""
 
-#: src/olympia/files/forms.py:88
+#: src/olympia/files/forms.py:90
 msgid "Cannot diff a version against itself"
 msgstr ""
 
@@ -8380,51 +8241,51 @@ msgstr ""
 msgid "There was an error accessing file %s."
 msgstr ""
 
-#: src/olympia/files/utils.py:343
+#: src/olympia/files/utils.py:340
 msgid "Could not parse uploaded file."
 msgstr ""
 
-#: src/olympia/files/utils.py:380
+#: src/olympia/files/utils.py:377
 msgid "Invalid file name in archive: {0}"
 msgstr ""
 
-#: src/olympia/files/utils.py:388
+#: src/olympia/files/utils.py:385
 msgid "File exceeding size limit in archive: {0}"
 msgstr ""
 
-#: src/olympia/files/utils.py:439
+#: src/olympia/files/utils.py:436
 msgid "Invalid archive."
 msgstr ""
 
-#: src/olympia/files/utils.py:529 src/olympia/files/utils.py:532
+#: src/olympia/files/utils.py:526 src/olympia/files/utils.py:529
 msgid "Could not parse the manifest file."
 msgstr ""
 
-#: src/olympia/files/utils.py:551
+#: src/olympia/files/utils.py:548
 msgid "Could not find an add-on ID."
 msgstr ""
 
-#: src/olympia/files/utils.py:554
+#: src/olympia/files/utils.py:551
 msgid "Add-on ID must be 64 characters or less."
 msgstr ""
 
-#: src/olympia/files/utils.py:556
+#: src/olympia/files/utils.py:553
 msgid "Add-on ID doesn't match add-on."
 msgstr ""
 
-#: src/olympia/files/utils.py:564
+#: src/olympia/files/utils.py:561
 msgid "Duplicate add-on ID found."
 msgstr ""
 
-#: src/olympia/files/utils.py:567
+#: src/olympia/files/utils.py:564
 msgid "Version numbers should have fewer than 32 characters."
 msgstr ""
 
-#: src/olympia/files/utils.py:570
+#: src/olympia/files/utils.py:567
 msgid "Version numbers should only contain letters, numbers, and these punctuation characters: +*.-_."
 msgstr ""
 
-#: src/olympia/files/utils.py:587
+#: src/olympia/files/utils.py:584
 msgid "<em:type> doesn't match add-on"
 msgstr ""
 
@@ -8523,6 +8384,10 @@ msgstr ""
 
 #: src/olympia/files/templates/files/viewer.html:134
 msgid "Fetching file."
+msgstr ""
+
+#: src/olympia/legacy_api/views.py:255
+msgid "Not implemented yet."
 msgstr ""
 
 #: src/olympia/lib/constants.py:6
@@ -9181,10 +9046,6 @@ msgstr ""
 msgid "Zimbabwe Dollar"
 msgstr ""
 
-#: src/olympia/lib/video/ffmpeg.py:112 src/olympia/lib/video/totem.py:81
-msgid "Videos must be in WebM."
-msgstr ""
-
 #: src/olympia/pages/templates/pages/about.lhtml:3 src/olympia/pages/templates/pages/about.lhtml:10
 msgid "About Mozilla Add-ons"
 msgstr ""
@@ -9196,7 +9057,7 @@ msgstr ""
 #: src/olympia/pages/templates/pages/about.lhtml:13
 msgid ""
 "addons.mozilla.org, commonly known as \"AMO\", is Mozilla's official site for add-ons to Mozilla software, such as Firefox, Thunderbird, and SeaMonkey. Add-ons let you add new features and change "
-"the way your browser or application works.  Take a look around and explore the thousands of ways to customize the way you do things online."
+"the way your browser or application works. Take a look around and explore the thousands of ways to customize the way you do things online."
 msgstr ""
 
 #: src/olympia/pages/templates/pages/about.lhtml:19
@@ -9541,7 +9402,7 @@ msgstr ""
 msgid ""
 "Yes. It's possible, but some of the functionality provided by these libraries are available through XPCOM, XUL, and JavaScript. In addition, authors should take care if libraries modify primitive "
 "object prototypes (String.prototype, Date.prototype, etc.) and/or define global functions (eg. the $ function). These are prone to cause conflict with other add-ons, in particular if different add-"
-"ons use different versions of libraries and so on. Developers need to be very, very careful with using them.  Mozilla does not offer documentation on using them to build add-ons."
+"ons use different versions of libraries and so on. Developers need to be very, very careful with using them. Mozilla does not offer documentation on using them to build add-ons."
 msgstr ""
 
 #: src/olympia/pages/templates/pages/dev_faq.html:165
@@ -9655,8 +9516,8 @@ msgstr ""
 #, python-format
 msgid ""
 "Yes. Many developers choose to host their own add-ons. Choosing to host your add-on on <a href=\"%(amo_url)s\">Mozilla's add-on site</a>, though, allows for much greater exposure to your add-on due "
-"to the large volume of visitors to the site.  <a href=\"%(md_url)s\">mozdev.org</a> offers free project hosting for Mozilla applications and extensions providing developers with tools to help "
-"manage source code, version control, bug tracking and documentation."
+"to the large volume of visitors to the site. <a href=\"%(md_url)s\">mozdev.org</a> offers free project hosting for Mozilla applications and extensions providing developers with tools to help manage "
+"source code, version control, bug tracking and documentation."
 msgstr ""
 
 #: src/olympia/pages/templates/pages/dev_faq.html:277
@@ -9704,7 +9565,7 @@ msgstr ""
 #: src/olympia/pages/templates/pages/dev_faq.html:314
 #, python-format
 msgid ""
-"Yes. Mozilla's <a href=\"%(p_url)s\">Add-on Policy</a> describes what is an acceptable submission. This policy is subject to change without notice.  In addition, the AMO editorial team uses the <a "
+"Yes. Mozilla's <a href=\"%(p_url)s\">Add-on Policy</a> describes what is an acceptable submission. This policy is subject to change without notice. In addition, the AMO editorial team uses the <a "
 "href=\"%(g_url)s\">Editors Reviewing Guide</a> to ensure that your add-on meets specific guidelines for functionality and security."
 msgstr ""
 
@@ -9821,7 +9682,7 @@ msgstr ""
 #: src/olympia/pages/templates/pages/dev_faq.html:434
 #, python-format
 msgid ""
-"This is why it's very important to read the <a href=\"%(g_url)s\">Editors Reviewing Guide</a> to ensure that your add-on is setup as expected.  It's also a good idea to read the blog post, <a href="
+"This is why it's very important to read the <a href=\"%(g_url)s\">Editors Reviewing Guide</a> to ensure that your add-on is setup as expected. It's also a good idea to read the blog post, <a href="
 "\"%(blog_url)s\">Successfully Getting your Add-on Reviewed</a> which provides excellent insight into ensuring a smooth review of your add-on."
 msgstr ""
 
@@ -9928,7 +9789,7 @@ msgstr ""
 
 #: src/olympia/pages/templates/pages/dev_faq.html:572
 msgid ""
-"Free Software Foundation provides short summaries of the key open source licenses, including whether the license qualifies as a free software license or a copyleft license.  Also includes a "
+"Free Software Foundation provides short summaries of the key open source licenses, including whether the license qualifies as a free software license or a copyleft license. Also includes a "
 "discussion of what constitutes a free software license or a copyleft license (e.g., a Copyleft license is a general method for making a program or other work free, and requiring all modified and "
 "extended versions of the program to be free as well.)"
 msgstr ""
@@ -10106,19 +9967,13 @@ msgid "Add-on Gallery"
 msgstr ""
 
 #: src/olympia/pages/templates/pages/faq.html:171
-msgid ""
-"How do I choose between add-ons that seem to do the same\n"
-"    thing?"
+msgid "How do I choose between add-ons that seem to do the same thing?"
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:173
+#: src/olympia/pages/templates/pages/faq.html:172
 msgid ""
-"There are often several add-ons that have similar features. To\n"
-"    figure out which is right for you, read the entire description of the\n"
-"    add-on and view its screenshots. If there are still several in the running,\n"
-"    read through the add-on's ratings, user reviews, and statistics to see\n"
-"    which is most liked by other users. Remember that you can also just try\n"
-"    out both and see which you like better."
+"There are often several add-ons that have similar features. To figure out which is right for you, read the entire description of the add-on and view its screenshots. If there are still several in "
+"the running, read through the add-on's ratings, user reviews, and statistics to see which is most liked by other users. Remember that you can also just try out both and see which you like better."
 msgstr ""
 
 #: src/olympia/pages/templates/pages/faq.html:180
@@ -10159,80 +10014,67 @@ msgid "How much do add-ons cost to purchase?"
 msgstr ""
 
 #: src/olympia/pages/templates/pages/faq.html:207
-msgid ""
-"Add-ons hosted in our gallery are free unless clearly marked\n"
-"    otherwise."
+msgid "Add-ons hosted in our gallery are free unless clearly marked otherwise."
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:210
+#: src/olympia/pages/templates/pages/faq.html:209
 msgid "What does it mean when an add-on asks for contributions?"
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:211
+#: src/olympia/pages/templates/pages/faq.html:210
 msgid ""
-"Some add-on authors request users who enjoy an add-on to\n"
-"        contribute to its development by making a monetary contribution. These\n"
-"        contributions go directly to the developer unless a third party is\n"
-"        indicated, such as the non-profit Mozilla Foundation."
+"Some add-on authors request users who enjoy an add-on to contribute to its development by making a monetary contribution. These contributions go directly to the developer unless a third party is "
+"indicated, such as the non-profit Mozilla Foundation."
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:216
+#: src/olympia/pages/templates/pages/faq.html:215
 msgid "What are beta add-ons?"
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:218
+#: src/olympia/pages/templates/pages/faq.html:217
 msgid ""
-"Beta add-ons are unreviewed versions which represent the\n"
-"        latest work of an add-on author. While different authors have different\n"
-"        standards for beta code quality, you should assume that these add-ons\n"
-"        are less stable than the general add-on releases."
+"Beta add-ons are unreviewed versions which represent the latest work of an add-on author. While different authors have different standards for beta code quality, you should assume that these add-"
+"ons are less stable than the general add-on releases."
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:222
+#: src/olympia/pages/templates/pages/faq.html:221
 msgid ""
 "Please note that when you install an add-on from the \"Beta Version\" section of an add-on's listing, you will continue to receive updates for that add-on as they become available. Like the initial "
 "version you installed, all beta releases are unreviewed by Mozilla and may harm your computer."
 msgstr ""
 
+#: src/olympia/pages/templates/pages/faq.html:228
+msgid "What does it mean when an add-on is flagged as slow?"
+msgstr ""
+
 #: src/olympia/pages/templates/pages/faq.html:229
-msgid ""
-"What does it mean when an add-on is flagged as\n"
-"    slow?"
+msgid "Most add-ons load code and resources at the same time Firefox is starting up. In most cases the impact in start-up time is minimal, but some add-ons can cause a noticeable slowdown."
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:231
-msgid ""
-"Most add-ons load code and resources at the same time Firefox\n"
-"        is starting up. In most cases the impact in start-up time is minimal,\n"
-"        but some add-ons can cause a noticeable slowdown."
-msgstr ""
-
-#: src/olympia/pages/templates/pages/faq.html:236
+#: src/olympia/pages/templates/pages/faq.html:234
 msgid "How do I report an inappropriate or spam user review?"
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:237
+#: src/olympia/pages/templates/pages/faq.html:235
 msgid ""
-"To report a user review of an add-on, log in with your account\n"
-"    and visit the add-on's reviews page. Find the review you wish to report,\n"
-"    click \"Report this review\" and select a reason. Our editorial team will\n"
-"    investigate the review and take appropriate action."
+"To report a user review of an add-on, log in with your account and visit the add-on's reviews page. Find the review you wish to report, click \"Report this review\" and select a reason. Our "
+"editorial team will investigate the review and take appropriate action."
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:242
+#: src/olympia/pages/templates/pages/faq.html:240
 msgid "How do I report a bug or contact the Mozilla Add-ons team?"
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:243
+#: src/olympia/pages/templates/pages/faq.html:241
 #, python-format
 msgid "Please visit our <a href=\"%(contact_url)s\">Contact page</a>."
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:246
+#: src/olympia/pages/templates/pages/faq.html:244
 msgid "What is a Source Code License?"
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:247
+#: src/olympia/pages/templates/pages/faq.html:245
 #, python-format
 msgid ""
 "The source code used to create an add-on is an exclusive copyright of the add-on author, unless otherwise declared in a source code license. Many add-ons on this site have <a href=\"%(url)s\" lang="
@@ -10240,60 +10082,60 @@ msgid ""
 "the GPL or BSD licenses instead of making up their own."
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:256
+#: src/olympia/pages/templates/pages/faq.html:254
 #, python-format
 msgid "Firefox and other Mozilla software are <a href=\"%(url)s\">open source</a>."
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:264
+#: src/olympia/pages/templates/pages/faq.html:262
 msgid "Collections and Favorites"
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:267
+#: src/olympia/pages/templates/pages/faq.html:265
 msgid "What is a collection?"
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:268
+#: src/olympia/pages/templates/pages/faq.html:266
 msgid "Collections are groups of related add-ons created by users to share."
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:270
+#: src/olympia/pages/templates/pages/faq.html:268
 msgid "What is the My Favorites collection?"
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:271
+#: src/olympia/pages/templates/pages/faq.html:269
 msgid "Favorite add-ons are add-ons that you have bookmarked to easily get back to later. You can add an add-on to your favorites collection by clicking \"Add to favorites\" on its details page."
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:275 src/olympia/templates/menu_links.html:13 src/olympia/templates/impala/header_title.html:17
+#: src/olympia/pages/templates/pages/faq.html:273 src/olympia/templates/menu_links.html:13 src/olympia/templates/impala/header_title.html:17
 msgid "Mobile Add-ons"
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:278
+#: src/olympia/pages/templates/pages/faq.html:276
 msgid "What are mobile add-ons?"
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:279
+#: src/olympia/pages/templates/pages/faq.html:277
 #, python-format
 msgid ""
 "Mobile add-ons work with <a href=\"%(mobile_url)s\">Firefox for Mobile</a> and add or modify functionality just like desktop add-ons. You can find add-ons that work with Firefox for Mobile in our "
 "<a href=\"%(gallery_url)s\">gallery</a>."
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:288
+#: src/olympia/pages/templates/pages/faq.html:286
 msgid "Developer Topics"
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:289
+#: src/olympia/pages/templates/pages/faq.html:287
 #, python-format
 msgid "Please see our <a href=\"%(faq_url)s\">Developer FAQ</a> and <a href=\"%(hub_url)s\">Developer Hub</a> for answers to add-on developer-related questions."
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:294
+#: src/olympia/pages/templates/pages/faq.html:292
 msgid "Still have questions?"
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:295
+#: src/olympia/pages/templates/pages/faq.html:293
 #, python-format
 msgid "For general Firefox support, visit our <a href=\"%(sumo_url)s\">support website</a>. For general add-on and website questions, visit our <a href=\"%(forum_url)s\">forum</a>."
 msgstr ""
@@ -10431,7 +10273,7 @@ msgstr ""
 
 #: src/olympia/pages/templates/pages/sunbird.html:29
 msgid ""
-"Development on the Sunbird project has halted and its final release was on March 30, 2010.  We've been proud to host Sunbird add-ons on this site but as the project is no longer maintained we have "
+"Development on the Sunbird project has halted and its final release was on March 30, 2010. We've been proud to host Sunbird add-ons on this site but as the project is no longer maintained we have "
 "disabled our support for the add-ons."
 msgstr ""
 
@@ -10509,7 +10351,7 @@ msgstr ""
 #, python-format
 msgid ""
 "<h2>Keep these tips in mind:</h2> <ul> <li> Write like you're telling a friend about your experience with the add-on. Give specifics and helpful details, such as what features you liked and/or "
-"disliked, how easy to use it is, and any disadvantages it has.  Avoid generic language such as calling it \"Great\" or \"Bad\" unless you can give reasons why you believe this is so. </li> <li> "
+"disliked, how easy to use it is, and any disadvantages it has. Avoid generic language such as calling it \"Great\" or \"Bad\" unless you can give reasons why you believe this is so. </li> <li> "
 "Please do not post bug reports in reviews. We do not make your email address available to add-on developers and they may need to contact you to help resolve your issue. See the <a href=\"%(support)s"
 "\">support section</a> to find out where to get assistance for this add-on. </li> <li>Please keep reviews clean, avoid the use of improper language and do not post any personal information. </li> </"
 "ul> <p>Please read the <a href=\"%(guide)s\" target=\"_blank\">Review Guidelines</a> for more detail about user add-on reviews.</p>"
@@ -10745,16 +10587,16 @@ msgstr ""
 
 #. L10n: {0} is an application, such as Firefox. This means "any version of
 #. Firefox."
-#: src/olympia/search/views.py:554
+#: src/olympia/search/views.py:547
 msgid "Any {0}"
 msgstr ""
 
 #. L10n: "All Systems" means show everything regardless of platform.
-#: src/olympia/search/views.py:589
+#: src/olympia/search/views.py:582
 msgid "All Systems"
 msgstr ""
 
-#: src/olympia/search/views.py:600
+#: src/olympia/search/views.py:593
 msgid "All Tags"
 msgstr ""
 
@@ -10928,31 +10770,31 @@ msgstr ""
 msgid "Share this Collection"
 msgstr ""
 
-#: src/olympia/signing/views.py:30 src/olympia/templates/base.html:75 src/olympia/templates/impala/base.html:115
+#: src/olympia/signing/views.py:33 src/olympia/templates/base.html:71 src/olympia/templates/impala/base.html:112
 msgid "Some features are temporarily disabled while we perform website maintenance. We'll be back to full capacity shortly."
 msgstr ""
 
-#: src/olympia/signing/views.py:53
+#: src/olympia/signing/views.py:56
 msgid "Could not find add-on with id \"{}\"."
 msgstr ""
 
-#: src/olympia/signing/views.py:67
+#: src/olympia/signing/views.py:70
 msgid "You do not own this addon."
 msgstr ""
 
-#: src/olympia/signing/views.py:82
+#: src/olympia/signing/views.py:87
 msgid "Missing \"upload\" key in multipart file data."
 msgstr ""
 
-#: src/olympia/signing/views.py:96
+#: src/olympia/signing/views.py:101
 msgid "Version does not match the manifest file."
 msgstr ""
 
-#: src/olympia/signing/views.py:100
+#: src/olympia/signing/views.py:105
 msgid "Version already exists."
 msgstr ""
 
-#: src/olympia/signing/views.py:136
+#: src/olympia/signing/views.py:141
 msgid "No uploaded file for that addon and version."
 msgstr ""
 
@@ -11065,89 +10907,89 @@ msgstr ""
 msgid "Statistics Dashboard :: Add-ons for {0}"
 msgstr ""
 
-#: src/olympia/stats/templates/stats/stats.html:30
-msgid "Controls:"
-msgstr ""
-
-#: src/olympia/stats/templates/stats/stats.html:33
-msgid "reset zoom"
-msgstr ""
-
-#: src/olympia/stats/templates/stats/stats.html:40
-msgid "Group by:"
-msgstr ""
-
-#: src/olympia/stats/templates/stats/stats.html:42
-msgid "day"
-msgstr ""
-
-#: src/olympia/stats/templates/stats/stats.html:45
-msgid "week"
-msgstr ""
-
-#: src/olympia/stats/templates/stats/stats.html:48
-msgid "month"
-msgstr ""
-
-#: src/olympia/stats/templates/stats/stats.html:54
-msgid "For last:"
-msgstr ""
-
-#: src/olympia/stats/templates/stats/stats.html:57
-msgid "7 days"
-msgstr ""
-
-#: src/olympia/stats/templates/stats/stats.html:60
-msgid "30 days"
-msgstr ""
-
-#: src/olympia/stats/templates/stats/stats.html:63
-msgid "90 days"
-msgstr ""
-
-#: src/olympia/stats/templates/stats/stats.html:66
-msgid "365 days"
-msgstr ""
-
-#: src/olympia/stats/templates/stats/stats.html:69
-msgid "Custom..."
-msgstr ""
-
 #. {0} is an add-on name
-#: src/olympia/stats/templates/stats/stats.html:88 src/olympia/stats/templates/stats/stats.html:91
+#: src/olympia/stats/templates/stats/stats.html:44 src/olympia/stats/templates/stats/stats.html:47
 msgid "Statistics for {0}"
 msgstr ""
 
-#: src/olympia/stats/templates/stats/stats.html:94
+#: src/olympia/stats/templates/stats/stats.html:50
 msgid "Statistics Dashboard"
 msgstr ""
 
-#: src/olympia/stats/templates/stats/stats.html:104
+#: src/olympia/stats/templates/stats/stats.html:57
+msgid "Controls:"
+msgstr ""
+
+#: src/olympia/stats/templates/stats/stats.html:60
+msgid "reset zoom"
+msgstr ""
+
+#: src/olympia/stats/templates/stats/stats.html:67
+msgid "Group by:"
+msgstr ""
+
+#: src/olympia/stats/templates/stats/stats.html:69
+msgid "day"
+msgstr ""
+
+#: src/olympia/stats/templates/stats/stats.html:72
+msgid "week"
+msgstr ""
+
+#: src/olympia/stats/templates/stats/stats.html:75
+msgid "month"
+msgstr ""
+
+#: src/olympia/stats/templates/stats/stats.html:81
+msgid "For last:"
+msgstr ""
+
+#: src/olympia/stats/templates/stats/stats.html:84
+msgid "7 days"
+msgstr ""
+
+#: src/olympia/stats/templates/stats/stats.html:87
+msgid "30 days"
+msgstr ""
+
+#: src/olympia/stats/templates/stats/stats.html:90
+msgid "90 days"
+msgstr ""
+
+#: src/olympia/stats/templates/stats/stats.html:93
+msgid "365 days"
+msgstr ""
+
+#: src/olympia/stats/templates/stats/stats.html:96
+msgid "Custom..."
+msgstr ""
+
+#: src/olympia/stats/templates/stats/stats.html:106
 msgid "Statistics processing is currently disabled, so recent data is unavailable. The statistics are still being collected and this page will be updated soon with the missing data."
 msgstr ""
 
-#: src/olympia/stats/templates/stats/stats.html:110
+#: src/olympia/stats/templates/stats/stats.html:112
 msgid "Loading the latest data&hellip;"
 msgstr ""
 
-#: src/olympia/stats/templates/stats/stats.html:142 src/olympia/stats/templates/stats/reports/overview.html:25 src/olympia/stats/templates/stats/reports/overview.html:37
+#: src/olympia/stats/templates/stats/stats.html:144 src/olympia/stats/templates/stats/reports/overview.html:25 src/olympia/stats/templates/stats/reports/overview.html:37
 #: src/olympia/stats/templates/stats/reports/overview.html:49
 msgid "No data available."
 msgstr ""
 
-#: src/olympia/stats/templates/stats/stats.html:177
+#: src/olympia/stats/templates/stats/stats.html:179
 msgid "This dashboard is currently <b>public</b>."
 msgstr ""
 
-#: src/olympia/stats/templates/stats/stats.html:179
+#: src/olympia/stats/templates/stats/stats.html:181
 msgid "Contribution stats are currently <b>private</b>."
 msgstr ""
 
-#: src/olympia/stats/templates/stats/stats.html:182
+#: src/olympia/stats/templates/stats/stats.html:184
 msgid "This dashboard is currently <b>private</b>."
 msgstr ""
 
-#: src/olympia/stats/templates/stats/stats.html:185
+#: src/olympia/stats/templates/stats/stats.html:187
 msgid "Change settings."
 msgstr ""
 
@@ -11299,15 +11141,6 @@ msgstr ""
 msgid "Application versions by Date"
 msgstr ""
 
-#: src/olympia/tags/templates/tags/top_cloud.html:4
-msgid "Top {0} Tags"
-msgstr ""
-
-#. {0} is the current application name
-#: src/olympia/tags/templates/tags/top_cloud.html:14
-msgid "{0} Top Tags"
-msgstr ""
-
 #: src/olympia/templates/amo_footer.html:6 src/olympia/templates/includes/lang_switcher.html:2
 msgid "Other languages"
 msgstr ""
@@ -11316,11 +11149,11 @@ msgstr ""
 msgid "Mozilla Add-ons"
 msgstr ""
 
-#: src/olympia/templates/base.html:91 src/olympia/templates/impala/base.html:81
+#: src/olympia/templates/base.html:89 src/olympia/templates/impala/base.html:78
 msgid "Find add-ons for other applications"
 msgstr ""
 
-#: src/olympia/templates/base.html:92 src/olympia/templates/impala/base.html:81
+#: src/olympia/templates/base.html:90 src/olympia/templates/impala/base.html:78
 msgid "Other Applications"
 msgstr ""
 
@@ -11345,7 +11178,7 @@ msgid "View Mobile Site"
 msgstr ""
 
 #: src/olympia/templates/copyright.html:7
-msgid "Site Status "
+msgid "Site Status"
 msgstr ""
 
 #: src/olympia/templates/footer.html:3
@@ -11445,35 +11278,35 @@ msgstr ""
 msgid "<a href=\"%(reg)s\">Register</a> or <a href=\"%(login)s\">Log in</a>"
 msgstr ""
 
-#: src/olympia/templates/impala/base.html:126
+#: src/olympia/templates/impala/base.html:123
 #, python-format
 msgid "To try the thousands of add-ons available here, download <a href=\"%(url)s\">Mozilla Firefox</a>, a fast, free way to surf the Web!"
 msgstr ""
 
-#: src/olympia/templates/impala/base.html:138
+#: src/olympia/templates/impala/base.html:135
 #, python-format
 msgid "Add-ons is switching to Firefox Accounts for login. <a href=\"%(url)s\" class=\"fxa-login\">Sign in now to transfer your account.</a>"
 msgstr ""
 
 #. {0} is an application, such as Firefox.
-#: src/olympia/templates/impala/base.html:148
+#: src/olympia/templates/impala/base.html:145
 msgid "Welcome to {0} Add-ons."
 msgstr ""
 
-#: src/olympia/templates/impala/base.html:151
+#: src/olympia/templates/impala/base.html:148
 msgid "Choose from thousands of extra features and styles to make Firefox your own."
 msgstr ""
 
-#: src/olympia/templates/impala/base.html:156
+#: src/olympia/templates/impala/base.html:153
 #, python-format
 msgid "Add extra features and styles to make %(app)s your own."
 msgstr ""
 
-#: src/olympia/templates/impala/base.html:164
+#: src/olympia/templates/impala/base.html:161
 msgid "On the go?"
 msgstr ""
 
-#: src/olympia/templates/impala/base.html:166
+#: src/olympia/templates/impala/base.html:163
 msgid "Check out our <a class=\"mobile-link\" href=\"#\">Mobile Add-ons site</a>."
 msgstr ""
 
@@ -11697,19 +11530,19 @@ msgstr ""
 
 #. L10n: {id} will be something like "13ad6a", just a random number
 #. to differentiate this user from other anonymous users.
-#: src/olympia/users/models.py:353
+#: src/olympia/users/models.py:362
 msgid "Anonymous user {id}"
 msgstr ""
 
-#: src/olympia/users/models.py:410
+#: src/olympia/users/models.py:419
 msgid "Your account has been restricted"
 msgstr ""
 
-#: src/olympia/users/models.py:480
+#: src/olympia/users/models.py:489
 msgid "Please confirm your email address"
 msgstr ""
 
-#: src/olympia/users/models.py:506
+#: src/olympia/users/models.py:515
 msgid "My Mobile Add-ons"
 msgstr ""
 
@@ -11986,7 +11819,7 @@ msgstr ""
 
 #: src/olympia/users/templates/users/edit.html:70
 #, python-format
-msgid "Change your password.  If you forgot your password, you can <a href=\"%(reset_url)s\">use the reset form</a>."
+msgid "Change your password. If you forgot your password, you can <a href=\"%(reset_url)s\">use the reset form</a>."
 msgstr ""
 
 #: src/olympia/users/templates/users/edit.html:76
@@ -12006,7 +11839,7 @@ msgid "Profile"
 msgstr ""
 
 #: src/olympia/users/templates/users/edit.html:100
-msgid "Give us a bit more information about yourself.  All these fields are optional, but they'll help other users get to know you better."
+msgid "Give us a bit more information about yourself. All these fields are optional, but they'll help other users get to know you better."
 msgstr ""
 
 #: src/olympia/users/templates/users/edit.html:124
@@ -12222,7 +12055,7 @@ msgid "Confirm password"
 msgstr ""
 
 #: src/olympia/users/templates/users/pwreset_confirm.html:47
-msgid "The password reset link was invalid, possibly because it has already been used.  Please request a new password reset."
+msgid "The password reset link was invalid, possibly because it has already been used. Please request a new password reset."
 msgstr ""
 
 #: src/olympia/users/templates/users/pwreset_request.html:15
@@ -12408,7 +12241,7 @@ msgstr ""
 
 #: src/olympia/users/templates/users/unsubscribe.html:30
 #, python-format
-msgid "Unfortunately, we weren't able to unsubscribe you.  The link you clicked is invalid. However, you can unsubscribe still unsubscribe on your <a href=\"%(edit_url)s\">edit profile page</a>."
+msgid "Unfortunately, we weren't able to unsubscribe you. The link you clicked is invalid. However, you can unsubscribe still unsubscribe on your <a href=\"%(edit_url)s\">edit profile page</a>."
 msgstr ""
 
 #: src/olympia/users/templates/users/vcard.html:2
@@ -12462,15 +12295,15 @@ msgstr ""
 msgid "Version History with Changelogs"
 msgstr ""
 
-#: src/olympia/versions/models.py:314
+#: src/olympia/versions/models.py:313
 msgid "Add-on uses binary components."
 msgstr ""
 
-#: src/olympia/versions/models.py:317
+#: src/olympia/versions/models.py:316
 msgid "Add-on has opted into strict compatibility checking."
 msgstr ""
 
-#: src/olympia/versions/models.py:715
+#: src/olympia/versions/models.py:711
 msgid "{app} {min} and later"
 msgstr ""
 
@@ -12545,4 +12378,8 @@ msgstr ""
 
 #: src/olympia/zadmin/forms.py:105
 msgid "Log emails instead of sending"
+msgstr ""
+
+#: src/olympia/zadmin/forms.py:215
+msgid "Deleted versions can`t be changed."
 msgstr ""

--- a/locale/or/LC_MESSAGES/djangojs.po
+++ b/locale/or/LC_MESSAGES/djangojs.po
@@ -1,1216 +1,1236 @@
-
 #, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2016-02-24 21:23+0000\n"
+"POT-Creation-Date: 2016-04-18 15:47+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
+"Language: \n"
 "MIME-Version: 1.0\n"
-"Content-Type: text/plain; charset=utf-8\n"
+"Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Generated-By: Babel 2.2.0\n"
 
-#: static/js/common/ratingwidget.js:31
+#: static/js/common-all.js:1426 static/js/impala-all.js:1511 static/js/zamboni/discovery-all.js:12598 static/js/zamboni/init.js:28 static/js/zamboni/mobile-all.js:14945
+msgid "This feature is temporarily disabled while we perform website maintenance. Please check back a little later."
+msgstr ""
+
+#. L10n: {0} is an app name like Firefox.
+#: static/js/common-all.js:1837 static/js/impala-all.js:1922 static/js/zamboni/buttons.js:73 static/js/zamboni/discovery-all.js:13108
+msgid "Accept and Install"
+msgstr ""
+
+#: static/js/common-all.js:1837 static/js/impala-all.js:1922 static/js/zamboni/buttons.js:73 static/js/zamboni/discovery-all.js:13108
+msgid "Add to {0}"
+msgstr ""
+
+#: static/js/common-all.js:1842 static/js/impala-all.js:1927 static/js/zamboni/buttons.js:78 static/js/zamboni/discovery-all.js:13113
+msgid "Download Now"
+msgstr ""
+
+#: static/js/common-all.js:1883 static/js/impala-all.js:1968 static/js/zamboni/buttons.js:119 static/js/zamboni/discovery-all.js:13154
+msgid "Add-on has not been updated to support default-to-compatible."
+msgstr ""
+
+#: static/js/common-all.js:1888 static/js/impala-all.js:1973 static/js/zamboni/buttons.js:124 static/js/zamboni/discovery-all.js:13159
+msgid "You need to be using Firefox 10.0 or higher."
+msgstr ""
+
+#: static/js/common-all.js:1900 static/js/impala-all.js:1985 static/js/zamboni/buttons.js:136 static/js/zamboni/discovery-all.js:13171
+msgid "Mozilla has marked this version as incompatible with your Firefox version."
+msgstr ""
+
+#. L10n: {0} is an platform like Windows or Linux.
+#: static/js/common-all.js:1981 static/js/impala-all.js:2066 static/js/zamboni/buttons.js:217 static/js/zamboni/discovery-all.js:13252
+msgid "Install for {0} anyway"
+msgstr ""
+
+#: static/js/common-all.js:1981 static/js/impala-all.js:2066 static/js/zamboni/buttons.js:217 static/js/zamboni/discovery-all.js:13252
+msgid "Download for {0} anyway"
+msgstr ""
+
+#: static/js/common-all.js:2038 static/js/impala-all.js:2123 static/js/zamboni/buttons.js:274 static/js/zamboni/discovery-all.js:13309
+msgid "Not available for your platform"
+msgstr ""
+
+#. L10n: {0} is an app name, {1} is the app version.
+#: static/js/common-all.js:2049 static/js/common-all.js:2086 static/js/impala-all.js:2134 static/js/impala-all.js:2171 static/js/zamboni/buttons.js:286 static/js/zamboni/buttons.js:324
+#: static/js/zamboni/discovery-all.js:13320 static/js/zamboni/discovery-all.js:13357
+msgid "Not available for {0} {1}"
+msgstr ""
+
+#: static/js/common-all.js:2112 static/js/impala-all.js:2197 static/js/zamboni/buttons.js:351 static/js/zamboni/discovery-all.js:13383
+msgid "Works with {app} {min} - {max}"
+msgstr ""
+
+#: static/js/common-all.js:2114 static/js/impala-all.js:2199 static/js/zamboni/buttons.js:353 static/js/zamboni/discovery-all.js:13385
+msgid "View other versions"
+msgstr ""
+
+#: static/js/common-all.js:2162 static/js/impala-all.js:2247 static/js/zamboni/buttons.js:401 static/js/zamboni/discovery-all.js:13433
+msgid "Only with Firefox — Get Firefox Now!"
+msgstr ""
+
+#: static/js/common-all.js:2278 static/js/impala-all.js:2363 static/js/zamboni/buttons.js:517 static/js/zamboni/discovery-all.js:13549 static/js/zamboni/mobile-all.js:15177
+#: static/js/zamboni/mobile/buttons.js:43
+msgid "Sorry, you need a Mozilla-based browser (such as Firefox) to install a search plugin."
+msgstr ""
+
+#: static/js/common-all.js:9088 static/js/impala-all.js:9649 static/js/zamboni/global.js:410
+msgid "Loading..."
+msgstr ""
+
+#. L10n: {0} is the number of characters left.
+#: static/js/common-all.js:9152 static/js/impala-all.js:9713 static/js/zamboni/global.js:474
+msgid "<b>{0}</b> character left."
+msgid_plural "<b>{0}</b> characters left."
+msgstr[0] ""
+msgstr[1] ""
+
+#: static/js/common-all.js:9589 static/js/common-min.js:6 static/js/impala-all.js:10052 static/js/impala-min.js:6 static/js/common/ratingwidget.js:31 static/js/zamboni/mobile-all.js:16123
+#: static/js/zamboni/mobile-min.js:6
 msgid "{0} star"
 msgid_plural "{0} stars"
 msgstr[0] ""
 msgstr[1] ""
 
-#: static/js/common/upload-addon.js:41 static/js/common/upload-image.js:128
+#: static/js/common-all.js:9676 static/js/common-min.js:6 static/js/impala-all.js:10139 static/js/impala-min.js:6 static/js/zamboni/l10n.js:45
+msgid "Remove this localization"
+msgstr ""
+
+#: static/js/common-all.js:10193 static/js/common-min.js:6 static/js/impala-all.js:10674 static/js/impala-min.js:6 static/js/zamboni/discovery-all.js:13678
+msgid "close"
+msgstr ""
+
+#: static/js/common-all.js:10860 static/js/common-min.js:6 static/js/impala-all.js:11481 static/js/impala-min.js:6 static/js/impala/reviews.js:23 static/js/zamboni/reviews.js:18
+msgid "Flagged for review"
+msgstr ""
+
+#: static/js/common-all.js:10876 static/js/common-min.js:6 static/js/impala-all.js:11498 static/js/impala-min.js:6 static/js/impala/reviews.js:40 static/js/zamboni/reviews.js:34
+msgid "Your input is required"
+msgstr ""
+
+#: static/js/common-all.js:10945 static/js/common-min.js:6 static/js/impala-all.js:11610 static/js/impala-min.js:7 static/js/impala/reviews.js:152 static/js/zamboni/reviews.js:103
+msgid "Marked for deletion"
+msgstr ""
+
+#: static/js/common-all.js:11573 static/js/common-min.js:7 static/js/impala-all.js:13809 static/js/impala-min.js:8 static/js/zamboni/collections.js:229
+msgid "Adding to Favorites&hellip;"
+msgstr ""
+
+#: static/js/common-all.js:11576 static/js/common-min.js:7 static/js/impala-all.js:13812 static/js/impala-min.js:8 static/js/zamboni/collections.js:232
+msgid "Removing Favorite&hellip;"
+msgstr ""
+
+#: static/js/common-all.js:11579 static/js/common-min.js:7 static/js/impala-all.js:13815 static/js/impala-min.js:8 static/js/zamboni/collections.js:235
+msgid "Add to Favorites"
+msgstr ""
+
+#: static/js/common-all.js:11582 static/js/common-min.js:7 static/js/impala-all.js:13818 static/js/impala-min.js:8 static/js/zamboni/collections.js:238
+msgid "Remove from Favorites"
+msgstr ""
+
+#: static/js/common-all.js:11647 static/js/common-min.js:7 static/js/impala-all.js:13883 static/js/impala-min.js:8 static/js/zamboni/collections.js:303
+msgid "Pending"
+msgstr ""
+
+#: static/js/common-all.js:11648 static/js/common-min.js:7 static/js/impala-all.js:13884 static/js/impala-min.js:8 static/js/zamboni/collections.js:304
+msgid "Add a comment"
+msgstr ""
+
+#: static/js/common-all.js:11648 static/js/common-min.js:7 static/js/impala-all.js:13884 static/js/impala-min.js:8 static/js/zamboni/collections.js:304
+msgid "Comment"
+msgstr ""
+
+#: static/js/common-all.js:11649 static/js/common-min.js:7 static/js/impala-all.js:13885 static/js/impala-min.js:8 static/js/zamboni/collections.js:305
+msgid "Remove this add-on from the collection"
+msgstr ""
+
+#: static/js/common-all.js:11649 static/js/common-all.js:11678 static/js/common-min.js:7 static/js/impala-all.js:13885 static/js/impala-all.js:13914 static/js/impala-min.js:8
+#: static/js/zamboni/collections.js:305 static/js/zamboni/collections.js:334
+msgid "Remove"
+msgstr ""
+
+#: static/js/common-all.js:11678 static/js/common-min.js:7 static/js/impala-all.js:13914 static/js/impala-min.js:8 static/js/zamboni/collections.js:334
+msgid "Remove this user as a contributor"
+msgstr ""
+
+#: static/js/common-all.js:11690 static/js/common-min.js:7 static/js/impala-all.js:13926 static/js/impala-min.js:8 static/js/zamboni/collections.js:346
+msgid "An email address is required."
+msgstr ""
+
+#: static/js/common-all.js:11708 static/js/common-min.js:7 static/js/impala-all.js:13944 static/js/impala-min.js:8 static/js/zamboni/collections.js:364
+msgid "You cannot add yourself as a contributor."
+msgstr ""
+
+#: static/js/common-all.js:11710 static/js/common-min.js:7 static/js/impala-all.js:13946 static/js/impala-min.js:8 static/js/zamboni/collections.js:366
+msgid "You have already added that user."
+msgstr ""
+
+#: static/js/common-all.js:11917 static/js/common-min.js:7 static/js/impala-all.js:14153 static/js/impala-min.js:8 static/js/zamboni/collections.js:573
+msgid "Add to favorites"
+msgstr ""
+
+#: static/js/common-all.js:11921 static/js/common-min.js:7 static/js/impala-all.js:14157 static/js/impala-min.js:8 static/js/zamboni/collections.js:577
+msgid "Remove from favorites"
+msgstr ""
+
+#: static/js/common-all.js:11939 static/js/common-min.js:7 static/js/impala-all.js:14175 static/js/impala-all.js:14233 static/js/impala-min.js:8 static/js/impala/collections.js:10
+#: static/js/zamboni/collections.js:595
+msgid "Follow this Collection"
+msgstr ""
+
+#: static/js/common-all.js:11948 static/js/common-min.js:7 static/js/impala-all.js:14184 static/js/impala-min.js:8 static/js/zamboni/collections.js:604
+msgid "Stop following"
+msgstr ""
+
+#: static/js/common-all.js:12096 static/js/common-min.js:7 static/js/zamboni/password-strength.js:20
+msgid "Password strength:"
+msgstr ""
+
+#: static/js/common-all.js:12102 static/js/common-min.js:7 static/js/zamboni/password-strength.js:26
+msgid "At least {0} character left."
+msgid_plural "At least {0} characters left."
+msgstr[0] ""
+msgstr[1] ""
+
+#: static/js/common-all.js:12286 static/js/common-min.js:7 static/js/impala-all.js:14632 static/js/impala-min.js:8 static/js/impala/suggestions.js:39
+msgid "Search themes for <b>{0}</b>"
+msgstr ""
+
+#: static/js/common-all.js:12288 static/js/common-min.js:7 static/js/impala-all.js:14634 static/js/impala-min.js:8 static/js/impala/suggestions.js:41
+msgid "Search apps for <b>{0}</b>"
+msgstr ""
+
+#: static/js/common-all.js:12290 static/js/common-min.js:7 static/js/impala-all.js:14636 static/js/impala-min.js:8 static/js/impala/suggestions.js:43
+msgid "Search add-ons for <b>{0}</b>"
+msgstr ""
+
+#: static/js/common-all.js:12521 static/js/common-min.js:7 static/js/impala-all.js:14867 static/js/impala-min.js:8 static/js/impala/site_suggestions.js:46
+msgid "Category"
+msgstr ""
+
+#. L10n: {0} is an app name.
+#: static/js/impala-all.js:11632 static/js/impala-min.js:7 static/js/impala/listing.js:11 static/js/zamboni/themes.js:13
+msgid "This theme is incompatible with your version of {0}"
+msgstr ""
+
+#: static/js/impala-all.js:12146 static/js/impala-all.js:14331 static/js/impala-min.js:7 static/js/impala-min.js:8 static/js/common/upload-image.js:97 static/js/impala/users.js:51
+#: static/js/zamboni/devhub-all.js:894 static/js/zamboni/devhub-min.js:1
+msgid "Images must be either PNG or JPG."
+msgstr ""
+
+#: static/js/impala-all.js:12150 static/js/impala-min.js:7 static/js/common/upload-image.js:101 static/js/zamboni/devhub-all.js:898 static/js/zamboni/devhub-min.js:1
+msgid "Videos must be in WebM."
+msgstr ""
+
+#: static/js/impala-all.js:12177 static/js/impala-min.js:7 static/js/common/upload-addon.js:41 static/js/common/upload-image.js:128 static/js/zamboni/devhub-all.js:272
+#: static/js/zamboni/devhub-all.js:925 static/js/zamboni/devhub-min.js:1
 msgid "There was a problem contacting the server."
 msgstr ""
 
-#: static/js/common/upload-addon.js:69
+#: static/js/impala-all.js:13298 static/js/impala-min.js:7 static/js/impala/persona_creation.js:60
+msgid "All Rights Reserved"
+msgstr ""
+
+#: static/js/impala-all.js:13302 static/js/impala-min.js:7 static/js/impala/persona_creation.js:64
+msgid "Creative Commons Attribution 3.0"
+msgstr ""
+
+#: static/js/impala-all.js:13307 static/js/impala-min.js:7 static/js/impala/persona_creation.js:69
+msgid "Creative Commons Attribution-NonCommercial 3.0"
+msgstr ""
+
+#: static/js/impala-all.js:13312 static/js/impala-min.js:7 static/js/impala/persona_creation.js:74
+msgid "Creative Commons Attribution-NonCommercial-NoDerivs 3.0"
+msgstr ""
+
+#: static/js/impala-all.js:13317 static/js/impala-min.js:7 static/js/impala/persona_creation.js:79
+msgid "Creative Commons Attribution-NonCommercial-Share Alike 3.0"
+msgstr ""
+
+#: static/js/impala-all.js:13322 static/js/impala-min.js:7 static/js/impala/persona_creation.js:84
+msgid "Creative Commons Attribution-NoDerivs 3.0"
+msgstr ""
+
+#: static/js/impala-all.js:13327 static/js/impala-min.js:7 static/js/impala/persona_creation.js:89
+msgid "Creative Commons Attribution-ShareAlike 3.0"
+msgstr ""
+
+#: static/js/impala-all.js:13530 static/js/impala-min.js:7 static/js/impala/persona_creation.js:292
+msgid "Your Theme's Name"
+msgstr ""
+
+#: static/js/impala-all.js:14242 static/js/impala-min.js:8 static/js/impala/collections.js:19
+msgid "Stop Following"
+msgstr ""
+
+#: static/js/impala-all.js:14243 static/js/impala-min.js:8 static/js/impala/collections.js:20
+msgid "Following"
+msgstr ""
+
+#: static/js/impala-all.js:14313 static/js/impala-min.js:8 static/js/impala/users.js:33
+msgid "use original"
+msgstr ""
+
+#: static/js/impala-all.js:14523 static/js/impala-min.js:8 static/js/impala/search.js:114
+msgid "Updating results&hellip;"
+msgstr ""
+
+#: static/js/common/upload-addon.js:69 static/js/zamboni/devhub-all.js:300 static/js/zamboni/devhub-min.js:1
 msgid "Select a file..."
 msgstr ""
 
-#: static/js/common/upload-addon.js:70
+#: static/js/common/upload-addon.js:70 static/js/zamboni/devhub-all.js:301 static/js/zamboni/devhub-min.js:1
 msgid "Your add-on should end with .xpi, .jar or .xml"
 msgstr ""
 
 #. L10n: {0} is the percent of the file that has been uploaded.
-#: static/js/common/upload-addon.js:104
+#: static/js/common/upload-addon.js:104 static/js/zamboni/devhub-all.js:335 static/js/zamboni/devhub-min.js:1
 #, python-format
 msgid "{0}% complete"
 msgstr ""
 
 #. L10n: "{bytes uploaded} of {total filesize}".
-#: static/js/common/upload-addon.js:107
+#: static/js/common/upload-addon.js:107 static/js/zamboni/devhub-all.js:338 static/js/zamboni/devhub-min.js:1
 msgid "{0} of {1}"
 msgstr ""
 
-#: static/js/common/upload-addon.js:140
+#: static/js/common/upload-addon.js:140 static/js/zamboni/devhub-all.js:371 static/js/zamboni/devhub-min.js:1
 msgid "Cancel"
 msgstr ""
 
-#: static/js/common/upload-addon.js:162
+#: static/js/common/upload-addon.js:162 static/js/zamboni/devhub-all.js:393 static/js/zamboni/devhub-min.js:1
 msgid "Uploading {0}"
 msgstr ""
 
-#: static/js/common/upload-addon.js:189
+#: static/js/common/upload-addon.js:189 static/js/zamboni/devhub-all.js:420 static/js/zamboni/devhub-min.js:1
 msgid "Error with {0}"
 msgstr ""
 
-#: static/js/common/upload-addon.js:194
+#: static/js/common/upload-addon.js:194 static/js/zamboni/devhub-all.js:425 static/js/zamboni/devhub-min.js:1
 msgid "Your add-on failed validation with {0} error."
 msgid_plural "Your add-on failed validation with {0} errors."
 msgstr[0] ""
 msgstr[1] ""
 
-#: static/js/common/upload-addon.js:208
+#: static/js/common/upload-addon.js:208 static/js/zamboni/devhub-all.js:439 static/js/zamboni/devhub-min.js:1
 msgid "&hellip;and {0} more"
 msgid_plural "&hellip;and {0} more"
 msgstr[0] ""
 msgstr[1] ""
 
-#: static/js/common/upload-addon.js:222 static/js/common/upload-addon.js:512
+#: static/js/common/upload-addon.js:222 static/js/common/upload-addon.js:497 static/js/zamboni/devhub-all.js:453 static/js/zamboni/devhub-all.js:743 static/js/zamboni/devhub-min.js:1
 msgid "See full validation report"
 msgstr ""
 
-#: static/js/common/upload-addon.js:234
+#: static/js/common/upload-addon.js:234 static/js/zamboni/devhub-all.js:465 static/js/zamboni/devhub-min.js:1
 msgid "Validating {0}"
 msgstr ""
 
 #. L10n: first argument is an HTTP status code
-#: static/js/common/upload-addon.js:273
+#: static/js/common/upload-addon.js:273 static/js/zamboni/devhub-all.js:504 static/js/zamboni/devhub-min.js:1
 msgid "Received an empty response from the server; status: {0}"
 msgstr ""
 
-#: static/js/common/upload-addon.js:373
+#: static/js/common/upload-addon.js:370 static/js/zamboni/devhub-all.js:604 static/js/zamboni/devhub-min.js:1
 msgid "Unexpected server error while validating."
 msgstr ""
 
-#: static/js/common/upload-addon.js:412
+#: static/js/common/upload-addon.js:409 static/js/zamboni/devhub-all.js:643 static/js/zamboni/devhub-min.js:1
 msgid "Finished validating {0}"
 msgstr ""
 
-#: static/js/common/upload-addon.js:418
+#: static/js/common/upload-addon.js:415 static/js/zamboni/devhub-all.js:649 static/js/zamboni/devhub-min.js:1
 msgid "Your add-on validation timed out, it will be manually reviewed."
 msgstr ""
 
-#: static/js/common/upload-addon.js:421
+#: static/js/common/upload-addon.js:418 static/js/zamboni/devhub-all.js:652 static/js/zamboni/devhub-min.js:1
 msgid "Your add-on was validated with no errors and {0} warning."
 msgid_plural "Your add-on was validated with no errors and {0} warnings."
 msgstr[0] ""
 msgstr[1] ""
 
-#: static/js/common/upload-addon.js:426
+#: static/js/common/upload-addon.js:423 static/js/zamboni/devhub-all.js:657 static/js/zamboni/devhub-min.js:1
 msgid "Your add-on was validated with no errors and {0} message."
 msgid_plural "Your add-on was validated with no errors and {0} messages."
 msgstr[0] ""
 msgstr[1] ""
 
-#: static/js/common/upload-addon.js:431
+#: static/js/common/upload-addon.js:428 static/js/zamboni/devhub-all.js:662 static/js/zamboni/devhub-min.js:1
 msgid "Your add-on was validated with no errors or warnings."
 msgstr ""
 
-#: static/js/common/upload-addon.js:446
+#: static/js/common/upload-addon.js:443 static/js/zamboni/devhub-all.js:677 static/js/zamboni/devhub-min.js:1
 msgid "Your submission will be automatically signed."
 msgstr ""
 
-#: static/js/common/upload-addon.js:465
+#: static/js/common/upload-addon.js:450 static/js/zamboni/devhub-all.js:696 static/js/zamboni/devhub-min.js:1
 msgid "Include detailed version notes (this can be done in the next step)."
 msgstr ""
 
-#: static/js/common/upload-addon.js:466
+#: static/js/common/upload-addon.js:451 static/js/zamboni/devhub-all.js:697 static/js/zamboni/devhub-min.js:1
 msgid "If your add-on requires an account to a website in order to be fully tested, include a test username and password in the Notes to Reviewer (this can be done in the next step)."
 msgstr ""
 
-#: static/js/common/upload-addon.js:467
+#: static/js/common/upload-addon.js:452 static/js/zamboni/devhub-all.js:698 static/js/zamboni/devhub-min.js:1
 msgid "If your add-on is intended for a limited audience you should choose Preliminary Review instead of Full Review."
 msgstr ""
 
-#: static/js/common/upload-addon.js:480
+#: static/js/common/upload-addon.js:465 static/js/zamboni/devhub-all.js:711 static/js/zamboni/devhub-min.js:1
 msgid "Add-on submission checklist"
 msgstr ""
 
-#: static/js/common/upload-addon.js:481
+#: static/js/common/upload-addon.js:466 static/js/zamboni/devhub-all.js:712 static/js/zamboni/devhub-min.js:1
 msgid "Please verify the following points before finalizing your submission. This will minimize delays or misunderstanding during the review process:"
 msgstr ""
 
-#: static/js/common/upload-addon.js:483
+#: static/js/common/upload-addon.js:468 static/js/zamboni/devhub-all.js:714 static/js/zamboni/devhub-min.js:1
 msgid ""
 "Compiled binaries, as well as minified or obfuscated scripts (excluding known libraries) need to have their sources submitted separately for review. Make sure that you use the source code upload "
 "field to avoid having your submission rejected."
 msgstr ""
 
-#: static/js/common/upload-addon.js:501
+#: static/js/common/upload-addon.js:486 static/js/zamboni/devhub-all.js:732 static/js/zamboni/devhub-min.js:1
 msgid "The validation process found these issues that can lead to rejections:"
 msgstr ""
 
-#: static/js/common/upload-addon.js:518
+#: static/js/common/upload-addon.js:503 static/js/zamboni/devhub-all.js:749 static/js/zamboni/devhub-min.js:1
 msgid "If you are unfamiliar with the add-ons review process, you can read about it here."
 msgstr ""
 
-#: static/js/common/upload-addon.js:555
+#: static/js/common/upload-addon.js:540 static/js/zamboni/devhub-all.js:786 static/js/zamboni/devhub-min.js:1
 msgid "Sorry, no supported platform has been found."
 msgstr ""
 
-#: static/js/common/upload-base.js:57
+#: static/js/common/upload-base.js:57 static/js/zamboni/devhub-all.js:187 static/js/zamboni/devhub-min.js:1
 msgid "The filetype you uploaded isn't recognized."
 msgstr ""
 
-#: static/js/common/upload-base.js:79
+#: static/js/common/upload-base.js:79 static/js/zamboni/devhub-all.js:209 static/js/zamboni/devhub-min.js:1
 msgid "You cancelled the upload."
 msgstr ""
 
-#: static/js/common/upload-image.js:97 static/js/impala/users.js:51
-msgid "Images must be either PNG or JPG."
-msgstr ""
-
-#: static/js/common/upload-image.js:101
-msgid "Videos must be in WebM."
-msgstr ""
-
-#: static/js/impala/collections.js:10 static/js/zamboni/collections.js:595
-msgid "Follow this Collection"
-msgstr ""
-
-#: static/js/impala/collections.js:19
-msgid "Stop Following"
-msgstr ""
-
-#: static/js/impala/collections.js:20
-msgid "Following"
-msgstr ""
-
-#. L10n: {0} is an app name.
-#: static/js/impala/listing.js:11 static/js/zamboni/themes.js:13
-msgid "This theme is incompatible with your version of {0}"
-msgstr ""
-
-#: static/js/impala/persona_creation.js:60
-msgid "All Rights Reserved"
-msgstr ""
-
-#: static/js/impala/persona_creation.js:64
-msgid "Creative Commons Attribution 3.0"
-msgstr ""
-
-#: static/js/impala/persona_creation.js:69
-msgid "Creative Commons Attribution-NonCommercial 3.0"
-msgstr ""
-
-#: static/js/impala/persona_creation.js:74
-msgid "Creative Commons Attribution-NonCommercial-NoDerivs 3.0"
-msgstr ""
-
-#: static/js/impala/persona_creation.js:79
-msgid "Creative Commons Attribution-NonCommercial-Share Alike 3.0"
-msgstr ""
-
-#: static/js/impala/persona_creation.js:84
-msgid "Creative Commons Attribution-NoDerivs 3.0"
-msgstr ""
-
-#: static/js/impala/persona_creation.js:89
-msgid "Creative Commons Attribution-ShareAlike 3.0"
-msgstr ""
-
-#: static/js/impala/persona_creation.js:292
-msgid "Your Theme's Name"
-msgstr ""
-
-#: static/js/impala/reviews.js:23 static/js/zamboni/reviews.js:18
-msgid "Flagged for review"
-msgstr ""
-
-#: static/js/impala/reviews.js:40 static/js/zamboni/reviews.js:34
-msgid "Your input is required"
-msgstr ""
-
-#: static/js/impala/reviews.js:152 static/js/zamboni/reviews.js:103
-msgid "Marked for deletion"
-msgstr ""
-
-#: static/js/impala/search.js:114
-msgid "Updating results&hellip;"
-msgstr ""
-
-#: static/js/impala/site_suggestions.js:46
-msgid "Category"
-msgstr ""
-
-#: static/js/impala/suggestions.js:39
-msgid "Search themes for <b>{0}</b>"
-msgstr ""
-
-#: static/js/impala/suggestions.js:41
-msgid "Search apps for <b>{0}</b>"
-msgstr ""
-
-#: static/js/impala/suggestions.js:43
-msgid "Search add-ons for <b>{0}</b>"
-msgstr ""
-
-#: static/js/impala/users.js:33
-msgid "use original"
-msgstr ""
-
-#: static/js/impala/stats/chart.js:267
+#: static/js/impala/stats/chart.js:267 static/js/zamboni/stats-all.js:16898 static/js/zamboni/stats-min.js:5
 msgid "Week of {0}"
 msgstr ""
 
-#: static/js/impala/stats/chart.js:269
+#: static/js/impala/stats/chart.js:269 static/js/zamboni/stats-all.js:16900 static/js/zamboni/stats-min.js:5
 msgid " downloads"
 msgstr ""
 
-#: static/js/impala/stats/chart.js:270
+#: static/js/impala/stats/chart.js:270 static/js/zamboni/stats-all.js:16901 static/js/zamboni/stats-min.js:5
 msgid "{0} users"
 msgstr ""
 
-#: static/js/impala/stats/chart.js:271
+#: static/js/impala/stats/chart.js:271 static/js/zamboni/stats-all.js:16902 static/js/zamboni/stats-min.js:5
 msgid "{0} add-ons"
 msgstr ""
 
-#: static/js/impala/stats/chart.js:272
+#: static/js/impala/stats/chart.js:272 static/js/zamboni/stats-all.js:16903 static/js/zamboni/stats-min.js:5
 msgid "{0} collections"
 msgstr ""
 
-#: static/js/impala/stats/chart.js:273
+#: static/js/impala/stats/chart.js:273 static/js/zamboni/stats-all.js:16904 static/js/zamboni/stats-min.js:5
 msgid "{0} reviews"
 msgstr ""
 
-#: static/js/impala/stats/chart.js:275
+#: static/js/impala/stats/chart.js:275 static/js/zamboni/stats-all.js:16906 static/js/zamboni/stats-min.js:5
 msgid "{0} sales"
 msgstr ""
 
-#: static/js/impala/stats/chart.js:276
+#: static/js/impala/stats/chart.js:276 static/js/zamboni/stats-all.js:16907 static/js/zamboni/stats-min.js:5
 msgid "{0} refunds"
 msgstr ""
 
-#: static/js/impala/stats/chart.js:277
+#: static/js/impala/stats/chart.js:277 static/js/zamboni/stats-all.js:16908 static/js/zamboni/stats-min.js:5
 msgid "{0} installs"
 msgstr ""
 
-#: static/js/impala/stats/chart.js:369 static/js/impala/stats/csv_keys.js:3 static/js/impala/stats/csv_keys.js:109
+#: static/js/impala/stats/chart.js:369 static/js/impala/stats/csv_keys.js:3 static/js/impala/stats/csv_keys.js:109 static/js/zamboni/stats-all.js:15284 static/js/zamboni/stats-all.js:15390
+#: static/js/zamboni/stats-all.js:17000 static/js/zamboni/stats-min.js:4 static/js/zamboni/stats-min.js:5
 msgid "Downloads"
 msgstr ""
 
-#: static/js/impala/stats/chart.js:379 static/js/impala/stats/csv_keys.js:6 static/js/impala/stats/csv_keys.js:110
+#: static/js/impala/stats/chart.js:379 static/js/impala/stats/csv_keys.js:6 static/js/impala/stats/csv_keys.js:110 static/js/zamboni/stats-all.js:15287 static/js/zamboni/stats-all.js:15391
+#: static/js/zamboni/stats-all.js:17010 static/js/zamboni/stats-min.js:4 static/js/zamboni/stats-min.js:5
 msgid "Daily Users"
 msgstr ""
 
-#: static/js/impala/stats/chart.js:410
+#: static/js/impala/stats/chart.js:410 static/js/zamboni/stats-all.js:17041 static/js/zamboni/stats-min.js:5
 msgid "Amount, in USD"
 msgstr ""
 
-#: static/js/impala/stats/chart.js:421 static/js/impala/stats/csv_keys.js:104
+#: static/js/impala/stats/chart.js:421 static/js/impala/stats/csv_keys.js:104 static/js/zamboni/stats-all.js:15385 static/js/zamboni/stats-all.js:17052 static/js/zamboni/stats-min.js:5
 msgid "Number of Contributions"
 msgstr ""
 
-#: static/js/impala/stats/chart.js:447
+#: static/js/impala/stats/chart.js:447 static/js/zamboni/stats-all.js:17078 static/js/zamboni/stats-min.js:5
 msgid "More Info..."
 msgstr ""
 
 #. L10n: {0} is an ISO-formatted date.
-#: static/js/impala/stats/chart.js:451
+#: static/js/impala/stats/chart.js:451 static/js/zamboni/stats-all.js:17082 static/js/zamboni/stats-min.js:5
 msgid "Details for {0}"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:9
+#: static/js/impala/stats/csv_keys.js:9 static/js/zamboni/stats-all.js:15290 static/js/zamboni/stats-min.js:4
 msgid "Collections Created"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:12
+#: static/js/impala/stats/csv_keys.js:12 static/js/zamboni/stats-all.js:15293 static/js/zamboni/stats-min.js:4
 msgid "Add-ons in Use"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:15
+#: static/js/impala/stats/csv_keys.js:15 static/js/zamboni/stats-all.js:15296 static/js/zamboni/stats-min.js:4
 msgid "Add-ons Created"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:18
+#: static/js/impala/stats/csv_keys.js:18 static/js/zamboni/stats-all.js:15299 static/js/zamboni/stats-min.js:4
 msgid "Add-ons Downloaded"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:21
+#: static/js/impala/stats/csv_keys.js:21 static/js/zamboni/stats-all.js:15302 static/js/zamboni/stats-min.js:4
 msgid "Add-ons Updated"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:24
+#: static/js/impala/stats/csv_keys.js:24 static/js/zamboni/stats-all.js:15305 static/js/zamboni/stats-min.js:4
 msgid "Reviews Written"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:27
+#: static/js/impala/stats/csv_keys.js:27 static/js/zamboni/stats-all.js:15308 static/js/zamboni/stats-min.js:4
 msgid "User Signups"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:30
+#: static/js/impala/stats/csv_keys.js:30 static/js/zamboni/stats-all.js:15311 static/js/zamboni/stats-min.js:4
 msgid "Subscribers"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:33
+#: static/js/impala/stats/csv_keys.js:33 static/js/zamboni/stats-all.js:15314 static/js/zamboni/stats-min.js:4
 msgid "Ratings"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:36 static/js/impala/stats/csv_keys.js:114
+#: static/js/impala/stats/csv_keys.js:36 static/js/impala/stats/csv_keys.js:114 static/js/zamboni/stats-all.js:15317 static/js/zamboni/stats-all.js:15395 static/js/zamboni/stats-min.js:4
+#: static/js/zamboni/stats-min.js:5
 msgid "Sales"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:39 static/js/impala/stats/csv_keys.js:113
+#: static/js/impala/stats/csv_keys.js:39 static/js/impala/stats/csv_keys.js:113 static/js/zamboni/stats-all.js:15320 static/js/zamboni/stats-all.js:15394 static/js/zamboni/stats-min.js:4
+#: static/js/zamboni/stats-min.js:5
 msgid "Installs"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:42
+#: static/js/impala/stats/csv_keys.js:42 static/js/zamboni/stats-all.js:15323 static/js/zamboni/stats-min.js:4
 msgid "Unknown"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:43
+#: static/js/impala/stats/csv_keys.js:43 static/js/zamboni/stats-all.js:15324 static/js/zamboni/stats-min.js:4
 msgid "Add-ons Manager"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:44
+#: static/js/impala/stats/csv_keys.js:44 static/js/zamboni/stats-all.js:15325 static/js/zamboni/stats-min.js:4
 msgid "Add-ons Manager Promo"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:45
+#: static/js/impala/stats/csv_keys.js:45 static/js/zamboni/stats-all.js:15326 static/js/zamboni/stats-min.js:4
 msgid "Add-ons Manager Featured"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:46
+#: static/js/impala/stats/csv_keys.js:46 static/js/zamboni/stats-all.js:15327 static/js/zamboni/stats-min.js:4
 msgid "Add-ons Manager Learn More"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:47
+#: static/js/impala/stats/csv_keys.js:47 static/js/zamboni/stats-all.js:15328 static/js/zamboni/stats-min.js:4
 msgid "Search Suggestions"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:48
+#: static/js/impala/stats/csv_keys.js:48 static/js/zamboni/stats-all.js:15329 static/js/zamboni/stats-min.js:4
 msgid "Search Results"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:49 static/js/impala/stats/csv_keys.js:50 static/js/impala/stats/csv_keys.js:51
+#: static/js/impala/stats/csv_keys.js:49 static/js/impala/stats/csv_keys.js:50 static/js/impala/stats/csv_keys.js:51 static/js/zamboni/stats-all.js:15330 static/js/zamboni/stats-all.js:15331
+#: static/js/zamboni/stats-all.js:15332 static/js/zamboni/stats-min.js:4
 msgid "Homepage Promo"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:52 static/js/impala/stats/csv_keys.js:53
+#: static/js/impala/stats/csv_keys.js:52 static/js/impala/stats/csv_keys.js:53 static/js/zamboni/stats-all.js:15333 static/js/zamboni/stats-all.js:15334 static/js/zamboni/stats-min.js:4
 msgid "Homepage Featured"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:54 static/js/impala/stats/csv_keys.js:55
+#: static/js/impala/stats/csv_keys.js:54 static/js/impala/stats/csv_keys.js:55 static/js/zamboni/stats-all.js:15335 static/js/zamboni/stats-all.js:15336 static/js/zamboni/stats-min.js:4
 msgid "Homepage Up and Coming"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:56
+#: static/js/impala/stats/csv_keys.js:56 static/js/zamboni/stats-all.js:15337 static/js/zamboni/stats-min.js:4
 msgid "Homepage Most Popular"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:57 static/js/impala/stats/csv_keys.js:59
+#: static/js/impala/stats/csv_keys.js:57 static/js/impala/stats/csv_keys.js:59 static/js/zamboni/stats-all.js:15338 static/js/zamboni/stats-all.js:15340 static/js/zamboni/stats-min.js:4
 msgid "Detail Page"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:58 static/js/impala/stats/csv_keys.js:60
+#: static/js/impala/stats/csv_keys.js:58 static/js/impala/stats/csv_keys.js:60 static/js/zamboni/stats-all.js:15339 static/js/zamboni/stats-all.js:15341 static/js/zamboni/stats-min.js:4
 msgid "Detail Page (bottom)"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:61
+#: static/js/impala/stats/csv_keys.js:61 static/js/zamboni/stats-all.js:15342 static/js/zamboni/stats-min.js:4
 msgid "Detail Page (Development Channel)"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:62 static/js/impala/stats/csv_keys.js:63 static/js/impala/stats/csv_keys.js:64
+#: static/js/impala/stats/csv_keys.js:62 static/js/impala/stats/csv_keys.js:63 static/js/impala/stats/csv_keys.js:64 static/js/zamboni/stats-all.js:15343 static/js/zamboni/stats-all.js:15344
+#: static/js/zamboni/stats-all.js:15345 static/js/zamboni/stats-min.js:4
 msgid "Often Used With"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:65 static/js/impala/stats/csv_keys.js:66
+#: static/js/impala/stats/csv_keys.js:65 static/js/impala/stats/csv_keys.js:66 static/js/zamboni/stats-all.js:15346 static/js/zamboni/stats-all.js:15347 static/js/zamboni/stats-min.js:4
 msgid "Others By Author"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:67 static/js/impala/stats/csv_keys.js:68
+#: static/js/impala/stats/csv_keys.js:67 static/js/impala/stats/csv_keys.js:68 static/js/zamboni/stats-all.js:15348 static/js/zamboni/stats-all.js:15349 static/js/zamboni/stats-min.js:4
 msgid "Dependencies"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:69 static/js/impala/stats/csv_keys.js:70
+#: static/js/impala/stats/csv_keys.js:69 static/js/impala/stats/csv_keys.js:70 static/js/zamboni/stats-all.js:15350 static/js/zamboni/stats-all.js:15351 static/js/zamboni/stats-min.js:4
 msgid "Upsell"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:71
+#: static/js/impala/stats/csv_keys.js:71 static/js/zamboni/stats-all.js:15352 static/js/zamboni/stats-min.js:4
 msgid "Meet the Developer"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:72
+#: static/js/impala/stats/csv_keys.js:72 static/js/zamboni/stats-all.js:15353 static/js/zamboni/stats-min.js:4
 msgid "User Profile"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:73
+#: static/js/impala/stats/csv_keys.js:73 static/js/zamboni/stats-all.js:15354 static/js/zamboni/stats-min.js:4
 msgid "Version History"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:75
+#: static/js/impala/stats/csv_keys.js:75 static/js/zamboni/stats-all.js:15356 static/js/zamboni/stats-min.js:4
 msgid "Sharing"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:76
+#: static/js/impala/stats/csv_keys.js:76 static/js/zamboni/stats-all.js:15357 static/js/zamboni/stats-min.js:4
 msgid "Category Pages"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:77
+#: static/js/impala/stats/csv_keys.js:77 static/js/zamboni/stats-all.js:15358 static/js/zamboni/stats-min.js:4
 msgid "Collections"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:78 static/js/impala/stats/csv_keys.js:79
+#: static/js/impala/stats/csv_keys.js:78 static/js/impala/stats/csv_keys.js:79 static/js/zamboni/stats-all.js:15359 static/js/zamboni/stats-all.js:15360 static/js/zamboni/stats-min.js:4
 msgid "Category Landing Featured Carousel"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:80 static/js/impala/stats/csv_keys.js:81
+#: static/js/impala/stats/csv_keys.js:80 static/js/impala/stats/csv_keys.js:81 static/js/zamboni/stats-all.js:15361 static/js/zamboni/stats-all.js:15362 static/js/zamboni/stats-min.js:4
 msgid "Category Landing Top Rated"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:82 static/js/impala/stats/csv_keys.js:83
+#: static/js/impala/stats/csv_keys.js:82 static/js/impala/stats/csv_keys.js:83 static/js/zamboni/stats-all.js:15363 static/js/zamboni/stats-all.js:15364 static/js/zamboni/stats-min.js:5
 msgid "Category Landing Most Popular"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:84 static/js/impala/stats/csv_keys.js:85
+#: static/js/impala/stats/csv_keys.js:84 static/js/impala/stats/csv_keys.js:85 static/js/zamboni/stats-all.js:15365 static/js/zamboni/stats-all.js:15366 static/js/zamboni/stats-min.js:5
 msgid "Category Landing Recently Added"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:86 static/js/impala/stats/csv_keys.js:87
+#: static/js/impala/stats/csv_keys.js:86 static/js/impala/stats/csv_keys.js:87 static/js/zamboni/stats-all.js:15367 static/js/zamboni/stats-all.js:15368 static/js/zamboni/stats-min.js:5
 msgid "Browse Listing Featured Sort"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:88 static/js/impala/stats/csv_keys.js:89
+#: static/js/impala/stats/csv_keys.js:88 static/js/impala/stats/csv_keys.js:89 static/js/zamboni/stats-all.js:15369 static/js/zamboni/stats-all.js:15370 static/js/zamboni/stats-min.js:5
 msgid "Browse Listing Users Sort"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:90 static/js/impala/stats/csv_keys.js:91
+#: static/js/impala/stats/csv_keys.js:90 static/js/impala/stats/csv_keys.js:91 static/js/zamboni/stats-all.js:15371 static/js/zamboni/stats-all.js:15372 static/js/zamboni/stats-min.js:5
 msgid "Browse Listing Rating Sort"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:92 static/js/impala/stats/csv_keys.js:93
+#: static/js/impala/stats/csv_keys.js:92 static/js/impala/stats/csv_keys.js:93 static/js/zamboni/stats-all.js:15373 static/js/zamboni/stats-all.js:15374 static/js/zamboni/stats-min.js:5
 msgid "Browse Listing Created Sort"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:94 static/js/impala/stats/csv_keys.js:95
+#: static/js/impala/stats/csv_keys.js:94 static/js/impala/stats/csv_keys.js:95 static/js/zamboni/stats-all.js:15375 static/js/zamboni/stats-all.js:15376 static/js/zamboni/stats-min.js:5
 msgid "Browse Listing Name Sort"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:96 static/js/impala/stats/csv_keys.js:97
+#: static/js/impala/stats/csv_keys.js:96 static/js/impala/stats/csv_keys.js:97 static/js/zamboni/stats-all.js:15377 static/js/zamboni/stats-all.js:15378 static/js/zamboni/stats-min.js:5
 msgid "Browse Listing Popular Sort"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:98 static/js/impala/stats/csv_keys.js:99
+#: static/js/impala/stats/csv_keys.js:98 static/js/impala/stats/csv_keys.js:99 static/js/zamboni/stats-all.js:15379 static/js/zamboni/stats-all.js:15380 static/js/zamboni/stats-min.js:5
 msgid "Browse Listing Updated Sort"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:100 static/js/impala/stats/csv_keys.js:101
+#: static/js/impala/stats/csv_keys.js:100 static/js/impala/stats/csv_keys.js:101 static/js/zamboni/stats-all.js:15381 static/js/zamboni/stats-all.js:15382 static/js/zamboni/stats-min.js:5
 msgid "Browse Listing Up and Coming Sort"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:105
+#: static/js/impala/stats/csv_keys.js:105 static/js/zamboni/stats-all.js:15386 static/js/zamboni/stats-min.js:5
 msgid "Total Amount Contributed"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:106
+#: static/js/impala/stats/csv_keys.js:106 static/js/zamboni/stats-all.js:15387 static/js/zamboni/stats-min.js:5
 msgid "Average Contribution"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:115
+#: static/js/impala/stats/csv_keys.js:115 static/js/zamboni/stats-all.js:15396 static/js/zamboni/stats-min.js:5
 msgid "Usage"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:118
+#: static/js/impala/stats/csv_keys.js:118 static/js/zamboni/stats-all.js:15399 static/js/zamboni/stats-min.js:5
 msgid "Firefox"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:119
+#: static/js/impala/stats/csv_keys.js:119 static/js/zamboni/stats-all.js:15400 static/js/zamboni/stats-min.js:5
 msgid "Mozilla"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:120
+#: static/js/impala/stats/csv_keys.js:120 static/js/zamboni/stats-all.js:15401 static/js/zamboni/stats-min.js:5
 msgid "Thunderbird"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:121
+#: static/js/impala/stats/csv_keys.js:121 static/js/zamboni/stats-all.js:15402 static/js/zamboni/stats-min.js:5
 msgid "Sunbird"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:122
+#: static/js/impala/stats/csv_keys.js:122 static/js/zamboni/stats-all.js:15403 static/js/zamboni/stats-min.js:5
 msgid "SeaMonkey"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:123
+#: static/js/impala/stats/csv_keys.js:123 static/js/zamboni/stats-all.js:15404 static/js/zamboni/stats-min.js:5
 msgid "Fennec"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:124
+#: static/js/impala/stats/csv_keys.js:124 static/js/zamboni/stats-all.js:15405 static/js/zamboni/stats-min.js:5
 msgid "Android"
 msgstr ""
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:129
+#: static/js/impala/stats/csv_keys.js:129 static/js/zamboni/stats-all.js:15410 static/js/zamboni/stats-min.js:5
 msgid "Downloads and Daily Users, last {0} days"
 msgstr ""
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:131
+#: static/js/impala/stats/csv_keys.js:131 static/js/zamboni/stats-all.js:15412 static/js/zamboni/stats-min.js:5
 msgid "Downloads and Daily Users from {0} to {1}"
 msgstr ""
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:135
+#: static/js/impala/stats/csv_keys.js:135 static/js/zamboni/stats-all.js:15416 static/js/zamboni/stats-min.js:5
 msgid "Installs and Daily Users, last {0} days"
 msgstr ""
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:137
+#: static/js/impala/stats/csv_keys.js:137 static/js/zamboni/stats-all.js:15418 static/js/zamboni/stats-min.js:5
 msgid "Installs and Daily Users from {0} to {1}"
 msgstr ""
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:141
+#: static/js/impala/stats/csv_keys.js:141 static/js/zamboni/stats-all.js:15422 static/js/zamboni/stats-min.js:5
 msgid "Downloads, last {0} days"
 msgstr ""
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:143
+#: static/js/impala/stats/csv_keys.js:143 static/js/zamboni/stats-all.js:15424 static/js/zamboni/stats-min.js:5
 msgid "Downloads from {0} to {1}"
 msgstr ""
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:147
+#: static/js/impala/stats/csv_keys.js:147 static/js/zamboni/stats-all.js:15428 static/js/zamboni/stats-min.js:5
 msgid "Daily Users, last {0} days"
 msgstr ""
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:149
+#: static/js/impala/stats/csv_keys.js:149 static/js/zamboni/stats-all.js:15430 static/js/zamboni/stats-min.js:5
 msgid "Daily Users from {0} to {1}"
 msgstr ""
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:153
+#: static/js/impala/stats/csv_keys.js:153 static/js/zamboni/stats-all.js:15434 static/js/zamboni/stats-min.js:5
 msgid "Applications, last {0} days"
 msgstr ""
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:155
+#: static/js/impala/stats/csv_keys.js:155 static/js/zamboni/stats-all.js:15436 static/js/zamboni/stats-min.js:5
 msgid "Applications from {0} to {1}"
 msgstr ""
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:159
+#: static/js/impala/stats/csv_keys.js:159 static/js/zamboni/stats-all.js:15440 static/js/zamboni/stats-min.js:5
 msgid "Platforms, last {0} days"
 msgstr ""
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:161
+#: static/js/impala/stats/csv_keys.js:161 static/js/zamboni/stats-all.js:15442 static/js/zamboni/stats-min.js:5
 msgid "Platforms from {0} to {1}"
 msgstr ""
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:165
+#: static/js/impala/stats/csv_keys.js:165 static/js/zamboni/stats-all.js:15446 static/js/zamboni/stats-min.js:5
 msgid "Languages, last {0} days"
 msgstr ""
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:167
+#: static/js/impala/stats/csv_keys.js:167 static/js/zamboni/stats-all.js:15448 static/js/zamboni/stats-min.js:5
 msgid "Languages from {0} to {1}"
 msgstr ""
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:171
+#: static/js/impala/stats/csv_keys.js:171 static/js/zamboni/stats-all.js:15452 static/js/zamboni/stats-min.js:5
 msgid "Add-on Versions, last {0} days"
 msgstr ""
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:173
+#: static/js/impala/stats/csv_keys.js:173 static/js/zamboni/stats-all.js:15454 static/js/zamboni/stats-min.js:5
 msgid "Add-on Versions from {0} to {1}"
 msgstr ""
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:177
+#: static/js/impala/stats/csv_keys.js:177 static/js/zamboni/stats-all.js:15458 static/js/zamboni/stats-min.js:5
 msgid "Add-on Status, last {0} days"
 msgstr ""
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:179
+#: static/js/impala/stats/csv_keys.js:179 static/js/zamboni/stats-all.js:15460 static/js/zamboni/stats-min.js:5
 msgid "Add-on Status from {0} to {1}"
 msgstr ""
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:183
+#: static/js/impala/stats/csv_keys.js:183 static/js/zamboni/stats-all.js:15464 static/js/zamboni/stats-min.js:5
 msgid "Download Sources, last {0} days"
 msgstr ""
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:185
+#: static/js/impala/stats/csv_keys.js:185 static/js/zamboni/stats-all.js:15466 static/js/zamboni/stats-min.js:5
 msgid "Download Sources from {0} to {1}"
 msgstr ""
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:189
+#: static/js/impala/stats/csv_keys.js:189 static/js/zamboni/stats-all.js:15470 static/js/zamboni/stats-min.js:5
 msgid "Contributions, last {0} days"
 msgstr ""
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:191
+#: static/js/impala/stats/csv_keys.js:191 static/js/zamboni/stats-all.js:15472 static/js/zamboni/stats-min.js:5
 msgid "Contributions from {0} to {1}"
 msgstr ""
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:195
+#: static/js/impala/stats/csv_keys.js:195 static/js/zamboni/stats-all.js:15476 static/js/zamboni/stats-min.js:5
 msgid "Site Metrics, last {0} days"
 msgstr ""
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:197
+#: static/js/impala/stats/csv_keys.js:197 static/js/zamboni/stats-all.js:15478 static/js/zamboni/stats-min.js:5
 msgid "Site Metrics from {0} to {1}"
 msgstr ""
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:201
+#: static/js/impala/stats/csv_keys.js:201 static/js/zamboni/stats-all.js:15482 static/js/zamboni/stats-min.js:5
 msgid "Add-ons in Use, last {0} days"
 msgstr ""
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:203
+#: static/js/impala/stats/csv_keys.js:203 static/js/zamboni/stats-all.js:15484 static/js/zamboni/stats-min.js:5
 msgid "Add-ons in Use from {0} to {1}"
 msgstr ""
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:207
+#: static/js/impala/stats/csv_keys.js:207 static/js/zamboni/stats-all.js:15488 static/js/zamboni/stats-min.js:5
 msgid "Add-ons Downloaded, last {0} days"
 msgstr ""
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:209
+#: static/js/impala/stats/csv_keys.js:209 static/js/zamboni/stats-all.js:15490 static/js/zamboni/stats-min.js:5
 msgid "Add-ons Downloaded from {0} to {1}"
 msgstr ""
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:213
+#: static/js/impala/stats/csv_keys.js:213 static/js/zamboni/stats-all.js:15494 static/js/zamboni/stats-min.js:5
 msgid "Add-ons Created, last {0} days"
 msgstr ""
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:215
+#: static/js/impala/stats/csv_keys.js:215 static/js/zamboni/stats-all.js:15496 static/js/zamboni/stats-min.js:5
 msgid "Add-ons Created from {0} to {1}"
 msgstr ""
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:219
+#: static/js/impala/stats/csv_keys.js:219 static/js/zamboni/stats-all.js:15500 static/js/zamboni/stats-min.js:5
 msgid "Add-ons Updated, last {0} days"
 msgstr ""
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:221
+#: static/js/impala/stats/csv_keys.js:221 static/js/zamboni/stats-all.js:15502 static/js/zamboni/stats-min.js:5
 msgid "Add-ons Updated from {0} to {1}"
 msgstr ""
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:225
+#: static/js/impala/stats/csv_keys.js:225 static/js/zamboni/stats-all.js:15506 static/js/zamboni/stats-min.js:5
 msgid "Reviews Written, last {0} days"
 msgstr ""
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:227
+#: static/js/impala/stats/csv_keys.js:227 static/js/zamboni/stats-all.js:15508 static/js/zamboni/stats-min.js:5
 msgid "Reviews Written from {0} to {1}"
 msgstr ""
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:231
+#: static/js/impala/stats/csv_keys.js:231 static/js/zamboni/stats-all.js:15512 static/js/zamboni/stats-min.js:5
 msgid "User Signups, last {0} days"
 msgstr ""
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:233
+#: static/js/impala/stats/csv_keys.js:233 static/js/zamboni/stats-all.js:15514 static/js/zamboni/stats-min.js:5
 msgid "User Signups from {0} to {1}"
 msgstr ""
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:237
+#: static/js/impala/stats/csv_keys.js:237 static/js/zamboni/stats-all.js:15518 static/js/zamboni/stats-min.js:5
 msgid "Collections Created, last {0} days"
 msgstr ""
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:239
+#: static/js/impala/stats/csv_keys.js:239 static/js/zamboni/stats-all.js:15520 static/js/zamboni/stats-min.js:5
 msgid "Collections Created from {0} to {1}"
 msgstr ""
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:243
+#: static/js/impala/stats/csv_keys.js:243 static/js/zamboni/stats-all.js:15524 static/js/zamboni/stats-min.js:5
 msgid "Subscribers, last {0} days"
 msgstr ""
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:245
+#: static/js/impala/stats/csv_keys.js:245 static/js/zamboni/stats-all.js:15526 static/js/zamboni/stats-min.js:5
 msgid "Subscribers from {0} to {1}"
 msgstr ""
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:249
+#: static/js/impala/stats/csv_keys.js:249 static/js/zamboni/stats-all.js:15530 static/js/zamboni/stats-min.js:5
 msgid "Ratings, last {0} days"
 msgstr ""
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:251
+#: static/js/impala/stats/csv_keys.js:251 static/js/zamboni/stats-all.js:15532 static/js/zamboni/stats-min.js:5
 msgid "Ratings from {0} to {1}"
 msgstr ""
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:255
+#: static/js/impala/stats/csv_keys.js:255 static/js/zamboni/stats-all.js:15536 static/js/zamboni/stats-min.js:5
 msgid "Sales, last {0} days"
 msgstr ""
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:257
+#: static/js/impala/stats/csv_keys.js:257 static/js/zamboni/stats-all.js:15538 static/js/zamboni/stats-min.js:5
 msgid "Sales from {0} to {1}"
 msgstr ""
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:261
+#: static/js/impala/stats/csv_keys.js:261 static/js/zamboni/stats-all.js:15542 static/js/zamboni/stats-min.js:5
 msgid "Installs, last {0} days"
 msgstr ""
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:263
+#: static/js/impala/stats/csv_keys.js:263 static/js/zamboni/stats-all.js:15544 static/js/zamboni/stats-min.js:5
 msgid "Installs from {0} to {1}"
 msgstr ""
 
 #. L10n: {0} and {1} are integers.
-#: static/js/impala/stats/csv_keys.js:269
+#: static/js/impala/stats/csv_keys.js:269 static/js/zamboni/stats-all.js:15550 static/js/zamboni/stats-min.js:5
 msgid "<b>{0}</b> in last {1} days"
 msgstr ""
 
 #. L10n: {0} is an integer and {1} and {2} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:271 static/js/impala/stats/csv_keys.js:277
+#: static/js/impala/stats/csv_keys.js:271 static/js/impala/stats/csv_keys.js:277 static/js/zamboni/stats-all.js:15552 static/js/zamboni/stats-all.js:15558 static/js/zamboni/stats-min.js:5
 msgid "<b>{0}</b> from {1} to {2}"
 msgstr ""
 
 #. L10n: {0} and {1} are integers.
-#: static/js/impala/stats/csv_keys.js:275
+#: static/js/impala/stats/csv_keys.js:275 static/js/zamboni/stats-all.js:15556 static/js/zamboni/stats-min.js:5
 msgid "<b>{0}</b> average in last {1} days"
 msgstr ""
 
-#: static/js/impala/stats/overview.js:19
+#: static/js/impala/stats/overview.js:19 static/js/zamboni/stats-all.js:16469 static/js/zamboni/stats-min.js:5
 msgid "No data available."
 msgstr ""
 
-#: static/js/impala/stats/table.js:74
+#: static/js/impala/stats/table.js:74 static/js/zamboni/stats-all.js:17209 static/js/zamboni/stats-min.js:5
 msgid "Date"
 msgstr ""
 
-#: static/js/impala/stats/topchart.js:96
+#: static/js/impala/stats/topchart.js:96 static/js/zamboni/stats-all.js:16600 static/js/zamboni/stats-min.js:5
 msgid "Other"
 msgstr ""
 
-#: static/js/zamboni/admin_validation.js:24 static/js/zamboni/devhub.js:1229 static/js/zamboni/editors.js:295
+#: static/js/zamboni/admin-all.js:180 static/js/zamboni/admin-min.js:1 static/js/zamboni/admin_validation.js:24 static/js/zamboni/devhub-all.js:2408 static/js/zamboni/devhub-min.js:2
+#: static/js/zamboni/devhub.js:1229 static/js/zamboni/editors-all.js:15576 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:295
 msgid "Select an application first"
 msgstr ""
 
-#: static/js/zamboni/admin_validation.js:51
+#: static/js/zamboni/admin-all.js:207 static/js/zamboni/admin-min.js:1 static/js/zamboni/admin_validation.js:51
 msgid "Set {0} add-on to a max version of {1} and email the author."
 msgid_plural "Set {0} add-ons to a max version of {1} and email the authors."
 msgstr[0] ""
 msgstr[1] ""
 
-#: static/js/zamboni/admin_validation.js:54
+#: static/js/zamboni/admin-all.js:210 static/js/zamboni/admin-min.js:1 static/js/zamboni/admin_validation.js:54
 msgid "Email author of {2} add-on which failed validation."
 msgid_plural "Email authors of {2} add-ons which failed validation."
 msgstr[0] ""
 msgstr[1] ""
 
-#. L10n: {0} is an app name like Firefox.
-#: static/js/zamboni/buttons.js:66
-msgid "Accept and Install"
-msgstr ""
-
-#: static/js/zamboni/buttons.js:66
-msgid "Add to {0}"
-msgstr ""
-
-#: static/js/zamboni/buttons.js:71
-msgid "Download Now"
-msgstr ""
-
-#: static/js/zamboni/buttons.js:112
-msgid "Add-on has not been updated to support default-to-compatible."
-msgstr ""
-
-#: static/js/zamboni/buttons.js:117
-msgid "You need to be using Firefox 10.0 or higher."
-msgstr ""
-
-#: static/js/zamboni/buttons.js:129
-msgid "Mozilla has marked this version as incompatible with your Firefox version."
-msgstr ""
-
-#. L10n: {0} is an platform like Windows or Linux.
-#: static/js/zamboni/buttons.js:210
-msgid "Install for {0} anyway"
-msgstr ""
-
-#: static/js/zamboni/buttons.js:210
-msgid "Download for {0} anyway"
-msgstr ""
-
-#: static/js/zamboni/buttons.js:267
-msgid "Not available for your platform"
-msgstr ""
-
-#. L10n: {0} is an app name, {1} is the app version.
-#: static/js/zamboni/buttons.js:278 static/js/zamboni/buttons.js:315
-msgid "Not available for {0} {1}"
-msgstr ""
-
-#: static/js/zamboni/buttons.js:341
-msgid "Works with {app} {min} - {max}"
-msgstr ""
-
-#: static/js/zamboni/buttons.js:343
-msgid "View other versions"
-msgstr ""
-
-#: static/js/zamboni/buttons.js:391
-msgid "Only with Firefox — Get Firefox Now!"
-msgstr ""
-
-#: static/js/zamboni/buttons.js:507 static/js/zamboni/mobile/buttons.js:43
-msgid "Sorry, you need a Mozilla-based browser (such as Firefox) to install a search plugin."
-msgstr ""
-
-#: static/js/zamboni/collections.js:229
-msgid "Adding to Favorites&hellip;"
-msgstr ""
-
-#: static/js/zamboni/collections.js:232
-msgid "Removing Favorite&hellip;"
-msgstr ""
-
-#: static/js/zamboni/collections.js:235
-msgid "Add to Favorites"
-msgstr ""
-
-#: static/js/zamboni/collections.js:238
-msgid "Remove from Favorites"
-msgstr ""
-
-#: static/js/zamboni/collections.js:303
-msgid "Pending"
-msgstr ""
-
-#: static/js/zamboni/collections.js:304
-msgid "Add a comment"
-msgstr ""
-
-#: static/js/zamboni/collections.js:304
-msgid "Comment"
-msgstr ""
-
-#: static/js/zamboni/collections.js:305
-msgid "Remove this add-on from the collection"
-msgstr ""
-
-#: static/js/zamboni/collections.js:305 static/js/zamboni/collections.js:334
-msgid "Remove"
-msgstr ""
-
-#: static/js/zamboni/collections.js:334
-msgid "Remove this user as a contributor"
-msgstr ""
-
-#: static/js/zamboni/collections.js:346
-msgid "An email address is required."
-msgstr ""
-
-#: static/js/zamboni/collections.js:364
-msgid "You cannot add yourself as a contributor."
-msgstr ""
-
-#: static/js/zamboni/collections.js:366
-msgid "You have already added that user."
-msgstr ""
-
-#: static/js/zamboni/collections.js:573
-msgid "Add to favorites"
-msgstr ""
-
-#: static/js/zamboni/collections.js:577
-msgid "Remove from favorites"
-msgstr ""
-
-#: static/js/zamboni/collections.js:604
-msgid "Stop following"
-msgstr ""
-
-#: static/js/zamboni/devhub.js:110
+#: static/js/zamboni/devhub-all.js:1289 static/js/zamboni/devhub-min.js:1 static/js/zamboni/devhub.js:110
 msgid "Your browser does not support the video tag"
 msgstr ""
 
-#: static/js/zamboni/devhub.js:371
+#: static/js/zamboni/devhub-all.js:1550 static/js/zamboni/devhub-min.js:1 static/js/zamboni/devhub.js:371
 msgid "Changes Saved"
 msgstr ""
 
-#: static/js/zamboni/devhub.js:387
+#: static/js/zamboni/devhub-all.js:1566 static/js/zamboni/devhub-min.js:1 static/js/zamboni/devhub.js:387
 msgid "Enter a new author's email address"
 msgstr ""
 
-#: static/js/zamboni/devhub.js:536
+#: static/js/zamboni/devhub-all.js:1715 static/js/zamboni/devhub-min.js:1 static/js/zamboni/devhub.js:536
 msgid "There was an error uploading your file."
 msgstr ""
 
-#: static/js/zamboni/devhub.js:681
+#: static/js/zamboni/devhub-all.js:1860 static/js/zamboni/devhub-min.js:1 static/js/zamboni/devhub.js:681
 msgid "{files} file"
 msgid_plural "{files} files"
 msgstr[0] ""
 msgstr[1] ""
 
-#: static/js/zamboni/devhub.js:684
+#: static/js/zamboni/devhub-all.js:1863 static/js/zamboni/devhub-min.js:1 static/js/zamboni/devhub.js:684
 msgid "{reviews} user review"
 msgid_plural "{reviews} user reviews"
 msgstr[0] ""
 msgstr[1] ""
 
-#: static/js/zamboni/devhub.js:796
+#: static/js/zamboni/devhub-all.js:1975 static/js/zamboni/devhub-min.js:2 static/js/zamboni/devhub.js:796
 msgid "Learn more"
 msgstr ""
 
-#: static/js/zamboni/devhub.js:800
+#: static/js/zamboni/devhub-all.js:1979 static/js/zamboni/devhub-min.js:2 static/js/zamboni/devhub.js:800
 msgid "Example"
 msgstr ""
 
-#: static/js/zamboni/devhub.js:1130
+#: static/js/zamboni/devhub-all.js:2309 static/js/zamboni/devhub-min.js:2 static/js/zamboni/devhub.js:1130
 msgid "Image changes being processed"
 msgstr ""
 
-#: static/js/zamboni/devhub.js:1280
+#: static/js/zamboni/devhub-all.js:2459 static/js/zamboni/devhub-min.js:2 static/js/zamboni/devhub.js:1280
 msgid "Must be a valid e-mail address."
+msgstr ""
+
+#: static/js/zamboni/devhub-all.js:2613 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:80
+msgid "All tests passed successfully."
+msgstr ""
+
+#: static/js/zamboni/devhub-all.js:2616 static/js/zamboni/devhub-all.js:3011 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:83 static/js/zamboni/validator.js:478
+msgid "These tests were not run."
+msgstr ""
+
+#: static/js/zamboni/devhub-all.js:2664 static/js/zamboni/devhub-all.js:2677 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:131 static/js/zamboni/validator.js:144
+msgid "Tests"
+msgstr ""
+
+#: static/js/zamboni/devhub-all.js:2779 static/js/zamboni/devhub-all.js:3108 static/js/zamboni/devhub-all.js:3127 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:246
+#: static/js/zamboni/validator.js:575 static/js/zamboni/validator.js:594
+msgid "Error"
+msgstr ""
+
+#: static/js/zamboni/devhub-all.js:2780 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:247
+msgid "Warning"
+msgstr ""
+
+#: static/js/zamboni/devhub-all.js:2794 static/js/zamboni/devhub-min.js:2 static/js/zamboni/files-all.js:5657 static/js/zamboni/files-min.js:3 static/js/zamboni/files.js:411
+#: static/js/zamboni/validator.js:261
+msgid "Ignore this message in future updates"
+msgstr ""
+
+#: static/js/zamboni/devhub-all.js:2817 static/js/zamboni/devhub-min.js:2 static/js/zamboni/files-all.js:5663 static/js/zamboni/files-min.js:3 static/js/zamboni/files.js:417
+#: static/js/zamboni/validator.js:284
+msgid "Severity for automated signing:"
+msgstr ""
+
+#: static/js/zamboni/devhub-all.js:2832 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:299
+msgid "Suggestions for passing automated signing:"
+msgstr ""
+
+#: static/js/zamboni/devhub-all.js:2920 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:387
+msgid "Compatibility Tests"
+msgstr ""
+
+#: static/js/zamboni/devhub-all.js:2999 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:466
+msgid "Add-on failed validation."
+msgstr ""
+
+#: static/js/zamboni/devhub-all.js:3001 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:468
+msgid "Add-on passed validation."
+msgstr ""
+
+#: static/js/zamboni/devhub-all.js:3014 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:481
+msgid "{0} error"
+msgid_plural "{0} errors"
+msgstr[0] ""
+msgstr[1] ""
+
+#: static/js/zamboni/devhub-all.js:3016 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:483
+msgid "{0} warning"
+msgid_plural "{0} warnings"
+msgstr[0] ""
+msgstr[1] ""
+
+#: static/js/zamboni/devhub-all.js:3018 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:485
+msgid "{0} notice"
+msgid_plural "{0} notices"
+msgstr[0] ""
+msgstr[1] ""
+
+#: static/js/zamboni/devhub-all.js:3110 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:577
+msgid "Validation task could not complete or completed with errors"
+msgstr ""
+
+#: static/js/zamboni/devhub-all.js:3128 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:595
+msgid "Internal server error"
 msgstr ""
 
 #: static/js/zamboni/devhub_search.js:8
 msgid "No results found."
 msgstr ""
 
-#: static/js/zamboni/editors.js:121
+#: static/js/zamboni/editors-all.js:15402 static/js/zamboni/editors-min.js:4 static/js/zamboni/editors.js:121
 msgid "{name} was viewing this page first."
 msgstr ""
 
-#: static/js/zamboni/editors.js:171
+#: static/js/zamboni/editors-all.js:15452 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:171
 msgid "Receipt checked by app."
 msgstr ""
 
-#: static/js/zamboni/editors.js:173
+#: static/js/zamboni/editors-all.js:15454 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:173
 msgid "Receipt was not checked by app."
 msgstr ""
 
-#: static/js/zamboni/editors.js:244
+#: static/js/zamboni/editors-all.js:15525 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:244
 msgid "{name} was viewing this add-on first."
 msgstr ""
 
-#: static/js/zamboni/editors.js:255
+#: static/js/zamboni/editors-all.js:15536 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:255
 msgid "Loading&hellip;"
 msgstr ""
 
-#: static/js/zamboni/editors.js:260
+#: static/js/zamboni/editors-all.js:15541 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:260
 msgid "Version Notes"
 msgstr ""
 
-#: static/js/zamboni/editors.js:265
+#: static/js/zamboni/editors-all.js:15546 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:265
 msgid "Notes for Reviewers"
 msgstr ""
 
-#: static/js/zamboni/editors.js:270
+#: static/js/zamboni/editors-all.js:15551 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:270
 msgid "No version notes found"
 msgstr ""
 
-#: static/js/zamboni/editors.js:330
+#: static/js/zamboni/editors-all.js:15611 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:330
 msgid "Average Reviews"
 msgstr ""
 
-#: static/js/zamboni/editors.js:386
+#: static/js/zamboni/editors-all.js:15667 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:386
 msgid "Number of Reviews"
 msgstr ""
 
-#: static/js/zamboni/editors.js:445
+#: static/js/zamboni/editors-all.js:15726 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:445
 msgid "Error loading translation"
 msgstr ""
 
-#: static/js/zamboni/files.js:411 static/js/zamboni/validator.js:261
-msgid "Ignore this message in future updates"
-msgstr ""
-
-#: static/js/zamboni/files.js:417 static/js/zamboni/validator.js:284
-msgid "Severity for automated signing:"
-msgstr ""
-
-#: static/js/zamboni/global.js:410
-msgid "Loading..."
-msgstr ""
-
-#. L10n: {0} is the number of characters left.
-#: static/js/zamboni/global.js:474
-msgid "<b>{0}</b> character left."
-msgid_plural "<b>{0}</b> characters left."
-msgstr[0] ""
-msgstr[1] ""
-
-#: static/js/zamboni/init.js:28
-msgid "This feature is temporarily disabled while we perform website maintenance. Please check back a little later."
-msgstr ""
-
-#: static/js/zamboni/l10n.js:45
-msgid "Remove this localization"
-msgstr ""
-
-#: static/js/zamboni/password-strength.js:20
-msgid "Password strength:"
-msgstr ""
-
-#: static/js/zamboni/password-strength.js:26
-msgid "At least {0} character left."
-msgid_plural "At least {0} characters left."
-msgstr[0] ""
-msgstr[1] ""
-
-#: static/js/zamboni/themes_review.js:176
-msgid "Requested Info"
-msgstr ""
-
-#: static/js/zamboni/themes_review.js:177
-msgid "Flagged"
-msgstr ""
-
-#: static/js/zamboni/themes_review.js:178
-msgid "Duplicate"
-msgstr ""
-
-#: static/js/zamboni/themes_review.js:179
-msgid "Rejected"
-msgstr ""
-
-#: static/js/zamboni/themes_review.js:180
-msgid "Approved"
-msgstr ""
-
-#: static/js/zamboni/themes_review.js:424
-msgid "No results found"
-msgstr ""
-
-#: static/js/zamboni/themes_review_templates.js:31
+#: static/js/zamboni/editors-all.js:15975 static/js/zamboni/editors-min.js:5 static/js/zamboni/themes_review_templates.js:31
 msgid "Theme"
 msgstr ""
 
-#: static/js/zamboni/themes_review_templates.js:33
+#: static/js/zamboni/editors-all.js:15977 static/js/zamboni/editors-min.js:5 static/js/zamboni/themes_review_templates.js:33
 msgid "Reviewer"
 msgstr ""
 
-#: static/js/zamboni/themes_review_templates.js:35
+#: static/js/zamboni/editors-all.js:15979 static/js/zamboni/editors-min.js:5 static/js/zamboni/themes_review_templates.js:35
 msgid "Status"
 msgstr ""
 
-#: static/js/zamboni/validator.js:80
-msgid "All tests passed successfully."
+#: static/js/zamboni/editors-all.js:16196 static/js/zamboni/editors-min.js:5 static/js/zamboni/themes_review.js:176
+msgid "Requested Info"
 msgstr ""
 
-#: static/js/zamboni/validator.js:83 static/js/zamboni/validator.js:478
-msgid "These tests were not run."
+#: static/js/zamboni/editors-all.js:16197 static/js/zamboni/editors-min.js:5 static/js/zamboni/themes_review.js:177
+msgid "Flagged"
 msgstr ""
 
-#: static/js/zamboni/validator.js:131 static/js/zamboni/validator.js:144
-msgid "Tests"
+#: static/js/zamboni/editors-all.js:16198 static/js/zamboni/editors-min.js:5 static/js/zamboni/themes_review.js:178
+msgid "Duplicate"
 msgstr ""
 
-#: static/js/zamboni/validator.js:246 static/js/zamboni/validator.js:575 static/js/zamboni/validator.js:594
-msgid "Error"
+#: static/js/zamboni/editors-all.js:16199 static/js/zamboni/editors-min.js:5 static/js/zamboni/themes_review.js:179
+msgid "Rejected"
 msgstr ""
 
-#: static/js/zamboni/validator.js:247
-msgid "Warning"
+#: static/js/zamboni/editors-all.js:16200 static/js/zamboni/editors-min.js:5 static/js/zamboni/themes_review.js:180
+msgid "Approved"
 msgstr ""
 
-#: static/js/zamboni/validator.js:299
-msgid "Suggestions for passing automated signing:"
+#: static/js/zamboni/editors-all.js:16444 static/js/zamboni/editors-min.js:5 static/js/zamboni/themes_review.js:424
+msgid "No results found"
 msgstr ""
 
-#: static/js/zamboni/validator.js:387
-msgid "Compatibility Tests"
-msgstr ""
-
-#: static/js/zamboni/validator.js:466
-msgid "Add-on failed validation."
-msgstr ""
-
-#: static/js/zamboni/validator.js:468
-msgid "Add-on passed validation."
-msgstr ""
-
-#: static/js/zamboni/validator.js:481
-msgid "{0} error"
-msgid_plural "{0} errors"
-msgstr[0] ""
-msgstr[1] ""
-
-#: static/js/zamboni/validator.js:483
-msgid "{0} warning"
-msgid_plural "{0} warnings"
-msgstr[0] ""
-msgstr[1] ""
-
-#: static/js/zamboni/validator.js:485
-msgid "{0} notice"
-msgid_plural "{0} notices"
-msgstr[0] ""
-msgstr[1] ""
-
-#: static/js/zamboni/validator.js:577
-msgid "Validation task could not complete or completed with errors"
-msgstr ""
-
-#: static/js/zamboni/validator.js:595
-msgid "Internal server error"
-msgstr ""
-
-#: static/js/zamboni/mobile/buttons.js:52
+#: static/js/zamboni/mobile-all.js:15186 static/js/zamboni/mobile/buttons.js:52
 msgid "Not Updated for {0} {1}"
 msgstr ""
 
-#: static/js/zamboni/mobile/buttons.js:53
+#: static/js/zamboni/mobile-all.js:15187 static/js/zamboni/mobile/buttons.js:53
 msgid "Requires Newer Version of {0}"
 msgstr ""
 
-#: static/js/zamboni/mobile/buttons.js:54
+#: static/js/zamboni/mobile-all.js:15188 static/js/zamboni/mobile/buttons.js:54
 msgid "Unreviewed"
 msgstr ""
 
-#: static/js/zamboni/mobile/buttons.js:55
+#: static/js/zamboni/mobile-all.js:15189 static/js/zamboni/mobile/buttons.js:55
 msgid "Experimental <span>(Learn More)</span>"
 msgstr ""
 
-#: static/js/zamboni/mobile/buttons.js:56 static/js/zamboni/mobile/buttons.js:57
+#: static/js/zamboni/mobile-all.js:15190 static/js/zamboni/mobile-all.js:15191 static/js/zamboni/mobile/buttons.js:56 static/js/zamboni/mobile/buttons.js:57
 msgid "Not Available for {0}"
 msgstr ""
 
-#: static/js/zamboni/mobile/buttons.js:58
+#: static/js/zamboni/mobile-all.js:15192 static/js/zamboni/mobile/buttons.js:58
 msgid "Experimental"
 msgstr ""
 
-#: static/js/zamboni/mobile/buttons.js:59
+#: static/js/zamboni/mobile-all.js:15193 static/js/zamboni/mobile/buttons.js:59
 msgid "Themes Require Newer Version of {0}"
 msgstr ""
 
-#: static/js/zamboni/mobile/buttons.js:60
+#: static/js/zamboni/mobile-all.js:15194 static/js/zamboni/mobile/buttons.js:60
 msgid "Themes Require {0}"
 msgstr ""
 
-#: static/js/zamboni/mobile/buttons.js:105
+#: static/js/zamboni/mobile-all.js:15239 static/js/zamboni/mobile/buttons.js:105
 msgid "Installing..."
 msgstr ""
 
-#: static/js/zamboni/mobile/buttons.js:125
+#: static/js/zamboni/mobile-all.js:15259 static/js/zamboni/mobile/buttons.js:125
 msgid "This add-on has been preliminarily reviewed by Mozilla."
 msgstr ""
 
-#: static/js/zamboni/mobile/buttons.js:250
+#: static/js/zamboni/mobile-all.js:15384 static/js/zamboni/mobile/buttons.js:250
 msgid "Keep it"
 msgstr ""
 
-#: static/js/zamboni/mobile/general.js:344
+#: static/js/zamboni/mobile-all.js:16049 static/js/zamboni/mobile-min.js:6 static/js/zamboni/mobile/general.js:344
 msgid "You're trying it on!"
 msgstr ""
 
-#: static/js/zamboni/mobile/general.js:356
+#: static/js/zamboni/mobile-all.js:16061 static/js/zamboni/mobile-min.js:6 static/js/zamboni/mobile/general.js:356
 msgid "Added to Firefox"
 msgstr ""
-

--- a/locale/pa/LC_MESSAGES/django.po
+++ b/locale/pa/LC_MESSAGES/django.po
@@ -3,7 +3,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2016-02-24 21:23+0000\n"
+"POT-Creation-Date: 2016-04-18 15:40+0000\n"
 "PO-Revision-Date: 2015-07-18 03:09+0000\n"
 "Last-Translator: ubuntuser13 <ubuntuser13@gmail.com>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -12,60 +12,60 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Generated-By: Babel 2.2.0\n"
 
-#: src/olympia/accounts/views.py:52
+#: src/olympia/accounts/views.py:54
 msgid "Your log in attempt could not be parsed. Please try again."
 msgstr ""
 
-#: src/olympia/accounts/views.py:54
+#: src/olympia/accounts/views.py:56
 msgid "Your Firefox Account could not be found. Please try again."
 msgstr ""
 
-#: src/olympia/accounts/views.py:55
+#: src/olympia/accounts/views.py:57
 msgid "You could not be logged in. Please try again."
 msgstr ""
 
-#: src/olympia/accounts/views.py:57
+#: src/olympia/accounts/views.py:59
 msgid "Your account has already been migrated to Firefox Accounts."
 msgstr ""
 
-#: src/olympia/accounts/views.py:59
+#: src/olympia/accounts/views.py:61
 msgid "Your Firefox Account already exists on this site."
 msgstr ""
 
-#: src/olympia/accounts/views.py:108
+#: src/olympia/accounts/views.py:110
 msgid "Great job!"
 msgstr ""
 
-#: src/olympia/accounts/views.py:109
+#: src/olympia/accounts/views.py:111
 msgid "You can now log in to Add-ons with your Firefox Account."
 msgstr ""
 
-#: src/olympia/accounts/views.py:121
+#: src/olympia/accounts/views.py:123
 msgid "Need help?"
 msgstr ""
 
-#: src/olympia/addons/buttons.py:180
+#: src/olympia/addons/buttons.py:177
 msgid "Download Now"
 msgstr "                  ਹੁਣੇ ਹੀ ਡਾਓਨਲੋਡ ਕਰੋ                "
 
-#: src/olympia/addons/buttons.py:182
+#: src/olympia/addons/buttons.py:179
 msgid "Download"
 msgstr "ਡਾਓਨਲੋਡ"
 
 #. L10n: please keep &nbsp; in the string so &rarr; does not wrap.
-#: src/olympia/addons/buttons.py:186
+#: src/olympia/addons/buttons.py:183
 msgid "Continue to Download&nbsp;&rarr;"
 msgstr "ਡਾਊਨਲੋਡ&nbsp;&rarr; ਲਈ ਜਾਰੀ"
 
-#: src/olympia/addons/buttons.py:202 src/olympia/addons/helpers.py:35 src/olympia/addons/views.py:319 src/olympia/addons/templates/addons/impala/details.html:114
+#: src/olympia/addons/buttons.py:199 src/olympia/addons/helpers.py:35 src/olympia/addons/views.py:333 src/olympia/addons/templates/addons/impala/details.html:111
 #: src/olympia/addons/templates/addons/impala/listing/items.html:17 src/olympia/addons/templates/addons/mobile/home.html:40 src/olympia/amo/templates/amo/side_nav.html:6
-#: src/olympia/amo/templates/amo/side_nav.html:10 src/olympia/amo/templates/amo/site_nav.html:2 src/olympia/amo/templates/amo/site_nav.html:55 src/olympia/bandwagon/views.py:95
-#: src/olympia/browse/views.py:54 src/olympia/browse/views.py:68 src/olympia/browse/views.py:235 src/olympia/browse/templates/browse/impala/category_landing.html:22
+#: src/olympia/amo/templates/amo/side_nav.html:10 src/olympia/amo/templates/amo/site_nav.html:2 src/olympia/amo/templates/amo/site_nav.html:53 src/olympia/bandwagon/views.py:95
+#: src/olympia/browse/views.py:54 src/olympia/browse/views.py:68 src/olympia/browse/views.py:202 src/olympia/browse/templates/browse/impala/category_landing.html:22
 #: src/olympia/browse/templates/browse/personas/mobile/category_landing.html:26
 msgid "Featured"
 msgstr "ਪੇਸ਼ ਕੀਤਾ"
 
-#: src/olympia/addons/buttons.py:221
+#: src/olympia/addons/buttons.py:218
 msgid "Add to {0}"
 msgstr "{0} ਨੂੰ ਸ਼ਾਮਲ ਕਰੋ"
 
@@ -113,39 +113,39 @@ msgid_plural "All tags must be at least {0} characters."
 msgstr[0] "ਸਾਰੇ ਟੈਗ ਘੱਟੋ-ਘੱਟ {0} ਅੱਖਰ ਦੇ ਹੋਣੇ ਚਾਹੀਦੇ ਹਨ।"
 msgstr[1] "ਸਾਰੇ ਟੈਗ ਘੱਟੋ-ਘੱਟ {0} ਅੱਖਰਾਂ ਦੇ ਹੋਣੇ ਚਾਹੀਦੇ ਹਨ।"
 
-#: src/olympia/addons/forms.py:234
+#: src/olympia/addons/forms.py:238
 msgid "Categories cannot be changed while your add-on is featured for this application."
 msgstr "ਵਰਗ ਬਦਲੇ ਨਹੀਂਂ ਜਾ ਸਕਦੇ ਜਦ ਕਿ ਤੁਹਾਡਾ ਐਡਓਨ ਇਸ ਐਪਲੀਕੇਸ਼ਨ ਲਈ ਪੇਸ਼ ਕੀਤਾ ਗਿਆ ਹੈ।"
 
 #. L10n: {0} is the number of categories.
-#: src/olympia/addons/forms.py:238
+#: src/olympia/addons/forms.py:242
 msgid "You can have only {0} category."
 msgid_plural "You can have only {0} categories."
 msgstr[0] "ਤੁਹਾਡੇ ਕੋਲ ਕੇਵਲ {0} ਵਰਗ ਹੋ ਸਕਦਾ ਹਨ।"
 msgstr[1] "ਤੁਹਾਡੇ ਕੋਲ ਕੇਵਲ {0} ਵਰਗ ਹੋ ਸਕਦੇ ਹਨ।"
 
-#: src/olympia/addons/forms.py:246
+#: src/olympia/addons/forms.py:250
 msgid "The miscellaneous category cannot be combined with additional categories."
 msgstr "ਫ਼ੁਟਕਲ ਵਰਗ ਹੋਰ ਵਰਗਾਂ ਨਾਲ ਜੋੜਿਆ ਨਹੀਂਂ ਜਾ ਸਕਦਾ।"
 
-#: src/olympia/addons/forms.py:369
+#: src/olympia/addons/forms.py:374
 #, python-format
 msgid "Before changing your default locale you must have a name, summary, and description in that locale. You are missing %s."
 msgstr "ਤੁਹਾਡਾ ਮੂਲ ਲੋਕੇਲ ਬਦਲਣ ਤੋਂ ਪਹਿਲਾਂ ਤੁਹਾਡੇ ਕੋਲ ਉਸ ਲੋਕੇਲ ਵਿੱਚ ਇੱਕ ਨਾਂ, ਸੰਖੇਪ ਖੁਲਾਸਾ, ਅਤੇ ਵੇਰਵਾ ਜ਼ਰੂਰ ਹੋਣਾ ਚਾਹੀਦਾ ਹੈ। ਤੁਸੀਂ %s ਭੁੱਲ ਗਏ ਹੋ।"
 
-#: src/olympia/addons/forms.py:484 src/olympia/addons/forms.py:575
+#: src/olympia/addons/forms.py:455 src/olympia/addons/forms.py:546
 msgid "A license must be selected."
 msgstr "ਇਕ ਲਾਇਸੰਸ ਚੁਣਿਆ ਜਾਣਾ ਚਾਹੀਦਾ ਹੈ।"
 
-#: src/olympia/addons/forms.py:556
+#: src/olympia/addons/forms.py:527
 msgid "Give Your Theme a Name."
 msgstr "ਆਪਣੇ ਥੀਮ ਨੂੰ ਇੱਕ ਨਾਂ ਦਿਓ।"
 
-#: src/olympia/addons/forms.py:562 src/olympia/devhub/templates/devhub/personas/submit.html:53
+#: src/olympia/addons/forms.py:533 src/olympia/devhub/templates/devhub/personas/submit.html:53
 msgid "Describe your Theme."
 msgstr "ਤੁਹਾਡਾ ਥੀਮ ਦਾ ਵਰਣਨ ਕਰੋ।"
 
-#: src/olympia/addons/forms.py:704
+#: src/olympia/addons/forms.py:675
 msgid "Enter a new author's email address"
 msgstr "ਇੱਕ ਨਵੇਂ ਲੇਖਕ ਦਾ ਈਮੇਲ ਪਤਾ ਭਰੋ"
 
@@ -153,37 +153,37 @@ msgstr "ਇੱਕ ਨਵੇਂ ਲੇਖਕ ਦਾ ਈਮੇਲ ਪਤਾ ਭਰ
 msgid "Not Reviewed"
 msgstr "ਪੁਨਰ ਵਿਚਾਰ ਨਹੀਂ"
 
-#: src/olympia/addons/models.py:301
+#: src/olympia/addons/models.py:298
 msgid "Users have the option of contributing more or less than this amount."
 msgstr "ਉਪਭੋਗੀਆਂ ਕੋਲ ਇਸ ਰਕਮ ਨਾਲੋਂ ਵੱਧ ਜਾਂ ਘੱਟ ਯੋਗਦਾਨ ਦੇਣ ਦੀ ਚੋਣ ਹੈ।"
 
-#: src/olympia/addons/models.py:309
-msgid "Users will always be asked in the Add-ons Manager (Firefox 4 and above)"
-msgstr "ਉਪਭੋਗੀਆਂ ਨੂੰ ਹਮੇਸ਼ਾ ਐਡ-ਆਨ ਮੈਨੇਜਰ ਵਿੱਚ ਕਿਹਾ ਜਾਵੇਗਾ (ਫ਼ਾਇਰਫ਼ਾਕਸ 4 ਅਤੇ ਉਪਰੋਕਤ)"
+#: src/olympia/addons/models.py:306
+msgid "Users will always be asked in the Add-ons Manager (Firefox 4 and above). Only applies to desktop."
+msgstr ""
 
-#: src/olympia/addons/models.py:1804 src/olympia/addons/templates/addons/details_box.html:55 src/olympia/devhub/templates/devhub/index.html:92
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:102
+#: src/olympia/addons/models.py:1802 src/olympia/addons/templates/addons/details_box.html:55 src/olympia/devhub/templates/devhub/index.html:92
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:89
 msgid "Listed"
 msgstr "ਸੂਚੀਬੱਧ"
 
-#: src/olympia/addons/views.py:320 src/olympia/browse/templates/browse/personas/mobile/category_landing.html:27
+#: src/olympia/addons/views.py:334 src/olympia/browse/templates/browse/personas/mobile/category_landing.html:27
 msgid "Popular"
 msgstr "ਮਸ਼ਹੂਰ"
 
-#: src/olympia/addons/views.py:321 src/olympia/browse/views.py:238 src/olympia/browse/views.py:280 src/olympia/browse/views.py:482
+#: src/olympia/addons/views.py:335 src/olympia/browse/views.py:205 src/olympia/browse/views.py:247 src/olympia/browse/views.py:449
 msgid "Recently Added"
 msgstr "ਹਾਲ ਹੀ ਵਿੱਚ ਸ਼ਾਮਲ ਕੀਤਾ"
 
-#: src/olympia/addons/views.py:322 src/olympia/bandwagon/views.py:99 src/olympia/browse/views.py:60 src/olympia/browse/views.py:71 src/olympia/search/forms.py:16 src/olympia/search/forms.py:91
+#: src/olympia/addons/views.py:336 src/olympia/bandwagon/views.py:99 src/olympia/browse/views.py:60 src/olympia/browse/views.py:71 src/olympia/search/forms.py:16 src/olympia/search/forms.py:91
 msgid "Recently Updated"
 msgstr "ਹਾਲ ਹੀ ਵਿੱਚ ਅੱਪਡੇਟ ਕੀਤਾ"
 
 #. l10n: {0} is the addon name
-#: src/olympia/addons/views.py:520
+#: src/olympia/addons/views.py:534
 msgid "Contribution for {0}"
 msgstr "{0} ਲਈ ਯੋਗਦਾਨ"
 
-#: src/olympia/addons/views.py:613
+#: src/olympia/addons/views.py:627
 msgid "Abuse reported."
 msgstr "ਬਦਸਲੂਕੀ ਦੀ ਸੂਚਨਾ।"
 
@@ -250,9 +250,9 @@ msgstr "ਯੋਗਦਾਨ ਪਾਓ"
 #: src/olympia/devhub/templates/devhub/addons/ajax_compat_update.html:36 src/olympia/devhub/templates/devhub/addons/profile.html:44 src/olympia/devhub/templates/devhub/addons/edit/admin.html:101
 #: src/olympia/devhub/templates/devhub/addons/edit/basic.html:152 src/olympia/devhub/templates/devhub/addons/edit/details.html:85 src/olympia/devhub/templates/devhub/addons/edit/support.html:67
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:166 src/olympia/devhub/templates/devhub/addons/forms_shared/media.html:149
-#: src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:44 src/olympia/devhub/templates/devhub/versions/add_file_modal.html:78 src/olympia/devhub/templates/devhub/versions/edit.html:139
-#: src/olympia/devhub/templates/devhub/versions/list.html:242 src/olympia/devhub/templates/devhub/versions/list.html:276 src/olympia/devhub/templates/devhub/versions/list.html:317
-#: src/olympia/devhub/templates/devhub/versions/list.html:351 src/olympia/reviews/templates/reviews/edit_review.html:16 src/olympia/translations/templates/translations/trans-menu.html:50
+#: src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:43 src/olympia/devhub/templates/devhub/versions/add_file_modal.html:58 src/olympia/devhub/templates/devhub/versions/edit.html:139
+#: src/olympia/devhub/templates/devhub/versions/list.html:239 src/olympia/devhub/templates/devhub/versions/list.html:281 src/olympia/devhub/templates/devhub/versions/list.html:315
+#: src/olympia/devhub/templates/devhub/versions/list.html:349 src/olympia/reviews/templates/reviews/edit_review.html:16 src/olympia/translations/templates/translations/trans-menu.html:50
 #: src/olympia/translations/templates/translations/trans-menu.html:62
 msgid "or"
 msgstr "ਜਾਂ"
@@ -362,7 +362,7 @@ msgid "Add-on Information for {0}"
 msgstr "{0} ਲਈ ਐਡ-ਆਨ ਦੀ ਜਾਣਕਾਰੀ"
 
 #: src/olympia/addons/templates/addons/details_box.html:30 src/olympia/addons/templates/addons/persona_detail_table.html:3 src/olympia/addons/templates/addons/mobile/details.html:63
-#: src/olympia/addons/templates/addons/mobile/persona_detail_table.html:7 src/olympia/browse/views.py:459 src/olympia/devhub/views.py:75
+#: src/olympia/addons/templates/addons/mobile/persona_detail_table.html:7 src/olympia/browse/views.py:426 src/olympia/devhub/views.py:74
 msgid "Updated"
 msgstr "ਅੱਪਡੇਟ ਹੋਇਆ"
 
@@ -381,11 +381,11 @@ msgstr "ਨਾਲ ਕੰਮ ਕਰਦਾ"
 msgid "Visibility"
 msgstr "ਪ੍ਰਤੱਖਤਾ"
 
-#: src/olympia/addons/templates/addons/details_box.html:57 src/olympia/devhub/templates/devhub/index.html:94 src/olympia/devhub/templates/devhub/includes/addon_details.html:104
+#: src/olympia/addons/templates/addons/details_box.html:57 src/olympia/devhub/templates/devhub/index.html:94 src/olympia/devhub/templates/devhub/includes/addon_details.html:91
 msgid "Hidden"
 msgstr "ਲੁਕਿਆ"
 
-#: src/olympia/addons/templates/addons/details_box.html:59 src/olympia/devhub/templates/devhub/index.html:96 src/olympia/devhub/templates/devhub/includes/addon_details.html:106
+#: src/olympia/addons/templates/addons/details_box.html:59 src/olympia/devhub/templates/devhub/index.html:96 src/olympia/devhub/templates/devhub/includes/addon_details.html:93
 msgid "Unlisted"
 msgstr "ਅਣਸੂਚੀਬੱਧ"
 
@@ -393,13 +393,13 @@ msgstr "ਅਣਸੂਚੀਬੱਧ"
 msgid "Required Add-ons"
 msgstr "ਲੌੜੀਂਦੇ ਐਡ-ਆਨ"
 
-#: src/olympia/addons/templates/addons/details_box.html:81 src/olympia/addons/templates/addons/persona_detail_table.html:15 src/olympia/browse/views.py:462 src/olympia/devhub/views.py:78
-#: src/olympia/devhub/views.py:85 src/olympia/discovery/templates/discovery/addons/detail.html:57 src/olympia/reviews/forms.py:62 src/olympia/reviews/templates/reviews/add.html:57
+#: src/olympia/addons/templates/addons/details_box.html:81 src/olympia/addons/templates/addons/persona_detail_table.html:15 src/olympia/browse/views.py:429 src/olympia/devhub/views.py:77
+#: src/olympia/devhub/views.py:84 src/olympia/discovery/templates/discovery/addons/detail.html:57 src/olympia/reviews/forms.py:62 src/olympia/reviews/templates/reviews/add.html:57
 #: src/olympia/reviews/templates/reviews/mobile/review_list.html:18
 msgid "Rating"
 msgstr "ਰੇਟਿੰਗ"
 
-#: src/olympia/addons/templates/addons/details_box.html:85 src/olympia/browse/views.py:461 src/olympia/devhub/views.py:77 src/olympia/devhub/views.py:84
+#: src/olympia/addons/templates/addons/details_box.html:85 src/olympia/browse/views.py:428 src/olympia/devhub/views.py:76 src/olympia/devhub/views.py:83
 #: src/olympia/stats/templates/stats/addon_report_menu.html:8 src/olympia/stats/templates/stats/collection_report_menu.html:18
 msgid "Downloads"
 msgstr "ਡਾਊਨਲੋਡ"
@@ -419,7 +419,7 @@ msgstr "ਦੁਰਵਿਹਾਰ ਸੂਚਨਾਵਾਂ"
 
 #. The Privacy Policy for this add-on.
 #: src/olympia/addons/templates/addons/details_box.html:121 src/olympia/addons/templates/addons/privacy.html:19 src/olympia/addons/templates/addons/privacy.html:23
-#: src/olympia/addons/templates/addons/impala/button.html:43 src/olympia/addons/templates/addons/impala/details.html:307 src/olympia/devhub/templates/devhub/includes/policy_form.html:20
+#: src/olympia/addons/templates/addons/impala/button.html:43 src/olympia/addons/templates/addons/impala/details.html:312 src/olympia/devhub/templates/devhub/includes/policy_form.html:23
 #: src/olympia/templates/mobile/base_addons.html:87
 msgid "Privacy Policy"
 msgstr "ਪਰਦਾ ਨੀਤੀ"
@@ -444,7 +444,7 @@ msgstr "ਤਸਵੀਰ ਗੈਲਰੀ"
 msgid "Developer Comments"
 msgstr "ਡਿਵੈਲਪਰ ਟਿੱਪਣੀਆਂ"
 
-#: src/olympia/addons/templates/addons/details_box.html:199 src/olympia/addons/templates/addons/impala/details.html:259
+#: src/olympia/addons/templates/addons/details_box.html:199 src/olympia/addons/templates/addons/impala/details.html:264
 msgid "Development Channel"
 msgstr "ਵਿਕਾਸ ਚੈਨਲ"
 
@@ -468,7 +468,7 @@ msgstr ""
 "<strong>ਸਾਵਧਾਨੀ:</strong> ਇਸ ਐਡ-ਆਨ ਦੇ ਵਿਕਾਸ ਵਰਜਨ ਦੀ ਮੌਜ਼ੀਲਾ ਵੱਲੋਂ ਸਮੀਖਿਆ ਨਹੀਂ ਕੀਤੀ ਗਈ। ਇੱਕ ਵਾਰ ਤੁਸੀਂ ਇੱਕ ਵਿਕਾਸ ਵਰਜਨ ਇੰਸਟਾਲ ਕਰ ਲਿਆ ਤਾਂ ਤੁਹਾਡਾ ਇਸ ਦੇ ਡਿਵੈਲਪਰ ਤੋਂ ਵਿਕਾਸ ਅੱਪਡੇਟਾਂ ਲੈਣਾ ਜਾਰੀ ਰਹੇਗਾ। ਵਿਕਾਸ "
 "ਅੱਪਡੇਟਾਂ ਲੈਣੀਆਂ ਬੰਦ ਕਰਨ ਲਈ, ਉੱਪਰ ਦਿੱਤੇ ਲਿੰਕ ਤੋਂ ਮੂਲ ਵਰਜਨ ਮੁੜ ਇੰਸਟਾਲ ਕਰੋ।"
 
-#: src/olympia/addons/templates/addons/details_box.html:220 src/olympia/addons/templates/addons/impala/details.html:278
+#: src/olympia/addons/templates/addons/details_box.html:220 src/olympia/addons/templates/addons/impala/details.html:283
 msgid "Version {0}:"
 msgstr "ਵਰਜਨ {0}:"
 
@@ -487,7 +487,7 @@ msgid "End-User License Agreement for {0}"
 msgstr "ਲਈ ਅੰਤ-ਉਪਭੋਗੀ ਲਾਇਸੰਸ ਸਮਝੌਤਾ {0}"
 
 #: src/olympia/addons/templates/addons/eula.html:17 src/olympia/addons/templates/addons/eula.html:21 src/olympia/addons/templates/addons/impala/button.html:48
-#: src/olympia/addons/templates/addons/impala/details.html:316 src/olympia/devhub/templates/devhub/includes/policy_form.html:3 src/olympia/discovery/templates/discovery/addons/eula.html:11
+#: src/olympia/addons/templates/addons/impala/details.html:321 src/olympia/devhub/templates/devhub/includes/policy_form.html:3 src/olympia/discovery/templates/discovery/addons/eula.html:11
 msgid "End-User License Agreement"
 msgstr "ਅੰਤ-ਉਪਭੋਗੀ ਲਾਇਸੰਸ ਸਮਝੌਤਾ"
 
@@ -504,7 +504,7 @@ msgstr "{0} ਤੇ ਵਾਪਸ"
 msgid "Add-ons for {0}"
 msgstr "ਇਕਸਟੈਨਸ਼ਨ ਪੇਸਕਸ਼"
 
-#: src/olympia/addons/templates/addons/home.html:10 src/olympia/addons/templates/addons/home.html:51 src/olympia/browse/templates/browse/impala/base_listing.html:11
+#: src/olympia/addons/templates/addons/home.html:10 src/olympia/addons/templates/addons/home.html:53 src/olympia/browse/templates/browse/impala/base_listing.html:11
 msgid "Featured Extensions"
 msgstr "ਇਕਸਟੈਨਸ਼ਨਾਂ ਦੀ ਪੇਸਕਸ਼"
 
@@ -512,29 +512,29 @@ msgstr "ਇਕਸਟੈਨਸ਼ਨਾਂ ਦੀ ਪੇਸਕਸ਼"
 msgid "Popular Extensions"
 msgstr "ਪ੍ਰਸਿੱਧ ਇਕਸਟੈਨਸ਼ਨਾਂ"
 
-#: src/olympia/addons/templates/addons/home.html:42 src/olympia/amo/templates/amo/side_nav.html:3 src/olympia/amo/templates/amo/side_nav.html:11 src/olympia/amo/templates/amo/site_nav.html:3
-#: src/olympia/amo/templates/amo/site_nav.html:25 src/olympia/browse/views.py:236 src/olympia/browse/views.py:281 src/olympia/browse/views.py:481
+#: src/olympia/addons/templates/addons/home.html:44 src/olympia/amo/templates/amo/side_nav.html:3 src/olympia/amo/templates/amo/side_nav.html:11 src/olympia/amo/templates/amo/site_nav.html:3
+#: src/olympia/amo/templates/amo/site_nav.html:25 src/olympia/browse/views.py:203 src/olympia/browse/views.py:248 src/olympia/browse/views.py:448
 msgid "Most Popular"
 msgstr "ਸੱਭ ਤੋਂ ਮਸ਼ਹੂਰ"
 
-#: src/olympia/addons/templates/addons/home.html:43
+#: src/olympia/addons/templates/addons/home.html:45
 msgid "All »"
 msgstr "ਸਾਰੇ »"
 
-#: src/olympia/addons/templates/addons/home.html:52 src/olympia/addons/templates/addons/home.html:61 src/olympia/addons/templates/addons/home.html:70 src/olympia/addons/templates/addons/home.html:78
+#: src/olympia/addons/templates/addons/home.html:54 src/olympia/addons/templates/addons/home.html:63 src/olympia/addons/templates/addons/home.html:72 src/olympia/addons/templates/addons/home.html:80
 #: src/olympia/browse/templates/browse/impala/category_landing.html:36
 msgid "See all »"
 msgstr "ਵੇਖੋ ਸਾਰੇ »"
 
-#: src/olympia/addons/templates/addons/home.html:60
+#: src/olympia/addons/templates/addons/home.html:62
 msgid "Up &amp; Coming Extensions"
 msgstr "ਉੱਤੇ &amp; ਆ ਰਹੀਆਂ ਇਕਸਟੈਨਸ਼ਨਾਂ"
 
-#: src/olympia/addons/templates/addons/home.html:69 src/olympia/browse/templates/browse/personas/category_landing.html:61 src/olympia/discovery/templates/discovery/pane.html:74
+#: src/olympia/addons/templates/addons/home.html:71 src/olympia/browse/templates/browse/personas/category_landing.html:61 src/olympia/discovery/templates/discovery/pane.html:74
 msgid "Featured Themes"
 msgstr "ਥੀਮ ਪੇਸਕਸ਼"
 
-#: src/olympia/addons/templates/addons/home.html:77 src/olympia/bandwagon/templates/bandwagon/impala/collection_listing.html:5
+#: src/olympia/addons/templates/addons/home.html:79 src/olympia/bandwagon/templates/bandwagon/impala/collection_listing.html:5
 msgid "Featured Collections"
 msgstr "ਸੰਗ੍ਰਹਿ ਪੇਸਕਸ਼"
 
@@ -552,7 +552,7 @@ msgid "Updated {0}"
 msgstr "ਅੱਪਡੇਟ ਹੋਇਆ {0}"
 
 #. {0} is a date.
-#: src/olympia/addons/templates/addons/macros.html:10 src/olympia/addons/templates/addons/macros.html:69 src/olympia/addons/templates/addons/persona_preview.html:21
+#: src/olympia/addons/templates/addons/macros.html:10 src/olympia/addons/templates/addons/macros.html:69 src/olympia/addons/templates/addons/persona_preview.html:22
 #: src/olympia/addons/templates/addons/listing/items_mobile.html:44 src/olympia/addons/templates/addons/listing/macros.html:39 src/olympia/bandwagon/templates/bandwagon/collection_listing_items.html:37
 #: src/olympia/bandwagon/templates/bandwagon/impala/collection_listing_items.html:37
 msgid "Added {0}"
@@ -573,15 +573,14 @@ msgstr[0] "%(num)s ਉਪਭੋਗੀ"
 msgstr[1] "%(num)s ਉਪਭੋਗੀ"
 
 #. {0} is the number of downloads.
-#: src/olympia/addons/templates/addons/macros.html:53 src/olympia/addons/templates/addons/impala/details.html:61
+#: src/olympia/addons/templates/addons/macros.html:53 src/olympia/addons/templates/addons/impala/details.html:59
 msgid "{0} weekly download"
 msgid_plural "{0} weekly downloads"
 msgstr[0] "{0} ਹਫ਼ਤੇਵਾਰ ਡਾਊਨਲੋਡ"
 msgstr[1] "{0} ਹਫ਼ਤੇਵਾਰ ਡਾਊਨਲੋਡ"
 
 #. {0} is the number of users.
-#: src/olympia/addons/templates/addons/macros.html:61 src/olympia/addons/templates/addons/impala/details.html:54 src/olympia/compat/templates/compat/index.html:71
-#: src/olympia/zadmin/templates/zadmin/compat.html:67
+#: src/olympia/addons/templates/addons/macros.html:61 src/olympia/addons/templates/addons/impala/details.html:52 src/olympia/zadmin/templates/zadmin/compat.html:67
 msgid "{0} user"
 msgid_plural "{0} users"
 msgstr[0] "{0} ਉਪਭੋਗੀ"
@@ -599,7 +598,7 @@ msgstr "ਭੁਗਤਾਨ ਮੁਕੰਮਲ ਹੋਇਆ"
 msgid "Return to the addon."
 msgstr "ਐਡ-ਆਨ ਤੇ ਵਾਪਸ।"
 
-#: src/olympia/addons/templates/addons/persona_detail.html:17 src/olympia/addons/templates/addons/impala/details.html:106 src/olympia/addons/templates/addons/mobile/details.html:23
+#: src/olympia/addons/templates/addons/persona_detail.html:17 src/olympia/addons/templates/addons/impala/details.html:103 src/olympia/addons/templates/addons/mobile/details.html:23
 #: src/olympia/addons/templates/addons/mobile/persona_detail.html:21 src/olympia/discovery/templates/discovery/addons/base.html:27 src/olympia/editors/templates/editors/review.html:31
 msgid "by"
 msgstr "ਵੱਲੋਂ"
@@ -643,34 +642,35 @@ msgstr "ਰੋਜ਼ਾਨਾ ਉਪਭੋਗੀ"
 msgid "License"
 msgstr "ਲਾਇਸੰਸ"
 
-#: src/olympia/addons/templates/addons/persona_preview.html:12 src/olympia/constants/base.py:48
+#: src/olympia/addons/templates/addons/persona_preview.html:13 src/olympia/constants/base.py:48
 msgid "Awaiting Review"
 msgstr "ਸਮੀਖਿਆ ਦੀ ਉਡੀਕ"
 
-#: src/olympia/addons/templates/addons/persona_preview.html:14 src/olympia/amo/log.py:180 src/olympia/constants/base.py:42 src/olympia/editors/helpers.py:62
+#: src/olympia/addons/templates/addons/persona_preview.html:15 src/olympia/amo/log.py:180 src/olympia/constants/base.py:42 src/olympia/editors/helpers.py:62
 msgid "Rejected"
 msgstr "ਠੁਕਰਾਇਆ"
 
-#: src/olympia/addons/templates/addons/persona_preview.html:16 src/olympia/amo/log.py:159
+#: src/olympia/addons/templates/addons/persona_preview.html:17 src/olympia/amo/log.py:159
 msgid "Approved"
 msgstr "ਮਨਜ਼ੂਰ ਹੋਇਆ"
 
 #. {0} is the number of users.
-#: src/olympia/addons/templates/addons/persona_preview.html:26 src/olympia/addons/templates/addons/listing/items_mobile.html:36 src/olympia/addons/templates/addons/listing/macros.html:31
+#: src/olympia/addons/templates/addons/persona_preview.html:27 src/olympia/addons/templates/addons/listing/items_mobile.html:36 src/olympia/addons/templates/addons/listing/macros.html:31
 msgid "<strong>{0}</strong> user"
 msgid_plural "<strong>{0}</strong> users"
 msgstr[0] "<strong>{0}</strong> ਉਪਭੋਗੀ"
 msgstr[1] "<strong>{0}</strong> ਉਪਭੋਗੀ"
 
-#: src/olympia/addons/templates/addons/persona_preview.html:40
+#: src/olympia/addons/templates/addons/persona_preview.html:41
 msgid "Hover to Preview"
 msgstr "ਝਲਕ ਵੇਖਣ ਲਈ ਘੁਮਾਓ"
 
-#: src/olympia/addons/templates/addons/persona_preview.html:46 src/olympia/addons/templates/addons/persona_preview.html:48 src/olympia/reviews/templates/reviews/add.html:15
+#: src/olympia/addons/templates/addons/persona_preview.html:47 src/olympia/addons/templates/addons/persona_preview.html:49 src/olympia/addons/templates/addons/persona_preview.html:97
+#: src/olympia/reviews/templates/reviews/add.html:15
 msgid "Add"
 msgstr "ਜੋੜੋ"
 
-#: src/olympia/addons/templates/addons/persona_preview.html:57 src/olympia/bandwagon/templates/bandwagon/ajax_new.html:16 src/olympia/bandwagon/templates/bandwagon/edit.html:19
+#: src/olympia/addons/templates/addons/persona_preview.html:58 src/olympia/bandwagon/templates/bandwagon/ajax_new.html:16 src/olympia/bandwagon/templates/bandwagon/edit.html:19
 #: src/olympia/bandwagon/templates/bandwagon/includes/addedit.html:19 src/olympia/devhub/templates/devhub/addons/edit/admin.html:13 src/olympia/devhub/templates/devhub/addons/edit/basic.html:10
 #: src/olympia/devhub/templates/devhub/addons/edit/details.html:8 src/olympia/devhub/templates/devhub/addons/edit/media.html:6 src/olympia/devhub/templates/devhub/addons/edit/support.html:8
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:9 src/olympia/devhub/templates/devhub/addons/submit/describe.html:29 src/olympia/editors/templates/editors/review.html:257
@@ -679,21 +679,21 @@ msgstr "ਸੋਧ"
 
 #. For datetime formatting, see the table on
 #. http://docs.python.org/library/datetime.html#strftime-and-strptime-behavior
-#: src/olympia/addons/templates/addons/persona_preview.html:66
+#: src/olympia/addons/templates/addons/persona_preview.html:67
 #, python-format
 msgid "%%Y-%%m-%%d"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/persona_preview.html:67
+#: src/olympia/addons/templates/addons/persona_preview.html:68
 msgid "by {0} on {1}"
 msgstr "{1} ਤੇ {0} ਵੱਲੋਂ"
 
-#: src/olympia/addons/templates/addons/persona_preview.html:75 src/olympia/reviews/helpers.py:17 src/olympia/reviews/templates/reviews/review_list.html:63
+#: src/olympia/addons/templates/addons/persona_preview.html:76 src/olympia/reviews/helpers.py:17 src/olympia/reviews/templates/reviews/review_list.html:63
 #: src/olympia/reviews/templates/reviews/reviews_link.html:21 src/olympia/reviews/templates/reviews/impala/reviews_link.html:16
 msgid "Not yet rated"
 msgstr "ਅਜੇ ਤੱਕ ਰੇਟ ਨਹੀਂ ਕੀਤਾ"
 
-#: src/olympia/addons/templates/addons/persona_preview.html:78
+#: src/olympia/addons/templates/addons/persona_preview.html:79
 msgid "<b>{0}</b> users"
 msgstr "<b>{0}</b> ਉਪਭੋਗੀ"
 
@@ -706,8 +706,8 @@ msgid "Learn more about Firefox"
 msgstr "ਫ਼ਾਇਰਫ਼ਾਕਸ ਬਾਰੇ ਹੋਰ ਜਾਣੋ"
 
 #: src/olympia/addons/templates/addons/popups.html:22
-msgid "or <b><a class=\"installer\" href=\"{url}\">download anyway</a></b>"
-msgstr "ਜਾਂ <b><a class=\"installer\"href=\"{url}\">ਕਿਸੇ ਵੀ ਤਰ੍ਹਾਂ ਡਾਊਨਲੋਡ ਕਰੋ</a></b>"
+msgid "or <b><a class=\"button installer\" href=\"{url}\">download anyway</a></b>"
+msgstr ""
 
 #: src/olympia/addons/templates/addons/popups.html:26
 msgid ""
@@ -768,8 +768,8 @@ msgstr "ਇਸ ਪਰਸੋਨਾ ਨੂੰ %(app)s %(new_version)s ਦੀ ਲ�
 
 #: src/olympia/addons/templates/addons/popups.html:108
 msgid ""
-"<strong>Caution:</strong> This add-on has not been reviewed by Mozilla and can't be installed on release versions of Firefox 43 and above.  Be careful when installing third-party software that "
-"might harm your computer."
+"<strong>Caution:</strong> This add-on has not been reviewed by Mozilla and can't be installed on release versions of Firefox 43 and above. Be careful when installing third-party software that might"
+" harm your computer."
 msgstr ""
 
 #: src/olympia/addons/templates/addons/popups.html:120
@@ -804,7 +804,7 @@ msgid "Want {0} on your mobile Firefox? Scan this QR code to install directly to
 msgstr "ਆਪਣੇ ਮੋਬਾਈਲ ਫ਼ਾਇਰਫ਼ਾਕਸ ਤੇ {0}ਚਾਹੀਦਾ? ਆਪਣੇ ਫ਼ੋਨ ਤੇ ਸਿੱਧਾ ਇੰਸਟਾਲ ਕਰਨ ਲਈ ਇਸ QR ਕੋਡ ਨੂੰ ਸਕੈਨ ਕਰੋ। ( ਤੁਹਾਨੂੰ ਇੱਕ QR ਰੀਡਰ ਦੀ ਜ਼ਰੂਰਤ ਹੈ। ਆਪਣੇ ਫ਼ੋਨ ਦਾ ਬਾਜ਼ਾਰ ਖੋਜੋ ਜੇਕਰ ਤੁਹਾਡੇ ਕੋਲ ਇਹ ਨਹੀਂ ਹੈ।)"
 
 #: src/olympia/addons/templates/addons/report_abuse.html:6 src/olympia/addons/templates/addons/report_abuse_full.html:10 src/olympia/addons/templates/addons/impala/details-more.html:23
-#: src/olympia/addons/templates/addons/impala/details.html:328
+#: src/olympia/addons/templates/addons/impala/details.html:333
 msgid "Report Abuse"
 msgstr "ਦੁਰਵਿਹਾਰ ਸੂਚਨਾ"
 
@@ -825,9 +825,9 @@ msgstr "ਰਿਪੋਰਟ ਭੇਜੋ"
 #: src/olympia/devhub/templates/devhub/addons/ajax_compat_update.html:36 src/olympia/devhub/templates/devhub/addons/profile.html:44 src/olympia/devhub/templates/devhub/addons/edit/admin.html:104
 #: src/olympia/devhub/templates/devhub/addons/edit/basic.html:155 src/olympia/devhub/templates/devhub/addons/edit/details.html:88 src/olympia/devhub/templates/devhub/addons/edit/support.html:70
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:169 src/olympia/devhub/templates/devhub/addons/forms_shared/media.html:152
-#: src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:44 src/olympia/devhub/templates/devhub/personas/edit.html:222 src/olympia/devhub/templates/devhub/versions/add_file_modal.html:79
-#: src/olympia/devhub/templates/devhub/versions/edit.html:140 src/olympia/devhub/templates/devhub/versions/list.html:208 src/olympia/devhub/templates/devhub/versions/list.html:242
-#: src/olympia/devhub/templates/devhub/versions/list.html:276 src/olympia/devhub/templates/devhub/versions/list.html:317 src/olympia/reviews/templates/reviews/edit_review.html:16
+#: src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:43 src/olympia/devhub/templates/devhub/personas/edit.html:222 src/olympia/devhub/templates/devhub/versions/add_file_modal.html:59
+#: src/olympia/devhub/templates/devhub/versions/edit.html:140 src/olympia/devhub/templates/devhub/versions/list.html:208 src/olympia/devhub/templates/devhub/versions/list.html:239
+#: src/olympia/devhub/templates/devhub/versions/list.html:281 src/olympia/devhub/templates/devhub/versions/list.html:315 src/olympia/reviews/templates/reviews/edit_review.html:16
 #: src/olympia/translations/templates/translations/trans-menu.html:50 src/olympia/translations/templates/translations/trans-menu.html:62 src/olympia/zadmin/templates/zadmin/validation.html:105
 msgid "Cancel"
 msgstr "ਰੱਦ"
@@ -872,7 +872,7 @@ msgstr "ਇਸ ਐਡ-ਆਨ ਲਈ ਸਹਾਇਤਾ ਕਿੱਥੋਂ ਲਈ
 msgid "Review Guidelines"
 msgstr "ਹਿਦਾਇਤਾਂ ਦੀ ਸਮੀਖਿਆ"
 
-#: src/olympia/addons/templates/addons/review_list_box.html:5 src/olympia/addons/templates/addons/impala/details-more.html:27 src/olympia/editors/helpers.py:921
+#: src/olympia/addons/templates/addons/review_list_box.html:5 src/olympia/addons/templates/addons/impala/details-more.html:27 src/olympia/editors/helpers.py:1001
 #: src/olympia/reviews/templates/reviews/add.html:14 src/olympia/reviews/templates/reviews/reply.html:14 src/olympia/reviews/templates/reviews/review_list.html:19
 #: src/olympia/reviews/templates/reviews/mobile/review_list.html:26
 msgid "Reviews"
@@ -963,103 +963,103 @@ msgid_plural "Other add-ons by these authors"
 msgstr[0] "%(author)s ਵੱਲੋਂ ਹੋਰ ਐਡ-ਆਨ"
 msgstr[1] "ਇਹਨਾਂ ਲੇਖਕਾਂ ਵੱਲੋਂ ਹੋਰ ਐਡ-ਆਨ"
 
-#: src/olympia/addons/templates/addons/impala/details.html:41
+#: src/olympia/addons/templates/addons/impala/details.html:39
 #, python-format
 msgid "<span itemprop=\"ratingCount\">%(num)s</span> user review"
 msgid_plural "<span itemprop=\"ratingCount\">%(num)s</span> user reviews"
 msgstr[0] "<span itemprop=\"ratingCount\">%(num)s</span> ਉਪਭੋਗੀ ਸਮੀਖਿਆ"
 msgstr[1] "<span itemprop=\"ratingCount\">%(num)s</span> ਉਪਭੋਗੀ ਸਮੀਖਿਆਵਾਂ"
 
-#: src/olympia/addons/templates/addons/impala/details.html:69
+#: src/olympia/addons/templates/addons/impala/details.html:66
 msgid "View statistics"
 msgstr "ਅੰਕੜੇ ਵੇਖੋ"
 
-#: src/olympia/addons/templates/addons/impala/details.html:84
+#: src/olympia/addons/templates/addons/impala/details.html:81
 msgid "Manage"
 msgstr "ਪ੍ਰਬੰਧ"
 
 #. {0} is an add-on name.
-#: src/olympia/addons/templates/addons/impala/details.html:96
+#: src/olympia/addons/templates/addons/impala/details.html:93
 msgid "Icon of {0}"
 msgstr "{0} ਦਾ ਆਈਕਾਨ"
 
-#: src/olympia/addons/templates/addons/impala/details.html:103 src/olympia/addons/templates/addons/impala/listing/items.html:14
+#: src/olympia/addons/templates/addons/impala/details.html:100 src/olympia/addons/templates/addons/impala/listing/items.html:14
 msgid "No Restart"
 msgstr "ਮੁੜ ਚਾਲੂ ਨਹੀਂ"
 
-#: src/olympia/addons/templates/addons/impala/details.html:127
+#: src/olympia/addons/templates/addons/impala/details.html:124
 #, fuzzy, python-format
 msgid "Meet the Developer: <a href=\"%(url)s\">%(name)s</a>"
 msgid_plural "<a href=\"%(url)s\">Meet the Developers</a>"
 msgstr[0] "ਡਿਵੈਲਪਰ ਨੂੰ ਮਿਲੋ: <a href=\"%(url)s\">%(name)s</a>"
 msgstr[1] "<a href=\"%(url)s\">ਡਿਵੈਲਪਰਾਂ ਨੂੰ ਮਿਲੋ</a>"
 
-#: src/olympia/addons/templates/addons/impala/details.html:137
+#: src/olympia/addons/templates/addons/impala/details.html:134
 msgid "Learn why {0} was created and find out what's next for this add-on."
 msgstr "ਜਾਣੋ {0} ਕਿਉਂ ਰਚਿਆ ਗਿਆ ਅਤੇ ਪਤਾ ਲਗਾਓ ਇਸ ਐਡ-ਆਨ ਵਾਸਤੇ ਅੱਗੇ ਕੀ ਹੈ।"
 
 #. {0} is an index.
-#: src/olympia/addons/templates/addons/impala/details.html:156
+#: src/olympia/addons/templates/addons/impala/details.html:161
 msgid "Add-on screenshot #{0}"
 msgstr "ਐਡ-ਆਨ ਸਕਰੀਨਸ਼ਾੱਟ #{0}"
 
-#: src/olympia/addons/templates/addons/impala/details.html:182
+#: src/olympia/addons/templates/addons/impala/details.html:187
 msgid "Add-on home page"
 msgstr "ਐਡ-ਆਨ ਮੁੱਖ ਸਫ਼ਾ"
 
-#: src/olympia/addons/templates/addons/impala/details.html:185
+#: src/olympia/addons/templates/addons/impala/details.html:190
 msgid "Support site"
 msgstr "ਸਹਿਯੋਗ ਸਾਈਟ"
 
-#: src/olympia/addons/templates/addons/impala/details.html:189
+#: src/olympia/addons/templates/addons/impala/details.html:194
 msgid "Support E-mail"
 msgstr "ਸਹਿਯੋਗ ਈ-ਮੇਲ"
 
-#: src/olympia/addons/templates/addons/impala/details.html:194 src/olympia/devhub/models.py:378 src/olympia/devhub/templates/devhub/versions/list.html:12
+#: src/olympia/addons/templates/addons/impala/details.html:199 src/olympia/devhub/models.py:378 src/olympia/devhub/templates/devhub/versions/list.html:12
 #: src/olympia/versions/templates/versions/version.html:6 src/olympia/versions/templates/versions/mobile/version.html:6
 msgid "Version {0}"
 msgstr "ਵਰਜਨ {0}"
 
-#: src/olympia/addons/templates/addons/impala/details.html:194
+#: src/olympia/addons/templates/addons/impala/details.html:199
 msgid "Info"
 msgstr "ਇੰਫ਼ੋ"
 
-#: src/olympia/addons/templates/addons/impala/details.html:195 src/olympia/devhub/templates/devhub/includes/addon_details.html:129
+#: src/olympia/addons/templates/addons/impala/details.html:200 src/olympia/devhub/templates/devhub/includes/addon_details.html:116
 msgid "Last Updated:"
 msgstr "ਆਖਰੀ ਅੱਪਡੇਟ ਹੋਇਆ:"
 
-#: src/olympia/addons/templates/addons/impala/details.html:200
+#: src/olympia/addons/templates/addons/impala/details.html:205
 #, python-format
 msgid "Released under <a target=\"_blank\" href=\"%(url)s\">%(name)s</a>"
 msgstr "<a target=\"_blank\" href=\"%(url)s\">%(name)s</a> ਦੇ ਅਧੀਨ ਜਾਰੀ ਹੋਇਆ"
 
-#: src/olympia/addons/templates/addons/impala/details.html:201 src/olympia/addons/templates/addons/impala/details.html:206 src/olympia/amo/helpers.py:398 src/olympia/devhub/forms.py:142
+#: src/olympia/addons/templates/addons/impala/details.html:206 src/olympia/addons/templates/addons/impala/details.html:211 src/olympia/amo/helpers.py:398 src/olympia/devhub/forms.py:142
 #: src/olympia/devhub/forms.py:173 src/olympia/versions/templates/versions/version.html:40 src/olympia/versions/templates/versions/version.html:45
 msgid "Custom License"
 msgstr "ਕਸਟਮ ਲਾਇਸੰਸ"
 
-#: src/olympia/addons/templates/addons/impala/details.html:205
+#: src/olympia/addons/templates/addons/impala/details.html:210
 #, python-format
 msgid "Released under <a href=\"%(url)s\">%(name)s</a>"
 msgstr "<a href=\"%(url)s\">%(name)s</a> ਦੇ ਅਧੀਨ ਜਾਰੀ ਹੋਇਆ"
 
-#: src/olympia/addons/templates/addons/impala/details.html:217
+#: src/olympia/addons/templates/addons/impala/details.html:222
 msgid "About this Add-on"
 msgstr "ਇਸ ਐਡ-ਆਨ ਬਾਰੇ"
 
-#: src/olympia/addons/templates/addons/impala/details.html:233
+#: src/olympia/addons/templates/addons/impala/details.html:238
 msgid "Developer’s Comments"
 msgstr "ਡਿਵੈਲਪਰ ਦੀਆਂ ਟਿੱਪਣੀਆਂ"
 
-#: src/olympia/addons/templates/addons/impala/details.html:243
+#: src/olympia/addons/templates/addons/impala/details.html:248
 msgid "Version Information"
 msgstr "ਵਰਜਨ ਜਾਣਕਾਰੀ"
 
-#: src/olympia/addons/templates/addons/impala/details.html:250
+#: src/olympia/addons/templates/addons/impala/details.html:255
 msgid "See complete version history"
 msgstr "ਵੇਖੋ ਸੰਪੂਰਨ ਵਰਜਨ ਇਤਿਹਾਸ"
 
-#: src/olympia/addons/templates/addons/impala/details.html:262
+#: src/olympia/addons/templates/addons/impala/details.html:267
 msgid ""
 "The Development Channel lets you test an experimental new version of this add-on before it's released to the general public. Once you install the development version, you will continue to get "
 "updates from this channel. To stop receiving development updates, reinstall the default version from the link above."
@@ -1067,17 +1067,17 @@ msgstr ""
 "ਵਿਕਾਸ ਚੈਨਲ ਤੁਹਾਨੂੰ ਇਸ ਐਡ-ਆਨ ਦੇ ਇੱਕ ਨਵੇਂ ਪ੍ਰਯੋਗਆਤਮਕ ਵਰਜਨ ਦੀ ਪਰਖ ਕਰਨ ਦਵੇਗਾ ਇਸ ਤੋਂ ਪਹਿਲਾਂ ਕਿ ਇਹ ਆਮ ਲੋਕਾਂ ਲਈ ਜਾਰੀ ਕੀਤਾ ਜਾਵੇ। ਇੱਕ ਵਾਰ ਤੁਸੀਂ ਵਿਕਾਸ ਵਰਜਨ ਇੰਸਟਾਲ ਕਰ ਲਿਆ, ਤੁਹਾਡਾ ਇਸ ਚੈਨਲ ਤੋਂ ਅੱਪਡੇਟਾਂ ਲੈਣਾ "
 "ਜਾਰੀ ਰਹੇਗਾ। ਵਿਕਾਸ ਅੱਪਡੇਟਾਂ ਲੈਣਾ ਬੰਦ ਕਰਨ ਲਈ, ਉੱਪਰ ਦਿੱਤੇ ਲਿੰਕ ਤੋਂ ਮੂਲ ਵਰਜਨ ਮੁੜ ਇੰਸਟਾਲ ਕਰੋ।"
 
-#: src/olympia/addons/templates/addons/impala/details.html:272
+#: src/olympia/addons/templates/addons/impala/details.html:277
 msgid "<strong>Caution:</strong> Development versions of this add-on have not been reviewed by Mozilla."
 msgstr ""
 
-#: src/olympia/addons/templates/addons/impala/details.html:287
+#: src/olympia/addons/templates/addons/impala/details.html:292
 msgid "See complete development channel history"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/impala/details.html:306 src/olympia/addons/templates/addons/impala/details.html:315 src/olympia/addons/templates/addons/impala/details.html:327
+#: src/olympia/addons/templates/addons/impala/details.html:311 src/olympia/addons/templates/addons/impala/details.html:320 src/olympia/addons/templates/addons/impala/details.html:332
 #: src/olympia/addons/templates/addons/impala/review_add_box.html:4 src/olympia/stats/templates/stats/popup.html:2 src/olympia/stats/templates/stats/popup.html:8
-#: src/olympia/stats/templates/stats/stats.html:202 src/olympia/users/templates/users/profile.html:119
+#: src/olympia/stats/templates/stats/stats.html:204 src/olympia/users/templates/users/profile.html:119
 msgid "close"
 msgstr "ਬੰਦ"
 
@@ -1133,15 +1133,11 @@ msgstr "{addon}ਲਈ ਸੋਰਸ ਕੋਡ ਲਾਇਸੰਸ"
 msgid "Source Code License"
 msgstr "ਸੋਰਸ ਕੋਡ ਲਾਇਸੰਸ"
 
-#: src/olympia/addons/templates/addons/impala/persona_grid.html:16 src/olympia/addons/templates/addons/impala/toplist.html:6
-msgid "{0} users"
-msgstr "{0} ਉਪਭੋਗੀ"
-
 #: src/olympia/addons/templates/addons/impala/review_list_box.html:19 src/olympia/reviews/templates/reviews/review.html:40
 msgid "permalink"
 msgstr "ਪਰਮਾਲਿੰਕ"
 
-#: src/olympia/addons/templates/addons/impala/review_list_box.html:23 src/olympia/editors/templates/editors/queue.html:98 src/olympia/reviews/templates/reviews/review.html:44
+#: src/olympia/addons/templates/addons/impala/review_list_box.html:23 src/olympia/editors/templates/editors/queue.html:104 src/olympia/reviews/templates/reviews/review.html:44
 msgid "translate"
 msgstr "ਅਨੁਵਾਦ"
 
@@ -1160,6 +1156,10 @@ msgstr "ਇਸ ਐਡ-ਆਨ ਦੀ ਅਜੇ ਸਮੀਖਿਆ ਨਹੀਂ �
 msgid "Be the first!"
 msgstr "ਪਹਿਲੇ ਹੋ!"
 
+#: src/olympia/addons/templates/addons/impala/toplist.html:6
+msgid "{0} users"
+msgstr "{0} ਉਪਭੋਗੀ"
+
 #: src/olympia/addons/templates/addons/impala/listing/sorter.html:14 src/olympia/devhub/templates/devhub/addons/listing/item_actions.html:49
 msgid "More"
 msgstr "ਹੋਰ"
@@ -1172,7 +1172,7 @@ msgstr "ਸੰਗ੍ਰਹਿ ਵਿੱਚ ਜੋੜੋ"
 msgid "My Add-ons"
 msgstr "ਮੇਰੇ ਐਡ-ਆਨ"
 
-#: src/olympia/addons/templates/addons/includes/dashboard_tabs.html:6 src/olympia/amo/context_processors.py:51
+#: src/olympia/addons/templates/addons/includes/dashboard_tabs.html:6 src/olympia/amo/context_processors.py:52
 msgid "My Themes"
 msgstr "ਮੇਰੇ ਥੀਮ"
 
@@ -1227,7 +1227,7 @@ msgstr "ਉਪਭੋਗੀ"
 msgid "Weekly Downloads"
 msgstr "ਹਫ਼ਤੇਵਾਰ ਡਾਊਨਲੋਡ"
 
-#: src/olympia/addons/templates/addons/mobile/details.html:99 src/olympia/compat/templates/compat/reporter_detail.html:46 src/olympia/devhub/forms.py:787
+#: src/olympia/addons/templates/addons/mobile/details.html:99 src/olympia/compat/templates/compat/reporter_detail.html:46 src/olympia/devhub/forms.py:788
 #: src/olympia/devhub/templates/devhub/versions/list.html:163
 msgid "Version"
 msgstr "ਵਰਜਨ"
@@ -1311,7 +1311,7 @@ msgstr ""
 #: src/olympia/browse/templates/browse/personas/base.html:6 src/olympia/browse/templates/browse/personas/base.html:42 src/olympia/browse/templates/browse/personas/category_landing.html:21
 #: src/olympia/browse/templates/browse/personas/category_landing.html:23 src/olympia/browse/templates/browse/personas/category_landing.html:38 src/olympia/browse/templates/browse/personas/grid.html:7
 #: src/olympia/browse/templates/browse/personas/grid.html:11 src/olympia/browse/templates/browse/personas/mobile/base.html:7 src/olympia/browse/templates/browse/personas/mobile/category_landing.html:19
-#: src/olympia/constants/base.py:180 src/olympia/devhub/templates/devhub/personas/submit.html:13 src/olympia/editors/helpers.py:105 src/olympia/editors/templates/editors/base.html:26
+#: src/olympia/constants/base.py:180 src/olympia/devhub/templates/devhub/personas/submit.html:13 src/olympia/editors/helpers.py:107 src/olympia/editors/templates/editors/base.html:26
 #: src/olympia/editors/templates/editors/performance.html:73 src/olympia/search/templates/search/personas.html:39 src/olympia/templates/menu_links.html:9
 msgid "Themes"
 msgstr "ਥੀਮ"
@@ -1332,7 +1332,7 @@ msgstr "ਹੋਰ ਐਡ-ਆਨ"
 msgid "Highest Rated"
 msgstr "ਸੱਭ ਤੋਂ ਵੱਧ ਰੇਟ ਹੋਇਆ"
 
-#: src/olympia/addons/templates/addons/mobile/home.html:74 src/olympia/amo/templates/amo/side_nav.html:5 src/olympia/amo/templates/amo/site_nav.html:27 src/olympia/amo/templates/amo/site_nav.html:57
+#: src/olympia/addons/templates/addons/mobile/home.html:74 src/olympia/amo/templates/amo/side_nav.html:5 src/olympia/amo/templates/amo/site_nav.html:27 src/olympia/amo/templates/amo/site_nav.html:55
 #: src/olympia/bandwagon/views.py:97 src/olympia/browse/views.py:57 src/olympia/browse/views.py:67 src/olympia/browse/templates/browse/personas/mobile/category_landing.html:65
 #: src/olympia/search/forms.py:15 src/olympia/search/forms.py:87
 msgid "Newest"
@@ -1350,84 +1350,84 @@ msgstr " ਥੀਮ ਇੰਫ਼ੋ &raquo;"
 msgid "Tools"
 msgstr "ਟੂਲ"
 
-#: src/olympia/amo/context_processors.py:48 src/olympia/discovery/templates/discovery/pane_account.html:8 src/olympia/users/templates/users/includes/navigation.html:2
+#: src/olympia/amo/context_processors.py:49 src/olympia/discovery/templates/discovery/pane_account.html:8 src/olympia/users/templates/users/includes/navigation.html:2
 msgid "My Profile"
 msgstr "ਮੇਰੀ ਪ੍ਰੋਫ਼ਾਈਲ"
 
-#: src/olympia/amo/context_processors.py:54 src/olympia/users/templates/users/edit.html:5 src/olympia/users/templates/users/includes/navigation.html:3
+#: src/olympia/amo/context_processors.py:55 src/olympia/users/templates/users/edit.html:5 src/olympia/users/templates/users/includes/navigation.html:3
 msgid "Account Settings"
 msgstr "ਖਾਤਾ ਸੈਟਿੰਗ"
 
-#: src/olympia/amo/context_processors.py:57 src/olympia/discovery/templates/discovery/pane_account.html:11 src/olympia/users/templates/users/profile.html:83
+#: src/olympia/amo/context_processors.py:58 src/olympia/discovery/templates/discovery/pane_account.html:11 src/olympia/users/templates/users/profile.html:83
 #: src/olympia/users/templates/users/includes/navigation.html:4
 msgid "My Collections"
 msgstr "ਮੇਰੇ ਸੰਗ੍ਰਹਿ"
 
-#: src/olympia/amo/context_processors.py:62 src/olympia/discovery/templates/discovery/pane_account.html:10 src/olympia/users/templates/users/includes/navigation.html:7
+#: src/olympia/amo/context_processors.py:63 src/olympia/discovery/templates/discovery/pane_account.html:10 src/olympia/users/templates/users/includes/navigation.html:7
 msgid "My Favorites"
 msgstr "ਮੇਰੇ ਪਸੰਦੀਦਾ"
 
-#: src/olympia/amo/context_processors.py:67 src/olympia/discovery/templates/discovery/pane_account.html:13 src/olympia/templates/impala/user_login.html:14 src/olympia/templates/mobile/header_auth.html:5
+#: src/olympia/amo/context_processors.py:68 src/olympia/discovery/templates/discovery/pane_account.html:13 src/olympia/templates/impala/user_login.html:14 src/olympia/templates/mobile/header_auth.html:5
 msgid "Log out"
 msgstr "ਲਾਗ ਆਉਟ"
 
-#: src/olympia/amo/context_processors.py:72 src/olympia/devhub/templates/devhub/addons/dashboard.html:4
+#: src/olympia/amo/context_processors.py:73 src/olympia/devhub/templates/devhub/addons/dashboard.html:4
 msgid "Manage My Submissions"
 msgstr "ਮੇਰੀਆਂ ਪੇਸ਼ਕਸ਼ਾਂ ਦਾ ਪ੍ਰਬੰਧ ਕਰੋ"
 
-#: src/olympia/amo/context_processors.py:75 src/olympia/devhub/templates/devhub/nav.html:27 src/olympia/devhub/templates/devhub/addons/dashboard.html:25
+#: src/olympia/amo/context_processors.py:76 src/olympia/devhub/templates/devhub/nav.html:27 src/olympia/devhub/templates/devhub/addons/dashboard.html:25
 #: src/olympia/devhub/templates/devhub/addons/submit/base.html:4
 msgid "Submit a New Add-on"
 msgstr "ਇੱਕ ਨਵਾਂ ਐਡ-ਆਨ ਭੇਜੋ"
 
-#: src/olympia/amo/context_processors.py:77 src/olympia/browse/templates/browse/personas/base.html:50 src/olympia/devhub/templates/devhub/index.html:24
+#: src/olympia/amo/context_processors.py:78 src/olympia/browse/templates/browse/personas/base.html:50 src/olympia/devhub/templates/devhub/index.html:24
 #: src/olympia/devhub/templates/devhub/addons/dashboard.html:29
 msgid "Submit a New Theme"
 msgstr "ਇੱਕ ਨਵਾਂ ਥੀਮ ਭੇਜੋ"
 
-#: src/olympia/amo/context_processors.py:79 src/olympia/amo/templates/amo/site_nav.html:87 src/olympia/devhub/helpers.py:36 src/olympia/devhub/helpers.py:68 src/olympia/devhub/helpers.py:102
+#: src/olympia/amo/context_processors.py:80 src/olympia/amo/templates/amo/site_nav.html:85 src/olympia/devhub/helpers.py:36 src/olympia/devhub/helpers.py:68 src/olympia/devhub/helpers.py:102
 #: src/olympia/templates/footer.html:6 src/olympia/templates/menu_links.html:14
 msgid "Developer Hub"
 msgstr "ਡਿਵੈਲਪਰ ਹਬ"
 
-#: src/olympia/amo/context_processors.py:83 src/olympia/devhub/views.py:1792
+#: src/olympia/amo/context_processors.py:84 src/olympia/devhub/views.py:1799
 msgid "Manage API Keys"
 msgstr ""
 
-#: src/olympia/amo/context_processors.py:88 src/olympia/editors/helpers.py:82 src/olympia/editors/helpers.py:102 src/olympia/editors/templates/editors/base.html:10
+#: src/olympia/amo/context_processors.py:89 src/olympia/editors/helpers.py:84 src/olympia/editors/helpers.py:104 src/olympia/editors/templates/editors/base.html:10
 msgid "Editor Tools"
 msgstr "ਸੰਪਾਦਕ ਟੂਲ"
 
-#: src/olympia/amo/context_processors.py:92
+#: src/olympia/amo/context_processors.py:93
 msgid "Admin Tools"
 msgstr "ਐਡਮਿਨ ਟੂਲ"
 
-#: src/olympia/amo/fields.py:15
+#: src/olympia/amo/fields.py:20
 msgid "Incorrect, please try again."
 msgstr ""
 
-#: src/olympia/amo/fields.py:16
+#: src/olympia/amo/fields.py:21
 msgid "Error verifying input, please try again."
 msgstr ""
 
-#: src/olympia/amo/fields.py:32
+#: src/olympia/amo/fields.py:37
 msgid "This must be a valid hex color code, such as #000000."
 msgstr "ਇਹ ਇੱਕ ਜਾਇਜ ਹੈਕਸ ਕਲਰ ਕੋਡ ਹੋਣਾ ਚਾਹੀਦਾ ਹੈ, ਜਿਵੇਂ ਕਿ #000000।"
 
-#: src/olympia/amo/fields.py:58
+#: src/olympia/amo/fields.py:63
 msgid "Enter at least one value."
 msgstr "ਘੱਟੋ ਘੱਟ ਇੱਕ ਵੈਲਯੂ ਭਰੋ।"
 
-#: src/olympia/amo/helpers.py:162 src/olympia/amo/templates/amo/site_nav.html:61 src/olympia/bandwagon/templates/bandwagon/add.html:9 src/olympia/bandwagon/templates/bandwagon/collection_detail.html:15
+#: src/olympia/amo/helpers.py:162 src/olympia/amo/templates/amo/site_nav.html:59 src/olympia/bandwagon/templates/bandwagon/add.html:9 src/olympia/bandwagon/templates/bandwagon/collection_detail.html:15
 #: src/olympia/bandwagon/templates/bandwagon/delete.html:9 src/olympia/bandwagon/templates/bandwagon/edit.html:15 src/olympia/bandwagon/templates/bandwagon/user_listing.html:18
 #: src/olympia/bandwagon/templates/bandwagon/user_listing.html:21 src/olympia/bandwagon/templates/bandwagon/impala/collection_listing.html:12
 #: src/olympia/bandwagon/templates/bandwagon/impala/collection_listing.html:20 src/olympia/bandwagon/templates/bandwagon/impala/collection_listing.html:24
 #: src/olympia/bandwagon/templates/bandwagon/impala/collection_sidebar.html:3 src/olympia/bandwagon/templates/bandwagon/includes/collection_sidebar.html:2
-#: src/olympia/bandwagon/templates/bandwagon/mobile/collection_listing.html:3 src/olympia/stats/templates/stats/stats.html:77 src/olympia/templates/menu_links.html:12
+#: src/olympia/bandwagon/templates/bandwagon/mobile/collection_listing.html:3 src/olympia/stats/templates/stats/stats.html:33 src/olympia/templates/menu_links.html:12
 msgid "Collections"
 msgstr "ਸੰਗ੍ਰਹਿ "
 
-#: src/olympia/amo/helpers.py:171 src/olympia/amo/templates/amo/site_nav.html:85 src/olympia/browse/templates/browse/language_tools.html:3
+#: src/olympia/amo/helpers.py:171 src/olympia/amo/templates/amo/site_nav.html:83 src/olympia/browse/templates/browse/language_tools.html:3
 msgid "Dictionaries & Language Packs"
 msgstr "ਸ਼ਬਦਕੋਸ ਅਤੇ ਭਾਸ਼ਾ ਪੈਕ"
 
@@ -1579,8 +1579,8 @@ msgstr "ਸੁਪਰ ਸਮੀਖਿਆ ਦੀ ਮੰਗ ਹੋਈ।"
 msgid "Comment on {addon} {version}."
 msgstr "ਟਿੱਪਣੀ {addon} {version}ਲਈ।"
 
-#: src/olympia/amo/log.py:236 src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:19 src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:47
-#: src/olympia/editors/helpers.py:511 src/olympia/editors/templates/editors/themes/history_table.html:11
+#: src/olympia/amo/log.py:236 src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:17 src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:45
+#: src/olympia/editors/helpers.py:584 src/olympia/editors/templates/editors/themes/history_table.html:11
 msgid "Comment"
 msgstr "ਟਿੱਪਣੀ"
 
@@ -1909,7 +1909,7 @@ msgstr "ਪਿਛਲਾ"
 #: src/olympia/amo/templates/amo/mobile/paginator.html:14 src/olympia/amo/templates/amo/mobile/paginator.html:16 src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:51
 #: src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:65 src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:78
 #: src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:91 src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:104
-#: src/olympia/discovery/templates/discovery/pane.html:45 src/olympia/discovery/templates/discovery/addons/detail.html:39 src/olympia/stats/templates/stats/stats.html:167
+#: src/olympia/discovery/templates/discovery/pane.html:45 src/olympia/discovery/templates/discovery/addons/detail.html:39 src/olympia/stats/templates/stats/stats.html:169
 msgid "Next"
 msgstr "ਅਗਲਾ"
 
@@ -1943,7 +1943,7 @@ msgstr ""
 "href=\"#\" id=\"recaptcha_different\">ਹੋਰ ਸ਼ਬਦਾਂ ਨੂੰ ਅਜ਼ਮਾ</a> ਸਕਦੇ ਹੋ ਜਾਂ ਇਸ ਦੀ ਬਜਾਏ <a href=\"#\" id=\"recaptcha_audio\">ਇੱਕ ਵੱਖਰੇ ਤਰ੍ਹਾਂ ਦੀ ਚੁਣੌਤੀ</a> ਦੀ ਕੋਸ਼ਿਸ ਕਰੋ। </p>"
 
 #: src/olympia/amo/templates/amo/side_nav.html:4 src/olympia/amo/templates/amo/side_nav.html:12 src/olympia/amo/templates/amo/site_nav.html:4 src/olympia/amo/templates/amo/site_nav.html:26
-#: src/olympia/browse/views.py:56 src/olympia/browse/views.py:66 src/olympia/browse/views.py:237 src/olympia/browse/views.py:282 src/olympia/search/forms.py:86
+#: src/olympia/browse/views.py:56 src/olympia/browse/views.py:66 src/olympia/browse/views.py:204 src/olympia/browse/views.py:249 src/olympia/search/forms.py:86
 msgid "Top Rated"
 msgstr "ਚੋਟੀ ਦਾ ਦਰਜਾ ਪ੍ਰਾਪਤ"
 
@@ -1957,37 +1957,37 @@ msgstr "ਪੜਚੋਲ"
 msgid "Extensions"
 msgstr "ਇਕਸਟੈਨਸ਼ਨ"
 
-#: src/olympia/amo/templates/amo/site_nav.html:45
+#: src/olympia/amo/templates/amo/site_nav.html:44
 msgid "Want more customization? Try <b>Complete Themes</b>"
 msgstr "ਹੋਰ ਆਪਣਾ ਬਣਾਉਣਾ ਚਾਹੁੰਦੇ ਹੋ? ਵਰਤੋਂ <b>ਮੁਕੰਮਲ ਥੀਮ</b>"
 
-#: src/olympia/amo/templates/amo/site_nav.html:56 src/olympia/bandwagon/views.py:96
+#: src/olympia/amo/templates/amo/site_nav.html:54 src/olympia/bandwagon/views.py:96
 msgid "Most Followers"
 msgstr "ਜਿਆਦਾਤਰ ਸਮਰਥਕ"
 
-#: src/olympia/amo/templates/amo/site_nav.html:68 src/olympia/bandwagon/templates/bandwagon/impala/collection_sidebar.html:16 src/olympia/bandwagon/templates/bandwagon/includes/collection_sidebar.html:18
+#: src/olympia/amo/templates/amo/site_nav.html:66 src/olympia/bandwagon/templates/bandwagon/impala/collection_sidebar.html:16 src/olympia/bandwagon/templates/bandwagon/includes/collection_sidebar.html:18
 msgid "Collections I've Made"
 msgstr "ਮੇਰੇ ਬਣਾਏ ਹੋਏ ਸੰਗ੍ਰਹਿ"
 
-#: src/olympia/amo/templates/amo/site_nav.html:70 src/olympia/bandwagon/templates/bandwagon/user_listing.html:4 src/olympia/bandwagon/templates/bandwagon/impala/collection_sidebar.html:13
+#: src/olympia/amo/templates/amo/site_nav.html:68 src/olympia/bandwagon/templates/bandwagon/user_listing.html:4 src/olympia/bandwagon/templates/bandwagon/impala/collection_sidebar.html:13
 #: src/olympia/bandwagon/templates/bandwagon/includes/collection_sidebar.html:15
 msgid "Collections I'm Following"
 msgstr "ਸੰਗ੍ਰਹਿ ਜਿਹਨਾਂ ਦਾ ਮੈਂ ਸਮਰਥਕ ਹਾਂ"
 
-#: src/olympia/amo/templates/amo/site_nav.html:73 src/olympia/bandwagon/templates/bandwagon/impala/collection_sidebar.html:18 src/olympia/bandwagon/templates/bandwagon/includes/collection_sidebar.html:20
-#: src/olympia/users/models.py:512
+#: src/olympia/amo/templates/amo/site_nav.html:71 src/olympia/bandwagon/templates/bandwagon/impala/collection_sidebar.html:18 src/olympia/bandwagon/templates/bandwagon/includes/collection_sidebar.html:20
+#: src/olympia/users/models.py:521
 msgid "My Favorite Add-ons"
 msgstr "ਮੇਰੇ ਪਸੰਦੀਦਾ ਐਡ-ਆਨ"
 
-#: src/olympia/amo/templates/amo/site_nav.html:78
+#: src/olympia/amo/templates/amo/site_nav.html:76
 msgid "More&hellip;"
 msgstr "ਹੋਰ&hellip;"
 
-#: src/olympia/amo/templates/amo/site_nav.html:82
+#: src/olympia/amo/templates/amo/site_nav.html:80
 msgid "Add-ons for Mobile"
 msgstr "ਮੋਬਾਈਲ ਲਈ ਐਡ-ਆਨ"
 
-#: src/olympia/amo/templates/amo/site_nav.html:86 src/olympia/browse/feeds.py:207 src/olympia/browse/templates/browse/search_tools.html:3 src/olympia/constants/base.py:176
+#: src/olympia/amo/templates/amo/site_nav.html:84 src/olympia/browse/feeds.py:207 src/olympia/browse/templates/browse/search_tools.html:3 src/olympia/constants/base.py:176
 #: src/olympia/templates/menu_links.html:10
 msgid "Search Tools"
 msgstr "ਖੋਜ ਟੂਲ"
@@ -2003,7 +2003,7 @@ msgid "Jump to first page"
 msgstr "ਪਹਿਲੇ ਸਫ਼ੇ ਤੇ ਜਾਓ"
 
 #: src/olympia/amo/templates/amo/impala/paginator.html:22 src/olympia/amo/templates/amo/mobile/impala_paginator.html:12 src/olympia/discovery/templates/discovery/pane.html:44
-#: src/olympia/discovery/templates/discovery/addons/detail.html:38 src/olympia/stats/templates/stats/stats.html:164
+#: src/olympia/discovery/templates/discovery/addons/detail.html:38 src/olympia/stats/templates/stats/stats.html:166
 msgid "Previous"
 msgstr "ਪਿਛਲਾ"
 
@@ -2026,31 +2026,50 @@ msgid_plural "Page {n}"
 msgstr[0] "ਸਫ਼ਾ {n}"
 msgstr[1] "ਸਫ਼ਾ {n}"
 
-#: src/olympia/amo/templates/services/install.html:38
-#, python-format
-msgid "If you are not prompted to install %(addon_name)s in a moment, please <a href=\"%(addon_xpi)s\">click here</a>."
-msgstr "ਜੇਕਰ ਤੁਹਾਨੂੰ ਇੱਕ ਪਲ ਵਿੱਚ %(addon_name)s ਇੰਸਟਾਲ ਕਰਨ ਬਾਰੇ ਨਹੀਂ ਪੁੱਛਿਆ ਗਿਆ, ਕਿਰਪਾ ਕਰਕੇ <a href=\"%(addon_xpi)s\">ਇੱਥੇ ਕਲਿੱਕ ਕਰੋ</a>।"
-
-#: src/olympia/amo/tests/test_messages.py:57 src/olympia/amo/tests/test_messages.py:58 src/olympia/reviews/forms.py:25 src/olympia/reviews/forms.py:50 src/olympia/reviews/templates/reviews/add.html:56
+#: src/olympia/amo/tests/test_messages.py:56 src/olympia/amo/tests/test_messages.py:57 src/olympia/reviews/forms.py:25 src/olympia/reviews/forms.py:50 src/olympia/reviews/templates/reviews/add.html:56
 #: src/olympia/reviews/templates/reviews/reply.html:30
 msgid "Title"
 msgstr "ਟਾਈਟਲ"
 
-#: src/olympia/amo/tests/test_messages.py:57 src/olympia/amo/tests/test_messages.py:58
+#: src/olympia/amo/tests/test_messages.py:56 src/olympia/amo/tests/test_messages.py:57
 msgid "Body"
 msgstr "ਬਾਡੀ"
 
-#: src/olympia/amo/tests/test_messages.py:59
+#: src/olympia/amo/tests/test_messages.py:58
 msgid "Another Title"
 msgstr "ਦੂਜਾ ਟਾਈਟਲ"
 
-#: src/olympia/amo/tests/test_messages.py:59
+#: src/olympia/amo/tests/test_messages.py:58
 msgid "Another Body"
 msgstr "ਦੂਜੀ ਬਾਡੀ"
 
-#: src/olympia/api/views.py:255
-msgid "Not implemented yet."
-msgstr "ਹਾਲੇ ਤੱਕ ਲਾਗੂ ਨਹੀਂ ਕੀਤਾ।"
+#: src/olympia/api/authentication.py:76
+msgid "Signature has expired."
+msgstr ""
+
+#: src/olympia/api/authentication.py:79
+msgid "Error decoding signature."
+msgstr ""
+
+#: src/olympia/api/authentication.py:82
+msgid "Invalid JWT Token."
+msgstr ""
+
+#: src/olympia/api/authentication.py:130
+msgid "Invalid Authorization header. No credentials provided."
+msgstr ""
+
+#: src/olympia/api/authentication.py:133
+msgid "Invalid Authorization header. Credentials string should not contain spaces."
+msgstr ""
+
+#: src/olympia/api/fields.py:29
+msgid "The field must have a length of at least {num} characters."
+msgstr ""
+
+#: src/olympia/api/fields.py:31
+msgid "The language code {lang_code} is invalid."
+msgstr ""
 
 #: src/olympia/applications/views.py:39 src/olympia/applications/templates/applications/appversions.html:3
 msgid "Application Versions"
@@ -2068,7 +2087,7 @@ msgstr "ਠੀਕ ਐਪਲੀਕੇਸ਼ਨ ਵਰਜਨ"
 msgid "Add-ons submitted to Mozilla Add-ons must have a manifest file with at least one of the below applications supported. Only the versions listed below are allowed for these applications."
 msgstr ""
 
-#: src/olympia/applications/templates/applications/appversions.html:25
+#: src/olympia/applications/templates/applications/appversions.html:25 src/olympia/editors/helpers.py:361
 msgid "GUID"
 msgstr "GUID"
 
@@ -2145,11 +2164,11 @@ msgstr "ਕਿਸੇ ਲਿੰਕ ਦੀ ਇਜ਼ਾਜਤ ਨਹੀਂ।"
 msgid "This url is already in use by another collection"
 msgstr "ਇਹ url ਪਹਿਲਾਂ ਹੀ ਕਿਸੇ ਹੋਰ ਸੰਗ੍ਰਹਿ ਵੱਲੋਂ ਵਰਤੀ ਜਾ ਰਹੀ ਹੈ"
 
-#: src/olympia/bandwagon/forms.py:197 src/olympia/devhub/views.py:1049
+#: src/olympia/bandwagon/forms.py:197 src/olympia/devhub/views.py:1050
 msgid "Icons must be either PNG or JPG."
 msgstr "ਆਈਕਾਨ PNG ਜਾਂJPG ਹੋਣਾ ਚਾਹੀਦਾ ਹੈ।"
 
-#: src/olympia/bandwagon/forms.py:202 src/olympia/devhub/views.py:1067 src/olympia/users/forms.py:476
+#: src/olympia/bandwagon/forms.py:202 src/olympia/devhub/views.py:1068 src/olympia/users/forms.py:476
 #, python-format
 msgid "Please use images smaller than %dMB."
 msgstr "ਕਿਰਪਾ ਕਰਕੇ %dMB ਤੋਂ ਛੋਟੀਆਂ ਤਸਵੀਰਾਂ ਵਰਤੋਂ।"
@@ -2182,8 +2201,8 @@ msgstr "ਪਸੰਦੀਦਾ"
 msgid "Remove from favorites"
 msgstr "ਪਸੰਦੀਦਾ ਵਿੱਚੋ ਹਟਾਓ"
 
-#: src/olympia/bandwagon/views.py:98 src/olympia/bandwagon/views.py:191 src/olympia/browse/views.py:58 src/olympia/browse/views.py:69 src/olympia/browse/views.py:458 src/olympia/devhub/views.py:74
-#: src/olympia/devhub/views.py:82 src/olympia/devhub/templates/devhub/addons/edit/basic.html:20 src/olympia/editors/templates/editors/leaderboard.html:24
+#: src/olympia/bandwagon/views.py:98 src/olympia/bandwagon/views.py:191 src/olympia/browse/views.py:58 src/olympia/browse/views.py:69 src/olympia/browse/views.py:425 src/olympia/devhub/views.py:73
+#: src/olympia/devhub/views.py:81 src/olympia/devhub/templates/devhub/addons/edit/basic.html:20 src/olympia/editors/templates/editors/leaderboard.html:24
 #: src/olympia/editors/templates/editors/themes/queue_list.html:48 src/olympia/search/forms.py:17 src/olympia/search/forms.py:89 src/olympia/users/templates/users/vcard.html:5
 msgid "Name"
 msgstr "ਨਾਂ"
@@ -2192,7 +2211,7 @@ msgstr "ਨਾਂ"
 msgid "Recently Popular"
 msgstr "ਹੁਣੇ ਮਸ਼ਹੂਰ ਹੋਏ"
 
-#: src/olympia/bandwagon/views.py:189 src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:18
+#: src/olympia/bandwagon/views.py:189 src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:16
 msgid "Added"
 msgstr "ਸ਼ਾਮਲ ਹੋਏ"
 
@@ -2206,8 +2225,8 @@ msgstr "ਸੰਗ੍ਰਹਿ ਰਚਿਆ!"
 
 #: src/olympia/bandwagon/views.py:316
 #, python-format
-msgid "Your new collection is shown below. You can <ahref=\"%(url)s\">edit additional settings</a> if you'dlike."
-msgstr ""
+msgid "Your new collection is shown below. You can <a href=\"%(url)s\">edit additional settings</a> if you'd like."
+msgstr "ਤੁਹਾਡਾ ਨਵਾਂ ਸੰਗ੍ਰਹਿ ਹੇਠ ਵਿਖਾਇਆ ਗਿਆ ਹੈ। ਤੁਸੀਂ <a href=\"%(url)s\">ਹੋਰ ਸੈਟਿੰਗ ਵਿੱਚ ਸੋਧ</a> ਕਰ ਸਕਦੇ ਹੋ ਜੇਕਰ ਤੁਸੀਂ ਪਸੰਦ ਕਰੋ।"
 
 #: src/olympia/bandwagon/views.py:322
 msgid "Collection updated!"
@@ -2334,8 +2353,8 @@ msgid_plural "%(num)s Add-ons in this Collection"
 msgstr[0] "ਇਸ ਸੰਗ੍ਰਹਿ ਵਿੱਚ %(num)s ਐਡ-ਆਨ"
 msgstr[1] "ਇਸ ਸੰਗ੍ਰਹਿ ਵਿੱਚ %(num)s ਐਡ-ਆਨ"
 
-#: src/olympia/bandwagon/templates/bandwagon/collection_detail.html:125 src/olympia/compat/templates/compat/index.html:25 src/olympia/compat/templates/compat/reporter_detail.html:29
-#: src/olympia/files/templates/files/viewer.html:29 src/olympia/templates/amo_footer.html:17 src/olympia/templates/includes/lang_switcher.html:10
+#: src/olympia/bandwagon/templates/bandwagon/collection_detail.html:125 src/olympia/compat/templates/compat/reporter_detail.html:29 src/olympia/files/templates/files/viewer.html:29
+#: src/olympia/templates/amo_footer.html:17 src/olympia/templates/includes/lang_switcher.html:10
 msgid "Go"
 msgstr "ਜਾਓ"
 
@@ -2506,7 +2525,7 @@ msgid "Remove this user as a contributor"
 msgstr "ਹਿੱਸੇਦਾਰ ਦੇ ਤੌਰ ਤੇ ਇਸ ਉਪਭੋਗੀ ਨੂੰ ਹਟਾਓ"
 
 #: src/olympia/bandwagon/templates/bandwagon/edit_contributors.html:18 src/olympia/bandwagon/templates/bandwagon/edit_contributors.html:43
-#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:20 src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:48
+#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:18 src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:46
 #: src/olympia/devhub/templates/devhub/addons/ajax_compat_update.html:19
 msgid "Remove"
 msgstr "ਹਟਾਓ"
@@ -2556,7 +2575,7 @@ msgid "<b>Warning:</b> By changing the owner of this collection, you will no lon
 msgstr "<b>ਚੇਤਾਵਨੀ:</b> ਇਸ ਸੰਗ੍ਰਹਿ ਦਾ ਮਾਲਕ ਬਦਲਣ ਨਾਲ, ਤੁਸੀਂ ਹੁਣ ਇਸ ਵਿੱਚ ਸੋਧ ਕਰਨ ਦੇ ਯੋਗ ਨਹੀਂ ਰਹੋਗੇ। ਤੁਸੀਂ ਇਸ ਵਿੱਚ ਕੇਵਲ ਐਡ-ਆਨ ਸ਼ਾਮਲ ਅਤੇ ਹਟਾਉਣ ਦੇ ਯੋਗ ਹੀ ਹੋਵੋਗੇ।"
 
 #: src/olympia/bandwagon/templates/bandwagon/edit_contributors.html:83 src/olympia/devhub/templates/devhub/addons/forms_shared/media.html:157
-#: src/olympia/devhub/templates/devhub/addons/submit/describe.html:69 src/olympia/devhub/templates/devhub/addons/submit/license.html:60 src/olympia/devhub/templates/devhub/addons/submit/upload.html:78
+#: src/olympia/devhub/templates/devhub/addons/submit/describe.html:69 src/olympia/devhub/templates/devhub/addons/submit/license.html:60 src/olympia/devhub/templates/devhub/addons/submit/upload.html:70
 #: src/olympia/devhub/templates/devhub/payments/tier.html:17 src/olympia/editors/templates/editors/themes/themes.html:111 src/olympia/editors/templates/editors/themes/themes.html:128
 #: src/olympia/editors/templates/editors/themes/themes.html:134 src/olympia/editors/templates/editors/themes/themes.html:141 src/olympia/users/templates/users/fxa_migration_prompt_content.html:10
 #: src/olympia/users/templates/users/login_form.html:42 src/olympia/users/templates/users/mobile/login.html:57
@@ -2639,32 +2658,31 @@ msgid "Add-ons in Your Collection"
 msgstr "ਤੁਹਾਡੇ ਸੰਗ੍ਰਹਿ ਵਿੱਚ ਐਡ-ਆਨ"
 
 #: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:4
-msgid "To include an add-on in this collection, enter its name in the box below and hit enter. You can also use the <strong>Add to Collection</strong> links throughout the site to include add-ons later."
+msgid "To include an add-on in this collection, enter its name in the box below and hit enter."
 msgstr ""
-"ਇਸ ਸੰਗ੍ਰਹਿ ਵਿੱਚ ਇੱਕ ਐਡ-ਆਨ ਸ਼ਾਮਲ ਕਰ ਲਈ, ਉਸਦਾ ਨਾਂ ਹੇਠ ਦਿੱਤੇ ਬਾਕਸ ਵਿੱਚ ਦਰਜ ਕਰੋ ਅਤੇ ਐਂਟਰ ਦੱਬੋ। ਤੁਸੀਂ ਐਡ-ਆਨ ਨੂੰ ਬਾਅਦ ਵਿੱਚ ਸ਼ਾਮਲ ਕਰਨ ਲਈ ਪੂਰੀ ਸਾਈਟ ਵਿੱੱਚ ਦਿੱਤੇ <strong>ਸੰਗ੍ਰਹਿ ਵਿੱਚ ਜੋੜੋ</strong> ਲਿੰਕਾਂ ਦੀ "
-"ਵੀ ਵਰਤੋਂ ਕਰ ਸਕਦੇ ਹੋ।"
 
-#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:17 src/olympia/constants/base.py:400 src/olympia/devhub/templates/devhub/addons/activity.html:62
+#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:15 src/olympia/constants/base.py:400 src/olympia/devhub/templates/devhub/addons/activity.html:62
+#: src/olympia/editors/helpers.py:273 src/olympia/editors/helpers.py:360
 msgid "Add-on"
 msgstr "ਐਡ-ਆਨ"
 
-#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:26
+#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:24
 msgid "Enter the name of the add-on to include"
 msgstr "ਸ਼ਾਮਲ ਕਰਨ ਲਈ ਐਡ-ਆਨ ਦਾ ਨਾਂ ਦਰਜ ਕਰੋ"
 
-#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:28
+#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:26
 msgid "Add to Collection"
 msgstr "ਸੰਗ੍ਰਹਿ ਵਿੱਚ ਜੋੜੋ"
 
-#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:45 src/olympia/editors/helpers.py:936 src/olympia/editors/helpers.py:956
+#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:43 src/olympia/editors/helpers.py:1016 src/olympia/editors/helpers.py:1036
 msgid "Pending"
 msgstr "ਅਧੂਰਾ"
 
-#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:47
+#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:45
 msgid "Add a comment"
 msgstr "ਇੱਕ ਟਿੱਪਣੀ ਜੋੜੋ"
 
-#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:48
+#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:46
 msgid "Remove this add-on from the collection"
 msgstr "ਸੰਗ੍ਰਹਿ ਤੋਂ ਇਸ ਐਡ-ਆਨ ਨੂੰ ਹਟਾਓ"
 
@@ -2773,12 +2791,12 @@ msgstr "ਖੋਜ ਟੂਲ"
 msgid "Most Users"
 msgstr "ਬਹੁਤ ਸਾਰੇ ਉਪਭੋਗੀ"
 
-#: src/olympia/browse/views.py:61 src/olympia/browse/views.py:72 src/olympia/browse/views.py:279 src/olympia/browse/templates/browse/personas/mobile/category_landing.html:63
+#: src/olympia/browse/views.py:61 src/olympia/browse/views.py:72 src/olympia/browse/views.py:246 src/olympia/browse/templates/browse/personas/mobile/category_landing.html:63
 #: src/olympia/discovery/templates/discovery/pane.html:67 src/olympia/search/forms.py:92
 msgid "Up & Coming"
 msgstr "ਉੱਪਰ ਅਤੇ ਆ ਰਿਹਾ"
 
-#: src/olympia/browse/views.py:460 src/olympia/devhub/views.py:76 src/olympia/devhub/views.py:83 src/olympia/discovery/templates/discovery/addons/detail.html:66
+#: src/olympia/browse/views.py:427 src/olympia/devhub/views.py:75 src/olympia/devhub/views.py:82 src/olympia/discovery/templates/discovery/addons/detail.html:66
 msgid "Created"
 msgstr "ਰਚਿਆ"
 
@@ -2966,8 +2984,8 @@ msgid_plural "See all %(cnt)s extensions in %(name)s &raquo;"
 msgstr[0] "%(name)s &raquo ਵਿੱਚ %(cnt)s ਇਕਸਟੈਨਸ਼ਨ ਵੇਖੋ; "
 msgstr[1] "%(name)s &raquo ਵਿੱਚ %(cnt)s ਇਕਸਟੈਨਸ਼ਨਾਂ ਵੇਖੋ; "
 
-#: src/olympia/browse/templates/browse/mobile/extensions.html:13 src/olympia/compat/templates/compat/index.html:82 src/olympia/devhub/templates/devhub/devhub_search.html:24
-#: src/olympia/devhub/templates/devhub/addons/activity.html:47 src/olympia/search/templates/search/no_results.html:4 src/olympia/search/templates/search/mobile/results.html:36
+#: src/olympia/browse/templates/browse/mobile/extensions.html:13 src/olympia/devhub/templates/devhub/devhub_search.html:24 src/olympia/devhub/templates/devhub/addons/activity.html:47
+#: src/olympia/search/templates/search/no_results.html:4 src/olympia/search/templates/search/mobile/results.html:36
 msgid "No results found."
 msgstr "ਕੋਈ ਨਤੀਜਾ ਨਹੀਂਂ ਮਿਲਿਆ"
 
@@ -3052,7 +3070,7 @@ msgstr "&laquo; ਸਾਰੇ ਥੀਮ"
 msgid "All"
 msgstr "ਸਾਰੇ"
 
-#: src/olympia/compat/forms.py:22 src/olympia/search/views.py:525
+#: src/olympia/compat/forms.py:22 src/olympia/editors/templates/editors/base.html:69 src/olympia/search/views.py:518
 msgid "All Add-ons"
 msgstr "ਸਾਰੇ ਐਡ-ਆਨ"
 
@@ -3063,53 +3081,6 @@ msgstr "ਬਾਈਨਰੀ"
 #: src/olympia/compat/forms.py:24
 msgid "Non-binary"
 msgstr "ਨਾਨ-ਬਾਈਨਰੀ"
-
-#. Review points sources other than add-ons and themes.
-#: src/olympia/compat/views.py:87 src/olympia/constants/base.py:388 src/olympia/devhub/forms.py:162 src/olympia/editors/templates/editors/performance.html:75
-msgid "Other"
-msgstr "ਦੂਜੇ"
-
-#: src/olympia/compat/templates/compat/index.html:4
-msgid "Add-on Compatibility Report for {app} {version}"
-msgstr "{app} {version} ਲਈ ਐਡ-ਆਨ ਅਨੁਕੂਲਤਾ ਰਿਪੋਰਟ"
-
-#: src/olympia/compat/templates/compat/index.html:11
-msgid "{app} {version} Compatibility"
-msgstr "{app} {version} ਅਨੁਕੂਲਤਾ"
-
-#: src/olympia/compat/templates/compat/index.html:17
-#, python-format
-msgid "Top 95%% compatible with previous version"
-msgstr ""
-
-#: src/olympia/compat/templates/compat/index.html:18
-#, python-format
-msgid "Top 95%% of all add-ons"
-msgstr ""
-
-#: src/olympia/compat/templates/compat/index.html:19
-msgid "All active add-ons"
-msgstr "ਸਾਰੇ ਕਾਰਜਸ਼ੀਲ ਐਡ-ਆਨ"
-
-#: src/olympia/compat/templates/compat/index.html:23 src/olympia/constants/base.py:401
-msgid "App"
-msgstr "ਐੱਪ"
-
-#: src/olympia/compat/templates/compat/index.html:55
-msgid "Details for add-ons compatible with previous version:"
-msgstr "ਪਿਛਲੇ ਵਰਜਨ ਨਾਲ ਅਨੁਕੂਲ ਐਡ-ਆਨ ਲਈ ਵੇਰਵਾ:"
-
-#: src/olympia/compat/templates/compat/index.html:57
-msgid "Show all versions"
-msgstr "ਸਾਰੇ ਵਰਜਨ ਵਿਖਾਓ"
-
-#: src/olympia/compat/templates/compat/index.html:59
-msgid "Details for add-ons compatible with all versions:"
-msgstr "ਸਾਰੇ ਵਰਜਨਾਂ ਨਾਲ ਅਨੁਕੂਲ ਐਡ-ਆਨ ਲਈ ਵੇਰਵਾ:"
-
-#: src/olympia/compat/templates/compat/index.html:61
-msgid "Show previous version only"
-msgstr "ਕੇਵਲ ਪਿਛਲਾ ਵਰਜਨ ਵਿਖਾਓ"
 
 #: src/olympia/compat/templates/compat/reporter.html:3
 msgid "Add-on Compatibility Reports"
@@ -3164,8 +3135,8 @@ msgstr "ਐਪਲੀਕੇਸ਼ਨ ਦੁਆਰਾ ਫ਼ਿਲਟਰ"
 msgid "Report Type"
 msgstr "ਰਿਪਰੋਟ ਟਾਈਪ"
 
-#: src/olympia/compat/templates/compat/reporter_detail.html:47 src/olympia/devhub/forms.py:784 src/olympia/devhub/templates/devhub/addons/ajax_compat_update.html:17 src/olympia/editors/forms.py:108
-#: src/olympia/zadmin/forms.py:45
+#: src/olympia/compat/templates/compat/reporter_detail.html:47 src/olympia/devhub/forms.py:785 src/olympia/devhub/templates/devhub/addons/ajax_compat_update.html:17 src/olympia/editors/forms.py:108
+#: src/olympia/editors/forms.py:248 src/olympia/zadmin/forms.py:45
 msgid "Application"
 msgstr "ਐਪਲੀਕੇਸ਼ਨ"
 
@@ -3253,7 +3224,8 @@ msgstr "ਸ਼ੁਰੂਆਤੀ ਤੌਰ ਤੇ ਸਮੀਖਿਆ ਹੋਈ"
 msgid "Preliminarily Reviewed and Awaiting Full Review"
 msgstr "ਸ਼ੁਰੂਆਤੀ ਤੌਰ ਤੇ ਸਮੀਖਿਆ ਹੋਈ ਅਤੇ ਪੂਰੀ ਸਮੀਖਿਆ ਦੀ ਉਡੀਕ"
 
-#: src/olympia/constants/base.py:33 src/olympia/editors/helpers.py:924 src/olympia/editors/templates/editors/themes/history_table.html:34
+#: src/olympia/constants/base.py:33 src/olympia/editors/forms.py:258 src/olympia/editors/helpers.py:73 src/olympia/editors/helpers.py:1004
+#: src/olympia/editors/templates/editors/themes/history_table.html:34
 msgid "Deleted"
 msgstr "ਹਟਾਇਆ"
 
@@ -3350,6 +3322,11 @@ msgstr "ਉਪਭੋਗੀ ਨੂੰ ਇਸ ਐਡ-ਆਨ ਡਾਊਨਲੋਡ 
 msgid "Ask before users can download this add-on"
 msgstr "ਉਪਭੋਗੀਆਂ ਨੂੰ ਇਸ ਐਡ-ਆਨ ਡਾਊਨਲੋਡ ਕਰਨ ਤੋਂ ਪਹਿਲਾਂ ਪੁੱਛੋ"
 
+#. Review points sources other than add-ons and themes.
+#: src/olympia/constants/base.py:388 src/olympia/devhub/forms.py:162 src/olympia/editors/templates/editors/performance.html:75
+msgid "Other"
+msgstr "ਦੂਜੇ"
+
 #: src/olympia/constants/base.py:389
 msgid "Exception"
 msgstr "ਅਪਵਾਦ"
@@ -3361,6 +3338,10 @@ msgstr "ਰਿਲੀਜ਼"
 #: src/olympia/constants/base.py:391
 msgid "Change"
 msgstr "ਬਦਲੋ"
+
+#: src/olympia/constants/base.py:401
+msgid "App"
+msgstr "ਐੱਪ"
 
 #: src/olympia/constants/base.py:402
 msgid "Persona"
@@ -3510,7 +3491,7 @@ msgstr "ਫ਼ਲੈਗ"
 msgid "Duplicate"
 msgstr "ਨਕਲ"
 
-#: src/olympia/constants/editors.py:17 src/olympia/editors/helpers.py:502 src/olympia/editors/templates/editors/themes/queue.html:71 src/olympia/editors/templates/editors/themes/themes.html:94
+#: src/olympia/constants/editors.py:17 src/olympia/editors/helpers.py:575 src/olympia/editors/templates/editors/themes/queue.html:71 src/olympia/editors/templates/editors/themes/themes.html:94
 msgid "Reject"
 msgstr "ਰੱਦ"
 
@@ -3610,7 +3591,7 @@ msgstr "ਸੋਲਰਿਸ"
 msgid "Android"
 msgstr "ਐਨਡਰੋਇਡ"
 
-#: src/olympia/core/apps.py:19
+#: src/olympia/core/apps.py:21
 msgid "Core"
 msgstr ""
 
@@ -3744,8 +3725,8 @@ msgid "Submit my add-on for manual review."
 msgstr "ਹੱਥਲਿਖਤ ਸਮੀਖਿਆ ਵਾਸਤੇ ਮੇਰਾ ਐਡ-ਆਨ ਦਾਖਲ ਕਰੋ।"
 
 #: src/olympia/devhub/forms.py:537
-msgid "Do not list my add-on on this site (beta)"
-msgstr "ਮੇਰੇ ਐਡ-ਆਨ ਨੂੰ ਇਸ ਸਾਈਟ ਤੇ ਸੂਚੀਬੱਧ ਨਾ ਕਰੋ(ਬੀਟਾ)"
+msgid "Do not list my add-on on this site"
+msgstr ""
 
 #: src/olympia/devhub/forms.py:538
 msgid "Check this option if you intend to distribute your add-on on your own and only need it to be signed by Mozilla."
@@ -3777,46 +3758,46 @@ msgstr "a|alpha|b|beta|pre|rc ਅਤੇ ਇੱਕ ਚੋਣਵੇਂ ਨੰਬ�
 
 #: src/olympia/devhub/forms.py:592
 #, python-format
-msgid "Version %s already exists"
-msgstr "ਵਰਜਨ %s ਪਹਿਲਾਂ ਤੋਂ ਮੌਜੂਦ"
+msgid "Version %s already exists, or was uploaded before."
+msgstr ""
 
-#: src/olympia/devhub/forms.py:604
+#: src/olympia/devhub/forms.py:605
 msgid "Select a valid choice. That choice is not one of the available choices."
 msgstr "ਇੱਕ ਠੀਕ ਪਸੰਦ ਨੂੰ ਚੁਣੋ। ਇਹ ਪਸੰਦ ਉੱਪਲਬਧ ਪਸੰਦਾਂ ਵਿੱਚੋਂ ਇੱਕ ਨਹੀਂ ਹੈ।"
 
-#: src/olympia/devhub/forms.py:610
+#: src/olympia/devhub/forms.py:611
 msgid "A file with a version ending with a|alpha|b|beta and an optional number is detected as beta."
 msgstr "ਇੱਕ ਫ਼ਾਈਲ ਦਾ ਏ|ਐਲਫ਼ਾ|ਬੀ|ਬੀਟਾ ਦੇ ਇੱਕ ਵਰਜਨ ਅਤੇ ਇੱਕ ਚੋਣਵੇਂ ਅੰਕ ਨਾਲ ਅੰਤ ਹੋਵੇ ਬੀਟਾ ਪਛਾਣੀ ਜਾਵੇਗੀ।"
 
-#: src/olympia/devhub/forms.py:633
+#: src/olympia/devhub/forms.py:634
 msgid "You cannot upload any more files for this version."
 msgstr "ਤੁਸੀਂ ਇਸ ਵਰਜਨ ਲਈ ਹੋਰ ਜਿਆਦਾ ਫ਼ਾਈਲਾਂ ਅੱਪਲੋਡ ਨਹੀਂ ਕਰ ਸਕਦੇ।"
 
-#: src/olympia/devhub/forms.py:639
+#: src/olympia/devhub/forms.py:640
 msgid "Version doesn't match"
 msgstr "ਵਰਜਨ ਮੇਲ ਨਹੀਂ ਖਾਂਦਾ।"
 
-#: src/olympia/devhub/forms.py:668
+#: src/olympia/devhub/forms.py:669
 msgid "You cannot delete a file once the review process has started. You must delete the whole version."
 msgstr "ਜਦੋਂ ਸਮੀਖਿਆ ਕਾਰਜ ਸ਼ੁਰੂ ਹੋ ਗਿਆ ਤੁਸੀਂ ਇੱਕ ਫ਼ਾਈਲ ਹਟਾ ਨਹੀਂ ਸਕਦੇ। ਤੁਹਾਨੂੰ ਸਾਰਾ ਵਰਜਨ ਹਟਾਉਣਾ ਚਾਹੀਦਾ ਹੈ।"
 
-#: src/olympia/devhub/forms.py:688
+#: src/olympia/devhub/forms.py:689
 msgid "The platform All cannot be combined with specific platforms."
 msgstr "ਪਲੇਟਫ਼ਾਰਮ ਆਲ ਨੂੰ ਖਾਸ ਪਲੇਟਫ਼ਾਰਮਾਂ ਦੇ ਨਾਲ ਜੋੜਿਆ ਨਹੀਂ ਜਾ ਸਕਦਾ।"
 
-#: src/olympia/devhub/forms.py:693
+#: src/olympia/devhub/forms.py:694
 msgid "A platform can only be chosen once."
 msgstr "ਇੱਕ ਪਲੇਟਫ਼ਾਰਮ ਨੂੰ ਇੱਕ ਵਾਰ ਹੀ ਚੁਣਿਆ ਜਾ ਸਕਦਾ।"
 
-#: src/olympia/devhub/forms.py:706
+#: src/olympia/devhub/forms.py:707
 msgid "A review type must be selected."
 msgstr "ਇੱਕ ਸਮੀਖਿਆ ਕਿਸਮ ਚੁਣੀ ਹੋਣੀ ਚਾਹੀਦੀ ਹੈ।"
 
-#: src/olympia/devhub/forms.py:788 src/olympia/editors/forms.py:114 src/olympia/zadmin/forms.py:49 src/olympia/zadmin/forms.py:52
+#: src/olympia/devhub/forms.py:789 src/olympia/editors/forms.py:114 src/olympia/editors/forms.py:254 src/olympia/zadmin/forms.py:49 src/olympia/zadmin/forms.py:52
 msgid "Select an application first"
 msgstr "ਪਹਿਲਾਂ ਇੱਕ ਐਪਲੀਕੇਸ਼ਨ ਚੁਣੋ"
 
-#: src/olympia/devhub/forms.py:840
+#: src/olympia/devhub/forms.py:841
 msgid "There cannot be more than 3 required add-ons."
 msgstr "ਇੱਥੇ 3 ਤੋਂ ਜਿਆਦਾ ਲੋੜੀਂਦੇ ਐਡ-ਆਨ ਨਹੀਂ ਹੋ ਸਕਦੇ।"
 
@@ -3850,160 +3831,160 @@ msgstr[1] "{0} ਚੇਤਾਵਨੀਆਂ"
 msgid "Review"
 msgstr "ਸਮੀਖਿਆ"
 
-#: src/olympia/devhub/tasks.py:551
+#: src/olympia/devhub/tasks.py:583
 #, python-format
 msgid "%s responded with %s (%s)."
 msgstr "%s ਦਾ ਜਵਾਬ %s (%s) ਦੇ ਨਾਲ ਦਿੱਤਾ।"
 
-#: src/olympia/devhub/tasks.py:555
+#: src/olympia/devhub/tasks.py:587
 #, python-format
 msgid "Connection to \"%s\" timed out."
 msgstr "\"%s\" ਲਈ ਕੁਨੈਕਸ਼ਨ ਦਾ ਸਮਾਂ ਖਤਮ ਹੋਇਆ।"
 
-#: src/olympia/devhub/tasks.py:557
+#: src/olympia/devhub/tasks.py:589
 #, python-format
 msgid "Could not contact host at \"%s\"."
 msgstr "\"%s\" ਤੇ ਹੋਸਟ ਨਾਲ ਸਪੰਰਕ ਨਹੀਂ ਕਰ ਸਕਿਆ।"
 
-#: src/olympia/devhub/utils.py:104
+#: src/olympia/devhub/utils.py:105
 #, python-format
 msgid "Validation generated too many errors/warnings so %s messages were truncated. After addressing the visible messages, you'll be able to see the others."
 msgstr "ਪ੍ਰਮਾਣਿਕਤਾ ਨੇ ਬਹੁਤ ਸਾਰੀਆਂ ਗਲਤੀਆਂ/ਚੇਤਾਵਨੀਆਂ ਪੈਦਾ ਕੀਤੀਆਂ ਇਸ ਲਈ %s ਸੁਨੇਹੇ ਛੋਟੇ ਹੋ ਗਏ। ਵੇਖਣਯੋਗ ਸੁਨੇਹਿਆਂ ਦਾ ਸੰਬੋਧਨ ਕਰਨ ਤੋਂ ਬਾਅਦ, ਤੁਸੀਂ ਹੋਰਾਂ ਨੂੰ ਵੇਖਣ ਦੇ ਯੋਗ ਹੋ ਜਾਵੋਗੇ।"
 
-#: src/olympia/devhub/views.py:183
+#: src/olympia/devhub/views.py:182
 msgid "All My Add-ons"
 msgstr "ਮੇਰੇ ਸਾਰੇ ਐਡ-ਆਨ"
 
-#: src/olympia/devhub/views.py:210
+#: src/olympia/devhub/views.py:209
 msgid "All Activity"
 msgstr "ਸਾਰੀ ਸਰਗਰਮੀ"
 
-#: src/olympia/devhub/views.py:211
+#: src/olympia/devhub/views.py:210
 msgid "Add-on Updates"
 msgstr "ਐਡ-ਆਨ ਅੱਪਡੇਟ"
 
-#: src/olympia/devhub/views.py:212
+#: src/olympia/devhub/views.py:211
 msgid "Add-on Status"
 msgstr "ਐਡ-ਆਨ ਦਰਜਾ"
 
-#: src/olympia/devhub/views.py:213
+#: src/olympia/devhub/views.py:212
 msgid "User Collections"
 msgstr "ਉਪਭੋਗੀ ਸੰਗ੍ਰਹਿ"
 
-#: src/olympia/devhub/views.py:214 src/olympia/devhub/templates/devhub/docs/policies-maintenance.html:68 src/olympia/pages/templates/pages/dev_faq.html:38
+#: src/olympia/devhub/views.py:213 src/olympia/devhub/templates/devhub/docs/policies-maintenance.html:68 src/olympia/pages/templates/pages/dev_faq.html:38
 #: src/olympia/pages/templates/pages/dev_faq.html:484
 msgid "User Reviews"
 msgstr "ਉਪਭੋਗੀ ਸਮੀਖਿਆਵਾਂ"
 
-#: src/olympia/devhub/views.py:327 src/olympia/devhub/views.py:331 src/olympia/devhub/views.py:484 src/olympia/devhub/views.py:513 src/olympia/devhub/views.py:564 src/olympia/devhub/views.py:1150
+#: src/olympia/devhub/views.py:326 src/olympia/devhub/views.py:330 src/olympia/devhub/views.py:485 src/olympia/devhub/views.py:514 src/olympia/devhub/views.py:565 src/olympia/devhub/views.py:1157
 msgid "Changes successfully saved."
 msgstr "ਬਦਲਾਵ ਸਫ਼ਲਤਾਪੂਰਕ ਸੰਭਾਲ੍ਹੇ ਗਏ।"
 
-#: src/olympia/devhub/views.py:334 src/olympia/devhub/views.py:1631
+#: src/olympia/devhub/views.py:333 src/olympia/devhub/views.py:1638
 msgid "Please check the form for errors."
 msgstr "ਗਲਤੀਆਂ ਲਈ ਫ਼ਾਰਮ ਦੀ ਪੜਤਾਲ ਕਰੋ।"
 
-#: src/olympia/devhub/views.py:346
+#: src/olympia/devhub/views.py:345
 msgid "Add-on cannot be deleted. Disable this add-on instead."
 msgstr "ਐਡ-ਆਨ ਹਟਾਇਆ ਨਹੀਂ ਜਾ ਸਕਿਆ। ਇਸ ਦੀ ਬਜਾਏ ਇਸ ਐਡ-ਆਨ ਨੂੰ ਅਯੋਗ ਕਰੋ।"
 
-#: src/olympia/devhub/views.py:356
+#: src/olympia/devhub/views.py:355
 msgid "Theme deleted."
 msgstr "ਥੀਮ ਹਟਾਇਆ।"
 
-#: src/olympia/devhub/views.py:356
+#: src/olympia/devhub/views.py:355
 msgid "Add-on deleted."
 msgstr "ਐਡ-ਆਨ ਹਟਾਇਆ।"
 
-#: src/olympia/devhub/views.py:362
+#: src/olympia/devhub/views.py:361
 msgid "URL name was incorrect. Theme was not deleted."
 msgstr ""
 
-#: src/olympia/devhub/views.py:367
+#: src/olympia/devhub/views.py:366
 msgid "URL name was incorrect. Add-on was not deleted."
 msgstr ""
 
-#: src/olympia/devhub/views.py:449
+#: src/olympia/devhub/views.py:450
 msgid "An author has been added to your add-on"
 msgstr "ਤੁਹਾਡੇ ਐਡ-ਆਨ ਵਿੱਚ ਇੱਕ ਲੇਖਕ ਸ਼ਾਮਲ ਕੀਤਾ ਗਿਆ"
 
-#: src/olympia/devhub/views.py:456
+#: src/olympia/devhub/views.py:457
 msgid "An author has a role changed on your add-on"
 msgstr "ਤੁਹਾਡੇ ਐਡ-ਆਨ ਤੇ ਇੱਕ ਲੇਖਕ ਦੀ ਭੂਮਿਕਾ ਬਦਲੀ ਗਈ"
 
-#: src/olympia/devhub/views.py:476
+#: src/olympia/devhub/views.py:477
 msgid "An author has been removed from your add-on"
 msgstr "ਤੁਹਾਡੇ ਐਡ-ਆਨ ਤੋਂ ਇੱਕ ਲੇਖਕ ਨੂੰ ਹਟਾਇਆ ਗਿਆ"
 
-#: src/olympia/devhub/views.py:519
+#: src/olympia/devhub/views.py:520
 msgid "There were errors in your submission."
 msgstr "ਤੁਹਾਡੀ ਬੇਨਤੀਆਂ ਵਿੱਚ ਗਲਤੀਆਂ ਹਨ।"
 
-#: src/olympia/devhub/views.py:583
+#: src/olympia/devhub/views.py:584
 msgid "Validate Add-on"
 msgstr "ਐਡ-ਆਨ ਦੀ ਪੜਤਾਲ"
 
-#: src/olympia/devhub/views.py:594
+#: src/olympia/devhub/views.py:595
 msgid "Check Add-on Compatibility"
 msgstr "ਐਡ-ਆਨ ਅਨੁਕੂਲਤਾ ਦੀ ਪੜਤਾਲ ਕਰੋ"
 
-#: src/olympia/devhub/views.py:808 src/olympia/signing/views.py:90
+#: src/olympia/devhub/views.py:809 src/olympia/signing/views.py:95
 msgid "You cannot submit this type of add-on"
 msgstr ""
 
-#: src/olympia/devhub/views.py:1051 src/olympia/users/forms.py:471
+#: src/olympia/devhub/views.py:1052 src/olympia/users/forms.py:471
 msgid "Images must be either PNG or JPG."
 msgstr "ਤਸਵੀਰਾਂ PNG ਜਾਂ JPG ਹੋਣੀਆਂ ਚਾਹੀਦੀਆਂ।"
 
-#: src/olympia/devhub/views.py:1055
+#: src/olympia/devhub/views.py:1056
 msgid "Icons cannot be animated."
 msgstr "ਆਈਕਾਨ ਐਨੀਮੇਟ ਨਹੀਂ ਹੋ ਸਕਦਾ।"
 
-#: src/olympia/devhub/views.py:1057
+#: src/olympia/devhub/views.py:1058
 msgid "Images cannot be animated."
 msgstr "ਤਸਵੀਰ ਐਨੀਮੇਟ ਨਹੀਂ ਹੋ ਸਕਦੀ।"
 
-#: src/olympia/devhub/views.py:1070
+#: src/olympia/devhub/views.py:1071
 #, python-format
 msgid "Images cannot be larger than %dKB."
 msgstr "ਤਸਵੀਰ %dKB ਤੋਂ ਵੱਡੀ ਨਹੀਂ ਹੋ ਸਕਦੀ।"
 
 #. L10n: {0} is an image width (in pixels), {1} is a height.
-#: src/olympia/devhub/views.py:1080
+#: src/olympia/devhub/views.py:1081
 msgid "Image must be exactly {0} pixels wide and {1} pixels tall."
 msgstr "ਤਸਵੀਰ ਬਿਲਕੁਲ {0} ਪਿਕਸਲ ਚੌੜੀ ਅਤੇ {1} ਪਿਕਸਲ ਲੰਬੀ ਹੋਣੀ ਚਾਹੀਦੀ ਹੈ।"
 
-#: src/olympia/devhub/views.py:1087
+#: src/olympia/devhub/views.py:1088
 msgid "There was an error uploading your preview."
 msgstr "ਤੁਹਾਡੀ ਝਲਕ ਨੂੰ ਅੱਪਲੋਡ ਕਰਨ ਵਿੱਚ ਖਾਮੀ ਆਈ।"
 
-#: src/olympia/devhub/views.py:1189
+#: src/olympia/devhub/views.py:1196
 #, python-format
 msgid "Version %s disabled."
 msgstr "ਵਰਜਨ %s ਅਯੋਗ ਹੋਇਆ।"
 
-#: src/olympia/devhub/views.py:1193
+#: src/olympia/devhub/views.py:1200
 #, python-format
 msgid "Version %s deleted."
 msgstr "ਵਰਜਨ %s ਹਟਾਇਆ।"
 
-#: src/olympia/devhub/views.py:1203
+#: src/olympia/devhub/views.py:1210
 msgid "This upload has failed validation, and may lack complete validation results. Please take due care when reviewing it."
 msgstr "ਇਸ ਅੱਪਲੋਡ ਦੀ ਪ੍ਰਮਾਣਿਕਤਾ ਫ਼ੇਲ੍ਹ ਹੋਈ ਅਤੇ ਹੋ ਸਕਦਾ ਮੁਕੰਮਲ ਪ੍ਰਮਾਣਿਕਤਾ ਨਤੀਜਿਆਂ ਦੀ ਘਾਟ ਹੋਵੇ। ਕਿਰਪਾ ਕਰਕੇ ਪੂਰਾ ਧਿਆਨ ਦੇਵੋ ਜਦੋਂ ਇਸ ਦੀ ਸਮੀਖਿਆ ਕਰ ਰਹੇ ਹੋਵੋ।"
 
-#: src/olympia/devhub/views.py:1677
+#: src/olympia/devhub/views.py:1684
 msgid "Preliminary Review Requested."
 msgstr "ਸ਼ੁਰੂਆਤੀ ਸਮੀਖਿਆ ਦੀ ਬੇਨਤੀ ਕੀਤੀ।"
 
-#: src/olympia/devhub/views.py:1678
+#: src/olympia/devhub/views.py:1685
 msgid "Full Review Requested."
 msgstr "ਪੂਰੀ ਸਮੀਖਿਆ ਦੀ ਬੇਨਤੀ ਕੀਤੀ।"
 
-#: src/olympia/devhub/views.py:1779
+#: src/olympia/devhub/views.py:1786
 msgid "Your old credentials were revoked and are no longer valid. Be sure to update all API clients with the new credentials."
 msgstr ""
 
-#: src/olympia/devhub/views.py:1797
+#: src/olympia/devhub/views.py:1804
 msgid "New API key created"
 msgstr ""
 
@@ -4033,7 +4014,7 @@ msgstr "ਐਡ-ਆਨ ਤੇ ਵਾਪਸ"
 msgid "{0} :: Search"
 msgstr "{0} :: ਖੋਜ"
 
-#: src/olympia/devhub/templates/devhub/devhub_search.html:6 src/olympia/devhub/templates/devhub/search.html:8 src/olympia/editors/forms.py:435 src/olympia/editors/forms.py:437
+#: src/olympia/devhub/templates/devhub/devhub_search.html:6 src/olympia/devhub/templates/devhub/search.html:8 src/olympia/editors/forms.py:534 src/olympia/editors/forms.py:536
 #: src/olympia/editors/templates/editors/queue.html:27 src/olympia/editors/templates/editors/themes/queue_list.html:14 src/olympia/search/templates/search/collections.html:17
 #: src/olympia/search/templates/search/personas.html:18 src/olympia/search/templates/search/results.html:18 src/olympia/search/templates/search/mobile/results.html:8 src/olympia/templates/search.html:14
 #: src/olympia/templates/impala/search.html:18
@@ -4096,12 +4077,12 @@ msgstr "ਹਰੇਕ ਚੀਜ਼ ਸਿੱਖਣ ਲਈ <a href=\"https://devel
 msgid "Start Making Add-ons"
 msgstr "ਐਡ-ਆਨ ਬਣਾਉਣਾ ਸ਼ੁਰੂ ਕਰੋ"
 
-#: src/olympia/devhub/templates/devhub/index.html:86 src/olympia/devhub/templates/devhub/addons/listing/items.html:25 src/olympia/devhub/templates/devhub/includes/addon_details.html:15
+#: src/olympia/devhub/templates/devhub/index.html:86 src/olympia/devhub/templates/devhub/addons/listing/items.html:25 src/olympia/devhub/templates/devhub/includes/addon_details.html:20
 #: src/olympia/devhub/templates/devhub/personas/edit.html:43
 msgid "Status:"
 msgstr "ਦਰਜਾ:"
 
-#: src/olympia/devhub/templates/devhub/index.html:90 src/olympia/devhub/templates/devhub/includes/addon_details.html:100
+#: src/olympia/devhub/templates/devhub/index.html:90 src/olympia/devhub/templates/devhub/includes/addon_details.html:87
 msgid "Visibility:"
 msgstr "ਪ੍ਰਤੱਖਤਾ:"
 
@@ -4109,11 +4090,11 @@ msgstr "ਪ੍ਰਤੱਖਤਾ:"
 msgid "Latest Version:"
 msgstr "ਤਾਜ਼ਾ ਵਰਜਨ:"
 
-#: src/olympia/devhub/templates/devhub/index.html:109 src/olympia/devhub/templates/devhub/includes/addon_details.html:145 src/olympia/devhub/templates/devhub/personas/edit.html:49
+#: src/olympia/devhub/templates/devhub/index.html:109 src/olympia/devhub/templates/devhub/includes/addon_details.html:131 src/olympia/devhub/templates/devhub/personas/edit.html:49
 msgid "Queue Position:"
 msgstr "ਕਤਾਰ ਸਥਿਤੀ:"
 
-#: src/olympia/devhub/templates/devhub/index.html:110 src/olympia/devhub/templates/devhub/includes/addon_details.html:146 src/olympia/devhub/templates/devhub/personas/edit.html:50
+#: src/olympia/devhub/templates/devhub/index.html:110 src/olympia/devhub/templates/devhub/includes/addon_details.html:132 src/olympia/devhub/templates/devhub/personas/edit.html:50
 #, python-format
 msgid "%(position)s of %(total)s"
 msgstr "%(total)s ਦੀ %(position)s"
@@ -4215,16 +4196,6 @@ msgstr "ਅੱਪਲੋਡ ਤੋਂ ਬਾਅਦ, ਤੁਹਾਡੀ ਫ਼ਾਈ�
 msgid "Do you want your add-on to be distributed on this site?"
 msgstr "ਕੀ ਤੁਸੀਂ ਚਾਹੁੰਦੇ ਹੋ ਕੀ ਤੁਹਾਡਾ ਐਡ-ਆਨ ਇਸ ਸਾਈਟ ਤੇ ਵਰਤਾਇਆ ਜਾਵੇ?"
 
-#: src/olympia/devhub/templates/devhub/validate_addon.html:49 src/olympia/devhub/templates/devhub/addons/submit/upload.html:30 src/olympia/devhub/templates/devhub/versions/add_file_modal.html:14
-#: src/olympia/devhub/templates/devhub/versions/add_file_modal.html:53 src/olympia/devhub/templates/devhub/versions/list.html:298
-msgid "Warning:"
-msgstr "ਚੇਤਾਵਨੀ:"
-
-#: src/olympia/devhub/templates/devhub/validate_addon.html:50 src/olympia/devhub/templates/devhub/addons/submit/upload.html:31
-#, python-format
-msgid "Submission of unlisted add-ons for signing is currently in an open beta. Please <a href=\"%(url)s\" target=\"_blank\">report any bugs</a> that you encounter."
-msgstr ""
-
 #. first parameter is a filename like lorem-ipsum-1.0.2.xpi
 #: src/olympia/devhub/templates/devhub/validation.html:5
 msgid "Validation Results for {0}"
@@ -4301,7 +4272,7 @@ msgstr "ਅਨੁਕੂਲਤਾ"
 msgid "Update Compatibility"
 msgstr "ਅਨੁਕੂਲਤਾ ਅੱਪਡੇਟ ਕਰੋ"
 
-#: src/olympia/devhub/templates/devhub/addons/ajax_compat_update.html:4
+#: src/olympia/devhub/templates/devhub/addons/ajax_compat_update.html:4 src/olympia/devhub/templates/devhub/versions/edit.html:45
 msgid "Adjusting application information here will allow users to install your add-on even if the install manifest in the package indicates that the add-on is incompatible."
 msgstr "ਇੱਥੇ ਐਪਲੀਕੇਸ਼ਨ ਦੀ ਜਾਣਕਾਰੀ ਵਿੱਚ ਕੀਤਾ ਫ਼ੇਰਬਦਲ ਉਪਭੋਗੀਆਂ ਨੂੰ ਤੁਹਾਡਾ ਐਡ-ਆਨ ਇੰਸਟਾਲ ਕਰਨ ਦੇਵੇਗਾ ਭਲੇ ਹੀ ਪੈਕੇਜ ਵਿੱਚ ਦਿੱਤਾ ਇੰਸਟਾਲ ਮੈਨਫ਼ੇਸ਼ਟ ਇਹ ਦੱਸੇ ਕਿ ਐਡ-ਆਨ ਅਨੁਕੂਲ ਨਹੀਂ ਹੈ।"
 
@@ -4313,9 +4284,9 @@ msgstr "ਸਹਿਯੋਗੀ ਵਰਜਨ"
 msgid "Add Another Application&hellip;"
 msgstr "ਹੋਰ ਐਪਲੀਕੇਸ਼ਨ ਜੋੜੋ&hellip;"
 
-#: src/olympia/devhub/templates/devhub/addons/ajax_compat_update.html:38 src/olympia/devhub/templates/devhub/addons/owner.html:86 src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:46
-#: src/olympia/devhub/templates/devhub/versions/list.html:351 src/olympia/devhub/templates/devhub/versions/list.html:353 src/olympia/templates/impala/base.html:132
-#: src/olympia/templates/impala/base.html:143 src/olympia/templates/impala/base.html:161 src/olympia/templates/impala/base.html:171
+#: src/olympia/devhub/templates/devhub/addons/ajax_compat_update.html:38 src/olympia/devhub/templates/devhub/addons/owner.html:86 src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:45
+#: src/olympia/devhub/templates/devhub/versions/list.html:349 src/olympia/devhub/templates/devhub/versions/list.html:351 src/olympia/templates/impala/base.html:129
+#: src/olympia/templates/impala/base.html:140 src/olympia/templates/impala/base.html:158 src/olympia/templates/impala/base.html:168
 msgid "Close"
 msgstr "ਬੰਦ"
 
@@ -4349,7 +4320,7 @@ msgstr "ਕੋਈ ਨਹੀਂ"
 msgid "Manage Authors & License"
 msgstr "ਲੇਖਕਾਂ ਅਤੇ ਲਾਇਸੰਸ ਦਾ ਪ੍ਰਬੰਧ ਕਰੋ"
 
-#: src/olympia/devhub/templates/devhub/addons/owner.html:29 src/olympia/editors/templates/editors/review.html:270
+#: src/olympia/devhub/templates/devhub/addons/owner.html:29 src/olympia/editors/helpers.py:362 src/olympia/editors/templates/editors/review.html:270
 msgid "Authors"
 msgstr "ਲੇਖਕ"
 
@@ -4756,16 +4727,14 @@ msgid "Deleting your add-on will permanently remove it from the site and prevent
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:24
-msgid ""
-"Enter the following text confirm your decision:\n"
-"           {slug}"
+msgid "Enter the following text confirm your decision: {slug}"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:34
+#: src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:33
 msgid "Please tell us why you are deleting your theme:"
 msgstr "ਕਿਰਪਾ ਕਰਕੇ ਸਾਨੂੰ ਦੱਸੋ ਤੁਸੀਂ ਆਪਣੇ ਥੀਮ ਨੂੰ ਕਿਉਂ ਹਟਾ ਰਹੇ ਹੋ:"
 
-#: src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:36
+#: src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:35
 msgid "Please tell us why you are deleting your add-on:"
 msgstr "ਕਿਰਪਾ ਕਰਕੇ ਸਾਨੂੰ ਦੱਸੋ ਤੁਸੀਂ ਆਪਣੇ ਐਡ-ਆਨ ਨੂੰ ਕਿਉਂ ਹਟਾ ਰਹੇ ਹੋ:"
 
@@ -4802,8 +4771,8 @@ msgstr "ਨਵਾਂ ਵਰਜਨ"
 msgid "Daily statistics on downloads and users."
 msgstr "ਡਾਊਨਲੋਡਾਂ ਅਤੇ ਉਪਭੋਗੀਆਂ ਉੱਤੇ ਰੋਜ਼ਾਨਾ ਅੰਕੜੇ।"
 
-#: src/olympia/devhub/templates/devhub/addons/listing/item_actions.html:45 src/olympia/stats/templates/stats/stats.html:75 src/olympia/stats/templates/stats/stats.html:79
-#: src/olympia/stats/templates/stats/stats.html:81
+#: src/olympia/devhub/templates/devhub/addons/listing/item_actions.html:45 src/olympia/stats/templates/stats/stats.html:31 src/olympia/stats/templates/stats/stats.html:35
+#: src/olympia/stats/templates/stats/stats.html:37
 msgid "Statistics"
 msgstr "ਅੰਕੜੇ"
 
@@ -5132,11 +5101,11 @@ msgstr "ਕਦਮ 2. ਆਪਣਾ ਐਡ-ਆਨ ਅੱਪਲੋਡ ਕਰੋ"
 msgid "Use the fields below to upload your add-on package and select any platform restrictions. After upload, a series of automated validation tests will be run on your file."
 msgstr "ਆਪਣਾ ਐਡ-ਆਨ ਪੈਕੇਜ ਅੱਪਲੋਡ ਕਰਨ ਲਈ ਹੇਠ ਦਿੱਤੇ ਖੇਤਰ ਦੀ ਵਰਤੋਂ ਕਰੋ ਅਤੇ ਕੋਈ ਵੀ ਪਲੇਟਫ਼ਾਰਮ ਪਾਬੰਦੀਆਂ ਚੁਣੋ। ਅੱਪਲੋਡ ਤੋਂ ਬਾਅਦ, ਸਵੈ ਪ੍ਰਮਾਣਿਕਤਾ ਜਾਂਚਾਂ ਦੀ ਇੱਕ ਲੜੀ ਤੁਹਾਡੀ ਫ਼ਾਈਲ ਉੱਤੇ ਚਲਾਈ ਜਾਏਗੀ।"
 
-#: src/olympia/devhub/templates/devhub/addons/submit/upload.html:59 src/olympia/devhub/templates/devhub/versions/add_file_modal.html:39
+#: src/olympia/devhub/templates/devhub/addons/submit/upload.html:51 src/olympia/devhub/templates/devhub/versions/add_file_modal.html:28
 msgid "Which platforms is this file compatible with?"
 msgstr "ਇਹ ਫ਼ਾਈਲ ਕਿਸ ਪਲੇਟਫ਼ਾਰਮ ਦੇ ਨਾਲ ਅਨੁਕੂਲ ਹੈ?"
 
-#: src/olympia/devhub/templates/devhub/addons/submit/upload.html:67 src/olympia/devhub/templates/devhub/versions/add_file_modal.html:65
+#: src/olympia/devhub/templates/devhub/addons/submit/upload.html:59 src/olympia/devhub/templates/devhub/versions/add_file_modal.html:45
 msgid "Administrative overrides"
 msgstr "ਪ੍ਰਬੰਧਕੀ ਓਵਰਰਾਈਡ"
 
@@ -5253,8 +5222,8 @@ msgstr "ਵੈੱਬਸਾਈਟ ਕਾਰਜਕੁਸ਼ਲਤਾ ਅਤੇ ਵ
 
 #: src/olympia/devhub/templates/devhub/docs/policies-contact.html:44
 msgid ""
-"If you've found a problem with the site, we'd love to fix it. Please <a href=\"https://github.com/mozilla/olympia/issues\">file a bug report</a> in GitHub, including the location of the problem and"
-" how you encountered it."
+"If you've found a problem with the site, we'd love to fix it. Please <a href=\"https://github.com/mozilla/addons/issues/new\">file a bug report</a> in GitHub, including the location of the problem "
+"and how you encountered it."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/docs/policies-maintenance.html:3 src/olympia/devhub/templates/devhub/docs/policies-maintenance.html:7
@@ -6107,60 +6076,55 @@ msgstr "ਸਾਡੀ ਸਾਈਟ ਲਈ ਆਪਣੇ ਕੰਮ ਨੂੰ ਭੇ
 msgid "How to get in touch with us regarding these policies or your add-on."
 msgstr "ਇਹਨਾਂ ਨੀਤੀਆਂ ਜਾਂ ਆਪਣੇ ਐਡ-ਆਨ ਦੇ ਸੰਬੰਧ ਵਿੱਚ ਸਾਡੇ ਨਾਲ ਸਪੰਰਕ ਵਿੱਚ ਕਿਵੇਂ ਰਹਿਆ ਜਾਵੇ।"
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:6
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:10
 msgid "You have disabled this add-on"
 msgstr "ਤੁਸੀਂ ਇਸ ਐਡ-ਆਨ ਨੂੰ ਅਯੋਗ ਕੀਤਾ"
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:20
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:24
 msgid "Your add-on's listing is disabled and is not showing anywhere in our gallery or update service."
 msgstr "ਤੁਹਾਡੀ ਐਡ-ਆਨ ਸੂਚੀ ਅਯੋਗ ਹੈ ਅਤੇ ਸਾਡੀ ਗੈਲਰੀ ਜਾਂ ਅੱਪਡੇਟ ਸੇਵਾ ਵਿੱਚ ਕਿਤੇ ਵੀ ਵਿਖਾਈ ਨਹੀਂ ਦਿੰਦੀ।"
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:25
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:27
 msgid "Please complete your add-on."
 msgstr "ਕਿਰਪਾ ਕਰਕੇ ਆਪਣਾ ਐਡ-ਆਨ ਮੁਕੰਮਲ ਕਰੋ।"
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:29
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:30
 msgid "You will receive an email when the review is complete."
 msgstr "ਜਦੋਂ ਸਮੀਖਿਆ ਮੁਕੰਮਲ ਹੋ ਜਾਵੇਗੀ ਤੁਹਾਨੂੰ ਇੱਕ ਈਮੇਲ ਪ੍ਰਾਪਤ ਹੋਵੇਗੀ।"
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:34
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:33
 msgid "You will receive an email when the review is complete. Until then, your add-on is not listed in our gallery but can be accessed directly from its details page."
 msgstr "ਤੁਹਾਨੂੰ ਇੱਕ ਈਮੇਲ ਪ੍ਰਾਪਤ ਹੋਵੇਗਾ ਜਦੋਂ ਸਮੀਖਿਆ ਮੁਕੰਮਲ ਹੋ ਜਾਵੇਗੀ। ਤਦ ਤੱਕ, ਤੁਹਾਡਾ ਐਡ-ਆਨ ਗੈਲਰੀ ਵਿੱਚ ਸੂਚੀਬੱਧ ਨਹੀਂ ਹੋਵੇਗਾ ਪਰ ਇਸ ਦੇ ਵੇਰਵੇ ਸਫ਼ੇ ਤੋਂ ਸਿੱਧੇ ਤੌਰ ਤੇ ਪਹੁੰਚਿਆ ਜਾ ਸਕਦਾ ਹੈ।"
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:38 src/olympia/devhub/templates/devhub/includes/addon_details.html:48
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:37 src/olympia/devhub/templates/devhub/includes/addon_details.html:45
 msgid "You will receive an email when the review is complete and your add-on is signed."
 msgstr "ਤੁਹਾਨੂੰ ਇੱਕ ਈਮੇਲ ਪ੍ਰਾਪਤ ਹੋਵੇਗੀ ਜਦੋਂ ਸਮੀਖਿਆ ਮੁਕੰਮਲ ਹੋਈ ਅਤੇ ਤੁਹਾਡਾ ਐਡ-ਆਨ ਹਸਤਾਖਰਿਤ ਹੋਇਆ।"
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:44
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:41
 msgid "You will receive an email when the review is complete. Until then, your add-on is not listed in our gallery but can be accessed directly from its details page."
 msgstr "ਤੁਹਾਨੂੰ ਇੱਕ ਈਮੇਲ ਪ੍ਰਾਪਤ ਹੋਵੇਗਾ ਜਦੋਂ ਸਮੀਖਿਆ ਮੁਕੰਮਲ ਹੋ ਜਾਵੇਗੀ। ਤਦ ਤੱਕ, ਤੁਹਾਡਾ ਐਡ-ਆਨ ਗੈਲਰੀ ਵਿੱਚ ਸੂਚੀਬੱਧ ਨਹੀਂ ਹੋਵੇਗਾ ਪਰ ਇਸ ਦੇ ਵੇਰਵੇ ਸਫ਼ੇ ਤੋਂ ਸਿੱਧੇ ਤੌਰ ਤੇ ਪਹੁੰਚਿਆ ਜਾ ਸਕਦਾ ਹੈ।"
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:54
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:49
 msgid "Your add-on is displayed in our gallery and users are receiving automatic updates."
 msgstr "ਤੁਹਾਡਾ ਐਡ-ਆਨ ਸਾਡੀ ਗੈਲਰੀ ਵਿੱਚ ਪੇਸ਼ ਕੀਤਾ ਗਿਆ ਅਤੇ ਉਪਭੋਗੀ ਆਪਣੇ ਆਪ ਹੀ ਅੱਪਡੇਟਾਂ ਪ੍ਰਾਪਤ ਕਰ ਰਹੇ ਹਨ।"
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:57
-msgid ""
-"Your add-on has been signed and can be bundled with an\n"
-"                             application installer."
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:52
+msgid "Your add-on has been signed and can be bundled with an application installer."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:63
-msgid ""
-"Your add-on was disabled by a site administrator and is no\n"
-"                             longer shown in our gallery. If you have any questions,\n"
-"                             please email amo-admins@mozilla.org."
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:56
+msgid "Your add-on was disabled by a site administrator and is no longer shown in our gallery. If you have any questions, please email amo-admins@mozilla.org."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:70
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:62
 msgid "Your add-on is displayed in our gallery as experimental and users are receiving automatic updates. Some features are unavailable to your add-on."
 msgstr "ਤੁਹਾਡਾ ਐਡ-ਆਨ ਸਾਡੀ ਗੈਲਰੀ ਵਿੱਚ ਪ੍ਰਯੋਗਆਤਮਕ ਤੌਰ ਤੇ ਪੇਸ਼ ਕੀਤਾ ਗਿਆ ਅਤੇ ਉਪਭੋਗੀ ਆਪਣੇ ਆਪ ਹੀ ਅੱਪਡੇਟਾਂ ਪ੍ਰਾਪਤ ਕਰ ਰਹੇ ਹਨ। ਕੁੱਝ ਵਿਸ਼ੇਸਤਾਵਾਂ ਤੁਹਾਡੇ ਐਡ-ਆਨ ਲਈ ਉੱਪਲਬਧ ਨਹੀਂ ਹਨ।"
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:74
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:66
 msgid "Your add-on has been signed."
 msgstr "ਤੁਹਾਡਾ ਐਡ-ਆਨ ਹਸਤਾਖਰਿਤ ਕੀਤਾ ਗਿਆ।"
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:79
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:69
 msgid ""
 "You will receive an email when the full review is complete. Until then, your add-on is displayed in our gallery as experimental and users are receiving automatic updates. Some features are "
 "unavailable to your add-on."
@@ -6168,44 +6132,41 @@ msgstr ""
 "ਤੁਹਾਨੂੰ ਇੱਕ ਈਮੇਲ ਪ੍ਰਾਪਤ ਹੋਵੇਗਾ ਜਦੋਂ ਮੁਕੰਮਲ ਸਮੀਖਿਆ ਪੂਰੀ ਹੋ ਜਾਵੇਗੀ। ਤਦ ਤੱਕ, ਤੁਹਾਡਾ ਐਡ-ਆਨ ਸਾਡੀ ਗੈਲਰੀ ਵਿੱਚ ਪ੍ਰਯੋਗਆਤਮਕ ਤੌਰ ਤੇ ਪੇਸ਼ ਕੀਤਾ ਜਾਵੇਗਾ ਅਤੇ ਉਪਭੋਗੀ ਆਪਣੇ ਆਪ ਅੱਪਡੇਟਾਂ ਪ੍ਰਾਪਤ ਕਰ ਰਹੇ ਹਨ। ਕੁੱਝ "
 "ਵਿਸ਼ੇਸਤਾਵਾਂ  ਤੁਹਾਡੇ ਐਡ-ਆਨ ਲਈ ਉੱਪਲਬਧ ਨਹੀਂ ਹਨ।"
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:84
-msgid ""
-"You will receive an email when the full review is\n"
-"                             complete, making you able to bundle your add-on with an\n"
-"                             application installer."
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:74
+msgid "You will receive an email when the full review is complete, making you able to bundle your add-on with an application installer."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:91
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:79
 msgid "All add-ons hosted in our gallery must now be reviewed by an editor. If you wish to continue hosting your add-on, please click to select a review process."
 msgstr "ਸਾਡੀ ਗੈਲਰੀ ਵਿੱਚ ਮੇਜ਼ਬਾਨ ਸਾਰੇ ਐਡ-ਆਨਾਂ ਦੀ ਹੁਣੇ ਇੱਕ ਸੰਪਾਦਕ ਵੱਲੋਂ ਸਮੀਖਿਆ ਹੋਣੀ ਚਾਹੀਦੀ ਹੈ। ਜੇਕਰ ਤੁਸੀਂ ਆਪਣੇ ਐਡ-ਆਨ ਦੀ ਮੇਜ਼ਬਾਨੀ ਜਾਰੀ ਰੱਖਣਾ ਚਾਹੁੰਦੇ ਹੋ, ਕਿਰਪਾ ਕਰਕੇ ਇੱਕ ਸਮੀਖਿਆ ਕਾਰਜ ਚੁਣਨ ਲਈ ਕਲਿੱਕ ਕਰੋ।"
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:113
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:100
 msgid "Current Version:"
 msgstr "ਮੌਜੂਦਾ ਵਰਜਨ:"
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:115
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:102
 msgid "This is the version of your add-on that will be installed if someone clicks the Install button on addons.mozilla.org. It is only relevant for listed add-ons."
 msgstr "ਤੁਹਾਡੇ ਐਡ-ਆਨ ਦਾ ਇਹ ਵਰਜਨ ਇੰਸਟਾਲ ਕੀਤਾ ਜਾਵੇਗਾ ਜੇਕਰ ਕੋਈ addons.mozilla.org ਤੇ ਇੰਸਟਾਲ ਬਟਨ ਤੇ ਕਲਿੱਕ ਕਰਦਾ। ਇਹ ਕੇਵਲ ਸੂਚੀਬੱਧ ਐਡ-ਆਨਾਂ ਲਈ ਢੁੱਕਵਾਂ ਹੈ।"
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:123
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:110
 msgid "Created:"
 msgstr "ਰਚਿਆ:"
 
 #. {0} is a date. dennis-ignore: E201
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:125 src/olympia/devhub/templates/devhub/includes/addon_details.html:131
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:112 src/olympia/devhub/templates/devhub/includes/addon_details.html:118
 #, python-format
 msgid "%%b %%e, %%Y"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:136
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:123
 msgid "Next Version:"
 msgstr "ਅਗਲਾ ਵਰਜਨ:"
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:138
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:125
 msgid "This is the newest uploaded version, however it isn’t live on the site yet."
 msgstr "ਇਹ ਬਿਲਕੁਲ ਨਵਾਂ ਅੱਪਲੋਡਿਡ ਵਰਜਨ ਹੈ, ਹਾਲਾਂਕਿ ਇਹ ਹਾਲੇ ਤੱਕ ਇਸ ਸਾਈਟ ਤੇ ਠਹਿਰਾਓ ਨਹੀਂ।"
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:144 src/olympia/devhub/templates/devhub/versions/list.html:30
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:130 src/olympia/devhub/templates/devhub/versions/list.html:30
 msgid "Queues are not reviewed strictly in order"
 msgstr "ਕਤਾਰਾਂ ਦੀ ਕਸਵੇਂ ਤੌਰ ਤੇ ਸਮੀਖਿਆ ਨਹੀਂ ਹੁੰਦੀ"
 
@@ -6304,12 +6265,10 @@ msgstr[1] "ਇਸ ਐਡ-ਆਨ ਲਈ <b>{0} ਤੱਕ</b> {1} ਸੰਗ੍ਰ�
 #: src/olympia/devhub/templates/devhub/includes/policy_form.html:4
 msgid ""
 "Users will be required to accept the following End-User License Agreement (EULA) prior to installing your add-on. The presence of a EULA significantly affects the number of downloads an add-on "
-"receives. Please note that a EULA is not the same as a code license, such as the GPL or MPL. It is only relevant for listed add-ons."
+"receives. Please note that a EULA is not the same as a code license, such as the GPL or MPL.It is only relevant for listed add-ons."
 msgstr ""
-"ਵਰਤੋਂਕਾਰਾਂ ਨੂੰ ਤੁਹਾਡਾ ਐਡ-ਆਨ ਇੰਸਟਾਲ ਕਰਨ ਤੋਂ ਪਹਿਲਾਂ ਅੱਗੇ ਦਿੱਤਾ ਅੰਤ-ਵਰਤੋਂਕਾਰ ਲਾਇਸੰਸ ਸਮਝੌਤਾ (EULA) ਮਨਜ਼ੂਰ ਹੋਣਾ ਚਾਹੀਦਾ। EULA ਦੀ ਮੌਜੂਦਗੀ ਵਿਸ਼ੇਸ ਤੌਰ ਤੇ ਐਡ-ਆਨ ਦੇ ਡਾਊਨਲੋਡਾਂ ਦੀ ਗਿਣਤੀ ਤੇ ਅਸਰ ਪਾਉਂਦੀ ਹੈ। ਕਿਰਪਾ "
-"ਕਰਕੇ ਧਿਆਨ ਰੱਖੋ EULA ਬਿਲਕੁੱਲ ਇੱਕ ਕੋਡ ਲਾਇਸੰਸ ਦੀ ਤਰ੍ਹਾਂ ਨਹੀਂ ਹੈ, ਜਿਵੇਂ ਕਿ GPL ਜਾਂ MPL। ਇਹ ਕੇਵਲ ਸੂਚੀਬੱਧ ਐਡ-ਆਨਾਂ ਲਈ ਢੁੱਕਵਾਂ ਹੈ।"
 
-#: src/olympia/devhub/templates/devhub/includes/policy_form.html:21
+#: src/olympia/devhub/templates/devhub/includes/policy_form.html:24
 msgid "If your add-on transmits any data from the user's computer, a privacy policy is required that explains what data is sent and how it is used. It is only relevant for listed add-ons."
 msgstr "ਜੇਕਰ ਤੁਹਾਡਾ ਐਡ-ਆਨ ਵਰਤੋਂਕਾਰ ਦੇ ਕੰਪਿਊਟਰ ਤੋਂ ਕੋਈ ਡਾਟਾ ਭੇਜਦਾ, ਇੱਕ ਪਰਦੇਦਾਰੀ ਨੀਤੀ ਦੀ ਲੋੜ ਹੈ ਜੋ ਦੱਸੇ ਕਿ ਕਿਹੜਾ ਡਾਟਾ ਭੇਜਿਆ ਅਤੇ ਇਹ ਕਿਵੇਂ ਵਰਤਿਆ ਜਾਏਗਾ। ਇਹ ਕੇਵਲ ਸੂਚੀਬੱਧ ਐਡ-ਆਨਾਂ ਲਈ ਢੁੱਕਵਾਂ ਹੈ।"
 
@@ -6480,7 +6439,7 @@ msgstr "ਸੰਗ੍ਰਹਿ ਚੁਣੋ ਜੋ ਤੁਹਾਡੇ ਥੀਮ �
 msgid "Add some tags to describe your Theme."
 msgstr "ਆਪਣੇ ਥੀਮ ਦੇ ਵੇਰਵੇ ਲਈ ਕੁੱਝ ਟੈਗ ਸ਼ਾਮਲ ਕਰੋ।"
 
-#: src/olympia/devhub/templates/devhub/personas/edit.html:106
+#: src/olympia/devhub/templates/devhub/personas/edit.html:106 src/olympia/devhub/templates/devhub/personas/submit.html:54
 msgid "A short explanation of your theme's basic functionality that is displayed in search and browse listings, as well as at the top of your theme's details page."
 msgstr "ਤੁਹਾਡੇ ਥੀਮ ਦੀ ਬੁਨਿਆਦੀ ਕਾਰਜਕੁਸ਼ਲਤਾ ਦੀ ਛੋਟੀ ਵਿਆਖਿਆ ਜੋ ਖੋਜ ਅਤੇ ਸੂਚੀ ਝਲਕ, ਨਾਲ ਹੀ ਨਾਲ ਤੁਹਾਡੇ ਥੀਮ ਦੇ ਵੇਰਵੇ ਸਫ਼ੇ ਦੇ ਉੱਪਰ ਵਿਖਾਈ ਜਾਏਗੀ।"
 
@@ -6620,10 +6579,6 @@ msgstr "ਬੈਕਗਰਾਂਊਡ ਥੀਮ ਤੁਹਾਨੂੰ ਤੁਹਾ
 msgid "Give your Theme a name."
 msgstr "ਆਪਣੇ ਥੀਮ ਨੂੰ ਇੱਕ ਨਾਂ ਦਿਓ।"
 
-#: src/olympia/devhub/templates/devhub/personas/submit.html:54
-msgid "A short explanation of your theme's basic functionality that is displayed in search and browse listings, as well as at the top of your theme's details page."
-msgstr "ਤੁਹਾਡੇ ਥੀਮ ਦੀ ਬੁਨਿਆਦੀ ਕਾਰਜਕੁਸ਼ਲਤਾ ਦੀ ਛੋਟੀ ਵਿਆਖਿਆ ਜੋ ਖੋਜ ਅਤੇ ਸੂਚੀ ਝਲਕ, ਨਾਲ ਹੀ ਨਾਲ ਤੁਹਾਡੇ ਥੀਮ ਦੇ ਵੇਰਵੇ ਸਫ਼ੇ ਦੇ ਉੱਪਰ ਵਿਖਾਈ ਜਾਏਗੀ।"
-
 #: src/olympia/devhub/templates/devhub/personas/submit.html:198
 #, python-format
 msgid ""
@@ -6700,31 +6655,17 @@ msgstr "ਇੱਕ ਵੱਖ ਪਦਲੇਖ ਤਸਵੀਰ"
 msgid "Files added to reviewed versions must be reviewed before they will be available for download."
 msgstr "ਸਮੀਖਿਅਕ ਵਰਜਨਾਂ ਵਿੱਚ ਸ਼ਾਮਲ ਫ਼ਾਈਲਾਂ ਦੀ ਸਮੀਖਿਆ ਹੋ ਜਾਣੀ ਚਾਹੀਦੀ ਹੈ ਇਸ ਤੋਂ ਪਹਿਲਾਂ ਕੀ ਉਹ ਡਾਊਨਲੋਡ ਲਈ ਉੱਪਲਬਧ ਹੋਣ।"
 
-#: src/olympia/devhub/templates/devhub/versions/add_file_modal.html:15
-#, python-format
-msgid ""
-"Submission of updates to unlisted add-ons for signing is currently in an open beta. Manual review may still be required for a large number of add-ons. Please <a href=\"%(url)s\" "
-"target=\"_blank\">report any bugs</a> that you encounter."
-msgstr ""
-
-#: src/olympia/devhub/templates/devhub/versions/add_file_modal.html:35
+#: src/olympia/devhub/templates/devhub/versions/add_file_modal.html:24
 msgid "Select the target platform for this file."
 msgstr "ਇਸ ਸਾਈਟ ਲਈ ਤੈਅ ਪਲੇਟਫ਼ਾਰਮ ਚੁਣੋ।"
 
-#: src/olympia/devhub/templates/devhub/versions/add_file_modal.html:46
+#: src/olympia/devhub/templates/devhub/versions/add_file_modal.html:35
 msgid "Which review type would you like to nominate for?"
 msgstr "ਤੁਸੀਂ ਕਿਸ ਢੰਗ ਦੀ ਸਮੀਖਿਆ ਲਈ ਨੁਮਾਇੰਦਗੀ ਲੈਣਾ ਚਾਹੋਗੇ?"
 
-#: src/olympia/devhub/templates/devhub/versions/add_file_modal.html:51
+#: src/olympia/devhub/templates/devhub/versions/add_file_modal.html:40
 msgid "Only publish this version to my beta channel."
 msgstr "ਕੇਵਲ ਇਸ ਵਰਜਨ ਨੂੰ ਮੇਰੇ ਬੀਟਾ ਚੈਨਲ ਵਿੱਚ ਜਾਰੀ ਕਰੋ।"
-
-#: src/olympia/devhub/templates/devhub/versions/add_file_modal.html:54
-#, python-format
-msgid ""
-"The behavior of the beta channel has changed to accommodate <a href=\"%(addon_signing_url)s\" target=\"_blank\">mandatory add-on signing</a>. The new process is currently in an open beta, and may "
-"change significantly in the near future. Please <a href=\"%(issues_url)s\" target=\"_blank\">report any bugs</a> that you encounter."
-msgstr ""
 
 #: src/olympia/devhub/templates/devhub/versions/edit.html:5
 msgid "Manage Version {0}"
@@ -6746,10 +6687,6 @@ msgstr "ਫ਼ਾਈਲਾਂ"
 #: src/olympia/devhub/templates/devhub/versions/edit.html:38
 msgid "Upload Another File"
 msgstr "ਹੋਰ ਫ਼ਾਈਲ ਅੱਪਲੋਡ ਕਰੋ"
-
-#: src/olympia/devhub/templates/devhub/versions/edit.html:45
-msgid "Adjusting application information here will allow users to install your add-on even if the install manifest in the package indicates that the add-on is incompatible."
-msgstr "ਇੱਥੇ ਐਪਲੀਕੇਸ਼ਨ ਦੀ ਜਾਣਕਾਰੀ ਵਿੱਚ ਕੀਤਾ ਫ਼ੇਰਬਦਲ ਉਪਭੋਗੀਆਂ ਨੂੰ ਤੁਹਾਡਾ ਐਡ-ਆਨ ਇੰਸਟਾਲ ਕਰਨ ਦੇਵੇਗਾ ਭਲੇ ਹੀ ਪੈਕੇਜ ਵਿੱਚ ਦਿੱਤਾ ਇੰਸਟਾਲ ਮੈਨਫ਼ੇਸ਼ਟ ਇਹ ਦੱਸੇ ਕਿ ਐਡ-ਆਨ ਅਨੁਕੂਲ ਨਹੀਂ ਹੈ।"
 
 #: src/olympia/devhub/templates/devhub/versions/edit.html:74
 msgid ""
@@ -6844,7 +6781,7 @@ msgstr "ਪੂਰੀ ਸਮੀਖਿਆ ਦੀ ਬੇਨਤੀ ਕਰੋ"
 msgid "Request Preliminary Review"
 msgstr "ਸ਼ੁਰੂਆਤੀ ਸਮੀਖਿਆ ਦੀ ਬੇਨਤੀ ਕਰੋ"
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:80 src/olympia/devhub/templates/devhub/versions/list.html:327 src/olympia/devhub/templates/devhub/versions/list.html:350
+#: src/olympia/devhub/templates/devhub/versions/list.html:80 src/olympia/devhub/templates/devhub/versions/list.html:325 src/olympia/devhub/templates/devhub/versions/list.html:348
 msgid "Cancel Review Request"
 msgstr "ਸਮੀਖਿਆ ਬੇਨਤੀ ਰੱਦ ਕਰੋ"
 
@@ -6873,8 +6810,8 @@ msgid "Unlisted:"
 msgstr "ਗੈਰ-ਸੂਚੀਬੱਧ:"
 
 #: src/olympia/devhub/templates/devhub/versions/list.html:114
-msgid "Not distributed on {0}. Developers will upload new versions for signing and distribute the add-ons on their own. (beta)"
-msgstr "{0} ਤੇ ਵੰਡਿਆ ਨਹੀਂ ਗਿਆ। ਡਿਵੈਲਪਰ ਸਾਈਨਿੰਗ ਲਈ ਨਵੇਂ ਵਰਜਨ ਅੱਪਲੋਡ ਕਰਨਗੇ ਅਤੇ ਨਿੱਜੀ ਤੌਰ ਤੇ ਐਡ-ਆਨ ਵੰਡਣਗੇ। (ਬੀਟਾ)"
+msgid "Not distributed on {0}. Developers will upload new versions for signing and distribute the add-ons on their own."
+msgstr ""
 
 #: src/olympia/devhub/templates/devhub/versions/list.html:122
 msgid "Current versions"
@@ -6935,78 +6872,73 @@ msgid "<strong>Important:</strong> Once a version has been deleted, you may not 
 msgstr "<strong>ਜ਼ਰੂਰੀ:</strong> ਜੇਕਰ ਇੱਕ ਵਾਰ ਵਰਜਨ ਹਟਾ ਲਿਆ ਗਿਆ, ਹੋ ਸਕਦਾ ਤੁਸੀਂ ਉਸੇ ਵਰਜਨ ਨੰਬਰ ਨਾਲ ਨਵਾਂ ਵਰਜਨ ਅੱਪਲੋਡ ਨਹੀਂ ਕਰ ਪਾਓ।"
 
 #: src/olympia/devhub/templates/devhub/versions/list.html:230
-msgid "Deleting a version which has already been reviewed may also cause a significant delay in the review of your next update."
-msgstr "ਸਮੀਖਿਆ ਕੀਤੇ ਗਏ ਵਰਜਨ ਨੂੰ ਹਟਾਉਣਾ ਤੁਹਾਡੇ ਅਗਲੇ ਅੱਪਡੇਟ ਦੀ ਸਮੀਖਿਆ ਵਿੱਚ ਕਾਫ਼ੀ ਦੇਰ ਹੋਣ ਦਾ ਕਾਰਨ ਬਣ ਸਕਦਾ।"
-
-#: src/olympia/devhub/templates/devhub/versions/list.html:233
 msgid "Are you sure you wish to delete this version?"
 msgstr "ਕੀ ਤੁਸੀਂ ਇਸ ਵਰਜਨ ਨੂੰ ਹਟਾਉਣ ਦੀ ਪੁਸ਼ਟੀ ਕਰਦੇ ਹੋ?"
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:238
+#: src/olympia/devhub/templates/devhub/versions/list.html:235
 msgid "Delete Version"
 msgstr "ਵਰਜਨ ਹਟਾਓ"
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:240
+#: src/olympia/devhub/templates/devhub/versions/list.html:237
 msgid "Disable Version"
 msgstr "ਵਰਜਨ ਅਯੋਗ ਕਰੋ"
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:247
+#: src/olympia/devhub/templates/devhub/versions/list.html:244
 msgid "Add a new Version"
 msgstr "ਨਵਾਂ ਵਰਜਨ ਸ਼ਾਮਲ ਕਰੋ"
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:249
+#: src/olympia/devhub/templates/devhub/versions/list.html:246
 msgid "Add Version"
 msgstr "ਵਰਜਨ ਸ਼ਾਮਲ ਕਰੋ"
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:256 src/olympia/devhub/templates/devhub/versions/list.html:274
+#: src/olympia/devhub/templates/devhub/versions/list.html:253 src/olympia/devhub/templates/devhub/versions/list.html:279
 msgid "Hide Add-on"
 msgstr "ਐਡ-ਆਨ ਲੁਕਾਓ"
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:259
+#: src/olympia/devhub/templates/devhub/versions/list.html:256
 msgid "Hiding your add-on will prevent it from appearing anywhere in our gallery and will stop users from receiving automatic updates."
 msgstr "ਆਪਣੇ ਐਡ-ਆਨ ਨੂੰ ਲੁਕਾਉਣਾ ਇਸ ਨੂੰ ਗੈਲਰੀ ਵਿੱਚ ਵਿਖਾਈ ਦੇਣ ਤੋਂ ਰੋਕੇਗਾ ਅਤੇ ਵਰਤੋਂਕਾਰਾਂ ਨੂੰ ਆਪਣੇ ਆਪ ਅੱਪਡੇਟਾਂ ਦੇਣਾ ਬੰਦ ਕਰ ਦੇਵੇਗਾ।"
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:265
+#: src/olympia/devhub/templates/devhub/versions/list.html:263
+msgid "The files awaiting review will be disabled and you will need to upload new versions."
+msgstr ""
+
+#: src/olympia/devhub/templates/devhub/versions/list.html:270
 msgid "Are you sure you wish to hide your add-on?"
 msgstr "ਪੁਸ਼ਟੀ ਕਰੋ ਕੀ ਆਪਣੇ ਐਡ-ਆਨ ਨੂੰ ਲੁਕਾਉਣਾ ਚਾਹੁੰਦੇ ਹੋ?"
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:286 src/olympia/devhub/templates/devhub/versions/list.html:315
+#: src/olympia/devhub/templates/devhub/versions/list.html:291 src/olympia/devhub/templates/devhub/versions/list.html:313
 msgid "Unlist Add-on"
 msgstr "ਐਡ-ਆਨ ਸੂਚੀ ਤੋਂ ਹਟਾਓ"
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:289
+#: src/olympia/devhub/templates/devhub/versions/list.html:294
 #, python-format
 msgid ""
 "Unlisting your add-on will make it (and each of its versions/files) invisible on this website. It won't show up in searches, won't have a public facing page, and won't be updated automatically for "
-"current users.  It is recommended for unlisted add-ons to provide a custom <a href=\"%(update_url)s\" target=\"_blank\">updateURL</a> in their manifest file for automatic updates."
+"current users. It is recommended for unlisted add-ons to provide a custom <a href=\"%(update_url)s\" target=\"_blank\">updateURL</a> in their manifest file for automatic updates."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:299
-#, python-format
-msgid "Switching add-ons to unlisted is currently in an open beta. Please <a href=\"%(url)s\" target=\"_blank\">report any bugs</a> that you encounter."
-msgstr ""
-
-#: src/olympia/devhub/templates/devhub/versions/list.html:305
+#: src/olympia/devhub/templates/devhub/versions/list.html:303
 msgid "Unlisting an add-on is irreversible!"
 msgstr "ਐਡ-ਆਨ ਨੂੰ ਗੈਰ-ਸੂਚੀਬੱਧ ਕਰਨਾ ਅਟੱਲ ਹੈ!"
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:305
+#: src/olympia/devhub/templates/devhub/versions/list.html:303
 msgid "An unlisted add-on cannot be switched to be listed."
 msgstr "ਗੈਰ-ਸੂਚੀਬੱਧ ਐਡ-ਆਨ ਨੂੰ ਸੂਚੀਬੱਧ ਕਰਨ ਲਈ ਸਵਿੱਚ ਨਹੀਂ ਕੀਤਾ ਜਾ ਸਕਦਾ।"
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:307
+#: src/olympia/devhub/templates/devhub/versions/list.html:305
 msgid "Are you sure you wish to unlist your add-on?"
 msgstr "ਕੀ ਤੁਸੀਂ ਆਪਣੇ ਐਡ-ਆਨ ਨੂੰ ਸੂਚੀ ਤੋਂ ਹਟਾਉਣ ਦੀ ਪੁਸ਼ਟੀ ਕਰਦੇ ਹੋ?"
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:330
+#: src/olympia/devhub/templates/devhub/versions/list.html:328
 msgid "Canceling your review request will leave your add-on as preliminarily reviewed."
 msgstr "ਆਪਣੀ ਸਮੀਖਿਆ ਬੇਨਤੀ ਰੱਦ ਕਰਨਾ ਤੁਹਾਡੇ ਐਡ-ਆਨ ਨੂੰ ਸ਼ਰੂਆਤੀ ਸਮੀਖਿਆ ਦੇ ਤੌਰ ਤੇ ਛੱਡ ਦੇਵੇਗਾ।"
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:335
+#: src/olympia/devhub/templates/devhub/versions/list.html:333
 msgid "Canceling your review request will mark your add-on incomplete. If you do not complete your add-on after several days by re-requesting review, it will be deleted."
 msgstr "ਆਪਣੀ ਸਮੀਖਿਆ ਬੇਨਤੀ ਨੂੰ ਰੱਦ ਕਰਨਾ ਤੁਹਾਡੇ ਐਡ-ਆਨ ਤੇ ਅਧੂਰੇ ਦਾ ਨਿਸ਼ਾਨ ਲਗਾ ਦੇਵੇਗਾ। ਜੇਕਰ ਤੁਸੀਂ ਮੁੜ-ਬੇਨਤੀ ਸਮੀਖਿਆ ਦੁਆਰਾ ਕੁੱਝ ਦਿਨਾਂ ਬਾਅਦ ਵੀ ਆਪਣਾ ਐਡ-ਆਨ ਮੁਕੰਮਲ ਨਹੀਂ ਕੀਤਾ, ਇਹ ਹਟਾ ਦਿੱਤਾ ਜਾਵੇਗਾ।"
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:343
+#: src/olympia/devhub/templates/devhub/versions/list.html:341
 msgid "Are you sure you wish to cancel your review request?"
 msgstr "ਕੀ ਤੁਸੀਂ ਆਪਣੀ ਸਮੀਖਿਆ ਬੇਨਤੀ ਨੂੰ ਰੱਦ ਕਰਨ ਦੀ ਪੁਸ਼ਟੀ ਕਰਦੇ ਹੋ?"
 
@@ -7345,19 +7277,19 @@ msgstr "ਐਡ-ਆਨ, ਸੰਪਾਦਕ ਜਾਂ ਟਿੱਪਣੀ"
 msgid "Search by add-on name / author email"
 msgstr "ਐਡ-ਆਨ ਨਾਂ/ ਲੇਖਕ ਈਮੇਲ ਦੁਅਾਰਾ ਖੋਜ ਕਰੋ"
 
-#: src/olympia/editors/forms.py:103
+#: src/olympia/editors/forms.py:103 src/olympia/editors/forms.py:244 src/olympia/editors/forms.py:257
 msgid "yes"
 msgstr "ਹਾਂ"
 
-#: src/olympia/editors/forms.py:104
+#: src/olympia/editors/forms.py:104 src/olympia/editors/forms.py:244 src/olympia/editors/forms.py:257
 msgid "no"
 msgstr "ਨਹੀਂ"
 
-#: src/olympia/editors/forms.py:105
+#: src/olympia/editors/forms.py:105 src/olympia/editors/forms.py:245
 msgid "Admin Flag"
 msgstr "ਪ੍ਰਬੰਧਕ ਝੰਡਾ"
 
-#: src/olympia/editors/forms.py:113
+#: src/olympia/editors/forms.py:113 src/olympia/editors/forms.py:253
 msgid "Max. Version"
 msgstr "ਮੈਕਸ. ਵਰਜਨ"
 
@@ -7369,55 +7301,59 @@ msgstr "ਦਾਖਲ ਕਾਰਜ ਬਾਅਦ ਦਿਨ"
 msgid "Add-on Types"
 msgstr "ਐਡ-ਆਨ ਕਿਸਮਾਂ"
 
-#: src/olympia/editors/forms.py:126 src/olympia/editors/helpers.py:267
+#: src/olympia/editors/forms.py:126 src/olympia/editors/helpers.py:279
 msgid "Platforms"
 msgstr "ਪਲੇਟਫ਼ਾਰਮ"
 
+#: src/olympia/editors/forms.py:237
+msgid "Search by add-on name / author email / guid"
+msgstr ""
+
 #. L10n: 0 = platform, 1 = filename, 2 = status message
-#: src/olympia/editors/forms.py:238
+#: src/olympia/editors/forms.py:342
 #, python-format
 msgid "<strong>%s</strong> &middot; %s &middot; %s"
 msgstr "<strong>%s</strong> &middot; %s &middot; %s"
 
-#: src/olympia/editors/forms.py:252
+#: src/olympia/editors/forms.py:356
 msgid "Comments:"
 msgstr "ਟਿੱਪਣੀਆਂ:"
 
-#: src/olympia/editors/forms.py:256
+#: src/olympia/editors/forms.py:360
 msgid "Operating systems:"
 msgstr "ਓਪਰੇਟਿੰਗ ਸਿਸਟਮ:"
 
-#: src/olympia/editors/forms.py:258
+#: src/olympia/editors/forms.py:362
 msgid "Applications:"
 msgstr "ਐਪਲੀਕੇਸ਼ਨਾਂ:"
 
-#: src/olympia/editors/forms.py:260
+#: src/olympia/editors/forms.py:364
 msgid "Notify me the next time this add-on is updated. (Subsequent updates will not generate an email)"
 msgstr "ਅਗਲੀ ਵਾਰ ਐਡ-ਆਨ ਅੱਪਡੇਟ ਹੋਵੇ ਮੈਨੂੰ ਸੂਚਿਤ ਕਰੋ। (ਪਿਛਲੀਆਂ ਅੱਪਡੇਟਾਂ ਈਮੇਲ ਜਾਰੀ ਨਹੀਂ ਕਰਨਗੀਆਂ)"
 
-#: src/olympia/editors/forms.py:265
+#: src/olympia/editors/forms.py:369
 msgid "Clear Admin Review Flag"
 msgstr "ਪ੍ਰਬੰਧਕ ਸਮੀਖਿਆ ਝੰਡਾ ਮਿਟਾਓ"
 
-#: src/olympia/editors/forms.py:267
+#: src/olympia/editors/forms.py:371
 msgid "Clear more info requested flag"
 msgstr ""
 
-#: src/olympia/editors/forms.py:281
+#: src/olympia/editors/forms.py:385
 msgid "Choose a canned response..."
 msgstr "ਇੱਕ ਡਿੱਬਾਬੰਦ ਜਵਾਬ ਚੁਣੋ..."
 
 #. L10n: Description of what can be searched for.
-#: src/olympia/editors/forms.py:324
+#: src/olympia/editors/forms.py:423
 msgid "theme name"
 msgstr "ਥੀਮ ਨਾਂ"
 
-#: src/olympia/editors/forms.py:350
+#: src/olympia/editors/forms.py:449
 msgid "Someone else is reviewing this theme."
 msgstr "ਇਸ ਥੀਮ ਦੀ ਸਮੀਖਿਆ ਕੋਈ ਹੋਰ ਕਰ ਰਿਹਾ ਹੈ।"
 
 #. L10n: Description of what can be searched for.
-#: src/olympia/editors/forms.py:447
+#: src/olympia/editors/forms.py:546
 msgid "app, reviewer, or comment"
 msgstr "ਐਪ, ਸਮੀਖਿਅਕ, ਜਾਂ ਟਿੱਪਣੀ"
 
@@ -7433,192 +7369,210 @@ msgstr "ਅਧੂਰੀ ਸ਼ੁਰੂਆਤੀ ਸਮੀਖਿਆ"
 msgid "Rejected or Unreviewed"
 msgstr "ਰੱਦ ਹੋਇਆ ਜਾਂ ਬਿਨਾਂ-ਸਮੀਖਿਆ"
 
-#: src/olympia/editors/helpers.py:123 src/olympia/editors/helpers.py:136
+#: src/olympia/editors/helpers.py:125 src/olympia/editors/helpers.py:138
 msgid "Queue"
 msgstr "ਕਤਾਰ"
 
-#: src/olympia/editors/helpers.py:124 src/olympia/editors/templates/editors/base.html:50 src/olympia/editors/templates/editors/base.html:65
+#: src/olympia/editors/helpers.py:126 src/olympia/editors/templates/editors/base.html:50 src/olympia/editors/templates/editors/base.html:65
 msgid "Pending Updates"
 msgstr "ਅਧੂਰੀਆਂ ਅੱਪਡੇਟਾਂ"
 
-#: src/olympia/editors/helpers.py:125 src/olympia/editors/templates/editors/base.html:48 src/olympia/editors/templates/editors/base.html:63
+#: src/olympia/editors/helpers.py:127 src/olympia/editors/templates/editors/base.html:48 src/olympia/editors/templates/editors/base.html:63
 msgid "Full Reviews"
 msgstr "ਮੁਕੰਮਲ ਸਮੀਖਿਆਵਾਂ"
 
-#: src/olympia/editors/helpers.py:126 src/olympia/editors/templates/editors/base.html:52 src/olympia/editors/templates/editors/base.html:67
+#: src/olympia/editors/helpers.py:128 src/olympia/editors/templates/editors/base.html:52 src/olympia/editors/templates/editors/base.html:67
 msgid "Preliminary Reviews"
 msgstr "ਸ਼ੁਰੂਆਤੀ ਸਮੀਖਿਆਵਾਂ"
 
-#: src/olympia/editors/helpers.py:127 src/olympia/editors/templates/editors/base.html:54
+#: src/olympia/editors/helpers.py:129 src/olympia/editors/templates/editors/base.html:54
 msgid "Moderated Reviews"
 msgstr "ਦਰਮਿਆਨੀ ਸਮੀਖਿਆਵਾਂ"
 
-#: src/olympia/editors/helpers.py:128 src/olympia/editors/templates/editors/base.html:46
+#: src/olympia/editors/helpers.py:130 src/olympia/editors/templates/editors/base.html:46
 msgid "Fast Track"
 msgstr "ਫ਼ਾਸਟ ਟਰੈਕ"
 
-#: src/olympia/editors/helpers.py:130
+#: src/olympia/editors/helpers.py:132
 msgid "Pending Themes"
 msgstr "ਅਧੂਰੇ ਥੀਮ"
 
-#: src/olympia/editors/helpers.py:131 src/olympia/editors/templates/editors/themes/queue.html:4
+#: src/olympia/editors/helpers.py:133 src/olympia/editors/templates/editors/themes/queue.html:4
 msgid "Flagged Themes"
 msgstr "ਫ਼ਲੈਗ ਕੀਤੇ ਥੀਮ"
 
-#: src/olympia/editors/helpers.py:132
+#: src/olympia/editors/helpers.py:134
 msgid "Update Themes"
 msgstr "ਥੀਮ ਅੱਪਡੇਟ ਕਰੋ"
 
-#: src/olympia/editors/helpers.py:137
+#: src/olympia/editors/helpers.py:139
 msgid "Unlisted Pending Updates"
 msgstr "ਗੈਰਸੂਚੀਬੱਧ ਅਧੂਰੀਆਂ ਅੱਪਡੇਟਾਂ"
 
-#: src/olympia/editors/helpers.py:138
+#: src/olympia/editors/helpers.py:140
 msgid "Unlisted Full Reviews"
 msgstr "ਗੈਰਸੂਚੀਬੱਧ ਮੁਕੰਮਲ ਸਮੀਖਿਆਵਾਂ"
 
-#: src/olympia/editors/helpers.py:139
+#: src/olympia/editors/helpers.py:141
 msgid "Unlisted Preliminary Reviews"
 msgstr "ਗੈਰਸੂਚੀਬੱਧ ਸ਼ੁਰੂਆਤੀ ਸਮੀਖਿਆਵਾਂ"
 
-#: src/olympia/editors/helpers.py:170
+#: src/olympia/editors/helpers.py:142
+msgid "Unlisted All Add-ons"
+msgstr ""
+
+#: src/olympia/editors/helpers.py:173
 msgid "Fast Track ({0})"
 msgid_plural "Fast Track ({0})"
 msgstr[0] "ਫ਼ਾਸਟ ਟਰੈਕ ({0})"
 msgstr[1] "ਫ਼ਾਸਟ ਟਰੈਕ ({0})"
 
-#: src/olympia/editors/helpers.py:175
+#: src/olympia/editors/helpers.py:178
 msgid "Full Review ({0})"
 msgid_plural "Full Reviews ({0})"
 msgstr[0] "ਮੁਕੰਮਲ ਸਮੀਖਿਆ ({0})"
 msgstr[1] "ਮੁਕੰਮਲ ਸਮੀਖਿਆਵਾਂ ({0})"
 
-#: src/olympia/editors/helpers.py:180
+#: src/olympia/editors/helpers.py:183
 msgid "Pending Update ({0})"
 msgid_plural "Pending Updates ({0})"
 msgstr[0] "ਅਧੂਰੀ ਅੱਪਡੇਟ ({0})"
 msgstr[1] "ਅਧੂਰੀਆਂ ਅੱਪਡੇਟਾਂ ({0})"
 
-#: src/olympia/editors/helpers.py:185
+#: src/olympia/editors/helpers.py:188
 msgid "Preliminary Review ({0})"
 msgid_plural "Preliminary Reviews ({0})"
 msgstr[0] "ਸ਼ੁਰੂਆਤੀ ਸਮੀਖਿਆ ({0})"
 msgstr[1] "ਸ਼ੁਰੂਆਤੀ ਸਮੀਖਿਆਵਾਂ ({0})"
 
-#: src/olympia/editors/helpers.py:190
+#: src/olympia/editors/helpers.py:193
 msgid "Moderated Review ({0})"
 msgid_plural "Moderated Reviews ({0})"
 msgstr[0] "ਦਰਮਿਆਨੀ ਸਮੀਖਿਆ ({0})"
 msgstr[1] "ਦਰਮਿਆਨੀ ਸਮੀਖਿਆਵਾਂ ({0})"
 
-#: src/olympia/editors/helpers.py:196
+#: src/olympia/editors/helpers.py:199
 msgid "Unlisted Full Review ({0})"
 msgid_plural "Unlisted Full Reviews ({0})"
 msgstr[0] "ਗੈਰਸੂਚੀਬੱਧ ਮੁਕੰਮਲ ਸਮੀਖਿਆ ({0})"
 msgstr[1] "ਗੈਰਸੂਚੀਬੱਧ ਮੁਕੰਮਲ ਸਮੀਖਿਆਵਾਂ ({0})"
 
-#: src/olympia/editors/helpers.py:201
+#: src/olympia/editors/helpers.py:204
 msgid "Unlisted Pending Update ({0})"
 msgid_plural "Unlisted Pending Updates ({0})"
 msgstr[0] "ਗੈਰਸੂਚੀਬੱਧ ਅਧੂਰੀ ਅੱਪਡੇਟ ({0})"
 msgstr[1] "ਗੈਰਸੂਚੀਬੱਧ ਅਧੂਰੀਆਂ ਅੱਪਡੇਟਾਂ ({0})"
 
-#: src/olympia/editors/helpers.py:206
+#: src/olympia/editors/helpers.py:209
 msgid "Unlisted Preliminary Review ({0})"
 msgid_plural "Unlisted Preliminary Reviews ({0})"
 msgstr[0] "ਗੈਰਸੂਚੀਬੱਧ ਸ਼ੁਰੂਆਤੀ ਸਮੀਖਿਆ ({0})"
 msgstr[1] "ਗੈਰਸੂਚੀਬੱਧ ਸ਼ੁਰੂਆਤੀ ਸਮੀਖਿਆ ({0})"
 
-#: src/olympia/editors/helpers.py:261
-msgid "Addon"
-msgstr "ਐਡਆਨ"
+#: src/olympia/editors/helpers.py:214
+msgid "Unlisted All Add-ons ({0})"
+msgid_plural "Unlisted All Add-ons ({0})"
+msgstr[0] ""
+msgstr[1] ""
 
-#: src/olympia/editors/helpers.py:262
+#: src/olympia/editors/helpers.py:274
 msgid "Type"
 msgstr "ਕਿਸਮ"
 
-#: src/olympia/editors/helpers.py:263
+#: src/olympia/editors/helpers.py:275
 msgid "Waiting Time"
 msgstr "ਉਡੀਕ ਸਮਾਂ"
 
-#: src/olympia/editors/helpers.py:264 src/olympia/editors/templates/editors/review.html:285
+#: src/olympia/editors/helpers.py:276 src/olympia/editors/templates/editors/review.html:285
 msgid "Flags"
 msgstr "ਝੰਡੇ"
 
-#: src/olympia/editors/helpers.py:265
+#: src/olympia/editors/helpers.py:277
 msgid "Applications"
 msgstr "ਐਪਲੀਕੇਸ਼ਨਾਂ"
 
-#: src/olympia/editors/helpers.py:270
+#: src/olympia/editors/helpers.py:282
 msgid "Additional"
 msgstr "ਵਾਧੂ"
 
-#: src/olympia/editors/helpers.py:285
+#: src/olympia/editors/helpers.py:302
 msgid "Site Specific"
 msgstr "ਸਾਈਟ ਖਾਸ਼"
 
-#: src/olympia/editors/helpers.py:287
+#: src/olympia/editors/helpers.py:304
 msgid "Requires External Software"
 msgstr "ਬਾਹਰੀ ਸਾਫ਼ਟਵੇਅਰ ਦੀ ਲੋੜ"
 
-#: src/olympia/editors/helpers.py:289
+#: src/olympia/editors/helpers.py:306
 msgid "Binary Components"
 msgstr "ਬਾਇਨਰੀ ਹਿੱਸੇ"
 
-#: src/olympia/editors/helpers.py:313
+#: src/olympia/editors/helpers.py:339
 msgid "moments ago"
 msgstr "ਪਲ ਪਹਿਲਾਂ"
 
 #. L10n: first argument is number of minutes
-#: src/olympia/editors/helpers.py:316
+#: src/olympia/editors/helpers.py:342
 msgid "{0} minute"
 msgid_plural "{0} minutes"
 msgstr[0] "{0} ਮਿੰਟ"
 msgstr[1] "{0} ਮਿੰਟਾਂ"
 
 #. L10n: first argument is number of hours
-#: src/olympia/editors/helpers.py:320
+#: src/olympia/editors/helpers.py:346
 msgid "{0} hour"
 msgid_plural "{0} hours"
 msgstr[0] "{0} ਘੰਟਾ"
 msgstr[1] "{0} ਘੰਟੇ"
 
 #. L10n: first argument is number of days
-#: src/olympia/editors/helpers.py:324
+#: src/olympia/editors/helpers.py:350
 msgid "{0} day"
 msgid_plural "{0} days"
 msgstr[0] "{0} ਦਿਨ"
 msgstr[1] "{0} ਦਿਨਾਂ"
 
-#: src/olympia/editors/helpers.py:488
+#: src/olympia/editors/helpers.py:364
+msgid "Last Review"
+msgstr ""
+
+#: src/olympia/editors/helpers.py:366
+msgid "Last Update"
+msgstr ""
+
+#: src/olympia/editors/helpers.py:387
+msgid "No Reviews"
+msgstr ""
+
+#: src/olympia/editors/helpers.py:561
 msgid "Push to public"
 msgstr "ਜਨਤਕ ਵੱਲ ਭੇਜੋ"
 
-#: src/olympia/editors/helpers.py:490
+#: src/olympia/editors/helpers.py:563
 msgid "Grant full review"
 msgstr "ਪੂਰੀ ਸਮੀਖਿਆ ਮਨਜ਼ੂਰ ਕਰੋ"
 
-#: src/olympia/editors/helpers.py:505
+#: src/olympia/editors/helpers.py:578
 msgid "Request more information"
 msgstr "ਹੋਰ ਜਾਣਕਾਰੀ ਲਈ ਬੇਨਤੀ ਕਰੋ"
 
-#: src/olympia/editors/helpers.py:508
+#: src/olympia/editors/helpers.py:581
 msgid "Request super-review"
 msgstr "ਉੱਤਮ-ਸਮੀਖਿਆ ਲਈ ਬੇਨਤੀ"
 
-#: src/olympia/editors/helpers.py:519
+#: src/olympia/editors/helpers.py:592
 msgid "Grant preliminary review"
 msgstr "ਸ਼ੁਰੂਆਤੀ ਸਮੀਖਿਆ ਦਿਓ"
 
-#: src/olympia/editors/helpers.py:520
+#: src/olympia/editors/helpers.py:593
 msgid "This will mark the files as preliminarily reviewed."
 msgstr "ਇਹ ਫ਼ਾਈਲਾਂ ਤੇ ਸ਼ੁਰੂਆਤੀ ਸਮੀਖਿਆ ਦਾ ਨਿਸ਼ਾਨ ਲਗਾ ਦੇਵੇਗਾ।"
 
-#: src/olympia/editors/helpers.py:522
+#: src/olympia/editors/helpers.py:595
 msgid "Use this form to request more information from the author. They will receive an email and be able to answer here. You will be notified by email when they reply."
 msgstr "ਲੇਖਕ ਕੋਲੋਂ ਹੋਰ ਜਾਣਕਾਰੀ ਦੀ ਬੇਨਤੀ ਲਈ ਇਸ ਫ਼ਾਰਮ ਦੀ ਵਰਤੋਂ ਕਰੋ। ਉਹਨਾਂ ਨੂੰ ਇੱਕ ਈਮੇਲ ਪ੍ਰਾਪਤ ਹੋਵੇਗਾ ਅਤੇ ਇੱਥੇ ਉਹ ਜਵਾਬ ਦੇਣਗੇ। ਤੁਹਾਨੂੰ ਈਮੇਲ ਰਾਹੀ ਸੂਚਨਾ ਦੇ ਦਿੱਤੀ ਜਾਵੇਗੀ ਜਦੋਂ ਉਹ ਜਵਾਬ ਦੇਣਗੇ।"
 
-#: src/olympia/editors/helpers.py:526
+#: src/olympia/editors/helpers.py:599
 msgid ""
 "If you have concerns about this add-on's security, copyright issues, or other concerns that an administrator should look into, enter your comments in the area below. They will be sent to "
 "administrators, not the author."
@@ -7626,55 +7580,55 @@ msgstr ""
 "ਜੇਕਰ ਤੁਹਾਡੇ ਕੋਲ ਇਸ ਐਡ-ਆਨ ਦੀ ਸੁਰੱਖਿਆ, ਕਾਪੀਰਾਈਟ ਮਸਲਿਆਂ, ਬਾਰੇ ਚਿੰਤਾਵਾਂ ਹਨ, ਜਾਂ ਕੋਈ ਚਿੰਤਾ ਹੈ ਜਿਸ ਬਾਰੇ ਪ੍ਰਬੰਧਕ ਨੂੰ ਧਿਆਨ ਦੇਣਾ ਚਾਹੀਦਾ, ਹੇਠ ਦਿੱਤੇ ਖੇਤਰ ਵਿੱਚ ਆਪਣੀ ਟਿੱਪਣੀਆਂ ਲਿਖੋ। ਉਹ ਲੇਖਕ ਨੂੰ ਨਹੀਂ, ਪ੍ਰਬੰਧਕ ਨੂੰ"
 " ਭੇਜ ਦਿੱਤੀਆਂ ਜਾਣਗੀਆਂ।"
 
-#: src/olympia/editors/helpers.py:532
+#: src/olympia/editors/helpers.py:605
 msgid "This will reject the add-on and remove it from the review queue."
 msgstr "ਉਹ ਐਡ-ਆਨ ਨੂੰ ਰੱਦ ਅਤੇ ਇਸ ਨੂੰ ਸਮੀਖਿਆ ਕਤਾਰ ਵਿੱਚ ਹਟਾ ਦੇਣਗੇ।"
 
-#: src/olympia/editors/helpers.py:534
+#: src/olympia/editors/helpers.py:607
 msgid "Make a comment on this version. The author won't be able to see this."
 msgstr "ਇਸ ਵਰਜਨ ਇੱਕ ਟਿੱਪਣੀ ਕਰੋ। ਲੇਖਕ ਇਸ ਨੂੰ ਨਹੀਂ ਵੇਖ ਸਕੇਗਾ।"
 
-#: src/olympia/editors/helpers.py:538
+#: src/olympia/editors/helpers.py:611
 msgid "This will reject the files and remove them from the review queue."
 msgstr "ਇਹ ਫ਼ਾਈਲਾਂ ਨੂੰ ਰੱਦ ਅਤੇ ਉਹਨਾਂ ਨੂੰ ਸਮੀਖਿਆ ਕਤਾਰ ਵਿੱਚੋਂ ਹਟਾ ਦੇਵੇਗਾ।"
 
-#: src/olympia/editors/helpers.py:542
+#: src/olympia/editors/helpers.py:615
 msgid "This will mark the add-on as preliminarily reviewed. Future versions will undergo preliminary review."
 msgstr "ਐਡ-ਆਨ ਤੇ ਇਹ ਸ਼ੁਰੂਆਤੀ ਸਮੀਖਿਆ ਦਾ ਨਿਸ਼ਾਨ ਲਗਾ ਦੇਵੇਗਾ। ਭਵਿੱਖ ਦੇ ਵਰਜਨ ਸ਼ੁਰੂਆਤੀ ਸਮੀਖਿਆ ਵਿੱਚੋਂ ਲੰਘਣਗੇ।"
 
-#: src/olympia/editors/helpers.py:547
+#: src/olympia/editors/helpers.py:620
 msgid "This will mark the files as preliminarily reviewed. Future versions will undergo preliminary review."
 msgstr "ਫ਼ਾਈਲਾਂ ਤੇ ਇਹ ਸ਼ੁਰੂਆਤੀ ਸਮੀਖਿਆ ਦਾ ਨਿਸ਼ਾਨ ਲਗਾ ਦੇਵੇਗਾ। ਭਵਿੱਖ ਦੇ ਵਰਜਨ ਸ਼ੁਰੂਆਤੀ ਸਮੀਖਿਆ ਵਿੱਚੋਂ ਲੰਘਣਗੇ।"
 
-#: src/olympia/editors/helpers.py:552
+#: src/olympia/editors/helpers.py:625
 msgid "Retain preliminary review"
 msgstr "ਸ਼ੁਰੂਆਤੀ ਸਮੀਖਿਆ ਬਰਕਰਾਰ ਰੱਖੋ"
 
-#: src/olympia/editors/helpers.py:553
+#: src/olympia/editors/helpers.py:626
 msgid "This will retain the add-on as preliminarily reviewed. Future versions will undergo preliminary review."
 msgstr "ਐਡ-ਆਨ ਨੂੰ ਇਹ ਸ਼ੁਰੂਆਤੀ ਸਮੀਖਿਆ ਦੇ ਤੌਰ ਤੇ ਬਰਕਰਾਰ ਰੱਖਣਗੇ। ਭਵਿੱਖ ਦੇ ਵਰਜਨ ਸ਼ੁਰੂਆਤੀ ਸਮੀਖਿਆ ਵਿੱਚੋਂ ਲੰਘਣਗੇ।"
 
-#: src/olympia/editors/helpers.py:558
+#: src/olympia/editors/helpers.py:631
 msgid "This will approve a sandboxed version of a public add-on to appear on the public side."
 msgstr "ਇਹ ਜਨਤਕ ਪਾਸੇ ਵਿਖਾਉਣ ਲਈ ਇੱਕ ਜਨਤਕ ਐਡ-ਆਨ ਦੇ ਸੈੰਡਬਾਕਸ ਵਰਜਨ ਨੂੰ ਮਨਜ਼ੂਰੀ ਦੇ ਦੇਵੇਗਾ।"
 
-#: src/olympia/editors/helpers.py:561
+#: src/olympia/editors/helpers.py:634
 msgid "This will reject a version of a public add-on and remove it from the queue."
 msgstr "ਇਹ ਜਨਤਕ ਐਡ-ਆਨ ਦੇ ਇੱਕ ਵਰਜਨ ਨੂੰ ਰੱਦ ਅਤੇ ਕਤਾਰ ਵਿੱਚੋਂ ਹਟਾ ਦੇਵੇਗਾ।"
 
-#: src/olympia/editors/helpers.py:564
+#: src/olympia/editors/helpers.py:637
 msgid "This will mark the add-on and its most recent version and files as public. Future versions will go into the sandbox until they are reviewed by an editor."
 msgstr "ਇਹ ਐਡ-ਆਨ ਅਤੇ ਉਸਦੇ ਤਾਜ਼ੇ ਵਰਜਨ ਅਤੇ ਫ਼ਾਈਲਾਂ ਤੇ ਜਨਤਕ ਦਾ ਨਿਸ਼ਾਨ ਲਗਾ ਦੇਵੇਗਾ। ਭਵਿੱਖ ਦੇ ਵਰਜਨ ਸੈੰਡਬਾਕਸ ਵਿੱਚ ਜਾਣਗੇ ਜਦੋਂ ਤੱਕ ਉਹਨਾਂ ਦੀ ਸੰਪਾਦਕ ਵੱਲੋਂ ਸਮੀਖਿਆ ਨਹੀਂ ਹੁੰਦੀ।"
 
-#: src/olympia/editors/helpers.py:637
+#: src/olympia/editors/helpers.py:714
 msgid "add-on"
 msgstr "ਐਡ-ਆਨ"
 
-#: src/olympia/editors/helpers.py:940 src/olympia/editors/helpers.py:960
+#: src/olympia/editors/helpers.py:1020 src/olympia/editors/helpers.py:1040
 msgid "Flagged"
 msgstr "ਨਿਸ਼ਾਨਬੱਧ"
 
-#: src/olympia/editors/helpers.py:944 src/olympia/editors/helpers.py:963
+#: src/olympia/editors/helpers.py:1024 src/olympia/editors/helpers.py:1043
 msgid "Updates"
 msgstr "ਅੱਪਡੇਟਾਂ"
 
@@ -7726,56 +7680,56 @@ msgstr "ਦਾਖਲ ਥੀਮ ਤੇ ਸਮੀਖਿਆ ਲਈ ਝੰਡਾ ਲ
 msgid "A question about your Theme submission"
 msgstr "ਤੁਹਾਡੇ ਦਾਖਲ ਕੀਤੇ ਥੀਮ ਬਾਰੇ ਇੱਕ ਸਵਾਲ"
 
-#: src/olympia/editors/views.py:144
+#: src/olympia/editors/views.py:146
 msgid "New Add-ons (Under 5 days)"
 msgstr "ਨਵੇਂ ਐਡ-ਆਨ (5 ਦਿਨਾਂ ਅੰਦਰ)"
 
-#: src/olympia/editors/views.py:145
+#: src/olympia/editors/views.py:147
 msgid "Passable (5 to 10 days)"
 msgstr "ਪਾਸਹੋਣਯੋਗ (5 ਤੋਂ 10 ਦਿਨ)"
 
-#: src/olympia/editors/views.py:146
+#: src/olympia/editors/views.py:148
 msgid "Overdue (Over 10 days)"
 msgstr "ਬਕਾਇਆ(10 ਦਿਨ ਬਾਅਦ)"
 
-#: src/olympia/editors/views.py:532
+#: src/olympia/editors/views.py:539
 msgid "An unknown error occurred"
 msgstr "ਅਣਜਾਣ ਖਾਮੀ ਆਈ"
 
-#: src/olympia/editors/views.py:587
+#: src/olympia/editors/views.py:592
 msgid "Self-reviews are not allowed."
 msgstr "ਸਵੈ-ਸਮੀਖਿਆਵਾਂ ਪ੍ਰਵਾਨ ਨਹੀਂ।"
 
-#: src/olympia/editors/views.py:609
+#: src/olympia/editors/views.py:613
 msgid "Review successfully processed."
 msgstr "ਸਮੀਖਿਆ ਤੇ ਕਾਰਵਾਈ ਸਫ਼ਲਤਾਪਰੂਵਕ ਹੋਈ।"
 
-#: src/olympia/editors/views.py:807
+#: src/olympia/editors/views.py:812
 msgid "was approved"
 msgstr "ਪ੍ਰਵਾਨਿਤ ਹੋਇਆ ਸੀ"
 
-#: src/olympia/editors/views.py:808
+#: src/olympia/editors/views.py:813
 msgid "given preliminary review"
 msgstr "ਸ਼ੁਰੂਆਤੀ ਸਮੀਖਿਆ ਦਿੱਤੀ ਗਈ"
 
-#: src/olympia/editors/views.py:809
+#: src/olympia/editors/views.py:814
 msgid "rejected"
 msgstr "ਰੱਦ ਕੀਤਾ"
 
-#: src/olympia/editors/views.py:810
+#: src/olympia/editors/views.py:815
 msgctxt "editors_review_history_nominated_adminreview"
 msgid "escalated"
 msgstr "ਵਧਿਆ"
 
-#: src/olympia/editors/views.py:812
+#: src/olympia/editors/views.py:817
 msgid "needs more information"
 msgstr "ਹੋਰ ਜਾਣਕਾਰੀ ਦੀ ਲੋੜ"
 
-#: src/olympia/editors/views.py:813
+#: src/olympia/editors/views.py:818
 msgid "needs super review"
 msgstr "ਉੱਤਮ ਸਮੀਖਿਆ ਦੀ ਲੋੜ"
 
-#: src/olympia/editors/views.py:814
+#: src/olympia/editors/views.py:819
 msgid "commented"
 msgstr "ਟਿੱਪਣੀ ਕੀਤੀ"
 
@@ -7820,28 +7774,28 @@ msgstr "ਕਤਾਰਾਂ"
 msgid "Unlisted Queues"
 msgstr "ਗੈਰਸੂਚੀਬੱਧ ਕਤਾਰਾਂ"
 
-#: src/olympia/editors/templates/editors/base.html:72 src/olympia/editors/templates/editors/performance.html:6
+#: src/olympia/editors/templates/editors/base.html:74 src/olympia/editors/templates/editors/performance.html:6
 msgid "Performance"
 msgstr "ਕਾਰਗੁਜ਼ਾਰੀ"
 
-#: src/olympia/editors/templates/editors/base.html:75 src/olympia/editors/templates/editors/themes/base.html:19 src/olympia/editors/templates/editors/themes/base.html:38
+#: src/olympia/editors/templates/editors/base.html:77 src/olympia/editors/templates/editors/themes/base.html:19 src/olympia/editors/templates/editors/themes/base.html:38
 msgid "Logs"
 msgstr "ਚਿੱਠੇ"
 
-#: src/olympia/editors/templates/editors/base.html:78 src/olympia/editors/templates/editors/reviewlog.html:4 src/olympia/editors/templates/editors/reviewlog.html:27
+#: src/olympia/editors/templates/editors/base.html:80 src/olympia/editors/templates/editors/reviewlog.html:4 src/olympia/editors/templates/editors/reviewlog.html:27
 msgid "Add-on Review Log"
 msgstr "ਐਡ-ਆਨ ਸਮੀਖਿਆ ਚਿੱਠਾ"
 
-#: src/olympia/editors/templates/editors/base.html:80 src/olympia/editors/templates/editors/eventlog.html:4 src/olympia/editors/templates/editors/eventlog.html:8
+#: src/olympia/editors/templates/editors/base.html:82 src/olympia/editors/templates/editors/eventlog.html:4 src/olympia/editors/templates/editors/eventlog.html:8
 #: src/olympia/editors/templates/editors/eventlog_detail.html:4
 msgid "Moderated Review Log"
 msgstr "ਦਰਮਿਆਨੀ ਸਮੀਖਿਆ ਚਿੱਠਾ"
 
-#: src/olympia/editors/templates/editors/base.html:82 src/olympia/editors/templates/editors/beta_signed_log.html:4 src/olympia/editors/templates/editors/beta_signed_log.html:8
+#: src/olympia/editors/templates/editors/base.html:84 src/olympia/editors/templates/editors/beta_signed_log.html:4 src/olympia/editors/templates/editors/beta_signed_log.html:8
 msgid "Signed Beta Files Log"
 msgstr "ਸਾਈਨ ਹੋਈਆਂ ਬੀਟਾ ਫਾਈਲਾਂ ਦਾ ਲਾਗ"
 
-#: src/olympia/editors/templates/editors/base.html:87 src/olympia/editors/templates/editors/includes/daily-message.html:4
+#: src/olympia/editors/templates/editors/base.html:89 src/olympia/editors/templates/editors/includes/daily-message.html:4
 msgid "Announcement"
 msgstr "ਐਲਾਨ"
 
@@ -8062,45 +8016,45 @@ msgstr "ਤਕਨੀਕੀ ਖੋਜ"
 msgid "clear search"
 msgstr "ਖੋਜ ਮਿਟਾਓ"
 
-#: src/olympia/editors/templates/editors/queue.html:72 src/olympia/editors/templates/editors/queue.html:122
+#: src/olympia/editors/templates/editors/queue.html:78 src/olympia/editors/templates/editors/queue.html:128
 msgid "Process Reviews"
 msgstr "ਸਮੀਖਿਆਵਾਂ ਤੇ ਕਾਰਵਾਈ"
 
-#: src/olympia/editors/templates/editors/queue.html:80
+#: src/olympia/editors/templates/editors/queue.html:86
 msgid "Moderation actions:"
 msgstr "ਦਰਮਿਆਨੀ ਕਾਰਵਾਈਆਂ:"
 
-#: src/olympia/editors/templates/editors/queue.html:90
+#: src/olympia/editors/templates/editors/queue.html:96
 #, python-format
 msgid "by %(user)s on %(date)s %(stars)s (%(locale)s)"
 msgstr "%(date)s %(stars)s (%(locale)s) ਤੇ %(user)s ਵੱਲੋਂ"
 
-#: src/olympia/editors/templates/editors/queue.html:106
+#: src/olympia/editors/templates/editors/queue.html:112
 #, python-format
 msgid "<strong>%(reason)s</strong> <span class=\"light\">Flagged by %(user)s on %(date)s</span>"
 msgstr "<strong>%(reason)s</strong> <span class=\"light\">%(date)s ਨੂੰ %(user)s ਵੱਲੋਂ ਫ਼ਲੈਗ ਕੀਤਾ</span>"
 
-#: src/olympia/editors/templates/editors/queue.html:119
+#: src/olympia/editors/templates/editors/queue.html:125
 msgid "All reviews have been moderated. Good work!"
 msgstr "ਸਾਰੀਆਂ ਸਮੀਖਿਆਵਾਂ ਸੰਤੁਲਿਤ ਕੀਤੀਆਂ ਗਈਆਂ। ਬਹੁਤ ਵਧੀਆ!"
 
-#: src/olympia/editors/templates/editors/queue.html:161
+#: src/olympia/editors/templates/editors/queue.html:167
 msgid "Version Notes / Notes for Reviewer"
 msgstr "ਵਰਜਨ ਨੋਟ / ਸਮੀਖਿਅਕ ਲਈ ਨੋਟ"
 
-#: src/olympia/editors/templates/editors/queue.html:169
+#: src/olympia/editors/templates/editors/queue.html:175
 msgid "There are currently no add-ons of this type to review."
 msgstr "ਇੱਥੇ ਸਮੀਖਿਆ ਲਈ ਮੌਜੂਦਾ ਤੌਰ ਤੇ ਇਸ ਕਿਸਮ ਦੇ ਕੋਈ ਐਡ-ਆਨ ਨਹੀਂ।"
 
-#: src/olympia/editors/templates/editors/queue.html:181 src/olympia/editors/templates/editors/themes/queue_list.html:85
+#: src/olympia/editors/templates/editors/queue.html:187 src/olympia/editors/templates/editors/themes/queue_list.html:85
 msgid "Helpful Links:"
 msgstr "ਸਹਾਇਕ ਲਿੰਕ:"
 
-#: src/olympia/editors/templates/editors/queue.html:182
+#: src/olympia/editors/templates/editors/queue.html:188
 msgid "Add-on Policy"
 msgstr "ਐਡ-ਆਨ ਨੀਤੀ"
 
-#: src/olympia/editors/templates/editors/queue.html:184
+#: src/olympia/editors/templates/editors/queue.html:190
 msgid "Editors' Guide"
 msgstr "ਸੰਪਾਦਕ ਗਾਈਡ"
 
@@ -8436,7 +8390,7 @@ msgstr "ਕਲਾਕਾਰ ਤੋਂ ਇੱਕ ਸਵਾਲ ਪੁੱਛੋ"
 msgid "Describe your reason for flagging"
 msgstr "ਫ਼ਲੈਗ ਕਰਨ ਲਈ ਆਪਣੇ ਕਾਰਨ ਦਾ ਵਰਣਨ ਕਰੋ"
 
-#: src/olympia/files/forms.py:88
+#: src/olympia/files/forms.py:90
 msgid "Cannot diff a version against itself"
 msgstr "ਵਰਜਨ ਦਾ ਖੁਦ ਤੋਂ ਫ਼ਰਕ ਨਹੀਂ ਕਰ ਸਕਦਾ"
 
@@ -8471,51 +8425,51 @@ msgstr "ਫ਼ਾਈਲ %s ਤੱਕ ਪਹੁੰਚ ਕਰਦੇ ਸਮੇਂ ਖ�
 msgid "There was an error accessing file %s."
 msgstr "ਫ਼ਾਈਲ %s ਤੱਕ ਪਹੁੰਚ ਕਰਦੇ ਸਮੇਂ ਖਾਮੀ ਆਈ।"
 
-#: src/olympia/files/utils.py:343
+#: src/olympia/files/utils.py:340
 msgid "Could not parse uploaded file."
 msgstr "ਅੱਪਲੋਡ ਫ਼ਾਈਲ ਨੂੰ ਪਾਰਸ ਨਹੀਂ ਕਰ ਸਕਦਾ।"
 
-#: src/olympia/files/utils.py:380
+#: src/olympia/files/utils.py:377
 msgid "Invalid file name in archive: {0}"
 msgstr "ਅਕਾਈਵ ਵਿੱਚ ਗਲਤ ਫ਼ਾਈਲ ਨਾਂ:{0}"
 
-#: src/olympia/files/utils.py:388
+#: src/olympia/files/utils.py:385
 msgid "File exceeding size limit in archive: {0}"
 msgstr "ਅਕਾਈਵ ਵਿੱਚ ਫ਼ਾਈਲ ਨੇ ਅਕਾਰ ਸੀਮਾ ਲੰਘੀ: {0}"
 
-#: src/olympia/files/utils.py:439
+#: src/olympia/files/utils.py:436
 msgid "Invalid archive."
 msgstr "ਗਲਤ ਅਕਾਈਵ।"
 
-#: src/olympia/files/utils.py:529 src/olympia/files/utils.py:532
+#: src/olympia/files/utils.py:526 src/olympia/files/utils.py:529
 msgid "Could not parse the manifest file."
 msgstr ""
 
-#: src/olympia/files/utils.py:551
+#: src/olympia/files/utils.py:548
 msgid "Could not find an add-on ID."
 msgstr ""
 
-#: src/olympia/files/utils.py:554
+#: src/olympia/files/utils.py:551
 msgid "Add-on ID must be 64 characters or less."
 msgstr ""
 
-#: src/olympia/files/utils.py:556
+#: src/olympia/files/utils.py:553
 msgid "Add-on ID doesn't match add-on."
 msgstr ""
 
-#: src/olympia/files/utils.py:564
+#: src/olympia/files/utils.py:561
 msgid "Duplicate add-on ID found."
 msgstr ""
 
-#: src/olympia/files/utils.py:567
+#: src/olympia/files/utils.py:564
 msgid "Version numbers should have fewer than 32 characters."
 msgstr "ਵਰਜਨ ਨੰਬਰ 32 ਅੱਖਰਾਂ ਤੋਂ ਘੱਟ ਦੇ ਹੋਣੇ ਚਾਹੀਦੇ ਹਨ।"
 
-#: src/olympia/files/utils.py:570
+#: src/olympia/files/utils.py:567
 msgid "Version numbers should only contain letters, numbers, and these punctuation characters: +*.-_."
 msgstr "ਵਰਜਨ ਨੰਬਰਾਂ ਵਿੱਚ ਕੇਵਲ ਅੱਖਰ,ਨੰਬਰ ਅਤੇ ਇਹ ਵਿਰਾਮ ਚਿੰਨ੍ਹ ਸ਼ਾਮਲ ਹੋਣੇ ਚਾਹੀਦੇ ਹਨ: +*.-_।"
 
-#: src/olympia/files/utils.py:587
+#: src/olympia/files/utils.py:584
 msgid "<em:type> doesn't match add-on"
 msgstr "<em:type> ਦਾ ਐਡ-ਆਨ ਨਾਲ ਮੇਲ ਨਹੀਂ"
 
@@ -8615,6 +8569,10 @@ msgstr "ਅੱਪਲੋਡ ਕੀਤੀ ਫ਼ਾਈਲ ਵਿੱਚ ਕੋਈ ਫ਼�
 #: src/olympia/files/templates/files/viewer.html:134
 msgid "Fetching file."
 msgstr "ਫ਼ਾਈਲ ਪ੍ਰਾਪਤ ਕਰ ਰਿਹਾ।"
+
+#: src/olympia/legacy_api/views.py:255
+msgid "Not implemented yet."
+msgstr "ਹਾਲੇ ਤੱਕ ਲਾਗੂ ਨਹੀਂ ਕੀਤਾ।"
 
 #: src/olympia/lib/constants.py:6
 msgid "United Arab Emirates Dirham"
@@ -9270,10 +9228,6 @@ msgstr ""
 
 #: src/olympia/lib/constants.py:169
 msgid "Zimbabwe Dollar"
-msgstr ""
-
-#: src/olympia/lib/video/ffmpeg.py:112 src/olympia/lib/video/totem.py:81
-msgid "Videos must be in WebM."
 msgstr ""
 
 #: src/olympia/pages/templates/pages/about.lhtml:3 src/olympia/pages/templates/pages/about.lhtml:10
@@ -10297,7 +10251,7 @@ msgstr "ਐਡ-ਆਨ ਗੈਲਰੀ"
 msgid "How do I choose between add-ons that seem to do the same thing?"
 msgstr "ਮੈਂ ਇੱਕੋ ਜਿਹੇ ਕੰਮ ਕਰਨ ਵਾਲੇ ਐਡ-ਆਨਾਂ ਵਿੱਚੋਂ ਚੋਣ ਕਿਵੇਂ ਕਰਾਂ?"
 
-#: src/olympia/pages/templates/pages/faq.html:173
+#: src/olympia/pages/templates/pages/faq.html:172
 msgid ""
 "There are often several add-ons that have similar features. To figure out which is right for you, read the entire description of the add-on and view its screenshots. If there are still several in "
 "the running, read through the add-on's ratings, user reviews, and statistics to see which is most liked by other users. Remember that you can also just try out both and see which you like better."
@@ -10353,11 +10307,11 @@ msgstr "ਐਡ-ਆਨਾਂ ਨੂੰ ਖਰੀਦਣ ਲਈ ਕਿੰਨੀ ਕ
 msgid "Add-ons hosted in our gallery are free unless clearly marked otherwise."
 msgstr "ਸਾਡੀ ਗੈਲਰੀ ਵਿੱਚ ਮੇਜ਼ਬਾਨ ਕੀਤੇ ਐਡ-ਆਨ ਮੁਫ਼ਤ ਹਨ ਜਦ ਤੱਕ ਸਾਫ਼ ਤੌਰ ਤੇ ਅੰਕਿਤ ਨਾ ਕੀਤੇ ਹੋਵੇ।"
 
-#: src/olympia/pages/templates/pages/faq.html:210
+#: src/olympia/pages/templates/pages/faq.html:209
 msgid "What does it mean when an add-on asks for contributions?"
 msgstr "ਜਦੋਂ ਐਡ-ਆਨ ਯੋਗਦਾਨ ਬਾਰੇ ਪੁੱਛੇ ਇਸ ਤੋਂ ਕੀ ਭਾਵ ਹੈ?"
 
-#: src/olympia/pages/templates/pages/faq.html:211
+#: src/olympia/pages/templates/pages/faq.html:210
 msgid ""
 "Some add-on authors request users who enjoy an add-on to contribute to its development by making a monetary contribution. These contributions go directly to the developer unless a third party is "
 "indicated, such as the non-profit Mozilla Foundation."
@@ -10365,11 +10319,11 @@ msgstr ""
 "ਕੁੱਝ ਐਡ-ਆਨ ਲੇਖਕ ਉਪਭੋਗੀਆਂ ਨੂੰ ਜੋ ਐਡ-ਆਨ ਦਾ ਆਨੰਦ ਮਾਨ ਰਹੇ ਹੋਣ ਨੂੰ ਇਸ ਦੇ ਵਿਕਾਸ ਲਈ ਮਾਇਆ ਦੇ ਯੋਗਦਾਨ ਦੀ ਬੇਨਤੀ ਕਰਦੇ ਹਨ। ਇਹ ਯੋਗਦਾਨ ਸਿੱਧੇ ਡਿਵੈਲਪਰ ਨੂੰ ਜਾਂਦੇ ਹਨ ਜਦ ਤੱਕ ਕਿਸੇ ਤੀਜੀ ਧਿਰ ਬਾਰੇ ਨਾ ਦੱਸਿਆ ਹੋਵੇ, ਜਿਵੇਂ ਕਿ "
 "ਗੈਰ-ਮੁਨਾਫ਼ਾ ਮੌਜੀਲਾ ਸੰਸਥਾ।"
 
-#: src/olympia/pages/templates/pages/faq.html:216
+#: src/olympia/pages/templates/pages/faq.html:215
 msgid "What are beta add-ons?"
 msgstr "ਬੀਟਾ ਐਡ-ਆਨ ਕੀ ਹਨ?"
 
-#: src/olympia/pages/templates/pages/faq.html:218
+#: src/olympia/pages/templates/pages/faq.html:217
 msgid ""
 "Beta add-ons are unreviewed versions which represent the latest work of an add-on author. While different authors have different standards for beta code quality, you should assume that these add-"
 "ons are less stable than the general add-on releases."
@@ -10377,7 +10331,7 @@ msgstr ""
 "ਬੀਟਾ ਐਡ-ਆਨ ਬਿਨਾਂ-ਸਮੀਖਿਆ ਵਾਲੇ ਵਰਜਨ ਹਨ ਜੋ ਐਡ-ਆਨ ਲੇਖਕ ਦਾ ਤਾਜ਼ਾ ਕੰਮ ਦੀ ਨੁਮਾਇੰਦਗੀ ਕਰਦੇ ਹਨ। ਜਦ ਕਿ ਵੱਖ-ਵੱਖ ਲੇਖਕਾਂ ਲਈ ਬੀਟਾ ਕੋਡ ਗੁਣਵੱਤਾ ਮਾਣਕ ਵੱਖ-ਵੱਖ ਹਨ, ਤੁਹਾਨੂੰ ਇਹ ਮੰਨਣਾ ਚਾਹੀਦਾ ਕੀ ਇਹ ਐਡ-ਆਨ ਜਾਰੀ ਹੋਏ ਆਮ "
 "ਐਡ-ਆਨਾਂ ਨਾਲੋਂ ਘੱਟ ਸਥਿਰ ਹਨ।"
 
-#: src/olympia/pages/templates/pages/faq.html:222
+#: src/olympia/pages/templates/pages/faq.html:221
 msgid ""
 "Please note that when you install an add-on from the \"Beta Version\" section of an add-on's listing, you will continue to receive updates for that add-on as they become available. Like the initial"
 " version you installed, all beta releases are unreviewed by Mozilla and may harm your computer."
@@ -10385,22 +10339,19 @@ msgstr ""
 "ਕਿਰਪਾ ਕਰਕੇ ਨੋਟ ਕਰੋ ਜਦੋਂ ਤੁਸੀਂ ਐਡ-ਆਨ ਸੂਚੀ ਦੇ \"ਬੀਟਾ ਵਰਜਨ\" ਭਾਗ ਵਿੱਚੋਂ ਐਡ-ਆਨ ਇੰਸਟਾਲ ਕਰਦੇ ਹੋ, ਤੁਹਾਨੂੰ ਉਸ ਐਡ-ਆਨ ਲਈ ਲਗਾਤਾਰ ਅੱਪਡੇਟਾਂ ਪ੍ਰਾਪਤ ਹੁੰਦੀਆਂ ਰਹਿਣਗੀਆਂ ਜਿਵੇਂ ਹੀ ਉਹ ਉੱਪਲਬਧ ਹੋਣ। ਤੁਹਾਡੇ ਵੱਲੋਂ ਇੰਸਟਾਲ "
 "ਕੀਤੇ ਸ਼ੁਰੂਆਤੀ ਵਰਜਨ ਦੀ ਤਰ੍ਹਾਂ, ਬੀਟਾ ਰੀਲੀਜ਼ਾਂ ਦੀ ਮੌਜੀਲਾ ਵੱਲੋਂ ਸਮੀਖਿਆ ਨਹੀਂ ਕੀਤੀ ਗਈ ਅਤੇ ਤੁਹਾਡੇ ਕੰਪਿਊਟਰ ਦਾ ਨੁਕਸਾਨ ਹੋ ਸਕਦਾ।"
 
-#: src/olympia/pages/templates/pages/faq.html:229
+#: src/olympia/pages/templates/pages/faq.html:228
 msgid "What does it mean when an add-on is flagged as slow?"
 msgstr "ਜਦੋਂ ਐਡ-ਆਨ ਤੇ \"ਹੌਲੀ\" ਦਾ ਨਿਸ਼ਾਨ ਲੱਗਿਆ ਹੋਵੇ ਇਸ ਤੋਂ ਕੀ ਭਾਵ ਹੈ?"
 
-#: src/olympia/pages/templates/pages/faq.html:231
-msgid ""
-"Most add-ons load code and resources at the same time Firefox\n"
-"        is starting up. In most cases the impact in start-up time is minimal,\n"
-"        but some add-ons can cause a noticeable slowdown."
+#: src/olympia/pages/templates/pages/faq.html:229
+msgid "Most add-ons load code and resources at the same time Firefox is starting up. In most cases the impact in start-up time is minimal, but some add-ons can cause a noticeable slowdown."
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:236
+#: src/olympia/pages/templates/pages/faq.html:234
 msgid "How do I report an inappropriate or spam user review?"
 msgstr "ਮੈਂ ਇੱਕ ਗਲਤ ਅਤੇ ਸਪੈਮ ਉਪਭੋਗੀ ਸਮੀਖਿਆ ਬਾਰੇ ਸੂਚਨਾ ਕਿਵੇਂ ਦਿਆਂ?"
 
-#: src/olympia/pages/templates/pages/faq.html:237
+#: src/olympia/pages/templates/pages/faq.html:235
 msgid ""
 "To report a user review of an add-on, log in with your account and visit the add-on's reviews page. Find the review you wish to report, click \"Report this review\" and select a reason. Our "
 "editorial team will investigate the review and take appropriate action."
@@ -10408,20 +10359,20 @@ msgstr ""
 "ਐਡ-ਆਨ ਦੀ ਉਪਭੋਗੀ ਸਮੀਖਿਆ ਬਾਰੇ ਸੂਚਨਾ ਦੇਣ ਲਈ, ਆਪਣੇ ਖਾਤੇ ਨਾਲ ਲਾਗਇਨ ਹੋਵੋ ਅਤੇ ਐਡ-ਆਨ ਦੇ ਸਮੀਖਿਆ ਸਫ਼ੇ ਤੇ ਜਾਓ। ਸਮੀਖਿਆ ਲੱਭੋ ਜਿਸਦੀ ਤੁਸੀਂ ਸੂਚਨਾ ਦੇਣਾ ਚਾਹੁੰਦੇ ਹੋ, \"ਇਸ ਸਮੀਖਿਆ ਦੀ ਸੂਚਨਾ ਦਿਓ\" ਤੇ ਕਲਿੱਕ ਕਰੋ ਅਤੇ ਇੱਕ "
 "ਕਾਰਨ ਦੱਸੋ। ਸਾਡੀ ਸੰਪਾਦਕ ਟੀਮ ਸਮੀਖਿਆ ਦੀ ਜਾਂਚ ਅਤੇ ਵਾਜਬ ਕਾਰਵਾਈ ਕਰੇਗੀ।"
 
-#: src/olympia/pages/templates/pages/faq.html:242
+#: src/olympia/pages/templates/pages/faq.html:240
 msgid "How do I report a bug or contact the Mozilla Add-ons team?"
 msgstr "ਮੈਂ ਮੌਜੀਲਾ ਐਡ-ਆਨ ਟੀਮ ਨੂੰ ਸੰਪਰਕ ਕਰਾਂ ਜਾਂ ਬੱਗ ਸੂਚਨਾ ਕਿਵੇਂ ਦਿਆਂ?"
 
-#: src/olympia/pages/templates/pages/faq.html:243
+#: src/olympia/pages/templates/pages/faq.html:241
 #, python-format
 msgid "Please visit our <a href=\"%(contact_url)s\">Contact page</a>."
 msgstr "ਕਿਰਪਾ ਕਰਕੇ ਸਾਡੇ <a href=\"%(contact_url)s\">ਸੰਪਰਕ ਸਫ਼ਾ</a>ਤੇ ਜਾਓ।"
 
-#: src/olympia/pages/templates/pages/faq.html:246
+#: src/olympia/pages/templates/pages/faq.html:244
 msgid "What is a Source Code License?"
 msgstr "ਸੋਰਸ ਕੋਡ ਲਾਇਸੰਸ ਕੀ ਹੈ?"
 
-#: src/olympia/pages/templates/pages/faq.html:247
+#: src/olympia/pages/templates/pages/faq.html:245
 #, python-format
 msgid ""
 "The source code used to create an add-on is an exclusive copyright of the add-on author, unless otherwise declared in a source code license. Many add-ons on this site have <a href=\"%(url)s\" "
@@ -10432,42 +10383,42 @@ msgstr ""
 " ਲਾਇਸੰਸ</a> ਹਨ ਜੋ ਲੇਖਕ ਦੁਆਰਾ ਤੈਅ ਕੀਤੀਆਂ ਸ਼ਰਤਾਂ ਦੇ ਅਧੀਨ ਸੋਰਸ ਕੋਡ ਨੂੰ ਜਨਤਕ ਤੌਰ ਤੇ ਕਾਪੀ ਅਤੇ ਮੁੜ-ਵਰਤਣ ਲਈ ਉੱਪਲਬਧ ਕਰਵਾਉਂਦੇ ਹਨ। ਬਹੁਤ ਸਾਰੇ ਲੇਖਕ ਆਪਣੇ ਬਣਾਉਣ ਦੀ ਥਾਂ ਵਿਆਪਕ ਤੌਰ ਤੇ ਵਰਤੇ ਜਾਣੇ ਜਾਂਦੇ ਓਪਨ ਸੋਰਸ "
 "ਲਾਇਸੰਸਾਂ ਜਿਵੇਂ GPL ਜਾਂ BSD ਲਾਇਸੰਸਾਂ ਦੀ ਚੋਣ ਕਰਦੇ ਹਨ।"
 
-#: src/olympia/pages/templates/pages/faq.html:256
+#: src/olympia/pages/templates/pages/faq.html:254
 #, python-format
 msgid "Firefox and other Mozilla software are <a href=\"%(url)s\">open source</a>."
 msgstr "ਫ਼ਾਇਰਫ਼ਾਕਸ ਅਤੇ ਹੋਰ ਮੌਜੀਲਾ ਸਾਫ਼ਟਵੇਅਰ <a href=\"%(url)s\">ਓਪਨ ਸੋਰਸ</a>ਹਨ।"
 
-#: src/olympia/pages/templates/pages/faq.html:264
+#: src/olympia/pages/templates/pages/faq.html:262
 msgid "Collections and Favorites"
 msgstr "ਸੰਗ੍ਰਹਿ ਅਤੇ ਪਸੰਦੀਦਾ"
 
-#: src/olympia/pages/templates/pages/faq.html:267
+#: src/olympia/pages/templates/pages/faq.html:265
 msgid "What is a collection?"
 msgstr "ਸੰਗ੍ਰਹਿ ਕੀ ਹੈ?"
 
-#: src/olympia/pages/templates/pages/faq.html:268
+#: src/olympia/pages/templates/pages/faq.html:266
 msgid "Collections are groups of related add-ons created by users to share."
 msgstr "ਸੰਗ੍ਰਹਿ ਉਪਭੋਗੀਆਂ ਵੱਲੋਂ ਵੰਡਣ ਲਈ ਤਿਆਰ ਕੀਤੇ ਸਬੰਧਤ ਐਡ-ਆਨਾਂ ਦੇ ਗਰੁੱਪ ਹਨ।"
 
-#: src/olympia/pages/templates/pages/faq.html:270
+#: src/olympia/pages/templates/pages/faq.html:268
 msgid "What is the My Favorites collection?"
 msgstr "ਮੇਰੇ ਪੰਸਦੀਦਾ ਸੰਗ੍ਰਹਿ ਕੀ ਹੈ?"
 
-#: src/olympia/pages/templates/pages/faq.html:271
+#: src/olympia/pages/templates/pages/faq.html:269
 msgid "Favorite add-ons are add-ons that you have bookmarked to easily get back to later. You can add an add-on to your favorites collection by clicking \"Add to favorites\" on its details page."
 msgstr ""
 "ਪੰਸਦੀਦਾ ਐਡ-ਆਨ ਉਹ ਐਡ-ਆਨ ਹਨ ਜਿਹਨਾਂ ਨੂੰ ਤੁਸੀਂ ਅਸਾਨੀ ਨਾਲ ਵਾਪਸ ਆਉਣ ਲਈ ਬੁੱਕਮਾਰਕ ਕੀਤਾ ਹੋਇਆ। ਤੁਸੀਂ ਐਡ-ਆਨ ਨੂੰ ਉਸ ਦੇ ਵੇਰਵੇ ਸਫ਼ੇ ਤੇ \"ਪਸੰਦੀਦਾ ਵਿੱਚ ਜੋੋੜੋ\" ਤੇ ਕਲਿੱਕ ਕਰਕੇ ਐਡ-ਆਨ ਨੂੰ ਆਪਣੇ ਪਸੰਦੀਦਾ ਸੰਗ੍ਰਹਿ ਵਿੱਚ "
 "ਸ਼ਾਮਲ ਕਰ ਸਕਦੇ ਹੋ।"
 
-#: src/olympia/pages/templates/pages/faq.html:275 src/olympia/templates/menu_links.html:13 src/olympia/templates/impala/header_title.html:17
+#: src/olympia/pages/templates/pages/faq.html:273 src/olympia/templates/menu_links.html:13 src/olympia/templates/impala/header_title.html:17
 msgid "Mobile Add-ons"
 msgstr "ਮੋਬਾਈਲ ਐਡ-ਆਨ"
 
-#: src/olympia/pages/templates/pages/faq.html:278
+#: src/olympia/pages/templates/pages/faq.html:276
 msgid "What are mobile add-ons?"
 msgstr "ਮੋਬਾਈਲ ਐਡ-ਆਨ ਕੀ ਹਨ?"
 
-#: src/olympia/pages/templates/pages/faq.html:279
+#: src/olympia/pages/templates/pages/faq.html:277
 #, python-format
 msgid ""
 "Mobile add-ons work with <a href=\"%(mobile_url)s\">Firefox for Mobile</a> and add or modify functionality just like desktop add-ons. You can find add-ons that work with Firefox for Mobile in our "
@@ -10476,20 +10427,20 @@ msgstr ""
 "ਮੋਬਾਈਲ ਐਡ-ਆਨ <a href=\"%(mobile_url)s\">ਮੋਬਾਈਲ ਲਈ ਫ਼ਾਇਰਫ਼ਾਕਸ</a> ਨਾਲ ਕੰਮ ਕਰਦੇ ਅਤੇ ਡੈਸਕਟੋਪ ਐਡ-ਆਨਾਂ ਦੀ ਤਰ੍ਹਾਂ ਕਾਰਜਕੁਸ਼ਲਤਾ ਨੂੰ ਸ਼ਾਮਲ ਜਾਂ ਵਧਾਉਂਦੇ ਹਨ। ਸਾਡੀ <a href=\"%(gallery_url)s\">ਗੈਲਰੀ</a> ਵਿੱਚ ਤੁਸੀਂ"
 " ਮੋਬਾਈਲ ਫ਼ਾਇਰਫ਼ਾਕਸ ਨਾਲ ਕੰਮ ਕਰਨ ਵਾਲੇ ਐਡ-ਆਨ ਲੱਭ ਸਕਦੇ ਹੋ।"
 
-#: src/olympia/pages/templates/pages/faq.html:288
+#: src/olympia/pages/templates/pages/faq.html:286
 msgid "Developer Topics"
 msgstr "ਡਿਵੈਲਪਰ ਵਿਸ਼ੇ"
 
-#: src/olympia/pages/templates/pages/faq.html:289
+#: src/olympia/pages/templates/pages/faq.html:287
 #, python-format
 msgid "Please see our <a href=\"%(faq_url)s\">Developer FAQ</a> and <a href=\"%(hub_url)s\">Developer Hub</a> for answers to add-on developer-related questions."
 msgstr " ਡਿਵੈਲਪਰ-ਸਬੰਧਤ ਸਵਾਲਾਂ ਦੇ ਜਵਾਬਾਂ ਲਈ ਕਿਰਪਾ ਕਰਕੇ ਸਾਡਾ <a href=\"%(faq_url)s\">ਡਿਵੈਲਪਰ FAQ</a> ਅਤੇ <a href=\"%(hub_url)s\">ਡਿਵੈਲਪਰ ਹੱਬ</a> ।"
 
-#: src/olympia/pages/templates/pages/faq.html:294
+#: src/olympia/pages/templates/pages/faq.html:292
 msgid "Still have questions?"
 msgstr "ਹਾਲੇ ਵੀ ਸਵਾਲ ਹਨ?"
 
-#: src/olympia/pages/templates/pages/faq.html:295
+#: src/olympia/pages/templates/pages/faq.html:293
 #, python-format
 msgid "For general Firefox support, visit our <a href=\"%(sumo_url)s\">support website</a>. For general add-on and website questions, visit our <a href=\"%(forum_url)s\">forum</a>."
 msgstr "ਫ਼ਾਇਰਫ਼ਾਕਸ ਆਮ ਸਹਿਯੋਗ ਲਈ, ਸਾਡੀ <a href=\"%(sumo_url)s\">ਸਹਿਯੋਗ ਵੈੱਬਸਾਈਟ</a>ਤੇ ਜਾਓ। ਆਮ ਫ਼ਾਇਰਫ਼ਾਕਸ ਐਡ-ਆਨ ਅਤੇ ਵੈੱਬਸਾਈਟ ਸਵਾਲਾਂ ਲਈ, ਸਾਡੀ <a href=\"%(forum_url)s\">ਫ਼ੋਰਮ</a>ਤੇ ਜਾਓ।"
@@ -10956,16 +10907,16 @@ msgstr "{0} ਐਡ-ਆਨ"
 
 #. L10n: {0} is an application, such as Firefox. This means "any version of
 #. Firefox."
-#: src/olympia/search/views.py:554
+#: src/olympia/search/views.py:547
 msgid "Any {0}"
 msgstr "ਕੋਈ {0}"
 
 #. L10n: "All Systems" means show everything regardless of platform.
-#: src/olympia/search/views.py:589
+#: src/olympia/search/views.py:582
 msgid "All Systems"
 msgstr "ਸਾਰੇ ਸਿਸਟਮ"
 
-#: src/olympia/search/views.py:600
+#: src/olympia/search/views.py:593
 msgid "All Tags"
 msgstr "ਸਾਰੇ ਟੈਗ"
 
@@ -11139,31 +11090,31 @@ msgstr "ਇਸ ਐਡ-ਆਨ ਨੂੰ ਸਾਂਝਾ ਕਰੋ"
 msgid "Share this Collection"
 msgstr "ਇਸ ਸੰਗ੍ਰਹਿ ਨੂੰ ਸਾਂਝਾ ਕਰੋ"
 
-#: src/olympia/signing/views.py:30 src/olympia/templates/base.html:75 src/olympia/templates/impala/base.html:115
+#: src/olympia/signing/views.py:33 src/olympia/templates/base.html:71 src/olympia/templates/impala/base.html:112
 msgid "Some features are temporarily disabled while we perform website maintenance. We'll be back to full capacity shortly."
 msgstr "ਕੁੱਝ ਗੁਣ ਅਸਥਾਈ ਤੌਰ ਤੇ ਬੰਦ ਹਨ ਜਦੋਂ ਤੱਕ ਅਸੀਂ ਵੈੱਬਸਾਈਟ ਦੀ ਸਾਂਭ-ਸੰਭਾਲ ਕਰ ਰਹੇ ਹਾਂ। ਅਸੀਂ ਥੋੜੇ ਸਮੇਂ ਵਿੱਚ ਪੂਰੀ ਸਮਰਥਾ ਨਾਲ ਵਾਪਸ ਆਵਾਂਗੇ।"
 
-#: src/olympia/signing/views.py:53
+#: src/olympia/signing/views.py:56
 msgid "Could not find add-on with id \"{}\"."
 msgstr ""
 
-#: src/olympia/signing/views.py:67
+#: src/olympia/signing/views.py:70
 msgid "You do not own this addon."
 msgstr ""
 
-#: src/olympia/signing/views.py:82
+#: src/olympia/signing/views.py:87
 msgid "Missing \"upload\" key in multipart file data."
 msgstr ""
 
-#: src/olympia/signing/views.py:96
+#: src/olympia/signing/views.py:101
 msgid "Version does not match the manifest file."
 msgstr ""
 
-#: src/olympia/signing/views.py:100
+#: src/olympia/signing/views.py:105
 msgid "Version already exists."
 msgstr ""
 
-#: src/olympia/signing/views.py:136
+#: src/olympia/signing/views.py:141
 msgid "No uploaded file for that addon and version."
 msgstr ""
 
@@ -11276,89 +11227,89 @@ msgstr "{0} :: ਅੰਕੜੇ ਡੈਸਬੋਰਡ"
 msgid "Statistics Dashboard :: Add-ons for {0}"
 msgstr "ਅੰਕੜੇ ਡੈਸਬੋਰਡ :: {0} ਲਈ ਐਡ-ਆਨ"
 
-#: src/olympia/stats/templates/stats/stats.html:30
-msgid "Controls:"
-msgstr "ਕੰਟਰੋਲ:"
-
-#: src/olympia/stats/templates/stats/stats.html:33
-msgid "reset zoom"
-msgstr "ਜ਼ੂਮ ਰੀਸੈੱਟ"
-
-#: src/olympia/stats/templates/stats/stats.html:40
-msgid "Group by:"
-msgstr "ਗਰੁੱਪ ਦੁਆਰਾ:"
-
-#: src/olympia/stats/templates/stats/stats.html:42
-msgid "day"
-msgstr "ਦਿਨ"
-
-#: src/olympia/stats/templates/stats/stats.html:45
-msgid "week"
-msgstr "ਹਫ਼ਤਾ"
-
-#: src/olympia/stats/templates/stats/stats.html:48
-msgid "month"
-msgstr "ਮਹੀਨਾ"
-
-#: src/olympia/stats/templates/stats/stats.html:54
-msgid "For last:"
-msgstr "ਲਈ ਆਖਰੀ:"
-
-#: src/olympia/stats/templates/stats/stats.html:57
-msgid "7 days"
-msgstr "7 ਦਿਨਾਂ"
-
-#: src/olympia/stats/templates/stats/stats.html:60
-msgid "30 days"
-msgstr "30 ਦਿਨਾਂ"
-
-#: src/olympia/stats/templates/stats/stats.html:63
-msgid "90 days"
-msgstr "90 ਦਿਨਾਂ"
-
-#: src/olympia/stats/templates/stats/stats.html:66
-msgid "365 days"
-msgstr "365 ਦਿਨਾਂ"
-
-#: src/olympia/stats/templates/stats/stats.html:69
-msgid "Custom..."
-msgstr "ਪਸੰਦੀਦਾ..."
-
 #. {0} is an add-on name
-#: src/olympia/stats/templates/stats/stats.html:88 src/olympia/stats/templates/stats/stats.html:91
+#: src/olympia/stats/templates/stats/stats.html:44 src/olympia/stats/templates/stats/stats.html:47
 msgid "Statistics for {0}"
 msgstr "{0} ਲਈ ਅੰਕੜੇ"
 
-#: src/olympia/stats/templates/stats/stats.html:94
+#: src/olympia/stats/templates/stats/stats.html:50
 msgid "Statistics Dashboard"
 msgstr "ਅੰਕੜੇ ਡੈਸਬੋਰਡ"
 
-#: src/olympia/stats/templates/stats/stats.html:104
+#: src/olympia/stats/templates/stats/stats.html:57
+msgid "Controls:"
+msgstr "ਕੰਟਰੋਲ:"
+
+#: src/olympia/stats/templates/stats/stats.html:60
+msgid "reset zoom"
+msgstr "ਜ਼ੂਮ ਰੀਸੈੱਟ"
+
+#: src/olympia/stats/templates/stats/stats.html:67
+msgid "Group by:"
+msgstr "ਗਰੁੱਪ ਦੁਆਰਾ:"
+
+#: src/olympia/stats/templates/stats/stats.html:69
+msgid "day"
+msgstr "ਦਿਨ"
+
+#: src/olympia/stats/templates/stats/stats.html:72
+msgid "week"
+msgstr "ਹਫ਼ਤਾ"
+
+#: src/olympia/stats/templates/stats/stats.html:75
+msgid "month"
+msgstr "ਮਹੀਨਾ"
+
+#: src/olympia/stats/templates/stats/stats.html:81
+msgid "For last:"
+msgstr "ਲਈ ਆਖਰੀ:"
+
+#: src/olympia/stats/templates/stats/stats.html:84
+msgid "7 days"
+msgstr "7 ਦਿਨਾਂ"
+
+#: src/olympia/stats/templates/stats/stats.html:87
+msgid "30 days"
+msgstr "30 ਦਿਨਾਂ"
+
+#: src/olympia/stats/templates/stats/stats.html:90
+msgid "90 days"
+msgstr "90 ਦਿਨਾਂ"
+
+#: src/olympia/stats/templates/stats/stats.html:93
+msgid "365 days"
+msgstr "365 ਦਿਨਾਂ"
+
+#: src/olympia/stats/templates/stats/stats.html:96
+msgid "Custom..."
+msgstr "ਪਸੰਦੀਦਾ..."
+
+#: src/olympia/stats/templates/stats/stats.html:106
 msgid "Statistics processing is currently disabled, so recent data is unavailable. The statistics are still being collected and this page will be updated soon with the missing data."
 msgstr ""
 
-#: src/olympia/stats/templates/stats/stats.html:110
+#: src/olympia/stats/templates/stats/stats.html:112
 msgid "Loading the latest data&hellip;"
 msgstr "ਤਾਜ਼ਾ ਡਾਟਾ ਲੋਡ ਕਰ ਰਿਹਾ&hellip;"
 
-#: src/olympia/stats/templates/stats/stats.html:142 src/olympia/stats/templates/stats/reports/overview.html:25 src/olympia/stats/templates/stats/reports/overview.html:37
+#: src/olympia/stats/templates/stats/stats.html:144 src/olympia/stats/templates/stats/reports/overview.html:25 src/olympia/stats/templates/stats/reports/overview.html:37
 #: src/olympia/stats/templates/stats/reports/overview.html:49
 msgid "No data available."
 msgstr "ਕੋਈ ਡਾਟਾ ਮੌਜੂਦ ਨਹੀਂ।"
 
-#: src/olympia/stats/templates/stats/stats.html:177
+#: src/olympia/stats/templates/stats/stats.html:179
 msgid "This dashboard is currently <b>public</b>."
 msgstr "ਇਹ ਡੈਸਬੋਰਡ ਮੌਜੂਦਾ ਤੌਰ ਤੇ <b>ਜਨਤਕ</b>ਹੈ।"
 
-#: src/olympia/stats/templates/stats/stats.html:179
+#: src/olympia/stats/templates/stats/stats.html:181
 msgid "Contribution stats are currently <b>private</b>."
 msgstr "ਯੋਗਦਾਨ ਅੰਕੜੇ ਮੌਜੂਦਾ ਤੌਰ ਤੇ <b>ਨਿੱਜੀ</b>ਹਨ।"
 
-#: src/olympia/stats/templates/stats/stats.html:182
+#: src/olympia/stats/templates/stats/stats.html:184
 msgid "This dashboard is currently <b>private</b>."
 msgstr "ਇਹ ਡੈਸਬੋਰਡ ਮੌਜੂਦਾ ਤੌਰ ਤੇ <b>ਜਨਤਕ</b> ਹੈ।"
 
-#: src/olympia/stats/templates/stats/stats.html:185
+#: src/olympia/stats/templates/stats/stats.html:187
 msgid "Change settings."
 msgstr "ਸੈਟਿੰਗ ਬਦਲੋ।"
 
@@ -11521,15 +11472,6 @@ msgstr "ਉਪਭੋੋਗੀ ਸਾਇਨ-ਅਪ ਮਿਤੀ ਅਨੁਸਾ�
 msgid "Application versions by Date"
 msgstr "ਐਪਲੀਕੇਸ਼ਨ ਵਰਜਨ ਮਿਤੀ ਅਨੁਸਾਰ"
 
-#: src/olympia/tags/templates/tags/top_cloud.html:4
-msgid "Top {0} Tags"
-msgstr "ਚੋਟੀ ਦੇ {0} ਟੈਗ"
-
-#. {0} is the current application name
-#: src/olympia/tags/templates/tags/top_cloud.html:14
-msgid "{0} Top Tags"
-msgstr "{0} ਚੋਟੀ ਦੇ ਟੈਗ"
-
 #: src/olympia/templates/amo_footer.html:6 src/olympia/templates/includes/lang_switcher.html:2
 msgid "Other languages"
 msgstr "ਹੋਰ ਭਾਸ਼ਾਵਾਂ"
@@ -11538,11 +11480,11 @@ msgstr "ਹੋਰ ਭਾਸ਼ਾਵਾਂ"
 msgid "Mozilla Add-ons"
 msgstr "ਮੌਜੀਲਾ ਐਡ-ਆਨ"
 
-#: src/olympia/templates/base.html:91 src/olympia/templates/impala/base.html:81
+#: src/olympia/templates/base.html:89 src/olympia/templates/impala/base.html:78
 msgid "Find add-ons for other applications"
 msgstr "ਹੋਰ ਐਪਲੀਕੇਸ਼ਨਾਂ ਲਈ ਐਡ-ਆਨ ਖੋਜੋ"
 
-#: src/olympia/templates/base.html:92 src/olympia/templates/impala/base.html:81
+#: src/olympia/templates/base.html:90 src/olympia/templates/impala/base.html:78
 msgid "Other Applications"
 msgstr "ਹੋਰ ਐਪਲੀਕੇਸ਼ਨਾਂ"
 
@@ -11567,7 +11509,7 @@ msgid "View Mobile Site"
 msgstr "ਮੋਬਾਈਲ ਸਾਈਟ ਵੇਖੋ"
 
 #: src/olympia/templates/copyright.html:7
-msgid "Site Status "
+msgid "Site Status"
 msgstr ""
 
 #: src/olympia/templates/footer.html:3
@@ -11667,35 +11609,35 @@ msgstr "ਜੀ ਆਇਆ ਨੂੰ, {0}"
 msgid "<a href=\"%(reg)s\">Register</a> or <a href=\"%(login)s\">Log in</a>"
 msgstr "<a href=\"%(reg)s\">ਦਰਜ ਹੋਵੇ</a> ਜਾਂ <a href=\"%(login)s\">ਲਾਗ ਇਨ</a>"
 
-#: src/olympia/templates/impala/base.html:126
+#: src/olympia/templates/impala/base.html:123
 #, python-format
 msgid "To try the thousands of add-ons available here, download <a href=\"%(url)s\">Mozilla Firefox</a>, a fast, free way to surf the Web!"
 msgstr "ਇੱਥੇ ਮੌਜੂਦ ਹਜ਼ਾਰਾਂ ਐਡ-ਆਨ ਵਰਤਣ ਲਈ , ਡਾਊਨਲੋਡ<a href=\"%(url)s\">ਮੋਜ਼ੀਲਾ ਫਾਇਰਫਾਕਸ</a>,ਇੱਕ ਤੇਜ , ਆਜ਼ਾਦ ਜਰੀਆ ਵੈਬ ਵਰਤੋਂ ਲਈ!"
 
-#: src/olympia/templates/impala/base.html:138
+#: src/olympia/templates/impala/base.html:135
 #, python-format
 msgid "Add-ons is switching to Firefox Accounts for login. <a href=\"%(url)s\" class=\"fxa-login\">Sign in now to transfer your account.</a>"
 msgstr ""
 
 #. {0} is an application, such as Firefox.
-#: src/olympia/templates/impala/base.html:148
+#: src/olympia/templates/impala/base.html:145
 msgid "Welcome to {0} Add-ons."
 msgstr "{0} ਐਡ-ਆਨ ਵਿੱਚ ਸਵਾਗਤ |"
 
-#: src/olympia/templates/impala/base.html:151
+#: src/olympia/templates/impala/base.html:148
 msgid "Choose from thousands of extra features and styles to make Firefox your own."
 msgstr "ਫਾਇਰਫਾਕਸ ਨੂੰ ਆਪਣਾ ਬਣਾਉਣ ਲਈ ਹਜ਼ਾਰਾਂ ਵਾਧੂ ਪੇਸ਼ਕਸਾਂ ਅਤੇ ਅੰਦਾਜ਼ਾਂ ਵਿੱਚੋ ਚੁਣੋ।"
 
-#: src/olympia/templates/impala/base.html:156
+#: src/olympia/templates/impala/base.html:153
 #, python-format
 msgid "Add extra features and styles to make %(app)s your own."
 msgstr "%(app)s ਨੂੂੰ ਆਪਣਾ ਬਣਾਉਣ ਲਈ ਵਾਧੂ ਪੇਸ਼ਕਸਾਂ ਅਤੇ ਅੰਦਾਜਾਂ ਨੂੰ ਜੋੜੋ।"
 
-#: src/olympia/templates/impala/base.html:164
+#: src/olympia/templates/impala/base.html:161
 msgid "On the go?"
 msgstr "ਕਿਰਿਆਸ਼ੀਲ?"
 
-#: src/olympia/templates/impala/base.html:166
+#: src/olympia/templates/impala/base.html:163
 msgid "Check out our <a class=\"mobile-link\" href=\"#\">Mobile Add-ons site</a>."
 msgstr "ਵੇਖੋ ਸਾਡੀ<a class=\"mobile-link\"href=\"#\">ਮੋਬਾਈਲ ਐਡ-ਆਨ ਸਾਈਟ</a>"
 
@@ -11919,19 +11861,19 @@ msgstr "ਇਸ ਈਮੇਲ ਨਾਲ ਕੋਈ ਉਪਭੋਗੀ ਨਹੀਂ�
 
 #. L10n: {id} will be something like "13ad6a", just a random number
 #. to differentiate this user from other anonymous users.
-#: src/olympia/users/models.py:353
+#: src/olympia/users/models.py:362
 msgid "Anonymous user {id}"
 msgstr ""
 
-#: src/olympia/users/models.py:410
+#: src/olympia/users/models.py:419
 msgid "Your account has been restricted"
 msgstr "ਤੁਹਾਡਾ ਖਾਤਾ ਸੀਮਿਤ ਕੀਤਾ ਗਿਆ"
 
-#: src/olympia/users/models.py:480
+#: src/olympia/users/models.py:489
 msgid "Please confirm your email address"
 msgstr "ਕਿਰਪਾ ਕਰਕੇ ਆਪਣੇ ਈਮੇਲ ਖਾਤੇ ਦੀ ਪੁਸ਼ਟੀ ਕਰੋ"
 
-#: src/olympia/users/models.py:506
+#: src/olympia/users/models.py:515
 msgid "My Mobile Add-ons"
 msgstr "ਮੇਰੇ ਮੋਬਾਈਲ ਐਡ-ਆਨ"
 
@@ -12691,15 +12633,15 @@ msgstr "%s ਵਰਜਨ ਇਤਿਹਾਸ"
 msgid "Version History with Changelogs"
 msgstr "ਤਬਦੀਲੀ-ਉਲੇਖਾਂ ਨਾਲ ਵਰਜਨ ਇਤਿਹਾਸ"
 
-#: src/olympia/versions/models.py:314
+#: src/olympia/versions/models.py:313
 msgid "Add-on uses binary components."
 msgstr "ਐਡ-ਆਨ ਬਾਇਨਰੀ ਹਿੱਸੇ ਵਰਤਦਾ ਹੈ।"
 
-#: src/olympia/versions/models.py:317
+#: src/olympia/versions/models.py:316
 msgid "Add-on has opted into strict compatibility checking."
 msgstr "ਐਡ-ਆਨ ਸ਼ਖਤ ਅਨੁਕੂਲਤਾ ਪੜਤਾਲ ਲਈ ਚੁਣਿਆ ਗਿਆ।"
 
-#: src/olympia/versions/models.py:715
+#: src/olympia/versions/models.py:711
 msgid "{app} {min} and later"
 msgstr "{app} {min} and ਬਾਅਦ"
 
@@ -12775,4 +12717,8 @@ msgstr "ਮੁਕੰਮਲ ਹੋਣ ਤੇ ਈਮੇਲ ਕਰੋ"
 #: src/olympia/zadmin/forms.py:105
 msgid "Log emails instead of sending"
 msgstr "ਭੇਜਣ ਦੀ ਥਾਂ ਈਮੇਲਾਂ ਲਾਗ ਕਰੋ"
+
+#: src/olympia/zadmin/forms.py:215
+msgid "Deleted versions can`t be changed."
+msgstr ""
 

--- a/locale/pa/LC_MESSAGES/djangojs.po
+++ b/locale/pa/LC_MESSAGES/djangojs.po
@@ -1,1217 +1,1237 @@
-
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2016-02-24 21:23+0000\n"
+"POT-Creation-Date: 2016-04-18 15:47+0000\n"
 "PO-Revision-Date: 2015-06-29 22:55+0000\n"
 "Last-Translator: jimidar <jimidar@gmail.com>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
+"Language: \n"
 "MIME-Version: 1.0\n"
-"Content-Type: text/plain; charset=utf-8\n"
+"Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Generated-By: Babel 2.2.0\n"
 
-#: static/js/common/ratingwidget.js:31
-msgid "{0} star"
-msgid_plural "{0} stars"
-msgstr[0] "{0} ਤਾਰਾ"
-msgstr[1] "{0} ਤਾਰੇ"
-
-#: static/js/common/upload-addon.js:41 static/js/common/upload-image.js:128
-msgid "There was a problem contacting the server."
-msgstr "ਸਰਵਰ ਨਾਲ ਸੰਪਰਕ ਵੇਲੇ ਇੱਕ ਮੁਸ਼ਕਲ ਸੀ।"
-
-#: static/js/common/upload-addon.js:69
-msgid "Select a file..."
-msgstr "ਇੱਕ ਫਾਈਲ ਚੁਣੋ..."
-
-#: static/js/common/upload-addon.js:70
-msgid "Your add-on should end with .xpi, .jar or .xml"
-msgstr "ਤੁਹਾਡਾ ਐਡ-ਆਨ .xpi, .jar ਜਾਂ .xml ਨਾਲ ਖਤਮ ਹੋਣਾ ਚਾਹੀਦਾ"
-
-#. L10n: {0} is the percent of the file that has been uploaded.
-#: static/js/common/upload-addon.js:104
-#, fuzzy, python-format
-msgid "{0}% complete"
-msgstr "{0}% ਮੁਕੰਮਲ"
-
-#. L10n: "{bytes uploaded} of {total filesize}".
-#: static/js/common/upload-addon.js:107
-msgid "{0} of {1}"
-msgstr "{1} ਵਿੱਚੋਂ {0}"
-
-#: static/js/common/upload-addon.js:140
-msgid "Cancel"
-msgstr "ਰੱਦ"
-
-#: static/js/common/upload-addon.js:162
-msgid "Uploading {0}"
-msgstr "{0} ਅੱਪਲੋਡ ਹੋ ਰਿਹਾ"
-
-#: static/js/common/upload-addon.js:189
-msgid "Error with {0}"
-msgstr "{0} ਨਾਲ ਖਾਮੀ"
-
-#: static/js/common/upload-addon.js:194
-msgid "Your add-on failed validation with {0} error."
-msgid_plural "Your add-on failed validation with {0} errors."
-msgstr[0] "ਤੁਹਾਡੇ ਐਡ-ਆਨ ਦੀ {0} ਖਾਮੀ ਨਾਲ ਵੈਧਤਾ ਫ਼ੇਲ੍ਹ ਹੋਈ।"
-msgstr[1] "ਤੁਹਾਡੇ ਐਡ-ਆਨ ਦੀ {0} ਖਾਮੀਆਂ ਨਾਲ ਵੈਧਤਾ ਫ਼ੇਲ੍ਹ ਹੋਈ।"
-
-#: static/js/common/upload-addon.js:208
-msgid "&hellip;and {0} more"
-msgid_plural "&hellip;and {0} more"
-msgstr[0] "&hellip;ਅਤੇ {0} ਹੋਰ"
-msgstr[1] "&hellip;ਅਤੇ {0} ਹੋਰ"
-
-#: static/js/common/upload-addon.js:222 static/js/common/upload-addon.js:512
-msgid "See full validation report"
-msgstr "ਪੂਰੀ ਵੈਧਤਾ ਰਿਪੋਰਟ ਵੇਖੋ"
-
-#: static/js/common/upload-addon.js:234
-msgid "Validating {0}"
-msgstr "{0} ਵੈਧਤਾ"
-
-#. L10n: first argument is an HTTP status code
-#: static/js/common/upload-addon.js:273
-msgid "Received an empty response from the server; status: {0}"
-msgstr "ਸਰਵਰ ਵੱਲੋਂ ਇੱਕ ਖਾਲੀ ਜਵਾਬ ਮਿਲਿਆ; ਸਥਿਤੀ: {0}"
-
-#: static/js/common/upload-addon.js:373
-msgid "Unexpected server error while validating."
-msgstr "ਵੈਧਤਾ ਦੌਰਾਨ ਅਚਾਨਕ ਸਰਵਰ ਗਲਤੀ।"
-
-#: static/js/common/upload-addon.js:412
-msgid "Finished validating {0}"
-msgstr "{0} ਵੈਧਤਾ ਮੁੰਕਮਲ ਹੋਈ"
-
-#: static/js/common/upload-addon.js:418
-msgid "Your add-on validation timed out, it will be manually reviewed."
-msgstr ""
-
-#: static/js/common/upload-addon.js:421
-msgid "Your add-on was validated with no errors and {0} warning."
-msgid_plural "Your add-on was validated with no errors and {0} warnings."
-msgstr[0] ""
-msgstr[1] ""
-
-#: static/js/common/upload-addon.js:426
-msgid "Your add-on was validated with no errors and {0} message."
-msgid_plural "Your add-on was validated with no errors and {0} messages."
-msgstr[0] "ਤੁਹਾਡਾ ਐਡ-ਆਨ ਬਿਨਾਂ ਕਿਸੇ ਖ਼ਾਮੀ ਅਤੇ {0} ਸੁਨੇਹੇ ਨਾਲ ਵੈਧ ਹੋਇਆ ਸੀ।"
-msgstr[1] "ਤੁਹਾਡਾ ਐਡ-ਆਨ ਬਿਨਾਂ ਕਿਸੇ ਖ਼ਾਮੀ ਅਤੇ {0} ਸੁਨੇਹਿਆਂ ਨਾਲ ਵੈਧ ਹੋਇਆ ਸੀ।"
-
-#: static/js/common/upload-addon.js:431
-msgid "Your add-on was validated with no errors or warnings."
-msgstr "ਤੁਹਾਡਾ ਐਡ-ਆਨ ਬਿਨਾਂ ਕਿਸੇ ਖ਼ਾਮੀਆਂ ਜਾਂ ਚੇਤਾਵਨੀਆਂ ਦੇ ਵੈਧ ਹੋਇਆ ਸੀ।"
-
-#: static/js/common/upload-addon.js:446
-msgid "Your submission will be automatically signed."
-msgstr ""
-
-#: static/js/common/upload-addon.js:465
-msgid "Include detailed version notes (this can be done in the next step)."
-msgstr "ਵਰਜਨ ਨੋਟਾਂ ਦਾ ਵੇਰਵਾ ਸ਼ਾਮਲ (ਇਹ ਅਗਲੇ ਕਦਮ ਵਿੱਚ ਕੀਤਾ ਜਾ ਸਕਦਾ)।"
-
-#: static/js/common/upload-addon.js:466
-msgid "If your add-on requires an account to a website in order to be fully tested, include a test username and password in the Notes to Reviewer (this can be done in the next step)."
-msgstr "ਜੇਕਰ ਤੁਹਾਡੇ ਐਡ-ਆਨ ਨੂੰ ਪੂਰੀ ਪਰਖ ਲਈ ਇੱਕ ਵੈੱਬਸਾਈਟ ਤੇ ਇੱਕ ਖਾਤੇ ਦੀ ਲੋੜ ਹੈ, ਸਮੀਖਿਅਕ ਲਈ ਨੋਟਾਂ ਵਿੱਚ ਇੱਕ ਟੈਸਟ ਵਰਤੋਂਕਾਰ ਅਤੇ ਪਾਸਵਰਡ ਸ਼ਾਮਲ ਕਰੋ (ਇਹ ਅਗਲੇ ਕਦਮ ਵਿੱਚ ਕੀਤਾ ਜਾ ਸਕਦਾ)।"
-
-#: static/js/common/upload-addon.js:467
-msgid "If your add-on is intended for a limited audience you should choose Preliminary Review instead of Full Review."
-msgstr "ਜੇਕਰ ਤੁਹਾਡਾ ਐਡ-ਆਨ ਇੱਕ ਸੀਮਿਤ ਜਨਤਾ ਲਈ ਨਿਯਤ ਹੈ ਤੁਹਾਨੂੰ ਮੁਕੰਮਲ ਸਮੀਖਿਆ ਦੀ ਥਾਂ ਸ਼ੁਰੂਆਤੀ ਸਮੀਖਿਆ ਨੂੰ ਚੁਣਨਾ ਚਾਹੀਦਾ ਹੈ।"
-
-#: static/js/common/upload-addon.js:480
-msgid "Add-on submission checklist"
-msgstr "ਐਡ-ਆਨ ਦਾਖਲ ਕਾਰਜ ਚੈੱਕਲਿਸਟ"
-
-#: static/js/common/upload-addon.js:481
-msgid "Please verify the following points before finalizing your submission. This will minimize delays or misunderstanding during the review process:"
-msgstr "ਆਪਣੇ ਦਾਖਲ ਕਾਰਜ ਨੂੰ ਮੁਕੰਮਲ ਕਰਨ ਤੋਂ ਪਹਿਲਾਂ ਅੱਗੇ ਦਿੱਤੇ ਅੰਕਾਂ ਦੀ ਪੁਸ਼ਟੀ ਕਰੋ। ਇਸ ਨਾਲ ਸਮੀਖਿਆ ਕਾਰਜ ਦੌਰਾਨ ਦੇਰੀ ਅਤੇ ਗਲਤਫ਼ਹਿਮੀ ਘੱਟ ਹੋਵੇਗੀ:"
-
-#: static/js/common/upload-addon.js:483
-msgid ""
-"Compiled binaries, as well as minified or obfuscated scripts (excluding known libraries) need to have their sources submitted separately for review. Make sure that you use the source code upload "
-"field to avoid having your submission rejected."
-msgstr ""
-"ਕੰਪਾਇਲਡ ਬਾਇਨਰੀਆਂ, ਨਾਲ ਦੀ ਨਾਲ ਛੋਟੀਆਂ ਜਾਂ ਬੇਕਾਰ ਸਕਰਿਪਟਾਂ (ਜਾਣੂ ਲਾਇਬਰ੍ਰੇਰੀਆਂ ਨੂੰ ਛੱਡ ਕੇ) ਨੂੰ ਸਮੀਖਿਆ ਲਈ ਆਪਣੇ ਸੋਰਸ ਕੋਡਾਂ ਨੂੰ ਵੱਖ ਤੋਂ ਦਾਖਲ ਕਰਨ ਦੀ ਜ਼ਰੂਰਤ ਹੈ। ਇਹ ਯਕੀਨੀ ਬਣਾਓ ਕੀ ਤੁਸੀਂ ਆਪਣੇ ਦਾਖਲ ਕਾਰਜ ਨੂੰ ਰੱਦ "
-"ਹੋਣ ਤੋਂ ਬਚਾਉਣ ਲਈ ਸੋਰਸ ਕੋਡ ਅੱਪਲੋਡ ਖੇਤਰ ਦੀ ਵਰਤੋਂ ਕਰ ਰਹੇ ਹੋ।"
-
-#: static/js/common/upload-addon.js:501
-msgid "The validation process found these issues that can lead to rejections:"
-msgstr "ਵੈਧਤਾ ਕਾਰਜ ਨੂੰ ਇਹ ਮਸਲੇ ਲੱਭੇ ਹਨ ਜੋ ਰੱਦ ਹੋਣ ਦਾ ਕਾਰਨ ਬਣ ਸਕਦੇ ਹਨ:"
-
-#: static/js/common/upload-addon.js:518
-msgid "If you are unfamiliar with the add-ons review process, you can read about it here."
-msgstr "ਜੇਕਰ ਤੁਸੀਂ ਐਡ-ਆਨ ਸਮੀਖਿਆ ਕਾਰਜ ਤੋਂ ਜਾਣੂ ਨਹੀਂ ਹੋ, ਤੁਸੀਂ ਉਸ ਬਾਰੇ ਇੱਥੇ ਪੜ੍ਹ ਸਕਦੇ ਹੋ।"
-
-#: static/js/common/upload-addon.js:555
-msgid "Sorry, no supported platform has been found."
-msgstr "ਮੁਆਫ਼ੀ, ਕੋਈ ਸਹਾਇਕ ਪਲੇਟਫਾਰਮ ਨਹੀਂ ਲੱਭਿਆ।"
-
-#: static/js/common/upload-base.js:57
-msgid "The filetype you uploaded isn't recognized."
-msgstr "ਤੁਹਾਨੂੰ ਵੱਲੋਂ ਅੱਪਲੋਡ ਕੀਤੀ ਫ਼ਾਈਲ ਕਿਸਮ ਦੀ ਪਛਾਣ ਨਹੀਂ ਹੋਈ।"
-
-#: static/js/common/upload-base.js:79
-msgid "You cancelled the upload."
-msgstr "ਤੁਸੀਂ ਅੱਪਲੋਡ ਨੂੰ ਰੱਦ ਕੀਤਾ।"
-
-#: static/js/common/upload-image.js:97 static/js/impala/users.js:51
-msgid "Images must be either PNG or JPG."
-msgstr "ਤਸਵੀਰਾਂ PNG ਜਾਂ JPG ਦੋਨਾਂ ਵਿੱਚ ਇੱਕ ਹੋਣੀਆਂ ਚਾਹੀਦੀਆਂ ਹਨ।"
-
-#: static/js/common/upload-image.js:101
-msgid "Videos must be in WebM."
-msgstr "ਵੀਡੀਓ WebM ਵਿੱਚ ਹੋਣੀਆਂ ਚਾਹੀਦੀਆਂ ਹਨ।"
-
-#: static/js/impala/collections.js:10 static/js/zamboni/collections.js:595
-msgid "Follow this Collection"
-msgstr "ਇਸ ਸੰਗ੍ਰਹਿ ਦਾ ਸਮਰਥਨ ਕਰੋ"
-
-#: static/js/impala/collections.js:19
-msgid "Stop Following"
-msgstr "ਸਮਰਥਨ ਰੋਕੋ"
-
-#: static/js/impala/collections.js:20
-msgid "Following"
-msgstr "ਸਮਰਥਨ ਕਰ ਰਿਹਾ"
-
-#. L10n: {0} is an app name.
-#: static/js/impala/listing.js:11 static/js/zamboni/themes.js:13
-msgid "This theme is incompatible with your version of {0}"
-msgstr "{0} ਦੇ ਤੁਹਾਡੇ ਵਰਜਨ ਨਾਲ ਇਹ ਥੀਮ ਅਨੁਕੂਲ ਨਹੀਂ ਹੈ"
-
-#: static/js/impala/persona_creation.js:60
-msgid "All Rights Reserved"
-msgstr "ਸਭ ਹੱਕ ਰਾਖਵੇ ਹਨ"
-
-#: static/js/impala/persona_creation.js:64
-msgid "Creative Commons Attribution 3.0"
-msgstr "ਕਰੀਏਟਿਵ ਕਾਮਨਜ਼ ਐਟਰੀਬਿਊਸ਼ਨ 3.0"
-
-#: static/js/impala/persona_creation.js:69
-msgid "Creative Commons Attribution-NonCommercial 3.0"
-msgstr "ਕਰੀਏਟਿਵ-ਕਾਮਨਜ਼ ਐਟਰੀਬਿਊਸ਼ਨ-ਨਾਨ-ਕਮਰਸ਼ੀਅਲ 3.0"
-
-#: static/js/impala/persona_creation.js:74
-msgid "Creative Commons Attribution-NonCommercial-NoDerivs 3.0"
-msgstr "ਕਰੀਏਟਿਵ ਕਾਮਨਜ਼ ਐਟਰੀਬਿਊਸ਼ਨ-ਨਾਨ ਕਮਰਸ਼ੀਅਲ-ਨੋਨ ਡਰਾਈਵ 3.0"
-
-#: static/js/impala/persona_creation.js:79
-msgid "Creative Commons Attribution-NonCommercial-Share Alike 3.0"
-msgstr "ਕਰੀਏਟਿਵ ਕਾਮਨਜ਼ ਐਟਰੀਬਿਊਸ਼ਨ-ਨਾਨ ਕਮਰਸ਼ੀਅਲ-ਸ਼ੇਅਰ-ਅਲਾਈਕ 3.0"
-
-#: static/js/impala/persona_creation.js:84
-msgid "Creative Commons Attribution-NoDerivs 3.0"
-msgstr "ਕਰੀਏਟਿਵ ਕਾਮਨਜ਼ ਐਟਰੀਬਿਊਸ਼ਨ-ਨੌਨ ਡਰਾਈਵ 3.0"
-
-#: static/js/impala/persona_creation.js:89
-msgid "Creative Commons Attribution-ShareAlike 3.0"
-msgstr "ਕਰੀਏਟਿਵ ਕਾਮਨਜ਼ ਐਟਰੀਬਿਊਸ਼ਨ-ਸੇਅਰ ਅਲਾਈਕ 3.0"
-
-#: static/js/impala/persona_creation.js:292
-msgid "Your Theme's Name"
-msgstr "ਤੁਹਾਡੇ ਥੀਮ ਦਾ ਨਾਮ"
-
-#: static/js/impala/reviews.js:23 static/js/zamboni/reviews.js:18
-msgid "Flagged for review"
-msgstr "ਸਮੀਖਿਆ ਲਈ ਫਲੈਗ ਕੀਤਾ"
-
-#: static/js/impala/reviews.js:40 static/js/zamboni/reviews.js:34
-msgid "Your input is required"
-msgstr "ਤੁਹਾਡੇ ਇਨਪੁੱਟ ਦੀ ਲੋੜ ਹੈ"
-
-#: static/js/impala/reviews.js:152 static/js/zamboni/reviews.js:103
-msgid "Marked for deletion"
-msgstr "ਹਟਾਉਣ ਲਈ ਮਾਰਕ ਕੀਤਾ"
-
-#: static/js/impala/search.js:114
-msgid "Updating results&hellip;"
-msgstr "ਅੱਪਡੇਟ ਨਤੀਜੇ&hellip;"
-
-#: static/js/impala/site_suggestions.js:46
-msgid "Category"
-msgstr "ਕੈਟਾਗਿਰੀ"
-
-#: static/js/impala/suggestions.js:39
-msgid "Search themes for <b>{0}</b>"
-msgstr "<b>{0}</b> ਲਈ ਥੀਮ ਖੋਜੋ"
-
-#: static/js/impala/suggestions.js:41
-msgid "Search apps for <b>{0}</b>"
-msgstr "<b>{0}</b> ਲਈ ਐਪ ਖੋਜੋ"
-
-#: static/js/impala/suggestions.js:43
-msgid "Search add-ons for <b>{0}</b>"
-msgstr "<b>{0}</b> ਲਈ ਐਡ-ਆਨ ਖੋਜੋ"
-
-#: static/js/impala/users.js:33
-msgid "use original"
-msgstr "ਅਸਲੀ ਵਰਤੋ"
-
-#: static/js/impala/stats/chart.js:267
-msgid "Week of {0}"
-msgstr "{0} ਦਾ ਹਫਤਾ"
-
-#: static/js/impala/stats/chart.js:269
-msgid " downloads"
-msgstr ""
-
-#: static/js/impala/stats/chart.js:270
-msgid "{0} users"
-msgstr "{0} ਯੂਜਰ"
-
-#: static/js/impala/stats/chart.js:271
-msgid "{0} add-ons"
-msgstr "{0} ਐਡ-ਆਨ"
-
-#: static/js/impala/stats/chart.js:272
-msgid "{0} collections"
-msgstr "{0} ਭੰਡਾਰ"
-
-#: static/js/impala/stats/chart.js:273
-msgid "{0} reviews"
-msgstr "{0} ਸਮੀਖਿਅਕ"
-
-#: static/js/impala/stats/chart.js:275
-msgid "{0} sales"
-msgstr "{0} ਸੇਲ"
-
-#: static/js/impala/stats/chart.js:276
-msgid "{0} refunds"
-msgstr "{0} ਰਿਫੰਡ"
-
-#: static/js/impala/stats/chart.js:277
-msgid "{0} installs"
-msgstr "{0} ਇੰਸਟਾਲ"
-
-#: static/js/impala/stats/chart.js:369 static/js/impala/stats/csv_keys.js:3 static/js/impala/stats/csv_keys.js:109
-msgid "Downloads"
-msgstr "ਡਾਊਨਲੋਡ"
-
-#: static/js/impala/stats/chart.js:379 static/js/impala/stats/csv_keys.js:6 static/js/impala/stats/csv_keys.js:110
-msgid "Daily Users"
-msgstr "ਰੋਜਾਨਾਂ ਯੂਜਰ"
-
-#: static/js/impala/stats/chart.js:410
-msgid "Amount, in USD"
-msgstr "USA ਵਿੱਚ, ਰਾਸ਼ੀ"
-
-#: static/js/impala/stats/chart.js:421 static/js/impala/stats/csv_keys.js:104
-msgid "Number of Contributions"
-msgstr "ਯੋਗਦਾਨ ਦੀ ਗਿਣਤੀ"
-
-#: static/js/impala/stats/chart.js:447
-msgid "More Info..."
-msgstr "ਜਿਆਦਾ ਜਾਣਕਾਰੀ...."
-
-#. L10n: {0} is an ISO-formatted date.
-#: static/js/impala/stats/chart.js:451
-msgid "Details for {0}"
-msgstr "{0} ਲਈ ਵੇਰਵਾ"
-
-#: static/js/impala/stats/csv_keys.js:9
-msgid "Collections Created"
-msgstr "ਬਣਾਇਆ ਭੰਡਾਰ"
-
-#: static/js/impala/stats/csv_keys.js:12
-msgid "Add-ons in Use"
-msgstr "ਐਡ-ਆਨ ਵਿੱਚ ਵਰਤੋ"
-
-#: static/js/impala/stats/csv_keys.js:15
-msgid "Add-ons Created"
-msgstr "ਐਡ-ਆਨ ਬਣਾਓ"
-
-#: static/js/impala/stats/csv_keys.js:18
-msgid "Add-ons Downloaded"
-msgstr "ਐਡ-ਆਨ ਡਾਊਨਲੋਡ"
-
-#: static/js/impala/stats/csv_keys.js:21
-msgid "Add-ons Updated"
-msgstr "ਐਡ-ਆਨ ਅੱਪਡੇਟ"
-
-#: static/js/impala/stats/csv_keys.js:24
-msgid "Reviews Written"
-msgstr "ਲਿਖਤੀ ਸਮੀਖਿਅਕ"
-
-#: static/js/impala/stats/csv_keys.js:27
-msgid "User Signups"
-msgstr "ਯੂਜਰ ਸਾਈਨਅੱਪ"
-
-#: static/js/impala/stats/csv_keys.js:30
-msgid "Subscribers"
-msgstr "ਗਾਹਕ"
-
-#: static/js/impala/stats/csv_keys.js:33
-msgid "Ratings"
-msgstr "ਰੇਟਿੰਗ"
-
-#: static/js/impala/stats/csv_keys.js:36 static/js/impala/stats/csv_keys.js:114
-msgid "Sales"
-msgstr "ਸੇਲ"
-
-#: static/js/impala/stats/csv_keys.js:39 static/js/impala/stats/csv_keys.js:113
-msgid "Installs"
-msgstr "ਇੰਸਟਾਲ"
-
-#: static/js/impala/stats/csv_keys.js:42
-msgid "Unknown"
-msgstr "ਅਣਜਾਣ"
-
-#: static/js/impala/stats/csv_keys.js:43
-msgid "Add-ons Manager"
-msgstr "ਐਡ-ਆਨ ਮਨੇਜਰ"
-
-#: static/js/impala/stats/csv_keys.js:44
-msgid "Add-ons Manager Promo"
-msgstr ""
-
-#: static/js/impala/stats/csv_keys.js:45
-msgid "Add-ons Manager Featured"
-msgstr ""
-
-#: static/js/impala/stats/csv_keys.js:46
-msgid "Add-ons Manager Learn More"
-msgstr ""
-
-#: static/js/impala/stats/csv_keys.js:47
-msgid "Search Suggestions"
-msgstr ""
-
-#: static/js/impala/stats/csv_keys.js:48
-msgid "Search Results"
-msgstr "ਨਤੀਜੇ ਖੋਜੋ"
-
-#: static/js/impala/stats/csv_keys.js:49 static/js/impala/stats/csv_keys.js:50 static/js/impala/stats/csv_keys.js:51
-msgid "Homepage Promo"
-msgstr "ਮੁੱਖ ਸਫਾ ਪਰੋਮੋ"
-
-#: static/js/impala/stats/csv_keys.js:52 static/js/impala/stats/csv_keys.js:53
-msgid "Homepage Featured"
-msgstr "ਮੁੱਖ ਸਫਾ ਗੁਣ"
-
-#: static/js/impala/stats/csv_keys.js:54 static/js/impala/stats/csv_keys.js:55
-msgid "Homepage Up and Coming"
-msgstr "ਮੁੱਖ ਸਫਾ ਉੱਪਰ ਅਤੇ ਆਉਣਾ"
-
-#: static/js/impala/stats/csv_keys.js:56
-msgid "Homepage Most Popular"
-msgstr "ਮੱਖ ਸਫਾ ਜਿਆਦਾ ਪ੍ਰਸਿੱਧ"
-
-#: static/js/impala/stats/csv_keys.js:57 static/js/impala/stats/csv_keys.js:59
-msgid "Detail Page"
-msgstr "ਸਫੇ ਦਾ ਵੇਰਵਾ"
-
-#: static/js/impala/stats/csv_keys.js:58 static/js/impala/stats/csv_keys.js:60
-msgid "Detail Page (bottom)"
-msgstr "ਸਫੇ ਦਾ ਵੇਰਵਾ (ਹੇਠਾਂ)"
-
-#: static/js/impala/stats/csv_keys.js:61
-msgid "Detail Page (Development Channel)"
-msgstr "ਸਫੇ ਦਾ ਵੇਰਵਾ (ਵਾਧਾ ਪ੍ਰਣਾਲੀ)"
-
-#: static/js/impala/stats/csv_keys.js:62 static/js/impala/stats/csv_keys.js:63 static/js/impala/stats/csv_keys.js:64
-msgid "Often Used With"
-msgstr "ਆਮ ਕਰਕੇ ਨਾਲ ਵਰਤਿਆ"
-
-#: static/js/impala/stats/csv_keys.js:65 static/js/impala/stats/csv_keys.js:66
-msgid "Others By Author"
-msgstr "ਲੇਖਕ ਵਲੋ ਹੋਰ"
-
-#: static/js/impala/stats/csv_keys.js:67 static/js/impala/stats/csv_keys.js:68
-msgid "Dependencies"
-msgstr "ਨਿਰਭਰਤਾਵਾਂ"
-
-#: static/js/impala/stats/csv_keys.js:69 static/js/impala/stats/csv_keys.js:70
-msgid "Upsell"
-msgstr "ਵਾਧੂ ਖਰੀਦਦਾਰੀ ਲਈ ਉਕਸਾਉਣਾ"
-
-#: static/js/impala/stats/csv_keys.js:71
-msgid "Meet the Developer"
-msgstr ""
-
-#: static/js/impala/stats/csv_keys.js:72
-msgid "User Profile"
-msgstr ""
-
-#: static/js/impala/stats/csv_keys.js:73
-msgid "Version History"
-msgstr ""
-
-#: static/js/impala/stats/csv_keys.js:75
-msgid "Sharing"
-msgstr "ਵੰਡਣਾ"
-
-#: static/js/impala/stats/csv_keys.js:76
-msgid "Category Pages"
-msgstr "ਸੰਗ੍ਰਹਿ ਪੰਨੇ"
-
-#: static/js/impala/stats/csv_keys.js:77
-msgid "Collections"
-msgstr "ਸੰਗ੍ਰਹਿ"
-
-#: static/js/impala/stats/csv_keys.js:78 static/js/impala/stats/csv_keys.js:79
-msgid "Category Landing Featured Carousel"
-msgstr "ਸੰਗ੍ਰਹਿ ਭੂਮੀ ਗੁਣ ਝੂਲਣਾ"
-
-#: static/js/impala/stats/csv_keys.js:80 static/js/impala/stats/csv_keys.js:81
-msgid "Category Landing Top Rated"
-msgstr "ਚੋਟੀ ਦੀ ਰੇਟਿੰਗ ਵਿੱਚ ਆਉਂਦੇ ਸੰਗ੍ਰਹਿ"
-
-#: static/js/impala/stats/csv_keys.js:82 static/js/impala/stats/csv_keys.js:83
-msgid "Category Landing Most Popular"
-msgstr "ਸੱਭ ਤੋਂ ਮਸ਼ਹੂਰ ਵਿੱਚ ਆਉਂਦੇ ਸੰਗ੍ਰਹਿ"
-
-#: static/js/impala/stats/csv_keys.js:84 static/js/impala/stats/csv_keys.js:85
-msgid "Category Landing Recently Added"
-msgstr "ਤਾਜਾ ਸ਼ਾਮਿਲ ਲੈਂਡਿੰਗ ਸ਼੍ਰੈਣੀ"
-
-#: static/js/impala/stats/csv_keys.js:86 static/js/impala/stats/csv_keys.js:87
-msgid "Browse Listing Featured Sort"
-msgstr "ਗੁਣ ਕਿਸਮ ਸੂਚੀ ਬਣਾਓ"
-
-#: static/js/impala/stats/csv_keys.js:88 static/js/impala/stats/csv_keys.js:89
-msgid "Browse Listing Users Sort"
-msgstr "ਯੂਜਰ ਕਿਸਮ ਸੂਚੀ ਬਣਾਓ"
-
-#: static/js/impala/stats/csv_keys.js:90 static/js/impala/stats/csv_keys.js:91
-msgid "Browse Listing Rating Sort"
-msgstr "ਰੇਟਿੰਗ ਕਿਸਮ ਸੂਚੀ ਬਣਾਓ"
-
-#: static/js/impala/stats/csv_keys.js:92 static/js/impala/stats/csv_keys.js:93
-msgid "Browse Listing Created Sort"
-msgstr "ਰਚਨਾਤਮਿਕ ਕਿਸਮ ਸੂਚੀ ਬਣਾਓ"
-
-#: static/js/impala/stats/csv_keys.js:94 static/js/impala/stats/csv_keys.js:95
-msgid "Browse Listing Name Sort"
-msgstr "ਨਾਮ ਕਿਸਮ ਸੂਚੀ ਬਣਾਓ"
-
-#: static/js/impala/stats/csv_keys.js:96 static/js/impala/stats/csv_keys.js:97
-msgid "Browse Listing Popular Sort"
-msgstr "ਪ੍ਰਸਿੱਧ ਕਿਸਮ ਸੂਚੀ ਬਣਾਓ"
-
-#: static/js/impala/stats/csv_keys.js:98 static/js/impala/stats/csv_keys.js:99
-msgid "Browse Listing Updated Sort"
-msgstr "ਅੱਪਡੇਟ ਕਿਸਮ ਸੂਚੀ ਬਣਾਓ"
-
-#: static/js/impala/stats/csv_keys.js:100 static/js/impala/stats/csv_keys.js:101
-msgid "Browse Listing Up and Coming Sort"
-msgstr "ਸੂਚੀਬੱਧਤਾ ਅਤੇ ਲੜੀਬੱਧਤਾ ਦੀ ਝਲਕ"
-
-#: static/js/impala/stats/csv_keys.js:105
-msgid "Total Amount Contributed"
-msgstr "ਕੁੱਲ ਰਕਮ ਯੋਗਦਾਨ ਪਾਇਆ"
-
-#: static/js/impala/stats/csv_keys.js:106
-msgid "Average Contribution"
-msgstr "ਔਸਤ ਯੋਗਦਾਨ"
-
-#: static/js/impala/stats/csv_keys.js:115
-msgid "Usage"
-msgstr "ਵਰਤੋਂ"
-
-#: static/js/impala/stats/csv_keys.js:118
-msgid "Firefox"
-msgstr "ਫਾਇਰਫਾਕਸ"
-
-#: static/js/impala/stats/csv_keys.js:119
-msgid "Mozilla"
-msgstr "ਮੌਜੀਲਾ"
-
-#: static/js/impala/stats/csv_keys.js:120
-msgid "Thunderbird"
-msgstr "ਥੰਡਰਬਰਡ"
-
-#: static/js/impala/stats/csv_keys.js:121
-msgid "Sunbird"
-msgstr "ਸਨਬਰਡ"
-
-#: static/js/impala/stats/csv_keys.js:122
-msgid "SeaMonkey"
-msgstr "ਸੀਮੌਂਕੀ"
-
-#: static/js/impala/stats/csv_keys.js:123
-msgid "Fennec"
-msgstr "ਫਿੱਨਸ"
-
-#: static/js/impala/stats/csv_keys.js:124
-msgid "Android"
-msgstr "ਐਨਡਰੋਇਡ"
-
-#. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:129
-msgid "Downloads and Daily Users, last {0} days"
-msgstr "ਡਾਊਨਲੋਡ ਅਤੇ ਰੋਜਾਨਾਂ ਯੂਜਰ, ਆਖਰੀ {0} ਦਿਨ"
-
-#. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:131
-msgid "Downloads and Daily Users from {0} to {1}"
-msgstr "{0} ਤੋਂ {1} ਤੱਕ ਡਾਊਨਲੋਡ ਅਤੇ ਰੋਜਾਨਾਂ ਯੂਜਰ"
-
-#. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:135
-msgid "Installs and Daily Users, last {0} days"
-msgstr "ਇੰਸਟਾਲ ਅਤੇ ਰੋਜਾਨਾਂ ਯੂਜਰ, ਆਖਰੀ {0} ਦਿਨ"
-
-#. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:137
-msgid "Installs and Daily Users from {0} to {1}"
-msgstr "{0} ਤੋ {1} ਤੱਕ ਇੰਸਟਾਲ ਅਤੇ ਰੋਜਾਨਾਂ ਯੂਜਰ"
-
-#. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:141
-msgid "Downloads, last {0} days"
-msgstr "ਡਾਊਨਲੋਡ, ਆਖਰੀ {0} ਦਿਨ"
-
-#. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:143
-msgid "Downloads from {0} to {1}"
-msgstr "{0} ਤੋਂ {1} ਤੱਕ ਡਾਊਨਲੋਡ"
-
-#. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:147
-msgid "Daily Users, last {0} days"
-msgstr "ਰੋਜਾਨਾਂ ਯੂਜਰ, ਆਖਰੀ {0} ਦਿਨ"
-
-#. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:149
-msgid "Daily Users from {0} to {1}"
-msgstr "{0} ਤੋਂ {1} ਤੱਕ ਰੋਜਾਨਾਂ ਯੂਜਰ"
-
-#. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:153
-msgid "Applications, last {0} days"
-msgstr "ਐਪਲੀਕੇਸ਼ਨ, ਆਖਰੀ {0} ਦਿਨ"
-
-#. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:155
-msgid "Applications from {0} to {1}"
-msgstr "{0} ਤੋਂ {1} ਤੱਕ ਐਪਲੀਕੇਸ਼ਨ"
-
-#. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:159
-msgid "Platforms, last {0} days"
-msgstr "ਪਲੇਟਫਾਰਮ, ਆਖਰੀ {0} ਦਿਨ"
-
-#. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:161
-msgid "Platforms from {0} to {1}"
-msgstr "{0} ਤੋਂ {1} ਤੱਕ ਪਲੇਟਫਾਰਮ"
-
-#. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:165
-msgid "Languages, last {0} days"
-msgstr "ਭਾਸ਼ਾਵਾਂ, ਆਖਰੀ {0} ਦਿਨ"
-
-#. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:167
-msgid "Languages from {0} to {1}"
-msgstr "{0} ਤੋਂ {1} ਤੱਕ ਭਾਸ਼ਾਵਾਂ"
-
-#. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:171
-msgid "Add-on Versions, last {0} days"
-msgstr "ਐਡ-ਆਨ ਵਰਜਨ, ਆਖਰੀ {0} ਦਿਨ"
-
-#. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:173
-msgid "Add-on Versions from {0} to {1}"
-msgstr "{0} ਤੋਂ {1} ਤੱਕ ਐਡ-ਆਨ ਵਰਜਨ"
-
-#. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:177
-msgid "Add-on Status, last {0} days"
-msgstr "ਐਡ-ਆਨ ਸਥਿਤੀ, ਆਖਰੀ {0} ਦਿਨ"
-
-#. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:179
-msgid "Add-on Status from {0} to {1}"
-msgstr "{0} ਤੋਂ {1} ਤੱਕ ਐਡ-ਆਨ ਸਥਿਤੀ"
-
-#. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:183
-msgid "Download Sources, last {0} days"
-msgstr "ਡਾਊਨਲੋਡ ਸਰੋਤ, ਆਖਰੀ {0} ਦਿਨ"
-
-#. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:185
-msgid "Download Sources from {0} to {1}"
-msgstr "{0} ਤੋਂ {1} ਤੱਕ ਡਾਊਨਲੋਡ ਸਰੋਤ"
-
-#. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:189
-msgid "Contributions, last {0} days"
-msgstr "ਪਿਛਲੇ {0} ਦਿਨ, ਯੋਗਦਾਨ"
-
-#. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:191
-msgid "Contributions from {0} to {1}"
-msgstr "{0} ਤੋਂ {1} ਤੱਕ ਯੋਗਦਾਨ"
-
-#. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:195
-msgid "Site Metrics, last {0} days"
-msgstr "ਪਿਛਲੇ {0} ਦਿਨ, ਸਾਈਟ ਮੈਟ੍ਰਿਕਸ"
-
-#. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:197
-msgid "Site Metrics from {0} to {1}"
-msgstr "ਵਲੋ ਸਾਈਟ ਬਿਓਰਾ {0} ਤੋ {1}"
-
-#. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:201
-msgid "Add-ons in Use, last {0} days"
-msgstr "ਅੈਡ-ਓਨ ਵਰਤੋ ਵਿੱਚ, ਆਖਰੀ {0} ਦਿਨ"
-
-#. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:203
-msgid "Add-ons in Use from {0} to {1}"
-msgstr "ਐਡ-ਆਨ ਵਰਤੋ ਵਿਚ {0} ਤੋਂ {1}"
-
-#. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:207
-msgid "Add-ons Downloaded, last {0} days"
-msgstr "ਆਖਰੀ {0} ਦਿਨ,ਐਡ-ਆਨ ਡਾਊਨਲੋਡ ਹੋਏ,"
-
-#. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:209
-msgid "Add-ons Downloaded from {0} to {1}"
-msgstr "ਐਡ-ਆਨ {0} ਤੋਂ {1} ਤੱਕ ਡਾਊਨਲੋਡ ਹੋਇਆ"
-
-#. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:213
-msgid "Add-ons Created, last {0} days"
-msgstr "ਆਖਰੀ {0} ਦਿਨ, ਅੈਡ-ਓਨ ਰਚੇ ਗਏ"
-
-#. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:215
-msgid "Add-ons Created from {0} to {1}"
-msgstr "{0} ਤੋਂ {1} ਵਲੋ ਐਡ-ਆਨ ਬਣਾਓ"
-
-#. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:219
-msgid "Add-ons Updated, last {0} days"
-msgstr " ਆਖਰੀ {0} ਦਿਨ, ਐਡ-ਆਨ ਅੱਪਡੇਟ"
-
-#. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:221
-msgid "Add-ons Updated from {0} to {1}"
-msgstr "{0} ਤੋਂ {1} ਵਿੱਚੋਂ ਐਡ-ਆਨ ਅੱਪਡੇਟ"
-
-#. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:225
-msgid "Reviews Written, last {0} days"
-msgstr " ਆਖਰੀ {0} ਦਿਨ, ਲਿਖਤੀ ਸਮੀਖਿਅਕ"
-
-#. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:227
-msgid "Reviews Written from {0} to {1}"
-msgstr "{0} ਤੋਂ {1} ਤੱਕ ਲਿਖਤੀ ਸਮੀਖਿਅਕ"
-
-#. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:231
-msgid "User Signups, last {0} days"
-msgstr "ਪਿਛਲੇ {0} ਦਿਨ, ਯੂਜਰ ਸਾਈਨ ਅੱਪ"
-
-#. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:233
-msgid "User Signups from {0} to {1}"
-msgstr "{0} ਤੋਂ {1} ਤੱਕ ਯੂਜਰ ਸਾਈਨ ਅੱਪ"
-
-#. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:237
-msgid "Collections Created, last {0} days"
-msgstr "ਪਿਛਲੇ {0} ਦਿਨ, ਭੰਡਾਰ ਬਣਾਏ"
-
-#. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:239
-msgid "Collections Created from {0} to {1}"
-msgstr "{0} ਤੋਂ {1} ਤੱਕ ਬਣਾਏ ਭੰਡਾਰ"
-
-#. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:243
-msgid "Subscribers, last {0} days"
-msgstr "ਪਿਛਲੇ {0} ਦਿਨ, ਗਾਹਕ"
-
-#. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:245
-msgid "Subscribers from {0} to {1}"
-msgstr "{0} ਤੋਂ {1} ਤੱਕ ਗਾਹਕ"
-
-#. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:249
-msgid "Ratings, last {0} days"
-msgstr "ਪਿਛਲੇ {0} ਦਿਨ, ਰੇਟਿੰਗ"
-
-#. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:251
-msgid "Ratings from {0} to {1}"
-msgstr "{0} ਤੋਂ {1} ਤੱਕ ਰੇਟਿੰਗ"
-
-#. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:255
-msgid "Sales, last {0} days"
-msgstr "ਆਖਰੀ {0} ਦਿਨ, ਵਿਕਰੀ"
-
-#. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:257
-msgid "Sales from {0} to {1}"
-msgstr "{0} ਤੋਂ {1} ਵਿੱਚੋਂ ਵਿਕਰੀ"
-
-#. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:261
-msgid "Installs, last {0} days"
-msgstr "ਆਖਰੀ {0} ਦਿਨ, ਇੰਸਟਾਲ"
-
-#. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:263
-msgid "Installs from {0} to {1}"
-msgstr "{0} ਤੋਂ {1} ਵੱਲੋਂ ਇੰਸਟਾਲ"
-
-#. L10n: {0} and {1} are integers.
-#: static/js/impala/stats/csv_keys.js:269
-msgid "<b>{0}</b> in last {1} days"
-msgstr "<b>{0}</b> ਆਖਰ ਵਿੱਚ {1} ਦਿਨ"
-
-#. L10n: {0} is an integer and {1} and {2} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:271 static/js/impala/stats/csv_keys.js:277
-msgid "<b>{0}</b> from {1} to {2}"
-msgstr "<b>{0}</b> ਵੱਲੋਂ {1} ਤੋਂ {2}"
-
-#. L10n: {0} and {1} are integers.
-#: static/js/impala/stats/csv_keys.js:275
-msgid "<b>{0}</b> average in last {1} days"
-msgstr "<b>{0}</b>ਅੌਸਤ ਆਖਰੀ {1} ਦਿਨਾਂ ਵਿਚ"
-
-#: static/js/impala/stats/overview.js:19
-msgid "No data available."
-msgstr "ਕੋਈ ਡਾਟਾ ਮੌਜ਼ੂਦ ਨਹੀ"
-
-#: static/js/impala/stats/table.js:74
-msgid "Date"
-msgstr "ਤਾਰੀਖ"
-
-#: static/js/impala/stats/topchart.js:96
-msgid "Other"
-msgstr "ਦੂਜਾ"
-
-#: static/js/zamboni/admin_validation.js:24 static/js/zamboni/devhub.js:1229 static/js/zamboni/editors.js:295
-msgid "Select an application first"
-msgstr "ਪਹਿਲਾਂ ਇੱਕ ਐਪਲੀਕੇਸ਼ਨ ਚੁੱਣੋ"
-
-#: static/js/zamboni/admin_validation.js:51
-msgid "Set {0} add-on to a max version of {1} and email the author."
-msgid_plural "Set {0} add-ons to a max version of {1} and email the authors."
-msgstr[0] "{0} ਐਡ-ਆਨ ਨੂੰ {1} ਦੇ ਮੈਕਸ ਵਰਜਨ ਤੇ ਸੈੱਟ ਕਰੋ ਅਤੇ ਲੇਖਕ ਨੂੰ ਈਮੇਲ ਕਰੋ।"
-msgstr[1] "{0} ਐਡ-ਆਨਾਂ ਨੂੰ {1} ਦੇ ਮੈਕਸ ਵਰਜਨ ਤੇ ਸੈੱਟ ਕਰੋ ਅਤੇ ਲੇਖਕਾਂ ਨੂੰ ਈਮੇਲ ਕਰੋ।"
-
-#: static/js/zamboni/admin_validation.js:54
-msgid "Email author of {2} add-on which failed validation."
-msgid_plural "Email authors of {2} add-ons which failed validation."
-msgstr[0] "ਪ੍ਰਮਾਣਿਕਤਾ ਵਿੱਚ ਫ਼ੇਲ੍ਹ ਹੋਏ {2} ਐਡ-ਆਨ ਦੇ ਲੇਖਕ ਨੂੰ ਈਮੇਲ ਕਰੋ।"
-msgstr[1] "ਪ੍ਰਮਾਣਿਕਤਾ ਵਿੱਚ ਫ਼ੇਲ੍ਹ ਹੋਏ {2} ਐਡ-ਆਨਾਂ ਦੇ ਲੇਖਕਾਂ ਨੂੰ ਈਮੇਲ ਕਰੋ।"
+#: static/js/common-all.js:1426 static/js/impala-all.js:1511 static/js/zamboni/discovery-all.js:12598 static/js/zamboni/init.js:28 static/js/zamboni/mobile-all.js:14945
+msgid "This feature is temporarily disabled while we perform website maintenance. Please check back a little later."
+msgstr "ਇਹ ਫ਼ੀਚਰ ਅਸਥਾਈ ਤੌਰ ਤੇ ਬੰਦ ਹੈ,ਜਦ ਤੱਕ ਅਸੀ ਵੈਬਸਾਈਟ ਚ ਸੁਧਾਰ ਕਰ ਰਹੇ ਹਾਂ । ਕਿਰਪਾ ਕਰਕੇ ਕੁਝ ਚਿਰ ਬਾਅਦ ਪੜਤਾਲ ਕਰੋ ।"
 
 #. L10n: {0} is an app name like Firefox.
-#: static/js/zamboni/buttons.js:66
+#: static/js/common-all.js:1837 static/js/impala-all.js:1922 static/js/zamboni/buttons.js:73 static/js/zamboni/discovery-all.js:13108
 msgid "Accept and Install"
 msgstr "ਸਵੀਕਾਰ ਕਰੋ ਅਤੇ ਇੰਸਟਾਲ ਕਰੋ"
 
-#: static/js/zamboni/buttons.js:66
+#: static/js/common-all.js:1837 static/js/impala-all.js:1922 static/js/zamboni/buttons.js:73 static/js/zamboni/discovery-all.js:13108
 msgid "Add to {0}"
 msgstr "ਸ਼ਾਮਲ ਕਰਨ ਲਈ {0}"
 
-#: static/js/zamboni/buttons.js:71
+#: static/js/common-all.js:1842 static/js/impala-all.js:1927 static/js/zamboni/buttons.js:78 static/js/zamboni/discovery-all.js:13113
 msgid "Download Now"
 msgstr "ਹੁਣ ਡਾਊਨਲੋਡ ਕਰੋ"
 
-#: static/js/zamboni/buttons.js:112
+#: static/js/common-all.js:1883 static/js/impala-all.js:1968 static/js/zamboni/buttons.js:119 static/js/zamboni/discovery-all.js:13154
 msgid "Add-on has not been updated to support default-to-compatible."
 msgstr "ਮੂਲ ਤੌਰ ਤੇ ਅਨੁਕੂਲਤਾ ਦਾ ਸਹਿਯੋਗ ਕਰਨ ਲਈ ਐਡ-ਆਨ ਅੱਪਡੇਟ ਨਹੀਂ ਕੀਤਾ ਗਿਆ।"
 
-#: static/js/zamboni/buttons.js:117
+#: static/js/common-all.js:1888 static/js/impala-all.js:1973 static/js/zamboni/buttons.js:124 static/js/zamboni/discovery-all.js:13159
 msgid "You need to be using Firefox 10.0 or higher."
 msgstr "ਤੁਹਾਨੂੰ ਫ਼ਾਇਰਫ਼ਾਕਸ 10.0 ਜਾਂ ਅੱਗੇ ਵਰਤੋਂ ਕਰਨ ਦੀ ਜਰੂਰਤ ਹੈ।"
 
-#: static/js/zamboni/buttons.js:129
+#: static/js/common-all.js:1900 static/js/impala-all.js:1985 static/js/zamboni/buttons.js:136 static/js/zamboni/discovery-all.js:13171
 msgid "Mozilla has marked this version as incompatible with your Firefox version."
 msgstr "ਮੌਜੀਲਾ ਨੇ ਇਸ ਵਰਜਨ ਤੇ ਤੁਹਾਡੇ ਫ਼ਾਇਰਫ਼ਾਕਸ ਵਰਜਨ ਨਾਲ ਅਨੁਕੂਲ ਨਾ ਹੋਣ ਦਾ ਨਿਸ਼ਾਨ ਲੱਗਾ ਦਿੱਤਾ।"
 
 #. L10n: {0} is an platform like Windows or Linux.
-#: static/js/zamboni/buttons.js:210
+#: static/js/common-all.js:1981 static/js/impala-all.js:2066 static/js/zamboni/buttons.js:217 static/js/zamboni/discovery-all.js:13252
 msgid "Install for {0} anyway"
 msgstr "ਕਿਸੇ ਵੀ {0} ਲਈ ਇੰਸਟਾਲ"
 
-#: static/js/zamboni/buttons.js:210
+#: static/js/common-all.js:1981 static/js/impala-all.js:2066 static/js/zamboni/buttons.js:217 static/js/zamboni/discovery-all.js:13252
 msgid "Download for {0} anyway"
 msgstr "ਕਿਸੇ ਵੀ {0} ਲਈ ਡਾਊਨਲੋਡ"
 
-#: static/js/zamboni/buttons.js:267
+#: static/js/common-all.js:2038 static/js/impala-all.js:2123 static/js/zamboni/buttons.js:274 static/js/zamboni/discovery-all.js:13309
 msgid "Not available for your platform"
 msgstr "ਤੁਹਾਡੇ ਪਲੇਟਫਾਰਮ ਲਈ ਉਪਲੱਬਧ ਨਹੀਂ"
 
 #. L10n: {0} is an app name, {1} is the app version.
-#: static/js/zamboni/buttons.js:278 static/js/zamboni/buttons.js:315
+#: static/js/common-all.js:2049 static/js/common-all.js:2086 static/js/impala-all.js:2134 static/js/impala-all.js:2171 static/js/zamboni/buttons.js:286 static/js/zamboni/buttons.js:324
+#: static/js/zamboni/discovery-all.js:13320 static/js/zamboni/discovery-all.js:13357
 msgid "Not available for {0} {1}"
 msgstr "{0} {1} ਲਈ ਉਪਲੱਬਧ ਨਹੀਂ"
 
-#: static/js/zamboni/buttons.js:341
+#: static/js/common-all.js:2112 static/js/impala-all.js:2197 static/js/zamboni/buttons.js:351 static/js/zamboni/discovery-all.js:13383
 msgid "Works with {app} {min} - {max}"
 msgstr "{app} {min} - {max} ਦੇ ਨਾਲ ਕੰਮ ਕਰਦਾ ਹੈ"
 
-#: static/js/zamboni/buttons.js:343
+#: static/js/common-all.js:2114 static/js/impala-all.js:2199 static/js/zamboni/buttons.js:353 static/js/zamboni/discovery-all.js:13385
 msgid "View other versions"
 msgstr "ਹੋਰ ਵਰਜਨ ਦੇਖੋ"
 
-#: static/js/zamboni/buttons.js:391
+#: static/js/common-all.js:2162 static/js/impala-all.js:2247 static/js/zamboni/buttons.js:401 static/js/zamboni/discovery-all.js:13433
 msgid "Only with Firefox — Get Firefox Now!"
 msgstr ""
 
-#: static/js/zamboni/buttons.js:507 static/js/zamboni/mobile/buttons.js:43
+#: static/js/common-all.js:2278 static/js/impala-all.js:2363 static/js/zamboni/buttons.js:517 static/js/zamboni/discovery-all.js:13549 static/js/zamboni/mobile-all.js:15177
+#: static/js/zamboni/mobile/buttons.js:43
 msgid "Sorry, you need a Mozilla-based browser (such as Firefox) to install a search plugin."
 msgstr "ਖਿਮਾ ਕਰੋ, ਤੁਹਾਨੂੰ ਖੋਜ ਪਲੱਗਇਨ ਨੂੰ ਇੰਸਟਾਲ ਕਰਨ ਲਈ ਮੌਜੀਲਾ-ਅਧਾਰਿਤ ਬਰਾਊਜ਼ਰ ਦੀ ਲੋੜ ਹੈ।"
 
-#: static/js/zamboni/collections.js:229
-msgid "Adding to Favorites&hellip;"
-msgstr "ਪਸੰਦ ਜੋੜ ਰਿਹਾ &hellip;                "
-
-#: static/js/zamboni/collections.js:232
-msgid "Removing Favorite&hellip;"
-msgstr "ਪਸੰਦੀਦਾ ਹਟਾ ਰਿਹਾ&hellip;"
-
-#: static/js/zamboni/collections.js:235
-msgid "Add to Favorites"
-msgstr "ਪਸੰਦ ਵਿਚ ਸ਼ਾਮਲ ਕਰੋ"
-
-#: static/js/zamboni/collections.js:238
-msgid "Remove from Favorites"
-msgstr "ਪਸੰਦ ਵਿਚੋਂ ਹਟਾਓ"
-
-#: static/js/zamboni/collections.js:303
-msgid "Pending"
-msgstr "ਬਕਾਇਆ"
-
-#: static/js/zamboni/collections.js:304
-msgid "Add a comment"
-msgstr "ਕਾਮੈਂਟ ਸ਼ਾਮਲ"
-
-#: static/js/zamboni/collections.js:304
-msgid "Comment"
-msgstr "ਕਾਮੈਂਟ"
-
-#: static/js/zamboni/collections.js:305
-msgid "Remove this add-on from the collection"
-msgstr "ਭੰਡਾਰ ਵਿੱਚੋਂ ਇਹ ਐਡ-ਆਨ ਹਟਾਓ"
-
-#: static/js/zamboni/collections.js:305 static/js/zamboni/collections.js:334
-msgid "Remove"
-msgstr "ਹਟਾਓ"
-
-#: static/js/zamboni/collections.js:334
-msgid "Remove this user as a contributor"
-msgstr "ਇਸ ਯੂਜਰ ਨੂੰ ਯੋਗਦਾਨ ਦੇ ਤੌਰ ਤੇ ਹਟਾਓ"
-
-#: static/js/zamboni/collections.js:346
-msgid "An email address is required."
-msgstr "ਇੱਕ ਈਮੇਲ ਐੱਡਰੈਸ ਦੀ ਜਰੂਰਤ ਹੈ।"
-
-#: static/js/zamboni/collections.js:364
-msgid "You cannot add yourself as a contributor."
-msgstr "ਹਟਾਓ"
-
-#: static/js/zamboni/collections.js:366
-msgid "You have already added that user."
-msgstr "ਤੁਸੀ ਇਸ ਯੂਜਰ ਨੂੰ ਪਹਿਲਾਂ ਹੀ ਸ਼ਾਮਲ ਕਰ ਚੁੱਕੇ ਹੋ"
-
-#: static/js/zamboni/collections.js:573
-msgid "Add to favorites"
-msgstr "ਪਸੰਦ ਵਿੱਚ ਸ਼ਾਮਿਲ ਕਰੋ"
-
-#: static/js/zamboni/collections.js:577
-msgid "Remove from favorites"
-msgstr "ਪਸੰਦ ਵਿੱਚੋਂ ਹਟਾਓ"
-
-#: static/js/zamboni/collections.js:604
-msgid "Stop following"
-msgstr "ਨਿਮਨ ਲਿਖਤ ਰੋਕੋ"
-
-#: static/js/zamboni/devhub.js:110
-msgid "Your browser does not support the video tag"
-msgstr "ਤੁਹਾਡਾ ਬਰਾਊਜਰ ਵੀਡੀਓ ਟੈਗ ਦਾ ਸਮਰਥਨ ਨਹੀ ਕਰਦਾ"
-
-#: static/js/zamboni/devhub.js:371
-msgid "Changes Saved"
-msgstr "ਬਦਲਾਅ ਸੰਭਾਲੇ"
-
-#: static/js/zamboni/devhub.js:387
-msgid "Enter a new author's email address"
-msgstr "ਨਵੇ ਲੇੇਖਕ ਦਾ ਈ-ਮੇਲ ਪਤਾ ਦਰਜ ਕਰੋ"
-
-#: static/js/zamboni/devhub.js:536
-msgid "There was an error uploading your file."
-msgstr "ਤੁਹਾਡੀ ਫਾਈਲ ਨੂੰ ਅੱਪਲੋਡ ਕਰਨ ਦੌਰਾਨ ਇੱਕ ਗਲਤੀ ਆਈ ਸੀ।"
-
-#: static/js/zamboni/devhub.js:681
-msgid "{files} file"
-msgid_plural "{files} files"
-msgstr[0] "{files} ਫਾਈਲ"
-msgstr[1] "{files} ਫਾਈਲਾਂ"
-
-#: static/js/zamboni/devhub.js:684
-msgid "{reviews} user review"
-msgid_plural "{reviews} user reviews"
-msgstr[0] "{reviews} ਉਪਭੋਗੀ ਸਮੀਖਿਆ"
-msgstr[1] "{reviews} ਉਪਭੋਗੀ ਸਮੀਖਿਆਵਾਂ"
-
-#: static/js/zamboni/devhub.js:796
-msgid "Learn more"
-msgstr "ਹੋਰ ਜਾਣੋ"
-
-#: static/js/zamboni/devhub.js:800
-msgid "Example"
-msgstr "ਉਦਾਹਰਨ"
-
-#: static/js/zamboni/devhub.js:1130
-msgid "Image changes being processed"
-msgstr "ਚਿੱਤਰ ਬਦਲਾਓ ਕਾਰਵਾਈ ਕੀਤੀ ਜਾ ਰਹੀ ਹੈ"
-
-#: static/js/zamboni/devhub.js:1280
-msgid "Must be a valid e-mail address."
-msgstr "ਈ-ਮੇਲ ਐਡਰੈੱਸ ਸਹੀ ਹੋਣਾ ਚਾਹੀਦਾ ਹੈ।"
-
-#: static/js/zamboni/devhub_search.js:8
-msgid "No results found."
-msgstr "ਕੋਈ ਨਤੀਜਾ ਨਹੀਂ ਮਿਲਿਆ।"
-
-#: static/js/zamboni/editors.js:121
-msgid "{name} was viewing this page first."
-msgstr "{name} ਇਹ ਸਫਾ ਪਹਿਲਾਂ ਦੇਖਿਆ ਸੀ।"
-
-#: static/js/zamboni/editors.js:171
-msgid "Receipt checked by app."
-msgstr "ਰਸ਼ੀਦ ਐਪ ਦੁਆਰਾ ਚੈੱਕ।"
-
-#: static/js/zamboni/editors.js:173
-msgid "Receipt was not checked by app."
-msgstr "ਰਸ਼ੀਦ ਐਪ ਦੁਆਰਾ ਚੈੱਕ ਨਹੀਂ ਕੀਤੀ ਸੀ।"
-
-#: static/js/zamboni/editors.js:244
-msgid "{name} was viewing this add-on first."
-msgstr "{name} ਇਹ ਐਡ-ਆਨ ਪਹਿਲਾਂ ਦੇਖਿਆ ਸੀ।"
-
-#: static/js/zamboni/editors.js:255
-msgid "Loading&hellip;"
-msgstr "&hellip; ਲ੍ਹੋਡ ਕੀਤਾ ਜਾ ਰਿਹਾ"
-
-#: static/js/zamboni/editors.js:260
-msgid "Version Notes"
-msgstr "ਸੂਚਨਾਂ ਵਰਜਨ"
-
-#: static/js/zamboni/editors.js:265
-msgid "Notes for Reviewers"
-msgstr "ਸਮੀਖਿਅਕ ਲਈ ਸੂਚਨਾਂ"
-
-#: static/js/zamboni/editors.js:270
-msgid "No version notes found"
-msgstr "ਵਰਜਨ ਨੂੰ ਨੋਟਿਸ ਨਹੀਂ ਮਿਲਿਆ"
-
-#: static/js/zamboni/editors.js:330
-msgid "Average Reviews"
-msgstr "ਔਸਤ ਸਮੀਖਿਆ"
-
-#: static/js/zamboni/editors.js:386
-msgid "Number of Reviews"
-msgstr "ਨੰਬਰ ਵਿੱਚੋਂ ਸਮੀਖਿਆ"
-
-#: static/js/zamboni/editors.js:445
-msgid "Error loading translation"
-msgstr "ਲ੍ਹੋਡ ਕਰਨ ਦੌਰਾਨ ਅਨੁਵਾਦ ਗਲਤੀ"
-
-#: static/js/zamboni/files.js:411 static/js/zamboni/validator.js:261
-msgid "Ignore this message in future updates"
-msgstr ""
-
-#: static/js/zamboni/files.js:417 static/js/zamboni/validator.js:284
-msgid "Severity for automated signing:"
-msgstr ""
-
-#: static/js/zamboni/global.js:410
+#: static/js/common-all.js:9088 static/js/impala-all.js:9649 static/js/zamboni/global.js:410
 msgid "Loading..."
 msgstr "ਲੋਡ ਹੋ ਰਿਹਾ ਹੈ..."
 
 #. L10n: {0} is the number of characters left.
-#: static/js/zamboni/global.js:474
+#: static/js/common-all.js:9152 static/js/impala-all.js:9713 static/js/zamboni/global.js:474
 msgid "<b>{0}</b> character left."
 msgid_plural "<b>{0}</b> characters left."
 msgstr[0] "<b>{0}</b> ਅੱਖਰ ਖੱਬੇ."
 msgstr[1] "<b>{0}</b> ਅੱਖਰ ਖੱਬੇ."
 
-#: static/js/zamboni/init.js:28
-msgid "This feature is temporarily disabled while we perform website maintenance. Please check back a little later."
-msgstr "ਇਹ ਫ਼ੀਚਰ ਅਸਥਾਈ ਤੌਰ ਤੇ ਬੰਦ ਹੈ,ਜਦ ਤੱਕ ਅਸੀ ਵੈਬਸਾਈਟ ਚ ਸੁਧਾਰ ਕਰ ਰਹੇ ਹਾਂ । ਕਿਰਪਾ ਕਰਕੇ ਕੁਝ ਚਿਰ ਬਾਅਦ ਪੜਤਾਲ ਕਰੋ ।"
+#: static/js/common-all.js:9589 static/js/common-min.js:6 static/js/impala-all.js:10052 static/js/impala-min.js:6 static/js/common/ratingwidget.js:31 static/js/zamboni/mobile-all.js:16123
+#: static/js/zamboni/mobile-min.js:6
+msgid "{0} star"
+msgid_plural "{0} stars"
+msgstr[0] "{0} ਤਾਰਾ"
+msgstr[1] "{0} ਤਾਰੇ"
 
-#: static/js/zamboni/l10n.js:45
+#: static/js/common-all.js:9676 static/js/common-min.js:6 static/js/impala-all.js:10139 static/js/impala-min.js:6 static/js/zamboni/l10n.js:45
 msgid "Remove this localization"
 msgstr "ਇਹ ਸਥਾਨੀਕਰਨ ਹਟਾਓ"
 
-#: static/js/zamboni/password-strength.js:20
+#: static/js/common-all.js:10193 static/js/common-min.js:6 static/js/impala-all.js:10674 static/js/impala-min.js:6 static/js/zamboni/discovery-all.js:13678
+msgid "close"
+msgstr ""
+
+#: static/js/common-all.js:10860 static/js/common-min.js:6 static/js/impala-all.js:11481 static/js/impala-min.js:6 static/js/impala/reviews.js:23 static/js/zamboni/reviews.js:18
+msgid "Flagged for review"
+msgstr "ਸਮੀਖਿਆ ਲਈ ਫਲੈਗ ਕੀਤਾ"
+
+#: static/js/common-all.js:10876 static/js/common-min.js:6 static/js/impala-all.js:11498 static/js/impala-min.js:6 static/js/impala/reviews.js:40 static/js/zamboni/reviews.js:34
+msgid "Your input is required"
+msgstr "ਤੁਹਾਡੇ ਇਨਪੁੱਟ ਦੀ ਲੋੜ ਹੈ"
+
+#: static/js/common-all.js:10945 static/js/common-min.js:6 static/js/impala-all.js:11610 static/js/impala-min.js:7 static/js/impala/reviews.js:152 static/js/zamboni/reviews.js:103
+msgid "Marked for deletion"
+msgstr "ਹਟਾਉਣ ਲਈ ਮਾਰਕ ਕੀਤਾ"
+
+#: static/js/common-all.js:11573 static/js/common-min.js:7 static/js/impala-all.js:13809 static/js/impala-min.js:8 static/js/zamboni/collections.js:229
+msgid "Adding to Favorites&hellip;"
+msgstr "ਪਸੰਦ ਜੋੜ ਰਿਹਾ &hellip;                "
+
+#: static/js/common-all.js:11576 static/js/common-min.js:7 static/js/impala-all.js:13812 static/js/impala-min.js:8 static/js/zamboni/collections.js:232
+msgid "Removing Favorite&hellip;"
+msgstr "ਪਸੰਦੀਦਾ ਹਟਾ ਰਿਹਾ&hellip;"
+
+#: static/js/common-all.js:11579 static/js/common-min.js:7 static/js/impala-all.js:13815 static/js/impala-min.js:8 static/js/zamboni/collections.js:235
+msgid "Add to Favorites"
+msgstr "ਪਸੰਦ ਵਿਚ ਸ਼ਾਮਲ ਕਰੋ"
+
+#: static/js/common-all.js:11582 static/js/common-min.js:7 static/js/impala-all.js:13818 static/js/impala-min.js:8 static/js/zamboni/collections.js:238
+msgid "Remove from Favorites"
+msgstr "ਪਸੰਦ ਵਿਚੋਂ ਹਟਾਓ"
+
+#: static/js/common-all.js:11647 static/js/common-min.js:7 static/js/impala-all.js:13883 static/js/impala-min.js:8 static/js/zamboni/collections.js:303
+msgid "Pending"
+msgstr "ਬਕਾਇਆ"
+
+#: static/js/common-all.js:11648 static/js/common-min.js:7 static/js/impala-all.js:13884 static/js/impala-min.js:8 static/js/zamboni/collections.js:304
+msgid "Add a comment"
+msgstr "ਕਾਮੈਂਟ ਸ਼ਾਮਲ"
+
+#: static/js/common-all.js:11648 static/js/common-min.js:7 static/js/impala-all.js:13884 static/js/impala-min.js:8 static/js/zamboni/collections.js:304
+msgid "Comment"
+msgstr "ਕਾਮੈਂਟ"
+
+#: static/js/common-all.js:11649 static/js/common-min.js:7 static/js/impala-all.js:13885 static/js/impala-min.js:8 static/js/zamboni/collections.js:305
+msgid "Remove this add-on from the collection"
+msgstr "ਭੰਡਾਰ ਵਿੱਚੋਂ ਇਹ ਐਡ-ਆਨ ਹਟਾਓ"
+
+#: static/js/common-all.js:11649 static/js/common-all.js:11678 static/js/common-min.js:7 static/js/impala-all.js:13885 static/js/impala-all.js:13914 static/js/impala-min.js:8
+#: static/js/zamboni/collections.js:305 static/js/zamboni/collections.js:334
+msgid "Remove"
+msgstr "ਹਟਾਓ"
+
+#: static/js/common-all.js:11678 static/js/common-min.js:7 static/js/impala-all.js:13914 static/js/impala-min.js:8 static/js/zamboni/collections.js:334
+msgid "Remove this user as a contributor"
+msgstr "ਇਸ ਯੂਜਰ ਨੂੰ ਯੋਗਦਾਨ ਦੇ ਤੌਰ ਤੇ ਹਟਾਓ"
+
+#: static/js/common-all.js:11690 static/js/common-min.js:7 static/js/impala-all.js:13926 static/js/impala-min.js:8 static/js/zamboni/collections.js:346
+msgid "An email address is required."
+msgstr "ਇੱਕ ਈਮੇਲ ਐੱਡਰੈਸ ਦੀ ਜਰੂਰਤ ਹੈ।"
+
+#: static/js/common-all.js:11708 static/js/common-min.js:7 static/js/impala-all.js:13944 static/js/impala-min.js:8 static/js/zamboni/collections.js:364
+msgid "You cannot add yourself as a contributor."
+msgstr "ਹਟਾਓ"
+
+#: static/js/common-all.js:11710 static/js/common-min.js:7 static/js/impala-all.js:13946 static/js/impala-min.js:8 static/js/zamboni/collections.js:366
+msgid "You have already added that user."
+msgstr "ਤੁਸੀ ਇਸ ਯੂਜਰ ਨੂੰ ਪਹਿਲਾਂ ਹੀ ਸ਼ਾਮਲ ਕਰ ਚੁੱਕੇ ਹੋ"
+
+#: static/js/common-all.js:11917 static/js/common-min.js:7 static/js/impala-all.js:14153 static/js/impala-min.js:8 static/js/zamboni/collections.js:573
+msgid "Add to favorites"
+msgstr "ਪਸੰਦ ਵਿੱਚ ਸ਼ਾਮਿਲ ਕਰੋ"
+
+#: static/js/common-all.js:11921 static/js/common-min.js:7 static/js/impala-all.js:14157 static/js/impala-min.js:8 static/js/zamboni/collections.js:577
+msgid "Remove from favorites"
+msgstr "ਪਸੰਦ ਵਿੱਚੋਂ ਹਟਾਓ"
+
+#: static/js/common-all.js:11939 static/js/common-min.js:7 static/js/impala-all.js:14175 static/js/impala-all.js:14233 static/js/impala-min.js:8 static/js/impala/collections.js:10
+#: static/js/zamboni/collections.js:595
+msgid "Follow this Collection"
+msgstr "ਇਸ ਸੰਗ੍ਰਹਿ ਦਾ ਸਮਰਥਨ ਕਰੋ"
+
+#: static/js/common-all.js:11948 static/js/common-min.js:7 static/js/impala-all.js:14184 static/js/impala-min.js:8 static/js/zamboni/collections.js:604
+msgid "Stop following"
+msgstr "ਨਿਮਨ ਲਿਖਤ ਰੋਕੋ"
+
+#: static/js/common-all.js:12096 static/js/common-min.js:7 static/js/zamboni/password-strength.js:20
 msgid "Password strength:"
 msgstr "ਪਾਸਵਰਡ ਤਾਕਤ"
 
-#: static/js/zamboni/password-strength.js:26
+#: static/js/common-all.js:12102 static/js/common-min.js:7 static/js/zamboni/password-strength.js:26
 msgid "At least {0} character left."
 msgid_plural "At least {0} characters left."
 msgstr[0] "ਘੱਟੋ ਤੋਂ ਘੱਟ {0} ਅੱਖਰ ਬਾਕੀ।"
 msgstr[1] "ਘੱਟੋ ਤੋਂ ਘੱਟ {0} ਅੱਖਰ ਬਾਕੀ।"
 
-#: static/js/zamboni/themes_review.js:176
-msgid "Requested Info"
-msgstr "ਜਾਣਕਾਰੀ ਲਈ ਬੇਨਤੀ"
+#: static/js/common-all.js:12286 static/js/common-min.js:7 static/js/impala-all.js:14632 static/js/impala-min.js:8 static/js/impala/suggestions.js:39
+msgid "Search themes for <b>{0}</b>"
+msgstr "<b>{0}</b> ਲਈ ਥੀਮ ਖੋਜੋ"
 
-#: static/js/zamboni/themes_review.js:177
-msgid "Flagged"
-msgstr "ਫਲੈਗ ਕੀਤੇ ਹੋਏ"
+#: static/js/common-all.js:12288 static/js/common-min.js:7 static/js/impala-all.js:14634 static/js/impala-min.js:8 static/js/impala/suggestions.js:41
+msgid "Search apps for <b>{0}</b>"
+msgstr "<b>{0}</b> ਲਈ ਐਪ ਖੋਜੋ"
 
-#: static/js/zamboni/themes_review.js:178
-msgid "Duplicate"
-msgstr "ਨਕਲੀ"
+#: static/js/common-all.js:12290 static/js/common-min.js:7 static/js/impala-all.js:14636 static/js/impala-min.js:8 static/js/impala/suggestions.js:43
+msgid "Search add-ons for <b>{0}</b>"
+msgstr "<b>{0}</b> ਲਈ ਐਡ-ਆਨ ਖੋਜੋ"
 
-#: static/js/zamboni/themes_review.js:179
-msgid "Rejected"
-msgstr "ਰੱਦ ਕਰੋ"
+#: static/js/common-all.js:12521 static/js/common-min.js:7 static/js/impala-all.js:14867 static/js/impala-min.js:8 static/js/impala/site_suggestions.js:46
+msgid "Category"
+msgstr "ਕੈਟਾਗਿਰੀ"
 
-#: static/js/zamboni/themes_review.js:180
-msgid "Approved"
-msgstr "ਮੰਨਜੂਰੀ ਦੇਣਾ"
+#. L10n: {0} is an app name.
+#: static/js/impala-all.js:11632 static/js/impala-min.js:7 static/js/impala/listing.js:11 static/js/zamboni/themes.js:13
+msgid "This theme is incompatible with your version of {0}"
+msgstr "{0} ਦੇ ਤੁਹਾਡੇ ਵਰਜਨ ਨਾਲ ਇਹ ਥੀਮ ਅਨੁਕੂਲ ਨਹੀਂ ਹੈ"
 
-#: static/js/zamboni/themes_review.js:424
-msgid "No results found"
+#: static/js/impala-all.js:12146 static/js/impala-all.js:14331 static/js/impala-min.js:7 static/js/impala-min.js:8 static/js/common/upload-image.js:97 static/js/impala/users.js:51
+#: static/js/zamboni/devhub-all.js:894 static/js/zamboni/devhub-min.js:1
+msgid "Images must be either PNG or JPG."
+msgstr "ਤਸਵੀਰਾਂ PNG ਜਾਂ JPG ਦੋਨਾਂ ਵਿੱਚ ਇੱਕ ਹੋਣੀਆਂ ਚਾਹੀਦੀਆਂ ਹਨ।"
+
+#: static/js/impala-all.js:12150 static/js/impala-min.js:7 static/js/common/upload-image.js:101 static/js/zamboni/devhub-all.js:898 static/js/zamboni/devhub-min.js:1
+msgid "Videos must be in WebM."
+msgstr "ਵੀਡੀਓ WebM ਵਿੱਚ ਹੋਣੀਆਂ ਚਾਹੀਦੀਆਂ ਹਨ।"
+
+#: static/js/impala-all.js:12177 static/js/impala-min.js:7 static/js/common/upload-addon.js:41 static/js/common/upload-image.js:128 static/js/zamboni/devhub-all.js:272
+#: static/js/zamboni/devhub-all.js:925 static/js/zamboni/devhub-min.js:1
+msgid "There was a problem contacting the server."
+msgstr "ਸਰਵਰ ਨਾਲ ਸੰਪਰਕ ਵੇਲੇ ਇੱਕ ਮੁਸ਼ਕਲ ਸੀ।"
+
+#: static/js/impala-all.js:13298 static/js/impala-min.js:7 static/js/impala/persona_creation.js:60
+msgid "All Rights Reserved"
+msgstr "ਸਭ ਹੱਕ ਰਾਖਵੇ ਹਨ"
+
+#: static/js/impala-all.js:13302 static/js/impala-min.js:7 static/js/impala/persona_creation.js:64
+msgid "Creative Commons Attribution 3.0"
+msgstr "ਕਰੀਏਟਿਵ ਕਾਮਨਜ਼ ਐਟਰੀਬਿਊਸ਼ਨ 3.0"
+
+#: static/js/impala-all.js:13307 static/js/impala-min.js:7 static/js/impala/persona_creation.js:69
+msgid "Creative Commons Attribution-NonCommercial 3.0"
+msgstr "ਕਰੀਏਟਿਵ-ਕਾਮਨਜ਼ ਐਟਰੀਬਿਊਸ਼ਨ-ਨਾਨ-ਕਮਰਸ਼ੀਅਲ 3.0"
+
+#: static/js/impala-all.js:13312 static/js/impala-min.js:7 static/js/impala/persona_creation.js:74
+msgid "Creative Commons Attribution-NonCommercial-NoDerivs 3.0"
+msgstr "ਕਰੀਏਟਿਵ ਕਾਮਨਜ਼ ਐਟਰੀਬਿਊਸ਼ਨ-ਨਾਨ ਕਮਰਸ਼ੀਅਲ-ਨੋਨ ਡਰਾਈਵ 3.0"
+
+#: static/js/impala-all.js:13317 static/js/impala-min.js:7 static/js/impala/persona_creation.js:79
+msgid "Creative Commons Attribution-NonCommercial-Share Alike 3.0"
+msgstr "ਕਰੀਏਟਿਵ ਕਾਮਨਜ਼ ਐਟਰੀਬਿਊਸ਼ਨ-ਨਾਨ ਕਮਰਸ਼ੀਅਲ-ਸ਼ੇਅਰ-ਅਲਾਈਕ 3.0"
+
+#: static/js/impala-all.js:13322 static/js/impala-min.js:7 static/js/impala/persona_creation.js:84
+msgid "Creative Commons Attribution-NoDerivs 3.0"
+msgstr "ਕਰੀਏਟਿਵ ਕਾਮਨਜ਼ ਐਟਰੀਬਿਊਸ਼ਨ-ਨੌਨ ਡਰਾਈਵ 3.0"
+
+#: static/js/impala-all.js:13327 static/js/impala-min.js:7 static/js/impala/persona_creation.js:89
+msgid "Creative Commons Attribution-ShareAlike 3.0"
+msgstr "ਕਰੀਏਟਿਵ ਕਾਮਨਜ਼ ਐਟਰੀਬਿਊਸ਼ਨ-ਸੇਅਰ ਅਲਾਈਕ 3.0"
+
+#: static/js/impala-all.js:13530 static/js/impala-min.js:7 static/js/impala/persona_creation.js:292
+msgid "Your Theme's Name"
+msgstr "ਤੁਹਾਡੇ ਥੀਮ ਦਾ ਨਾਮ"
+
+#: static/js/impala-all.js:14242 static/js/impala-min.js:8 static/js/impala/collections.js:19
+msgid "Stop Following"
+msgstr "ਸਮਰਥਨ ਰੋਕੋ"
+
+#: static/js/impala-all.js:14243 static/js/impala-min.js:8 static/js/impala/collections.js:20
+msgid "Following"
+msgstr "ਸਮਰਥਨ ਕਰ ਰਿਹਾ"
+
+#: static/js/impala-all.js:14313 static/js/impala-min.js:8 static/js/impala/users.js:33
+msgid "use original"
+msgstr "ਅਸਲੀ ਵਰਤੋ"
+
+#: static/js/impala-all.js:14523 static/js/impala-min.js:8 static/js/impala/search.js:114
+msgid "Updating results&hellip;"
+msgstr "ਅੱਪਡੇਟ ਨਤੀਜੇ&hellip;"
+
+#: static/js/common/upload-addon.js:69 static/js/zamboni/devhub-all.js:300 static/js/zamboni/devhub-min.js:1
+msgid "Select a file..."
+msgstr "ਇੱਕ ਫਾਈਲ ਚੁਣੋ..."
+
+#: static/js/common/upload-addon.js:70 static/js/zamboni/devhub-all.js:301 static/js/zamboni/devhub-min.js:1
+msgid "Your add-on should end with .xpi, .jar or .xml"
+msgstr "ਤੁਹਾਡਾ ਐਡ-ਆਨ .xpi, .jar ਜਾਂ .xml ਨਾਲ ਖਤਮ ਹੋਣਾ ਚਾਹੀਦਾ"
+
+#. L10n: {0} is the percent of the file that has been uploaded.
+#: static/js/common/upload-addon.js:104 static/js/zamboni/devhub-all.js:335 static/js/zamboni/devhub-min.js:1
+#, fuzzy, python-format
+msgid "{0}% complete"
+msgstr "{0}% ਮੁਕੰਮਲ"
+
+#. L10n: "{bytes uploaded} of {total filesize}".
+#: static/js/common/upload-addon.js:107 static/js/zamboni/devhub-all.js:338 static/js/zamboni/devhub-min.js:1
+msgid "{0} of {1}"
+msgstr "{1} ਵਿੱਚੋਂ {0}"
+
+#: static/js/common/upload-addon.js:140 static/js/zamboni/devhub-all.js:371 static/js/zamboni/devhub-min.js:1
+msgid "Cancel"
+msgstr "ਰੱਦ"
+
+#: static/js/common/upload-addon.js:162 static/js/zamboni/devhub-all.js:393 static/js/zamboni/devhub-min.js:1
+msgid "Uploading {0}"
+msgstr "{0} ਅੱਪਲੋਡ ਹੋ ਰਿਹਾ"
+
+#: static/js/common/upload-addon.js:189 static/js/zamboni/devhub-all.js:420 static/js/zamboni/devhub-min.js:1
+msgid "Error with {0}"
+msgstr "{0} ਨਾਲ ਖਾਮੀ"
+
+#: static/js/common/upload-addon.js:194 static/js/zamboni/devhub-all.js:425 static/js/zamboni/devhub-min.js:1
+msgid "Your add-on failed validation with {0} error."
+msgid_plural "Your add-on failed validation with {0} errors."
+msgstr[0] "ਤੁਹਾਡੇ ਐਡ-ਆਨ ਦੀ {0} ਖਾਮੀ ਨਾਲ ਵੈਧਤਾ ਫ਼ੇਲ੍ਹ ਹੋਈ।"
+msgstr[1] "ਤੁਹਾਡੇ ਐਡ-ਆਨ ਦੀ {0} ਖਾਮੀਆਂ ਨਾਲ ਵੈਧਤਾ ਫ਼ੇਲ੍ਹ ਹੋਈ।"
+
+#: static/js/common/upload-addon.js:208 static/js/zamboni/devhub-all.js:439 static/js/zamboni/devhub-min.js:1
+msgid "&hellip;and {0} more"
+msgid_plural "&hellip;and {0} more"
+msgstr[0] "&hellip;ਅਤੇ {0} ਹੋਰ"
+msgstr[1] "&hellip;ਅਤੇ {0} ਹੋਰ"
+
+#: static/js/common/upload-addon.js:222 static/js/common/upload-addon.js:497 static/js/zamboni/devhub-all.js:453 static/js/zamboni/devhub-all.js:743 static/js/zamboni/devhub-min.js:1
+msgid "See full validation report"
+msgstr "ਪੂਰੀ ਵੈਧਤਾ ਰਿਪੋਰਟ ਵੇਖੋ"
+
+#: static/js/common/upload-addon.js:234 static/js/zamboni/devhub-all.js:465 static/js/zamboni/devhub-min.js:1
+msgid "Validating {0}"
+msgstr "{0} ਵੈਧਤਾ"
+
+#. L10n: first argument is an HTTP status code
+#: static/js/common/upload-addon.js:273 static/js/zamboni/devhub-all.js:504 static/js/zamboni/devhub-min.js:1
+msgid "Received an empty response from the server; status: {0}"
+msgstr "ਸਰਵਰ ਵੱਲੋਂ ਇੱਕ ਖਾਲੀ ਜਵਾਬ ਮਿਲਿਆ; ਸਥਿਤੀ: {0}"
+
+#: static/js/common/upload-addon.js:370 static/js/zamboni/devhub-all.js:604 static/js/zamboni/devhub-min.js:1
+msgid "Unexpected server error while validating."
+msgstr "ਵੈਧਤਾ ਦੌਰਾਨ ਅਚਾਨਕ ਸਰਵਰ ਗਲਤੀ।"
+
+#: static/js/common/upload-addon.js:409 static/js/zamboni/devhub-all.js:643 static/js/zamboni/devhub-min.js:1
+msgid "Finished validating {0}"
+msgstr "{0} ਵੈਧਤਾ ਮੁੰਕਮਲ ਹੋਈ"
+
+#: static/js/common/upload-addon.js:415 static/js/zamboni/devhub-all.js:649 static/js/zamboni/devhub-min.js:1
+msgid "Your add-on validation timed out, it will be manually reviewed."
 msgstr ""
 
-#: static/js/zamboni/themes_review_templates.js:31
-msgid "Theme"
+#: static/js/common/upload-addon.js:418 static/js/zamboni/devhub-all.js:652 static/js/zamboni/devhub-min.js:1
+msgid "Your add-on was validated with no errors and {0} warning."
+msgid_plural "Your add-on was validated with no errors and {0} warnings."
+msgstr[0] ""
+msgstr[1] ""
+
+#: static/js/common/upload-addon.js:423 static/js/zamboni/devhub-all.js:657 static/js/zamboni/devhub-min.js:1
+msgid "Your add-on was validated with no errors and {0} message."
+msgid_plural "Your add-on was validated with no errors and {0} messages."
+msgstr[0] "ਤੁਹਾਡਾ ਐਡ-ਆਨ ਬਿਨਾਂ ਕਿਸੇ ਖ਼ਾਮੀ ਅਤੇ {0} ਸੁਨੇਹੇ ਨਾਲ ਵੈਧ ਹੋਇਆ ਸੀ।"
+msgstr[1] "ਤੁਹਾਡਾ ਐਡ-ਆਨ ਬਿਨਾਂ ਕਿਸੇ ਖ਼ਾਮੀ ਅਤੇ {0} ਸੁਨੇਹਿਆਂ ਨਾਲ ਵੈਧ ਹੋਇਆ ਸੀ।"
+
+#: static/js/common/upload-addon.js:428 static/js/zamboni/devhub-all.js:662 static/js/zamboni/devhub-min.js:1
+msgid "Your add-on was validated with no errors or warnings."
+msgstr "ਤੁਹਾਡਾ ਐਡ-ਆਨ ਬਿਨਾਂ ਕਿਸੇ ਖ਼ਾਮੀਆਂ ਜਾਂ ਚੇਤਾਵਨੀਆਂ ਦੇ ਵੈਧ ਹੋਇਆ ਸੀ।"
+
+#: static/js/common/upload-addon.js:443 static/js/zamboni/devhub-all.js:677 static/js/zamboni/devhub-min.js:1
+msgid "Your submission will be automatically signed."
 msgstr ""
 
-#: static/js/zamboni/themes_review_templates.js:33
-msgid "Reviewer"
+#: static/js/common/upload-addon.js:450 static/js/zamboni/devhub-all.js:696 static/js/zamboni/devhub-min.js:1
+msgid "Include detailed version notes (this can be done in the next step)."
+msgstr "ਵਰਜਨ ਨੋਟਾਂ ਦਾ ਵੇਰਵਾ ਸ਼ਾਮਲ (ਇਹ ਅਗਲੇ ਕਦਮ ਵਿੱਚ ਕੀਤਾ ਜਾ ਸਕਦਾ)।"
+
+#: static/js/common/upload-addon.js:451 static/js/zamboni/devhub-all.js:697 static/js/zamboni/devhub-min.js:1
+msgid "If your add-on requires an account to a website in order to be fully tested, include a test username and password in the Notes to Reviewer (this can be done in the next step)."
+msgstr "ਜੇਕਰ ਤੁਹਾਡੇ ਐਡ-ਆਨ ਨੂੰ ਪੂਰੀ ਪਰਖ ਲਈ ਇੱਕ ਵੈੱਬਸਾਈਟ ਤੇ ਇੱਕ ਖਾਤੇ ਦੀ ਲੋੜ ਹੈ, ਸਮੀਖਿਅਕ ਲਈ ਨੋਟਾਂ ਵਿੱਚ ਇੱਕ ਟੈਸਟ ਵਰਤੋਂਕਾਰ ਅਤੇ ਪਾਸਵਰਡ ਸ਼ਾਮਲ ਕਰੋ (ਇਹ ਅਗਲੇ ਕਦਮ ਵਿੱਚ ਕੀਤਾ ਜਾ ਸਕਦਾ)।"
+
+#: static/js/common/upload-addon.js:452 static/js/zamboni/devhub-all.js:698 static/js/zamboni/devhub-min.js:1
+msgid "If your add-on is intended for a limited audience you should choose Preliminary Review instead of Full Review."
+msgstr "ਜੇਕਰ ਤੁਹਾਡਾ ਐਡ-ਆਨ ਇੱਕ ਸੀਮਿਤ ਜਨਤਾ ਲਈ ਨਿਯਤ ਹੈ ਤੁਹਾਨੂੰ ਮੁਕੰਮਲ ਸਮੀਖਿਆ ਦੀ ਥਾਂ ਸ਼ੁਰੂਆਤੀ ਸਮੀਖਿਆ ਨੂੰ ਚੁਣਨਾ ਚਾਹੀਦਾ ਹੈ।"
+
+#: static/js/common/upload-addon.js:465 static/js/zamboni/devhub-all.js:711 static/js/zamboni/devhub-min.js:1
+msgid "Add-on submission checklist"
+msgstr "ਐਡ-ਆਨ ਦਾਖਲ ਕਾਰਜ ਚੈੱਕਲਿਸਟ"
+
+#: static/js/common/upload-addon.js:466 static/js/zamboni/devhub-all.js:712 static/js/zamboni/devhub-min.js:1
+msgid "Please verify the following points before finalizing your submission. This will minimize delays or misunderstanding during the review process:"
+msgstr "ਆਪਣੇ ਦਾਖਲ ਕਾਰਜ ਨੂੰ ਮੁਕੰਮਲ ਕਰਨ ਤੋਂ ਪਹਿਲਾਂ ਅੱਗੇ ਦਿੱਤੇ ਅੰਕਾਂ ਦੀ ਪੁਸ਼ਟੀ ਕਰੋ। ਇਸ ਨਾਲ ਸਮੀਖਿਆ ਕਾਰਜ ਦੌਰਾਨ ਦੇਰੀ ਅਤੇ ਗਲਤਫ਼ਹਿਮੀ ਘੱਟ ਹੋਵੇਗੀ:"
+
+#: static/js/common/upload-addon.js:468 static/js/zamboni/devhub-all.js:714 static/js/zamboni/devhub-min.js:1
+msgid ""
+"Compiled binaries, as well as minified or obfuscated scripts (excluding known libraries) need to have their sources submitted separately for review. Make sure that you use the source code upload "
+"field to avoid having your submission rejected."
+msgstr ""
+"ਕੰਪਾਇਲਡ ਬਾਇਨਰੀਆਂ, ਨਾਲ ਦੀ ਨਾਲ ਛੋਟੀਆਂ ਜਾਂ ਬੇਕਾਰ ਸਕਰਿਪਟਾਂ (ਜਾਣੂ ਲਾਇਬਰ੍ਰੇਰੀਆਂ ਨੂੰ ਛੱਡ ਕੇ) ਨੂੰ ਸਮੀਖਿਆ ਲਈ ਆਪਣੇ ਸੋਰਸ ਕੋਡਾਂ ਨੂੰ ਵੱਖ ਤੋਂ ਦਾਖਲ ਕਰਨ ਦੀ ਜ਼ਰੂਰਤ ਹੈ। ਇਹ ਯਕੀਨੀ ਬਣਾਓ ਕੀ ਤੁਸੀਂ ਆਪਣੇ ਦਾਖਲ ਕਾਰਜ ਨੂੰ ਰੱਦ ਹੋਣ ਤੋਂ ਬਚਾਉਣ ਲਈ ਸੋਰਸ ਕੋਡ ਅੱਪਲੋਡ ਖੇਤਰ ਦੀ "
+"ਵਰਤੋਂ ਕਰ ਰਹੇ ਹੋ।"
+
+#: static/js/common/upload-addon.js:486 static/js/zamboni/devhub-all.js:732 static/js/zamboni/devhub-min.js:1
+msgid "The validation process found these issues that can lead to rejections:"
+msgstr "ਵੈਧਤਾ ਕਾਰਜ ਨੂੰ ਇਹ ਮਸਲੇ ਲੱਭੇ ਹਨ ਜੋ ਰੱਦ ਹੋਣ ਦਾ ਕਾਰਨ ਬਣ ਸਕਦੇ ਹਨ:"
+
+#: static/js/common/upload-addon.js:503 static/js/zamboni/devhub-all.js:749 static/js/zamboni/devhub-min.js:1
+msgid "If you are unfamiliar with the add-ons review process, you can read about it here."
+msgstr "ਜੇਕਰ ਤੁਸੀਂ ਐਡ-ਆਨ ਸਮੀਖਿਆ ਕਾਰਜ ਤੋਂ ਜਾਣੂ ਨਹੀਂ ਹੋ, ਤੁਸੀਂ ਉਸ ਬਾਰੇ ਇੱਥੇ ਪੜ੍ਹ ਸਕਦੇ ਹੋ।"
+
+#: static/js/common/upload-addon.js:540 static/js/zamboni/devhub-all.js:786 static/js/zamboni/devhub-min.js:1
+msgid "Sorry, no supported platform has been found."
+msgstr "ਮੁਆਫ਼ੀ, ਕੋਈ ਸਹਾਇਕ ਪਲੇਟਫਾਰਮ ਨਹੀਂ ਲੱਭਿਆ।"
+
+#: static/js/common/upload-base.js:57 static/js/zamboni/devhub-all.js:187 static/js/zamboni/devhub-min.js:1
+msgid "The filetype you uploaded isn't recognized."
+msgstr "ਤੁਹਾਨੂੰ ਵੱਲੋਂ ਅੱਪਲੋਡ ਕੀਤੀ ਫ਼ਾਈਲ ਕਿਸਮ ਦੀ ਪਛਾਣ ਨਹੀਂ ਹੋਈ।"
+
+#: static/js/common/upload-base.js:79 static/js/zamboni/devhub-all.js:209 static/js/zamboni/devhub-min.js:1
+msgid "You cancelled the upload."
+msgstr "ਤੁਸੀਂ ਅੱਪਲੋਡ ਨੂੰ ਰੱਦ ਕੀਤਾ।"
+
+#: static/js/impala/stats/chart.js:267 static/js/zamboni/stats-all.js:16898 static/js/zamboni/stats-min.js:5
+msgid "Week of {0}"
+msgstr "{0} ਦਾ ਹਫਤਾ"
+
+#: static/js/impala/stats/chart.js:269 static/js/zamboni/stats-all.js:16900 static/js/zamboni/stats-min.js:5
+msgid " downloads"
 msgstr ""
 
-#: static/js/zamboni/themes_review_templates.js:35
-msgid "Status"
+#: static/js/impala/stats/chart.js:270 static/js/zamboni/stats-all.js:16901 static/js/zamboni/stats-min.js:5
+msgid "{0} users"
+msgstr "{0} ਯੂਜਰ"
+
+#: static/js/impala/stats/chart.js:271 static/js/zamboni/stats-all.js:16902 static/js/zamboni/stats-min.js:5
+msgid "{0} add-ons"
+msgstr "{0} ਐਡ-ਆਨ"
+
+#: static/js/impala/stats/chart.js:272 static/js/zamboni/stats-all.js:16903 static/js/zamboni/stats-min.js:5
+msgid "{0} collections"
+msgstr "{0} ਭੰਡਾਰ"
+
+#: static/js/impala/stats/chart.js:273 static/js/zamboni/stats-all.js:16904 static/js/zamboni/stats-min.js:5
+msgid "{0} reviews"
+msgstr "{0} ਸਮੀਖਿਅਕ"
+
+#: static/js/impala/stats/chart.js:275 static/js/zamboni/stats-all.js:16906 static/js/zamboni/stats-min.js:5
+msgid "{0} sales"
+msgstr "{0} ਸੇਲ"
+
+#: static/js/impala/stats/chart.js:276 static/js/zamboni/stats-all.js:16907 static/js/zamboni/stats-min.js:5
+msgid "{0} refunds"
+msgstr "{0} ਰਿਫੰਡ"
+
+#: static/js/impala/stats/chart.js:277 static/js/zamboni/stats-all.js:16908 static/js/zamboni/stats-min.js:5
+msgid "{0} installs"
+msgstr "{0} ਇੰਸਟਾਲ"
+
+#: static/js/impala/stats/chart.js:369 static/js/impala/stats/csv_keys.js:3 static/js/impala/stats/csv_keys.js:109 static/js/zamboni/stats-all.js:15284 static/js/zamboni/stats-all.js:15390
+#: static/js/zamboni/stats-all.js:17000 static/js/zamboni/stats-min.js:4 static/js/zamboni/stats-min.js:5
+msgid "Downloads"
+msgstr "ਡਾਊਨਲੋਡ"
+
+#: static/js/impala/stats/chart.js:379 static/js/impala/stats/csv_keys.js:6 static/js/impala/stats/csv_keys.js:110 static/js/zamboni/stats-all.js:15287 static/js/zamboni/stats-all.js:15391
+#: static/js/zamboni/stats-all.js:17010 static/js/zamboni/stats-min.js:4 static/js/zamboni/stats-min.js:5
+msgid "Daily Users"
+msgstr "ਰੋਜਾਨਾਂ ਯੂਜਰ"
+
+#: static/js/impala/stats/chart.js:410 static/js/zamboni/stats-all.js:17041 static/js/zamboni/stats-min.js:5
+msgid "Amount, in USD"
+msgstr "USA ਵਿੱਚ, ਰਾਸ਼ੀ"
+
+#: static/js/impala/stats/chart.js:421 static/js/impala/stats/csv_keys.js:104 static/js/zamboni/stats-all.js:15385 static/js/zamboni/stats-all.js:17052 static/js/zamboni/stats-min.js:5
+msgid "Number of Contributions"
+msgstr "ਯੋਗਦਾਨ ਦੀ ਗਿਣਤੀ"
+
+#: static/js/impala/stats/chart.js:447 static/js/zamboni/stats-all.js:17078 static/js/zamboni/stats-min.js:5
+msgid "More Info..."
+msgstr "ਜਿਆਦਾ ਜਾਣਕਾਰੀ...."
+
+#. L10n: {0} is an ISO-formatted date.
+#: static/js/impala/stats/chart.js:451 static/js/zamboni/stats-all.js:17082 static/js/zamboni/stats-min.js:5
+msgid "Details for {0}"
+msgstr "{0} ਲਈ ਵੇਰਵਾ"
+
+#: static/js/impala/stats/csv_keys.js:9 static/js/zamboni/stats-all.js:15290 static/js/zamboni/stats-min.js:4
+msgid "Collections Created"
+msgstr "ਬਣਾਇਆ ਭੰਡਾਰ"
+
+#: static/js/impala/stats/csv_keys.js:12 static/js/zamboni/stats-all.js:15293 static/js/zamboni/stats-min.js:4
+msgid "Add-ons in Use"
+msgstr "ਐਡ-ਆਨ ਵਿੱਚ ਵਰਤੋ"
+
+#: static/js/impala/stats/csv_keys.js:15 static/js/zamboni/stats-all.js:15296 static/js/zamboni/stats-min.js:4
+msgid "Add-ons Created"
+msgstr "ਐਡ-ਆਨ ਬਣਾਓ"
+
+#: static/js/impala/stats/csv_keys.js:18 static/js/zamboni/stats-all.js:15299 static/js/zamboni/stats-min.js:4
+msgid "Add-ons Downloaded"
+msgstr "ਐਡ-ਆਨ ਡਾਊਨਲੋਡ"
+
+#: static/js/impala/stats/csv_keys.js:21 static/js/zamboni/stats-all.js:15302 static/js/zamboni/stats-min.js:4
+msgid "Add-ons Updated"
+msgstr "ਐਡ-ਆਨ ਅੱਪਡੇਟ"
+
+#: static/js/impala/stats/csv_keys.js:24 static/js/zamboni/stats-all.js:15305 static/js/zamboni/stats-min.js:4
+msgid "Reviews Written"
+msgstr "ਲਿਖਤੀ ਸਮੀਖਿਅਕ"
+
+#: static/js/impala/stats/csv_keys.js:27 static/js/zamboni/stats-all.js:15308 static/js/zamboni/stats-min.js:4
+msgid "User Signups"
+msgstr "ਯੂਜਰ ਸਾਈਨਅੱਪ"
+
+#: static/js/impala/stats/csv_keys.js:30 static/js/zamboni/stats-all.js:15311 static/js/zamboni/stats-min.js:4
+msgid "Subscribers"
+msgstr "ਗਾਹਕ"
+
+#: static/js/impala/stats/csv_keys.js:33 static/js/zamboni/stats-all.js:15314 static/js/zamboni/stats-min.js:4
+msgid "Ratings"
+msgstr "ਰੇਟਿੰਗ"
+
+#: static/js/impala/stats/csv_keys.js:36 static/js/impala/stats/csv_keys.js:114 static/js/zamboni/stats-all.js:15317 static/js/zamboni/stats-all.js:15395 static/js/zamboni/stats-min.js:4
+#: static/js/zamboni/stats-min.js:5
+msgid "Sales"
+msgstr "ਸੇਲ"
+
+#: static/js/impala/stats/csv_keys.js:39 static/js/impala/stats/csv_keys.js:113 static/js/zamboni/stats-all.js:15320 static/js/zamboni/stats-all.js:15394 static/js/zamboni/stats-min.js:4
+#: static/js/zamboni/stats-min.js:5
+msgid "Installs"
+msgstr "ਇੰਸਟਾਲ"
+
+#: static/js/impala/stats/csv_keys.js:42 static/js/zamboni/stats-all.js:15323 static/js/zamboni/stats-min.js:4
+msgid "Unknown"
+msgstr "ਅਣਜਾਣ"
+
+#: static/js/impala/stats/csv_keys.js:43 static/js/zamboni/stats-all.js:15324 static/js/zamboni/stats-min.js:4
+msgid "Add-ons Manager"
+msgstr "ਐਡ-ਆਨ ਮਨੇਜਰ"
+
+#: static/js/impala/stats/csv_keys.js:44 static/js/zamboni/stats-all.js:15325 static/js/zamboni/stats-min.js:4
+msgid "Add-ons Manager Promo"
 msgstr ""
 
-#: static/js/zamboni/validator.js:80
+#: static/js/impala/stats/csv_keys.js:45 static/js/zamboni/stats-all.js:15326 static/js/zamboni/stats-min.js:4
+msgid "Add-ons Manager Featured"
+msgstr ""
+
+#: static/js/impala/stats/csv_keys.js:46 static/js/zamboni/stats-all.js:15327 static/js/zamboni/stats-min.js:4
+msgid "Add-ons Manager Learn More"
+msgstr ""
+
+#: static/js/impala/stats/csv_keys.js:47 static/js/zamboni/stats-all.js:15328 static/js/zamboni/stats-min.js:4
+msgid "Search Suggestions"
+msgstr ""
+
+#: static/js/impala/stats/csv_keys.js:48 static/js/zamboni/stats-all.js:15329 static/js/zamboni/stats-min.js:4
+msgid "Search Results"
+msgstr "ਨਤੀਜੇ ਖੋਜੋ"
+
+#: static/js/impala/stats/csv_keys.js:49 static/js/impala/stats/csv_keys.js:50 static/js/impala/stats/csv_keys.js:51 static/js/zamboni/stats-all.js:15330 static/js/zamboni/stats-all.js:15331
+#: static/js/zamboni/stats-all.js:15332 static/js/zamboni/stats-min.js:4
+msgid "Homepage Promo"
+msgstr "ਮੁੱਖ ਸਫਾ ਪਰੋਮੋ"
+
+#: static/js/impala/stats/csv_keys.js:52 static/js/impala/stats/csv_keys.js:53 static/js/zamboni/stats-all.js:15333 static/js/zamboni/stats-all.js:15334 static/js/zamboni/stats-min.js:4
+msgid "Homepage Featured"
+msgstr "ਮੁੱਖ ਸਫਾ ਗੁਣ"
+
+#: static/js/impala/stats/csv_keys.js:54 static/js/impala/stats/csv_keys.js:55 static/js/zamboni/stats-all.js:15335 static/js/zamboni/stats-all.js:15336 static/js/zamboni/stats-min.js:4
+msgid "Homepage Up and Coming"
+msgstr "ਮੁੱਖ ਸਫਾ ਉੱਪਰ ਅਤੇ ਆਉਣਾ"
+
+#: static/js/impala/stats/csv_keys.js:56 static/js/zamboni/stats-all.js:15337 static/js/zamboni/stats-min.js:4
+msgid "Homepage Most Popular"
+msgstr "ਮੱਖ ਸਫਾ ਜਿਆਦਾ ਪ੍ਰਸਿੱਧ"
+
+#: static/js/impala/stats/csv_keys.js:57 static/js/impala/stats/csv_keys.js:59 static/js/zamboni/stats-all.js:15338 static/js/zamboni/stats-all.js:15340 static/js/zamboni/stats-min.js:4
+msgid "Detail Page"
+msgstr "ਸਫੇ ਦਾ ਵੇਰਵਾ"
+
+#: static/js/impala/stats/csv_keys.js:58 static/js/impala/stats/csv_keys.js:60 static/js/zamboni/stats-all.js:15339 static/js/zamboni/stats-all.js:15341 static/js/zamboni/stats-min.js:4
+msgid "Detail Page (bottom)"
+msgstr "ਸਫੇ ਦਾ ਵੇਰਵਾ (ਹੇਠਾਂ)"
+
+#: static/js/impala/stats/csv_keys.js:61 static/js/zamboni/stats-all.js:15342 static/js/zamboni/stats-min.js:4
+msgid "Detail Page (Development Channel)"
+msgstr "ਸਫੇ ਦਾ ਵੇਰਵਾ (ਵਾਧਾ ਪ੍ਰਣਾਲੀ)"
+
+#: static/js/impala/stats/csv_keys.js:62 static/js/impala/stats/csv_keys.js:63 static/js/impala/stats/csv_keys.js:64 static/js/zamboni/stats-all.js:15343 static/js/zamboni/stats-all.js:15344
+#: static/js/zamboni/stats-all.js:15345 static/js/zamboni/stats-min.js:4
+msgid "Often Used With"
+msgstr "ਆਮ ਕਰਕੇ ਨਾਲ ਵਰਤਿਆ"
+
+#: static/js/impala/stats/csv_keys.js:65 static/js/impala/stats/csv_keys.js:66 static/js/zamboni/stats-all.js:15346 static/js/zamboni/stats-all.js:15347 static/js/zamboni/stats-min.js:4
+msgid "Others By Author"
+msgstr "ਲੇਖਕ ਵਲੋ ਹੋਰ"
+
+#: static/js/impala/stats/csv_keys.js:67 static/js/impala/stats/csv_keys.js:68 static/js/zamboni/stats-all.js:15348 static/js/zamboni/stats-all.js:15349 static/js/zamboni/stats-min.js:4
+msgid "Dependencies"
+msgstr "ਨਿਰਭਰਤਾਵਾਂ"
+
+#: static/js/impala/stats/csv_keys.js:69 static/js/impala/stats/csv_keys.js:70 static/js/zamboni/stats-all.js:15350 static/js/zamboni/stats-all.js:15351 static/js/zamboni/stats-min.js:4
+msgid "Upsell"
+msgstr "ਵਾਧੂ ਖਰੀਦਦਾਰੀ ਲਈ ਉਕਸਾਉਣਾ"
+
+#: static/js/impala/stats/csv_keys.js:71 static/js/zamboni/stats-all.js:15352 static/js/zamboni/stats-min.js:4
+msgid "Meet the Developer"
+msgstr ""
+
+#: static/js/impala/stats/csv_keys.js:72 static/js/zamboni/stats-all.js:15353 static/js/zamboni/stats-min.js:4
+msgid "User Profile"
+msgstr ""
+
+#: static/js/impala/stats/csv_keys.js:73 static/js/zamboni/stats-all.js:15354 static/js/zamboni/stats-min.js:4
+msgid "Version History"
+msgstr ""
+
+#: static/js/impala/stats/csv_keys.js:75 static/js/zamboni/stats-all.js:15356 static/js/zamboni/stats-min.js:4
+msgid "Sharing"
+msgstr "ਵੰਡਣਾ"
+
+#: static/js/impala/stats/csv_keys.js:76 static/js/zamboni/stats-all.js:15357 static/js/zamboni/stats-min.js:4
+msgid "Category Pages"
+msgstr "ਸੰਗ੍ਰਹਿ ਪੰਨੇ"
+
+#: static/js/impala/stats/csv_keys.js:77 static/js/zamboni/stats-all.js:15358 static/js/zamboni/stats-min.js:4
+msgid "Collections"
+msgstr "ਸੰਗ੍ਰਹਿ"
+
+#: static/js/impala/stats/csv_keys.js:78 static/js/impala/stats/csv_keys.js:79 static/js/zamboni/stats-all.js:15359 static/js/zamboni/stats-all.js:15360 static/js/zamboni/stats-min.js:4
+msgid "Category Landing Featured Carousel"
+msgstr "ਸੰਗ੍ਰਹਿ ਭੂਮੀ ਗੁਣ ਝੂਲਣਾ"
+
+#: static/js/impala/stats/csv_keys.js:80 static/js/impala/stats/csv_keys.js:81 static/js/zamboni/stats-all.js:15361 static/js/zamboni/stats-all.js:15362 static/js/zamboni/stats-min.js:4
+msgid "Category Landing Top Rated"
+msgstr "ਚੋਟੀ ਦੀ ਰੇਟਿੰਗ ਵਿੱਚ ਆਉਂਦੇ ਸੰਗ੍ਰਹਿ"
+
+#: static/js/impala/stats/csv_keys.js:82 static/js/impala/stats/csv_keys.js:83 static/js/zamboni/stats-all.js:15363 static/js/zamboni/stats-all.js:15364 static/js/zamboni/stats-min.js:5
+msgid "Category Landing Most Popular"
+msgstr "ਸੱਭ ਤੋਂ ਮਸ਼ਹੂਰ ਵਿੱਚ ਆਉਂਦੇ ਸੰਗ੍ਰਹਿ"
+
+#: static/js/impala/stats/csv_keys.js:84 static/js/impala/stats/csv_keys.js:85 static/js/zamboni/stats-all.js:15365 static/js/zamboni/stats-all.js:15366 static/js/zamboni/stats-min.js:5
+msgid "Category Landing Recently Added"
+msgstr "ਤਾਜਾ ਸ਼ਾਮਿਲ ਲੈਂਡਿੰਗ ਸ਼੍ਰੈਣੀ"
+
+#: static/js/impala/stats/csv_keys.js:86 static/js/impala/stats/csv_keys.js:87 static/js/zamboni/stats-all.js:15367 static/js/zamboni/stats-all.js:15368 static/js/zamboni/stats-min.js:5
+msgid "Browse Listing Featured Sort"
+msgstr "ਗੁਣ ਕਿਸਮ ਸੂਚੀ ਬਣਾਓ"
+
+#: static/js/impala/stats/csv_keys.js:88 static/js/impala/stats/csv_keys.js:89 static/js/zamboni/stats-all.js:15369 static/js/zamboni/stats-all.js:15370 static/js/zamboni/stats-min.js:5
+msgid "Browse Listing Users Sort"
+msgstr "ਯੂਜਰ ਕਿਸਮ ਸੂਚੀ ਬਣਾਓ"
+
+#: static/js/impala/stats/csv_keys.js:90 static/js/impala/stats/csv_keys.js:91 static/js/zamboni/stats-all.js:15371 static/js/zamboni/stats-all.js:15372 static/js/zamboni/stats-min.js:5
+msgid "Browse Listing Rating Sort"
+msgstr "ਰੇਟਿੰਗ ਕਿਸਮ ਸੂਚੀ ਬਣਾਓ"
+
+#: static/js/impala/stats/csv_keys.js:92 static/js/impala/stats/csv_keys.js:93 static/js/zamboni/stats-all.js:15373 static/js/zamboni/stats-all.js:15374 static/js/zamboni/stats-min.js:5
+msgid "Browse Listing Created Sort"
+msgstr "ਰਚਨਾਤਮਿਕ ਕਿਸਮ ਸੂਚੀ ਬਣਾਓ"
+
+#: static/js/impala/stats/csv_keys.js:94 static/js/impala/stats/csv_keys.js:95 static/js/zamboni/stats-all.js:15375 static/js/zamboni/stats-all.js:15376 static/js/zamboni/stats-min.js:5
+msgid "Browse Listing Name Sort"
+msgstr "ਨਾਮ ਕਿਸਮ ਸੂਚੀ ਬਣਾਓ"
+
+#: static/js/impala/stats/csv_keys.js:96 static/js/impala/stats/csv_keys.js:97 static/js/zamboni/stats-all.js:15377 static/js/zamboni/stats-all.js:15378 static/js/zamboni/stats-min.js:5
+msgid "Browse Listing Popular Sort"
+msgstr "ਪ੍ਰਸਿੱਧ ਕਿਸਮ ਸੂਚੀ ਬਣਾਓ"
+
+#: static/js/impala/stats/csv_keys.js:98 static/js/impala/stats/csv_keys.js:99 static/js/zamboni/stats-all.js:15379 static/js/zamboni/stats-all.js:15380 static/js/zamboni/stats-min.js:5
+msgid "Browse Listing Updated Sort"
+msgstr "ਅੱਪਡੇਟ ਕਿਸਮ ਸੂਚੀ ਬਣਾਓ"
+
+#: static/js/impala/stats/csv_keys.js:100 static/js/impala/stats/csv_keys.js:101 static/js/zamboni/stats-all.js:15381 static/js/zamboni/stats-all.js:15382 static/js/zamboni/stats-min.js:5
+msgid "Browse Listing Up and Coming Sort"
+msgstr "ਸੂਚੀਬੱਧਤਾ ਅਤੇ ਲੜੀਬੱਧਤਾ ਦੀ ਝਲਕ"
+
+#: static/js/impala/stats/csv_keys.js:105 static/js/zamboni/stats-all.js:15386 static/js/zamboni/stats-min.js:5
+msgid "Total Amount Contributed"
+msgstr "ਕੁੱਲ ਰਕਮ ਯੋਗਦਾਨ ਪਾਇਆ"
+
+#: static/js/impala/stats/csv_keys.js:106 static/js/zamboni/stats-all.js:15387 static/js/zamboni/stats-min.js:5
+msgid "Average Contribution"
+msgstr "ਔਸਤ ਯੋਗਦਾਨ"
+
+#: static/js/impala/stats/csv_keys.js:115 static/js/zamboni/stats-all.js:15396 static/js/zamboni/stats-min.js:5
+msgid "Usage"
+msgstr "ਵਰਤੋਂ"
+
+#: static/js/impala/stats/csv_keys.js:118 static/js/zamboni/stats-all.js:15399 static/js/zamboni/stats-min.js:5
+msgid "Firefox"
+msgstr "ਫਾਇਰਫਾਕਸ"
+
+#: static/js/impala/stats/csv_keys.js:119 static/js/zamboni/stats-all.js:15400 static/js/zamboni/stats-min.js:5
+msgid "Mozilla"
+msgstr "ਮੌਜੀਲਾ"
+
+#: static/js/impala/stats/csv_keys.js:120 static/js/zamboni/stats-all.js:15401 static/js/zamboni/stats-min.js:5
+msgid "Thunderbird"
+msgstr "ਥੰਡਰਬਰਡ"
+
+#: static/js/impala/stats/csv_keys.js:121 static/js/zamboni/stats-all.js:15402 static/js/zamboni/stats-min.js:5
+msgid "Sunbird"
+msgstr "ਸਨਬਰਡ"
+
+#: static/js/impala/stats/csv_keys.js:122 static/js/zamboni/stats-all.js:15403 static/js/zamboni/stats-min.js:5
+msgid "SeaMonkey"
+msgstr "ਸੀਮੌਂਕੀ"
+
+#: static/js/impala/stats/csv_keys.js:123 static/js/zamboni/stats-all.js:15404 static/js/zamboni/stats-min.js:5
+msgid "Fennec"
+msgstr "ਫਿੱਨਸ"
+
+#: static/js/impala/stats/csv_keys.js:124 static/js/zamboni/stats-all.js:15405 static/js/zamboni/stats-min.js:5
+msgid "Android"
+msgstr "ਐਨਡਰੋਇਡ"
+
+#. L10n: {0} is an integer.
+#: static/js/impala/stats/csv_keys.js:129 static/js/zamboni/stats-all.js:15410 static/js/zamboni/stats-min.js:5
+msgid "Downloads and Daily Users, last {0} days"
+msgstr "ਡਾਊਨਲੋਡ ਅਤੇ ਰੋਜਾਨਾਂ ਯੂਜਰ, ਆਖਰੀ {0} ਦਿਨ"
+
+#. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
+#: static/js/impala/stats/csv_keys.js:131 static/js/zamboni/stats-all.js:15412 static/js/zamboni/stats-min.js:5
+msgid "Downloads and Daily Users from {0} to {1}"
+msgstr "{0} ਤੋਂ {1} ਤੱਕ ਡਾਊਨਲੋਡ ਅਤੇ ਰੋਜਾਨਾਂ ਯੂਜਰ"
+
+#. L10n: {0} is an integer.
+#: static/js/impala/stats/csv_keys.js:135 static/js/zamboni/stats-all.js:15416 static/js/zamboni/stats-min.js:5
+msgid "Installs and Daily Users, last {0} days"
+msgstr "ਇੰਸਟਾਲ ਅਤੇ ਰੋਜਾਨਾਂ ਯੂਜਰ, ਆਖਰੀ {0} ਦਿਨ"
+
+#. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
+#: static/js/impala/stats/csv_keys.js:137 static/js/zamboni/stats-all.js:15418 static/js/zamboni/stats-min.js:5
+msgid "Installs and Daily Users from {0} to {1}"
+msgstr "{0} ਤੋ {1} ਤੱਕ ਇੰਸਟਾਲ ਅਤੇ ਰੋਜਾਨਾਂ ਯੂਜਰ"
+
+#. L10n: {0} is an integer.
+#: static/js/impala/stats/csv_keys.js:141 static/js/zamboni/stats-all.js:15422 static/js/zamboni/stats-min.js:5
+msgid "Downloads, last {0} days"
+msgstr "ਡਾਊਨਲੋਡ, ਆਖਰੀ {0} ਦਿਨ"
+
+#. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
+#: static/js/impala/stats/csv_keys.js:143 static/js/zamboni/stats-all.js:15424 static/js/zamboni/stats-min.js:5
+msgid "Downloads from {0} to {1}"
+msgstr "{0} ਤੋਂ {1} ਤੱਕ ਡਾਊਨਲੋਡ"
+
+#. L10n: {0} is an integer.
+#: static/js/impala/stats/csv_keys.js:147 static/js/zamboni/stats-all.js:15428 static/js/zamboni/stats-min.js:5
+msgid "Daily Users, last {0} days"
+msgstr "ਰੋਜਾਨਾਂ ਯੂਜਰ, ਆਖਰੀ {0} ਦਿਨ"
+
+#. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
+#: static/js/impala/stats/csv_keys.js:149 static/js/zamboni/stats-all.js:15430 static/js/zamboni/stats-min.js:5
+msgid "Daily Users from {0} to {1}"
+msgstr "{0} ਤੋਂ {1} ਤੱਕ ਰੋਜਾਨਾਂ ਯੂਜਰ"
+
+#. L10n: {0} is an integer.
+#: static/js/impala/stats/csv_keys.js:153 static/js/zamboni/stats-all.js:15434 static/js/zamboni/stats-min.js:5
+msgid "Applications, last {0} days"
+msgstr "ਐਪਲੀਕੇਸ਼ਨ, ਆਖਰੀ {0} ਦਿਨ"
+
+#. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
+#: static/js/impala/stats/csv_keys.js:155 static/js/zamboni/stats-all.js:15436 static/js/zamboni/stats-min.js:5
+msgid "Applications from {0} to {1}"
+msgstr "{0} ਤੋਂ {1} ਤੱਕ ਐਪਲੀਕੇਸ਼ਨ"
+
+#. L10n: {0} is an integer.
+#: static/js/impala/stats/csv_keys.js:159 static/js/zamboni/stats-all.js:15440 static/js/zamboni/stats-min.js:5
+msgid "Platforms, last {0} days"
+msgstr "ਪਲੇਟਫਾਰਮ, ਆਖਰੀ {0} ਦਿਨ"
+
+#. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
+#: static/js/impala/stats/csv_keys.js:161 static/js/zamboni/stats-all.js:15442 static/js/zamboni/stats-min.js:5
+msgid "Platforms from {0} to {1}"
+msgstr "{0} ਤੋਂ {1} ਤੱਕ ਪਲੇਟਫਾਰਮ"
+
+#. L10n: {0} is an integer.
+#: static/js/impala/stats/csv_keys.js:165 static/js/zamboni/stats-all.js:15446 static/js/zamboni/stats-min.js:5
+msgid "Languages, last {0} days"
+msgstr "ਭਾਸ਼ਾਵਾਂ, ਆਖਰੀ {0} ਦਿਨ"
+
+#. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
+#: static/js/impala/stats/csv_keys.js:167 static/js/zamboni/stats-all.js:15448 static/js/zamboni/stats-min.js:5
+msgid "Languages from {0} to {1}"
+msgstr "{0} ਤੋਂ {1} ਤੱਕ ਭਾਸ਼ਾਵਾਂ"
+
+#. L10n: {0} is an integer.
+#: static/js/impala/stats/csv_keys.js:171 static/js/zamboni/stats-all.js:15452 static/js/zamboni/stats-min.js:5
+msgid "Add-on Versions, last {0} days"
+msgstr "ਐਡ-ਆਨ ਵਰਜਨ, ਆਖਰੀ {0} ਦਿਨ"
+
+#. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
+#: static/js/impala/stats/csv_keys.js:173 static/js/zamboni/stats-all.js:15454 static/js/zamboni/stats-min.js:5
+msgid "Add-on Versions from {0} to {1}"
+msgstr "{0} ਤੋਂ {1} ਤੱਕ ਐਡ-ਆਨ ਵਰਜਨ"
+
+#. L10n: {0} is an integer.
+#: static/js/impala/stats/csv_keys.js:177 static/js/zamboni/stats-all.js:15458 static/js/zamboni/stats-min.js:5
+msgid "Add-on Status, last {0} days"
+msgstr "ਐਡ-ਆਨ ਸਥਿਤੀ, ਆਖਰੀ {0} ਦਿਨ"
+
+#. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
+#: static/js/impala/stats/csv_keys.js:179 static/js/zamboni/stats-all.js:15460 static/js/zamboni/stats-min.js:5
+msgid "Add-on Status from {0} to {1}"
+msgstr "{0} ਤੋਂ {1} ਤੱਕ ਐਡ-ਆਨ ਸਥਿਤੀ"
+
+#. L10n: {0} is an integer.
+#: static/js/impala/stats/csv_keys.js:183 static/js/zamboni/stats-all.js:15464 static/js/zamboni/stats-min.js:5
+msgid "Download Sources, last {0} days"
+msgstr "ਡਾਊਨਲੋਡ ਸਰੋਤ, ਆਖਰੀ {0} ਦਿਨ"
+
+#. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
+#: static/js/impala/stats/csv_keys.js:185 static/js/zamboni/stats-all.js:15466 static/js/zamboni/stats-min.js:5
+msgid "Download Sources from {0} to {1}"
+msgstr "{0} ਤੋਂ {1} ਤੱਕ ਡਾਊਨਲੋਡ ਸਰੋਤ"
+
+#. L10n: {0} is an integer.
+#: static/js/impala/stats/csv_keys.js:189 static/js/zamboni/stats-all.js:15470 static/js/zamboni/stats-min.js:5
+msgid "Contributions, last {0} days"
+msgstr "ਪਿਛਲੇ {0} ਦਿਨ, ਯੋਗਦਾਨ"
+
+#. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
+#: static/js/impala/stats/csv_keys.js:191 static/js/zamboni/stats-all.js:15472 static/js/zamboni/stats-min.js:5
+msgid "Contributions from {0} to {1}"
+msgstr "{0} ਤੋਂ {1} ਤੱਕ ਯੋਗਦਾਨ"
+
+#. L10n: {0} is an integer.
+#: static/js/impala/stats/csv_keys.js:195 static/js/zamboni/stats-all.js:15476 static/js/zamboni/stats-min.js:5
+msgid "Site Metrics, last {0} days"
+msgstr "ਪਿਛਲੇ {0} ਦਿਨ, ਸਾਈਟ ਮੈਟ੍ਰਿਕਸ"
+
+#. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
+#: static/js/impala/stats/csv_keys.js:197 static/js/zamboni/stats-all.js:15478 static/js/zamboni/stats-min.js:5
+msgid "Site Metrics from {0} to {1}"
+msgstr "ਵਲੋ ਸਾਈਟ ਬਿਓਰਾ {0} ਤੋ {1}"
+
+#. L10n: {0} is an integer.
+#: static/js/impala/stats/csv_keys.js:201 static/js/zamboni/stats-all.js:15482 static/js/zamboni/stats-min.js:5
+msgid "Add-ons in Use, last {0} days"
+msgstr "ਅੈਡ-ਓਨ ਵਰਤੋ ਵਿੱਚ, ਆਖਰੀ {0} ਦਿਨ"
+
+#. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
+#: static/js/impala/stats/csv_keys.js:203 static/js/zamboni/stats-all.js:15484 static/js/zamboni/stats-min.js:5
+msgid "Add-ons in Use from {0} to {1}"
+msgstr "ਐਡ-ਆਨ ਵਰਤੋ ਵਿਚ {0} ਤੋਂ {1}"
+
+#. L10n: {0} is an integer.
+#: static/js/impala/stats/csv_keys.js:207 static/js/zamboni/stats-all.js:15488 static/js/zamboni/stats-min.js:5
+msgid "Add-ons Downloaded, last {0} days"
+msgstr "ਆਖਰੀ {0} ਦਿਨ,ਐਡ-ਆਨ ਡਾਊਨਲੋਡ ਹੋਏ,"
+
+#. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
+#: static/js/impala/stats/csv_keys.js:209 static/js/zamboni/stats-all.js:15490 static/js/zamboni/stats-min.js:5
+msgid "Add-ons Downloaded from {0} to {1}"
+msgstr "ਐਡ-ਆਨ {0} ਤੋਂ {1} ਤੱਕ ਡਾਊਨਲੋਡ ਹੋਇਆ"
+
+#. L10n: {0} is an integer.
+#: static/js/impala/stats/csv_keys.js:213 static/js/zamboni/stats-all.js:15494 static/js/zamboni/stats-min.js:5
+msgid "Add-ons Created, last {0} days"
+msgstr "ਆਖਰੀ {0} ਦਿਨ, ਅੈਡ-ਓਨ ਰਚੇ ਗਏ"
+
+#. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
+#: static/js/impala/stats/csv_keys.js:215 static/js/zamboni/stats-all.js:15496 static/js/zamboni/stats-min.js:5
+msgid "Add-ons Created from {0} to {1}"
+msgstr "{0} ਤੋਂ {1} ਵਲੋ ਐਡ-ਆਨ ਬਣਾਓ"
+
+#. L10n: {0} is an integer.
+#: static/js/impala/stats/csv_keys.js:219 static/js/zamboni/stats-all.js:15500 static/js/zamboni/stats-min.js:5
+msgid "Add-ons Updated, last {0} days"
+msgstr " ਆਖਰੀ {0} ਦਿਨ, ਐਡ-ਆਨ ਅੱਪਡੇਟ"
+
+#. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
+#: static/js/impala/stats/csv_keys.js:221 static/js/zamboni/stats-all.js:15502 static/js/zamboni/stats-min.js:5
+msgid "Add-ons Updated from {0} to {1}"
+msgstr "{0} ਤੋਂ {1} ਵਿੱਚੋਂ ਐਡ-ਆਨ ਅੱਪਡੇਟ"
+
+#. L10n: {0} is an integer.
+#: static/js/impala/stats/csv_keys.js:225 static/js/zamboni/stats-all.js:15506 static/js/zamboni/stats-min.js:5
+msgid "Reviews Written, last {0} days"
+msgstr " ਆਖਰੀ {0} ਦਿਨ, ਲਿਖਤੀ ਸਮੀਖਿਅਕ"
+
+#. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
+#: static/js/impala/stats/csv_keys.js:227 static/js/zamboni/stats-all.js:15508 static/js/zamboni/stats-min.js:5
+msgid "Reviews Written from {0} to {1}"
+msgstr "{0} ਤੋਂ {1} ਤੱਕ ਲਿਖਤੀ ਸਮੀਖਿਅਕ"
+
+#. L10n: {0} is an integer.
+#: static/js/impala/stats/csv_keys.js:231 static/js/zamboni/stats-all.js:15512 static/js/zamboni/stats-min.js:5
+msgid "User Signups, last {0} days"
+msgstr "ਪਿਛਲੇ {0} ਦਿਨ, ਯੂਜਰ ਸਾਈਨ ਅੱਪ"
+
+#. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
+#: static/js/impala/stats/csv_keys.js:233 static/js/zamboni/stats-all.js:15514 static/js/zamboni/stats-min.js:5
+msgid "User Signups from {0} to {1}"
+msgstr "{0} ਤੋਂ {1} ਤੱਕ ਯੂਜਰ ਸਾਈਨ ਅੱਪ"
+
+#. L10n: {0} is an integer.
+#: static/js/impala/stats/csv_keys.js:237 static/js/zamboni/stats-all.js:15518 static/js/zamboni/stats-min.js:5
+msgid "Collections Created, last {0} days"
+msgstr "ਪਿਛਲੇ {0} ਦਿਨ, ਭੰਡਾਰ ਬਣਾਏ"
+
+#. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
+#: static/js/impala/stats/csv_keys.js:239 static/js/zamboni/stats-all.js:15520 static/js/zamboni/stats-min.js:5
+msgid "Collections Created from {0} to {1}"
+msgstr "{0} ਤੋਂ {1} ਤੱਕ ਬਣਾਏ ਭੰਡਾਰ"
+
+#. L10n: {0} is an integer.
+#: static/js/impala/stats/csv_keys.js:243 static/js/zamboni/stats-all.js:15524 static/js/zamboni/stats-min.js:5
+msgid "Subscribers, last {0} days"
+msgstr "ਪਿਛਲੇ {0} ਦਿਨ, ਗਾਹਕ"
+
+#. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
+#: static/js/impala/stats/csv_keys.js:245 static/js/zamboni/stats-all.js:15526 static/js/zamboni/stats-min.js:5
+msgid "Subscribers from {0} to {1}"
+msgstr "{0} ਤੋਂ {1} ਤੱਕ ਗਾਹਕ"
+
+#. L10n: {0} is an integer.
+#: static/js/impala/stats/csv_keys.js:249 static/js/zamboni/stats-all.js:15530 static/js/zamboni/stats-min.js:5
+msgid "Ratings, last {0} days"
+msgstr "ਪਿਛਲੇ {0} ਦਿਨ, ਰੇਟਿੰਗ"
+
+#. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
+#: static/js/impala/stats/csv_keys.js:251 static/js/zamboni/stats-all.js:15532 static/js/zamboni/stats-min.js:5
+msgid "Ratings from {0} to {1}"
+msgstr "{0} ਤੋਂ {1} ਤੱਕ ਰੇਟਿੰਗ"
+
+#. L10n: {0} is an integer.
+#: static/js/impala/stats/csv_keys.js:255 static/js/zamboni/stats-all.js:15536 static/js/zamboni/stats-min.js:5
+msgid "Sales, last {0} days"
+msgstr "ਆਖਰੀ {0} ਦਿਨ, ਵਿਕਰੀ"
+
+#. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
+#: static/js/impala/stats/csv_keys.js:257 static/js/zamboni/stats-all.js:15538 static/js/zamboni/stats-min.js:5
+msgid "Sales from {0} to {1}"
+msgstr "{0} ਤੋਂ {1} ਵਿੱਚੋਂ ਵਿਕਰੀ"
+
+#. L10n: {0} is an integer.
+#: static/js/impala/stats/csv_keys.js:261 static/js/zamboni/stats-all.js:15542 static/js/zamboni/stats-min.js:5
+msgid "Installs, last {0} days"
+msgstr "ਆਖਰੀ {0} ਦਿਨ, ਇੰਸਟਾਲ"
+
+#. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
+#: static/js/impala/stats/csv_keys.js:263 static/js/zamboni/stats-all.js:15544 static/js/zamboni/stats-min.js:5
+msgid "Installs from {0} to {1}"
+msgstr "{0} ਤੋਂ {1} ਵੱਲੋਂ ਇੰਸਟਾਲ"
+
+#. L10n: {0} and {1} are integers.
+#: static/js/impala/stats/csv_keys.js:269 static/js/zamboni/stats-all.js:15550 static/js/zamboni/stats-min.js:5
+msgid "<b>{0}</b> in last {1} days"
+msgstr "<b>{0}</b> ਆਖਰ ਵਿੱਚ {1} ਦਿਨ"
+
+#. L10n: {0} is an integer and {1} and {2} are dates in YYYY-MM-DD format.
+#: static/js/impala/stats/csv_keys.js:271 static/js/impala/stats/csv_keys.js:277 static/js/zamboni/stats-all.js:15552 static/js/zamboni/stats-all.js:15558 static/js/zamboni/stats-min.js:5
+msgid "<b>{0}</b> from {1} to {2}"
+msgstr "<b>{0}</b> ਵੱਲੋਂ {1} ਤੋਂ {2}"
+
+#. L10n: {0} and {1} are integers.
+#: static/js/impala/stats/csv_keys.js:275 static/js/zamboni/stats-all.js:15556 static/js/zamboni/stats-min.js:5
+msgid "<b>{0}</b> average in last {1} days"
+msgstr "<b>{0}</b>ਅੌਸਤ ਆਖਰੀ {1} ਦਿਨਾਂ ਵਿਚ"
+
+#: static/js/impala/stats/overview.js:19 static/js/zamboni/stats-all.js:16469 static/js/zamboni/stats-min.js:5
+msgid "No data available."
+msgstr "ਕੋਈ ਡਾਟਾ ਮੌਜ਼ੂਦ ਨਹੀ"
+
+#: static/js/impala/stats/table.js:74 static/js/zamboni/stats-all.js:17209 static/js/zamboni/stats-min.js:5
+msgid "Date"
+msgstr "ਤਾਰੀਖ"
+
+#: static/js/impala/stats/topchart.js:96 static/js/zamboni/stats-all.js:16600 static/js/zamboni/stats-min.js:5
+msgid "Other"
+msgstr "ਦੂਜਾ"
+
+#: static/js/zamboni/admin-all.js:180 static/js/zamboni/admin-min.js:1 static/js/zamboni/admin_validation.js:24 static/js/zamboni/devhub-all.js:2408 static/js/zamboni/devhub-min.js:2
+#: static/js/zamboni/devhub.js:1229 static/js/zamboni/editors-all.js:15576 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:295
+msgid "Select an application first"
+msgstr "ਪਹਿਲਾਂ ਇੱਕ ਐਪਲੀਕੇਸ਼ਨ ਚੁੱਣੋ"
+
+#: static/js/zamboni/admin-all.js:207 static/js/zamboni/admin-min.js:1 static/js/zamboni/admin_validation.js:51
+msgid "Set {0} add-on to a max version of {1} and email the author."
+msgid_plural "Set {0} add-ons to a max version of {1} and email the authors."
+msgstr[0] "{0} ਐਡ-ਆਨ ਨੂੰ {1} ਦੇ ਮੈਕਸ ਵਰਜਨ ਤੇ ਸੈੱਟ ਕਰੋ ਅਤੇ ਲੇਖਕ ਨੂੰ ਈਮੇਲ ਕਰੋ।"
+msgstr[1] "{0} ਐਡ-ਆਨਾਂ ਨੂੰ {1} ਦੇ ਮੈਕਸ ਵਰਜਨ ਤੇ ਸੈੱਟ ਕਰੋ ਅਤੇ ਲੇਖਕਾਂ ਨੂੰ ਈਮੇਲ ਕਰੋ।"
+
+#: static/js/zamboni/admin-all.js:210 static/js/zamboni/admin-min.js:1 static/js/zamboni/admin_validation.js:54
+msgid "Email author of {2} add-on which failed validation."
+msgid_plural "Email authors of {2} add-ons which failed validation."
+msgstr[0] "ਪ੍ਰਮਾਣਿਕਤਾ ਵਿੱਚ ਫ਼ੇਲ੍ਹ ਹੋਏ {2} ਐਡ-ਆਨ ਦੇ ਲੇਖਕ ਨੂੰ ਈਮੇਲ ਕਰੋ।"
+msgstr[1] "ਪ੍ਰਮਾਣਿਕਤਾ ਵਿੱਚ ਫ਼ੇਲ੍ਹ ਹੋਏ {2} ਐਡ-ਆਨਾਂ ਦੇ ਲੇਖਕਾਂ ਨੂੰ ਈਮੇਲ ਕਰੋ।"
+
+#: static/js/zamboni/devhub-all.js:1289 static/js/zamboni/devhub-min.js:1 static/js/zamboni/devhub.js:110
+msgid "Your browser does not support the video tag"
+msgstr "ਤੁਹਾਡਾ ਬਰਾਊਜਰ ਵੀਡੀਓ ਟੈਗ ਦਾ ਸਮਰਥਨ ਨਹੀ ਕਰਦਾ"
+
+#: static/js/zamboni/devhub-all.js:1550 static/js/zamboni/devhub-min.js:1 static/js/zamboni/devhub.js:371
+msgid "Changes Saved"
+msgstr "ਬਦਲਾਅ ਸੰਭਾਲੇ"
+
+#: static/js/zamboni/devhub-all.js:1566 static/js/zamboni/devhub-min.js:1 static/js/zamboni/devhub.js:387
+msgid "Enter a new author's email address"
+msgstr "ਨਵੇ ਲੇੇਖਕ ਦਾ ਈ-ਮੇਲ ਪਤਾ ਦਰਜ ਕਰੋ"
+
+#: static/js/zamboni/devhub-all.js:1715 static/js/zamboni/devhub-min.js:1 static/js/zamboni/devhub.js:536
+msgid "There was an error uploading your file."
+msgstr "ਤੁਹਾਡੀ ਫਾਈਲ ਨੂੰ ਅੱਪਲੋਡ ਕਰਨ ਦੌਰਾਨ ਇੱਕ ਗਲਤੀ ਆਈ ਸੀ।"
+
+#: static/js/zamboni/devhub-all.js:1860 static/js/zamboni/devhub-min.js:1 static/js/zamboni/devhub.js:681
+msgid "{files} file"
+msgid_plural "{files} files"
+msgstr[0] "{files} ਫਾਈਲ"
+msgstr[1] "{files} ਫਾਈਲਾਂ"
+
+#: static/js/zamboni/devhub-all.js:1863 static/js/zamboni/devhub-min.js:1 static/js/zamboni/devhub.js:684
+msgid "{reviews} user review"
+msgid_plural "{reviews} user reviews"
+msgstr[0] "{reviews} ਉਪਭੋਗੀ ਸਮੀਖਿਆ"
+msgstr[1] "{reviews} ਉਪਭੋਗੀ ਸਮੀਖਿਆਵਾਂ"
+
+#: static/js/zamboni/devhub-all.js:1975 static/js/zamboni/devhub-min.js:2 static/js/zamboni/devhub.js:796
+msgid "Learn more"
+msgstr "ਹੋਰ ਜਾਣੋ"
+
+#: static/js/zamboni/devhub-all.js:1979 static/js/zamboni/devhub-min.js:2 static/js/zamboni/devhub.js:800
+msgid "Example"
+msgstr "ਉਦਾਹਰਨ"
+
+#: static/js/zamboni/devhub-all.js:2309 static/js/zamboni/devhub-min.js:2 static/js/zamboni/devhub.js:1130
+msgid "Image changes being processed"
+msgstr "ਚਿੱਤਰ ਬਦਲਾਓ ਕਾਰਵਾਈ ਕੀਤੀ ਜਾ ਰਹੀ ਹੈ"
+
+#: static/js/zamboni/devhub-all.js:2459 static/js/zamboni/devhub-min.js:2 static/js/zamboni/devhub.js:1280
+msgid "Must be a valid e-mail address."
+msgstr "ਈ-ਮੇਲ ਐਡਰੈੱਸ ਸਹੀ ਹੋਣਾ ਚਾਹੀਦਾ ਹੈ।"
+
+#: static/js/zamboni/devhub-all.js:2613 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:80
 msgid "All tests passed successfully."
 msgstr "ਸਾਰੇ ਟੈਸਟ ਸਫਲਤਾਪੂਰਵਕ ਪਾਸ ਹੋਏ।"
 
-#: static/js/zamboni/validator.js:83 static/js/zamboni/validator.js:478
+#: static/js/zamboni/devhub-all.js:2616 static/js/zamboni/devhub-all.js:3011 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:83 static/js/zamboni/validator.js:478
 msgid "These tests were not run."
 msgstr "ਇਹ ਟੈਸਟ ਨਹੀਂ ਚਲਾਉਣੇ ਸਨ।"
 
-#: static/js/zamboni/validator.js:131 static/js/zamboni/validator.js:144
+#: static/js/zamboni/devhub-all.js:2664 static/js/zamboni/devhub-all.js:2677 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:131 static/js/zamboni/validator.js:144
 msgid "Tests"
 msgstr "ਟੈਸਟ"
 
-#: static/js/zamboni/validator.js:246 static/js/zamboni/validator.js:575 static/js/zamboni/validator.js:594
+#: static/js/zamboni/devhub-all.js:2779 static/js/zamboni/devhub-all.js:3108 static/js/zamboni/devhub-all.js:3127 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:246
+#: static/js/zamboni/validator.js:575 static/js/zamboni/validator.js:594
 msgid "Error"
 msgstr "ਗਲਤੀ"
 
-#: static/js/zamboni/validator.js:247
+#: static/js/zamboni/devhub-all.js:2780 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:247
 msgid "Warning"
 msgstr "ਚੇਤਾਵਨੀ"
 
-#: static/js/zamboni/validator.js:299
+#: static/js/zamboni/devhub-all.js:2794 static/js/zamboni/devhub-min.js:2 static/js/zamboni/files-all.js:5657 static/js/zamboni/files-min.js:3 static/js/zamboni/files.js:411
+#: static/js/zamboni/validator.js:261
+msgid "Ignore this message in future updates"
+msgstr ""
+
+#: static/js/zamboni/devhub-all.js:2817 static/js/zamboni/devhub-min.js:2 static/js/zamboni/files-all.js:5663 static/js/zamboni/files-min.js:3 static/js/zamboni/files.js:417
+#: static/js/zamboni/validator.js:284
+msgid "Severity for automated signing:"
+msgstr ""
+
+#: static/js/zamboni/devhub-all.js:2832 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:299
 msgid "Suggestions for passing automated signing:"
 msgstr ""
 
-#: static/js/zamboni/validator.js:387
+#: static/js/zamboni/devhub-all.js:2920 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:387
 msgid "Compatibility Tests"
 msgstr "ਅਨਕੂਲਤਾ ਟੈਸਟ"
 
-#: static/js/zamboni/validator.js:466
+#: static/js/zamboni/devhub-all.js:2999 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:466
 msgid "Add-on failed validation."
 msgstr "ਐਡ-ਆਨ ਪ੍ਰਮਾਣਿਕਤਾ ਫ਼ੇਲ੍ਹ ਹੋਈ।"
 
-#: static/js/zamboni/validator.js:468
+#: static/js/zamboni/devhub-all.js:3001 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:468
 msgid "Add-on passed validation."
 msgstr "ਐਡ-ਆਨ ਨੇ ਪ੍ਰਮਾਣਿਕਤਾ ਪਾਸ ਕੀਤੀ।"
 
-#: static/js/zamboni/validator.js:481
+#: static/js/zamboni/devhub-all.js:3014 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:481
 msgid "{0} error"
 msgid_plural "{0} errors"
 msgstr[0] "{0} ਗਲਤੀ"
 msgstr[1] "{0}ਗਲਤੀਆਂ"
 
-#: static/js/zamboni/validator.js:483
+#: static/js/zamboni/devhub-all.js:3016 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:483
 msgid "{0} warning"
 msgid_plural "{0} warnings"
 msgstr[0] "{0} ਚੇਤਾਵਨੀ"
 msgstr[1] "{0} ਚੇਤਾਵਨੀਆਂ"
 
-#: static/js/zamboni/validator.js:485
+#: static/js/zamboni/devhub-all.js:3018 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:485
 msgid "{0} notice"
 msgid_plural "{0} notices"
 msgstr[0] "{0} ਨੋਟਿਸ"
 msgstr[1] "{0} ਨੋਟਿਸ"
 
-#: static/js/zamboni/validator.js:577
+#: static/js/zamboni/devhub-all.js:3110 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:577
 msgid "Validation task could not complete or completed with errors"
 msgstr "ਪ੍ਰਮਾਣਿਕਤਾ ਕਾਰਜ ਮੁਕੰਮਲ ਨਹੀਂ ਹੋਇਆ ਜਾਂ ਖਾਮੀਆਂ ਨਾਲ ਮੁਕੰਮਲ ਹੋਇਆ"
 
-#: static/js/zamboni/validator.js:595
+#: static/js/zamboni/devhub-all.js:3128 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:595
 msgid "Internal server error"
 msgstr "ਅੰਦਰੂਨੀ ਸਰਵਰ ਗਲਤੀ"
 
-#: static/js/zamboni/mobile/buttons.js:52
+#: static/js/zamboni/devhub_search.js:8
+msgid "No results found."
+msgstr "ਕੋਈ ਨਤੀਜਾ ਨਹੀਂ ਮਿਲਿਆ।"
+
+#: static/js/zamboni/editors-all.js:15402 static/js/zamboni/editors-min.js:4 static/js/zamboni/editors.js:121
+msgid "{name} was viewing this page first."
+msgstr "{name} ਇਹ ਸਫਾ ਪਹਿਲਾਂ ਦੇਖਿਆ ਸੀ।"
+
+#: static/js/zamboni/editors-all.js:15452 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:171
+msgid "Receipt checked by app."
+msgstr "ਰਸ਼ੀਦ ਐਪ ਦੁਆਰਾ ਚੈੱਕ।"
+
+#: static/js/zamboni/editors-all.js:15454 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:173
+msgid "Receipt was not checked by app."
+msgstr "ਰਸ਼ੀਦ ਐਪ ਦੁਆਰਾ ਚੈੱਕ ਨਹੀਂ ਕੀਤੀ ਸੀ।"
+
+#: static/js/zamboni/editors-all.js:15525 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:244
+msgid "{name} was viewing this add-on first."
+msgstr "{name} ਇਹ ਐਡ-ਆਨ ਪਹਿਲਾਂ ਦੇਖਿਆ ਸੀ।"
+
+#: static/js/zamboni/editors-all.js:15536 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:255
+msgid "Loading&hellip;"
+msgstr "&hellip; ਲ੍ਹੋਡ ਕੀਤਾ ਜਾ ਰਿਹਾ"
+
+#: static/js/zamboni/editors-all.js:15541 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:260
+msgid "Version Notes"
+msgstr "ਸੂਚਨਾਂ ਵਰਜਨ"
+
+#: static/js/zamboni/editors-all.js:15546 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:265
+msgid "Notes for Reviewers"
+msgstr "ਸਮੀਖਿਅਕ ਲਈ ਸੂਚਨਾਂ"
+
+#: static/js/zamboni/editors-all.js:15551 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:270
+msgid "No version notes found"
+msgstr "ਵਰਜਨ ਨੂੰ ਨੋਟਿਸ ਨਹੀਂ ਮਿਲਿਆ"
+
+#: static/js/zamboni/editors-all.js:15611 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:330
+msgid "Average Reviews"
+msgstr "ਔਸਤ ਸਮੀਖਿਆ"
+
+#: static/js/zamboni/editors-all.js:15667 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:386
+msgid "Number of Reviews"
+msgstr "ਨੰਬਰ ਵਿੱਚੋਂ ਸਮੀਖਿਆ"
+
+#: static/js/zamboni/editors-all.js:15726 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:445
+msgid "Error loading translation"
+msgstr "ਲ੍ਹੋਡ ਕਰਨ ਦੌਰਾਨ ਅਨੁਵਾਦ ਗਲਤੀ"
+
+#: static/js/zamboni/editors-all.js:15975 static/js/zamboni/editors-min.js:5 static/js/zamboni/themes_review_templates.js:31
+msgid "Theme"
+msgstr ""
+
+#: static/js/zamboni/editors-all.js:15977 static/js/zamboni/editors-min.js:5 static/js/zamboni/themes_review_templates.js:33
+msgid "Reviewer"
+msgstr ""
+
+#: static/js/zamboni/editors-all.js:15979 static/js/zamboni/editors-min.js:5 static/js/zamboni/themes_review_templates.js:35
+msgid "Status"
+msgstr ""
+
+#: static/js/zamboni/editors-all.js:16196 static/js/zamboni/editors-min.js:5 static/js/zamboni/themes_review.js:176
+msgid "Requested Info"
+msgstr "ਜਾਣਕਾਰੀ ਲਈ ਬੇਨਤੀ"
+
+#: static/js/zamboni/editors-all.js:16197 static/js/zamboni/editors-min.js:5 static/js/zamboni/themes_review.js:177
+msgid "Flagged"
+msgstr "ਫਲੈਗ ਕੀਤੇ ਹੋਏ"
+
+#: static/js/zamboni/editors-all.js:16198 static/js/zamboni/editors-min.js:5 static/js/zamboni/themes_review.js:178
+msgid "Duplicate"
+msgstr "ਨਕਲੀ"
+
+#: static/js/zamboni/editors-all.js:16199 static/js/zamboni/editors-min.js:5 static/js/zamboni/themes_review.js:179
+msgid "Rejected"
+msgstr "ਰੱਦ ਕਰੋ"
+
+#: static/js/zamboni/editors-all.js:16200 static/js/zamboni/editors-min.js:5 static/js/zamboni/themes_review.js:180
+msgid "Approved"
+msgstr "ਮੰਨਜੂਰੀ ਦੇਣਾ"
+
+#: static/js/zamboni/editors-all.js:16444 static/js/zamboni/editors-min.js:5 static/js/zamboni/themes_review.js:424
+msgid "No results found"
+msgstr ""
+
+#: static/js/zamboni/mobile-all.js:15186 static/js/zamboni/mobile/buttons.js:52
 msgid "Not Updated for {0} {1}"
 msgstr "{0} {1} ਲਈ ਅੱਪਡੇਟ ਨਹੀਂ"
 
-#: static/js/zamboni/mobile/buttons.js:53
+#: static/js/zamboni/mobile-all.js:15187 static/js/zamboni/mobile/buttons.js:53
 msgid "Requires Newer Version of {0}"
 msgstr "{0} ਤੋਂ ਨਵੇਂ ਵਰਜਨ ਦੀ ਮੰਗ"
 
-#: static/js/zamboni/mobile/buttons.js:54
+#: static/js/zamboni/mobile-all.js:15188 static/js/zamboni/mobile/buttons.js:54
 msgid "Unreviewed"
 msgstr "ਨਾ-ਸਮੀਖਿਆ"
 
-#: static/js/zamboni/mobile/buttons.js:55
+#: static/js/zamboni/mobile-all.js:15189 static/js/zamboni/mobile/buttons.js:55
 msgid "Experimental <span>(Learn More)</span>"
 msgstr "ਪ੍ਰਯੋਗਆਤਮਕ <span>(ਹੋਰ ਜਾਣੋ)</span>"
 
-#: static/js/zamboni/mobile/buttons.js:56 static/js/zamboni/mobile/buttons.js:57
+#: static/js/zamboni/mobile-all.js:15190 static/js/zamboni/mobile-all.js:15191 static/js/zamboni/mobile/buttons.js:56 static/js/zamboni/mobile/buttons.js:57
 msgid "Not Available for {0}"
 msgstr "{0} ਲਈ ਉੱਪਲਬਧ ਨਹੀਂ"
 
-#: static/js/zamboni/mobile/buttons.js:58
+#: static/js/zamboni/mobile-all.js:15192 static/js/zamboni/mobile/buttons.js:58
 msgid "Experimental"
 msgstr "ਤਜਰਬੇ"
 
-#: static/js/zamboni/mobile/buttons.js:59
+#: static/js/zamboni/mobile-all.js:15193 static/js/zamboni/mobile/buttons.js:59
 msgid "Themes Require Newer Version of {0}"
 msgstr "ਥੀਮਾਂ ਨੂੰ {0} ਦੇ ਨਵੇਂ ਵਰਜਨ ਦੀ ਲੋੜ"
 
-#: static/js/zamboni/mobile/buttons.js:60
+#: static/js/zamboni/mobile-all.js:15194 static/js/zamboni/mobile/buttons.js:60
 msgid "Themes Require {0}"
 msgstr "ਥੀਮਾਂ ਨੂੰ {0} ਦੀ ਲੋੜ"
 
-#: static/js/zamboni/mobile/buttons.js:105
+#: static/js/zamboni/mobile-all.js:15239 static/js/zamboni/mobile/buttons.js:105
 msgid "Installing..."
 msgstr "ਇੰਸਟਾਲ ਕਰਨਾ"
 
-#: static/js/zamboni/mobile/buttons.js:125
+#: static/js/zamboni/mobile-all.js:15259 static/js/zamboni/mobile/buttons.js:125
 msgid "This add-on has been preliminarily reviewed by Mozilla."
 msgstr "ਮੌਜੀਲਾ ਨੇ ਇਸ ਐਡ-ਆਨ ਦੀ ਸ਼ੁਰੂਆਤੀ ਸਮੀਖਿਆ ਕੀਤੀ।"
 
-#: static/js/zamboni/mobile/buttons.js:250
+#: static/js/zamboni/mobile-all.js:15384 static/js/zamboni/mobile/buttons.js:250
 msgid "Keep it"
 msgstr "ਇਸ ਨੂੰ ਰੱਖੋ"
 
-#: static/js/zamboni/mobile/general.js:344
+#: static/js/zamboni/mobile-all.js:16049 static/js/zamboni/mobile-min.js:6 static/js/zamboni/mobile/general.js:344
 msgid "You're trying it on!"
 msgstr "ਤੁਸੀਂ ਇਸਦੀ ਪਰਖ ਕਰ ਰਹੇ ਹੋ!"
 
-#: static/js/zamboni/mobile/general.js:356
+#: static/js/zamboni/mobile-all.js:16061 static/js/zamboni/mobile-min.js:6 static/js/zamboni/mobile/general.js:356
 msgid "Added to Firefox"
 msgstr "ਫ਼ਾਇਰਫ਼ਾਕਸ ਵਿੱਚ ਸ਼ਾਮਲ"
-

--- a/locale/pa_IN/LC_MESSAGES/django.po
+++ b/locale/pa_IN/LC_MESSAGES/django.po
@@ -2,72 +2,71 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2016-02-24 21:23+0000\n"
+"POT-Creation-Date: 2016-04-18 15:47+0000\n"
 "PO-Revision-Date: 2015-07-18 03:09+0000\n"
 "Last-Translator: ubuntuser13 <ubuntuser13@gmail.com>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
-"Language: pa_IN\n"
+"Language: \n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1) ;\n"
-"X-Generator: Pootle 2.5.0\n"
-"X-POOTLE-MTIME: 1437188980.0\n"
+"Generated-By: Babel 2.2.0\n"
 
-#: src/olympia/accounts/views.py:52
+#: src/olympia/accounts/views.py:54
 msgid "Your log in attempt could not be parsed. Please try again."
 msgstr ""
 
-#: src/olympia/accounts/views.py:54
+#: src/olympia/accounts/views.py:56
 msgid "Your Firefox Account could not be found. Please try again."
 msgstr ""
 
-#: src/olympia/accounts/views.py:55
+#: src/olympia/accounts/views.py:57
 msgid "You could not be logged in. Please try again."
 msgstr ""
 
-#: src/olympia/accounts/views.py:57
+#: src/olympia/accounts/views.py:59
 msgid "Your account has already been migrated to Firefox Accounts."
 msgstr ""
 
-#: src/olympia/accounts/views.py:59
+#: src/olympia/accounts/views.py:61
 msgid "Your Firefox Account already exists on this site."
 msgstr ""
 
-#: src/olympia/accounts/views.py:108
+#: src/olympia/accounts/views.py:110
 msgid "Great job!"
 msgstr ""
 
-#: src/olympia/accounts/views.py:109
+#: src/olympia/accounts/views.py:111
 msgid "You can now log in to Add-ons with your Firefox Account."
 msgstr ""
 
-#: src/olympia/accounts/views.py:121
+#: src/olympia/accounts/views.py:123
 msgid "Need help?"
 msgstr ""
 
-#: src/olympia/addons/buttons.py:180
+#: src/olympia/addons/buttons.py:177
 msgid "Download Now"
 msgstr "                  ਹੁਣੇ ਹੀ ਡਾਓਨਲੋਡ ਕਰੋ                "
 
-#: src/olympia/addons/buttons.py:182
+#: src/olympia/addons/buttons.py:179
 msgid "Download"
 msgstr "ਡਾਓਨਲੋਡ"
 
 #. L10n: please keep &nbsp; in the string so &rarr; does not wrap.
-#: src/olympia/addons/buttons.py:186
+#: src/olympia/addons/buttons.py:183
 msgid "Continue to Download&nbsp;&rarr;"
 msgstr "ਡਾਊਨਲੋਡ&nbsp;&rarr; ਲਈ ਜਾਰੀ"
 
-#: src/olympia/addons/buttons.py:202 src/olympia/addons/helpers.py:35 src/olympia/addons/views.py:319 src/olympia/addons/templates/addons/impala/details.html:114
+#: src/olympia/addons/buttons.py:199 src/olympia/addons/helpers.py:35 src/olympia/addons/views.py:333 src/olympia/addons/templates/addons/impala/details.html:111
 #: src/olympia/addons/templates/addons/impala/listing/items.html:17 src/olympia/addons/templates/addons/mobile/home.html:40 src/olympia/amo/templates/amo/side_nav.html:6
-#: src/olympia/amo/templates/amo/side_nav.html:10 src/olympia/amo/templates/amo/site_nav.html:2 src/olympia/amo/templates/amo/site_nav.html:55 src/olympia/bandwagon/views.py:95
-#: src/olympia/browse/views.py:54 src/olympia/browse/views.py:68 src/olympia/browse/views.py:235 src/olympia/browse/templates/browse/impala/category_landing.html:22
+#: src/olympia/amo/templates/amo/side_nav.html:10 src/olympia/amo/templates/amo/site_nav.html:2 src/olympia/amo/templates/amo/site_nav.html:53 src/olympia/bandwagon/views.py:95
+#: src/olympia/browse/views.py:54 src/olympia/browse/views.py:68 src/olympia/browse/views.py:202 src/olympia/browse/templates/browse/impala/category_landing.html:22
 #: src/olympia/browse/templates/browse/personas/mobile/category_landing.html:26
 msgid "Featured"
 msgstr "ਪੇਸ਼ ਕੀਤਾ"
 
-#: src/olympia/addons/buttons.py:221
+#: src/olympia/addons/buttons.py:218
 msgid "Add to {0}"
 msgstr "{0} ਨੂੰ ਸ਼ਾਮਲ ਕਰੋ"
 
@@ -115,39 +114,39 @@ msgid_plural "All tags must be at least {0} characters."
 msgstr[0] "ਸਾਰੇ ਟੈਗ ਘੱਟੋ-ਘੱਟ {0} ਅੱਖਰ ਦੇ ਹੋਣੇ ਚਾਹੀਦੇ ਹਨ।"
 msgstr[1] "ਸਾਰੇ ਟੈਗ ਘੱਟੋ-ਘੱਟ {0} ਅੱਖਰਾਂ ਦੇ ਹੋਣੇ ਚਾਹੀਦੇ ਹਨ।"
 
-#: src/olympia/addons/forms.py:234
+#: src/olympia/addons/forms.py:238
 msgid "Categories cannot be changed while your add-on is featured for this application."
 msgstr "ਵਰਗ ਬਦਲੇ ਨਹੀਂਂ ਜਾ ਸਕਦੇ ਜਦ ਕਿ ਤੁਹਾਡਾ ਐਡਓਨ ਇਸ ਐਪਲੀਕੇਸ਼ਨ ਲਈ ਪੇਸ਼ ਕੀਤਾ ਗਿਆ ਹੈ।"
 
 #. L10n: {0} is the number of categories.
-#: src/olympia/addons/forms.py:238
+#: src/olympia/addons/forms.py:242
 msgid "You can have only {0} category."
 msgid_plural "You can have only {0} categories."
 msgstr[0] "ਤੁਹਾਡੇ ਕੋਲ ਕੇਵਲ {0} ਵਰਗ ਹੋ ਸਕਦਾ ਹਨ।"
 msgstr[1] "ਤੁਹਾਡੇ ਕੋਲ ਕੇਵਲ {0} ਵਰਗ ਹੋ ਸਕਦੇ ਹਨ।"
 
-#: src/olympia/addons/forms.py:246
+#: src/olympia/addons/forms.py:250
 msgid "The miscellaneous category cannot be combined with additional categories."
 msgstr "ਫ਼ੁਟਕਲ ਵਰਗ ਹੋਰ ਵਰਗਾਂ ਨਾਲ ਜੋੜਿਆ ਨਹੀਂਂ ਜਾ ਸਕਦਾ।"
 
-#: src/olympia/addons/forms.py:369
+#: src/olympia/addons/forms.py:374
 #, python-format
 msgid "Before changing your default locale you must have a name, summary, and description in that locale. You are missing %s."
 msgstr "ਤੁਹਾਡਾ ਮੂਲ ਲੋਕੇਲ ਬਦਲਣ ਤੋਂ ਪਹਿਲਾਂ ਤੁਹਾਡੇ ਕੋਲ ਉਸ ਲੋਕੇਲ ਵਿੱਚ ਇੱਕ ਨਾਂ, ਸੰਖੇਪ ਖੁਲਾਸਾ, ਅਤੇ ਵੇਰਵਾ ਜ਼ਰੂਰ ਹੋਣਾ ਚਾਹੀਦਾ ਹੈ। ਤੁਸੀਂ %s ਭੁੱਲ ਗਏ ਹੋ।"
 
-#: src/olympia/addons/forms.py:484 src/olympia/addons/forms.py:575
+#: src/olympia/addons/forms.py:455 src/olympia/addons/forms.py:546
 msgid "A license must be selected."
 msgstr "ਇਕ ਲਾਇਸੰਸ ਚੁਣਿਆ ਜਾਣਾ ਚਾਹੀਦਾ ਹੈ।"
 
-#: src/olympia/addons/forms.py:556
+#: src/olympia/addons/forms.py:527
 msgid "Give Your Theme a Name."
 msgstr "ਆਪਣੇ ਥੀਮ ਨੂੰ ਇੱਕ ਨਾਂ ਦਿਓ।"
 
-#: src/olympia/addons/forms.py:562 src/olympia/devhub/templates/devhub/personas/submit.html:53
+#: src/olympia/addons/forms.py:533 src/olympia/devhub/templates/devhub/personas/submit.html:53
 msgid "Describe your Theme."
 msgstr "ਤੁਹਾਡਾ ਥੀਮ ਦਾ ਵਰਣਨ ਕਰੋ।"
 
-#: src/olympia/addons/forms.py:704
+#: src/olympia/addons/forms.py:675
 msgid "Enter a new author's email address"
 msgstr "ਇੱਕ ਨਵੇਂ ਲੇਖਕ ਦਾ ਈਮੇਲ ਪਤਾ ਭਰੋ"
 
@@ -155,37 +154,37 @@ msgstr "ਇੱਕ ਨਵੇਂ ਲੇਖਕ ਦਾ ਈਮੇਲ ਪਤਾ ਭਰ
 msgid "Not Reviewed"
 msgstr "ਪੁਨਰ ਵਿਚਾਰ ਨਹੀਂ"
 
-#: src/olympia/addons/models.py:301
+#: src/olympia/addons/models.py:298
 msgid "Users have the option of contributing more or less than this amount."
 msgstr "ਉਪਭੋਗੀਆਂ ਕੋਲ ਇਸ ਰਕਮ ਨਾਲੋਂ ਵੱਧ ਜਾਂ ਘੱਟ ਯੋਗਦਾਨ ਦੇਣ ਦੀ ਚੋਣ ਹੈ।"
 
-#: src/olympia/addons/models.py:309
-msgid "Users will always be asked in the Add-ons Manager (Firefox 4 and above)"
-msgstr "ਉਪਭੋਗੀਆਂ ਨੂੰ ਹਮੇਸ਼ਾ ਐਡ-ਆਨ ਮੈਨੇਜਰ ਵਿੱਚ ਕਿਹਾ ਜਾਵੇਗਾ (ਫ਼ਾਇਰਫ਼ਾਕਸ 4 ਅਤੇ ਉਪਰੋਕਤ)"
+#: src/olympia/addons/models.py:306
+msgid "Users will always be asked in the Add-ons Manager (Firefox 4 and above). Only applies to desktop."
+msgstr ""
 
-#: src/olympia/addons/models.py:1804 src/olympia/addons/templates/addons/details_box.html:55 src/olympia/devhub/templates/devhub/index.html:92
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:102
+#: src/olympia/addons/models.py:1802 src/olympia/addons/templates/addons/details_box.html:55 src/olympia/devhub/templates/devhub/index.html:92
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:89
 msgid "Listed"
 msgstr "ਸੂਚੀਬੱਧ"
 
-#: src/olympia/addons/views.py:320 src/olympia/browse/templates/browse/personas/mobile/category_landing.html:27
+#: src/olympia/addons/views.py:334 src/olympia/browse/templates/browse/personas/mobile/category_landing.html:27
 msgid "Popular"
 msgstr "ਮਸ਼ਹੂਰ"
 
-#: src/olympia/addons/views.py:321 src/olympia/browse/views.py:238 src/olympia/browse/views.py:280 src/olympia/browse/views.py:482
+#: src/olympia/addons/views.py:335 src/olympia/browse/views.py:205 src/olympia/browse/views.py:247 src/olympia/browse/views.py:449
 msgid "Recently Added"
 msgstr "ਹਾਲ ਹੀ ਵਿੱਚ ਸ਼ਾਮਲ ਕੀਤਾ"
 
-#: src/olympia/addons/views.py:322 src/olympia/bandwagon/views.py:99 src/olympia/browse/views.py:60 src/olympia/browse/views.py:71 src/olympia/search/forms.py:16 src/olympia/search/forms.py:91
+#: src/olympia/addons/views.py:336 src/olympia/bandwagon/views.py:99 src/olympia/browse/views.py:60 src/olympia/browse/views.py:71 src/olympia/search/forms.py:16 src/olympia/search/forms.py:91
 msgid "Recently Updated"
 msgstr "ਹਾਲ ਹੀ ਵਿੱਚ ਅੱਪਡੇਟ ਕੀਤਾ"
 
 #. l10n: {0} is the addon name
-#: src/olympia/addons/views.py:520
+#: src/olympia/addons/views.py:534
 msgid "Contribution for {0}"
 msgstr "{0} ਲਈ ਯੋਗਦਾਨ"
 
-#: src/olympia/addons/views.py:613
+#: src/olympia/addons/views.py:627
 msgid "Abuse reported."
 msgstr "ਬਦਸਲੂਕੀ ਦੀ ਸੂਚਨਾ।"
 
@@ -252,9 +251,9 @@ msgstr "ਯੋਗਦਾਨ ਪਾਓ"
 #: src/olympia/devhub/templates/devhub/addons/ajax_compat_update.html:36 src/olympia/devhub/templates/devhub/addons/profile.html:44 src/olympia/devhub/templates/devhub/addons/edit/admin.html:101
 #: src/olympia/devhub/templates/devhub/addons/edit/basic.html:152 src/olympia/devhub/templates/devhub/addons/edit/details.html:85 src/olympia/devhub/templates/devhub/addons/edit/support.html:67
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:166 src/olympia/devhub/templates/devhub/addons/forms_shared/media.html:149
-#: src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:44 src/olympia/devhub/templates/devhub/versions/add_file_modal.html:78 src/olympia/devhub/templates/devhub/versions/edit.html:139
-#: src/olympia/devhub/templates/devhub/versions/list.html:242 src/olympia/devhub/templates/devhub/versions/list.html:276 src/olympia/devhub/templates/devhub/versions/list.html:317
-#: src/olympia/devhub/templates/devhub/versions/list.html:351 src/olympia/reviews/templates/reviews/edit_review.html:16 src/olympia/translations/templates/translations/trans-menu.html:50
+#: src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:43 src/olympia/devhub/templates/devhub/versions/add_file_modal.html:58 src/olympia/devhub/templates/devhub/versions/edit.html:139
+#: src/olympia/devhub/templates/devhub/versions/list.html:239 src/olympia/devhub/templates/devhub/versions/list.html:281 src/olympia/devhub/templates/devhub/versions/list.html:315
+#: src/olympia/devhub/templates/devhub/versions/list.html:349 src/olympia/reviews/templates/reviews/edit_review.html:16 src/olympia/translations/templates/translations/trans-menu.html:50
 #: src/olympia/translations/templates/translations/trans-menu.html:62
 msgid "or"
 msgstr "ਜਾਂ"
@@ -365,7 +364,7 @@ msgid "Add-on Information for {0}"
 msgstr "{0} ਲਈ ਐਡ-ਆਨ ਦੀ ਜਾਣਕਾਰੀ"
 
 #: src/olympia/addons/templates/addons/details_box.html:30 src/olympia/addons/templates/addons/persona_detail_table.html:3 src/olympia/addons/templates/addons/mobile/details.html:63
-#: src/olympia/addons/templates/addons/mobile/persona_detail_table.html:7 src/olympia/browse/views.py:459 src/olympia/devhub/views.py:75
+#: src/olympia/addons/templates/addons/mobile/persona_detail_table.html:7 src/olympia/browse/views.py:426 src/olympia/devhub/views.py:73
 msgid "Updated"
 msgstr "ਅੱਪਡੇਟ ਹੋਇਆ"
 
@@ -384,11 +383,11 @@ msgstr "ਨਾਲ ਕੰਮ ਕਰਦਾ"
 msgid "Visibility"
 msgstr "ਪ੍ਰਤੱਖਤਾ"
 
-#: src/olympia/addons/templates/addons/details_box.html:57 src/olympia/devhub/templates/devhub/index.html:94 src/olympia/devhub/templates/devhub/includes/addon_details.html:104
+#: src/olympia/addons/templates/addons/details_box.html:57 src/olympia/devhub/templates/devhub/index.html:94 src/olympia/devhub/templates/devhub/includes/addon_details.html:91
 msgid "Hidden"
 msgstr "ਲੁਕਿਆ"
 
-#: src/olympia/addons/templates/addons/details_box.html:59 src/olympia/devhub/templates/devhub/index.html:96 src/olympia/devhub/templates/devhub/includes/addon_details.html:106
+#: src/olympia/addons/templates/addons/details_box.html:59 src/olympia/devhub/templates/devhub/index.html:96 src/olympia/devhub/templates/devhub/includes/addon_details.html:93
 msgid "Unlisted"
 msgstr "ਅਣਸੂਚੀਬੱਧ"
 
@@ -396,13 +395,13 @@ msgstr "ਅਣਸੂਚੀਬੱਧ"
 msgid "Required Add-ons"
 msgstr "ਲੌੜੀਂਦੇ ਐਡ-ਆਨ"
 
-#: src/olympia/addons/templates/addons/details_box.html:81 src/olympia/addons/templates/addons/persona_detail_table.html:15 src/olympia/browse/views.py:462 src/olympia/devhub/views.py:78
-#: src/olympia/devhub/views.py:85 src/olympia/discovery/templates/discovery/addons/detail.html:57 src/olympia/reviews/forms.py:62 src/olympia/reviews/templates/reviews/add.html:57
+#: src/olympia/addons/templates/addons/details_box.html:81 src/olympia/addons/templates/addons/persona_detail_table.html:15 src/olympia/browse/views.py:429 src/olympia/devhub/views.py:76
+#: src/olympia/devhub/views.py:83 src/olympia/discovery/templates/discovery/addons/detail.html:57 src/olympia/reviews/forms.py:62 src/olympia/reviews/templates/reviews/add.html:57
 #: src/olympia/reviews/templates/reviews/mobile/review_list.html:18
 msgid "Rating"
 msgstr "ਰੇਟਿੰਗ"
 
-#: src/olympia/addons/templates/addons/details_box.html:85 src/olympia/browse/views.py:461 src/olympia/devhub/views.py:77 src/olympia/devhub/views.py:84
+#: src/olympia/addons/templates/addons/details_box.html:85 src/olympia/browse/views.py:428 src/olympia/devhub/views.py:75 src/olympia/devhub/views.py:82
 #: src/olympia/stats/templates/stats/addon_report_menu.html:8 src/olympia/stats/templates/stats/collection_report_menu.html:18
 msgid "Downloads"
 msgstr "ਡਾਊਨਲੋਡ"
@@ -422,7 +421,7 @@ msgstr "ਦੁਰਵਿਹਾਰ ਸੂਚਨਾਵਾਂ"
 
 #. The Privacy Policy for this add-on.
 #: src/olympia/addons/templates/addons/details_box.html:121 src/olympia/addons/templates/addons/privacy.html:19 src/olympia/addons/templates/addons/privacy.html:23
-#: src/olympia/addons/templates/addons/impala/button.html:43 src/olympia/addons/templates/addons/impala/details.html:307 src/olympia/devhub/templates/devhub/includes/policy_form.html:20
+#: src/olympia/addons/templates/addons/impala/button.html:43 src/olympia/addons/templates/addons/impala/details.html:312 src/olympia/devhub/templates/devhub/includes/policy_form.html:23
 #: src/olympia/templates/mobile/base_addons.html:87
 msgid "Privacy Policy"
 msgstr "ਪਰਦਾ ਨੀਤੀ"
@@ -447,7 +446,7 @@ msgstr "ਤਸਵੀਰ ਗੈਲਰੀ"
 msgid "Developer Comments"
 msgstr "ਡਿਵੈਲਪਰ ਟਿੱਪਣੀਆਂ"
 
-#: src/olympia/addons/templates/addons/details_box.html:199 src/olympia/addons/templates/addons/impala/details.html:259
+#: src/olympia/addons/templates/addons/details_box.html:199 src/olympia/addons/templates/addons/impala/details.html:264
 msgid "Development Channel"
 msgstr "ਵਿਕਾਸ ਚੈਨਲ"
 
@@ -469,7 +468,7 @@ msgstr ""
 "<strong>ਸਾਵਧਾਨੀ:</strong> ਇਸ ਐਡ-ਆਨ ਦੇ ਵਿਕਾਸ ਵਰਜਨ ਦੀ ਮੌਜ਼ੀਲਾ ਵੱਲੋਂ ਸਮੀਖਿਆ ਨਹੀਂ ਕੀਤੀ ਗਈ। ਇੱਕ ਵਾਰ ਤੁਸੀਂ ਇੱਕ ਵਿਕਾਸ ਵਰਜਨ ਇੰਸਟਾਲ ਕਰ ਲਿਆ ਤਾਂ ਤੁਹਾਡਾ ਇਸ ਦੇ ਡਿਵੈਲਪਰ ਤੋਂ ਵਿਕਾਸ ਅੱਪਡੇਟਾਂ ਲੈਣਾ ਜਾਰੀ ਰਹੇਗਾ। ਵਿਕਾਸ ਅੱਪਡੇਟਾਂ ਲੈਣੀਆਂ ਬੰਦ ਕਰਨ ਲਈ, "
 "ਉੱਪਰ ਦਿੱਤੇ ਲਿੰਕ ਤੋਂ ਮੂਲ ਵਰਜਨ ਮੁੜ ਇੰਸਟਾਲ ਕਰੋ।"
 
-#: src/olympia/addons/templates/addons/details_box.html:220 src/olympia/addons/templates/addons/impala/details.html:278
+#: src/olympia/addons/templates/addons/details_box.html:220 src/olympia/addons/templates/addons/impala/details.html:283
 msgid "Version {0}:"
 msgstr "ਵਰਜਨ {0}:"
 
@@ -488,7 +487,7 @@ msgid "End-User License Agreement for {0}"
 msgstr "ਲਈ ਅੰਤ-ਉਪਭੋਗੀ ਲਾਇਸੰਸ ਸਮਝੌਤਾ {0}"
 
 #: src/olympia/addons/templates/addons/eula.html:17 src/olympia/addons/templates/addons/eula.html:21 src/olympia/addons/templates/addons/impala/button.html:48
-#: src/olympia/addons/templates/addons/impala/details.html:316 src/olympia/devhub/templates/devhub/includes/policy_form.html:3 src/olympia/discovery/templates/discovery/addons/eula.html:11
+#: src/olympia/addons/templates/addons/impala/details.html:321 src/olympia/devhub/templates/devhub/includes/policy_form.html:3 src/olympia/discovery/templates/discovery/addons/eula.html:11
 msgid "End-User License Agreement"
 msgstr "ਅੰਤ-ਉਪਭੋਗੀ ਲਾਇਸੰਸ ਸਮਝੌਤਾ"
 
@@ -505,7 +504,7 @@ msgstr "{0} ਤੇ ਵਾਪਸ"
 msgid "Add-ons for {0}"
 msgstr "ਇਕਸਟੈਨਸ਼ਨ ਪੇਸਕਸ਼"
 
-#: src/olympia/addons/templates/addons/home.html:10 src/olympia/addons/templates/addons/home.html:51 src/olympia/browse/templates/browse/impala/base_listing.html:11
+#: src/olympia/addons/templates/addons/home.html:10 src/olympia/addons/templates/addons/home.html:53 src/olympia/browse/templates/browse/impala/base_listing.html:11
 msgid "Featured Extensions"
 msgstr "ਇਕਸਟੈਨਸ਼ਨਾਂ ਦੀ ਪੇਸਕਸ਼"
 
@@ -513,29 +512,29 @@ msgstr "ਇਕਸਟੈਨਸ਼ਨਾਂ ਦੀ ਪੇਸਕਸ਼"
 msgid "Popular Extensions"
 msgstr "ਪ੍ਰਸਿੱਧ ਇਕਸਟੈਨਸ਼ਨਾਂ"
 
-#: src/olympia/addons/templates/addons/home.html:42 src/olympia/amo/templates/amo/side_nav.html:3 src/olympia/amo/templates/amo/side_nav.html:11 src/olympia/amo/templates/amo/site_nav.html:3
-#: src/olympia/amo/templates/amo/site_nav.html:25 src/olympia/browse/views.py:236 src/olympia/browse/views.py:281 src/olympia/browse/views.py:481
+#: src/olympia/addons/templates/addons/home.html:44 src/olympia/amo/templates/amo/side_nav.html:3 src/olympia/amo/templates/amo/side_nav.html:11 src/olympia/amo/templates/amo/site_nav.html:3
+#: src/olympia/amo/templates/amo/site_nav.html:25 src/olympia/browse/views.py:203 src/olympia/browse/views.py:248 src/olympia/browse/views.py:448
 msgid "Most Popular"
 msgstr "ਸੱਭ ਤੋਂ ਮਸ਼ਹੂਰ"
 
-#: src/olympia/addons/templates/addons/home.html:43
+#: src/olympia/addons/templates/addons/home.html:45
 msgid "All »"
 msgstr "ਸਾਰੇ »"
 
-#: src/olympia/addons/templates/addons/home.html:52 src/olympia/addons/templates/addons/home.html:61 src/olympia/addons/templates/addons/home.html:70 src/olympia/addons/templates/addons/home.html:78
+#: src/olympia/addons/templates/addons/home.html:54 src/olympia/addons/templates/addons/home.html:63 src/olympia/addons/templates/addons/home.html:72 src/olympia/addons/templates/addons/home.html:80
 #: src/olympia/browse/templates/browse/impala/category_landing.html:36
 msgid "See all »"
 msgstr "ਵੇਖੋ ਸਾਰੇ »"
 
-#: src/olympia/addons/templates/addons/home.html:60
+#: src/olympia/addons/templates/addons/home.html:62
 msgid "Up &amp; Coming Extensions"
 msgstr "ਉੱਤੇ &amp; ਆ ਰਹੀਆਂ ਇਕਸਟੈਨਸ਼ਨਾਂ"
 
-#: src/olympia/addons/templates/addons/home.html:69 src/olympia/browse/templates/browse/personas/category_landing.html:61 src/olympia/discovery/templates/discovery/pane.html:74
+#: src/olympia/addons/templates/addons/home.html:71 src/olympia/browse/templates/browse/personas/category_landing.html:61 src/olympia/discovery/templates/discovery/pane.html:74
 msgid "Featured Themes"
 msgstr "ਥੀਮ ਪੇਸਕਸ਼"
 
-#: src/olympia/addons/templates/addons/home.html:77 src/olympia/bandwagon/templates/bandwagon/impala/collection_listing.html:5
+#: src/olympia/addons/templates/addons/home.html:79 src/olympia/bandwagon/templates/bandwagon/impala/collection_listing.html:5
 msgid "Featured Collections"
 msgstr "ਸੰਗ੍ਰਹਿ ਪੇਸਕਸ਼"
 
@@ -553,7 +552,7 @@ msgid "Updated {0}"
 msgstr "ਅੱਪਡੇਟ ਹੋਇਆ {0}"
 
 #. {0} is a date.
-#: src/olympia/addons/templates/addons/macros.html:10 src/olympia/addons/templates/addons/macros.html:69 src/olympia/addons/templates/addons/persona_preview.html:21
+#: src/olympia/addons/templates/addons/macros.html:10 src/olympia/addons/templates/addons/macros.html:69 src/olympia/addons/templates/addons/persona_preview.html:22
 #: src/olympia/addons/templates/addons/listing/items_mobile.html:44 src/olympia/addons/templates/addons/listing/macros.html:39
 #: src/olympia/bandwagon/templates/bandwagon/collection_listing_items.html:37 src/olympia/bandwagon/templates/bandwagon/impala/collection_listing_items.html:37
 msgid "Added {0}"
@@ -574,15 +573,14 @@ msgstr[0] "%(num)s ਉਪਭੋਗੀ"
 msgstr[1] "%(num)s ਉਪਭੋਗੀ"
 
 #. {0} is the number of downloads.
-#: src/olympia/addons/templates/addons/macros.html:53 src/olympia/addons/templates/addons/impala/details.html:61
+#: src/olympia/addons/templates/addons/macros.html:53 src/olympia/addons/templates/addons/impala/details.html:59
 msgid "{0} weekly download"
 msgid_plural "{0} weekly downloads"
 msgstr[0] "{0} ਹਫ਼ਤੇਵਾਰ ਡਾਊਨਲੋਡ"
 msgstr[1] "{0} ਹਫ਼ਤੇਵਾਰ ਡਾਊਨਲੋਡ"
 
 #. {0} is the number of users.
-#: src/olympia/addons/templates/addons/macros.html:61 src/olympia/addons/templates/addons/impala/details.html:54 src/olympia/compat/templates/compat/index.html:71
-#: src/olympia/zadmin/templates/zadmin/compat.html:67
+#: src/olympia/addons/templates/addons/macros.html:61 src/olympia/addons/templates/addons/impala/details.html:52 src/olympia/zadmin/templates/zadmin/compat.html:67
 msgid "{0} user"
 msgid_plural "{0} users"
 msgstr[0] "{0} ਉਪਭੋਗੀ"
@@ -600,7 +598,7 @@ msgstr "ਭੁਗਤਾਨ ਮੁਕੰਮਲ ਹੋਇਆ"
 msgid "Return to the addon."
 msgstr "ਐਡ-ਆਨ ਤੇ ਵਾਪਸ।"
 
-#: src/olympia/addons/templates/addons/persona_detail.html:17 src/olympia/addons/templates/addons/impala/details.html:106 src/olympia/addons/templates/addons/mobile/details.html:23
+#: src/olympia/addons/templates/addons/persona_detail.html:17 src/olympia/addons/templates/addons/impala/details.html:103 src/olympia/addons/templates/addons/mobile/details.html:23
 #: src/olympia/addons/templates/addons/mobile/persona_detail.html:21 src/olympia/discovery/templates/discovery/addons/base.html:27 src/olympia/editors/templates/editors/review.html:31
 msgid "by"
 msgstr "ਵੱਲੋਂ"
@@ -644,34 +642,35 @@ msgstr "ਰੋਜ਼ਾਨਾ ਉਪਭੋਗੀ"
 msgid "License"
 msgstr "ਲਾਇਸੰਸ"
 
-#: src/olympia/addons/templates/addons/persona_preview.html:12 src/olympia/constants/base.py:48
+#: src/olympia/addons/templates/addons/persona_preview.html:13 src/olympia/constants/base.py:48
 msgid "Awaiting Review"
 msgstr "ਸਮੀਖਿਆ ਦੀ ਉਡੀਕ"
 
-#: src/olympia/addons/templates/addons/persona_preview.html:14 src/olympia/amo/log.py:180 src/olympia/constants/base.py:42 src/olympia/editors/helpers.py:62
+#: src/olympia/addons/templates/addons/persona_preview.html:15 src/olympia/amo/log.py:180 src/olympia/constants/base.py:42 src/olympia/editors/helpers.py:62
 msgid "Rejected"
 msgstr "ਠੁਕਰਾਇਆ"
 
-#: src/olympia/addons/templates/addons/persona_preview.html:16 src/olympia/amo/log.py:159
+#: src/olympia/addons/templates/addons/persona_preview.html:17 src/olympia/amo/log.py:159
 msgid "Approved"
 msgstr "ਮਨਜ਼ੂਰ ਹੋਇਆ"
 
 #. {0} is the number of users.
-#: src/olympia/addons/templates/addons/persona_preview.html:26 src/olympia/addons/templates/addons/listing/items_mobile.html:36 src/olympia/addons/templates/addons/listing/macros.html:31
+#: src/olympia/addons/templates/addons/persona_preview.html:27 src/olympia/addons/templates/addons/listing/items_mobile.html:36 src/olympia/addons/templates/addons/listing/macros.html:31
 msgid "<strong>{0}</strong> user"
 msgid_plural "<strong>{0}</strong> users"
 msgstr[0] "<strong>{0}</strong> ਉਪਭੋਗੀ"
 msgstr[1] "<strong>{0}</strong> ਉਪਭੋਗੀ"
 
-#: src/olympia/addons/templates/addons/persona_preview.html:40
+#: src/olympia/addons/templates/addons/persona_preview.html:41
 msgid "Hover to Preview"
 msgstr "ਝਲਕ ਵੇਖਣ ਲਈ ਘੁਮਾਓ"
 
-#: src/olympia/addons/templates/addons/persona_preview.html:46 src/olympia/addons/templates/addons/persona_preview.html:48 src/olympia/reviews/templates/reviews/add.html:15
+#: src/olympia/addons/templates/addons/persona_preview.html:47 src/olympia/addons/templates/addons/persona_preview.html:49 src/olympia/addons/templates/addons/persona_preview.html:97
+#: src/olympia/reviews/templates/reviews/add.html:15
 msgid "Add"
 msgstr "ਜੋੜੋ"
 
-#: src/olympia/addons/templates/addons/persona_preview.html:57 src/olympia/bandwagon/templates/bandwagon/ajax_new.html:16 src/olympia/bandwagon/templates/bandwagon/edit.html:19
+#: src/olympia/addons/templates/addons/persona_preview.html:58 src/olympia/bandwagon/templates/bandwagon/ajax_new.html:16 src/olympia/bandwagon/templates/bandwagon/edit.html:19
 #: src/olympia/bandwagon/templates/bandwagon/includes/addedit.html:19 src/olympia/devhub/templates/devhub/addons/edit/admin.html:13 src/olympia/devhub/templates/devhub/addons/edit/basic.html:10
 #: src/olympia/devhub/templates/devhub/addons/edit/details.html:8 src/olympia/devhub/templates/devhub/addons/edit/media.html:6 src/olympia/devhub/templates/devhub/addons/edit/support.html:8
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:9 src/olympia/devhub/templates/devhub/addons/submit/describe.html:29 src/olympia/editors/templates/editors/review.html:257
@@ -680,21 +679,21 @@ msgstr "ਸੋਧ"
 
 #. For datetime formatting, see the table on
 #. http://docs.python.org/library/datetime.html#strftime-and-strptime-behavior
-#: src/olympia/addons/templates/addons/persona_preview.html:66
+#: src/olympia/addons/templates/addons/persona_preview.html:67
 #, python-format
 msgid "%%Y-%%m-%%d"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/persona_preview.html:67
+#: src/olympia/addons/templates/addons/persona_preview.html:68
 msgid "by {0} on {1}"
 msgstr "{1} ਤੇ {0} ਵੱਲੋਂ"
 
-#: src/olympia/addons/templates/addons/persona_preview.html:75 src/olympia/reviews/helpers.py:17 src/olympia/reviews/templates/reviews/review_list.html:63
+#: src/olympia/addons/templates/addons/persona_preview.html:76 src/olympia/reviews/helpers.py:17 src/olympia/reviews/templates/reviews/review_list.html:63
 #: src/olympia/reviews/templates/reviews/reviews_link.html:21 src/olympia/reviews/templates/reviews/impala/reviews_link.html:16
 msgid "Not yet rated"
 msgstr "ਅਜੇ ਤੱਕ ਰੇਟ ਨਹੀਂ ਕੀਤਾ"
 
-#: src/olympia/addons/templates/addons/persona_preview.html:78
+#: src/olympia/addons/templates/addons/persona_preview.html:79
 msgid "<b>{0}</b> users"
 msgstr "<b>{0}</b> ਉਪਭੋਗੀ"
 
@@ -707,8 +706,8 @@ msgid "Learn more about Firefox"
 msgstr "ਫ਼ਾਇਰਫ਼ਾਕਸ ਬਾਰੇ ਹੋਰ ਜਾਣੋ"
 
 #: src/olympia/addons/templates/addons/popups.html:22
-msgid "or <b><a class=\"installer\" href=\"{url}\">download anyway</a></b>"
-msgstr "ਜਾਂ <b><a class=\"installer\"href=\"{url}\">ਕਿਸੇ ਵੀ ਤਰ੍ਹਾਂ ਡਾਊਨਲੋਡ ਕਰੋ</a></b>"
+msgid "or <b><a class=\"button installer\" href=\"{url}\">download anyway</a></b>"
+msgstr ""
 
 #: src/olympia/addons/templates/addons/popups.html:26
 msgid ""
@@ -808,7 +807,7 @@ msgid ""
 msgstr ""
 
 #: src/olympia/addons/templates/addons/report_abuse.html:6 src/olympia/addons/templates/addons/report_abuse_full.html:10 src/olympia/addons/templates/addons/impala/details-more.html:23
-#: src/olympia/addons/templates/addons/impala/details.html:328
+#: src/olympia/addons/templates/addons/impala/details.html:333
 msgid "Report Abuse"
 msgstr "ਦੁਰਵਿਹਾਰ ਸੂਚਨਾ"
 
@@ -829,9 +828,9 @@ msgstr "ਰਿਪੋਰਟ ਭੇਜੋ"
 #: src/olympia/devhub/templates/devhub/addons/ajax_compat_update.html:36 src/olympia/devhub/templates/devhub/addons/profile.html:44 src/olympia/devhub/templates/devhub/addons/edit/admin.html:104
 #: src/olympia/devhub/templates/devhub/addons/edit/basic.html:155 src/olympia/devhub/templates/devhub/addons/edit/details.html:88 src/olympia/devhub/templates/devhub/addons/edit/support.html:70
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:169 src/olympia/devhub/templates/devhub/addons/forms_shared/media.html:152
-#: src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:44 src/olympia/devhub/templates/devhub/personas/edit.html:222 src/olympia/devhub/templates/devhub/versions/add_file_modal.html:79
-#: src/olympia/devhub/templates/devhub/versions/edit.html:140 src/olympia/devhub/templates/devhub/versions/list.html:208 src/olympia/devhub/templates/devhub/versions/list.html:242
-#: src/olympia/devhub/templates/devhub/versions/list.html:276 src/olympia/devhub/templates/devhub/versions/list.html:317 src/olympia/reviews/templates/reviews/edit_review.html:16
+#: src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:43 src/olympia/devhub/templates/devhub/personas/edit.html:222 src/olympia/devhub/templates/devhub/versions/add_file_modal.html:59
+#: src/olympia/devhub/templates/devhub/versions/edit.html:140 src/olympia/devhub/templates/devhub/versions/list.html:208 src/olympia/devhub/templates/devhub/versions/list.html:239
+#: src/olympia/devhub/templates/devhub/versions/list.html:281 src/olympia/devhub/templates/devhub/versions/list.html:315 src/olympia/reviews/templates/reviews/edit_review.html:16
 #: src/olympia/translations/templates/translations/trans-menu.html:50 src/olympia/translations/templates/translations/trans-menu.html:62 src/olympia/zadmin/templates/zadmin/validation.html:105
 msgid "Cancel"
 msgstr "ਰੱਦ"
@@ -876,7 +875,7 @@ msgstr "ਇਸ ਐਡ-ਆਨ ਲਈ ਸਹਾਇਤਾ ਕਿੱਥੋਂ ਲਈ
 msgid "Review Guidelines"
 msgstr "ਹਿਦਾਇਤਾਂ ਦੀ ਸਮੀਖਿਆ"
 
-#: src/olympia/addons/templates/addons/review_list_box.html:5 src/olympia/addons/templates/addons/impala/details-more.html:27 src/olympia/editors/helpers.py:921
+#: src/olympia/addons/templates/addons/review_list_box.html:5 src/olympia/addons/templates/addons/impala/details-more.html:27 src/olympia/editors/helpers.py:1001
 #: src/olympia/reviews/templates/reviews/add.html:14 src/olympia/reviews/templates/reviews/reply.html:14 src/olympia/reviews/templates/reviews/review_list.html:19
 #: src/olympia/reviews/templates/reviews/mobile/review_list.html:26
 msgid "Reviews"
@@ -967,103 +966,103 @@ msgid_plural "Other add-ons by these authors"
 msgstr[0] "%(author)s ਵੱਲੋਂ ਹੋਰ ਐਡ-ਆਨ"
 msgstr[1] "ਇਹਨਾਂ ਲੇਖਕਾਂ ਵੱਲੋਂ ਹੋਰ ਐਡ-ਆਨ"
 
-#: src/olympia/addons/templates/addons/impala/details.html:41
+#: src/olympia/addons/templates/addons/impala/details.html:39
 #, python-format
 msgid "<span itemprop=\"ratingCount\">%(num)s</span> user review"
 msgid_plural "<span itemprop=\"ratingCount\">%(num)s</span> user reviews"
 msgstr[0] "<span itemprop=\"ratingCount\">%(num)s</span> ਉਪਭੋਗੀ ਸਮੀਖਿਆ"
 msgstr[1] "<span itemprop=\"ratingCount\">%(num)s</span> ਉਪਭੋਗੀ ਸਮੀਖਿਆਵਾਂ"
 
-#: src/olympia/addons/templates/addons/impala/details.html:69
+#: src/olympia/addons/templates/addons/impala/details.html:66
 msgid "View statistics"
 msgstr "ਅੰਕੜੇ ਵੇਖੋ"
 
-#: src/olympia/addons/templates/addons/impala/details.html:84
+#: src/olympia/addons/templates/addons/impala/details.html:81
 msgid "Manage"
 msgstr "ਪ੍ਰਬੰਧ"
 
 #. {0} is an add-on name.
-#: src/olympia/addons/templates/addons/impala/details.html:96
+#: src/olympia/addons/templates/addons/impala/details.html:93
 msgid "Icon of {0}"
 msgstr "{0} ਦਾ ਆਈਕਾਨ"
 
-#: src/olympia/addons/templates/addons/impala/details.html:103 src/olympia/addons/templates/addons/impala/listing/items.html:14
+#: src/olympia/addons/templates/addons/impala/details.html:100 src/olympia/addons/templates/addons/impala/listing/items.html:14
 msgid "No Restart"
 msgstr "ਮੁੜ ਚਾਲੂ ਨਹੀਂ"
 
-#: src/olympia/addons/templates/addons/impala/details.html:127
+#: src/olympia/addons/templates/addons/impala/details.html:124
 #, fuzzy, python-format
 msgid "Meet the Developer: <a href=\"%(url)s\">%(name)s</a>"
 msgid_plural "<a href=\"%(url)s\">Meet the Developers</a>"
 msgstr[0] "ਡਿਵੈਲਪਰ ਨੂੰ ਮਿਲੋ: <a href=\"%(url)s\">%(name)s</a>"
 msgstr[1] "<a href=\"%(url)s\">ਡਿਵੈਲਪਰਾਂ ਨੂੰ ਮਿਲੋ</a>"
 
-#: src/olympia/addons/templates/addons/impala/details.html:137
+#: src/olympia/addons/templates/addons/impala/details.html:134
 msgid "Learn why {0} was created and find out what's next for this add-on."
 msgstr "ਜਾਣੋ {0} ਕਿਉਂ ਰਚਿਆ ਗਿਆ ਅਤੇ ਪਤਾ ਲਗਾਓ ਇਸ ਐਡ-ਆਨ ਵਾਸਤੇ ਅੱਗੇ ਕੀ ਹੈ।"
 
 #. {0} is an index.
-#: src/olympia/addons/templates/addons/impala/details.html:156
+#: src/olympia/addons/templates/addons/impala/details.html:161
 msgid "Add-on screenshot #{0}"
 msgstr "ਐਡ-ਆਨ ਸਕਰੀਨਸ਼ਾੱਟ #{0}"
 
-#: src/olympia/addons/templates/addons/impala/details.html:182
+#: src/olympia/addons/templates/addons/impala/details.html:187
 msgid "Add-on home page"
 msgstr "ਐਡ-ਆਨ ਮੁੱਖ ਸਫ਼ਾ"
 
-#: src/olympia/addons/templates/addons/impala/details.html:185
+#: src/olympia/addons/templates/addons/impala/details.html:190
 msgid "Support site"
 msgstr "ਸਹਿਯੋਗ ਸਾਈਟ"
 
-#: src/olympia/addons/templates/addons/impala/details.html:189
+#: src/olympia/addons/templates/addons/impala/details.html:194
 msgid "Support E-mail"
 msgstr "ਸਹਿਯੋਗ ਈ-ਮੇਲ"
 
-#: src/olympia/addons/templates/addons/impala/details.html:194 src/olympia/devhub/models.py:378 src/olympia/devhub/templates/devhub/versions/list.html:12
+#: src/olympia/addons/templates/addons/impala/details.html:199 src/olympia/devhub/models.py:378 src/olympia/devhub/templates/devhub/versions/list.html:12
 #: src/olympia/versions/templates/versions/version.html:6 src/olympia/versions/templates/versions/mobile/version.html:6
 msgid "Version {0}"
 msgstr "ਵਰਜਨ {0}"
 
-#: src/olympia/addons/templates/addons/impala/details.html:194
+#: src/olympia/addons/templates/addons/impala/details.html:199
 msgid "Info"
 msgstr "ਇੰਫ਼ੋ"
 
-#: src/olympia/addons/templates/addons/impala/details.html:195 src/olympia/devhub/templates/devhub/includes/addon_details.html:129
+#: src/olympia/addons/templates/addons/impala/details.html:200 src/olympia/devhub/templates/devhub/includes/addon_details.html:116
 msgid "Last Updated:"
 msgstr "ਆਖਰੀ ਅੱਪਡੇਟ ਹੋਇਆ:"
 
-#: src/olympia/addons/templates/addons/impala/details.html:200
+#: src/olympia/addons/templates/addons/impala/details.html:205
 #, python-format
 msgid "Released under <a target=\"_blank\" href=\"%(url)s\">%(name)s</a>"
 msgstr "<a target=\"_blank\" href=\"%(url)s\">%(name)s</a> ਦੇ ਅਧੀਨ ਜਾਰੀ ਹੋਇਆ"
 
-#: src/olympia/addons/templates/addons/impala/details.html:201 src/olympia/addons/templates/addons/impala/details.html:206 src/olympia/amo/helpers.py:398 src/olympia/devhub/forms.py:142
+#: src/olympia/addons/templates/addons/impala/details.html:206 src/olympia/addons/templates/addons/impala/details.html:211 src/olympia/amo/helpers.py:398 src/olympia/devhub/forms.py:142
 #: src/olympia/devhub/forms.py:173 src/olympia/versions/templates/versions/version.html:40 src/olympia/versions/templates/versions/version.html:45
 msgid "Custom License"
 msgstr "ਕਸਟਮ ਲਾਇਸੰਸ"
 
-#: src/olympia/addons/templates/addons/impala/details.html:205
+#: src/olympia/addons/templates/addons/impala/details.html:210
 #, python-format
 msgid "Released under <a href=\"%(url)s\">%(name)s</a>"
 msgstr "<a href=\"%(url)s\">%(name)s</a> ਦੇ ਅਧੀਨ ਜਾਰੀ ਹੋਇਆ"
 
-#: src/olympia/addons/templates/addons/impala/details.html:217
+#: src/olympia/addons/templates/addons/impala/details.html:222
 msgid "About this Add-on"
 msgstr "ਇਸ ਐਡ-ਆਨ ਬਾਰੇ"
 
-#: src/olympia/addons/templates/addons/impala/details.html:233
+#: src/olympia/addons/templates/addons/impala/details.html:238
 msgid "Developer’s Comments"
 msgstr "ਡਿਵੈਲਪਰ ਦੀਆਂ ਟਿੱਪਣੀਆਂ"
 
-#: src/olympia/addons/templates/addons/impala/details.html:243
+#: src/olympia/addons/templates/addons/impala/details.html:248
 msgid "Version Information"
 msgstr "ਵਰਜਨ ਜਾਣਕਾਰੀ"
 
-#: src/olympia/addons/templates/addons/impala/details.html:250
+#: src/olympia/addons/templates/addons/impala/details.html:255
 msgid "See complete version history"
 msgstr "ਵੇਖੋ ਸੰਪੂਰਨ ਵਰਜਨ ਇਤਿਹਾਸ"
 
-#: src/olympia/addons/templates/addons/impala/details.html:262
+#: src/olympia/addons/templates/addons/impala/details.html:267
 msgid ""
 "The Development Channel lets you test an experimental new version of this add-on before it's released to the general public. Once you install the development version, you will continue to get "
 "updates from this channel. To stop receiving development updates, reinstall the default version from the link above."
@@ -1071,17 +1070,17 @@ msgstr ""
 "ਵਿਕਾਸ ਚੈਨਲ ਤੁਹਾਨੂੰ ਇਸ ਐਡ-ਆਨ ਦੇ ਇੱਕ ਨਵੇਂ ਪ੍ਰਯੋਗਆਤਮਕ ਵਰਜਨ ਦੀ ਪਰਖ ਕਰਨ ਦਵੇਗਾ ਇਸ ਤੋਂ ਪਹਿਲਾਂ ਕਿ ਇਹ ਆਮ ਲੋਕਾਂ ਲਈ ਜਾਰੀ ਕੀਤਾ ਜਾਵੇ। ਇੱਕ ਵਾਰ ਤੁਸੀਂ ਵਿਕਾਸ ਵਰਜਨ ਇੰਸਟਾਲ ਕਰ ਲਿਆ, ਤੁਹਾਡਾ ਇਸ ਚੈਨਲ ਤੋਂ ਅੱਪਡੇਟਾਂ ਲੈਣਾ ਜਾਰੀ ਰਹੇਗਾ। ਵਿਕਾਸ ਅੱਪਡੇਟਾਂ ਲੈਣਾ ਬੰਦ "
 "ਕਰਨ ਲਈ, ਉੱਪਰ ਦਿੱਤੇ ਲਿੰਕ ਤੋਂ ਮੂਲ ਵਰਜਨ ਮੁੜ ਇੰਸਟਾਲ ਕਰੋ।"
 
-#: src/olympia/addons/templates/addons/impala/details.html:272
+#: src/olympia/addons/templates/addons/impala/details.html:277
 msgid "<strong>Caution:</strong> Development versions of this add-on have not been reviewed by Mozilla."
 msgstr ""
 
-#: src/olympia/addons/templates/addons/impala/details.html:287
+#: src/olympia/addons/templates/addons/impala/details.html:292
 msgid "See complete development channel history"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/impala/details.html:306 src/olympia/addons/templates/addons/impala/details.html:315 src/olympia/addons/templates/addons/impala/details.html:327
+#: src/olympia/addons/templates/addons/impala/details.html:311 src/olympia/addons/templates/addons/impala/details.html:320 src/olympia/addons/templates/addons/impala/details.html:332
 #: src/olympia/addons/templates/addons/impala/review_add_box.html:4 src/olympia/stats/templates/stats/popup.html:2 src/olympia/stats/templates/stats/popup.html:8
-#: src/olympia/stats/templates/stats/stats.html:202 src/olympia/users/templates/users/profile.html:119
+#: src/olympia/stats/templates/stats/stats.html:204 src/olympia/users/templates/users/profile.html:119
 msgid "close"
 msgstr "ਬੰਦ"
 
@@ -1137,15 +1136,11 @@ msgstr "{addon}ਲਈ ਸੋਰਸ ਕੋਡ ਲਾਇਸੰਸ"
 msgid "Source Code License"
 msgstr "ਸੋਰਸ ਕੋਡ ਲਾਇਸੰਸ"
 
-#: src/olympia/addons/templates/addons/impala/persona_grid.html:16 src/olympia/addons/templates/addons/impala/toplist.html:6
-msgid "{0} users"
-msgstr "{0} ਉਪਭੋਗੀ"
-
 #: src/olympia/addons/templates/addons/impala/review_list_box.html:19 src/olympia/reviews/templates/reviews/review.html:40
 msgid "permalink"
 msgstr "ਪਰਮਾਲਿੰਕ"
 
-#: src/olympia/addons/templates/addons/impala/review_list_box.html:23 src/olympia/editors/templates/editors/queue.html:98 src/olympia/reviews/templates/reviews/review.html:44
+#: src/olympia/addons/templates/addons/impala/review_list_box.html:23 src/olympia/editors/templates/editors/queue.html:104 src/olympia/reviews/templates/reviews/review.html:44
 msgid "translate"
 msgstr "ਅਨੁਵਾਦ"
 
@@ -1164,6 +1159,10 @@ msgstr "ਇਸ ਐਡ-ਆਨ ਦੀ ਅਜੇ ਸਮੀਖਿਆ ਨਹੀਂ �
 msgid "Be the first!"
 msgstr "ਪਹਿਲੇ ਹੋ!"
 
+#: src/olympia/addons/templates/addons/impala/toplist.html:6
+msgid "{0} users"
+msgstr "{0} ਉਪਭੋਗੀ"
+
 #: src/olympia/addons/templates/addons/impala/listing/sorter.html:14 src/olympia/devhub/templates/devhub/addons/listing/item_actions.html:49
 msgid "More"
 msgstr "ਹੋਰ"
@@ -1176,7 +1175,7 @@ msgstr "ਸੰਗ੍ਰਹਿ ਵਿੱਚ ਜੋੜੋ"
 msgid "My Add-ons"
 msgstr "ਮੇਰੇ ਐਡ-ਆਨ"
 
-#: src/olympia/addons/templates/addons/includes/dashboard_tabs.html:6 src/olympia/amo/context_processors.py:51
+#: src/olympia/addons/templates/addons/includes/dashboard_tabs.html:6 src/olympia/amo/context_processors.py:50
 msgid "My Themes"
 msgstr "ਮੇਰੇ ਥੀਮ"
 
@@ -1231,7 +1230,7 @@ msgstr "ਉਪਭੋਗੀ"
 msgid "Weekly Downloads"
 msgstr "ਹਫ਼ਤੇਵਾਰ ਡਾਊਨਲੋਡ"
 
-#: src/olympia/addons/templates/addons/mobile/details.html:99 src/olympia/compat/templates/compat/reporter_detail.html:46 src/olympia/devhub/forms.py:787
+#: src/olympia/addons/templates/addons/mobile/details.html:99 src/olympia/compat/templates/compat/reporter_detail.html:46 src/olympia/devhub/forms.py:788
 #: src/olympia/devhub/templates/devhub/versions/list.html:163
 msgid "Version"
 msgstr "ਵਰਜਨ"
@@ -1317,7 +1316,7 @@ msgstr ""
 #: src/olympia/browse/templates/browse/personas/category_landing.html:21 src/olympia/browse/templates/browse/personas/category_landing.html:23
 #: src/olympia/browse/templates/browse/personas/category_landing.html:38 src/olympia/browse/templates/browse/personas/grid.html:7 src/olympia/browse/templates/browse/personas/grid.html:11
 #: src/olympia/browse/templates/browse/personas/mobile/base.html:7 src/olympia/browse/templates/browse/personas/mobile/category_landing.html:19 src/olympia/constants/base.py:180
-#: src/olympia/devhub/templates/devhub/personas/submit.html:13 src/olympia/editors/helpers.py:105 src/olympia/editors/templates/editors/base.html:26
+#: src/olympia/devhub/templates/devhub/personas/submit.html:13 src/olympia/editors/helpers.py:107 src/olympia/editors/templates/editors/base.html:26
 #: src/olympia/editors/templates/editors/performance.html:73 src/olympia/search/templates/search/personas.html:39 src/olympia/templates/menu_links.html:9
 msgid "Themes"
 msgstr "ਥੀਮ"
@@ -1338,7 +1337,7 @@ msgstr "ਹੋਰ ਐਡ-ਆਨ"
 msgid "Highest Rated"
 msgstr "ਸੱਭ ਤੋਂ ਵੱਧ ਰੇਟ ਹੋਇਆ"
 
-#: src/olympia/addons/templates/addons/mobile/home.html:74 src/olympia/amo/templates/amo/side_nav.html:5 src/olympia/amo/templates/amo/site_nav.html:27 src/olympia/amo/templates/amo/site_nav.html:57
+#: src/olympia/addons/templates/addons/mobile/home.html:74 src/olympia/amo/templates/amo/side_nav.html:5 src/olympia/amo/templates/amo/site_nav.html:27 src/olympia/amo/templates/amo/site_nav.html:55
 #: src/olympia/bandwagon/views.py:97 src/olympia/browse/views.py:57 src/olympia/browse/views.py:67 src/olympia/browse/templates/browse/personas/mobile/category_landing.html:65
 #: src/olympia/search/forms.py:15 src/olympia/search/forms.py:87
 msgid "Newest"
@@ -1352,90 +1351,90 @@ msgstr "ਪਰਖ ਕਰੋ!"
 msgid "Theme Info &raquo;"
 msgstr " ਥੀਮ ਇੰਫ਼ੋ &raquo;"
 
-#: src/olympia/amo/context_processors.py:39 src/olympia/devhub/templates/devhub/nav.html:43
+#: src/olympia/amo/context_processors.py:37 src/olympia/devhub/templates/devhub/nav.html:43
 msgid "Tools"
 msgstr "ਟੂਲ"
 
-#: src/olympia/amo/context_processors.py:48 src/olympia/discovery/templates/discovery/pane_account.html:8 src/olympia/users/templates/users/includes/navigation.html:2
+#: src/olympia/amo/context_processors.py:47 src/olympia/discovery/templates/discovery/pane_account.html:8 src/olympia/users/templates/users/includes/navigation.html:2
 msgid "My Profile"
 msgstr "ਮੇਰੀ ਪ੍ਰੋਫ਼ਾਈਲ"
 
-#: src/olympia/amo/context_processors.py:54 src/olympia/users/templates/users/edit.html:5 src/olympia/users/templates/users/includes/navigation.html:3
+#: src/olympia/amo/context_processors.py:53 src/olympia/users/templates/users/edit.html:5 src/olympia/users/templates/users/includes/navigation.html:3
 msgid "Account Settings"
 msgstr "ਖਾਤਾ ਸੈਟਿੰਗ"
 
-#: src/olympia/amo/context_processors.py:57 src/olympia/discovery/templates/discovery/pane_account.html:11 src/olympia/users/templates/users/profile.html:83
+#: src/olympia/amo/context_processors.py:56 src/olympia/discovery/templates/discovery/pane_account.html:11 src/olympia/users/templates/users/profile.html:83
 #: src/olympia/users/templates/users/includes/navigation.html:4
 msgid "My Collections"
 msgstr "ਮੇਰੇ ਸੰਗ੍ਰਹਿ"
 
-#: src/olympia/amo/context_processors.py:62 src/olympia/discovery/templates/discovery/pane_account.html:10 src/olympia/users/templates/users/includes/navigation.html:7
+#: src/olympia/amo/context_processors.py:61 src/olympia/discovery/templates/discovery/pane_account.html:10 src/olympia/users/templates/users/includes/navigation.html:7
 msgid "My Favorites"
 msgstr "ਮੇਰੇ ਪਸੰਦੀਦਾ"
 
-#: src/olympia/amo/context_processors.py:67 src/olympia/discovery/templates/discovery/pane_account.html:13 src/olympia/templates/impala/user_login.html:14
+#: src/olympia/amo/context_processors.py:66 src/olympia/discovery/templates/discovery/pane_account.html:13 src/olympia/templates/impala/user_login.html:14
 #: src/olympia/templates/mobile/header_auth.html:5
 msgid "Log out"
 msgstr "ਲਾਗ ਆਉਟ"
 
-#: src/olympia/amo/context_processors.py:72 src/olympia/devhub/templates/devhub/addons/dashboard.html:4
+#: src/olympia/amo/context_processors.py:71 src/olympia/devhub/templates/devhub/addons/dashboard.html:4
 msgid "Manage My Submissions"
 msgstr "ਮੇਰੀਆਂ ਪੇਸ਼ਕਸ਼ਾਂ ਦਾ ਪ੍ਰਬੰਧ ਕਰੋ"
 
-#: src/olympia/amo/context_processors.py:75 src/olympia/devhub/templates/devhub/nav.html:27 src/olympia/devhub/templates/devhub/addons/dashboard.html:25
+#: src/olympia/amo/context_processors.py:74 src/olympia/devhub/templates/devhub/nav.html:27 src/olympia/devhub/templates/devhub/addons/dashboard.html:25
 #: src/olympia/devhub/templates/devhub/addons/submit/base.html:4
 msgid "Submit a New Add-on"
 msgstr "ਇੱਕ ਨਵਾਂ ਐਡ-ਆਨ ਭੇਜੋ"
 
-#: src/olympia/amo/context_processors.py:77 src/olympia/browse/templates/browse/personas/base.html:50 src/olympia/devhub/templates/devhub/index.html:24
+#: src/olympia/amo/context_processors.py:76 src/olympia/browse/templates/browse/personas/base.html:50 src/olympia/devhub/templates/devhub/index.html:24
 #: src/olympia/devhub/templates/devhub/addons/dashboard.html:29
 msgid "Submit a New Theme"
 msgstr "ਇੱਕ ਨਵਾਂ ਥੀਮ ਭੇਜੋ"
 
-#: src/olympia/amo/context_processors.py:79 src/olympia/amo/templates/amo/site_nav.html:87 src/olympia/devhub/helpers.py:36 src/olympia/devhub/helpers.py:68 src/olympia/devhub/helpers.py:102
+#: src/olympia/amo/context_processors.py:78 src/olympia/amo/templates/amo/site_nav.html:85 src/olympia/devhub/helpers.py:36 src/olympia/devhub/helpers.py:68 src/olympia/devhub/helpers.py:102
 #: src/olympia/templates/footer.html:6 src/olympia/templates/menu_links.html:14
 msgid "Developer Hub"
 msgstr "ਡਿਵੈਲਪਰ ਹਬ"
 
-#: src/olympia/amo/context_processors.py:83 src/olympia/devhub/views.py:1792
+#: src/olympia/amo/context_processors.py:81 src/olympia/devhub/views.py:1796
 msgid "Manage API Keys"
 msgstr ""
 
-#: src/olympia/amo/context_processors.py:88 src/olympia/editors/helpers.py:82 src/olympia/editors/helpers.py:102 src/olympia/editors/templates/editors/base.html:10
+#: src/olympia/amo/context_processors.py:86 src/olympia/editors/helpers.py:84 src/olympia/editors/helpers.py:104 src/olympia/editors/templates/editors/base.html:10
 msgid "Editor Tools"
 msgstr "ਸੰਪਾਦਕ ਟੂਲ"
 
-#: src/olympia/amo/context_processors.py:92
+#: src/olympia/amo/context_processors.py:90
 msgid "Admin Tools"
 msgstr "ਐਡਮਿਨ ਟੂਲ"
 
-#: src/olympia/amo/fields.py:15
+#: src/olympia/amo/fields.py:20
 msgid "Incorrect, please try again."
 msgstr ""
 
-#: src/olympia/amo/fields.py:16
+#: src/olympia/amo/fields.py:21
 msgid "Error verifying input, please try again."
 msgstr ""
 
-#: src/olympia/amo/fields.py:32
+#: src/olympia/amo/fields.py:37
 msgid "This must be a valid hex color code, such as #000000."
 msgstr "ਇਹ ਇੱਕ ਜਾਇਜ ਹੈਕਸ ਕਲਰ ਕੋਡ ਹੋਣਾ ਚਾਹੀਦਾ ਹੈ, ਜਿਵੇਂ ਕਿ #000000।"
 
-#: src/olympia/amo/fields.py:58
+#: src/olympia/amo/fields.py:63
 msgid "Enter at least one value."
 msgstr "ਘੱਟੋ ਘੱਟ ਇੱਕ ਵੈਲਯੂ ਭਰੋ।"
 
-#: src/olympia/amo/helpers.py:162 src/olympia/amo/templates/amo/site_nav.html:61 src/olympia/bandwagon/templates/bandwagon/add.html:9
+#: src/olympia/amo/helpers.py:162 src/olympia/amo/templates/amo/site_nav.html:59 src/olympia/bandwagon/templates/bandwagon/add.html:9
 #: src/olympia/bandwagon/templates/bandwagon/collection_detail.html:15 src/olympia/bandwagon/templates/bandwagon/delete.html:9 src/olympia/bandwagon/templates/bandwagon/edit.html:15
 #: src/olympia/bandwagon/templates/bandwagon/user_listing.html:18 src/olympia/bandwagon/templates/bandwagon/user_listing.html:21
 #: src/olympia/bandwagon/templates/bandwagon/impala/collection_listing.html:12 src/olympia/bandwagon/templates/bandwagon/impala/collection_listing.html:20
 #: src/olympia/bandwagon/templates/bandwagon/impala/collection_listing.html:24 src/olympia/bandwagon/templates/bandwagon/impala/collection_sidebar.html:3
 #: src/olympia/bandwagon/templates/bandwagon/includes/collection_sidebar.html:2 src/olympia/bandwagon/templates/bandwagon/mobile/collection_listing.html:3
-#: src/olympia/stats/templates/stats/stats.html:77 src/olympia/templates/menu_links.html:12
+#: src/olympia/stats/templates/stats/stats.html:33 src/olympia/templates/menu_links.html:12
 msgid "Collections"
 msgstr "ਸੰਗ੍ਰਹਿ "
 
-#: src/olympia/amo/helpers.py:171 src/olympia/amo/templates/amo/site_nav.html:85 src/olympia/browse/templates/browse/language_tools.html:3
+#: src/olympia/amo/helpers.py:171 src/olympia/amo/templates/amo/site_nav.html:83 src/olympia/browse/templates/browse/language_tools.html:3
 msgid "Dictionaries & Language Packs"
 msgstr "ਸ਼ਬਦਕੋਸ ਅਤੇ ਭਾਸ਼ਾ ਪੈਕ"
 
@@ -1587,8 +1586,8 @@ msgstr "ਸੁਪਰ ਸਮੀਖਿਆ ਦੀ ਮੰਗ ਹੋਈ।"
 msgid "Comment on {addon} {version}."
 msgstr "ਟਿੱਪਣੀ {addon} {version}ਲਈ।"
 
-#: src/olympia/amo/log.py:236 src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:19 src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:47
-#: src/olympia/editors/helpers.py:511 src/olympia/editors/templates/editors/themes/history_table.html:11
+#: src/olympia/amo/log.py:236 src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:17 src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:45
+#: src/olympia/editors/helpers.py:584 src/olympia/editors/templates/editors/themes/history_table.html:11
 msgid "Comment"
 msgstr "ਟਿੱਪਣੀ"
 
@@ -1916,7 +1915,7 @@ msgstr "ਪਿਛਲਾ"
 #: src/olympia/amo/templates/amo/mobile/paginator.html:14 src/olympia/amo/templates/amo/mobile/paginator.html:16 src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:51
 #: src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:65 src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:78
 #: src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:91 src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:104
-#: src/olympia/discovery/templates/discovery/pane.html:45 src/olympia/discovery/templates/discovery/addons/detail.html:39 src/olympia/stats/templates/stats/stats.html:167
+#: src/olympia/discovery/templates/discovery/pane.html:45 src/olympia/discovery/templates/discovery/addons/detail.html:39 src/olympia/stats/templates/stats/stats.html:169
 msgid "Next"
 msgstr "ਅਗਲਾ"
 
@@ -1950,7 +1949,7 @@ msgstr ""
 "\"recaptcha_different\">ਹੋਰ ਸ਼ਬਦਾਂ ਨੂੰ ਅਜ਼ਮਾ</a> ਸਕਦੇ ਹੋ ਜਾਂ ਇਸ ਦੀ ਬਜਾਏ <a href=\"#\" id=\"recaptcha_audio\">ਇੱਕ ਵੱਖਰੇ ਤਰ੍ਹਾਂ ਦੀ ਚੁਣੌਤੀ</a> ਦੀ ਕੋਸ਼ਿਸ ਕਰੋ। </p>"
 
 #: src/olympia/amo/templates/amo/side_nav.html:4 src/olympia/amo/templates/amo/side_nav.html:12 src/olympia/amo/templates/amo/site_nav.html:4 src/olympia/amo/templates/amo/site_nav.html:26
-#: src/olympia/browse/views.py:56 src/olympia/browse/views.py:66 src/olympia/browse/views.py:237 src/olympia/browse/views.py:282 src/olympia/search/forms.py:86
+#: src/olympia/browse/views.py:56 src/olympia/browse/views.py:66 src/olympia/browse/views.py:204 src/olympia/browse/views.py:249 src/olympia/search/forms.py:86
 msgid "Top Rated"
 msgstr "ਚੋਟੀ ਦਾ ਦਰਜਾ ਪ੍ਰਾਪਤ"
 
@@ -1964,38 +1963,38 @@ msgstr "ਪੜਚੋਲ"
 msgid "Extensions"
 msgstr "ਇਕਸਟੈਨਸ਼ਨ"
 
-#: src/olympia/amo/templates/amo/site_nav.html:45
+#: src/olympia/amo/templates/amo/site_nav.html:44
 msgid "Want more customization? Try <b>Complete Themes</b>"
 msgstr ""
 
-#: src/olympia/amo/templates/amo/site_nav.html:56 src/olympia/bandwagon/views.py:96
+#: src/olympia/amo/templates/amo/site_nav.html:54 src/olympia/bandwagon/views.py:96
 msgid "Most Followers"
 msgstr "ਜਿਆਦਾਤਰ ਸਮਰਥਕ"
 
-#: src/olympia/amo/templates/amo/site_nav.html:68 src/olympia/bandwagon/templates/bandwagon/impala/collection_sidebar.html:16
+#: src/olympia/amo/templates/amo/site_nav.html:66 src/olympia/bandwagon/templates/bandwagon/impala/collection_sidebar.html:16
 #: src/olympia/bandwagon/templates/bandwagon/includes/collection_sidebar.html:18
 msgid "Collections I've Made"
 msgstr "ਮੇਰੇ ਬਣਾਏ ਹੋਏ ਸੰਗ੍ਰਹਿ"
 
-#: src/olympia/amo/templates/amo/site_nav.html:70 src/olympia/bandwagon/templates/bandwagon/user_listing.html:4 src/olympia/bandwagon/templates/bandwagon/impala/collection_sidebar.html:13
+#: src/olympia/amo/templates/amo/site_nav.html:68 src/olympia/bandwagon/templates/bandwagon/user_listing.html:4 src/olympia/bandwagon/templates/bandwagon/impala/collection_sidebar.html:13
 #: src/olympia/bandwagon/templates/bandwagon/includes/collection_sidebar.html:15
 msgid "Collections I'm Following"
 msgstr "ਸੰਗ੍ਰਹਿ ਜਿਹਨਾਂ ਦਾ ਮੈਂ ਸਮਰਥਕ ਹਾਂ"
 
-#: src/olympia/amo/templates/amo/site_nav.html:73 src/olympia/bandwagon/templates/bandwagon/impala/collection_sidebar.html:18
-#: src/olympia/bandwagon/templates/bandwagon/includes/collection_sidebar.html:20 src/olympia/users/models.py:512
+#: src/olympia/amo/templates/amo/site_nav.html:71 src/olympia/bandwagon/templates/bandwagon/impala/collection_sidebar.html:18
+#: src/olympia/bandwagon/templates/bandwagon/includes/collection_sidebar.html:20 src/olympia/users/models.py:521
 msgid "My Favorite Add-ons"
 msgstr "ਮੇਰੇ ਪਸੰਦੀਦਾ ਐਡ-ਆਨ"
 
-#: src/olympia/amo/templates/amo/site_nav.html:78
+#: src/olympia/amo/templates/amo/site_nav.html:76
 msgid "More&hellip;"
 msgstr "ਹੋਰ&hellip;"
 
-#: src/olympia/amo/templates/amo/site_nav.html:82
+#: src/olympia/amo/templates/amo/site_nav.html:80
 msgid "Add-ons for Mobile"
 msgstr "ਮੋਬਾਈਲ ਲਈ ਐਡ-ਆਨ"
 
-#: src/olympia/amo/templates/amo/site_nav.html:86 src/olympia/browse/feeds.py:207 src/olympia/browse/templates/browse/search_tools.html:3 src/olympia/constants/base.py:176
+#: src/olympia/amo/templates/amo/site_nav.html:84 src/olympia/browse/feeds.py:207 src/olympia/browse/templates/browse/search_tools.html:3 src/olympia/constants/base.py:176
 #: src/olympia/templates/menu_links.html:10
 msgid "Search Tools"
 msgstr "ਖੋਜ ਟੂਲ"
@@ -2011,7 +2010,7 @@ msgid "Jump to first page"
 msgstr "ਪਹਿਲੇ ਸਫ਼ੇ ਤੇ ਜਾਓ"
 
 #: src/olympia/amo/templates/amo/impala/paginator.html:22 src/olympia/amo/templates/amo/mobile/impala_paginator.html:12 src/olympia/discovery/templates/discovery/pane.html:44
-#: src/olympia/discovery/templates/discovery/addons/detail.html:38 src/olympia/stats/templates/stats/stats.html:164
+#: src/olympia/discovery/templates/discovery/addons/detail.html:38 src/olympia/stats/templates/stats/stats.html:166
 msgid "Previous"
 msgstr "ਪਿਛਲਾ"
 
@@ -2034,31 +2033,50 @@ msgid_plural "Page {n}"
 msgstr[0] "ਸਫ਼ਾ {n}"
 msgstr[1] "ਸਫ਼ਾ {n}"
 
-#: src/olympia/amo/templates/services/install.html:38
-#, python-format
-msgid "If you are not prompted to install %(addon_name)s in a moment, please <a href=\"%(addon_xpi)s\">click here</a>."
-msgstr "ਜੇਕਰ ਤੁਹਾਨੂੰ ਇੱਕ ਪਲ ਵਿੱਚ %(addon_name)s ਇੰਸਟਾਲ ਕਰਨ ਬਾਰੇ ਨਹੀਂ ਪੁੱਛਿਆ ਗਿਆ, ਕਿਰਪਾ ਕਰਕੇ <a href=\"%(addon_xpi)s\">ਇੱਥੇ ਕਲਿੱਕ ਕਰੋ</a>।"
-
-#: src/olympia/amo/tests/test_messages.py:57 src/olympia/amo/tests/test_messages.py:58 src/olympia/reviews/forms.py:25 src/olympia/reviews/forms.py:50 src/olympia/reviews/templates/reviews/add.html:56
+#: src/olympia/amo/tests/test_messages.py:56 src/olympia/amo/tests/test_messages.py:57 src/olympia/reviews/forms.py:25 src/olympia/reviews/forms.py:50 src/olympia/reviews/templates/reviews/add.html:56
 #: src/olympia/reviews/templates/reviews/reply.html:30
 msgid "Title"
 msgstr "ਟਾਈਟਲ"
 
-#: src/olympia/amo/tests/test_messages.py:57 src/olympia/amo/tests/test_messages.py:58
+#: src/olympia/amo/tests/test_messages.py:56 src/olympia/amo/tests/test_messages.py:57
 msgid "Body"
 msgstr "ਬਾਡੀ"
 
-#: src/olympia/amo/tests/test_messages.py:59
+#: src/olympia/amo/tests/test_messages.py:58
 msgid "Another Title"
 msgstr "ਦੂਜਾ ਟਾਈਟਲ"
 
-#: src/olympia/amo/tests/test_messages.py:59
+#: src/olympia/amo/tests/test_messages.py:58
 msgid "Another Body"
 msgstr "ਦੂਜੀ ਬਾਡੀ"
 
-#: src/olympia/api/views.py:255
-msgid "Not implemented yet."
-msgstr "ਹਾਲੇ ਤੱਕ ਲਾਗੂ ਨਹੀਂ ਕੀਤਾ।"
+#: src/olympia/api/authentication.py:76
+msgid "Signature has expired."
+msgstr ""
+
+#: src/olympia/api/authentication.py:79
+msgid "Error decoding signature."
+msgstr ""
+
+#: src/olympia/api/authentication.py:82
+msgid "Invalid JWT Token."
+msgstr ""
+
+#: src/olympia/api/authentication.py:130
+msgid "Invalid Authorization header. No credentials provided."
+msgstr ""
+
+#: src/olympia/api/authentication.py:133
+msgid "Invalid Authorization header. Credentials string should not contain spaces."
+msgstr ""
+
+#: src/olympia/api/fields.py:29
+msgid "The field must have a length of at least {num} characters."
+msgstr ""
+
+#: src/olympia/api/fields.py:31
+msgid "The language code {lang_code} is invalid."
+msgstr ""
 
 #: src/olympia/applications/views.py:39 src/olympia/applications/templates/applications/appversions.html:3
 msgid "Application Versions"
@@ -2076,7 +2094,7 @@ msgstr "ਠੀਕ ਐਪਲੀਕੇਸ਼ਨ ਵਰਜਨ"
 msgid "Add-ons submitted to Mozilla Add-ons must have a manifest file with at least one of the below applications supported. Only the versions listed below are allowed for these applications."
 msgstr ""
 
-#: src/olympia/applications/templates/applications/appversions.html:25
+#: src/olympia/applications/templates/applications/appversions.html:25 src/olympia/editors/helpers.py:361
 msgid "GUID"
 msgstr "GUID"
 
@@ -2190,8 +2208,8 @@ msgstr "ਪਸੰਦੀਦਾ"
 msgid "Remove from favorites"
 msgstr "ਪਸੰਦੀਦਾ ਵਿੱਚੋ ਹਟਾਓ"
 
-#: src/olympia/bandwagon/views.py:98 src/olympia/bandwagon/views.py:191 src/olympia/browse/views.py:58 src/olympia/browse/views.py:69 src/olympia/browse/views.py:458 src/olympia/devhub/views.py:74
-#: src/olympia/devhub/views.py:82 src/olympia/devhub/templates/devhub/addons/edit/basic.html:20 src/olympia/editors/templates/editors/leaderboard.html:24
+#: src/olympia/bandwagon/views.py:98 src/olympia/bandwagon/views.py:191 src/olympia/browse/views.py:58 src/olympia/browse/views.py:69 src/olympia/browse/views.py:425 src/olympia/devhub/views.py:72
+#: src/olympia/devhub/views.py:80 src/olympia/devhub/templates/devhub/addons/edit/basic.html:20 src/olympia/editors/templates/editors/leaderboard.html:24
 #: src/olympia/editors/templates/editors/themes/queue_list.html:48 src/olympia/search/forms.py:17 src/olympia/search/forms.py:89 src/olympia/users/templates/users/vcard.html:5
 msgid "Name"
 msgstr "ਨਾਂ"
@@ -2200,7 +2218,7 @@ msgstr "ਨਾਂ"
 msgid "Recently Popular"
 msgstr "ਹੁਣੇ ਮਸ਼ਹੂਰ ਹੋਏ"
 
-#: src/olympia/bandwagon/views.py:189 src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:18
+#: src/olympia/bandwagon/views.py:189 src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:16
 msgid "Added"
 msgstr "ਸ਼ਾਮਲ ਹੋਏ"
 
@@ -2214,7 +2232,7 @@ msgstr "ਸੰਗ੍ਰਹਿ ਰਚਿਆ!"
 
 #: src/olympia/bandwagon/views.py:316
 #, python-format
-msgid "Your new collection is shown below. You can <ahref=\"%(url)s\">edit additional settings</a> if you'dlike."
+msgid "Your new collection is shown below. You can <a href=\"%(url)s\">edit additional settings</a> if you'd like."
 msgstr ""
 
 #: src/olympia/bandwagon/views.py:322
@@ -2342,8 +2360,8 @@ msgid_plural "%(num)s Add-ons in this Collection"
 msgstr[0] "ਇਸ ਸੰਗ੍ਰਹਿ ਵਿੱਚ %(num)s ਐਡ-ਆਨ"
 msgstr[1] "ਇਸ ਸੰਗ੍ਰਹਿ ਵਿੱਚ %(num)s ਐਡ-ਆਨ"
 
-#: src/olympia/bandwagon/templates/bandwagon/collection_detail.html:125 src/olympia/compat/templates/compat/index.html:25 src/olympia/compat/templates/compat/reporter_detail.html:29
-#: src/olympia/files/templates/files/viewer.html:29 src/olympia/templates/amo_footer.html:17 src/olympia/templates/includes/lang_switcher.html:10
+#: src/olympia/bandwagon/templates/bandwagon/collection_detail.html:125 src/olympia/compat/templates/compat/reporter_detail.html:29 src/olympia/files/templates/files/viewer.html:29
+#: src/olympia/templates/amo_footer.html:17 src/olympia/templates/includes/lang_switcher.html:10
 msgid "Go"
 msgstr "ਜਾਓ"
 
@@ -2512,7 +2530,7 @@ msgid "Remove this user as a contributor"
 msgstr "ਹਿੱਸੇਦਾਰ ਦੇ ਤੌਰ ਤੇ ਇਸ ਉਪਭੋਗੀ ਨੂੰ ਹਟਾਓ"
 
 #: src/olympia/bandwagon/templates/bandwagon/edit_contributors.html:18 src/olympia/bandwagon/templates/bandwagon/edit_contributors.html:43
-#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:20 src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:48
+#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:18 src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:46
 #: src/olympia/devhub/templates/devhub/addons/ajax_compat_update.html:19
 msgid "Remove"
 msgstr "ਹਟਾਓ"
@@ -2560,7 +2578,7 @@ msgid "<b>Warning:</b> By changing the owner of this collection, you will no lon
 msgstr "<b>ਚੇਤਾਵਨੀ:</b> ਇਸ ਸੰਗ੍ਰਹਿ ਦਾ ਮਾਲਕ ਬਦਲਣ ਨਾਲ, ਤੁਸੀਂ ਹੁਣ ਇਸ ਵਿੱਚ ਸੋਧ ਕਰਨ ਦੇ ਯੋਗ ਨਹੀਂ ਰਹੋਗੇ। ਤੁਸੀਂ ਇਸ ਵਿੱਚ ਕੇਵਲ ਐਡ-ਆਨ ਸ਼ਾਮਲ ਅਤੇ ਹਟਾਉਣ ਦੇ ਯੋਗ ਹੀ ਹੋਵੋਗੇ।"
 
 #: src/olympia/bandwagon/templates/bandwagon/edit_contributors.html:83 src/olympia/devhub/templates/devhub/addons/forms_shared/media.html:157
-#: src/olympia/devhub/templates/devhub/addons/submit/describe.html:69 src/olympia/devhub/templates/devhub/addons/submit/license.html:60 src/olympia/devhub/templates/devhub/addons/submit/upload.html:78
+#: src/olympia/devhub/templates/devhub/addons/submit/describe.html:69 src/olympia/devhub/templates/devhub/addons/submit/license.html:60 src/olympia/devhub/templates/devhub/addons/submit/upload.html:70
 #: src/olympia/devhub/templates/devhub/payments/tier.html:17 src/olympia/editors/templates/editors/themes/themes.html:111 src/olympia/editors/templates/editors/themes/themes.html:128
 #: src/olympia/editors/templates/editors/themes/themes.html:134 src/olympia/editors/templates/editors/themes/themes.html:141 src/olympia/users/templates/users/fxa_migration_prompt_content.html:10
 #: src/olympia/users/templates/users/login_form.html:42 src/olympia/users/templates/users/mobile/login.html:57
@@ -2643,31 +2661,31 @@ msgid "Add-ons in Your Collection"
 msgstr "ਤੁਹਾਡੇ ਸੰਗ੍ਰਹਿ ਵਿੱਚ ਐਡ-ਆਨ"
 
 #: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:4
-msgid ""
-"To include an add-on in this collection, enter its name in the box below and hit enter.  You can also use the <strong>Add to Collection</strong> links throughout the site to include add-ons later."
+msgid "To include an add-on in this collection, enter its name in the box below and hit enter."
 msgstr ""
 
-#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:17 src/olympia/constants/base.py:400 src/olympia/devhub/templates/devhub/addons/activity.html:62
+#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:15 src/olympia/constants/base.py:400 src/olympia/devhub/templates/devhub/addons/activity.html:62
+#: src/olympia/editors/helpers.py:273 src/olympia/editors/helpers.py:360
 msgid "Add-on"
 msgstr "ਐਡ-ਆਨ"
 
-#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:26
+#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:24
 msgid "Enter the name of the add-on to include"
 msgstr "ਸ਼ਾਮਲ ਕਰਨ ਲਈ ਐਡ-ਆਨ ਦਾ ਨਾਂ ਦਰਜ ਕਰੋ"
 
-#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:28
+#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:26
 msgid "Add to Collection"
 msgstr "ਸੰਗ੍ਰਹਿ ਵਿੱਚ ਜੋੜੋ"
 
-#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:45 src/olympia/editors/helpers.py:936 src/olympia/editors/helpers.py:956
+#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:43 src/olympia/editors/helpers.py:1016 src/olympia/editors/helpers.py:1036
 msgid "Pending"
 msgstr "ਅਧੂਰਾ"
 
-#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:47
+#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:45
 msgid "Add a comment"
 msgstr "ਇੱਕ ਟਿੱਪਣੀ ਜੋੜੋ"
 
-#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:48
+#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:46
 msgid "Remove this add-on from the collection"
 msgstr "ਸੰਗ੍ਰਹਿ ਤੋਂ ਇਸ ਐਡ-ਆਨ ਨੂੰ ਹਟਾਓ"
 
@@ -2774,12 +2792,12 @@ msgstr "ਖੋਜ ਟੂਲ"
 msgid "Most Users"
 msgstr "ਬਹੁਤ ਸਾਰੇ ਉਪਭੋਗੀ"
 
-#: src/olympia/browse/views.py:61 src/olympia/browse/views.py:72 src/olympia/browse/views.py:279 src/olympia/browse/templates/browse/personas/mobile/category_landing.html:63
+#: src/olympia/browse/views.py:61 src/olympia/browse/views.py:72 src/olympia/browse/views.py:246 src/olympia/browse/templates/browse/personas/mobile/category_landing.html:63
 #: src/olympia/discovery/templates/discovery/pane.html:67 src/olympia/search/forms.py:92
 msgid "Up & Coming"
 msgstr "ਉੱਪਰ ਅਤੇ ਆ ਰਿਹਾ"
 
-#: src/olympia/browse/views.py:460 src/olympia/devhub/views.py:76 src/olympia/devhub/views.py:83 src/olympia/discovery/templates/discovery/addons/detail.html:66
+#: src/olympia/browse/views.py:427 src/olympia/devhub/views.py:74 src/olympia/devhub/views.py:81 src/olympia/discovery/templates/discovery/addons/detail.html:66
 msgid "Created"
 msgstr "ਰਚਿਆ"
 
@@ -2967,8 +2985,8 @@ msgid_plural "See all %(cnt)s extensions in %(name)s &raquo;"
 msgstr[0] "%(name)s &raquo ਵਿੱਚ %(cnt)s ਇਕਸਟੈਨਸ਼ਨ ਵੇਖੋ; "
 msgstr[1] "%(name)s &raquo ਵਿੱਚ %(cnt)s ਇਕਸਟੈਨਸ਼ਨਾਂ ਵੇਖੋ; "
 
-#: src/olympia/browse/templates/browse/mobile/extensions.html:13 src/olympia/compat/templates/compat/index.html:82 src/olympia/devhub/templates/devhub/devhub_search.html:24
-#: src/olympia/devhub/templates/devhub/addons/activity.html:47 src/olympia/search/templates/search/no_results.html:4 src/olympia/search/templates/search/mobile/results.html:36
+#: src/olympia/browse/templates/browse/mobile/extensions.html:13 src/olympia/devhub/templates/devhub/devhub_search.html:24 src/olympia/devhub/templates/devhub/addons/activity.html:47
+#: src/olympia/search/templates/search/no_results.html:4 src/olympia/search/templates/search/mobile/results.html:36
 msgid "No results found."
 msgstr "ਕੋਈ ਨਤੀਜਾ ਨਹੀਂਂ ਮਿਲਿਆ"
 
@@ -3053,7 +3071,7 @@ msgstr "&laquo; ਸਾਰੇ ਥੀਮ"
 msgid "All"
 msgstr "ਸਾਰੇ"
 
-#: src/olympia/compat/forms.py:22 src/olympia/search/views.py:525
+#: src/olympia/compat/forms.py:22 src/olympia/editors/templates/editors/base.html:69 src/olympia/search/views.py:518
 msgid "All Add-ons"
 msgstr "ਸਾਰੇ ਐਡ-ਆਨ"
 
@@ -3064,53 +3082,6 @@ msgstr "ਬਾਈਨਰੀ"
 #: src/olympia/compat/forms.py:24
 msgid "Non-binary"
 msgstr "ਨਾਨ-ਬਾਈਨਰੀ"
-
-#. Review points sources other than add-ons and themes.
-#: src/olympia/compat/views.py:87 src/olympia/constants/base.py:388 src/olympia/devhub/forms.py:162 src/olympia/editors/templates/editors/performance.html:75
-msgid "Other"
-msgstr "ਦੂਜੇ"
-
-#: src/olympia/compat/templates/compat/index.html:4
-msgid "Add-on Compatibility Report for {app} {version}"
-msgstr "{app} {version} ਲਈ ਐਡ-ਆਨ ਅਨੁਕੂਲਤਾ ਰਿਪੋਰਟ"
-
-#: src/olympia/compat/templates/compat/index.html:11
-msgid "{app} {version} Compatibility"
-msgstr "{app} {version} ਅਨੁਕੂਲਤਾ"
-
-#: src/olympia/compat/templates/compat/index.html:17
-#, python-format
-msgid "Top 95%% compatible with previous version"
-msgstr ""
-
-#: src/olympia/compat/templates/compat/index.html:18
-#, python-format
-msgid "Top 95%% of all add-ons"
-msgstr ""
-
-#: src/olympia/compat/templates/compat/index.html:19
-msgid "All active add-ons"
-msgstr "ਸਾਰੇ ਕਾਰਜਸ਼ੀਲ ਐਡ-ਆਨ"
-
-#: src/olympia/compat/templates/compat/index.html:23 src/olympia/constants/base.py:401
-msgid "App"
-msgstr "ਐੱਪ"
-
-#: src/olympia/compat/templates/compat/index.html:55
-msgid "Details for add-ons compatible with previous version:"
-msgstr "ਪਿਛਲੇ ਵਰਜਨ ਨਾਲ ਅਨੁਕੂਲ ਐਡ-ਆਨ ਲਈ ਵੇਰਵਾ:"
-
-#: src/olympia/compat/templates/compat/index.html:57
-msgid "Show all versions"
-msgstr "ਸਾਰੇ ਵਰਜਨ ਵਿਖਾਓ"
-
-#: src/olympia/compat/templates/compat/index.html:59
-msgid "Details for add-ons compatible with all versions:"
-msgstr "ਸਾਰੇ ਵਰਜਨਾਂ ਨਾਲ ਅਨੁਕੂਲ ਐਡ-ਆਨ ਲਈ ਵੇਰਵਾ:"
-
-#: src/olympia/compat/templates/compat/index.html:61
-msgid "Show previous version only"
-msgstr "ਕੇਵਲ ਪਿਛਲਾ ਵਰਜਨ ਵਿਖਾਓ"
 
 #: src/olympia/compat/templates/compat/reporter.html:3
 msgid "Add-on Compatibility Reports"
@@ -3165,8 +3136,8 @@ msgstr "ਐਪਲੀਕੇਸ਼ਨ ਦੁਆਰਾ ਫ਼ਿਲਟਰ"
 msgid "Report Type"
 msgstr "ਰਿਪਰੋਟ ਟਾਈਪ"
 
-#: src/olympia/compat/templates/compat/reporter_detail.html:47 src/olympia/devhub/forms.py:784 src/olympia/devhub/templates/devhub/addons/ajax_compat_update.html:17 src/olympia/editors/forms.py:108
-#: src/olympia/zadmin/forms.py:45
+#: src/olympia/compat/templates/compat/reporter_detail.html:47 src/olympia/devhub/forms.py:785 src/olympia/devhub/templates/devhub/addons/ajax_compat_update.html:17 src/olympia/editors/forms.py:108
+#: src/olympia/editors/forms.py:248 src/olympia/zadmin/forms.py:45
 msgid "Application"
 msgstr "ਐਪਲੀਕੇਸ਼ਨ"
 
@@ -3254,7 +3225,8 @@ msgstr "ਸ਼ੁਰੂਆਤੀ ਤੌਰ ਤੇ ਸਮੀਖਿਆ ਹੋਈ"
 msgid "Preliminarily Reviewed and Awaiting Full Review"
 msgstr "ਸ਼ੁਰੂਆਤੀ ਤੌਰ ਤੇ ਸਮੀਖਿਆ ਹੋਈ ਅਤੇ ਪੂਰੀ ਸਮੀਖਿਆ ਦੀ ਉਡੀਕ"
 
-#: src/olympia/constants/base.py:33 src/olympia/editors/helpers.py:924 src/olympia/editors/templates/editors/themes/history_table.html:34
+#: src/olympia/constants/base.py:33 src/olympia/editors/forms.py:258 src/olympia/editors/helpers.py:73 src/olympia/editors/helpers.py:1004
+#: src/olympia/editors/templates/editors/themes/history_table.html:34
 msgid "Deleted"
 msgstr "ਹਟਾਇਆ"
 
@@ -3351,6 +3323,11 @@ msgstr "ਉਪਭੋਗੀ ਨੂੰ ਇਸ ਐਡ-ਆਨ ਡਾਊਨਲੋਡ 
 msgid "Ask before users can download this add-on"
 msgstr "ਉਪਭੋਗੀਆਂ ਨੂੰ ਇਸ ਐਡ-ਆਨ ਡਾਊਨਲੋਡ ਕਰਨ ਤੋਂ ਪਹਿਲਾਂ ਪੁੱਛੋ"
 
+#. Review points sources other than add-ons and themes.
+#: src/olympia/constants/base.py:388 src/olympia/devhub/forms.py:162 src/olympia/editors/templates/editors/performance.html:75
+msgid "Other"
+msgstr "ਦੂਜੇ"
+
 #: src/olympia/constants/base.py:389
 msgid "Exception"
 msgstr "ਅਪਵਾਦ"
@@ -3362,6 +3339,10 @@ msgstr "ਰਿਲੀਜ਼"
 #: src/olympia/constants/base.py:391
 msgid "Change"
 msgstr "ਬਦਲੋ"
+
+#: src/olympia/constants/base.py:401
+msgid "App"
+msgstr "ਐੱਪ"
 
 #: src/olympia/constants/base.py:402
 msgid "Persona"
@@ -3511,7 +3492,7 @@ msgstr "ਫ਼ਲੈਗ"
 msgid "Duplicate"
 msgstr "ਨਕਲ"
 
-#: src/olympia/constants/editors.py:17 src/olympia/editors/helpers.py:502 src/olympia/editors/templates/editors/themes/queue.html:71 src/olympia/editors/templates/editors/themes/themes.html:94
+#: src/olympia/constants/editors.py:17 src/olympia/editors/helpers.py:575 src/olympia/editors/templates/editors/themes/queue.html:71 src/olympia/editors/templates/editors/themes/themes.html:94
 msgid "Reject"
 msgstr "ਰੱਦ"
 
@@ -3611,7 +3592,7 @@ msgstr "ਸੋਲਰਿਸ"
 msgid "Android"
 msgstr "ਐਨਡਰੋਇਡ"
 
-#: src/olympia/core/apps.py:19
+#: src/olympia/core/apps.py:21
 msgid "Core"
 msgstr ""
 
@@ -3745,8 +3726,8 @@ msgid "Submit my add-on for manual review."
 msgstr "ਹੱਥਲਿਖਤ ਸਮੀਖਿਆ ਵਾਸਤੇ ਮੇਰਾ ਐਡ-ਆਨ ਦਾਖਲ ਕਰੋ।"
 
 #: src/olympia/devhub/forms.py:537
-msgid "Do not list my add-on on this site (beta)"
-msgstr "ਮੇਰੇ ਐਡ-ਆਨ ਨੂੰ ਇਸ ਸਾਈਟ ਤੇ ਸੂਚੀਬੱਧ ਨਾ ਕਰੋ(ਬੀਟਾ)"
+msgid "Do not list my add-on on this site"
+msgstr ""
 
 #: src/olympia/devhub/forms.py:538
 msgid "Check this option if you intend to distribute your add-on on your own and only need it to be signed by Mozilla."
@@ -3778,46 +3759,46 @@ msgstr "a|alpha|b|beta|pre|rc ਅਤੇ ਇੱਕ ਚੋਣਵੇਂ ਨੰਬ�
 
 #: src/olympia/devhub/forms.py:592
 #, python-format
-msgid "Version %s already exists"
-msgstr "ਵਰਜਨ %s ਪਹਿਲਾਂ ਤੋਂ ਮੌਜੂਦ"
+msgid "Version %s already exists, or was uploaded before."
+msgstr ""
 
-#: src/olympia/devhub/forms.py:604
+#: src/olympia/devhub/forms.py:605
 msgid "Select a valid choice. That choice is not one of the available choices."
 msgstr "ਇੱਕ ਠੀਕ ਪਸੰਦ ਨੂੰ ਚੁਣੋ। ਇਹ ਪਸੰਦ ਉੱਪਲਬਧ ਪਸੰਦਾਂ ਵਿੱਚੋਂ ਇੱਕ ਨਹੀਂ ਹੈ।"
 
-#: src/olympia/devhub/forms.py:610
+#: src/olympia/devhub/forms.py:611
 msgid "A file with a version ending with a|alpha|b|beta and an optional number is detected as beta."
 msgstr "ਇੱਕ ਫ਼ਾਈਲ ਦਾ ਏ|ਐਲਫ਼ਾ|ਬੀ|ਬੀਟਾ ਦੇ ਇੱਕ ਵਰਜਨ ਅਤੇ ਇੱਕ ਚੋਣਵੇਂ ਅੰਕ ਨਾਲ ਅੰਤ ਹੋਵੇ ਬੀਟਾ ਪਛਾਣੀ ਜਾਵੇਗੀ।"
 
-#: src/olympia/devhub/forms.py:633
+#: src/olympia/devhub/forms.py:634
 msgid "You cannot upload any more files for this version."
 msgstr "ਤੁਸੀਂ ਇਸ ਵਰਜਨ ਲਈ ਹੋਰ ਜਿਆਦਾ ਫ਼ਾਈਲਾਂ ਅੱਪਲੋਡ ਨਹੀਂ ਕਰ ਸਕਦੇ।"
 
-#: src/olympia/devhub/forms.py:639
+#: src/olympia/devhub/forms.py:640
 msgid "Version doesn't match"
 msgstr "ਵਰਜਨ ਮੇਲ ਨਹੀਂ ਖਾਂਦਾ।"
 
-#: src/olympia/devhub/forms.py:668
+#: src/olympia/devhub/forms.py:669
 msgid "You cannot delete a file once the review process has started.  You must delete the whole version."
 msgstr ""
 
-#: src/olympia/devhub/forms.py:688
+#: src/olympia/devhub/forms.py:689
 msgid "The platform All cannot be combined with specific platforms."
 msgstr "ਪਲੇਟਫ਼ਾਰਮ ਆਲ ਨੂੰ ਖਾਸ ਪਲੇਟਫ਼ਾਰਮਾਂ ਦੇ ਨਾਲ ਜੋੜਿਆ ਨਹੀਂ ਜਾ ਸਕਦਾ।"
 
-#: src/olympia/devhub/forms.py:693
+#: src/olympia/devhub/forms.py:694
 msgid "A platform can only be chosen once."
 msgstr "ਇੱਕ ਪਲੇਟਫ਼ਾਰਮ ਨੂੰ ਇੱਕ ਵਾਰ ਹੀ ਚੁਣਿਆ ਜਾ ਸਕਦਾ।"
 
-#: src/olympia/devhub/forms.py:706
+#: src/olympia/devhub/forms.py:707
 msgid "A review type must be selected."
 msgstr "ਇੱਕ ਸਮੀਖਿਆ ਕਿਸਮ ਚੁਣੀ ਹੋਣੀ ਚਾਹੀਦੀ ਹੈ।"
 
-#: src/olympia/devhub/forms.py:788 src/olympia/editors/forms.py:114 src/olympia/zadmin/forms.py:49 src/olympia/zadmin/forms.py:52
+#: src/olympia/devhub/forms.py:789 src/olympia/editors/forms.py:114 src/olympia/editors/forms.py:254 src/olympia/zadmin/forms.py:49 src/olympia/zadmin/forms.py:52
 msgid "Select an application first"
 msgstr "ਪਹਿਲਾਂ ਇੱਕ ਐਪਲੀਕੇਸ਼ਨ ਚੁਣੋ"
 
-#: src/olympia/devhub/forms.py:840
+#: src/olympia/devhub/forms.py:841
 msgid "There cannot be more than 3 required add-ons."
 msgstr "ਇੱਥੇ 3 ਤੋਂ ਜਿਆਦਾ ਲੋੜੀਂਦੇ ਐਡ-ਆਨ ਨਹੀਂ ਹੋ ਸਕਦੇ।"
 
@@ -3851,76 +3832,76 @@ msgstr[1] "{0} ਚੇਤਾਵਨੀਆਂ"
 msgid "Review"
 msgstr "ਸਮੀਖਿਆ"
 
-#: src/olympia/devhub/tasks.py:551
+#: src/olympia/devhub/tasks.py:583
 #, python-format
 msgid "%s responded with %s (%s)."
 msgstr "%s ਦਾ ਜਵਾਬ %s (%s) ਦੇ ਨਾਲ ਦਿੱਤਾ।"
 
-#: src/olympia/devhub/tasks.py:555
+#: src/olympia/devhub/tasks.py:587
 #, python-format
 msgid "Connection to \"%s\" timed out."
 msgstr "\"%s\" ਲਈ ਕੁਨੈਕਸ਼ਨ ਦਾ ਸਮਾਂ ਖਤਮ ਹੋਇਆ।"
 
-#: src/olympia/devhub/tasks.py:557
+#: src/olympia/devhub/tasks.py:589
 #, python-format
 msgid "Could not contact host at \"%s\"."
 msgstr "\"%s\" ਤੇ ਹੋਸਟ ਨਾਲ ਸਪੰਰਕ ਨਹੀਂ ਕਰ ਸਕਿਆ।"
 
-#: src/olympia/devhub/utils.py:104
+#: src/olympia/devhub/utils.py:105
 #, python-format
 msgid "Validation generated too many errors/warnings so %s messages were truncated. After addressing the visible messages, you'll be able to see the others."
 msgstr "ਪ੍ਰਮਾਣਿਕਤਾ ਨੇ ਬਹੁਤ ਸਾਰੀਆਂ ਗਲਤੀਆਂ/ਚੇਤਾਵਨੀਆਂ ਪੈਦਾ ਕੀਤੀਆਂ ਇਸ ਲਈ %s ਸੁਨੇਹੇ ਛੋਟੇ ਹੋ ਗਏ। ਵੇਖਣਯੋਗ ਸੁਨੇਹਿਆਂ ਦਾ ਸੰਬੋਧਨ ਕਰਨ ਤੋਂ ਬਾਅਦ, ਤੁਸੀਂ ਹੋਰਾਂ ਨੂੰ ਵੇਖਣ ਦੇ ਯੋਗ ਹੋ ਜਾਵੋਗੇ।"
 
-#: src/olympia/devhub/views.py:183
+#: src/olympia/devhub/views.py:181
 msgid "All My Add-ons"
 msgstr "ਮੇਰੇ ਸਾਰੇ ਐਡ-ਆਨ"
 
-#: src/olympia/devhub/views.py:210
+#: src/olympia/devhub/views.py:208
 msgid "All Activity"
 msgstr "ਸਾਰੀ ਸਰਗਰਮੀ"
 
-#: src/olympia/devhub/views.py:211
+#: src/olympia/devhub/views.py:209
 msgid "Add-on Updates"
 msgstr "ਐਡ-ਆਨ ਅੱਪਡੇਟ"
 
-#: src/olympia/devhub/views.py:212
+#: src/olympia/devhub/views.py:210
 msgid "Add-on Status"
 msgstr "ਐਡ-ਆਨ ਦਰਜਾ"
 
-#: src/olympia/devhub/views.py:213
+#: src/olympia/devhub/views.py:211
 msgid "User Collections"
 msgstr "ਉਪਭੋਗੀ ਸੰਗ੍ਰਹਿ"
 
-#: src/olympia/devhub/views.py:214 src/olympia/devhub/templates/devhub/docs/policies-maintenance.html:68 src/olympia/pages/templates/pages/dev_faq.html:38
+#: src/olympia/devhub/views.py:212 src/olympia/devhub/templates/devhub/docs/policies-maintenance.html:68 src/olympia/pages/templates/pages/dev_faq.html:38
 #: src/olympia/pages/templates/pages/dev_faq.html:484
 msgid "User Reviews"
 msgstr "ਉਪਭੋਗੀ ਸਮੀਖਿਆਵਾਂ"
 
-#: src/olympia/devhub/views.py:327 src/olympia/devhub/views.py:331 src/olympia/devhub/views.py:484 src/olympia/devhub/views.py:513 src/olympia/devhub/views.py:564 src/olympia/devhub/views.py:1150
+#: src/olympia/devhub/views.py:325 src/olympia/devhub/views.py:329 src/olympia/devhub/views.py:484 src/olympia/devhub/views.py:513 src/olympia/devhub/views.py:564 src/olympia/devhub/views.py:1156
 msgid "Changes successfully saved."
 msgstr "ਬਦਲਾਵ ਸਫ਼ਲਤਾਪੂਰਕ ਸੰਭਾਲ੍ਹੇ ਗਏ।"
 
-#: src/olympia/devhub/views.py:334 src/olympia/devhub/views.py:1631
+#: src/olympia/devhub/views.py:332 src/olympia/devhub/views.py:1637
 msgid "Please check the form for errors."
 msgstr "ਗਲਤੀਆਂ ਲਈ ਫ਼ਾਰਮ ਦੀ ਪੜਤਾਲ ਕਰੋ।"
 
-#: src/olympia/devhub/views.py:346
+#: src/olympia/devhub/views.py:344
 msgid "Add-on cannot be deleted. Disable this add-on instead."
 msgstr "ਐਡ-ਆਨ ਹਟਾਇਆ ਨਹੀਂ ਜਾ ਸਕਿਆ। ਇਸ ਦੀ ਬਜਾਏ ਇਸ ਐਡ-ਆਨ ਨੂੰ ਅਯੋਗ ਕਰੋ।"
 
-#: src/olympia/devhub/views.py:356
+#: src/olympia/devhub/views.py:354
 msgid "Theme deleted."
 msgstr "ਥੀਮ ਹਟਾਇਆ।"
 
-#: src/olympia/devhub/views.py:356
+#: src/olympia/devhub/views.py:354
 msgid "Add-on deleted."
 msgstr "ਐਡ-ਆਨ ਹਟਾਇਆ।"
 
-#: src/olympia/devhub/views.py:362
+#: src/olympia/devhub/views.py:360
 msgid "URL name was incorrect. Theme was not deleted."
 msgstr ""
 
-#: src/olympia/devhub/views.py:367
+#: src/olympia/devhub/views.py:365
 msgid "URL name was incorrect. Add-on was not deleted."
 msgstr ""
 
@@ -3948,7 +3929,7 @@ msgstr "ਐਡ-ਆਨ ਦੀ ਪੜਤਾਲ"
 msgid "Check Add-on Compatibility"
 msgstr "ਐਡ-ਆਨ ਅਨੁਕੂਲਤਾ ਦੀ ਪੜਤਾਲ ਕਰੋ"
 
-#: src/olympia/devhub/views.py:808 src/olympia/signing/views.py:90
+#: src/olympia/devhub/views.py:808 src/olympia/signing/views.py:95
 msgid "You cannot submit this type of add-on"
 msgstr ""
 
@@ -3978,33 +3959,33 @@ msgstr "ਤਸਵੀਰ ਬਿਲਕੁਲ {0} ਪਿਕਸਲ ਚੌੜੀ ਅ�
 msgid "There was an error uploading your preview."
 msgstr "ਤੁਹਾਡੀ ਝਲਕ ਨੂੰ ਅੱਪਲੋਡ ਕਰਨ ਵਿੱਚ ਖਾਮੀ ਆਈ।"
 
-#: src/olympia/devhub/views.py:1189
+#: src/olympia/devhub/views.py:1195
 #, python-format
 msgid "Version %s disabled."
 msgstr "ਵਰਜਨ %s ਅਯੋਗ ਹੋਇਆ।"
 
-#: src/olympia/devhub/views.py:1193
+#: src/olympia/devhub/views.py:1199
 #, python-format
 msgid "Version %s deleted."
 msgstr "ਵਰਜਨ %s ਹਟਾਇਆ।"
 
-#: src/olympia/devhub/views.py:1203
+#: src/olympia/devhub/views.py:1209
 msgid "This upload has failed validation, and may lack complete validation results. Please take due care when reviewing it."
 msgstr "ਇਸ ਅੱਪਲੋਡ ਦੀ ਪ੍ਰਮਾਣਿਕਤਾ ਫ਼ੇਲ੍ਹ ਹੋਈ ਅਤੇ ਹੋ ਸਕਦਾ ਮੁਕੰਮਲ ਪ੍ਰਮਾਣਿਕਤਾ ਨਤੀਜਿਆਂ ਦੀ ਘਾਟ ਹੋਵੇ। ਕਿਰਪਾ ਕਰਕੇ ਪੂਰਾ ਧਿਆਨ ਦੇਵੋ ਜਦੋਂ ਇਸ ਦੀ ਸਮੀਖਿਆ ਕਰ ਰਹੇ ਹੋਵੋ।"
 
-#: src/olympia/devhub/views.py:1677
+#: src/olympia/devhub/views.py:1683
 msgid "Preliminary Review Requested."
 msgstr "ਸ਼ੁਰੂਆਤੀ ਸਮੀਖਿਆ ਦੀ ਬੇਨਤੀ ਕੀਤੀ।"
 
-#: src/olympia/devhub/views.py:1678
+#: src/olympia/devhub/views.py:1684
 msgid "Full Review Requested."
 msgstr "ਪੂਰੀ ਸਮੀਖਿਆ ਦੀ ਬੇਨਤੀ ਕੀਤੀ।"
 
-#: src/olympia/devhub/views.py:1779
+#: src/olympia/devhub/views.py:1783
 msgid "Your old credentials were revoked and are no longer valid. Be sure to update all API clients with the new credentials."
 msgstr ""
 
-#: src/olympia/devhub/views.py:1797
+#: src/olympia/devhub/views.py:1801
 msgid "New API key created"
 msgstr ""
 
@@ -4034,7 +4015,7 @@ msgstr "ਐਡ-ਆਨ ਤੇ ਵਾਪਸ"
 msgid "{0} :: Search"
 msgstr "{0} :: ਖੋਜ"
 
-#: src/olympia/devhub/templates/devhub/devhub_search.html:6 src/olympia/devhub/templates/devhub/search.html:8 src/olympia/editors/forms.py:435 src/olympia/editors/forms.py:437
+#: src/olympia/devhub/templates/devhub/devhub_search.html:6 src/olympia/devhub/templates/devhub/search.html:8 src/olympia/editors/forms.py:534 src/olympia/editors/forms.py:536
 #: src/olympia/editors/templates/editors/queue.html:27 src/olympia/editors/templates/editors/themes/queue_list.html:14 src/olympia/search/templates/search/collections.html:17
 #: src/olympia/search/templates/search/personas.html:18 src/olympia/search/templates/search/results.html:18 src/olympia/search/templates/search/mobile/results.html:8
 #: src/olympia/templates/search.html:14 src/olympia/templates/impala/search.html:18
@@ -4096,12 +4077,12 @@ msgstr "ਹਰੇਕ ਚੀਜ਼ ਸਿੱਖਣ ਲਈ <a href=\"https://devel
 msgid "Start Making Add-ons"
 msgstr "ਐਡ-ਆਨ ਬਣਾਉਣਾ ਸ਼ੁਰੂ ਕਰੋ"
 
-#: src/olympia/devhub/templates/devhub/index.html:86 src/olympia/devhub/templates/devhub/addons/listing/items.html:25 src/olympia/devhub/templates/devhub/includes/addon_details.html:15
+#: src/olympia/devhub/templates/devhub/index.html:86 src/olympia/devhub/templates/devhub/addons/listing/items.html:25 src/olympia/devhub/templates/devhub/includes/addon_details.html:20
 #: src/olympia/devhub/templates/devhub/personas/edit.html:43
 msgid "Status:"
 msgstr "ਦਰਜਾ:"
 
-#: src/olympia/devhub/templates/devhub/index.html:90 src/olympia/devhub/templates/devhub/includes/addon_details.html:100
+#: src/olympia/devhub/templates/devhub/index.html:90 src/olympia/devhub/templates/devhub/includes/addon_details.html:87
 msgid "Visibility:"
 msgstr "ਪ੍ਰਤੱਖਤਾ:"
 
@@ -4109,11 +4090,11 @@ msgstr "ਪ੍ਰਤੱਖਤਾ:"
 msgid "Latest Version:"
 msgstr "ਤਾਜ਼ਾ ਵਰਜਨ:"
 
-#: src/olympia/devhub/templates/devhub/index.html:109 src/olympia/devhub/templates/devhub/includes/addon_details.html:145 src/olympia/devhub/templates/devhub/personas/edit.html:49
+#: src/olympia/devhub/templates/devhub/index.html:109 src/olympia/devhub/templates/devhub/includes/addon_details.html:131 src/olympia/devhub/templates/devhub/personas/edit.html:49
 msgid "Queue Position:"
 msgstr "ਕਤਾਰ ਸਥਿਤੀ:"
 
-#: src/olympia/devhub/templates/devhub/index.html:110 src/olympia/devhub/templates/devhub/includes/addon_details.html:146 src/olympia/devhub/templates/devhub/personas/edit.html:50
+#: src/olympia/devhub/templates/devhub/index.html:110 src/olympia/devhub/templates/devhub/includes/addon_details.html:132 src/olympia/devhub/templates/devhub/personas/edit.html:50
 #, python-format
 msgid "%(position)s of %(total)s"
 msgstr "%(total)s ਦੀ %(position)s"
@@ -4215,16 +4196,6 @@ msgstr "ਅੱਪਲੋਡ ਤੋਂ ਬਾਅਦ, ਤੁਹਾਡੀ ਫ਼ਾਈ�
 msgid "Do you want your add-on to be distributed on this site?"
 msgstr "ਕੀ ਤੁਸੀਂ ਚਾਹੁੰਦੇ ਹੋ ਕੀ ਤੁਹਾਡਾ ਐਡ-ਆਨ ਇਸ ਸਾਈਟ ਤੇ ਵਰਤਾਇਆ ਜਾਵੇ?"
 
-#: src/olympia/devhub/templates/devhub/validate_addon.html:49 src/olympia/devhub/templates/devhub/addons/submit/upload.html:30 src/olympia/devhub/templates/devhub/versions/add_file_modal.html:14
-#: src/olympia/devhub/templates/devhub/versions/add_file_modal.html:53 src/olympia/devhub/templates/devhub/versions/list.html:298
-msgid "Warning:"
-msgstr "ਚੇਤਾਵਨੀ:"
-
-#: src/olympia/devhub/templates/devhub/validate_addon.html:50 src/olympia/devhub/templates/devhub/addons/submit/upload.html:31
-#, python-format
-msgid "Submission of unlisted add-ons for signing is currently in an open beta. Please <a href=\"%(url)s\" target=\"_blank\">report any bugs</a> that you encounter."
-msgstr ""
-
 #. first parameter is a filename like lorem-ipsum-1.0.2.xpi
 #: src/olympia/devhub/templates/devhub/validation.html:5
 msgid "Validation Results for {0}"
@@ -4301,7 +4272,7 @@ msgstr "ਅਨੁਕੂਲਤਾ"
 msgid "Update Compatibility"
 msgstr "ਅਨੁਕੂਲਤਾ ਅੱਪਡੇਟ ਕਰੋ"
 
-#: src/olympia/devhub/templates/devhub/addons/ajax_compat_update.html:4
+#: src/olympia/devhub/templates/devhub/addons/ajax_compat_update.html:4 src/olympia/devhub/templates/devhub/versions/edit.html:45
 msgid "Adjusting application information here will allow users to install your add-on even if the install manifest in the package indicates that the add-on is incompatible."
 msgstr "ਇੱਥੇ ਐਪਲੀਕੇਸ਼ਨ ਦੀ ਜਾਣਕਾਰੀ ਵਿੱਚ ਕੀਤਾ ਫ਼ੇਰਬਦਲ ਉਪਭੋਗੀਆਂ ਨੂੰ ਤੁਹਾਡਾ ਐਡ-ਆਨ ਇੰਸਟਾਲ ਕਰਨ ਦੇਵੇਗਾ ਭਲੇ ਹੀ ਪੈਕੇਜ ਵਿੱਚ ਦਿੱਤਾ ਇੰਸਟਾਲ ਮੈਨਫ਼ੇਸ਼ਟ ਇਹ ਦੱਸੇ ਕਿ ਐਡ-ਆਨ ਅਨੁਕੂਲ ਨਹੀਂ ਹੈ।"
 
@@ -4313,9 +4284,9 @@ msgstr "ਸਹਿਯੋਗੀ ਵਰਜਨ"
 msgid "Add Another Application&hellip;"
 msgstr "ਹੋਰ ਐਪਲੀਕੇਸ਼ਨ ਜੋੜੋ&hellip;"
 
-#: src/olympia/devhub/templates/devhub/addons/ajax_compat_update.html:38 src/olympia/devhub/templates/devhub/addons/owner.html:86 src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:46
-#: src/olympia/devhub/templates/devhub/versions/list.html:351 src/olympia/devhub/templates/devhub/versions/list.html:353 src/olympia/templates/impala/base.html:132
-#: src/olympia/templates/impala/base.html:143 src/olympia/templates/impala/base.html:161 src/olympia/templates/impala/base.html:171
+#: src/olympia/devhub/templates/devhub/addons/ajax_compat_update.html:38 src/olympia/devhub/templates/devhub/addons/owner.html:86 src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:45
+#: src/olympia/devhub/templates/devhub/versions/list.html:349 src/olympia/devhub/templates/devhub/versions/list.html:351 src/olympia/templates/impala/base.html:129
+#: src/olympia/templates/impala/base.html:140 src/olympia/templates/impala/base.html:158 src/olympia/templates/impala/base.html:168
 msgid "Close"
 msgstr "ਬੰਦ"
 
@@ -4349,7 +4320,7 @@ msgstr "ਕੋਈ ਨਹੀਂ"
 msgid "Manage Authors & License"
 msgstr "ਲੇਖਕਾਂ ਅਤੇ ਲਾਇਸੰਸ ਦਾ ਪ੍ਰਬੰਧ ਕਰੋ"
 
-#: src/olympia/devhub/templates/devhub/addons/owner.html:29 src/olympia/editors/templates/editors/review.html:270
+#: src/olympia/devhub/templates/devhub/addons/owner.html:29 src/olympia/editors/helpers.py:362 src/olympia/editors/templates/editors/review.html:270
 msgid "Authors"
 msgstr "ਲੇਖਕ"
 
@@ -4420,18 +4391,12 @@ msgstr "ਸੰਖੇਪ"
 
 #: src/olympia/devhub/templates/devhub/addons/edit/basic.html:52
 msgid ""
-"A short explanation of your add-on's basic\n"
-"                          functionality that is displayed in search and browse\n"
-"                          listings, as well as at the top of your add-on's\n"
-"                          details page. It is only relevant for listed add-ons."
-msgstr ""
+"A short explanation of your add-on's basic functionality that is displayed in search and browse listings, as well as at the top of your add-on's details page. It is only relevant for listed add-ons."
+msgstr "ਤੁਹਾਡੇ ਐਡ-ਆਨ ਦੀ ਬੁਨਿਆਦੀ ਕਾਰਗੁਜ਼ਾਰੀ ਦੀ ਇੱਕ ਛੋਟੀ ਵਿਆਖਿਆ ਜੋ ਖੋਜ ਅਤੇ ਝਲਕ ਸੂਚੀਆਂ ਵਿੱਚ, ਨਾਲ ਦੀ ਨਾਲ ਤੁਹਾਡੇ ਐਡ-ਆਨ ਦੇ ਵੇਰਵੇ ਸਫ਼ੇ ਤੇ ਵਿਖਾਈ ਜਾਂਦੀ ਹੈ। ਇਹ ਕੇਵਲ ਸੂਚੀਬੱਧ ਐਡ-ਆਨ ਲਈ ਢੁੱਕਵੀਂ ਹੈ।"
 
 #: src/olympia/devhub/templates/devhub/addons/edit/basic.html:73
-msgid ""
-"Categories are the primary way users browse through add-ons.\n"
-"                        Choose any that fit your add-on's functionality for the most\n"
-"                        exposure. It is only relevant for listed add-ons."
-msgstr ""
+msgid "Categories are the primary way users browse through add-ons. Choose any that fit your add-on's functionality for the most exposure. It is only relevant for listed add-ons."
+msgstr "ਵਰਤੋਂਕਾਰਾਂ ਲਈ ਐਡ-ਆਨ ਵੇਖਣ ਦਾ ਮੁੱਖ ਢੰਗ ਸੰਗ੍ਰਹਿ ਹਨ। ਕਿਸੇ ਨੂੰ ਵੀ ਚੁਣੋ ਜੋ ਜਿਆਦਾ ਪ੍ਰਭਾਵ ਪਾਉਣ ਲਈ ਤੁਹਾਡੇ ਐਡ-ਆਨ ਦੀ ਕਾਰਗੁਜ਼ਾਰੀ ਲਈ ਠੀਕ ਹੋਵੇ।"
 
 #: src/olympia/devhub/templates/devhub/addons/edit/basic.html:90
 #, python-format
@@ -4440,12 +4405,8 @@ msgid ""
 msgstr "ਸੰਗ੍ਰਹਿ ਬਦਲੇ ਨਹੀਂ ਜਾ ਸਕਣਗੇ ਜਦ ਤੱਕ ਤੁਹਾਡਾ ਐਡ-ਆਨ ਇਸ ਐਪਲੀਕੇਸ਼ਨ ਲਈ ਪੇਸ਼ ਕੀਤਾ ਗਿਆ ਹੈ। ਕਿਰਪਾ ਕਰਕੇ ਈਮੇਲ ਕਰੋ <a href=\"mailto:%(email)s\">%(email)s</a> ਜੇਕਰ ਕਿਸੇ ਕਾਰਨ ਤੁਹਾਨੂੰ ਤੁਹਾਡੇ ਸੰਗ੍ਰਹਿਾਂ ਵਿੱਚ ਤਬਦੀਲੀ ਕਰਨ ਦੀ ਲੋੜ ਹੈ।"
 
 #: src/olympia/devhub/templates/devhub/addons/edit/basic.html:119
-msgid ""
-"Tags help users find your add-on and should be short\n"
-"                        descriptors such as tabs, toolbar, or twitter.  You\n"
-"                        may have a maximum of {0} tags. It is only relevant\n"
-"                        for listed add-ons."
-msgstr ""
+msgid "Tags help users find your add-on and should be short descriptors such as tabs, toolbar, or twitter. You may have a maximum of {0} tags. It is only relevant for listed add-ons."
+msgstr "ਟੈਗ ਵਰਤੋਂਕਾਰਾਂ ਦੀ ਤੁਹਾਡਾ ਐਡ-ਆਨ ਲੱਭਣ ਵਿੱਚ ਮਦਦ ਕਰਦੇ ਅਤੇ ਛੋਟੇ ਵਰਣਨ ਵਾਲੇ ਹੋਣੇ ਚਾਹੀਦੇ ਹਨ ਜਿਵੇਂ ਕਿ ਟੈਬਾਂ, ਟੂਲਬਾਰ, ਜਾਂ ਟਵਿੱਟਰ। ਤੁਹਾਡੇ ਕੋਲ ਵੱਧ ਤੋਂ ਵੱਧ {0} ਟੈਗ ਹੋ ਸਕਦੇ ਹਨ। ਇਹ ਕੇਵਲ ਸੂਚੀਬੱਧ ਐਡ-ਆਨਾਂ ਲਈ ਢੁੱਕਵੇਂ ਹਨ।"
 
 #: src/olympia/devhub/templates/devhub/addons/edit/basic.html:129 src/olympia/devhub/templates/devhub/personas/edit.html:97 src/olympia/devhub/templates/devhub/personas/submit.html:46
 msgid "Comma-separated, minimum of {0} character."
@@ -4472,23 +4433,16 @@ msgid "Add-on Details for {0}"
 msgstr "{0} ਲਈ ਐਡ-ਆਨ ਵੇਰਵਾ"
 
 #: src/olympia/devhub/templates/devhub/addons/edit/details.html:22
-msgid ""
-"A longer explanation of features,\n"
-"                          functionality, and other relevant information. This\n"
-"                          field is only displayed on the add-on's details\n"
-"                          page. It is only relevant for listed add-ons."
-msgstr ""
+msgid "A longer explanation of features, functionality, and other relevant information. This field is only displayed on the add-on's details page. It is only relevant for listed add-ons."
+msgstr "ਗੁਣਾਂ, ਕਾਰਗੁਜ਼ਾਰੀ, ਅਤੇ ਹੋਰ ਸੰਬੰਧਤ ਜਾਣਕਾਰੀ ਦੀ ਇੱਕ ਲੰਬੀ ਵਿਆਖਿਆ। ਇਹ ਖੇਤਰ ਕੇਵਲ ਐਡ-ਆਨ ਦੇ ਮੁੱਖ ਸਫ਼ੇ ਤੇ ਵਿਆਖਿਆ ਜਾਂਦਾ। ਇਹ ਕੇਵਲ ਸੂਚੀਬੱਧ ਐਡ-ਆਨਾਂ ਲਈ ਢੁੱਕਵੀਂ ਹੈ।"
 
 #: src/olympia/devhub/templates/devhub/addons/edit/details.html:44 src/olympia/translations/templates/translations/trans-menu.html:13
 msgid "Default Locale"
 msgstr "ਮੂਲ ਲੋਕੇਲ"
 
 #: src/olympia/devhub/templates/devhub/addons/edit/details.html:45
-msgid ""
-"Information about your add-on is displayed in this locale\n"
-"                        unless you override it with a locale-specific translation.\n"
-"                        It is only relevant for listed add-ons."
-msgstr ""
+msgid "Information about your add-on is displayed in this locale unless you override it with a locale-specific translation. It is only relevant for listed add-ons."
+msgstr "ਤੁਹਾਡੇ ਐਡ-ਆਨ ਬਾਰੇ ਜਾਣਕਾਰੀ ਇਸ ਲੋਕੇਲ ਵਿੱਚ ਵਿਖਾਈ ਜਾਂਦੀ ਹੈ ਜਦ ਤੱਕ ਤੁਸੀਂ ਇਸ ਨੂੰ ਇੱਕ ਖ਼ਾਸ-ਲੋਕੇਲ ਤਰਜਮੇ ਨਾਲ ਮੁੜ ਨਹੀਂ ਲਿੱਖਦੇ। ਇਹ ਕੇਵਲ ਸੂਚੀਬੱਧ ਐਡ-ਆਨਾਂ ਲਈ ਢੁੱਕਵਾਂ ਹੈ।"
 
 #: src/olympia/devhub/templates/devhub/addons/edit/details.html:61 src/olympia/users/forms.py:311 src/olympia/users/templates/users/edit.html:122 src/olympia/users/templates/users/register.html:57
 #: src/olympia/users/templates/users/vcard.html:22
@@ -4497,11 +4451,9 @@ msgstr "ਮੁੱਖ ਸਫ਼ਾ"
 
 #: src/olympia/devhub/templates/devhub/addons/edit/details.html:63
 msgid ""
-"If your add-on has another homepage, enter its\n"
-"                          address here. If your website is localized into other\n"
-"                          languages multiple translations of this field can be\n"
-"                          added. It is only relevant for listed add-ons."
-msgstr ""
+"If your add-on has another homepage, enter its address here. If your website is localized into other languages multiple translations of this field can be added. It is only relevant for listed add-"
+"ons."
+msgstr "ਜੇਕਰ ਤੁਹਾਡੇ ਐਡ-ਆਨ ਦਾ ਕੋਈ ਹੋਰ ਵੀ ਮੁੱਖ-ਸਫ਼ਾ ਹੈ, ਉਸ ਦਾ ਪਤਾ ਇੱਥੇ ਦਰਜ ਕਰੋ। ਜੇਕਰ ਤੁਹਾਡੀ ਵੈੱਬਸਾਈਟ ਦਾ ਤਰਜਮਾ ਹੋਰ ਭਾਸ਼ਾਵਾਂ ਵਿੱਚ ਹੋਇਆ ਇਸ ਖੇਤਰ ਦੇ ਬਹੁਤ ਸਾਰੇ ਅਨੁਵਾਦ ਸ਼ਾਮਲ ਕੀਤੇ ਜਾ ਸਕਦੇ ਹਨ। ਇਹ ਕੇਵਲ ਸੂਚੀਬੱਧ ਐਡ-ਆਨਾਂ ਲਈ ਢੁੱਕਵਾਂ ਹੈ।"
 
 #: src/olympia/devhub/templates/devhub/addons/edit/media.html:3
 msgid "Images"
@@ -4518,20 +4470,15 @@ msgstr "{0} ਲਈ ਸਹਿਯੋਗ ਜਾਣਕਾਰੀ"
 
 #: src/olympia/devhub/templates/devhub/addons/edit/support.html:22
 msgid ""
-"If you wish to display an e-mail address for support\n"
-"                          inquiries, enter it here. If you have different\n"
-"                          addresses for each language multiple translations of\n"
-"                          this field can be added. It is only relevant for\n"
-"                          listed add-ons."
-msgstr ""
+"If you wish to display an e-mail address for support inquiries, enter it here. If you have different addresses for each language multiple translations of this field can be added. It is only "
+"relevant for listed add-ons."
+msgstr "ਜੇਕਰ ਤੁਸੀਂ ਸਹਿਯੋਗ ਪੁੱਛਗਿੱਛਾਂ ਲਈ ਇੱਕ ਈਮੇਲ ਪਤਾ ਵਿਖਾਉਣ ਦੇ ਚਾਹਵਾਨ ਹੋ, ਇੱਥੇ ਦਰਜ ਕਰੋ। ਜੇਕਰ ਤੁਹਾਡੇ ਕੋਲ ਹਰੇਕ ਭਾਸ਼ਾ ਲਈ ਵੱਖ-ਵੱਖ ਪਤੇ ਹਨ ਇਸ ਖੇਤਰ ਦੇ ਬਹੁਤ ਸਾਰੇ ਅਨੁਵਾਦ ਸ਼ਾਮਲ ਕੀਤੇ ਜਾ ਸਕਦੇ ਹਨ। ਇਹ ਕੇਵਲ ਸੂਚੀਬੱਧ ਐਡ-ਆਨਾਂ ਲਈ ਢੁੱਕਵਾਂ ਹੈ।"
 
 #: src/olympia/devhub/templates/devhub/addons/edit/support.html:45
 msgid ""
-"If your add-on has a support website or forum, enter\n"
-"                          its address here. If your website is localized into\n"
-"                          other languages, multiple translations of this field can\n"
-"                          be added. It is only relevant for listed add-ons."
-msgstr ""
+"If your add-on has a support website or forum, enter its address here. If your website is localized into other languages, multiple translations of this field can be added. It is only relevant for "
+"listed add-ons."
+msgstr "ਜੇਕਰ ਤੁਹਾਡੇ ਐਡ-ਆਨ ਦੀ ਇੱਕ ਸਹਿਯੋਗ ਵੈੱਬਸਾਈਟ ਜਾਂ ਫੋਰਮ ਹੈ, ਉਸ ਦਾ ਪਤਾ ਇੱਥੇ ਦਰਜ ਕਰੋ। ਜੇਕਰ ਤੁਹਾਡੀ ਵੈੱਬਸਾਈਟ ਦਾ ਹੋਰ ਭਾਸ਼ਾਵਾਂ ਵਿੱਚ ਤਰਜਮਾ ਹੋਇਆ, ਇਸ ਖੇਤਰ ਦੇ ਬਹੁਤ ਸਾਰੇ ਅਨੁਵਾਦ ਸ਼ਾਮਲ ਕੀਤੇ ਜਾ ਸਕਦੇ ਹਨ। ਇਹ ਕੇਵਲ ਸੂਚੀਬੱਧ ਐਡ-ਆਨਾਂ ਲਈ ਢੁੱਕਵਾਂ ਹੈ।"
 
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:6
 msgid "Technical Details"
@@ -4544,12 +4491,11 @@ msgstr "{0} ਲਈ ਤਕਨੀਕੀ ਜਾਣਕਾਰੀ"
 
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:23
 msgid ""
-"Any information end users may want to know that isn't\n"
-"                          necessarily applicable to the add-on summary or description.\n"
-"                          Common uses include listing known major bugs, information on\n"
-"                          how to report bugs, anticipated release date of a new version,\n"
-"                          etc. It is only relevant for listed add-ons."
+"Any information end users may want to know that isn't necessarily applicable to the add-on summary or description. Common uses include listing known major bugs, information on how to report bugs, "
+"anticipated release date of a new version, etc. It is only relevant for listed add-ons."
 msgstr ""
+"ਅੰਤ ਵਰਤੋਂਕਾਰ ਕੋਈ ਵੀ ਜਾਣਕਾਰੀ ਲੈਣਾ ਚਾਹੁੰਦੇ ਹੋਣ ਜੋ ਜ਼ਰੂਰੀ ਨਹੀਂ ਐਡ-ਆਨ ਦੇ ਸੰਖੇਪ ਵਰਣਨ ਜਾਂ ਵੇਰਵੇ ਤੇ ਲਾਗੂ ਹੋਵੋ। ਆਮ ਵਰਤੋਂ ਵਿੱਚ ਸ਼ਾਮਲ ਮੁੱਖ ਜਾਣੂ ਬੱਗਾਂ ਦੀ ਸੂਚੀ, ਬੱਗਾਂ ਦੀ ਸੂਚਨਾ ਕਿਵੇਂ ਭੇਜੀਏ ਦੀ ਜਾਣਕਾਰੀ, ਨਵੇਂ ਵਰਜਨ ਦੇ ਜਾਰੀ ਹੋਣ ਦੀ ਤਰੀਕ ਦਾ ਅਨੁਮਾਨ, ਆਦਿ। ਇਹ ਕੇਵਲ "
+"ਸੂਚੀਬੱਧ ਐਡ-ਆਨਾਂ ਲਈ ਢੁੱਕਵਾਂ ਹੈ।"
 
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:46
 msgid "Limit 3"
@@ -4560,10 +4506,8 @@ msgid "Add-on Flags"
 msgstr "ਐਡ-ਆਨ ਫ਼ਲੈਗ"
 
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:69
-msgid ""
-"These flags are used to classify add-ons. It is only\n"
-"                        relevant for listed add-ons."
-msgstr ""
+msgid "These flags are used to classify add-ons. It is only relevant for listed add-ons."
+msgstr "ਇਹ ਝੰਡੇ ਐਡ-ਆਨਾਂ ਦੇ ਵਰਗੀਕਰਨ ਲਈ ਵਰਤੇ ਜਾਂਦੇ ਹਨ। ਇਹ ਕੇਵਲ ਸੂਚੀਬੱਧ ਐਡ-ਆਨਾਂ ਲਈ ਢੁੱਕਵਾਂ ਹੈ।"
 
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:74
 msgid "This is a site-specific add-on."
@@ -4578,10 +4522,8 @@ msgid "View Source?"
 msgstr "ਸਰੋਤ ਵੇਖੋ?"
 
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:90
-msgid ""
-"Whether the source of your add-on can be displayed in our\n"
-"                        online viewer. It is only relevant for listed add-ons."
-msgstr ""
+msgid "Whether the source of your add-on can be displayed in our online viewer. It is only relevant for listed add-ons."
+msgstr "ਚਾਹੇ ਤੁਹਾਡੇ ਐਡ-ਆਨ ਦਾ ਸੋਰਸ ਸਾਡੇ ਆਨਲਾਈਨ ਦਰਸ਼ਕ ਵਿੱਚ ਵਿਖਾਇਆ ਜਾਵੇ। ਇਹ ਕੇਵਲ ਸੂਚੀਬੱਧ ਐਡ-ਆਨਾਂ ਲਈ ਢੁੱਕਵਾਂ ਹੈ।"
 
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:94
 msgid "This add-on's source code is publicly viewable."
@@ -4596,11 +4538,8 @@ msgid "Public Stats?"
 msgstr "ਜਨਤਕ ਅੰਕੜੇ?"
 
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:102
-msgid ""
-"Whether the download and usage stats of your add-on can\n"
-"                        be displayed in our online viewer.\n"
-"                        It is only relevant for listed add-ons."
-msgstr ""
+msgid "Whether the download and usage stats of your add-on can be displayed in our online viewer. It is only relevant for listed add-ons."
+msgstr "ਚਾਹੇ ਤੁਹਾਡੇ ਐਡ-ਆਨ ਦੇ ਡਾਊਨਲੋਡ ਅਤੇ ਵਰਤੋਂ ਅੰਕੜੇ ਸਾਡੇ ਆਨਲਾਈਨ ਦਰਸ਼ਕ ਵਿੱਚ ਵਿਖਾਏ ਜਾਣ। ਇਹ ਕੇਵਲ ਸੂਚੀਬੱਧ ਐਡ-ਆਨਾਂ ਲਈ ਢੁੱਕਵਾਂ ਹੈ।"
 
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:107
 msgid "This add-on's stats are publicly viewable."
@@ -4615,11 +4554,8 @@ msgid "Upgrade SDK?"
 msgstr "ਅੱਪਗਰੇਡ SDK?"
 
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:116
-msgid ""
-"If selected, we will try to automatically upgrade your\n"
-"                        add-on when a new version of the SDK is released.\n"
-"                        It is only relevant for listed add-ons."
-msgstr ""
+msgid "If selected, we will try to automatically upgrade your add-on when a new version of the SDK is released. It is only relevant for listed add-ons."
+msgstr "ਜੇਕਰ ਚੁਣਿਆ ਹੋਵੇ, ਅਸੀਂ ਆਪਣੇ ਆਪ ਤੁਹਾਡੇ ਐਡ-ਆਨ ਨੂੰ ਅੱਪਗਰੇਡ ਕਰਨ ਦੀ ਕੋਸ਼ਿਸ ਕਰਾਂਗੇ ਜਦੋਂ SDK ਦਾ ਨਵਾਂ ਵਰਜਨ ਜਾਰੀ ਹੋਵੇ। ਇਹ ਕੇਵਲ ਸੂਚੀਬੱਧ ਐਡ-ਆਨ ਲਈ ਢੁੱਕਵਾਂ ਹੈ।"
 
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:121
 msgid "This add-on will be automatically upgraded to new versions of the Add-on SDK."
@@ -4669,11 +4605,11 @@ msgstr "ਐਡ-ਆਨ ਆਈਕਾਨ"
 
 #: src/olympia/devhub/templates/devhub/addons/forms_shared/media.html:16
 msgid ""
-"Upload an icon for your add-on or choose from one of ours. The\n"
-"                      icon is displayed nearly everywhere your add-on is. Uploaded images\n"
-"                      must be one of the following image types: .png, .jpg.\n"
-"                      It is only relevant for listed add-ons."
+"Upload an icon for your add-on or choose from one of ours. The icon is displayed nearly everywhere your add-on is. Uploaded images must be one of the following image types: .png, .jpg. It is only "
+"relevant for listed add-ons."
 msgstr ""
+"ਆਪਣੇ ਐਡ-ਆਨ ਲਈ ਇੱਕ ਆਈਕਾਨ ਅੱਪਲੋਡ ਕਰੋ ਜਾਂ ਸਾਡਿਆਂ ਵਿੱਚ ਇੱਕ ਚੁਣੋ। ਆਈਕਾਨ ਲਗਭਗ ਹਰੇਕ ਥਾਂ ਵਿਖਾਇਆ ਜਾਏਗਾ ਜਿੱਥੇ ਵੀ ਤੁਹਾਡਾ ਐਡ-ਆਨ ਹੈ। ਅੱਪਲੋਡ ਕੀਤੀਆਂ ਤਸਵੀਰਾਂ ਅੱਗੇ ਦਿੱਤੀਆਂ ਤਸਵੀਰ ਕਿਸਮਾਂ ਵਿੱਚ ਇੱਕ ਹੋਣੀਆਂ ਚਾਹੀਦੀਆਂ ਹਨ: .png, .jpg। ਇਹ ਕੇਵਲ ਸੂਚੀਬੱਧ ਐਡ-ਆਨਾਂ "
+"ਲਈ ਢੁੱਕਵਾਂ ਹੈ।"
 
 #: src/olympia/devhub/templates/devhub/addons/forms_shared/media.html:25
 msgid "Select an icon for your add-on:"
@@ -4685,10 +4621,8 @@ msgid "32x32px"
 msgstr "32x32px"
 
 #: src/olympia/devhub/templates/devhub/addons/forms_shared/media.html:39
-msgid ""
-"Used in listings of add-ons, like search results\n"
-"                            and featured add-ons."
-msgstr ""
+msgid "Used in listings of add-ons, like search results and featured add-ons."
+msgstr "ਐਡ-ਆਨਾਂ ਦੀ ਸੂਚੀ ਵਿੱਚ ਵਰਤੇ ਗਏ, ਜਿਵੇਂ ਖੋਜ ਨਤੀਜੇ ਅਤੇ ਪੇਸ਼ ਕੀਤੇ ਐਡ-ਆਨ।"
 
 #. The size of the icon
 #: src/olympia/devhub/templates/devhub/addons/forms_shared/media.html:48
@@ -4782,16 +4716,14 @@ msgid "Deleting your add-on will permanently remove it from the site and prevent
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:24
-msgid ""
-"Enter the following text confirm your decision:\n"
-"           {slug}"
+msgid "Enter the following text confirm your decision: {slug}"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:34
+#: src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:33
 msgid "Please tell us why you are deleting your theme:"
 msgstr "ਕਿਰਪਾ ਕਰਕੇ ਸਾਨੂੰ ਦੱਸੋ ਤੁਸੀਂ ਆਪਣੇ ਥੀਮ ਨੂੰ ਕਿਉਂ ਹਟਾ ਰਹੇ ਹੋ:"
 
-#: src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:36
+#: src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:35
 msgid "Please tell us why you are deleting your add-on:"
 msgstr "ਕਿਰਪਾ ਕਰਕੇ ਸਾਨੂੰ ਦੱਸੋ ਤੁਸੀਂ ਆਪਣੇ ਐਡ-ਆਨ ਨੂੰ ਕਿਉਂ ਹਟਾ ਰਹੇ ਹੋ:"
 
@@ -4828,8 +4760,8 @@ msgstr "ਨਵਾਂ ਵਰਜਨ"
 msgid "Daily statistics on downloads and users."
 msgstr "ਡਾਊਨਲੋਡਾਂ ਅਤੇ ਉਪਭੋਗੀਆਂ ਉੱਤੇ ਰੋਜ਼ਾਨਾ ਅੰਕੜੇ।"
 
-#: src/olympia/devhub/templates/devhub/addons/listing/item_actions.html:45 src/olympia/stats/templates/stats/stats.html:75 src/olympia/stats/templates/stats/stats.html:79
-#: src/olympia/stats/templates/stats/stats.html:81
+#: src/olympia/devhub/templates/devhub/addons/listing/item_actions.html:45 src/olympia/stats/templates/stats/stats.html:31 src/olympia/stats/templates/stats/stats.html:35
+#: src/olympia/stats/templates/stats/stats.html:37
 msgid "Statistics"
 msgstr "ਅੰਕੜੇ"
 
@@ -4948,11 +4880,8 @@ msgid "Your add-on has been submitted to the Full Review queue."
 msgstr "ਤੁਹਾਡਾ ਐਡ-ਆਨ ਪੂਰਨ ਸਮੀਖਿਆ ਕਤਾਰ ਵਿੱਚ ਦਾਖਲ ਕਰ ਦਿੱਤਾ ਗਿਆ ਹੈ।"
 
 #: src/olympia/devhub/templates/devhub/addons/submit/done.html:18
-msgid ""
-"You'll receive an email once it has been reviewed by an editor. In\n"
-"          the meantime, you and your friends can install it directly from its\n"
-"          details page:"
-msgstr ""
+msgid "You'll receive an email once it has been reviewed by an editor. In the meantime, you and your friends can install it directly from its details page:"
+msgstr "ਇੱਕ ਵਾਰ ਸੰਪਾਦਕ ਵੱਲੋਂ ਇਸ ਦੀ ਸਮੀਖਿਆ ਕਰਨ ਤੇ ਤੁਹਾਨੂੰ ਇੱਕ ਈਮੇਲ ਪ੍ਰਾਪਤ ਹੋਵੇਗਾ। ਇਸ ਦੌਰਾਨ, ਤੁਸੀਂ ਅਤੇ ਤੁਹਾਡੇ ਦੌਸਤ ਇਸ ਨੂੰ ਸਿੱਧੇ ਇਸ ਦੇ ਵੇਰਵੇ ਵਾਲੇ ਸਫ਼ੇ ਤੋਂ ਇੰਸਟਾਲ ਕਰ ਸਕਦੇ ਹਨ:"
 
 #: src/olympia/devhub/templates/devhub/addons/submit/done.html:27 src/olympia/devhub/templates/devhub/addons/submit/done.html:77 src/olympia/devhub/templates/devhub/personas/submit_done.html:16
 msgid "Next steps:"
@@ -5159,11 +5088,11 @@ msgstr "ਕਦਮ 2. ਆਪਣਾ ਐਡ-ਆਨ ਅੱਪਲੋਡ ਕਰੋ"
 msgid "Use the fields below to upload your add-on package and select any platform restrictions. After upload, a series of automated validation tests will be run on your file."
 msgstr "ਆਪਣਾ ਐਡ-ਆਨ ਪੈਕੇਜ ਅੱਪਲੋਡ ਕਰਨ ਲਈ ਹੇਠ ਦਿੱਤੇ ਖੇਤਰ ਦੀ ਵਰਤੋਂ ਕਰੋ ਅਤੇ ਕੋਈ ਵੀ ਪਲੇਟਫ਼ਾਰਮ ਪਾਬੰਦੀਆਂ ਚੁਣੋ। ਅੱਪਲੋਡ ਤੋਂ ਬਾਅਦ, ਸਵੈ ਪ੍ਰਮਾਣਿਕਤਾ ਜਾਂਚਾਂ ਦੀ ਇੱਕ ਲੜੀ ਤੁਹਾਡੀ ਫ਼ਾਈਲ ਉੱਤੇ ਚਲਾਈ ਜਾਏਗੀ।"
 
-#: src/olympia/devhub/templates/devhub/addons/submit/upload.html:59 src/olympia/devhub/templates/devhub/versions/add_file_modal.html:39
+#: src/olympia/devhub/templates/devhub/addons/submit/upload.html:51 src/olympia/devhub/templates/devhub/versions/add_file_modal.html:28
 msgid "Which platforms is this file compatible with?"
 msgstr "ਇਹ ਫ਼ਾਈਲ ਕਿਸ ਪਲੇਟਫ਼ਾਰਮ ਦੇ ਨਾਲ ਅਨੁਕੂਲ ਹੈ?"
 
-#: src/olympia/devhub/templates/devhub/addons/submit/upload.html:67 src/olympia/devhub/templates/devhub/versions/add_file_modal.html:65
+#: src/olympia/devhub/templates/devhub/addons/submit/upload.html:59 src/olympia/devhub/templates/devhub/versions/add_file_modal.html:45
 msgid "Administrative overrides"
 msgstr "ਪ੍ਰਬੰਧਕੀ ਓਵਰਰਾਈਡ"
 
@@ -5279,8 +5208,8 @@ msgstr "ਵੈੱਬਸਾਈਟ ਕਾਰਜਕੁਸ਼ਲਤਾ ਅਤੇ ਵ
 
 #: src/olympia/devhub/templates/devhub/docs/policies-contact.html:44
 msgid ""
-"If you've found a problem with the site, we'd love to fix it. Please <a href=\"https://github.com/mozilla/olympia/issues\">file a bug report</a> in GitHub, including the location of the problem and "
-"how you encountered it."
+"If you've found a problem with the site, we'd love to fix it. Please <a href=\"https://github.com/mozilla/addons/issues/new\">file a bug report</a> in GitHub, including the location of the problem "
+"and how you encountered it."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/docs/policies-maintenance.html:3 src/olympia/devhub/templates/devhub/docs/policies-maintenance.html:7
@@ -5908,9 +5837,11 @@ msgstr "ਪਰਦੇਦਾਰੀ ਬਰਾਊਜ਼ਿੰਗ ਮੋਡ"
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:282
 msgid ""
-"Add-ons that store or otherwise handle browsing data must support <a href=\"https://developer.mozilla.org/En/Supporting_private_browsing_mode\">Private Browsing Mode</a>.  During a Private Browsing "
+"Add-ons that store or otherwise handle browsing data must support <a href=\"https://developer.mozilla.org/En/Supporting_private_browsing_mode\">Private Browsing Mode</a>. During a Private Browsing "
 "session, no browsing data can be written to disk, and all of this data must be cleared when Firefox quits or the Private Browsing session ends."
 msgstr ""
+"ਜਿਹੜੇ ਐਡ-ਆਨ ਬਰਾਊਜ਼ਿੰਗ ਡਾਟਾ ਸੰਭਾਲ੍ਹਦੇ ਜਾਂ ਵਰਤਦੇ ਹਨ ਨੂੰ <a href=\"https://developer.mozilla.org/En/Supporting_private_browsing_mode\">ਪਰਦੇਦਾਰੀ ਬਰਾਊਜ਼ਿੰਗ ਮੋਡ</a>ਨੂੰ ਸਹਿਯੋਗ ਕਰਨਾ ਚਾਹੀਦਾ। ਪਰਦੇਦਾਰੀ ਬਰਾਊਜ਼ਿੰਗ ਸ਼ੈਸਨ ਦੇ ਦੌਰਾਨ, ਕੋਈ "
+"ਵੀ ਬਰਾਊਜ਼ਿੰਗ ਡਾਟਾ ਡਿਸਕ ਉੱਤੇ ਲਿਖਿਆ ਨਹੀਂ ਜਾ ਸਕਦਾ ਅਤੇ ਇਹ ਸਾਰਾ ਡਾਟਾ ਮਿਟ ਜਾਣਾ ਚਾਹੀਦਾ ਜਦੋਂ ਫ਼ਾਇਰਫ਼ਾਕਸ ਬੰਦ ਜਾਂ ਪਰਦੇਦਾਰੀ ਬਰਾਊਜ਼ਿੰਗ ਸ਼ੈਸਨ ਖਤਮ ਹੋਵੇ।"
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:287
 msgid "Binary Components & Obfuscated Code"
@@ -6109,129 +6040,95 @@ msgstr "ਸਾਡੀ ਸਾਈਟ ਲਈ ਆਪਣੇ ਕੰਮ ਨੂੰ ਭੇ
 msgid "How to get in touch with us regarding these policies or your add-on."
 msgstr "ਇਹਨਾਂ ਨੀਤੀਆਂ ਜਾਂ ਆਪਣੇ ਐਡ-ਆਨ ਦੇ ਸੰਬੰਧ ਵਿੱਚ ਸਾਡੇ ਨਾਲ ਸਪੰਰਕ ਵਿੱਚ ਕਿਵੇਂ ਰਹਿਆ ਜਾਵੇ।"
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:6
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:10
 msgid "You have disabled this add-on"
 msgstr "ਤੁਸੀਂ ਇਸ ਐਡ-ਆਨ ਨੂੰ ਅਯੋਗ ਕੀਤਾ"
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:20
-msgid ""
-"Your add-on's listing is disabled and is not showing\n"
-"                             anywhere in our gallery or update service."
-msgstr ""
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:24
+msgid "Your add-on's listing is disabled and is not showing anywhere in our gallery or update service."
+msgstr "ਤੁਹਾਡੀ ਐਡ-ਆਨ ਸੂਚੀ ਅਯੋਗ ਹੈ ਅਤੇ ਸਾਡੀ ਗੈਲਰੀ ਜਾਂ ਅੱਪਡੇਟ ਸੇਵਾ ਵਿੱਚ ਕਿਤੇ ਵੀ ਵਿਖਾਈ ਨਹੀਂ ਦਿੰਦੀ।"
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:25
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:27
 msgid "Please complete your add-on."
 msgstr "ਕਿਰਪਾ ਕਰਕੇ ਆਪਣਾ ਐਡ-ਆਨ ਮੁਕੰਮਲ ਕਰੋ।"
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:29
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:30
 msgid "You will receive an email when the review is complete."
 msgstr "ਜਦੋਂ ਸਮੀਖਿਆ ਮੁਕੰਮਲ ਹੋ ਜਾਵੇਗੀ ਤੁਹਾਨੂੰ ਇੱਕ ਈਮੇਲ ਪ੍ਰਾਪਤ ਹੋਵੇਗੀ।"
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:34
-msgid ""
-"You will receive an email when the review is complete. Until\n"
-"                             then, your add-on is not listed in our gallery but can be\n"
-"                             accessed directly from its details page."
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:33
+msgid "You will receive an email when the review is complete. Until then, your add-on is not listed in our gallery but can be accessed directly from its details page."
+msgstr "ਤੁਹਾਨੂੰ ਇੱਕ ਈਮੇਲ ਪ੍ਰਾਪਤ ਹੋਵੇਗਾ ਜਦੋਂ ਸਮੀਖਿਆ ਮੁਕੰਮਲ ਹੋ ਜਾਵੇਗੀ। ਤਦ ਤੱਕ, ਤੁਹਾਡਾ ਐਡ-ਆਨ ਗੈਲਰੀ ਵਿੱਚ ਸੂਚੀਬੱਧ ਨਹੀਂ ਹੋਵੇਗਾ ਪਰ ਇਸ ਦੇ ਵੇਰਵੇ ਸਫ਼ੇ ਤੋਂ ਸਿੱਧੇ ਤੌਰ ਤੇ ਪਹੁੰਚਿਆ ਜਾ ਸਕਦਾ ਹੈ।"
+
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:37 src/olympia/devhub/templates/devhub/includes/addon_details.html:45
+msgid "You will receive an email when the review is complete and your add-on is signed."
+msgstr "ਤੁਹਾਨੂੰ ਇੱਕ ਈਮੇਲ ਪ੍ਰਾਪਤ ਹੋਵੇਗੀ ਜਦੋਂ ਸਮੀਖਿਆ ਮੁਕੰਮਲ ਹੋਈ ਅਤੇ ਤੁਹਾਡਾ ਐਡ-ਆਨ ਹਸਤਾਖਰਿਤ ਹੋਇਆ।"
+
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:41
+msgid "You will receive an email when the review is complete. Until then, your add-on is not listed in our gallery but can be accessed directly from its details page. "
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:38 src/olympia/devhub/templates/devhub/includes/addon_details.html:48
-msgid ""
-"You will receive an email when the review is\n"
-"                             complete and your add-on is signed."
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:49
+msgid "Your add-on is displayed in our gallery and users are receiving automatic updates."
+msgstr "ਤੁਹਾਡਾ ਐਡ-ਆਨ ਸਾਡੀ ਗੈਲਰੀ ਵਿੱਚ ਪੇਸ਼ ਕੀਤਾ ਗਿਆ ਅਤੇ ਉਪਭੋਗੀ ਆਪਣੇ ਆਪ ਹੀ ਅੱਪਡੇਟਾਂ ਪ੍ਰਾਪਤ ਕਰ ਰਹੇ ਹਨ।"
+
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:52
+msgid "Your add-on has been signed and can be bundled with an application installer."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:44
-msgid ""
-"You will receive an email when the review is complete. Until\n"
-"                             then, your add-on is not listed in our gallery but can be\n"
-"                             accessed directly from its details page. "
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:56
+msgid "Your add-on was disabled by a site administrator and is no longer shown in our gallery. If you have any questions, please email amo-admins@mozilla.org."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:54
-msgid ""
-"Your add-on is displayed in our gallery and users are\n"
-"                             receiving automatic updates."
-msgstr ""
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:62
+msgid "Your add-on is displayed in our gallery as experimental and users are receiving automatic updates. Some features are unavailable to your add-on."
+msgstr "ਤੁਹਾਡਾ ਐਡ-ਆਨ ਸਾਡੀ ਗੈਲਰੀ ਵਿੱਚ ਪ੍ਰਯੋਗਆਤਮਕ ਤੌਰ ਤੇ ਪੇਸ਼ ਕੀਤਾ ਗਿਆ ਅਤੇ ਉਪਭੋਗੀ ਆਪਣੇ ਆਪ ਹੀ ਅੱਪਡੇਟਾਂ ਪ੍ਰਾਪਤ ਕਰ ਰਹੇ ਹਨ। ਕੁੱਝ ਵਿਸ਼ੇਸਤਾਵਾਂ ਤੁਹਾਡੇ ਐਡ-ਆਨ ਲਈ ਉੱਪਲਬਧ ਨਹੀਂ ਹਨ।"
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:57
-msgid ""
-"Your add-on has been signed and can be bundled with an\n"
-"                             application installer."
-msgstr ""
-
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:63
-msgid ""
-"Your add-on was disabled by a site administrator and is no\n"
-"                             longer shown in our gallery. If you have any questions,\n"
-"                             please email amo-admins@mozilla.org."
-msgstr ""
-
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:70
-msgid ""
-"Your add-on is displayed in our gallery as experimental\n"
-"                             and users are receiving automatic updates. Some features\n"
-"                             are unavailable to your add-on."
-msgstr ""
-
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:74
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:66
 msgid "Your add-on has been signed."
 msgstr "ਤੁਹਾਡਾ ਐਡ-ਆਨ ਹਸਤਾਖਰਿਤ ਕੀਤਾ ਗਿਆ।"
 
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:69
+msgid ""
+"You will receive an email when the full review is complete. Until then, your add-on is displayed in our gallery as experimental and users are receiving automatic updates. Some features are "
+"unavailable to your add-on."
+msgstr "ਤੁਹਾਨੂੰ ਇੱਕ ਈਮੇਲ ਪ੍ਰਾਪਤ ਹੋਵੇਗਾ ਜਦੋਂ ਮੁਕੰਮਲ ਸਮੀਖਿਆ ਪੂਰੀ ਹੋ ਜਾਵੇਗੀ। ਤਦ ਤੱਕ, ਤੁਹਾਡਾ ਐਡ-ਆਨ ਸਾਡੀ ਗੈਲਰੀ ਵਿੱਚ ਪ੍ਰਯੋਗਆਤਮਕ ਤੌਰ ਤੇ ਪੇਸ਼ ਕੀਤਾ ਜਾਵੇਗਾ ਅਤੇ ਉਪਭੋਗੀ ਆਪਣੇ ਆਪ ਅੱਪਡੇਟਾਂ ਪ੍ਰਾਪਤ ਕਰ ਰਹੇ ਹਨ। ਕੁੱਝ ਵਿਸ਼ੇਸਤਾਵਾਂ  ਤੁਹਾਡੇ ਐਡ-ਆਨ ਲਈ ਉੱਪਲਬਧ ਨਹੀਂ ਹਨ।"
+
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:74
+msgid "You will receive an email when the full review is complete, making you able to bundle your add-on with an application installer."
+msgstr ""
+
 #: src/olympia/devhub/templates/devhub/includes/addon_details.html:79
-msgid ""
-"You will receive an email when the full review is complete.\n"
-"                             Until then, your add-on is displayed in our gallery as\n"
-"                             experimental and users are receiving automatic updates.\n"
-"                             Some features are unavailable to your add-on."
-msgstr ""
+msgid "All add-ons hosted in our gallery must now be reviewed by an editor. If you wish to continue hosting your add-on, please click to select a review process."
+msgstr "ਸਾਡੀ ਗੈਲਰੀ ਵਿੱਚ ਮੇਜ਼ਬਾਨ ਸਾਰੇ ਐਡ-ਆਨਾਂ ਦੀ ਹੁਣੇ ਇੱਕ ਸੰਪਾਦਕ ਵੱਲੋਂ ਸਮੀਖਿਆ ਹੋਣੀ ਚਾਹੀਦੀ ਹੈ। ਜੇਕਰ ਤੁਸੀਂ ਆਪਣੇ ਐਡ-ਆਨ ਦੀ ਮੇਜ਼ਬਾਨੀ ਜਾਰੀ ਰੱਖਣਾ ਚਾਹੁੰਦੇ ਹੋ, ਕਿਰਪਾ ਕਰਕੇ ਇੱਕ ਸਮੀਖਿਆ ਕਾਰਜ ਚੁਣਨ ਲਈ ਕਲਿੱਕ ਕਰੋ।"
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:84
-msgid ""
-"You will receive an email when the full review is\n"
-"                             complete, making you able to bundle your add-on with an\n"
-"                             application installer."
-msgstr ""
-
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:91
-msgid ""
-"All add-ons hosted in our gallery must now be reviewed by an\n"
-"                             editor. If you wish to continue hosting your add-on, please\n"
-"                             click to select a review process."
-msgstr ""
-
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:113
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:100
 msgid "Current Version:"
 msgstr "ਮੌਜੂਦਾ ਵਰਜਨ:"
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:115
-msgid ""
-"This is the version of your add-on that will\n"
-"                                           be installed if someone clicks the Install\n"
-"                                           button on addons.mozilla.org. It is only\n"
-"                                           relevant for listed add-ons."
-msgstr ""
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:102
+msgid "This is the version of your add-on that will be installed if someone clicks the Install button on addons.mozilla.org. It is only relevant for listed add-ons."
+msgstr "ਤੁਹਾਡੇ ਐਡ-ਆਨ ਦਾ ਇਹ ਵਰਜਨ ਇੰਸਟਾਲ ਕੀਤਾ ਜਾਵੇਗਾ ਜੇਕਰ ਕੋਈ addons.mozilla.org ਤੇ ਇੰਸਟਾਲ ਬਟਨ ਤੇ ਕਲਿੱਕ ਕਰਦਾ। ਇਹ ਕੇਵਲ ਸੂਚੀਬੱਧ ਐਡ-ਆਨਾਂ ਲਈ ਢੁੱਕਵਾਂ ਹੈ।"
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:123
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:110
 msgid "Created:"
 msgstr "ਰਚਿਆ:"
 
 #. {0} is a date. dennis-ignore: E201
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:125 src/olympia/devhub/templates/devhub/includes/addon_details.html:131
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:112 src/olympia/devhub/templates/devhub/includes/addon_details.html:118
 #, python-format
 msgid "%%b %%e, %%Y"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:136
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:123
 msgid "Next Version:"
 msgstr "ਅਗਲਾ ਵਰਜਨ:"
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:138
-msgid ""
-"This is the newest uploaded version, however\n"
-"                                           it isn’t live on the site yet."
-msgstr ""
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:125
+msgid "This is the newest uploaded version, however it isn’t live on the site yet."
+msgstr "ਇਹ ਬਿਲਕੁਲ ਨਵਾਂ ਅੱਪਲੋਡਿਡ ਵਰਜਨ ਹੈ, ਹਾਲਾਂਕਿ ਇਹ ਹਾਲੇ ਤੱਕ ਇਸ ਸਾਈਟ ਤੇ ਠਹਿਰਾਓ ਨਹੀਂ।"
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:144 src/olympia/devhub/templates/devhub/versions/list.html:30
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:130 src/olympia/devhub/templates/devhub/versions/list.html:30
 msgid "Queues are not reviewed strictly in order"
 msgstr "ਕਤਾਰਾਂ ਦੀ ਕਸਵੇਂ ਤੌਰ ਤੇ ਸਮੀਖਿਆ ਨਹੀਂ ਹੁੰਦੀ"
 
@@ -6300,10 +6197,8 @@ msgid "View the blog &#9658;"
 msgstr "ਬਲੌਗ ਵੇਖੋ &#9658;"
 
 #: src/olympia/devhub/templates/devhub/includes/license_form.html:6
-msgid ""
-"Please choose a license appropriate for the rights you grant on your source code.\n"
-"                  It is only relevant for listed add-ons."
-msgstr ""
+msgid "Please choose a license appropriate for the rights you grant on your source code. It is only relevant for listed add-ons."
+msgstr "ਤੁਹਾਡੇ ਵੱਲੋਂ ਆਪਣੇ ਸੋਰਸ ਕੋਡ ਨੂੰ ਦਿੱਤੇ ਅਧਿਕਾਰਾਂ ਦੇ ਅਨੁਕੂਲ ਕਿਰਪਾ ਕਰਕੇ ਇੱਕ ਲਾਇਸੰਸ ਚੁਣੋ। ਇਹ ਕੇਵਲ ਸੂਚੀਬੱਧ ਐਡ-ਆਨਾਂ ਲਈ ਢੁੱਕਵਾਂ ਹੈ।"
 
 #. {0} is a list of HTML tags.
 #: src/olympia/devhub/templates/devhub/includes/macros.html:7
@@ -6329,15 +6224,12 @@ msgstr[1] "ਇਸ ਐਡ-ਆਨ ਲਈ <b>{0} ਤੱਕ</b> {1} ਸੰਗ੍ਰ�
 #: src/olympia/devhub/templates/devhub/includes/policy_form.html:4
 msgid ""
 "Users will be required to accept the following End-User License Agreement (EULA) prior to installing your add-on. The presence of a EULA significantly affects the number of downloads an add-on "
-"receives. Please note that a EULA is not the same as a code license, such as the GPL or MPL.\n"
-"                It is only relevant for listed add-ons."
+"receives. Please note that a EULA is not the same as a code license, such as the GPL or MPL.It is only relevant for listed add-ons."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/policy_form.html:21
-msgid ""
-"If your add-on transmits any data from the user's computer, a privacy policy is required that explains what data is sent and how it is used.\n"
-"                It is only relevant for listed add-ons."
-msgstr ""
+#: src/olympia/devhub/templates/devhub/includes/policy_form.html:24
+msgid "If your add-on transmits any data from the user's computer, a privacy policy is required that explains what data is sent and how it is used. It is only relevant for listed add-ons."
+msgstr "ਜੇਕਰ ਤੁਹਾਡਾ ਐਡ-ਆਨ ਵਰਤੋਂਕਾਰ ਦੇ ਕੰਪਿਊਟਰ ਤੋਂ ਕੋਈ ਡਾਟਾ ਭੇਜਦਾ, ਇੱਕ ਪਰਦੇਦਾਰੀ ਨੀਤੀ ਦੀ ਲੋੜ ਹੈ ਜੋ ਦੱਸੇ ਕਿ ਕਿਹੜਾ ਡਾਟਾ ਭੇਜਿਆ ਅਤੇ ਇਹ ਕਿਵੇਂ ਵਰਤਿਆ ਜਾਏਗਾ। ਇਹ ਕੇਵਲ ਸੂਚੀਬੱਧ ਐਡ-ਆਨਾਂ ਲਈ ਢੁੱਕਵਾਂ ਹੈ।"
 
 #: src/olympia/devhub/templates/devhub/includes/source_form_field.html:2
 msgid "If your add-on contains binary or obfuscated code other than known libraries, upload its sources for review."
@@ -6504,13 +6396,9 @@ msgstr "ਸੰਗ੍ਰਹਿ ਚੁਣੋ ਜੋ ਤੁਹਾਡੇ ਥੀਮ �
 msgid "Add some tags to describe your Theme."
 msgstr "ਆਪਣੇ ਥੀਮ ਦੇ ਵੇਰਵੇ ਲਈ ਕੁੱਝ ਟੈਗ ਸ਼ਾਮਲ ਕਰੋ।"
 
-#: src/olympia/devhub/templates/devhub/personas/edit.html:106
-msgid ""
-"A short explanation of your theme's\n"
-"                                basic functionality that is displayed in\n"
-"                                search and browse listings, as well as at\n"
-"                                the top of your theme's details page."
-msgstr ""
+#: src/olympia/devhub/templates/devhub/personas/edit.html:106 src/olympia/devhub/templates/devhub/personas/submit.html:54
+msgid "A short explanation of your theme's basic functionality that is displayed in search and browse listings, as well as at the top of your theme's details page."
+msgstr "ਤੁਹਾਡੇ ਥੀਮ ਦੀ ਬੁਨਿਆਦੀ ਕਾਰਜਕੁਸ਼ਲਤਾ ਦੀ ਛੋਟੀ ਵਿਆਖਿਆ ਜੋ ਖੋਜ ਅਤੇ ਸੂਚੀ ਝਲਕ, ਨਾਲ ਹੀ ਨਾਲ ਤੁਹਾਡੇ ਥੀਮ ਦੇ ਵੇਰਵੇ ਸਫ਼ੇ ਦੇ ਉੱਪਰ ਵਿਖਾਈ ਜਾਏਗੀ।"
 
 #: src/olympia/devhub/templates/devhub/personas/edit.html:122 src/olympia/devhub/templates/devhub/personas/submit.html:68
 msgid "Theme License"
@@ -6579,8 +6467,8 @@ msgid "Upon upload and form submission, the AMO Team will review your updated de
 msgstr "ਅੱਪਲੋਡ ਅਤੇ ਫ਼ਾਰਮ ਦਾਖਲ ਕਰਨ ਤੋਂ ਬਾਅਦ, AMO ਟੀਮ ਤੁਹਾਡੇ ਅੱਪਡੇਟ ਕੀਤੇ ਡਿਜਾਇਨ ਦੀ ਸਮੀਖਿਆ ਕਰੇਗੀ। ਇਸ ਦੌਰਾਨ ਤੁਹਾਡਾ ਮੌਜੂਦਾ ਡਿਜਾਇਨ ਅਜੇ ਵੀ ਜਨਤਕ ਰਹੇਗਾ।"
 
 #: src/olympia/devhub/templates/devhub/personas/edit.html:241
-msgid "Your previously resubmitted design,  which is under pending review."
-msgstr ""
+msgid "Your previously resubmitted design, which is under pending review."
+msgstr "ਤੁਹਾਡਾ ਪਿਛਲਾ ਮੁੜ-ਦਾਖਲ ਹੋਇਆ ਡਿਜਾਇਨ, ਜਿਹੜਾ ਅਧੂਰੀ ਸਮੀਖਿਆ ਦੇ ਅਧੀਨ ਹੈ।"
 
 #: src/olympia/devhub/templates/devhub/personas/edit.html:245
 msgid "Pending Header"
@@ -6647,14 +6535,6 @@ msgstr "ਬੈਕਗਰਾਂਊਡ ਥੀਮ ਤੁਹਾਨੂੰ ਤੁਹਾ
 #: src/olympia/devhub/templates/devhub/personas/submit.html:33
 msgid "Give your Theme a name."
 msgstr "ਆਪਣੇ ਥੀਮ ਨੂੰ ਇੱਕ ਨਾਂ ਦਿਓ।"
-
-#: src/olympia/devhub/templates/devhub/personas/submit.html:54
-msgid ""
-"A short explanation of your theme's\n"
-"                                      basic functionality that is displayed in\n"
-"                                      search and browse listings, as well as at\n"
-"                                      the top of your theme's details page."
-msgstr ""
 
 #: src/olympia/devhub/templates/devhub/personas/submit.html:198
 #, python-format
@@ -6732,31 +6612,17 @@ msgstr "ਇੱਕ ਵੱਖ ਪਦਲੇਖ ਤਸਵੀਰ"
 msgid "Files added to reviewed versions must be reviewed before they will be available for download."
 msgstr "ਸਮੀਖਿਅਕ ਵਰਜਨਾਂ ਵਿੱਚ ਸ਼ਾਮਲ ਫ਼ਾਈਲਾਂ ਦੀ ਸਮੀਖਿਆ ਹੋ ਜਾਣੀ ਚਾਹੀਦੀ ਹੈ ਇਸ ਤੋਂ ਪਹਿਲਾਂ ਕੀ ਉਹ ਡਾਊਨਲੋਡ ਲਈ ਉੱਪਲਬਧ ਹੋਣ।"
 
-#: src/olympia/devhub/templates/devhub/versions/add_file_modal.html:15
-#, python-format
-msgid ""
-"Submission of updates to unlisted add-ons for signing is currently in an open beta. Manual review may still be required for a large number of add-ons. Please <a href=\"%(url)s\" target=\"_blank"
-"\">report any bugs</a> that you encounter."
-msgstr ""
-
-#: src/olympia/devhub/templates/devhub/versions/add_file_modal.html:35
+#: src/olympia/devhub/templates/devhub/versions/add_file_modal.html:24
 msgid "Select the target platform for this file."
 msgstr "ਇਸ ਸਾਈਟ ਲਈ ਤੈਅ ਪਲੇਟਫ਼ਾਰਮ ਚੁਣੋ।"
 
-#: src/olympia/devhub/templates/devhub/versions/add_file_modal.html:46
+#: src/olympia/devhub/templates/devhub/versions/add_file_modal.html:35
 msgid "Which review type would you like to nominate for?"
 msgstr "ਤੁਸੀਂ ਕਿਸ ਢੰਗ ਦੀ ਸਮੀਖਿਆ ਲਈ ਨੁਮਾਇੰਦਗੀ ਲੈਣਾ ਚਾਹੋਗੇ?"
 
-#: src/olympia/devhub/templates/devhub/versions/add_file_modal.html:51
+#: src/olympia/devhub/templates/devhub/versions/add_file_modal.html:40
 msgid "Only publish this version to my beta channel."
 msgstr "ਕੇਵਲ ਇਸ ਵਰਜਨ ਨੂੰ ਮੇਰੇ ਬੀਟਾ ਚੈਨਲ ਵਿੱਚ ਜਾਰੀ ਕਰੋ।"
-
-#: src/olympia/devhub/templates/devhub/versions/add_file_modal.html:54
-#, python-format
-msgid ""
-"The behavior of the beta channel has changed to accommodate <a href=\"%(addon_signing_url)s\" target=\"_blank\">mandatory add-on signing</a>. The new process is currently in an open beta, and may "
-"change significantly in the near future. Please <a href=\"%(issues_url)s\" target=\"_blank\">report any bugs</a> that you encounter."
-msgstr ""
 
 #: src/olympia/devhub/templates/devhub/versions/edit.html:5
 msgid "Manage Version {0}"
@@ -6779,20 +6645,11 @@ msgstr "ਫ਼ਾਈਲਾਂ"
 msgid "Upload Another File"
 msgstr "ਹੋਰ ਫ਼ਾਈਲ ਅੱਪਲੋਡ ਕਰੋ"
 
-#: src/olympia/devhub/templates/devhub/versions/edit.html:45
-msgid ""
-"Adjusting application information here will allow users to install your\n"
-"                          add-on even if the install manifest in the package indicates that the\n"
-"                          add-on is incompatible."
-msgstr ""
-
 #: src/olympia/devhub/templates/devhub/versions/edit.html:74
 msgid ""
-"Information about changes in this release, new features,\n"
-"                              known bugs, and other useful information specific to this\n"
-"                              release/version. This information is also shown in the\n"
-"                              Add-ons Manager when updating."
-msgstr ""
+"Information about changes in this release, new features, known bugs, and other useful information specific to this release/version. This information is also shown in the Add-ons Manager when "
+"updating."
+msgstr "ਇਸ ਰੀਲੀਜ਼ ਵਿੱਚ ਬਦਲਾਵਾਂ ਬਾਰੇ ਜਾਣਕਾਰੀ, ਨਵੇਂ ਗੁਣ, ਜਾਣੂ ਬੱਗ, ਅਤੇ ਇਸ ਰੀਲੀਜ਼/ਵਰਜਨ ਦੇ ਮੁਤਾਬਿਕ ਹੋਰ ਖਾਸ ਲਾਭਕਾਰੀ ਜਾਣਕਾਰੀ। ਅੱਪਡੇਟ ਸਮੇਂ ਇਹ ਜਾਣਕਾਰੀ ਐਡ-ਆਨ ਮੈਨੇਜਰ ਵਿੱਚ ਵੀ ਵਿਖਾਈ ਜਾਵੇਗੀ।"
 
 #: src/olympia/devhub/templates/devhub/versions/edit.html:99
 msgid "Approval Status"
@@ -6803,11 +6660,8 @@ msgid "Notes for Reviewers"
 msgstr "ਸਮੀਖਿਅਕਾਂ ਲਈ ਨੋਟ"
 
 #: src/olympia/devhub/templates/devhub/versions/edit.html:114
-msgid ""
-"Optionally, enter any information that may be useful\n"
-"                              to the Editor reviewing this add-on, such as test\n"
-"                              account information."
-msgstr ""
+msgid "Optionally, enter any information that may be useful to the Editor reviewing this add-on, such as test account information."
+msgstr "ਵਿਕਲਪਕ ਤੌਰ ਤੇ, ਕੋਈ ਵੀ ਜਾਣਕਾਰੀ ਦਾਖਲ ਕਰੋ ਜੋ ਇਸ ਐਡ-ਆਨ ਦੀ ਸਮੀਖਿਆ ਕਰਦੇ ਸਮੇਂ ਸੰਪਾਦਕ ਲਈ ਲਾਭਕਾਰੀ ਹੋ ਸਕਦੀ ਹੈ, ਜਿਵੇਂ ਕਿ ਜਾਂਚ ਖਾਤਾ ਜਾਣਕਾਰੀ।"
 
 #: src/olympia/devhub/templates/devhub/versions/edit.html:127
 msgid "Source code"
@@ -6884,7 +6738,7 @@ msgstr "ਪੂਰੀ ਸਮੀਖਿਆ ਦੀ ਬੇਨਤੀ ਕਰੋ"
 msgid "Request Preliminary Review"
 msgstr "ਸ਼ੁਰੂਆਤੀ ਸਮੀਖਿਆ ਦੀ ਬੇਨਤੀ ਕਰੋ"
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:80 src/olympia/devhub/templates/devhub/versions/list.html:327 src/olympia/devhub/templates/devhub/versions/list.html:350
+#: src/olympia/devhub/templates/devhub/versions/list.html:80 src/olympia/devhub/templates/devhub/versions/list.html:325 src/olympia/devhub/templates/devhub/versions/list.html:348
 msgid "Cancel Review Request"
 msgstr "ਸਮੀਖਿਆ ਬੇਨਤੀ ਰੱਦ ਕਰੋ"
 
@@ -6913,8 +6767,8 @@ msgid "Unlisted:"
 msgstr "ਗੈਰ-ਸੂਚੀਬੱਧ:"
 
 #: src/olympia/devhub/templates/devhub/versions/list.html:114
-msgid "Not distributed on {0}. Developers will upload new versions for signing and distribute the add-ons on their own. (beta)"
-msgstr "{0} ਤੇ ਵੰਡਿਆ ਨਹੀਂ ਗਿਆ। ਡਿਵੈਲਪਰ ਸਾਈਨਿੰਗ ਲਈ ਨਵੇਂ ਵਰਜਨ ਅੱਪਲੋਡ ਕਰਨਗੇ ਅਤੇ ਨਿੱਜੀ ਤੌਰ ਤੇ ਐਡ-ਆਨ ਵੰਡਣਗੇ। (ਬੀਟਾ)"
+msgid "Not distributed on {0}. Developers will upload new versions for signing and distribute the add-ons on their own."
+msgstr ""
 
 #: src/olympia/devhub/templates/devhub/versions/list.html:122
 msgid "Current versions"
@@ -6976,81 +6830,73 @@ msgid "<strong>Important:</strong> Once a version has been deleted, you may not 
 msgstr "<strong>ਜ਼ਰੂਰੀ:</strong> ਜੇਕਰ ਇੱਕ ਵਾਰ ਵਰਜਨ ਹਟਾ ਲਿਆ ਗਿਆ, ਹੋ ਸਕਦਾ ਤੁਸੀਂ ਉਸੇ ਵਰਜਨ ਨੰਬਰ ਨਾਲ ਨਵਾਂ ਵਰਜਨ ਅੱਪਲੋਡ ਨਹੀਂ ਕਰ ਪਾਓ।"
 
 #: src/olympia/devhub/templates/devhub/versions/list.html:230
-msgid ""
-"Deleting a version which has already been reviewed\n"
-"               may also cause a significant delay in the review of\n"
-"               your next update."
-msgstr ""
-
-#: src/olympia/devhub/templates/devhub/versions/list.html:233
 msgid "Are you sure you wish to delete this version?"
 msgstr "ਕੀ ਤੁਸੀਂ ਇਸ ਵਰਜਨ ਨੂੰ ਹਟਾਉਣ ਦੀ ਪੁਸ਼ਟੀ ਕਰਦੇ ਹੋ?"
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:238
+#: src/olympia/devhub/templates/devhub/versions/list.html:235
 msgid "Delete Version"
 msgstr "ਵਰਜਨ ਹਟਾਓ"
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:240
+#: src/olympia/devhub/templates/devhub/versions/list.html:237
 msgid "Disable Version"
 msgstr "ਵਰਜਨ ਅਯੋਗ ਕਰੋ"
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:247
+#: src/olympia/devhub/templates/devhub/versions/list.html:244
 msgid "Add a new Version"
 msgstr "ਨਵਾਂ ਵਰਜਨ ਸ਼ਾਮਲ ਕਰੋ"
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:249
+#: src/olympia/devhub/templates/devhub/versions/list.html:246
 msgid "Add Version"
 msgstr "ਵਰਜਨ ਸ਼ਾਮਲ ਕਰੋ"
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:256 src/olympia/devhub/templates/devhub/versions/list.html:274
+#: src/olympia/devhub/templates/devhub/versions/list.html:253 src/olympia/devhub/templates/devhub/versions/list.html:279
 msgid "Hide Add-on"
 msgstr "ਐਡ-ਆਨ ਲੁਕਾਓ"
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:259
+#: src/olympia/devhub/templates/devhub/versions/list.html:256
 msgid "Hiding your add-on will prevent it from appearing anywhere in our gallery and will stop users from receiving automatic updates."
 msgstr "ਆਪਣੇ ਐਡ-ਆਨ ਨੂੰ ਲੁਕਾਉਣਾ ਇਸ ਨੂੰ ਗੈਲਰੀ ਵਿੱਚ ਵਿਖਾਈ ਦੇਣ ਤੋਂ ਰੋਕੇਗਾ ਅਤੇ ਵਰਤੋਂਕਾਰਾਂ ਨੂੰ ਆਪਣੇ ਆਪ ਅੱਪਡੇਟਾਂ ਦੇਣਾ ਬੰਦ ਕਰ ਦੇਵੇਗਾ।"
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:265
+#: src/olympia/devhub/templates/devhub/versions/list.html:263
+msgid "The files awaiting review will be disabled and you will need to upload new versions."
+msgstr ""
+
+#: src/olympia/devhub/templates/devhub/versions/list.html:270
 msgid "Are you sure you wish to hide your add-on?"
 msgstr "ਪੁਸ਼ਟੀ ਕਰੋ ਕੀ ਆਪਣੇ ਐਡ-ਆਨ ਨੂੰ ਲੁਕਾਉਣਾ ਚਾਹੁੰਦੇ ਹੋ?"
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:286 src/olympia/devhub/templates/devhub/versions/list.html:315
+#: src/olympia/devhub/templates/devhub/versions/list.html:291 src/olympia/devhub/templates/devhub/versions/list.html:313
 msgid "Unlist Add-on"
 msgstr "ਐਡ-ਆਨ ਸੂਚੀ ਤੋਂ ਹਟਾਓ"
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:289
+#: src/olympia/devhub/templates/devhub/versions/list.html:294
 #, python-format
 msgid ""
 "Unlisting your add-on will make it (and each of its versions/files) invisible on this website. It won't show up in searches, won't have a public facing page, and won't be updated automatically for "
-"current users.  It is recommended for unlisted add-ons to provide a custom <a href=\"%(update_url)s\" target=\"_blank\">updateURL</a> in their manifest file for automatic updates."
+"current users. It is recommended for unlisted add-ons to provide a custom <a href=\"%(update_url)s\" target=\"_blank\">updateURL</a> in their manifest file for automatic updates."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:299
-#, python-format
-msgid "Switching add-ons to unlisted is currently in an open beta. Please <a href=\"%(url)s\" target=\"_blank\">report any bugs</a> that you encounter."
-msgstr ""
-
-#: src/olympia/devhub/templates/devhub/versions/list.html:305
+#: src/olympia/devhub/templates/devhub/versions/list.html:303
 msgid "Unlisting an add-on is irreversible!"
 msgstr "ਐਡ-ਆਨ ਨੂੰ ਗੈਰ-ਸੂਚੀਬੱਧ ਕਰਨਾ ਅਟੱਲ ਹੈ!"
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:305
+#: src/olympia/devhub/templates/devhub/versions/list.html:303
 msgid "An unlisted add-on cannot be switched to be listed."
 msgstr "ਗੈਰ-ਸੂਚੀਬੱਧ ਐਡ-ਆਨ ਨੂੰ ਸੂਚੀਬੱਧ ਕਰਨ ਲਈ ਸਵਿੱਚ ਨਹੀਂ ਕੀਤਾ ਜਾ ਸਕਦਾ।"
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:307
+#: src/olympia/devhub/templates/devhub/versions/list.html:305
 msgid "Are you sure you wish to unlist your add-on?"
 msgstr "ਕੀ ਤੁਸੀਂ ਆਪਣੇ ਐਡ-ਆਨ ਨੂੰ ਸੂਚੀ ਤੋਂ ਹਟਾਉਣ ਦੀ ਪੁਸ਼ਟੀ ਕਰਦੇ ਹੋ?"
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:330
+#: src/olympia/devhub/templates/devhub/versions/list.html:328
 msgid "Canceling your review request will leave your add-on as preliminarily reviewed."
 msgstr "ਆਪਣੀ ਸਮੀਖਿਆ ਬੇਨਤੀ ਰੱਦ ਕਰਨਾ ਤੁਹਾਡੇ ਐਡ-ਆਨ ਨੂੰ ਸ਼ਰੂਆਤੀ ਸਮੀਖਿਆ ਦੇ ਤੌਰ ਤੇ ਛੱਡ ਦੇਵੇਗਾ।"
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:335
+#: src/olympia/devhub/templates/devhub/versions/list.html:333
 msgid "Canceling your review request will mark your add-on incomplete. If you do not complete your add-on after several days by re-requesting review, it will be deleted."
 msgstr "ਆਪਣੀ ਸਮੀਖਿਆ ਬੇਨਤੀ ਨੂੰ ਰੱਦ ਕਰਨਾ ਤੁਹਾਡੇ ਐਡ-ਆਨ ਤੇ ਅਧੂਰੇ ਦਾ ਨਿਸ਼ਾਨ ਲਗਾ ਦੇਵੇਗਾ। ਜੇਕਰ ਤੁਸੀਂ ਮੁੜ-ਬੇਨਤੀ ਸਮੀਖਿਆ ਦੁਆਰਾ ਕੁੱਝ ਦਿਨਾਂ ਬਾਅਦ ਵੀ ਆਪਣਾ ਐਡ-ਆਨ ਮੁਕੰਮਲ ਨਹੀਂ ਕੀਤਾ, ਇਹ ਹਟਾ ਦਿੱਤਾ ਜਾਵੇਗਾ।"
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:343
+#: src/olympia/devhub/templates/devhub/versions/list.html:341
 msgid "Are you sure you wish to cancel your review request?"
 msgstr "ਕੀ ਤੁਸੀਂ ਆਪਣੀ ਸਮੀਖਿਆ ਬੇਨਤੀ ਨੂੰ ਰੱਦ ਕਰਨ ਦੀ ਪੁਸ਼ਟੀ ਕਰਦੇ ਹੋ?"
 
@@ -7389,19 +7235,19 @@ msgstr "ਐਡ-ਆਨ, ਸੰਪਾਦਕ ਜਾਂ ਟਿੱਪਣੀ"
 msgid "Search by add-on name / author email"
 msgstr "ਐਡ-ਆਨ ਨਾਂ/ ਲੇਖਕ ਈਮੇਲ ਦੁਅਾਰਾ ਖੋਜ ਕਰੋ"
 
-#: src/olympia/editors/forms.py:103
+#: src/olympia/editors/forms.py:103 src/olympia/editors/forms.py:244 src/olympia/editors/forms.py:257
 msgid "yes"
 msgstr "ਹਾਂ"
 
-#: src/olympia/editors/forms.py:104
+#: src/olympia/editors/forms.py:104 src/olympia/editors/forms.py:244 src/olympia/editors/forms.py:257
 msgid "no"
 msgstr "ਨਹੀਂ"
 
-#: src/olympia/editors/forms.py:105
+#: src/olympia/editors/forms.py:105 src/olympia/editors/forms.py:245
 msgid "Admin Flag"
 msgstr "ਪ੍ਰਬੰਧਕ ਝੰਡਾ"
 
-#: src/olympia/editors/forms.py:113
+#: src/olympia/editors/forms.py:113 src/olympia/editors/forms.py:253
 msgid "Max. Version"
 msgstr "ਮੈਕਸ. ਵਰਜਨ"
 
@@ -7413,55 +7259,59 @@ msgstr "ਦਾਖਲ ਕਾਰਜ ਬਾਅਦ ਦਿਨ"
 msgid "Add-on Types"
 msgstr "ਐਡ-ਆਨ ਕਿਸਮਾਂ"
 
-#: src/olympia/editors/forms.py:126 src/olympia/editors/helpers.py:267
+#: src/olympia/editors/forms.py:126 src/olympia/editors/helpers.py:279
 msgid "Platforms"
 msgstr "ਪਲੇਟਫ਼ਾਰਮ"
 
+#: src/olympia/editors/forms.py:237
+msgid "Search by add-on name / author email / guid"
+msgstr ""
+
 #. L10n: 0 = platform, 1 = filename, 2 = status message
-#: src/olympia/editors/forms.py:238
+#: src/olympia/editors/forms.py:342
 #, python-format
 msgid "<strong>%s</strong> &middot; %s &middot; %s"
 msgstr "<strong>%s</strong> &middot; %s &middot; %s"
 
-#: src/olympia/editors/forms.py:252
+#: src/olympia/editors/forms.py:356
 msgid "Comments:"
 msgstr "ਟਿੱਪਣੀਆਂ:"
 
-#: src/olympia/editors/forms.py:256
+#: src/olympia/editors/forms.py:360
 msgid "Operating systems:"
 msgstr "ਓਪਰੇਟਿੰਗ ਸਿਸਟਮ:"
 
-#: src/olympia/editors/forms.py:258
+#: src/olympia/editors/forms.py:362
 msgid "Applications:"
 msgstr "ਐਪਲੀਕੇਸ਼ਨਾਂ:"
 
-#: src/olympia/editors/forms.py:260
+#: src/olympia/editors/forms.py:364
 msgid "Notify me the next time this add-on is updated. (Subsequent updates will not generate an email)"
 msgstr "ਅਗਲੀ ਵਾਰ ਐਡ-ਆਨ ਅੱਪਡੇਟ ਹੋਵੇ ਮੈਨੂੰ ਸੂਚਿਤ ਕਰੋ। (ਪਿਛਲੀਆਂ ਅੱਪਡੇਟਾਂ ਈਮੇਲ ਜਾਰੀ ਨਹੀਂ ਕਰਨਗੀਆਂ)"
 
-#: src/olympia/editors/forms.py:265
+#: src/olympia/editors/forms.py:369
 msgid "Clear Admin Review Flag"
 msgstr "ਪ੍ਰਬੰਧਕ ਸਮੀਖਿਆ ਝੰਡਾ ਮਿਟਾਓ"
 
-#: src/olympia/editors/forms.py:267
+#: src/olympia/editors/forms.py:371
 msgid "Clear more info requested flag"
 msgstr ""
 
-#: src/olympia/editors/forms.py:281
+#: src/olympia/editors/forms.py:385
 msgid "Choose a canned response..."
 msgstr "ਇੱਕ ਡਿੱਬਾਬੰਦ ਜਵਾਬ ਚੁਣੋ..."
 
 #. L10n: Description of what can be searched for.
-#: src/olympia/editors/forms.py:324
+#: src/olympia/editors/forms.py:423
 msgid "theme name"
 msgstr "ਥੀਮ ਨਾਂ"
 
-#: src/olympia/editors/forms.py:350
+#: src/olympia/editors/forms.py:449
 msgid "Someone else is reviewing this theme."
 msgstr "ਇਸ ਥੀਮ ਦੀ ਸਮੀਖਿਆ ਕੋਈ ਹੋਰ ਕਰ ਰਿਹਾ ਹੈ।"
 
 #. L10n: Description of what can be searched for.
-#: src/olympia/editors/forms.py:447
+#: src/olympia/editors/forms.py:546
 msgid "app, reviewer, or comment"
 msgstr "ਐਪ, ਸਮੀਖਿਅਕ, ਜਾਂ ਟਿੱਪਣੀ"
 
@@ -7477,246 +7327,264 @@ msgstr "ਅਧੂਰੀ ਸ਼ੁਰੂਆਤੀ ਸਮੀਖਿਆ"
 msgid "Rejected or Unreviewed"
 msgstr "ਰੱਦ ਹੋਇਆ ਜਾਂ ਬਿਨਾਂ-ਸਮੀਖਿਆ"
 
-#: src/olympia/editors/helpers.py:123 src/olympia/editors/helpers.py:136
+#: src/olympia/editors/helpers.py:125 src/olympia/editors/helpers.py:138
 msgid "Queue"
 msgstr "ਕਤਾਰ"
 
-#: src/olympia/editors/helpers.py:124 src/olympia/editors/templates/editors/base.html:50 src/olympia/editors/templates/editors/base.html:65
+#: src/olympia/editors/helpers.py:126 src/olympia/editors/templates/editors/base.html:50 src/olympia/editors/templates/editors/base.html:65
 msgid "Pending Updates"
 msgstr "ਅਧੂਰੀਆਂ ਅੱਪਡੇਟਾਂ"
 
-#: src/olympia/editors/helpers.py:125 src/olympia/editors/templates/editors/base.html:48 src/olympia/editors/templates/editors/base.html:63
+#: src/olympia/editors/helpers.py:127 src/olympia/editors/templates/editors/base.html:48 src/olympia/editors/templates/editors/base.html:63
 msgid "Full Reviews"
 msgstr "ਮੁਕੰਮਲ ਸਮੀਖਿਆਵਾਂ"
 
-#: src/olympia/editors/helpers.py:126 src/olympia/editors/templates/editors/base.html:52 src/olympia/editors/templates/editors/base.html:67
+#: src/olympia/editors/helpers.py:128 src/olympia/editors/templates/editors/base.html:52 src/olympia/editors/templates/editors/base.html:67
 msgid "Preliminary Reviews"
 msgstr "ਸ਼ੁਰੂਆਤੀ ਸਮੀਖਿਆਵਾਂ"
 
-#: src/olympia/editors/helpers.py:127 src/olympia/editors/templates/editors/base.html:54
+#: src/olympia/editors/helpers.py:129 src/olympia/editors/templates/editors/base.html:54
 msgid "Moderated Reviews"
 msgstr "ਦਰਮਿਆਨੀ ਸਮੀਖਿਆਵਾਂ"
 
-#: src/olympia/editors/helpers.py:128 src/olympia/editors/templates/editors/base.html:46
+#: src/olympia/editors/helpers.py:130 src/olympia/editors/templates/editors/base.html:46
 msgid "Fast Track"
 msgstr "ਫ਼ਾਸਟ ਟਰੈਕ"
 
-#: src/olympia/editors/helpers.py:130
+#: src/olympia/editors/helpers.py:132
 msgid "Pending Themes"
 msgstr "ਅਧੂਰੇ ਥੀਮ"
 
-#: src/olympia/editors/helpers.py:131 src/olympia/editors/templates/editors/themes/queue.html:4
+#: src/olympia/editors/helpers.py:133 src/olympia/editors/templates/editors/themes/queue.html:4
 msgid "Flagged Themes"
 msgstr "ਫ਼ਲੈਗ ਕੀਤੇ ਥੀਮ"
 
-#: src/olympia/editors/helpers.py:132
+#: src/olympia/editors/helpers.py:134
 msgid "Update Themes"
 msgstr "ਥੀਮ ਅੱਪਡੇਟ ਕਰੋ"
 
-#: src/olympia/editors/helpers.py:137
+#: src/olympia/editors/helpers.py:139
 msgid "Unlisted Pending Updates"
 msgstr "ਗੈਰਸੂਚੀਬੱਧ ਅਧੂਰੀਆਂ ਅੱਪਡੇਟਾਂ"
 
-#: src/olympia/editors/helpers.py:138
+#: src/olympia/editors/helpers.py:140
 msgid "Unlisted Full Reviews"
 msgstr "ਗੈਰਸੂਚੀਬੱਧ ਮੁਕੰਮਲ ਸਮੀਖਿਆਵਾਂ"
 
-#: src/olympia/editors/helpers.py:139
+#: src/olympia/editors/helpers.py:141
 msgid "Unlisted Preliminary Reviews"
 msgstr "ਗੈਰਸੂਚੀਬੱਧ ਸ਼ੁਰੂਆਤੀ ਸਮੀਖਿਆਵਾਂ"
 
-#: src/olympia/editors/helpers.py:170
+#: src/olympia/editors/helpers.py:142
+msgid "Unlisted All Add-ons"
+msgstr ""
+
+#: src/olympia/editors/helpers.py:173
 msgid "Fast Track ({0})"
 msgid_plural "Fast Track ({0})"
 msgstr[0] "ਫ਼ਾਸਟ ਟਰੈਕ ({0})"
 msgstr[1] "ਫ਼ਾਸਟ ਟਰੈਕ ({0})"
 
-#: src/olympia/editors/helpers.py:175
+#: src/olympia/editors/helpers.py:178
 msgid "Full Review ({0})"
 msgid_plural "Full Reviews ({0})"
 msgstr[0] "ਮੁਕੰਮਲ ਸਮੀਖਿਆ ({0})"
 msgstr[1] "ਮੁਕੰਮਲ ਸਮੀਖਿਆਵਾਂ ({0})"
 
-#: src/olympia/editors/helpers.py:180
+#: src/olympia/editors/helpers.py:183
 msgid "Pending Update ({0})"
 msgid_plural "Pending Updates ({0})"
 msgstr[0] "ਅਧੂਰੀ ਅੱਪਡੇਟ ({0})"
 msgstr[1] "ਅਧੂਰੀਆਂ ਅੱਪਡੇਟਾਂ ({0})"
 
-#: src/olympia/editors/helpers.py:185
+#: src/olympia/editors/helpers.py:188
 msgid "Preliminary Review ({0})"
 msgid_plural "Preliminary Reviews ({0})"
 msgstr[0] "ਸ਼ੁਰੂਆਤੀ ਸਮੀਖਿਆ ({0})"
 msgstr[1] "ਸ਼ੁਰੂਆਤੀ ਸਮੀਖਿਆਵਾਂ ({0})"
 
-#: src/olympia/editors/helpers.py:190
+#: src/olympia/editors/helpers.py:193
 msgid "Moderated Review ({0})"
 msgid_plural "Moderated Reviews ({0})"
 msgstr[0] "ਦਰਮਿਆਨੀ ਸਮੀਖਿਆ ({0})"
 msgstr[1] "ਦਰਮਿਆਨੀ ਸਮੀਖਿਆਵਾਂ ({0})"
 
-#: src/olympia/editors/helpers.py:196
+#: src/olympia/editors/helpers.py:199
 msgid "Unlisted Full Review ({0})"
 msgid_plural "Unlisted Full Reviews ({0})"
 msgstr[0] "ਗੈਰਸੂਚੀਬੱਧ ਮੁਕੰਮਲ ਸਮੀਖਿਆ ({0})"
 msgstr[1] "ਗੈਰਸੂਚੀਬੱਧ ਮੁਕੰਮਲ ਸਮੀਖਿਆਵਾਂ ({0})"
 
-#: src/olympia/editors/helpers.py:201
+#: src/olympia/editors/helpers.py:204
 msgid "Unlisted Pending Update ({0})"
 msgid_plural "Unlisted Pending Updates ({0})"
 msgstr[0] "ਗੈਰਸੂਚੀਬੱਧ ਅਧੂਰੀ ਅੱਪਡੇਟ ({0})"
 msgstr[1] "ਗੈਰਸੂਚੀਬੱਧ ਅਧੂਰੀਆਂ ਅੱਪਡੇਟਾਂ ({0})"
 
-#: src/olympia/editors/helpers.py:206
+#: src/olympia/editors/helpers.py:209
 msgid "Unlisted Preliminary Review ({0})"
 msgid_plural "Unlisted Preliminary Reviews ({0})"
 msgstr[0] "ਗੈਰਸੂਚੀਬੱਧ ਸ਼ੁਰੂਆਤੀ ਸਮੀਖਿਆ ({0})"
 msgstr[1] "ਗੈਰਸੂਚੀਬੱਧ ਸ਼ੁਰੂਆਤੀ ਸਮੀਖਿਆ ({0})"
 
-#: src/olympia/editors/helpers.py:261
-msgid "Addon"
-msgstr "ਐਡਆਨ"
+#: src/olympia/editors/helpers.py:214
+msgid "Unlisted All Add-ons ({0})"
+msgid_plural "Unlisted All Add-ons ({0})"
+msgstr[0] ""
+msgstr[1] ""
 
-#: src/olympia/editors/helpers.py:262
+#: src/olympia/editors/helpers.py:274
 msgid "Type"
 msgstr "ਕਿਸਮ"
 
-#: src/olympia/editors/helpers.py:263
+#: src/olympia/editors/helpers.py:275
 msgid "Waiting Time"
 msgstr "ਉਡੀਕ ਸਮਾਂ"
 
-#: src/olympia/editors/helpers.py:264 src/olympia/editors/templates/editors/review.html:285
+#: src/olympia/editors/helpers.py:276 src/olympia/editors/templates/editors/review.html:285
 msgid "Flags"
 msgstr "ਝੰਡੇ"
 
-#: src/olympia/editors/helpers.py:265
+#: src/olympia/editors/helpers.py:277
 msgid "Applications"
 msgstr "ਐਪਲੀਕੇਸ਼ਨਾਂ"
 
-#: src/olympia/editors/helpers.py:270
+#: src/olympia/editors/helpers.py:282
 msgid "Additional"
 msgstr "ਵਾਧੂ"
 
-#: src/olympia/editors/helpers.py:285
+#: src/olympia/editors/helpers.py:302
 msgid "Site Specific"
 msgstr "ਸਾਈਟ ਖਾਸ਼"
 
-#: src/olympia/editors/helpers.py:287
+#: src/olympia/editors/helpers.py:304
 msgid "Requires External Software"
 msgstr "ਬਾਹਰੀ ਸਾਫ਼ਟਵੇਅਰ ਦੀ ਲੋੜ"
 
-#: src/olympia/editors/helpers.py:289
+#: src/olympia/editors/helpers.py:306
 msgid "Binary Components"
 msgstr "ਬਾਇਨਰੀ ਹਿੱਸੇ"
 
-#: src/olympia/editors/helpers.py:313
+#: src/olympia/editors/helpers.py:339
 msgid "moments ago"
 msgstr "ਪਲ ਪਹਿਲਾਂ"
 
 #. L10n: first argument is number of minutes
-#: src/olympia/editors/helpers.py:316
+#: src/olympia/editors/helpers.py:342
 msgid "{0} minute"
 msgid_plural "{0} minutes"
 msgstr[0] "{0} ਮਿੰਟ"
 msgstr[1] "{0} ਮਿੰਟਾਂ"
 
 #. L10n: first argument is number of hours
-#: src/olympia/editors/helpers.py:320
+#: src/olympia/editors/helpers.py:346
 msgid "{0} hour"
 msgid_plural "{0} hours"
 msgstr[0] "{0} ਘੰਟਾ"
 msgstr[1] "{0} ਘੰਟੇ"
 
 #. L10n: first argument is number of days
-#: src/olympia/editors/helpers.py:324
+#: src/olympia/editors/helpers.py:350
 msgid "{0} day"
 msgid_plural "{0} days"
 msgstr[0] "{0} ਦਿਨ"
 msgstr[1] "{0} ਦਿਨਾਂ"
 
-#: src/olympia/editors/helpers.py:488
+#: src/olympia/editors/helpers.py:364
+msgid "Last Review"
+msgstr ""
+
+#: src/olympia/editors/helpers.py:366
+msgid "Last Update"
+msgstr ""
+
+#: src/olympia/editors/helpers.py:387
+msgid "No Reviews"
+msgstr ""
+
+#: src/olympia/editors/helpers.py:561
 msgid "Push to public"
 msgstr "ਜਨਤਕ ਵੱਲ ਭੇਜੋ"
 
-#: src/olympia/editors/helpers.py:490
+#: src/olympia/editors/helpers.py:563
 msgid "Grant full review"
 msgstr "ਪੂਰੀ ਸਮੀਖਿਆ ਮਨਜ਼ੂਰ ਕਰੋ"
 
-#: src/olympia/editors/helpers.py:505
+#: src/olympia/editors/helpers.py:578
 msgid "Request more information"
 msgstr "ਹੋਰ ਜਾਣਕਾਰੀ ਲਈ ਬੇਨਤੀ ਕਰੋ"
 
-#: src/olympia/editors/helpers.py:508
+#: src/olympia/editors/helpers.py:581
 msgid "Request super-review"
 msgstr "ਉੱਤਮ-ਸਮੀਖਿਆ ਲਈ ਬੇਨਤੀ"
 
-#: src/olympia/editors/helpers.py:519
+#: src/olympia/editors/helpers.py:592
 msgid "Grant preliminary review"
 msgstr "ਸ਼ੁਰੂਆਤੀ ਸਮੀਖਿਆ ਦਿਓ"
 
-#: src/olympia/editors/helpers.py:520
+#: src/olympia/editors/helpers.py:593
 msgid "This will mark the files as preliminarily reviewed."
 msgstr "ਇਹ ਫ਼ਾਈਲਾਂ ਤੇ ਸ਼ੁਰੂਆਤੀ ਸਮੀਖਿਆ ਦਾ ਨਿਸ਼ਾਨ ਲਗਾ ਦੇਵੇਗਾ।"
 
-#: src/olympia/editors/helpers.py:522
+#: src/olympia/editors/helpers.py:595
 msgid "Use this form to request more information from the author. They will receive an email and be able to answer here. You will be notified by email when they reply."
 msgstr "ਲੇਖਕ ਕੋਲੋਂ ਹੋਰ ਜਾਣਕਾਰੀ ਦੀ ਬੇਨਤੀ ਲਈ ਇਸ ਫ਼ਾਰਮ ਦੀ ਵਰਤੋਂ ਕਰੋ। ਉਹਨਾਂ ਨੂੰ ਇੱਕ ਈਮੇਲ ਪ੍ਰਾਪਤ ਹੋਵੇਗਾ ਅਤੇ ਇੱਥੇ ਉਹ ਜਵਾਬ ਦੇਣਗੇ। ਤੁਹਾਨੂੰ ਈਮੇਲ ਰਾਹੀ ਸੂਚਨਾ ਦੇ ਦਿੱਤੀ ਜਾਵੇਗੀ ਜਦੋਂ ਉਹ ਜਵਾਬ ਦੇਣਗੇ।"
 
-#: src/olympia/editors/helpers.py:526
+#: src/olympia/editors/helpers.py:599
 msgid ""
 "If you have concerns about this add-on's security, copyright issues, or other concerns that an administrator should look into, enter your comments in the area below. They will be sent to "
 "administrators, not the author."
 msgstr "ਜੇਕਰ ਤੁਹਾਡੇ ਕੋਲ ਇਸ ਐਡ-ਆਨ ਦੀ ਸੁਰੱਖਿਆ, ਕਾਪੀਰਾਈਟ ਮਸਲਿਆਂ, ਬਾਰੇ ਚਿੰਤਾਵਾਂ ਹਨ, ਜਾਂ ਕੋਈ ਚਿੰਤਾ ਹੈ ਜਿਸ ਬਾਰੇ ਪ੍ਰਬੰਧਕ ਨੂੰ ਧਿਆਨ ਦੇਣਾ ਚਾਹੀਦਾ, ਹੇਠ ਦਿੱਤੇ ਖੇਤਰ ਵਿੱਚ ਆਪਣੀ ਟਿੱਪਣੀਆਂ ਲਿਖੋ। ਉਹ ਲੇਖਕ ਨੂੰ ਨਹੀਂ, ਪ੍ਰਬੰਧਕ ਨੂੰ ਭੇਜ ਦਿੱਤੀਆਂ ਜਾਣਗੀਆਂ।"
 
-#: src/olympia/editors/helpers.py:532
+#: src/olympia/editors/helpers.py:605
 msgid "This will reject the add-on and remove it from the review queue."
 msgstr "ਉਹ ਐਡ-ਆਨ ਨੂੰ ਰੱਦ ਅਤੇ ਇਸ ਨੂੰ ਸਮੀਖਿਆ ਕਤਾਰ ਵਿੱਚ ਹਟਾ ਦੇਣਗੇ।"
 
-#: src/olympia/editors/helpers.py:534
-msgid "Make a comment on this version.  The author won't be able to see this."
-msgstr ""
+#: src/olympia/editors/helpers.py:607
+msgid "Make a comment on this version. The author won't be able to see this."
+msgstr "ਇਸ ਵਰਜਨ ਇੱਕ ਟਿੱਪਣੀ ਕਰੋ। ਲੇਖਕ ਇਸ ਨੂੰ ਨਹੀਂ ਵੇਖ ਸਕੇਗਾ।"
 
-#: src/olympia/editors/helpers.py:538
+#: src/olympia/editors/helpers.py:611
 msgid "This will reject the files and remove them from the review queue."
 msgstr "ਇਹ ਫ਼ਾਈਲਾਂ ਨੂੰ ਰੱਦ ਅਤੇ ਉਹਨਾਂ ਨੂੰ ਸਮੀਖਿਆ ਕਤਾਰ ਵਿੱਚੋਂ ਹਟਾ ਦੇਵੇਗਾ।"
 
-#: src/olympia/editors/helpers.py:542
+#: src/olympia/editors/helpers.py:615
 msgid "This will mark the add-on as preliminarily reviewed. Future versions will undergo preliminary review."
 msgstr "ਐਡ-ਆਨ ਤੇ ਇਹ ਸ਼ੁਰੂਆਤੀ ਸਮੀਖਿਆ ਦਾ ਨਿਸ਼ਾਨ ਲਗਾ ਦੇਵੇਗਾ। ਭਵਿੱਖ ਦੇ ਵਰਜਨ ਸ਼ੁਰੂਆਤੀ ਸਮੀਖਿਆ ਵਿੱਚੋਂ ਲੰਘਣਗੇ।"
 
-#: src/olympia/editors/helpers.py:547
+#: src/olympia/editors/helpers.py:620
 msgid "This will mark the files as preliminarily reviewed. Future versions will undergo preliminary review."
 msgstr "ਫ਼ਾਈਲਾਂ ਤੇ ਇਹ ਸ਼ੁਰੂਆਤੀ ਸਮੀਖਿਆ ਦਾ ਨਿਸ਼ਾਨ ਲਗਾ ਦੇਵੇਗਾ। ਭਵਿੱਖ ਦੇ ਵਰਜਨ ਸ਼ੁਰੂਆਤੀ ਸਮੀਖਿਆ ਵਿੱਚੋਂ ਲੰਘਣਗੇ।"
 
-#: src/olympia/editors/helpers.py:552
+#: src/olympia/editors/helpers.py:625
 msgid "Retain preliminary review"
 msgstr "ਸ਼ੁਰੂਆਤੀ ਸਮੀਖਿਆ ਬਰਕਰਾਰ ਰੱਖੋ"
 
-#: src/olympia/editors/helpers.py:553
+#: src/olympia/editors/helpers.py:626
 msgid "This will retain the add-on as preliminarily reviewed. Future versions will undergo preliminary review."
 msgstr "ਐਡ-ਆਨ ਨੂੰ ਇਹ ਸ਼ੁਰੂਆਤੀ ਸਮੀਖਿਆ ਦੇ ਤੌਰ ਤੇ ਬਰਕਰਾਰ ਰੱਖਣਗੇ। ਭਵਿੱਖ ਦੇ ਵਰਜਨ ਸ਼ੁਰੂਆਤੀ ਸਮੀਖਿਆ ਵਿੱਚੋਂ ਲੰਘਣਗੇ।"
 
-#: src/olympia/editors/helpers.py:558
+#: src/olympia/editors/helpers.py:631
 msgid "This will approve a sandboxed version of a public add-on to appear on the public side."
 msgstr "ਇਹ ਜਨਤਕ ਪਾਸੇ ਵਿਖਾਉਣ ਲਈ ਇੱਕ ਜਨਤਕ ਐਡ-ਆਨ ਦੇ ਸੈੰਡਬਾਕਸ ਵਰਜਨ ਨੂੰ ਮਨਜ਼ੂਰੀ ਦੇ ਦੇਵੇਗਾ।"
 
-#: src/olympia/editors/helpers.py:561
+#: src/olympia/editors/helpers.py:634
 msgid "This will reject a version of a public add-on and remove it from the queue."
 msgstr "ਇਹ ਜਨਤਕ ਐਡ-ਆਨ ਦੇ ਇੱਕ ਵਰਜਨ ਨੂੰ ਰੱਦ ਅਤੇ ਕਤਾਰ ਵਿੱਚੋਂ ਹਟਾ ਦੇਵੇਗਾ।"
 
-#: src/olympia/editors/helpers.py:564
+#: src/olympia/editors/helpers.py:637
 msgid "This will mark the add-on and its most recent version and files as public. Future versions will go into the sandbox until they are reviewed by an editor."
 msgstr "ਇਹ ਐਡ-ਆਨ ਅਤੇ ਉਸਦੇ ਤਾਜ਼ੇ ਵਰਜਨ ਅਤੇ ਫ਼ਾਈਲਾਂ ਤੇ ਜਨਤਕ ਦਾ ਨਿਸ਼ਾਨ ਲਗਾ ਦੇਵੇਗਾ। ਭਵਿੱਖ ਦੇ ਵਰਜਨ ਸੈੰਡਬਾਕਸ ਵਿੱਚ ਜਾਣਗੇ ਜਦੋਂ ਤੱਕ ਉਹਨਾਂ ਦੀ ਸੰਪਾਦਕ ਵੱਲੋਂ ਸਮੀਖਿਆ ਨਹੀਂ ਹੁੰਦੀ।"
 
-#: src/olympia/editors/helpers.py:637
+#: src/olympia/editors/helpers.py:714
 msgid "add-on"
 msgstr "ਐਡ-ਆਨ"
 
-#: src/olympia/editors/helpers.py:940 src/olympia/editors/helpers.py:960
+#: src/olympia/editors/helpers.py:1020 src/olympia/editors/helpers.py:1040
 msgid "Flagged"
 msgstr "ਨਿਸ਼ਾਨਬੱਧ"
 
-#: src/olympia/editors/helpers.py:944 src/olympia/editors/helpers.py:963
+#: src/olympia/editors/helpers.py:1024 src/olympia/editors/helpers.py:1043
 msgid "Updates"
 msgstr "ਅੱਪਡੇਟਾਂ"
 
@@ -7768,56 +7636,56 @@ msgstr "ਦਾਖਲ ਥੀਮ ਤੇ ਸਮੀਖਿਆ ਲਈ ਝੰਡਾ ਲ
 msgid "A question about your Theme submission"
 msgstr "ਤੁਹਾਡੇ ਦਾਖਲ ਕੀਤੇ ਥੀਮ ਬਾਰੇ ਇੱਕ ਸਵਾਲ"
 
-#: src/olympia/editors/views.py:144
+#: src/olympia/editors/views.py:146
 msgid "New Add-ons (Under 5 days)"
 msgstr "ਨਵੇਂ ਐਡ-ਆਨ (5 ਦਿਨਾਂ ਅੰਦਰ)"
 
-#: src/olympia/editors/views.py:145
+#: src/olympia/editors/views.py:147
 msgid "Passable (5 to 10 days)"
 msgstr "ਪਾਸਹੋਣਯੋਗ (5 ਤੋਂ 10 ਦਿਨ)"
 
-#: src/olympia/editors/views.py:146
+#: src/olympia/editors/views.py:148
 msgid "Overdue (Over 10 days)"
 msgstr "ਬਕਾਇਆ(10 ਦਿਨ ਬਾਅਦ)"
 
-#: src/olympia/editors/views.py:532
+#: src/olympia/editors/views.py:539
 msgid "An unknown error occurred"
 msgstr "ਅਣਜਾਣ ਖਾਮੀ ਆਈ"
 
-#: src/olympia/editors/views.py:587
+#: src/olympia/editors/views.py:592
 msgid "Self-reviews are not allowed."
 msgstr "ਸਵੈ-ਸਮੀਖਿਆਵਾਂ ਪ੍ਰਵਾਨ ਨਹੀਂ।"
 
-#: src/olympia/editors/views.py:609
+#: src/olympia/editors/views.py:613
 msgid "Review successfully processed."
 msgstr "ਸਮੀਖਿਆ ਤੇ ਕਾਰਵਾਈ ਸਫ਼ਲਤਾਪਰੂਵਕ ਹੋਈ।"
 
-#: src/olympia/editors/views.py:807
+#: src/olympia/editors/views.py:812
 msgid "was approved"
 msgstr "ਪ੍ਰਵਾਨਿਤ ਹੋਇਆ ਸੀ"
 
-#: src/olympia/editors/views.py:808
+#: src/olympia/editors/views.py:813
 msgid "given preliminary review"
 msgstr "ਸ਼ੁਰੂਆਤੀ ਸਮੀਖਿਆ ਦਿੱਤੀ ਗਈ"
 
-#: src/olympia/editors/views.py:809
+#: src/olympia/editors/views.py:814
 msgid "rejected"
 msgstr "ਰੱਦ ਕੀਤਾ"
 
-#: src/olympia/editors/views.py:810
+#: src/olympia/editors/views.py:815
 msgctxt "editors_review_history_nominated_adminreview"
 msgid "escalated"
 msgstr "ਵਧਿਆ"
 
-#: src/olympia/editors/views.py:812
+#: src/olympia/editors/views.py:817
 msgid "needs more information"
 msgstr "ਹੋਰ ਜਾਣਕਾਰੀ ਦੀ ਲੋੜ"
 
-#: src/olympia/editors/views.py:813
+#: src/olympia/editors/views.py:818
 msgid "needs super review"
 msgstr "ਉੱਤਮ ਸਮੀਖਿਆ ਦੀ ਲੋੜ"
 
-#: src/olympia/editors/views.py:814
+#: src/olympia/editors/views.py:819
 msgid "commented"
 msgstr "ਟਿੱਪਣੀ ਕੀਤੀ"
 
@@ -7862,28 +7730,28 @@ msgstr "ਕਤਾਰਾਂ"
 msgid "Unlisted Queues"
 msgstr "ਗੈਰਸੂਚੀਬੱਧ ਕਤਾਰਾਂ"
 
-#: src/olympia/editors/templates/editors/base.html:72 src/olympia/editors/templates/editors/performance.html:6
+#: src/olympia/editors/templates/editors/base.html:74 src/olympia/editors/templates/editors/performance.html:6
 msgid "Performance"
 msgstr "ਕਾਰਗੁਜ਼ਾਰੀ"
 
-#: src/olympia/editors/templates/editors/base.html:75 src/olympia/editors/templates/editors/themes/base.html:19 src/olympia/editors/templates/editors/themes/base.html:38
+#: src/olympia/editors/templates/editors/base.html:77 src/olympia/editors/templates/editors/themes/base.html:19 src/olympia/editors/templates/editors/themes/base.html:38
 msgid "Logs"
 msgstr "ਚਿੱਠੇ"
 
-#: src/olympia/editors/templates/editors/base.html:78 src/olympia/editors/templates/editors/reviewlog.html:4 src/olympia/editors/templates/editors/reviewlog.html:27
+#: src/olympia/editors/templates/editors/base.html:80 src/olympia/editors/templates/editors/reviewlog.html:4 src/olympia/editors/templates/editors/reviewlog.html:27
 msgid "Add-on Review Log"
 msgstr "ਐਡ-ਆਨ ਸਮੀਖਿਆ ਚਿੱਠਾ"
 
-#: src/olympia/editors/templates/editors/base.html:80 src/olympia/editors/templates/editors/eventlog.html:4 src/olympia/editors/templates/editors/eventlog.html:8
+#: src/olympia/editors/templates/editors/base.html:82 src/olympia/editors/templates/editors/eventlog.html:4 src/olympia/editors/templates/editors/eventlog.html:8
 #: src/olympia/editors/templates/editors/eventlog_detail.html:4
 msgid "Moderated Review Log"
 msgstr "ਦਰਮਿਆਨੀ ਸਮੀਖਿਆ ਚਿੱਠਾ"
 
-#: src/olympia/editors/templates/editors/base.html:82 src/olympia/editors/templates/editors/beta_signed_log.html:4 src/olympia/editors/templates/editors/beta_signed_log.html:8
+#: src/olympia/editors/templates/editors/base.html:84 src/olympia/editors/templates/editors/beta_signed_log.html:4 src/olympia/editors/templates/editors/beta_signed_log.html:8
 msgid "Signed Beta Files Log"
 msgstr "ਸਾਈਨ ਹੋਈਆਂ ਬੀਟਾ ਫਾਈਲਾਂ ਦਾ ਲਾਗ"
 
-#: src/olympia/editors/templates/editors/base.html:87 src/olympia/editors/templates/editors/includes/daily-message.html:4
+#: src/olympia/editors/templates/editors/base.html:89 src/olympia/editors/templates/editors/includes/daily-message.html:4
 msgid "Announcement"
 msgstr "ਐਲਾਨ"
 
@@ -8104,45 +7972,45 @@ msgstr "ਤਕਨੀਕੀ ਖੋਜ"
 msgid "clear search"
 msgstr "ਖੋਜ ਮਿਟਾਓ"
 
-#: src/olympia/editors/templates/editors/queue.html:72 src/olympia/editors/templates/editors/queue.html:122
+#: src/olympia/editors/templates/editors/queue.html:78 src/olympia/editors/templates/editors/queue.html:128
 msgid "Process Reviews"
 msgstr "ਸਮੀਖਿਆਵਾਂ ਤੇ ਕਾਰਵਾਈ"
 
-#: src/olympia/editors/templates/editors/queue.html:80
+#: src/olympia/editors/templates/editors/queue.html:86
 msgid "Moderation actions:"
 msgstr "ਦਰਮਿਆਨੀ ਕਾਰਵਾਈਆਂ:"
 
-#: src/olympia/editors/templates/editors/queue.html:90
+#: src/olympia/editors/templates/editors/queue.html:96
 #, python-format
 msgid "by %(user)s on %(date)s %(stars)s (%(locale)s)"
 msgstr "%(date)s %(stars)s (%(locale)s) ਤੇ %(user)s ਵੱਲੋਂ"
 
-#: src/olympia/editors/templates/editors/queue.html:106
+#: src/olympia/editors/templates/editors/queue.html:112
 #, python-format
 msgid "<strong>%(reason)s</strong> <span class=\"light\">Flagged by %(user)s on %(date)s</span>"
 msgstr "<strong>%(reason)s</strong> <span class=\"light\">%(date)s ਨੂੰ %(user)s ਵੱਲੋਂ ਫ਼ਲੈਗ ਕੀਤਾ</span>"
 
-#: src/olympia/editors/templates/editors/queue.html:119
-msgid "All reviews have been moderated.  Good work!"
-msgstr ""
+#: src/olympia/editors/templates/editors/queue.html:125
+msgid "All reviews have been moderated. Good work!"
+msgstr "ਸਾਰੀਆਂ ਸਮੀਖਿਆਵਾਂ ਸੰਤੁਲਿਤ ਕੀਤੀਆਂ ਗਈਆਂ। ਬਹੁਤ ਵਧੀਆ!"
 
-#: src/olympia/editors/templates/editors/queue.html:161
+#: src/olympia/editors/templates/editors/queue.html:167
 msgid "Version Notes / Notes for Reviewer"
 msgstr "ਵਰਜਨ ਨੋਟ / ਸਮੀਖਿਅਕ ਲਈ ਨੋਟ"
 
-#: src/olympia/editors/templates/editors/queue.html:169
+#: src/olympia/editors/templates/editors/queue.html:175
 msgid "There are currently no add-ons of this type to review."
 msgstr "ਇੱਥੇ ਸਮੀਖਿਆ ਲਈ ਮੌਜੂਦਾ ਤੌਰ ਤੇ ਇਸ ਕਿਸਮ ਦੇ ਕੋਈ ਐਡ-ਆਨ ਨਹੀਂ।"
 
-#: src/olympia/editors/templates/editors/queue.html:181 src/olympia/editors/templates/editors/themes/queue_list.html:85
+#: src/olympia/editors/templates/editors/queue.html:187 src/olympia/editors/templates/editors/themes/queue_list.html:85
 msgid "Helpful Links:"
 msgstr "ਸਹਾਇਕ ਲਿੰਕ:"
 
-#: src/olympia/editors/templates/editors/queue.html:182
+#: src/olympia/editors/templates/editors/queue.html:188
 msgid "Add-on Policy"
 msgstr "ਐਡ-ਆਨ ਨੀਤੀ"
 
-#: src/olympia/editors/templates/editors/queue.html:184
+#: src/olympia/editors/templates/editors/queue.html:190
 msgid "Editors' Guide"
 msgstr "ਸੰਪਾਦਕ ਗਾਈਡ"
 
@@ -8205,11 +8073,8 @@ msgid "<strong>Warning!</strong> Another user was viewing this page before you."
 msgstr "<strong>ਚੇਤਾਵਨੀ!</strong> ਦੂਜਾ ਉਪਭੋਗੀ ਤੁਹਾਡੇ ਤੋਂ ਪਹਿਲਾਂ ਇਹ ਸਫ਼ਾ ਵੇਖ ਰਿਹਾ ਸੀ।"
 
 #: src/olympia/editors/templates/editors/review.html:237
-msgid ""
-"The whiteboard is the place to exchange information relevant to\n"
-"               this addon (whatever the version), between the developer and the\n"
-"               editor. This is visible and editable by both."
-msgstr ""
+msgid "The whiteboard is the place to exchange information relevant to this addon (whatever the version), between the developer and the editor. This is visible and editable by both."
+msgstr "ਵਾਇਟਬੋਰਡ ਡਿਵੈਲਪਰ ਅਤੇ ਸੰਪਾਦਕ ਵਿਚਾਲੇ, ਇਸ ਐਡ-ਆਨ ਨਾਲ ਸੰਬੰਧਤ ਜਾਣਕਾਰੀ ਵਟਾਉਣ ਦੀ ਥਾਂ ਹੈ (ਜੋ ਵੀ ਵਰਜਨ ਹੋਵੇ)। ਇਹ ਦੋਨਾਂ ਵੱਲੋਂ ਵਿਖਾਈ ਦੇਣ ਅਤੇ ਸੋਧ ਕਰਨਯੋਗ ਹੈ।"
 
 #: src/olympia/editors/templates/editors/review.html:241
 msgid "Update the whiteboard"
@@ -8482,7 +8347,7 @@ msgstr "ਕਲਾਕਾਰ ਤੋਂ ਇੱਕ ਸਵਾਲ ਪੁੱਛੋ"
 msgid "Describe your reason for flagging"
 msgstr "ਫ਼ਲੈਗ ਕਰਨ ਲਈ ਆਪਣੇ ਕਾਰਨ ਦਾ ਵਰਣਨ ਕਰੋ"
 
-#: src/olympia/files/forms.py:88
+#: src/olympia/files/forms.py:90
 msgid "Cannot diff a version against itself"
 msgstr "ਵਰਜਨ ਦਾ ਖੁਦ ਤੋਂ ਫ਼ਰਕ ਨਹੀਂ ਕਰ ਸਕਦਾ"
 
@@ -8517,51 +8382,51 @@ msgstr "ਫ਼ਾਈਲ %s ਤੱਕ ਪਹੁੰਚ ਕਰਦੇ ਸਮੇਂ ਖ�
 msgid "There was an error accessing file %s."
 msgstr "ਫ਼ਾਈਲ %s ਤੱਕ ਪਹੁੰਚ ਕਰਦੇ ਸਮੇਂ ਖਾਮੀ ਆਈ।"
 
-#: src/olympia/files/utils.py:343
+#: src/olympia/files/utils.py:340
 msgid "Could not parse uploaded file."
 msgstr "ਅੱਪਲੋਡ ਫ਼ਾਈਲ ਨੂੰ ਪਾਰਸ ਨਹੀਂ ਕਰ ਸਕਦਾ।"
 
-#: src/olympia/files/utils.py:380
+#: src/olympia/files/utils.py:377
 msgid "Invalid file name in archive: {0}"
 msgstr "ਅਕਾਈਵ ਵਿੱਚ ਗਲਤ ਫ਼ਾਈਲ ਨਾਂ:{0}"
 
-#: src/olympia/files/utils.py:388
+#: src/olympia/files/utils.py:385
 msgid "File exceeding size limit in archive: {0}"
 msgstr "ਅਕਾਈਵ ਵਿੱਚ ਫ਼ਾਈਲ ਨੇ ਅਕਾਰ ਸੀਮਾ ਲੰਘੀ: {0}"
 
-#: src/olympia/files/utils.py:439
+#: src/olympia/files/utils.py:436
 msgid "Invalid archive."
 msgstr "ਗਲਤ ਅਕਾਈਵ।"
 
-#: src/olympia/files/utils.py:529 src/olympia/files/utils.py:532
+#: src/olympia/files/utils.py:526 src/olympia/files/utils.py:529
 msgid "Could not parse the manifest file."
 msgstr ""
 
-#: src/olympia/files/utils.py:551
+#: src/olympia/files/utils.py:548
 msgid "Could not find an add-on ID."
 msgstr ""
 
-#: src/olympia/files/utils.py:554
+#: src/olympia/files/utils.py:551
 msgid "Add-on ID must be 64 characters or less."
 msgstr ""
 
-#: src/olympia/files/utils.py:556
+#: src/olympia/files/utils.py:553
 msgid "Add-on ID doesn't match add-on."
 msgstr ""
 
-#: src/olympia/files/utils.py:564
+#: src/olympia/files/utils.py:561
 msgid "Duplicate add-on ID found."
 msgstr ""
 
-#: src/olympia/files/utils.py:567
+#: src/olympia/files/utils.py:564
 msgid "Version numbers should have fewer than 32 characters."
 msgstr "ਵਰਜਨ ਨੰਬਰ 32 ਅੱਖਰਾਂ ਤੋਂ ਘੱਟ ਦੇ ਹੋਣੇ ਚਾਹੀਦੇ ਹਨ।"
 
-#: src/olympia/files/utils.py:570
+#: src/olympia/files/utils.py:567
 msgid "Version numbers should only contain letters, numbers, and these punctuation characters: +*.-_."
 msgstr "ਵਰਜਨ ਨੰਬਰਾਂ ਵਿੱਚ ਕੇਵਲ ਅੱਖਰ,ਨੰਬਰ ਅਤੇ ਇਹ ਵਿਰਾਮ ਚਿੰਨ੍ਹ ਸ਼ਾਮਲ ਹੋਣੇ ਚਾਹੀਦੇ ਹਨ: +*.-_।"
 
-#: src/olympia/files/utils.py:587
+#: src/olympia/files/utils.py:584
 msgid "<em:type> doesn't match add-on"
 msgstr "<em:type> ਦਾ ਐਡ-ਆਨ ਨਾਲ ਮੇਲ ਨਹੀਂ"
 
@@ -8661,6 +8526,10 @@ msgstr "ਅੱਪਲੋਡ ਕੀਤੀ ਫ਼ਾਈਲ ਵਿੱਚ ਕੋਈ ਫ਼�
 #: src/olympia/files/templates/files/viewer.html:134
 msgid "Fetching file."
 msgstr "ਫ਼ਾਈਲ ਪ੍ਰਾਪਤ ਕਰ ਰਿਹਾ।"
+
+#: src/olympia/legacy_api/views.py:255
+msgid "Not implemented yet."
+msgstr "ਹਾਲੇ ਤੱਕ ਲਾਗੂ ਨਹੀਂ ਕੀਤਾ।"
 
 #: src/olympia/lib/constants.py:6
 msgid "United Arab Emirates Dirham"
@@ -9318,10 +9187,6 @@ msgstr ""
 msgid "Zimbabwe Dollar"
 msgstr ""
 
-#: src/olympia/lib/video/ffmpeg.py:112 src/olympia/lib/video/totem.py:81
-msgid "Videos must be in WebM."
-msgstr ""
-
 #: src/olympia/pages/templates/pages/about.lhtml:3 src/olympia/pages/templates/pages/about.lhtml:10
 msgid "About Mozilla Add-ons"
 msgstr "ਮੌਜੀਲਾ ਐਡ-ਆਨਾਂ ਬਾਰੇ"
@@ -9333,8 +9198,10 @@ msgstr "ਇਹ ਵੈੱਬਸਾਈਟ ਕੀ ਹੈ?"
 #: src/olympia/pages/templates/pages/about.lhtml:13
 msgid ""
 "addons.mozilla.org, commonly known as \"AMO\", is Mozilla's official site for add-ons to Mozilla software, such as Firefox, Thunderbird, and SeaMonkey. Add-ons let you add new features and change "
-"the way your browser or application works.  Take a look around and explore the thousands of ways to customize the way you do things online."
+"the way your browser or application works. Take a look around and explore the thousands of ways to customize the way you do things online."
 msgstr ""
+"addons.mozilla.org, ਆਮ ਕਰਕੇ \"AMO\" ਵਜੋਂ ਜਾਣੀ ਜਾਂਦੀ, ਮੌਜੀਲਾ ਸਾਫ਼ਟਵੇਅਰ ਦੇ ਐਡ-ਆਨਾਂ ਲਈ ਮੌਜੀਲਾ ਦੀ ਅਧਿਕਾਰਕ ਸਾਈਟ ਹੈ, ਜਿਵੇਂ ਕਿ ਫ਼ਾਇਰਫ਼ਾਕਸ, ਥੰਡਰਬਰਡ, ਅਤੇ ਸੀਮੰਕੀ। ਐਡ-ਆਨ ਤੁਹਾਨੂੰ ਨਵੇਂ ਗੁਣ ਸ਼ਾਮਲ ਅਤੇ ਆਪਣੇ ਬਰਾਊਜ਼ਰ ਜਾਂ ਐਪਲੀਕੇਸ਼ਨ ਦੇ ਕੰਮ ਕਰਨ ਦੇ ਢੰਗ "
+"ਵਿੱਚ ਬਦਲਾਅ ਕਰਨ ਦਿੰਦੇ ਹਨ। ਆਲੇ-ਦੁਆਲੇ ਇੱਕ ਨਜ਼ਰ ਮਾਰੋ ਅਤੇ ਆਪਣੇ ਆਨਲਾਈਨ ਕੰਮ ਕਰਨ ਦੇ ਤਰੀਕਿਆਂ ਵਿੱਚ ਬਦਲਾਅ ਕਰਨ ਲਈ ਹਜ਼ਾਰਾਂ ਢੰਗਾਂ ਦੀ ਪੜਚੋਲ ਕਰੋ।"
 
 #: src/olympia/pages/templates/pages/about.lhtml:19
 msgid "Who creates these add-ons?"
@@ -9699,8 +9566,11 @@ msgstr "ਕੀ ਮੈਂ ਆਪਣੇ ਐਡ-ਆਨ ਬਣਾਉਣ ਲਈ ਜ�
 msgid ""
 "Yes. It's possible, but some of the functionality provided by these libraries are available through XPCOM, XUL, and JavaScript. In addition, authors should take care if libraries modify primitive "
 "object prototypes (String.prototype, Date.prototype, etc.) and/or define global functions (eg. the $ function). These are prone to cause conflict with other add-ons, in particular if different add-"
-"ons use different versions of libraries and so on. Developers need to be very, very careful with using them.  Mozilla does not offer documentation on using them to build add-ons."
+"ons use different versions of libraries and so on. Developers need to be very, very careful with using them. Mozilla does not offer documentation on using them to build add-ons."
 msgstr ""
+"ਹਾਂ, ਇਹ ਮੁਮਕਿਨ ਹੈ, ਪਰ ਇਹਨਾਂ ਲਾਇਬਰ੍ਰੇਰੀਆਂ ਵੱਲੋਂ ਮੁਹੱਈਆ ਕਰਵਾਏ ਕੁੱਝ ਗੁਣ XPCOM, XUL, ਅਤੇ JavaScript ਦੁਆਰਾ ਉੱਪਲਬਧ ਹੋਣਗੇ। ਇਸ ਦੀ ਥਾਂ, ਲੇਖਕਾਂ ਨੂੰ ਧਿਆਨ ਰੱਖਣਾ ਚਾਹੀਦਾ ਜੇਕਰ ਲਾਇਬਰ੍ਰੇਰੀਆਂ ਪੁਰਾਣੇ ਇਕਾਈ ਨਮੂਨਿਆਂ (string.prototype, date,prototype, "
+"ਆਦਿ)ਵਿੱਚ ਸੋਧ ਅਤੇ/ਜਾਂ ਗਲੋਬਲ ਫ਼ੰਕਸ਼ਨਾਂ (ਜਿਵੇਂ $ function) ਨੂੰ ਪ੍ਰਭਾਸ਼ਿਤ ਕਰਨ। ਇਹ ਹੋਰਾਂ ਐਡ-ਆਨਾਂ ਨਾਲ ਅਪਵਾਦ ਦਾ ਕਾਰਨ ਬਣਦੇ ਹਨ, ਖਾਸ ਤੌਰ ਤੇ ਜੇਕਰ ਵੱਖ ਐਡ-ਆਨ ਵੱਖ-ਵੱਖ ਲਾਇਬਰ੍ਰੇਰੀ ਵਰਜਨਾਂ ਦੀ ਵਰਤੋਂ ਕਰਦੇ ਹੋਣ ਅਤੇ ਹੋਰ ਵੀ। ਡਿਵੈਲਪਰਾਂ ਨੂੰ ਇਹਨਾਂ ਦੀ ਵਰਤੋਂ ਕਰਦੇ ਸਮੇਂ "
+"ਬਹੁਤ ਹੀ ਸਾਵਧਾਨ ਰਹਿਣ ਦੀ ਲੋੜ ਹੈ। ਐਡ-ਆਨ ਬਣਾਉਣ ਲਈ ਮੌਜੀਲਾ ਇਹਨਾਂ ਦੀ ਵਰਤੋਂ ਕਰਨ ਬਾਰੇ ਦਸਤਾਵੇਜ਼ਾਂ ਦੀ ਪੇਸ਼ਕਸ ਨਹੀਂ ਕਰਦਾ।"
 
 #: src/olympia/pages/templates/pages/dev_faq.html:165
 msgid "How do I debug my add-on?"
@@ -9822,9 +9692,11 @@ msgstr "ਕੀ ਮੈਂ ਆਪਣੇ ਐਡ-ਆਨਾਂ ਦੀ ਮੇਜ਼ਬ
 #, python-format
 msgid ""
 "Yes. Many developers choose to host their own add-ons. Choosing to host your add-on on <a href=\"%(amo_url)s\">Mozilla's add-on site</a>, though, allows for much greater exposure to your add-on due "
-"to the large volume of visitors to the site.  <a href=\"%(md_url)s\">mozdev.org</a> offers free project hosting for Mozilla applications and extensions providing developers with tools to help "
-"manage source code, version control, bug tracking and documentation."
+"to the large volume of visitors to the site. <a href=\"%(md_url)s\">mozdev.org</a> offers free project hosting for Mozilla applications and extensions providing developers with tools to help manage "
+"source code, version control, bug tracking and documentation."
 msgstr ""
+"ਹਾਂ, ਬਹੁਤ ਸਾਰੇ ਡਿਵੈਲਪਰ ਆਪਣੇ ਐਡ-ਆਨਾਂ ਦੀ ਮੇਜ਼ਬਾਨੀ ਚੁਣਦੇ ਹਨ। <a href=\"%(amo_url)s\">ਮੌਜੀਲਾ ਐਡ-ਆਨ ਸਾਈਟ</a>ਤੇ ਆਪਣੇ ਐਡ-ਆਨਾਂ ਦੀ ਮੇਜ਼ਬਾਨੀ ਚੁਣਨਾ, ਪਰ , ਇਸ ਸਾਈਟ ਦੇ ਜਿਆਦਾ ਸੈਲਾਨੀਆਂ ਦੀ ਵਜ੍ਹਾ ਨਾਲ ਤੁਹਾਡਾ ਐਡ-ਆਨ ਨੂੰ ਜਿਆਦਾ ਪਛਾਣ ਦਵਾਉਂਦਾ ਹੈ। "
+"<a href=\"%(md_url)s\">mozdev.org</a> ਮੌਜੀਲਾ ਐਪਲੀਕੇਸ਼ਨਾਂ ਅਤੇ ਐਕਸਟੇਸ਼ਨਾਂ ਲਈ ਮੁਫ਼ਤ ਪ੍ਰੋਜੈਕਟ ਮੇਜ਼ਬਾਨੀ ਦੇ ਨਾਲ ਡਿਵੈਲਪਰਾਂ ਦੀ ਸੋਰਸ ਕੋਡ ਸੰਭਾਲਣ ਵਿੱਚ ਟੂਲਾਂ ਨਾਲ ਮਦਦ ਕਰਦਾ, ਵਰਜਨ ਕੰਟਰੋਲ, ਬਗ ਨਿਗਰਾਨੀ ਅਤੇ ਦਸਤਾਵੇਜ਼ ਮੁੱਹਈਆ ਕਰਵਾਉਂਦਾ ਹੈ।"
 
 #: src/olympia/pages/templates/pages/dev_faq.html:277
 msgid "Can Mozilla host my add-on?"
@@ -9873,9 +9745,11 @@ msgstr "ਪ੍ਰਵਾਨਿਤ ਦਾਖਲ ਕਾਰਜ ਕੀ ਹੈ ਕੀ 
 #: src/olympia/pages/templates/pages/dev_faq.html:314
 #, python-format
 msgid ""
-"Yes. Mozilla's <a href=\"%(p_url)s\">Add-on Policy</a> describes what is an acceptable submission. This policy is subject to change without notice.  In addition, the AMO editorial team uses the <a "
+"Yes. Mozilla's <a href=\"%(p_url)s\">Add-on Policy</a> describes what is an acceptable submission. This policy is subject to change without notice. In addition, the AMO editorial team uses the <a "
 "href=\"%(g_url)s\">Editors Reviewing Guide</a> to ensure that your add-on meets specific guidelines for functionality and security."
 msgstr ""
+"ਹਾਂ, ਮੌਜੀਲਾ ਦੀ <a href=\"%(p_url)s\">ਐਡ-ਆਨ ਨੀਤੀ</a> ਦੱਸਦੀ ਹੈ ਕੀ ਇੱਕ ਪ੍ਰਵਾਨਿਤ ਦਾਖਲ ਕਾਰਜ ਕੀ ਹੈ। ਇਸ ਨੀਤੀ ਬਿਨਾਂ ਸੂਚਨਾ ਦੇ ਬਦਲਾਅ ਦੇ ਅਧੀਨ ਹੈ, ਇਸ ਦੇ ਨਾਲ ਹੀ, AMO ਸੰਪਾਦਕੀ ਟੀਮ ਇਹ ਯਕੀਨੀ ਬਣਾਉਣ ਲਈ ਕੀ ਤੁਹਾਡਾ ਐਡ-ਆਣ  ਕਾਰਜਕਸ਼ਲਤਾ ਅਤੇ "
+"ਸੁਰੱਖਿਆ ਦੇ ਖਾਸ਼ ਦਿਸ਼ਾ-ਨਿਰਦੇਸ਼ਾਂ ਨੂੰ ਪੂਰੇ ਕਰਦਾ ਲਈ <a href=\"%(g_url)s\">ਸੰਪਾਦਕ ਸਮੀਖਿਆ ਗਾਈਡ</a> ਦੀ ਵਰਤੋਂ ਕਰਦੀ ਹੈ।"
 
 #: src/olympia/pages/templates/pages/dev_faq.html:324
 msgid "How do I submit my add-on for review?"
@@ -10000,9 +9874,11 @@ msgstr "ਖੋਜੇ ਗਏ ਖਾਮੀ ਖੇਤਰਾਂ ਦੀ ਗਿਣਤ�
 #: src/olympia/pages/templates/pages/dev_faq.html:434
 #, python-format
 msgid ""
-"This is why it's very important to read the <a href=\"%(g_url)s\">Editors Reviewing Guide</a> to ensure that your add-on is setup as expected.  It's also a good idea to read the blog post, <a href="
+"This is why it's very important to read the <a href=\"%(g_url)s\">Editors Reviewing Guide</a> to ensure that your add-on is setup as expected. It's also a good idea to read the blog post, <a href="
 "\"%(blog_url)s\">Successfully Getting your Add-on Reviewed</a> which provides excellent insight into ensuring a smooth review of your add-on."
 msgstr ""
+"ਇਹੀ ਕਾਰਨ ਹੈ ਕੀ <a href=\"%(g_url)s\">ਸੰਪਾਦਕੀ ਸਮੀਖਿਆ ਗਾਈਡ</a> ਨੂੰ ਪੜ੍ਹਨਾ ਲਾਜ਼ਮੀ ਹੈ ਇਹ ਯਕੀਨੀ ਬਣਾਉਣ ਲਈ ਕੀ ਤੁਹਾਡਾ ਐਡ-ਆਨ ਉਮੀਦ ਅਨੁਸਾਰ ਸੈੱਟ ਹੋਇਆ। <a href=\"%(blog_url)s\">ਆਪਣੇ ਐਡ-ਆਨ ਦੀ ਸਫ਼ਲਤਾਪੂਰਵਕ ਸਮੀਖਿਆ ਕਰਵਾਓ</a> ਬਲਾਗ "
+"ਪੋਸਟ ਨੂੰ ਪੜ੍ਹਨਾ ਇੱਕ ਵਧੀਆ ਤਰਕੀਬ ਹੈ, ਜੋ ਤੁਹਾਡੇ ਐਡ-ਆਨ ਦੀ ਇੱਕ ਨਿਰਵਿਘਨ ਸਮੀਖਿਆ ਯਕੀਨੀ ਬਣਾਉਣ ਲਈ ਉੱਤਮ ਸਮਝ ਦਿੰਦਾ ਹੈ।"
 
 #: src/olympia/pages/templates/pages/dev_faq.html:446
 msgid "How can I see how many times my add-on has been downloaded?"
@@ -10114,10 +9990,12 @@ msgstr "ਇੱਕ ਟੇਬਲ ਸੰਖੇਪ ਜਾਣਕਾਰੀ ਦਿੰ�
 
 #: src/olympia/pages/templates/pages/dev_faq.html:572
 msgid ""
-"Free Software Foundation provides short summaries of the key open source licenses, including whether the license qualifies as a free software license or a copyleft license.  Also includes a "
+"Free Software Foundation provides short summaries of the key open source licenses, including whether the license qualifies as a free software license or a copyleft license. Also includes a "
 "discussion of what constitutes a free software license or a copyleft license (e.g., a Copyleft license is a general method for making a program or other work free, and requiring all modified and "
 "extended versions of the program to be free as well.)"
 msgstr ""
+"ਮੁਫ਼ਤ ਸਾਫ਼ਟਵੇਅਰ ਸੰਸਥਾ ਖਾਸ਼ ਓਪਨ ਸੋਰਸ ਲਾਇਸੰਸਾਂ ਬਾਰੇ ਛੋਟੀਆਂ ਸੰਖੇਪ ਜਾਣਕਾਰੀਆਂ ਮੁਹੱਈਆ ਕਰਵਾਉਂਦੀ ਹੈ, ਭਾਵੇ ਲਾਇਸੰਸ ਇੱਕ ਮੁਫ਼ਤ ਸਾਫ਼ਟਵੇਅਰ ਲਾਇਸੰਸ ਜਾਂ ਕਾਪੀਲੇਫ਼ਟ ਲਾਇਸੰਸ ਦੇ ਤੌਰ ਤੇ ਕਾਬਲ ਹੋਵੇ ਨੂੰ ਸ਼ਾਮਲ ਕਰਦੇ ਹੋਏ। ਨਾਲ ਹੀ ਇੱਕ ਮੁਫ਼ਤ ਸਾਫ਼ਟਵੇਅਰ ਲਾਇਸੰਸ ਜਾਂ ਕਾਪੀਲੇਫ਼ਟ ਲਾਇਸੰਸ "
+"ਦਾ ਗਠਨ ਕੀ ਹੈ ਬਾਰੇ ਇੱਕ ਵਿਚਾਰ-ਚਰਚਾ ਸ਼ਾਮਲ ਕਰਦੇ ਹੋਏ (ਜਿਵੇਂ, ਕਾਪੀਲੇਫ਼ਟ ਲਾਇਸੰਸ ਇੱਕ ਪ੍ਰੋਗਰਾਮ ਜਾਂ ਹੋਰ ਕੰਮ ਨੂੰ, ਅਤੇ ਪ੍ਰੋਗਰਾਮ ਦੇ ਸਾਰੇ ਸੋਧ ਅਤੇ ਵਧਾਏ ਵਰਜਨਾਂ ਨੂੰ ਵੀ ਨਾਲ ਹੀ ਮੁਫ਼ਤ ਦੇਣ ਦਾ ਇੱਕ ਆਮ ਤਰੀਕਾ ਹੈ।)"
 
 #: src/olympia/pages/templates/pages/dev_faq.html:589
 msgid "Open Source Initiative provides the terms of some of the key open source licenses."
@@ -10313,20 +10191,16 @@ msgid "Add-on Gallery"
 msgstr "ਐਡ-ਆਨ ਗੈਲਰੀ"
 
 #: src/olympia/pages/templates/pages/faq.html:171
-msgid ""
-"How do I choose between add-ons that seem to do the same\n"
-"    thing?"
-msgstr ""
+msgid "How do I choose between add-ons that seem to do the same thing?"
+msgstr "ਮੈਂ ਇੱਕੋ ਜਿਹੇ ਕੰਮ ਕਰਨ ਵਾਲੇ ਐਡ-ਆਨਾਂ ਵਿੱਚੋਂ ਚੋਣ ਕਿਵੇਂ ਕਰਾਂ?"
 
-#: src/olympia/pages/templates/pages/faq.html:173
+#: src/olympia/pages/templates/pages/faq.html:172
 msgid ""
-"There are often several add-ons that have similar features. To\n"
-"    figure out which is right for you, read the entire description of the\n"
-"    add-on and view its screenshots. If there are still several in the running,\n"
-"    read through the add-on's ratings, user reviews, and statistics to see\n"
-"    which is most liked by other users. Remember that you can also just try\n"
-"    out both and see which you like better."
+"There are often several add-ons that have similar features. To figure out which is right for you, read the entire description of the add-on and view its screenshots. If there are still several in "
+"the running, read through the add-on's ratings, user reviews, and statistics to see which is most liked by other users. Remember that you can also just try out both and see which you like better."
 msgstr ""
+"ਇੱਥੇ ਆਮ ਕਰਕੇ ਕੁੱਝ ਐਡ-ਆਨ ਹਨ ਜਿਹਨਾਂ ਦੇ ਗੁਣ ਸਮਾਨ ਹਨ। ਇਹ ਸਮਝਣ ਕੀ ਤੁਹਾਡੇ ਲਈ ਕਿਹੜਾ ਠੀਕ ਹੈ, ਐਡ-ਆਨ ਦਾ ਪੂਰਾ ਵਰਣਨ ਪੜ੍ਹੋ ਅਤੇ ਉਸ ਦੇ ਸਕਰੀਨਸ਼ਾੱਟ ਵੇਖੋ। ਜੇਕਰ ਹਾਲੇ ਵਿੱਚ ਬਹੁਤ ਲੱਗ ਰਹੇ ਹਨ,  ਹੋਰਾਂ ਵੱਲੋਂ ਕਿਹੜਾ ਸੱਭ ਤੋਂ ਪਸੰਦ ਕੀਤਾ ਗਿਆ ਜਾਨਣ ਲਈ ਐਡ-ਆਨ ਦੀਆਂ "
+"ਰੇਟਿੰਗਾਂ, ਉਪਭੋਗੀਆਂ ਸਮੀਖਿਆਵਾਂ ਪੜ੍ਹੋ ਅਤੇ ਅੰਕੜੇ ਵੇਖੋ। ਯਾਦ ਰੱਖੋ ਤੁਸੀਂ ਦੋਵਾਂ ਨੂੰ ਪਰਖ ਦੇ ਵੇਖ ਸਕਦੇ ਹੋ ਅਤੇ ਵੇਖੋ ਤੁਹਾਨੂੰ ਕਿਹੜਾ ਪਸੰਦ ਆਉਂਦਾ।"
 
 #: src/olympia/pages/templates/pages/faq.html:180
 msgid "What if I can't find an add-on I'm looking for?"
@@ -10372,36 +10246,30 @@ msgid "How much do add-ons cost to purchase?"
 msgstr "ਐਡ-ਆਨਾਂ ਨੂੰ ਖਰੀਦਣ ਲਈ ਕਿੰਨੀ ਕੀਮਤ ਅਦਾ ਕਰਨੀ ਪਵੇਗੀ?"
 
 #: src/olympia/pages/templates/pages/faq.html:207
-msgid ""
-"Add-ons hosted in our gallery are free unless clearly marked\n"
-"    otherwise."
-msgstr ""
+msgid "Add-ons hosted in our gallery are free unless clearly marked otherwise."
+msgstr "ਸਾਡੀ ਗੈਲਰੀ ਵਿੱਚ ਮੇਜ਼ਬਾਨ ਕੀਤੇ ਐਡ-ਆਨ ਮੁਫ਼ਤ ਹਨ ਜਦ ਤੱਕ ਸਾਫ਼ ਤੌਰ ਤੇ ਅੰਕਿਤ ਨਾ ਕੀਤੇ ਹੋਵੇ।"
 
-#: src/olympia/pages/templates/pages/faq.html:210
+#: src/olympia/pages/templates/pages/faq.html:209
 msgid "What does it mean when an add-on asks for contributions?"
 msgstr "ਜਦੋਂ ਐਡ-ਆਨ ਯੋਗਦਾਨ ਬਾਰੇ ਪੁੱਛੇ ਇਸ ਤੋਂ ਕੀ ਭਾਵ ਹੈ?"
 
-#: src/olympia/pages/templates/pages/faq.html:211
+#: src/olympia/pages/templates/pages/faq.html:210
 msgid ""
-"Some add-on authors request users who enjoy an add-on to\n"
-"        contribute to its development by making a monetary contribution. These\n"
-"        contributions go directly to the developer unless a third party is\n"
-"        indicated, such as the non-profit Mozilla Foundation."
-msgstr ""
+"Some add-on authors request users who enjoy an add-on to contribute to its development by making a monetary contribution. These contributions go directly to the developer unless a third party is "
+"indicated, such as the non-profit Mozilla Foundation."
+msgstr "ਕੁੱਝ ਐਡ-ਆਨ ਲੇਖਕ ਉਪਭੋਗੀਆਂ ਨੂੰ ਜੋ ਐਡ-ਆਨ ਦਾ ਆਨੰਦ ਮਾਨ ਰਹੇ ਹੋਣ ਨੂੰ ਇਸ ਦੇ ਵਿਕਾਸ ਲਈ ਮਾਇਆ ਦੇ ਯੋਗਦਾਨ ਦੀ ਬੇਨਤੀ ਕਰਦੇ ਹਨ। ਇਹ ਯੋਗਦਾਨ ਸਿੱਧੇ ਡਿਵੈਲਪਰ ਨੂੰ ਜਾਂਦੇ ਹਨ ਜਦ ਤੱਕ ਕਿਸੇ ਤੀਜੀ ਧਿਰ ਬਾਰੇ ਨਾ ਦੱਸਿਆ ਹੋਵੇ, ਜਿਵੇਂ ਕਿ ਗੈਰ-ਮੁਨਾਫ਼ਾ ਮੌਜੀਲਾ ਸੰਸਥਾ।"
 
-#: src/olympia/pages/templates/pages/faq.html:216
+#: src/olympia/pages/templates/pages/faq.html:215
 msgid "What are beta add-ons?"
 msgstr "ਬੀਟਾ ਐਡ-ਆਨ ਕੀ ਹਨ?"
 
-#: src/olympia/pages/templates/pages/faq.html:218
+#: src/olympia/pages/templates/pages/faq.html:217
 msgid ""
-"Beta add-ons are unreviewed versions which represent the\n"
-"        latest work of an add-on author. While different authors have different\n"
-"        standards for beta code quality, you should assume that these add-ons\n"
-"        are less stable than the general add-on releases."
-msgstr ""
+"Beta add-ons are unreviewed versions which represent the latest work of an add-on author. While different authors have different standards for beta code quality, you should assume that these add-"
+"ons are less stable than the general add-on releases."
+msgstr "ਬੀਟਾ ਐਡ-ਆਨ ਬਿਨਾਂ-ਸਮੀਖਿਆ ਵਾਲੇ ਵਰਜਨ ਹਨ ਜੋ ਐਡ-ਆਨ ਲੇਖਕ ਦਾ ਤਾਜ਼ਾ ਕੰਮ ਦੀ ਨੁਮਾਇੰਦਗੀ ਕਰਦੇ ਹਨ। ਜਦ ਕਿ ਵੱਖ-ਵੱਖ ਲੇਖਕਾਂ ਲਈ ਬੀਟਾ ਕੋਡ ਗੁਣਵੱਤਾ ਮਾਣਕ ਵੱਖ-ਵੱਖ ਹਨ, ਤੁਹਾਨੂੰ ਇਹ ਮੰਨਣਾ ਚਾਹੀਦਾ ਕੀ ਇਹ ਐਡ-ਆਨ ਜਾਰੀ ਹੋਏ ਆਮ ਐਡ-ਆਨਾਂ ਨਾਲੋਂ ਘੱਟ ਸਥਿਰ ਹਨ।"
 
-#: src/olympia/pages/templates/pages/faq.html:222
+#: src/olympia/pages/templates/pages/faq.html:221
 msgid ""
 "Please note that when you install an add-on from the \"Beta Version\" section of an add-on's listing, you will continue to receive updates for that add-on as they become available. Like the initial "
 "version you installed, all beta releases are unreviewed by Mozilla and may harm your computer."
@@ -10409,45 +10277,40 @@ msgstr ""
 "ਕਿਰਪਾ ਕਰਕੇ ਨੋਟ ਕਰੋ ਜਦੋਂ ਤੁਸੀਂ ਐਡ-ਆਨ ਸੂਚੀ ਦੇ \"ਬੀਟਾ ਵਰਜਨ\" ਭਾਗ ਵਿੱਚੋਂ ਐਡ-ਆਨ ਇੰਸਟਾਲ ਕਰਦੇ ਹੋ, ਤੁਹਾਨੂੰ ਉਸ ਐਡ-ਆਨ ਲਈ ਲਗਾਤਾਰ ਅੱਪਡੇਟਾਂ ਪ੍ਰਾਪਤ ਹੁੰਦੀਆਂ ਰਹਿਣਗੀਆਂ ਜਿਵੇਂ ਹੀ ਉਹ ਉੱਪਲਬਧ ਹੋਣ। ਤੁਹਾਡੇ ਵੱਲੋਂ ਇੰਸਟਾਲ ਕੀਤੇ ਸ਼ੁਰੂਆਤੀ ਵਰਜਨ ਦੀ ਤਰ੍ਹਾਂ, ਬੀਟਾ ਰੀਲੀਜ਼ਾਂ ਦੀ "
 "ਮੌਜੀਲਾ ਵੱਲੋਂ ਸਮੀਖਿਆ ਨਹੀਂ ਕੀਤੀ ਗਈ ਅਤੇ ਤੁਹਾਡੇ ਕੰਪਿਊਟਰ ਦਾ ਨੁਕਸਾਨ ਹੋ ਸਕਦਾ।"
 
+#: src/olympia/pages/templates/pages/faq.html:228
+msgid "What does it mean when an add-on is flagged as slow?"
+msgstr "ਜਦੋਂ ਐਡ-ਆਨ ਤੇ \"ਹੌਲੀ\" ਦਾ ਨਿਸ਼ਾਨ ਲੱਗਿਆ ਹੋਵੇ ਇਸ ਤੋਂ ਕੀ ਭਾਵ ਹੈ?"
+
 #: src/olympia/pages/templates/pages/faq.html:229
-msgid ""
-"What does it mean when an add-on is flagged as\n"
-"    slow?"
+msgid "Most add-ons load code and resources at the same time Firefox is starting up. In most cases the impact in start-up time is minimal, but some add-ons can cause a noticeable slowdown."
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:231
-msgid ""
-"Most add-ons load code and resources at the same time Firefox\n"
-"        is starting up. In most cases the impact in start-up time is minimal,\n"
-"        but some add-ons can cause a noticeable slowdown."
-msgstr ""
-
-#: src/olympia/pages/templates/pages/faq.html:236
+#: src/olympia/pages/templates/pages/faq.html:234
 msgid "How do I report an inappropriate or spam user review?"
 msgstr "ਮੈਂ ਇੱਕ ਗਲਤ ਅਤੇ ਸਪੈਮ ਉਪਭੋਗੀ ਸਮੀਖਿਆ ਬਾਰੇ ਸੂਚਨਾ ਕਿਵੇਂ ਦਿਆਂ?"
 
-#: src/olympia/pages/templates/pages/faq.html:237
+#: src/olympia/pages/templates/pages/faq.html:235
 msgid ""
-"To report a user review of an add-on, log in with your account\n"
-"    and visit the add-on's reviews page. Find the review you wish to report,\n"
-"    click \"Report this review\" and select a reason. Our editorial team will\n"
-"    investigate the review and take appropriate action."
+"To report a user review of an add-on, log in with your account and visit the add-on's reviews page. Find the review you wish to report, click \"Report this review\" and select a reason. Our "
+"editorial team will investigate the review and take appropriate action."
 msgstr ""
+"ਐਡ-ਆਨ ਦੀ ਉਪਭੋਗੀ ਸਮੀਖਿਆ ਬਾਰੇ ਸੂਚਨਾ ਦੇਣ ਲਈ, ਆਪਣੇ ਖਾਤੇ ਨਾਲ ਲਾਗਇਨ ਹੋਵੋ ਅਤੇ ਐਡ-ਆਨ ਦੇ ਸਮੀਖਿਆ ਸਫ਼ੇ ਤੇ ਜਾਓ। ਸਮੀਖਿਆ ਲੱਭੋ ਜਿਸਦੀ ਤੁਸੀਂ ਸੂਚਨਾ ਦੇਣਾ ਚਾਹੁੰਦੇ ਹੋ, \"ਇਸ ਸਮੀਖਿਆ ਦੀ ਸੂਚਨਾ ਦਿਓ\" ਤੇ ਕਲਿੱਕ ਕਰੋ ਅਤੇ ਇੱਕ ਕਾਰਨ ਦੱਸੋ। ਸਾਡੀ ਸੰਪਾਦਕ ਟੀਮ ਸਮੀਖਿਆ "
+"ਦੀ ਜਾਂਚ ਅਤੇ ਵਾਜਬ ਕਾਰਵਾਈ ਕਰੇਗੀ।"
 
-#: src/olympia/pages/templates/pages/faq.html:242
+#: src/olympia/pages/templates/pages/faq.html:240
 msgid "How do I report a bug or contact the Mozilla Add-ons team?"
 msgstr "ਮੈਂ ਮੌਜੀਲਾ ਐਡ-ਆਨ ਟੀਮ ਨੂੰ ਸੰਪਰਕ ਕਰਾਂ ਜਾਂ ਬੱਗ ਸੂਚਨਾ ਕਿਵੇਂ ਦਿਆਂ?"
 
-#: src/olympia/pages/templates/pages/faq.html:243
+#: src/olympia/pages/templates/pages/faq.html:241
 #, python-format
 msgid "Please visit our <a href=\"%(contact_url)s\">Contact page</a>."
 msgstr "ਕਿਰਪਾ ਕਰਕੇ ਸਾਡੇ <a href=\"%(contact_url)s\">ਸੰਪਰਕ ਸਫ਼ਾ</a>ਤੇ ਜਾਓ।"
 
-#: src/olympia/pages/templates/pages/faq.html:246
+#: src/olympia/pages/templates/pages/faq.html:244
 msgid "What is a Source Code License?"
 msgstr "ਸੋਰਸ ਕੋਡ ਲਾਇਸੰਸ ਕੀ ਹੈ?"
 
-#: src/olympia/pages/templates/pages/faq.html:247
+#: src/olympia/pages/templates/pages/faq.html:245
 #, python-format
 msgid ""
 "The source code used to create an add-on is an exclusive copyright of the add-on author, unless otherwise declared in a source code license. Many add-ons on this site have <a href=\"%(url)s\" lang="
@@ -10457,40 +10320,40 @@ msgstr ""
 "ਐਡ-ਆਨ ਬਣਾਉਣ ਲਈ ਵਰਤਿਆ ਸੋਰਸ ਕੋਡ ਐਡ-ਆਨ ਲੇਖਕ ਦਾ ਇੱਕ ਉਚੇਚਾ ਕਾਪੀਰਾਈਟ ਹੈ, ਜਦ ਤੱਕ ਸੋਰਸ ਕੋਡ ਲਾਇਸੰਸ ਵਿੱਚ ਹੋਰ ਰੂਪ ਵਿੱਚ ਐਲਾਨਿਆ ਨਾ ਜਾਵੇ। ਇਸ ਸਾਈਤ ਦੇ ਬਹੁਤ ਸਾਰੇ ਐਡ-ਆਨਾਂ ਕੋਲ <a href=\"%(url)s\" lang=\"en\">ਓਪਨ ਸੋਰਸ ਲਾਇਸੰਸ</a> ਹਨ ਜੋ ਲੇਖਕ "
 "ਦੁਆਰਾ ਤੈਅ ਕੀਤੀਆਂ ਸ਼ਰਤਾਂ ਦੇ ਅਧੀਨ ਸੋਰਸ ਕੋਡ ਨੂੰ ਜਨਤਕ ਤੌਰ ਤੇ ਕਾਪੀ ਅਤੇ ਮੁੜ-ਵਰਤਣ ਲਈ ਉੱਪਲਬਧ ਕਰਵਾਉਂਦੇ ਹਨ। ਬਹੁਤ ਸਾਰੇ ਲੇਖਕ ਆਪਣੇ ਬਣਾਉਣ ਦੀ ਥਾਂ ਵਿਆਪਕ ਤੌਰ ਤੇ ਵਰਤੇ ਜਾਣੇ ਜਾਂਦੇ ਓਪਨ ਸੋਰਸ ਲਾਇਸੰਸਾਂ ਜਿਵੇਂ GPL ਜਾਂ BSD ਲਾਇਸੰਸਾਂ ਦੀ ਚੋਣ ਕਰਦੇ ਹਨ।"
 
-#: src/olympia/pages/templates/pages/faq.html:256
+#: src/olympia/pages/templates/pages/faq.html:254
 #, python-format
 msgid "Firefox and other Mozilla software are <a href=\"%(url)s\">open source</a>."
 msgstr "ਫ਼ਾਇਰਫ਼ਾਕਸ ਅਤੇ ਹੋਰ ਮੌਜੀਲਾ ਸਾਫ਼ਟਵੇਅਰ <a href=\"%(url)s\">ਓਪਨ ਸੋਰਸ</a>ਹਨ।"
 
-#: src/olympia/pages/templates/pages/faq.html:264
+#: src/olympia/pages/templates/pages/faq.html:262
 msgid "Collections and Favorites"
 msgstr "ਸੰਗ੍ਰਹਿ ਅਤੇ ਪਸੰਦੀਦਾ"
 
-#: src/olympia/pages/templates/pages/faq.html:267
+#: src/olympia/pages/templates/pages/faq.html:265
 msgid "What is a collection?"
 msgstr "ਸੰਗ੍ਰਹਿ ਕੀ ਹੈ?"
 
-#: src/olympia/pages/templates/pages/faq.html:268
+#: src/olympia/pages/templates/pages/faq.html:266
 msgid "Collections are groups of related add-ons created by users to share."
 msgstr "ਸੰਗ੍ਰਹਿ ਉਪਭੋਗੀਆਂ ਵੱਲੋਂ ਵੰਡਣ ਲਈ ਤਿਆਰ ਕੀਤੇ ਸਬੰਧਤ ਐਡ-ਆਨਾਂ ਦੇ ਗਰੁੱਪ ਹਨ।"
 
-#: src/olympia/pages/templates/pages/faq.html:270
+#: src/olympia/pages/templates/pages/faq.html:268
 msgid "What is the My Favorites collection?"
 msgstr "ਮੇਰੇ ਪੰਸਦੀਦਾ ਸੰਗ੍ਰਹਿ ਕੀ ਹੈ?"
 
-#: src/olympia/pages/templates/pages/faq.html:271
+#: src/olympia/pages/templates/pages/faq.html:269
 msgid "Favorite add-ons are add-ons that you have bookmarked to easily get back to later. You can add an add-on to your favorites collection by clicking \"Add to favorites\" on its details page."
 msgstr "ਪੰਸਦੀਦਾ ਐਡ-ਆਨ ਉਹ ਐਡ-ਆਨ ਹਨ ਜਿਹਨਾਂ ਨੂੰ ਤੁਸੀਂ ਅਸਾਨੀ ਨਾਲ ਵਾਪਸ ਆਉਣ ਲਈ ਬੁੱਕਮਾਰਕ ਕੀਤਾ ਹੋਇਆ। ਤੁਸੀਂ ਐਡ-ਆਨ ਨੂੰ ਉਸ ਦੇ ਵੇਰਵੇ ਸਫ਼ੇ ਤੇ \"ਪਸੰਦੀਦਾ ਵਿੱਚ ਜੋੋੜੋ\" ਤੇ ਕਲਿੱਕ ਕਰਕੇ ਐਡ-ਆਨ ਨੂੰ ਆਪਣੇ ਪਸੰਦੀਦਾ ਸੰਗ੍ਰਹਿ ਵਿੱਚ ਸ਼ਾਮਲ ਕਰ ਸਕਦੇ ਹੋ।"
 
-#: src/olympia/pages/templates/pages/faq.html:275 src/olympia/templates/menu_links.html:13 src/olympia/templates/impala/header_title.html:17
+#: src/olympia/pages/templates/pages/faq.html:273 src/olympia/templates/menu_links.html:13 src/olympia/templates/impala/header_title.html:17
 msgid "Mobile Add-ons"
 msgstr "ਮੋਬਾਈਲ ਐਡ-ਆਨ"
 
-#: src/olympia/pages/templates/pages/faq.html:278
+#: src/olympia/pages/templates/pages/faq.html:276
 msgid "What are mobile add-ons?"
 msgstr "ਮੋਬਾਈਲ ਐਡ-ਆਨ ਕੀ ਹਨ?"
 
-#: src/olympia/pages/templates/pages/faq.html:279
+#: src/olympia/pages/templates/pages/faq.html:277
 #, python-format
 msgid ""
 "Mobile add-ons work with <a href=\"%(mobile_url)s\">Firefox for Mobile</a> and add or modify functionality just like desktop add-ons. You can find add-ons that work with Firefox for Mobile in our "
@@ -10499,20 +10362,20 @@ msgstr ""
 "ਮੋਬਾਈਲ ਐਡ-ਆਨ <a href=\"%(mobile_url)s\">ਮੋਬਾਈਲ ਲਈ ਫ਼ਾਇਰਫ਼ਾਕਸ</a> ਨਾਲ ਕੰਮ ਕਰਦੇ ਅਤੇ ਡੈਸਕਟੋਪ ਐਡ-ਆਨਾਂ ਦੀ ਤਰ੍ਹਾਂ ਕਾਰਜਕੁਸ਼ਲਤਾ ਨੂੰ ਸ਼ਾਮਲ ਜਾਂ ਵਧਾਉਂਦੇ ਹਨ। ਸਾਡੀ <a href=\"%(gallery_url)s\">ਗੈਲਰੀ</a> ਵਿੱਚ ਤੁਸੀਂ ਮੋਬਾਈਲ ਫ਼ਾਇਰਫ਼ਾਕਸ ਨਾਲ ਕੰਮ "
 "ਕਰਨ ਵਾਲੇ ਐਡ-ਆਨ ਲੱਭ ਸਕਦੇ ਹੋ।"
 
-#: src/olympia/pages/templates/pages/faq.html:288
+#: src/olympia/pages/templates/pages/faq.html:286
 msgid "Developer Topics"
 msgstr "ਡਿਵੈਲਪਰ ਵਿਸ਼ੇ"
 
-#: src/olympia/pages/templates/pages/faq.html:289
+#: src/olympia/pages/templates/pages/faq.html:287
 #, python-format
 msgid "Please see our <a href=\"%(faq_url)s\">Developer FAQ</a> and <a href=\"%(hub_url)s\">Developer Hub</a> for answers to add-on developer-related questions."
 msgstr " ਡਿਵੈਲਪਰ-ਸਬੰਧਤ ਸਵਾਲਾਂ ਦੇ ਜਵਾਬਾਂ ਲਈ ਕਿਰਪਾ ਕਰਕੇ ਸਾਡਾ <a href=\"%(faq_url)s\">ਡਿਵੈਲਪਰ FAQ</a> ਅਤੇ <a href=\"%(hub_url)s\">ਡਿਵੈਲਪਰ ਹੱਬ</a> ।"
 
-#: src/olympia/pages/templates/pages/faq.html:294
+#: src/olympia/pages/templates/pages/faq.html:292
 msgid "Still have questions?"
 msgstr "ਹਾਲੇ ਵੀ ਸਵਾਲ ਹਨ?"
 
-#: src/olympia/pages/templates/pages/faq.html:295
+#: src/olympia/pages/templates/pages/faq.html:293
 #, python-format
 msgid "For general Firefox support, visit our <a href=\"%(sumo_url)s\">support website</a>. For general add-on and website questions, visit our <a href=\"%(forum_url)s\">forum</a>."
 msgstr "ਫ਼ਾਇਰਫ਼ਾਕਸ ਆਮ ਸਹਿਯੋਗ ਲਈ, ਸਾਡੀ <a href=\"%(sumo_url)s\">ਸਹਿਯੋਗ ਵੈੱਬਸਾਈਟ</a>ਤੇ ਜਾਓ। ਆਮ ਫ਼ਾਇਰਫ਼ਾਕਸ ਐਡ-ਆਨ ਅਤੇ ਵੈੱਬਸਾਈਟ ਸਵਾਲਾਂ ਲਈ, ਸਾਡੀ <a href=\"%(forum_url)s\">ਫ਼ੋਰਮ</a>ਤੇ ਜਾਓ।"
@@ -10657,9 +10520,10 @@ msgstr "ਸਨਬਰਡ ਰਿਟਾਇਰ ਹੋ ਗਿਆ"
 
 #: src/olympia/pages/templates/pages/sunbird.html:29
 msgid ""
-"Development on the Sunbird project has halted and its final release was on March 30, 2010.  We've been proud to host Sunbird add-ons on this site but as the project is no longer maintained we have "
+"Development on the Sunbird project has halted and its final release was on March 30, 2010. We've been proud to host Sunbird add-ons on this site but as the project is no longer maintained we have "
 "disabled our support for the add-ons."
 msgstr ""
+"ਸਨਬਰਡ ਪ੍ਰੋਜੈਕਟਾਂ ਦਾ ਵਿਕਾਸ ਬੰਦ ਕਰ ਦਿੱਤਾ ਗਿਆ ਅਤੇ ਇਸ ਦੀ ਆਖਰੀ ਰੀਲੀਜ਼ ਮਾਰਚ 30, 2010 ਨੂੰ ਸੀ। ਅਸੀਂ ਸਨਬਰਡ ਐਡ-ਆਨਾਂ ਦੀ ਇਸ ਸਾਈਟ ਤੇ ਮੇਜ਼ਬਾਨੀ ਕਰਨ ਤੇ ਮਾਣ ਮਹਿਸੂਸ ਕਰਦੇ ਹਾਂ ਪਰ ਪ੍ਰੋਜੈਕਟ ਹੁਣ ਬੰਦ ਹੋਣ ਕਾਰਨ ਅਸੀਂ ਐਡ-ਆਨ ਲਈ ਆਪਣਾ ਸਹਿਯੋਗ ਬੰਦ ਕਰ ਚੁੱਕੇ ਹਾਂ।"
 
 #: src/olympia/pages/templates/pages/sunbird.html:38
 #, python-format
@@ -10735,11 +10599,15 @@ msgstr "{0} ਲਈ ਇੱਕ ਸਮੀਖਿਆ ਜੋੜੋ"
 #, python-format
 msgid ""
 "<h2>Keep these tips in mind:</h2> <ul> <li> Write like you're telling a friend about your experience with the add-on. Give specifics and helpful details, such as what features you liked and/or "
-"disliked, how easy to use it is, and any disadvantages it has.  Avoid generic language such as calling it \"Great\" or \"Bad\" unless you can give reasons why you believe this is so. </li> <li> "
+"disliked, how easy to use it is, and any disadvantages it has. Avoid generic language such as calling it \"Great\" or \"Bad\" unless you can give reasons why you believe this is so. </li> <li> "
 "Please do not post bug reports in reviews. We do not make your email address available to add-on developers and they may need to contact you to help resolve your issue. See the <a href=\"%(support)s"
 "\">support section</a> to find out where to get assistance for this add-on. </li> <li>Please keep reviews clean, avoid the use of improper language and do not post any personal information. </li> </"
 "ul> <p>Please read the <a href=\"%(guide)s\" target=\"_blank\">Review Guidelines</a> for more detail about user add-on reviews.</p>"
 msgstr ""
+"<h2>ਇਹਨਾਂ ਨੁਕਤਿਆਂ ਨੂੰ ਧਿਆਨ ਵਿੱਚ ਰੱਖੋ:</h2> <ul> <li> ਇਵੇਂ ਲਿਖੋ ਜਿਵੇਂ ਤੁਸੀਂ ਆਪਣੇ ਮਿੱਤਰ ਨੂੰ ਇਸ ਐਡ-ਆਨ ਨਾਲ ਆਪਣੇ ਅਨੁਭਵ ਬਾਰੇ ਦੱਸ ਰਹੇ ਹੋਵੋ। ਖਾਸ਼ ਅਤੇ ਲਾਭਕਾਰੀ ਵੇਰਵੇ ਦਿਓ, ਜਿਵੇਂ ਕਿ ਤੁਸੀਂ ਕਿਹੜੇ ਗੁਣ ਪਸੰਦ ਅਤੇ/ਜਾਂ ਨਾਪਸੰਦ ਹਨ,ਇਸ ਨੂੰ ਵਰਤਣਾ ਕਿੰਨਾ ਸੌਖਾ ਹੈ, ਅਤੇ ਇਸ "
+"ਦੇ ਕੀ ਨੁਕਸਾਨ ਹਨ। ਆਮ ਭਾਸ਼ਾ ਦੀ ਵਰਤੋਂ ਤੋਂ ਬਚੋ ਜਿਵੇਂ ਕਹਿਣਾ \"ਮਹਾਨ\" ਜਾਂ \"ਬੁਰਾ\" ਜਦ ਤੱਕ ਤੁਸੀਂ ਕਾਰਨ ਨਾ ਦਿਓ ਕੀ ਤੁਹਾਨੂੰ ਇਹ ਏਦਾਂ ਦਾ ਕਿਉਂ ਲੱਗਦਾ। </li> <li> ਕਿਰਪਾ ਕਰਕੇ ਸਮੀਖਿਆਵਾਂ ਵਿੱਚ ਬੱਗ ਸੂਚਨਾਵਾਂ ਪੋਸਟ ਨਾ ਕਰੋ। ਅਸੀਂ ਤੁਹਾਡਾ ਈਮੇਲ ਪਤਾ ਐਡ-ਆਨ "
+"ਡਿਵੈਲਪਰਾਂ ਨੂੰ ਉੱਪਲਬਧ ਨਹੀਂ ਕਰਵਾਉਂਦੇ ਅਤੇ ਹੋ ਸਕਦਾ ਉਹਨਾਂ ਨੂੰ ਤੁਹਾਡੇ ਮਸਲੇ ਨੂੰ ਹੱਲ ਕਰਨ ਲਈ ਤੁਹਾਨੂੰ ਸੰਪਰਕ ਕਰਨ ਦੀ ਲੋੜ ਪਵੇ। ਇਸ ਐਡ-ਆਨ ਲਈ ਸਹਾਇਤਾ ਕਿੱਥੇ ਲਈਏ ਲੱਭਣ ਲਈ <a href=\"%(support)s\">ਸਹਿਯੋਗ ਭਾਗ</a> ਵੇਖੋ। </li> <li>ਕਿਰਪਾ ਕਰਕੇ ਸਮੀਖਿਆ ਨੂੰ ਸਾਫ਼ "
+"ਰੱਖੋ, ਗਲਤ ਭਾਸ਼ਾ ਦੀ ਵਰਤੋਂ ਤੋਂ ਬਚੋ ਅਤੇ ਕੋਈ ਵੀ ਨਿੱਜੀ ਜਾਣਕਾਰੀ ਪੋਸਟ ਨਾ ਕਰੋ। </li> </ul> <p>ਉਪਭੋਗੀ ਐਡ-ਆਨ ਸਮੀਖਿਆਵਾਂ ਬਾਰੇ ਹੋਰ ਵੇਰਵੇ ਲਈ ਕਿਰਪਾ ਕਰਕੇ <a href=\"%(guide)s\" target=\"_blank\">ਸਮੀਖਿਆ ਦਿਸ਼ਾ-ਨਿਰਦੇਸ਼</a> ਪੜੋ</p>"
 
 #: src/olympia/reviews/templates/reviews/reply.html:4
 msgid "Reply to review by {0}"
@@ -10971,16 +10839,16 @@ msgstr "{0} ਐਡ-ਆਨ"
 
 #. L10n: {0} is an application, such as Firefox. This means "any version of
 #. Firefox."
-#: src/olympia/search/views.py:554
+#: src/olympia/search/views.py:547
 msgid "Any {0}"
 msgstr "ਕੋਈ {0}"
 
 #. L10n: "All Systems" means show everything regardless of platform.
-#: src/olympia/search/views.py:589
+#: src/olympia/search/views.py:582
 msgid "All Systems"
 msgstr "ਸਾਰੇ ਸਿਸਟਮ"
 
-#: src/olympia/search/views.py:600
+#: src/olympia/search/views.py:593
 msgid "All Tags"
 msgstr "ਸਾਰੇ ਟੈਗ"
 
@@ -11154,31 +11022,31 @@ msgstr "ਇਸ ਐਡ-ਆਨ ਨੂੰ ਸਾਂਝਾ ਕਰੋ"
 msgid "Share this Collection"
 msgstr "ਇਸ ਸੰਗ੍ਰਹਿ ਨੂੰ ਸਾਂਝਾ ਕਰੋ"
 
-#: src/olympia/signing/views.py:30 src/olympia/templates/base.html:75 src/olympia/templates/impala/base.html:115
+#: src/olympia/signing/views.py:33 src/olympia/templates/base.html:71 src/olympia/templates/impala/base.html:112
 msgid "Some features are temporarily disabled while we perform website maintenance. We'll be back to full capacity shortly."
 msgstr "ਕੁੱਝ ਗੁਣ ਅਸਥਾਈ ਤੌਰ ਤੇ ਬੰਦ ਹਨ ਜਦੋਂ ਤੱਕ ਅਸੀਂ ਵੈੱਬਸਾਈਟ ਦੀ ਸਾਂਭ-ਸੰਭਾਲ ਕਰ ਰਹੇ ਹਾਂ। ਅਸੀਂ ਥੋੜੇ ਸਮੇਂ ਵਿੱਚ ਪੂਰੀ ਸਮਰਥਾ ਨਾਲ ਵਾਪਸ ਆਵਾਂਗੇ।"
 
-#: src/olympia/signing/views.py:53
+#: src/olympia/signing/views.py:56
 msgid "Could not find add-on with id \"{}\"."
 msgstr ""
 
-#: src/olympia/signing/views.py:67
+#: src/olympia/signing/views.py:70
 msgid "You do not own this addon."
 msgstr ""
 
-#: src/olympia/signing/views.py:82
+#: src/olympia/signing/views.py:87
 msgid "Missing \"upload\" key in multipart file data."
 msgstr ""
 
-#: src/olympia/signing/views.py:96
+#: src/olympia/signing/views.py:101
 msgid "Version does not match the manifest file."
 msgstr ""
 
-#: src/olympia/signing/views.py:100
+#: src/olympia/signing/views.py:105
 msgid "Version already exists."
 msgstr ""
 
-#: src/olympia/signing/views.py:136
+#: src/olympia/signing/views.py:141
 msgid "No uploaded file for that addon and version."
 msgstr ""
 
@@ -11291,89 +11159,89 @@ msgstr "{0} :: ਅੰਕੜੇ ਡੈਸਬੋਰਡ"
 msgid "Statistics Dashboard :: Add-ons for {0}"
 msgstr "ਅੰਕੜੇ ਡੈਸਬੋਰਡ :: {0} ਲਈ ਐਡ-ਆਨ"
 
-#: src/olympia/stats/templates/stats/stats.html:30
-msgid "Controls:"
-msgstr "ਕੰਟਰੋਲ:"
-
-#: src/olympia/stats/templates/stats/stats.html:33
-msgid "reset zoom"
-msgstr "ਜ਼ੂਮ ਰੀਸੈੱਟ"
-
-#: src/olympia/stats/templates/stats/stats.html:40
-msgid "Group by:"
-msgstr "ਗਰੁੱਪ ਦੁਆਰਾ:"
-
-#: src/olympia/stats/templates/stats/stats.html:42
-msgid "day"
-msgstr "ਦਿਨ"
-
-#: src/olympia/stats/templates/stats/stats.html:45
-msgid "week"
-msgstr "ਹਫ਼ਤਾ"
-
-#: src/olympia/stats/templates/stats/stats.html:48
-msgid "month"
-msgstr "ਮਹੀਨਾ"
-
-#: src/olympia/stats/templates/stats/stats.html:54
-msgid "For last:"
-msgstr "ਲਈ ਆਖਰੀ:"
-
-#: src/olympia/stats/templates/stats/stats.html:57
-msgid "7 days"
-msgstr "7 ਦਿਨਾਂ"
-
-#: src/olympia/stats/templates/stats/stats.html:60
-msgid "30 days"
-msgstr "30 ਦਿਨਾਂ"
-
-#: src/olympia/stats/templates/stats/stats.html:63
-msgid "90 days"
-msgstr "90 ਦਿਨਾਂ"
-
-#: src/olympia/stats/templates/stats/stats.html:66
-msgid "365 days"
-msgstr "365 ਦਿਨਾਂ"
-
-#: src/olympia/stats/templates/stats/stats.html:69
-msgid "Custom..."
-msgstr "ਪਸੰਦੀਦਾ..."
-
 #. {0} is an add-on name
-#: src/olympia/stats/templates/stats/stats.html:88 src/olympia/stats/templates/stats/stats.html:91
+#: src/olympia/stats/templates/stats/stats.html:44 src/olympia/stats/templates/stats/stats.html:47
 msgid "Statistics for {0}"
 msgstr "{0} ਲਈ ਅੰਕੜੇ"
 
-#: src/olympia/stats/templates/stats/stats.html:94
+#: src/olympia/stats/templates/stats/stats.html:50
 msgid "Statistics Dashboard"
 msgstr "ਅੰਕੜੇ ਡੈਸਬੋਰਡ"
 
-#: src/olympia/stats/templates/stats/stats.html:104
+#: src/olympia/stats/templates/stats/stats.html:57
+msgid "Controls:"
+msgstr "ਕੰਟਰੋਲ:"
+
+#: src/olympia/stats/templates/stats/stats.html:60
+msgid "reset zoom"
+msgstr "ਜ਼ੂਮ ਰੀਸੈੱਟ"
+
+#: src/olympia/stats/templates/stats/stats.html:67
+msgid "Group by:"
+msgstr "ਗਰੁੱਪ ਦੁਆਰਾ:"
+
+#: src/olympia/stats/templates/stats/stats.html:69
+msgid "day"
+msgstr "ਦਿਨ"
+
+#: src/olympia/stats/templates/stats/stats.html:72
+msgid "week"
+msgstr "ਹਫ਼ਤਾ"
+
+#: src/olympia/stats/templates/stats/stats.html:75
+msgid "month"
+msgstr "ਮਹੀਨਾ"
+
+#: src/olympia/stats/templates/stats/stats.html:81
+msgid "For last:"
+msgstr "ਲਈ ਆਖਰੀ:"
+
+#: src/olympia/stats/templates/stats/stats.html:84
+msgid "7 days"
+msgstr "7 ਦਿਨਾਂ"
+
+#: src/olympia/stats/templates/stats/stats.html:87
+msgid "30 days"
+msgstr "30 ਦਿਨਾਂ"
+
+#: src/olympia/stats/templates/stats/stats.html:90
+msgid "90 days"
+msgstr "90 ਦਿਨਾਂ"
+
+#: src/olympia/stats/templates/stats/stats.html:93
+msgid "365 days"
+msgstr "365 ਦਿਨਾਂ"
+
+#: src/olympia/stats/templates/stats/stats.html:96
+msgid "Custom..."
+msgstr "ਪਸੰਦੀਦਾ..."
+
+#: src/olympia/stats/templates/stats/stats.html:106
 msgid "Statistics processing is currently disabled, so recent data is unavailable. The statistics are still being collected and this page will be updated soon with the missing data."
 msgstr ""
 
-#: src/olympia/stats/templates/stats/stats.html:110
+#: src/olympia/stats/templates/stats/stats.html:112
 msgid "Loading the latest data&hellip;"
 msgstr "ਤਾਜ਼ਾ ਡਾਟਾ ਲੋਡ ਕਰ ਰਿਹਾ&hellip;"
 
-#: src/olympia/stats/templates/stats/stats.html:142 src/olympia/stats/templates/stats/reports/overview.html:25 src/olympia/stats/templates/stats/reports/overview.html:37
+#: src/olympia/stats/templates/stats/stats.html:144 src/olympia/stats/templates/stats/reports/overview.html:25 src/olympia/stats/templates/stats/reports/overview.html:37
 #: src/olympia/stats/templates/stats/reports/overview.html:49
 msgid "No data available."
 msgstr "ਕੋਈ ਡਾਟਾ ਮੌਜੂਦ ਨਹੀਂ।"
 
-#: src/olympia/stats/templates/stats/stats.html:177
+#: src/olympia/stats/templates/stats/stats.html:179
 msgid "This dashboard is currently <b>public</b>."
 msgstr "ਇਹ ਡੈਸਬੋਰਡ ਮੌਜੂਦਾ ਤੌਰ ਤੇ <b>ਜਨਤਕ</b>ਹੈ।"
 
-#: src/olympia/stats/templates/stats/stats.html:179
+#: src/olympia/stats/templates/stats/stats.html:181
 msgid "Contribution stats are currently <b>private</b>."
 msgstr "ਯੋਗਦਾਨ ਅੰਕੜੇ ਮੌਜੂਦਾ ਤੌਰ ਤੇ <b>ਨਿੱਜੀ</b>ਹਨ।"
 
-#: src/olympia/stats/templates/stats/stats.html:182
+#: src/olympia/stats/templates/stats/stats.html:184
 msgid "This dashboard is currently <b>private</b>."
 msgstr "ਇਹ ਡੈਸਬੋਰਡ ਮੌਜੂਦਾ ਤੌਰ ਤੇ <b>ਜਨਤਕ</b> ਹੈ।"
 
-#: src/olympia/stats/templates/stats/stats.html:185
+#: src/olympia/stats/templates/stats/stats.html:187
 msgid "Change settings."
 msgstr "ਸੈਟਿੰਗ ਬਦਲੋ।"
 
@@ -11533,15 +11401,6 @@ msgstr "ਉਪਭੋੋਗੀ ਸਾਇਨ-ਅਪ ਮਿਤੀ ਅਨੁਸਾ�
 msgid "Application versions by Date"
 msgstr "ਐਪਲੀਕੇਸ਼ਨ ਵਰਜਨ ਮਿਤੀ ਅਨੁਸਾਰ"
 
-#: src/olympia/tags/templates/tags/top_cloud.html:4
-msgid "Top {0} Tags"
-msgstr "ਚੋਟੀ ਦੇ {0} ਟੈਗ"
-
-#. {0} is the current application name
-#: src/olympia/tags/templates/tags/top_cloud.html:14
-msgid "{0} Top Tags"
-msgstr "{0} ਚੋਟੀ ਦੇ ਟੈਗ"
-
 #: src/olympia/templates/amo_footer.html:6 src/olympia/templates/includes/lang_switcher.html:2
 msgid "Other languages"
 msgstr "ਹੋਰ ਭਾਸ਼ਾਵਾਂ"
@@ -11550,11 +11409,11 @@ msgstr "ਹੋਰ ਭਾਸ਼ਾਵਾਂ"
 msgid "Mozilla Add-ons"
 msgstr "ਮੌਜੀਲਾ ਐਡ-ਆਨ"
 
-#: src/olympia/templates/base.html:91 src/olympia/templates/impala/base.html:81
+#: src/olympia/templates/base.html:89 src/olympia/templates/impala/base.html:78
 msgid "Find add-ons for other applications"
 msgstr "ਹੋਰ ਐਪਲੀਕੇਸ਼ਨਾਂ ਲਈ ਐਡ-ਆਨ ਖੋਜੋ"
 
-#: src/olympia/templates/base.html:92 src/olympia/templates/impala/base.html:81
+#: src/olympia/templates/base.html:90 src/olympia/templates/impala/base.html:78
 msgid "Other Applications"
 msgstr "ਹੋਰ ਐਪਲੀਕੇਸ਼ਨਾਂ"
 
@@ -11579,7 +11438,7 @@ msgid "View Mobile Site"
 msgstr "ਮੋਬਾਈਲ ਸਾਈਟ ਵੇਖੋ"
 
 #: src/olympia/templates/copyright.html:7
-msgid "Site Status "
+msgid "Site Status"
 msgstr ""
 
 #: src/olympia/templates/footer.html:3
@@ -11679,35 +11538,35 @@ msgstr "ਜੀ ਆਇਆ ਨੂੰ, {0}"
 msgid "<a href=\"%(reg)s\">Register</a> or <a href=\"%(login)s\">Log in</a>"
 msgstr "<a href=\"%(reg)s\">ਦਰਜ ਹੋਵੇ</a> ਜਾਂ <a href=\"%(login)s\">ਲਾਗ ਇਨ</a>"
 
-#: src/olympia/templates/impala/base.html:126
+#: src/olympia/templates/impala/base.html:123
 #, python-format
 msgid "To try the thousands of add-ons available here, download <a href=\"%(url)s\">Mozilla Firefox</a>, a fast, free way to surf the Web!"
 msgstr "ਇੱਥੇ ਮੌਜੂਦ ਹਜ਼ਾਰਾਂ ਐਡ-ਆਨ ਵਰਤਣ ਲਈ , ਡਾਊਨਲੋਡ<a href=\"%(url)s\">ਮੋਜ਼ੀਲਾ ਫਾਇਰਫਾਕਸ</a>,ਇੱਕ ਤੇਜ , ਆਜ਼ਾਦ ਜਰੀਆ ਵੈਬ ਵਰਤੋਂ ਲਈ!"
 
-#: src/olympia/templates/impala/base.html:138
+#: src/olympia/templates/impala/base.html:135
 #, python-format
 msgid "Add-ons is switching to Firefox Accounts for login. <a href=\"%(url)s\" class=\"fxa-login\">Sign in now to transfer your account.</a>"
 msgstr ""
 
 #. {0} is an application, such as Firefox.
-#: src/olympia/templates/impala/base.html:148
+#: src/olympia/templates/impala/base.html:145
 msgid "Welcome to {0} Add-ons."
 msgstr "{0} ਐਡ-ਆਨ ਵਿੱਚ ਸਵਾਗਤ |"
 
-#: src/olympia/templates/impala/base.html:151
+#: src/olympia/templates/impala/base.html:148
 msgid "Choose from thousands of extra features and styles to make Firefox your own."
 msgstr "ਫਾਇਰਫਾਕਸ ਨੂੰ ਆਪਣਾ ਬਣਾਉਣ ਲਈ ਹਜ਼ਾਰਾਂ ਵਾਧੂ ਪੇਸ਼ਕਸਾਂ ਅਤੇ ਅੰਦਾਜ਼ਾਂ ਵਿੱਚੋ ਚੁਣੋ।"
 
-#: src/olympia/templates/impala/base.html:156
+#: src/olympia/templates/impala/base.html:153
 #, python-format
 msgid "Add extra features and styles to make %(app)s your own."
 msgstr "%(app)s ਨੂੂੰ ਆਪਣਾ ਬਣਾਉਣ ਲਈ ਵਾਧੂ ਪੇਸ਼ਕਸਾਂ ਅਤੇ ਅੰਦਾਜਾਂ ਨੂੰ ਜੋੜੋ।"
 
-#: src/olympia/templates/impala/base.html:164
+#: src/olympia/templates/impala/base.html:161
 msgid "On the go?"
 msgstr "ਕਿਰਿਆਸ਼ੀਲ?"
 
-#: src/olympia/templates/impala/base.html:166
+#: src/olympia/templates/impala/base.html:163
 msgid "Check out our <a class=\"mobile-link\" href=\"#\">Mobile Add-ons site</a>."
 msgstr "ਵੇਖੋ ਸਾਡੀ<a class=\"mobile-link\"href=\"#\">ਮੋਬਾਈਲ ਐਡ-ਆਨ ਸਾਈਟ</a>"
 
@@ -11931,19 +11790,19 @@ msgstr "ਇਸ ਈਮੇਲ ਨਾਲ ਕੋਈ ਉਪਭੋਗੀ ਨਹੀਂ�
 
 #. L10n: {id} will be something like "13ad6a", just a random number
 #. to differentiate this user from other anonymous users.
-#: src/olympia/users/models.py:353
+#: src/olympia/users/models.py:362
 msgid "Anonymous user {id}"
 msgstr ""
 
-#: src/olympia/users/models.py:410
+#: src/olympia/users/models.py:419
 msgid "Your account has been restricted"
 msgstr "ਤੁਹਾਡਾ ਖਾਤਾ ਸੀਮਿਤ ਕੀਤਾ ਗਿਆ"
 
-#: src/olympia/users/models.py:480
+#: src/olympia/users/models.py:489
 msgid "Please confirm your email address"
 msgstr "ਕਿਰਪਾ ਕਰਕੇ ਆਪਣੇ ਈਮੇਲ ਖਾਤੇ ਦੀ ਪੁਸ਼ਟੀ ਕਰੋ"
 
-#: src/olympia/users/models.py:506
+#: src/olympia/users/models.py:515
 msgid "My Mobile Add-ons"
 msgstr "ਮੇਰੇ ਮੋਬਾਈਲ ਐਡ-ਆਨ"
 
@@ -12224,8 +12083,8 @@ msgstr "ਪਾਸਵਰਡ"
 
 #: src/olympia/users/templates/users/edit.html:70
 #, python-format
-msgid "Change your password.  If you forgot your password, you can <a href=\"%(reset_url)s\">use the reset form</a>."
-msgstr ""
+msgid "Change your password. If you forgot your password, you can <a href=\"%(reset_url)s\">use the reset form</a>."
+msgstr "ਆਪਣਾ ਪਾਸਵਰਡ ਬਦਲੋ। ਜੇਕਰ ਤੁਸੀਂ ਪਾਸਵਰਡ ਭੁੱਲ ਗਏ ਹੋ, ਤੁਸੀਂ <a href=\"%(reset_url)s\">ਰੀਸੈੱਟ ਫ਼ਾਰਮ ਦੀ ਵਰਤੋਂ</a>ਕਰ ਸਕਦੇ ਹੋ।"
 
 #: src/olympia/users/templates/users/edit.html:76
 msgid "Old Password"
@@ -12244,8 +12103,8 @@ msgid "Profile"
 msgstr "ਪ੍ਰੋਫ਼ਾਈਲ"
 
 #: src/olympia/users/templates/users/edit.html:100
-msgid "Give us a bit more information about yourself.  All these fields are optional, but they'll help other users get to know you better."
-msgstr ""
+msgid "Give us a bit more information about yourself. All these fields are optional, but they'll help other users get to know you better."
+msgstr "ਸਾਨੂੰ ਆਪਣੇ ਬਾਰੇ ਥੋੜੀ ਹੋਰ ਜਾਣਕਾਰੀ ਦਿਓ। ਇਹ ਸਾਰੇ ਖੇਤਰ ਚੋਣਵੇਂ ਹਨ, ਪਰ ਇਹ ਦੂਜੇ ਉਪਭੋਗੀਆਂ ਲਈ ਤੁਹਾਡੇ ਬਾਰੇ ਜਾਨਣ ਵਿੱਚ ਸਹਾਇਕ ਹੋਣਗੇ।"
 
 #: src/olympia/users/templates/users/edit.html:124
 msgid "This URL will only be visible if you are a developer."
@@ -12460,8 +12319,8 @@ msgid "Confirm password"
 msgstr "ਪਾਸਵਰਡ ਪੁਸ਼ਟੀ"
 
 #: src/olympia/users/templates/users/pwreset_confirm.html:47
-msgid "The password reset link was invalid, possibly because it has already been used.  Please request a new password reset."
-msgstr ""
+msgid "The password reset link was invalid, possibly because it has already been used. Please request a new password reset."
+msgstr "ਪਾਸਵਰਡ ਰੀਸੈੱਟ ਲਿੰਕ ਗਲਤ ਸੀ, ਕਿਉਂਕਿ ਇਹ ਪਹਿਲਾਂ ਹੀ ਵਰਤਿਆ ਜਾ ਚੁੱਕਿਆ। ਕਿਰਪਾ ਕਰਕੇ ਨਵੇਂ ਪਾਸਵਰਡ ਰੀਸੈੱਟ ਦੀ ਬੇਨਤੀ ਕਰੋ।"
 
 #: src/olympia/users/templates/users/pwreset_request.html:15
 msgid "Forgotten your password? Enter your e-mail address below, and we'll e-mail instructions for setting a new one."
@@ -12648,8 +12507,8 @@ msgstr "ਅਸੀਂ ਤੁਹਾਡੀ ਗਾਹਕੀ ਰੱਦ ਨਹੀਂ �
 
 #: src/olympia/users/templates/users/unsubscribe.html:30
 #, python-format
-msgid "Unfortunately, we weren't able to unsubscribe you.  The link you clicked is invalid. However, you can unsubscribe still unsubscribe on your <a href=\"%(edit_url)s\">edit profile page</a>."
-msgstr ""
+msgid "Unfortunately, we weren't able to unsubscribe you. The link you clicked is invalid. However, you can unsubscribe still unsubscribe on your <a href=\"%(edit_url)s\">edit profile page</a>."
+msgstr "ਬਦਕਿਸਮਤੀ ਨਾਲ, ਅਸੀਂ ਤੁਹਾਡੀ ਗਾਹਕੀ ਰੱਦ ਕਰਨਯੋਗ ਨਹੀਂ। ਤੁਹਾਡੇ ਵੱਲੋਂ ਕਲਿੱਕ ਕੀਤਾ ਲਿੰਕ ਗਲਤ ਹੈ। ਜਦਕਿ, ਤੁਸੀਂ <a href=\"%(edit_url)s\">ਪ੍ਰੋਫ਼ਾਈਲ ਸਫ਼ੇ ਵਿੱਚ ਸੋਧ</a>ਕਰਕੇ ਗਾਹਕੀ ਰੱਦ ਕਰ ਸਕਦੇ ਹੋ।"
 
 #: src/olympia/users/templates/users/vcard.html:2
 msgid "Developer Information"
@@ -12702,15 +12561,15 @@ msgstr "%s ਵਰਜਨ ਇਤਿਹਾਸ"
 msgid "Version History with Changelogs"
 msgstr "ਤਬਦੀਲੀ-ਉਲੇਖਾਂ ਨਾਲ ਵਰਜਨ ਇਤਿਹਾਸ"
 
-#: src/olympia/versions/models.py:314
+#: src/olympia/versions/models.py:313
 msgid "Add-on uses binary components."
 msgstr "ਐਡ-ਆਨ ਬਾਇਨਰੀ ਹਿੱਸੇ ਵਰਤਦਾ ਹੈ।"
 
-#: src/olympia/versions/models.py:317
+#: src/olympia/versions/models.py:316
 msgid "Add-on has opted into strict compatibility checking."
 msgstr "ਐਡ-ਆਨ ਸ਼ਖਤ ਅਨੁਕੂਲਤਾ ਪੜਤਾਲ ਲਈ ਚੁਣਿਆ ਗਿਆ।"
 
-#: src/olympia/versions/models.py:715
+#: src/olympia/versions/models.py:711
 msgid "{app} {min} and later"
 msgstr "{app} {min} and ਬਾਅਦ"
 
@@ -12786,3 +12645,7 @@ msgstr "ਮੁਕੰਮਲ ਹੋਣ ਤੇ ਈਮੇਲ ਕਰੋ"
 #: src/olympia/zadmin/forms.py:105
 msgid "Log emails instead of sending"
 msgstr "ਭੇਜਣ ਦੀ ਥਾਂ ਈਮੇਲਾਂ ਲਾਗ ਕਰੋ"
+
+#: src/olympia/zadmin/forms.py:215
+msgid "Deleted versions can`t be changed."
+msgstr ""

--- a/locale/pa_IN/LC_MESSAGES/djangojs.po
+++ b/locale/pa_IN/LC_MESSAGES/djangojs.po
@@ -2,137 +2,392 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2016-02-24 21:23+0000\n"
+"POT-Creation-Date: 2016-04-18 15:47+0000\n"
 "PO-Revision-Date: 2015-06-29 22:55+0000\n"
 "Last-Translator: jimidar <jimidar@gmail.com>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
-"Language: pa_IN\n"
+"Language: \n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1) ;\n"
-"X-Generator: Pootle 2.5.0\n"
-"X-POOTLE-MTIME: 1435618503.0\n"
+"Generated-By: Babel 2.2.0\n"
 
-#: static/js/common/ratingwidget.js:31
+#: static/js/common-all.js:1426 static/js/impala-all.js:1511 static/js/zamboni/discovery-all.js:12598 static/js/zamboni/init.js:28 static/js/zamboni/mobile-all.js:14945
+msgid "This feature is temporarily disabled while we perform website maintenance. Please check back a little later."
+msgstr "ਇਹ ਫ਼ੀਚਰ ਅਸਥਾਈ ਤੌਰ ਤੇ ਬੰਦ ਹੈ,ਜਦ ਤੱਕ ਅਸੀ ਵੈਬਸਾਈਟ ਚ ਸੁਧਾਰ ਕਰ ਰਹੇ ਹਾਂ । ਕਿਰਪਾ ਕਰਕੇ ਕੁਝ ਚਿਰ ਬਾਅਦ ਪੜਤਾਲ ਕਰੋ ।"
+
+#. L10n: {0} is an app name like Firefox.
+#: static/js/common-all.js:1837 static/js/impala-all.js:1922 static/js/zamboni/buttons.js:73 static/js/zamboni/discovery-all.js:13108
+msgid "Accept and Install"
+msgstr "ਸਵੀਕਾਰ ਕਰੋ ਅਤੇ ਇੰਸਟਾਲ ਕਰੋ"
+
+#: static/js/common-all.js:1837 static/js/impala-all.js:1922 static/js/zamboni/buttons.js:73 static/js/zamboni/discovery-all.js:13108
+msgid "Add to {0}"
+msgstr "ਸ਼ਾਮਲ ਕਰਨ ਲਈ {0}"
+
+#: static/js/common-all.js:1842 static/js/impala-all.js:1927 static/js/zamboni/buttons.js:78 static/js/zamboni/discovery-all.js:13113
+msgid "Download Now"
+msgstr "ਹੁਣ ਡਾਊਨਲੋਡ ਕਰੋ"
+
+#: static/js/common-all.js:1883 static/js/impala-all.js:1968 static/js/zamboni/buttons.js:119 static/js/zamboni/discovery-all.js:13154
+msgid "Add-on has not been updated to support default-to-compatible."
+msgstr "ਮੂਲ ਤੌਰ ਤੇ ਅਨੁਕੂਲਤਾ ਦਾ ਸਹਿਯੋਗ ਕਰਨ ਲਈ ਐਡ-ਆਨ ਅੱਪਡੇਟ ਨਹੀਂ ਕੀਤਾ ਗਿਆ।"
+
+#: static/js/common-all.js:1888 static/js/impala-all.js:1973 static/js/zamboni/buttons.js:124 static/js/zamboni/discovery-all.js:13159
+msgid "You need to be using Firefox 10.0 or higher."
+msgstr "ਤੁਹਾਨੂੰ ਫ਼ਾਇਰਫ਼ਾਕਸ 10.0 ਜਾਂ ਅੱਗੇ ਵਰਤੋਂ ਕਰਨ ਦੀ ਜਰੂਰਤ ਹੈ।"
+
+#: static/js/common-all.js:1900 static/js/impala-all.js:1985 static/js/zamboni/buttons.js:136 static/js/zamboni/discovery-all.js:13171
+msgid "Mozilla has marked this version as incompatible with your Firefox version."
+msgstr "ਮੌਜੀਲਾ ਨੇ ਇਸ ਵਰਜਨ ਤੇ ਤੁਹਾਡੇ ਫ਼ਾਇਰਫ਼ਾਕਸ ਵਰਜਨ ਨਾਲ ਅਨੁਕੂਲ ਨਾ ਹੋਣ ਦਾ ਨਿਸ਼ਾਨ ਲੱਗਾ ਦਿੱਤਾ।"
+
+#. L10n: {0} is an platform like Windows or Linux.
+#: static/js/common-all.js:1981 static/js/impala-all.js:2066 static/js/zamboni/buttons.js:217 static/js/zamboni/discovery-all.js:13252
+msgid "Install for {0} anyway"
+msgstr "ਕਿਸੇ ਵੀ {0} ਲਈ ਇੰਸਟਾਲ"
+
+#: static/js/common-all.js:1981 static/js/impala-all.js:2066 static/js/zamboni/buttons.js:217 static/js/zamboni/discovery-all.js:13252
+msgid "Download for {0} anyway"
+msgstr "ਕਿਸੇ ਵੀ {0} ਲਈ ਡਾਊਨਲੋਡ"
+
+#: static/js/common-all.js:2038 static/js/impala-all.js:2123 static/js/zamboni/buttons.js:274 static/js/zamboni/discovery-all.js:13309
+msgid "Not available for your platform"
+msgstr "ਤੁਹਾਡੇ ਪਲੇਟਫਾਰਮ ਲਈ ਉਪਲੱਬਧ ਨਹੀਂ"
+
+#. L10n: {0} is an app name, {1} is the app version.
+#: static/js/common-all.js:2049 static/js/common-all.js:2086 static/js/impala-all.js:2134 static/js/impala-all.js:2171 static/js/zamboni/buttons.js:286 static/js/zamboni/buttons.js:324
+#: static/js/zamboni/discovery-all.js:13320 static/js/zamboni/discovery-all.js:13357
+msgid "Not available for {0} {1}"
+msgstr "{0} {1} ਲਈ ਉਪਲੱਬਧ ਨਹੀਂ"
+
+#: static/js/common-all.js:2112 static/js/impala-all.js:2197 static/js/zamboni/buttons.js:351 static/js/zamboni/discovery-all.js:13383
+msgid "Works with {app} {min} - {max}"
+msgstr "{app} {min} - {max} ਦੇ ਨਾਲ ਕੰਮ ਕਰਦਾ ਹੈ"
+
+#: static/js/common-all.js:2114 static/js/impala-all.js:2199 static/js/zamboni/buttons.js:353 static/js/zamboni/discovery-all.js:13385
+msgid "View other versions"
+msgstr "ਹੋਰ ਵਰਜਨ ਦੇਖੋ"
+
+#: static/js/common-all.js:2162 static/js/impala-all.js:2247 static/js/zamboni/buttons.js:401 static/js/zamboni/discovery-all.js:13433
+msgid "Only with Firefox — Get Firefox Now!"
+msgstr ""
+
+#: static/js/common-all.js:2278 static/js/impala-all.js:2363 static/js/zamboni/buttons.js:517 static/js/zamboni/discovery-all.js:13549 static/js/zamboni/mobile-all.js:15177
+#: static/js/zamboni/mobile/buttons.js:43
+msgid "Sorry, you need a Mozilla-based browser (such as Firefox) to install a search plugin."
+msgstr "ਖਿਮਾ ਕਰੋ, ਤੁਹਾਨੂੰ ਖੋਜ ਪਲੱਗਇਨ ਨੂੰ ਇੰਸਟਾਲ ਕਰਨ ਲਈ ਮੌਜੀਲਾ-ਅਧਾਰਿਤ ਬਰਾਊਜ਼ਰ ਦੀ ਲੋੜ ਹੈ।"
+
+#: static/js/common-all.js:9088 static/js/impala-all.js:9649 static/js/zamboni/global.js:410
+msgid "Loading..."
+msgstr "ਲੋਡ ਹੋ ਰਿਹਾ ਹੈ..."
+
+#. L10n: {0} is the number of characters left.
+#: static/js/common-all.js:9152 static/js/impala-all.js:9713 static/js/zamboni/global.js:474
+msgid "<b>{0}</b> character left."
+msgid_plural "<b>{0}</b> characters left."
+msgstr[0] "<b>{0}</b> ਅੱਖਰ ਖੱਬੇ."
+msgstr[1] "<b>{0}</b> ਅੱਖਰ ਖੱਬੇ."
+
+#: static/js/common-all.js:9589 static/js/common-min.js:6 static/js/impala-all.js:10052 static/js/impala-min.js:6 static/js/common/ratingwidget.js:31 static/js/zamboni/mobile-all.js:16123
+#: static/js/zamboni/mobile-min.js:6
 msgid "{0} star"
 msgid_plural "{0} stars"
 msgstr[0] "{0} ਤਾਰਾ"
 msgstr[1] "{0} ਤਾਰੇ"
 
-#: static/js/common/upload-addon.js:41 static/js/common/upload-image.js:128
+#: static/js/common-all.js:9676 static/js/common-min.js:6 static/js/impala-all.js:10139 static/js/impala-min.js:6 static/js/zamboni/l10n.js:45
+msgid "Remove this localization"
+msgstr "ਇਹ ਸਥਾਨੀਕਰਨ ਹਟਾਓ"
+
+#: static/js/common-all.js:10193 static/js/common-min.js:6 static/js/impala-all.js:10674 static/js/impala-min.js:6 static/js/zamboni/discovery-all.js:13678
+msgid "close"
+msgstr ""
+
+#: static/js/common-all.js:10860 static/js/common-min.js:6 static/js/impala-all.js:11481 static/js/impala-min.js:6 static/js/impala/reviews.js:23 static/js/zamboni/reviews.js:18
+msgid "Flagged for review"
+msgstr "ਸਮੀਖਿਆ ਲਈ ਫਲੈਗ ਕੀਤਾ"
+
+#: static/js/common-all.js:10876 static/js/common-min.js:6 static/js/impala-all.js:11498 static/js/impala-min.js:6 static/js/impala/reviews.js:40 static/js/zamboni/reviews.js:34
+msgid "Your input is required"
+msgstr "ਤੁਹਾਡੇ ਇਨਪੁੱਟ ਦੀ ਲੋੜ ਹੈ"
+
+#: static/js/common-all.js:10945 static/js/common-min.js:6 static/js/impala-all.js:11610 static/js/impala-min.js:7 static/js/impala/reviews.js:152 static/js/zamboni/reviews.js:103
+msgid "Marked for deletion"
+msgstr "ਹਟਾਉਣ ਲਈ ਮਾਰਕ ਕੀਤਾ"
+
+#: static/js/common-all.js:11573 static/js/common-min.js:7 static/js/impala-all.js:13809 static/js/impala-min.js:8 static/js/zamboni/collections.js:229
+msgid "Adding to Favorites&hellip;"
+msgstr "ਪਸੰਦ ਜੋੜ ਰਿਹਾ &hellip;                "
+
+#: static/js/common-all.js:11576 static/js/common-min.js:7 static/js/impala-all.js:13812 static/js/impala-min.js:8 static/js/zamboni/collections.js:232
+msgid "Removing Favorite&hellip;"
+msgstr "ਪਸੰਦੀਦਾ ਹਟਾ ਰਿਹਾ&hellip;"
+
+#: static/js/common-all.js:11579 static/js/common-min.js:7 static/js/impala-all.js:13815 static/js/impala-min.js:8 static/js/zamboni/collections.js:235
+msgid "Add to Favorites"
+msgstr "ਪਸੰਦ ਵਿਚ ਸ਼ਾਮਲ ਕਰੋ"
+
+#: static/js/common-all.js:11582 static/js/common-min.js:7 static/js/impala-all.js:13818 static/js/impala-min.js:8 static/js/zamboni/collections.js:238
+msgid "Remove from Favorites"
+msgstr "ਪਸੰਦ ਵਿਚੋਂ ਹਟਾਓ"
+
+#: static/js/common-all.js:11647 static/js/common-min.js:7 static/js/impala-all.js:13883 static/js/impala-min.js:8 static/js/zamboni/collections.js:303
+msgid "Pending"
+msgstr "ਬਕਾਇਆ"
+
+#: static/js/common-all.js:11648 static/js/common-min.js:7 static/js/impala-all.js:13884 static/js/impala-min.js:8 static/js/zamboni/collections.js:304
+msgid "Add a comment"
+msgstr "ਕਾਮੈਂਟ ਸ਼ਾਮਲ"
+
+#: static/js/common-all.js:11648 static/js/common-min.js:7 static/js/impala-all.js:13884 static/js/impala-min.js:8 static/js/zamboni/collections.js:304
+msgid "Comment"
+msgstr "ਕਾਮੈਂਟ"
+
+#: static/js/common-all.js:11649 static/js/common-min.js:7 static/js/impala-all.js:13885 static/js/impala-min.js:8 static/js/zamboni/collections.js:305
+msgid "Remove this add-on from the collection"
+msgstr "ਭੰਡਾਰ ਵਿੱਚੋਂ ਇਹ ਐਡ-ਆਨ ਹਟਾਓ"
+
+#: static/js/common-all.js:11649 static/js/common-all.js:11678 static/js/common-min.js:7 static/js/impala-all.js:13885 static/js/impala-all.js:13914 static/js/impala-min.js:8
+#: static/js/zamboni/collections.js:305 static/js/zamboni/collections.js:334
+msgid "Remove"
+msgstr "ਹਟਾਓ"
+
+#: static/js/common-all.js:11678 static/js/common-min.js:7 static/js/impala-all.js:13914 static/js/impala-min.js:8 static/js/zamboni/collections.js:334
+msgid "Remove this user as a contributor"
+msgstr "ਇਸ ਯੂਜਰ ਨੂੰ ਯੋਗਦਾਨ ਦੇ ਤੌਰ ਤੇ ਹਟਾਓ"
+
+#: static/js/common-all.js:11690 static/js/common-min.js:7 static/js/impala-all.js:13926 static/js/impala-min.js:8 static/js/zamboni/collections.js:346
+msgid "An email address is required."
+msgstr "ਇੱਕ ਈਮੇਲ ਐੱਡਰੈਸ ਦੀ ਜਰੂਰਤ ਹੈ।"
+
+#: static/js/common-all.js:11708 static/js/common-min.js:7 static/js/impala-all.js:13944 static/js/impala-min.js:8 static/js/zamboni/collections.js:364
+msgid "You cannot add yourself as a contributor."
+msgstr "ਹਟਾਓ"
+
+#: static/js/common-all.js:11710 static/js/common-min.js:7 static/js/impala-all.js:13946 static/js/impala-min.js:8 static/js/zamboni/collections.js:366
+msgid "You have already added that user."
+msgstr "ਤੁਸੀ ਇਸ ਯੂਜਰ ਨੂੰ ਪਹਿਲਾਂ ਹੀ ਸ਼ਾਮਲ ਕਰ ਚੁੱਕੇ ਹੋ"
+
+#: static/js/common-all.js:11917 static/js/common-min.js:7 static/js/impala-all.js:14153 static/js/impala-min.js:8 static/js/zamboni/collections.js:573
+msgid "Add to favorites"
+msgstr "ਪਸੰਦ ਵਿੱਚ ਸ਼ਾਮਿਲ ਕਰੋ"
+
+#: static/js/common-all.js:11921 static/js/common-min.js:7 static/js/impala-all.js:14157 static/js/impala-min.js:8 static/js/zamboni/collections.js:577
+msgid "Remove from favorites"
+msgstr "ਪਸੰਦ ਵਿੱਚੋਂ ਹਟਾਓ"
+
+#: static/js/common-all.js:11939 static/js/common-min.js:7 static/js/impala-all.js:14175 static/js/impala-all.js:14233 static/js/impala-min.js:8 static/js/impala/collections.js:10
+#: static/js/zamboni/collections.js:595
+msgid "Follow this Collection"
+msgstr "ਇਸ ਸੰਗ੍ਰਹਿ ਦਾ ਸਮਰਥਨ ਕਰੋ"
+
+#: static/js/common-all.js:11948 static/js/common-min.js:7 static/js/impala-all.js:14184 static/js/impala-min.js:8 static/js/zamboni/collections.js:604
+msgid "Stop following"
+msgstr "ਨਿਮਨ ਲਿਖਤ ਰੋਕੋ"
+
+#: static/js/common-all.js:12096 static/js/common-min.js:7 static/js/zamboni/password-strength.js:20
+msgid "Password strength:"
+msgstr "ਪਾਸਵਰਡ ਤਾਕਤ"
+
+#: static/js/common-all.js:12102 static/js/common-min.js:7 static/js/zamboni/password-strength.js:26
+msgid "At least {0} character left."
+msgid_plural "At least {0} characters left."
+msgstr[0] "ਘੱਟੋ ਤੋਂ ਘੱਟ {0} ਅੱਖਰ ਬਾਕੀ।"
+msgstr[1] "ਘੱਟੋ ਤੋਂ ਘੱਟ {0} ਅੱਖਰ ਬਾਕੀ।"
+
+#: static/js/common-all.js:12286 static/js/common-min.js:7 static/js/impala-all.js:14632 static/js/impala-min.js:8 static/js/impala/suggestions.js:39
+msgid "Search themes for <b>{0}</b>"
+msgstr "<b>{0}</b> ਲਈ ਥੀਮ ਖੋਜੋ"
+
+#: static/js/common-all.js:12288 static/js/common-min.js:7 static/js/impala-all.js:14634 static/js/impala-min.js:8 static/js/impala/suggestions.js:41
+msgid "Search apps for <b>{0}</b>"
+msgstr "<b>{0}</b> ਲਈ ਐਪ ਖੋਜੋ"
+
+#: static/js/common-all.js:12290 static/js/common-min.js:7 static/js/impala-all.js:14636 static/js/impala-min.js:8 static/js/impala/suggestions.js:43
+msgid "Search add-ons for <b>{0}</b>"
+msgstr "<b>{0}</b> ਲਈ ਐਡ-ਆਨ ਖੋਜੋ"
+
+#: static/js/common-all.js:12521 static/js/common-min.js:7 static/js/impala-all.js:14867 static/js/impala-min.js:8 static/js/impala/site_suggestions.js:46
+msgid "Category"
+msgstr "ਕੈਟਾਗਿਰੀ"
+
+#. L10n: {0} is an app name.
+#: static/js/impala-all.js:11632 static/js/impala-min.js:7 static/js/impala/listing.js:11 static/js/zamboni/themes.js:13
+msgid "This theme is incompatible with your version of {0}"
+msgstr "{0} ਦੇ ਤੁਹਾਡੇ ਵਰਜਨ ਨਾਲ ਇਹ ਥੀਮ ਅਨੁਕੂਲ ਨਹੀਂ ਹੈ"
+
+#: static/js/impala-all.js:12146 static/js/impala-all.js:14331 static/js/impala-min.js:7 static/js/impala-min.js:8 static/js/common/upload-image.js:97 static/js/impala/users.js:51
+#: static/js/zamboni/devhub-all.js:894 static/js/zamboni/devhub-min.js:1
+msgid "Images must be either PNG or JPG."
+msgstr "ਤਸਵੀਰਾਂ PNG ਜਾਂ JPG ਦੋਨਾਂ ਵਿੱਚ ਇੱਕ ਹੋਣੀਆਂ ਚਾਹੀਦੀਆਂ ਹਨ।"
+
+#: static/js/impala-all.js:12150 static/js/impala-min.js:7 static/js/common/upload-image.js:101 static/js/zamboni/devhub-all.js:898 static/js/zamboni/devhub-min.js:1
+msgid "Videos must be in WebM."
+msgstr "ਵੀਡੀਓ WebM ਵਿੱਚ ਹੋਣੀਆਂ ਚਾਹੀਦੀਆਂ ਹਨ।"
+
+#: static/js/impala-all.js:12177 static/js/impala-min.js:7 static/js/common/upload-addon.js:41 static/js/common/upload-image.js:128 static/js/zamboni/devhub-all.js:272
+#: static/js/zamboni/devhub-all.js:925 static/js/zamboni/devhub-min.js:1
 msgid "There was a problem contacting the server."
 msgstr "ਸਰਵਰ ਨਾਲ ਸੰਪਰਕ ਵੇਲੇ ਇੱਕ ਮੁਸ਼ਕਲ ਸੀ।"
 
-#: static/js/common/upload-addon.js:69
+#: static/js/impala-all.js:13298 static/js/impala-min.js:7 static/js/impala/persona_creation.js:60
+msgid "All Rights Reserved"
+msgstr "ਸਭ ਹੱਕ ਰਾਖਵੇ ਹਨ"
+
+#: static/js/impala-all.js:13302 static/js/impala-min.js:7 static/js/impala/persona_creation.js:64
+msgid "Creative Commons Attribution 3.0"
+msgstr "ਕਰੀਏਟਿਵ ਕਾਮਨਜ਼ ਐਟਰੀਬਿਊਸ਼ਨ 3.0"
+
+#: static/js/impala-all.js:13307 static/js/impala-min.js:7 static/js/impala/persona_creation.js:69
+msgid "Creative Commons Attribution-NonCommercial 3.0"
+msgstr "ਕਰੀਏਟਿਵ-ਕਾਮਨਜ਼ ਐਟਰੀਬਿਊਸ਼ਨ-ਨਾਨ-ਕਮਰਸ਼ੀਅਲ 3.0"
+
+#: static/js/impala-all.js:13312 static/js/impala-min.js:7 static/js/impala/persona_creation.js:74
+msgid "Creative Commons Attribution-NonCommercial-NoDerivs 3.0"
+msgstr "ਕਰੀਏਟਿਵ ਕਾਮਨਜ਼ ਐਟਰੀਬਿਊਸ਼ਨ-ਨਾਨ ਕਮਰਸ਼ੀਅਲ-ਨੋਨ ਡਰਾਈਵ 3.0"
+
+#: static/js/impala-all.js:13317 static/js/impala-min.js:7 static/js/impala/persona_creation.js:79
+msgid "Creative Commons Attribution-NonCommercial-Share Alike 3.0"
+msgstr "ਕਰੀਏਟਿਵ ਕਾਮਨਜ਼ ਐਟਰੀਬਿਊਸ਼ਨ-ਨਾਨ ਕਮਰਸ਼ੀਅਲ-ਸ਼ੇਅਰ-ਅਲਾਈਕ 3.0"
+
+#: static/js/impala-all.js:13322 static/js/impala-min.js:7 static/js/impala/persona_creation.js:84
+msgid "Creative Commons Attribution-NoDerivs 3.0"
+msgstr "ਕਰੀਏਟਿਵ ਕਾਮਨਜ਼ ਐਟਰੀਬਿਊਸ਼ਨ-ਨੌਨ ਡਰਾਈਵ 3.0"
+
+#: static/js/impala-all.js:13327 static/js/impala-min.js:7 static/js/impala/persona_creation.js:89
+msgid "Creative Commons Attribution-ShareAlike 3.0"
+msgstr "ਕਰੀਏਟਿਵ ਕਾਮਨਜ਼ ਐਟਰੀਬਿਊਸ਼ਨ-ਸੇਅਰ ਅਲਾਈਕ 3.0"
+
+#: static/js/impala-all.js:13530 static/js/impala-min.js:7 static/js/impala/persona_creation.js:292
+msgid "Your Theme's Name"
+msgstr "ਤੁਹਾਡੇ ਥੀਮ ਦਾ ਨਾਮ"
+
+#: static/js/impala-all.js:14242 static/js/impala-min.js:8 static/js/impala/collections.js:19
+msgid "Stop Following"
+msgstr "ਸਮਰਥਨ ਰੋਕੋ"
+
+#: static/js/impala-all.js:14243 static/js/impala-min.js:8 static/js/impala/collections.js:20
+msgid "Following"
+msgstr "ਸਮਰਥਨ ਕਰ ਰਿਹਾ"
+
+#: static/js/impala-all.js:14313 static/js/impala-min.js:8 static/js/impala/users.js:33
+msgid "use original"
+msgstr "ਅਸਲੀ ਵਰਤੋ"
+
+#: static/js/impala-all.js:14523 static/js/impala-min.js:8 static/js/impala/search.js:114
+msgid "Updating results&hellip;"
+msgstr "ਅੱਪਡੇਟ ਨਤੀਜੇ&hellip;"
+
+#: static/js/common/upload-addon.js:69 static/js/zamboni/devhub-all.js:300 static/js/zamboni/devhub-min.js:1
 msgid "Select a file..."
 msgstr "ਇੱਕ ਫਾਈਲ ਚੁਣੋ..."
 
-#: static/js/common/upload-addon.js:70
+#: static/js/common/upload-addon.js:70 static/js/zamboni/devhub-all.js:301 static/js/zamboni/devhub-min.js:1
 msgid "Your add-on should end with .xpi, .jar or .xml"
 msgstr "ਤੁਹਾਡਾ ਐਡ-ਆਨ .xpi, .jar ਜਾਂ .xml ਨਾਲ ਖਤਮ ਹੋਣਾ ਚਾਹੀਦਾ"
 
 #. L10n: {0} is the percent of the file that has been uploaded.
-#: static/js/common/upload-addon.js:104
+#: static/js/common/upload-addon.js:104 static/js/zamboni/devhub-all.js:335 static/js/zamboni/devhub-min.js:1
 #, fuzzy, python-format
 msgid "{0}% complete"
 msgstr "{0}% ਮੁਕੰਮਲ"
 
 #. L10n: "{bytes uploaded} of {total filesize}".
-#: static/js/common/upload-addon.js:107
+#: static/js/common/upload-addon.js:107 static/js/zamboni/devhub-all.js:338 static/js/zamboni/devhub-min.js:1
 msgid "{0} of {1}"
 msgstr "{1} ਵਿੱਚੋਂ {0}"
 
-#: static/js/common/upload-addon.js:140
+#: static/js/common/upload-addon.js:140 static/js/zamboni/devhub-all.js:371 static/js/zamboni/devhub-min.js:1
 msgid "Cancel"
 msgstr "ਰੱਦ"
 
-#: static/js/common/upload-addon.js:162
+#: static/js/common/upload-addon.js:162 static/js/zamboni/devhub-all.js:393 static/js/zamboni/devhub-min.js:1
 msgid "Uploading {0}"
 msgstr "{0} ਅੱਪਲੋਡ ਹੋ ਰਿਹਾ"
 
-#: static/js/common/upload-addon.js:189
+#: static/js/common/upload-addon.js:189 static/js/zamboni/devhub-all.js:420 static/js/zamboni/devhub-min.js:1
 msgid "Error with {0}"
 msgstr "{0} ਨਾਲ ਖਾਮੀ"
 
-#: static/js/common/upload-addon.js:194
+#: static/js/common/upload-addon.js:194 static/js/zamboni/devhub-all.js:425 static/js/zamboni/devhub-min.js:1
 msgid "Your add-on failed validation with {0} error."
 msgid_plural "Your add-on failed validation with {0} errors."
 msgstr[0] "ਤੁਹਾਡੇ ਐਡ-ਆਨ ਦੀ {0} ਖਾਮੀ ਨਾਲ ਵੈਧਤਾ ਫ਼ੇਲ੍ਹ ਹੋਈ।"
 msgstr[1] "ਤੁਹਾਡੇ ਐਡ-ਆਨ ਦੀ {0} ਖਾਮੀਆਂ ਨਾਲ ਵੈਧਤਾ ਫ਼ੇਲ੍ਹ ਹੋਈ।"
 
-#: static/js/common/upload-addon.js:208
+#: static/js/common/upload-addon.js:208 static/js/zamboni/devhub-all.js:439 static/js/zamboni/devhub-min.js:1
 msgid "&hellip;and {0} more"
 msgid_plural "&hellip;and {0} more"
 msgstr[0] "&hellip;ਅਤੇ {0} ਹੋਰ"
 msgstr[1] "&hellip;ਅਤੇ {0} ਹੋਰ"
 
-#: static/js/common/upload-addon.js:222 static/js/common/upload-addon.js:512
+#: static/js/common/upload-addon.js:222 static/js/common/upload-addon.js:497 static/js/zamboni/devhub-all.js:453 static/js/zamboni/devhub-all.js:743 static/js/zamboni/devhub-min.js:1
 msgid "See full validation report"
 msgstr "ਪੂਰੀ ਵੈਧਤਾ ਰਿਪੋਰਟ ਵੇਖੋ"
 
-#: static/js/common/upload-addon.js:234
+#: static/js/common/upload-addon.js:234 static/js/zamboni/devhub-all.js:465 static/js/zamboni/devhub-min.js:1
 msgid "Validating {0}"
 msgstr "{0} ਵੈਧਤਾ"
 
 #. L10n: first argument is an HTTP status code
-#: static/js/common/upload-addon.js:273
+#: static/js/common/upload-addon.js:273 static/js/zamboni/devhub-all.js:504 static/js/zamboni/devhub-min.js:1
 msgid "Received an empty response from the server; status: {0}"
 msgstr "ਸਰਵਰ ਵੱਲੋਂ ਇੱਕ ਖਾਲੀ ਜਵਾਬ ਮਿਲਿਆ; ਸਥਿਤੀ: {0}"
 
-#: static/js/common/upload-addon.js:373
+#: static/js/common/upload-addon.js:370 static/js/zamboni/devhub-all.js:604 static/js/zamboni/devhub-min.js:1
 msgid "Unexpected server error while validating."
 msgstr "ਵੈਧਤਾ ਦੌਰਾਨ ਅਚਾਨਕ ਸਰਵਰ ਗਲਤੀ।"
 
-#: static/js/common/upload-addon.js:412
+#: static/js/common/upload-addon.js:409 static/js/zamboni/devhub-all.js:643 static/js/zamboni/devhub-min.js:1
 msgid "Finished validating {0}"
 msgstr "{0} ਵੈਧਤਾ ਮੁੰਕਮਲ ਹੋਈ"
 
-#: static/js/common/upload-addon.js:418
+#: static/js/common/upload-addon.js:415 static/js/zamboni/devhub-all.js:649 static/js/zamboni/devhub-min.js:1
 msgid "Your add-on validation timed out, it will be manually reviewed."
 msgstr ""
 
-#: static/js/common/upload-addon.js:421
+#: static/js/common/upload-addon.js:418 static/js/zamboni/devhub-all.js:652 static/js/zamboni/devhub-min.js:1
 msgid "Your add-on was validated with no errors and {0} warning."
 msgid_plural "Your add-on was validated with no errors and {0} warnings."
 msgstr[0] ""
 msgstr[1] ""
 
-#: static/js/common/upload-addon.js:426
+#: static/js/common/upload-addon.js:423 static/js/zamboni/devhub-all.js:657 static/js/zamboni/devhub-min.js:1
 msgid "Your add-on was validated with no errors and {0} message."
 msgid_plural "Your add-on was validated with no errors and {0} messages."
 msgstr[0] "ਤੁਹਾਡਾ ਐਡ-ਆਨ ਬਿਨਾਂ ਕਿਸੇ ਖ਼ਾਮੀ ਅਤੇ {0} ਸੁਨੇਹੇ ਨਾਲ ਵੈਧ ਹੋਇਆ ਸੀ।"
 msgstr[1] "ਤੁਹਾਡਾ ਐਡ-ਆਨ ਬਿਨਾਂ ਕਿਸੇ ਖ਼ਾਮੀ ਅਤੇ {0} ਸੁਨੇਹਿਆਂ ਨਾਲ ਵੈਧ ਹੋਇਆ ਸੀ।"
 
-#: static/js/common/upload-addon.js:431
+#: static/js/common/upload-addon.js:428 static/js/zamboni/devhub-all.js:662 static/js/zamboni/devhub-min.js:1
 msgid "Your add-on was validated with no errors or warnings."
 msgstr "ਤੁਹਾਡਾ ਐਡ-ਆਨ ਬਿਨਾਂ ਕਿਸੇ ਖ਼ਾਮੀਆਂ ਜਾਂ ਚੇਤਾਵਨੀਆਂ ਦੇ ਵੈਧ ਹੋਇਆ ਸੀ।"
 
-#: static/js/common/upload-addon.js:446
+#: static/js/common/upload-addon.js:443 static/js/zamboni/devhub-all.js:677 static/js/zamboni/devhub-min.js:1
 msgid "Your submission will be automatically signed."
 msgstr ""
 
-#: static/js/common/upload-addon.js:465
+#: static/js/common/upload-addon.js:450 static/js/zamboni/devhub-all.js:696 static/js/zamboni/devhub-min.js:1
 msgid "Include detailed version notes (this can be done in the next step)."
 msgstr "ਵਰਜਨ ਨੋਟਾਂ ਦਾ ਵੇਰਵਾ ਸ਼ਾਮਲ (ਇਹ ਅਗਲੇ ਕਦਮ ਵਿੱਚ ਕੀਤਾ ਜਾ ਸਕਦਾ)।"
 
-#: static/js/common/upload-addon.js:466
+#: static/js/common/upload-addon.js:451 static/js/zamboni/devhub-all.js:697 static/js/zamboni/devhub-min.js:1
 msgid "If your add-on requires an account to a website in order to be fully tested, include a test username and password in the Notes to Reviewer (this can be done in the next step)."
 msgstr "ਜੇਕਰ ਤੁਹਾਡੇ ਐਡ-ਆਨ ਨੂੰ ਪੂਰੀ ਪਰਖ ਲਈ ਇੱਕ ਵੈੱਬਸਾਈਟ ਤੇ ਇੱਕ ਖਾਤੇ ਦੀ ਲੋੜ ਹੈ, ਸਮੀਖਿਅਕ ਲਈ ਨੋਟਾਂ ਵਿੱਚ ਇੱਕ ਟੈਸਟ ਵਰਤੋਂਕਾਰ ਅਤੇ ਪਾਸਵਰਡ ਸ਼ਾਮਲ ਕਰੋ (ਇਹ ਅਗਲੇ ਕਦਮ ਵਿੱਚ ਕੀਤਾ ਜਾ ਸਕਦਾ)।"
 
-#: static/js/common/upload-addon.js:467
+#: static/js/common/upload-addon.js:452 static/js/zamboni/devhub-all.js:698 static/js/zamboni/devhub-min.js:1
 msgid "If your add-on is intended for a limited audience you should choose Preliminary Review instead of Full Review."
 msgstr "ਜੇਕਰ ਤੁਹਾਡਾ ਐਡ-ਆਨ ਇੱਕ ਸੀਮਿਤ ਜਨਤਾ ਲਈ ਨਿਯਤ ਹੈ ਤੁਹਾਨੂੰ ਮੁਕੰਮਲ ਸਮੀਖਿਆ ਦੀ ਥਾਂ ਸ਼ੁਰੂਆਤੀ ਸਮੀਖਿਆ ਨੂੰ ਚੁਣਨਾ ਚਾਹੀਦਾ ਹੈ।"
 
-#: static/js/common/upload-addon.js:480
+#: static/js/common/upload-addon.js:465 static/js/zamboni/devhub-all.js:711 static/js/zamboni/devhub-min.js:1
 msgid "Add-on submission checklist"
 msgstr "ਐਡ-ਆਨ ਦਾਖਲ ਕਾਰਜ ਚੈੱਕਲਿਸਟ"
 
-#: static/js/common/upload-addon.js:481
+#: static/js/common/upload-addon.js:466 static/js/zamboni/devhub-all.js:712 static/js/zamboni/devhub-min.js:1
 msgid "Please verify the following points before finalizing your submission. This will minimize delays or misunderstanding during the review process:"
 msgstr "ਆਪਣੇ ਦਾਖਲ ਕਾਰਜ ਨੂੰ ਮੁਕੰਮਲ ਕਰਨ ਤੋਂ ਪਹਿਲਾਂ ਅੱਗੇ ਦਿੱਤੇ ਅੰਕਾਂ ਦੀ ਪੁਸ਼ਟੀ ਕਰੋ। ਇਸ ਨਾਲ ਸਮੀਖਿਆ ਕਾਰਜ ਦੌਰਾਨ ਦੇਰੀ ਅਤੇ ਗਲਤਫ਼ਹਿਮੀ ਘੱਟ ਹੋਵੇਗੀ:"
 
-#: static/js/common/upload-addon.js:483
+#: static/js/common/upload-addon.js:468 static/js/zamboni/devhub-all.js:714 static/js/zamboni/devhub-min.js:1
 msgid ""
 "Compiled binaries, as well as minified or obfuscated scripts (excluding known libraries) need to have their sources submitted separately for review. Make sure that you use the source code upload "
 "field to avoid having your submission rejected."
@@ -140,1079 +395,844 @@ msgstr ""
 "ਕੰਪਾਇਲਡ ਬਾਇਨਰੀਆਂ, ਨਾਲ ਦੀ ਨਾਲ ਛੋਟੀਆਂ ਜਾਂ ਬੇਕਾਰ ਸਕਰਿਪਟਾਂ (ਜਾਣੂ ਲਾਇਬਰ੍ਰੇਰੀਆਂ ਨੂੰ ਛੱਡ ਕੇ) ਨੂੰ ਸਮੀਖਿਆ ਲਈ ਆਪਣੇ ਸੋਰਸ ਕੋਡਾਂ ਨੂੰ ਵੱਖ ਤੋਂ ਦਾਖਲ ਕਰਨ ਦੀ ਜ਼ਰੂਰਤ ਹੈ। ਇਹ ਯਕੀਨੀ ਬਣਾਓ ਕੀ ਤੁਸੀਂ ਆਪਣੇ ਦਾਖਲ ਕਾਰਜ ਨੂੰ ਰੱਦ ਹੋਣ ਤੋਂ ਬਚਾਉਣ ਲਈ ਸੋਰਸ ਕੋਡ ਅੱਪਲੋਡ ਖੇਤਰ ਦੀ "
 "ਵਰਤੋਂ ਕਰ ਰਹੇ ਹੋ।"
 
-#: static/js/common/upload-addon.js:501
+#: static/js/common/upload-addon.js:486 static/js/zamboni/devhub-all.js:732 static/js/zamboni/devhub-min.js:1
 msgid "The validation process found these issues that can lead to rejections:"
 msgstr "ਵੈਧਤਾ ਕਾਰਜ ਨੂੰ ਇਹ ਮਸਲੇ ਲੱਭੇ ਹਨ ਜੋ ਰੱਦ ਹੋਣ ਦਾ ਕਾਰਨ ਬਣ ਸਕਦੇ ਹਨ:"
 
-#: static/js/common/upload-addon.js:518
+#: static/js/common/upload-addon.js:503 static/js/zamboni/devhub-all.js:749 static/js/zamboni/devhub-min.js:1
 msgid "If you are unfamiliar with the add-ons review process, you can read about it here."
 msgstr "ਜੇਕਰ ਤੁਸੀਂ ਐਡ-ਆਨ ਸਮੀਖਿਆ ਕਾਰਜ ਤੋਂ ਜਾਣੂ ਨਹੀਂ ਹੋ, ਤੁਸੀਂ ਉਸ ਬਾਰੇ ਇੱਥੇ ਪੜ੍ਹ ਸਕਦੇ ਹੋ।"
 
-#: static/js/common/upload-addon.js:555
+#: static/js/common/upload-addon.js:540 static/js/zamboni/devhub-all.js:786 static/js/zamboni/devhub-min.js:1
 msgid "Sorry, no supported platform has been found."
 msgstr "ਮੁਆਫ਼ੀ, ਕੋਈ ਸਹਾਇਕ ਪਲੇਟਫਾਰਮ ਨਹੀਂ ਲੱਭਿਆ।"
 
-#: static/js/common/upload-base.js:57
+#: static/js/common/upload-base.js:57 static/js/zamboni/devhub-all.js:187 static/js/zamboni/devhub-min.js:1
 msgid "The filetype you uploaded isn't recognized."
 msgstr "ਤੁਹਾਨੂੰ ਵੱਲੋਂ ਅੱਪਲੋਡ ਕੀਤੀ ਫ਼ਾਈਲ ਕਿਸਮ ਦੀ ਪਛਾਣ ਨਹੀਂ ਹੋਈ।"
 
-#: static/js/common/upload-base.js:79
+#: static/js/common/upload-base.js:79 static/js/zamboni/devhub-all.js:209 static/js/zamboni/devhub-min.js:1
 msgid "You cancelled the upload."
 msgstr "ਤੁਸੀਂ ਅੱਪਲੋਡ ਨੂੰ ਰੱਦ ਕੀਤਾ।"
 
-#: static/js/common/upload-image.js:97 static/js/impala/users.js:51
-msgid "Images must be either PNG or JPG."
-msgstr "ਤਸਵੀਰਾਂ PNG ਜਾਂ JPG ਦੋਨਾਂ ਵਿੱਚ ਇੱਕ ਹੋਣੀਆਂ ਚਾਹੀਦੀਆਂ ਹਨ।"
-
-#: static/js/common/upload-image.js:101
-msgid "Videos must be in WebM."
-msgstr "ਵੀਡੀਓ WebM ਵਿੱਚ ਹੋਣੀਆਂ ਚਾਹੀਦੀਆਂ ਹਨ।"
-
-#: static/js/impala/collections.js:10 static/js/zamboni/collections.js:595
-msgid "Follow this Collection"
-msgstr "ਇਸ ਸੰਗ੍ਰਹਿ ਦਾ ਸਮਰਥਨ ਕਰੋ"
-
-#: static/js/impala/collections.js:19
-msgid "Stop Following"
-msgstr "ਸਮਰਥਨ ਰੋਕੋ"
-
-#: static/js/impala/collections.js:20
-msgid "Following"
-msgstr "ਸਮਰਥਨ ਕਰ ਰਿਹਾ"
-
-#. L10n: {0} is an app name.
-#: static/js/impala/listing.js:11 static/js/zamboni/themes.js:13
-msgid "This theme is incompatible with your version of {0}"
-msgstr "{0} ਦੇ ਤੁਹਾਡੇ ਵਰਜਨ ਨਾਲ ਇਹ ਥੀਮ ਅਨੁਕੂਲ ਨਹੀਂ ਹੈ"
-
-#: static/js/impala/persona_creation.js:60
-msgid "All Rights Reserved"
-msgstr "ਸਭ ਹੱਕ ਰਾਖਵੇ ਹਨ"
-
-#: static/js/impala/persona_creation.js:64
-msgid "Creative Commons Attribution 3.0"
-msgstr "ਕਰੀਏਟਿਵ ਕਾਮਨਜ਼ ਐਟਰੀਬਿਊਸ਼ਨ 3.0"
-
-#: static/js/impala/persona_creation.js:69
-msgid "Creative Commons Attribution-NonCommercial 3.0"
-msgstr "ਕਰੀਏਟਿਵ-ਕਾਮਨਜ਼ ਐਟਰੀਬਿਊਸ਼ਨ-ਨਾਨ-ਕਮਰਸ਼ੀਅਲ 3.0"
-
-#: static/js/impala/persona_creation.js:74
-msgid "Creative Commons Attribution-NonCommercial-NoDerivs 3.0"
-msgstr "ਕਰੀਏਟਿਵ ਕਾਮਨਜ਼ ਐਟਰੀਬਿਊਸ਼ਨ-ਨਾਨ ਕਮਰਸ਼ੀਅਲ-ਨੋਨ ਡਰਾਈਵ 3.0"
-
-#: static/js/impala/persona_creation.js:79
-msgid "Creative Commons Attribution-NonCommercial-Share Alike 3.0"
-msgstr "ਕਰੀਏਟਿਵ ਕਾਮਨਜ਼ ਐਟਰੀਬਿਊਸ਼ਨ-ਨਾਨ ਕਮਰਸ਼ੀਅਲ-ਸ਼ੇਅਰ-ਅਲਾਈਕ 3.0"
-
-#: static/js/impala/persona_creation.js:84
-msgid "Creative Commons Attribution-NoDerivs 3.0"
-msgstr "ਕਰੀਏਟਿਵ ਕਾਮਨਜ਼ ਐਟਰੀਬਿਊਸ਼ਨ-ਨੌਨ ਡਰਾਈਵ 3.0"
-
-#: static/js/impala/persona_creation.js:89
-msgid "Creative Commons Attribution-ShareAlike 3.0"
-msgstr "ਕਰੀਏਟਿਵ ਕਾਮਨਜ਼ ਐਟਰੀਬਿਊਸ਼ਨ-ਸੇਅਰ ਅਲਾਈਕ 3.0"
-
-#: static/js/impala/persona_creation.js:292
-msgid "Your Theme's Name"
-msgstr "ਤੁਹਾਡੇ ਥੀਮ ਦਾ ਨਾਮ"
-
-#: static/js/impala/reviews.js:23 static/js/zamboni/reviews.js:18
-msgid "Flagged for review"
-msgstr "ਸਮੀਖਿਆ ਲਈ ਫਲੈਗ ਕੀਤਾ"
-
-#: static/js/impala/reviews.js:40 static/js/zamboni/reviews.js:34
-msgid "Your input is required"
-msgstr "ਤੁਹਾਡੇ ਇਨਪੁੱਟ ਦੀ ਲੋੜ ਹੈ"
-
-#: static/js/impala/reviews.js:152 static/js/zamboni/reviews.js:103
-msgid "Marked for deletion"
-msgstr "ਹਟਾਉਣ ਲਈ ਮਾਰਕ ਕੀਤਾ"
-
-#: static/js/impala/search.js:114
-msgid "Updating results&hellip;"
-msgstr "ਅੱਪਡੇਟ ਨਤੀਜੇ&hellip;"
-
-#: static/js/impala/site_suggestions.js:46
-msgid "Category"
-msgstr "ਕੈਟਾਗਿਰੀ"
-
-#: static/js/impala/suggestions.js:39
-msgid "Search themes for <b>{0}</b>"
-msgstr "<b>{0}</b> ਲਈ ਥੀਮ ਖੋਜੋ"
-
-#: static/js/impala/suggestions.js:41
-msgid "Search apps for <b>{0}</b>"
-msgstr "<b>{0}</b> ਲਈ ਐਪ ਖੋਜੋ"
-
-#: static/js/impala/suggestions.js:43
-msgid "Search add-ons for <b>{0}</b>"
-msgstr "<b>{0}</b> ਲਈ ਐਡ-ਆਨ ਖੋਜੋ"
-
-#: static/js/impala/users.js:33
-msgid "use original"
-msgstr "ਅਸਲੀ ਵਰਤੋ"
-
-#: static/js/impala/stats/chart.js:267
+#: static/js/impala/stats/chart.js:267 static/js/zamboni/stats-all.js:16898 static/js/zamboni/stats-min.js:5
 msgid "Week of {0}"
 msgstr "{0} ਦਾ ਹਫਤਾ"
 
-#: static/js/impala/stats/chart.js:269
+#: static/js/impala/stats/chart.js:269 static/js/zamboni/stats-all.js:16900 static/js/zamboni/stats-min.js:5
 msgid " downloads"
 msgstr ""
 
-#: static/js/impala/stats/chart.js:270
+#: static/js/impala/stats/chart.js:270 static/js/zamboni/stats-all.js:16901 static/js/zamboni/stats-min.js:5
 msgid "{0} users"
 msgstr "{0} ਯੂਜਰ"
 
-#: static/js/impala/stats/chart.js:271
+#: static/js/impala/stats/chart.js:271 static/js/zamboni/stats-all.js:16902 static/js/zamboni/stats-min.js:5
 msgid "{0} add-ons"
 msgstr "{0} ਐਡ-ਆਨ"
 
-#: static/js/impala/stats/chart.js:272
+#: static/js/impala/stats/chart.js:272 static/js/zamboni/stats-all.js:16903 static/js/zamboni/stats-min.js:5
 msgid "{0} collections"
 msgstr "{0} ਭੰਡਾਰ"
 
-#: static/js/impala/stats/chart.js:273
+#: static/js/impala/stats/chart.js:273 static/js/zamboni/stats-all.js:16904 static/js/zamboni/stats-min.js:5
 msgid "{0} reviews"
 msgstr "{0} ਸਮੀਖਿਅਕ"
 
-#: static/js/impala/stats/chart.js:275
+#: static/js/impala/stats/chart.js:275 static/js/zamboni/stats-all.js:16906 static/js/zamboni/stats-min.js:5
 msgid "{0} sales"
 msgstr "{0} ਸੇਲ"
 
-#: static/js/impala/stats/chart.js:276
+#: static/js/impala/stats/chart.js:276 static/js/zamboni/stats-all.js:16907 static/js/zamboni/stats-min.js:5
 msgid "{0} refunds"
 msgstr "{0} ਰਿਫੰਡ"
 
-#: static/js/impala/stats/chart.js:277
+#: static/js/impala/stats/chart.js:277 static/js/zamboni/stats-all.js:16908 static/js/zamboni/stats-min.js:5
 msgid "{0} installs"
 msgstr "{0} ਇੰਸਟਾਲ"
 
-#: static/js/impala/stats/chart.js:369 static/js/impala/stats/csv_keys.js:3 static/js/impala/stats/csv_keys.js:109
+#: static/js/impala/stats/chart.js:369 static/js/impala/stats/csv_keys.js:3 static/js/impala/stats/csv_keys.js:109 static/js/zamboni/stats-all.js:15284 static/js/zamboni/stats-all.js:15390
+#: static/js/zamboni/stats-all.js:17000 static/js/zamboni/stats-min.js:4 static/js/zamboni/stats-min.js:5
 msgid "Downloads"
 msgstr "ਡਾਊਨਲੋਡ"
 
-#: static/js/impala/stats/chart.js:379 static/js/impala/stats/csv_keys.js:6 static/js/impala/stats/csv_keys.js:110
+#: static/js/impala/stats/chart.js:379 static/js/impala/stats/csv_keys.js:6 static/js/impala/stats/csv_keys.js:110 static/js/zamboni/stats-all.js:15287 static/js/zamboni/stats-all.js:15391
+#: static/js/zamboni/stats-all.js:17010 static/js/zamboni/stats-min.js:4 static/js/zamboni/stats-min.js:5
 msgid "Daily Users"
 msgstr "ਰੋਜਾਨਾਂ ਯੂਜਰ"
 
-#: static/js/impala/stats/chart.js:410
+#: static/js/impala/stats/chart.js:410 static/js/zamboni/stats-all.js:17041 static/js/zamboni/stats-min.js:5
 msgid "Amount, in USD"
 msgstr "USA ਵਿੱਚ, ਰਾਸ਼ੀ"
 
-#: static/js/impala/stats/chart.js:421 static/js/impala/stats/csv_keys.js:104
+#: static/js/impala/stats/chart.js:421 static/js/impala/stats/csv_keys.js:104 static/js/zamboni/stats-all.js:15385 static/js/zamboni/stats-all.js:17052 static/js/zamboni/stats-min.js:5
 msgid "Number of Contributions"
 msgstr "ਯੋਗਦਾਨ ਦੀ ਗਿਣਤੀ"
 
-#: static/js/impala/stats/chart.js:447
+#: static/js/impala/stats/chart.js:447 static/js/zamboni/stats-all.js:17078 static/js/zamboni/stats-min.js:5
 msgid "More Info..."
 msgstr "ਜਿਆਦਾ ਜਾਣਕਾਰੀ...."
 
 #. L10n: {0} is an ISO-formatted date.
-#: static/js/impala/stats/chart.js:451
+#: static/js/impala/stats/chart.js:451 static/js/zamboni/stats-all.js:17082 static/js/zamboni/stats-min.js:5
 msgid "Details for {0}"
 msgstr "{0} ਲਈ ਵੇਰਵਾ"
 
-#: static/js/impala/stats/csv_keys.js:9
+#: static/js/impala/stats/csv_keys.js:9 static/js/zamboni/stats-all.js:15290 static/js/zamboni/stats-min.js:4
 msgid "Collections Created"
 msgstr "ਬਣਾਇਆ ਭੰਡਾਰ"
 
-#: static/js/impala/stats/csv_keys.js:12
+#: static/js/impala/stats/csv_keys.js:12 static/js/zamboni/stats-all.js:15293 static/js/zamboni/stats-min.js:4
 msgid "Add-ons in Use"
 msgstr "ਐਡ-ਆਨ ਵਿੱਚ ਵਰਤੋ"
 
-#: static/js/impala/stats/csv_keys.js:15
+#: static/js/impala/stats/csv_keys.js:15 static/js/zamboni/stats-all.js:15296 static/js/zamboni/stats-min.js:4
 msgid "Add-ons Created"
 msgstr "ਐਡ-ਆਨ ਬਣਾਓ"
 
-#: static/js/impala/stats/csv_keys.js:18
+#: static/js/impala/stats/csv_keys.js:18 static/js/zamboni/stats-all.js:15299 static/js/zamboni/stats-min.js:4
 msgid "Add-ons Downloaded"
 msgstr "ਐਡ-ਆਨ ਡਾਊਨਲੋਡ"
 
-#: static/js/impala/stats/csv_keys.js:21
+#: static/js/impala/stats/csv_keys.js:21 static/js/zamboni/stats-all.js:15302 static/js/zamboni/stats-min.js:4
 msgid "Add-ons Updated"
 msgstr "ਐਡ-ਆਨ ਅੱਪਡੇਟ"
 
-#: static/js/impala/stats/csv_keys.js:24
+#: static/js/impala/stats/csv_keys.js:24 static/js/zamboni/stats-all.js:15305 static/js/zamboni/stats-min.js:4
 msgid "Reviews Written"
 msgstr "ਲਿਖਤੀ ਸਮੀਖਿਅਕ"
 
-#: static/js/impala/stats/csv_keys.js:27
+#: static/js/impala/stats/csv_keys.js:27 static/js/zamboni/stats-all.js:15308 static/js/zamboni/stats-min.js:4
 msgid "User Signups"
 msgstr "ਯੂਜਰ ਸਾਈਨਅੱਪ"
 
-#: static/js/impala/stats/csv_keys.js:30
+#: static/js/impala/stats/csv_keys.js:30 static/js/zamboni/stats-all.js:15311 static/js/zamboni/stats-min.js:4
 msgid "Subscribers"
 msgstr "ਗਾਹਕ"
 
-#: static/js/impala/stats/csv_keys.js:33
+#: static/js/impala/stats/csv_keys.js:33 static/js/zamboni/stats-all.js:15314 static/js/zamboni/stats-min.js:4
 msgid "Ratings"
 msgstr "ਰੇਟਿੰਗ"
 
-#: static/js/impala/stats/csv_keys.js:36 static/js/impala/stats/csv_keys.js:114
+#: static/js/impala/stats/csv_keys.js:36 static/js/impala/stats/csv_keys.js:114 static/js/zamboni/stats-all.js:15317 static/js/zamboni/stats-all.js:15395 static/js/zamboni/stats-min.js:4
+#: static/js/zamboni/stats-min.js:5
 msgid "Sales"
 msgstr "ਸੇਲ"
 
-#: static/js/impala/stats/csv_keys.js:39 static/js/impala/stats/csv_keys.js:113
+#: static/js/impala/stats/csv_keys.js:39 static/js/impala/stats/csv_keys.js:113 static/js/zamboni/stats-all.js:15320 static/js/zamboni/stats-all.js:15394 static/js/zamboni/stats-min.js:4
+#: static/js/zamboni/stats-min.js:5
 msgid "Installs"
 msgstr "ਇੰਸਟਾਲ"
 
-#: static/js/impala/stats/csv_keys.js:42
+#: static/js/impala/stats/csv_keys.js:42 static/js/zamboni/stats-all.js:15323 static/js/zamboni/stats-min.js:4
 msgid "Unknown"
 msgstr "ਅਣਜਾਣ"
 
-#: static/js/impala/stats/csv_keys.js:43
+#: static/js/impala/stats/csv_keys.js:43 static/js/zamboni/stats-all.js:15324 static/js/zamboni/stats-min.js:4
 msgid "Add-ons Manager"
 msgstr "ਐਡ-ਆਨ ਮਨੇਜਰ"
 
-#: static/js/impala/stats/csv_keys.js:44
+#: static/js/impala/stats/csv_keys.js:44 static/js/zamboni/stats-all.js:15325 static/js/zamboni/stats-min.js:4
 msgid "Add-ons Manager Promo"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:45
+#: static/js/impala/stats/csv_keys.js:45 static/js/zamboni/stats-all.js:15326 static/js/zamboni/stats-min.js:4
 msgid "Add-ons Manager Featured"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:46
+#: static/js/impala/stats/csv_keys.js:46 static/js/zamboni/stats-all.js:15327 static/js/zamboni/stats-min.js:4
 msgid "Add-ons Manager Learn More"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:47
+#: static/js/impala/stats/csv_keys.js:47 static/js/zamboni/stats-all.js:15328 static/js/zamboni/stats-min.js:4
 msgid "Search Suggestions"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:48
+#: static/js/impala/stats/csv_keys.js:48 static/js/zamboni/stats-all.js:15329 static/js/zamboni/stats-min.js:4
 msgid "Search Results"
 msgstr "ਨਤੀਜੇ ਖੋਜੋ"
 
-#: static/js/impala/stats/csv_keys.js:49 static/js/impala/stats/csv_keys.js:50 static/js/impala/stats/csv_keys.js:51
+#: static/js/impala/stats/csv_keys.js:49 static/js/impala/stats/csv_keys.js:50 static/js/impala/stats/csv_keys.js:51 static/js/zamboni/stats-all.js:15330 static/js/zamboni/stats-all.js:15331
+#: static/js/zamboni/stats-all.js:15332 static/js/zamboni/stats-min.js:4
 msgid "Homepage Promo"
 msgstr "ਮੁੱਖ ਸਫਾ ਪਰੋਮੋ"
 
-#: static/js/impala/stats/csv_keys.js:52 static/js/impala/stats/csv_keys.js:53
+#: static/js/impala/stats/csv_keys.js:52 static/js/impala/stats/csv_keys.js:53 static/js/zamboni/stats-all.js:15333 static/js/zamboni/stats-all.js:15334 static/js/zamboni/stats-min.js:4
 msgid "Homepage Featured"
 msgstr "ਮੁੱਖ ਸਫਾ ਗੁਣ"
 
-#: static/js/impala/stats/csv_keys.js:54 static/js/impala/stats/csv_keys.js:55
+#: static/js/impala/stats/csv_keys.js:54 static/js/impala/stats/csv_keys.js:55 static/js/zamboni/stats-all.js:15335 static/js/zamboni/stats-all.js:15336 static/js/zamboni/stats-min.js:4
 msgid "Homepage Up and Coming"
 msgstr "ਮੁੱਖ ਸਫਾ ਉੱਪਰ ਅਤੇ ਆਉਣਾ"
 
-#: static/js/impala/stats/csv_keys.js:56
+#: static/js/impala/stats/csv_keys.js:56 static/js/zamboni/stats-all.js:15337 static/js/zamboni/stats-min.js:4
 msgid "Homepage Most Popular"
 msgstr "ਮੱਖ ਸਫਾ ਜਿਆਦਾ ਪ੍ਰਸਿੱਧ"
 
-#: static/js/impala/stats/csv_keys.js:57 static/js/impala/stats/csv_keys.js:59
+#: static/js/impala/stats/csv_keys.js:57 static/js/impala/stats/csv_keys.js:59 static/js/zamboni/stats-all.js:15338 static/js/zamboni/stats-all.js:15340 static/js/zamboni/stats-min.js:4
 msgid "Detail Page"
 msgstr "ਸਫੇ ਦਾ ਵੇਰਵਾ"
 
-#: static/js/impala/stats/csv_keys.js:58 static/js/impala/stats/csv_keys.js:60
+#: static/js/impala/stats/csv_keys.js:58 static/js/impala/stats/csv_keys.js:60 static/js/zamboni/stats-all.js:15339 static/js/zamboni/stats-all.js:15341 static/js/zamboni/stats-min.js:4
 msgid "Detail Page (bottom)"
 msgstr "ਸਫੇ ਦਾ ਵੇਰਵਾ (ਹੇਠਾਂ)"
 
-#: static/js/impala/stats/csv_keys.js:61
+#: static/js/impala/stats/csv_keys.js:61 static/js/zamboni/stats-all.js:15342 static/js/zamboni/stats-min.js:4
 msgid "Detail Page (Development Channel)"
 msgstr "ਸਫੇ ਦਾ ਵੇਰਵਾ (ਵਾਧਾ ਪ੍ਰਣਾਲੀ)"
 
-#: static/js/impala/stats/csv_keys.js:62 static/js/impala/stats/csv_keys.js:63 static/js/impala/stats/csv_keys.js:64
+#: static/js/impala/stats/csv_keys.js:62 static/js/impala/stats/csv_keys.js:63 static/js/impala/stats/csv_keys.js:64 static/js/zamboni/stats-all.js:15343 static/js/zamboni/stats-all.js:15344
+#: static/js/zamboni/stats-all.js:15345 static/js/zamboni/stats-min.js:4
 msgid "Often Used With"
 msgstr "ਆਮ ਕਰਕੇ ਨਾਲ ਵਰਤਿਆ"
 
-#: static/js/impala/stats/csv_keys.js:65 static/js/impala/stats/csv_keys.js:66
+#: static/js/impala/stats/csv_keys.js:65 static/js/impala/stats/csv_keys.js:66 static/js/zamboni/stats-all.js:15346 static/js/zamboni/stats-all.js:15347 static/js/zamboni/stats-min.js:4
 msgid "Others By Author"
 msgstr "ਲੇਖਕ ਵਲੋ ਹੋਰ"
 
-#: static/js/impala/stats/csv_keys.js:67 static/js/impala/stats/csv_keys.js:68
+#: static/js/impala/stats/csv_keys.js:67 static/js/impala/stats/csv_keys.js:68 static/js/zamboni/stats-all.js:15348 static/js/zamboni/stats-all.js:15349 static/js/zamboni/stats-min.js:4
 msgid "Dependencies"
 msgstr "ਨਿਰਭਰਤਾਵਾਂ"
 
-#: static/js/impala/stats/csv_keys.js:69 static/js/impala/stats/csv_keys.js:70
+#: static/js/impala/stats/csv_keys.js:69 static/js/impala/stats/csv_keys.js:70 static/js/zamboni/stats-all.js:15350 static/js/zamboni/stats-all.js:15351 static/js/zamboni/stats-min.js:4
 msgid "Upsell"
 msgstr "ਵਾਧੂ ਖਰੀਦਦਾਰੀ ਲਈ ਉਕਸਾਉਣਾ"
 
-#: static/js/impala/stats/csv_keys.js:71
+#: static/js/impala/stats/csv_keys.js:71 static/js/zamboni/stats-all.js:15352 static/js/zamboni/stats-min.js:4
 msgid "Meet the Developer"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:72
+#: static/js/impala/stats/csv_keys.js:72 static/js/zamboni/stats-all.js:15353 static/js/zamboni/stats-min.js:4
 msgid "User Profile"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:73
+#: static/js/impala/stats/csv_keys.js:73 static/js/zamboni/stats-all.js:15354 static/js/zamboni/stats-min.js:4
 msgid "Version History"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:75
+#: static/js/impala/stats/csv_keys.js:75 static/js/zamboni/stats-all.js:15356 static/js/zamboni/stats-min.js:4
 msgid "Sharing"
 msgstr "ਵੰਡਣਾ"
 
-#: static/js/impala/stats/csv_keys.js:76
+#: static/js/impala/stats/csv_keys.js:76 static/js/zamboni/stats-all.js:15357 static/js/zamboni/stats-min.js:4
 msgid "Category Pages"
 msgstr "ਸੰਗ੍ਰਹਿ ਪੰਨੇ"
 
-#: static/js/impala/stats/csv_keys.js:77
+#: static/js/impala/stats/csv_keys.js:77 static/js/zamboni/stats-all.js:15358 static/js/zamboni/stats-min.js:4
 msgid "Collections"
 msgstr "ਸੰਗ੍ਰਹਿ"
 
-#: static/js/impala/stats/csv_keys.js:78 static/js/impala/stats/csv_keys.js:79
+#: static/js/impala/stats/csv_keys.js:78 static/js/impala/stats/csv_keys.js:79 static/js/zamboni/stats-all.js:15359 static/js/zamboni/stats-all.js:15360 static/js/zamboni/stats-min.js:4
 msgid "Category Landing Featured Carousel"
 msgstr "ਸੰਗ੍ਰਹਿ ਭੂਮੀ ਗੁਣ ਝੂਲਣਾ"
 
-#: static/js/impala/stats/csv_keys.js:80 static/js/impala/stats/csv_keys.js:81
+#: static/js/impala/stats/csv_keys.js:80 static/js/impala/stats/csv_keys.js:81 static/js/zamboni/stats-all.js:15361 static/js/zamboni/stats-all.js:15362 static/js/zamboni/stats-min.js:4
 msgid "Category Landing Top Rated"
 msgstr "ਚੋਟੀ ਦੀ ਰੇਟਿੰਗ ਵਿੱਚ ਆਉਂਦੇ ਸੰਗ੍ਰਹਿ"
 
-#: static/js/impala/stats/csv_keys.js:82 static/js/impala/stats/csv_keys.js:83
+#: static/js/impala/stats/csv_keys.js:82 static/js/impala/stats/csv_keys.js:83 static/js/zamboni/stats-all.js:15363 static/js/zamboni/stats-all.js:15364 static/js/zamboni/stats-min.js:5
 msgid "Category Landing Most Popular"
 msgstr "ਸੱਭ ਤੋਂ ਮਸ਼ਹੂਰ ਵਿੱਚ ਆਉਂਦੇ ਸੰਗ੍ਰਹਿ"
 
-#: static/js/impala/stats/csv_keys.js:84 static/js/impala/stats/csv_keys.js:85
+#: static/js/impala/stats/csv_keys.js:84 static/js/impala/stats/csv_keys.js:85 static/js/zamboni/stats-all.js:15365 static/js/zamboni/stats-all.js:15366 static/js/zamboni/stats-min.js:5
 msgid "Category Landing Recently Added"
 msgstr "ਤਾਜਾ ਸ਼ਾਮਿਲ ਲੈਂਡਿੰਗ ਸ਼੍ਰੈਣੀ"
 
-#: static/js/impala/stats/csv_keys.js:86 static/js/impala/stats/csv_keys.js:87
+#: static/js/impala/stats/csv_keys.js:86 static/js/impala/stats/csv_keys.js:87 static/js/zamboni/stats-all.js:15367 static/js/zamboni/stats-all.js:15368 static/js/zamboni/stats-min.js:5
 msgid "Browse Listing Featured Sort"
 msgstr "ਗੁਣ ਕਿਸਮ ਸੂਚੀ ਬਣਾਓ"
 
-#: static/js/impala/stats/csv_keys.js:88 static/js/impala/stats/csv_keys.js:89
+#: static/js/impala/stats/csv_keys.js:88 static/js/impala/stats/csv_keys.js:89 static/js/zamboni/stats-all.js:15369 static/js/zamboni/stats-all.js:15370 static/js/zamboni/stats-min.js:5
 msgid "Browse Listing Users Sort"
 msgstr "ਯੂਜਰ ਕਿਸਮ ਸੂਚੀ ਬਣਾਓ"
 
-#: static/js/impala/stats/csv_keys.js:90 static/js/impala/stats/csv_keys.js:91
+#: static/js/impala/stats/csv_keys.js:90 static/js/impala/stats/csv_keys.js:91 static/js/zamboni/stats-all.js:15371 static/js/zamboni/stats-all.js:15372 static/js/zamboni/stats-min.js:5
 msgid "Browse Listing Rating Sort"
 msgstr "ਰੇਟਿੰਗ ਕਿਸਮ ਸੂਚੀ ਬਣਾਓ"
 
-#: static/js/impala/stats/csv_keys.js:92 static/js/impala/stats/csv_keys.js:93
+#: static/js/impala/stats/csv_keys.js:92 static/js/impala/stats/csv_keys.js:93 static/js/zamboni/stats-all.js:15373 static/js/zamboni/stats-all.js:15374 static/js/zamboni/stats-min.js:5
 msgid "Browse Listing Created Sort"
 msgstr "ਰਚਨਾਤਮਿਕ ਕਿਸਮ ਸੂਚੀ ਬਣਾਓ"
 
-#: static/js/impala/stats/csv_keys.js:94 static/js/impala/stats/csv_keys.js:95
+#: static/js/impala/stats/csv_keys.js:94 static/js/impala/stats/csv_keys.js:95 static/js/zamboni/stats-all.js:15375 static/js/zamboni/stats-all.js:15376 static/js/zamboni/stats-min.js:5
 msgid "Browse Listing Name Sort"
 msgstr "ਨਾਮ ਕਿਸਮ ਸੂਚੀ ਬਣਾਓ"
 
-#: static/js/impala/stats/csv_keys.js:96 static/js/impala/stats/csv_keys.js:97
+#: static/js/impala/stats/csv_keys.js:96 static/js/impala/stats/csv_keys.js:97 static/js/zamboni/stats-all.js:15377 static/js/zamboni/stats-all.js:15378 static/js/zamboni/stats-min.js:5
 msgid "Browse Listing Popular Sort"
 msgstr "ਪ੍ਰਸਿੱਧ ਕਿਸਮ ਸੂਚੀ ਬਣਾਓ"
 
-#: static/js/impala/stats/csv_keys.js:98 static/js/impala/stats/csv_keys.js:99
+#: static/js/impala/stats/csv_keys.js:98 static/js/impala/stats/csv_keys.js:99 static/js/zamboni/stats-all.js:15379 static/js/zamboni/stats-all.js:15380 static/js/zamboni/stats-min.js:5
 msgid "Browse Listing Updated Sort"
 msgstr "ਅੱਪਡੇਟ ਕਿਸਮ ਸੂਚੀ ਬਣਾਓ"
 
-#: static/js/impala/stats/csv_keys.js:100 static/js/impala/stats/csv_keys.js:101
+#: static/js/impala/stats/csv_keys.js:100 static/js/impala/stats/csv_keys.js:101 static/js/zamboni/stats-all.js:15381 static/js/zamboni/stats-all.js:15382 static/js/zamboni/stats-min.js:5
 msgid "Browse Listing Up and Coming Sort"
 msgstr "ਸੂਚੀਬੱਧਤਾ ਅਤੇ ਲੜੀਬੱਧਤਾ ਦੀ ਝਲਕ"
 
-#: static/js/impala/stats/csv_keys.js:105
+#: static/js/impala/stats/csv_keys.js:105 static/js/zamboni/stats-all.js:15386 static/js/zamboni/stats-min.js:5
 msgid "Total Amount Contributed"
 msgstr "ਕੁੱਲ ਰਕਮ ਯੋਗਦਾਨ ਪਾਇਆ"
 
-#: static/js/impala/stats/csv_keys.js:106
+#: static/js/impala/stats/csv_keys.js:106 static/js/zamboni/stats-all.js:15387 static/js/zamboni/stats-min.js:5
 msgid "Average Contribution"
 msgstr "ਔਸਤ ਯੋਗਦਾਨ"
 
-#: static/js/impala/stats/csv_keys.js:115
+#: static/js/impala/stats/csv_keys.js:115 static/js/zamboni/stats-all.js:15396 static/js/zamboni/stats-min.js:5
 msgid "Usage"
 msgstr "ਵਰਤੋਂ"
 
-#: static/js/impala/stats/csv_keys.js:118
+#: static/js/impala/stats/csv_keys.js:118 static/js/zamboni/stats-all.js:15399 static/js/zamboni/stats-min.js:5
 msgid "Firefox"
 msgstr "ਫਾਇਰਫਾਕਸ"
 
-#: static/js/impala/stats/csv_keys.js:119
+#: static/js/impala/stats/csv_keys.js:119 static/js/zamboni/stats-all.js:15400 static/js/zamboni/stats-min.js:5
 msgid "Mozilla"
 msgstr "ਮੌਜੀਲਾ"
 
-#: static/js/impala/stats/csv_keys.js:120
+#: static/js/impala/stats/csv_keys.js:120 static/js/zamboni/stats-all.js:15401 static/js/zamboni/stats-min.js:5
 msgid "Thunderbird"
 msgstr "ਥੰਡਰਬਰਡ"
 
-#: static/js/impala/stats/csv_keys.js:121
+#: static/js/impala/stats/csv_keys.js:121 static/js/zamboni/stats-all.js:15402 static/js/zamboni/stats-min.js:5
 msgid "Sunbird"
 msgstr "ਸਨਬਰਡ"
 
-#: static/js/impala/stats/csv_keys.js:122
+#: static/js/impala/stats/csv_keys.js:122 static/js/zamboni/stats-all.js:15403 static/js/zamboni/stats-min.js:5
 msgid "SeaMonkey"
 msgstr "ਸੀਮੌਂਕੀ"
 
-#: static/js/impala/stats/csv_keys.js:123
+#: static/js/impala/stats/csv_keys.js:123 static/js/zamboni/stats-all.js:15404 static/js/zamboni/stats-min.js:5
 msgid "Fennec"
 msgstr "ਫਿੱਨਸ"
 
-#: static/js/impala/stats/csv_keys.js:124
+#: static/js/impala/stats/csv_keys.js:124 static/js/zamboni/stats-all.js:15405 static/js/zamboni/stats-min.js:5
 msgid "Android"
 msgstr "ਐਨਡਰੋਇਡ"
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:129
+#: static/js/impala/stats/csv_keys.js:129 static/js/zamboni/stats-all.js:15410 static/js/zamboni/stats-min.js:5
 msgid "Downloads and Daily Users, last {0} days"
 msgstr "ਡਾਊਨਲੋਡ ਅਤੇ ਰੋਜਾਨਾਂ ਯੂਜਰ, ਆਖਰੀ {0} ਦਿਨ"
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:131
+#: static/js/impala/stats/csv_keys.js:131 static/js/zamboni/stats-all.js:15412 static/js/zamboni/stats-min.js:5
 msgid "Downloads and Daily Users from {0} to {1}"
 msgstr "{0} ਤੋਂ {1} ਤੱਕ ਡਾਊਨਲੋਡ ਅਤੇ ਰੋਜਾਨਾਂ ਯੂਜਰ"
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:135
+#: static/js/impala/stats/csv_keys.js:135 static/js/zamboni/stats-all.js:15416 static/js/zamboni/stats-min.js:5
 msgid "Installs and Daily Users, last {0} days"
 msgstr "ਇੰਸਟਾਲ ਅਤੇ ਰੋਜਾਨਾਂ ਯੂਜਰ, ਆਖਰੀ {0} ਦਿਨ"
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:137
+#: static/js/impala/stats/csv_keys.js:137 static/js/zamboni/stats-all.js:15418 static/js/zamboni/stats-min.js:5
 msgid "Installs and Daily Users from {0} to {1}"
 msgstr "{0} ਤੋ {1} ਤੱਕ ਇੰਸਟਾਲ ਅਤੇ ਰੋਜਾਨਾਂ ਯੂਜਰ"
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:141
+#: static/js/impala/stats/csv_keys.js:141 static/js/zamboni/stats-all.js:15422 static/js/zamboni/stats-min.js:5
 msgid "Downloads, last {0} days"
 msgstr "ਡਾਊਨਲੋਡ, ਆਖਰੀ {0} ਦਿਨ"
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:143
+#: static/js/impala/stats/csv_keys.js:143 static/js/zamboni/stats-all.js:15424 static/js/zamboni/stats-min.js:5
 msgid "Downloads from {0} to {1}"
 msgstr "{0} ਤੋਂ {1} ਤੱਕ ਡਾਊਨਲੋਡ"
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:147
+#: static/js/impala/stats/csv_keys.js:147 static/js/zamboni/stats-all.js:15428 static/js/zamboni/stats-min.js:5
 msgid "Daily Users, last {0} days"
 msgstr "ਰੋਜਾਨਾਂ ਯੂਜਰ, ਆਖਰੀ {0} ਦਿਨ"
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:149
+#: static/js/impala/stats/csv_keys.js:149 static/js/zamboni/stats-all.js:15430 static/js/zamboni/stats-min.js:5
 msgid "Daily Users from {0} to {1}"
 msgstr "{0} ਤੋਂ {1} ਤੱਕ ਰੋਜਾਨਾਂ ਯੂਜਰ"
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:153
+#: static/js/impala/stats/csv_keys.js:153 static/js/zamboni/stats-all.js:15434 static/js/zamboni/stats-min.js:5
 msgid "Applications, last {0} days"
 msgstr "ਐਪਲੀਕੇਸ਼ਨ, ਆਖਰੀ {0} ਦਿਨ"
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:155
+#: static/js/impala/stats/csv_keys.js:155 static/js/zamboni/stats-all.js:15436 static/js/zamboni/stats-min.js:5
 msgid "Applications from {0} to {1}"
 msgstr "{0} ਤੋਂ {1} ਤੱਕ ਐਪਲੀਕੇਸ਼ਨ"
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:159
+#: static/js/impala/stats/csv_keys.js:159 static/js/zamboni/stats-all.js:15440 static/js/zamboni/stats-min.js:5
 msgid "Platforms, last {0} days"
 msgstr "ਪਲੇਟਫਾਰਮ, ਆਖਰੀ {0} ਦਿਨ"
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:161
+#: static/js/impala/stats/csv_keys.js:161 static/js/zamboni/stats-all.js:15442 static/js/zamboni/stats-min.js:5
 msgid "Platforms from {0} to {1}"
 msgstr "{0} ਤੋਂ {1} ਤੱਕ ਪਲੇਟਫਾਰਮ"
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:165
+#: static/js/impala/stats/csv_keys.js:165 static/js/zamboni/stats-all.js:15446 static/js/zamboni/stats-min.js:5
 msgid "Languages, last {0} days"
 msgstr "ਭਾਸ਼ਾਵਾਂ, ਆਖਰੀ {0} ਦਿਨ"
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:167
+#: static/js/impala/stats/csv_keys.js:167 static/js/zamboni/stats-all.js:15448 static/js/zamboni/stats-min.js:5
 msgid "Languages from {0} to {1}"
 msgstr "{0} ਤੋਂ {1} ਤੱਕ ਭਾਸ਼ਾਵਾਂ"
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:171
+#: static/js/impala/stats/csv_keys.js:171 static/js/zamboni/stats-all.js:15452 static/js/zamboni/stats-min.js:5
 msgid "Add-on Versions, last {0} days"
 msgstr "ਐਡ-ਆਨ ਵਰਜਨ, ਆਖਰੀ {0} ਦਿਨ"
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:173
+#: static/js/impala/stats/csv_keys.js:173 static/js/zamboni/stats-all.js:15454 static/js/zamboni/stats-min.js:5
 msgid "Add-on Versions from {0} to {1}"
 msgstr "{0} ਤੋਂ {1} ਤੱਕ ਐਡ-ਆਨ ਵਰਜਨ"
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:177
+#: static/js/impala/stats/csv_keys.js:177 static/js/zamboni/stats-all.js:15458 static/js/zamboni/stats-min.js:5
 msgid "Add-on Status, last {0} days"
 msgstr "ਐਡ-ਆਨ ਸਥਿਤੀ, ਆਖਰੀ {0} ਦਿਨ"
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:179
+#: static/js/impala/stats/csv_keys.js:179 static/js/zamboni/stats-all.js:15460 static/js/zamboni/stats-min.js:5
 msgid "Add-on Status from {0} to {1}"
 msgstr "{0} ਤੋਂ {1} ਤੱਕ ਐਡ-ਆਨ ਸਥਿਤੀ"
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:183
+#: static/js/impala/stats/csv_keys.js:183 static/js/zamboni/stats-all.js:15464 static/js/zamboni/stats-min.js:5
 msgid "Download Sources, last {0} days"
 msgstr "ਡਾਊਨਲੋਡ ਸਰੋਤ, ਆਖਰੀ {0} ਦਿਨ"
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:185
+#: static/js/impala/stats/csv_keys.js:185 static/js/zamboni/stats-all.js:15466 static/js/zamboni/stats-min.js:5
 msgid "Download Sources from {0} to {1}"
 msgstr "{0} ਤੋਂ {1} ਤੱਕ ਡਾਊਨਲੋਡ ਸਰੋਤ"
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:189
+#: static/js/impala/stats/csv_keys.js:189 static/js/zamboni/stats-all.js:15470 static/js/zamboni/stats-min.js:5
 msgid "Contributions, last {0} days"
 msgstr "ਪਿਛਲੇ {0} ਦਿਨ, ਯੋਗਦਾਨ"
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:191
+#: static/js/impala/stats/csv_keys.js:191 static/js/zamboni/stats-all.js:15472 static/js/zamboni/stats-min.js:5
 msgid "Contributions from {0} to {1}"
 msgstr "{0} ਤੋਂ {1} ਤੱਕ ਯੋਗਦਾਨ"
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:195
+#: static/js/impala/stats/csv_keys.js:195 static/js/zamboni/stats-all.js:15476 static/js/zamboni/stats-min.js:5
 msgid "Site Metrics, last {0} days"
 msgstr "ਪਿਛਲੇ {0} ਦਿਨ, ਸਾਈਟ ਮੈਟ੍ਰਿਕਸ"
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:197
+#: static/js/impala/stats/csv_keys.js:197 static/js/zamboni/stats-all.js:15478 static/js/zamboni/stats-min.js:5
 msgid "Site Metrics from {0} to {1}"
 msgstr "ਵਲੋ ਸਾਈਟ ਬਿਓਰਾ {0} ਤੋ {1}"
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:201
+#: static/js/impala/stats/csv_keys.js:201 static/js/zamboni/stats-all.js:15482 static/js/zamboni/stats-min.js:5
 msgid "Add-ons in Use, last {0} days"
 msgstr "ਅੈਡ-ਓਨ ਵਰਤੋ ਵਿੱਚ, ਆਖਰੀ {0} ਦਿਨ"
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:203
+#: static/js/impala/stats/csv_keys.js:203 static/js/zamboni/stats-all.js:15484 static/js/zamboni/stats-min.js:5
 msgid "Add-ons in Use from {0} to {1}"
 msgstr "ਐਡ-ਆਨ ਵਰਤੋ ਵਿਚ {0} ਤੋਂ {1}"
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:207
+#: static/js/impala/stats/csv_keys.js:207 static/js/zamboni/stats-all.js:15488 static/js/zamboni/stats-min.js:5
 msgid "Add-ons Downloaded, last {0} days"
 msgstr "ਆਖਰੀ {0} ਦਿਨ,ਐਡ-ਆਨ ਡਾਊਨਲੋਡ ਹੋਏ,"
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:209
+#: static/js/impala/stats/csv_keys.js:209 static/js/zamboni/stats-all.js:15490 static/js/zamboni/stats-min.js:5
 msgid "Add-ons Downloaded from {0} to {1}"
 msgstr "ਐਡ-ਆਨ {0} ਤੋਂ {1} ਤੱਕ ਡਾਊਨਲੋਡ ਹੋਇਆ"
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:213
+#: static/js/impala/stats/csv_keys.js:213 static/js/zamboni/stats-all.js:15494 static/js/zamboni/stats-min.js:5
 msgid "Add-ons Created, last {0} days"
 msgstr "ਆਖਰੀ {0} ਦਿਨ, ਅੈਡ-ਓਨ ਰਚੇ ਗਏ"
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:215
+#: static/js/impala/stats/csv_keys.js:215 static/js/zamboni/stats-all.js:15496 static/js/zamboni/stats-min.js:5
 msgid "Add-ons Created from {0} to {1}"
 msgstr "{0} ਤੋਂ {1} ਵਲੋ ਐਡ-ਆਨ ਬਣਾਓ"
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:219
+#: static/js/impala/stats/csv_keys.js:219 static/js/zamboni/stats-all.js:15500 static/js/zamboni/stats-min.js:5
 msgid "Add-ons Updated, last {0} days"
 msgstr " ਆਖਰੀ {0} ਦਿਨ, ਐਡ-ਆਨ ਅੱਪਡੇਟ"
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:221
+#: static/js/impala/stats/csv_keys.js:221 static/js/zamboni/stats-all.js:15502 static/js/zamboni/stats-min.js:5
 msgid "Add-ons Updated from {0} to {1}"
 msgstr "{0} ਤੋਂ {1} ਵਿੱਚੋਂ ਐਡ-ਆਨ ਅੱਪਡੇਟ"
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:225
+#: static/js/impala/stats/csv_keys.js:225 static/js/zamboni/stats-all.js:15506 static/js/zamboni/stats-min.js:5
 msgid "Reviews Written, last {0} days"
 msgstr " ਆਖਰੀ {0} ਦਿਨ, ਲਿਖਤੀ ਸਮੀਖਿਅਕ"
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:227
+#: static/js/impala/stats/csv_keys.js:227 static/js/zamboni/stats-all.js:15508 static/js/zamboni/stats-min.js:5
 msgid "Reviews Written from {0} to {1}"
 msgstr "{0} ਤੋਂ {1} ਤੱਕ ਲਿਖਤੀ ਸਮੀਖਿਅਕ"
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:231
+#: static/js/impala/stats/csv_keys.js:231 static/js/zamboni/stats-all.js:15512 static/js/zamboni/stats-min.js:5
 msgid "User Signups, last {0} days"
 msgstr "ਪਿਛਲੇ {0} ਦਿਨ, ਯੂਜਰ ਸਾਈਨ ਅੱਪ"
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:233
+#: static/js/impala/stats/csv_keys.js:233 static/js/zamboni/stats-all.js:15514 static/js/zamboni/stats-min.js:5
 msgid "User Signups from {0} to {1}"
 msgstr "{0} ਤੋਂ {1} ਤੱਕ ਯੂਜਰ ਸਾਈਨ ਅੱਪ"
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:237
+#: static/js/impala/stats/csv_keys.js:237 static/js/zamboni/stats-all.js:15518 static/js/zamboni/stats-min.js:5
 msgid "Collections Created, last {0} days"
 msgstr "ਪਿਛਲੇ {0} ਦਿਨ, ਭੰਡਾਰ ਬਣਾਏ"
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:239
+#: static/js/impala/stats/csv_keys.js:239 static/js/zamboni/stats-all.js:15520 static/js/zamboni/stats-min.js:5
 msgid "Collections Created from {0} to {1}"
 msgstr "{0} ਤੋਂ {1} ਤੱਕ ਬਣਾਏ ਭੰਡਾਰ"
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:243
+#: static/js/impala/stats/csv_keys.js:243 static/js/zamboni/stats-all.js:15524 static/js/zamboni/stats-min.js:5
 msgid "Subscribers, last {0} days"
 msgstr "ਪਿਛਲੇ {0} ਦਿਨ, ਗਾਹਕ"
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:245
+#: static/js/impala/stats/csv_keys.js:245 static/js/zamboni/stats-all.js:15526 static/js/zamboni/stats-min.js:5
 msgid "Subscribers from {0} to {1}"
 msgstr "{0} ਤੋਂ {1} ਤੱਕ ਗਾਹਕ"
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:249
+#: static/js/impala/stats/csv_keys.js:249 static/js/zamboni/stats-all.js:15530 static/js/zamboni/stats-min.js:5
 msgid "Ratings, last {0} days"
 msgstr "ਪਿਛਲੇ {0} ਦਿਨ, ਰੇਟਿੰਗ"
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:251
+#: static/js/impala/stats/csv_keys.js:251 static/js/zamboni/stats-all.js:15532 static/js/zamboni/stats-min.js:5
 msgid "Ratings from {0} to {1}"
 msgstr "{0} ਤੋਂ {1} ਤੱਕ ਰੇਟਿੰਗ"
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:255
+#: static/js/impala/stats/csv_keys.js:255 static/js/zamboni/stats-all.js:15536 static/js/zamboni/stats-min.js:5
 msgid "Sales, last {0} days"
 msgstr "ਆਖਰੀ {0} ਦਿਨ, ਵਿਕਰੀ"
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:257
+#: static/js/impala/stats/csv_keys.js:257 static/js/zamboni/stats-all.js:15538 static/js/zamboni/stats-min.js:5
 msgid "Sales from {0} to {1}"
 msgstr "{0} ਤੋਂ {1} ਵਿੱਚੋਂ ਵਿਕਰੀ"
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:261
+#: static/js/impala/stats/csv_keys.js:261 static/js/zamboni/stats-all.js:15542 static/js/zamboni/stats-min.js:5
 msgid "Installs, last {0} days"
 msgstr "ਆਖਰੀ {0} ਦਿਨ, ਇੰਸਟਾਲ"
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:263
+#: static/js/impala/stats/csv_keys.js:263 static/js/zamboni/stats-all.js:15544 static/js/zamboni/stats-min.js:5
 msgid "Installs from {0} to {1}"
 msgstr "{0} ਤੋਂ {1} ਵੱਲੋਂ ਇੰਸਟਾਲ"
 
 #. L10n: {0} and {1} are integers.
-#: static/js/impala/stats/csv_keys.js:269
+#: static/js/impala/stats/csv_keys.js:269 static/js/zamboni/stats-all.js:15550 static/js/zamboni/stats-min.js:5
 msgid "<b>{0}</b> in last {1} days"
 msgstr "<b>{0}</b> ਆਖਰ ਵਿੱਚ {1} ਦਿਨ"
 
 #. L10n: {0} is an integer and {1} and {2} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:271 static/js/impala/stats/csv_keys.js:277
+#: static/js/impala/stats/csv_keys.js:271 static/js/impala/stats/csv_keys.js:277 static/js/zamboni/stats-all.js:15552 static/js/zamboni/stats-all.js:15558 static/js/zamboni/stats-min.js:5
 msgid "<b>{0}</b> from {1} to {2}"
 msgstr "<b>{0}</b> ਵੱਲੋਂ {1} ਤੋਂ {2}"
 
 #. L10n: {0} and {1} are integers.
-#: static/js/impala/stats/csv_keys.js:275
+#: static/js/impala/stats/csv_keys.js:275 static/js/zamboni/stats-all.js:15556 static/js/zamboni/stats-min.js:5
 msgid "<b>{0}</b> average in last {1} days"
 msgstr "<b>{0}</b>ਅੌਸਤ ਆਖਰੀ {1} ਦਿਨਾਂ ਵਿਚ"
 
-#: static/js/impala/stats/overview.js:19
+#: static/js/impala/stats/overview.js:19 static/js/zamboni/stats-all.js:16469 static/js/zamboni/stats-min.js:5
 msgid "No data available."
 msgstr "ਕੋਈ ਡਾਟਾ ਮੌਜ਼ੂਦ ਨਹੀ"
 
-#: static/js/impala/stats/table.js:74
+#: static/js/impala/stats/table.js:74 static/js/zamboni/stats-all.js:17209 static/js/zamboni/stats-min.js:5
 msgid "Date"
 msgstr "ਤਾਰੀਖ"
 
-#: static/js/impala/stats/topchart.js:96
+#: static/js/impala/stats/topchart.js:96 static/js/zamboni/stats-all.js:16600 static/js/zamboni/stats-min.js:5
 msgid "Other"
 msgstr "ਦੂਜਾ"
 
-#: static/js/zamboni/admin_validation.js:24 static/js/zamboni/devhub.js:1229 static/js/zamboni/editors.js:295
+#: static/js/zamboni/admin-all.js:180 static/js/zamboni/admin-min.js:1 static/js/zamboni/admin_validation.js:24 static/js/zamboni/devhub-all.js:2408 static/js/zamboni/devhub-min.js:2
+#: static/js/zamboni/devhub.js:1229 static/js/zamboni/editors-all.js:15576 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:295
 msgid "Select an application first"
 msgstr "ਪਹਿਲਾਂ ਇੱਕ ਐਪਲੀਕੇਸ਼ਨ ਚੁੱਣੋ"
 
-#: static/js/zamboni/admin_validation.js:51
+#: static/js/zamboni/admin-all.js:207 static/js/zamboni/admin-min.js:1 static/js/zamboni/admin_validation.js:51
 msgid "Set {0} add-on to a max version of {1} and email the author."
 msgid_plural "Set {0} add-ons to a max version of {1} and email the authors."
 msgstr[0] "{0} ਐਡ-ਆਨ ਨੂੰ {1} ਦੇ ਮੈਕਸ ਵਰਜਨ ਤੇ ਸੈੱਟ ਕਰੋ ਅਤੇ ਲੇਖਕ ਨੂੰ ਈਮੇਲ ਕਰੋ।"
 msgstr[1] "{0} ਐਡ-ਆਨਾਂ ਨੂੰ {1} ਦੇ ਮੈਕਸ ਵਰਜਨ ਤੇ ਸੈੱਟ ਕਰੋ ਅਤੇ ਲੇਖਕਾਂ ਨੂੰ ਈਮੇਲ ਕਰੋ।"
 
-#: static/js/zamboni/admin_validation.js:54
+#: static/js/zamboni/admin-all.js:210 static/js/zamboni/admin-min.js:1 static/js/zamboni/admin_validation.js:54
 msgid "Email author of {2} add-on which failed validation."
 msgid_plural "Email authors of {2} add-ons which failed validation."
 msgstr[0] "ਪ੍ਰਮਾਣਿਕਤਾ ਵਿੱਚ ਫ਼ੇਲ੍ਹ ਹੋਏ {2} ਐਡ-ਆਨ ਦੇ ਲੇਖਕ ਨੂੰ ਈਮੇਲ ਕਰੋ।"
 msgstr[1] "ਪ੍ਰਮਾਣਿਕਤਾ ਵਿੱਚ ਫ਼ੇਲ੍ਹ ਹੋਏ {2} ਐਡ-ਆਨਾਂ ਦੇ ਲੇਖਕਾਂ ਨੂੰ ਈਮੇਲ ਕਰੋ।"
 
-#. L10n: {0} is an app name like Firefox.
-#: static/js/zamboni/buttons.js:66
-msgid "Accept and Install"
-msgstr "ਸਵੀਕਾਰ ਕਰੋ ਅਤੇ ਇੰਸਟਾਲ ਕਰੋ"
-
-#: static/js/zamboni/buttons.js:66
-msgid "Add to {0}"
-msgstr "ਸ਼ਾਮਲ ਕਰਨ ਲਈ {0}"
-
-#: static/js/zamboni/buttons.js:71
-msgid "Download Now"
-msgstr "ਹੁਣ ਡਾਊਨਲੋਡ ਕਰੋ"
-
-#: static/js/zamboni/buttons.js:112
-msgid "Add-on has not been updated to support default-to-compatible."
-msgstr "ਮੂਲ ਤੌਰ ਤੇ ਅਨੁਕੂਲਤਾ ਦਾ ਸਹਿਯੋਗ ਕਰਨ ਲਈ ਐਡ-ਆਨ ਅੱਪਡੇਟ ਨਹੀਂ ਕੀਤਾ ਗਿਆ।"
-
-#: static/js/zamboni/buttons.js:117
-msgid "You need to be using Firefox 10.0 or higher."
-msgstr "ਤੁਹਾਨੂੰ ਫ਼ਾਇਰਫ਼ਾਕਸ 10.0 ਜਾਂ ਅੱਗੇ ਵਰਤੋਂ ਕਰਨ ਦੀ ਜਰੂਰਤ ਹੈ।"
-
-#: static/js/zamboni/buttons.js:129
-msgid "Mozilla has marked this version as incompatible with your Firefox version."
-msgstr "ਮੌਜੀਲਾ ਨੇ ਇਸ ਵਰਜਨ ਤੇ ਤੁਹਾਡੇ ਫ਼ਾਇਰਫ਼ਾਕਸ ਵਰਜਨ ਨਾਲ ਅਨੁਕੂਲ ਨਾ ਹੋਣ ਦਾ ਨਿਸ਼ਾਨ ਲੱਗਾ ਦਿੱਤਾ।"
-
-#. L10n: {0} is an platform like Windows or Linux.
-#: static/js/zamboni/buttons.js:210
-msgid "Install for {0} anyway"
-msgstr "ਕਿਸੇ ਵੀ {0} ਲਈ ਇੰਸਟਾਲ"
-
-#: static/js/zamboni/buttons.js:210
-msgid "Download for {0} anyway"
-msgstr "ਕਿਸੇ ਵੀ {0} ਲਈ ਡਾਊਨਲੋਡ"
-
-#: static/js/zamboni/buttons.js:267
-msgid "Not available for your platform"
-msgstr "ਤੁਹਾਡੇ ਪਲੇਟਫਾਰਮ ਲਈ ਉਪਲੱਬਧ ਨਹੀਂ"
-
-#. L10n: {0} is an app name, {1} is the app version.
-#: static/js/zamboni/buttons.js:278 static/js/zamboni/buttons.js:315
-msgid "Not available for {0} {1}"
-msgstr "{0} {1} ਲਈ ਉਪਲੱਬਧ ਨਹੀਂ"
-
-#: static/js/zamboni/buttons.js:341
-msgid "Works with {app} {min} - {max}"
-msgstr "{app} {min} - {max} ਦੇ ਨਾਲ ਕੰਮ ਕਰਦਾ ਹੈ"
-
-#: static/js/zamboni/buttons.js:343
-msgid "View other versions"
-msgstr "ਹੋਰ ਵਰਜਨ ਦੇਖੋ"
-
-#: static/js/zamboni/buttons.js:391
-msgid "Only with Firefox — Get Firefox Now!"
-msgstr ""
-
-#: static/js/zamboni/buttons.js:507 static/js/zamboni/mobile/buttons.js:43
-msgid "Sorry, you need a Mozilla-based browser (such as Firefox) to install a search plugin."
-msgstr "ਖਿਮਾ ਕਰੋ, ਤੁਹਾਨੂੰ ਖੋਜ ਪਲੱਗਇਨ ਨੂੰ ਇੰਸਟਾਲ ਕਰਨ ਲਈ ਮੌਜੀਲਾ-ਅਧਾਰਿਤ ਬਰਾਊਜ਼ਰ ਦੀ ਲੋੜ ਹੈ।"
-
-#: static/js/zamboni/collections.js:229
-msgid "Adding to Favorites&hellip;"
-msgstr "ਪਸੰਦ ਜੋੜ ਰਿਹਾ &hellip;                "
-
-#: static/js/zamboni/collections.js:232
-msgid "Removing Favorite&hellip;"
-msgstr "ਪਸੰਦੀਦਾ ਹਟਾ ਰਿਹਾ&hellip;"
-
-#: static/js/zamboni/collections.js:235
-msgid "Add to Favorites"
-msgstr "ਪਸੰਦ ਵਿਚ ਸ਼ਾਮਲ ਕਰੋ"
-
-#: static/js/zamboni/collections.js:238
-msgid "Remove from Favorites"
-msgstr "ਪਸੰਦ ਵਿਚੋਂ ਹਟਾਓ"
-
-#: static/js/zamboni/collections.js:303
-msgid "Pending"
-msgstr "ਬਕਾਇਆ"
-
-#: static/js/zamboni/collections.js:304
-msgid "Add a comment"
-msgstr "ਕਾਮੈਂਟ ਸ਼ਾਮਲ"
-
-#: static/js/zamboni/collections.js:304
-msgid "Comment"
-msgstr "ਕਾਮੈਂਟ"
-
-#: static/js/zamboni/collections.js:305
-msgid "Remove this add-on from the collection"
-msgstr "ਭੰਡਾਰ ਵਿੱਚੋਂ ਇਹ ਐਡ-ਆਨ ਹਟਾਓ"
-
-#: static/js/zamboni/collections.js:305 static/js/zamboni/collections.js:334
-msgid "Remove"
-msgstr "ਹਟਾਓ"
-
-#: static/js/zamboni/collections.js:334
-msgid "Remove this user as a contributor"
-msgstr "ਇਸ ਯੂਜਰ ਨੂੰ ਯੋਗਦਾਨ ਦੇ ਤੌਰ ਤੇ ਹਟਾਓ"
-
-#: static/js/zamboni/collections.js:346
-msgid "An email address is required."
-msgstr "ਇੱਕ ਈਮੇਲ ਐੱਡਰੈਸ ਦੀ ਜਰੂਰਤ ਹੈ।"
-
-#: static/js/zamboni/collections.js:364
-msgid "You cannot add yourself as a contributor."
-msgstr "ਹਟਾਓ"
-
-#: static/js/zamboni/collections.js:366
-msgid "You have already added that user."
-msgstr "ਤੁਸੀ ਇਸ ਯੂਜਰ ਨੂੰ ਪਹਿਲਾਂ ਹੀ ਸ਼ਾਮਲ ਕਰ ਚੁੱਕੇ ਹੋ"
-
-#: static/js/zamboni/collections.js:573
-msgid "Add to favorites"
-msgstr "ਪਸੰਦ ਵਿੱਚ ਸ਼ਾਮਿਲ ਕਰੋ"
-
-#: static/js/zamboni/collections.js:577
-msgid "Remove from favorites"
-msgstr "ਪਸੰਦ ਵਿੱਚੋਂ ਹਟਾਓ"
-
-#: static/js/zamboni/collections.js:604
-msgid "Stop following"
-msgstr "ਨਿਮਨ ਲਿਖਤ ਰੋਕੋ"
-
-#: static/js/zamboni/devhub.js:110
+#: static/js/zamboni/devhub-all.js:1289 static/js/zamboni/devhub-min.js:1 static/js/zamboni/devhub.js:110
 msgid "Your browser does not support the video tag"
 msgstr "ਤੁਹਾਡਾ ਬਰਾਊਜਰ ਵੀਡੀਓ ਟੈਗ ਦਾ ਸਮਰਥਨ ਨਹੀ ਕਰਦਾ"
 
-#: static/js/zamboni/devhub.js:371
+#: static/js/zamboni/devhub-all.js:1550 static/js/zamboni/devhub-min.js:1 static/js/zamboni/devhub.js:371
 msgid "Changes Saved"
 msgstr "ਬਦਲਾਅ ਸੰਭਾਲੇ"
 
-#: static/js/zamboni/devhub.js:387
+#: static/js/zamboni/devhub-all.js:1566 static/js/zamboni/devhub-min.js:1 static/js/zamboni/devhub.js:387
 msgid "Enter a new author's email address"
 msgstr "ਨਵੇ ਲੇੇਖਕ ਦਾ ਈ-ਮੇਲ ਪਤਾ ਦਰਜ ਕਰੋ"
 
-#: static/js/zamboni/devhub.js:536
+#: static/js/zamboni/devhub-all.js:1715 static/js/zamboni/devhub-min.js:1 static/js/zamboni/devhub.js:536
 msgid "There was an error uploading your file."
 msgstr "ਤੁਹਾਡੀ ਫਾਈਲ ਨੂੰ ਅੱਪਲੋਡ ਕਰਨ ਦੌਰਾਨ ਇੱਕ ਗਲਤੀ ਆਈ ਸੀ।"
 
-#: static/js/zamboni/devhub.js:681
+#: static/js/zamboni/devhub-all.js:1860 static/js/zamboni/devhub-min.js:1 static/js/zamboni/devhub.js:681
 msgid "{files} file"
 msgid_plural "{files} files"
 msgstr[0] "{files} ਫਾਈਲ"
 msgstr[1] "{files} ਫਾਈਲਾਂ"
 
-#: static/js/zamboni/devhub.js:684
+#: static/js/zamboni/devhub-all.js:1863 static/js/zamboni/devhub-min.js:1 static/js/zamboni/devhub.js:684
 msgid "{reviews} user review"
 msgid_plural "{reviews} user reviews"
 msgstr[0] "{reviews} ਉਪਭੋਗੀ ਸਮੀਖਿਆ"
 msgstr[1] "{reviews} ਉਪਭੋਗੀ ਸਮੀਖਿਆਵਾਂ"
 
-#: static/js/zamboni/devhub.js:796
+#: static/js/zamboni/devhub-all.js:1975 static/js/zamboni/devhub-min.js:2 static/js/zamboni/devhub.js:796
 msgid "Learn more"
 msgstr "ਹੋਰ ਜਾਣੋ"
 
-#: static/js/zamboni/devhub.js:800
+#: static/js/zamboni/devhub-all.js:1979 static/js/zamboni/devhub-min.js:2 static/js/zamboni/devhub.js:800
 msgid "Example"
 msgstr "ਉਦਾਹਰਨ"
 
-#: static/js/zamboni/devhub.js:1130
+#: static/js/zamboni/devhub-all.js:2309 static/js/zamboni/devhub-min.js:2 static/js/zamboni/devhub.js:1130
 msgid "Image changes being processed"
 msgstr "ਚਿੱਤਰ ਬਦਲਾਓ ਕਾਰਵਾਈ ਕੀਤੀ ਜਾ ਰਹੀ ਹੈ"
 
-#: static/js/zamboni/devhub.js:1280
+#: static/js/zamboni/devhub-all.js:2459 static/js/zamboni/devhub-min.js:2 static/js/zamboni/devhub.js:1280
 msgid "Must be a valid e-mail address."
 msgstr "ਈ-ਮੇਲ ਐਡਰੈੱਸ ਸਹੀ ਹੋਣਾ ਚਾਹੀਦਾ ਹੈ।"
 
-#: static/js/zamboni/devhub_search.js:8
-msgid "No results found."
-msgstr "ਕੋਈ ਨਤੀਜਾ ਨਹੀਂ ਮਿਲਿਆ।"
-
-#: static/js/zamboni/editors.js:121
-msgid "{name} was viewing this page first."
-msgstr "{name} ਇਹ ਸਫਾ ਪਹਿਲਾਂ ਦੇਖਿਆ ਸੀ।"
-
-#: static/js/zamboni/editors.js:171
-msgid "Receipt checked by app."
-msgstr "ਰਸ਼ੀਦ ਐਪ ਦੁਆਰਾ ਚੈੱਕ।"
-
-#: static/js/zamboni/editors.js:173
-msgid "Receipt was not checked by app."
-msgstr "ਰਸ਼ੀਦ ਐਪ ਦੁਆਰਾ ਚੈੱਕ ਨਹੀਂ ਕੀਤੀ ਸੀ।"
-
-#: static/js/zamboni/editors.js:244
-msgid "{name} was viewing this add-on first."
-msgstr "{name} ਇਹ ਐਡ-ਆਨ ਪਹਿਲਾਂ ਦੇਖਿਆ ਸੀ।"
-
-#: static/js/zamboni/editors.js:255
-msgid "Loading&hellip;"
-msgstr "&hellip; ਲ੍ਹੋਡ ਕੀਤਾ ਜਾ ਰਿਹਾ"
-
-#: static/js/zamboni/editors.js:260
-msgid "Version Notes"
-msgstr "ਸੂਚਨਾਂ ਵਰਜਨ"
-
-#: static/js/zamboni/editors.js:265
-msgid "Notes for Reviewers"
-msgstr "ਸਮੀਖਿਅਕ ਲਈ ਸੂਚਨਾਂ"
-
-#: static/js/zamboni/editors.js:270
-msgid "No version notes found"
-msgstr "ਵਰਜਨ ਨੂੰ ਨੋਟਿਸ ਨਹੀਂ ਮਿਲਿਆ"
-
-#: static/js/zamboni/editors.js:330
-msgid "Average Reviews"
-msgstr ""
-
-#: static/js/zamboni/editors.js:386
-msgid "Number of Reviews"
-msgstr ""
-
-#: static/js/zamboni/editors.js:445
-msgid "Error loading translation"
-msgstr "ਲ੍ਹੋਡ ਕਰਨ ਦੌਰਾਨ ਅਨੁਵਾਦ ਗਲਤੀ"
-
-#: static/js/zamboni/files.js:411 static/js/zamboni/validator.js:261
-msgid "Ignore this message in future updates"
-msgstr ""
-
-#: static/js/zamboni/files.js:417 static/js/zamboni/validator.js:284
-msgid "Severity for automated signing:"
-msgstr ""
-
-#: static/js/zamboni/global.js:410
-msgid "Loading..."
-msgstr "ਲੋਡ ਹੋ ਰਿਹਾ ਹੈ..."
-
-#. L10n: {0} is the number of characters left.
-#: static/js/zamboni/global.js:474
-msgid "<b>{0}</b> character left."
-msgid_plural "<b>{0}</b> characters left."
-msgstr[0] "<b>{0}</b> ਅੱਖਰ ਖੱਬੇ."
-msgstr[1] "<b>{0}</b> ਅੱਖਰ ਖੱਬੇ."
-
-#: static/js/zamboni/init.js:28
-msgid "This feature is temporarily disabled while we perform website maintenance. Please check back a little later."
-msgstr "ਇਹ ਫ਼ੀਚਰ ਅਸਥਾਈ ਤੌਰ ਤੇ ਬੰਦ ਹੈ,ਜਦ ਤੱਕ ਅਸੀ ਵੈਬਸਾਈਟ ਚ ਸੁਧਾਰ ਕਰ ਰਹੇ ਹਾਂ । ਕਿਰਪਾ ਕਰਕੇ ਕੁਝ ਚਿਰ ਬਾਅਦ ਪੜਤਾਲ ਕਰੋ ।"
-
-#: static/js/zamboni/l10n.js:45
-msgid "Remove this localization"
-msgstr "ਇਹ ਸਥਾਨੀਕਰਨ ਹਟਾਓ"
-
-#: static/js/zamboni/password-strength.js:20
-msgid "Password strength:"
-msgstr "ਪਾਸਵਰਡ ਤਾਕਤ"
-
-#: static/js/zamboni/password-strength.js:26
-msgid "At least {0} character left."
-msgid_plural "At least {0} characters left."
-msgstr[0] "ਘੱਟੋ ਤੋਂ ਘੱਟ {0} ਅੱਖਰ ਬਾਕੀ।"
-msgstr[1] "ਘੱਟੋ ਤੋਂ ਘੱਟ {0} ਅੱਖਰ ਬਾਕੀ।"
-
-#: static/js/zamboni/themes_review.js:176
-msgid "Requested Info"
-msgstr "ਜਾਣਕਾਰੀ ਲਈ ਬੇਨਤੀ"
-
-#: static/js/zamboni/themes_review.js:177
-msgid "Flagged"
-msgstr "ਫਲੈਗ ਕੀਤੇ ਹੋਏ"
-
-#: static/js/zamboni/themes_review.js:178
-msgid "Duplicate"
-msgstr "ਨਕਲੀ"
-
-#: static/js/zamboni/themes_review.js:179
-msgid "Rejected"
-msgstr "ਰੱਦ ਕਰੋ"
-
-#: static/js/zamboni/themes_review.js:180
-msgid "Approved"
-msgstr "ਮੰਨਜੂਰੀ ਦੇਣਾ"
-
-#: static/js/zamboni/themes_review.js:424
-msgid "No results found"
-msgstr ""
-
-#: static/js/zamboni/themes_review_templates.js:31
-msgid "Theme"
-msgstr ""
-
-#: static/js/zamboni/themes_review_templates.js:33
-msgid "Reviewer"
-msgstr ""
-
-#: static/js/zamboni/themes_review_templates.js:35
-msgid "Status"
-msgstr ""
-
-#: static/js/zamboni/validator.js:80
+#: static/js/zamboni/devhub-all.js:2613 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:80
 msgid "All tests passed successfully."
 msgstr "ਸਾਰੇ ਟੈਸਟ ਸਫਲਤਾਪੂਰਵਕ ਪਾਸ ਹੋਏ।"
 
-#: static/js/zamboni/validator.js:83 static/js/zamboni/validator.js:478
+#: static/js/zamboni/devhub-all.js:2616 static/js/zamboni/devhub-all.js:3011 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:83 static/js/zamboni/validator.js:478
 msgid "These tests were not run."
 msgstr "ਇਹ ਟੈਸਟ ਨਹੀਂ ਚਲਾਉਣੇ ਸਨ।"
 
-#: static/js/zamboni/validator.js:131 static/js/zamboni/validator.js:144
+#: static/js/zamboni/devhub-all.js:2664 static/js/zamboni/devhub-all.js:2677 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:131 static/js/zamboni/validator.js:144
 msgid "Tests"
 msgstr "ਟੈਸਟ"
 
-#: static/js/zamboni/validator.js:246 static/js/zamboni/validator.js:575 static/js/zamboni/validator.js:594
+#: static/js/zamboni/devhub-all.js:2779 static/js/zamboni/devhub-all.js:3108 static/js/zamboni/devhub-all.js:3127 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:246
+#: static/js/zamboni/validator.js:575 static/js/zamboni/validator.js:594
 msgid "Error"
 msgstr "ਗਲਤੀ"
 
-#: static/js/zamboni/validator.js:247
+#: static/js/zamboni/devhub-all.js:2780 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:247
 msgid "Warning"
 msgstr "ਚੇਤਾਵਨੀ"
 
-#: static/js/zamboni/validator.js:299
+#: static/js/zamboni/devhub-all.js:2794 static/js/zamboni/devhub-min.js:2 static/js/zamboni/files-all.js:5657 static/js/zamboni/files-min.js:3 static/js/zamboni/files.js:411
+#: static/js/zamboni/validator.js:261
+msgid "Ignore this message in future updates"
+msgstr ""
+
+#: static/js/zamboni/devhub-all.js:2817 static/js/zamboni/devhub-min.js:2 static/js/zamboni/files-all.js:5663 static/js/zamboni/files-min.js:3 static/js/zamboni/files.js:417
+#: static/js/zamboni/validator.js:284
+msgid "Severity for automated signing:"
+msgstr ""
+
+#: static/js/zamboni/devhub-all.js:2832 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:299
 msgid "Suggestions for passing automated signing:"
 msgstr ""
 
-#: static/js/zamboni/validator.js:387
+#: static/js/zamboni/devhub-all.js:2920 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:387
 msgid "Compatibility Tests"
 msgstr "ਅਨਕੂਲਤਾ ਟੈਸਟ"
 
-#: static/js/zamboni/validator.js:466
+#: static/js/zamboni/devhub-all.js:2999 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:466
 msgid "Add-on failed validation."
 msgstr "ਐਡ-ਆਨ ਪ੍ਰਮਾਣਿਕਤਾ ਫ਼ੇਲ੍ਹ ਹੋਈ।"
 
-#: static/js/zamboni/validator.js:468
+#: static/js/zamboni/devhub-all.js:3001 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:468
 msgid "Add-on passed validation."
 msgstr "ਐਡ-ਆਨ ਨੇ ਪ੍ਰਮਾਣਿਕਤਾ ਪਾਸ ਕੀਤੀ।"
 
-#: static/js/zamboni/validator.js:481
+#: static/js/zamboni/devhub-all.js:3014 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:481
 msgid "{0} error"
 msgid_plural "{0} errors"
 msgstr[0] "{0} ਗਲਤੀ"
 msgstr[1] "{0}ਗਲਤੀਆਂ"
 
-#: static/js/zamboni/validator.js:483
+#: static/js/zamboni/devhub-all.js:3016 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:483
 msgid "{0} warning"
 msgid_plural "{0} warnings"
 msgstr[0] "{0} ਚੇਤਾਵਨੀ"
 msgstr[1] "{0} ਚੇਤਾਵਨੀਆਂ"
 
-#: static/js/zamboni/validator.js:485
+#: static/js/zamboni/devhub-all.js:3018 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:485
 msgid "{0} notice"
 msgid_plural "{0} notices"
 msgstr[0] "{0} ਨੋਟਿਸ"
 msgstr[1] "{0} ਨੋਟਿਸ"
 
-#: static/js/zamboni/validator.js:577
+#: static/js/zamboni/devhub-all.js:3110 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:577
 msgid "Validation task could not complete or completed with errors"
 msgstr "ਪ੍ਰਮਾਣਿਕਤਾ ਕਾਰਜ ਮੁਕੰਮਲ ਨਹੀਂ ਹੋਇਆ ਜਾਂ ਖਾਮੀਆਂ ਨਾਲ ਮੁਕੰਮਲ ਹੋਇਆ"
 
-#: static/js/zamboni/validator.js:595
+#: static/js/zamboni/devhub-all.js:3128 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:595
 msgid "Internal server error"
 msgstr "ਅੰਦਰੂਨੀ ਸਰਵਰ ਗਲਤੀ"
 
-#: static/js/zamboni/mobile/buttons.js:52
+#: static/js/zamboni/devhub_search.js:8
+msgid "No results found."
+msgstr "ਕੋਈ ਨਤੀਜਾ ਨਹੀਂ ਮਿਲਿਆ।"
+
+#: static/js/zamboni/editors-all.js:15402 static/js/zamboni/editors-min.js:4 static/js/zamboni/editors.js:121
+msgid "{name} was viewing this page first."
+msgstr "{name} ਇਹ ਸਫਾ ਪਹਿਲਾਂ ਦੇਖਿਆ ਸੀ।"
+
+#: static/js/zamboni/editors-all.js:15452 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:171
+msgid "Receipt checked by app."
+msgstr "ਰਸ਼ੀਦ ਐਪ ਦੁਆਰਾ ਚੈੱਕ।"
+
+#: static/js/zamboni/editors-all.js:15454 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:173
+msgid "Receipt was not checked by app."
+msgstr "ਰਸ਼ੀਦ ਐਪ ਦੁਆਰਾ ਚੈੱਕ ਨਹੀਂ ਕੀਤੀ ਸੀ।"
+
+#: static/js/zamboni/editors-all.js:15525 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:244
+msgid "{name} was viewing this add-on first."
+msgstr "{name} ਇਹ ਐਡ-ਆਨ ਪਹਿਲਾਂ ਦੇਖਿਆ ਸੀ।"
+
+#: static/js/zamboni/editors-all.js:15536 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:255
+msgid "Loading&hellip;"
+msgstr "&hellip; ਲ੍ਹੋਡ ਕੀਤਾ ਜਾ ਰਿਹਾ"
+
+#: static/js/zamboni/editors-all.js:15541 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:260
+msgid "Version Notes"
+msgstr "ਸੂਚਨਾਂ ਵਰਜਨ"
+
+#: static/js/zamboni/editors-all.js:15546 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:265
+msgid "Notes for Reviewers"
+msgstr "ਸਮੀਖਿਅਕ ਲਈ ਸੂਚਨਾਂ"
+
+#: static/js/zamboni/editors-all.js:15551 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:270
+msgid "No version notes found"
+msgstr "ਵਰਜਨ ਨੂੰ ਨੋਟਿਸ ਨਹੀਂ ਮਿਲਿਆ"
+
+#: static/js/zamboni/editors-all.js:15611 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:330
+msgid "Average Reviews"
+msgstr ""
+
+#: static/js/zamboni/editors-all.js:15667 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:386
+msgid "Number of Reviews"
+msgstr ""
+
+#: static/js/zamboni/editors-all.js:15726 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:445
+msgid "Error loading translation"
+msgstr "ਲ੍ਹੋਡ ਕਰਨ ਦੌਰਾਨ ਅਨੁਵਾਦ ਗਲਤੀ"
+
+#: static/js/zamboni/editors-all.js:15975 static/js/zamboni/editors-min.js:5 static/js/zamboni/themes_review_templates.js:31
+msgid "Theme"
+msgstr ""
+
+#: static/js/zamboni/editors-all.js:15977 static/js/zamboni/editors-min.js:5 static/js/zamboni/themes_review_templates.js:33
+msgid "Reviewer"
+msgstr ""
+
+#: static/js/zamboni/editors-all.js:15979 static/js/zamboni/editors-min.js:5 static/js/zamboni/themes_review_templates.js:35
+msgid "Status"
+msgstr ""
+
+#: static/js/zamboni/editors-all.js:16196 static/js/zamboni/editors-min.js:5 static/js/zamboni/themes_review.js:176
+msgid "Requested Info"
+msgstr "ਜਾਣਕਾਰੀ ਲਈ ਬੇਨਤੀ"
+
+#: static/js/zamboni/editors-all.js:16197 static/js/zamboni/editors-min.js:5 static/js/zamboni/themes_review.js:177
+msgid "Flagged"
+msgstr "ਫਲੈਗ ਕੀਤੇ ਹੋਏ"
+
+#: static/js/zamboni/editors-all.js:16198 static/js/zamboni/editors-min.js:5 static/js/zamboni/themes_review.js:178
+msgid "Duplicate"
+msgstr "ਨਕਲੀ"
+
+#: static/js/zamboni/editors-all.js:16199 static/js/zamboni/editors-min.js:5 static/js/zamboni/themes_review.js:179
+msgid "Rejected"
+msgstr "ਰੱਦ ਕਰੋ"
+
+#: static/js/zamboni/editors-all.js:16200 static/js/zamboni/editors-min.js:5 static/js/zamboni/themes_review.js:180
+msgid "Approved"
+msgstr "ਮੰਨਜੂਰੀ ਦੇਣਾ"
+
+#: static/js/zamboni/editors-all.js:16444 static/js/zamboni/editors-min.js:5 static/js/zamboni/themes_review.js:424
+msgid "No results found"
+msgstr ""
+
+#: static/js/zamboni/mobile-all.js:15186 static/js/zamboni/mobile/buttons.js:52
 msgid "Not Updated for {0} {1}"
 msgstr "{0} {1} ਲਈ ਅੱਪਡੇਟ ਨਹੀਂ"
 
-#: static/js/zamboni/mobile/buttons.js:53
+#: static/js/zamboni/mobile-all.js:15187 static/js/zamboni/mobile/buttons.js:53
 msgid "Requires Newer Version of {0}"
 msgstr "{0} ਤੋਂ ਨਵੇਂ ਵਰਜਨ ਦੀ ਮੰਗ"
 
-#: static/js/zamboni/mobile/buttons.js:54
+#: static/js/zamboni/mobile-all.js:15188 static/js/zamboni/mobile/buttons.js:54
 msgid "Unreviewed"
 msgstr "ਨਾ-ਸਮੀਖਿਆ"
 
-#: static/js/zamboni/mobile/buttons.js:55
+#: static/js/zamboni/mobile-all.js:15189 static/js/zamboni/mobile/buttons.js:55
 msgid "Experimental <span>(Learn More)</span>"
 msgstr "ਪ੍ਰਯੋਗਆਤਮਕ <span>(ਹੋਰ ਜਾਣੋ)</span>"
 
-#: static/js/zamboni/mobile/buttons.js:56 static/js/zamboni/mobile/buttons.js:57
+#: static/js/zamboni/mobile-all.js:15190 static/js/zamboni/mobile-all.js:15191 static/js/zamboni/mobile/buttons.js:56 static/js/zamboni/mobile/buttons.js:57
 msgid "Not Available for {0}"
 msgstr "{0} ਲਈ ਉੱਪਲਬਧ ਨਹੀਂ"
 
-#: static/js/zamboni/mobile/buttons.js:58
+#: static/js/zamboni/mobile-all.js:15192 static/js/zamboni/mobile/buttons.js:58
 msgid "Experimental"
 msgstr "ਤਜਰਬੇ"
 
-#: static/js/zamboni/mobile/buttons.js:59
+#: static/js/zamboni/mobile-all.js:15193 static/js/zamboni/mobile/buttons.js:59
 msgid "Themes Require Newer Version of {0}"
 msgstr "ਥੀਮਾਂ ਨੂੰ {0} ਦੇ ਨਵੇਂ ਵਰਜਨ ਦੀ ਲੋੜ"
 
-#: static/js/zamboni/mobile/buttons.js:60
+#: static/js/zamboni/mobile-all.js:15194 static/js/zamboni/mobile/buttons.js:60
 msgid "Themes Require {0}"
 msgstr "ਥੀਮਾਂ ਨੂੰ {0} ਦੀ ਲੋੜ"
 
-#: static/js/zamboni/mobile/buttons.js:105
+#: static/js/zamboni/mobile-all.js:15239 static/js/zamboni/mobile/buttons.js:105
 msgid "Installing..."
 msgstr "ਇੰਸਟਾਲ ਕਰਨਾ"
 
-#: static/js/zamboni/mobile/buttons.js:125
+#: static/js/zamboni/mobile-all.js:15259 static/js/zamboni/mobile/buttons.js:125
 msgid "This add-on has been preliminarily reviewed by Mozilla."
 msgstr "ਮੌਜੀਲਾ ਨੇ ਇਸ ਐਡ-ਆਨ ਦੀ ਸ਼ੁਰੂਆਤੀ ਸਮੀਖਿਆ ਕੀਤੀ।"
 
-#: static/js/zamboni/mobile/buttons.js:250
+#: static/js/zamboni/mobile-all.js:15384 static/js/zamboni/mobile/buttons.js:250
 msgid "Keep it"
 msgstr "ਇਸ ਨੂੰ ਰੱਖੋ"
 
-#: static/js/zamboni/mobile/general.js:344
+#: static/js/zamboni/mobile-all.js:16049 static/js/zamboni/mobile-min.js:6 static/js/zamboni/mobile/general.js:344
 msgid "You're trying it on!"
 msgstr "ਤੁਸੀਂ ਇਸਦੀ ਪਰਖ ਕਰ ਰਹੇ ਹੋ!"
 
-#: static/js/zamboni/mobile/general.js:356
+#: static/js/zamboni/mobile-all.js:16061 static/js/zamboni/mobile-min.js:6 static/js/zamboni/mobile/general.js:356
 msgid "Added to Firefox"
 msgstr "ਫ਼ਾਇਰਫ਼ਾਕਸ ਵਿੱਚ ਸ਼ਾਮਲ"

--- a/locale/pl/LC_MESSAGES/django.po
+++ b/locale/pl/LC_MESSAGES/django.po
@@ -11,7 +11,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version:  addons\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2016-02-24 21:23+0000\n"
+"POT-Creation-Date: 2016-04-18 15:40+0000\n"
 "PO-Revision-Date: 2015-11-03 12:10+0100\n"
 "Last-Translator: Wojciech Szczęsny\n"
 "Language-Team: Polish <kde-i18n-doc@kde.org>\n"
@@ -20,60 +20,60 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Generated-By: Babel 2.2.0\n"
 
-#: src/olympia/accounts/views.py:52
+#: src/olympia/accounts/views.py:54
 msgid "Your log in attempt could not be parsed. Please try again."
 msgstr ""
 
-#: src/olympia/accounts/views.py:54
+#: src/olympia/accounts/views.py:56
 msgid "Your Firefox Account could not be found. Please try again."
 msgstr ""
 
-#: src/olympia/accounts/views.py:55
+#: src/olympia/accounts/views.py:57
 msgid "You could not be logged in. Please try again."
 msgstr ""
 
-#: src/olympia/accounts/views.py:57
+#: src/olympia/accounts/views.py:59
 msgid "Your account has already been migrated to Firefox Accounts."
 msgstr ""
 
-#: src/olympia/accounts/views.py:59
+#: src/olympia/accounts/views.py:61
 msgid "Your Firefox Account already exists on this site."
 msgstr ""
 
-#: src/olympia/accounts/views.py:108
+#: src/olympia/accounts/views.py:110
 msgid "Great job!"
 msgstr ""
 
-#: src/olympia/accounts/views.py:109
+#: src/olympia/accounts/views.py:111
 msgid "You can now log in to Add-ons with your Firefox Account."
 msgstr ""
 
-#: src/olympia/accounts/views.py:121
+#: src/olympia/accounts/views.py:123
 msgid "Need help?"
 msgstr ""
 
-#: src/olympia/addons/buttons.py:180
+#: src/olympia/addons/buttons.py:177
 msgid "Download Now"
 msgstr "Pobierz"
 
-#: src/olympia/addons/buttons.py:182
+#: src/olympia/addons/buttons.py:179
 msgid "Download"
 msgstr "Pobierz"
 
 #. L10n: please keep &nbsp; in the string so &rarr; does not wrap.
-#: src/olympia/addons/buttons.py:186
+#: src/olympia/addons/buttons.py:183
 msgid "Continue to Download&nbsp;&rarr;"
 msgstr "Dalej&nbsp;&rarr;"
 
-#: src/olympia/addons/buttons.py:202 src/olympia/addons/helpers.py:35 src/olympia/addons/views.py:319 src/olympia/addons/templates/addons/impala/details.html:114
+#: src/olympia/addons/buttons.py:199 src/olympia/addons/helpers.py:35 src/olympia/addons/views.py:333 src/olympia/addons/templates/addons/impala/details.html:111
 #: src/olympia/addons/templates/addons/impala/listing/items.html:17 src/olympia/addons/templates/addons/mobile/home.html:40 src/olympia/amo/templates/amo/side_nav.html:6
-#: src/olympia/amo/templates/amo/side_nav.html:10 src/olympia/amo/templates/amo/site_nav.html:2 src/olympia/amo/templates/amo/site_nav.html:55 src/olympia/bandwagon/views.py:95
-#: src/olympia/browse/views.py:54 src/olympia/browse/views.py:68 src/olympia/browse/views.py:235 src/olympia/browse/templates/browse/impala/category_landing.html:22
+#: src/olympia/amo/templates/amo/side_nav.html:10 src/olympia/amo/templates/amo/site_nav.html:2 src/olympia/amo/templates/amo/site_nav.html:53 src/olympia/bandwagon/views.py:95
+#: src/olympia/browse/views.py:54 src/olympia/browse/views.py:68 src/olympia/browse/views.py:202 src/olympia/browse/templates/browse/impala/category_landing.html:22
 #: src/olympia/browse/templates/browse/personas/mobile/category_landing.html:26
 msgid "Featured"
 msgstr "Polecane"
 
-#: src/olympia/addons/buttons.py:221
+#: src/olympia/addons/buttons.py:218
 msgid "Add to {0}"
 msgstr "Zainstaluj"
 
@@ -96,7 +96,6 @@ msgid "Invalid tag: {0}"
 msgid_plural "Invalid tags: {0}"
 msgstr[0] "Nieprawidłowa etykieta: {0}"
 msgstr[1] "Nieprawidłowe etykiety: {0}"
-msgstr[2] "Nieprawidłowe etykiety: {0}"
 
 #. L10n: {0} is a single tag or a comma-separated list of tags.
 #: src/olympia/addons/forms.py:103
@@ -104,14 +103,12 @@ msgid "\"{0}\" is a reserved tag and cannot be used."
 msgid_plural "\"{0}\" are reserved tags and cannot be used."
 msgstr[0] "Etykieta „{0}” jest zarezerwowana i nie może zostać użyta."
 msgstr[1] "Etykiety „{0}” są zarezerwowane i nie mogą zostać użyte."
-msgstr[2] "Etykiety „{0}” są zarezerwowane i nie mogą zostać użyte."
 
 #: src/olympia/addons/forms.py:111
 msgid "You have {0} too many tags."
 msgid_plural "You have {0} too many tags."
 msgstr[0] "Masz za dużo {0} etykietę."
 msgstr[1] "Masz za dużo o {0} etykiety."
-msgstr[2] "Masz za dużo o {0} etykiet."
 
 #: src/olympia/addons/forms.py:117
 #, python-format
@@ -123,42 +120,40 @@ msgid "All tags must be at least {0} character."
 msgid_plural "All tags must be at least {0} characters."
 msgstr[0] "Każda etykieta musi mieć przynajmniej {0} znak."
 msgstr[1] "Każda etykieta musi mieć przynajmniej {0} znaki."
-msgstr[2] "Każda etykieta musi mieć przynajmniej {0} znaków."
 
-#: src/olympia/addons/forms.py:234
+#: src/olympia/addons/forms.py:238
 msgid "Categories cannot be changed while your add-on is featured for this application."
 msgstr "Nie można zmieniać kategorii, gdy dodatek jest polecany dla tego programu."
 
 #. L10n: {0} is the number of categories.
-#: src/olympia/addons/forms.py:238
+#: src/olympia/addons/forms.py:242
 msgid "You can have only {0} category."
 msgid_plural "You can have only {0} categories."
 msgstr[0] "Można wybrać tylko {0} kategorię."
 msgstr[1] "Można wybrać tylko {0} kategorie."
-msgstr[2] "Można wybrać tylko {0} kategorii."
 
-#: src/olympia/addons/forms.py:246
+#: src/olympia/addons/forms.py:250
 msgid "The miscellaneous category cannot be combined with additional categories."
 msgstr "Kategoria „Ogólne” nie może być łączona z innymi kategoriami."
 
-#: src/olympia/addons/forms.py:369
+#: src/olympia/addons/forms.py:374
 #, python-format
 msgid "Before changing your default locale you must have a name, summary, and description in that locale. You are missing %s."
 msgstr "Zanim zmienisz domyślną lokalizację na inną, musi być dla nowej lokalizacji podana nazwa, skrócony oraz pełny opis. Brakuje: %s."
 
-#: src/olympia/addons/forms.py:484 src/olympia/addons/forms.py:575
+#: src/olympia/addons/forms.py:455 src/olympia/addons/forms.py:546
 msgid "A license must be selected."
 msgstr "Licencja musi być określona."
 
-#: src/olympia/addons/forms.py:556
+#: src/olympia/addons/forms.py:527
 msgid "Give Your Theme a Name."
 msgstr "Podaj nazwę swojego motywu"
 
-#: src/olympia/addons/forms.py:562 src/olympia/devhub/templates/devhub/personas/submit.html:53
+#: src/olympia/addons/forms.py:533 src/olympia/devhub/templates/devhub/personas/submit.html:53
 msgid "Describe your Theme."
 msgstr "Opisz swój motyw."
 
-#: src/olympia/addons/forms.py:704
+#: src/olympia/addons/forms.py:675
 msgid "Enter a new author's email address"
 msgstr "Wprowadź nowy adres e-mail autora"
 
@@ -166,39 +161,39 @@ msgstr "Wprowadź nowy adres e-mail autora"
 msgid "Not Reviewed"
 msgstr "Niesprawdzony"
 
-#: src/olympia/addons/models.py:301
+#: src/olympia/addons/models.py:298
 msgid "Users have the option of contributing more or less than this amount."
 msgstr "Otrzymana kwota dotacji może być różna od tutaj podanej."
 
-#: src/olympia/addons/models.py:309
-msgid "Users will always be asked in the Add-ons Manager (Firefox 4 and above)"
-msgstr "Prośby o dotacje będą zawsze wyświetlane w menedżerze dodatków (Firefox 4 i nowsze wersje)"
+#: src/olympia/addons/models.py:306
+msgid "Users will always be asked in the Add-ons Manager (Firefox 4 and above). Only applies to desktop."
+msgstr ""
 
 # Column name in a table.
-#: src/olympia/addons/models.py:1804 src/olympia/addons/templates/addons/details_box.html:55 src/olympia/devhub/templates/devhub/index.html:92
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:102
+#: src/olympia/addons/models.py:1802 src/olympia/addons/templates/addons/details_box.html:55 src/olympia/devhub/templates/devhub/index.html:92
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:89
 msgid "Listed"
 msgstr "Wyświetlanie"
 
-#: src/olympia/addons/views.py:320 src/olympia/browse/templates/browse/personas/mobile/category_landing.html:27
+#: src/olympia/addons/views.py:334 src/olympia/browse/templates/browse/personas/mobile/category_landing.html:27
 msgid "Popular"
 msgstr "Popularne"
 
-#: src/olympia/addons/views.py:321 src/olympia/browse/views.py:238 src/olympia/browse/views.py:280 src/olympia/browse/views.py:482
+#: src/olympia/addons/views.py:335 src/olympia/browse/views.py:205 src/olympia/browse/views.py:247 src/olympia/browse/views.py:449
 msgid "Recently Added"
 msgstr "Najnowsze"
 
-#: src/olympia/addons/views.py:322 src/olympia/bandwagon/views.py:99 src/olympia/browse/views.py:60 src/olympia/browse/views.py:71 src/olympia/search/forms.py:16 src/olympia/search/forms.py:91
+#: src/olympia/addons/views.py:336 src/olympia/bandwagon/views.py:99 src/olympia/browse/views.py:60 src/olympia/browse/views.py:71 src/olympia/search/forms.py:16 src/olympia/search/forms.py:91
 msgid "Recently Updated"
 msgstr "Zaktualizowane"
 
 # %1 is an add-on name.
 #. l10n: {0} is the addon name
-#: src/olympia/addons/views.py:520
+#: src/olympia/addons/views.py:534
 msgid "Contribution for {0}"
 msgstr "Dotacja dla {0}"
 
-#: src/olympia/addons/views.py:613
+#: src/olympia/addons/views.py:627
 msgid "Abuse reported."
 msgstr "Zgłoszono naruszenie zasad."
 
@@ -267,9 +262,9 @@ msgstr "Przekaż dotację"
 #: src/olympia/devhub/templates/devhub/addons/ajax_compat_update.html:36 src/olympia/devhub/templates/devhub/addons/profile.html:44 src/olympia/devhub/templates/devhub/addons/edit/admin.html:101
 #: src/olympia/devhub/templates/devhub/addons/edit/basic.html:152 src/olympia/devhub/templates/devhub/addons/edit/details.html:85 src/olympia/devhub/templates/devhub/addons/edit/support.html:67
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:166 src/olympia/devhub/templates/devhub/addons/forms_shared/media.html:149
-#: src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:44 src/olympia/devhub/templates/devhub/versions/add_file_modal.html:78 src/olympia/devhub/templates/devhub/versions/edit.html:139
-#: src/olympia/devhub/templates/devhub/versions/list.html:242 src/olympia/devhub/templates/devhub/versions/list.html:276 src/olympia/devhub/templates/devhub/versions/list.html:317
-#: src/olympia/devhub/templates/devhub/versions/list.html:351 src/olympia/reviews/templates/reviews/edit_review.html:16 src/olympia/translations/templates/translations/trans-menu.html:50
+#: src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:43 src/olympia/devhub/templates/devhub/versions/add_file_modal.html:58 src/olympia/devhub/templates/devhub/versions/edit.html:139
+#: src/olympia/devhub/templates/devhub/versions/list.html:239 src/olympia/devhub/templates/devhub/versions/list.html:281 src/olympia/devhub/templates/devhub/versions/list.html:315
+#: src/olympia/devhub/templates/devhub/versions/list.html:349 src/olympia/reviews/templates/reviews/edit_review.html:16 src/olympia/translations/templates/translations/trans-menu.html:50
 #: src/olympia/translations/templates/translations/trans-menu.html:62
 msgid "or"
 msgstr "lub"
@@ -379,7 +374,7 @@ msgid "Add-on Information for {0}"
 msgstr "Informacje o dodatku {0}"
 
 #: src/olympia/addons/templates/addons/details_box.html:30 src/olympia/addons/templates/addons/persona_detail_table.html:3 src/olympia/addons/templates/addons/mobile/details.html:63
-#: src/olympia/addons/templates/addons/mobile/persona_detail_table.html:7 src/olympia/browse/views.py:459 src/olympia/devhub/views.py:75
+#: src/olympia/addons/templates/addons/mobile/persona_detail_table.html:7 src/olympia/browse/views.py:426 src/olympia/devhub/views.py:74
 msgid "Updated"
 msgstr "Aktualizacja"
 
@@ -398,11 +393,11 @@ msgstr "Działa z"
 msgid "Visibility"
 msgstr "Widoczność"
 
-#: src/olympia/addons/templates/addons/details_box.html:57 src/olympia/devhub/templates/devhub/index.html:94 src/olympia/devhub/templates/devhub/includes/addon_details.html:104
+#: src/olympia/addons/templates/addons/details_box.html:57 src/olympia/devhub/templates/devhub/index.html:94 src/olympia/devhub/templates/devhub/includes/addon_details.html:91
 msgid "Hidden"
 msgstr "Ukryty"
 
-#: src/olympia/addons/templates/addons/details_box.html:59 src/olympia/devhub/templates/devhub/index.html:96 src/olympia/devhub/templates/devhub/includes/addon_details.html:106
+#: src/olympia/addons/templates/addons/details_box.html:59 src/olympia/devhub/templates/devhub/index.html:96 src/olympia/devhub/templates/devhub/includes/addon_details.html:93
 msgid "Unlisted"
 msgstr "Niewyświetlany"
 
@@ -410,13 +405,13 @@ msgstr "Niewyświetlany"
 msgid "Required Add-ons"
 msgstr "Wymagane dodatki"
 
-#: src/olympia/addons/templates/addons/details_box.html:81 src/olympia/addons/templates/addons/persona_detail_table.html:15 src/olympia/browse/views.py:462 src/olympia/devhub/views.py:78
-#: src/olympia/devhub/views.py:85 src/olympia/discovery/templates/discovery/addons/detail.html:57 src/olympia/reviews/forms.py:62 src/olympia/reviews/templates/reviews/add.html:57
+#: src/olympia/addons/templates/addons/details_box.html:81 src/olympia/addons/templates/addons/persona_detail_table.html:15 src/olympia/browse/views.py:429 src/olympia/devhub/views.py:77
+#: src/olympia/devhub/views.py:84 src/olympia/discovery/templates/discovery/addons/detail.html:57 src/olympia/reviews/forms.py:62 src/olympia/reviews/templates/reviews/add.html:57
 #: src/olympia/reviews/templates/reviews/mobile/review_list.html:18
 msgid "Rating"
 msgstr "Oceny"
 
-#: src/olympia/addons/templates/addons/details_box.html:85 src/olympia/browse/views.py:461 src/olympia/devhub/views.py:77 src/olympia/devhub/views.py:84
+#: src/olympia/addons/templates/addons/details_box.html:85 src/olympia/browse/views.py:428 src/olympia/devhub/views.py:76 src/olympia/devhub/views.py:83
 #: src/olympia/stats/templates/stats/addon_report_menu.html:8 src/olympia/stats/templates/stats/collection_report_menu.html:18
 msgid "Downloads"
 msgstr "Liczba pobrań"
@@ -436,7 +431,7 @@ msgstr "Zgłoszenia naruszenia zasad"
 
 #. The Privacy Policy for this add-on.
 #: src/olympia/addons/templates/addons/details_box.html:121 src/olympia/addons/templates/addons/privacy.html:19 src/olympia/addons/templates/addons/privacy.html:23
-#: src/olympia/addons/templates/addons/impala/button.html:43 src/olympia/addons/templates/addons/impala/details.html:307 src/olympia/devhub/templates/devhub/includes/policy_form.html:20
+#: src/olympia/addons/templates/addons/impala/button.html:43 src/olympia/addons/templates/addons/impala/details.html:312 src/olympia/devhub/templates/devhub/includes/policy_form.html:23
 #: src/olympia/templates/mobile/base_addons.html:87
 msgid "Privacy Policy"
 msgstr "Polityka prywatności"
@@ -461,7 +456,7 @@ msgstr "Galeria obrazków"
 msgid "Developer Comments"
 msgstr "Komentarze autora"
 
-#: src/olympia/addons/templates/addons/details_box.html:199 src/olympia/addons/templates/addons/impala/details.html:259
+#: src/olympia/addons/templates/addons/details_box.html:199 src/olympia/addons/templates/addons/impala/details.html:264
 msgid "Development Channel"
 msgstr "Kanał rozwoju"
 
@@ -485,7 +480,7 @@ msgstr ""
 "<strong>Uwaga!</strong> Wersje rozwojowe tego dodatku nie były sprawdzane przez Mozillę. Po zainstalowaniu wersji rozwojowej będziesz automatycznie otrzymywać jej kolejne wersje rozwojowe. Aby nie "
 "otrzymywać rozwojowych aktualizacji, zainstaluj stabilną wersję dodatku, używając odnośnika zamieszczonego na górze strony."
 
-#: src/olympia/addons/templates/addons/details_box.html:220 src/olympia/addons/templates/addons/impala/details.html:278
+#: src/olympia/addons/templates/addons/details_box.html:220 src/olympia/addons/templates/addons/impala/details.html:283
 msgid "Version {0}:"
 msgstr "Wersja {0}:"
 
@@ -504,7 +499,7 @@ msgid "End-User License Agreement for {0}"
 msgstr "Licencja użytkownika dla {0}"
 
 #: src/olympia/addons/templates/addons/eula.html:17 src/olympia/addons/templates/addons/eula.html:21 src/olympia/addons/templates/addons/impala/button.html:48
-#: src/olympia/addons/templates/addons/impala/details.html:316 src/olympia/devhub/templates/devhub/includes/policy_form.html:3 src/olympia/discovery/templates/discovery/addons/eula.html:11
+#: src/olympia/addons/templates/addons/impala/details.html:321 src/olympia/devhub/templates/devhub/includes/policy_form.html:3 src/olympia/discovery/templates/discovery/addons/eula.html:11
 msgid "End-User License Agreement"
 msgstr "Licencja użytkownika"
 
@@ -523,7 +518,7 @@ msgstr "Wróć do {0}…"
 msgid "Add-ons for {0}"
 msgstr "Dodatki dla programu {0}"
 
-#: src/olympia/addons/templates/addons/home.html:10 src/olympia/addons/templates/addons/home.html:51 src/olympia/browse/templates/browse/impala/base_listing.html:11
+#: src/olympia/addons/templates/addons/home.html:10 src/olympia/addons/templates/addons/home.html:53 src/olympia/browse/templates/browse/impala/base_listing.html:11
 msgid "Featured Extensions"
 msgstr "Polecane rozszerzenia"
 
@@ -531,29 +526,29 @@ msgstr "Polecane rozszerzenia"
 msgid "Popular Extensions"
 msgstr "Popularne rozszerzenia"
 
-#: src/olympia/addons/templates/addons/home.html:42 src/olympia/amo/templates/amo/side_nav.html:3 src/olympia/amo/templates/amo/side_nav.html:11 src/olympia/amo/templates/amo/site_nav.html:3
-#: src/olympia/amo/templates/amo/site_nav.html:25 src/olympia/browse/views.py:236 src/olympia/browse/views.py:281 src/olympia/browse/views.py:481
+#: src/olympia/addons/templates/addons/home.html:44 src/olympia/amo/templates/amo/side_nav.html:3 src/olympia/amo/templates/amo/side_nav.html:11 src/olympia/amo/templates/amo/site_nav.html:3
+#: src/olympia/amo/templates/amo/site_nav.html:25 src/olympia/browse/views.py:203 src/olympia/browse/views.py:248 src/olympia/browse/views.py:448
 msgid "Most Popular"
 msgstr "Najpopularniejsze"
 
-#: src/olympia/addons/templates/addons/home.html:43
+#: src/olympia/addons/templates/addons/home.html:45
 msgid "All »"
 msgstr "Wszystkie »"
 
-#: src/olympia/addons/templates/addons/home.html:52 src/olympia/addons/templates/addons/home.html:61 src/olympia/addons/templates/addons/home.html:70 src/olympia/addons/templates/addons/home.html:78
+#: src/olympia/addons/templates/addons/home.html:54 src/olympia/addons/templates/addons/home.html:63 src/olympia/addons/templates/addons/home.html:72 src/olympia/addons/templates/addons/home.html:80
 #: src/olympia/browse/templates/browse/impala/category_landing.html:36
 msgid "See all »"
 msgstr "Wszystkie »"
 
-#: src/olympia/addons/templates/addons/home.html:60
+#: src/olympia/addons/templates/addons/home.html:62
 msgid "Up &amp; Coming Extensions"
 msgstr "Najczęściej używane rozszerzenia"
 
-#: src/olympia/addons/templates/addons/home.html:69 src/olympia/browse/templates/browse/personas/category_landing.html:61 src/olympia/discovery/templates/discovery/pane.html:74
+#: src/olympia/addons/templates/addons/home.html:71 src/olympia/browse/templates/browse/personas/category_landing.html:61 src/olympia/discovery/templates/discovery/pane.html:74
 msgid "Featured Themes"
 msgstr "Polecane motywy"
 
-#: src/olympia/addons/templates/addons/home.html:77 src/olympia/bandwagon/templates/bandwagon/impala/collection_listing.html:5
+#: src/olympia/addons/templates/addons/home.html:79 src/olympia/bandwagon/templates/bandwagon/impala/collection_listing.html:5
 msgid "Featured Collections"
 msgstr "Polecane kolekcje"
 
@@ -571,7 +566,7 @@ msgid "Updated {0}"
 msgstr "Zaktualizowano {0}"
 
 #. {0} is a date.
-#: src/olympia/addons/templates/addons/macros.html:10 src/olympia/addons/templates/addons/macros.html:69 src/olympia/addons/templates/addons/persona_preview.html:21
+#: src/olympia/addons/templates/addons/macros.html:10 src/olympia/addons/templates/addons/macros.html:69 src/olympia/addons/templates/addons/persona_preview.html:22
 #: src/olympia/addons/templates/addons/listing/items_mobile.html:44 src/olympia/addons/templates/addons/listing/macros.html:39 src/olympia/bandwagon/templates/bandwagon/collection_listing_items.html:37
 #: src/olympia/bandwagon/templates/bandwagon/impala/collection_listing_items.html:37
 msgid "Added {0}"
@@ -583,7 +578,6 @@ msgid "%(num)s weekly download"
 msgid_plural "%(num)s weekly downloads"
 msgstr[0] "%(num)s pobranie tygodniowo"
 msgstr[1] "%(num)s pobrania tygodniowo"
-msgstr[2] "%(num)s pobrań tygodniowo"
 
 #: src/olympia/addons/templates/addons/macros.html:28
 #, python-format
@@ -591,24 +585,20 @@ msgid "%(num)s user"
 msgid_plural "%(num)s users"
 msgstr[0] "%(num)s użytkownik"
 msgstr[1] "%(num)s użytkowników"
-msgstr[2] "%(num)s użytkowników"
 
 #. {0} is the number of downloads.
-#: src/olympia/addons/templates/addons/macros.html:53 src/olympia/addons/templates/addons/impala/details.html:61
+#: src/olympia/addons/templates/addons/macros.html:53 src/olympia/addons/templates/addons/impala/details.html:59
 msgid "{0} weekly download"
 msgid_plural "{0} weekly downloads"
 msgstr[0] "{0} pobranie tygodniowo"
 msgstr[1] "{0} pobrania tygodniowo"
-msgstr[2] "{0} pobrań tygodniowo"
 
 #. {0} is the number of users.
-#: src/olympia/addons/templates/addons/macros.html:61 src/olympia/addons/templates/addons/impala/details.html:54 src/olympia/compat/templates/compat/index.html:71
-#: src/olympia/zadmin/templates/zadmin/compat.html:67
+#: src/olympia/addons/templates/addons/macros.html:61 src/olympia/addons/templates/addons/impala/details.html:52 src/olympia/zadmin/templates/zadmin/compat.html:67
 msgid "{0} user"
 msgid_plural "{0} users"
 msgstr[0] "{0} użytkownik"
 msgstr[1] "{0} użytkowników"
-msgstr[2] "{0} użytkowników"
 
 #: src/olympia/addons/templates/addons/paypal_result.html:12
 msgid "Payment cancelled"
@@ -622,7 +612,7 @@ msgstr "Płatność została dokonana"
 msgid "Return to the addon."
 msgstr "Wróć do dodatku"
 
-#: src/olympia/addons/templates/addons/persona_detail.html:17 src/olympia/addons/templates/addons/impala/details.html:106 src/olympia/addons/templates/addons/mobile/details.html:23
+#: src/olympia/addons/templates/addons/persona_detail.html:17 src/olympia/addons/templates/addons/impala/details.html:103 src/olympia/addons/templates/addons/mobile/details.html:23
 #: src/olympia/addons/templates/addons/mobile/persona_detail.html:21 src/olympia/discovery/templates/discovery/addons/base.html:27 src/olympia/editors/templates/editors/review.html:31
 msgid "by"
 msgstr "Autor:"
@@ -666,35 +656,35 @@ msgstr "Dzienni użytkownicy"
 msgid "License"
 msgstr "Licencja"
 
-#: src/olympia/addons/templates/addons/persona_preview.html:12 src/olympia/constants/base.py:48
+#: src/olympia/addons/templates/addons/persona_preview.html:13 src/olympia/constants/base.py:48
 msgid "Awaiting Review"
 msgstr "Oczekujące sprawdzenie"
 
-#: src/olympia/addons/templates/addons/persona_preview.html:14 src/olympia/amo/log.py:180 src/olympia/constants/base.py:42 src/olympia/editors/helpers.py:62
+#: src/olympia/addons/templates/addons/persona_preview.html:15 src/olympia/amo/log.py:180 src/olympia/constants/base.py:42 src/olympia/editors/helpers.py:62
 msgid "Rejected"
 msgstr "Odrzucono"
 
-#: src/olympia/addons/templates/addons/persona_preview.html:16 src/olympia/amo/log.py:159
+#: src/olympia/addons/templates/addons/persona_preview.html:17 src/olympia/amo/log.py:159
 msgid "Approved"
 msgstr "Zatwierdzone"
 
 #. {0} is the number of users.
-#: src/olympia/addons/templates/addons/persona_preview.html:26 src/olympia/addons/templates/addons/listing/items_mobile.html:36 src/olympia/addons/templates/addons/listing/macros.html:31
+#: src/olympia/addons/templates/addons/persona_preview.html:27 src/olympia/addons/templates/addons/listing/items_mobile.html:36 src/olympia/addons/templates/addons/listing/macros.html:31
 msgid "<strong>{0}</strong> user"
 msgid_plural "<strong>{0}</strong> users"
 msgstr[0] "<strong>{0}</strong> użytkownik"
 msgstr[1] "<strong>{0}</strong> użytkowników"
-msgstr[2] "<strong>{0}</strong> użytkowników"
 
-#: src/olympia/addons/templates/addons/persona_preview.html:40
+#: src/olympia/addons/templates/addons/persona_preview.html:41
 msgid "Hover to Preview"
 msgstr "Wskaż, by zobaczyć podgląd"
 
-#: src/olympia/addons/templates/addons/persona_preview.html:46 src/olympia/addons/templates/addons/persona_preview.html:48 src/olympia/reviews/templates/reviews/add.html:15
+#: src/olympia/addons/templates/addons/persona_preview.html:47 src/olympia/addons/templates/addons/persona_preview.html:49 src/olympia/addons/templates/addons/persona_preview.html:97
+#: src/olympia/reviews/templates/reviews/add.html:15
 msgid "Add"
 msgstr "Dodaj"
 
-#: src/olympia/addons/templates/addons/persona_preview.html:57 src/olympia/bandwagon/templates/bandwagon/ajax_new.html:16 src/olympia/bandwagon/templates/bandwagon/edit.html:19
+#: src/olympia/addons/templates/addons/persona_preview.html:58 src/olympia/bandwagon/templates/bandwagon/ajax_new.html:16 src/olympia/bandwagon/templates/bandwagon/edit.html:19
 #: src/olympia/bandwagon/templates/bandwagon/includes/addedit.html:19 src/olympia/devhub/templates/devhub/addons/edit/admin.html:13 src/olympia/devhub/templates/devhub/addons/edit/basic.html:10
 #: src/olympia/devhub/templates/devhub/addons/edit/details.html:8 src/olympia/devhub/templates/devhub/addons/edit/media.html:6 src/olympia/devhub/templates/devhub/addons/edit/support.html:8
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:9 src/olympia/devhub/templates/devhub/addons/submit/describe.html:29 src/olympia/editors/templates/editors/review.html:257
@@ -703,21 +693,21 @@ msgstr "Edytuj"
 
 #. For datetime formatting, see the table on
 #. http://docs.python.org/library/datetime.html#strftime-and-strptime-behavior
-#: src/olympia/addons/templates/addons/persona_preview.html:66
+#: src/olympia/addons/templates/addons/persona_preview.html:67
 #, python-format
 msgid "%%Y-%%m-%%d"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/persona_preview.html:67
+#: src/olympia/addons/templates/addons/persona_preview.html:68
 msgid "by {0} on {1}"
 msgstr "zamieszczony przez {0} – {1}"
 
-#: src/olympia/addons/templates/addons/persona_preview.html:75 src/olympia/reviews/helpers.py:17 src/olympia/reviews/templates/reviews/review_list.html:63
+#: src/olympia/addons/templates/addons/persona_preview.html:76 src/olympia/reviews/helpers.py:17 src/olympia/reviews/templates/reviews/review_list.html:63
 #: src/olympia/reviews/templates/reviews/reviews_link.html:21 src/olympia/reviews/templates/reviews/impala/reviews_link.html:16
 msgid "Not yet rated"
 msgstr "Brak ocen"
 
-#: src/olympia/addons/templates/addons/persona_preview.html:78
+#: src/olympia/addons/templates/addons/persona_preview.html:79
 msgid "<b>{0}</b> users"
 msgstr "<b>{0}</b> użytkowników"
 
@@ -730,8 +720,8 @@ msgid "Learn more about Firefox"
 msgstr "Dowiedz się więcej o Firefoksie"
 
 #: src/olympia/addons/templates/addons/popups.html:22
-msgid "or <b><a class=\"installer\" href=\"{url}\">download anyway</a></b>"
-msgstr "lub <b><a class=\"installer\" href=\"{url}\">pobierz mimo wszystko</a></b>"
+msgid "or <b><a class=\"button installer\" href=\"{url}\">download anyway</a></b>"
+msgstr ""
 
 #: src/olympia/addons/templates/addons/popups.html:26
 msgid ""
@@ -832,7 +822,7 @@ msgstr ""
 "obsługującym twój telefon."
 
 #: src/olympia/addons/templates/addons/report_abuse.html:6 src/olympia/addons/templates/addons/report_abuse_full.html:10 src/olympia/addons/templates/addons/impala/details-more.html:23
-#: src/olympia/addons/templates/addons/impala/details.html:328
+#: src/olympia/addons/templates/addons/impala/details.html:333
 msgid "Report Abuse"
 msgstr "Zgłoś nadużycie"
 
@@ -853,9 +843,9 @@ msgstr "Wyślij zgłoszenie"
 #: src/olympia/devhub/templates/devhub/addons/ajax_compat_update.html:36 src/olympia/devhub/templates/devhub/addons/profile.html:44 src/olympia/devhub/templates/devhub/addons/edit/admin.html:104
 #: src/olympia/devhub/templates/devhub/addons/edit/basic.html:155 src/olympia/devhub/templates/devhub/addons/edit/details.html:88 src/olympia/devhub/templates/devhub/addons/edit/support.html:70
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:169 src/olympia/devhub/templates/devhub/addons/forms_shared/media.html:152
-#: src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:44 src/olympia/devhub/templates/devhub/personas/edit.html:222 src/olympia/devhub/templates/devhub/versions/add_file_modal.html:79
-#: src/olympia/devhub/templates/devhub/versions/edit.html:140 src/olympia/devhub/templates/devhub/versions/list.html:208 src/olympia/devhub/templates/devhub/versions/list.html:242
-#: src/olympia/devhub/templates/devhub/versions/list.html:276 src/olympia/devhub/templates/devhub/versions/list.html:317 src/olympia/reviews/templates/reviews/edit_review.html:16
+#: src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:43 src/olympia/devhub/templates/devhub/personas/edit.html:222 src/olympia/devhub/templates/devhub/versions/add_file_modal.html:59
+#: src/olympia/devhub/templates/devhub/versions/edit.html:140 src/olympia/devhub/templates/devhub/versions/list.html:208 src/olympia/devhub/templates/devhub/versions/list.html:239
+#: src/olympia/devhub/templates/devhub/versions/list.html:281 src/olympia/devhub/templates/devhub/versions/list.html:315 src/olympia/reviews/templates/reviews/edit_review.html:16
 #: src/olympia/translations/templates/translations/trans-menu.html:50 src/olympia/translations/templates/translations/trans-menu.html:62 src/olympia/zadmin/templates/zadmin/validation.html:105
 msgid "Cancel"
 msgstr "Anuluj"
@@ -900,7 +890,7 @@ msgstr "Sprawdź w sekcji <a href=\"%(support)s\">wsparcie techniczne</a>, gdzie
 msgid "Review Guidelines"
 msgstr "Wytyczne dla autorów opinii"
 
-#: src/olympia/addons/templates/addons/review_list_box.html:5 src/olympia/addons/templates/addons/impala/details-more.html:27 src/olympia/editors/helpers.py:921
+#: src/olympia/addons/templates/addons/review_list_box.html:5 src/olympia/addons/templates/addons/impala/details-more.html:27 src/olympia/editors/helpers.py:1001
 #: src/olympia/reviews/templates/reviews/add.html:14 src/olympia/reviews/templates/reviews/reply.html:14 src/olympia/reviews/templates/reviews/review_list.html:19
 #: src/olympia/reviews/templates/reviews/mobile/review_list.html:26
 msgid "Reviews"
@@ -921,7 +911,6 @@ msgid "See all reviews of this add-on"
 msgid_plural "See all %(cnt)s reviews of this add-on"
 msgstr[0] "Wszystkie opinie o tym dodatku"
 msgstr[1] "Wszystkie %(cnt)s opinie o tym dodatku"
-msgstr[2] "Wszystkie %(cnt)s opinii o tym dodatku"
 
 #: src/olympia/addons/templates/addons/tags_box.html:3 src/olympia/devhub/templates/devhub/addons/edit/basic.html:118
 msgid "Tags"
@@ -991,108 +980,105 @@ msgid "Other add-ons by %(author)s"
 msgid_plural "Other add-ons by these authors"
 msgstr[0] "Inne dodatki autorstwa %(author)s"
 msgstr[1] "Inne dodatki tych autorów"
-msgstr[2] "Inne dodatki tych autorów"
 
-#: src/olympia/addons/templates/addons/impala/details.html:41
+#: src/olympia/addons/templates/addons/impala/details.html:39
 #, python-format
 msgid "<span itemprop=\"ratingCount\">%(num)s</span> user review"
 msgid_plural "<span itemprop=\"ratingCount\">%(num)s</span> user reviews"
 msgstr[0] "<span itemprop=\"ratingCount\">%(num)s</span> opinia użytkownika"
 msgstr[1] "<span itemprop=\"ratingCount\">%(num)s</span> opinie użytkowników"
-msgstr[2] "<span itemprop=\"ratingCount\">%(num)s</span> opinii użytkowników"
 
-#: src/olympia/addons/templates/addons/impala/details.html:69
+#: src/olympia/addons/templates/addons/impala/details.html:66
 msgid "View statistics"
 msgstr "Zobacz statystyki"
 
-#: src/olympia/addons/templates/addons/impala/details.html:84
+#: src/olympia/addons/templates/addons/impala/details.html:81
 msgid "Manage"
 msgstr "Zarządzaj"
 
 #. {0} is an add-on name.
-#: src/olympia/addons/templates/addons/impala/details.html:96
+#: src/olympia/addons/templates/addons/impala/details.html:93
 msgid "Icon of {0}"
 msgstr "Ikona {0}"
 
-#: src/olympia/addons/templates/addons/impala/details.html:103 src/olympia/addons/templates/addons/impala/listing/items.html:14
+#: src/olympia/addons/templates/addons/impala/details.html:100 src/olympia/addons/templates/addons/impala/listing/items.html:14
 msgid "No Restart"
 msgstr "Nie wymaga ponownego uruchomienia"
 
-#: src/olympia/addons/templates/addons/impala/details.html:127
+#: src/olympia/addons/templates/addons/impala/details.html:124
 #, fuzzy, python-format
 msgid "Meet the Developer: <a href=\"%(url)s\">%(name)s</a>"
 msgid_plural "<a href=\"%(url)s\">Meet the Developers</a>"
 msgstr[0] "Poznaj autora: <a href=\"%(url)s\">%(name)s</a>"
 msgstr[1] "<a href=\"%(url)s\">Poznaj autorów</a>"
-msgstr[2] "<a href=\"%(url)s\">Poznaj autorów</a>"
 
 # {0} is an add-on name.
-#: src/olympia/addons/templates/addons/impala/details.html:137
+#: src/olympia/addons/templates/addons/impala/details.html:134
 msgid "Learn why {0} was created and find out what's next for this add-on."
 msgstr "Dowiedz się, dlaczego dodatek {0} został stworzony, i co nowego jest planowane."
 
 #. {0} is an index.
-#: src/olympia/addons/templates/addons/impala/details.html:156
+#: src/olympia/addons/templates/addons/impala/details.html:161
 msgid "Add-on screenshot #{0}"
 msgstr "Obrazek dodatku #{0}"
 
-#: src/olympia/addons/templates/addons/impala/details.html:182
+#: src/olympia/addons/templates/addons/impala/details.html:187
 msgid "Add-on home page"
 msgstr "Strona domowa"
 
-#: src/olympia/addons/templates/addons/impala/details.html:185
+#: src/olympia/addons/templates/addons/impala/details.html:190
 msgid "Support site"
 msgstr "Pomoc"
 
-#: src/olympia/addons/templates/addons/impala/details.html:189
+#: src/olympia/addons/templates/addons/impala/details.html:194
 msgid "Support E-mail"
 msgstr "E-mail pomocy"
 
-#: src/olympia/addons/templates/addons/impala/details.html:194 src/olympia/devhub/models.py:378 src/olympia/devhub/templates/devhub/versions/list.html:12
+#: src/olympia/addons/templates/addons/impala/details.html:199 src/olympia/devhub/models.py:378 src/olympia/devhub/templates/devhub/versions/list.html:12
 #: src/olympia/versions/templates/versions/version.html:6 src/olympia/versions/templates/versions/mobile/version.html:6
 msgid "Version {0}"
 msgstr "Wersja {0}"
 
-#: src/olympia/addons/templates/addons/impala/details.html:194
+#: src/olympia/addons/templates/addons/impala/details.html:199
 msgid "Info"
 msgstr "Informacje"
 
-#: src/olympia/addons/templates/addons/impala/details.html:195 src/olympia/devhub/templates/devhub/includes/addon_details.html:129
+#: src/olympia/addons/templates/addons/impala/details.html:200 src/olympia/devhub/templates/devhub/includes/addon_details.html:116
 msgid "Last Updated:"
 msgstr "Ostatnia aktualizacja:"
 
-#: src/olympia/addons/templates/addons/impala/details.html:200
+#: src/olympia/addons/templates/addons/impala/details.html:205
 #, python-format
 msgid "Released under <a target=\"_blank\" href=\"%(url)s\">%(name)s</a>"
 msgstr "Licencja <a target=\"_blank\" href=\"%(url)s\">%(name)s</a>"
 
-#: src/olympia/addons/templates/addons/impala/details.html:201 src/olympia/addons/templates/addons/impala/details.html:206 src/olympia/amo/helpers.py:398 src/olympia/devhub/forms.py:142
+#: src/olympia/addons/templates/addons/impala/details.html:206 src/olympia/addons/templates/addons/impala/details.html:211 src/olympia/amo/helpers.py:398 src/olympia/devhub/forms.py:142
 #: src/olympia/devhub/forms.py:173 src/olympia/versions/templates/versions/version.html:40 src/olympia/versions/templates/versions/version.html:45
 msgid "Custom License"
 msgstr "Własna licencja"
 
-#: src/olympia/addons/templates/addons/impala/details.html:205
+#: src/olympia/addons/templates/addons/impala/details.html:210
 #, python-format
 msgid "Released under <a href=\"%(url)s\">%(name)s</a>"
 msgstr "Wydany na licencji <a href=\"%(url)s\">%(name)s</a>"
 
-#: src/olympia/addons/templates/addons/impala/details.html:217
+#: src/olympia/addons/templates/addons/impala/details.html:222
 msgid "About this Add-on"
 msgstr "Więcej o tym dodatku"
 
-#: src/olympia/addons/templates/addons/impala/details.html:233
+#: src/olympia/addons/templates/addons/impala/details.html:238
 msgid "Developer’s Comments"
 msgstr "Komentarze autora"
 
-#: src/olympia/addons/templates/addons/impala/details.html:243
+#: src/olympia/addons/templates/addons/impala/details.html:248
 msgid "Version Information"
 msgstr "Informacje o wersji"
 
-#: src/olympia/addons/templates/addons/impala/details.html:250
+#: src/olympia/addons/templates/addons/impala/details.html:255
 msgid "See complete version history"
 msgstr "Zobacz całą historię wersji"
 
-#: src/olympia/addons/templates/addons/impala/details.html:262
+#: src/olympia/addons/templates/addons/impala/details.html:267
 msgid ""
 "The Development Channel lets you test an experimental new version of this add-on before it's released to the general public. Once you install the development version, you will continue to get "
 "updates from this channel. To stop receiving development updates, reinstall the default version from the link above."
@@ -1100,17 +1086,17 @@ msgstr ""
 "Kanał rozwoju umożliwia testowanie eksperymentalnych, nowych wersji tego dodatku przed jego upublicznieniem. Po zainstalowaniu wersji rozwojowej będziesz automatycznie otrzymywać aktualizacje z "
 "tego kanału. Aby zakończyć otrzymywanie rozwojowych aktualizacji, zainstaluj na nowo domyślną wersję z odnośnika powyżej."
 
-#: src/olympia/addons/templates/addons/impala/details.html:272
+#: src/olympia/addons/templates/addons/impala/details.html:277
 msgid "<strong>Caution:</strong> Development versions of this add-on have not been reviewed by Mozilla."
 msgstr "<strong>Uwaga:</strong> Wersje robocze tego dodatku nie zostały sprawdzone przez Mozillę."
 
-#: src/olympia/addons/templates/addons/impala/details.html:287
+#: src/olympia/addons/templates/addons/impala/details.html:292
 msgid "See complete development channel history"
 msgstr "Zobacz pełną historię kanału rozwojowego"
 
-#: src/olympia/addons/templates/addons/impala/details.html:306 src/olympia/addons/templates/addons/impala/details.html:315 src/olympia/addons/templates/addons/impala/details.html:327
+#: src/olympia/addons/templates/addons/impala/details.html:311 src/olympia/addons/templates/addons/impala/details.html:320 src/olympia/addons/templates/addons/impala/details.html:332
 #: src/olympia/addons/templates/addons/impala/review_add_box.html:4 src/olympia/stats/templates/stats/popup.html:2 src/olympia/stats/templates/stats/popup.html:8
-#: src/olympia/stats/templates/stats/stats.html:202 src/olympia/users/templates/users/profile.html:119
+#: src/olympia/stats/templates/stats/stats.html:204 src/olympia/users/templates/users/profile.html:119
 msgid "close"
 msgstr "zamknij"
 
@@ -1144,7 +1130,6 @@ msgid "About the Developer"
 msgid_plural "About the Developers"
 msgstr[0] "O autorze"
 msgstr[1] "O autorach"
-msgstr[2] "O autorach"
 
 #: src/olympia/addons/templates/addons/impala/developers.html:96 src/olympia/users/templates/users/edit.html:130 src/olympia/users/templates/users/profile.html:26
 msgid "No Photo"
@@ -1170,15 +1155,11 @@ msgstr "Licencja kodu źródłowego dla {addon}"
 msgid "Source Code License"
 msgstr "Licencja kodu źródłowego"
 
-#: src/olympia/addons/templates/addons/impala/persona_grid.html:16 src/olympia/addons/templates/addons/impala/toplist.html:6
-msgid "{0} users"
-msgstr "{0} użytkowników"
-
 #: src/olympia/addons/templates/addons/impala/review_list_box.html:19 src/olympia/reviews/templates/reviews/review.html:40
 msgid "permalink"
 msgstr "zobacz całą"
 
-#: src/olympia/addons/templates/addons/impala/review_list_box.html:23 src/olympia/editors/templates/editors/queue.html:98 src/olympia/reviews/templates/reviews/review.html:44
+#: src/olympia/addons/templates/addons/impala/review_list_box.html:23 src/olympia/editors/templates/editors/queue.html:104 src/olympia/reviews/templates/reviews/review.html:44
 msgid "translate"
 msgstr "przetłumacz"
 
@@ -1188,7 +1169,6 @@ msgid "See all user reviews"
 msgid_plural "See all %(cnt)s user reviews"
 msgstr[0] "Zobacz wszystkie opinie"
 msgstr[1] "Zobacz wszystkie %(cnt)s opinie"
-msgstr[2] "Zobacz wszystkie %(cnt)s opinii"
 
 #: src/olympia/addons/templates/addons/impala/review_list_box.html:47 src/olympia/reviews/templates/reviews/review_list.html:84
 msgid "This add-on has not yet been reviewed."
@@ -1197,6 +1177,10 @@ msgstr "Nie napisano jeszcze żadnej opinii o tym dodatku."
 #: src/olympia/addons/templates/addons/impala/review_list_box.html:50
 msgid "Be the first!"
 msgstr "Napisz pierwszą opinię!"
+
+#: src/olympia/addons/templates/addons/impala/toplist.html:6
+msgid "{0} users"
+msgstr "{0} użytkowników"
 
 #: src/olympia/addons/templates/addons/impala/listing/sorter.html:14 src/olympia/devhub/templates/devhub/addons/listing/item_actions.html:49
 msgid "More"
@@ -1210,7 +1194,7 @@ msgstr "Dodaj do kolekcji"
 msgid "My Add-ons"
 msgstr "Moje dodatki"
 
-#: src/olympia/addons/templates/addons/includes/dashboard_tabs.html:6 src/olympia/amo/context_processors.py:51
+#: src/olympia/addons/templates/addons/includes/dashboard_tabs.html:6 src/olympia/amo/context_processors.py:52
 msgid "My Themes"
 msgstr "Moje motywy"
 
@@ -1252,7 +1236,6 @@ msgid "<strong>{0}</strong> weekly download"
 msgid_plural "<strong>{0}</strong> weekly downloads"
 msgstr[0] "<strong>{0}</strong> pobranie tygodniowo"
 msgstr[1] "<strong>{0}</strong> pobrania tygodniowo"
-msgstr[2] "<strong>{0}</strong> pobrań tygodniowo"
 
 #: src/olympia/addons/templates/addons/mobile/details.html:32
 msgid "Read More"
@@ -1266,7 +1249,7 @@ msgstr "Użytkownicy"
 msgid "Weekly Downloads"
 msgstr "Tygodniowe pobrania"
 
-#: src/olympia/addons/templates/addons/mobile/details.html:99 src/olympia/compat/templates/compat/reporter_detail.html:46 src/olympia/devhub/forms.py:787
+#: src/olympia/addons/templates/addons/mobile/details.html:99 src/olympia/compat/templates/compat/reporter_detail.html:46 src/olympia/devhub/forms.py:788
 #: src/olympia/devhub/templates/devhub/versions/list.html:163
 msgid "Version"
 msgstr "Wersja"
@@ -1351,7 +1334,7 @@ msgstr ""
 #: src/olympia/browse/templates/browse/personas/base.html:6 src/olympia/browse/templates/browse/personas/base.html:42 src/olympia/browse/templates/browse/personas/category_landing.html:21
 #: src/olympia/browse/templates/browse/personas/category_landing.html:23 src/olympia/browse/templates/browse/personas/category_landing.html:38 src/olympia/browse/templates/browse/personas/grid.html:7
 #: src/olympia/browse/templates/browse/personas/grid.html:11 src/olympia/browse/templates/browse/personas/mobile/base.html:7 src/olympia/browse/templates/browse/personas/mobile/category_landing.html:19
-#: src/olympia/constants/base.py:180 src/olympia/devhub/templates/devhub/personas/submit.html:13 src/olympia/editors/helpers.py:105 src/olympia/editors/templates/editors/base.html:26
+#: src/olympia/constants/base.py:180 src/olympia/devhub/templates/devhub/personas/submit.html:13 src/olympia/editors/helpers.py:107 src/olympia/editors/templates/editors/base.html:26
 #: src/olympia/editors/templates/editors/performance.html:73 src/olympia/search/templates/search/personas.html:39 src/olympia/templates/menu_links.html:9
 msgid "Themes"
 msgstr "Motywy"
@@ -1372,7 +1355,7 @@ msgstr "Więcej dodatków"
 msgid "Highest Rated"
 msgstr "Najwyżej oceniane"
 
-#: src/olympia/addons/templates/addons/mobile/home.html:74 src/olympia/amo/templates/amo/side_nav.html:5 src/olympia/amo/templates/amo/site_nav.html:27 src/olympia/amo/templates/amo/site_nav.html:57
+#: src/olympia/addons/templates/addons/mobile/home.html:74 src/olympia/amo/templates/amo/side_nav.html:5 src/olympia/amo/templates/amo/site_nav.html:27 src/olympia/amo/templates/amo/site_nav.html:55
 #: src/olympia/bandwagon/views.py:97 src/olympia/browse/views.py:57 src/olympia/browse/views.py:67 src/olympia/browse/templates/browse/personas/mobile/category_landing.html:65
 #: src/olympia/search/forms.py:15 src/olympia/search/forms.py:87
 msgid "Newest"
@@ -1390,84 +1373,84 @@ msgstr "Informacje o motywie &raquo;"
 msgid "Tools"
 msgstr "Narzędzia"
 
-#: src/olympia/amo/context_processors.py:48 src/olympia/discovery/templates/discovery/pane_account.html:8 src/olympia/users/templates/users/includes/navigation.html:2
+#: src/olympia/amo/context_processors.py:49 src/olympia/discovery/templates/discovery/pane_account.html:8 src/olympia/users/templates/users/includes/navigation.html:2
 msgid "My Profile"
 msgstr "Mój profil"
 
-#: src/olympia/amo/context_processors.py:54 src/olympia/users/templates/users/edit.html:5 src/olympia/users/templates/users/includes/navigation.html:3
+#: src/olympia/amo/context_processors.py:55 src/olympia/users/templates/users/edit.html:5 src/olympia/users/templates/users/includes/navigation.html:3
 msgid "Account Settings"
 msgstr "Ustawienia konta"
 
-#: src/olympia/amo/context_processors.py:57 src/olympia/discovery/templates/discovery/pane_account.html:11 src/olympia/users/templates/users/profile.html:83
+#: src/olympia/amo/context_processors.py:58 src/olympia/discovery/templates/discovery/pane_account.html:11 src/olympia/users/templates/users/profile.html:83
 #: src/olympia/users/templates/users/includes/navigation.html:4
 msgid "My Collections"
 msgstr "Moje kolekcje"
 
-#: src/olympia/amo/context_processors.py:62 src/olympia/discovery/templates/discovery/pane_account.html:10 src/olympia/users/templates/users/includes/navigation.html:7
+#: src/olympia/amo/context_processors.py:63 src/olympia/discovery/templates/discovery/pane_account.html:10 src/olympia/users/templates/users/includes/navigation.html:7
 msgid "My Favorites"
 msgstr "Moje ulubione"
 
-#: src/olympia/amo/context_processors.py:67 src/olympia/discovery/templates/discovery/pane_account.html:13 src/olympia/templates/impala/user_login.html:14 src/olympia/templates/mobile/header_auth.html:5
+#: src/olympia/amo/context_processors.py:68 src/olympia/discovery/templates/discovery/pane_account.html:13 src/olympia/templates/impala/user_login.html:14 src/olympia/templates/mobile/header_auth.html:5
 msgid "Log out"
 msgstr "Wyloguj"
 
-#: src/olympia/amo/context_processors.py:72 src/olympia/devhub/templates/devhub/addons/dashboard.html:4
+#: src/olympia/amo/context_processors.py:73 src/olympia/devhub/templates/devhub/addons/dashboard.html:4
 msgid "Manage My Submissions"
 msgstr "Zarządzanie zgłoszeniami"
 
-#: src/olympia/amo/context_processors.py:75 src/olympia/devhub/templates/devhub/nav.html:27 src/olympia/devhub/templates/devhub/addons/dashboard.html:25
+#: src/olympia/amo/context_processors.py:76 src/olympia/devhub/templates/devhub/nav.html:27 src/olympia/devhub/templates/devhub/addons/dashboard.html:25
 #: src/olympia/devhub/templates/devhub/addons/submit/base.html:4
 msgid "Submit a New Add-on"
 msgstr "Zamieść nowy dodatek"
 
-#: src/olympia/amo/context_processors.py:77 src/olympia/browse/templates/browse/personas/base.html:50 src/olympia/devhub/templates/devhub/index.html:24
+#: src/olympia/amo/context_processors.py:78 src/olympia/browse/templates/browse/personas/base.html:50 src/olympia/devhub/templates/devhub/index.html:24
 #: src/olympia/devhub/templates/devhub/addons/dashboard.html:29
 msgid "Submit a New Theme"
 msgstr "Prześlij nowy motyw"
 
-#: src/olympia/amo/context_processors.py:79 src/olympia/amo/templates/amo/site_nav.html:87 src/olympia/devhub/helpers.py:36 src/olympia/devhub/helpers.py:68 src/olympia/devhub/helpers.py:102
+#: src/olympia/amo/context_processors.py:80 src/olympia/amo/templates/amo/site_nav.html:85 src/olympia/devhub/helpers.py:36 src/olympia/devhub/helpers.py:68 src/olympia/devhub/helpers.py:102
 #: src/olympia/templates/footer.html:6 src/olympia/templates/menu_links.html:14
 msgid "Developer Hub"
 msgstr "Strefa autora"
 
-#: src/olympia/amo/context_processors.py:83 src/olympia/devhub/views.py:1792
+#: src/olympia/amo/context_processors.py:84 src/olympia/devhub/views.py:1799
 msgid "Manage API Keys"
 msgstr "Zarządzaj kluczami API"
 
-#: src/olympia/amo/context_processors.py:88 src/olympia/editors/helpers.py:82 src/olympia/editors/helpers.py:102 src/olympia/editors/templates/editors/base.html:10
+#: src/olympia/amo/context_processors.py:89 src/olympia/editors/helpers.py:84 src/olympia/editors/helpers.py:104 src/olympia/editors/templates/editors/base.html:10
 msgid "Editor Tools"
 msgstr "Strefa recenzenta"
 
-#: src/olympia/amo/context_processors.py:92
+#: src/olympia/amo/context_processors.py:93
 msgid "Admin Tools"
 msgstr "Strefa administratora"
 
-#: src/olympia/amo/fields.py:15
+#: src/olympia/amo/fields.py:20
 msgid "Incorrect, please try again."
 msgstr ""
 
-#: src/olympia/amo/fields.py:16
+#: src/olympia/amo/fields.py:21
 msgid "Error verifying input, please try again."
 msgstr ""
 
-#: src/olympia/amo/fields.py:32
+#: src/olympia/amo/fields.py:37
 msgid "This must be a valid hex color code, such as #000000."
 msgstr "To musi być poprawny kod szesnastkowy koloru, taki jak #000000."
 
-#: src/olympia/amo/fields.py:58
+#: src/olympia/amo/fields.py:63
 msgid "Enter at least one value."
 msgstr "Wprowadź przynajmniej jedną wartość."
 
-#: src/olympia/amo/helpers.py:162 src/olympia/amo/templates/amo/site_nav.html:61 src/olympia/bandwagon/templates/bandwagon/add.html:9 src/olympia/bandwagon/templates/bandwagon/collection_detail.html:15
+#: src/olympia/amo/helpers.py:162 src/olympia/amo/templates/amo/site_nav.html:59 src/olympia/bandwagon/templates/bandwagon/add.html:9 src/olympia/bandwagon/templates/bandwagon/collection_detail.html:15
 #: src/olympia/bandwagon/templates/bandwagon/delete.html:9 src/olympia/bandwagon/templates/bandwagon/edit.html:15 src/olympia/bandwagon/templates/bandwagon/user_listing.html:18
 #: src/olympia/bandwagon/templates/bandwagon/user_listing.html:21 src/olympia/bandwagon/templates/bandwagon/impala/collection_listing.html:12
 #: src/olympia/bandwagon/templates/bandwagon/impala/collection_listing.html:20 src/olympia/bandwagon/templates/bandwagon/impala/collection_listing.html:24
 #: src/olympia/bandwagon/templates/bandwagon/impala/collection_sidebar.html:3 src/olympia/bandwagon/templates/bandwagon/includes/collection_sidebar.html:2
-#: src/olympia/bandwagon/templates/bandwagon/mobile/collection_listing.html:3 src/olympia/stats/templates/stats/stats.html:77 src/olympia/templates/menu_links.html:12
+#: src/olympia/bandwagon/templates/bandwagon/mobile/collection_listing.html:3 src/olympia/stats/templates/stats/stats.html:33 src/olympia/templates/menu_links.html:12
 msgid "Collections"
 msgstr "Kolekcje"
 
-#: src/olympia/amo/helpers.py:171 src/olympia/amo/templates/amo/site_nav.html:85 src/olympia/browse/templates/browse/language_tools.html:3
+#: src/olympia/amo/helpers.py:171 src/olympia/amo/templates/amo/site_nav.html:83 src/olympia/browse/templates/browse/language_tools.html:3
 msgid "Dictionaries & Language Packs"
 msgstr "Słowniki i pakiety językowe"
 
@@ -1619,8 +1602,8 @@ msgstr "Poproszono o specjalne sprawdzenie"
 msgid "Comment on {addon} {version}."
 msgstr "Skomentuj dodatek {addon} {version}."
 
-#: src/olympia/amo/log.py:236 src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:19 src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:47
-#: src/olympia/editors/helpers.py:511 src/olympia/editors/templates/editors/themes/history_table.html:11
+#: src/olympia/amo/log.py:236 src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:17 src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:45
+#: src/olympia/editors/helpers.py:584 src/olympia/editors/templates/editors/themes/history_table.html:11
 msgid "Comment"
 msgstr "Komentarz"
 
@@ -1949,7 +1932,7 @@ msgstr "Wstecz"
 #: src/olympia/amo/templates/amo/mobile/paginator.html:14 src/olympia/amo/templates/amo/mobile/paginator.html:16 src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:51
 #: src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:65 src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:78
 #: src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:91 src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:104
-#: src/olympia/discovery/templates/discovery/pane.html:45 src/olympia/discovery/templates/discovery/addons/detail.html:39 src/olympia/stats/templates/stats/stats.html:167
+#: src/olympia/discovery/templates/discovery/pane.html:45 src/olympia/discovery/templates/discovery/addons/detail.html:39 src/olympia/stats/templates/stats/stats.html:169
 msgid "Next"
 msgstr "Dalej"
 
@@ -1983,7 +1966,7 @@ msgstr ""
 "id=\"recaptcha_different\">spróbować zamiast tego innych słów</a> lub <a href=\"#\" id=\"recaptcha_audio\">innego rodzaju weryfikacji</a>. </p>"
 
 #: src/olympia/amo/templates/amo/side_nav.html:4 src/olympia/amo/templates/amo/side_nav.html:12 src/olympia/amo/templates/amo/site_nav.html:4 src/olympia/amo/templates/amo/site_nav.html:26
-#: src/olympia/browse/views.py:56 src/olympia/browse/views.py:66 src/olympia/browse/views.py:237 src/olympia/browse/views.py:282 src/olympia/search/forms.py:86
+#: src/olympia/browse/views.py:56 src/olympia/browse/views.py:66 src/olympia/browse/views.py:204 src/olympia/browse/views.py:249 src/olympia/search/forms.py:86
 msgid "Top Rated"
 msgstr "Najwyżej oceniane"
 
@@ -1998,37 +1981,37 @@ msgstr "Przejrzyj"
 msgid "Extensions"
 msgstr "Rozszerzenia"
 
-#: src/olympia/amo/templates/amo/site_nav.html:45
+#: src/olympia/amo/templates/amo/site_nav.html:44
 msgid "Want more customization? Try <b>Complete Themes</b>"
 msgstr ""
 
-#: src/olympia/amo/templates/amo/site_nav.html:56 src/olympia/bandwagon/views.py:96
+#: src/olympia/amo/templates/amo/site_nav.html:54 src/olympia/bandwagon/views.py:96
 msgid "Most Followers"
 msgstr "Najczęściej obserwowane"
 
-#: src/olympia/amo/templates/amo/site_nav.html:68 src/olympia/bandwagon/templates/bandwagon/impala/collection_sidebar.html:16 src/olympia/bandwagon/templates/bandwagon/includes/collection_sidebar.html:18
+#: src/olympia/amo/templates/amo/site_nav.html:66 src/olympia/bandwagon/templates/bandwagon/impala/collection_sidebar.html:16 src/olympia/bandwagon/templates/bandwagon/includes/collection_sidebar.html:18
 msgid "Collections I've Made"
 msgstr "Moje kolekcje"
 
-#: src/olympia/amo/templates/amo/site_nav.html:70 src/olympia/bandwagon/templates/bandwagon/user_listing.html:4 src/olympia/bandwagon/templates/bandwagon/impala/collection_sidebar.html:13
+#: src/olympia/amo/templates/amo/site_nav.html:68 src/olympia/bandwagon/templates/bandwagon/user_listing.html:4 src/olympia/bandwagon/templates/bandwagon/impala/collection_sidebar.html:13
 #: src/olympia/bandwagon/templates/bandwagon/includes/collection_sidebar.html:15
 msgid "Collections I'm Following"
 msgstr "Obserwowane kolekcje"
 
-#: src/olympia/amo/templates/amo/site_nav.html:73 src/olympia/bandwagon/templates/bandwagon/impala/collection_sidebar.html:18 src/olympia/bandwagon/templates/bandwagon/includes/collection_sidebar.html:20
-#: src/olympia/users/models.py:512
+#: src/olympia/amo/templates/amo/site_nav.html:71 src/olympia/bandwagon/templates/bandwagon/impala/collection_sidebar.html:18 src/olympia/bandwagon/templates/bandwagon/includes/collection_sidebar.html:20
+#: src/olympia/users/models.py:521
 msgid "My Favorite Add-ons"
 msgstr "Moje ulubione dodatki"
 
-#: src/olympia/amo/templates/amo/site_nav.html:78
+#: src/olympia/amo/templates/amo/site_nav.html:76
 msgid "More&hellip;"
 msgstr "Więcej&hellip;"
 
-#: src/olympia/amo/templates/amo/site_nav.html:82
+#: src/olympia/amo/templates/amo/site_nav.html:80
 msgid "Add-ons for Mobile"
 msgstr "Dodatki dla Mobile"
 
-#: src/olympia/amo/templates/amo/site_nav.html:86 src/olympia/browse/feeds.py:207 src/olympia/browse/templates/browse/search_tools.html:3 src/olympia/constants/base.py:176
+#: src/olympia/amo/templates/amo/site_nav.html:84 src/olympia/browse/feeds.py:207 src/olympia/browse/templates/browse/search_tools.html:3 src/olympia/constants/base.py:176
 #: src/olympia/templates/menu_links.html:10
 msgid "Search Tools"
 msgstr "Wyszukiwanie"
@@ -2044,7 +2027,7 @@ msgid "Jump to first page"
 msgstr "Przejdź do pierwszej strony"
 
 #: src/olympia/amo/templates/amo/impala/paginator.html:22 src/olympia/amo/templates/amo/mobile/impala_paginator.html:12 src/olympia/discovery/templates/discovery/pane.html:44
-#: src/olympia/discovery/templates/discovery/addons/detail.html:38 src/olympia/stats/templates/stats/stats.html:164
+#: src/olympia/discovery/templates/discovery/addons/detail.html:38 src/olympia/stats/templates/stats/stats.html:166
 msgid "Previous"
 msgstr "Wstecz"
 
@@ -2066,33 +2049,51 @@ msgid "Page {n}"
 msgid_plural "Page {n}"
 msgstr[0] "Strona {n}"
 msgstr[1] "Strona {n}"
-msgstr[2] "Strona {n}"
 
-#: src/olympia/amo/templates/services/install.html:38
-#, python-format
-msgid "If you are not prompted to install %(addon_name)s in a moment, please <a href=\"%(addon_xpi)s\">click here</a>."
-msgstr "Jeśli za chwilę nie pojawi się prośba o zainstalowanie dodatku %(addon_name)s, <a href=\"%(addon_xpi)s\">kliknij tutaj</a>."
-
-#: src/olympia/amo/tests/test_messages.py:57 src/olympia/amo/tests/test_messages.py:58 src/olympia/reviews/forms.py:25 src/olympia/reviews/forms.py:50 src/olympia/reviews/templates/reviews/add.html:56
+#: src/olympia/amo/tests/test_messages.py:56 src/olympia/amo/tests/test_messages.py:57 src/olympia/reviews/forms.py:25 src/olympia/reviews/forms.py:50 src/olympia/reviews/templates/reviews/add.html:56
 #: src/olympia/reviews/templates/reviews/reply.html:30
 msgid "Title"
 msgstr "Tytuł"
 
-#: src/olympia/amo/tests/test_messages.py:57 src/olympia/amo/tests/test_messages.py:58
+#: src/olympia/amo/tests/test_messages.py:56 src/olympia/amo/tests/test_messages.py:57
 msgid "Body"
 msgstr "Treść"
 
-#: src/olympia/amo/tests/test_messages.py:59
+#: src/olympia/amo/tests/test_messages.py:58
 msgid "Another Title"
 msgstr "Inny tytuł"
 
-#: src/olympia/amo/tests/test_messages.py:59
+#: src/olympia/amo/tests/test_messages.py:58
 msgid "Another Body"
 msgstr "Inna treść"
 
-#: src/olympia/api/views.py:255
-msgid "Not implemented yet."
-msgstr "Jeszcze niezaimplementowane."
+#: src/olympia/api/authentication.py:76
+msgid "Signature has expired."
+msgstr ""
+
+#: src/olympia/api/authentication.py:79
+msgid "Error decoding signature."
+msgstr ""
+
+#: src/olympia/api/authentication.py:82
+msgid "Invalid JWT Token."
+msgstr ""
+
+#: src/olympia/api/authentication.py:130
+msgid "Invalid Authorization header. No credentials provided."
+msgstr ""
+
+#: src/olympia/api/authentication.py:133
+msgid "Invalid Authorization header. Credentials string should not contain spaces."
+msgstr ""
+
+#: src/olympia/api/fields.py:29
+msgid "The field must have a length of at least {num} characters."
+msgstr ""
+
+#: src/olympia/api/fields.py:31
+msgid "The language code {lang_code} is invalid."
+msgstr ""
 
 #: src/olympia/applications/views.py:39 src/olympia/applications/templates/applications/appversions.html:3
 msgid "Application Versions"
@@ -2110,7 +2111,7 @@ msgstr "Poprawne wersje programu"
 msgid "Add-ons submitted to Mozilla Add-ons must have a manifest file with at least one of the below applications supported. Only the versions listed below are allowed for these applications."
 msgstr ""
 
-#: src/olympia/applications/templates/applications/appversions.html:25
+#: src/olympia/applications/templates/applications/appversions.html:25 src/olympia/editors/helpers.py:361
 msgid "GUID"
 msgstr "GUID"
 
@@ -2187,11 +2188,11 @@ msgstr "Odnośniki są niedozwolone."
 msgid "This url is already in use by another collection"
 msgstr "Ten adres url jest już używany przez inną kolekcję"
 
-#: src/olympia/bandwagon/forms.py:197 src/olympia/devhub/views.py:1049
+#: src/olympia/bandwagon/forms.py:197 src/olympia/devhub/views.py:1050
 msgid "Icons must be either PNG or JPG."
 msgstr "Ikona musi być w formacie PNG lub JPG."
 
-#: src/olympia/bandwagon/forms.py:202 src/olympia/devhub/views.py:1067 src/olympia/users/forms.py:476
+#: src/olympia/bandwagon/forms.py:202 src/olympia/devhub/views.py:1068 src/olympia/users/forms.py:476
 #, python-format
 msgid "Please use images smaller than %dMB."
 msgstr "Proszę użyć obrazków mniejszych niż %dMB."
@@ -2224,8 +2225,8 @@ msgstr "Ulubione"
 msgid "Remove from favorites"
 msgstr "Usuń z ulubionych"
 
-#: src/olympia/bandwagon/views.py:98 src/olympia/bandwagon/views.py:191 src/olympia/browse/views.py:58 src/olympia/browse/views.py:69 src/olympia/browse/views.py:458 src/olympia/devhub/views.py:74
-#: src/olympia/devhub/views.py:82 src/olympia/devhub/templates/devhub/addons/edit/basic.html:20 src/olympia/editors/templates/editors/leaderboard.html:24
+#: src/olympia/bandwagon/views.py:98 src/olympia/bandwagon/views.py:191 src/olympia/browse/views.py:58 src/olympia/browse/views.py:69 src/olympia/browse/views.py:425 src/olympia/devhub/views.py:73
+#: src/olympia/devhub/views.py:81 src/olympia/devhub/templates/devhub/addons/edit/basic.html:20 src/olympia/editors/templates/editors/leaderboard.html:24
 #: src/olympia/editors/templates/editors/themes/queue_list.html:48 src/olympia/search/forms.py:17 src/olympia/search/forms.py:89 src/olympia/users/templates/users/vcard.html:5
 msgid "Name"
 msgstr "Nazwa"
@@ -2234,7 +2235,7 @@ msgstr "Nazwa"
 msgid "Recently Popular"
 msgstr "Ostatnio popularne"
 
-#: src/olympia/bandwagon/views.py:189 src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:18
+#: src/olympia/bandwagon/views.py:189 src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:16
 msgid "Added"
 msgstr "Dodano"
 
@@ -2248,8 +2249,8 @@ msgstr "Kolekcja została utworzona!"
 
 #: src/olympia/bandwagon/views.py:316
 #, python-format
-msgid "Your new collection is shown below. You can <ahref=\"%(url)s\">edit additional settings</a> if you'dlike."
-msgstr ""
+msgid "Your new collection is shown below. You can <a href=\"%(url)s\">edit additional settings</a> if you'd like."
+msgstr "Poniżej znajduje się twoja nowa kolekcja. Jeśli chcesz, możesz <a href=\"%(url)s\">edytować dodatkowe ustawienia</a>."
 
 #: src/olympia/bandwagon/views.py:322
 msgid "Collection updated!"
@@ -2329,7 +2330,6 @@ msgid "<span>%(num)s</span> follower"
 msgid_plural "<span>%(num)s</span> followers"
 msgstr[0] "<span>%(num)s</span> obserwator"
 msgstr[1] "<span>%(num)s</span> obserwatorów"
-msgstr[2] "<span>%(num)s</span> obserwatorów"
 
 #: src/olympia/bandwagon/templates/bandwagon/collection_detail.html:54
 msgid "About this Collection"
@@ -2369,7 +2369,6 @@ msgid "%(num)s Theme in this Collection"
 msgid_plural "%(num)s Themes in this Collection"
 msgstr[0] "%(num)s motyw w tej kolekcji"
 msgstr[1] "%(num)s motywy w tej kolekcji"
-msgstr[2] "%(num)s motywów w tej kolekcji"
 
 #: src/olympia/bandwagon/templates/bandwagon/collection_detail.html:111
 #, python-format
@@ -2377,10 +2376,9 @@ msgid "%(num)s Add-on in this Collection"
 msgid_plural "%(num)s Add-ons in this Collection"
 msgstr[0] "W tej kolekcji znajduje się %(num)s dodatek"
 msgstr[1] "W tej kolekcji znajdują się %(num)s dodatki"
-msgstr[2] "W tej kolekcji znajduje się %(num)s dodatków"
 
-#: src/olympia/bandwagon/templates/bandwagon/collection_detail.html:125 src/olympia/compat/templates/compat/index.html:25 src/olympia/compat/templates/compat/reporter_detail.html:29
-#: src/olympia/files/templates/files/viewer.html:29 src/olympia/templates/amo_footer.html:17 src/olympia/templates/includes/lang_switcher.html:10
+#: src/olympia/bandwagon/templates/bandwagon/collection_detail.html:125 src/olympia/compat/templates/compat/reporter_detail.html:29 src/olympia/files/templates/files/viewer.html:29
+#: src/olympia/templates/amo_footer.html:17 src/olympia/templates/includes/lang_switcher.html:10
 msgid "Go"
 msgstr "Przejdź"
 
@@ -2430,7 +2428,6 @@ msgid "<span>%(addons)s</span> add-on"
 msgid_plural "<span>%(addons)s</span> add-ons"
 msgstr[0] "<span>%(addons)s</span> dodatek"
 msgstr[1] "<span>%(addons)s</span> dodatki"
-msgstr[2] "<span>%(addons)s</span> dodatków"
 
 #: src/olympia/bandwagon/templates/bandwagon/collection_grid.html:32
 #, python-format
@@ -2438,7 +2435,6 @@ msgid "<span>%(followers)s</span> follower"
 msgid_plural "<span>%(followers)s</span> followers"
 msgstr[0] "<span>%(followers)s</span> obserwator"
 msgstr[1] "<span>%(followers)s</span> obserwatorów"
-msgstr[2] "<span>%(followers)s</span> obserwatorów"
 
 #. People "follow" collections to get notified of updates.                    Like
 #. Twitter followers.
@@ -2450,7 +2446,6 @@ msgid "%(num)s weekly follower"
 msgid_plural "%(num)s weekly followers"
 msgstr[0] "%(num)s obserwator tygodniowo"
 msgstr[1] "%(num)s obserwatorzy tygodniowo"
-msgstr[2] "%(num)s obserwatorów tygodniowo"
 
 #. People "follow" collections to get notified of updates.                    Like
 #. Twitter followers.
@@ -2460,7 +2455,6 @@ msgid "%(num)s monthly follower"
 msgid_plural "%(num)s monthly followers"
 msgstr[0] "%(num)s obserwator miesięcznie"
 msgstr[1] "%(num)s obserwatorów miesięcznie"
-msgstr[2] "%(num)s obserwatorów miesięcznie"
 
 #. People "follow" collections to get notified of updates.                    Like
 #. Twitter followers.
@@ -2472,7 +2466,6 @@ msgid "%(num)s follower"
 msgid_plural "%(num)s followers"
 msgstr[0] "%(num)s obserwator"
 msgstr[1] "%(num)s obserwatorów"
-msgstr[2] "%(num)s obserwatorów"
 
 #: src/olympia/bandwagon/templates/bandwagon/collection_listing_items.html:56 src/olympia/bandwagon/templates/bandwagon/impala/collection_listing_items.html:9
 #: src/olympia/devhub/templates/devhub/personas/edit.html:27
@@ -2557,7 +2550,7 @@ msgid "Remove this user as a contributor"
 msgstr "Usuń tego użytkownika z listy autorów"
 
 #: src/olympia/bandwagon/templates/bandwagon/edit_contributors.html:18 src/olympia/bandwagon/templates/bandwagon/edit_contributors.html:43
-#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:20 src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:48
+#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:18 src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:46
 #: src/olympia/devhub/templates/devhub/addons/ajax_compat_update.html:19
 msgid "Remove"
 msgstr "Usuń"
@@ -2608,7 +2601,7 @@ msgid "<b>Warning:</b> By changing the owner of this collection, you will no lon
 msgstr "<b>Ostrzeżenie:</b> Po zmianie właściciela tej kolekcji nie będziesz mieć możliwości edytowania tej kolekcji. Będziesz tylko mieć możliwość dodawania i usuwania z niej dodatków."
 
 #: src/olympia/bandwagon/templates/bandwagon/edit_contributors.html:83 src/olympia/devhub/templates/devhub/addons/forms_shared/media.html:157
-#: src/olympia/devhub/templates/devhub/addons/submit/describe.html:69 src/olympia/devhub/templates/devhub/addons/submit/license.html:60 src/olympia/devhub/templates/devhub/addons/submit/upload.html:78
+#: src/olympia/devhub/templates/devhub/addons/submit/describe.html:69 src/olympia/devhub/templates/devhub/addons/submit/license.html:60 src/olympia/devhub/templates/devhub/addons/submit/upload.html:70
 #: src/olympia/devhub/templates/devhub/payments/tier.html:17 src/olympia/editors/templates/editors/themes/themes.html:111 src/olympia/editors/templates/editors/themes/themes.html:128
 #: src/olympia/editors/templates/editors/themes/themes.html:134 src/olympia/editors/templates/editors/themes/themes.html:141 src/olympia/users/templates/users/fxa_migration_prompt_content.html:10
 #: src/olympia/users/templates/users/login_form.html:42 src/olympia/users/templates/users/mobile/login.html:57
@@ -2691,32 +2684,31 @@ msgid "Add-ons in Your Collection"
 msgstr "Dodatki w tej kolekcji"
 
 #: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:4
-msgid "To include an add-on in this collection, enter its name in the box below and hit enter. You can also use the <strong>Add to Collection</strong> links throughout the site to include add-ons later."
+msgid "To include an add-on in this collection, enter its name in the box below and hit enter."
 msgstr ""
-"Aby dodać dodatek do tej kolekcji, wprowadź jego nazwę w polu poniżej i naciśnij Enter. Aby dodać dodatek później, można użyć odnośnika <strong>Dodaj do kolekcji</strong> znajdującego się w wielu "
-"miejscach witryny."
 
-#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:17 src/olympia/constants/base.py:400 src/olympia/devhub/templates/devhub/addons/activity.html:62
+#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:15 src/olympia/constants/base.py:400 src/olympia/devhub/templates/devhub/addons/activity.html:62
+#: src/olympia/editors/helpers.py:273 src/olympia/editors/helpers.py:360
 msgid "Add-on"
 msgstr "Dodatek"
 
-#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:26
+#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:24
 msgid "Enter the name of the add-on to include"
 msgstr "Aby dodać dodatek, podaj jego nazwę"
 
-#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:28
+#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:26
 msgid "Add to Collection"
 msgstr "Dodaj do kolekcji"
 
-#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:45 src/olympia/editors/helpers.py:936 src/olympia/editors/helpers.py:956
+#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:43 src/olympia/editors/helpers.py:1016 src/olympia/editors/helpers.py:1036
 msgid "Pending"
 msgstr "Oczekujące"
 
-#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:47
+#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:45
 msgid "Add a comment"
 msgstr "Dodaj komentarz"
 
-#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:48
+#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:46
 msgid "Remove this add-on from the collection"
 msgstr "Usuń ten dodatek z kolekcji"
 
@@ -2826,12 +2818,12 @@ msgstr "Narzędzia wyszukiwania"
 msgid "Most Users"
 msgstr "Najwięcej użytkowników"
 
-#: src/olympia/browse/views.py:61 src/olympia/browse/views.py:72 src/olympia/browse/views.py:279 src/olympia/browse/templates/browse/personas/mobile/category_landing.html:63
+#: src/olympia/browse/views.py:61 src/olympia/browse/views.py:72 src/olympia/browse/views.py:246 src/olympia/browse/templates/browse/personas/mobile/category_landing.html:63
 #: src/olympia/discovery/templates/discovery/pane.html:67 src/olympia/search/forms.py:92
 msgid "Up & Coming"
 msgstr "Najczęściej używane"
 
-#: src/olympia/browse/views.py:460 src/olympia/devhub/views.py:76 src/olympia/devhub/views.py:83 src/olympia/discovery/templates/discovery/addons/detail.html:66
+#: src/olympia/browse/views.py:427 src/olympia/devhub/views.py:75 src/olympia/devhub/views.py:82 src/olympia/discovery/templates/discovery/addons/detail.html:66
 msgid "Created"
 msgstr "Data utworzenia"
 
@@ -2912,7 +2904,6 @@ msgid "<b>{0}</b> add-on"
 msgid_plural "<b>{0}</b> add-ons"
 msgstr[0] "<b>{0}</b> dodatek"
 msgstr[1] "<b>{0}</b> dodatki"
-msgstr[2] "<b>{0}</b> dodatków"
 
 #: src/olympia/browse/templates/browse/search_tools.html:61
 msgid "Search Extensions"
@@ -3019,10 +3010,9 @@ msgid "See the %(cnt)s extension in %(name)s &raquo;"
 msgid_plural "See all %(cnt)s extensions in %(name)s &raquo;"
 msgstr[0] "Zobacz rozszerzenie z kategorii %(name)s &raquo;"
 msgstr[1] "Zobacz wszystkie %(cnt)s rozszerzenia z kategorii %(name)s &raquo;"
-msgstr[2] "Zobacz wszystkie %(cnt)s rozszerzeń z kategorii %(name)s &raquo;"
 
-#: src/olympia/browse/templates/browse/mobile/extensions.html:13 src/olympia/compat/templates/compat/index.html:82 src/olympia/devhub/templates/devhub/devhub_search.html:24
-#: src/olympia/devhub/templates/devhub/addons/activity.html:47 src/olympia/search/templates/search/no_results.html:4 src/olympia/search/templates/search/mobile/results.html:36
+#: src/olympia/browse/templates/browse/mobile/extensions.html:13 src/olympia/devhub/templates/devhub/devhub_search.html:24 src/olympia/devhub/templates/devhub/addons/activity.html:47
+#: src/olympia/search/templates/search/no_results.html:4 src/olympia/search/templates/search/mobile/results.html:36
 msgid "No results found."
 msgstr "Nic nie znaleziono."
 
@@ -3107,7 +3097,7 @@ msgstr "&laquo; Wszystkie motywy"
 msgid "All"
 msgstr "Wszystko"
 
-#: src/olympia/compat/forms.py:22 src/olympia/search/views.py:525
+#: src/olympia/compat/forms.py:22 src/olympia/editors/templates/editors/base.html:69 src/olympia/search/views.py:518
 msgid "All Add-ons"
 msgstr "Wszystkie dodatki"
 
@@ -3118,53 +3108,6 @@ msgstr "Binarny"
 #: src/olympia/compat/forms.py:24
 msgid "Non-binary"
 msgstr "Niebinarny"
-
-#. Review points sources other than add-ons and themes.
-#: src/olympia/compat/views.py:87 src/olympia/constants/base.py:388 src/olympia/devhub/forms.py:162 src/olympia/editors/templates/editors/performance.html:75
-msgid "Other"
-msgstr "Inna"
-
-#: src/olympia/compat/templates/compat/index.html:4
-msgid "Add-on Compatibility Report for {app} {version}"
-msgstr "Zgłoszenie kompatybilności dodatku z programem {app} {version}"
-
-#: src/olympia/compat/templates/compat/index.html:11
-msgid "{app} {version} Compatibility"
-msgstr "Kompatybilność z {app} {version}"
-
-#: src/olympia/compat/templates/compat/index.html:17
-#, python-format
-msgid "Top 95%% compatible with previous version"
-msgstr ""
-
-#: src/olympia/compat/templates/compat/index.html:18
-#, python-format
-msgid "Top 95%% of all add-ons"
-msgstr ""
-
-#: src/olympia/compat/templates/compat/index.html:19
-msgid "All active add-ons"
-msgstr "Wszystkie aktywne dodatki"
-
-#: src/olympia/compat/templates/compat/index.html:23 src/olympia/constants/base.py:401
-msgid "App"
-msgstr "Aplikacja"
-
-#: src/olympia/compat/templates/compat/index.html:55
-msgid "Details for add-ons compatible with previous version:"
-msgstr "Szczegóły dodatków kompatybilnych z poprzednią wersją:"
-
-#: src/olympia/compat/templates/compat/index.html:57
-msgid "Show all versions"
-msgstr "Wszystkie wersje"
-
-#: src/olympia/compat/templates/compat/index.html:59
-msgid "Details for add-ons compatible with all versions:"
-msgstr "Szczegóły dodatków kompatybilnych z wszystkimi wersjami:"
-
-#: src/olympia/compat/templates/compat/index.html:61
-msgid "Show previous version only"
-msgstr "Tylko poprzednia wersja"
 
 #: src/olympia/compat/templates/compat/reporter.html:3
 msgid "Add-on Compatibility Reports"
@@ -3200,14 +3143,12 @@ msgid "{0} success report"
 msgid_plural "{0} success reports"
 msgstr[0] "{0} zgłoszenie poprawności"
 msgstr[1] "{0} zgłoszenia poprawności"
-msgstr[2] "{0} zgłoszeń poprawności"
 
 #: src/olympia/compat/templates/compat/reporter_detail.html:17
 msgid "{0} problem report"
 msgid_plural "{0} problem reports"
 msgstr[0] "{0} zgłoszenie problemów"
 msgstr[1] "{0} zgłoszenia problemów"
-msgstr[2] "{0} zgłoszeń problemów"
 
 #: src/olympia/compat/templates/compat/reporter_detail.html:21 src/olympia/users/templates/users/profile.html:70
 msgid "View all"
@@ -3221,8 +3162,8 @@ msgstr "Filtruj wg aplikacji"
 msgid "Report Type"
 msgstr "Typ zgłoszenia"
 
-#: src/olympia/compat/templates/compat/reporter_detail.html:47 src/olympia/devhub/forms.py:784 src/olympia/devhub/templates/devhub/addons/ajax_compat_update.html:17 src/olympia/editors/forms.py:108
-#: src/olympia/zadmin/forms.py:45
+#: src/olympia/compat/templates/compat/reporter_detail.html:47 src/olympia/devhub/forms.py:785 src/olympia/devhub/templates/devhub/addons/ajax_compat_update.html:17 src/olympia/editors/forms.py:108
+#: src/olympia/editors/forms.py:248 src/olympia/zadmin/forms.py:45
 msgid "Application"
 msgstr "Program"
 
@@ -3310,7 +3251,8 @@ msgstr "Wstępnie sprawdzony"
 msgid "Preliminarily Reviewed and Awaiting Full Review"
 msgstr "Sprawdzono wstępnie i oczekuje na pełne sprawdzenie"
 
-#: src/olympia/constants/base.py:33 src/olympia/editors/helpers.py:924 src/olympia/editors/templates/editors/themes/history_table.html:34
+#: src/olympia/constants/base.py:33 src/olympia/editors/forms.py:258 src/olympia/editors/helpers.py:73 src/olympia/editors/helpers.py:1004
+#: src/olympia/editors/templates/editors/themes/history_table.html:34
 msgid "Deleted"
 msgstr "Usunięto"
 
@@ -3410,6 +3352,11 @@ msgstr "Wyświetlaj prośbę po rozpoczęciu pobierania dodatku"
 msgid "Ask before users can download this add-on"
 msgstr "Wyświetlaj prośbę przed pobraniem dodatku"
 
+#. Review points sources other than add-ons and themes.
+#: src/olympia/constants/base.py:388 src/olympia/devhub/forms.py:162 src/olympia/editors/templates/editors/performance.html:75
+msgid "Other"
+msgstr "Inna"
+
 #: src/olympia/constants/base.py:389
 msgid "Exception"
 msgstr "Wyjątek"
@@ -3421,6 +3368,10 @@ msgstr "Wydanie"
 #: src/olympia/constants/base.py:391
 msgid "Change"
 msgstr "Zmień"
+
+#: src/olympia/constants/base.py:401
+msgid "App"
+msgstr "Aplikacja"
 
 #: src/olympia/constants/base.py:402
 msgid "Persona"
@@ -3570,7 +3521,7 @@ msgstr "Oznacz"
 msgid "Duplicate"
 msgstr "Duplikat"
 
-#: src/olympia/constants/editors.py:17 src/olympia/editors/helpers.py:502 src/olympia/editors/templates/editors/themes/queue.html:71 src/olympia/editors/templates/editors/themes/themes.html:94
+#: src/olympia/constants/editors.py:17 src/olympia/editors/helpers.py:575 src/olympia/editors/templates/editors/themes/queue.html:71 src/olympia/editors/templates/editors/themes/themes.html:94
 msgid "Reject"
 msgstr "Odrzuć"
 
@@ -3670,7 +3621,7 @@ msgstr "Solaris"
 msgid "Android"
 msgstr "Android"
 
-#: src/olympia/core/apps.py:19
+#: src/olympia/core/apps.py:21
 msgid "Core"
 msgstr ""
 
@@ -3804,8 +3755,8 @@ msgid "Submit my add-on for manual review."
 msgstr "Prześlij dodatek do ręcznego sprawdzenia."
 
 #: src/olympia/devhub/forms.py:537
-msgid "Do not list my add-on on this site (beta)"
-msgstr "Nie wyświetlaj mojego dodatku na tej stronie (beta)"
+msgid "Do not list my add-on on this site"
+msgstr ""
 
 #: src/olympia/devhub/forms.py:538
 msgid "Check this option if you intend to distribute your add-on on your own and only need it to be signed by Mozilla."
@@ -3837,46 +3788,46 @@ msgstr "Plik z wersją kończącą się na a|alpha|b|beta|pre|rc i opcjonalnym n
 
 #: src/olympia/devhub/forms.py:592
 #, python-format
-msgid "Version %s already exists"
-msgstr "Wersja %s już istnieje"
+msgid "Version %s already exists, or was uploaded before."
+msgstr ""
 
-#: src/olympia/devhub/forms.py:604
+#: src/olympia/devhub/forms.py:605
 msgid "Select a valid choice. That choice is not one of the available choices."
 msgstr "Zaznacz poprawny wybór. Ten wybór nie jest jednym z dostępnych."
 
-#: src/olympia/devhub/forms.py:610
+#: src/olympia/devhub/forms.py:611
 msgid "A file with a version ending with a|alpha|b|beta and an optional number is detected as beta."
 msgstr "Plik z wersją kończącą się na a|alpha|b|beta i opcjonalnym numerem jest rozpoznawany jako beta."
 
-#: src/olympia/devhub/forms.py:633
+#: src/olympia/devhub/forms.py:634
 msgid "You cannot upload any more files for this version."
 msgstr "Nie możesz przesłać więcej plików dla tej wersji."
 
-#: src/olympia/devhub/forms.py:639
+#: src/olympia/devhub/forms.py:640
 msgid "Version doesn't match"
 msgstr "Wersja nie pasuje"
 
-#: src/olympia/devhub/forms.py:668
+#: src/olympia/devhub/forms.py:669
 msgid "You cannot delete a file once the review process has started. You must delete the whole version."
 msgstr "Po rozpoczęciu procesu sprawdzania nie możesz usunąć pliku. Musisz usunąć całą wersję."
 
-#: src/olympia/devhub/forms.py:688
+#: src/olympia/devhub/forms.py:689
 msgid "The platform All cannot be combined with specific platforms."
 msgstr "Oznaczenie „Wszystkie” nie może być połączone z konkretnymi systemami."
 
-#: src/olympia/devhub/forms.py:693
+#: src/olympia/devhub/forms.py:694
 msgid "A platform can only be chosen once."
 msgstr "System może zostać wybrany tylko raz."
 
-#: src/olympia/devhub/forms.py:706
+#: src/olympia/devhub/forms.py:707
 msgid "A review type must be selected."
 msgstr "Musi zostać wybrany typ sprawdzenia."
 
-#: src/olympia/devhub/forms.py:788 src/olympia/editors/forms.py:114 src/olympia/zadmin/forms.py:49 src/olympia/zadmin/forms.py:52
+#: src/olympia/devhub/forms.py:789 src/olympia/editors/forms.py:114 src/olympia/editors/forms.py:254 src/olympia/zadmin/forms.py:49 src/olympia/zadmin/forms.py:52
 msgid "Select an application first"
 msgstr "Wybierz najpierw program"
 
-#: src/olympia/devhub/forms.py:840
+#: src/olympia/devhub/forms.py:841
 msgid "There cannot be more than 3 required add-ons."
 msgstr "Nie więcej niż trzy wymagane dodatki."
 
@@ -3898,7 +3849,6 @@ msgid "{0} error"
 msgid_plural "{0} errors"
 msgstr[0] "{0} błąd"
 msgstr[1] "{0} błędy"
-msgstr[2] "{0} błędów"
 
 #. L10n: first parameter is the number of warnings
 #: src/olympia/devhub/helpers.py:203
@@ -3906,166 +3856,165 @@ msgid "{0} warning"
 msgid_plural "{0} warnings"
 msgstr[0] "{0} ostrzeżenie"
 msgstr[1] "{0} ostrzeżenia"
-msgstr[2] "{0} ostrzeżeń"
 
 #: src/olympia/devhub/models.py:375 src/olympia/reviews/templates/reviews/add.html:58
 msgid "Review"
 msgstr "Opinia"
 
-#: src/olympia/devhub/tasks.py:551
+#: src/olympia/devhub/tasks.py:583
 #, python-format
 msgid "%s responded with %s (%s)."
 msgstr "%s odpowiada %s (%s)."
 
-#: src/olympia/devhub/tasks.py:555
+#: src/olympia/devhub/tasks.py:587
 #, python-format
 msgid "Connection to \"%s\" timed out."
 msgstr "Upłynął limit czasu połączenia z „%s”."
 
-#: src/olympia/devhub/tasks.py:557
+#: src/olympia/devhub/tasks.py:589
 #, python-format
 msgid "Could not contact host at \"%s\"."
 msgstr "Nie można połączyć się z serwerem „%s”."
 
-#: src/olympia/devhub/utils.py:104
+#: src/olympia/devhub/utils.py:105
 #, python-format
 msgid "Validation generated too many errors/warnings so %s messages were truncated. After addressing the visible messages, you'll be able to see the others."
 msgstr "Sprawdzenie wygenerowało zbyt dużo błędów/ostrzeżeń, zatem przycięto komunikaty %s."
 
-#: src/olympia/devhub/views.py:183
+#: src/olympia/devhub/views.py:182
 msgid "All My Add-ons"
 msgstr "Moje dodatki"
 
-#: src/olympia/devhub/views.py:210
+#: src/olympia/devhub/views.py:209
 msgid "All Activity"
 msgstr "Wszystkie czynności"
 
-#: src/olympia/devhub/views.py:211
+#: src/olympia/devhub/views.py:210
 msgid "Add-on Updates"
 msgstr "Aktualizacje dodatku"
 
-#: src/olympia/devhub/views.py:212
+#: src/olympia/devhub/views.py:211
 msgid "Add-on Status"
 msgstr "Status dodatku"
 
-#: src/olympia/devhub/views.py:213
+#: src/olympia/devhub/views.py:212
 msgid "User Collections"
 msgstr "Kolekcje użytkownika"
 
-#: src/olympia/devhub/views.py:214 src/olympia/devhub/templates/devhub/docs/policies-maintenance.html:68 src/olympia/pages/templates/pages/dev_faq.html:38
+#: src/olympia/devhub/views.py:213 src/olympia/devhub/templates/devhub/docs/policies-maintenance.html:68 src/olympia/pages/templates/pages/dev_faq.html:38
 #: src/olympia/pages/templates/pages/dev_faq.html:484
 msgid "User Reviews"
 msgstr "Opinie użytkownika"
 
-#: src/olympia/devhub/views.py:327 src/olympia/devhub/views.py:331 src/olympia/devhub/views.py:484 src/olympia/devhub/views.py:513 src/olympia/devhub/views.py:564 src/olympia/devhub/views.py:1150
+#: src/olympia/devhub/views.py:326 src/olympia/devhub/views.py:330 src/olympia/devhub/views.py:485 src/olympia/devhub/views.py:514 src/olympia/devhub/views.py:565 src/olympia/devhub/views.py:1157
 msgid "Changes successfully saved."
 msgstr "Zmiany zostały zapisane."
 
-#: src/olympia/devhub/views.py:334 src/olympia/devhub/views.py:1631
+#: src/olympia/devhub/views.py:333 src/olympia/devhub/views.py:1638
 msgid "Please check the form for errors."
 msgstr "Sprawdź błędy w formularzu."
 
-#: src/olympia/devhub/views.py:346
+#: src/olympia/devhub/views.py:345
 msgid "Add-on cannot be deleted. Disable this add-on instead."
 msgstr "Dodatek nie może zostać usunięty. Zamiast tego możesz go wyłączyć."
 
-#: src/olympia/devhub/views.py:356
+#: src/olympia/devhub/views.py:355
 msgid "Theme deleted."
 msgstr "Usunięto motyw."
 
-#: src/olympia/devhub/views.py:356
+#: src/olympia/devhub/views.py:355
 msgid "Add-on deleted."
 msgstr "Dodatek został usunięty."
 
-#: src/olympia/devhub/views.py:362
+#: src/olympia/devhub/views.py:361
 msgid "URL name was incorrect. Theme was not deleted."
 msgstr ""
 
-#: src/olympia/devhub/views.py:367
+#: src/olympia/devhub/views.py:366
 msgid "URL name was incorrect. Add-on was not deleted."
 msgstr ""
 
-#: src/olympia/devhub/views.py:449
+#: src/olympia/devhub/views.py:450
 msgid "An author has been added to your add-on"
 msgstr "Dodano autora do twojego dodatku"
 
-#: src/olympia/devhub/views.py:456
+#: src/olympia/devhub/views.py:457
 msgid "An author has a role changed on your add-on"
 msgstr "Zmieniono rolę autora twojego dodatku"
 
-#: src/olympia/devhub/views.py:476
+#: src/olympia/devhub/views.py:477
 msgid "An author has been removed from your add-on"
 msgstr "sunięto autora twojego dodatku"
 
-#: src/olympia/devhub/views.py:519
+#: src/olympia/devhub/views.py:520
 msgid "There were errors in your submission."
 msgstr "Podczas zamieszczania dodatku wystąpiły błędy."
 
-#: src/olympia/devhub/views.py:583
+#: src/olympia/devhub/views.py:584
 msgid "Validate Add-on"
 msgstr "Sprawdzanie dodatku"
 
-#: src/olympia/devhub/views.py:594
+#: src/olympia/devhub/views.py:595
 msgid "Check Add-on Compatibility"
 msgstr "Sprawdź kompatybilność dodatku"
 
-#: src/olympia/devhub/views.py:808 src/olympia/signing/views.py:90
+#: src/olympia/devhub/views.py:809 src/olympia/signing/views.py:95
 msgid "You cannot submit this type of add-on"
 msgstr ""
 
-#: src/olympia/devhub/views.py:1051 src/olympia/users/forms.py:471
+#: src/olympia/devhub/views.py:1052 src/olympia/users/forms.py:471
 msgid "Images must be either PNG or JPG."
 msgstr "Obrazki muszą być w formacie PNG lub JPG."
 
-#: src/olympia/devhub/views.py:1055
+#: src/olympia/devhub/views.py:1056
 msgid "Icons cannot be animated."
 msgstr "Nie można używać animowanych ikon."
 
-#: src/olympia/devhub/views.py:1057
+#: src/olympia/devhub/views.py:1058
 msgid "Images cannot be animated."
 msgstr "Nie można używać animowanych obrazków."
 
-#: src/olympia/devhub/views.py:1070
+#: src/olympia/devhub/views.py:1071
 #, python-format
 msgid "Images cannot be larger than %dKB."
 msgstr "Plik graficzny nie może być większy niż %d KB."
 
 #. L10n: {0} is an image width (in pixels), {1} is a height.
-#: src/olympia/devhub/views.py:1080
+#: src/olympia/devhub/views.py:1081
 msgid "Image must be exactly {0} pixels wide and {1} pixels tall."
 msgstr "Obrazek musi mieć dokładnie {0} pikseli szerokości i {1} pikseli wysokości."
 
-#: src/olympia/devhub/views.py:1087
+#: src/olympia/devhub/views.py:1088
 msgid "There was an error uploading your preview."
 msgstr "Wystąpił błąd podczas przesyłania obrazka."
 
-#: src/olympia/devhub/views.py:1189
+#: src/olympia/devhub/views.py:1196
 #, python-format
 msgid "Version %s disabled."
 msgstr "Wersja %s niedostępna."
 
-#: src/olympia/devhub/views.py:1193
+#: src/olympia/devhub/views.py:1200
 #, python-format
 msgid "Version %s deleted."
 msgstr "Wersja %s została usunięta."
 
-#: src/olympia/devhub/views.py:1203
+#: src/olympia/devhub/views.py:1210
 msgid "This upload has failed validation, and may lack complete validation results. Please take due care when reviewing it."
 msgstr "Nie powiodła się weryfikacja tego zgłoszenia i może brakować pełnych wyników weryfikacji. Weź to pod uwagę podczas sprawdzania."
 
-#: src/olympia/devhub/views.py:1677
+#: src/olympia/devhub/views.py:1684
 msgid "Preliminary Review Requested."
 msgstr "Poproszono o wstępne sprawdzenie."
 
-#: src/olympia/devhub/views.py:1678
+#: src/olympia/devhub/views.py:1685
 msgid "Full Review Requested."
 msgstr "Poproszono o pełne sprawdzenie."
 
-#: src/olympia/devhub/views.py:1779
+#: src/olympia/devhub/views.py:1786
 msgid "Your old credentials were revoked and are no longer valid. Be sure to update all API clients with the new credentials."
 msgstr ""
 
-#: src/olympia/devhub/views.py:1797
+#: src/olympia/devhub/views.py:1804
 msgid "New API key created"
 msgstr ""
 
@@ -4095,7 +4044,7 @@ msgstr "Dodatki"
 msgid "{0} :: Search"
 msgstr "{0} :: Wyszukiwanie"
 
-#: src/olympia/devhub/templates/devhub/devhub_search.html:6 src/olympia/devhub/templates/devhub/search.html:8 src/olympia/editors/forms.py:435 src/olympia/editors/forms.py:437
+#: src/olympia/devhub/templates/devhub/devhub_search.html:6 src/olympia/devhub/templates/devhub/search.html:8 src/olympia/editors/forms.py:534 src/olympia/editors/forms.py:536
 #: src/olympia/editors/templates/editors/queue.html:27 src/olympia/editors/templates/editors/themes/queue_list.html:14 src/olympia/search/templates/search/collections.html:17
 #: src/olympia/search/templates/search/personas.html:18 src/olympia/search/templates/search/results.html:18 src/olympia/search/templates/search/mobile/results.html:8 src/olympia/templates/search.html:14
 #: src/olympia/templates/impala/search.html:18
@@ -4155,12 +4104,12 @@ msgstr "Przejdź do <a href=\"https://developer.mozilla.org/Add-ons\">Mozilla De
 msgid "Start Making Add-ons"
 msgstr "Zacznij tworzyć dodatki"
 
-#: src/olympia/devhub/templates/devhub/index.html:86 src/olympia/devhub/templates/devhub/addons/listing/items.html:25 src/olympia/devhub/templates/devhub/includes/addon_details.html:15
+#: src/olympia/devhub/templates/devhub/index.html:86 src/olympia/devhub/templates/devhub/addons/listing/items.html:25 src/olympia/devhub/templates/devhub/includes/addon_details.html:20
 #: src/olympia/devhub/templates/devhub/personas/edit.html:43
 msgid "Status:"
 msgstr "Status:"
 
-#: src/olympia/devhub/templates/devhub/index.html:90 src/olympia/devhub/templates/devhub/includes/addon_details.html:100
+#: src/olympia/devhub/templates/devhub/index.html:90 src/olympia/devhub/templates/devhub/includes/addon_details.html:87
 msgid "Visibility:"
 msgstr "Widoczność:"
 
@@ -4168,11 +4117,11 @@ msgstr "Widoczność:"
 msgid "Latest Version:"
 msgstr "Najnowsza wersja:"
 
-#: src/olympia/devhub/templates/devhub/index.html:109 src/olympia/devhub/templates/devhub/includes/addon_details.html:145 src/olympia/devhub/templates/devhub/personas/edit.html:49
+#: src/olympia/devhub/templates/devhub/index.html:109 src/olympia/devhub/templates/devhub/includes/addon_details.html:131 src/olympia/devhub/templates/devhub/personas/edit.html:49
 msgid "Queue Position:"
 msgstr "Pozycja w kolejce:"
 
-#: src/olympia/devhub/templates/devhub/index.html:110 src/olympia/devhub/templates/devhub/includes/addon_details.html:146 src/olympia/devhub/templates/devhub/personas/edit.html:50
+#: src/olympia/devhub/templates/devhub/index.html:110 src/olympia/devhub/templates/devhub/includes/addon_details.html:132 src/olympia/devhub/templates/devhub/personas/edit.html:50
 #, python-format
 msgid "%(position)s of %(total)s"
 msgstr "%(position)s z %(total)s"
@@ -4274,16 +4223,6 @@ msgstr "Po przesłaniu dodatku zostanie uruchomiona seria automatycznych testów
 msgid "Do you want your add-on to be distributed on this site?"
 msgstr "Czy chcesz, aby twój dodatek był dystrybuowany na tej witrynie?"
 
-#: src/olympia/devhub/templates/devhub/validate_addon.html:49 src/olympia/devhub/templates/devhub/addons/submit/upload.html:30 src/olympia/devhub/templates/devhub/versions/add_file_modal.html:14
-#: src/olympia/devhub/templates/devhub/versions/add_file_modal.html:53 src/olympia/devhub/templates/devhub/versions/list.html:298
-msgid "Warning:"
-msgstr "Uwaga:"
-
-#: src/olympia/devhub/templates/devhub/validate_addon.html:50 src/olympia/devhub/templates/devhub/addons/submit/upload.html:31
-#, python-format
-msgid "Submission of unlisted add-ons for signing is currently in an open beta. Please <a href=\"%(url)s\" target=\"_blank\">report any bugs</a> that you encounter."
-msgstr ""
-
 #. first parameter is a filename like lorem-ipsum-1.0.2.xpi
 #: src/olympia/devhub/templates/devhub/validation.html:5
 msgid "Validation Results for {0}"
@@ -4362,7 +4301,7 @@ msgstr "Kompatybilność"
 msgid "Update Compatibility"
 msgstr "Aktualizuj"
 
-#: src/olympia/devhub/templates/devhub/addons/ajax_compat_update.html:4
+#: src/olympia/devhub/templates/devhub/addons/ajax_compat_update.html:4 src/olympia/devhub/templates/devhub/versions/edit.html:45
 msgid "Adjusting application information here will allow users to install your add-on even if the install manifest in the package indicates that the add-on is incompatible."
 msgstr "Podanie tutaj informacji dotyczących modyfikacji aplikacji umożliwi użytkownikom zainstalowanie dodatku, nawet jeśli dane zawarte w pliku install.rdf wskazują, że dodatek jest niekompatybilny."
 
@@ -4374,9 +4313,9 @@ msgstr "Obsługiwane wersje"
 msgid "Add Another Application&hellip;"
 msgstr "Dodaj następny program&hellip;"
 
-#: src/olympia/devhub/templates/devhub/addons/ajax_compat_update.html:38 src/olympia/devhub/templates/devhub/addons/owner.html:86 src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:46
-#: src/olympia/devhub/templates/devhub/versions/list.html:351 src/olympia/devhub/templates/devhub/versions/list.html:353 src/olympia/templates/impala/base.html:132
-#: src/olympia/templates/impala/base.html:143 src/olympia/templates/impala/base.html:161 src/olympia/templates/impala/base.html:171
+#: src/olympia/devhub/templates/devhub/addons/ajax_compat_update.html:38 src/olympia/devhub/templates/devhub/addons/owner.html:86 src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:45
+#: src/olympia/devhub/templates/devhub/versions/list.html:349 src/olympia/devhub/templates/devhub/versions/list.html:351 src/olympia/templates/impala/base.html:129
+#: src/olympia/templates/impala/base.html:140 src/olympia/templates/impala/base.html:158 src/olympia/templates/impala/base.html:168
 msgid "Close"
 msgstr "Zamknij"
 
@@ -4395,7 +4334,6 @@ msgid "<b>{0}</b> theme"
 msgid_plural "<b>{0}</b> themes"
 msgstr[0] "<b>{0}</b> motyw"
 msgstr[1] "<b>{0}</b> motywy"
-msgstr[2] "<b>{0}</b> motywów"
 
 #: src/olympia/devhub/templates/devhub/addons/edit.html:3 src/olympia/devhub/templates/devhub/addons/listing/item_actions.html:25
 #: src/olympia/devhub/templates/devhub/addons/listing/item_actions_theme.html:7 src/olympia/devhub/templates/devhub/includes/addons_edit_nav.html:2
@@ -4411,7 +4349,7 @@ msgstr "Brak"
 msgid "Manage Authors & License"
 msgstr "Zarządzanie autorami i licencją"
 
-#: src/olympia/devhub/templates/devhub/addons/owner.html:29 src/olympia/editors/templates/editors/review.html:270
+#: src/olympia/devhub/templates/devhub/addons/owner.html:29 src/olympia/editors/helpers.py:362 src/olympia/editors/templates/editors/review.html:270
 msgid "Authors"
 msgstr "Autorzy"
 
@@ -4509,7 +4447,6 @@ msgid "Comma-separated, minimum of {0} character."
 msgid_plural "Comma-separated, minimum of {0} characters."
 msgstr[0] "Rozdzielane przecinkami, minimum {0} znak."
 msgstr[1] "Rozdzielane przecinkami, minimum {0} znaki."
-msgstr[2] "Rozdzielane przecinkami, minimum {0} znaków."
 
 #: src/olympia/devhub/templates/devhub/addons/edit/basic.html:132 src/olympia/devhub/templates/devhub/personas/edit.html:100 src/olympia/devhub/templates/devhub/personas/submit.html:49
 msgid "Example: dark, cinema, noir. Limit 20."
@@ -4520,7 +4457,6 @@ msgid "Reserved tag:"
 msgid_plural "Reserved tags:"
 msgstr[0] "Zarezerwowana etykieta:"
 msgstr[1] "Zarezerwowane etykiety:"
-msgstr[2] "Zarezerwowane etykiety:"
 
 #: src/olympia/devhub/templates/devhub/addons/edit/details.html:5
 msgid "Add-on Details"
@@ -4818,16 +4754,14 @@ msgid "Deleting your add-on will permanently remove it from the site and prevent
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:24
-msgid ""
-"Enter the following text confirm your decision:\n"
-"           {slug}"
+msgid "Enter the following text confirm your decision: {slug}"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:34
+#: src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:33
 msgid "Please tell us why you are deleting your theme:"
 msgstr "Napisz nam, dlaczego usuwasz swój motyw:"
 
-#: src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:36
+#: src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:35
 msgid "Please tell us why you are deleting your add-on:"
 msgstr "Napisz nam, dlaczego usuwasz swój dodatek:"
 
@@ -4864,8 +4798,8 @@ msgstr "Nowa wersja"
 msgid "Daily statistics on downloads and users."
 msgstr "Dzienne statystyki pobrań i użytkowników."
 
-#: src/olympia/devhub/templates/devhub/addons/listing/item_actions.html:45 src/olympia/stats/templates/stats/stats.html:75 src/olympia/stats/templates/stats/stats.html:79
-#: src/olympia/stats/templates/stats/stats.html:81
+#: src/olympia/devhub/templates/devhub/addons/listing/item_actions.html:45 src/olympia/stats/templates/stats/stats.html:31 src/olympia/stats/templates/stats/stats.html:35
+#: src/olympia/stats/templates/stats/stats.html:37
 msgid "Statistics"
 msgstr "Statystyki"
 
@@ -4926,7 +4860,6 @@ msgid "<strong>{0}</strong> active user"
 msgid_plural "<strong>{0}</strong> active users"
 msgstr[0] "<strong>{0}</strong> aktywny użytkownik"
 msgstr[1] "<strong>{0}</strong> aktywnych użytkowników"
-msgstr[2] "<strong>{0}</strong> aktywnych użytkowników"
 
 #: src/olympia/devhub/templates/devhub/addons/submit/base.html:11
 msgid "Submit Add-on"
@@ -5195,11 +5128,11 @@ msgstr "Krok 2. Prześlij dodatek"
 msgid "Use the fields below to upload your add-on package and select any platform restrictions. After upload, a series of automated validation tests will be run on your file."
 msgstr "Użyj poniższego formularza, by przesłać spakowany plik dodatku i określić systemy operacyjne. Po przesłaniu dodatku zostanie uruchomiona seria automatycznych testów sprawdzających."
 
-#: src/olympia/devhub/templates/devhub/addons/submit/upload.html:59 src/olympia/devhub/templates/devhub/versions/add_file_modal.html:39
+#: src/olympia/devhub/templates/devhub/addons/submit/upload.html:51 src/olympia/devhub/templates/devhub/versions/add_file_modal.html:28
 msgid "Which platforms is this file compatible with?"
 msgstr "Z którymi systemami ten plik jest kompatybilny?"
 
-#: src/olympia/devhub/templates/devhub/addons/submit/upload.html:67 src/olympia/devhub/templates/devhub/versions/add_file_modal.html:65
+#: src/olympia/devhub/templates/devhub/addons/submit/upload.html:59 src/olympia/devhub/templates/devhub/versions/add_file_modal.html:45
 msgid "Administrative overrides"
 msgstr "Administracyjne zastąpienia"
 
@@ -5316,8 +5249,8 @@ msgstr "Zagadnienia związane z funkcjonalnością i budową witryny"
 
 #: src/olympia/devhub/templates/devhub/docs/policies-contact.html:44
 msgid ""
-"If you've found a problem with the site, we'd love to fix it. Please <a href=\"https://github.com/mozilla/olympia/issues\">file a bug report</a> in GitHub, including the location of the problem and"
-" how you encountered it."
+"If you've found a problem with the site, we'd love to fix it. Please <a href=\"https://github.com/mozilla/addons/issues/new\">file a bug report</a> in GitHub, including the location of the problem "
+"and how you encountered it."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/docs/policies-maintenance.html:3 src/olympia/devhub/templates/devhub/docs/policies-maintenance.html:7
@@ -6195,60 +6128,55 @@ msgstr "Zasady użytkowania serwisu przez autorów dodatków zamieszczanych na n
 msgid "How to get in touch with us regarding these policies or your add-on."
 msgstr "Jak skontaktować się z nami w sprawach dotyczących tych zasad lub twojego dodatku."
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:6
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:10
 msgid "You have disabled this add-on"
 msgstr "Wyłączono ten dodatek"
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:20
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:24
 msgid "Your add-on's listing is disabled and is not showing anywhere in our gallery or update service."
 msgstr "Wyświetlanie dodatku jest wyłączone i nie pokazuje się on nigdzie w galerii i usłudze aktualizacji."
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:25
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:27
 msgid "Please complete your add-on."
 msgstr "Ukończ swój dodatek."
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:29
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:30
 msgid "You will receive an email when the review is complete."
 msgstr "Otrzymasz e-mail, gdy sprawdzanie zostanie zakończone."
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:34
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:33
 msgid "You will receive an email when the review is complete. Until then, your add-on is not listed in our gallery but can be accessed directly from its details page."
 msgstr "Gdy sprawdzanie zostanie zakończone, otrzymasz odpowiednią wiadomość e-mail. Do tego momentu dodatek nie jest wyświetlany w naszej galerii, ale jest dostępny z poziomu swojej strony."
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:38 src/olympia/devhub/templates/devhub/includes/addon_details.html:48
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:37 src/olympia/devhub/templates/devhub/includes/addon_details.html:45
 msgid "You will receive an email when the review is complete and your add-on is signed."
 msgstr "Otrzymasz e-mail, gdy sprawdzenie będzie zakończone i dodatek zostanie oznaczony."
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:44
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:41
 msgid "You will receive an email when the review is complete. Until then, your add-on is not listed in our gallery but can be accessed directly from its details page."
 msgstr "Gdy sprawdzanie zostanie zakończone, otrzymasz odpowiednią wiadomość e-mail. Do tego momentu dodatek nie jest wyświetlany w naszej galerii, ale jest dostępny z poziomu swojej strony."
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:54
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:49
 msgid "Your add-on is displayed in our gallery and users are receiving automatic updates."
 msgstr "Dodatek jest wyświetlany w naszej galerii i użytkownicy otrzymują jego automatyczne aktualizacje."
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:57
-msgid ""
-"Your add-on has been signed and can be bundled with an\n"
-"                             application installer."
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:52
+msgid "Your add-on has been signed and can be bundled with an application installer."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:63
-msgid ""
-"Your add-on was disabled by a site administrator and is no\n"
-"                             longer shown in our gallery. If you have any questions,\n"
-"                             please email amo-admins@mozilla.org."
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:56
+msgid "Your add-on was disabled by a site administrator and is no longer shown in our gallery. If you have any questions, please email amo-admins@mozilla.org."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:70
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:62
 msgid "Your add-on is displayed in our gallery as experimental and users are receiving automatic updates. Some features are unavailable to your add-on."
 msgstr "Dodatek jest wyświetlany w naszej galerii jako „eksperymentalny” i użytkownicy otrzymują jego automatyczne aktualizacje. Niektóre funkcje są dla tego dodatku niedostępne."
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:74
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:66
 msgid "Your add-on has been signed."
 msgstr "Dodatek został oznaczony."
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:79
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:69
 msgid ""
 "You will receive an email when the full review is complete. Until then, your add-on is displayed in our gallery as experimental and users are receiving automatic updates. Some features are "
 "unavailable to your add-on."
@@ -6256,44 +6184,41 @@ msgstr ""
 "Gdy pełne sprawdzanie zostanie zakończone, otrzymasz odpowiednią wiadomość e-mail. Do tego momentu dodatek jest wyświetlany w naszej galerii jako „eksperymentalny” i użytkownicy otrzymują jego "
 "automatyczne aktualizacje. Niektóre funkcje są dla tego dodatku niedostępne."
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:84
-msgid ""
-"You will receive an email when the full review is\n"
-"                             complete, making you able to bundle your add-on with an\n"
-"                             application installer."
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:74
+msgid "You will receive an email when the full review is complete, making you able to bundle your add-on with an application installer."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:91
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:79
 msgid "All add-ons hosted in our gallery must now be reviewed by an editor. If you wish to continue hosting your add-on, please click to select a review process."
 msgstr "Wszystkie dodatki utrzymywane w naszej galerii muszą zostać teraz sprawdzone przez recenzenta. Jeśli chcesz kontynuować udostępnianie dodatku, kliknij, aby wybrać proces sprawdzenia."
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:113
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:100
 msgid "Current Version:"
 msgstr "Aktualne wersja:"
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:115
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:102
 msgid "This is the version of your add-on that will be installed if someone clicks the Install button on addons.mozilla.org. It is only relevant for listed add-ons."
 msgstr "To jest wersja twojego dodatku, która zostanie zainstalowana, jeśli ktoś kliknie przycisk instalowania na stronie addons.mozilla.org. Dotyczy tylko wyświetlanych dodatków."
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:123
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:110
 msgid "Created:"
 msgstr "Utworzono:"
 
 #. {0} is a date. dennis-ignore: E201
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:125 src/olympia/devhub/templates/devhub/includes/addon_details.html:131
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:112 src/olympia/devhub/templates/devhub/includes/addon_details.html:118
 #, python-format
 msgid "%%b %%e, %%Y"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:136
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:123
 msgid "Next Version:"
 msgstr "Następna wersja:"
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:138
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:125
 msgid "This is the newest uploaded version, however it isn’t live on the site yet."
 msgstr "To jest najnowsza załadowana wersja, jednak nie jest jeszcze dostępna na stronie."
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:144 src/olympia/devhub/templates/devhub/versions/list.html:30
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:130 src/olympia/devhub/templates/devhub/versions/list.html:30
 msgid "Queues are not reviewed strictly in order"
 msgstr "Kolejki nie są sprawdzane dokładnie w kolejności"
 
@@ -6386,16 +6311,14 @@ msgid "Select <b>up to {0}</b> {1} category for this add-on:"
 msgid_plural "Select <b>up to {0}</b> {1} categories for this add-on:"
 msgstr[0] "Dla programu {1} wybierz <b>maksymalnie {0}</b> kategorię tego dodatku."
 msgstr[1] "Dla programu {1} wybierz <b>maksymalnie {0}</b> kategorie tego dodatku."
-msgstr[2] "Dla programu {1} wybierz <b>maksymalnie {0}</b> kategorii tego dodatku."
 
 #: src/olympia/devhub/templates/devhub/includes/policy_form.html:4
 msgid ""
 "Users will be required to accept the following End-User License Agreement (EULA) prior to installing your add-on. The presence of a EULA significantly affects the number of downloads an add-on "
-"receives. Please note that a EULA is not the same as a code license, such as the GPL or MPL.\n"
-"                It is only relevant for listed add-ons."
+"receives. Please note that a EULA is not the same as a code license, such as the GPL or MPL.It is only relevant for listed add-ons."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/policy_form.html:21
+#: src/olympia/devhub/templates/devhub/includes/policy_form.html:24
 msgid "If your add-on transmits any data from the user's computer, a privacy policy is required that explains what data is sent and how it is used. It is only relevant for listed add-ons."
 msgstr ""
 "Jeśli twój dodatek przekazuje jakieś dane z komputera użytkownika, wymagana jest polityka prywatności, wyjaśniająca, jakie dane są przesyłane oraz w jaki sposób są używane. Dotyczy tylko "
@@ -6568,7 +6491,7 @@ msgstr "Wybierz kategorię najlepiej opisującą twój motyw."
 msgid "Add some tags to describe your Theme."
 msgstr "Dodaj etykiety opisujące twój motyw."
 
-#: src/olympia/devhub/templates/devhub/personas/edit.html:106
+#: src/olympia/devhub/templates/devhub/personas/edit.html:106 src/olympia/devhub/templates/devhub/personas/submit.html:54
 msgid "A short explanation of your theme's basic functionality that is displayed in search and browse listings, as well as at the top of your theme's details page."
 msgstr "Krótkie wyjaśnienie podstawowej funkcjonalności twojego motywu, które jest wyświetlane w wyszukiwarce i na listach przeglądania, a także na górze strony ze szczegółami motywu."
 
@@ -6708,10 +6631,6 @@ msgstr "Motywy tła pozwalają łatwo spersonalizować wygląd Firefoksa. Prześ
 msgid "Give your Theme a name."
 msgstr "Podaj nazwę motywu"
 
-#: src/olympia/devhub/templates/devhub/personas/submit.html:54
-msgid "A short explanation of your theme's basic functionality that is displayed in search and browse listings, as well as at the top of your theme's details page."
-msgstr "Krótkie wyjaśnienie podstawowej funkcjonalności twojego motywu, które jest wyświetlane w wyszukiwarce i na listach przeglądania, a także na górze strony ze szczegółami motywu."
-
 #: src/olympia/devhub/templates/devhub/personas/submit.html:198
 #, python-format
 msgid ""
@@ -6786,31 +6705,17 @@ msgstr "Wybierz inny obrazek stopki"
 msgid "Files added to reviewed versions must be reviewed before they will be available for download."
 msgstr "Pliki dodane do sprawdzonych wersji muszą być sprawdzone przed udostępnieniem ich do pobierania."
 
-#: src/olympia/devhub/templates/devhub/versions/add_file_modal.html:15
-#, python-format
-msgid ""
-"Submission of updates to unlisted add-ons for signing is currently in an open beta. Manual review may still be required for a large number of add-ons. Please <a href=\"%(url)s\" "
-"target=\"_blank\">report any bugs</a> that you encounter."
-msgstr ""
-
-#: src/olympia/devhub/templates/devhub/versions/add_file_modal.html:35
+#: src/olympia/devhub/templates/devhub/versions/add_file_modal.html:24
 msgid "Select the target platform for this file."
 msgstr "Wybierz docelowy system operacyjny dla tego pliku."
 
-#: src/olympia/devhub/templates/devhub/versions/add_file_modal.html:46
+#: src/olympia/devhub/templates/devhub/versions/add_file_modal.html:35
 msgid "Which review type would you like to nominate for?"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/add_file_modal.html:51
+#: src/olympia/devhub/templates/devhub/versions/add_file_modal.html:40
 msgid "Only publish this version to my beta channel."
 msgstr "Opublikuj tę wersję tylko na moim kanale beta."
-
-#: src/olympia/devhub/templates/devhub/versions/add_file_modal.html:54
-#, python-format
-msgid ""
-"The behavior of the beta channel has changed to accommodate <a href=\"%(addon_signing_url)s\" target=\"_blank\">mandatory add-on signing</a>. The new process is currently in an open beta, and may "
-"change significantly in the near future. Please <a href=\"%(issues_url)s\" target=\"_blank\">report any bugs</a> that you encounter."
-msgstr ""
 
 #: src/olympia/devhub/templates/devhub/versions/edit.html:5
 msgid "Manage Version {0}"
@@ -6833,10 +6738,6 @@ msgstr "Pliki"
 #: src/olympia/devhub/templates/devhub/versions/edit.html:38
 msgid "Upload Another File"
 msgstr "Prześlij kolejny plik"
-
-#: src/olympia/devhub/templates/devhub/versions/edit.html:45
-msgid "Adjusting application information here will allow users to install your add-on even if the install manifest in the package indicates that the add-on is incompatible."
-msgstr "Podanie tutaj informacji dotyczących modyfikacji aplikacji umożliwi użytkownikom zainstalowanie dodatku, nawet jeśli dane zawarte w pliku install.rdf wskazują, że dodatek jest niekompatybilny."
 
 #: src/olympia/devhub/templates/devhub/versions/edit.html:74
 msgid ""
@@ -6907,7 +6808,6 @@ msgid "{0} file"
 msgid_plural "{0} files"
 msgstr[0] "{0} plik"
 msgstr[1] "{0} pliki"
-msgstr[2] "{0} plików"
 
 #: src/olympia/devhub/templates/devhub/versions/list.html:25
 msgid "0 files"
@@ -6934,7 +6834,7 @@ msgstr "Poproś o pełne sprawdzenie"
 msgid "Request Preliminary Review"
 msgstr "Poproś o wstępne sprawdzenie"
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:80 src/olympia/devhub/templates/devhub/versions/list.html:327 src/olympia/devhub/templates/devhub/versions/list.html:350
+#: src/olympia/devhub/templates/devhub/versions/list.html:80 src/olympia/devhub/templates/devhub/versions/list.html:325 src/olympia/devhub/templates/devhub/versions/list.html:348
 msgid "Cancel Review Request"
 msgstr "Anuluj prośbę o sprawdzenie"
 
@@ -6963,7 +6863,7 @@ msgid "Unlisted:"
 msgstr "Niewyświetlany:"
 
 #: src/olympia/devhub/templates/devhub/versions/list.html:114
-msgid "Not distributed on {0}. Developers will upload new versions for signing and distribute the add-ons on their own. (beta)"
+msgid "Not distributed on {0}. Developers will upload new versions for signing and distribute the add-ons on their own."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/versions/list.html:122
@@ -7026,80 +6926,75 @@ msgid "<strong>Important:</strong> Once a version has been deleted, you may not 
 msgstr "<strong>Ważne:</strong> Po usunięciu wersji nie można przesłać nowej wersji z tym samym numerem wersji."
 
 #: src/olympia/devhub/templates/devhub/versions/list.html:230
-msgid "Deleting a version which has already been reviewed may also cause a significant delay in the review of your next update."
-msgstr "Usunięcie wersji, która jest właśnie sprawdzana, może spowodować znaczące opóźnienie sprawdzenia twojej następnej aktualizacji."
-
-#: src/olympia/devhub/templates/devhub/versions/list.html:233
 msgid "Are you sure you wish to delete this version?"
 msgstr "Czy na pewno chcesz usunąć tę wersję?"
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:238
+#: src/olympia/devhub/templates/devhub/versions/list.html:235
 msgid "Delete Version"
 msgstr "Usuń wersję"
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:240
+#: src/olympia/devhub/templates/devhub/versions/list.html:237
 msgid "Disable Version"
 msgstr "Wyłącz wersję"
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:247
+#: src/olympia/devhub/templates/devhub/versions/list.html:244
 msgid "Add a new Version"
 msgstr "Dodaj nową wersję"
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:249
+#: src/olympia/devhub/templates/devhub/versions/list.html:246
 msgid "Add Version"
 msgstr "Dodaj wersję"
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:256 src/olympia/devhub/templates/devhub/versions/list.html:274
+#: src/olympia/devhub/templates/devhub/versions/list.html:253 src/olympia/devhub/templates/devhub/versions/list.html:279
 msgid "Hide Add-on"
 msgstr "Ukryj dodatek"
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:259
+#: src/olympia/devhub/templates/devhub/versions/list.html:256
 msgid "Hiding your add-on will prevent it from appearing anywhere in our gallery and will stop users from receiving automatic updates."
 msgstr "Ukrycie dodatku zapobiega pojawianiu się go w naszej galerii i zatrzymuje otrzymywanie przez użytkowników automatycznych aktualizacji."
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:265
+#: src/olympia/devhub/templates/devhub/versions/list.html:263
+msgid "The files awaiting review will be disabled and you will need to upload new versions."
+msgstr ""
+
+#: src/olympia/devhub/templates/devhub/versions/list.html:270
 msgid "Are you sure you wish to hide your add-on?"
 msgstr "Czy na pewno chcesz ukryć swój dodatek?"
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:286 src/olympia/devhub/templates/devhub/versions/list.html:315
+#: src/olympia/devhub/templates/devhub/versions/list.html:291 src/olympia/devhub/templates/devhub/versions/list.html:313
 msgid "Unlist Add-on"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:289
+#: src/olympia/devhub/templates/devhub/versions/list.html:294
 #, python-format
 msgid ""
 "Unlisting your add-on will make it (and each of its versions/files) invisible on this website. It won't show up in searches, won't have a public facing page, and won't be updated automatically for "
-"current users.  It is recommended for unlisted add-ons to provide a custom <a href=\"%(update_url)s\" target=\"_blank\">updateURL</a> in their manifest file for automatic updates."
+"current users. It is recommended for unlisted add-ons to provide a custom <a href=\"%(update_url)s\" target=\"_blank\">updateURL</a> in their manifest file for automatic updates."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:299
-#, python-format
-msgid "Switching add-ons to unlisted is currently in an open beta. Please <a href=\"%(url)s\" target=\"_blank\">report any bugs</a> that you encounter."
-msgstr ""
-
-#: src/olympia/devhub/templates/devhub/versions/list.html:305
+#: src/olympia/devhub/templates/devhub/versions/list.html:303
 msgid "Unlisting an add-on is irreversible!"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:305
+#: src/olympia/devhub/templates/devhub/versions/list.html:303
 msgid "An unlisted add-on cannot be switched to be listed."
 msgstr "Niewyświetlany dodatek może zostać zmieniony na wyświetlany."
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:307
+#: src/olympia/devhub/templates/devhub/versions/list.html:305
 msgid "Are you sure you wish to unlist your add-on?"
 msgstr "Czy na pewno chcesz, by dodatek nie był wyświetlany?"
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:330
+#: src/olympia/devhub/templates/devhub/versions/list.html:328
 msgid "Canceling your review request will leave your add-on as preliminarily reviewed."
 msgstr "Anulowanie prośby o sprawdzenie spowoduje pozostawienie dodatku jako wstępnie sprawdzonego."
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:335
+#: src/olympia/devhub/templates/devhub/versions/list.html:333
 msgid "Canceling your review request will mark your add-on incomplete. If you do not complete your add-on after several days by re-requesting review, it will be deleted."
 msgstr ""
 "Anulowanie prośby o sprawdzenie spowoduje oznaczenie dodatku jako niekompletnego. Jeśli zamieszczanie dodatku nie zostanie zakończone w ciągu kilku dni poprzez ponowną prośbę o sprawdzenie – "
 "zostanie usunięty."
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:343
+#: src/olympia/devhub/templates/devhub/versions/list.html:341
 msgid "Are you sure you wish to cancel your review request?"
 msgstr "Czy na pewno chcesz anulować prośbę o sprawdzenie?"
 
@@ -7442,19 +7337,19 @@ msgstr "dodatek, recenzent lub komentarz"
 msgid "Search by add-on name / author email"
 msgstr "Szukaj wg nazwy dodatku/e-maila autora"
 
-#: src/olympia/editors/forms.py:103
+#: src/olympia/editors/forms.py:103 src/olympia/editors/forms.py:244 src/olympia/editors/forms.py:257
 msgid "yes"
 msgstr "tak"
 
-#: src/olympia/editors/forms.py:104
+#: src/olympia/editors/forms.py:104 src/olympia/editors/forms.py:244 src/olympia/editors/forms.py:257
 msgid "no"
 msgstr "nie"
 
-#: src/olympia/editors/forms.py:105
+#: src/olympia/editors/forms.py:105 src/olympia/editors/forms.py:245
 msgid "Admin Flag"
 msgstr "Oznaczenie admina"
 
-#: src/olympia/editors/forms.py:113
+#: src/olympia/editors/forms.py:113 src/olympia/editors/forms.py:253
 msgid "Max. Version"
 msgstr "Maks. wersja"
 
@@ -7466,55 +7361,59 @@ msgstr "Dni od przesłania"
 msgid "Add-on Types"
 msgstr "Typy dodatku"
 
-#: src/olympia/editors/forms.py:126 src/olympia/editors/helpers.py:267
+#: src/olympia/editors/forms.py:126 src/olympia/editors/helpers.py:279
 msgid "Platforms"
 msgstr "Systemy"
 
+#: src/olympia/editors/forms.py:237
+msgid "Search by add-on name / author email / guid"
+msgstr ""
+
 #. L10n: 0 = platform, 1 = filename, 2 = status message
-#: src/olympia/editors/forms.py:238
+#: src/olympia/editors/forms.py:342
 #, python-format
 msgid "<strong>%s</strong> &middot; %s &middot; %s"
 msgstr "<strong>%s</strong> &middot; %s &middot; %s"
 
-#: src/olympia/editors/forms.py:252
+#: src/olympia/editors/forms.py:356
 msgid "Comments:"
 msgstr "Komentarze:"
 
-#: src/olympia/editors/forms.py:256
+#: src/olympia/editors/forms.py:360
 msgid "Operating systems:"
 msgstr "Systemy operacyjne:"
 
-#: src/olympia/editors/forms.py:258
+#: src/olympia/editors/forms.py:362
 msgid "Applications:"
 msgstr "Programy:"
 
-#: src/olympia/editors/forms.py:260
+#: src/olympia/editors/forms.py:364
 msgid "Notify me the next time this add-on is updated. (Subsequent updates will not generate an email)"
 msgstr "Powiadom mnie, gdy ten dodatek zostanie zaktualizowany. (Kolejne aktualizacje nie będą generowały powiadomień."
 
-#: src/olympia/editors/forms.py:265
+#: src/olympia/editors/forms.py:369
 msgid "Clear Admin Review Flag"
 msgstr "Usuń oznaczenie „Do sprawdzenia przez administratora”"
 
-#: src/olympia/editors/forms.py:267
+#: src/olympia/editors/forms.py:371
 msgid "Clear more info requested flag"
 msgstr ""
 
-#: src/olympia/editors/forms.py:281
+#: src/olympia/editors/forms.py:385
 msgid "Choose a canned response..."
 msgstr "Wybierz gotową odpowiedź…"
 
 #. L10n: Description of what can be searched for.
-#: src/olympia/editors/forms.py:324
+#: src/olympia/editors/forms.py:423
 msgid "theme name"
 msgstr "nazwa motywu"
 
-#: src/olympia/editors/forms.py:350
+#: src/olympia/editors/forms.py:449
 msgid "Someone else is reviewing this theme."
 msgstr "Ktoś jeszcze sprawdza ten motyw."
 
 #. L10n: Description of what can be searched for.
-#: src/olympia/editors/forms.py:447
+#: src/olympia/editors/forms.py:546
 msgid "app, reviewer, or comment"
 msgstr "aplikacja, recenzent lub komentarz"
 
@@ -7530,203 +7429,210 @@ msgstr "Oczekujące na wstępne sprawdzenie"
 msgid "Rejected or Unreviewed"
 msgstr "Odrzucone lub niesprawdzone"
 
-#: src/olympia/editors/helpers.py:123 src/olympia/editors/helpers.py:136
+#: src/olympia/editors/helpers.py:125 src/olympia/editors/helpers.py:138
 msgid "Queue"
 msgstr "Kolejka"
 
-#: src/olympia/editors/helpers.py:124 src/olympia/editors/templates/editors/base.html:50 src/olympia/editors/templates/editors/base.html:65
+#: src/olympia/editors/helpers.py:126 src/olympia/editors/templates/editors/base.html:50 src/olympia/editors/templates/editors/base.html:65
 msgid "Pending Updates"
 msgstr "Aktualizacje"
 
-#: src/olympia/editors/helpers.py:125 src/olympia/editors/templates/editors/base.html:48 src/olympia/editors/templates/editors/base.html:63
+#: src/olympia/editors/helpers.py:127 src/olympia/editors/templates/editors/base.html:48 src/olympia/editors/templates/editors/base.html:63
 msgid "Full Reviews"
 msgstr "Pełne sprawdzenie"
 
-#: src/olympia/editors/helpers.py:126 src/olympia/editors/templates/editors/base.html:52 src/olympia/editors/templates/editors/base.html:67
+#: src/olympia/editors/helpers.py:128 src/olympia/editors/templates/editors/base.html:52 src/olympia/editors/templates/editors/base.html:67
 msgid "Preliminary Reviews"
 msgstr "Wstępne sprawdzenie"
 
-#: src/olympia/editors/helpers.py:127 src/olympia/editors/templates/editors/base.html:54
+#: src/olympia/editors/helpers.py:129 src/olympia/editors/templates/editors/base.html:54
 msgid "Moderated Reviews"
 msgstr "Opinie do moderacji"
 
-#: src/olympia/editors/helpers.py:128 src/olympia/editors/templates/editors/base.html:46
+#: src/olympia/editors/helpers.py:130 src/olympia/editors/templates/editors/base.html:46
 msgid "Fast Track"
 msgstr "Szybka ścieżka"
 
-#: src/olympia/editors/helpers.py:130
+#: src/olympia/editors/helpers.py:132
 msgid "Pending Themes"
 msgstr "Oczekujące motywy"
 
-#: src/olympia/editors/helpers.py:131 src/olympia/editors/templates/editors/themes/queue.html:4
+#: src/olympia/editors/helpers.py:133 src/olympia/editors/templates/editors/themes/queue.html:4
 msgid "Flagged Themes"
 msgstr "Oznaczone motywy"
 
-#: src/olympia/editors/helpers.py:132
+#: src/olympia/editors/helpers.py:134
 msgid "Update Themes"
 msgstr "Zaktualizowane motywy"
 
-#: src/olympia/editors/helpers.py:137
+#: src/olympia/editors/helpers.py:139
 msgid "Unlisted Pending Updates"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:138
+#: src/olympia/editors/helpers.py:140
 msgid "Unlisted Full Reviews"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:139
+#: src/olympia/editors/helpers.py:141
 msgid "Unlisted Preliminary Reviews"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:170
+#: src/olympia/editors/helpers.py:142
+msgid "Unlisted All Add-ons"
+msgstr ""
+
+#: src/olympia/editors/helpers.py:173
 msgid "Fast Track ({0})"
 msgid_plural "Fast Track ({0})"
 msgstr[0] "Szybka ścieżka ({0})"
 msgstr[1] "Szybka ścieżka ({0})"
-msgstr[2] "Szybka ścieżka ({0})"
 
-#: src/olympia/editors/helpers.py:175
+#: src/olympia/editors/helpers.py:178
 msgid "Full Review ({0})"
 msgid_plural "Full Reviews ({0})"
 msgstr[0] "Pełne sprawdzenie ({0})"
 msgstr[1] "Pełne sprawdzenie ({0})"
-msgstr[2] "Pełne sprawdzenie ({0})"
 
-#: src/olympia/editors/helpers.py:180
+#: src/olympia/editors/helpers.py:183
 msgid "Pending Update ({0})"
 msgid_plural "Pending Updates ({0})"
 msgstr[0] "Aktualizacje ({0})"
 msgstr[1] "Aktualizacje ({0})"
-msgstr[2] "Aktualizacje ({0})"
 
-#: src/olympia/editors/helpers.py:185
+#: src/olympia/editors/helpers.py:188
 msgid "Preliminary Review ({0})"
 msgid_plural "Preliminary Reviews ({0})"
 msgstr[0] "Wstępne sprawdzenie ({0})"
 msgstr[1] "Wstępne sprawdzenie ({0})"
-msgstr[2] "Wstępne sprawdzenie ({0})"
 
-#: src/olympia/editors/helpers.py:190
+#: src/olympia/editors/helpers.py:193
 msgid "Moderated Review ({0})"
 msgid_plural "Moderated Reviews ({0})"
 msgstr[0] "Opinie do moderacji ({0})"
 msgstr[1] "Opinie do moderacji ({0})"
-msgstr[2] "Opinie do moderacji ({0})"
 
-#: src/olympia/editors/helpers.py:196
+#: src/olympia/editors/helpers.py:199
 msgid "Unlisted Full Review ({0})"
 msgid_plural "Unlisted Full Reviews ({0})"
 msgstr[0] ""
 msgstr[1] ""
-msgstr[2] ""
 
-#: src/olympia/editors/helpers.py:201
+#: src/olympia/editors/helpers.py:204
 msgid "Unlisted Pending Update ({0})"
 msgid_plural "Unlisted Pending Updates ({0})"
 msgstr[0] ""
 msgstr[1] ""
-msgstr[2] ""
 
-#: src/olympia/editors/helpers.py:206
+#: src/olympia/editors/helpers.py:209
 msgid "Unlisted Preliminary Review ({0})"
 msgid_plural "Unlisted Preliminary Reviews ({0})"
 msgstr[0] ""
 msgstr[1] ""
-msgstr[2] ""
 
-#: src/olympia/editors/helpers.py:261
-msgid "Addon"
-msgstr "Dodatek"
+#: src/olympia/editors/helpers.py:214
+msgid "Unlisted All Add-ons ({0})"
+msgid_plural "Unlisted All Add-ons ({0})"
+msgstr[0] ""
+msgstr[1] ""
 
-#: src/olympia/editors/helpers.py:262
+#: src/olympia/editors/helpers.py:274
 msgid "Type"
 msgstr "Typ"
 
-#: src/olympia/editors/helpers.py:263
+#: src/olympia/editors/helpers.py:275
 msgid "Waiting Time"
 msgstr "Czas oczekiwania"
 
-#: src/olympia/editors/helpers.py:264 src/olympia/editors/templates/editors/review.html:285
+#: src/olympia/editors/helpers.py:276 src/olympia/editors/templates/editors/review.html:285
 msgid "Flags"
 msgstr "Flagi"
 
-#: src/olympia/editors/helpers.py:265
+#: src/olympia/editors/helpers.py:277
 msgid "Applications"
 msgstr "Programy"
 
-#: src/olympia/editors/helpers.py:270
+#: src/olympia/editors/helpers.py:282
 msgid "Additional"
 msgstr "Dodatkowe informacje"
 
-#: src/olympia/editors/helpers.py:285
+#: src/olympia/editors/helpers.py:302
 msgid "Site Specific"
 msgstr "Dedykowany danej witrynie"
 
-#: src/olympia/editors/helpers.py:287
+#: src/olympia/editors/helpers.py:304
 msgid "Requires External Software"
 msgstr "Wymaga zewnętrznego oprogramowania"
 
-#: src/olympia/editors/helpers.py:289
+#: src/olympia/editors/helpers.py:306
 msgid "Binary Components"
 msgstr "Komponenty binarne"
 
-#: src/olympia/editors/helpers.py:313
+#: src/olympia/editors/helpers.py:339
 msgid "moments ago"
 msgstr "chwilę temu"
 
 #. L10n: first argument is number of minutes
-#: src/olympia/editors/helpers.py:316
+#: src/olympia/editors/helpers.py:342
 msgid "{0} minute"
 msgid_plural "{0} minutes"
 msgstr[0] "{0} minuta"
 msgstr[1] "{0} minuty"
-msgstr[2] "{0} minut"
 
 #. L10n: first argument is number of hours
-#: src/olympia/editors/helpers.py:320
+#: src/olympia/editors/helpers.py:346
 msgid "{0} hour"
 msgid_plural "{0} hours"
 msgstr[0] "{0} godzina"
 msgstr[1] "{0} godziny"
-msgstr[2] "{0} godzin"
 
 #. L10n: first argument is number of days
-#: src/olympia/editors/helpers.py:324
+#: src/olympia/editors/helpers.py:350
 msgid "{0} day"
 msgid_plural "{0} days"
 msgstr[0] "{0} dzień"
 msgstr[1] "{0} dni"
-msgstr[2] "{0} dni"
 
-#: src/olympia/editors/helpers.py:488
+#: src/olympia/editors/helpers.py:364
+msgid "Last Review"
+msgstr ""
+
+#: src/olympia/editors/helpers.py:366
+msgid "Last Update"
+msgstr ""
+
+#: src/olympia/editors/helpers.py:387
+msgid "No Reviews"
+msgstr ""
+
+#: src/olympia/editors/helpers.py:561
 msgid "Push to public"
 msgstr "Opublikuj"
 
-#: src/olympia/editors/helpers.py:490
+#: src/olympia/editors/helpers.py:563
 msgid "Grant full review"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:505
+#: src/olympia/editors/helpers.py:578
 msgid "Request more information"
 msgstr "Więcej informacji"
 
-#: src/olympia/editors/helpers.py:508
+#: src/olympia/editors/helpers.py:581
 msgid "Request super-review"
 msgstr "Sprawdzenie specjalne"
 
-#: src/olympia/editors/helpers.py:519
+#: src/olympia/editors/helpers.py:592
 msgid "Grant preliminary review"
 msgstr "Akceptuj wstępnie"
 
-#: src/olympia/editors/helpers.py:520
+#: src/olympia/editors/helpers.py:593
 msgid "This will mark the files as preliminarily reviewed."
 msgstr "Oznaczy te pliki jako wstępnie sprawdzone."
 
-#: src/olympia/editors/helpers.py:522
+#: src/olympia/editors/helpers.py:595
 msgid "Use this form to request more information from the author. They will receive an email and be able to answer here. You will be notified by email when they reply."
 msgstr "Aby poprosić o więcej informacji od autora, skorzystaj z tego formularza. Autor otrzyma wiadomość i odpowie ci, używając formularza. Powiadomienie o odpowiedzi zostanie wysłane e-mailem."
 
-#: src/olympia/editors/helpers.py:526
+#: src/olympia/editors/helpers.py:599
 msgid ""
 "If you have concerns about this add-on's security, copyright issues, or other concerns that an administrator should look into, enter your comments in the area below. They will be sent to "
 "administrators, not the author."
@@ -7734,55 +7640,55 @@ msgstr ""
 "Jeśli masz obawy dotyczące bezpieczeństwa dodatku, praw autorskich lub innych spraw, którymi powinni się zająć administratorzy, wprowadź swój komentarz w poniższym formularzu. Zostanie on wysłany "
 "do administratorów, a nie do autorów."
 
-#: src/olympia/editors/helpers.py:532
+#: src/olympia/editors/helpers.py:605
 msgid "This will reject the add-on and remove it from the review queue."
 msgstr "Dodatek zostanie odrzucony i usunięty z kolejki do sprawdzenia."
 
-#: src/olympia/editors/helpers.py:534
+#: src/olympia/editors/helpers.py:607
 msgid "Make a comment on this version. The author won't be able to see this."
 msgstr "Skomentuj tę wersję. Twój komentarz nie będzie widoczny dla autora."
 
-#: src/olympia/editors/helpers.py:538
+#: src/olympia/editors/helpers.py:611
 msgid "This will reject the files and remove them from the review queue."
 msgstr "Pakiet zostanie odrzucony i usunięty z kolejki do sprawdzenia."
 
-#: src/olympia/editors/helpers.py:542
+#: src/olympia/editors/helpers.py:615
 msgid "This will mark the add-on as preliminarily reviewed. Future versions will undergo preliminary review."
 msgstr "Dodatek zostanie oznaczony jako wstępnie sprawdzony. Kolejne wersje będą poddawane wstępnemu sprawdzeniu."
 
-#: src/olympia/editors/helpers.py:547
+#: src/olympia/editors/helpers.py:620
 msgid "This will mark the files as preliminarily reviewed. Future versions will undergo preliminary review."
 msgstr "Pakiet zostanie oznaczony jako wstępnie sprawdzony. Kolejne wersje będą poddawane wstępnemu sprawdzeniu."
 
-#: src/olympia/editors/helpers.py:552
+#: src/olympia/editors/helpers.py:625
 msgid "Retain preliminary review"
 msgstr "Zachowaj status wstępnego sprawdzenia"
 
-#: src/olympia/editors/helpers.py:553
+#: src/olympia/editors/helpers.py:626
 msgid "This will retain the add-on as preliminarily reviewed. Future versions will undergo preliminary review."
 msgstr "Dodatek otrzyma ponownie status wstępnego sprawdzenia. Kolejne wersje będą poddawane wstępnemu sprawdzeniu."
 
-#: src/olympia/editors/helpers.py:558
+#: src/olympia/editors/helpers.py:631
 msgid "This will approve a sandboxed version of a public add-on to appear on the public side."
 msgstr "Dodatek zostanie zaakceptowany do opublikowania i będzie dostępny dla wszystkich użytkowników."
 
-#: src/olympia/editors/helpers.py:561
+#: src/olympia/editors/helpers.py:634
 msgid "This will reject a version of a public add-on and remove it from the queue."
 msgstr "Dodatek zostanie odrzucony i usunięty z kolejki."
 
-#: src/olympia/editors/helpers.py:564
+#: src/olympia/editors/helpers.py:637
 msgid "This will mark the add-on and its most recent version and files as public. Future versions will go into the sandbox until they are reviewed by an editor."
 msgstr "Najnowsza wersja dodatku zostanie opublikowana. Kolejne wersje będą oczekiwały w piaskownicy na sprawdzenie przez recenzenta."
 
-#: src/olympia/editors/helpers.py:637
+#: src/olympia/editors/helpers.py:714
 msgid "add-on"
 msgstr "dodatek"
 
-#: src/olympia/editors/helpers.py:940 src/olympia/editors/helpers.py:960
+#: src/olympia/editors/helpers.py:1020 src/olympia/editors/helpers.py:1040
 msgid "Flagged"
 msgstr "Oznaczone"
 
-#: src/olympia/editors/helpers.py:944 src/olympia/editors/helpers.py:963
+#: src/olympia/editors/helpers.py:1024 src/olympia/editors/helpers.py:1043
 msgid "Updates"
 msgstr "Aktualizacje"
 
@@ -7834,56 +7740,56 @@ msgstr "Zgłoszenie motywu oznaczono do sprawdzenia"
 msgid "A question about your Theme submission"
 msgstr "Pytanie dotyczące zgłoszenia twojego motywu"
 
-#: src/olympia/editors/views.py:144
+#: src/olympia/editors/views.py:146
 msgid "New Add-ons (Under 5 days)"
 msgstr "W terminie (poniżej 5 dni)"
 
-#: src/olympia/editors/views.py:145
+#: src/olympia/editors/views.py:147
 msgid "Passable (5 to 10 days)"
 msgstr "W terminie (5 do 10 dni)"
 
-#: src/olympia/editors/views.py:146
+#: src/olympia/editors/views.py:148
 msgid "Overdue (Over 10 days)"
 msgstr "Przeterminowane (ponad 10 dni)"
 
-#: src/olympia/editors/views.py:532
+#: src/olympia/editors/views.py:539
 msgid "An unknown error occurred"
 msgstr "Wystąpił nieznany błąd"
 
-#: src/olympia/editors/views.py:587
+#: src/olympia/editors/views.py:592
 msgid "Self-reviews are not allowed."
 msgstr "Sprawdzanie własnych dodatków jest niedozwolone."
 
-#: src/olympia/editors/views.py:609
+#: src/olympia/editors/views.py:613
 msgid "Review successfully processed."
 msgstr "Sprawdzenie zakończone pomyślnie."
 
-#: src/olympia/editors/views.py:807
+#: src/olympia/editors/views.py:812
 msgid "was approved"
 msgstr "zaakceptowany"
 
-#: src/olympia/editors/views.py:808
+#: src/olympia/editors/views.py:813
 msgid "given preliminary review"
 msgstr "wstępnie sprawdzony"
 
-#: src/olympia/editors/views.py:809
+#: src/olympia/editors/views.py:814
 msgid "rejected"
 msgstr "odrzucony"
 
-#: src/olympia/editors/views.py:810
+#: src/olympia/editors/views.py:815
 msgctxt "editors_review_history_nominated_adminreview"
 msgid "escalated"
 msgstr "rozszerzone"
 
-#: src/olympia/editors/views.py:812
+#: src/olympia/editors/views.py:817
 msgid "needs more information"
 msgstr "potrzebuje więcej informacji"
 
-#: src/olympia/editors/views.py:813
+#: src/olympia/editors/views.py:818
 msgid "needs super review"
 msgstr "potrzebuje specjalnego sprawdzenia"
 
-#: src/olympia/editors/views.py:814
+#: src/olympia/editors/views.py:819
 msgid "commented"
 msgstr ""
 
@@ -7892,7 +7798,6 @@ msgid "{0} theme review successfully processed (+{1} points, {2} total)."
 msgid_plural "{0} theme reviews successfully processed (+{1} points, {2} total)."
 msgstr[0] ""
 msgstr[1] ""
-msgstr[2] ""
 
 #: src/olympia/editors/views_themes.py:341
 msgid "Your theme locks have successfully been released. Other reviewers may now review those released themes. You may have to refresh the page to see the changes reflected in the table below."
@@ -7929,28 +7834,28 @@ msgstr "Kolejki"
 msgid "Unlisted Queues"
 msgstr "Kolejka niewyświetlanych"
 
-#: src/olympia/editors/templates/editors/base.html:72 src/olympia/editors/templates/editors/performance.html:6
+#: src/olympia/editors/templates/editors/base.html:74 src/olympia/editors/templates/editors/performance.html:6
 msgid "Performance"
 msgstr "Wydajność"
 
-#: src/olympia/editors/templates/editors/base.html:75 src/olympia/editors/templates/editors/themes/base.html:19 src/olympia/editors/templates/editors/themes/base.html:38
+#: src/olympia/editors/templates/editors/base.html:77 src/olympia/editors/templates/editors/themes/base.html:19 src/olympia/editors/templates/editors/themes/base.html:38
 msgid "Logs"
 msgstr "Dzienniki"
 
-#: src/olympia/editors/templates/editors/base.html:78 src/olympia/editors/templates/editors/reviewlog.html:4 src/olympia/editors/templates/editors/reviewlog.html:27
+#: src/olympia/editors/templates/editors/base.html:80 src/olympia/editors/templates/editors/reviewlog.html:4 src/olympia/editors/templates/editors/reviewlog.html:27
 msgid "Add-on Review Log"
 msgstr "Dziennik sprawdzeń dodatków"
 
-#: src/olympia/editors/templates/editors/base.html:80 src/olympia/editors/templates/editors/eventlog.html:4 src/olympia/editors/templates/editors/eventlog.html:8
+#: src/olympia/editors/templates/editors/base.html:82 src/olympia/editors/templates/editors/eventlog.html:4 src/olympia/editors/templates/editors/eventlog.html:8
 #: src/olympia/editors/templates/editors/eventlog_detail.html:4
 msgid "Moderated Review Log"
 msgstr "Dziennik moderacji opinii"
 
-#: src/olympia/editors/templates/editors/base.html:82 src/olympia/editors/templates/editors/beta_signed_log.html:4 src/olympia/editors/templates/editors/beta_signed_log.html:8
+#: src/olympia/editors/templates/editors/base.html:84 src/olympia/editors/templates/editors/beta_signed_log.html:4 src/olympia/editors/templates/editors/beta_signed_log.html:8
 msgid "Signed Beta Files Log"
 msgstr ""
 
-#: src/olympia/editors/templates/editors/base.html:87 src/olympia/editors/templates/editors/includes/daily-message.html:4
+#: src/olympia/editors/templates/editors/base.html:89 src/olympia/editors/templates/editors/includes/daily-message.html:4
 msgid "Announcement"
 msgstr "Komunikaty"
 
@@ -8010,21 +7915,18 @@ msgid "Full Review ({num})"
 msgid_plural "Full Reviews ({num})"
 msgstr[0] "Pełne sprawdzenie({num})"
 msgstr[1] "Pełne sprawdzenie ({num})"
-msgstr[2] "Pełne sprawdzenie ({num})"
 
 #: src/olympia/editors/templates/editors/home.html:18
 msgid "Pending Update ({num})"
 msgid_plural "Pending Updates ({num})"
 msgstr[0] "Aktualizacje ({num})"
 msgstr[1] "Aktualizacje ({num})"
-msgstr[2] "Aktualizacje ({num})"
 
 #: src/olympia/editors/templates/editors/home.html:25
 msgid "Preliminary Review ({num})"
 msgid_plural "Preliminary Reviews ({num})"
 msgstr[0] "Wstępne sprawdzenie ({num}"
 msgstr[1] "Wstępne sprawdzenie ({num})"
-msgstr[2] "Wstępne sprawdzenie ({num})"
 
 #: src/olympia/editors/templates/editors/home.html:36 src/olympia/editors/templates/editors/home.html:86
 msgid "Current waiting times:"
@@ -8035,7 +7937,6 @@ msgid "{0} add-on"
 msgid_plural "{0} add-ons"
 msgstr[0] "{0} dodatek"
 msgstr[1] "{0} dodatki"
-msgstr[2] "{0} dodatków"
 
 #: src/olympia/editors/templates/editors/home.html:45 src/olympia/editors/templates/editors/home.html:95
 #, python-format
@@ -8047,21 +7948,18 @@ msgid "Unlisted Full Review ({num})"
 msgid_plural "Unlisted Full Reviews ({num})"
 msgstr[0] ""
 msgstr[1] ""
-msgstr[2] ""
 
 #: src/olympia/editors/templates/editors/home.html:68
 msgid "Unlisted Pending Update ({num})"
 msgid_plural "Unlisted Pending Updates ({num})"
 msgstr[0] ""
 msgstr[1] ""
-msgstr[2] ""
 
 #: src/olympia/editors/templates/editors/home.html:75
 msgid "Unlisted Preliminary Review ({num})"
 msgid_plural "Unlisted Preliminary Reviews ({num})"
 msgstr[0] ""
 msgstr[1] ""
-msgstr[2] ""
 
 #: src/olympia/editors/templates/editors/home.html:109 src/olympia/editors/templates/editors/performance.html:37 src/olympia/editors/templates/editors/themes/home.html:54
 msgid "Total Reviews"
@@ -8085,7 +7983,6 @@ msgid "Moderated Review ({num})"
 msgid_plural "Moderated Reviews ({num})"
 msgstr[0] "Opinie do moderacji ({num})"
 msgstr[1] "Opinie do moderacji ({num})"
-msgstr[2] "Opinie do moderacji ({num})"
 
 #: src/olympia/editors/templates/editors/leaderboard.html:3 src/olympia/editors/templates/editors/includes/reviewers_score_bar.html:56
 msgid "Reviewer Leaderboard"
@@ -8179,45 +8076,45 @@ msgstr "Szukanie zaawansowane"
 msgid "clear search"
 msgstr "wyczyść"
 
-#: src/olympia/editors/templates/editors/queue.html:72 src/olympia/editors/templates/editors/queue.html:122
+#: src/olympia/editors/templates/editors/queue.html:78 src/olympia/editors/templates/editors/queue.html:128
 msgid "Process Reviews"
 msgstr "Przetwórz sprawdzenia"
 
-#: src/olympia/editors/templates/editors/queue.html:80
+#: src/olympia/editors/templates/editors/queue.html:86
 msgid "Moderation actions:"
 msgstr "Czynności moderacyjne:"
 
-#: src/olympia/editors/templates/editors/queue.html:90
+#: src/olympia/editors/templates/editors/queue.html:96
 #, python-format
 msgid "by %(user)s on %(date)s %(stars)s (%(locale)s)"
 msgstr "autor: %(user)s dnia %(date)s %(stars)s (%(locale)s)"
 
-#: src/olympia/editors/templates/editors/queue.html:106
+#: src/olympia/editors/templates/editors/queue.html:112
 #, python-format
 msgid "<strong>%(reason)s</strong> <span class=\"light\">Flagged by %(user)s on %(date)s</span>"
 msgstr "<strong>%(reason)s</strong> <span class=\"light\">Oznaczony przez %(user)s dnia %(date)s</span>"
 
-#: src/olympia/editors/templates/editors/queue.html:119
+#: src/olympia/editors/templates/editors/queue.html:125
 msgid "All reviews have been moderated. Good work!"
 msgstr "Wszystkie sprawdzenia zostały zmoderowane. Dobra robota!"
 
-#: src/olympia/editors/templates/editors/queue.html:161
+#: src/olympia/editors/templates/editors/queue.html:167
 msgid "Version Notes / Notes for Reviewer"
 msgstr "Informacje o wersji / Informacje dla recenzentów"
 
-#: src/olympia/editors/templates/editors/queue.html:169
+#: src/olympia/editors/templates/editors/queue.html:175
 msgid "There are currently no add-ons of this type to review."
 msgstr "Tego typu dodatków nie ma obecnie do sprawdzenia."
 
-#: src/olympia/editors/templates/editors/queue.html:181 src/olympia/editors/templates/editors/themes/queue_list.html:85
+#: src/olympia/editors/templates/editors/queue.html:187 src/olympia/editors/templates/editors/themes/queue_list.html:85
 msgid "Helpful Links:"
 msgstr "Pomocne odnośniki:"
 
-#: src/olympia/editors/templates/editors/queue.html:182
+#: src/olympia/editors/templates/editors/queue.html:188
 msgid "Add-on Policy"
 msgstr "Zasady dodatków"
 
-#: src/olympia/editors/templates/editors/queue.html:184
+#: src/olympia/editors/templates/editors/queue.html:190
 msgid "Editors' Guide"
 msgstr "Wytyczne dla recenzentów"
 
@@ -8423,21 +8320,18 @@ msgid "{num} Pending Theme Review"
 msgid_plural "{num} Pending Theme Reviews"
 msgstr[0] "{num} motyw w trakcie sprawdzania"
 msgstr[1] "{num} motywy w trakcie sprawdzania"
-msgstr[2] "{num} motywów w trakcie sprawdzania"
 
 #: src/olympia/editors/templates/editors/themes/home.html:27
 msgid "{num} Flagged Review"
 msgid_plural "{num} Flagged Reviews"
 msgstr[0] "{num} oflagowana opinia"
 msgstr[1] "{num} oflagowane opinie"
-msgstr[2] "{num} oflagowanych opinii"
 
 #: src/olympia/editors/templates/editors/themes/home.html:34
 msgid "{num} Update"
 msgid_plural "{num} Updates"
 msgstr[0] "{num} aktualizacja"
 msgstr[1] "{num} aktualizacje"
-msgstr[2] "{num} aktualizacji"
 
 #: src/olympia/editors/templates/editors/themes/logs.html:4
 msgid "Theme Review Log"
@@ -8556,7 +8450,7 @@ msgstr "Zadaj pytanie autorowi"
 msgid "Describe your reason for flagging"
 msgstr "Opisz twój powód oznaczenia."
 
-#: src/olympia/files/forms.py:88
+#: src/olympia/files/forms.py:90
 msgid "Cannot diff a version against itself"
 msgstr "Nie można porównać wersji samej z sobą"
 
@@ -8591,51 +8485,51 @@ msgstr "Wystąpił błąd w dostępie do pliku %s. %s."
 msgid "There was an error accessing file %s."
 msgstr "Wystąpił błąd w dostępie do pliku %s."
 
-#: src/olympia/files/utils.py:343
+#: src/olympia/files/utils.py:340
 msgid "Could not parse uploaded file."
 msgstr "Nie można przetworzyć przesłanego pliku."
 
-#: src/olympia/files/utils.py:380
+#: src/olympia/files/utils.py:377
 msgid "Invalid file name in archive: {0}"
 msgstr "Nieprawidłowa nazwa pliku w archiwum: {0}"
 
-#: src/olympia/files/utils.py:388
+#: src/olympia/files/utils.py:385
 msgid "File exceeding size limit in archive: {0}"
 msgstr "Plik przekracza limit rozmiaru w archiwum: {0}"
 
-#: src/olympia/files/utils.py:439
+#: src/olympia/files/utils.py:436
 msgid "Invalid archive."
 msgstr "Niewłaściwe archiwum."
 
-#: src/olympia/files/utils.py:529 src/olympia/files/utils.py:532
+#: src/olympia/files/utils.py:526 src/olympia/files/utils.py:529
 msgid "Could not parse the manifest file."
 msgstr ""
 
-#: src/olympia/files/utils.py:551
+#: src/olympia/files/utils.py:548
 msgid "Could not find an add-on ID."
 msgstr "Nie można znaleźć ID dodatku."
 
-#: src/olympia/files/utils.py:554
+#: src/olympia/files/utils.py:551
 msgid "Add-on ID must be 64 characters or less."
 msgstr "ID dodatku musi zawierać 64 znaki lub mniej."
 
-#: src/olympia/files/utils.py:556
+#: src/olympia/files/utils.py:553
 msgid "Add-on ID doesn't match add-on."
 msgstr "ID dodatku nie pasuje do dodatku."
 
-#: src/olympia/files/utils.py:564
+#: src/olympia/files/utils.py:561
 msgid "Duplicate add-on ID found."
 msgstr "Znaleziono zduplikowane ID dodatku."
 
-#: src/olympia/files/utils.py:567
+#: src/olympia/files/utils.py:564
 msgid "Version numbers should have fewer than 32 characters."
 msgstr "Numer wersji powinien zawierać mniej niż 32 znaki."
 
-#: src/olympia/files/utils.py:570
+#: src/olympia/files/utils.py:567
 msgid "Version numbers should only contain letters, numbers, and these punctuation characters: +*.-_."
 msgstr "Numer wersji powinien zawierać tylko litery, cyfry i następujące znaki interpunkcyjne: +*.-_."
 
-#: src/olympia/files/utils.py:587
+#: src/olympia/files/utils.py:584
 msgid "<em:type> doesn't match add-on"
 msgstr "Typ <em:type> nie pasuje do dodatku"
 
@@ -8735,6 +8629,10 @@ msgstr "Brak plików w przesyłanym pliku."
 #: src/olympia/files/templates/files/viewer.html:134
 msgid "Fetching file."
 msgstr "Pobieranie pliku."
+
+#: src/olympia/legacy_api/views.py:255
+msgid "Not implemented yet."
+msgstr "Jeszcze niezaimplementowane."
 
 #: src/olympia/lib/constants.py:6
 msgid "United Arab Emirates Dirham"
@@ -9390,10 +9288,6 @@ msgstr ""
 
 #: src/olympia/lib/constants.py:169
 msgid "Zimbabwe Dollar"
-msgstr ""
-
-#: src/olympia/lib/video/ffmpeg.py:112 src/olympia/lib/video/totem.py:81
-msgid "Videos must be in WebM."
 msgstr ""
 
 #: src/olympia/pages/templates/pages/about.lhtml:3 src/olympia/pages/templates/pages/about.lhtml:10
@@ -10429,7 +10323,7 @@ msgstr "Galeria dodatków"
 msgid "How do I choose between add-ons that seem to do the same thing?"
 msgstr "Jak dokonać wyboru spośród dodatków, których działanie wydaje się takie same?"
 
-#: src/olympia/pages/templates/pages/faq.html:173
+#: src/olympia/pages/templates/pages/faq.html:172
 msgid ""
 "There are often several add-ons that have similar features. To figure out which is right for you, read the entire description of the add-on and view its screenshots. If there are still several in "
 "the running, read through the add-on's ratings, user reviews, and statistics to see which is most liked by other users. Remember that you can also just try out both and see which you like better."
@@ -10483,11 +10377,11 @@ msgstr "Ile kosztują dodatki?"
 msgid "Add-ons hosted in our gallery are free unless clearly marked otherwise."
 msgstr "Dodatki znajdujące się w naszej galerii są darmowe, chyba że wyraźnie zaznaczono inaczej."
 
-#: src/olympia/pages/templates/pages/faq.html:210
+#: src/olympia/pages/templates/pages/faq.html:209
 msgid "What does it mean when an add-on asks for contributions?"
 msgstr "Co oznacza prośba o dotację? "
 
-#: src/olympia/pages/templates/pages/faq.html:211
+#: src/olympia/pages/templates/pages/faq.html:210
 msgid ""
 "Some add-on authors request users who enjoy an add-on to contribute to its development by making a monetary contribution. These contributions go directly to the developer unless a third party is "
 "indicated, such as the non-profit Mozilla Foundation."
@@ -10495,11 +10389,11 @@ msgstr ""
 "Niektórzy autorzy proszą użytkowników korzystających z ich dodatków o wsparcie finansowe dalszego rozwoju tych dodatków. Dotacje te są bezpośrednio przekazywane do autora, chyba że wskazał on inny "
 "podmiot w postaci organizacji pożytku publicznego, np. Fundację Mozilla."
 
-#: src/olympia/pages/templates/pages/faq.html:216
+#: src/olympia/pages/templates/pages/faq.html:215
 msgid "What are beta add-ons?"
 msgstr "Co to są dodatki „beta”?"
 
-#: src/olympia/pages/templates/pages/faq.html:218
+#: src/olympia/pages/templates/pages/faq.html:217
 msgid ""
 "Beta add-ons are unreviewed versions which represent the latest work of an add-on author. While different authors have different standards for beta code quality, you should assume that these add-"
 "ons are less stable than the general add-on releases."
@@ -10507,7 +10401,7 @@ msgstr ""
 "Dodatki „beta” są niesprawdzonymi przez recenzentów wersjami rozwojowymi danego dodatku. Autorzy dodatków przyjmują różne standardy dla jakości kodu wersji „beta”. Należy przyjąć, że stabilność "
 "dodatków tego typu jest mniejsza niż wydań głównych."
 
-#: src/olympia/pages/templates/pages/faq.html:222
+#: src/olympia/pages/templates/pages/faq.html:221
 msgid ""
 "Please note that when you install an add-on from the \"Beta Version\" section of an add-on's listing, you will continue to receive updates for that add-on as they become available. Like the initial"
 " version you installed, all beta releases are unreviewed by Mozilla and may harm your computer."
@@ -10515,22 +10409,19 @@ msgstr ""
 "Po zainstalowaniu dodatku z sekcji „Wersje beta” będziesz otrzymywać aktualizacje tego dodatku, gdy będą one dostępne. Tak jak wersja początkowa, wszystkie wersje „beta” nie są sprawdzane przez "
 "Mozillę i mogą uszkodzić twój komputer."
 
-#: src/olympia/pages/templates/pages/faq.html:229
+#: src/olympia/pages/templates/pages/faq.html:228
 msgid "What does it mean when an add-on is flagged as slow?"
 msgstr "Co to znaczy, gdy dodatek jest oznaczony jako spowalniający?"
 
-#: src/olympia/pages/templates/pages/faq.html:231
-msgid ""
-"Most add-ons load code and resources at the same time Firefox\n"
-"        is starting up. In most cases the impact in start-up time is minimal,\n"
-"        but some add-ons can cause a noticeable slowdown."
+#: src/olympia/pages/templates/pages/faq.html:229
+msgid "Most add-ons load code and resources at the same time Firefox is starting up. In most cases the impact in start-up time is minimal, but some add-ons can cause a noticeable slowdown."
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:236
+#: src/olympia/pages/templates/pages/faq.html:234
 msgid "How do I report an inappropriate or spam user review?"
 msgstr "Jak zgłosić opinię zawierającą spam lub niestosowną treść?"
 
-#: src/olympia/pages/templates/pages/faq.html:237
+#: src/olympia/pages/templates/pages/faq.html:235
 msgid ""
 "To report a user review of an add-on, log in with your account and visit the add-on's reviews page. Find the review you wish to report, click \"Report this review\" and select a reason. Our "
 "editorial team will investigate the review and take appropriate action."
@@ -10538,20 +10429,20 @@ msgstr ""
 "Aby zgłosić opinię o tym dodatku, zaloguj się i przejdź na jego stronę opinii. Znajdź opinię, którą chcesz zgłosić, kliknij odnośnik „Zgłoś tę opinię” i podaj powód. Nasz zespół recenzentów "
 "sprawdzi opinię i podejmie odpowiednie kroki."
 
-#: src/olympia/pages/templates/pages/faq.html:242
+#: src/olympia/pages/templates/pages/faq.html:240
 msgid "How do I report a bug or contact the Mozilla Add-ons team?"
 msgstr "Jak zgłosić błąd lub skontaktować się z zespołem Mozilla Add-ons?"
 
-#: src/olympia/pages/templates/pages/faq.html:243
+#: src/olympia/pages/templates/pages/faq.html:241
 #, python-format
 msgid "Please visit our <a href=\"%(contact_url)s\">Contact page</a>."
 msgstr "Przejdź na naszą <a href=\"%(contact_url)s\">stronę kontaktową</a>."
 
-#: src/olympia/pages/templates/pages/faq.html:246
+#: src/olympia/pages/templates/pages/faq.html:244
 msgid "What is a Source Code License?"
 msgstr "Co to jest licencja kodu źródłowego?"
 
-#: src/olympia/pages/templates/pages/faq.html:247
+#: src/olympia/pages/templates/pages/faq.html:245
 #, python-format
 msgid ""
 "The source code used to create an add-on is an exclusive copyright of the add-on author, unless otherwise declared in a source code license. Many add-ons on this site have <a href=\"%(url)s\" "
@@ -10562,40 +10453,40 @@ msgstr ""
 "licencjach <a href=\"%(url)s\" lang=\"en\">open source</a>, które umożliwiają kopiowanie i używanie kodu źródłowego zgodnie z warunkami określonymi przez autora. Większość autorów zamiast tworzyć "
 "własne, wybiera powszechnie znane licencje open source, takie jak licencje GPL lub BSD."
 
-#: src/olympia/pages/templates/pages/faq.html:256
+#: src/olympia/pages/templates/pages/faq.html:254
 #, python-format
 msgid "Firefox and other Mozilla software are <a href=\"%(url)s\">open source</a>."
 msgstr "Firefox i inne programy Mozilli są oprogramowaniem o <a href=\"%(url)s\">otwartym kodzie źródłowym</a>."
 
-#: src/olympia/pages/templates/pages/faq.html:264
+#: src/olympia/pages/templates/pages/faq.html:262
 msgid "Collections and Favorites"
 msgstr "Kolekcje i ulubione"
 
-#: src/olympia/pages/templates/pages/faq.html:267
+#: src/olympia/pages/templates/pages/faq.html:265
 msgid "What is a collection?"
 msgstr "Co to jest kolekcja?"
 
-#: src/olympia/pages/templates/pages/faq.html:268
+#: src/olympia/pages/templates/pages/faq.html:266
 msgid "Collections are groups of related add-ons created by users to share."
 msgstr "Kolekcje to utworzone przez użytkowników grupy pokrewnych dodatków, aby ułatwić ich udostępnianie."
 
-#: src/olympia/pages/templates/pages/faq.html:270
+#: src/olympia/pages/templates/pages/faq.html:268
 msgid "What is the My Favorites collection?"
 msgstr "Co to jest ulubiona kolekcja?"
 
-#: src/olympia/pages/templates/pages/faq.html:271
+#: src/olympia/pages/templates/pages/faq.html:269
 msgid "Favorite add-ons are add-ons that you have bookmarked to easily get back to later. You can add an add-on to your favorites collection by clicking \"Add to favorites\" on its details page."
 msgstr "Ulubione dodatki to oznaczone dodatki, by można było łatwo do nich powrócić. Możesz dołączyć dodatek do swojej ulubionej kolekcji, klikając na stronie dodatku „Dodaj do ulubionych”."
 
-#: src/olympia/pages/templates/pages/faq.html:275 src/olympia/templates/menu_links.html:13 src/olympia/templates/impala/header_title.html:17
+#: src/olympia/pages/templates/pages/faq.html:273 src/olympia/templates/menu_links.html:13 src/olympia/templates/impala/header_title.html:17
 msgid "Mobile Add-ons"
 msgstr "Dla Mobile"
 
-#: src/olympia/pages/templates/pages/faq.html:278
+#: src/olympia/pages/templates/pages/faq.html:276
 msgid "What are mobile add-ons?"
 msgstr "Co to są dodatki „mobilne”?"
 
-#: src/olympia/pages/templates/pages/faq.html:279
+#: src/olympia/pages/templates/pages/faq.html:277
 #, python-format
 msgid ""
 "Mobile add-ons work with <a href=\"%(mobile_url)s\">Firefox for Mobile</a> and add or modify functionality just like desktop add-ons. You can find add-ons that work with Firefox for Mobile in our "
@@ -10604,20 +10495,20 @@ msgstr ""
 "Dodatki „mobilne” są przeznaczone dla <a href=\"%(mobile_url)s\">Firefoksa Mobile</a> i dodają lub modyfikują funkcje przeglądarki tak samo, jak dodatki dla wersji stacjonarnych. Dodatki dla "
 "Firefoksa dla urządzeń mobilnych można znaleźć w naszej <a href=\"%(gallery_url)s\">galerii</a>."
 
-#: src/olympia/pages/templates/pages/faq.html:288
+#: src/olympia/pages/templates/pages/faq.html:286
 msgid "Developer Topics"
 msgstr "Dla autorów dodatków"
 
-#: src/olympia/pages/templates/pages/faq.html:289
+#: src/olympia/pages/templates/pages/faq.html:287
 #, python-format
 msgid "Please see our <a href=\"%(faq_url)s\">Developer FAQ</a> and <a href=\"%(hub_url)s\">Developer Hub</a> for answers to add-on developer-related questions."
 msgstr "Aby uzyskać odpowiedź na pytania dotyczące tworzenia dodatków, przejdź na stronę <a href=\"%(faq_url)s\">Tworzenie dodatków – FAQ</a> i <a href=\"%(hub_url)s\">Strefa autora</a>."
 
-#: src/olympia/pages/templates/pages/faq.html:294
+#: src/olympia/pages/templates/pages/faq.html:292
 msgid "Still have questions?"
 msgstr "Nadal masz pytania?"
 
-#: src/olympia/pages/templates/pages/faq.html:295
+#: src/olympia/pages/templates/pages/faq.html:293
 #, python-format
 msgid "For general Firefox support, visit our <a href=\"%(sumo_url)s\">support website</a>. For general add-on and website questions, visit our <a href=\"%(forum_url)s\">forum</a>."
 msgstr ""
@@ -10901,7 +10792,6 @@ msgid "This user has a <a href=\"%(user_review_url)s\">previous review</a> of th
 msgid_plural "This user has <a href=\"%(user_review_url)s\">%(cnt)s previous reviews</a> of this add-on."
 msgstr[0] "Ten użytkownik wystawił dla tego dodatku także <a href=\"%(user_review_url)s\">inną opinię</a>."
 msgstr[1] "Ten użytkownik wystawił dla tego dodatku także <a href=\"%(user_review_url)s\">%(cnt)s inne opinie</a>."
-msgstr[2] "Ten użytkownik wystawił dla tego dodatku także <a href=\"%(user_review_url)s\">%(cnt)s innych opinii</a>."
 
 #: src/olympia/reviews/templates/reviews/review.html:62
 #, python-format
@@ -10948,7 +10838,6 @@ msgid "<b>{0}</b> review for this add-on"
 msgid_plural "<b>{0}</b> reviews for this add-on"
 msgstr[0] "<b>{0}</b> opinia o tym dodatku"
 msgstr[1] "<b>{0}</b> opinie o tym dodatku"
-msgstr[2] "<b>{0}</b> opinii o tym dodatku"
 
 #. {0} is a developer's name.
 #: src/olympia/reviews/templates/reviews/review_list.html:33
@@ -10961,7 +10850,6 @@ msgid "Review for %(addon)s by %(user)s"
 msgid_plural "Reviews for %(addon)s by %(user)s"
 msgstr[0] "Opinia o %(addon)s autorstwa %(user)s"
 msgstr[1] "Opinie o %(addon)s autorstwa %(user)s"
-msgstr[2] "Opinie o %(addon)s autorstwa %(user)s"
 
 #: src/olympia/reviews/templates/reviews/review_list.html:42
 msgid "No reviews found."
@@ -10985,7 +10873,6 @@ msgid "{num} review"
 msgid_plural "{num} reviews"
 msgstr[0] "{num} opinia"
 msgstr[1] "{num} opinie"
-msgstr[2] "{num} opinii"
 
 #: src/olympia/reviews/templates/reviews/impala/reviews_rating.html:1
 msgid "Rated {0} out of 5 stars"
@@ -11013,7 +10900,6 @@ msgid "Average from {0} Rating"
 msgid_plural "Average from {0} Ratings"
 msgstr[0] "Średnia z {0} oceny"
 msgstr[1] "Średnia z {0} ocen"
-msgstr[2] "Średnia z {0} ocen"
 
 #: src/olympia/reviews/templates/reviews/mobile/review_list.html:34
 #, python-format
@@ -11030,7 +10916,6 @@ msgid "See All Reviews"
 msgid_plural "See All %(cnt)s Reviews"
 msgstr[0] "Zobacz wszystkie opinie"
 msgstr[1] "Zobacz wszystkie %(cnt)s opinie"
-msgstr[2] "Zobacz wszystkie %(cnt)s opinii"
 
 #: src/olympia/search/forms.py:11
 msgid "Most popular this week"
@@ -11111,16 +10996,16 @@ msgstr "Dodatki dla {0}"
 
 #. L10n: {0} is an application, such as Firefox. This means "any version of
 #. Firefox."
-#: src/olympia/search/views.py:554
+#: src/olympia/search/views.py:547
 msgid "Any {0}"
 msgstr "Każda wersja programu {0}"
 
 #. L10n: "All Systems" means show everything regardless of platform.
-#: src/olympia/search/views.py:589
+#: src/olympia/search/views.py:582
 msgid "All Systems"
 msgstr "Wszystkie systemy"
 
-#: src/olympia/search/views.py:600
+#: src/olympia/search/views.py:593
 msgid "All Tags"
 msgstr "Wszystkie etykiety"
 
@@ -11165,7 +11050,6 @@ msgid "<b>{0}</b> matching result"
 msgid_plural "<b>{0}</b> matching results"
 msgstr[0] "<b>{0}</b> pasujący wynik"
 msgstr[1] "<b>{0}</b> pasujące wyniki"
-msgstr[2] "<b>{0}</b> pasujących wyników"
 
 #: src/olympia/search/templates/search/results.html:67
 msgid "Filter Results"
@@ -11188,7 +11072,6 @@ msgid "{0} post"
 msgid_plural "{0} posts"
 msgstr[0] "{0} post"
 msgstr[1] "{0} posty"
-msgstr[2] "{0} postów"
 
 #: src/olympia/sharing/__init__.py:20
 msgid "Post to Facebook"
@@ -11199,7 +11082,6 @@ msgid "{0} Like"
 msgid_plural "{0} Likes"
 msgstr[0] "{0} polubienie"
 msgstr[1] "{0} polubienia"
-msgstr[2] "{0} polubień"
 
 #: src/olympia/sharing/__init__.py:30
 msgid "Tweet on Twitter"
@@ -11210,7 +11092,6 @@ msgid "{0} tweet"
 msgid_plural "{0} tweets"
 msgstr[0] "{0} tweet"
 msgstr[1] "{0} tweety"
-msgstr[2] "{0} tweetów"
 
 #: src/olympia/sharing/__init__.py:40
 msgid "Share on g+"
@@ -11245,7 +11126,6 @@ msgid "{0} post on localservice1"
 msgid_plural "{0} posts on localservice1"
 msgstr[0] "{0} post na localservice1"
 msgstr[1] "{0} posty na localservice1"
-msgstr[2] "{0} postów na localservice1"
 
 #. L10n: Only change if you have reason! wiki.mozilla.org/AMO:Localizers
 #: src/olympia/sharing/__init__.py:76
@@ -11268,7 +11148,6 @@ msgid "{0} post on localservice2"
 msgid_plural "{0} posts on localservice2"
 msgstr[0] "{0} post na localservice2"
 msgstr[1] "{0} posty na localservice2"
-msgstr[2] "{0} postów na localservice2"
 
 #. L10n: Only change if you have reason! wiki.mozilla.org/AMO:Localizers
 #: src/olympia/sharing/__init__.py:91
@@ -11291,7 +11170,6 @@ msgid "{0} post on localservice3"
 msgid_plural "{0} posts on localservice3"
 msgstr[0] "{0} post na localservice3"
 msgstr[1] "{0} posy na localservice3"
-msgstr[2] "{0} postów na localservice3"
 
 #: src/olympia/sharing/templates/sharing/sharing_widget.html:2
 msgid "Share this Add-on"
@@ -11301,31 +11179,31 @@ msgstr "Udostępnij"
 msgid "Share this Collection"
 msgstr "Udostępnij"
 
-#: src/olympia/signing/views.py:30 src/olympia/templates/base.html:75 src/olympia/templates/impala/base.html:115
+#: src/olympia/signing/views.py:33 src/olympia/templates/base.html:71 src/olympia/templates/impala/base.html:112
 msgid "Some features are temporarily disabled while we perform website maintenance. We'll be back to full capacity shortly."
 msgstr "W trakcie wykonywania serwisu witryny niektóre funkcje są tymczasowo wyłączone. Pełna funkcjonalność zostanie przywrócona wkrótce."
 
-#: src/olympia/signing/views.py:53
+#: src/olympia/signing/views.py:56
 msgid "Could not find add-on with id \"{}\"."
 msgstr ""
 
-#: src/olympia/signing/views.py:67
+#: src/olympia/signing/views.py:70
 msgid "You do not own this addon."
 msgstr ""
 
-#: src/olympia/signing/views.py:82
+#: src/olympia/signing/views.py:87
 msgid "Missing \"upload\" key in multipart file data."
 msgstr ""
 
-#: src/olympia/signing/views.py:96
+#: src/olympia/signing/views.py:101
 msgid "Version does not match the manifest file."
 msgstr ""
 
-#: src/olympia/signing/views.py:100
+#: src/olympia/signing/views.py:105
 msgid "Version already exists."
 msgstr ""
 
-#: src/olympia/signing/views.py:136
+#: src/olympia/signing/views.py:141
 msgid "No uploaded file for that addon and version."
 msgstr ""
 
@@ -11438,90 +11316,90 @@ msgstr "{0} :: Panel statystyk"
 msgid "Statistics Dashboard :: Add-ons for {0}"
 msgstr "Panel statystyk :: Dodatki dla {0}"
 
-#: src/olympia/stats/templates/stats/stats.html:30
-msgid "Controls:"
-msgstr "Sterowanie:"
-
-#: src/olympia/stats/templates/stats/stats.html:33
-msgid "reset zoom"
-msgstr "resetuj przybliżenie"
-
-#: src/olympia/stats/templates/stats/stats.html:40
-msgid "Group by:"
-msgstr "Grupuj wg:"
-
-#: src/olympia/stats/templates/stats/stats.html:42
-msgid "day"
-msgstr "dzień"
-
-#: src/olympia/stats/templates/stats/stats.html:45
-msgid "week"
-msgstr "tydzień"
-
-#: src/olympia/stats/templates/stats/stats.html:48
-msgid "month"
-msgstr "miesiąc"
-
-#: src/olympia/stats/templates/stats/stats.html:54
-msgid "For last:"
-msgstr "W ciągu ostatnich:"
-
-#: src/olympia/stats/templates/stats/stats.html:57
-msgid "7 days"
-msgstr "7 dni"
-
-#: src/olympia/stats/templates/stats/stats.html:60
-msgid "30 days"
-msgstr "30 dni"
-
-#: src/olympia/stats/templates/stats/stats.html:63
-msgid "90 days"
-msgstr "90 dni"
-
-#: src/olympia/stats/templates/stats/stats.html:66
-msgid "365 days"
-msgstr "365 dni"
-
-#: src/olympia/stats/templates/stats/stats.html:69
-msgid "Custom..."
-msgstr "Inny przedział…"
-
 # %1 is the name of a collection
 #. {0} is an add-on name
-#: src/olympia/stats/templates/stats/stats.html:88 src/olympia/stats/templates/stats/stats.html:91
+#: src/olympia/stats/templates/stats/stats.html:44 src/olympia/stats/templates/stats/stats.html:47
 msgid "Statistics for {0}"
 msgstr "Statystyki dla {0}"
 
-#: src/olympia/stats/templates/stats/stats.html:94
+#: src/olympia/stats/templates/stats/stats.html:50
 msgid "Statistics Dashboard"
 msgstr "Panel statystyk"
 
-#: src/olympia/stats/templates/stats/stats.html:104
+#: src/olympia/stats/templates/stats/stats.html:57
+msgid "Controls:"
+msgstr "Sterowanie:"
+
+#: src/olympia/stats/templates/stats/stats.html:60
+msgid "reset zoom"
+msgstr "resetuj przybliżenie"
+
+#: src/olympia/stats/templates/stats/stats.html:67
+msgid "Group by:"
+msgstr "Grupuj wg:"
+
+#: src/olympia/stats/templates/stats/stats.html:69
+msgid "day"
+msgstr "dzień"
+
+#: src/olympia/stats/templates/stats/stats.html:72
+msgid "week"
+msgstr "tydzień"
+
+#: src/olympia/stats/templates/stats/stats.html:75
+msgid "month"
+msgstr "miesiąc"
+
+#: src/olympia/stats/templates/stats/stats.html:81
+msgid "For last:"
+msgstr "W ciągu ostatnich:"
+
+#: src/olympia/stats/templates/stats/stats.html:84
+msgid "7 days"
+msgstr "7 dni"
+
+#: src/olympia/stats/templates/stats/stats.html:87
+msgid "30 days"
+msgstr "30 dni"
+
+#: src/olympia/stats/templates/stats/stats.html:90
+msgid "90 days"
+msgstr "90 dni"
+
+#: src/olympia/stats/templates/stats/stats.html:93
+msgid "365 days"
+msgstr "365 dni"
+
+#: src/olympia/stats/templates/stats/stats.html:96
+msgid "Custom..."
+msgstr "Inny przedział…"
+
+#: src/olympia/stats/templates/stats/stats.html:106
 msgid "Statistics processing is currently disabled, so recent data is unavailable. The statistics are still being collected and this page will be updated soon with the missing data."
 msgstr ""
 
-#: src/olympia/stats/templates/stats/stats.html:110
+#: src/olympia/stats/templates/stats/stats.html:112
 msgid "Loading the latest data&hellip;"
 msgstr "Wczytywanie najnowszych danych&hellip;"
 
-#: src/olympia/stats/templates/stats/stats.html:142 src/olympia/stats/templates/stats/reports/overview.html:25 src/olympia/stats/templates/stats/reports/overview.html:37
+#: src/olympia/stats/templates/stats/stats.html:144 src/olympia/stats/templates/stats/reports/overview.html:25 src/olympia/stats/templates/stats/reports/overview.html:37
 #: src/olympia/stats/templates/stats/reports/overview.html:49
 msgid "No data available."
 msgstr "Brak dostępnych danych."
 
-#: src/olympia/stats/templates/stats/stats.html:177
+#: src/olympia/stats/templates/stats/stats.html:179
 msgid "This dashboard is currently <b>public</b>."
 msgstr "Ten panel jest obecnie <b>upubliczniony</b>."
 
-#: src/olympia/stats/templates/stats/stats.html:179
+#: src/olympia/stats/templates/stats/stats.html:181
 msgid "Contribution stats are currently <b>private</b>."
 msgstr "Statystyki dotacji są obecnie <b>nieupublicznione</b>."
 
-#: src/olympia/stats/templates/stats/stats.html:182
+#: src/olympia/stats/templates/stats/stats.html:184
 msgid "This dashboard is currently <b>private</b>."
 msgstr "Ten panel jest obecnie <b>nieupubliczniony</b>."
 
-#: src/olympia/stats/templates/stats/stats.html:185
+#: src/olympia/stats/templates/stats/stats.html:187
 msgid "Change settings."
 msgstr "Zmień ustawienia."
 
@@ -11685,15 +11563,6 @@ msgstr "Logowania użytkowników wg daty"
 msgid "Application versions by Date"
 msgstr "Wersje programu wg daty"
 
-#: src/olympia/tags/templates/tags/top_cloud.html:4
-msgid "Top {0} Tags"
-msgstr "{0} popularnych etykiet"
-
-#. {0} is the current application name
-#: src/olympia/tags/templates/tags/top_cloud.html:14
-msgid "{0} Top Tags"
-msgstr "{0} – popularne etykiety"
-
 #: src/olympia/templates/amo_footer.html:6 src/olympia/templates/includes/lang_switcher.html:2
 msgid "Other languages"
 msgstr "Inne języki"
@@ -11702,11 +11571,11 @@ msgstr "Inne języki"
 msgid "Mozilla Add-ons"
 msgstr "Mozilla Add-ons"
 
-#: src/olympia/templates/base.html:91 src/olympia/templates/impala/base.html:81
+#: src/olympia/templates/base.html:89 src/olympia/templates/impala/base.html:78
 msgid "Find add-ons for other applications"
 msgstr "Znajdź dodatki dla innych programów"
 
-#: src/olympia/templates/base.html:92 src/olympia/templates/impala/base.html:81
+#: src/olympia/templates/base.html:90 src/olympia/templates/impala/base.html:78
 msgid "Other Applications"
 msgstr "Inne programy"
 
@@ -11731,7 +11600,7 @@ msgid "View Mobile Site"
 msgstr "Przejdź do witryny Mobile"
 
 #: src/olympia/templates/copyright.html:7
-msgid "Site Status "
+msgid "Site Status"
 msgstr ""
 
 #: src/olympia/templates/footer.html:3
@@ -11833,35 +11702,35 @@ msgstr "Witaj, {0}"
 msgid "<a href=\"%(reg)s\">Register</a> or <a href=\"%(login)s\">Log in</a>"
 msgstr "<a href=\"%(reg)s\">Zarejestruj się</a> lub <a href=\"%(login)s\">Zaloguj się</a>"
 
-#: src/olympia/templates/impala/base.html:126
+#: src/olympia/templates/impala/base.html:123
 #, python-format
 msgid "To try the thousands of add-ons available here, download <a href=\"%(url)s\">Mozilla Firefox</a>, a fast, free way to surf the Web!"
 msgstr "Aby wypróbować tysiące dostępnych tu dodatków, pobierz program <a href=\"%(url)s\">Mozilla Firefox</a> – szybki i darmowy sposób przeglądania sieci!"
 
-#: src/olympia/templates/impala/base.html:138
+#: src/olympia/templates/impala/base.html:135
 #, python-format
 msgid "Add-ons is switching to Firefox Accounts for login. <a href=\"%(url)s\" class=\"fxa-login\">Sign in now to transfer your account.</a>"
 msgstr ""
 
 #. {0} is an application, such as Firefox.
-#: src/olympia/templates/impala/base.html:148
+#: src/olympia/templates/impala/base.html:145
 msgid "Welcome to {0} Add-ons."
 msgstr "Witamy na witrynie Dodatki dla programu {0}."
 
-#: src/olympia/templates/impala/base.html:151
+#: src/olympia/templates/impala/base.html:148
 msgid "Choose from thousands of extra features and styles to make Firefox your own."
 msgstr "Wybierz spośród tysięcy dodatkowych funkcji i motywów, by dostosować program Firefox do swoich potrzeb."
 
-#: src/olympia/templates/impala/base.html:156
+#: src/olympia/templates/impala/base.html:153
 #, python-format
 msgid "Add extra features and styles to make %(app)s your own."
 msgstr "Dodaj dodatkowe funkcje i motywy, by dostosować program %(app)s do swoich potrzeb."
 
-#: src/olympia/templates/impala/base.html:164
+#: src/olympia/templates/impala/base.html:161
 msgid "On the go?"
 msgstr "Jesteś w podróży?"
 
-#: src/olympia/templates/impala/base.html:166
+#: src/olympia/templates/impala/base.html:163
 msgid "Check out our <a class=\"mobile-link\" href=\"#\">Mobile Add-ons site</a>."
 msgstr "Sprawdź naszą witrynę <a class=\"mobile-link\" href=\"#\">dodatków dla Firefoksa Mobile</a>."
 
@@ -12085,19 +11954,19 @@ msgstr "Nie ma użytkownika z takim adresem e-mail."
 
 #. L10n: {id} will be something like "13ad6a", just a random number
 #. to differentiate this user from other anonymous users.
-#: src/olympia/users/models.py:353
+#: src/olympia/users/models.py:362
 msgid "Anonymous user {id}"
 msgstr ""
 
-#: src/olympia/users/models.py:410
+#: src/olympia/users/models.py:419
 msgid "Your account has been restricted"
 msgstr "Twoje konto zostało ograniczone"
 
-#: src/olympia/users/models.py:480
+#: src/olympia/users/models.py:489
 msgid "Please confirm your email address"
 msgstr "Potwierdź swój adres e-mail"
 
-#: src/olympia/users/models.py:506
+#: src/olympia/users/models.py:515
 msgid "My Mobile Add-ons"
 msgstr "Moje dodatki dla Firefoksa Mobile"
 
@@ -12843,7 +12712,6 @@ msgid "%(num)s theme"
 msgid_plural "%(num)s themes"
 msgstr[0] "%(num)s motyw"
 msgstr[1] "%(num)s motywy"
-msgstr[2] "%(num)s motywów"
 
 #: src/olympia/users/templates/users/vcard.html:62
 #, python-format
@@ -12851,7 +12719,6 @@ msgid "%(num)s add-on"
 msgid_plural "%(num)s add-ons"
 msgstr[0] "%(num)s dodatek"
 msgstr[1] "%(num)s dodatki"
-msgstr[2] "%(num)s dodatków"
 
 #: src/olympia/users/templates/users/vcard.html:75
 msgid "Average rating of developer's add-ons"
@@ -12866,15 +12733,15 @@ msgstr "Historia wersji %s"
 msgid "Version History with Changelogs"
 msgstr "Historia wersji z informacjami o zmianach"
 
-#: src/olympia/versions/models.py:314
+#: src/olympia/versions/models.py:313
 msgid "Add-on uses binary components."
 msgstr "Dodatek używa komponentów binarnych."
 
-#: src/olympia/versions/models.py:317
+#: src/olympia/versions/models.py:316
 msgid "Add-on has opted into strict compatibility checking."
 msgstr "Dodatek skierowano do sprawdzenia w trybie ścisłej zgodności."
 
-#: src/olympia/versions/models.py:715
+#: src/olympia/versions/models.py:711
 msgid "{app} {min} and later"
 msgstr "{app} {min} i późniejsze"
 
@@ -12913,7 +12780,6 @@ msgid "<b>{0}</b> version"
 msgid_plural "<b>{0}</b> versions"
 msgstr[0] "<b>{0}</b> wersja"
 msgstr[1] "<b>{0}</b> wersje"
-msgstr[2] "<b>{0}</b> wersji"
 
 #: src/olympia/versions/templates/versions/version_list.html:35 src/olympia/versions/templates/versions/mobile/version_list.html:14
 msgid "Be careful with old versions!"
@@ -12952,4 +12818,8 @@ msgstr "Wyślij, gdy skończy"
 #: src/olympia/zadmin/forms.py:105
 msgid "Log emails instead of sending"
 msgstr "Rejestruj e-maile zamiast wysyłania"
+
+#: src/olympia/zadmin/forms.py:215
+msgid "Deleted versions can`t be changed."
+msgstr ""
 

--- a/locale/pl/LC_MESSAGES/djangojs.po
+++ b/locale/pl/LC_MESSAGES/djangojs.po
@@ -4,1229 +4,1236 @@ msgid ""
 msgstr ""
 "Project-Id-Version: AMO-JS 0.1\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2016-02-24 21:23+0000\n"
+"POT-Creation-Date: 2016-04-18 15:47+0000\n"
 "PO-Revision-Date: 2015-11-03 11:53+0100\n"
 "Last-Translator: Wojciech Szczęsny\n"
 "Language-Team: Polish <kde-i18n-doc@kde.org>\n"
+"Language: pl\n"
 "MIME-Version: 1.0\n"
-"Content-Type: text/plain; charset=utf-8\n"
+"Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Generated-By: Babel 2.2.0\n"
 
-#: static/js/common/ratingwidget.js:31
+#: static/js/common-all.js:1426 static/js/impala-all.js:1511 static/js/zamboni/discovery-all.js:12598 static/js/zamboni/init.js:28 static/js/zamboni/mobile-all.js:14945
+msgid "This feature is temporarily disabled while we perform website maintenance. Please check back a little later."
+msgstr "W trakcie wykonywania serwisu witryny ta funkcja jest tymczasowo wyłączona. Sprawdź ponownie nieco później."
+
+#. L10n: {0} is an app name like Firefox.
+#: static/js/common-all.js:1837 static/js/impala-all.js:1922 static/js/zamboni/buttons.js:73 static/js/zamboni/discovery-all.js:13108
+msgid "Accept and Install"
+msgstr "Akceptuję, zainstaluj"
+
+#: static/js/common-all.js:1837 static/js/impala-all.js:1922 static/js/zamboni/buttons.js:73 static/js/zamboni/discovery-all.js:13108
+msgid "Add to {0}"
+msgstr "Zainstaluj"
+
+#: static/js/common-all.js:1842 static/js/impala-all.js:1927 static/js/zamboni/buttons.js:78 static/js/zamboni/discovery-all.js:13113
+msgid "Download Now"
+msgstr "Pobierz"
+
+#: static/js/common-all.js:1883 static/js/impala-all.js:1968 static/js/zamboni/buttons.js:119 static/js/zamboni/discovery-all.js:13154
+msgid "Add-on has not been updated to support default-to-compatible."
+msgstr "Dodatek nie został zaktualizowany, by wspierać domyślną kompatybilność."
+
+#: static/js/common-all.js:1888 static/js/impala-all.js:1973 static/js/zamboni/buttons.js:124 static/js/zamboni/discovery-all.js:13159
+msgid "You need to be using Firefox 10.0 or higher."
+msgstr "Musisz używać Firefoksa 10 lub nowszego."
+
+#: static/js/common-all.js:1900 static/js/impala-all.js:1985 static/js/zamboni/buttons.js:136 static/js/zamboni/discovery-all.js:13171
+msgid "Mozilla has marked this version as incompatible with your Firefox version."
+msgstr "Mozilla oznaczyła tę wersję jako niekompatybilną z twoją wersją Firefoksa."
+
+#. L10n: {0} is an platform like Windows or Linux.
+#: static/js/common-all.js:1981 static/js/impala-all.js:2066 static/js/zamboni/buttons.js:217 static/js/zamboni/discovery-all.js:13252
+msgid "Install for {0} anyway"
+msgstr "Mimo wszystko zainstaluj dla systemu (0)"
+
+#: static/js/common-all.js:1981 static/js/impala-all.js:2066 static/js/zamboni/buttons.js:217 static/js/zamboni/discovery-all.js:13252
+msgid "Download for {0} anyway"
+msgstr "Mimo wszystko pobierz dla (0)"
+
+#: static/js/common-all.js:2038 static/js/impala-all.js:2123 static/js/zamboni/buttons.js:274 static/js/zamboni/discovery-all.js:13309
+msgid "Not available for your platform"
+msgstr "Niedostępny dla twojego systemu"
+
+#. L10n: {0} is an app name, {1} is the app version.
+#: static/js/common-all.js:2049 static/js/common-all.js:2086 static/js/impala-all.js:2134 static/js/impala-all.js:2171 static/js/zamboni/buttons.js:286 static/js/zamboni/buttons.js:324
+#: static/js/zamboni/discovery-all.js:13320 static/js/zamboni/discovery-all.js:13357
+msgid "Not available for {0} {1}"
+msgstr "Niedostępny dla {0} {1}"
+
+#: static/js/common-all.js:2112 static/js/impala-all.js:2197 static/js/zamboni/buttons.js:351 static/js/zamboni/discovery-all.js:13383
+msgid "Works with {app} {min} - {max}"
+msgstr "Działa z {app} {min} - {max}"
+
+#: static/js/common-all.js:2114 static/js/impala-all.js:2199 static/js/zamboni/buttons.js:353 static/js/zamboni/discovery-all.js:13385
+msgid "View other versions"
+msgstr "Zobacz inne wersje"
+
+#: static/js/common-all.js:2162 static/js/impala-all.js:2247 static/js/zamboni/buttons.js:401 static/js/zamboni/discovery-all.js:13433
+msgid "Only with Firefox — Get Firefox Now!"
+msgstr ""
+
+#: static/js/common-all.js:2278 static/js/impala-all.js:2363 static/js/zamboni/buttons.js:517 static/js/zamboni/discovery-all.js:13549 static/js/zamboni/mobile-all.js:15177
+#: static/js/zamboni/mobile/buttons.js:43
+msgid "Sorry, you need a Mozilla-based browser (such as Firefox) to install a search plugin."
+msgstr "Przepraszamy. Aby zainstalować wtyczkę wyszukiwarki, potrzebna jest przeglądarka zbudowana w oparciu o technologię Mozilli – taka jak np. Firefox."
+
+#: static/js/common-all.js:9088 static/js/impala-all.js:9649 static/js/zamboni/global.js:410
+msgid "Loading..."
+msgstr "Wczytywanie…"
+
+#. L10n: {0} is the number of characters left.
+#: static/js/common-all.js:9152 static/js/impala-all.js:9713 static/js/zamboni/global.js:474
+msgid "<b>{0}</b> character left."
+msgid_plural "<b>{0}</b> characters left."
+msgstr[0] "Pozostał <b>{0}</b> znak."
+msgstr[1] "Pozostały <b>{0}</b> znaki."
+
+#: static/js/common-all.js:9589 static/js/common-min.js:6 static/js/impala-all.js:10052 static/js/impala-min.js:6 static/js/common/ratingwidget.js:31 static/js/zamboni/mobile-all.js:16123
+#: static/js/zamboni/mobile-min.js:6
 msgid "{0} star"
 msgid_plural "{0} stars"
 msgstr[0] "{0} gwiazdka"
 msgstr[1] "{0} gwiazdki"
-msgstr[2] "{0} gwiazdek"
 
-#: static/js/common/upload-addon.js:41 static/js/common/upload-image.js:128
+#: static/js/common-all.js:9676 static/js/common-min.js:6 static/js/impala-all.js:10139 static/js/impala-min.js:6 static/js/zamboni/l10n.js:45
+msgid "Remove this localization"
+msgstr "Usuń tę lokalizację"
+
+#: static/js/common-all.js:10193 static/js/common-min.js:6 static/js/impala-all.js:10674 static/js/impala-min.js:6 static/js/zamboni/discovery-all.js:13678
+msgid "close"
+msgstr ""
+
+#: static/js/common-all.js:10860 static/js/common-min.js:6 static/js/impala-all.js:11481 static/js/impala-min.js:6 static/js/impala/reviews.js:23 static/js/zamboni/reviews.js:18
+msgid "Flagged for review"
+msgstr "Oznaczona do sprawdzenia"
+
+#: static/js/common-all.js:10876 static/js/common-min.js:6 static/js/impala-all.js:11498 static/js/impala-min.js:6 static/js/impala/reviews.js:40 static/js/zamboni/reviews.js:34
+msgid "Your input is required"
+msgstr "Wymagane jest wprowadzenie danych"
+
+#: static/js/common-all.js:10945 static/js/common-min.js:6 static/js/impala-all.js:11610 static/js/impala-min.js:7 static/js/impala/reviews.js:152 static/js/zamboni/reviews.js:103
+msgid "Marked for deletion"
+msgstr "Oznaczona do usunięcia"
+
+#: static/js/common-all.js:11573 static/js/common-min.js:7 static/js/impala-all.js:13809 static/js/impala-min.js:8 static/js/zamboni/collections.js:229
+msgid "Adding to Favorites&hellip;"
+msgstr "Dodawanie do ulubionych&hellip;"
+
+#: static/js/common-all.js:11576 static/js/common-min.js:7 static/js/impala-all.js:13812 static/js/impala-min.js:8 static/js/zamboni/collections.js:232
+msgid "Removing Favorite&hellip;"
+msgstr "Usuwanie z ulubionych&hellip;"
+
+#: static/js/common-all.js:11579 static/js/common-min.js:7 static/js/impala-all.js:13815 static/js/impala-min.js:8 static/js/zamboni/collections.js:235
+msgid "Add to Favorites"
+msgstr "Dodaj do ulubionych"
+
+#: static/js/common-all.js:11582 static/js/common-min.js:7 static/js/impala-all.js:13818 static/js/impala-min.js:8 static/js/zamboni/collections.js:238
+msgid "Remove from Favorites"
+msgstr "Usuń z ulubionych"
+
+#: static/js/common-all.js:11647 static/js/common-min.js:7 static/js/impala-all.js:13883 static/js/impala-min.js:8 static/js/zamboni/collections.js:303
+msgid "Pending"
+msgstr "Oczekujące"
+
+#: static/js/common-all.js:11648 static/js/common-min.js:7 static/js/impala-all.js:13884 static/js/impala-min.js:8 static/js/zamboni/collections.js:304
+msgid "Add a comment"
+msgstr "Dodaj komentarz"
+
+#: static/js/common-all.js:11648 static/js/common-min.js:7 static/js/impala-all.js:13884 static/js/impala-min.js:8 static/js/zamboni/collections.js:304
+msgid "Comment"
+msgstr "Komentarz"
+
+#: static/js/common-all.js:11649 static/js/common-min.js:7 static/js/impala-all.js:13885 static/js/impala-min.js:8 static/js/zamboni/collections.js:305
+msgid "Remove this add-on from the collection"
+msgstr "Usuń ten dodatek z kolekcji"
+
+#: static/js/common-all.js:11649 static/js/common-all.js:11678 static/js/common-min.js:7 static/js/impala-all.js:13885 static/js/impala-all.js:13914 static/js/impala-min.js:8
+#: static/js/zamboni/collections.js:305 static/js/zamboni/collections.js:334
+msgid "Remove"
+msgstr "Usuń"
+
+#: static/js/common-all.js:11678 static/js/common-min.js:7 static/js/impala-all.js:13914 static/js/impala-min.js:8 static/js/zamboni/collections.js:334
+msgid "Remove this user as a contributor"
+msgstr "Usuń tego użytkownika z listy autorów"
+
+#: static/js/common-all.js:11690 static/js/common-min.js:7 static/js/impala-all.js:13926 static/js/impala-min.js:8 static/js/zamboni/collections.js:346
+msgid "An email address is required."
+msgstr "Adres e-mail jest wymagany."
+
+#: static/js/common-all.js:11708 static/js/common-min.js:7 static/js/impala-all.js:13944 static/js/impala-min.js:8 static/js/zamboni/collections.js:364
+msgid "You cannot add yourself as a contributor."
+msgstr "Nie możesz dodać siebie jako współautora."
+
+#: static/js/common-all.js:11710 static/js/common-min.js:7 static/js/impala-all.js:13946 static/js/impala-min.js:8 static/js/zamboni/collections.js:366
+msgid "You have already added that user."
+msgstr "Ten użytkownik został już dodany."
+
+#: static/js/common-all.js:11917 static/js/common-min.js:7 static/js/impala-all.js:14153 static/js/impala-min.js:8 static/js/zamboni/collections.js:573
+msgid "Add to favorites"
+msgstr "Dodaj do ulubionych"
+
+#: static/js/common-all.js:11921 static/js/common-min.js:7 static/js/impala-all.js:14157 static/js/impala-min.js:8 static/js/zamboni/collections.js:577
+msgid "Remove from favorites"
+msgstr "Usuń z ulubionych"
+
+#: static/js/common-all.js:11939 static/js/common-min.js:7 static/js/impala-all.js:14175 static/js/impala-all.js:14233 static/js/impala-min.js:8 static/js/impala/collections.js:10
+#: static/js/zamboni/collections.js:595
+msgid "Follow this Collection"
+msgstr "Obserwuj tę kolekcję"
+
+#: static/js/common-all.js:11948 static/js/common-min.js:7 static/js/impala-all.js:14184 static/js/impala-min.js:8 static/js/zamboni/collections.js:604
+msgid "Stop following"
+msgstr "Zaprzestań obserwacji"
+
+#: static/js/common-all.js:12096 static/js/common-min.js:7 static/js/zamboni/password-strength.js:20
+msgid "Password strength:"
+msgstr "Siła hasła:"
+
+#: static/js/common-all.js:12102 static/js/common-min.js:7 static/js/zamboni/password-strength.js:26
+msgid "At least {0} character left."
+msgid_plural "At least {0} characters left."
+msgstr[0] "Pozostał przynajmniej {0} znak."
+msgstr[1] "Pozostały przynajmniej {0} znaki."
+
+#: static/js/common-all.js:12286 static/js/common-min.js:7 static/js/impala-all.js:14632 static/js/impala-min.js:8 static/js/impala/suggestions.js:39
+msgid "Search themes for <b>{0}</b>"
+msgstr "Szukaj motywów dla <b>{0}</b>"
+
+#: static/js/common-all.js:12288 static/js/common-min.js:7 static/js/impala-all.js:14634 static/js/impala-min.js:8 static/js/impala/suggestions.js:41
+msgid "Search apps for <b>{0}</b>"
+msgstr "Szukaj aplikacji dla <b>{0}</b>"
+
+#: static/js/common-all.js:12290 static/js/common-min.js:7 static/js/impala-all.js:14636 static/js/impala-min.js:8 static/js/impala/suggestions.js:43
+msgid "Search add-ons for <b>{0}</b>"
+msgstr "Szukaj dodatków dla <b>{0}</b>"
+
+#: static/js/common-all.js:12521 static/js/common-min.js:7 static/js/impala-all.js:14867 static/js/impala-min.js:8 static/js/impala/site_suggestions.js:46
+msgid "Category"
+msgstr "Kategoria"
+
+#. L10n: {0} is an app name.
+#: static/js/impala-all.js:11632 static/js/impala-min.js:7 static/js/impala/listing.js:11 static/js/zamboni/themes.js:13
+msgid "This theme is incompatible with your version of {0}"
+msgstr "Ten motyw jest niekompatybilny z twoją wersją programu {0}"
+
+#: static/js/impala-all.js:12146 static/js/impala-all.js:14331 static/js/impala-min.js:7 static/js/impala-min.js:8 static/js/common/upload-image.js:97 static/js/impala/users.js:51
+#: static/js/zamboni/devhub-all.js:894 static/js/zamboni/devhub-min.js:1
+msgid "Images must be either PNG or JPG."
+msgstr "Obrazki muszą być w formacie PNG lub JPG."
+
+#: static/js/impala-all.js:12150 static/js/impala-min.js:7 static/js/common/upload-image.js:101 static/js/zamboni/devhub-all.js:898 static/js/zamboni/devhub-min.js:1
+msgid "Videos must be in WebM."
+msgstr "Wideo musi być w formacie WebM."
+
+#: static/js/impala-all.js:12177 static/js/impala-min.js:7 static/js/common/upload-addon.js:41 static/js/common/upload-image.js:128 static/js/zamboni/devhub-all.js:272
+#: static/js/zamboni/devhub-all.js:925 static/js/zamboni/devhub-min.js:1
 msgid "There was a problem contacting the server."
 msgstr "Wystąpił problem skontaktowania się z serwerem."
 
-#: static/js/common/upload-addon.js:69
+#: static/js/impala-all.js:13298 static/js/impala-min.js:7 static/js/impala/persona_creation.js:60
+msgid "All Rights Reserved"
+msgstr "Wszystkie prawa zastrzeżone"
+
+#: static/js/impala-all.js:13302 static/js/impala-min.js:7 static/js/impala/persona_creation.js:64
+msgid "Creative Commons Attribution 3.0"
+msgstr "Creative Commons Attribution 3.0"
+
+#: static/js/impala-all.js:13307 static/js/impala-min.js:7 static/js/impala/persona_creation.js:69
+msgid "Creative Commons Attribution-NonCommercial 3.0"
+msgstr "Creative Commons Attribution-NonCommercial 3.0"
+
+#: static/js/impala-all.js:13312 static/js/impala-min.js:7 static/js/impala/persona_creation.js:74
+msgid "Creative Commons Attribution-NonCommercial-NoDerivs 3.0"
+msgstr "Creative Commons Attribution-NonCommercial-NoDerivs 3.0"
+
+#: static/js/impala-all.js:13317 static/js/impala-min.js:7 static/js/impala/persona_creation.js:79
+msgid "Creative Commons Attribution-NonCommercial-Share Alike 3.0"
+msgstr "Creative Commons Attribution-NonCommercial-Share Alike 3.0"
+
+#: static/js/impala-all.js:13322 static/js/impala-min.js:7 static/js/impala/persona_creation.js:84
+msgid "Creative Commons Attribution-NoDerivs 3.0"
+msgstr "Creative Commons Attribution-NoDerivs 3.0"
+
+#: static/js/impala-all.js:13327 static/js/impala-min.js:7 static/js/impala/persona_creation.js:89
+msgid "Creative Commons Attribution-ShareAlike 3.0"
+msgstr "Creative Commons Attribution-ShareAlike 3.0"
+
+#: static/js/impala-all.js:13530 static/js/impala-min.js:7 static/js/impala/persona_creation.js:292
+msgid "Your Theme's Name"
+msgstr "Nazwa  twojego motywu"
+
+#: static/js/impala-all.js:14242 static/js/impala-min.js:8 static/js/impala/collections.js:19
+msgid "Stop Following"
+msgstr "Zaprzestań obserwacji"
+
+#: static/js/impala-all.js:14243 static/js/impala-min.js:8 static/js/impala/collections.js:20
+msgid "Following"
+msgstr "Obserwuj"
+
+#: static/js/impala-all.js:14313 static/js/impala-min.js:8 static/js/impala/users.js:33
+msgid "use original"
+msgstr "użyj oryginału"
+
+#: static/js/impala-all.js:14523 static/js/impala-min.js:8 static/js/impala/search.js:114
+msgid "Updating results&hellip;"
+msgstr "Aktualizowanie wyników&hellip;"
+
+#: static/js/common/upload-addon.js:69 static/js/zamboni/devhub-all.js:300 static/js/zamboni/devhub-min.js:1
 msgid "Select a file..."
 msgstr "Wybierz plik…"
 
-#: static/js/common/upload-addon.js:70
+#: static/js/common/upload-addon.js:70 static/js/zamboni/devhub-all.js:301 static/js/zamboni/devhub-min.js:1
 msgid "Your add-on should end with .xpi, .jar or .xml"
 msgstr "Nazwa pliku dodatku powinna kończyć się rozszerzeniem .xpi, .jar lub .xml"
 
 #. L10n: {0} is the percent of the file that has been uploaded.
-#: static/js/common/upload-addon.js:104
+#: static/js/common/upload-addon.js:104 static/js/zamboni/devhub-all.js:335 static/js/zamboni/devhub-min.js:1
 #, fuzzy, python-format
 msgid "{0}% complete"
 msgstr "Ukończono {0}%"
 
 #. L10n: "{bytes uploaded} of {total filesize}".
-#: static/js/common/upload-addon.js:107
+#: static/js/common/upload-addon.js:107 static/js/zamboni/devhub-all.js:338 static/js/zamboni/devhub-min.js:1
 msgid "{0} of {1}"
 msgstr "{0} z {1}"
 
-#: static/js/common/upload-addon.js:140
+#: static/js/common/upload-addon.js:140 static/js/zamboni/devhub-all.js:371 static/js/zamboni/devhub-min.js:1
 msgid "Cancel"
 msgstr "Anuluj"
 
-#: static/js/common/upload-addon.js:162
+#: static/js/common/upload-addon.js:162 static/js/zamboni/devhub-all.js:393 static/js/zamboni/devhub-min.js:1
 msgid "Uploading {0}"
 msgstr "Przesyłanie {0}"
 
-#: static/js/common/upload-addon.js:189
+#: static/js/common/upload-addon.js:189 static/js/zamboni/devhub-all.js:420 static/js/zamboni/devhub-min.js:1
 msgid "Error with {0}"
 msgstr "Błąd z {0}"
 
-#: static/js/common/upload-addon.js:194
+#: static/js/common/upload-addon.js:194 static/js/zamboni/devhub-all.js:425 static/js/zamboni/devhub-min.js:1
 msgid "Your add-on failed validation with {0} error."
 msgid_plural "Your add-on failed validation with {0} errors."
 msgstr[0] "Dodatek nie przeszedł weryfikacji z powodu {0} błędu."
 msgstr[1] "Dodatek nie przeszedł weryfikacji z powodu {0} błędów."
-msgstr[2] "Dodatek nie przeszedł weryfikacji z powodu {0} błędów."
 
-#: static/js/common/upload-addon.js:208
+#: static/js/common/upload-addon.js:208 static/js/zamboni/devhub-all.js:439 static/js/zamboni/devhub-min.js:1
 msgid "&hellip;and {0} more"
 msgid_plural "&hellip;and {0} more"
 msgstr[0] "&hellip;i {0} więcej"
 msgstr[1] "&hellip;i {0} więcej"
-msgstr[2] "&hellip;i {0} więcej"
 
-#: static/js/common/upload-addon.js:222 static/js/common/upload-addon.js:512
+#: static/js/common/upload-addon.js:222 static/js/common/upload-addon.js:497 static/js/zamboni/devhub-all.js:453 static/js/zamboni/devhub-all.js:743 static/js/zamboni/devhub-min.js:1
 msgid "See full validation report"
 msgstr "Zobacz pełny raport"
 
-#: static/js/common/upload-addon.js:234
+#: static/js/common/upload-addon.js:234 static/js/zamboni/devhub-all.js:465 static/js/zamboni/devhub-min.js:1
 msgid "Validating {0}"
 msgstr "Weryfikowanie {0}"
 
 #. L10n: first argument is an HTTP status code
-#: static/js/common/upload-addon.js:273
+#: static/js/common/upload-addon.js:273 static/js/zamboni/devhub-all.js:504 static/js/zamboni/devhub-min.js:1
 msgid "Received an empty response from the server; status: {0}"
 msgstr "Otrzymano pustą odpowiedź z serwera; status: {0}"
 
-#: static/js/common/upload-addon.js:373
+#: static/js/common/upload-addon.js:370 static/js/zamboni/devhub-all.js:604 static/js/zamboni/devhub-min.js:1
 msgid "Unexpected server error while validating."
 msgstr "W czasie weryfikacji wystąpił nieoczekiwany błąd serwera."
 
-#: static/js/common/upload-addon.js:412
+#: static/js/common/upload-addon.js:409 static/js/zamboni/devhub-all.js:643 static/js/zamboni/devhub-min.js:1
 msgid "Finished validating {0}"
 msgstr "Zakończono sprawdzanie {0}"
 
-#: static/js/common/upload-addon.js:418
+#: static/js/common/upload-addon.js:415 static/js/zamboni/devhub-all.js:649 static/js/zamboni/devhub-min.js:1
 msgid "Your add-on validation timed out, it will be manually reviewed."
 msgstr "Limit czasowy sprawdzenia dodatku wygasł, zostanie sprawdzony ręcznie."
 
-#: static/js/common/upload-addon.js:421
+#: static/js/common/upload-addon.js:418 static/js/zamboni/devhub-all.js:652 static/js/zamboni/devhub-min.js:1
 msgid "Your add-on was validated with no errors and {0} warning."
 msgid_plural "Your add-on was validated with no errors and {0} warnings."
 msgstr[0] "Dodatek przeszedł weryfikację bez błędów i z {0} ostrzeżeniem."
 msgstr[1] "Dodatek przeszedł weryfikację bez błędów i z {0} ostrzeżeniami."
-msgstr[2] "Dodatek przeszedł weryfikację bez błędów i z {0} ostrzeżeniami."
 
-#: static/js/common/upload-addon.js:426
+#: static/js/common/upload-addon.js:423 static/js/zamboni/devhub-all.js:657 static/js/zamboni/devhub-min.js:1
 msgid "Your add-on was validated with no errors and {0} message."
 msgid_plural "Your add-on was validated with no errors and {0} messages."
 msgstr[0] "Dodatek przeszedł weryfikację bez błędów i z {0} wiadomością."
 msgstr[1] "Dodatek przeszedł weryfikację bez błędów i z {0} wiadomościami."
-msgstr[2] "Dodatek przeszedł weryfikację bez błędów i z {0} wiadomościami."
 
-#: static/js/common/upload-addon.js:431
+#: static/js/common/upload-addon.js:428 static/js/zamboni/devhub-all.js:662 static/js/zamboni/devhub-min.js:1
 msgid "Your add-on was validated with no errors or warnings."
 msgstr "Dodatek przeszedł weryfikację bez błędów i ostrzeżeń."
 
-#: static/js/common/upload-addon.js:446
+#: static/js/common/upload-addon.js:443 static/js/zamboni/devhub-all.js:677 static/js/zamboni/devhub-min.js:1
 msgid "Your submission will be automatically signed."
 msgstr ""
 
-#: static/js/common/upload-addon.js:465
+#: static/js/common/upload-addon.js:450 static/js/zamboni/devhub-all.js:696 static/js/zamboni/devhub-min.js:1
 msgid "Include detailed version notes (this can be done in the next step)."
 msgstr "Dołącz szczegółowe informacje o wersji dodatku (można zrobić to w kolejnym kroku)."
 
-#: static/js/common/upload-addon.js:466
+#: static/js/common/upload-addon.js:451 static/js/zamboni/devhub-all.js:697 static/js/zamboni/devhub-min.js:1
 msgid "If your add-on requires an account to a website in order to be fully tested, include a test username and password in the Notes to Reviewer (this can be done in the next step)."
 msgstr "Jeśli dodatek wymaga konta na stronie w celu pełnego przetestowania, podaj testową nazwę użytkownika i hasło w informacjach dla recenzenta (można to zrobić w kolejnym kroku)."
 
-#: static/js/common/upload-addon.js:467
+#: static/js/common/upload-addon.js:452 static/js/zamboni/devhub-all.js:698 static/js/zamboni/devhub-min.js:1
 msgid "If your add-on is intended for a limited audience you should choose Preliminary Review instead of Full Review."
 msgstr "Jeśli dodatek przeznaczony jest dla ograniczonej grupy odbiorców, należy wybrać wstępne sprawdzenie zamiast pełnego sprawdzenia."
 
-#: static/js/common/upload-addon.js:480
+#: static/js/common/upload-addon.js:465 static/js/zamboni/devhub-all.js:711 static/js/zamboni/devhub-min.js:1
 msgid "Add-on submission checklist"
 msgstr "Lista kontrolna zgłaszania dodatku"
 
-#: static/js/common/upload-addon.js:481
+#: static/js/common/upload-addon.js:466 static/js/zamboni/devhub-all.js:712 static/js/zamboni/devhub-min.js:1
 msgid "Please verify the following points before finalizing your submission. This will minimize delays or misunderstanding during the review process:"
 msgstr "Sprawdź następujące punkty przed zakończeniem zgłoszenia. Pozwoli to zminimalizować opóźnienia i nieporozumienia podczas sprawdzania: "
 
-#: static/js/common/upload-addon.js:483
+#: static/js/common/upload-addon.js:468 static/js/zamboni/devhub-all.js:714 static/js/zamboni/devhub-min.js:1
 msgid ""
 "Compiled binaries, as well as minified or obfuscated scripts (excluding known libraries) need to have their sources submitted separately for review. Make sure that you use the source code upload "
 "field to avoid having your submission rejected."
 msgstr ""
-"Skompilowane pliki binarne oraz zminimalizowane i zaciemnione skrypty (z wyłączeniem znanych bibliotek) wymagają oddzielnie przesłanych kodów źródłowych do sprawdzenia. Upewnij się, że używasz pola"
-" do załadowania kodu źródłowego, aby uniknąć odrzucenia zgłoszenia."
+"Skompilowane pliki binarne oraz zminimalizowane i zaciemnione skrypty (z wyłączeniem znanych bibliotek) wymagają oddzielnie przesłanych kodów źródłowych do sprawdzenia. Upewnij się, że używasz pola "
+"do załadowania kodu źródłowego, aby uniknąć odrzucenia zgłoszenia."
 
-#: static/js/common/upload-addon.js:501
+#: static/js/common/upload-addon.js:486 static/js/zamboni/devhub-all.js:732 static/js/zamboni/devhub-min.js:1
 msgid "The validation process found these issues that can lead to rejections:"
 msgstr "Podczas weryfikacji znaleziono poniższe problemy, które mogą prowadzić do odrzucenia dodatku:"
 
-#: static/js/common/upload-addon.js:518
+#: static/js/common/upload-addon.js:503 static/js/zamboni/devhub-all.js:749 static/js/zamboni/devhub-min.js:1
 msgid "If you are unfamiliar with the add-ons review process, you can read about it here."
 msgstr "Jeśli nie wiesz, na czym polega proces oceniania dodatków, możesz przeczytać o tym tutaj."
 
-#: static/js/common/upload-addon.js:555
+#: static/js/common/upload-addon.js:540 static/js/zamboni/devhub-all.js:786 static/js/zamboni/devhub-min.js:1
 msgid "Sorry, no supported platform has been found."
 msgstr "Przepraszamy, nie znaleziono obsługiwanego systemu."
 
-#: static/js/common/upload-base.js:57
+#: static/js/common/upload-base.js:57 static/js/zamboni/devhub-all.js:187 static/js/zamboni/devhub-min.js:1
 msgid "The filetype you uploaded isn't recognized."
 msgstr "Nie rozpoznano typu przesłanego pliku."
 
-#: static/js/common/upload-base.js:79
+#: static/js/common/upload-base.js:79 static/js/zamboni/devhub-all.js:209 static/js/zamboni/devhub-min.js:1
 msgid "You cancelled the upload."
 msgstr "Anulowano przesyłanie."
 
-#: static/js/common/upload-image.js:97 static/js/impala/users.js:51
-msgid "Images must be either PNG or JPG."
-msgstr "Obrazki muszą być w formacie PNG lub JPG."
-
-#: static/js/common/upload-image.js:101
-msgid "Videos must be in WebM."
-msgstr "Wideo musi być w formacie WebM."
-
-#: static/js/impala/collections.js:10 static/js/zamboni/collections.js:595
-msgid "Follow this Collection"
-msgstr "Obserwuj tę kolekcję"
-
-#: static/js/impala/collections.js:19
-msgid "Stop Following"
-msgstr "Zaprzestań obserwacji"
-
-#: static/js/impala/collections.js:20
-msgid "Following"
-msgstr "Obserwuj"
-
-#. L10n: {0} is an app name.
-#: static/js/impala/listing.js:11 static/js/zamboni/themes.js:13
-msgid "This theme is incompatible with your version of {0}"
-msgstr "Ten motyw jest niekompatybilny z twoją wersją programu {0}"
-
-#: static/js/impala/persona_creation.js:60
-msgid "All Rights Reserved"
-msgstr "Wszystkie prawa zastrzeżone"
-
-#: static/js/impala/persona_creation.js:64
-msgid "Creative Commons Attribution 3.0"
-msgstr "Creative Commons Attribution 3.0"
-
-#: static/js/impala/persona_creation.js:69
-msgid "Creative Commons Attribution-NonCommercial 3.0"
-msgstr "Creative Commons Attribution-NonCommercial 3.0"
-
-#: static/js/impala/persona_creation.js:74
-msgid "Creative Commons Attribution-NonCommercial-NoDerivs 3.0"
-msgstr "Creative Commons Attribution-NonCommercial-NoDerivs 3.0"
-
-#: static/js/impala/persona_creation.js:79
-msgid "Creative Commons Attribution-NonCommercial-Share Alike 3.0"
-msgstr "Creative Commons Attribution-NonCommercial-Share Alike 3.0"
-
-#: static/js/impala/persona_creation.js:84
-msgid "Creative Commons Attribution-NoDerivs 3.0"
-msgstr "Creative Commons Attribution-NoDerivs 3.0"
-
-#: static/js/impala/persona_creation.js:89
-msgid "Creative Commons Attribution-ShareAlike 3.0"
-msgstr "Creative Commons Attribution-ShareAlike 3.0"
-
-#: static/js/impala/persona_creation.js:292
-msgid "Your Theme's Name"
-msgstr "Nazwa  twojego motywu"
-
-#: static/js/impala/reviews.js:23 static/js/zamboni/reviews.js:18
-msgid "Flagged for review"
-msgstr "Oznaczona do sprawdzenia"
-
-#: static/js/impala/reviews.js:40 static/js/zamboni/reviews.js:34
-msgid "Your input is required"
-msgstr "Wymagane jest wprowadzenie danych"
-
-#: static/js/impala/reviews.js:152 static/js/zamboni/reviews.js:103
-msgid "Marked for deletion"
-msgstr "Oznaczona do usunięcia"
-
-#: static/js/impala/search.js:114
-msgid "Updating results&hellip;"
-msgstr "Aktualizowanie wyników&hellip;"
-
-#: static/js/impala/site_suggestions.js:46
-msgid "Category"
-msgstr "Kategoria"
-
-#: static/js/impala/suggestions.js:39
-msgid "Search themes for <b>{0}</b>"
-msgstr "Szukaj motywów dla <b>{0}</b>"
-
-#: static/js/impala/suggestions.js:41
-msgid "Search apps for <b>{0}</b>"
-msgstr "Szukaj aplikacji dla <b>{0}</b>"
-
-#: static/js/impala/suggestions.js:43
-msgid "Search add-ons for <b>{0}</b>"
-msgstr "Szukaj dodatków dla <b>{0}</b>"
-
-#: static/js/impala/users.js:33
-msgid "use original"
-msgstr "użyj oryginału"
-
-#: static/js/impala/stats/chart.js:267
+#: static/js/impala/stats/chart.js:267 static/js/zamboni/stats-all.js:16898 static/js/zamboni/stats-min.js:5
 msgid "Week of {0}"
 msgstr "Tydzień: {0}"
 
-#: static/js/impala/stats/chart.js:269
+#: static/js/impala/stats/chart.js:269 static/js/zamboni/stats-all.js:16900 static/js/zamboni/stats-min.js:5
 msgid " downloads"
-msgstr "pobrania"
+msgstr ""
 
-#: static/js/impala/stats/chart.js:270
+#: static/js/impala/stats/chart.js:270 static/js/zamboni/stats-all.js:16901 static/js/zamboni/stats-min.js:5
 msgid "{0} users"
 msgstr "użytkownicy: {0}"
 
-#: static/js/impala/stats/chart.js:271
+#: static/js/impala/stats/chart.js:271 static/js/zamboni/stats-all.js:16902 static/js/zamboni/stats-min.js:5
 msgid "{0} add-ons"
 msgstr "Dodatki: {0}"
 
-#: static/js/impala/stats/chart.js:272
+#: static/js/impala/stats/chart.js:272 static/js/zamboni/stats-all.js:16903 static/js/zamboni/stats-min.js:5
 msgid "{0} collections"
 msgstr "kolekcje: {0}"
 
-#: static/js/impala/stats/chart.js:273
+#: static/js/impala/stats/chart.js:273 static/js/zamboni/stats-all.js:16904 static/js/zamboni/stats-min.js:5
 msgid "{0} reviews"
 msgstr "opinie: {0}"
 
-#: static/js/impala/stats/chart.js:275
+#: static/js/impala/stats/chart.js:275 static/js/zamboni/stats-all.js:16906 static/js/zamboni/stats-min.js:5
 msgid "{0} sales"
 msgstr "sprzedaże: "
 
-#: static/js/impala/stats/chart.js:276
+#: static/js/impala/stats/chart.js:276 static/js/zamboni/stats-all.js:16907 static/js/zamboni/stats-min.js:5
 msgid "{0} refunds"
 msgstr "zwroty: {0}"
 
-#: static/js/impala/stats/chart.js:277
+#: static/js/impala/stats/chart.js:277 static/js/zamboni/stats-all.js:16908 static/js/zamboni/stats-min.js:5
 msgid "{0} installs"
 msgstr "Instalacje: {0}"
 
-#: static/js/impala/stats/chart.js:369 static/js/impala/stats/csv_keys.js:3 static/js/impala/stats/csv_keys.js:109
+#: static/js/impala/stats/chart.js:369 static/js/impala/stats/csv_keys.js:3 static/js/impala/stats/csv_keys.js:109 static/js/zamboni/stats-all.js:15284 static/js/zamboni/stats-all.js:15390
+#: static/js/zamboni/stats-all.js:17000 static/js/zamboni/stats-min.js:4 static/js/zamboni/stats-min.js:5
 msgid "Downloads"
 msgstr "Pobrania"
 
-#: static/js/impala/stats/chart.js:379 static/js/impala/stats/csv_keys.js:6 static/js/impala/stats/csv_keys.js:110
+#: static/js/impala/stats/chart.js:379 static/js/impala/stats/csv_keys.js:6 static/js/impala/stats/csv_keys.js:110 static/js/zamboni/stats-all.js:15287 static/js/zamboni/stats-all.js:15391
+#: static/js/zamboni/stats-all.js:17010 static/js/zamboni/stats-min.js:4 static/js/zamboni/stats-min.js:5
 msgid "Daily Users"
 msgstr "Dzienni użytkownicy"
 
-#: static/js/impala/stats/chart.js:410
+#: static/js/impala/stats/chart.js:410 static/js/zamboni/stats-all.js:17041 static/js/zamboni/stats-min.js:5
 msgid "Amount, in USD"
 msgstr "Kwota w dolarach amerykańskich"
 
-#: static/js/impala/stats/chart.js:421 static/js/impala/stats/csv_keys.js:104
+#: static/js/impala/stats/chart.js:421 static/js/impala/stats/csv_keys.js:104 static/js/zamboni/stats-all.js:15385 static/js/zamboni/stats-all.js:17052 static/js/zamboni/stats-min.js:5
 msgid "Number of Contributions"
 msgstr "Liczba dotacji"
 
-#: static/js/impala/stats/chart.js:447
+#: static/js/impala/stats/chart.js:447 static/js/zamboni/stats-all.js:17078 static/js/zamboni/stats-min.js:5
 msgid "More Info..."
 msgstr "Więcej informacji…"
 
 #. L10n: {0} is an ISO-formatted date.
-#: static/js/impala/stats/chart.js:451
+#: static/js/impala/stats/chart.js:451 static/js/zamboni/stats-all.js:17082 static/js/zamboni/stats-min.js:5
 msgid "Details for {0}"
 msgstr "Szczegóły dla {0}"
 
-#: static/js/impala/stats/csv_keys.js:9
+#: static/js/impala/stats/csv_keys.js:9 static/js/zamboni/stats-all.js:15290 static/js/zamboni/stats-min.js:4
 msgid "Collections Created"
 msgstr "Utworzone kolekcje"
 
-#: static/js/impala/stats/csv_keys.js:12
+#: static/js/impala/stats/csv_keys.js:12 static/js/zamboni/stats-all.js:15293 static/js/zamboni/stats-min.js:4
 msgid "Add-ons in Use"
 msgstr "Używane dodatki"
 
-#: static/js/impala/stats/csv_keys.js:15
+#: static/js/impala/stats/csv_keys.js:15 static/js/zamboni/stats-all.js:15296 static/js/zamboni/stats-min.js:4
 msgid "Add-ons Created"
 msgstr "Utworzone dodatki"
 
-#: static/js/impala/stats/csv_keys.js:18
+#: static/js/impala/stats/csv_keys.js:18 static/js/zamboni/stats-all.js:15299 static/js/zamboni/stats-min.js:4
 msgid "Add-ons Downloaded"
 msgstr "Pobrane dodatki"
 
-#: static/js/impala/stats/csv_keys.js:21
+#: static/js/impala/stats/csv_keys.js:21 static/js/zamboni/stats-all.js:15302 static/js/zamboni/stats-min.js:4
 msgid "Add-ons Updated"
 msgstr "Zaktualizowane dodatki"
 
-#: static/js/impala/stats/csv_keys.js:24
+#: static/js/impala/stats/csv_keys.js:24 static/js/zamboni/stats-all.js:15305 static/js/zamboni/stats-min.js:4
 msgid "Reviews Written"
 msgstr "Napisane opinie"
 
-#: static/js/impala/stats/csv_keys.js:27
+#: static/js/impala/stats/csv_keys.js:27 static/js/zamboni/stats-all.js:15308 static/js/zamboni/stats-min.js:4
 msgid "User Signups"
 msgstr "Logowania użytkowników"
 
-#: static/js/impala/stats/csv_keys.js:30
+#: static/js/impala/stats/csv_keys.js:30 static/js/zamboni/stats-all.js:15311 static/js/zamboni/stats-min.js:4
 msgid "Subscribers"
 msgstr "Subskrybenci"
 
-#: static/js/impala/stats/csv_keys.js:33
+#: static/js/impala/stats/csv_keys.js:33 static/js/zamboni/stats-all.js:15314 static/js/zamboni/stats-min.js:4
 msgid "Ratings"
 msgstr "Oceny"
 
-#: static/js/impala/stats/csv_keys.js:36 static/js/impala/stats/csv_keys.js:114
+#: static/js/impala/stats/csv_keys.js:36 static/js/impala/stats/csv_keys.js:114 static/js/zamboni/stats-all.js:15317 static/js/zamboni/stats-all.js:15395 static/js/zamboni/stats-min.js:4
+#: static/js/zamboni/stats-min.js:5
 msgid "Sales"
 msgstr "Sprzedaże"
 
-#: static/js/impala/stats/csv_keys.js:39 static/js/impala/stats/csv_keys.js:113
+#: static/js/impala/stats/csv_keys.js:39 static/js/impala/stats/csv_keys.js:113 static/js/zamboni/stats-all.js:15320 static/js/zamboni/stats-all.js:15394 static/js/zamboni/stats-min.js:4
+#: static/js/zamboni/stats-min.js:5
 msgid "Installs"
 msgstr "Instalacje"
 
-#: static/js/impala/stats/csv_keys.js:42
+#: static/js/impala/stats/csv_keys.js:42 static/js/zamboni/stats-all.js:15323 static/js/zamboni/stats-min.js:4
 msgid "Unknown"
 msgstr "Nieznane"
 
-#: static/js/impala/stats/csv_keys.js:43
+#: static/js/impala/stats/csv_keys.js:43 static/js/zamboni/stats-all.js:15324 static/js/zamboni/stats-min.js:4
 msgid "Add-ons Manager"
 msgstr "Menedżer dodatków"
 
-#: static/js/impala/stats/csv_keys.js:44
+#: static/js/impala/stats/csv_keys.js:44 static/js/zamboni/stats-all.js:15325 static/js/zamboni/stats-min.js:4
 msgid "Add-ons Manager Promo"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:45
+#: static/js/impala/stats/csv_keys.js:45 static/js/zamboni/stats-all.js:15326 static/js/zamboni/stats-min.js:4
 msgid "Add-ons Manager Featured"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:46
+#: static/js/impala/stats/csv_keys.js:46 static/js/zamboni/stats-all.js:15327 static/js/zamboni/stats-min.js:4
 msgid "Add-ons Manager Learn More"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:47
+#: static/js/impala/stats/csv_keys.js:47 static/js/zamboni/stats-all.js:15328 static/js/zamboni/stats-min.js:4
 msgid "Search Suggestions"
 msgstr "Sugestie wyszukiwania"
 
-#: static/js/impala/stats/csv_keys.js:48
+#: static/js/impala/stats/csv_keys.js:48 static/js/zamboni/stats-all.js:15329 static/js/zamboni/stats-min.js:4
 msgid "Search Results"
 msgstr "Wyniki wyszukiwania"
 
-#: static/js/impala/stats/csv_keys.js:49 static/js/impala/stats/csv_keys.js:50 static/js/impala/stats/csv_keys.js:51
+#: static/js/impala/stats/csv_keys.js:49 static/js/impala/stats/csv_keys.js:50 static/js/impala/stats/csv_keys.js:51 static/js/zamboni/stats-all.js:15330 static/js/zamboni/stats-all.js:15331
+#: static/js/zamboni/stats-all.js:15332 static/js/zamboni/stats-min.js:4
 msgid "Homepage Promo"
 msgstr "Strona promocji"
 
-#: static/js/impala/stats/csv_keys.js:52 static/js/impala/stats/csv_keys.js:53
+#: static/js/impala/stats/csv_keys.js:52 static/js/impala/stats/csv_keys.js:53 static/js/zamboni/stats-all.js:15333 static/js/zamboni/stats-all.js:15334 static/js/zamboni/stats-min.js:4
 msgid "Homepage Featured"
 msgstr "Strona polecanych"
 
-#: static/js/impala/stats/csv_keys.js:54 static/js/impala/stats/csv_keys.js:55
+#: static/js/impala/stats/csv_keys.js:54 static/js/impala/stats/csv_keys.js:55 static/js/zamboni/stats-all.js:15335 static/js/zamboni/stats-all.js:15336 static/js/zamboni/stats-min.js:4
 msgid "Homepage Up and Coming"
 msgstr "Strona najnowszych"
 
-#: static/js/impala/stats/csv_keys.js:56
+#: static/js/impala/stats/csv_keys.js:56 static/js/zamboni/stats-all.js:15337 static/js/zamboni/stats-min.js:4
 msgid "Homepage Most Popular"
 msgstr "Strona najpopularniejszych"
 
-#: static/js/impala/stats/csv_keys.js:57 static/js/impala/stats/csv_keys.js:59
+#: static/js/impala/stats/csv_keys.js:57 static/js/impala/stats/csv_keys.js:59 static/js/zamboni/stats-all.js:15338 static/js/zamboni/stats-all.js:15340 static/js/zamboni/stats-min.js:4
 msgid "Detail Page"
 msgstr "Strona dodatku"
 
-#: static/js/impala/stats/csv_keys.js:58 static/js/impala/stats/csv_keys.js:60
+#: static/js/impala/stats/csv_keys.js:58 static/js/impala/stats/csv_keys.js:60 static/js/zamboni/stats-all.js:15339 static/js/zamboni/stats-all.js:15341 static/js/zamboni/stats-min.js:4
 msgid "Detail Page (bottom)"
 msgstr "Strona dodatku (przycisk)"
 
-#: static/js/impala/stats/csv_keys.js:61
+#: static/js/impala/stats/csv_keys.js:61 static/js/zamboni/stats-all.js:15342 static/js/zamboni/stats-min.js:4
 msgid "Detail Page (Development Channel)"
 msgstr "Strona dodatku (kanał rozwoju)"
 
-#: static/js/impala/stats/csv_keys.js:62 static/js/impala/stats/csv_keys.js:63 static/js/impala/stats/csv_keys.js:64
+#: static/js/impala/stats/csv_keys.js:62 static/js/impala/stats/csv_keys.js:63 static/js/impala/stats/csv_keys.js:64 static/js/zamboni/stats-all.js:15343 static/js/zamboni/stats-all.js:15344
+#: static/js/zamboni/stats-all.js:15345 static/js/zamboni/stats-min.js:4
 msgid "Often Used With"
 msgstr "Często używane z"
 
-#: static/js/impala/stats/csv_keys.js:65 static/js/impala/stats/csv_keys.js:66
+#: static/js/impala/stats/csv_keys.js:65 static/js/impala/stats/csv_keys.js:66 static/js/zamboni/stats-all.js:15346 static/js/zamboni/stats-all.js:15347 static/js/zamboni/stats-min.js:4
 msgid "Others By Author"
 msgstr "Inne tego autora"
 
-#: static/js/impala/stats/csv_keys.js:67 static/js/impala/stats/csv_keys.js:68
+#: static/js/impala/stats/csv_keys.js:67 static/js/impala/stats/csv_keys.js:68 static/js/zamboni/stats-all.js:15348 static/js/zamboni/stats-all.js:15349 static/js/zamboni/stats-min.js:4
 msgid "Dependencies"
 msgstr "Zależności"
 
-#: static/js/impala/stats/csv_keys.js:69 static/js/impala/stats/csv_keys.js:70
+#: static/js/impala/stats/csv_keys.js:69 static/js/impala/stats/csv_keys.js:70 static/js/zamboni/stats-all.js:15350 static/js/zamboni/stats-all.js:15351 static/js/zamboni/stats-min.js:4
 msgid "Upsell"
 msgstr "Usprawnienia"
 
-#: static/js/impala/stats/csv_keys.js:71
+#: static/js/impala/stats/csv_keys.js:71 static/js/zamboni/stats-all.js:15352 static/js/zamboni/stats-min.js:4
 msgid "Meet the Developer"
 msgstr "Poznaj autora"
 
-#: static/js/impala/stats/csv_keys.js:72
+#: static/js/impala/stats/csv_keys.js:72 static/js/zamboni/stats-all.js:15353 static/js/zamboni/stats-min.js:4
 msgid "User Profile"
 msgstr "Profil użytkownika"
 
-#: static/js/impala/stats/csv_keys.js:73
+#: static/js/impala/stats/csv_keys.js:73 static/js/zamboni/stats-all.js:15354 static/js/zamboni/stats-min.js:4
 msgid "Version History"
 msgstr "Historia wersji"
 
-#: static/js/impala/stats/csv_keys.js:75
+#: static/js/impala/stats/csv_keys.js:75 static/js/zamboni/stats-all.js:15356 static/js/zamboni/stats-min.js:4
 msgid "Sharing"
 msgstr "Udostępnianie"
 
-#: static/js/impala/stats/csv_keys.js:76
+#: static/js/impala/stats/csv_keys.js:76 static/js/zamboni/stats-all.js:15357 static/js/zamboni/stats-min.js:4
 msgid "Category Pages"
 msgstr "Strony kategorii"
 
-#: static/js/impala/stats/csv_keys.js:77
+#: static/js/impala/stats/csv_keys.js:77 static/js/zamboni/stats-all.js:15358 static/js/zamboni/stats-min.js:4
 msgid "Collections"
 msgstr "Kolekcje"
 
-#: static/js/impala/stats/csv_keys.js:78 static/js/impala/stats/csv_keys.js:79
+#: static/js/impala/stats/csv_keys.js:78 static/js/impala/stats/csv_keys.js:79 static/js/zamboni/stats-all.js:15359 static/js/zamboni/stats-all.js:15360 static/js/zamboni/stats-min.js:4
 msgid "Category Landing Featured Carousel"
 msgstr "Karuzela polecanych"
 
-#: static/js/impala/stats/csv_keys.js:80 static/js/impala/stats/csv_keys.js:81
+#: static/js/impala/stats/csv_keys.js:80 static/js/impala/stats/csv_keys.js:81 static/js/zamboni/stats-all.js:15361 static/js/zamboni/stats-all.js:15362 static/js/zamboni/stats-min.js:4
 msgid "Category Landing Top Rated"
 msgstr "Najwyżej oceniane"
 
-#: static/js/impala/stats/csv_keys.js:82 static/js/impala/stats/csv_keys.js:83
+#: static/js/impala/stats/csv_keys.js:82 static/js/impala/stats/csv_keys.js:83 static/js/zamboni/stats-all.js:15363 static/js/zamboni/stats-all.js:15364 static/js/zamboni/stats-min.js:5
 msgid "Category Landing Most Popular"
 msgstr "Najpopularniejsze"
 
-#: static/js/impala/stats/csv_keys.js:84 static/js/impala/stats/csv_keys.js:85
+#: static/js/impala/stats/csv_keys.js:84 static/js/impala/stats/csv_keys.js:85 static/js/zamboni/stats-all.js:15365 static/js/zamboni/stats-all.js:15366 static/js/zamboni/stats-min.js:5
 msgid "Category Landing Recently Added"
 msgstr "Ostatnio dodane"
 
-#: static/js/impala/stats/csv_keys.js:86 static/js/impala/stats/csv_keys.js:87
+#: static/js/impala/stats/csv_keys.js:86 static/js/impala/stats/csv_keys.js:87 static/js/zamboni/stats-all.js:15367 static/js/zamboni/stats-all.js:15368 static/js/zamboni/stats-min.js:5
 msgid "Browse Listing Featured Sort"
 msgstr "Wykaz przeglądania polecanych"
 
-#: static/js/impala/stats/csv_keys.js:88 static/js/impala/stats/csv_keys.js:89
+#: static/js/impala/stats/csv_keys.js:88 static/js/impala/stats/csv_keys.js:89 static/js/zamboni/stats-all.js:15369 static/js/zamboni/stats-all.js:15370 static/js/zamboni/stats-min.js:5
 msgid "Browse Listing Users Sort"
 msgstr "Wykaz przeglądania liczby użytkowników"
 
-#: static/js/impala/stats/csv_keys.js:90 static/js/impala/stats/csv_keys.js:91
+#: static/js/impala/stats/csv_keys.js:90 static/js/impala/stats/csv_keys.js:91 static/js/zamboni/stats-all.js:15371 static/js/zamboni/stats-all.js:15372 static/js/zamboni/stats-min.js:5
 msgid "Browse Listing Rating Sort"
 msgstr "Wykaz przeglądania ocen"
 
-#: static/js/impala/stats/csv_keys.js:92 static/js/impala/stats/csv_keys.js:93
+#: static/js/impala/stats/csv_keys.js:92 static/js/impala/stats/csv_keys.js:93 static/js/zamboni/stats-all.js:15373 static/js/zamboni/stats-all.js:15374 static/js/zamboni/stats-min.js:5
 msgid "Browse Listing Created Sort"
 msgstr "Wykaz przeglądania utworzonych"
 
-#: static/js/impala/stats/csv_keys.js:94 static/js/impala/stats/csv_keys.js:95
+#: static/js/impala/stats/csv_keys.js:94 static/js/impala/stats/csv_keys.js:95 static/js/zamboni/stats-all.js:15375 static/js/zamboni/stats-all.js:15376 static/js/zamboni/stats-min.js:5
 msgid "Browse Listing Name Sort"
 msgstr "Wykaz przeglądania nazw"
 
-#: static/js/impala/stats/csv_keys.js:96 static/js/impala/stats/csv_keys.js:97
+#: static/js/impala/stats/csv_keys.js:96 static/js/impala/stats/csv_keys.js:97 static/js/zamboni/stats-all.js:15377 static/js/zamboni/stats-all.js:15378 static/js/zamboni/stats-min.js:5
 msgid "Browse Listing Popular Sort"
 msgstr "Wykaz przeglądania popularnych"
 
-#: static/js/impala/stats/csv_keys.js:98 static/js/impala/stats/csv_keys.js:99
+#: static/js/impala/stats/csv_keys.js:98 static/js/impala/stats/csv_keys.js:99 static/js/zamboni/stats-all.js:15379 static/js/zamboni/stats-all.js:15380 static/js/zamboni/stats-min.js:5
 msgid "Browse Listing Updated Sort"
 msgstr "Wykaz przeglądania ostatnio zaktualizowanych"
 
-#: static/js/impala/stats/csv_keys.js:100 static/js/impala/stats/csv_keys.js:101
+#: static/js/impala/stats/csv_keys.js:100 static/js/impala/stats/csv_keys.js:101 static/js/zamboni/stats-all.js:15381 static/js/zamboni/stats-all.js:15382 static/js/zamboni/stats-min.js:5
 msgid "Browse Listing Up and Coming Sort"
 msgstr "Wykaz przeglądania obiecujących"
 
-#: static/js/impala/stats/csv_keys.js:105
+#: static/js/impala/stats/csv_keys.js:105 static/js/zamboni/stats-all.js:15386 static/js/zamboni/stats-min.js:5
 msgid "Total Amount Contributed"
 msgstr "Cała kwota dotacji"
 
-#: static/js/impala/stats/csv_keys.js:106
+#: static/js/impala/stats/csv_keys.js:106 static/js/zamboni/stats-all.js:15387 static/js/zamboni/stats-min.js:5
 msgid "Average Contribution"
 msgstr "Średnia dotacji"
 
-#: static/js/impala/stats/csv_keys.js:115
+#: static/js/impala/stats/csv_keys.js:115 static/js/zamboni/stats-all.js:15396 static/js/zamboni/stats-min.js:5
 msgid "Usage"
 msgstr "Użycie"
 
-#: static/js/impala/stats/csv_keys.js:118
+#: static/js/impala/stats/csv_keys.js:118 static/js/zamboni/stats-all.js:15399 static/js/zamboni/stats-min.js:5
 msgid "Firefox"
 msgstr "Firefox"
 
-#: static/js/impala/stats/csv_keys.js:119
+#: static/js/impala/stats/csv_keys.js:119 static/js/zamboni/stats-all.js:15400 static/js/zamboni/stats-min.js:5
 msgid "Mozilla"
 msgstr "Mozilla"
 
-#: static/js/impala/stats/csv_keys.js:120
+#: static/js/impala/stats/csv_keys.js:120 static/js/zamboni/stats-all.js:15401 static/js/zamboni/stats-min.js:5
 msgid "Thunderbird"
 msgstr "Thunderbird"
 
-#: static/js/impala/stats/csv_keys.js:121
+#: static/js/impala/stats/csv_keys.js:121 static/js/zamboni/stats-all.js:15402 static/js/zamboni/stats-min.js:5
 msgid "Sunbird"
 msgstr "Sunbird"
 
-#: static/js/impala/stats/csv_keys.js:122
+#: static/js/impala/stats/csv_keys.js:122 static/js/zamboni/stats-all.js:15403 static/js/zamboni/stats-min.js:5
 msgid "SeaMonkey"
 msgstr "SeaMonkey"
 
-#: static/js/impala/stats/csv_keys.js:123
+#: static/js/impala/stats/csv_keys.js:123 static/js/zamboni/stats-all.js:15404 static/js/zamboni/stats-min.js:5
 msgid "Fennec"
 msgstr "Fennec"
 
-#: static/js/impala/stats/csv_keys.js:124
+#: static/js/impala/stats/csv_keys.js:124 static/js/zamboni/stats-all.js:15405 static/js/zamboni/stats-min.js:5
 msgid "Android"
 msgstr "Android"
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:129
+#: static/js/impala/stats/csv_keys.js:129 static/js/zamboni/stats-all.js:15410 static/js/zamboni/stats-min.js:5
 msgid "Downloads and Daily Users, last {0} days"
 msgstr "Liczba pobrań i dziennych użytkowników – ostatnie {0} dni"
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:131
+#: static/js/impala/stats/csv_keys.js:131 static/js/zamboni/stats-all.js:15412 static/js/zamboni/stats-min.js:5
 msgid "Downloads and Daily Users from {0} to {1}"
 msgstr "Liczba pobrań i dziennych użytkowników od {0} do {1} dni"
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:135
+#: static/js/impala/stats/csv_keys.js:135 static/js/zamboni/stats-all.js:15416 static/js/zamboni/stats-min.js:5
 msgid "Installs and Daily Users, last {0} days"
 msgstr "Instalacje i dzienni użytkownicy, ostatnie {0} dni"
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:137
+#: static/js/impala/stats/csv_keys.js:137 static/js/zamboni/stats-all.js:15418 static/js/zamboni/stats-min.js:5
 msgid "Installs and Daily Users from {0} to {1}"
 msgstr "Instalacje i dzienni użytkownicy od {0} do {1}"
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:141
+#: static/js/impala/stats/csv_keys.js:141 static/js/zamboni/stats-all.js:15422 static/js/zamboni/stats-min.js:5
 msgid "Downloads, last {0} days"
 msgstr "Liczba pobrań – ostatnie {0} dni"
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:143
+#: static/js/impala/stats/csv_keys.js:143 static/js/zamboni/stats-all.js:15424 static/js/zamboni/stats-min.js:5
 msgid "Downloads from {0} to {1}"
 msgstr "Liczba pobrań od {0} do {1} dni"
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:147
+#: static/js/impala/stats/csv_keys.js:147 static/js/zamboni/stats-all.js:15428 static/js/zamboni/stats-min.js:5
 msgid "Daily Users, last {0} days"
 msgstr "Liczba dziennych użytkowników – ostatnie {0} dni"
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:149
+#: static/js/impala/stats/csv_keys.js:149 static/js/zamboni/stats-all.js:15430 static/js/zamboni/stats-min.js:5
 msgid "Daily Users from {0} to {1}"
 msgstr "Liczba dziennych użytkowników od {0} do {1} dni"
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:153
+#: static/js/impala/stats/csv_keys.js:153 static/js/zamboni/stats-all.js:15434 static/js/zamboni/stats-min.js:5
 msgid "Applications, last {0} days"
 msgstr "Programy – ostatnie {0} dni"
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:155
+#: static/js/impala/stats/csv_keys.js:155 static/js/zamboni/stats-all.js:15436 static/js/zamboni/stats-min.js:5
 msgid "Applications from {0} to {1}"
 msgstr "Programy od {0} do {1} dni"
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:159
+#: static/js/impala/stats/csv_keys.js:159 static/js/zamboni/stats-all.js:15440 static/js/zamboni/stats-min.js:5
 msgid "Platforms, last {0} days"
 msgstr "Systemy operacyjne – ostatnie {0} dni"
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:161
+#: static/js/impala/stats/csv_keys.js:161 static/js/zamboni/stats-all.js:15442 static/js/zamboni/stats-min.js:5
 msgid "Platforms from {0} to {1}"
 msgstr "Systemy operacyjne od {0} do {1} dni"
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:165
+#: static/js/impala/stats/csv_keys.js:165 static/js/zamboni/stats-all.js:15446 static/js/zamboni/stats-min.js:5
 msgid "Languages, last {0} days"
 msgstr "Języki – ostatnie {0} dni"
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:167
+#: static/js/impala/stats/csv_keys.js:167 static/js/zamboni/stats-all.js:15448 static/js/zamboni/stats-min.js:5
 msgid "Languages from {0} to {1}"
 msgstr "Języki od {0} do {1} dni"
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:171
+#: static/js/impala/stats/csv_keys.js:171 static/js/zamboni/stats-all.js:15452 static/js/zamboni/stats-min.js:5
 msgid "Add-on Versions, last {0} days"
 msgstr "Wersje dodatku – ostatnie {0} dni"
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:173
+#: static/js/impala/stats/csv_keys.js:173 static/js/zamboni/stats-all.js:15454 static/js/zamboni/stats-min.js:5
 msgid "Add-on Versions from {0} to {1}"
 msgstr "Wersje dodatku od {0} do {1} dni"
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:177
+#: static/js/impala/stats/csv_keys.js:177 static/js/zamboni/stats-all.js:15458 static/js/zamboni/stats-min.js:5
 msgid "Add-on Status, last {0} days"
 msgstr "Status dodatku – ostatnie {0} dni"
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:179
+#: static/js/impala/stats/csv_keys.js:179 static/js/zamboni/stats-all.js:15460 static/js/zamboni/stats-min.js:5
 msgid "Add-on Status from {0} to {1}"
 msgstr "Status dodatku od {0} do {1} dni"
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:183
+#: static/js/impala/stats/csv_keys.js:183 static/js/zamboni/stats-all.js:15464 static/js/zamboni/stats-min.js:5
 msgid "Download Sources, last {0} days"
 msgstr "Źródła pobierania – ostatnie {0} dni"
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:185
+#: static/js/impala/stats/csv_keys.js:185 static/js/zamboni/stats-all.js:15466 static/js/zamboni/stats-min.js:5
 msgid "Download Sources from {0} to {1}"
 msgstr "Źródła pobierania od {0} do {1}"
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:189
+#: static/js/impala/stats/csv_keys.js:189 static/js/zamboni/stats-all.js:15470 static/js/zamboni/stats-min.js:5
 msgid "Contributions, last {0} days"
 msgstr "Dotacje – ostatnie {0} dni"
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:191
+#: static/js/impala/stats/csv_keys.js:191 static/js/zamboni/stats-all.js:15472 static/js/zamboni/stats-min.js:5
 msgid "Contributions from {0} to {1}"
 msgstr "Dotacje od {0} do {1}"
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:195
+#: static/js/impala/stats/csv_keys.js:195 static/js/zamboni/stats-all.js:15476 static/js/zamboni/stats-min.js:5
 msgid "Site Metrics, last {0} days"
 msgstr "Statystyki strony, ostatnie {0} dni"
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:197
+#: static/js/impala/stats/csv_keys.js:197 static/js/zamboni/stats-all.js:15478 static/js/zamboni/stats-min.js:5
 msgid "Site Metrics from {0} to {1}"
 msgstr "Statystyki strony od {0} do {1}"
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:201
+#: static/js/impala/stats/csv_keys.js:201 static/js/zamboni/stats-all.js:15482 static/js/zamboni/stats-min.js:5
 msgid "Add-ons in Use, last {0} days"
 msgstr "Używane dodatki, ostatnie {0} dni"
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:203
+#: static/js/impala/stats/csv_keys.js:203 static/js/zamboni/stats-all.js:15484 static/js/zamboni/stats-min.js:5
 msgid "Add-ons in Use from {0} to {1}"
 msgstr "Używane dodatki od {0} do {1}"
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:207
+#: static/js/impala/stats/csv_keys.js:207 static/js/zamboni/stats-all.js:15488 static/js/zamboni/stats-min.js:5
 msgid "Add-ons Downloaded, last {0} days"
 msgstr "Pobrane dodatki, ostatnie {0} dni"
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:209
+#: static/js/impala/stats/csv_keys.js:209 static/js/zamboni/stats-all.js:15490 static/js/zamboni/stats-min.js:5
 msgid "Add-ons Downloaded from {0} to {1}"
 msgstr "Pobrane dodatki od {0} do {1}"
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:213
+#: static/js/impala/stats/csv_keys.js:213 static/js/zamboni/stats-all.js:15494 static/js/zamboni/stats-min.js:5
 msgid "Add-ons Created, last {0} days"
 msgstr "Utworzone dodatki, ostatnie {0} dni"
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:215
+#: static/js/impala/stats/csv_keys.js:215 static/js/zamboni/stats-all.js:15496 static/js/zamboni/stats-min.js:5
 msgid "Add-ons Created from {0} to {1}"
 msgstr "Utworzone dodatki od {0} do {1}"
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:219
+#: static/js/impala/stats/csv_keys.js:219 static/js/zamboni/stats-all.js:15500 static/js/zamboni/stats-min.js:5
 msgid "Add-ons Updated, last {0} days"
 msgstr "Zaktualizowane dodatki, ostatnie {0} dni"
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:221
+#: static/js/impala/stats/csv_keys.js:221 static/js/zamboni/stats-all.js:15502 static/js/zamboni/stats-min.js:5
 msgid "Add-ons Updated from {0} to {1}"
 msgstr "Zaktualizowane dodatki od {0} do {1}"
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:225
+#: static/js/impala/stats/csv_keys.js:225 static/js/zamboni/stats-all.js:15506 static/js/zamboni/stats-min.js:5
 msgid "Reviews Written, last {0} days"
 msgstr "Napisane opinie, ostatnie {0} dni"
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:227
+#: static/js/impala/stats/csv_keys.js:227 static/js/zamboni/stats-all.js:15508 static/js/zamboni/stats-min.js:5
 msgid "Reviews Written from {0} to {1}"
 msgstr "Napisane opinie do {0} do {1}"
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:231
+#: static/js/impala/stats/csv_keys.js:231 static/js/zamboni/stats-all.js:15512 static/js/zamboni/stats-min.js:5
 msgid "User Signups, last {0} days"
 msgstr "Logowania użytkowników, ostatnie {0} dni."
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:233
+#: static/js/impala/stats/csv_keys.js:233 static/js/zamboni/stats-all.js:15514 static/js/zamboni/stats-min.js:5
 msgid "User Signups from {0} to {1}"
 msgstr "Logowania użytkowników od {0} do {1}"
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:237
+#: static/js/impala/stats/csv_keys.js:237 static/js/zamboni/stats-all.js:15518 static/js/zamboni/stats-min.js:5
 msgid "Collections Created, last {0} days"
 msgstr "Utworzone kolekcje, ostatnie {0} dni"
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:239
+#: static/js/impala/stats/csv_keys.js:239 static/js/zamboni/stats-all.js:15520 static/js/zamboni/stats-min.js:5
 msgid "Collections Created from {0} to {1}"
 msgstr "Utworzone kolekcje od {0} do {1}"
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:243
+#: static/js/impala/stats/csv_keys.js:243 static/js/zamboni/stats-all.js:15524 static/js/zamboni/stats-min.js:5
 msgid "Subscribers, last {0} days"
 msgstr "Subskrybenci, ostatnie {0} dni"
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:245
+#: static/js/impala/stats/csv_keys.js:245 static/js/zamboni/stats-all.js:15526 static/js/zamboni/stats-min.js:5
 msgid "Subscribers from {0} to {1}"
 msgstr "Subskrybenci od {0} do {1}"
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:249
+#: static/js/impala/stats/csv_keys.js:249 static/js/zamboni/stats-all.js:15530 static/js/zamboni/stats-min.js:5
 msgid "Ratings, last {0} days"
 msgstr "Oceny, ostatnie {0} dni"
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:251
+#: static/js/impala/stats/csv_keys.js:251 static/js/zamboni/stats-all.js:15532 static/js/zamboni/stats-min.js:5
 msgid "Ratings from {0} to {1}"
 msgstr "Oceny od {0} do {1}"
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:255
+#: static/js/impala/stats/csv_keys.js:255 static/js/zamboni/stats-all.js:15536 static/js/zamboni/stats-min.js:5
 msgid "Sales, last {0} days"
 msgstr "Sprzedaże, ostatnie {0} dni"
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:257
+#: static/js/impala/stats/csv_keys.js:257 static/js/zamboni/stats-all.js:15538 static/js/zamboni/stats-min.js:5
 msgid "Sales from {0} to {1}"
 msgstr "Sprzedaże od {0} do {1}"
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:261
+#: static/js/impala/stats/csv_keys.js:261 static/js/zamboni/stats-all.js:15542 static/js/zamboni/stats-min.js:5
 msgid "Installs, last {0} days"
 msgstr "Instalacje ostatnie {0} dni"
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:263
+#: static/js/impala/stats/csv_keys.js:263 static/js/zamboni/stats-all.js:15544 static/js/zamboni/stats-min.js:5
 msgid "Installs from {0} to {1}"
 msgstr "Instalacje od {0} do {1}"
 
 #. L10n: {0} and {1} are integers.
-#: static/js/impala/stats/csv_keys.js:269
+#: static/js/impala/stats/csv_keys.js:269 static/js/zamboni/stats-all.js:15550 static/js/zamboni/stats-min.js:5
 msgid "<b>{0}</b> in last {1} days"
 msgstr "<b>{0}</b> w ciągu ostatnich {1} dni"
 
 #. L10n: {0} is an integer and {1} and {2} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:271 static/js/impala/stats/csv_keys.js:277
+#: static/js/impala/stats/csv_keys.js:271 static/js/impala/stats/csv_keys.js:277 static/js/zamboni/stats-all.js:15552 static/js/zamboni/stats-all.js:15558 static/js/zamboni/stats-min.js:5
 msgid "<b>{0}</b> from {1} to {2}"
 msgstr "<b>{0}</b> od {1} do {2}"
 
 #. L10n: {0} and {1} are integers.
-#: static/js/impala/stats/csv_keys.js:275
+#: static/js/impala/stats/csv_keys.js:275 static/js/zamboni/stats-all.js:15556 static/js/zamboni/stats-min.js:5
 msgid "<b>{0}</b> average in last {1} days"
 msgstr "Średnio <b>{0}</b> w ciągu ostatnich {1} dni"
 
-#: static/js/impala/stats/overview.js:19
+#: static/js/impala/stats/overview.js:19 static/js/zamboni/stats-all.js:16469 static/js/zamboni/stats-min.js:5
 msgid "No data available."
 msgstr "Brak dostępnych danych."
 
-#: static/js/impala/stats/table.js:74
+#: static/js/impala/stats/table.js:74 static/js/zamboni/stats-all.js:17209 static/js/zamboni/stats-min.js:5
 msgid "Date"
 msgstr "Data"
 
-#: static/js/impala/stats/topchart.js:96
+#: static/js/impala/stats/topchart.js:96 static/js/zamboni/stats-all.js:16600 static/js/zamboni/stats-min.js:5
 msgid "Other"
 msgstr "Inny"
 
-#: static/js/zamboni/admin_validation.js:24 static/js/zamboni/devhub.js:1229 static/js/zamboni/editors.js:295
+#: static/js/zamboni/admin-all.js:180 static/js/zamboni/admin-min.js:1 static/js/zamboni/admin_validation.js:24 static/js/zamboni/devhub-all.js:2408 static/js/zamboni/devhub-min.js:2
+#: static/js/zamboni/devhub.js:1229 static/js/zamboni/editors-all.js:15576 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:295
 msgid "Select an application first"
 msgstr "Wybierz najpierw program"
 
-#: static/js/zamboni/admin_validation.js:51
+#: static/js/zamboni/admin-all.js:207 static/js/zamboni/admin-min.js:1 static/js/zamboni/admin_validation.js:51
 msgid "Set {0} add-on to a max version of {1} and email the author."
 msgid_plural "Set {0} add-ons to a max version of {1} and email the authors."
 msgstr[0] "Ustaw {0} dodatek na najwyższą wersję programu {1} i powiadom autora."
 msgstr[1] "Ustaw {0} dodatki na najwyższą wersję programu {1} i powiadom autorów."
-msgstr[2] "Ustaw {0} dodatków na najwyższą wersję programu {1} i powiadom autorów."
 
-#: static/js/zamboni/admin_validation.js:54
+#: static/js/zamboni/admin-all.js:210 static/js/zamboni/admin-min.js:1 static/js/zamboni/admin_validation.js:54
 msgid "Email author of {2} add-on which failed validation."
 msgid_plural "Email authors of {2} add-ons which failed validation."
 msgstr[0] "Poinformuj mailowo autora {2} dodatku, który nie przeszedł weryfikacji."
 msgstr[1] "Poinformuj mailowo autora {2} dodatków, które nie przeszły weryfikacji."
-msgstr[2] "Poinformuj mailowo autora {2} dodatków, które nie przeszły weryfikacji."
 
-#. L10n: {0} is an app name like Firefox.
-#: static/js/zamboni/buttons.js:66
-msgid "Accept and Install"
-msgstr "Akceptuję, zainstaluj"
-
-#: static/js/zamboni/buttons.js:66
-msgid "Add to {0}"
-msgstr "Zainstaluj"
-
-#: static/js/zamboni/buttons.js:71
-msgid "Download Now"
-msgstr "Pobierz"
-
-#: static/js/zamboni/buttons.js:112
-msgid "Add-on has not been updated to support default-to-compatible."
-msgstr "Dodatek nie został zaktualizowany, by wspierać domyślną kompatybilność."
-
-#: static/js/zamboni/buttons.js:117
-msgid "You need to be using Firefox 10.0 or higher."
-msgstr "Musisz używać Firefoksa 10 lub nowszego."
-
-#: static/js/zamboni/buttons.js:129
-msgid "Mozilla has marked this version as incompatible with your Firefox version."
-msgstr "Mozilla oznaczyła tę wersję jako niekompatybilną z twoją wersją Firefoksa."
-
-#. L10n: {0} is an platform like Windows or Linux.
-#: static/js/zamboni/buttons.js:210
-msgid "Install for {0} anyway"
-msgstr "Mimo wszystko zainstaluj dla systemu (0)"
-
-#: static/js/zamboni/buttons.js:210
-msgid "Download for {0} anyway"
-msgstr "Mimo wszystko pobierz dla (0)"
-
-#: static/js/zamboni/buttons.js:267
-msgid "Not available for your platform"
-msgstr "Niedostępny dla twojego systemu"
-
-#. L10n: {0} is an app name, {1} is the app version.
-#: static/js/zamboni/buttons.js:278 static/js/zamboni/buttons.js:315
-msgid "Not available for {0} {1}"
-msgstr "Niedostępny dla {0} {1}"
-
-#: static/js/zamboni/buttons.js:341
-msgid "Works with {app} {min} - {max}"
-msgstr "Działa z {app} {min} - {max}"
-
-#: static/js/zamboni/buttons.js:343
-msgid "View other versions"
-msgstr "Zobacz inne wersje"
-
-#: static/js/zamboni/buttons.js:391
-msgid "Only with Firefox — Get Firefox Now!"
-msgstr ""
-
-#: static/js/zamboni/buttons.js:507 static/js/zamboni/mobile/buttons.js:43
-msgid "Sorry, you need a Mozilla-based browser (such as Firefox) to install a search plugin."
-msgstr "Przepraszamy. Aby zainstalować wtyczkę wyszukiwarki, potrzebna jest przeglądarka zbudowana w oparciu o technologię Mozilli – taka jak np. Firefox."
-
-#: static/js/zamboni/collections.js:229
-msgid "Adding to Favorites&hellip;"
-msgstr "Dodawanie do ulubionych&hellip;"
-
-#: static/js/zamboni/collections.js:232
-msgid "Removing Favorite&hellip;"
-msgstr "Usuwanie z ulubionych&hellip;"
-
-#: static/js/zamboni/collections.js:235
-msgid "Add to Favorites"
-msgstr "Dodaj do ulubionych"
-
-#: static/js/zamboni/collections.js:238
-msgid "Remove from Favorites"
-msgstr "Usuń z ulubionych"
-
-#: static/js/zamboni/collections.js:303
-msgid "Pending"
-msgstr "Oczekujące"
-
-#: static/js/zamboni/collections.js:304
-msgid "Add a comment"
-msgstr "Dodaj komentarz"
-
-#: static/js/zamboni/collections.js:304
-msgid "Comment"
-msgstr "Komentarz"
-
-#: static/js/zamboni/collections.js:305
-msgid "Remove this add-on from the collection"
-msgstr "Usuń ten dodatek z kolekcji"
-
-#: static/js/zamboni/collections.js:305 static/js/zamboni/collections.js:334
-msgid "Remove"
-msgstr "Usuń"
-
-#: static/js/zamboni/collections.js:334
-msgid "Remove this user as a contributor"
-msgstr "Usuń tego użytkownika z listy autorów"
-
-#: static/js/zamboni/collections.js:346
-msgid "An email address is required."
-msgstr "Adres e-mail jest wymagany."
-
-#: static/js/zamboni/collections.js:364
-msgid "You cannot add yourself as a contributor."
-msgstr "Nie możesz dodać siebie jako współautora."
-
-#: static/js/zamboni/collections.js:366
-msgid "You have already added that user."
-msgstr "Ten użytkownik został już dodany."
-
-#: static/js/zamboni/collections.js:573
-msgid "Add to favorites"
-msgstr "Dodaj do ulubionych"
-
-#: static/js/zamboni/collections.js:577
-msgid "Remove from favorites"
-msgstr "Usuń z ulubionych"
-
-#: static/js/zamboni/collections.js:604
-msgid "Stop following"
-msgstr "Zaprzestań obserwacji"
-
-#: static/js/zamboni/devhub.js:110
+#: static/js/zamboni/devhub-all.js:1289 static/js/zamboni/devhub-min.js:1 static/js/zamboni/devhub.js:110
 msgid "Your browser does not support the video tag"
 msgstr "Twoja przeglądarka nie obsługuje znacznika video"
 
-#: static/js/zamboni/devhub.js:371
+#: static/js/zamboni/devhub-all.js:1550 static/js/zamboni/devhub-min.js:1 static/js/zamboni/devhub.js:371
 msgid "Changes Saved"
 msgstr "Zmiany zostały zapisane"
 
-#: static/js/zamboni/devhub.js:387
+#: static/js/zamboni/devhub-all.js:1566 static/js/zamboni/devhub-min.js:1 static/js/zamboni/devhub.js:387
 msgid "Enter a new author's email address"
 msgstr "Podaj nowy adres e-mail autora"
 
-#: static/js/zamboni/devhub.js:536
+#: static/js/zamboni/devhub-all.js:1715 static/js/zamboni/devhub-min.js:1 static/js/zamboni/devhub.js:536
 msgid "There was an error uploading your file."
 msgstr "Wystąpił problem z przesłaniem twojego pliku."
 
-#: static/js/zamboni/devhub.js:681
+#: static/js/zamboni/devhub-all.js:1860 static/js/zamboni/devhub-min.js:1 static/js/zamboni/devhub.js:681
 msgid "{files} file"
 msgid_plural "{files} files"
 msgstr[0] "{files} plik"
 msgstr[1] "{files} pliki"
-msgstr[2] "{files} plików"
 
-#: static/js/zamboni/devhub.js:684
+#: static/js/zamboni/devhub-all.js:1863 static/js/zamboni/devhub-min.js:1 static/js/zamboni/devhub.js:684
 msgid "{reviews} user review"
 msgid_plural "{reviews} user reviews"
 msgstr[0] "{reviews} opinia użytkownika"
 msgstr[1] "{reviews} opinie użytkowników"
-msgstr[2] "{reviews} opinii użytkowników"
 
-#: static/js/zamboni/devhub.js:796
+#: static/js/zamboni/devhub-all.js:1975 static/js/zamboni/devhub-min.js:2 static/js/zamboni/devhub.js:796
 msgid "Learn more"
 msgstr "Dowiedz się więcej"
 
-#: static/js/zamboni/devhub.js:800
+#: static/js/zamboni/devhub-all.js:1979 static/js/zamboni/devhub-min.js:2 static/js/zamboni/devhub.js:800
 msgid "Example"
 msgstr "Przykład"
 
-#: static/js/zamboni/devhub.js:1130
+#: static/js/zamboni/devhub-all.js:2309 static/js/zamboni/devhub-min.js:2 static/js/zamboni/devhub.js:1130
 msgid "Image changes being processed"
 msgstr "Przetwarzanie zmian obrazka…"
 
-#: static/js/zamboni/devhub.js:1280
+#: static/js/zamboni/devhub-all.js:2459 static/js/zamboni/devhub-min.js:2 static/js/zamboni/devhub.js:1280
 msgid "Must be a valid e-mail address."
 msgstr "Prawidłowy adres e-mail musi zostać wprowadzony."
+
+#: static/js/zamboni/devhub-all.js:2613 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:80
+msgid "All tests passed successfully."
+msgstr "Wszystkie testy zostały zaliczone."
+
+#: static/js/zamboni/devhub-all.js:2616 static/js/zamboni/devhub-all.js:3011 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:83 static/js/zamboni/validator.js:478
+msgid "These tests were not run."
+msgstr "Testy te nie zostały uruchomione."
+
+#: static/js/zamboni/devhub-all.js:2664 static/js/zamboni/devhub-all.js:2677 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:131 static/js/zamboni/validator.js:144
+msgid "Tests"
+msgstr "Testy"
+
+#: static/js/zamboni/devhub-all.js:2779 static/js/zamboni/devhub-all.js:3108 static/js/zamboni/devhub-all.js:3127 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:246
+#: static/js/zamboni/validator.js:575 static/js/zamboni/validator.js:594
+msgid "Error"
+msgstr "Błąd"
+
+#: static/js/zamboni/devhub-all.js:2780 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:247
+msgid "Warning"
+msgstr "Ostrzeżenie"
+
+#: static/js/zamboni/devhub-all.js:2794 static/js/zamboni/devhub-min.js:2 static/js/zamboni/files-all.js:5657 static/js/zamboni/files-min.js:3 static/js/zamboni/files.js:411
+#: static/js/zamboni/validator.js:261
+msgid "Ignore this message in future updates"
+msgstr "Ignoruj ten komunikat w przyszłych aktualizacjach."
+
+#: static/js/zamboni/devhub-all.js:2817 static/js/zamboni/devhub-min.js:2 static/js/zamboni/files-all.js:5663 static/js/zamboni/files-min.js:3 static/js/zamboni/files.js:417
+#: static/js/zamboni/validator.js:284
+msgid "Severity for automated signing:"
+msgstr ""
+
+#: static/js/zamboni/devhub-all.js:2832 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:299
+msgid "Suggestions for passing automated signing:"
+msgstr ""
+
+#: static/js/zamboni/devhub-all.js:2920 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:387
+msgid "Compatibility Tests"
+msgstr "Testy kompatybilności"
+
+#: static/js/zamboni/devhub-all.js:2999 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:466
+msgid "Add-on failed validation."
+msgstr "Dodatek nie przeszedł weryfikacji."
+
+#: static/js/zamboni/devhub-all.js:3001 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:468
+msgid "Add-on passed validation."
+msgstr "Dodatek przeszedł weryfikację."
+
+#: static/js/zamboni/devhub-all.js:3014 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:481
+msgid "{0} error"
+msgid_plural "{0} errors"
+msgstr[0] "{0} błąd"
+msgstr[1] "{0} błędy"
+
+#: static/js/zamboni/devhub-all.js:3016 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:483
+msgid "{0} warning"
+msgid_plural "{0} warnings"
+msgstr[0] "{0} ostrzeżenie"
+msgstr[1] "{0} ostrzeżenia"
+
+#: static/js/zamboni/devhub-all.js:3018 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:485
+msgid "{0} notice"
+msgid_plural "{0} notices"
+msgstr[0] "{0} informacja"
+msgstr[1] "{0} informacje"
+
+#: static/js/zamboni/devhub-all.js:3110 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:577
+msgid "Validation task could not complete or completed with errors"
+msgstr "Nie można dokończyć weryfikacji lub zadanie zostało zakończone z błędami"
+
+#: static/js/zamboni/devhub-all.js:3128 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:595
+msgid "Internal server error"
+msgstr "Wewnętrzny błąd serwera"
 
 #: static/js/zamboni/devhub_search.js:8
 msgid "No results found."
 msgstr "Nic nie znaleziono."
 
-#: static/js/zamboni/editors.js:121
+#: static/js/zamboni/editors-all.js:15402 static/js/zamboni/editors-min.js:4 static/js/zamboni/editors.js:121
 msgid "{name} was viewing this page first."
 msgstr "Strona została wyświetlona po raz pierwszy przez {name}."
 
-#: static/js/zamboni/editors.js:171
+#: static/js/zamboni/editors-all.js:15452 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:171
 msgid "Receipt checked by app."
 msgstr "Potwierdzenie zostało sprawdzone przez aplikację."
 
-#: static/js/zamboni/editors.js:173
+#: static/js/zamboni/editors-all.js:15454 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:173
 msgid "Receipt was not checked by app."
 msgstr "Potwierdzenie nie zostało sprawdzone przez aplikację."
 
-#: static/js/zamboni/editors.js:244
+#: static/js/zamboni/editors-all.js:15525 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:244
 msgid "{name} was viewing this add-on first."
 msgstr "Użytkownik {name} oglądał ten dodatek pierwszy."
 
-#: static/js/zamboni/editors.js:255
+#: static/js/zamboni/editors-all.js:15536 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:255
 msgid "Loading&hellip;"
 msgstr "Wczytywanie &hellip;"
 
-#: static/js/zamboni/editors.js:260
+#: static/js/zamboni/editors-all.js:15541 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:260
 msgid "Version Notes"
 msgstr "Informacje o wersji"
 
-#: static/js/zamboni/editors.js:265
+#: static/js/zamboni/editors-all.js:15546 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:265
 msgid "Notes for Reviewers"
 msgstr "Informacje dla recenzentów"
 
-#: static/js/zamboni/editors.js:270
+#: static/js/zamboni/editors-all.js:15551 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:270
 msgid "No version notes found"
 msgstr "Brak informacji o wersji"
 
-#: static/js/zamboni/editors.js:330
+#: static/js/zamboni/editors-all.js:15611 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:330
 msgid "Average Reviews"
 msgstr ""
 
-#: static/js/zamboni/editors.js:386
+#: static/js/zamboni/editors-all.js:15667 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:386
 msgid "Number of Reviews"
 msgstr ""
 
-#: static/js/zamboni/editors.js:445
+#: static/js/zamboni/editors-all.js:15726 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:445
 msgid "Error loading translation"
 msgstr "Błąd wczytywania tłumaczenia"
 
-#: static/js/zamboni/files.js:411 static/js/zamboni/validator.js:261
-msgid "Ignore this message in future updates"
-msgstr "Ignoruj ten komunikat w przyszłych aktualizacjach."
-
-#: static/js/zamboni/files.js:417 static/js/zamboni/validator.js:284
-msgid "Severity for automated signing:"
-msgstr ""
-
-#: static/js/zamboni/global.js:410
-msgid "Loading..."
-msgstr "Wczytywanie…"
-
-#. L10n: {0} is the number of characters left.
-#: static/js/zamboni/global.js:474
-msgid "<b>{0}</b> character left."
-msgid_plural "<b>{0}</b> characters left."
-msgstr[0] "Pozostał <b>{0}</b> znak."
-msgstr[1] "Pozostały <b>{0}</b> znaki."
-msgstr[2] "Pozostało <b>{0}</b> znaków."
-
-#: static/js/zamboni/init.js:28
-msgid "This feature is temporarily disabled while we perform website maintenance. Please check back a little later."
-msgstr "W trakcie wykonywania serwisu witryny ta funkcja jest tymczasowo wyłączona. Sprawdź ponownie nieco później."
-
-#: static/js/zamboni/l10n.js:45
-msgid "Remove this localization"
-msgstr "Usuń tę lokalizację"
-
-#: static/js/zamboni/password-strength.js:20
-msgid "Password strength:"
-msgstr "Siła hasła:"
-
-#: static/js/zamboni/password-strength.js:26
-msgid "At least {0} character left."
-msgid_plural "At least {0} characters left."
-msgstr[0] "Pozostał przynajmniej {0} znak."
-msgstr[1] "Pozostały przynajmniej {0} znaki."
-msgstr[2] "Pozostało przynajmniej {0} znaków."
-
-#: static/js/zamboni/themes_review.js:176
-msgid "Requested Info"
-msgstr "Żądana informacja"
-
-#: static/js/zamboni/themes_review.js:177
-msgid "Flagged"
-msgstr "Oznaczono"
-
-#: static/js/zamboni/themes_review.js:178
-msgid "Duplicate"
-msgstr "Duplikat"
-
-#: static/js/zamboni/themes_review.js:179
-msgid "Rejected"
-msgstr "Odrzucono"
-
-#: static/js/zamboni/themes_review.js:180
-msgid "Approved"
-msgstr "Zaakceptowano"
-
-#: static/js/zamboni/themes_review.js:424
-msgid "No results found"
-msgstr ""
-
-#: static/js/zamboni/themes_review_templates.js:31
+#: static/js/zamboni/editors-all.js:15975 static/js/zamboni/editors-min.js:5 static/js/zamboni/themes_review_templates.js:31
 msgid "Theme"
 msgstr ""
 
-#: static/js/zamboni/themes_review_templates.js:33
+#: static/js/zamboni/editors-all.js:15977 static/js/zamboni/editors-min.js:5 static/js/zamboni/themes_review_templates.js:33
 msgid "Reviewer"
 msgstr ""
 
-#: static/js/zamboni/themes_review_templates.js:35
+#: static/js/zamboni/editors-all.js:15979 static/js/zamboni/editors-min.js:5 static/js/zamboni/themes_review_templates.js:35
 msgid "Status"
 msgstr ""
 
-#: static/js/zamboni/validator.js:80
-msgid "All tests passed successfully."
-msgstr "Wszystkie testy zostały zaliczone."
+#: static/js/zamboni/editors-all.js:16196 static/js/zamboni/editors-min.js:5 static/js/zamboni/themes_review.js:176
+msgid "Requested Info"
+msgstr "Żądana informacja"
 
-#: static/js/zamboni/validator.js:83 static/js/zamboni/validator.js:478
-msgid "These tests were not run."
-msgstr "Testy te nie zostały uruchomione."
+#: static/js/zamboni/editors-all.js:16197 static/js/zamboni/editors-min.js:5 static/js/zamboni/themes_review.js:177
+msgid "Flagged"
+msgstr "Oznaczono"
 
-#: static/js/zamboni/validator.js:131 static/js/zamboni/validator.js:144
-msgid "Tests"
-msgstr "Testy"
+#: static/js/zamboni/editors-all.js:16198 static/js/zamboni/editors-min.js:5 static/js/zamboni/themes_review.js:178
+msgid "Duplicate"
+msgstr "Duplikat"
 
-#: static/js/zamboni/validator.js:246 static/js/zamboni/validator.js:575 static/js/zamboni/validator.js:594
-msgid "Error"
-msgstr "Błąd"
+#: static/js/zamboni/editors-all.js:16199 static/js/zamboni/editors-min.js:5 static/js/zamboni/themes_review.js:179
+msgid "Rejected"
+msgstr "Odrzucono"
 
-#: static/js/zamboni/validator.js:247
-msgid "Warning"
-msgstr "Ostrzeżenie"
+#: static/js/zamboni/editors-all.js:16200 static/js/zamboni/editors-min.js:5 static/js/zamboni/themes_review.js:180
+msgid "Approved"
+msgstr "Zaakceptowano"
 
-#: static/js/zamboni/validator.js:299
-msgid "Suggestions for passing automated signing:"
+#: static/js/zamboni/editors-all.js:16444 static/js/zamboni/editors-min.js:5 static/js/zamboni/themes_review.js:424
+msgid "No results found"
 msgstr ""
 
-#: static/js/zamboni/validator.js:387
-msgid "Compatibility Tests"
-msgstr "Testy kompatybilności"
-
-#: static/js/zamboni/validator.js:466
-msgid "Add-on failed validation."
-msgstr "Dodatek nie przeszedł weryfikacji."
-
-#: static/js/zamboni/validator.js:468
-msgid "Add-on passed validation."
-msgstr "Dodatek przeszedł weryfikację."
-
-#: static/js/zamboni/validator.js:481
-msgid "{0} error"
-msgid_plural "{0} errors"
-msgstr[0] "{0} błąd"
-msgstr[1] "{0} błędy"
-msgstr[2] "{0} błędów"
-
-#: static/js/zamboni/validator.js:483
-msgid "{0} warning"
-msgid_plural "{0} warnings"
-msgstr[0] "{0} ostrzeżenie"
-msgstr[1] "{0} ostrzeżenia"
-msgstr[2] "{0} ostrzeżeń"
-
-#: static/js/zamboni/validator.js:485
-msgid "{0} notice"
-msgid_plural "{0} notices"
-msgstr[0] "{0} informacja"
-msgstr[1] "{0} informacje"
-msgstr[2] "{0} informacji"
-
-#: static/js/zamboni/validator.js:577
-msgid "Validation task could not complete or completed with errors"
-msgstr "Nie można dokończyć weryfikacji lub zadanie zostało zakończone z błędami"
-
-#: static/js/zamboni/validator.js:595
-msgid "Internal server error"
-msgstr "Wewnętrzny błąd serwera"
-
-#: static/js/zamboni/mobile/buttons.js:52
+#: static/js/zamboni/mobile-all.js:15186 static/js/zamboni/mobile/buttons.js:52
 msgid "Not Updated for {0} {1}"
 msgstr "Niezaktualizowany dla {0} {1}"
 
-#: static/js/zamboni/mobile/buttons.js:53
+#: static/js/zamboni/mobile-all.js:15187 static/js/zamboni/mobile/buttons.js:53
 msgid "Requires Newer Version of {0}"
 msgstr "Wymaga najnowszej wersji {0}"
 
-#: static/js/zamboni/mobile/buttons.js:54
+#: static/js/zamboni/mobile-all.js:15188 static/js/zamboni/mobile/buttons.js:54
 msgid "Unreviewed"
 msgstr "Niesprawdzony"
 
-#: static/js/zamboni/mobile/buttons.js:55
+#: static/js/zamboni/mobile-all.js:15189 static/js/zamboni/mobile/buttons.js:55
 msgid "Experimental <span>(Learn More)</span>"
 msgstr "Eksperymentalny <span>(Dowiedz się więcej)</span>"
 
-#: static/js/zamboni/mobile/buttons.js:56 static/js/zamboni/mobile/buttons.js:57
+#: static/js/zamboni/mobile-all.js:15190 static/js/zamboni/mobile-all.js:15191 static/js/zamboni/mobile/buttons.js:56 static/js/zamboni/mobile/buttons.js:57
 msgid "Not Available for {0}"
 msgstr "Niedostępny dla {0}"
 
-#: static/js/zamboni/mobile/buttons.js:58
+#: static/js/zamboni/mobile-all.js:15192 static/js/zamboni/mobile/buttons.js:58
 msgid "Experimental"
 msgstr "Eksperymentalny"
 
-#: static/js/zamboni/mobile/buttons.js:59
+#: static/js/zamboni/mobile-all.js:15193 static/js/zamboni/mobile/buttons.js:59
 msgid "Themes Require Newer Version of {0}"
 msgstr "Motyw wymaga nowszej wersji: {0}"
 
-#: static/js/zamboni/mobile/buttons.js:60
+#: static/js/zamboni/mobile-all.js:15194 static/js/zamboni/mobile/buttons.js:60
 msgid "Themes Require {0}"
 msgstr "Motyw wymaga: {0}"
 
-#: static/js/zamboni/mobile/buttons.js:105
+#: static/js/zamboni/mobile-all.js:15239 static/js/zamboni/mobile/buttons.js:105
 msgid "Installing..."
 msgstr "Instalacja…"
 
-#: static/js/zamboni/mobile/buttons.js:125
+#: static/js/zamboni/mobile-all.js:15259 static/js/zamboni/mobile/buttons.js:125
 msgid "This add-on has been preliminarily reviewed by Mozilla."
 msgstr "Ten dodatek został wstępnie sprawdzony przez Mozillę."
 
-#: static/js/zamboni/mobile/buttons.js:250
+#: static/js/zamboni/mobile-all.js:15384 static/js/zamboni/mobile/buttons.js:250
 msgid "Keep it"
 msgstr "Zatrzymaj"
 
-#: static/js/zamboni/mobile/general.js:344
+#: static/js/zamboni/mobile-all.js:16049 static/js/zamboni/mobile-min.js:6 static/js/zamboni/mobile/general.js:344
 msgid "You're trying it on!"
 msgstr "Próbujesz to!"
 
-#: static/js/zamboni/mobile/general.js:356
+#: static/js/zamboni/mobile-all.js:16061 static/js/zamboni/mobile-min.js:6 static/js/zamboni/mobile/general.js:356
 msgid "Added to Firefox"
 msgstr "Dodano do Firefoksa"
-

--- a/locale/pt/LC_MESSAGES/django.po
+++ b/locale/pt/LC_MESSAGES/django.po
@@ -1,8 +1,9 @@
+
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2016-02-24 21:23+0000\n"
+"POT-Creation-Date: 2016-04-18 15:40+0000\n"
 "PO-Revision-Date: 2015-10-15 01:01+0000\n"
 "Last-Translator: Cláudio <cesperanc@gmail.com>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -11,60 +12,60 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Generated-By: Babel 2.2.0\n"
 
-#: src/olympia/accounts/views.py:52
+#: src/olympia/accounts/views.py:54
 msgid "Your log in attempt could not be parsed. Please try again."
 msgstr ""
 
-#: src/olympia/accounts/views.py:54
+#: src/olympia/accounts/views.py:56
 msgid "Your Firefox Account could not be found. Please try again."
 msgstr ""
 
-#: src/olympia/accounts/views.py:55
+#: src/olympia/accounts/views.py:57
 msgid "You could not be logged in. Please try again."
 msgstr ""
 
-#: src/olympia/accounts/views.py:57
+#: src/olympia/accounts/views.py:59
 msgid "Your account has already been migrated to Firefox Accounts."
 msgstr ""
 
-#: src/olympia/accounts/views.py:59
+#: src/olympia/accounts/views.py:61
 msgid "Your Firefox Account already exists on this site."
 msgstr ""
 
-#: src/olympia/accounts/views.py:108
+#: src/olympia/accounts/views.py:110
 msgid "Great job!"
 msgstr ""
 
-#: src/olympia/accounts/views.py:109
+#: src/olympia/accounts/views.py:111
 msgid "You can now log in to Add-ons with your Firefox Account."
 msgstr ""
 
-#: src/olympia/accounts/views.py:121
+#: src/olympia/accounts/views.py:123
 msgid "Need help?"
 msgstr ""
 
-#: src/olympia/addons/buttons.py:180
+#: src/olympia/addons/buttons.py:177
 msgid "Download Now"
 msgstr "Descarregar agora"
 
-#: src/olympia/addons/buttons.py:182
+#: src/olympia/addons/buttons.py:179
 msgid "Download"
 msgstr "Descarregar"
 
 #. L10n: please keep &nbsp; in the string so &rarr; does not wrap.
-#: src/olympia/addons/buttons.py:186
+#: src/olympia/addons/buttons.py:183
 msgid "Continue to Download&nbsp;&rarr;"
 msgstr "Continuar para a transferência&nbsp;&rarr;"
 
-#: src/olympia/addons/buttons.py:202 src/olympia/addons/helpers.py:35 src/olympia/addons/views.py:319 src/olympia/addons/templates/addons/impala/details.html:114
+#: src/olympia/addons/buttons.py:199 src/olympia/addons/helpers.py:35 src/olympia/addons/views.py:333 src/olympia/addons/templates/addons/impala/details.html:111
 #: src/olympia/addons/templates/addons/impala/listing/items.html:17 src/olympia/addons/templates/addons/mobile/home.html:40 src/olympia/amo/templates/amo/side_nav.html:6
-#: src/olympia/amo/templates/amo/side_nav.html:10 src/olympia/amo/templates/amo/site_nav.html:2 src/olympia/amo/templates/amo/site_nav.html:55 src/olympia/bandwagon/views.py:95
-#: src/olympia/browse/views.py:54 src/olympia/browse/views.py:68 src/olympia/browse/views.py:235 src/olympia/browse/templates/browse/impala/category_landing.html:22
+#: src/olympia/amo/templates/amo/side_nav.html:10 src/olympia/amo/templates/amo/site_nav.html:2 src/olympia/amo/templates/amo/site_nav.html:53 src/olympia/bandwagon/views.py:95
+#: src/olympia/browse/views.py:54 src/olympia/browse/views.py:68 src/olympia/browse/views.py:202 src/olympia/browse/templates/browse/impala/category_landing.html:22
 #: src/olympia/browse/templates/browse/personas/mobile/category_landing.html:26
 msgid "Featured"
 msgstr "Em destaque"
 
-#: src/olympia/addons/buttons.py:221
+#: src/olympia/addons/buttons.py:218
 msgid "Add to {0}"
 msgstr "Adicionar a {0}"
 
@@ -112,39 +113,39 @@ msgid_plural "All tags must be at least {0} characters."
 msgstr[0] "Todas as etiquetas têm de ter pelo menos {0} caracter."
 msgstr[1] "Todas as etiquetas têm de ter pelo menos {0} caracteres."
 
-#: src/olympia/addons/forms.py:234
+#: src/olympia/addons/forms.py:238
 msgid "Categories cannot be changed while your add-on is featured for this application."
 msgstr "As categorias não podem ser alteradas enquanto o seu extra estiver a ser destacado para esta aplicação."
 
 #. L10n: {0} is the number of categories.
-#: src/olympia/addons/forms.py:238
+#: src/olympia/addons/forms.py:242
 msgid "You can have only {0} category."
 msgid_plural "You can have only {0} categories."
 msgstr[0] "Apenas pode ter {0} categoria."
 msgstr[1] "Apenas pode ter {0} categorias."
 
-#: src/olympia/addons/forms.py:246
+#: src/olympia/addons/forms.py:250
 msgid "The miscellaneous category cannot be combined with additional categories."
 msgstr "A categoria diversos não pode ser combinada com categorias adicionais."
 
-#: src/olympia/addons/forms.py:369
+#: src/olympia/addons/forms.py:374
 #, python-format
 msgid "Before changing your default locale you must have a name, summary, and description in that locale. You are missing %s."
 msgstr "Antes de alterar o seu idioma por omissão tem de ter um nome, resumo e uma descrição nesse idioma. Falta %s."
 
-#: src/olympia/addons/forms.py:484 src/olympia/addons/forms.py:575
+#: src/olympia/addons/forms.py:455 src/olympia/addons/forms.py:546
 msgid "A license must be selected."
 msgstr "Tem de ser selecionada uma licença."
 
-#: src/olympia/addons/forms.py:556
+#: src/olympia/addons/forms.py:527
 msgid "Give Your Theme a Name."
 msgstr "Dê um nome ao seu tema."
 
-#: src/olympia/addons/forms.py:562 src/olympia/devhub/templates/devhub/personas/submit.html:53
+#: src/olympia/addons/forms.py:533 src/olympia/devhub/templates/devhub/personas/submit.html:53
 msgid "Describe your Theme."
 msgstr "Descreva o seu tema."
 
-#: src/olympia/addons/forms.py:704
+#: src/olympia/addons/forms.py:675
 msgid "Enter a new author's email address"
 msgstr "Introduza o novo endereço de email do autor"
 
@@ -152,37 +153,37 @@ msgstr "Introduza o novo endereço de email do autor"
 msgid "Not Reviewed"
 msgstr "Não revisto"
 
-#: src/olympia/addons/models.py:301
+#: src/olympia/addons/models.py:298
 msgid "Users have the option of contributing more or less than this amount."
 msgstr "Os utilizadores têm a opção de contribuir com mais ou menos do que esta quantia."
 
-#: src/olympia/addons/models.py:309
-msgid "Users will always be asked in the Add-ons Manager (Firefox 4 and above)"
-msgstr "Os utilizadores serão sempre questionados no Gestor de Extras (Firefox 4 e superiores)"
+#: src/olympia/addons/models.py:306
+msgid "Users will always be asked in the Add-ons Manager (Firefox 4 and above). Only applies to desktop."
+msgstr ""
 
-#: src/olympia/addons/models.py:1804 src/olympia/addons/templates/addons/details_box.html:55 src/olympia/devhub/templates/devhub/index.html:92
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:102
+#: src/olympia/addons/models.py:1802 src/olympia/addons/templates/addons/details_box.html:55 src/olympia/devhub/templates/devhub/index.html:92
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:89
 msgid "Listed"
 msgstr "Listado"
 
-#: src/olympia/addons/views.py:320 src/olympia/browse/templates/browse/personas/mobile/category_landing.html:27
+#: src/olympia/addons/views.py:334 src/olympia/browse/templates/browse/personas/mobile/category_landing.html:27
 msgid "Popular"
 msgstr "Popular"
 
-#: src/olympia/addons/views.py:321 src/olympia/browse/views.py:238 src/olympia/browse/views.py:280 src/olympia/browse/views.py:482
+#: src/olympia/addons/views.py:335 src/olympia/browse/views.py:205 src/olympia/browse/views.py:247 src/olympia/browse/views.py:449
 msgid "Recently Added"
 msgstr "Adicionado recentemente"
 
-#: src/olympia/addons/views.py:322 src/olympia/bandwagon/views.py:99 src/olympia/browse/views.py:60 src/olympia/browse/views.py:71 src/olympia/search/forms.py:16 src/olympia/search/forms.py:91
+#: src/olympia/addons/views.py:336 src/olympia/bandwagon/views.py:99 src/olympia/browse/views.py:60 src/olympia/browse/views.py:71 src/olympia/search/forms.py:16 src/olympia/search/forms.py:91
 msgid "Recently Updated"
 msgstr "Atualizado recentemente"
 
 #. l10n: {0} is the addon name
-#: src/olympia/addons/views.py:520
+#: src/olympia/addons/views.py:534
 msgid "Contribution for {0}"
 msgstr "Contribuição para {0}"
 
-#: src/olympia/addons/views.py:613
+#: src/olympia/addons/views.py:627
 msgid "Abuse reported."
 msgstr "Abuso reportado."
 
@@ -249,9 +250,9 @@ msgstr "Contribuir"
 #: src/olympia/devhub/templates/devhub/addons/ajax_compat_update.html:36 src/olympia/devhub/templates/devhub/addons/profile.html:44 src/olympia/devhub/templates/devhub/addons/edit/admin.html:101
 #: src/olympia/devhub/templates/devhub/addons/edit/basic.html:152 src/olympia/devhub/templates/devhub/addons/edit/details.html:85 src/olympia/devhub/templates/devhub/addons/edit/support.html:67
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:166 src/olympia/devhub/templates/devhub/addons/forms_shared/media.html:149
-#: src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:44 src/olympia/devhub/templates/devhub/versions/add_file_modal.html:78 src/olympia/devhub/templates/devhub/versions/edit.html:139
-#: src/olympia/devhub/templates/devhub/versions/list.html:242 src/olympia/devhub/templates/devhub/versions/list.html:276 src/olympia/devhub/templates/devhub/versions/list.html:317
-#: src/olympia/devhub/templates/devhub/versions/list.html:351 src/olympia/reviews/templates/reviews/edit_review.html:16 src/olympia/translations/templates/translations/trans-menu.html:50
+#: src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:43 src/olympia/devhub/templates/devhub/versions/add_file_modal.html:58 src/olympia/devhub/templates/devhub/versions/edit.html:139
+#: src/olympia/devhub/templates/devhub/versions/list.html:239 src/olympia/devhub/templates/devhub/versions/list.html:281 src/olympia/devhub/templates/devhub/versions/list.html:315
+#: src/olympia/devhub/templates/devhub/versions/list.html:349 src/olympia/reviews/templates/reviews/edit_review.html:16 src/olympia/translations/templates/translations/trans-menu.html:50
 #: src/olympia/translations/templates/translations/trans-menu.html:62
 msgid "or"
 msgstr "ou"
@@ -289,19 +290,17 @@ msgstr "Ajude a suportar o desenvolvimento contínuo de <strong>%(addon_name)s</
 
 #: src/olympia/addons/templates/addons/contributions_lightbox.html:15
 #, python-format
-msgid ""
-"To show your support for <b>%(addon_name)s</b>, the developer asks that you make a donation to the <a href=\"%(charity_url)s\">%(charity_name)s</a> through <a href=\"%(paypal_url)s\">PayPal</a>."
-msgstr ""
-"Para mostrar o seu apoio a <b>%(addon_name)s</b>, o programador solicita que faça uma doação para <a href=\"%(charity_url)s\">%(charity_name)s</a> através do <a href=\"%(paypal_url)s\">PayPal</a>."
+msgid "To show your support for <b>%(addon_name)s</b>, the developer asks that you make a donation to the <a href=\"%(charity_url)s\">%(charity_name)s</a> through <a href=\"%(paypal_url)s\">PayPal</a>."
+msgstr "Para mostrar o seu apoio a <b>%(addon_name)s</b>, o programador solicita que faça uma doação para <a href=\"%(charity_url)s\">%(charity_name)s</a> através do <a href=\"%(paypal_url)s\">PayPal</a>."
 
 #: src/olympia/addons/templates/addons/contributions_lightbox.html:21
 #, python-format
 msgid ""
-"To show your support for <b>%(addon_name)s</b>, the developer asks that you make a small contribution to <a href=\"%(charity_url)s\">%(charity_name)s</a> through <a href=\"%(paypal_url)s\">PayPal</"
-"a>."
+"To show your support for <b>%(addon_name)s</b>, the developer asks that you make a small contribution to <a href=\"%(charity_url)s\">%(charity_name)s</a> through <a "
+"href=\"%(paypal_url)s\">PayPal</a>."
 msgstr ""
-"Para mostrar o seu apoio a <b>%(addon_name)s</b>, o programador solicita que faça uma pequena doação para <a href=\"%(charity_url)s\">%(charity_name)s</a> através do <a href=\"%(paypal_url)s"
-"\">PayPal</a>."
+"Para mostrar o seu apoio a <b>%(addon_name)s</b>, o programador solicita que faça uma pequena doação para <a href=\"%(charity_url)s\">%(charity_name)s</a> através do <a "
+"href=\"%(paypal_url)s\">PayPal</a>."
 
 #: src/olympia/addons/templates/addons/contributions_lightbox.html:30
 msgid "How much would you like to contribute?"
@@ -365,7 +364,7 @@ msgid "Add-on Information for {0}"
 msgstr "Informação do extra para {0}"
 
 #: src/olympia/addons/templates/addons/details_box.html:30 src/olympia/addons/templates/addons/persona_detail_table.html:3 src/olympia/addons/templates/addons/mobile/details.html:63
-#: src/olympia/addons/templates/addons/mobile/persona_detail_table.html:7 src/olympia/browse/views.py:459 src/olympia/devhub/views.py:75
+#: src/olympia/addons/templates/addons/mobile/persona_detail_table.html:7 src/olympia/browse/views.py:426 src/olympia/devhub/views.py:74
 msgid "Updated"
 msgstr "Atualizado"
 
@@ -384,11 +383,11 @@ msgstr "Funciona com"
 msgid "Visibility"
 msgstr "Visibilidade"
 
-#: src/olympia/addons/templates/addons/details_box.html:57 src/olympia/devhub/templates/devhub/index.html:94 src/olympia/devhub/templates/devhub/includes/addon_details.html:104
+#: src/olympia/addons/templates/addons/details_box.html:57 src/olympia/devhub/templates/devhub/index.html:94 src/olympia/devhub/templates/devhub/includes/addon_details.html:91
 msgid "Hidden"
 msgstr "Oculta"
 
-#: src/olympia/addons/templates/addons/details_box.html:59 src/olympia/devhub/templates/devhub/index.html:96 src/olympia/devhub/templates/devhub/includes/addon_details.html:106
+#: src/olympia/addons/templates/addons/details_box.html:59 src/olympia/devhub/templates/devhub/index.html:96 src/olympia/devhub/templates/devhub/includes/addon_details.html:93
 msgid "Unlisted"
 msgstr "Não listada"
 
@@ -396,13 +395,13 @@ msgstr "Não listada"
 msgid "Required Add-ons"
 msgstr "Extras necessários"
 
-#: src/olympia/addons/templates/addons/details_box.html:81 src/olympia/addons/templates/addons/persona_detail_table.html:15 src/olympia/browse/views.py:462 src/olympia/devhub/views.py:78
-#: src/olympia/devhub/views.py:85 src/olympia/discovery/templates/discovery/addons/detail.html:57 src/olympia/reviews/forms.py:62 src/olympia/reviews/templates/reviews/add.html:57
+#: src/olympia/addons/templates/addons/details_box.html:81 src/olympia/addons/templates/addons/persona_detail_table.html:15 src/olympia/browse/views.py:429 src/olympia/devhub/views.py:77
+#: src/olympia/devhub/views.py:84 src/olympia/discovery/templates/discovery/addons/detail.html:57 src/olympia/reviews/forms.py:62 src/olympia/reviews/templates/reviews/add.html:57
 #: src/olympia/reviews/templates/reviews/mobile/review_list.html:18
 msgid "Rating"
 msgstr "Classificação"
 
-#: src/olympia/addons/templates/addons/details_box.html:85 src/olympia/browse/views.py:461 src/olympia/devhub/views.py:77 src/olympia/devhub/views.py:84
+#: src/olympia/addons/templates/addons/details_box.html:85 src/olympia/browse/views.py:428 src/olympia/devhub/views.py:76 src/olympia/devhub/views.py:83
 #: src/olympia/stats/templates/stats/addon_report_menu.html:8 src/olympia/stats/templates/stats/collection_report_menu.html:18
 msgid "Downloads"
 msgstr "Transferências"
@@ -422,7 +421,7 @@ msgstr "Denúncias de abuso"
 
 #. The Privacy Policy for this add-on.
 #: src/olympia/addons/templates/addons/details_box.html:121 src/olympia/addons/templates/addons/privacy.html:19 src/olympia/addons/templates/addons/privacy.html:23
-#: src/olympia/addons/templates/addons/impala/button.html:43 src/olympia/addons/templates/addons/impala/details.html:307 src/olympia/devhub/templates/devhub/includes/policy_form.html:20
+#: src/olympia/addons/templates/addons/impala/button.html:43 src/olympia/addons/templates/addons/impala/details.html:312 src/olympia/devhub/templates/devhub/includes/policy_form.html:23
 #: src/olympia/templates/mobile/base_addons.html:87
 msgid "Privacy Policy"
 msgstr "Política de privacidade"
@@ -447,7 +446,7 @@ msgstr "Galeria de imagens"
 msgid "Developer Comments"
 msgstr "Comentários do programador"
 
-#: src/olympia/addons/templates/addons/details_box.html:199 src/olympia/addons/templates/addons/impala/details.html:259
+#: src/olympia/addons/templates/addons/details_box.html:199 src/olympia/addons/templates/addons/impala/details.html:264
 msgid "Development Channel"
 msgstr "Canal de desenvolvimento"
 
@@ -456,8 +455,8 @@ msgid ""
 "The Development Channel lets you test an experimental new version of this add-on before it's released to the general public. Once you install the development version, you will continue to get "
 "updates from this channel."
 msgstr ""
-"O Canal de Desenvolvimento permite que teste uma versão experimental do novo extra antes de este ser lançado para o público em geral. Depois de instalar a versão de desenvolvimento, vai continuar a "
-"receber as atualizações a partir deste canal."
+"O Canal de Desenvolvimento permite que teste uma versão experimental do novo extra antes de este ser lançado para o público em geral. Depois de instalar a versão de desenvolvimento, vai continuar a"
+" receber as atualizações a partir deste canal."
 
 #: src/olympia/addons/templates/addons/details_box.html:207
 msgid "Install development version"
@@ -471,7 +470,7 @@ msgstr ""
 "<strong>Cuidado:</strong> As versões de desenvolvimento deste extra não foram revistas pela Mozilla. Depois de instalar uma versão de desenvolvimento vai continuar a receber atualizações de "
 "desenvolvimento deste programador. Para parar de receber atualizações de desenvolvimento, reinstale a versão por omissão na ligação acima."
 
-#: src/olympia/addons/templates/addons/details_box.html:220 src/olympia/addons/templates/addons/impala/details.html:278
+#: src/olympia/addons/templates/addons/details_box.html:220 src/olympia/addons/templates/addons/impala/details.html:283
 msgid "Version {0}:"
 msgstr "Versão {0}:"
 
@@ -490,7 +489,7 @@ msgid "End-User License Agreement for {0}"
 msgstr "Acordo de licenciamento para o utilizador final para {0}"
 
 #: src/olympia/addons/templates/addons/eula.html:17 src/olympia/addons/templates/addons/eula.html:21 src/olympia/addons/templates/addons/impala/button.html:48
-#: src/olympia/addons/templates/addons/impala/details.html:316 src/olympia/devhub/templates/devhub/includes/policy_form.html:3 src/olympia/discovery/templates/discovery/addons/eula.html:11
+#: src/olympia/addons/templates/addons/impala/details.html:321 src/olympia/devhub/templates/devhub/includes/policy_form.html:3 src/olympia/discovery/templates/discovery/addons/eula.html:11
 msgid "End-User License Agreement"
 msgstr "Acordo de licenciamento para o utilizador final"
 
@@ -507,7 +506,7 @@ msgstr "Voltar para {0}…"
 msgid "Add-ons for {0}"
 msgstr "Extras para {0} "
 
-#: src/olympia/addons/templates/addons/home.html:10 src/olympia/addons/templates/addons/home.html:51 src/olympia/browse/templates/browse/impala/base_listing.html:11
+#: src/olympia/addons/templates/addons/home.html:10 src/olympia/addons/templates/addons/home.html:53 src/olympia/browse/templates/browse/impala/base_listing.html:11
 msgid "Featured Extensions"
 msgstr "Extensões em destaque"
 
@@ -515,29 +514,29 @@ msgstr "Extensões em destaque"
 msgid "Popular Extensions"
 msgstr "Extensões populares"
 
-#: src/olympia/addons/templates/addons/home.html:42 src/olympia/amo/templates/amo/side_nav.html:3 src/olympia/amo/templates/amo/side_nav.html:11 src/olympia/amo/templates/amo/site_nav.html:3
-#: src/olympia/amo/templates/amo/site_nav.html:25 src/olympia/browse/views.py:236 src/olympia/browse/views.py:281 src/olympia/browse/views.py:481
+#: src/olympia/addons/templates/addons/home.html:44 src/olympia/amo/templates/amo/side_nav.html:3 src/olympia/amo/templates/amo/side_nav.html:11 src/olympia/amo/templates/amo/site_nav.html:3
+#: src/olympia/amo/templates/amo/site_nav.html:25 src/olympia/browse/views.py:203 src/olympia/browse/views.py:248 src/olympia/browse/views.py:448
 msgid "Most Popular"
 msgstr "Mais populares"
 
-#: src/olympia/addons/templates/addons/home.html:43
+#: src/olympia/addons/templates/addons/home.html:45
 msgid "All »"
 msgstr "Tudo »"
 
-#: src/olympia/addons/templates/addons/home.html:52 src/olympia/addons/templates/addons/home.html:61 src/olympia/addons/templates/addons/home.html:70 src/olympia/addons/templates/addons/home.html:78
+#: src/olympia/addons/templates/addons/home.html:54 src/olympia/addons/templates/addons/home.html:63 src/olympia/addons/templates/addons/home.html:72 src/olympia/addons/templates/addons/home.html:80
 #: src/olympia/browse/templates/browse/impala/category_landing.html:36
 msgid "See all »"
 msgstr "Ver tudo »"
 
-#: src/olympia/addons/templates/addons/home.html:60
+#: src/olympia/addons/templates/addons/home.html:62
 msgid "Up &amp; Coming Extensions"
 msgstr "Próximas extensões"
 
-#: src/olympia/addons/templates/addons/home.html:69 src/olympia/browse/templates/browse/personas/category_landing.html:61 src/olympia/discovery/templates/discovery/pane.html:74
+#: src/olympia/addons/templates/addons/home.html:71 src/olympia/browse/templates/browse/personas/category_landing.html:61 src/olympia/discovery/templates/discovery/pane.html:74
 msgid "Featured Themes"
 msgstr "Temas em destaque"
 
-#: src/olympia/addons/templates/addons/home.html:77 src/olympia/bandwagon/templates/bandwagon/impala/collection_listing.html:5
+#: src/olympia/addons/templates/addons/home.html:79 src/olympia/bandwagon/templates/bandwagon/impala/collection_listing.html:5
 msgid "Featured Collections"
 msgstr "Coleções em destaque"
 
@@ -555,9 +554,9 @@ msgid "Updated {0}"
 msgstr "Atualizado {0}"
 
 #. {0} is a date.
-#: src/olympia/addons/templates/addons/macros.html:10 src/olympia/addons/templates/addons/macros.html:69 src/olympia/addons/templates/addons/persona_preview.html:21
-#: src/olympia/addons/templates/addons/listing/items_mobile.html:44 src/olympia/addons/templates/addons/listing/macros.html:39
-#: src/olympia/bandwagon/templates/bandwagon/collection_listing_items.html:37 src/olympia/bandwagon/templates/bandwagon/impala/collection_listing_items.html:37
+#: src/olympia/addons/templates/addons/macros.html:10 src/olympia/addons/templates/addons/macros.html:69 src/olympia/addons/templates/addons/persona_preview.html:22
+#: src/olympia/addons/templates/addons/listing/items_mobile.html:44 src/olympia/addons/templates/addons/listing/macros.html:39 src/olympia/bandwagon/templates/bandwagon/collection_listing_items.html:37
+#: src/olympia/bandwagon/templates/bandwagon/impala/collection_listing_items.html:37
 msgid "Added {0}"
 msgstr "Adicionado {0}"
 
@@ -576,15 +575,14 @@ msgstr[0] "%(num)s utilizador"
 msgstr[1] "%(num)s utilizadores"
 
 #. {0} is the number of downloads.
-#: src/olympia/addons/templates/addons/macros.html:53 src/olympia/addons/templates/addons/impala/details.html:61
+#: src/olympia/addons/templates/addons/macros.html:53 src/olympia/addons/templates/addons/impala/details.html:59
 msgid "{0} weekly download"
 msgid_plural "{0} weekly downloads"
 msgstr[0] "{0} transferência semanal"
 msgstr[1] "{0} transferências semanais"
 
 #. {0} is the number of users.
-#: src/olympia/addons/templates/addons/macros.html:61 src/olympia/addons/templates/addons/impala/details.html:54 src/olympia/compat/templates/compat/index.html:71
-#: src/olympia/zadmin/templates/zadmin/compat.html:67
+#: src/olympia/addons/templates/addons/macros.html:61 src/olympia/addons/templates/addons/impala/details.html:52 src/olympia/zadmin/templates/zadmin/compat.html:67
 msgid "{0} user"
 msgid_plural "{0} users"
 msgstr[0] "{0} utilizador"
@@ -602,7 +600,7 @@ msgstr "Pagamento concluído"
 msgid "Return to the addon."
 msgstr "Voltar ao extra."
 
-#: src/olympia/addons/templates/addons/persona_detail.html:17 src/olympia/addons/templates/addons/impala/details.html:106 src/olympia/addons/templates/addons/mobile/details.html:23
+#: src/olympia/addons/templates/addons/persona_detail.html:17 src/olympia/addons/templates/addons/impala/details.html:103 src/olympia/addons/templates/addons/mobile/details.html:23
 #: src/olympia/addons/templates/addons/mobile/persona_detail.html:21 src/olympia/discovery/templates/discovery/addons/base.html:27 src/olympia/editors/templates/editors/review.html:31
 msgid "by"
 msgstr "por"
@@ -646,34 +644,35 @@ msgstr "Utilizadores diários"
 msgid "License"
 msgstr "Licença"
 
-#: src/olympia/addons/templates/addons/persona_preview.html:12 src/olympia/constants/base.py:48
+#: src/olympia/addons/templates/addons/persona_preview.html:13 src/olympia/constants/base.py:48
 msgid "Awaiting Review"
 msgstr "A aguardar pela revisão"
 
-#: src/olympia/addons/templates/addons/persona_preview.html:14 src/olympia/amo/log.py:180 src/olympia/constants/base.py:42 src/olympia/editors/helpers.py:62
+#: src/olympia/addons/templates/addons/persona_preview.html:15 src/olympia/amo/log.py:180 src/olympia/constants/base.py:42 src/olympia/editors/helpers.py:62
 msgid "Rejected"
 msgstr "Rejeitado"
 
-#: src/olympia/addons/templates/addons/persona_preview.html:16 src/olympia/amo/log.py:159
+#: src/olympia/addons/templates/addons/persona_preview.html:17 src/olympia/amo/log.py:159
 msgid "Approved"
 msgstr "Aprovado"
 
 #. {0} is the number of users.
-#: src/olympia/addons/templates/addons/persona_preview.html:26 src/olympia/addons/templates/addons/listing/items_mobile.html:36 src/olympia/addons/templates/addons/listing/macros.html:31
+#: src/olympia/addons/templates/addons/persona_preview.html:27 src/olympia/addons/templates/addons/listing/items_mobile.html:36 src/olympia/addons/templates/addons/listing/macros.html:31
 msgid "<strong>{0}</strong> user"
 msgid_plural "<strong>{0}</strong> users"
 msgstr[0] "<strong>{0}</strong> utilizador"
 msgstr[1] "<strong>{0}</strong> utilizadores"
 
-#: src/olympia/addons/templates/addons/persona_preview.html:40
+#: src/olympia/addons/templates/addons/persona_preview.html:41
 msgid "Hover to Preview"
 msgstr "Passe para pré-visualizar"
 
-#: src/olympia/addons/templates/addons/persona_preview.html:46 src/olympia/addons/templates/addons/persona_preview.html:48 src/olympia/reviews/templates/reviews/add.html:15
+#: src/olympia/addons/templates/addons/persona_preview.html:47 src/olympia/addons/templates/addons/persona_preview.html:49 src/olympia/addons/templates/addons/persona_preview.html:97
+#: src/olympia/reviews/templates/reviews/add.html:15
 msgid "Add"
 msgstr "Adicionar"
 
-#: src/olympia/addons/templates/addons/persona_preview.html:57 src/olympia/bandwagon/templates/bandwagon/ajax_new.html:16 src/olympia/bandwagon/templates/bandwagon/edit.html:19
+#: src/olympia/addons/templates/addons/persona_preview.html:58 src/olympia/bandwagon/templates/bandwagon/ajax_new.html:16 src/olympia/bandwagon/templates/bandwagon/edit.html:19
 #: src/olympia/bandwagon/templates/bandwagon/includes/addedit.html:19 src/olympia/devhub/templates/devhub/addons/edit/admin.html:13 src/olympia/devhub/templates/devhub/addons/edit/basic.html:10
 #: src/olympia/devhub/templates/devhub/addons/edit/details.html:8 src/olympia/devhub/templates/devhub/addons/edit/media.html:6 src/olympia/devhub/templates/devhub/addons/edit/support.html:8
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:9 src/olympia/devhub/templates/devhub/addons/submit/describe.html:29 src/olympia/editors/templates/editors/review.html:257
@@ -682,21 +681,21 @@ msgstr "Editar"
 
 #. For datetime formatting, see the table on
 #. http://docs.python.org/library/datetime.html#strftime-and-strptime-behavior
-#: src/olympia/addons/templates/addons/persona_preview.html:66
+#: src/olympia/addons/templates/addons/persona_preview.html:67
 #, python-format
 msgid "%%Y-%%m-%%d"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/persona_preview.html:67
+#: src/olympia/addons/templates/addons/persona_preview.html:68
 msgid "by {0} on {1}"
 msgstr "por {0} em {1}"
 
-#: src/olympia/addons/templates/addons/persona_preview.html:75 src/olympia/reviews/helpers.py:17 src/olympia/reviews/templates/reviews/review_list.html:63
+#: src/olympia/addons/templates/addons/persona_preview.html:76 src/olympia/reviews/helpers.py:17 src/olympia/reviews/templates/reviews/review_list.html:63
 #: src/olympia/reviews/templates/reviews/reviews_link.html:21 src/olympia/reviews/templates/reviews/impala/reviews_link.html:16
 msgid "Not yet rated"
 msgstr "Ainda não foi avaliado"
 
-#: src/olympia/addons/templates/addons/persona_preview.html:78
+#: src/olympia/addons/templates/addons/persona_preview.html:79
 msgid "<b>{0}</b> users"
 msgstr "<b>{0}</b> utilizadores"
 
@@ -709,8 +708,8 @@ msgid "Learn more about Firefox"
 msgstr "Saber mais sobre o Firefox"
 
 #: src/olympia/addons/templates/addons/popups.html:22
-msgid "or <b><a class=\"installer\" href=\"{url}\">download anyway</a></b>"
-msgstr "ou <b><a class=\"installer\" href=\"{url}\">descarregar ainda assim</a></b>"
+msgid "or <b><a class=\"button installer\" href=\"{url}\">download anyway</a></b>"
+msgstr ""
 
 #: src/olympia/addons/templates/addons/popups.html:26
 msgid ""
@@ -771,8 +770,8 @@ msgstr "Este Persona necessita do %(app)s %(new_version)s. Está a utilizar o %(
 
 #: src/olympia/addons/templates/addons/popups.html:108
 msgid ""
-"<strong>Caution:</strong> This add-on has not been reviewed by Mozilla and can't be installed on release versions of Firefox 43 and above. Be careful when installing third-party software that might "
-"harm your computer."
+"<strong>Caution:</strong> This add-on has not been reviewed by Mozilla and can't be installed on release versions of Firefox 43 and above. Be careful when installing third-party software that might"
+" harm your computer."
 msgstr ""
 "<strong>Atenção:</strong> Este extra não foi revisto pela Mozilla e não pode ser instalado em versões de lançamento do Firefox 43 e superiores. Tenha cuidado quando instalar software de terceiros "
 "que pode danificar o seu computador."
@@ -811,7 +810,7 @@ msgstr ""
 "telefone se não tiver um.)"
 
 #: src/olympia/addons/templates/addons/report_abuse.html:6 src/olympia/addons/templates/addons/report_abuse_full.html:10 src/olympia/addons/templates/addons/impala/details-more.html:23
-#: src/olympia/addons/templates/addons/impala/details.html:328
+#: src/olympia/addons/templates/addons/impala/details.html:333
 msgid "Report Abuse"
 msgstr "Denunciar abuso"
 
@@ -832,9 +831,9 @@ msgstr "Enviar relatório"
 #: src/olympia/devhub/templates/devhub/addons/ajax_compat_update.html:36 src/olympia/devhub/templates/devhub/addons/profile.html:44 src/olympia/devhub/templates/devhub/addons/edit/admin.html:104
 #: src/olympia/devhub/templates/devhub/addons/edit/basic.html:155 src/olympia/devhub/templates/devhub/addons/edit/details.html:88 src/olympia/devhub/templates/devhub/addons/edit/support.html:70
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:169 src/olympia/devhub/templates/devhub/addons/forms_shared/media.html:152
-#: src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:44 src/olympia/devhub/templates/devhub/personas/edit.html:222 src/olympia/devhub/templates/devhub/versions/add_file_modal.html:79
-#: src/olympia/devhub/templates/devhub/versions/edit.html:140 src/olympia/devhub/templates/devhub/versions/list.html:208 src/olympia/devhub/templates/devhub/versions/list.html:242
-#: src/olympia/devhub/templates/devhub/versions/list.html:276 src/olympia/devhub/templates/devhub/versions/list.html:317 src/olympia/reviews/templates/reviews/edit_review.html:16
+#: src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:43 src/olympia/devhub/templates/devhub/personas/edit.html:222 src/olympia/devhub/templates/devhub/versions/add_file_modal.html:59
+#: src/olympia/devhub/templates/devhub/versions/edit.html:140 src/olympia/devhub/templates/devhub/versions/list.html:208 src/olympia/devhub/templates/devhub/versions/list.html:239
+#: src/olympia/devhub/templates/devhub/versions/list.html:281 src/olympia/devhub/templates/devhub/versions/list.html:315 src/olympia/reviews/templates/reviews/edit_review.html:16
 #: src/olympia/translations/templates/translations/trans-menu.html:50 src/olympia/translations/templates/translations/trans-menu.html:62 src/olympia/zadmin/templates/zadmin/validation.html:105
 msgid "Cancel"
 msgstr "Cancelar"
@@ -881,7 +880,7 @@ msgstr "Consulte a <a href=\"%(support)s\">secção de apoio</a> para obter assi
 msgid "Review Guidelines"
 msgstr "Orientações para comentários"
 
-#: src/olympia/addons/templates/addons/review_list_box.html:5 src/olympia/addons/templates/addons/impala/details-more.html:27 src/olympia/editors/helpers.py:921
+#: src/olympia/addons/templates/addons/review_list_box.html:5 src/olympia/addons/templates/addons/impala/details-more.html:27 src/olympia/editors/helpers.py:1001
 #: src/olympia/reviews/templates/reviews/add.html:14 src/olympia/reviews/templates/reviews/reply.html:14 src/olympia/reviews/templates/reviews/review_list.html:19
 #: src/olympia/reviews/templates/reviews/mobile/review_list.html:26
 msgid "Reviews"
@@ -972,103 +971,103 @@ msgid_plural "Other add-ons by these authors"
 msgstr[0] "Outros extras de %(author)s"
 msgstr[1] "Outros extras destes autores"
 
-#: src/olympia/addons/templates/addons/impala/details.html:41
+#: src/olympia/addons/templates/addons/impala/details.html:39
 #, python-format
 msgid "<span itemprop=\"ratingCount\">%(num)s</span> user review"
 msgid_plural "<span itemprop=\"ratingCount\">%(num)s</span> user reviews"
 msgstr[0] "<span itemprop=\"ratingCount\">%(num)s</span> análise de um utilizador"
 msgstr[1] "<span itemprop=\"ratingCount\">%(num)s</span> análises de utilizadores"
 
-#: src/olympia/addons/templates/addons/impala/details.html:69
+#: src/olympia/addons/templates/addons/impala/details.html:66
 msgid "View statistics"
 msgstr "Ver estatísticas"
 
-#: src/olympia/addons/templates/addons/impala/details.html:84
+#: src/olympia/addons/templates/addons/impala/details.html:81
 msgid "Manage"
 msgstr "Gerir"
 
 #. {0} is an add-on name.
-#: src/olympia/addons/templates/addons/impala/details.html:96
+#: src/olympia/addons/templates/addons/impala/details.html:93
 msgid "Icon of {0}"
 msgstr "Ícone de {0}"
 
-#: src/olympia/addons/templates/addons/impala/details.html:103 src/olympia/addons/templates/addons/impala/listing/items.html:14
+#: src/olympia/addons/templates/addons/impala/details.html:100 src/olympia/addons/templates/addons/impala/listing/items.html:14
 msgid "No Restart"
 msgstr "Sem reínicio"
 
-#: src/olympia/addons/templates/addons/impala/details.html:127
+#: src/olympia/addons/templates/addons/impala/details.html:124
 #, fuzzy, python-format
 msgid "Meet the Developer: <a href=\"%(url)s\">%(name)s</a>"
 msgid_plural "<a href=\"%(url)s\">Meet the Developers</a>"
 msgstr[0] "Conheça o programador: <a href=\"%(url)s\">%(name)s</a>"
 msgstr[1] "<a href=\"%(url)s\">Conheça os programadores</a>"
 
-#: src/olympia/addons/templates/addons/impala/details.html:137
+#: src/olympia/addons/templates/addons/impala/details.html:134
 msgid "Learn why {0} was created and find out what's next for this add-on."
 msgstr "Saiba porque é que {0} foi criado e saiba o que vem a seguir para este extra."
 
 #. {0} is an index.
-#: src/olympia/addons/templates/addons/impala/details.html:156
+#: src/olympia/addons/templates/addons/impala/details.html:161
 msgid "Add-on screenshot #{0}"
 msgstr "Captura de ecrã nº{0} do extra"
 
-#: src/olympia/addons/templates/addons/impala/details.html:182
+#: src/olympia/addons/templates/addons/impala/details.html:187
 msgid "Add-on home page"
 msgstr "Página do extra"
 
-#: src/olympia/addons/templates/addons/impala/details.html:185
+#: src/olympia/addons/templates/addons/impala/details.html:190
 msgid "Support site"
 msgstr "Página de ajuda"
 
-#: src/olympia/addons/templates/addons/impala/details.html:189
+#: src/olympia/addons/templates/addons/impala/details.html:194
 msgid "Support E-mail"
 msgstr "Email de suporte"
 
-#: src/olympia/addons/templates/addons/impala/details.html:194 src/olympia/devhub/models.py:378 src/olympia/devhub/templates/devhub/versions/list.html:12
+#: src/olympia/addons/templates/addons/impala/details.html:199 src/olympia/devhub/models.py:378 src/olympia/devhub/templates/devhub/versions/list.html:12
 #: src/olympia/versions/templates/versions/version.html:6 src/olympia/versions/templates/versions/mobile/version.html:6
 msgid "Version {0}"
 msgstr "Versão {0}"
 
-#: src/olympia/addons/templates/addons/impala/details.html:194
+#: src/olympia/addons/templates/addons/impala/details.html:199
 msgid "Info"
 msgstr "Informação"
 
-#: src/olympia/addons/templates/addons/impala/details.html:195 src/olympia/devhub/templates/devhub/includes/addon_details.html:129
+#: src/olympia/addons/templates/addons/impala/details.html:200 src/olympia/devhub/templates/devhub/includes/addon_details.html:116
 msgid "Last Updated:"
 msgstr "Última atualização:"
 
-#: src/olympia/addons/templates/addons/impala/details.html:200
+#: src/olympia/addons/templates/addons/impala/details.html:205
 #, python-format
 msgid "Released under <a target=\"_blank\" href=\"%(url)s\">%(name)s</a>"
 msgstr "Disponibilizado sob <a target=\"_blank\" href=\"%(url)s\">%(name)s</a>"
 
-#: src/olympia/addons/templates/addons/impala/details.html:201 src/olympia/addons/templates/addons/impala/details.html:206 src/olympia/amo/helpers.py:398 src/olympia/devhub/forms.py:142
+#: src/olympia/addons/templates/addons/impala/details.html:206 src/olympia/addons/templates/addons/impala/details.html:211 src/olympia/amo/helpers.py:398 src/olympia/devhub/forms.py:142
 #: src/olympia/devhub/forms.py:173 src/olympia/versions/templates/versions/version.html:40 src/olympia/versions/templates/versions/version.html:45
 msgid "Custom License"
 msgstr "Licença personalizada"
 
-#: src/olympia/addons/templates/addons/impala/details.html:205
+#: src/olympia/addons/templates/addons/impala/details.html:210
 #, python-format
 msgid "Released under <a href=\"%(url)s\">%(name)s</a>"
 msgstr "Disponibilizado sob <a href=\"%(url)s\">%(name)s</a>"
 
-#: src/olympia/addons/templates/addons/impala/details.html:217
+#: src/olympia/addons/templates/addons/impala/details.html:222
 msgid "About this Add-on"
 msgstr "Sobre este extra"
 
-#: src/olympia/addons/templates/addons/impala/details.html:233
+#: src/olympia/addons/templates/addons/impala/details.html:238
 msgid "Developer’s Comments"
 msgstr "Comentários do programador"
 
-#: src/olympia/addons/templates/addons/impala/details.html:243
+#: src/olympia/addons/templates/addons/impala/details.html:248
 msgid "Version Information"
 msgstr "Informação da versão"
 
-#: src/olympia/addons/templates/addons/impala/details.html:250
+#: src/olympia/addons/templates/addons/impala/details.html:255
 msgid "See complete version history"
 msgstr "Ver o histórico completo da versão"
 
-#: src/olympia/addons/templates/addons/impala/details.html:262
+#: src/olympia/addons/templates/addons/impala/details.html:267
 msgid ""
 "The Development Channel lets you test an experimental new version of this add-on before it's released to the general public. Once you install the development version, you will continue to get "
 "updates from this channel. To stop receiving development updates, reinstall the default version from the link above."
@@ -1076,17 +1075,17 @@ msgstr ""
 "O Canal de Desenvolvimento permite que teste uma nova versão experimental deste extra antes deste ser lançado ao público em geral. Depois de instalar a versão de desenvolvimento, vai continuar a "
 "receber atualizações deste canal. Para parar de receber atualizações de desenvolvimento, reinstale a versão por omissão a partir da ligação acima."
 
-#: src/olympia/addons/templates/addons/impala/details.html:272
+#: src/olympia/addons/templates/addons/impala/details.html:277
 msgid "<strong>Caution:</strong> Development versions of this add-on have not been reviewed by Mozilla."
 msgstr "<strong>Atenção:</strong> As versões de desenvolvimento deste extra não foram revistas pela Mozilla."
 
-#: src/olympia/addons/templates/addons/impala/details.html:287
+#: src/olympia/addons/templates/addons/impala/details.html:292
 msgid "See complete development channel history"
 msgstr "Consulte o histórico completo do canal de desenvolvimento"
 
-#: src/olympia/addons/templates/addons/impala/details.html:306 src/olympia/addons/templates/addons/impala/details.html:315 src/olympia/addons/templates/addons/impala/details.html:327
+#: src/olympia/addons/templates/addons/impala/details.html:311 src/olympia/addons/templates/addons/impala/details.html:320 src/olympia/addons/templates/addons/impala/details.html:332
 #: src/olympia/addons/templates/addons/impala/review_add_box.html:4 src/olympia/stats/templates/stats/popup.html:2 src/olympia/stats/templates/stats/popup.html:8
-#: src/olympia/stats/templates/stats/stats.html:202 src/olympia/users/templates/users/profile.html:119
+#: src/olympia/stats/templates/stats/stats.html:204 src/olympia/users/templates/users/profile.html:119
 msgid "close"
 msgstr "fechar"
 
@@ -1142,15 +1141,11 @@ msgstr "Licença do código fonte para {addon}"
 msgid "Source Code License"
 msgstr "Licença do código fonte"
 
-#: src/olympia/addons/templates/addons/impala/persona_grid.html:16 src/olympia/addons/templates/addons/impala/toplist.html:6
-msgid "{0} users"
-msgstr "{0} utilizadores"
-
 #: src/olympia/addons/templates/addons/impala/review_list_box.html:19 src/olympia/reviews/templates/reviews/review.html:40
 msgid "permalink"
 msgstr "ligação permanente"
 
-#: src/olympia/addons/templates/addons/impala/review_list_box.html:23 src/olympia/editors/templates/editors/queue.html:98 src/olympia/reviews/templates/reviews/review.html:44
+#: src/olympia/addons/templates/addons/impala/review_list_box.html:23 src/olympia/editors/templates/editors/queue.html:104 src/olympia/reviews/templates/reviews/review.html:44
 msgid "translate"
 msgstr "traduzir"
 
@@ -1169,6 +1164,10 @@ msgstr "Ainda não foram adicionados comentários a este extra."
 msgid "Be the first!"
 msgstr "Seja o primeiro!"
 
+#: src/olympia/addons/templates/addons/impala/toplist.html:6
+msgid "{0} users"
+msgstr "{0} utilizadores"
+
 #: src/olympia/addons/templates/addons/impala/listing/sorter.html:14 src/olympia/devhub/templates/devhub/addons/listing/item_actions.html:49
 msgid "More"
 msgstr "Mais"
@@ -1181,7 +1180,7 @@ msgstr "Adicionar à coleção"
 msgid "My Add-ons"
 msgstr "Os meus Extras"
 
-#: src/olympia/addons/templates/addons/includes/dashboard_tabs.html:6 src/olympia/amo/context_processors.py:51
+#: src/olympia/addons/templates/addons/includes/dashboard_tabs.html:6 src/olympia/amo/context_processors.py:52
 msgid "My Themes"
 msgstr "Os meus temas"
 
@@ -1236,7 +1235,7 @@ msgstr "Utilizadores"
 msgid "Weekly Downloads"
 msgstr "Transferências semanais"
 
-#: src/olympia/addons/templates/addons/mobile/details.html:99 src/olympia/compat/templates/compat/reporter_detail.html:46 src/olympia/devhub/forms.py:787
+#: src/olympia/addons/templates/addons/mobile/details.html:99 src/olympia/compat/templates/compat/reporter_detail.html:46 src/olympia/devhub/forms.py:788
 #: src/olympia/devhub/templates/devhub/versions/list.html:163
 msgid "Version"
 msgstr "Versão"
@@ -1292,9 +1291,8 @@ msgid "Return to the {0} Add-ons homepage"
 msgstr "Voltar à página inicial dos extras de {0}"
 
 #: src/olympia/addons/templates/addons/mobile/home.html:21 src/olympia/amo/helpers.py:237 src/olympia/bandwagon/templates/bandwagon/edit.html:34 src/olympia/discovery/templates/discovery/pane.html:92
-#: src/olympia/editors/templates/editors/base.html:21 src/olympia/editors/templates/editors/performance.html:72 src/olympia/templates/menu_links.html:4
-#: src/olympia/templates/impala/header_title.html:13 src/olympia/templates/impala/header_title.html:15 src/olympia/templates/impala/header_title.html:19
-#: src/olympia/templates/impala/header_title.html:23 src/olympia/templates/mobile/base_addons.html:47
+#: src/olympia/editors/templates/editors/base.html:21 src/olympia/editors/templates/editors/performance.html:72 src/olympia/templates/menu_links.html:4 src/olympia/templates/impala/header_title.html:13
+#: src/olympia/templates/impala/header_title.html:15 src/olympia/templates/impala/header_title.html:19 src/olympia/templates/impala/header_title.html:23 src/olympia/templates/mobile/base_addons.html:47
 msgid "Add-ons"
 msgstr "Extras"
 
@@ -1317,12 +1315,11 @@ msgstr ""
 
 #. {0} is a category name. Ex: "Sports"
 #. {0} is a category name, such as Nature.
-#: src/olympia/addons/templates/addons/mobile/home.html:43 src/olympia/amo/templates/amo/site_nav.html:32 src/olympia/browse/feeds.py:107
-#: src/olympia/browse/templates/browse/impala/base_listing.html:38 src/olympia/browse/templates/browse/personas/base.html:6 src/olympia/browse/templates/browse/personas/base.html:42
-#: src/olympia/browse/templates/browse/personas/category_landing.html:21 src/olympia/browse/templates/browse/personas/category_landing.html:23
-#: src/olympia/browse/templates/browse/personas/category_landing.html:38 src/olympia/browse/templates/browse/personas/grid.html:7 src/olympia/browse/templates/browse/personas/grid.html:11
-#: src/olympia/browse/templates/browse/personas/mobile/base.html:7 src/olympia/browse/templates/browse/personas/mobile/category_landing.html:19 src/olympia/constants/base.py:180
-#: src/olympia/devhub/templates/devhub/personas/submit.html:13 src/olympia/editors/helpers.py:105 src/olympia/editors/templates/editors/base.html:26
+#: src/olympia/addons/templates/addons/mobile/home.html:43 src/olympia/amo/templates/amo/site_nav.html:32 src/olympia/browse/feeds.py:107 src/olympia/browse/templates/browse/impala/base_listing.html:38
+#: src/olympia/browse/templates/browse/personas/base.html:6 src/olympia/browse/templates/browse/personas/base.html:42 src/olympia/browse/templates/browse/personas/category_landing.html:21
+#: src/olympia/browse/templates/browse/personas/category_landing.html:23 src/olympia/browse/templates/browse/personas/category_landing.html:38 src/olympia/browse/templates/browse/personas/grid.html:7
+#: src/olympia/browse/templates/browse/personas/grid.html:11 src/olympia/browse/templates/browse/personas/mobile/base.html:7 src/olympia/browse/templates/browse/personas/mobile/category_landing.html:19
+#: src/olympia/constants/base.py:180 src/olympia/devhub/templates/devhub/personas/submit.html:13 src/olympia/editors/helpers.py:107 src/olympia/editors/templates/editors/base.html:26
 #: src/olympia/editors/templates/editors/performance.html:73 src/olympia/search/templates/search/personas.html:39 src/olympia/templates/menu_links.html:9
 msgid "Themes"
 msgstr "Temas"
@@ -1343,7 +1340,7 @@ msgstr "Mais extras"
 msgid "Highest Rated"
 msgstr "Melhor classificado"
 
-#: src/olympia/addons/templates/addons/mobile/home.html:74 src/olympia/amo/templates/amo/side_nav.html:5 src/olympia/amo/templates/amo/site_nav.html:27 src/olympia/amo/templates/amo/site_nav.html:57
+#: src/olympia/addons/templates/addons/mobile/home.html:74 src/olympia/amo/templates/amo/side_nav.html:5 src/olympia/amo/templates/amo/site_nav.html:27 src/olympia/amo/templates/amo/site_nav.html:55
 #: src/olympia/bandwagon/views.py:97 src/olympia/browse/views.py:57 src/olympia/browse/views.py:67 src/olympia/browse/templates/browse/personas/mobile/category_landing.html:65
 #: src/olympia/search/forms.py:15 src/olympia/search/forms.py:87
 msgid "Newest"
@@ -1361,86 +1358,84 @@ msgstr "Informações do tema &raquo;"
 msgid "Tools"
 msgstr "Ferramentas"
 
-#: src/olympia/amo/context_processors.py:48 src/olympia/discovery/templates/discovery/pane_account.html:8 src/olympia/users/templates/users/includes/navigation.html:2
+#: src/olympia/amo/context_processors.py:49 src/olympia/discovery/templates/discovery/pane_account.html:8 src/olympia/users/templates/users/includes/navigation.html:2
 msgid "My Profile"
 msgstr "O meu perfil"
 
-#: src/olympia/amo/context_processors.py:54 src/olympia/users/templates/users/edit.html:5 src/olympia/users/templates/users/includes/navigation.html:3
+#: src/olympia/amo/context_processors.py:55 src/olympia/users/templates/users/edit.html:5 src/olympia/users/templates/users/includes/navigation.html:3
 msgid "Account Settings"
 msgstr "Definições da conta"
 
-#: src/olympia/amo/context_processors.py:57 src/olympia/discovery/templates/discovery/pane_account.html:11 src/olympia/users/templates/users/profile.html:83
+#: src/olympia/amo/context_processors.py:58 src/olympia/discovery/templates/discovery/pane_account.html:11 src/olympia/users/templates/users/profile.html:83
 #: src/olympia/users/templates/users/includes/navigation.html:4
 msgid "My Collections"
 msgstr "As minhas coleções"
 
-#: src/olympia/amo/context_processors.py:62 src/olympia/discovery/templates/discovery/pane_account.html:10 src/olympia/users/templates/users/includes/navigation.html:7
+#: src/olympia/amo/context_processors.py:63 src/olympia/discovery/templates/discovery/pane_account.html:10 src/olympia/users/templates/users/includes/navigation.html:7
 msgid "My Favorites"
 msgstr "Os meus favoritos"
 
-#: src/olympia/amo/context_processors.py:67 src/olympia/discovery/templates/discovery/pane_account.html:13 src/olympia/templates/impala/user_login.html:14
-#: src/olympia/templates/mobile/header_auth.html:5
+#: src/olympia/amo/context_processors.py:68 src/olympia/discovery/templates/discovery/pane_account.html:13 src/olympia/templates/impala/user_login.html:14 src/olympia/templates/mobile/header_auth.html:5
 msgid "Log out"
 msgstr "Sair"
 
-#: src/olympia/amo/context_processors.py:72 src/olympia/devhub/templates/devhub/addons/dashboard.html:4
+#: src/olympia/amo/context_processors.py:73 src/olympia/devhub/templates/devhub/addons/dashboard.html:4
 msgid "Manage My Submissions"
 msgstr "Gerir os meus envios"
 
-#: src/olympia/amo/context_processors.py:75 src/olympia/devhub/templates/devhub/nav.html:27 src/olympia/devhub/templates/devhub/addons/dashboard.html:25
+#: src/olympia/amo/context_processors.py:76 src/olympia/devhub/templates/devhub/nav.html:27 src/olympia/devhub/templates/devhub/addons/dashboard.html:25
 #: src/olympia/devhub/templates/devhub/addons/submit/base.html:4
 msgid "Submit a New Add-on"
 msgstr "Submeter um novo extra"
 
-#: src/olympia/amo/context_processors.py:77 src/olympia/browse/templates/browse/personas/base.html:50 src/olympia/devhub/templates/devhub/index.html:24
+#: src/olympia/amo/context_processors.py:78 src/olympia/browse/templates/browse/personas/base.html:50 src/olympia/devhub/templates/devhub/index.html:24
 #: src/olympia/devhub/templates/devhub/addons/dashboard.html:29
 msgid "Submit a New Theme"
 msgstr "Enviar um tema novo"
 
-#: src/olympia/amo/context_processors.py:79 src/olympia/amo/templates/amo/site_nav.html:87 src/olympia/devhub/helpers.py:36 src/olympia/devhub/helpers.py:68 src/olympia/devhub/helpers.py:102
+#: src/olympia/amo/context_processors.py:80 src/olympia/amo/templates/amo/site_nav.html:85 src/olympia/devhub/helpers.py:36 src/olympia/devhub/helpers.py:68 src/olympia/devhub/helpers.py:102
 #: src/olympia/templates/footer.html:6 src/olympia/templates/menu_links.html:14
 msgid "Developer Hub"
 msgstr "Central do programador"
 
-#: src/olympia/amo/context_processors.py:83 src/olympia/devhub/views.py:1792
+#: src/olympia/amo/context_processors.py:84 src/olympia/devhub/views.py:1799
 msgid "Manage API Keys"
 msgstr "Gerir chaves da API"
 
-#: src/olympia/amo/context_processors.py:88 src/olympia/editors/helpers.py:82 src/olympia/editors/helpers.py:102 src/olympia/editors/templates/editors/base.html:10
+#: src/olympia/amo/context_processors.py:89 src/olympia/editors/helpers.py:84 src/olympia/editors/helpers.py:104 src/olympia/editors/templates/editors/base.html:10
 msgid "Editor Tools"
 msgstr "Ferramentas do editor"
 
-#: src/olympia/amo/context_processors.py:92
+#: src/olympia/amo/context_processors.py:93
 msgid "Admin Tools"
 msgstr "Ferramentas do administrador"
 
-#: src/olympia/amo/fields.py:15
+#: src/olympia/amo/fields.py:20
 msgid "Incorrect, please try again."
 msgstr ""
 
-#: src/olympia/amo/fields.py:16
+#: src/olympia/amo/fields.py:21
 msgid "Error verifying input, please try again."
 msgstr ""
 
-#: src/olympia/amo/fields.py:32
+#: src/olympia/amo/fields.py:37
 msgid "This must be a valid hex color code, such as #000000."
 msgstr "Tem de ser um código de cor hexadecimal válido, tal como #000000."
 
-#: src/olympia/amo/fields.py:58
+#: src/olympia/amo/fields.py:63
 msgid "Enter at least one value."
 msgstr "Insira pelo menos um valor."
 
-#: src/olympia/amo/helpers.py:162 src/olympia/amo/templates/amo/site_nav.html:61 src/olympia/bandwagon/templates/bandwagon/add.html:9
-#: src/olympia/bandwagon/templates/bandwagon/collection_detail.html:15 src/olympia/bandwagon/templates/bandwagon/delete.html:9 src/olympia/bandwagon/templates/bandwagon/edit.html:15
-#: src/olympia/bandwagon/templates/bandwagon/user_listing.html:18 src/olympia/bandwagon/templates/bandwagon/user_listing.html:21
-#: src/olympia/bandwagon/templates/bandwagon/impala/collection_listing.html:12 src/olympia/bandwagon/templates/bandwagon/impala/collection_listing.html:20
-#: src/olympia/bandwagon/templates/bandwagon/impala/collection_listing.html:24 src/olympia/bandwagon/templates/bandwagon/impala/collection_sidebar.html:3
-#: src/olympia/bandwagon/templates/bandwagon/includes/collection_sidebar.html:2 src/olympia/bandwagon/templates/bandwagon/mobile/collection_listing.html:3
-#: src/olympia/stats/templates/stats/stats.html:77 src/olympia/templates/menu_links.html:12
+#: src/olympia/amo/helpers.py:162 src/olympia/amo/templates/amo/site_nav.html:59 src/olympia/bandwagon/templates/bandwagon/add.html:9 src/olympia/bandwagon/templates/bandwagon/collection_detail.html:15
+#: src/olympia/bandwagon/templates/bandwagon/delete.html:9 src/olympia/bandwagon/templates/bandwagon/edit.html:15 src/olympia/bandwagon/templates/bandwagon/user_listing.html:18
+#: src/olympia/bandwagon/templates/bandwagon/user_listing.html:21 src/olympia/bandwagon/templates/bandwagon/impala/collection_listing.html:12
+#: src/olympia/bandwagon/templates/bandwagon/impala/collection_listing.html:20 src/olympia/bandwagon/templates/bandwagon/impala/collection_listing.html:24
+#: src/olympia/bandwagon/templates/bandwagon/impala/collection_sidebar.html:3 src/olympia/bandwagon/templates/bandwagon/includes/collection_sidebar.html:2
+#: src/olympia/bandwagon/templates/bandwagon/mobile/collection_listing.html:3 src/olympia/stats/templates/stats/stats.html:33 src/olympia/templates/menu_links.html:12
 msgid "Collections"
 msgstr "Coleções"
 
-#: src/olympia/amo/helpers.py:171 src/olympia/amo/templates/amo/site_nav.html:85 src/olympia/browse/templates/browse/language_tools.html:3
+#: src/olympia/amo/helpers.py:171 src/olympia/amo/templates/amo/site_nav.html:83 src/olympia/browse/templates/browse/language_tools.html:3
 msgid "Dictionaries & Language Packs"
 msgstr "Dicionários e pacotes de idioma"
 
@@ -1592,8 +1587,8 @@ msgstr "Solicitada uma super revisão"
 msgid "Comment on {addon} {version}."
 msgstr "Comentário a {addon} {version}."
 
-#: src/olympia/amo/log.py:236 src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:19 src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:47
-#: src/olympia/editors/helpers.py:511 src/olympia/editors/templates/editors/themes/history_table.html:11
+#: src/olympia/amo/log.py:236 src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:17 src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:45
+#: src/olympia/editors/helpers.py:584 src/olympia/editors/templates/editors/themes/history_table.html:11
 msgid "Comment"
 msgstr "Comentário"
 
@@ -1880,17 +1875,17 @@ msgstr "Não encontrado"
 #, python-format
 msgid ""
 "<h1>We're sorry, but we can't find what you're looking for.</h1> <p> The page or file you requested wasn't found on our site. It's possible that you clicked a link that's out of date, or typed in "
-"the address incorrectly. </p> <ul> <li>If you typed in the address, please double check the spelling.</li> <li> If you followed a link from somewhere, please let us know at <a href=\"mailto:"
-"webmaster@mozilla.com\">webmaster@mozilla.com</a>. Tell us where you came from and what you were looking for, and we'll do our best to fix it. </li> </ul> <p>Or you can just jump over to some of "
-"the popular pages on our website.</p> <ul> <li>Are you interested in a <a href=\"%(rec)s\">list of featured add-ons</a>?</li> <li> Do you want to <a href=\"%(search)s\">search for add-ons</a>? You "
-"may go to the <a href=\"%(search)s\">search page</a> or just use the search field above. </li> <li> If you prefer to start over, just go to the <a href=\"%(home)s\">add-ons front page</a>. </li> </"
-"ul>"
+"the address incorrectly. </p> <ul> <li>If you typed in the address, please double check the spelling.</li> <li> If you followed a link from somewhere, please let us know at <a "
+"href=\"mailto:webmaster@mozilla.com\">webmaster@mozilla.com</a>. Tell us where you came from and what you were looking for, and we'll do our best to fix it. </li> </ul> <p>Or you can just jump over"
+" to some of the popular pages on our website.</p> <ul> <li>Are you interested in a <a href=\"%(rec)s\">list of featured add-ons</a>?</li> <li> Do you want to <a href=\"%(search)s\">search for add-"
+"ons</a>? You may go to the <a href=\"%(search)s\">search page</a> or just use the search field above. </li> <li> If you prefer to start over, just go to the <a href=\"%(home)s\">add-ons front "
+"page</a>. </li> </ul>"
 msgstr ""
 "<h1>Pedimos desculpa mas não encontrámos o que procura.</h1> <p>A página ou ficheiro que solicitou não foi encontrado no nosso site. É possível que tenha clicado numa ligação desatualizada, ou que "
-"tenha escrito o endereço incorretamente. </p> <ul> <li> Se escreveu o endereço, confirme o que digitou.</li> <li> Se seguiu uma ligação de um outro local, por favor informe-nos em <a href=\"mailto:"
-"webmaster@mozilla.com\">webmaster@mozilla.com</a>. Diga-nos de onde veio e o que procura e nós faremos os possíveis para o corrigir.</li> </ul> <p>Ou pode ir para algumas das páginas populares do "
-"nosso site. </p> <ul> <li>Está interessado numa <a href=\"%(rec)s\">lista de extras em destaque</a>?</li> <li>Quer <a href=\"%(search)s\">procurar extras</a>? Pode ir para a <a href=\"%(search)s"
-"\">página de pesquisa</a> ou utilizar o campo de pesquisa acima.</li> <li> Se preferir recomeçar, vá para a <a href=\"%(home)s\">página inicial dos extras</a>.</li> </ul>"
+"tenha escrito o endereço incorretamente. </p> <ul> <li> Se escreveu o endereço, confirme o que digitou.</li> <li> Se seguiu uma ligação de um outro local, por favor informe-nos em <a "
+"href=\"mailto:webmaster@mozilla.com\">webmaster@mozilla.com</a>. Diga-nos de onde veio e o que procura e nós faremos os possíveis para o corrigir.</li> </ul> <p>Ou pode ir para algumas das páginas "
+"populares do nosso site. </p> <ul> <li>Está interessado numa <a href=\"%(rec)s\">lista de extras em destaque</a>?</li> <li>Quer <a href=\"%(search)s\">procurar extras</a>? Pode ir para a <a "
+"href=\"%(search)s\">página de pesquisa</a> ou utilizar o campo de pesquisa acima.</li> <li> Se preferir recomeçar, vá para a <a href=\"%(home)s\">página inicial dos extras</a>.</li> </ul>"
 
 #: src/olympia/amo/templates/amo/500.html:3
 msgid "Oops"
@@ -1921,7 +1916,7 @@ msgstr "Anterior"
 #: src/olympia/amo/templates/amo/mobile/paginator.html:14 src/olympia/amo/templates/amo/mobile/paginator.html:16 src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:51
 #: src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:65 src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:78
 #: src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:91 src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:104
-#: src/olympia/discovery/templates/discovery/pane.html:45 src/olympia/discovery/templates/discovery/addons/detail.html:39 src/olympia/stats/templates/stats/stats.html:167
+#: src/olympia/discovery/templates/discovery/pane.html:45 src/olympia/discovery/templates/discovery/addons/detail.html:39 src/olympia/stats/templates/stats/stats.html:169
 msgid "Next"
 msgstr "Seguinte"
 
@@ -1951,11 +1946,11 @@ msgid ""
 "<p> Please enter <strong>all the words</strong> below, <strong>separated by a space if necessary</strong>. </p> <p> If this is hard to read, you can <a href=\"#\" id=\"recaptcha_different\">try "
 "different words</a> or <a href=\"#\" id=\"recaptcha_audio\">try a different type of challenge</a> instead. </p>"
 msgstr ""
-"<p> Por favor introduza <strong>todas as palavras</strong> abaixo, <strong>separadas por um espaço se necessário</strong>. </p> <p> Se isto for difícil de ler, pode <a href=\"#\" id="
-"\"recaptcha_different\">tentar palavras diferentes</a> ou <a href=\"#\" id=\"recaptcha_audio\">tentar um tipo de desafio diferente</a>. </p>"
+"<p> Por favor introduza <strong>todas as palavras</strong> abaixo, <strong>separadas por um espaço se necessário</strong>. </p> <p> Se isto for difícil de ler, pode <a href=\"#\" "
+"id=\"recaptcha_different\">tentar palavras diferentes</a> ou <a href=\"#\" id=\"recaptcha_audio\">tentar um tipo de desafio diferente</a>. </p>"
 
 #: src/olympia/amo/templates/amo/side_nav.html:4 src/olympia/amo/templates/amo/side_nav.html:12 src/olympia/amo/templates/amo/site_nav.html:4 src/olympia/amo/templates/amo/site_nav.html:26
-#: src/olympia/browse/views.py:56 src/olympia/browse/views.py:66 src/olympia/browse/views.py:237 src/olympia/browse/views.py:282 src/olympia/search/forms.py:86
+#: src/olympia/browse/views.py:56 src/olympia/browse/views.py:66 src/olympia/browse/views.py:204 src/olympia/browse/views.py:249 src/olympia/search/forms.py:86
 msgid "Top Rated"
 msgstr "Melhor classificado"
 
@@ -1969,38 +1964,37 @@ msgstr "Explorar"
 msgid "Extensions"
 msgstr "Extensões"
 
-#: src/olympia/amo/templates/amo/site_nav.html:45
+#: src/olympia/amo/templates/amo/site_nav.html:44
 msgid "Want more customization? Try <b>Complete Themes</b>"
 msgstr ""
 
-#: src/olympia/amo/templates/amo/site_nav.html:56 src/olympia/bandwagon/views.py:96
+#: src/olympia/amo/templates/amo/site_nav.html:54 src/olympia/bandwagon/views.py:96
 msgid "Most Followers"
 msgstr "Mais seguidores"
 
-#: src/olympia/amo/templates/amo/site_nav.html:68 src/olympia/bandwagon/templates/bandwagon/impala/collection_sidebar.html:16
-#: src/olympia/bandwagon/templates/bandwagon/includes/collection_sidebar.html:18
+#: src/olympia/amo/templates/amo/site_nav.html:66 src/olympia/bandwagon/templates/bandwagon/impala/collection_sidebar.html:16 src/olympia/bandwagon/templates/bandwagon/includes/collection_sidebar.html:18
 msgid "Collections I've Made"
 msgstr "Coleções que fiz"
 
-#: src/olympia/amo/templates/amo/site_nav.html:70 src/olympia/bandwagon/templates/bandwagon/user_listing.html:4 src/olympia/bandwagon/templates/bandwagon/impala/collection_sidebar.html:13
+#: src/olympia/amo/templates/amo/site_nav.html:68 src/olympia/bandwagon/templates/bandwagon/user_listing.html:4 src/olympia/bandwagon/templates/bandwagon/impala/collection_sidebar.html:13
 #: src/olympia/bandwagon/templates/bandwagon/includes/collection_sidebar.html:15
 msgid "Collections I'm Following"
 msgstr "Coleções que acompanho"
 
-#: src/olympia/amo/templates/amo/site_nav.html:73 src/olympia/bandwagon/templates/bandwagon/impala/collection_sidebar.html:18
-#: src/olympia/bandwagon/templates/bandwagon/includes/collection_sidebar.html:20 src/olympia/users/models.py:512
+#: src/olympia/amo/templates/amo/site_nav.html:71 src/olympia/bandwagon/templates/bandwagon/impala/collection_sidebar.html:18 src/olympia/bandwagon/templates/bandwagon/includes/collection_sidebar.html:20
+#: src/olympia/users/models.py:521
 msgid "My Favorite Add-ons"
 msgstr "Os meus extras favoritos"
 
-#: src/olympia/amo/templates/amo/site_nav.html:78
+#: src/olympia/amo/templates/amo/site_nav.html:76
 msgid "More&hellip;"
 msgstr "Mais&hellip;"
 
-#: src/olympia/amo/templates/amo/site_nav.html:82
+#: src/olympia/amo/templates/amo/site_nav.html:80
 msgid "Add-ons for Mobile"
 msgstr "Extras para o móvel"
 
-#: src/olympia/amo/templates/amo/site_nav.html:86 src/olympia/browse/feeds.py:207 src/olympia/browse/templates/browse/search_tools.html:3 src/olympia/constants/base.py:176
+#: src/olympia/amo/templates/amo/site_nav.html:84 src/olympia/browse/feeds.py:207 src/olympia/browse/templates/browse/search_tools.html:3 src/olympia/constants/base.py:176
 #: src/olympia/templates/menu_links.html:10
 msgid "Search Tools"
 msgstr "Ferramentas de pesquisa"
@@ -2016,7 +2010,7 @@ msgid "Jump to first page"
 msgstr "Saltar para a primeira página"
 
 #: src/olympia/amo/templates/amo/impala/paginator.html:22 src/olympia/amo/templates/amo/mobile/impala_paginator.html:12 src/olympia/discovery/templates/discovery/pane.html:44
-#: src/olympia/discovery/templates/discovery/addons/detail.html:38 src/olympia/stats/templates/stats/stats.html:164
+#: src/olympia/discovery/templates/discovery/addons/detail.html:38 src/olympia/stats/templates/stats/stats.html:166
 msgid "Previous"
 msgstr "Anterior"
 
@@ -2039,31 +2033,50 @@ msgid_plural "Page {n}"
 msgstr[0] "Página {n}"
 msgstr[1] "Página {n}"
 
-#: src/olympia/amo/templates/services/install.html:38
-#, python-format
-msgid "If you are not prompted to install %(addon_name)s in a moment, please <a href=\"%(addon_xpi)s\">click here</a>."
-msgstr "Se dentro de momentos, não for questionado para instalar %(addon_name)s, por favor <a href=\"%(addon_xpi)s\">clique aqui</a>."
-
-#: src/olympia/amo/tests/test_messages.py:57 src/olympia/amo/tests/test_messages.py:58 src/olympia/reviews/forms.py:25 src/olympia/reviews/forms.py:50 src/olympia/reviews/templates/reviews/add.html:56
+#: src/olympia/amo/tests/test_messages.py:56 src/olympia/amo/tests/test_messages.py:57 src/olympia/reviews/forms.py:25 src/olympia/reviews/forms.py:50 src/olympia/reviews/templates/reviews/add.html:56
 #: src/olympia/reviews/templates/reviews/reply.html:30
 msgid "Title"
 msgstr "Título"
 
-#: src/olympia/amo/tests/test_messages.py:57 src/olympia/amo/tests/test_messages.py:58
+#: src/olympia/amo/tests/test_messages.py:56 src/olympia/amo/tests/test_messages.py:57
 msgid "Body"
 msgstr "Corpo"
 
-#: src/olympia/amo/tests/test_messages.py:59
+#: src/olympia/amo/tests/test_messages.py:58
 msgid "Another Title"
 msgstr "Outro título"
 
-#: src/olympia/amo/tests/test_messages.py:59
+#: src/olympia/amo/tests/test_messages.py:58
 msgid "Another Body"
 msgstr "Outro corpo"
 
-#: src/olympia/api/views.py:255
-msgid "Not implemented yet."
-msgstr "Ainda não implementado."
+#: src/olympia/api/authentication.py:76
+msgid "Signature has expired."
+msgstr ""
+
+#: src/olympia/api/authentication.py:79
+msgid "Error decoding signature."
+msgstr ""
+
+#: src/olympia/api/authentication.py:82
+msgid "Invalid JWT Token."
+msgstr ""
+
+#: src/olympia/api/authentication.py:130
+msgid "Invalid Authorization header. No credentials provided."
+msgstr ""
+
+#: src/olympia/api/authentication.py:133
+msgid "Invalid Authorization header. Credentials string should not contain spaces."
+msgstr ""
+
+#: src/olympia/api/fields.py:29
+msgid "The field must have a length of at least {num} characters."
+msgstr ""
+
+#: src/olympia/api/fields.py:31
+msgid "The language code {lang_code} is invalid."
+msgstr ""
 
 #: src/olympia/applications/views.py:39 src/olympia/applications/templates/applications/appversions.html:3
 msgid "Application Versions"
@@ -2081,7 +2094,7 @@ msgstr "Versões válidas da aplicação"
 msgid "Add-ons submitted to Mozilla Add-ons must have a manifest file with at least one of the below applications supported. Only the versions listed below are allowed for these applications."
 msgstr ""
 
-#: src/olympia/applications/templates/applications/appversions.html:25
+#: src/olympia/applications/templates/applications/appversions.html:25 src/olympia/editors/helpers.py:361
 msgid "GUID"
 msgstr "GUID"
 
@@ -2158,11 +2171,11 @@ msgstr "Não são permitidas ligações."
 msgid "This url is already in use by another collection"
 msgstr "Esta url já está a ser utilizada por outra coleção"
 
-#: src/olympia/bandwagon/forms.py:197 src/olympia/devhub/views.py:1049
+#: src/olympia/bandwagon/forms.py:197 src/olympia/devhub/views.py:1050
 msgid "Icons must be either PNG or JPG."
 msgstr "Os ícones devem ser PNG ou JPG."
 
-#: src/olympia/bandwagon/forms.py:202 src/olympia/devhub/views.py:1067 src/olympia/users/forms.py:476
+#: src/olympia/bandwagon/forms.py:202 src/olympia/devhub/views.py:1068 src/olympia/users/forms.py:476
 #, python-format
 msgid "Please use images smaller than %dMB."
 msgstr "Por favor utilize imagens menores que %dMB."
@@ -2195,8 +2208,8 @@ msgstr "Favorito"
 msgid "Remove from favorites"
 msgstr "Remover dos favoritos"
 
-#: src/olympia/bandwagon/views.py:98 src/olympia/bandwagon/views.py:191 src/olympia/browse/views.py:58 src/olympia/browse/views.py:69 src/olympia/browse/views.py:458 src/olympia/devhub/views.py:74
-#: src/olympia/devhub/views.py:82 src/olympia/devhub/templates/devhub/addons/edit/basic.html:20 src/olympia/editors/templates/editors/leaderboard.html:24
+#: src/olympia/bandwagon/views.py:98 src/olympia/bandwagon/views.py:191 src/olympia/browse/views.py:58 src/olympia/browse/views.py:69 src/olympia/browse/views.py:425 src/olympia/devhub/views.py:73
+#: src/olympia/devhub/views.py:81 src/olympia/devhub/templates/devhub/addons/edit/basic.html:20 src/olympia/editors/templates/editors/leaderboard.html:24
 #: src/olympia/editors/templates/editors/themes/queue_list.html:48 src/olympia/search/forms.py:17 src/olympia/search/forms.py:89 src/olympia/users/templates/users/vcard.html:5
 msgid "Name"
 msgstr "Nome"
@@ -2205,7 +2218,7 @@ msgstr "Nome"
 msgid "Recently Popular"
 msgstr "Recentemente popular"
 
-#: src/olympia/bandwagon/views.py:189 src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:18
+#: src/olympia/bandwagon/views.py:189 src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:16
 msgid "Added"
 msgstr "Adicionado"
 
@@ -2219,8 +2232,8 @@ msgstr "Coleção criada!"
 
 #: src/olympia/bandwagon/views.py:316
 #, python-format
-msgid "Your new collection is shown below. You can <ahref=\"%(url)s\">edit additional settings</a> if you'dlike."
-msgstr ""
+msgid "Your new collection is shown below. You can <a href=\"%(url)s\">edit additional settings</a> if you'd like."
+msgstr "A sua nova coleção é apresentada abaixo. Se quiser pode <a href=\"%(url)s\">editar as definições adicionais</a>."
 
 #: src/olympia/bandwagon/views.py:322
 msgid "Collection updated!"
@@ -2347,8 +2360,8 @@ msgid_plural "%(num)s Add-ons in this Collection"
 msgstr[0] "%(num)s extra nesta coleção"
 msgstr[1] "%(num)s extras nesta coleção"
 
-#: src/olympia/bandwagon/templates/bandwagon/collection_detail.html:125 src/olympia/compat/templates/compat/index.html:25 src/olympia/compat/templates/compat/reporter_detail.html:29
-#: src/olympia/files/templates/files/viewer.html:29 src/olympia/templates/amo_footer.html:17 src/olympia/templates/includes/lang_switcher.html:10
+#: src/olympia/bandwagon/templates/bandwagon/collection_detail.html:125 src/olympia/compat/templates/compat/reporter_detail.html:29 src/olympia/files/templates/files/viewer.html:29
+#: src/olympia/templates/amo_footer.html:17 src/olympia/templates/includes/lang_switcher.html:10
 msgid "Go"
 msgstr "Ir"
 
@@ -2519,7 +2532,7 @@ msgid "Remove this user as a contributor"
 msgstr "Remover este utilizador como colaborador"
 
 #: src/olympia/bandwagon/templates/bandwagon/edit_contributors.html:18 src/olympia/bandwagon/templates/bandwagon/edit_contributors.html:43
-#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:20 src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:48
+#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:18 src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:46
 #: src/olympia/devhub/templates/devhub/addons/ajax_compat_update.html:19
 msgid "Remove"
 msgstr "Remover"
@@ -2569,7 +2582,7 @@ msgid "<b>Warning:</b> By changing the owner of this collection, you will no lon
 msgstr "<b>Aviso:</b> Ao alterar o dono desta coleção, já não a poderá editar. Apenas poderá adicionar ou remover extras da mesma."
 
 #: src/olympia/bandwagon/templates/bandwagon/edit_contributors.html:83 src/olympia/devhub/templates/devhub/addons/forms_shared/media.html:157
-#: src/olympia/devhub/templates/devhub/addons/submit/describe.html:69 src/olympia/devhub/templates/devhub/addons/submit/license.html:60 src/olympia/devhub/templates/devhub/addons/submit/upload.html:78
+#: src/olympia/devhub/templates/devhub/addons/submit/describe.html:69 src/olympia/devhub/templates/devhub/addons/submit/license.html:60 src/olympia/devhub/templates/devhub/addons/submit/upload.html:70
 #: src/olympia/devhub/templates/devhub/payments/tier.html:17 src/olympia/editors/templates/editors/themes/themes.html:111 src/olympia/editors/templates/editors/themes/themes.html:128
 #: src/olympia/editors/templates/editors/themes/themes.html:134 src/olympia/editors/templates/editors/themes/themes.html:141 src/olympia/users/templates/users/fxa_migration_prompt_content.html:10
 #: src/olympia/users/templates/users/login_form.html:42 src/olympia/users/templates/users/mobile/login.html:57
@@ -2652,33 +2665,31 @@ msgid "Add-ons in Your Collection"
 msgstr "Extras na sua coleção"
 
 #: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:4
-msgid ""
-"To include an add-on in this collection, enter its name in the box below and hit enter. You can also use the <strong>Add to Collection</strong> links throughout the site to include add-ons later."
+msgid "To include an add-on in this collection, enter its name in the box below and hit enter."
 msgstr ""
-"Para incluir um extra nesta coleção, digite o nome na caixa abaixo e clique em enter. Pode também usar as ligações <strong>Adicionar à coleção</strong> presentes em todo o site para incluir extras "
-"mais tarde."
 
-#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:17 src/olympia/constants/base.py:400 src/olympia/devhub/templates/devhub/addons/activity.html:62
+#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:15 src/olympia/constants/base.py:400 src/olympia/devhub/templates/devhub/addons/activity.html:62
+#: src/olympia/editors/helpers.py:273 src/olympia/editors/helpers.py:360
 msgid "Add-on"
 msgstr "Extra"
 
-#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:26
+#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:24
 msgid "Enter the name of the add-on to include"
 msgstr "Escreva o nome do extra a incluir"
 
-#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:28
+#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:26
 msgid "Add to Collection"
 msgstr "Adicionar à coleção"
 
-#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:45 src/olympia/editors/helpers.py:936 src/olympia/editors/helpers.py:956
+#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:43 src/olympia/editors/helpers.py:1016 src/olympia/editors/helpers.py:1036
 msgid "Pending"
 msgstr "Pendente"
 
-#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:47
+#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:45
 msgid "Add a comment"
 msgstr "Adicionar um comentário"
 
-#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:48
+#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:46
 msgid "Remove this add-on from the collection"
 msgstr "Remover este extra da coleção"
 
@@ -2729,8 +2740,8 @@ msgid ""
 "When Mozilla becomes aware of add-ons, plugins, or other third-party software that seriously compromises %(app)s security, stability, or performance and meets <a href=\"%(criteria)s\">certain "
 "criteria</a>, the software may be blocked from general use. For more information, please read <a href=\"%(support)s\">this support article</a>."
 msgstr ""
-"Quando a Mozilla toma conhecimento de extras, plugins, ou software de terceiros, que comprometam seriamente a segurança, estabilidade ou desempenho do %(app)s em conjunto com <a href=\"%(criteria)s"
-"\">determinados critérios </a >, o software pode ser impedido de ser utilizado. Para mais informações, por favor leia <a href=\"%(support)s\">este artigo de ajuda</a>."
+"Quando a Mozilla toma conhecimento de extras, plugins, ou software de terceiros, que comprometam seriamente a segurança, estabilidade ou desempenho do %(app)s em conjunto com <a "
+"href=\"%(criteria)s\">determinados critérios </a >, o software pode ser impedido de ser utilizado. Para mais informações, por favor leia <a href=\"%(support)s\">este artigo de ajuda</a>."
 
 #: src/olympia/blocklist/templates/blocklist/blocked_detail.html:44
 #, python-format
@@ -2787,12 +2798,12 @@ msgstr "Ferramentas de pesquisa"
 msgid "Most Users"
 msgstr "Maior número de utilizadores"
 
-#: src/olympia/browse/views.py:61 src/olympia/browse/views.py:72 src/olympia/browse/views.py:279 src/olympia/browse/templates/browse/personas/mobile/category_landing.html:63
+#: src/olympia/browse/views.py:61 src/olympia/browse/views.py:72 src/olympia/browse/views.py:246 src/olympia/browse/templates/browse/personas/mobile/category_landing.html:63
 #: src/olympia/discovery/templates/discovery/pane.html:67 src/olympia/search/forms.py:92
 msgid "Up & Coming"
 msgstr "A aparecer"
 
-#: src/olympia/browse/views.py:460 src/olympia/devhub/views.py:76 src/olympia/devhub/views.py:83 src/olympia/discovery/templates/discovery/addons/detail.html:66
+#: src/olympia/browse/views.py:427 src/olympia/devhub/views.py:75 src/olympia/devhub/views.py:82 src/olympia/discovery/templates/discovery/addons/detail.html:66
 msgid "Created"
 msgstr "Criado"
 
@@ -2980,8 +2991,8 @@ msgid_plural "See all %(cnt)s extensions in %(name)s &raquo;"
 msgstr[0] "Ver a extensão %(cnt)s em %(name)s &raquo;"
 msgstr[1] "Ver todas as extensões %(cnt)s em %(name)s &raquo;"
 
-#: src/olympia/browse/templates/browse/mobile/extensions.html:13 src/olympia/compat/templates/compat/index.html:82 src/olympia/devhub/templates/devhub/devhub_search.html:24
-#: src/olympia/devhub/templates/devhub/addons/activity.html:47 src/olympia/search/templates/search/no_results.html:4 src/olympia/search/templates/search/mobile/results.html:36
+#: src/olympia/browse/templates/browse/mobile/extensions.html:13 src/olympia/devhub/templates/devhub/devhub_search.html:24 src/olympia/devhub/templates/devhub/addons/activity.html:47
+#: src/olympia/search/templates/search/no_results.html:4 src/olympia/search/templates/search/mobile/results.html:36
 msgid "No results found."
 msgstr "Não foram encontrados resultados."
 
@@ -3068,7 +3079,7 @@ msgstr "&laquo; Todos os temas"
 msgid "All"
 msgstr "Todos"
 
-#: src/olympia/compat/forms.py:22 src/olympia/search/views.py:525
+#: src/olympia/compat/forms.py:22 src/olympia/editors/templates/editors/base.html:69 src/olympia/search/views.py:518
 msgid "All Add-ons"
 msgstr "Todos os extras"
 
@@ -3079,53 +3090,6 @@ msgstr "Binário"
 #: src/olympia/compat/forms.py:24
 msgid "Non-binary"
 msgstr "Não-binário"
-
-#. Review points sources other than add-ons and themes.
-#: src/olympia/compat/views.py:87 src/olympia/constants/base.py:388 src/olympia/devhub/forms.py:162 src/olympia/editors/templates/editors/performance.html:75
-msgid "Other"
-msgstr "Outro"
-
-#: src/olympia/compat/templates/compat/index.html:4
-msgid "Add-on Compatibility Report for {app} {version}"
-msgstr "Relatório de compatibilidade do extra para {app} {version}"
-
-#: src/olympia/compat/templates/compat/index.html:11
-msgid "{app} {version} Compatibility"
-msgstr "Compatibilidade de {app} {version}"
-
-#: src/olympia/compat/templates/compat/index.html:17
-#, python-format
-msgid "Top 95%% compatible with previous version"
-msgstr ""
-
-#: src/olympia/compat/templates/compat/index.html:18
-#, python-format
-msgid "Top 95%% of all add-ons"
-msgstr ""
-
-#: src/olympia/compat/templates/compat/index.html:19
-msgid "All active add-ons"
-msgstr "Todos os extras ativos"
-
-#: src/olympia/compat/templates/compat/index.html:23 src/olympia/constants/base.py:401
-msgid "App"
-msgstr "Aplicação"
-
-#: src/olympia/compat/templates/compat/index.html:55
-msgid "Details for add-ons compatible with previous version:"
-msgstr "Detalhes dos extras compatíveis com a versão anterior:"
-
-#: src/olympia/compat/templates/compat/index.html:57
-msgid "Show all versions"
-msgstr "Mostrar todas as versões"
-
-#: src/olympia/compat/templates/compat/index.html:59
-msgid "Details for add-ons compatible with all versions:"
-msgstr "Detalhes para extras compatíveis com todas as versões:"
-
-#: src/olympia/compat/templates/compat/index.html:61
-msgid "Show previous version only"
-msgstr "Mostrar apenas a versão anterior"
 
 #: src/olympia/compat/templates/compat/reporter.html:3
 msgid "Add-on Compatibility Reports"
@@ -3180,8 +3144,8 @@ msgstr "Filtrar por aplicação"
 msgid "Report Type"
 msgstr "Tipo de relatório"
 
-#: src/olympia/compat/templates/compat/reporter_detail.html:47 src/olympia/devhub/forms.py:784 src/olympia/devhub/templates/devhub/addons/ajax_compat_update.html:17 src/olympia/editors/forms.py:108
-#: src/olympia/zadmin/forms.py:45
+#: src/olympia/compat/templates/compat/reporter_detail.html:47 src/olympia/devhub/forms.py:785 src/olympia/devhub/templates/devhub/addons/ajax_compat_update.html:17 src/olympia/editors/forms.py:108
+#: src/olympia/editors/forms.py:248 src/olympia/zadmin/forms.py:45
 msgid "Application"
 msgstr "Aplicação"
 
@@ -3269,7 +3233,8 @@ msgstr "Preliminarmente analisado"
 msgid "Preliminarily Reviewed and Awaiting Full Review"
 msgstr "Preliminarmente analisado e aguardar por análise completa"
 
-#: src/olympia/constants/base.py:33 src/olympia/editors/helpers.py:924 src/olympia/editors/templates/editors/themes/history_table.html:34
+#: src/olympia/constants/base.py:33 src/olympia/editors/forms.py:258 src/olympia/editors/helpers.py:73 src/olympia/editors/helpers.py:1004
+#: src/olympia/editors/templates/editors/themes/history_table.html:34
 msgid "Deleted"
 msgstr "Eliminado"
 
@@ -3366,6 +3331,11 @@ msgstr "Perguntar depois de os utilizadores começarem a descarregar este extra"
 msgid "Ask before users can download this add-on"
 msgstr "Perguntar antes de os utilizadores poderem descarregar este extra"
 
+#. Review points sources other than add-ons and themes.
+#: src/olympia/constants/base.py:388 src/olympia/devhub/forms.py:162 src/olympia/editors/templates/editors/performance.html:75
+msgid "Other"
+msgstr "Outro"
+
 #: src/olympia/constants/base.py:389
 msgid "Exception"
 msgstr "Exceção"
@@ -3377,6 +3347,10 @@ msgstr "Lançamento"
 #: src/olympia/constants/base.py:391
 msgid "Change"
 msgstr "Alterar"
+
+#: src/olympia/constants/base.py:401
+msgid "App"
+msgstr "Aplicação"
 
 #: src/olympia/constants/base.py:402
 msgid "Persona"
@@ -3526,7 +3500,7 @@ msgstr "Sinalizar"
 msgid "Duplicate"
 msgstr "Duplicar"
 
-#: src/olympia/constants/editors.py:17 src/olympia/editors/helpers.py:502 src/olympia/editors/templates/editors/themes/queue.html:71 src/olympia/editors/templates/editors/themes/themes.html:94
+#: src/olympia/constants/editors.py:17 src/olympia/editors/helpers.py:575 src/olympia/editors/templates/editors/themes/queue.html:71 src/olympia/editors/templates/editors/themes/themes.html:94
 msgid "Reject"
 msgstr "Rejeitar"
 
@@ -3626,7 +3600,7 @@ msgstr "Solaris"
 msgid "Android"
 msgstr "Android"
 
-#: src/olympia/core/apps.py:19
+#: src/olympia/core/apps.py:21
 msgid "Core"
 msgstr ""
 
@@ -3760,8 +3734,8 @@ msgid "Submit my add-on for manual review."
 msgstr "Enviar o meu extra para revisão manual."
 
 #: src/olympia/devhub/forms.py:537
-msgid "Do not list my add-on on this site (beta)"
-msgstr "Não listar o meu extra neste sítio (beta)"
+msgid "Do not list my add-on on this site"
+msgstr ""
 
 #: src/olympia/devhub/forms.py:538
 msgid "Check this option if you intend to distribute your add-on on your own and only need it to be signed by Mozilla."
@@ -3793,46 +3767,46 @@ msgstr "Um ficheiro com uma versão terminada com a|alpha|b|beta|pre|rc e com um
 
 #: src/olympia/devhub/forms.py:592
 #, python-format
-msgid "Version %s already exists"
-msgstr "A versão %s já existe"
+msgid "Version %s already exists, or was uploaded before."
+msgstr ""
 
-#: src/olympia/devhub/forms.py:604
+#: src/olympia/devhub/forms.py:605
 msgid "Select a valid choice. That choice is not one of the available choices."
 msgstr "Escolha uma opção válida. Essa escolha não é uma das escolhas disponíveis."
 
-#: src/olympia/devhub/forms.py:610
+#: src/olympia/devhub/forms.py:611
 msgid "A file with a version ending with a|alpha|b|beta and an optional number is detected as beta."
 msgstr "Um ficheiro com uma versão que termine com a|alpha|b|beta e um número opcional é detetado como beta."
 
-#: src/olympia/devhub/forms.py:633
+#: src/olympia/devhub/forms.py:634
 msgid "You cannot upload any more files for this version."
 msgstr "Não pode carregar mais ficheiros para esta versão."
 
-#: src/olympia/devhub/forms.py:639
+#: src/olympia/devhub/forms.py:640
 msgid "Version doesn't match"
 msgstr "A versão não corresponde."
 
-#: src/olympia/devhub/forms.py:668
+#: src/olympia/devhub/forms.py:669
 msgid "You cannot delete a file once the review process has started. You must delete the whole version."
 msgstr "Não pode eliminar um ficheiro depois do processo de análise começar. Tem de eliminar a versão completa."
 
-#: src/olympia/devhub/forms.py:688
+#: src/olympia/devhub/forms.py:689
 msgid "The platform All cannot be combined with specific platforms."
 msgstr "A plataforma Todos não pode ser combinada com plataformas específicas."
 
-#: src/olympia/devhub/forms.py:693
+#: src/olympia/devhub/forms.py:694
 msgid "A platform can only be chosen once."
 msgstr "Uma plataforma só pode ser escolhida uma vez."
 
-#: src/olympia/devhub/forms.py:706
+#: src/olympia/devhub/forms.py:707
 msgid "A review type must be selected."
 msgstr "Tem de ser selecionado um tipo de revisão."
 
-#: src/olympia/devhub/forms.py:788 src/olympia/editors/forms.py:114 src/olympia/zadmin/forms.py:49 src/olympia/zadmin/forms.py:52
+#: src/olympia/devhub/forms.py:789 src/olympia/editors/forms.py:114 src/olympia/editors/forms.py:254 src/olympia/zadmin/forms.py:49 src/olympia/zadmin/forms.py:52
 msgid "Select an application first"
 msgstr "Selecione uma aplicação primeiro"
 
-#: src/olympia/devhub/forms.py:840
+#: src/olympia/devhub/forms.py:841
 msgid "There cannot be more than 3 required add-ons."
 msgstr "Não podem existir mais do que 3 extras requeridos."
 
@@ -3866,160 +3840,160 @@ msgstr[1] "{0} avisos"
 msgid "Review"
 msgstr "Revisão"
 
-#: src/olympia/devhub/tasks.py:551
+#: src/olympia/devhub/tasks.py:583
 #, python-format
 msgid "%s responded with %s (%s)."
 msgstr "%s respondeu com %s (%s)."
 
-#: src/olympia/devhub/tasks.py:555
+#: src/olympia/devhub/tasks.py:587
 #, python-format
 msgid "Connection to \"%s\" timed out."
 msgstr "A ligação a \"%s\" expirou."
 
-#: src/olympia/devhub/tasks.py:557
+#: src/olympia/devhub/tasks.py:589
 #, python-format
 msgid "Could not contact host at \"%s\"."
 msgstr "Não foi possível contactar o servidor em  \"%s\"."
 
-#: src/olympia/devhub/utils.py:104
+#: src/olympia/devhub/utils.py:105
 #, python-format
 msgid "Validation generated too many errors/warnings so %s messages were truncated. After addressing the visible messages, you'll be able to see the others."
 msgstr "A validação gerou muitos erros/alertas pelo que %s mensagens foram cortadas. Após corrigir as mensagens visíveis, poderá ver as outras mensagens."
 
-#: src/olympia/devhub/views.py:183
+#: src/olympia/devhub/views.py:182
 msgid "All My Add-ons"
 msgstr "Todos os meus extras"
 
-#: src/olympia/devhub/views.py:210
+#: src/olympia/devhub/views.py:209
 msgid "All Activity"
 msgstr "Toda a atividade"
 
-#: src/olympia/devhub/views.py:211
+#: src/olympia/devhub/views.py:210
 msgid "Add-on Updates"
 msgstr "Atualizações do extra"
 
-#: src/olympia/devhub/views.py:212
+#: src/olympia/devhub/views.py:211
 msgid "Add-on Status"
 msgstr "Estado do extra"
 
-#: src/olympia/devhub/views.py:213
+#: src/olympia/devhub/views.py:212
 msgid "User Collections"
 msgstr "Coleções do utilizador"
 
-#: src/olympia/devhub/views.py:214 src/olympia/devhub/templates/devhub/docs/policies-maintenance.html:68 src/olympia/pages/templates/pages/dev_faq.html:38
+#: src/olympia/devhub/views.py:213 src/olympia/devhub/templates/devhub/docs/policies-maintenance.html:68 src/olympia/pages/templates/pages/dev_faq.html:38
 #: src/olympia/pages/templates/pages/dev_faq.html:484
 msgid "User Reviews"
 msgstr "Comentários do utilizador"
 
-#: src/olympia/devhub/views.py:327 src/olympia/devhub/views.py:331 src/olympia/devhub/views.py:484 src/olympia/devhub/views.py:513 src/olympia/devhub/views.py:564 src/olympia/devhub/views.py:1150
+#: src/olympia/devhub/views.py:326 src/olympia/devhub/views.py:330 src/olympia/devhub/views.py:485 src/olympia/devhub/views.py:514 src/olympia/devhub/views.py:565 src/olympia/devhub/views.py:1157
 msgid "Changes successfully saved."
 msgstr "Alterações guardadas com sucesso."
 
-#: src/olympia/devhub/views.py:334 src/olympia/devhub/views.py:1631
+#: src/olympia/devhub/views.py:333 src/olympia/devhub/views.py:1638
 msgid "Please check the form for errors."
 msgstr "Por favor confirme se o formulário tem erros."
 
-#: src/olympia/devhub/views.py:346
+#: src/olympia/devhub/views.py:345
 msgid "Add-on cannot be deleted. Disable this add-on instead."
 msgstr "O extra não pode ser eliminado. Em vez disso desative este extra."
 
-#: src/olympia/devhub/views.py:356
+#: src/olympia/devhub/views.py:355
 msgid "Theme deleted."
 msgstr "Tema eliminado."
 
-#: src/olympia/devhub/views.py:356
+#: src/olympia/devhub/views.py:355
 msgid "Add-on deleted."
 msgstr "Extra eliminado."
 
-#: src/olympia/devhub/views.py:362
+#: src/olympia/devhub/views.py:361
 msgid "URL name was incorrect. Theme was not deleted."
 msgstr ""
 
-#: src/olympia/devhub/views.py:367
+#: src/olympia/devhub/views.py:366
 msgid "URL name was incorrect. Add-on was not deleted."
 msgstr ""
 
-#: src/olympia/devhub/views.py:449
+#: src/olympia/devhub/views.py:450
 msgid "An author has been added to your add-on"
 msgstr "Foi adicionado um autor ao seu extra"
 
-#: src/olympia/devhub/views.py:456
+#: src/olympia/devhub/views.py:457
 msgid "An author has a role changed on your add-on"
 msgstr "Um autor teve o seu papel alterado no seu extra"
 
-#: src/olympia/devhub/views.py:476
+#: src/olympia/devhub/views.py:477
 msgid "An author has been removed from your add-on"
 msgstr "Foi removido um autor do seu extra"
 
-#: src/olympia/devhub/views.py:519
+#: src/olympia/devhub/views.py:520
 msgid "There were errors in your submission."
 msgstr "Ocorreram erros na sua submissão."
 
-#: src/olympia/devhub/views.py:583
+#: src/olympia/devhub/views.py:584
 msgid "Validate Add-on"
 msgstr "Validar extra"
 
-#: src/olympia/devhub/views.py:594
+#: src/olympia/devhub/views.py:595
 msgid "Check Add-on Compatibility"
 msgstr "Verifique a compatibilidade do extra"
 
-#: src/olympia/devhub/views.py:808 src/olympia/signing/views.py:90
+#: src/olympia/devhub/views.py:809 src/olympia/signing/views.py:95
 msgid "You cannot submit this type of add-on"
 msgstr ""
 
-#: src/olympia/devhub/views.py:1051 src/olympia/users/forms.py:471
+#: src/olympia/devhub/views.py:1052 src/olympia/users/forms.py:471
 msgid "Images must be either PNG or JPG."
 msgstr "As imagens devem ser PNG ou JPG."
 
-#: src/olympia/devhub/views.py:1055
+#: src/olympia/devhub/views.py:1056
 msgid "Icons cannot be animated."
 msgstr "Os ícones não podem ser animados."
 
-#: src/olympia/devhub/views.py:1057
+#: src/olympia/devhub/views.py:1058
 msgid "Images cannot be animated."
 msgstr "As imagens não podem ser animadas."
 
-#: src/olympia/devhub/views.py:1070
+#: src/olympia/devhub/views.py:1071
 #, python-format
 msgid "Images cannot be larger than %dKB."
 msgstr "As imagens não podem ser maiores que %dKB."
 
 #. L10n: {0} is an image width (in pixels), {1} is a height.
-#: src/olympia/devhub/views.py:1080
+#: src/olympia/devhub/views.py:1081
 msgid "Image must be exactly {0} pixels wide and {1} pixels tall."
 msgstr "A imagem tem de ter exatamente {0} pixeis de largura e {1} pixeis de altura."
 
-#: src/olympia/devhub/views.py:1087
+#: src/olympia/devhub/views.py:1088
 msgid "There was an error uploading your preview."
 msgstr "Ocorreu um erro ao carregar a sua pré-visualização."
 
-#: src/olympia/devhub/views.py:1189
+#: src/olympia/devhub/views.py:1196
 #, python-format
 msgid "Version %s disabled."
 msgstr "Versão %s desativada."
 
-#: src/olympia/devhub/views.py:1193
+#: src/olympia/devhub/views.py:1200
 #, python-format
 msgid "Version %s deleted."
 msgstr "Versão %s eliminada."
 
-#: src/olympia/devhub/views.py:1203
+#: src/olympia/devhub/views.py:1210
 msgid "This upload has failed validation, and may lack complete validation results. Please take due care when reviewing it."
 msgstr "Este envio falhou a validação e pode não ter os resultados completos da validação. Por favor tenha cuidado quando o estiver a rever."
 
-#: src/olympia/devhub/views.py:1677
+#: src/olympia/devhub/views.py:1684
 msgid "Preliminary Review Requested."
 msgstr "Solicitada uma revisão preliminar."
 
-#: src/olympia/devhub/views.py:1678
+#: src/olympia/devhub/views.py:1685
 msgid "Full Review Requested."
 msgstr "Solicitada uma revisão completa."
 
-#: src/olympia/devhub/views.py:1779
+#: src/olympia/devhub/views.py:1786
 msgid "Your old credentials were revoked and are no longer valid. Be sure to update all API clients with the new credentials."
 msgstr ""
 
-#: src/olympia/devhub/views.py:1797
+#: src/olympia/devhub/views.py:1804
 msgid "New API key created"
 msgstr ""
 
@@ -4049,10 +4023,10 @@ msgstr "Voltar aos extras"
 msgid "{0} :: Search"
 msgstr "{0} :: Pesquisa"
 
-#: src/olympia/devhub/templates/devhub/devhub_search.html:6 src/olympia/devhub/templates/devhub/search.html:8 src/olympia/editors/forms.py:435 src/olympia/editors/forms.py:437
+#: src/olympia/devhub/templates/devhub/devhub_search.html:6 src/olympia/devhub/templates/devhub/search.html:8 src/olympia/editors/forms.py:534 src/olympia/editors/forms.py:536
 #: src/olympia/editors/templates/editors/queue.html:27 src/olympia/editors/templates/editors/themes/queue_list.html:14 src/olympia/search/templates/search/collections.html:17
-#: src/olympia/search/templates/search/personas.html:18 src/olympia/search/templates/search/results.html:18 src/olympia/search/templates/search/mobile/results.html:8
-#: src/olympia/templates/search.html:14 src/olympia/templates/impala/search.html:18
+#: src/olympia/search/templates/search/personas.html:18 src/olympia/search/templates/search/results.html:18 src/olympia/search/templates/search/mobile/results.html:8 src/olympia/templates/search.html:14
+#: src/olympia/templates/impala/search.html:18
 msgid "Search"
 msgstr "Pesquisar"
 
@@ -4096,13 +4070,13 @@ msgstr "Saber tudo sobre extras"
 
 #: src/olympia/devhub/templates/devhub/index.html:41
 msgid ""
-"Add-ons let millions of Firefox users enhance and customize their browsing experience. If you're a Web developer and know <a href=\"https://developer.mozilla.org/docs/Web/HTML\">HTML</a>, <a href="
-"\"https://developer.mozilla.org/docs/Web/JavaScript\">JavaScript</a>, and <a href=\"https://developer.mozilla.org/docs/Web/CSS\">CSS</a>, you already have all the necessary skills to make a great "
-"add-on."
+"Add-ons let millions of Firefox users enhance and customize their browsing experience. If you're a Web developer and know <a href=\"https://developer.mozilla.org/docs/Web/HTML\">HTML</a>, <a "
+"href=\"https://developer.mozilla.org/docs/Web/JavaScript\">JavaScript</a>, and <a href=\"https://developer.mozilla.org/docs/Web/CSS\">CSS</a>, you already have all the necessary skills to make a "
+"great add-on."
 msgstr ""
-"Os extras permitem que milhões de utilizadores do Firefox melhorem e personalizem a sua experiência de navegação. Se é um programador web e sabe <a href=\"https://developer.mozilla.org/docs/Web/HTML"
-"\">HTML</a>, <a href=\"https://developer.mozilla.org/docs/Web/JavaScript\">JavaScript</a> e <a href=\"https://developer.mozilla.org/docs/Web/CSS\">CSS</a>, então já tem todas as capacidades "
-"necessárias para fazer um ótimo extra."
+"Os extras permitem que milhões de utilizadores do Firefox melhorem e personalizem a sua experiência de navegação. Se é um programador web e sabe <a "
+"href=\"https://developer.mozilla.org/docs/Web/HTML\">HTML</a>, <a href=\"https://developer.mozilla.org/docs/Web/JavaScript\">JavaScript</a> e <a "
+"href=\"https://developer.mozilla.org/docs/Web/CSS\">CSS</a>, então já tem todas as capacidades necessárias para fazer um ótimo extra."
 
 #: src/olympia/devhub/templates/devhub/index.html:51
 msgid "Head over to the <a href=\"https://developer.mozilla.org/Add-ons\">Mozilla Developer Network</a> to learn everything you need to know to get started."
@@ -4112,12 +4086,12 @@ msgstr "Visite a <a href=\"https://developer.mozilla.org/Add-ons\">Rede de Progr
 msgid "Start Making Add-ons"
 msgstr "Começar a fazer extras"
 
-#: src/olympia/devhub/templates/devhub/index.html:86 src/olympia/devhub/templates/devhub/addons/listing/items.html:25 src/olympia/devhub/templates/devhub/includes/addon_details.html:15
+#: src/olympia/devhub/templates/devhub/index.html:86 src/olympia/devhub/templates/devhub/addons/listing/items.html:25 src/olympia/devhub/templates/devhub/includes/addon_details.html:20
 #: src/olympia/devhub/templates/devhub/personas/edit.html:43
 msgid "Status:"
 msgstr "Estado:"
 
-#: src/olympia/devhub/templates/devhub/index.html:90 src/olympia/devhub/templates/devhub/includes/addon_details.html:100
+#: src/olympia/devhub/templates/devhub/index.html:90 src/olympia/devhub/templates/devhub/includes/addon_details.html:87
 msgid "Visibility:"
 msgstr "Visibilidade:"
 
@@ -4125,11 +4099,11 @@ msgstr "Visibilidade:"
 msgid "Latest Version:"
 msgstr "Última versão:"
 
-#: src/olympia/devhub/templates/devhub/index.html:109 src/olympia/devhub/templates/devhub/includes/addon_details.html:145 src/olympia/devhub/templates/devhub/personas/edit.html:49
+#: src/olympia/devhub/templates/devhub/index.html:109 src/olympia/devhub/templates/devhub/includes/addon_details.html:131 src/olympia/devhub/templates/devhub/personas/edit.html:49
 msgid "Queue Position:"
 msgstr "Posição na fila:"
 
-#: src/olympia/devhub/templates/devhub/index.html:110 src/olympia/devhub/templates/devhub/includes/addon_details.html:146 src/olympia/devhub/templates/devhub/personas/edit.html:50
+#: src/olympia/devhub/templates/devhub/index.html:110 src/olympia/devhub/templates/devhub/includes/addon_details.html:132 src/olympia/devhub/templates/devhub/personas/edit.html:50
 #, python-format
 msgid "%(position)s of %(total)s"
 msgstr "%(position)s de %(total)s"
@@ -4231,16 +4205,6 @@ msgstr "Depois de enviado, serão executados uma série de testes automáticos d
 msgid "Do you want your add-on to be distributed on this site?"
 msgstr "Gostaria que o seu extra fosse distribuído neste sítio?"
 
-#: src/olympia/devhub/templates/devhub/validate_addon.html:49 src/olympia/devhub/templates/devhub/addons/submit/upload.html:30 src/olympia/devhub/templates/devhub/versions/add_file_modal.html:14
-#: src/olympia/devhub/templates/devhub/versions/add_file_modal.html:53 src/olympia/devhub/templates/devhub/versions/list.html:298
-msgid "Warning:"
-msgstr "Aviso:"
-
-#: src/olympia/devhub/templates/devhub/validate_addon.html:50 src/olympia/devhub/templates/devhub/addons/submit/upload.html:31
-#, python-format
-msgid "Submission of unlisted add-ons for signing is currently in an open beta. Please <a href=\"%(url)s\" target=\"_blank\">report any bugs</a> that you encounter."
-msgstr ""
-
 #. first parameter is a filename like lorem-ipsum-1.0.2.xpi
 #: src/olympia/devhub/templates/devhub/validation.html:5
 msgid "Validation Results for {0}"
@@ -4301,11 +4265,11 @@ msgstr ""
 #: src/olympia/devhub/templates/devhub/addons/ajax_compat_error.html:15
 #, python-format
 msgid ""
-"<a href=\"#\" class=\"button compat-update\" data-updateurl=\"%(update_url)s\">Update Compatibility</a> <a href=\"%(version_url)s\" class=\"button\">Upload New Version</a> or <a href=\"#\" class="
-"\"close\">Ignore</a>"
+"<a href=\"#\" class=\"button compat-update\" data-updateurl=\"%(update_url)s\">Update Compatibility</a> <a href=\"%(version_url)s\" class=\"button\">Upload New Version</a> or <a href=\"#\" "
+"class=\"close\">Ignore</a>"
 msgstr ""
-"<a href=\"#\" class=\"button compat-update\" data-updateurl=\"%(update_url)s\">Atualizar a compatibilidade</a> <a href=\"%(version_url)s\" class=\"button\">Submeter uma nova versão</a> ou <a href="
-"\"#\" class=\"close\">Ignorar</a>"
+"<a href=\"#\" class=\"button compat-update\" data-updateurl=\"%(update_url)s\">Atualizar a compatibilidade</a> <a href=\"%(version_url)s\" class=\"button\">Submeter uma nova versão</a> ou <a "
+"href=\"#\" class=\"close\">Ignorar</a>"
 
 #: src/olympia/devhub/templates/devhub/addons/ajax_compat_status.html:5
 msgid "View and update application compatibility ranges."
@@ -4331,9 +4295,9 @@ msgstr "Versões suportadas"
 msgid "Add Another Application&hellip;"
 msgstr "Adicionar outra aplicação&hellip;"
 
-#: src/olympia/devhub/templates/devhub/addons/ajax_compat_update.html:38 src/olympia/devhub/templates/devhub/addons/owner.html:86 src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:46
-#: src/olympia/devhub/templates/devhub/versions/list.html:351 src/olympia/devhub/templates/devhub/versions/list.html:353 src/olympia/templates/impala/base.html:132
-#: src/olympia/templates/impala/base.html:143 src/olympia/templates/impala/base.html:161 src/olympia/templates/impala/base.html:171
+#: src/olympia/devhub/templates/devhub/addons/ajax_compat_update.html:38 src/olympia/devhub/templates/devhub/addons/owner.html:86 src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:45
+#: src/olympia/devhub/templates/devhub/versions/list.html:349 src/olympia/devhub/templates/devhub/versions/list.html:351 src/olympia/templates/impala/base.html:129
+#: src/olympia/templates/impala/base.html:140 src/olympia/templates/impala/base.html:158 src/olympia/templates/impala/base.html:168
 msgid "Close"
 msgstr "Fechar"
 
@@ -4367,7 +4331,7 @@ msgstr "Nenhum"
 msgid "Manage Authors & License"
 msgstr "Gerir autores e licença"
 
-#: src/olympia/devhub/templates/devhub/addons/owner.html:29 src/olympia/editors/templates/editors/review.html:270
+#: src/olympia/devhub/templates/devhub/addons/owner.html:29 src/olympia/editors/helpers.py:362 src/olympia/editors/templates/editors/review.html:270
 msgid "Authors"
 msgstr "Autores"
 
@@ -4438,11 +4402,10 @@ msgid "Summary"
 msgstr "Resumo"
 
 #: src/olympia/devhub/templates/devhub/addons/edit/basic.html:52
-msgid ""
-"A short explanation of your add-on's basic functionality that is displayed in search and browse listings, as well as at the top of your add-on's details page. It is only relevant for listed add-ons."
+msgid "A short explanation of your add-on's basic functionality that is displayed in search and browse listings, as well as at the top of your add-on's details page. It is only relevant for listed add-ons."
 msgstr ""
-"Uma explicação curta da funcionalidade básica do seu extra que é apresentada em listas de pesquisas e de navegação, bem como no topo da página de detalhes do seu extra. Isto apenas é relevante para "
-"extras listados."
+"Uma explicação curta da funcionalidade básica do seu extra que é apresentada em listas de pesquisas e de navegação, bem como no topo da página de detalhes do seu extra. Isto apenas é relevante para"
+" extras listados."
 
 #: src/olympia/devhub/templates/devhub/addons/edit/basic.html:73
 msgid "Categories are the primary way users browse through add-ons. Choose any that fit your add-on's functionality for the most exposure. It is only relevant for listed add-ons."
@@ -4452,8 +4415,7 @@ msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/basic.html:90
 #, python-format
-msgid ""
-"Categories cannot be changed while your add-on is featured for this application. Please email <a href=\"mailto:%(email)s\">%(email)s</a> if there is a reason you need to modify your categories."
+msgid "Categories cannot be changed while your add-on is featured for this application. Please email <a href=\"mailto:%(email)s\">%(email)s</a> if there is a reason you need to modify your categories."
 msgstr ""
 "As categorias não podem ser alteradas enquanto o seu extra estiver em destaque para esta aplicação. Por favor, envie uma mensagem de correio para <a href=\"mailto:%(email)s\">%(email)s</a> se "
 "existir um motivo pelo qual necessite de modificar as suas categorias."
@@ -4780,16 +4742,14 @@ msgid "Deleting your add-on will permanently remove it from the site and prevent
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:24
-msgid ""
-"Enter the following text confirm your decision:\n"
-"           {slug}"
+msgid "Enter the following text confirm your decision: {slug}"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:34
+#: src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:33
 msgid "Please tell us why you are deleting your theme:"
 msgstr "Por favor diga-nos porque está a eliminar o seu tema:"
 
-#: src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:36
+#: src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:35
 msgid "Please tell us why you are deleting your add-on:"
 msgstr "Por favor diga-nos porque está a eliminar o seu extra:"
 
@@ -4826,13 +4786,13 @@ msgstr "Nova versão"
 msgid "Daily statistics on downloads and users."
 msgstr "Estatísticas diárias sobre transferências e utilizadores."
 
-#: src/olympia/devhub/templates/devhub/addons/listing/item_actions.html:45 src/olympia/stats/templates/stats/stats.html:75 src/olympia/stats/templates/stats/stats.html:79
-#: src/olympia/stats/templates/stats/stats.html:81
+#: src/olympia/devhub/templates/devhub/addons/listing/item_actions.html:45 src/olympia/stats/templates/stats/stats.html:31 src/olympia/stats/templates/stats/stats.html:35
+#: src/olympia/stats/templates/stats/stats.html:37
 msgid "Statistics"
 msgstr "Estatísticas"
 
-#: src/olympia/devhub/templates/devhub/addons/listing/item_actions.html:54 src/olympia/devhub/templates/devhub/includes/addons_edit_nav.html:5
-#: src/olympia/devhub/templates/devhub/payments/payments.html:3 src/olympia/devhub/templates/devhub/payments/tier.html:4
+#: src/olympia/devhub/templates/devhub/addons/listing/item_actions.html:54 src/olympia/devhub/templates/devhub/includes/addons_edit_nav.html:5 src/olympia/devhub/templates/devhub/payments/payments.html:3
+#: src/olympia/devhub/templates/devhub/payments/tier.html:4
 msgid "Manage Payments"
 msgstr "Gerir pagamentos"
 
@@ -5154,14 +5114,13 @@ msgstr "Passo 2. Envie o seu extra"
 
 #: src/olympia/devhub/templates/devhub/addons/submit/upload.html:11
 msgid "Use the fields below to upload your add-on package and select any platform restrictions. After upload, a series of automated validation tests will be run on your file."
-msgstr ""
-"Utilize os campos abaixo para submeter o pacote do seu extra e selecionar quaisquer restrições de plataforma. Depois do envio, uma série de testes automáticos irão ser executados no seu ficheiro."
+msgstr "Utilize os campos abaixo para submeter o pacote do seu extra e selecionar quaisquer restrições de plataforma. Depois do envio, uma série de testes automáticos irão ser executados no seu ficheiro."
 
-#: src/olympia/devhub/templates/devhub/addons/submit/upload.html:59 src/olympia/devhub/templates/devhub/versions/add_file_modal.html:39
+#: src/olympia/devhub/templates/devhub/addons/submit/upload.html:51 src/olympia/devhub/templates/devhub/versions/add_file_modal.html:28
 msgid "Which platforms is this file compatible with?"
 msgstr "Com que plataformas é este ficheiro compatível?"
 
-#: src/olympia/devhub/templates/devhub/addons/submit/upload.html:67 src/olympia/devhub/templates/devhub/versions/add_file_modal.html:65
+#: src/olympia/devhub/templates/devhub/addons/submit/upload.html:59 src/olympia/devhub/templates/devhub/versions/add_file_modal.html:45
 msgid "Administrative overrides"
 msgstr "Sobreposições administrativas"
 
@@ -5189,8 +5148,8 @@ msgstr "Segredo JWT"
 #: src/olympia/devhub/templates/devhub/api/key.html:37
 #, python-format
 msgid ""
-"To make API requests, send a <a href=\"%(jwt_url)s\">JSON Web Token (JWT)</a> as the authorization header. You'll need to generate a JWT for every request as explained in the <a href=\"%(docs_url)s"
-"\">API documentation</a>."
+"To make API requests, send a <a href=\"%(jwt_url)s\">JSON Web Token (JWT)</a> as the authorization header. You'll need to generate a JWT for every request as explained in the <a "
+"href=\"%(docs_url)s\">API documentation</a>."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/api/key.html:47
@@ -5210,8 +5169,8 @@ msgstr ""
 msgid "Generate new credentials"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/docs/policies-agreement.html:3 src/olympia/devhub/templates/devhub/docs/policies-agreement.html:7
-#: src/olympia/devhub/templates/devhub/docs/policies-agreement.html:9 src/olympia/devhub/templates/devhub/docs/policies.html:24 src/olympia/devhub/templates/devhub/docs/policies.html:103
+#: src/olympia/devhub/templates/devhub/docs/policies-agreement.html:3 src/olympia/devhub/templates/devhub/docs/policies-agreement.html:7 src/olympia/devhub/templates/devhub/docs/policies-agreement.html:9
+#: src/olympia/devhub/templates/devhub/docs/policies.html:24 src/olympia/devhub/templates/devhub/docs/policies.html:103
 msgid "Developer Agreement"
 msgstr "Acordo de programador"
 
@@ -5222,8 +5181,7 @@ msgstr "Contacte-nos"
 
 #: src/olympia/devhub/templates/devhub/docs/policies-contact.html:12
 msgid "Thanks for your interest in contacting the Mozilla Add-ons team. Please read this page carefully to ensure your request goes to the right place."
-msgstr ""
-"Obrigado pelo seu interesse em entrar em contacto com a equipa de extras da Mozilla. Por favor, leia esta página cuidadosamente para garantir que o seu pedido é encaminhado para o sítio certo."
+msgstr "Obrigado pelo seu interesse em entrar em contacto com a equipa de extras da Mozilla. Por favor, leia esta página cuidadosamente para garantir que o seu pedido é encaminhado para o sítio certo."
 
 #: src/olympia/devhub/templates/devhub/docs/policies-contact.html:17
 msgid "Add-on Support"
@@ -5248,11 +5206,11 @@ msgstr "amo-editors arroba mozilla ponto org"
 #: src/olympia/devhub/templates/devhub/docs/policies-contact.html:26
 #, python-format
 msgid ""
-"If you have a question about an Editor's review of an add-on or want to report a policy violation, please email %(mail_editors)s. <strong>Almost all add-on reports fall under this category.</"
-"strong> Please be sure to include a link to the add-on in question and a detailed description of your question or comment."
+"If you have a question about an Editor's review of an add-on or want to report a policy violation, please email %(mail_editors)s. <strong>Almost all add-on reports fall under this "
+"category.</strong> Please be sure to include a link to the add-on in question and a detailed description of your question or comment."
 msgstr ""
-"Se tiver uma pergunta sobre um comentário de um editor de um extra ou quer denunciar uma violação de uma política, por favor envie uma mensagem de correio para %(mail_editors)s. <strong>Quase todas "
-"as denúncias de extras enquadram-se nesta categoria.</strong> Por favor não se esqueça de incluir uma ligação para o extra em questão e uma descrição detalhada da sua questão ou comentário."
+"Se tiver uma pergunta sobre um comentário de um editor de um extra ou quer denunciar uma violação de uma política, por favor envie uma mensagem de correio para %(mail_editors)s. <strong>Quase todas"
+" as denúncias de extras enquadram-se nesta categoria.</strong> Por favor não se esqueça de incluir uma ligação para o extra em questão e uma descrição detalhada da sua questão ou comentário."
 
 #: src/olympia/devhub/templates/devhub/docs/policies-contact.html:31
 msgid "Add-on Security Vulnerabilities"
@@ -5266,12 +5224,12 @@ msgstr "amo-admins arroba mozilla ponto org"
 #, python-format
 msgid ""
 "If you have discovered a security vulnerability in an add-on, even if it is not hosted here, Mozilla is very interested in your discovery and will work with the add-on developer to correct the "
-"issue as soon as possible. Add-on security issues can be reported <a href=\"http://www.mozilla.org/projects/security/security-bugs-policy.html\">confidentially</a> in <a href=\"%(link_bugzilla)s"
-"\">Bugzilla</a> or by emailing %(mail_admins)s."
+"issue as soon as possible. Add-on security issues can be reported <a href=\"http://www.mozilla.org/projects/security/security-bugs-policy.html\">confidentially</a> in <a "
+"href=\"%(link_bugzilla)s\">Bugzilla</a> or by emailing %(mail_admins)s."
 msgstr ""
 "Se descobriu uma vulnerabilidade de segurança num extra, mesmo que não esteja alojado aqui, a Mozilla está muito interessada na sua descoberta e vai trabalhar com o programador do extra para "
-"corrigir o problema o mais rapidamente possível. Problemas de segurança de extras podem ser reportados <a href=\"http://www.mozilla.org/projects/security/security-bugs-policy.html"
-"\">confidencialmente</a> no <a href=\"%(link_bugzilla)s\">Bugzilla</a> ou enviando uma mensagem de correio para %(mail_admins)s."
+"corrigir o problema o mais rapidamente possível. Problemas de segurança de extras podem ser reportados <a href=\"http://www.mozilla.org/projects/security/security-bugs-"
+"policy.html\">confidencialmente</a> no <a href=\"%(link_bugzilla)s\">Bugzilla</a> ou enviando uma mensagem de correio para %(mail_admins)s."
 
 #: src/olympia/devhub/templates/devhub/docs/policies-contact.html:42
 msgid "Website Functionality & Development"
@@ -5279,8 +5237,8 @@ msgstr "Funcionalidade ou programação do site web"
 
 #: src/olympia/devhub/templates/devhub/docs/policies-contact.html:44
 msgid ""
-"If you've found a problem with the site, we'd love to fix it. Please <a href=\"https://github.com/mozilla/olympia/issues\">file a bug report</a> in GitHub, including the location of the problem and "
-"how you encountered it."
+"If you've found a problem with the site, we'd love to fix it. Please <a href=\"https://github.com/mozilla/addons/issues/new\">file a bug report</a> in GitHub, including the location of the problem "
+"and how you encountered it."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/docs/policies-maintenance.html:3 src/olympia/devhub/templates/devhub/docs/policies-maintenance.html:7
@@ -5294,19 +5252,19 @@ msgstr "Submeter novas versões do seu extra"
 
 #: src/olympia/devhub/templates/devhub/docs/policies-maintenance.html:12
 msgid ""
-"Developers are encouraged to submit updates to their add-ons to fix bugs, add features, and otherwise improve their product. New versions of an add-on must have a <a href=\"https://developer."
-"mozilla.org/en/Toolkit_version_format\">higher version number</a> and can be submitted through the Developer Tools provided. There is no limit to the number of versions that can be submitted, but "
-"please remember that versions must be reviewed by an editor."
+"Developers are encouraged to submit updates to their add-ons to fix bugs, add features, and otherwise improve their product. New versions of an add-on must have a <a "
+"href=\"https://developer.mozilla.org/en/Toolkit_version_format\">higher version number</a> and can be submitted through the Developer Tools provided. There is no limit to the number of versions "
+"that can be submitted, but please remember that versions must be reviewed by an editor."
 msgstr ""
 "Os programadores são encorajados a apresentar atualizações para os seus extras para corrigir problemas, adicionar funcionalidades ou melhorar o seu produto. Novas versões de um extra devem ter um "
-"<a href=\"https://developer.mozilla.org/en/Toolkit_version_format\">número de versão superior</a> e podem ser enviadas através das Ferramentas do programador fornecidas. Não há limite para o número "
-"de versões que podem ser enviadas, mas lembre-se que as versões devem ser revistas ​​por um editor."
+"<a href=\"https://developer.mozilla.org/en/Toolkit_version_format\">número de versão superior</a> e podem ser enviadas através das Ferramentas do programador fornecidas. Não há limite para o número"
+" de versões que podem ser enviadas, mas lembre-se que as versões devem ser revistas ​​por um editor."
 
 #: src/olympia/devhub/templates/devhub/docs/policies-maintenance.html:18
 msgid "New versions will be added to a pending review queue, and any additional versions submitted before the review is completed will move that version to the end of the queue."
 msgstr ""
-"Novas versões serão adicionados a uma fila de revisão onde ficarão pendentes e todas as versões adicionais enviadas antes de a revisão ser concluída vão fazer com que essa versão passe para o final "
-"da fila."
+"Novas versões serão adicionados a uma fila de revisão onde ficarão pendentes e todas as versões adicionais enviadas antes de a revisão ser concluída vão fazer com que essa versão passe para o final"
+" da fila."
 
 #: src/olympia/devhub/templates/devhub/docs/policies-maintenance.html:23
 msgid "How do I submit a Beta add-on?"
@@ -5354,8 +5312,8 @@ msgid ""
 "developers to reasonably accommodate their own schedules, but if the issue is of a serious enough nature, add-ons that cannot issue an update with the requested fix may be demoted from fully-"
 "reviewed status, disabled, or permanently removed from the site."
 msgstr ""
-"Podem surgir situações em que a Mozilla pode pedir a um programador de um extra para atualizar os seus extras dentro de um determinado período de tempo para resolver um grande problema de segurança "
-"ou uma violação de uma política. Trabalhamos com os programadores para acomodar de forma razoável as suas próprias planificações, mas se o problema tiver uma natureza suficientemente grave, os "
+"Podem surgir situações em que a Mozilla pode pedir a um programador de um extra para atualizar os seus extras dentro de um determinado período de tempo para resolver um grande problema de segurança"
+" ou uma violação de uma política. Trabalhamos com os programadores para acomodar de forma razoável as suas próprias planificações, mas se o problema tiver uma natureza suficientemente grave, os "
 "extras que não lançarem uma atualização com a correção necessária podem ser despromovidos de categoria de totalmente revistos, ser desativados ou removidos de forma permanentemente do site."
 
 #: src/olympia/devhub/templates/devhub/docs/policies-maintenance.html:55
@@ -5377,11 +5335,11 @@ msgstr "A Mozilla pode ajudar com a concessão de permissões adicionais de uma 
 
 #: src/olympia/devhub/templates/devhub/docs/policies-maintenance.html:70
 msgid ""
-"Mozilla encourages its users to offer feedback on their experiences when using an add-on. This allows other users to determine if the add-on is stable and useful. It also provides valuable feedback "
-"to developers, allowing them to continuously improve their add-on to meet user needs."
+"Mozilla encourages its users to offer feedback on their experiences when using an add-on. This allows other users to determine if the add-on is stable and useful. It also provides valuable feedback"
+" to developers, allowing them to continuously improve their add-on to meet user needs."
 msgstr ""
-"A Mozilla incentiva os seus utilizadores a oferecer feedback sobre as suas experiências ao utilizar um extra. Isto permite que outros utilizadores determinem se o extra é estável e útil. Ele também "
-"fornece informações valiosas para os programadores, permitindo-lhes melhorar continuamente os seus extra para atender às necessidades do utilizador."
+"A Mozilla incentiva os seus utilizadores a oferecer feedback sobre as suas experiências ao utilizar um extra. Isto permite que outros utilizadores determinem se o extra é estável e útil. Ele também"
+" fornece informações valiosas para os programadores, permitindo-lhes melhorar continuamente os seus extra para atender às necessidades do utilizador."
 
 #: src/olympia/devhub/templates/devhub/docs/policies-maintenance.html:76
 #, python-format
@@ -5422,8 +5380,7 @@ msgstr ""
 
 #: src/olympia/devhub/templates/devhub/docs/policies-maintenance.html:102
 msgid "If you are unsure of the current copyright status of an add-on's source code, you must contact the original author and receive explicit permission before using the source code."
-msgstr ""
-"Se não tiver a certeza sobre o estado dos direitos de autor atuais sobre o código fonte de um extra, deve contactar o autor original e obter permissão explícita antes de utilizar o código fonte."
+msgstr "Se não tiver a certeza sobre o estado dos direitos de autor atuais sobre o código fonte de um extra, deve contactar o autor original e obter permissão explícita antes de utilizar o código fonte."
 
 #: src/olympia/devhub/templates/devhub/docs/policies-maintenance.html:107 src/olympia/devhub/templates/devhub/docs/policies-reviews.html:306
 #: src/olympia/devhub/templates/devhub/docs/policies-submission.html:97
@@ -5440,8 +5397,7 @@ msgstr ""
 "mostram o poder da personalização do Firefox e são úteis para uma audiência mais ampla."
 
 #: src/olympia/devhub/templates/devhub/docs/policies-recommended.html:19
-msgid ""
-"Featured add-ons are chosen by the Featured Add-ons Advisory Board, a small group of add-on developers and fans from the Mozilla community who have volunteered to review and vote on nominations."
+msgid "Featured add-ons are chosen by the Featured Add-ons Advisory Board, a small group of add-on developers and fans from the Mozilla community who have volunteered to review and vote on nominations."
 msgstr ""
 "Os extras em destaque são escolhidos pelo Conselho Consultivo de Extras em destaque, um pequeno grupo de programadores e fãs de extras da comunidade Mozilla que se voluntariaram para rever e votar "
 "em nomeados."
@@ -5538,8 +5494,8 @@ msgid ""
 "suboptimal user experience, quality or security issues, incompatibility, and similarity to another featured add-on. Rejected add-ons cannot be re-nominated within 3 months."
 msgstr ""
 "As nomeações de extras são revistas pelo Conselho Consultivo uma vez por mês (uma todos os 3 meses para nomeações de tema completas). As razões mais comuns de rejeição incluem falta de apelo aos "
-"consumidores, experiência de utilizador não ideal, qualidade ou problemas de segurança, incompatibilidade e semelhanças com outro extra destacado. Extras rejeitados não podem ser novamente nomeados "
-"durante 3 meses. "
+"consumidores, experiência de utilizador não ideal, qualidade ou problemas de segurança, incompatibilidade e semelhanças com outro extra destacado. Extras rejeitados não podem ser novamente nomeados"
+" durante 3 meses. "
 
 #: src/olympia/devhub/templates/devhub/docs/policies-recommended.html:73
 msgid "Rotating Featured Add-ons"
@@ -5566,8 +5522,8 @@ msgid ""
 "Incompatibility with upcoming Firefox versions &mdash; Featured add-ons are expected to be compatible with stable and beta versions of Firefox. Add-ons not yet compatible with a Beta version of "
 "Firefox four weeks before its expected release will lose their featured status."
 msgstr ""
-"Incompatibilidade com as próximas versões do Firefox &mdash; Espera-se que os extras em destaque sejam compatíveis com as versões estável e beta do Firefox. Extras que ainda não são compatíveis com "
-"uma versão beta do Firefox quatro semanas antes de esta ser lançada perdem o seu estatuto de destaque."
+"Incompatibilidade com as próximas versões do Firefox &mdash; Espera-se que os extras em destaque sejam compatíveis com as versões estável e beta do Firefox. Extras que ainda não são compatíveis com"
+" uma versão beta do Firefox quatro semanas antes de esta ser lançada perdem o seu estatuto de destaque."
 
 #: src/olympia/devhub/templates/devhub/docs/policies-recommended.html:99
 msgid "Joining the Featured Add-ons Advisory Board"
@@ -5647,12 +5603,12 @@ msgstr ""
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:31
 msgid ""
-"Detailed descriptions of each option are below. After selecting a review process at submission, the add-on will be placed in the queue. Add-ons are reviewed by the <a href=\"https://wiki.mozilla."
-"org/AMO:Editors\">AMO Editors</a>, a group of talented developers that volunteer to help the Mozilla project by reviewing add-ons to ensure a stable and safe experience for users. Developers will "
-"receive an email with any updates throughout the review process."
+"Detailed descriptions of each option are below. After selecting a review process at submission, the add-on will be placed in the queue. Add-ons are reviewed by the <a "
+"href=\"https://wiki.mozilla.org/AMO:Editors\">AMO Editors</a>, a group of talented developers that volunteer to help the Mozilla project by reviewing add-ons to ensure a stable and safe experience "
+"for users. Developers will receive an email with any updates throughout the review process."
 msgstr ""
-"Estão disponíveis descrições detalhadas de cada opção abaixo. Após escolher um processo de revisão na submissão, o extra será colocado na fila de revisão. Os extras são analisados pelos <a href="
-"\"https://wiki.mozilla.org/AMO:Editors\">editores do AMO</a>, um grupo de talentosos programadores que se voluntariam para ajudar no projeto Mozilla analisando os extras para garantir uma "
+"Estão disponíveis descrições detalhadas de cada opção abaixo. Após escolher um processo de revisão na submissão, o extra será colocado na fila de revisão. Os extras são analisados pelos <a "
+"href=\"https://wiki.mozilla.org/AMO:Editors\">editores do AMO</a>, um grupo de talentosos programadores que se voluntariam para ajudar no projeto Mozilla analisando os extras para garantir uma "
 "experiência estável e segura para os utilizadores. Os programadores irão receber uma mensagem com quaisquer atualizações durante o processo de revisão."
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:37
@@ -5665,8 +5621,8 @@ msgstr ""
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:44
 msgid ""
-"Full reviews are appropriate for add-ons that are well-tested, stable, fast, and have wide appeal to our users. If you aren't confident that your add-on meets that criteria, please consider working "
-"out the kinks while in preliminary review and accumulating user feedback first."
+"Full reviews are appropriate for add-ons that are well-tested, stable, fast, and have wide appeal to our users. If you aren't confident that your add-on meets that criteria, please consider working"
+" out the kinks while in preliminary review and accumulating user feedback first."
 msgstr ""
 "Análises completas são adequadas para extras bem testados, estáveis, rápidos e que sejam apelativos aos utilizadores. Se não está confiante que o seu extra cumpre estes critérios, considere "
 "resolver os problemas durante a revisão preliminar, recolhendo primeiro feedback dos utilizadores."
@@ -5708,8 +5664,8 @@ msgid ""
 "<strong>JavaScript namespace pollution</strong> &mdash; the most common violation. Be sure to <a href=\"https://developer.mozilla.org/en/XUL_School/JavaScript_Object_Management\">wrap your loose "
 "variables</a>"
 msgstr ""
-"<strong>Poluição do espaço de nomes JavaScript</strong> &mdash; a violação mais comum. Confirme que <a href=\"https://developer.mozilla.org/en/XUL_School/JavaScript_Object_Management\">encapsula as "
-"suas variáveis soltas</a>"
+"<strong>Poluição do espaço de nomes JavaScript</strong> &mdash; a violação mais comum. Confirme que <a href=\"https://developer.mozilla.org/en/XUL_School/JavaScript_Object_Management\">encapsula as"
+" suas variáveis soltas</a>"
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:99
 msgid "proper preference naming - all preference names should begin with \"extensions.\", followed by the add-on name or some other unique identifier"
@@ -5767,8 +5723,8 @@ msgstr ""
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:123
 #, python-format
 msgid ""
-"Many of the above restrictions are tested automatically by an extension scanner that will flag suspicious add-ons for editor review. You can read more about this scanner in the <a href="
-"\"%(link_validation)s\">Validation Help</a> document."
+"Many of the above restrictions are tested automatically by an extension scanner that will flag suspicious add-ons for editor review. You can read more about this scanner in the <a "
+"href=\"%(link_validation)s\">Validation Help</a> document."
 msgstr ""
 "Muitas das restrições acima são testadas automaticamente por um analisador de extensões que sinalizará extras suspeitos para uma revisão por um editor. Pode ler mais sobre este analisador no "
 "documento de <a href=\"%(link_validation)s\">ajuda à validação</a>."
@@ -5791,13 +5747,13 @@ msgid ""
 "Once an add-on is granted full review, it will immediately be available in the gallery, showing in browse and search results with a warning-free install button. All features, including voluntary "
 "contributions and beta channels will be available."
 msgstr ""
-"Assim que o extra for aprovado na revisão completa, ele será imediatamente disponibilizado na galeria, sendo apresentado na navegação e resultados de pesquisa sem alertas ao ser instalado. Todos os "
-"recursos, incluindo doações voluntárias e canais beta, estarão disponíveis."
+"Assim que o extra for aprovado na revisão completa, ele será imediatamente disponibilizado na galeria, sendo apresentado na navegação e resultados de pesquisa sem alertas ao ser instalado. Todos os"
+" recursos, incluindo doações voluntárias e canais beta, estarão disponíveis."
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:142
 msgid ""
-"Subsequent versions of the add-on will automatically be placed in the full review queue. Until the review is completed, the new version will only be displayed on the Version History page of the add-"
-"on. Once reviewed, the version will be updated across the site and deployed through the automatic update service."
+"Subsequent versions of the add-on will automatically be placed in the full review queue. Until the review is completed, the new version will only be displayed on the Version History page of the "
+"add-on. Once reviewed, the version will be updated across the site and deployed through the automatic update service."
 msgstr ""
 "Versões subsequentes do extra serão posicionadas automaticamente na fila de espera de revisões completas. Até que a revisão esteja concluída, a nova versão será apresentada somente no histórico de "
 "versões do extra. Assim que for revista, a versão será atualizada no site e distribuída pelo serviço de atualizações automáticas."
@@ -5815,8 +5771,8 @@ msgid ""
 "Preliminary reviews are appropriate for experimental add-ons and provide a way to get user testing and feedback without going through the longer, more thorough review process. We aim to complete "
 "these reviews in under 3 days."
 msgstr ""
-"Análises preliminares são adequadas para extras experimentais e oferecem uma maneira de os utilizadores testarem e mandarem suas opiniões sem passar pelo processo de revisão mais longo e detalhado. "
-"A nossa meta é completar estas revisões em menos de 3 dias."
+"Análises preliminares são adequadas para extras experimentais e oferecem uma maneira de os utilizadores testarem e mandarem suas opiniões sem passar pelo processo de revisão mais longo e detalhado."
+" A nossa meta é completar estas revisões em menos de 3 dias."
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:160
 msgid "Testing Methods"
@@ -5827,8 +5783,8 @@ msgid ""
 "When performing a preliminary review, editors will review the source code for security issues and major policy violations, but will not install the add-on to test functionality in most cases. "
 "Preliminary review will be granted unless a security vulnerability or major policy violation is discovered."
 msgstr ""
-"Ao realizar uma revisão preliminar, os editores irão analisar o código-fonte em busca de problemas de segurança e violações graves das nossas políticas, mas não irão instalar o extra na maioria dos "
-"casos. As revisões preliminares serão aprovadas a menos que uma vulnerabilidade de segurança ou violação grave das nossas políticas seja encontrada."
+"Ao realizar uma revisão preliminar, os editores irão analisar o código-fonte em busca de problemas de segurança e violações graves das nossas políticas, mas não irão instalar o extra na maioria dos"
+" casos. As revisões preliminares serão aprovadas a menos que uma vulnerabilidade de segurança ou violação grave das nossas políticas seja encontrada."
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:171
 msgid ""
@@ -5849,8 +5805,8 @@ msgid ""
 "Subsequent versions of the add-on will automatically be placed in the preliminary review queue. Until the review is completed, the new version will only be displayed on the Version History page of "
 "the add-on. Once reviewed, the version will be updated across the site and deployed through the automatic update service."
 msgstr ""
-"Versões posteriores do extra serão posicionadas automaticamente na fila de revisões preliminares. Até que a revisão seja concluída, a nova versão será somente apresentada no histórico de versões do "
-"extra. Assim que for revista, a versão será atualizada no site e distribuída pelo serviço de atualizações automáticas."
+"Versões posteriores do extra serão posicionadas automaticamente na fila de revisões preliminares. Até que a revisão seja concluída, a nova versão será somente apresentada no histórico de versões do"
+" extra. Assim que for revista, a versão será atualizada no site e distribuída pelo serviço de atualizações automáticas."
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:188
 msgid "Policies on Specific Add-on Practices"
@@ -5873,8 +5829,8 @@ msgid ""
 "Illegal and criminal add-ons, such as <a href=\"http://en.wikipedia.org/wiki/Click_fraud\">click fraud</a> generators, <a href=\"http://en.wikipedia.org/wiki/Warez\">warez</a> download and "
 "directory assistants, child pornography finders, etc."
 msgstr ""
-"Extras ilegais e criminosos, como <a href=\"http://en.wikipedia.org/wiki/Click_fraud\">geradores de cliques falsos</a>, assistentes de transferências de <a href=\"http://en.wikipedia.org/wiki/Warez"
-"\">warez</a> e assistentes de diretório, pesquisadores de pornografia infantil, etc."
+"Extras ilegais e criminosos, como <a href=\"http://en.wikipedia.org/wiki/Click_fraud\">geradores de cliques falsos</a>, assistentes de transferências de <a "
+"href=\"http://en.wikipedia.org/wiki/Warez\">warez</a> e assistentes de diretório, pesquisadores de pornografia infantil, etc."
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:204
 msgid "Add-ons whose main purpose is to facilitate access to pornographic material, or include references to this material in their descriptions"
@@ -5917,16 +5873,16 @@ msgstr ""
 msgid ""
 "<p> Whenever an add-on includes any unexpected* feature that </p> <ul> <li>compromises user privacy or security (like sending data to third parties),</li> <li>changes default settings like the "
 "homepage or search engine, or</li> <li>changes settings or features in other add-ons or deactivates them altogether</li> </ul> <p>the features must adhere to the following requirements:</p> <ul> "
-"<li>The add-on description must clearly state what changes the add-on makes.</li> <li>All changes must be opt-in, meaning the user must take non-default action to enact the change.</li> <li>The opt-"
-"in dialog must clearly state the name of the add-on requesting the change.</li> <li>Uninstalling the add-on restores the user's original settings if they were changed.</li> </ul> <p>*Unexpected "
-"features are those that are unrelated to the add-on's primary function.</p>"
+"<li>The add-on description must clearly state what changes the add-on makes.</li> <li>All changes must be opt-in, meaning the user must take non-default action to enact the change.</li> <li>The "
+"opt-in dialog must clearly state the name of the add-on requesting the change.</li> <li>Uninstalling the add-on restores the user's original settings if they were changed.</li> </ul> <p>*Unexpected"
+" features are those that are unrelated to the add-on's primary function.</p>"
 msgstr ""
 "<p> Sempre que um extra incluir uma funcionalidade inesperada* que </p> <ul> <li>afete a privacidade ou segurança do utilizador (por exemplo, se enviar dados para terceiros),</li> <li>altere "
 "configurações por omissão como a página inicial ou motor de pesquisa ou</li> <li>altere configurações e funcionalidades de outros extras ou os desative completamente,</li> </ul> <p>as "
 "funcionalidades devem atender aos seguintes requisitos:</p> <ul> <li>A descrição do extra deve listar claramente quais alterações serão efetuadas pelo extra.</li> <li>Todas as alterações deverão "
-"ser implicitamente opcionais, ou seja, deve ser o utilizador a selecionar a opção que não esteja por omissão para ativar a alteração.</li> <li>A janela de opção deve indicar claramente qual o extra "
-"que está a solicitar as alterações.</li> <li>A desinstalação do extra deverá restaurar as configurações originais do utilizador caso as mesmas tenham sido alteradas.</li> </ul> <p>*Funcionalidades "
-"inesperadas são aquelas que não estão relacionadas com a principal função do extra.</p>"
+"ser implicitamente opcionais, ou seja, deve ser o utilizador a selecionar a opção que não esteja por omissão para ativar a alteração.</li> <li>A janela de opção deve indicar claramente qual o extra"
+" que está a solicitar as alterações.</li> <li>A desinstalação do extra deverá restaurar as configurações originais do utilizador caso as mesmas tenham sido alteradas.</li> </ul> <p>*Funcionalidades"
+" inesperadas são aquelas que não estão relacionadas com a principal função do extra.</p>"
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:268
 msgid "These features cannot be introduced into an update of a fully-reviewed add-on; the opt-in change process must be part of the initial review."
@@ -5994,16 +5950,16 @@ msgid ""
 "discussions, or that you even need to fix every bug, but we do expect that you will respond to issues in a manner that's appropriate to the severity of the issue in question."
 msgstr ""
 "<strong>É você o responsável?</strong> Esperamos que um autor que esteja a promover o seu extra aos muitos utilizadores das nossas aplicações esteja disponível para responder relatos de problemas, "
-"mantenha suas informações de contacto atualizadas e atualize o seu extra ativamente para mantê-lo compatível com as versões recentes do Firefox e alterações das nossas políticas. Isto não significa "
-"que terá que responder a todas as perguntas que alguém colocar em discussões sobre o extra, ou que precisa de corrigir cada problema, mas esperamos que responda aos problemas de maneira apropriada "
-"à severidade do problema em questão."
+"mantenha suas informações de contacto atualizadas e atualize o seu extra ativamente para mantê-lo compatível com as versões recentes do Firefox e alterações das nossas políticas. Isto não significa"
+" que terá que responder a todas as perguntas que alguém colocar em discussões sobre o extra, ou que precisa de corrigir cada problema, mas esperamos que responda aos problemas de maneira apropriada"
+" à severidade do problema em questão."
 
 #: src/olympia/devhub/templates/devhub/docs/policies-submission.html:25
 msgid ""
-"<strong>Is the add-on clearly and accurately described?</strong> It's of the utmost importance to us that users get what they expect when they try a new add-on. Your add-on name should be clear and "
-"concise, and you should refrain from using special characters or numbers to get higher search rankings or for decorative purposes. Your description should provide details about what the add-on "
-"does, how a user should take advantage of it, and what the user should expect when they install it. Links to external documents for detailed instructions are fine, but the description itself should "
-"cover the basics and leave users confident that they know what they'll get. Also, it is important that you maintain version notes appropriately as you improve and change your add-on. Users should "
+"<strong>Is the add-on clearly and accurately described?</strong> It's of the utmost importance to us that users get what they expect when they try a new add-on. Your add-on name should be clear and"
+" concise, and you should refrain from using special characters or numbers to get higher search rankings or for decorative purposes. Your description should provide details about what the add-on "
+"does, how a user should take advantage of it, and what the user should expect when they install it. Links to external documents for detailed instructions are fine, but the description itself should"
+" cover the basics and leave users confident that they know what they'll get. Also, it is important that you maintain version notes appropriately as you improve and change your add-on. Users should "
 "be able to see what's new in an add-on they may have tried previously, and should be made aware of changes that might affect their current use of the add-on when they update."
 msgstr ""
 "<strong>A descrição do extra é clara e precisa?</strong> É extremamente importante para nós que os utilizadores encontrem o que esperam ao experimentar um novo extra. O nome do seu extra deve ser "
@@ -6026,22 +5982,22 @@ msgstr ""
 #: src/olympia/devhub/templates/devhub/docs/policies-submission.html:37
 msgid ""
 "<strong>Has the add-on been well-tested, and is it free of obvious or serious defects?</strong> One important thing that we look for when considering an add-on is whether its user reviews indicate "
-"that it has received thorough testing, and that it doesn't have serious problems or negative impacts on the browser. If reviewers report problems such as major performance issues, crashes, frequent "
-"problems using the functions of the add-on, or spamming of messages to the error console, you should take those reports to heart, and re-submit your add-on after you've addressed them as best you "
+"that it has received thorough testing, and that it doesn't have serious problems or negative impacts on the browser. If reviewers report problems such as major performance issues, crashes, frequent"
+" problems using the functions of the add-on, or spamming of messages to the error console, you should take those reports to heart, and re-submit your add-on after you've addressed them as best you "
 "can. We don't expect you to perfectly optimize or have zero bugs &mdash; Firefox itself undergoes constant improvement in these areas &mdash; but we do want you to take reasonable efforts to "
 "minimize downsides, and to clearly call out cases where users may be surprised by those that remain."
 msgstr ""
 "<strong>O extra foi bem testado e está livre de falhas óbvias ou graves?</strong> Uma coisa importante que procuramos ao considerar um extra é se os comentários dos utilizadores indicam se o extra "
 "foi bem testado e se este não tem problemas sérios ou impactos negativos sobre o navegador. Se os comentários dos utilizadores indicarem problemas graves de desempenho, bloqueios, problemas "
-"frequentes ao utilizar funções do extra ou excesso de mensagens na consola de erros, deve considerar estes comentários com cuidado e reenviar seu extra depois melhorá-lo o máximo que conseguir. Não "
-"esperamos que otimize perfeitamente o seu extra ou que este não tenha nenhum problema &mdash; o próprio Firefox passa por melhorias constantes nestas áreas &mdash; mas queremos que tome as "
+"frequentes ao utilizar funções do extra ou excesso de mensagens na consola de erros, deve considerar estes comentários com cuidado e reenviar seu extra depois melhorá-lo o máximo que conseguir. Não"
+" esperamos que otimize perfeitamente o seu extra ou que este não tenha nenhum problema &mdash; o próprio Firefox passa por melhorias constantes nestas áreas &mdash; mas queremos que tome as "
 "providências consideradas razoáveis para minimizar os aspetos negativos e anunciar claramente os casos em que o utilizador possa ser surpreendido pelos problemas remanescentes."
 
 #: src/olympia/devhub/templates/devhub/docs/policies-submission.html:43
 msgid ""
 "<strong>Do the add-on and add-on author both treat the user respectfully?</strong> Your software should not intrude on the user unnecessarily, try to trick the user, or conceal any of its "
-"activities from the user. Users (or even non-users) are sometimes rude in their comments, and while we will do our best to filter out inaccurate reviews as they're reported to us, we do expect that "
-"authors will avoid retaliating with rudeness of their own."
+"activities from the user. Users (or even non-users) are sometimes rude in their comments, and while we will do our best to filter out inaccurate reviews as they're reported to us, we do expect that"
+" authors will avoid retaliating with rudeness of their own."
 msgstr ""
 "<strong>O extra e o seu autor tratam o utilizador com respeito?</strong> O seu software não deve fornecer uma experiência de utilização intrusiva e desnecessária, tentar enganá-lo ou esconder "
 "quaisquer atividades do utilizador. Utilizadores (ou mesmo não-utilizadores) algumas vezes são rudes nos seus comentários e, ao mesmo tempo que tentamos fazer o nosso melhor para filtrar "
@@ -6057,8 +6013,8 @@ msgstr ""
 
 #: src/olympia/devhub/templates/devhub/docs/policies-submission.html:55
 msgid ""
-"We are constantly looking at ways to improve the organization of the site to better accommodate add-ons that are exemplary in other ways, but are aimed at only a small community of potential users. "
-"Correctly categorizing and maintaining the metadata of your add-on will help us figure out how we can surface more of those sorts of add-ons to people who are most likely to benefit from them."
+"We are constantly looking at ways to improve the organization of the site to better accommodate add-ons that are exemplary in other ways, but are aimed at only a small community of potential users."
+" Correctly categorizing and maintaining the metadata of your add-on will help us figure out how we can surface more of those sorts of add-ons to people who are most likely to benefit from them."
 msgstr ""
 "Estamos constantemente à procura de formas de melhorar a organização do site para melhor acomodar extras excelentes de outras formas, mas destinados apenas a uma pequena comunidade de potenciais "
 "utilizadores. Manter e categorizar corretamente os meta-dados do seu extra irá ajudar-nos a perceber como podemos destacar este tipo de extras para pessoas que provavelmente iriam beneficiar mais "
@@ -6075,8 +6031,8 @@ msgstr ""
 
 #: src/olympia/devhub/templates/devhub/docs/policies-submission.html:67
 msgid ""
-"<strong>Is the add-on free of unlicensed trademarks and copyrights?</strong> Though you may mean no harm to the holder of a trademark, or the owner of a copyrighted work, we can't host add-ons that "
-"infringe on trademarks or copyrights. If you don't have permission to use a trademarked name or image, please do not submit your add-on to us. If your add-on includes code that is copyrighted by "
+"<strong>Is the add-on free of unlicensed trademarks and copyrights?</strong> Though you may mean no harm to the holder of a trademark, or the owner of a copyrighted work, we can't host add-ons that"
+" infringe on trademarks or copyrights. If you don't have permission to use a trademarked name or image, please do not submit your add-on to us. If your add-on includes code that is copyrighted by "
 "someone else, and is not licensed to you to use in your add-on, please do not submit your add-on to us."
 msgstr ""
 "<strong>O extra está isento de marcas ou de diretos de autor não licenciados?</strong> Mesmo que não tenha nenhuma má intenção para o detentor de uma marca registada ou dono de um trabalho com "
@@ -6100,8 +6056,8 @@ msgid ""
 "Foundation."
 msgstr ""
 "Isto também se aplica a marcas registadas da Fundação Mozilla, incluindo \"Mozilla\", \"Firefox\" e \"Thunderbird\". A política sobre a utilização da marca da Mozilla foi criada para nos proteger "
-"contra a confusão entre marcas e evitar que as marcas registadas sejam anuladas devido à falta de proteção; por favor, respeite a necessidade de tal proteção e ajude-nos a preservar alguns dos bens "
-"mais valiosos da Fundação Mozilla."
+"contra a confusão entre marcas e evitar que as marcas registadas sejam anuladas devido à falta de proteção; por favor, respeite a necessidade de tal proteção e ajude-nos a preservar alguns dos bens"
+" mais valiosos da Fundação Mozilla."
 
 #: src/olympia/devhub/templates/devhub/docs/policies-submission.html:84
 msgid "Licensing"
@@ -6109,8 +6065,8 @@ msgstr "Licenciamento"
 
 #: src/olympia/devhub/templates/devhub/docs/policies-submission.html:86
 msgid ""
-"Selecting an appropriate license for your add-on is a very important step in the submission process. A license specifies the rights you grant on your source code and is important in protecting your "
-"intellectual property."
+"Selecting an appropriate license for your add-on is a very important step in the submission process. A license specifies the rights you grant on your source code and is important in protecting your"
+" intellectual property."
 msgstr ""
 "Selecionar uma licença adequada para o seu extra é um passo muito importante do processo de submissão. Uma licença especifica os direitos que permite com o seu código-fonte e é importante na "
 "proteção da sua propriedade intelectual."
@@ -6159,53 +6115,55 @@ msgstr "Termos do Serviço para a submissão do seu trabalho no nosso site. Os p
 msgid "How to get in touch with us regarding these policies or your add-on."
 msgstr "Como entrar em contacto connosco a respeito destas políticas ou do seu extra."
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:6
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:10
 msgid "You have disabled this add-on"
 msgstr "Desativou este extra"
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:20
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:24
 msgid "Your add-on's listing is disabled and is not showing anywhere in our gallery or update service."
 msgstr "A apresentação do seu extra em listagens está desativada e não será apresentado em qualquer área da nossa galeria ou serviço de atualização."
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:25
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:27
 msgid "Please complete your add-on."
 msgstr "Por favor, complete o seu extra."
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:29
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:30
 msgid "You will receive an email when the review is complete."
 msgstr "Irá receber um email quando a revisão estiver completa."
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:34 src/olympia/devhub/templates/devhub/includes/addon_details.html:44
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:33
 msgid "You will receive an email when the review is complete. Until then, your add-on is not listed in our gallery but can be accessed directly from its details page."
-msgstr ""
-"Irá receber uma mensagem de correio quando a revisão estiver concluída. Até lá, o extra não será listado na nossa galeria, mas pode ser acedido diretamente a partir da respetiva página de detalhes."
+msgstr "Irá receber uma mensagem de correio quando a revisão estiver concluída. Até lá, o extra não será listado na nossa galeria, mas pode ser acedido diretamente a partir da respetiva página de detalhes."
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:38 src/olympia/devhub/templates/devhub/includes/addon_details.html:48
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:37 src/olympia/devhub/templates/devhub/includes/addon_details.html:45
 msgid "You will receive an email when the review is complete and your add-on is signed."
 msgstr "Irá receber um email quando a revisão estiver concluída e o seu extra assinado."
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:54
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:41
+msgid "You will receive an email when the review is complete. Until then, your add-on is not listed in our gallery but can be accessed directly from its details page."
+msgstr "Irá receber uma mensagem de correio quando a revisão estiver concluída. Até lá, o extra não será listado na nossa galeria, mas pode ser acedido diretamente a partir da respetiva página de detalhes."
+
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:49
 msgid "Your add-on is displayed in our gallery and users are receiving automatic updates."
 msgstr "O seu extra está a ser apresentado na nossa galeria e os utilizadores estão a receber atualizações automáticas."
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:57
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:52
 msgid "Your add-on has been signed and can be bundled with an application installer."
 msgstr "O seu extra foi assinado e pode ser incorporado com um instalador de aplicação."
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:63
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:56
 msgid "Your add-on was disabled by a site administrator and is no longer shown in our gallery. If you have any questions, please email amo-admins@mozilla.org."
 msgstr "O seu extra foi desativado por um administrador do sítio e já não é apresentado na nossa galeria. Se tiver quaisquer questões, por favor envie um email para amo-admins@mozilla.org."
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:70
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:62
 msgid "Your add-on is displayed in our gallery as experimental and users are receiving automatic updates. Some features are unavailable to your add-on."
-msgstr ""
-"O seu extra está a ser apresentado na nossa galeria como experimental e os utilizadores estão a receber atualizações automáticas. Algumas funcionalidades não estão disponíveis para o seu extra."
+msgstr "O seu extra está a ser apresentado na nossa galeria como experimental e os utilizadores estão a receber atualizações automáticas. Algumas funcionalidades não estão disponíveis para o seu extra."
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:74
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:66
 msgid "Your add-on has been signed."
 msgstr "O seu extra foi assinado."
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:79
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:69
 msgid ""
 "You will receive an email when the full review is complete. Until then, your add-on is displayed in our gallery as experimental and users are receiving automatic updates. Some features are "
 "unavailable to your add-on."
@@ -6213,41 +6171,41 @@ msgstr ""
 "Irá receber uma mensagem de correio quando a revisão completa estiver terminada. Até lá, o extra é apresentado na nossa galeria como experimental e os utilizadores estão a receber atualizações "
 "automáticas. Algumas funcionalidades não estão disponíveis para o seu extra."
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:84
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:74
 msgid "You will receive an email when the full review is complete, making you able to bundle your add-on with an application installer."
 msgstr "Irá receber um email quando a revisão completa estiver concluída, fazendo com que possa incorporar o seu extra com um instalador de aplicação."
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:91
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:79
 msgid "All add-ons hosted in our gallery must now be reviewed by an editor. If you wish to continue hosting your add-on, please click to select a review process."
 msgstr "Todos os extras alojados na nossa galeria devem ser revistos por um editor. Se quiser continuar a alojar o seu extra, por favor clique para selecionar um processo de revisão."
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:113
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:100
 msgid "Current Version:"
 msgstr "Versão atual:"
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:115
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:102
 msgid "This is the version of your add-on that will be installed if someone clicks the Install button on addons.mozilla.org. It is only relevant for listed add-ons."
 msgstr "Esta é a versão do seu extra que será instalada se alguém clicar no botão Instalar em addons.mozilla.org. Isto apenas é relevante para extras listados."
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:123
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:110
 msgid "Created:"
 msgstr "Criado:"
 
 #. {0} is a date. dennis-ignore: E201
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:125 src/olympia/devhub/templates/devhub/includes/addon_details.html:131
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:112 src/olympia/devhub/templates/devhub/includes/addon_details.html:118
 #, python-format
 msgid "%%b %%e, %%Y"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:136
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:123
 msgid "Next Version:"
 msgstr "Próxima versão:"
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:138
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:125
 msgid "This is the newest uploaded version, however it isn’t live on the site yet."
 msgstr "Esta é a versão mas recente que foi enviada, mas que ainda não foi disponibilizada no site."
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:144 src/olympia/devhub/templates/devhub/versions/list.html:30
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:130 src/olympia/devhub/templates/devhub/versions/list.html:30
 msgid "Queues are not reviewed strictly in order"
 msgstr "As filas não são revistas numa ordem rigorosa"
 
@@ -6344,12 +6302,10 @@ msgstr[1] "Selecione <b>até {0}</b> categorias {1} para este extra:"
 #: src/olympia/devhub/templates/devhub/includes/policy_form.html:4
 msgid ""
 "Users will be required to accept the following End-User License Agreement (EULA) prior to installing your add-on. The presence of a EULA significantly affects the number of downloads an add-on "
-"receives. Please note that a EULA is not the same as a code license, such as the GPL or MPL. It is only relevant for listed add-ons."
+"receives. Please note that a EULA is not the same as a code license, such as the GPL or MPL.It is only relevant for listed add-ons."
 msgstr ""
-"Os utilizadores terão de aceitar o seu acordo de licenciamento para o utilizador final (EULA) antes de instalar o seu extra. A presença de um EULA afeta significativamente o número de "
-"transferências que um extra recebe. Por favor note que um EULA não é o mesmo que uma licença de código, tal como a GPL ou a MPL. Isto apenas é relevante para extras listados."
 
-#: src/olympia/devhub/templates/devhub/includes/policy_form.html:21
+#: src/olympia/devhub/templates/devhub/includes/policy_form.html:24
 msgid "If your add-on transmits any data from the user's computer, a privacy policy is required that explains what data is sent and how it is used. It is only relevant for listed add-ons."
 msgstr ""
 "Se o seu extra transmite quaisquer dados a partir do computador do utilizador, é necessária uma política de privacidade que explique que dados são enviados e como são utilizados. Isto apenas é "
@@ -6488,8 +6444,8 @@ msgstr "Iremos enviar uma mensagem de correio automaticamente para os utilizador
 
 #: src/olympia/devhub/templates/devhub/payments/voluntary.html:49
 msgid ""
-"We recommend thanking the user and telling them how much you appreciate their support. You might also want to tell them about what's next for your add-on and about any other add-ons you've made for "
-"them to try."
+"We recommend thanking the user and telling them how much you appreciate their support. You might also want to tell them about what's next for your add-on and about any other add-ons you've made for"
+" them to try."
 msgstr ""
 "Recomendamos agradecer ao utilizador e dizer-lhe o quanto aprecia a sua ajuda. Pode também querer falar sobre os próximos passos do seu extra e de outros extras que tenha feito para que eles os "
 "possam experimentar."
@@ -6668,8 +6624,8 @@ msgid ""
 "I agree to the <a href=\"%(agreement_url)s\" target=\"_blank\">Firefox Add-on Distribution Agreement</a> and to my information being handled as described in the <a href=\"%(privacy_notice_url)s\" "
 "target=\"_blank\">Websites, Communications and Cookies Privacy Notice</a>."
 msgstr ""
-"Eu concordo com o <a href=\"%(agreement_url)s\" target=\"_blank\">acordo de distribuição de extra do Firefox</a> e com o facto da minha informação ser gerida tal como descrito na <a href="
-"\"%(privacy_notice_url)s\" target=\"_blank\">nota de privacidade para sítios web, comunicação e cookies</a>."
+"Eu concordo com o <a href=\"%(agreement_url)s\" target=\"_blank\">acordo de distribuição de extra do Firefox</a> e com o facto da minha informação ser gerida tal como descrito na <a "
+"href=\"%(privacy_notice_url)s\" target=\"_blank\">nota de privacidade para sítios web, comunicação e cookies</a>."
 
 #: src/olympia/devhub/templates/devhub/personas/submit.html:205
 msgid "Submit Theme"
@@ -6738,31 +6694,17 @@ msgstr "Selecione uma imagem de rodapé diferente"
 msgid "Files added to reviewed versions must be reviewed before they will be available for download."
 msgstr "Os ficheiros adicionados a versões já revistas têm de voltar a ser revistos antes de ficarem disponíveis para serem descarregados."
 
-#: src/olympia/devhub/templates/devhub/versions/add_file_modal.html:15
-#, python-format
-msgid ""
-"Submission of updates to unlisted add-ons for signing is currently in an open beta. Manual review may still be required for a large number of add-ons. Please <a href=\"%(url)s\" target=\"_blank"
-"\">report any bugs</a> that you encounter."
-msgstr ""
-
-#: src/olympia/devhub/templates/devhub/versions/add_file_modal.html:35
+#: src/olympia/devhub/templates/devhub/versions/add_file_modal.html:24
 msgid "Select the target platform for this file."
 msgstr "Selecione a plataforma de destino para este ficheiro."
 
-#: src/olympia/devhub/templates/devhub/versions/add_file_modal.html:46
+#: src/olympia/devhub/templates/devhub/versions/add_file_modal.html:35
 msgid "Which review type would you like to nominate for?"
 msgstr "Para que tipo de revisão gostaria de nomear?"
 
-#: src/olympia/devhub/templates/devhub/versions/add_file_modal.html:51
+#: src/olympia/devhub/templates/devhub/versions/add_file_modal.html:40
 msgid "Only publish this version to my beta channel."
 msgstr "Publicar esta versão apenas para o meu canal beta."
-
-#: src/olympia/devhub/templates/devhub/versions/add_file_modal.html:54
-#, python-format
-msgid ""
-"The behavior of the beta channel has changed to accommodate <a href=\"%(addon_signing_url)s\" target=\"_blank\">mandatory add-on signing</a>. The new process is currently in an open beta, and may "
-"change significantly in the near future. Please <a href=\"%(issues_url)s\" target=\"_blank\">report any bugs</a> that you encounter."
-msgstr ""
 
 #: src/olympia/devhub/templates/devhub/versions/edit.html:5
 msgid "Manage Version {0}"
@@ -6790,8 +6732,8 @@ msgid ""
 "Information about changes in this release, new features, known bugs, and other useful information specific to this release/version. This information is also shown in the Add-ons Manager when "
 "updating."
 msgstr ""
-"Informações sobre mudanças nesta versão, novas funcionalidades, bugs conhecidos e outras informações úteis específicas para este lançamento/versão. Esta informação também é apresentada no gestor de "
-"extras ao atualizar."
+"Informações sobre mudanças nesta versão, novas funcionalidades, bugs conhecidos e outras informações úteis específicas para este lançamento/versão. Esta informação também é apresentada no gestor de"
+" extras ao atualizar."
 
 #: src/olympia/devhub/templates/devhub/versions/edit.html:99
 msgid "Approval Status"
@@ -6880,7 +6822,7 @@ msgstr "Pedir revisão completa"
 msgid "Request Preliminary Review"
 msgstr "Pedir revisão preliminar"
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:80 src/olympia/devhub/templates/devhub/versions/list.html:327 src/olympia/devhub/templates/devhub/versions/list.html:350
+#: src/olympia/devhub/templates/devhub/versions/list.html:80 src/olympia/devhub/templates/devhub/versions/list.html:325 src/olympia/devhub/templates/devhub/versions/list.html:348
 msgid "Cancel Review Request"
 msgstr "Cancelar pedido de revisão"
 
@@ -6909,8 +6851,8 @@ msgid "Unlisted:"
 msgstr "Não-listado:"
 
 #: src/olympia/devhub/templates/devhub/versions/list.html:114
-msgid "Not distributed on {0}. Developers will upload new versions for signing and distribute the add-ons on their own. (beta)"
-msgstr "Não distribuído em {0}. Os programadores irão enviar novas versões para serem assinadas e distribuir os extras utilizando meios próprios. (beta)"
+msgid "Not distributed on {0}. Developers will upload new versions for signing and distribute the add-ons on their own."
+msgstr ""
 
 #: src/olympia/devhub/templates/devhub/versions/list.html:122
 msgid "Current versions"
@@ -6961,10 +6903,8 @@ msgid "Delete Version {version}"
 msgstr "Eliminar versão {version}"
 
 #: src/olympia/devhub/templates/devhub/versions/list.html:218
-msgid ""
-"You are about to delete the current version of your add-on. This may cause your add-on status to change, or your listing to lose public visibility, if this is the only public version of your add-on."
-msgstr ""
-"Está a eliminar a versão atual deste extra. Isto pode fazer com que o estado do seu extra mude ou que a sua listagem perca a visibilidade pública, se esta for a única versão pública do seu extra."
+msgid "You are about to delete the current version of your add-on. This may cause your add-on status to change, or your listing to lose public visibility, if this is the only public version of your add-on."
+msgstr "Está a eliminar a versão atual deste extra. Isto pode fazer com que o estado do seu extra mude ou que a sua listagem perca a visibilidade pública, se esta for a única versão pública do seu extra."
 
 #: src/olympia/devhub/templates/devhub/versions/list.html:219
 msgid "Deleting this version will permanently delete:"
@@ -6975,78 +6915,73 @@ msgid "<strong>Important:</strong> Once a version has been deleted, you may not 
 msgstr "<strong>Importante:</strong> Assim que uma versão for eliminada, não poderá enviar uma nova versão com o mesmo número de versão."
 
 #: src/olympia/devhub/templates/devhub/versions/list.html:230
-msgid "Deleting a version which has already been reviewed may also cause a significant delay in the review of your next update."
-msgstr "Eliminar uma versão que já foi revista pode também causar um atraso significativo na revisão da sua próxima atualização."
-
-#: src/olympia/devhub/templates/devhub/versions/list.html:233
 msgid "Are you sure you wish to delete this version?"
 msgstr "Tem a certeza que deseja eliminar esta versão?"
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:238
+#: src/olympia/devhub/templates/devhub/versions/list.html:235
 msgid "Delete Version"
 msgstr "Eliminar versão"
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:240
+#: src/olympia/devhub/templates/devhub/versions/list.html:237
 msgid "Disable Version"
 msgstr "Desativar versão"
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:247
+#: src/olympia/devhub/templates/devhub/versions/list.html:244
 msgid "Add a new Version"
 msgstr "Adicionar uma nova versão"
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:249
+#: src/olympia/devhub/templates/devhub/versions/list.html:246
 msgid "Add Version"
 msgstr "Adicionar versão"
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:256 src/olympia/devhub/templates/devhub/versions/list.html:274
+#: src/olympia/devhub/templates/devhub/versions/list.html:253 src/olympia/devhub/templates/devhub/versions/list.html:279
 msgid "Hide Add-on"
 msgstr "Ocultar extra"
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:259
+#: src/olympia/devhub/templates/devhub/versions/list.html:256
 msgid "Hiding your add-on will prevent it from appearing anywhere in our gallery and will stop users from receiving automatic updates."
 msgstr "Ocultar o seu extra irá impedir que o mesmo seja apresentado em qualquer lugar na nossa galeria e irá impedir que os utilizadores possam receber atualizações automáticas."
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:265
+#: src/olympia/devhub/templates/devhub/versions/list.html:263
+msgid "The files awaiting review will be disabled and you will need to upload new versions."
+msgstr ""
+
+#: src/olympia/devhub/templates/devhub/versions/list.html:270
 msgid "Are you sure you wish to hide your add-on?"
 msgstr "Tem a certeza que pretende ocultar o seu extra?"
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:286 src/olympia/devhub/templates/devhub/versions/list.html:315
+#: src/olympia/devhub/templates/devhub/versions/list.html:291 src/olympia/devhub/templates/devhub/versions/list.html:313
 msgid "Unlist Add-on"
 msgstr "Não listar extra"
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:289
+#: src/olympia/devhub/templates/devhub/versions/list.html:294
 #, python-format
 msgid ""
 "Unlisting your add-on will make it (and each of its versions/files) invisible on this website. It won't show up in searches, won't have a public facing page, and won't be updated automatically for "
-"current users.  It is recommended for unlisted add-ons to provide a custom <a href=\"%(update_url)s\" target=\"_blank\">updateURL</a> in their manifest file for automatic updates."
+"current users. It is recommended for unlisted add-ons to provide a custom <a href=\"%(update_url)s\" target=\"_blank\">updateURL</a> in their manifest file for automatic updates."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:299
-#, python-format
-msgid "Switching add-ons to unlisted is currently in an open beta. Please <a href=\"%(url)s\" target=\"_blank\">report any bugs</a> that you encounter."
-msgstr ""
-
-#: src/olympia/devhub/templates/devhub/versions/list.html:305
+#: src/olympia/devhub/templates/devhub/versions/list.html:303
 msgid "Unlisting an add-on is irreversible!"
 msgstr "A não-listagem de um extra é irreversível!"
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:305
+#: src/olympia/devhub/templates/devhub/versions/list.html:303
 msgid "An unlisted add-on cannot be switched to be listed."
 msgstr "Um extra não-listado não pode ser modificado para ser listado."
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:307
+#: src/olympia/devhub/templates/devhub/versions/list.html:305
 msgid "Are you sure you wish to unlist your add-on?"
 msgstr "Tem a certeza que pretende não listar o seu extra?"
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:330
+#: src/olympia/devhub/templates/devhub/versions/list.html:328
 msgid "Canceling your review request will leave your add-on as preliminarily reviewed."
 msgstr "Cancelar o seu pedido de revisão vai deixar o extra como preliminarmente revisto."
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:335
+#: src/olympia/devhub/templates/devhub/versions/list.html:333
 msgid "Canceling your review request will mark your add-on incomplete. If you do not complete your add-on after several days by re-requesting review, it will be deleted."
 msgstr "Cancelar o seu pedido de revisão vai marcar o seu extra como incompleto. Se não completar o seu extra passados alguns dias solicitando uma revisão, ele será eliminado."
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:343
+#: src/olympia/devhub/templates/devhub/versions/list.html:341
 msgid "Are you sure you wish to cancel your review request?"
 msgstr "Tem a certeza que deseja cancelar o seu pedido de revisão?"
 
@@ -7389,19 +7324,19 @@ msgstr "extra, editor ou comentário"
 msgid "Search by add-on name / author email"
 msgstr "Procurar por nome do extra / correio eletrónico do autor"
 
-#: src/olympia/editors/forms.py:103
+#: src/olympia/editors/forms.py:103 src/olympia/editors/forms.py:244 src/olympia/editors/forms.py:257
 msgid "yes"
 msgstr "sim"
 
-#: src/olympia/editors/forms.py:104
+#: src/olympia/editors/forms.py:104 src/olympia/editors/forms.py:244 src/olympia/editors/forms.py:257
 msgid "no"
 msgstr "não"
 
-#: src/olympia/editors/forms.py:105
+#: src/olympia/editors/forms.py:105 src/olympia/editors/forms.py:245
 msgid "Admin Flag"
 msgstr "Etiqueta de administração"
 
-#: src/olympia/editors/forms.py:113
+#: src/olympia/editors/forms.py:113 src/olympia/editors/forms.py:253
 msgid "Max. Version"
 msgstr "Versão máxima"
 
@@ -7413,55 +7348,59 @@ msgstr "Dias desde a submissão"
 msgid "Add-on Types"
 msgstr "Tipos de extras"
 
-#: src/olympia/editors/forms.py:126 src/olympia/editors/helpers.py:267
+#: src/olympia/editors/forms.py:126 src/olympia/editors/helpers.py:279
 msgid "Platforms"
 msgstr "Plataformas"
 
+#: src/olympia/editors/forms.py:237
+msgid "Search by add-on name / author email / guid"
+msgstr ""
+
 #. L10n: 0 = platform, 1 = filename, 2 = status message
-#: src/olympia/editors/forms.py:238
+#: src/olympia/editors/forms.py:342
 #, python-format
 msgid "<strong>%s</strong> &middot; %s &middot; %s"
 msgstr "<strong>%s</strong> &middot; %s &middot; %s"
 
-#: src/olympia/editors/forms.py:252
+#: src/olympia/editors/forms.py:356
 msgid "Comments:"
 msgstr "Comentários:"
 
-#: src/olympia/editors/forms.py:256
+#: src/olympia/editors/forms.py:360
 msgid "Operating systems:"
 msgstr "Sistemas operativos:"
 
-#: src/olympia/editors/forms.py:258
+#: src/olympia/editors/forms.py:362
 msgid "Applications:"
 msgstr "Aplicações:"
 
-#: src/olympia/editors/forms.py:260
+#: src/olympia/editors/forms.py:364
 msgid "Notify me the next time this add-on is updated. (Subsequent updates will not generate an email)"
 msgstr "Notificar-me da próxima vez que este extra for atualizado (as atualizações seguintes não vão criar uma mensagem de correio)"
 
-#: src/olympia/editors/forms.py:265
+#: src/olympia/editors/forms.py:369
 msgid "Clear Admin Review Flag"
 msgstr "Limpar etiqueta de revisão de administração"
 
-#: src/olympia/editors/forms.py:267
+#: src/olympia/editors/forms.py:371
 msgid "Clear more info requested flag"
 msgstr "Limpar a etiqueta de mais informação solicitada"
 
-#: src/olympia/editors/forms.py:281
+#: src/olympia/editors/forms.py:385
 msgid "Choose a canned response..."
 msgstr "Escolha um modelo de resposta..."
 
 #. L10n: Description of what can be searched for.
-#: src/olympia/editors/forms.py:324
+#: src/olympia/editors/forms.py:423
 msgid "theme name"
 msgstr "nome do tema"
 
-#: src/olympia/editors/forms.py:350
+#: src/olympia/editors/forms.py:449
 msgid "Someone else is reviewing this theme."
 msgstr "Este tema está a ser revisto por outra pessoa."
 
 #. L10n: Description of what can be searched for.
-#: src/olympia/editors/forms.py:447
+#: src/olympia/editors/forms.py:546
 msgid "app, reviewer, or comment"
 msgstr "aplicação, revisor ou comentário"
 
@@ -7477,194 +7416,212 @@ msgstr "Aguarda revisão preliminar"
 msgid "Rejected or Unreviewed"
 msgstr "Rejeitado ou não revisto"
 
-#: src/olympia/editors/helpers.py:123 src/olympia/editors/helpers.py:136
+#: src/olympia/editors/helpers.py:125 src/olympia/editors/helpers.py:138
 msgid "Queue"
 msgstr "Fila"
 
-#: src/olympia/editors/helpers.py:124 src/olympia/editors/templates/editors/base.html:50 src/olympia/editors/templates/editors/base.html:65
+#: src/olympia/editors/helpers.py:126 src/olympia/editors/templates/editors/base.html:50 src/olympia/editors/templates/editors/base.html:65
 msgid "Pending Updates"
 msgstr "Atualizações pendentes"
 
-#: src/olympia/editors/helpers.py:125 src/olympia/editors/templates/editors/base.html:48 src/olympia/editors/templates/editors/base.html:63
+#: src/olympia/editors/helpers.py:127 src/olympia/editors/templates/editors/base.html:48 src/olympia/editors/templates/editors/base.html:63
 msgid "Full Reviews"
 msgstr "Revisões completas"
 
-#: src/olympia/editors/helpers.py:126 src/olympia/editors/templates/editors/base.html:52 src/olympia/editors/templates/editors/base.html:67
+#: src/olympia/editors/helpers.py:128 src/olympia/editors/templates/editors/base.html:52 src/olympia/editors/templates/editors/base.html:67
 msgid "Preliminary Reviews"
 msgstr "Revisões preliminares"
 
-#: src/olympia/editors/helpers.py:127 src/olympia/editors/templates/editors/base.html:54
+#: src/olympia/editors/helpers.py:129 src/olympia/editors/templates/editors/base.html:54
 msgid "Moderated Reviews"
 msgstr "Revisões moderadas"
 
-#: src/olympia/editors/helpers.py:128 src/olympia/editors/templates/editors/base.html:46
+#: src/olympia/editors/helpers.py:130 src/olympia/editors/templates/editors/base.html:46
 msgid "Fast Track"
 msgstr "Fila rápida"
 
-#: src/olympia/editors/helpers.py:130
+#: src/olympia/editors/helpers.py:132
 msgid "Pending Themes"
 msgstr "Temas pendentes"
 
-#: src/olympia/editors/helpers.py:131 src/olympia/editors/templates/editors/themes/queue.html:4
+#: src/olympia/editors/helpers.py:133 src/olympia/editors/templates/editors/themes/queue.html:4
 msgid "Flagged Themes"
 msgstr "Temas marcados"
 
-#: src/olympia/editors/helpers.py:132
+#: src/olympia/editors/helpers.py:134
 msgid "Update Themes"
 msgstr "Atualizar temas"
 
-#: src/olympia/editors/helpers.py:137
+#: src/olympia/editors/helpers.py:139
 msgid "Unlisted Pending Updates"
 msgstr "Atualizações pendentes não listadas"
 
-#: src/olympia/editors/helpers.py:138
+#: src/olympia/editors/helpers.py:140
 msgid "Unlisted Full Reviews"
 msgstr "Análise completas não listadas"
 
-#: src/olympia/editors/helpers.py:139
+#: src/olympia/editors/helpers.py:141
 msgid "Unlisted Preliminary Reviews"
 msgstr "Análises preliminares não listadas"
 
-#: src/olympia/editors/helpers.py:170
+#: src/olympia/editors/helpers.py:142
+msgid "Unlisted All Add-ons"
+msgstr ""
+
+#: src/olympia/editors/helpers.py:173
 msgid "Fast Track ({0})"
 msgid_plural "Fast Track ({0})"
 msgstr[0] "Fila rápida ({0})"
 msgstr[1] "Fila rápida ({0})"
 
-#: src/olympia/editors/helpers.py:175
+#: src/olympia/editors/helpers.py:178
 msgid "Full Review ({0})"
 msgid_plural "Full Reviews ({0})"
 msgstr[0] "Revisão completa ({0})"
 msgstr[1] "Revisões completas ({0})"
 
-#: src/olympia/editors/helpers.py:180
+#: src/olympia/editors/helpers.py:183
 msgid "Pending Update ({0})"
 msgid_plural "Pending Updates ({0})"
 msgstr[0] "Atualização em falta ({0})"
 msgstr[1] "Atualizações em falta ({0})"
 
-#: src/olympia/editors/helpers.py:185
+#: src/olympia/editors/helpers.py:188
 msgid "Preliminary Review ({0})"
 msgid_plural "Preliminary Reviews ({0})"
 msgstr[0] "Revisão preliminar ({0})"
 msgstr[1] "Revisões preliminares ({0})"
 
-#: src/olympia/editors/helpers.py:190
+#: src/olympia/editors/helpers.py:193
 msgid "Moderated Review ({0})"
 msgid_plural "Moderated Reviews ({0})"
 msgstr[0] "Revisão moderada ({0})"
 msgstr[1] "Revisões moderadas ({0})"
 
-#: src/olympia/editors/helpers.py:196
+#: src/olympia/editors/helpers.py:199
 msgid "Unlisted Full Review ({0})"
 msgid_plural "Unlisted Full Reviews ({0})"
 msgstr[0] "Análise completa não listada ({0})"
 msgstr[1] "Análises completas não listadas ({0})"
 
-#: src/olympia/editors/helpers.py:201
+#: src/olympia/editors/helpers.py:204
 msgid "Unlisted Pending Update ({0})"
 msgid_plural "Unlisted Pending Updates ({0})"
 msgstr[0] "Atualização pendente não listada ({0})"
 msgstr[1] "Atualizações pendentes não listadas ({0})"
 
-#: src/olympia/editors/helpers.py:206
+#: src/olympia/editors/helpers.py:209
 msgid "Unlisted Preliminary Review ({0})"
 msgid_plural "Unlisted Preliminary Reviews ({0})"
 msgstr[0] "Análise preliminar não listada ({0})"
 msgstr[1] "Análises preliminares não listadas ({0})"
 
-#: src/olympia/editors/helpers.py:261
-msgid "Addon"
-msgstr "Extra"
+#: src/olympia/editors/helpers.py:214
+msgid "Unlisted All Add-ons ({0})"
+msgid_plural "Unlisted All Add-ons ({0})"
+msgstr[0] ""
+msgstr[1] ""
 
-#: src/olympia/editors/helpers.py:262
+#: src/olympia/editors/helpers.py:274
 msgid "Type"
 msgstr "Tipo"
 
-#: src/olympia/editors/helpers.py:263
+#: src/olympia/editors/helpers.py:275
 msgid "Waiting Time"
 msgstr "Tempo de espera"
 
-#: src/olympia/editors/helpers.py:264 src/olympia/editors/templates/editors/review.html:285
+#: src/olympia/editors/helpers.py:276 src/olympia/editors/templates/editors/review.html:285
 msgid "Flags"
 msgstr "Etiquetas"
 
-#: src/olympia/editors/helpers.py:265
+#: src/olympia/editors/helpers.py:277
 msgid "Applications"
 msgstr "Aplicações"
 
-#: src/olympia/editors/helpers.py:270
+#: src/olympia/editors/helpers.py:282
 msgid "Additional"
 msgstr "Adicional"
 
-#: src/olympia/editors/helpers.py:285
+#: src/olympia/editors/helpers.py:302
 msgid "Site Specific"
 msgstr "Específico de site"
 
-#: src/olympia/editors/helpers.py:287
+#: src/olympia/editors/helpers.py:304
 msgid "Requires External Software"
 msgstr "Necessita de software externo"
 
-#: src/olympia/editors/helpers.py:289
+#: src/olympia/editors/helpers.py:306
 msgid "Binary Components"
 msgstr "Componentes binários"
 
-#: src/olympia/editors/helpers.py:313
+#: src/olympia/editors/helpers.py:339
 msgid "moments ago"
 msgstr "à instantes"
 
 #. L10n: first argument is number of minutes
-#: src/olympia/editors/helpers.py:316
+#: src/olympia/editors/helpers.py:342
 msgid "{0} minute"
 msgid_plural "{0} minutes"
 msgstr[0] "{0} minuto"
 msgstr[1] "{0} minutos"
 
 #. L10n: first argument is number of hours
-#: src/olympia/editors/helpers.py:320
+#: src/olympia/editors/helpers.py:346
 msgid "{0} hour"
 msgid_plural "{0} hours"
 msgstr[0] "{0} hora"
 msgstr[1] "{0} horas"
 
 #. L10n: first argument is number of days
-#: src/olympia/editors/helpers.py:324
+#: src/olympia/editors/helpers.py:350
 msgid "{0} day"
 msgid_plural "{0} days"
 msgstr[0] "{0} dia"
 msgstr[1] "{0} dias"
 
-#: src/olympia/editors/helpers.py:488
+#: src/olympia/editors/helpers.py:364
+msgid "Last Review"
+msgstr ""
+
+#: src/olympia/editors/helpers.py:366
+msgid "Last Update"
+msgstr ""
+
+#: src/olympia/editors/helpers.py:387
+msgid "No Reviews"
+msgstr ""
+
+#: src/olympia/editors/helpers.py:561
 msgid "Push to public"
 msgstr "Enviar para o público"
 
-#: src/olympia/editors/helpers.py:490
+#: src/olympia/editors/helpers.py:563
 msgid "Grant full review"
 msgstr "Atribuir revisão completa"
 
-#: src/olympia/editors/helpers.py:505
+#: src/olympia/editors/helpers.py:578
 msgid "Request more information"
 msgstr "Pedir mais informação"
 
-#: src/olympia/editors/helpers.py:508
+#: src/olympia/editors/helpers.py:581
 msgid "Request super-review"
 msgstr "Solicitar super-revisão"
 
-#: src/olympia/editors/helpers.py:519
+#: src/olympia/editors/helpers.py:592
 msgid "Grant preliminary review"
 msgstr "Permitir revisão preliminar"
 
-#: src/olympia/editors/helpers.py:520
+#: src/olympia/editors/helpers.py:593
 msgid "This will mark the files as preliminarily reviewed."
 msgstr "Isto irá marcar os ficheiros como preliminarmente revistos."
 
-#: src/olympia/editors/helpers.py:522
+#: src/olympia/editors/helpers.py:595
 msgid "Use this form to request more information from the author. They will receive an email and be able to answer here. You will be notified by email when they reply."
 msgstr ""
 "Utilize este formulário para solicitar mais informações do autor. Eles irão receber uma mensagem de correio e serão capazes de responder aqui. Você será notificado por correio eletrónico quando "
 "eles responderem."
 
-#: src/olympia/editors/helpers.py:526
+#: src/olympia/editors/helpers.py:599
 msgid ""
 "If you have concerns about this add-on's security, copyright issues, or other concerns that an administrator should look into, enter your comments in the area below. They will be sent to "
 "administrators, not the author."
@@ -7672,55 +7629,55 @@ msgstr ""
 "Se tiver dúvidas sobre a segurança deste extra, questões de direitos autor, ou outras preocupações que um administrador deva considerar, introduza os seus comentários no espaço abaixo. Eles serão "
 "enviados para os administradores, não ao autor."
 
-#: src/olympia/editors/helpers.py:532
+#: src/olympia/editors/helpers.py:605
 msgid "This will reject the add-on and remove it from the review queue."
 msgstr "Isto vai rejeitar o extra e removê-lo da fila de revisão."
 
-#: src/olympia/editors/helpers.py:534
+#: src/olympia/editors/helpers.py:607
 msgid "Make a comment on this version. The author won't be able to see this."
 msgstr "Faça um comentário sobre esta versão. O autor não será capaz de o ver."
 
-#: src/olympia/editors/helpers.py:538
+#: src/olympia/editors/helpers.py:611
 msgid "This will reject the files and remove them from the review queue."
 msgstr "Isto vai rejeitar os ficheiros e removê-los da fila de revisão."
 
-#: src/olympia/editors/helpers.py:542
+#: src/olympia/editors/helpers.py:615
 msgid "This will mark the add-on as preliminarily reviewed. Future versions will undergo preliminary review."
 msgstr "Isto vai marcar o extra como preliminarmente revisto. Versões futuras irão passar por uma revisão preliminar."
 
-#: src/olympia/editors/helpers.py:547
+#: src/olympia/editors/helpers.py:620
 msgid "This will mark the files as preliminarily reviewed. Future versions will undergo preliminary review."
 msgstr "Isto vai marcar os ficheiros como preliminarmente revistos. Versões futuras irão passar por uma revisão preliminar."
 
-#: src/olympia/editors/helpers.py:552
+#: src/olympia/editors/helpers.py:625
 msgid "Retain preliminary review"
 msgstr "Reter revisão preliminar"
 
-#: src/olympia/editors/helpers.py:553
+#: src/olympia/editors/helpers.py:626
 msgid "This will retain the add-on as preliminarily reviewed. Future versions will undergo preliminary review."
 msgstr "Isto vai reter o extra como preliminarmente revisto. Versões futuras irão ter passar por uma revisão preliminar."
 
-#: src/olympia/editors/helpers.py:558
+#: src/olympia/editors/helpers.py:631
 msgid "This will approve a sandboxed version of a public add-on to appear on the public side."
 msgstr "Isto vai aprovar uma versão encapsulada de um extra público para aparecer no lado público."
 
-#: src/olympia/editors/helpers.py:561
+#: src/olympia/editors/helpers.py:634
 msgid "This will reject a version of a public add-on and remove it from the queue."
 msgstr "Isto vai rejeitar a versão de um extra público e removê-lo da fila."
 
-#: src/olympia/editors/helpers.py:564
+#: src/olympia/editors/helpers.py:637
 msgid "This will mark the add-on and its most recent version and files as public. Future versions will go into the sandbox until they are reviewed by an editor."
 msgstr "Isto vai marcar o extra, a sua versão mais recente e os ficheiros como públicos. Versões futuras irão para a zona de segurança até que sejam revistas ​​por um editor."
 
-#: src/olympia/editors/helpers.py:637
+#: src/olympia/editors/helpers.py:714
 msgid "add-on"
 msgstr "extra"
 
-#: src/olympia/editors/helpers.py:940 src/olympia/editors/helpers.py:960
+#: src/olympia/editors/helpers.py:1020 src/olympia/editors/helpers.py:1040
 msgid "Flagged"
 msgstr "Marcado"
 
-#: src/olympia/editors/helpers.py:944 src/olympia/editors/helpers.py:963
+#: src/olympia/editors/helpers.py:1024 src/olympia/editors/helpers.py:1043
 msgid "Updates"
 msgstr "Atualizações"
 
@@ -7772,56 +7729,56 @@ msgstr "Submissão de tema marcada para revisão"
 msgid "A question about your Theme submission"
 msgstr "Uma questão sobre a submissão do seu tema"
 
-#: src/olympia/editors/views.py:144
+#: src/olympia/editors/views.py:146
 msgid "New Add-ons (Under 5 days)"
 msgstr "Novos extras (até 5 dias)"
 
-#: src/olympia/editors/views.py:145
+#: src/olympia/editors/views.py:147
 msgid "Passable (5 to 10 days)"
 msgstr "Razoável (5 a 10 dias)"
 
-#: src/olympia/editors/views.py:146
+#: src/olympia/editors/views.py:148
 msgid "Overdue (Over 10 days)"
 msgstr "Atrasados (mais de 10 dias)"
 
-#: src/olympia/editors/views.py:532
+#: src/olympia/editors/views.py:539
 msgid "An unknown error occurred"
 msgstr "Ocorreu um erro desconhecido"
 
-#: src/olympia/editors/views.py:587
+#: src/olympia/editors/views.py:592
 msgid "Self-reviews are not allowed."
 msgstr "Não são permitidas auto-revisões."
 
-#: src/olympia/editors/views.py:609
+#: src/olympia/editors/views.py:613
 msgid "Review successfully processed."
 msgstr "Revisão processada com sucesso."
 
-#: src/olympia/editors/views.py:807
+#: src/olympia/editors/views.py:812
 msgid "was approved"
 msgstr "foi aprovado"
 
-#: src/olympia/editors/views.py:808
+#: src/olympia/editors/views.py:813
 msgid "given preliminary review"
 msgstr "dada revisão preliminar"
 
-#: src/olympia/editors/views.py:809
+#: src/olympia/editors/views.py:814
 msgid "rejected"
 msgstr "rejeitado"
 
-#: src/olympia/editors/views.py:810
+#: src/olympia/editors/views.py:815
 msgctxt "editors_review_history_nominated_adminreview"
 msgid "escalated"
 msgstr "escalado"
 
-#: src/olympia/editors/views.py:812
+#: src/olympia/editors/views.py:817
 msgid "needs more information"
 msgstr "requer mais informação"
 
-#: src/olympia/editors/views.py:813
+#: src/olympia/editors/views.py:818
 msgid "needs super review"
 msgstr "requer uma super revisão"
 
-#: src/olympia/editors/views.py:814
+#: src/olympia/editors/views.py:819
 msgid "commented"
 msgstr "comentado"
 
@@ -7833,8 +7790,7 @@ msgstr[1] "{0} revisões de temas processadas com sucesso (+{1} pontos, {2} tota
 
 #: src/olympia/editors/views_themes.py:341
 msgid "Your theme locks have successfully been released. Other reviewers may now review those released themes. You may have to refresh the page to see the changes reflected in the table below."
-msgstr ""
-"Os bloqueios ao seu tema foram libertados com sucesso. Outros revisores podem agora rever os temas libertados. Pode ter de atualizar a página para ver as alterações refletidas na tabela em baixo."
+msgstr "Os bloqueios ao seu tema foram libertados com sucesso. Outros revisores podem agora rever os temas libertados. Pode ter de atualizar a página para ver as alterações refletidas na tabela em baixo."
 
 #: src/olympia/editors/templates/editors/abuse_reports.html:4
 msgid "{addon} :: Abuse Reports"
@@ -7867,28 +7823,28 @@ msgstr "Filas"
 msgid "Unlisted Queues"
 msgstr "Filas não listadas"
 
-#: src/olympia/editors/templates/editors/base.html:72 src/olympia/editors/templates/editors/performance.html:6
+#: src/olympia/editors/templates/editors/base.html:74 src/olympia/editors/templates/editors/performance.html:6
 msgid "Performance"
 msgstr "Desempenho"
 
-#: src/olympia/editors/templates/editors/base.html:75 src/olympia/editors/templates/editors/themes/base.html:19 src/olympia/editors/templates/editors/themes/base.html:38
+#: src/olympia/editors/templates/editors/base.html:77 src/olympia/editors/templates/editors/themes/base.html:19 src/olympia/editors/templates/editors/themes/base.html:38
 msgid "Logs"
 msgstr "Registos"
 
-#: src/olympia/editors/templates/editors/base.html:78 src/olympia/editors/templates/editors/reviewlog.html:4 src/olympia/editors/templates/editors/reviewlog.html:27
+#: src/olympia/editors/templates/editors/base.html:80 src/olympia/editors/templates/editors/reviewlog.html:4 src/olympia/editors/templates/editors/reviewlog.html:27
 msgid "Add-on Review Log"
 msgstr "Registo da revisão do extra"
 
-#: src/olympia/editors/templates/editors/base.html:80 src/olympia/editors/templates/editors/eventlog.html:4 src/olympia/editors/templates/editors/eventlog.html:8
+#: src/olympia/editors/templates/editors/base.html:82 src/olympia/editors/templates/editors/eventlog.html:4 src/olympia/editors/templates/editors/eventlog.html:8
 #: src/olympia/editors/templates/editors/eventlog_detail.html:4
 msgid "Moderated Review Log"
 msgstr "Registo da moderação da revisão "
 
-#: src/olympia/editors/templates/editors/base.html:82 src/olympia/editors/templates/editors/beta_signed_log.html:4 src/olympia/editors/templates/editors/beta_signed_log.html:8
+#: src/olympia/editors/templates/editors/base.html:84 src/olympia/editors/templates/editors/beta_signed_log.html:4 src/olympia/editors/templates/editors/beta_signed_log.html:8
 msgid "Signed Beta Files Log"
 msgstr "Registo de ficheiros beta assinados"
 
-#: src/olympia/editors/templates/editors/base.html:87 src/olympia/editors/templates/editors/includes/daily-message.html:4
+#: src/olympia/editors/templates/editors/base.html:89 src/olympia/editors/templates/editors/includes/daily-message.html:4
 msgid "Announcement"
 msgstr "Anúncio"
 
@@ -8109,45 +8065,45 @@ msgstr "Pesquisa avançada"
 msgid "clear search"
 msgstr "limpar pesquisa"
 
-#: src/olympia/editors/templates/editors/queue.html:72 src/olympia/editors/templates/editors/queue.html:122
+#: src/olympia/editors/templates/editors/queue.html:78 src/olympia/editors/templates/editors/queue.html:128
 msgid "Process Reviews"
 msgstr "Processar revisões"
 
-#: src/olympia/editors/templates/editors/queue.html:80
+#: src/olympia/editors/templates/editors/queue.html:86
 msgid "Moderation actions:"
 msgstr "Ações de moderação:"
 
-#: src/olympia/editors/templates/editors/queue.html:90
+#: src/olympia/editors/templates/editors/queue.html:96
 #, python-format
 msgid "by %(user)s on %(date)s %(stars)s (%(locale)s)"
 msgstr "por %(user)s em %(date)s %(stars)s (%(locale)s)"
 
-#: src/olympia/editors/templates/editors/queue.html:106
+#: src/olympia/editors/templates/editors/queue.html:112
 #, python-format
 msgid "<strong>%(reason)s</strong> <span class=\"light\">Flagged by %(user)s on %(date)s</span>"
 msgstr "<strong>%(reason)s</strong> <span class=\"light\">Marcado por %(user)s em %(date)s</span>"
 
-#: src/olympia/editors/templates/editors/queue.html:119
+#: src/olympia/editors/templates/editors/queue.html:125
 msgid "All reviews have been moderated. Good work!"
 msgstr "Todas as revisões foram moderadas. Bom trabalho!"
 
-#: src/olympia/editors/templates/editors/queue.html:161
+#: src/olympia/editors/templates/editors/queue.html:167
 msgid "Version Notes / Notes for Reviewer"
 msgstr "Notas da versão / Notas para o editor"
 
-#: src/olympia/editors/templates/editors/queue.html:169
+#: src/olympia/editors/templates/editors/queue.html:175
 msgid "There are currently no add-ons of this type to review."
 msgstr "De momento não existem extras deste tipo para rever."
 
-#: src/olympia/editors/templates/editors/queue.html:181 src/olympia/editors/templates/editors/themes/queue_list.html:85
+#: src/olympia/editors/templates/editors/queue.html:187 src/olympia/editors/templates/editors/themes/queue_list.html:85
 msgid "Helpful Links:"
 msgstr "Ligações úteis:"
 
-#: src/olympia/editors/templates/editors/queue.html:182
+#: src/olympia/editors/templates/editors/queue.html:188
 msgid "Add-on Policy"
 msgstr "Política do extra"
 
-#: src/olympia/editors/templates/editors/queue.html:184
+#: src/olympia/editors/templates/editors/queue.html:190
 msgid "Editors' Guide"
 msgstr "Guia do editor"
 
@@ -8311,9 +8267,8 @@ msgstr "Desde sempre"
 msgid "You have <span>{0}</span> points."
 msgstr "Tem <span>{0}</span> pontos."
 
-#: src/olympia/editors/templates/editors/includes/search_results_themes.html:6 src/olympia/editors/templates/editors/themes/history_table.html:7
-#: src/olympia/editors/templates/editors/themes/logs.html:19 src/olympia/editors/templates/editors/themes/queue_list.html:49 src/olympia/editors/templates/editors/themes/single.html:26
-#: src/olympia/editors/templates/editors/themes/themes.html:45
+#: src/olympia/editors/templates/editors/includes/search_results_themes.html:6 src/olympia/editors/templates/editors/themes/history_table.html:7 src/olympia/editors/templates/editors/themes/logs.html:19
+#: src/olympia/editors/templates/editors/themes/queue_list.html:49 src/olympia/editors/templates/editors/themes/single.html:26 src/olympia/editors/templates/editors/themes/themes.html:45
 msgid "Reviewer"
 msgstr "Revisor"
 
@@ -8484,7 +8439,7 @@ msgstr "Fazer uma pergunta ao artista"
 msgid "Describe your reason for flagging"
 msgstr "Descreva o motivo da marcação"
 
-#: src/olympia/files/forms.py:88
+#: src/olympia/files/forms.py:90
 msgid "Cannot diff a version against itself"
 msgstr "Não é possível comparar uma versão consigo própria"
 
@@ -8519,51 +8474,51 @@ msgstr "Ocorreu um erro ao aceder ao ficheiro %s. %s."
 msgid "There was an error accessing file %s."
 msgstr "Ocorreu um erro ao aceder ao ficheiro %s."
 
-#: src/olympia/files/utils.py:343
+#: src/olympia/files/utils.py:340
 msgid "Could not parse uploaded file."
 msgstr "Não foi possível interpretar o ficheiro enviado."
 
-#: src/olympia/files/utils.py:380
+#: src/olympia/files/utils.py:377
 msgid "Invalid file name in archive: {0}"
 msgstr "Nome de ficheiro inválido no arquivo: {0}"
 
-#: src/olympia/files/utils.py:388
+#: src/olympia/files/utils.py:385
 msgid "File exceeding size limit in archive: {0}"
 msgstr "Ficheiro que excede o limite de tamanho no arquivo: {0}"
 
-#: src/olympia/files/utils.py:439
+#: src/olympia/files/utils.py:436
 msgid "Invalid archive."
 msgstr "Arquivo inválido."
 
-#: src/olympia/files/utils.py:529 src/olympia/files/utils.py:532
+#: src/olympia/files/utils.py:526 src/olympia/files/utils.py:529
 msgid "Could not parse the manifest file."
 msgstr ""
 
-#: src/olympia/files/utils.py:551
+#: src/olympia/files/utils.py:548
 msgid "Could not find an add-on ID."
 msgstr "Não foi possível encontrar um ID do extra."
 
-#: src/olympia/files/utils.py:554
+#: src/olympia/files/utils.py:551
 msgid "Add-on ID must be 64 characters or less."
 msgstr "O ID do extra deve ter no máximo 64 caracteres."
 
-#: src/olympia/files/utils.py:556
+#: src/olympia/files/utils.py:553
 msgid "Add-on ID doesn't match add-on."
 msgstr "O ID do extra não coincide com o extra."
 
-#: src/olympia/files/utils.py:564
+#: src/olympia/files/utils.py:561
 msgid "Duplicate add-on ID found."
 msgstr "Foi encontrado um ID de extra duplicado."
 
-#: src/olympia/files/utils.py:567
+#: src/olympia/files/utils.py:564
 msgid "Version numbers should have fewer than 32 characters."
 msgstr "Os números de versão devem ter menos de 32 caracteres."
 
-#: src/olympia/files/utils.py:570
+#: src/olympia/files/utils.py:567
 msgid "Version numbers should only contain letters, numbers, and these punctuation characters: +*.-_."
 msgstr "Os números de versão devem conter apenas letras, números e estes caracteres de pontuação: +*.-_."
 
-#: src/olympia/files/utils.py:587
+#: src/olympia/files/utils.py:584
 msgid "<em:type> doesn't match add-on"
 msgstr "<em:type> não corresponde ao extra"
 
@@ -8663,6 +8618,10 @@ msgstr "Não há ficheiros no ficheiro enviado."
 #: src/olympia/files/templates/files/viewer.html:134
 msgid "Fetching file."
 msgstr "A obter o ficheiro."
+
+#: src/olympia/legacy_api/views.py:255
+msgid "Not implemented yet."
+msgstr "Ainda não implementado."
 
 #: src/olympia/lib/constants.py:6
 msgid "United Arab Emirates Dirham"
@@ -9320,10 +9279,6 @@ msgstr ""
 msgid "Zimbabwe Dollar"
 msgstr ""
 
-#: src/olympia/lib/video/ffmpeg.py:112 src/olympia/lib/video/totem.py:81
-msgid "Videos must be in WebM."
-msgstr ""
-
 #: src/olympia/pages/templates/pages/about.lhtml:3 src/olympia/pages/templates/pages/about.lhtml:10
 msgid "About Mozilla Add-ons"
 msgstr "Acerca dos extras da Mozilla"
@@ -9397,8 +9352,7 @@ msgstr ""
 
 #: src/olympia/pages/templates/pages/about.lhtml:49
 #, python-format
-msgid ""
-"Help improve this website. It's open source, and you can file bugs and submit patches. <a href=\"%(url)s\"> GitHub</a> contains all of our current bugs, legacy bugs can still be found in Bugzilla."
+msgid "Help improve this website. It's open source, and you can file bugs and submit patches. <a href=\"%(url)s\"> GitHub</a> contains all of our current bugs, legacy bugs can still be found in Bugzilla."
 msgstr ""
 
 #: src/olympia/pages/templates/pages/about.lhtml:55
@@ -9443,8 +9397,8 @@ msgstr "Quem trabalha neste site?"
 #: src/olympia/pages/templates/pages/about.lhtml:77
 #, python-format
 msgid ""
-"Over the years, many people have contributed to this website, including both volunteers from the community and a dedicated AMO team. A list of significant contributors can be found on our <a href="
-"\"%(url)s\"> Site Credits</a> page."
+"Over the years, many people have contributed to this website, including both volunteers from the community and a dedicated AMO team. A list of significant contributors can be found on our <a "
+"href=\"%(url)s\"> Site Credits</a> page."
 msgstr ""
 "Ao longo dos anos, muitas pessoas contribuíram para este site, incluindo voluntários da comunidade e uma equipa dedicada do AMO. Uma lista dos colaboradores mais significativos pode ser encontrada "
 "na nossa página de <a href=\"%(url)s\">créditos do site</a>."
@@ -9479,16 +9433,17 @@ msgid ""
 "Submitting a report will help us tell the add-on developer whether their add-on is working properly in this version or might need some fixes."
 msgstr ""
 "Assim que tiver a certeza que um determinado extra funciona corretamente ou que apresente problemas, aceda ao Gestor de extras e clique no botão de Compatibilidade junto ao extra e partilhe com a "
-"Mozilla o que descobriu nos seus testes. Submeter um relatório irá ajudar-nos a informar o programador sobre se o extra está a funcionar corretamente nesta versão ou se precisa de algumas correções."
+"Mozilla o que descobriu nos seus testes. Submeter um relatório irá ajudar-nos a informar o programador sobre se o extra está a funcionar corretamente nesta versão ou se precisa de algumas "
+"correções."
 
 #: src/olympia/pages/templates/pages/acr_firstrun.html:61
 #, python-format
 msgid ""
-"If you upgrade to a new version of Firefox or update your add-ons, your reports for the old versions will be hidden to allow you to test the new version. If you have any questions, please ask in <a "
-"href=\"%(url)s\">our forums</a>."
+"If you upgrade to a new version of Firefox or update your add-ons, your reports for the old versions will be hidden to allow you to test the new version. If you have any questions, please ask in <a"
+" href=\"%(url)s\">our forums</a>."
 msgstr ""
-"Se atualizar para uma nova versão do Firefox ou atualizar os seus extras, os seus relatórios para as versões antigas serão ocultados para permitir que possa testar a nova versão. Se tiver quaisquer "
-"questões, por faça as suas perguntas nos <a href=\"%(url)s\">nossos fóruns</a>."
+"Se atualizar para uma nova versão do Firefox ou atualizar os seus extras, os seus relatórios para as versões antigas serão ocultados para permitir que possa testar a nova versão. Se tiver quaisquer"
+" questões, por faça as suas perguntas nos <a href=\"%(url)s\">nossos fóruns</a>."
 
 #: src/olympia/pages/templates/pages/acr_firstrun.html:69
 msgid ""
@@ -9544,24 +9499,24 @@ msgid ""
 "Some icons used are from the <a href=\"http://www.famfamfam.com/lab/icons/silk/\">famfamfam Silk Icon Set</a>, licensed under a <a href=\"http://creativecommons.org/licenses/by/2.5/\">Creative "
 "Commons Attribution 2.5 License</a>."
 msgstr ""
-"Alguns ícones utilizados são do conjunto de ícones de <a href=\"http://www.famfamfam.com/lab/icons/silk/\">famfamfam Silk</a>, licenciado sob uma licença <a href=\"http://creativecommons.org/"
-"licenses/by/2.5/\">Creative Commons Atribuição 2.5 Genérica</a>."
+"Alguns ícones utilizados são do conjunto de ícones de <a href=\"http://www.famfamfam.com/lab/icons/silk/\">famfamfam Silk</a>, licenciado sob uma licença <a "
+"href=\"http://creativecommons.org/licenses/by/2.5/\">Creative Commons Atribuição 2.5 Genérica</a>."
 
 #: src/olympia/pages/templates/pages/credits.html:60
 msgid ""
 "Some icons used are from the <a href=\"http://www.fatcow.com/free-icons/\">FatCow Farm-Fresh Web Icons Set</a>, licensed under a <a href=\"http://creativecommons.org/licenses/by/3.0/us/\">Creative "
 "Commons Attribution 3.0 License</a>."
 msgstr ""
-"Alguns ícones utilizados são do conjunto de ícones de <a href=\"http://www.fatcow.com/free-icons/\">FatCow Farm-Fresh Web</a>, licenciado sob uma licença <a href=\"http://creativecommons.org/"
-"licenses/by/3.0/us/\">Creative Commons Atribuição 3.0 Estados Unidos</a>."
+"Alguns ícones utilizados são do conjunto de ícones de <a href=\"http://www.fatcow.com/free-icons/\">FatCow Farm-Fresh Web</a>, licenciado sob uma licença <a "
+"href=\"http://creativecommons.org/licenses/by/3.0/us/\">Creative Commons Atribuição 3.0 Estados Unidos</a>."
 
 #: src/olympia/pages/templates/pages/credits.html:61
 msgid ""
-"Some pages use elements of <a href=\"http://shop.highsoft.com/highcharts.html\">Highcharts</a> (non-commercial), licensed under a <a href=\"http://creativecommons.org/licenses/by-nc/3.0/\">Creative "
-"Commons Attribution-NonCommercial 3.0 License</a>."
+"Some pages use elements of <a href=\"http://shop.highsoft.com/highcharts.html\">Highcharts</a> (non-commercial), licensed under a <a href=\"http://creativecommons.org/licenses/by-nc/3.0/\">Creative"
+" Commons Attribution-NonCommercial 3.0 License</a>."
 msgstr ""
-"Algumas páginas utilizam elementos de <a href=\"http://shop.highsoft.com/highcharts.html\">Highcharts</a> (não-comercial), licenciado sob uma licença <a href=\"http://creativecommons.org/licenses/"
-"by-nc/3.0/\">Creative Commons Atribuição-NãoComercial 3.0 Não Adaptada</a>."
+"Algumas páginas utilizam elementos de <a href=\"http://shop.highsoft.com/highcharts.html\">Highcharts</a> (não-comercial), licenciado sob uma licença <a href=\"http://creativecommons.org/licenses"
+"/by-nc/3.0/\">Creative Commons Atribuição-NãoComercial 3.0 Não Adaptada</a>."
 
 #: src/olympia/pages/templates/pages/credits.html:65
 #, python-format
@@ -9670,7 +9625,8 @@ msgid ""
 "trees, etc that can be used to enhance add-ons by modifying parts of the browser UI."
 msgstr ""
 "O XUL (XML User Interface Language, linguagem de interface XML) é uma linguagem da Mozilla baseada em XML que permite construir interfaces ricas compatíveis com diversas aplicações multi-"
-"plataforma. Ela oferece widgets de interface como botões, barras de ferramentas, árvores, entre outros, que podem ser utilizados para melhorar os extras modificando partes da interface do navegador."
+"plataforma. Ela oferece widgets de interface como botões, barras de ferramentas, árvores, entre outros, que podem ser utilizados para melhorar os extras modificando partes da interface do "
+"navegador."
 
 #: src/olympia/pages/templates/pages/dev_faq.html:119
 msgid "What is the \"install.rdf\" file used for?"
@@ -9684,8 +9640,8 @@ msgid ""
 "be updated, and so on. The format of the Install Manifest is RDF/XML."
 msgstr ""
 "Este ficheiro, denominado por <a href=\"%(url)s\">manifesto de instalação</a>, é utilizado por aplicações de gestão de extras baseados em XUL para obter informações sobre um extra enquanto este é "
-"instalado. Contem meta-dados que identificam o extra, fornecendo informação sobre quem o criou, onde podem ser encontradas mais informações sobre o mesmo, com que versões e aplicações é compatível, "
-"como deve ser atualizado, etc. O formato do manifesto de instalação é RDF/XML."
+"instalado. Contem meta-dados que identificam o extra, fornecendo informação sobre quem o criou, onde podem ser encontradas mais informações sobre o mesmo, com que versões e aplicações é compatível,"
+" como deve ser atualizado, etc. O formato do manifesto de instalação é RDF/XML."
 
 #: src/olympia/pages/templates/pages/dev_faq.html:132
 msgid "What does \"maxVersion\" mean?"
@@ -9701,8 +9657,7 @@ msgstr "O meu extra pode conter componentes binários?"
 
 #: src/olympia/pages/templates/pages/dev_faq.html:143
 #, python-format
-msgid ""
-"Yes. You can use Mozilla's <a href=\"%(url)s\">XPCOM component object model</a> to enhance your add-ons. XPCOM components be used and implemented in JavaScript, Java, and Python in addition to C++."
+msgid "Yes. You can use Mozilla's <a href=\"%(url)s\">XPCOM component object model</a> to enhance your add-ons. XPCOM components be used and implemented in JavaScript, Java, and Python in addition to C++."
 msgstr ""
 "Sim. Pode utilizar o <a href=\"%(url)s\">modelo de componentes de objeto XPCOM</a> da Mozilla para melhorar os seus extras. Os componentes XPCOM podem ser utilizados e implementados em JavaScript, "
 "Java e Python para além do C++."
@@ -9719,8 +9674,8 @@ msgid ""
 msgstr ""
 "Sim. É possível, mas alguma da funcionalidade fornecida por estas bibliotecas está disponível  através do XPCOM, XUL e JavaScript. Para além disto, autores devem ter atenção se as bibliotecas "
 "modificam tipos de objetos primitivos (String.prototype, Date.prototype, etc.) e/ou definem funções globais (por exemplo a função $). Estes são propícios a causar conflitos com outros extras, em "
-"particular se diferentes extras utilizam versões diferentes de bibliotecas entre outros. Os programadores devem ter mesmo muito cuidado na sua utilização. A Mozilla não fornece documentação sobre a "
-"sua utilização para a construção de extras."
+"particular se diferentes extras utilizam versões diferentes de bibliotecas entre outros. Os programadores devem ter mesmo muito cuidado na sua utilização. A Mozilla não fornece documentação sobre a"
+" sua utilização para a construção de extras."
 
 #: src/olympia/pages/templates/pages/dev_faq.html:165
 msgid "How do I debug my add-on?"
@@ -9741,10 +9696,10 @@ msgid ""
 "many cases, the latest version of Mozilla software may be a beta release. Since these releases at times introduce architectural changes that may impact the functionality of your add-on, it's "
 "important to be actively involved in the beta process to ensure that your add-on users are not negatively impacted upon final release of Mozilla software."
 msgstr ""
-"Para garantir a compatibilidade com as últimas versões do software da Mozilla, é importante transferir atualizações assim que estes são disponibilizados e testar o seu extra para garantir que ainda "
-"funciona como esperado. Em muitos casos a última versão do software da Mozilla pode ser um lançamento beta. Dado que estes lançamentos podem por vezes apresentar alterações arquiteturais que podem "
-"ter impacto na funcionalidade do seu extra, é importante estar envolvido ativamente no processo beta para garantir que os utilizadores do seu extra não são negativamente afetados após o lançamento "
-"do software da Mozilla."
+"Para garantir a compatibilidade com as últimas versões do software da Mozilla, é importante transferir atualizações assim que estes são disponibilizados e testar o seu extra para garantir que ainda"
+" funciona como esperado. Em muitos casos a última versão do software da Mozilla pode ser um lançamento beta. Dado que estes lançamentos podem por vezes apresentar alterações arquiteturais que podem"
+" ter impacto na funcionalidade do seu extra, é importante estar envolvido ativamente no processo beta para garantir que os utilizadores do seu extra não são negativamente afetados após o lançamento"
+" do software da Mozilla."
 
 #: src/olympia/pages/templates/pages/dev_faq.html:185
 msgid "How to improve the performance of my add-on?"
@@ -9753,11 +9708,11 @@ msgstr "Como melhorar o desempenho do meu extra?"
 #: src/olympia/pages/templates/pages/dev_faq.html:187
 #, python-format
 msgid ""
-"Poorly written extensions can have a severe impact on the browsing experience, including on the overall performance of Firefox itself. The following page contains many good <a href=\"%(url)s"
-"\">guides</a> that help you improve performance, whether you're developing core Mozilla code or an add-on."
+"Poorly written extensions can have a severe impact on the browsing experience, including on the overall performance of Firefox itself. The following page contains many good <a "
+"href=\"%(url)s\">guides</a> that help you improve performance, whether you're developing core Mozilla code or an add-on."
 msgstr ""
-"Extensões mal escritas podem ter um impacto significativo na experiência de navegação, incluindo na performance geral do próprio Firefox. A página seguinte contém muito bons <a href=\"%(url)s"
-"\">guias</a> que podem ajudá-lo a melhorar o desempenho, quer esteja a desenvolver código central para a Mozilla ou um extra."
+"Extensões mal escritas podem ter um impacto significativo na experiência de navegação, incluindo na performance geral do próprio Firefox. A página seguinte contém muito bons <a "
+"href=\"%(url)s\">guias</a> que podem ajudá-lo a melhorar o desempenho, quer esteja a desenvolver código central para a Mozilla ou um extra."
 
 #: src/olympia/pages/templates/pages/dev_faq.html:195
 msgid "Can my add-on support multiple locales?"
@@ -9829,8 +9784,8 @@ msgstr "Existem outros programadores que eu possa contratar para construir o meu
 #: src/olympia/pages/templates/pages/dev_faq.html:248
 #, python-format
 msgid ""
-"Yes. You may find 3rd party developers via the <a href=\"%(forum_url)s\">Add-ons forum</a>, <a href=\"%(list_url)s\">mozilla.jobs list</a>, <a href=\"%(mz_url)s\">mozillaZine forums</a> or <a href="
-"\"%(wiki_url)s\">the Mozilla Wiki</a>. Please note that Mozilla does not offer developer recommendations."
+"Yes. You may find 3rd party developers via the <a href=\"%(forum_url)s\">Add-ons forum</a>, <a href=\"%(list_url)s\">mozilla.jobs list</a>, <a href=\"%(mz_url)s\">mozillaZine forums</a> or <a "
+"href=\"%(wiki_url)s\">the Mozilla Wiki</a>. Please note that Mozilla does not offer developer recommendations."
 msgstr ""
 "Sim. Pode encontrar outros programadores através do <a href=\"%(forum_url)s\">fórum de Extras</a>, <a href=\"%(list_url)s\">lista mozilla.jobs</a>, <a href=\"%(mz_url)s\">fóruns mozillaZine</a> ou "
 "<a href=\"%(wiki_url)s\">na Wiki da Mozilla</a>. Tenha em consideração que a Mozilla não fornece recomendações de programadores."
@@ -9842,9 +9797,9 @@ msgstr "Posso alojar o meu próprio extra?"
 #: src/olympia/pages/templates/pages/dev_faq.html:265
 #, python-format
 msgid ""
-"Yes. Many developers choose to host their own add-ons. Choosing to host your add-on on <a href=\"%(amo_url)s\">Mozilla's add-on site</a>, though, allows for much greater exposure to your add-on due "
-"to the large volume of visitors to the site. <a href=\"%(md_url)s\">mozdev.org</a> offers free project hosting for Mozilla applications and extensions providing developers with tools to help manage "
-"source code, version control, bug tracking and documentation."
+"Yes. Many developers choose to host their own add-ons. Choosing to host your add-on on <a href=\"%(amo_url)s\">Mozilla's add-on site</a>, though, allows for much greater exposure to your add-on due"
+" to the large volume of visitors to the site. <a href=\"%(md_url)s\">mozdev.org</a> offers free project hosting for Mozilla applications and extensions providing developers with tools to help "
+"manage source code, version control, bug tracking and documentation."
 msgstr ""
 "Sim. Muitos programadores preferem alojar os seus próprios extras. No entanto, o alojamento no <a href=\"%(amo_url)s\">site de extras da Mozilla</a> oferece uma maior exposição ao seu extra devido "
 "ao elevado volume de visitantes. O <a href=\"%(md_url)s\">mozdev.org</a> oferece o alojamento gratuito a projetos para aplicações e extensões Mozilla, oferecendo aos programadores ferramentas de "
@@ -9868,8 +9823,8 @@ msgid ""
 "Mozilla's AMO (<a href=\"https://addons.mozilla.org\">https://addons.mozilla.org</a>) is the incubator that helps developers build, distribute, and support fantastic consumer products powered by "
 "Mozilla. It provides you the tools and infrastructure necessary to manage, host and expose your add-on to a massive base of Mozilla users."
 msgstr ""
-"O AMO da Mozilla (<a href=\"https://addons.mozilla.org\">https://addons.mozilla.org</a>) é a incubadora que ajuda os programadores a construir, distribuir e suportar produtos fantásticos de consumo "
-"potenciados pela Mozilla. Fornece as ferramentas e infraestrutura necessária para gerir, alojar e expor o seu extra a uma base massiva de utilizadores Mozilla."
+"O AMO da Mozilla (<a href=\"https://addons.mozilla.org\">https://addons.mozilla.org</a>) é a incubadora que ajuda os programadores a construir, distribuir e suportar produtos fantásticos de consumo"
+" potenciados pela Mozilla. Fornece as ferramentas e infraestrutura necessária para gerir, alojar e expor o seu extra a uma base massiva de utilizadores Mozilla."
 
 #: src/olympia/pages/templates/pages/dev_faq.html:295
 msgid "Does Mozilla keep my account information private?"
@@ -9889,8 +9844,8 @@ msgid ""
 "The \"Developer Tools\" dashboard is the area that provides you the tools to successfully manage your add-ons. It provides the functionality necessary to submit your add-ons to AMO, manage add-on "
 "information, and review statistics."
 msgstr ""
-"O painel \"ferramentas do programador\" é a área que fornece as ferramentas para gerir com sucesso os seus extras. Fornece a funcionalidade necessária para submeter os seus extras para o AMO, gerir "
-"informações de extras e consultas as estatísticas."
+"O painel \"ferramentas do programador\" é a área que fornece as ferramentas para gerir com sucesso os seus extras. Fornece a funcionalidade necessária para submeter os seus extras para o AMO, gerir"
+" informações de extras e consultas as estatísticas."
 
 #: src/olympia/pages/templates/pages/dev_faq.html:312
 msgid "Does Mozilla have a policy in place as to what is an acceptable submission?"
@@ -9932,8 +9887,8 @@ msgstr "Que categoria devo escolher para o meu extra?"
 
 #: src/olympia/pages/templates/pages/dev_faq.html:346
 msgid ""
-"The choice of category is dependent on what type of audience you are targeting and the functionality of your add-on. If you're unsure of which category your add-on falls into, please choose \"Other"
-"\". The AMO team may re-categorize your add-on if it's determined that it's better suited in a different category."
+"The choice of category is dependent on what type of audience you are targeting and the functionality of your add-on. If you're unsure of which category your add-on falls into, please choose "
+"\"Other\". The AMO team may re-categorize your add-on if it's determined that it's better suited in a different category."
 msgstr ""
 "A escolha da categoria depende do tipo de audiência que deseja alcançar e a funcionalidade do seu extra. Se não tiver certeza de qual categoria onde o seu extra se encaixa, selecione \"Outros\". A "
 "equipa do AMO poderá re-categorizar o seu extra se for determinado que este se encaixa melhor numa categoria diferente."
@@ -9963,8 +9918,8 @@ msgstr "Posso incluir uma política de privacidade para o meu extra?"
 #: src/olympia/pages/templates/pages/dev_faq.html:374
 msgid "Yes. You can specify a privacy policy when submitting your add-on. You can also add or update a privacy policy via the Developer Tools dashboard after your add-on has been submitted."
 msgstr ""
-"Sim. Pode especificar uma política de privacidade ao submeter o seu extra. Pode também adicionar ou atualizar a política de privacidade através do painel de Ferramentas do programador depois do seu "
-"extra ter sido submetido."
+"Sim. Pode especificar uma política de privacidade ao submeter o seu extra. Pode também adicionar ou atualizar a política de privacidade através do painel de Ferramentas do programador depois do seu"
+" extra ter sido submetido."
 
 #: src/olympia/pages/templates/pages/dev_faq.html:383
 msgid "Why must my add-on be reviewed?"
@@ -9973,8 +9928,8 @@ msgstr "Porque é que o meu extra tem de ser revisto?"
 #: src/olympia/pages/templates/pages/dev_faq.html:385
 #, python-format
 msgid ""
-"All add-ons submitted, whether new or updated, are reviewed to ensure that Mozilla users have a stable and safe experience. All add-ons submissions are reviewed using the guidelines outlined in the "
-"<a href=\"%(url)s\">Editors Reviewing Guide</a>."
+"All add-ons submitted, whether new or updated, are reviewed to ensure that Mozilla users have a stable and safe experience. All add-ons submissions are reviewed using the guidelines outlined in the"
+" <a href=\"%(url)s\">Editors Reviewing Guide</a>."
 msgstr ""
 "Todos os extras submetidos, sejam novos ou atualizações, são revistos para assegurar que os utilizadores da Mozilla têm uma experiência estável e segura. Todas as submissões de extras são revistas "
 "de acordo com as diretrizes descritas no <a href=\"%(url)s\">guia de revisão para editores</a>."
@@ -10004,8 +9959,8 @@ msgid ""
 "The Mozilla editorial team follows the <a href=\"%(url)s\">Editors Reviewing Guide</a> when testing an add-on for acceptance onto AMO. It is important that add-on developers review this guide to "
 "ensure that common problem areas are addressed prior to submitting their add-on for review. This will greatly assist in expediting the review process."
 msgstr ""
-"A equipa editorial da Mozilla segue o <a href=\"%(url)s\">guia de revisão para editores</a> ao testar um extra para ser aceite no AMO. É importante que os programadores de extras analisem este guia "
-"para garantir que áreas problemáticas comuns são trabalhadas antes de submeter os seus extras para revisão. Isto irá tornar o processo de revisão mais expedito."
+"A equipa editorial da Mozilla segue o <a href=\"%(url)s\">guia de revisão para editores</a> ao testar um extra para ser aceite no AMO. É importante que os programadores de extras analisem este guia"
+" para garantir que áreas problemáticas comuns são trabalhadas antes de submeter os seus extras para revisão. Isto irá tornar o processo de revisão mais expedito."
 
 #: src/olympia/pages/templates/pages/dev_faq.html:418
 msgid "How long will it take for my add-on to be reviewed?"
@@ -10033,11 +9988,11 @@ msgstr "o número de áreas problemáticas encontradas"
 #: src/olympia/pages/templates/pages/dev_faq.html:434
 #, python-format
 msgid ""
-"This is why it's very important to read the <a href=\"%(g_url)s\">Editors Reviewing Guide</a> to ensure that your add-on is setup as expected. It's also a good idea to read the blog post, <a href="
-"\"%(blog_url)s\">Successfully Getting your Add-on Reviewed</a> which provides excellent insight into ensuring a smooth review of your add-on."
+"This is why it's very important to read the <a href=\"%(g_url)s\">Editors Reviewing Guide</a> to ensure that your add-on is setup as expected. It's also a good idea to read the blog post, <a "
+"href=\"%(blog_url)s\">Successfully Getting your Add-on Reviewed</a> which provides excellent insight into ensuring a smooth review of your add-on."
 msgstr ""
-"É por isto que é muito importante ler o <a href=\"%(g_url)s\">Guia de revisões para editores</a> para garantir que o seu extra esteja conforme. Também é uma ótima ideia ler o artigo <a href="
-"\"%(blog_url)s\">ter o seu extra revisto com sucesso</a>, que fornece uma excelente visão do processo, assegurando uma revisão tranquila do seu extra."
+"É por isto que é muito importante ler o <a href=\"%(g_url)s\">Guia de revisões para editores</a> para garantir que o seu extra esteja conforme. Também é uma ótima ideia ler o artigo <a "
+"href=\"%(blog_url)s\">ter o seu extra revisto com sucesso</a>, que fornece uma excelente visão do processo, assegurando uma revisão tranquila do seu extra."
 
 #: src/olympia/pages/templates/pages/dev_faq.html:446
 msgid "How can I see how many times my add-on has been downloaded?"
@@ -10054,11 +10009,10 @@ msgid "How can I see how many active users are using my add-on?"
 msgstr "Como posso ver quantos utilizadores ativos estão a utilizar o meu extra?"
 
 #: src/olympia/pages/templates/pages/dev_faq.html:457
-msgid ""
-"The Statistics Dashboard found in the Developer Tools dashboard provides information that can help you determine how many users have been actively using your add-on since you've submitted it to AMO."
+msgid "The Statistics Dashboard found in the Developer Tools dashboard provides information that can help you determine how many users have been actively using your add-on since you've submitted it to AMO."
 msgstr ""
-"O painel de estatísticas disponível na página Ferramentas do programador fornece informações que podem ajudá-lo a determinar quantos utilizadores estão a utilizar ativamente o seu extra desde que o "
-"submeteu para o AMO."
+"O painel de estatísticas disponível na página Ferramentas do programador fornece informações que podem ajudá-lo a determinar quantos utilizadores estão a utilizar ativamente o seu extra desde que o"
+" submeteu para o AMO."
 
 #: src/olympia/pages/templates/pages/dev_faq.html:464
 msgid "How do I submit an update for my add-on?"
@@ -10147,8 +10101,8 @@ msgid ""
 "In addition to the full text of the Mozilla Public License(\"MPL\"), this also provides an annotated version of the MPL and an <abbr title=\"Frequently Asked Questions\">FAQ</abbr> to help you if "
 "you want to use or distribute code licensed under it."
 msgstr ""
-"Além do texto integral da Licença Pública da Mozilla (\"MPL\"), isto também fornece uma versão anotada da MPL e as <abbr title=\"perguntas frequentes\">FAQ</abbr> para o ajudar caso queira utilizar "
-"ou distribuir código licenciado sob a MPL."
+"Além do texto integral da Licença Pública da Mozilla (\"MPL\"), isto também fornece uma versão anotada da MPL e as <abbr title=\"perguntas frequentes\">FAQ</abbr> para o ajudar caso queira utilizar"
+" ou distribuir código licenciado sob a MPL."
 
 #: src/olympia/pages/templates/pages/dev_faq.html:559
 msgid "A table summarizing and comparing how some of the key open source licenses treat distributions, proprietary software linking, and redistribution of code with changes."
@@ -10195,8 +10149,8 @@ msgid ""
 "or change its visual appearance. Through add-ons, you can customize %(app_name)s to meet your needs and tastes. <a href=\"%(learnmore_url)s\">Learn more about customization</a>"
 msgstr ""
 "Os extras são pequenos pedaços de software que adicionam novas funcionalidades à sua instalação do %(app_name)s. Os extras podem potenciar o %(app_name)s com novas funcionalidades, dicionários de "
-"idiomas estrangeiros ou alterar a aparência visual. Através dos extras, pode personalizar o %(app_name)s conforme as suas necessidades e preferências. <a href=\"%(learnmore_url)s\">Saber mais sobre "
-"a personalização</a>"
+"idiomas estrangeiros ou alterar a aparência visual. Através dos extras, pode personalizar o %(app_name)s conforme as suas necessidades e preferências. <a href=\"%(learnmore_url)s\">Saber mais sobre"
+" a personalização</a>"
 
 #: src/olympia/pages/templates/pages/faq.html:26
 msgid "Will add-ons work with my web browser or application?"
@@ -10205,12 +10159,13 @@ msgstr "Os extras funcionam com o meu navegador web ou aplicação?"
 #: src/olympia/pages/templates/pages/faq.html:27
 #, python-format
 msgid ""
-"Add-ons listed in this gallery only work with Mozilla-based applications, such as <a href=\"%(getfirefox_url)s\">Firefox</a>, <a href=\"%(getmobile_url)s\">Firefox Mobile</a>, <a href="
-"\"%(getseamonkey_url)s\">SeaMonkey</a>, and <a href=\"%(getthunderbird_url)s\">Thunderbird</a>. However, not all add-ons work with each of those applications or every version of those applications. "
-"Each add-on specifies which applications and versions it works with, such as Firefox 2.0 - 3.6.*. For Firefox add-ons, the install buttons will indicate whether the add-on is compatible or not."
+"Add-ons listed in this gallery only work with Mozilla-based applications, such as <a href=\"%(getfirefox_url)s\">Firefox</a>, <a href=\"%(getmobile_url)s\">Firefox Mobile</a>, <a "
+"href=\"%(getseamonkey_url)s\">SeaMonkey</a>, and <a href=\"%(getthunderbird_url)s\">Thunderbird</a>. However, not all add-ons work with each of those applications or every version of those "
+"applications. Each add-on specifies which applications and versions it works with, such as Firefox 2.0 - 3.6.*. For Firefox add-ons, the install buttons will indicate whether the add-on is "
+"compatible or not."
 msgstr ""
-"Os extras listados nesta galeria apenas funcionam com aplicações baseadas na Mozilla, tais como o <a href=\"%(getfirefox_url)s\">Firefox</a>, <a href=\"%(getmobile_url)s\">Firefox para dispositivos "
-"móveis</a>, <a href=\"%(getseamonkey_url)s\">SeaMonkey</a>, e <a href=\"%(getthunderbird_url)s\">Thunderbird</a>. No entanto, nem todos os extras funcionam com todas as aplicações ou em qualquer "
+"Os extras listados nesta galeria apenas funcionam com aplicações baseadas na Mozilla, tais como o <a href=\"%(getfirefox_url)s\">Firefox</a>, <a href=\"%(getmobile_url)s\">Firefox para dispositivos"
+" móveis</a>, <a href=\"%(getseamonkey_url)s\">SeaMonkey</a>, e <a href=\"%(getthunderbird_url)s\">Thunderbird</a>. No entanto, nem todos os extras funcionam com todas as aplicações ou em qualquer "
 "versão das mesmas. Cada extra especifica quais as aplicações com as quais funcionam, tais como o Firefox 2.0 - 3.6.*. Para extras do Firefox, o botão instalar indica se o extra é compatível ou não."
 
 #: src/olympia/pages/templates/pages/faq.html:42
@@ -10280,8 +10235,8 @@ msgstr "Como é que instalo extras sem reiniciar o Firefox?"
 #: src/olympia/pages/templates/pages/faq.html:101
 #, python-format
 msgid ""
-"In Firefox, add-ons marked with \"No restart required\" can be installed without restarting. These add-ons have been created using the <a href=\"%(sdk_url)s\">Add-on SDK</a> or <a href="
-"\"%(bootstrap_url)s\">bootstrapping</a>. Other add-ons will still require a restart before you can use them."
+"In Firefox, add-ons marked with \"No restart required\" can be installed without restarting. These add-ons have been created using the <a href=\"%(sdk_url)s\">Add-on SDK</a> or <a "
+"href=\"%(bootstrap_url)s\">bootstrapping</a>. Other add-ons will still require a restart before you can use them."
 msgstr ""
 "No Firefox, extras marcados com \"Não é necessário reiniciar\" podem ser instalados sem a necessidade de reiniciar a aplicação. Estes extras foram criados utilizando o <a href=\"%(sdk_url)s\">SDK "
 "de extras</a> ou <a href=\"%(bootstrap_url)s\">bootstrapping</a>. Os outros extras irão requerer um reinicio antes de os poder utilizar."
@@ -10294,8 +10249,8 @@ msgstr "Como mantenho os extras atualizados?"
 #, python-format
 msgid ""
 "Add-ons, unlike plugins, are automatically checked for updates once every day. In Firefox, updates are automatically installed by default. Versions of Firefox prior to 4 (and other applications) "
-"will alert you that updates to your add-ons are available. <a href=\"%(plugin_url)s\">Plugins</a> are not currently automatically checked for updates, so be sure to regularly visit the <a href="
-"\"%(plugincheck_url)s\">Plugin Check</a> page to stay up-to-date."
+"will alert you that updates to your add-ons are available. <a href=\"%(plugin_url)s\">Plugins</a> are not currently automatically checked for updates, so be sure to regularly visit the <a "
+"href=\"%(plugincheck_url)s\">Plugin Check</a> page to stay up-to-date."
 msgstr ""
 "Os extras, ao contrário dos plugins, são verificados diariamente e de forma automática em busca de atualizações. No Firefox, as atualizações são instaladas automaticamente por omissao. Versões do "
 "Firefox anteriores à versão 4 (e outras aplicações) irão emitir um aviso quando existirem atualizações disponíveis para os seus extras. Os <a href=\"%(plugin_url)s\">plugins</a> não são atualmente "
@@ -10308,9 +10263,9 @@ msgstr "É seguro instalar extras?"
 #: src/olympia/pages/templates/pages/faq.html:123
 #, python-format
 msgid ""
-"Unless clearly marked otherwise, add-ons available from this gallery have been checked and approved by Mozilla's team of editors and are safe to install. We recommend that you only install approved "
-"add-ons. If you wish to install unapproved add-ons or add-ons from third-party websites, use caution as these add-ons may harm your computer or violate your privacy. <a href=\"%(learnmore_url)s"
-"\">Learn more about our approval process</a>"
+"Unless clearly marked otherwise, add-ons available from this gallery have been checked and approved by Mozilla's team of editors and are safe to install. We recommend that you only install approved"
+" add-ons. If you wish to install unapproved add-ons or add-ons from third-party websites, use caution as these add-ons may harm your computer or violate your privacy. <a "
+"href=\"%(learnmore_url)s\">Learn more about our approval process</a>"
 msgstr ""
 "A menos que indicado em contrário, os extras presentes nesta galeria foram verificados e aprovados pela equipa de editores da Mozilla e é seguro instalá-los. Recomendamos que instale apenas os "
 "extras que tenham sido aprovados. Se desejar instalar extras não aprovados a partir de outros sites web, tenha cuidado pois estes extras podem danificar o seu computador ou violar a sua "
@@ -10337,8 +10292,8 @@ msgstr "O %(app_name)s informou-me que um extra não é compatível. Existe algu
 #, python-format
 msgid ""
 "If an add-on isn't compatible with your version of %(app_name)s, it is usually either because your version of %(app_name)s is outdated or the add-on author has not yet updated the add-on to be "
-"compatible with a newer version you are using. Mozilla does not recommend trying to circumvent these compatibility checks, as they can lead to browser instability or in some cases loss of data. For "
-"users who are testing out alpha or beta versions of Firefox, we offer the <a href=\"%(acr_url)s\">Add-on Compatibility Reporter</a> to help add-on developers update their compatibility."
+"compatible with a newer version you are using. Mozilla does not recommend trying to circumvent these compatibility checks, as they can lead to browser instability or in some cases loss of data. For"
+" users who are testing out alpha or beta versions of Firefox, we offer the <a href=\"%(acr_url)s\">Add-on Compatibility Reporter</a> to help add-on developers update their compatibility."
 msgstr ""
 "Se um extra não for compatível com a sua versão do %(app_name)s, é devido ou à sua versão do %(app_name)s estar desatualizada ou ao autor do extra ainda não ter atualizado o extra para ser "
 "compatível com a versão mais recente que está a utilizar. A Mozilla não recomenda tentar ultrapassar esta verificações de compatibilidade, pois podem levar à instabilidade do navegador e em alguns "
@@ -10368,7 +10323,7 @@ msgstr "Galeria de extras"
 msgid "How do I choose between add-ons that seem to do the same thing?"
 msgstr "Como é que escolho entre extras que parecem fazer o mesmo?"
 
-#: src/olympia/pages/templates/pages/faq.html:173
+#: src/olympia/pages/templates/pages/faq.html:172
 msgid ""
 "There are often several add-ons that have similar features. To figure out which is right for you, read the entire description of the add-on and view its screenshots. If there are still several in "
 "the running, read through the add-on's ratings, user reviews, and statistics to see which is most liked by other users. Remember that you can also just try out both and see which you like better."
@@ -10397,8 +10352,8 @@ msgstr "O que significa um extra ser \"experimental\" ou \"preliminarmente revis
 #: src/olympia/pages/templates/pages/faq.html:188
 #, python-format
 msgid ""
-"Experimental add-ons have been checked by our editors to make sure they don't have security problems, but they may still have bugs or not work properly. Use caution when installing experimental add-"
-"ons and uninstall the add-on immediately if you notice problems. <a href=\"%(url)s\">Learn more about our review process</a></dd>"
+"Experimental add-ons have been checked by our editors to make sure they don't have security problems, but they may still have bugs or not work properly. Use caution when installing experimental "
+"add-ons and uninstall the add-on immediately if you notice problems. <a href=\"%(url)s\">Learn more about our review process</a></dd>"
 msgstr ""
 "Extras experimentais foram verificados pelos nossos editores para se certificarem de que não têm problemas de segurança, mas eles podem ainda ter erros ou não funcionar corretamente. Tenha cuidado "
 "ao instalar extras experimentais e desinstale o extra imediatamente se notar problemas. <a href=\"%(url)s\">Saiba mais sobre o processo de revisão</a></dd>"
@@ -10425,23 +10380,23 @@ msgstr "Quanto custam os extras?"
 msgid "Add-ons hosted in our gallery are free unless clearly marked otherwise."
 msgstr "Os extras alojados na nossa galeria são gratuitos a menos que exista uma indicação em contrário."
 
-#: src/olympia/pages/templates/pages/faq.html:210
+#: src/olympia/pages/templates/pages/faq.html:209
 msgid "What does it mean when an add-on asks for contributions?"
 msgstr "O que significa quando um extra pede contribuições?"
 
-#: src/olympia/pages/templates/pages/faq.html:211
+#: src/olympia/pages/templates/pages/faq.html:210
 msgid ""
 "Some add-on authors request users who enjoy an add-on to contribute to its development by making a monetary contribution. These contributions go directly to the developer unless a third party is "
 "indicated, such as the non-profit Mozilla Foundation."
 msgstr ""
-"Alguns autores pedem aos utilizadores que gostaram do extra para contribuírem para o seu desenvolvimento fazendo uma contribuição monetária. Estas contribuições vão diretamente para o programador a "
-"menos que, uma outra entidade seja indicada, tal como a fundação sem fins lucrativos da Mozilla."
+"Alguns autores pedem aos utilizadores que gostaram do extra para contribuírem para o seu desenvolvimento fazendo uma contribuição monetária. Estas contribuições vão diretamente para o programador a"
+" menos que, uma outra entidade seja indicada, tal como a fundação sem fins lucrativos da Mozilla."
 
-#: src/olympia/pages/templates/pages/faq.html:216
+#: src/olympia/pages/templates/pages/faq.html:215
 msgid "What are beta add-ons?"
 msgstr "O que são os extras beta?"
 
-#: src/olympia/pages/templates/pages/faq.html:218
+#: src/olympia/pages/templates/pages/faq.html:217
 msgid ""
 "Beta add-ons are unreviewed versions which represent the latest work of an add-on author. While different authors have different standards for beta code quality, you should assume that these add-"
 "ons are less stable than the general add-on releases."
@@ -10449,30 +10404,27 @@ msgstr ""
 "Os extras Beta são versões não avaliadas que representam o último trabalho do autor do extra. Enquanto diferentes autores têm diferentes standards para a qualidade do código beta, deve partir do "
 "princípio que estes extras são menos estáveis que as versões gerais."
 
-#: src/olympia/pages/templates/pages/faq.html:222
+#: src/olympia/pages/templates/pages/faq.html:221
 msgid ""
-"Please note that when you install an add-on from the \"Beta Version\" section of an add-on's listing, you will continue to receive updates for that add-on as they become available. Like the initial "
-"version you installed, all beta releases are unreviewed by Mozilla and may harm your computer."
+"Please note that when you install an add-on from the \"Beta Version\" section of an add-on's listing, you will continue to receive updates for that add-on as they become available. Like the initial"
+" version you installed, all beta releases are unreviewed by Mozilla and may harm your computer."
 msgstr ""
 "Tenha em atenção que quando instala extras da secção \"versão Beta\" de uma listagem de extras, continua a receber atualizações assim que estas estejam disponíveis. Tal como a versão que instalou, "
 "todos os lançamentos beta não são revistos pela Mozilla e podem danificar o seu computador."
 
-#: src/olympia/pages/templates/pages/faq.html:229
+#: src/olympia/pages/templates/pages/faq.html:228
 msgid "What does it mean when an add-on is flagged as slow?"
 msgstr "O que significa um extra indicado como lento?"
 
-#: src/olympia/pages/templates/pages/faq.html:231
-msgid ""
-"Most add-ons load code and resources at the same time Firefox\n"
-"        is starting up. In most cases the impact in start-up time is minimal,\n"
-"        but some add-ons can cause a noticeable slowdown."
+#: src/olympia/pages/templates/pages/faq.html:229
+msgid "Most add-ons load code and resources at the same time Firefox is starting up. In most cases the impact in start-up time is minimal, but some add-ons can cause a noticeable slowdown."
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:236
+#: src/olympia/pages/templates/pages/faq.html:234
 msgid "How do I report an inappropriate or spam user review?"
 msgstr "Como reporto um comentário de um utilizador como inapropriado ou spam?"
 
-#: src/olympia/pages/templates/pages/faq.html:237
+#: src/olympia/pages/templates/pages/faq.html:235
 msgid ""
 "To report a user review of an add-on, log in with your account and visit the add-on's reviews page. Find the review you wish to report, click \"Report this review\" and select a reason. Our "
 "editorial team will investigate the review and take appropriate action."
@@ -10480,66 +10432,66 @@ msgstr ""
 "Para denunciar um comentário de um utilizador de um extra, inicie sessão com a sua conta e visite a página de comentários do extra. Encontre o comentário que deseja reportar, clique em \"Denunciar "
 "este comentário\" e selecione a razão. A nossa equipa editorial irá investigar e tomar a ação apropriada."
 
-#: src/olympia/pages/templates/pages/faq.html:242
+#: src/olympia/pages/templates/pages/faq.html:240
 msgid "How do I report a bug or contact the Mozilla Add-ons team?"
 msgstr "Como é que reporto um bug ou contacto a equipa dos extras da Mozilla?"
 
-#: src/olympia/pages/templates/pages/faq.html:243
+#: src/olympia/pages/templates/pages/faq.html:241
 #, python-format
 msgid "Please visit our <a href=\"%(contact_url)s\">Contact page</a>."
 msgstr "Por favor visite a nossa <a href=\"%(contact_url)s\">página de contactos</a>."
 
-#: src/olympia/pages/templates/pages/faq.html:246
+#: src/olympia/pages/templates/pages/faq.html:244
 msgid "What is a Source Code License?"
 msgstr "O que é uma licença de código fonte?"
 
-#: src/olympia/pages/templates/pages/faq.html:247
+#: src/olympia/pages/templates/pages/faq.html:245
 #, python-format
 msgid ""
-"The source code used to create an add-on is an exclusive copyright of the add-on author, unless otherwise declared in a source code license. Many add-ons on this site have <a href=\"%(url)s\" lang="
-"\"en\">open source licenses</a> that make the source code publicly available for copy and reuse under conditions determined by the author. Most authors choose widely known open source licenses like "
-"the GPL or BSD licenses instead of making up their own."
+"The source code used to create an add-on is an exclusive copyright of the add-on author, unless otherwise declared in a source code license. Many add-ons on this site have <a href=\"%(url)s\" "
+"lang=\"en\">open source licenses</a> that make the source code publicly available for copy and reuse under conditions determined by the author. Most authors choose widely known open source licenses"
+" like the GPL or BSD licenses instead of making up their own."
 msgstr ""
-"O código fonte utilizado para criar um extra é um direito registado e exclusivo do autor do extra, a menos que indicado na licença do código fonte. Muitos extras deste sítio têm <a href=\"%(url)s\" "
-"lang=\"en\">licenças de código aberto</a> que fazem com que o código fonte esteja disponível para copiar e reutilizar sobre determinadas condições pelo autor. Muitos autores escolhem licenças de "
+"O código fonte utilizado para criar um extra é um direito registado e exclusivo do autor do extra, a menos que indicado na licença do código fonte. Muitos extras deste sítio têm <a href=\"%(url)s\""
+" lang=\"en\">licenças de código aberto</a> que fazem com que o código fonte esteja disponível para copiar e reutilizar sobre determinadas condições pelo autor. Muitos autores escolhem licenças de "
 "código aberto muito conhecidas como as licenças GPL ou BSD em vez de fazerem a sua própria licença."
 
-#: src/olympia/pages/templates/pages/faq.html:256
+#: src/olympia/pages/templates/pages/faq.html:254
 #, python-format
 msgid "Firefox and other Mozilla software are <a href=\"%(url)s\">open source</a>."
 msgstr "O Firefox e outro software da Mozilla são de <a href=\"%(url)s\">código aberto</a>."
 
-#: src/olympia/pages/templates/pages/faq.html:264
+#: src/olympia/pages/templates/pages/faq.html:262
 msgid "Collections and Favorites"
 msgstr "Coleções e favoritos"
 
-#: src/olympia/pages/templates/pages/faq.html:267
+#: src/olympia/pages/templates/pages/faq.html:265
 msgid "What is a collection?"
 msgstr "O que é uma coleção?"
 
-#: src/olympia/pages/templates/pages/faq.html:268
+#: src/olympia/pages/templates/pages/faq.html:266
 msgid "Collections are groups of related add-ons created by users to share."
 msgstr "As coleções são grupos de extras criados pelos utilizadores para serem partilhadas."
 
-#: src/olympia/pages/templates/pages/faq.html:270
+#: src/olympia/pages/templates/pages/faq.html:268
 msgid "What is the My Favorites collection?"
 msgstr "Qual é a coleção Meus favoritos?"
 
-#: src/olympia/pages/templates/pages/faq.html:271
+#: src/olympia/pages/templates/pages/faq.html:269
 msgid "Favorite add-ons are add-ons that you have bookmarked to easily get back to later. You can add an add-on to your favorites collection by clicking \"Add to favorites\" on its details page."
 msgstr ""
-"Os extras favoritos são extras que adicionou aos marcadores para que possa regresssar facilmente mais tarde. Pode adicionar um extra à sua coleção de favoritos clicando em \"Adicionar aos favoritos"
-"\" na página de detalhes do extra."
+"Os extras favoritos são extras que adicionou aos marcadores para que possa regresssar facilmente mais tarde. Pode adicionar um extra à sua coleção de favoritos clicando em \"Adicionar aos "
+"favoritos\" na página de detalhes do extra."
 
-#: src/olympia/pages/templates/pages/faq.html:275 src/olympia/templates/menu_links.html:13 src/olympia/templates/impala/header_title.html:17
+#: src/olympia/pages/templates/pages/faq.html:273 src/olympia/templates/menu_links.html:13 src/olympia/templates/impala/header_title.html:17
 msgid "Mobile Add-ons"
 msgstr "Extras móveis"
 
-#: src/olympia/pages/templates/pages/faq.html:278
+#: src/olympia/pages/templates/pages/faq.html:276
 msgid "What are mobile add-ons?"
 msgstr "O que são extras móveis?"
 
-#: src/olympia/pages/templates/pages/faq.html:279
+#: src/olympia/pages/templates/pages/faq.html:277
 #, python-format
 msgid ""
 "Mobile add-ons work with <a href=\"%(mobile_url)s\">Firefox for Mobile</a> and add or modify functionality just like desktop add-ons. You can find add-ons that work with Firefox for Mobile in our "
@@ -10548,26 +10500,25 @@ msgstr ""
 "Os extras móveis funcionam no <a href=\"%(mobile_url)s\">Firefox para dispositivos móveis</a> e adicionam ou modificam funcionalidades tais como os extras de computador. Pode encontrar extras que "
 "funcionam com o Firefox para dispositivos móveis na nossa <a href=\"%(gallery_url)s\">galeria</a>."
 
-#: src/olympia/pages/templates/pages/faq.html:288
+#: src/olympia/pages/templates/pages/faq.html:286
 msgid "Developer Topics"
 msgstr "Tópicos do programador"
 
-#: src/olympia/pages/templates/pages/faq.html:289
+#: src/olympia/pages/templates/pages/faq.html:287
 #, python-format
 msgid "Please see our <a href=\"%(faq_url)s\">Developer FAQ</a> and <a href=\"%(hub_url)s\">Developer Hub</a> for answers to add-on developer-related questions."
-msgstr ""
-"Por favor veja a nossa <a href=\"%(faq_url)s\">FAQ do programador</a> e a <a href=\"%(hub_url)s\">central do programador</a> para respostas a questões relacionadas com o desenvolvimento de extras."
+msgstr "Por favor veja a nossa <a href=\"%(faq_url)s\">FAQ do programador</a> e a <a href=\"%(hub_url)s\">central do programador</a> para respostas a questões relacionadas com o desenvolvimento de extras."
 
-#: src/olympia/pages/templates/pages/faq.html:294
+#: src/olympia/pages/templates/pages/faq.html:292
 msgid "Still have questions?"
 msgstr "Ainda tem questões?"
 
-#: src/olympia/pages/templates/pages/faq.html:295
+#: src/olympia/pages/templates/pages/faq.html:293
 #, python-format
 msgid "For general Firefox support, visit our <a href=\"%(sumo_url)s\">support website</a>. For general add-on and website questions, visit our <a href=\"%(forum_url)s\">forum</a>."
 msgstr ""
-"Para apoio geral para o Firefox, visite o nosso <a href=\"%(sumo_url)s\">sítio web de ajuda</a>. Para questões gerais sobre extras ou sobre o sítio web, visite o nosso <a href=\"%(forum_url)s"
-"\">fórum</a>."
+"Para apoio geral para o Firefox, visite o nosso <a href=\"%(sumo_url)s\">sítio web de ajuda</a>. Para questões gerais sobre extras ou sobre o sítio web, visite o nosso <a "
+"href=\"%(forum_url)s\">fórum</a>."
 
 #: src/olympia/pages/templates/pages/review_guide.html:36 src/olympia/pages/templates/pages/review_guide.html:51
 msgid "Some tips for writing a great review"
@@ -10715,8 +10666,8 @@ msgid ""
 "Development on the Sunbird project has halted and its final release was on March 30, 2010. We've been proud to host Sunbird add-ons on this site but as the project is no longer maintained we have "
 "disabled our support for the add-ons."
 msgstr ""
-"O desenvolvimento do projeto Sunbird foi suspenso e a última versão foi lançada em 30 de março de 2010. Temos o orgulho de alojar extras para o Sunbird neste sitio, mas uma vez que o projeto deixou "
-"de ser mantido, nós desativámos o nosso suporte para os seus extras."
+"O desenvolvimento do projeto Sunbird foi suspenso e a última versão foi lançada em 30 de março de 2010. Temos o orgulho de alojar extras para o Sunbird neste sitio, mas uma vez que o projeto deixou"
+" de ser mantido, nós desativámos o nosso suporte para os seus extras."
 
 #: src/olympia/pages/templates/pages/sunbird.html:38
 #, python-format
@@ -10793,15 +10744,15 @@ msgstr "Adicionar um comentário a {0}"
 msgid ""
 "<h2>Keep these tips in mind:</h2> <ul> <li> Write like you're telling a friend about your experience with the add-on. Give specifics and helpful details, such as what features you liked and/or "
 "disliked, how easy to use it is, and any disadvantages it has. Avoid generic language such as calling it \"Great\" or \"Bad\" unless you can give reasons why you believe this is so. </li> <li> "
-"Please do not post bug reports in reviews. We do not make your email address available to add-on developers and they may need to contact you to help resolve your issue. See the <a href=\"%(support)s"
-"\">support section</a> to find out where to get assistance for this add-on. </li> <li>Please keep reviews clean, avoid the use of improper language and do not post any personal information. </li> </"
-"ul> <p>Please read the <a href=\"%(guide)s\" target=\"_blank\">Review Guidelines</a> for more detail about user add-on reviews.</p>"
+"Please do not post bug reports in reviews. We do not make your email address available to add-on developers and they may need to contact you to help resolve your issue. See the <a "
+"href=\"%(support)s\">support section</a> to find out where to get assistance for this add-on. </li> <li>Please keep reviews clean, avoid the use of improper language and do not post any personal "
+"information. </li> </ul> <p>Please read the <a href=\"%(guide)s\" target=\"_blank\">Review Guidelines</a> for more detail about user add-on reviews.</p>"
 msgstr ""
 "<h2>Tenha em consideração estas dicas:</h2> <ul> <li> Escreva como se estivesse a partilhar com um amigo a sua experiência com um extra. Forneça detalhes específicos e úteis, tais como as "
 "funcionalidade que gostou e/ou não gostou, quão simples era de utilizar e quaisquer desvantagens que esta tenha. Evite linguagem genérica, como dizer que era \"Fantástico\" ou \"Mau\" a menos que "
 "fundamente a sua opinião com razões para a sua apreciação. </li> <li> Por favor, não coloque relatórios de falha nas análises. Nós não disponibilizamos o seu endereço de email aos programadores do "
-"extra e estes podem precisar de entrar em contacto consigo para o ajudar a resolver o seu problema. Consulte a <a href=\"%(support)s\">secção de apoio</a> para saber onde pode obter ajuda para este "
-"extra. </li> <li>Por favor mantenha os comentários limpos, evite utilizar linguagem imprópria e não publique qualquer informação pessoal. </li> </ul> <p>Por favor leia as <a href=\"%(guide)s\" "
+"extra e estes podem precisar de entrar em contacto consigo para o ajudar a resolver o seu problema. Consulte a <a href=\"%(support)s\">secção de apoio</a> para saber onde pode obter ajuda para este"
+" extra. </li> <li>Por favor mantenha os comentários limpos, evite utilizar linguagem imprópria e não publique qualquer informação pessoal. </li> </ul> <p>Por favor leia as <a href=\"%(guide)s\" "
 "target=\"_blank\">diretrizes de revisão</a> para mais detalhes sobre as análises de utilizadores de extras.</p>"
 
 #: src/olympia/reviews/templates/reviews/reply.html:4
@@ -11034,16 +10985,16 @@ msgstr "{0} extras"
 
 #. L10n: {0} is an application, such as Firefox. This means "any version of
 #. Firefox."
-#: src/olympia/search/views.py:554
+#: src/olympia/search/views.py:547
 msgid "Any {0}"
 msgstr "Qualquer {0}"
 
 #. L10n: "All Systems" means show everything regardless of platform.
-#: src/olympia/search/views.py:589
+#: src/olympia/search/views.py:582
 msgid "All Systems"
 msgstr "Todos os sistemas"
 
-#: src/olympia/search/views.py:600
+#: src/olympia/search/views.py:593
 msgid "All Tags"
 msgstr "Todas as etiquetas"
 
@@ -11217,31 +11168,31 @@ msgstr "Partilhar este extra"
 msgid "Share this Collection"
 msgstr "Partilhar esta coleção"
 
-#: src/olympia/signing/views.py:30 src/olympia/templates/base.html:75 src/olympia/templates/impala/base.html:115
+#: src/olympia/signing/views.py:33 src/olympia/templates/base.html:71 src/olympia/templates/impala/base.html:112
 msgid "Some features are temporarily disabled while we perform website maintenance. We'll be back to full capacity shortly."
 msgstr "Algumas funcionalidades estão temporariamente desativadas enquanto efetuamos uma manutenção ao sítio web. Voltamos em breve com todas as funcionalidades."
 
-#: src/olympia/signing/views.py:53
+#: src/olympia/signing/views.py:56
 msgid "Could not find add-on with id \"{}\"."
 msgstr ""
 
-#: src/olympia/signing/views.py:67
+#: src/olympia/signing/views.py:70
 msgid "You do not own this addon."
 msgstr ""
 
-#: src/olympia/signing/views.py:82
+#: src/olympia/signing/views.py:87
 msgid "Missing \"upload\" key in multipart file data."
 msgstr ""
 
-#: src/olympia/signing/views.py:96
+#: src/olympia/signing/views.py:101
 msgid "Version does not match the manifest file."
 msgstr ""
 
-#: src/olympia/signing/views.py:100
+#: src/olympia/signing/views.py:105
 msgid "Version already exists."
 msgstr ""
 
-#: src/olympia/signing/views.py:136
+#: src/olympia/signing/views.py:141
 msgid "No uploaded file for that addon and version."
 msgstr ""
 
@@ -11354,89 +11305,89 @@ msgstr "{0} :: Painel de estatísticas"
 msgid "Statistics Dashboard :: Add-ons for {0}"
 msgstr "Painel de estatísticas :: Extras para {0}"
 
-#: src/olympia/stats/templates/stats/stats.html:30
-msgid "Controls:"
-msgstr "Controlos:"
-
-#: src/olympia/stats/templates/stats/stats.html:33
-msgid "reset zoom"
-msgstr "repor zoom"
-
-#: src/olympia/stats/templates/stats/stats.html:40
-msgid "Group by:"
-msgstr "Agrupar por:"
-
-#: src/olympia/stats/templates/stats/stats.html:42
-msgid "day"
-msgstr "dia"
-
-#: src/olympia/stats/templates/stats/stats.html:45
-msgid "week"
-msgstr "semana"
-
-#: src/olympia/stats/templates/stats/stats.html:48
-msgid "month"
-msgstr "mês"
-
-#: src/olympia/stats/templates/stats/stats.html:54
-msgid "For last:"
-msgstr "Por últimos:"
-
-#: src/olympia/stats/templates/stats/stats.html:57
-msgid "7 days"
-msgstr "7 dias"
-
-#: src/olympia/stats/templates/stats/stats.html:60
-msgid "30 days"
-msgstr "30 dias"
-
-#: src/olympia/stats/templates/stats/stats.html:63
-msgid "90 days"
-msgstr "90 dias"
-
-#: src/olympia/stats/templates/stats/stats.html:66
-msgid "365 days"
-msgstr "365 dias"
-
-#: src/olympia/stats/templates/stats/stats.html:69
-msgid "Custom..."
-msgstr "Personalizar..."
-
 #. {0} is an add-on name
-#: src/olympia/stats/templates/stats/stats.html:88 src/olympia/stats/templates/stats/stats.html:91
+#: src/olympia/stats/templates/stats/stats.html:44 src/olympia/stats/templates/stats/stats.html:47
 msgid "Statistics for {0}"
 msgstr "Estatísticas para {0}"
 
-#: src/olympia/stats/templates/stats/stats.html:94
+#: src/olympia/stats/templates/stats/stats.html:50
 msgid "Statistics Dashboard"
 msgstr "Painel de estatísticas"
 
-#: src/olympia/stats/templates/stats/stats.html:104
+#: src/olympia/stats/templates/stats/stats.html:57
+msgid "Controls:"
+msgstr "Controlos:"
+
+#: src/olympia/stats/templates/stats/stats.html:60
+msgid "reset zoom"
+msgstr "repor zoom"
+
+#: src/olympia/stats/templates/stats/stats.html:67
+msgid "Group by:"
+msgstr "Agrupar por:"
+
+#: src/olympia/stats/templates/stats/stats.html:69
+msgid "day"
+msgstr "dia"
+
+#: src/olympia/stats/templates/stats/stats.html:72
+msgid "week"
+msgstr "semana"
+
+#: src/olympia/stats/templates/stats/stats.html:75
+msgid "month"
+msgstr "mês"
+
+#: src/olympia/stats/templates/stats/stats.html:81
+msgid "For last:"
+msgstr "Por últimos:"
+
+#: src/olympia/stats/templates/stats/stats.html:84
+msgid "7 days"
+msgstr "7 dias"
+
+#: src/olympia/stats/templates/stats/stats.html:87
+msgid "30 days"
+msgstr "30 dias"
+
+#: src/olympia/stats/templates/stats/stats.html:90
+msgid "90 days"
+msgstr "90 dias"
+
+#: src/olympia/stats/templates/stats/stats.html:93
+msgid "365 days"
+msgstr "365 dias"
+
+#: src/olympia/stats/templates/stats/stats.html:96
+msgid "Custom..."
+msgstr "Personalizar..."
+
+#: src/olympia/stats/templates/stats/stats.html:106
 msgid "Statistics processing is currently disabled, so recent data is unavailable. The statistics are still being collected and this page will be updated soon with the missing data."
 msgstr ""
 
-#: src/olympia/stats/templates/stats/stats.html:110
+#: src/olympia/stats/templates/stats/stats.html:112
 msgid "Loading the latest data&hellip;"
 msgstr "A carregar os últimos dados&hellip;"
 
-#: src/olympia/stats/templates/stats/stats.html:142 src/olympia/stats/templates/stats/reports/overview.html:25 src/olympia/stats/templates/stats/reports/overview.html:37
+#: src/olympia/stats/templates/stats/stats.html:144 src/olympia/stats/templates/stats/reports/overview.html:25 src/olympia/stats/templates/stats/reports/overview.html:37
 #: src/olympia/stats/templates/stats/reports/overview.html:49
 msgid "No data available."
 msgstr "Sem dados disponíveis."
 
-#: src/olympia/stats/templates/stats/stats.html:177
+#: src/olympia/stats/templates/stats/stats.html:179
 msgid "This dashboard is currently <b>public</b>."
 msgstr "Este painel está atualmente <b>público</b>."
 
-#: src/olympia/stats/templates/stats/stats.html:179
+#: src/olympia/stats/templates/stats/stats.html:181
 msgid "Contribution stats are currently <b>private</b>."
 msgstr "As estatísticas de contribuição estão atualmente <b>privadas</b>."
 
-#: src/olympia/stats/templates/stats/stats.html:182
+#: src/olympia/stats/templates/stats/stats.html:184
 msgid "This dashboard is currently <b>private</b>."
 msgstr "Este painel está atualmente <b>privado</b>."
 
-#: src/olympia/stats/templates/stats/stats.html:185
+#: src/olympia/stats/templates/stats/stats.html:187
 msgid "Change settings."
 msgstr "Alterar definições."
 
@@ -11548,17 +11499,17 @@ msgstr "Sobre a monitorização de fontes externas..."
 #, python-format
 msgid ""
 "<h2>Tracking external sources</h2> <p> If you link to your add-on's details page or directly to its file from an external site, such as your blog or website, you can append a parameter to be "
-"tracked as an additional download source on this page. For example, the following links would appear as sourced by your blog: <dl> <dt>Add-on Details Page</dt> <dd>https://addons.mozilla.org/addon/"
-"%(slug)s?src=<b>external-blog</b></dd> <dt>Direct File Link</dt> <dd>https://addons.mozilla.org/downloads/latest/%(id)s/addon-%(id)s-latest.xpi?src=<b>external-blog</b></dd> </dl> <p> Only src "
-"parameters that begin with \"external-\" will be tracked, up to 61 additional characters. Any text after \"external-\" can be used to describe the source, such as \"external-blog\", \"external-"
-"sidebar\", \"external-campaign225\", etc. The following URL-safe characters are allowed: <code>a-z A-Z - . _ ~ %% +</code>"
+"tracked as an additional download source on this page. For example, the following links would appear as sourced by your blog: <dl> <dt>Add-on Details Page</dt> "
+"<dd>https://addons.mozilla.org/addon/%(slug)s?src=<b>external-blog</b></dd> <dt>Direct File Link</dt> <dd>https://addons.mozilla.org/downloads/latest/%(id)s/addon-%(id)s-latest.xpi?src=<b>external-"
+"blog</b></dd> </dl> <p> Only src parameters that begin with \"external-\" will be tracked, up to 61 additional characters. Any text after \"external-\" can be used to describe the source, such as "
+"\"external-blog\", \"external-sidebar\", \"external-campaign225\", etc. The following URL-safe characters are allowed: <code>a-z A-Z - . _ ~ %% +</code>"
 msgstr ""
 "<h2>Monitorização de fontes externas</h2> <p> Se ligou a página de detalhes do extra ou diretamente o respetivo ficheiro a partir de um site externo, tal como o seu blogue ou site web, pode "
 "adicionar um parâmetro para ser referenciado como uma fonte adicional da transferência nesta página. Por exemplo, as ligações seguintes iriam aparecer classificadas como o seu blogue: <dl> "
-"<dt>Página de detalhes do extra</dt> <dd>https://addons.mozilla.org/addon/%(slug)s?src=<b>external-blogue</b></dd> <dt>Ligação direta ao ficheiro</dt> <dd>https://addons.mozilla.org/downloads/"
-"latest/%(id)s/addon-%(id)s-latest.xpi?src=<b>external-blogue</b></dd> </dl> <p> Apenas os parâmetros src que começam com \"external-\" serão monitorizados, até 61 carateres adicionais. Qualquer "
-"texto depois de \"external-\" pode ser utilizado para descrever a fonte, tais como \"external-blogue\", \"external-barra-lateral\", \"external-campanha225\", etc. Os seguintes caracteres, seguros "
-"para URLs, são permitidos: <code>a-z A-Z - . _ ~ %% +</code>"
+"<dt>Página de detalhes do extra</dt> <dd>https://addons.mozilla.org/addon/%(slug)s?src=<b>external-blogue</b></dd> <dt>Ligação direta ao ficheiro</dt> "
+"<dd>https://addons.mozilla.org/downloads/latest/%(id)s/addon-%(id)s-latest.xpi?src=<b>external-blogue</b></dd> </dl> <p> Apenas os parâmetros src que começam com \"external-\" serão monitorizados, "
+"até 61 carateres adicionais. Qualquer texto depois de \"external-\" pode ser utilizado para descrever a fonte, tais como \"external-blogue\", \"external-barra-lateral\", \"external-campanha225\", "
+"etc. Os seguintes caracteres, seguros para URLs, são permitidos: <code>a-z A-Z - . _ ~ %% +</code>"
 
 #: src/olympia/stats/templates/stats/reports/statuses.html:3
 msgid "Add-on Status by Date"
@@ -11586,8 +11537,8 @@ msgstr ""
 
 #: src/olympia/stats/templates/stats/reports/usage.html:20
 msgid ""
-"<h2>What are daily users?</h2> <p> Add-ons downloaded from this site check for updates once per day. The total number of these update pings is known as Active Daily Users. Daily users can be broken "
-"down by add-on version, operating system, add-on status, application, and locale. </p>"
+"<h2>What are daily users?</h2> <p> Add-ons downloaded from this site check for updates once per day. The total number of these update pings is known as Active Daily Users. Daily users can be broken"
+" down by add-on version, operating system, add-on status, application, and locale. </p>"
 msgstr ""
 "<h2>O que são utilizadores diários?</h2> <p> Os extras instalados a partir deste site procuram por atualizações diariamente. O número total destas verificações por atualizações são conhecidas como "
 "utilizadores diários ativos. Os utilizadores diários podem ser decompostos por versão do extra, sistema operativo, estado do extra, aplicação e idioma. </p>"
@@ -11600,15 +11551,6 @@ msgstr "Registos de utilizador por data"
 msgid "Application versions by Date"
 msgstr "Versões da aplicação por data"
 
-#: src/olympia/tags/templates/tags/top_cloud.html:4
-msgid "Top {0} Tags"
-msgstr "Top {0} de etiquetas"
-
-#. {0} is the current application name
-#: src/olympia/tags/templates/tags/top_cloud.html:14
-msgid "{0} Top Tags"
-msgstr "Top de etiquetas de {0}"
-
 #: src/olympia/templates/amo_footer.html:6 src/olympia/templates/includes/lang_switcher.html:2
 msgid "Other languages"
 msgstr "Outros idiomas"
@@ -11617,11 +11559,11 @@ msgstr "Outros idiomas"
 msgid "Mozilla Add-ons"
 msgstr "Extras da Mozilla"
 
-#: src/olympia/templates/base.html:91 src/olympia/templates/impala/base.html:81
+#: src/olympia/templates/base.html:89 src/olympia/templates/impala/base.html:78
 msgid "Find add-ons for other applications"
 msgstr "Procure extras para outras aplicações"
 
-#: src/olympia/templates/base.html:92 src/olympia/templates/impala/base.html:81
+#: src/olympia/templates/base.html:90 src/olympia/templates/impala/base.html:78
 msgid "Other Applications"
 msgstr "Outras aplicações"
 
@@ -11646,7 +11588,7 @@ msgid "View Mobile Site"
 msgstr "Ver versão móvel"
 
 #: src/olympia/templates/copyright.html:7
-msgid "Site Status "
+msgid "Site Status"
 msgstr ""
 
 #: src/olympia/templates/footer.html:3
@@ -11746,35 +11688,35 @@ msgstr "Bem vindo, {0}"
 msgid "<a href=\"%(reg)s\">Register</a> or <a href=\"%(login)s\">Log in</a>"
 msgstr "<a href=\"%(reg)s\">Registe-se</a> ou <a href=\"%(login)s\">Inicie sessão</a>"
 
-#: src/olympia/templates/impala/base.html:126
+#: src/olympia/templates/impala/base.html:123
 #, python-format
 msgid "To try the thousands of add-ons available here, download <a href=\"%(url)s\">Mozilla Firefox</a>, a fast, free way to surf the Web!"
 msgstr "Para experimentar as centenas de extras disponíveis aqui, transfira o <a href=\"%(url)s\">Mozilla Firefox</a>, uma maneira rápida e gratuita de navegar na Web!"
 
-#: src/olympia/templates/impala/base.html:138
+#: src/olympia/templates/impala/base.html:135
 #, python-format
 msgid "Add-ons is switching to Firefox Accounts for login. <a href=\"%(url)s\" class=\"fxa-login\">Sign in now to transfer your account.</a>"
 msgstr ""
 
 #. {0} is an application, such as Firefox.
-#: src/olympia/templates/impala/base.html:148
+#: src/olympia/templates/impala/base.html:145
 msgid "Welcome to {0} Add-ons."
 msgstr "Bem-vindo aos extras do {0}."
 
-#: src/olympia/templates/impala/base.html:151
+#: src/olympia/templates/impala/base.html:148
 msgid "Choose from thousands of extra features and styles to make Firefox your own."
 msgstr "Escolha a partir de centenas de funcionalidades e estilos adicionais para tornar o Firefox só seu."
 
-#: src/olympia/templates/impala/base.html:156
+#: src/olympia/templates/impala/base.html:153
 #, python-format
 msgid "Add extra features and styles to make %(app)s your own."
 msgstr "Adicione funcionalidades e estilos adicionais para tornar o %(app)s só seu."
 
-#: src/olympia/templates/impala/base.html:164
+#: src/olympia/templates/impala/base.html:161
 msgid "On the go?"
 msgstr "Em qualquer lugar?"
 
-#: src/olympia/templates/impala/base.html:166
+#: src/olympia/templates/impala/base.html:163
 msgid "Check out our <a class=\"mobile-link\" href=\"#\">Mobile Add-ons site</a>."
 msgstr "Consulte o nosso <a class=\"mobile-link\" href=\"#\">sítio de extras para dispositivos móveis</a>."
 
@@ -11998,19 +11940,19 @@ msgstr "Nenhum utilizador com esse email."
 
 #. L10n: {id} will be something like "13ad6a", just a random number
 #. to differentiate this user from other anonymous users.
-#: src/olympia/users/models.py:353
+#: src/olympia/users/models.py:362
 msgid "Anonymous user {id}"
 msgstr ""
 
-#: src/olympia/users/models.py:410
+#: src/olympia/users/models.py:419
 msgid "Your account has been restricted"
 msgstr "A sua conta foi restringida"
 
-#: src/olympia/users/models.py:480
+#: src/olympia/users/models.py:489
 msgid "Please confirm your email address"
 msgstr "Confirme o seu endereço de email"
 
-#: src/olympia/users/models.py:506
+#: src/olympia/users/models.py:515
 msgid "My Mobile Add-ons"
 msgstr "Os meus extras do móvel"
 
@@ -12543,8 +12485,7 @@ msgid "Send password reset link"
 msgstr "Enviar ligação de reposição da palavra-passe"
 
 #: src/olympia/users/templates/users/pwreset_sent.html:10
-msgid ""
-"An email has been sent to the requested account with further information. If you do not receive an email then please confirm you have entered the same email address used during account registration."
+msgid "An email has been sent to the requested account with further information. If you do not receive an email then please confirm you have entered the same email address used during account registration."
 msgstr ""
 "Foi enviada uma mensagem de correio para a conta solicitada com mais informação. Se não receber a mensagem de correio por favor se introduziu o mesmo endereço de correio que utilizou durante o "
 "registo da conta."
@@ -12579,8 +12520,7 @@ msgstr "Se for um programador de extras e quiser enviar o seu extra para ser dis
 
 #: src/olympia/users/templates/users/register.html:23
 msgid "Upon successful registration, you will be sent a confirmation email to the address you provided. Please follow the instructions there to confirm your account."
-msgstr ""
-"Após um registo bem sucedido, será enviada uma mensagem de correio eletrónico de confirmação para o endereço que forneceu. Por favor, siga as instruções nessa mensagem para confirmar a sua conta."
+msgstr "Após um registo bem sucedido, será enviada uma mensagem de correio eletrónico de confirmação para o endereço que forneceu. Por favor, siga as instruções nessa mensagem para confirmar a sua conta."
 
 #: src/olympia/users/templates/users/register.html:30
 #, python-format
@@ -12776,15 +12716,15 @@ msgstr "Histórico da versão %s"
 msgid "Version History with Changelogs"
 msgstr "Histórico da versão com registo de alterações"
 
-#: src/olympia/versions/models.py:314
+#: src/olympia/versions/models.py:313
 msgid "Add-on uses binary components."
 msgstr "O extra utiliza componentes binários."
 
-#: src/olympia/versions/models.py:317
+#: src/olympia/versions/models.py:316
 msgid "Add-on has opted into strict compatibility checking."
 msgstr "O extra optou pela verificação de compatibilidade estrita."
 
-#: src/olympia/versions/models.py:715
+#: src/olympia/versions/models.py:711
 msgid "{app} {min} and later"
 msgstr "{app} {min} e superiores"
 
@@ -12860,3 +12800,8 @@ msgstr "Correio eletrónico após terminar"
 #: src/olympia/zadmin/forms.py:105
 msgid "Log emails instead of sending"
 msgstr "Registar mensagens de correio em vez de enviar"
+
+#: src/olympia/zadmin/forms.py:215
+msgid "Deleted versions can`t be changed."
+msgstr ""
+

--- a/locale/pt/LC_MESSAGES/djangojs.po
+++ b/locale/pt/LC_MESSAGES/djangojs.po
@@ -1,1217 +1,1237 @@
-
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2016-02-24 21:23+0000\n"
+"POT-Creation-Date: 2016-04-18 15:47+0000\n"
 "PO-Revision-Date: 2015-10-15 00:51+0000\n"
 "Last-Translator: Cláudio <cesperanc@gmail.com>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
+"Language: \n"
 "MIME-Version: 1.0\n"
-"Content-Type: text/plain; charset=utf-8\n"
+"Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Generated-By: Babel 2.2.0\n"
 
-#: static/js/common/ratingwidget.js:31
-msgid "{0} star"
-msgid_plural "{0} stars"
-msgstr[0] "{0} estrela"
-msgstr[1] "{0} estrelas"
-
-#: static/js/common/upload-addon.js:41 static/js/common/upload-image.js:128
-msgid "There was a problem contacting the server."
-msgstr "Ocorreu um problema ao contactar o servidor."
-
-#: static/js/common/upload-addon.js:69
-msgid "Select a file..."
-msgstr "Selecionar um ficheiro..."
-
-#: static/js/common/upload-addon.js:70
-msgid "Your add-on should end with .xpi, .jar or .xml"
-msgstr "O seu extra deve terminar com .xpi, .jar ou .xml"
-
-#. L10n: {0} is the percent of the file that has been uploaded.
-#: static/js/common/upload-addon.js:104
-#, python-format
-msgid "{0}% complete"
-msgstr "{0}% concluído"
-
-#. L10n: "{bytes uploaded} of {total filesize}".
-#: static/js/common/upload-addon.js:107
-msgid "{0} of {1}"
-msgstr "{0} de {1}"
-
-#: static/js/common/upload-addon.js:140
-msgid "Cancel"
-msgstr "Cancelar"
-
-#: static/js/common/upload-addon.js:162
-msgid "Uploading {0}"
-msgstr "A carregar {0}"
-
-#: static/js/common/upload-addon.js:189
-msgid "Error with {0}"
-msgstr "Erro com {0}"
-
-#: static/js/common/upload-addon.js:194
-msgid "Your add-on failed validation with {0} error."
-msgid_plural "Your add-on failed validation with {0} errors."
-msgstr[0] "O seu extra falhou a validação com {0} erro."
-msgstr[1] "O seu extra falhou a validação com {0} erros."
-
-#: static/js/common/upload-addon.js:208
-msgid "&hellip;and {0} more"
-msgid_plural "&hellip;and {0} more"
-msgstr[0] "&hellip;e mais {0}"
-msgstr[1] "&hellip;e mais {0}"
-
-#: static/js/common/upload-addon.js:222 static/js/common/upload-addon.js:512
-msgid "See full validation report"
-msgstr "Ver relatório completo da validação"
-
-#: static/js/common/upload-addon.js:234
-msgid "Validating {0}"
-msgstr "A validar {0}"
-
-#. L10n: first argument is an HTTP status code
-#: static/js/common/upload-addon.js:273
-msgid "Received an empty response from the server; status: {0}"
-msgstr "Foi recebida uma resposta vazia do servidor; estado: {0}"
-
-#: static/js/common/upload-addon.js:373
-msgid "Unexpected server error while validating."
-msgstr "Erro inesperado do servidor na validação."
-
-#: static/js/common/upload-addon.js:412
-msgid "Finished validating {0}"
-msgstr "Terminou a validação de {0}"
-
-#: static/js/common/upload-addon.js:418
-msgid "Your add-on validation timed out, it will be manually reviewed."
-msgstr "A validação do extra expirou, será automaticamente revisto."
-
-#: static/js/common/upload-addon.js:421
-msgid "Your add-on was validated with no errors and {0} warning."
-msgid_plural "Your add-on was validated with no errors and {0} warnings."
-msgstr[0] "O seu extra foi validado sem erros e {0} aviso."
-msgstr[1] "O seu extra foi validado sem erros e {0} avisos."
-
-#: static/js/common/upload-addon.js:426
-msgid "Your add-on was validated with no errors and {0} message."
-msgid_plural "Your add-on was validated with no errors and {0} messages."
-msgstr[0] "O seu extra foi validado sem erros e {0} mensagem."
-msgstr[1] "O seu extra foi validado sem erros e {0} mensagens."
-
-#: static/js/common/upload-addon.js:431
-msgid "Your add-on was validated with no errors or warnings."
-msgstr "O seu extra foi validado sem erros ou mensagens."
-
-#: static/js/common/upload-addon.js:446
-msgid "Your submission will be automatically signed."
-msgstr ""
-
-#: static/js/common/upload-addon.js:465
-msgid "Include detailed version notes (this can be done in the next step)."
-msgstr "Incluir notas detalhadas da versão (isto pode ser feito no próximo passo)."
-
-#: static/js/common/upload-addon.js:466
-msgid "If your add-on requires an account to a website in order to be fully tested, include a test username and password in the Notes to Reviewer (this can be done in the next step)."
-msgstr "Se o seu extra requer uma conta num site web para ser completamente testado, inclua um nome de utilizador e senha de teste nas Notas para o Revisor (isto pode ser feito no próximo passo)."
-
-#: static/js/common/upload-addon.js:467
-msgid "If your add-on is intended for a limited audience you should choose Preliminary Review instead of Full Review."
-msgstr "Se um extra é direcionado a uma audiência limitada deve escolher a Revisão preliminar em vez de uma Revisão completa"
-
-#: static/js/common/upload-addon.js:480
-msgid "Add-on submission checklist"
-msgstr "Lista de verificação da submissão de extra"
-
-#: static/js/common/upload-addon.js:481
-msgid "Please verify the following points before finalizing your submission. This will minimize delays or misunderstanding during the review process:"
-msgstr "Por favor confirme os pontos seguintes antes de finalizar a sua submissão. Isto irá minimizar atrasos ou confusões durante o processo de revisão:"
-
-#: static/js/common/upload-addon.js:483
-msgid ""
-"Compiled binaries, as well as minified or obfuscated scripts (excluding known libraries) need to have their sources submitted separately for review. Make sure that you use the source code upload "
-"field to avoid having your submission rejected."
-msgstr ""
-"Binários compilados, bem como scripts minificados ou ofuscados (excluindo bibliotecas conhecidas) devem ter as suas fontes submetidas separadamente para revisão. Tenha a certeza que utiliza o campo"
-" de envio de código fonte para evitar que as sua submissão seja rejeitada."
-
-#: static/js/common/upload-addon.js:501
-msgid "The validation process found these issues that can lead to rejections:"
-msgstr "O processo de validação encontrou estes problemas que podem levar a rejeições:"
-
-#: static/js/common/upload-addon.js:518
-msgid "If you are unfamiliar with the add-ons review process, you can read about it here."
-msgstr "Se não está familiarizado com o processo de revisão de extras, pode ler mais sobre o mesmo aqui."
-
-#: static/js/common/upload-addon.js:555
-msgid "Sorry, no supported platform has been found."
-msgstr "Lamentamos, mas não foi encontrada nenhuma plataforma suportada."
-
-#: static/js/common/upload-base.js:57
-msgid "The filetype you uploaded isn't recognized."
-msgstr "O tipo de ficheiro que enviou não foi reconhecido."
-
-#: static/js/common/upload-base.js:79
-msgid "You cancelled the upload."
-msgstr "Cancelou o envio."
-
-#: static/js/common/upload-image.js:97 static/js/impala/users.js:51
-msgid "Images must be either PNG or JPG."
-msgstr "Imagens têm de ser PNG ou JPG."
-
-#: static/js/common/upload-image.js:101
-msgid "Videos must be in WebM."
-msgstr "Vídeos têm de ser em WebM."
-
-#: static/js/impala/collections.js:10 static/js/zamboni/collections.js:595
-msgid "Follow this Collection"
-msgstr "Seguir esta Coleção"
-
-#: static/js/impala/collections.js:19
-msgid "Stop Following"
-msgstr "Parar de seguir"
-
-#: static/js/impala/collections.js:20
-msgid "Following"
-msgstr "A seguir"
-
-#. L10n: {0} is an app name.
-#: static/js/impala/listing.js:11 static/js/zamboni/themes.js:13
-msgid "This theme is incompatible with your version of {0}"
-msgstr "Este tema é incompatível com a sua versão de {0}"
-
-#: static/js/impala/persona_creation.js:60
-msgid "All Rights Reserved"
-msgstr "Todos os direitos reservados"
-
-#: static/js/impala/persona_creation.js:64
-msgid "Creative Commons Attribution 3.0"
-msgstr "Creative Commons Atribuição 3.0"
-
-#: static/js/impala/persona_creation.js:69
-msgid "Creative Commons Attribution-NonCommercial 3.0"
-msgstr "Creative Commons Atribuição-NãoComercial 3.0"
-
-#: static/js/impala/persona_creation.js:74
-msgid "Creative Commons Attribution-NonCommercial-NoDerivs 3.0"
-msgstr "Creative Commons Atribuição-NãoComercial-SemDerivações 3.0"
-
-#: static/js/impala/persona_creation.js:79
-msgid "Creative Commons Attribution-NonCommercial-Share Alike 3.0"
-msgstr "Creative Commons Atribuição-NãoComercial-CompartilhaIgual 3.0"
-
-#: static/js/impala/persona_creation.js:84
-msgid "Creative Commons Attribution-NoDerivs 3.0"
-msgstr "Creative Commons Atribuição-SemDerivações 3.0"
-
-#: static/js/impala/persona_creation.js:89
-msgid "Creative Commons Attribution-ShareAlike 3.0"
-msgstr "Creative Commons Atribuição-CompartilhaIgual 3.0"
-
-#: static/js/impala/persona_creation.js:292
-msgid "Your Theme's Name"
-msgstr "O nome do seu tema"
-
-#: static/js/impala/reviews.js:23 static/js/zamboni/reviews.js:18
-msgid "Flagged for review"
-msgstr "Etiquetado para revisão"
-
-#: static/js/impala/reviews.js:40 static/js/zamboni/reviews.js:34
-msgid "Your input is required"
-msgstr "A sua opinião é necessária"
-
-#: static/js/impala/reviews.js:152 static/js/zamboni/reviews.js:103
-msgid "Marked for deletion"
-msgstr "Marcado para ser eliminado"
-
-#: static/js/impala/search.js:114
-msgid "Updating results&hellip;"
-msgstr "A atualizar resultados&hellip;"
-
-#: static/js/impala/site_suggestions.js:46
-msgid "Category"
-msgstr "Categoria"
-
-#: static/js/impala/suggestions.js:39
-msgid "Search themes for <b>{0}</b>"
-msgstr "Procurar temas por <b>{0}</b>"
-
-#: static/js/impala/suggestions.js:41
-msgid "Search apps for <b>{0}</b>"
-msgstr "Procurar aplicações por <b>{0}</b>"
-
-#: static/js/impala/suggestions.js:43
-msgid "Search add-ons for <b>{0}</b>"
-msgstr "Procurar extras por <b>{0}</b>"
-
-#: static/js/impala/users.js:33
-msgid "use original"
-msgstr "utilizar original"
-
-#: static/js/impala/stats/chart.js:267
-msgid "Week of {0}"
-msgstr "Semana de {0}"
-
-#: static/js/impala/stats/chart.js:269
-msgid " downloads"
-msgstr " descargas"
-
-#: static/js/impala/stats/chart.js:270
-msgid "{0} users"
-msgstr "{0} utilizadores"
-
-#: static/js/impala/stats/chart.js:271
-msgid "{0} add-ons"
-msgstr "{0} extras"
-
-#: static/js/impala/stats/chart.js:272
-msgid "{0} collections"
-msgstr "{0} coleções"
-
-#: static/js/impala/stats/chart.js:273
-msgid "{0} reviews"
-msgstr "{0} análises"
-
-#: static/js/impala/stats/chart.js:275
-msgid "{0} sales"
-msgstr "{0} vendas"
-
-#: static/js/impala/stats/chart.js:276
-msgid "{0} refunds"
-msgstr "{0} devoluções"
-
-#: static/js/impala/stats/chart.js:277
-msgid "{0} installs"
-msgstr "{0} instalações"
-
-#: static/js/impala/stats/chart.js:369 static/js/impala/stats/csv_keys.js:3 static/js/impala/stats/csv_keys.js:109
-msgid "Downloads"
-msgstr "Transferências"
-
-#: static/js/impala/stats/chart.js:379 static/js/impala/stats/csv_keys.js:6 static/js/impala/stats/csv_keys.js:110
-msgid "Daily Users"
-msgstr "Utilizadores diários"
-
-#: static/js/impala/stats/chart.js:410
-msgid "Amount, in USD"
-msgstr "Valor, em USD"
-
-#: static/js/impala/stats/chart.js:421 static/js/impala/stats/csv_keys.js:104
-msgid "Number of Contributions"
-msgstr "Número de contribuições"
-
-#: static/js/impala/stats/chart.js:447
-msgid "More Info..."
-msgstr "Mais informação..."
-
-#. L10n: {0} is an ISO-formatted date.
-#: static/js/impala/stats/chart.js:451
-msgid "Details for {0}"
-msgstr "Detalhes para {0}"
-
-#: static/js/impala/stats/csv_keys.js:9
-msgid "Collections Created"
-msgstr "Coleções criadas"
-
-#: static/js/impala/stats/csv_keys.js:12
-msgid "Add-ons in Use"
-msgstr "Extras em uso"
-
-#: static/js/impala/stats/csv_keys.js:15
-msgid "Add-ons Created"
-msgstr "Extras criados"
-
-#: static/js/impala/stats/csv_keys.js:18
-msgid "Add-ons Downloaded"
-msgstr "Extras transferidos"
-
-#: static/js/impala/stats/csv_keys.js:21
-msgid "Add-ons Updated"
-msgstr "Extras atualizados"
-
-#: static/js/impala/stats/csv_keys.js:24
-msgid "Reviews Written"
-msgstr "Análises escritas"
-
-#: static/js/impala/stats/csv_keys.js:27
-msgid "User Signups"
-msgstr "Registos de utilizador"
-
-#: static/js/impala/stats/csv_keys.js:30
-msgid "Subscribers"
-msgstr "Subscritores"
-
-#: static/js/impala/stats/csv_keys.js:33
-msgid "Ratings"
-msgstr "Classificações"
-
-#: static/js/impala/stats/csv_keys.js:36 static/js/impala/stats/csv_keys.js:114
-msgid "Sales"
-msgstr "Vendas"
-
-#: static/js/impala/stats/csv_keys.js:39 static/js/impala/stats/csv_keys.js:113
-msgid "Installs"
-msgstr "Instalações"
-
-#: static/js/impala/stats/csv_keys.js:42
-msgid "Unknown"
-msgstr "Desconhecido"
-
-#: static/js/impala/stats/csv_keys.js:43
-msgid "Add-ons Manager"
-msgstr "Gestor de extras"
-
-#: static/js/impala/stats/csv_keys.js:44
-msgid "Add-ons Manager Promo"
-msgstr "Gestor de Promoção de Extras"
-
-#: static/js/impala/stats/csv_keys.js:45
-msgid "Add-ons Manager Featured"
-msgstr "Gestor de Destaques de Extras"
-
-#: static/js/impala/stats/csv_keys.js:46
-msgid "Add-ons Manager Learn More"
-msgstr "Gestor de Saber Mais sobre Extras"
-
-#: static/js/impala/stats/csv_keys.js:47
-msgid "Search Suggestions"
-msgstr "Sugestões de pesquisa"
-
-#: static/js/impala/stats/csv_keys.js:48
-msgid "Search Results"
-msgstr "Resultados da pesquisa"
-
-#: static/js/impala/stats/csv_keys.js:49 static/js/impala/stats/csv_keys.js:50 static/js/impala/stats/csv_keys.js:51
-msgid "Homepage Promo"
-msgstr "Página inicial de promoção"
-
-#: static/js/impala/stats/csv_keys.js:52 static/js/impala/stats/csv_keys.js:53
-msgid "Homepage Featured"
-msgstr "Página inicial de destaque"
-
-#: static/js/impala/stats/csv_keys.js:54 static/js/impala/stats/csv_keys.js:55
-msgid "Homepage Up and Coming"
-msgstr "Página inicial de novo e a chegar"
-
-#: static/js/impala/stats/csv_keys.js:56
-msgid "Homepage Most Popular"
-msgstr "Página inicial mais populares"
-
-#: static/js/impala/stats/csv_keys.js:57 static/js/impala/stats/csv_keys.js:59
-msgid "Detail Page"
-msgstr "Página de detalhe"
-
-#: static/js/impala/stats/csv_keys.js:58 static/js/impala/stats/csv_keys.js:60
-msgid "Detail Page (bottom)"
-msgstr "Página de detalhe (inferior)"
-
-#: static/js/impala/stats/csv_keys.js:61
-msgid "Detail Page (Development Channel)"
-msgstr "Página de detalhe (canal de desenvolvimento)"
-
-#: static/js/impala/stats/csv_keys.js:62 static/js/impala/stats/csv_keys.js:63 static/js/impala/stats/csv_keys.js:64
-msgid "Often Used With"
-msgstr "Muito utilizado com"
-
-#: static/js/impala/stats/csv_keys.js:65 static/js/impala/stats/csv_keys.js:66
-msgid "Others By Author"
-msgstr "Outros do autor"
-
-#: static/js/impala/stats/csv_keys.js:67 static/js/impala/stats/csv_keys.js:68
-msgid "Dependencies"
-msgstr "Dependências"
-
-#: static/js/impala/stats/csv_keys.js:69 static/js/impala/stats/csv_keys.js:70
-msgid "Upsell"
-msgstr "Upsell"
-
-#: static/js/impala/stats/csv_keys.js:71
-msgid "Meet the Developer"
-msgstr "Conheça o programador"
-
-#: static/js/impala/stats/csv_keys.js:72
-msgid "User Profile"
-msgstr "Perfil do utilizador"
-
-#: static/js/impala/stats/csv_keys.js:73
-msgid "Version History"
-msgstr "Histórico da versão"
-
-#: static/js/impala/stats/csv_keys.js:75
-msgid "Sharing"
-msgstr "Partilha"
-
-#: static/js/impala/stats/csv_keys.js:76
-msgid "Category Pages"
-msgstr "Páginas de categoria"
-
-#: static/js/impala/stats/csv_keys.js:77
-msgid "Collections"
-msgstr "Coleções"
-
-#: static/js/impala/stats/csv_keys.js:78 static/js/impala/stats/csv_keys.js:79
-msgid "Category Landing Featured Carousel"
-msgstr "Página inicial de categoria de carrossel de destaque"
-
-#: static/js/impala/stats/csv_keys.js:80 static/js/impala/stats/csv_keys.js:81
-msgid "Category Landing Top Rated"
-msgstr "Página inicial de categoria de melhor classificada"
-
-#: static/js/impala/stats/csv_keys.js:82 static/js/impala/stats/csv_keys.js:83
-msgid "Category Landing Most Popular"
-msgstr "Página inicial de categoria de mais popular"
-
-#: static/js/impala/stats/csv_keys.js:84 static/js/impala/stats/csv_keys.js:85
-msgid "Category Landing Recently Added"
-msgstr "Página inicial de categoria de adicionado recentemente"
-
-#: static/js/impala/stats/csv_keys.js:86 static/js/impala/stats/csv_keys.js:87
-msgid "Browse Listing Featured Sort"
-msgstr "Navegar na lista ordenada por destaque"
-
-#: static/js/impala/stats/csv_keys.js:88 static/js/impala/stats/csv_keys.js:89
-msgid "Browse Listing Users Sort"
-msgstr "Navegar na lista ordenada por utilizadores"
-
-#: static/js/impala/stats/csv_keys.js:90 static/js/impala/stats/csv_keys.js:91
-msgid "Browse Listing Rating Sort"
-msgstr "Navegar na lista ordenada por classificação"
-
-#: static/js/impala/stats/csv_keys.js:92 static/js/impala/stats/csv_keys.js:93
-msgid "Browse Listing Created Sort"
-msgstr "Navegar na lista ordenada por criação"
-
-#: static/js/impala/stats/csv_keys.js:94 static/js/impala/stats/csv_keys.js:95
-msgid "Browse Listing Name Sort"
-msgstr "Navegar na lista ordenada por nome"
-
-#: static/js/impala/stats/csv_keys.js:96 static/js/impala/stats/csv_keys.js:97
-msgid "Browse Listing Popular Sort"
-msgstr "Navegar na lista ordenada por popularidade"
-
-#: static/js/impala/stats/csv_keys.js:98 static/js/impala/stats/csv_keys.js:99
-msgid "Browse Listing Updated Sort"
-msgstr "Navegar na lista ordenada por atualização"
-
-#: static/js/impala/stats/csv_keys.js:100 static/js/impala/stats/csv_keys.js:101
-msgid "Browse Listing Up and Coming Sort"
-msgstr "Navegar na lista ordenada por novas e a chegar"
-
-#: static/js/impala/stats/csv_keys.js:105
-msgid "Total Amount Contributed"
-msgstr "Valor total contribuído"
-
-#: static/js/impala/stats/csv_keys.js:106
-msgid "Average Contribution"
-msgstr "Contribuição média"
-
-#: static/js/impala/stats/csv_keys.js:115
-msgid "Usage"
-msgstr "Utilização"
-
-#: static/js/impala/stats/csv_keys.js:118
-msgid "Firefox"
-msgstr "Firefox"
-
-#: static/js/impala/stats/csv_keys.js:119
-msgid "Mozilla"
-msgstr "Mozilla"
-
-#: static/js/impala/stats/csv_keys.js:120
-msgid "Thunderbird"
-msgstr "Thunderbird"
-
-#: static/js/impala/stats/csv_keys.js:121
-msgid "Sunbird"
-msgstr "Sunbird"
-
-#: static/js/impala/stats/csv_keys.js:122
-msgid "SeaMonkey"
-msgstr "SeaMonkey"
-
-#: static/js/impala/stats/csv_keys.js:123
-msgid "Fennec"
-msgstr "Fennec"
-
-#: static/js/impala/stats/csv_keys.js:124
-msgid "Android"
-msgstr "Android"
-
-#. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:129
-msgid "Downloads and Daily Users, last {0} days"
-msgstr "Transferências e utilizadores diários, últimos {0} dias"
-
-#. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:131
-msgid "Downloads and Daily Users from {0} to {1}"
-msgstr "Transferências e utilizadores diários de {0} a {1}"
-
-#. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:135
-msgid "Installs and Daily Users, last {0} days"
-msgstr "Instalações e utilizadores diários, últimos {0} dias"
-
-#. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:137
-msgid "Installs and Daily Users from {0} to {1}"
-msgstr "Instalações e utilizadores diários de {0} a {1}"
-
-#. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:141
-msgid "Downloads, last {0} days"
-msgstr "Transferências, últimos {0} dias"
-
-#. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:143
-msgid "Downloads from {0} to {1}"
-msgstr "Transferências de {0} a {1}"
-
-#. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:147
-msgid "Daily Users, last {0} days"
-msgstr "Utilizadores diários, últimos {0} dias"
-
-#. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:149
-msgid "Daily Users from {0} to {1}"
-msgstr "Utilizadores diários de {0} a {1}"
-
-#. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:153
-msgid "Applications, last {0} days"
-msgstr "Aplicações, últimos {0} dias"
-
-#. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:155
-msgid "Applications from {0} to {1}"
-msgstr "Aplicações de {0} a {1}"
-
-#. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:159
-msgid "Platforms, last {0} days"
-msgstr "Plataformas, últimos {0} dias"
-
-#. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:161
-msgid "Platforms from {0} to {1}"
-msgstr "Plataformas de {0} a {1}"
-
-#. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:165
-msgid "Languages, last {0} days"
-msgstr "Idiomas, últimos {0} dias"
-
-#. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:167
-msgid "Languages from {0} to {1}"
-msgstr "Idiomas de {0} a {1}"
-
-#. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:171
-msgid "Add-on Versions, last {0} days"
-msgstr "Versões de extra, últimos {0} dias"
-
-#. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:173
-msgid "Add-on Versions from {0} to {1}"
-msgstr "Versões de extra de {0} a {1}"
-
-#. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:177
-msgid "Add-on Status, last {0} days"
-msgstr "Versões de extra, últimos {0} dias"
-
-#. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:179
-msgid "Add-on Status from {0} to {1}"
-msgstr "Estado de extra de {0} a {1}"
-
-#. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:183
-msgid "Download Sources, last {0} days"
-msgstr "Transferências de fontes, últimos {0} dias"
-
-#. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:185
-msgid "Download Sources from {0} to {1}"
-msgstr "Transferências de fontes de {0} a {1}"
-
-#. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:189
-msgid "Contributions, last {0} days"
-msgstr "Contribuições, últimos {0} dias"
-
-#. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:191
-msgid "Contributions from {0} to {1}"
-msgstr "Contribuições de {0} a {1}"
-
-#. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:195
-msgid "Site Metrics, last {0} days"
-msgstr "Métricas do site, últimos {0} dias"
-
-#. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:197
-msgid "Site Metrics from {0} to {1}"
-msgstr "Métricas do site de {0} a {1}"
-
-#. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:201
-msgid "Add-ons in Use, last {0} days"
-msgstr "Extras em utilização, últimos {0} dias"
-
-#. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:203
-msgid "Add-ons in Use from {0} to {1}"
-msgstr "Extras em utilização de {0} a {1}"
-
-#. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:207
-msgid "Add-ons Downloaded, last {0} days"
-msgstr "Extras transferidos, últimos {0} dias"
-
-#. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:209
-msgid "Add-ons Downloaded from {0} to {1}"
-msgstr "Extras transferidos de {0} a {1}"
-
-#. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:213
-msgid "Add-ons Created, last {0} days"
-msgstr "Extras criados, últimos {0} dias"
-
-#. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:215
-msgid "Add-ons Created from {0} to {1}"
-msgstr "Extras criados de {0} a {1}"
-
-#. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:219
-msgid "Add-ons Updated, last {0} days"
-msgstr "Extras atualizados, últimos {0} dias"
-
-#. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:221
-msgid "Add-ons Updated from {0} to {1}"
-msgstr "Extras atualizados de {0} a {1}"
-
-#. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:225
-msgid "Reviews Written, last {0} days"
-msgstr "Análises feitas, últimos {0} dias"
-
-#. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:227
-msgid "Reviews Written from {0} to {1}"
-msgstr "Análises feitas de {0} a {1}"
-
-#. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:231
-msgid "User Signups, last {0} days"
-msgstr "Registo de utilizadores, últimos {0} dias"
-
-#. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:233
-msgid "User Signups from {0} to {1}"
-msgstr "Registo de utilizadores de {0} a {1}"
-
-#. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:237
-msgid "Collections Created, last {0} days"
-msgstr "Coleções criadas, últimos {0} dias"
-
-#. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:239
-msgid "Collections Created from {0} to {1}"
-msgstr "Coleções criadas de {0} a {1}"
-
-#. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:243
-msgid "Subscribers, last {0} days"
-msgstr "Subscritores, últimos {0} dias"
-
-#. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:245
-msgid "Subscribers from {0} to {1}"
-msgstr "Subscritores de {0} a {1}"
-
-#. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:249
-msgid "Ratings, last {0} days"
-msgstr "Classificações, últimos {0} dias"
-
-#. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:251
-msgid "Ratings from {0} to {1}"
-msgstr "Classificações de {0} a {1}"
-
-#. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:255
-msgid "Sales, last {0} days"
-msgstr "Vendas, últimos {0} dias"
-
-#. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:257
-msgid "Sales from {0} to {1}"
-msgstr "Vendas de {0} a {1}"
-
-#. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:261
-msgid "Installs, last {0} days"
-msgstr "Instalações, últimos {0} dias"
-
-#. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:263
-msgid "Installs from {0} to {1}"
-msgstr "Instalações de {0} a {1}"
-
-#. L10n: {0} and {1} are integers.
-#: static/js/impala/stats/csv_keys.js:269
-msgid "<b>{0}</b> in last {1} days"
-msgstr "<b>{0}</b> nos últimos {1} dias"
-
-#. L10n: {0} is an integer and {1} and {2} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:271 static/js/impala/stats/csv_keys.js:277
-msgid "<b>{0}</b> from {1} to {2}"
-msgstr "<b>{0}</b> de {1} a {2}"
-
-#. L10n: {0} and {1} are integers.
-#: static/js/impala/stats/csv_keys.js:275
-msgid "<b>{0}</b> average in last {1} days"
-msgstr "<b>{0}</b> em média nos últimos {1} dias"
-
-#: static/js/impala/stats/overview.js:19
-msgid "No data available."
-msgstr "Sem dados disponíveis."
-
-#: static/js/impala/stats/table.js:74
-msgid "Date"
-msgstr "Data"
-
-#: static/js/impala/stats/topchart.js:96
-msgid "Other"
-msgstr "Outro"
-
-#: static/js/zamboni/admin_validation.js:24 static/js/zamboni/devhub.js:1229 static/js/zamboni/editors.js:295
-msgid "Select an application first"
-msgstr "Selecione primeiro uma aplicação"
-
-#: static/js/zamboni/admin_validation.js:51
-msgid "Set {0} add-on to a max version of {1} and email the author."
-msgid_plural "Set {0} add-ons to a max version of {1} and email the authors."
-msgstr[0] "Defina {0} extra para uma versão máxima de {1} e envie um email para o autor."
-msgstr[1] "Defina {0} extras para uma versão máxima de {1} e envie um email aos autores."
-
-#: static/js/zamboni/admin_validation.js:54
-msgid "Email author of {2} add-on which failed validation."
-msgid_plural "Email authors of {2} add-ons which failed validation."
-msgstr[0] "Envie um email ao autor de {2} extra que falhou a validação."
-msgstr[1] "Envie um email aos autores de {2} extras que falharam a validação."
+#: static/js/common-all.js:1426 static/js/impala-all.js:1511 static/js/zamboni/discovery-all.js:12598 static/js/zamboni/init.js:28 static/js/zamboni/mobile-all.js:14945
+msgid "This feature is temporarily disabled while we perform website maintenance. Please check back a little later."
+msgstr "Está funcionalidade está temporariamente desativada enquanto realizamos a manutenção do site. Por favor tente novamente mais tarde."
 
 #. L10n: {0} is an app name like Firefox.
-#: static/js/zamboni/buttons.js:66
+#: static/js/common-all.js:1837 static/js/impala-all.js:1922 static/js/zamboni/buttons.js:73 static/js/zamboni/discovery-all.js:13108
 msgid "Accept and Install"
 msgstr "Aceitar e Instalar"
 
-#: static/js/zamboni/buttons.js:66
+#: static/js/common-all.js:1837 static/js/impala-all.js:1922 static/js/zamboni/buttons.js:73 static/js/zamboni/discovery-all.js:13108
 msgid "Add to {0}"
 msgstr "Adicionar a {0}"
 
-#: static/js/zamboni/buttons.js:71
+#: static/js/common-all.js:1842 static/js/impala-all.js:1927 static/js/zamboni/buttons.js:78 static/js/zamboni/discovery-all.js:13113
 msgid "Download Now"
 msgstr "Descarregar agora"
 
-#: static/js/zamboni/buttons.js:112
+#: static/js/common-all.js:1883 static/js/impala-all.js:1968 static/js/zamboni/buttons.js:119 static/js/zamboni/discovery-all.js:13154
 msgid "Add-on has not been updated to support default-to-compatible."
 msgstr "O extra não foi atualizado para suportar default-to-compatible."
 
-#: static/js/zamboni/buttons.js:117
+#: static/js/common-all.js:1888 static/js/impala-all.js:1973 static/js/zamboni/buttons.js:124 static/js/zamboni/discovery-all.js:13159
 msgid "You need to be using Firefox 10.0 or higher."
 msgstr "Precisa de estar a utilizar o Firefox 10.0 ou mais recente."
 
-#: static/js/zamboni/buttons.js:129
+#: static/js/common-all.js:1900 static/js/impala-all.js:1985 static/js/zamboni/buttons.js:136 static/js/zamboni/discovery-all.js:13171
 msgid "Mozilla has marked this version as incompatible with your Firefox version."
 msgstr "A Mozilla marcou esta versão como incompatível com a sua versão do Firefox."
 
 #. L10n: {0} is an platform like Windows or Linux.
-#: static/js/zamboni/buttons.js:210
+#: static/js/common-all.js:1981 static/js/impala-all.js:2066 static/js/zamboni/buttons.js:217 static/js/zamboni/discovery-all.js:13252
 msgid "Install for {0} anyway"
 msgstr "Instalar para {0} mesmo assim"
 
-#: static/js/zamboni/buttons.js:210
+#: static/js/common-all.js:1981 static/js/impala-all.js:2066 static/js/zamboni/buttons.js:217 static/js/zamboni/discovery-all.js:13252
 msgid "Download for {0} anyway"
 msgstr "Descarregar para {0} mesmo assim"
 
-#: static/js/zamboni/buttons.js:267
+#: static/js/common-all.js:2038 static/js/impala-all.js:2123 static/js/zamboni/buttons.js:274 static/js/zamboni/discovery-all.js:13309
 msgid "Not available for your platform"
 msgstr "Não disponível para a sua plataforma"
 
 #. L10n: {0} is an app name, {1} is the app version.
-#: static/js/zamboni/buttons.js:278 static/js/zamboni/buttons.js:315
+#: static/js/common-all.js:2049 static/js/common-all.js:2086 static/js/impala-all.js:2134 static/js/impala-all.js:2171 static/js/zamboni/buttons.js:286 static/js/zamboni/buttons.js:324
+#: static/js/zamboni/discovery-all.js:13320 static/js/zamboni/discovery-all.js:13357
 msgid "Not available for {0} {1}"
 msgstr "Não disponível para {0} {1}"
 
-#: static/js/zamboni/buttons.js:341
+#: static/js/common-all.js:2112 static/js/impala-all.js:2197 static/js/zamboni/buttons.js:351 static/js/zamboni/discovery-all.js:13383
 msgid "Works with {app} {min} - {max}"
 msgstr "Funciona com {app} {min} - {max}"
 
-#: static/js/zamboni/buttons.js:343
+#: static/js/common-all.js:2114 static/js/impala-all.js:2199 static/js/zamboni/buttons.js:353 static/js/zamboni/discovery-all.js:13385
 msgid "View other versions"
 msgstr "Ver outras versões"
 
-#: static/js/zamboni/buttons.js:391
+#: static/js/common-all.js:2162 static/js/impala-all.js:2247 static/js/zamboni/buttons.js:401 static/js/zamboni/discovery-all.js:13433
 msgid "Only with Firefox — Get Firefox Now!"
 msgstr "Apenas com o Firefox — Obter o Firefox agora!"
 
-#: static/js/zamboni/buttons.js:507 static/js/zamboni/mobile/buttons.js:43
+#: static/js/common-all.js:2278 static/js/impala-all.js:2363 static/js/zamboni/buttons.js:517 static/js/zamboni/discovery-all.js:13549 static/js/zamboni/mobile-all.js:15177
+#: static/js/zamboni/mobile/buttons.js:43
 msgid "Sorry, you need a Mozilla-based browser (such as Firefox) to install a search plugin."
 msgstr "Lamentamos, mas precisa de ter um navegador da Mozilla (como o Firefox) para instalar uma extensão de pesquisa."
 
-#: static/js/zamboni/collections.js:229
-msgid "Adding to Favorites&hellip;"
-msgstr "A adicionar aos Favoritos&hellip;"
-
-#: static/js/zamboni/collections.js:232
-msgid "Removing Favorite&hellip;"
-msgstr "A remover dos Favoritos&hellip;"
-
-#: static/js/zamboni/collections.js:235
-msgid "Add to Favorites"
-msgstr "Adicionar aos Favoritos"
-
-#: static/js/zamboni/collections.js:238
-msgid "Remove from Favorites"
-msgstr "Remover dos Favoritos"
-
-#: static/js/zamboni/collections.js:303
-msgid "Pending"
-msgstr "Em espera"
-
-#: static/js/zamboni/collections.js:304
-msgid "Add a comment"
-msgstr "Adicionar um comentário"
-
-#: static/js/zamboni/collections.js:304
-msgid "Comment"
-msgstr "Comentário"
-
-#: static/js/zamboni/collections.js:305
-msgid "Remove this add-on from the collection"
-msgstr "Remover este extra desta coleção"
-
-#: static/js/zamboni/collections.js:305 static/js/zamboni/collections.js:334
-msgid "Remove"
-msgstr "Remover"
-
-#: static/js/zamboni/collections.js:334
-msgid "Remove this user as a contributor"
-msgstr "Remover este utilizador dos colaboradores"
-
-#: static/js/zamboni/collections.js:346
-msgid "An email address is required."
-msgstr "É necessário um endereço de email."
-
-#: static/js/zamboni/collections.js:364
-msgid "You cannot add yourself as a contributor."
-msgstr "Não pode adicionar-se a si próprio como colaborador."
-
-#: static/js/zamboni/collections.js:366
-msgid "You have already added that user."
-msgstr "Já adicionou esse utilizador."
-
-#: static/js/zamboni/collections.js:573
-msgid "Add to favorites"
-msgstr "Adicionar aos favoritos"
-
-#: static/js/zamboni/collections.js:577
-msgid "Remove from favorites"
-msgstr "Remover dos favoritos"
-
-#: static/js/zamboni/collections.js:604
-msgid "Stop following"
-msgstr "Parar de seguir"
-
-#: static/js/zamboni/devhub.js:110
-msgid "Your browser does not support the video tag"
-msgstr "O seu navegador não suporta a tag video"
-
-#: static/js/zamboni/devhub.js:371
-msgid "Changes Saved"
-msgstr "Alterações guardadas"
-
-#: static/js/zamboni/devhub.js:387
-msgid "Enter a new author's email address"
-msgstr "Introduza um novo endereço de email do autor"
-
-#: static/js/zamboni/devhub.js:536
-msgid "There was an error uploading your file."
-msgstr "Ocorreu um erro ao enviar o seu ficheiro."
-
-#: static/js/zamboni/devhub.js:681
-msgid "{files} file"
-msgid_plural "{files} files"
-msgstr[0] "{files} ficheiro"
-msgstr[1] "{files} ficheiros"
-
-#: static/js/zamboni/devhub.js:684
-msgid "{reviews} user review"
-msgid_plural "{reviews} user reviews"
-msgstr[0] "{reviews} análise de utilizador"
-msgstr[1] "{reviews} análises de utilizadores"
-
-#: static/js/zamboni/devhub.js:796
-msgid "Learn more"
-msgstr "Saber mais"
-
-#: static/js/zamboni/devhub.js:800
-msgid "Example"
-msgstr "Exemplo"
-
-#: static/js/zamboni/devhub.js:1130
-msgid "Image changes being processed"
-msgstr "As alterações à imagem estão a ser processadas"
-
-#: static/js/zamboni/devhub.js:1280
-msgid "Must be a valid e-mail address."
-msgstr "Tem de ser um endereço de email válido."
-
-#: static/js/zamboni/devhub_search.js:8
-msgid "No results found."
-msgstr "Não foram encontrados resultados."
-
-#: static/js/zamboni/editors.js:121
-msgid "{name} was viewing this page first."
-msgstr "{name} estava a ver esta página primeiro."
-
-#: static/js/zamboni/editors.js:171
-msgid "Receipt checked by app."
-msgstr "Recibo confirmado pela aplicação."
-
-#: static/js/zamboni/editors.js:173
-msgid "Receipt was not checked by app."
-msgstr "O recibo não foi confirmado pela aplicação."
-
-#: static/js/zamboni/editors.js:244
-msgid "{name} was viewing this add-on first."
-msgstr "{name} estava a ver este extra primeiro."
-
-#: static/js/zamboni/editors.js:255
-msgid "Loading&hellip;"
-msgstr "A carregar&hellip;"
-
-#: static/js/zamboni/editors.js:260
-msgid "Version Notes"
-msgstr "Notas da versão"
-
-#: static/js/zamboni/editors.js:265
-msgid "Notes for Reviewers"
-msgstr "Notas para os Revisores"
-
-#: static/js/zamboni/editors.js:270
-msgid "No version notes found"
-msgstr "Não foram encontradas notas para a versão"
-
-#: static/js/zamboni/editors.js:330
-msgid "Average Reviews"
-msgstr ""
-
-#: static/js/zamboni/editors.js:386
-msgid "Number of Reviews"
-msgstr ""
-
-#: static/js/zamboni/editors.js:445
-msgid "Error loading translation"
-msgstr "Erro ao carregar a tradução"
-
-#: static/js/zamboni/files.js:411 static/js/zamboni/validator.js:261
-msgid "Ignore this message in future updates"
-msgstr "Ignorar esta mensagem em futuras atualizações"
-
-#: static/js/zamboni/files.js:417 static/js/zamboni/validator.js:284
-msgid "Severity for automated signing:"
-msgstr "Severidade para assinatura automática:"
-
-#: static/js/zamboni/global.js:410
+#: static/js/common-all.js:9088 static/js/impala-all.js:9649 static/js/zamboni/global.js:410
 msgid "Loading..."
 msgstr "A carregar..."
 
 #. L10n: {0} is the number of characters left.
-#: static/js/zamboni/global.js:474
+#: static/js/common-all.js:9152 static/js/impala-all.js:9713 static/js/zamboni/global.js:474
 msgid "<b>{0}</b> character left."
 msgid_plural "<b>{0}</b> characters left."
 msgstr[0] "<b>{0}</b> caratere remanescente."
 msgstr[1] "<b>{0}</b> carateres remanescentes."
 
-#: static/js/zamboni/init.js:28
-msgid "This feature is temporarily disabled while we perform website maintenance. Please check back a little later."
-msgstr "Está funcionalidade está temporariamente desativada enquanto realizamos a manutenção do site. Por favor tente novamente mais tarde."
+#: static/js/common-all.js:9589 static/js/common-min.js:6 static/js/impala-all.js:10052 static/js/impala-min.js:6 static/js/common/ratingwidget.js:31 static/js/zamboni/mobile-all.js:16123
+#: static/js/zamboni/mobile-min.js:6
+msgid "{0} star"
+msgid_plural "{0} stars"
+msgstr[0] "{0} estrela"
+msgstr[1] "{0} estrelas"
 
-#: static/js/zamboni/l10n.js:45
+#: static/js/common-all.js:9676 static/js/common-min.js:6 static/js/impala-all.js:10139 static/js/impala-min.js:6 static/js/zamboni/l10n.js:45
 msgid "Remove this localization"
 msgstr "Remover esta tradução"
 
-#: static/js/zamboni/password-strength.js:20
+#: static/js/common-all.js:10193 static/js/common-min.js:6 static/js/impala-all.js:10674 static/js/impala-min.js:6 static/js/zamboni/discovery-all.js:13678
+msgid "close"
+msgstr ""
+
+#: static/js/common-all.js:10860 static/js/common-min.js:6 static/js/impala-all.js:11481 static/js/impala-min.js:6 static/js/impala/reviews.js:23 static/js/zamboni/reviews.js:18
+msgid "Flagged for review"
+msgstr "Etiquetado para revisão"
+
+#: static/js/common-all.js:10876 static/js/common-min.js:6 static/js/impala-all.js:11498 static/js/impala-min.js:6 static/js/impala/reviews.js:40 static/js/zamboni/reviews.js:34
+msgid "Your input is required"
+msgstr "A sua opinião é necessária"
+
+#: static/js/common-all.js:10945 static/js/common-min.js:6 static/js/impala-all.js:11610 static/js/impala-min.js:7 static/js/impala/reviews.js:152 static/js/zamboni/reviews.js:103
+msgid "Marked for deletion"
+msgstr "Marcado para ser eliminado"
+
+#: static/js/common-all.js:11573 static/js/common-min.js:7 static/js/impala-all.js:13809 static/js/impala-min.js:8 static/js/zamboni/collections.js:229
+msgid "Adding to Favorites&hellip;"
+msgstr "A adicionar aos Favoritos&hellip;"
+
+#: static/js/common-all.js:11576 static/js/common-min.js:7 static/js/impala-all.js:13812 static/js/impala-min.js:8 static/js/zamboni/collections.js:232
+msgid "Removing Favorite&hellip;"
+msgstr "A remover dos Favoritos&hellip;"
+
+#: static/js/common-all.js:11579 static/js/common-min.js:7 static/js/impala-all.js:13815 static/js/impala-min.js:8 static/js/zamboni/collections.js:235
+msgid "Add to Favorites"
+msgstr "Adicionar aos Favoritos"
+
+#: static/js/common-all.js:11582 static/js/common-min.js:7 static/js/impala-all.js:13818 static/js/impala-min.js:8 static/js/zamboni/collections.js:238
+msgid "Remove from Favorites"
+msgstr "Remover dos Favoritos"
+
+#: static/js/common-all.js:11647 static/js/common-min.js:7 static/js/impala-all.js:13883 static/js/impala-min.js:8 static/js/zamboni/collections.js:303
+msgid "Pending"
+msgstr "Em espera"
+
+#: static/js/common-all.js:11648 static/js/common-min.js:7 static/js/impala-all.js:13884 static/js/impala-min.js:8 static/js/zamboni/collections.js:304
+msgid "Add a comment"
+msgstr "Adicionar um comentário"
+
+#: static/js/common-all.js:11648 static/js/common-min.js:7 static/js/impala-all.js:13884 static/js/impala-min.js:8 static/js/zamboni/collections.js:304
+msgid "Comment"
+msgstr "Comentário"
+
+#: static/js/common-all.js:11649 static/js/common-min.js:7 static/js/impala-all.js:13885 static/js/impala-min.js:8 static/js/zamboni/collections.js:305
+msgid "Remove this add-on from the collection"
+msgstr "Remover este extra desta coleção"
+
+#: static/js/common-all.js:11649 static/js/common-all.js:11678 static/js/common-min.js:7 static/js/impala-all.js:13885 static/js/impala-all.js:13914 static/js/impala-min.js:8
+#: static/js/zamboni/collections.js:305 static/js/zamboni/collections.js:334
+msgid "Remove"
+msgstr "Remover"
+
+#: static/js/common-all.js:11678 static/js/common-min.js:7 static/js/impala-all.js:13914 static/js/impala-min.js:8 static/js/zamboni/collections.js:334
+msgid "Remove this user as a contributor"
+msgstr "Remover este utilizador dos colaboradores"
+
+#: static/js/common-all.js:11690 static/js/common-min.js:7 static/js/impala-all.js:13926 static/js/impala-min.js:8 static/js/zamboni/collections.js:346
+msgid "An email address is required."
+msgstr "É necessário um endereço de email."
+
+#: static/js/common-all.js:11708 static/js/common-min.js:7 static/js/impala-all.js:13944 static/js/impala-min.js:8 static/js/zamboni/collections.js:364
+msgid "You cannot add yourself as a contributor."
+msgstr "Não pode adicionar-se a si próprio como colaborador."
+
+#: static/js/common-all.js:11710 static/js/common-min.js:7 static/js/impala-all.js:13946 static/js/impala-min.js:8 static/js/zamboni/collections.js:366
+msgid "You have already added that user."
+msgstr "Já adicionou esse utilizador."
+
+#: static/js/common-all.js:11917 static/js/common-min.js:7 static/js/impala-all.js:14153 static/js/impala-min.js:8 static/js/zamboni/collections.js:573
+msgid "Add to favorites"
+msgstr "Adicionar aos favoritos"
+
+#: static/js/common-all.js:11921 static/js/common-min.js:7 static/js/impala-all.js:14157 static/js/impala-min.js:8 static/js/zamboni/collections.js:577
+msgid "Remove from favorites"
+msgstr "Remover dos favoritos"
+
+#: static/js/common-all.js:11939 static/js/common-min.js:7 static/js/impala-all.js:14175 static/js/impala-all.js:14233 static/js/impala-min.js:8 static/js/impala/collections.js:10
+#: static/js/zamboni/collections.js:595
+msgid "Follow this Collection"
+msgstr "Seguir esta Coleção"
+
+#: static/js/common-all.js:11948 static/js/common-min.js:7 static/js/impala-all.js:14184 static/js/impala-min.js:8 static/js/zamboni/collections.js:604
+msgid "Stop following"
+msgstr "Parar de seguir"
+
+#: static/js/common-all.js:12096 static/js/common-min.js:7 static/js/zamboni/password-strength.js:20
 msgid "Password strength:"
 msgstr "Força da palavra-passe:"
 
-#: static/js/zamboni/password-strength.js:26
+#: static/js/common-all.js:12102 static/js/common-min.js:7 static/js/zamboni/password-strength.js:26
 msgid "At least {0} character left."
 msgid_plural "At least {0} characters left."
 msgstr[0] "Falta pelo menos {0} caratere."
 msgstr[1] "Falta pelo menos {0} carateres."
 
-#: static/js/zamboni/themes_review.js:176
-msgid "Requested Info"
-msgstr "Informação solicitada"
+#: static/js/common-all.js:12286 static/js/common-min.js:7 static/js/impala-all.js:14632 static/js/impala-min.js:8 static/js/impala/suggestions.js:39
+msgid "Search themes for <b>{0}</b>"
+msgstr "Procurar temas por <b>{0}</b>"
 
-#: static/js/zamboni/themes_review.js:177
-msgid "Flagged"
-msgstr "Marcado"
+#: static/js/common-all.js:12288 static/js/common-min.js:7 static/js/impala-all.js:14634 static/js/impala-min.js:8 static/js/impala/suggestions.js:41
+msgid "Search apps for <b>{0}</b>"
+msgstr "Procurar aplicações por <b>{0}</b>"
 
-#: static/js/zamboni/themes_review.js:178
-msgid "Duplicate"
-msgstr "Duplicado"
+#: static/js/common-all.js:12290 static/js/common-min.js:7 static/js/impala-all.js:14636 static/js/impala-min.js:8 static/js/impala/suggestions.js:43
+msgid "Search add-ons for <b>{0}</b>"
+msgstr "Procurar extras por <b>{0}</b>"
 
-#: static/js/zamboni/themes_review.js:179
-msgid "Rejected"
-msgstr "Rejeitado"
+#: static/js/common-all.js:12521 static/js/common-min.js:7 static/js/impala-all.js:14867 static/js/impala-min.js:8 static/js/impala/site_suggestions.js:46
+msgid "Category"
+msgstr "Categoria"
 
-#: static/js/zamboni/themes_review.js:180
-msgid "Approved"
-msgstr "Aprovado"
+#. L10n: {0} is an app name.
+#: static/js/impala-all.js:11632 static/js/impala-min.js:7 static/js/impala/listing.js:11 static/js/zamboni/themes.js:13
+msgid "This theme is incompatible with your version of {0}"
+msgstr "Este tema é incompatível com a sua versão de {0}"
 
-#: static/js/zamboni/themes_review.js:424
-msgid "No results found"
+#: static/js/impala-all.js:12146 static/js/impala-all.js:14331 static/js/impala-min.js:7 static/js/impala-min.js:8 static/js/common/upload-image.js:97 static/js/impala/users.js:51
+#: static/js/zamboni/devhub-all.js:894 static/js/zamboni/devhub-min.js:1
+msgid "Images must be either PNG or JPG."
+msgstr "Imagens têm de ser PNG ou JPG."
+
+#: static/js/impala-all.js:12150 static/js/impala-min.js:7 static/js/common/upload-image.js:101 static/js/zamboni/devhub-all.js:898 static/js/zamboni/devhub-min.js:1
+msgid "Videos must be in WebM."
+msgstr "Vídeos têm de ser em WebM."
+
+#: static/js/impala-all.js:12177 static/js/impala-min.js:7 static/js/common/upload-addon.js:41 static/js/common/upload-image.js:128 static/js/zamboni/devhub-all.js:272
+#: static/js/zamboni/devhub-all.js:925 static/js/zamboni/devhub-min.js:1
+msgid "There was a problem contacting the server."
+msgstr "Ocorreu um problema ao contactar o servidor."
+
+#: static/js/impala-all.js:13298 static/js/impala-min.js:7 static/js/impala/persona_creation.js:60
+msgid "All Rights Reserved"
+msgstr "Todos os direitos reservados"
+
+#: static/js/impala-all.js:13302 static/js/impala-min.js:7 static/js/impala/persona_creation.js:64
+msgid "Creative Commons Attribution 3.0"
+msgstr "Creative Commons Atribuição 3.0"
+
+#: static/js/impala-all.js:13307 static/js/impala-min.js:7 static/js/impala/persona_creation.js:69
+msgid "Creative Commons Attribution-NonCommercial 3.0"
+msgstr "Creative Commons Atribuição-NãoComercial 3.0"
+
+#: static/js/impala-all.js:13312 static/js/impala-min.js:7 static/js/impala/persona_creation.js:74
+msgid "Creative Commons Attribution-NonCommercial-NoDerivs 3.0"
+msgstr "Creative Commons Atribuição-NãoComercial-SemDerivações 3.0"
+
+#: static/js/impala-all.js:13317 static/js/impala-min.js:7 static/js/impala/persona_creation.js:79
+msgid "Creative Commons Attribution-NonCommercial-Share Alike 3.0"
+msgstr "Creative Commons Atribuição-NãoComercial-CompartilhaIgual 3.0"
+
+#: static/js/impala-all.js:13322 static/js/impala-min.js:7 static/js/impala/persona_creation.js:84
+msgid "Creative Commons Attribution-NoDerivs 3.0"
+msgstr "Creative Commons Atribuição-SemDerivações 3.0"
+
+#: static/js/impala-all.js:13327 static/js/impala-min.js:7 static/js/impala/persona_creation.js:89
+msgid "Creative Commons Attribution-ShareAlike 3.0"
+msgstr "Creative Commons Atribuição-CompartilhaIgual 3.0"
+
+#: static/js/impala-all.js:13530 static/js/impala-min.js:7 static/js/impala/persona_creation.js:292
+msgid "Your Theme's Name"
+msgstr "O nome do seu tema"
+
+#: static/js/impala-all.js:14242 static/js/impala-min.js:8 static/js/impala/collections.js:19
+msgid "Stop Following"
+msgstr "Parar de seguir"
+
+#: static/js/impala-all.js:14243 static/js/impala-min.js:8 static/js/impala/collections.js:20
+msgid "Following"
+msgstr "A seguir"
+
+#: static/js/impala-all.js:14313 static/js/impala-min.js:8 static/js/impala/users.js:33
+msgid "use original"
+msgstr "utilizar original"
+
+#: static/js/impala-all.js:14523 static/js/impala-min.js:8 static/js/impala/search.js:114
+msgid "Updating results&hellip;"
+msgstr "A atualizar resultados&hellip;"
+
+#: static/js/common/upload-addon.js:69 static/js/zamboni/devhub-all.js:300 static/js/zamboni/devhub-min.js:1
+msgid "Select a file..."
+msgstr "Selecionar um ficheiro..."
+
+#: static/js/common/upload-addon.js:70 static/js/zamboni/devhub-all.js:301 static/js/zamboni/devhub-min.js:1
+msgid "Your add-on should end with .xpi, .jar or .xml"
+msgstr "O seu extra deve terminar com .xpi, .jar ou .xml"
+
+#. L10n: {0} is the percent of the file that has been uploaded.
+#: static/js/common/upload-addon.js:104 static/js/zamboni/devhub-all.js:335 static/js/zamboni/devhub-min.js:1
+#, python-format
+msgid "{0}% complete"
+msgstr "{0}% concluído"
+
+#. L10n: "{bytes uploaded} of {total filesize}".
+#: static/js/common/upload-addon.js:107 static/js/zamboni/devhub-all.js:338 static/js/zamboni/devhub-min.js:1
+msgid "{0} of {1}"
+msgstr "{0} de {1}"
+
+#: static/js/common/upload-addon.js:140 static/js/zamboni/devhub-all.js:371 static/js/zamboni/devhub-min.js:1
+msgid "Cancel"
+msgstr "Cancelar"
+
+#: static/js/common/upload-addon.js:162 static/js/zamboni/devhub-all.js:393 static/js/zamboni/devhub-min.js:1
+msgid "Uploading {0}"
+msgstr "A carregar {0}"
+
+#: static/js/common/upload-addon.js:189 static/js/zamboni/devhub-all.js:420 static/js/zamboni/devhub-min.js:1
+msgid "Error with {0}"
+msgstr "Erro com {0}"
+
+#: static/js/common/upload-addon.js:194 static/js/zamboni/devhub-all.js:425 static/js/zamboni/devhub-min.js:1
+msgid "Your add-on failed validation with {0} error."
+msgid_plural "Your add-on failed validation with {0} errors."
+msgstr[0] "O seu extra falhou a validação com {0} erro."
+msgstr[1] "O seu extra falhou a validação com {0} erros."
+
+#: static/js/common/upload-addon.js:208 static/js/zamboni/devhub-all.js:439 static/js/zamboni/devhub-min.js:1
+msgid "&hellip;and {0} more"
+msgid_plural "&hellip;and {0} more"
+msgstr[0] "&hellip;e mais {0}"
+msgstr[1] "&hellip;e mais {0}"
+
+#: static/js/common/upload-addon.js:222 static/js/common/upload-addon.js:497 static/js/zamboni/devhub-all.js:453 static/js/zamboni/devhub-all.js:743 static/js/zamboni/devhub-min.js:1
+msgid "See full validation report"
+msgstr "Ver relatório completo da validação"
+
+#: static/js/common/upload-addon.js:234 static/js/zamboni/devhub-all.js:465 static/js/zamboni/devhub-min.js:1
+msgid "Validating {0}"
+msgstr "A validar {0}"
+
+#. L10n: first argument is an HTTP status code
+#: static/js/common/upload-addon.js:273 static/js/zamboni/devhub-all.js:504 static/js/zamboni/devhub-min.js:1
+msgid "Received an empty response from the server; status: {0}"
+msgstr "Foi recebida uma resposta vazia do servidor; estado: {0}"
+
+#: static/js/common/upload-addon.js:370 static/js/zamboni/devhub-all.js:604 static/js/zamboni/devhub-min.js:1
+msgid "Unexpected server error while validating."
+msgstr "Erro inesperado do servidor na validação."
+
+#: static/js/common/upload-addon.js:409 static/js/zamboni/devhub-all.js:643 static/js/zamboni/devhub-min.js:1
+msgid "Finished validating {0}"
+msgstr "Terminou a validação de {0}"
+
+#: static/js/common/upload-addon.js:415 static/js/zamboni/devhub-all.js:649 static/js/zamboni/devhub-min.js:1
+msgid "Your add-on validation timed out, it will be manually reviewed."
+msgstr "A validação do extra expirou, será automaticamente revisto."
+
+#: static/js/common/upload-addon.js:418 static/js/zamboni/devhub-all.js:652 static/js/zamboni/devhub-min.js:1
+msgid "Your add-on was validated with no errors and {0} warning."
+msgid_plural "Your add-on was validated with no errors and {0} warnings."
+msgstr[0] "O seu extra foi validado sem erros e {0} aviso."
+msgstr[1] "O seu extra foi validado sem erros e {0} avisos."
+
+#: static/js/common/upload-addon.js:423 static/js/zamboni/devhub-all.js:657 static/js/zamboni/devhub-min.js:1
+msgid "Your add-on was validated with no errors and {0} message."
+msgid_plural "Your add-on was validated with no errors and {0} messages."
+msgstr[0] "O seu extra foi validado sem erros e {0} mensagem."
+msgstr[1] "O seu extra foi validado sem erros e {0} mensagens."
+
+#: static/js/common/upload-addon.js:428 static/js/zamboni/devhub-all.js:662 static/js/zamboni/devhub-min.js:1
+msgid "Your add-on was validated with no errors or warnings."
+msgstr "O seu extra foi validado sem erros ou mensagens."
+
+#: static/js/common/upload-addon.js:443 static/js/zamboni/devhub-all.js:677 static/js/zamboni/devhub-min.js:1
+msgid "Your submission will be automatically signed."
 msgstr ""
 
-#: static/js/zamboni/themes_review_templates.js:31
-msgid "Theme"
+#: static/js/common/upload-addon.js:450 static/js/zamboni/devhub-all.js:696 static/js/zamboni/devhub-min.js:1
+msgid "Include detailed version notes (this can be done in the next step)."
+msgstr "Incluir notas detalhadas da versão (isto pode ser feito no próximo passo)."
+
+#: static/js/common/upload-addon.js:451 static/js/zamboni/devhub-all.js:697 static/js/zamboni/devhub-min.js:1
+msgid "If your add-on requires an account to a website in order to be fully tested, include a test username and password in the Notes to Reviewer (this can be done in the next step)."
+msgstr "Se o seu extra requer uma conta num site web para ser completamente testado, inclua um nome de utilizador e senha de teste nas Notas para o Revisor (isto pode ser feito no próximo passo)."
+
+#: static/js/common/upload-addon.js:452 static/js/zamboni/devhub-all.js:698 static/js/zamboni/devhub-min.js:1
+msgid "If your add-on is intended for a limited audience you should choose Preliminary Review instead of Full Review."
+msgstr "Se um extra é direcionado a uma audiência limitada deve escolher a Revisão preliminar em vez de uma Revisão completa"
+
+#: static/js/common/upload-addon.js:465 static/js/zamboni/devhub-all.js:711 static/js/zamboni/devhub-min.js:1
+msgid "Add-on submission checklist"
+msgstr "Lista de verificação da submissão de extra"
+
+#: static/js/common/upload-addon.js:466 static/js/zamboni/devhub-all.js:712 static/js/zamboni/devhub-min.js:1
+msgid "Please verify the following points before finalizing your submission. This will minimize delays or misunderstanding during the review process:"
+msgstr "Por favor confirme os pontos seguintes antes de finalizar a sua submissão. Isto irá minimizar atrasos ou confusões durante o processo de revisão:"
+
+#: static/js/common/upload-addon.js:468 static/js/zamboni/devhub-all.js:714 static/js/zamboni/devhub-min.js:1
+msgid ""
+"Compiled binaries, as well as minified or obfuscated scripts (excluding known libraries) need to have their sources submitted separately for review. Make sure that you use the source code upload "
+"field to avoid having your submission rejected."
+msgstr ""
+"Binários compilados, bem como scripts minificados ou ofuscados (excluindo bibliotecas conhecidas) devem ter as suas fontes submetidas separadamente para revisão. Tenha a certeza que utiliza o campo "
+"de envio de código fonte para evitar que as sua submissão seja rejeitada."
+
+#: static/js/common/upload-addon.js:486 static/js/zamboni/devhub-all.js:732 static/js/zamboni/devhub-min.js:1
+msgid "The validation process found these issues that can lead to rejections:"
+msgstr "O processo de validação encontrou estes problemas que podem levar a rejeições:"
+
+#: static/js/common/upload-addon.js:503 static/js/zamboni/devhub-all.js:749 static/js/zamboni/devhub-min.js:1
+msgid "If you are unfamiliar with the add-ons review process, you can read about it here."
+msgstr "Se não está familiarizado com o processo de revisão de extras, pode ler mais sobre o mesmo aqui."
+
+#: static/js/common/upload-addon.js:540 static/js/zamboni/devhub-all.js:786 static/js/zamboni/devhub-min.js:1
+msgid "Sorry, no supported platform has been found."
+msgstr "Lamentamos, mas não foi encontrada nenhuma plataforma suportada."
+
+#: static/js/common/upload-base.js:57 static/js/zamboni/devhub-all.js:187 static/js/zamboni/devhub-min.js:1
+msgid "The filetype you uploaded isn't recognized."
+msgstr "O tipo de ficheiro que enviou não foi reconhecido."
+
+#: static/js/common/upload-base.js:79 static/js/zamboni/devhub-all.js:209 static/js/zamboni/devhub-min.js:1
+msgid "You cancelled the upload."
+msgstr "Cancelou o envio."
+
+#: static/js/impala/stats/chart.js:267 static/js/zamboni/stats-all.js:16898 static/js/zamboni/stats-min.js:5
+msgid "Week of {0}"
+msgstr "Semana de {0}"
+
+#: static/js/impala/stats/chart.js:269 static/js/zamboni/stats-all.js:16900 static/js/zamboni/stats-min.js:5
+msgid " downloads"
 msgstr ""
 
-#: static/js/zamboni/themes_review_templates.js:33
-msgid "Reviewer"
-msgstr ""
+#: static/js/impala/stats/chart.js:270 static/js/zamboni/stats-all.js:16901 static/js/zamboni/stats-min.js:5
+msgid "{0} users"
+msgstr "{0} utilizadores"
 
-#: static/js/zamboni/themes_review_templates.js:35
-msgid "Status"
-msgstr ""
+#: static/js/impala/stats/chart.js:271 static/js/zamboni/stats-all.js:16902 static/js/zamboni/stats-min.js:5
+msgid "{0} add-ons"
+msgstr "{0} extras"
 
-#: static/js/zamboni/validator.js:80
+#: static/js/impala/stats/chart.js:272 static/js/zamboni/stats-all.js:16903 static/js/zamboni/stats-min.js:5
+msgid "{0} collections"
+msgstr "{0} coleções"
+
+#: static/js/impala/stats/chart.js:273 static/js/zamboni/stats-all.js:16904 static/js/zamboni/stats-min.js:5
+msgid "{0} reviews"
+msgstr "{0} análises"
+
+#: static/js/impala/stats/chart.js:275 static/js/zamboni/stats-all.js:16906 static/js/zamboni/stats-min.js:5
+msgid "{0} sales"
+msgstr "{0} vendas"
+
+#: static/js/impala/stats/chart.js:276 static/js/zamboni/stats-all.js:16907 static/js/zamboni/stats-min.js:5
+msgid "{0} refunds"
+msgstr "{0} devoluções"
+
+#: static/js/impala/stats/chart.js:277 static/js/zamboni/stats-all.js:16908 static/js/zamboni/stats-min.js:5
+msgid "{0} installs"
+msgstr "{0} instalações"
+
+#: static/js/impala/stats/chart.js:369 static/js/impala/stats/csv_keys.js:3 static/js/impala/stats/csv_keys.js:109 static/js/zamboni/stats-all.js:15284 static/js/zamboni/stats-all.js:15390
+#: static/js/zamboni/stats-all.js:17000 static/js/zamboni/stats-min.js:4 static/js/zamboni/stats-min.js:5
+msgid "Downloads"
+msgstr "Transferências"
+
+#: static/js/impala/stats/chart.js:379 static/js/impala/stats/csv_keys.js:6 static/js/impala/stats/csv_keys.js:110 static/js/zamboni/stats-all.js:15287 static/js/zamboni/stats-all.js:15391
+#: static/js/zamboni/stats-all.js:17010 static/js/zamboni/stats-min.js:4 static/js/zamboni/stats-min.js:5
+msgid "Daily Users"
+msgstr "Utilizadores diários"
+
+#: static/js/impala/stats/chart.js:410 static/js/zamboni/stats-all.js:17041 static/js/zamboni/stats-min.js:5
+msgid "Amount, in USD"
+msgstr "Valor, em USD"
+
+#: static/js/impala/stats/chart.js:421 static/js/impala/stats/csv_keys.js:104 static/js/zamboni/stats-all.js:15385 static/js/zamboni/stats-all.js:17052 static/js/zamboni/stats-min.js:5
+msgid "Number of Contributions"
+msgstr "Número de contribuições"
+
+#: static/js/impala/stats/chart.js:447 static/js/zamboni/stats-all.js:17078 static/js/zamboni/stats-min.js:5
+msgid "More Info..."
+msgstr "Mais informação..."
+
+#. L10n: {0} is an ISO-formatted date.
+#: static/js/impala/stats/chart.js:451 static/js/zamboni/stats-all.js:17082 static/js/zamboni/stats-min.js:5
+msgid "Details for {0}"
+msgstr "Detalhes para {0}"
+
+#: static/js/impala/stats/csv_keys.js:9 static/js/zamboni/stats-all.js:15290 static/js/zamboni/stats-min.js:4
+msgid "Collections Created"
+msgstr "Coleções criadas"
+
+#: static/js/impala/stats/csv_keys.js:12 static/js/zamboni/stats-all.js:15293 static/js/zamboni/stats-min.js:4
+msgid "Add-ons in Use"
+msgstr "Extras em uso"
+
+#: static/js/impala/stats/csv_keys.js:15 static/js/zamboni/stats-all.js:15296 static/js/zamboni/stats-min.js:4
+msgid "Add-ons Created"
+msgstr "Extras criados"
+
+#: static/js/impala/stats/csv_keys.js:18 static/js/zamboni/stats-all.js:15299 static/js/zamboni/stats-min.js:4
+msgid "Add-ons Downloaded"
+msgstr "Extras transferidos"
+
+#: static/js/impala/stats/csv_keys.js:21 static/js/zamboni/stats-all.js:15302 static/js/zamboni/stats-min.js:4
+msgid "Add-ons Updated"
+msgstr "Extras atualizados"
+
+#: static/js/impala/stats/csv_keys.js:24 static/js/zamboni/stats-all.js:15305 static/js/zamboni/stats-min.js:4
+msgid "Reviews Written"
+msgstr "Análises escritas"
+
+#: static/js/impala/stats/csv_keys.js:27 static/js/zamboni/stats-all.js:15308 static/js/zamboni/stats-min.js:4
+msgid "User Signups"
+msgstr "Registos de utilizador"
+
+#: static/js/impala/stats/csv_keys.js:30 static/js/zamboni/stats-all.js:15311 static/js/zamboni/stats-min.js:4
+msgid "Subscribers"
+msgstr "Subscritores"
+
+#: static/js/impala/stats/csv_keys.js:33 static/js/zamboni/stats-all.js:15314 static/js/zamboni/stats-min.js:4
+msgid "Ratings"
+msgstr "Classificações"
+
+#: static/js/impala/stats/csv_keys.js:36 static/js/impala/stats/csv_keys.js:114 static/js/zamboni/stats-all.js:15317 static/js/zamboni/stats-all.js:15395 static/js/zamboni/stats-min.js:4
+#: static/js/zamboni/stats-min.js:5
+msgid "Sales"
+msgstr "Vendas"
+
+#: static/js/impala/stats/csv_keys.js:39 static/js/impala/stats/csv_keys.js:113 static/js/zamboni/stats-all.js:15320 static/js/zamboni/stats-all.js:15394 static/js/zamboni/stats-min.js:4
+#: static/js/zamboni/stats-min.js:5
+msgid "Installs"
+msgstr "Instalações"
+
+#: static/js/impala/stats/csv_keys.js:42 static/js/zamboni/stats-all.js:15323 static/js/zamboni/stats-min.js:4
+msgid "Unknown"
+msgstr "Desconhecido"
+
+#: static/js/impala/stats/csv_keys.js:43 static/js/zamboni/stats-all.js:15324 static/js/zamboni/stats-min.js:4
+msgid "Add-ons Manager"
+msgstr "Gestor de extras"
+
+#: static/js/impala/stats/csv_keys.js:44 static/js/zamboni/stats-all.js:15325 static/js/zamboni/stats-min.js:4
+msgid "Add-ons Manager Promo"
+msgstr "Gestor de Promoção de Extras"
+
+#: static/js/impala/stats/csv_keys.js:45 static/js/zamboni/stats-all.js:15326 static/js/zamboni/stats-min.js:4
+msgid "Add-ons Manager Featured"
+msgstr "Gestor de Destaques de Extras"
+
+#: static/js/impala/stats/csv_keys.js:46 static/js/zamboni/stats-all.js:15327 static/js/zamboni/stats-min.js:4
+msgid "Add-ons Manager Learn More"
+msgstr "Gestor de Saber Mais sobre Extras"
+
+#: static/js/impala/stats/csv_keys.js:47 static/js/zamboni/stats-all.js:15328 static/js/zamboni/stats-min.js:4
+msgid "Search Suggestions"
+msgstr "Sugestões de pesquisa"
+
+#: static/js/impala/stats/csv_keys.js:48 static/js/zamboni/stats-all.js:15329 static/js/zamboni/stats-min.js:4
+msgid "Search Results"
+msgstr "Resultados da pesquisa"
+
+#: static/js/impala/stats/csv_keys.js:49 static/js/impala/stats/csv_keys.js:50 static/js/impala/stats/csv_keys.js:51 static/js/zamboni/stats-all.js:15330 static/js/zamboni/stats-all.js:15331
+#: static/js/zamboni/stats-all.js:15332 static/js/zamboni/stats-min.js:4
+msgid "Homepage Promo"
+msgstr "Página inicial de promoção"
+
+#: static/js/impala/stats/csv_keys.js:52 static/js/impala/stats/csv_keys.js:53 static/js/zamboni/stats-all.js:15333 static/js/zamboni/stats-all.js:15334 static/js/zamboni/stats-min.js:4
+msgid "Homepage Featured"
+msgstr "Página inicial de destaque"
+
+#: static/js/impala/stats/csv_keys.js:54 static/js/impala/stats/csv_keys.js:55 static/js/zamboni/stats-all.js:15335 static/js/zamboni/stats-all.js:15336 static/js/zamboni/stats-min.js:4
+msgid "Homepage Up and Coming"
+msgstr "Página inicial de novo e a chegar"
+
+#: static/js/impala/stats/csv_keys.js:56 static/js/zamboni/stats-all.js:15337 static/js/zamboni/stats-min.js:4
+msgid "Homepage Most Popular"
+msgstr "Página inicial mais populares"
+
+#: static/js/impala/stats/csv_keys.js:57 static/js/impala/stats/csv_keys.js:59 static/js/zamboni/stats-all.js:15338 static/js/zamboni/stats-all.js:15340 static/js/zamboni/stats-min.js:4
+msgid "Detail Page"
+msgstr "Página de detalhe"
+
+#: static/js/impala/stats/csv_keys.js:58 static/js/impala/stats/csv_keys.js:60 static/js/zamboni/stats-all.js:15339 static/js/zamboni/stats-all.js:15341 static/js/zamboni/stats-min.js:4
+msgid "Detail Page (bottom)"
+msgstr "Página de detalhe (inferior)"
+
+#: static/js/impala/stats/csv_keys.js:61 static/js/zamboni/stats-all.js:15342 static/js/zamboni/stats-min.js:4
+msgid "Detail Page (Development Channel)"
+msgstr "Página de detalhe (canal de desenvolvimento)"
+
+#: static/js/impala/stats/csv_keys.js:62 static/js/impala/stats/csv_keys.js:63 static/js/impala/stats/csv_keys.js:64 static/js/zamboni/stats-all.js:15343 static/js/zamboni/stats-all.js:15344
+#: static/js/zamboni/stats-all.js:15345 static/js/zamboni/stats-min.js:4
+msgid "Often Used With"
+msgstr "Muito utilizado com"
+
+#: static/js/impala/stats/csv_keys.js:65 static/js/impala/stats/csv_keys.js:66 static/js/zamboni/stats-all.js:15346 static/js/zamboni/stats-all.js:15347 static/js/zamboni/stats-min.js:4
+msgid "Others By Author"
+msgstr "Outros do autor"
+
+#: static/js/impala/stats/csv_keys.js:67 static/js/impala/stats/csv_keys.js:68 static/js/zamboni/stats-all.js:15348 static/js/zamboni/stats-all.js:15349 static/js/zamboni/stats-min.js:4
+msgid "Dependencies"
+msgstr "Dependências"
+
+#: static/js/impala/stats/csv_keys.js:69 static/js/impala/stats/csv_keys.js:70 static/js/zamboni/stats-all.js:15350 static/js/zamboni/stats-all.js:15351 static/js/zamboni/stats-min.js:4
+msgid "Upsell"
+msgstr "Upsell"
+
+#: static/js/impala/stats/csv_keys.js:71 static/js/zamboni/stats-all.js:15352 static/js/zamboni/stats-min.js:4
+msgid "Meet the Developer"
+msgstr "Conheça o programador"
+
+#: static/js/impala/stats/csv_keys.js:72 static/js/zamboni/stats-all.js:15353 static/js/zamboni/stats-min.js:4
+msgid "User Profile"
+msgstr "Perfil do utilizador"
+
+#: static/js/impala/stats/csv_keys.js:73 static/js/zamboni/stats-all.js:15354 static/js/zamboni/stats-min.js:4
+msgid "Version History"
+msgstr "Histórico da versão"
+
+#: static/js/impala/stats/csv_keys.js:75 static/js/zamboni/stats-all.js:15356 static/js/zamboni/stats-min.js:4
+msgid "Sharing"
+msgstr "Partilha"
+
+#: static/js/impala/stats/csv_keys.js:76 static/js/zamboni/stats-all.js:15357 static/js/zamboni/stats-min.js:4
+msgid "Category Pages"
+msgstr "Páginas de categoria"
+
+#: static/js/impala/stats/csv_keys.js:77 static/js/zamboni/stats-all.js:15358 static/js/zamboni/stats-min.js:4
+msgid "Collections"
+msgstr "Coleções"
+
+#: static/js/impala/stats/csv_keys.js:78 static/js/impala/stats/csv_keys.js:79 static/js/zamboni/stats-all.js:15359 static/js/zamboni/stats-all.js:15360 static/js/zamboni/stats-min.js:4
+msgid "Category Landing Featured Carousel"
+msgstr "Página inicial de categoria de carrossel de destaque"
+
+#: static/js/impala/stats/csv_keys.js:80 static/js/impala/stats/csv_keys.js:81 static/js/zamboni/stats-all.js:15361 static/js/zamboni/stats-all.js:15362 static/js/zamboni/stats-min.js:4
+msgid "Category Landing Top Rated"
+msgstr "Página inicial de categoria de melhor classificada"
+
+#: static/js/impala/stats/csv_keys.js:82 static/js/impala/stats/csv_keys.js:83 static/js/zamboni/stats-all.js:15363 static/js/zamboni/stats-all.js:15364 static/js/zamboni/stats-min.js:5
+msgid "Category Landing Most Popular"
+msgstr "Página inicial de categoria de mais popular"
+
+#: static/js/impala/stats/csv_keys.js:84 static/js/impala/stats/csv_keys.js:85 static/js/zamboni/stats-all.js:15365 static/js/zamboni/stats-all.js:15366 static/js/zamboni/stats-min.js:5
+msgid "Category Landing Recently Added"
+msgstr "Página inicial de categoria de adicionado recentemente"
+
+#: static/js/impala/stats/csv_keys.js:86 static/js/impala/stats/csv_keys.js:87 static/js/zamboni/stats-all.js:15367 static/js/zamboni/stats-all.js:15368 static/js/zamboni/stats-min.js:5
+msgid "Browse Listing Featured Sort"
+msgstr "Navegar na lista ordenada por destaque"
+
+#: static/js/impala/stats/csv_keys.js:88 static/js/impala/stats/csv_keys.js:89 static/js/zamboni/stats-all.js:15369 static/js/zamboni/stats-all.js:15370 static/js/zamboni/stats-min.js:5
+msgid "Browse Listing Users Sort"
+msgstr "Navegar na lista ordenada por utilizadores"
+
+#: static/js/impala/stats/csv_keys.js:90 static/js/impala/stats/csv_keys.js:91 static/js/zamboni/stats-all.js:15371 static/js/zamboni/stats-all.js:15372 static/js/zamboni/stats-min.js:5
+msgid "Browse Listing Rating Sort"
+msgstr "Navegar na lista ordenada por classificação"
+
+#: static/js/impala/stats/csv_keys.js:92 static/js/impala/stats/csv_keys.js:93 static/js/zamboni/stats-all.js:15373 static/js/zamboni/stats-all.js:15374 static/js/zamboni/stats-min.js:5
+msgid "Browse Listing Created Sort"
+msgstr "Navegar na lista ordenada por criação"
+
+#: static/js/impala/stats/csv_keys.js:94 static/js/impala/stats/csv_keys.js:95 static/js/zamboni/stats-all.js:15375 static/js/zamboni/stats-all.js:15376 static/js/zamboni/stats-min.js:5
+msgid "Browse Listing Name Sort"
+msgstr "Navegar na lista ordenada por nome"
+
+#: static/js/impala/stats/csv_keys.js:96 static/js/impala/stats/csv_keys.js:97 static/js/zamboni/stats-all.js:15377 static/js/zamboni/stats-all.js:15378 static/js/zamboni/stats-min.js:5
+msgid "Browse Listing Popular Sort"
+msgstr "Navegar na lista ordenada por popularidade"
+
+#: static/js/impala/stats/csv_keys.js:98 static/js/impala/stats/csv_keys.js:99 static/js/zamboni/stats-all.js:15379 static/js/zamboni/stats-all.js:15380 static/js/zamboni/stats-min.js:5
+msgid "Browse Listing Updated Sort"
+msgstr "Navegar na lista ordenada por atualização"
+
+#: static/js/impala/stats/csv_keys.js:100 static/js/impala/stats/csv_keys.js:101 static/js/zamboni/stats-all.js:15381 static/js/zamboni/stats-all.js:15382 static/js/zamboni/stats-min.js:5
+msgid "Browse Listing Up and Coming Sort"
+msgstr "Navegar na lista ordenada por novas e a chegar"
+
+#: static/js/impala/stats/csv_keys.js:105 static/js/zamboni/stats-all.js:15386 static/js/zamboni/stats-min.js:5
+msgid "Total Amount Contributed"
+msgstr "Valor total contribuído"
+
+#: static/js/impala/stats/csv_keys.js:106 static/js/zamboni/stats-all.js:15387 static/js/zamboni/stats-min.js:5
+msgid "Average Contribution"
+msgstr "Contribuição média"
+
+#: static/js/impala/stats/csv_keys.js:115 static/js/zamboni/stats-all.js:15396 static/js/zamboni/stats-min.js:5
+msgid "Usage"
+msgstr "Utilização"
+
+#: static/js/impala/stats/csv_keys.js:118 static/js/zamboni/stats-all.js:15399 static/js/zamboni/stats-min.js:5
+msgid "Firefox"
+msgstr "Firefox"
+
+#: static/js/impala/stats/csv_keys.js:119 static/js/zamboni/stats-all.js:15400 static/js/zamboni/stats-min.js:5
+msgid "Mozilla"
+msgstr "Mozilla"
+
+#: static/js/impala/stats/csv_keys.js:120 static/js/zamboni/stats-all.js:15401 static/js/zamboni/stats-min.js:5
+msgid "Thunderbird"
+msgstr "Thunderbird"
+
+#: static/js/impala/stats/csv_keys.js:121 static/js/zamboni/stats-all.js:15402 static/js/zamboni/stats-min.js:5
+msgid "Sunbird"
+msgstr "Sunbird"
+
+#: static/js/impala/stats/csv_keys.js:122 static/js/zamboni/stats-all.js:15403 static/js/zamboni/stats-min.js:5
+msgid "SeaMonkey"
+msgstr "SeaMonkey"
+
+#: static/js/impala/stats/csv_keys.js:123 static/js/zamboni/stats-all.js:15404 static/js/zamboni/stats-min.js:5
+msgid "Fennec"
+msgstr "Fennec"
+
+#: static/js/impala/stats/csv_keys.js:124 static/js/zamboni/stats-all.js:15405 static/js/zamboni/stats-min.js:5
+msgid "Android"
+msgstr "Android"
+
+#. L10n: {0} is an integer.
+#: static/js/impala/stats/csv_keys.js:129 static/js/zamboni/stats-all.js:15410 static/js/zamboni/stats-min.js:5
+msgid "Downloads and Daily Users, last {0} days"
+msgstr "Transferências e utilizadores diários, últimos {0} dias"
+
+#. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
+#: static/js/impala/stats/csv_keys.js:131 static/js/zamboni/stats-all.js:15412 static/js/zamboni/stats-min.js:5
+msgid "Downloads and Daily Users from {0} to {1}"
+msgstr "Transferências e utilizadores diários de {0} a {1}"
+
+#. L10n: {0} is an integer.
+#: static/js/impala/stats/csv_keys.js:135 static/js/zamboni/stats-all.js:15416 static/js/zamboni/stats-min.js:5
+msgid "Installs and Daily Users, last {0} days"
+msgstr "Instalações e utilizadores diários, últimos {0} dias"
+
+#. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
+#: static/js/impala/stats/csv_keys.js:137 static/js/zamboni/stats-all.js:15418 static/js/zamboni/stats-min.js:5
+msgid "Installs and Daily Users from {0} to {1}"
+msgstr "Instalações e utilizadores diários de {0} a {1}"
+
+#. L10n: {0} is an integer.
+#: static/js/impala/stats/csv_keys.js:141 static/js/zamboni/stats-all.js:15422 static/js/zamboni/stats-min.js:5
+msgid "Downloads, last {0} days"
+msgstr "Transferências, últimos {0} dias"
+
+#. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
+#: static/js/impala/stats/csv_keys.js:143 static/js/zamboni/stats-all.js:15424 static/js/zamboni/stats-min.js:5
+msgid "Downloads from {0} to {1}"
+msgstr "Transferências de {0} a {1}"
+
+#. L10n: {0} is an integer.
+#: static/js/impala/stats/csv_keys.js:147 static/js/zamboni/stats-all.js:15428 static/js/zamboni/stats-min.js:5
+msgid "Daily Users, last {0} days"
+msgstr "Utilizadores diários, últimos {0} dias"
+
+#. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
+#: static/js/impala/stats/csv_keys.js:149 static/js/zamboni/stats-all.js:15430 static/js/zamboni/stats-min.js:5
+msgid "Daily Users from {0} to {1}"
+msgstr "Utilizadores diários de {0} a {1}"
+
+#. L10n: {0} is an integer.
+#: static/js/impala/stats/csv_keys.js:153 static/js/zamboni/stats-all.js:15434 static/js/zamboni/stats-min.js:5
+msgid "Applications, last {0} days"
+msgstr "Aplicações, últimos {0} dias"
+
+#. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
+#: static/js/impala/stats/csv_keys.js:155 static/js/zamboni/stats-all.js:15436 static/js/zamboni/stats-min.js:5
+msgid "Applications from {0} to {1}"
+msgstr "Aplicações de {0} a {1}"
+
+#. L10n: {0} is an integer.
+#: static/js/impala/stats/csv_keys.js:159 static/js/zamboni/stats-all.js:15440 static/js/zamboni/stats-min.js:5
+msgid "Platforms, last {0} days"
+msgstr "Plataformas, últimos {0} dias"
+
+#. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
+#: static/js/impala/stats/csv_keys.js:161 static/js/zamboni/stats-all.js:15442 static/js/zamboni/stats-min.js:5
+msgid "Platforms from {0} to {1}"
+msgstr "Plataformas de {0} a {1}"
+
+#. L10n: {0} is an integer.
+#: static/js/impala/stats/csv_keys.js:165 static/js/zamboni/stats-all.js:15446 static/js/zamboni/stats-min.js:5
+msgid "Languages, last {0} days"
+msgstr "Idiomas, últimos {0} dias"
+
+#. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
+#: static/js/impala/stats/csv_keys.js:167 static/js/zamboni/stats-all.js:15448 static/js/zamboni/stats-min.js:5
+msgid "Languages from {0} to {1}"
+msgstr "Idiomas de {0} a {1}"
+
+#. L10n: {0} is an integer.
+#: static/js/impala/stats/csv_keys.js:171 static/js/zamboni/stats-all.js:15452 static/js/zamboni/stats-min.js:5
+msgid "Add-on Versions, last {0} days"
+msgstr "Versões de extra, últimos {0} dias"
+
+#. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
+#: static/js/impala/stats/csv_keys.js:173 static/js/zamboni/stats-all.js:15454 static/js/zamboni/stats-min.js:5
+msgid "Add-on Versions from {0} to {1}"
+msgstr "Versões de extra de {0} a {1}"
+
+#. L10n: {0} is an integer.
+#: static/js/impala/stats/csv_keys.js:177 static/js/zamboni/stats-all.js:15458 static/js/zamboni/stats-min.js:5
+msgid "Add-on Status, last {0} days"
+msgstr "Versões de extra, últimos {0} dias"
+
+#. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
+#: static/js/impala/stats/csv_keys.js:179 static/js/zamboni/stats-all.js:15460 static/js/zamboni/stats-min.js:5
+msgid "Add-on Status from {0} to {1}"
+msgstr "Estado de extra de {0} a {1}"
+
+#. L10n: {0} is an integer.
+#: static/js/impala/stats/csv_keys.js:183 static/js/zamboni/stats-all.js:15464 static/js/zamboni/stats-min.js:5
+msgid "Download Sources, last {0} days"
+msgstr "Transferências de fontes, últimos {0} dias"
+
+#. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
+#: static/js/impala/stats/csv_keys.js:185 static/js/zamboni/stats-all.js:15466 static/js/zamboni/stats-min.js:5
+msgid "Download Sources from {0} to {1}"
+msgstr "Transferências de fontes de {0} a {1}"
+
+#. L10n: {0} is an integer.
+#: static/js/impala/stats/csv_keys.js:189 static/js/zamboni/stats-all.js:15470 static/js/zamboni/stats-min.js:5
+msgid "Contributions, last {0} days"
+msgstr "Contribuições, últimos {0} dias"
+
+#. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
+#: static/js/impala/stats/csv_keys.js:191 static/js/zamboni/stats-all.js:15472 static/js/zamboni/stats-min.js:5
+msgid "Contributions from {0} to {1}"
+msgstr "Contribuições de {0} a {1}"
+
+#. L10n: {0} is an integer.
+#: static/js/impala/stats/csv_keys.js:195 static/js/zamboni/stats-all.js:15476 static/js/zamboni/stats-min.js:5
+msgid "Site Metrics, last {0} days"
+msgstr "Métricas do site, últimos {0} dias"
+
+#. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
+#: static/js/impala/stats/csv_keys.js:197 static/js/zamboni/stats-all.js:15478 static/js/zamboni/stats-min.js:5
+msgid "Site Metrics from {0} to {1}"
+msgstr "Métricas do site de {0} a {1}"
+
+#. L10n: {0} is an integer.
+#: static/js/impala/stats/csv_keys.js:201 static/js/zamboni/stats-all.js:15482 static/js/zamboni/stats-min.js:5
+msgid "Add-ons in Use, last {0} days"
+msgstr "Extras em utilização, últimos {0} dias"
+
+#. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
+#: static/js/impala/stats/csv_keys.js:203 static/js/zamboni/stats-all.js:15484 static/js/zamboni/stats-min.js:5
+msgid "Add-ons in Use from {0} to {1}"
+msgstr "Extras em utilização de {0} a {1}"
+
+#. L10n: {0} is an integer.
+#: static/js/impala/stats/csv_keys.js:207 static/js/zamboni/stats-all.js:15488 static/js/zamboni/stats-min.js:5
+msgid "Add-ons Downloaded, last {0} days"
+msgstr "Extras transferidos, últimos {0} dias"
+
+#. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
+#: static/js/impala/stats/csv_keys.js:209 static/js/zamboni/stats-all.js:15490 static/js/zamboni/stats-min.js:5
+msgid "Add-ons Downloaded from {0} to {1}"
+msgstr "Extras transferidos de {0} a {1}"
+
+#. L10n: {0} is an integer.
+#: static/js/impala/stats/csv_keys.js:213 static/js/zamboni/stats-all.js:15494 static/js/zamboni/stats-min.js:5
+msgid "Add-ons Created, last {0} days"
+msgstr "Extras criados, últimos {0} dias"
+
+#. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
+#: static/js/impala/stats/csv_keys.js:215 static/js/zamboni/stats-all.js:15496 static/js/zamboni/stats-min.js:5
+msgid "Add-ons Created from {0} to {1}"
+msgstr "Extras criados de {0} a {1}"
+
+#. L10n: {0} is an integer.
+#: static/js/impala/stats/csv_keys.js:219 static/js/zamboni/stats-all.js:15500 static/js/zamboni/stats-min.js:5
+msgid "Add-ons Updated, last {0} days"
+msgstr "Extras atualizados, últimos {0} dias"
+
+#. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
+#: static/js/impala/stats/csv_keys.js:221 static/js/zamboni/stats-all.js:15502 static/js/zamboni/stats-min.js:5
+msgid "Add-ons Updated from {0} to {1}"
+msgstr "Extras atualizados de {0} a {1}"
+
+#. L10n: {0} is an integer.
+#: static/js/impala/stats/csv_keys.js:225 static/js/zamboni/stats-all.js:15506 static/js/zamboni/stats-min.js:5
+msgid "Reviews Written, last {0} days"
+msgstr "Análises feitas, últimos {0} dias"
+
+#. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
+#: static/js/impala/stats/csv_keys.js:227 static/js/zamboni/stats-all.js:15508 static/js/zamboni/stats-min.js:5
+msgid "Reviews Written from {0} to {1}"
+msgstr "Análises feitas de {0} a {1}"
+
+#. L10n: {0} is an integer.
+#: static/js/impala/stats/csv_keys.js:231 static/js/zamboni/stats-all.js:15512 static/js/zamboni/stats-min.js:5
+msgid "User Signups, last {0} days"
+msgstr "Registo de utilizadores, últimos {0} dias"
+
+#. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
+#: static/js/impala/stats/csv_keys.js:233 static/js/zamboni/stats-all.js:15514 static/js/zamboni/stats-min.js:5
+msgid "User Signups from {0} to {1}"
+msgstr "Registo de utilizadores de {0} a {1}"
+
+#. L10n: {0} is an integer.
+#: static/js/impala/stats/csv_keys.js:237 static/js/zamboni/stats-all.js:15518 static/js/zamboni/stats-min.js:5
+msgid "Collections Created, last {0} days"
+msgstr "Coleções criadas, últimos {0} dias"
+
+#. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
+#: static/js/impala/stats/csv_keys.js:239 static/js/zamboni/stats-all.js:15520 static/js/zamboni/stats-min.js:5
+msgid "Collections Created from {0} to {1}"
+msgstr "Coleções criadas de {0} a {1}"
+
+#. L10n: {0} is an integer.
+#: static/js/impala/stats/csv_keys.js:243 static/js/zamboni/stats-all.js:15524 static/js/zamboni/stats-min.js:5
+msgid "Subscribers, last {0} days"
+msgstr "Subscritores, últimos {0} dias"
+
+#. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
+#: static/js/impala/stats/csv_keys.js:245 static/js/zamboni/stats-all.js:15526 static/js/zamboni/stats-min.js:5
+msgid "Subscribers from {0} to {1}"
+msgstr "Subscritores de {0} a {1}"
+
+#. L10n: {0} is an integer.
+#: static/js/impala/stats/csv_keys.js:249 static/js/zamboni/stats-all.js:15530 static/js/zamboni/stats-min.js:5
+msgid "Ratings, last {0} days"
+msgstr "Classificações, últimos {0} dias"
+
+#. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
+#: static/js/impala/stats/csv_keys.js:251 static/js/zamboni/stats-all.js:15532 static/js/zamboni/stats-min.js:5
+msgid "Ratings from {0} to {1}"
+msgstr "Classificações de {0} a {1}"
+
+#. L10n: {0} is an integer.
+#: static/js/impala/stats/csv_keys.js:255 static/js/zamboni/stats-all.js:15536 static/js/zamboni/stats-min.js:5
+msgid "Sales, last {0} days"
+msgstr "Vendas, últimos {0} dias"
+
+#. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
+#: static/js/impala/stats/csv_keys.js:257 static/js/zamboni/stats-all.js:15538 static/js/zamboni/stats-min.js:5
+msgid "Sales from {0} to {1}"
+msgstr "Vendas de {0} a {1}"
+
+#. L10n: {0} is an integer.
+#: static/js/impala/stats/csv_keys.js:261 static/js/zamboni/stats-all.js:15542 static/js/zamboni/stats-min.js:5
+msgid "Installs, last {0} days"
+msgstr "Instalações, últimos {0} dias"
+
+#. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
+#: static/js/impala/stats/csv_keys.js:263 static/js/zamboni/stats-all.js:15544 static/js/zamboni/stats-min.js:5
+msgid "Installs from {0} to {1}"
+msgstr "Instalações de {0} a {1}"
+
+#. L10n: {0} and {1} are integers.
+#: static/js/impala/stats/csv_keys.js:269 static/js/zamboni/stats-all.js:15550 static/js/zamboni/stats-min.js:5
+msgid "<b>{0}</b> in last {1} days"
+msgstr "<b>{0}</b> nos últimos {1} dias"
+
+#. L10n: {0} is an integer and {1} and {2} are dates in YYYY-MM-DD format.
+#: static/js/impala/stats/csv_keys.js:271 static/js/impala/stats/csv_keys.js:277 static/js/zamboni/stats-all.js:15552 static/js/zamboni/stats-all.js:15558 static/js/zamboni/stats-min.js:5
+msgid "<b>{0}</b> from {1} to {2}"
+msgstr "<b>{0}</b> de {1} a {2}"
+
+#. L10n: {0} and {1} are integers.
+#: static/js/impala/stats/csv_keys.js:275 static/js/zamboni/stats-all.js:15556 static/js/zamboni/stats-min.js:5
+msgid "<b>{0}</b> average in last {1} days"
+msgstr "<b>{0}</b> em média nos últimos {1} dias"
+
+#: static/js/impala/stats/overview.js:19 static/js/zamboni/stats-all.js:16469 static/js/zamboni/stats-min.js:5
+msgid "No data available."
+msgstr "Sem dados disponíveis."
+
+#: static/js/impala/stats/table.js:74 static/js/zamboni/stats-all.js:17209 static/js/zamboni/stats-min.js:5
+msgid "Date"
+msgstr "Data"
+
+#: static/js/impala/stats/topchart.js:96 static/js/zamboni/stats-all.js:16600 static/js/zamboni/stats-min.js:5
+msgid "Other"
+msgstr "Outro"
+
+#: static/js/zamboni/admin-all.js:180 static/js/zamboni/admin-min.js:1 static/js/zamboni/admin_validation.js:24 static/js/zamboni/devhub-all.js:2408 static/js/zamboni/devhub-min.js:2
+#: static/js/zamboni/devhub.js:1229 static/js/zamboni/editors-all.js:15576 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:295
+msgid "Select an application first"
+msgstr "Selecione primeiro uma aplicação"
+
+#: static/js/zamboni/admin-all.js:207 static/js/zamboni/admin-min.js:1 static/js/zamboni/admin_validation.js:51
+msgid "Set {0} add-on to a max version of {1} and email the author."
+msgid_plural "Set {0} add-ons to a max version of {1} and email the authors."
+msgstr[0] "Defina {0} extra para uma versão máxima de {1} e envie um email para o autor."
+msgstr[1] "Defina {0} extras para uma versão máxima de {1} e envie um email aos autores."
+
+#: static/js/zamboni/admin-all.js:210 static/js/zamboni/admin-min.js:1 static/js/zamboni/admin_validation.js:54
+msgid "Email author of {2} add-on which failed validation."
+msgid_plural "Email authors of {2} add-ons which failed validation."
+msgstr[0] "Envie um email ao autor de {2} extra que falhou a validação."
+msgstr[1] "Envie um email aos autores de {2} extras que falharam a validação."
+
+#: static/js/zamboni/devhub-all.js:1289 static/js/zamboni/devhub-min.js:1 static/js/zamboni/devhub.js:110
+msgid "Your browser does not support the video tag"
+msgstr "O seu navegador não suporta a tag video"
+
+#: static/js/zamboni/devhub-all.js:1550 static/js/zamboni/devhub-min.js:1 static/js/zamboni/devhub.js:371
+msgid "Changes Saved"
+msgstr "Alterações guardadas"
+
+#: static/js/zamboni/devhub-all.js:1566 static/js/zamboni/devhub-min.js:1 static/js/zamboni/devhub.js:387
+msgid "Enter a new author's email address"
+msgstr "Introduza um novo endereço de email do autor"
+
+#: static/js/zamboni/devhub-all.js:1715 static/js/zamboni/devhub-min.js:1 static/js/zamboni/devhub.js:536
+msgid "There was an error uploading your file."
+msgstr "Ocorreu um erro ao enviar o seu ficheiro."
+
+#: static/js/zamboni/devhub-all.js:1860 static/js/zamboni/devhub-min.js:1 static/js/zamboni/devhub.js:681
+msgid "{files} file"
+msgid_plural "{files} files"
+msgstr[0] "{files} ficheiro"
+msgstr[1] "{files} ficheiros"
+
+#: static/js/zamboni/devhub-all.js:1863 static/js/zamboni/devhub-min.js:1 static/js/zamboni/devhub.js:684
+msgid "{reviews} user review"
+msgid_plural "{reviews} user reviews"
+msgstr[0] "{reviews} análise de utilizador"
+msgstr[1] "{reviews} análises de utilizadores"
+
+#: static/js/zamboni/devhub-all.js:1975 static/js/zamboni/devhub-min.js:2 static/js/zamboni/devhub.js:796
+msgid "Learn more"
+msgstr "Saber mais"
+
+#: static/js/zamboni/devhub-all.js:1979 static/js/zamboni/devhub-min.js:2 static/js/zamboni/devhub.js:800
+msgid "Example"
+msgstr "Exemplo"
+
+#: static/js/zamboni/devhub-all.js:2309 static/js/zamboni/devhub-min.js:2 static/js/zamboni/devhub.js:1130
+msgid "Image changes being processed"
+msgstr "As alterações à imagem estão a ser processadas"
+
+#: static/js/zamboni/devhub-all.js:2459 static/js/zamboni/devhub-min.js:2 static/js/zamboni/devhub.js:1280
+msgid "Must be a valid e-mail address."
+msgstr "Tem de ser um endereço de email válido."
+
+#: static/js/zamboni/devhub-all.js:2613 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:80
 msgid "All tests passed successfully."
 msgstr "Todos os testes foram concluídos com sucesso."
 
-#: static/js/zamboni/validator.js:83 static/js/zamboni/validator.js:478
+#: static/js/zamboni/devhub-all.js:2616 static/js/zamboni/devhub-all.js:3011 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:83 static/js/zamboni/validator.js:478
 msgid "These tests were not run."
 msgstr "Estes testes não foram executados."
 
-#: static/js/zamboni/validator.js:131 static/js/zamboni/validator.js:144
+#: static/js/zamboni/devhub-all.js:2664 static/js/zamboni/devhub-all.js:2677 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:131 static/js/zamboni/validator.js:144
 msgid "Tests"
 msgstr "Testes"
 
-#: static/js/zamboni/validator.js:246 static/js/zamboni/validator.js:575 static/js/zamboni/validator.js:594
+#: static/js/zamboni/devhub-all.js:2779 static/js/zamboni/devhub-all.js:3108 static/js/zamboni/devhub-all.js:3127 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:246
+#: static/js/zamboni/validator.js:575 static/js/zamboni/validator.js:594
 msgid "Error"
 msgstr "Erro"
 
-#: static/js/zamboni/validator.js:247
+#: static/js/zamboni/devhub-all.js:2780 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:247
 msgid "Warning"
 msgstr "Aviso"
 
-#: static/js/zamboni/validator.js:299
+#: static/js/zamboni/devhub-all.js:2794 static/js/zamboni/devhub-min.js:2 static/js/zamboni/files-all.js:5657 static/js/zamboni/files-min.js:3 static/js/zamboni/files.js:411
+#: static/js/zamboni/validator.js:261
+msgid "Ignore this message in future updates"
+msgstr "Ignorar esta mensagem em futuras atualizações"
+
+#: static/js/zamboni/devhub-all.js:2817 static/js/zamboni/devhub-min.js:2 static/js/zamboni/files-all.js:5663 static/js/zamboni/files-min.js:3 static/js/zamboni/files.js:417
+#: static/js/zamboni/validator.js:284
+msgid "Severity for automated signing:"
+msgstr "Severidade para assinatura automática:"
+
+#: static/js/zamboni/devhub-all.js:2832 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:299
 msgid "Suggestions for passing automated signing:"
 msgstr "Sugestões para passar a assinatura automática:"
 
-#: static/js/zamboni/validator.js:387
+#: static/js/zamboni/devhub-all.js:2920 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:387
 msgid "Compatibility Tests"
 msgstr "Testes de compatibilidade"
 
-#: static/js/zamboni/validator.js:466
+#: static/js/zamboni/devhub-all.js:2999 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:466
 msgid "Add-on failed validation."
 msgstr "O extra falhou a validação."
 
-#: static/js/zamboni/validator.js:468
+#: static/js/zamboni/devhub-all.js:3001 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:468
 msgid "Add-on passed validation."
 msgstr "O extra passou a validação."
 
-#: static/js/zamboni/validator.js:481
+#: static/js/zamboni/devhub-all.js:3014 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:481
 msgid "{0} error"
 msgid_plural "{0} errors"
 msgstr[0] "{0} erro"
 msgstr[1] "{0} erros"
 
-#: static/js/zamboni/validator.js:483
+#: static/js/zamboni/devhub-all.js:3016 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:483
 msgid "{0} warning"
 msgid_plural "{0} warnings"
 msgstr[0] "{0} aviso"
 msgstr[1] "{0} avisos"
 
-#: static/js/zamboni/validator.js:485
+#: static/js/zamboni/devhub-all.js:3018 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:485
 msgid "{0} notice"
 msgid_plural "{0} notices"
 msgstr[0] "{0} nota"
 msgstr[1] "{0} notas"
 
-#: static/js/zamboni/validator.js:577
+#: static/js/zamboni/devhub-all.js:3110 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:577
 msgid "Validation task could not complete or completed with errors"
 msgstr "A tarefa de validação não foi concluída ou foi concluída com erros"
 
-#: static/js/zamboni/validator.js:595
+#: static/js/zamboni/devhub-all.js:3128 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:595
 msgid "Internal server error"
 msgstr "Erro interno do servidor"
 
-#: static/js/zamboni/mobile/buttons.js:52
+#: static/js/zamboni/devhub_search.js:8
+msgid "No results found."
+msgstr "Não foram encontrados resultados."
+
+#: static/js/zamboni/editors-all.js:15402 static/js/zamboni/editors-min.js:4 static/js/zamboni/editors.js:121
+msgid "{name} was viewing this page first."
+msgstr "{name} estava a ver esta página primeiro."
+
+#: static/js/zamboni/editors-all.js:15452 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:171
+msgid "Receipt checked by app."
+msgstr "Recibo confirmado pela aplicação."
+
+#: static/js/zamboni/editors-all.js:15454 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:173
+msgid "Receipt was not checked by app."
+msgstr "O recibo não foi confirmado pela aplicação."
+
+#: static/js/zamboni/editors-all.js:15525 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:244
+msgid "{name} was viewing this add-on first."
+msgstr "{name} estava a ver este extra primeiro."
+
+#: static/js/zamboni/editors-all.js:15536 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:255
+msgid "Loading&hellip;"
+msgstr "A carregar&hellip;"
+
+#: static/js/zamboni/editors-all.js:15541 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:260
+msgid "Version Notes"
+msgstr "Notas da versão"
+
+#: static/js/zamboni/editors-all.js:15546 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:265
+msgid "Notes for Reviewers"
+msgstr "Notas para os Revisores"
+
+#: static/js/zamboni/editors-all.js:15551 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:270
+msgid "No version notes found"
+msgstr "Não foram encontradas notas para a versão"
+
+#: static/js/zamboni/editors-all.js:15611 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:330
+msgid "Average Reviews"
+msgstr ""
+
+#: static/js/zamboni/editors-all.js:15667 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:386
+msgid "Number of Reviews"
+msgstr ""
+
+#: static/js/zamboni/editors-all.js:15726 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:445
+msgid "Error loading translation"
+msgstr "Erro ao carregar a tradução"
+
+#: static/js/zamboni/editors-all.js:15975 static/js/zamboni/editors-min.js:5 static/js/zamboni/themes_review_templates.js:31
+msgid "Theme"
+msgstr ""
+
+#: static/js/zamboni/editors-all.js:15977 static/js/zamboni/editors-min.js:5 static/js/zamboni/themes_review_templates.js:33
+msgid "Reviewer"
+msgstr ""
+
+#: static/js/zamboni/editors-all.js:15979 static/js/zamboni/editors-min.js:5 static/js/zamboni/themes_review_templates.js:35
+msgid "Status"
+msgstr ""
+
+#: static/js/zamboni/editors-all.js:16196 static/js/zamboni/editors-min.js:5 static/js/zamboni/themes_review.js:176
+msgid "Requested Info"
+msgstr "Informação solicitada"
+
+#: static/js/zamboni/editors-all.js:16197 static/js/zamboni/editors-min.js:5 static/js/zamboni/themes_review.js:177
+msgid "Flagged"
+msgstr "Marcado"
+
+#: static/js/zamboni/editors-all.js:16198 static/js/zamboni/editors-min.js:5 static/js/zamboni/themes_review.js:178
+msgid "Duplicate"
+msgstr "Duplicado"
+
+#: static/js/zamboni/editors-all.js:16199 static/js/zamboni/editors-min.js:5 static/js/zamboni/themes_review.js:179
+msgid "Rejected"
+msgstr "Rejeitado"
+
+#: static/js/zamboni/editors-all.js:16200 static/js/zamboni/editors-min.js:5 static/js/zamboni/themes_review.js:180
+msgid "Approved"
+msgstr "Aprovado"
+
+#: static/js/zamboni/editors-all.js:16444 static/js/zamboni/editors-min.js:5 static/js/zamboni/themes_review.js:424
+msgid "No results found"
+msgstr ""
+
+#: static/js/zamboni/mobile-all.js:15186 static/js/zamboni/mobile/buttons.js:52
 msgid "Not Updated for {0} {1}"
 msgstr "Não atualizado para {0} {1}"
 
-#: static/js/zamboni/mobile/buttons.js:53
+#: static/js/zamboni/mobile-all.js:15187 static/js/zamboni/mobile/buttons.js:53
 msgid "Requires Newer Version of {0}"
 msgstr "Requer uma nova versão de {0}"
 
-#: static/js/zamboni/mobile/buttons.js:54
+#: static/js/zamboni/mobile-all.js:15188 static/js/zamboni/mobile/buttons.js:54
 msgid "Unreviewed"
 msgstr "Não revisto"
 
-#: static/js/zamboni/mobile/buttons.js:55
+#: static/js/zamboni/mobile-all.js:15189 static/js/zamboni/mobile/buttons.js:55
 msgid "Experimental <span>(Learn More)</span>"
 msgstr "Experimental <span>(Saber mais)</span>"
 
-#: static/js/zamboni/mobile/buttons.js:56 static/js/zamboni/mobile/buttons.js:57
+#: static/js/zamboni/mobile-all.js:15190 static/js/zamboni/mobile-all.js:15191 static/js/zamboni/mobile/buttons.js:56 static/js/zamboni/mobile/buttons.js:57
 msgid "Not Available for {0}"
 msgstr "Não disponível para {0}"
 
-#: static/js/zamboni/mobile/buttons.js:58
+#: static/js/zamboni/mobile-all.js:15192 static/js/zamboni/mobile/buttons.js:58
 msgid "Experimental"
 msgstr "Experimental"
 
-#: static/js/zamboni/mobile/buttons.js:59
+#: static/js/zamboni/mobile-all.js:15193 static/js/zamboni/mobile/buttons.js:59
 msgid "Themes Require Newer Version of {0}"
 msgstr "Os temas necessitam de uma nova versão de {0}"
 
-#: static/js/zamboni/mobile/buttons.js:60
+#: static/js/zamboni/mobile-all.js:15194 static/js/zamboni/mobile/buttons.js:60
 msgid "Themes Require {0}"
 msgstr "Os temas necessitam {0}"
 
-#: static/js/zamboni/mobile/buttons.js:105
+#: static/js/zamboni/mobile-all.js:15239 static/js/zamboni/mobile/buttons.js:105
 msgid "Installing..."
 msgstr "A instalar..."
 
-#: static/js/zamboni/mobile/buttons.js:125
+#: static/js/zamboni/mobile-all.js:15259 static/js/zamboni/mobile/buttons.js:125
 msgid "This add-on has been preliminarily reviewed by Mozilla."
 msgstr "Este extra foi revisto preliminarmente pela Mozilla."
 
-#: static/js/zamboni/mobile/buttons.js:250
+#: static/js/zamboni/mobile-all.js:15384 static/js/zamboni/mobile/buttons.js:250
 msgid "Keep it"
 msgstr "Manter"
 
-#: static/js/zamboni/mobile/general.js:344
+#: static/js/zamboni/mobile-all.js:16049 static/js/zamboni/mobile-min.js:6 static/js/zamboni/mobile/general.js:344
 msgid "You're trying it on!"
 msgstr "Está a experimentá-lo!"
 
-#: static/js/zamboni/mobile/general.js:356
+#: static/js/zamboni/mobile-all.js:16061 static/js/zamboni/mobile-min.js:6 static/js/zamboni/mobile/general.js:356
 msgid "Added to Firefox"
 msgstr "Adicionado ao Firefox"
-

--- a/locale/pt_BR/LC_MESSAGES/django.po
+++ b/locale/pt_BR/LC_MESSAGES/django.po
@@ -6,84 +6,72 @@ msgid ""
 msgstr ""
 "Project-Id-Version: REMORA 0.1\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2016-02-24 21:23+0000\n"
+"POT-Creation-Date: 2016-04-18 15:47+0000\n"
 "PO-Revision-Date: 2016-04-12 17:24+0000\n"
 "Last-Translator: Marco Aurélio <fxhelp@yahoo.com>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
-"Language: pt_BR\n"
+"Language: \n"
 "MIME-Version: 1.0\n"
-"Content-Type: text/plain; charset=utf-8\n"
+"Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n > 1);\n"
 "Generated-By: Babel 2.2.0\n"
-"X-Generator: Pontoon\n"
-
-#: src/olympia/accounts/views.py:52
-msgid "Your log in attempt could not be parsed. Please try again."
-msgstr ""
-"A sua tentativa de entrar não pôde ser analisada. Por favor, tente "
-"novamente."
 
 #: src/olympia/accounts/views.py:54
-msgid "Your Firefox Account could not be found. Please try again."
-msgstr ""
-"A sua conta Firefox não pôde ser encontrada. Por favor, tente novamente."
+msgid "Your log in attempt could not be parsed. Please try again."
+msgstr "A sua tentativa de entrar não pôde ser analisada. Por favor, tente novamente."
 
-#: src/olympia/accounts/views.py:55
+#: src/olympia/accounts/views.py:56
+msgid "Your Firefox Account could not be found. Please try again."
+msgstr "A sua conta Firefox não pôde ser encontrada. Por favor, tente novamente."
+
+#: src/olympia/accounts/views.py:57
 msgid "You could not be logged in. Please try again."
 msgstr "Não pôde entrar. Por favor, tente novamente."
 
-#: src/olympia/accounts/views.py:57
+#: src/olympia/accounts/views.py:59
 msgid "Your account has already been migrated to Firefox Accounts."
 msgstr "A sua conta já foi migrada para a conta Firefox."
 
-#: src/olympia/accounts/views.py:59
+#: src/olympia/accounts/views.py:61
 msgid "Your Firefox Account already exists on this site."
 msgstr "A sua conta Firefox já existe neste site."
 
-#: src/olympia/accounts/views.py:108
+#: src/olympia/accounts/views.py:110
 msgid "Great job!"
 msgstr "Bom trabalho!"
 
-#: src/olympia/accounts/views.py:109
+#: src/olympia/accounts/views.py:111
 msgid "You can now log in to Add-ons with your Firefox Account."
 msgstr "Agora poderá entrar com a sua conta Firefox."
 
-#: src/olympia/accounts/views.py:121
+#: src/olympia/accounts/views.py:123
 msgid "Need help?"
 msgstr "Precisa de ajuda?"
 
 # This is the text that appears on buttons to download add-ons.
-#: src/olympia/addons/buttons.py:180
+#: src/olympia/addons/buttons.py:177
 msgid "Download Now"
 msgstr "Baixar agora"
 
-#: src/olympia/addons/buttons.py:182
+#: src/olympia/addons/buttons.py:179
 msgid "Download"
 msgstr "Baixar"
 
 #. L10n: please keep &nbsp; in the string so &rarr; does not wrap.
-#: src/olympia/addons/buttons.py:186
+#: src/olympia/addons/buttons.py:183
 msgid "Continue to Download&nbsp;&rarr;"
 msgstr "Ir para download&nbsp;&rarr;"
 
-#: src/olympia/addons/buttons.py:202 src/olympia/addons/helpers.py:35
-#: src/olympia/addons/views.py:319
-#: src/olympia/addons/templates/addons/impala/details.html:114
-#: src/olympia/addons/templates/addons/impala/listing/items.html:17
-#: src/olympia/addons/templates/addons/mobile/home.html:40
-#: src/olympia/amo/templates/amo/side_nav.html:6
-#: src/olympia/amo/templates/amo/side_nav.html:10
-#: src/olympia/amo/templates/amo/site_nav.html:2
-#: src/olympia/amo/templates/amo/site_nav.html:55
-#: src/olympia/bandwagon/views.py:95 src/olympia/browse/views.py:54
-#: src/olympia/browse/views.py:68 src/olympia/browse/views.py:235
-#: src/olympia/browse/templates/browse/impala/category_landing.html:22
+#: src/olympia/addons/buttons.py:199 src/olympia/addons/helpers.py:35 src/olympia/addons/views.py:333 src/olympia/addons/templates/addons/impala/details.html:111
+#: src/olympia/addons/templates/addons/impala/listing/items.html:17 src/olympia/addons/templates/addons/mobile/home.html:40 src/olympia/amo/templates/amo/side_nav.html:6
+#: src/olympia/amo/templates/amo/side_nav.html:10 src/olympia/amo/templates/amo/site_nav.html:2 src/olympia/amo/templates/amo/site_nav.html:53 src/olympia/bandwagon/views.py:95
+#: src/olympia/browse/views.py:54 src/olympia/browse/views.py:68 src/olympia/browse/views.py:202 src/olympia/browse/templates/browse/impala/category_landing.html:22
 #: src/olympia/browse/templates/browse/personas/mobile/category_landing.html:26
 msgid "Featured"
 msgstr "Em destaque"
 
-#: src/olympia/addons/buttons.py:221
+#: src/olympia/addons/buttons.py:218
 msgid "Add to {0}"
 msgstr "Adicionar ao {0}"
 
@@ -122,11 +110,8 @@ msgstr[1] "Você tem {0} etiquetas em excesso."
 
 #: src/olympia/addons/forms.py:117
 #, python-format
-msgid ""
-"All tags must be %s characters or less after invalid characters are removed."
-msgstr ""
-"Todas as etiquetas devem ter %s caracteres ou menos após os caracteres "
-"inválidos serem removidos."
+msgid "All tags must be %s characters or less after invalid characters are removed."
+msgstr "Todas as etiquetas devem ter %s caracteres ou menos após os caracteres inválidos serem removidos."
 
 #: src/olympia/addons/forms.py:121
 msgid "All tags must be at least {0} character."
@@ -134,49 +119,39 @@ msgid_plural "All tags must be at least {0} characters."
 msgstr[0] "Todas as etiquetas devem ter pelo menos {0} caractere."
 msgstr[1] "Todas as etiquetas devem ter pelo menos {0} caracteres."
 
-#: src/olympia/addons/forms.py:234
-msgid ""
-"Categories cannot be changed while your add-on is featured for this "
-"application."
-msgstr ""
-"As categorias não podem ser alteradas enquanto seu complemento é destaque "
-"para este aplicativo."
+#: src/olympia/addons/forms.py:238
+msgid "Categories cannot be changed while your add-on is featured for this application."
+msgstr "As categorias não podem ser alteradas enquanto seu complemento é destaque para este aplicativo."
 
 #. L10n: {0} is the number of categories.
-#: src/olympia/addons/forms.py:238
+#: src/olympia/addons/forms.py:242
 msgid "You can have only {0} category."
 msgid_plural "You can have only {0} categories."
 msgstr[0] "Você pode ter apenas {0} categoria."
 msgstr[1] "Você pode ter apenas {0} categorias."
 
-#: src/olympia/addons/forms.py:246
-msgid ""
-"The miscellaneous category cannot be combined with additional categories."
+#: src/olympia/addons/forms.py:250
+msgid "The miscellaneous category cannot be combined with additional categories."
 msgstr "A categoria diversos não pode ser combinada com outras categorias."
 
-#: src/olympia/addons/forms.py:369
+#: src/olympia/addons/forms.py:374
 #, python-format
-msgid ""
-"Before changing your default locale you must have a name, summary, and "
-"description in that locale. You are missing %s."
-msgstr ""
-"Antes de alterar o idioma padrão você deve ter um nome, resumo e descrição "
-"no novo idioma. Você esqueceu de %s."
+msgid "Before changing your default locale you must have a name, summary, and description in that locale. You are missing %s."
+msgstr "Antes de alterar o idioma padrão você deve ter um nome, resumo e descrição no novo idioma. Você esqueceu de %s."
 
-#: src/olympia/addons/forms.py:484 src/olympia/addons/forms.py:575
+#: src/olympia/addons/forms.py:455 src/olympia/addons/forms.py:546
 msgid "A license must be selected."
 msgstr "Você deve selecionar uma licença."
 
-#: src/olympia/addons/forms.py:556
+#: src/olympia/addons/forms.py:527
 msgid "Give Your Theme a Name."
 msgstr "Dê um nome para o seu tema."
 
-#: src/olympia/addons/forms.py:562
-#: src/olympia/devhub/templates/devhub/personas/submit.html:53
+#: src/olympia/addons/forms.py:533 src/olympia/devhub/templates/devhub/personas/submit.html:53
 msgid "Describe your Theme."
 msgstr "Descreva seu tema."
 
-#: src/olympia/addons/forms.py:704
+#: src/olympia/addons/forms.py:675
 msgid "Enter a new author's email address"
 msgstr "Insira um endereço de e-mail do novo autor"
 
@@ -184,50 +159,39 @@ msgstr "Insira um endereço de e-mail do novo autor"
 msgid "Not Reviewed"
 msgstr "Não analisado"
 
-#: src/olympia/addons/models.py:301
+#: src/olympia/addons/models.py:298
 msgid "Users have the option of contributing more or less than this amount."
-msgstr ""
-"Os usuários podem optar por contribuir com um valor maior ou menor que essa "
-"quantia."
+msgstr "Os usuários podem optar por contribuir com um valor maior ou menor que essa quantia."
 
-#: src/olympia/addons/models.py:309
-msgid ""
-"Users will always be asked in the Add-ons Manager (Firefox 4 and above)"
+#: src/olympia/addons/models.py:306
+msgid "Users will always be asked in the Add-ons Manager (Firefox 4 and above). Only applies to desktop."
 msgstr ""
-"Os usuários sempre serão consultados no Gerenciador de Complementos (Firefox"
-" 4 ou superiores)"
 
 # Column name in a table.
-#: src/olympia/addons/models.py:1804
-#: src/olympia/addons/templates/addons/details_box.html:55
-#: src/olympia/devhub/templates/devhub/index.html:92
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:102
+#: src/olympia/addons/models.py:1802 src/olympia/addons/templates/addons/details_box.html:55 src/olympia/devhub/templates/devhub/index.html:92
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:89
 msgid "Listed"
 msgstr "Listado"
 
-#: src/olympia/addons/views.py:320
-#: src/olympia/browse/templates/browse/personas/mobile/category_landing.html:27
+#: src/olympia/addons/views.py:334 src/olympia/browse/templates/browse/personas/mobile/category_landing.html:27
 msgid "Popular"
 msgstr "Populares"
 
-#: src/olympia/addons/views.py:321 src/olympia/browse/views.py:238
-#: src/olympia/browse/views.py:280 src/olympia/browse/views.py:482
+#: src/olympia/addons/views.py:335 src/olympia/browse/views.py:205 src/olympia/browse/views.py:247 src/olympia/browse/views.py:449
 msgid "Recently Added"
 msgstr "Adicionados recentemente"
 
-#: src/olympia/addons/views.py:322 src/olympia/bandwagon/views.py:99
-#: src/olympia/browse/views.py:60 src/olympia/browse/views.py:71
-#: src/olympia/search/forms.py:16 src/olympia/search/forms.py:91
+#: src/olympia/addons/views.py:336 src/olympia/bandwagon/views.py:99 src/olympia/browse/views.py:60 src/olympia/browse/views.py:71 src/olympia/search/forms.py:16 src/olympia/search/forms.py:91
 msgid "Recently Updated"
 msgstr "Atualizados recentemente"
 
-#. l10n: {0} is the addon name
 # %1 is an add-on name.
-#: src/olympia/addons/views.py:520
+#. l10n: {0} is the addon name
+#: src/olympia/addons/views.py:534
 msgid "Contribution for {0}"
 msgstr "Contribuição para {0}"
 
-#: src/olympia/addons/views.py:613
+#: src/olympia/addons/views.py:627
 msgid "Abuse reported."
 msgstr "Abuso denunciado."
 
@@ -235,116 +199,70 @@ msgstr "Abuso denunciado."
 msgid "My add-on doesn't fit into any of the categories"
 msgstr "Meu complemento não se enquadra em nenhuma das categorias"
 
-#: src/olympia/addons/templates/addons/button.html:27
-#: src/olympia/addons/templates/addons/impala/button.html:11
-#: src/olympia/addons/templates/addons/mobile/button.html:11
+#: src/olympia/addons/templates/addons/button.html:27 src/olympia/addons/templates/addons/impala/button.html:11 src/olympia/addons/templates/addons/mobile/button.html:11
 msgid "No compatible versions"
 msgstr "Nenhuma versão compatível"
 
-#: src/olympia/addons/templates/addons/button.html:35
-#: src/olympia/addons/templates/addons/impala/button.html:19
+#: src/olympia/addons/templates/addons/button.html:35 src/olympia/addons/templates/addons/impala/button.html:19
 msgid "Added to Mobile"
 msgstr "Adicionado ao Firefox Móvel"
 
-#: src/olympia/addons/templates/addons/button.html:37
-#: src/olympia/addons/templates/addons/impala/button.html:21
+#: src/olympia/addons/templates/addons/button.html:37 src/olympia/addons/templates/addons/impala/button.html:21
 msgid "Add to Mobile"
 msgstr "Adicionar ao Firefox Móvel"
 
 #. {0} is a platform name like Windows or Mac OS X.
-#: src/olympia/addons/templates/addons/button.html:66
-#: src/olympia/addons/templates/addons/includes/install_button.html:19
+#: src/olympia/addons/templates/addons/button.html:66 src/olympia/addons/templates/addons/includes/install_button.html:19
 msgid "for {0}"
 msgstr "para {0}"
 
-#: src/olympia/addons/templates/addons/button.html:82
-#: src/olympia/addons/templates/addons/mobile/button.html:23
+#: src/olympia/addons/templates/addons/button.html:82 src/olympia/addons/templates/addons/mobile/button.html:23
 msgid "View privacy policy"
 msgstr "Ver a política de privacidade"
 
-#: src/olympia/addons/templates/addons/button.html:87
-#: src/olympia/addons/templates/addons/details_box.html:133
-#: src/olympia/addons/templates/addons/mobile/button.html:28
+#: src/olympia/addons/templates/addons/button.html:87 src/olympia/addons/templates/addons/details_box.html:133 src/olympia/addons/templates/addons/mobile/button.html:28
 #: src/olympia/discovery/templates/discovery/addons/detail.html:28
 msgid "View End-User License Agreement"
 msgstr "Ver contrato de licença de usuário final"
 
-#: src/olympia/addons/templates/addons/button.html:92
-#: src/olympia/addons/templates/addons/impala/button.html:54
+#: src/olympia/addons/templates/addons/button.html:92 src/olympia/addons/templates/addons/impala/button.html:54
 #, python-format
-msgid ""
-"This add-on has not been reviewed by Mozilla. <a href=\"%(url)s\">Learn "
-"more</a>"
-msgstr ""
-"Esse complemento não foi analisado pela Mozilla. <a href=\"%(url)s\">Saiba "
-"mais</a>"
+msgid "This add-on has not been reviewed by Mozilla. <a href=\"%(url)s\">Learn more</a>"
+msgstr "Esse complemento não foi analisado pela Mozilla. <a href=\"%(url)s\">Saiba mais</a>"
 
-#: src/olympia/addons/templates/addons/button.html:97
-#: src/olympia/addons/templates/addons/impala/button.html:60
+#: src/olympia/addons/templates/addons/button.html:97 src/olympia/addons/templates/addons/impala/button.html:60
 #, python-format
-msgid ""
-"This add-on has been preliminarily reviewed by Mozilla. <a "
-"href=\"%(url)s\">Learn more</a>"
-msgstr ""
-"Esse complemento foi analisado preliminarmente pela Mozilla. <a "
-"href=\"%(url)s\">Saiba mais</a>"
+msgid "This add-on has been preliminarily reviewed by Mozilla. <a href=\"%(url)s\">Learn more</a>"
+msgstr "Esse complemento foi analisado preliminarmente pela Mozilla. <a href=\"%(url)s\">Saiba mais</a>"
 
-#: src/olympia/addons/templates/addons/contribution.html:11
-#: src/olympia/addons/templates/addons/impala/developers.html:44
-msgid ""
-"The developer of this add-on asks that you help support its continued "
-"development by making a small contribution."
-msgstr ""
-"O desenvolvedor deste complemento pede que o ajude na continuação do "
-"desenvolvimento, fazendo uma pequena contribuição."
+#: src/olympia/addons/templates/addons/contribution.html:11 src/olympia/addons/templates/addons/impala/developers.html:44
+msgid "The developer of this add-on asks that you help support its continued development by making a small contribution."
+msgstr "O desenvolvedor deste complemento pede que o ajude na continuação do desenvolvimento, fazendo uma pequena contribuição."
 
 #: src/olympia/addons/templates/addons/contribution.html:14
 #, python-format
-msgid ""
-"The developer of this add-on asks that you show your support by making a "
-"donation to the <a href=\"%(charity_url)s\">%(charity_name)s</a>."
-msgstr ""
-"O desenvolvedor deste complemento pede que mostre o seu apoio fazendo uma "
-"doação para <a href=\"%(charity_url)s\">%(charity_name)s</a>."
+msgid "The developer of this add-on asks that you show your support by making a donation to the <a href=\"%(charity_url)s\">%(charity_name)s</a>."
+msgstr "O desenvolvedor deste complemento pede que mostre o seu apoio fazendo uma doação para <a href=\"%(charity_url)s\">%(charity_name)s</a>."
 
 #: src/olympia/addons/templates/addons/contribution.html:19
 #, python-format
-msgid ""
-"The developer of this add-on asks that you show your support by making a "
-"small contribution to <a href=\"%(charity_url)s\">%(charity_name)s</a>."
-msgstr ""
-"O desenvolvedor desse complemento pede que mostre o seu apoio, fazendo uma "
-"pequena contribuição para <a href=\"%(charity_url)s\">%(charity_name)s</a>."
+msgid "The developer of this add-on asks that you show your support by making a small contribution to <a href=\"%(charity_url)s\">%(charity_name)s</a>."
+msgstr "O desenvolvedor desse complemento pede que mostre o seu apoio, fazendo uma pequena contribuição para <a href=\"%(charity_url)s\">%(charity_name)s</a>."
 
-#: src/olympia/addons/templates/addons/contribution.html:30
-#: src/olympia/addons/templates/addons/impala/contribution.html:18
-#: src/olympia/templates/menu_links.html:25
+#: src/olympia/addons/templates/addons/contribution.html:30 src/olympia/addons/templates/addons/impala/contribution.html:18 src/olympia/templates/menu_links.html:25
 msgid "Contribute"
 msgstr "Contribuir"
 
-#. Click Contribute button OR Install button
 # This is a separator between the graphical [contribute] button and the
 # graphical [download now] button
-#: src/olympia/addons/templates/addons/contribution.html:34
-#: src/olympia/addons/templates/addons/report_abuse.html:26
-#: src/olympia/addons/templates/addons/impala/contribution.html:32
-#: src/olympia/devhub/templates/devhub/addons/ajax_compat_update.html:36
-#: src/olympia/devhub/templates/devhub/addons/profile.html:44
-#: src/olympia/devhub/templates/devhub/addons/edit/admin.html:101
-#: src/olympia/devhub/templates/devhub/addons/edit/basic.html:152
-#: src/olympia/devhub/templates/devhub/addons/edit/details.html:85
-#: src/olympia/devhub/templates/devhub/addons/edit/support.html:67
-#: src/olympia/devhub/templates/devhub/addons/edit/technical.html:166
-#: src/olympia/devhub/templates/devhub/addons/forms_shared/media.html:149
-#: src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:44
-#: src/olympia/devhub/templates/devhub/versions/add_file_modal.html:78
-#: src/olympia/devhub/templates/devhub/versions/edit.html:139
-#: src/olympia/devhub/templates/devhub/versions/list.html:242
-#: src/olympia/devhub/templates/devhub/versions/list.html:276
-#: src/olympia/devhub/templates/devhub/versions/list.html:317
-#: src/olympia/devhub/templates/devhub/versions/list.html:351
-#: src/olympia/reviews/templates/reviews/edit_review.html:16
-#: src/olympia/translations/templates/translations/trans-menu.html:50
+#. Click Contribute button OR Install button
+#: src/olympia/addons/templates/addons/contribution.html:34 src/olympia/addons/templates/addons/report_abuse.html:26 src/olympia/addons/templates/addons/impala/contribution.html:32
+#: src/olympia/devhub/templates/devhub/addons/ajax_compat_update.html:36 src/olympia/devhub/templates/devhub/addons/profile.html:44 src/olympia/devhub/templates/devhub/addons/edit/admin.html:101
+#: src/olympia/devhub/templates/devhub/addons/edit/basic.html:152 src/olympia/devhub/templates/devhub/addons/edit/details.html:85 src/olympia/devhub/templates/devhub/addons/edit/support.html:67
+#: src/olympia/devhub/templates/devhub/addons/edit/technical.html:166 src/olympia/devhub/templates/devhub/addons/forms_shared/media.html:149
+#: src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:43 src/olympia/devhub/templates/devhub/versions/add_file_modal.html:58 src/olympia/devhub/templates/devhub/versions/edit.html:139
+#: src/olympia/devhub/templates/devhub/versions/list.html:239 src/olympia/devhub/templates/devhub/versions/list.html:281 src/olympia/devhub/templates/devhub/versions/list.html:315
+#: src/olympia/devhub/templates/devhub/versions/list.html:349 src/olympia/reviews/templates/reviews/edit_review.html:16 src/olympia/translations/templates/translations/trans-menu.html:50
 #: src/olympia/translations/templates/translations/trans-menu.html:62
 msgid "or"
 msgstr "ou"
@@ -356,41 +274,23 @@ msgid "Suggested Contribution: {0}"
 msgstr "Contribuição sugerida: {0}"
 
 # 100%
-#: src/olympia/addons/templates/addons/contribution.html:48
-#: src/olympia/amo/templates/amo/recaptcha.html:5
-#: src/olympia/versions/templates/versions/version.html:52
+#: src/olympia/addons/templates/addons/contribution.html:48 src/olympia/amo/templates/amo/recaptcha.html:5 src/olympia/versions/templates/versions/version.html:52
 msgid "What's this?"
 msgstr "O que é isso?"
 
 #: src/olympia/addons/templates/addons/contribution.html:63
 #, python-format
-msgid ""
-"The developer of this add-on would like you to consider making a donation to"
-" the <a href=\"%(charity_url)s\">%(charity_name)s</a> if you enjoy using it."
-msgstr ""
-"O desenvolvedor desse complemento gostaria que considerasse fazer uma doação"
-" para <a href=\"%(charity_url)s\">%(charity_name)s</a> caso goste de usá-lo."
+msgid "The developer of this add-on would like you to consider making a donation to the <a href=\"%(charity_url)s\">%(charity_name)s</a> if you enjoy using it."
+msgstr "O desenvolvedor desse complemento gostaria que considerasse fazer uma doação para <a href=\"%(charity_url)s\">%(charity_name)s</a> caso goste de usá-lo."
 
 #: src/olympia/addons/templates/addons/contribution.html:69
 #, python-format
-msgid ""
-"The developer of this add-on would like you to consider making a small "
-"contribution to <a href=\"%(charity_url)s\">%(charity_name)s</a> if you "
-"enjoy using it."
-msgstr ""
-"O desenvolvedor desse complemento gostaria que considerasse fazer uma "
-"pequena contribuição para <a href=\"%(charity_url)s\">%(charity_name)s</a> "
-"caso goste de usá-lo."
+msgid "The developer of this add-on would like you to consider making a small contribution to <a href=\"%(charity_url)s\">%(charity_name)s</a> if you enjoy using it."
+msgstr "O desenvolvedor desse complemento gostaria que considerasse fazer uma pequena contribuição para <a href=\"%(charity_url)s\">%(charity_name)s</a> caso goste de usá-lo."
 
 #: src/olympia/addons/templates/addons/contribution.html:76
-msgid ""
-"Mozilla is committed to supporting a vibrant and healthy developer "
-"ecosystem. Your optional contribution helps sustain further development of "
-"this add-on."
-msgstr ""
-"A Mozilla está comprometida com o desenvolvimento de um ecossistema de "
-"desenvolvedores saudável e vibrante. Sua doação pode contribuir para o "
-"desenvolvimento deste complemento."
+msgid "Mozilla is committed to supporting a vibrant and healthy developer ecosystem. Your optional contribution helps sustain further development of this add-on."
+msgstr "A Mozilla está comprometida com o desenvolvimento de um ecossistema de desenvolvedores saudável e vibrante. Sua doação pode contribuir para o desenvolvimento deste complemento."
 
 #: src/olympia/addons/templates/addons/contributions_lightbox.html:5
 msgid "Make a Contribution"
@@ -398,36 +298,23 @@ msgstr "Fazer uma contribuição"
 
 #: src/olympia/addons/templates/addons/contributions_lightbox.html:9
 #, python-format
-msgid ""
-"Help support the continued development of <strong>%(addon_name)s</strong> by"
-" making a small contribution through <a href=\"%(paypal_url)s\">PayPal</a>."
-msgstr ""
-"Ajude no desenvolvimento contínuo de <strong>%(addon_name)s</strong> fazendo"
-" uma pequena contribuição usando o <a href=\"%(paypal_url)s\">PayPal</a>."
+msgid "Help support the continued development of <strong>%(addon_name)s</strong> by making a small contribution through <a href=\"%(paypal_url)s\">PayPal</a>."
+msgstr "Ajude no desenvolvimento contínuo de <strong>%(addon_name)s</strong> fazendo uma pequena contribuição usando o <a href=\"%(paypal_url)s\">PayPal</a>."
 
 #: src/olympia/addons/templates/addons/contributions_lightbox.html:15
 #, python-format
 msgid ""
-"To show your support for <b>%(addon_name)s</b>, the developer asks that you "
-"make a donation to the <a href=\"%(charity_url)s\">%(charity_name)s</a> "
-"through <a href=\"%(paypal_url)s\">PayPal</a>."
-msgstr ""
-"Para mostrar o seu apoio a <b>%(addon_name)s</b>, o desenvolvedor solicita "
-"uma doação para <a href=\"%(charity_url)s\">%(charity_name)s</a> usando o <a"
-" href=\"%(paypal_url)s\">PayPal</a>."
+"To show your support for <b>%(addon_name)s</b>, the developer asks that you make a donation to the <a href=\"%(charity_url)s\">%(charity_name)s</a> through <a href=\"%(paypal_url)s\">PayPal</a>."
+msgstr "Para mostrar o seu apoio a <b>%(addon_name)s</b>, o desenvolvedor solicita uma doação para <a href=\"%(charity_url)s\">%(charity_name)s</a> usando o <a href=\"%(paypal_url)s\">PayPal</a>."
 
 #: src/olympia/addons/templates/addons/contributions_lightbox.html:21
 #, python-format
 msgid ""
-"To show your support for <b>%(addon_name)s</b>, the developer asks that you "
-"make a small contribution to <a "
-"href=\"%(charity_url)s\">%(charity_name)s</a> through <a "
-"href=\"%(paypal_url)s\">PayPal</a>."
+"To show your support for <b>%(addon_name)s</b>, the developer asks that you make a small contribution to <a href=\"%(charity_url)s\">%(charity_name)s</a> through <a href=\"%(paypal_url)s\">PayPal</"
+"a>."
 msgstr ""
-"Para mostrar o seu apoio a <b>%(addon_name)s</b>, o desenvolvedor solicita "
-"que faça uma pequena contribuição para <a "
-"href=\"%(charity_url)s\">%(charity_name)s</a> usando o <a "
-"href=\"%(paypal_url)s\">PayPal</a>."
+"Para mostrar o seu apoio a <b>%(addon_name)s</b>, o desenvolvedor solicita que faça uma pequena contribuição para <a href=\"%(charity_url)s\">%(charity_name)s</a> usando o <a href=\"%(paypal_url)s"
+"\">PayPal</a>."
 
 #: src/olympia/addons/templates/addons/contributions_lightbox.html:30
 msgid "How much would you like to contribute?"
@@ -450,8 +337,7 @@ msgstr "O valor da contribuição deve ser um número."
 msgid "A one-time suggested contribution of {0}"
 msgstr "Uma contribuição única no valor sugerido de {0}"
 
-#. {0} is a currency symbol (e.g., $),                    {1} is an amount
-#. input
+#. {0} is a currency symbol (e.g., $),                    {1} is an amount input
 #. field
 #: src/olympia/addons/templates/addons/contributions_lightbox.html:64
 msgid "A one-time contribution of {0} {1}"
@@ -461,11 +347,8 @@ msgstr "Uma contribuição única de {0} {1}"
 msgid "Leave a comment or request with your contribution."
 msgstr "Deixe um comentário ou pedido com a sua contribuição."
 
-#: src/olympia/addons/templates/addons/contributions_lightbox.html:74
-#: src/olympia/bandwagon/templates/bandwagon/ajax_new.html:20
-#: src/olympia/bandwagon/templates/bandwagon/includes/addedit.html:37
-#: src/olympia/reviews/templates/reviews/mobile/add_form.html:13
-#: src/olympia/templates/includes/forms.html:10
+#: src/olympia/addons/templates/addons/contributions_lightbox.html:74 src/olympia/bandwagon/templates/bandwagon/ajax_new.html:20 src/olympia/bandwagon/templates/bandwagon/includes/addedit.html:37
+#: src/olympia/reviews/templates/reviews/mobile/add_form.html:13 src/olympia/templates/includes/forms.html:10
 msgid "(optional)"
 msgstr "(opcional)"
 
@@ -485,36 +368,27 @@ msgstr "Não, obrigado"
 msgid "Contribution made, thank you."
 msgstr "Contribuição efetuada, obrigado."
 
-#: src/olympia/addons/templates/addons/details_box.html:10
-#: src/olympia/discovery/templates/discovery/addons/detail.html:19
+#: src/olympia/addons/templates/addons/details_box.html:10 src/olympia/discovery/templates/discovery/addons/detail.html:19
 msgid "No restart required"
 msgstr "Não é necessário reiniciar"
 
 #. This is a caption for a table. {0} is an add-on name.
-#: src/olympia/addons/templates/addons/details_box.html:26
-#: src/olympia/addons/templates/addons/includes/persona.html:9
+#: src/olympia/addons/templates/addons/details_box.html:26 src/olympia/addons/templates/addons/includes/persona.html:9
 msgid "Add-on Information for {0}"
 msgstr "Informações do complemento {0}"
 
-#: src/olympia/addons/templates/addons/details_box.html:30
-#: src/olympia/addons/templates/addons/persona_detail_table.html:3
-#: src/olympia/addons/templates/addons/mobile/details.html:63
-#: src/olympia/addons/templates/addons/mobile/persona_detail_table.html:7
-#: src/olympia/browse/views.py:459 src/olympia/devhub/views.py:75
+#: src/olympia/addons/templates/addons/details_box.html:30 src/olympia/addons/templates/addons/persona_detail_table.html:3 src/olympia/addons/templates/addons/mobile/details.html:63
+#: src/olympia/addons/templates/addons/mobile/persona_detail_table.html:7 src/olympia/browse/views.py:426 src/olympia/devhub/views.py:73
 msgid "Updated"
 msgstr "Atualizado"
 
-#: src/olympia/addons/templates/addons/details_box.html:38
-#: src/olympia/addons/templates/addons/mobile/details.html:71
-#: src/olympia/devhub/templates/devhub/addons/edit/support.html:43
+#: src/olympia/addons/templates/addons/details_box.html:38 src/olympia/addons/templates/addons/mobile/details.html:71 src/olympia/devhub/templates/devhub/addons/edit/support.html:43
 #: src/olympia/discovery/templates/discovery/addons/detail.html:77
 msgid "Website"
 msgstr "Site"
 
 #. This refers to this version's compatible applications, such as Firefox 8.0
-#: src/olympia/addons/templates/addons/details_box.html:47
-#: src/olympia/addons/templates/addons/mobile/details.html:80
-#: src/olympia/search/templates/search/results.html:72
+#: src/olympia/addons/templates/addons/details_box.html:47 src/olympia/addons/templates/addons/mobile/details.html:80 src/olympia/search/templates/search/results.html:72
 #: src/olympia/versions/templates/versions/version.html:21
 msgid "Works with"
 msgstr "Funciona com"
@@ -523,45 +397,30 @@ msgstr "Funciona com"
 msgid "Visibility"
 msgstr "Visibilidade"
 
-#: src/olympia/addons/templates/addons/details_box.html:57
-#: src/olympia/devhub/templates/devhub/index.html:94
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:104
+#: src/olympia/addons/templates/addons/details_box.html:57 src/olympia/devhub/templates/devhub/index.html:94 src/olympia/devhub/templates/devhub/includes/addon_details.html:91
 msgid "Hidden"
 msgstr "Oculto"
 
-#: src/olympia/addons/templates/addons/details_box.html:59
-#: src/olympia/devhub/templates/devhub/index.html:96
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:106
+#: src/olympia/addons/templates/addons/details_box.html:59 src/olympia/devhub/templates/devhub/index.html:96 src/olympia/devhub/templates/devhub/includes/addon_details.html:93
 msgid "Unlisted"
 msgstr "Não listado"
 
-#: src/olympia/addons/templates/addons/details_box.html:67
-#: src/olympia/devhub/templates/devhub/addons/edit/technical.html:44
+#: src/olympia/addons/templates/addons/details_box.html:67 src/olympia/devhub/templates/devhub/addons/edit/technical.html:44
 msgid "Required Add-ons"
 msgstr "Complementos requeridos"
 
-#: src/olympia/addons/templates/addons/details_box.html:81
-#: src/olympia/addons/templates/addons/persona_detail_table.html:15
-#: src/olympia/browse/views.py:462 src/olympia/devhub/views.py:78
-#: src/olympia/devhub/views.py:85
-#: src/olympia/discovery/templates/discovery/addons/detail.html:57
-#: src/olympia/reviews/forms.py:62
-#: src/olympia/reviews/templates/reviews/add.html:57
+#: src/olympia/addons/templates/addons/details_box.html:81 src/olympia/addons/templates/addons/persona_detail_table.html:15 src/olympia/browse/views.py:429 src/olympia/devhub/views.py:76
+#: src/olympia/devhub/views.py:83 src/olympia/discovery/templates/discovery/addons/detail.html:57 src/olympia/reviews/forms.py:62 src/olympia/reviews/templates/reviews/add.html:57
 #: src/olympia/reviews/templates/reviews/mobile/review_list.html:18
 msgid "Rating"
 msgstr "Avaliação"
 
-#: src/olympia/addons/templates/addons/details_box.html:85
-#: src/olympia/browse/views.py:461 src/olympia/devhub/views.py:77
-#: src/olympia/devhub/views.py:84
-#: src/olympia/stats/templates/stats/addon_report_menu.html:8
-#: src/olympia/stats/templates/stats/collection_report_menu.html:18
+#: src/olympia/addons/templates/addons/details_box.html:85 src/olympia/browse/views.py:428 src/olympia/devhub/views.py:75 src/olympia/devhub/views.py:82
+#: src/olympia/stats/templates/stats/addon_report_menu.html:8 src/olympia/stats/templates/stats/collection_report_menu.html:18
 msgid "Downloads"
 msgstr "Downloads"
 
-#: src/olympia/addons/templates/addons/details_box.html:91
-#: src/olympia/addons/templates/addons/details_box.html:103
-#: src/olympia/devhub/templates/devhub/addons/listing/item_actions_theme.html:17
+#: src/olympia/addons/templates/addons/details_box.html:91 src/olympia/addons/templates/addons/details_box.html:103 src/olympia/devhub/templates/devhub/addons/listing/item_actions_theme.html:17
 #: src/olympia/devhub/templates/devhub/personas/edit.html:60
 msgid "View Statistics"
 msgstr "Ver estatísticas"
@@ -575,18 +434,13 @@ msgid "Abuse Reports"
 msgstr "Denúncias de abuso"
 
 #. The Privacy Policy for this add-on.
-#: src/olympia/addons/templates/addons/details_box.html:121
-#: src/olympia/addons/templates/addons/privacy.html:19
-#: src/olympia/addons/templates/addons/privacy.html:23
-#: src/olympia/addons/templates/addons/impala/button.html:43
-#: src/olympia/addons/templates/addons/impala/details.html:307
-#: src/olympia/devhub/templates/devhub/includes/policy_form.html:20
+#: src/olympia/addons/templates/addons/details_box.html:121 src/olympia/addons/templates/addons/privacy.html:19 src/olympia/addons/templates/addons/privacy.html:23
+#: src/olympia/addons/templates/addons/impala/button.html:43 src/olympia/addons/templates/addons/impala/details.html:312 src/olympia/devhub/templates/devhub/includes/policy_form.html:23
 #: src/olympia/templates/mobile/base_addons.html:87
 msgid "Privacy Policy"
 msgstr "Política de privacidade"
 
-#: src/olympia/addons/templates/addons/details_box.html:124
-#: src/olympia/discovery/templates/discovery/addons/detail.html:24
+#: src/olympia/addons/templates/addons/details_box.html:124 src/olympia/discovery/templates/discovery/addons/detail.html:24
 msgid "View Privacy Policy"
 msgstr "Ver a política de privacidade"
 
@@ -594,8 +448,7 @@ msgstr "Ver a política de privacidade"
 msgid "EULA"
 msgstr "Licença"
 
-#: src/olympia/addons/templates/addons/details_box.html:171
-#: src/olympia/addons/templates/addons/details_box.html:231
+#: src/olympia/addons/templates/addons/details_box.html:171 src/olympia/addons/templates/addons/details_box.html:231
 msgid "More about this add-on"
 msgstr "Mais sobre esse complemento"
 
@@ -603,27 +456,21 @@ msgstr "Mais sobre esse complemento"
 msgid "Image Gallery"
 msgstr "Galeria de imagens"
 
-#: src/olympia/addons/templates/addons/details_box.html:190
-#: src/olympia/devhub/templates/devhub/addons/edit/technical.html:21
+#: src/olympia/addons/templates/addons/details_box.html:190 src/olympia/devhub/templates/devhub/addons/edit/technical.html:21
 msgid "Developer Comments"
 msgstr "Comentários do desenvolvedor"
 
-#: src/olympia/addons/templates/addons/details_box.html:199
-#: src/olympia/addons/templates/addons/impala/details.html:259
+#: src/olympia/addons/templates/addons/details_box.html:199 src/olympia/addons/templates/addons/impala/details.html:264
 msgid "Development Channel"
 msgstr "Canal de desenvolvimento"
 
-#: src/olympia/addons/templates/addons/details_box.html:202
-#: src/olympia/addons/templates/addons/mobile/details.html:124
+#: src/olympia/addons/templates/addons/details_box.html:202 src/olympia/addons/templates/addons/mobile/details.html:124
 msgid ""
-"The Development Channel lets you test an experimental new version of this "
-"add-on before it's released to the general public. Once you install the "
-"development version, you will continue to get updates from this channel."
+"The Development Channel lets you test an experimental new version of this add-on before it's released to the general public. Once you install the development version, you will continue to get "
+"updates from this channel."
 msgstr ""
-"O canal de desenvolvimento permite que teste um nova versão experimental "
-"deste complemento antes dele ser lançado ao público em geral. Uma vez "
-"instalada a versão em desenvolvimento, você continuará a receber "
-"atualizações desse canal."
+"O canal de desenvolvimento permite que teste um nova versão experimental deste complemento antes dele ser lançado ao público em geral. Uma vez instalada a versão em desenvolvimento, você continuará "
+"a receber atualizações desse canal."
 
 #: src/olympia/addons/templates/addons/details_box.html:207
 msgid "Install development version"
@@ -631,78 +478,54 @@ msgstr "Instalar versão em desenvolvimento"
 
 #: src/olympia/addons/templates/addons/details_box.html:211
 msgid ""
-"<strong>Caution:</strong> Development versions of this add-on have not been "
-"reviewed by Mozilla. Once you install a development version you will "
-"continue to receive development updates from this developer. To stop "
-"receiving development updates, reinstall the default version from the link "
-"above."
+"<strong>Caution:</strong> Development versions of this add-on have not been reviewed by Mozilla. Once you install a development version you will continue to receive development updates from this "
+"developer. To stop receiving development updates, reinstall the default version from the link above."
 msgstr ""
-"<strong>Cuidado:</strong> versões em desenvolvimento desse complemento não "
-"foram analisadas pela Mozilla. Ao instalar uma versão em desenvolvimento, "
-"você continuará a receber atualizações em desenvolvimento desse "
-"desenvolvedor. Para parar de recebê-las, reinstale a versão padrão no link "
-"acima."
+"<strong>Cuidado:</strong> versões em desenvolvimento desse complemento não foram analisadas pela Mozilla. Ao instalar uma versão em desenvolvimento, você continuará a receber atualizações em "
+"desenvolvimento desse desenvolvedor. Para parar de recebê-las, reinstale a versão padrão no link acima."
 
-#: src/olympia/addons/templates/addons/details_box.html:220
-#: src/olympia/addons/templates/addons/impala/details.html:278
+#: src/olympia/addons/templates/addons/details_box.html:220 src/olympia/addons/templates/addons/impala/details.html:283
 msgid "Version {0}:"
 msgstr "Versão {0}:"
 
 #: src/olympia/addons/templates/addons/details_box.html:234
 msgid "Nothing to see here!  The developer did not include any details."
-msgstr "Nada por aqui!  O desenvolvedor não incluiu detalhes."
+msgstr ""
 
-#: src/olympia/addons/templates/addons/details_box.html:251
-#: src/olympia/devhub/templates/devhub/versions/edit.html:73
-#: src/olympia/editors/templates/editors/review.html:98
+#: src/olympia/addons/templates/addons/details_box.html:251 src/olympia/devhub/templates/devhub/versions/edit.html:73 src/olympia/editors/templates/editors/review.html:98
 msgid "Version Notes"
 msgstr "Notas da versão"
 
 #. {0} is the name of the add-on.
 #. {0} is the name of the add-on
-#: src/olympia/addons/templates/addons/eula.html:6
-#: src/olympia/discovery/templates/discovery/addons/eula.html:5
+#: src/olympia/addons/templates/addons/eula.html:6 src/olympia/discovery/templates/discovery/addons/eula.html:5
 msgid "End-User License Agreement for {0}"
 msgstr "Acordo de Licença para {0}"
 
-#: src/olympia/addons/templates/addons/eula.html:17
-#: src/olympia/addons/templates/addons/eula.html:21
-#: src/olympia/addons/templates/addons/impala/button.html:48
-#: src/olympia/addons/templates/addons/impala/details.html:316
-#: src/olympia/devhub/templates/devhub/includes/policy_form.html:3
-#: src/olympia/discovery/templates/discovery/addons/eula.html:11
+#: src/olympia/addons/templates/addons/eula.html:17 src/olympia/addons/templates/addons/eula.html:21 src/olympia/addons/templates/addons/impala/button.html:48
+#: src/olympia/addons/templates/addons/impala/details.html:321 src/olympia/devhub/templates/devhub/includes/policy_form.html:3 src/olympia/discovery/templates/discovery/addons/eula.html:11
 msgid "End-User License Agreement"
 msgstr "Acordo de Licença"
 
 # %s is the name of the add-on
-#: src/olympia/addons/templates/addons/eula.html:23
-#: src/olympia/discovery/templates/discovery/addons/eula.html:13
+#: src/olympia/addons/templates/addons/eula.html:23 src/olympia/discovery/templates/discovery/addons/eula.html:13
 #, python-format
-msgid ""
-"%(addon_name)s requires that you accept the following End-User License "
-"Agreement before installation can proceed:"
-msgstr ""
-"%(addon_name)s precisa que aceite o acordo de licenciamento a seguir antes "
-"de prosseguir a instalação:"
+msgid "%(addon_name)s requires that you accept the following End-User License Agreement before installation can proceed:"
+msgstr "%(addon_name)s precisa que aceite o acordo de licenciamento a seguir antes de prosseguir a instalação:"
 
-#: src/olympia/addons/templates/addons/eula.html:34
-#: src/olympia/addons/templates/addons/privacy.html:26
+#: src/olympia/addons/templates/addons/eula.html:34 src/olympia/addons/templates/addons/privacy.html:26
 msgid "Back to {0}…"
 msgstr "Voltar para {0}…"
 
 # {0} is the application the user is browsing.  Examples:  Thunderbird,
 # Firefox,
 # Sunbird
-#: src/olympia/addons/templates/addons/home.html:3
-#: src/olympia/addons/templates/addons/mobile/home.html:3
-#: src/olympia/amo/helpers.py:235
+#: src/olympia/addons/templates/addons/home.html:3 src/olympia/addons/templates/addons/mobile/home.html:3 src/olympia/amo/helpers.py:235
 msgid "Add-ons for {0}"
 msgstr "Complementos para o {0}"
 
 # Plural in this context means many of the add-on type
-#: src/olympia/addons/templates/addons/home.html:10
-#: src/olympia/addons/templates/addons/home.html:51
-#: src/olympia/browse/templates/browse/impala/base_listing.html:11
+#: src/olympia/addons/templates/addons/home.html:10 src/olympia/addons/templates/addons/home.html:53 src/olympia/browse/templates/browse/impala/base_listing.html:11
 msgid "Featured Extensions"
 msgstr "Extensões em destaque"
 
@@ -711,71 +534,50 @@ msgstr "Extensões em destaque"
 msgid "Popular Extensions"
 msgstr "Extensões populares"
 
-#: src/olympia/addons/templates/addons/home.html:42
-#: src/olympia/amo/templates/amo/side_nav.html:3
-#: src/olympia/amo/templates/amo/side_nav.html:11
-#: src/olympia/amo/templates/amo/site_nav.html:3
-#: src/olympia/amo/templates/amo/site_nav.html:25
-#: src/olympia/browse/views.py:236 src/olympia/browse/views.py:281
-#: src/olympia/browse/views.py:481
+#: src/olympia/addons/templates/addons/home.html:44 src/olympia/amo/templates/amo/side_nav.html:3 src/olympia/amo/templates/amo/side_nav.html:11 src/olympia/amo/templates/amo/site_nav.html:3
+#: src/olympia/amo/templates/amo/site_nav.html:25 src/olympia/browse/views.py:203 src/olympia/browse/views.py:248 src/olympia/browse/views.py:448
 msgid "Most Popular"
 msgstr "Mais populares"
 
-#: src/olympia/addons/templates/addons/home.html:43
+#: src/olympia/addons/templates/addons/home.html:45
 msgid "All »"
 msgstr "Todos »"
 
-#: src/olympia/addons/templates/addons/home.html:52
-#: src/olympia/addons/templates/addons/home.html:61
-#: src/olympia/addons/templates/addons/home.html:70
-#: src/olympia/addons/templates/addons/home.html:78
+#: src/olympia/addons/templates/addons/home.html:54 src/olympia/addons/templates/addons/home.html:63 src/olympia/addons/templates/addons/home.html:72 src/olympia/addons/templates/addons/home.html:80
 #: src/olympia/browse/templates/browse/impala/category_landing.html:36
 msgid "See all »"
 msgstr "Ver todas »"
 
-#: src/olympia/addons/templates/addons/home.html:60
+#: src/olympia/addons/templates/addons/home.html:62
 msgid "Up &amp; Coming Extensions"
 msgstr "Extensões em ascensão"
 
-#: src/olympia/addons/templates/addons/home.html:69
-#: src/olympia/browse/templates/browse/personas/category_landing.html:61
-#: src/olympia/discovery/templates/discovery/pane.html:74
+#: src/olympia/addons/templates/addons/home.html:71 src/olympia/browse/templates/browse/personas/category_landing.html:61 src/olympia/discovery/templates/discovery/pane.html:74
 msgid "Featured Themes"
 msgstr "Temas em destaque"
 
-#: src/olympia/addons/templates/addons/home.html:77
-#: src/olympia/bandwagon/templates/bandwagon/impala/collection_listing.html:5
+#: src/olympia/addons/templates/addons/home.html:79 src/olympia/bandwagon/templates/bandwagon/impala/collection_listing.html:5
 msgid "Featured Collections"
 msgstr "Coleções em destaque"
 
-#: src/olympia/addons/templates/addons/listing_header.html:3
-#: src/olympia/addons/templates/addons/impala/listing/sorter.html:2
-#: src/olympia/amo/templates/amo/mobile/sort_by.html:2
+#: src/olympia/addons/templates/addons/listing_header.html:3 src/olympia/addons/templates/addons/impala/listing/sorter.html:2 src/olympia/amo/templates/amo/mobile/sort_by.html:2
 #: src/olympia/bandwagon/templates/bandwagon/collection_detail.html:118
 msgid "Sort by:"
 msgstr "Ordenar por:"
 
 #. {0} is a date.
 #. {0} is a date
-#: src/olympia/addons/templates/addons/macros.html:7
-#: src/olympia/addons/templates/addons/macros.html:72
-#: src/olympia/addons/templates/addons/listing/items_mobile.html:48
-#: src/olympia/addons/templates/addons/listing/macros.html:42
-#: src/olympia/bandwagon/templates/bandwagon/collection_detail.html:50
-#: src/olympia/bandwagon/templates/bandwagon/collection_listing_items.html:40
-#: src/olympia/bandwagon/templates/bandwagon/impala/collection_listing_items.html:40
+#: src/olympia/addons/templates/addons/macros.html:7 src/olympia/addons/templates/addons/macros.html:72 src/olympia/addons/templates/addons/listing/items_mobile.html:48
+#: src/olympia/addons/templates/addons/listing/macros.html:42 src/olympia/bandwagon/templates/bandwagon/collection_detail.html:50
+#: src/olympia/bandwagon/templates/bandwagon/collection_listing_items.html:40 src/olympia/bandwagon/templates/bandwagon/impala/collection_listing_items.html:40
 msgid "Updated {0}"
 msgstr "Atualizado em {0}"
 
-#. {0} is a date.
 # %s is a date in the _('date') format
-#: src/olympia/addons/templates/addons/macros.html:10
-#: src/olympia/addons/templates/addons/macros.html:69
-#: src/olympia/addons/templates/addons/persona_preview.html:21
-#: src/olympia/addons/templates/addons/listing/items_mobile.html:44
-#: src/olympia/addons/templates/addons/listing/macros.html:39
-#: src/olympia/bandwagon/templates/bandwagon/collection_listing_items.html:37
-#: src/olympia/bandwagon/templates/bandwagon/impala/collection_listing_items.html:37
+#. {0} is a date.
+#: src/olympia/addons/templates/addons/macros.html:10 src/olympia/addons/templates/addons/macros.html:69 src/olympia/addons/templates/addons/persona_preview.html:22
+#: src/olympia/addons/templates/addons/listing/items_mobile.html:44 src/olympia/addons/templates/addons/listing/macros.html:39
+#: src/olympia/bandwagon/templates/bandwagon/collection_listing_items.html:37 src/olympia/bandwagon/templates/bandwagon/impala/collection_listing_items.html:37
 msgid "Added {0}"
 msgstr "Adicionado em {0}"
 
@@ -794,18 +596,14 @@ msgstr[0] "%(num)s usuário"
 msgstr[1] "%(num)s usuários"
 
 #. {0} is the number of downloads.
-#: src/olympia/addons/templates/addons/macros.html:53
-#: src/olympia/addons/templates/addons/impala/details.html:61
+#: src/olympia/addons/templates/addons/macros.html:53 src/olympia/addons/templates/addons/impala/details.html:59
 msgid "{0} weekly download"
 msgid_plural "{0} weekly downloads"
 msgstr[0] "{0} download semanal"
 msgstr[1] "{0} downloads semanais"
 
 #. {0} is the number of users.
-#: src/olympia/addons/templates/addons/macros.html:61
-#: src/olympia/addons/templates/addons/impala/details.html:54
-#: src/olympia/compat/templates/compat/index.html:71
-#: src/olympia/zadmin/templates/zadmin/compat.html:67
+#: src/olympia/addons/templates/addons/macros.html:61 src/olympia/addons/templates/addons/impala/details.html:52 src/olympia/zadmin/templates/zadmin/compat.html:67
 msgid "{0} user"
 msgid_plural "{0} users"
 msgstr[0] "{0} usuário"
@@ -823,12 +621,8 @@ msgstr "Pagamento concluído"
 msgid "Return to the addon."
 msgstr "Voltar para o complemento."
 
-#: src/olympia/addons/templates/addons/persona_detail.html:17
-#: src/olympia/addons/templates/addons/impala/details.html:106
-#: src/olympia/addons/templates/addons/mobile/details.html:23
-#: src/olympia/addons/templates/addons/mobile/persona_detail.html:21
-#: src/olympia/discovery/templates/discovery/addons/base.html:27
-#: src/olympia/editors/templates/editors/review.html:31
+#: src/olympia/addons/templates/addons/persona_detail.html:17 src/olympia/addons/templates/addons/impala/details.html:103 src/olympia/addons/templates/addons/mobile/details.html:23
+#: src/olympia/addons/templates/addons/mobile/persona_detail.html:21 src/olympia/discovery/templates/discovery/addons/base.html:27 src/olympia/editors/templates/editors/review.html:31
 msgid "by"
 msgstr "por"
 
@@ -838,8 +632,7 @@ msgid "More {0} Themes"
 msgstr "Mais temas em {0}"
 
 #. {0} is a category name, such as Nature
-#: src/olympia/addons/templates/addons/persona_detail.html:39
-#: src/olympia/addons/templates/addons/mobile/persona_detail.html:66
+#: src/olympia/addons/templates/addons/persona_detail.html:39 src/olympia/addons/templates/addons/mobile/persona_detail.html:66
 msgid "See all {0} Themes"
 msgstr "Ver todos os temas em {0}"
 
@@ -847,65 +640,45 @@ msgstr "Ver todos os temas em {0}"
 msgid "More by this Artist"
 msgstr "Mais desse artista"
 
-#: src/olympia/addons/templates/addons/persona_detail.html:52
-#: src/olympia/addons/templates/addons/mobile/persona_detail.html:49
+#: src/olympia/addons/templates/addons/persona_detail.html:52 src/olympia/addons/templates/addons/mobile/persona_detail.html:49
 msgid "See all Themes by this Artist"
 msgstr "Ver todos os temas deste artista"
 
-#: src/olympia/addons/templates/addons/persona_detail.html:71
-#: src/olympia/addons/templates/addons/mobile/home.html:42
-#: src/olympia/amo/templates/amo/side_nav.html:22
-#: src/olympia/browse/templates/browse/personas/mobile/category_landing.html:28
-#: src/olympia/devhub/templates/devhub/addons/edit/basic.html:72
-#: src/olympia/editors/templates/editors/review.html:277
-#: src/olympia/editors/templates/editors/themes/themes.html:34
-#: src/olympia/templates/categories.html:7
+#: src/olympia/addons/templates/addons/persona_detail.html:71 src/olympia/addons/templates/addons/mobile/home.html:42 src/olympia/amo/templates/amo/side_nav.html:22
+#: src/olympia/browse/templates/browse/personas/mobile/category_landing.html:28 src/olympia/devhub/templates/devhub/addons/edit/basic.html:72 src/olympia/editors/templates/editors/review.html:277
+#: src/olympia/editors/templates/editors/themes/themes.html:34 src/olympia/templates/categories.html:7
 msgid "Categories"
 msgstr "Categorias"
 
-#: src/olympia/addons/templates/addons/persona_detail_table.html:10
-#: src/olympia/addons/templates/addons/mobile/persona_detail_table.html:3
-#: src/olympia/editors/templates/editors/themes/deleted.html:19
+#: src/olympia/addons/templates/addons/persona_detail_table.html:10 src/olympia/addons/templates/addons/mobile/persona_detail_table.html:3 src/olympia/editors/templates/editors/themes/deleted.html:19
 #: src/olympia/editors/templates/editors/themes/themes.html:25
 msgid "Artist"
 msgstr "Artista"
 
-#: src/olympia/addons/templates/addons/persona_detail_table.html:19
-#: src/olympia/addons/templates/addons/mobile/persona_detail_table.html:14
-#: src/olympia/stats/templates/stats/addon_report_menu.html:17
+#: src/olympia/addons/templates/addons/persona_detail_table.html:19 src/olympia/addons/templates/addons/mobile/persona_detail_table.html:14 src/olympia/stats/templates/stats/addon_report_menu.html:17
 msgid "Daily Users"
 msgstr "Usuários diários"
 
 #. The License for this add-on.
-#: src/olympia/addons/templates/addons/persona_detail_table.html:26
-#: src/olympia/addons/templates/addons/impala/license.html:17
-#: src/olympia/addons/templates/addons/mobile/persona_detail_table.html:21
-#: src/olympia/devhub/templates/devhub/includes/license_form.html:5
-#: src/olympia/devhub/templates/devhub/versions/edit.html:89
-#: src/olympia/editors/templates/editors/themes/themes.html:41
+#: src/olympia/addons/templates/addons/persona_detail_table.html:26 src/olympia/addons/templates/addons/impala/license.html:17 src/olympia/addons/templates/addons/mobile/persona_detail_table.html:21
+#: src/olympia/devhub/templates/devhub/includes/license_form.html:5 src/olympia/devhub/templates/devhub/versions/edit.html:89 src/olympia/editors/templates/editors/themes/themes.html:41
 msgid "License"
 msgstr "Licença"
 
-#: src/olympia/addons/templates/addons/persona_preview.html:12
-#: src/olympia/constants/base.py:48
+#: src/olympia/addons/templates/addons/persona_preview.html:13 src/olympia/constants/base.py:48
 msgid "Awaiting Review"
 msgstr "Esperando análise"
 
-#: src/olympia/addons/templates/addons/persona_preview.html:14
-#: src/olympia/amo/log.py:180 src/olympia/constants/base.py:42
-#: src/olympia/editors/helpers.py:62
+#: src/olympia/addons/templates/addons/persona_preview.html:15 src/olympia/amo/log.py:180 src/olympia/constants/base.py:42 src/olympia/editors/helpers.py:62
 msgid "Rejected"
 msgstr "Rejeitado"
 
-#: src/olympia/addons/templates/addons/persona_preview.html:16
-#: src/olympia/amo/log.py:159
+#: src/olympia/addons/templates/addons/persona_preview.html:17 src/olympia/amo/log.py:159
 msgid "Approved"
 msgstr "Aprovado"
 
 #. {0} is the number of users.
-#: src/olympia/addons/templates/addons/persona_preview.html:26
-#: src/olympia/addons/templates/addons/listing/items_mobile.html:36
-#: src/olympia/addons/templates/addons/listing/macros.html:31
+#: src/olympia/addons/templates/addons/persona_preview.html:27 src/olympia/addons/templates/addons/listing/items_mobile.html:36 src/olympia/addons/templates/addons/listing/macros.html:31
 msgid "<strong>{0}</strong> user"
 msgid_plural "<strong>{0}</strong> users"
 msgstr[0] "<strong>{0}</strong> usuário"
@@ -915,105 +688,74 @@ msgstr[1] "<strong>{0}</strong> usuários"
 # return
 # the user to the add-on's review page (it only appears if the add-on is being
 # reviewed)
-#: src/olympia/addons/templates/addons/persona_preview.html:40
+#: src/olympia/addons/templates/addons/persona_preview.html:41
 msgid "Hover to Preview"
 msgstr "Aponte para visualizar"
 
-#: src/olympia/addons/templates/addons/persona_preview.html:46
-#: src/olympia/addons/templates/addons/persona_preview.html:48
+#: src/olympia/addons/templates/addons/persona_preview.html:47 src/olympia/addons/templates/addons/persona_preview.html:49 src/olympia/addons/templates/addons/persona_preview.html:97
 #: src/olympia/reviews/templates/reviews/add.html:15
 msgid "Add"
 msgstr "Adicionar"
 
-#: src/olympia/addons/templates/addons/persona_preview.html:57
-#: src/olympia/bandwagon/templates/bandwagon/ajax_new.html:16
-#: src/olympia/bandwagon/templates/bandwagon/edit.html:19
-#: src/olympia/bandwagon/templates/bandwagon/includes/addedit.html:19
-#: src/olympia/devhub/templates/devhub/addons/edit/admin.html:13
-#: src/olympia/devhub/templates/devhub/addons/edit/basic.html:10
-#: src/olympia/devhub/templates/devhub/addons/edit/details.html:8
-#: src/olympia/devhub/templates/devhub/addons/edit/media.html:6
-#: src/olympia/devhub/templates/devhub/addons/edit/support.html:8
-#: src/olympia/devhub/templates/devhub/addons/edit/technical.html:9
-#: src/olympia/devhub/templates/devhub/addons/submit/describe.html:29
-#: src/olympia/editors/templates/editors/review.html:257
+#: src/olympia/addons/templates/addons/persona_preview.html:58 src/olympia/bandwagon/templates/bandwagon/ajax_new.html:16 src/olympia/bandwagon/templates/bandwagon/edit.html:19
+#: src/olympia/bandwagon/templates/bandwagon/includes/addedit.html:19 src/olympia/devhub/templates/devhub/addons/edit/admin.html:13 src/olympia/devhub/templates/devhub/addons/edit/basic.html:10
+#: src/olympia/devhub/templates/devhub/addons/edit/details.html:8 src/olympia/devhub/templates/devhub/addons/edit/media.html:6 src/olympia/devhub/templates/devhub/addons/edit/support.html:8
+#: src/olympia/devhub/templates/devhub/addons/edit/technical.html:9 src/olympia/devhub/templates/devhub/addons/submit/describe.html:29 src/olympia/editors/templates/editors/review.html:257
 msgid "Edit"
 msgstr "Editar"
 
 #. For datetime formatting, see the table on
 #. http://docs.python.org/library/datetime.html#strftime-and-strptime-behavior
-#: src/olympia/addons/templates/addons/persona_preview.html:66
+#: src/olympia/addons/templates/addons/persona_preview.html:67
 #, python-format
 msgid "%%Y-%%m-%%d"
 msgstr "%%d-%%m-%%Y"
 
-#: src/olympia/addons/templates/addons/persona_preview.html:67
+#: src/olympia/addons/templates/addons/persona_preview.html:68
 msgid "by {0} on {1}"
 msgstr "por {0} em {1}"
 
-#: src/olympia/addons/templates/addons/persona_preview.html:75
-#: src/olympia/reviews/helpers.py:17
-#: src/olympia/reviews/templates/reviews/review_list.html:63
-#: src/olympia/reviews/templates/reviews/reviews_link.html:21
-#: src/olympia/reviews/templates/reviews/impala/reviews_link.html:16
+#: src/olympia/addons/templates/addons/persona_preview.html:76 src/olympia/reviews/helpers.py:17 src/olympia/reviews/templates/reviews/review_list.html:63
+#: src/olympia/reviews/templates/reviews/reviews_link.html:21 src/olympia/reviews/templates/reviews/impala/reviews_link.html:16
 msgid "Not yet rated"
 msgstr "Ainda não foi avaliado"
 
-#: src/olympia/addons/templates/addons/persona_preview.html:78
+#: src/olympia/addons/templates/addons/persona_preview.html:79
 msgid "<b>{0}</b> users"
 msgstr "<b>{0}</b> usuários"
 
 #: src/olympia/addons/templates/addons/popups.html:17
-msgid ""
-"To install this add-on and thousands more, <b>get Firefox</b>, a free and "
-"open web browser from Mozilla."
-msgstr ""
-"Para instalar esse complemento e milhares de outros, <b>baixe o Firefox</b>,"
-" um navegador aberto e gratuito da Mozilla."
+msgid "To install this add-on and thousands more, <b>get Firefox</b>, a free and open web browser from Mozilla."
+msgstr "Para instalar esse complemento e milhares de outros, <b>baixe o Firefox</b>, um navegador aberto e gratuito da Mozilla."
 
 # %1 is the add-on name
-#: src/olympia/addons/templates/addons/popups.html:21
-#: src/olympia/addons/templates/addons/popups.html:52
+#: src/olympia/addons/templates/addons/popups.html:21 src/olympia/addons/templates/addons/popups.html:52
 msgid "Learn more about Firefox"
 msgstr "Saiba mais sobre o Firefox"
 
 #: src/olympia/addons/templates/addons/popups.html:22
-msgid "or <b><a class=\"installer\" href=\"{url}\">download anyway</a></b>"
-msgstr "ou <b><a class=\"installer\" href=\"{url}\">baixar mesmo assim</a></b>"
+msgid "or <b><a class=\"button installer\" href=\"{url}\">download anyway</a></b>"
+msgstr ""
 
 #: src/olympia/addons/templates/addons/popups.html:26
 msgid ""
-"<strong>How to Install in Thunderbird</strong> <ol> <li>Download and save "
-"the file to your hard disk.</li> <li>In Mozilla Thunderbird, open Add-ons "
-"from the Tools menu.</li> <li>From the options button next to the add-on "
-"search field, select \"Install Add-on From File...\" and locate the "
-"downloaded add-on.</li> </ol>"
+"<strong>How to Install in Thunderbird</strong> <ol> <li>Download and save the file to your hard disk.</li> <li>In Mozilla Thunderbird, open Add-ons from the Tools menu.</li> <li>From the options "
+"button next to the add-on search field, select \"Install Add-on From File...\" and locate the downloaded add-on.</li> </ol>"
 msgstr ""
-"<strong>Como instalar no Thunderbird</strong> <ol> <li>Baixe e salve o "
-"arquivo no seu disco.</li> <li>No Mozilla Thunderbird, abra Complementos no "
-"menu Ferramentas.</li> <li>No botão de opções, ao lado do campo de pesquisa "
-"de complementos, selecione \"Instalar de um arquivo…\" e localize o "
-"complemento baixado.</li> </ol>"
+"<strong>Como instalar no Thunderbird</strong> <ol> <li>Baixe e salve o arquivo no seu disco.</li> <li>No Mozilla Thunderbird, abra Complementos no menu Ferramentas.</li> <li>No botão de opções, ao "
+"lado do campo de pesquisa de complementos, selecione \"Instalar de um arquivo…\" e localize o complemento baixado.</li> </ol>"
 
 #: src/olympia/addons/templates/addons/popups.html:41
-msgid ""
-"To install this Theme, <b>get Thunderbird</b>, a free and open source email "
-"client from Mozilla Messaging and install the Personas Plus add-on."
-msgstr ""
-"Para instalar este tema, <b>baixe o Thunderbird</b>, um cliente de e-mails "
-"gratuito e de código aberto da Mozilla e instale o complemento Persona Plus."
+msgid "To install this Theme, <b>get Thunderbird</b>, a free and open source email client from Mozilla Messaging and install the Personas Plus add-on."
+msgstr "Para instalar este tema, <b>baixe o Thunderbird</b>, um cliente de e-mails gratuito e de código aberto da Mozilla e instale o complemento Persona Plus."
 
 #: src/olympia/addons/templates/addons/popups.html:46
 msgid "Learn more about Thunderbird"
 msgstr "Saiba mais sobre o Thunderbird"
 
 #: src/olympia/addons/templates/addons/popups.html:48
-msgid ""
-"To install this Theme and thousands more, <b>get Firefox</b>, a free and "
-"open web browser from Mozilla."
-msgstr ""
-"Para instalar esse ou centenas de outros temas, <b>baixe o Firefox</b>, um "
-"navegador da Web gratuito e aberto da Mozilla."
+msgid "To install this Theme and thousands more, <b>get Firefox</b>, a free and open web browser from Mozilla."
+msgstr "Para instalar esse ou centenas de outros temas, <b>baixe o Firefox</b>, um navegador da Web gratuito e aberto da Mozilla."
 
 # %(app)s is an application name and version.  Example: Firefox 3.1
 #: src/olympia/addons/templates/addons/popups.html:60
@@ -1021,17 +763,13 @@ msgstr ""
 msgid "This add-on has not been updated to work with your version of %(app)s."
 msgstr "Esse complemento não é compatível com a sua versão do %(app)s."
 
-#: src/olympia/addons/templates/addons/popups.html:63
-#: src/olympia/addons/templates/addons/popups.html:140
-#: src/olympia/addons/templates/addons/popups.html:150
+#: src/olympia/addons/templates/addons/popups.html:63 src/olympia/addons/templates/addons/popups.html:140 src/olympia/addons/templates/addons/popups.html:150
 msgid "Install Anyway"
 msgstr "Instalar mesmo assim"
 
 #: src/olympia/addons/templates/addons/popups.html:71
-msgid ""
-"This add-on requires a version of Firefox that has not been released yet."
-msgstr ""
-"Esse complemento requer uma versão do Firefox que ainda não foi lançada."
+msgid "This add-on requires a version of Firefox that has not been released yet."
+msgstr "Esse complemento requer uma versão do Firefox que ainda não foi lançada."
 
 #: src/olympia/addons/templates/addons/popups.html:74
 msgid "Help test new Firefox Versions"
@@ -1039,16 +777,11 @@ msgstr "Ajude a testar novas versões do Firefox"
 
 #: src/olympia/addons/templates/addons/popups.html:77
 #, python-format
-msgid ""
-"This add-on requires %(app)s {new_version}. You are currently using %(app)s "
-"{old_version}."
-msgstr ""
-"Esse complemento requer o %(app)s {new_version}. Você está usando atualmente"
-" o %(app)s {old_version}."
+msgid "This add-on requires %(app)s {new_version}. You are currently using %(app)s {old_version}."
+msgstr "Esse complemento requer o %(app)s {new_version}. Você está usando atualmente o %(app)s {old_version}."
 
 #. {0} is an app name, like Firefox.
-#: src/olympia/addons/templates/addons/popups.html:82
-#: src/olympia/addons/templates/addons/popups.html:101
+#: src/olympia/addons/templates/addons/popups.html:82 src/olympia/addons/templates/addons/popups.html:101
 msgid "Upgrade {0}"
 msgstr "Atualizar {0}"
 
@@ -1059,45 +792,26 @@ msgstr "ou veja as <a href=\"%(href)s\">versões anteriores desse complemento</a
 
 #: src/olympia/addons/templates/addons/popups.html:96
 #, python-format
-msgid ""
-"This Persona requires %(app)s %(new_version)s. You are currently using "
-"%(app)s {old_version}."
-msgstr ""
-"Essa Persona requer o %(app)s %(new_version)s. Você está usando atualmente o"
-" %(app)s {old_version}."
+msgid "This Persona requires %(app)s %(new_version)s. You are currently using %(app)s {old_version}."
+msgstr "Essa Persona requer o %(app)s %(new_version)s. Você está usando atualmente o %(app)s {old_version}."
 
 #: src/olympia/addons/templates/addons/popups.html:108
 msgid ""
-"<strong>Caution:</strong> This add-on has not been reviewed by Mozilla and "
-"can't be installed on release versions of Firefox 43 and above.  Be careful "
-"when installing third-party software that might harm your computer."
+"<strong>Caution:</strong> This add-on has not been reviewed by Mozilla and can't be installed on release versions of Firefox 43 and above.  Be careful when installing third-party software that "
+"might harm your computer."
 msgstr ""
-"<strong>Cuidado:</strong> Este complemento não foi revisado pela Mozilla e "
-"não pode ser instalado em versões finais do FIrefox 43 e superiores.  Seja "
-"cuidadoso ao instalar programas de terceiros que podem prejudicar o seu "
-"computador."
 
 # %1$s is an application name and version.  Example: Firefox 3.1
 #: src/olympia/addons/templates/addons/popups.html:120
-msgid ""
-"<strong>Please note:</strong> This add-on is not compatible with your "
-"operating system."
-msgstr ""
-"<strong>Atenção:</strong> este complemento não é compatível com o seu "
-"sistema operacional."
+msgid "<strong>Please note:</strong> This add-on is not compatible with your operating system."
+msgstr "<strong>Atenção:</strong> este complemento não é compatível com o seu sistema operacional."
 
-#: src/olympia/addons/templates/addons/popups.html:136
-#: src/olympia/addons/templates/addons/impala/button.html:70
+#: src/olympia/addons/templates/addons/popups.html:136 src/olympia/addons/templates/addons/impala/button.html:70
 #, python-format
-msgid ""
-"This add-on is not compatible with your version of %(app)s because of the "
-"following:"
-msgstr ""
-"Esse complemento não é compatível com a sua versão do %(app)s pelos "
-"seguintes motivos:"
+msgid "This add-on is not compatible with your version of %(app)s because of the following:"
+msgstr "Esse complemento não é compatível com a sua versão do %(app)s pelos seguintes motivos:"
 
-#: src/olympia/addons/templates/addons/popups.html:141
-#: src/olympia/addons/templates/addons/popups.html:151
+#: src/olympia/addons/templates/addons/popups.html:141 src/olympia/addons/templates/addons/popups.html:151
 msgid "View other versions"
 msgstr "Ver outras versões"
 
@@ -1121,147 +835,92 @@ msgid ""
 "  to your phone.  (You'll need a QR reader.  Search your phone's marketplace if\n"
 "  don't have one.)"
 msgstr ""
-"Deseja ter o {0} na versão mobile do FIrefox? Escaneie este QR code para instalá-lo direto\n"
-"  no seu telefone.  (Você precisará de um leitor de QR codes. Procure na loja de aplicativos \n"
-"  se você não tiver um)"
 
-#: src/olympia/addons/templates/addons/report_abuse.html:6
-#: src/olympia/addons/templates/addons/report_abuse_full.html:10
-#: src/olympia/addons/templates/addons/impala/details-more.html:23
-#: src/olympia/addons/templates/addons/impala/details.html:328
+#: src/olympia/addons/templates/addons/report_abuse.html:6 src/olympia/addons/templates/addons/report_abuse_full.html:10 src/olympia/addons/templates/addons/impala/details-more.html:23
+#: src/olympia/addons/templates/addons/impala/details.html:333
 msgid "Report Abuse"
 msgstr "Denunciar abuso"
 
 #: src/olympia/addons/templates/addons/report_abuse.html:10
 #, python-format
 msgid ""
-"If you suspect this add-on violates <a href=\"%(url)s\">our policies</a> or "
-"has security or privacy issues, please use the form below to describe your "
-"concerns. Please do not use this form for any other reason."
+"If you suspect this add-on violates <a href=\"%(url)s\">our policies</a> or has security or privacy issues, please use the form below to describe your concerns. Please do not use this form for any "
+"other reason."
 msgstr ""
-"Se você suspeita que esse complemento viola as <a href=\"%(url)s\">nossas "
-"políticas</a> ou tem problemas de segurança ou privacidade, por favor, use o"
-" formulário abaixo para descrever suas preocupações. Por favor, não utilize "
-"esse formulário por nenhuma outra razão."
+"Se você suspeita que esse complemento viola as <a href=\"%(url)s\">nossas políticas</a> ou tem problemas de segurança ou privacidade, por favor, use o formulário abaixo para descrever suas "
+"preocupações. Por favor, não utilize esse formulário por nenhuma outra razão."
 
-#: src/olympia/addons/templates/addons/report_abuse.html:24
-#: src/olympia/users/templates/users/report_abuse.html:19
+#: src/olympia/addons/templates/addons/report_abuse.html:24 src/olympia/users/templates/users/report_abuse.html:19
 msgid "Send Report"
 msgstr "Enviar denúncia"
 
-#: src/olympia/addons/templates/addons/report_abuse.html:26
-#: src/olympia/addons/templates/addons/mobile/eula.html:16
-#: src/olympia/addons/templates/addons/mobile/persona_confirm.html:7
-#: src/olympia/devhub/templates/devhub/addons/ajax_compat_update.html:36
-#: src/olympia/devhub/templates/devhub/addons/profile.html:44
-#: src/olympia/devhub/templates/devhub/addons/edit/admin.html:104
-#: src/olympia/devhub/templates/devhub/addons/edit/basic.html:155
-#: src/olympia/devhub/templates/devhub/addons/edit/details.html:88
-#: src/olympia/devhub/templates/devhub/addons/edit/support.html:70
-#: src/olympia/devhub/templates/devhub/addons/edit/technical.html:169
-#: src/olympia/devhub/templates/devhub/addons/forms_shared/media.html:152
-#: src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:44
-#: src/olympia/devhub/templates/devhub/personas/edit.html:222
-#: src/olympia/devhub/templates/devhub/versions/add_file_modal.html:79
-#: src/olympia/devhub/templates/devhub/versions/edit.html:140
-#: src/olympia/devhub/templates/devhub/versions/list.html:208
-#: src/olympia/devhub/templates/devhub/versions/list.html:242
-#: src/olympia/devhub/templates/devhub/versions/list.html:276
-#: src/olympia/devhub/templates/devhub/versions/list.html:317
-#: src/olympia/reviews/templates/reviews/edit_review.html:16
-#: src/olympia/translations/templates/translations/trans-menu.html:50
-#: src/olympia/translations/templates/translations/trans-menu.html:62
-#: src/olympia/zadmin/templates/zadmin/validation.html:105
+#: src/olympia/addons/templates/addons/report_abuse.html:26 src/olympia/addons/templates/addons/mobile/eula.html:16 src/olympia/addons/templates/addons/mobile/persona_confirm.html:7
+#: src/olympia/devhub/templates/devhub/addons/ajax_compat_update.html:36 src/olympia/devhub/templates/devhub/addons/profile.html:44 src/olympia/devhub/templates/devhub/addons/edit/admin.html:104
+#: src/olympia/devhub/templates/devhub/addons/edit/basic.html:155 src/olympia/devhub/templates/devhub/addons/edit/details.html:88 src/olympia/devhub/templates/devhub/addons/edit/support.html:70
+#: src/olympia/devhub/templates/devhub/addons/edit/technical.html:169 src/olympia/devhub/templates/devhub/addons/forms_shared/media.html:152
+#: src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:43 src/olympia/devhub/templates/devhub/personas/edit.html:222 src/olympia/devhub/templates/devhub/versions/add_file_modal.html:59
+#: src/olympia/devhub/templates/devhub/versions/edit.html:140 src/olympia/devhub/templates/devhub/versions/list.html:208 src/olympia/devhub/templates/devhub/versions/list.html:239
+#: src/olympia/devhub/templates/devhub/versions/list.html:281 src/olympia/devhub/templates/devhub/versions/list.html:315 src/olympia/reviews/templates/reviews/edit_review.html:16
+#: src/olympia/translations/templates/translations/trans-menu.html:50 src/olympia/translations/templates/translations/trans-menu.html:62 src/olympia/zadmin/templates/zadmin/validation.html:105
 msgid "Cancel"
 msgstr "Cancelar"
 
-#: src/olympia/addons/templates/addons/review_add_box.html:3
-#: src/olympia/addons/templates/addons/impala/review_add_box.html:5
+#: src/olympia/addons/templates/addons/review_add_box.html:3 src/olympia/addons/templates/addons/impala/review_add_box.html:5
 msgid "What do you think?"
 msgstr "O que você acha?"
 
 # %1 is a URL
-#: src/olympia/addons/templates/addons/review_add_box.html:7
-#: src/olympia/addons/templates/addons/impala/review_add_box.html:9
+#: src/olympia/addons/templates/addons/review_add_box.html:7 src/olympia/addons/templates/addons/impala/review_add_box.html:9
 #, python-format
 msgid "Please <a href=\"%(login)s\">log in</a> to submit a review"
-msgstr ""
-"Por favor, <a href=\"%(login)s\">identifique-se</a> para enviar uma análise"
+msgstr "Por favor, <a href=\"%(login)s\">identifique-se</a> para enviar uma análise"
 
-#: src/olympia/addons/templates/addons/review_add_box.html:16
-#: src/olympia/addons/templates/addons/impala/review_add_box.html:18
-#: src/olympia/reviews/templates/reviews/mobile/add_form.html:13
+#: src/olympia/addons/templates/addons/review_add_box.html:16 src/olympia/addons/templates/addons/impala/review_add_box.html:18 src/olympia/reviews/templates/reviews/mobile/add_form.html:13
 msgid "Title:"
 msgstr "Título:"
 
-#: src/olympia/addons/templates/addons/review_add_box.html:17
-#: src/olympia/addons/templates/addons/impala/review_add_box.html:19
-#: src/olympia/reviews/templates/reviews/mobile/add_form.html:17
+#: src/olympia/addons/templates/addons/review_add_box.html:17 src/olympia/addons/templates/addons/impala/review_add_box.html:19 src/olympia/reviews/templates/reviews/mobile/add_form.html:17
 msgid "Review:"
 msgstr "Análise:"
 
-#: src/olympia/addons/templates/addons/review_add_box.html:18
-#: src/olympia/addons/templates/addons/impala/review_add_box.html:20
-#: src/olympia/reviews/templates/reviews/mobile/add_form.html:16
+#: src/olympia/addons/templates/addons/review_add_box.html:18 src/olympia/addons/templates/addons/impala/review_add_box.html:20 src/olympia/reviews/templates/reviews/mobile/add_form.html:16
 msgid "Rating:"
 msgstr "Avaliação:"
 
-#: src/olympia/addons/templates/addons/review_add_box.html:19
-#: src/olympia/addons/templates/addons/impala/review_add_box.html:21
-#: src/olympia/reviews/templates/reviews/add.html:63
-#: src/olympia/reviews/templates/reviews/edit_review.html:15
-#: src/olympia/reviews/templates/reviews/mobile/add_form.html:18
+#: src/olympia/addons/templates/addons/review_add_box.html:19 src/olympia/addons/templates/addons/impala/review_add_box.html:21 src/olympia/reviews/templates/reviews/add.html:63
+#: src/olympia/reviews/templates/reviews/edit_review.html:15 src/olympia/reviews/templates/reviews/mobile/add_form.html:18
 msgid "Submit review"
 msgstr "Enviar análise"
 
-#: src/olympia/addons/templates/addons/review_add_box.html:24
-#: src/olympia/addons/templates/addons/impala/review_add_box.html:26
-msgid ""
-"Please do not post bug reports in reviews. We do not make your email address"
-" available to add-on developers and they may need to contact you to help "
-"resolve your issue."
+#: src/olympia/addons/templates/addons/review_add_box.html:24 src/olympia/addons/templates/addons/impala/review_add_box.html:26
+msgid "Please do not post bug reports in reviews. We do not make your email address available to add-on developers and they may need to contact you to help resolve your issue."
 msgstr ""
-"Por favor, não envie relatos de bugs nas análises. Nós não informamos seu "
-"endereço de e-mail para os desenvolvedores dos complementos e eles podem "
-"precisar entrar em contato com você para ajudar a resolver o seu problema."
+"Por favor, não envie relatos de bugs nas análises. Nós não informamos seu endereço de e-mail para os desenvolvedores dos complementos e eles podem precisar entrar em contato com você para ajudar a "
+"resolver o seu problema."
 
 # %1 is the support section link
-#: src/olympia/addons/templates/addons/review_add_box.html:32
-#: src/olympia/addons/templates/addons/impala/review_add_box.html:35
+#: src/olympia/addons/templates/addons/review_add_box.html:32 src/olympia/addons/templates/addons/impala/review_add_box.html:35
 #, python-format
-msgid ""
-"See the <a href=\"%(support)s\">support section</a> to find out where to get"
-" assistance for this add-on."
-msgstr ""
-"Veja a <a href=\"%(support)s\">seção de suporte</a> para descobrir onde "
-"conseguir ajuda para este complemento."
+msgid "See the <a href=\"%(support)s\">support section</a> to find out where to get assistance for this add-on."
+msgstr "Veja a <a href=\"%(support)s\">seção de suporte</a> para descobrir onde conseguir ajuda para este complemento."
 
-#: src/olympia/addons/templates/addons/review_add_box.html:38
-#: src/olympia/addons/templates/addons/impala/review_add_box.html:42
-#: src/olympia/pages/templates/pages/review_guide.html:3
+#: src/olympia/addons/templates/addons/review_add_box.html:38 src/olympia/addons/templates/addons/impala/review_add_box.html:42 src/olympia/pages/templates/pages/review_guide.html:3
 #: src/olympia/pages/templates/pages/review_guide.html:44
 msgid "Review Guidelines"
 msgstr "Regras gerais para análises"
 
-#: src/olympia/addons/templates/addons/review_list_box.html:5
-#: src/olympia/addons/templates/addons/impala/details-more.html:27
-#: src/olympia/editors/helpers.py:921
-#: src/olympia/reviews/templates/reviews/add.html:14
-#: src/olympia/reviews/templates/reviews/reply.html:14
-#: src/olympia/reviews/templates/reviews/review_list.html:19
+#: src/olympia/addons/templates/addons/review_list_box.html:5 src/olympia/addons/templates/addons/impala/details-more.html:27 src/olympia/editors/helpers.py:1001
+#: src/olympia/reviews/templates/reviews/add.html:14 src/olympia/reviews/templates/reviews/reply.html:14 src/olympia/reviews/templates/reviews/review_list.html:19
 #: src/olympia/reviews/templates/reviews/mobile/review_list.html:26
 msgid "Reviews"
 msgstr "Análises"
 
-#: src/olympia/addons/templates/addons/review_list_box.html:14
-#: src/olympia/addons/templates/addons/impala/review_list_box.html:14
-#: src/olympia/reviews/templates/reviews/review.html:30
+#: src/olympia/addons/templates/addons/review_list_box.html:14 src/olympia/addons/templates/addons/impala/review_list_box.html:14 src/olympia/reviews/templates/reviews/review.html:30
 #, python-format
 msgid "by %(user)s on %(date)s"
 msgstr "por %(user)s em %(date)s"
 
-#: src/olympia/addons/templates/addons/review_list_box.html:19
-#: src/olympia/addons/templates/addons/impala/review_list_box.html:29
+#: src/olympia/addons/templates/addons/review_list_box.html:19 src/olympia/addons/templates/addons/impala/review_list_box.html:29
 msgid "Show the developer's reply to this review"
 msgstr "Exibir a resposta do desenvolvedor para essa análise"
 
@@ -1273,21 +932,16 @@ msgid_plural "See all %(cnt)s reviews of this add-on"
 msgstr[0] "Ver todas as análises desse complemento"
 msgstr[1] "Ver todas as %(cnt)s análises desse complemento"
 
-#: src/olympia/addons/templates/addons/tags_box.html:3
-#: src/olympia/devhub/templates/devhub/addons/edit/basic.html:118
+#: src/olympia/addons/templates/addons/tags_box.html:3 src/olympia/devhub/templates/devhub/addons/edit/basic.html:118
 msgid "Tags"
 msgstr "Etiquetas"
 
-#: src/olympia/addons/templates/addons/impala/addon_hovercard.html:7
-#: src/olympia/addons/templates/addons/impala/addon_hovercard.html:9
+#: src/olympia/addons/templates/addons/impala/addon_hovercard.html:7 src/olympia/addons/templates/addons/impala/addon_hovercard.html:9
 msgid "Icon for {0}"
 msgstr "Ícone para {0}"
 
-#: src/olympia/addons/templates/addons/impala/addon_hovercard.html:34
-#: src/olympia/addons/templates/addons/impala/featured_grid.html:26
-#: src/olympia/addons/templates/addons/impala/theme_grid.html:22
-#: src/olympia/bandwagon/templates/bandwagon/collection_detail.html:31
-#: src/olympia/users/templates/users/helpers/addon_users_list.html:7
+#: src/olympia/addons/templates/addons/impala/addon_hovercard.html:34 src/olympia/addons/templates/addons/impala/featured_grid.html:26 src/olympia/addons/templates/addons/impala/theme_grid.html:22
+#: src/olympia/bandwagon/templates/bandwagon/collection_detail.html:31 src/olympia/users/templates/users/helpers/addon_users_list.html:7
 #, python-format
 msgid "by %(users)s"
 msgstr "por %(users)s"
@@ -1307,40 +961,22 @@ msgstr "Gostou desse complemento?"
 
 #: src/olympia/addons/templates/addons/impala/contribution.html:43
 #, python-format
-msgid ""
-"The <a href=\"%(meet_url)s\">developer of this add-on</a> asks that you help"
-" support its continued development by making a small contribution."
-msgstr ""
-"O <a href=\"%(meet_url)s\">desenvolvedor desse complemento</a> pede que você"
-" apoie o seu desenvolvimento contínuo deixando uma pequena contribuição."
+msgid "The <a href=\"%(meet_url)s\">developer of this add-on</a> asks that you help support its continued development by making a small contribution."
+msgstr "O <a href=\"%(meet_url)s\">desenvolvedor desse complemento</a> pede que você apoie o seu desenvolvimento contínuo deixando uma pequena contribuição."
 
 #: src/olympia/addons/templates/addons/impala/contribution.html:48
 #, python-format
-msgid ""
-"The <a href=\"%(meet_url)s\">developer of this add-on</a> asks that you show"
-" your support by making a donation to the <a "
-"href=\"%(charity_url)s\">%(charity_name)s</a>."
-msgstr ""
-"O <a href=\"%(meet_url)s\">desenvolvedor desse complemento</a> pede que você"
-" mostre seu apoio fazendo uma doação para <a "
-"href=\"%(charity_url)s\">%(charity_name)s</a>."
+msgid "The <a href=\"%(meet_url)s\">developer of this add-on</a> asks that you show your support by making a donation to the <a href=\"%(charity_url)s\">%(charity_name)s</a>."
+msgstr "O <a href=\"%(meet_url)s\">desenvolvedor desse complemento</a> pede que você mostre seu apoio fazendo uma doação para <a href=\"%(charity_url)s\">%(charity_name)s</a>."
 
 #: src/olympia/addons/templates/addons/impala/contribution.html:53
 #, python-format
-msgid ""
-"The <a href=\"%(meet_url)s\">developer of this add-on</a> asks that you show"
-" your support by making a small contribution to <a "
-"href=\"%(charity_url)s\">%(charity_name)s</a>."
-msgstr ""
-"O <a href=\"%(meet_url)s\">desenvolvedor desse complemento</a> pede que você"
-" mostre seu apoio deixando uma pequena contribuição para <a "
-"href=\"%(charity_url)s\">%(charity_name)s</a>."
+msgid "The <a href=\"%(meet_url)s\">developer of this add-on</a> asks that you show your support by making a small contribution to <a href=\"%(charity_url)s\">%(charity_name)s</a>."
+msgstr "O <a href=\"%(meet_url)s\">desenvolvedor desse complemento</a> pede que você mostre seu apoio deixando uma pequena contribuição para <a href=\"%(charity_url)s\">%(charity_name)s</a>."
 
 #: src/olympia/addons/templates/addons/impala/dependencies_note.html:4
 msgid "This add-on requires the following add-ons to work properly:"
-msgstr ""
-"Esse complemento requer os seguintes complementos para funcionar "
-"corretamente:"
+msgstr "Esse complemento requer os seguintes complementos para funcionar corretamente:"
 
 #: src/olympia/addons/templates/addons/impala/details-more.html:13
 msgid "Average"
@@ -1368,32 +1004,31 @@ msgid_plural "Other add-ons by these authors"
 msgstr[0] "Outros complementos de %(author)s"
 msgstr[1] "Outros complementos desses autores"
 
-#: src/olympia/addons/templates/addons/impala/details.html:41
+#: src/olympia/addons/templates/addons/impala/details.html:39
 #, python-format
 msgid "<span itemprop=\"ratingCount\">%(num)s</span> user review"
 msgid_plural "<span itemprop=\"ratingCount\">%(num)s</span> user reviews"
 msgstr[0] "<span itemprop=\"ratingCount\">%(num)s</span> análise de usuários"
 msgstr[1] "<span itemprop=\"ratingCount\">%(num)s</span> análises de usuários"
 
-#: src/olympia/addons/templates/addons/impala/details.html:69
+#: src/olympia/addons/templates/addons/impala/details.html:66
 msgid "View statistics"
 msgstr "Ver estatísticas"
 
-#: src/olympia/addons/templates/addons/impala/details.html:84
+#: src/olympia/addons/templates/addons/impala/details.html:81
 msgid "Manage"
 msgstr "Gerenciar"
 
 #. {0} is an add-on name.
-#: src/olympia/addons/templates/addons/impala/details.html:96
+#: src/olympia/addons/templates/addons/impala/details.html:93
 msgid "Icon of {0}"
 msgstr "Ícone de {0}"
 
-#: src/olympia/addons/templates/addons/impala/details.html:103
-#: src/olympia/addons/templates/addons/impala/listing/items.html:14
+#: src/olympia/addons/templates/addons/impala/details.html:100 src/olympia/addons/templates/addons/impala/listing/items.html:14
 msgid "No Restart"
 msgstr "Não precisa reiniciar"
 
-#: src/olympia/addons/templates/addons/impala/details.html:127
+#: src/olympia/addons/templates/addons/impala/details.html:124
 #, python-format
 msgid "Meet the Developer: <a href=\"%(url)s\">%(name)s</a>"
 msgid_plural "<a href=\"%(url)s\">Meet the Developers</a>"
@@ -1401,114 +1036,90 @@ msgstr[0] "Conheça o desenvolvedor: <a href=\"%(url)s\">%(name)s</a>"
 msgstr[1] "<a href=\"%(url)s\">Conheça os desenvolvedores</a>"
 
 # {0} is an add-on name.
-#: src/olympia/addons/templates/addons/impala/details.html:137
+#: src/olympia/addons/templates/addons/impala/details.html:134
 msgid "Learn why {0} was created and find out what's next for this add-on."
-msgstr ""
-"Saiba por que {0} foi criado e descubra o que vem aí para esse complemento."
+msgstr "Saiba por que {0} foi criado e descubra o que vem aí para esse complemento."
 
 #. {0} is an index.
-#: src/olympia/addons/templates/addons/impala/details.html:156
+#: src/olympia/addons/templates/addons/impala/details.html:161
 msgid "Add-on screenshot #{0}"
 msgstr "Captura de tela n.{0} do complemento"
 
-#: src/olympia/addons/templates/addons/impala/details.html:182
+#: src/olympia/addons/templates/addons/impala/details.html:187
 msgid "Add-on home page"
 msgstr "Página do complemento"
 
-#: src/olympia/addons/templates/addons/impala/details.html:185
+#: src/olympia/addons/templates/addons/impala/details.html:190
 msgid "Support site"
 msgstr "Página de ajuda"
 
-#: src/olympia/addons/templates/addons/impala/details.html:189
+#: src/olympia/addons/templates/addons/impala/details.html:194
 msgid "Support E-mail"
 msgstr "E-mail de ajuda"
 
-#: src/olympia/addons/templates/addons/impala/details.html:194
-#: src/olympia/devhub/models.py:378
-#: src/olympia/devhub/templates/devhub/versions/list.html:12
-#: src/olympia/versions/templates/versions/version.html:6
-#: src/olympia/versions/templates/versions/mobile/version.html:6
+#: src/olympia/addons/templates/addons/impala/details.html:199 src/olympia/devhub/models.py:378 src/olympia/devhub/templates/devhub/versions/list.html:12
+#: src/olympia/versions/templates/versions/version.html:6 src/olympia/versions/templates/versions/mobile/version.html:6
 msgid "Version {0}"
 msgstr "Versão {0}"
 
-#: src/olympia/addons/templates/addons/impala/details.html:194
+#: src/olympia/addons/templates/addons/impala/details.html:199
 msgid "Info"
 msgstr "Informações"
 
-#: src/olympia/addons/templates/addons/impala/details.html:195
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:129
+#: src/olympia/addons/templates/addons/impala/details.html:200 src/olympia/devhub/templates/devhub/includes/addon_details.html:116
 msgid "Last Updated:"
 msgstr "Última Atualização:"
 
-#: src/olympia/addons/templates/addons/impala/details.html:200
+#: src/olympia/addons/templates/addons/impala/details.html:205
 #, python-format
 msgid "Released under <a target=\"_blank\" href=\"%(url)s\">%(name)s</a>"
 msgstr "Lançado sob <a target=\"_blank\" href=\"%(url)s\">%(name)s</a>"
 
-#: src/olympia/addons/templates/addons/impala/details.html:201
-#: src/olympia/addons/templates/addons/impala/details.html:206
-#: src/olympia/amo/helpers.py:398 src/olympia/devhub/forms.py:142
-#: src/olympia/devhub/forms.py:173
-#: src/olympia/versions/templates/versions/version.html:40
-#: src/olympia/versions/templates/versions/version.html:45
+#: src/olympia/addons/templates/addons/impala/details.html:206 src/olympia/addons/templates/addons/impala/details.html:211 src/olympia/amo/helpers.py:398 src/olympia/devhub/forms.py:142
+#: src/olympia/devhub/forms.py:173 src/olympia/versions/templates/versions/version.html:40 src/olympia/versions/templates/versions/version.html:45
 msgid "Custom License"
 msgstr "Licença personalizada"
 
-#: src/olympia/addons/templates/addons/impala/details.html:205
+#: src/olympia/addons/templates/addons/impala/details.html:210
 #, python-format
 msgid "Released under <a href=\"%(url)s\">%(name)s</a>"
 msgstr "Lançado sob <a href=\"%(url)s\">%(name)s</a>"
 
-#: src/olympia/addons/templates/addons/impala/details.html:217
+#: src/olympia/addons/templates/addons/impala/details.html:222
 msgid "About this Add-on"
 msgstr "Sobre esse complemento"
 
-#: src/olympia/addons/templates/addons/impala/details.html:233
+#: src/olympia/addons/templates/addons/impala/details.html:238
 msgid "Developer’s Comments"
 msgstr "Comentários do desenvolvedor"
 
-#: src/olympia/addons/templates/addons/impala/details.html:243
+#: src/olympia/addons/templates/addons/impala/details.html:248
 msgid "Version Information"
 msgstr "Informações da versão"
 
-#: src/olympia/addons/templates/addons/impala/details.html:250
+#: src/olympia/addons/templates/addons/impala/details.html:255
 msgid "See complete version history"
 msgstr "Ver o histórico completo de versões"
 
-#: src/olympia/addons/templates/addons/impala/details.html:262
+#: src/olympia/addons/templates/addons/impala/details.html:267
 msgid ""
-"The Development Channel lets you test an experimental new version of this "
-"add-on before it's released to the general public. Once you install the "
-"development version, you will continue to get updates from this channel. To "
-"stop receiving development updates, reinstall the default version from the "
-"link above."
+"The Development Channel lets you test an experimental new version of this add-on before it's released to the general public. Once you install the development version, you will continue to get "
+"updates from this channel. To stop receiving development updates, reinstall the default version from the link above."
 msgstr ""
-"O Canal de Desenvolvimento permite que você teste um nova versão "
-"experimental desse complemento antes dele ser lançado ao público em geral. "
-"Uma vez instalada a versão em desenvolvimento, você continuará a receber "
-"atualizações desse canal. Para parar de recebê-las, reinstale a versão "
-"padrão no link acima."
+"O Canal de Desenvolvimento permite que você teste um nova versão experimental desse complemento antes dele ser lançado ao público em geral. Uma vez instalada a versão em desenvolvimento, você "
+"continuará a receber atualizações desse canal. Para parar de recebê-las, reinstale a versão padrão no link acima."
 
-#: src/olympia/addons/templates/addons/impala/details.html:272
-msgid ""
-"<strong>Caution:</strong> Development versions of this add-on have not been "
-"reviewed by Mozilla."
-msgstr ""
-"<strong>Atenção:</strong> Versões de desenvolvimento deste complemento não "
-"foram avaliadas pela Mozilla."
+#: src/olympia/addons/templates/addons/impala/details.html:277
+msgid "<strong>Caution:</strong> Development versions of this add-on have not been reviewed by Mozilla."
+msgstr "<strong>Atenção:</strong> Versões de desenvolvimento deste complemento não foram avaliadas pela Mozilla."
 
-#: src/olympia/addons/templates/addons/impala/details.html:287
+#: src/olympia/addons/templates/addons/impala/details.html:292
 msgid "See complete development channel history"
 msgstr "Veja o histórico completo de desenvolvimento no canal"
 
-#: src/olympia/addons/templates/addons/impala/details.html:306
-#: src/olympia/addons/templates/addons/impala/details.html:315
-#: src/olympia/addons/templates/addons/impala/details.html:327
-#: src/olympia/addons/templates/addons/impala/review_add_box.html:4
-#: src/olympia/stats/templates/stats/popup.html:2
-#: src/olympia/stats/templates/stats/popup.html:8
-#: src/olympia/stats/templates/stats/stats.html:202
-#: src/olympia/users/templates/users/profile.html:119
+#: src/olympia/addons/templates/addons/impala/details.html:311 src/olympia/addons/templates/addons/impala/details.html:320 src/olympia/addons/templates/addons/impala/details.html:332
+#: src/olympia/addons/templates/addons/impala/review_add_box.html:4 src/olympia/stats/templates/stats/popup.html:2 src/olympia/stats/templates/stats/popup.html:8
+#: src/olympia/stats/templates/stats/stats.html:204 src/olympia/users/templates/users/profile.html:119
 msgid "close"
 msgstr "fechar"
 
@@ -1517,19 +1128,15 @@ msgstr "fechar"
 msgid "Thank you for installing {0}"
 msgstr "Obrigado por instalar {0}"
 
-#. {0} is an add-on name.
 # %1 is an add-on name.
+#. {0} is an add-on name.
 #: src/olympia/addons/templates/addons/impala/developers.html:12
 msgid "Meet the {0} Developer"
 msgstr "Conheça o desenvolvedor de {0}"
 
 #: src/olympia/addons/templates/addons/impala/developers.html:41
-msgid ""
-"Before downloading this add-on, please consider supporting the development "
-"of this add-on by making a small contribution."
-msgstr ""
-"Antes de baixar esse complemento, por favor, considere apoiar o seu "
-"desenvolvimento deixando uma pequena contribuição."
+msgid "Before downloading this add-on, please consider supporting the development of this add-on by making a small contribution."
+msgstr "Antes de baixar esse complemento, por favor, considere apoiar o seu desenvolvimento deixando uma pequena contribuição."
 
 # %1 is an add-on name.
 #: src/olympia/addons/templates/addons/impala/developers.html:80
@@ -1547,9 +1154,7 @@ msgid_plural "About the Developers"
 msgstr[0] "Sobre o desenvolvedor"
 msgstr[1] "Sobre os desenvolvedores"
 
-#: src/olympia/addons/templates/addons/impala/developers.html:96
-#: src/olympia/users/templates/users/edit.html:130
-#: src/olympia/users/templates/users/profile.html:26
+#: src/olympia/addons/templates/addons/impala/developers.html:96 src/olympia/users/templates/users/edit.html:130 src/olympia/users/templates/users/profile.html:26
 msgid "No Photo"
 msgstr "Sem foto"
 
@@ -1569,24 +1174,15 @@ msgstr "Este complemento foi desabilitado por um administrador."
 msgid "Source Code License for {addon}"
 msgstr "Licença do código-fonte de {addon}"
 
-#: src/olympia/addons/templates/addons/impala/license.html:21
-#: src/olympia/versions/templates/versions/mobile/version.html:18
+#: src/olympia/addons/templates/addons/impala/license.html:21 src/olympia/versions/templates/versions/mobile/version.html:18
 msgid "Source Code License"
 msgstr "Licença do código-fonte"
 
-#: src/olympia/addons/templates/addons/impala/persona_grid.html:16
-#: src/olympia/addons/templates/addons/impala/toplist.html:6
-msgid "{0} users"
-msgstr "{0} usuários"
-
-#: src/olympia/addons/templates/addons/impala/review_list_box.html:19
-#: src/olympia/reviews/templates/reviews/review.html:40
+#: src/olympia/addons/templates/addons/impala/review_list_box.html:19 src/olympia/reviews/templates/reviews/review.html:40
 msgid "permalink"
 msgstr "link permanente"
 
-#: src/olympia/addons/templates/addons/impala/review_list_box.html:23
-#: src/olympia/editors/templates/editors/queue.html:98
-#: src/olympia/reviews/templates/reviews/review.html:44
+#: src/olympia/addons/templates/addons/impala/review_list_box.html:23 src/olympia/editors/templates/editors/queue.html:104 src/olympia/reviews/templates/reviews/review.html:44
 msgid "translate"
 msgstr "traduzir"
 
@@ -1597,8 +1193,7 @@ msgid_plural "See all %(cnt)s user reviews"
 msgstr[0] "Ver todas as análises de usuários"
 msgstr[1] "Ver todas as %(cnt)s análises de usuários"
 
-#: src/olympia/addons/templates/addons/impala/review_list_box.html:47
-#: src/olympia/reviews/templates/reviews/review_list.html:84
+#: src/olympia/addons/templates/addons/impala/review_list_box.html:47 src/olympia/reviews/templates/reviews/review_list.html:84
 msgid "This add-on has not yet been reviewed."
 msgstr "Esse complemento ainda não foi analisado."
 
@@ -1606,26 +1201,25 @@ msgstr "Esse complemento ainda não foi analisado."
 msgid "Be the first!"
 msgstr "Seja o primeiro!"
 
+#: src/olympia/addons/templates/addons/impala/toplist.html:6
+msgid "{0} users"
+msgstr "{0} usuários"
+
 # This is a separator between the graphical [contribute] button and the
 # graphical [download now] button
-#: src/olympia/addons/templates/addons/impala/listing/sorter.html:14
-#: src/olympia/devhub/templates/devhub/addons/listing/item_actions.html:49
+#: src/olympia/addons/templates/addons/impala/listing/sorter.html:14 src/olympia/devhub/templates/devhub/addons/listing/item_actions.html:49
 msgid "More"
 msgstr "Mais"
 
-#: src/olympia/addons/templates/addons/includes/collection_add_widget.html:7
-#: src/olympia/addons/templates/addons/includes/collection_add_widget.html:10
+#: src/olympia/addons/templates/addons/includes/collection_add_widget.html:7 src/olympia/addons/templates/addons/includes/collection_add_widget.html:10
 msgid "Add to collection"
 msgstr "Adicionar a uma coleção"
 
-#: src/olympia/addons/templates/addons/includes/dashboard_tabs.html:4
-#: src/olympia/devhub/templates/devhub/index.html:73
-#: src/olympia/devhub/templates/devhub/nav.html:14
+#: src/olympia/addons/templates/addons/includes/dashboard_tabs.html:4 src/olympia/devhub/templates/devhub/index.html:73 src/olympia/devhub/templates/devhub/nav.html:14
 msgid "My Add-ons"
 msgstr "Meus complementos"
 
-#: src/olympia/addons/templates/addons/includes/dashboard_tabs.html:6
-#: src/olympia/amo/context_processors.py:51
+#: src/olympia/addons/templates/addons/includes/dashboard_tabs.html:6 src/olympia/amo/context_processors.py:50
 msgid "My Themes"
 msgstr "Meus temas"
 
@@ -1641,22 +1235,17 @@ msgstr "Editar tema"
 msgid "Approve / Reject"
 msgstr "Aprovar / Rejeitar"
 
-#: src/olympia/addons/templates/addons/includes/persona.html:25
-#: src/olympia/editors/templates/editors/themes/single.html:43
+#: src/olympia/addons/templates/addons/includes/persona.html:25 src/olympia/editors/templates/editors/themes/single.html:43
 msgid "Review History"
 msgstr "Histórico de análises"
 
 #: src/olympia/addons/templates/addons/includes/persona_pending_notice.html:3
 msgid "Sorry, this theme is pending. Please come back later."
-msgstr ""
-"Desculpe, mas este tema ainda não está pronto. Por favor, confira novamente "
-"em breve."
+msgstr "Desculpe, mas este tema ainda não está pronto. Por favor, confira novamente em breve."
 
 #: src/olympia/addons/templates/addons/includes/persona_pending_notice.html:8
 msgid "This theme is pending. It is invisible to everyone but you."
-msgstr ""
-"Este tema ainda não está pronto. Ele fica invisível para todo mundo, menos "
-"para você."
+msgstr "Este tema ainda não está pronto. Ele fica invisível para todo mundo, menos para você."
 
 #: src/olympia/addons/templates/addons/listing/items.html:29
 msgid "Collector's Note"
@@ -1666,11 +1255,9 @@ msgstr "Nota do colecionador"
 msgid "Not Yet Rated"
 msgstr "Ainda sem avaliações"
 
-#. {0} is the number of downloads.
 # {0} is the count of addons in a collection
-#: src/olympia/addons/templates/addons/listing/items_mobile.html:27
-#: src/olympia/addons/templates/addons/listing/macros.html:24
-#: src/olympia/devhub/templates/devhub/addons/listing/macros.html:15
+#. {0} is the number of downloads.
+#: src/olympia/addons/templates/addons/listing/items_mobile.html:27 src/olympia/addons/templates/addons/listing/macros.html:24 src/olympia/devhub/templates/devhub/addons/listing/macros.html:15
 msgid "<strong>{0}</strong> weekly download"
 msgid_plural "<strong>{0}</strong> weekly downloads"
 msgstr[0] "<strong>{0}</strong> download semanal"
@@ -1684,15 +1271,11 @@ msgstr "Leia mais"
 msgid "Users"
 msgstr "Usuários"
 
-#: src/olympia/addons/templates/addons/mobile/details.html:92
-#: src/olympia/browse/views.py:59 src/olympia/browse/views.py:70
-#: src/olympia/search/forms.py:90
+#: src/olympia/addons/templates/addons/mobile/details.html:92 src/olympia/browse/views.py:59 src/olympia/browse/views.py:70 src/olympia/search/forms.py:90
 msgid "Weekly Downloads"
 msgstr "Downloads semanais"
 
-#: src/olympia/addons/templates/addons/mobile/details.html:99
-#: src/olympia/compat/templates/compat/reporter_detail.html:46
-#: src/olympia/devhub/forms.py:787
+#: src/olympia/addons/templates/addons/mobile/details.html:99 src/olympia/compat/templates/compat/reporter_detail.html:46 src/olympia/devhub/forms.py:788
 #: src/olympia/devhub/templates/devhub/versions/list.html:163
 msgid "Version"
 msgstr "Versão"
@@ -1729,50 +1312,30 @@ msgstr "Acordo de Licença"
 # %(name)s is the name of the add-on
 #: src/olympia/addons/templates/addons/mobile/eula.html:5
 #, python-format
-msgid ""
-"%(name)s requires that you accept the following End-User License Agreement "
-"before installation can proceed:"
-msgstr ""
-"%(name)s precisa que você aceite o Acordo de Licença a seguir antes de "
-"continuar a instalação:"
+msgid "%(name)s requires that you accept the following End-User License Agreement before installation can proceed:"
+msgstr "%(name)s precisa que você aceite o Acordo de Licença a seguir antes de continuar a instalação:"
 
 #: src/olympia/addons/templates/addons/mobile/eula.html:15
 msgid "Accept"
 msgstr "Aceitar"
 
-#: src/olympia/addons/templates/addons/mobile/home.html:10
-#: src/olympia/templates/mobile/base_addons.html:53
+#: src/olympia/addons/templates/addons/mobile/home.html:10 src/olympia/templates/mobile/base_addons.html:53
 msgid "Add-ons are not currently available on Firefox for iOS."
 msgstr "Atualmente os complementos não estão disponíveis no Firefox para iOS."
 
-#: src/olympia/addons/templates/addons/mobile/home.html:12
-#: src/olympia/templates/mobile/base_addons.html:55
-msgid ""
-"You need Firefox to install add-ons. <a "
-"href=\"http://mozilla.com/mobile\">Learn More&nbsp;&raquo;</a>"
-msgstr ""
-"Você precisa do Firefox para instalar complementos. <a "
-"href=\"http://mozilla.com/mobile\">Saiba mais&nbsp;&raquo;</a>"
+#: src/olympia/addons/templates/addons/mobile/home.html:12 src/olympia/templates/mobile/base_addons.html:55
+msgid "You need Firefox to install add-ons. <a href=\"http://mozilla.com/mobile\">Learn More&nbsp;&raquo;</a>"
+msgstr "Você precisa do Firefox para instalar complementos. <a href=\"http://mozilla.com/mobile\">Saiba mais&nbsp;&raquo;</a>"
 
 # {0} is the application name.  Example:  Firefox
-#: src/olympia/addons/templates/addons/mobile/home.html:19
-#: src/olympia/templates/header_title.html:4
-#: src/olympia/templates/impala/header_title.html:3
+#: src/olympia/addons/templates/addons/mobile/home.html:19 src/olympia/templates/header_title.html:4 src/olympia/templates/impala/header_title.html:3
 msgid "Return to the {0} Add-ons homepage"
 msgstr "Voltar para a página inicial de complementos para o {0}"
 
-#: src/olympia/addons/templates/addons/mobile/home.html:21
-#: src/olympia/amo/helpers.py:237
-#: src/olympia/bandwagon/templates/bandwagon/edit.html:34
-#: src/olympia/discovery/templates/discovery/pane.html:92
-#: src/olympia/editors/templates/editors/base.html:21
-#: src/olympia/editors/templates/editors/performance.html:72
-#: src/olympia/templates/menu_links.html:4
-#: src/olympia/templates/impala/header_title.html:13
-#: src/olympia/templates/impala/header_title.html:15
-#: src/olympia/templates/impala/header_title.html:19
-#: src/olympia/templates/impala/header_title.html:23
-#: src/olympia/templates/mobile/base_addons.html:47
+#: src/olympia/addons/templates/addons/mobile/home.html:21 src/olympia/amo/helpers.py:237 src/olympia/bandwagon/templates/bandwagon/edit.html:34 src/olympia/discovery/templates/discovery/pane.html:92
+#: src/olympia/editors/templates/editors/base.html:21 src/olympia/editors/templates/editors/performance.html:72 src/olympia/templates/menu_links.html:4
+#: src/olympia/templates/impala/header_title.html:13 src/olympia/templates/impala/header_title.html:15 src/olympia/templates/impala/header_title.html:19
+#: src/olympia/templates/impala/header_title.html:23 src/olympia/templates/mobile/base_addons.html:47
 msgid "Add-ons"
 msgstr "Complementos"
 
@@ -1780,49 +1343,29 @@ msgstr "Complementos"
 msgid "Easy ways to personalize."
 msgstr "Maneiras fáceis de personalizar."
 
-#: src/olympia/addons/templates/addons/mobile/home.html:24
-#: src/olympia/devhub/templates/devhub/addons/submit/done.html:47
-#: src/olympia/discovery/templates/discovery/pane.html:34
-#: src/olympia/discovery/templates/discovery/addons/detail.html:16
-#: src/olympia/discovery/templates/discovery/modules/featured.html:21
-#: src/olympia/discovery/templates/discovery/modules/monthly.html:22
+#: src/olympia/addons/templates/addons/mobile/home.html:24 src/olympia/devhub/templates/devhub/addons/submit/done.html:47 src/olympia/discovery/templates/discovery/pane.html:34
+#: src/olympia/discovery/templates/discovery/addons/detail.html:16 src/olympia/discovery/templates/discovery/modules/featured.html:21 src/olympia/discovery/templates/discovery/modules/monthly.html:22
 msgid "Learn More"
 msgstr "Saiba mais"
 
 #: src/olympia/addons/templates/addons/mobile/home.html:26
 msgid ""
-"Add-ons are applications that let you personalize Firefox with extra "
-"functionality and style. Whether you mistype the name of a website or can't "
-"read a busy page, there's an add-on to improve your on-the-go browsing."
+"Add-ons are applications that let you personalize Firefox with extra functionality and style. Whether you mistype the name of a website or can't read a busy page, there's an add-on to improve your "
+"on-the-go browsing."
 msgstr ""
-"Complementos são pedaços de programas que permitem personalizar o Firefox "
-"com recursos e estilo extras. Quer você digite errado o nome de um site ou "
-"não consiga ler uma página ocupada, existe um complemento para melhorar a "
-"sua navegação."
+"Complementos são pedaços de programas que permitem personalizar o Firefox com recursos e estilo extras. Quer você digite errado o nome de um site ou não consiga ler uma página ocupada, existe um "
+"complemento para melhorar a sua navegação."
 
+# Plural in this context means many of the add-on type
 #. {0} is a category name. Ex: "Sports"
 #. {0} is a category name, such as Nature.
-# Plural in this context means many of the add-on type
-#: src/olympia/addons/templates/addons/mobile/home.html:43
-#: src/olympia/amo/templates/amo/site_nav.html:32
-#: src/olympia/browse/feeds.py:107
-#: src/olympia/browse/templates/browse/impala/base_listing.html:38
-#: src/olympia/browse/templates/browse/personas/base.html:6
-#: src/olympia/browse/templates/browse/personas/base.html:42
-#: src/olympia/browse/templates/browse/personas/category_landing.html:21
-#: src/olympia/browse/templates/browse/personas/category_landing.html:23
-#: src/olympia/browse/templates/browse/personas/category_landing.html:38
-#: src/olympia/browse/templates/browse/personas/grid.html:7
-#: src/olympia/browse/templates/browse/personas/grid.html:11
-#: src/olympia/browse/templates/browse/personas/mobile/base.html:7
-#: src/olympia/browse/templates/browse/personas/mobile/category_landing.html:19
-#: src/olympia/constants/base.py:180
-#: src/olympia/devhub/templates/devhub/personas/submit.html:13
-#: src/olympia/editors/helpers.py:105
-#: src/olympia/editors/templates/editors/base.html:26
-#: src/olympia/editors/templates/editors/performance.html:73
-#: src/olympia/search/templates/search/personas.html:39
-#: src/olympia/templates/menu_links.html:9
+#: src/olympia/addons/templates/addons/mobile/home.html:43 src/olympia/amo/templates/amo/site_nav.html:32 src/olympia/browse/feeds.py:107
+#: src/olympia/browse/templates/browse/impala/base_listing.html:38 src/olympia/browse/templates/browse/personas/base.html:6 src/olympia/browse/templates/browse/personas/base.html:42
+#: src/olympia/browse/templates/browse/personas/category_landing.html:21 src/olympia/browse/templates/browse/personas/category_landing.html:23
+#: src/olympia/browse/templates/browse/personas/category_landing.html:38 src/olympia/browse/templates/browse/personas/grid.html:7 src/olympia/browse/templates/browse/personas/grid.html:11
+#: src/olympia/browse/templates/browse/personas/mobile/base.html:7 src/olympia/browse/templates/browse/personas/mobile/category_landing.html:19 src/olympia/constants/base.py:180
+#: src/olympia/devhub/templates/devhub/personas/submit.html:13 src/olympia/editors/helpers.py:107 src/olympia/editors/templates/editors/base.html:26
+#: src/olympia/editors/templates/editors/performance.html:73 src/olympia/search/templates/search/personas.html:39 src/olympia/templates/menu_links.html:9
 msgid "Themes"
 msgstr "Temas"
 
@@ -1840,19 +1383,12 @@ msgstr "Ver todos os complementos populares"
 msgid "More Add-ons"
 msgstr "Mais complementos"
 
-#: src/olympia/addons/templates/addons/mobile/home.html:72
-#: src/olympia/browse/templates/browse/personas/mobile/category_landing.html:64
-#: src/olympia/search/forms.py:14
+#: src/olympia/addons/templates/addons/mobile/home.html:72 src/olympia/browse/templates/browse/personas/mobile/category_landing.html:64 src/olympia/search/forms.py:14
 msgid "Highest Rated"
 msgstr "Melhor avaliadas"
 
-#: src/olympia/addons/templates/addons/mobile/home.html:74
-#: src/olympia/amo/templates/amo/side_nav.html:5
-#: src/olympia/amo/templates/amo/site_nav.html:27
-#: src/olympia/amo/templates/amo/site_nav.html:57
-#: src/olympia/bandwagon/views.py:97 src/olympia/browse/views.py:57
-#: src/olympia/browse/views.py:67
-#: src/olympia/browse/templates/browse/personas/mobile/category_landing.html:65
+#: src/olympia/addons/templates/addons/mobile/home.html:74 src/olympia/amo/templates/amo/side_nav.html:5 src/olympia/amo/templates/amo/site_nav.html:27 src/olympia/amo/templates/amo/site_nav.html:55
+#: src/olympia/bandwagon/views.py:97 src/olympia/browse/views.py:57 src/olympia/browse/views.py:67 src/olympia/browse/templates/browse/personas/mobile/category_landing.html:65
 #: src/olympia/search/forms.py:15 src/olympia/search/forms.py:87
 msgid "Newest"
 msgstr "Mais recentes"
@@ -1865,122 +1401,90 @@ msgstr "Experimentar!"
 msgid "Theme Info &raquo;"
 msgstr "Informações do tema"
 
-#: src/olympia/amo/context_processors.py:39
-#: src/olympia/devhub/templates/devhub/nav.html:43
+#: src/olympia/amo/context_processors.py:37 src/olympia/devhub/templates/devhub/nav.html:43
 msgid "Tools"
 msgstr "Ferramentas"
 
-#: src/olympia/amo/context_processors.py:48
-#: src/olympia/discovery/templates/discovery/pane_account.html:8
-#: src/olympia/users/templates/users/includes/navigation.html:2
+#: src/olympia/amo/context_processors.py:47 src/olympia/discovery/templates/discovery/pane_account.html:8 src/olympia/users/templates/users/includes/navigation.html:2
 msgid "My Profile"
 msgstr "Meu perfil"
 
-#: src/olympia/amo/context_processors.py:54
-#: src/olympia/users/templates/users/edit.html:5
-#: src/olympia/users/templates/users/includes/navigation.html:3
+#: src/olympia/amo/context_processors.py:53 src/olympia/users/templates/users/edit.html:5 src/olympia/users/templates/users/includes/navigation.html:3
 msgid "Account Settings"
 msgstr "Configurações da conta"
 
-#: src/olympia/amo/context_processors.py:57
-#: src/olympia/discovery/templates/discovery/pane_account.html:11
-#: src/olympia/users/templates/users/profile.html:83
+#: src/olympia/amo/context_processors.py:56 src/olympia/discovery/templates/discovery/pane_account.html:11 src/olympia/users/templates/users/profile.html:83
 #: src/olympia/users/templates/users/includes/navigation.html:4
 msgid "My Collections"
 msgstr "Minhas coleções"
 
-#: src/olympia/amo/context_processors.py:62
-#: src/olympia/discovery/templates/discovery/pane_account.html:10
-#: src/olympia/users/templates/users/includes/navigation.html:7
+#: src/olympia/amo/context_processors.py:61 src/olympia/discovery/templates/discovery/pane_account.html:10 src/olympia/users/templates/users/includes/navigation.html:7
 msgid "My Favorites"
 msgstr "Meus favoritos"
 
-#: src/olympia/amo/context_processors.py:67
-#: src/olympia/discovery/templates/discovery/pane_account.html:13
-#: src/olympia/templates/impala/user_login.html:14
+#: src/olympia/amo/context_processors.py:66 src/olympia/discovery/templates/discovery/pane_account.html:13 src/olympia/templates/impala/user_login.html:14
 #: src/olympia/templates/mobile/header_auth.html:5
 msgid "Log out"
 msgstr "Sair"
 
-#: src/olympia/amo/context_processors.py:72
-#: src/olympia/devhub/templates/devhub/addons/dashboard.html:4
+#: src/olympia/amo/context_processors.py:71 src/olympia/devhub/templates/devhub/addons/dashboard.html:4
 msgid "Manage My Submissions"
 msgstr "Gerenciar minhas submissões"
 
-#: src/olympia/amo/context_processors.py:75
-#: src/olympia/devhub/templates/devhub/nav.html:27
-#: src/olympia/devhub/templates/devhub/addons/dashboard.html:25
+#: src/olympia/amo/context_processors.py:74 src/olympia/devhub/templates/devhub/nav.html:27 src/olympia/devhub/templates/devhub/addons/dashboard.html:25
 #: src/olympia/devhub/templates/devhub/addons/submit/base.html:4
 msgid "Submit a New Add-on"
 msgstr "Enviar um complemento novo"
 
-#: src/olympia/amo/context_processors.py:77
-#: src/olympia/browse/templates/browse/personas/base.html:50
-#: src/olympia/devhub/templates/devhub/index.html:24
+#: src/olympia/amo/context_processors.py:76 src/olympia/browse/templates/browse/personas/base.html:50 src/olympia/devhub/templates/devhub/index.html:24
 #: src/olympia/devhub/templates/devhub/addons/dashboard.html:29
 msgid "Submit a New Theme"
 msgstr "Enviar um tema novo"
 
-#: src/olympia/amo/context_processors.py:79
-#: src/olympia/amo/templates/amo/site_nav.html:87
-#: src/olympia/devhub/helpers.py:36 src/olympia/devhub/helpers.py:68
-#: src/olympia/devhub/helpers.py:102 src/olympia/templates/footer.html:6
-#: src/olympia/templates/menu_links.html:14
+#: src/olympia/amo/context_processors.py:78 src/olympia/amo/templates/amo/site_nav.html:85 src/olympia/devhub/helpers.py:36 src/olympia/devhub/helpers.py:68 src/olympia/devhub/helpers.py:102
+#: src/olympia/templates/footer.html:6 src/olympia/templates/menu_links.html:14
 msgid "Developer Hub"
 msgstr "Central do Desenvolvedor"
 
-#: src/olympia/amo/context_processors.py:83 src/olympia/devhub/views.py:1792
+#: src/olympia/amo/context_processors.py:81 src/olympia/devhub/views.py:1796
 msgid "Manage API Keys"
 msgstr "Gerenciar chaves API"
 
-#: src/olympia/amo/context_processors.py:88 src/olympia/editors/helpers.py:82
-#: src/olympia/editors/helpers.py:102
-#: src/olympia/editors/templates/editors/base.html:10
+#: src/olympia/amo/context_processors.py:86 src/olympia/editors/helpers.py:84 src/olympia/editors/helpers.py:104 src/olympia/editors/templates/editors/base.html:10
 msgid "Editor Tools"
 msgstr "Ferramentas do editor"
 
-#: src/olympia/amo/context_processors.py:92
+#: src/olympia/amo/context_processors.py:90
 msgid "Admin Tools"
 msgstr "Ferramentas de administração"
 
-#: src/olympia/amo/fields.py:15
+#: src/olympia/amo/fields.py:20
 msgid "Incorrect, please try again."
 msgstr "Incorreto, tente novamente."
 
-#: src/olympia/amo/fields.py:16
+#: src/olympia/amo/fields.py:21
 msgid "Error verifying input, please try again."
 msgstr "Erro ao verificar entrada, tente novamente."
 
-#: src/olympia/amo/fields.py:32
+#: src/olympia/amo/fields.py:37
 msgid "This must be a valid hex color code, such as #000000."
 msgstr "Deve ser um código de cor hexadecimal válido, como #000000."
 
-#: src/olympia/amo/fields.py:58
+#: src/olympia/amo/fields.py:63
 msgid "Enter at least one value."
 msgstr "Insira pelo menos um valor."
 
-#: src/olympia/amo/helpers.py:162
-#: src/olympia/amo/templates/amo/site_nav.html:61
-#: src/olympia/bandwagon/templates/bandwagon/add.html:9
-#: src/olympia/bandwagon/templates/bandwagon/collection_detail.html:15
-#: src/olympia/bandwagon/templates/bandwagon/delete.html:9
-#: src/olympia/bandwagon/templates/bandwagon/edit.html:15
-#: src/olympia/bandwagon/templates/bandwagon/user_listing.html:18
-#: src/olympia/bandwagon/templates/bandwagon/user_listing.html:21
-#: src/olympia/bandwagon/templates/bandwagon/impala/collection_listing.html:12
-#: src/olympia/bandwagon/templates/bandwagon/impala/collection_listing.html:20
-#: src/olympia/bandwagon/templates/bandwagon/impala/collection_listing.html:24
-#: src/olympia/bandwagon/templates/bandwagon/impala/collection_sidebar.html:3
-#: src/olympia/bandwagon/templates/bandwagon/includes/collection_sidebar.html:2
-#: src/olympia/bandwagon/templates/bandwagon/mobile/collection_listing.html:3
-#: src/olympia/stats/templates/stats/stats.html:77
-#: src/olympia/templates/menu_links.html:12
+#: src/olympia/amo/helpers.py:162 src/olympia/amo/templates/amo/site_nav.html:59 src/olympia/bandwagon/templates/bandwagon/add.html:9
+#: src/olympia/bandwagon/templates/bandwagon/collection_detail.html:15 src/olympia/bandwagon/templates/bandwagon/delete.html:9 src/olympia/bandwagon/templates/bandwagon/edit.html:15
+#: src/olympia/bandwagon/templates/bandwagon/user_listing.html:18 src/olympia/bandwagon/templates/bandwagon/user_listing.html:21
+#: src/olympia/bandwagon/templates/bandwagon/impala/collection_listing.html:12 src/olympia/bandwagon/templates/bandwagon/impala/collection_listing.html:20
+#: src/olympia/bandwagon/templates/bandwagon/impala/collection_listing.html:24 src/olympia/bandwagon/templates/bandwagon/impala/collection_sidebar.html:3
+#: src/olympia/bandwagon/templates/bandwagon/includes/collection_sidebar.html:2 src/olympia/bandwagon/templates/bandwagon/mobile/collection_listing.html:3
+#: src/olympia/stats/templates/stats/stats.html:33 src/olympia/templates/menu_links.html:12
 msgid "Collections"
 msgstr "Coleções"
 
-#: src/olympia/amo/helpers.py:171
-#: src/olympia/amo/templates/amo/site_nav.html:85
-#: src/olympia/browse/templates/browse/language_tools.html:3
+#: src/olympia/amo/helpers.py:171 src/olympia/amo/templates/amo/site_nav.html:83 src/olympia/browse/templates/browse/language_tools.html:3
 msgid "Dictionaries & Language Packs"
 msgstr "Dicionários e Pacotes de idioma"
 
@@ -2146,11 +1650,8 @@ msgstr "Análise completa solicitada"
 msgid "Comment on {addon} {version}."
 msgstr "Comentário sobre {addon} {version}."
 
-#: src/olympia/amo/log.py:236
-#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:19
-#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:47
-#: src/olympia/editors/helpers.py:511
-#: src/olympia/editors/templates/editors/themes/history_table.html:11
+#: src/olympia/amo/log.py:236 src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:17 src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:45
+#: src/olympia/editors/helpers.py:584 src/olympia/editors/templates/editors/themes/history_table.html:11
 msgid "Comment"
 msgstr "Comentário"
 
@@ -2238,9 +1739,7 @@ msgstr "Versão máxima da aplicação para {version} atualizada."
 
 #: src/olympia/amo/log.py:359
 msgid "Authors emailed about compatibility of {version}."
-msgstr ""
-"Os autores foram notificados por e-mail sobre a compatibilidade de "
-"{version}."
+msgstr "Os autores foram notificados por e-mail sobre a compatibilidade de {version}."
 
 #: src/olympia/amo/log.py:364
 msgid "Email sent to Author about add-on compatibility."
@@ -2292,9 +1791,7 @@ msgstr "Aplicativo desabilitado"
 
 #: src/olympia/amo/log.py:425
 msgid "{addon} escalated because of high number of abuse reports."
-msgstr ""
-"{addon} foi encaminhado para análise superior devido a um grande número de "
-"denúncias de abuso."
+msgstr "{addon} foi encaminhado para análise superior devido a um grande número de denúncias de abuso."
 
 #: src/olympia/amo/log.py:426
 msgid "High Abuse Reports"
@@ -2310,7 +1807,7 @@ msgstr "Encaminhamento para análise superior do editor"
 
 #: src/olympia/amo/log.py:442
 msgid "Video removed from {addon} because of a problem with the video. "
-msgstr "O vídeo de {addon} foi removido devido a um problema com o arquivo. "
+msgstr ""
 
 #: src/olympia/amo/log.py:444
 msgid "Video removed"
@@ -2414,10 +1911,7 @@ msgstr "{addon} classificação de conteúdo alterado."
 msgid "{addon} unlisted."
 msgstr "{addon} não listado."
 
-#: src/olympia/amo/log.py:592 src/olympia/amo/log.py:598
-#: src/olympia/amo/log.py:612 src/olympia/amo/log.py:618
-#: src/olympia/amo/log.py:624 src/olympia/amo/log.py:630
-#: src/olympia/amo/log.py:636
+#: src/olympia/amo/log.py:592 src/olympia/amo/log.py:598 src/olympia/amo/log.py:612 src/olympia/amo/log.py:618 src/olympia/amo/log.py:624 src/olympia/amo/log.py:630 src/olympia/amo/log.py:636
 msgid "{file} was signed."
 msgstr "{file} foi assinado."
 
@@ -2431,20 +1925,12 @@ msgid "Not allowed"
 msgstr "Não permitido"
 
 #: src/olympia/amo/templates/amo/403.html:7
-msgid ""
-"<h1>Oops! Not allowed.</h1> <p>You tried to do something that you weren't "
-"allowed to.</p>"
-msgstr ""
-"<h1>Ops! Não permitido.</h1> <p>Tentou fazer algo que não está autorizado a "
-"fazer.</p>"
+msgid "<h1>Oops! Not allowed.</h1> <p>You tried to do something that you weren't allowed to.</p>"
+msgstr "<h1>Ops! Não permitido.</h1> <p>Tentou fazer algo que não está autorizado a fazer.</p>"
 
 #: src/olympia/amo/templates/amo/403.html:12
-msgid ""
-"<p>Try going back to the previous page, refreshing and then trying "
-"again.</p>"
-msgstr ""
-"<p>Tente voltar para a página anterior, atualizá-la, e então tente "
-"novamente.</p>"
+msgid "<p>Try going back to the previous page, refreshing and then trying again.</p>"
+msgstr "<p>Tente voltar para a página anterior, atualizá-la, e então tente novamente.</p>"
 
 #: src/olympia/amo/templates/amo/404.html:3
 msgid "Not Found"
@@ -2453,37 +1939,19 @@ msgstr "Não encontrado"
 #: src/olympia/amo/templates/amo/404.html:6
 #, python-format
 msgid ""
-"<h1>We're sorry, but we can't find what you're looking for.</h1> <p> The "
-"page or file you requested wasn't found on our site. It's possible that you "
-"clicked a link that's out of date, or typed in the address incorrectly. </p>"
-" <ul> <li>If you typed in the address, please double check the "
-"spelling.</li> <li> If you followed a link from somewhere, please let us "
-"know at <a href=\"mailto:webmaster@mozilla.com\">webmaster@mozilla.com</a>. "
-"Tell us where you came from and what you were looking for, and we'll do our "
-"best to fix it. </li> </ul> <p>Or you can just jump over to some of the "
-"popular pages on our website.</p> <ul> <li>Are you interested in a <a "
-"href=\"%(rec)s\">list of featured add-ons</a>?</li> <li> Do you want to <a "
-"href=\"%(search)s\">search for add-ons</a>? You may go to the <a "
-"href=\"%(search)s\">search page</a> or just use the search field above. "
-"</li> <li> If you prefer to start over, just go to the <a href=\"%(home)s"
-"\">add-ons front page</a>. </li> </ul>"
+"<h1>We're sorry, but we can't find what you're looking for.</h1> <p> The page or file you requested wasn't found on our site. It's possible that you clicked a link that's out of date, or typed in "
+"the address incorrectly. </p> <ul> <li>If you typed in the address, please double check the spelling.</li> <li> If you followed a link from somewhere, please let us know at <a href=\"mailto:"
+"webmaster@mozilla.com\">webmaster@mozilla.com</a>. Tell us where you came from and what you were looking for, and we'll do our best to fix it. </li> </ul> <p>Or you can just jump over to some of "
+"the popular pages on our website.</p> <ul> <li>Are you interested in a <a href=\"%(rec)s\">list of featured add-ons</a>?</li> <li> Do you want to <a href=\"%(search)s\">search for add-ons</a>? You "
+"may go to the <a href=\"%(search)s\">search page</a> or just use the search field above. </li> <li> If you prefer to start over, just go to the <a href=\"%(home)s\">add-ons front page</a>. </li> </"
+"ul>"
 msgstr ""
-"<h1>Lamentamos, mas não pudemos encontrar o que você está procurando.</h1> "
-"<p> A página ou arquivo que você solicitou não foi encontrado no nosso site."
-" É possível que você tenha clicado em um link que está desatualizado, ou "
-"digitado o endereço incorretamente. </p> <ul> <li>Se você digitou o "
-"endereço, por favor, verifique a digitação.</li> <li> Se você seguiu um link"
-" de algum lugar, por favor informe-nos em <a "
-"href=\"mailto:webmaster@mozilla.com\">webmaster@mozilla.com</a>. Diga de "
-"onde veio e o que você estava procurando, e nós faremos o melhor para "
-"corrigir esse problema. </li> </ul> <p>Ou você pode simplesmente ir para "
-"algumas das páginas mais populares do nosso site.</p> <ul> <li>Você está "
-"interessado em uma <a href=\"%(rec)s\">lista de complementos em "
-"destaque</a>?</li> <li> Deseja <a href=\"%(search)s\">procurar "
-"complementos</a>? Você pode ir até a <a href=\"%(search)s\">página de "
-"pesquisa</a> ou simplesmente usar o campo de pesquisa acima. </li> <li> Se "
-"preferir começar de novo, basta ir até a <a href=\"%(home)s\">página inicial"
-" de complementos</a>. </li> </ul>"
+"<h1>Lamentamos, mas não pudemos encontrar o que você está procurando.</h1> <p> A página ou arquivo que você solicitou não foi encontrado no nosso site. É possível que você tenha clicado em um link "
+"que está desatualizado, ou digitado o endereço incorretamente. </p> <ul> <li>Se você digitou o endereço, por favor, verifique a digitação.</li> <li> Se você seguiu um link de algum lugar, por favor "
+"informe-nos em <a href=\"mailto:webmaster@mozilla.com\">webmaster@mozilla.com</a>. Diga de onde veio e o que você estava procurando, e nós faremos o melhor para corrigir esse problema. </li> </ul> "
+"<p>Ou você pode simplesmente ir para algumas das páginas mais populares do nosso site.</p> <ul> <li>Você está interessado em uma <a href=\"%(rec)s\">lista de complementos em destaque</a>?</li> <li> "
+"Deseja <a href=\"%(search)s\">procurar complementos</a>? Você pode ir até a <a href=\"%(search)s\">página de pesquisa</a> ou simplesmente usar o campo de pesquisa acima. </li> <li> Se preferir "
+"começar de novo, basta ir até a <a href=\"%(home)s\">página inicial de complementos</a>. </li> </ul>"
 
 #: src/olympia/amo/templates/amo/500.html:3
 msgid "Oops"
@@ -2491,83 +1959,49 @@ msgstr "Ops"
 
 #: src/olympia/amo/templates/amo/500.html:6
 #, python-format
-msgid ""
-"<h1>Oops!  We had an error.</h1> <p>We'll get to fixing that soon.</p> <p> "
-"You can try refreshing the page, or head back to the <a href=\"%(home)s"
-"\">Add-ons homepage</a>. </p>"
+msgid "<h1>Oops!  We had an error.</h1> <p>We'll get to fixing that soon.</p> <p> You can try refreshing the page, or head back to the <a href=\"%(home)s\">Add-ons homepage</a>. </p>"
 msgstr ""
-"<h1>Opa!  Tivemos um problema.</h1> <p>Nós consertaremos isso logo.</p> "
-"<p>Você pode tentar atualizar a página ou voltar para a <a "
-"href=\"%(home)s\">página inicial dos complementos</a>.</p>"
 
 #: src/olympia/amo/templates/amo/license_link.html:10
 msgid "Some rights reserved"
 msgstr "Alguns direitos reservados"
 
-#: src/olympia/amo/templates/amo/no_results.html:1
-#: src/olympia/editors/templates/editors/includes/search_results_themes.html:26
+#: src/olympia/amo/templates/amo/no_results.html:1 src/olympia/editors/templates/editors/includes/search_results_themes.html:26
 msgid "No results found"
 msgstr "Nenhum resultado encontrado"
 
 #. abbreviation of 'previous'
-#: src/olympia/amo/templates/amo/paginator.html:6
-#: src/olympia/amo/templates/amo/mobile/paginator.html:4
-#: src/olympia/amo/templates/amo/mobile/paginator.html:6
-#: src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:49
-#: src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:63
-#: src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:76
-#: src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:89
+#: src/olympia/amo/templates/amo/paginator.html:6 src/olympia/amo/templates/amo/mobile/paginator.html:4 src/olympia/amo/templates/amo/mobile/paginator.html:6
+#: src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:49 src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:63
+#: src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:76 src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:89
 #: src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:102
 msgid "Prev"
 msgstr "Anterior"
 
-#: src/olympia/amo/templates/amo/paginator.html:26
-#: src/olympia/amo/templates/amo/impala/paginator.html:26
-#: src/olympia/amo/templates/amo/mobile/impala_paginator.html:16
-#: src/olympia/amo/templates/amo/mobile/paginator.html:14
-#: src/olympia/amo/templates/amo/mobile/paginator.html:16
-#: src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:51
-#: src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:65
-#: src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:78
-#: src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:91
-#: src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:104
-#: src/olympia/discovery/templates/discovery/pane.html:45
-#: src/olympia/discovery/templates/discovery/addons/detail.html:39
-#: src/olympia/stats/templates/stats/stats.html:167
+#: src/olympia/amo/templates/amo/paginator.html:26 src/olympia/amo/templates/amo/impala/paginator.html:26 src/olympia/amo/templates/amo/mobile/impala_paginator.html:16
+#: src/olympia/amo/templates/amo/mobile/paginator.html:14 src/olympia/amo/templates/amo/mobile/paginator.html:16 src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:51
+#: src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:65 src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:78
+#: src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:91 src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:104
+#: src/olympia/discovery/templates/discovery/pane.html:45 src/olympia/discovery/templates/discovery/addons/detail.html:39 src/olympia/stats/templates/stats/stats.html:169
 msgid "Next"
 msgstr "Próxima"
 
-#: src/olympia/amo/templates/amo/paginator.html:32
-#: src/olympia/editors/templates/editors/includes/paginator_history.html:11
+#: src/olympia/amo/templates/amo/paginator.html:32 src/olympia/editors/templates/editors/includes/paginator_history.html:11
 #, python-format
-msgid ""
-"Results <strong>%(begin)s</strong>&ndash;<strong>%(end)s</strong> of "
-"<strong>%(count)s</strong>"
-msgstr ""
-"Resultados <strong>%(begin)s</strong> a <strong>%(end)s</strong> de "
-"<strong>%(count)s</strong>"
+msgid "Results <strong>%(begin)s</strong>&ndash;<strong>%(end)s</strong> of <strong>%(count)s</strong>"
+msgstr "Resultados <strong>%(begin)s</strong> a <strong>%(end)s</strong> de <strong>%(count)s</strong>"
 
-#: src/olympia/amo/templates/amo/read-only.html:3
-#: src/olympia/amo/templates/amo/read-only.html:7
+#: src/olympia/amo/templates/amo/read-only.html:3 src/olympia/amo/templates/amo/read-only.html:7
 msgid "Maintenance in progress"
 msgstr "Manutenção em progresso"
 
 #: src/olympia/amo/templates/amo/read-only.html:9
-msgid ""
-"This feature is temporarily disabled while we perform website maintenance. "
-"Please use your browser's Back button and try again a little later."
-msgstr ""
-"Este recurso foi temporariamente desabilitado para realizamos a manutenção "
-"do site. Por favor, use o botão voltar do navegador e tente novamente mais "
-"tarde."
+msgid "This feature is temporarily disabled while we perform website maintenance. Please use your browser's Back button and try again a little later."
+msgstr "Este recurso foi temporariamente desabilitado para realizamos a manutenção do site. Por favor, use o botão voltar do navegador e tente novamente mais tarde."
 
 #: src/olympia/amo/templates/amo/read-only.html:14
-msgid ""
-"Some features on this page are temporarily disabled while we perform website"
-" maintenance. Please try again a little later."
-msgstr ""
-"Alguns recursos desta página foram temporariamente desabilitados para "
-"realizamos a manutenção do site. Por favor, tente novamente mais tarde."
+msgid "Some features on this page are temporarily disabled while we perform website maintenance. Please try again a little later."
+msgstr "Alguns recursos desta página foram temporariamente desabilitados para realizamos a manutenção do site. Por favor, tente novamente mais tarde."
 
 #: src/olympia/amo/templates/amo/recaptcha.html:4
 msgid "Are you human?"
@@ -2575,25 +2009,14 @@ msgstr "Você é humano?"
 
 #: src/olympia/amo/templates/amo/recaptcha.html:8
 msgid ""
-"<p> Please enter <strong>all the words</strong> below, <strong>separated by "
-"a space if necessary</strong>. </p> <p> If this is hard to read, you can <a "
-"href=\"#\" id=\"recaptcha_different\">try different words</a> or <a "
-"href=\"#\" id=\"recaptcha_audio\">try a different type of challenge</a> "
-"instead. </p>"
+"<p> Please enter <strong>all the words</strong> below, <strong>separated by a space if necessary</strong>. </p> <p> If this is hard to read, you can <a href=\"#\" id=\"recaptcha_different\">try "
+"different words</a> or <a href=\"#\" id=\"recaptcha_audio\">try a different type of challenge</a> instead. </p>"
 msgstr ""
-"<p> Por favor insira <strong>todas as palavras</strong> abaixo, "
-"<strong>separadas por um espaço, se necessário</strong>. </p> <p> Se estiver"
-" difícil de ler, você pode <a href=\"#\" id=\"recaptcha_different\">tentar "
-"palavras diferentes</a> ou <a href=\"#\" id=\"recaptcha_audio\">um tipo "
-"diferente de desafio</a>. </p>"
+"<p> Por favor insira <strong>todas as palavras</strong> abaixo, <strong>separadas por um espaço, se necessário</strong>. </p> <p> Se estiver difícil de ler, você pode <a href=\"#\" id="
+"\"recaptcha_different\">tentar palavras diferentes</a> ou <a href=\"#\" id=\"recaptcha_audio\">um tipo diferente de desafio</a>. </p>"
 
-#: src/olympia/amo/templates/amo/side_nav.html:4
-#: src/olympia/amo/templates/amo/side_nav.html:12
-#: src/olympia/amo/templates/amo/site_nav.html:4
-#: src/olympia/amo/templates/amo/site_nav.html:26
-#: src/olympia/browse/views.py:56 src/olympia/browse/views.py:66
-#: src/olympia/browse/views.py:237 src/olympia/browse/views.py:282
-#: src/olympia/search/forms.py:86
+#: src/olympia/amo/templates/amo/side_nav.html:4 src/olympia/amo/templates/amo/side_nav.html:12 src/olympia/amo/templates/amo/site_nav.html:4 src/olympia/amo/templates/amo/site_nav.html:26
+#: src/olympia/browse/views.py:56 src/olympia/browse/views.py:66 src/olympia/browse/views.py:204 src/olympia/browse/views.py:249 src/olympia/search/forms.py:86
 msgid "Top Rated"
 msgstr "Melhor avaliados"
 
@@ -2602,81 +2025,60 @@ msgid "Explore"
 msgstr "Explorar"
 
 # Plural in this context means many of the add-on type
-#: src/olympia/amo/templates/amo/site_nav.html:23
-#: src/olympia/browse/feeds.py:65 src/olympia/browse/feeds.py:78
-#: src/olympia/browse/feeds.py:92 src/olympia/browse/feeds.py:100
-#: src/olympia/browse/templates/browse/base_listing.html:7
-#: src/olympia/browse/templates/browse/creatured.html:10
-#: src/olympia/browse/templates/browse/impala/base_listing.html:37
+#: src/olympia/amo/templates/amo/site_nav.html:23 src/olympia/browse/feeds.py:65 src/olympia/browse/feeds.py:78 src/olympia/browse/feeds.py:92 src/olympia/browse/feeds.py:100
+#: src/olympia/browse/templates/browse/base_listing.html:7 src/olympia/browse/templates/browse/creatured.html:10 src/olympia/browse/templates/browse/impala/base_listing.html:37
 #: src/olympia/constants/base.py:173 src/olympia/templates/menu_links.html:8
 msgid "Extensions"
 msgstr "Extensões"
 
-#: src/olympia/amo/templates/amo/site_nav.html:45
+#: src/olympia/amo/templates/amo/site_nav.html:44
 msgid "Want more customization? Try <b>Complete Themes</b>"
 msgstr "Quer personalizar ainda mais? Experimente os <b>temas completos</b>"
 
-#: src/olympia/amo/templates/amo/site_nav.html:56
-#: src/olympia/bandwagon/views.py:96
+#: src/olympia/amo/templates/amo/site_nav.html:54 src/olympia/bandwagon/views.py:96
 msgid "Most Followers"
 msgstr "Mais seguidores"
 
-#: src/olympia/amo/templates/amo/site_nav.html:68
-#: src/olympia/bandwagon/templates/bandwagon/impala/collection_sidebar.html:16
+#: src/olympia/amo/templates/amo/site_nav.html:66 src/olympia/bandwagon/templates/bandwagon/impala/collection_sidebar.html:16
 #: src/olympia/bandwagon/templates/bandwagon/includes/collection_sidebar.html:18
 msgid "Collections I've Made"
 msgstr "Coleções que eu criei"
 
-#: src/olympia/amo/templates/amo/site_nav.html:70
-#: src/olympia/bandwagon/templates/bandwagon/user_listing.html:4
-#: src/olympia/bandwagon/templates/bandwagon/impala/collection_sidebar.html:13
+#: src/olympia/amo/templates/amo/site_nav.html:68 src/olympia/bandwagon/templates/bandwagon/user_listing.html:4 src/olympia/bandwagon/templates/bandwagon/impala/collection_sidebar.html:13
 #: src/olympia/bandwagon/templates/bandwagon/includes/collection_sidebar.html:15
 msgid "Collections I'm Following"
 msgstr "Coleções que estou seguindo"
 
-#: src/olympia/amo/templates/amo/site_nav.html:73
-#: src/olympia/bandwagon/templates/bandwagon/impala/collection_sidebar.html:18
-#: src/olympia/bandwagon/templates/bandwagon/includes/collection_sidebar.html:20
-#: src/olympia/users/models.py:512
+#: src/olympia/amo/templates/amo/site_nav.html:71 src/olympia/bandwagon/templates/bandwagon/impala/collection_sidebar.html:18
+#: src/olympia/bandwagon/templates/bandwagon/includes/collection_sidebar.html:20 src/olympia/users/models.py:521
 msgid "My Favorite Add-ons"
 msgstr "Meus complementos favoritos"
 
-#: src/olympia/amo/templates/amo/site_nav.html:78
+#: src/olympia/amo/templates/amo/site_nav.html:76
 msgid "More&hellip;"
 msgstr "Mais&hellip;"
 
-#: src/olympia/amo/templates/amo/site_nav.html:82
+#: src/olympia/amo/templates/amo/site_nav.html:80
 msgid "Add-ons for Mobile"
 msgstr "Complementos para o Firefox Móvel"
 
-#: src/olympia/amo/templates/amo/site_nav.html:86
-#: src/olympia/browse/feeds.py:207
-#: src/olympia/browse/templates/browse/search_tools.html:3
-#: src/olympia/constants/base.py:176 src/olympia/templates/menu_links.html:10
+#: src/olympia/amo/templates/amo/site_nav.html:84 src/olympia/browse/feeds.py:207 src/olympia/browse/templates/browse/search_tools.html:3 src/olympia/constants/base.py:176
+#: src/olympia/templates/menu_links.html:10
 msgid "Search Tools"
 msgstr "Ferramentas de pesquisa"
 
 #. This is a page range (e.g., Page 1 of 50).
-#: src/olympia/amo/templates/amo/impala/paginator.html:5
-#: src/olympia/amo/templates/amo/mobile/impala_paginator.html:26
+#: src/olympia/amo/templates/amo/impala/paginator.html:5 src/olympia/amo/templates/amo/mobile/impala_paginator.html:26
 #, python-format
-msgid ""
-"Page <a href=\"%(current_pg_url)s\">%(current_pg)s</a> of <a "
-"href=\"%(last_pg_url)s\">%(last_pg)s</a>"
-msgstr ""
-"Página <a href=\"%(current_pg_url)s\">%(current_pg)s</a> de <a "
-"href=\"%(last_pg_url)s\">%(last_pg)s</a>"
+msgid "Page <a href=\"%(current_pg_url)s\">%(current_pg)s</a> of <a href=\"%(last_pg_url)s\">%(last_pg)s</a>"
+msgstr "Página <a href=\"%(current_pg_url)s\">%(current_pg)s</a> de <a href=\"%(last_pg_url)s\">%(last_pg)s</a>"
 
-#: src/olympia/amo/templates/amo/impala/paginator.html:16
-#: src/olympia/amo/templates/amo/mobile/impala_paginator.html:6
+#: src/olympia/amo/templates/amo/impala/paginator.html:16 src/olympia/amo/templates/amo/mobile/impala_paginator.html:6
 msgid "Jump to first page"
 msgstr "Pular para a primeira página"
 
-#: src/olympia/amo/templates/amo/impala/paginator.html:22
-#: src/olympia/amo/templates/amo/mobile/impala_paginator.html:12
-#: src/olympia/discovery/templates/discovery/pane.html:44
-#: src/olympia/discovery/templates/discovery/addons/detail.html:38
-#: src/olympia/stats/templates/stats/stats.html:164
+#: src/olympia/amo/templates/amo/impala/paginator.html:22 src/olympia/amo/templates/amo/mobile/impala_paginator.html:12 src/olympia/discovery/templates/discovery/pane.html:44
+#: src/olympia/discovery/templates/discovery/addons/detail.html:38 src/olympia/stats/templates/stats/stats.html:166
 msgid "Previous"
 msgstr "Anterior"
 
@@ -2686,10 +2088,9 @@ msgstr "Pular para última página"
 
 #. First and second arguments are the result range (e.g., 1-20);
 #. third argument is the number of total results (e.g., 1,000).
-#. third
+#. First and second arguments are the result range (e.g., 1-20);              third
 #. argument is the number of total results (e.g., 1,000).
-#: src/olympia/amo/templates/amo/impala/paginator.html:36
-#: src/olympia/amo/templates/amo/mobile/impala_paginator.html:38
+#: src/olympia/amo/templates/amo/impala/paginator.html:36 src/olympia/amo/templates/amo/mobile/impala_paginator.html:38
 #, python-format
 msgid "Showing <b>%(begin)s</b>&ndash;<b>%(end)s</b> of <b>%(count)s</b>"
 msgstr "Exibindo <b>%(begin)s</b> a <b>%(end)s</b> de <b>%(count)s</b>"
@@ -2700,42 +2101,52 @@ msgid_plural "Page {n}"
 msgstr[0] "Página {n}"
 msgstr[1] "Página {n}"
 
-#: src/olympia/amo/templates/services/install.html:38
-#, python-format
-msgid ""
-"If you are not prompted to install %(addon_name)s in a moment, please <a "
-"href=\"%(addon_xpi)s\">click here</a>."
-msgstr ""
-"Se você não for consultado para instalar %(addon_name)s em alguns instantes,"
-" por favor, <a href=\"%(addon_xpi)s\">clique aqui</a>."
-
-#: src/olympia/amo/tests/test_messages.py:57
-#: src/olympia/amo/tests/test_messages.py:58 src/olympia/reviews/forms.py:25
-#: src/olympia/reviews/forms.py:50
-#: src/olympia/reviews/templates/reviews/add.html:56
+#: src/olympia/amo/tests/test_messages.py:56 src/olympia/amo/tests/test_messages.py:57 src/olympia/reviews/forms.py:25 src/olympia/reviews/forms.py:50 src/olympia/reviews/templates/reviews/add.html:56
 #: src/olympia/reviews/templates/reviews/reply.html:30
 msgid "Title"
 msgstr "Título"
 
-#: src/olympia/amo/tests/test_messages.py:57
-#: src/olympia/amo/tests/test_messages.py:58
+#: src/olympia/amo/tests/test_messages.py:56 src/olympia/amo/tests/test_messages.py:57
 msgid "Body"
 msgstr "Corpo"
 
-#: src/olympia/amo/tests/test_messages.py:59
+#: src/olympia/amo/tests/test_messages.py:58
 msgid "Another Title"
 msgstr "Outro título"
 
-#: src/olympia/amo/tests/test_messages.py:59
+#: src/olympia/amo/tests/test_messages.py:58
 msgid "Another Body"
 msgstr "Outro corpo"
 
-#: src/olympia/api/views.py:255
-msgid "Not implemented yet."
-msgstr "Ainda não implementado."
+#: src/olympia/api/authentication.py:76
+msgid "Signature has expired."
+msgstr ""
 
-#: src/olympia/applications/views.py:39
-#: src/olympia/applications/templates/applications/appversions.html:3
+#: src/olympia/api/authentication.py:79
+msgid "Error decoding signature."
+msgstr ""
+
+#: src/olympia/api/authentication.py:82
+msgid "Invalid JWT Token."
+msgstr ""
+
+#: src/olympia/api/authentication.py:130
+msgid "Invalid Authorization header. No credentials provided."
+msgstr ""
+
+#: src/olympia/api/authentication.py:133
+msgid "Invalid Authorization header. Credentials string should not contain spaces."
+msgstr ""
+
+#: src/olympia/api/fields.py:29
+msgid "The field must have a length of at least {num} characters."
+msgstr ""
+
+#: src/olympia/api/fields.py:31
+msgid "The language code {lang_code} is invalid."
+msgstr ""
+
+#: src/olympia/applications/views.py:39 src/olympia/applications/templates/applications/appversions.html:3
 msgid "Application Versions"
 msgstr "Versões da aplicação"
 
@@ -2748,22 +2159,15 @@ msgid "Valid Application Versions"
 msgstr "Versões válidas da aplicação"
 
 #: src/olympia/applications/templates/applications/appversions.html:12
-msgid ""
-"Add-ons submitted to Mozilla Add-ons must have a manifest file with at least"
-" one of the below applications supported. Only the versions listed below are"
-" allowed for these applications."
-msgstr ""
-"Complementos submetidos, necessitam ter um arquivo manifest com pelo menos "
-"um dos aplicativos suportados abaixo. Apenas as versões listadas abaixo são "
-"permitidas para estes aplicativos."
+msgid "Add-ons submitted to Mozilla Add-ons must have a manifest file with at least one of the below applications supported. Only the versions listed below are allowed for these applications."
+msgstr "Complementos submetidos, necessitam ter um arquivo manifest com pelo menos um dos aplicativos suportados abaixo. Apenas as versões listadas abaixo são permitidas para estes aplicativos."
 
-#: src/olympia/applications/templates/applications/appversions.html:25
+#: src/olympia/applications/templates/applications/appversions.html:25 src/olympia/editors/helpers.py:361
 msgid "GUID"
 msgstr "GUID"
 
 #. {0} is an add-on name.
-#: src/olympia/applications/templates/applications/appversions.html:26
-#: src/olympia/versions/templates/versions/version_list.html:23
+#: src/olympia/applications/templates/applications/appversions.html:26 src/olympia/versions/templates/versions/version_list.html:23
 msgid "Versions"
 msgstr "Versões"
 
@@ -2773,14 +2177,8 @@ msgstr "https://developer.mozilla.org/pt/install.rdf"
 
 #: src/olympia/applications/templates/applications/appversions.html:31
 #, python-format
-msgid ""
-"If your supported application does not require a manifest file, you still "
-"must include one with the required properties as specified <a "
-"href=\"%(url)s\">here</a>."
-msgstr ""
-"Se o seu aplicativo suportado não requer um arquivo manifest, você ainda tem"
-" de incluir um com as propriedades requeridas como especificado <a "
-"href=\"%(url)s\">aqui</a>."
+msgid "If your supported application does not require a manifest file, you still must include one with the required properties as specified <a href=\"%(url)s\">here</a>."
+msgstr "Se o seu aplicativo suportado não requer um arquivo manifest, você ainda tem de incluir um com as propriedades requeridas como especificado <a href=\"%(url)s\">aqui</a>."
 
 #. L10n: {0} is 'Add-ons for <app>'.
 #: src/olympia/bandwagon/feeds.py:44
@@ -2788,13 +2186,9 @@ msgstr ""
 msgid "Collections :: %s"
 msgstr "Coleções :: %s"
 
-#: src/olympia/bandwagon/feeds.py:50
-#: src/olympia/bandwagon/templates/bandwagon/collection_detail.html:137
-msgid ""
-"Collections are groups of related add-ons that anyone can create and share."
-msgstr ""
-"Coleções são grupos de complementos relacionados que qualquer pessoa pode "
-"criar e compartilhar."
+#: src/olympia/bandwagon/feeds.py:50 src/olympia/bandwagon/templates/bandwagon/collection_detail.html:137
+msgid "Collections are groups of related add-ons that anyone can create and share."
+msgstr "Coleções são grupos de complementos relacionados que qualquer pessoa pode criar e compartilhar."
 
 #. L10n: {0} is a collection name, {1} is 'Add-ons for <app>'.
 #: src/olympia/bandwagon/feeds.py:70
@@ -2831,8 +2225,7 @@ msgstr "Ícone"
 
 #: src/olympia/bandwagon/forms.py:143
 msgid "Please don't fill out this field, it's used to catch bots"
-msgstr ""
-"Por favor não preencha este campo pois ele é utilizado para apanhar bots"
+msgstr "Por favor não preencha este campo pois ele é utilizado para apanhar bots"
 
 #: src/olympia/bandwagon/forms.py:167
 msgid "This name cannot be used."
@@ -2850,8 +2243,7 @@ msgstr "Essa URL já está sendo usada por outra coleção"
 msgid "Icons must be either PNG or JPG."
 msgstr "Os ícones devem ser em PNG ou JPG."
 
-#: src/olympia/bandwagon/forms.py:202 src/olympia/devhub/views.py:1067
-#: src/olympia/users/forms.py:476
+#: src/olympia/bandwagon/forms.py:202 src/olympia/devhub/views.py:1067 src/olympia/users/forms.py:476
 #, python-format
 msgid "Please use images smaller than %dMB."
 msgstr "Por favor, use imagens menores que %dMB."
@@ -2872,8 +2264,7 @@ msgstr "Remover meu voto dessa coleção"
 msgid "Log in to vote for this collection"
 msgstr "Identifique-se para votar nessa coleção"
 
-#: src/olympia/bandwagon/helpers.py:123
-#: src/olympia/bandwagon/templates/bandwagon/favorites_widget.html:2
+#: src/olympia/bandwagon/helpers.py:123 src/olympia/bandwagon/templates/bandwagon/favorites_widget.html:2
 msgid "Add to favorites"
 msgstr "Adicionar aos favoritos"
 
@@ -2882,22 +2273,15 @@ msgstr "Adicionar aos favoritos"
 msgid "Favorite"
 msgstr "Favorito"
 
-#: src/olympia/bandwagon/helpers.py:124
-#: src/olympia/bandwagon/templates/bandwagon/favorites_widget.html:2
+#: src/olympia/bandwagon/helpers.py:124 src/olympia/bandwagon/templates/bandwagon/favorites_widget.html:2
 msgid "Remove from favorites"
 msgstr "Remover dos favoritos"
 
 # 80%
 # 100%
-#: src/olympia/bandwagon/views.py:98 src/olympia/bandwagon/views.py:191
-#: src/olympia/browse/views.py:58 src/olympia/browse/views.py:69
-#: src/olympia/browse/views.py:458 src/olympia/devhub/views.py:74
-#: src/olympia/devhub/views.py:82
-#: src/olympia/devhub/templates/devhub/addons/edit/basic.html:20
-#: src/olympia/editors/templates/editors/leaderboard.html:24
-#: src/olympia/editors/templates/editors/themes/queue_list.html:48
-#: src/olympia/search/forms.py:17 src/olympia/search/forms.py:89
-#: src/olympia/users/templates/users/vcard.html:5
+#: src/olympia/bandwagon/views.py:98 src/olympia/bandwagon/views.py:191 src/olympia/browse/views.py:58 src/olympia/browse/views.py:69 src/olympia/browse/views.py:425 src/olympia/devhub/views.py:72
+#: src/olympia/devhub/views.py:80 src/olympia/devhub/templates/devhub/addons/edit/basic.html:20 src/olympia/editors/templates/editors/leaderboard.html:24
+#: src/olympia/editors/templates/editors/themes/queue_list.html:48 src/olympia/search/forms.py:17 src/olympia/search/forms.py:89 src/olympia/users/templates/users/vcard.html:5
 msgid "Name"
 msgstr "Nome"
 
@@ -2906,8 +2290,7 @@ msgid "Recently Popular"
 msgstr "Populares recentemente"
 
 # %s is a date in the _('date') format
-#: src/olympia/bandwagon/views.py:189
-#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:18
+#: src/olympia/bandwagon/views.py:189 src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:16
 msgid "Added"
 msgstr "Adição"
 
@@ -2922,12 +2305,8 @@ msgstr "Coleção criada!"
 
 #: src/olympia/bandwagon/views.py:316
 #, python-format
-msgid ""
-"Your new collection is shown below. You can <ahref=\"%(url)s\">edit "
-"additional settings</a> if you'dlike."
+msgid "Your new collection is shown below. You can <a href=\"%(url)s\">edit additional settings</a> if you'd like."
 msgstr ""
-"Sua nova coleção está sendo exibida abaixo. Você pode "
-"<ahref=\"%(url)s\">editar configurações adicionais</a> se quiser."
 
 #: src/olympia/bandwagon/views.py:322
 msgid "Collection updated!"
@@ -2942,31 +2321,20 @@ msgstr "<a href=\"%(url)s\">Veja sua coleção</a> para ver as alterações."
 msgid "Icon Deleted"
 msgstr "Ícone excluído"
 
-#: src/olympia/bandwagon/templates/bandwagon/add.html:3
-#: src/olympia/bandwagon/templates/bandwagon/add.html:11
-#: src/olympia/bandwagon/templates/bandwagon/includes/collection_sidebar.html:26
+#: src/olympia/bandwagon/templates/bandwagon/add.html:3 src/olympia/bandwagon/templates/bandwagon/add.html:11 src/olympia/bandwagon/templates/bandwagon/includes/collection_sidebar.html:26
 msgid "Create a New Collection"
 msgstr "Criar uma coleção nova"
 
-#: src/olympia/bandwagon/templates/bandwagon/add.html:9
-#: src/olympia/devhub/templates/devhub/personas/submit.html:14
+#: src/olympia/bandwagon/templates/bandwagon/add.html:9 src/olympia/devhub/templates/devhub/personas/submit.html:14
 msgid "Create"
 msgstr "Criar"
 
-#: src/olympia/bandwagon/templates/bandwagon/add.html:24
-#: src/olympia/bandwagon/templates/bandwagon/ajax_new.html:28
+#: src/olympia/bandwagon/templates/bandwagon/add.html:24 src/olympia/bandwagon/templates/bandwagon/ajax_new.html:28
 #, python-format
-msgid ""
-"As noted in our <a href=\"%(legal)s\">Legal Notices</a>, individual "
-"collection arrangements are governed by the Creative Commons Attribution "
-"Share-Alike License"
-msgstr ""
-"Conforme observado em nossos <a href=\"%(legal)s\">Avisos legais</a>, "
-"acordos de coleções individuais são regidos pela Licença Creative Commons "
-"Atribuição-Compartilhamento pela mesma licença"
+msgid "As noted in our <a href=\"%(legal)s\">Legal Notices</a>, individual collection arrangements are governed by the Creative Commons Attribution Share-Alike License"
+msgstr "Conforme observado em nossos <a href=\"%(legal)s\">Avisos legais</a>, acordos de coleções individuais são regidos pela Licença Creative Commons Atribuição-Compartilhamento pela mesma licença"
 
-#: src/olympia/bandwagon/templates/bandwagon/add.html:33
-#: src/olympia/bandwagon/templates/bandwagon/ajax_new.html:38
+#: src/olympia/bandwagon/templates/bandwagon/add.html:33 src/olympia/bandwagon/templates/bandwagon/ajax_new.html:38
 msgid "Create Collection"
 msgstr "Criar coleção"
 
@@ -2982,8 +2350,7 @@ msgstr "Começar uma coleção nova..."
 msgid "Start a New Collection"
 msgstr "Começar uma coleção nova"
 
-#: src/olympia/bandwagon/templates/bandwagon/ajax_new.html:6
-#: src/olympia/bandwagon/templates/bandwagon/includes/addedit.html:7
+#: src/olympia/bandwagon/templates/bandwagon/ajax_new.html:6 src/olympia/bandwagon/templates/bandwagon/includes/addedit.html:7
 msgid "Name:"
 msgstr "Nome:"
 
@@ -2996,15 +2363,11 @@ msgstr "ou <a id=\"collections-new-cancel\" href=\"#\">Cancelar</a>"
 msgid "To rate collections, you must have an add-ons account."
 msgstr "Para avaliar coleções, você deve ter uma conta de complementos."
 
-#: src/olympia/bandwagon/templates/bandwagon/barometer.html:18
-#: src/olympia/templates/base.html:145
-#: src/olympia/templates/impala/base.html:198
+#: src/olympia/bandwagon/templates/bandwagon/barometer.html:18 src/olympia/templates/base.html:145 src/olympia/templates/impala/base.html:198
 msgid "Create an Add-ons Account"
 msgstr "Crie uma conta de complementos"
 
-#: src/olympia/bandwagon/templates/bandwagon/barometer.html:21
-#: src/olympia/templates/base.html:148
-#: src/olympia/templates/impala/base.html:201
+#: src/olympia/bandwagon/templates/bandwagon/barometer.html:21 src/olympia/templates/base.html:148 src/olympia/templates/impala/base.html:201
 #, python-format
 msgid "or <a href=\"%(login)s\">log in to your current account</a>"
 msgstr "ou <a href=\"%(login)s\">identifique-se em sua conta existente</a>"
@@ -3017,8 +2380,7 @@ msgstr "{0} :: Coleções"
 msgid "private"
 msgstr "privada"
 
-#: src/olympia/bandwagon/templates/bandwagon/collection_detail.html:45
-#: src/olympia/bandwagon/templates/bandwagon/mobile/listing_items.html:9
+#: src/olympia/bandwagon/templates/bandwagon/collection_detail.html:45 src/olympia/bandwagon/templates/bandwagon/mobile/listing_items.html:9
 #, python-format
 msgid "<span>%(num)s</span> follower"
 msgid_plural "<span>%(num)s</span> followers"
@@ -3053,8 +2415,7 @@ msgstr "Mais opções:"
 msgid "Edit Collection"
 msgstr "Editar coleção"
 
-#: src/olympia/bandwagon/templates/bandwagon/collection_detail.html:88
-#: src/olympia/bandwagon/templates/bandwagon/includes/delete.html:3
+#: src/olympia/bandwagon/templates/bandwagon/collection_detail.html:88 src/olympia/bandwagon/templates/bandwagon/includes/delete.html:3
 msgid "Delete Collection"
 msgstr "Excluir coleção"
 
@@ -3073,12 +2434,8 @@ msgid_plural "%(num)s Add-ons in this Collection"
 msgstr[0] "%(num)s complemento nessa coleção"
 msgstr[1] "%(num)s complementos nessa coleção"
 
-#: src/olympia/bandwagon/templates/bandwagon/collection_detail.html:125
-#: src/olympia/compat/templates/compat/index.html:25
-#: src/olympia/compat/templates/compat/reporter_detail.html:29
-#: src/olympia/files/templates/files/viewer.html:29
-#: src/olympia/templates/amo_footer.html:17
-#: src/olympia/templates/includes/lang_switcher.html:10
+#: src/olympia/bandwagon/templates/bandwagon/collection_detail.html:125 src/olympia/compat/templates/compat/reporter_detail.html:29 src/olympia/files/templates/files/viewer.html:29
+#: src/olympia/templates/amo_footer.html:17 src/olympia/templates/includes/lang_switcher.html:10
 msgid "Go"
 msgstr "Ir"
 
@@ -3105,27 +2462,17 @@ msgstr "Ver todas as coleções desse usuário"
 
 #: src/olympia/bandwagon/templates/bandwagon/collection_detail.html:179
 msgid ""
-"Add-ons that you mark as favorites using the <b>Add to Favorites</b> feature"
-" appear below. This collection is currently <b>public</b>, which means "
-"everyone can see it. If you would like to hide it from public view, click "
-"the button below to make it private."
+"Add-ons that you mark as favorites using the <b>Add to Favorites</b> feature appear below. This collection is currently <b>public</b>, which means everyone can see it. If you would like to hide it "
+"from public view, click the button below to make it private."
 msgstr ""
-"Complementos que marca como favoritos usando o recurso <b>Adicionar aos "
-"favoritos</b> aparecem abaixo. Essa coleção atualmente é <b>pública</b>, o "
-"que significa que todo mundo pode vê-la. Se desejar escondê-la da visão do "
-"público, clique no botão abaixo para torná-la privada."
+"Complementos que marca como favoritos usando o recurso <b>Adicionar aos favoritos</b> aparecem abaixo. Essa coleção atualmente é <b>pública</b>, o que significa que todo mundo pode vê-la. Se "
+"desejar escondê-la da visão do público, clique no botão abaixo para torná-la privada."
 
 #: src/olympia/bandwagon/templates/bandwagon/collection_detail.html:186
 msgid ""
-"Add-ons that you mark as favorites using the <b>Add to Favorites</b> feature"
-" appear below. This collection is currently <b>private</b>, which means only"
-" you can see it.  If you would like everyone to be able to see your "
-"favorites, click the button below to make it public."
+"Add-ons that you mark as favorites using the <b>Add to Favorites</b> feature appear below. This collection is currently <b>private</b>, which means only you can see it.  If you would like everyone "
+"to be able to see your favorites, click the button below to make it public."
 msgstr ""
-"Complementos que você marcar como favoritos usando a funcionalidade "
-"<b>Adicionar aos Favoritos</b> são exibidos abaixo. Esta coleção é "
-"<b>privada</b>, apenas você pode vê-la. Se você quiser que qualquer pessoa "
-"possa vê-la, clique no botão abaixo para torná-la pública."
 
 #: src/olympia/bandwagon/templates/bandwagon/collection_detail.html:196
 msgid "My favorite add-ons"
@@ -3145,20 +2492,18 @@ msgid_plural "<span>%(followers)s</span> followers"
 msgstr[0] "<span>%(followers)s</span> seguidor"
 msgstr[1] "<span>%(followers)s</span> seguidores"
 
-#. People "follow" collections to get notified of updates.
-#. Like
+#. People "follow" collections to get notified of updates.                    Like
 #. Twitter followers.
+#. People "follow" collections to get notified of updates.
 #. Like Twitter followers.
-#: src/olympia/bandwagon/templates/bandwagon/collection_listing_items.html:10
-#: src/olympia/bandwagon/templates/bandwagon/impala/collection_listing_items.html:18
+#: src/olympia/bandwagon/templates/bandwagon/collection_listing_items.html:10 src/olympia/bandwagon/templates/bandwagon/impala/collection_listing_items.html:18
 #, python-format
 msgid "%(num)s weekly follower"
 msgid_plural "%(num)s weekly followers"
 msgstr[0] "%(num)s seguidor semanal"
 msgstr[1] "%(num)s seguidores semanais"
 
-#. People "follow" collections to get notified of updates.
-#. Like
+#. People "follow" collections to get notified of updates.                    Like
 #. Twitter followers.
 #: src/olympia/bandwagon/templates/bandwagon/collection_listing_items.html:18
 #, python-format
@@ -3167,32 +2512,28 @@ msgid_plural "%(num)s monthly followers"
 msgstr[0] "%(num)s seguidor mensal"
 msgstr[1] "%(num)s seguidores mensais"
 
-#. People "follow" collections to get notified of updates.
-#. Like
+#. People "follow" collections to get notified of updates.                    Like
 #. Twitter followers.
+#. People "follow" collections to get notified of updates.
 #. Like Twitter followers.
-#: src/olympia/bandwagon/templates/bandwagon/collection_listing_items.html:26
-#: src/olympia/bandwagon/templates/bandwagon/impala/collection_listing_items.html:26
+#: src/olympia/bandwagon/templates/bandwagon/collection_listing_items.html:26 src/olympia/bandwagon/templates/bandwagon/impala/collection_listing_items.html:26
 #, python-format
 msgid "%(num)s follower"
 msgid_plural "%(num)s followers"
 msgstr[0] "%(num)s seguidor"
 msgstr[1] "%(num)s seguidores"
 
-#: src/olympia/bandwagon/templates/bandwagon/collection_listing_items.html:56
-#: src/olympia/bandwagon/templates/bandwagon/impala/collection_listing_items.html:9
+#: src/olympia/bandwagon/templates/bandwagon/collection_listing_items.html:56 src/olympia/bandwagon/templates/bandwagon/impala/collection_listing_items.html:9
 #: src/olympia/devhub/templates/devhub/personas/edit.html:27
 msgid "by {0}"
 msgstr "por {0}"
 
-#: src/olympia/bandwagon/templates/bandwagon/collection_widgets.html:5
-#: src/olympia/bandwagon/templates/bandwagon/collection_widgets.html:7
+#: src/olympia/bandwagon/templates/bandwagon/collection_widgets.html:5 src/olympia/bandwagon/templates/bandwagon/collection_widgets.html:7
 #: src/olympia/bandwagon/templates/bandwagon/impala/collection_listing_items.html:53
 msgid "Stop Following"
 msgstr "Deixar de seguir"
 
-#: src/olympia/bandwagon/templates/bandwagon/collection_widgets.html:6
-#: src/olympia/bandwagon/templates/bandwagon/collection_widgets.html:7
+#: src/olympia/bandwagon/templates/bandwagon/collection_widgets.html:6 src/olympia/bandwagon/templates/bandwagon/collection_widgets.html:7
 #: src/olympia/bandwagon/templates/bandwagon/impala/collection_listing_items.html:53
 msgid "Follow this Collection"
 msgstr "Seguir essa coleção"
@@ -3202,16 +2543,12 @@ msgid "Edit this Collection"
 msgstr "Editar esta coleção"
 
 #. %s is the name of the collection.
-#: src/olympia/bandwagon/templates/bandwagon/delete.html:4
-#: src/olympia/bandwagon/templates/bandwagon/delete.html:15
+#: src/olympia/bandwagon/templates/bandwagon/delete.html:4 src/olympia/bandwagon/templates/bandwagon/delete.html:15
 msgid "Delete {0}"
 msgstr "Excluir {0}"
 
-#: src/olympia/bandwagon/templates/bandwagon/delete.html:13
-#: src/olympia/devhub/templates/devhub/addons/listing/item_actions.html:14
-#: src/olympia/devhub/templates/devhub/addons/listing/item_actions_theme.html:28
-#: src/olympia/devhub/templates/devhub/versions/list.html:131
-#: src/olympia/devhub/templates/devhub/versions/list.html:149
+#: src/olympia/bandwagon/templates/bandwagon/delete.html:13 src/olympia/devhub/templates/devhub/addons/listing/item_actions.html:14
+#: src/olympia/devhub/templates/devhub/addons/listing/item_actions_theme.html:28 src/olympia/devhub/templates/devhub/versions/list.html:131 src/olympia/devhub/templates/devhub/versions/list.html:149
 #: src/olympia/devhub/templates/devhub/versions/list.html:166
 msgid "Delete"
 msgstr "Excluir"
@@ -3220,36 +2557,25 @@ msgstr "Excluir"
 msgid "Are you sure?"
 msgstr "Você tem certeza?"
 
-#: src/olympia/bandwagon/templates/bandwagon/delete.html:21
-#: src/olympia/devhub/templates/devhub/personas/edit.html:131
-#: src/olympia/devhub/templates/devhub/personas/edit.html:152
-#: src/olympia/devhub/templates/devhub/personas/edit.html:173
-#: src/olympia/devhub/templates/devhub/personas/submit.html:77
-#: src/olympia/devhub/templates/devhub/personas/submit.html:98
+#: src/olympia/bandwagon/templates/bandwagon/delete.html:21 src/olympia/devhub/templates/devhub/personas/edit.html:131 src/olympia/devhub/templates/devhub/personas/edit.html:152
+#: src/olympia/devhub/templates/devhub/personas/edit.html:173 src/olympia/devhub/templates/devhub/personas/submit.html:77 src/olympia/devhub/templates/devhub/personas/submit.html:98
 #: src/olympia/devhub/templates/devhub/personas/submit.html:119
 msgid "Yes"
 msgstr "Sim"
 
-#: src/olympia/bandwagon/templates/bandwagon/delete.html:22
-#: src/olympia/devhub/templates/devhub/personas/edit.html:140
-#: src/olympia/devhub/templates/devhub/personas/edit.html:161
-#: src/olympia/devhub/templates/devhub/personas/edit.html:191
-#: src/olympia/devhub/templates/devhub/personas/submit.html:86
-#: src/olympia/devhub/templates/devhub/personas/submit.html:107
+#: src/olympia/bandwagon/templates/bandwagon/delete.html:22 src/olympia/devhub/templates/devhub/personas/edit.html:140 src/olympia/devhub/templates/devhub/personas/edit.html:161
+#: src/olympia/devhub/templates/devhub/personas/edit.html:191 src/olympia/devhub/templates/devhub/personas/submit.html:86 src/olympia/devhub/templates/devhub/personas/submit.html:107
 #: src/olympia/devhub/templates/devhub/personas/submit.html:137
 msgid "No"
 msgstr "Não"
 
-#. {0} is the name of the collection.
 # %s is the add-on name.
-#: src/olympia/bandwagon/templates/bandwagon/edit.html:5
-#: src/olympia/bandwagon/templates/bandwagon/edit.html:21
+#. {0} is the name of the collection.
+#: src/olympia/bandwagon/templates/bandwagon/edit.html:5 src/olympia/bandwagon/templates/bandwagon/edit.html:21
 msgid "Edit {0}"
 msgstr "Editar {0}"
 
-#: src/olympia/bandwagon/templates/bandwagon/edit.html:29
-#: src/olympia/devhub/templates/devhub/addons/edit/details.html:20
-#: src/olympia/editors/templates/editors/themes/themes.html:62
+#: src/olympia/bandwagon/templates/bandwagon/edit.html:29 src/olympia/devhub/templates/devhub/addons/edit/details.html:20 src/olympia/editors/templates/editors/themes/themes.html:62
 msgid "Description"
 msgstr "Descrição"
 
@@ -3257,32 +2583,18 @@ msgstr "Descrição"
 msgid "Contributors & More"
 msgstr "Colaboradores e mais"
 
-#: src/olympia/bandwagon/templates/bandwagon/edit.html:54
-#: src/olympia/bandwagon/templates/bandwagon/edit.html:67
-#: src/olympia/bandwagon/templates/bandwagon/edit.html:82
-#: src/olympia/devhub/templates/devhub/addons/ajax_compat_update.html:35
-#: src/olympia/devhub/templates/devhub/addons/owner.html:59
-#: src/olympia/devhub/templates/devhub/addons/profile.html:42
-#: src/olympia/devhub/templates/devhub/addons/edit/admin.html:101
-#: src/olympia/devhub/templates/devhub/addons/edit/basic.html:152
-#: src/olympia/devhub/templates/devhub/addons/edit/details.html:85
-#: src/olympia/devhub/templates/devhub/addons/edit/support.html:67
-#: src/olympia/devhub/templates/devhub/addons/edit/technical.html:166
-#: src/olympia/devhub/templates/devhub/addons/forms_shared/media.html:149
-#: src/olympia/devhub/templates/devhub/payments/voluntary.html:64
-#: src/olympia/devhub/templates/devhub/personas/edit.html:35
-#: src/olympia/devhub/templates/devhub/personas/edit.html:304
-#: src/olympia/devhub/templates/devhub/versions/edit.html:139
-#: src/olympia/translations/templates/translations/trans-menu.html:48
+#: src/olympia/bandwagon/templates/bandwagon/edit.html:54 src/olympia/bandwagon/templates/bandwagon/edit.html:67 src/olympia/bandwagon/templates/bandwagon/edit.html:82
+#: src/olympia/devhub/templates/devhub/addons/ajax_compat_update.html:35 src/olympia/devhub/templates/devhub/addons/owner.html:59 src/olympia/devhub/templates/devhub/addons/profile.html:42
+#: src/olympia/devhub/templates/devhub/addons/edit/admin.html:101 src/olympia/devhub/templates/devhub/addons/edit/basic.html:152 src/olympia/devhub/templates/devhub/addons/edit/details.html:85
+#: src/olympia/devhub/templates/devhub/addons/edit/support.html:67 src/olympia/devhub/templates/devhub/addons/edit/technical.html:166
+#: src/olympia/devhub/templates/devhub/addons/forms_shared/media.html:149 src/olympia/devhub/templates/devhub/payments/voluntary.html:64 src/olympia/devhub/templates/devhub/personas/edit.html:35
+#: src/olympia/devhub/templates/devhub/personas/edit.html:304 src/olympia/devhub/templates/devhub/versions/edit.html:139 src/olympia/translations/templates/translations/trans-menu.html:48
 msgid "Save Changes"
 msgstr "Salvar alterações"
 
 # <option> text in a <select> for Author role in an add-on.
-#: src/olympia/bandwagon/templates/bandwagon/edit_contributors.html:9
-#: src/olympia/bandwagon/templates/bandwagon/edit_contributors.html:12
-#: src/olympia/bandwagon/templates/bandwagon/edit_contributors.html:17
-#: src/olympia/bandwagon/templates/bandwagon/edit_contributors.html:58
-#: src/olympia/constants/base.py:134
+#: src/olympia/bandwagon/templates/bandwagon/edit_contributors.html:9 src/olympia/bandwagon/templates/bandwagon/edit_contributors.html:12
+#: src/olympia/bandwagon/templates/bandwagon/edit_contributors.html:17 src/olympia/bandwagon/templates/bandwagon/edit_contributors.html:58 src/olympia/constants/base.py:134
 msgid "Owner"
 msgstr "Dono"
 
@@ -3295,10 +2607,8 @@ msgid "Remove this user as a contributor"
 msgstr "Remover esse usuário como um colaborador"
 
 # Alt text to remove tag (verb)
-#: src/olympia/bandwagon/templates/bandwagon/edit_contributors.html:18
-#: src/olympia/bandwagon/templates/bandwagon/edit_contributors.html:43
-#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:20
-#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:48
+#: src/olympia/bandwagon/templates/bandwagon/edit_contributors.html:18 src/olympia/bandwagon/templates/bandwagon/edit_contributors.html:43
+#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:18 src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:46
 #: src/olympia/devhub/templates/devhub/addons/ajax_compat_update.html:19
 msgid "Remove"
 msgstr "Remover"
@@ -3309,23 +2619,15 @@ msgstr "Colaboradores da coleção"
 
 #: src/olympia/bandwagon/templates/bandwagon/edit_contributors.html:26
 msgid ""
-"You can add multiple contributors to this collection.  A contributor can add"
-" and remove add-ons from this collection, but cannot change its name or "
-"description.  To add a contributor, enter their email in the box below. "
-"Contributors must have a Mozilla Add-ons account."
+"You can add multiple contributors to this collection.  A contributor can add and remove add-ons from this collection, but cannot change its name or description.  To add a contributor, enter their "
+"email in the box below. Contributors must have a Mozilla Add-ons account."
 msgstr ""
-"Você pode adicionar vários contribuidores a esta coleção. Um contribuidor "
-"pode adicionar ou remover complementos desta coleção, mas não pode mudar o "
-"nome ou descrição. Para adicionar um contribuidor, digite o endereço de "
-"email dele abaixo. Contribuidores precisam ter uma conta da Mozilla Add-ons."
 
 #: src/olympia/bandwagon/templates/bandwagon/edit_contributors.html:40
 msgid "User"
 msgstr "Usuário"
 
-#: src/olympia/bandwagon/templates/bandwagon/edit_contributors.html:41
-#: src/olympia/devhub/templates/devhub/addons/edit/support.html:20
-#: src/olympia/users/templates/users/delete.html:49
+#: src/olympia/bandwagon/templates/bandwagon/edit_contributors.html:41 src/olympia/devhub/templates/devhub/addons/edit/support.html:20 src/olympia/users/templates/users/delete.html:49
 msgid "Email"
 msgstr "E-mail"
 
@@ -3351,27 +2653,14 @@ msgid "Admin Settings"
 msgstr "Configurações de administração"
 
 #: src/olympia/bandwagon/templates/bandwagon/edit_contributors.html:76
-msgid ""
-"<b>Warning:</b> By changing the owner of this collection, you will no longer"
-" be able to edit it. You will only be able to add and remove add-ons from "
-"it."
-msgstr ""
-"<b>Alerta:</b> ao mudar o dono dessa coleção, você não poderá mais editá-la."
-" Você somente poderá adicionar e remover complementos dela."
+msgid "<b>Warning:</b> By changing the owner of this collection, you will no longer be able to edit it. You will only be able to add and remove add-ons from it."
+msgstr "<b>Alerta:</b> ao mudar o dono dessa coleção, você não poderá mais editá-la. Você somente poderá adicionar e remover complementos dela."
 
-#: src/olympia/bandwagon/templates/bandwagon/edit_contributors.html:83
-#: src/olympia/devhub/templates/devhub/addons/forms_shared/media.html:157
-#: src/olympia/devhub/templates/devhub/addons/submit/describe.html:69
-#: src/olympia/devhub/templates/devhub/addons/submit/license.html:60
-#: src/olympia/devhub/templates/devhub/addons/submit/upload.html:78
-#: src/olympia/devhub/templates/devhub/payments/tier.html:17
-#: src/olympia/editors/templates/editors/themes/themes.html:111
-#: src/olympia/editors/templates/editors/themes/themes.html:128
-#: src/olympia/editors/templates/editors/themes/themes.html:134
-#: src/olympia/editors/templates/editors/themes/themes.html:141
-#: src/olympia/users/templates/users/fxa_migration_prompt_content.html:10
-#: src/olympia/users/templates/users/login_form.html:42
-#: src/olympia/users/templates/users/mobile/login.html:57
+#: src/olympia/bandwagon/templates/bandwagon/edit_contributors.html:83 src/olympia/devhub/templates/devhub/addons/forms_shared/media.html:157
+#: src/olympia/devhub/templates/devhub/addons/submit/describe.html:69 src/olympia/devhub/templates/devhub/addons/submit/license.html:60 src/olympia/devhub/templates/devhub/addons/submit/upload.html:70
+#: src/olympia/devhub/templates/devhub/payments/tier.html:17 src/olympia/editors/templates/editors/themes/themes.html:111 src/olympia/editors/templates/editors/themes/themes.html:128
+#: src/olympia/editors/templates/editors/themes/themes.html:134 src/olympia/editors/templates/editors/themes/themes.html:141 src/olympia/users/templates/users/fxa_migration_prompt_content.html:10
+#: src/olympia/users/templates/users/login_form.html:42 src/olympia/users/templates/users/mobile/login.html:57
 msgid "Continue"
 msgstr "Continuar"
 
@@ -3410,19 +2699,11 @@ msgstr "Coleções populares recentemente"
 
 #: src/olympia/bandwagon/templates/bandwagon/impala/collection_listing.html:28
 #, python-format
-msgid ""
-"Collections are groups of related add-ons that anyone can create and share. "
-"Explore collections created by other users or <a href=\"%(url)s\">create "
-"your own</a>."
-msgstr ""
-"Coleções são grupos de complementos relacionados que qualquer pessoa pode "
-"criar e compartilhar. Explore coleções criadas por outros usuários ou <a "
-"href=\"%(url)s\">crie a sua</a>."
+msgid "Collections are groups of related add-ons that anyone can create and share. Explore collections created by other users or <a href=\"%(url)s\">create your own</a>."
+msgstr "Coleções são grupos de complementos relacionados que qualquer pessoa pode criar e compartilhar. Explore coleções criadas por outros usuários ou <a href=\"%(url)s\">crie a sua</a>."
 
 # 100%
-#: src/olympia/bandwagon/templates/bandwagon/impala/collection_listing.html:37
-#: src/olympia/browse/templates/browse/extensions.html:13
-#: src/olympia/browse/templates/browse/themes.html:14
+#: src/olympia/bandwagon/templates/bandwagon/impala/collection_listing.html:37 src/olympia/browse/templates/browse/extensions.html:13 src/olympia/browse/templates/browse/themes.html:14
 msgid "Subscribe"
 msgstr "Assinar"
 
@@ -3430,20 +2711,14 @@ msgstr "Assinar"
 msgid "Following"
 msgstr "Seguindo"
 
-#: src/olympia/bandwagon/templates/bandwagon/impala/collection_sidebar.html:22
-#: src/olympia/bandwagon/templates/bandwagon/impala/collection_sidebar.html:28
+#: src/olympia/bandwagon/templates/bandwagon/impala/collection_sidebar.html:22 src/olympia/bandwagon/templates/bandwagon/impala/collection_sidebar.html:28
 #: src/olympia/bandwagon/templates/bandwagon/includes/collection_sidebar.html:32
 msgid "Create a Collection"
 msgstr "Criar uma coleção"
 
-#: src/olympia/bandwagon/templates/bandwagon/impala/collection_sidebar.html:23
-#: src/olympia/bandwagon/templates/bandwagon/includes/collection_sidebar.html:27
-msgid ""
-"Collections make it easy to keep track of favorite add-ons and share your "
-"perfectly customized browser with others."
-msgstr ""
-"Coleções tornam fácil acompanhar seus complementos favoritos e compartilhar "
-"o seu navegador perfeitamente personalizado com outras pessoas."
+#: src/olympia/bandwagon/templates/bandwagon/impala/collection_sidebar.html:23 src/olympia/bandwagon/templates/bandwagon/includes/collection_sidebar.html:27
+msgid "Collections make it easy to keep track of favorite add-ons and share your perfectly customized browser with others."
+msgstr "Coleções tornam fácil acompanhar seus complementos favoritos e compartilhar o seu navegador perfeitamente personalizado com outras pessoas."
 
 #: src/olympia/bandwagon/templates/bandwagon/includes/addedit.html:42
 msgid "Collection Icon"
@@ -3455,50 +2730,42 @@ msgstr "Redefinir"
 
 #: src/olympia/bandwagon/templates/bandwagon/includes/addedit.html:53
 msgid "PNG and JPG supported.  Image will be resized to 32x32."
-msgstr "PNG e JPG são suportados.  Imagens serão redimensionadas para 32x32."
+msgstr ""
 
 #: src/olympia/bandwagon/templates/bandwagon/includes/addedit_errors.html:3
 msgid "There are errors in this form.  Please correct them below."
-msgstr "Existem erros no formulário.  Por favor corrija-os abaixo."
+msgstr ""
 
 #: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:2
 msgid "Add-ons in Your Collection"
 msgstr "Complementos na sua coleção"
 
 #: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:4
-msgid ""
-"To include an add-on in this collection, enter its name in the box below and"
-" hit enter.  You can also use the <strong>Add to Collection</strong> links "
-"throughout the site to include add-ons later."
+msgid "To include an add-on in this collection, enter its name in the box below and hit enter."
 msgstr ""
-"Para adicionar um complemento a esta coleção, digite o nome no campo abaixo "
-"e aperte Enter.  Você também pode usar os links <strong>Adicionar à "
-"Coleção</strong> espalhados pelo site."
 
-#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:17
-#: src/olympia/constants/base.py:400
-#: src/olympia/devhub/templates/devhub/addons/activity.html:62
+#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:15 src/olympia/constants/base.py:400 src/olympia/devhub/templates/devhub/addons/activity.html:62
+#: src/olympia/editors/helpers.py:273 src/olympia/editors/helpers.py:360
 msgid "Add-on"
 msgstr "Complemento"
 
-#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:26
+#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:24
 msgid "Enter the name of the add-on to include"
 msgstr "Digite o nome do complemento para incluí-lo"
 
-#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:28
+#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:26
 msgid "Add to Collection"
 msgstr "Adicionar à coleção"
 
-#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:45
-#: src/olympia/editors/helpers.py:936 src/olympia/editors/helpers.py:956
+#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:43 src/olympia/editors/helpers.py:1016 src/olympia/editors/helpers.py:1036
 msgid "Pending"
 msgstr "Pendente"
 
-#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:47
+#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:45
 msgid "Add a comment"
 msgstr "Adicionar um comentário"
 
-#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:48
+#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:46
 msgid "Remove this add-on from the collection"
 msgstr "Remover esse complemento da coleção"
 
@@ -3510,19 +2777,16 @@ msgstr "COLEÇÕES"
 msgid "Groups of related add-ons that anyone can create."
 msgstr "Grupos de complementos relacionados que qualquer um pode criar."
 
-#: src/olympia/blocklist/templates/blocklist/blocked_detail.html:3
-#: src/olympia/blocklist/templates/blocklist/blocked_list.html:3
-#: src/olympia/blocklist/templates/blocklist/blocked_list.html:10
+#: src/olympia/blocklist/templates/blocklist/blocked_detail.html:3 src/olympia/blocklist/templates/blocklist/blocked_list.html:3 src/olympia/blocklist/templates/blocklist/blocked_list.html:10
 msgid "Blocked Add-ons"
 msgstr "Complementos bloqueados"
 
-#: src/olympia/blocklist/templates/blocklist/blocked_detail.html:8
-#: src/olympia/blocklist/templates/blocklist/blocked_list.html:6
+#: src/olympia/blocklist/templates/blocklist/blocked_detail.html:8 src/olympia/blocklist/templates/blocklist/blocked_list.html:6
 msgid "Blocklist"
 msgstr "Lista de bloqueios"
 
-#. {0} is an add-on name.
 # %1$s is the collection name
+#. {0} is an add-on name.
 #: src/olympia/blocklist/templates/blocklist/blocked_detail.html:13
 msgid "<b>{0}</b> has been blocked for your protection."
 msgstr "<b>{0}</b> foi bloqueado para sua proteção."
@@ -3541,42 +2805,24 @@ msgid "What does this mean?"
 msgstr "O que isso significa?"
 
 #: src/olympia/blocklist/templates/blocklist/blocked_detail.html:22
-msgid ""
-"Users are strongly encouraged to disable the problematic add-on or plugin, "
-"but may choose to continue using it if they accept the risks described."
-msgstr ""
-"Os usuários são fortemente encorajados a desabilitar complementos ou plugins"
-" problemáticos, mas podem continuar a usá-los, desde que aceitem os riscos "
-"descritos."
+msgid "Users are strongly encouraged to disable the problematic add-on or plugin, but may choose to continue using it if they accept the risks described."
+msgstr "Os usuários são fortemente encorajados a desabilitar complementos ou plugins problemáticos, mas podem continuar a usá-los, desde que aceitem os riscos descritos."
 
 #: src/olympia/blocklist/templates/blocklist/blocked_detail.html:27
-msgid ""
-"The problematic add-on or plugin will be automatically disabled and no "
-"longer usable."
-msgstr ""
-"O complemento ou plugin problemático será automaticamente desabilitado e não"
-" será mais usado."
+msgid "The problematic add-on or plugin will be automatically disabled and no longer usable."
+msgstr "O complemento ou plugin problemático será automaticamente desabilitado e não será mais usado."
 
 #: src/olympia/blocklist/templates/blocklist/blocked_detail.html:33
 #, python-format
 msgid ""
-"When Mozilla becomes aware of add-ons, plugins, or other third-party "
-"software that seriously compromises %(app)s security, stability, or "
-"performance and meets <a href=\"%(criteria)s\">certain criteria</a>, the "
-"software may be blocked from general use.  For more information, please read"
-" <a href=\"%(support)s\">this support article</a>."
+"When Mozilla becomes aware of add-ons, plugins, or other third-party software that seriously compromises %(app)s security, stability, or performance and meets <a href=\"%(criteria)s\">certain "
+"criteria</a>, the software may be blocked from general use.  For more information, please read <a href=\"%(support)s\">this support article</a>."
 msgstr ""
-"Quando a Mozilla identifica que um complemento, plugin ou outro software de "
-"terceiros compromete seriamente a %(app)s segurança, estabilidade ou "
-"performance e se encaixa em <a href=\"%(criteria)s\">certos critérios</a>, o"
-" software pode ser bloqueado.  Para mais informações, por favor leia <a "
-"href=\"%(support)s\"> este artigo de suporte</a>."
 
 #: src/olympia/blocklist/templates/blocklist/blocked_detail.html:44
 #, python-format
 msgid "Blocked on %(date)s. <a href=\"%(link)s\">View block request</a>."
-msgstr ""
-"Bloqueado em %(date)s. <a href=\"%(link)s\">Ver solicitação de bloqueio</a>."
+msgstr "Bloqueado em %(date)s. <a href=\"%(link)s\">Ver solicitação de bloqueio</a>."
 
 #: src/olympia/blocklist/templates/blocklist/blocked_detail.html:48
 #, python-format
@@ -3584,12 +2830,8 @@ msgid "Blocked on %(date)s."
 msgstr "Bloqueado em %(date)s."
 
 #: src/olympia/blocklist/templates/blocklist/blocked_list.html:11
-msgid ""
-"The following software is known to cause serious security, stability, or "
-"performance issues with {app}."
-msgstr ""
-"O seguinte programa é conhecido por provocar sérios problemas de segurança, "
-"estabilidade ou desempenho no {app}."
+msgid "The following software is known to cause serious security, stability, or performance issues with {app}."
+msgstr "O seguinte programa é conhecido por provocar sérios problemas de segurança, estabilidade ou desempenho no {app}."
 
 #. L10n: %s is a category name.
 #: src/olympia/browse/feeds.py:76 src/olympia/browse/feeds.py:98
@@ -3611,14 +2853,11 @@ msgstr "Complementos em destaque :: %s"
 #. L10n: %s is an app name.
 #: src/olympia/browse/feeds.py:138
 #, python-format
-msgid ""
-"Here's a few of our favorite add-ons to help you get started customizing %s."
-msgstr ""
-"Aqui estão alguns dos nossos complementos favoritos para ajudar a começar a "
-"personalizar o %s."
+msgid "Here's a few of our favorite add-ons to help you get started customizing %s."
+msgstr "Aqui estão alguns dos nossos complementos favoritos para ajudar a começar a personalizar o %s."
 
-#. L10n: %s is a category name.
 # %s is the terms the user is searching for (a string)
+#. L10n: %s is a category name.
 #: src/olympia/browse/feeds.py:157
 #, python-format
 msgid "Search tools relating to %s"
@@ -3632,43 +2871,28 @@ msgstr "Ferramentas de pesquisa e extensões relacionadas com pesquisas"
 msgid "Search tools"
 msgstr "Ferramentas de pesquisa"
 
-#: src/olympia/browse/views.py:55 src/olympia/browse/views.py:65
-#: src/olympia/search/forms.py:85
+#: src/olympia/browse/views.py:55 src/olympia/browse/views.py:65 src/olympia/search/forms.py:85
 msgid "Most Users"
 msgstr "Mais populares"
 
-#: src/olympia/browse/views.py:61 src/olympia/browse/views.py:72
-#: src/olympia/browse/views.py:279
-#: src/olympia/browse/templates/browse/personas/mobile/category_landing.html:63
-#: src/olympia/discovery/templates/discovery/pane.html:67
-#: src/olympia/search/forms.py:92
+#: src/olympia/browse/views.py:61 src/olympia/browse/views.py:72 src/olympia/browse/views.py:246 src/olympia/browse/templates/browse/personas/mobile/category_landing.html:63
+#: src/olympia/discovery/templates/discovery/pane.html:67 src/olympia/search/forms.py:92
 msgid "Up & Coming"
 msgstr "Em ascensão"
 
-#: src/olympia/browse/views.py:460 src/olympia/devhub/views.py:76
-#: src/olympia/devhub/views.py:83
-#: src/olympia/discovery/templates/discovery/addons/detail.html:66
+#: src/olympia/browse/views.py:427 src/olympia/devhub/views.py:74 src/olympia/devhub/views.py:81 src/olympia/discovery/templates/discovery/addons/detail.html:66
 msgid "Created"
 msgstr "Criação"
 
 #. {0} is the category name. Ex: Sports
-#: src/olympia/browse/templates/browse/creatured.html:5
-#: src/olympia/browse/templates/browse/creatured.html:13
+#: src/olympia/browse/templates/browse/creatured.html:5 src/olympia/browse/templates/browse/creatured.html:13
 msgid "{0}: Featured Add-ons"
 msgstr "{0}: Complementos em destaque"
 
-#: src/olympia/browse/templates/browse/creatured.html:12
-#: src/olympia/browse/templates/browse/featured.html:4
-#: src/olympia/browse/templates/browse/featured.html:12
-#: src/olympia/browse/templates/browse/featured.html:13
-#: src/olympia/devhub/templates/devhub/docs/policies-recommended.html:3
-#: src/olympia/devhub/templates/devhub/docs/policies-recommended.html:7
-#: src/olympia/devhub/templates/devhub/docs/policies-recommended.html:9
-#: src/olympia/devhub/templates/devhub/docs/policies.html:21
-#: src/olympia/devhub/templates/devhub/docs/policies.html:90
-#: src/olympia/discovery/modules.py:341
-#: src/olympia/discovery/templates/discovery/pane.html:52
-#: src/olympia/templates/menu_links.html:7
+#: src/olympia/browse/templates/browse/creatured.html:12 src/olympia/browse/templates/browse/featured.html:4 src/olympia/browse/templates/browse/featured.html:12
+#: src/olympia/browse/templates/browse/featured.html:13 src/olympia/devhub/templates/devhub/docs/policies-recommended.html:3 src/olympia/devhub/templates/devhub/docs/policies-recommended.html:7
+#: src/olympia/devhub/templates/devhub/docs/policies-recommended.html:9 src/olympia/devhub/templates/devhub/docs/policies.html:21 src/olympia/devhub/templates/devhub/docs/policies.html:90
+#: src/olympia/discovery/modules.py:341 src/olympia/discovery/templates/discovery/pane.html:52 src/olympia/templates/menu_links.html:7
 msgid "Featured Add-ons"
 msgstr "Complementos em destaque"
 
@@ -3679,12 +2903,8 @@ msgstr "Nenhum complemento em destaque em {0}."
 
 #: src/olympia/browse/templates/browse/featured.html:15
 #, python-format
-msgid ""
-"Here's a few of our favorite add-ons to help you get started customizing "
-"%(app)s."
-msgstr ""
-"Aqui estão alguns dos nossos complementos favoritos para ajudar a começar a "
-"personalizar o %(app)s."
+msgid "Here's a few of our favorite add-ons to help you get started customizing %(app)s."
+msgstr "Aqui estão alguns dos nossos complementos favoritos para ajudar a começar a personalizar o %(app)s."
 
 #: src/olympia/browse/templates/browse/language_tools.html:9
 msgid "Install Dictionary"
@@ -3710,19 +2930,15 @@ msgstr "Disponíveis no seu idioma"
 msgid "List of language packs and dictionaries available in your locale."
 msgstr "Lista de pacotes de idioma e dicionários disponíveis no seu idioma."
 
-#: src/olympia/browse/templates/browse/language_tools.html:41
-#: src/olympia/browse/templates/browse/language_tools.html:63
+#: src/olympia/browse/templates/browse/language_tools.html:41 src/olympia/browse/templates/browse/language_tools.html:63
 msgid "Language"
 msgstr "Idioma"
 
-#: src/olympia/browse/templates/browse/language_tools.html:42
-#: src/olympia/browse/templates/browse/language_tools.html:64
-#: src/olympia/constants/base.py:162
+#: src/olympia/browse/templates/browse/language_tools.html:42 src/olympia/browse/templates/browse/language_tools.html:64 src/olympia/constants/base.py:162
 msgid "Dictionary"
 msgstr "Dicionário"
 
-#: src/olympia/browse/templates/browse/language_tools.html:43
-#: src/olympia/browse/templates/browse/language_tools.html:65
+#: src/olympia/browse/templates/browse/language_tools.html:43 src/olympia/browse/templates/browse/language_tools.html:65
 msgid "Language Pack"
 msgstr "Pacote de idioma"
 
@@ -3740,8 +2956,7 @@ msgid "{0} :: Search Tools"
 msgstr "{0} :: Ferramentas de pesquisa"
 
 #. {0} is an integer.
-#: src/olympia/browse/templates/browse/search_tools.html:39
-#: src/olympia/devhub/templates/devhub/addons/dashboard.html:17
+#: src/olympia/browse/templates/browse/search_tools.html:39 src/olympia/devhub/templates/devhub/addons/dashboard.html:17
 msgid "<b>{0}</b> add-on"
 msgid_plural "<b>{0}</b> add-ons"
 msgstr[0] "<b>{0}</b> complemento"
@@ -3771,35 +2986,18 @@ msgstr "Recursos adicionais"
 
 #. {0} is an app name, like Firefox.
 #: src/olympia/browse/templates/browse/search_tools.html:93
-msgid ""
-"Learn more about the <a "
-"href=\"http://support.mozilla.com/kb/Search+bar\">search bar</a> in {0}"
-msgstr ""
-"Aprenda mais sobre o <a "
-"href=\"http://support.mozilla.com/kb/Search+bar\">campo de pesquisa</a> no "
-"{0}"
+msgid "Learn more about the <a href=\"http://support.mozilla.com/kb/Search+bar\">search bar</a> in {0}"
+msgstr "Aprenda mais sobre o <a href=\"http://support.mozilla.com/kb/Search+bar\">campo de pesquisa</a> no {0}"
 
 #: src/olympia/browse/templates/browse/search_tools.html:94
-msgid ""
-"Browse through even more search providers at <a "
-"href=\"http://mycroft.mozdev.org/\">mycroft.mozdev.org</a>"
-msgstr ""
-"Encontre mais mecanismos em <a "
-"href=\"http://mycroft.mozdev.org/\">mycroft.mozdev.org</a>"
+msgid "Browse through even more search providers at <a href=\"http://mycroft.mozdev.org/\">mycroft.mozdev.org</a>"
+msgstr "Encontre mais mecanismos em <a href=\"http://mycroft.mozdev.org/\">mycroft.mozdev.org</a>"
 
 #: src/olympia/browse/templates/browse/search_tools.html:95
-msgid ""
-"<a "
-"href=\"https://developer.mozilla.org/en/Creating_OpenSearch_plugins_for_Firefox\">Make"
-" your own</a> search tool"
-msgstr ""
-"<a "
-"href=\"https://developer.mozilla.org/en/Creating_OpenSearch_plugins_for_Firefox\">Faça"
-" a sua própria</a> ferramenta de pesquisa"
+msgid "<a href=\"https://developer.mozilla.org/en/Creating_OpenSearch_plugins_for_Firefox\">Make your own</a> search tool"
+msgstr "<a href=\"https://developer.mozilla.org/en/Creating_OpenSearch_plugins_for_Firefox\">Faça a sua própria</a> ferramenta de pesquisa"
 
-#: src/olympia/browse/templates/browse/themes.html:6
-#: src/olympia/browse/templates/browse/themes.html:9
-#: src/olympia/constants/base.py:174
+#: src/olympia/browse/templates/browse/themes.html:6 src/olympia/browse/templates/browse/themes.html:9 src/olympia/constants/base.py:174
 msgid "Complete Themes"
 msgstr "Temas Completos"
 
@@ -3872,24 +3070,17 @@ msgid_plural "See all %(cnt)s extensions in %(name)s &raquo;"
 msgstr[0] "Ver todas as extensões em %(name)s &raquo;"
 msgstr[1] "Ver todas as %(cnt)s extensões em %(name)s &raquo;"
 
-#: src/olympia/browse/templates/browse/mobile/extensions.html:13
-#: src/olympia/compat/templates/compat/index.html:82
-#: src/olympia/devhub/templates/devhub/devhub_search.html:24
-#: src/olympia/devhub/templates/devhub/addons/activity.html:47
-#: src/olympia/search/templates/search/no_results.html:4
-#: src/olympia/search/templates/search/mobile/results.html:36
+#: src/olympia/browse/templates/browse/mobile/extensions.html:13 src/olympia/devhub/templates/devhub/devhub_search.html:24 src/olympia/devhub/templates/devhub/addons/activity.html:47
+#: src/olympia/search/templates/search/no_results.html:4 src/olympia/search/templates/search/mobile/results.html:36
 msgid "No results found."
 msgstr "Nenhum resultado encontrado."
 
-#: src/olympia/browse/templates/browse/personas/base.html:6
-#: src/olympia/browse/templates/browse/personas/mobile/base.html:7
+#: src/olympia/browse/templates/browse/personas/base.html:6 src/olympia/browse/templates/browse/personas/mobile/base.html:7
 msgid "{0} Themes"
 msgstr "Temas sobre {0}"
 
 #. {0} is a user's name.
-#: src/olympia/browse/templates/browse/personas/base.html:15
-#: src/olympia/browse/templates/browse/personas/base.html:40
-#: src/olympia/browse/templates/browse/personas/grid.html:8
+#: src/olympia/browse/templates/browse/personas/base.html:15 src/olympia/browse/templates/browse/personas/base.html:40 src/olympia/browse/templates/browse/personas/grid.html:8
 msgid "{0}'s Themes"
 msgstr "Temas de {0}"
 
@@ -3909,31 +3100,22 @@ msgstr "Seu navegador, seu estilo! Vista seu Firefox com seu próprio design!"
 msgid "Learn more"
 msgstr "Saiba mais"
 
-#: src/olympia/browse/templates/browse/personas/category_landing.html:6
-#: src/olympia/browse/templates/browse/personas/mobile/category_landing.html:5
+#: src/olympia/browse/templates/browse/personas/category_landing.html:6 src/olympia/browse/templates/browse/personas/mobile/category_landing.html:5
 msgid "View All Recently Added"
 msgstr "Ver todas adicionadas recentemente"
 
-#: src/olympia/browse/templates/browse/personas/category_landing.html:7
-#: src/olympia/browse/templates/browse/personas/mobile/category_landing.html:6
+#: src/olympia/browse/templates/browse/personas/category_landing.html:7 src/olympia/browse/templates/browse/personas/mobile/category_landing.html:6
 msgid "View All Most Popular"
 msgstr "Ver todas mais populares"
 
-#: src/olympia/browse/templates/browse/personas/category_landing.html:8
-#: src/olympia/browse/templates/browse/personas/mobile/category_landing.html:7
+#: src/olympia/browse/templates/browse/personas/category_landing.html:8 src/olympia/browse/templates/browse/personas/mobile/category_landing.html:7
 msgid "View All Top Rated"
 msgstr "Ver todas melhor avaliadas"
 
 #: src/olympia/browse/templates/browse/personas/category_landing.html:40
 #, python-format
-msgid ""
-"Over 300,000 designs to personalize your browser! Move your mouse over a "
-"Background Theme to try it on. <a href=\"%(url)s\" class=\"more-info\">Start"
-" exploring</a>"
-msgstr ""
-"Mais de 300.000 desenhos para personalizar seu navegador! Aponte o cursor do"
-" mouse sobre um tema de fundo para experimentá-lo. <a href=\"%(url)s\" class"
-"=\"more-info\">Explorar o site</a>"
+msgid "Over 300,000 designs to personalize your browser! Move your mouse over a Background Theme to try it on. <a href=\"%(url)s\" class=\"more-info\">Start exploring</a>"
+msgstr "Mais de 300.000 desenhos para personalizar seu navegador! Aponte o cursor do mouse sobre um tema de fundo para experimentá-lo. <a href=\"%(url)s\" class=\"more-info\">Explorar o site</a>"
 
 #: src/olympia/browse/templates/browse/personas/category_landing.html:47
 msgid "Want more personalization?"
@@ -3943,14 +3125,8 @@ msgstr "Quer personalizar ainda mais?"
 #. theme.
 #: src/olympia/browse/templates/browse/personas/category_landing.html:50
 #, python-format
-msgid ""
-"Complete Themes transform the look of your browser with styles for the "
-"window frame, address bar, buttons, tabs, and menus. <a href=\"%(url)s\" "
-"class=\"more-info\">Start exploring</a>"
-msgstr ""
-"Temas completos mudam o visual do seu navegador, incluindo a janela, barra "
-"de endereços, menus, botões e abas. <a href=\"%(url)s\" class=\"more-"
-"info\">Explorar o site</a>"
+msgid "Complete Themes transform the look of your browser with styles for the window frame, address bar, buttons, tabs, and menus. <a href=\"%(url)s\" class=\"more-info\">Start exploring</a>"
+msgstr "Temas completos mudam o visual do seu navegador, incluindo a janela, barra de endereços, menus, botões e abas. <a href=\"%(url)s\" class=\"more-info\">Explorar o site</a>"
 
 #: src/olympia/browse/templates/browse/personas/category_landing.html:76
 msgid "Up & Coming Themes"
@@ -3980,7 +3156,7 @@ msgstr "&laquo; Todos os temas"
 msgid "All"
 msgstr "Todas"
 
-#: src/olympia/compat/forms.py:22 src/olympia/search/views.py:525
+#: src/olympia/compat/forms.py:22 src/olympia/editors/templates/editors/base.html:69 src/olympia/search/views.py:518
 msgid "All Add-ons"
 msgstr "Todos os complementos"
 
@@ -3992,92 +3168,32 @@ msgstr "Binário"
 msgid "Non-binary"
 msgstr "Não binário"
 
-#. Review points sources other than add-ons and themes.
-#: src/olympia/compat/views.py:87 src/olympia/constants/base.py:388
-#: src/olympia/devhub/forms.py:162
-#: src/olympia/editors/templates/editors/performance.html:75
-msgid "Other"
-msgstr "Outro"
-
-#: src/olympia/compat/templates/compat/index.html:4
-msgid "Add-on Compatibility Report for {app} {version}"
-msgstr "Relatório de compatibilidade de {app} {version}"
-
-#: src/olympia/compat/templates/compat/index.html:11
-msgid "{app} {version} Compatibility"
-msgstr "Compatibilidade de {app} {version}"
-
-#: src/olympia/compat/templates/compat/index.html:17
-#, python-format
-msgid "Top 95%% compatible with previous version"
-msgstr "Top 95 %% compatíveis com a versão anterior"
-
-#: src/olympia/compat/templates/compat/index.html:18
-#, python-format
-msgid "Top 95%% of all add-ons"
-msgstr "Top 95 %% de todos os complementos"
-
-#: src/olympia/compat/templates/compat/index.html:19
-msgid "All active add-ons"
-msgstr "Todos os complementos ativos"
-
-#: src/olympia/compat/templates/compat/index.html:23
-#: src/olympia/constants/base.py:401
-msgid "App"
-msgstr "Aplicativo"
-
-#: src/olympia/compat/templates/compat/index.html:55
-msgid "Details for add-ons compatible with previous version:"
-msgstr "Detalhes para complementos compatíveis com a versão anterior:"
-
-#: src/olympia/compat/templates/compat/index.html:57
-msgid "Show all versions"
-msgstr "Exibir todas as versões"
-
-#: src/olympia/compat/templates/compat/index.html:59
-msgid "Details for add-ons compatible with all versions:"
-msgstr "Detalhes para complementos compatíveis com todas as versões:"
-
-#: src/olympia/compat/templates/compat/index.html:61
-msgid "Show previous version only"
-msgstr "Exibir somente a versão anterior"
-
 #: src/olympia/compat/templates/compat/reporter.html:3
 msgid "Add-on Compatibility Reports"
 msgstr "Relatórios de compatibilidade de complementos"
 
-#: src/olympia/compat/templates/compat/reporter.html:11
-#: src/olympia/compat/templates/compat/reporter_detail.html:35
+#: src/olympia/compat/templates/compat/reporter.html:11 src/olympia/compat/templates/compat/reporter_detail.html:35
 #, python-format
 msgid ""
-"<p> Reports submitted to us through the <a href=\"%(url_)s\">Add-on "
-"Compatibility Reporter</a> are collected here for developers to view. These "
-"reports help us determine which add-ons will need help supporting an "
-"upcoming Firefox version. </p>"
+"<p> Reports submitted to us through the <a href=\"%(url_)s\">Add-on Compatibility Reporter</a> are collected here for developers to view. These reports help us determine which add-ons will need "
+"help supporting an upcoming Firefox version. </p>"
 msgstr ""
-"<p> Relatórios submetido usando o <a href=\"%(url_)s\">Add-on Compatibility "
-"Reporter</a> são reunidos aqui para que os desenvolvedores possam vê-los. "
-"Esses relatórios nos auxiliam a determinar quais complementos precisarão de "
-"ajuda para suportar uma versão futura do Firefox. </p>"
+"<p> Relatórios submetido usando o <a href=\"%(url_)s\">Add-on Compatibility Reporter</a> são reunidos aqui para que os desenvolvedores possam vê-los. Esses relatórios nos auxiliam a determinar "
+"quais complementos precisarão de ajuda para suportar uma versão futura do Firefox. </p>"
 
 #: src/olympia/compat/templates/compat/reporter.html:18
 msgid "Reports for your Add-ons"
 msgstr "Relatórios dos seus complementos"
 
-#: src/olympia/compat/templates/compat/reporter.html:30
-#: src/olympia/compat/templates/compat/reporter_detail.html:9
+#: src/olympia/compat/templates/compat/reporter.html:30 src/olympia/compat/templates/compat/reporter_detail.html:9
 msgid "Add-on Compatibility Center"
 msgstr "Centro de Compatibilidade"
 
 #: src/olympia/compat/templates/compat/reporter.html:34
 msgid "Enter the GUID of an add-on below to view any reports we've received."
-msgstr ""
-"Insira o GUID de um complemento abaixo para ver todos os relatórios que "
-"recebemos."
+msgstr "Insira o GUID de um complemento abaixo para ver todos os relatórios que recebemos."
 
-#: src/olympia/compat/templates/compat/reporter_detail.html:3
-#: src/olympia/compat/templates/compat/reporter_detail.html:10
-#: src/olympia/compat/templates/compat/reporter_detail.html:25
+#: src/olympia/compat/templates/compat/reporter_detail.html:3 src/olympia/compat/templates/compat/reporter_detail.html:10 src/olympia/compat/templates/compat/reporter_detail.html:25
 msgid "{addon} Compatibility Reports"
 msgstr "Relatórios de compatibilidade de {addon}"
 
@@ -4093,8 +3209,7 @@ msgid_plural "{0} problem reports"
 msgstr[0] "{0} relatório com problemas"
 msgstr[1] "{0} relatórios com problemas"
 
-#: src/olympia/compat/templates/compat/reporter_detail.html:21
-#: src/olympia/users/templates/users/profile.html:70
+#: src/olympia/compat/templates/compat/reporter_detail.html:21 src/olympia/users/templates/users/profile.html:70
 msgid "View all"
 msgstr "Ver todos"
 
@@ -4106,10 +3221,8 @@ msgstr "Filtrar por Aplicação"
 msgid "Report Type"
 msgstr "Tipo de relatório"
 
-#: src/olympia/compat/templates/compat/reporter_detail.html:47
-#: src/olympia/devhub/forms.py:784
-#: src/olympia/devhub/templates/devhub/addons/ajax_compat_update.html:17
-#: src/olympia/editors/forms.py:108 src/olympia/zadmin/forms.py:45
+#: src/olympia/compat/templates/compat/reporter_detail.html:47 src/olympia/devhub/forms.py:785 src/olympia/devhub/templates/devhub/addons/ajax_compat_update.html:17 src/olympia/editors/forms.py:108
+#: src/olympia/editors/forms.py:248 src/olympia/zadmin/forms.py:45
 msgid "Application"
 msgstr "Aplicativo"
 
@@ -4121,8 +3234,7 @@ msgstr "Build da aplicação"
 msgid "Platform"
 msgstr "Plataforma"
 
-#: src/olympia/compat/templates/compat/reporter_detail.html:50
-#: src/olympia/editors/templates/editors/themes/themes.html:40
+#: src/olympia/compat/templates/compat/reporter_detail.html:50 src/olympia/editors/templates/editors/themes/themes.html:40
 msgid "Submitted"
 msgstr "Submetido"
 
@@ -4150,8 +3262,7 @@ msgstr "Thunderbird"
 msgid "SeaMonkey"
 msgstr "SeaMonkey"
 
-#: src/olympia/constants/applications.py:75
-#: src/olympia/pages/templates/pages/sunbird.html:4
+#: src/olympia/constants/applications.py:75 src/olympia/pages/templates/pages/sunbird.html:4
 msgid "Sunbird"
 msgstr "Sunbird"
 
@@ -4205,7 +3316,7 @@ msgstr "Analisado preliminarmente"
 msgid "Preliminarily Reviewed and Awaiting Full Review"
 msgstr "Analisado preliminarmente e aguardando análise completa"
 
-#: src/olympia/constants/base.py:33 src/olympia/editors/helpers.py:924
+#: src/olympia/constants/base.py:33 src/olympia/editors/forms.py:258 src/olympia/editors/helpers.py:73 src/olympia/editors/helpers.py:1004
 #: src/olympia/editors/templates/editors/themes/history_table.html:34
 msgid "Deleted"
 msgstr "Excluído"
@@ -4239,13 +3350,11 @@ msgstr "Desenvolvedor"
 msgid "Viewer"
 msgstr "Visualizador"
 
-#: src/olympia/constants/base.py:137
-#: src/olympia/templates/mobile/header.html:7
+#: src/olympia/constants/base.py:137 src/olympia/templates/mobile/header.html:7
 msgid "Support"
 msgstr "Suporte"
 
-#: src/olympia/constants/base.py:159 src/olympia/constants/base.py:172
-#: src/olympia/constants/platforms.py:10
+#: src/olympia/constants/base.py:159 src/olympia/constants/base.py:172 src/olympia/constants/platforms.py:10
 msgid "Any"
 msgstr "Qualquer"
 
@@ -4273,11 +3382,8 @@ msgstr "Pacote de idioma (complemento)"
 msgid "Plugin"
 msgstr "Plugin"
 
-#: src/olympia/constants/base.py:167
-#: src/olympia/editors/templates/editors/includes/search_results_themes.html:5
-#: src/olympia/editors/templates/editors/themes/deleted.html:18
-#: src/olympia/editors/templates/editors/themes/history_table.html:8
-#: src/olympia/editors/templates/editors/themes/logs.html:17
+#: src/olympia/constants/base.py:167 src/olympia/editors/templates/editors/includes/search_results_themes.html:5 src/olympia/editors/templates/editors/themes/deleted.html:18
+#: src/olympia/editors/templates/editors/themes/history_table.html:8 src/olympia/editors/templates/editors/themes/logs.html:17
 msgid "Theme"
 msgstr "Tema"
 
@@ -4304,8 +3410,7 @@ msgstr "Plugins"
 # %1$s is a URL where the user can see an example
 #: src/olympia/constants/base.py:271
 msgid "Only ask on this add-on's page and developer profile"
-msgstr ""
-"Pedir somente na página desse complemento e no perfil do desenvolvedor"
+msgstr "Pedir somente na página desse complemento e no perfil do desenvolvedor"
 
 # %1$s is a URL where the user can see an example
 #: src/olympia/constants/base.py:272
@@ -4316,6 +3421,11 @@ msgstr "Pedir depois que os usuários começarem a baixar esse complemento"
 #: src/olympia/constants/base.py:273
 msgid "Ask before users can download this add-on"
 msgstr "Pedir antes que os usuários possam baixar esse complemento"
+
+#. Review points sources other than add-ons and themes.
+#: src/olympia/constants/base.py:388 src/olympia/devhub/forms.py:162 src/olympia/editors/templates/editors/performance.html:75
+msgid "Other"
+msgstr "Outro"
 
 #: src/olympia/constants/base.py:389
 msgid "Exception"
@@ -4328,6 +3438,10 @@ msgstr "Lançamento"
 #: src/olympia/constants/base.py:391
 msgid "Change"
 msgstr "Alterar"
+
+#: src/olympia/constants/base.py:401
+msgid "App"
+msgstr "Aplicativo"
 
 #: src/olympia/constants/base.py:402
 msgid "Persona"
@@ -4465,32 +3579,23 @@ msgstr "Assinado para uma análise completa"
 msgid "Signed of a preliminary review"
 msgstr "Assinado para uma análise preliminar"
 
-#: src/olympia/constants/editors.py:14
-#: src/olympia/editors/templates/editors/themes/queue.html:76
-#: src/olympia/editors/templates/editors/themes/themes.html:87
+#: src/olympia/constants/editors.py:14 src/olympia/editors/templates/editors/themes/queue.html:76 src/olympia/editors/templates/editors/themes/themes.html:87
 msgid "Request More Info"
 msgstr "Solicitar mais informações"
 
-#: src/olympia/constants/editors.py:15
-#: src/olympia/editors/templates/editors/themes/queue.html:74
-#: src/olympia/editors/templates/editors/themes/themes.html:91
+#: src/olympia/constants/editors.py:15 src/olympia/editors/templates/editors/themes/queue.html:74 src/olympia/editors/templates/editors/themes/themes.html:91
 msgid "Flag"
 msgstr "Marcar"
 
-#: src/olympia/constants/editors.py:16
-#: src/olympia/editors/templates/editors/themes/queue.html:72
-#: src/olympia/editors/templates/editors/themes/themes.html:93
+#: src/olympia/constants/editors.py:16 src/olympia/editors/templates/editors/themes/queue.html:72 src/olympia/editors/templates/editors/themes/themes.html:93
 msgid "Duplicate"
 msgstr "Duplicar"
 
-#: src/olympia/constants/editors.py:17 src/olympia/editors/helpers.py:502
-#: src/olympia/editors/templates/editors/themes/queue.html:71
-#: src/olympia/editors/templates/editors/themes/themes.html:94
+#: src/olympia/constants/editors.py:17 src/olympia/editors/helpers.py:575 src/olympia/editors/templates/editors/themes/queue.html:71 src/olympia/editors/templates/editors/themes/themes.html:94
 msgid "Reject"
 msgstr "Rejeitar"
 
-#: src/olympia/constants/editors.py:18
-#: src/olympia/editors/templates/editors/themes/queue.html:70
+#: src/olympia/constants/editors.py:18 src/olympia/editors/templates/editors/themes/queue.html:70
 msgid "Approve"
 msgstr "Aprovar"
 
@@ -4544,15 +3649,11 @@ msgstr "Creative Commons Atribuição-Uso não-comercial 3.0"
 
 #: src/olympia/constants/licenses.py:36
 msgid "Creative Commons Attribution-NonCommercial-NoDerivs 3.0"
-msgstr ""
-"Creative Commons Atribuição-Uso não-comercial-Vedada a criação de obras "
-"derivadas 3.0"
+msgstr "Creative Commons Atribuição-Uso não-comercial-Vedada a criação de obras derivadas 3.0"
 
 #: src/olympia/constants/licenses.py:43
 msgid "Creative Commons Attribution-NonCommercial-Share Alike 3.0"
-msgstr ""
-"Creative Commons Atribuição-Uso não-comercial-Compartilhamento pela mesma "
-"licença 3.0"
+msgstr "Creative Commons Atribuição-Uso não-comercial-Compartilhamento pela mesma licença 3.0"
 
 #: src/olympia/constants/licenses.py:50
 msgid "Creative Commons Attribution-NoDerivs 3.0"
@@ -4590,7 +3691,7 @@ msgstr "Solaris"
 msgid "Android"
 msgstr "Android"
 
-#: src/olympia/core/apps.py:19
+#: src/olympia/core/apps.py:21
 msgid "Core"
 msgstr "Núcleo"
 
@@ -4627,9 +3728,7 @@ msgstr "Objeto JSON inválido"
 msgid "Message not eligible for annotation"
 msgstr "Mensagem não elegível para anotação"
 
-#: src/olympia/devhub/forms.py:124
-#: src/olympia/devhub/templates/devhub/versions/edit.html:94
-#: src/olympia/users/templates/users/edit.html:150
+#: src/olympia/devhub/forms.py:124 src/olympia/devhub/templates/devhub/versions/edit.html:94 src/olympia/users/templates/users/edit.html:150
 msgid "Details"
 msgstr "Detalhes"
 
@@ -4700,9 +3799,7 @@ msgstr "O ID do PayPal não pôde ser validado."
 
 #: src/olympia/devhub/forms.py:388
 msgid "Unsupported file type, please upload an archive file {extensions}."
-msgstr ""
-"Tipo de arquivo não suportado, por favor enviar um arquivo no formato "
-"{extensions}."
+msgstr "Tipo de arquivo não suportado, por favor enviar um arquivo no formato {extensions}."
 
 #: src/olympia/devhub/forms.py:407
 msgid "View current"
@@ -4729,39 +3826,26 @@ msgid "Submit my add-on for manual review."
 msgstr "Submeter o meu complemento para revisão manual."
 
 #: src/olympia/devhub/forms.py:537
-msgid "Do not list my add-on on this site (beta)"
-msgstr "Não listar meu complemento neste site (beta)"
+msgid "Do not list my add-on on this site"
+msgstr ""
 
 #: src/olympia/devhub/forms.py:538
-msgid ""
-"Check this option if you intend to distribute your add-on on your own and "
-"only need it to be signed by Mozilla."
-msgstr ""
-"Marque esta opção se pretende distribuir seu complemento por conta própria e"
-" só precisa que ele seja assinado pela Mozilla."
+msgid "Check this option if you intend to distribute your add-on on your own and only need it to be signed by Mozilla."
+msgstr "Marque esta opção se pretende distribuir seu complemento por conta própria e só precisa que ele seja assinado pela Mozilla."
 
 #: src/olympia/devhub/forms.py:544
 msgid "This add-on will be bundled with an application installer."
 msgstr "Este complemento vai ser empacotado com um instalador de aplicativo."
 
 #: src/olympia/devhub/forms.py:546
-msgid ""
-"Add-ons that are bundled with application installers will be code reviewed "
-"by Mozilla before they are signed and are held to a higher quality standard."
-msgstr ""
-"Os complementos que são incorporados com instaladores de aplicativos terão o"
-" código revisados pela Mozilla antes de serem assinados e são acompanhados "
-"de um padrão de qualidade superior."
+msgid "Add-ons that are bundled with application installers will be code reviewed by Mozilla before they are signed and are held to a higher quality standard."
+msgstr "Os complementos que são incorporados com instaladores de aplicativos terão o código revisados pela Mozilla antes de serem assinados e são acompanhados de um padrão de qualidade superior."
 
-#: src/olympia/devhub/forms.py:565
-#: src/olympia/devhub/templates/devhub/addons/submit/select-review.html:24
-#: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:42
+#: src/olympia/devhub/forms.py:565 src/olympia/devhub/templates/devhub/addons/submit/select-review.html:24 src/olympia/devhub/templates/devhub/docs/policies-reviews.html:42
 msgid "Full Review"
 msgstr "Análise completa"
 
-#: src/olympia/devhub/forms.py:566
-#: src/olympia/devhub/templates/devhub/addons/submit/select-review.html:47
-#: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:153
+#: src/olympia/devhub/forms.py:566 src/olympia/devhub/templates/devhub/addons/submit/select-review.html:47 src/olympia/devhub/templates/devhub/docs/policies-reviews.html:153
 msgid "Preliminary Review"
 msgstr "Análise preliminar"
 
@@ -4770,67 +3854,51 @@ msgid "Please choose a review nomination type"
 msgstr "Por favor, escolha um tipo de nomeação para revisão"
 
 #: src/olympia/devhub/forms.py:574
-msgid ""
-"A file with a version ending with a|alpha|b|beta|pre|rc and an optional "
-"number is detected as beta."
-msgstr ""
-"Um arquivo com uma versão que termina com a|alpha|b|beta|pre|rc e um número "
-"opcional é detectado como beta."
+msgid "A file with a version ending with a|alpha|b|beta|pre|rc and an optional number is detected as beta."
+msgstr "Um arquivo com uma versão que termina com a|alpha|b|beta|pre|rc e um número opcional é detectado como beta."
 
 #: src/olympia/devhub/forms.py:592
 #, python-format
-msgid "Version %s already exists"
-msgstr "A versão %s já existe"
-
-#: src/olympia/devhub/forms.py:604
-msgid ""
-"Select a valid choice. That choice is not one of the available choices."
+msgid "Version %s already exists, or was uploaded before."
 msgstr ""
-"Selecione uma opção válida. Essa escolha não é uma das opções disponíveis."
 
-#: src/olympia/devhub/forms.py:610
-msgid ""
-"A file with a version ending with a|alpha|b|beta and an optional number is "
-"detected as beta."
-msgstr ""
-"Um arquivo com uma versão terminando com a|alpha|b|beta e um número opcional"
-" é detectado como beta."
+#: src/olympia/devhub/forms.py:605
+msgid "Select a valid choice. That choice is not one of the available choices."
+msgstr "Selecione uma opção válida. Essa escolha não é uma das opções disponíveis."
 
-#: src/olympia/devhub/forms.py:633
+#: src/olympia/devhub/forms.py:611
+msgid "A file with a version ending with a|alpha|b|beta and an optional number is detected as beta."
+msgstr "Um arquivo com uma versão terminando com a|alpha|b|beta e um número opcional é detectado como beta."
+
+#: src/olympia/devhub/forms.py:634
 msgid "You cannot upload any more files for this version."
 msgstr "Você não pode enviar mais nenhum arquivo para essa versão."
 
-#: src/olympia/devhub/forms.py:639
+#: src/olympia/devhub/forms.py:640
 msgid "Version doesn't match"
 msgstr "A versão não corresponde"
 
-#: src/olympia/devhub/forms.py:668
-msgid ""
-"You cannot delete a file once the review process has started.  You must "
-"delete the whole version."
+#: src/olympia/devhub/forms.py:669
+msgid "You cannot delete a file once the review process has started.  You must delete the whole version."
 msgstr ""
-"Você não pode remover um arquivo uma vez que o processo de revisão foi "
-"iniciado.  Você precisa remover a versão completa."
 
-#: src/olympia/devhub/forms.py:688
+#: src/olympia/devhub/forms.py:689
 msgid "The platform All cannot be combined with specific platforms."
-msgstr ""
-"A plataforma Todas não pode ser combinada com plataformas específicas."
+msgstr "A plataforma Todas não pode ser combinada com plataformas específicas."
 
-#: src/olympia/devhub/forms.py:693
+#: src/olympia/devhub/forms.py:694
 msgid "A platform can only be chosen once."
 msgstr "Uma plataforma só pode ser escolhida uma vez."
 
-#: src/olympia/devhub/forms.py:706
+#: src/olympia/devhub/forms.py:707
 msgid "A review type must be selected."
 msgstr "Um tipo de análise deve ser selecionado."
 
-#: src/olympia/devhub/forms.py:788 src/olympia/editors/forms.py:114
-#: src/olympia/zadmin/forms.py:49 src/olympia/zadmin/forms.py:52
+#: src/olympia/devhub/forms.py:789 src/olympia/editors/forms.py:114 src/olympia/editors/forms.py:254 src/olympia/zadmin/forms.py:49 src/olympia/zadmin/forms.py:52
 msgid "Select an application first"
 msgstr "Selecione uma aplicação antes"
 
-#: src/olympia/devhub/forms.py:840
+#: src/olympia/devhub/forms.py:841
 msgid "There cannot be more than 3 required add-ons."
 msgstr "Não pode haver mais que 3 complementos requeridos."
 
@@ -4846,106 +3914,97 @@ msgstr "As minhas submissões"
 msgid "Developer Docs"
 msgstr "Documentos para desenvolvedores"
 
-#. L10n: first parameter is the number of errors
 # {0} is a number
+#. L10n: first parameter is the number of errors
 #: src/olympia/devhub/helpers.py:200
 msgid "{0} error"
 msgid_plural "{0} errors"
 msgstr[0] "{0} erro"
 msgstr[1] "{0} erros"
 
-#. L10n: first parameter is the number of warnings
 # {0} is a number
+#. L10n: first parameter is the number of warnings
 #: src/olympia/devhub/helpers.py:203
 msgid "{0} warning"
 msgid_plural "{0} warnings"
 msgstr[0] "{0} alerta"
 msgstr[1] "{0} alertas"
 
-#: src/olympia/devhub/models.py:375
-#: src/olympia/reviews/templates/reviews/add.html:58
+#: src/olympia/devhub/models.py:375 src/olympia/reviews/templates/reviews/add.html:58
 msgid "Review"
 msgstr "Análise"
 
-#: src/olympia/devhub/tasks.py:551
+#: src/olympia/devhub/tasks.py:583
 #, python-format
 msgid "%s responded with %s (%s)."
 msgstr "%s respondeu com %s (%s)."
 
-#: src/olympia/devhub/tasks.py:555
+#: src/olympia/devhub/tasks.py:587
 #, python-format
 msgid "Connection to \"%s\" timed out."
 msgstr "A conexão com \"%s\" expirou."
 
-#: src/olympia/devhub/tasks.py:557
+#: src/olympia/devhub/tasks.py:589
 #, python-format
 msgid "Could not contact host at \"%s\"."
 msgstr "Não foi possível contatar o servidor em \"%s\"."
 
-#: src/olympia/devhub/utils.py:104
+#: src/olympia/devhub/utils.py:105
 #, python-format
-msgid ""
-"Validation generated too many errors/warnings so %s messages were truncated."
-" After addressing the visible messages, you'll be able to see the others."
-msgstr ""
-"A validação gerou muitos erros/alertas então %s mensagens foram cortadas. "
-"Após corrigir as mensagens visíveis, você poderá ver as outras mensagens."
+msgid "Validation generated too many errors/warnings so %s messages were truncated. After addressing the visible messages, you'll be able to see the others."
+msgstr "A validação gerou muitos erros/alertas então %s mensagens foram cortadas. Após corrigir as mensagens visíveis, você poderá ver as outras mensagens."
 
-#: src/olympia/devhub/views.py:183
+#: src/olympia/devhub/views.py:181
 msgid "All My Add-ons"
 msgstr "Todos os meus complementos"
 
-#: src/olympia/devhub/views.py:210
+#: src/olympia/devhub/views.py:208
 msgid "All Activity"
 msgstr "Tudo"
 
-#: src/olympia/devhub/views.py:211
+#: src/olympia/devhub/views.py:209
 msgid "Add-on Updates"
 msgstr "Atualizações do complemento"
 
-#: src/olympia/devhub/views.py:212
+#: src/olympia/devhub/views.py:210
 msgid "Add-on Status"
 msgstr "Status do complemento"
 
 # %1$s is the name of the collection
-#: src/olympia/devhub/views.py:213
+#: src/olympia/devhub/views.py:211
 msgid "User Collections"
 msgstr "Coleções de usuários"
 
-#: src/olympia/devhub/views.py:214
-#: src/olympia/devhub/templates/devhub/docs/policies-maintenance.html:68
-#: src/olympia/pages/templates/pages/dev_faq.html:38
+#: src/olympia/devhub/views.py:212 src/olympia/devhub/templates/devhub/docs/policies-maintenance.html:68 src/olympia/pages/templates/pages/dev_faq.html:38
 #: src/olympia/pages/templates/pages/dev_faq.html:484
 msgid "User Reviews"
 msgstr "Análises de usuários"
 
-#: src/olympia/devhub/views.py:327 src/olympia/devhub/views.py:331
-#: src/olympia/devhub/views.py:484 src/olympia/devhub/views.py:513
-#: src/olympia/devhub/views.py:564 src/olympia/devhub/views.py:1150
+#: src/olympia/devhub/views.py:325 src/olympia/devhub/views.py:329 src/olympia/devhub/views.py:484 src/olympia/devhub/views.py:513 src/olympia/devhub/views.py:564 src/olympia/devhub/views.py:1156
 msgid "Changes successfully saved."
 msgstr "Alterações salvas com sucesso."
 
-#: src/olympia/devhub/views.py:334 src/olympia/devhub/views.py:1631
+#: src/olympia/devhub/views.py:332 src/olympia/devhub/views.py:1637
 msgid "Please check the form for errors."
 msgstr "Por favor, verifique se ha erros no formulário."
 
-#: src/olympia/devhub/views.py:346
+#: src/olympia/devhub/views.py:344
 msgid "Add-on cannot be deleted. Disable this add-on instead."
 msgstr "O complemento não pode ser excluído. Desabilite-o, em vez disso."
 
-#: src/olympia/devhub/views.py:356
+#: src/olympia/devhub/views.py:354
 msgid "Theme deleted."
 msgstr "Tema excluído."
 
-#: src/olympia/devhub/views.py:356
+#: src/olympia/devhub/views.py:354
 msgid "Add-on deleted."
 msgstr "Complemento excluído."
 
-#: src/olympia/devhub/views.py:362
+#: src/olympia/devhub/views.py:360
 msgid "URL name was incorrect. Theme was not deleted."
 msgstr "O nome da URL estava incorreto. O tema não foi removido."
 
-#: src/olympia/devhub/views.py:367
+#: src/olympia/devhub/views.py:365
 msgid "URL name was incorrect. Add-on was not deleted."
 msgstr "O nome da URL estava incorreto. O complemento não foi removido."
 
@@ -4973,7 +4032,7 @@ msgstr "Validar complemento"
 msgid "Check Add-on Compatibility"
 msgstr "Verificação de compatibilidade do complemento"
 
-#: src/olympia/devhub/views.py:808 src/olympia/signing/views.py:90
+#: src/olympia/devhub/views.py:808 src/olympia/signing/views.py:95
 msgid "You cannot submit this type of add-on"
 msgstr "Você não pode submeter este tipo de complemento"
 
@@ -4997,62 +4056,47 @@ msgstr "As imagens não podem ser maiores que %d kB."
 #. L10n: {0} is an image width (in pixels), {1} is a height.
 #: src/olympia/devhub/views.py:1080
 msgid "Image must be exactly {0} pixels wide and {1} pixels tall."
-msgstr ""
-"A imagem deve ter exatamente {0} píxeis de largura e {1} píxeis de altura."
+msgstr "A imagem deve ter exatamente {0} píxeis de largura e {1} píxeis de altura."
 
 #: src/olympia/devhub/views.py:1087
 msgid "There was an error uploading your preview."
 msgstr "Ocorreu um erro ao enviar sua imagem."
 
-#: src/olympia/devhub/views.py:1189
+#: src/olympia/devhub/views.py:1195
 #, python-format
 msgid "Version %s disabled."
 msgstr "Versão %s desabilitada."
 
 # %s is the version number, e.g. 3.2.
-#: src/olympia/devhub/views.py:1193
+#: src/olympia/devhub/views.py:1199
 #, python-format
 msgid "Version %s deleted."
 msgstr "Versão %s excluída."
 
-#: src/olympia/devhub/views.py:1203
-msgid ""
-"This upload has failed validation, and may lack complete validation results."
-" Please take due care when reviewing it."
-msgstr ""
-"Esse arquivo falhou em algum dos testes de validação e pode não apresentar "
-"resultados completos de validação. Por favor, tome o devido cuidado ao "
-"analisá-lo."
+#: src/olympia/devhub/views.py:1209
+msgid "This upload has failed validation, and may lack complete validation results. Please take due care when reviewing it."
+msgstr "Esse arquivo falhou em algum dos testes de validação e pode não apresentar resultados completos de validação. Por favor, tome o devido cuidado ao analisá-lo."
 
-#: src/olympia/devhub/views.py:1677
+#: src/olympia/devhub/views.py:1683
 msgid "Preliminary Review Requested."
 msgstr "Análise preliminar solicitada."
 
-#: src/olympia/devhub/views.py:1678
+#: src/olympia/devhub/views.py:1684
 msgid "Full Review Requested."
 msgstr "Análise completa solicitada."
 
-#: src/olympia/devhub/views.py:1779
-msgid ""
-"Your old credentials were revoked and are no longer valid. Be sure to update"
-" all API clients with the new credentials."
-msgstr ""
-"As suas credenciais antigas foram revogadas e já não são válidas. Atualize "
-"todos os clientes da API com as novas credenciais."
+#: src/olympia/devhub/views.py:1783
+msgid "Your old credentials were revoked and are no longer valid. Be sure to update all API clients with the new credentials."
+msgstr "As suas credenciais antigas foram revogadas e já não são válidas. Atualize todos os clientes da API com as novas credenciais."
 
-#: src/olympia/devhub/views.py:1797
+#: src/olympia/devhub/views.py:1801
 msgid "New API key created"
 msgstr "Criana nova chave de API"
 
 #: src/olympia/devhub/templates/devhub/agreement.html:2
-msgid ""
-"Before starting, please read and accept our Firefox Add-on Distribution "
-"Agreement. It also links to our Privacy Notice which explains how we handle "
-"your information."
+msgid "Before starting, please read and accept our Firefox Add-on Distribution Agreement. It also links to our Privacy Notice which explains how we handle your information."
 msgstr ""
-"Antes de iniciar, por favor leia e aceite nosso acordo de distribuição de "
-"complementos Firefox. Ele também vincula a nossa notificação de privacidade "
-"que explica como nós tratamos sua informação."
+"Antes de iniciar, por favor leia e aceite nosso acordo de distribuição de complementos Firefox. Ele também vincula a nossa notificação de privacidade que explica como nós tratamos sua informação."
 
 #: src/olympia/devhub/templates/devhub/agreement.html:13
 msgid "Printable Version"
@@ -5066,44 +4110,30 @@ msgstr "Eu aceito esse acordo"
 msgid "or <a href=\"{0}\">Cancel</a>"
 msgstr "ou <a href=\"{0}\">Cancelar</a>"
 
-#: src/olympia/devhub/templates/devhub/base.html:23
-#: src/olympia/devhub/templates/devhub/base_impala.html:20
-#: src/olympia/discovery/templates/discovery/addons/base.html:17
+#: src/olympia/devhub/templates/devhub/base.html:23 src/olympia/devhub/templates/devhub/base_impala.html:20 src/olympia/discovery/templates/discovery/addons/base.html:17
 msgid "Back to Add-ons"
 msgstr "Voltar para os complementos"
 
 #. {0} is a search term, such as Firebug.
 #. {0} is a search query.
-#: src/olympia/devhub/templates/devhub/devhub_search.html:4
-#: src/olympia/search/templates/search/results.html:9
-#: src/olympia/search/templates/search/mobile/results.html:6
+#: src/olympia/devhub/templates/devhub/devhub_search.html:4 src/olympia/search/templates/search/results.html:9 src/olympia/search/templates/search/mobile/results.html:6
 msgid "{0} :: Search"
 msgstr "{0} :: Pesquisa"
 
-#: src/olympia/devhub/templates/devhub/devhub_search.html:6
-#: src/olympia/devhub/templates/devhub/search.html:8
-#: src/olympia/editors/forms.py:435 src/olympia/editors/forms.py:437
-#: src/olympia/editors/templates/editors/queue.html:27
-#: src/olympia/editors/templates/editors/themes/queue_list.html:14
-#: src/olympia/search/templates/search/collections.html:17
-#: src/olympia/search/templates/search/personas.html:18
-#: src/olympia/search/templates/search/results.html:18
-#: src/olympia/search/templates/search/mobile/results.html:8
-#: src/olympia/templates/search.html:14
-#: src/olympia/templates/impala/search.html:18
+#: src/olympia/devhub/templates/devhub/devhub_search.html:6 src/olympia/devhub/templates/devhub/search.html:8 src/olympia/editors/forms.py:534 src/olympia/editors/forms.py:536
+#: src/olympia/editors/templates/editors/queue.html:27 src/olympia/editors/templates/editors/themes/queue_list.html:14 src/olympia/search/templates/search/collections.html:17
+#: src/olympia/search/templates/search/personas.html:18 src/olympia/search/templates/search/results.html:18 src/olympia/search/templates/search/mobile/results.html:8
+#: src/olympia/templates/search.html:14 src/olympia/templates/impala/search.html:18
 msgid "Search"
 msgstr "Pesquisar"
 
-#: src/olympia/devhub/templates/devhub/devhub_search.html:11
-#: src/olympia/devhub/templates/devhub/devhub_search.html:15
-#: src/olympia/search/templates/search/collections.html:18
+#: src/olympia/devhub/templates/devhub/devhub_search.html:11 src/olympia/devhub/templates/devhub/devhub_search.html:15 src/olympia/search/templates/search/collections.html:18
 #: src/olympia/search/templates/search/personas.html:20
 msgid "Search Results"
 msgstr "Resultados da pesquisa"
 
 #. {0} is a search term, such as Firebug.
-#: src/olympia/devhub/templates/devhub/devhub_search.html:13
-#: src/olympia/search/templates/search/results.html:11
+#: src/olympia/devhub/templates/devhub/devhub_search.html:13 src/olympia/search/templates/search/results.html:11
 msgid "Search Results for \"{0}\""
 msgstr "Resultados da pesquisa para \"{0}\""
 
@@ -5124,12 +4154,8 @@ msgid "AMO Reviewers"
 msgstr "Revisores do AMO"
 
 #: src/olympia/devhub/templates/devhub/index.html:29
-msgid ""
-"Get ahead! Become an AMO Reviewer today and get your add-ons reviewed "
-"faster."
-msgstr ""
-"Vá em frente! Torne-se um revisor do AMO agora mesmo e acelere o processo de"
-" análise dos seus complementos."
+msgid "Get ahead! Become an AMO Reviewer today and get your add-ons reviewed faster."
+msgstr "Vá em frente! Torne-se um revisor do AMO agora mesmo e acelere o processo de análise dos seus complementos."
 
 #: src/olympia/devhub/templates/devhub/index.html:32
 msgid "Become an AMO Reviewer"
@@ -5141,41 +4167,28 @@ msgstr "Saiba tudo sobre complementos"
 
 #: src/olympia/devhub/templates/devhub/index.html:41
 msgid ""
-"Add-ons let millions of Firefox users enhance and customize their browsing "
-"experience. If you're a Web developer and know <a "
-"href=\"https://developer.mozilla.org/docs/Web/HTML\">HTML</a>, <a "
-"href=\"https://developer.mozilla.org/docs/Web/JavaScript\">JavaScript</a>, "
-"and <a href=\"https://developer.mozilla.org/docs/Web/CSS\">CSS</a>, you "
-"already have all the necessary skills to make a great add-on."
+"Add-ons let millions of Firefox users enhance and customize their browsing experience. If you're a Web developer and know <a href=\"https://developer.mozilla.org/docs/Web/HTML\">HTML</a>, <a href="
+"\"https://developer.mozilla.org/docs/Web/JavaScript\">JavaScript</a>, and <a href=\"https://developer.mozilla.org/docs/Web/CSS\">CSS</a>, you already have all the necessary skills to make a great "
+"add-on."
 msgstr ""
-"Os complementos permitem que milhões de usuários do Firefox melhorem e "
-"personalizem a sua experiência de navegação. Se é um desenvolvedor web e "
-"sabe <a href=\"https://developer.mozilla.org/docs/Web/HTML\">HTML</a>, <a "
-"href=\"https://developer.mozilla.org/docs/Web/JavaScript\">JavaScript</a> e "
-"<a href=\"https://developer.mozilla.org/docs/Web/CSS\">CSS</a>, então já tem"
-" todas as capacidades necessárias para fazer um ótimo complemento."
+"Os complementos permitem que milhões de usuários do Firefox melhorem e personalizem a sua experiência de navegação. Se é um desenvolvedor web e sabe <a href=\"https://developer.mozilla.org/docs/Web/"
+"HTML\">HTML</a>, <a href=\"https://developer.mozilla.org/docs/Web/JavaScript\">JavaScript</a> e <a href=\"https://developer.mozilla.org/docs/Web/CSS\">CSS</a>, então já tem todas as capacidades "
+"necessárias para fazer um ótimo complemento."
 
 #: src/olympia/devhub/templates/devhub/index.html:51
-msgid ""
-"Head over to the <a href=\"https://developer.mozilla.org/Add-ons\">Mozilla "
-"Developer Network</a> to learn everything you need to know to get started."
-msgstr ""
-"Visite a <a href=\"https://developer.mozilla.org/Add-ons\">Mozilla Developer"
-" Network</a> para aprender tudo o que precisa saber para começar."
+msgid "Head over to the <a href=\"https://developer.mozilla.org/Add-ons\">Mozilla Developer Network</a> to learn everything you need to know to get started."
+msgstr "Visite a <a href=\"https://developer.mozilla.org/Add-ons\">Mozilla Developer Network</a> para aprender tudo o que precisa saber para começar."
 
 #: src/olympia/devhub/templates/devhub/index.html:58
 msgid "Start Making Add-ons"
 msgstr "Começar a criar complementos"
 
-#: src/olympia/devhub/templates/devhub/index.html:86
-#: src/olympia/devhub/templates/devhub/addons/listing/items.html:25
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:15
+#: src/olympia/devhub/templates/devhub/index.html:86 src/olympia/devhub/templates/devhub/addons/listing/items.html:25 src/olympia/devhub/templates/devhub/includes/addon_details.html:20
 #: src/olympia/devhub/templates/devhub/personas/edit.html:43
 msgid "Status:"
 msgstr "Status:"
 
-#: src/olympia/devhub/templates/devhub/index.html:90
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:100
+#: src/olympia/devhub/templates/devhub/index.html:90 src/olympia/devhub/templates/devhub/includes/addon_details.html:87
 msgid "Visibility:"
 msgstr "Visibilidade:"
 
@@ -5183,21 +4196,16 @@ msgstr "Visibilidade:"
 msgid "Latest Version:"
 msgstr "Versão mais recente:"
 
-#: src/olympia/devhub/templates/devhub/index.html:109
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:145
-#: src/olympia/devhub/templates/devhub/personas/edit.html:49
+#: src/olympia/devhub/templates/devhub/index.html:109 src/olympia/devhub/templates/devhub/includes/addon_details.html:131 src/olympia/devhub/templates/devhub/personas/edit.html:49
 msgid "Queue Position:"
 msgstr "Posição na fila:"
 
-#: src/olympia/devhub/templates/devhub/index.html:110
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:146
-#: src/olympia/devhub/templates/devhub/personas/edit.html:50
+#: src/olympia/devhub/templates/devhub/index.html:110 src/olympia/devhub/templates/devhub/includes/addon_details.html:132 src/olympia/devhub/templates/devhub/personas/edit.html:50
 #, python-format
 msgid "%(position)s of %(total)s"
 msgstr "%(position)s de %(total)s"
 
-#: src/olympia/devhub/templates/devhub/index.html:120
-#: src/olympia/devhub/templates/devhub/includes/addons_edit_nav.html:19
+#: src/olympia/devhub/templates/devhub/index.html:120 src/olympia/devhub/templates/devhub/includes/addons_edit_nav.html:19
 msgid "Upload New Version"
 msgstr "Enviar versão nova"
 
@@ -5211,12 +4219,8 @@ msgstr "Publique seus complementos!"
 
 #: src/olympia/devhub/templates/devhub/index.html:136
 #, python-format
-msgid ""
-"Upload an <a href=\"%(addon_url)s\">add-on</a> or <a "
-"href=\"%(theme_url)s\">theme</a> to get started!"
-msgstr ""
-"Envie um <a href=\"%(addon_url)s\">complemento</a> ou um <a "
-"href=\"%(theme_url)s\">tema</a> para começar!"
+msgid "Upload an <a href=\"%(addon_url)s\">add-on</a> or <a href=\"%(theme_url)s\">theme</a> to get started!"
+msgstr "Envie um <a href=\"%(addon_url)s\">complemento</a> ou um <a href=\"%(theme_url)s\">tema</a> para começar!"
 
 #: src/olympia/devhub/templates/devhub/nav.html:2
 msgid "Return to the DevHub homepage"
@@ -5243,17 +4247,10 @@ msgstr "Desenvolvimento de extensões"
 msgid "Lightweight Themes"
 msgstr "Temas leves"
 
-#: src/olympia/devhub/templates/devhub/nav.html:39
-#: src/olympia/devhub/templates/devhub/docs/policies-agreement.html:6
-#: src/olympia/devhub/templates/devhub/docs/policies-contact.html:6
-#: src/olympia/devhub/templates/devhub/docs/policies-maintenance.html:6
-#: src/olympia/devhub/templates/devhub/docs/policies-recommended.html:6
-#: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:6
-#: src/olympia/devhub/templates/devhub/docs/policies-submission.html:6
-#: src/olympia/devhub/templates/devhub/docs/policies.html:3
-#: src/olympia/devhub/templates/devhub/docs/policies.html:9
-#: src/olympia/devhub/templates/devhub/docs/policies.html:38
-#: src/olympia/devhub/templates/devhub/docs/policies.html:39
+#: src/olympia/devhub/templates/devhub/nav.html:39 src/olympia/devhub/templates/devhub/docs/policies-agreement.html:6 src/olympia/devhub/templates/devhub/docs/policies-contact.html:6
+#: src/olympia/devhub/templates/devhub/docs/policies-maintenance.html:6 src/olympia/devhub/templates/devhub/docs/policies-recommended.html:6
+#: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:6 src/olympia/devhub/templates/devhub/docs/policies-submission.html:6 src/olympia/devhub/templates/devhub/docs/policies.html:3
+#: src/olympia/devhub/templates/devhub/docs/policies.html:9 src/olympia/devhub/templates/devhub/docs/policies.html:38 src/olympia/devhub/templates/devhub/docs/policies.html:39
 msgid "Add-on Policies"
 msgstr "Políticas de complementos"
 
@@ -5294,48 +4291,19 @@ msgid "Use the field below to upload your add-on package."
 msgstr "Use o campo abaixo para enviar o pacote do seu complemento."
 
 #: src/olympia/devhub/templates/devhub/validate_addon.html:19
-msgid ""
-"After upload, a series of automated validation tests will run to check "
-"compatibility with the following application version:"
-msgstr ""
-"Depois do envio, uma série de testes automáticos de validação serão "
-"executados para verificar a compatibilidade com a seguinte aplicação:"
+msgid "After upload, a series of automated validation tests will run to check compatibility with the following application version:"
+msgstr "Depois do envio, uma série de testes automáticos de validação serão executados para verificar a compatibilidade com a seguinte aplicação:"
 
 #: src/olympia/devhub/templates/devhub/validate_addon.html:34
-msgid ""
-"After upload, a series of automated validation tests will be run on your "
-"file."
-msgstr ""
-"Depois do envio, uma série de testes automáticos de validação serão "
-"executados no seu arquivo."
+msgid "After upload, a series of automated validation tests will be run on your file."
+msgstr "Depois do envio, uma série de testes automáticos de validação serão executados no seu arquivo."
 
-#: src/olympia/devhub/templates/devhub/validate_addon.html:42
-#: src/olympia/devhub/templates/devhub/addons/submit/upload.html:23
+#: src/olympia/devhub/templates/devhub/validate_addon.html:42 src/olympia/devhub/templates/devhub/addons/submit/upload.html:23
 msgid "Do you want your add-on to be distributed on this site?"
 msgstr "Gostaria que o seu complemento fosse distribuído neste site?"
 
-#: src/olympia/devhub/templates/devhub/validate_addon.html:49
-#: src/olympia/devhub/templates/devhub/addons/submit/upload.html:30
-#: src/olympia/devhub/templates/devhub/versions/add_file_modal.html:14
-#: src/olympia/devhub/templates/devhub/versions/add_file_modal.html:53
-#: src/olympia/devhub/templates/devhub/versions/list.html:298
-msgid "Warning:"
-msgstr "Aviso:"
-
-#: src/olympia/devhub/templates/devhub/validate_addon.html:50
-#: src/olympia/devhub/templates/devhub/addons/submit/upload.html:31
-#, python-format
-msgid ""
-"Submission of unlisted add-ons for signing is currently in an open beta. "
-"Please <a href=\"%(url)s\" target=\"_blank\">report any bugs</a> that you "
-"encounter."
-msgstr ""
-"A submissão de complementos não listados para assinatura está atualmente em "
-"beta.Por favor <a href=\"%(url)s\" target=\"_blank\">reporte quaisquer "
-"bugs</a> que você encontrar."
-
-#. first parameter is a filename like lorem-ipsum-1.0.2.xpi
 # {0} is a filename. example: windows.exe
+#. first parameter is a filename like lorem-ipsum-1.0.2.xpi
 #: src/olympia/devhub/templates/devhub/validation.html:5
 msgid "Validation Results for {0}"
 msgstr "Resultados da validação de {0}"
@@ -5354,16 +4322,13 @@ msgstr "Compatibilidade testada para:"
 
 # 80%
 # 100%
-#: src/olympia/devhub/templates/devhub/addons/activity.html:4
-#: src/olympia/devhub/templates/devhub/addons/activity.html:20
+#: src/olympia/devhub/templates/devhub/addons/activity.html:4 src/olympia/devhub/templates/devhub/addons/activity.html:20
 msgid "Recent Activity for My Add-ons"
 msgstr "Atividade recente dos Meus complementos"
 
 # 80%
 # 100%
-#: src/olympia/devhub/templates/devhub/addons/activity.html:14
-#: src/olympia/devhub/templates/devhub/addons/activity.html:19
-#: src/olympia/devhub/templates/devhub/addons/dashboard.html:33
+#: src/olympia/devhub/templates/devhub/addons/activity.html:14 src/olympia/devhub/templates/devhub/addons/activity.html:19 src/olympia/devhub/templates/devhub/addons/dashboard.html:33
 msgid "Recent Activity"
 msgstr "Atividade recente"
 
@@ -5385,45 +4350,34 @@ msgstr "Filtrar atividade"
 msgid "Activity"
 msgstr "Atividade"
 
-#: src/olympia/devhub/templates/devhub/addons/activity.html:83
-#: src/olympia/devhub/templates/devhub/addons/dashboard.html:34
-#: src/olympia/devhub/templates/devhub/addons/dashboard.html:35
-#: src/olympia/devhub/templates/devhub/includes/blog_posts.html:4
-#: src/olympia/devhub/templates/devhub/includes/blog_posts.html:6
+#: src/olympia/devhub/templates/devhub/addons/activity.html:83 src/olympia/devhub/templates/devhub/addons/dashboard.html:34 src/olympia/devhub/templates/devhub/addons/dashboard.html:35
+#: src/olympia/devhub/templates/devhub/includes/blog_posts.html:4 src/olympia/devhub/templates/devhub/includes/blog_posts.html:6
 msgid "Subscribe to this feed"
 msgstr "Assinar este feed"
 
 #: src/olympia/devhub/templates/devhub/addons/ajax_compat_error.html:7
 #, python-format
 msgid ""
-"This add-on is incompatible with <b>%(app_name)s %(app_version)s</b>, the "
-"latest release of %(app_name)s. Please consider updating your add-on's "
-"compatibility info, or uploading a newer version of this add-on."
+"This add-on is incompatible with <b>%(app_name)s %(app_version)s</b>, the latest release of %(app_name)s. Please consider updating your add-on's compatibility info, or uploading a newer version of "
+"this add-on."
 msgstr ""
-"Esse complemento não é compatível com o <b>%(app_name)s %(app_version)s</b>,"
-" a versão mais recente do %(app_name)s. Por favor, considere atualizar as "
-"informações de compatibilidade do seu complemento ou enviar uma nova versão "
-"desse complemento."
+"Esse complemento não é compatível com o <b>%(app_name)s %(app_version)s</b>, a versão mais recente do %(app_name)s. Por favor, considere atualizar as informações de compatibilidade do seu "
+"complemento ou enviar uma nova versão desse complemento."
 
 #: src/olympia/devhub/templates/devhub/addons/ajax_compat_error.html:15
 #, python-format
 msgid ""
-"<a href=\"#\" class=\"button compat-update\" data-"
-"updateurl=\"%(update_url)s\">Update Compatibility</a> <a "
-"href=\"%(version_url)s\" class=\"button\">Upload New Version</a> or <a "
-"href=\"#\" class=\"close\">Ignore</a>"
+"<a href=\"#\" class=\"button compat-update\" data-updateurl=\"%(update_url)s\">Update Compatibility</a> <a href=\"%(version_url)s\" class=\"button\">Upload New Version</a> or <a href=\"#\" class="
+"\"close\">Ignore</a>"
 msgstr ""
-"<a href=\"#\" class=\"button compat-update\" data-"
-"updateurl=\"%(update_url)s\">Atualizar compatibilidade</a>, <a "
-"href=\"%(version_url)s\" class=\"button\">Enviar uma nova versão</a> ou <a "
-"href=\"#\" class=\"close\">Ignorar</a>"
+"<a href=\"#\" class=\"button compat-update\" data-updateurl=\"%(update_url)s\">Atualizar compatibilidade</a>, <a href=\"%(version_url)s\" class=\"button\">Enviar uma nova versão</a> ou <a href=\"#"
+"\" class=\"close\">Ignorar</a>"
 
 #: src/olympia/devhub/templates/devhub/addons/ajax_compat_status.html:5
 msgid "View and update application compatibility ranges."
 msgstr "Ver e atualizar os parâmetros de compatibilidade da aplicação."
 
-#: src/olympia/devhub/templates/devhub/addons/ajax_compat_status.html:6
-#: src/olympia/devhub/templates/devhub/versions/edit.html:44
+#: src/olympia/devhub/templates/devhub/addons/ajax_compat_status.html:6 src/olympia/devhub/templates/devhub/versions/edit.html:44
 msgid "Compatibility"
 msgstr "Compatibilidade"
 
@@ -5433,39 +4387,25 @@ msgid "Update Compatibility"
 msgstr "Atualizar compatibilidade"
 
 # %s is href=... and should stay in the <a> tag.
-#: src/olympia/devhub/templates/devhub/addons/ajax_compat_update.html:4
-msgid ""
-"Adjusting application information here will allow users to install your add-"
-"on even if the install manifest in the package indicates that the add-on is "
-"incompatible."
-msgstr ""
-"Ajustando as informações do aplicativo aqui, permitirá aos usuários "
-"instalarem o seu complemento mesmo que o manifesto de instalação do pacote "
-"indique que o complemento é incompatível."
+#: src/olympia/devhub/templates/devhub/addons/ajax_compat_update.html:4 src/olympia/devhub/templates/devhub/versions/edit.html:45
+msgid "Adjusting application information here will allow users to install your add-on even if the install manifest in the package indicates that the add-on is incompatible."
+msgstr "Ajustando as informações do aplicativo aqui, permitirá aos usuários instalarem o seu complemento mesmo que o manifesto de instalação do pacote indique que o complemento é incompatível."
 
 #: src/olympia/devhub/templates/devhub/addons/ajax_compat_update.html:18
 msgid "Supported Versions"
 msgstr "Versões suportadas"
 
-#: src/olympia/devhub/templates/devhub/addons/ajax_compat_update.html:31
-#: src/olympia/devhub/templates/devhub/versions/edit.html:63
+#: src/olympia/devhub/templates/devhub/addons/ajax_compat_update.html:31 src/olympia/devhub/templates/devhub/versions/edit.html:63
 msgid "Add Another Application&hellip;"
 msgstr "Adicionar outra aplicação&hellip;"
 
-#: src/olympia/devhub/templates/devhub/addons/ajax_compat_update.html:38
-#: src/olympia/devhub/templates/devhub/addons/owner.html:86
-#: src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:46
-#: src/olympia/devhub/templates/devhub/versions/list.html:351
-#: src/olympia/devhub/templates/devhub/versions/list.html:353
-#: src/olympia/templates/impala/base.html:132
-#: src/olympia/templates/impala/base.html:143
-#: src/olympia/templates/impala/base.html:161
-#: src/olympia/templates/impala/base.html:171
+#: src/olympia/devhub/templates/devhub/addons/ajax_compat_update.html:38 src/olympia/devhub/templates/devhub/addons/owner.html:86 src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:45
+#: src/olympia/devhub/templates/devhub/versions/list.html:349 src/olympia/devhub/templates/devhub/versions/list.html:351 src/olympia/templates/impala/base.html:129
+#: src/olympia/templates/impala/base.html:140 src/olympia/templates/impala/base.html:158 src/olympia/templates/impala/base.html:168
 msgid "Close"
 msgstr "Fechar"
 
-#: src/olympia/devhub/templates/devhub/addons/dashboard.html:43
-#: src/olympia/zadmin/templates/zadmin/index.html:22
+#: src/olympia/devhub/templates/devhub/addons/dashboard.html:43 src/olympia/zadmin/templates/zadmin/index.html:22
 #, python-format
 msgid "%(ago)s by %(user)s"
 msgstr "%(ago)s por %(user)s"
@@ -5481,29 +4421,21 @@ msgid_plural "<b>{0}</b> themes"
 msgstr[0] "<b>{0}</b> tema"
 msgstr[1] "<b>{0}</b> temas"
 
-#: src/olympia/devhub/templates/devhub/addons/edit.html:3
-#: src/olympia/devhub/templates/devhub/addons/listing/item_actions.html:25
-#: src/olympia/devhub/templates/devhub/addons/listing/item_actions_theme.html:7
-#: src/olympia/devhub/templates/devhub/includes/addons_edit_nav.html:2
-#: src/olympia/devhub/templates/devhub/personas/edit.html:6
-#: src/olympia/editors/templates/editors/themes/single.html:37
+#: src/olympia/devhub/templates/devhub/addons/edit.html:3 src/olympia/devhub/templates/devhub/addons/listing/item_actions.html:25
+#: src/olympia/devhub/templates/devhub/addons/listing/item_actions_theme.html:7 src/olympia/devhub/templates/devhub/includes/addons_edit_nav.html:2
+#: src/olympia/devhub/templates/devhub/personas/edit.html:6 src/olympia/editors/templates/editors/themes/single.html:37
 msgid "Edit Listing"
 msgstr "Editar detalhes"
 
-#: src/olympia/devhub/templates/devhub/addons/edit.html:13
-#: src/olympia/devhub/templates/devhub/includes/macros.html:18
-#: src/olympia/translations/templates/translations/all-locales.html:6
+#: src/olympia/devhub/templates/devhub/addons/edit.html:13 src/olympia/devhub/templates/devhub/includes/macros.html:18 src/olympia/translations/templates/translations/all-locales.html:6
 msgid "None"
 msgstr "Nenhum(a)"
 
-#: src/olympia/devhub/templates/devhub/addons/owner.html:4
-#: src/olympia/devhub/templates/devhub/addons/listing/item_actions.html:52
-#: src/olympia/devhub/templates/devhub/includes/addons_edit_nav.html:3
+#: src/olympia/devhub/templates/devhub/addons/owner.html:4 src/olympia/devhub/templates/devhub/addons/listing/item_actions.html:52 src/olympia/devhub/templates/devhub/includes/addons_edit_nav.html:3
 msgid "Manage Authors & License"
 msgstr "Gerenciar autores e licença"
 
-#: src/olympia/devhub/templates/devhub/addons/owner.html:29
-#: src/olympia/editors/templates/editors/review.html:270
+#: src/olympia/devhub/templates/devhub/addons/owner.html:29 src/olympia/editors/helpers.py:362 src/olympia/editors/templates/editors/review.html:270
 msgid "Authors"
 msgstr "Autores"
 
@@ -5513,35 +4445,22 @@ msgstr "Sobre as funções do autor"
 
 #: src/olympia/devhub/templates/devhub/addons/owner.html:78
 msgid ""
-"<p>Add-ons can have any number of authors with 3 possible roles:</p> <ul> "
-"<li><b>Owner:</b> Can manage all aspects of the add-on's listing, including "
-"adding and removing other authors</li> <li><b>Developer:</b> Can manage all "
-"aspects of the add-on's listing, except for adding and removing other "
-"authors and managing payments</li> <li><b>Viewer:</b> Can view the add-on's "
-"settings and statistics, but cannot make any changes</li> </ul>"
+"<p>Add-ons can have any number of authors with 3 possible roles:</p> <ul> <li><b>Owner:</b> Can manage all aspects of the add-on's listing, including adding and removing other authors</li> "
+"<li><b>Developer:</b> Can manage all aspects of the add-on's listing, except for adding and removing other authors and managing payments</li> <li><b>Viewer:</b> Can view the add-on's settings and "
+"statistics, but cannot make any changes</li> </ul>"
 msgstr ""
-"<p>Complementos podem ter qualquer número de autores com 3 possíveis "
-"funções:</p> <ul> <li><b>Dono:</b> pode gerenciar todos os detalhes do "
-"complemento, incluindo adicionar e remover outros autores</li> "
-"<li><b>Desenvolvedor:</b> pode gerenciar todos os detalhes do complemento, "
-"exceto adicionar ou remover outros autores e gerenciar pagamentos</li> "
-"<li><b>Visualizador:</b> pode ver as configurações e estatísticas do "
-"complemento, mas não pode fazer nenhuma alteração</li> </ul>"
+"<p>Complementos podem ter qualquer número de autores com 3 possíveis funções:</p> <ul> <li><b>Dono:</b> pode gerenciar todos os detalhes do complemento, incluindo adicionar e remover outros "
+"autores</li> <li><b>Desenvolvedor:</b> pode gerenciar todos os detalhes do complemento, exceto adicionar ou remover outros autores e gerenciar pagamentos</li> <li><b>Visualizador:</b> pode ver as "
+"configurações e estatísticas do complemento, mas não pode fazer nenhuma alteração</li> </ul>"
 
-#: src/olympia/devhub/templates/devhub/addons/profile.html:3
-#: src/olympia/devhub/templates/devhub/addons/listing/item_actions.html:53
-#: src/olympia/devhub/templates/devhub/includes/addons_edit_nav.html:4
+#: src/olympia/devhub/templates/devhub/addons/profile.html:3 src/olympia/devhub/templates/devhub/addons/listing/item_actions.html:53 src/olympia/devhub/templates/devhub/includes/addons_edit_nav.html:4
 msgid "Manage Developer Profile"
 msgstr "Gerenciar perfil de desenvolvedor"
 
 #: src/olympia/devhub/templates/devhub/addons/profile.html:16
 #, python-format
-msgid ""
-"Your <a href=\"%(url)s\">developer profile</a> is currently "
-"<strong>public</strong> and <strong>required</strong> for contributions."
-msgstr ""
-"Atualmente o seu <a href=\"%(url)s\">perfil de desenvolvedor</a> é "
-"<strong>público</strong> e <strong>necessário</strong> para contribuições."
+msgid "Your <a href=\"%(url)s\">developer profile</a> is currently <strong>public</strong> and <strong>required</strong> for contributions."
+msgstr "Atualmente o seu <a href=\"%(url)s\">perfil de desenvolvedor</a> é <strong>público</strong> e <strong>necessário</strong> para contribuições."
 
 #: src/olympia/devhub/templates/devhub/addons/profile.html:22
 msgid "Remove Both"
@@ -5550,12 +4469,8 @@ msgstr "Remover ambos"
 # %1 is a URL.
 #: src/olympia/devhub/templates/devhub/addons/profile.html:27
 #, python-format
-msgid ""
-"Your <a href=\"%(url)s\">developer profile</a> is currently "
-"<strong>public</strong>."
-msgstr ""
-"Atualmente o seu <a href=\"%(url)s\">perfil de desenvolvedor</a> é "
-"<strong>público</strong>."
+msgid "Your <a href=\"%(url)s\">developer profile</a> is currently <strong>public</strong>."
+msgstr "Atualmente o seu <a href=\"%(url)s\">perfil de desenvolvedor</a> é <strong>público</strong>."
 
 #: src/olympia/devhub/templates/devhub/addons/profile.html:33
 msgid "Remove Profile"
@@ -5582,11 +4497,8 @@ msgstr "URL do complemento"
 msgid "Choose a short, unique URL slug for your add-on."
 msgstr "Escolha uma URL curta e exclusiva para o seu complemento."
 
-#: src/olympia/devhub/templates/devhub/addons/edit/basic.html:43
-#: src/olympia/devhub/templates/devhub/includes/addons_edit_nav.html:35
-#: src/olympia/devhub/templates/devhub/personas/edit.html:56
-#: src/olympia/editors/templates/editors/review.html:255
-#: src/olympia/editors/templates/editors/themes/single.html:33
+#: src/olympia/devhub/templates/devhub/addons/edit/basic.html:43 src/olympia/devhub/templates/devhub/includes/addons_edit_nav.html:35 src/olympia/devhub/templates/devhub/personas/edit.html:56
+#: src/olympia/editors/templates/editors/review.html:255 src/olympia/editors/templates/editors/themes/single.html:33
 msgid "View Listing"
 msgstr "Ver página do complemento"
 
@@ -5596,10 +4508,7 @@ msgstr "Resumo"
 
 #: src/olympia/devhub/templates/devhub/addons/edit/basic.html:52
 msgid ""
-"A short explanation of your add-on's basic\n"
-"                          functionality that is displayed in search and browse\n"
-"                          listings, as well as at the top of your add-on's\n"
-"                          details page. It is only relevant for listed add-ons."
+"A short explanation of your add-on's basic functionality that is displayed in search and browse listings, as well as at the top of your add-on's details page. It is only relevant for listed add-ons."
 msgstr ""
 "Uma curta explicação do funcionamento básico\n"
 "                          do seu complemento que será exibida na busca e nas\n"
@@ -5607,10 +4516,7 @@ msgstr ""
 "                          do complemento. É relevante apenas para complementos listados."
 
 #: src/olympia/devhub/templates/devhub/addons/edit/basic.html:73
-msgid ""
-"Categories are the primary way users browse through add-ons.\n"
-"                        Choose any that fit your add-on's functionality for the most\n"
-"                        exposure. It is only relevant for listed add-ons."
+msgid "Categories are the primary way users browse through add-ons. Choose any that fit your add-on's functionality for the most exposure. It is only relevant for listed add-ons."
 msgstr ""
 "Categorias são a principal forma de navegação através dos complementos.\n"
 "                        Selecione qualquer uma que se encaixe nas funcionalidades do seu complemento\n"
@@ -5619,38 +4525,26 @@ msgstr ""
 #: src/olympia/devhub/templates/devhub/addons/edit/basic.html:90
 #, python-format
 msgid ""
-"Categories cannot be changed while your add-on is featured for this "
-"application. Please email <a href=\"mailto:%(email)s\">%(email)s</a> if "
-"there is a reason you need to modify your categories."
+"Categories cannot be changed while your add-on is featured for this application. Please email <a href=\"mailto:%(email)s\">%(email)s</a> if there is a reason you need to modify your categories."
 msgstr ""
-"Categorias não podem ser alteradas enquanto o seu complemento estiver em "
-"destaque para essa aplicação. Por favor, entre em contato pelo endereço <a "
-"href=\"mailto:%(email)s\">%(email)s</a> se houver alguma razão para alterar "
-"suas categorias."
+"Categorias não podem ser alteradas enquanto o seu complemento estiver em destaque para essa aplicação. Por favor, entre em contato pelo endereço <a href=\"mailto:%(email)s\">%(email)s</a> se houver "
+"alguma razão para alterar suas categorias."
 
 #: src/olympia/devhub/templates/devhub/addons/edit/basic.html:119
-msgid ""
-"Tags help users find your add-on and should be short\n"
-"                        descriptors such as tabs, toolbar, or twitter.  You\n"
-"                        may have a maximum of {0} tags. It is only relevant\n"
-"                        for listed add-ons."
+msgid "Tags help users find your add-on and should be short descriptors such as tabs, toolbar, or twitter. You may have a maximum of {0} tags. It is only relevant for listed add-ons."
 msgstr ""
 "Etiquetas ajudam usuários a encontrar seu complemento e devem ser \n"
 "                        descrições curtas como abas, barra de ferramentas ou Twitter.  Você\n"
 "                        pode ter um máximo de {0} etiquetas. É relevante apenas \n"
 "                        para complementos listados."
 
-#: src/olympia/devhub/templates/devhub/addons/edit/basic.html:129
-#: src/olympia/devhub/templates/devhub/personas/edit.html:97
-#: src/olympia/devhub/templates/devhub/personas/submit.html:46
+#: src/olympia/devhub/templates/devhub/addons/edit/basic.html:129 src/olympia/devhub/templates/devhub/personas/edit.html:97 src/olympia/devhub/templates/devhub/personas/submit.html:46
 msgid "Comma-separated, minimum of {0} character."
 msgid_plural "Comma-separated, minimum of {0} characters."
 msgstr[0] "Separadas por vírgula, mínimo de {0} caractere."
 msgstr[1] "Separadas por vírgula, mínimo de {0} caracteres."
 
-#: src/olympia/devhub/templates/devhub/addons/edit/basic.html:132
-#: src/olympia/devhub/templates/devhub/personas/edit.html:100
-#: src/olympia/devhub/templates/devhub/personas/submit.html:49
+#: src/olympia/devhub/templates/devhub/addons/edit/basic.html:132 src/olympia/devhub/templates/devhub/personas/edit.html:100 src/olympia/devhub/templates/devhub/personas/submit.html:49
 msgid "Example: dark, cinema, noir. Limit 20."
 msgstr "Exemplo: escuro, cinema, noir. Limite: 20."
 
@@ -5669,46 +4563,33 @@ msgid "Add-on Details for {0}"
 msgstr "Detalhes de {0}"
 
 #: src/olympia/devhub/templates/devhub/addons/edit/details.html:22
-msgid ""
-"A longer explanation of features,\n"
-"                          functionality, and other relevant information. This\n"
-"                          field is only displayed on the add-on's details\n"
-"                          page. It is only relevant for listed add-ons."
+msgid "A longer explanation of features, functionality, and other relevant information. This field is only displayed on the add-on's details page. It is only relevant for listed add-ons."
 msgstr ""
 "Uma explicação mais longa das características,\n"
 "                          funcionalidades e outras informações relevantes. Este\n"
 "                          campo é exibido apenas na página de detalhes do\n"
 "                          complemento. É relevante apenas para complementos listados."
 
-#: src/olympia/devhub/templates/devhub/addons/edit/details.html:44
-#: src/olympia/translations/templates/translations/trans-menu.html:13
+#: src/olympia/devhub/templates/devhub/addons/edit/details.html:44 src/olympia/translations/templates/translations/trans-menu.html:13
 msgid "Default Locale"
 msgstr "Idioma padrão"
 
 #: src/olympia/devhub/templates/devhub/addons/edit/details.html:45
-msgid ""
-"Information about your add-on is displayed in this locale\n"
-"                        unless you override it with a locale-specific translation.\n"
-"                        It is only relevant for listed add-ons."
+msgid "Information about your add-on is displayed in this locale unless you override it with a locale-specific translation. It is only relevant for listed add-ons."
 msgstr ""
 "As informações sobre o seu complemento serão exibidas neste idioma,\n"
 "                        a não ser que você substitua-o com uma tradução específica.\n"
 "                        Isto só é válido para complementos listados."
 
-#: src/olympia/devhub/templates/devhub/addons/edit/details.html:61
-#: src/olympia/users/forms.py:311
-#: src/olympia/users/templates/users/edit.html:122
-#: src/olympia/users/templates/users/register.html:57
+#: src/olympia/devhub/templates/devhub/addons/edit/details.html:61 src/olympia/users/forms.py:311 src/olympia/users/templates/users/edit.html:122 src/olympia/users/templates/users/register.html:57
 #: src/olympia/users/templates/users/vcard.html:22
 msgid "Homepage"
 msgstr "Página inicial"
 
 #: src/olympia/devhub/templates/devhub/addons/edit/details.html:63
 msgid ""
-"If your add-on has another homepage, enter its\n"
-"                          address here. If your website is localized into other\n"
-"                          languages multiple translations of this field can be\n"
-"                          added. It is only relevant for listed add-ons."
+"If your add-on has another homepage, enter its address here. If your website is localized into other languages multiple translations of this field can be added. It is only relevant for listed add-"
+"ons."
 msgstr ""
 "Se o seu complemento tem uma outra página inicial, digite o\n"
 "                          endereço aqui. Se o seu site está localizado em outro\n"
@@ -5730,11 +4611,8 @@ msgstr "Informações de suporte para {0}"
 
 #: src/olympia/devhub/templates/devhub/addons/edit/support.html:22
 msgid ""
-"If you wish to display an e-mail address for support\n"
-"                          inquiries, enter it here. If you have different\n"
-"                          addresses for each language multiple translations of\n"
-"                          this field can be added. It is only relevant for\n"
-"                          listed add-ons."
+"If you wish to display an e-mail address for support inquiries, enter it here. If you have different addresses for each language multiple translations of this field can be added. It is only "
+"relevant for listed add-ons."
 msgstr ""
 "Se você desejar exibir um endereço de e-mail para suporte\n"
 "                          digite-o aqui. Se você tiver endereços de e-mail\n"
@@ -5744,10 +4622,8 @@ msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/support.html:45
 msgid ""
-"If your add-on has a support website or forum, enter\n"
-"                          its address here. If your website is localized into\n"
-"                          other languages, multiple translations of this field can\n"
-"                          be added. It is only relevant for listed add-ons."
+"If your add-on has a support website or forum, enter its address here. If your website is localized into other languages, multiple translations of this field can be added. It is only relevant for "
+"listed add-ons."
 msgstr ""
 "Se o seu complemento tem um site de suporte ou fórum, insira\n"
 "                          o endereço aqui. Se o seu site está localizado em\n"
@@ -5765,11 +4641,8 @@ msgstr "Detalhes técnicos de {0}"
 
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:23
 msgid ""
-"Any information end users may want to know that isn't\n"
-"                          necessarily applicable to the add-on summary or description.\n"
-"                          Common uses include listing known major bugs, information on\n"
-"                          how to report bugs, anticipated release date of a new version,\n"
-"                          etc. It is only relevant for listed add-ons."
+"Any information end users may want to know that isn't necessarily applicable to the add-on summary or description. Common uses include listing known major bugs, information on how to report bugs, "
+"anticipated release date of a new version, etc. It is only relevant for listed add-ons."
 msgstr ""
 "Qualquer informação que os usuários finais queiram saber que não sejam\n"
 "                          necessariamente aplicáveis ao resumo ou a descrição de add-ons.\n"
@@ -5786,9 +4659,7 @@ msgid "Add-on Flags"
 msgstr "Propriedades"
 
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:69
-msgid ""
-"These flags are used to classify add-ons. It is only\n"
-"                        relevant for listed add-ons."
+msgid "These flags are used to classify add-ons. It is only relevant for listed add-ons."
 msgstr ""
 "Estas etiquetas são usadas para classificar os complementos. Isto só é\n"
 "                        válido para complementos listados."
@@ -5806,9 +4677,7 @@ msgid "View Source?"
 msgstr "Exibir código-fonte?"
 
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:90
-msgid ""
-"Whether the source of your add-on can be displayed in our\n"
-"                        online viewer. It is only relevant for listed add-ons."
+msgid "Whether the source of your add-on can be displayed in our online viewer. It is only relevant for listed add-ons."
 msgstr ""
 "Se a fonte de seu add-on pode ser exibido em nosso\n"
 "                         visualizador online. Ele só é relevante para add-ons listados."
@@ -5826,10 +4695,7 @@ msgid "Public Stats?"
 msgstr "Publicar estatísticas?"
 
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:102
-msgid ""
-"Whether the download and usage stats of your add-on can\n"
-"                        be displayed in our online viewer.\n"
-"                        It is only relevant for listed add-ons."
+msgid "Whether the download and usage stats of your add-on can be displayed in our online viewer. It is only relevant for listed add-ons."
 msgstr ""
 "Se o download e as estatísticas de uso do seu add-on podem\n"
 "                        ser mostradas no nosso visualizador online.\n"
@@ -5848,22 +4714,15 @@ msgid "Upgrade SDK?"
 msgstr "Atualizar SDK?"
 
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:116
-msgid ""
-"If selected, we will try to automatically upgrade your\n"
-"                        add-on when a new version of the SDK is released.\n"
-"                        It is only relevant for listed add-ons."
+msgid "If selected, we will try to automatically upgrade your add-on when a new version of the SDK is released. It is only relevant for listed add-ons."
 msgstr ""
 "Se selecionado, iremos tentar atualizar automaticamente o seu\n"
 "                        complemento quando uma nova versão do SDK for lançada.\n"
 "                        Isto só é válido para complementos listados."
 
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:121
-msgid ""
-"This add-on will be automatically upgraded to new versions of the Add-on "
-"SDK."
-msgstr ""
-"Esse complemento será atualizado automaticamente para as novas versões do "
-"SDK."
+msgid "This add-on will be automatically upgraded to new versions of the Add-on SDK."
+msgstr "Esse complemento será atualizado automaticamente para as novas versões do SDK."
 
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:123
 msgid "No, this add-on will be upgraded manually."
@@ -5878,30 +4737,20 @@ msgid "UUID"
 msgstr "UUID"
 
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:132
-msgid ""
-"The UUID of your add-on is specified in its install manifest and uniquely "
-"identifies it. You cannot change your UUID once it has been submitted."
-msgstr ""
-"O UUID do seu complemento é especificado em seu manifesto de instalação e o "
-"identifica unicamente. Você não pode mudar seu UUID uma vez que foi "
-"submetido."
+msgid "The UUID of your add-on is specified in its install manifest and uniquely identifies it. You cannot change your UUID once it has been submitted."
+msgstr "O UUID do seu complemento é especificado em seu manifesto de instalação e o identifica unicamente. Você não pode mudar seu UUID uma vez que foi submetido."
 
-#: src/olympia/devhub/templates/devhub/addons/edit/technical.html:143
-#: src/olympia/devhub/templates/devhub/addons/edit/technical.html:144
+#: src/olympia/devhub/templates/devhub/addons/edit/technical.html:143 src/olympia/devhub/templates/devhub/addons/edit/technical.html:144
 msgid "Whiteboard"
 msgstr "Quadro branco"
 
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:146
 msgid ""
-"The whiteboard is the place to provide information relevant to your addon, "
-"whatever the version, to the editor. Use it to provide ways to test the "
-"addon, and any additional information that may help. This whiteboard is also"
-" editable by editors."
+"The whiteboard is the place to provide information relevant to your addon, whatever the version, to the editor. Use it to provide ways to test the addon, and any additional information that may "
+"help. This whiteboard is also editable by editors."
 msgstr ""
-"O quadro branco é um site para fornecer informação relevante para o seu "
-"complemento, qualquer que seja a versão, para o editor. Utilize-o para "
-"fornecer formas de testar o complemento e qualquer informação adicional que "
-"possa ajudar. O quadro branco é também editável pelos editores."
+"O quadro branco é um site para fornecer informação relevante para o seu complemento, qualquer que seja a versão, para o editor. Utilize-o para fornecer formas de testar o complemento e qualquer "
+"informação adicional que possa ajudar. O quadro branco é também editável pelos editores."
 
 #: src/olympia/devhub/templates/devhub/addons/edit/technical_dependencies.html:9
 msgid "Remove this dependent add-on"
@@ -5921,10 +4770,8 @@ msgstr "Ícone do complemento"
 
 #: src/olympia/devhub/templates/devhub/addons/forms_shared/media.html:16
 msgid ""
-"Upload an icon for your add-on or choose from one of ours. The\n"
-"                      icon is displayed nearly everywhere your add-on is. Uploaded images\n"
-"                      must be one of the following image types: .png, .jpg.\n"
-"                      It is only relevant for listed add-ons."
+"Upload an icon for your add-on or choose from one of ours. The icon is displayed nearly everywhere your add-on is. Uploaded images must be one of the following image types: .png, .jpg. It is only "
+"relevant for listed add-ons."
 msgstr ""
 "Carregue um ícone para o seu add-on ou  escolha um dos nossos. O\n"
 "                      ícone é exibido em quase toda parte em que está o seu add-on. As imagens carregadas\n"
@@ -5942,9 +4789,7 @@ msgid "32x32px"
 msgstr "32x32"
 
 #: src/olympia/devhub/templates/devhub/addons/forms_shared/media.html:39
-msgid ""
-"Used in listings of add-ons, like search results\n"
-"                            and featured add-ons."
+msgid "Used in listings of add-ons, like search results and featured add-ons."
 msgstr ""
 "Usado em listas de complementos, como resultados de busca\n"
 "                            e complementos em destaque."
@@ -5964,9 +4809,7 @@ msgstr "Enviar ícone..."
 
 #: src/olympia/devhub/templates/devhub/addons/forms_shared/media.html:65
 msgid "PNG and JPG supported. Icons resized to 64x64 pixels if larger."
-msgstr ""
-"PNG e JPG suportados. Os ícones serão redimensionados para 64x64 píxeis caso"
-" sejam maiores."
+msgstr "PNG e JPG suportados. Os ícones serão redimensionados para 64x64 píxeis caso sejam maiores."
 
 #: src/olympia/devhub/templates/devhub/addons/forms_shared/media.html:83
 msgid "Screenshots"
@@ -5989,62 +4832,51 @@ msgid "Tests"
 msgstr "Testes"
 
 # This is the name/category for a group of tests
-#: src/olympia/devhub/templates/devhub/addons/includes/validation_compat_test_results.html:25
-#: src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:5
+#: src/olympia/devhub/templates/devhub/addons/includes/validation_compat_test_results.html:25 src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:5
 #: src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:53
 msgid "General Tests"
 msgstr "Testes gerais"
 
 # This is the name/category for a group of tests
-#: src/olympia/devhub/templates/devhub/addons/includes/validation_compat_test_results.html:32
-#: src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:9
+#: src/olympia/devhub/templates/devhub/addons/includes/validation_compat_test_results.html:32 src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:9
 #: src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:67
 msgid "Security Tests"
 msgstr "Testes de segurança"
 
 # Plural in this context means many of the add-on type
-#: src/olympia/devhub/templates/devhub/addons/includes/validation_compat_test_results.html:39
-#: src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:13
+#: src/olympia/devhub/templates/devhub/addons/includes/validation_compat_test_results.html:39 src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:13
 #: src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:80
 msgid "Extension Tests"
 msgstr "Testes de extensões"
 
-#: src/olympia/devhub/templates/devhub/addons/includes/validation_compat_test_results.html:46
-#: src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:17
+#: src/olympia/devhub/templates/devhub/addons/includes/validation_compat_test_results.html:46 src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:17
 #: src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:93
 msgid "Localization Tests"
 msgstr "Testes de idiomas"
 
-#: src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:21
-#: src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:106
+#: src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:21 src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:106
 msgid "Compatibility Tests"
 msgstr "Testes de compatibilidade"
 
-#: src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:29
-#: src/olympia/files/templates/files/viewer.html:142
+#: src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:29 src/olympia/files/templates/files/viewer.html:142
 msgid "Hide messages not required for automated signing"
 msgstr "Não é necessário ocultar mensagens para a assinatura automática"
 
-#: src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:35
-#: src/olympia/files/templates/files/viewer.html:150
+#: src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:35 src/olympia/files/templates/files/viewer.html:150
 msgid "Hide messages present in previous version and ignored"
 msgstr "Ocultar mensagens presentes na versão anterior e ignoradas"
 
-#: src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:50
-#: src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:64
-#: src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:77
-#: src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:90
+#: src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:50 src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:64
+#: src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:77 src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:90
 #: src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:103
 msgid "Top"
 msgstr "Topo"
 
-#: src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:2
-#: src/olympia/devhub/templates/devhub/personas/edit.html:63
+#: src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:2 src/olympia/devhub/templates/devhub/personas/edit.html:63
 msgid "Delete Theme"
 msgstr "Excluir tema"
 
-#: src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:2
-#: src/olympia/devhub/templates/devhub/versions/list.html:117
+#: src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:2 src/olympia/devhub/templates/devhub/versions/list.html:117
 msgid "Delete Add-on"
 msgstr "Excluir complemento"
 
@@ -6053,31 +4885,24 @@ msgid "Deleting your theme will permanently remove it from the site."
 msgstr "Excluir seu tema irá removê-lo permanentemente do site."
 
 #: src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:14
-msgid ""
-"Deleting your add-on will permanently remove it from the site and prevent "
-"its GUID from being submitted again by others."
-msgstr ""
-"Excluir seu complemento irá removê-lo permanentemente do site e impedir que "
-"o GUID seja enviado novamente por outros."
+msgid "Deleting your add-on will permanently remove it from the site and prevent its GUID from being submitted again by others."
+msgstr "Excluir seu complemento irá removê-lo permanentemente do site e impedir que o GUID seja enviado novamente por outros."
 
 #: src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:24
-msgid ""
-"Enter the following text confirm your decision:\n"
-"           {slug}"
+msgid "Enter the following text confirm your decision: {slug}"
 msgstr ""
 "Digite o seguinte texto para confirmar sua decisão:\n"
 "           {slug}"
 
-#: src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:34
+#: src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:33
 msgid "Please tell us why you are deleting your theme:"
 msgstr "Por favor, nos diga porquê está excluindo o seu tema:"
 
-#: src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:36
+#: src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:35
 msgid "Please tell us why you are deleting your add-on:"
 msgstr "Por favor, nos diga porquê está excluindo o seu complemento:"
 
-#: src/olympia/devhub/templates/devhub/addons/listing/item_actions.html:1
-#: src/olympia/devhub/templates/devhub/addons/listing/item_actions_theme.html:1
+#: src/olympia/devhub/templates/devhub/addons/listing/item_actions.html:1 src/olympia/devhub/templates/devhub/addons/listing/item_actions_theme.html:1
 #: src/olympia/editors/templates/editors/review.html:253
 msgid "Actions"
 msgstr "Ações"
@@ -6111,23 +4936,18 @@ msgstr "Nova versão"
 msgid "Daily statistics on downloads and users."
 msgstr "Estatísticas diárias de downloads e usuários."
 
-#: src/olympia/devhub/templates/devhub/addons/listing/item_actions.html:45
-#: src/olympia/stats/templates/stats/stats.html:75
-#: src/olympia/stats/templates/stats/stats.html:79
-#: src/olympia/stats/templates/stats/stats.html:81
+#: src/olympia/devhub/templates/devhub/addons/listing/item_actions.html:45 src/olympia/stats/templates/stats/stats.html:31 src/olympia/stats/templates/stats/stats.html:35
+#: src/olympia/stats/templates/stats/stats.html:37
 msgid "Statistics"
 msgstr "Estatísticas"
 
-#: src/olympia/devhub/templates/devhub/addons/listing/item_actions.html:54
-#: src/olympia/devhub/templates/devhub/includes/addons_edit_nav.html:5
-#: src/olympia/devhub/templates/devhub/payments/payments.html:3
-#: src/olympia/devhub/templates/devhub/payments/tier.html:4
+#: src/olympia/devhub/templates/devhub/addons/listing/item_actions.html:54 src/olympia/devhub/templates/devhub/includes/addons_edit_nav.html:5
+#: src/olympia/devhub/templates/devhub/payments/payments.html:3 src/olympia/devhub/templates/devhub/payments/tier.html:4
 msgid "Manage Payments"
 msgstr "Gerenciar pagamentos"
 
 # %s is the version number.
-#: src/olympia/devhub/templates/devhub/addons/listing/item_actions.html:55
-#: src/olympia/devhub/templates/devhub/includes/addons_edit_nav.html:6
+#: src/olympia/devhub/templates/devhub/addons/listing/item_actions.html:55 src/olympia/devhub/templates/devhub/includes/addons_edit_nav.html:6
 msgid "Manage Status & Versions"
 msgstr "Gerenciar status e versões"
 
@@ -6135,10 +4955,8 @@ msgstr "Gerenciar status e versões"
 msgid "View Add-on Listing"
 msgstr "Ver página do complemento"
 
-#: src/olympia/devhub/templates/devhub/addons/listing/item_actions.html:64
-#: src/olympia/devhub/templates/devhub/addons/listing/item_actions_theme.html:12
-#: src/olympia/devhub/templates/devhub/includes/addons_edit_nav.html:37
-#: src/olympia/devhub/templates/devhub/personas/edit.html:58
+#: src/olympia/devhub/templates/devhub/addons/listing/item_actions.html:64 src/olympia/devhub/templates/devhub/addons/listing/item_actions_theme.html:12
+#: src/olympia/devhub/templates/devhub/includes/addons_edit_nav.html:37 src/olympia/devhub/templates/devhub/personas/edit.html:58
 msgid "View Recent Changes"
 msgstr "Ver alterações recentes"
 
@@ -6163,12 +4981,8 @@ msgid "Delete this theme."
 msgstr "Excluir este tema."
 
 #: src/olympia/devhub/templates/devhub/addons/listing/items.html:10
-msgid ""
-"This add-on will be deleted automatically after a few days if the submission"
-" process is not completed."
-msgstr ""
-"Este complemento será excluído automaticamente após alguns dias caso o "
-"processo de submissão não seja completado."
+msgid "This add-on will be deleted automatically after a few days if the submission process is not completed."
+msgstr "Este complemento será excluído automaticamente após alguns dias caso o processo de submissão não seja completado."
 
 #: src/olympia/devhub/templates/devhub/addons/listing/items.html:27
 msgid "Disabled"
@@ -6179,8 +4993,8 @@ msgstr "Desabilitado"
 msgid "<b>Queue position:</b> %(pos)s of %(total)s"
 msgstr "<b>Posição na fila:</b> %(pos)s de %(total)s"
 
-#. {0} is the number of active users.
 # %1$s is the count of subscribers for a collection
+#. {0} is the number of active users.
 #: src/olympia/devhub/templates/devhub/addons/listing/macros.html:23
 msgid "<strong>{0}</strong> active user"
 msgid_plural "<strong>{0}</strong> active users"
@@ -6207,13 +5021,9 @@ msgstr "Nome e versão:"
 msgid "The detail page will be:"
 msgstr "A página de detalhes será:"
 
-#: src/olympia/devhub/templates/devhub/addons/submit/describe.html:24
-#: src/olympia/devhub/templates/devhub/personas/edit.html:89
-#: src/olympia/devhub/templates/devhub/personas/submit.html:38
+#: src/olympia/devhub/templates/devhub/addons/submit/describe.html:24 src/olympia/devhub/templates/devhub/personas/edit.html:89 src/olympia/devhub/templates/devhub/personas/submit.html:38
 msgid "Please use only letters, numbers, underscores, and dashes in your URL."
-msgstr ""
-"Por favor, use apenas letras, números, traços inferiores e barras na sua "
-"URL."
+msgstr "Por favor, use apenas letras, números, traços inferiores e barras na sua URL."
 
 #: src/olympia/devhub/templates/devhub/addons/submit/describe.html:34
 msgid "Provide a brief summary:"
@@ -6231,14 +5041,11 @@ msgstr "Forneça uma descrição mais detalhada:"
 msgid "The description will appear on the detail page."
 msgstr "A descrição aparecerá na página de detalhes."
 
-#: src/olympia/devhub/templates/devhub/addons/submit/done.html:4
-#: src/olympia/devhub/templates/devhub/personas/submit_done.html:4
+#: src/olympia/devhub/templates/devhub/addons/submit/done.html:4 src/olympia/devhub/templates/devhub/personas/submit_done.html:4
 msgid "Submission Complete"
 msgstr "Submissão concluída"
 
-#: src/olympia/devhub/templates/devhub/addons/submit/done.html:8
-#: src/olympia/devhub/templates/devhub/addons/submit/sidebar.html:13
-#: src/olympia/devhub/templates/devhub/personas/submit_done.html:8
+#: src/olympia/devhub/templates/devhub/addons/submit/done.html:8 src/olympia/devhub/templates/devhub/addons/submit/sidebar.html:13 src/olympia/devhub/templates/devhub/personas/submit_done.html:8
 msgid "You're done!"
 msgstr "Você terminou!"
 
@@ -6251,50 +5058,33 @@ msgid "Your add-on has been submitted to the Full Review queue."
 msgstr "Seu complemento foi submetido para uma análise completa."
 
 #: src/olympia/devhub/templates/devhub/addons/submit/done.html:18
-msgid ""
-"You'll receive an email once it has been reviewed by an editor. In\n"
-"          the meantime, you and your friends can install it directly from its\n"
-"          details page:"
+msgid "You'll receive an email once it has been reviewed by an editor. In the meantime, you and your friends can install it directly from its details page:"
 msgstr ""
 "Vocẽ receberá um e-mail quando um editor revisá-lo. \n"
 "          Enquanto isso, você e seus amigos podem instalá-lo diretamente\n"
 "          da sua página de detalhes:"
 
-#: src/olympia/devhub/templates/devhub/addons/submit/done.html:27
-#: src/olympia/devhub/templates/devhub/addons/submit/done.html:77
-#: src/olympia/devhub/templates/devhub/personas/submit_done.html:16
+#: src/olympia/devhub/templates/devhub/addons/submit/done.html:27 src/olympia/devhub/templates/devhub/addons/submit/done.html:77 src/olympia/devhub/templates/devhub/personas/submit_done.html:16
 msgid "Next steps:"
 msgstr "Próximos passos:"
 
-#: src/olympia/devhub/templates/devhub/addons/submit/done.html:32
-#: src/olympia/devhub/templates/devhub/addons/submit/done.html:82
+#: src/olympia/devhub/templates/devhub/addons/submit/done.html:32 src/olympia/devhub/templates/devhub/addons/submit/done.html:82
 msgid "<a href=\"{0}\">Upload</a> another platform-specific file to this version."
-msgstr ""
-"<a href=\"{0}\">Enviar</a> outro arquivo específico de uma plataforma para "
-"essa versão."
+msgstr "<a href=\"{0}\">Enviar</a> outro arquivo específico de uma plataforma para essa versão."
 
 #: src/olympia/devhub/templates/devhub/addons/submit/done.html:34
 msgid "Provide more details by <a href=\"{0}\">editing its listing</a>."
 msgstr "Forneça mais informações <a href=\"{0}\">editando seus detalhes</a>."
 
 #: src/olympia/devhub/templates/devhub/addons/submit/done.html:35
-msgid ""
-"Tell your users why you created this in your <a href=\"{0}\">Developer "
-"Profile</a>."
-msgstr ""
-"Conte aos seus usuários por que você o criou no seu <a href=\"{0}\">Perfil "
-"de desenvolvedor</a>."
+msgid "Tell your users why you created this in your <a href=\"{0}\">Developer Profile</a>."
+msgstr "Conte aos seus usuários por que você o criou no seu <a href=\"{0}\">Perfil de desenvolvedor</a>."
 
 #: src/olympia/devhub/templates/devhub/addons/submit/done.html:36
-msgid ""
-"View and subscribe to your add-on's <a href=\"{0}\">activity feed</a> to "
-"stay updated on reviews, collections, and more."
-msgstr ""
-"Veja e assine a <a href=\"{0}\">atividade do seu complemento</a> para ficar "
-"atualizado sobre análises, coleções e mais."
+msgid "View and subscribe to your add-on's <a href=\"{0}\">activity feed</a> to stay updated on reviews, collections, and more."
+msgstr "Veja e assine a <a href=\"{0}\">atividade do seu complemento</a> para ficar atualizado sobre análises, coleções e mais."
 
-#: src/olympia/devhub/templates/devhub/addons/submit/done.html:37
-#: src/olympia/devhub/templates/devhub/addons/submit/done.html:86
+#: src/olympia/devhub/templates/devhub/addons/submit/done.html:37 src/olympia/devhub/templates/devhub/addons/submit/done.html:86
 msgid "View approximate review queue <a href=\"{0}\">wait times</a>."
 msgstr "Ver o <a href=\"{0}\">tempo de espera</a> aproximado da análise."
 
@@ -6304,45 +5094,31 @@ msgstr "Passe na frente na fila de análise!"
 
 #: src/olympia/devhub/templates/devhub/addons/submit/done.html:45
 msgid "Become an AMO Reviewer today and get your add-ons reviewed faster."
-msgstr ""
-"Torne-se um revisor do AMO agora mesmo e acelere o processo de análise dos "
-"seus complementos."
+msgstr "Torne-se um revisor do AMO agora mesmo e acelere o processo de análise dos seus complementos."
 
 #: src/olympia/devhub/templates/devhub/addons/submit/done.html:54
-msgid ""
-"Your add-on has been signed and it's ready to use. You can download it here:"
-msgstr ""
-"O seu complemento foi assinado e está pronto a ser usado. Pode ser baixado "
-"aqui:"
+msgid "Your add-on has been signed and it's ready to use. You can download it here:"
+msgstr "O seu complemento foi assinado e está pronto a ser usado. Pode ser baixado aqui:"
 
 #: src/olympia/devhub/templates/devhub/addons/submit/done.html:64
-msgid ""
-"Your add-on has been submitted to the Unlisted Preliminary Review queue."
-msgstr ""
-"Seu complemento foi submetido para a fila de revisão preliminar não listada."
+msgid "Your add-on has been submitted to the Unlisted Preliminary Review queue."
+msgstr "Seu complemento foi submetido para a fila de revisão preliminar não listada."
 
 #: src/olympia/devhub/templates/devhub/addons/submit/done.html:66
 msgid "Your add-on has been submitted to the Unlisted Full Review queue."
-msgstr ""
-"Seu complemento foi submetido para a fila de revisão completa não listada."
+msgstr "Seu complemento foi submetido para a fila de revisão completa não listada."
 
 #: src/olympia/devhub/templates/devhub/addons/submit/done.html:70
-msgid ""
-"You'll receive an email once it has been reviewed by an editor and signed."
-msgstr ""
-"Você receberá um e-mail assim que for revisado por um editor e assinado."
+msgid "You'll receive an email once it has been reviewed by an editor and signed."
+msgstr "Você receberá um e-mail assim que for revisado por um editor e assinado."
 
 #: src/olympia/devhub/templates/devhub/addons/submit/done.html:74
 msgid "Your add-on will not be publicly available on this website."
 msgstr "O seu complemento não estará disponível publicamente neste site."
 
 #: src/olympia/devhub/templates/devhub/addons/submit/done.html:84
-msgid ""
-"You can upload new versions of your add-on in the <a href=\"{0}\">add-on's "
-"developer page</a>."
-msgstr ""
-"Você pode enviar novas versões do seu complemento na <a href=\"{0}\">página "
-"do desenvolvedor do complemento</a>."
+msgid "You can upload new versions of your add-on in the <a href=\"{0}\">add-on's developer page</a>."
+msgstr "Você pode enviar novas versões do seu complemento na <a href=\"{0}\">página do desenvolvedor do complemento</a>."
 
 #: src/olympia/devhub/templates/devhub/addons/submit/license.html:4
 msgid "Step 5"
@@ -6353,14 +5129,9 @@ msgid "Step 5. Select a License"
 msgstr "5º passo. Selecione uma Licença"
 
 #: src/olympia/devhub/templates/devhub/addons/submit/license.html:9
-msgid ""
-"We require all add-ons to indicate the terms under which their source code "
-"is licensed. Please select a license from the list below or enter a custom "
-"license."
+msgid "We require all add-ons to indicate the terms under which their source code is licensed. Please select a license from the list below or enter a custom license."
 msgstr ""
-"Nós solicitamos que todos os complementos indiquem os termos sob os quais "
-"seu código-fonte está licenciado. Por favor, selecione uma licença da lista "
-"abaixo ou insira uma licença personalizada."
+"Nós solicitamos que todos os complementos indiquem os termos sob os quais seu código-fonte está licenciado. Por favor, selecione uma licença da lista abaixo ou insira uma licença personalizada."
 
 # %s is the application name (Firefox, Thunderbird).
 #: src/olympia/devhub/templates/devhub/addons/submit/license.html:18
@@ -6377,14 +5148,11 @@ msgstr "4º passo. Adicione imagens"
 
 #: src/olympia/devhub/templates/devhub/addons/submit/media.html:9
 msgid ""
-"Custom icons and screenshots draw attention and help users understand what "
-"it does. We strongly recommend uploading a custom icon, as in some areas of "
-"the website, only the icon and name will appear."
+"Custom icons and screenshots draw attention and help users understand what it does. We strongly recommend uploading a custom icon, as in some areas of the website, only the icon and name will "
+"appear."
 msgstr ""
-"Ícones e capturas de tela personalizadas chamam a atenção e ajudam usuários "
-"a entender o que seu complemento faz. Nós recomendamos fortemente que você "
-"adicione um ícone personalizado, já que em algumas áreas do site somente o "
-"ícone e o nome aparecerão."
+"Ícones e capturas de tela personalizadas chamam a atenção e ajudam usuários a entender o que seu complemento faz. Nós recomendamos fortemente que você adicione um ícone personalizado, já que em "
+"algumas áreas do site somente o ícone e o nome aparecerão."
 
 #: src/olympia/devhub/templates/devhub/addons/submit/select-review.html:5
 msgid "Step 6"
@@ -6396,25 +5164,16 @@ msgstr "6º passo. Selecione um processo de análise"
 
 #: src/olympia/devhub/templates/devhub/addons/submit/select-review.html:10
 msgid ""
-"All add-ons hosted in our gallery must be reviewed by an editor before they "
-"appear in categories or search results. While waiting for review, your add-"
-"on can still be accessed through its direct URL. Please choose the review "
-"process below that best fits your add-on."
+"All add-ons hosted in our gallery must be reviewed by an editor before they appear in categories or search results. While waiting for review, your add-on can still be accessed through its direct "
+"URL. Please choose the review process below that best fits your add-on."
 msgstr ""
-"Todos os complementos hospedados em nossa galeria devem ser analisados por "
-"um editor antes de aparecer nas categorias ou resultados de pesquisas. "
-"Enquanto aguarda a análise, seu complemento pode ser acessado pela sua "
-"página de detalhes. Por favor, escolha o processo de análise mais adequado "
-"ao seu complemento abaixo."
+"Todos os complementos hospedados em nossa galeria devem ser analisados por um editor antes de aparecer nas categorias ou resultados de pesquisas. Enquanto aguarda a análise, seu complemento pode "
+"ser acessado pela sua página de detalhes. Por favor, escolha o processo de análise mais adequado ao seu complemento abaixo."
 
 #: src/olympia/devhub/templates/devhub/addons/submit/select-review.html:26
 #, python-format
-msgid ""
-"A complete review of your add-on's source and functionality. <a "
-"href=\"%(url)s\">Learn more&hellip;</a>"
-msgstr ""
-"Uma análise completa do código-fonte e da funcionalidade do seu complemento."
-" <a href=\"%(url)s\">Saiba mais&hellip;</a>"
+msgid "A complete review of your add-on's source and functionality. <a href=\"%(url)s\">Learn more&hellip;</a>"
+msgstr "Uma análise completa do código-fonte e da funcionalidade do seu complemento. <a href=\"%(url)s\">Saiba mais&hellip;</a>"
 
 #: src/olympia/devhub/templates/devhub/addons/submit/select-review.html:32
 msgid "Appropriate for polished add-ons"
@@ -6442,12 +5201,8 @@ msgstr "Escolher análise completa"
 
 #: src/olympia/devhub/templates/devhub/addons/submit/select-review.html:49
 #, python-format
-msgid ""
-"A faster review of your add-on's source for any major problems. <a "
-"href=\"%(url)s\">Learn more&hellip;</a>"
-msgstr ""
-"Uma análise rápida do código-fonte do seu complemento em busca de problemas "
-"mais graves. <a href=\"%(url)s\">Saiba mais&hellip;</a>"
+msgid "A faster review of your add-on's source for any major problems. <a href=\"%(url)s\">Learn more&hellip;</a>"
+msgstr "Uma análise rápida do código-fonte do seu complemento em busca de problemas mais graves. <a href=\"%(url)s\">Saiba mais&hellip;</a>"
 
 #: src/olympia/devhub/templates/devhub/addons/submit/select-review.html:55
 msgid "Appropriate for experimental add-ons"
@@ -6495,10 +5250,8 @@ msgstr "Selecione uma licença"
 msgid "Select a review process"
 msgstr "Selecione um processo de análise"
 
-#: src/olympia/devhub/templates/devhub/addons/submit/sidebar.html:18
-#: src/olympia/devhub/templates/devhub/docs/policies-submission.html:3
-#: src/olympia/devhub/templates/devhub/docs/policies-submission.html:7
-#: src/olympia/devhub/templates/devhub/docs/policies-submission.html:9
+#: src/olympia/devhub/templates/devhub/addons/submit/sidebar.html:18 src/olympia/devhub/templates/devhub/docs/policies-submission.html:3
+#: src/olympia/devhub/templates/devhub/docs/policies-submission.html:7 src/olympia/devhub/templates/devhub/docs/policies-submission.html:9
 msgid "Submission Process"
 msgstr "Processo de submissão"
 
@@ -6519,27 +5272,20 @@ msgid "Step 2. Upload Your Add-on"
 msgstr "2º passo. Envie seu complemento"
 
 #: src/olympia/devhub/templates/devhub/addons/submit/upload.html:11
-msgid ""
-"Use the fields below to upload your add-on package and select any platform "
-"restrictions. After upload, a series of automated validation tests will be "
-"run on your file."
+msgid "Use the fields below to upload your add-on package and select any platform restrictions. After upload, a series of automated validation tests will be run on your file."
 msgstr ""
-"Use os campos abaixo para enviar o pacote do seu complemento e selecionar "
-"quaisquer restrições de plataforma. Depois do envio, uma série de testes de "
-"validação automáticos será executada em seu arquivo."
+"Use os campos abaixo para enviar o pacote do seu complemento e selecionar quaisquer restrições de plataforma. Depois do envio, uma série de testes de validação automáticos será executada em seu "
+"arquivo."
 
-#: src/olympia/devhub/templates/devhub/addons/submit/upload.html:59
-#: src/olympia/devhub/templates/devhub/versions/add_file_modal.html:39
+#: src/olympia/devhub/templates/devhub/addons/submit/upload.html:51 src/olympia/devhub/templates/devhub/versions/add_file_modal.html:28
 msgid "Which platforms is this file compatible with?"
 msgstr "Esse arquivo é compatível com quais plataformas?"
 
-#: src/olympia/devhub/templates/devhub/addons/submit/upload.html:67
-#: src/olympia/devhub/templates/devhub/versions/add_file_modal.html:65
+#: src/olympia/devhub/templates/devhub/addons/submit/upload.html:59 src/olympia/devhub/templates/devhub/versions/add_file_modal.html:45
 msgid "Administrative overrides"
 msgstr "Substituições administrativas"
 
-#: src/olympia/devhub/templates/devhub/api/agreement.html:3
-#: src/olympia/devhub/templates/devhub/api/agreement.html:11
+#: src/olympia/devhub/templates/devhub/api/agreement.html:3 src/olympia/devhub/templates/devhub/api/agreement.html:11
 msgid "Firefox Add-on Distribution Agreement"
 msgstr "Acordo de distribuição de complementos Firefox"
 
@@ -6549,12 +5295,8 @@ msgstr "Credenciais da API"
 
 #: src/olympia/devhub/templates/devhub/api/key.html:20
 #, python-format
-msgid ""
-"For detailed instructions, consult the <a href=\"%(docs_url)s\">API "
-"documentation</a>."
-msgstr ""
-"Para instruções detalhadas, consulte a <a href=\"%(docs_url)s\"> "
-"documentação da API</a>."
+msgid "For detailed instructions, consult the <a href=\"%(docs_url)s\">API documentation</a>."
+msgstr "Para instruções detalhadas, consulte a <a href=\"%(docs_url)s\"> documentação da API</a>."
 
 #: src/olympia/devhub/templates/devhub/api/key.html:28
 msgid "JWT issuer"
@@ -6567,15 +5309,11 @@ msgstr "Segredo JWT"
 #: src/olympia/devhub/templates/devhub/api/key.html:37
 #, python-format
 msgid ""
-"To make API requests, send a <a href=\"%(jwt_url)s\">JSON Web Token "
-"(JWT)</a> as the authorization header. You'll need to generate a JWT for "
-"every request as explained in the <a href=\"%(docs_url)s\">API "
-"documentation</a>."
+"To make API requests, send a <a href=\"%(jwt_url)s\">JSON Web Token (JWT)</a> as the authorization header. You'll need to generate a JWT for every request as explained in the <a href=\"%(docs_url)s"
+"\">API documentation</a>."
 msgstr ""
-"Para fazer requisições via API, envie o<a href=\"%(jwt_url)s\"> JSON Web "
-"Token (JWT)</a> como cabeçalho de autorização. Você precisará gerar um JWT "
-"para cada requisição como explicado na <a href=\"%(docs_url)s\">documentação"
-" da API</a>."
+"Para fazer requisições via API, envie o<a href=\"%(jwt_url)s\"> JSON Web Token (JWT)</a> como cabeçalho de autorização. Você precisará gerar um JWT para cada requisição como explicado na <a href="
+"\"%(docs_url)s\">documentação da API</a>."
 
 #: src/olympia/devhub/templates/devhub/api/key.html:47
 msgid "You don't have any API credentials yet."
@@ -6583,12 +5321,8 @@ msgstr "Você ainda não tem nenhuma credencial da API."
 
 #: src/olympia/devhub/templates/devhub/api/key.html:53
 #, python-format
-msgid ""
-"This feature is under active development. If you find a problem please <a "
-"target=\"_blank\" href=\"%(bug_link)s\">report a bug</a>."
-msgstr ""
-"Esta funcionalidade está em desenvolvimento. Se encontrar um problema, por "
-"favor <a target=\"_blank\" href=\"%(bug_link)s\">reporte um bug</a>."
+msgid "This feature is under active development. If you find a problem please <a target=\"_blank\" href=\"%(bug_link)s\">report a bug</a>."
+msgstr "Esta funcionalidade está em desenvolvimento. Se encontrar um problema, por favor <a target=\"_blank\" href=\"%(bug_link)s\">reporte um bug</a>."
 
 #: src/olympia/devhub/templates/devhub/api/key.html:61
 msgid "Revoke and regenerate credentials"
@@ -6598,30 +5332,19 @@ msgstr "Revogue e regenere as credenciais"
 msgid "Generate new credentials"
 msgstr "Gerar novas credenciais"
 
-#: src/olympia/devhub/templates/devhub/docs/policies-agreement.html:3
-#: src/olympia/devhub/templates/devhub/docs/policies-agreement.html:7
-#: src/olympia/devhub/templates/devhub/docs/policies-agreement.html:9
-#: src/olympia/devhub/templates/devhub/docs/policies.html:24
-#: src/olympia/devhub/templates/devhub/docs/policies.html:103
+#: src/olympia/devhub/templates/devhub/docs/policies-agreement.html:3 src/olympia/devhub/templates/devhub/docs/policies-agreement.html:7
+#: src/olympia/devhub/templates/devhub/docs/policies-agreement.html:9 src/olympia/devhub/templates/devhub/docs/policies.html:24 src/olympia/devhub/templates/devhub/docs/policies.html:103
 msgid "Developer Agreement"
 msgstr "Acordo com o desenvolvedor"
 
-#: src/olympia/devhub/templates/devhub/docs/policies-contact.html:3
-#: src/olympia/devhub/templates/devhub/docs/policies-contact.html:7
-#: src/olympia/devhub/templates/devhub/docs/policies-contact.html:9
-#: src/olympia/devhub/templates/devhub/docs/policies.html:27
-#: src/olympia/devhub/templates/devhub/docs/policies.html:115
+#: src/olympia/devhub/templates/devhub/docs/policies-contact.html:3 src/olympia/devhub/templates/devhub/docs/policies-contact.html:7 src/olympia/devhub/templates/devhub/docs/policies-contact.html:9
+#: src/olympia/devhub/templates/devhub/docs/policies.html:27 src/olympia/devhub/templates/devhub/docs/policies.html:115
 msgid "Contacting Us"
 msgstr "Entrando em contato conosco"
 
 #: src/olympia/devhub/templates/devhub/docs/policies-contact.html:12
-msgid ""
-"Thanks for your interest in contacting the Mozilla Add-ons team. Please read"
-" this page carefully to ensure your request goes to the right place."
-msgstr ""
-"Obrigado pelo interesse em entrar em contato com a equipe do Mozilla Add-"
-"ons. Por favor, leia esta página com atenção para ter certeza de que sua "
-"solicitação está indo para o lugar certo."
+msgid "Thanks for your interest in contacting the Mozilla Add-ons team. Please read this page carefully to ensure your request goes to the right place."
+msgstr "Obrigado pelo interesse em entrar em contato com a equipe do Mozilla Add-ons. Por favor, leia esta página com atenção para ter certeza de que sua solicitação está indo para o lugar certo."
 
 #: src/olympia/devhub/templates/devhub/docs/policies-contact.html:17
 msgid "Add-on Support"
@@ -6629,15 +5352,11 @@ msgstr "Suporte a um complemento"
 
 #: src/olympia/devhub/templates/devhub/docs/policies-contact.html:19
 msgid ""
-"If you have a support question about a particular add-on, such as \"how do I"
-" use this add-on?\" or \"why doesn't this work properly?\", please contact "
-"that add-on's author through the support channels listed on the add-on's "
-"listing page."
+"If you have a support question about a particular add-on, such as \"how do I use this add-on?\" or \"why doesn't this work properly?\", please contact that add-on's author through the support "
+"channels listed on the add-on's listing page."
 msgstr ""
-"Se você tem uma dúvida de suporte sobre um complemento em particular, como "
-"\"como eu uso esse complemento?\" ou \"por que ele não funciona direito?\", "
-"por favor, entre em contato com o autor do complemento usando os canais "
-"listados na página do complemento."
+"Se você tem uma dúvida de suporte sobre um complemento em particular, como \"como eu uso esse complemento?\" ou \"por que ele não funciona direito?\", por favor, entre em contato com o autor do "
+"complemento usando os canais listados na página do complemento."
 
 #: src/olympia/devhub/templates/devhub/docs/policies-contact.html:24
 msgid "Add-on Editorial Concerns"
@@ -6650,18 +5369,11 @@ msgstr "amo-editors arroba mozilla ponto org"
 #: src/olympia/devhub/templates/devhub/docs/policies-contact.html:26
 #, python-format
 msgid ""
-"If you have a question about an Editor's review of an add-on or want to "
-"report a policy violation, please email %(mail_editors)s. <strong>Almost all"
-" add-on reports fall under this category.</strong> Please be sure to include"
-" a link to the add-on in question and a detailed description of your "
-"question or comment."
+"If you have a question about an Editor's review of an add-on or want to report a policy violation, please email %(mail_editors)s. <strong>Almost all add-on reports fall under this category.</"
+"strong> Please be sure to include a link to the add-on in question and a detailed description of your question or comment."
 msgstr ""
-"Se você tem uma pergunta sobre uma análise de um Editor sobre um complemento"
-" ou quer denunciar uma violação das nossas políticas, por favor, escreva "
-"para %(mail_editors)s. <strong>Quase todas as denúncias de complementos se "
-"enquadram nessa categoria.</strong> Por favor, lembre-se de incluir um link "
-"para o complemento em questão e uma descrição detalhada da sua pergunta ou "
-"comentário."
+"Se você tem uma pergunta sobre uma análise de um Editor sobre um complemento ou quer denunciar uma violação das nossas políticas, por favor, escreva para %(mail_editors)s. <strong>Quase todas as "
+"denúncias de complementos se enquadram nessa categoria.</strong> Por favor, lembre-se de incluir um link para o complemento em questão e uma descrição detalhada da sua pergunta ou comentário."
 
 #: src/olympia/devhub/templates/devhub/docs/policies-contact.html:31
 msgid "Add-on Security Vulnerabilities"
@@ -6674,22 +5386,13 @@ msgstr "amo-admins arroba mozilla ponto org"
 #: src/olympia/devhub/templates/devhub/docs/policies-contact.html:36
 #, python-format
 msgid ""
-"If you have discovered a security vulnerability in an add-on, even if it is "
-"not hosted here, Mozilla is very interested in your discovery and will work "
-"with the add-on developer to correct the issue as soon as possible. Add-on "
-"security issues can be reported <a "
-"href=\"http://www.mozilla.org/projects/security/security-bugs-"
-"policy.html\">confidentially</a> in <a "
-"href=\"%(link_bugzilla)s\">Bugzilla</a> or by emailing %(mail_admins)s."
+"If you have discovered a security vulnerability in an add-on, even if it is not hosted here, Mozilla is very interested in your discovery and will work with the add-on developer to correct the "
+"issue as soon as possible. Add-on security issues can be reported <a href=\"http://www.mozilla.org/projects/security/security-bugs-policy.html\">confidentially</a> in <a href=\"%(link_bugzilla)s"
+"\">Bugzilla</a> or by emailing %(mail_admins)s."
 msgstr ""
-"Se você descobriu uma vulnerabilidade de segurança em um complemento, mesmo "
-"que ele não esteja hospedado aqui, a Mozilla está muito interessada na sua "
-"descoberta e trabalhará com o desenvolvedor do complemento para corrigir o "
-"problema o mais rápido possível. Problemas de segurança de complementos "
-"podem ser relatados <a href=\"http://www.mozilla.org/projects/security"
-"/security-bugs-policy.html\">confidencialmente</a> no <a "
-"href=\"%(link_bugzilla)s\">Bugzilla</a> ou enviando uma mensagem para "
-"%(mail_admins)s."
+"Se você descobriu uma vulnerabilidade de segurança em um complemento, mesmo que ele não esteja hospedado aqui, a Mozilla está muito interessada na sua descoberta e trabalhará com o desenvolvedor do "
+"complemento para corrigir o problema o mais rápido possível. Problemas de segurança de complementos podem ser relatados <a href=\"http://www.mozilla.org/projects/security/security-bugs-policy.html"
+"\">confidencialmente</a> no <a href=\"%(link_bugzilla)s\">Bugzilla</a> ou enviando uma mensagem para %(mail_admins)s."
 
 #: src/olympia/devhub/templates/devhub/docs/policies-contact.html:42
 msgid "Website Functionality & Development"
@@ -6697,17 +5400,11 @@ msgstr "Funcionalidade e desenvolvimento do site"
 
 #: src/olympia/devhub/templates/devhub/docs/policies-contact.html:44
 msgid ""
-"If you've found a problem with the site, we'd love to fix it. Please <a "
-"href=\"https://github.com/mozilla/olympia/issues\">file a bug report</a> in "
-"GitHub, including the location of the problem and how you encountered it."
+"If you've found a problem with the site, we'd love to fix it. Please <a href=\"https://github.com/mozilla/addons/issues/new\">file a bug report</a> in GitHub, including the location of the problem "
+"and how you encountered it."
 msgstr ""
-"Se você encontrou algum problema neste site, nós adoraríamos corrigi-lo. Por"
-" favor <a href=\"https://github.com/mozilla/olympia/issues\"> registre um "
-"relatório de bug</a> no GitHub, incluindo a localização do problema e como "
-"você o encontrou."
 
-#: src/olympia/devhub/templates/devhub/docs/policies-maintenance.html:3
-#: src/olympia/devhub/templates/devhub/docs/policies-maintenance.html:7
+#: src/olympia/devhub/templates/devhub/docs/policies-maintenance.html:3 src/olympia/devhub/templates/devhub/docs/policies-maintenance.html:7
 #: src/olympia/devhub/templates/devhub/docs/policies-maintenance.html:8
 msgid "Maintaining Your Add-ons"
 msgstr "Manutenção dos seus complementos"
@@ -6718,32 +5415,17 @@ msgstr "Enviando novas versões do seu complemento"
 
 #: src/olympia/devhub/templates/devhub/docs/policies-maintenance.html:12
 msgid ""
-"Developers are encouraged to submit updates to their add-ons to fix bugs, "
-"add features, and otherwise improve their product. New versions of an add-on"
-" must have a <a "
-"href=\"https://developer.mozilla.org/en/Toolkit_version_format\">higher "
-"version number</a> and can be submitted through the Developer Tools "
-"provided. There is no limit to the number of versions that can be submitted,"
-" but please remember that versions must be reviewed by an editor."
+"Developers are encouraged to submit updates to their add-ons to fix bugs, add features, and otherwise improve their product. New versions of an add-on must have a <a href=\"https://developer."
+"mozilla.org/en/Toolkit_version_format\">higher version number</a> and can be submitted through the Developer Tools provided. There is no limit to the number of versions that can be submitted, but "
+"please remember that versions must be reviewed by an editor."
 msgstr ""
-"Desenvolvedores são encorajados a enviar atualizações de seus complementos "
-"para corrigir bugs, adicionar funcionalidades ou melhorar seu produto de "
-"alguma outra forma. Novas versões de um complemento devem ter um <a "
-"href=\"https://developer.mozilla.org/en/Toolkit_version_format\">número de "
-"versão maior</a> e podem ser submetido usando as Ferramentas do "
-"desenvolvedor oferecidas. Não há limite para o número de versões que podem "
-"ser submetidas, mas lembre-se que todas as versões devem ser analisadas "
-"​​por um editor."
+"Desenvolvedores são encorajados a enviar atualizações de seus complementos para corrigir bugs, adicionar funcionalidades ou melhorar seu produto de alguma outra forma. Novas versões de um "
+"complemento devem ter um <a href=\"https://developer.mozilla.org/en/Toolkit_version_format\">número de versão maior</a> e podem ser submetido usando as Ferramentas do desenvolvedor oferecidas. Não "
+"há limite para o número de versões que podem ser submetidas, mas lembre-se que todas as versões devem ser analisadas ​​por um editor."
 
 #: src/olympia/devhub/templates/devhub/docs/policies-maintenance.html:18
-msgid ""
-"New versions will be added to a pending review queue, and any additional "
-"versions submitted before the review is completed will move that version to "
-"the end of the queue."
-msgstr ""
-"Novas versões serão adicionadas à uma fila de análises e qualquer versão "
-"adicional submetida antes dessa análise ser concluída será movida para o "
-"final da fila."
+msgid "New versions will be added to a pending review queue, and any additional versions submitted before the review is completed will move that version to the end of the queue."
+msgstr "Novas versões serão adicionadas à uma fila de análises e qualquer versão adicional submetida antes dessa análise ser concluída será movida para o final da fila."
 
 #: src/olympia/devhub/templates/devhub/docs/policies-maintenance.html:23
 msgid "How do I submit a Beta add-on?"
@@ -6751,58 +5433,35 @@ msgstr "Como eu envio um complemento Beta?"
 
 #: src/olympia/devhub/templates/devhub/docs/policies-maintenance.html:25
 msgid "Beta channels are only available to fully-reviewed add-ons."
-msgstr ""
-"Canais Beta só estão disponíveis para complementos completamente analisados."
+msgstr "Canais Beta só estão disponíveis para complementos completamente analisados."
 
 #: src/olympia/devhub/templates/devhub/docs/policies-maintenance.html:31
 msgid ""
-"To create a beta channel, upload a file with a unique version string that "
-"contains any of the following strings: <code>a,b,alpha,beta,pre,rc</code>, "
-"with an optional number at the end. This text must come at the end of the "
-"version string. If you understand regex format, here's what we look for in "
-"the version number: <code>\"(a|alpha|b|beta|pre|rc)\\d*$\"</code>."
+"To create a beta channel, upload a file with a unique version string that contains any of the following strings: <code>a,b,alpha,beta,pre,rc</code>, with an optional number at the end. This text "
+"must come at the end of the version string. If you understand regex format, here's what we look for in the version number: <code>\"(a|alpha|b|beta|pre|rc)\\d*$\"</code>."
 msgstr ""
-"Para criar um canal beta, envie um arquivo com uma string de versão única "
-"contendo qualquer um dos seguintes sufixos: "
-"<code>a,b,alpha,beta,pre,rc</code>, com um número opcional no final. Esse "
-"texto deve vir no final da string de versão. Se você compreende o formato "
-"RegEx, aqui está o que estamos pedindo no número de versão: "
-"<code>\"(a|alpha|b|beta|pre|rc)\\d*$\"</code>."
+"Para criar um canal beta, envie um arquivo com uma string de versão única contendo qualquer um dos seguintes sufixos: <code>a,b,alpha,beta,pre,rc</code>, com um número opcional no final. Esse texto "
+"deve vir no final da string de versão. Se você compreende o formato RegEx, aqui está o que estamos pedindo no número de versão: <code>\"(a|alpha|b|beta|pre|rc)\\d*$\"</code>."
 
 #: src/olympia/devhub/templates/devhub/docs/policies-maintenance.html:37
 msgid ""
-"Once a file meeting this criteria is uploaded to AMO, it will automatically "
-"be marked as a beta version. Users of add-ons with these unique version "
-"numbers will automatically be served the newest beta updates."
+"Once a file meeting this criteria is uploaded to AMO, it will automatically be marked as a beta version. Users of add-ons with these unique version numbers will automatically be served the newest "
+"beta updates."
 msgstr ""
-"Quando um arquivo que atende a esse critério é enviado ao AMO, ele será "
-"automaticamente marcado como uma versão beta. Usuários de complementos com "
-"essas versões serão automaticamente servidos com as atualizações beta mais "
-"recentes."
+"Quando um arquivo que atende a esse critério é enviado ao AMO, ele será automaticamente marcado como uma versão beta. Usuários de complementos com essas versões serão automaticamente servidos com "
+"as atualizações beta mais recentes."
 
 #: src/olympia/devhub/templates/devhub/docs/policies-maintenance.html:43
 msgid ""
-"While we call these \"Beta versions\", you can use this channel for "
-"nightlies, or alphas, or prerelease versions as you wish. Please note that "
-"there is only one channel for this purpose and all of your users on this "
-"channel will receive the latest add-ons submitted. For instance, if you "
-"upload <code>1.0beta1</code> to the release channel and then upload "
-"<code>1.1alpha1</code>, all users of <code>1.0beta1</code> will be offered "
-"an upgrade to <code>1.1alpha1</code>. Updates are pushed by submission date "
-"and not version number, so users will always get the most recent channel "
-"update regardless of any kind of alphabetical sorting."
+"While we call these \"Beta versions\", you can use this channel for nightlies, or alphas, or prerelease versions as you wish. Please note that there is only one channel for this purpose and all of "
+"your users on this channel will receive the latest add-ons submitted. For instance, if you upload <code>1.0beta1</code> to the release channel and then upload <code>1.1alpha1</code>, all users of "
+"<code>1.0beta1</code> will be offered an upgrade to <code>1.1alpha1</code>. Updates are pushed by submission date and not version number, so users will always get the most recent channel update "
+"regardless of any kind of alphabetical sorting."
 msgstr ""
-"Apesar de nós chamarmos de \"versões beta\", você pode usar esse canal de "
-"atualizações para versôes nightlies, alphas e de pré-lançamento como "
-"desejar. Por favor, note que há apenas um canal para este fim e todos os "
-"seus seus usuários nesse canal receberão os últimos complementos submetidos."
-" Por exemplo, se enviar a <code>1.0beta1</code> para o canal de "
-"disponibilização e em seguida enviar a <code>1.1alpha1</code>, será "
-"disponibilizada uma atualização a todos os utilizadores de "
-"<code>1.0beta1</code> para <code>1.1alpha1</code>. As atualizações são "
-"enviadas por data de submissão e não por número de versão, para que os "
-"usuários tenham sempre a atualização mais recente do canal, "
-"independentemente de qualquer tipo de ordenação alfabética."
+"Apesar de nós chamarmos de \"versões beta\", você pode usar esse canal de atualizações para versôes nightlies, alphas e de pré-lançamento como desejar. Por favor, note que há apenas um canal para "
+"este fim e todos os seus seus usuários nesse canal receberão os últimos complementos submetidos. Por exemplo, se enviar a <code>1.0beta1</code> para o canal de disponibilização e em seguida enviar "
+"a <code>1.1alpha1</code>, será disponibilizada uma atualização a todos os utilizadores de <code>1.0beta1</code> para <code>1.1alpha1</code>. As atualizações são enviadas por data de submissão e não "
+"por número de versão, para que os usuários tenham sempre a atualização mais recente do canal, independentemente de qualquer tipo de ordenação alfabética."
 
 #: src/olympia/devhub/templates/devhub/docs/policies-maintenance.html:48
 msgid "Required Updates"
@@ -6810,21 +5469,13 @@ msgstr "Atualizações necessárias"
 
 #: src/olympia/devhub/templates/devhub/docs/policies-maintenance.html:50
 msgid ""
-"Certain situations may arise in which Mozilla requests that an add-on "
-"developer update their add-on within a given time period to address a major "
-"security issue or policy violation. We work with developers to reasonably "
-"accommodate their own schedules, but if the issue is of a serious enough "
-"nature, add-ons that cannot issue an update with the requested fix may be "
-"demoted from fully-reviewed status, disabled, or permanently removed from "
-"the site."
+"Certain situations may arise in which Mozilla requests that an add-on developer update their add-on within a given time period to address a major security issue or policy violation. We work with "
+"developers to reasonably accommodate their own schedules, but if the issue is of a serious enough nature, add-ons that cannot issue an update with the requested fix may be demoted from fully-"
+"reviewed status, disabled, or permanently removed from the site."
 msgstr ""
-"Podem surgir situações em que a Mozilla pode pedir a um desenvolvedor para "
-"atualizar seu complemento dentro de um determinado período de tempo para "
-"resolver um grande problema de segurança ou uma violação de política. Nós "
-"trabalhamos com os desenvolvedores para definir os seus próprios horários, "
-"mas se o problema for grave, os complementos que não lançarem uma "
-"atualização com a correção necessária podem perder o status de completamente"
-" analisados, serem desabilitados ou removidos permanentemente deste site."
+"Podem surgir situações em que a Mozilla pode pedir a um desenvolvedor para atualizar seu complemento dentro de um determinado período de tempo para resolver um grande problema de segurança ou uma "
+"violação de política. Nós trabalhamos com os desenvolvedores para definir os seus próprios horários, mas se o problema for grave, os complementos que não lançarem uma atualização com a correção "
+"necessária podem perder o status de completamente analisados, serem desabilitados ou removidos permanentemente deste site."
 
 #: src/olympia/devhub/templates/devhub/docs/policies-maintenance.html:55
 msgid "Transfer of Ownership"
@@ -6832,66 +5483,41 @@ msgstr "Transferência de propriedade"
 
 #: src/olympia/devhub/templates/devhub/docs/policies-maintenance.html:57
 msgid ""
-"Add-ons can have multiple users with permission to update and manage the "
-"listing. Existing authors of an add-on can transfer ownership and add "
-"additional developers to an add-on's listing through the Developer Tools "
-"provided. No interaction with Mozilla representatives is necessary for a "
-"transfer of ownership."
+"Add-ons can have multiple users with permission to update and manage the listing. Existing authors of an add-on can transfer ownership and add additional developers to an add-on's listing through "
+"the Developer Tools provided. No interaction with Mozilla representatives is necessary for a transfer of ownership."
 msgstr ""
-"Complementos podem ter vários usuários com permissão para atualizar e "
-"administrar sua página. Autores existentes de complementos podem transferir "
-"sua propriedade e adicionar desenvolvedores adicionais a um complemento "
-"usando das Ferramentas do desenvolvedor fornecidas. Nenhuma interação com "
-"representantes da Mozilla é necessária para uma transferência de "
-"propriedade."
+"Complementos podem ter vários usuários com permissão para atualizar e administrar sua página. Autores existentes de complementos podem transferir sua propriedade e adicionar desenvolvedores "
+"adicionais a um complemento usando das Ferramentas do desenvolvedor fornecidas. Nenhuma interação com representantes da Mozilla é necessária para uma transferência de propriedade."
 
 #: src/olympia/devhub/templates/devhub/docs/policies-maintenance.html:63
 #, python-format
-msgid ""
-"Mozilla can assist with granting additional permissions of an add-on's "
-"listing if <a href=\"%(link_contact)s\">contacted</a> by the add-on's "
-"current owner."
-msgstr ""
-"A Mozilla pode ajudar com a concessão de permissões adicionais para a página"
-" de um complemento se <a href=\"%(link_contact)s\">contatada</a> pelo atual "
-"dono do complemento."
+msgid "Mozilla can assist with granting additional permissions of an add-on's listing if <a href=\"%(link_contact)s\">contacted</a> by the add-on's current owner."
+msgstr "A Mozilla pode ajudar com a concessão de permissões adicionais para a página de um complemento se <a href=\"%(link_contact)s\">contatada</a> pelo atual dono do complemento."
 
 #: src/olympia/devhub/templates/devhub/docs/policies-maintenance.html:70
 msgid ""
-"Mozilla encourages its users to offer feedback on their experiences when "
-"using an add-on. This allows other users to determine if the add-on is "
-"stable and useful. It also provides valuable feedback to developers, "
-"allowing them to continuously improve their add-on to meet user needs."
+"Mozilla encourages its users to offer feedback on their experiences when using an add-on. This allows other users to determine if the add-on is stable and useful. It also provides valuable feedback "
+"to developers, allowing them to continuously improve their add-on to meet user needs."
 msgstr ""
-"A Mozilla encoraja seus usuários a comentarem sobre suas experiências ao "
-"usar um complemento. Isso permite que outros usuários determinem se um "
-"complemento é estável e útil. Além disso, suas opiniões são valiosas para os"
-" desenvolvedores, permitindo que eles melhorem continuamente seus "
-"complementos para atender as necessidades dos usuários."
+"A Mozilla encoraja seus usuários a comentarem sobre suas experiências ao usar um complemento. Isso permite que outros usuários determinem se um complemento é estável e útil. Além disso, suas "
+"opiniões são valiosas para os desenvolvedores, permitindo que eles melhorem continuamente seus complementos para atender as necessidades dos usuários."
 
 #: src/olympia/devhub/templates/devhub/docs/policies-maintenance.html:76
 #, python-format
 msgid ""
-"Reviews must follow the <a href=\"%(link_guidelines)s\">review "
-"guidelines</a>. Reviews that do not meet these guidelines may be flagged for"
-" moderation, but negative reviews will not be removed unless they provide "
-"false information."
+"Reviews must follow the <a href=\"%(link_guidelines)s\">review guidelines</a>. Reviews that do not meet these guidelines may be flagged for moderation, but negative reviews will not be removed "
+"unless they provide false information."
 msgstr ""
-"As análises devem seguir as <a href=\"%(link_guidelines)s\">regras gerais "
-"para análises</a>. As análises que não seguirem essas regras poderão ser "
-"marcadas para moderação; no entanto análises negativas não serão removidas a"
-" menos que elas contenham informações falsas."
+"As análises devem seguir as <a href=\"%(link_guidelines)s\">regras gerais para análises</a>. As análises que não seguirem essas regras poderão ser marcadas para moderação; no entanto análises "
+"negativas não serão removidas a menos que elas contenham informações falsas."
 
 #: src/olympia/devhub/templates/devhub/docs/policies-maintenance.html:82
 msgid ""
-"Many developers provide a support mechanism, such as a forum, discussion "
-"group, or email address. It is recommended that support questions be posted "
-"via those mediums instead of in an add-on's review section."
+"Many developers provide a support mechanism, such as a forum, discussion group, or email address. It is recommended that support questions be posted via those mediums instead of in an add-on's "
+"review section."
 msgstr ""
-"Muitos desenvolvedores fornecem um mecanismo de suporte, como um fórum, "
-"grupo de discussão ou endereço de email. Recomenda-se que o suporte deve ser"
-" disponibilizado através desses meios, em vez de em uma seção de revisão do "
-"complemento."
+"Muitos desenvolvedores fornecem um mecanismo de suporte, como um fórum, grupo de discussão ou endereço de email. Recomenda-se que o suporte deve ser disponibilizado através desses meios, em vez de "
+"em uma seção de revisão do complemento."
 
 #: src/olympia/devhub/templates/devhub/docs/policies-maintenance.html:87
 msgid "Code Disputes"
@@ -6899,45 +5525,26 @@ msgstr "Conflitos de código"
 
 #: src/olympia/devhub/templates/devhub/docs/policies-maintenance.html:90
 msgid ""
-"Many add-ons allow their source code to be openly viewed. This does not mean"
-" that the source code is open source or available for use in another add-on."
-" The original author of an add-on retains copyright of their work unless "
-"otherwise noted in the add-on's license."
+"Many add-ons allow their source code to be openly viewed. This does not mean that the source code is open source or available for use in another add-on. The original author of an add-on retains "
+"copyright of their work unless otherwise noted in the add-on's license."
 msgstr ""
-"Muitos complementos permitem que seu código-fonte seja visualizado "
-"abertamente. Isso não significa que o código-fonte seja código aberto ou que"
-" esteja disponível para ser usado em outro complemento. O autor original de "
-"um complemento retém os direitos sobre seu trabalho a menos que o contrário "
-"esteja especificado na licença do complemento."
+"Muitos complementos permitem que seu código-fonte seja visualizado abertamente. Isso não significa que o código-fonte seja código aberto ou que esteja disponível para ser usado em outro "
+"complemento. O autor original de um complemento retém os direitos sobre seu trabalho a menos que o contrário esteja especificado na licença do complemento."
 
 #: src/olympia/devhub/templates/devhub/docs/policies-maintenance.html:96
 msgid ""
-"In the event that we're notified of a copyright or license infringement, we "
-"will take steps to review the situation and determine if an actual "
-"infringement has occurred. If we determine that there is an infringement, we"
-" will remove the offending add-on and contact the author. New add-on "
-"submissions (including updates) containing infringing code will be denied "
-"approval for public status."
+"In the event that we're notified of a copyright or license infringement, we will take steps to review the situation and determine if an actual infringement has occurred. If we determine that there "
+"is an infringement, we will remove the offending add-on and contact the author. New add-on submissions (including updates) containing infringing code will be denied approval for public status."
 msgstr ""
-"No caso de sermos notificados de uma violação de direitos do autor ou "
-"licença, tomaremos medidas para analisar a situação e determinar se de fato "
-"ocorreu uma violação. Se determinarmos que existe uma infração, vamos "
-"remover o complemento em questão e entraremos em contato com o autor. Será "
-"negada a aprovação de publicação a novas submissões do complemento "
-"(incluindo atualizações) com o código em questão."
+"No caso de sermos notificados de uma violação de direitos do autor ou licença, tomaremos medidas para analisar a situação e determinar se de fato ocorreu uma violação. Se determinarmos que existe "
+"uma infração, vamos remover o complemento em questão e entraremos em contato com o autor. Será negada a aprovação de publicação a novas submissões do complemento (incluindo atualizações) com o "
+"código em questão."
 
 #: src/olympia/devhub/templates/devhub/docs/policies-maintenance.html:102
-msgid ""
-"If you are unsure of the current copyright status of an add-on's source "
-"code, you must contact the original author and receive explicit permission "
-"before using the source code."
-msgstr ""
-"Se você não tiver certeza sobre a situação dos direitos do código-fonte de "
-"um complemento, você deve contatar o autor original e receber uma permissão "
-"explícita antes de usar o código-fonte."
+msgid "If you are unsure of the current copyright status of an add-on's source code, you must contact the original author and receive explicit permission before using the source code."
+msgstr "Se você não tiver certeza sobre a situação dos direitos do código-fonte de um complemento, você deve contatar o autor original e receber uma permissão explícita antes de usar o código-fonte."
 
-#: src/olympia/devhub/templates/devhub/docs/policies-maintenance.html:107
-#: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:306
+#: src/olympia/devhub/templates/devhub/docs/policies-maintenance.html:107 src/olympia/devhub/templates/devhub/docs/policies-reviews.html:306
 #: src/olympia/devhub/templates/devhub/docs/policies-submission.html:97
 msgid "Last updated: January 13, 2011"
 msgstr "Última atualização: 13 de janeiro de 2011"
@@ -6945,54 +5552,35 @@ msgstr "Última atualização: 13 de janeiro de 2011"
 #: src/olympia/devhub/templates/devhub/docs/policies-recommended.html:13
 #, python-format
 msgid ""
-"Featured add-ons are top-quality extensions and themes highlighted on <a "
-"href=\"%(link_gallery)s\">AMO</a>, Firefox's Add-ons Manager, and across "
-"other Mozilla websites. These add-ons showcase the power of Firefox "
-"customization and are useful to a wide audience."
+"Featured add-ons are top-quality extensions and themes highlighted on <a href=\"%(link_gallery)s\">AMO</a>, Firefox's Add-ons Manager, and across other Mozilla websites. These add-ons showcase the "
+"power of Firefox customization and are useful to a wide audience."
 msgstr ""
-"Os complementos em destaque são escolhidos com base na sua popularidade no "
-"<a href=\"%(link_gallery)s\">AMO</a>, Gerenciador de Complementos do Firefox"
-" e em outros sites da Mozilla. Estes complementos são exemplos da capacidade"
-" de personalização do Firefox, e são úteis para muitas pessoas."
+"Os complementos em destaque são escolhidos com base na sua popularidade no <a href=\"%(link_gallery)s\">AMO</a>, Gerenciador de Complementos do Firefox e em outros sites da Mozilla. Estes "
+"complementos são exemplos da capacidade de personalização do Firefox, e são úteis para muitas pessoas."
 
 #: src/olympia/devhub/templates/devhub/docs/policies-recommended.html:19
 msgid ""
-"Featured add-ons are chosen by the Featured Add-ons Advisory Board, a small "
-"group of add-on developers and fans from the Mozilla community who have "
-"volunteered to review and vote on nominations."
+"Featured add-ons are chosen by the Featured Add-ons Advisory Board, a small group of add-on developers and fans from the Mozilla community who have volunteered to review and vote on nominations."
 msgstr ""
-"Os complementos em destaque são escolhidos pelo Conselho de Complementos em "
-"Destaque, um pequeno grupo de desenvolvedores e fãs da comunidade Mozilla "
-"que, voluntariamente, analisam um por um e escolhem os melhores."
+"Os complementos em destaque são escolhidos pelo Conselho de Complementos em Destaque, um pequeno grupo de desenvolvedores e fãs da comunidade Mozilla que, voluntariamente, analisam um por um e "
+"escolhem os melhores."
 
 #: src/olympia/devhub/templates/devhub/docs/policies-recommended.html:25
 #, python-format
-msgid ""
-"<a href=\"%(link_featured)s\">Featured extensions</a> are chosen every "
-"month, and <a href=\"%(link_themes)s\">featured complete themes</a> are "
-"chosen every quarter."
-msgstr ""
-"<a href=\"%(link_featured)s\">Os complementos destaques</a> são escolhidos "
-"mensalmente e <a href=\"%(link_themes)s\">os temas destaque</a> são "
-"escolhidos a cada quadrimestre."
+msgid "<a href=\"%(link_featured)s\">Featured extensions</a> are chosen every month, and <a href=\"%(link_themes)s\">featured complete themes</a> are chosen every quarter."
+msgstr "<a href=\"%(link_featured)s\">Os complementos destaques</a> são escolhidos mensalmente e <a href=\"%(link_themes)s\">os temas destaque</a> são escolhidos a cada quadrimestre."
 
 #: src/olympia/devhub/templates/devhub/docs/policies-recommended.html:30
 msgid "Criteria for Featured Add-ons"
 msgstr "Critérios para complementos em destaque"
 
 #: src/olympia/devhub/templates/devhub/docs/policies-recommended.html:33
-msgid ""
-"Before nominating an add-on to be featured, please ensure it meets the "
-"following criteria:"
-msgstr ""
-"Antes de sugerir um complemento para ser destaque, por favor, confira se ele"
-" cumpre as seguintes exigências:"
+msgid "Before nominating an add-on to be featured, please ensure it meets the following criteria:"
+msgstr "Antes de sugerir um complemento para ser destaque, por favor, confira se ele cumpre as seguintes exigências:"
 
 #: src/olympia/devhub/templates/devhub/docs/policies-recommended.html:39
-msgid ""
-"The add-on must have a complete and informative listing on AMO. This means:"
-msgstr ""
-"O complemento deve ter um página de detalhes completa. Isso significa:"
+msgid "The add-on must have a complete and informative listing on AMO. This means:"
+msgstr "O complemento deve ter um página de detalhes completa. Isso significa:"
 
 #: src/olympia/devhub/templates/devhub/docs/policies-recommended.html:41
 msgid "a 64-pixel custom icon"
@@ -7012,49 +5600,31 @@ msgstr "descrição detalhada e política de privacidade, se for o caso"
 
 #: src/olympia/devhub/templates/devhub/docs/policies-recommended.html:45
 msgid "updated screenshots of the add-on's functionality"
-msgstr ""
-"capturas de tela atualizadas demonstrando a funcionalidade do complemento"
+msgstr "capturas de tela atualizadas demonstrando a funcionalidade do complemento"
 
 #: src/olympia/devhub/templates/devhub/docs/policies-recommended.html:46
-msgid ""
-"must be fully approved by AMO editors (no preliminarily reviewed entries)"
-msgstr ""
-"deve ser completamente aprovado pelos editores do AMO (e não analisados "
-"preliminarmente)"
+msgid "must be fully approved by AMO editors (no preliminarily reviewed entries)"
+msgstr "deve ser completamente aprovado pelos editores do AMO (e não analisados preliminarmente)"
 
 #: src/olympia/devhub/templates/devhub/docs/policies-recommended.html:48
-msgid ""
-"The add-on must have excellent user reviews and any problems or support "
-"requests must be promptly addressed by the developer."
-msgstr ""
-"O complemento deve ter excelentes análises de usuários e quaisquer "
-"solicitações de ajuda devem ser encaminhadas corretamente pelo "
-"desenvolvedor."
+msgid "The add-on must have excellent user reviews and any problems or support requests must be promptly addressed by the developer."
+msgstr "O complemento deve ter excelentes análises de usuários e quaisquer solicitações de ajuda devem ser encaminhadas corretamente pelo desenvolvedor."
 
 #: src/olympia/devhub/templates/devhub/docs/policies-recommended.html:49
 msgid "The add-on must have a minimum of 2,000 users."
 msgstr "O complemento deve ter um mínimo de 2.000 usuários."
 
 #: src/olympia/devhub/templates/devhub/docs/policies-recommended.html:50
-msgid ""
-"The add-on must be compatible with the latest release of Firefox and must be"
-" compatible with beta versions 4 weeks before their final release."
-msgstr ""
-"O complemento deve ser compatível com a versão mais recente do Firefox e "
-"deve ser compatível com versões beta 4 semanas antes de se tornarem versões "
-"finais de lançamento."
+msgid "The add-on must be compatible with the latest release of Firefox and must be compatible with beta versions 4 weeks before their final release."
+msgstr "O complemento deve ser compatível com a versão mais recente do Firefox e deve ser compatível com versões beta 4 semanas antes de se tornarem versões finais de lançamento."
 
 #: src/olympia/devhub/templates/devhub/docs/policies-recommended.html:51
 msgid ""
-"<strong>Most importantly</strong>, the add-on must have wide consumer appeal"
-" to Firefox's users and be outstanding in nearly every way: user experience,"
-" performance, security, and usefulness or entertainment value. Featured "
-"complete themes must also be visually appealing."
+"<strong>Most importantly</strong>, the add-on must have wide consumer appeal to Firefox's users and be outstanding in nearly every way: user experience, performance, security, and usefulness or "
+"entertainment value. Featured complete themes must also be visually appealing."
 msgstr ""
-"<strong>Mais importante ainda,</strong> o complemento precisa ser muito "
-"popular entre os usuários do Firefox e ser bom em todos os sentidos: "
-"usabilidade, performance, segurança e utilidade. Além disso, é recomendável "
-"que o complemento seja perfeito em questões visuais."
+"<strong>Mais importante ainda,</strong> o complemento precisa ser muito popular entre os usuários do Firefox e ser bom em todos os sentidos: usabilidade, performance, segurança e utilidade. Além "
+"disso, é recomendável que o complemento seja perfeito em questões visuais."
 
 #: src/olympia/devhub/templates/devhub/docs/policies-recommended.html:54
 msgid "Nominating an Add-on"
@@ -7066,273 +5636,163 @@ msgstr "amo-featured arroba mozilla ponto org"
 
 #: src/olympia/devhub/templates/devhub/docs/policies-recommended.html:57
 #, python-format
-msgid ""
-"If you wish to nominate an add-on to be featured and it meets the criteria "
-"above, send an email to %(mail_featured)s with:"
-msgstr ""
-"Se você deseja indicar um complemento para estar em destaque e ele atende "
-"aos critérios acima, envie uma mensagem para %(mail_featured)s com:"
+msgid "If you wish to nominate an add-on to be featured and it meets the criteria above, send an email to %(mail_featured)s with:"
+msgstr "Se você deseja indicar um complemento para estar em destaque e ele atende aos critérios acima, envie uma mensagem para %(mail_featured)s com:"
 
 #: src/olympia/devhub/templates/devhub/docs/policies-recommended.html:62
 msgid "the add-on name, URL, and whether you are its developer"
-msgstr ""
-"o nome do complemento e URL e informando se você é o desenvolvedor do "
-"complemento"
+msgstr "o nome do complemento e URL e informando se você é o desenvolvedor do complemento"
 
 #: src/olympia/devhub/templates/devhub/docs/policies-recommended.html:63
-msgid ""
-"a short explanation of why the add-on has wide appeal and should be featured"
-msgstr ""
-"uma breve explicação de por que o complemento tem grande apelo e deve ser "
-"apresentado"
+msgid "a short explanation of why the add-on has wide appeal and should be featured"
+msgstr "uma breve explicação de por que o complemento tem grande apelo e deve ser apresentado"
 
 #: src/olympia/devhub/templates/devhub/docs/policies-recommended.html:64
-msgid ""
-"optionally, links to any external reviews or articles mentioning the add-on"
-msgstr ""
-"opcionalmente, links para análises externas ou artigos mencionando o "
-"complemento"
+msgid "optionally, links to any external reviews or articles mentioning the add-on"
+msgstr "opcionalmente, links para análises externas ou artigos mencionando o complemento"
 
 #: src/olympia/devhub/templates/devhub/docs/policies-recommended.html:68
 msgid ""
-"Add-on nominations are reviewed by the Advisory Board once a month (once "
-"every 3 months for complete theme nominations). Common reasons for rejection"
-" include lacking wide appeal to consumers, a suboptimal user experience, "
-"quality or security issues, incompatibility, and similarity to another "
-"featured add-on. Rejected add-ons cannot be re-nominated within 3 months."
+"Add-on nominations are reviewed by the Advisory Board once a month (once every 3 months for complete theme nominations). Common reasons for rejection include lacking wide appeal to consumers, a "
+"suboptimal user experience, quality or security issues, incompatibility, and similarity to another featured add-on. Rejected add-ons cannot be re-nominated within 3 months."
 msgstr ""
-"Complementos candidatos são analisadas pelo Conselho Consultivo, uma vez por"
-" mês (uma vez a cada 3 meses para indicações ao tema completo). As razões "
-"mais comuns para a rejeição incluem falta de grande apelo para os "
-"consumidores, uma experiência de usuário de qualidade inferior, problemas de"
-" qualidade ou de segurança, incompatibilidade, e similaridade com outro "
-"complemento em destaque. Complementos rejeitados não podem ser renomeados no"
-" prazo de 3 meses."
+"Complementos candidatos são analisadas pelo Conselho Consultivo, uma vez por mês (uma vez a cada 3 meses para indicações ao tema completo). As razões mais comuns para a rejeição incluem falta de "
+"grande apelo para os consumidores, uma experiência de usuário de qualidade inferior, problemas de qualidade ou de segurança, incompatibilidade, e similaridade com outro complemento em destaque. "
+"Complementos rejeitados não podem ser renomeados no prazo de 3 meses."
 
 #: src/olympia/devhub/templates/devhub/docs/policies-recommended.html:73
 msgid "Rotating Featured Add-ons"
 msgstr "Rotatividade dos complementos em destaque"
 
 #: src/olympia/devhub/templates/devhub/docs/policies-recommended.html:76
-msgid ""
-"Mozilla and the Featured Add-ons Advisory Board regularly evaluate and "
-"rotate out featured add-ons. Some of the most common reasons for add-ons "
-"being removed from the featured list are:"
-msgstr ""
-"A Mozilla e o Conselho de Complementos em Destaque reavaliam e renovam os "
-"complementos em destaque. Algumas das razões mais comuns para um complemento"
-" deixar de estar em destaque são:"
+msgid "Mozilla and the Featured Add-ons Advisory Board regularly evaluate and rotate out featured add-ons. Some of the most common reasons for add-ons being removed from the featured list are:"
+msgstr "A Mozilla e o Conselho de Complementos em Destaque reavaliam e renovam os complementos em destaque. Algumas das razões mais comuns para um complemento deixar de estar em destaque são:"
 
 #: src/olympia/devhub/templates/devhub/docs/policies-recommended.html:83
 msgid ""
-"Lack of growth &mdash; Add-ons that are featured typically experience a "
-"substantial gain in both downloads and active users. If an add-on is not "
-"demonstrating growth in any substantial way, that's a good indicator the "
-"add-on may not be very useful to our users."
+"Lack of growth &mdash; Add-ons that are featured typically experience a substantial gain in both downloads and active users. If an add-on is not demonstrating growth in any substantial way, that's "
+"a good indicator the add-on may not be very useful to our users."
 msgstr ""
-"Pouco crescimento &mdash; Complementos em destaque geralmente apresentam um "
-"grande crescimento no número de downloads e usuários ativos. Se o "
-"complemento não apresentar esse comportamento, provavelmente, não está sendo"
-" muito útil para nossos usuários."
+"Pouco crescimento &mdash; Complementos em destaque geralmente apresentam um grande crescimento no número de downloads e usuários ativos. Se o complemento não apresentar esse comportamento, "
+"provavelmente, não está sendo muito útil para nossos usuários."
 
 #: src/olympia/devhub/templates/devhub/docs/policies-recommended.html:88
-msgid ""
-"Negative reviews &mdash; Featured add-ons should have a great experience and"
-" very few bugs, so add-ons with many negative reviews may be reconsidered."
-msgstr ""
-"Análises negativas &mdash; complementos em destaque devem oferecer uma ótima"
-" experiência e ter poucos bugs, então complementos com análises negativas "
-"devem ser reconsiderados."
+msgid "Negative reviews &mdash; Featured add-ons should have a great experience and very few bugs, so add-ons with many negative reviews may be reconsidered."
+msgstr "Análises negativas &mdash; complementos em destaque devem oferecer uma ótima experiência e ter poucos bugs, então complementos com análises negativas devem ser reconsiderados."
 
 #: src/olympia/devhub/templates/devhub/docs/policies-recommended.html:93
 msgid ""
-"Incompatibility with upcoming Firefox versions &mdash; Featured add-ons are "
-"expected to be compatible with stable and beta versions of Firefox. Add-ons "
-"not yet compatible with a Beta version of Firefox four weeks before its "
-"expected release will lose their featured status."
+"Incompatibility with upcoming Firefox versions &mdash; Featured add-ons are expected to be compatible with stable and beta versions of Firefox. Add-ons not yet compatible with a Beta version of "
+"Firefox four weeks before its expected release will lose their featured status."
 msgstr ""
-"Incompatibilidade com novas versões do Firefox &mdash; espera-se que "
-"complementos em destaque sejam compatíveis com versões estáveis e betas do "
-"Firefox. Complementos que ainda não são compatíveis com uma versão Beta do "
-"Firefox quatro semanas antes da data esperada do seu lançamento perderão seu"
-" status de destaque."
+"Incompatibilidade com novas versões do Firefox &mdash; espera-se que complementos em destaque sejam compatíveis com versões estáveis e betas do Firefox. Complementos que ainda não são compatíveis "
+"com uma versão Beta do Firefox quatro semanas antes da data esperada do seu lançamento perderão seu status de destaque."
 
 #: src/olympia/devhub/templates/devhub/docs/policies-recommended.html:99
 msgid "Joining the Featured Add-ons Advisory Board"
 msgstr "Fazendo parte do Conselho de Complementos em Destaque"
 
 #: src/olympia/devhub/templates/devhub/docs/policies-recommended.html:102
-msgid ""
-"Every six months a new Advisory Board is chosen based on applications from "
-"the add-ons community. Members must:"
-msgstr ""
-"A cada seis meses o Conselho é renovado, sempre com membros da comunidade "
-"Mozilla. Os candidatos devem:"
+msgid "Every six months a new Advisory Board is chosen based on applications from the add-ons community. Members must:"
+msgstr "A cada seis meses o Conselho é renovado, sempre com membros da comunidade Mozilla. Os candidatos devem:"
 
 #: src/olympia/devhub/templates/devhub/docs/policies-recommended.html:108
-msgid ""
-"be active members of the add-ons community, whether as a developer, "
-"evangelist, or fan"
-msgstr ""
-"ser membros ativos da comunidade de complementos, sejam como "
-"desenvolvedores, evangelistas ou fãs"
+msgid "be active members of the add-ons community, whether as a developer, evangelist, or fan"
+msgstr "ser membros ativos da comunidade de complementos, sejam como desenvolvedores, evangelistas ou fãs"
 
 #: src/olympia/devhub/templates/devhub/docs/policies-recommended.html:109
-msgid ""
-"commit to trying all the nominations submitted, giving their feedback, and "
-"casting their votes every month"
-msgstr ""
-"comprometer-se em testar todas as sugestões de complementos, dando sua "
-"opinião e voto, mensalmente"
+msgid "commit to trying all the nominations submitted, giving their feedback, and casting their votes every month"
+msgstr "comprometer-se em testar todas as sugestões de complementos, dando sua opinião e voto, mensalmente"
 
 #: src/olympia/devhub/templates/devhub/docs/policies-recommended.html:110
-msgid ""
-"abstain from voting on add-ons that they have any business or personal "
-"affiliations with, as well as direct competitors of any such add-ons"
-msgstr ""
-"abster-se de votar em complementos com os quais possuam qualquer negócio ou "
-"afiliação pessoal, assim como concorrentes diretos de tais complementos"
+msgid "abstain from voting on add-ons that they have any business or personal affiliations with, as well as direct competitors of any such add-ons"
+msgstr "abster-se de votar em complementos com os quais possuam qualquer negócio ou afiliação pessoal, assim como concorrentes diretos de tais complementos"
 
 #: src/olympia/devhub/templates/devhub/docs/policies-recommended.html:114
 msgid ""
-"Members of the Mozilla Add-ons team may veto any add-on's selection because "
-"of security, privacy, compatibility, or any other reason, but in general it "
-"is up to the Board to select add-ons to feature."
+"Members of the Mozilla Add-ons team may veto any add-on's selection because of security, privacy, compatibility, or any other reason, but in general it is up to the Board to select add-ons to "
+"feature."
 msgstr ""
-"Os membros da equipe do Mozilla Addons podem vetar qualquer complemento "
-"selecionado por problemas de segurança, privacidade, compatibilidade ou "
-"qualquer outra razão, mas em geral cabe ao Conselho selecionar os "
-"complementos."
+"Os membros da equipe do Mozilla Addons podem vetar qualquer complemento selecionado por problemas de segurança, privacidade, compatibilidade ou qualquer outra razão, mas em geral cabe ao Conselho "
+"selecionar os complementos."
 
 #: src/olympia/devhub/templates/devhub/docs/policies-recommended.html:120
 msgid ""
-"This featured policy only applies to the addons.mozilla.org global list of "
-"featured add-ons. Add-ons featured in other locations are often pulled from "
-"this list, but Mozilla may feature any add-on in other locations without the"
-" Board's consent. Additionally, locale-specific features override the global"
-" defaults, so if a locale has opted to select its own features, some or all "
-"of the global features may not appear in that locale."
+"This featured policy only applies to the addons.mozilla.org global list of featured add-ons. Add-ons featured in other locations are often pulled from this list, but Mozilla may feature any add-on "
+"in other locations without the Board's consent. Additionally, locale-specific features override the global defaults, so if a locale has opted to select its own features, some or all of the global "
+"features may not appear in that locale."
 msgstr ""
-"A política de destaques só se aplica ao site addons.mozilla.org. "
-"Complementos em destaque em outros lugares geralmente são obtidos dessa "
-"lista, mas a Mozilla pode colocar qualquer complemento em destaque em outros"
-" locais sem o consentimento do Conselho. Além disso, complementos para "
-"regiões específicas sobrepõem-se sobre os destaques mundiais, então, se uma "
-"região optar por seus próprios complementos em destaque, alguns ou todos os "
-"destaques globais podem não aparecer nessa região."
+"A política de destaques só se aplica ao site addons.mozilla.org. Complementos em destaque em outros lugares geralmente são obtidos dessa lista, mas a Mozilla pode colocar qualquer complemento em "
+"destaque em outros locais sem o consentimento do Conselho. Além disso, complementos para regiões específicas sobrepõem-se sobre os destaques mundiais, então, se uma região optar por seus próprios "
+"complementos em destaque, alguns ou todos os destaques globais podem não aparecer nessa região."
 
 #: src/olympia/devhub/templates/devhub/docs/policies-recommended.html:126
 #, python-format
-msgid ""
-"Follow the <a href=\"%(link_blog)s\">Add-ons Blog</a> or <a "
-"href=\"%(link_twitter)s\">@mozamo</a> on Twitter to learn when the next "
-"application period opens."
-msgstr ""
-"Siga o <a href=\"%(link_blog)s\">Blog de Complementos</a> ou a <a "
-"href=\"%(link_twitter)s\">@mozamo</a> no Twitter e saiba quando novas "
-"eleições foram abertas."
+msgid "Follow the <a href=\"%(link_blog)s\">Add-ons Blog</a> or <a href=\"%(link_twitter)s\">@mozamo</a> on Twitter to learn when the next application period opens."
+msgstr "Siga o <a href=\"%(link_blog)s\">Blog de Complementos</a> ou a <a href=\"%(link_twitter)s\">@mozamo</a> no Twitter e saiba quando novas eleições foram abertas."
 
 #: src/olympia/devhub/templates/devhub/docs/policies-recommended.html:131
 msgid "Last updated: January 31, 2013"
 msgstr "Atualizado em 31 de Janeiro de 2013"
 
-#: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:3
-#: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:7
-#: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:8
-#: src/olympia/devhub/templates/devhub/docs/policies.html:15
-#: src/olympia/devhub/templates/devhub/docs/policies.html:64
+#: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:3 src/olympia/devhub/templates/devhub/docs/policies-reviews.html:7 src/olympia/devhub/templates/devhub/docs/policies-reviews.html:8
+#: src/olympia/devhub/templates/devhub/docs/policies.html:15 src/olympia/devhub/templates/devhub/docs/policies.html:64
 msgid "Review Process"
 msgstr "Processo de revisão"
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:12
 msgid ""
-"In order to ensure all add-ons hosted in our gallery are safe for users to "
-"install, Mozilla will begin requiring all hosted add-ons to undergo review. "
-"We offer two types of review and developers are free to choose the best fit "
-"for their add-on."
+"In order to ensure all add-ons hosted in our gallery are safe for users to install, Mozilla will begin requiring all hosted add-ons to undergo review. We offer two types of review and developers "
+"are free to choose the best fit for their add-on."
 msgstr ""
-"A fim de garantir que todos os complementos hospedados em nossa galeria são "
-"seguros para os usuários, a Mozilla passará a exigir que todos os "
-"complementos sejam submetidos a uma análise. Nós oferecemos dois tipos de "
-"análise para que os desenvolvedores possam escolher o mais adequado ao seu "
-"complemento."
+"A fim de garantir que todos os complementos hospedados em nossa galeria são seguros para os usuários, a Mozilla passará a exigir que todos os complementos sejam submetidos a uma análise. Nós "
+"oferecemos dois tipos de análise para que os desenvolvedores possam escolher o mais adequado ao seu complemento."
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:19
 msgid ""
-"<strong><a href=\"#full\">Full Review</a></strong> &mdash; a thorough "
-"functional and code review of the add-on, appropriate for add-ons ready for "
-"distribution to the masses. All site features are available to these add-"
-"ons."
+"<strong><a href=\"#full\">Full Review</a></strong> &mdash; a thorough functional and code review of the add-on, appropriate for add-ons ready for distribution to the masses. All site features are "
+"available to these add-ons."
 msgstr ""
-"<strong><a href=\"#full\">Análise completa</a></strong> &mdash; uma análise "
-"completa do código-fonte e funcionalidades do complemento, adequada para "
-"complementos prontos para a distribuição em massa. Todos os recursos do site"
-" estão disponíveis para esses complementos."
+"<strong><a href=\"#full\">Análise completa</a></strong> &mdash; uma análise completa do código-fonte e funcionalidades do complemento, adequada para complementos prontos para a distribuição em "
+"massa. Todos os recursos do site estão disponíveis para esses complementos."
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:24
 msgid ""
-"<strong><a href=\"#preliminary\">Preliminary Review</a></strong> &mdash; a "
-"faster review intended for experimental add-ons. Preliminary reviews do not "
-"check for functionality or full policy compliance, but the reviewed add-ons "
-"have install button cautions and some feature limitations."
+"<strong><a href=\"#preliminary\">Preliminary Review</a></strong> &mdash; a faster review intended for experimental add-ons. Preliminary reviews do not check for functionality or full policy "
+"compliance, but the reviewed add-ons have install button cautions and some feature limitations."
 msgstr ""
-"<strong><a href=\"#preliminary\">Análise preliminar</a></strong> &mdash; uma"
-" análise mais rápida destinada a complementos experimentais. Análises "
-"preliminares não verificam funcionalidades ou o cumprimento pleno de nossas "
-"políticas, mas os complementos analisados dessa forma exibem alertas na hora"
-" de sua instalação e possuem limites nos recursos disponíveis no site."
+"<strong><a href=\"#preliminary\">Análise preliminar</a></strong> &mdash; uma análise mais rápida destinada a complementos experimentais. Análises preliminares não verificam funcionalidades ou o "
+"cumprimento pleno de nossas políticas, mas os complementos analisados dessa forma exibem alertas na hora de sua instalação e possuem limites nos recursos disponíveis no site."
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:31
 msgid ""
-"Detailed descriptions of each option are below. After selecting a review "
-"process at submission, the add-on will be placed in the queue. Add-ons are "
-"reviewed by the <a href=\"https://wiki.mozilla.org/AMO:Editors\">AMO "
-"Editors</a>, a group of talented developers that volunteer to help the "
-"Mozilla project by reviewing add-ons to ensure a stable and safe experience "
-"for users. Developers will receive an email with any updates throughout the "
-"review process."
+"Detailed descriptions of each option are below. After selecting a review process at submission, the add-on will be placed in the queue. Add-ons are reviewed by the <a href=\"https://wiki.mozilla."
+"org/AMO:Editors\">AMO Editors</a>, a group of talented developers that volunteer to help the Mozilla project by reviewing add-ons to ensure a stable and safe experience for users. Developers will "
+"receive an email with any updates throughout the review process."
 msgstr ""
-"Estão disponíveis descrições detalhadas de cada opção abaixo. Após escolher "
-"um processo de revisão na submissão, o complemento será colocado na fila de "
-"revisão. Os complementos são analisados pelos <a "
-"href=\"https://wiki.mozilla.org/AMO:Editors\">editores do AMO</a>, um grupo "
-"de desenvolvedores talentosos que são voluntários no projeto Mozilla "
-"analisando os complementos para garantir uma experiência estável e segura "
-"para os usuários. Os desenvolvedores receberão uma mensagem com quaisquer "
-"atualizações durante o processo de revisão."
+"Estão disponíveis descrições detalhadas de cada opção abaixo. Após escolher um processo de revisão na submissão, o complemento será colocado na fila de revisão. Os complementos são analisados pelos "
+"<a href=\"https://wiki.mozilla.org/AMO:Editors\">editores do AMO</a>, um grupo de desenvolvedores talentosos que são voluntários no projeto Mozilla analisando os complementos para garantir uma "
+"experiência estável e segura para os usuários. Os desenvolvedores receberão uma mensagem com quaisquer atualizações durante o processo de revisão."
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:37
 msgid ""
-"While waiting for review, add-ons will not appear anywhere in the gallery "
-"publicly, but direct links to the add-on's details page will work. This "
-"allows the author to blog or share the link with friends, inviting them to "
-"try it out, even when not yet reviewed."
+"While waiting for review, add-ons will not appear anywhere in the gallery publicly, but direct links to the add-on's details page will work. This allows the author to blog or share the link with "
+"friends, inviting them to try it out, even when not yet reviewed."
 msgstr ""
-"Enquanto aguarda sua análise, um complemento não aparecerá publicamente em "
-"qualquer lugar da galeria, mas estará disponível na sua página de detalhes. "
-"Isso permite que um autor compartilhem o link e convide amigos para testar "
-"seu complemento, mesmo que ele ainda não tenha sido analisado."
+"Enquanto aguarda sua análise, um complemento não aparecerá publicamente em qualquer lugar da galeria, mas estará disponível na sua página de detalhes. Isso permite que um autor compartilhem o link "
+"e convide amigos para testar seu complemento, mesmo que ele ainda não tenha sido analisado."
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:44
 msgid ""
-"Full reviews are appropriate for add-ons that are well-tested, stable, fast,"
-" and have wide appeal to our users. If you aren't confident that your add-on"
-" meets that criteria, please consider working out the kinks while in "
-"preliminary review and accumulating user feedback first."
+"Full reviews are appropriate for add-ons that are well-tested, stable, fast, and have wide appeal to our users. If you aren't confident that your add-on meets that criteria, please consider working "
+"out the kinks while in preliminary review and accumulating user feedback first."
 msgstr ""
-"Análises completas são adequadas para complementos bem testados, estáveis, "
-"rápidos e que possuem um grande apelo aos nossos usuários. Se você não tem "
-"certeza se seu complemento atende a esses critérios, considere trabalhar com"
-" menos recursos com a análise preliminar e obter opiniões de seus usuários "
-"antes."
+"Análises completas são adequadas para complementos bem testados, estáveis, rápidos e que possuem um grande apelo aos nossos usuários. Se você não tem certeza se seu complemento atende a esses "
+"critérios, considere trabalhar com menos recursos com a análise preliminar e obter opiniões de seus usuários antes."
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:50
-msgid ""
-"We aim to perform full reviews in under 10 days, though most add-ons are "
-"reviewed in much less time."
-msgstr ""
-"Nossa meta é realizar análises completas em até 10 dias, embora a maioria "
-"dos complementos seja analisada em muito menos tempo."
+msgid "We aim to perform full reviews in under 10 days, though most add-ons are reviewed in much less time."
+msgstr "Nossa meta é realizar análises completas em até 10 dias, embora a maioria dos complementos seja analisada em muito menos tempo."
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:55
 msgid "Testing Methods &amp; Common Issues"
@@ -7343,62 +5803,36 @@ msgid "When performing a full review, editors will:"
 msgstr "Ao realizar uma análise completa, os editores irão:"
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:64
-msgid ""
-"install the add-on, making sure it functions as described and is free of "
-"major defects"
-msgstr ""
-"instalar o complemento, certificando-se de que ele funciona como descrito e "
-"não possui defeitos graves"
+msgid "install the add-on, making sure it functions as described and is free of major defects"
+msgstr "instalar o complemento, certificando-se de que ele funciona como descrito e não possui defeitos graves"
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:69
-msgid ""
-"perform a source code review, looking for performance and security best "
-"practices"
-msgstr ""
-"realizar uma análise do código-fonte, buscando as boas práticas de "
-"desempenho e segurança"
+msgid "perform a source code review, looking for performance and security best practices"
+msgstr "realizar uma análise do código-fonte, buscando as boas práticas de desempenho e segurança"
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:74
 msgid "ensure the add-on's privacy policy is in line with its functionality"
-msgstr ""
-"assegurar-se de que a política de privacidade do complemento está em "
-"sintonia com a sua funcionalidade"
+msgstr "assegurar-se de que a política de privacidade do complemento está em sintonia com a sua funcionalidade"
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:79
-msgid ""
-"look for compliance with all of Mozilla's policies, detailed in these "
-"documents"
-msgstr ""
-"verificar o cumprimento de todas as políticas Mozilla, detalhadas nestes "
-"documentos"
+msgid "look for compliance with all of Mozilla's policies, detailed in these documents"
+msgstr "verificar o cumprimento de todas as políticas Mozilla, detalhadas nestes documentos"
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:86
-msgid ""
-"Some of the most common issues we see when performing these reviews are:"
-msgstr ""
-"Alguns dos problemas mais comuns que encontramos ao realizar essas análises "
-"são:"
+msgid "Some of the most common issues we see when performing these reviews are:"
+msgstr "Alguns dos problemas mais comuns que encontramos ao realizar essas análises são:"
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:93
 msgid ""
-"<strong>JavaScript namespace pollution</strong> &mdash; the most common "
-"violation. Be sure to <a "
-"href=\"https://developer.mozilla.org/en/XUL_School/JavaScript_Object_Management\">wrap"
-" your loose variables</a>"
+"<strong>JavaScript namespace pollution</strong> &mdash; the most common violation. Be sure to <a href=\"https://developer.mozilla.org/en/XUL_School/JavaScript_Object_Management\">wrap your loose "
+"variables</a>"
 msgstr ""
-"<strong>poluição do namespace JavaScript</strong> &mdash; a violação mais "
-"comum. Lembre-se de <a "
-"href=\"https://developer.mozilla.org/en/XUL_School/JavaScript_Object_Management\">encapsular"
-" suas variáveis perdidas</a>"
+"<strong>poluição do namespace JavaScript</strong> &mdash; a violação mais comum. Lembre-se de <a href=\"https://developer.mozilla.org/en/XUL_School/JavaScript_Object_Management\">encapsular suas "
+"variáveis perdidas</a>"
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:99
-msgid ""
-"proper preference naming - all preference names should begin with "
-"\"extensions.\", followed by the add-on name or some other unique identifier"
-msgstr ""
-"nomeação inadequada de preferências &mdash; todas as preferências devem "
-"começar com \"extensions.\", seguida pelo nome do complemento ou algum outro"
-" identificador exclusivo"
+msgid "proper preference naming - all preference names should begin with \"extensions.\", followed by the add-on name or some other unique identifier"
+msgstr "nomeação inadequada de preferências &mdash; todas as preferências devem começar com \"extensions.\", seguida pelo nome do complemento ou algum outro identificador exclusivo"
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:103
 msgid "remote JavaScript execution or injection"
@@ -7438,107 +5872,70 @@ msgstr "possíveis conflitos com outros complementos"
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:113
 msgid "application start-up or page load performance degradation"
-msgstr ""
-"impacto negativo no desempenho ao iniciar a aplicação ou carregar conteúdo"
+msgstr "impacto negativo no desempenho ao iniciar a aplicação ou carregar conteúdo"
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:117
 #, python-format
 msgid ""
-"For information on how to avoid these problems, please see our <a "
-"href=\"%(link_howto)s\">How-to Library</a>. Some of these practices, such as"
-" binary or obfuscated code, are allowed under certain conditions outlined "
-"below."
+"For information on how to avoid these problems, please see our <a href=\"%(link_howto)s\">How-to Library</a>. Some of these practices, such as binary or obfuscated code, are allowed under certain "
+"conditions outlined below."
 msgstr ""
-"Para mais informações sobre como evitar esses problemas, leia a nossa <a "
-"href=\"%(link_howto)s\">Biblioteca de tutoriais</a>. Algumas dessas "
-"práticas, como código binário ou ofuscado, são permitidas sob certas "
-"condições destacadas abaixo."
+"Para mais informações sobre como evitar esses problemas, leia a nossa <a href=\"%(link_howto)s\">Biblioteca de tutoriais</a>. Algumas dessas práticas, como código binário ou ofuscado, são "
+"permitidas sob certas condições destacadas abaixo."
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:123
 #, python-format
 msgid ""
-"Many of the above restrictions are tested automatically by an extension "
-"scanner that will flag suspicious add-ons for editor review. You can read "
-"more about this scanner in the <a href=\"%(link_validation)s\">Validation "
-"Help</a> document."
+"Many of the above restrictions are tested automatically by an extension scanner that will flag suspicious add-ons for editor review. You can read more about this scanner in the <a href="
+"\"%(link_validation)s\">Validation Help</a> document."
 msgstr ""
-"Muitas das restrições acima são testadas automaticamente por um script que "
-"sinalizará complementos suspeitos para uma análise de um editor. Você pode "
-"ler mais sobre esse script na documentação de <a "
-"href=\"%(link_validation)s\">Ajuda da validação</a>."
+"Muitas das restrições acima são testadas automaticamente por um script que sinalizará complementos suspeitos para uma análise de um editor. Você pode ler mais sobre esse script na documentação de "
+"<a href=\"%(link_validation)s\">Ajuda da validação</a>."
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:129
 msgid ""
-"If the add-on is site-specific, it is recommended that a test account is "
-"provided for use during the review process. Additionally, including detailed"
-" testing instructions will allow an editor to better understand how the add-"
-"on functions and expedite the testing process. This information can be "
-"placed in the Notes to Reviewer field when editing a version in the "
-"Developer Hub."
+"If the add-on is site-specific, it is recommended that a test account is provided for use during the review process. Additionally, including detailed testing instructions will allow an editor to "
+"better understand how the add-on functions and expedite the testing process. This information can be placed in the Notes to Reviewer field when editing a version in the Developer Hub."
 msgstr ""
-"Se o complemento funcionar com um site específico, é recomendado que uma "
-"conta de testes seja fornecida para uso durante o processo de análise. "
-"Adicionalmente, a inclusão de instruções detalhadas de teste permitirão que "
-"o Editor entenda melhor como o complemento funciona e agilizarão o processo "
-"de testes. Essas informações podem ser incluídas no campo Comentários ao "
-"editor ao editar uma versão na Central de Desenvolvedores."
+"Se o complemento funcionar com um site específico, é recomendado que uma conta de testes seja fornecida para uso durante o processo de análise. Adicionalmente, a inclusão de instruções detalhadas "
+"de teste permitirão que o Editor entenda melhor como o complemento funciona e agilizarão o processo de testes. Essas informações podem ser incluídas no campo Comentários ao editor ao editar uma "
+"versão na Central de Desenvolvedores."
 
-#: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:134
-#: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:168
+#: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:134 src/olympia/devhub/templates/devhub/docs/policies-reviews.html:168
 msgid "After the Review"
 msgstr "Após a análise"
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:136
 msgid ""
-"Once an add-on is granted full review, it will immediately be available in "
-"the gallery, showing in browse and search results with a warning-free "
-"install button. All features, including voluntary contributions and beta "
-"channels will be available."
+"Once an add-on is granted full review, it will immediately be available in the gallery, showing in browse and search results with a warning-free install button. All features, including voluntary "
+"contributions and beta channels will be available."
 msgstr ""
-"Assim que o complemento for aprovado na análise completa, ele será "
-"disponibilizado na galeria, sendo exibido na navegação e resultados de "
-"pesquisa sem alertas ao ser instalado. Todos os recursos, incluindo doações "
-"voluntárias e canais beta, estarão disponíveis."
+"Assim que o complemento for aprovado na análise completa, ele será disponibilizado na galeria, sendo exibido na navegação e resultados de pesquisa sem alertas ao ser instalado. Todos os recursos, "
+"incluindo doações voluntárias e canais beta, estarão disponíveis."
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:142
 msgid ""
-"Subsequent versions of the add-on will automatically be placed in the full "
-"review queue. Until the review is completed, the new version will only be "
-"displayed on the Version History page of the add-on. Once reviewed, the "
-"version will be updated across the site and deployed through the automatic "
-"update service."
+"Subsequent versions of the add-on will automatically be placed in the full review queue. Until the review is completed, the new version will only be displayed on the Version History page of the add-"
+"on. Once reviewed, the version will be updated across the site and deployed through the automatic update service."
 msgstr ""
-"Versões posteriores do complemento serão posicionadas automaticamente na "
-"fila de espera de análises completas. Até que a análise seja completada, a "
-"nova versão será exibida somente no histórico de versões do complemento. "
-"Assim que for analisada, a versão será atualizada no site e distribuída pelo"
-" serviço de atualizações automáticas."
+"Versões posteriores do complemento serão posicionadas automaticamente na fila de espera de análises completas. Até que a análise seja completada, a nova versão será exibida somente no histórico de "
+"versões do complemento. Assim que for analisada, a versão será atualizada no site e distribuída pelo serviço de atualizações automáticas."
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:148
 msgid ""
-"If a version does not meet the criteria for full review, it can either be "
-"granted preliminary review or disabled if there is a security concern. The "
-"author will receive an email explaining the action taken and how to fix it. "
-"In most cases, the developer can simply fix the problem and re-submit for "
-"full review."
+"If a version does not meet the criteria for full review, it can either be granted preliminary review or disabled if there is a security concern. The author will receive an email explaining the "
+"action taken and how to fix it. In most cases, the developer can simply fix the problem and re-submit for full review."
 msgstr ""
-"Se uma versão não satisfaz os critérios da análise completa, ela poderá "
-"obter o status de análise preliminar ou ser desabilitada, caso haja "
-"preocupações com a segurança do usuário. O autor receberá uma mensagem "
-"explicando a ação tomada e como corrigi-la. Na maioria dos casos, o "
-"desenvolvedor pode simplesmente corrigir o problema e reenviar a versão para"
-" uma nova análise completa."
+"Se uma versão não satisfaz os critérios da análise completa, ela poderá obter o status de análise preliminar ou ser desabilitada, caso haja preocupações com a segurança do usuário. O autor receberá "
+"uma mensagem explicando a ação tomada e como corrigi-la. Na maioria dos casos, o desenvolvedor pode simplesmente corrigir o problema e reenviar a versão para uma nova análise completa."
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:155
 msgid ""
-"Preliminary reviews are appropriate for experimental add-ons and provide a "
-"way to get user testing and feedback without going through the longer, more "
-"thorough review process. We aim to complete these reviews in under 3 days."
+"Preliminary reviews are appropriate for experimental add-ons and provide a way to get user testing and feedback without going through the longer, more thorough review process. We aim to complete "
+"these reviews in under 3 days."
 msgstr ""
-"Análises preliminares são adequadas para complementos experimentais e "
-"oferecem uma maneira para usuários testarem e mandarem suas opiniões sem "
-"passar pelo processo de análise mais longo e detalhado. Nossa meta é "
-"completar essas análises em até 3 dias."
+"Análises preliminares são adequadas para complementos experimentais e oferecem uma maneira para usuários testarem e mandarem suas opiniões sem passar pelo processo de análise mais longo e "
+"detalhado. Nossa meta é completar essas análises em até 3 dias."
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:160
 msgid "Testing Methods"
@@ -7546,57 +5943,33 @@ msgstr "Métodos de teste"
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:162
 msgid ""
-"When performing a preliminary review, editors will review the source code "
-"for security issues and major policy violations, but will not install the "
-"add-on to test functionality in most cases. Preliminary review will be "
-"granted unless a security vulnerability or major policy violation is "
-"discovered."
+"When performing a preliminary review, editors will review the source code for security issues and major policy violations, but will not install the add-on to test functionality in most cases. "
+"Preliminary review will be granted unless a security vulnerability or major policy violation is discovered."
 msgstr ""
-"Ao realizar uma análise preliminar, os editores analisarão o código-fonte "
-"buscando problemas de segurança e violações graves das nossas políticas, mas"
-" não instalarão o complemento na maioria dos casos. Análises preliminares "
-"serão aprovadas a menos que uma vulnerabilidade de segurança ou violação "
-"grave de nossas políticas sejam encontradas."
+"Ao realizar uma análise preliminar, os editores analisarão o código-fonte buscando problemas de segurança e violações graves das nossas políticas, mas não instalarão o complemento na maioria dos "
+"casos. Análises preliminares serão aprovadas a menos que uma vulnerabilidade de segurança ou violação grave de nossas políticas sejam encontradas."
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:171
 msgid ""
-"Once preliminary review is granted, the add-on will be immediately available"
-" in the gallery, showing in browse and search results but ranked lower than "
-"fully-reviewed add-ons. Install buttons will have caution stripes and a "
-"notice that the add-on is experimental and not fully reviewed by Mozilla, "
-"though no click-through is required. Additionally, these add-ons cannot use "
-"the voluntary contributions and beta channel features."
+"Once preliminary review is granted, the add-on will be immediately available in the gallery, showing in browse and search results but ranked lower than fully-reviewed add-ons. Install buttons will "
+"have caution stripes and a notice that the add-on is experimental and not fully reviewed by Mozilla, though no click-through is required. Additionally, these add-ons cannot use the voluntary "
+"contributions and beta channel features."
 msgstr ""
-"Assim que o complemento for aprovado na análise preliminar, ele será "
-"disponibilizado na galeria, sendo exibido na navegação e resultados de "
-"pesquisa, porém em posições posteriores aos complementos com análise "
-"completa. Seu botão de instalação exibirá listras de alerta e uma "
-"notificação informando que o complemento é experimental e não foi "
-"completamente analisado pela Mozilla. Além disso, esses complementos não "
-"podem receber doações voluntárias ou usar canais beta."
+"Assim que o complemento for aprovado na análise preliminar, ele será disponibilizado na galeria, sendo exibido na navegação e resultados de pesquisa, porém em posições posteriores aos complementos "
+"com análise completa. Seu botão de instalação exibirá listras de alerta e uma notificação informando que o complemento é experimental e não foi completamente analisado pela Mozilla. Além disso, "
+"esses complementos não podem receber doações voluntárias ou usar canais beta."
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:177
-msgid ""
-"After being granted preliminary review, Mozilla may later revoke the review "
-"if other serious problems are reported to us by users."
-msgstr ""
-"Após aprovar a análise preliminar, a Mozilla poderá revogar a análise "
-"posteriormente caso algum problema sério seja relatado para nós pelos "
-"usuários."
+msgid "After being granted preliminary review, Mozilla may later revoke the review if other serious problems are reported to us by users."
+msgstr "Após aprovar a análise preliminar, a Mozilla poderá revogar a análise posteriormente caso algum problema sério seja relatado para nós pelos usuários."
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:183
 msgid ""
-"Subsequent versions of the add-on will automatically be placed in the "
-"preliminary review queue. Until the review is completed, the new version "
-"will only be displayed on the Version History page of the add-on. Once "
-"reviewed, the version will be updated across the site and deployed through "
-"the automatic update service."
+"Subsequent versions of the add-on will automatically be placed in the preliminary review queue. Until the review is completed, the new version will only be displayed on the Version History page of "
+"the add-on. Once reviewed, the version will be updated across the site and deployed through the automatic update service."
 msgstr ""
-"Versões posteriores do complemento serão posicionadas automaticamente na "
-"fila de espera de análises preliminares. Até que a análise seja completada, "
-"a nova versão será exibida somente no histórico de versões do complemento. "
-"Assim que for analisada, a versão será atualizada no site e distribuída pelo"
-" serviço de atualizações automáticas."
+"Versões posteriores do complemento serão posicionadas automaticamente na fila de espera de análises preliminares. Até que a análise seja completada, a nova versão será exibida somente no histórico "
+"de versões do complemento. Assim que for analisada, a versão será atualizada no site e distribuída pelo serviço de atualizações automáticas."
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:188
 msgid "Policies on Specific Add-on Practices"
@@ -7611,69 +5984,40 @@ msgid "The following add-ons are not permitted in any form:"
 msgstr "Os seguintes complementos não são permitidos de maneira nenhuma:"
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:194
-msgid ""
-"Add-ons that embed known <a "
-"href=\"http://en.wikipedia.org/wiki/Spyware\">spyware</a> or <a "
-"href=\"http://en.wikipedia.org/wiki/Malware\">malware</a>"
-msgstr ""
-"Complementos que carregam <a "
-"href=\"http://pt.wikipedia.org/wiki/Spyware\">spyware</a> ou <a "
-"href=\"http://pt.wikipedia.org/wiki/Malware\">malware</a> conhecidos"
+msgid "Add-ons that embed known <a href=\"http://en.wikipedia.org/wiki/Spyware\">spyware</a> or <a href=\"http://en.wikipedia.org/wiki/Malware\">malware</a>"
+msgstr "Complementos que carregam <a href=\"http://pt.wikipedia.org/wiki/Spyware\">spyware</a> ou <a href=\"http://pt.wikipedia.org/wiki/Malware\">malware</a> conhecidos"
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:199
 msgid ""
-"Illegal and criminal add-ons, such as <a "
-"href=\"http://en.wikipedia.org/wiki/Click_fraud\">click fraud</a> "
-"generators, <a href=\"http://en.wikipedia.org/wiki/Warez\">warez</a> "
-"download and directory assistants, child pornography finders, etc."
+"Illegal and criminal add-ons, such as <a href=\"http://en.wikipedia.org/wiki/Click_fraud\">click fraud</a> generators, <a href=\"http://en.wikipedia.org/wiki/Warez\">warez</a> download and "
+"directory assistants, child pornography finders, etc."
 msgstr ""
-"Complementos ilegais e criminosos, como <a "
-"href=\"http://en.wikipedia.org/wiki/Click_fraud\">geradores de cliques "
-"falsos</a>, assistentes de download de <a "
-"href=\"http://pt.wikipedia.org/wiki/Warez\">warez</a>, localizadores de "
-"pornografia infantil, etc."
+"Complementos ilegais e criminosos, como <a href=\"http://en.wikipedia.org/wiki/Click_fraud\">geradores de cliques falsos</a>, assistentes de download de <a href=\"http://pt.wikipedia.org/wiki/Warez"
+"\">warez</a>, localizadores de pornografia infantil, etc."
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:204
-msgid ""
-"Add-ons whose main purpose is to facilitate access to pornographic material,"
-" or include references to this material in their descriptions"
-msgstr ""
-"Complementos com o objetivo de facilitar o acesso a material pornográfico ou"
-" que incluam referências a esses materiais em suas descrições"
+msgid "Add-ons whose main purpose is to facilitate access to pornographic material, or include references to this material in their descriptions"
+msgstr "Complementos com o objetivo de facilitar o acesso a material pornográfico ou que incluam referências a esses materiais em suas descrições"
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:210
-msgid ""
-"Add-ons that, upon installation, auto-install or launch installers of non-"
-"Firefox software"
-msgstr ""
-"Complementos que, após sua instalação, instalam automaticamente ou carregam "
-"instaladores de softwares não relacionados ao Firefox"
+msgid "Add-ons that, upon installation, auto-install or launch installers of non-Firefox software"
+msgstr "Complementos que, após sua instalação, instalam automaticamente ou carregam instaladores de softwares não relacionados ao Firefox"
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:215
-msgid ""
-"Add-ons that provide their own update mechanism for code or search engines"
-msgstr ""
-"Complementos que forneçam seu próprio serviço de atualização de código ou "
-"mecanismos de pesquisa"
+msgid "Add-ons that provide their own update mechanism for code or search engines"
+msgstr "Complementos que forneçam seu próprio serviço de atualização de código ou mecanismos de pesquisa"
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:220
-msgid ""
-"Add-ons that make changes to web content in ways that are non-obvious or "
-"difficult to trace by their users"
-msgstr ""
-"Complementos que façam alterações no conteúdo da internet de maneira pouco "
-"óbvia ou difícil de detectar pelos usuários"
+msgid "Add-ons that make changes to web content in ways that are non-obvious or difficult to trace by their users"
+msgstr "Complementos que façam alterações no conteúdo da internet de maneira pouco óbvia ou difícil de detectar pelos usuários"
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:225
 msgid "Add-ons that snoop on or intercept the network traffic of other users"
-msgstr ""
-"Complementos que espionam ou interceptam o tráfego da rede de outros "
-"usuários"
+msgstr "Complementos que espionam ou interceptam o tráfego da rede de outros usuários"
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:230
 msgid "Conduit-based toolbars without explicit pre-approval"
-msgstr ""
-"Barras de ferramentas baseadas no Conduit sem aprovação prévia explícita"
+msgstr "Barras de ferramentas baseadas no Conduit sem aprovação prévia explícita"
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:236
 msgid "Changing of Defaults and Unexpected Features"
@@ -7681,69 +6025,37 @@ msgstr "Alterações de padrões e funcionalidades inesperadas"
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:238
 msgid ""
-"Surprises can be appropriate in many situations, but they are not welcome "
-"when user security, privacy, and control are at stake. It is extremely "
-"important to be as transparent as possible when submitting an add-on for "
-"hosting on this site. A Mozilla user should be able to easily discern what "
-"the functionality of an add-on is and not be presented with unexpected "
-"experiences post-install."
+"Surprises can be appropriate in many situations, but they are not welcome when user security, privacy, and control are at stake. It is extremely important to be as transparent as possible when "
+"submitting an add-on for hosting on this site. A Mozilla user should be able to easily discern what the functionality of an add-on is and not be presented with unexpected experiences post-install."
 msgstr ""
-"Surpresas podem ser agradáveis em muitas situações, mas elas não são bem-"
-"vindas quando se trata do controle, segurança e privacidade dos usuários. É "
-"extremamente importante ser o mais transparente possível ao enviar um "
-"complemento para ser hospedado neste site. Um usuário da Mozilla deve ser "
-"capaz de discernir facilmente qual é função do complemento e não deve "
-"enfrentar experiências inesperadas após instalar um complemento."
+"Surpresas podem ser agradáveis em muitas situações, mas elas não são bem-vindas quando se trata do controle, segurança e privacidade dos usuários. É extremamente importante ser o mais transparente "
+"possível ao enviar um complemento para ser hospedado neste site. Um usuário da Mozilla deve ser capaz de discernir facilmente qual é função do complemento e não deve enfrentar experiências "
+"inesperadas após instalar um complemento."
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:243
 msgid ""
-"<p> Whenever an add-on includes any unexpected* feature that </p> <ul> "
-"<li>compromises user privacy or security (like sending data to third "
-"parties),</li> <li>changes default settings like the homepage or search "
-"engine, or</li> <li>changes settings or features in other add-ons or "
-"deactivates them altogether</li> </ul> <p>the features must adhere to the "
-"following requirements:</p> <ul> <li>The add-on description must clearly "
-"state what changes the add-on makes.</li> <li>All changes must be opt-in, "
-"meaning the user must take non-default action to enact the change.</li> "
-"<li>The opt-in dialog must clearly state the name of the add-on requesting "
-"the change.</li> <li>Uninstalling the add-on restores the user's original "
-"settings if they were changed.</li> </ul> <p>*Unexpected features are those "
-"that are unrelated to the add-on's primary function.</p>"
+"<p> Whenever an add-on includes any unexpected* feature that </p> <ul> <li>compromises user privacy or security (like sending data to third parties),</li> <li>changes default settings like the "
+"homepage or search engine, or</li> <li>changes settings or features in other add-ons or deactivates them altogether</li> </ul> <p>the features must adhere to the following requirements:</p> <ul> "
+"<li>The add-on description must clearly state what changes the add-on makes.</li> <li>All changes must be opt-in, meaning the user must take non-default action to enact the change.</li> <li>The opt-"
+"in dialog must clearly state the name of the add-on requesting the change.</li> <li>Uninstalling the add-on restores the user's original settings if they were changed.</li> </ul> <p>*Unexpected "
+"features are those that are unrelated to the add-on's primary function.</p>"
 msgstr ""
-"<p> Sempre que um complemento incluir um recurso inesperado* que </p> <ul> "
-"<li>afeta a privacidade ou segurança do usuário (enviando dados para "
-"terceiros, por exemplo),</li> <li>altera configurações padrão como a página "
-"inicial ou mecanismo de pesquisa ou</li> <li>altera configurações e "
-"funcionalidades de outros complementos ou os desativa completamente,</li> "
-"</ul> <p>esse recurso deve atender aos seguintes requisitos:</p> <ul> <li>A "
-"descrição do complemento deve listar claramente quais alterações serão "
-"feitas pelo complemento.</li> <li>Todas as alterações deverão ser <em>opt-"
-"in</em>, ou seja, o usuário deve ativar ou solicitar as alterações "
-"manualmente, sem nenhuma alteração automática.</li> <li>O diálogo de "
-"ativação deve deixar claro qual complemento está solicitando as "
-"alterações.</li> <li>A desinstalação do complemento deverá restaurar as "
-"configurações originais do usuário caso elas tenham sido alteradas.</li> "
-"</ul> <p>* Recursos inesperados são aqueles que não estão relacionados à "
-"função primária do complemento.</p>"
+"<p> Sempre que um complemento incluir um recurso inesperado* que </p> <ul> <li>afeta a privacidade ou segurança do usuário (enviando dados para terceiros, por exemplo),</li> <li>altera "
+"configurações padrão como a página inicial ou mecanismo de pesquisa ou</li> <li>altera configurações e funcionalidades de outros complementos ou os desativa completamente,</li> </ul> <p>esse "
+"recurso deve atender aos seguintes requisitos:</p> <ul> <li>A descrição do complemento deve listar claramente quais alterações serão feitas pelo complemento.</li> <li>Todas as alterações deverão "
+"ser <em>opt-in</em>, ou seja, o usuário deve ativar ou solicitar as alterações manualmente, sem nenhuma alteração automática.</li> <li>O diálogo de ativação deve deixar claro qual complemento está "
+"solicitando as alterações.</li> <li>A desinstalação do complemento deverá restaurar as configurações originais do usuário caso elas tenham sido alteradas.</li> </ul> <p>* Recursos inesperados são "
+"aqueles que não estão relacionados à função primária do complemento.</p>"
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:268
-msgid ""
-"These features cannot be introduced into an update of a fully-reviewed add-"
-"on; the opt-in change process must be part of the initial review."
-msgstr ""
-"Esses recursos não podem ser inseridos em uma atualização de um complemento "
-"com análise completa; o processo de ativação de recursos opt-in deve fazer "
-"parte a análise inicial."
+msgid "These features cannot be introduced into an update of a fully-reviewed add-on; the opt-in change process must be part of the initial review."
+msgstr "Esses recursos não podem ser inseridos em uma atualização de um complemento com análise completa; o processo de ativação de recursos opt-in deve fazer parte a análise inicial."
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:274
-msgid ""
-"These are minimum requirements and not a guarantee that the add-on will be "
-"approved. This section applies to all add-ons hosted on the site, including "
-"preliminarily reviewed add-ons."
+msgid "These are minimum requirements and not a guarantee that the add-on will be approved. This section applies to all add-ons hosted on the site, including preliminarily reviewed add-ons."
 msgstr ""
-"Esses são os requisitos mínimos e não uma garantia de que o complemento será"
-" aprovado. Esta seção aplica-se a todos os complementos hospedados neste "
-"site, incluindo complementos com análise preliminar."
+"Esses são os requisitos mínimos e não uma garantia de que o complemento será aprovado. Esta seção aplica-se a todos os complementos hospedados neste site, incluindo complementos com análise "
+"preliminar."
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:279
 msgid "Private Browsing Mode"
@@ -7751,18 +6063,11 @@ msgstr "Modo de navegação privada"
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:282
 msgid ""
-"Add-ons that store or otherwise handle browsing data must support <a "
-"href=\"https://developer.mozilla.org/En/Supporting_private_browsing_mode\">Private"
-" Browsing Mode</a>.  During a Private Browsing session, no browsing data can"
-" be written to disk, and all of this data must be cleared when Firefox quits"
-" or the Private Browsing session ends."
+"Add-ons that store or otherwise handle browsing data must support <a href=\"https://developer.mozilla.org/En/Supporting_private_browsing_mode\">Private Browsing Mode</a>. During a Private Browsing "
+"session, no browsing data can be written to disk, and all of this data must be cleared when Firefox quits or the Private Browsing session ends."
 msgstr ""
-"Add-ons que armazenam ou manipulam dados de navegação devem dar suporte ao "
-"<a "
-"href=\"https://developer.mozilla.org/En/Supporting_private_browsing_mode\">Modo"
-" de Navegação Privada</a>.  Durante uma sessão de Navegação Privada, nenhum "
-"dado de navegação pode ser gravado em disco e todos esses dados devem ser "
-"removidos quando o Firefox fechar ou a sessão de Navegação Privada terminar."
+"Add-ons que armazenam ou manipulam dados de navegação devem dar suporte ao <a href=\"https://developer.mozilla.org/En/Supporting_private_browsing_mode\">Modo de Navegação Privada</a>.  Durante uma "
+"sessão de Navegação Privada, nenhum dado de navegação pode ser gravado em disco e todos esses dados devem ser removidos quando o Firefox fechar ou a sessão de Navegação Privada terminar."
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:287
 msgid "Binary Components & Obfuscated Code"
@@ -7770,43 +6075,26 @@ msgstr "Código ofuscado e componentes binários"
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:289
 msgid ""
-"Add-ons may contain binary, obfuscated and minified source code, but Mozilla"
-" must be allowed to review a copy of the human-readable source code of each "
-"version of an add-on submitted for review. These add-ons are ineligible for "
-"preliminary review and must choose the full review process."
+"Add-ons may contain binary, obfuscated and minified source code, but Mozilla must be allowed to review a copy of the human-readable source code of each version of an add-on submitted for review. "
+"These add-ons are ineligible for preliminary review and must choose the full review process."
 msgstr ""
-"Complementos podem conter código-fonte binário, ofuscado ou minimizado, mas "
-"a Mozilla deve ter permissão para analisar uma cópia legível do código-fonte"
-" de cada versão de um complemento submetido para análise. Esses complementos"
-" não podem pedir uma análise preliminar e devem selecionar o processo de "
-"análise completa."
+"Complementos podem conter código-fonte binário, ofuscado ou minimizado, mas a Mozilla deve ter permissão para analisar uma cópia legível do código-fonte de cada versão de um complemento submetido "
+"para análise. Esses complementos não podem pedir uma análise preliminar e devem selecionar o processo de análise completa."
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:295
 msgid ""
-"If an add-on contains binary or obfuscated source code, the author will "
-"receive a message when the add-on is reviewed indicating whom to contact at "
-"Mozilla to coordinate review of the source code. This code will be reviewed "
-"by an administrator and will not be shared or redistributed in any way. The "
-"code will only be used for the purpose of reviewing the add-on."
+"If an add-on contains binary or obfuscated source code, the author will receive a message when the add-on is reviewed indicating whom to contact at Mozilla to coordinate review of the source code. "
+"This code will be reviewed by an administrator and will not be shared or redistributed in any way. The code will only be used for the purpose of reviewing the add-on."
 msgstr ""
-"Se um complemento contiver código-fonte binário ou ofuscado, o autor "
-"receberá uma mensagem quando o complemento for analisado indicando como "
-"contatar a Mozilla para coordenar a análise do código-fonte. Esse código "
-"será analisado por um administrador e não será compartilhado ou "
-"redistribuído de maneira alguma. O código será usado somente com o propósito"
-" de analisar o complemento."
+"Se um complemento contiver código-fonte binário ou ofuscado, o autor receberá uma mensagem quando o complemento for analisado indicando como contatar a Mozilla para coordenar a análise do código-"
+"fonte. Esse código será analisado por um administrador e não será compartilhado ou redistribuído de maneira alguma. O código será usado somente com o propósito de analisar o complemento."
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:301
 #, python-format
-msgid ""
-"If your add-on contains binary or obfuscated code that you don't own or "
-"can't get the source code for, you may <a href=\"%(link_contact)s\">contact "
-"us</a> for information on how to proceed."
+msgid "If your add-on contains binary or obfuscated code that you don't own or can't get the source code for, you may <a href=\"%(link_contact)s\">contact us</a> for information on how to proceed."
 msgstr ""
-"Se o seu complemento contiver código binário ou ofuscado que não pertence a "
-"você ou você não possui uma versão legível do código-fonte, você pode <a "
-"href=\"%(link_contact)s\">entrar em contato conosco</a> para obter "
-"informações sobre como proceder."
+"Se o seu complemento contiver código binário ou ofuscado que não pertence a você ou você não possui uma versão legível do código-fonte, você pode <a href=\"%(link_contact)s\">entrar em contato "
+"conosco</a> para obter informações sobre como proceder."
 
 #: src/olympia/devhub/templates/devhub/docs/policies-submission.html:11
 msgid "Criteria for Submission"
@@ -7814,233 +6102,127 @@ msgstr "Critérios para submissão"
 
 #: src/olympia/devhub/templates/devhub/docs/policies-submission.html:13
 msgid ""
-"Add-ons hosted on Mozilla Add-ons should be of high quality and give users "
-"an improved web experience. We look for the following things when deciding "
-"whether an add-on is appropriate to be public and unrestricted:"
+"Add-ons hosted on Mozilla Add-ons should be of high quality and give users an improved web experience. We look for the following things when deciding whether an add-on is appropriate to be public "
+"and unrestricted:"
 msgstr ""
-"Complementos hospedados no Mozilla Add-ons devem oferecer alta qualidade e "
-"uma experiência melhor na Web para os usuários. Ao decidir se um complemento"
-" é adequado para ser público e irrestrito, nós avaliamos o seguinte:"
+"Complementos hospedados no Mozilla Add-ons devem oferecer alta qualidade e uma experiência melhor na Web para os usuários. Ao decidir se um complemento é adequado para ser público e irrestrito, nós "
+"avaliamos o seguinte:"
 
 #: src/olympia/devhub/templates/devhub/docs/policies-submission.html:19
 msgid ""
-"<strong>Are you responsive?</strong> We expect that an author who is "
-"promoting their add-on to our applications' many users is responsive to "
-"problem reports, maintains their contact information, and updates their add-"
-"on promptly to keep current with Firefox releases and changes in our "
-"policies. This doesn't mean that you have to reply to every question that "
-"someone posts in the discussions, or that you even need to fix every bug, "
-"but we do expect that you will respond to issues in a manner that's "
-"appropriate to the severity of the issue in question."
+"<strong>Are you responsive?</strong> We expect that an author who is promoting their add-on to our applications' many users is responsive to problem reports, maintains their contact information, "
+"and updates their add-on promptly to keep current with Firefox releases and changes in our policies. This doesn't mean that you have to reply to every question that someone posts in the "
+"discussions, or that you even need to fix every bug, but we do expect that you will respond to issues in a manner that's appropriate to the severity of the issue in question."
 msgstr ""
-"<strong>Você é responsável?</strong> Nós esperamos que um autor que está "
-"promovendo seu complemento aos muitos usuários de nossas aplicações esteja "
-"disponível para responder relatos de problemas, mantenha suas informações de"
-" contato atualizadas e atualize seu complemento prontamente para mantê-lo "
-"compatível com as versões recentes do Firefox e alterações em nossas "
-"políticas. Isso não significa que você terá que responder todas as perguntas"
-" que alguém postar em discussões sobre o complemento, ou que você precisa "
-"corrigir cada bug, mas esperamos que você responda aos problemas de maneira "
-"apropriada à severidade do problema em questão."
+"<strong>Você é responsável?</strong> Nós esperamos que um autor que está promovendo seu complemento aos muitos usuários de nossas aplicações esteja disponível para responder relatos de problemas, "
+"mantenha suas informações de contato atualizadas e atualize seu complemento prontamente para mantê-lo compatível com as versões recentes do Firefox e alterações em nossas políticas. Isso não "
+"significa que você terá que responder todas as perguntas que alguém postar em discussões sobre o complemento, ou que você precisa corrigir cada bug, mas esperamos que você responda aos problemas de "
+"maneira apropriada à severidade do problema em questão."
 
 #: src/olympia/devhub/templates/devhub/docs/policies-submission.html:25
 msgid ""
-"<strong>Is the add-on clearly and accurately described?</strong> It's of the"
-" utmost importance to us that users get what they expect when they try a new"
-" add-on. Your add-on name should be clear and concise, and you should "
-"refrain from using special characters or numbers to get higher search "
-"rankings or for decorative purposes. Your description should provide details"
-" about what the add-on does, how a user should take advantage of it, and "
-"what the user should expect when they install it. Links to external "
-"documents for detailed instructions are fine, but the description itself "
-"should cover the basics and leave users confident that they know what "
-"they'll get. Also, it is important that you maintain version notes "
-"appropriately as you improve and change your add-on. Users should be able to"
-" see what's new in an add-on they may have tried previously, and should be "
-"made aware of changes that might affect their current use of the add-on when"
-" they update."
+"<strong>Is the add-on clearly and accurately described?</strong> It's of the utmost importance to us that users get what they expect when they try a new add-on. Your add-on name should be clear and "
+"concise, and you should refrain from using special characters or numbers to get higher search rankings or for decorative purposes. Your description should provide details about what the add-on "
+"does, how a user should take advantage of it, and what the user should expect when they install it. Links to external documents for detailed instructions are fine, but the description itself should "
+"cover the basics and leave users confident that they know what they'll get. Also, it is important that you maintain version notes appropriately as you improve and change your add-on. Users should "
+"be able to see what's new in an add-on they may have tried previously, and should be made aware of changes that might affect their current use of the add-on when they update."
 msgstr ""
-"<strong>A descrição do complemento é clara e precisa?</strong> É da mais "
-"alta importância para nós que os usuários encontrem o que esperam ao "
-"experimentar um novo complemento. O nome do seu complemento deve ser claro e"
-" conciso e deve evitar o uso de caracteres especiais ou números para obter "
-"posições melhores nas pesquisas ou para propósitos decorativos. Sua "
-"descrição deve fornecer detalhes sobre o que o complemento faz, como um "
-"usuário pode se beneficiar dele e o que o usuário deve esperar ao instalá-"
-"lo. Links para documentação externa com instruções detalhadas podem ser "
-"usados, mas a descrição em si deve conter o básico e deixar os usuários "
-"confiantes de que eles sabem o que vão obter. Além disso, é importante que "
-"você mantenha notas de versão ao realizar melhorias e alterações no seu "
-"complemento. Os usuários devem ser capazes de ver o que há de novo em um "
-"complemento que eles já podem ter experimentado e devem estar cientes das "
-"alterações que podem afetar o uso atual do complemento ao atualizá-lo."
+"<strong>A descrição do complemento é clara e precisa?</strong> É da mais alta importância para nós que os usuários encontrem o que esperam ao experimentar um novo complemento. O nome do seu "
+"complemento deve ser claro e conciso e deve evitar o uso de caracteres especiais ou números para obter posições melhores nas pesquisas ou para propósitos decorativos. Sua descrição deve fornecer "
+"detalhes sobre o que o complemento faz, como um usuário pode se beneficiar dele e o que o usuário deve esperar ao instalá-lo. Links para documentação externa com instruções detalhadas podem ser "
+"usados, mas a descrição em si deve conter o básico e deixar os usuários confiantes de que eles sabem o que vão obter. Além disso, é importante que você mantenha notas de versão ao realizar "
+"melhorias e alterações no seu complemento. Os usuários devem ser capazes de ver o que há de novo em um complemento que eles já podem ter experimentado e devem estar cientes das alterações que podem "
+"afetar o uso atual do complemento ao atualizá-lo."
 
 #: src/olympia/devhub/templates/devhub/docs/policies-submission.html:31
 msgid ""
-"<strong>Are all privacy and security concerns clearly spelled out?</strong> "
-"This is an aspect of a clear and accurate description, but such an important"
-" one that we feel it deserves specific mention. Many very useful and well-"
-"written add-ons manipulate some form of user data, or can present security "
-"hazards if misused; they are welcome on the site, but they must make it very"
-" clear to users what risks they might encounter, and what they can do to "
-"protect themselves."
+"<strong>Are all privacy and security concerns clearly spelled out?</strong> This is an aspect of a clear and accurate description, but such an important one that we feel it deserves specific "
+"mention. Many very useful and well-written add-ons manipulate some form of user data, or can present security hazards if misused; they are welcome on the site, but they must make it very clear to "
+"users what risks they might encounter, and what they can do to protect themselves."
 msgstr ""
-"<strong>Todas as questões relacionadas a privacidade e segurança estão "
-"claramente informadas?</strong> Essa preocupação faz parte de uma descrição "
-"clara e precisa, mas é tão importante que preferimos mencionar "
-"separadamente. Muitos complementos úteis e bem escritos manipulam dados do "
-"usuário de alguma forma ou podem apresentar riscos de segurança se mal "
-"utilizados; eles são bem-vindos ao site, mas devem deixar claro aos usuários"
-" os riscos que eles podem correr e o que podem fazer para se proteger."
+"<strong>Todas as questões relacionadas a privacidade e segurança estão claramente informadas?</strong> Essa preocupação faz parte de uma descrição clara e precisa, mas é tão importante que "
+"preferimos mencionar separadamente. Muitos complementos úteis e bem escritos manipulam dados do usuário de alguma forma ou podem apresentar riscos de segurança se mal utilizados; eles são bem-"
+"vindos ao site, mas devem deixar claro aos usuários os riscos que eles podem correr e o que podem fazer para se proteger."
 
 #: src/olympia/devhub/templates/devhub/docs/policies-submission.html:37
 msgid ""
-"<strong>Has the add-on been well-tested, and is it free of obvious or "
-"serious defects?</strong> One important thing that we look for when "
-"considering an add-on is whether its user reviews indicate that it has "
-"received thorough testing, and that it doesn't have serious problems or "
-"negative impacts on the browser. If reviewers report problems such as major "
-"performance issues, crashes, frequent problems using the functions of the "
-"add-on, or spamming of messages to the error console, you should take those "
-"reports to heart, and re-submit your add-on after you've addressed them as "
-"best you can. We don't expect you to perfectly optimize or have zero bugs "
-"&mdash; Firefox itself undergoes constant improvement in these areas &mdash;"
-" but we do want you to take reasonable efforts to minimize downsides, and to"
-" clearly call out cases where users may be surprised by those that remain."
+"<strong>Has the add-on been well-tested, and is it free of obvious or serious defects?</strong> One important thing that we look for when considering an add-on is whether its user reviews indicate "
+"that it has received thorough testing, and that it doesn't have serious problems or negative impacts on the browser. If reviewers report problems such as major performance issues, crashes, frequent "
+"problems using the functions of the add-on, or spamming of messages to the error console, you should take those reports to heart, and re-submit your add-on after you've addressed them as best you "
+"can. We don't expect you to perfectly optimize or have zero bugs &mdash; Firefox itself undergoes constant improvement in these areas &mdash; but we do want you to take reasonable efforts to "
+"minimize downsides, and to clearly call out cases where users may be surprised by those that remain."
 msgstr ""
-"<strong>O complemento foi bem testado e está livre de falhas óbvias ou "
-"graves?</strong> Uma coisa importante que procuramos ao considerar um "
-"complemento é se as análises dos usuários indicam que o complemento foi "
-"testado completamente e que ele não tem problemas sérios ou impactos "
-"negativos sobre o navegador. Se as análises dos usuários relatarem problemas"
-" graves de desempenho, travamentos, problemas frequentes ao usar funções do "
-"complemento ou excesso de mensagens no console de erros, você deve "
-"considerar essas análises com carinho e reenviar seu complemento depois "
-"melhorá-lo o máximo que puder. Não esperamos que você o otimize "
-"perfeitamente ou que ele não tenha nenhum bug &mdash; o próprio Firefox "
-"passa por melhorias constantes nesses quesitos &mdash;, mas queremos que "
-"você tome medidas razoáveis para minimizar os aspectos negativos e anunciar "
-"claramente os casos em que o usuário possa ser surpreendido pelos problemas "
-"remanescentes."
+"<strong>O complemento foi bem testado e está livre de falhas óbvias ou graves?</strong> Uma coisa importante que procuramos ao considerar um complemento é se as análises dos usuários indicam que o "
+"complemento foi testado completamente e que ele não tem problemas sérios ou impactos negativos sobre o navegador. Se as análises dos usuários relatarem problemas graves de desempenho, travamentos, "
+"problemas frequentes ao usar funções do complemento ou excesso de mensagens no console de erros, você deve considerar essas análises com carinho e reenviar seu complemento depois melhorá-lo o "
+"máximo que puder. Não esperamos que você o otimize perfeitamente ou que ele não tenha nenhum bug &mdash; o próprio Firefox passa por melhorias constantes nesses quesitos &mdash;, mas queremos que "
+"você tome medidas razoáveis para minimizar os aspectos negativos e anunciar claramente os casos em que o usuário possa ser surpreendido pelos problemas remanescentes."
 
 #: src/olympia/devhub/templates/devhub/docs/policies-submission.html:43
 msgid ""
-"<strong>Do the add-on and add-on author both treat the user "
-"respectfully?</strong> Your software should not intrude on the user "
-"unnecessarily, try to trick the user, or conceal any of its activities from "
-"the user. Users (or even non-users) are sometimes rude in their comments, "
-"and while we will do our best to filter out inaccurate reviews as they're "
-"reported to us, we do expect that authors will avoid retaliating with "
-"rudeness of their own."
+"<strong>Do the add-on and add-on author both treat the user respectfully?</strong> Your software should not intrude on the user unnecessarily, try to trick the user, or conceal any of its "
+"activities from the user. Users (or even non-users) are sometimes rude in their comments, and while we will do our best to filter out inaccurate reviews as they're reported to us, we do expect that "
+"authors will avoid retaliating with rudeness of their own."
 msgstr ""
-"<strong>O completo e seu autor tratam o usuário de maneira "
-"respeitosa?</strong> Seu software não deve se intrometer na experiência do "
-"usuário de forma desnecessária, tentar enganá-lo ou esconder quaisquer de "
-"suas atividades do usuário. Usuários (ou mesmo não-usuários) algumas vezes "
-"são rudes em seus comentários, e ao mesmo tempo que fazemos o nosso melhor "
-"para filtrar análises imprecisas assim que são enviadas, esperamos que os "
-"autores evitem retaliar de forma rude por conta própria."
+"<strong>O completo e seu autor tratam o usuário de maneira respeitosa?</strong> Seu software não deve se intrometer na experiência do usuário de forma desnecessária, tentar enganá-lo ou esconder "
+"quaisquer de suas atividades do usuário. Usuários (ou mesmo não-usuários) algumas vezes são rudes em seus comentários, e ao mesmo tempo que fazemos o nosso melhor para filtrar análises imprecisas "
+"assim que são enviadas, esperamos que os autores evitem retaliar de forma rude por conta própria."
 
 #: src/olympia/devhub/templates/devhub/docs/policies-submission.html:49
 msgid ""
-"<strong>Is the add-on useful to an appropriately wide portion of Firefox's "
-"users?</strong> Your add-on doesn't need to be the next Greasemonkey or "
-"Firebug, but if it is only useful to people at your company or who are part "
-"of a small web community, we may feel that it's not yet appropriate to put "
-"it in front of all of our users."
+"<strong>Is the add-on useful to an appropriately wide portion of Firefox's users?</strong> Your add-on doesn't need to be the next Greasemonkey or Firebug, but if it is only useful to people at "
+"your company or who are part of a small web community, we may feel that it's not yet appropriate to put it in front of all of our users."
 msgstr ""
-"<strong>O complemento é útil para uma boa parte dos usuários do "
-"Firefox?</strong> Seu complemento não precisa ser o próximo Greasemonkey ou "
-"Firebug, mas se ele só é útil para pessoas de sua empresa ou para quem é "
-"parte de uma pequena comunidade, nós podemos achar que ele é adequado para "
-"ser disponibilizado para todos os usuários."
+"<strong>O complemento é útil para uma boa parte dos usuários do Firefox?</strong> Seu complemento não precisa ser o próximo Greasemonkey ou Firebug, mas se ele só é útil para pessoas de sua empresa "
+"ou para quem é parte de uma pequena comunidade, nós podemos achar que ele é adequado para ser disponibilizado para todos os usuários."
 
 #: src/olympia/devhub/templates/devhub/docs/policies-submission.html:55
 msgid ""
-"We are constantly looking at ways to improve the organization of the site to"
-" better accommodate add-ons that are exemplary in other ways, but are aimed "
-"at only a small community of potential users. Correctly categorizing and "
-"maintaining the metadata of your add-on will help us figure out how we can "
-"surface more of those sorts of add-ons to people who are most likely to "
-"benefit from them."
+"We are constantly looking at ways to improve the organization of the site to better accommodate add-ons that are exemplary in other ways, but are aimed at only a small community of potential users. "
+"Correctly categorizing and maintaining the metadata of your add-on will help us figure out how we can surface more of those sorts of add-ons to people who are most likely to benefit from them."
 msgstr ""
-"Estamos procurando constantemente maneiras de melhorar a organização do "
-"nosso site para acomodar melhor complementos exemplares em diversos "
-"aspectos, mas que visam somente uma comunidade pequena de usuários em "
-"potencial. Categorizar corretamente e manter os dados do seu complemento "
-"atualizados nos ajudará a descobrir como podemos oferecer esse tipo de "
-"complemento para as pessoas que mais se beneficiarão dele."
+"Estamos procurando constantemente maneiras de melhorar a organização do nosso site para acomodar melhor complementos exemplares em diversos aspectos, mas que visam somente uma comunidade pequena de "
+"usuários em potencial. Categorizar corretamente e manter os dados do seu complemento atualizados nos ajudará a descobrir como podemos oferecer esse tipo de complemento para as pessoas que mais se "
+"beneficiarão dele."
 
 #: src/olympia/devhub/templates/devhub/docs/policies-submission.html:61
 msgid ""
-"If your add-on just provides bookmarks or other simple access points to your"
-" site, it's probably not appropriate for the gallery. Like the rest of the "
-"Mozilla project, we love web applications and new web services, but Firefox "
-"add-ons should provide an improved browsing experience for the user and not "
-"just be a way to promote a new site or service through a Mozilla Add-ons "
-"listing."
+"If your add-on just provides bookmarks or other simple access points to your site, it's probably not appropriate for the gallery. Like the rest of the Mozilla project, we love web applications and "
+"new web services, but Firefox add-ons should provide an improved browsing experience for the user and not just be a way to promote a new site or service through a Mozilla Add-ons listing."
 msgstr ""
-"Se o seu complemento apenas oferece favoritos ou outros atalhos de acesso ao"
-" seu site, é provável que ele não seja adequado para a galeria. Como o "
-"restante do projeto Mozilla, nós amamos aplicações web e novos serviços web,"
-" mas os complementos para o Firefox devem oferecer uma experiência melhorada"
-" para os usuários e não apenas uma maneira de promover um novo site ou "
-"serviço através da galeria do Mozilla Add-ons."
+"Se o seu complemento apenas oferece favoritos ou outros atalhos de acesso ao seu site, é provável que ele não seja adequado para a galeria. Como o restante do projeto Mozilla, nós amamos aplicações "
+"web e novos serviços web, mas os complementos para o Firefox devem oferecer uma experiência melhorada para os usuários e não apenas uma maneira de promover um novo site ou serviço através da "
+"galeria do Mozilla Add-ons."
 
 #: src/olympia/devhub/templates/devhub/docs/policies-submission.html:67
 msgid ""
-"<strong>Is the add-on free of unlicensed trademarks and copyrights?</strong>"
-" Though you may mean no harm to the holder of a trademark, or the owner of a"
-" copyrighted work, we can't host add-ons that infringe on trademarks or "
-"copyrights. If you don't have permission to use a trademarked name or image,"
-" please do not submit your add-on to us. If your add-on includes code that "
-"is copyrighted by someone else, and is not licensed to you to use in your "
-"add-on, please do not submit your add-on to us."
+"<strong>Is the add-on free of unlicensed trademarks and copyrights?</strong> Though you may mean no harm to the holder of a trademark, or the owner of a copyrighted work, we can't host add-ons that "
+"infringe on trademarks or copyrights. If you don't have permission to use a trademarked name or image, please do not submit your add-on to us. If your add-on includes code that is copyrighted by "
+"someone else, and is not licensed to you to use in your add-on, please do not submit your add-on to us."
 msgstr ""
-"<strong>O complemento está livre de marcas e direitos autorais não "
-"licenciados?</strong> Mesmo que você não tenha nenhuma má intenção para o "
-"detentor de uma marca registrada ou dono de um trabalho com direitos "
-"reservados, não podemos hospedar complementos que infringem marcas "
-"registradas ou direitos autorais. Se você não tem permissão para usar um "
-"nome ou imagem de uma marca registrada, por favor, não envie seu complemento"
-" para nós. Se seu complemento incluir código com direitos reservados que "
-"pertencem outra pessoa e não for licenciado, por favor, não envie seu "
-"complemento para nós."
+"<strong>O complemento está livre de marcas e direitos autorais não licenciados?</strong> Mesmo que você não tenha nenhuma má intenção para o detentor de uma marca registrada ou dono de um trabalho "
+"com direitos reservados, não podemos hospedar complementos que infringem marcas registradas ou direitos autorais. Se você não tem permissão para usar um nome ou imagem de uma marca registrada, por "
+"favor, não envie seu complemento para nós. Se seu complemento incluir código com direitos reservados que pertencem outra pessoa e não for licenciado, por favor, não envie seu complemento para nós."
 
 #: src/olympia/devhub/templates/devhub/docs/policies-submission.html:73
 msgid ""
-"In terms of reuse of source code from other add-ons, if the author has not "
-"clearly stated that you are permitted to use his or her code in your own "
-"work &mdash; such as by placing it under an open source license &mdash; then"
-" you should assume that you do not have the right to do so. You can contact "
-"the author to seek such permission, but we can't provide you with any "
-"special rights to it just because it's listed on the site, or because the "
-"author isn't responding to your request."
+"In terms of reuse of source code from other add-ons, if the author has not clearly stated that you are permitted to use his or her code in your own work &mdash; such as by placing it under an open "
+"source license &mdash; then you should assume that you do not have the right to do so. You can contact the author to seek such permission, but we can't provide you with any special rights to it "
+"just because it's listed on the site, or because the author isn't responding to your request."
 msgstr ""
-"Em termos de reuso de código de outros complementos, se o autor não indicou "
-"claramente que você tem permissão para utilizar o código do autor em seu "
-"próprio trabalho &mdash; licenciando-o sob uma licença livre, por exemplo "
-"&mdash;, então você deve assumir que você não tem o direito de fazê-lo. Você"
-" pode entrar em contato com o autor para conseguir tal permissão, mas nós "
-"não podemos fornecer quaisquer direitos especiais para seu complemento "
-"apenas porque ele está listado no site ou porque o autor não está a "
-"responder à sua solicitação."
+"Em termos de reuso de código de outros complementos, se o autor não indicou claramente que você tem permissão para utilizar o código do autor em seu próprio trabalho &mdash; licenciando-o sob uma "
+"licença livre, por exemplo &mdash;, então você deve assumir que você não tem o direito de fazê-lo. Você pode entrar em contato com o autor para conseguir tal permissão, mas nós não podemos fornecer "
+"quaisquer direitos especiais para seu complemento apenas porque ele está listado no site ou porque o autor não está a responder à sua solicitação."
 
 #: src/olympia/devhub/templates/devhub/docs/policies-submission.html:79
 msgid ""
-"This applies to the Mozilla Foundation's trademarks as well, including "
-"\"Mozilla\", \"Firefox\", and \"Thunderbird\". The Mozilla policy on "
-"trademark use is designed to protect against confusion, and prevent the "
-"trademarks from being overturned due to lack of protection; please respect "
-"the need for such protection, and help us preserve some of the most valuable"
-" assets of the Mozilla Foundation."
+"This applies to the Mozilla Foundation's trademarks as well, including \"Mozilla\", \"Firefox\", and \"Thunderbird\". The Mozilla policy on trademark use is designed to protect against confusion, "
+"and prevent the trademarks from being overturned due to lack of protection; please respect the need for such protection, and help us preserve some of the most valuable assets of the Mozilla "
+"Foundation."
 msgstr ""
-"Isso também se aplica a marcas registradas da Fundação Mozilla, incluindo "
-"\"Mozilla\", \"Firefox\" e \"Thunderbird\". A política sobre o uso de marca "
-"da Mozilla foi criada para nos proteger contra a confusão entre marcas e "
-"evitar que as marcas registradas sejam anuladas devido à falta de proteção; "
-"por favor, respeite a necessidade de tal proteção e nos ajude a preservar "
-"alguns dos bens mais valiosos da Fundação Mozilla."
+"Isso também se aplica a marcas registradas da Fundação Mozilla, incluindo \"Mozilla\", \"Firefox\" e \"Thunderbird\". A política sobre o uso de marca da Mozilla foi criada para nos proteger contra "
+"a confusão entre marcas e evitar que as marcas registradas sejam anuladas devido à falta de proteção; por favor, respeite a necessidade de tal proteção e nos ajude a preservar alguns dos bens mais "
+"valiosos da Fundação Mozilla."
 
 #: src/olympia/devhub/templates/devhub/docs/policies-submission.html:84
 msgid "Licensing"
@@ -8048,258 +6230,179 @@ msgstr "Licenciamento"
 
 #: src/olympia/devhub/templates/devhub/docs/policies-submission.html:86
 msgid ""
-"Selecting an appropriate license for your add-on is a very important step in"
-" the submission process. A license specifies the rights you grant on your "
-"source code and is important in protecting your intellectual property."
+"Selecting an appropriate license for your add-on is a very important step in the submission process. A license specifies the rights you grant on your source code and is important in protecting your "
+"intellectual property."
 msgstr ""
-"Selecionar uma licença adequada para o seu complemento é um passo muito "
-"importante do processo de submissão. Uma licença especifica os direitos que "
-"concede em seu código-fonte e é importante para proteger a sua propriedade "
-"intelectual."
+"Selecionar uma licença adequada para o seu complemento é um passo muito importante do processo de submissão. Uma licença especifica os direitos que concede em seu código-fonte e é importante para "
+"proteger a sua propriedade intelectual."
 
 #: src/olympia/devhub/templates/devhub/docs/policies-submission.html:92
 msgid ""
-"During the add-on submission process, you will be presented with a list of "
-"popular licenses to choose from, as well as the ability to specify your own "
-"license. It is best to consult with a legal professional about which license"
-" option is best for you. Choosing the right license for your source code "
-"will help to prevent confusion and code conflicts in the future."
+"During the add-on submission process, you will be presented with a list of popular licenses to choose from, as well as the ability to specify your own license. It is best to consult with a legal "
+"professional about which license option is best for you. Choosing the right license for your source code will help to prevent confusion and code conflicts in the future."
 msgstr ""
-"Durante o processo de submissão de complementos, será apresentada uma lista "
-"de licenças populares para que possa escolher entre uma delas, além de poder"
-" especificar sua própria licença. Recomendamos que consulte um profissional "
-"de direito para aconselhá-lo sobre a melhor opção para você. Escolher a "
-"licença correta para o seu código irá ajudá-lo a evitar confusões e "
-"conflitos de código no futuro."
+"Durante o processo de submissão de complementos, será apresentada uma lista de licenças populares para que possa escolher entre uma delas, além de poder especificar sua própria licença. "
+"Recomendamos que consulte um profissional de direito para aconselhá-lo sobre a melhor opção para você. Escolher a licença correta para o seu código irá ajudá-lo a evitar confusões e conflitos de "
+"código no futuro."
 
-#: src/olympia/devhub/templates/devhub/docs/policies.html:12
-#: src/olympia/devhub/templates/devhub/docs/policies.html:52
+#: src/olympia/devhub/templates/devhub/docs/policies.html:12 src/olympia/devhub/templates/devhub/docs/policies.html:52
 msgid "Add-on Submission"
 msgstr "Submissão de complementos"
 
-#: src/olympia/devhub/templates/devhub/docs/policies.html:18
-#: src/olympia/devhub/templates/devhub/docs/policies.html:78
+#: src/olympia/devhub/templates/devhub/docs/policies.html:18 src/olympia/devhub/templates/devhub/docs/policies.html:78
 msgid "Maintaining Your Add-on"
 msgstr "Manutenção do seu complemento"
 
 #: src/olympia/devhub/templates/devhub/docs/policies.html:43
-msgid ""
-"Mozilla is committed to ensuring a great add-ons experience for our users "
-"and developers. Please review the policies below before submitting your add-"
-"on."
-msgstr ""
-"A Mozilla está empenhada em garantir uma excelente experiência com "
-"complementos para nossos usuários e desenvolvedores. Por favor, revise as "
-"políticas abaixo antes de enviar seu complemento."
+msgid "Mozilla is committed to ensuring a great add-ons experience for our users and developers. Please review the policies below before submitting your add-on."
+msgstr "A Mozilla está empenhada em garantir uma excelente experiência com complementos para nossos usuários e desenvolvedores. Por favor, revise as políticas abaixo antes de enviar seu complemento."
 
 #: src/olympia/devhub/templates/devhub/docs/policies.html:55
-msgid ""
-"Find out what is expected of add-ons we host and our policies on specific "
-"add-on practices."
-msgstr ""
-"Descubra o que é esperado dos complementos que hospedamos e nossas políticas"
-" específicas sobre práticas de complementos."
+msgid "Find out what is expected of add-ons we host and our policies on specific add-on practices."
+msgstr "Descubra o que é esperado dos complementos que hospedamos e nossas políticas específicas sobre práticas de complementos."
 
 #: src/olympia/devhub/templates/devhub/docs/policies.html:67
-msgid ""
-"What happens after your add-on is submitted? Learn about how our Editors "
-"review submissions."
-msgstr ""
-"O que acontece depois que um complemento é submetido? Saiba mais sobre como "
-"os nossos editores analisam as submissões."
+msgid "What happens after your add-on is submitted? Learn about how our Editors review submissions."
+msgstr "O que acontece depois que um complemento é submetido? Saiba mais sobre como os nossos editores analisam as submissões."
 
 #: src/olympia/devhub/templates/devhub/docs/policies.html:81
-msgid ""
-"Add-on updates, transferring ownership, user reviews, and what to expect "
-"once your add-on is approved."
-msgstr ""
-"Atualizações de complementos, transferência de propriedade, análises de "
-"usuários e o que esperar uma vez que seu complemento for aprovado."
+msgid "Add-on updates, transferring ownership, user reviews, and what to expect once your add-on is approved."
+msgstr "Atualizações de complementos, transferência de propriedade, análises de usuários e o que esperar uma vez que seu complemento for aprovado."
 
 #: src/olympia/devhub/templates/devhub/docs/policies.html:93
-msgid ""
-"How up-and-coming add-ons become featured and what&#039;s involved in the "
-"process."
-msgstr ""
-"Como complementos em ascensão tornam-se complementos em destaque e o que "
-"está envolvido nesse processo."
+msgid "How up-and-coming add-ons become featured and what&#039;s involved in the process."
+msgstr "Como complementos em ascensão tornam-se complementos em destaque e o que está envolvido nesse processo."
 
 #: src/olympia/devhub/templates/devhub/docs/policies.html:106
-msgid ""
-"Terms of Service for submitting your work to our site. Developers are "
-"required to accept this agreement before submission."
-msgstr ""
-"Termos do serviço para a submissão do seu trabalho no nosso site. Os "
-"desenvolvedores são obrigados a aceitar este contrato antes da submissão."
+msgid "Terms of Service for submitting your work to our site. Developers are required to accept this agreement before submission."
+msgstr "Termos do serviço para a submissão do seu trabalho no nosso site. Os desenvolvedores são obrigados a aceitar este contrato antes da submissão."
 
 #: src/olympia/devhub/templates/devhub/docs/policies.html:118
 msgid "How to get in touch with us regarding these policies or your add-on."
-msgstr ""
-"Como entrar em contato conosco a respeito dessas políticas ou sobre seu "
-"complemento."
+msgstr "Como entrar em contato conosco a respeito dessas políticas ou sobre seu complemento."
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:6
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:10
 msgid "You have disabled this add-on"
 msgstr "Você desabilitou este complemento"
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:20
-msgid ""
-"Your add-on's listing is disabled and is not showing\n"
-"                             anywhere in our gallery or update service."
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:24
+msgid "Your add-on's listing is disabled and is not showing anywhere in our gallery or update service."
 msgstr ""
 "A listagem dos seus complementos está desativada e não será exibida\n"
 "                             em nenhuma de nossas galerias ou atualização de serviços."
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:25
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:27
 msgid "Please complete your add-on."
 msgstr "Por favor, complete seu complemento."
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:29
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:30
 msgid "You will receive an email when the review is complete."
 msgstr "Você receberá um e-mail quando a análise estiver completa."
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:34
-msgid ""
-"You will receive an email when the review is complete. Until\n"
-"                             then, your add-on is not listed in our gallery but can be\n"
-"                             accessed directly from its details page."
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:33
+msgid "You will receive an email when the review is complete. Until then, your add-on is not listed in our gallery but can be accessed directly from its details page."
 msgstr ""
 "Você receberá um e-mail quando a revisão for concluída. Portanto,\n"
 "                             seu complemento não será listado em nossa galeria, mas você\n"
 "                             poderá acessá-lo diretamente em sua página de detalhes."
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:38
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:48
-msgid ""
-"You will receive an email when the review is\n"
-"                             complete and your add-on is signed."
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:37 src/olympia/devhub/templates/devhub/includes/addon_details.html:45
+msgid "You will receive an email when the review is complete and your add-on is signed."
 msgstr ""
 "Você receberá um e-mail quando a revisão for\n"
 "                             concluída e seu complemento for assinado."
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:44
-msgid ""
-"You will receive an email when the review is complete. Until\n"
-"                             then, your add-on is not listed in our gallery but can be\n"
-"                             accessed directly from its details page. "
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:41
+msgid "You will receive an email when the review is complete. Until then, your add-on is not listed in our gallery but can be accessed directly from its details page. "
 msgstr ""
-"Você receberá um e-mail quando a revisão for concluída. Enquanto\n"
-"                             isso, seu complemento não será lista em nossa galeria, mas você\n"
-"                             pode acessá-lo diretamente em sua página de detalhes. "
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:54
-msgid ""
-"Your add-on is displayed in our gallery and users are\n"
-"                             receiving automatic updates."
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:49
+msgid "Your add-on is displayed in our gallery and users are receiving automatic updates."
 msgstr ""
 "Seu complemento será exibido em nossa galeria e os usuários\n"
 "                             receberão atualizações automáticas."
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:57
-msgid ""
-"Your add-on has been signed and can be bundled with an\n"
-"                             application installer."
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:52
+msgid "Your add-on has been signed and can be bundled with an application installer."
 msgstr ""
 "Seu complemento foi assinado e poderá ser empacotado com um\n"
 "                             instalador de aplicativo."
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:63
-msgid ""
-"Your add-on was disabled by a site administrator and is no\n"
-"                             longer shown in our gallery. If you have any questions,\n"
-"                             please email amo-admins@mozilla.org."
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:56
+msgid "Your add-on was disabled by a site administrator and is no longer shown in our gallery. If you have any questions, please email amo-admins@mozilla.org."
 msgstr ""
 "Seu complemento foi desativado por um administrador do site e não será\n"
 "                             mais exibido em nossa galeria. Se você tiver alguma dúvida,\n"
 "                             por favor, envie um e-mail para amo-admins@mozilla.org."
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:70
-msgid ""
-"Your add-on is displayed in our gallery as experimental\n"
-"                             and users are receiving automatic updates. Some features\n"
-"                             are unavailable to your add-on."
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:62
+msgid "Your add-on is displayed in our gallery as experimental and users are receiving automatic updates. Some features are unavailable to your add-on."
 msgstr ""
 "Seu add-on é exibido na nossa galeria como experimental\n"
 "                             e os usuários recebem atualizações automáticas. Alguns recursos\n"
 "                             são indisponíveis para o seu add-on."
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:74
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:66
 msgid "Your add-on has been signed."
 msgstr "O seu complemento foi assinado."
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:79
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:69
 msgid ""
-"You will receive an email when the full review is complete.\n"
-"                             Until then, your add-on is displayed in our gallery as\n"
-"                             experimental and users are receiving automatic updates.\n"
-"                             Some features are unavailable to your add-on."
+"You will receive an email when the full review is complete. Until then, your add-on is displayed in our gallery as experimental and users are receiving automatic updates. Some features are "
+"unavailable to your add-on."
 msgstr ""
 "Você receberá um e-mail quando a revisão estiver completa.\n"
 "                             Até então, seu complemento será exibido em nossa galeria como\n"
 "                             experimental e os usuários recebem atualizações automáticas.\n"
 "                             Alguns recursos são indisponíveis para o seu complemento."
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:84
-msgid ""
-"You will receive an email when the full review is\n"
-"                             complete, making you able to bundle your add-on with an\n"
-"                             application installer."
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:74
+msgid "You will receive an email when the full review is complete, making you able to bundle your add-on with an application installer."
 msgstr ""
 "Você receberá um e-mail quando a revisão estiver\n"
 "                             completa, tornando-o capaz de empacotar seu complemento com um\n"
 "                             instalador de aplicativo."
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:91
-msgid ""
-"All add-ons hosted in our gallery must now be reviewed by an\n"
-"                             editor. If you wish to continue hosting your add-on, please\n"
-"                             click to select a review process."
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:79
+msgid "All add-ons hosted in our gallery must now be reviewed by an editor. If you wish to continue hosting your add-on, please click to select a review process."
 msgstr ""
 "Todos os complementos hospedados na nossa galeria devem ser revisados por um\n"
 "                             editor. Se desejar continuar hospedando seu complemento, por favor\n"
 "                             clique para selecionar um processo de revisão."
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:113
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:100
 msgid "Current Version:"
 msgstr "Versão atual:"
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:115
-msgid ""
-"This is the version of your add-on that will\n"
-"                                           be installed if someone clicks the Install\n"
-"                                           button on addons.mozilla.org. It is only\n"
-"                                           relevant for listed add-ons."
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:102
+msgid "This is the version of your add-on that will be installed if someone clicks the Install button on addons.mozilla.org. It is only relevant for listed add-ons."
 msgstr ""
 "Esta é a versão do seu add-on que será\n"
 "                                           instalado se alguém clicar no botão\n"
 "                                           Instalar em addons.mozilla.org. Somente é\n"
 "                                           relevante para os add-ons listados."
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:123
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:110
 msgid "Created:"
 msgstr "Criação:"
 
 #. {0} is a date. dennis-ignore: E201
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:125
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:131
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:112 src/olympia/devhub/templates/devhub/includes/addon_details.html:118
 #, python-format
 msgid "%%b %%e, %%Y"
 msgstr "%%e %%b %%Y"
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:136
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:123
 msgid "Next Version:"
 msgstr "Próxima versão:"
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:138
-msgid ""
-"This is the newest uploaded version, however\n"
-"                                           it isn’t live on the site yet."
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:125
+msgid "This is the newest uploaded version, however it isn’t live on the site yet."
 msgstr ""
 "Esta é a última versão carregada, entretanto\n"
 "                                           ainda não está disponível no site."
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:144
-#: src/olympia/devhub/templates/devhub/versions/list.html:30
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:130 src/olympia/devhub/templates/devhub/versions/list.html:30
 msgid "Queues are not reviewed strictly in order"
 msgstr "Filas não são revisadas de forma rigorosa"
 
@@ -8317,15 +6420,11 @@ msgstr "Criar um perfil de desenvolvedor"
 
 #: src/olympia/devhub/templates/devhub/includes/addons_create_profile.html:24
 msgid ""
-"Your developer profile will tell users about you, why you made this add-on, "
-"and what's next for the add-on. This profile is required for add-ons "
-"requesting contributions, but can be useful for any developer interested in "
-"connecting with users."
+"Your developer profile will tell users about you, why you made this add-on, and what's next for the add-on. This profile is required for add-ons requesting contributions, but can be useful for any "
+"developer interested in connecting with users."
 msgstr ""
-"Seu perfil de desenvolvedor contará aos usuários mais sobre você, por que "
-"você criou esse aplicativo e o que vem aí para ele. Esse perfil é necessário"
-" para complementos pedido contribuições, mas pode ser útil para qualquer "
-"desenvolvedor interessado em entrar em contato com seus usuários."
+"Seu perfil de desenvolvedor contará aos usuários mais sobre você, por que você criou esse aplicativo e o que vem aí para ele. Esse perfil é necessário para complementos pedido contribuições, mas "
+"pode ser útil para qualquer desenvolvedor interessado em entrar em contato com seus usuários."
 
 #: src/olympia/devhub/templates/devhub/includes/addons_create_profile.html:32
 msgid "Make sure your user profile is up to date."
@@ -8337,20 +6436,12 @@ msgid "<a href=\"%(url)s\"><strong>Update your user profile.</strong></a>"
 msgstr "<a href=\"%(url)s\"><strong>Atualizar meu perfil de usuário.</strong></a>"
 
 #: src/olympia/devhub/templates/devhub/includes/addons_create_profile.html:45
-msgid ""
-"Whether it was an idea while in line at the grocery store or the solution to"
-" one of life's great problems, share your story."
-msgstr ""
-"Seja uma ideia que você teve na fila do supermercado ou a solução para um "
-"grande problema na sua vida, compartilhe sua história."
+msgid "Whether it was an idea while in line at the grocery store or the solution to one of life's great problems, share your story."
+msgstr "Seja uma ideia que você teve na fila do supermercado ou a solução para um grande problema na sua vida, compartilhe sua história."
 
 #: src/olympia/devhub/templates/devhub/includes/addons_create_profile.html:61
-msgid ""
-"Telling your users what's coming soon will give them something to look "
-"forward to."
-msgstr ""
-"Informar o que virá nas próximas versões faz com que seus usuários tenham "
-"interesse nas próximas versões."
+msgid "Telling your users what's coming soon will give them something to look forward to."
+msgstr "Informar o que virá nas próximas versões faz com que seus usuários tenham interesse nas próximas versões."
 
 #: src/olympia/devhub/templates/devhub/includes/addons_edit_nav.html:23
 msgid "View All"
@@ -8381,9 +6472,7 @@ msgid "View the blog &#9658;"
 msgstr "Ver o blog &#9658;"
 
 #: src/olympia/devhub/templates/devhub/includes/license_form.html:6
-msgid ""
-"Please choose a license appropriate for the rights you grant on your source code.\n"
-"                  It is only relevant for listed add-ons."
+msgid "Please choose a license appropriate for the rights you grant on your source code. It is only relevant for listed add-ons."
 msgstr ""
 "Por favor escolha uma licença apropriada para o seu código fonte.\n"
 "                  Isto é relevante apenas para complementos listados."
@@ -8401,10 +6490,9 @@ msgstr "Alguns elementos HTML são suportados."
 msgid "Remove this application"
 msgstr "Remover esta aplicação"
 
-#. {0} is the maximum number of add-on categories allowed.                {1}
-#. is
-#. the application name.
 # {1} is the application name (Firefox, Thunderbird)
+#. {0} is the maximum number of add-on categories allowed.                {1} is
+#. the application name.
 #: src/olympia/devhub/templates/devhub/includes/macros.html:70
 msgid "Select <b>up to {0}</b> {1} category for this add-on:"
 msgid_plural "Select <b>up to {0}</b> {1} categories for this add-on:"
@@ -8413,39 +6501,27 @@ msgstr[1] "Selecione <b>até {0}</b> categorias do {1} para esse complemento:"
 
 #: src/olympia/devhub/templates/devhub/includes/policy_form.html:4
 msgid ""
-"Users will be required to accept the following End-User License Agreement (EULA) prior to installing your add-on. The presence of a EULA significantly affects the number of downloads an add-on receives. Please note that a EULA is not the same as a code license, such as the GPL or MPL.\n"
-"                It is only relevant for listed add-ons."
+"Users will be required to accept the following End-User License Agreement (EULA) prior to installing your add-on. The presence of a EULA significantly affects the number of downloads an add-on "
+"receives. Please note that a EULA is not the same as a code license, such as the GPL or MPL.It is only relevant for listed add-ons."
 msgstr ""
-"Os usuários terão que aceitar o seguinte Acordo de Licença de Usuário Final(EULA) antes de instalar seu add-on. A presença de um EULA afeta signifcativamente o número de downloads de um add-on. Por favor, note que um EULA não é o mesmo que licença de código, como GPL ou MPL.\n"
-"                Somente é relevante para os add-ons listados."
 
-#: src/olympia/devhub/templates/devhub/includes/policy_form.html:21
-msgid ""
-"If your add-on transmits any data from the user's computer, a privacy policy is required that explains what data is sent and how it is used.\n"
-"                It is only relevant for listed add-ons."
+#: src/olympia/devhub/templates/devhub/includes/policy_form.html:24
+msgid "If your add-on transmits any data from the user's computer, a privacy policy is required that explains what data is sent and how it is used. It is only relevant for listed add-ons."
 msgstr ""
 "Se seu add-on transmite qualquer dado do computador do usuário, é obrigatória uma política de privacidade que explique quais dados são enviados e como são utilizados.\n"
 "                Somente é relevante para os add-ons listados."
 
 #: src/olympia/devhub/templates/devhub/includes/source_form_field.html:2
-msgid ""
-"If your add-on contains binary or obfuscated code other than known "
-"libraries, upload its sources for review."
-msgstr ""
-"Se o seu complemento contém o código binário ou ofuscado de diferente "
-"bibliotecas conhecidas, envie suas fontes para a revisão."
+msgid "If your add-on contains binary or obfuscated code other than known libraries, upload its sources for review."
+msgstr "Se o seu complemento contém o código binário ou ofuscado de diferente bibliotecas conhecidas, envie suas fontes para a revisão."
 
 #: src/olympia/devhub/templates/devhub/includes/source_form_field.html:3
 msgid "Read more about the source code review policy."
 msgstr "Leia mais sobre a política de revisão de código fonte."
 
 #: src/olympia/devhub/templates/devhub/includes/version_file.html:20
-msgid ""
-"You cannot remove an individual file after the review process has begun. You"
-" must delete the entire version."
-msgstr ""
-"Você não pode remover um arquivo individual depois de o processo de análise "
-"ter começado. Você deve excluir a versão inteira."
+msgid "You cannot remove an individual file after the review process has begun. You must delete the entire version."
+msgstr "Você não pode remover um arquivo individual depois de o processo de análise ter começado. Você deve excluir a versão inteira."
 
 # %s is href="..." and should stay in the <a> tag.
 #: src/olympia/devhub/templates/devhub/includes/version_file.html:36
@@ -8474,29 +6550,20 @@ msgid "Voluntary Contributions"
 msgstr "Contribuições voluntárias"
 
 #: src/olympia/devhub/templates/devhub/payments/payments.html:38
-msgid ""
-"Add-ons enrolled in our contributions program can request voluntary "
-"financial support from users."
-msgstr ""
-"Complementos inscritos em nosso programa de contribuições podem solicitar "
-"apoio financeiro voluntário dos usuários."
+msgid "Add-ons enrolled in our contributions program can request voluntary financial support from users."
+msgstr "Complementos inscritos em nosso programa de contribuições podem solicitar apoio financeiro voluntário dos usuários."
 
 #: src/olympia/devhub/templates/devhub/payments/payments.html:40
 msgid "Encourage users to support your add-on through your Developer Profile"
-msgstr ""
-"Encoraje usuários a apoiar seu complemento pelo perfil de desenvolvedor"
+msgstr "Encoraje usuários a apoiar seu complemento pelo perfil de desenvolvedor"
 
 #: src/olympia/devhub/templates/devhub/payments/payments.html:41
 msgid "Choose when and how users are asked to contribute"
 msgstr "Escolha quando e como as solicitações de contribuição serão exibidas"
 
 #: src/olympia/devhub/templates/devhub/payments/payments.html:42
-msgid ""
-"Receive contributions in your PayPal account or send them to an organization"
-" of your choice"
-msgstr ""
-"Receba contribuições na sua conta do PayPal ou mande para uma organização da"
-" sua escolha"
+msgid "Receive contributions in your PayPal account or send them to an organization of your choice"
+msgstr "Receba contribuições na sua conta do PayPal ou mande para uma organização da sua escolha"
 
 #: src/olympia/devhub/templates/devhub/payments/payments.html:46
 msgid "Contributions are only available for listed add-ons."
@@ -8504,21 +6571,14 @@ msgstr "As contribuições só estão disponíveis para complementos listados."
 
 #: src/olympia/devhub/templates/devhub/payments/payments.html:53
 #, python-format
-msgid ""
-"Contributions are only available for add-ons with a <a "
-"href=\"%(url)s\">completed developer profile</a>."
-msgstr ""
-"As contribuições só estão disponíveis para complementos com um <a "
-"href=\"%(url)s\">perfil de desenvolvedor completo</a>."
+msgid "Contributions are only available for add-ons with a <a href=\"%(url)s\">completed developer profile</a>."
+msgstr "As contribuições só estão disponíveis para complementos com um <a href=\"%(url)s\">perfil de desenvolvedor completo</a>."
 
 #: src/olympia/devhub/templates/devhub/payments/payments.html:59
 msgid "Contributions are only available for fully reviewed add-ons."
-msgstr ""
-"As contribuições só estão disponíveis para complementos com análise "
-"completa."
+msgstr "As contribuições só estão disponíveis para complementos com análise completa."
 
-#: src/olympia/devhub/templates/devhub/payments/payments.html:65
-#: src/olympia/devhub/templates/devhub/payments/voluntary.html:2
+#: src/olympia/devhub/templates/devhub/payments/payments.html:65 src/olympia/devhub/templates/devhub/payments/voluntary.html:2
 msgid "Set up Contributions"
 msgstr "Definir contribuições"
 
@@ -8531,18 +6591,13 @@ msgstr "2º passo. Preço e disponibilidade"
 msgid "or <a href=\"%(cancel)s\">Cancel</a>"
 msgstr "ou <a href=\"%(cancel)s\">Cancelar</a>"
 
-#: src/olympia/devhub/templates/devhub/payments/voluntary.html:2
-#: src/olympia/stats/templates/stats/addon_report_menu.html:39
+#: src/olympia/devhub/templates/devhub/payments/voluntary.html:2 src/olympia/stats/templates/stats/addon_report_menu.html:39
 msgid "Contributions"
 msgstr "Contribuições"
 
 #: src/olympia/devhub/templates/devhub/payments/voluntary.html:3
-msgid ""
-"Fill in the fields below to begin asking for voluntary contributions from "
-"users."
-msgstr ""
-"Preencha os campos abaixo para começar a pedir contribuições voluntárias dos"
-" usuários."
+msgid "Fill in the fields below to begin asking for voluntary contributions from users."
+msgstr "Preencha os campos abaixo para começar a pedir contribuições voluntárias dos usuários."
 
 #: src/olympia/devhub/templates/devhub/payments/voluntary.html:11
 msgid "Who will receive contributions to this add-on?"
@@ -8587,23 +6642,16 @@ msgid "Send a thank-you note?"
 msgstr "Enviar uma mensagem de agradecimento?"
 
 #: src/olympia/devhub/templates/devhub/payments/voluntary.html:47
-msgid ""
-"We'll automatically email users who contribute to your add-on with this "
-"message."
-msgstr ""
-"Nós enviaremos uma mensagem automática para usuários que contribuírem com o "
-"seu complemento."
+msgid "We'll automatically email users who contribute to your add-on with this message."
+msgstr "Nós enviaremos uma mensagem automática para usuários que contribuírem com o seu complemento."
 
 #: src/olympia/devhub/templates/devhub/payments/voluntary.html:49
 msgid ""
-"We recommend thanking the user and telling them how much you appreciate "
-"their support. You might also want to tell them about what's next for your "
-"add-on and about any other add-ons you've made for them to try."
+"We recommend thanking the user and telling them how much you appreciate their support. You might also want to tell them about what's next for your add-on and about any other add-ons you've made for "
+"them to try."
 msgstr ""
-"Recomendamos que você agradeça aos usuários e conte o quanto você aprecia o "
-"apoio deles. Você também pode contar as próximas novidades do seu "
-"complemento e sobre qualquer outro complemento que você tenha feito para "
-"eles testarem."
+"Recomendamos que você agradeça aos usuários e conte o quanto você aprecia o apoio deles. Você também pode contar as próximas novidades do seu complemento e sobre qualquer outro complemento que você "
+"tenha feito para eles testarem."
 
 #: src/olympia/devhub/templates/devhub/payments/voluntary.html:64
 msgid "Activate Contributions"
@@ -8617,156 +6665,103 @@ msgstr "ou <a id=\"setup-cancel\" href=\"#\">Cancelar</a>"
 msgid "Transfer ownership"
 msgstr "Transferir propriedade"
 
-#: src/olympia/devhub/templates/devhub/personas/edit.html:77
-#: src/olympia/devhub/templates/devhub/personas/submit.html:31
+#: src/olympia/devhub/templates/devhub/personas/edit.html:77 src/olympia/devhub/templates/devhub/personas/submit.html:31
 msgid "Theme Details"
 msgstr "Detalhes do tema"
 
-#: src/olympia/devhub/templates/devhub/personas/edit.html:87
-#: src/olympia/devhub/templates/devhub/personas/submit.html:36
+#: src/olympia/devhub/templates/devhub/personas/edit.html:87 src/olympia/devhub/templates/devhub/personas/submit.html:36
 msgid "Supply a pretty URL for your detail page."
 msgstr "Forneça uma URL fácil para a sua página de detalhes."
 
 # 86%
-#: src/olympia/devhub/templates/devhub/personas/edit.html:92
-#: src/olympia/devhub/templates/devhub/personas/submit.html:41
+#: src/olympia/devhub/templates/devhub/personas/edit.html:92 src/olympia/devhub/templates/devhub/personas/submit.html:41
 msgid "Select the category that best describes your Theme."
 msgstr "Selecione a categoria que descreve melhor o seu tema."
 
-#: src/olympia/devhub/templates/devhub/personas/edit.html:95
-#: src/olympia/devhub/templates/devhub/personas/submit.html:44
+#: src/olympia/devhub/templates/devhub/personas/edit.html:95 src/olympia/devhub/templates/devhub/personas/submit.html:44
 msgid "Add some tags to describe your Theme."
 msgstr "Adicione algumas etiquetas para descrever o seu tema."
 
-#: src/olympia/devhub/templates/devhub/personas/edit.html:106
-msgid ""
-"A short explanation of your theme's\n"
-"                                basic functionality that is displayed in\n"
-"                                search and browse listings, as well as at\n"
-"                                the top of your theme's details page."
+#: src/olympia/devhub/templates/devhub/personas/edit.html:106 src/olympia/devhub/templates/devhub/personas/submit.html:54
+msgid "A short explanation of your theme's basic functionality that is displayed in search and browse listings, as well as at the top of your theme's details page."
 msgstr ""
 "Uma breve explicação da funcionalidade\n"
 "                                básica do tema que é exibido nas\n"
 "                                listas de busca e navegação, bem como no\n"
 "                                topo da página de detalhes do seu tema."
 
-#: src/olympia/devhub/templates/devhub/personas/edit.html:122
-#: src/olympia/devhub/templates/devhub/personas/submit.html:68
+#: src/olympia/devhub/templates/devhub/personas/edit.html:122 src/olympia/devhub/templates/devhub/personas/submit.html:68
 msgid "Theme License"
 msgstr "Licença do tema"
 
 # 88%
-#: src/olympia/devhub/templates/devhub/personas/edit.html:126
-#: src/olympia/devhub/templates/devhub/personas/submit.html:72
+#: src/olympia/devhub/templates/devhub/personas/edit.html:126 src/olympia/devhub/templates/devhub/personas/submit.html:72
 msgid "Can others share your Theme, as long as you're given credit?"
-msgstr ""
-"Outras pessoas podem compartilhar seu tema, desde que dando crédito a você?"
+msgstr "Outras pessoas podem compartilhar seu tema, desde que dando crédito a você?"
 
-#: src/olympia/devhub/templates/devhub/personas/edit.html:132
-#: src/olympia/devhub/templates/devhub/personas/edit.html:153
-#: src/olympia/devhub/templates/devhub/personas/submit.html:78
+#: src/olympia/devhub/templates/devhub/personas/edit.html:132 src/olympia/devhub/templates/devhub/personas/edit.html:153 src/olympia/devhub/templates/devhub/personas/submit.html:78
 #: src/olympia/devhub/templates/devhub/personas/submit.html:99
-msgid ""
-"The licensor permits others to copy, distribute, display, and perform the "
-"work, including for commercial purposes."
-msgstr ""
-"O licenciador permite que outras pessoas copiem, distribuam, exibam e "
-"executem o trabalho, incluindo para fins comerciais."
+msgid "The licensor permits others to copy, distribute, display, and perform the work, including for commercial purposes."
+msgstr "O licenciador permite que outras pessoas copiem, distribuam, exibam e executem o trabalho, incluindo para fins comerciais."
 
-#: src/olympia/devhub/templates/devhub/personas/edit.html:141
-#: src/olympia/devhub/templates/devhub/personas/edit.html:162
-#: src/olympia/devhub/templates/devhub/personas/submit.html:87
+#: src/olympia/devhub/templates/devhub/personas/edit.html:141 src/olympia/devhub/templates/devhub/personas/edit.html:162 src/olympia/devhub/templates/devhub/personas/submit.html:87
 #: src/olympia/devhub/templates/devhub/personas/submit.html:108
-msgid ""
-"The licensor permits others to copy, distribute, display, and perform the "
-"work for non-commercial purposes only."
-msgstr ""
-"O licenciador permite que outras pessoas copiem, distribuam, exibam e "
-"executem o trabalho apenas para fins não comerciais."
+msgid "The licensor permits others to copy, distribute, display, and perform the work for non-commercial purposes only."
+msgstr "O licenciador permite que outras pessoas copiem, distribuam, exibam e executem o trabalho apenas para fins não comerciais."
 
 # 85%
-#: src/olympia/devhub/templates/devhub/personas/edit.html:147
-#: src/olympia/devhub/templates/devhub/personas/submit.html:93
+#: src/olympia/devhub/templates/devhub/personas/edit.html:147 src/olympia/devhub/templates/devhub/personas/submit.html:93
 msgid "Can others make commercial use of your Theme?"
 msgstr "Outras pessoas podem usar seu tema comercialmente?"
 
 # 86%
-#: src/olympia/devhub/templates/devhub/personas/edit.html:168
-#: src/olympia/devhub/templates/devhub/personas/submit.html:114
+#: src/olympia/devhub/templates/devhub/personas/edit.html:168 src/olympia/devhub/templates/devhub/personas/submit.html:114
 msgid "Can others create derivative works from your Theme?"
 msgstr "Outras pessoas podem criar outros trabalhos derivados do seu tema?"
 
-#: src/olympia/devhub/templates/devhub/personas/edit.html:174
-#: src/olympia/devhub/templates/devhub/personas/submit.html:120
-msgid ""
-"The licensor permits others to copy, distribute, display and perform the "
-"work, as well as make derivative works based on it."
-msgstr ""
-"O licenciador permite que outras pessoas copiem, distribuam, exibam e "
-"executem o trabalho, além de poder criar trabalhos derivados baseados nele."
+#: src/olympia/devhub/templates/devhub/personas/edit.html:174 src/olympia/devhub/templates/devhub/personas/submit.html:120
+msgid "The licensor permits others to copy, distribute, display and perform the work, as well as make derivative works based on it."
+msgstr "O licenciador permite que outras pessoas copiem, distribuam, exibam e executem o trabalho, além de poder criar trabalhos derivados baseados nele."
 
-#: src/olympia/devhub/templates/devhub/personas/edit.html:182
-#: src/olympia/devhub/templates/devhub/personas/submit.html:128
+#: src/olympia/devhub/templates/devhub/personas/edit.html:182 src/olympia/devhub/templates/devhub/personas/submit.html:128
 msgid "Yes, as long as they share alike"
 msgstr "Sim, contanto que eles sejam distribuídos pela mesma licença"
 
-#: src/olympia/devhub/templates/devhub/personas/edit.html:183
-#: src/olympia/devhub/templates/devhub/personas/submit.html:129
-msgid ""
-"The licensor permits others to distribute derivativeworks only under the "
-"same license or one compatible with the one that governs the licensor's "
-"work."
-msgstr ""
-"O licenciador permite que outras pessoas distribuam trabalhos derivados "
-"apenas sob a mesma licença ou uma compatível com a que governa o trabalho do"
-" licenciante."
+#: src/olympia/devhub/templates/devhub/personas/edit.html:183 src/olympia/devhub/templates/devhub/personas/submit.html:129
+msgid "The licensor permits others to distribute derivativeworks only under the same license or one compatible with the one that governs the licensor's work."
+msgstr "O licenciador permite que outras pessoas distribuam trabalhos derivados apenas sob a mesma licença ou uma compatível com a que governa o trabalho do licenciante."
 
-#: src/olympia/devhub/templates/devhub/personas/edit.html:192
-#: src/olympia/devhub/templates/devhub/personas/submit.html:138
-msgid ""
-"The licensor permits others to copy, distribute and transmit only unaltered "
-"copies of the work — not derivative works based on it."
-msgstr ""
-"O licenciador permite que outras pessoas copiem, distribuam e transmitam "
-"apenas cópias inalteradas do trabalho — e não trabalhos derivados baseados "
-"nele."
+#: src/olympia/devhub/templates/devhub/personas/edit.html:192 src/olympia/devhub/templates/devhub/personas/submit.html:138
+msgid "The licensor permits others to copy, distribute and transmit only unaltered copies of the work — not derivative works based on it."
+msgstr "O licenciador permite que outras pessoas copiem, distribuam e transmitam apenas cópias inalteradas do trabalho — e não trabalhos derivados baseados nele."
 
 # 87%
-#: src/olympia/devhub/templates/devhub/personas/edit.html:199
-#: src/olympia/devhub/templates/devhub/personas/submit.html:145
+#: src/olympia/devhub/templates/devhub/personas/edit.html:199 src/olympia/devhub/templates/devhub/personas/submit.html:145
 msgid "Your Theme will be released under the following license:"
 msgstr "Seu tema será lançado sob a seguinte licença:"
 
-#: src/olympia/devhub/templates/devhub/personas/edit.html:202
-#: src/olympia/devhub/templates/devhub/personas/submit.html:148
+#: src/olympia/devhub/templates/devhub/personas/edit.html:202 src/olympia/devhub/templates/devhub/personas/submit.html:148
 msgid "Select a different license."
 msgstr "Selecione uma licença diferente."
 
-#: src/olympia/devhub/templates/devhub/personas/edit.html:207
-#: src/olympia/devhub/templates/devhub/personas/submit.html:153
+#: src/olympia/devhub/templates/devhub/personas/edit.html:207 src/olympia/devhub/templates/devhub/personas/submit.html:153
 msgid "Select a license for your Theme."
 msgstr "Selecione uma licença para o seu tema."
 
-#: src/olympia/devhub/templates/devhub/personas/edit.html:217
-#: src/olympia/devhub/templates/devhub/personas/submit.html:163
+#: src/olympia/devhub/templates/devhub/personas/edit.html:217 src/olympia/devhub/templates/devhub/personas/submit.html:163
 msgid "Theme Design"
 msgstr "Design do tema"
 
-#: src/olympia/devhub/templates/devhub/personas/edit.html:221
-#: src/olympia/devhub/templates/devhub/personas/edit.html:224
+#: src/olympia/devhub/templates/devhub/personas/edit.html:221 src/olympia/devhub/templates/devhub/personas/edit.html:224
 msgid "Upload New Design"
 msgstr "Fazer upload de um design novo"
 
 #: src/olympia/devhub/templates/devhub/personas/edit.html:226
-msgid ""
-"Upon upload and form submission, the AMO Team will review your updated "
-"design. Your current design will still be public in the meantime."
-msgstr ""
-"Após envio e submissão do formulário, o time do AMO irá rever o seu projeto "
-"atualizado. Seu projeto atual continuará público nesse período."
+msgid "Upon upload and form submission, the AMO Team will review your updated design. Your current design will still be public in the meantime."
+msgstr "Após envio e submissão do formulário, o time do AMO irá rever o seu projeto atualizado. Seu projeto atual continuará público nesse período."
 
 #: src/olympia/devhub/templates/devhub/personas/edit.html:241
-msgid "Your previously resubmitted design,  which is under pending review."
+msgid "Your previously resubmitted design, which is under pending review."
 msgstr "Seu design reenviado anteriormente,   que está pendente de revisão."
 
 #: src/olympia/devhub/templates/devhub/personas/edit.html:245
@@ -8789,43 +6784,35 @@ msgstr "Cabeçalho"
 msgid "Footer"
 msgstr "Rodapé"
 
-#: src/olympia/devhub/templates/devhub/personas/edit.html:274
-#: src/olympia/devhub/templates/devhub/personas/submit.html:167
+#: src/olympia/devhub/templates/devhub/personas/edit.html:274 src/olympia/devhub/templates/devhub/personas/submit.html:167
 msgid "Select colors for your Theme."
 msgstr "Selecione as cores do seu tema."
 
-#: src/olympia/devhub/templates/devhub/personas/edit.html:276
-#: src/olympia/devhub/templates/devhub/personas/submit.html:169
+#: src/olympia/devhub/templates/devhub/personas/edit.html:276 src/olympia/devhub/templates/devhub/personas/submit.html:169
 msgid "Foreground Text"
 msgstr "Cor do texto"
 
-#: src/olympia/devhub/templates/devhub/personas/edit.html:277
-#: src/olympia/devhub/templates/devhub/personas/submit.html:170
+#: src/olympia/devhub/templates/devhub/personas/edit.html:277 src/olympia/devhub/templates/devhub/personas/submit.html:170
 msgid "This is the color of the tab text."
 msgstr "Esta é a cor do texto das abas."
 
-#: src/olympia/devhub/templates/devhub/personas/edit.html:279
-#: src/olympia/devhub/templates/devhub/personas/submit.html:172
+#: src/olympia/devhub/templates/devhub/personas/edit.html:279 src/olympia/devhub/templates/devhub/personas/submit.html:172
 msgid "Background"
 msgstr "Fundo"
 
-#: src/olympia/devhub/templates/devhub/personas/edit.html:280
-#: src/olympia/devhub/templates/devhub/personas/submit.html:173
+#: src/olympia/devhub/templates/devhub/personas/edit.html:280 src/olympia/devhub/templates/devhub/personas/submit.html:173
 msgid "This is the color of the tabs."
 msgstr "Esta é a cor do fundo das abas."
 
-#: src/olympia/devhub/templates/devhub/personas/edit.html:285
-#: src/olympia/devhub/templates/devhub/personas/submit.html:178
+#: src/olympia/devhub/templates/devhub/personas/edit.html:285 src/olympia/devhub/templates/devhub/personas/submit.html:178
 msgid "Preview"
 msgstr "Visualizar"
 
-#: src/olympia/devhub/templates/devhub/personas/edit.html:291
-#: src/olympia/devhub/templates/devhub/personas/submit.html:183
+#: src/olympia/devhub/templates/devhub/personas/edit.html:291 src/olympia/devhub/templates/devhub/personas/submit.html:183
 msgid "Your Theme's Name"
 msgstr "Nome do seu tema"
 
-#: src/olympia/devhub/templates/devhub/personas/edit.html:294
-#: src/olympia/devhub/templates/devhub/personas/submit.html:186
+#: src/olympia/devhub/templates/devhub/personas/edit.html:294 src/olympia/devhub/templates/devhub/personas/submit.html:186
 #, python-format
 msgid "by <a href=\"%(profile_url)s\" target=\"_blank\">%(user)s</a>"
 msgstr "por <a href=\"%(profile_url)s\" target=\"_blank\">%(user)s</a>"
@@ -8836,73 +6823,39 @@ msgstr "Criar um novo tema"
 
 #: src/olympia/devhub/templates/devhub/personas/submit.html:18
 #, python-format
-msgid ""
-"Background themes let you easily personalize the look of your Firefox. "
-"Submit your own design below, or <a href=\"%(submit_url)s\">learn how to "
-"create one</a>!"
-msgstr ""
-"Temas de fundo permitem que você personalize facilmente o visual do seu "
-"Firefox. Envie seu próprio design abaixo, ou <a "
-"href=\"%(submit_url)s\">saiba como criar um</a>!"
+msgid "Background themes let you easily personalize the look of your Firefox. Submit your own design below, or <a href=\"%(submit_url)s\">learn how to create one</a>!"
+msgstr "Temas de fundo permitem que você personalize facilmente o visual do seu Firefox. Envie seu próprio design abaixo, ou <a href=\"%(submit_url)s\">saiba como criar um</a>!"
 
 #: src/olympia/devhub/templates/devhub/personas/submit.html:33
 msgid "Give your Theme a name."
 msgstr "Digite um nome para seu tema."
 
-#: src/olympia/devhub/templates/devhub/personas/submit.html:54
-msgid ""
-"A short explanation of your theme's\n"
-"                                      basic functionality that is displayed in\n"
-"                                      search and browse listings, as well as at\n"
-"                                      the top of your theme's details page."
-msgstr ""
-"Uma breve explicação da funcionalidade\n"
-"                                      básica do tema que é exibido nas\n"
-"                                      listas de busca e navegação, bem como no\n"
-"                                      topo da página de detalhes do seu tema."
-
 #: src/olympia/devhub/templates/devhub/personas/submit.html:198
 #, python-format
 msgid ""
-"I agree to the <a href=\"%(agreement_url)s\" target=\"_blank\">Firefox Add-"
-"on Distribution Agreement</a> and to my information being handled as "
-"described in the <a href=\"%(privacy_notice_url)s\" "
+"I agree to the <a href=\"%(agreement_url)s\" target=\"_blank\">Firefox Add-on Distribution Agreement</a> and to my information being handled as described in the <a href=\"%(privacy_notice_url)s\" "
 "target=\"_blank\">Websites, Communications and Cookies Privacy Notice</a>."
 msgstr ""
-"Concordo que o <a href=\"%(agreement_url)s\" target=\"_blank\">Acordo de "
-"distribuição do Firefox Add-on</a> e minhas informações sendo tratados "
-"conforme descrito no <a href=\"%(privacy_notice_url)s\" "
-"target=\"_blank\">aviso de privacidade de Cookies, sites e comunicações</a>."
+"Concordo que o <a href=\"%(agreement_url)s\" target=\"_blank\">Acordo de distribuição do Firefox Add-on</a> e minhas informações sendo tratados conforme descrito no <a href=\"%(privacy_notice_url)s"
+"\" target=\"_blank\">aviso de privacidade de Cookies, sites e comunicações</a>."
 
 #: src/olympia/devhub/templates/devhub/personas/submit.html:205
 msgid "Submit Theme"
 msgstr "Enviar tema"
 
 #: src/olympia/devhub/templates/devhub/personas/submit_done.html:11
-msgid ""
-"Your theme has been submitted to the Review Queue. You'll receive an email "
-"once it has been reviewed, typically within 24 hours."
-msgstr ""
-"Seu tema foi submetido para uma análise. Você receberá uma mensagem assim "
-"que ele for analisado por um editor, normalmente em 24 horas."
+msgid "Your theme has been submitted to the Review Queue. You'll receive an email once it has been reviewed, typically within 24 hours."
+msgstr "Seu tema foi submetido para uma análise. Você receberá uma mensagem assim que ele for analisado por um editor, normalmente em 24 horas."
 
 #: src/olympia/devhub/templates/devhub/personas/submit_done.html:19
 #, python-format
-msgid ""
-"Provide more details about your theme by <a href=\"%(edit_url)s\">editing "
-"its listing</a>."
-msgstr ""
-"Forneça mais detalhes sobre seu tema editando a sua <a "
-"href=\"%(edit_url)s\">página de detalhes</a>."
+msgid "Provide more details about your theme by <a href=\"%(edit_url)s\">editing its listing</a>."
+msgstr "Forneça mais detalhes sobre seu tema editando a sua <a href=\"%(edit_url)s\">página de detalhes</a>."
 
 #: src/olympia/devhub/templates/devhub/personas/submit_done.html:25
 #, python-format
-msgid ""
-"View and subscribe to your theme's <a href=\"%(feed_url)s\">activity "
-"feed</a> to stay updated on reviews, collections, and more."
-msgstr ""
-"Veja e assine a <a href=\"%(feed_url)s\">atividade do seu tema</a> para "
-"ficar atualizado sobre análises, coleções e mais."
+msgid "View and subscribe to your theme's <a href=\"%(feed_url)s\">activity feed</a> to stay updated on reviews, collections, and more."
+msgstr "Veja e assine a <a href=\"%(feed_url)s\">atividade do seu tema</a> para ficar atualizado sobre análises, coleções e mais."
 
 #: src/olympia/devhub/templates/devhub/personas/submit_done.html:32
 #, python-format
@@ -8918,13 +6871,11 @@ msgstr "Selecione uma imagem de cabeçalho para seu tema."
 msgid "3000 &times; 200 pixels"
 msgstr "3000 &times; 200 píxeis"
 
-#: src/olympia/devhub/templates/devhub/personas/includes/theme_design.html:9
-#: src/olympia/devhub/templates/devhub/personas/includes/theme_design.html:25
+#: src/olympia/devhub/templates/devhub/personas/includes/theme_design.html:9 src/olympia/devhub/templates/devhub/personas/includes/theme_design.html:25
 msgid "300 KB max"
 msgstr "máximo de 300 KB"
 
-#: src/olympia/devhub/templates/devhub/personas/includes/theme_design.html:10
-#: src/olympia/devhub/templates/devhub/personas/includes/theme_design.html:26
+#: src/olympia/devhub/templates/devhub/personas/includes/theme_design.html:10 src/olympia/devhub/templates/devhub/personas/includes/theme_design.html:26
 msgid "PNG or JPG"
 msgstr "PNG ou JPG"
 
@@ -8954,65 +6905,32 @@ msgid "Select a different footer image"
 msgstr "Selecione uma imagem diferente de rodapé"
 
 #: src/olympia/devhub/templates/devhub/versions/add_file_modal.html:8
-msgid ""
-"Files added to reviewed versions must be reviewed before they will be "
-"available for download."
-msgstr ""
-"Arquivos adicionados a versões analisadas devem ser analisados antes de "
-"estarem disponíveis para download."
+msgid "Files added to reviewed versions must be reviewed before they will be available for download."
+msgstr "Arquivos adicionados a versões analisadas devem ser analisados antes de estarem disponíveis para download."
 
-#: src/olympia/devhub/templates/devhub/versions/add_file_modal.html:15
-#, python-format
-msgid ""
-"Submission of updates to unlisted add-ons for signing is currently in an "
-"open beta. Manual review may still be required for a large number of add-"
-"ons. Please <a href=\"%(url)s\" target=\"_blank\">report any bugs</a> that "
-"you encounter."
-msgstr ""
-"A submissão de atualizações de complementos não listados para assinatura "
-"está atualmente em beta. A revisão manual ainda pode ser requerida para um "
-"grande número de complementos.Por favor <a href=\"%(url)s\" "
-"target=\"_blank\"> reporte qualquer bug</a> que você encontre."
-
-#: src/olympia/devhub/templates/devhub/versions/add_file_modal.html:35
+#: src/olympia/devhub/templates/devhub/versions/add_file_modal.html:24
 msgid "Select the target platform for this file."
 msgstr "Selecione a plataforma alvo para este arquivo."
 
-#: src/olympia/devhub/templates/devhub/versions/add_file_modal.html:46
+#: src/olympia/devhub/templates/devhub/versions/add_file_modal.html:35
 msgid "Which review type would you like to nominate for?"
 msgstr "Para que tipo de revisão gostaria de nomear?"
 
-#: src/olympia/devhub/templates/devhub/versions/add_file_modal.html:51
+#: src/olympia/devhub/templates/devhub/versions/add_file_modal.html:40
 msgid "Only publish this version to my beta channel."
 msgstr "Publicar esta versão apenas no meu canal beta."
-
-#: src/olympia/devhub/templates/devhub/versions/add_file_modal.html:54
-#, python-format
-msgid ""
-"The behavior of the beta channel has changed to accommodate <a "
-"href=\"%(addon_signing_url)s\" target=\"_blank\">mandatory add-on "
-"signing</a>. The new process is currently in an open beta, and may change "
-"significantly in the near future. Please <a href=\"%(issues_url)s\" "
-"target=\"_blank\">report any bugs</a> that you encounter."
-msgstr ""
-"O comportamento com o canal beta foi alterado para acomodar <a "
-"href=\"%(addon_signing_url)s\" target=\"_blank\"> a assinatura mandatória de"
-" complementos</a>. O novo processo está atualmente em beta e pode mudar "
-"significativamente no futuro próximo. Por favor <a href=\"%(issues_url)s\" "
-"target=\"_blank\">reporte qualquer bug</a> que você encontre."
 
 # %s is the version number.
 #: src/olympia/devhub/templates/devhub/versions/edit.html:5
 msgid "Manage Version {0}"
 msgstr "Gerenciar versão {0}"
 
-#: src/olympia/devhub/templates/devhub/versions/edit.html:12
-#: src/olympia/devhub/templates/devhub/versions/list.html:3
+#: src/olympia/devhub/templates/devhub/versions/edit.html:12 src/olympia/devhub/templates/devhub/versions/list.html:3
 msgid "Status & Versions"
 msgstr "Status e versões"
 
-#. {0} is an add-on name.
 # {0} is the name of the collection
+#. {0} is an add-on name.
 #: src/olympia/devhub/templates/devhub/versions/edit.html:16
 msgid "Manage {0}"
 msgstr "Gerenciar {0}"
@@ -9025,22 +6943,10 @@ msgstr "Arquivos"
 msgid "Upload Another File"
 msgstr "Enviar outro arquivo"
 
-#: src/olympia/devhub/templates/devhub/versions/edit.html:45
-msgid ""
-"Adjusting application information here will allow users to install your\n"
-"                          add-on even if the install manifest in the package indicates that the\n"
-"                          add-on is incompatible."
-msgstr ""
-"Ajustar aqui a informação da aplicação permitirá aos usuários instalar\n"
-"                          seu add-on mesmo se o manifest de instalação do pacote indicar que\n"
-"                          o add-on é incompatível."
-
 #: src/olympia/devhub/templates/devhub/versions/edit.html:74
 msgid ""
-"Information about changes in this release, new features,\n"
-"                              known bugs, and other useful information specific to this\n"
-"                              release/version. This information is also shown in the\n"
-"                              Add-ons Manager when updating."
+"Information about changes in this release, new features, known bugs, and other useful information specific to this release/version. This information is also shown in the Add-ons Manager when "
+"updating."
 msgstr ""
 "Informação sobre mudanças nesta versão, novos recursos,\n"
 "                              erros conhecidos, e outra informação útil específica desta\n"
@@ -9051,16 +6957,12 @@ msgstr ""
 msgid "Approval Status"
 msgstr "Status da aprovação"
 
-#: src/olympia/devhub/templates/devhub/versions/edit.html:113
-#: src/olympia/editors/templates/editors/review.html:108
+#: src/olympia/devhub/templates/devhub/versions/edit.html:113 src/olympia/editors/templates/editors/review.html:108
 msgid "Notes for Reviewers"
 msgstr "Comentários ao editor"
 
 #: src/olympia/devhub/templates/devhub/versions/edit.html:114
-msgid ""
-"Optionally, enter any information that may be useful\n"
-"                              to the Editor reviewing this add-on, such as test\n"
-"                              account information."
+msgid "Optionally, enter any information that may be useful to the Editor reviewing this add-on, such as test account information."
 msgstr ""
 "Opcionalmente, digite qualquer informação que possa ser útil\n"
 "                              para o Editor revisor deste complemento, como informações\n"
@@ -9071,15 +6973,10 @@ msgid "Source code"
 msgstr "Código-fonte"
 
 #: src/olympia/devhub/templates/devhub/versions/edit.html:128
-msgid ""
-"If your add-on contain binary or obfuscated code, make the source available "
-"here for reviewers."
-msgstr ""
-"Se o seu complemento contém o código binário ou ofuscado, disponibilize a "
-"fonte para os revisores."
+msgid "If your add-on contain binary or obfuscated code, make the source available here for reviewers."
+msgstr "Se o seu complemento contém o código binário ou ofuscado, disponibilize a fonte para os revisores."
 
-#: src/olympia/devhub/templates/devhub/versions/edit.html:145
-#: src/olympia/devhub/templates/devhub/versions/edit.html:149
+#: src/olympia/devhub/templates/devhub/versions/edit.html:145 src/olympia/devhub/templates/devhub/versions/edit.html:149
 msgid "Upload a new file"
 msgstr "Enviar um arquivo novo"
 
@@ -9148,9 +7045,7 @@ msgstr "Solicitar análise completa"
 msgid "Request Preliminary Review"
 msgstr "Solicitar análise preliminar"
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:80
-#: src/olympia/devhub/templates/devhub/versions/list.html:327
-#: src/olympia/devhub/templates/devhub/versions/list.html:350
+#: src/olympia/devhub/templates/devhub/versions/list.html:80 src/olympia/devhub/templates/devhub/versions/list.html:325 src/olympia/devhub/templates/devhub/versions/list.html:348
 msgid "Cancel Review Request"
 msgstr "Cancelar solicitação de análise"
 
@@ -9163,35 +7058,24 @@ msgid "Listed:"
 msgstr "Na lista:"
 
 #: src/olympia/devhub/templates/devhub/versions/list.html:102
-msgid ""
-"Visible to everyone on {0} and included in search results and listing pages"
-msgstr ""
-"Visível para todos em {0} e incluídos no resultado de pesquisa e listando "
-"nas páginas "
+msgid "Visible to everyone on {0} and included in search results and listing pages"
+msgstr "Visível para todos em {0} e incluídos no resultado de pesquisa e listando nas páginas "
 
 #: src/olympia/devhub/templates/devhub/versions/list.html:108
 msgid "Hidden:"
 msgstr "Oculto:"
 
 #: src/olympia/devhub/templates/devhub/versions/list.html:108
-msgid ""
-"Hosted on {0}, but hidden to anyone but authors. Used to temporarily hide "
-"listings or discontinue them."
-msgstr ""
-"Hospedado no {0}, mas oculto para todos exceto os autores. Usado para "
-"ocultar temporariamente listagens ou para as descontinuar."
+msgid "Hosted on {0}, but hidden to anyone but authors. Used to temporarily hide listings or discontinue them."
+msgstr "Hospedado no {0}, mas oculto para todos exceto os autores. Usado para ocultar temporariamente listagens ou para as descontinuar."
 
 #: src/olympia/devhub/templates/devhub/versions/list.html:114
 msgid "Unlisted:"
 msgstr "Não listado:"
 
 #: src/olympia/devhub/templates/devhub/versions/list.html:114
-msgid ""
-"Not distributed on {0}. Developers will upload new versions for signing and "
-"distribute the add-ons on their own. (beta)"
+msgid "Not distributed on {0}. Developers will upload new versions for signing and distribute the add-ons on their own."
 msgstr ""
-"Não distribuído no {0}. Os desenvolvedores vão enviar novas versões para "
-"assinatura e distribuí-los por conta própria. (beta)"
 
 #: src/olympia/devhub/templates/devhub/versions/list.html:122
 msgid "Current versions"
@@ -9203,18 +7087,13 @@ msgstr "Atualmente no AMO"
 
 # 85%
 # 100%
-#: src/olympia/devhub/templates/devhub/versions/list.html:129
-#: src/olympia/devhub/templates/devhub/versions/list.html:147
-#: src/olympia/devhub/templates/devhub/versions/list.html:164
-#: src/olympia/editors/templates/editors/includes/search_results_themes.html:7
-#: src/olympia/editors/templates/editors/themes/queue_list.html:50
+#: src/olympia/devhub/templates/devhub/versions/list.html:129 src/olympia/devhub/templates/devhub/versions/list.html:147 src/olympia/devhub/templates/devhub/versions/list.html:164
+#: src/olympia/editors/templates/editors/includes/search_results_themes.html:7 src/olympia/editors/templates/editors/themes/queue_list.html:50
 msgid "Status"
 msgstr "Status"
 
 # Header for a column in a table
-#: src/olympia/devhub/templates/devhub/versions/list.html:130
-#: src/olympia/devhub/templates/devhub/versions/list.html:148
-#: src/olympia/devhub/templates/devhub/versions/list.html:165
+#: src/olympia/devhub/templates/devhub/versions/list.html:130 src/olympia/devhub/templates/devhub/versions/list.html:148 src/olympia/devhub/templates/devhub/versions/list.html:165
 #: src/olympia/editors/templates/editors/includes/files_view.html:11
 msgid "Validation"
 msgstr "Validação"
@@ -9236,15 +7115,10 @@ msgid "Full review may not be required"
 msgstr "A revisão completa pode não ser necessária"
 
 #: src/olympia/devhub/templates/devhub/versions/list.html:201
-msgid ""
-"Unlisted add-ons don't need Full Review unless they are distributed as part "
-"of an application installer. Read <a href=\"{link}\" target=\"_blank\">this "
-"documentation</a> for more information."
+msgid "Unlisted add-ons don't need Full Review unless they are distributed as part of an application installer. Read <a href=\"{link}\" target=\"_blank\">this documentation</a> for more information."
 msgstr ""
-"Complementos não listados não precisam de revisão completa, a menos que eles"
-" sejão distribuídos como parte de um instalador de aplicativo. Leia <a "
-"href=\"{link}\" target=\"_blank\">esta documentação</a> para obter mais "
-"informações."
+"Complementos não listados não precisam de revisão completa, a menos que eles sejão distribuídos como parte de um instalador de aplicativo. Leia <a href=\"{link}\" target=\"_blank\">esta "
+"documentação</a> para obter mais informações."
 
 #: src/olympia/devhub/templates/devhub/versions/list.html:209
 msgid "Request full review"
@@ -9257,138 +7131,90 @@ msgstr "Excluir versão {version}"
 
 #: src/olympia/devhub/templates/devhub/versions/list.html:218
 msgid ""
-"You are about to delete the current version of your add-on. This may cause "
-"your add-on status to change, or your listing to lose public visibility, if "
-"this is the only public version of your add-on."
+"You are about to delete the current version of your add-on. This may cause your add-on status to change, or your listing to lose public visibility, if this is the only public version of your add-on."
 msgstr ""
-"Você está prestes a excluir a versão atual deste complemento. Isso pode "
-"fazer com que o seu estado mude ou que sua listagem perca visibilidade "
-"pública, se esta for a única versão pública do seu complemento."
+"Você está prestes a excluir a versão atual deste complemento. Isso pode fazer com que o seu estado mude ou que sua listagem perca visibilidade pública, se esta for a única versão pública do seu "
+"complemento."
 
 #: src/olympia/devhub/templates/devhub/versions/list.html:219
 msgid "Deleting this version will permanently delete:"
 msgstr "Excluindo essa versão irá excluir permanentemente:"
 
 #: src/olympia/devhub/templates/devhub/versions/list.html:225
-msgid ""
-"<strong>Important:</strong> Once a version has been deleted, you may not "
-"upload a new version with the same version number."
-msgstr ""
-"<strong>Importante:</strong> Assim que uma versão for excluída, não poderá "
-"enviar uma nova versão com o mesmo número de versão."
+msgid "<strong>Important:</strong> Once a version has been deleted, you may not upload a new version with the same version number."
+msgstr "<strong>Importante:</strong> Assim que uma versão for excluída, não poderá enviar uma nova versão com o mesmo número de versão."
 
 #: src/olympia/devhub/templates/devhub/versions/list.html:230
-msgid ""
-"Deleting a version which has already been reviewed\n"
-"               may also cause a significant delay in the review of\n"
-"               your next update."
-msgstr ""
-"Remover uma versão que já foi avaliada\n"
-"               pode causar um atraso significativo na avaliação da\n"
-"               sua próxima atualização."
-
-#: src/olympia/devhub/templates/devhub/versions/list.html:233
 msgid "Are you sure you wish to delete this version?"
 msgstr "Tem certeza de que deseja excluir essa versão?"
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:238
+#: src/olympia/devhub/templates/devhub/versions/list.html:235
 msgid "Delete Version"
 msgstr "Excluir versão"
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:240
+#: src/olympia/devhub/templates/devhub/versions/list.html:237
 msgid "Disable Version"
 msgstr "Desabilitar a versão"
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:247
+#: src/olympia/devhub/templates/devhub/versions/list.html:244
 msgid "Add a new Version"
 msgstr "Adicionar uma nova versão"
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:249
+#: src/olympia/devhub/templates/devhub/versions/list.html:246
 msgid "Add Version"
 msgstr "Adicionar versão"
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:256
-#: src/olympia/devhub/templates/devhub/versions/list.html:274
+#: src/olympia/devhub/templates/devhub/versions/list.html:253 src/olympia/devhub/templates/devhub/versions/list.html:279
 msgid "Hide Add-on"
 msgstr "Ocultar complemento"
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:259
-msgid ""
-"Hiding your add-on will prevent it from appearing anywhere in our gallery "
-"and will stop users from receiving automatic updates."
-msgstr ""
-"Ocultar o seu complemento irá impedir que o mesmo seja apresentado em "
-"qualquer lugar na nossa galeria e irá impedir que os usuários possam receber"
-" atualizações automáticas."
+#: src/olympia/devhub/templates/devhub/versions/list.html:256
+msgid "Hiding your add-on will prevent it from appearing anywhere in our gallery and will stop users from receiving automatic updates."
+msgstr "Ocultar o seu complemento irá impedir que o mesmo seja apresentado em qualquer lugar na nossa galeria e irá impedir que os usuários possam receber atualizações automáticas."
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:265
+#: src/olympia/devhub/templates/devhub/versions/list.html:263
+msgid "The files awaiting review will be disabled and you will need to upload new versions."
+msgstr ""
+
+#: src/olympia/devhub/templates/devhub/versions/list.html:270
 msgid "Are you sure you wish to hide your add-on?"
 msgstr "Tem certeza de que deseja ocultar o seu complemento?"
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:286
-#: src/olympia/devhub/templates/devhub/versions/list.html:315
+#: src/olympia/devhub/templates/devhub/versions/list.html:291 src/olympia/devhub/templates/devhub/versions/list.html:313
 msgid "Unlist Add-on"
 msgstr "Não listar complemento"
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:289
+#: src/olympia/devhub/templates/devhub/versions/list.html:294
 #, python-format
 msgid ""
-"Unlisting your add-on will make it (and each of its versions/files) "
-"invisible on this website. It won't show up in searches, won't have a public"
-" facing page, and won't be updated automatically for current users.  It is "
-"recommended for unlisted add-ons to provide a custom <a "
-"href=\"%(update_url)s\" target=\"_blank\">updateURL</a> in their manifest "
-"file for automatic updates."
+"Unlisting your add-on will make it (and each of its versions/files) invisible on this website. It won't show up in searches, won't have a public facing page, and won't be updated automatically for "
+"current users. It is recommended for unlisted add-ons to provide a custom <a href=\"%(update_url)s\" target=\"_blank\">updateURL</a> in their manifest file for automatic updates."
 msgstr ""
-"Remover seu complemento da listagem irá torná-lo (e todas as suas versões e "
-"arquivos) invisível neste site. Ele não aparecerá em buscas, não terá uma "
-"página disponível ao público externo e não será atualizado automaticamente "
-"para usuários atuais. É recomendado que complementos não listados "
-"disponibilizem uma <a href=\"%(update_url)s\" "
-"target=\"_blank\">updateURL</a> própria no arquivo de manifesto para "
-"atualizações automáticas."
+"Remover seu complemento da listagem irá torná-lo (e todas as suas versões e arquivos) invisível neste site. Ele não aparecerá em buscas, não terá uma página disponível ao público externo e não será "
+"atualizado automaticamente para usuários atuais. É recomendado que complementos não listados disponibilizem uma <a href=\"%(update_url)s\" target=\"_blank\">updateURL</a> própria no arquivo de "
+"manifesto para atualizações automáticas."
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:299
-#, python-format
-msgid ""
-"Switching add-ons to unlisted is currently in an open beta. Please <a "
-"href=\"%(url)s\" target=\"_blank\">report any bugs</a> that you encounter."
-msgstr ""
-"Mudar complementos para não listado está atualmente em uma versão beta.Por "
-"favor <a href=\"%(url)s\" target=\"_blank\">reporte quaisquer bugs</a> que "
-"você encontrar."
-
-#: src/olympia/devhub/templates/devhub/versions/list.html:305
+#: src/olympia/devhub/templates/devhub/versions/list.html:303
 msgid "Unlisting an add-on is irreversible!"
 msgstr "A remoção de um complemento é irreversível!"
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:305
+#: src/olympia/devhub/templates/devhub/versions/list.html:303
 msgid "An unlisted add-on cannot be switched to be listed."
 msgstr "Um complemento não listado não pode ser comutado para ser listado."
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:307
+#: src/olympia/devhub/templates/devhub/versions/list.html:305
 msgid "Are you sure you wish to unlist your add-on?"
 msgstr "Tem certeza de que não deseja listar o seu complemento?"
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:330
-msgid ""
-"Canceling your review request will leave your add-on as preliminarily "
-"reviewed."
-msgstr ""
-"Cancelar sua solicitação de análise manterá seu complemento como analisado "
-"preliminarmente."
+#: src/olympia/devhub/templates/devhub/versions/list.html:328
+msgid "Canceling your review request will leave your add-on as preliminarily reviewed."
+msgstr "Cancelar sua solicitação de análise manterá seu complemento como analisado preliminarmente."
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:335
-msgid ""
-"Canceling your review request will mark your add-on incomplete. If you do "
-"not complete your add-on after several days by re-requesting review, it will"
-" be deleted."
-msgstr ""
-"Cancelar sua solicitação de análise marcará seu complemento como incompleto."
-" Se não completar seu complemento solicitando uma nova análise após vários "
-"dias, ele será excluído."
+#: src/olympia/devhub/templates/devhub/versions/list.html:333
+msgid "Canceling your review request will mark your add-on incomplete. If you do not complete your add-on after several days by re-requesting review, it will be deleted."
+msgstr "Cancelar sua solicitação de análise marcará seu complemento como incompleto. Se não completar seu complemento solicitando uma nova análise após vários dias, ele será excluído."
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:343
+#: src/olympia/devhub/templates/devhub/versions/list.html:341
 msgid "Are you sure you wish to cancel your review request?"
 msgstr "Você tem certeza de que deseja cancelar sua solicitação de análise?"
 
@@ -9398,8 +7224,7 @@ msgstr "Fazer compras ficou mais fácil"
 
 #: src/olympia/discovery/modules.py:141
 msgid "Save on your favorite items from the comfort of your browser."
-msgstr ""
-"Economize comprando seus produtos favoritos no conforto do seu navegador."
+msgstr "Economize comprando seus produtos favoritos no conforto do seu navegador."
 
 #: src/olympia/discovery/modules.py:149
 msgid "Build the perfect website"
@@ -9423,19 +7248,12 @@ msgid "Translate content on the web from and into over 40 languages."
 msgstr "Traduz o conteúdo da internet para mais de 40 idiomas."
 
 #: src/olympia/discovery/modules.py:171
-msgid ""
-"Easily connect to your social networks, and share or comment on the page "
-"you're visiting."
-msgstr ""
-"Conecte-se facilmente às suas redes sociais e compartilhe ou comente a "
-"página que está visitando."
+msgid "Easily connect to your social networks, and share or comment on the page you're visiting."
+msgstr "Conecte-se facilmente às suas redes sociais e compartilhe ou comente a página que está visitando."
 
 #: src/olympia/discovery/modules.py:173
-msgid ""
-"A quick view to compare prices when you shop online or search for flights."
-msgstr ""
-"Uma visão rápida para comparar preços quando for comprar on-line ou procurar"
-" por voos."
+msgid "A quick view to compare prices when you shop online or search for flights."
+msgstr "Uma visão rápida para comparar preços quando for comprar on-line ou procurar por voos."
 
 #: src/olympia/discovery/modules.py:183
 msgid "Firefox 4 Collection"
@@ -9478,24 +7296,16 @@ msgid "Add-ons that help you on your travels!"
 msgstr "Complementos que ajudam em suas viagens!"
 
 #: src/olympia/discovery/modules.py:226
-msgid ""
-"Displays a country flag depicting the location of the current website's "
-"server and more."
-msgstr ""
-"Exibe uma bandeira referente à localização do servidor do site visitado e "
-"mais."
+msgid "Displays a country flag depicting the location of the current website's server and more."
+msgstr "Exibe uma bandeira referente à localização do servidor do site visitado e mais."
 
 #: src/olympia/discovery/modules.py:228
 msgid "FoxClocks let you keep an eye on the time around the world."
 msgstr "O FoxClocks permite que você fique de olho no tempo em todo o mundo."
 
 #: src/olympia/discovery/modules.py:230
-msgid ""
-"Automatically get the lowest price when you shop online or search for "
-"flights."
-msgstr ""
-"Encontre automaticamente o menor preço ao pesquisar passagens e voos on-"
-"line."
+msgid "Automatically get the lowest price when you shop online or search for flights."
+msgstr "Encontre automaticamente o menor preço ao pesquisar passagens e voos on-line."
 
 #: src/olympia/discovery/modules.py:240
 msgid "A+ add-ons for School"
@@ -9534,12 +7344,8 @@ msgid "Put a Theme on It!"
 msgstr "Troque o tema dele!"
 
 #: src/olympia/discovery/modules.py:281
-msgid ""
-"Visit addons.mozilla.org from Firefox for Android and dress up your mobile "
-"browser to match your style, mood, or the season."
-msgstr ""
-"Visite addons.mozilla.org no seu Firefox para Android e vista seu navegador "
-"de acordo com seu estilo, humor ou vontade."
+msgid "Visit addons.mozilla.org from Firefox for Android and dress up your mobile browser to match your style, mood, or the season."
+msgstr "Visite addons.mozilla.org no seu Firefox para Android e vista seu navegador de acordo com seu estilo, humor ou vontade."
 
 #: src/olympia/discovery/modules.py:290
 msgid "Get up and move!"
@@ -9547,8 +7353,7 @@ msgstr "Levante-se e se mexa!"
 
 #: src/olympia/discovery/modules.py:291
 msgid "Install these fitness add-ons to keep you active and healthy."
-msgstr ""
-"Instale esses complementos que vão te ajudar a manter sua saúde em dia."
+msgstr "Instale esses complementos que vão te ajudar a manter sua saúde em dia."
 
 #: src/olympia/discovery/modules.py:299
 msgid "New &amp; Now"
@@ -9567,12 +7372,8 @@ msgid "Protect your privacy online with the add-ons in this collection."
 msgstr "Proteja sua privacidade online com os complementos dessa coleção"
 
 #: src/olympia/discovery/modules.py:342
-msgid ""
-"Great add-ons for work, fun, privacy, productivity&hellip; just about "
-"anything!"
-msgstr ""
-"Complementos que servem para tudo: aumentar a produtividade no trabalho, "
-"aumentar a diversão em casa... confira!"
+msgid "Great add-ons for work, fun, privacy, productivity&hellip; just about anything!"
+msgstr "Complementos que servem para tudo: aumentar a produtividade no trabalho, aumentar a diversão em casa... confira!"
 
 #: src/olympia/discovery/modules.py:350
 msgid "Add-ons for Australis Contest Winners"
@@ -9592,21 +7393,16 @@ msgstr "O que são Complementos?"
 
 #: src/olympia/discovery/templates/discovery/pane.html:28
 #, python-format
-msgid ""
-"Add-ons are applications that let you personalize %(app)s with extra "
-"functionality or style. Try a time-saving sidebar, a weather notifier, or a "
-"themed look to make %(app)s your own."
+msgid "Add-ons are applications that let you personalize %(app)s with extra functionality or style. Try a time-saving sidebar, a weather notifier, or a themed look to make %(app)s your own."
 msgstr ""
-"Complementos são aplicativos que permitem que você personalize o %(app)s com"
-" estilos ou recursos extras. Teste um painel lateral para economizar tempo, "
-"um notificador do clima ou um visual temático para tornar o %(app)s só seu."
+"Complementos são aplicativos que permitem que você personalize o %(app)s com estilos ou recursos extras. Teste um painel lateral para economizar tempo, um notificador do clima ou um visual temático "
+"para tornar o %(app)s só seu."
 
 #: src/olympia/discovery/templates/discovery/pane.html:62
 msgid "Learn More About Add-ons"
 msgstr "Saiba mais sobre os complementos"
 
-#: src/olympia/discovery/templates/discovery/pane.html:66
-#: src/olympia/discovery/templates/discovery/pane.html:73
+#: src/olympia/discovery/templates/discovery/pane.html:66 src/olympia/discovery/templates/discovery/pane.html:73
 msgid "See all"
 msgstr "Ver todos"
 
@@ -9628,9 +7424,7 @@ msgstr "Fechar vídeo"
 
 #: src/olympia/discovery/templates/discovery/pane.html:94
 msgid "While the video plays, the add-ons being mentioned will appear here."
-msgstr ""
-"Enquanto o vídeo é reproduzido, o complemento sendo mencionado aparecerá "
-"aqui."
+msgstr "Enquanto o vídeo é reproduzido, o complemento sendo mencionado aparecerá aqui."
 
 #. {0} is the user's login name.
 #: src/olympia/discovery/templates/discovery/pane_account.html:6
@@ -9639,12 +7433,8 @@ msgstr "Olá {0}"
 
 #: src/olympia/discovery/templates/discovery/pane_account.html:17
 #, python-format
-msgid ""
-"Thanks for using %(app)s and supporting <a href=\"%(url)s\">Mozilla's "
-"mission</a>!"
-msgstr ""
-"Obrigado por usar o %(app)s e apoiar a <a href=\"%(url)s\">Missão "
-"Mozilla</a>!"
+msgid "Thanks for using %(app)s and supporting <a href=\"%(url)s\">Mozilla's mission</a>!"
+msgstr "Obrigado por usar o %(app)s e apoiar a <a href=\"%(url)s\">Missão Mozilla</a>!"
 
 #: src/olympia/discovery/templates/discovery/pane_account.html:23
 msgid "Add-ons downloaded:"
@@ -9668,15 +7458,10 @@ msgstr "Baixe complementos onde estiver"
 
 #: src/olympia/discovery/templates/discovery/modules/go-mobile.html:8
 #, python-format
-msgid ""
-"Visit <a href=\"%(url)s\">firefox.com/m</a> to get Firefox on your phone and"
-" personalize your browser anytime, anywhere. Easily discover and install "
-"add-ons from the mobile Add-ons Manager."
+msgid "Visit <a href=\"%(url)s\">firefox.com/m</a> to get Firefox on your phone and personalize your browser anytime, anywhere. Easily discover and install add-ons from the mobile Add-ons Manager."
 msgstr ""
-"Visite <a href=\"%(url)s\">firefox.com/m</a> para baixar o Firefox Móvel no "
-"seu celular e personalizar seu navegador em qualquer lugar, a qualquer hora."
-" Encontre e instale complementos facilmente usando o Gerenciador de "
-"complementos direto do seu aparelho."
+"Visite <a href=\"%(url)s\">firefox.com/m</a> para baixar o Firefox Móvel no seu celular e personalizar seu navegador em qualquer lugar, a qualquer hora. Encontre e instale complementos facilmente "
+"usando o Gerenciador de complementos direto do seu aparelho."
 
 #: src/olympia/discovery/templates/discovery/modules/go-mobile.html:13
 msgid "Get Mobile Add-ons"
@@ -9688,30 +7473,19 @@ msgstr "Compre com inteligência nas temporadas de férias"
 
 #: src/olympia/discovery/templates/discovery/modules/holiday.html:5
 msgid "Find great add-ons to help you with all your holiday shopping needs."
-msgstr ""
-"Encontre ótimos complementos para ajudá-lo com suas compras de temporada de "
-"férias."
+msgstr "Encontre ótimos complementos para ajudá-lo com suas compras de temporada de férias."
 
 #: src/olympia/discovery/templates/discovery/modules/holiday.html:13
-msgid ""
-"Install the Amazon Browser Apps and receive special Amazon features right at"
-" your fingertips."
-msgstr ""
-"Instale os aplicativos Amazon Browser e receba recursos especiais do Amazon "
-"na ponta dos seus dedos."
+msgid "Install the Amazon Browser Apps and receive special Amazon features right at your fingertips."
+msgstr "Instale os aplicativos Amazon Browser e receba recursos especiais do Amazon na ponta dos seus dedos."
 
 #: src/olympia/discovery/templates/discovery/modules/holiday.html:22
-msgid ""
-"Keep an eye on your eBay activity wherever you are on the web when you "
-"install the eBay Sidebar for Firefox."
-msgstr ""
-"Fique de olho nas suas atividades do eBay onde estiver na Web instalando o "
-"eBay Sidebar para Firefox."
+msgid "Keep an eye on your eBay activity wherever you are on the web when you install the eBay Sidebar for Firefox."
+msgstr "Fique de olho nas suas atividades do eBay onde estiver na Web instalando o eBay Sidebar para Firefox."
 
 #: src/olympia/discovery/templates/discovery/modules/holiday.html:31
 msgid "See the entire holiday shopping add-on collection."
-msgstr ""
-"Ver a coleção inteira de complementos para compras de temporada de férias."
+msgstr "Ver a coleção inteira de complementos para compras de temporada de férias."
 
 #: src/olympia/discovery/templates/discovery/modules/monthly.html:8
 msgid "Mozilla&rsquo;s Pick of the Month!"
@@ -9785,19 +7559,19 @@ msgstr "complemento, editor ou comentário"
 msgid "Search by add-on name / author email"
 msgstr "Procurar pelo nome do complemento / e-mail do autor"
 
-#: src/olympia/editors/forms.py:103
+#: src/olympia/editors/forms.py:103 src/olympia/editors/forms.py:244 src/olympia/editors/forms.py:257
 msgid "yes"
 msgstr "sim"
 
-#: src/olympia/editors/forms.py:104
+#: src/olympia/editors/forms.py:104 src/olympia/editors/forms.py:244 src/olympia/editors/forms.py:257
 msgid "no"
 msgstr "não"
 
-#: src/olympia/editors/forms.py:105
+#: src/olympia/editors/forms.py:105 src/olympia/editors/forms.py:245
 msgid "Admin Flag"
 msgstr "Propriedade de administração"
 
-#: src/olympia/editors/forms.py:113
+#: src/olympia/editors/forms.py:113 src/olympia/editors/forms.py:253
 msgid "Max. Version"
 msgstr "Versão máx."
 
@@ -9809,60 +7583,60 @@ msgstr "Dias desde a submissão"
 msgid "Add-on Types"
 msgstr "Tipos de complemento"
 
-#: src/olympia/editors/forms.py:126 src/olympia/editors/helpers.py:267
+#: src/olympia/editors/forms.py:126 src/olympia/editors/helpers.py:279
 msgid "Platforms"
 msgstr "Plataformas"
 
-#. L10n: 0 = platform, 1 = filename, 2 = status message
+#: src/olympia/editors/forms.py:237
+msgid "Search by add-on name / author email / guid"
+msgstr ""
+
 # %1 is the add-ons rank in the queue, %2 is the total queue length
-#: src/olympia/editors/forms.py:238
+#. L10n: 0 = platform, 1 = filename, 2 = status message
+#: src/olympia/editors/forms.py:342
 #, python-format
 msgid "<strong>%s</strong> &middot; %s &middot; %s"
 msgstr "<strong>%s</strong> &middot; %s &middot; %s"
 
-#: src/olympia/editors/forms.py:252
+#: src/olympia/editors/forms.py:356
 msgid "Comments:"
 msgstr "Comentários:"
 
-#: src/olympia/editors/forms.py:256
+#: src/olympia/editors/forms.py:360
 msgid "Operating systems:"
 msgstr "Sistemas operacionais:"
 
-#: src/olympia/editors/forms.py:258
+#: src/olympia/editors/forms.py:362
 msgid "Applications:"
 msgstr "Aplicações:"
 
-#: src/olympia/editors/forms.py:260
-msgid ""
-"Notify me the next time this add-on is updated. (Subsequent updates will not"
-" generate an email)"
-msgstr ""
-"Notificar-me na próxima vez que este complemento for atualizado. "
-"(Atualizações posteriores não gerarão uma mensagem)"
+#: src/olympia/editors/forms.py:364
+msgid "Notify me the next time this add-on is updated. (Subsequent updates will not generate an email)"
+msgstr "Notificar-me na próxima vez que este complemento for atualizado. (Atualizações posteriores não gerarão uma mensagem)"
 
-#: src/olympia/editors/forms.py:265
+#: src/olympia/editors/forms.py:369
 msgid "Clear Admin Review Flag"
 msgstr "Limpar propriedade de administração"
 
-#: src/olympia/editors/forms.py:267
+#: src/olympia/editors/forms.py:371
 msgid "Clear more info requested flag"
 msgstr "Limpar a marcação de mais informação solicitada"
 
-#: src/olympia/editors/forms.py:281
+#: src/olympia/editors/forms.py:385
 msgid "Choose a canned response..."
 msgstr "Escolha um modelo de resposta..."
 
 #. L10n: Description of what can be searched for.
-#: src/olympia/editors/forms.py:324
+#: src/olympia/editors/forms.py:423
 msgid "theme name"
 msgstr "nome do tema"
 
-#: src/olympia/editors/forms.py:350
+#: src/olympia/editors/forms.py:449
 msgid "Someone else is reviewing this theme."
 msgstr "Outra pessoa está analisando este tema."
 
 #. L10n: Description of what can be searched for.
-#: src/olympia/editors/forms.py:447
+#: src/olympia/editors/forms.py:546
 msgid "app, reviewer, or comment"
 msgstr "aplicativo, editor ou comentário"
 
@@ -9880,79 +7654,74 @@ msgstr "Aguardando análise preliminar"
 msgid "Rejected or Unreviewed"
 msgstr "Rejeitados ou não revisados"
 
-#: src/olympia/editors/helpers.py:123 src/olympia/editors/helpers.py:136
+#: src/olympia/editors/helpers.py:125 src/olympia/editors/helpers.py:138
 msgid "Queue"
 msgstr "Fila"
 
 # %1 is the update count
-#: src/olympia/editors/helpers.py:124
-#: src/olympia/editors/templates/editors/base.html:50
-#: src/olympia/editors/templates/editors/base.html:65
+#: src/olympia/editors/helpers.py:126 src/olympia/editors/templates/editors/base.html:50 src/olympia/editors/templates/editors/base.html:65
 msgid "Pending Updates"
 msgstr "Atualizações pendentes"
 
-#: src/olympia/editors/helpers.py:125
-#: src/olympia/editors/templates/editors/base.html:48
-#: src/olympia/editors/templates/editors/base.html:63
+#: src/olympia/editors/helpers.py:127 src/olympia/editors/templates/editors/base.html:48 src/olympia/editors/templates/editors/base.html:63
 msgid "Full Reviews"
 msgstr "Análises completas"
 
-#: src/olympia/editors/helpers.py:126
-#: src/olympia/editors/templates/editors/base.html:52
-#: src/olympia/editors/templates/editors/base.html:67
+#: src/olympia/editors/helpers.py:128 src/olympia/editors/templates/editors/base.html:52 src/olympia/editors/templates/editors/base.html:67
 msgid "Preliminary Reviews"
 msgstr "Análises preliminares"
 
 # %1 is the review count
-#: src/olympia/editors/helpers.py:127
-#: src/olympia/editors/templates/editors/base.html:54
+#: src/olympia/editors/helpers.py:129 src/olympia/editors/templates/editors/base.html:54
 msgid "Moderated Reviews"
 msgstr "Análises moderadas"
 
-#: src/olympia/editors/helpers.py:128
-#: src/olympia/editors/templates/editors/base.html:46
+#: src/olympia/editors/helpers.py:130 src/olympia/editors/templates/editors/base.html:46
 msgid "Fast Track"
 msgstr "Fast Track"
 
-#: src/olympia/editors/helpers.py:130
+#: src/olympia/editors/helpers.py:132
 msgid "Pending Themes"
 msgstr "Temas pendentes"
 
-#: src/olympia/editors/helpers.py:131
-#: src/olympia/editors/templates/editors/themes/queue.html:4
+#: src/olympia/editors/helpers.py:133 src/olympia/editors/templates/editors/themes/queue.html:4
 msgid "Flagged Themes"
 msgstr "Temas marcados"
 
-#: src/olympia/editors/helpers.py:132
+#: src/olympia/editors/helpers.py:134
 msgid "Update Themes"
 msgstr "Temas atualizados"
 
-#: src/olympia/editors/helpers.py:137
+#: src/olympia/editors/helpers.py:139
 msgid "Unlisted Pending Updates"
 msgstr "Atualizações pendentes não listadas"
 
-#: src/olympia/editors/helpers.py:138
+#: src/olympia/editors/helpers.py:140
 msgid "Unlisted Full Reviews"
 msgstr "Revisões completas não listadas"
 
-#: src/olympia/editors/helpers.py:139
+#: src/olympia/editors/helpers.py:141
 msgid "Unlisted Preliminary Reviews"
 msgstr "Análises preliminares não listadas"
 
-#: src/olympia/editors/helpers.py:170
+#: src/olympia/editors/helpers.py:142
+msgid "Unlisted All Add-ons"
+msgstr ""
+
+#: src/olympia/editors/helpers.py:173
 msgid "Fast Track ({0})"
 msgid_plural "Fast Track ({0})"
 msgstr[0] "Fast Track ({0})"
 msgstr[1] "Fast Track ({0})"
 
-#: src/olympia/editors/helpers.py:175
+#: src/olympia/editors/helpers.py:178
 msgid "Full Review ({0})"
 msgid_plural "Full Reviews ({0})"
 msgstr[0] "Análise completa ({0})"
 msgstr[1] "Análises completas ({0})"
 
 # %1 is the update count
-#: src/olympia/editors/helpers.py:180
+#: src/olympia/editors/helpers.py:183
 msgid "Pending Update ({0})"
 msgid_plural "Pending Updates ({0})"
 msgstr[0] "Atualização pendente ({0})"
@@ -9960,220 +7729,200 @@ msgstr[1] "Atualizações pendentes ({0})"
 
 # 75%
 # 100%
-#: src/olympia/editors/helpers.py:185
+#: src/olympia/editors/helpers.py:188
 msgid "Preliminary Review ({0})"
 msgid_plural "Preliminary Reviews ({0})"
 msgstr[0] "Análise preliminar ({0})"
 msgstr[1] "Análises preliminares ({0})"
 
 # %1 is the review count
-#: src/olympia/editors/helpers.py:190
+#: src/olympia/editors/helpers.py:193
 msgid "Moderated Review ({0})"
 msgid_plural "Moderated Reviews ({0})"
 msgstr[0] "Análise moderada ({0})"
 msgstr[1] "Análises moderadas ({0})"
 
-#: src/olympia/editors/helpers.py:196
+#: src/olympia/editors/helpers.py:199
 msgid "Unlisted Full Review ({0})"
 msgid_plural "Unlisted Full Reviews ({0})"
 msgstr[0] "Análise completa não listada ({0})"
 msgstr[1] "Análises completas não listadas ({0})"
 
-#: src/olympia/editors/helpers.py:201
+#: src/olympia/editors/helpers.py:204
 msgid "Unlisted Pending Update ({0})"
 msgid_plural "Unlisted Pending Updates ({0})"
 msgstr[0] "Atualização pendente não listada ({0})"
 msgstr[1] "Atualizações pendentes não listadas ({0})"
 
-#: src/olympia/editors/helpers.py:206
+#: src/olympia/editors/helpers.py:209
 msgid "Unlisted Preliminary Review ({0})"
 msgid_plural "Unlisted Preliminary Reviews ({0})"
 msgstr[0] "Análise preliminar não listada ({0})"
 msgstr[1] "Análises preliminares não listadas ({0})"
 
-#: src/olympia/editors/helpers.py:261
-msgid "Addon"
-msgstr "Complemento"
+#: src/olympia/editors/helpers.py:214
+msgid "Unlisted All Add-ons ({0})"
+msgid_plural "Unlisted All Add-ons ({0})"
+msgstr[0] ""
+msgstr[1] ""
 
-#: src/olympia/editors/helpers.py:262
+#: src/olympia/editors/helpers.py:274
 msgid "Type"
 msgstr "Tipo"
 
-#: src/olympia/editors/helpers.py:263
+#: src/olympia/editors/helpers.py:275
 msgid "Waiting Time"
 msgstr "Tempo de espera"
 
-#: src/olympia/editors/helpers.py:264
-#: src/olympia/editors/templates/editors/review.html:285
+#: src/olympia/editors/helpers.py:276 src/olympia/editors/templates/editors/review.html:285
 msgid "Flags"
 msgstr "Propriedades"
 
-#: src/olympia/editors/helpers.py:265
+#: src/olympia/editors/helpers.py:277
 msgid "Applications"
 msgstr "Aplicativos"
 
-#: src/olympia/editors/helpers.py:270
+#: src/olympia/editors/helpers.py:282
 msgid "Additional"
 msgstr "Adicional"
 
-#: src/olympia/editors/helpers.py:285
+#: src/olympia/editors/helpers.py:302
 msgid "Site Specific"
 msgstr "Funciona com um site específico"
 
-#: src/olympia/editors/helpers.py:287
+#: src/olympia/editors/helpers.py:304
 msgid "Requires External Software"
 msgstr "Requer software externo"
 
-#: src/olympia/editors/helpers.py:289
+#: src/olympia/editors/helpers.py:306
 msgid "Binary Components"
 msgstr "Componentes binários"
 
-#: src/olympia/editors/helpers.py:313
+#: src/olympia/editors/helpers.py:339
 msgid "moments ago"
 msgstr "momentos atrás"
 
 #. L10n: first argument is number of minutes
-#: src/olympia/editors/helpers.py:316
+#: src/olympia/editors/helpers.py:342
 msgid "{0} minute"
 msgid_plural "{0} minutes"
 msgstr[0] "{0} minuto"
 msgstr[1] "{0} minutos"
 
 #. L10n: first argument is number of hours
-#: src/olympia/editors/helpers.py:320
+#: src/olympia/editors/helpers.py:346
 msgid "{0} hour"
 msgid_plural "{0} hours"
 msgstr[0] "{0} hora"
 msgstr[1] "{0} horas"
 
 #. L10n: first argument is number of days
-#: src/olympia/editors/helpers.py:324
+#: src/olympia/editors/helpers.py:350
 msgid "{0} day"
 msgid_plural "{0} days"
 msgstr[0] "{0} dia"
 msgstr[1] "{0} dias"
 
-#: src/olympia/editors/helpers.py:488
+#: src/olympia/editors/helpers.py:364
+msgid "Last Review"
+msgstr ""
+
+#: src/olympia/editors/helpers.py:366
+msgid "Last Update"
+msgstr ""
+
+#: src/olympia/editors/helpers.py:387
+msgid "No Reviews"
+msgstr ""
+
+#: src/olympia/editors/helpers.py:561
 msgid "Push to public"
 msgstr "Publicar"
 
-#: src/olympia/editors/helpers.py:490
+#: src/olympia/editors/helpers.py:563
 msgid "Grant full review"
 msgstr "Atribuir revisão completa"
 
-#: src/olympia/editors/helpers.py:505
+#: src/olympia/editors/helpers.py:578
 msgid "Request more information"
 msgstr "Solicitar mais informações"
 
-#: src/olympia/editors/helpers.py:508
+#: src/olympia/editors/helpers.py:581
 msgid "Request super-review"
 msgstr "Solicitar superanálise"
 
 # 80%
 # 100%
-#: src/olympia/editors/helpers.py:519
+#: src/olympia/editors/helpers.py:592
 msgid "Grant preliminary review"
 msgstr "Aprovar análise preliminar"
 
-#: src/olympia/editors/helpers.py:520
+#: src/olympia/editors/helpers.py:593
 msgid "This will mark the files as preliminarily reviewed."
 msgstr "Essa ação vai marcar estes arquivos como analisados previamente"
 
-#: src/olympia/editors/helpers.py:522
-msgid ""
-"Use this form to request more information from the author. They will receive"
-" an email and be able to answer here. You will be notified by email when "
-"they reply."
-msgstr ""
-"Use este formulário para pedir mais informações para o autor. Ele receberá "
-"uma mensagem e poderá responder aqui. Você será notificado por e-mail quando"
-" for receber uma resposta."
+#: src/olympia/editors/helpers.py:595
+msgid "Use this form to request more information from the author. They will receive an email and be able to answer here. You will be notified by email when they reply."
+msgstr "Use este formulário para pedir mais informações para o autor. Ele receberá uma mensagem e poderá responder aqui. Você será notificado por e-mail quando for receber uma resposta."
 
-#: src/olympia/editors/helpers.py:526
+#: src/olympia/editors/helpers.py:599
 msgid ""
-"If you have concerns about this add-on's security, copyright issues, or "
-"other concerns that an administrator should look into, enter your comments "
-"in the area below. They will be sent to administrators, not the author."
+"If you have concerns about this add-on's security, copyright issues, or other concerns that an administrator should look into, enter your comments in the area below. They will be sent to "
+"administrators, not the author."
 msgstr ""
-"Se você possui dúvidas ou preocupações relacionadas à segurança, questões de"
-" direitos reservados ou outras dúvidas sobre esse complemento que um "
-"administrador poderia solucionar, insira seus comentários abaixo. Eles serão"
-" enviados aos administradores, não para o autor."
+"Se você possui dúvidas ou preocupações relacionadas à segurança, questões de direitos reservados ou outras dúvidas sobre esse complemento que um administrador poderia solucionar, insira seus "
+"comentários abaixo. Eles serão enviados aos administradores, não para o autor."
 
-#: src/olympia/editors/helpers.py:532
+#: src/olympia/editors/helpers.py:605
 msgid "This will reject the add-on and remove it from the review queue."
 msgstr "Isto rejeitará o complemento e o removerá da fila de análises."
 
-#: src/olympia/editors/helpers.py:534
-msgid "Make a comment on this version.  The author won't be able to see this."
+#: src/olympia/editors/helpers.py:607
+msgid "Make a comment on this version. The author won't be able to see this."
 msgstr "Deixe um comentário para esta versão.  O autor não poderá lê-lo."
 
-#: src/olympia/editors/helpers.py:538
+#: src/olympia/editors/helpers.py:611
 msgid "This will reject the files and remove them from the review queue."
 msgstr "Isso rejeitará os arquivos e os removerá da fila de análises."
 
-#: src/olympia/editors/helpers.py:542
-msgid ""
-"This will mark the add-on as preliminarily reviewed. Future versions will "
-"undergo preliminary review."
-msgstr ""
-"Isso marcará o complemento como analisado preliminarmente. Versões futuras "
-"serão submetidas a análises preliminares."
+#: src/olympia/editors/helpers.py:615
+msgid "This will mark the add-on as preliminarily reviewed. Future versions will undergo preliminary review."
+msgstr "Isso marcará o complemento como analisado preliminarmente. Versões futuras serão submetidas a análises preliminares."
 
-#: src/olympia/editors/helpers.py:547
-msgid ""
-"This will mark the files as preliminarily reviewed. Future versions will "
-"undergo preliminary review."
-msgstr ""
-"Isso marcará os arquivos como analisados preliminarmente. Versões futuras "
-"serão submetidas a análises preliminares."
+#: src/olympia/editors/helpers.py:620
+msgid "This will mark the files as preliminarily reviewed. Future versions will undergo preliminary review."
+msgstr "Isso marcará os arquivos como analisados preliminarmente. Versões futuras serão submetidas a análises preliminares."
 
-#: src/olympia/editors/helpers.py:552
+#: src/olympia/editors/helpers.py:625
 msgid "Retain preliminary review"
 msgstr "Manter análise preliminar"
 
-#: src/olympia/editors/helpers.py:553
-msgid ""
-"This will retain the add-on as preliminarily reviewed. Future versions will "
-"undergo preliminary review."
-msgstr ""
-"Isso manterá o complemento como analisado preliminarmente. Versões futuras "
-"serão submetidas a análises preliminares."
+#: src/olympia/editors/helpers.py:626
+msgid "This will retain the add-on as preliminarily reviewed. Future versions will undergo preliminary review."
+msgstr "Isso manterá o complemento como analisado preliminarmente. Versões futuras serão submetidas a análises preliminares."
 
-#: src/olympia/editors/helpers.py:558
-msgid ""
-"This will approve a sandboxed version of a public add-on to appear on the "
-"public side."
-msgstr ""
-"Isso aprovará uma versão restrita de um complemento público de forma que ele"
-" apareça na galeria pública."
+#: src/olympia/editors/helpers.py:631
+msgid "This will approve a sandboxed version of a public add-on to appear on the public side."
+msgstr "Isso aprovará uma versão restrita de um complemento público de forma que ele apareça na galeria pública."
 
-#: src/olympia/editors/helpers.py:561
-msgid ""
-"This will reject a version of a public add-on and remove it from the queue."
-msgstr ""
-"Isso rejeitará uma versão de um complemento público e o removerá da fila."
-
-#: src/olympia/editors/helpers.py:564
-msgid ""
-"This will mark the add-on and its most recent version and files as public. "
-"Future versions will go into the sandbox until they are reviewed by an "
-"editor."
-msgstr ""
-"Isso marcará o complemento, sua versão e arquivos mais recentes como "
-"públicos. Versões futuras serão restritas até que sejam analisadas por um "
-"editor."
+#: src/olympia/editors/helpers.py:634
+msgid "This will reject a version of a public add-on and remove it from the queue."
+msgstr "Isso rejeitará uma versão de um complemento público e o removerá da fila."
 
 #: src/olympia/editors/helpers.py:637
+msgid "This will mark the add-on and its most recent version and files as public. Future versions will go into the sandbox until they are reviewed by an editor."
+msgstr "Isso marcará o complemento, sua versão e arquivos mais recentes como públicos. Versões futuras serão restritas até que sejam analisadas por um editor."
+
+#: src/olympia/editors/helpers.py:714
 msgid "add-on"
 msgstr "complemento"
 
-#: src/olympia/editors/helpers.py:940 src/olympia/editors/helpers.py:960
+#: src/olympia/editors/helpers.py:1020 src/olympia/editors/helpers.py:1040
 msgid "Flagged"
 msgstr "Marcado"
 
 # 85%
-#: src/olympia/editors/helpers.py:944 src/olympia/editors/helpers.py:963
+#: src/olympia/editors/helpers.py:1024 src/olympia/editors/helpers.py:1043
 msgid "Updates"
 msgstr "Atualizações"
 
@@ -10225,79 +7974,70 @@ msgstr "Submissão de tema marcada para revisão"
 msgid "A question about your Theme submission"
 msgstr "Uma questão sobre a submissão do seu tema"
 
-#: src/olympia/editors/views.py:144
+#: src/olympia/editors/views.py:146
 msgid "New Add-ons (Under 5 days)"
 msgstr "Complementos novos (menos de 5 dias)"
 
-#: src/olympia/editors/views.py:145
+#: src/olympia/editors/views.py:147
 msgid "Passable (5 to 10 days)"
 msgstr "Razoáveis (entre 5 e 10 dias)"
 
-#: src/olympia/editors/views.py:146
+#: src/olympia/editors/views.py:148
 msgid "Overdue (Over 10 days)"
 msgstr "Antigos (mais de 10 dias)"
 
-#: src/olympia/editors/views.py:532
+#: src/olympia/editors/views.py:539
 msgid "An unknown error occurred"
 msgstr "Ocorreu um erro desconhecido"
 
-#: src/olympia/editors/views.py:587
+#: src/olympia/editors/views.py:592
 msgid "Self-reviews are not allowed."
 msgstr "Autoavaliações não são permitidas."
 
-#: src/olympia/editors/views.py:609
+#: src/olympia/editors/views.py:613
 msgid "Review successfully processed."
 msgstr "Avaliação processada com sucesso."
 
-#: src/olympia/editors/views.py:807
+#: src/olympia/editors/views.py:812
 msgid "was approved"
 msgstr "foi aprovado"
 
 # 80%
 # 100%
-#: src/olympia/editors/views.py:808
+#: src/olympia/editors/views.py:813
 msgid "given preliminary review"
 msgstr "foi aprovado na análise preliminar"
 
-#: src/olympia/editors/views.py:809
+#: src/olympia/editors/views.py:814
 msgid "rejected"
 msgstr "rejeitado"
 
-#: src/olympia/editors/views.py:810
+#: src/olympia/editors/views.py:815
 msgctxt "editors_review_history_nominated_adminreview"
 msgid "escalated"
 msgstr "encaminhado para análise superior"
 
-#: src/olympia/editors/views.py:812
+#: src/olympia/editors/views.py:817
 msgid "needs more information"
 msgstr "precisa de mais informações"
 
-#: src/olympia/editors/views.py:813
+#: src/olympia/editors/views.py:818
 msgid "needs super review"
 msgstr "precisa de superanálise"
 
-#: src/olympia/editors/views.py:814
+#: src/olympia/editors/views.py:819
 msgid "commented"
 msgstr "comentou"
 
 #: src/olympia/editors/views_themes.py:326
 msgid "{0} theme review successfully processed (+{1} points, {2} total)."
-msgid_plural ""
-"{0} theme reviews successfully processed (+{1} points, {2} total)."
-msgstr[0] ""
-"{0} revisão do tema processada com sucesso  (+{1} pontos, {2} total)."
-msgstr[1] ""
-"{0} revisões do tema processadas com sucesso  (+{1} pontos, {2} total)."
+msgid_plural "{0} theme reviews successfully processed (+{1} points, {2} total)."
+msgstr[0] "{0} revisão do tema processada com sucesso  (+{1} pontos, {2} total)."
+msgstr[1] "{0} revisões do tema processadas com sucesso  (+{1} pontos, {2} total)."
 
 #: src/olympia/editors/views_themes.py:341
-msgid ""
-"Your theme locks have successfully been released. Other reviewers may now "
-"review those released themes. You may have to refresh the page to see the "
-"changes reflected in the table below."
-msgstr ""
-"Sua atualização de tema foi publicada com sucesso. Outros revisores devem "
-"validar esse tema agora. É necessário atualizar a página para que as "
-"alterações sejam exibidas na tabela abaixo."
+msgid "Your theme locks have successfully been released. Other reviewers may now review those released themes. You may have to refresh the page to see the changes reflected in the table below."
+msgstr "Sua atualização de tema foi publicada com sucesso. Outros revisores devem validar esse tema agora. É necessário atualizar a página para que as alterações sejam exibidas na tabela abaixo."
 
 #: src/olympia/editors/templates/editors/abuse_reports.html:4
 msgid "{addon} :: Abuse Reports"
@@ -10322,9 +8062,7 @@ msgstr "<i>anônimo</i> em %(date)s [%(ip_address)s]"
 msgid "Return to the Editor Tools homepage"
 msgstr "Voltar para a página de Ferramentas do Editor"
 
-#: src/olympia/editors/templates/editors/base.html:43
-#: src/olympia/editors/templates/editors/themes/base.html:14
-#: src/olympia/editors/templates/editors/themes/base.html:28
+#: src/olympia/editors/templates/editors/base.html:43 src/olympia/editors/templates/editors/themes/base.html:14 src/olympia/editors/templates/editors/themes/base.html:28
 #: src/olympia/editors/templates/editors/themes/queue.html:25
 msgid "Queues"
 msgstr "Filas"
@@ -10333,74 +8071,54 @@ msgstr "Filas"
 msgid "Unlisted Queues"
 msgstr "Filas não listadas"
 
-#: src/olympia/editors/templates/editors/base.html:72
-#: src/olympia/editors/templates/editors/performance.html:6
+#: src/olympia/editors/templates/editors/base.html:74 src/olympia/editors/templates/editors/performance.html:6
 msgid "Performance"
 msgstr "Desempenho"
 
-#: src/olympia/editors/templates/editors/base.html:75
-#: src/olympia/editors/templates/editors/themes/base.html:19
-#: src/olympia/editors/templates/editors/themes/base.html:38
+#: src/olympia/editors/templates/editors/base.html:77 src/olympia/editors/templates/editors/themes/base.html:19 src/olympia/editors/templates/editors/themes/base.html:38
 msgid "Logs"
 msgstr "Registros"
 
-#: src/olympia/editors/templates/editors/base.html:78
-#: src/olympia/editors/templates/editors/reviewlog.html:4
-#: src/olympia/editors/templates/editors/reviewlog.html:27
+#: src/olympia/editors/templates/editors/base.html:80 src/olympia/editors/templates/editors/reviewlog.html:4 src/olympia/editors/templates/editors/reviewlog.html:27
 msgid "Add-on Review Log"
 msgstr "Registro de análise do complemento"
 
 # %1 is the review count
 # 80%
 # 100%
-#: src/olympia/editors/templates/editors/base.html:80
-#: src/olympia/editors/templates/editors/eventlog.html:4
-#: src/olympia/editors/templates/editors/eventlog.html:8
+#: src/olympia/editors/templates/editors/base.html:82 src/olympia/editors/templates/editors/eventlog.html:4 src/olympia/editors/templates/editors/eventlog.html:8
 #: src/olympia/editors/templates/editors/eventlog_detail.html:4
 msgid "Moderated Review Log"
 msgstr "Registro de análise moderada"
 
-#: src/olympia/editors/templates/editors/base.html:82
-#: src/olympia/editors/templates/editors/beta_signed_log.html:4
-#: src/olympia/editors/templates/editors/beta_signed_log.html:8
+#: src/olympia/editors/templates/editors/base.html:84 src/olympia/editors/templates/editors/beta_signed_log.html:4 src/olympia/editors/templates/editors/beta_signed_log.html:8
 msgid "Signed Beta Files Log"
 msgstr "Arquivos de registro beta assinado"
 
-#: src/olympia/editors/templates/editors/base.html:87
-#: src/olympia/editors/templates/editors/includes/daily-message.html:4
+#: src/olympia/editors/templates/editors/base.html:89 src/olympia/editors/templates/editors/includes/daily-message.html:4
 msgid "Announcement"
 msgstr "Anúncio"
 
 #. "Filter" is a button label (verb)
-#: src/olympia/editors/templates/editors/beta_signed_log.html:17
-#: src/olympia/editors/templates/editors/eventlog.html:24
-#: src/olympia/editors/templates/editors/reviewlog.html:21
-#: src/olympia/editors/templates/editors/themes/macros.html:45
-#: src/olympia/editors/templates/editors/themes/includes/logs_filter_deleted.html:12
+#: src/olympia/editors/templates/editors/beta_signed_log.html:17 src/olympia/editors/templates/editors/eventlog.html:24 src/olympia/editors/templates/editors/reviewlog.html:21
+#: src/olympia/editors/templates/editors/themes/macros.html:45 src/olympia/editors/templates/editors/themes/includes/logs_filter_deleted.html:12
 msgid "Filter"
 msgstr "Filtrar"
 
-#: src/olympia/editors/templates/editors/beta_signed_log.html:23
-#: src/olympia/editors/templates/editors/eventlog.html:30
-#: src/olympia/editors/templates/editors/reviewlog.html:34
+#: src/olympia/editors/templates/editors/beta_signed_log.html:23 src/olympia/editors/templates/editors/eventlog.html:30 src/olympia/editors/templates/editors/reviewlog.html:34
 #: src/olympia/editors/templates/editors/themes/logs.html:16
 msgid "Date"
 msgstr "Data"
 
-#: src/olympia/editors/templates/editors/beta_signed_log.html:24
-#: src/olympia/editors/templates/editors/eventlog.html:31
-#: src/olympia/editors/templates/editors/reviewlog.html:35
+#: src/olympia/editors/templates/editors/beta_signed_log.html:24 src/olympia/editors/templates/editors/eventlog.html:31 src/olympia/editors/templates/editors/reviewlog.html:35
 msgid "Event"
 msgstr "Evento"
 
-#: src/olympia/editors/templates/editors/beta_signed_log.html:37
-#: src/olympia/editors/templates/editors/eventlog.html:44
-#: src/olympia/editors/templates/editors/home.html:180
+#: src/olympia/editors/templates/editors/beta_signed_log.html:37 src/olympia/editors/templates/editors/eventlog.html:44 src/olympia/editors/templates/editors/home.html:180
 msgid "More details."
 msgstr "Mais detalhes."
 
-#: src/olympia/editors/templates/editors/beta_signed_log.html:46
-#: src/olympia/editors/templates/editors/eventlog.html:53
+#: src/olympia/editors/templates/editors/beta_signed_log.html:46 src/olympia/editors/templates/editors/eventlog.html:53
 msgid "No events found for this period."
 msgstr "Nenhum evento encontrado nesse período."
 
@@ -10456,22 +8174,19 @@ msgid_plural "Preliminary Reviews ({num})"
 msgstr[0] "Análise preliminar ({num})"
 msgstr[1] "Análises preliminares ({num})"
 
-#: src/olympia/editors/templates/editors/home.html:36
-#: src/olympia/editors/templates/editors/home.html:86
+#: src/olympia/editors/templates/editors/home.html:36 src/olympia/editors/templates/editors/home.html:86
 msgid "Current waiting times:"
 msgstr "Tempo de espera atual:"
 
 # 81%
 # 100%
-#: src/olympia/editors/templates/editors/home.html:44
-#: src/olympia/editors/templates/editors/home.html:94
+#: src/olympia/editors/templates/editors/home.html:44 src/olympia/editors/templates/editors/home.html:94
 msgid "{0} add-on"
 msgid_plural "{0} add-ons"
 msgstr[0] "{0} complemento"
 msgstr[1] "{0} complementos"
 
-#: src/olympia/editors/templates/editors/home.html:45
-#: src/olympia/editors/templates/editors/home.html:95
+#: src/olympia/editors/templates/editors/home.html:45 src/olympia/editors/templates/editors/home.html:95
 #, python-format
 msgid "{0}%%"
 msgstr "{0}%%"
@@ -10494,14 +8209,11 @@ msgid_plural "Unlisted Preliminary Reviews ({num})"
 msgstr[0] "Análise preliminar não listada ({num})"
 msgstr[1] "Análises preliminares não listadas ({num})"
 
-#: src/olympia/editors/templates/editors/home.html:109
-#: src/olympia/editors/templates/editors/performance.html:37
-#: src/olympia/editors/templates/editors/themes/home.html:54
+#: src/olympia/editors/templates/editors/home.html:109 src/olympia/editors/templates/editors/performance.html:37 src/olympia/editors/templates/editors/themes/home.html:54
 msgid "Total Reviews"
 msgstr "Análises totais"
 
-#: src/olympia/editors/templates/editors/home.html:110
-#: src/olympia/editors/templates/editors/themes/home.html:55
+#: src/olympia/editors/templates/editors/home.html:110 src/olympia/editors/templates/editors/themes/home.html:55
 msgid "Reviews This Month"
 msgstr "Análises deste mês"
 
@@ -10509,28 +8221,25 @@ msgstr "Análises deste mês"
 msgid "New Editors"
 msgstr "Novos editores"
 
-#: src/olympia/editors/templates/editors/home.html:126
-#: src/olympia/editors/templates/editors/home.html:141
+#: src/olympia/editors/templates/editors/home.html:126 src/olympia/editors/templates/editors/home.html:141
 msgid "You're #{0} with {1} reviews"
 msgstr "Você é o número {0} com {1} revisões"
 
-#. num = number of reviews in the queue
 # %1 is the review count
 # 87%
 # 100%
+#. num = number of reviews in the queue
 #: src/olympia/editors/templates/editors/home.html:171
 msgid "Moderated Review ({num})"
 msgid_plural "Moderated Reviews ({num})"
 msgstr[0] "Análise moderada ({num})"
 msgstr[1] "Análises moderadas ({num})"
 
-#: src/olympia/editors/templates/editors/leaderboard.html:3
-#: src/olympia/editors/templates/editors/includes/reviewers_score_bar.html:56
+#: src/olympia/editors/templates/editors/leaderboard.html:3 src/olympia/editors/templates/editors/includes/reviewers_score_bar.html:56
 msgid "Reviewer Leaderboard"
 msgstr "Ranking dos Editores"
 
-#: src/olympia/editors/templates/editors/leaderboard.html:18
-#: src/olympia/editors/templates/editors/performance.html:65
+#: src/olympia/editors/templates/editors/leaderboard.html:18 src/olympia/editors/templates/editors/performance.html:65
 msgid "No review points awarded yet."
 msgstr "Nenhum ponto recebido ainda."
 
@@ -10550,8 +8259,7 @@ msgstr "Mensagem do dia"
 msgid "Update message of the day"
 msgstr "Atualizar a mensagem do dia"
 
-#: src/olympia/editors/templates/editors/motd.html:15
-#: src/olympia/editors/templates/editors/review.html:224
+#: src/olympia/editors/templates/editors/motd.html:15 src/olympia/editors/templates/editors/review.html:224
 msgid "Save"
 msgstr "Salvar"
 
@@ -10621,52 +8329,46 @@ msgstr "Pesquisa avançada"
 msgid "clear search"
 msgstr "limpar pesquisa"
 
-#: src/olympia/editors/templates/editors/queue.html:72
-#: src/olympia/editors/templates/editors/queue.html:122
+#: src/olympia/editors/templates/editors/queue.html:78 src/olympia/editors/templates/editors/queue.html:128
 msgid "Process Reviews"
 msgstr "Processar análises"
 
-#: src/olympia/editors/templates/editors/queue.html:80
+#: src/olympia/editors/templates/editors/queue.html:86
 msgid "Moderation actions:"
 msgstr "Ações de moderação:"
 
-#: src/olympia/editors/templates/editors/queue.html:90
+#: src/olympia/editors/templates/editors/queue.html:96
 #, python-format
 msgid "by %(user)s on %(date)s %(stars)s (%(locale)s)"
 msgstr "por %(user)s em %(date)s %(stars)s (%(locale)s)"
 
-#: src/olympia/editors/templates/editors/queue.html:106
+#: src/olympia/editors/templates/editors/queue.html:112
 #, python-format
-msgid ""
-"<strong>%(reason)s</strong> <span class=\"light\">Flagged by %(user)s on "
-"%(date)s</span>"
-msgstr ""
-"<strong>%(reason)s</strong> <span class=\"light\">Denunciado por %(user)s em"
-" %(date)s</span>"
+msgid "<strong>%(reason)s</strong> <span class=\"light\">Flagged by %(user)s on %(date)s</span>"
+msgstr "<strong>%(reason)s</strong> <span class=\"light\">Denunciado por %(user)s em %(date)s</span>"
 
-#: src/olympia/editors/templates/editors/queue.html:119
-msgid "All reviews have been moderated.  Good work!"
+#: src/olympia/editors/templates/editors/queue.html:125
+msgid "All reviews have been moderated. Good work!"
 msgstr "Todas as revisões foram moderadas.  Bom trabalho!"
 
-#: src/olympia/editors/templates/editors/queue.html:161
+#: src/olympia/editors/templates/editors/queue.html:167
 msgid "Version Notes / Notes for Reviewer"
 msgstr "Notas da versão / Comentários ao editor"
 
 # %1 is the queue mode
-#: src/olympia/editors/templates/editors/queue.html:169
+#: src/olympia/editors/templates/editors/queue.html:175
 msgid "There are currently no add-ons of this type to review."
 msgstr "Atualmente não há complementos desse tipo para analisar."
 
-#: src/olympia/editors/templates/editors/queue.html:181
-#: src/olympia/editors/templates/editors/themes/queue_list.html:85
+#: src/olympia/editors/templates/editors/queue.html:187 src/olympia/editors/templates/editors/themes/queue_list.html:85
 msgid "Helpful Links:"
 msgstr "Links úteis:"
 
-#: src/olympia/editors/templates/editors/queue.html:182
+#: src/olympia/editors/templates/editors/queue.html:188
 msgid "Add-on Policy"
 msgstr "Política do complemento"
 
-#: src/olympia/editors/templates/editors/queue.html:184
+#: src/olympia/editors/templates/editors/queue.html:190
 msgid "Editors' Guide"
 msgstr "Guia do editor"
 
@@ -10679,19 +8381,14 @@ msgstr "Revisão {0}"
 msgid "Add-on user change history"
 msgstr "Histórico de alterações de usuário do complemento"
 
-#: src/olympia/editors/templates/editors/review.html:52
-#: src/olympia/editors/templates/editors/review.html:266
+#: src/olympia/editors/templates/editors/review.html:52 src/olympia/editors/templates/editors/review.html:266
 msgid "Add-on History"
 msgstr "Histórico do complemento"
 
 #: src/olympia/editors/templates/editors/review.html:64
 #, python-format
-msgid ""
-"Version %(version)s &middot; %(created)s <span class=\"light\">&middot; "
-"%(version_status)s</span>"
-msgstr ""
-"Versão %(version)s &middot; %(created)s <span class=\"light\">&middot; "
-"%(version_status)s</span>"
+msgid "Version %(version)s &middot; %(created)s <span class=\"light\">&middot; %(version_status)s</span>"
+msgstr "Versão %(version)s &middot; %(created)s <span class=\"light\">&middot; %(version_status)s</span>"
 
 #: src/olympia/editors/templates/editors/review.html:73
 msgid "Compatibility:"
@@ -10714,19 +8411,14 @@ msgid "This version has not been reviewed."
 msgstr "Esta versão não foi analisada."
 
 #: src/olympia/editors/templates/editors/review.html:154
-msgid ""
-"You can still submit this form, however only do so if you know it won't "
-"conflict."
-msgstr ""
-"Você ainda pode enviar este formulário; no entanto, faça isso apenas se "
-"tiver certeza de que não haverá conflitos."
+msgid "You can still submit this form, however only do so if you know it won't conflict."
+msgstr "Você ainda pode enviar este formulário; no entanto, faça isso apenas se tiver certeza de que não haverá conflitos."
 
 #: src/olympia/editors/templates/editors/review.html:161
 msgid "Insert canned response..."
 msgstr "Inserir resposta padrão..."
 
-#: src/olympia/editors/templates/editors/review.html:167
-#: src/olympia/files/templates/files/viewer.html:54
+#: src/olympia/editors/templates/editors/review.html:167 src/olympia/files/templates/files/viewer.html:54
 msgid "Files:"
 msgstr "Arquivos:"
 
@@ -10735,17 +8427,11 @@ msgid "Tested on:"
 msgstr "Testado em:"
 
 #: src/olympia/editors/templates/editors/review.html:220
-msgid ""
-"<strong>Warning!</strong> Another user was viewing this page before you."
-msgstr ""
-"<strong>Aviso!</strong> Outro usuário estava visualizando essa página antes "
-"de você."
+msgid "<strong>Warning!</strong> Another user was viewing this page before you."
+msgstr "<strong>Aviso!</strong> Outro usuário estava visualizando essa página antes de você."
 
 #: src/olympia/editors/templates/editors/review.html:237
-msgid ""
-"The whiteboard is the place to exchange information relevant to\n"
-"               this addon (whatever the version), between the developer and the\n"
-"               editor. This is visible and editable by both."
+msgid "The whiteboard is the place to exchange information relevant to this addon (whatever the version), between the developer and the editor. This is visible and editable by both."
 msgstr ""
 "O quadro branco é o local para se trocar informações relevantes para\n"
 "               este complemento (qualquer versão) entre o desenvolvedor e o editor.\n"
@@ -10755,8 +8441,7 @@ msgstr ""
 msgid "Update the whiteboard"
 msgstr "Atualizar o quadro branco"
 
-#: src/olympia/editors/templates/editors/review.html:257
-#: src/olympia/editors/templates/editors/review.html:258
+#: src/olympia/editors/templates/editors/review.html:257 src/olympia/editors/templates/editors/review.html:258
 msgid "(admin)"
 msgstr "(administrador)"
 
@@ -10784,18 +8469,15 @@ msgstr "Editor"
 msgid "Add-on has been deleted."
 msgstr "O complemento foi excluído."
 
-#: src/olympia/editors/templates/editors/reviewlog.html:59
-#: src/olympia/editors/templates/editors/themes/logs.html:36
+#: src/olympia/editors/templates/editors/reviewlog.html:59 src/olympia/editors/templates/editors/themes/logs.html:36
 msgid "Show Comments"
 msgstr "Mostrar comentários"
 
-#: src/olympia/editors/templates/editors/reviewlog.html:60
-#: src/olympia/editors/templates/editors/themes/logs.html:37
+#: src/olympia/editors/templates/editors/reviewlog.html:60 src/olympia/editors/templates/editors/themes/logs.html:37
 msgid "Hide Comments"
 msgstr "Ocultar comentários"
 
-#: src/olympia/editors/templates/editors/reviewlog.html:72
-#: src/olympia/editors/templates/editors/themes/logs.html:54
+#: src/olympia/editors/templates/editors/reviewlog.html:72 src/olympia/editors/templates/editors/themes/logs.html:54
 msgid "No reviews found for this period."
 msgstr "Não foram encontradas análises nesse período."
 
@@ -10854,11 +8536,8 @@ msgid "You have <span>{0}</span> points."
 msgstr "Você possui <span>{0}</span> pontos."
 
 # 88%
-#: src/olympia/editors/templates/editors/includes/search_results_themes.html:6
-#: src/olympia/editors/templates/editors/themes/history_table.html:7
-#: src/olympia/editors/templates/editors/themes/logs.html:19
-#: src/olympia/editors/templates/editors/themes/queue_list.html:49
-#: src/olympia/editors/templates/editors/themes/single.html:26
+#: src/olympia/editors/templates/editors/includes/search_results_themes.html:6 src/olympia/editors/templates/editors/themes/history_table.html:7
+#: src/olympia/editors/templates/editors/themes/logs.html:19 src/olympia/editors/templates/editors/themes/queue_list.html:49 src/olympia/editors/templates/editors/themes/single.html:26
 #: src/olympia/editors/templates/editors/themes/themes.html:45
 msgid "Reviewer"
 msgstr "Editores"
@@ -10883,8 +8562,7 @@ msgstr "Histórico de análises do tema {0}"
 msgid "Review Date"
 msgstr "Data da análise"
 
-#: src/olympia/editors/templates/editors/themes/history_table.html:9
-#: src/olympia/editors/templates/editors/themes/logs.html:18
+#: src/olympia/editors/templates/editors/themes/history_table.html:9 src/olympia/editors/templates/editors/themes/logs.html:18
 msgid "Action"
 msgstr "Ação"
 
@@ -11031,7 +8709,7 @@ msgstr "Fazer uma pergunta ao artista"
 msgid "Describe your reason for flagging"
 msgstr "Descreva o motivo da sua marcação"
 
-#: src/olympia/files/forms.py:88
+#: src/olympia/files/forms.py:90
 msgid "Cannot diff a version against itself"
 msgstr "Não é possível comparar a mesma versão"
 
@@ -11049,12 +8727,8 @@ msgid "Problems decoding {0}."
 msgstr "Problemas ao decodificar {0}."
 
 #: src/olympia/files/helpers.py:186
-msgid ""
-"This file is not viewable online. Please download the file to view the "
-"contents."
-msgstr ""
-"O arquivo não é visível on-line. Por favor, baixe o arquivo para visualizar "
-"seu conteúdo."
+msgid "This file is not viewable online. Please download the file to view the contents."
+msgstr "O arquivo não é visível on-line. Por favor, baixe o arquivo para visualizar seu conteúdo."
 
 #: src/olympia/files/helpers.py:194
 msgid "This file is a directory."
@@ -11070,56 +8744,52 @@ msgstr "Houve um erro ao acessar o arquivo %s. %s."
 msgid "There was an error accessing file %s."
 msgstr "Houve um erro ao acessar o arquivo %s."
 
-#: src/olympia/files/utils.py:343
+#: src/olympia/files/utils.py:340
 msgid "Could not parse uploaded file."
 msgstr "Não foi possível interpretar o arquivo enviado."
 
-#: src/olympia/files/utils.py:380
+#: src/olympia/files/utils.py:377
 msgid "Invalid file name in archive: {0}"
 msgstr "Nome de arquivo inválido em: {0}"
 
-#: src/olympia/files/utils.py:388
+#: src/olympia/files/utils.py:385
 msgid "File exceeding size limit in archive: {0}"
 msgstr "Arquivos maiores do que o permitido em: {0}"
 
-#: src/olympia/files/utils.py:439
+#: src/olympia/files/utils.py:436
 msgid "Invalid archive."
 msgstr "Arquivo inválido."
 
-#: src/olympia/files/utils.py:529 src/olympia/files/utils.py:532
+#: src/olympia/files/utils.py:526 src/olympia/files/utils.py:529
 msgid "Could not parse the manifest file."
 msgstr "Não foi possível analisar o arquivo manifest."
 
-#: src/olympia/files/utils.py:551
+#: src/olympia/files/utils.py:548
 msgid "Could not find an add-on ID."
 msgstr "Não foi possível encontrar um ID do complemento."
 
-#: src/olympia/files/utils.py:554
+#: src/olympia/files/utils.py:551
 msgid "Add-on ID must be 64 characters or less."
 msgstr "O ID do complemento deve ter 64 caracteres ou menos."
 
-#: src/olympia/files/utils.py:556
+#: src/olympia/files/utils.py:553
 msgid "Add-on ID doesn't match add-on."
 msgstr "O ID de complemento não corresponde com o complemento."
 
-#: src/olympia/files/utils.py:564
+#: src/olympia/files/utils.py:561
 msgid "Duplicate add-on ID found."
 msgstr "Encontrado ID de complemento duplicado."
 
 # %1$s is a number.
-#: src/olympia/files/utils.py:567
+#: src/olympia/files/utils.py:564
 msgid "Version numbers should have fewer than 32 characters."
 msgstr "Os números de versão devem ter menos de 32 caracteres."
 
-#: src/olympia/files/utils.py:570
-msgid ""
-"Version numbers should only contain letters, numbers, and these punctuation "
-"characters: +*.-_."
-msgstr ""
-"Os números de versão devem conter apenas letras, números e os seguintes "
-"caracteres de pontuação: +*-_."
+#: src/olympia/files/utils.py:567
+msgid "Version numbers should only contain letters, numbers, and these punctuation characters: +*.-_."
+msgstr "Os números de versão devem conter apenas letras, números e os seguintes caracteres de pontuação: +*-_."
 
-#: src/olympia/files/utils.py:587
+#: src/olympia/files/utils.py:584
 msgid "<em:type> doesn't match add-on"
 msgstr "<em:type> não corresponde ao complemento"
 
@@ -11139,12 +8809,8 @@ msgstr "Download {0}"
 
 #: src/olympia/files/templates/files/file.html:4
 #, python-format
-msgid ""
-"Version: %(version)s &bull; Size: %(size)s &bull; MD5 hash: %(md5)s &bull; "
-"Mimetype: %(mimetype)s"
-msgstr ""
-"Versão: %(version)s &bull; Tamanho: %(size)s &bull; MD5 hash: %(md5)s &bull;"
-" Tipo MIME: %(mimetype)s"
+msgid "Version: %(version)s &bull; Size: %(size)s &bull; MD5 hash: %(md5)s &bull; Mimetype: %(mimetype)s"
+msgstr "Versão: %(version)s &bull; Tamanho: %(size)s &bull; MD5 hash: %(md5)s &bull; Tipo MIME: %(mimetype)s"
 
 #: src/olympia/files/templates/files/viewer.html:4
 msgid "File Compare :: Editor tools"
@@ -11182,33 +8848,27 @@ msgstr "Versão do Add-on SDK:"
 msgid "Tab stops:"
 msgstr "A aba para:"
 
-#: src/olympia/files/templates/files/viewer.html:79
-#: src/olympia/files/templates/files/viewer.html:80
+#: src/olympia/files/templates/files/viewer.html:79 src/olympia/files/templates/files/viewer.html:80
 msgid "Up file"
 msgstr "Acima do arquivo"
 
-#: src/olympia/files/templates/files/viewer.html:84
-#: src/olympia/files/templates/files/viewer.html:85
+#: src/olympia/files/templates/files/viewer.html:84 src/olympia/files/templates/files/viewer.html:85
 msgid "Down file"
 msgstr "Abaixo do arquivo"
 
-#: src/olympia/files/templates/files/viewer.html:90
-#: src/olympia/files/templates/files/viewer.html:91
+#: src/olympia/files/templates/files/viewer.html:90 src/olympia/files/templates/files/viewer.html:91
 msgid "Previous diff"
 msgstr "Diff anterior"
 
-#: src/olympia/files/templates/files/viewer.html:93
-#: src/olympia/files/templates/files/viewer.html:94
+#: src/olympia/files/templates/files/viewer.html:93 src/olympia/files/templates/files/viewer.html:94
 msgid "Previous note"
 msgstr "Nota anterior"
 
-#: src/olympia/files/templates/files/viewer.html:100
-#: src/olympia/files/templates/files/viewer.html:101
+#: src/olympia/files/templates/files/viewer.html:100 src/olympia/files/templates/files/viewer.html:101
 msgid "Next diff"
 msgstr "Próximo diff"
 
-#: src/olympia/files/templates/files/viewer.html:103
-#: src/olympia/files/templates/files/viewer.html:104
+#: src/olympia/files/templates/files/viewer.html:103 src/olympia/files/templates/files/viewer.html:104
 msgid "Next note"
 msgstr "Próxima nota"
 
@@ -11217,18 +8877,15 @@ msgstr "Próxima nota"
 # contents of all the directories (normally you would click on each one to see
 # the
 # contents)
-#: src/olympia/files/templates/files/viewer.html:109
-#: src/olympia/files/templates/files/viewer.html:110
+#: src/olympia/files/templates/files/viewer.html:109 src/olympia/files/templates/files/viewer.html:110
 msgid "Expand all"
 msgstr "Expandir tudo"
 
-#: src/olympia/files/templates/files/viewer.html:114
-#: src/olympia/files/templates/files/viewer.html:115
+#: src/olympia/files/templates/files/viewer.html:114 src/olympia/files/templates/files/viewer.html:115
 msgid "Hide or unhide tree"
 msgstr "Exibir/ocultar árvore"
 
-#: src/olympia/files/templates/files/viewer.html:119
-#: src/olympia/files/templates/files/viewer.html:120
+#: src/olympia/files/templates/files/viewer.html:119 src/olympia/files/templates/files/viewer.html:120
 msgid "Wrap or unwrap text"
 msgstr "Quebra/não quebrar linhas"
 
@@ -11239,6 +8896,10 @@ msgstr "Não há arquivos no arquivo enviado."
 #: src/olympia/files/templates/files/viewer.html:134
 msgid "Fetching file."
 msgstr "Obtendo arquivo."
+
+#: src/olympia/legacy_api/views.py:255
+msgid "Not implemented yet."
+msgstr "Ainda não implementado."
 
 #: src/olympia/lib/constants.py:6
 msgid "United Arab Emirates Dirham"
@@ -11896,12 +9557,7 @@ msgstr "Kwacha da Zâmbia"
 msgid "Zimbabwe Dollar"
 msgstr "Dólar do Zimbabué"
 
-#: src/olympia/lib/video/ffmpeg.py:112 src/olympia/lib/video/totem.py:81
-msgid "Videos must be in WebM."
-msgstr "Os vídeos devem estar em WebM."
-
-#: src/olympia/pages/templates/pages/about.lhtml:3
-#: src/olympia/pages/templates/pages/about.lhtml:10
+#: src/olympia/pages/templates/pages/about.lhtml:3 src/olympia/pages/templates/pages/about.lhtml:10
 msgid "About Mozilla Add-ons"
 msgstr "Sobre os complementos Mozilla"
 
@@ -11911,18 +9567,12 @@ msgstr "O que é este site?"
 
 #: src/olympia/pages/templates/pages/about.lhtml:13
 msgid ""
-"addons.mozilla.org, commonly known as \"AMO\", is Mozilla's official site "
-"for add-ons to Mozilla software, such as Firefox, Thunderbird, and "
-"SeaMonkey. Add-ons let you add new features and change the way your browser "
-"or application works.  Take a look around and explore the thousands of ways "
-"to customize the way you do things online."
+"addons.mozilla.org, commonly known as \"AMO\", is Mozilla's official site for add-ons to Mozilla software, such as Firefox, Thunderbird, and SeaMonkey. Add-ons let you add new features and change "
+"the way your browser or application works. Take a look around and explore the thousands of ways to customize the way you do things online."
 msgstr ""
-"O endereço addons.mozilla.org, comumente conhecido como \"AMO\", é o site "
-"oficial de complementos para softwares da Mozilla como o Firefox, "
-"Thunderbird e o SeaMonkey. Complementos permitem que você adicione novas "
-"funcionalidades ou altere a forma com que o navegador ou outra aplicação "
-"funciona. Dê uma olhada em volta e explore as milhares de formas de "
-"customizar o seu jeito de fazer as coisas online."
+"O endereço addons.mozilla.org, comumente conhecido como \"AMO\", é o site oficial de complementos para softwares da Mozilla como o Firefox, Thunderbird e o SeaMonkey. Complementos permitem que você "
+"adicione novas funcionalidades ou altere a forma com que o navegador ou outra aplicação funciona. Dê uma olhada em volta e explore as milhares de formas de customizar o seu jeito de fazer as coisas "
+"online."
 
 #: src/olympia/pages/templates/pages/about.lhtml:19
 msgid "Who creates these add-ons?"
@@ -11930,107 +9580,66 @@ msgstr "Quem cria estes complementos?"
 
 #: src/olympia/pages/templates/pages/about.lhtml:20
 msgid ""
-"The add-ons listed here have been created by thousands of developers from "
-"our community, ranging from individual hobbyists to large corporations. All "
-"publicly listed add-ons are reviewed by a team of editors before being "
-"released. Add-ons marked as Experimental have not been reviewed and should "
-"only be installed with caution."
+"The add-ons listed here have been created by thousands of developers from our community, ranging from individual hobbyists to large corporations. All publicly listed add-ons are reviewed by a team "
+"of editors before being released. Add-ons marked as Experimental have not been reviewed and should only be installed with caution."
 msgstr ""
-"Os complementos listados aqui foram criados por milhares de desenvolvedores "
-"de nossa comunidade, que vão desde amadores a grandes corporações. Todos os "
-"complementos de capital aberto são analisados ​​por uma equipe de editores "
-"antes de serem liberados. Complementos marcados como experimental não foram "
-"revisados e só deve ser instalado com cautela."
+"Os complementos listados aqui foram criados por milhares de desenvolvedores de nossa comunidade, que vão desde amadores a grandes corporações. Todos os complementos de capital aberto são analisados ​​"
+"por uma equipe de editores antes de serem liberados. Complementos marcados como experimental não foram revisados e só deve ser instalado com cautela."
 
 #: src/olympia/pages/templates/pages/about.lhtml:26
 msgid "How do I keep up with what's happening at AMO?"
 msgstr "Como faço para acompanhar o que está acontecendo na AMO?"
 
 #: src/olympia/pages/templates/pages/about.lhtml:27
-msgid ""
-"There are several ways to find out the latest news from the world of add-"
-"ons:"
-msgstr ""
-"Existem várias maneiras de descobrir as últimas notícias do mundo dos "
-"complementos:"
+msgid "There are several ways to find out the latest news from the world of add-ons:"
+msgstr "Existem várias maneiras de descobrir as últimas notícias do mundo dos complementos:"
 
 #: src/olympia/pages/templates/pages/about.lhtml:29
 #, python-format
-msgid ""
-"Our <a href=\"%(url)s\">Add-ons Blog</a> is regularly updated with "
-"information for both add-on enthusiasts and developers."
-msgstr ""
-"Nosso <a href=\"%(url)s\">blog de complementos</a> é atualizado regularmente"
-" com informações sobre os complementos tanto para entusiastas como "
-"desenvolvedores."
+msgid "Our <a href=\"%(url)s\">Add-ons Blog</a> is regularly updated with information for both add-on enthusiasts and developers."
+msgstr "Nosso <a href=\"%(url)s\">blog de complementos</a> é atualizado regularmente com informações sobre os complementos tanto para entusiastas como desenvolvedores."
 
 #: src/olympia/pages/templates/pages/about.lhtml:32
 #, python-format
-msgid ""
-"We often post news, tips, and tricks to our Twitter account, <a "
-"href=\"%(url)s\">mozamo</a>"
-msgstr ""
-"Muitas vezes postamos notícias, dicas e truques na nossa conta do Twitter, "
-"<a href=\"%(url)s\">mozamo</a>"
+msgid "We often post news, tips, and tricks to our Twitter account, <a href=\"%(url)s\">mozamo</a>"
+msgstr "Muitas vezes postamos notícias, dicas e truques na nossa conta do Twitter, <a href=\"%(url)s\">mozamo</a>"
 
 #: src/olympia/pages/templates/pages/about.lhtml:34
 #, python-format
-msgid ""
-"Our <a href=\"%(url)s\">forums</a> are a good place to interact with the "
-"add-ons community and discuss upcoming changes to AMO."
-msgstr ""
-"Nossos <a href=\"%(url)s\">fórum</a> são um bom lugar para interagir com a "
-"comunidade de complementos e discutir futuras alterações na AMO."
+msgid "Our <a href=\"%(url)s\">forums</a> are a good place to interact with the add-ons community and discuss upcoming changes to AMO."
+msgstr "Nossos <a href=\"%(url)s\">fórum</a> são um bom lugar para interagir com a comunidade de complementos e discutir futuras alterações na AMO."
 
 #: src/olympia/pages/templates/pages/about.lhtml:39
 msgid "This sounds great! How can I get involved?"
 msgstr "Isto soa muito bem! Como posso me envolver?"
 
 #: src/olympia/pages/templates/pages/about.lhtml:40
-msgid ""
-"There are plenty of ways to get involved. If you're on the technical side:"
+msgid "There are plenty of ways to get involved. If you're on the technical side:"
 msgstr "Há muitas maneiras de se envolver. Se você tem habilidades técnicas:"
 
 #: src/olympia/pages/templates/pages/about.lhtml:42
 #, python-format
-msgid ""
-"<a href=\"%(url)s\">Make your own add-on</a>. We provide free hosting and "
-"update services and can help you reach a large audience of users."
-msgstr ""
-"<a href=\"%(url)s\">Faça o seu próprio complemento</a>. Nós fornecemos os "
-"serviços de hospedagem e atualização gratuita e podemos te ajudar a atingir "
-"uma grande audiência de usuários."
+msgid "<a href=\"%(url)s\">Make your own add-on</a>. We provide free hosting and update services and can help you reach a large audience of users."
+msgstr "<a href=\"%(url)s\">Faça o seu próprio complemento</a>. Nós fornecemos os serviços de hospedagem e atualização gratuita e podemos te ajudar a atingir uma grande audiência de usuários."
 
 #: src/olympia/pages/templates/pages/about.lhtml:45
 #, python-format
-msgid ""
-"If you have add-on development experience, <a href=\"%(url)s\"> become an "
-"editor</a>! Our editors are add-on fans with a technical background who "
-"review add-ons for code quality and stability."
+msgid "If you have add-on development experience, <a href=\"%(url)s\"> become an editor</a>! Our editors are add-on fans with a technical background who review add-ons for code quality and stability."
 msgstr ""
-"Se você tem experiência de desenvolvimento de complementos, <a "
-"href=\"%(url)s\">tornar-se um editor</a>! Nossos editores são fãs de "
-"complementos com uma formação técnica que permite revisar complementos e "
-"comprovar a qualidade do código e estabilidade."
+"Se você tem experiência de desenvolvimento de complementos, <a href=\"%(url)s\">tornar-se um editor</a>! Nossos editores são fãs de complementos com uma formação técnica que permite revisar "
+"complementos e comprovar a qualidade do código e estabilidade."
 
 #: src/olympia/pages/templates/pages/about.lhtml:49
 #, python-format
 msgid ""
-"Help improve this website. It's open source, and you can file bugs and "
-"submit patches. <a href=\"%(url)s\"> GitHub</a> contains all of our current "
-"bugs, legacy bugs can still be found in Bugzilla."
+"Help improve this website. It's open source, and you can file bugs and submit patches. <a href=\"%(url)s\"> GitHub</a> contains all of our current bugs, legacy bugs can still be found in Bugzilla."
 msgstr ""
-"Ajude a melhorar este website. Ele é de código aberto e você pode registrar "
-"bugs e submeter correções.<a href=\"%(url)s\">GitHub</a> contém todos os "
-"nossos bugs atuais, bugs legados ainda podem ser encontrados no Bugzilla."
+"Ajude a melhorar este website. Ele é de código aberto e você pode registrar bugs e submeter correções.<a href=\"%(url)s\">GitHub</a> contém todos os nossos bugs atuais, bugs legados ainda podem ser "
+"encontrados no Bugzilla."
 
 #: src/olympia/pages/templates/pages/about.lhtml:55
-msgid ""
-"If you're interested in add-ons but not quite as technical, there are still "
-"ways to help:"
-msgstr ""
-"Se você estiver interessado em complementos mas não como técnico, ainda há "
-"maneiras de ajudar:"
+msgid "If you're interested in add-ons but not quite as technical, there are still ways to help:"
+msgstr "Se você estiver interessado em complementos mas não como técnico, ainda há maneiras de ajudar:"
 
 #: src/olympia/pages/templates/pages/about.lhtml:58
 msgid "Tell your friends! Let people know which add-ons you use."
@@ -12042,13 +9651,8 @@ msgid "Participate in our <a href=\"%(url)s\">forums</a>."
 msgstr "Participe de nosso <a href=\"%(url)s\">fórum</a>."
 
 #: src/olympia/pages/templates/pages/about.lhtml:61
-msgid ""
-"Review add-ons on the site. Add-on authors are more likely to improve their "
-"add-ons and write new ones when they know people appreciate their work."
-msgstr ""
-"Analise complementos no site. Autores de complementos são mais propensos a "
-"melhorar os seus complementos e escrever novos quando conhecem o que as "
-"pessoas apreciam no seu trabalho."
+msgid "Review add-ons on the site. Add-on authors are more likely to improve their add-ons and write new ones when they know people appreciate their work."
+msgstr "Analise complementos no site. Autores de complementos são mais propensos a melhorar os seus complementos e escrever novos quando conhecem o que as pessoas apreciam no seu trabalho."
 
 #: src/olympia/pages/templates/pages/about.lhtml:66
 msgid "I have a question"
@@ -12057,23 +9661,16 @@ msgstr "Eu tenho uma pergunta"
 #: src/olympia/pages/templates/pages/about.lhtml:67
 #, python-format
 msgid ""
-"A good place to start is our <a href=\"%(faq_url)s\"><abbr "
-"title=\"Frequently Asked Questions\">FAQ</abbr></a>. If you don't find an "
-"answer there, you can <a href=\"%(forum_url)s\"> ask on our forums</a>."
+"A good place to start is our <a href=\"%(faq_url)s\"><abbr title=\"Frequently Asked Questions\">FAQ</abbr></a>. If you don't find an answer there, you can <a href=\"%(forum_url)s\"> ask on our "
+"forums</a>."
 msgstr ""
-"Um bom lugar para começar é o nosso <a href=\"%(faq_url)s\"><abbr "
-"title=\"Frequently Asked Questions\">FAQ</abbr></a>. Se não encontrar uma "
-"resposta, você pode <a href=\"%(forum_url)s\"> perguntar em nossos "
-"fóruns</a>."
+"Um bom lugar para começar é o nosso <a href=\"%(faq_url)s\"><abbr title=\"Frequently Asked Questions\">FAQ</abbr></a>. Se não encontrar uma resposta, você pode <a href=\"%(forum_url)s\"> perguntar "
+"em nossos fóruns</a>."
 
 #: src/olympia/pages/templates/pages/about.lhtml:72
 #, python-format
-msgid ""
-"If you really need to contact someone from the Mozilla team, please see our "
-"<a href=\"%(url)s\"> contact information</a> page."
-msgstr ""
-"Se você realmente precisa entrar em contato com alguém da equipe Mozilla, "
-"consulte a nossa página de  <a href=\"%(url)s\">informações de contato</a>."
+msgid "If you really need to contact someone from the Mozilla team, please see our <a href=\"%(url)s\"> contact information</a> page."
+msgstr "Se você realmente precisa entrar em contato com alguém da equipe Mozilla, consulte a nossa página de  <a href=\"%(url)s\">informações de contato</a>."
 
 #: src/olympia/pages/templates/pages/about.lhtml:76
 msgid "Who works on this website?"
@@ -12082,15 +9679,11 @@ msgstr "Quem trabalha neste site?"
 #: src/olympia/pages/templates/pages/about.lhtml:77
 #, python-format
 msgid ""
-"Over the years, many people have contributed to this website, including both"
-" volunteers from the community and a dedicated AMO team. A list of "
-"significant contributors can be found on our <a href=\"%(url)s\"> Site "
-"Credits</a> page."
+"Over the years, many people have contributed to this website, including both volunteers from the community and a dedicated AMO team. A list of significant contributors can be found on our <a href="
+"\"%(url)s\"> Site Credits</a> page."
 msgstr ""
-"Ao longo dos anos, muitas pessoas têm contribuído para este website, "
-"incluindo os voluntários da comunidade e uma equipe dedicada AMO. A lista "
-"dos contribuintes significativos podem ser encontrados em nossa página de <a"
-" href=\"%(url)s\">Créditos do Site</a>."
+"Ao longo dos anos, muitas pessoas têm contribuído para este website, incluindo os voluntários da comunidade e uma equipe dedicada AMO. A lista dos contribuintes significativos podem ser encontrados "
+"em nossa página de <a href=\"%(url)s\">Créditos do Site</a>."
 
 #: src/olympia/pages/templates/pages/acr_firstrun.html:4
 msgid "Add-on Compatibility Reporter"
@@ -12101,69 +9694,46 @@ msgid "Add-on Compatibility Reporter has been installed"
 msgstr "O Add-on Compatibility Reporter foi instalado"
 
 #: src/olympia/pages/templates/pages/acr_firstrun.html:28
-msgid ""
-"It’s easy to help us make sure add-ons are updated in time for the release "
-"of the next version of Firefox."
-msgstr ""
-"É fácil nos ajudar a garantir que os complementos sejam atualizados a tempo "
-"quando uma nova versão do Firefox for lançada."
+msgid "It’s easy to help us make sure add-ons are updated in time for the release of the next version of Firefox."
+msgstr "É fácil nos ajudar a garantir que os complementos sejam atualizados a tempo quando uma nova versão do Firefox for lançada."
 
 #: src/olympia/pages/templates/pages/acr_firstrun.html:35
 msgid "Here’s how to get started reporting add-on compatibility:"
-msgstr ""
-"Aqui está como nos ajudar a relatar a compatibilidade dos complementos:"
+msgstr "Aqui está como nos ajudar a relatar a compatibilidade dos complementos:"
 
 #: src/olympia/pages/templates/pages/acr_firstrun.html:40
 msgid ""
-"As you start browsing and using your add-ons, take careful note of anything "
-"that seems different from when you last used the extension. This might be a "
-"display glitch, such as a menu item missing, or something more serious, like"
-" the add-on not working at all or showing errors."
+"As you start browsing and using your add-ons, take careful note of anything that seems different from when you last used the extension. This might be a display glitch, such as a menu item missing, "
+"or something more serious, like the add-on not working at all or showing errors."
 msgstr ""
-"Ao navegar e usar seus complementos, observe cuidadosamente qualquer "
-"comportamento que pareça diferente da última vez em que você usou a "
-"extensão. Poderia ser um erro de exibição, como um item de menu faltando, ou"
-" algo mais sério, como o complemento deixar de funcionar completamente ou "
-"exibindo erros."
+"Ao navegar e usar seus complementos, observe cuidadosamente qualquer comportamento que pareça diferente da última vez em que você usou a extensão. Poderia ser um erro de exibição, como um item de "
+"menu faltando, ou algo mais sério, como o complemento deixar de funcionar completamente ou exibindo erros."
 
 #: src/olympia/pages/templates/pages/acr_firstrun.html:49
 msgid ""
-"Once you know whether a particular add-on works properly or has problems, "
-"open the Add-ons Manager and click Compatibility next to the add-on to let "
-"Mozilla know what you found in your testing. Submitting a report will help "
-"us tell the add-on developer whether their add-on is working properly in "
-"this version or might need some fixes."
+"Once you know whether a particular add-on works properly or has problems, open the Add-ons Manager and click Compatibility next to the add-on to let Mozilla know what you found in your testing. "
+"Submitting a report will help us tell the add-on developer whether their add-on is working properly in this version or might need some fixes."
 msgstr ""
-"Assim que você tiver certeza de que um complemento em particular estiver "
-"funcionando corretamente ou apresentando algum problema, abra o Gerenciador "
-"de complementos e clique no botão de compatibilidade próximo ao complemento "
-"e deixe a Mozilla saber o que você encontrou nos seus testes. Enviar o "
-"relatório nos ajudará a dizer ao desenvolvedor se seu complemento está "
-"funcionando corretamente nesta versão ou se precisa de correções."
+"Assim que você tiver certeza de que um complemento em particular estiver funcionando corretamente ou apresentando algum problema, abra o Gerenciador de complementos e clique no botão de "
+"compatibilidade próximo ao complemento e deixe a Mozilla saber o que você encontrou nos seus testes. Enviar o relatório nos ajudará a dizer ao desenvolvedor se seu complemento está funcionando "
+"corretamente nesta versão ou se precisa de correções."
 
 #: src/olympia/pages/templates/pages/acr_firstrun.html:61
 #, python-format
 msgid ""
-"If you upgrade to a new version of Firefox or update your add-ons, your "
-"reports for the old versions will be hidden to allow you to test the new "
-"version. If you have any questions, please ask in <a href=\"%(url)s\">our "
-"forums</a>."
+"If you upgrade to a new version of Firefox or update your add-ons, your reports for the old versions will be hidden to allow you to test the new version. If you have any questions, please ask in <a "
+"href=\"%(url)s\">our forums</a>."
 msgstr ""
-"Se atualizar para uma nova versão do Firefox ou atualizar o complemento, "
-"seus relatórios das versões antigas não serão exibidos para permitir que "
-"possa testar a nova versão. Se tiver dúvidas, por favor, pergunte nos <a "
-"href=\"%(url)s\">nossos fóruns</a>."
+"Se atualizar para uma nova versão do Firefox ou atualizar o complemento, seus relatórios das versões antigas não serão exibidos para permitir que possa testar a nova versão. Se tiver dúvidas, por "
+"favor, pergunte nos <a href=\"%(url)s\">nossos fóruns</a>."
 
 #: src/olympia/pages/templates/pages/acr_firstrun.html:69
 msgid ""
-"Thousands of add-ons are made by our community every year, and your "
-"assistance with compatibility testing helps us make sure these add-ons stay "
-"useful as we strive to provide a great user experience."
+"Thousands of add-ons are made by our community every year, and your assistance with compatibility testing helps us make sure these add-ons stay useful as we strive to provide a great user "
+"experience."
 msgstr ""
-"Milhares de complementos são criados pela nossa comunidade todos os anos, e "
-"sua assistência testando a compatibilidade nos ajuda a garantir que esses "
-"complementos continuem úteis, impulsionando nossos esforços em oferecer uma "
-"excelente experiência ao usuário."
+"Milhares de complementos são criados pela nossa comunidade todos os anos, e sua assistência testando a compatibilidade nos ajuda a garantir que esses complementos continuem úteis, impulsionando "
+"nossos esforços em oferecer uma excelente experiência ao usuário."
 
 #: src/olympia/pages/templates/pages/acr_firstrun.html:75
 msgid "Thank you!"
@@ -12174,12 +9744,8 @@ msgid "Site Credits"
 msgstr "Créditos do site"
 
 #: src/olympia/pages/templates/pages/credits.html:12
-msgid ""
-"Mozilla would like to thank the following people for their contributions to "
-"the addons.mozilla.org project over the years:"
-msgstr ""
-"A Mozilla gostaria de agradecer às seguintes pessoas por suas colaborações "
-"ao projeto addons.mozilla.org ao longo dos anos:"
+msgid "Mozilla would like to thank the following people for their contributions to the addons.mozilla.org project over the years:"
+msgstr "A Mozilla gostaria de agradecer às seguintes pessoas por suas colaborações ao projeto addons.mozilla.org ao longo dos anos:"
 
 #: src/olympia/pages/templates/pages/credits.html:18
 msgid "Developers &amp; Administrators"
@@ -12212,90 +9778,63 @@ msgstr "Software e imagens"
 
 #: src/olympia/pages/templates/pages/credits.html:59
 msgid ""
-"Some icons used are from the <a "
-"href=\"http://www.famfamfam.com/lab/icons/silk/\">famfamfam Silk Icon "
-"Set</a>, licensed under a <a "
-"href=\"http://creativecommons.org/licenses/by/2.5/\">Creative Commons "
-"Attribution 2.5 License</a>."
+"Some icons used are from the <a href=\"http://www.famfamfam.com/lab/icons/silk/\">famfamfam Silk Icon Set</a>, licensed under a <a href=\"http://creativecommons.org/licenses/by/2.5/\">Creative "
+"Commons Attribution 2.5 License</a>."
 msgstr ""
-"Alguns ícones usados são do conjunto de ícones <a "
-"href=\"http://www.famfamfam.com/lab/icons/silk/\">famfamfam Silk</a>, "
-"licenciado sob uma licença <a "
-"href=\"http://creativecommons.org/licenses/by/2.5/deed.pt_BR\">Creative "
-"Commons Atribuição 2.5 Genérica</a>."
+"Alguns ícones usados são do conjunto de ícones <a href=\"http://www.famfamfam.com/lab/icons/silk/\">famfamfam Silk</a>, licenciado sob uma licença <a href=\"http://creativecommons.org/licenses/"
+"by/2.5/deed.pt_BR\">Creative Commons Atribuição 2.5 Genérica</a>."
 
 #: src/olympia/pages/templates/pages/credits.html:60
 msgid ""
-"Some icons used are from the <a href=\"http://www.fatcow.com/free-"
-"icons/\">FatCow Farm-Fresh Web Icons Set</a>, licensed under a <a "
-"href=\"http://creativecommons.org/licenses/by/3.0/us/\">Creative Commons "
-"Attribution 3.0 License</a>."
+"Some icons used are from the <a href=\"http://www.fatcow.com/free-icons/\">FatCow Farm-Fresh Web Icons Set</a>, licensed under a <a href=\"http://creativecommons.org/licenses/by/3.0/us/\">Creative "
+"Commons Attribution 3.0 License</a>."
 msgstr ""
-"Alguns ícones usados são do conjunto de ícones <a "
-"href=\"http://www.fatcow.com/free-icons/\">FatCow Farm-Fresh Web</a>, "
-"licenciado sob uma licença <a "
-"href=\"http://creativecommons.org/licenses/by/3.0/deed.pt_BR\">Creative "
-"Commons Atribuição 3.0 Não Adaptada</a>."
+"Alguns ícones usados são do conjunto de ícones <a href=\"http://www.fatcow.com/free-icons/\">FatCow Farm-Fresh Web</a>, licenciado sob uma licença <a href=\"http://creativecommons.org/licenses/"
+"by/3.0/deed.pt_BR\">Creative Commons Atribuição 3.0 Não Adaptada</a>."
 
 #: src/olympia/pages/templates/pages/credits.html:61
 msgid ""
-"Some pages use elements of <a "
-"href=\"http://shop.highsoft.com/highcharts.html\">Highcharts</a> (non-"
-"commercial), licensed under a <a href=\"http://creativecommons.org/licenses"
-"/by-nc/3.0/\">Creative Commons Attribution-NonCommercial 3.0 License</a>."
+"Some pages use elements of <a href=\"http://shop.highsoft.com/highcharts.html\">Highcharts</a> (non-commercial), licensed under a <a href=\"http://creativecommons.org/licenses/by-nc/3.0/\">Creative "
+"Commons Attribution-NonCommercial 3.0 License</a>."
 msgstr ""
-"Algumas páginas usam elementos do <a "
-"href=\"http://shop.highsoft.com/highcharts.html\">Highcharts</a> (não-"
-"comercial), licenciado sob uma licença <a "
-"href=\"http://creativecommons.org/licenses/by-nc/3.0/deed.pt_BR\">Creative "
-"Commons Atribuição-NãoComercial 3.0 Não Adaptada</a>."
+"Algumas páginas usam elementos do <a href=\"http://shop.highsoft.com/highcharts.html\">Highcharts</a> (não-comercial), licenciado sob uma licença <a href=\"http://creativecommons.org/licenses/by-"
+"nc/3.0/deed.pt_BR\">Creative Commons Atribuição-NãoComercial 3.0 Não Adaptada</a>."
 
 #: src/olympia/pages/templates/pages/credits.html:65
 #, python-format
-msgid ""
-"For information on contributing, please see our <a href=\"%(url)s\">wiki "
-"page</a>."
-msgstr ""
-"Para informações sobre colaboração, por favor, visite nossa <a "
-"href=\"%(url)s\">página wiki</a>."
+msgid "For information on contributing, please see our <a href=\"%(url)s\">wiki page</a>."
+msgstr "Para informações sobre colaboração, por favor, visite nossa <a href=\"%(url)s\">página wiki</a>."
 
 #: src/olympia/pages/templates/pages/dev_faq.html:4
 msgid "Developer FAQ"
 msgstr "Dúvidas comuns do desenvolvedor"
 
-#: src/olympia/pages/templates/pages/dev_faq.html:31
-#: src/olympia/pages/templates/pages/review_guide.html:33
+#: src/olympia/pages/templates/pages/dev_faq.html:31 src/olympia/pages/templates/pages/review_guide.html:33
 msgid "Sections"
 msgstr "Seções"
 
-#: src/olympia/pages/templates/pages/dev_faq.html:33
-#: src/olympia/pages/templates/pages/dev_faq.html:45
+#: src/olympia/pages/templates/pages/dev_faq.html:33 src/olympia/pages/templates/pages/dev_faq.html:45
 msgid "Developing an Add-on"
 msgstr "Desenvolvendo um complemento"
 
 #. Heading for a list of resources for developers
-#: src/olympia/pages/templates/pages/dev_faq.html:34
-#: src/olympia/pages/templates/pages/dev_faq.html:208
+#: src/olympia/pages/templates/pages/dev_faq.html:34 src/olympia/pages/templates/pages/dev_faq.html:208
 msgid "Support Resources"
 msgstr "Recursos de suporte"
 
-#: src/olympia/pages/templates/pages/dev_faq.html:35
-#: src/olympia/pages/templates/pages/dev_faq.html:261
+#: src/olympia/pages/templates/pages/dev_faq.html:35 src/olympia/pages/templates/pages/dev_faq.html:261
 msgid "Contributing your Add-on"
 msgstr "Colaborando com o seu complemento"
 
-#: src/olympia/pages/templates/pages/dev_faq.html:36
-#: src/olympia/pages/templates/pages/dev_faq.html:381
+#: src/olympia/pages/templates/pages/dev_faq.html:36 src/olympia/pages/templates/pages/dev_faq.html:381
 msgid "Add-on Review Process"
 msgstr "Processo de análise de complementos"
 
-#: src/olympia/pages/templates/pages/dev_faq.html:37
-#: src/olympia/pages/templates/pages/dev_faq.html:444
+#: src/olympia/pages/templates/pages/dev_faq.html:37 src/olympia/pages/templates/pages/dev_faq.html:444
 msgid "Managing Your Add-on"
 msgstr "Gerenciando seu complemento"
 
-#: src/olympia/pages/templates/pages/dev_faq.html:39
-#: src/olympia/pages/templates/pages/dev_faq.html:528
+#: src/olympia/pages/templates/pages/dev_faq.html:39 src/olympia/pages/templates/pages/dev_faq.html:528
 msgid "References for Open Source Licenses"
 msgstr "Referências de licenças de código aberto"
 
@@ -12305,14 +9844,8 @@ msgstr "Dúvidas comuns de desenvolvedores de complementos"
 
 #: src/olympia/pages/templates/pages/dev_faq.html:47
 #, python-format
-msgid ""
-"<h3>How do I build an Add-on?</h3> <p> Mozilla provides documentation on how"
-" to build an add-on via the <a href=\"%(url)s\">Mozilla Developer "
-"Network</a>. </p>"
-msgstr ""
-"<h3>Como faço para criar um complemento?</h3> <p>A Mozilla fornece "
-"documentação sobre como criar um complemento através do <a "
-"href=\"%(url)s\">Mozilla Developer Network</a>.</p>"
+msgid "<h3>How do I build an Add-on?</h3> <p> Mozilla provides documentation on how to build an add-on via the <a href=\"%(url)s\">Mozilla Developer Network</a>. </p>"
+msgstr "<h3>Como faço para criar um complemento?</h3> <p>A Mozilla fornece documentação sobre como criar um complemento através do <a href=\"%(url)s\">Mozilla Developer Network</a>.</p>"
 
 #: src/olympia/pages/templates/pages/dev_faq.html:55
 msgid "Other resources include:"
@@ -12332,14 +9865,11 @@ msgstr "De que ferramentas eu preciso para poder criar um complemento?"
 
 #: src/olympia/pages/templates/pages/dev_faq.html:68
 msgid ""
-"You will need to have a version of the Mozilla software that you're building"
-" the add-on for and a code editor of your choice. Add-ons can be built for "
-"almost all Mozilla software but are primarily targeted for:"
+"You will need to have a version of the Mozilla software that you're building the add-on for and a code editor of your choice. Add-ons can be built for almost all Mozilla software but are primarily "
+"targeted for:"
 msgstr ""
-"Você precisará de uma versão da aplicação Mozilla para a qual você está "
-"criando um complemento e um editor de código da sua escolha. Complementos "
-"podem ser criados para quase todas as aplicações baseadas na tecnologia "
-"Mozilla, mas o foco primário é:"
+"Você precisará de uma versão da aplicação Mozilla para a qual você está criando um complemento e um editor de código da sua escolha. Complementos podem ser criados para quase todas as aplicações "
+"baseadas na tecnologia Mozilla, mas o foco primário é:"
 
 #: src/olympia/pages/templates/pages/dev_faq.html:82
 msgid "Popular code editors include:"
@@ -12348,37 +9878,24 @@ msgstr "Editores de código populares incluem:"
 #. This is a list of popular code editors.  Feel free to adjust as you like.
 #: src/olympia/pages/templates/pages/dev_faq.html:85
 msgid ""
-"<li><a href=\"http://komodoide.com/komodo-edit/\">Komodo Edit</a></li> "
-"<li><a href=\"http://macromates.com/\">TextMate</a></li> <li><a href=\"http"
-"://notepad-plus-plus.org/\">Notepad++</a></li> <li><a "
-"href=\"http://www.eclipse.org/\">Eclipse IDE</a></li>"
+"<li><a href=\"http://komodoide.com/komodo-edit/\">Komodo Edit</a></li> <li><a href=\"http://macromates.com/\">TextMate</a></li> <li><a href=\"http://notepad-plus-plus.org/\">Notepad++</a></li> "
+"<li><a href=\"http://www.eclipse.org/\">Eclipse IDE</a></li>"
 msgstr ""
-"<li><a href=\"http://komodoide.com/komodo-edit/\">Komodo Edit</a></li> "
-"<li><a href=\"http://macromates.com/\">TextMate</a></li> <li><a href=\"http"
-"://notepad-plus-plus.org/\">Notepad++</a></li> <li><a "
-"href=\"http://www.eclipse.org/\">Eclipse IDE</a></li>"
+"<li><a href=\"http://komodoide.com/komodo-edit/\">Komodo Edit</a></li> <li><a href=\"http://macromates.com/\">TextMate</a></li> <li><a href=\"http://notepad-plus-plus.org/\">Notepad++</a></li> "
+"<li><a href=\"http://www.eclipse.org/\">Eclipse IDE</a></li>"
 
 #: src/olympia/pages/templates/pages/dev_faq.html:94
 #, python-format
-msgid ""
-"You can also learn more about setting up your development environment via "
-"the MDN article <a href=\"%(url)s\">Setting up extension development "
-"environment</a>"
-msgstr ""
-"Você também pode aprender mais sobre como configurar seu ambiente de "
-"desenvolvimento, através do artigo <a href=\"%(url)s\">Configurando o "
-"ambiente de desenvolvimento de extensão</a> no MDN"
+msgid "You can also learn more about setting up your development environment via the MDN article <a href=\"%(url)s\">Setting up extension development environment</a>"
+msgstr "Você também pode aprender mais sobre como configurar seu ambiente de desenvolvimento, através do artigo <a href=\"%(url)s\">Configurando o ambiente de desenvolvimento de extensão</a> no MDN"
 
 #: src/olympia/pages/templates/pages/dev_faq.html:100
 msgid "What is a \".xpi\" file?"
 msgstr "O que é um arquivo \".xpi\"?"
 
 #: src/olympia/pages/templates/pages/dev_faq.html:102
-msgid ""
-"Extensions are packaged and distributed in ZIP files or Bundles, with the "
-"XPI (pronounced \"zippy\") file extension."
-msgstr ""
-"Extensões são empacotadas e distribuídas em arquivos ZIP com a extensão XPI."
+msgid "Extensions are packaged and distributed in ZIP files or Bundles, with the XPI (pronounced \"zippy\") file extension."
+msgstr "Extensões são empacotadas e distribuídas em arquivos ZIP com a extensão XPI."
 
 #: src/olympia/pages/templates/pages/dev_faq.html:108
 msgid "What is XUL?"
@@ -12386,17 +9903,11 @@ msgstr "O que é XUL?"
 
 #: src/olympia/pages/templates/pages/dev_faq.html:110
 msgid ""
-"XUL (XML User Interface Language) is Mozilla's XML-based language that lets "
-"you build feature-rich cross platform applications. It provides user "
-"interface widgets like buttons, menus, toolbars, trees, etc that can be used"
-" to enhance add-ons by modifying parts of the browser UI."
+"XUL (XML User Interface Language) is Mozilla's XML-based language that lets you build feature-rich cross platform applications. It provides user interface widgets like buttons, menus, toolbars, "
+"trees, etc that can be used to enhance add-ons by modifying parts of the browser UI."
 msgstr ""
-"XUL (XML User Interface Language, linguagem de interface XML) é uma "
-"linguagem da Mozilla baseada em XML que permite construir interfaces ricas "
-"compatíveis com diversas aplicações multiplataforma. Ela oferece widgets de "
-"interface como botões, barras de ferramentas, árvores, entre outros, que "
-"podem ser usados para melhorar os complementos modificando partes da "
-"interface do navegador."
+"XUL (XML User Interface Language, linguagem de interface XML) é uma linguagem da Mozilla baseada em XML que permite construir interfaces ricas compatíveis com diversas aplicações multiplataforma. "
+"Ela oferece widgets de interface como botões, barras de ferramentas, árvores, entre outros, que podem ser usados para melhorar os complementos modificando partes da interface do navegador."
 
 #: src/olympia/pages/templates/pages/dev_faq.html:119
 msgid "What is the \"install.rdf\" file used for?"
@@ -12405,36 +9916,21 @@ msgstr "Para que serve o arquivo \"install.rdf\"?"
 #: src/olympia/pages/templates/pages/dev_faq.html:121
 #, python-format
 msgid ""
-"This file, called an <a href=\"%(url)s\">Install Manifest</a>, is used by "
-"Add-on Manager-enabled XUL applications to determine information about an "
-"add-on as it is being installed. It contains metadata identifying the add-"
-"on, providing information about who created it, where more information can "
-"be found about it, which versions of what applications it is compatible "
-"with, how it should be updated, and so on. The format of the Install "
-"Manifest is RDF/XML."
+"This file, called an <a href=\"%(url)s\">Install Manifest</a>, is used by Add-on Manager-enabled XUL applications to determine information about an add-on as it is being installed. It contains "
+"metadata identifying the add-on, providing information about who created it, where more information can be found about it, which versions of what applications it is compatible with, how it should "
+"be updated, and so on. The format of the Install Manifest is RDF/XML."
 msgstr ""
-"Esse arquivo, conhecido como <a href=\"%(url)s\">Manifesto de "
-"Instalação</a>, é usado por aplicativos XUL habilitados no Gerenciador de "
-"complementos para obter informações sobre como um complemento está sendo "
-"instalado. Ele contém metadados que identificam o complemento, fornecendo "
-"informações sobre quem o criou, onde mais informações podem ser encontradas,"
-" quais versões de quais aplicativos são compatíveis com o complemento, como "
-"ele deve ser atualizado, entre outros. O formato do manifesto de instalação "
-"é RDF/XML."
+"Esse arquivo, conhecido como <a href=\"%(url)s\">Manifesto de Instalação</a>, é usado por aplicativos XUL habilitados no Gerenciador de complementos para obter informações sobre como um complemento "
+"está sendo instalado. Ele contém metadados que identificam o complemento, fornecendo informações sobre quem o criou, onde mais informações podem ser encontradas, quais versões de quais aplicativos "
+"são compatíveis com o complemento, como ele deve ser atualizado, entre outros. O formato do manifesto de instalação é RDF/XML."
 
 #: src/olympia/pages/templates/pages/dev_faq.html:132
 msgid "What does \"maxVersion\" mean?"
 msgstr "O que significa \"maxVersion\"?"
 
 #: src/olympia/pages/templates/pages/dev_faq.html:134
-msgid ""
-"This determines the maximum version of Firefox you're saying this extension "
-"will work with. Set this to be no newer than the newest currently available "
-"version!"
-msgstr ""
-"Essa propriedade determina a versão máxima do Firefox com a qual você afirma"
-" que seu complemento vai funcionar. Defina um valor que não seja maior que a"
-" versão mais recente atualmente!"
+msgid "This determines the maximum version of Firefox you're saying this extension will work with. Set this to be no newer than the newest currently available version!"
+msgstr "Essa propriedade determina a versão máxima do Firefox com a qual você afirma que seu complemento vai funcionar. Defina um valor que não seja maior que a versão mais recente atualmente!"
 
 #: src/olympia/pages/templates/pages/dev_faq.html:141
 msgid "Can my add-on contain binary components?"
@@ -12443,43 +9939,25 @@ msgstr "O meu complemento pode conter componentes binários?"
 #: src/olympia/pages/templates/pages/dev_faq.html:143
 #, python-format
 msgid ""
-"Yes. You can use Mozilla's <a href=\"%(url)s\">XPCOM component object "
-"model</a> to enhance your add-ons. XPCOM components be used and implemented "
-"in JavaScript, Java, and Python in addition to C++."
+"Yes. You can use Mozilla's <a href=\"%(url)s\">XPCOM component object model</a> to enhance your add-ons. XPCOM components be used and implemented in JavaScript, Java, and Python in addition to C++."
 msgstr ""
-"Sim. Você pode usar o <a href=\"%(url)s\">XPCOM</a>, modelo de componentes e"
-" objetos da Mozilla, para melhorar seus complementos. Os componentes XPCOM "
-"podem ser usados e implementados em JavaScript, Java e Python, além de C++."
+"Sim. Você pode usar o <a href=\"%(url)s\">XPCOM</a>, modelo de componentes e objetos da Mozilla, para melhorar seus complementos. Os componentes XPCOM podem ser usados e implementados em "
+"JavaScript, Java e Python, além de C++."
 
 #: src/olympia/pages/templates/pages/dev_faq.html:150
-msgid ""
-"Can I use a JavaScript library like jQuery, MooTools or Prototype to build "
-"my add-on?"
-msgstr ""
-"Eu posso usar uma biblioteca JavaScript como jQuery, MooTools ou Prototype "
-"para criar meu complemento?"
+msgid "Can I use a JavaScript library like jQuery, MooTools or Prototype to build my add-on?"
+msgstr "Eu posso usar uma biblioteca JavaScript como jQuery, MooTools ou Prototype para criar meu complemento?"
 
 #: src/olympia/pages/templates/pages/dev_faq.html:152
 msgid ""
-"Yes. It's possible, but some of the functionality provided by these "
-"libraries are available through XPCOM, XUL, and JavaScript. In addition, "
-"authors should take care if libraries modify primitive object prototypes "
-"(String.prototype, Date.prototype, etc.) and/or define global functions (eg."
-" the $ function). These are prone to cause conflict with other add-ons, in "
-"particular if different add-ons use different versions of libraries and so "
-"on. Developers need to be very, very careful with using them.  Mozilla does "
-"not offer documentation on using them to build add-ons."
+"Yes. It's possible, but some of the functionality provided by these libraries are available through XPCOM, XUL, and JavaScript. In addition, authors should take care if libraries modify primitive "
+"object prototypes (String.prototype, Date.prototype, etc.) and/or define global functions (eg. the $ function). These are prone to cause conflict with other add-ons, in particular if different add-"
+"ons use different versions of libraries and so on. Developers need to be very, very careful with using them. Mozilla does not offer documentation on using them to build add-ons."
 msgstr ""
-"Sim. É possível, porém algumas funcionalidades providas por estas "
-"bibliotecas estão disponíveis através do XPCOM, XUL e JavaScript. "
-"Adicionalmente, autores devem estar atentos se bibliotecas modificam tipos "
-"primitivos (String.prototype, Date.prototype, etc) e/ou definem funções "
-"globais (como por exemplo a função $). Estes tipos de modificações "
-"normalmente causam conflitos com outros complementos, principalmente se "
-"complementos distintos usam versões diferentes da mesma biblioteca. "
-"Desenvolvedores precisam ser bastante cuidados ao usá-las. A Mozilla não "
-"provê documentação sobre o uso destas bibliotecas no desenvolvimento de "
-"complementos."
+"Sim. É possível, porém algumas funcionalidades providas por estas bibliotecas estão disponíveis através do XPCOM, XUL e JavaScript. Adicionalmente, autores devem estar atentos se bibliotecas "
+"modificam tipos primitivos (String.prototype, Date.prototype, etc) e/ou definem funções globais (como por exemplo a função $). Estes tipos de modificações normalmente causam conflitos com outros "
+"complementos, principalmente se complementos distintos usam versões diferentes da mesma biblioteca. Desenvolvedores precisam ser bastante cuidados ao usá-las. A Mozilla não provê documentação sobre "
+"o uso destas bibliotecas no desenvolvimento de complementos."
 
 #: src/olympia/pages/templates/pages/dev_faq.html:165
 msgid "How do I debug my add-on?"
@@ -12491,32 +9969,19 @@ msgid "You can use the <a href=\"%(url)s\">Add-on Debugger</a>."
 msgstr "Você pode usar o <a href=\"%(url)s\">Add-on Debugger</a>."
 
 #: src/olympia/pages/templates/pages/dev_faq.html:172
-msgid ""
-"How do I test for compatibility with the latest version of Mozilla software?"
-msgstr ""
-"Como eu posso testar a compatibilidade com as versões mais recentes dos "
-"aplicativos Mozilla?"
+msgid "How do I test for compatibility with the latest version of Mozilla software?"
+msgstr "Como eu posso testar a compatibilidade com as versões mais recentes dos aplicativos Mozilla?"
 
 #: src/olympia/pages/templates/pages/dev_faq.html:174
 msgid ""
-"To ensure compatibility with the latest Mozilla software, it's important to "
-"download updates as they become available and test your add-on to ensure "
-"that it is still functioning as expected. In many cases, the latest version "
-"of Mozilla software may be a beta release. Since these releases at times "
-"introduce architectural changes that may impact the functionality of your "
-"add-on, it's important to be actively involved in the beta process to ensure"
-" that your add-on users are not negatively impacted upon final release of "
-"Mozilla software."
+"To ensure compatibility with the latest Mozilla software, it's important to download updates as they become available and test your add-on to ensure that it is still functioning as expected. In "
+"many cases, the latest version of Mozilla software may be a beta release. Since these releases at times introduce architectural changes that may impact the functionality of your add-on, it's "
+"important to be actively involved in the beta process to ensure that your add-on users are not negatively impacted upon final release of Mozilla software."
 msgstr ""
-"Para garantir a compatibilidade com as últimas versões do software da "
-"Mozilla, é importante transferir atualizações assim que são disponibilizadas"
-" e testar o seu complemento para garantir que ainda funciona como esperado. "
-"Em muitos casos a última versão do software da Mozilla pode ser um "
-"lançamento beta. Dado que estes lançamentos podem por vezes apresentar "
-"alterações arquiteturais que podem ter impacto na funcionalidade do seu "
-"complemento, é importante estar envolvido ativamente no processo beta para "
-"garantir que os usuários do seu complemento não sejam negativamente afetados"
-" após o lançamento do software da Mozilla."
+"Para garantir a compatibilidade com as últimas versões do software da Mozilla, é importante transferir atualizações assim que são disponibilizadas e testar o seu complemento para garantir que ainda "
+"funciona como esperado. Em muitos casos a última versão do software da Mozilla pode ser um lançamento beta. Dado que estes lançamentos podem por vezes apresentar alterações arquiteturais que podem "
+"ter impacto na funcionalidade do seu complemento, é importante estar envolvido ativamente no processo beta para garantir que os usuários do seu complemento não sejam negativamente afetados após o "
+"lançamento do software da Mozilla."
 
 #: src/olympia/pages/templates/pages/dev_faq.html:185
 msgid "How to improve the performance of my add-on?"
@@ -12525,17 +9990,11 @@ msgstr "Como melhorar o desempenho do meu complemento?"
 #: src/olympia/pages/templates/pages/dev_faq.html:187
 #, python-format
 msgid ""
-"Poorly written extensions can have a severe impact on the browsing "
-"experience, including on the overall performance of Firefox itself. The "
-"following page contains many good <a href=\"%(url)s\">guides</a> that help "
-"you improve performance, whether you're developing core Mozilla code or an "
-"add-on."
+"Poorly written extensions can have a severe impact on the browsing experience, including on the overall performance of Firefox itself. The following page contains many good <a href=\"%(url)s"
+"\">guides</a> that help you improve performance, whether you're developing core Mozilla code or an add-on."
 msgstr ""
-"Extensões mal escritas podem ter um impacto significativo na experiência de "
-"navegação, incluindo na performance geral do próprio Firefox. A página "
-"seguinte contém bons <a href=\"%(url)s\">guias</a> que podem ajudá-lo a "
-"melhorar o desempenho, esteja desenvolvendo código central para a Mozilla ou"
-" um complemento."
+"Extensões mal escritas podem ter um impacto significativo na experiência de navegação, incluindo na performance geral do próprio Firefox. A página seguinte contém bons <a href=\"%(url)s\">guias</a> "
+"que podem ajudá-lo a melhorar o desempenho, esteja desenvolvendo código central para a Mozilla ou um complemento."
 
 #: src/olympia/pages/templates/pages/dev_faq.html:195
 msgid "Can my add-on support multiple locales?"
@@ -12544,22 +10003,15 @@ msgstr "O meu complemento pode suportar mais de um idioma?"
 #: src/olympia/pages/templates/pages/dev_faq.html:197
 #, python-format
 msgid ""
-"Yes. Details on localizing your add-on can be found in the the <a "
-"href=\"%(l10n_url)s\">Mozilla Developer Network Localization page</a>. <a "
-"href=\"%(bz_url)s\">The BabelZilla project</a> is also a great resource for "
-"learning about localization and volunteering to help translate add-ons."
+"Yes. Details on localizing your add-on can be found in the the <a href=\"%(l10n_url)s\">Mozilla Developer Network Localization page</a>. <a href=\"%(bz_url)s\">The BabelZilla project</a> is also a "
+"great resource for learning about localization and volunteering to help translate add-ons."
 msgstr ""
-"Sim. Detalhes sobre como traduzir o seu complemento podem ser encontrados na"
-" <a href=\"%(l10n_url)s\">página de Tradução do Mozilla Developer "
-"Network</a>. <a href=\"%(bz_url)s\">O projeto BabelZilla</a> é também um "
-"ótimo recurso para saber mais sobre tradução e contribuir com a tradução de "
-"complementos."
+"Sim. Detalhes sobre como traduzir o seu complemento podem ser encontrados na <a href=\"%(l10n_url)s\">página de Tradução do Mozilla Developer Network</a>. <a href=\"%(bz_url)s\">O projeto "
+"BabelZilla</a> é também um ótimo recurso para saber mais sobre tradução e contribuir com a tradução de complementos."
 
 #: src/olympia/pages/templates/pages/dev_faq.html:210
 msgid "I need some advice building my add-on. Where can I find help?"
-msgstr ""
-"Eu preciso de dicas para criar meu complemento. Onde eu posso encontrar "
-"ajuda?"
+msgstr "Eu preciso de dicas para criar meu complemento. Onde eu posso encontrar ajuda?"
 
 #. #extdev is the name of the IRC channel.  do not change.
 #: src/olympia/pages/templates/pages/dev_faq.html:216
@@ -12569,17 +10021,12 @@ msgstr "#extdev (para discussões de desenvolvimento de complementos)"
 #. #amo is the name of the IRC channel.  do not change.
 #: src/olympia/pages/templates/pages/dev_faq.html:218
 msgid "#amo (for support relating to hosting your add-on on AMO)"
-msgstr ""
-"#amo (para suporte relacionado à hospedagem do seu complemento no AMO)"
+msgstr "#amo (para suporte relacionado à hospedagem do seu complemento no AMO)"
 
 #. #jetpack is the name of the IRC channel.  do not change.
 #: src/olympia/pages/templates/pages/dev_faq.html:220
-msgid ""
-"#jetpack (for discussions about the Add-ons SDK and cfx/jpm - formerly known"
-" as Jetpack)"
-msgstr ""
-"#jetpack (para discussões sobre o Add-ons SDK e cfx/jpm - anteriormente "
-"conhecido como Jetpack)"
+msgid "#jetpack (for discussions about the Add-ons SDK and cfx/jpm - formerly known as Jetpack)"
+msgstr "#jetpack (para discussões sobre o Add-ons SDK e cfx/jpm - anteriormente conhecido como Jetpack)"
 
 #. Label for a link to the extension developers mailing list
 #: src/olympia/pages/templates/pages/dev_faq.html:225
@@ -12614,24 +10061,16 @@ msgstr "Não."
 
 #: src/olympia/pages/templates/pages/dev_faq.html:246
 msgid "Are there 3rd party developers that I can hire to build my add-on?"
-msgstr ""
-"Existem desenvolvedores terceirizados que eu posso contratar para criar meu "
-"complemento?"
+msgstr "Existem desenvolvedores terceirizados que eu posso contratar para criar meu complemento?"
 
 #: src/olympia/pages/templates/pages/dev_faq.html:248
 #, python-format
 msgid ""
-"Yes. You may find 3rd party developers via the <a href=\"%(forum_url)s"
-"\">Add-ons forum</a>, <a href=\"%(list_url)s\">mozilla.jobs list</a>, <a "
-"href=\"%(mz_url)s\">mozillaZine forums</a> or <a href=\"%(wiki_url)s\">the "
-"Mozilla Wiki</a>. Please note that Mozilla does not offer developer "
-"recommendations."
+"Yes. You may find 3rd party developers via the <a href=\"%(forum_url)s\">Add-ons forum</a>, <a href=\"%(list_url)s\">mozilla.jobs list</a>, <a href=\"%(mz_url)s\">mozillaZine forums</a> or <a href="
+"\"%(wiki_url)s\">the Mozilla Wiki</a>. Please note that Mozilla does not offer developer recommendations."
 msgstr ""
-"Sim. Você pode encontrar desenvolvedores no <a href=\"%(forum_url)s\">Add-"
-"ons forum</a>, <a href=\"%(list_url)s\">mozilla.jobs list</a>, <a "
-"href=\"%(mz_url)s\">mozillaZine forums</a> ou <a "
-"href=\"%(wiki_url)s\">Mozilla Wiki</a>. Por favor, note que a Mozilla não "
-"oferece recomendações para desenvolvedores."
+"Sim. Você pode encontrar desenvolvedores no <a href=\"%(forum_url)s\">Add-ons forum</a>, <a href=\"%(list_url)s\">mozilla.jobs list</a>, <a href=\"%(mz_url)s\">mozillaZine forums</a> ou <a href="
+"\"%(wiki_url)s\">Mozilla Wiki</a>. Por favor, note que a Mozilla não oferece recomendações para desenvolvedores."
 
 #: src/olympia/pages/templates/pages/dev_faq.html:263
 msgid "Can I host my own add-on?"
@@ -12640,21 +10079,13 @@ msgstr "Eu posso hospedar eu mesmo meu complemento?"
 #: src/olympia/pages/templates/pages/dev_faq.html:265
 #, python-format
 msgid ""
-"Yes. Many developers choose to host their own add-ons. Choosing to host your"
-" add-on on <a href=\"%(amo_url)s\">Mozilla's add-on site</a>, though, allows"
-" for much greater exposure to your add-on due to the large volume of "
-"visitors to the site.  <a href=\"%(md_url)s\">mozdev.org</a> offers free "
-"project hosting for Mozilla applications and extensions providing developers"
-" with tools to help manage source code, version control, bug tracking and "
-"documentation."
+"Yes. Many developers choose to host their own add-ons. Choosing to host your add-on on <a href=\"%(amo_url)s\">Mozilla's add-on site</a>, though, allows for much greater exposure to your add-on due "
+"to the large volume of visitors to the site. <a href=\"%(md_url)s\">mozdev.org</a> offers free project hosting for Mozilla applications and extensions providing developers with tools to help manage "
+"source code, version control, bug tracking and documentation."
 msgstr ""
-"Sim. Muitos desenvolvedores preferem hospedar seus próprios complementos. "
-"Entretanto, hospedar seus complementos no <a href=\"%(amo_url)s\">site de "
-"complementos da Mozilla</a> permite uma maior exposição deles devido ao "
-"grande volume de visitantes do site. O <a href=\"%(md_url)s\">mozdev.org</a>"
-" oferece host gratuito de projetos para aplicações da Mozilla e extensões "
-"que ajudam os desenvolvedores a gerenciar código fonte, controle de versão, "
-"acompanhamento de bugs e documentação."
+"Sim. Muitos desenvolvedores preferem hospedar seus próprios complementos. Entretanto, hospedar seus complementos no <a href=\"%(amo_url)s\">site de complementos da Mozilla</a> permite uma maior "
+"exposição deles devido ao grande volume de visitantes do site. O <a href=\"%(md_url)s\">mozdev.org</a> oferece host gratuito de projetos para aplicações da Mozilla e extensões que ajudam os "
+"desenvolvedores a gerenciar código fonte, controle de versão, acompanhamento de bugs e documentação."
 
 #: src/olympia/pages/templates/pages/dev_faq.html:277
 msgid "Can Mozilla host my add-on?"
@@ -12662,12 +10093,8 @@ msgstr "A Mozilla pode hospedar o meu complemento?"
 
 #: src/olympia/pages/templates/pages/dev_faq.html:279
 #, python-format
-msgid ""
-"Yes. You can host your add-on on <a href=\"%(url)s\">Mozilla's add-on "
-"website</a>."
-msgstr ""
-"Sim. O seu complemento pode ser hospedado no site <a "
-"href=\"%(url)s\">Mozilla Add-ons</a>."
+msgid "Yes. You can host your add-on on <a href=\"%(url)s\">Mozilla's add-on website</a>."
+msgstr "Sim. O seu complemento pode ser hospedado no site <a href=\"%(url)s\">Mozilla Add-ons</a>."
 
 #: src/olympia/pages/templates/pages/dev_faq.html:284
 msgid "What is AMO?"
@@ -12675,19 +10102,11 @@ msgstr "O que é AMO?"
 
 #: src/olympia/pages/templates/pages/dev_faq.html:286
 msgid ""
-"Mozilla's AMO (<a "
-"href=\"https://addons.mozilla.org\">https://addons.mozilla.org</a>) is the "
-"incubator that helps developers build, distribute, and support fantastic "
-"consumer products powered by Mozilla. It provides you the tools and "
-"infrastructure necessary to manage, host and expose your add-on to a massive"
-" base of Mozilla users."
+"Mozilla's AMO (<a href=\"https://addons.mozilla.org\">https://addons.mozilla.org</a>) is the incubator that helps developers build, distribute, and support fantastic consumer products powered by "
+"Mozilla. It provides you the tools and infrastructure necessary to manage, host and expose your add-on to a massive base of Mozilla users."
 msgstr ""
-"O Mozilla AMO (<a "
-"href=\"https://addons.mozilla.org\">https://addons.mozilla.org</a>) é a "
-"incubadora que ajuda os desenvolvedores a criar, distribuir e oferecer "
-"suporte a produtos excelentes usando a tecnologia Mozilla. Ele fornece as "
-"ferramentas e infraestrutura necessárias para gerenciar, hospedar e expor "
-"seu complemento para uma vasta base de usuários Mozilla."
+"O Mozilla AMO (<a href=\"https://addons.mozilla.org\">https://addons.mozilla.org</a>) é a incubadora que ajuda os desenvolvedores a criar, distribuir e oferecer suporte a produtos excelentes usando "
+"a tecnologia Mozilla. Ele fornece as ferramentas e infraestrutura necessárias para gerenciar, hospedar e expor seu complemento para uma vasta base de usuários Mozilla."
 
 #: src/olympia/pages/templates/pages/dev_faq.html:295
 msgid "Does Mozilla keep my account information private?"
@@ -12695,12 +10114,8 @@ msgstr "A Mozilla mantém em segredo as informações da minha conta?"
 
 #: src/olympia/pages/templates/pages/dev_faq.html:297
 #, python-format
-msgid ""
-"Yes. Our <a href=\"%(url)s\">Privacy Policy</a> describes how your "
-"information is managed by Mozilla."
-msgstr ""
-"Sim. Nossa <a href=\"%(url)s\">Política de privacidade</a> descreve como "
-"suas informações são gerenciadas pela Mozilla."
+msgid "Yes. Our <a href=\"%(url)s\">Privacy Policy</a> describes how your information is managed by Mozilla."
+msgstr "Sim. Nossa <a href=\"%(url)s\">Política de privacidade</a> descreve como suas informações são gerenciadas pela Mozilla."
 
 #: src/olympia/pages/templates/pages/dev_faq.html:302
 msgid "What are the \"developer tools\" listed on AMO?"
@@ -12708,37 +10123,24 @@ msgstr "O que são as \"ferramentas do desenvolvedor\" listadas no AMO?"
 
 #: src/olympia/pages/templates/pages/dev_faq.html:304
 msgid ""
-"The \"Developer Tools\" dashboard is the area that provides you the tools to"
-" successfully manage your add-ons. It provides the functionality necessary "
-"to submit your add-ons to AMO, manage add-on information, and review "
-"statistics."
+"The \"Developer Tools\" dashboard is the area that provides you the tools to successfully manage your add-ons. It provides the functionality necessary to submit your add-ons to AMO, manage add-on "
+"information, and review statistics."
 msgstr ""
-"A página \"Meus complementos\" é a área que oferece ferramentas para "
-"gerenciar seus complementos. Ele fornece as funcionalidades necessárias para"
-" enviar seu complemento para o AMO, gerenciar as informações do complemento "
-"e acompanhar estatísticas."
+"A página \"Meus complementos\" é a área que oferece ferramentas para gerenciar seus complementos. Ele fornece as funcionalidades necessárias para enviar seu complemento para o AMO, gerenciar as "
+"informações do complemento e acompanhar estatísticas."
 
 #: src/olympia/pages/templates/pages/dev_faq.html:312
-msgid ""
-"Does Mozilla have a policy in place as to what is an acceptable submission?"
-msgstr ""
-"A Mozilla possui uma política que descreva os critérios de submissão de "
-"complementos?"
+msgid "Does Mozilla have a policy in place as to what is an acceptable submission?"
+msgstr "A Mozilla possui uma política que descreva os critérios de submissão de complementos?"
 
 #: src/olympia/pages/templates/pages/dev_faq.html:314
 #, python-format
 msgid ""
-"Yes. Mozilla's <a href=\"%(p_url)s\">Add-on Policy</a> describes what is an "
-"acceptable submission. This policy is subject to change without notice.  In "
-"addition, the AMO editorial team uses the <a href=\"%(g_url)s\">Editors "
-"Reviewing Guide</a> to ensure that your add-on meets specific guidelines for"
-" functionality and security."
+"Yes. Mozilla's <a href=\"%(p_url)s\">Add-on Policy</a> describes what is an acceptable submission. This policy is subject to change without notice. In addition, the AMO editorial team uses the <a "
+"href=\"%(g_url)s\">Editors Reviewing Guide</a> to ensure that your add-on meets specific guidelines for functionality and security."
 msgstr ""
-"Sim, a <a href=\"%(p_url)s\">Política de Complementos</a> da Mozilla "
-"descreve o que é uma submissão aceitável. Esta política pode ser alterada "
-"sem aviso prévio.  Adicionalmente, o time editorial do AMO usa o <a "
-"href=\"%(g_url)s\">Guia de Avaliação do Editor</a> para garantir que seus "
-"complementos cumprem certos requisitos de funcionalidade e segurança."
+"Sim, a <a href=\"%(p_url)s\">Política de Complementos</a> da Mozilla descreve o que é uma submissão aceitável. Esta política pode ser alterada sem aviso prévio.  Adicionalmente, o time editorial do "
+"AMO usa o <a href=\"%(g_url)s\">Guia de Avaliação do Editor</a> para garantir que seus complementos cumprem certos requisitos de funcionalidade e segurança."
 
 #: src/olympia/pages/templates/pages/dev_faq.html:324
 msgid "How do I submit my add-on for review?"
@@ -12747,30 +10149,19 @@ msgstr "Como eu envio meu complemento para análise?"
 #: src/olympia/pages/templates/pages/dev_faq.html:326
 #, python-format
 msgid ""
-"The Developer Tools dashboard will allow you to upload and submit add-ons to"
-" AMO. You must be a registered AMO users before you can submit an add-on. "
-"Before submitting your add-on be sure to you have read the AMO <a "
-"href=\"%(url)s\">Editors Reviewing Guide</a> to ensure that your add-on has "
-"met the guidelines used by editors to review add-ons."
+"The Developer Tools dashboard will allow you to upload and submit add-ons to AMO. You must be a registered AMO users before you can submit an add-on. Before submitting your add-on be sure to you "
+"have read the AMO <a href=\"%(url)s\">Editors Reviewing Guide</a> to ensure that your add-on has met the guidelines used by editors to review add-ons."
 msgstr ""
-"A página \"Meus complementos\" permite que envie complementos para o AMO. "
-"Você deve ser um usuário registrado no AMO antes de poder enviar um "
-"complemento. Antes de enviar seu complemento, certifique-se de ler o <a "
-"href=\"%(url)s\">Guia de análise para editores</a> da Mozilla para garantir "
-"que seu complemento atende aos critérios usados pelos editores para analisar"
-" complementos."
+"A página \"Meus complementos\" permite que envie complementos para o AMO. Você deve ser um usuário registrado no AMO antes de poder enviar um complemento. Antes de enviar seu complemento, "
+"certifique-se de ler o <a href=\"%(url)s\">Guia de análise para editores</a> da Mozilla para garantir que seu complemento atende aos critérios usados pelos editores para analisar complementos."
 
 #: src/olympia/pages/templates/pages/dev_faq.html:336
 msgid "What operating system do I choose for my add-on?"
 msgstr "Que sistema operacional eu escolho para meu complemento?"
 
 #: src/olympia/pages/templates/pages/dev_faq.html:338
-msgid ""
-"You must choose the operating systems on which your add-on will successfully"
-" function."
-msgstr ""
-"Você deve escolher os sistemas operacionais nos quais o seu complemento "
-"funcionará com sucesso."
+msgid "You must choose the operating systems on which your add-on will successfully function."
+msgstr "Você deve escolher os sistemas operacionais nos quais o seu complemento funcionará com sucesso."
 
 #: src/olympia/pages/templates/pages/dev_faq.html:344
 msgid "What category do I choose for my add-on?"
@@ -12778,60 +10169,39 @@ msgstr "Que categoria eu devo escolher para o meu complemento?"
 
 #: src/olympia/pages/templates/pages/dev_faq.html:346
 msgid ""
-"The choice of category is dependent on what type of audience you are "
-"targeting and the functionality of your add-on. If you're unsure of which "
-"category your add-on falls into, please choose \"Other\". The AMO team may "
-"re-categorize your add-on if it's determined that it's better suited in a "
-"different category."
+"The choice of category is dependent on what type of audience you are targeting and the functionality of your add-on. If you're unsure of which category your add-on falls into, please choose \"Other"
+"\". The AMO team may re-categorize your add-on if it's determined that it's better suited in a different category."
 msgstr ""
-"A escolha da categoria depende do tipo de audiência que você deseja alcançar"
-" e a funcionalidade do seu complemento. Se você não tiver certeza de qual "
-"categoria você deve selecionar para seu complemento, selecione \"Outros\". A"
-" equipe do AMO poderá recategorizar seu complemento se for determinado que "
-"ele se encaixa melhor em uma categoria diferente."
+"A escolha da categoria depende do tipo de audiência que você deseja alcançar e a funcionalidade do seu complemento. Se você não tiver certeza de qual categoria você deve selecionar para seu "
+"complemento, selecione \"Outros\". A equipe do AMO poderá recategorizar seu complemento se for determinado que ele se encaixa melhor em uma categoria diferente."
 
 #: src/olympia/pages/templates/pages/dev_faq.html:355
 msgid "What does \"nominating\" my add-on mean?"
 msgstr "O que significa \"indicar\" meu complemento?"
 
 #: src/olympia/pages/templates/pages/dev_faq.html:357
-msgid ""
-"Nominated add-ons are new add-ons that the author has nominated to become "
-"public via the Developer Tools."
-msgstr ""
-"Complementos indicados são complementos cujo autor indicou para se tornarem "
-"públicos pelas Ferramentas do desenvolvedor."
+msgid "Nominated add-ons are new add-ons that the author has nominated to become public via the Developer Tools."
+msgstr "Complementos indicados são complementos cujo autor indicou para se tornarem públicos pelas Ferramentas do desenvolvedor."
 
 #: src/olympia/pages/templates/pages/dev_faq.html:363
 msgid "Can I specify a license agreement for using my add-on?"
-msgstr ""
-"Eu posso especificar um acordo de licença para usar com meu complemento?"
+msgstr "Eu posso especificar um acordo de licença para usar com meu complemento?"
 
 #: src/olympia/pages/templates/pages/dev_faq.html:365
-msgid ""
-"Yes. You can specify a license agreement when submitting your add-on. You "
-"can also add or update a license agreement via the Developer Tools dashboard"
-" after your add-on has been submitted."
+msgid "Yes. You can specify a license agreement when submitting your add-on. You can also add or update a license agreement via the Developer Tools dashboard after your add-on has been submitted."
 msgstr ""
-"Sim. Você pode especificar um acordo de licença ao enviar um complemento. "
-"Você também pode adicionar ou atualizar um acordo de licença através do "
-"painel de Ferramentas do desenvolvedor depois do seu complemento ter sido "
-"submetido."
+"Sim. Você pode especificar um acordo de licença ao enviar um complemento. Você também pode adicionar ou atualizar um acordo de licença através do painel de Ferramentas do desenvolvedor depois do "
+"seu complemento ter sido submetido."
 
 #: src/olympia/pages/templates/pages/dev_faq.html:372
 msgid "Can I include a privacy policy for my add-on?"
 msgstr "Eu posso incluir uma política de privacidade no meu complemento?"
 
 #: src/olympia/pages/templates/pages/dev_faq.html:374
-msgid ""
-"Yes. You can specify a privacy policy when submitting your add-on. You can "
-"also add or update a privacy policy via the Developer Tools dashboard after "
-"your add-on has been submitted."
+msgid "Yes. You can specify a privacy policy when submitting your add-on. You can also add or update a privacy policy via the Developer Tools dashboard after your add-on has been submitted."
 msgstr ""
-"Sim. Você pode especificar uma política de privacidade ao enviar um "
-"complemento. Você também pode adicionar ou atualizar uma política de "
-"privacidade através do painel de Ferramentas do desenvolvedor depois do seu "
-"complemento ter sido submetido."
+"Sim. Você pode especificar uma política de privacidade ao enviar um complemento. Você também pode adicionar ou atualizar uma política de privacidade através do painel de Ferramentas do "
+"desenvolvedor depois do seu complemento ter sido submetido."
 
 #: src/olympia/pages/templates/pages/dev_faq.html:383
 msgid "Why must my add-on be reviewed?"
@@ -12840,15 +10210,11 @@ msgstr "Por que meu complemento deve ser analisado?"
 #: src/olympia/pages/templates/pages/dev_faq.html:385
 #, python-format
 msgid ""
-"All add-ons submitted, whether new or updated, are reviewed to ensure that "
-"Mozilla users have a stable and safe experience. All add-ons submissions are"
-" reviewed using the guidelines outlined in the <a href=\"%(url)s\">Editors "
-"Reviewing Guide</a>."
+"All add-ons submitted, whether new or updated, are reviewed to ensure that Mozilla users have a stable and safe experience. All add-ons submissions are reviewed using the guidelines outlined in the "
+"<a href=\"%(url)s\">Editors Reviewing Guide</a>."
 msgstr ""
-"Todos os complementos submetidos, sejam novos ou atualizações, são "
-"analisados para garantir que os usuários da Mozilla tenham uma experiência "
-"estável e segura. Todos os complementos são analisados seguindo os critérios"
-" do <a href=\"%(url)s\">Guia de análise para editores</a>."
+"Todos os complementos submetidos, sejam novos ou atualizações, são analisados para garantir que os usuários da Mozilla tenham uma experiência estável e segura. Todos os complementos são analisados "
+"seguindo os critérios do <a href=\"%(url)s\">Guia de análise para editores</a>."
 
 #: src/olympia/pages/templates/pages/dev_faq.html:393
 msgid "Who reviews my add-on?"
@@ -12857,21 +10223,13 @@ msgstr "Quem analisa meu complemento?"
 #: src/olympia/pages/templates/pages/dev_faq.html:395
 #, python-format
 msgid ""
-"Add-ons are reviewed by the AMO Editors, a group of talented developers that"
-" volunteer to help the Mozilla project by reviewing add-ons to ensure a "
-"stable and safe experience for Mozilla users. When communicating with "
-"editors, please be courteous, patient and respectful as they are working "
-"hard to ensure that your add-on is set up correctly and follows the "
-"guidelines outlined in the <a href=\"%(url)s\">Editors Reviewing Guide</a>."
+"Add-ons are reviewed by the AMO Editors, a group of talented developers that volunteer to help the Mozilla project by reviewing add-ons to ensure a stable and safe experience for Mozilla users. "
+"When communicating with editors, please be courteous, patient and respectful as they are working hard to ensure that your add-on is set up correctly and follows the guidelines outlined in the <a "
+"href=\"%(url)s\">Editors Reviewing Guide</a>."
 msgstr ""
-"Complementos são revistos pelos Editores AMO, um grupo de desenvolvedores "
-"talentosos que trabalham como voluntários para ajudar o projeto Mozilla, "
-"revisando os complementos para garantir uma experiência estável e segura "
-"para os usuários da Mozilla. Ao se comunicar com os editores, por favor, "
-"seja cortês, paciente e respeitoso, eles estão trabalhando duro para "
-"garantir que o seu complemento esteja configurado corretamente e segue as "
-"diretrizes definidas no <a href=\"%(url)s\">Guia de Revisão para "
-"Editores</a>."
+"Complementos são revistos pelos Editores AMO, um grupo de desenvolvedores talentosos que trabalham como voluntários para ajudar o projeto Mozilla, revisando os complementos para garantir uma "
+"experiência estável e segura para os usuários da Mozilla. Ao se comunicar com os editores, por favor, seja cortês, paciente e respeitoso, eles estão trabalhando duro para garantir que o seu "
+"complemento esteja configurado corretamente e segue as diretrizes definidas no <a href=\"%(url)s\">Guia de Revisão para Editores</a>."
 
 #: src/olympia/pages/templates/pages/dev_faq.html:406
 msgid "What are the guidelines used to review my add-on?"
@@ -12880,30 +10238,19 @@ msgstr "Quais são os critérios usados para analisar o meu complemento?"
 #: src/olympia/pages/templates/pages/dev_faq.html:408
 #, python-format
 msgid ""
-"The Mozilla editorial team follows the <a href=\"%(url)s\">Editors Reviewing"
-" Guide</a> when testing an add-on for acceptance onto AMO. It is important "
-"that add-on developers review this guide to ensure that common problem areas"
-" are addressed prior to submitting their add-on for review. This will "
-"greatly assist in expediting the review process."
+"The Mozilla editorial team follows the <a href=\"%(url)s\">Editors Reviewing Guide</a> when testing an add-on for acceptance onto AMO. It is important that add-on developers review this guide to "
+"ensure that common problem areas are addressed prior to submitting their add-on for review. This will greatly assist in expediting the review process."
 msgstr ""
-"A equipe editorial da Mozilla segue o <a href=\"%(url)s\">guia de revisão "
-"para editores</a> ao testar um complemento para ser aceito no AMO. É "
-"importante que os desenvolvedores de complementos analisem esse guia para "
-"garantir que áreas problemáticas comuns são trabalhadas antes de enviar os "
-"seus complementos para revisão. Isto irá tornar o processo de revisão mais "
-"rápido."
+"A equipe editorial da Mozilla segue o <a href=\"%(url)s\">guia de revisão para editores</a> ao testar um complemento para ser aceito no AMO. É importante que os desenvolvedores de complementos "
+"analisem esse guia para garantir que áreas problemáticas comuns são trabalhadas antes de enviar os seus complementos para revisão. Isto irá tornar o processo de revisão mais rápido."
 
 #: src/olympia/pages/templates/pages/dev_faq.html:418
 msgid "How long will it take for my add-on to be reviewed?"
 msgstr "Quanto tempo levará para o meu complemento ser analisado?"
 
 #: src/olympia/pages/templates/pages/dev_faq.html:420
-msgid ""
-"We cannot give a time estimate as to how long it will take before an add-on "
-"is reviewed. Many factors affect the time including the:"
-msgstr ""
-"Nós não podemos informar um tempo estimado de espera até seu complemento ser"
-" analisado. Muitos fatores afetam o tempo de espera, incluindo:"
+msgid "We cannot give a time estimate as to how long it will take before an add-on is reviewed. Many factors affect the time including the:"
+msgstr "Nós não podemos informar um tempo estimado de espera até seu complemento ser analisado. Muitos fatores afetam o tempo de espera, incluindo:"
 
 #. part of a list (<li>)
 #: src/olympia/pages/templates/pages/dev_faq.html:427
@@ -12923,62 +10270,40 @@ msgstr "número de problemas descobertos"
 #: src/olympia/pages/templates/pages/dev_faq.html:434
 #, python-format
 msgid ""
-"This is why it's very important to read the <a href=\"%(g_url)s\">Editors "
-"Reviewing Guide</a> to ensure that your add-on is setup as expected.  It's "
-"also a good idea to read the blog post, <a "
-"href=\"%(blog_url)s\">Successfully Getting your Add-on Reviewed</a> which "
-"provides excellent insight into ensuring a smooth review of your add-on."
+"This is why it's very important to read the <a href=\"%(g_url)s\">Editors Reviewing Guide</a> to ensure that your add-on is setup as expected. It's also a good idea to read the blog post, <a href="
+"\"%(blog_url)s\">Successfully Getting your Add-on Reviewed</a> which provides excellent insight into ensuring a smooth review of your add-on."
 msgstr ""
-"Este é o motivo pelo qual é muito importante ler o <a "
-"href=\"%(g_url)s\">Guia de Revisão do Editor</a> para garantir que o seu "
-"complemento funciona como o esperado. Também é uma boa ideia ler a postagem "
-"<a href=\"%(blog_url)s\">Successfully Getting your Add-on Reviewed</a> no "
-"blog que provê uma excelente visão sobre como garantir uma revisão tranquila"
-" para o seu complemento."
+"Este é o motivo pelo qual é muito importante ler o <a href=\"%(g_url)s\">Guia de Revisão do Editor</a> para garantir que o seu complemento funciona como o esperado. Também é uma boa ideia ler a "
+"postagem <a href=\"%(blog_url)s\">Successfully Getting your Add-on Reviewed</a> no blog que provê uma excelente visão sobre como garantir uma revisão tranquila para o seu complemento."
 
 #: src/olympia/pages/templates/pages/dev_faq.html:446
 msgid "How can I see how many times my add-on has been downloaded?"
 msgstr "Como eu posso ver quantas vezes meu complemento foi baixado?"
 
 #: src/olympia/pages/templates/pages/dev_faq.html:448
-msgid ""
-"The Statistics Dashboard found in the Developer Tools dashboard provides "
-"information that can help you determine your add-on downloads since you've "
-"submitted it to AMO."
+msgid "The Statistics Dashboard found in the Developer Tools dashboard provides information that can help you determine your add-on downloads since you've submitted it to AMO."
 msgstr ""
-"O painel de estatísticas disponível no painel de Ferramentas do "
-"desenvolvedor fornece informações que podem ajudá-lo a determinar o número "
-"de downloads do seu complemento desde que o submeteu para o AMO."
+"O painel de estatísticas disponível no painel de Ferramentas do desenvolvedor fornece informações que podem ajudá-lo a determinar o número de downloads do seu complemento desde que o submeteu para "
+"o AMO."
 
 #: src/olympia/pages/templates/pages/dev_faq.html:455
 msgid "How can I see how many active users are using my add-on?"
-msgstr ""
-"Como eu posso ver quantos usuários ativos estão usando meu complemento?"
+msgstr "Como eu posso ver quantos usuários ativos estão usando meu complemento?"
 
 #: src/olympia/pages/templates/pages/dev_faq.html:457
 msgid ""
-"The Statistics Dashboard found in the Developer Tools dashboard provides "
-"information that can help you determine how many users have been actively "
-"using your add-on since you've submitted it to AMO."
+"The Statistics Dashboard found in the Developer Tools dashboard provides information that can help you determine how many users have been actively using your add-on since you've submitted it to AMO."
 msgstr ""
-"O painel de estatísticas disponível na página Ferramentas do desenvolvedor "
-"fornece informações que podem ajudá-lo a determinar quantos utilizadores "
-"estão a utilizar ativamente o seu complemento desde que o submeteu para o "
-"AMO."
+"O painel de estatísticas disponível na página Ferramentas do desenvolvedor fornece informações que podem ajudá-lo a determinar quantos utilizadores estão a utilizar ativamente o seu complemento "
+"desde que o submeteu para o AMO."
 
 #: src/olympia/pages/templates/pages/dev_faq.html:464
 msgid "How do I submit an update for my add-on?"
 msgstr "Como eu envio uma atualização do meu complemento?"
 
 #: src/olympia/pages/templates/pages/dev_faq.html:466
-msgid ""
-"You can submit an update for your add-on via the Developer Tools dashboard "
-"by choosing the option \"Upload a new version\" and uploading a new .xpi "
-"file for your add-on."
-msgstr ""
-"Você pode enviar uma atualização do seu complemento pela página \"Meus "
-"complementos\" escolhendo a opção \"Enviar uma nova versão\" e enviando um "
-"novo arquivo .xpi para o seu complemento."
+msgid "You can submit an update for your add-on via the Developer Tools dashboard by choosing the option \"Upload a new version\" and uploading a new .xpi file for your add-on."
+msgstr "Você pode enviar uma atualização do seu complemento pela página \"Meus complementos\" escolhendo a opção \"Enviar uma nova versão\" e enviando um novo arquivo .xpi para o seu complemento."
 
 #: src/olympia/pages/templates/pages/dev_faq.html:473
 msgid "Does my update need to be reviewed by editors?"
@@ -12986,50 +10311,32 @@ msgstr "A minha atualização precisa ser analisada pelos editores?"
 
 #: src/olympia/pages/templates/pages/dev_faq.html:475
 msgid ""
-"That depends. If you are simply changing a description of your add-on or "
-"updating a \"maxVersion\" to ensure compatibility with a new Mozilla "
-"software update, then your add-on does not need to be reviewed again. If, "
-"however, you submit a new updated file, then your add-on update will need to"
-" be reviewed by an editor."
+"That depends. If you are simply changing a description of your add-on or updating a \"maxVersion\" to ensure compatibility with a new Mozilla software update, then your add-on does not need to be "
+"reviewed again. If, however, you submit a new updated file, then your add-on update will need to be reviewed by an editor."
 msgstr ""
-"Depende. Se você estiver simplesmente alterando a descrição do seu "
-"complemento ou atualizando a propriedade \"maxVersion\" para assegurar "
-"compatibilidade com novas versões das aplicações Mozilla, então seu "
-"complemento não precisa ser analisado novamente. Entretanto, se você enviar "
-"um novo arquivo de atualização, então a atualização do seu complemento "
-"deverá ser analisada por um editor."
+"Depende. Se você estiver simplesmente alterando a descrição do seu complemento ou atualizando a propriedade \"maxVersion\" para assegurar compatibilidade com novas versões das aplicações Mozilla, "
+"então seu complemento não precisa ser analisado novamente. Entretanto, se você enviar um novo arquivo de atualização, então a atualização do seu complemento deverá ser analisada por um editor."
 
 #: src/olympia/pages/templates/pages/dev_faq.html:486
-msgid ""
-"How do I reply to a user who has posted a negative review of my add-on?"
-msgstr ""
-"Como eu posso responder para um usuário que postou uma análise negativa do "
-"meu complemento?"
+msgid "How do I reply to a user who has posted a negative review of my add-on?"
+msgstr "Como eu posso responder para um usuário que postou uma análise negativa do meu complemento?"
 
 #: src/olympia/pages/templates/pages/dev_faq.html:488
-msgid ""
-"A developer may reply to any review posted to their add-on as long as they "
-"are logged into AMO. In addition, any user can flag a review as:"
-msgstr ""
-"Um desenvolvedor pode responder qualquer análise postada para seu "
-"complemento desde que esteja identificado no AMO. Além disso, qualquer "
-"usuário pode denunciar uma análise como:"
+msgid "A developer may reply to any review posted to their add-on as long as they are logged into AMO. In addition, any user can flag a review as:"
+msgstr "Um desenvolvedor pode responder qualquer análise postada para seu complemento desde que esteja identificado no AMO. Além disso, qualquer usuário pode denunciar uma análise como:"
 
 #. part of a list (<li>)
-#: src/olympia/pages/templates/pages/dev_faq.html:495
-#: src/olympia/reviews/models.py:159
+#: src/olympia/pages/templates/pages/dev_faq.html:495 src/olympia/reviews/models.py:159
 msgid "Spam or otherwise non-review content"
 msgstr "Spam ou conteúdo que não é uma análise"
 
 #. part of a list (<li>)
-#: src/olympia/pages/templates/pages/dev_faq.html:497
-#: src/olympia/reviews/models.py:160
+#: src/olympia/pages/templates/pages/dev_faq.html:497 src/olympia/reviews/models.py:160
 msgid "Inappropriate language/dialog"
 msgstr "Diálogo/linguagem inapropriada"
 
 #. part of a list (<li>)
-#: src/olympia/pages/templates/pages/dev_faq.html:499
-#: src/olympia/reviews/models.py:161
+#: src/olympia/pages/templates/pages/dev_faq.html:499 src/olympia/reviews/models.py:161
 msgid "Misplaced bug report or support request"
 msgstr "Pedido de ajuda ou bug reportado no local errado"
 
@@ -13039,129 +10346,73 @@ msgid "Other (provides a pop-up prompt for information)"
 msgstr "Outro (você poderá fornecer mais informações)"
 
 #: src/olympia/pages/templates/pages/dev_faq.html:504
-msgid ""
-"Currently, AMO does not provide a mechanism to directly communicate with a "
-"reviewer but this feature is being investigated and considered for a future "
-"update."
-msgstr ""
-"Atualmente o AMO não fornece um mecanismo de comunicação direta com o autor "
-"da análise, mas esse recurso está sendo considerado para uma atualização "
-"futura."
+msgid "Currently, AMO does not provide a mechanism to directly communicate with a reviewer but this feature is being investigated and considered for a future update."
+msgstr "Atualmente o AMO não fornece um mecanismo de comunicação direta com o autor da análise, mas esse recurso está sendo considerado para uma atualização futura."
 
 #: src/olympia/pages/templates/pages/dev_faq.html:511
 msgid "Can I request that a review be removed if the review is negative?"
-msgstr ""
-"Eu posso solicitar que uma análise seja removida caso ela seja negativa?"
+msgstr "Eu posso solicitar que uma análise seja removida caso ela seja negativa?"
 
 #: src/olympia/pages/templates/pages/dev_faq.html:513
-msgid ""
-"No. We do not remove negative reviews from add-ons unless they are found to "
-"be false."
-msgstr ""
-"Não. Nós não removemos análises negativas dos complementos a menos que "
-"provem ser falsas."
+msgid "No. We do not remove negative reviews from add-ons unless they are found to be false."
+msgstr "Não. Nós não removemos análises negativas dos complementos a menos que provem ser falsas."
 
 #: src/olympia/pages/templates/pages/dev_faq.html:519
 msgid "Can I request that a review be removed if the review is inaccurate?"
-msgstr ""
-"Eu posso solicitar que uma análise seja removida caso ela seja imprecisa?"
+msgstr "Eu posso solicitar que uma análise seja removida caso ela seja imprecisa?"
 
 #: src/olympia/pages/templates/pages/dev_faq.html:521
-msgid ""
-"If an author contacts us and asks for a review containing false or "
-"inaccurate information to be removed, we will review the post and consider "
-"removing it."
-msgstr ""
-"Se um autor entrar em contato conosco e pedir que uma análise contendo "
-"informações falsas ou imprecisas seja removida, nós analisaremos e "
-"consideraremos a sua remoção."
+msgid "If an author contacts us and asks for a review containing false or inaccurate information to be removed, we will review the post and consider removing it."
+msgstr "Se um autor entrar em contato conosco e pedir que uma análise contendo informações falsas ou imprecisas seja removida, nós analisaremos e consideraremos a sua remoção."
 
 #: src/olympia/pages/templates/pages/dev_faq.html:530
 msgid ""
-"Do you need more information about the various open source licenses? Are you"
-" confused as to which license you should select? What rights does a specific"
-" license grant? While nothing replaces reading the full terms of a license, "
-"below are some sites that contain information about some of the key open "
-"source licenses that may help you sort out the differences between them. "
-"These sites are being provided solely for your convenience and as a "
-"reference for your personal use. These resources do not constitute legal "
-"advice nor should they be used in lieu of such advice. Mozilla neither "
-"guarantees nor is responsible for the content of these sites or your "
-"reliance on such content."
+"Do you need more information about the various open source licenses? Are you confused as to which license you should select? What rights does a specific license grant? While nothing replaces "
+"reading the full terms of a license, below are some sites that contain information about some of the key open source licenses that may help you sort out the differences between them. These sites "
+"are being provided solely for your convenience and as a reference for your personal use. These resources do not constitute legal advice nor should they be used in lieu of such advice. Mozilla "
+"neither guarantees nor is responsible for the content of these sites or your reliance on such content."
 msgstr ""
-"Você precisa de mais informações sobre as várias licenças de código aberto? "
-"Você está confuso sobre qual licença deve selecionar? Que direitos uma "
-"licença específica concede? Apesar de nada substituir a leitura integral dos"
-" termos da licença, abaixo há alguns sites que contêm informações sobre as "
-"principais licenças que podem ajudá-lo a entender as diferenças entre elas. "
-"Esses sites são oferecidos meramente para sua conveniência e como uma "
-"referência para seu uso pessoal. Essas fontes não constituem um "
-"aconselhamento legal e tampouco devem ser usadas como tal. A Mozilla não "
-"garante ou é responsável pelo conteúdo desses sites ou pela precisão de tais"
-" conteúdos."
+"Você precisa de mais informações sobre as várias licenças de código aberto? Você está confuso sobre qual licença deve selecionar? Que direitos uma licença específica concede? Apesar de nada "
+"substituir a leitura integral dos termos da licença, abaixo há alguns sites que contêm informações sobre as principais licenças que podem ajudá-lo a entender as diferenças entre elas. Esses sites "
+"são oferecidos meramente para sua conveniência e como uma referência para seu uso pessoal. Essas fontes não constituem um aconselhamento legal e tampouco devem ser usadas como tal. A Mozilla não "
+"garante ou é responsável pelo conteúdo desses sites ou pela precisão de tais conteúdos."
 
 #: src/olympia/pages/templates/pages/dev_faq.html:545
 msgid ""
-"In addition to the full text of the Mozilla Public License(\"MPL\"), this "
-"also provides an annotated version of the MPL and an <abbr "
-"title=\"Frequently Asked Questions\">FAQ</abbr> to help you if you want to "
-"use or distribute code licensed under it."
+"In addition to the full text of the Mozilla Public License(\"MPL\"), this also provides an annotated version of the MPL and an <abbr title=\"Frequently Asked Questions\">FAQ</abbr> to help you if "
+"you want to use or distribute code licensed under it."
 msgstr ""
-"Além do texto integral da Licença Pública Mozilla (MLP), isso também oferece"
-" uma versão comentada da MPL e uma seção de dúvidas comuns para ajudá-lo "
-"caso você queira usar ou distribuir código licenciado sob a MPL."
+"Além do texto integral da Licença Pública Mozilla (MLP), isso também oferece uma versão comentada da MPL e uma seção de dúvidas comuns para ajudá-lo caso você queira usar ou distribuir código "
+"licenciado sob a MPL."
 
 #: src/olympia/pages/templates/pages/dev_faq.html:559
-msgid ""
-"A table summarizing and comparing how some of the key open source licenses "
-"treat distributions, proprietary software linking, and redistribution of "
-"code with changes."
-msgstr ""
-"Uma tabela resumindo e comparando a distribuição, vinculação de software "
-"proprietário e redistribuição de código com alterações de algumas das "
-"principais licenças de código aberto."
+msgid "A table summarizing and comparing how some of the key open source licenses treat distributions, proprietary software linking, and redistribution of code with changes."
+msgstr "Uma tabela resumindo e comparando a distribuição, vinculação de software proprietário e redistribuição de código com alterações de algumas das principais licenças de código aberto."
 
 #: src/olympia/pages/templates/pages/dev_faq.html:572
 msgid ""
-"Free Software Foundation provides short summaries of the key open source "
-"licenses, including whether the license qualifies as a free software license"
-" or a copyleft license.  Also includes a discussion of what constitutes a "
-"free software license or a copyleft license (e.g., a Copyleft license is a "
-"general method for making a program or other work free, and requiring all "
-"modified and extended versions of the program to be free as well.)"
+"Free Software Foundation provides short summaries of the key open source licenses, including whether the license qualifies as a free software license or a copyleft license. Also includes a "
+"discussion of what constitutes a free software license or a copyleft license (e.g., a Copyleft license is a general method for making a program or other work free, and requiring all modified and "
+"extended versions of the program to be free as well.)"
 msgstr ""
-"A Free Software Foundation dispõe de resumos das principais licenças de "
-"código aberto, inclusive informando se uma licença pode ser qualificada como"
-" licença de código aberto ou copyleft. Ela também provê uma detalhamento "
-"sobre o que constitui uma licença de código aberto e uma licença copyleft "
-"(por exemplo, uma licença copylef é um método geral de garantir que um "
-"programa ou outro trabalho será livre, requerendo que todas as versões "
-"modificadas ou estendidas dele sejam livres também)."
+"A Free Software Foundation dispõe de resumos das principais licenças de código aberto, inclusive informando se uma licença pode ser qualificada como licença de código aberto ou copyleft. Ela também "
+"provê uma detalhamento sobre o que constitui uma licença de código aberto e uma licença copyleft (por exemplo, uma licença copylef é um método geral de garantir que um programa ou outro trabalho "
+"será livre, requerendo que todas as versões modificadas ou estendidas dele sejam livres também)."
 
 #: src/olympia/pages/templates/pages/dev_faq.html:589
-msgid ""
-"Open Source Initiative provides the terms of some of the key open source "
-"licenses."
-msgstr ""
-"A Open Source Initiative fornece os termos de algumas das principais "
-"licenças de código aberto."
+msgid "Open Source Initiative provides the terms of some of the key open source licenses."
+msgstr "A Open Source Initiative fornece os termos de algumas das principais licenças de código aberto."
 
 #: src/olympia/pages/templates/pages/dev_faq.html:599
 msgid "A comparison of known open source licenses on Wikipedia."
 msgstr "Comparação das licenças mais comuns de código aberto na Wikipédia."
 
 #: src/olympia/pages/templates/pages/dev_faq.html:605
-msgid ""
-"A site to provide non-judgmental guidance on choosing a license for your "
-"open source project."
-msgstr ""
-"Um site para prover um guia imparcial sobre a escolha da licença para seu "
-"projeto de código aberto."
+msgid "A site to provide non-judgmental guidance on choosing a license for your open source project."
+msgstr "Um site para prover um guia imparcial sobre a escolha da licença para seu projeto de código aberto."
 
 # Full text for the FAQ abbreviation.
-#: src/olympia/pages/templates/pages/faq.html:3
-#: src/olympia/pages/templates/pages/faq.html:9
-#: src/olympia/pages/templates/pages/faq.html:10
+#: src/olympia/pages/templates/pages/faq.html:3 src/olympia/pages/templates/pages/faq.html:9 src/olympia/pages/templates/pages/faq.html:10
 msgid "Frequently Asked Questions"
 msgstr "Dúvidas comuns"
 
@@ -13176,19 +10427,12 @@ msgstr "O que é um complemento?"
 #: src/olympia/pages/templates/pages/faq.html:16
 #, python-format
 msgid ""
-"Add-ons are small pieces of software that add new features or functionality "
-"to your installation of %(app_name)s. Add-ons can augment %(app_name)s with "
-"new features, foreign language dictionaries, or change its visual "
-"appearance. Through add-ons, you can customize %(app_name)s to meet your "
-"needs and tastes. <a href=\"%(learnmore_url)s\">Learn more about "
-"customization</a>"
+"Add-ons are small pieces of software that add new features or functionality to your installation of %(app_name)s. Add-ons can augment %(app_name)s with new features, foreign language dictionaries, "
+"or change its visual appearance. Through add-ons, you can customize %(app_name)s to meet your needs and tastes. <a href=\"%(learnmore_url)s\">Learn more about customization</a>"
 msgstr ""
-"Complementos são pequenos pedaços de programas que adicionam novos recursos "
-"e funcionalidades à sua instalação do %(app_name)s. Os complementos podem "
-"melhorar o %(app_name)s com novos recursos, como corretores ortográficos, ou"
-" alterar a sua aparência. Usando complementos, você pode personalizar o "
-"%(app_name)s para que ele corresponda às suas necessidades e gostos. <a "
-"href=\"%(learnmore_url)s\">Saiba mais sobre personalização</a>"
+"Complementos são pequenos pedaços de programas que adicionam novos recursos e funcionalidades à sua instalação do %(app_name)s. Os complementos podem melhorar o %(app_name)s com novos recursos, "
+"como corretores ortográficos, ou alterar a sua aparência. Usando complementos, você pode personalizar o %(app_name)s para que ele corresponda às suas necessidades e gostos. <a href="
+"\"%(learnmore_url)s\">Saiba mais sobre personalização</a>"
 
 #: src/olympia/pages/templates/pages/faq.html:26
 msgid "Will add-ons work with my web browser or application?"
@@ -13197,27 +10441,14 @@ msgstr "Os complementos funcionarão com o meu navegador ou aplicação?"
 #: src/olympia/pages/templates/pages/faq.html:27
 #, python-format
 msgid ""
-"Add-ons listed in this gallery only work with Mozilla-based applications, "
-"such as <a href=\"%(getfirefox_url)s\">Firefox</a>, <a "
-"href=\"%(getmobile_url)s\">Firefox Mobile</a>, <a "
-"href=\"%(getseamonkey_url)s\">SeaMonkey</a>, and <a "
-"href=\"%(getthunderbird_url)s\">Thunderbird</a>. However, not all add-ons "
-"work with each of those applications or every version of those applications."
-" Each add-on specifies which applications and versions it works with, such "
-"as Firefox 2.0 - 3.6.*. For Firefox add-ons, the install buttons will "
-"indicate whether the add-on is compatible or not."
+"Add-ons listed in this gallery only work with Mozilla-based applications, such as <a href=\"%(getfirefox_url)s\">Firefox</a>, <a href=\"%(getmobile_url)s\">Firefox Mobile</a>, <a href="
+"\"%(getseamonkey_url)s\">SeaMonkey</a>, and <a href=\"%(getthunderbird_url)s\">Thunderbird</a>. However, not all add-ons work with each of those applications or every version of those applications. "
+"Each add-on specifies which applications and versions it works with, such as Firefox 2.0 - 3.6.*. For Firefox add-ons, the install buttons will indicate whether the add-on is compatible or not."
 msgstr ""
-"Os complementos listados nesta galeria funcionam somente em aplicações "
-"baseadas no software Mozilla, como o <a "
-"href=\"%(getfirefox_url)s\">Firefox</a>, o <a "
-"href=\"%(getmobile_url)s\">Firefox Móvel</a>, o <a "
-"href=\"%(getthunderbird_url)s\">Thunderbird</a> e o <a "
-"href=\"%(getseamonkey_url)s\">SeaMonkey</a>. No entanto, nem todos os "
-"complementos funcionam com cada uma dessas aplicações ou todas as versões "
-"dessas aplicações. Cada complemento especifica com quais aplicações e "
-"versões eles funcionam, tais como o Firefox 10.0 - 12.*. Para os "
-"complementos do Firefox, os botões de instalação indicarão se o complemento "
-"é compatível ou não."
+"Os complementos listados nesta galeria funcionam somente em aplicações baseadas no software Mozilla, como o <a href=\"%(getfirefox_url)s\">Firefox</a>, o <a href=\"%(getmobile_url)s\">Firefox "
+"Móvel</a>, o <a href=\"%(getthunderbird_url)s\">Thunderbird</a> e o <a href=\"%(getseamonkey_url)s\">SeaMonkey</a>. No entanto, nem todos os complementos funcionam com cada uma dessas aplicações ou "
+"todas as versões dessas aplicações. Cada complemento especifica com quais aplicações e versões eles funcionam, tais como o Firefox 10.0 - 12.*. Para os complementos do Firefox, os botões de "
+"instalação indicarão se o complemento é compatível ou não."
 
 # %s is a locale, like en-US.
 #: src/olympia/pages/templates/pages/faq.html:42
@@ -13226,78 +10457,42 @@ msgstr "Quais são os diferentes tipos de complementos?"
 
 #: src/olympia/pages/templates/pages/faq.html:43
 #, python-format
-msgid ""
-"There are several kinds of add-ons that customize %(app_name)s in different "
-"ways:"
-msgstr ""
-"Há vários tipos de complementos que personalizam o %(app_name)s de "
-"diferentes maneiras:"
+msgid "There are several kinds of add-ons that customize %(app_name)s in different ways:"
+msgstr "Há vários tipos de complementos que personalizam o %(app_name)s de diferentes maneiras:"
 
 #: src/olympia/pages/templates/pages/faq.html:47
 #, python-format
 msgid ""
-"<strong><a href=\"%(browse_url)s\">Extensions</a></strong> add new features "
-"to %(app_name)s or modify existing functionality. There are extensions that "
-"allow you to block advertisements, download videos from websites, integrate "
-"more closely with social websites, and add features you see in other "
-"applications."
+"<strong><a href=\"%(browse_url)s\">Extensions</a></strong> add new features to %(app_name)s or modify existing functionality. There are extensions that allow you to block advertisements, download "
+"videos from websites, integrate more closely with social websites, and add features you see in other applications."
 msgstr ""
-"<strong><a href=\"%(browse_url)s\">Extensões</a></strong> adicionam novos "
-"recursos ao %(app_name)s ou modificam funcionalidades existentes. Há "
-"extensões que permitem que você bloqueie anúncios, baixe vídeos de páginas "
-"da Web, integre-se a redes sociais e adicione recursos que você encontra em "
-"outras aplicações."
+"<strong><a href=\"%(browse_url)s\">Extensões</a></strong> adicionam novos recursos ao %(app_name)s ou modificam funcionalidades existentes. Há extensões que permitem que você bloqueie anúncios, "
+"baixe vídeos de páginas da Web, integre-se a redes sociais e adicione recursos que você encontra em outras aplicações."
 
 #: src/olympia/pages/templates/pages/faq.html:55
 #, python-format
-msgid ""
-"<strong><a href=\"%(browse_url)s\">Complete Themes</a></strong> change the "
-"entire appearance of %(app_name)s, usually including icons, colors, dialogs,"
-" and other visual styles."
-msgstr ""
-"<strong><a href=\"%(browse_url)s\">Temas completos</a></strong> podem "
-"alterar completamente a aparência do %(app_name)s, incluindo ícones, cores, "
-"diálogos e outros estilos visuais."
+msgid "<strong><a href=\"%(browse_url)s\">Complete Themes</a></strong> change the entire appearance of %(app_name)s, usually including icons, colors, dialogs, and other visual styles."
+msgstr "<strong><a href=\"%(browse_url)s\">Temas completos</a></strong> podem alterar completamente a aparência do %(app_name)s, incluindo ícones, cores, diálogos e outros estilos visuais."
 
 #: src/olympia/pages/templates/pages/faq.html:61
 #, python-format
-msgid ""
-"<strong><a href=\"%(browse_url)s\">Themes</a></strong> are lightweight "
-"themes that use background images to customize your %(app_name)s toolbars."
-msgstr ""
-"<strong><a href=\"%(browse_url)s\">Temas</a></strong> são alterações leves "
-"que usam imagens de fundo para personalizar a janela do seu %(app_name)s."
+msgid "<strong><a href=\"%(browse_url)s\">Themes</a></strong> are lightweight themes that use background images to customize your %(app_name)s toolbars."
+msgstr "<strong><a href=\"%(browse_url)s\">Temas</a></strong> são alterações leves que usam imagens de fundo para personalizar a janela do seu %(app_name)s."
 
 #: src/olympia/pages/templates/pages/faq.html:66
 #, python-format
-msgid ""
-"<strong><a href=\"%(browse_url)s\">Search Providers</a> </strong> add "
-"additional choices to the search box dropdown. These providers allow you to "
-"quickly search any website."
-msgstr ""
-"<strong><a href=\"%(browse_url)s\">Mecanismos de pesquisa</a></strong> "
-"adicionam opções extras ao campo de pesquisa. Esses mecanismos permitem que "
-"você pesquise rapidamente em qualquer site."
+msgid "<strong><a href=\"%(browse_url)s\">Search Providers</a> </strong> add additional choices to the search box dropdown. These providers allow you to quickly search any website."
+msgstr "<strong><a href=\"%(browse_url)s\">Mecanismos de pesquisa</a></strong> adicionam opções extras ao campo de pesquisa. Esses mecanismos permitem que você pesquise rapidamente em qualquer site."
 
 #: src/olympia/pages/templates/pages/faq.html:72
 #, python-format
-msgid ""
-"<strong><a href=\"%(browse_url)s\">Dictionaries & Language "
-"Packs</a></strong> add support for additional languages to %(app_name)s."
-msgstr ""
-"<strong><a href=\"%(browse_url)s\">Dicionários e Pacotes de "
-"idiomas</a></strong> adicionam suporte para outros idiomas ao %(app_name)s."
+msgid "<strong><a href=\"%(browse_url)s\">Dictionaries & Language Packs</a></strong> add support for additional languages to %(app_name)s."
+msgstr "<strong><a href=\"%(browse_url)s\">Dicionários e Pacotes de idiomas</a></strong> adicionam suporte para outros idiomas ao %(app_name)s."
 
 #: src/olympia/pages/templates/pages/faq.html:77
 #, python-format
-msgid ""
-"<strong><a href=\"%(browse_url)s\">Plugins</a></strong> help %(app_name)s "
-"display or understand different types of media, such as Adobe Flash or Apple"
-" Quicktime."
-msgstr ""
-"<strong><a href=\"%(browse_url)s\">Plugins</a></strong> ajudam o "
-"%(app_name)s a exibir ou entender diferentes tipos de mídia, como o Adobe "
-"Flash ou Apple Quicktime."
+msgid "<strong><a href=\"%(browse_url)s\">Plugins</a></strong> help %(app_name)s display or understand different types of media, such as Adobe Flash or Apple Quicktime."
+msgstr "<strong><a href=\"%(browse_url)s\">Plugins</a></strong> ajudam o %(app_name)s a exibir ou entender diferentes tipos de mídia, como o Adobe Flash ou Apple Quicktime."
 
 #: src/olympia/pages/templates/pages/faq.html:85
 msgid "How do I install, manage, or remove an add-on?"
@@ -13306,22 +10501,13 @@ msgstr "Como eu instalo, gerencio ou excluo um complemento?"
 #: src/olympia/pages/templates/pages/faq.html:86
 #, python-format
 msgid ""
-"In most cases, add-ons can be installed by simply clicking the install "
-"button provided. Add-ons can be managed, disabled, or uninstalled from the "
-"Add-ons Manager in %(app_name)s. For more detailed instructions, read <a "
-"href=\"%(extension_url)s\">this article on extensions</a> or <a "
-"href=\"%(theme_url)s\">this one for Themes and Complete Themes</a>. If you "
-"have difficulty installing add-ons, see <a "
-"href=\"%(troubleshooting_url)s\">Troubleshooting Extensions and Themes</a>."
+"In most cases, add-ons can be installed by simply clicking the install button provided. Add-ons can be managed, disabled, or uninstalled from the Add-ons Manager in %(app_name)s. For more detailed "
+"instructions, read <a href=\"%(extension_url)s\">this article on extensions</a> or <a href=\"%(theme_url)s\">this one for Themes and Complete Themes</a>. If you have difficulty installing add-ons, "
+"see <a href=\"%(troubleshooting_url)s\">Troubleshooting Extensions and Themes</a>."
 msgstr ""
-"Na maioria dos casos, os complementos podem ser instalados com um clique no "
-"botão Instalar. Para gerenciar, desabilitar ou desinstalar um complemento, "
-"use o Gerenciador de complementos do %(app_name)s. Para mais informações, "
-"leia <a href=\"%(extension_url)s\">este artigo sobre complementos</a> ou <a "
-"href=\"%(theme_url)s\">este sobre temas</a>. Se tiver dificuldades ao "
-"instalar complementos, leia o artigo <a "
-"href=\"%(troubleshooting_url)s\">Solucionando problemas com extensões e "
-"temas</a>."
+"Na maioria dos casos, os complementos podem ser instalados com um clique no botão Instalar. Para gerenciar, desabilitar ou desinstalar um complemento, use o Gerenciador de complementos do "
+"%(app_name)s. Para mais informações, leia <a href=\"%(extension_url)s\">este artigo sobre complementos</a> ou <a href=\"%(theme_url)s\">este sobre temas</a>. Se tiver dificuldades ao instalar "
+"complementos, leia o artigo <a href=\"%(troubleshooting_url)s\">Solucionando problemas com extensões e temas</a>."
 
 #: src/olympia/pages/templates/pages/faq.html:100
 msgid "How do I install add-ons without restarting Firefox?"
@@ -13330,17 +10516,11 @@ msgstr "Como eu posso instalar complementos sem reiniciar o Firefox?"
 #: src/olympia/pages/templates/pages/faq.html:101
 #, python-format
 msgid ""
-"In Firefox, add-ons marked with \"No restart required\" can be installed "
-"without restarting. These add-ons have been created using the <a "
-"href=\"%(sdk_url)s\">Add-on SDK</a> or <a "
-"href=\"%(bootstrap_url)s\">bootstrapping</a>. Other add-ons will still "
-"require a restart before you can use them."
+"In Firefox, add-ons marked with \"No restart required\" can be installed without restarting. These add-ons have been created using the <a href=\"%(sdk_url)s\">Add-on SDK</a> or <a href="
+"\"%(bootstrap_url)s\">bootstrapping</a>. Other add-ons will still require a restart before you can use them."
 msgstr ""
-"No Firefox, complementos marcados com \"Não precisa reiniciar\" podem ser "
-"instalados sem a necessidade de reiniciá-lo. Esses complementos foram "
-"criados usando o <a href=\"%(sdk_url)s\">Add-on SDK</a> ou criando <a "
-"href=\"%(bootstrap_url)s\">extensões bootstrapped</a>. Outros complementos "
-"ainda requerem o reinício antes de poder usá-los."
+"No Firefox, complementos marcados com \"Não precisa reiniciar\" podem ser instalados sem a necessidade de reiniciá-lo. Esses complementos foram criados usando o <a href=\"%(sdk_url)s\">Add-on SDK</"
+"a> ou criando <a href=\"%(bootstrap_url)s\">extensões bootstrapped</a>. Outros complementos ainda requerem o reinício antes de poder usá-los."
 
 #: src/olympia/pages/templates/pages/faq.html:110
 msgid "How do I keep add-ons up-to-date?"
@@ -13349,23 +10529,13 @@ msgstr "Como eu mantenho os complementos atualizados?"
 #: src/olympia/pages/templates/pages/faq.html:111
 #, python-format
 msgid ""
-"Add-ons, unlike plugins, are automatically checked for updates once every "
-"day. In Firefox, updates are automatically installed by default. Versions of"
-" Firefox prior to 4 (and other applications) will alert you that updates to "
-"your add-ons are available. <a href=\"%(plugin_url)s\">Plugins</a> are not "
-"currently automatically checked for updates, so be sure to regularly visit "
-"the <a href=\"%(plugincheck_url)s\">Plugin Check</a> page to stay up-to-"
-"date."
+"Add-ons, unlike plugins, are automatically checked for updates once every day. In Firefox, updates are automatically installed by default. Versions of Firefox prior to 4 (and other applications) "
+"will alert you that updates to your add-ons are available. <a href=\"%(plugin_url)s\">Plugins</a> are not currently automatically checked for updates, so be sure to regularly visit the <a href="
+"\"%(plugincheck_url)s\">Plugin Check</a> page to stay up-to-date."
 msgstr ""
-"Complementos, diferentemente dos plugins, são verificados automaticamente à "
-"procura de atualizações uma vez por dia. No Firefox, as atualizações são "
-"instaladas automaticamente por padrão. Versões do Firefox a partir da versão"
-" 4 (e outras aplicações) alertarão quando houver atualizações disponíveis "
-"para seus complementos. <a href=\"%(plugin_url)s\">Plugins</a> não são "
-"verificados automaticamente à procura de atualizações atualmente, então "
-"lembre-se de visitar regularmente a página <a "
-"href=\"%(plugincheck_url)s\">Verificação de plugins</a> para mantê-los "
-"atualizados."
+"Complementos, diferentemente dos plugins, são verificados automaticamente à procura de atualizações uma vez por dia. No Firefox, as atualizações são instaladas automaticamente por padrão. Versões "
+"do Firefox a partir da versão 4 (e outras aplicações) alertarão quando houver atualizações disponíveis para seus complementos. <a href=\"%(plugin_url)s\">Plugins</a> não são verificados "
+"automaticamente à procura de atualizações atualmente, então lembre-se de visitar regularmente a página <a href=\"%(plugincheck_url)s\">Verificação de plugins</a> para mantê-los atualizados."
 
 #: src/olympia/pages/templates/pages/faq.html:122
 msgid "Are add-ons safe to install?"
@@ -13374,21 +10544,13 @@ msgstr "É seguro instalar complementos?"
 #: src/olympia/pages/templates/pages/faq.html:123
 #, python-format
 msgid ""
-"Unless clearly marked otherwise, add-ons available from this gallery have "
-"been checked and approved by Mozilla's team of editors and are safe to "
-"install. We recommend that you only install approved add-ons. If you wish to"
-" install unapproved add-ons or add-ons from third-party websites, use "
-"caution as these add-ons may harm your computer or violate your privacy. <a "
-"href=\"%(learnmore_url)s\">Learn more about our approval process</a>"
+"Unless clearly marked otherwise, add-ons available from this gallery have been checked and approved by Mozilla's team of editors and are safe to install. We recommend that you only install approved "
+"add-ons. If you wish to install unapproved add-ons or add-ons from third-party websites, use caution as these add-ons may harm your computer or violate your privacy. <a href=\"%(learnmore_url)s"
+"\">Learn more about our approval process</a>"
 msgstr ""
-"Exceto quando houver clara indicação do contrário, os complementos "
-"disponíveis nesta galeria foram verificados e aprovados pela equipe de "
-"editores da Mozilla e são seguros para serem instalados. Nós recomendamos "
-"que você instale somente complementos aprovados. Se você quiser instalar "
-"complementos não aprovados ou de páginas de terceiros, tenha cuidado, pois "
-"esses complementos podem danificar seu computador e violar a sua "
-"privacidade. <a href=\"%(learnmore_url)s\">Saiba mais sobre nosso processo "
-"de aprovação</a>"
+"Exceto quando houver clara indicação do contrário, os complementos disponíveis nesta galeria foram verificados e aprovados pela equipe de editores da Mozilla e são seguros para serem instalados. "
+"Nós recomendamos que você instale somente complementos aprovados. Se você quiser instalar complementos não aprovados ou de páginas de terceiros, tenha cuidado, pois esses complementos podem "
+"danificar seu computador e violar a sua privacidade. <a href=\"%(learnmore_url)s\">Saiba mais sobre nosso processo de aprovação</a>"
 
 #: src/olympia/pages/templates/pages/faq.html:133
 #, python-format
@@ -13398,45 +10560,27 @@ msgstr "Os complementos podem tornar o %(app_name)s lento?"
 #: src/olympia/pages/templates/pages/faq.html:135
 #, python-format
 msgid ""
-"Most add-ons do not cause a perceivable performance decrease in "
-"%(app_name)s, though installing an excessive number may have adverse "
-"effects. If you suspect an add-on is causing %(app_name)s to be slow, try "
-"disabling it."
+"Most add-ons do not cause a perceivable performance decrease in %(app_name)s, though installing an excessive number may have adverse effects. If you suspect an add-on is causing %(app_name)s to be "
+"slow, try disabling it."
 msgstr ""
-"A maioria dos complementos não causam uma perda de performance perceptível "
-"no %(app_name)s, entretanto instalar muitos complementos pode ter efeitos "
-"adversos. Se suspeita que um complemento está fazendo %(app_name)s ficar "
-"lento, tente desativá-lo."
+"A maioria dos complementos não causam uma perda de performance perceptível no %(app_name)s, entretanto instalar muitos complementos pode ter efeitos adversos. Se suspeita que um complemento está "
+"fazendo %(app_name)s ficar lento, tente desativá-lo."
 
 #: src/olympia/pages/templates/pages/faq.html:141
 #, python-format
-msgid ""
-"%(app_name)s told me an add-on isn't compatible. Is there a way I can still "
-"use it?"
-msgstr ""
-"O %(app_name)s me informou que um complemento não é compatível. Eu ainda "
-"posso usá-lo de alguma maneira?"
+msgid "%(app_name)s told me an add-on isn't compatible. Is there a way I can still use it?"
+msgstr "O %(app_name)s me informou que um complemento não é compatível. Eu ainda posso usá-lo de alguma maneira?"
 
 #: src/olympia/pages/templates/pages/faq.html:144
 #, python-format
 msgid ""
-"If an add-on isn't compatible with your version of %(app_name)s, it is "
-"usually either because your version of %(app_name)s is outdated or the add-"
-"on author has not yet updated the add-on to be compatible with a newer "
-"version you are using. Mozilla does not recommend trying to circumvent these"
-" compatibility checks, as they can lead to browser instability or in some "
-"cases loss of data. For users who are testing out alpha or beta versions of "
-"Firefox, we offer the <a href=\"%(acr_url)s\">Add-on Compatibility "
-"Reporter</a> to help add-on developers update their compatibility."
+"If an add-on isn't compatible with your version of %(app_name)s, it is usually either because your version of %(app_name)s is outdated or the add-on author has not yet updated the add-on to be "
+"compatible with a newer version you are using. Mozilla does not recommend trying to circumvent these compatibility checks, as they can lead to browser instability or in some cases loss of data. For "
+"users who are testing out alpha or beta versions of Firefox, we offer the <a href=\"%(acr_url)s\">Add-on Compatibility Reporter</a> to help add-on developers update their compatibility."
 msgstr ""
-"Se um complemento não for compatível com a sua versão do %(app_name)s, "
-"normalmente é devido à sua versão do %(app_name)s estar desatualizada ou ao "
-"autor do complemento ainda não ter atualizado o complemento para ser "
-"compatível com a versão mais recente que você está usando. A Mozilla não "
-"recomenda ignorar essas verificações de compatibilidade, pois isso pode "
-"levar à instabilidade do navegador e em alguns casos à perda de dados. Para "
-"usuários testando versões alfa ou beta do Firefox, oferecemos o <a "
-"href=\"%(acr_url)s\">Add-on Compatibility Reporter</a> para ajudar os "
+"Se um complemento não for compatível com a sua versão do %(app_name)s, normalmente é devido à sua versão do %(app_name)s estar desatualizada ou ao autor do complemento ainda não ter atualizado o "
+"complemento para ser compatível com a versão mais recente que você está usando. A Mozilla não recomenda ignorar essas verificações de compatibilidade, pois isso pode levar à instabilidade do "
+"navegador e em alguns casos à perda de dados. Para usuários testando versões alfa ou beta do Firefox, oferecemos o <a href=\"%(acr_url)s\">Add-on Compatibility Reporter</a> para ajudar os "
 "desenvolvedores a atualizar a compatibilidade dos seus complementos."
 
 #: src/olympia/pages/templates/pages/faq.html:156
@@ -13446,41 +10590,28 @@ msgstr "E se eu tiver problemas com um complemento?"
 #: src/olympia/pages/templates/pages/faq.html:157
 #, python-format
 msgid ""
-"Add-ons are usually created by third-party developers from around the world,"
-" so the best way to get help with an add-on is to look for support links on "
-"the add-on's homepage or contact the developer. If you are having issues "
-"with %(app_name)s that you suspect are related to add-ons you have "
-"installed, <a href=\"%(troubleshooting_url)s\">visit this support "
-"article</a> for troubleshooting tips."
+"Add-ons are usually created by third-party developers from around the world, so the best way to get help with an add-on is to look for support links on the add-on's homepage or contact the "
+"developer. If you are having issues with %(app_name)s that you suspect are related to add-ons you have installed, <a href=\"%(troubleshooting_url)s\">visit this support article</a> for "
+"troubleshooting tips."
 msgstr ""
-"Complementos normalmente são criados por desenvolvedores independentes do "
-"mundo todo, então a melhor maneira de obter ajuda para um complemento é "
-"procurar pelos links de suporte na página do complemento ou entrar em "
-"contato com o desenvolvedor. Se você estiver tendo problemas com o "
-"%(app_name)s, que você suspeita que estejam relacionados com o complemento "
-"que você instalou, <a href=\"%(troubleshooting_url)s\">visite este artigo "
-"sobre suporte</a> para obter dicas de soluções de problemas."
+"Complementos normalmente são criados por desenvolvedores independentes do mundo todo, então a melhor maneira de obter ajuda para um complemento é procurar pelos links de suporte na página do "
+"complemento ou entrar em contato com o desenvolvedor. Se você estiver tendo problemas com o %(app_name)s, que você suspeita que estejam relacionados com o complemento que você instalou, <a href="
+"\"%(troubleshooting_url)s\">visite este artigo sobre suporte</a> para obter dicas de soluções de problemas."
 
 #: src/olympia/pages/templates/pages/faq.html:169
 msgid "Add-on Gallery"
 msgstr "Galeria de complementos"
 
 #: src/olympia/pages/templates/pages/faq.html:171
-msgid ""
-"How do I choose between add-ons that seem to do the same\n"
-"    thing?"
+msgid "How do I choose between add-ons that seem to do the same thing?"
 msgstr ""
 "Como decido qual complemento usar entre dois que parecem fazer a mesma \n"
 "    coisa?"
 
-#: src/olympia/pages/templates/pages/faq.html:173
+#: src/olympia/pages/templates/pages/faq.html:172
 msgid ""
-"There are often several add-ons that have similar features. To\n"
-"    figure out which is right for you, read the entire description of the\n"
-"    add-on and view its screenshots. If there are still several in the running,\n"
-"    read through the add-on's ratings, user reviews, and statistics to see\n"
-"    which is most liked by other users. Remember that you can also just try\n"
-"    out both and see which you like better."
+"There are often several add-ons that have similar features. To figure out which is right for you, read the entire description of the add-on and view its screenshots. If there are still several in "
+"the running, read through the add-on's ratings, user reviews, and statistics to see which is most liked by other users. Remember that you can also just try out both and see which you like better."
 msgstr ""
 "É comum existirem diversos complementos com características similares. Para\n"
 "    descobrir qual é o melhor pra você, leia a descrição completa do complemento\n"
@@ -13496,39 +10627,25 @@ msgstr "E se eu não conseguir encontrar um complemento que estou procurando?"
 #: src/olympia/pages/templates/pages/faq.html:181
 #, python-format
 msgid ""
-"With thousands of add-ons available, there's something for everyone. But if "
-"you're looking for a particular add-on and can't find it, you might try "
-"searching on other sites or posting about it in our <a href=\"%(forum_url)s"
-"\">Add-ons </a>forum."
+"With thousands of add-ons available, there's something for everyone. But if you're looking for a particular add-on and can't find it, you might try searching on other sites or posting about it in "
+"our <a href=\"%(forum_url)s\">Add-ons </a>forum."
 msgstr ""
-"Com milhares de complementos disponíveis, tem algo para todo mundo. Mas se "
-"você estiver procurando um complemento em particular e não consegue "
-"encontrá-lo, você pode tentar pesquisar em outros sites ou postar sobre isso"
-" em nosso fórum de <a href=\"%(forum_url)s\">coplementos</a>."
+"Com milhares de complementos disponíveis, tem algo para todo mundo. Mas se você estiver procurando um complemento em particular e não consegue encontrá-lo, você pode tentar pesquisar em outros "
+"sites ou postar sobre isso em nosso fórum de <a href=\"%(forum_url)s\">coplementos</a>."
 
 #: src/olympia/pages/templates/pages/faq.html:187
-msgid ""
-"What does it mean if an add-on is \"experimental\" or \"preliminarily "
-"reviewed\"?"
-msgstr ""
-"O que significa se um complemento é \"experimental\" ou \"analisado "
-"preliminarmente\"?"
+msgid "What does it mean if an add-on is \"experimental\" or \"preliminarily reviewed\"?"
+msgstr "O que significa se um complemento é \"experimental\" ou \"analisado preliminarmente\"?"
 
 #: src/olympia/pages/templates/pages/faq.html:188
 #, python-format
 msgid ""
-"Experimental add-ons have been checked by our editors to make sure they "
-"don't have security problems, but they may still have bugs or not work "
-"properly. Use caution when installing experimental add-ons and uninstall the"
-" add-on immediately if you notice problems. <a href=\"%(url)s\">Learn more "
-"about our review process</a></dd>"
+"Experimental add-ons have been checked by our editors to make sure they don't have security problems, but they may still have bugs or not work properly. Use caution when installing experimental add-"
+"ons and uninstall the add-on immediately if you notice problems. <a href=\"%(url)s\">Learn more about our review process</a></dd>"
 msgstr ""
-"Os complementos experimentais foram verificados pelos nossos editores para "
-"ter certeza de que eles não apresentam problemas de segurança, mas eles "
-"ainda podem conter bugs ou não funcionar corretamente. Tenha cuidado ao "
-"instalar complementos experimentais e desinstale-os imediatamente se você "
-"encontrar algum problema. <a href=\"%(url)s\">Saiba mais sobre o nosso "
-"processo de análise</a></dd>"
+"Os complementos experimentais foram verificados pelos nossos editores para ter certeza de que eles não apresentam problemas de segurança, mas eles ainda podem conter bugs ou não funcionar "
+"corretamente. Tenha cuidado ao instalar complementos experimentais e desinstale-os imediatamente se você encontrar algum problema. <a href=\"%(url)s\">Saiba mais sobre o nosso processo de análise</"
+"a></dd>"
 
 #: src/olympia/pages/templates/pages/faq.html:196
 msgid "What does it mean if an add-on is \"not reviewed\"?"
@@ -13537,272 +10654,198 @@ msgstr "O que significa se um complemento não foi analisado?"
 #: src/olympia/pages/templates/pages/faq.html:197
 #, python-format
 msgid ""
-"While all add-ons publicly available in our gallery are reviewed by an "
-"editor, you may receive a direct link to an add-on that hasn't yet been "
-"reviewed. Use caution when installing these add-ons, as they could harm your"
-" computer or violate your privacy. We recommend that you only install "
-"reviewed add-ons. <a href=\"%(url)s\">Learn more about our review "
-"process</a></dd>"
+"While all add-ons publicly available in our gallery are reviewed by an editor, you may receive a direct link to an add-on that hasn't yet been reviewed. Use caution when installing these add-ons, "
+"as they could harm your computer or violate your privacy. We recommend that you only install reviewed add-ons. <a href=\"%(url)s\">Learn more about our review process</a></dd>"
 msgstr ""
-"Embora todos os complementos disponíveis publicamente em nossa galeria "
-"tenham sido analisados por um editor, você pode receber um link direto para "
-"um complemento que ainda não foi analisado; é provável que esse complemento "
-"ainda esteja aguardando sua análise. Tome cuidado ao instalar esses "
-"complementos, pois eles podem danificar seu computador ou violar a sua "
-"privacidade. Nós recomendamos que você instale somente complementos "
-"analisados. <a href=\"%(url)s\">Saiba mais sobre o nosso processo de "
-"análise</a></dd>"
+"Embora todos os complementos disponíveis publicamente em nossa galeria tenham sido analisados por um editor, você pode receber um link direto para um complemento que ainda não foi analisado; é "
+"provável que esse complemento ainda esteja aguardando sua análise. Tome cuidado ao instalar esses complementos, pois eles podem danificar seu computador ou violar a sua privacidade. Nós "
+"recomendamos que você instale somente complementos analisados. <a href=\"%(url)s\">Saiba mais sobre o nosso processo de análise</a></dd>"
 
 #: src/olympia/pages/templates/pages/faq.html:206
 msgid "How much do add-ons cost to purchase?"
 msgstr "Quanto custam os complementos?"
 
 #: src/olympia/pages/templates/pages/faq.html:207
-msgid ""
-"Add-ons hosted in our gallery are free unless clearly marked\n"
-"    otherwise."
+msgid "Add-ons hosted in our gallery are free unless clearly marked otherwise."
 msgstr ""
 "Os complementos hospedados em nossa galeria são gratuitos, exceto quando houver uma indicação\n"
 "    clara do contrário."
 
-#: src/olympia/pages/templates/pages/faq.html:210
+#: src/olympia/pages/templates/pages/faq.html:209
 msgid "What does it mean when an add-on asks for contributions?"
 msgstr "O que significa quando um complemento pede contribuições?"
 
-#: src/olympia/pages/templates/pages/faq.html:211
+#: src/olympia/pages/templates/pages/faq.html:210
 msgid ""
-"Some add-on authors request users who enjoy an add-on to\n"
-"        contribute to its development by making a monetary contribution. These\n"
-"        contributions go directly to the developer unless a third party is\n"
-"        indicated, such as the non-profit Mozilla Foundation."
+"Some add-on authors request users who enjoy an add-on to contribute to its development by making a monetary contribution. These contributions go directly to the developer unless a third party is "
+"indicated, such as the non-profit Mozilla Foundation."
 msgstr ""
 "Alguns autores de complementos pedem que usuários que gostam de um complemento\n"
 "        ajudem no desenvolvimento através de contribuições monetárias. Estas \n"
 "        contribuições vão diretamente para o desenvolvedor a menos que outra\n"
 "        entidade esteja envolvida, como a Mozilla Foundation que não tem fins lucrativos."
 
-#: src/olympia/pages/templates/pages/faq.html:216
+#: src/olympia/pages/templates/pages/faq.html:215
 msgid "What are beta add-ons?"
 msgstr "O que são complementos beta?"
 
-#: src/olympia/pages/templates/pages/faq.html:218
+#: src/olympia/pages/templates/pages/faq.html:217
 msgid ""
-"Beta add-ons are unreviewed versions which represent the\n"
-"        latest work of an add-on author. While different authors have different\n"
-"        standards for beta code quality, you should assume that these add-ons\n"
-"        are less stable than the general add-on releases."
+"Beta add-ons are unreviewed versions which represent the latest work of an add-on author. While different authors have different standards for beta code quality, you should assume that these add-"
+"ons are less stable than the general add-on releases."
 msgstr ""
 "Complementos em fase Beta são versões não avaliadas que representam\n"
 "        o trabalho mais recente do autor de um complemento. Diferentes autores têm\n"
 "        diferentes parâmetros de qualidade de código em fase beta, você deve assumir que\n"
 "        estes complementos são menos estáveis que as versões disponibilizadas ao público em geral."
 
-#: src/olympia/pages/templates/pages/faq.html:222
+#: src/olympia/pages/templates/pages/faq.html:221
 msgid ""
-"Please note that when you install an add-on from the \"Beta Version\" "
-"section of an add-on's listing, you will continue to receive updates for "
-"that add-on as they become available. Like the initial version you "
-"installed, all beta releases are unreviewed by Mozilla and may harm your "
-"computer."
+"Please note that when you install an add-on from the \"Beta Version\" section of an add-on's listing, you will continue to receive updates for that add-on as they become available. Like the initial "
+"version you installed, all beta releases are unreviewed by Mozilla and may harm your computer."
 msgstr ""
-"Por favor, observe que quando você instala um complemento da seção \"Versão "
-"Beta\" da página de um complemento, você continuará a receber atualizações "
-"para o seu complemento conforme elas se tornem disponíveis. Assim como a "
-"versão inicial que você instalou, todos os lançamentos beta não foram "
-"analisados pela Mozilla e podem danificar seu computador."
+"Por favor, observe que quando você instala um complemento da seção \"Versão Beta\" da página de um complemento, você continuará a receber atualizações para o seu complemento conforme elas se tornem "
+"disponíveis. Assim como a versão inicial que você instalou, todos os lançamentos beta não foram analisados pela Mozilla e podem danificar seu computador."
 
-#: src/olympia/pages/templates/pages/faq.html:229
-msgid ""
-"What does it mean when an add-on is flagged as\n"
-"    slow?"
+#: src/olympia/pages/templates/pages/faq.html:228
+msgid "What does it mean when an add-on is flagged as slow?"
 msgstr ""
 "O que significa quando um complemento é marcado como\n"
 "    lento?"
 
-#: src/olympia/pages/templates/pages/faq.html:231
-msgid ""
-"Most add-ons load code and resources at the same time Firefox\n"
-"        is starting up. In most cases the impact in start-up time is minimal,\n"
-"        but some add-ons can cause a noticeable slowdown."
+#: src/olympia/pages/templates/pages/faq.html:229
+msgid "Most add-ons load code and resources at the same time Firefox is starting up. In most cases the impact in start-up time is minimal, but some add-ons can cause a noticeable slowdown."
 msgstr ""
 "A maioria dos complementos carrega código e recursos ao mesmo tempo que o Firefox\n"
 "        está iniciando. Na maioria dos casos o impacto na performance é mínimo, \n"
 "        mas alguns complementos podem causar lentidões perceptíveis."
 
-#: src/olympia/pages/templates/pages/faq.html:236
+#: src/olympia/pages/templates/pages/faq.html:234
 msgid "How do I report an inappropriate or spam user review?"
 msgstr "Como eu posso denunciar uma análise inadequada ou spam?"
 
-#: src/olympia/pages/templates/pages/faq.html:237
+#: src/olympia/pages/templates/pages/faq.html:235
 msgid ""
-"To report a user review of an add-on, log in with your account\n"
-"    and visit the add-on's reviews page. Find the review you wish to report,\n"
-"    click \"Report this review\" and select a reason. Our editorial team will\n"
-"    investigate the review and take appropriate action."
+"To report a user review of an add-on, log in with your account and visit the add-on's reviews page. Find the review you wish to report, click \"Report this review\" and select a reason. Our "
+"editorial team will investigate the review and take appropriate action."
 msgstr ""
 "Para reportar uma revisão do usuário de um addo-on, faça o login com a sua conta\n"
 "     e acesse a página de revisões de add-on's. Encontre o comentário que você deseja reportar,\n"
 "    clique em \"Reportar esta revisão\" e selecione um motivo. Nossos time de editores irá\n"
 "    investigar a revisão e tomar as devidas ações."
 
-#: src/olympia/pages/templates/pages/faq.html:242
+#: src/olympia/pages/templates/pages/faq.html:240
 msgid "How do I report a bug or contact the Mozilla Add-ons team?"
-msgstr ""
-"Como eu faço para relatar um bug ou entrar em contato com a equipe do "
-"Mozilla Add-ons?"
+msgstr "Como eu faço para relatar um bug ou entrar em contato com a equipe do Mozilla Add-ons?"
 
-#: src/olympia/pages/templates/pages/faq.html:243
+#: src/olympia/pages/templates/pages/faq.html:241
 #, python-format
 msgid "Please visit our <a href=\"%(contact_url)s\">Contact page</a>."
-msgstr ""
-"Por favor, visite nossa <a href=\"%(contact_url)s\">página de contato</a>."
+msgstr "Por favor, visite nossa <a href=\"%(contact_url)s\">página de contato</a>."
 
-#: src/olympia/pages/templates/pages/faq.html:246
+#: src/olympia/pages/templates/pages/faq.html:244
 msgid "What is a Source Code License?"
 msgstr "O que é Licença do Código-Fonte?"
 
-#: src/olympia/pages/templates/pages/faq.html:247
+#: src/olympia/pages/templates/pages/faq.html:245
 #, python-format
 msgid ""
-"The source code used to create an add-on is an exclusive copyright of the "
-"add-on author, unless otherwise declared in a source code license. Many add-"
-"ons on this site have <a href=\"%(url)s\" lang=\"en\">open source "
-"licenses</a> that make the source code publicly available for copy and reuse"
-" under conditions determined by the author. Most authors choose widely known"
-" open source licenses like the GPL or BSD licenses instead of making up "
-"their own."
+"The source code used to create an add-on is an exclusive copyright of the add-on author, unless otherwise declared in a source code license. Many add-ons on this site have <a href=\"%(url)s\" lang="
+"\"en\">open source licenses</a> that make the source code publicly available for copy and reuse under conditions determined by the author. Most authors choose widely known open source licenses like "
+"the GPL or BSD licenses instead of making up their own."
 msgstr ""
-"O código fonte usado para criar um complemento é um direito autoral "
-"exclusivo do autor do complemento, a não ser que seja declarado de outra "
-"maneira na licença do código-fonte. Muitos complementos neste site têm <a "
-"href=\"%(url)s\" lang=\"en\">licenças de código aberto</a> que deixam o "
-"código-fonte disponível publicamente para cópia e reutilização sob condições"
-" determinadas pelo autor. A maioria dos autores escolhem licenças de código "
-"aberto amplamente conhecidas, como as licenças GPL ou BSD, em vez de criar "
-"suas próprias."
+"O código fonte usado para criar um complemento é um direito autoral exclusivo do autor do complemento, a não ser que seja declarado de outra maneira na licença do código-fonte. Muitos complementos "
+"neste site têm <a href=\"%(url)s\" lang=\"en\">licenças de código aberto</a> que deixam o código-fonte disponível publicamente para cópia e reutilização sob condições determinadas pelo autor. A "
+"maioria dos autores escolhem licenças de código aberto amplamente conhecidas, como as licenças GPL ou BSD, em vez de criar suas próprias."
 
-#: src/olympia/pages/templates/pages/faq.html:256
+#: src/olympia/pages/templates/pages/faq.html:254
 #, python-format
-msgid ""
-"Firefox and other Mozilla software are <a href=\"%(url)s\">open source</a>."
-msgstr ""
-"O Firefox e outros programas Mozilla possuem <a href=\"%(url)s\">código "
-"aberto</a>."
+msgid "Firefox and other Mozilla software are <a href=\"%(url)s\">open source</a>."
+msgstr "O Firefox e outros programas Mozilla possuem <a href=\"%(url)s\">código aberto</a>."
 
-#: src/olympia/pages/templates/pages/faq.html:264
+#: src/olympia/pages/templates/pages/faq.html:262
 msgid "Collections and Favorites"
 msgstr "Coleções e Favoritos"
 
-#: src/olympia/pages/templates/pages/faq.html:267
+#: src/olympia/pages/templates/pages/faq.html:265
 msgid "What is a collection?"
 msgstr "O que é uma coleção?"
 
-#: src/olympia/pages/templates/pages/faq.html:268
+#: src/olympia/pages/templates/pages/faq.html:266
 msgid "Collections are groups of related add-ons created by users to share."
-msgstr ""
-"Coleções são grupos de complementos relacionados criadas pelos usuários para"
-" compartilhá-los."
+msgstr "Coleções são grupos de complementos relacionados criadas pelos usuários para compartilhá-los."
 
-#: src/olympia/pages/templates/pages/faq.html:270
+#: src/olympia/pages/templates/pages/faq.html:268
 msgid "What is the My Favorites collection?"
 msgstr "O que é a coleção Meus complementos favoritos?"
 
-#: src/olympia/pages/templates/pages/faq.html:271
-msgid ""
-"Favorite add-ons are add-ons that you have bookmarked to easily get back to "
-"later. You can add an add-on to your favorites collection by clicking \"Add "
-"to favorites\" on its details page."
+#: src/olympia/pages/templates/pages/faq.html:269
+msgid "Favorite add-ons are add-ons that you have bookmarked to easily get back to later. You can add an add-on to your favorites collection by clicking \"Add to favorites\" on its details page."
 msgstr ""
-"Complementos favoritos são aqueles que você marcou para poder encontrar "
-"facilmente mais tarde. Você pode adicionar um complemento à sua coleção de "
-"favoritos ao clicar em \"Adicionar aos favoritos\" na sua página de "
-"detalhes."
+"Complementos favoritos são aqueles que você marcou para poder encontrar facilmente mais tarde. Você pode adicionar um complemento à sua coleção de favoritos ao clicar em \"Adicionar aos favoritos\" "
+"na sua página de detalhes."
 
-#: src/olympia/pages/templates/pages/faq.html:275
-#: src/olympia/templates/menu_links.html:13
-#: src/olympia/templates/impala/header_title.html:17
+#: src/olympia/pages/templates/pages/faq.html:273 src/olympia/templates/menu_links.html:13 src/olympia/templates/impala/header_title.html:17
 msgid "Mobile Add-ons"
 msgstr "Complementos móveis"
 
-#: src/olympia/pages/templates/pages/faq.html:278
+#: src/olympia/pages/templates/pages/faq.html:276
 msgid "What are mobile add-ons?"
 msgstr "O que são complementos móveis?"
 
-#: src/olympia/pages/templates/pages/faq.html:279
+#: src/olympia/pages/templates/pages/faq.html:277
 #, python-format
 msgid ""
-"Mobile add-ons work with <a href=\"%(mobile_url)s\">Firefox for Mobile</a> "
-"and add or modify functionality just like desktop add-ons. You can find add-"
-"ons that work with Firefox for Mobile in our <a "
-"href=\"%(gallery_url)s\">gallery</a>."
+"Mobile add-ons work with <a href=\"%(mobile_url)s\">Firefox for Mobile</a> and add or modify functionality just like desktop add-ons. You can find add-ons that work with Firefox for Mobile in our "
+"<a href=\"%(gallery_url)s\">gallery</a>."
 msgstr ""
-"Os complementos móveis funcionam com o <a href=\"%(mobile_url)s\">Firefox "
-"Móvel</a> e adicionam ou modificam funcionalidades exatamente como os "
-"complementos normais. Você pode encontrar complementos para o Firefox Móvel "
-"em nossa <a href=\"%(gallery_url)s\">galeria</a>."
+"Os complementos móveis funcionam com o <a href=\"%(mobile_url)s\">Firefox Móvel</a> e adicionam ou modificam funcionalidades exatamente como os complementos normais. Você pode encontrar "
+"complementos para o Firefox Móvel em nossa <a href=\"%(gallery_url)s\">galeria</a>."
 
-#: src/olympia/pages/templates/pages/faq.html:288
+#: src/olympia/pages/templates/pages/faq.html:286
 msgid "Developer Topics"
 msgstr "Tópicos de desenvolvimento"
 
-#: src/olympia/pages/templates/pages/faq.html:289
+#: src/olympia/pages/templates/pages/faq.html:287
 #, python-format
-msgid ""
-"Please see our <a href=\"%(faq_url)s\">Developer FAQ</a> and <a "
-"href=\"%(hub_url)s\">Developer Hub</a> for answers to add-on developer-"
-"related questions."
+msgid "Please see our <a href=\"%(faq_url)s\">Developer FAQ</a> and <a href=\"%(hub_url)s\">Developer Hub</a> for answers to add-on developer-related questions."
 msgstr ""
-"Por favor, leia nossas <a href=\"%(faq_url)s\">Dúvidas comuns do "
-"desenvolvedor</a> e a <a href=\"%(hub_url)s\">Central do Desenvolvedor</a> "
-"para respostas sobre questões relacionados ao desenvolvimento de "
-"complementos."
+"Por favor, leia nossas <a href=\"%(faq_url)s\">Dúvidas comuns do desenvolvedor</a> e a <a href=\"%(hub_url)s\">Central do Desenvolvedor</a> para respostas sobre questões relacionados ao "
+"desenvolvimento de complementos."
 
-#: src/olympia/pages/templates/pages/faq.html:294
+#: src/olympia/pages/templates/pages/faq.html:292
 msgid "Still have questions?"
 msgstr "Ainda tem dúvidas?"
 
-#: src/olympia/pages/templates/pages/faq.html:295
+#: src/olympia/pages/templates/pages/faq.html:293
 #, python-format
-msgid ""
-"For general Firefox support, visit our <a href=\"%(sumo_url)s\">support "
-"website</a>. For general add-on and website questions, visit our <a "
-"href=\"%(forum_url)s\">forum</a>."
+msgid "For general Firefox support, visit our <a href=\"%(sumo_url)s\">support website</a>. For general add-on and website questions, visit our <a href=\"%(forum_url)s\">forum</a>."
 msgstr ""
-"Para suporte geral do Firefox, visite nosso <a href=\"%(sumo_url)s\">site de"
-" suporte</a>. Para questões gerais sobre os complementos e sobre o site, "
-"visite nosso <a href=\"%(forum_url)s\">fórum</a>."
+"Para suporte geral do Firefox, visite nosso <a href=\"%(sumo_url)s\">site de suporte</a>. Para questões gerais sobre os complementos e sobre o site, visite nosso <a href=\"%(forum_url)s\">fórum</a>."
 
-#: src/olympia/pages/templates/pages/review_guide.html:36
-#: src/olympia/pages/templates/pages/review_guide.html:51
+#: src/olympia/pages/templates/pages/review_guide.html:36 src/olympia/pages/templates/pages/review_guide.html:51
 msgid "Some tips for writing a great review"
 msgstr "Algumas dicas para escrever uma excelente análise"
 
-#: src/olympia/pages/templates/pages/review_guide.html:39
-#: src/olympia/pages/templates/pages/review_guide.html:131
+#: src/olympia/pages/templates/pages/review_guide.html:39 src/olympia/pages/templates/pages/review_guide.html:131
 msgid "Frequently Asked Questions about Reviews"
 msgstr "Dúvidas comuns sobre análises"
 
 #: src/olympia/pages/templates/pages/review_guide.html:46
 msgid ""
-"Add-on reviews are a way for you to share your opinions about the add-ons "
-"you’ve installed and used. Our review moderation team reserves the right to "
-"refuse or remove any review that does not comply with these guidelines."
+"Add-on reviews are a way for you to share your opinions about the add-ons you’ve installed and used. Our review moderation team reserves the right to refuse or remove any review that does not "
+"comply with these guidelines."
 msgstr ""
-"Revisões de complementos são uma forma de compartilhar as suas opiniões "
-"sobre os complementos que instalou e usou. A nossa equipe de moderação "
-"reserva o direito de recusar ou de remover qualquer análise que não cumpra "
-"com estas diretrizes."
+"Revisões de complementos são uma forma de compartilhar as suas opiniões sobre os complementos que instalou e usou. A nossa equipe de moderação reserva o direito de recusar ou de remover qualquer "
+"análise que não cumpra com estas diretrizes."
 
 #: src/olympia/pages/templates/pages/review_guide.html:53
 msgid "Do:"
 msgstr "O que fazer:"
 
 #: src/olympia/pages/templates/pages/review_guide.html:56
-msgid ""
-"Write like you are telling a friend about your experience with the add-on."
-msgstr ""
-"Escreva como se estivesse contando a um amigo sobre a sua experiência com o "
-"complemento."
+msgid "Write like you are telling a friend about your experience with the add-on."
+msgstr "Escreva como se estivesse contando a um amigo sobre a sua experiência com o complemento."
 
 #: src/olympia/pages/templates/pages/review_guide.html:61
 msgid "Keep reviews concise and easy to understand."
@@ -13833,11 +10876,8 @@ msgid "Will you continue to use this add-on?"
 msgstr "Você continuará usando esse complemento?"
 
 #: src/olympia/pages/templates/pages/review_guide.html:73
-msgid ""
-"Take a moment to read your review before submitting it to minimize typos."
-msgstr ""
-"Leia novamente a sua revisão antes de enviá-la para minimizar erros "
-"ortográficos."
+msgid "Take a moment to read your review before submitting it to minimize typos."
+msgstr "Leia novamente a sua revisão antes de enviá-la para minimizar erros ortográficos."
 
 #: src/olympia/pages/templates/pages/review_guide.html:79
 msgid "Don’t:"
@@ -13845,73 +10885,47 @@ msgstr "O que não fazer:"
 
 #: src/olympia/pages/templates/pages/review_guide.html:82
 msgid "Submit one-word reviews such as \"Great!\", \"wonderful,\" or \"bad.\""
-msgstr ""
-"Enviar análises com uma palavra, tais como \"Ótimo!\", \"maravilhoso\" ou "
-"\"ruim\"."
+msgstr "Enviar análises com uma palavra, tais como \"Ótimo!\", \"maravilhoso\" ou \"ruim\"."
 
 #: src/olympia/pages/templates/pages/review_guide.html:87
 msgid ""
-"Post technical issues, support requests, or feature suggestions. Use the "
-"available support options for each add-on, if available. You can find them "
-"in the side column next to the About this Add-on section."
+"Post technical issues, support requests, or feature suggestions. Use the available support options for each add-on, if available. You can find them in the side column next to the About this Add-on "
+"section."
 msgstr ""
-"Colocar problemas técnico, pedidos de suporte ou sugestões de "
-"funcionalidades. Use as opções de suporte disponíveis para cada complemento,"
-" se disponíveis. Pode encontrá-las na coluna lateral perto da seção Sobre "
-"este complemento."
+"Colocar problemas técnico, pedidos de suporte ou sugestões de funcionalidades. Use as opções de suporte disponíveis para cada complemento, se disponíveis. Pode encontrá-las na coluna lateral perto "
+"da seção Sobre este complemento."
 
 #: src/olympia/pages/templates/pages/review_guide.html:92
 msgid "Write reviews for add-ons which you have not personally used."
 msgstr "Não escreva análises para complementos que você nunca chegou a usar."
 
 #: src/olympia/pages/templates/pages/review_guide.html:97
-msgid ""
-"Use profanity, sexual language or language that can be construed as hateful."
-msgstr ""
-"Não use linguagem inadequada, de conteúdo sexual ou que pode ser considerada"
-" odiosa."
+msgid "Use profanity, sexual language or language that can be construed as hateful."
+msgstr "Não use linguagem inadequada, de conteúdo sexual ou que pode ser considerada odiosa."
 
 #: src/olympia/pages/templates/pages/review_guide.html:103
-msgid ""
-"Include HTML, links, source code or code snippets. Reviews are meant to be "
-"text only."
-msgstr ""
-"Incluir HTML, links, código fonte ou partes de código. As análises devem ser"
-" apenas texto."
+msgid "Include HTML, links, source code or code snippets. Reviews are meant to be text only."
+msgstr "Incluir HTML, links, código fonte ou partes de código. As análises devem ser apenas texto."
 
 #: src/olympia/pages/templates/pages/review_guide.html:108
-msgid ""
-"Make false statements, disparage add-on authors or personally insult them."
-msgstr ""
-"Não faça afirmações falsas, deprecie os autores do complemento ou os insulte"
-" pessoalmente."
+msgid "Make false statements, disparage add-on authors or personally insult them."
+msgstr "Não faça afirmações falsas, deprecie os autores do complemento ou os insulte pessoalmente."
 
 #: src/olympia/pages/templates/pages/review_guide.html:114
-msgid ""
-"Include your own or anyone else’s email, phone number, or other personal "
-"details."
-msgstr ""
-"Incluir o seu e-mail, telefone ou quaisquer outros dados ou os de qualquer "
-"outra pessoa."
+msgid "Include your own or anyone else’s email, phone number, or other personal details."
+msgstr "Incluir o seu e-mail, telefone ou quaisquer outros dados ou os de qualquer outra pessoa."
 
 #: src/olympia/pages/templates/pages/review_guide.html:119
-msgid ""
-"Post reviews for an add-on you or your organization wrote or represent."
-msgstr ""
-"Não poste análises para um complemento que você ou sua organização criou ou "
-"representa."
+msgid "Post reviews for an add-on you or your organization wrote or represent."
+msgstr "Não poste análises para um complemento que você ou sua organização criou ou representa."
 
 #: src/olympia/pages/templates/pages/review_guide.html:125
 msgid ""
-"Criticize an add-on for something it’s intended to do. For example, leaving "
-"a negative review of an add-on for displaying ads or requiring data "
-"gathering, when that is the intended purpose of the add-on, or the add-on "
-"requires gathering data to function."
+"Criticize an add-on for something it’s intended to do. For example, leaving a negative review of an add-on for displaying ads or requiring data gathering, when that is the intended purpose of the "
+"add-on, or the add-on requires gathering data to function."
 msgstr ""
-"Criticar um complemento por algo que é suposto fazer. Por exemplo, deixar "
-"uma análise negativa de um complemento por mostrar complementos ou "
-"necessitar de recolher dados, quando este é o objetivo do complemento ou se "
-"o complemento necessita de recolher dados para funcionar."
+"Criticar um complemento por algo que é suposto fazer. Por exemplo, deixar uma análise negativa de um complemento por mostrar complementos ou necessitar de recolher dados, quando este é o objetivo "
+"do complemento ou se o complemento necessita de recolher dados para funcionar."
 
 #: src/olympia/pages/templates/pages/review_guide.html:133
 msgid "How can I report a problematic review?"
@@ -13919,15 +10933,11 @@ msgstr "Como eu posso denunciar uma análise problemática?"
 
 #: src/olympia/pages/templates/pages/review_guide.html:135
 msgid ""
-"Please report or flag any questionable reviews by clicking the \"Report this"
-" review\" and it will be submitted to the site for moderation. Our "
-"moderation team will use the Review Guidelines to evaluate whether or not to"
-" delete the review or restore it back to the site."
+"Please report or flag any questionable reviews by clicking the \"Report this review\" and it will be submitted to the site for moderation. Our moderation team will use the Review Guidelines to "
+"evaluate whether or not to delete the review or restore it back to the site."
 msgstr ""
-"Por favor, denuncie ou reporte quaisquer análises questionáveis clicando em "
-"\"Reportar esta análise\" e esta será submetida ao site para moderação. "
-"Nossa equipe de moderação irá usar as linhas orientadoras da revisão para "
-"avaliar se a análise deve ser excluída ou reposta no site."
+"Por favor, denuncie ou reporte quaisquer análises questionáveis clicando em \"Reportar esta análise\" e esta será submetida ao site para moderação. Nossa equipe de moderação irá usar as linhas "
+"orientadoras da revisão para avaliar se a análise deve ser excluída ou reposta no site."
 
 #: src/olympia/pages/templates/pages/review_guide.html:140
 msgid "I’m an add-on author, can I respond to reviews?"
@@ -13935,35 +10945,20 @@ msgstr "Eu sou um autor de complementos, eu posso responder análises?"
 
 #: src/olympia/pages/templates/pages/review_guide.html:142
 #, python-format
-msgid ""
-"Yes, add-on authors can provide a single response to a review. You can set "
-"up a discussion topic in our <a href=\"%(forum_url)s\">forum</a> to engage "
-"in additional discussion or follow-up."
-msgstr ""
-"Sim, os autores de um extra podem fornecer uma única reposta a uma análise. "
-"Pode definir o tópico de discussão no nosso <a "
-"href=\"%(forum_url)s\">fórum</a> para continuar a discussão."
+msgid "Yes, add-on authors can provide a single response to a review. You can set up a discussion topic in our <a href=\"%(forum_url)s\">forum</a> to engage in additional discussion or follow-up."
+msgstr "Sim, os autores de um extra podem fornecer uma única reposta a uma análise. Pode definir o tópico de discussão no nosso <a href=\"%(forum_url)s\">fórum</a> para continuar a discussão."
 
 #: src/olympia/pages/templates/pages/review_guide.html:149
 msgid "I’m an add-on author, can I delete unfavorable reviews or ratings?"
-msgstr ""
-"Eu sou um autor de complemento, eu posso excluir análises ou avaliações "
-"desfavoráveis?"
+msgstr "Eu sou um autor de complemento, eu posso excluir análises ou avaliações desfavoráveis?"
 
 #: src/olympia/pages/templates/pages/review_guide.html:151
 msgid ""
-"In general, no. But if the review did not meet the review guidelines "
-"outlined above, you can click \"Report this review\" and have it moderated. "
-"If a review included a complaint that is no longer valid due to a new "
-"release of your add-on, we may consider deleting the review. Submit your "
-"detailed request to amo-editors@mozilla.org."
+"In general, no. But if the review did not meet the review guidelines outlined above, you can click \"Report this review\" and have it moderated. If a review included a complaint that is no longer "
+"valid due to a new release of your add-on, we may consider deleting the review. Submit your detailed request to amo-editors@mozilla.org."
 msgstr ""
-"No geral, não. Ma se análise não cumprir com as linhas orientadoras da "
-"revisão descritas em cima, pode clicar em \"reportar esta análise\" para que"
-" a mesma seja moderada. Se uma análise tiver uma reclamação que já não seja "
-"válida devido ao lançamento de uma nova versão do complemento, podemos "
-"considerar apagar a análise. Envie o pedido detalhado para amo-"
-"editors@mozilla.org."
+"No geral, não. Ma se análise não cumprir com as linhas orientadoras da revisão descritas em cima, pode clicar em \"reportar esta análise\" para que a mesma seja moderada. Se uma análise tiver uma "
+"reclamação que já não seja válida devido ao lançamento de uma nova versão do complemento, podemos considerar apagar a análise. Envie o pedido detalhado para amo-editors@mozilla.org."
 
 #: src/olympia/pages/templates/pages/sunbird.html:26
 msgid "Sunbird has retired"
@@ -13971,24 +10966,16 @@ msgstr "O Sunbird se aposentou"
 
 #: src/olympia/pages/templates/pages/sunbird.html:29
 msgid ""
-"Development on the Sunbird project has halted and its final release was on "
-"March 30, 2010.  We've been proud to host Sunbird add-ons on this site but "
-"as the project is no longer maintained we have disabled our support for the "
-"add-ons."
+"Development on the Sunbird project has halted and its final release was on March 30, 2010. We've been proud to host Sunbird add-ons on this site but as the project is no longer maintained we have "
+"disabled our support for the add-ons."
 msgstr ""
-"O desenvolvimento do projeto Sunbird cessou e a versão final foi "
-"disponibilizada em 30 de março de 2010.  Nos orgulhamos de ter hospedado "
-"complementos do Sunbird neste site mas devido ao projeto não ser mais "
-"mantido desativamos o suporte a estes complementos."
+"O desenvolvimento do projeto Sunbird cessou e a versão final foi disponibilizada em 30 de março de 2010.  Nos orgulhamos de ter hospedado complementos do Sunbird neste site mas devido ao projeto "
+"não ser mais mantido desativamos o suporte a estes complementos."
 
 #: src/olympia/pages/templates/pages/sunbird.html:38
 #, python-format
-msgid ""
-"We recommend upgrading to <a href=\"%(tb_url)s\">Thunderbird</a> and <a "
-"href=\"%(lightning_url)s\">Lightning</a>."
-msgstr ""
-"Nós recomendamos migrar para o <a href=\"%(tb_url)s\">Thunderbird</a> e <a "
-"href=\"%(lightning_url)s\">Lightning</a>."
+msgid "We recommend upgrading to <a href=\"%(tb_url)s\">Thunderbird</a> and <a href=\"%(lightning_url)s\">Lightning</a>."
+msgstr "Nós recomendamos migrar para o <a href=\"%(tb_url)s\">Thunderbird</a> e <a href=\"%(lightning_url)s\">Lightning</a>."
 
 #: src/olympia/pages/templates/pages/sunbird.html:45
 msgid "Read more about Sunbird"
@@ -13996,9 +10983,7 @@ msgstr "Saiba mais sobre o Sunbird"
 
 #: src/olympia/paypal/__init__.py:25
 msgid "There was an error communicating with PayPal. Please try again later."
-msgstr ""
-"Houve um erro ao comunicar-se com o PayPal. Por favor, tente novamente mais "
-"tarde."
+msgstr "Houve um erro ao comunicar-se com o PayPal. Por favor, tente novamente mais tarde."
 
 #: src/olympia/paypal/__init__.py:50
 msgid "There was an error with this currency."
@@ -14028,8 +11013,8 @@ msgstr "Análises de %s"
 msgid "Review History for this Addon"
 msgstr "Histórico de análises desse complemento"
 
-#. L10n: This describes the number of stars given out of 5
 # %1 is the number of stars this add-on has
+#. L10n: This describes the number of stars given out of 5
 #: src/olympia/reviews/feeds.py:49
 #, python-format
 msgid "Rated %d out of 5 stars"
@@ -14043,8 +11028,7 @@ msgstr "Manter análise; remover denúncias"
 msgid "Skip for now"
 msgstr "Ignorar por enquanto"
 
-#: src/olympia/reviews/forms.py:151
-#: src/olympia/reviews/templates/reviews/review.html:107
+#: src/olympia/reviews/forms.py:151 src/olympia/reviews/templates/reviews/review.html:107
 msgid "Delete review"
 msgstr "Excluir análise"
 
@@ -14064,42 +11048,25 @@ msgstr "Adicionar uma análise de {0}"
 #: src/olympia/reviews/templates/reviews/add.html:26
 #, python-format
 msgid ""
-"<h2>Keep these tips in mind:</h2> <ul> <li> Write like you're telling a "
-"friend about your experience with the add-on. Give specifics and helpful "
-"details, such as what features you liked and/or disliked, how easy to use it"
-" is, and any disadvantages it has.  Avoid generic language such as calling "
-"it \"Great\" or \"Bad\" unless you can give reasons why you believe this is "
-"so. </li> <li> Please do not post bug reports in reviews. We do not make "
-"your email address available to add-on developers and they may need to "
-"contact you to help resolve your issue. See the <a "
-"href=\"%(support)s\">support section</a> to find out where to get assistance"
-" for this add-on. </li> <li>Please keep reviews clean, avoid the use of "
-"improper language and do not post any personal information. </li> </ul> "
-"<p>Please read the <a href=\"%(guide)s\" target=\"_blank\">Review "
-"Guidelines</a> for more detail about user add-on reviews.</p>"
+"<h2>Keep these tips in mind:</h2> <ul> <li> Write like you're telling a friend about your experience with the add-on. Give specifics and helpful details, such as what features you liked and/or "
+"disliked, how easy to use it is, and any disadvantages it has. Avoid generic language such as calling it \"Great\" or \"Bad\" unless you can give reasons why you believe this is so. </li> <li> "
+"Please do not post bug reports in reviews. We do not make your email address available to add-on developers and they may need to contact you to help resolve your issue. See the <a href=\"%(support)s"
+"\">support section</a> to find out where to get assistance for this add-on. </li> <li>Please keep reviews clean, avoid the use of improper language and do not post any personal information. </li> </"
+"ul> <p>Please read the <a href=\"%(guide)s\" target=\"_blank\">Review Guidelines</a> for more detail about user add-on reviews.</p>"
 msgstr ""
-"<h2>Mantenha estas dicas em mente:</h2> <ul> <li> Escreva como se você "
-"estivesse contando a um amigo sobre suas experiências com o complemento. Dê "
-"detalhes específicos e úteis, tais como quais características você gostou ou"
-" não, quão fácil é usar o complemento e qualquer desvantagem que ele tenha. "
-"Evite usar linguagem genérica como “Legal” ou “Ruim” a menos que você dê as "
-"razões para achar isso. </li> <li> Por favor não coloque relatos de bugs nas"
-" avaliações. Nós não disponibilizamos o seu endereço de e-mail para os "
-"desenvolvedores e provavelmente eles precisarão entrar em contato com você "
-"para resolver o problema. Veja a href=\"%(support)s\">seção de suporte</a> "
-"para saber onde encontrar assistência para usar este complemento. </li> <li>"
-" Por favor mantenha as avaliações limpas, evite usar linguagem imprópria e "
-"não publique nenhuma informação pessoal. </li> <li> Por favor leia o <a "
-"href=\"%(guide)s\" target=\"_blank\">Guia de Avaliações</a> para obter mais "
-"detalhes sobre as avaliações de complementos feitas por usuários.</p>"
+"<h2>Mantenha estas dicas em mente:</h2> <ul> <li> Escreva como se você estivesse contando a um amigo sobre suas experiências com o complemento. Dê detalhes específicos e úteis, tais como quais "
+"características você gostou ou não, quão fácil é usar o complemento e qualquer desvantagem que ele tenha. Evite usar linguagem genérica como “Legal” ou “Ruim” a menos que você dê as razões para "
+"achar isso. </li> <li> Por favor não coloque relatos de bugs nas avaliações. Nós não disponibilizamos o seu endereço de e-mail para os desenvolvedores e provavelmente eles precisarão entrar em "
+"contato com você para resolver o problema. Veja a href=\"%(support)s\">seção de suporte</a> para saber onde encontrar assistência para usar este complemento. </li> <li> Por favor mantenha as "
+"avaliações limpas, evite usar linguagem imprópria e não publique nenhuma informação pessoal. </li> <li> Por favor leia o <a href=\"%(guide)s\" target=\"_blank\">Guia de Avaliações</a> para obter "
+"mais detalhes sobre as avaliações de complementos feitas por usuários.</p>"
 
 #: src/olympia/reviews/templates/reviews/reply.html:4
 msgid "Reply to review by {0}"
 msgstr "Resposta da análise por {0}"
 
 # a noun: shown in an add-on's editor review history
-#: src/olympia/reviews/templates/reviews/reply.html:15
-#: src/olympia/reviews/templates/reviews/reply.html:31
+#: src/olympia/reviews/templates/reviews/reply.html:15 src/olympia/reviews/templates/reviews/reply.html:31
 msgid "Reply"
 msgstr "Responder"
 
@@ -14108,8 +11075,7 @@ msgstr "Responder"
 msgid "Write a Reply"
 msgstr "Escrever resposta"
 
-#: src/olympia/reviews/templates/reviews/reply.html:36
-#: src/olympia/reviews/templates/reviews/report_review.html:12
+#: src/olympia/reviews/templates/reviews/reply.html:36 src/olympia/reviews/templates/reviews/report_review.html:12
 msgid "Submit"
 msgstr "Enviar"
 
@@ -14130,34 +11096,21 @@ msgid "by %(user)s <b>(Developer)</b> on %(date)s"
 msgstr "por %(user)s <b>(Desenvolvedor)</b> em %(date)s"
 
 #. {0} is a version number (like 1.01)
-#: src/olympia/reviews/templates/reviews/review.html:50
-#: src/olympia/reviews/templates/reviews/mobile/review_list.html:41
+#: src/olympia/reviews/templates/reviews/review.html:50 src/olympia/reviews/templates/reviews/mobile/review_list.html:41
 msgid "This review is for a previous version of the add-on ({0})."
 msgstr "Essa avaliação é para um versão anterior do complemento ({0})."
 
 #: src/olympia/reviews/templates/reviews/review.html:56
 #, python-format
-msgid ""
-"This user has a <a href=\"%(user_review_url)s\">previous review</a> of this "
-"add-on."
-msgid_plural ""
-"This user has <a href=\"%(user_review_url)s\">%(cnt)s previous reviews</a> "
-"of this add-on."
-msgstr[0] ""
-"Esse usuário tem uma <a href=\"%(user_review_url)s\">análise anterior</a> "
-"desse complemento."
-msgstr[1] ""
-"Esse usuário tem <a href=\"%(user_review_url)s\">%(cnt)s análises "
-"anteriores</a> desse complemento."
+msgid "This user has a <a href=\"%(user_review_url)s\">previous review</a> of this add-on."
+msgid_plural "This user has <a href=\"%(user_review_url)s\">%(cnt)s previous reviews</a> of this add-on."
+msgstr[0] "Esse usuário tem uma <a href=\"%(user_review_url)s\">análise anterior</a> desse complemento."
+msgstr[1] "Esse usuário tem <a href=\"%(user_review_url)s\">%(cnt)s análises anteriores</a> desse complemento."
 
 #: src/olympia/reviews/templates/reviews/review.html:62
 #, python-format
-msgid ""
-"This user has <a href=\"%(user_review_url)s\">other reviews</a> of this add-"
-"on."
-msgstr ""
-"Esse usuário tem <a href=\"%(user_review_url)s\">outras análises</a> desse "
-"complemento."
+msgid "This user has <a href=\"%(user_review_url)s\">other reviews</a> of this add-on."
+msgstr "Esse usuário tem <a href=\"%(user_review_url)s\">outras análises</a> desse complemento."
 
 #: src/olympia/reviews/templates/reviews/review.html:72
 msgid "Flagged for review"
@@ -14183,22 +11136,20 @@ msgstr "Editar análise"
 msgid "Delete reply"
 msgstr "Excluir resposta"
 
-#. {0} is an add-on name.
 # "My" in this context is the logged in user who is reading the page
+#. {0} is an add-on name.
 #: src/olympia/reviews/templates/reviews/review_list.html:5
 msgid "{0} :: Reviews"
 msgstr "{0} :: Análises"
 
-#. {0} is an addon name.
 # %1 is the add-on name
-#: src/olympia/reviews/templates/reviews/review_list.html:24
-#: src/olympia/reviews/templates/reviews/mobile/add.html:4
-#: src/olympia/reviews/templates/reviews/mobile/review_list.html:4
+#. {0} is an addon name.
+#: src/olympia/reviews/templates/reviews/review_list.html:24 src/olympia/reviews/templates/reviews/mobile/add.html:4 src/olympia/reviews/templates/reviews/mobile/review_list.html:4
 msgid "Reviews for {0}"
 msgstr "Análises de {0}"
 
-#. {0} is a number.
 # %1 is a number.
+#. {0} is a number.
 #: src/olympia/reviews/templates/reviews/review_list.html:27
 msgid "<b>{0}</b> review for this add-on"
 msgid_plural "<b>{0}</b> reviews for this add-on"
@@ -14230,8 +11181,7 @@ msgstr "<strong>Média</strong> (%(total)s)"
 msgid "Write a New Review"
 msgstr "Escrever uma análise nova"
 
-#: src/olympia/reviews/templates/reviews/review_list.html:81
-#: src/olympia/reviews/templates/reviews/mobile/reviews_link.html:15
+#: src/olympia/reviews/templates/reviews/review_list.html:81 src/olympia/reviews/templates/reviews/mobile/reviews_link.html:15
 msgid "Be the first to write a review."
 msgstr "Seja o primeiro a escrever uma análise."
 
@@ -14250,8 +11200,7 @@ msgstr "Avaliado em {0} de 5 estrelas"
 msgid "Rated %(rating)s out of 5 stars"
 msgstr "Avaliado em %(rating)s de 5 estrelas"
 
-#: src/olympia/reviews/templates/reviews/mobile/add_form.html:3
-#: src/olympia/reviews/templates/reviews/mobile/add_form.html:8
+#: src/olympia/reviews/templates/reviews/mobile/add_form.html:3 src/olympia/reviews/templates/reviews/mobile/add_form.html:8
 msgid "Add a Review"
 msgstr "Adicionar uma análise"
 
@@ -14323,11 +11272,8 @@ msgid "Relevance"
 msgstr "Relevância"
 
 #: src/olympia/search/helpers.py:24
-msgid ""
-"Results <strong>{0}</strong>-<strong>{1}</strong> of <strong>{2}</strong>"
-msgstr ""
-"Resultados <strong>{0}</strong> a <strong>{1}</strong> de "
-"<strong>{2}</strong>"
+msgid "Results <strong>{0}</strong>-<strong>{1}</strong> of <strong>{2}</strong>"
+msgstr "Resultados <strong>{0}</strong> a <strong>{1}</strong> de <strong>{2}</strong>"
 
 # {0} is a number
 # {1} is a number
@@ -14335,12 +11281,8 @@ msgstr ""
 # {3} is the word the person is searching for
 # {4} is a word (the add-on is tagged with it)
 #: src/olympia/search/helpers.py:44
-msgid ""
-"Showing {0} - {1} of {2} results for <strong>{3}</strong> tagged with "
-"<strong>{4}</strong>"
-msgstr ""
-"Exibindo resultados {0} a {1} de {2} com <strong>{3}</strong> e com a "
-"etiqueta <strong>{4}</strong>"
+msgid "Showing {0} - {1} of {2} results for <strong>{3}</strong> tagged with <strong>{4}</strong>"
+msgstr "Exibindo resultados {0} a {1} de {2} com <strong>{3}</strong> e com a etiqueta <strong>{4}</strong>"
 
 # {0} is a number
 # {1} is a number
@@ -14356,8 +11298,7 @@ msgstr "Exibindo resultados {0} a {1} de {2} com <strong>{3}</strong>"
 # {3} is a word (the add-on is tagged with it)
 #: src/olympia/search/helpers.py:52
 msgid "Showing {0} - {1} of {2} results tagged with <strong>{3}</strong>"
-msgstr ""
-"Exibindo resultados {0} a {1} de {2} com a etiqueta <strong>{3}</strong>"
+msgstr "Exibindo resultados {0} a {1} de {2} com a etiqueta <strong>{3}</strong>"
 
 # {0} is a number
 # {1} is a number
@@ -14367,24 +11308,22 @@ msgid "Showing {0} - {1} of {2} results"
 msgstr "Exibindo resultados {0} a {1} de {2}"
 
 #. {0} is an application, like Firefox.
-#: src/olympia/search/views.py:264 src/olympia/templates/base.html:17
-#: src/olympia/templates/impala/base.html:17
-#: src/olympia/templates/mobile/base_addons.html:17
+#: src/olympia/search/views.py:264 src/olympia/templates/base.html:17 src/olympia/templates/impala/base.html:17 src/olympia/templates/mobile/base_addons.html:17
 msgid "{0} Add-ons"
 msgstr "Complementos para o {0}"
 
 #. L10n: {0} is an application, such as Firefox. This means "any version of
 #. Firefox."
-#: src/olympia/search/views.py:554
+#: src/olympia/search/views.py:547
 msgid "Any {0}"
 msgstr "Qualquer {0}"
 
 #. L10n: "All Systems" means show everything regardless of platform.
-#: src/olympia/search/views.py:589
+#: src/olympia/search/views.py:582
 msgid "All Systems"
 msgstr "Todos os sistemas"
 
-#: src/olympia/search/views.py:600
+#: src/olympia/search/views.py:593
 msgid "All Tags"
 msgstr "Todas as etiquetas"
 
@@ -14403,9 +11342,7 @@ msgstr "Pesquisa indisponível"
 
 #: src/olympia/search/templates/search/down.html:6
 msgid "Search is temporarily unavailable. Please try again in a few minutes."
-msgstr ""
-"A pesquisa está temporariamente indisponível. Por favor, tente novamente em "
-"alguns minutos."
+msgstr "A pesquisa está temporariamente indisponível. Por favor, tente novamente em alguns minutos."
 
 #. {0} is the string the user was searching for
 #: src/olympia/search/templates/search/personas.html:9
@@ -14560,36 +11497,31 @@ msgstr "Compartilhar esse complemento"
 msgid "Share this Collection"
 msgstr "Compartilhar essa coleção"
 
-#: src/olympia/signing/views.py:30 src/olympia/templates/base.html:75
-#: src/olympia/templates/impala/base.html:115
-msgid ""
-"Some features are temporarily disabled while we perform website maintenance."
-" We'll be back to full capacity shortly."
-msgstr ""
-"Alguns recursos foram temporariamente desativados para realizamos a "
-"manutenção do site. Em breve estaremos de volta a plena capacidade."
+#: src/olympia/signing/views.py:33 src/olympia/templates/base.html:71 src/olympia/templates/impala/base.html:112
+msgid "Some features are temporarily disabled while we perform website maintenance. We'll be back to full capacity shortly."
+msgstr "Alguns recursos foram temporariamente desativados para realizamos a manutenção do site. Em breve estaremos de volta a plena capacidade."
 
-#: src/olympia/signing/views.py:53
+#: src/olympia/signing/views.py:56
 msgid "Could not find add-on with id \"{}\"."
 msgstr "Não foi possível encontrar o complemento com o id \"{}\"."
 
-#: src/olympia/signing/views.py:67
+#: src/olympia/signing/views.py:70
 msgid "You do not own this addon."
 msgstr "Você não possui este complemento."
 
-#: src/olympia/signing/views.py:82
+#: src/olympia/signing/views.py:87
 msgid "Missing \"upload\" key in multipart file data."
 msgstr "Chave \"upload\" em falta nos dados multi-parte do arquivo."
 
-#: src/olympia/signing/views.py:96
+#: src/olympia/signing/views.py:101
 msgid "Version does not match the manifest file."
 msgstr "A versão não corresponde ao arquivo manifest."
 
-#: src/olympia/signing/views.py:100
+#: src/olympia/signing/views.py:105
 msgid "Version already exists."
 msgstr "Versão já existente."
 
-#: src/olympia/signing/views.py:136
+#: src/olympia/signing/views.py:141
 msgid "No uploaded file for that addon and version."
 msgstr "Nenhum arquivo carregado para este complemento e versão."
 
@@ -14681,8 +11613,7 @@ msgstr "De"
 msgid "To"
 msgstr "Para"
 
-#: src/olympia/stats/templates/stats/popup.html:27
-#: src/olympia/users/templates/users/pwreset_confirm.html:38
+#: src/olympia/stats/templates/stats/popup.html:27 src/olympia/users/templates/users/pwreset_confirm.html:38
 msgid "Update"
 msgstr "Atualizar"
 
@@ -14703,98 +11634,91 @@ msgstr "{0} :: Painel de estatísticas"
 msgid "Statistics Dashboard :: Add-ons for {0}"
 msgstr "Painel de estatísticas :: Complementos para o {0}"
 
-#: src/olympia/stats/templates/stats/stats.html:30
-msgid "Controls:"
-msgstr "Controles:"
-
-#: src/olympia/stats/templates/stats/stats.html:33
-msgid "reset zoom"
-msgstr "restaurar escala"
-
-#: src/olympia/stats/templates/stats/stats.html:40
-msgid "Group by:"
-msgstr "Agrupar por:"
-
-#: src/olympia/stats/templates/stats/stats.html:42
-msgid "day"
-msgstr "dia"
-
-#: src/olympia/stats/templates/stats/stats.html:45
-msgid "week"
-msgstr "semana"
-
-#: src/olympia/stats/templates/stats/stats.html:48
-msgid "month"
-msgstr "mês"
-
-#: src/olympia/stats/templates/stats/stats.html:54
-msgid "For last:"
-msgstr "Exibir últimos:"
-
-#: src/olympia/stats/templates/stats/stats.html:57
-msgid "7 days"
-msgstr "7 dias"
-
-#: src/olympia/stats/templates/stats/stats.html:60
-msgid "30 days"
-msgstr "30 dias"
-
-#: src/olympia/stats/templates/stats/stats.html:63
-msgid "90 days"
-msgstr "90 dias"
-
-#: src/olympia/stats/templates/stats/stats.html:66
-msgid "365 days"
-msgstr "365 dias"
-
-#: src/olympia/stats/templates/stats/stats.html:69
-msgid "Custom..."
-msgstr "Personalizar..."
-
 #. {0} is an add-on name
-#: src/olympia/stats/templates/stats/stats.html:88
-#: src/olympia/stats/templates/stats/stats.html:91
+#: src/olympia/stats/templates/stats/stats.html:44 src/olympia/stats/templates/stats/stats.html:47
 msgid "Statistics for {0}"
 msgstr "Estatísticas de {0}"
 
-#: src/olympia/stats/templates/stats/stats.html:94
+#: src/olympia/stats/templates/stats/stats.html:50
 msgid "Statistics Dashboard"
 msgstr "Painel de estatísticas"
 
-#: src/olympia/stats/templates/stats/stats.html:104
-msgid ""
-"Statistics processing is currently disabled, so recent data is unavailable. "
-"The statistics are still being collected and this page will be updated soon "
-"with the missing data."
-msgstr ""
-"O processamento de estatísticas está desabilitado no momento, então, dados "
-"recentes não estão disponíveis. As estatísticas ainda estão sendo coletadas "
-"e esta página será atualizada em breve com os dados em falta."
+#: src/olympia/stats/templates/stats/stats.html:57
+msgid "Controls:"
+msgstr "Controles:"
 
-#: src/olympia/stats/templates/stats/stats.html:110
+#: src/olympia/stats/templates/stats/stats.html:60
+msgid "reset zoom"
+msgstr "restaurar escala"
+
+#: src/olympia/stats/templates/stats/stats.html:67
+msgid "Group by:"
+msgstr "Agrupar por:"
+
+#: src/olympia/stats/templates/stats/stats.html:69
+msgid "day"
+msgstr "dia"
+
+#: src/olympia/stats/templates/stats/stats.html:72
+msgid "week"
+msgstr "semana"
+
+#: src/olympia/stats/templates/stats/stats.html:75
+msgid "month"
+msgstr "mês"
+
+#: src/olympia/stats/templates/stats/stats.html:81
+msgid "For last:"
+msgstr "Exibir últimos:"
+
+#: src/olympia/stats/templates/stats/stats.html:84
+msgid "7 days"
+msgstr "7 dias"
+
+#: src/olympia/stats/templates/stats/stats.html:87
+msgid "30 days"
+msgstr "30 dias"
+
+#: src/olympia/stats/templates/stats/stats.html:90
+msgid "90 days"
+msgstr "90 dias"
+
+#: src/olympia/stats/templates/stats/stats.html:93
+msgid "365 days"
+msgstr "365 dias"
+
+#: src/olympia/stats/templates/stats/stats.html:96
+msgid "Custom..."
+msgstr "Personalizar..."
+
+#: src/olympia/stats/templates/stats/stats.html:106
+msgid "Statistics processing is currently disabled, so recent data is unavailable. The statistics are still being collected and this page will be updated soon with the missing data."
+msgstr ""
+"O processamento de estatísticas está desabilitado no momento, então, dados recentes não estão disponíveis. As estatísticas ainda estão sendo coletadas e esta página será atualizada em breve com os "
+"dados em falta."
+
+#: src/olympia/stats/templates/stats/stats.html:112
 msgid "Loading the latest data&hellip;"
 msgstr "Carregando os dados mais recentes&hellip;"
 
-#: src/olympia/stats/templates/stats/stats.html:142
-#: src/olympia/stats/templates/stats/reports/overview.html:25
-#: src/olympia/stats/templates/stats/reports/overview.html:37
+#: src/olympia/stats/templates/stats/stats.html:144 src/olympia/stats/templates/stats/reports/overview.html:25 src/olympia/stats/templates/stats/reports/overview.html:37
 #: src/olympia/stats/templates/stats/reports/overview.html:49
 msgid "No data available."
 msgstr "Nenhum dado disponível."
 
-#: src/olympia/stats/templates/stats/stats.html:177
+#: src/olympia/stats/templates/stats/stats.html:179
 msgid "This dashboard is currently <b>public</b>."
 msgstr "Este painel atualmente é <b>público</b>."
 
-#: src/olympia/stats/templates/stats/stats.html:179
+#: src/olympia/stats/templates/stats/stats.html:181
 msgid "Contribution stats are currently <b>private</b>."
 msgstr "As estatísticas de contribuição atualmente são <b>privadas</b>."
 
-#: src/olympia/stats/templates/stats/stats.html:182
+#: src/olympia/stats/templates/stats/stats.html:184
 msgid "This dashboard is currently <b>private</b>."
 msgstr "Este painel atualmente é <b>privado</b>."
 
-#: src/olympia/stats/templates/stats/stats.html:185
+#: src/olympia/stats/templates/stats/stats.html:187
 msgid "Change settings."
 msgstr "Alterar configurações."
 
@@ -14836,14 +11760,11 @@ msgstr "Como os downloads são contados?"
 
 #: src/olympia/stats/templates/stats/reports/downloads.html:10
 msgid ""
-"<h2>How are downloads counted?</h2> <p> Download counts are updated every "
-"evening and only include original add-on downloads, not updates. Downloads "
-"can be broken down by the specific source referring the download. </p>"
+"<h2>How are downloads counted?</h2> <p> Download counts are updated every evening and only include original add-on downloads, not updates. Downloads can be broken down by the specific source "
+"referring the download. </p>"
 msgstr ""
-"<h2>Como os downloads são contados?</h2> <p> A contagem de downloads é "
-"atualizada todas as noites e incluem somente downloads originais de "
-"complementos, e não atualizações. Os downloads podem ser discriminados pela "
-"origem do download. </p>"
+"<h2>Como os downloads são contados?</h2> <p> A contagem de downloads é atualizada todas as noites e incluem somente downloads originais de complementos, e não atualizações. Os downloads podem ser "
+"discriminados pela origem do download. </p>"
 
 #: src/olympia/stats/templates/stats/reports/locales.html:3
 msgid "User languages by Date"
@@ -14857,8 +11778,7 @@ msgstr "Plataformas por Data"
 msgid "<b>{0}</b> Downloads"
 msgstr "<b>{0}</b> downloads"
 
-#: src/olympia/stats/templates/stats/reports/overview.html:9
-#: src/olympia/stats/templates/stats/reports/overview.html:13
+#: src/olympia/stats/templates/stats/reports/overview.html:9 src/olympia/stats/templates/stats/reports/overview.html:13
 msgid "Loading..."
 msgstr "Carregando..."
 
@@ -14909,34 +11829,17 @@ msgstr "Sobre o monitoramento de fontes externas..."
 #: src/olympia/stats/templates/stats/reports/sources.html:10
 #, python-format
 msgid ""
-"<h2>Tracking external sources</h2> <p> If you link to your add-on's details "
-"page or directly to its file from an external site, such as your blog or "
-"website, you can append a parameter to be tracked as an additional download "
-"source on this page. For example, the following links would appear as "
-"sourced by your blog: <dl> <dt>Add-on Details Page</dt> "
-"<dd>https://addons.mozilla.org/addon/%(slug)s?src=<b>external-blog</b></dd> "
-"<dt>Direct File Link</dt> "
-"<dd>https://addons.mozilla.org/downloads/latest/%(id)s/addon-%(id)s-latest.xpi?src=<b"
-">external-blog</b></dd> </dl> <p> Only src parameters that begin with "
-"\"external-\" will be tracked, up to 61 additional characters. Any text "
-"after \"external-\" can be used to describe the source, such as \"external-"
-"blog\", \"external-sidebar\", \"external-campaign225\", etc. The following "
-"URL-safe characters are allowed: <code>a-z A-Z - . _ ~ %% +</code>"
+"<h2>Tracking external sources</h2> <p> If you link to your add-on's details page or directly to its file from an external site, such as your blog or website, you can append a parameter to be "
+"tracked as an additional download source on this page. For example, the following links would appear as sourced by your blog: <dl> <dt>Add-on Details Page</dt> <dd>https://addons.mozilla.org/addon/"
+"%(slug)s?src=<b>external-blog</b></dd> <dt>Direct File Link</dt> <dd>https://addons.mozilla.org/downloads/latest/%(id)s/addon-%(id)s-latest.xpi?src=<b>external-blog</b></dd> </dl> <p> Only src "
+"parameters that begin with \"external-\" will be tracked, up to 61 additional characters. Any text after \"external-\" can be used to describe the source, such as \"external-blog\", \"external-"
+"sidebar\", \"external-campaign225\", etc. The following URL-safe characters are allowed: <code>a-z A-Z - . _ ~ %% +</code>"
 msgstr ""
-"<h2>Monitoramento de fontes externas</h2> <p> Se você criar um link em um "
-"blog ou no seu site para a página de detalhes do seu complemento ou direto "
-"pro arquivo de download, você pode especificar um parâmetro para ser "
-"monitorado como uma fonte adicional de download nesta página. Por exemplo, "
-"os links a seguir apareceriam como originados do seu blog: <dl> <dt>Página "
-"de detalhes do complemento</dt> "
-"<dd>https://addons.mozilla.org/addon/%(slug)s?src=<b>external-blog</b></dd> "
-"<dt>Download direto</dt> "
-"<dd>https://addons.mozilla.org/downloads/latest/%(id)s/addon-%(id)s-latest.xpi?src=<b"
-">external-blog</b></dd> </dl> <p> Somente parâmetros src que começam com "
-"\"external-\" serão monitorados, com no máximo 61 caracteres. Qualquer texto"
-" após \"external-\" pode ser usado para descrever a fonte, como \"external-"
-"blog\", \"external-painel-lateral\", \"external-campanha123\", etc. Os "
-"seguintes caracteres são permitidos: <code>a-z A-Z - . _ ~ %% +</code>"
+"<h2>Monitoramento de fontes externas</h2> <p> Se você criar um link em um blog ou no seu site para a página de detalhes do seu complemento ou direto pro arquivo de download, você pode especificar "
+"um parâmetro para ser monitorado como uma fonte adicional de download nesta página. Por exemplo, os links a seguir apareceriam como originados do seu blog: <dl> <dt>Página de detalhes do "
+"complemento</dt> <dd>https://addons.mozilla.org/addon/%(slug)s?src=<b>external-blog</b></dd> <dt>Download direto</dt> <dd>https://addons.mozilla.org/downloads/latest/%(id)s/addon-%(id)s-latest.xpi?"
+"src=<b>external-blog</b></dd> </dl> <p> Somente parâmetros src que começam com \"external-\" serão monitorados, com no máximo 61 caracteres. Qualquer texto após \"external-\" pode ser usado para "
+"descrever a fonte, como \"external-blog\", \"external-painel-lateral\", \"external-campanha123\", etc. Os seguintes caracteres são permitidos: <code>a-z A-Z - . _ ~ %% +</code>"
 
 #: src/olympia/stats/templates/stats/reports/statuses.html:3
 msgid "Add-on Status by Date"
@@ -14956,28 +11859,19 @@ msgstr "O que são usuários diários?"
 
 #: src/olympia/stats/templates/stats/reports/usage.html:11
 msgid ""
-"<h2>What are daily users?</h2> <p> Themes installed from this site check for"
-" updates once per day. The total number of these update pings is known as "
-"Active Daily Users, or the total number of people using your theme by day. "
-"</p>"
+"<h2>What are daily users?</h2> <p> Themes installed from this site check for updates once per day. The total number of these update pings is known as Active Daily Users, or the total number of "
+"people using your theme by day. </p>"
 msgstr ""
-"<h2>O que são usuários diários?</h2> <p> Temas instalados a partir deste "
-"site, verifica por atualizações uma vez por dia. O número total dessas "
-"atualizações é conhecido como Usuários ativos por dia ou o número total de "
-"pessoas usando o seu tema por dia. </p>"
+"<h2>O que são usuários diários?</h2> <p> Temas instalados a partir deste site, verifica por atualizações uma vez por dia. O número total dessas atualizações é conhecido como Usuários ativos por dia "
+"ou o número total de pessoas usando o seu tema por dia. </p>"
 
 #: src/olympia/stats/templates/stats/reports/usage.html:20
 msgid ""
-"<h2>What are daily users?</h2> <p> Add-ons downloaded from this site check "
-"for updates once per day. The total number of these update pings is known as"
-" Active Daily Users. Daily users can be broken down by add-on version, "
-"operating system, add-on status, application, and locale. </p>"
+"<h2>What are daily users?</h2> <p> Add-ons downloaded from this site check for updates once per day. The total number of these update pings is known as Active Daily Users. Daily users can be broken "
+"down by add-on version, operating system, add-on status, application, and locale. </p>"
 msgstr ""
-"<h2>O que são usuários diários?</h2> <p>Complementos baixados deste site "
-"procuram atualizações uma vez por dia. O número total de vezes em que são "
-"procuradas atualizações é conhecido como Usuários ativos diários. Usuários "
-"diários podem ser discriminados por versão do complemento, sistema "
-"operacional, status do complemento, aplicação e idioma.</p>"
+"<h2>O que são usuários diários?</h2> <p>Complementos baixados deste site procuram atualizações uma vez por dia. O número total de vezes em que são procuradas atualizações é conhecido como Usuários "
+"ativos diários. Usuários diários podem ser discriminados por versão do complemento, sistema operacional, status do complemento, aplicação e idioma.</p>"
 
 #: src/olympia/stats/templates/stats/reports/users_created.html:3
 msgid "User Signups by Date"
@@ -14987,46 +11881,27 @@ msgstr "Cadastros por Data"
 msgid "Application versions by Date"
 msgstr "Versões do complemento por Data"
 
-# {0} is a number
-#: src/olympia/tags/templates/tags/top_cloud.html:4
-msgid "Top {0} Tags"
-msgstr "{0} etiquetas mais populares"
-
-#. {0} is the current application name
-#: src/olympia/tags/templates/tags/top_cloud.html:14
-msgid "{0} Top Tags"
-msgstr "Etiquetas populares {0}"
-
-#: src/olympia/templates/amo_footer.html:6
-#: src/olympia/templates/includes/lang_switcher.html:2
+#: src/olympia/templates/amo_footer.html:6 src/olympia/templates/includes/lang_switcher.html:2
 msgid "Other languages"
 msgstr "Outros idiomas"
 
-#: src/olympia/templates/base.html:9 src/olympia/templates/impala/base.html:9
-#: src/olympia/templates/mobile/base_addons.html:9
+#: src/olympia/templates/base.html:9 src/olympia/templates/impala/base.html:9 src/olympia/templates/mobile/base_addons.html:9
 msgid "Mozilla Add-ons"
 msgstr "Mozilla Add-ons"
 
-#: src/olympia/templates/base.html:91
-#: src/olympia/templates/impala/base.html:81
+#: src/olympia/templates/base.html:89 src/olympia/templates/impala/base.html:78
 msgid "Find add-ons for other applications"
 msgstr "Procurar complementos para outras aplicações"
 
-#: src/olympia/templates/base.html:92
-#: src/olympia/templates/impala/base.html:81
+#: src/olympia/templates/base.html:90 src/olympia/templates/impala/base.html:78
 msgid "Other Applications"
 msgstr "Outras aplicações"
 
-#: src/olympia/templates/base.html:141
-#: src/olympia/templates/impala/base.html:194
-msgid ""
-"To create your own collections, you must have a Mozilla Add-ons account."
-msgstr ""
-"Para criar as suas próprias coleções, você deve ter uma conta no Mozilla "
-"Add-ons."
+#: src/olympia/templates/base.html:141 src/olympia/templates/impala/base.html:194
+msgid "To create your own collections, you must have a Mozilla Add-ons account."
+msgstr "Para criar as suas próprias coleções, você deve ter uma conta no Mozilla Add-ons."
 
-#: src/olympia/templates/base.html:168
-#: src/olympia/templates/impala/base.html:215
+#: src/olympia/templates/base.html:168 src/olympia/templates/impala/base.html:215
 msgid "Footer logo"
 msgstr "Logotipo de rodapé"
 
@@ -15043,7 +11918,7 @@ msgid "View Mobile Site"
 msgstr "Exibir versão móvel"
 
 #: src/olympia/templates/copyright.html:7
-msgid "Site Status "
+msgid "Site Status"
 msgstr "Status do Site "
 
 #: src/olympia/templates/footer.html:3
@@ -15051,14 +11926,12 @@ msgid "get to know <b>add-ons</b>"
 msgstr "conheça os <b>complementos</b>"
 
 # Link text for the AMO About page.
-#: src/olympia/templates/footer.html:4
-#: src/olympia/templates/menu_links.html:20
+#: src/olympia/templates/footer.html:4 src/olympia/templates/menu_links.html:20
 msgid "About"
 msgstr "Sobre"
 
 # Link text to the AMO blog.
-#: src/olympia/templates/footer.html:5
-#: src/olympia/templates/menu_links.html:32
+#: src/olympia/templates/footer.html:5 src/olympia/templates/menu_links.html:32
 msgid "Blog"
 msgstr "Blog"
 
@@ -15142,9 +12015,7 @@ msgstr "Avisos legais"
 msgid "Contact Us"
 msgstr "Entrar em contato"
 
-#: src/olympia/templates/user_login.html:22
-#: src/olympia/users/templates/users/edit.html:31
-#: src/olympia/users/templates/users/includes/navigation.html:12
+#: src/olympia/templates/user_login.html:22 src/olympia/users/templates/users/edit.html:31 src/olympia/users/templates/users/includes/navigation.html:12
 msgid "My Account"
 msgstr "Minha conta"
 
@@ -15155,67 +12026,48 @@ msgstr "Bem-vindo(a), {0}"
 
 # %1 is the URL to the registration page
 # %2 is the URL to the login page
-#: src/olympia/templates/user_login.html:41
-#: src/olympia/templates/impala/user_login.html:20
+#: src/olympia/templates/user_login.html:41 src/olympia/templates/impala/user_login.html:20
 #, python-format
 msgid "<a href=\"%(reg)s\">Register</a> or <a href=\"%(login)s\">Log in</a>"
-msgstr ""
-"<a href=\"%(reg)s\">Crie uma conta</a> ou <a href=\"%(login)s\">Identifique-"
-"se</a>"
+msgstr "<a href=\"%(reg)s\">Crie uma conta</a> ou <a href=\"%(login)s\">Identifique-se</a>"
 
-#: src/olympia/templates/impala/base.html:126
+#: src/olympia/templates/impala/base.html:123
 #, python-format
-msgid ""
-"To try the thousands of add-ons available here, download <a "
-"href=\"%(url)s\">Mozilla Firefox</a>, a fast, free way to surf the Web!"
-msgstr ""
-"Para experimentar os milhares de complementos disponíveis aqui, baixe o <a "
-"href=\"%(url)s\">Mozilla Firefox</a>, uma maneira rápida e gratuita de "
-"navegar na Web!"
+msgid "To try the thousands of add-ons available here, download <a href=\"%(url)s\">Mozilla Firefox</a>, a fast, free way to surf the Web!"
+msgstr "Para experimentar os milhares de complementos disponíveis aqui, baixe o <a href=\"%(url)s\">Mozilla Firefox</a>, uma maneira rápida e gratuita de navegar na Web!"
 
-#: src/olympia/templates/impala/base.html:138
+#: src/olympia/templates/impala/base.html:135
 #, python-format
-msgid ""
-"Add-ons is switching to Firefox Accounts for login. <a href=\"%(url)s\" "
-"class=\"fxa-login\">Sign in now to transfer your account.</a>"
-msgstr ""
-"Complementos estão mudando para as contas Firefox para efetuar login. <a "
-"href=\"%(url)s\" class=\"fxa-login\">Entre agora para transferir a sua "
-"conta.</a>"
+msgid "Add-ons is switching to Firefox Accounts for login. <a href=\"%(url)s\" class=\"fxa-login\">Sign in now to transfer your account.</a>"
+msgstr "Complementos estão mudando para as contas Firefox para efetuar login. <a href=\"%(url)s\" class=\"fxa-login\">Entre agora para transferir a sua conta.</a>"
 
 #. {0} is an application, such as Firefox.
-#: src/olympia/templates/impala/base.html:148
+#: src/olympia/templates/impala/base.html:145
 msgid "Welcome to {0} Add-ons."
 msgstr "Bem-vindo aos Complementos para o {0}."
 
-#: src/olympia/templates/impala/base.html:151
-msgid ""
-"Choose from thousands of extra features and styles to make Firefox your own."
-msgstr ""
-"Escolha entre milhares de recursos extras e estilos para tornar o Firefox só"
-" seu."
+#: src/olympia/templates/impala/base.html:148
+msgid "Choose from thousands of extra features and styles to make Firefox your own."
+msgstr "Escolha entre milhares de recursos extras e estilos para tornar o Firefox só seu."
 
-#: src/olympia/templates/impala/base.html:156
+#: src/olympia/templates/impala/base.html:153
 #, python-format
 msgid "Add extra features and styles to make %(app)s your own."
 msgstr "Adicione recursos e estilos extras para tornar o %(app)s só seu."
 
-#: src/olympia/templates/impala/base.html:164
+#: src/olympia/templates/impala/base.html:161
 msgid "On the go?"
 msgstr "Em movimento?"
 
-#: src/olympia/templates/impala/base.html:166
+#: src/olympia/templates/impala/base.html:163
 msgid "Check out our <a class=\"mobile-link\" href=\"#\">Mobile Add-ons site</a>."
-msgstr ""
-"Veja a nossa página de <a class=\"mobile-link\" href=\"#\">Complementos "
-"Móveis</a>."
+msgstr "Veja a nossa página de <a class=\"mobile-link\" href=\"#\">Complementos Móveis</a>."
 
 #: src/olympia/templates/impala/header_title.html:21
 msgid "Android Add-ons"
 msgstr "Complementos para Android"
 
-#: src/olympia/templates/includes/forms.html:2
-#: src/olympia/templates/includes/forms.html:6
+#: src/olympia/templates/includes/forms.html:2 src/olympia/templates/includes/forms.html:6
 msgid "required"
 msgstr "obrigatório"
 
@@ -15255,21 +12107,17 @@ msgstr "Complementos"
 msgid "Visit Mozilla"
 msgstr "Visitar a Mozilla"
 
-#. a link
 # 75%
+#. a link
 #: src/olympia/templates/mobile/header.html:10
 msgid "menu"
 msgstr "menu"
 
-#: src/olympia/templates/mobile/header_auth.html:7
-#: src/olympia/users/templates/users/register.html:41
-#: src/olympia/users/templates/users/register.html:89
+#: src/olympia/templates/mobile/header_auth.html:7 src/olympia/users/templates/users/register.html:41 src/olympia/users/templates/users/register.html:89
 msgid "Register"
 msgstr "Registrar"
 
-#: src/olympia/templates/mobile/header_auth.html:8
-#: src/olympia/users/templates/users/login_form.html:41
-#: src/olympia/users/templates/users/pwreset_complete.html:15
+#: src/olympia/templates/mobile/header_auth.html:8 src/olympia/users/templates/users/login_form.html:41 src/olympia/users/templates/users/pwreset_complete.html:15
 #: src/olympia/users/templates/users/mobile/login.html:56
 msgid "Log in"
 msgstr "Entrar"
@@ -15280,8 +12128,7 @@ msgstr "Entrar"
 msgid "Localize for: <a id=\"change-locale\" href=\"#\">%(dl)s</a>"
 msgstr "Informações para o idioma: <a id=\"change-locale\" href=\"#\">%(dl)s</a>"
 
-#: src/olympia/translations/templates/translations/trans-menu.html:16
-#: src/olympia/translations/templates/translations/trans-menu.html:29
+#: src/olympia/translations/templates/translations/trans-menu.html:16 src/olympia/translations/templates/translations/trans-menu.html:29
 #, python-format
 msgid "%(title)s <em>&middot; %(lang)s</em>"
 msgstr "%(title)s <em>&middot; %(lang)s</em>"
@@ -15296,12 +12143,8 @@ msgstr "Novos idiomas"
 
 #. {0} is a language name, like 'French'
 #: src/olympia/translations/templates/translations/trans-menu.html:42
-msgid ""
-"You have unsaved changes in the <b>{0}</b> locale. Would you like to save "
-"your changes before switching locales?"
-msgstr ""
-"Você realizou alterações não salvas no idioma <b>{0}</b>. Você gostaria de "
-"salvar as suas alterações antes de trocar de idioma?"
+msgid "You have unsaved changes in the <b>{0}</b> locale. Would you like to save your changes before switching locales?"
+msgstr "Você realizou alterações não salvas no idioma <b>{0}</b>. Você gostaria de salvar as suas alterações antes de trocar de idioma?"
 
 #: src/olympia/translations/templates/translations/trans-menu.html:49
 msgid "Discard Changes"
@@ -15309,12 +12152,8 @@ msgstr "Descartar alterações"
 
 #. {0} is a language name, like 'French'
 #: src/olympia/translations/templates/translations/trans-menu.html:56
-msgid ""
-"Are you sure you want to remove all <b>{0}</b> translations? This cannot be "
-"undone."
-msgstr ""
-"Deseja realmente remover todas as traduções de <b>{0}</b>? Isso não poderá "
-"ser desfeito."
+msgid "Are you sure you want to remove all <b>{0}</b> translations? This cannot be undone."
+msgstr "Deseja realmente remover todas as traduções de <b>{0}</b>? Isso não poderá ser desfeito."
 
 #: src/olympia/translations/templates/translations/trans-menu.html:61
 msgid "Delete Locale"
@@ -15335,25 +12174,14 @@ msgstr "Essa senha não é permitida."
 
 #: src/olympia/users/forms.py:90
 #, python-format
-msgid ""
-"As part of our new password policy, your password must be %s characters or "
-"more. Please update your password by <a href=\"%s\">issuing a password "
-"reset</a>."
-msgstr ""
-"Como parte da nova política de senha, sua senha deve ter %s caracteres ou "
-"mais. Por favor, atualize sua senha <a href=\"%s\">solicitando a redefinição"
-" da senha</a>."
+msgid "As part of our new password policy, your password must be %s characters or more. Please update your password by <a href=\"%s\">issuing a password reset</a>."
+msgstr "Como parte da nova política de senha, sua senha deve ter %s caracteres ou mais. Por favor, atualize sua senha <a href=\"%s\">solicitando a redefinição da senha</a>."
 
 #: src/olympia/users/forms.py:115
-msgid ""
-"You must recover your password through Firefox Accounts. Try logging in "
-"instead."
-msgstr ""
-"Você deve recuperar sua senha através da Conta Firefox. Tente iniciar a "
-"sessão."
+msgid "You must recover your password through Firefox Accounts. Try logging in instead."
+msgstr "Você deve recuperar sua senha através da Conta Firefox. Tente iniciar a sessão."
 
-#: src/olympia/users/forms.py:206
-#: src/olympia/users/templates/users/pwreset_confirm.html:24
+#: src/olympia/users/forms.py:206 src/olympia/users/templates/users/pwreset_confirm.html:24
 msgid "New password"
 msgstr "Senha nova"
 
@@ -15366,12 +12194,8 @@ msgid "Usernames cannot contain only digits."
 msgstr "Nomes de usuário não pode conter apenas dígitos."
 
 #: src/olympia/users/forms.py:274
-msgid ""
-"Enter a valid username consisting of letters, numbers, underscores or "
-"hyphens."
-msgstr ""
-"Digite um nome de usuário válido constituído por letras, números, traços "
-"inferiores ou hifens."
+msgid "Enter a valid username consisting of letters, numbers, underscores or hyphens."
+msgstr "Digite um nome de usuário válido constituído por letras, números, traços inferiores ou hifens."
 
 #: src/olympia/users/forms.py:277
 msgid "This username cannot be used."
@@ -15383,38 +12207,25 @@ msgstr "Esse nome de usuário já está sendo usado."
 
 # 91%
 # 100%
-#: src/olympia/users/forms.py:296
-#: src/olympia/users/templates/users/edit.html:107
+#: src/olympia/users/forms.py:296 src/olympia/users/templates/users/edit.html:107
 msgid "Display Name"
 msgstr "Nome"
 
-#: src/olympia/users/forms.py:298
-#: src/olympia/users/templates/users/edit.html:112
-#: src/olympia/users/templates/users/vcard.html:10
+#: src/olympia/users/forms.py:298 src/olympia/users/templates/users/edit.html:112 src/olympia/users/templates/users/vcard.html:10
 msgid "Location"
 msgstr "Localização"
 
-#: src/olympia/users/forms.py:300
-#: src/olympia/users/templates/users/edit.html:117
-#: src/olympia/users/templates/users/vcard.html:16
+#: src/olympia/users/forms.py:300 src/olympia/users/templates/users/edit.html:117 src/olympia/users/templates/users/vcard.html:16
 msgid "Occupation"
 msgstr "Ocupação"
 
 #: src/olympia/users/forms.py:329
-msgid ""
-"This URL has an invalid format. Valid URLs look like "
-"http://example.com/my_page."
-msgstr ""
-"Este endereço tem um formato inválido. Endereços válidos são do tipo "
-"http://example.com/minha_página."
+msgid "This URL has an invalid format. Valid URLs look like http://example.com/my_page."
+msgstr "Este endereço tem um formato inválido. Endereços válidos são do tipo http://example.com/minha_página."
 
 #: src/olympia/users/forms.py:337
-msgid ""
-"Please use an email address from a different provider to complete your "
-"registration."
-msgstr ""
-"Por favor, use um endereço de e-mail de um provedor diferente para completar"
-" o seu registro."
+msgid "Please use an email address from a different provider to complete your registration."
+msgstr "Por favor, use um endereço de e-mail de um provedor diferente para completar o seu registro."
 
 #: src/olympia/users/forms.py:345
 msgid "This display name cannot be used."
@@ -15424,21 +12235,17 @@ msgstr "Este nome de apresentação não pode ser usado."
 msgid "The passwords did not match."
 msgstr "As senhas não conferem."
 
-#: src/olympia/users/forms.py:377
-#: src/olympia/users/templates/users/edit.html:128
+#: src/olympia/users/forms.py:377 src/olympia/users/templates/users/edit.html:128
 msgid "Profile Photo"
 msgstr "Foto do perfil"
 
-#: src/olympia/users/forms.py:385
-#: src/olympia/users/templates/users/edit.html:142
+#: src/olympia/users/forms.py:385 src/olympia/users/templates/users/edit.html:142
 msgid "Default locale"
 msgstr "Local padrão"
 
 #: src/olympia/users/forms.py:412
 msgid "Firefox Accounts users cannot currently change their email address."
-msgstr ""
-"Usuários da Conta Firefox no momento não podem modificar o endereço de "
-"e-mail."
+msgstr "Usuários da Conta Firefox no momento não podem modificar o endereço de e-mail."
 
 #: src/olympia/users/forms.py:446
 msgid "Wrong password entered!"
@@ -15449,12 +12256,8 @@ msgid "Email cannot be changed."
 msgstr "O e-mail não pode ser alterado."
 
 #: src/olympia/users/forms.py:541
-msgid ""
-"To anonymize, enter a reason for the change but do not change any other "
-"field."
-msgstr ""
-"Para se manter anônimo, insira um motivo para a alteração mas não altere "
-"nenhum outro campo."
+msgid "To anonymize, enter a reason for the change but do not change any other field."
+msgstr "Para se manter anônimo, insira um motivo para a alteração mas não altere nenhum outro campo."
 
 #: src/olympia/users/forms.py:587
 msgid "Please enter at least one name to blacklist."
@@ -15484,20 +12287,20 @@ msgstr "Nenhum usuário com esse e-mail."
 
 #. L10n: {id} will be something like "13ad6a", just a random number
 #. to differentiate this user from other anonymous users.
-#: src/olympia/users/models.py:353
+#: src/olympia/users/models.py:362
 msgid "Anonymous user {id}"
 msgstr "Usuário anônimo {id}"
 
-#: src/olympia/users/models.py:410
+#: src/olympia/users/models.py:419
 msgid "Your account has been restricted"
 msgstr "Sua conta foi restringida"
 
 # %1 is the application name
-#: src/olympia/users/models.py:480
+#: src/olympia/users/models.py:489
 msgid "Please confirm your email address"
 msgstr "Por favor, confirme seu endereço de e-mail"
 
-#: src/olympia/users/models.py:506
+#: src/olympia/users/models.py:515
 msgid "My Mobile Add-ons"
 msgstr "Meus complementos móveis"
 
@@ -15562,17 +12365,12 @@ msgid "Mozilla needs to contact me about my individual app"
 msgstr "a Mozilla precisa entrar em contato sobre meu aplicativo"
 
 #: src/olympia/users/notifications.py:139
-msgid ""
-"Mozilla wants to contact me about relevant App Developer news and surveys"
-msgstr ""
-"a Mozilla quer entrar em contato sobre novidades e pesquisas para "
-"desenvolvedores de aplicativos"
+msgid "Mozilla wants to contact me about relevant App Developer news and surveys"
+msgstr "a Mozilla quer entrar em contato sobre novidades e pesquisas para desenvolvedores de aplicativos"
 
 #: src/olympia/users/notifications.py:150
 msgid "Mozilla wants to contact me about new regions added to the Marketplace"
-msgstr ""
-"a Mozilla quer entrar em contato sobre novas regiões adicionadas ao "
-"Marketplace"
+msgstr "a Mozilla quer entrar em contato sobre novas regiões adicionadas ao Marketplace"
 
 #: src/olympia/users/notifications.py:158
 msgid "User Notifications"
@@ -15595,14 +12393,8 @@ msgid "Successfully verified!"
 msgstr "Verificado com sucesso!"
 
 #: src/olympia/users/views.py:132
-msgid ""
-"An email has been sent to your address to confirm your account. Before you "
-"can log in, you have to activate your account by clicking on the link "
-"provided in this email."
-msgstr ""
-"Uma mensagem foi enviada ao seu e-mail para confirmar sua conta. Antes de "
-"poder acessar, você precisa ativar sua conta clicando no link fornecido no "
-"e-mail."
+msgid "An email has been sent to your address to confirm your account. Before you can log in, you have to activate your account by clicking on the link provided in this email."
+msgstr "Uma mensagem foi enviada ao seu e-mail para confirmar sua conta. Antes de poder acessar, você precisa ativar sua conta clicando no link fornecido no e-mail."
 
 #: src/olympia/users/views.py:136 src/olympia/users/views.py:619
 msgid "Confirmation Email Sent"
@@ -15626,14 +12418,11 @@ msgstr "Mensagem de confirmação de endereço enviada"
 
 #: src/olympia/users/views.py:197
 msgid ""
-"An email has been sent to {0} to confirm your new email address. For the "
-"change to take effect, you need to click on the link provided in this email."
-" Until then, you can keep logging in with your current email address."
+"An email has been sent to {0} to confirm your new email address. For the change to take effect, you need to click on the link provided in this email. Until then, you can keep logging in with your "
+"current email address."
 msgstr ""
-"Uma mensagem foi enviada para o endereço {0} para confirmar seu novo "
-"endereço de e-mail. Para que a alteração tenha efeito, você deve clicar no "
-"link fornecido na mensagem. Até lá, continue se identificando com o endereço"
-" de e-mail atual."
+"Uma mensagem foi enviada para o endereço {0} para confirmar seu novo endereço de e-mail. Para que a alteração tenha efeito, você deve clicar no link fornecido na mensagem. Até lá, continue se "
+"identificando com o endereço de e-mail atual."
 
 #: src/olympia/users/views.py:210
 #, python-format
@@ -15645,18 +12434,12 @@ msgid "Errors Found"
 msgstr "Erros encontrados"
 
 #: src/olympia/users/views.py:225
-msgid ""
-"There were errors in the changes you made. Please correct them and resubmit."
-msgstr ""
-"Existem erros nas alterações feitas por você. Por favor, corrija-os e envie "
-"novamente."
+msgid "There were errors in the changes you made. Please correct them and resubmit."
+msgstr "Existem erros nas alterações feitas por você. Por favor, corrija-os e envie novamente."
 
 #: src/olympia/users/views.py:273
-msgid ""
-"We're sorry, but you are not eligible to request a t-shirt at this time."
-msgstr ""
-"Pedimos desculpas, mas você não é elegível para solicitar uma camiseta neste"
-" momento."
+msgid "We're sorry, but you are not eligible to request a t-shirt at this time."
+msgstr "Pedimos desculpas, mas você não é elegível para solicitar uma camiseta neste momento."
 
 # %1 is the new email address
 #: src/olympia/users/views.py:329
@@ -15672,25 +12455,17 @@ msgid "Wrong email address or password!"
 msgstr "Endereço de e-mail ou senha incorretos!"
 
 #: src/olympia/users/views.py:434
-msgid ""
-"A link to activate your user account was sent by email to your address {0}. "
-"You have to click it before you can log in."
-msgstr ""
-"Um link para ativar a sua conta foi enviado por e-mail para o endereço {0}. "
-"Você deve abrir esse link antes de poder se identificar."
+msgid "A link to activate your user account was sent by email to your address {0}. You have to click it before you can log in."
+msgstr "Um link para ativar a sua conta foi enviado por e-mail para o endereço {0}. Você deve abrir esse link antes de poder se identificar."
 
 #: src/olympia/users/views.py:439
 #, python-format
 msgid ""
-"If you did not receive the confirmation email, make sure your email service "
-"did not mark it as \"junk mail\" or \"spam\". If you need to, you can have "
-"us <a href=\"%s\">resend the confirmation message</a> to your email address "
-"mentioned above."
+"If you did not receive the confirmation email, make sure your email service did not mark it as \"junk mail\" or \"spam\". If you need to, you can have us <a href=\"%s\">resend the confirmation "
+"message</a> to your email address mentioned above."
 msgstr ""
-"Se você não recebeu uma mensagem de confirmação, tenha certeza de que seu "
-"serviço de e-mail não marcou a mensagem como \"Lixo\" ou \"Spam\". Se você "
-"precisar, nós podemos <a href=\"%s\">reenviar a mensagem de confirmação</a> "
-"para o seu endereço de e-mail mencionado acima."
+"Se você não recebeu uma mensagem de confirmação, tenha certeza de que seu serviço de e-mail não marcou a mensagem como \"Lixo\" ou \"Spam\". Se você precisar, nós podemos <a href=\"%s\">reenviar a "
+"mensagem de confirmação</a> para o seu endereço de e-mail mencionado acima."
 
 #: src/olympia/users/views.py:444
 msgid "Activation Email Sent"
@@ -15711,14 +12486,8 @@ msgstr "Parabéns! Sua conta foi criada com sucesso."
 
 # %1 is the user's email address
 #: src/olympia/users/views.py:615
-msgid ""
-"An email has been sent to your address {0} to confirm your account. Before "
-"you can log in, you have to activate your account by clicking on the link "
-"provided in this email."
-msgstr ""
-"Uma mensagem foi enviada para o endereço {0} para que sua conta seja "
-"confirmada. Antes de poder se identificar, você deve ativar sua conta "
-"clicando no link fornecido na mensagem."
+msgid "An email has been sent to your address {0} to confirm your account. Before you can log in, you have to activate your account by clicking on the link provided in this email."
+msgstr "Uma mensagem foi enviada para o endereço {0} para que sua conta seja confirmada. Antes de poder se identificar, você deve ativar sua conta clicando no link fornecido na mensagem."
 
 #: src/olympia/users/views.py:639
 msgid "There are errors in this form"
@@ -15736,8 +12505,7 @@ msgstr "Usuário denunciado."
 msgid "new"
 msgstr "novo"
 
-#: src/olympia/users/templates/users/delete.html:4
-#: src/olympia/users/templates/users/delete.html:10
+#: src/olympia/users/templates/users/delete.html:4 src/olympia/users/templates/users/delete.html:10
 msgid "Delete User Account"
 msgstr "Excluir conta do usuário"
 
@@ -15745,24 +12513,15 @@ msgstr "Excluir conta do usuário"
 #: src/olympia/users/templates/users/delete.html:14
 #, python-format
 msgid ""
-"You cannot delete your account if you are listed as an <a href=\"%(link)s\">"
-" author of any add-ons</a>. To delete your account, please have another "
-"person in your development group delete you from the list of authors for "
-"your add-ons. Afterwards you will be able to delete your account here."
+"You cannot delete your account if you are listed as an <a href=\"%(link)s\"> author of any add-ons</a>. To delete your account, please have another person in your development group delete you from "
+"the list of authors for your add-ons. Afterwards you will be able to delete your account here."
 msgstr ""
-"Você não pode excluir sua conta se estiver listado como um <a "
-"href=\"%(link)s\">autor de algum complemento</a>. Para excluir sua conta, "
-"peça a outra pessoa do seu grupo de desenvolvimento para excluí-lo da lista "
-"de autores dos seus complementos. Após isso, você poderá excluir aqui a sua "
-"conta."
+"Você não pode excluir sua conta se estiver listado como um <a href=\"%(link)s\">autor de algum complemento</a>. Para excluir sua conta, peça a outra pessoa do seu grupo de desenvolvimento para "
+"excluí-lo da lista de autores dos seus complementos. Após isso, você poderá excluir aqui a sua conta."
 
 #: src/olympia/users/templates/users/delete.html:29
-msgid ""
-"By clicking \"delete\" your account is going to be <strong>permanently "
-"removed</strong>. That means:"
-msgstr ""
-"Ao clicar em \"Excluir\" sua conta vai ser <strong>removida "
-"permanentemente</strong>. Isso significa que:"
+msgid "By clicking \"delete\" your account is going to be <strong>permanently removed</strong>. That means:"
+msgstr "Ao clicar em \"Excluir\" sua conta vai ser <strong>removida permanentemente</strong>. Isso significa que:"
 
 #: src/olympia/users/templates/users/delete.html:35
 #, python-format
@@ -15770,12 +12529,8 @@ msgid "You will not be able to log into %(site)s anymore."
 msgstr "Você não será capaz de entrar no %(site)s mais."
 
 #: src/olympia/users/templates/users/delete.html:40
-msgid ""
-"Your reviews and ratings will not be deleted, but they will no longer be "
-"associated with you."
-msgstr ""
-"Seus comentários e avaliações não serão excluídos, mas deixarão de estar "
-"associados a você."
+msgid "Your reviews and ratings will not be deleted, but they will no longer be associated with you."
+msgstr "Seus comentários e avaliações não serão excluídos, mas deixarão de estar associados a você."
 
 #: src/olympia/users/templates/users/delete.html:46
 msgid "Confirm account deletion"
@@ -15789,8 +12544,7 @@ msgstr "Eu entendo que essa ação não poderá ser desfeita."
 msgid "Delete my user account now"
 msgstr "Excluir minha conta agora"
 
-#: src/olympia/users/templates/users/delete_photo.html:3
-#: src/olympia/users/templates/users/delete_photo.html:9
+#: src/olympia/users/templates/users/delete_photo.html:3 src/olympia/users/templates/users/delete_photo.html:9
 msgid "Delete User Photo"
 msgstr "Excluir foto do usuário"
 
@@ -15803,27 +12557,18 @@ msgid "Please set your display name"
 msgstr "Por favor, insira o seu nome de exibição"
 
 #: src/olympia/users/templates/users/edit.html:21
-msgid ""
-"Please set your display name or username to complete the registration "
-"process."
-msgstr ""
-"Por favor, insira o seu nome de exibição ou nome de usuário para concluir o "
-"processo de registro."
+msgid "Please set your display name or username to complete the registration process."
+msgstr "Por favor, insira o seu nome de exibição ou nome de usuário para concluir o processo de registro."
 
 #: src/olympia/users/templates/users/edit.html:33
 msgid "Manage basic account information, such as username and email address."
-msgstr ""
-"Gerencie as informações básicas da sua conta, como seu nome de usuário e "
-"endereço de e-mail."
+msgstr "Gerencie as informações básicas da sua conta, como seu nome de usuário e endereço de e-mail."
 
-#: src/olympia/users/templates/users/edit.html:39
-#: src/olympia/users/templates/users/register.html:47
+#: src/olympia/users/templates/users/edit.html:39 src/olympia/users/templates/users/register.html:47
 msgid "Username"
 msgstr "Usuário"
 
-#: src/olympia/users/templates/users/edit.html:45
-#: src/olympia/users/templates/users/pwreset_request.html:21
-#: src/olympia/users/templates/users/register.html:62
+#: src/olympia/users/templates/users/edit.html:45 src/olympia/users/templates/users/pwreset_request.html:21 src/olympia/users/templates/users/register.html:62
 msgid "Email Address"
 msgstr "E-mail"
 
@@ -15835,21 +12580,15 @@ msgstr "Gerenciar a conta do Firefox..."
 msgid "Change Password"
 msgstr "Alterar senha"
 
-#: src/olympia/users/templates/users/edit.html:68
-#: src/olympia/users/templates/users/login_form.html:22
-#: src/olympia/users/templates/users/register.html:67
+#: src/olympia/users/templates/users/edit.html:68 src/olympia/users/templates/users/login_form.html:22 src/olympia/users/templates/users/register.html:67
 #: src/olympia/users/templates/users/mobile/login.html:37
 msgid "Password"
 msgstr "Senha"
 
 #: src/olympia/users/templates/users/edit.html:70
 #, python-format
-msgid ""
-"Change your password.  If you forgot your password, you can <a "
-"href=\"%(reset_url)s\">use the reset form</a>."
-msgstr ""
-"Altere sua senha.  Se você esquecer sua senha, você pode <a "
-"href=\"%(reset_url)s\">usar esse formulário</a>."
+msgid "Change your password. If you forgot your password, you can <a href=\"%(reset_url)s\">use the reset form</a>."
+msgstr "Altere sua senha.  Se você esquecer sua senha, você pode <a href=\"%(reset_url)s\">usar esse formulário</a>."
 
 #: src/olympia/users/templates/users/edit.html:76
 msgid "Old Password"
@@ -15868,12 +12607,8 @@ msgid "Profile"
 msgstr "Perfil"
 
 #: src/olympia/users/templates/users/edit.html:100
-msgid ""
-"Give us a bit more information about yourself.  All these fields are "
-"optional, but they'll help other users get to know you better."
-msgstr ""
-"Nos fale mais sobre você.  Todos esses campos são opcionais, mas ajudarão "
-"outros usuários a conhecê-lo melhor."
+msgid "Give us a bit more information about yourself. All these fields are optional, but they'll help other users get to know you better."
+msgstr "Nos fale mais sobre você.  Todos esses campos são opcionais, mas ajudarão outros usuários a conhecê-lo melhor."
 
 #: src/olympia/users/templates/users/edit.html:124
 msgid "This URL will only be visible if you are a developer."
@@ -15888,20 +12623,12 @@ msgid "Delete current photo"
 msgstr "Excluir a foto atual"
 
 #: src/olympia/users/templates/users/edit.html:144
-msgid ""
-"This is the default locale used to display information about you (like your "
-"description)."
-msgstr ""
-"Esse será o local padrão usado para mostrar informações sobre você (como sua"
-" descrição)."
+msgid "This is the default locale used to display information about you (like your description)."
+msgstr "Esse será o local padrão usado para mostrar informações sobre você (como sua descrição)."
 
 #: src/olympia/users/templates/users/edit.html:152
-msgid ""
-"Introduce yourself to the community, if you like! This text will appear "
-"publicly on your user info page."
-msgstr ""
-"Apresente-se à comunidade, se você quiser! Esse texto será exibido "
-"publicamente no seu perfil de usuário."
+msgid "Introduce yourself to the community, if you like! This text will appear publicly on your user info page."
+msgstr "Apresente-se à comunidade, se você quiser! Esse texto será exibido publicamente no seu perfil de usuário."
 
 #: src/olympia/users/templates/users/edit.html:161
 msgid "Allowed HTML: {0}. Links are forbidden."
@@ -15928,22 +12655,12 @@ msgid "Notifications"
 msgstr "Notificações"
 
 #: src/olympia/users/templates/users/edit.html:195
-msgid ""
-"From time to time, Mozilla may send you email about upcoming releases and "
-"add-on events. Please select the topics you are interested in."
-msgstr ""
-"De tempos em tempos, a Mozilla pode enviar mensagens para você sobre novos "
-"lançamentos e eventos de complementos. Por favor, selecione os tópicos nos "
-"quais você tem interesse."
+msgid "From time to time, Mozilla may send you email about upcoming releases and add-on events. Please select the topics you are interested in."
+msgstr "De tempos em tempos, a Mozilla pode enviar mensagens para você sobre novos lançamentos e eventos de complementos. Por favor, selecione os tópicos nos quais você tem interesse."
 
 #: src/olympia/users/templates/users/edit.html:205
-msgid ""
-"Mozilla reserves the right to contact you individually about specific "
-"concerns with your hosted add-ons."
-msgstr ""
-"A Mozilla reserva para si o direito de entrar em contato com você "
-"individualmente sobre possíveis questões com os seus complementos "
-"hospedados."
+msgid "Mozilla reserves the right to contact you individually about specific concerns with your hosted add-ons."
+msgstr "A Mozilla reserva para si o direito de entrar em contato com você individualmente sobre possíveis questões com os seus complementos hospedados."
 
 #: src/olympia/users/templates/users/edit.html:215
 msgid "Admin"
@@ -15965,63 +12682,49 @@ msgstr "nenhuma"
 msgid "all"
 msgstr "todas"
 
-#: src/olympia/users/templates/users/fxa_migration.html:3
-#: src/olympia/users/templates/users/fxa_migration.html:11
-#: src/olympia/users/templates/users/mobile/fxa_migration.html:3
+#: src/olympia/users/templates/users/fxa_migration.html:3 src/olympia/users/templates/users/fxa_migration.html:11 src/olympia/users/templates/users/mobile/fxa_migration.html:3
 #: src/olympia/users/templates/users/mobile/fxa_migration.html:8
 msgid "Migrate to Firefox Accounts"
 msgstr "Migrar para Conta Firefox"
 
 #: src/olympia/users/templates/users/fxa_migration_prompt_content.html:3
-msgid ""
-"Mozilla Add-ons has transitioned to Firefox Accounts for login. Continue to "
-"complete the simple upgrade process."
-msgstr ""
-"Complementos da Mozilla fizeram a transição para as Contas Firefox para o "
-"login. Continue para completar o processo de atualização."
+msgid "Mozilla Add-ons has transitioned to Firefox Accounts for login. Continue to complete the simple upgrade process."
+msgstr "Complementos da Mozilla fizeram a transição para as Contas Firefox para o login. Continue para completar o processo de atualização."
 
 #: src/olympia/users/templates/users/fxa_migration_prompt_content.html:14
 msgid "Skip"
 msgstr "Pular"
 
-#: src/olympia/users/templates/users/login.html:3
-#: src/olympia/users/templates/users/mobile/login.html:3
+#: src/olympia/users/templates/users/login.html:3 src/olympia/users/templates/users/mobile/login.html:3
 msgid "User Login"
 msgstr "Identificação do usuário"
 
-#: src/olympia/users/templates/users/login.html:13
-#: src/olympia/users/templates/users/mobile/login.html:21
+#: src/olympia/users/templates/users/login.html:13 src/olympia/users/templates/users/mobile/login.html:21
 msgid "Enter your email"
 msgstr "Digite seu e-mail"
 
-#: src/olympia/users/templates/users/login.html:15
-#: src/olympia/users/templates/users/mobile/login.html:23
+#: src/olympia/users/templates/users/login.html:15 src/olympia/users/templates/users/mobile/login.html:23
 msgid "Log In"
 msgstr "Identificação"
 
-#: src/olympia/users/templates/users/login_form.html:17
-#: src/olympia/users/templates/users/mobile/login.html:32
+#: src/olympia/users/templates/users/login_form.html:17 src/olympia/users/templates/users/mobile/login.html:32
 msgid "Email address"
 msgstr "Endereço de e-mail"
 
-#: src/olympia/users/templates/users/login_form.html:30
-#: src/olympia/users/templates/users/mobile/login.html:44
+#: src/olympia/users/templates/users/login_form.html:30 src/olympia/users/templates/users/mobile/login.html:44
 msgid "Remember me on this device"
 msgstr "Lembre-se de mim neste dispositivo"
 
 # This is a header for additional help options
-#: src/olympia/users/templates/users/login_help.html:3
-#: src/olympia/users/templates/users/mobile/login.html:63
+#: src/olympia/users/templates/users/login_help.html:3 src/olympia/users/templates/users/mobile/login.html:63
 msgid "Login Problems?"
 msgstr "Problemas para entrar?"
 
-#: src/olympia/users/templates/users/login_help.html:5
-#: src/olympia/users/templates/users/mobile/login.html:65
+#: src/olympia/users/templates/users/login_help.html:5 src/olympia/users/templates/users/mobile/login.html:65
 msgid "I don't have an account."
 msgstr "Eu não tenho uma conta."
 
-#: src/olympia/users/templates/users/login_help.html:6
-#: src/olympia/users/templates/users/mobile/login.html:66
+#: src/olympia/users/templates/users/login_help.html:6 src/olympia/users/templates/users/mobile/login.html:66
 msgid "I forgot my password."
 msgstr "Eu esqueci minha senha."
 
@@ -16030,15 +12733,9 @@ msgstr "Eu esqueci minha senha."
 msgid "You are now logged in as <strong>%(user_email)s</strong>!"
 msgstr "Você está identificado como <strong>%(user_email)s</strong>!"
 
-#: src/olympia/users/templates/users/newpw_sent.html:3
-#: src/olympia/users/templates/users/newpw_sent.html:8
-#: src/olympia/users/templates/users/pwreset_complete.html:3
-#: src/olympia/users/templates/users/pwreset_confirm.html:4
-#: src/olympia/users/templates/users/pwreset_confirm.html:18
-#: src/olympia/users/templates/users/pwreset_request.html:4
-#: src/olympia/users/templates/users/pwreset_request.html:10
-#: src/olympia/users/templates/users/pwreset_sent.html:3
-#: src/olympia/users/templates/users/pwreset_sent.html:8
+#: src/olympia/users/templates/users/newpw_sent.html:3 src/olympia/users/templates/users/newpw_sent.html:8 src/olympia/users/templates/users/pwreset_complete.html:3
+#: src/olympia/users/templates/users/pwreset_confirm.html:4 src/olympia/users/templates/users/pwreset_confirm.html:18 src/olympia/users/templates/users/pwreset_request.html:4
+#: src/olympia/users/templates/users/pwreset_request.html:10 src/olympia/users/templates/users/pwreset_sent.html:3 src/olympia/users/templates/users/pwreset_sent.html:8
 msgid "Password Reset"
 msgstr "Redefinição de senha"
 
@@ -16054,8 +12751,7 @@ msgstr "Editar perfil"
 msgid "Manage user"
 msgstr "Gerenciar usuário"
 
-#: src/olympia/users/templates/users/profile.html:18
-#: src/olympia/users/templates/users/report_abuse_full.html:9
+#: src/olympia/users/templates/users/profile.html:18 src/olympia/users/templates/users/report_abuse_full.html:9
 msgid "Report user"
 msgstr "Denunciar usuário"
 
@@ -16119,38 +12815,25 @@ msgstr "Sucesso!"
 msgid "Password successfully reset."
 msgstr "Senha redefinida com sucesso."
 
-#: src/olympia/users/templates/users/pwreset_confirm.html:13
-#: src/olympia/users/templates/users/pwreset_confirm.html:46
+#: src/olympia/users/templates/users/pwreset_confirm.html:13 src/olympia/users/templates/users/pwreset_confirm.html:46
 msgid "Password reset unsuccessful"
 msgstr "Redefinição de senha sem sucesso"
 
 #: src/olympia/users/templates/users/pwreset_confirm.html:14
-msgid ""
-"You have migrated to Firefox Accounts. You can no longer change your "
-"password here."
-msgstr ""
-"Você migrou para a Conta Firefox. Não é mais possível mudar sua senha aqui."
+msgid "You have migrated to Firefox Accounts. You can no longer change your password here."
+msgstr "Você migrou para a Conta Firefox. Não é mais possível mudar sua senha aqui."
 
-#: src/olympia/users/templates/users/pwreset_confirm.html:31
-#: src/olympia/users/templates/users/register.html:72
+#: src/olympia/users/templates/users/pwreset_confirm.html:31 src/olympia/users/templates/users/register.html:72
 msgid "Confirm password"
 msgstr "Confirmar senha"
 
 #: src/olympia/users/templates/users/pwreset_confirm.html:47
-msgid ""
-"The password reset link was invalid, possibly because it has already been "
-"used.  Please request a new password reset."
-msgstr ""
-"O link de redefinição de senha é inválido, provavelmente já foi utilizado.  "
-"Por favor solicite um novo link de redefinição de senha."
+msgid "The password reset link was invalid, possibly because it has already been used. Please request a new password reset."
+msgstr "O link de redefinição de senha é inválido, provavelmente já foi utilizado.  Por favor solicite um novo link de redefinição de senha."
 
 #: src/olympia/users/templates/users/pwreset_request.html:15
-msgid ""
-"Forgotten your password? Enter your e-mail address below, and we'll e-mail "
-"instructions for setting a new one."
-msgstr ""
-"Esqueceu sua senha? Digite seu endereço de e-mail abaixo e nós enviaremos "
-"instruções para definir uma nova."
+msgid "Forgotten your password? Enter your e-mail address below, and we'll e-mail instructions for setting a new one."
+msgstr "Esqueceu sua senha? Digite seu endereço de e-mail abaixo e nós enviaremos instruções para definir uma nova."
 
 #: src/olympia/users/templates/users/pwreset_request.html:25
 msgid "Send password reset link"
@@ -16158,13 +12841,10 @@ msgstr "Enviar link de redefinição de senha"
 
 #: src/olympia/users/templates/users/pwreset_sent.html:10
 msgid ""
-"An email has been sent to the requested account with further information. If"
-" you do not receive an email then please confirm you have entered the same "
-"email address used during account registration."
+"An email has been sent to the requested account with further information. If you do not receive an email then please confirm you have entered the same email address used during account registration."
 msgstr ""
-"Uma mensagem com mais informações foi enviada para a conta solicitada. Se "
-"você não receber uma mensagem, por favor, verifique se você inseriu o mesmo "
-"endereço de e-mail usado durante a criação da sua conta."
+"Uma mensagem com mais informações foi enviada para a conta solicitada. Se você não receber uma mensagem, por favor, verifique se você inseriu o mesmo endereço de e-mail usado durante a criação da "
+"sua conta."
 
 #: src/olympia/users/templates/users/register.html:4
 msgid "New User Registration"
@@ -16175,12 +12855,8 @@ msgid "Why register?"
 msgstr "Por que eu devo criar uma conta?"
 
 #: src/olympia/users/templates/users/register.html:14
-msgid ""
-"Registration on AMO is <strong>not required</strong> if you simply want to "
-"download and install public add-ons."
-msgstr ""
-"<strong>Não é necessário</strong> o registro na AMO se você simplesmente "
-"deseja instalar complementos públicos."
+msgid "Registration on AMO is <strong>not required</strong> if you simply want to download and install public add-ons."
+msgstr "<strong>Não é necessário</strong> o registro na AMO se você simplesmente deseja instalar complementos públicos."
 
 #: src/olympia/users/templates/users/register.html:16
 msgid "You only need to register if:"
@@ -16191,52 +12867,29 @@ msgid "You want to submit reviews for add-ons"
 msgstr "Você deseja enviar revisões sobre os complementos"
 
 #: src/olympia/users/templates/users/register.html:19
-msgid ""
-"You want to keep track of your favorite add-on collections or create one "
-"yourself"
-msgstr ""
-"Você quer acompanhar as suas coleções favoritas de complementos ou criar uma"
-" você mesmo"
+msgid "You want to keep track of your favorite add-on collections or create one yourself"
+msgstr "Você quer acompanhar as suas coleções favoritas de complementos ou criar uma você mesmo"
 
 #: src/olympia/users/templates/users/register.html:20
-msgid ""
-"You are an add-on developer and want to upload your add-on for hosting on "
-"AMO"
-msgstr ""
-"Você é um desenvolvedor e deseja enviar o complemento para hospedagem no AMO"
+msgid "You are an add-on developer and want to upload your add-on for hosting on AMO"
+msgstr "Você é um desenvolvedor e deseja enviar o complemento para hospedagem no AMO"
 
 #: src/olympia/users/templates/users/register.html:23
-msgid ""
-"Upon successful registration, you will be sent a confirmation email to the "
-"address you provided. Please follow the instructions there to confirm your "
-"account."
-msgstr ""
-"Após o registo bem sucedido, será enviado um email de confirmação para o "
-"endereço que você forneceu. Por favor, siga as instruções para confirmar sua"
-" conta."
+msgid "Upon successful registration, you will be sent a confirmation email to the address you provided. Please follow the instructions there to confirm your account."
+msgstr "Após o registo bem sucedido, será enviado um email de confirmação para o endereço que você forneceu. Por favor, siga as instruções para confirmar sua conta."
 
 #: src/olympia/users/templates/users/register.html:30
 #, python-format
-msgid ""
-"If you like, you can read our <a href=\"%(legal)s\" title=\"Legal "
-"Notices\">Legal Notices</a> and <a href=\"%(privacy)s\" title=\"Privacy "
-"Policy\">Privacy Policy</a>."
-msgstr ""
-"Se deseja, você pode ler os nossos <a href=\"%(legal)s\" title=\"Legal "
-"Notices\">Avisos Legais</a> e a nossa <a href=\"%(privacy)s\" "
-"title=\"Privacy Policy\">Política de Privacidade</a>"
+msgid "If you like, you can read our <a href=\"%(legal)s\" title=\"Legal Notices\">Legal Notices</a> and <a href=\"%(privacy)s\" title=\"Privacy Policy\">Privacy Policy</a>."
+msgstr "Se deseja, você pode ler os nossos <a href=\"%(legal)s\" title=\"Legal Notices\">Avisos Legais</a> e a nossa <a href=\"%(privacy)s\" title=\"Privacy Policy\">Política de Privacidade</a>"
 
 #: src/olympia/users/templates/users/register.html:52
 msgid "Display name"
 msgstr "Nome exibido"
 
 #: src/olympia/users/templates/users/report_abuse.html:7
-msgid ""
-"Please describe why you are reporting this user, such as for spam or an "
-"inappropriate picture."
-msgstr ""
-"Por favor, descreva por que você está denunciando esse usuário; por exemplo,"
-" se é por spam ou uma foto inadequada."
+msgid "Please describe why you are reporting this user, such as for spam or an inappropriate picture."
+msgstr "Por favor, descreva por que você está denunciando esse usuário; por exemplo, se é por spam ou uma foto inadequada."
 
 #: src/olympia/users/templates/users/report_abuse_full.html:3
 msgid "Report user {0}"
@@ -16250,43 +12903,25 @@ msgstr "Pedido da camiseta"
 msgid "Special Edition Add-on Creator T-shirt"
 msgstr "Edição especial da camiseta Add-on Creator"
 
-#: src/olympia/users/templates/users/t-shirt.html:14
-#: src/olympia/users/templates/users/t-shirt.html:120
+#: src/olympia/users/templates/users/t-shirt.html:14 src/olympia/users/templates/users/t-shirt.html:120
 msgid "Note:"
 msgstr "Nota:"
 
 #: src/olympia/users/templates/users/t-shirt.html:15
-msgid ""
-"You have already submitted a request for a t-shirt. You may re-submit this "
-"form to update your information, but you will only receive one shirt."
-msgstr ""
-"Você já apresentou um pedido para uma t-shirt. Você pode re-enviar este "
-"formulário para atualizar suas informações, mas você só vai receber uma "
-"camisa."
+msgid "You have already submitted a request for a t-shirt. You may re-submit this form to update your information, but you will only receive one shirt."
+msgstr "Você já apresentou um pedido para uma t-shirt. Você pode re-enviar este formulário para atualizar suas informações, mas você só vai receber uma camisa."
 
 #: src/olympia/users/templates/users/t-shirt.html:26
-msgid ""
-"Thank you for helping to make Firefox the most extensible browser available!"
-msgstr ""
-"Obrigado por ajudar a tornar o Firefox o navegador mais extensível "
-"disponível!"
+msgid "Thank you for helping to make Firefox the most extensible browser available!"
+msgstr "Obrigado por ajudar a tornar o Firefox o navegador mais extensível disponível!"
 
 #: src/olympia/users/templates/users/t-shirt.html:33
-msgid ""
-"As a thank you gift, we'd like to send you a special-edition, community-"
-"designed t-shirt. To receive your shirt, please fill out the form below."
-msgstr ""
-"Como um presente de agradecimento, gostaríamos de enviar-lhe uma edição "
-"especial da camiseta community-designed. Para receber sua camisa, por favor,"
-" preencha o formulário abaixo."
+msgid "As a thank you gift, we'd like to send you a special-edition, community-designed t-shirt. To receive your shirt, please fill out the form below."
+msgstr "Como um presente de agradecimento, gostaríamos de enviar-lhe uma edição especial da camiseta community-designed. Para receber sua camisa, por favor, preencha o formulário abaixo."
 
 #: src/olympia/users/templates/users/t-shirt.html:41
-msgid ""
-"Your contact information will only be used by Mozilla to ship this special "
-"edition t-shirt."
-msgstr ""
-"Suas informações só serão utilizadas pela Mozilla para enviar esta edição "
-"especial da camiseta."
+msgid "Your contact information will only be used by Mozilla to ship this special edition t-shirt."
+msgstr "Suas informações só serão utilizadas pela Mozilla para enviar esta edição especial da camiseta."
 
 #: src/olympia/users/templates/users/t-shirt.html:60
 msgid "Mailing Address"
@@ -16342,23 +12977,15 @@ msgstr "Pedido da camiseta"
 
 #: src/olympia/users/templates/users/t-shirt.html:137
 msgid ""
-"We're sorry, but in order to qualify for our special edition t-shirt, you "
-"must be an add-on developer with at least one listed add-on, one unlisted "
-"but signed add-on, or any number of background themes with a combined total "
-"of 10,000 average daily users."
+"We're sorry, but in order to qualify for our special edition t-shirt, you must be an add-on developer with at least one listed add-on, one unlisted but signed add-on, or any number of background "
+"themes with a combined total of 10,000 average daily users."
 msgstr ""
-"Pedimos desculpas, mas para se qualificar para nossa edição especial da "
-"camiseta, você deve ser um desenvolvedor de complemento, com pelo menos um "
-"complemento listado, um complemento não listado mas assinado ou qualquer "
-"número de temas, com um total de 10.000 usuários em média diáriamente."
+"Pedimos desculpas, mas para se qualificar para nossa edição especial da camiseta, você deve ser um desenvolvedor de complemento, com pelo menos um complemento listado, um complemento não listado "
+"mas assinado ou qualquer número de temas, com um total de 10.000 usuários em média diáriamente."
 
 #: src/olympia/users/templates/users/tougher_password.html:2
-msgid ""
-"For your account a password must contain at least 8 characters including "
-"letters and numbers."
-msgstr ""
-"A senha da sua conta deve conter pelo menos 8 caracteres, incluindo letras e"
-" números."
+msgid "For your account a password must contain at least 8 characters including letters and numbers."
+msgstr "A senha da sua conta deve conter pelo menos 8 caracteres, incluindo letras e números."
 
 #: src/olympia/users/templates/users/unsubscribe.html:2
 msgid "Unsubscribe"
@@ -16370,11 +12997,8 @@ msgstr "Você deixou de assinar com sucesso!"
 
 #: src/olympia/users/templates/users/unsubscribe.html:10
 #, python-format
-msgid ""
-"The email address <strong>%(email)s</strong> will no longer get messages "
-"when:"
-msgstr ""
-"O endereço <strong>%(email)s</strong> deixará de receber mensagens ao:"
+msgid "The email address <strong>%(email)s</strong> will no longer get messages when:"
+msgstr "O endereço <strong>%(email)s</strong> deixará de receber mensagens ao:"
 
 #: src/olympia/users/templates/users/unsubscribe.html:20
 msgid "More Actions:"
@@ -16394,14 +13018,8 @@ msgstr "Não pudemos cancelar sua assinatura"
 
 #: src/olympia/users/templates/users/unsubscribe.html:30
 #, python-format
-msgid ""
-"Unfortunately, we weren't able to unsubscribe you.  The link you clicked is "
-"invalid. However, you can unsubscribe still unsubscribe on your <a "
-"href=\"%(edit_url)s\">edit profile page</a>."
-msgstr ""
-"Infelizmente não conseguimos descadastrá-lo.  O link que você clicou é "
-"inválido. Entretanto, você ainda pode se descadastrar <a "
-"href=\"%(edit_url)s\">editando o seu perfil</a>."
+msgid "Unfortunately, we weren't able to unsubscribe you. The link you clicked is invalid. However, you can unsubscribe still unsubscribe on your <a href=\"%(edit_url)s\">edit profile page</a>."
+msgstr "Infelizmente não conseguimos descadastrá-lo.  O link que você clicou é inválido. Entretanto, você ainda pode se descadastrar <a href=\"%(edit_url)s\">editando o seu perfil</a>."
 
 #: src/olympia/users/templates/users/vcard.html:2
 msgid "Developer Information"
@@ -16455,15 +13073,15 @@ msgstr "Histórico de versões de %s"
 msgid "Version History with Changelogs"
 msgstr "Histórico de versões com listas de alterações"
 
-#: src/olympia/versions/models.py:314
+#: src/olympia/versions/models.py:313
 msgid "Add-on uses binary components."
 msgstr "O complemento usa componentes binários."
 
-#: src/olympia/versions/models.py:317
+#: src/olympia/versions/models.py:316
 msgid "Add-on has opted into strict compatibility checking."
 msgstr "O complemento optou pela verificação de compatibilidade estrita."
 
-#: src/olympia/versions/models.py:715
+#: src/olympia/versions/models.py:711
 msgid "{app} {min} and later"
 msgstr "{app} {min} e superiores"
 
@@ -16479,9 +13097,7 @@ msgstr "Lançado em {0}"
 #: src/olympia/versions/templates/versions/version.html:39
 #, python-format
 msgid "Source code released under <a target=\"_blank\" href=\"%(url)s\">%(name)s</a>"
-msgstr ""
-"Código-fonte disponibilizado sob <a target=\"_blank\" "
-"href=\"%(url)s\">%(name)s</a>"
+msgstr "Código-fonte disponibilizado sob <a target=\"_blank\" href=\"%(url)s\">%(name)s</a>"
 
 #: src/olympia/versions/templates/versions/version.html:44
 #, python-format
@@ -16492,8 +13108,8 @@ msgstr "Código-fonte disponibilizado sob <a href=\"%(url)s\">%(name)s</a>"
 msgid "View the source"
 msgstr "Ver o código-fonte"
 
-#. {0} is an add-on name.
 # {0} is the add-on name
+#. {0} is an add-on name.
 #: src/olympia/versions/templates/versions/version_list.html:26
 msgid "{0} Version History"
 msgstr "Histórico de versões de {0}"
@@ -16505,21 +13121,14 @@ msgid_plural "<b>{0}</b> versions"
 msgstr[0] "<b>{0}</b> versão"
 msgstr[1] "<b>{0}</b> versões"
 
-#: src/olympia/versions/templates/versions/version_list.html:35
-#: src/olympia/versions/templates/versions/mobile/version_list.html:14
+#: src/olympia/versions/templates/versions/version_list.html:35 src/olympia/versions/templates/versions/mobile/version_list.html:14
 msgid "Be careful with old versions!"
 msgstr "Tenha cuidado com versões antigas!"
 
-#: src/olympia/versions/templates/versions/version_list.html:36
-#: src/olympia/versions/templates/versions/mobile/version_list.html:15
+#: src/olympia/versions/templates/versions/version_list.html:36 src/olympia/versions/templates/versions/mobile/version_list.html:15
 #, python-format
-msgid ""
-"These versions are displayed for reference and testing purposes. You should "
-"always use the <a href=\"%(url)s\">latest version</a> of an add-on."
-msgstr ""
-"Estas versões são exibidas com o propósito de testes e referência. Você deve"
-" sempre usar a <a href=\"%(url)s\">versão mais recente</a> de um "
-"complemento."
+msgid "These versions are displayed for reference and testing purposes. You should always use the <a href=\"%(url)s\">latest version</a> of an add-on."
+msgstr "Estas versões são exibidas com o propósito de testes e referência. Você deve sempre usar a <a href=\"%(url)s\">versão mais recente</a> de um complemento."
 
 #: src/olympia/versions/templates/versions/mobile/version.html:4
 msgid "Beta Version {0}"
@@ -16529,8 +13138,8 @@ msgstr "Versão beta {0}"
 msgid "Works with:"
 msgstr "Funciona com:"
 
-#. {0} is an add-on name.
 # %1$s is the add-on name
+#. {0} is an add-on name.
 #: src/olympia/versions/templates/versions/mobile/version_list.html:12
 msgid "Version History"
 msgstr "Histórico de versões"
@@ -16550,3 +13159,7 @@ msgstr "Enviar mensagem quando concluir"
 #: src/olympia/zadmin/forms.py:105
 msgid "Log emails instead of sending"
 msgstr "Registrar mensagens em vez de enviá-las"
+
+#: src/olympia/zadmin/forms.py:215
+msgid "Deleted versions can`t be changed."
+msgstr ""

--- a/locale/pt_BR/LC_MESSAGES/djangojs.po
+++ b/locale/pt_BR/LC_MESSAGES/djangojs.po
@@ -1,1279 +1,1240 @@
-# 
+#
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2016-02-24 21:23+0000\n"
+"POT-Creation-Date: 2016-04-18 15:47+0000\n"
 "PO-Revision-Date: 2016-01-30 15:19+0000\n"
 "Last-Translator: Marco Aurélio <ouesten@me.com>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
-"Language: pt_BR\n"
+"Language: \n"
 "MIME-Version: 1.0\n"
-"Content-Type: text/plain; charset=utf-8\n"
+"Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n > 1);\n"
 "Generated-By: Babel 2.2.0\n"
-"X-Generator: Pontoon\n"
 
-#: static/js/common/ratingwidget.js:31
-msgid "{0} star"
-msgid_plural "{0} stars"
-msgstr[0] "{0} estrela"
-msgstr[1] "{0} estrelas"
-
-#: static/js/common/upload-addon.js:41 static/js/common/upload-image.js:128
-msgid "There was a problem contacting the server."
-msgstr "Houve um problema ao contatar o servidor."
-
-#: static/js/common/upload-addon.js:69
-msgid "Select a file..."
-msgstr "Selecione um arquivo..."
-
-#: static/js/common/upload-addon.js:70
-msgid "Your add-on should end with .xpi, .jar or .xml"
-msgstr "Seu complemento deve terminar com .xpi, .jar ou .xml"
-
-#. L10n: {0} is the percent of the file that has been uploaded.
-#: static/js/common/upload-addon.js:104
-#, python-format
-msgid "{0}% complete"
-msgstr "{0}% completo"
-
-#. L10n: "{bytes uploaded} of {total filesize}".
-#: static/js/common/upload-addon.js:107
-msgid "{0} of {1}"
-msgstr "{0} de {1}"
-
-#: static/js/common/upload-addon.js:140
-msgid "Cancel"
-msgstr "Cancelar"
-
-#: static/js/common/upload-addon.js:162
-msgid "Uploading {0}"
-msgstr "Enviando {0}"
-
-#: static/js/common/upload-addon.js:189
-msgid "Error with {0}"
-msgstr "Erro com {0}"
-
-#: static/js/common/upload-addon.js:194
-msgid "Your add-on failed validation with {0} error."
-msgid_plural "Your add-on failed validation with {0} errors."
-msgstr[0] "Seu complemento falhou na validação com {0} erro."
-msgstr[1] "Seu complemento falhou na validação com {0} erros."
-
-#: static/js/common/upload-addon.js:208
-msgid "&hellip;and {0} more"
-msgid_plural "&hellip;and {0} more"
-msgstr[0] "&hellip;e mais {0}"
-msgstr[1] "&hellip;e mais {0}"
-
-#: static/js/common/upload-addon.js:222 static/js/common/upload-addon.js:512
-msgid "See full validation report"
-msgstr "Ver o relatório de validação completo"
-
-#: static/js/common/upload-addon.js:234
-msgid "Validating {0}"
-msgstr "Validando {0}"
-
-#. L10n: first argument is an HTTP status code
-#: static/js/common/upload-addon.js:273
-msgid "Received an empty response from the server; status: {0}"
-msgstr "Uma resposta vazia foi recebida do servidor: {0}"
-
-#: static/js/common/upload-addon.js:373
-msgid "Unexpected server error while validating."
-msgstr "Erro inesperado do servidor durante a validação."
-
-#: static/js/common/upload-addon.js:412
-msgid "Finished validating {0}"
-msgstr "Validação de {0} concluída"
-
-#: static/js/common/upload-addon.js:418
-msgid "Your add-on validation timed out, it will be manually reviewed."
-msgstr ""
-"O tempo para validação do complemento esgotou, ele será avaliado "
-"manualmente."
-
-#: static/js/common/upload-addon.js:421
-msgid "Your add-on was validated with no errors and {0} warning."
-msgid_plural "Your add-on was validated with no errors and {0} warnings."
-msgstr[0] "Seu complemento foi validado sem nenhum erro e {0} avisos."
-msgstr[1] "Seu complemento passou na validação sem erros e {0} alertas."
-
-#: static/js/common/upload-addon.js:426
-msgid "Your add-on was validated with no errors and {0} message."
-msgid_plural "Your add-on was validated with no errors and {0} messages."
-msgstr[0] "Seu complemento foi validado sem erros e {0} mensagem."
-msgstr[1] "O seu complemento foi validado sem erros e {0} mensagens."
-
-#: static/js/common/upload-addon.js:431
-msgid "Your add-on was validated with no errors or warnings."
-msgstr "Seu complemento foi validado sem erros ou avisos."
-
-#: static/js/common/upload-addon.js:446
-msgid "Your submission will be automatically signed."
-msgstr "Sua submissão será automaticamente assinada."
-
-#: static/js/common/upload-addon.js:465
-msgid "Include detailed version notes (this can be done in the next step)."
-msgstr ""
-"Incluir notas detalhadas da versão (isto pode ser feito no próximo passo)."
-
-#: static/js/common/upload-addon.js:466
-msgid ""
-"If your add-on requires an account to a website in order to be fully tested,"
-" include a test username and password in the Notes to Reviewer (this can be "
-"done in the next step)."
-msgstr ""
-"Se o seu complemento necessita de uma conta num site web para ser "
-"completamente testado, inclua um nome de usuário e senha de teste nas Notas "
-"para o Revisor (isto pode ser feito no próximo passo)."
-
-#: static/js/common/upload-addon.js:467
-msgid ""
-"If your add-on is intended for a limited audience you should choose "
-"Preliminary Review instead of Full Review."
-msgstr ""
-"Se um complemento é direcionado a uma audiência limitada deve escolher a "
-"avaliação preliminar em vez de uma avaliação completa."
-
-#: static/js/common/upload-addon.js:480
-msgid "Add-on submission checklist"
-msgstr "Lista de verificação da submissão do complemento"
-
-#: static/js/common/upload-addon.js:481
-msgid ""
-"Please verify the following points before finalizing your submission. This "
-"will minimize delays or misunderstanding during the review process:"
-msgstr ""
-"Por favor confirme os pontos seguintes antes de finalizar a sua submissão. "
-"Isto irá minimizar atrasos ou confusões durante o processo de avaliação:"
-
-#: static/js/common/upload-addon.js:483
-msgid ""
-"Compiled binaries, as well as minified or obfuscated scripts (excluding "
-"known libraries) need to have their sources submitted separately for review."
-" Make sure that you use the source code upload field to avoid having your "
-"submission rejected."
-msgstr ""
-"Binários compilados, bem como scripts minificados ou ofuscados (excluindo "
-"bibliotecas conhecidas) devem ter as suas fontes submetidas separadamente "
-"para avaliação. Tenha a certeza que utiliza o campo de envio de código fonte"
-" para evitar que as sua submissão seja rejeitada."
-
-#: static/js/common/upload-addon.js:501
-msgid "The validation process found these issues that can lead to rejections:"
-msgstr ""
-"O processo de validação encontrou estes problemas que podem levar a "
-"rejeições:"
-
-#: static/js/common/upload-addon.js:518
-msgid ""
-"If you are unfamiliar with the add-ons review process, you can read about it"
-" here."
-msgstr ""
-"Se não está familiarizado com o processo de avaliação de complementos, pode "
-"ler mais sobre o mesmo aqui."
-
-#: static/js/common/upload-addon.js:555
-msgid "Sorry, no supported platform has been found."
-msgstr "Desculpe, nenhuma plataforma suportada foi encontrada."
-
-#: static/js/common/upload-base.js:57
-msgid "The filetype you uploaded isn't recognized."
-msgstr "O tipo de arquivo que você enviou não foi reconhecido."
-
-#: static/js/common/upload-base.js:79
-msgid "You cancelled the upload."
-msgstr "Você cancelou o envio."
-
-#: static/js/common/upload-image.js:97 static/js/impala/users.js:51
-msgid "Images must be either PNG or JPG."
-msgstr "As imagens devem ser PNG ou JPG."
-
-#: static/js/common/upload-image.js:101
-msgid "Videos must be in WebM."
-msgstr "Os vídeos devem ser WebM."
-
-#: static/js/impala/collections.js:10 static/js/zamboni/collections.js:595
-msgid "Follow this Collection"
-msgstr "Seguir essa coleção"
-
-#: static/js/impala/collections.js:19
-msgid "Stop Following"
-msgstr "Deixar de seguir"
-
-#: static/js/impala/collections.js:20
-msgid "Following"
-msgstr "Seguindo"
-
-#. L10n: {0} is an app name.
-#: static/js/impala/listing.js:11 static/js/zamboni/themes.js:13
-msgid "This theme is incompatible with your version of {0}"
-msgstr "Esse tema não é compatível com a sua versão do {0}"
-
-#: static/js/impala/persona_creation.js:60
-msgid "All Rights Reserved"
-msgstr "Todos os direitos reservados"
-
-#: static/js/impala/persona_creation.js:64
-msgid "Creative Commons Attribution 3.0"
-msgstr "Creative Commons Atribuição 3.0"
-
-#: static/js/impala/persona_creation.js:69
-msgid "Creative Commons Attribution-NonCommercial 3.0"
-msgstr "Creative Commons Atribuição-Uso não-comercial 3.0"
-
-#: static/js/impala/persona_creation.js:74
-msgid "Creative Commons Attribution-NonCommercial-NoDerivs 3.0"
-msgstr ""
-"Creative Commons Atribuição-Uso não-comercial-Vedada a criação de obras "
-"derivadas 3.0"
-
-#: static/js/impala/persona_creation.js:79
-msgid "Creative Commons Attribution-NonCommercial-Share Alike 3.0"
-msgstr ""
-"Creative Commons Atribuição-Uso não-comercial-Compartilhamento pela mesma "
-"licença 3.0"
-
-#: static/js/impala/persona_creation.js:84
-msgid "Creative Commons Attribution-NoDerivs 3.0"
-msgstr "Creative Commons Atribuição-Vedada a criação de obras derivadas 3.0"
-
-#: static/js/impala/persona_creation.js:89
-msgid "Creative Commons Attribution-ShareAlike 3.0"
-msgstr "Creative Commons Atribuição-Compartilhamento pela mesma licença 3.0"
-
-#: static/js/impala/persona_creation.js:292
-msgid "Your Theme's Name"
-msgstr "Nome do seu tema"
-
-#: static/js/impala/reviews.js:23 static/js/zamboni/reviews.js:18
-msgid "Flagged for review"
-msgstr "Marcado para avaliação"
-
-#: static/js/impala/reviews.js:40 static/js/zamboni/reviews.js:34
-msgid "Your input is required"
-msgstr "Seu preenchimento é necessário"
-
-#: static/js/impala/reviews.js:152 static/js/zamboni/reviews.js:103
-msgid "Marked for deletion"
-msgstr "Marcado para exclusão"
-
-#: static/js/impala/search.js:114
-msgid "Updating results&hellip;"
-msgstr "Atualizando resultados&hellip;"
-
-#: static/js/impala/site_suggestions.js:46
-msgid "Category"
-msgstr "Categoria"
-
-#: static/js/impala/suggestions.js:39
-msgid "Search themes for <b>{0}</b>"
-msgstr "Procurar nos temas por <b>{0}</b>"
-
-#: static/js/impala/suggestions.js:41
-msgid "Search apps for <b>{0}</b>"
-msgstr "Aplicativos com <b>{0}</b>"
-
-#: static/js/impala/suggestions.js:43
-msgid "Search add-ons for <b>{0}</b>"
-msgstr "Pesquisar complementos com <b>{0}</b>"
-
-#: static/js/impala/users.js:33
-msgid "use original"
-msgstr "usar original"
-
-#: static/js/impala/stats/chart.js:267
-msgid "Week of {0}"
-msgstr "Semana de {0}"
-
-#: static/js/impala/stats/chart.js:269
-msgid " downloads"
-msgstr " downloads"
-
-#: static/js/impala/stats/chart.js:270
-msgid "{0} users"
-msgstr "{0} usuários"
-
-#: static/js/impala/stats/chart.js:271
-msgid "{0} add-ons"
-msgstr "{0} complementos"
-
-#: static/js/impala/stats/chart.js:272
-msgid "{0} collections"
-msgstr "{0} coleções"
-
-#: static/js/impala/stats/chart.js:273
-msgid "{0} reviews"
-msgstr "{0} avaliações"
-
-#: static/js/impala/stats/chart.js:275
-msgid "{0} sales"
-msgstr "{0} vendas"
-
-#: static/js/impala/stats/chart.js:276
-msgid "{0} refunds"
-msgstr "{0} reembolsos"
-
-#: static/js/impala/stats/chart.js:277
-msgid "{0} installs"
-msgstr "{0} instalações"
-
-#: static/js/impala/stats/chart.js:369 static/js/impala/stats/csv_keys.js:3
-#: static/js/impala/stats/csv_keys.js:109
-msgid "Downloads"
-msgstr "Downloads"
-
-#: static/js/impala/stats/chart.js:379 static/js/impala/stats/csv_keys.js:6
-#: static/js/impala/stats/csv_keys.js:110
-msgid "Daily Users"
-msgstr "Usuários diários"
-
-#: static/js/impala/stats/chart.js:410
-msgid "Amount, in USD"
-msgstr "Quantia, em Dólares Estadunidenses"
-
-#: static/js/impala/stats/chart.js:421 static/js/impala/stats/csv_keys.js:104
-msgid "Number of Contributions"
-msgstr "Número de contribuições"
-
-#: static/js/impala/stats/chart.js:447
-msgid "More Info..."
-msgstr "Mais informações..."
-
-#. L10n: {0} is an ISO-formatted date.
-#: static/js/impala/stats/chart.js:451
-msgid "Details for {0}"
-msgstr "Detalhes em {0}"
-
-#: static/js/impala/stats/csv_keys.js:9
-msgid "Collections Created"
-msgstr "Coleções criadas"
-
-#: static/js/impala/stats/csv_keys.js:12
-msgid "Add-ons in Use"
-msgstr "Complementos em uso"
-
-#: static/js/impala/stats/csv_keys.js:15
-msgid "Add-ons Created"
-msgstr "Complementos criados"
-
-#: static/js/impala/stats/csv_keys.js:18
-msgid "Add-ons Downloaded"
-msgstr "Complementos baixados"
-
-#: static/js/impala/stats/csv_keys.js:21
-msgid "Add-ons Updated"
-msgstr "Complementos atualizados"
-
-#: static/js/impala/stats/csv_keys.js:24
-msgid "Reviews Written"
-msgstr "Avaliações escritas"
-
-#: static/js/impala/stats/csv_keys.js:27
-msgid "User Signups"
-msgstr "Inscrições de usuários"
-
-#: static/js/impala/stats/csv_keys.js:30
-msgid "Subscribers"
-msgstr "Assinantes"
-
-#: static/js/impala/stats/csv_keys.js:33
-msgid "Ratings"
-msgstr "Avaliações"
-
-#: static/js/impala/stats/csv_keys.js:36
-#: static/js/impala/stats/csv_keys.js:114
-msgid "Sales"
-msgstr "Vendas"
-
-#: static/js/impala/stats/csv_keys.js:39
-#: static/js/impala/stats/csv_keys.js:113
-msgid "Installs"
-msgstr "Instalações"
-
-#: static/js/impala/stats/csv_keys.js:42
-msgid "Unknown"
-msgstr "Desconhecido"
-
-#: static/js/impala/stats/csv_keys.js:43
-msgid "Add-ons Manager"
-msgstr "Gerenciador de complementos"
-
-#: static/js/impala/stats/csv_keys.js:44
-msgid "Add-ons Manager Promo"
-msgstr "Gerenciador de complementos em promoção"
-
-#: static/js/impala/stats/csv_keys.js:45
-msgid "Add-ons Manager Featured"
-msgstr "Gerenciador de complementos em destaque"
-
-#: static/js/impala/stats/csv_keys.js:46
-msgid "Add-ons Manager Learn More"
-msgstr "Gerenciador do saiba mais dos complementos"
-
-#: static/js/impala/stats/csv_keys.js:47
-msgid "Search Suggestions"
-msgstr "Pesquisar Sugestões"
-
-#: static/js/impala/stats/csv_keys.js:48
-msgid "Search Results"
-msgstr "Resultados da pesquisa"
-
-#: static/js/impala/stats/csv_keys.js:49 static/js/impala/stats/csv_keys.js:50
-#: static/js/impala/stats/csv_keys.js:51
-msgid "Homepage Promo"
-msgstr "Promoção na página inicial"
-
-#: static/js/impala/stats/csv_keys.js:52 static/js/impala/stats/csv_keys.js:53
-msgid "Homepage Featured"
-msgstr "Em destaque na página inicial"
-
-#: static/js/impala/stats/csv_keys.js:54 static/js/impala/stats/csv_keys.js:55
-msgid "Homepage Up and Coming"
-msgstr "Complementos em ascensão da página inicial"
-
-#: static/js/impala/stats/csv_keys.js:56
-msgid "Homepage Most Popular"
-msgstr "Mais populares na página inicial"
-
-#: static/js/impala/stats/csv_keys.js:57 static/js/impala/stats/csv_keys.js:59
-msgid "Detail Page"
-msgstr "Página de detalhes"
-
-#: static/js/impala/stats/csv_keys.js:58 static/js/impala/stats/csv_keys.js:60
-msgid "Detail Page (bottom)"
-msgstr "Página de detalhes (fim)"
-
-#: static/js/impala/stats/csv_keys.js:61
-msgid "Detail Page (Development Channel)"
-msgstr "Página de detalhes (Canal de Desenvolvimento)"
-
-#: static/js/impala/stats/csv_keys.js:62 static/js/impala/stats/csv_keys.js:63
-#: static/js/impala/stats/csv_keys.js:64
-msgid "Often Used With"
-msgstr "Usado frequentemente com"
-
-#: static/js/impala/stats/csv_keys.js:65 static/js/impala/stats/csv_keys.js:66
-msgid "Others By Author"
-msgstr "Outros desse autor"
-
-#: static/js/impala/stats/csv_keys.js:67 static/js/impala/stats/csv_keys.js:68
-msgid "Dependencies"
-msgstr "Dependências"
-
-#: static/js/impala/stats/csv_keys.js:69 static/js/impala/stats/csv_keys.js:70
-msgid "Upsell"
-msgstr "Divulgação"
-
-#: static/js/impala/stats/csv_keys.js:71
-msgid "Meet the Developer"
-msgstr "Encontre o desenvolvedor"
-
-#: static/js/impala/stats/csv_keys.js:72
-msgid "User Profile"
-msgstr "Perfil de usuário"
-
-#: static/js/impala/stats/csv_keys.js:73
-msgid "Version History"
-msgstr "Histórico da versão"
-
-#: static/js/impala/stats/csv_keys.js:75
-msgid "Sharing"
-msgstr "Compartilhamento"
-
-#: static/js/impala/stats/csv_keys.js:76
-msgid "Category Pages"
-msgstr "Páginas de Categorias"
-
-#: static/js/impala/stats/csv_keys.js:77
-msgid "Collections"
-msgstr "Coleções"
-
-#: static/js/impala/stats/csv_keys.js:78 static/js/impala/stats/csv_keys.js:79
-msgid "Category Landing Featured Carousel"
-msgstr "Galeria de destaques"
-
-#: static/js/impala/stats/csv_keys.js:80 static/js/impala/stats/csv_keys.js:81
-msgid "Category Landing Top Rated"
-msgstr "Melhor avaliados"
-
-#: static/js/impala/stats/csv_keys.js:82 static/js/impala/stats/csv_keys.js:83
-msgid "Category Landing Most Popular"
-msgstr "Mais populares"
-
-#: static/js/impala/stats/csv_keys.js:84 static/js/impala/stats/csv_keys.js:85
-msgid "Category Landing Recently Added"
-msgstr "Adicionados recentemente"
-
-#: static/js/impala/stats/csv_keys.js:86 static/js/impala/stats/csv_keys.js:87
-msgid "Browse Listing Featured Sort"
-msgstr "Lista ordenada por Destaques"
-
-#: static/js/impala/stats/csv_keys.js:88 static/js/impala/stats/csv_keys.js:89
-msgid "Browse Listing Users Sort"
-msgstr "Lista ordenada por Usuários"
-
-#: static/js/impala/stats/csv_keys.js:90 static/js/impala/stats/csv_keys.js:91
-msgid "Browse Listing Rating Sort"
-msgstr "Lista ordenada por Avaliações"
-
-#: static/js/impala/stats/csv_keys.js:92 static/js/impala/stats/csv_keys.js:93
-msgid "Browse Listing Created Sort"
-msgstr "Lista ordenada por Criação"
-
-#: static/js/impala/stats/csv_keys.js:94 static/js/impala/stats/csv_keys.js:95
-msgid "Browse Listing Name Sort"
-msgstr "Lista ordenada por Nome"
-
-#: static/js/impala/stats/csv_keys.js:96 static/js/impala/stats/csv_keys.js:97
-msgid "Browse Listing Popular Sort"
-msgstr "Lista ordenada por Popularidade"
-
-#: static/js/impala/stats/csv_keys.js:98 static/js/impala/stats/csv_keys.js:99
-msgid "Browse Listing Updated Sort"
-msgstr "Lista ordenada por Atualização"
-
-#: static/js/impala/stats/csv_keys.js:100
-#: static/js/impala/stats/csv_keys.js:101
-msgid "Browse Listing Up and Coming Sort"
-msgstr "Lista ordenada por Ascensão"
-
-#: static/js/impala/stats/csv_keys.js:105
-msgid "Total Amount Contributed"
-msgstr "Quantia total arrecadada"
-
-#: static/js/impala/stats/csv_keys.js:106
-msgid "Average Contribution"
-msgstr "Contribuição média"
-
-#: static/js/impala/stats/csv_keys.js:115
-msgid "Usage"
-msgstr "Uso"
-
-#: static/js/impala/stats/csv_keys.js:118
-msgid "Firefox"
-msgstr "Firefox"
-
-#: static/js/impala/stats/csv_keys.js:119
-msgid "Mozilla"
-msgstr "Mozilla"
-
-#: static/js/impala/stats/csv_keys.js:120
-msgid "Thunderbird"
-msgstr "Thunderbird"
-
-#: static/js/impala/stats/csv_keys.js:121
-msgid "Sunbird"
-msgstr "Sunbird"
-
-#: static/js/impala/stats/csv_keys.js:122
-msgid "SeaMonkey"
-msgstr "SeaMonkey"
-
-#: static/js/impala/stats/csv_keys.js:123
-msgid "Fennec"
-msgstr "Fennec"
-
-#: static/js/impala/stats/csv_keys.js:124
-msgid "Android"
-msgstr "Android"
-
-#. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:129
-msgid "Downloads and Daily Users, last {0} days"
-msgstr "Downloads e usuários diários nos últimos {0} dias"
-
-#. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:131
-msgid "Downloads and Daily Users from {0} to {1}"
-msgstr "Downloads e usuários diários de {0} a {1}"
-
-#. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:135
-msgid "Installs and Daily Users, last {0} days"
-msgstr "Instalações e usuários diários nos últimos {0} dias"
-
-#. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:137
-msgid "Installs and Daily Users from {0} to {1}"
-msgstr "Instalações e usuários diários de {0} a {1}"
-
-#. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:141
-msgid "Downloads, last {0} days"
-msgstr "Downloads nos últimos {0} dias"
-
-#. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:143
-msgid "Downloads from {0} to {1}"
-msgstr "Downloads de {0} a {1}"
-
-#. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:147
-msgid "Daily Users, last {0} days"
-msgstr "Usuários diários nos últimos {0} dias"
-
-#. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:149
-msgid "Daily Users from {0} to {1}"
-msgstr "Usuários diários de {0} a {1}"
-
-#. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:153
-msgid "Applications, last {0} days"
-msgstr "Aplicativos nos últimos {0}"
-
-#. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:155
-msgid "Applications from {0} to {1}"
-msgstr "Aplicativos de {0} a {1}"
-
-#. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:159
-msgid "Platforms, last {0} days"
-msgstr "Plataformas nos últimos {0} dias"
-
-#. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:161
-msgid "Platforms from {0} to {1}"
-msgstr "Plataformas de {0} a {1}"
-
-#. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:165
-msgid "Languages, last {0} days"
-msgstr "Idiomas nos últimos {0} dias"
-
-#. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:167
-msgid "Languages from {0} to {1}"
-msgstr "Idiomas de {0} a {1}"
-
-#. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:171
-msgid "Add-on Versions, last {0} days"
-msgstr "Versões do complemento nos últimos {0} dias"
-
-#. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:173
-msgid "Add-on Versions from {0} to {1}"
-msgstr "Versões do complemento de {0} a {1}"
-
-#. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:177
-msgid "Add-on Status, last {0} days"
-msgstr "Status do complemento nos últimos {0} dias"
-
-#. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:179
-msgid "Add-on Status from {0} to {1}"
-msgstr "Status do complemento de {0} a {1}"
-
-#. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:183
-msgid "Download Sources, last {0} days"
-msgstr "Origem dos downloads nos últimos {0} dias"
-
-#. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:185
-msgid "Download Sources from {0} to {1}"
-msgstr "Origem dos downloads de {0} a {1}"
-
-#. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:189
-msgid "Contributions, last {0} days"
-msgstr "Contribuições nos últimos {0} dias"
-
-#. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:191
-msgid "Contributions from {0} to {1}"
-msgstr "Contribuições de {0} a {1}"
-
-#. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:195
-msgid "Site Metrics, last {0} days"
-msgstr "Estatísticas do site nos últimos {0} dias"
-
-#. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:197
-msgid "Site Metrics from {0} to {1}"
-msgstr "Estatísticas do site de {0} a {1}"
-
-#. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:201
-msgid "Add-ons in Use, last {0} days"
-msgstr "Complementos em uso nos últimos {0} dias"
-
-#. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:203
-msgid "Add-ons in Use from {0} to {1}"
-msgstr "Complementos em uso de {0} a {1}"
-
-#. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:207
-msgid "Add-ons Downloaded, last {0} days"
-msgstr "Complementos baixados nos últimos {0} dias"
-
-#. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:209
-msgid "Add-ons Downloaded from {0} to {1}"
-msgstr "Complementos baixados de {0} a {1}"
-
-#. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:213
-msgid "Add-ons Created, last {0} days"
-msgstr "Complementos criados nos últimos {0} dias"
-
-#. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:215
-msgid "Add-ons Created from {0} to {1}"
-msgstr "Complementos criados de {0} a {1}"
-
-#. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:219
-msgid "Add-ons Updated, last {0} days"
-msgstr "Complementos atualizados nos últimos {0} dias"
-
-#. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:221
-msgid "Add-ons Updated from {0} to {1}"
-msgstr "Complementos atualizados de {0} a {1}"
-
-#. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:225
-msgid "Reviews Written, last {0} days"
-msgstr "Avaliações escritas nos últimos {0} dias"
-
-#. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:227
-msgid "Reviews Written from {0} to {1}"
-msgstr "Avaliações escritas de {0} a {1}"
-
-#. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:231
-msgid "User Signups, last {0} days"
-msgstr "Inscrições de usuários nos últimos {0} dias"
-
-#. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:233
-msgid "User Signups from {0} to {1}"
-msgstr "Inscrições de usuários de {0} a {1}"
-
-#. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:237
-msgid "Collections Created, last {0} days"
-msgstr "Coleções criadas nos últimos {0} dias"
-
-#. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:239
-msgid "Collections Created from {0} to {1}"
-msgstr "Coleções criadas de {0} a {1}"
-
-#. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:243
-msgid "Subscribers, last {0} days"
-msgstr "Assinantes nos últimos {0} dias"
-
-#. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:245
-msgid "Subscribers from {0} to {1}"
-msgstr "Assinantes de {0} a {1}"
-
-#. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:249
-msgid "Ratings, last {0} days"
-msgstr "Avaliações nos últimos {0} dias"
-
-#. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:251
-msgid "Ratings from {0} to {1}"
-msgstr "Avaliações de {0} a {1}"
-
-#. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:255
-msgid "Sales, last {0} days"
-msgstr "Vendas nos últimos {0} dias"
-
-#. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:257
-msgid "Sales from {0} to {1}"
-msgstr "Vendas de {0} a {1}"
-
-#. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:261
-msgid "Installs, last {0} days"
-msgstr "Instalações nos últimos {0} dias"
-
-#. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:263
-msgid "Installs from {0} to {1}"
-msgstr "Instalações de {0} a {1}"
-
-#. L10n: {0} and {1} are integers.
-#: static/js/impala/stats/csv_keys.js:269
-msgid "<b>{0}</b> in last {1} days"
-msgstr "<b>{0}</b> nos últimos {1} dias"
-
-#. L10n: {0} is an integer and {1} and {2} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:271
-#: static/js/impala/stats/csv_keys.js:277
-msgid "<b>{0}</b> from {1} to {2}"
-msgstr "<b>{0}</b> de {1} a {2}"
-
-#. L10n: {0} and {1} are integers.
-#: static/js/impala/stats/csv_keys.js:275
-msgid "<b>{0}</b> average in last {1} days"
-msgstr "<b>{0}</b> em média nos últimos {1} dias"
-
-#: static/js/impala/stats/overview.js:19
-msgid "No data available."
-msgstr "Nenhum dado disponível."
-
-#: static/js/impala/stats/table.js:74
-msgid "Date"
-msgstr "Data"
-
-#: static/js/impala/stats/topchart.js:96
-msgid "Other"
-msgstr "Outro"
-
-#: static/js/zamboni/admin_validation.js:24 static/js/zamboni/devhub.js:1229
-#: static/js/zamboni/editors.js:295
-msgid "Select an application first"
-msgstr "Selecione uma aplicação antes"
-
-#: static/js/zamboni/admin_validation.js:51
-msgid "Set {0} add-on to a max version of {1} and email the author."
-msgid_plural "Set {0} add-ons to a max version of {1} and email the authors."
-msgstr[0] ""
-"Definir a versão máxima do complemento {0} para {1} e notificar o autor."
-msgstr[1] ""
-"Definir a versão máxima dos complementos {0} para {1} e notificar os "
-"autores."
-
-#: static/js/zamboni/admin_validation.js:54
-msgid "Email author of {2} add-on which failed validation."
-msgid_plural "Email authors of {2} add-ons which failed validation."
-msgstr[0] ""
-"Enviar e-mail ao autor do complemento {2} que não conseguiu a validação."
-msgstr[1] ""
-"Enviar e-mail aos autores dos complementos {2} que não conseguiram a "
-"validação."
+#: static/js/common-all.js:1426 static/js/impala-all.js:1511 static/js/zamboni/discovery-all.js:12598 static/js/zamboni/init.js:28 static/js/zamboni/mobile-all.js:14945
+msgid "This feature is temporarily disabled while we perform website maintenance. Please check back a little later."
+msgstr "Este recurso foi temporariamente desabilitado para realizamos a manutenção do site. Por favor, volte mais tarde."
 
 #. L10n: {0} is an app name like Firefox.
-#: static/js/zamboni/buttons.js:66
+#: static/js/common-all.js:1837 static/js/impala-all.js:1922 static/js/zamboni/buttons.js:73 static/js/zamboni/discovery-all.js:13108
 msgid "Accept and Install"
 msgstr "Aceitar e Instalar"
 
-#: static/js/zamboni/buttons.js:66
+#: static/js/common-all.js:1837 static/js/impala-all.js:1922 static/js/zamboni/buttons.js:73 static/js/zamboni/discovery-all.js:13108
 msgid "Add to {0}"
 msgstr "Adicionar ao {0}"
 
-#: static/js/zamboni/buttons.js:71
+#: static/js/common-all.js:1842 static/js/impala-all.js:1927 static/js/zamboni/buttons.js:78 static/js/zamboni/discovery-all.js:13113
 msgid "Download Now"
 msgstr "Baixar agora"
 
-#: static/js/zamboni/buttons.js:112
+#: static/js/common-all.js:1883 static/js/impala-all.js:1968 static/js/zamboni/buttons.js:119 static/js/zamboni/discovery-all.js:13154
 msgid "Add-on has not been updated to support default-to-compatible."
-msgstr ""
-"O complemento não foi atualizado para suportar a compatibilidade por padrão."
+msgstr "O complemento não foi atualizado para suportar a compatibilidade por padrão."
 
-#: static/js/zamboni/buttons.js:117
+#: static/js/common-all.js:1888 static/js/impala-all.js:1973 static/js/zamboni/buttons.js:124 static/js/zamboni/discovery-all.js:13159
 msgid "You need to be using Firefox 10.0 or higher."
 msgstr "Você precisa usar o Firefox 10.0 ou superior."
 
-#: static/js/zamboni/buttons.js:129
-msgid ""
-"Mozilla has marked this version as incompatible with your Firefox version."
-msgstr ""
-"A Mozilla marcou essa versão como sendo incompatível com a sua versão do "
-"Firefox."
+#: static/js/common-all.js:1900 static/js/impala-all.js:1985 static/js/zamboni/buttons.js:136 static/js/zamboni/discovery-all.js:13171
+msgid "Mozilla has marked this version as incompatible with your Firefox version."
+msgstr "A Mozilla marcou essa versão como sendo incompatível com a sua versão do Firefox."
 
 #. L10n: {0} is an platform like Windows or Linux.
-#: static/js/zamboni/buttons.js:210
+#: static/js/common-all.js:1981 static/js/impala-all.js:2066 static/js/zamboni/buttons.js:217 static/js/zamboni/discovery-all.js:13252
 msgid "Install for {0} anyway"
 msgstr "Instalar no {0} mesmo assim"
 
-#: static/js/zamboni/buttons.js:210
+#: static/js/common-all.js:1981 static/js/impala-all.js:2066 static/js/zamboni/buttons.js:217 static/js/zamboni/discovery-all.js:13252
 msgid "Download for {0} anyway"
 msgstr "Baixar para o {0} mesmo assim"
 
-#: static/js/zamboni/buttons.js:267
+#: static/js/common-all.js:2038 static/js/impala-all.js:2123 static/js/zamboni/buttons.js:274 static/js/zamboni/discovery-all.js:13309
 msgid "Not available for your platform"
 msgstr "Indisponível para a sua plataforma"
 
 #. L10n: {0} is an app name, {1} is the app version.
-#: static/js/zamboni/buttons.js:278 static/js/zamboni/buttons.js:315
+#: static/js/common-all.js:2049 static/js/common-all.js:2086 static/js/impala-all.js:2134 static/js/impala-all.js:2171 static/js/zamboni/buttons.js:286 static/js/zamboni/buttons.js:324
+#: static/js/zamboni/discovery-all.js:13320 static/js/zamboni/discovery-all.js:13357
 msgid "Not available for {0} {1}"
 msgstr "Indisponível para o {0} {1}"
 
-#: static/js/zamboni/buttons.js:341
+#: static/js/common-all.js:2112 static/js/impala-all.js:2197 static/js/zamboni/buttons.js:351 static/js/zamboni/discovery-all.js:13383
 msgid "Works with {app} {min} - {max}"
 msgstr "Funciona com o {app} {min} - {max}"
 
-#: static/js/zamboni/buttons.js:343
+#: static/js/common-all.js:2114 static/js/impala-all.js:2199 static/js/zamboni/buttons.js:353 static/js/zamboni/discovery-all.js:13385
 msgid "View other versions"
 msgstr "Ver outras versões"
 
-#: static/js/zamboni/buttons.js:391
+#: static/js/common-all.js:2162 static/js/impala-all.js:2247 static/js/zamboni/buttons.js:401 static/js/zamboni/discovery-all.js:13433
 msgid "Only with Firefox — Get Firefox Now!"
 msgstr "Apenas com o Firefox — Obter o Firefox agora!"
 
-#: static/js/zamboni/buttons.js:507 static/js/zamboni/mobile/buttons.js:43
-msgid ""
-"Sorry, you need a Mozilla-based browser (such as Firefox) to install a "
-"search plugin."
-msgstr ""
-"Sentimos, mas você precisa de um navegador baseado no Mozilla (como o "
-"Firefox) para instalar um plug-in de pesquisa."
+#: static/js/common-all.js:2278 static/js/impala-all.js:2363 static/js/zamboni/buttons.js:517 static/js/zamboni/discovery-all.js:13549 static/js/zamboni/mobile-all.js:15177
+#: static/js/zamboni/mobile/buttons.js:43
+msgid "Sorry, you need a Mozilla-based browser (such as Firefox) to install a search plugin."
+msgstr "Sentimos, mas você precisa de um navegador baseado no Mozilla (como o Firefox) para instalar um plug-in de pesquisa."
 
-#: static/js/zamboni/collections.js:229
-msgid "Adding to Favorites&hellip;"
-msgstr "Adicionando aos favoritos&hellip;"
-
-#: static/js/zamboni/collections.js:232
-msgid "Removing Favorite&hellip;"
-msgstr "Removendo favorito&hellip;"
-
-#: static/js/zamboni/collections.js:235
-msgid "Add to Favorites"
-msgstr "Adicionar aos favoritos"
-
-#: static/js/zamboni/collections.js:238
-msgid "Remove from Favorites"
-msgstr "Remover dos favoritos"
-
-#: static/js/zamboni/collections.js:303
-msgid "Pending"
-msgstr "Em espera"
-
-#: static/js/zamboni/collections.js:304
-msgid "Add a comment"
-msgstr "Adicionar um comentário"
-
-#: static/js/zamboni/collections.js:304
-msgid "Comment"
-msgstr "Comentário"
-
-#: static/js/zamboni/collections.js:305
-msgid "Remove this add-on from the collection"
-msgstr "Remover esse complemento da coleção"
-
-#: static/js/zamboni/collections.js:305 static/js/zamboni/collections.js:334
-msgid "Remove"
-msgstr "Remover"
-
-#: static/js/zamboni/collections.js:334
-msgid "Remove this user as a contributor"
-msgstr "Remover esse usuário dos colaboradores"
-
-#: static/js/zamboni/collections.js:346
-msgid "An email address is required."
-msgstr "Um endereço de e-mail é requerido."
-
-#: static/js/zamboni/collections.js:364
-msgid "You cannot add yourself as a contributor."
-msgstr "Você não pode adicionar a si mesmo como um colaborador."
-
-#: static/js/zamboni/collections.js:366
-msgid "You have already added that user."
-msgstr "Você já adicionou esse usuário."
-
-#: static/js/zamboni/collections.js:573
-msgid "Add to favorites"
-msgstr "Adicionar aos favoritos"
-
-#: static/js/zamboni/collections.js:577
-msgid "Remove from favorites"
-msgstr "Remover dos favoritos"
-
-#: static/js/zamboni/collections.js:604
-msgid "Stop following"
-msgstr "Deixar de seguir"
-
-#: static/js/zamboni/devhub.js:110
-msgid "Your browser does not support the video tag"
-msgstr "O seu navegador não suporta o elemento &lt;video&gt;"
-
-#: static/js/zamboni/devhub.js:371
-msgid "Changes Saved"
-msgstr "Alterações salvas"
-
-#: static/js/zamboni/devhub.js:387
-msgid "Enter a new author's email address"
-msgstr "Insira o e-mail de um novo autor"
-
-#: static/js/zamboni/devhub.js:536
-msgid "There was an error uploading your file."
-msgstr "Houve um erro ao enviar seu arquivo."
-
-#: static/js/zamboni/devhub.js:681
-msgid "{files} file"
-msgid_plural "{files} files"
-msgstr[0] "{files} arquivo"
-msgstr[1] "{files} arquivos"
-
-#: static/js/zamboni/devhub.js:684
-msgid "{reviews} user review"
-msgid_plural "{reviews} user reviews"
-msgstr[0] "{reviews} avaliação de usuário"
-msgstr[1] "{reviews} avaliações de usuários"
-
-#: static/js/zamboni/devhub.js:796
-msgid "Learn more"
-msgstr "Saiba mais"
-
-#: static/js/zamboni/devhub.js:800
-msgid "Example"
-msgstr "Exemplo"
-
-#: static/js/zamboni/devhub.js:1130
-msgid "Image changes being processed"
-msgstr "Processando alterações na imagem"
-
-#: static/js/zamboni/devhub.js:1280
-msgid "Must be a valid e-mail address."
-msgstr "Deve ser um endereço de e-mail válido."
-
-#: static/js/zamboni/devhub_search.js:8
-msgid "No results found."
-msgstr "Nenhum resultado encontrado."
-
-#: static/js/zamboni/editors.js:121
-msgid "{name} was viewing this page first."
-msgstr "{name} estava visualizando essa página antes."
-
-#: static/js/zamboni/editors.js:171
-msgid "Receipt checked by app."
-msgstr "Recibo verificado pelo aplicativo."
-
-#: static/js/zamboni/editors.js:173
-msgid "Receipt was not checked by app."
-msgstr "Recibo não verificado pelo aplicativo."
-
-#: static/js/zamboni/editors.js:244
-msgid "{name} was viewing this add-on first."
-msgstr "{name} estava visualizando esse complemento antes."
-
-#: static/js/zamboni/editors.js:255
-msgid "Loading&hellip;"
-msgstr "Carregando&hellip;"
-
-#: static/js/zamboni/editors.js:260
-msgid "Version Notes"
-msgstr "Notas da versão"
-
-#: static/js/zamboni/editors.js:265
-msgid "Notes for Reviewers"
-msgstr "Notas aos revisores"
-
-#: static/js/zamboni/editors.js:270
-msgid "No version notes found"
-msgstr "Não foram encontradas notas de versão"
-
-#: static/js/zamboni/editors.js:330
-msgid "Average Reviews"
-msgstr "Média de avaliações"
-
-#: static/js/zamboni/editors.js:386
-msgid "Number of Reviews"
-msgstr "Número de avaliações"
-
-#: static/js/zamboni/editors.js:445
-msgid "Error loading translation"
-msgstr "Erro ao carregar tradução"
-
-#: static/js/zamboni/files.js:411 static/js/zamboni/validator.js:261
-msgid "Ignore this message in future updates"
-msgstr "Ignore esta mensagem em atualizações futuras"
-
-#: static/js/zamboni/files.js:417 static/js/zamboni/validator.js:284
-msgid "Severity for automated signing:"
-msgstr "Severidade para assinatura automatizada:"
-
-#: static/js/zamboni/global.js:410
+#: static/js/common-all.js:9088 static/js/impala-all.js:9649 static/js/zamboni/global.js:410
 msgid "Loading..."
 msgstr "Carregando..."
 
 #. L10n: {0} is the number of characters left.
-#: static/js/zamboni/global.js:474
+#: static/js/common-all.js:9152 static/js/impala-all.js:9713 static/js/zamboni/global.js:474
 msgid "<b>{0}</b> character left."
 msgid_plural "<b>{0}</b> characters left."
 msgstr[0] "<b>{0}</b> caractere restante."
 msgstr[1] "<b>{0}</b> caracteres restantes."
 
-#: static/js/zamboni/init.js:28
-msgid ""
-"This feature is temporarily disabled while we perform website maintenance. "
-"Please check back a little later."
-msgstr ""
-"Este recurso foi temporariamente desabilitado para realizamos a manutenção "
-"do site. Por favor, volte mais tarde."
+#: static/js/common-all.js:9589 static/js/common-min.js:6 static/js/impala-all.js:10052 static/js/impala-min.js:6 static/js/common/ratingwidget.js:31 static/js/zamboni/mobile-all.js:16123
+#: static/js/zamboni/mobile-min.js:6
+msgid "{0} star"
+msgid_plural "{0} stars"
+msgstr[0] "{0} estrela"
+msgstr[1] "{0} estrelas"
 
-#: static/js/zamboni/l10n.js:45
+#: static/js/common-all.js:9676 static/js/common-min.js:6 static/js/impala-all.js:10139 static/js/impala-min.js:6 static/js/zamboni/l10n.js:45
 msgid "Remove this localization"
 msgstr "Remover essa localização"
 
-#: static/js/zamboni/password-strength.js:20
+#: static/js/common-all.js:10193 static/js/common-min.js:6 static/js/impala-all.js:10674 static/js/impala-min.js:6 static/js/zamboni/discovery-all.js:13678
+msgid "close"
+msgstr ""
+
+#: static/js/common-all.js:10860 static/js/common-min.js:6 static/js/impala-all.js:11481 static/js/impala-min.js:6 static/js/impala/reviews.js:23 static/js/zamboni/reviews.js:18
+msgid "Flagged for review"
+msgstr "Marcado para avaliação"
+
+#: static/js/common-all.js:10876 static/js/common-min.js:6 static/js/impala-all.js:11498 static/js/impala-min.js:6 static/js/impala/reviews.js:40 static/js/zamboni/reviews.js:34
+msgid "Your input is required"
+msgstr "Seu preenchimento é necessário"
+
+#: static/js/common-all.js:10945 static/js/common-min.js:6 static/js/impala-all.js:11610 static/js/impala-min.js:7 static/js/impala/reviews.js:152 static/js/zamboni/reviews.js:103
+msgid "Marked for deletion"
+msgstr "Marcado para exclusão"
+
+#: static/js/common-all.js:11573 static/js/common-min.js:7 static/js/impala-all.js:13809 static/js/impala-min.js:8 static/js/zamboni/collections.js:229
+msgid "Adding to Favorites&hellip;"
+msgstr "Adicionando aos favoritos&hellip;"
+
+#: static/js/common-all.js:11576 static/js/common-min.js:7 static/js/impala-all.js:13812 static/js/impala-min.js:8 static/js/zamboni/collections.js:232
+msgid "Removing Favorite&hellip;"
+msgstr "Removendo favorito&hellip;"
+
+#: static/js/common-all.js:11579 static/js/common-min.js:7 static/js/impala-all.js:13815 static/js/impala-min.js:8 static/js/zamboni/collections.js:235
+msgid "Add to Favorites"
+msgstr "Adicionar aos favoritos"
+
+#: static/js/common-all.js:11582 static/js/common-min.js:7 static/js/impala-all.js:13818 static/js/impala-min.js:8 static/js/zamboni/collections.js:238
+msgid "Remove from Favorites"
+msgstr "Remover dos favoritos"
+
+#: static/js/common-all.js:11647 static/js/common-min.js:7 static/js/impala-all.js:13883 static/js/impala-min.js:8 static/js/zamboni/collections.js:303
+msgid "Pending"
+msgstr "Em espera"
+
+#: static/js/common-all.js:11648 static/js/common-min.js:7 static/js/impala-all.js:13884 static/js/impala-min.js:8 static/js/zamboni/collections.js:304
+msgid "Add a comment"
+msgstr "Adicionar um comentário"
+
+#: static/js/common-all.js:11648 static/js/common-min.js:7 static/js/impala-all.js:13884 static/js/impala-min.js:8 static/js/zamboni/collections.js:304
+msgid "Comment"
+msgstr "Comentário"
+
+#: static/js/common-all.js:11649 static/js/common-min.js:7 static/js/impala-all.js:13885 static/js/impala-min.js:8 static/js/zamboni/collections.js:305
+msgid "Remove this add-on from the collection"
+msgstr "Remover esse complemento da coleção"
+
+#: static/js/common-all.js:11649 static/js/common-all.js:11678 static/js/common-min.js:7 static/js/impala-all.js:13885 static/js/impala-all.js:13914 static/js/impala-min.js:8
+#: static/js/zamboni/collections.js:305 static/js/zamboni/collections.js:334
+msgid "Remove"
+msgstr "Remover"
+
+#: static/js/common-all.js:11678 static/js/common-min.js:7 static/js/impala-all.js:13914 static/js/impala-min.js:8 static/js/zamboni/collections.js:334
+msgid "Remove this user as a contributor"
+msgstr "Remover esse usuário dos colaboradores"
+
+#: static/js/common-all.js:11690 static/js/common-min.js:7 static/js/impala-all.js:13926 static/js/impala-min.js:8 static/js/zamboni/collections.js:346
+msgid "An email address is required."
+msgstr "Um endereço de e-mail é requerido."
+
+#: static/js/common-all.js:11708 static/js/common-min.js:7 static/js/impala-all.js:13944 static/js/impala-min.js:8 static/js/zamboni/collections.js:364
+msgid "You cannot add yourself as a contributor."
+msgstr "Você não pode adicionar a si mesmo como um colaborador."
+
+#: static/js/common-all.js:11710 static/js/common-min.js:7 static/js/impala-all.js:13946 static/js/impala-min.js:8 static/js/zamboni/collections.js:366
+msgid "You have already added that user."
+msgstr "Você já adicionou esse usuário."
+
+#: static/js/common-all.js:11917 static/js/common-min.js:7 static/js/impala-all.js:14153 static/js/impala-min.js:8 static/js/zamboni/collections.js:573
+msgid "Add to favorites"
+msgstr "Adicionar aos favoritos"
+
+#: static/js/common-all.js:11921 static/js/common-min.js:7 static/js/impala-all.js:14157 static/js/impala-min.js:8 static/js/zamboni/collections.js:577
+msgid "Remove from favorites"
+msgstr "Remover dos favoritos"
+
+#: static/js/common-all.js:11939 static/js/common-min.js:7 static/js/impala-all.js:14175 static/js/impala-all.js:14233 static/js/impala-min.js:8 static/js/impala/collections.js:10
+#: static/js/zamboni/collections.js:595
+msgid "Follow this Collection"
+msgstr "Seguir essa coleção"
+
+#: static/js/common-all.js:11948 static/js/common-min.js:7 static/js/impala-all.js:14184 static/js/impala-min.js:8 static/js/zamboni/collections.js:604
+msgid "Stop following"
+msgstr "Deixar de seguir"
+
+#: static/js/common-all.js:12096 static/js/common-min.js:7 static/js/zamboni/password-strength.js:20
 msgid "Password strength:"
 msgstr "Qualidade da senha:"
 
-#: static/js/zamboni/password-strength.js:26
+#: static/js/common-all.js:12102 static/js/common-min.js:7 static/js/zamboni/password-strength.js:26
 msgid "At least {0} character left."
 msgid_plural "At least {0} characters left."
 msgstr[0] "Pelo menos {0} caractere restante."
 msgstr[1] "Pelo menos {0} caracteres restantes."
 
-#: static/js/zamboni/themes_review.js:176
-msgid "Requested Info"
-msgstr "Informações solicitadas"
+#: static/js/common-all.js:12286 static/js/common-min.js:7 static/js/impala-all.js:14632 static/js/impala-min.js:8 static/js/impala/suggestions.js:39
+msgid "Search themes for <b>{0}</b>"
+msgstr "Procurar nos temas por <b>{0}</b>"
 
-#: static/js/zamboni/themes_review.js:177
-msgid "Flagged"
-msgstr "Marcado"
+#: static/js/common-all.js:12288 static/js/common-min.js:7 static/js/impala-all.js:14634 static/js/impala-min.js:8 static/js/impala/suggestions.js:41
+msgid "Search apps for <b>{0}</b>"
+msgstr "Aplicativos com <b>{0}</b>"
 
-#: static/js/zamboni/themes_review.js:178
-msgid "Duplicate"
-msgstr "Duplicado"
+#: static/js/common-all.js:12290 static/js/common-min.js:7 static/js/impala-all.js:14636 static/js/impala-min.js:8 static/js/impala/suggestions.js:43
+msgid "Search add-ons for <b>{0}</b>"
+msgstr "Pesquisar complementos com <b>{0}</b>"
 
-#: static/js/zamboni/themes_review.js:179
-msgid "Rejected"
-msgstr "Rejeitado"
+#: static/js/common-all.js:12521 static/js/common-min.js:7 static/js/impala-all.js:14867 static/js/impala-min.js:8 static/js/impala/site_suggestions.js:46
+msgid "Category"
+msgstr "Categoria"
 
-#: static/js/zamboni/themes_review.js:180
-msgid "Approved"
-msgstr "Aprovado"
+#. L10n: {0} is an app name.
+#: static/js/impala-all.js:11632 static/js/impala-min.js:7 static/js/impala/listing.js:11 static/js/zamboni/themes.js:13
+msgid "This theme is incompatible with your version of {0}"
+msgstr "Esse tema não é compatível com a sua versão do {0}"
 
-#: static/js/zamboni/themes_review.js:424
-msgid "No results found"
-msgstr "Nenhum resultado encontrado"
+#: static/js/impala-all.js:12146 static/js/impala-all.js:14331 static/js/impala-min.js:7 static/js/impala-min.js:8 static/js/common/upload-image.js:97 static/js/impala/users.js:51
+#: static/js/zamboni/devhub-all.js:894 static/js/zamboni/devhub-min.js:1
+msgid "Images must be either PNG or JPG."
+msgstr "As imagens devem ser PNG ou JPG."
 
-#: static/js/zamboni/themes_review_templates.js:31
-msgid "Theme"
-msgstr "Tema"
+#: static/js/impala-all.js:12150 static/js/impala-min.js:7 static/js/common/upload-image.js:101 static/js/zamboni/devhub-all.js:898 static/js/zamboni/devhub-min.js:1
+msgid "Videos must be in WebM."
+msgstr "Os vídeos devem ser WebM."
 
-#: static/js/zamboni/themes_review_templates.js:33
-msgid "Reviewer"
-msgstr "Revisor"
+#: static/js/impala-all.js:12177 static/js/impala-min.js:7 static/js/common/upload-addon.js:41 static/js/common/upload-image.js:128 static/js/zamboni/devhub-all.js:272
+#: static/js/zamboni/devhub-all.js:925 static/js/zamboni/devhub-min.js:1
+msgid "There was a problem contacting the server."
+msgstr "Houve um problema ao contatar o servidor."
 
-#: static/js/zamboni/themes_review_templates.js:35
-msgid "Status"
-msgstr "Estado"
+#: static/js/impala-all.js:13298 static/js/impala-min.js:7 static/js/impala/persona_creation.js:60
+msgid "All Rights Reserved"
+msgstr "Todos os direitos reservados"
 
-#: static/js/zamboni/validator.js:80
+#: static/js/impala-all.js:13302 static/js/impala-min.js:7 static/js/impala/persona_creation.js:64
+msgid "Creative Commons Attribution 3.0"
+msgstr "Creative Commons Atribuição 3.0"
+
+#: static/js/impala-all.js:13307 static/js/impala-min.js:7 static/js/impala/persona_creation.js:69
+msgid "Creative Commons Attribution-NonCommercial 3.0"
+msgstr "Creative Commons Atribuição-Uso não-comercial 3.0"
+
+#: static/js/impala-all.js:13312 static/js/impala-min.js:7 static/js/impala/persona_creation.js:74
+msgid "Creative Commons Attribution-NonCommercial-NoDerivs 3.0"
+msgstr "Creative Commons Atribuição-Uso não-comercial-Vedada a criação de obras derivadas 3.0"
+
+#: static/js/impala-all.js:13317 static/js/impala-min.js:7 static/js/impala/persona_creation.js:79
+msgid "Creative Commons Attribution-NonCommercial-Share Alike 3.0"
+msgstr "Creative Commons Atribuição-Uso não-comercial-Compartilhamento pela mesma licença 3.0"
+
+#: static/js/impala-all.js:13322 static/js/impala-min.js:7 static/js/impala/persona_creation.js:84
+msgid "Creative Commons Attribution-NoDerivs 3.0"
+msgstr "Creative Commons Atribuição-Vedada a criação de obras derivadas 3.0"
+
+#: static/js/impala-all.js:13327 static/js/impala-min.js:7 static/js/impala/persona_creation.js:89
+msgid "Creative Commons Attribution-ShareAlike 3.0"
+msgstr "Creative Commons Atribuição-Compartilhamento pela mesma licença 3.0"
+
+#: static/js/impala-all.js:13530 static/js/impala-min.js:7 static/js/impala/persona_creation.js:292
+msgid "Your Theme's Name"
+msgstr "Nome do seu tema"
+
+#: static/js/impala-all.js:14242 static/js/impala-min.js:8 static/js/impala/collections.js:19
+msgid "Stop Following"
+msgstr "Deixar de seguir"
+
+#: static/js/impala-all.js:14243 static/js/impala-min.js:8 static/js/impala/collections.js:20
+msgid "Following"
+msgstr "Seguindo"
+
+#: static/js/impala-all.js:14313 static/js/impala-min.js:8 static/js/impala/users.js:33
+msgid "use original"
+msgstr "usar original"
+
+#: static/js/impala-all.js:14523 static/js/impala-min.js:8 static/js/impala/search.js:114
+msgid "Updating results&hellip;"
+msgstr "Atualizando resultados&hellip;"
+
+#: static/js/common/upload-addon.js:69 static/js/zamboni/devhub-all.js:300 static/js/zamboni/devhub-min.js:1
+msgid "Select a file..."
+msgstr "Selecione um arquivo..."
+
+#: static/js/common/upload-addon.js:70 static/js/zamboni/devhub-all.js:301 static/js/zamboni/devhub-min.js:1
+msgid "Your add-on should end with .xpi, .jar or .xml"
+msgstr "Seu complemento deve terminar com .xpi, .jar ou .xml"
+
+#. L10n: {0} is the percent of the file that has been uploaded.
+#: static/js/common/upload-addon.js:104 static/js/zamboni/devhub-all.js:335 static/js/zamboni/devhub-min.js:1
+#, python-format
+msgid "{0}% complete"
+msgstr "{0}% completo"
+
+#. L10n: "{bytes uploaded} of {total filesize}".
+#: static/js/common/upload-addon.js:107 static/js/zamboni/devhub-all.js:338 static/js/zamboni/devhub-min.js:1
+msgid "{0} of {1}"
+msgstr "{0} de {1}"
+
+#: static/js/common/upload-addon.js:140 static/js/zamboni/devhub-all.js:371 static/js/zamboni/devhub-min.js:1
+msgid "Cancel"
+msgstr "Cancelar"
+
+#: static/js/common/upload-addon.js:162 static/js/zamboni/devhub-all.js:393 static/js/zamboni/devhub-min.js:1
+msgid "Uploading {0}"
+msgstr "Enviando {0}"
+
+#: static/js/common/upload-addon.js:189 static/js/zamboni/devhub-all.js:420 static/js/zamboni/devhub-min.js:1
+msgid "Error with {0}"
+msgstr "Erro com {0}"
+
+#: static/js/common/upload-addon.js:194 static/js/zamboni/devhub-all.js:425 static/js/zamboni/devhub-min.js:1
+msgid "Your add-on failed validation with {0} error."
+msgid_plural "Your add-on failed validation with {0} errors."
+msgstr[0] "Seu complemento falhou na validação com {0} erro."
+msgstr[1] "Seu complemento falhou na validação com {0} erros."
+
+#: static/js/common/upload-addon.js:208 static/js/zamboni/devhub-all.js:439 static/js/zamboni/devhub-min.js:1
+msgid "&hellip;and {0} more"
+msgid_plural "&hellip;and {0} more"
+msgstr[0] "&hellip;e mais {0}"
+msgstr[1] "&hellip;e mais {0}"
+
+#: static/js/common/upload-addon.js:222 static/js/common/upload-addon.js:497 static/js/zamboni/devhub-all.js:453 static/js/zamboni/devhub-all.js:743 static/js/zamboni/devhub-min.js:1
+msgid "See full validation report"
+msgstr "Ver o relatório de validação completo"
+
+#: static/js/common/upload-addon.js:234 static/js/zamboni/devhub-all.js:465 static/js/zamboni/devhub-min.js:1
+msgid "Validating {0}"
+msgstr "Validando {0}"
+
+#. L10n: first argument is an HTTP status code
+#: static/js/common/upload-addon.js:273 static/js/zamboni/devhub-all.js:504 static/js/zamboni/devhub-min.js:1
+msgid "Received an empty response from the server; status: {0}"
+msgstr "Uma resposta vazia foi recebida do servidor: {0}"
+
+#: static/js/common/upload-addon.js:370 static/js/zamboni/devhub-all.js:604 static/js/zamboni/devhub-min.js:1
+msgid "Unexpected server error while validating."
+msgstr "Erro inesperado do servidor durante a validação."
+
+#: static/js/common/upload-addon.js:409 static/js/zamboni/devhub-all.js:643 static/js/zamboni/devhub-min.js:1
+msgid "Finished validating {0}"
+msgstr "Validação de {0} concluída"
+
+#: static/js/common/upload-addon.js:415 static/js/zamboni/devhub-all.js:649 static/js/zamboni/devhub-min.js:1
+msgid "Your add-on validation timed out, it will be manually reviewed."
+msgstr "O tempo para validação do complemento esgotou, ele será avaliado manualmente."
+
+#: static/js/common/upload-addon.js:418 static/js/zamboni/devhub-all.js:652 static/js/zamboni/devhub-min.js:1
+msgid "Your add-on was validated with no errors and {0} warning."
+msgid_plural "Your add-on was validated with no errors and {0} warnings."
+msgstr[0] "Seu complemento foi validado sem nenhum erro e {0} avisos."
+msgstr[1] "Seu complemento passou na validação sem erros e {0} alertas."
+
+#: static/js/common/upload-addon.js:423 static/js/zamboni/devhub-all.js:657 static/js/zamboni/devhub-min.js:1
+msgid "Your add-on was validated with no errors and {0} message."
+msgid_plural "Your add-on was validated with no errors and {0} messages."
+msgstr[0] "Seu complemento foi validado sem erros e {0} mensagem."
+msgstr[1] "O seu complemento foi validado sem erros e {0} mensagens."
+
+#: static/js/common/upload-addon.js:428 static/js/zamboni/devhub-all.js:662 static/js/zamboni/devhub-min.js:1
+msgid "Your add-on was validated with no errors or warnings."
+msgstr "Seu complemento foi validado sem erros ou avisos."
+
+#: static/js/common/upload-addon.js:443 static/js/zamboni/devhub-all.js:677 static/js/zamboni/devhub-min.js:1
+msgid "Your submission will be automatically signed."
+msgstr "Sua submissão será automaticamente assinada."
+
+#: static/js/common/upload-addon.js:450 static/js/zamboni/devhub-all.js:696 static/js/zamboni/devhub-min.js:1
+msgid "Include detailed version notes (this can be done in the next step)."
+msgstr "Incluir notas detalhadas da versão (isto pode ser feito no próximo passo)."
+
+#: static/js/common/upload-addon.js:451 static/js/zamboni/devhub-all.js:697 static/js/zamboni/devhub-min.js:1
+msgid "If your add-on requires an account to a website in order to be fully tested, include a test username and password in the Notes to Reviewer (this can be done in the next step)."
+msgstr ""
+"Se o seu complemento necessita de uma conta num site web para ser completamente testado, inclua um nome de usuário e senha de teste nas Notas para o Revisor (isto pode ser feito no próximo passo)."
+
+#: static/js/common/upload-addon.js:452 static/js/zamboni/devhub-all.js:698 static/js/zamboni/devhub-min.js:1
+msgid "If your add-on is intended for a limited audience you should choose Preliminary Review instead of Full Review."
+msgstr "Se um complemento é direcionado a uma audiência limitada deve escolher a avaliação preliminar em vez de uma avaliação completa."
+
+#: static/js/common/upload-addon.js:465 static/js/zamboni/devhub-all.js:711 static/js/zamboni/devhub-min.js:1
+msgid "Add-on submission checklist"
+msgstr "Lista de verificação da submissão do complemento"
+
+#: static/js/common/upload-addon.js:466 static/js/zamboni/devhub-all.js:712 static/js/zamboni/devhub-min.js:1
+msgid "Please verify the following points before finalizing your submission. This will minimize delays or misunderstanding during the review process:"
+msgstr "Por favor confirme os pontos seguintes antes de finalizar a sua submissão. Isto irá minimizar atrasos ou confusões durante o processo de avaliação:"
+
+#: static/js/common/upload-addon.js:468 static/js/zamboni/devhub-all.js:714 static/js/zamboni/devhub-min.js:1
+msgid ""
+"Compiled binaries, as well as minified or obfuscated scripts (excluding known libraries) need to have their sources submitted separately for review. Make sure that you use the source code upload "
+"field to avoid having your submission rejected."
+msgstr ""
+"Binários compilados, bem como scripts minificados ou ofuscados (excluindo bibliotecas conhecidas) devem ter as suas fontes submetidas separadamente para avaliação. Tenha a certeza que utiliza o "
+"campo de envio de código fonte para evitar que as sua submissão seja rejeitada."
+
+#: static/js/common/upload-addon.js:486 static/js/zamboni/devhub-all.js:732 static/js/zamboni/devhub-min.js:1
+msgid "The validation process found these issues that can lead to rejections:"
+msgstr "O processo de validação encontrou estes problemas que podem levar a rejeições:"
+
+#: static/js/common/upload-addon.js:503 static/js/zamboni/devhub-all.js:749 static/js/zamboni/devhub-min.js:1
+msgid "If you are unfamiliar with the add-ons review process, you can read about it here."
+msgstr "Se não está familiarizado com o processo de avaliação de complementos, pode ler mais sobre o mesmo aqui."
+
+#: static/js/common/upload-addon.js:540 static/js/zamboni/devhub-all.js:786 static/js/zamboni/devhub-min.js:1
+msgid "Sorry, no supported platform has been found."
+msgstr "Desculpe, nenhuma plataforma suportada foi encontrada."
+
+#: static/js/common/upload-base.js:57 static/js/zamboni/devhub-all.js:187 static/js/zamboni/devhub-min.js:1
+msgid "The filetype you uploaded isn't recognized."
+msgstr "O tipo de arquivo que você enviou não foi reconhecido."
+
+#: static/js/common/upload-base.js:79 static/js/zamboni/devhub-all.js:209 static/js/zamboni/devhub-min.js:1
+msgid "You cancelled the upload."
+msgstr "Você cancelou o envio."
+
+#: static/js/impala/stats/chart.js:267 static/js/zamboni/stats-all.js:16898 static/js/zamboni/stats-min.js:5
+msgid "Week of {0}"
+msgstr "Semana de {0}"
+
+#: static/js/impala/stats/chart.js:269 static/js/zamboni/stats-all.js:16900 static/js/zamboni/stats-min.js:5
+msgid " downloads"
+msgstr ""
+
+#: static/js/impala/stats/chart.js:270 static/js/zamboni/stats-all.js:16901 static/js/zamboni/stats-min.js:5
+msgid "{0} users"
+msgstr "{0} usuários"
+
+#: static/js/impala/stats/chart.js:271 static/js/zamboni/stats-all.js:16902 static/js/zamboni/stats-min.js:5
+msgid "{0} add-ons"
+msgstr "{0} complementos"
+
+#: static/js/impala/stats/chart.js:272 static/js/zamboni/stats-all.js:16903 static/js/zamboni/stats-min.js:5
+msgid "{0} collections"
+msgstr "{0} coleções"
+
+#: static/js/impala/stats/chart.js:273 static/js/zamboni/stats-all.js:16904 static/js/zamboni/stats-min.js:5
+msgid "{0} reviews"
+msgstr "{0} avaliações"
+
+#: static/js/impala/stats/chart.js:275 static/js/zamboni/stats-all.js:16906 static/js/zamboni/stats-min.js:5
+msgid "{0} sales"
+msgstr "{0} vendas"
+
+#: static/js/impala/stats/chart.js:276 static/js/zamboni/stats-all.js:16907 static/js/zamboni/stats-min.js:5
+msgid "{0} refunds"
+msgstr "{0} reembolsos"
+
+#: static/js/impala/stats/chart.js:277 static/js/zamboni/stats-all.js:16908 static/js/zamboni/stats-min.js:5
+msgid "{0} installs"
+msgstr "{0} instalações"
+
+#: static/js/impala/stats/chart.js:369 static/js/impala/stats/csv_keys.js:3 static/js/impala/stats/csv_keys.js:109 static/js/zamboni/stats-all.js:15284 static/js/zamboni/stats-all.js:15390
+#: static/js/zamboni/stats-all.js:17000 static/js/zamboni/stats-min.js:4 static/js/zamboni/stats-min.js:5
+msgid "Downloads"
+msgstr "Downloads"
+
+#: static/js/impala/stats/chart.js:379 static/js/impala/stats/csv_keys.js:6 static/js/impala/stats/csv_keys.js:110 static/js/zamboni/stats-all.js:15287 static/js/zamboni/stats-all.js:15391
+#: static/js/zamboni/stats-all.js:17010 static/js/zamboni/stats-min.js:4 static/js/zamboni/stats-min.js:5
+msgid "Daily Users"
+msgstr "Usuários diários"
+
+#: static/js/impala/stats/chart.js:410 static/js/zamboni/stats-all.js:17041 static/js/zamboni/stats-min.js:5
+msgid "Amount, in USD"
+msgstr "Quantia, em Dólares Estadunidenses"
+
+#: static/js/impala/stats/chart.js:421 static/js/impala/stats/csv_keys.js:104 static/js/zamboni/stats-all.js:15385 static/js/zamboni/stats-all.js:17052 static/js/zamboni/stats-min.js:5
+msgid "Number of Contributions"
+msgstr "Número de contribuições"
+
+#: static/js/impala/stats/chart.js:447 static/js/zamboni/stats-all.js:17078 static/js/zamboni/stats-min.js:5
+msgid "More Info..."
+msgstr "Mais informações..."
+
+#. L10n: {0} is an ISO-formatted date.
+#: static/js/impala/stats/chart.js:451 static/js/zamboni/stats-all.js:17082 static/js/zamboni/stats-min.js:5
+msgid "Details for {0}"
+msgstr "Detalhes em {0}"
+
+#: static/js/impala/stats/csv_keys.js:9 static/js/zamboni/stats-all.js:15290 static/js/zamboni/stats-min.js:4
+msgid "Collections Created"
+msgstr "Coleções criadas"
+
+#: static/js/impala/stats/csv_keys.js:12 static/js/zamboni/stats-all.js:15293 static/js/zamboni/stats-min.js:4
+msgid "Add-ons in Use"
+msgstr "Complementos em uso"
+
+#: static/js/impala/stats/csv_keys.js:15 static/js/zamboni/stats-all.js:15296 static/js/zamboni/stats-min.js:4
+msgid "Add-ons Created"
+msgstr "Complementos criados"
+
+#: static/js/impala/stats/csv_keys.js:18 static/js/zamboni/stats-all.js:15299 static/js/zamboni/stats-min.js:4
+msgid "Add-ons Downloaded"
+msgstr "Complementos baixados"
+
+#: static/js/impala/stats/csv_keys.js:21 static/js/zamboni/stats-all.js:15302 static/js/zamboni/stats-min.js:4
+msgid "Add-ons Updated"
+msgstr "Complementos atualizados"
+
+#: static/js/impala/stats/csv_keys.js:24 static/js/zamboni/stats-all.js:15305 static/js/zamboni/stats-min.js:4
+msgid "Reviews Written"
+msgstr "Avaliações escritas"
+
+#: static/js/impala/stats/csv_keys.js:27 static/js/zamboni/stats-all.js:15308 static/js/zamboni/stats-min.js:4
+msgid "User Signups"
+msgstr "Inscrições de usuários"
+
+#: static/js/impala/stats/csv_keys.js:30 static/js/zamboni/stats-all.js:15311 static/js/zamboni/stats-min.js:4
+msgid "Subscribers"
+msgstr "Assinantes"
+
+#: static/js/impala/stats/csv_keys.js:33 static/js/zamboni/stats-all.js:15314 static/js/zamboni/stats-min.js:4
+msgid "Ratings"
+msgstr "Avaliações"
+
+#: static/js/impala/stats/csv_keys.js:36 static/js/impala/stats/csv_keys.js:114 static/js/zamboni/stats-all.js:15317 static/js/zamboni/stats-all.js:15395 static/js/zamboni/stats-min.js:4
+#: static/js/zamboni/stats-min.js:5
+msgid "Sales"
+msgstr "Vendas"
+
+#: static/js/impala/stats/csv_keys.js:39 static/js/impala/stats/csv_keys.js:113 static/js/zamboni/stats-all.js:15320 static/js/zamboni/stats-all.js:15394 static/js/zamboni/stats-min.js:4
+#: static/js/zamboni/stats-min.js:5
+msgid "Installs"
+msgstr "Instalações"
+
+#: static/js/impala/stats/csv_keys.js:42 static/js/zamboni/stats-all.js:15323 static/js/zamboni/stats-min.js:4
+msgid "Unknown"
+msgstr "Desconhecido"
+
+#: static/js/impala/stats/csv_keys.js:43 static/js/zamboni/stats-all.js:15324 static/js/zamboni/stats-min.js:4
+msgid "Add-ons Manager"
+msgstr "Gerenciador de complementos"
+
+#: static/js/impala/stats/csv_keys.js:44 static/js/zamboni/stats-all.js:15325 static/js/zamboni/stats-min.js:4
+msgid "Add-ons Manager Promo"
+msgstr "Gerenciador de complementos em promoção"
+
+#: static/js/impala/stats/csv_keys.js:45 static/js/zamboni/stats-all.js:15326 static/js/zamboni/stats-min.js:4
+msgid "Add-ons Manager Featured"
+msgstr "Gerenciador de complementos em destaque"
+
+#: static/js/impala/stats/csv_keys.js:46 static/js/zamboni/stats-all.js:15327 static/js/zamboni/stats-min.js:4
+msgid "Add-ons Manager Learn More"
+msgstr "Gerenciador do saiba mais dos complementos"
+
+#: static/js/impala/stats/csv_keys.js:47 static/js/zamboni/stats-all.js:15328 static/js/zamboni/stats-min.js:4
+msgid "Search Suggestions"
+msgstr "Pesquisar Sugestões"
+
+#: static/js/impala/stats/csv_keys.js:48 static/js/zamboni/stats-all.js:15329 static/js/zamboni/stats-min.js:4
+msgid "Search Results"
+msgstr "Resultados da pesquisa"
+
+#: static/js/impala/stats/csv_keys.js:49 static/js/impala/stats/csv_keys.js:50 static/js/impala/stats/csv_keys.js:51 static/js/zamboni/stats-all.js:15330 static/js/zamboni/stats-all.js:15331
+#: static/js/zamboni/stats-all.js:15332 static/js/zamboni/stats-min.js:4
+msgid "Homepage Promo"
+msgstr "Promoção na página inicial"
+
+#: static/js/impala/stats/csv_keys.js:52 static/js/impala/stats/csv_keys.js:53 static/js/zamboni/stats-all.js:15333 static/js/zamboni/stats-all.js:15334 static/js/zamboni/stats-min.js:4
+msgid "Homepage Featured"
+msgstr "Em destaque na página inicial"
+
+#: static/js/impala/stats/csv_keys.js:54 static/js/impala/stats/csv_keys.js:55 static/js/zamboni/stats-all.js:15335 static/js/zamboni/stats-all.js:15336 static/js/zamboni/stats-min.js:4
+msgid "Homepage Up and Coming"
+msgstr "Complementos em ascensão da página inicial"
+
+#: static/js/impala/stats/csv_keys.js:56 static/js/zamboni/stats-all.js:15337 static/js/zamboni/stats-min.js:4
+msgid "Homepage Most Popular"
+msgstr "Mais populares na página inicial"
+
+#: static/js/impala/stats/csv_keys.js:57 static/js/impala/stats/csv_keys.js:59 static/js/zamboni/stats-all.js:15338 static/js/zamboni/stats-all.js:15340 static/js/zamboni/stats-min.js:4
+msgid "Detail Page"
+msgstr "Página de detalhes"
+
+#: static/js/impala/stats/csv_keys.js:58 static/js/impala/stats/csv_keys.js:60 static/js/zamboni/stats-all.js:15339 static/js/zamboni/stats-all.js:15341 static/js/zamboni/stats-min.js:4
+msgid "Detail Page (bottom)"
+msgstr "Página de detalhes (fim)"
+
+#: static/js/impala/stats/csv_keys.js:61 static/js/zamboni/stats-all.js:15342 static/js/zamboni/stats-min.js:4
+msgid "Detail Page (Development Channel)"
+msgstr "Página de detalhes (Canal de Desenvolvimento)"
+
+#: static/js/impala/stats/csv_keys.js:62 static/js/impala/stats/csv_keys.js:63 static/js/impala/stats/csv_keys.js:64 static/js/zamboni/stats-all.js:15343 static/js/zamboni/stats-all.js:15344
+#: static/js/zamboni/stats-all.js:15345 static/js/zamboni/stats-min.js:4
+msgid "Often Used With"
+msgstr "Usado frequentemente com"
+
+#: static/js/impala/stats/csv_keys.js:65 static/js/impala/stats/csv_keys.js:66 static/js/zamboni/stats-all.js:15346 static/js/zamboni/stats-all.js:15347 static/js/zamboni/stats-min.js:4
+msgid "Others By Author"
+msgstr "Outros desse autor"
+
+#: static/js/impala/stats/csv_keys.js:67 static/js/impala/stats/csv_keys.js:68 static/js/zamboni/stats-all.js:15348 static/js/zamboni/stats-all.js:15349 static/js/zamboni/stats-min.js:4
+msgid "Dependencies"
+msgstr "Dependências"
+
+#: static/js/impala/stats/csv_keys.js:69 static/js/impala/stats/csv_keys.js:70 static/js/zamboni/stats-all.js:15350 static/js/zamboni/stats-all.js:15351 static/js/zamboni/stats-min.js:4
+msgid "Upsell"
+msgstr "Divulgação"
+
+#: static/js/impala/stats/csv_keys.js:71 static/js/zamboni/stats-all.js:15352 static/js/zamboni/stats-min.js:4
+msgid "Meet the Developer"
+msgstr "Encontre o desenvolvedor"
+
+#: static/js/impala/stats/csv_keys.js:72 static/js/zamboni/stats-all.js:15353 static/js/zamboni/stats-min.js:4
+msgid "User Profile"
+msgstr "Perfil de usuário"
+
+#: static/js/impala/stats/csv_keys.js:73 static/js/zamboni/stats-all.js:15354 static/js/zamboni/stats-min.js:4
+msgid "Version History"
+msgstr "Histórico da versão"
+
+#: static/js/impala/stats/csv_keys.js:75 static/js/zamboni/stats-all.js:15356 static/js/zamboni/stats-min.js:4
+msgid "Sharing"
+msgstr "Compartilhamento"
+
+#: static/js/impala/stats/csv_keys.js:76 static/js/zamboni/stats-all.js:15357 static/js/zamboni/stats-min.js:4
+msgid "Category Pages"
+msgstr "Páginas de Categorias"
+
+#: static/js/impala/stats/csv_keys.js:77 static/js/zamboni/stats-all.js:15358 static/js/zamboni/stats-min.js:4
+msgid "Collections"
+msgstr "Coleções"
+
+#: static/js/impala/stats/csv_keys.js:78 static/js/impala/stats/csv_keys.js:79 static/js/zamboni/stats-all.js:15359 static/js/zamboni/stats-all.js:15360 static/js/zamboni/stats-min.js:4
+msgid "Category Landing Featured Carousel"
+msgstr "Galeria de destaques"
+
+#: static/js/impala/stats/csv_keys.js:80 static/js/impala/stats/csv_keys.js:81 static/js/zamboni/stats-all.js:15361 static/js/zamboni/stats-all.js:15362 static/js/zamboni/stats-min.js:4
+msgid "Category Landing Top Rated"
+msgstr "Melhor avaliados"
+
+#: static/js/impala/stats/csv_keys.js:82 static/js/impala/stats/csv_keys.js:83 static/js/zamboni/stats-all.js:15363 static/js/zamboni/stats-all.js:15364 static/js/zamboni/stats-min.js:5
+msgid "Category Landing Most Popular"
+msgstr "Mais populares"
+
+#: static/js/impala/stats/csv_keys.js:84 static/js/impala/stats/csv_keys.js:85 static/js/zamboni/stats-all.js:15365 static/js/zamboni/stats-all.js:15366 static/js/zamboni/stats-min.js:5
+msgid "Category Landing Recently Added"
+msgstr "Adicionados recentemente"
+
+#: static/js/impala/stats/csv_keys.js:86 static/js/impala/stats/csv_keys.js:87 static/js/zamboni/stats-all.js:15367 static/js/zamboni/stats-all.js:15368 static/js/zamboni/stats-min.js:5
+msgid "Browse Listing Featured Sort"
+msgstr "Lista ordenada por Destaques"
+
+#: static/js/impala/stats/csv_keys.js:88 static/js/impala/stats/csv_keys.js:89 static/js/zamboni/stats-all.js:15369 static/js/zamboni/stats-all.js:15370 static/js/zamboni/stats-min.js:5
+msgid "Browse Listing Users Sort"
+msgstr "Lista ordenada por Usuários"
+
+#: static/js/impala/stats/csv_keys.js:90 static/js/impala/stats/csv_keys.js:91 static/js/zamboni/stats-all.js:15371 static/js/zamboni/stats-all.js:15372 static/js/zamboni/stats-min.js:5
+msgid "Browse Listing Rating Sort"
+msgstr "Lista ordenada por Avaliações"
+
+#: static/js/impala/stats/csv_keys.js:92 static/js/impala/stats/csv_keys.js:93 static/js/zamboni/stats-all.js:15373 static/js/zamboni/stats-all.js:15374 static/js/zamboni/stats-min.js:5
+msgid "Browse Listing Created Sort"
+msgstr "Lista ordenada por Criação"
+
+#: static/js/impala/stats/csv_keys.js:94 static/js/impala/stats/csv_keys.js:95 static/js/zamboni/stats-all.js:15375 static/js/zamboni/stats-all.js:15376 static/js/zamboni/stats-min.js:5
+msgid "Browse Listing Name Sort"
+msgstr "Lista ordenada por Nome"
+
+#: static/js/impala/stats/csv_keys.js:96 static/js/impala/stats/csv_keys.js:97 static/js/zamboni/stats-all.js:15377 static/js/zamboni/stats-all.js:15378 static/js/zamboni/stats-min.js:5
+msgid "Browse Listing Popular Sort"
+msgstr "Lista ordenada por Popularidade"
+
+#: static/js/impala/stats/csv_keys.js:98 static/js/impala/stats/csv_keys.js:99 static/js/zamboni/stats-all.js:15379 static/js/zamboni/stats-all.js:15380 static/js/zamboni/stats-min.js:5
+msgid "Browse Listing Updated Sort"
+msgstr "Lista ordenada por Atualização"
+
+#: static/js/impala/stats/csv_keys.js:100 static/js/impala/stats/csv_keys.js:101 static/js/zamboni/stats-all.js:15381 static/js/zamboni/stats-all.js:15382 static/js/zamboni/stats-min.js:5
+msgid "Browse Listing Up and Coming Sort"
+msgstr "Lista ordenada por Ascensão"
+
+#: static/js/impala/stats/csv_keys.js:105 static/js/zamboni/stats-all.js:15386 static/js/zamboni/stats-min.js:5
+msgid "Total Amount Contributed"
+msgstr "Quantia total arrecadada"
+
+#: static/js/impala/stats/csv_keys.js:106 static/js/zamboni/stats-all.js:15387 static/js/zamboni/stats-min.js:5
+msgid "Average Contribution"
+msgstr "Contribuição média"
+
+#: static/js/impala/stats/csv_keys.js:115 static/js/zamboni/stats-all.js:15396 static/js/zamboni/stats-min.js:5
+msgid "Usage"
+msgstr "Uso"
+
+#: static/js/impala/stats/csv_keys.js:118 static/js/zamboni/stats-all.js:15399 static/js/zamboni/stats-min.js:5
+msgid "Firefox"
+msgstr "Firefox"
+
+#: static/js/impala/stats/csv_keys.js:119 static/js/zamboni/stats-all.js:15400 static/js/zamboni/stats-min.js:5
+msgid "Mozilla"
+msgstr "Mozilla"
+
+#: static/js/impala/stats/csv_keys.js:120 static/js/zamboni/stats-all.js:15401 static/js/zamboni/stats-min.js:5
+msgid "Thunderbird"
+msgstr "Thunderbird"
+
+#: static/js/impala/stats/csv_keys.js:121 static/js/zamboni/stats-all.js:15402 static/js/zamboni/stats-min.js:5
+msgid "Sunbird"
+msgstr "Sunbird"
+
+#: static/js/impala/stats/csv_keys.js:122 static/js/zamboni/stats-all.js:15403 static/js/zamboni/stats-min.js:5
+msgid "SeaMonkey"
+msgstr "SeaMonkey"
+
+#: static/js/impala/stats/csv_keys.js:123 static/js/zamboni/stats-all.js:15404 static/js/zamboni/stats-min.js:5
+msgid "Fennec"
+msgstr "Fennec"
+
+#: static/js/impala/stats/csv_keys.js:124 static/js/zamboni/stats-all.js:15405 static/js/zamboni/stats-min.js:5
+msgid "Android"
+msgstr "Android"
+
+#. L10n: {0} is an integer.
+#: static/js/impala/stats/csv_keys.js:129 static/js/zamboni/stats-all.js:15410 static/js/zamboni/stats-min.js:5
+msgid "Downloads and Daily Users, last {0} days"
+msgstr "Downloads e usuários diários nos últimos {0} dias"
+
+#. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
+#: static/js/impala/stats/csv_keys.js:131 static/js/zamboni/stats-all.js:15412 static/js/zamboni/stats-min.js:5
+msgid "Downloads and Daily Users from {0} to {1}"
+msgstr "Downloads e usuários diários de {0} a {1}"
+
+#. L10n: {0} is an integer.
+#: static/js/impala/stats/csv_keys.js:135 static/js/zamboni/stats-all.js:15416 static/js/zamboni/stats-min.js:5
+msgid "Installs and Daily Users, last {0} days"
+msgstr "Instalações e usuários diários nos últimos {0} dias"
+
+#. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
+#: static/js/impala/stats/csv_keys.js:137 static/js/zamboni/stats-all.js:15418 static/js/zamboni/stats-min.js:5
+msgid "Installs and Daily Users from {0} to {1}"
+msgstr "Instalações e usuários diários de {0} a {1}"
+
+#. L10n: {0} is an integer.
+#: static/js/impala/stats/csv_keys.js:141 static/js/zamboni/stats-all.js:15422 static/js/zamboni/stats-min.js:5
+msgid "Downloads, last {0} days"
+msgstr "Downloads nos últimos {0} dias"
+
+#. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
+#: static/js/impala/stats/csv_keys.js:143 static/js/zamboni/stats-all.js:15424 static/js/zamboni/stats-min.js:5
+msgid "Downloads from {0} to {1}"
+msgstr "Downloads de {0} a {1}"
+
+#. L10n: {0} is an integer.
+#: static/js/impala/stats/csv_keys.js:147 static/js/zamboni/stats-all.js:15428 static/js/zamboni/stats-min.js:5
+msgid "Daily Users, last {0} days"
+msgstr "Usuários diários nos últimos {0} dias"
+
+#. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
+#: static/js/impala/stats/csv_keys.js:149 static/js/zamboni/stats-all.js:15430 static/js/zamboni/stats-min.js:5
+msgid "Daily Users from {0} to {1}"
+msgstr "Usuários diários de {0} a {1}"
+
+#. L10n: {0} is an integer.
+#: static/js/impala/stats/csv_keys.js:153 static/js/zamboni/stats-all.js:15434 static/js/zamboni/stats-min.js:5
+msgid "Applications, last {0} days"
+msgstr "Aplicativos nos últimos {0}"
+
+#. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
+#: static/js/impala/stats/csv_keys.js:155 static/js/zamboni/stats-all.js:15436 static/js/zamboni/stats-min.js:5
+msgid "Applications from {0} to {1}"
+msgstr "Aplicativos de {0} a {1}"
+
+#. L10n: {0} is an integer.
+#: static/js/impala/stats/csv_keys.js:159 static/js/zamboni/stats-all.js:15440 static/js/zamboni/stats-min.js:5
+msgid "Platforms, last {0} days"
+msgstr "Plataformas nos últimos {0} dias"
+
+#. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
+#: static/js/impala/stats/csv_keys.js:161 static/js/zamboni/stats-all.js:15442 static/js/zamboni/stats-min.js:5
+msgid "Platforms from {0} to {1}"
+msgstr "Plataformas de {0} a {1}"
+
+#. L10n: {0} is an integer.
+#: static/js/impala/stats/csv_keys.js:165 static/js/zamboni/stats-all.js:15446 static/js/zamboni/stats-min.js:5
+msgid "Languages, last {0} days"
+msgstr "Idiomas nos últimos {0} dias"
+
+#. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
+#: static/js/impala/stats/csv_keys.js:167 static/js/zamboni/stats-all.js:15448 static/js/zamboni/stats-min.js:5
+msgid "Languages from {0} to {1}"
+msgstr "Idiomas de {0} a {1}"
+
+#. L10n: {0} is an integer.
+#: static/js/impala/stats/csv_keys.js:171 static/js/zamboni/stats-all.js:15452 static/js/zamboni/stats-min.js:5
+msgid "Add-on Versions, last {0} days"
+msgstr "Versões do complemento nos últimos {0} dias"
+
+#. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
+#: static/js/impala/stats/csv_keys.js:173 static/js/zamboni/stats-all.js:15454 static/js/zamboni/stats-min.js:5
+msgid "Add-on Versions from {0} to {1}"
+msgstr "Versões do complemento de {0} a {1}"
+
+#. L10n: {0} is an integer.
+#: static/js/impala/stats/csv_keys.js:177 static/js/zamboni/stats-all.js:15458 static/js/zamboni/stats-min.js:5
+msgid "Add-on Status, last {0} days"
+msgstr "Status do complemento nos últimos {0} dias"
+
+#. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
+#: static/js/impala/stats/csv_keys.js:179 static/js/zamboni/stats-all.js:15460 static/js/zamboni/stats-min.js:5
+msgid "Add-on Status from {0} to {1}"
+msgstr "Status do complemento de {0} a {1}"
+
+#. L10n: {0} is an integer.
+#: static/js/impala/stats/csv_keys.js:183 static/js/zamboni/stats-all.js:15464 static/js/zamboni/stats-min.js:5
+msgid "Download Sources, last {0} days"
+msgstr "Origem dos downloads nos últimos {0} dias"
+
+#. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
+#: static/js/impala/stats/csv_keys.js:185 static/js/zamboni/stats-all.js:15466 static/js/zamboni/stats-min.js:5
+msgid "Download Sources from {0} to {1}"
+msgstr "Origem dos downloads de {0} a {1}"
+
+#. L10n: {0} is an integer.
+#: static/js/impala/stats/csv_keys.js:189 static/js/zamboni/stats-all.js:15470 static/js/zamboni/stats-min.js:5
+msgid "Contributions, last {0} days"
+msgstr "Contribuições nos últimos {0} dias"
+
+#. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
+#: static/js/impala/stats/csv_keys.js:191 static/js/zamboni/stats-all.js:15472 static/js/zamboni/stats-min.js:5
+msgid "Contributions from {0} to {1}"
+msgstr "Contribuições de {0} a {1}"
+
+#. L10n: {0} is an integer.
+#: static/js/impala/stats/csv_keys.js:195 static/js/zamboni/stats-all.js:15476 static/js/zamboni/stats-min.js:5
+msgid "Site Metrics, last {0} days"
+msgstr "Estatísticas do site nos últimos {0} dias"
+
+#. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
+#: static/js/impala/stats/csv_keys.js:197 static/js/zamboni/stats-all.js:15478 static/js/zamboni/stats-min.js:5
+msgid "Site Metrics from {0} to {1}"
+msgstr "Estatísticas do site de {0} a {1}"
+
+#. L10n: {0} is an integer.
+#: static/js/impala/stats/csv_keys.js:201 static/js/zamboni/stats-all.js:15482 static/js/zamboni/stats-min.js:5
+msgid "Add-ons in Use, last {0} days"
+msgstr "Complementos em uso nos últimos {0} dias"
+
+#. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
+#: static/js/impala/stats/csv_keys.js:203 static/js/zamboni/stats-all.js:15484 static/js/zamboni/stats-min.js:5
+msgid "Add-ons in Use from {0} to {1}"
+msgstr "Complementos em uso de {0} a {1}"
+
+#. L10n: {0} is an integer.
+#: static/js/impala/stats/csv_keys.js:207 static/js/zamboni/stats-all.js:15488 static/js/zamboni/stats-min.js:5
+msgid "Add-ons Downloaded, last {0} days"
+msgstr "Complementos baixados nos últimos {0} dias"
+
+#. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
+#: static/js/impala/stats/csv_keys.js:209 static/js/zamboni/stats-all.js:15490 static/js/zamboni/stats-min.js:5
+msgid "Add-ons Downloaded from {0} to {1}"
+msgstr "Complementos baixados de {0} a {1}"
+
+#. L10n: {0} is an integer.
+#: static/js/impala/stats/csv_keys.js:213 static/js/zamboni/stats-all.js:15494 static/js/zamboni/stats-min.js:5
+msgid "Add-ons Created, last {0} days"
+msgstr "Complementos criados nos últimos {0} dias"
+
+#. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
+#: static/js/impala/stats/csv_keys.js:215 static/js/zamboni/stats-all.js:15496 static/js/zamboni/stats-min.js:5
+msgid "Add-ons Created from {0} to {1}"
+msgstr "Complementos criados de {0} a {1}"
+
+#. L10n: {0} is an integer.
+#: static/js/impala/stats/csv_keys.js:219 static/js/zamboni/stats-all.js:15500 static/js/zamboni/stats-min.js:5
+msgid "Add-ons Updated, last {0} days"
+msgstr "Complementos atualizados nos últimos {0} dias"
+
+#. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
+#: static/js/impala/stats/csv_keys.js:221 static/js/zamboni/stats-all.js:15502 static/js/zamboni/stats-min.js:5
+msgid "Add-ons Updated from {0} to {1}"
+msgstr "Complementos atualizados de {0} a {1}"
+
+#. L10n: {0} is an integer.
+#: static/js/impala/stats/csv_keys.js:225 static/js/zamboni/stats-all.js:15506 static/js/zamboni/stats-min.js:5
+msgid "Reviews Written, last {0} days"
+msgstr "Avaliações escritas nos últimos {0} dias"
+
+#. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
+#: static/js/impala/stats/csv_keys.js:227 static/js/zamboni/stats-all.js:15508 static/js/zamboni/stats-min.js:5
+msgid "Reviews Written from {0} to {1}"
+msgstr "Avaliações escritas de {0} a {1}"
+
+#. L10n: {0} is an integer.
+#: static/js/impala/stats/csv_keys.js:231 static/js/zamboni/stats-all.js:15512 static/js/zamboni/stats-min.js:5
+msgid "User Signups, last {0} days"
+msgstr "Inscrições de usuários nos últimos {0} dias"
+
+#. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
+#: static/js/impala/stats/csv_keys.js:233 static/js/zamboni/stats-all.js:15514 static/js/zamboni/stats-min.js:5
+msgid "User Signups from {0} to {1}"
+msgstr "Inscrições de usuários de {0} a {1}"
+
+#. L10n: {0} is an integer.
+#: static/js/impala/stats/csv_keys.js:237 static/js/zamboni/stats-all.js:15518 static/js/zamboni/stats-min.js:5
+msgid "Collections Created, last {0} days"
+msgstr "Coleções criadas nos últimos {0} dias"
+
+#. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
+#: static/js/impala/stats/csv_keys.js:239 static/js/zamboni/stats-all.js:15520 static/js/zamboni/stats-min.js:5
+msgid "Collections Created from {0} to {1}"
+msgstr "Coleções criadas de {0} a {1}"
+
+#. L10n: {0} is an integer.
+#: static/js/impala/stats/csv_keys.js:243 static/js/zamboni/stats-all.js:15524 static/js/zamboni/stats-min.js:5
+msgid "Subscribers, last {0} days"
+msgstr "Assinantes nos últimos {0} dias"
+
+#. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
+#: static/js/impala/stats/csv_keys.js:245 static/js/zamboni/stats-all.js:15526 static/js/zamboni/stats-min.js:5
+msgid "Subscribers from {0} to {1}"
+msgstr "Assinantes de {0} a {1}"
+
+#. L10n: {0} is an integer.
+#: static/js/impala/stats/csv_keys.js:249 static/js/zamboni/stats-all.js:15530 static/js/zamboni/stats-min.js:5
+msgid "Ratings, last {0} days"
+msgstr "Avaliações nos últimos {0} dias"
+
+#. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
+#: static/js/impala/stats/csv_keys.js:251 static/js/zamboni/stats-all.js:15532 static/js/zamboni/stats-min.js:5
+msgid "Ratings from {0} to {1}"
+msgstr "Avaliações de {0} a {1}"
+
+#. L10n: {0} is an integer.
+#: static/js/impala/stats/csv_keys.js:255 static/js/zamboni/stats-all.js:15536 static/js/zamboni/stats-min.js:5
+msgid "Sales, last {0} days"
+msgstr "Vendas nos últimos {0} dias"
+
+#. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
+#: static/js/impala/stats/csv_keys.js:257 static/js/zamboni/stats-all.js:15538 static/js/zamboni/stats-min.js:5
+msgid "Sales from {0} to {1}"
+msgstr "Vendas de {0} a {1}"
+
+#. L10n: {0} is an integer.
+#: static/js/impala/stats/csv_keys.js:261 static/js/zamboni/stats-all.js:15542 static/js/zamboni/stats-min.js:5
+msgid "Installs, last {0} days"
+msgstr "Instalações nos últimos {0} dias"
+
+#. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
+#: static/js/impala/stats/csv_keys.js:263 static/js/zamboni/stats-all.js:15544 static/js/zamboni/stats-min.js:5
+msgid "Installs from {0} to {1}"
+msgstr "Instalações de {0} a {1}"
+
+#. L10n: {0} and {1} are integers.
+#: static/js/impala/stats/csv_keys.js:269 static/js/zamboni/stats-all.js:15550 static/js/zamboni/stats-min.js:5
+msgid "<b>{0}</b> in last {1} days"
+msgstr "<b>{0}</b> nos últimos {1} dias"
+
+#. L10n: {0} is an integer and {1} and {2} are dates in YYYY-MM-DD format.
+#: static/js/impala/stats/csv_keys.js:271 static/js/impala/stats/csv_keys.js:277 static/js/zamboni/stats-all.js:15552 static/js/zamboni/stats-all.js:15558 static/js/zamboni/stats-min.js:5
+msgid "<b>{0}</b> from {1} to {2}"
+msgstr "<b>{0}</b> de {1} a {2}"
+
+#. L10n: {0} and {1} are integers.
+#: static/js/impala/stats/csv_keys.js:275 static/js/zamboni/stats-all.js:15556 static/js/zamboni/stats-min.js:5
+msgid "<b>{0}</b> average in last {1} days"
+msgstr "<b>{0}</b> em média nos últimos {1} dias"
+
+#: static/js/impala/stats/overview.js:19 static/js/zamboni/stats-all.js:16469 static/js/zamboni/stats-min.js:5
+msgid "No data available."
+msgstr "Nenhum dado disponível."
+
+#: static/js/impala/stats/table.js:74 static/js/zamboni/stats-all.js:17209 static/js/zamboni/stats-min.js:5
+msgid "Date"
+msgstr "Data"
+
+#: static/js/impala/stats/topchart.js:96 static/js/zamboni/stats-all.js:16600 static/js/zamboni/stats-min.js:5
+msgid "Other"
+msgstr "Outro"
+
+#: static/js/zamboni/admin-all.js:180 static/js/zamboni/admin-min.js:1 static/js/zamboni/admin_validation.js:24 static/js/zamboni/devhub-all.js:2408 static/js/zamboni/devhub-min.js:2
+#: static/js/zamboni/devhub.js:1229 static/js/zamboni/editors-all.js:15576 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:295
+msgid "Select an application first"
+msgstr "Selecione uma aplicação antes"
+
+#: static/js/zamboni/admin-all.js:207 static/js/zamboni/admin-min.js:1 static/js/zamboni/admin_validation.js:51
+msgid "Set {0} add-on to a max version of {1} and email the author."
+msgid_plural "Set {0} add-ons to a max version of {1} and email the authors."
+msgstr[0] "Definir a versão máxima do complemento {0} para {1} e notificar o autor."
+msgstr[1] "Definir a versão máxima dos complementos {0} para {1} e notificar os autores."
+
+#: static/js/zamboni/admin-all.js:210 static/js/zamboni/admin-min.js:1 static/js/zamboni/admin_validation.js:54
+msgid "Email author of {2} add-on which failed validation."
+msgid_plural "Email authors of {2} add-ons which failed validation."
+msgstr[0] "Enviar e-mail ao autor do complemento {2} que não conseguiu a validação."
+msgstr[1] "Enviar e-mail aos autores dos complementos {2} que não conseguiram a validação."
+
+#: static/js/zamboni/devhub-all.js:1289 static/js/zamboni/devhub-min.js:1 static/js/zamboni/devhub.js:110
+msgid "Your browser does not support the video tag"
+msgstr "O seu navegador não suporta o elemento &lt;video&gt;"
+
+#: static/js/zamboni/devhub-all.js:1550 static/js/zamboni/devhub-min.js:1 static/js/zamboni/devhub.js:371
+msgid "Changes Saved"
+msgstr "Alterações salvas"
+
+#: static/js/zamboni/devhub-all.js:1566 static/js/zamboni/devhub-min.js:1 static/js/zamboni/devhub.js:387
+msgid "Enter a new author's email address"
+msgstr "Insira o e-mail de um novo autor"
+
+#: static/js/zamboni/devhub-all.js:1715 static/js/zamboni/devhub-min.js:1 static/js/zamboni/devhub.js:536
+msgid "There was an error uploading your file."
+msgstr "Houve um erro ao enviar seu arquivo."
+
+#: static/js/zamboni/devhub-all.js:1860 static/js/zamboni/devhub-min.js:1 static/js/zamboni/devhub.js:681
+msgid "{files} file"
+msgid_plural "{files} files"
+msgstr[0] "{files} arquivo"
+msgstr[1] "{files} arquivos"
+
+#: static/js/zamboni/devhub-all.js:1863 static/js/zamboni/devhub-min.js:1 static/js/zamboni/devhub.js:684
+msgid "{reviews} user review"
+msgid_plural "{reviews} user reviews"
+msgstr[0] "{reviews} avaliação de usuário"
+msgstr[1] "{reviews} avaliações de usuários"
+
+#: static/js/zamboni/devhub-all.js:1975 static/js/zamboni/devhub-min.js:2 static/js/zamboni/devhub.js:796
+msgid "Learn more"
+msgstr "Saiba mais"
+
+#: static/js/zamboni/devhub-all.js:1979 static/js/zamboni/devhub-min.js:2 static/js/zamboni/devhub.js:800
+msgid "Example"
+msgstr "Exemplo"
+
+#: static/js/zamboni/devhub-all.js:2309 static/js/zamboni/devhub-min.js:2 static/js/zamboni/devhub.js:1130
+msgid "Image changes being processed"
+msgstr "Processando alterações na imagem"
+
+#: static/js/zamboni/devhub-all.js:2459 static/js/zamboni/devhub-min.js:2 static/js/zamboni/devhub.js:1280
+msgid "Must be a valid e-mail address."
+msgstr "Deve ser um endereço de e-mail válido."
+
+#: static/js/zamboni/devhub-all.js:2613 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:80
 msgid "All tests passed successfully."
 msgstr "Todos os testes foram aprovados com sucesso."
 
-#: static/js/zamboni/validator.js:83 static/js/zamboni/validator.js:478
+#: static/js/zamboni/devhub-all.js:2616 static/js/zamboni/devhub-all.js:3011 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:83 static/js/zamboni/validator.js:478
 msgid "These tests were not run."
 msgstr "Esses testes não foram executados."
 
-#: static/js/zamboni/validator.js:131 static/js/zamboni/validator.js:144
+#: static/js/zamboni/devhub-all.js:2664 static/js/zamboni/devhub-all.js:2677 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:131 static/js/zamboni/validator.js:144
 msgid "Tests"
 msgstr "Testes"
 
-#: static/js/zamboni/validator.js:246 static/js/zamboni/validator.js:575
-#: static/js/zamboni/validator.js:594
+#: static/js/zamboni/devhub-all.js:2779 static/js/zamboni/devhub-all.js:3108 static/js/zamboni/devhub-all.js:3127 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:246
+#: static/js/zamboni/validator.js:575 static/js/zamboni/validator.js:594
 msgid "Error"
 msgstr "Erro"
 
-#: static/js/zamboni/validator.js:247
+#: static/js/zamboni/devhub-all.js:2780 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:247
 msgid "Warning"
 msgstr "Alerta"
 
-#: static/js/zamboni/validator.js:299
+#: static/js/zamboni/devhub-all.js:2794 static/js/zamboni/devhub-min.js:2 static/js/zamboni/files-all.js:5657 static/js/zamboni/files-min.js:3 static/js/zamboni/files.js:411
+#: static/js/zamboni/validator.js:261
+msgid "Ignore this message in future updates"
+msgstr "Ignore esta mensagem em atualizações futuras"
+
+#: static/js/zamboni/devhub-all.js:2817 static/js/zamboni/devhub-min.js:2 static/js/zamboni/files-all.js:5663 static/js/zamboni/files-min.js:3 static/js/zamboni/files.js:417
+#: static/js/zamboni/validator.js:284
+msgid "Severity for automated signing:"
+msgstr "Severidade para assinatura automatizada:"
+
+#: static/js/zamboni/devhub-all.js:2832 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:299
 msgid "Suggestions for passing automated signing:"
 msgstr "Sugestões para a passagem automática de assinatura:"
 
-#: static/js/zamboni/validator.js:387
+#: static/js/zamboni/devhub-all.js:2920 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:387
 msgid "Compatibility Tests"
 msgstr "Testes de compatibilidade"
 
-#: static/js/zamboni/validator.js:466
+#: static/js/zamboni/devhub-all.js:2999 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:466
 msgid "Add-on failed validation."
 msgstr "A validação do complemento falhou."
 
-#: static/js/zamboni/validator.js:468
+#: static/js/zamboni/devhub-all.js:3001 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:468
 msgid "Add-on passed validation."
 msgstr "O complemento foi aprovado na validação."
 
-#: static/js/zamboni/validator.js:481
+#: static/js/zamboni/devhub-all.js:3014 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:481
 msgid "{0} error"
 msgid_plural "{0} errors"
 msgstr[0] "{0} erro"
 msgstr[1] "{0} erros"
 
-#: static/js/zamboni/validator.js:483
+#: static/js/zamboni/devhub-all.js:3016 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:483
 msgid "{0} warning"
 msgid_plural "{0} warnings"
 msgstr[0] "{0} alerta"
 msgstr[1] "{0} alertas"
 
-#: static/js/zamboni/validator.js:485
+#: static/js/zamboni/devhub-all.js:3018 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:485
 msgid "{0} notice"
 msgid_plural "{0} notices"
 msgstr[0] "{0} notícia"
 msgstr[1] "{0} notícias"
 
-#: static/js/zamboni/validator.js:577
+#: static/js/zamboni/devhub-all.js:3110 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:577
 msgid "Validation task could not complete or completed with errors"
 msgstr "A validação não pôde ser completada ou foi completada com erros"
 
-#: static/js/zamboni/validator.js:595
+#: static/js/zamboni/devhub-all.js:3128 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:595
 msgid "Internal server error"
 msgstr "Erro interno do servidor"
 
-#: static/js/zamboni/mobile/buttons.js:52
+#: static/js/zamboni/devhub_search.js:8
+msgid "No results found."
+msgstr "Nenhum resultado encontrado."
+
+#: static/js/zamboni/editors-all.js:15402 static/js/zamboni/editors-min.js:4 static/js/zamboni/editors.js:121
+msgid "{name} was viewing this page first."
+msgstr "{name} estava visualizando essa página antes."
+
+#: static/js/zamboni/editors-all.js:15452 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:171
+msgid "Receipt checked by app."
+msgstr "Recibo verificado pelo aplicativo."
+
+#: static/js/zamboni/editors-all.js:15454 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:173
+msgid "Receipt was not checked by app."
+msgstr "Recibo não verificado pelo aplicativo."
+
+#: static/js/zamboni/editors-all.js:15525 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:244
+msgid "{name} was viewing this add-on first."
+msgstr "{name} estava visualizando esse complemento antes."
+
+#: static/js/zamboni/editors-all.js:15536 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:255
+msgid "Loading&hellip;"
+msgstr "Carregando&hellip;"
+
+#: static/js/zamboni/editors-all.js:15541 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:260
+msgid "Version Notes"
+msgstr "Notas da versão"
+
+#: static/js/zamboni/editors-all.js:15546 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:265
+msgid "Notes for Reviewers"
+msgstr "Notas aos revisores"
+
+#: static/js/zamboni/editors-all.js:15551 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:270
+msgid "No version notes found"
+msgstr "Não foram encontradas notas de versão"
+
+#: static/js/zamboni/editors-all.js:15611 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:330
+msgid "Average Reviews"
+msgstr "Média de avaliações"
+
+#: static/js/zamboni/editors-all.js:15667 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:386
+msgid "Number of Reviews"
+msgstr "Número de avaliações"
+
+#: static/js/zamboni/editors-all.js:15726 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:445
+msgid "Error loading translation"
+msgstr "Erro ao carregar tradução"
+
+#: static/js/zamboni/editors-all.js:15975 static/js/zamboni/editors-min.js:5 static/js/zamboni/themes_review_templates.js:31
+msgid "Theme"
+msgstr "Tema"
+
+#: static/js/zamboni/editors-all.js:15977 static/js/zamboni/editors-min.js:5 static/js/zamboni/themes_review_templates.js:33
+msgid "Reviewer"
+msgstr "Revisor"
+
+#: static/js/zamboni/editors-all.js:15979 static/js/zamboni/editors-min.js:5 static/js/zamboni/themes_review_templates.js:35
+msgid "Status"
+msgstr "Estado"
+
+#: static/js/zamboni/editors-all.js:16196 static/js/zamboni/editors-min.js:5 static/js/zamboni/themes_review.js:176
+msgid "Requested Info"
+msgstr "Informações solicitadas"
+
+#: static/js/zamboni/editors-all.js:16197 static/js/zamboni/editors-min.js:5 static/js/zamboni/themes_review.js:177
+msgid "Flagged"
+msgstr "Marcado"
+
+#: static/js/zamboni/editors-all.js:16198 static/js/zamboni/editors-min.js:5 static/js/zamboni/themes_review.js:178
+msgid "Duplicate"
+msgstr "Duplicado"
+
+#: static/js/zamboni/editors-all.js:16199 static/js/zamboni/editors-min.js:5 static/js/zamboni/themes_review.js:179
+msgid "Rejected"
+msgstr "Rejeitado"
+
+#: static/js/zamboni/editors-all.js:16200 static/js/zamboni/editors-min.js:5 static/js/zamboni/themes_review.js:180
+msgid "Approved"
+msgstr "Aprovado"
+
+#: static/js/zamboni/editors-all.js:16444 static/js/zamboni/editors-min.js:5 static/js/zamboni/themes_review.js:424
+msgid "No results found"
+msgstr "Nenhum resultado encontrado"
+
+#: static/js/zamboni/mobile-all.js:15186 static/js/zamboni/mobile/buttons.js:52
 msgid "Not Updated for {0} {1}"
 msgstr "Não atualizado para {0} {1}"
 
-#: static/js/zamboni/mobile/buttons.js:53
+#: static/js/zamboni/mobile-all.js:15187 static/js/zamboni/mobile/buttons.js:53
 msgid "Requires Newer Version of {0}"
 msgstr "Requer uma versão mais recente de {0}"
 
-#: static/js/zamboni/mobile/buttons.js:54
+#: static/js/zamboni/mobile-all.js:15188 static/js/zamboni/mobile/buttons.js:54
 msgid "Unreviewed"
 msgstr "Não avaliado"
 
-#: static/js/zamboni/mobile/buttons.js:55
+#: static/js/zamboni/mobile-all.js:15189 static/js/zamboni/mobile/buttons.js:55
 msgid "Experimental <span>(Learn More)</span>"
 msgstr "Experimental <span>(Saiba mais)</span>"
 
-#: static/js/zamboni/mobile/buttons.js:56
-#: static/js/zamboni/mobile/buttons.js:57
+#: static/js/zamboni/mobile-all.js:15190 static/js/zamboni/mobile-all.js:15191 static/js/zamboni/mobile/buttons.js:56 static/js/zamboni/mobile/buttons.js:57
 msgid "Not Available for {0}"
 msgstr "Não disponível para o {0}"
 
-#: static/js/zamboni/mobile/buttons.js:58
+#: static/js/zamboni/mobile-all.js:15192 static/js/zamboni/mobile/buttons.js:58
 msgid "Experimental"
 msgstr "Experimental"
 
-#: static/js/zamboni/mobile/buttons.js:59
+#: static/js/zamboni/mobile-all.js:15193 static/js/zamboni/mobile/buttons.js:59
 msgid "Themes Require Newer Version of {0}"
 msgstr "Para usar temas, é preciso estar com a última versão do {0}"
 
-#: static/js/zamboni/mobile/buttons.js:60
+#: static/js/zamboni/mobile-all.js:15194 static/js/zamboni/mobile/buttons.js:60
 msgid "Themes Require {0}"
 msgstr "O uso de temas exige o {0}"
 
-#: static/js/zamboni/mobile/buttons.js:105
+#: static/js/zamboni/mobile-all.js:15239 static/js/zamboni/mobile/buttons.js:105
 msgid "Installing..."
 msgstr "Instalando..."
 
-#: static/js/zamboni/mobile/buttons.js:125
+#: static/js/zamboni/mobile-all.js:15259 static/js/zamboni/mobile/buttons.js:125
 msgid "This add-on has been preliminarily reviewed by Mozilla."
 msgstr "Este complemento foi avaliado preliminarmente pela Mozilla."
 
-#: static/js/zamboni/mobile/buttons.js:250
+#: static/js/zamboni/mobile-all.js:15384 static/js/zamboni/mobile/buttons.js:250
 msgid "Keep it"
 msgstr "Manter"
 
-#: static/js/zamboni/mobile/general.js:344
+#: static/js/zamboni/mobile-all.js:16049 static/js/zamboni/mobile-min.js:6 static/js/zamboni/mobile/general.js:344
 msgid "You're trying it on!"
 msgstr "Você está experimentando!"
 
-#: static/js/zamboni/mobile/general.js:356
+#: static/js/zamboni/mobile-all.js:16061 static/js/zamboni/mobile-min.js:6 static/js/zamboni/mobile/general.js:356
 msgid "Added to Firefox"
 msgstr "Adicionado ao Firefox"

--- a/locale/pt_PT/LC_MESSAGES/django.po
+++ b/locale/pt_PT/LC_MESSAGES/django.po
@@ -1,85 +1,73 @@
-# 
+#
 msgid ""
 msgstr ""
 "Project-Id-Version: AMO (olympia)\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2016-02-24 21:23+0000\n"
+"POT-Creation-Date: 2016-04-18 15:47+0000\n"
 "PO-Revision-Date: 2016-04-16 23:54+0000\n"
 "Last-Translator: Rodrigo <rodrigo.mcunha@hotmail.com>\n"
 "Language-Team: pt-PT <portuguese european>\n"
-"Language: pt_PT\n"
+"Language: \n"
 "MIME-Version: 1.0\n"
-"Content-Type: text/plain; charset=utf-8\n"
+"Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 "Generated-By: Babel 2.2.0\n"
-"X-Generator: Pontoon\n"
-
-#: src/olympia/accounts/views.py:52
-msgid "Your log in attempt could not be parsed. Please try again."
-msgstr ""
-"A sua tentativa de iniciar sessão não pôde ser analisada. Por favor, tente "
-"novamente."
 
 #: src/olympia/accounts/views.py:54
-msgid "Your Firefox Account could not be found. Please try again."
-msgstr ""
-"A sua Conta Firefox não pôde ser encontrada. Por favor, tente novamente."
+msgid "Your log in attempt could not be parsed. Please try again."
+msgstr "A sua tentativa de iniciar sessão não pôde ser analisada. Por favor, tente novamente."
 
-#: src/olympia/accounts/views.py:55
+#: src/olympia/accounts/views.py:56
+msgid "Your Firefox Account could not be found. Please try again."
+msgstr "A sua Conta Firefox não pôde ser encontrada. Por favor, tente novamente."
+
+#: src/olympia/accounts/views.py:57
 msgid "You could not be logged in. Please try again."
 msgstr "Não pôde iniciar sessão. Por favor, tente novamente."
 
-#: src/olympia/accounts/views.py:57
+#: src/olympia/accounts/views.py:59
 msgid "Your account has already been migrated to Firefox Accounts."
 msgstr "A sua conta já foi migrada para o Contas Firefox."
 
-#: src/olympia/accounts/views.py:59
+#: src/olympia/accounts/views.py:61
 msgid "Your Firefox Account already exists on this site."
 msgstr "A sua Conta Firefox já existe neste site."
 
-#: src/olympia/accounts/views.py:108
+#: src/olympia/accounts/views.py:110
 msgid "Great job!"
 msgstr "Bom trabalho!"
 
-#: src/olympia/accounts/views.py:109
+#: src/olympia/accounts/views.py:111
 msgid "You can now log in to Add-ons with your Firefox Account."
 msgstr "Agora poderá iniciar sessão no Extras com a sua Conta Firefox."
 
-#: src/olympia/accounts/views.py:121
+#: src/olympia/accounts/views.py:123
 msgid "Need help?"
 msgstr "Precisa de ajuda?"
 
-#: src/olympia/addons/buttons.py:180
+#: src/olympia/addons/buttons.py:177
 msgid "Download Now"
 msgstr "Descarregar agora"
 
-#: src/olympia/addons/buttons.py:182
+#: src/olympia/addons/buttons.py:179
 msgid "Download"
 msgstr "Descarregar"
 
 #. L10n: please keep &nbsp; in the string so &rarr; does not wrap.
-#: src/olympia/addons/buttons.py:186
+#: src/olympia/addons/buttons.py:183
 msgid "Continue to Download&nbsp;&rarr;"
 msgstr "Continuar para a descarga&nbsp;&rarr;"
 
-#: src/olympia/addons/buttons.py:202 src/olympia/addons/helpers.py:35
-#: src/olympia/addons/views.py:319
-#: src/olympia/addons/templates/addons/impala/details.html:114
-#: src/olympia/addons/templates/addons/impala/listing/items.html:17
-#: src/olympia/addons/templates/addons/mobile/home.html:40
-#: src/olympia/amo/templates/amo/side_nav.html:6
-#: src/olympia/amo/templates/amo/side_nav.html:10
-#: src/olympia/amo/templates/amo/site_nav.html:2
-#: src/olympia/amo/templates/amo/site_nav.html:55
-#: src/olympia/bandwagon/views.py:95 src/olympia/browse/views.py:54
-#: src/olympia/browse/views.py:68 src/olympia/browse/views.py:235
-#: src/olympia/browse/templates/browse/impala/category_landing.html:22
+#: src/olympia/addons/buttons.py:199 src/olympia/addons/helpers.py:35 src/olympia/addons/views.py:333 src/olympia/addons/templates/addons/impala/details.html:111
+#: src/olympia/addons/templates/addons/impala/listing/items.html:17 src/olympia/addons/templates/addons/mobile/home.html:40 src/olympia/amo/templates/amo/side_nav.html:6
+#: src/olympia/amo/templates/amo/side_nav.html:10 src/olympia/amo/templates/amo/site_nav.html:2 src/olympia/amo/templates/amo/site_nav.html:53 src/olympia/bandwagon/views.py:95
+#: src/olympia/browse/views.py:54 src/olympia/browse/views.py:68 src/olympia/browse/views.py:202 src/olympia/browse/templates/browse/impala/category_landing.html:22
 #: src/olympia/browse/templates/browse/personas/mobile/category_landing.html:26
 msgid "Featured"
 msgstr "Em destaque"
 
-#: src/olympia/addons/buttons.py:221
+#: src/olympia/addons/buttons.py:218
 msgid "Add to {0}"
 msgstr "Adicionar ao {0}"
 
@@ -118,11 +106,8 @@ msgstr[1] "Tem {0} etiquetas a mais."
 
 #: src/olympia/addons/forms.py:117
 #, python-format
-msgid ""
-"All tags must be %s characters or less after invalid characters are removed."
-msgstr ""
-"Todas as etiquetas têm de ter %s caracteres ou menos depois de removidos os "
-"caracteres inválidos."
+msgid "All tags must be %s characters or less after invalid characters are removed."
+msgstr "Todas as etiquetas têm de ter %s caracteres ou menos depois de removidos os caracteres inválidos."
 
 #: src/olympia/addons/forms.py:121
 msgid "All tags must be at least {0} character."
@@ -130,49 +115,39 @@ msgid_plural "All tags must be at least {0} characters."
 msgstr[0] "Todas as etiquetas têm de ter pelo menos {0} caractere."
 msgstr[1] "Todas as etiquetas têm de ter pelo menos {0} caracteres."
 
-#: src/olympia/addons/forms.py:234
-msgid ""
-"Categories cannot be changed while your add-on is featured for this "
-"application."
-msgstr ""
-"As categorias não podem ser alteradas enquanto o seu extra estiver indicado "
-"para esta aplicação."
+#: src/olympia/addons/forms.py:238
+msgid "Categories cannot be changed while your add-on is featured for this application."
+msgstr "As categorias não podem ser alteradas enquanto o seu extra estiver indicado para esta aplicação."
 
 #. L10n: {0} is the number of categories.
-#: src/olympia/addons/forms.py:238
+#: src/olympia/addons/forms.py:242
 msgid "You can have only {0} category."
 msgid_plural "You can have only {0} categories."
 msgstr[0] "Apenas pode ter {0} categoria."
 msgstr[1] "Apenas pode ter {0} categorias."
 
-#: src/olympia/addons/forms.py:246
-msgid ""
-"The miscellaneous category cannot be combined with additional categories."
+#: src/olympia/addons/forms.py:250
+msgid "The miscellaneous category cannot be combined with additional categories."
 msgstr "A categoria Diversos não pode ser combinada com outras categorias."
 
-#: src/olympia/addons/forms.py:369
+#: src/olympia/addons/forms.py:374
 #, python-format
-msgid ""
-"Before changing your default locale you must have a name, summary, and "
-"description in that locale. You are missing %s."
-msgstr ""
-"Antes de alterar o seu idioma predefinido tem de ter um nome, resumo e uma "
-"descrição nesse idioma. Falta %s."
+msgid "Before changing your default locale you must have a name, summary, and description in that locale. You are missing %s."
+msgstr "Antes de alterar o seu idioma predefinido tem de ter um nome, resumo e uma descrição nesse idioma. Falta %s."
 
-#: src/olympia/addons/forms.py:484 src/olympia/addons/forms.py:575
+#: src/olympia/addons/forms.py:455 src/olympia/addons/forms.py:546
 msgid "A license must be selected."
 msgstr "Tem de ser selecionada uma licença."
 
-#: src/olympia/addons/forms.py:556
+#: src/olympia/addons/forms.py:527
 msgid "Give Your Theme a Name."
 msgstr "Dê um nome ao seu tema."
 
-#: src/olympia/addons/forms.py:562
-#: src/olympia/devhub/templates/devhub/personas/submit.html:53
+#: src/olympia/addons/forms.py:533 src/olympia/devhub/templates/devhub/personas/submit.html:53
 msgid "Describe your Theme."
 msgstr "Descreva o seu tema."
 
-#: src/olympia/addons/forms.py:704
+#: src/olympia/addons/forms.py:675
 msgid "Enter a new author's email address"
 msgstr "Introduza o novo endereço de email do autor"
 
@@ -180,49 +155,39 @@ msgstr "Introduza o novo endereço de email do autor"
 msgid "Not Reviewed"
 msgstr "Não revisto"
 
-#: src/olympia/addons/models.py:301
+#: src/olympia/addons/models.py:298
 msgid "Users have the option of contributing more or less than this amount."
-msgstr ""
-"Os utilizadores têm a opção de contribuir com mais ou menos desta quantia."
+msgstr "Os utilizadores têm a opção de contribuir com mais ou menos desta quantia."
 
-#: src/olympia/addons/models.py:309
-msgid ""
-"Users will always be asked in the Add-ons Manager (Firefox 4 and above)"
+#: src/olympia/addons/models.py:306
+msgid "Users will always be asked in the Add-ons Manager (Firefox 4 and above). Only applies to desktop."
 msgstr ""
-"Os utilizadores serão sempre informados no Gestor de Extras (Firefox 4 e "
-"superior)"
 
 # Column name in a table.
-#: src/olympia/addons/models.py:1804
-#: src/olympia/addons/templates/addons/details_box.html:55
-#: src/olympia/devhub/templates/devhub/index.html:92
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:102
+#: src/olympia/addons/models.py:1802 src/olympia/addons/templates/addons/details_box.html:55 src/olympia/devhub/templates/devhub/index.html:92
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:89
 msgid "Listed"
 msgstr "Listado"
 
-#: src/olympia/addons/views.py:320
-#: src/olympia/browse/templates/browse/personas/mobile/category_landing.html:27
+#: src/olympia/addons/views.py:334 src/olympia/browse/templates/browse/personas/mobile/category_landing.html:27
 msgid "Popular"
 msgstr "Popular"
 
-#: src/olympia/addons/views.py:321 src/olympia/browse/views.py:238
-#: src/olympia/browse/views.py:280 src/olympia/browse/views.py:482
+#: src/olympia/addons/views.py:335 src/olympia/browse/views.py:205 src/olympia/browse/views.py:247 src/olympia/browse/views.py:449
 msgid "Recently Added"
 msgstr "Adicionado recentemente"
 
-#: src/olympia/addons/views.py:322 src/olympia/bandwagon/views.py:99
-#: src/olympia/browse/views.py:60 src/olympia/browse/views.py:71
-#: src/olympia/search/forms.py:16 src/olympia/search/forms.py:91
+#: src/olympia/addons/views.py:336 src/olympia/bandwagon/views.py:99 src/olympia/browse/views.py:60 src/olympia/browse/views.py:71 src/olympia/search/forms.py:16 src/olympia/search/forms.py:91
 msgid "Recently Updated"
 msgstr "Atualizado recentemente"
 
-#. l10n: {0} is the addon name
 # %1 is an add-on name.
-#: src/olympia/addons/views.py:520
+#. l10n: {0} is the addon name
+#: src/olympia/addons/views.py:534
 msgid "Contribution for {0}"
 msgstr "Contribuição para {0}"
 
-#: src/olympia/addons/views.py:613
+#: src/olympia/addons/views.py:627
 msgid "Abuse reported."
 msgstr "Abuso reportado."
 
@@ -230,115 +195,70 @@ msgstr "Abuso reportado."
 msgid "My add-on doesn't fit into any of the categories"
 msgstr "O meu extra não se enquadra em nenhuma das categorias"
 
-#: src/olympia/addons/templates/addons/button.html:27
-#: src/olympia/addons/templates/addons/impala/button.html:11
-#: src/olympia/addons/templates/addons/mobile/button.html:11
+#: src/olympia/addons/templates/addons/button.html:27 src/olympia/addons/templates/addons/impala/button.html:11 src/olympia/addons/templates/addons/mobile/button.html:11
 msgid "No compatible versions"
 msgstr "Nenhuma versão compatível"
 
-#: src/olympia/addons/templates/addons/button.html:35
-#: src/olympia/addons/templates/addons/impala/button.html:19
+#: src/olympia/addons/templates/addons/button.html:35 src/olympia/addons/templates/addons/impala/button.html:19
 msgid "Added to Mobile"
 msgstr "Adicionado ao Mobile"
 
-#: src/olympia/addons/templates/addons/button.html:37
-#: src/olympia/addons/templates/addons/impala/button.html:21
+#: src/olympia/addons/templates/addons/button.html:37 src/olympia/addons/templates/addons/impala/button.html:21
 msgid "Add to Mobile"
 msgstr "Adicionar ao Mobile"
 
 #. {0} is a platform name like Windows or Mac OS X.
-#: src/olympia/addons/templates/addons/button.html:66
-#: src/olympia/addons/templates/addons/includes/install_button.html:19
+#: src/olympia/addons/templates/addons/button.html:66 src/olympia/addons/templates/addons/includes/install_button.html:19
 msgid "for {0}"
 msgstr "para {0}"
 
-#: src/olympia/addons/templates/addons/button.html:82
-#: src/olympia/addons/templates/addons/mobile/button.html:23
+#: src/olympia/addons/templates/addons/button.html:82 src/olympia/addons/templates/addons/mobile/button.html:23
 msgid "View privacy policy"
 msgstr "Ver a política de privacidade"
 
-#: src/olympia/addons/templates/addons/button.html:87
-#: src/olympia/addons/templates/addons/details_box.html:133
-#: src/olympia/addons/templates/addons/mobile/button.html:28
+#: src/olympia/addons/templates/addons/button.html:87 src/olympia/addons/templates/addons/details_box.html:133 src/olympia/addons/templates/addons/mobile/button.html:28
 #: src/olympia/discovery/templates/discovery/addons/detail.html:28
 msgid "View End-User License Agreement"
 msgstr "Ver acordo de licenciamento para o utilizador final"
 
-#: src/olympia/addons/templates/addons/button.html:92
-#: src/olympia/addons/templates/addons/impala/button.html:54
+#: src/olympia/addons/templates/addons/button.html:92 src/olympia/addons/templates/addons/impala/button.html:54
 #, python-format
-msgid ""
-"This add-on has not been reviewed by Mozilla. <a href=\"%(url)s\">Learn "
-"more</a>"
-msgstr ""
-"Este extra não foi revisto pela Mozilla. <a href=\"%(url)s\">Saiba mais</a>"
+msgid "This add-on has not been reviewed by Mozilla. <a href=\"%(url)s\">Learn more</a>"
+msgstr "Este extra não foi revisto pela Mozilla. <a href=\"%(url)s\">Saiba mais</a>"
 
-#: src/olympia/addons/templates/addons/button.html:97
-#: src/olympia/addons/templates/addons/impala/button.html:60
+#: src/olympia/addons/templates/addons/button.html:97 src/olympia/addons/templates/addons/impala/button.html:60
 #, python-format
-msgid ""
-"This add-on has been preliminarily reviewed by Mozilla. <a "
-"href=\"%(url)s\">Learn more</a>"
-msgstr ""
-"Este extra foi revisto preliminarmente pela Mozilla. <a "
-"href=\"%(url)s\">Saiba mais</a>"
+msgid "This add-on has been preliminarily reviewed by Mozilla. <a href=\"%(url)s\">Learn more</a>"
+msgstr "Este extra foi revisto preliminarmente pela Mozilla. <a href=\"%(url)s\">Saiba mais</a>"
 
-#: src/olympia/addons/templates/addons/contribution.html:11
-#: src/olympia/addons/templates/addons/impala/developers.html:44
-msgid ""
-"The developer of this add-on asks that you help support its continued "
-"development by making a small contribution."
-msgstr ""
-"O programador deste extra pede que o ajude a continuar o desenvolvimento com"
-" uma pequena contribuição."
+#: src/olympia/addons/templates/addons/contribution.html:11 src/olympia/addons/templates/addons/impala/developers.html:44
+msgid "The developer of this add-on asks that you help support its continued development by making a small contribution."
+msgstr "O programador deste extra pede que o ajude a continuar o desenvolvimento com uma pequena contribuição."
 
 #: src/olympia/addons/templates/addons/contribution.html:14
 #, python-format
-msgid ""
-"The developer of this add-on asks that you show your support by making a "
-"donation to the <a href=\"%(charity_url)s\">%(charity_name)s</a>."
-msgstr ""
-"O programador deste extra pede que mostre o seu apoio fazendo um donativo "
-"para <a href=\"%(charity_url)s\">%(charity_name)s</a>."
+msgid "The developer of this add-on asks that you show your support by making a donation to the <a href=\"%(charity_url)s\">%(charity_name)s</a>."
+msgstr "O programador deste extra pede que mostre o seu apoio fazendo um donativo para <a href=\"%(charity_url)s\">%(charity_name)s</a>."
 
 #: src/olympia/addons/templates/addons/contribution.html:19
 #, python-format
-msgid ""
-"The developer of this add-on asks that you show your support by making a "
-"small contribution to <a href=\"%(charity_url)s\">%(charity_name)s</a>."
-msgstr ""
-"O programador deste extra pede que mostre o seu apoio fazendo um pequeno "
-"donativo para <a href=\"%(charity_url)s\">%(charity_name)s</a>."
+msgid "The developer of this add-on asks that you show your support by making a small contribution to <a href=\"%(charity_url)s\">%(charity_name)s</a>."
+msgstr "O programador deste extra pede que mostre o seu apoio fazendo um pequeno donativo para <a href=\"%(charity_url)s\">%(charity_name)s</a>."
 
-#: src/olympia/addons/templates/addons/contribution.html:30
-#: src/olympia/addons/templates/addons/impala/contribution.html:18
-#: src/olympia/templates/menu_links.html:25
+#: src/olympia/addons/templates/addons/contribution.html:30 src/olympia/addons/templates/addons/impala/contribution.html:18 src/olympia/templates/menu_links.html:25
 msgid "Contribute"
 msgstr "Contribuir"
 
-#. Click Contribute button OR Install button
 # This is a separator between the graphical [contribute] button and the
 # graphical [download now] button
-#: src/olympia/addons/templates/addons/contribution.html:34
-#: src/olympia/addons/templates/addons/report_abuse.html:26
-#: src/olympia/addons/templates/addons/impala/contribution.html:32
-#: src/olympia/devhub/templates/devhub/addons/ajax_compat_update.html:36
-#: src/olympia/devhub/templates/devhub/addons/profile.html:44
-#: src/olympia/devhub/templates/devhub/addons/edit/admin.html:101
-#: src/olympia/devhub/templates/devhub/addons/edit/basic.html:152
-#: src/olympia/devhub/templates/devhub/addons/edit/details.html:85
-#: src/olympia/devhub/templates/devhub/addons/edit/support.html:67
-#: src/olympia/devhub/templates/devhub/addons/edit/technical.html:166
-#: src/olympia/devhub/templates/devhub/addons/forms_shared/media.html:149
-#: src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:44
-#: src/olympia/devhub/templates/devhub/versions/add_file_modal.html:78
-#: src/olympia/devhub/templates/devhub/versions/edit.html:139
-#: src/olympia/devhub/templates/devhub/versions/list.html:242
-#: src/olympia/devhub/templates/devhub/versions/list.html:276
-#: src/olympia/devhub/templates/devhub/versions/list.html:317
-#: src/olympia/devhub/templates/devhub/versions/list.html:351
-#: src/olympia/reviews/templates/reviews/edit_review.html:16
-#: src/olympia/translations/templates/translations/trans-menu.html:50
+#. Click Contribute button OR Install button
+#: src/olympia/addons/templates/addons/contribution.html:34 src/olympia/addons/templates/addons/report_abuse.html:26 src/olympia/addons/templates/addons/impala/contribution.html:32
+#: src/olympia/devhub/templates/devhub/addons/ajax_compat_update.html:36 src/olympia/devhub/templates/devhub/addons/profile.html:44 src/olympia/devhub/templates/devhub/addons/edit/admin.html:101
+#: src/olympia/devhub/templates/devhub/addons/edit/basic.html:152 src/olympia/devhub/templates/devhub/addons/edit/details.html:85 src/olympia/devhub/templates/devhub/addons/edit/support.html:67
+#: src/olympia/devhub/templates/devhub/addons/edit/technical.html:166 src/olympia/devhub/templates/devhub/addons/forms_shared/media.html:149
+#: src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:43 src/olympia/devhub/templates/devhub/versions/add_file_modal.html:58 src/olympia/devhub/templates/devhub/versions/edit.html:139
+#: src/olympia/devhub/templates/devhub/versions/list.html:239 src/olympia/devhub/templates/devhub/versions/list.html:281 src/olympia/devhub/templates/devhub/versions/list.html:315
+#: src/olympia/devhub/templates/devhub/versions/list.html:349 src/olympia/reviews/templates/reviews/edit_review.html:16 src/olympia/translations/templates/translations/trans-menu.html:50
 #: src/olympia/translations/templates/translations/trans-menu.html:62
 msgid "or"
 msgstr "ou"
@@ -347,40 +267,23 @@ msgstr "ou"
 msgid "Suggested Contribution: {0}"
 msgstr "Contribuição sugerida: {0}"
 
-#: src/olympia/addons/templates/addons/contribution.html:48
-#: src/olympia/amo/templates/amo/recaptcha.html:5
-#: src/olympia/versions/templates/versions/version.html:52
+#: src/olympia/addons/templates/addons/contribution.html:48 src/olympia/amo/templates/amo/recaptcha.html:5 src/olympia/versions/templates/versions/version.html:52
 msgid "What's this?"
 msgstr "O que é isto?"
 
 #: src/olympia/addons/templates/addons/contribution.html:63
 #, python-format
-msgid ""
-"The developer of this add-on would like you to consider making a donation to"
-" the <a href=\"%(charity_url)s\">%(charity_name)s</a> if you enjoy using it."
-msgstr ""
-"O programador deste extra gostaria que fizesse um donativo para <a "
-"href=\"%(charity_url)s\">%(charity_name)s</a> se gosta de o usar."
+msgid "The developer of this add-on would like you to consider making a donation to the <a href=\"%(charity_url)s\">%(charity_name)s</a> if you enjoy using it."
+msgstr "O programador deste extra gostaria que fizesse um donativo para <a href=\"%(charity_url)s\">%(charity_name)s</a> se gosta de o usar."
 
 #: src/olympia/addons/templates/addons/contribution.html:69
 #, python-format
-msgid ""
-"The developer of this add-on would like you to consider making a small "
-"contribution to <a href=\"%(charity_url)s\">%(charity_name)s</a> if you "
-"enjoy using it."
-msgstr ""
-"O programador deste extra gostaria que fizesse uma pequena contribuição para"
-" <a href=\"%(charity_url)s\">%(charity_name)s</a> se gosta de o usar."
+msgid "The developer of this add-on would like you to consider making a small contribution to <a href=\"%(charity_url)s\">%(charity_name)s</a> if you enjoy using it."
+msgstr "O programador deste extra gostaria que fizesse uma pequena contribuição para <a href=\"%(charity_url)s\">%(charity_name)s</a> se gosta de o usar."
 
 #: src/olympia/addons/templates/addons/contribution.html:76
-msgid ""
-"Mozilla is committed to supporting a vibrant and healthy developer "
-"ecosystem. Your optional contribution helps sustain further development of "
-"this add-on."
-msgstr ""
-"A Mozilla está empenhada em ajudar um eco-sistema de programadores saudável "
-"e vibrante. A sua contribuição opcional ajuda a um desenvolvimento contínuo "
-"deste extra."
+msgid "Mozilla is committed to supporting a vibrant and healthy developer ecosystem. Your optional contribution helps sustain further development of this add-on."
+msgstr "A Mozilla está empenhada em ajudar um eco-sistema de programadores saudável e vibrante. A sua contribuição opcional ajuda a um desenvolvimento contínuo deste extra."
 
 #: src/olympia/addons/templates/addons/contributions_lightbox.html:5
 msgid "Make a Contribution"
@@ -388,38 +291,25 @@ msgstr "Fazer uma contribuição"
 
 #: src/olympia/addons/templates/addons/contributions_lightbox.html:9
 #, python-format
-msgid ""
-"Help support the continued development of <strong>%(addon_name)s</strong> by"
-" making a small contribution through <a href=\"%(paypal_url)s\">PayPal</a>."
-msgstr ""
-"Ajude a suportar o desenvolvimento contínuo do "
-"<strong>%(addon_name)s</strong> com uma pequena contribuição através do <a "
-"href=\"%(paypal_url)s\">PayPal</a>."
+msgid "Help support the continued development of <strong>%(addon_name)s</strong> by making a small contribution through <a href=\"%(paypal_url)s\">PayPal</a>."
+msgstr "Ajude a suportar o desenvolvimento contínuo do <strong>%(addon_name)s</strong> com uma pequena contribuição através do <a href=\"%(paypal_url)s\">PayPal</a>."
 
 #: src/olympia/addons/templates/addons/contributions_lightbox.html:15
 #, python-format
 msgid ""
-"To show your support for <b>%(addon_name)s</b>, the developer asks that you "
-"make a donation to the <a href=\"%(charity_url)s\">%(charity_name)s</a> "
-"through <a href=\"%(paypal_url)s\">PayPal</a>."
+"To show your support for <b>%(addon_name)s</b>, the developer asks that you make a donation to the <a href=\"%(charity_url)s\">%(charity_name)s</a> through <a href=\"%(paypal_url)s\">PayPal</a>."
 msgstr ""
-"Para mostrar o seu apoio ao <strong>%(addon_name)s</strong>, o programador "
-"pede que faça umm donativo para <a "
-"href=\"%(charity_url)s\">%(charity_name)s</a> através do <a "
-"href=\"%(paypal_url)s\">PayPal</a>."
+"Para mostrar o seu apoio ao <strong>%(addon_name)s</strong>, o programador pede que faça umm donativo para <a href=\"%(charity_url)s\">%(charity_name)s</a> através do <a href=\"%(paypal_url)s"
+"\">PayPal</a>."
 
 #: src/olympia/addons/templates/addons/contributions_lightbox.html:21
 #, python-format
 msgid ""
-"To show your support for <b>%(addon_name)s</b>, the developer asks that you "
-"make a small contribution to <a "
-"href=\"%(charity_url)s\">%(charity_name)s</a> through <a "
-"href=\"%(paypal_url)s\">PayPal</a>."
+"To show your support for <b>%(addon_name)s</b>, the developer asks that you make a small contribution to <a href=\"%(charity_url)s\">%(charity_name)s</a> through <a href=\"%(paypal_url)s\">PayPal</"
+"a>."
 msgstr ""
-"Para mostrar o seu apoio ao <b>%(addon_name)s</b>, o programador pede que "
-"faça um pequeno donativo para <a "
-"href=\"%(charity_url)s\">%(charity_name)s</a> através do <a "
-"href=\"%(paypal_url)s\">PayPal</a>."
+"Para mostrar o seu apoio ao <b>%(addon_name)s</b>, o programador pede que faça um pequeno donativo para <a href=\"%(charity_url)s\">%(charity_name)s</a> através do <a href=\"%(paypal_url)s"
+"\">PayPal</a>."
 
 #: src/olympia/addons/templates/addons/contributions_lightbox.html:30
 msgid "How much would you like to contribute?"
@@ -442,8 +332,7 @@ msgstr "A quantia de contribuição tem de ser um número."
 msgid "A one-time suggested contribution of {0}"
 msgstr "Sugestão para uma contribuição única de {0}"
 
-#. {0} is a currency symbol (e.g., $),                    {1} is an amount
-#. input
+#. {0} is a currency symbol (e.g., $),                    {1} is an amount input
 #. field
 #: src/olympia/addons/templates/addons/contributions_lightbox.html:64
 msgid "A one-time contribution of {0} {1}"
@@ -453,11 +342,8 @@ msgstr "Uma contribuição única de {0} {1}"
 msgid "Leave a comment or request with your contribution."
 msgstr "Deixe um comentário ou pedido com a sua contribuição."
 
-#: src/olympia/addons/templates/addons/contributions_lightbox.html:74
-#: src/olympia/bandwagon/templates/bandwagon/ajax_new.html:20
-#: src/olympia/bandwagon/templates/bandwagon/includes/addedit.html:37
-#: src/olympia/reviews/templates/reviews/mobile/add_form.html:13
-#: src/olympia/templates/includes/forms.html:10
+#: src/olympia/addons/templates/addons/contributions_lightbox.html:74 src/olympia/bandwagon/templates/bandwagon/ajax_new.html:20 src/olympia/bandwagon/templates/bandwagon/includes/addedit.html:37
+#: src/olympia/reviews/templates/reviews/mobile/add_form.html:13 src/olympia/templates/includes/forms.html:10
 msgid "(optional)"
 msgstr "(opcional)"
 
@@ -477,36 +363,27 @@ msgstr "Não, obrigado"
 msgid "Contribution made, thank you."
 msgstr "Contribuição efetuada, obrigado."
 
-#: src/olympia/addons/templates/addons/details_box.html:10
-#: src/olympia/discovery/templates/discovery/addons/detail.html:19
+#: src/olympia/addons/templates/addons/details_box.html:10 src/olympia/discovery/templates/discovery/addons/detail.html:19
 msgid "No restart required"
 msgstr "Não necessita de reiniciar"
 
 #. This is a caption for a table. {0} is an add-on name.
-#: src/olympia/addons/templates/addons/details_box.html:26
-#: src/olympia/addons/templates/addons/includes/persona.html:9
+#: src/olympia/addons/templates/addons/details_box.html:26 src/olympia/addons/templates/addons/includes/persona.html:9
 msgid "Add-on Information for {0}"
 msgstr "Informação do extra para {0}"
 
-#: src/olympia/addons/templates/addons/details_box.html:30
-#: src/olympia/addons/templates/addons/persona_detail_table.html:3
-#: src/olympia/addons/templates/addons/mobile/details.html:63
-#: src/olympia/addons/templates/addons/mobile/persona_detail_table.html:7
-#: src/olympia/browse/views.py:459 src/olympia/devhub/views.py:75
+#: src/olympia/addons/templates/addons/details_box.html:30 src/olympia/addons/templates/addons/persona_detail_table.html:3 src/olympia/addons/templates/addons/mobile/details.html:63
+#: src/olympia/addons/templates/addons/mobile/persona_detail_table.html:7 src/olympia/browse/views.py:426 src/olympia/devhub/views.py:73
 msgid "Updated"
 msgstr "Atualizado"
 
-#: src/olympia/addons/templates/addons/details_box.html:38
-#: src/olympia/addons/templates/addons/mobile/details.html:71
-#: src/olympia/devhub/templates/devhub/addons/edit/support.html:43
+#: src/olympia/addons/templates/addons/details_box.html:38 src/olympia/addons/templates/addons/mobile/details.html:71 src/olympia/devhub/templates/devhub/addons/edit/support.html:43
 #: src/olympia/discovery/templates/discovery/addons/detail.html:77
 msgid "Website"
 msgstr "Website"
 
 #. This refers to this version's compatible applications, such as Firefox 8.0
-#: src/olympia/addons/templates/addons/details_box.html:47
-#: src/olympia/addons/templates/addons/mobile/details.html:80
-#: src/olympia/search/templates/search/results.html:72
+#: src/olympia/addons/templates/addons/details_box.html:47 src/olympia/addons/templates/addons/mobile/details.html:80 src/olympia/search/templates/search/results.html:72
 #: src/olympia/versions/templates/versions/version.html:21
 msgid "Works with"
 msgstr "Funciona com"
@@ -515,45 +392,30 @@ msgstr "Funciona com"
 msgid "Visibility"
 msgstr "Visibilidade"
 
-#: src/olympia/addons/templates/addons/details_box.html:57
-#: src/olympia/devhub/templates/devhub/index.html:94
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:104
+#: src/olympia/addons/templates/addons/details_box.html:57 src/olympia/devhub/templates/devhub/index.html:94 src/olympia/devhub/templates/devhub/includes/addon_details.html:91
 msgid "Hidden"
 msgstr "Oculta"
 
-#: src/olympia/addons/templates/addons/details_box.html:59
-#: src/olympia/devhub/templates/devhub/index.html:96
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:106
+#: src/olympia/addons/templates/addons/details_box.html:59 src/olympia/devhub/templates/devhub/index.html:96 src/olympia/devhub/templates/devhub/includes/addon_details.html:93
 msgid "Unlisted"
 msgstr "Não listada"
 
-#: src/olympia/addons/templates/addons/details_box.html:67
-#: src/olympia/devhub/templates/devhub/addons/edit/technical.html:44
+#: src/olympia/addons/templates/addons/details_box.html:67 src/olympia/devhub/templates/devhub/addons/edit/technical.html:44
 msgid "Required Add-ons"
 msgstr "Extras necessários"
 
-#: src/olympia/addons/templates/addons/details_box.html:81
-#: src/olympia/addons/templates/addons/persona_detail_table.html:15
-#: src/olympia/browse/views.py:462 src/olympia/devhub/views.py:78
-#: src/olympia/devhub/views.py:85
-#: src/olympia/discovery/templates/discovery/addons/detail.html:57
-#: src/olympia/reviews/forms.py:62
-#: src/olympia/reviews/templates/reviews/add.html:57
+#: src/olympia/addons/templates/addons/details_box.html:81 src/olympia/addons/templates/addons/persona_detail_table.html:15 src/olympia/browse/views.py:429 src/olympia/devhub/views.py:76
+#: src/olympia/devhub/views.py:83 src/olympia/discovery/templates/discovery/addons/detail.html:57 src/olympia/reviews/forms.py:62 src/olympia/reviews/templates/reviews/add.html:57
 #: src/olympia/reviews/templates/reviews/mobile/review_list.html:18
 msgid "Rating"
 msgstr "Avaliação"
 
-#: src/olympia/addons/templates/addons/details_box.html:85
-#: src/olympia/browse/views.py:461 src/olympia/devhub/views.py:77
-#: src/olympia/devhub/views.py:84
-#: src/olympia/stats/templates/stats/addon_report_menu.html:8
-#: src/olympia/stats/templates/stats/collection_report_menu.html:18
+#: src/olympia/addons/templates/addons/details_box.html:85 src/olympia/browse/views.py:428 src/olympia/devhub/views.py:75 src/olympia/devhub/views.py:82
+#: src/olympia/stats/templates/stats/addon_report_menu.html:8 src/olympia/stats/templates/stats/collection_report_menu.html:18
 msgid "Downloads"
 msgstr "Descargas"
 
-#: src/olympia/addons/templates/addons/details_box.html:91
-#: src/olympia/addons/templates/addons/details_box.html:103
-#: src/olympia/devhub/templates/devhub/addons/listing/item_actions_theme.html:17
+#: src/olympia/addons/templates/addons/details_box.html:91 src/olympia/addons/templates/addons/details_box.html:103 src/olympia/devhub/templates/devhub/addons/listing/item_actions_theme.html:17
 #: src/olympia/devhub/templates/devhub/personas/edit.html:60
 msgid "View Statistics"
 msgstr "Ver estatísticas"
@@ -567,18 +429,13 @@ msgid "Abuse Reports"
 msgstr "Relatórios de abuso"
 
 #. The Privacy Policy for this add-on.
-#: src/olympia/addons/templates/addons/details_box.html:121
-#: src/olympia/addons/templates/addons/privacy.html:19
-#: src/olympia/addons/templates/addons/privacy.html:23
-#: src/olympia/addons/templates/addons/impala/button.html:43
-#: src/olympia/addons/templates/addons/impala/details.html:307
-#: src/olympia/devhub/templates/devhub/includes/policy_form.html:20
+#: src/olympia/addons/templates/addons/details_box.html:121 src/olympia/addons/templates/addons/privacy.html:19 src/olympia/addons/templates/addons/privacy.html:23
+#: src/olympia/addons/templates/addons/impala/button.html:43 src/olympia/addons/templates/addons/impala/details.html:312 src/olympia/devhub/templates/devhub/includes/policy_form.html:23
 #: src/olympia/templates/mobile/base_addons.html:87
 msgid "Privacy Policy"
 msgstr "Política de privacidade"
 
-#: src/olympia/addons/templates/addons/details_box.html:124
-#: src/olympia/discovery/templates/discovery/addons/detail.html:24
+#: src/olympia/addons/templates/addons/details_box.html:124 src/olympia/discovery/templates/discovery/addons/detail.html:24
 msgid "View Privacy Policy"
 msgstr "Ver política de privacidade"
 
@@ -586,8 +443,7 @@ msgstr "Ver política de privacidade"
 msgid "EULA"
 msgstr "EULA"
 
-#: src/olympia/addons/templates/addons/details_box.html:171
-#: src/olympia/addons/templates/addons/details_box.html:231
+#: src/olympia/addons/templates/addons/details_box.html:171 src/olympia/addons/templates/addons/details_box.html:231
 msgid "More about this add-on"
 msgstr "Mais acerca deste extra"
 
@@ -595,27 +451,21 @@ msgstr "Mais acerca deste extra"
 msgid "Image Gallery"
 msgstr "Galeria de imagens"
 
-#: src/olympia/addons/templates/addons/details_box.html:190
-#: src/olympia/devhub/templates/devhub/addons/edit/technical.html:21
+#: src/olympia/addons/templates/addons/details_box.html:190 src/olympia/devhub/templates/devhub/addons/edit/technical.html:21
 msgid "Developer Comments"
 msgstr "Comentários do programador"
 
-#: src/olympia/addons/templates/addons/details_box.html:199
-#: src/olympia/addons/templates/addons/impala/details.html:259
+#: src/olympia/addons/templates/addons/details_box.html:199 src/olympia/addons/templates/addons/impala/details.html:264
 msgid "Development Channel"
 msgstr "Canal de desenvolvimento"
 
-#: src/olympia/addons/templates/addons/details_box.html:202
-#: src/olympia/addons/templates/addons/mobile/details.html:124
+#: src/olympia/addons/templates/addons/details_box.html:202 src/olympia/addons/templates/addons/mobile/details.html:124
 msgid ""
-"The Development Channel lets you test an experimental new version of this "
-"add-on before it's released to the general public. Once you install the "
-"development version, you will continue to get updates from this channel."
+"The Development Channel lets you test an experimental new version of this add-on before it's released to the general public. Once you install the development version, you will continue to get "
+"updates from this channel."
 msgstr ""
-"O canal de desenvolvimento permite que teste uma versão nova experimental "
-"deste extra antes de ser lançado ao público em geral. Depois de instalar a "
-"versão de desenvolvimento irá continuar a receber as atualizações deste "
-"canal."
+"O canal de desenvolvimento permite que teste uma versão nova experimental deste extra antes de ser lançado ao público em geral. Depois de instalar a versão de desenvolvimento irá continuar a "
+"receber as atualizações deste canal."
 
 #: src/olympia/addons/templates/addons/details_box.html:207
 msgid "Install development version"
@@ -623,76 +473,52 @@ msgstr "Instalar versão de desenvolvimento"
 
 #: src/olympia/addons/templates/addons/details_box.html:211
 msgid ""
-"<strong>Caution:</strong> Development versions of this add-on have not been "
-"reviewed by Mozilla. Once you install a development version you will "
-"continue to receive development updates from this developer. To stop "
-"receiving development updates, reinstall the default version from the link "
-"above."
+"<strong>Caution:</strong> Development versions of this add-on have not been reviewed by Mozilla. Once you install a development version you will continue to receive development updates from this "
+"developer. To stop receiving development updates, reinstall the default version from the link above."
 msgstr ""
-"<strong>Cuidado:</strong> As versões de desenvolvimento deste extra não "
-"foram revistas pela Mozilla. Depois de instalar uma versão de "
-"desenvolvimento vai continuar a receber atualizações deste programador. Para"
-" parar de receber atualizações de desenvolvimento, reinstale a versão "
-"predefinida na ligação acima."
+"<strong>Cuidado:</strong> As versões de desenvolvimento deste extra não foram revistas pela Mozilla. Depois de instalar uma versão de desenvolvimento vai continuar a receber atualizações deste "
+"programador. Para parar de receber atualizações de desenvolvimento, reinstale a versão predefinida na ligação acima."
 
-#: src/olympia/addons/templates/addons/details_box.html:220
-#: src/olympia/addons/templates/addons/impala/details.html:278
+#: src/olympia/addons/templates/addons/details_box.html:220 src/olympia/addons/templates/addons/impala/details.html:283
 msgid "Version {0}:"
 msgstr "Versão {0}:"
 
 #: src/olympia/addons/templates/addons/details_box.html:234
 msgid "Nothing to see here!  The developer did not include any details."
-msgstr "Nada a mostrar aqui!  O programador não incluiu quaisquer detalhes."
+msgstr ""
 
-#: src/olympia/addons/templates/addons/details_box.html:251
-#: src/olympia/devhub/templates/devhub/versions/edit.html:73
-#: src/olympia/editors/templates/editors/review.html:98
+#: src/olympia/addons/templates/addons/details_box.html:251 src/olympia/devhub/templates/devhub/versions/edit.html:73 src/olympia/editors/templates/editors/review.html:98
 msgid "Version Notes"
 msgstr "Notas da versão"
 
 #. {0} is the name of the add-on.
 #. {0} is the name of the add-on
-#: src/olympia/addons/templates/addons/eula.html:6
-#: src/olympia/discovery/templates/discovery/addons/eula.html:5
+#: src/olympia/addons/templates/addons/eula.html:6 src/olympia/discovery/templates/discovery/addons/eula.html:5
 msgid "End-User License Agreement for {0}"
 msgstr "Acordo de Licença para o Utilizador Final para {0}"
 
-#: src/olympia/addons/templates/addons/eula.html:17
-#: src/olympia/addons/templates/addons/eula.html:21
-#: src/olympia/addons/templates/addons/impala/button.html:48
-#: src/olympia/addons/templates/addons/impala/details.html:316
-#: src/olympia/devhub/templates/devhub/includes/policy_form.html:3
-#: src/olympia/discovery/templates/discovery/addons/eula.html:11
+#: src/olympia/addons/templates/addons/eula.html:17 src/olympia/addons/templates/addons/eula.html:21 src/olympia/addons/templates/addons/impala/button.html:48
+#: src/olympia/addons/templates/addons/impala/details.html:321 src/olympia/devhub/templates/devhub/includes/policy_form.html:3 src/olympia/discovery/templates/discovery/addons/eula.html:11
 msgid "End-User License Agreement"
 msgstr "Acordo de licença de utilizador final"
 
-#: src/olympia/addons/templates/addons/eula.html:23
-#: src/olympia/discovery/templates/discovery/addons/eula.html:13
+#: src/olympia/addons/templates/addons/eula.html:23 src/olympia/discovery/templates/discovery/addons/eula.html:13
 #, python-format
-msgid ""
-"%(addon_name)s requires that you accept the following End-User License "
-"Agreement before installation can proceed:"
-msgstr ""
-"%(addon_name)s necessita que aceite o seguinte Acordo de Licença para o "
-"Utilizador Final antes de continuar com a instalação:"
+msgid "%(addon_name)s requires that you accept the following End-User License Agreement before installation can proceed:"
+msgstr "%(addon_name)s necessita que aceite o seguinte Acordo de Licença para o Utilizador Final antes de continuar com a instalação:"
 
-#: src/olympia/addons/templates/addons/eula.html:34
-#: src/olympia/addons/templates/addons/privacy.html:26
+#: src/olympia/addons/templates/addons/eula.html:34 src/olympia/addons/templates/addons/privacy.html:26
 msgid "Back to {0}…"
 msgstr "Voltar para {0}…"
 
 # {0} is the application the user is browsing.  Examples:  Thunderbird,
 # Firefox,
 # Sunbird
-#: src/olympia/addons/templates/addons/home.html:3
-#: src/olympia/addons/templates/addons/mobile/home.html:3
-#: src/olympia/amo/helpers.py:235
+#: src/olympia/addons/templates/addons/home.html:3 src/olympia/addons/templates/addons/mobile/home.html:3 src/olympia/amo/helpers.py:235
 msgid "Add-ons for {0}"
 msgstr "Extras para o {0} "
 
-#: src/olympia/addons/templates/addons/home.html:10
-#: src/olympia/addons/templates/addons/home.html:51
-#: src/olympia/browse/templates/browse/impala/base_listing.html:11
+#: src/olympia/addons/templates/addons/home.html:10 src/olympia/addons/templates/addons/home.html:53 src/olympia/browse/templates/browse/impala/base_listing.html:11
 msgid "Featured Extensions"
 msgstr "Extensões em destaque"
 
@@ -700,70 +526,49 @@ msgstr "Extensões em destaque"
 msgid "Popular Extensions"
 msgstr "Extensões populares"
 
-#: src/olympia/addons/templates/addons/home.html:42
-#: src/olympia/amo/templates/amo/side_nav.html:3
-#: src/olympia/amo/templates/amo/side_nav.html:11
-#: src/olympia/amo/templates/amo/site_nav.html:3
-#: src/olympia/amo/templates/amo/site_nav.html:25
-#: src/olympia/browse/views.py:236 src/olympia/browse/views.py:281
-#: src/olympia/browse/views.py:481
+#: src/olympia/addons/templates/addons/home.html:44 src/olympia/amo/templates/amo/side_nav.html:3 src/olympia/amo/templates/amo/side_nav.html:11 src/olympia/amo/templates/amo/site_nav.html:3
+#: src/olympia/amo/templates/amo/site_nav.html:25 src/olympia/browse/views.py:203 src/olympia/browse/views.py:248 src/olympia/browse/views.py:448
 msgid "Most Popular"
 msgstr "Mais populares"
 
-#: src/olympia/addons/templates/addons/home.html:43
+#: src/olympia/addons/templates/addons/home.html:45
 msgid "All »"
 msgstr "Tudo »"
 
-#: src/olympia/addons/templates/addons/home.html:52
-#: src/olympia/addons/templates/addons/home.html:61
-#: src/olympia/addons/templates/addons/home.html:70
-#: src/olympia/addons/templates/addons/home.html:78
+#: src/olympia/addons/templates/addons/home.html:54 src/olympia/addons/templates/addons/home.html:63 src/olympia/addons/templates/addons/home.html:72 src/olympia/addons/templates/addons/home.html:80
 #: src/olympia/browse/templates/browse/impala/category_landing.html:36
 msgid "See all »"
 msgstr "Ver tudo »"
 
-#: src/olympia/addons/templates/addons/home.html:60
+#: src/olympia/addons/templates/addons/home.html:62
 msgid "Up &amp; Coming Extensions"
 msgstr "Próximas extensões"
 
-#: src/olympia/addons/templates/addons/home.html:69
-#: src/olympia/browse/templates/browse/personas/category_landing.html:61
-#: src/olympia/discovery/templates/discovery/pane.html:74
+#: src/olympia/addons/templates/addons/home.html:71 src/olympia/browse/templates/browse/personas/category_landing.html:61 src/olympia/discovery/templates/discovery/pane.html:74
 msgid "Featured Themes"
 msgstr "Temas em destaque"
 
-#: src/olympia/addons/templates/addons/home.html:77
-#: src/olympia/bandwagon/templates/bandwagon/impala/collection_listing.html:5
+#: src/olympia/addons/templates/addons/home.html:79 src/olympia/bandwagon/templates/bandwagon/impala/collection_listing.html:5
 msgid "Featured Collections"
 msgstr "Coleções incluídas"
 
-#: src/olympia/addons/templates/addons/listing_header.html:3
-#: src/olympia/addons/templates/addons/impala/listing/sorter.html:2
-#: src/olympia/amo/templates/amo/mobile/sort_by.html:2
+#: src/olympia/addons/templates/addons/listing_header.html:3 src/olympia/addons/templates/addons/impala/listing/sorter.html:2 src/olympia/amo/templates/amo/mobile/sort_by.html:2
 #: src/olympia/bandwagon/templates/bandwagon/collection_detail.html:118
 msgid "Sort by:"
 msgstr "Ordenar por:"
 
 #. {0} is a date.
 #. {0} is a date
-#: src/olympia/addons/templates/addons/macros.html:7
-#: src/olympia/addons/templates/addons/macros.html:72
-#: src/olympia/addons/templates/addons/listing/items_mobile.html:48
-#: src/olympia/addons/templates/addons/listing/macros.html:42
-#: src/olympia/bandwagon/templates/bandwagon/collection_detail.html:50
-#: src/olympia/bandwagon/templates/bandwagon/collection_listing_items.html:40
-#: src/olympia/bandwagon/templates/bandwagon/impala/collection_listing_items.html:40
+#: src/olympia/addons/templates/addons/macros.html:7 src/olympia/addons/templates/addons/macros.html:72 src/olympia/addons/templates/addons/listing/items_mobile.html:48
+#: src/olympia/addons/templates/addons/listing/macros.html:42 src/olympia/bandwagon/templates/bandwagon/collection_detail.html:50
+#: src/olympia/bandwagon/templates/bandwagon/collection_listing_items.html:40 src/olympia/bandwagon/templates/bandwagon/impala/collection_listing_items.html:40
 msgid "Updated {0}"
 msgstr "Atualizado {0}"
 
 #. {0} is a date.
-#: src/olympia/addons/templates/addons/macros.html:10
-#: src/olympia/addons/templates/addons/macros.html:69
-#: src/olympia/addons/templates/addons/persona_preview.html:21
-#: src/olympia/addons/templates/addons/listing/items_mobile.html:44
-#: src/olympia/addons/templates/addons/listing/macros.html:39
-#: src/olympia/bandwagon/templates/bandwagon/collection_listing_items.html:37
-#: src/olympia/bandwagon/templates/bandwagon/impala/collection_listing_items.html:37
+#: src/olympia/addons/templates/addons/macros.html:10 src/olympia/addons/templates/addons/macros.html:69 src/olympia/addons/templates/addons/persona_preview.html:22
+#: src/olympia/addons/templates/addons/listing/items_mobile.html:44 src/olympia/addons/templates/addons/listing/macros.html:39
+#: src/olympia/bandwagon/templates/bandwagon/collection_listing_items.html:37 src/olympia/bandwagon/templates/bandwagon/impala/collection_listing_items.html:37
 msgid "Added {0}"
 msgstr "Adicionado {0}"
 
@@ -782,18 +587,14 @@ msgstr[0] "%(num)s utilizador"
 msgstr[1] "%(num)s utilizadores"
 
 #. {0} is the number of downloads.
-#: src/olympia/addons/templates/addons/macros.html:53
-#: src/olympia/addons/templates/addons/impala/details.html:61
+#: src/olympia/addons/templates/addons/macros.html:53 src/olympia/addons/templates/addons/impala/details.html:59
 msgid "{0} weekly download"
 msgid_plural "{0} weekly downloads"
 msgstr[0] "{0} descarga semanal"
 msgstr[1] "{0} descargas semanais"
 
 #. {0} is the number of users.
-#: src/olympia/addons/templates/addons/macros.html:61
-#: src/olympia/addons/templates/addons/impala/details.html:54
-#: src/olympia/compat/templates/compat/index.html:71
-#: src/olympia/zadmin/templates/zadmin/compat.html:67
+#: src/olympia/addons/templates/addons/macros.html:61 src/olympia/addons/templates/addons/impala/details.html:52 src/olympia/zadmin/templates/zadmin/compat.html:67
 msgid "{0} user"
 msgid_plural "{0} users"
 msgstr[0] "{0} utilizador"
@@ -811,12 +612,8 @@ msgstr "Pagamento concluído"
 msgid "Return to the addon."
 msgstr "Voltar ao extra."
 
-#: src/olympia/addons/templates/addons/persona_detail.html:17
-#: src/olympia/addons/templates/addons/impala/details.html:106
-#: src/olympia/addons/templates/addons/mobile/details.html:23
-#: src/olympia/addons/templates/addons/mobile/persona_detail.html:21
-#: src/olympia/discovery/templates/discovery/addons/base.html:27
-#: src/olympia/editors/templates/editors/review.html:31
+#: src/olympia/addons/templates/addons/persona_detail.html:17 src/olympia/addons/templates/addons/impala/details.html:103 src/olympia/addons/templates/addons/mobile/details.html:23
+#: src/olympia/addons/templates/addons/mobile/persona_detail.html:21 src/olympia/discovery/templates/discovery/addons/base.html:27 src/olympia/editors/templates/editors/review.html:31
 msgid "by"
 msgstr "por"
 
@@ -826,8 +623,7 @@ msgid "More {0} Themes"
 msgstr "Mais {0} temas"
 
 #. {0} is a category name, such as Nature
-#: src/olympia/addons/templates/addons/persona_detail.html:39
-#: src/olympia/addons/templates/addons/mobile/persona_detail.html:66
+#: src/olympia/addons/templates/addons/persona_detail.html:39 src/olympia/addons/templates/addons/mobile/persona_detail.html:66
 msgid "See all {0} Themes"
 msgstr "Ver todos os {0} temas"
 
@@ -835,186 +631,130 @@ msgstr "Ver todos os {0} temas"
 msgid "More by this Artist"
 msgstr "Mais deste artista"
 
-#: src/olympia/addons/templates/addons/persona_detail.html:52
-#: src/olympia/addons/templates/addons/mobile/persona_detail.html:49
+#: src/olympia/addons/templates/addons/persona_detail.html:52 src/olympia/addons/templates/addons/mobile/persona_detail.html:49
 msgid "See all Themes by this Artist"
 msgstr "Ver todos os temas deste artista"
 
-#: src/olympia/addons/templates/addons/persona_detail.html:71
-#: src/olympia/addons/templates/addons/mobile/home.html:42
-#: src/olympia/amo/templates/amo/side_nav.html:22
-#: src/olympia/browse/templates/browse/personas/mobile/category_landing.html:28
-#: src/olympia/devhub/templates/devhub/addons/edit/basic.html:72
-#: src/olympia/editors/templates/editors/review.html:277
-#: src/olympia/editors/templates/editors/themes/themes.html:34
-#: src/olympia/templates/categories.html:7
+#: src/olympia/addons/templates/addons/persona_detail.html:71 src/olympia/addons/templates/addons/mobile/home.html:42 src/olympia/amo/templates/amo/side_nav.html:22
+#: src/olympia/browse/templates/browse/personas/mobile/category_landing.html:28 src/olympia/devhub/templates/devhub/addons/edit/basic.html:72 src/olympia/editors/templates/editors/review.html:277
+#: src/olympia/editors/templates/editors/themes/themes.html:34 src/olympia/templates/categories.html:7
 msgid "Categories"
 msgstr "Categorias"
 
-#: src/olympia/addons/templates/addons/persona_detail_table.html:10
-#: src/olympia/addons/templates/addons/mobile/persona_detail_table.html:3
-#: src/olympia/editors/templates/editors/themes/deleted.html:19
+#: src/olympia/addons/templates/addons/persona_detail_table.html:10 src/olympia/addons/templates/addons/mobile/persona_detail_table.html:3 src/olympia/editors/templates/editors/themes/deleted.html:19
 #: src/olympia/editors/templates/editors/themes/themes.html:25
 msgid "Artist"
 msgstr "Artista"
 
-#: src/olympia/addons/templates/addons/persona_detail_table.html:19
-#: src/olympia/addons/templates/addons/mobile/persona_detail_table.html:14
-#: src/olympia/stats/templates/stats/addon_report_menu.html:17
+#: src/olympia/addons/templates/addons/persona_detail_table.html:19 src/olympia/addons/templates/addons/mobile/persona_detail_table.html:14 src/olympia/stats/templates/stats/addon_report_menu.html:17
 msgid "Daily Users"
 msgstr "Utilizadores diários"
 
 #. The License for this add-on.
-#: src/olympia/addons/templates/addons/persona_detail_table.html:26
-#: src/olympia/addons/templates/addons/impala/license.html:17
-#: src/olympia/addons/templates/addons/mobile/persona_detail_table.html:21
-#: src/olympia/devhub/templates/devhub/includes/license_form.html:5
-#: src/olympia/devhub/templates/devhub/versions/edit.html:89
-#: src/olympia/editors/templates/editors/themes/themes.html:41
+#: src/olympia/addons/templates/addons/persona_detail_table.html:26 src/olympia/addons/templates/addons/impala/license.html:17 src/olympia/addons/templates/addons/mobile/persona_detail_table.html:21
+#: src/olympia/devhub/templates/devhub/includes/license_form.html:5 src/olympia/devhub/templates/devhub/versions/edit.html:89 src/olympia/editors/templates/editors/themes/themes.html:41
 msgid "License"
 msgstr "Licença"
 
-#: src/olympia/addons/templates/addons/persona_preview.html:12
-#: src/olympia/constants/base.py:48
+#: src/olympia/addons/templates/addons/persona_preview.html:13 src/olympia/constants/base.py:48
 msgid "Awaiting Review"
 msgstr "A aguardar análise"
 
-#: src/olympia/addons/templates/addons/persona_preview.html:14
-#: src/olympia/amo/log.py:180 src/olympia/constants/base.py:42
-#: src/olympia/editors/helpers.py:62
+#: src/olympia/addons/templates/addons/persona_preview.html:15 src/olympia/amo/log.py:180 src/olympia/constants/base.py:42 src/olympia/editors/helpers.py:62
 msgid "Rejected"
 msgstr "Rejeitado"
 
-#: src/olympia/addons/templates/addons/persona_preview.html:16
-#: src/olympia/amo/log.py:159
+#: src/olympia/addons/templates/addons/persona_preview.html:17 src/olympia/amo/log.py:159
 msgid "Approved"
 msgstr "Aprovado"
 
 #. {0} is the number of users.
-#: src/olympia/addons/templates/addons/persona_preview.html:26
-#: src/olympia/addons/templates/addons/listing/items_mobile.html:36
-#: src/olympia/addons/templates/addons/listing/macros.html:31
+#: src/olympia/addons/templates/addons/persona_preview.html:27 src/olympia/addons/templates/addons/listing/items_mobile.html:36 src/olympia/addons/templates/addons/listing/macros.html:31
 msgid "<strong>{0}</strong> user"
 msgid_plural "<strong>{0}</strong> users"
 msgstr[0] "<strong>{0}</strong> utilizador"
 msgstr[1] "<strong>{0}</strong> utilizadores"
 
-#: src/olympia/addons/templates/addons/persona_preview.html:40
+#: src/olympia/addons/templates/addons/persona_preview.html:41
 msgid "Hover to Preview"
 msgstr "Passe para Visualizar"
 
-#: src/olympia/addons/templates/addons/persona_preview.html:46
-#: src/olympia/addons/templates/addons/persona_preview.html:48
+#: src/olympia/addons/templates/addons/persona_preview.html:47 src/olympia/addons/templates/addons/persona_preview.html:49 src/olympia/addons/templates/addons/persona_preview.html:97
 #: src/olympia/reviews/templates/reviews/add.html:15
 msgid "Add"
 msgstr "Adicionar"
 
-#: src/olympia/addons/templates/addons/persona_preview.html:57
-#: src/olympia/bandwagon/templates/bandwagon/ajax_new.html:16
-#: src/olympia/bandwagon/templates/bandwagon/edit.html:19
-#: src/olympia/bandwagon/templates/bandwagon/includes/addedit.html:19
-#: src/olympia/devhub/templates/devhub/addons/edit/admin.html:13
-#: src/olympia/devhub/templates/devhub/addons/edit/basic.html:10
-#: src/olympia/devhub/templates/devhub/addons/edit/details.html:8
-#: src/olympia/devhub/templates/devhub/addons/edit/media.html:6
-#: src/olympia/devhub/templates/devhub/addons/edit/support.html:8
-#: src/olympia/devhub/templates/devhub/addons/edit/technical.html:9
-#: src/olympia/devhub/templates/devhub/addons/submit/describe.html:29
-#: src/olympia/editors/templates/editors/review.html:257
+#: src/olympia/addons/templates/addons/persona_preview.html:58 src/olympia/bandwagon/templates/bandwagon/ajax_new.html:16 src/olympia/bandwagon/templates/bandwagon/edit.html:19
+#: src/olympia/bandwagon/templates/bandwagon/includes/addedit.html:19 src/olympia/devhub/templates/devhub/addons/edit/admin.html:13 src/olympia/devhub/templates/devhub/addons/edit/basic.html:10
+#: src/olympia/devhub/templates/devhub/addons/edit/details.html:8 src/olympia/devhub/templates/devhub/addons/edit/media.html:6 src/olympia/devhub/templates/devhub/addons/edit/support.html:8
+#: src/olympia/devhub/templates/devhub/addons/edit/technical.html:9 src/olympia/devhub/templates/devhub/addons/submit/describe.html:29 src/olympia/editors/templates/editors/review.html:257
 msgid "Edit"
 msgstr "Editar"
 
 #. For datetime formatting, see the table on
 #. http://docs.python.org/library/datetime.html#strftime-and-strptime-behavior
-#: src/olympia/addons/templates/addons/persona_preview.html:66
+#: src/olympia/addons/templates/addons/persona_preview.html:67
 #, python-format
 msgid "%%Y-%%m-%%d"
 msgstr "%%d/%%m/%%Y"
 
-#: src/olympia/addons/templates/addons/persona_preview.html:67
+#: src/olympia/addons/templates/addons/persona_preview.html:68
 msgid "by {0} on {1}"
 msgstr "por {0} em {1}"
 
-#: src/olympia/addons/templates/addons/persona_preview.html:75
-#: src/olympia/reviews/helpers.py:17
-#: src/olympia/reviews/templates/reviews/review_list.html:63
-#: src/olympia/reviews/templates/reviews/reviews_link.html:21
-#: src/olympia/reviews/templates/reviews/impala/reviews_link.html:16
+#: src/olympia/addons/templates/addons/persona_preview.html:76 src/olympia/reviews/helpers.py:17 src/olympia/reviews/templates/reviews/review_list.html:63
+#: src/olympia/reviews/templates/reviews/reviews_link.html:21 src/olympia/reviews/templates/reviews/impala/reviews_link.html:16
 msgid "Not yet rated"
 msgstr "Ainda sem avaliação"
 
-#: src/olympia/addons/templates/addons/persona_preview.html:78
+#: src/olympia/addons/templates/addons/persona_preview.html:79
 msgid "<b>{0}</b> users"
 msgstr "<b>{0}</b> utilizadores"
 
 #: src/olympia/addons/templates/addons/popups.html:17
-msgid ""
-"To install this add-on and thousands more, <b>get Firefox</b>, a free and "
-"open web browser from Mozilla."
-msgstr ""
-"Para instalar este extra e muitos mais, <b>obtenha o Firefox</b>, o "
-"navegador grátis da Mozilla."
+msgid "To install this add-on and thousands more, <b>get Firefox</b>, a free and open web browser from Mozilla."
+msgstr "Para instalar este extra e muitos mais, <b>obtenha o Firefox</b>, o navegador grátis da Mozilla."
 
-#: src/olympia/addons/templates/addons/popups.html:21
-#: src/olympia/addons/templates/addons/popups.html:52
+#: src/olympia/addons/templates/addons/popups.html:21 src/olympia/addons/templates/addons/popups.html:52
 msgid "Learn more about Firefox"
 msgstr "Saber mais sobre o Firefox"
 
 #: src/olympia/addons/templates/addons/popups.html:22
-msgid "or <b><a class=\"installer\" href=\"{url}\">download anyway</a></b>"
-msgstr "ou <b><a class=\"installer\" href=\"{url}\">descarregar ainda assim</a></b>"
+msgid "or <b><a class=\"button installer\" href=\"{url}\">download anyway</a></b>"
+msgstr ""
 
 #: src/olympia/addons/templates/addons/popups.html:26
 msgid ""
-"<strong>How to Install in Thunderbird</strong> <ol> <li>Download and save "
-"the file to your hard disk.</li> <li>In Mozilla Thunderbird, open Add-ons "
-"from the Tools menu.</li> <li>From the options button next to the add-on "
-"search field, select \"Install Add-on From File...\" and locate the "
-"downloaded add-on.</li> </ol>"
+"<strong>How to Install in Thunderbird</strong> <ol> <li>Download and save the file to your hard disk.</li> <li>In Mozilla Thunderbird, open Add-ons from the Tools menu.</li> <li>From the options "
+"button next to the add-on search field, select \"Install Add-on From File...\" and locate the downloaded add-on.</li> </ol>"
 msgstr ""
-"<strong>Como instalar no Thunderbird</strong> <ol> <li>Descarregue e guarde "
-"o ficheiro no seu disco.</li> <li>No Mozilla Thunderbird, abra o Extras a "
-"partir do menu Ferramentas.</li> <li>A partir do botão opções a seguir ao "
-"campo da pesquisa, selecione \"Instalar extra a partir de ficheiro...\" e "
-"localize o extra descarregado.</li> </ol>"
+"<strong>Como instalar no Thunderbird</strong> <ol> <li>Descarregue e guarde o ficheiro no seu disco.</li> <li>No Mozilla Thunderbird, abra o Extras a partir do menu Ferramentas.</li> <li>A partir "
+"do botão opções a seguir ao campo da pesquisa, selecione \"Instalar extra a partir de ficheiro...\" e localize o extra descarregado.</li> </ol>"
 
 #: src/olympia/addons/templates/addons/popups.html:41
-msgid ""
-"To install this Theme, <b>get Thunderbird</b>, a free and open source email "
-"client from Mozilla Messaging and install the Personas Plus add-on."
-msgstr ""
-"Para instalar este tema <b>obtenha o Thunderbird</b>, um cliente de email "
-"gratuito e de código aberto da Mozilla, e instale o extra Personas Plus."
+msgid "To install this Theme, <b>get Thunderbird</b>, a free and open source email client from Mozilla Messaging and install the Personas Plus add-on."
+msgstr "Para instalar este tema <b>obtenha o Thunderbird</b>, um cliente de email gratuito e de código aberto da Mozilla, e instale o extra Personas Plus."
 
 #: src/olympia/addons/templates/addons/popups.html:46
 msgid "Learn more about Thunderbird"
 msgstr "Saber mais sobre o Thunderbird"
 
 #: src/olympia/addons/templates/addons/popups.html:48
-msgid ""
-"To install this Theme and thousands more, <b>get Firefox</b>, a free and "
-"open web browser from Mozilla."
-msgstr ""
-"Para instalar este tema e muitos mais, <b>obtenha o Firefox</b>, um "
-"navegador grátis e aberto da Mozilla."
+msgid "To install this Theme and thousands more, <b>get Firefox</b>, a free and open web browser from Mozilla."
+msgstr "Para instalar este tema e muitos mais, <b>obtenha o Firefox</b>, um navegador grátis e aberto da Mozilla."
 
 #: src/olympia/addons/templates/addons/popups.html:60
 #, python-format
 msgid "This add-on has not been updated to work with your version of %(app)s."
-msgstr ""
-"Este extra não foi atualizado para funcionar com a sua versão do %(app)s."
+msgstr "Este extra não foi atualizado para funcionar com a sua versão do %(app)s."
 
-#: src/olympia/addons/templates/addons/popups.html:63
-#: src/olympia/addons/templates/addons/popups.html:140
-#: src/olympia/addons/templates/addons/popups.html:150
+#: src/olympia/addons/templates/addons/popups.html:63 src/olympia/addons/templates/addons/popups.html:140 src/olympia/addons/templates/addons/popups.html:150
 msgid "Install Anyway"
 msgstr "Instalar de qualquer maneira"
 
 #: src/olympia/addons/templates/addons/popups.html:71
-msgid ""
-"This add-on requires a version of Firefox that has not been released yet."
-msgstr ""
-"Este extra necessita de uma versão do Firefox que ainda não foi lançada."
+msgid "This add-on requires a version of Firefox that has not been released yet."
+msgstr "Este extra necessita de uma versão do Firefox que ainda não foi lançada."
 
 #: src/olympia/addons/templates/addons/popups.html:74
 msgid "Help test new Firefox Versions"
@@ -1022,16 +762,11 @@ msgstr "Ajude a testar novas versões do Firefox"
 
 #: src/olympia/addons/templates/addons/popups.html:77
 #, python-format
-msgid ""
-"This add-on requires %(app)s {new_version}. You are currently using %(app)s "
-"{old_version}."
-msgstr ""
-"Este extra necessita o %(app)s {new_version}. Está a utilizar o %(app)s "
-"{old_version}."
+msgid "This add-on requires %(app)s {new_version}. You are currently using %(app)s {old_version}."
+msgstr "Este extra necessita o %(app)s {new_version}. Está a utilizar o %(app)s {old_version}."
 
 #. {0} is an app name, like Firefox.
-#: src/olympia/addons/templates/addons/popups.html:82
-#: src/olympia/addons/templates/addons/popups.html:101
+#: src/olympia/addons/templates/addons/popups.html:82 src/olympia/addons/templates/addons/popups.html:101
 msgid "Upgrade {0}"
 msgstr "Atualizar {0}"
 
@@ -1042,44 +777,25 @@ msgstr "ou veja <a href=\"%(href)s\">versões antigas deste extra</a>."
 
 #: src/olympia/addons/templates/addons/popups.html:96
 #, python-format
-msgid ""
-"This Persona requires %(app)s %(new_version)s. You are currently using "
-"%(app)s {old_version}."
-msgstr ""
-"Este Persona necessita %(app)s %(new_version)s. Está a usar %(app)s "
-"{old_version}."
+msgid "This Persona requires %(app)s %(new_version)s. You are currently using %(app)s {old_version}."
+msgstr "Este Persona necessita %(app)s %(new_version)s. Está a usar %(app)s {old_version}."
 
 #: src/olympia/addons/templates/addons/popups.html:108
 msgid ""
-"<strong>Caution:</strong> This add-on has not been reviewed by Mozilla and "
-"can't be installed on release versions of Firefox 43 and above.  Be careful "
-"when installing third-party software that might harm your computer."
+"<strong>Caution:</strong> This add-on has not been reviewed by Mozilla and can't be installed on release versions of Firefox 43 and above.  Be careful when installing third-party software that "
+"might harm your computer."
 msgstr ""
-"<strong>Atenção:</strong> Este extra não foi revisto pela Mozilla e não pode"
-" ser instalado em versões finais do Firefox 43 e mais recentes.  Tenha "
-"cuidado ao instalar software de terceiros que possa danificar o seu "
-"computador."
 
 #: src/olympia/addons/templates/addons/popups.html:120
-msgid ""
-"<strong>Please note:</strong> This add-on is not compatible with your "
-"operating system."
-msgstr ""
-"<strong>Tenha em atenção:</strong> Este extra não é compatível com o seu "
-"sistema."
+msgid "<strong>Please note:</strong> This add-on is not compatible with your operating system."
+msgstr "<strong>Tenha em atenção:</strong> Este extra não é compatível com o seu sistema."
 
-#: src/olympia/addons/templates/addons/popups.html:136
-#: src/olympia/addons/templates/addons/impala/button.html:70
+#: src/olympia/addons/templates/addons/popups.html:136 src/olympia/addons/templates/addons/impala/button.html:70
 #, python-format
-msgid ""
-"This add-on is not compatible with your version of %(app)s because of the "
-"following:"
-msgstr ""
-"Este extra não é compatível com a sua versão do %(app)s pelos seguintes "
-"motivos:"
+msgid "This add-on is not compatible with your version of %(app)s because of the following:"
+msgstr "Este extra não é compatível com a sua versão do %(app)s pelos seguintes motivos:"
 
-#: src/olympia/addons/templates/addons/popups.html:141
-#: src/olympia/addons/templates/addons/popups.html:151
+#: src/olympia/addons/templates/addons/popups.html:141 src/olympia/addons/templates/addons/popups.html:151
 msgid "View other versions"
 msgstr "Ver outras versões"
 
@@ -1103,146 +819,88 @@ msgid ""
 "  to your phone.  (You'll need a QR reader.  Search your phone's marketplace if\n"
 "  don't have one.)"
 msgstr ""
-"Quer o {0} no seu Firefox móvel?  Digitalize este código QR para instalar diretamente\n"
-"  no seu telefone. (Irá precisar de um leitor de QR.  Procure no mercado de aplicações\n"
-"  do seu telefone se não tiver uma.)"
 
-#: src/olympia/addons/templates/addons/report_abuse.html:6
-#: src/olympia/addons/templates/addons/report_abuse_full.html:10
-#: src/olympia/addons/templates/addons/impala/details-more.html:23
-#: src/olympia/addons/templates/addons/impala/details.html:328
+#: src/olympia/addons/templates/addons/report_abuse.html:6 src/olympia/addons/templates/addons/report_abuse_full.html:10 src/olympia/addons/templates/addons/impala/details-more.html:23
+#: src/olympia/addons/templates/addons/impala/details.html:333
 msgid "Report Abuse"
 msgstr "Reportar abuso"
 
 #: src/olympia/addons/templates/addons/report_abuse.html:10
 #, python-format
 msgid ""
-"If you suspect this add-on violates <a href=\"%(url)s\">our policies</a> or "
-"has security or privacy issues, please use the form below to describe your "
-"concerns. Please do not use this form for any other reason."
+"If you suspect this add-on violates <a href=\"%(url)s\">our policies</a> or has security or privacy issues, please use the form below to describe your concerns. Please do not use this form for any "
+"other reason."
 msgstr ""
-"Se suspeita que este extra <a href=\"%(url)s\">viola as nossas políticas</a>"
-" ou tem problemas de segurança ou privacidade, por favor use o formulário "
-"abaixo para descrever as suas preocupações. Por favor, não use esse "
-"formulário para qualquer outro motivo."
+"Se suspeita que este extra <a href=\"%(url)s\">viola as nossas políticas</a> ou tem problemas de segurança ou privacidade, por favor use o formulário abaixo para descrever as suas preocupações. Por "
+"favor, não use esse formulário para qualquer outro motivo."
 
-#: src/olympia/addons/templates/addons/report_abuse.html:24
-#: src/olympia/users/templates/users/report_abuse.html:19
+#: src/olympia/addons/templates/addons/report_abuse.html:24 src/olympia/users/templates/users/report_abuse.html:19
 msgid "Send Report"
 msgstr "Enviar relatório"
 
-#: src/olympia/addons/templates/addons/report_abuse.html:26
-#: src/olympia/addons/templates/addons/mobile/eula.html:16
-#: src/olympia/addons/templates/addons/mobile/persona_confirm.html:7
-#: src/olympia/devhub/templates/devhub/addons/ajax_compat_update.html:36
-#: src/olympia/devhub/templates/devhub/addons/profile.html:44
-#: src/olympia/devhub/templates/devhub/addons/edit/admin.html:104
-#: src/olympia/devhub/templates/devhub/addons/edit/basic.html:155
-#: src/olympia/devhub/templates/devhub/addons/edit/details.html:88
-#: src/olympia/devhub/templates/devhub/addons/edit/support.html:70
-#: src/olympia/devhub/templates/devhub/addons/edit/technical.html:169
-#: src/olympia/devhub/templates/devhub/addons/forms_shared/media.html:152
-#: src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:44
-#: src/olympia/devhub/templates/devhub/personas/edit.html:222
-#: src/olympia/devhub/templates/devhub/versions/add_file_modal.html:79
-#: src/olympia/devhub/templates/devhub/versions/edit.html:140
-#: src/olympia/devhub/templates/devhub/versions/list.html:208
-#: src/olympia/devhub/templates/devhub/versions/list.html:242
-#: src/olympia/devhub/templates/devhub/versions/list.html:276
-#: src/olympia/devhub/templates/devhub/versions/list.html:317
-#: src/olympia/reviews/templates/reviews/edit_review.html:16
-#: src/olympia/translations/templates/translations/trans-menu.html:50
-#: src/olympia/translations/templates/translations/trans-menu.html:62
-#: src/olympia/zadmin/templates/zadmin/validation.html:105
+#: src/olympia/addons/templates/addons/report_abuse.html:26 src/olympia/addons/templates/addons/mobile/eula.html:16 src/olympia/addons/templates/addons/mobile/persona_confirm.html:7
+#: src/olympia/devhub/templates/devhub/addons/ajax_compat_update.html:36 src/olympia/devhub/templates/devhub/addons/profile.html:44 src/olympia/devhub/templates/devhub/addons/edit/admin.html:104
+#: src/olympia/devhub/templates/devhub/addons/edit/basic.html:155 src/olympia/devhub/templates/devhub/addons/edit/details.html:88 src/olympia/devhub/templates/devhub/addons/edit/support.html:70
+#: src/olympia/devhub/templates/devhub/addons/edit/technical.html:169 src/olympia/devhub/templates/devhub/addons/forms_shared/media.html:152
+#: src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:43 src/olympia/devhub/templates/devhub/personas/edit.html:222 src/olympia/devhub/templates/devhub/versions/add_file_modal.html:59
+#: src/olympia/devhub/templates/devhub/versions/edit.html:140 src/olympia/devhub/templates/devhub/versions/list.html:208 src/olympia/devhub/templates/devhub/versions/list.html:239
+#: src/olympia/devhub/templates/devhub/versions/list.html:281 src/olympia/devhub/templates/devhub/versions/list.html:315 src/olympia/reviews/templates/reviews/edit_review.html:16
+#: src/olympia/translations/templates/translations/trans-menu.html:50 src/olympia/translations/templates/translations/trans-menu.html:62 src/olympia/zadmin/templates/zadmin/validation.html:105
 msgid "Cancel"
 msgstr "Cancelar"
 
-#: src/olympia/addons/templates/addons/review_add_box.html:3
-#: src/olympia/addons/templates/addons/impala/review_add_box.html:5
+#: src/olympia/addons/templates/addons/review_add_box.html:3 src/olympia/addons/templates/addons/impala/review_add_box.html:5
 msgid "What do you think?"
 msgstr "O que acha?"
 
-#: src/olympia/addons/templates/addons/review_add_box.html:7
-#: src/olympia/addons/templates/addons/impala/review_add_box.html:9
+#: src/olympia/addons/templates/addons/review_add_box.html:7 src/olympia/addons/templates/addons/impala/review_add_box.html:9
 #, python-format
 msgid "Please <a href=\"%(login)s\">log in</a> to submit a review"
-msgstr ""
-"Por favor <a href=\"%(login)s\">inicie sessão</a> para submeter um "
-"comentário"
+msgstr "Por favor <a href=\"%(login)s\">inicie sessão</a> para submeter um comentário"
 
-#: src/olympia/addons/templates/addons/review_add_box.html:16
-#: src/olympia/addons/templates/addons/impala/review_add_box.html:18
-#: src/olympia/reviews/templates/reviews/mobile/add_form.html:13
+#: src/olympia/addons/templates/addons/review_add_box.html:16 src/olympia/addons/templates/addons/impala/review_add_box.html:18 src/olympia/reviews/templates/reviews/mobile/add_form.html:13
 msgid "Title:"
 msgstr "Título:"
 
-#: src/olympia/addons/templates/addons/review_add_box.html:17
-#: src/olympia/addons/templates/addons/impala/review_add_box.html:19
-#: src/olympia/reviews/templates/reviews/mobile/add_form.html:17
+#: src/olympia/addons/templates/addons/review_add_box.html:17 src/olympia/addons/templates/addons/impala/review_add_box.html:19 src/olympia/reviews/templates/reviews/mobile/add_form.html:17
 msgid "Review:"
 msgstr "Comentário:"
 
-#: src/olympia/addons/templates/addons/review_add_box.html:18
-#: src/olympia/addons/templates/addons/impala/review_add_box.html:20
-#: src/olympia/reviews/templates/reviews/mobile/add_form.html:16
+#: src/olympia/addons/templates/addons/review_add_box.html:18 src/olympia/addons/templates/addons/impala/review_add_box.html:20 src/olympia/reviews/templates/reviews/mobile/add_form.html:16
 msgid "Rating:"
 msgstr "Classificação:"
 
-#: src/olympia/addons/templates/addons/review_add_box.html:19
-#: src/olympia/addons/templates/addons/impala/review_add_box.html:21
-#: src/olympia/reviews/templates/reviews/add.html:63
-#: src/olympia/reviews/templates/reviews/edit_review.html:15
-#: src/olympia/reviews/templates/reviews/mobile/add_form.html:18
+#: src/olympia/addons/templates/addons/review_add_box.html:19 src/olympia/addons/templates/addons/impala/review_add_box.html:21 src/olympia/reviews/templates/reviews/add.html:63
+#: src/olympia/reviews/templates/reviews/edit_review.html:15 src/olympia/reviews/templates/reviews/mobile/add_form.html:18
 msgid "Submit review"
 msgstr "Submeter comentário"
 
-#: src/olympia/addons/templates/addons/review_add_box.html:24
-#: src/olympia/addons/templates/addons/impala/review_add_box.html:26
-msgid ""
-"Please do not post bug reports in reviews. We do not make your email address"
-" available to add-on developers and they may need to contact you to help "
-"resolve your issue."
-msgstr ""
-"Por favor, não insira relatos de erro nos comentários. Não disponibilizamos "
-"o seu endereço de email aos programadores de extras e eles poderão ter que o"
-" contactar para resolver o problema."
+#: src/olympia/addons/templates/addons/review_add_box.html:24 src/olympia/addons/templates/addons/impala/review_add_box.html:26
+msgid "Please do not post bug reports in reviews. We do not make your email address available to add-on developers and they may need to contact you to help resolve your issue."
+msgstr "Por favor, não insira relatos de erro nos comentários. Não disponibilizamos o seu endereço de email aos programadores de extras e eles poderão ter que o contactar para resolver o problema."
 
-#: src/olympia/addons/templates/addons/review_add_box.html:32
-#: src/olympia/addons/templates/addons/impala/review_add_box.html:35
+#: src/olympia/addons/templates/addons/review_add_box.html:32 src/olympia/addons/templates/addons/impala/review_add_box.html:35
 #, python-format
-msgid ""
-"See the <a href=\"%(support)s\">support section</a> to find out where to get"
-" assistance for this add-on."
-msgstr ""
-"Veja a <a href=\"%(support)s\">secção de suporte</a> para encontrar "
-"assistência para este extra."
+msgid "See the <a href=\"%(support)s\">support section</a> to find out where to get assistance for this add-on."
+msgstr "Veja a <a href=\"%(support)s\">secção de suporte</a> para encontrar assistência para este extra."
 
-#: src/olympia/addons/templates/addons/review_add_box.html:38
-#: src/olympia/addons/templates/addons/impala/review_add_box.html:42
-#: src/olympia/pages/templates/pages/review_guide.html:3
+#: src/olympia/addons/templates/addons/review_add_box.html:38 src/olympia/addons/templates/addons/impala/review_add_box.html:42 src/olympia/pages/templates/pages/review_guide.html:3
 #: src/olympia/pages/templates/pages/review_guide.html:44
 msgid "Review Guidelines"
 msgstr "Guia sobre comentários"
 
-#: src/olympia/addons/templates/addons/review_list_box.html:5
-#: src/olympia/addons/templates/addons/impala/details-more.html:27
-#: src/olympia/editors/helpers.py:921
-#: src/olympia/reviews/templates/reviews/add.html:14
-#: src/olympia/reviews/templates/reviews/reply.html:14
-#: src/olympia/reviews/templates/reviews/review_list.html:19
+#: src/olympia/addons/templates/addons/review_list_box.html:5 src/olympia/addons/templates/addons/impala/details-more.html:27 src/olympia/editors/helpers.py:1001
+#: src/olympia/reviews/templates/reviews/add.html:14 src/olympia/reviews/templates/reviews/reply.html:14 src/olympia/reviews/templates/reviews/review_list.html:19
 #: src/olympia/reviews/templates/reviews/mobile/review_list.html:26
 msgid "Reviews"
 msgstr "Comentários"
 
-#: src/olympia/addons/templates/addons/review_list_box.html:14
-#: src/olympia/addons/templates/addons/impala/review_list_box.html:14
-#: src/olympia/reviews/templates/reviews/review.html:30
+#: src/olympia/addons/templates/addons/review_list_box.html:14 src/olympia/addons/templates/addons/impala/review_list_box.html:14 src/olympia/reviews/templates/reviews/review.html:30
 #, python-format
 msgid "by %(user)s on %(date)s"
 msgstr "por %(user)s em %(date)s"
 
-#: src/olympia/addons/templates/addons/review_list_box.html:19
-#: src/olympia/addons/templates/addons/impala/review_list_box.html:29
+#: src/olympia/addons/templates/addons/review_list_box.html:19 src/olympia/addons/templates/addons/impala/review_list_box.html:29
 msgid "Show the developer's reply to this review"
 msgstr "Mostrar a resposta do programador a esta revisão"
 
@@ -1253,21 +911,16 @@ msgid_plural "See all %(cnt)s reviews of this add-on"
 msgstr[0] "Ver todos os comentários para este extra"
 msgstr[1] "Ver todos os %(cnt)s comentários para este extra"
 
-#: src/olympia/addons/templates/addons/tags_box.html:3
-#: src/olympia/devhub/templates/devhub/addons/edit/basic.html:118
+#: src/olympia/addons/templates/addons/tags_box.html:3 src/olympia/devhub/templates/devhub/addons/edit/basic.html:118
 msgid "Tags"
 msgstr "Etiquetas"
 
-#: src/olympia/addons/templates/addons/impala/addon_hovercard.html:7
-#: src/olympia/addons/templates/addons/impala/addon_hovercard.html:9
+#: src/olympia/addons/templates/addons/impala/addon_hovercard.html:7 src/olympia/addons/templates/addons/impala/addon_hovercard.html:9
 msgid "Icon for {0}"
 msgstr "Ícone para {0}"
 
-#: src/olympia/addons/templates/addons/impala/addon_hovercard.html:34
-#: src/olympia/addons/templates/addons/impala/featured_grid.html:26
-#: src/olympia/addons/templates/addons/impala/theme_grid.html:22
-#: src/olympia/bandwagon/templates/bandwagon/collection_detail.html:31
-#: src/olympia/users/templates/users/helpers/addon_users_list.html:7
+#: src/olympia/addons/templates/addons/impala/addon_hovercard.html:34 src/olympia/addons/templates/addons/impala/featured_grid.html:26 src/olympia/addons/templates/addons/impala/theme_grid.html:22
+#: src/olympia/bandwagon/templates/bandwagon/collection_detail.html:31 src/olympia/users/templates/users/helpers/addon_users_list.html:7
 #, python-format
 msgid "by %(users)s"
 msgstr "por %(users)s"
@@ -1287,39 +940,22 @@ msgstr "Gostou deste extra?"
 
 #: src/olympia/addons/templates/addons/impala/contribution.html:43
 #, python-format
-msgid ""
-"The <a href=\"%(meet_url)s\">developer of this add-on</a> asks that you help"
-" support its continued development by making a small contribution."
-msgstr ""
-"O <a href=\"%(meet_url)s\">programador deste extra</a> pede que o apoie no "
-"desenvolvimento com uma pequena contribuição."
+msgid "The <a href=\"%(meet_url)s\">developer of this add-on</a> asks that you help support its continued development by making a small contribution."
+msgstr "O <a href=\"%(meet_url)s\">programador deste extra</a> pede que o apoie no desenvolvimento com uma pequena contribuição."
 
 #: src/olympia/addons/templates/addons/impala/contribution.html:48
 #, python-format
-msgid ""
-"The <a href=\"%(meet_url)s\">developer of this add-on</a> asks that you show"
-" your support by making a donation to the <a "
-"href=\"%(charity_url)s\">%(charity_name)s</a>."
-msgstr ""
-"O <a href=\"%(meet_url)s\">programador deste extra</a> pede mostre o seu "
-"apoio com uma contribuição para <a "
-"href=\"%(charity_url)s\">%(charity_name)s</a>."
+msgid "The <a href=\"%(meet_url)s\">developer of this add-on</a> asks that you show your support by making a donation to the <a href=\"%(charity_url)s\">%(charity_name)s</a>."
+msgstr "O <a href=\"%(meet_url)s\">programador deste extra</a> pede mostre o seu apoio com uma contribuição para <a href=\"%(charity_url)s\">%(charity_name)s</a>."
 
 #: src/olympia/addons/templates/addons/impala/contribution.html:53
 #, python-format
-msgid ""
-"The <a href=\"%(meet_url)s\">developer of this add-on</a> asks that you show"
-" your support by making a small contribution to <a "
-"href=\"%(charity_url)s\">%(charity_name)s</a>."
-msgstr ""
-"O <a href=\"%(meet_url)s\">programador deste extra</a> pede que o apoie no "
-"desenvolvimento com uma pequena contribuição para <a "
-"href=\"%(charity_url)s\">%(charity_name)s</a>."
+msgid "The <a href=\"%(meet_url)s\">developer of this add-on</a> asks that you show your support by making a small contribution to <a href=\"%(charity_url)s\">%(charity_name)s</a>."
+msgstr "O <a href=\"%(meet_url)s\">programador deste extra</a> pede que o apoie no desenvolvimento com uma pequena contribuição para <a href=\"%(charity_url)s\">%(charity_name)s</a>."
 
 #: src/olympia/addons/templates/addons/impala/dependencies_note.html:4
 msgid "This add-on requires the following add-ons to work properly:"
-msgstr ""
-"Este extra necessita dos seguintes extras para funcionar corretamente:"
+msgstr "Este extra necessita dos seguintes extras para funcionar corretamente:"
 
 #: src/olympia/addons/templates/addons/impala/details-more.html:13
 msgid "Average"
@@ -1344,33 +980,31 @@ msgid_plural "Other add-ons by these authors"
 msgstr[0] "Outros extras de %(author)s"
 msgstr[1] "Outros extras destes autores"
 
-#: src/olympia/addons/templates/addons/impala/details.html:41
+#: src/olympia/addons/templates/addons/impala/details.html:39
 #, python-format
 msgid "<span itemprop=\"ratingCount\">%(num)s</span> user review"
 msgid_plural "<span itemprop=\"ratingCount\">%(num)s</span> user reviews"
 msgstr[0] "<span itemprop=\"ratingCount\">%(num)s</span> comentário de utilizador"
-msgstr[1] ""
-"<span itemprop=\"ratingCount\">%(num)s</span> comentários de utilizadores"
+msgstr[1] "<span itemprop=\"ratingCount\">%(num)s</span> comentários de utilizadores"
 
-#: src/olympia/addons/templates/addons/impala/details.html:69
+#: src/olympia/addons/templates/addons/impala/details.html:66
 msgid "View statistics"
 msgstr "Ver estatísticas"
 
-#: src/olympia/addons/templates/addons/impala/details.html:84
+#: src/olympia/addons/templates/addons/impala/details.html:81
 msgid "Manage"
 msgstr "Gerir"
 
 #. {0} is an add-on name.
-#: src/olympia/addons/templates/addons/impala/details.html:96
+#: src/olympia/addons/templates/addons/impala/details.html:93
 msgid "Icon of {0}"
 msgstr "Ícone de {0}"
 
-#: src/olympia/addons/templates/addons/impala/details.html:103
-#: src/olympia/addons/templates/addons/impala/listing/items.html:14
+#: src/olympia/addons/templates/addons/impala/details.html:100 src/olympia/addons/templates/addons/impala/listing/items.html:14
 msgid "No Restart"
 msgstr "Sem reínicio"
 
-#: src/olympia/addons/templates/addons/impala/details.html:127
+#: src/olympia/addons/templates/addons/impala/details.html:124
 #, python-format
 msgid "Meet the Developer: <a href=\"%(url)s\">%(name)s</a>"
 msgid_plural "<a href=\"%(url)s\">Meet the Developers</a>"
@@ -1378,115 +1012,90 @@ msgstr[0] "Conheça o programador: <a href=\"%(url)s\">%(name)s</a>"
 msgstr[1] "<a href=\"%(url)s\">Conheça os programadores</a>"
 
 # {0} is an add-on name.
-#: src/olympia/addons/templates/addons/impala/details.html:137
+#: src/olympia/addons/templates/addons/impala/details.html:134
 msgid "Learn why {0} was created and find out what's next for this add-on."
-msgstr ""
-"Saiba porque é que o {0} foi criado e descubra o próximo desenvolvimento "
-"para este extra."
+msgstr "Saiba porque é que o {0} foi criado e descubra o próximo desenvolvimento para este extra."
 
 #. {0} is an index.
-#: src/olympia/addons/templates/addons/impala/details.html:156
+#: src/olympia/addons/templates/addons/impala/details.html:161
 msgid "Add-on screenshot #{0}"
 msgstr "Captura de ecrã número {0} do extra"
 
-#: src/olympia/addons/templates/addons/impala/details.html:182
+#: src/olympia/addons/templates/addons/impala/details.html:187
 msgid "Add-on home page"
 msgstr "Página do extra"
 
-#: src/olympia/addons/templates/addons/impala/details.html:185
+#: src/olympia/addons/templates/addons/impala/details.html:190
 msgid "Support site"
 msgstr "Site de apoio"
 
-#: src/olympia/addons/templates/addons/impala/details.html:189
+#: src/olympia/addons/templates/addons/impala/details.html:194
 msgid "Support E-mail"
 msgstr "Endereço de e-mail de apoio"
 
-#: src/olympia/addons/templates/addons/impala/details.html:194
-#: src/olympia/devhub/models.py:378
-#: src/olympia/devhub/templates/devhub/versions/list.html:12
-#: src/olympia/versions/templates/versions/version.html:6
-#: src/olympia/versions/templates/versions/mobile/version.html:6
+#: src/olympia/addons/templates/addons/impala/details.html:199 src/olympia/devhub/models.py:378 src/olympia/devhub/templates/devhub/versions/list.html:12
+#: src/olympia/versions/templates/versions/version.html:6 src/olympia/versions/templates/versions/mobile/version.html:6
 msgid "Version {0}"
 msgstr "Versão {0}"
 
-#: src/olympia/addons/templates/addons/impala/details.html:194
+#: src/olympia/addons/templates/addons/impala/details.html:199
 msgid "Info"
 msgstr "Info"
 
-#: src/olympia/addons/templates/addons/impala/details.html:195
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:129
+#: src/olympia/addons/templates/addons/impala/details.html:200 src/olympia/devhub/templates/devhub/includes/addon_details.html:116
 msgid "Last Updated:"
 msgstr "Última atualização:"
 
-#: src/olympia/addons/templates/addons/impala/details.html:200
+#: src/olympia/addons/templates/addons/impala/details.html:205
 #, python-format
 msgid "Released under <a target=\"_blank\" href=\"%(url)s\">%(name)s</a>"
 msgstr "Lançado sobre a <a target=\"_blank\" href=\"%(url)s\">%(name)s</a>"
 
-#: src/olympia/addons/templates/addons/impala/details.html:201
-#: src/olympia/addons/templates/addons/impala/details.html:206
-#: src/olympia/amo/helpers.py:398 src/olympia/devhub/forms.py:142
-#: src/olympia/devhub/forms.py:173
-#: src/olympia/versions/templates/versions/version.html:40
-#: src/olympia/versions/templates/versions/version.html:45
+#: src/olympia/addons/templates/addons/impala/details.html:206 src/olympia/addons/templates/addons/impala/details.html:211 src/olympia/amo/helpers.py:398 src/olympia/devhub/forms.py:142
+#: src/olympia/devhub/forms.py:173 src/olympia/versions/templates/versions/version.html:40 src/olympia/versions/templates/versions/version.html:45
 msgid "Custom License"
 msgstr "Licença personalizada"
 
-#: src/olympia/addons/templates/addons/impala/details.html:205
+#: src/olympia/addons/templates/addons/impala/details.html:210
 #, python-format
 msgid "Released under <a href=\"%(url)s\">%(name)s</a>"
 msgstr "Lançado sobre <a href=\"%(url)s\">%(name)s</a>"
 
-#: src/olympia/addons/templates/addons/impala/details.html:217
+#: src/olympia/addons/templates/addons/impala/details.html:222
 msgid "About this Add-on"
 msgstr "Sobre este extra"
 
-#: src/olympia/addons/templates/addons/impala/details.html:233
+#: src/olympia/addons/templates/addons/impala/details.html:238
 msgid "Developer’s Comments"
 msgstr "Comentários do programador"
 
-#: src/olympia/addons/templates/addons/impala/details.html:243
+#: src/olympia/addons/templates/addons/impala/details.html:248
 msgid "Version Information"
 msgstr "Informação da versão"
 
-#: src/olympia/addons/templates/addons/impala/details.html:250
+#: src/olympia/addons/templates/addons/impala/details.html:255
 msgid "See complete version history"
 msgstr "Ver o histórico completo de versões"
 
-#: src/olympia/addons/templates/addons/impala/details.html:262
+#: src/olympia/addons/templates/addons/impala/details.html:267
 msgid ""
-"The Development Channel lets you test an experimental new version of this "
-"add-on before it's released to the general public. Once you install the "
-"development version, you will continue to get updates from this channel. To "
-"stop receiving development updates, reinstall the default version from the "
-"link above."
+"The Development Channel lets you test an experimental new version of this add-on before it's released to the general public. Once you install the development version, you will continue to get "
+"updates from this channel. To stop receiving development updates, reinstall the default version from the link above."
 msgstr ""
-"O canal de desenvolvimento permite que teste uma nova versão experimental "
-"deste extra antes de ser lançado ao público em geral. Assim que instalar a "
-"versão de desenvolvimento, vai continuar a receber as atualizações deste "
-"canal. Para parar de receber atualizações de desenvolvimento, reinstale a "
-"versão normal a partir da ligação em cima."
+"O canal de desenvolvimento permite que teste uma nova versão experimental deste extra antes de ser lançado ao público em geral. Assim que instalar a versão de desenvolvimento, vai continuar a "
+"receber as atualizações deste canal. Para parar de receber atualizações de desenvolvimento, reinstale a versão normal a partir da ligação em cima."
 
-#: src/olympia/addons/templates/addons/impala/details.html:272
-msgid ""
-"<strong>Caution:</strong> Development versions of this add-on have not been "
-"reviewed by Mozilla."
-msgstr ""
-"<strong>Atenção:</strong> As versões de desenvolvimento deste extra não "
-"foram revistas pela Mozilla."
+#: src/olympia/addons/templates/addons/impala/details.html:277
+msgid "<strong>Caution:</strong> Development versions of this add-on have not been reviewed by Mozilla."
+msgstr "<strong>Atenção:</strong> As versões de desenvolvimento deste extra não foram revistas pela Mozilla."
 
-#: src/olympia/addons/templates/addons/impala/details.html:287
+#: src/olympia/addons/templates/addons/impala/details.html:292
 msgid "See complete development channel history"
 msgstr "Ver o histórico completo do canal de desenvolvimento"
 
-#: src/olympia/addons/templates/addons/impala/details.html:306
-#: src/olympia/addons/templates/addons/impala/details.html:315
-#: src/olympia/addons/templates/addons/impala/details.html:327
-#: src/olympia/addons/templates/addons/impala/review_add_box.html:4
-#: src/olympia/stats/templates/stats/popup.html:2
-#: src/olympia/stats/templates/stats/popup.html:8
-#: src/olympia/stats/templates/stats/stats.html:202
-#: src/olympia/users/templates/users/profile.html:119
+#: src/olympia/addons/templates/addons/impala/details.html:311 src/olympia/addons/templates/addons/impala/details.html:320 src/olympia/addons/templates/addons/impala/details.html:332
+#: src/olympia/addons/templates/addons/impala/review_add_box.html:4 src/olympia/stats/templates/stats/popup.html:2 src/olympia/stats/templates/stats/popup.html:8
+#: src/olympia/stats/templates/stats/stats.html:204 src/olympia/users/templates/users/profile.html:119
 msgid "close"
 msgstr "fechar"
 
@@ -1495,19 +1104,15 @@ msgstr "fechar"
 msgid "Thank you for installing {0}"
 msgstr "Obrigado por instalar {0}"
 
-#. {0} is an add-on name.
 # %1 is an add-on name.
+#. {0} is an add-on name.
 #: src/olympia/addons/templates/addons/impala/developers.html:12
 msgid "Meet the {0} Developer"
 msgstr "Conheça o programador de {0}"
 
 #: src/olympia/addons/templates/addons/impala/developers.html:41
-msgid ""
-"Before downloading this add-on, please consider supporting the development "
-"of this add-on by making a small contribution."
-msgstr ""
-"Antes de descarregar este extra, considere ajudar o desenvolvimento deste "
-"extra com uma pequena contribuição."
+msgid "Before downloading this add-on, please consider supporting the development of this add-on by making a small contribution."
+msgstr "Antes de descarregar este extra, considere ajudar o desenvolvimento deste extra com uma pequena contribuição."
 
 # %1 is an add-on name.
 #: src/olympia/addons/templates/addons/impala/developers.html:80
@@ -1525,9 +1130,7 @@ msgid_plural "About the Developers"
 msgstr[0] "Sobre o programador"
 msgstr[1] "Sobre os desenvolvedores"
 
-#: src/olympia/addons/templates/addons/impala/developers.html:96
-#: src/olympia/users/templates/users/edit.html:130
-#: src/olympia/users/templates/users/profile.html:26
+#: src/olympia/addons/templates/addons/impala/developers.html:96 src/olympia/users/templates/users/edit.html:130 src/olympia/users/templates/users/profile.html:26
 msgid "No Photo"
 msgstr "Sem fotografia"
 
@@ -1547,24 +1150,15 @@ msgstr "Este extra foi desativado por um administrador."
 msgid "Source Code License for {addon}"
 msgstr "Licença do código fonte para {addon}"
 
-#: src/olympia/addons/templates/addons/impala/license.html:21
-#: src/olympia/versions/templates/versions/mobile/version.html:18
+#: src/olympia/addons/templates/addons/impala/license.html:21 src/olympia/versions/templates/versions/mobile/version.html:18
 msgid "Source Code License"
 msgstr "Licença do código fonte"
 
-#: src/olympia/addons/templates/addons/impala/persona_grid.html:16
-#: src/olympia/addons/templates/addons/impala/toplist.html:6
-msgid "{0} users"
-msgstr "{0} utilizadores"
-
-#: src/olympia/addons/templates/addons/impala/review_list_box.html:19
-#: src/olympia/reviews/templates/reviews/review.html:40
+#: src/olympia/addons/templates/addons/impala/review_list_box.html:19 src/olympia/reviews/templates/reviews/review.html:40
 msgid "permalink"
 msgstr "ligação permanente"
 
-#: src/olympia/addons/templates/addons/impala/review_list_box.html:23
-#: src/olympia/editors/templates/editors/queue.html:98
-#: src/olympia/reviews/templates/reviews/review.html:44
+#: src/olympia/addons/templates/addons/impala/review_list_box.html:23 src/olympia/editors/templates/editors/queue.html:104 src/olympia/reviews/templates/reviews/review.html:44
 msgid "translate"
 msgstr "traduzir"
 
@@ -1575,8 +1169,7 @@ msgid_plural "See all %(cnt)s user reviews"
 msgstr[0] "Ver todos os comentários do utilizador"
 msgstr[1] "Ver todos os %(cnt)s comentários de utilizadores"
 
-#: src/olympia/addons/templates/addons/impala/review_list_box.html:47
-#: src/olympia/reviews/templates/reviews/review_list.html:84
+#: src/olympia/addons/templates/addons/impala/review_list_box.html:47 src/olympia/reviews/templates/reviews/review_list.html:84
 msgid "This add-on has not yet been reviewed."
 msgstr "Este extra ainda não foi revisto."
 
@@ -1584,24 +1177,23 @@ msgstr "Este extra ainda não foi revisto."
 msgid "Be the first!"
 msgstr "Seja o primeiro!"
 
-#: src/olympia/addons/templates/addons/impala/listing/sorter.html:14
-#: src/olympia/devhub/templates/devhub/addons/listing/item_actions.html:49
+#: src/olympia/addons/templates/addons/impala/toplist.html:6
+msgid "{0} users"
+msgstr "{0} utilizadores"
+
+#: src/olympia/addons/templates/addons/impala/listing/sorter.html:14 src/olympia/devhub/templates/devhub/addons/listing/item_actions.html:49
 msgid "More"
 msgstr "Mais"
 
-#: src/olympia/addons/templates/addons/includes/collection_add_widget.html:7
-#: src/olympia/addons/templates/addons/includes/collection_add_widget.html:10
+#: src/olympia/addons/templates/addons/includes/collection_add_widget.html:7 src/olympia/addons/templates/addons/includes/collection_add_widget.html:10
 msgid "Add to collection"
 msgstr "Adicionar à coleção"
 
-#: src/olympia/addons/templates/addons/includes/dashboard_tabs.html:4
-#: src/olympia/devhub/templates/devhub/index.html:73
-#: src/olympia/devhub/templates/devhub/nav.html:14
+#: src/olympia/addons/templates/addons/includes/dashboard_tabs.html:4 src/olympia/devhub/templates/devhub/index.html:73 src/olympia/devhub/templates/devhub/nav.html:14
 msgid "My Add-ons"
 msgstr "Os meus Extras"
 
-#: src/olympia/addons/templates/addons/includes/dashboard_tabs.html:6
-#: src/olympia/amo/context_processors.py:51
+#: src/olympia/addons/templates/addons/includes/dashboard_tabs.html:6 src/olympia/amo/context_processors.py:50
 msgid "My Themes"
 msgstr "Os meus temas"
 
@@ -1617,8 +1209,7 @@ msgstr "Editar tema"
 msgid "Approve / Reject"
 msgstr "Aprovar / Rejeitar"
 
-#: src/olympia/addons/templates/addons/includes/persona.html:25
-#: src/olympia/editors/templates/editors/themes/single.html:43
+#: src/olympia/addons/templates/addons/includes/persona.html:25 src/olympia/editors/templates/editors/themes/single.html:43
 msgid "Review History"
 msgstr "Histórico de revisões"
 
@@ -1639,9 +1230,7 @@ msgid "Not Yet Rated"
 msgstr "Sem avaliações"
 
 #. {0} is the number of downloads.
-#: src/olympia/addons/templates/addons/listing/items_mobile.html:27
-#: src/olympia/addons/templates/addons/listing/macros.html:24
-#: src/olympia/devhub/templates/devhub/addons/listing/macros.html:15
+#: src/olympia/addons/templates/addons/listing/items_mobile.html:27 src/olympia/addons/templates/addons/listing/macros.html:24 src/olympia/devhub/templates/devhub/addons/listing/macros.html:15
 msgid "<strong>{0}</strong> weekly download"
 msgid_plural "<strong>{0}</strong> weekly downloads"
 msgstr[0] "<strong>{0}</strong> descarga semanal"
@@ -1655,15 +1244,11 @@ msgstr "Ler mais"
 msgid "Users"
 msgstr "Utilizadores"
 
-#: src/olympia/addons/templates/addons/mobile/details.html:92
-#: src/olympia/browse/views.py:59 src/olympia/browse/views.py:70
-#: src/olympia/search/forms.py:90
+#: src/olympia/addons/templates/addons/mobile/details.html:92 src/olympia/browse/views.py:59 src/olympia/browse/views.py:70 src/olympia/search/forms.py:90
 msgid "Weekly Downloads"
 msgstr "Descargas semanais"
 
-#: src/olympia/addons/templates/addons/mobile/details.html:99
-#: src/olympia/compat/templates/compat/reporter_detail.html:46
-#: src/olympia/devhub/forms.py:787
+#: src/olympia/addons/templates/addons/mobile/details.html:99 src/olympia/compat/templates/compat/reporter_detail.html:46 src/olympia/devhub/forms.py:788
 #: src/olympia/devhub/templates/devhub/versions/list.html:163
 msgid "Version"
 msgstr "Versão"
@@ -1699,50 +1284,30 @@ msgstr "Acordo de licenciamento"
 
 #: src/olympia/addons/templates/addons/mobile/eula.html:5
 #, python-format
-msgid ""
-"%(name)s requires that you accept the following End-User License Agreement "
-"before installation can proceed:"
-msgstr ""
-"%(name)s necessita que aceite o seguinte Acordo de Licenciamento de "
-"Utilizador Final antes da instalação poder continuar:"
+msgid "%(name)s requires that you accept the following End-User License Agreement before installation can proceed:"
+msgstr "%(name)s necessita que aceite o seguinte Acordo de Licenciamento de Utilizador Final antes da instalação poder continuar:"
 
 #: src/olympia/addons/templates/addons/mobile/eula.html:15
 msgid "Accept"
 msgstr "Aceitar"
 
-#: src/olympia/addons/templates/addons/mobile/home.html:10
-#: src/olympia/templates/mobile/base_addons.html:53
+#: src/olympia/addons/templates/addons/mobile/home.html:10 src/olympia/templates/mobile/base_addons.html:53
 msgid "Add-ons are not currently available on Firefox for iOS."
 msgstr "Os extras não estão atualmente disponíveis no Firefox para iOS."
 
-#: src/olympia/addons/templates/addons/mobile/home.html:12
-#: src/olympia/templates/mobile/base_addons.html:55
-msgid ""
-"You need Firefox to install add-ons. <a "
-"href=\"http://mozilla.com/mobile\">Learn More&nbsp;&raquo;</a>"
-msgstr ""
-"Precisa do Firefox para instalar extras, <a "
-"href=\"http://mozilla.com/mobile\">Saber mais&nbsp;&raquo;</a>"
+#: src/olympia/addons/templates/addons/mobile/home.html:12 src/olympia/templates/mobile/base_addons.html:55
+msgid "You need Firefox to install add-ons. <a href=\"http://mozilla.com/mobile\">Learn More&nbsp;&raquo;</a>"
+msgstr "Precisa do Firefox para instalar extras, <a href=\"http://mozilla.com/mobile\">Saber mais&nbsp;&raquo;</a>"
 
 # {0} is the application name.  Example:  Firefox
-#: src/olympia/addons/templates/addons/mobile/home.html:19
-#: src/olympia/templates/header_title.html:4
-#: src/olympia/templates/impala/header_title.html:3
+#: src/olympia/addons/templates/addons/mobile/home.html:19 src/olympia/templates/header_title.html:4 src/olympia/templates/impala/header_title.html:3
 msgid "Return to the {0} Add-ons homepage"
 msgstr "Voltar à página inicial dos extras do {0}"
 
-#: src/olympia/addons/templates/addons/mobile/home.html:21
-#: src/olympia/amo/helpers.py:237
-#: src/olympia/bandwagon/templates/bandwagon/edit.html:34
-#: src/olympia/discovery/templates/discovery/pane.html:92
-#: src/olympia/editors/templates/editors/base.html:21
-#: src/olympia/editors/templates/editors/performance.html:72
-#: src/olympia/templates/menu_links.html:4
-#: src/olympia/templates/impala/header_title.html:13
-#: src/olympia/templates/impala/header_title.html:15
-#: src/olympia/templates/impala/header_title.html:19
-#: src/olympia/templates/impala/header_title.html:23
-#: src/olympia/templates/mobile/base_addons.html:47
+#: src/olympia/addons/templates/addons/mobile/home.html:21 src/olympia/amo/helpers.py:237 src/olympia/bandwagon/templates/bandwagon/edit.html:34 src/olympia/discovery/templates/discovery/pane.html:92
+#: src/olympia/editors/templates/editors/base.html:21 src/olympia/editors/templates/editors/performance.html:72 src/olympia/templates/menu_links.html:4
+#: src/olympia/templates/impala/header_title.html:13 src/olympia/templates/impala/header_title.html:15 src/olympia/templates/impala/header_title.html:19
+#: src/olympia/templates/impala/header_title.html:23 src/olympia/templates/mobile/base_addons.html:47
 msgid "Add-ons"
 msgstr "Extras"
 
@@ -1750,48 +1315,28 @@ msgstr "Extras"
 msgid "Easy ways to personalize."
 msgstr "Maneiras simples de personalizar."
 
-#: src/olympia/addons/templates/addons/mobile/home.html:24
-#: src/olympia/devhub/templates/devhub/addons/submit/done.html:47
-#: src/olympia/discovery/templates/discovery/pane.html:34
-#: src/olympia/discovery/templates/discovery/addons/detail.html:16
-#: src/olympia/discovery/templates/discovery/modules/featured.html:21
-#: src/olympia/discovery/templates/discovery/modules/monthly.html:22
+#: src/olympia/addons/templates/addons/mobile/home.html:24 src/olympia/devhub/templates/devhub/addons/submit/done.html:47 src/olympia/discovery/templates/discovery/pane.html:34
+#: src/olympia/discovery/templates/discovery/addons/detail.html:16 src/olympia/discovery/templates/discovery/modules/featured.html:21 src/olympia/discovery/templates/discovery/modules/monthly.html:22
 msgid "Learn More"
 msgstr "Saber mais"
 
 #: src/olympia/addons/templates/addons/mobile/home.html:26
 msgid ""
-"Add-ons are applications that let you personalize Firefox with extra "
-"functionality and style. Whether you mistype the name of a website or can't "
-"read a busy page, there's an add-on to improve your on-the-go browsing."
+"Add-ons are applications that let you personalize Firefox with extra functionality and style. Whether you mistype the name of a website or can't read a busy page, there's an add-on to improve your "
+"on-the-go browsing."
 msgstr ""
-"Os extras são aplicações que permitem personalizar o Firefox com "
-"funcionalidade e estilo extra. Se escrever mal o nome de um site ou não "
-"consegue ler uma página ocupada, existe um extra para melhorar a sua "
-"experiência de navegação."
+"Os extras são aplicações que permitem personalizar o Firefox com funcionalidade e estilo extra. Se escrever mal o nome de um site ou não consegue ler uma página ocupada, existe um extra para "
+"melhorar a sua experiência de navegação."
 
 #. {0} is a category name. Ex: "Sports"
 #. {0} is a category name, such as Nature.
-#: src/olympia/addons/templates/addons/mobile/home.html:43
-#: src/olympia/amo/templates/amo/site_nav.html:32
-#: src/olympia/browse/feeds.py:107
-#: src/olympia/browse/templates/browse/impala/base_listing.html:38
-#: src/olympia/browse/templates/browse/personas/base.html:6
-#: src/olympia/browse/templates/browse/personas/base.html:42
-#: src/olympia/browse/templates/browse/personas/category_landing.html:21
-#: src/olympia/browse/templates/browse/personas/category_landing.html:23
-#: src/olympia/browse/templates/browse/personas/category_landing.html:38
-#: src/olympia/browse/templates/browse/personas/grid.html:7
-#: src/olympia/browse/templates/browse/personas/grid.html:11
-#: src/olympia/browse/templates/browse/personas/mobile/base.html:7
-#: src/olympia/browse/templates/browse/personas/mobile/category_landing.html:19
-#: src/olympia/constants/base.py:180
-#: src/olympia/devhub/templates/devhub/personas/submit.html:13
-#: src/olympia/editors/helpers.py:105
-#: src/olympia/editors/templates/editors/base.html:26
-#: src/olympia/editors/templates/editors/performance.html:73
-#: src/olympia/search/templates/search/personas.html:39
-#: src/olympia/templates/menu_links.html:9
+#: src/olympia/addons/templates/addons/mobile/home.html:43 src/olympia/amo/templates/amo/site_nav.html:32 src/olympia/browse/feeds.py:107
+#: src/olympia/browse/templates/browse/impala/base_listing.html:38 src/olympia/browse/templates/browse/personas/base.html:6 src/olympia/browse/templates/browse/personas/base.html:42
+#: src/olympia/browse/templates/browse/personas/category_landing.html:21 src/olympia/browse/templates/browse/personas/category_landing.html:23
+#: src/olympia/browse/templates/browse/personas/category_landing.html:38 src/olympia/browse/templates/browse/personas/grid.html:7 src/olympia/browse/templates/browse/personas/grid.html:11
+#: src/olympia/browse/templates/browse/personas/mobile/base.html:7 src/olympia/browse/templates/browse/personas/mobile/category_landing.html:19 src/olympia/constants/base.py:180
+#: src/olympia/devhub/templates/devhub/personas/submit.html:13 src/olympia/editors/helpers.py:107 src/olympia/editors/templates/editors/base.html:26
+#: src/olympia/editors/templates/editors/performance.html:73 src/olympia/search/templates/search/personas.html:39 src/olympia/templates/menu_links.html:9
 msgid "Themes"
 msgstr "Temas"
 
@@ -1807,19 +1352,12 @@ msgstr "Ver todos os extras populares"
 msgid "More Add-ons"
 msgstr "Mais extras"
 
-#: src/olympia/addons/templates/addons/mobile/home.html:72
-#: src/olympia/browse/templates/browse/personas/mobile/category_landing.html:64
-#: src/olympia/search/forms.py:14
+#: src/olympia/addons/templates/addons/mobile/home.html:72 src/olympia/browse/templates/browse/personas/mobile/category_landing.html:64 src/olympia/search/forms.py:14
 msgid "Highest Rated"
 msgstr "Avaliação mais alta"
 
-#: src/olympia/addons/templates/addons/mobile/home.html:74
-#: src/olympia/amo/templates/amo/side_nav.html:5
-#: src/olympia/amo/templates/amo/site_nav.html:27
-#: src/olympia/amo/templates/amo/site_nav.html:57
-#: src/olympia/bandwagon/views.py:97 src/olympia/browse/views.py:57
-#: src/olympia/browse/views.py:67
-#: src/olympia/browse/templates/browse/personas/mobile/category_landing.html:65
+#: src/olympia/addons/templates/addons/mobile/home.html:74 src/olympia/amo/templates/amo/side_nav.html:5 src/olympia/amo/templates/amo/site_nav.html:27 src/olympia/amo/templates/amo/site_nav.html:55
+#: src/olympia/bandwagon/views.py:97 src/olympia/browse/views.py:57 src/olympia/browse/views.py:67 src/olympia/browse/templates/browse/personas/mobile/category_landing.html:65
 #: src/olympia/search/forms.py:15 src/olympia/search/forms.py:87
 msgid "Newest"
 msgstr "Mais recente"
@@ -1832,122 +1370,90 @@ msgstr "Experimentar!"
 msgid "Theme Info &raquo;"
 msgstr "Informações do tema &raquo;"
 
-#: src/olympia/amo/context_processors.py:39
-#: src/olympia/devhub/templates/devhub/nav.html:43
+#: src/olympia/amo/context_processors.py:37 src/olympia/devhub/templates/devhub/nav.html:43
 msgid "Tools"
 msgstr "Ferramentas"
 
-#: src/olympia/amo/context_processors.py:48
-#: src/olympia/discovery/templates/discovery/pane_account.html:8
-#: src/olympia/users/templates/users/includes/navigation.html:2
+#: src/olympia/amo/context_processors.py:47 src/olympia/discovery/templates/discovery/pane_account.html:8 src/olympia/users/templates/users/includes/navigation.html:2
 msgid "My Profile"
 msgstr "O meu perfil"
 
-#: src/olympia/amo/context_processors.py:54
-#: src/olympia/users/templates/users/edit.html:5
-#: src/olympia/users/templates/users/includes/navigation.html:3
+#: src/olympia/amo/context_processors.py:53 src/olympia/users/templates/users/edit.html:5 src/olympia/users/templates/users/includes/navigation.html:3
 msgid "Account Settings"
 msgstr "Definições da conta"
 
-#: src/olympia/amo/context_processors.py:57
-#: src/olympia/discovery/templates/discovery/pane_account.html:11
-#: src/olympia/users/templates/users/profile.html:83
+#: src/olympia/amo/context_processors.py:56 src/olympia/discovery/templates/discovery/pane_account.html:11 src/olympia/users/templates/users/profile.html:83
 #: src/olympia/users/templates/users/includes/navigation.html:4
 msgid "My Collections"
 msgstr "As minhas coleções"
 
-#: src/olympia/amo/context_processors.py:62
-#: src/olympia/discovery/templates/discovery/pane_account.html:10
-#: src/olympia/users/templates/users/includes/navigation.html:7
+#: src/olympia/amo/context_processors.py:61 src/olympia/discovery/templates/discovery/pane_account.html:10 src/olympia/users/templates/users/includes/navigation.html:7
 msgid "My Favorites"
 msgstr "Os meus favoritos"
 
-#: src/olympia/amo/context_processors.py:67
-#: src/olympia/discovery/templates/discovery/pane_account.html:13
-#: src/olympia/templates/impala/user_login.html:14
+#: src/olympia/amo/context_processors.py:66 src/olympia/discovery/templates/discovery/pane_account.html:13 src/olympia/templates/impala/user_login.html:14
 #: src/olympia/templates/mobile/header_auth.html:5
 msgid "Log out"
 msgstr "Sair"
 
-#: src/olympia/amo/context_processors.py:72
-#: src/olympia/devhub/templates/devhub/addons/dashboard.html:4
+#: src/olympia/amo/context_processors.py:71 src/olympia/devhub/templates/devhub/addons/dashboard.html:4
 msgid "Manage My Submissions"
 msgstr "Gerir as minhas submissões"
 
-#: src/olympia/amo/context_processors.py:75
-#: src/olympia/devhub/templates/devhub/nav.html:27
-#: src/olympia/devhub/templates/devhub/addons/dashboard.html:25
+#: src/olympia/amo/context_processors.py:74 src/olympia/devhub/templates/devhub/nav.html:27 src/olympia/devhub/templates/devhub/addons/dashboard.html:25
 #: src/olympia/devhub/templates/devhub/addons/submit/base.html:4
 msgid "Submit a New Add-on"
 msgstr "Submeter um novo extra"
 
-#: src/olympia/amo/context_processors.py:77
-#: src/olympia/browse/templates/browse/personas/base.html:50
-#: src/olympia/devhub/templates/devhub/index.html:24
+#: src/olympia/amo/context_processors.py:76 src/olympia/browse/templates/browse/personas/base.html:50 src/olympia/devhub/templates/devhub/index.html:24
 #: src/olympia/devhub/templates/devhub/addons/dashboard.html:29
 msgid "Submit a New Theme"
 msgstr "Submeter um novo tema"
 
-#: src/olympia/amo/context_processors.py:79
-#: src/olympia/amo/templates/amo/site_nav.html:87
-#: src/olympia/devhub/helpers.py:36 src/olympia/devhub/helpers.py:68
-#: src/olympia/devhub/helpers.py:102 src/olympia/templates/footer.html:6
-#: src/olympia/templates/menu_links.html:14
+#: src/olympia/amo/context_processors.py:78 src/olympia/amo/templates/amo/site_nav.html:85 src/olympia/devhub/helpers.py:36 src/olympia/devhub/helpers.py:68 src/olympia/devhub/helpers.py:102
+#: src/olympia/templates/footer.html:6 src/olympia/templates/menu_links.html:14
 msgid "Developer Hub"
 msgstr "Central do programador"
 
-#: src/olympia/amo/context_processors.py:83 src/olympia/devhub/views.py:1792
+#: src/olympia/amo/context_processors.py:81 src/olympia/devhub/views.py:1796
 msgid "Manage API Keys"
 msgstr "Gerir chaves da API"
 
-#: src/olympia/amo/context_processors.py:88 src/olympia/editors/helpers.py:82
-#: src/olympia/editors/helpers.py:102
-#: src/olympia/editors/templates/editors/base.html:10
+#: src/olympia/amo/context_processors.py:86 src/olympia/editors/helpers.py:84 src/olympia/editors/helpers.py:104 src/olympia/editors/templates/editors/base.html:10
 msgid "Editor Tools"
 msgstr "Ferramentas do editor"
 
-#: src/olympia/amo/context_processors.py:92
+#: src/olympia/amo/context_processors.py:90
 msgid "Admin Tools"
 msgstr "Ferramentas do admin"
 
-#: src/olympia/amo/fields.py:15
+#: src/olympia/amo/fields.py:20
 msgid "Incorrect, please try again."
 msgstr "Incorreto, por favor, tente novamente."
 
-#: src/olympia/amo/fields.py:16
+#: src/olympia/amo/fields.py:21
 msgid "Error verifying input, please try again."
 msgstr "Erro ao verificar a entrada, por favor, tente novamente."
 
-#: src/olympia/amo/fields.py:32
+#: src/olympia/amo/fields.py:37
 msgid "This must be a valid hex color code, such as #000000."
 msgstr "É necessário um código hexadecimal de cor válido, tal como #000000."
 
-#: src/olympia/amo/fields.py:58
+#: src/olympia/amo/fields.py:63
 msgid "Enter at least one value."
 msgstr "Insira pelo menos um valor."
 
-#: src/olympia/amo/helpers.py:162
-#: src/olympia/amo/templates/amo/site_nav.html:61
-#: src/olympia/bandwagon/templates/bandwagon/add.html:9
-#: src/olympia/bandwagon/templates/bandwagon/collection_detail.html:15
-#: src/olympia/bandwagon/templates/bandwagon/delete.html:9
-#: src/olympia/bandwagon/templates/bandwagon/edit.html:15
-#: src/olympia/bandwagon/templates/bandwagon/user_listing.html:18
-#: src/olympia/bandwagon/templates/bandwagon/user_listing.html:21
-#: src/olympia/bandwagon/templates/bandwagon/impala/collection_listing.html:12
-#: src/olympia/bandwagon/templates/bandwagon/impala/collection_listing.html:20
-#: src/olympia/bandwagon/templates/bandwagon/impala/collection_listing.html:24
-#: src/olympia/bandwagon/templates/bandwagon/impala/collection_sidebar.html:3
-#: src/olympia/bandwagon/templates/bandwagon/includes/collection_sidebar.html:2
-#: src/olympia/bandwagon/templates/bandwagon/mobile/collection_listing.html:3
-#: src/olympia/stats/templates/stats/stats.html:77
-#: src/olympia/templates/menu_links.html:12
+#: src/olympia/amo/helpers.py:162 src/olympia/amo/templates/amo/site_nav.html:59 src/olympia/bandwagon/templates/bandwagon/add.html:9
+#: src/olympia/bandwagon/templates/bandwagon/collection_detail.html:15 src/olympia/bandwagon/templates/bandwagon/delete.html:9 src/olympia/bandwagon/templates/bandwagon/edit.html:15
+#: src/olympia/bandwagon/templates/bandwagon/user_listing.html:18 src/olympia/bandwagon/templates/bandwagon/user_listing.html:21
+#: src/olympia/bandwagon/templates/bandwagon/impala/collection_listing.html:12 src/olympia/bandwagon/templates/bandwagon/impala/collection_listing.html:20
+#: src/olympia/bandwagon/templates/bandwagon/impala/collection_listing.html:24 src/olympia/bandwagon/templates/bandwagon/impala/collection_sidebar.html:3
+#: src/olympia/bandwagon/templates/bandwagon/includes/collection_sidebar.html:2 src/olympia/bandwagon/templates/bandwagon/mobile/collection_listing.html:3
+#: src/olympia/stats/templates/stats/stats.html:33 src/olympia/templates/menu_links.html:12
 msgid "Collections"
 msgstr "Coleções"
 
-#: src/olympia/amo/helpers.py:171
-#: src/olympia/amo/templates/amo/site_nav.html:85
-#: src/olympia/browse/templates/browse/language_tools.html:3
+#: src/olympia/amo/helpers.py:171 src/olympia/amo/templates/amo/site_nav.html:83 src/olympia/browse/templates/browse/language_tools.html:3
 msgid "Dictionaries & Language Packs"
 msgstr "Dicionários e pacotes de idiomas"
 
@@ -2099,11 +1605,8 @@ msgstr "Solicitada super revisão"
 msgid "Comment on {addon} {version}."
 msgstr "Comentário sobre {addon} {version}."
 
-#: src/olympia/amo/log.py:236
-#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:19
-#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:47
-#: src/olympia/editors/helpers.py:511
-#: src/olympia/editors/templates/editors/themes/history_table.html:11
+#: src/olympia/amo/log.py:236 src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:17 src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:45
+#: src/olympia/editors/helpers.py:584 src/olympia/editors/templates/editors/themes/history_table.html:11
 msgid "Comment"
 msgstr "Comentário"
 
@@ -2258,7 +1761,7 @@ msgstr "Escalação do revisor"
 
 #: src/olympia/amo/log.py:442
 msgid "Video removed from {addon} because of a problem with the video. "
-msgstr "Vídeo removido de {addon} devido a um problema com o vídeo. "
+msgstr ""
 
 #: src/olympia/amo/log.py:444
 msgid "Video removed"
@@ -2266,8 +1769,7 @@ msgstr "Vídeo removido"
 
 #: src/olympia/amo/log.py:449
 msgid "{addon} re-review because of new device(s) added."
-msgstr ""
-"{addon} revisto novamente devido à incorporação de novo(s) dispositivo(s)."
+msgstr "{addon} revisto novamente devido à incorporação de novo(s) dispositivo(s)."
 
 #: src/olympia/amo/log.py:450
 msgid "Device(s) Added"
@@ -2275,8 +1777,7 @@ msgstr "Dispositivo(s) adicionado(s)"
 
 #: src/olympia/amo/log.py:457
 msgid "{addon} device support manually changed by reviewer."
-msgstr ""
-"Suporte de {addon} ao dispositivo foi modificado manualmente pelo revisor."
+msgstr "Suporte de {addon} ao dispositivo foi modificado manualmente pelo revisor."
 
 #: src/olympia/amo/log.py:458
 msgid "Device(s) Changed by Reviewer"
@@ -2351,8 +1852,7 @@ msgstr "Estado de {version} alterado para {0}."
 #. L10n: {0} is the status
 #: src/olympia/amo/log.py:569
 msgid "User {0.name} {0.id} deleted via lookup tool."
-msgstr ""
-"Utilizador {0.name} {0.id} eliminado através de ferramenta de pesquisa."
+msgstr "Utilizador {0.name} {0.id} eliminado através de ferramenta de pesquisa."
 
 #: src/olympia/amo/log.py:575
 msgid "{addon} content rating changed to Adult."
@@ -2366,10 +1866,7 @@ msgstr "Classificação de conteúdo de {addon} alterada."
 msgid "{addon} unlisted."
 msgstr "{addon} não listado."
 
-#: src/olympia/amo/log.py:592 src/olympia/amo/log.py:598
-#: src/olympia/amo/log.py:612 src/olympia/amo/log.py:618
-#: src/olympia/amo/log.py:624 src/olympia/amo/log.py:630
-#: src/olympia/amo/log.py:636
+#: src/olympia/amo/log.py:592 src/olympia/amo/log.py:598 src/olympia/amo/log.py:612 src/olympia/amo/log.py:618 src/olympia/amo/log.py:624 src/olympia/amo/log.py:630 src/olympia/amo/log.py:636
 msgid "{file} was signed."
 msgstr "{file} assinado."
 
@@ -2383,20 +1880,12 @@ msgid "Not allowed"
 msgstr "Não permitido"
 
 #: src/olympia/amo/templates/amo/403.html:7
-msgid ""
-"<h1>Oops! Not allowed.</h1> <p>You tried to do something that you weren't "
-"allowed to.</p>"
-msgstr ""
-"<h1>Oops! Não permitido.</h1> <p>Tentou fazer algo que não está autorizado a"
-" fazer.</p>"
+msgid "<h1>Oops! Not allowed.</h1> <p>You tried to do something that you weren't allowed to.</p>"
+msgstr "<h1>Oops! Não permitido.</h1> <p>Tentou fazer algo que não está autorizado a fazer.</p>"
 
 #: src/olympia/amo/templates/amo/403.html:12
-msgid ""
-"<p>Try going back to the previous page, refreshing and then trying "
-"again.</p>"
-msgstr ""
-"<p>Tente voltar para a página anterior, atualize e depois tente "
-"novamente.</p>"
+msgid "<p>Try going back to the previous page, refreshing and then trying again.</p>"
+msgstr "<p>Tente voltar para a página anterior, atualize e depois tente novamente.</p>"
 
 #: src/olympia/amo/templates/amo/404.html:3
 msgid "Not Found"
@@ -2405,35 +1894,18 @@ msgstr "Não encontrado"
 #: src/olympia/amo/templates/amo/404.html:6
 #, python-format
 msgid ""
-"<h1>We're sorry, but we can't find what you're looking for.</h1> <p> The "
-"page or file you requested wasn't found on our site. It's possible that you "
-"clicked a link that's out of date, or typed in the address incorrectly. </p>"
-" <ul> <li>If you typed in the address, please double check the "
-"spelling.</li> <li> If you followed a link from somewhere, please let us "
-"know at <a href=\"mailto:webmaster@mozilla.com\">webmaster@mozilla.com</a>. "
-"Tell us where you came from and what you were looking for, and we'll do our "
-"best to fix it. </li> </ul> <p>Or you can just jump over to some of the "
-"popular pages on our website.</p> <ul> <li>Are you interested in a <a "
-"href=\"%(rec)s\">list of featured add-ons</a>?</li> <li> Do you want to <a "
-"href=\"%(search)s\">search for add-ons</a>? You may go to the <a "
-"href=\"%(search)s\">search page</a> or just use the search field above. "
-"</li> <li> If you prefer to start over, just go to the <a href=\"%(home)s"
-"\">add-ons front page</a>. </li> </ul>"
+"<h1>We're sorry, but we can't find what you're looking for.</h1> <p> The page or file you requested wasn't found on our site. It's possible that you clicked a link that's out of date, or typed in "
+"the address incorrectly. </p> <ul> <li>If you typed in the address, please double check the spelling.</li> <li> If you followed a link from somewhere, please let us know at <a href=\"mailto:"
+"webmaster@mozilla.com\">webmaster@mozilla.com</a>. Tell us where you came from and what you were looking for, and we'll do our best to fix it. </li> </ul> <p>Or you can just jump over to some of "
+"the popular pages on our website.</p> <ul> <li>Are you interested in a <a href=\"%(rec)s\">list of featured add-ons</a>?</li> <li> Do you want to <a href=\"%(search)s\">search for add-ons</a>? You "
+"may go to the <a href=\"%(search)s\">search page</a> or just use the search field above. </li> <li> If you prefer to start over, just go to the <a href=\"%(home)s\">add-ons front page</a>. </li> </"
+"ul>"
 msgstr ""
-"<h1>Pedimos desculpa, mas não encontrámos o que procura.</h1> <p> A página "
-"ou ficheiro que pediu não foi encontrado no nosso site. É possível que tenha"
-" clicado numa ligação desatualizada, ou tenha digitado o endereço "
-"incorretamente. </p> <ul> <li> Se digitou o endereço, verifique a "
-"ortografia.</li> <li> Se seguiu uma ligação de um outro local, por favor "
-"informe-nos em <a "
-"href=\"mailto:webmaster@mozilla.com\">webmaster@mozilla.com</a>. Diga-nos de"
-" onde veio e o que procura e nós faremos os possíveis para o corrigir.</li> "
-"</ul> <p>Ou pode ir a algumas das páginas populares do nosso website. </p> "
-"<ul> <li>Está interessado numa <a href=\"%(rec)s\">lista de extras em "
-"destaque</a>?</li> <li>Deseja <a href=\"%(search)s\">procurar extras</a>? "
-"Pode ir para a <a href=\"%(search)s\">página de pesquisa</a> ou para o campo"
-" de pesquisa em cima.</li> <li> Se preferir recomeçar, vá para a <a "
-"href=\"%(home)s\">página inicial dos extras</a>.</li> </ul>"
+"<h1>Pedimos desculpa, mas não encontrámos o que procura.</h1> <p> A página ou ficheiro que pediu não foi encontrado no nosso site. É possível que tenha clicado numa ligação desatualizada, ou tenha "
+"digitado o endereço incorretamente. </p> <ul> <li> Se digitou o endereço, verifique a ortografia.</li> <li> Se seguiu uma ligação de um outro local, por favor informe-nos em <a href=\"mailto:"
+"webmaster@mozilla.com\">webmaster@mozilla.com</a>. Diga-nos de onde veio e o que procura e nós faremos os possíveis para o corrigir.</li> </ul> <p>Ou pode ir a algumas das páginas populares do "
+"nosso website. </p> <ul> <li>Está interessado numa <a href=\"%(rec)s\">lista de extras em destaque</a>?</li> <li>Deseja <a href=\"%(search)s\">procurar extras</a>? Pode ir para a <a href="
+"\"%(search)s\">página de pesquisa</a> ou para o campo de pesquisa em cima.</li> <li> Se preferir recomeçar, vá para a <a href=\"%(home)s\">página inicial dos extras</a>.</li> </ul>"
 
 #: src/olympia/amo/templates/amo/500.html:3
 msgid "Oops"
@@ -2441,83 +1913,49 @@ msgstr "Oops"
 
 #: src/olympia/amo/templates/amo/500.html:6
 #, python-format
-msgid ""
-"<h1>Oops!  We had an error.</h1> <p>We'll get to fixing that soon.</p> <p> "
-"You can try refreshing the page, or head back to the <a href=\"%(home)s"
-"\">Add-ons homepage</a>. </p>"
+msgid "<h1>Oops!  We had an error.</h1> <p>We'll get to fixing that soon.</p> <p> You can try refreshing the page, or head back to the <a href=\"%(home)s\">Add-ons homepage</a>. </p>"
 msgstr ""
-"<h1>Ups!  Tivemos um erro.</h1> <p>Iremos começar a resolver isto "
-"brevemente.</p> <p> Pode tentar atualizar a página ou voltar para a <a "
-"href=\"%(home)s\">página inicial dos Extras</a>. </p>"
 
 #: src/olympia/amo/templates/amo/license_link.html:10
 msgid "Some rights reserved"
 msgstr "Alguns direitos reservados"
 
-#: src/olympia/amo/templates/amo/no_results.html:1
-#: src/olympia/editors/templates/editors/includes/search_results_themes.html:26
+#: src/olympia/amo/templates/amo/no_results.html:1 src/olympia/editors/templates/editors/includes/search_results_themes.html:26
 msgid "No results found"
 msgstr "Não foram encontrados resultados"
 
 #. abbreviation of 'previous'
-#: src/olympia/amo/templates/amo/paginator.html:6
-#: src/olympia/amo/templates/amo/mobile/paginator.html:4
-#: src/olympia/amo/templates/amo/mobile/paginator.html:6
-#: src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:49
-#: src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:63
-#: src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:76
-#: src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:89
+#: src/olympia/amo/templates/amo/paginator.html:6 src/olympia/amo/templates/amo/mobile/paginator.html:4 src/olympia/amo/templates/amo/mobile/paginator.html:6
+#: src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:49 src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:63
+#: src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:76 src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:89
 #: src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:102
 msgid "Prev"
 msgstr "Anterior"
 
-#: src/olympia/amo/templates/amo/paginator.html:26
-#: src/olympia/amo/templates/amo/impala/paginator.html:26
-#: src/olympia/amo/templates/amo/mobile/impala_paginator.html:16
-#: src/olympia/amo/templates/amo/mobile/paginator.html:14
-#: src/olympia/amo/templates/amo/mobile/paginator.html:16
-#: src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:51
-#: src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:65
-#: src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:78
-#: src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:91
-#: src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:104
-#: src/olympia/discovery/templates/discovery/pane.html:45
-#: src/olympia/discovery/templates/discovery/addons/detail.html:39
-#: src/olympia/stats/templates/stats/stats.html:167
+#: src/olympia/amo/templates/amo/paginator.html:26 src/olympia/amo/templates/amo/impala/paginator.html:26 src/olympia/amo/templates/amo/mobile/impala_paginator.html:16
+#: src/olympia/amo/templates/amo/mobile/paginator.html:14 src/olympia/amo/templates/amo/mobile/paginator.html:16 src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:51
+#: src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:65 src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:78
+#: src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:91 src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:104
+#: src/olympia/discovery/templates/discovery/pane.html:45 src/olympia/discovery/templates/discovery/addons/detail.html:39 src/olympia/stats/templates/stats/stats.html:169
 msgid "Next"
 msgstr "Seguinte"
 
-#: src/olympia/amo/templates/amo/paginator.html:32
-#: src/olympia/editors/templates/editors/includes/paginator_history.html:11
+#: src/olympia/amo/templates/amo/paginator.html:32 src/olympia/editors/templates/editors/includes/paginator_history.html:11
 #, python-format
-msgid ""
-"Results <strong>%(begin)s</strong>&ndash;<strong>%(end)s</strong> of "
-"<strong>%(count)s</strong>"
-msgstr ""
-"Resultados <strong>%(begin)s</strong>&ndash;<strong>%(end)s</strong> de "
-"<strong>%(count)s</strong>"
+msgid "Results <strong>%(begin)s</strong>&ndash;<strong>%(end)s</strong> of <strong>%(count)s</strong>"
+msgstr "Resultados <strong>%(begin)s</strong>&ndash;<strong>%(end)s</strong> de <strong>%(count)s</strong>"
 
-#: src/olympia/amo/templates/amo/read-only.html:3
-#: src/olympia/amo/templates/amo/read-only.html:7
+#: src/olympia/amo/templates/amo/read-only.html:3 src/olympia/amo/templates/amo/read-only.html:7
 msgid "Maintenance in progress"
 msgstr "Manutenção em curso"
 
 #: src/olympia/amo/templates/amo/read-only.html:9
-msgid ""
-"This feature is temporarily disabled while we perform website maintenance. "
-"Please use your browser's Back button and try again a little later."
-msgstr ""
-"Esta funcionalidade está temporariamente desativada enquanto efetuamos uma "
-"manutenção ao website. Use o botão retroceder do seu navegador e tente de "
-"novo mais tarde."
+msgid "This feature is temporarily disabled while we perform website maintenance. Please use your browser's Back button and try again a little later."
+msgstr "Esta funcionalidade está temporariamente desativada enquanto efetuamos uma manutenção ao website. Use o botão retroceder do seu navegador e tente de novo mais tarde."
 
 #: src/olympia/amo/templates/amo/read-only.html:14
-msgid ""
-"Some features on this page are temporarily disabled while we perform website"
-" maintenance. Please try again a little later."
-msgstr ""
-"Algumas funcionalidades estão temporariamente desativadas enquanto efetuamos"
-" uma manutenção ao website. Volte a tentar dentro de alguns minutos."
+msgid "Some features on this page are temporarily disabled while we perform website maintenance. Please try again a little later."
+msgstr "Algumas funcionalidades estão temporariamente desativadas enquanto efetuamos uma manutenção ao website. Volte a tentar dentro de alguns minutos."
 
 #: src/olympia/amo/templates/amo/recaptcha.html:4
 msgid "Are you human?"
@@ -2525,25 +1963,14 @@ msgstr "Você é humano?"
 
 #: src/olympia/amo/templates/amo/recaptcha.html:8
 msgid ""
-"<p> Please enter <strong>all the words</strong> below, <strong>separated by "
-"a space if necessary</strong>. </p> <p> If this is hard to read, you can <a "
-"href=\"#\" id=\"recaptcha_different\">try different words</a> or <a "
-"href=\"#\" id=\"recaptcha_audio\">try a different type of challenge</a> "
-"instead. </p>"
+"<p> Please enter <strong>all the words</strong> below, <strong>separated by a space if necessary</strong>. </p> <p> If this is hard to read, you can <a href=\"#\" id=\"recaptcha_different\">try "
+"different words</a> or <a href=\"#\" id=\"recaptcha_audio\">try a different type of challenge</a> instead. </p>"
 msgstr ""
-"<p> Por favor introduza <strong>todas as palavras</strong> abaixo, "
-"<strong>separadas por um espaço se necessário</strong>. </p> <p> Se isto for"
-" difícil de ler, pode <a href=\"#\" id=\"recaptcha_different\">tentar com "
-"palavras diferentes</a> ou <a href=\"#\" id=\"recaptcha_audio\">experimentar"
-" um tipo de desafio diferente</a>. </p>"
+"<p> Por favor introduza <strong>todas as palavras</strong> abaixo, <strong>separadas por um espaço se necessário</strong>. </p> <p> Se isto for difícil de ler, pode <a href=\"#\" id="
+"\"recaptcha_different\">tentar com palavras diferentes</a> ou <a href=\"#\" id=\"recaptcha_audio\">experimentar um tipo de desafio diferente</a>. </p>"
 
-#: src/olympia/amo/templates/amo/side_nav.html:4
-#: src/olympia/amo/templates/amo/side_nav.html:12
-#: src/olympia/amo/templates/amo/site_nav.html:4
-#: src/olympia/amo/templates/amo/site_nav.html:26
-#: src/olympia/browse/views.py:56 src/olympia/browse/views.py:66
-#: src/olympia/browse/views.py:237 src/olympia/browse/views.py:282
-#: src/olympia/search/forms.py:86
+#: src/olympia/amo/templates/amo/side_nav.html:4 src/olympia/amo/templates/amo/side_nav.html:12 src/olympia/amo/templates/amo/site_nav.html:4 src/olympia/amo/templates/amo/site_nav.html:26
+#: src/olympia/browse/views.py:56 src/olympia/browse/views.py:66 src/olympia/browse/views.py:204 src/olympia/browse/views.py:249 src/olympia/search/forms.py:86
 msgid "Top Rated"
 msgstr "Top de avaliações"
 
@@ -2552,81 +1979,60 @@ msgid "Explore"
 msgstr "Explorar"
 
 # Plural in this context means many of the add-on type
-#: src/olympia/amo/templates/amo/site_nav.html:23
-#: src/olympia/browse/feeds.py:65 src/olympia/browse/feeds.py:78
-#: src/olympia/browse/feeds.py:92 src/olympia/browse/feeds.py:100
-#: src/olympia/browse/templates/browse/base_listing.html:7
-#: src/olympia/browse/templates/browse/creatured.html:10
-#: src/olympia/browse/templates/browse/impala/base_listing.html:37
+#: src/olympia/amo/templates/amo/site_nav.html:23 src/olympia/browse/feeds.py:65 src/olympia/browse/feeds.py:78 src/olympia/browse/feeds.py:92 src/olympia/browse/feeds.py:100
+#: src/olympia/browse/templates/browse/base_listing.html:7 src/olympia/browse/templates/browse/creatured.html:10 src/olympia/browse/templates/browse/impala/base_listing.html:37
 #: src/olympia/constants/base.py:173 src/olympia/templates/menu_links.html:8
 msgid "Extensions"
 msgstr "Extensões"
 
-#: src/olympia/amo/templates/amo/site_nav.html:45
+#: src/olympia/amo/templates/amo/site_nav.html:44
 msgid "Want more customization? Try <b>Complete Themes</b>"
 msgstr "Quer mais personalização? Experimente <b>Temas completos</b>"
 
-#: src/olympia/amo/templates/amo/site_nav.html:56
-#: src/olympia/bandwagon/views.py:96
+#: src/olympia/amo/templates/amo/site_nav.html:54 src/olympia/bandwagon/views.py:96
 msgid "Most Followers"
 msgstr "Maior número de seguidores"
 
-#: src/olympia/amo/templates/amo/site_nav.html:68
-#: src/olympia/bandwagon/templates/bandwagon/impala/collection_sidebar.html:16
+#: src/olympia/amo/templates/amo/site_nav.html:66 src/olympia/bandwagon/templates/bandwagon/impala/collection_sidebar.html:16
 #: src/olympia/bandwagon/templates/bandwagon/includes/collection_sidebar.html:18
 msgid "Collections I've Made"
 msgstr "Coleções que eu fiz"
 
-#: src/olympia/amo/templates/amo/site_nav.html:70
-#: src/olympia/bandwagon/templates/bandwagon/user_listing.html:4
-#: src/olympia/bandwagon/templates/bandwagon/impala/collection_sidebar.html:13
+#: src/olympia/amo/templates/amo/site_nav.html:68 src/olympia/bandwagon/templates/bandwagon/user_listing.html:4 src/olympia/bandwagon/templates/bandwagon/impala/collection_sidebar.html:13
 #: src/olympia/bandwagon/templates/bandwagon/includes/collection_sidebar.html:15
 msgid "Collections I'm Following"
 msgstr "Coleções que acompanho"
 
-#: src/olympia/amo/templates/amo/site_nav.html:73
-#: src/olympia/bandwagon/templates/bandwagon/impala/collection_sidebar.html:18
-#: src/olympia/bandwagon/templates/bandwagon/includes/collection_sidebar.html:20
-#: src/olympia/users/models.py:512
+#: src/olympia/amo/templates/amo/site_nav.html:71 src/olympia/bandwagon/templates/bandwagon/impala/collection_sidebar.html:18
+#: src/olympia/bandwagon/templates/bandwagon/includes/collection_sidebar.html:20 src/olympia/users/models.py:521
 msgid "My Favorite Add-ons"
 msgstr "Os meus extras favoritos"
 
-#: src/olympia/amo/templates/amo/site_nav.html:78
+#: src/olympia/amo/templates/amo/site_nav.html:76
 msgid "More&hellip;"
 msgstr "Mais&hellip;"
 
-#: src/olympia/amo/templates/amo/site_nav.html:82
+#: src/olympia/amo/templates/amo/site_nav.html:80
 msgid "Add-ons for Mobile"
 msgstr "Extras para dispositivos móveis"
 
-#: src/olympia/amo/templates/amo/site_nav.html:86
-#: src/olympia/browse/feeds.py:207
-#: src/olympia/browse/templates/browse/search_tools.html:3
-#: src/olympia/constants/base.py:176 src/olympia/templates/menu_links.html:10
+#: src/olympia/amo/templates/amo/site_nav.html:84 src/olympia/browse/feeds.py:207 src/olympia/browse/templates/browse/search_tools.html:3 src/olympia/constants/base.py:176
+#: src/olympia/templates/menu_links.html:10
 msgid "Search Tools"
 msgstr "Ferramentas de pesquisa"
 
 #. This is a page range (e.g., Page 1 of 50).
-#: src/olympia/amo/templates/amo/impala/paginator.html:5
-#: src/olympia/amo/templates/amo/mobile/impala_paginator.html:26
+#: src/olympia/amo/templates/amo/impala/paginator.html:5 src/olympia/amo/templates/amo/mobile/impala_paginator.html:26
 #, python-format
-msgid ""
-"Page <a href=\"%(current_pg_url)s\">%(current_pg)s</a> of <a "
-"href=\"%(last_pg_url)s\">%(last_pg)s</a>"
-msgstr ""
-"Página <a href=\"%(current_pg_url)s\">%(current_pg)s</a> de <a "
-"href=\"%(last_pg_url)s\">%(last_pg)s</a>"
+msgid "Page <a href=\"%(current_pg_url)s\">%(current_pg)s</a> of <a href=\"%(last_pg_url)s\">%(last_pg)s</a>"
+msgstr "Página <a href=\"%(current_pg_url)s\">%(current_pg)s</a> de <a href=\"%(last_pg_url)s\">%(last_pg)s</a>"
 
-#: src/olympia/amo/templates/amo/impala/paginator.html:16
-#: src/olympia/amo/templates/amo/mobile/impala_paginator.html:6
+#: src/olympia/amo/templates/amo/impala/paginator.html:16 src/olympia/amo/templates/amo/mobile/impala_paginator.html:6
 msgid "Jump to first page"
 msgstr "Saltar para a primeira página"
 
-#: src/olympia/amo/templates/amo/impala/paginator.html:22
-#: src/olympia/amo/templates/amo/mobile/impala_paginator.html:12
-#: src/olympia/discovery/templates/discovery/pane.html:44
-#: src/olympia/discovery/templates/discovery/addons/detail.html:38
-#: src/olympia/stats/templates/stats/stats.html:164
+#: src/olympia/amo/templates/amo/impala/paginator.html:22 src/olympia/amo/templates/amo/mobile/impala_paginator.html:12 src/olympia/discovery/templates/discovery/pane.html:44
+#: src/olympia/discovery/templates/discovery/addons/detail.html:38 src/olympia/stats/templates/stats/stats.html:166
 msgid "Previous"
 msgstr "Anterior"
 
@@ -2636,10 +2042,9 @@ msgstr "Saltar para a última página"
 
 #. First and second arguments are the result range (e.g., 1-20);
 #. third argument is the number of total results (e.g., 1,000).
-#. third
+#. First and second arguments are the result range (e.g., 1-20);              third
 #. argument is the number of total results (e.g., 1,000).
-#: src/olympia/amo/templates/amo/impala/paginator.html:36
-#: src/olympia/amo/templates/amo/mobile/impala_paginator.html:38
+#: src/olympia/amo/templates/amo/impala/paginator.html:36 src/olympia/amo/templates/amo/mobile/impala_paginator.html:38
 #, python-format
 msgid "Showing <b>%(begin)s</b>&ndash;<b>%(end)s</b> of <b>%(count)s</b>"
 msgstr "A mostrar <b>%(begin)s</b>&ndash;<b>%(end)s</b> de <b>%(count)s</b>"
@@ -2650,42 +2055,52 @@ msgid_plural "Page {n}"
 msgstr[0] "Página {n}"
 msgstr[1] "Página {n}"
 
-#: src/olympia/amo/templates/services/install.html:38
-#, python-format
-msgid ""
-"If you are not prompted to install %(addon_name)s in a moment, please <a "
-"href=\"%(addon_xpi)s\">click here</a>."
-msgstr ""
-"Se dentro de momentos, não for avisado para instalar %(addon_name)s, por "
-"favor <a href=\"%(addon_xpi)s\">clique aqui</a>."
-
-#: src/olympia/amo/tests/test_messages.py:57
-#: src/olympia/amo/tests/test_messages.py:58 src/olympia/reviews/forms.py:25
-#: src/olympia/reviews/forms.py:50
-#: src/olympia/reviews/templates/reviews/add.html:56
+#: src/olympia/amo/tests/test_messages.py:56 src/olympia/amo/tests/test_messages.py:57 src/olympia/reviews/forms.py:25 src/olympia/reviews/forms.py:50 src/olympia/reviews/templates/reviews/add.html:56
 #: src/olympia/reviews/templates/reviews/reply.html:30
 msgid "Title"
 msgstr "Título"
 
-#: src/olympia/amo/tests/test_messages.py:57
-#: src/olympia/amo/tests/test_messages.py:58
+#: src/olympia/amo/tests/test_messages.py:56 src/olympia/amo/tests/test_messages.py:57
 msgid "Body"
 msgstr "Corpo"
 
-#: src/olympia/amo/tests/test_messages.py:59
+#: src/olympia/amo/tests/test_messages.py:58
 msgid "Another Title"
 msgstr "Outro título"
 
-#: src/olympia/amo/tests/test_messages.py:59
+#: src/olympia/amo/tests/test_messages.py:58
 msgid "Another Body"
 msgstr "Outro corpo"
 
-#: src/olympia/api/views.py:255
-msgid "Not implemented yet."
-msgstr "Ainda não implementado."
+#: src/olympia/api/authentication.py:76
+msgid "Signature has expired."
+msgstr ""
 
-#: src/olympia/applications/views.py:39
-#: src/olympia/applications/templates/applications/appversions.html:3
+#: src/olympia/api/authentication.py:79
+msgid "Error decoding signature."
+msgstr ""
+
+#: src/olympia/api/authentication.py:82
+msgid "Invalid JWT Token."
+msgstr ""
+
+#: src/olympia/api/authentication.py:130
+msgid "Invalid Authorization header. No credentials provided."
+msgstr ""
+
+#: src/olympia/api/authentication.py:133
+msgid "Invalid Authorization header. Credentials string should not contain spaces."
+msgstr ""
+
+#: src/olympia/api/fields.py:29
+msgid "The field must have a length of at least {num} characters."
+msgstr ""
+
+#: src/olympia/api/fields.py:31
+msgid "The language code {lang_code} is invalid."
+msgstr ""
+
+#: src/olympia/applications/views.py:39 src/olympia/applications/templates/applications/appversions.html:3
 msgid "Application Versions"
 msgstr "Versões da aplicação"
 
@@ -2698,22 +2113,17 @@ msgid "Valid Application Versions"
 msgstr "Versões Válidas da Aplicação"
 
 #: src/olympia/applications/templates/applications/appversions.html:12
-msgid ""
-"Add-ons submitted to Mozilla Add-ons must have a manifest file with at least"
-" one of the below applications supported. Only the versions listed below are"
-" allowed for these applications."
+msgid "Add-ons submitted to Mozilla Add-ons must have a manifest file with at least one of the below applications supported. Only the versions listed below are allowed for these applications."
 msgstr ""
-"Extras submetidos no Extras da Mozilla necessitam de ter um ficheiro "
-"manifest com pelo menos uma das aplicações suportadas abaixo. Apenas as "
-"versões listadas abaixo são permitidas para estas aplicações."
+"Extras submetidos no Extras da Mozilla necessitam de ter um ficheiro manifest com pelo menos uma das aplicações suportadas abaixo. Apenas as versões listadas abaixo são permitidas para estas "
+"aplicações."
 
-#: src/olympia/applications/templates/applications/appversions.html:25
+#: src/olympia/applications/templates/applications/appversions.html:25 src/olympia/editors/helpers.py:361
 msgid "GUID"
 msgstr "GUID"
 
 #. {0} is an add-on name.
-#: src/olympia/applications/templates/applications/appversions.html:26
-#: src/olympia/versions/templates/versions/version_list.html:23
+#: src/olympia/applications/templates/applications/appversions.html:26 src/olympia/versions/templates/versions/version_list.html:23
 msgid "Versions"
 msgstr "Versões"
 
@@ -2723,14 +2133,8 @@ msgstr "http://developer.mozilla.org/en/docs/Install_Manifests"
 
 #: src/olympia/applications/templates/applications/appversions.html:31
 #, python-format
-msgid ""
-"If your supported application does not require a manifest file, you still "
-"must include one with the required properties as specified <a "
-"href=\"%(url)s\">here</a>."
-msgstr ""
-"Se a sua aplicação suportada não requer um ficheiro manifest, você ainda tem"
-" de incluir um com as propriedades requeridas como especificado <a "
-"href=\"%(url)s\">aqui</a>."
+msgid "If your supported application does not require a manifest file, you still must include one with the required properties as specified <a href=\"%(url)s\">here</a>."
+msgstr "Se a sua aplicação suportada não requer um ficheiro manifest, você ainda tem de incluir um com as propriedades requeridas como especificado <a href=\"%(url)s\">aqui</a>."
 
 #. L10n: {0} is 'Add-ons for <app>'.
 #: src/olympia/bandwagon/feeds.py:44
@@ -2738,13 +2142,9 @@ msgstr ""
 msgid "Collections :: %s"
 msgstr "Coleções :: %s"
 
-#: src/olympia/bandwagon/feeds.py:50
-#: src/olympia/bandwagon/templates/bandwagon/collection_detail.html:137
-msgid ""
-"Collections are groups of related add-ons that anyone can create and share."
-msgstr ""
-"Coleções são grupos de extras relacionados que qualquer um pode criar e "
-"partilhar."
+#: src/olympia/bandwagon/feeds.py:50 src/olympia/bandwagon/templates/bandwagon/collection_detail.html:137
+msgid "Collections are groups of related add-ons that anyone can create and share."
+msgstr "Coleções são grupos de extras relacionados que qualquer um pode criar e partilhar."
 
 #. L10n: {0} is a collection name, {1} is 'Add-ons for <app>'.
 #: src/olympia/bandwagon/feeds.py:70
@@ -2781,8 +2181,7 @@ msgstr "Ícone"
 
 #: src/olympia/bandwagon/forms.py:143
 msgid "Please don't fill out this field, it's used to catch bots"
-msgstr ""
-"Por favor, não preencha este campo, pois é utilizado para apanhar bots"
+msgstr "Por favor, não preencha este campo, pois é utilizado para apanhar bots"
 
 #: src/olympia/bandwagon/forms.py:167
 msgid "This name cannot be used."
@@ -2800,8 +2199,7 @@ msgstr "Este url já está a ser utilizado por outra coleção"
 msgid "Icons must be either PNG or JPG."
 msgstr "Os ícones devem ser PNG ou JPG."
 
-#: src/olympia/bandwagon/forms.py:202 src/olympia/devhub/views.py:1067
-#: src/olympia/users/forms.py:476
+#: src/olympia/bandwagon/forms.py:202 src/olympia/devhub/views.py:1067 src/olympia/users/forms.py:476
 #, python-format
 msgid "Please use images smaller than %dMB."
 msgstr "Por favor, use imagens menores que %dMB."
@@ -2822,8 +2220,7 @@ msgstr "Remover o meu voto para esta coleção"
 msgid "Log in to vote for this collection"
 msgstr "Inicie sessão para votar nesta coleção"
 
-#: src/olympia/bandwagon/helpers.py:123
-#: src/olympia/bandwagon/templates/bandwagon/favorites_widget.html:2
+#: src/olympia/bandwagon/helpers.py:123 src/olympia/bandwagon/templates/bandwagon/favorites_widget.html:2
 msgid "Add to favorites"
 msgstr "Adicionar aos favoritos"
 
@@ -2831,20 +2228,13 @@ msgstr "Adicionar aos favoritos"
 msgid "Favorite"
 msgstr "Favorito"
 
-#: src/olympia/bandwagon/helpers.py:124
-#: src/olympia/bandwagon/templates/bandwagon/favorites_widget.html:2
+#: src/olympia/bandwagon/helpers.py:124 src/olympia/bandwagon/templates/bandwagon/favorites_widget.html:2
 msgid "Remove from favorites"
 msgstr "Remover dos favoritos"
 
-#: src/olympia/bandwagon/views.py:98 src/olympia/bandwagon/views.py:191
-#: src/olympia/browse/views.py:58 src/olympia/browse/views.py:69
-#: src/olympia/browse/views.py:458 src/olympia/devhub/views.py:74
-#: src/olympia/devhub/views.py:82
-#: src/olympia/devhub/templates/devhub/addons/edit/basic.html:20
-#: src/olympia/editors/templates/editors/leaderboard.html:24
-#: src/olympia/editors/templates/editors/themes/queue_list.html:48
-#: src/olympia/search/forms.py:17 src/olympia/search/forms.py:89
-#: src/olympia/users/templates/users/vcard.html:5
+#: src/olympia/bandwagon/views.py:98 src/olympia/bandwagon/views.py:191 src/olympia/browse/views.py:58 src/olympia/browse/views.py:69 src/olympia/browse/views.py:425 src/olympia/devhub/views.py:72
+#: src/olympia/devhub/views.py:80 src/olympia/devhub/templates/devhub/addons/edit/basic.html:20 src/olympia/editors/templates/editors/leaderboard.html:24
+#: src/olympia/editors/templates/editors/themes/queue_list.html:48 src/olympia/search/forms.py:17 src/olympia/search/forms.py:89 src/olympia/users/templates/users/vcard.html:5
 msgid "Name"
 msgstr "Nome"
 
@@ -2852,8 +2242,7 @@ msgstr "Nome"
 msgid "Recently Popular"
 msgstr "Recentemente popular"
 
-#: src/olympia/bandwagon/views.py:189
-#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:18
+#: src/olympia/bandwagon/views.py:189 src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:16
 msgid "Added"
 msgstr "Adicionado"
 
@@ -2867,12 +2256,8 @@ msgstr "Coleção criada!"
 
 #: src/olympia/bandwagon/views.py:316
 #, python-format
-msgid ""
-"Your new collection is shown below. You can <ahref=\"%(url)s\">edit "
-"additional settings</a> if you'dlike."
+msgid "Your new collection is shown below. You can <a href=\"%(url)s\">edit additional settings</a> if you'd like."
 msgstr ""
-"A sua nova coleção é apresentada abaixo. Pode <a href=\"%(url)s\">editar "
-"definições adicionais</a> se quiser."
 
 #: src/olympia/bandwagon/views.py:322
 msgid "Collection updated!"
@@ -2887,31 +2272,20 @@ msgstr "<a href=\"%(url)s\">Veja a sua coleção</a> com as alterações."
 msgid "Icon Deleted"
 msgstr "Ícone eliminado"
 
-#: src/olympia/bandwagon/templates/bandwagon/add.html:3
-#: src/olympia/bandwagon/templates/bandwagon/add.html:11
-#: src/olympia/bandwagon/templates/bandwagon/includes/collection_sidebar.html:26
+#: src/olympia/bandwagon/templates/bandwagon/add.html:3 src/olympia/bandwagon/templates/bandwagon/add.html:11 src/olympia/bandwagon/templates/bandwagon/includes/collection_sidebar.html:26
 msgid "Create a New Collection"
 msgstr "Criar uma nova coleção"
 
-#: src/olympia/bandwagon/templates/bandwagon/add.html:9
-#: src/olympia/devhub/templates/devhub/personas/submit.html:14
+#: src/olympia/bandwagon/templates/bandwagon/add.html:9 src/olympia/devhub/templates/devhub/personas/submit.html:14
 msgid "Create"
 msgstr "Criar"
 
-#: src/olympia/bandwagon/templates/bandwagon/add.html:24
-#: src/olympia/bandwagon/templates/bandwagon/ajax_new.html:28
+#: src/olympia/bandwagon/templates/bandwagon/add.html:24 src/olympia/bandwagon/templates/bandwagon/ajax_new.html:28
 #, python-format
-msgid ""
-"As noted in our <a href=\"%(legal)s\">Legal Notices</a>, individual "
-"collection arrangements are governed by the Creative Commons Attribution "
-"Share-Alike License"
-msgstr ""
-"Como indicado nas nossas <a href=\"%(legal)s\">Informações legais</a>, a "
-"criação de coleções individuais é regida pela Licença  Creative Commons "
-"Attribution Share-Alike"
+msgid "As noted in our <a href=\"%(legal)s\">Legal Notices</a>, individual collection arrangements are governed by the Creative Commons Attribution Share-Alike License"
+msgstr "Como indicado nas nossas <a href=\"%(legal)s\">Informações legais</a>, a criação de coleções individuais é regida pela Licença  Creative Commons Attribution Share-Alike"
 
-#: src/olympia/bandwagon/templates/bandwagon/add.html:33
-#: src/olympia/bandwagon/templates/bandwagon/ajax_new.html:38
+#: src/olympia/bandwagon/templates/bandwagon/add.html:33 src/olympia/bandwagon/templates/bandwagon/ajax_new.html:38
 msgid "Create Collection"
 msgstr "Criar coleção"
 
@@ -2927,8 +2301,7 @@ msgstr "Iniciar uma nova coleção..."
 msgid "Start a New Collection"
 msgstr "Iniciar uma nova coleção"
 
-#: src/olympia/bandwagon/templates/bandwagon/ajax_new.html:6
-#: src/olympia/bandwagon/templates/bandwagon/includes/addedit.html:7
+#: src/olympia/bandwagon/templates/bandwagon/ajax_new.html:6 src/olympia/bandwagon/templates/bandwagon/includes/addedit.html:7
 msgid "Name:"
 msgstr "Nome:"
 
@@ -2941,15 +2314,11 @@ msgstr "ou <a id=\"collections-new-cancel\" href=\"#\">Cancele</a>"
 msgid "To rate collections, you must have an add-ons account."
 msgstr "Para avaliar extras, é necessário uma conta dos extras."
 
-#: src/olympia/bandwagon/templates/bandwagon/barometer.html:18
-#: src/olympia/templates/base.html:145
-#: src/olympia/templates/impala/base.html:198
+#: src/olympia/bandwagon/templates/bandwagon/barometer.html:18 src/olympia/templates/base.html:145 src/olympia/templates/impala/base.html:198
 msgid "Create an Add-ons Account"
 msgstr "Criar uma conta dos extras"
 
-#: src/olympia/bandwagon/templates/bandwagon/barometer.html:21
-#: src/olympia/templates/base.html:148
-#: src/olympia/templates/impala/base.html:201
+#: src/olympia/bandwagon/templates/bandwagon/barometer.html:21 src/olympia/templates/base.html:148 src/olympia/templates/impala/base.html:201
 #, python-format
 msgid "or <a href=\"%(login)s\">log in to your current account</a>"
 msgstr "ou <a href=\"%(login)s\">inicie sessão na sua conta atual</a>"
@@ -2962,8 +2331,7 @@ msgstr "{0} :: Coleções"
 msgid "private"
 msgstr "privado"
 
-#: src/olympia/bandwagon/templates/bandwagon/collection_detail.html:45
-#: src/olympia/bandwagon/templates/bandwagon/mobile/listing_items.html:9
+#: src/olympia/bandwagon/templates/bandwagon/collection_detail.html:45 src/olympia/bandwagon/templates/bandwagon/mobile/listing_items.html:9
 #, python-format
 msgid "<span>%(num)s</span> follower"
 msgid_plural "<span>%(num)s</span> followers"
@@ -2998,8 +2366,7 @@ msgstr "Mais opções:"
 msgid "Edit Collection"
 msgstr "Editar coleção"
 
-#: src/olympia/bandwagon/templates/bandwagon/collection_detail.html:88
-#: src/olympia/bandwagon/templates/bandwagon/includes/delete.html:3
+#: src/olympia/bandwagon/templates/bandwagon/collection_detail.html:88 src/olympia/bandwagon/templates/bandwagon/includes/delete.html:3
 msgid "Delete Collection"
 msgstr "Eliminar coleção"
 
@@ -3017,12 +2384,8 @@ msgid_plural "%(num)s Add-ons in this Collection"
 msgstr[0] "Coleção com %(num)s extra "
 msgstr[1] "Coleção com %(num)s extras"
 
-#: src/olympia/bandwagon/templates/bandwagon/collection_detail.html:125
-#: src/olympia/compat/templates/compat/index.html:25
-#: src/olympia/compat/templates/compat/reporter_detail.html:29
-#: src/olympia/files/templates/files/viewer.html:29
-#: src/olympia/templates/amo_footer.html:17
-#: src/olympia/templates/includes/lang_switcher.html:10
+#: src/olympia/bandwagon/templates/bandwagon/collection_detail.html:125 src/olympia/compat/templates/compat/reporter_detail.html:29 src/olympia/files/templates/files/viewer.html:29
+#: src/olympia/templates/amo_footer.html:17 src/olympia/templates/includes/lang_switcher.html:10
 msgid "Go"
 msgstr "Ir"
 
@@ -3048,28 +2411,17 @@ msgstr "Ver todas as coleções deste utilizador"
 
 #: src/olympia/bandwagon/templates/bandwagon/collection_detail.html:179
 msgid ""
-"Add-ons that you mark as favorites using the <b>Add to Favorites</b> feature"
-" appear below. This collection is currently <b>public</b>, which means "
-"everyone can see it. If you would like to hide it from public view, click "
-"the button below to make it private."
+"Add-ons that you mark as favorites using the <b>Add to Favorites</b> feature appear below. This collection is currently <b>public</b>, which means everyone can see it. If you would like to hide it "
+"from public view, click the button below to make it private."
 msgstr ""
-"Os extras que marcar como favoritos usando a funcionalidade <b>Adicionar aos"
-" favoritos</b> aparecem em baixo. Esta coleção atualmente é <b>pública</b>, "
-"o que significa que todos a podem ver. Se desejar ocultá-la, clique no botão"
-" em baixo para a tornar privada."
+"Os extras que marcar como favoritos usando a funcionalidade <b>Adicionar aos favoritos</b> aparecem em baixo. Esta coleção atualmente é <b>pública</b>, o que significa que todos a podem ver. Se "
+"desejar ocultá-la, clique no botão em baixo para a tornar privada."
 
 #: src/olympia/bandwagon/templates/bandwagon/collection_detail.html:186
 msgid ""
-"Add-ons that you mark as favorites using the <b>Add to Favorites</b> feature"
-" appear below. This collection is currently <b>private</b>, which means only"
-" you can see it.  If you would like everyone to be able to see your "
-"favorites, click the button below to make it public."
+"Add-ons that you mark as favorites using the <b>Add to Favorites</b> feature appear below. This collection is currently <b>private</b>, which means only you can see it.  If you would like everyone "
+"to be able to see your favorites, click the button below to make it public."
 msgstr ""
-"Os extras que marcar como favoritos utilizando a funcionalidade <b>Adicionar"
-" aos favoritos</b> aparecem em baixo. Esta coleção é atualmente "
-"<b>privada</b>, o que significa que apenas você a pode ver. Se quiser que "
-"todos possam ver os seus favoritos, clique no botão em baixo para a tornar "
-"pública."
 
 #: src/olympia/bandwagon/templates/bandwagon/collection_detail.html:196
 msgid "My favorite add-ons"
@@ -3089,20 +2441,18 @@ msgid_plural "<span>%(followers)s</span> followers"
 msgstr[0] "<span>%(followers)s</span> seguidor"
 msgstr[1] "<span>%(followers)s</span> seguidores"
 
-#. People "follow" collections to get notified of updates.
-#. Like
+#. People "follow" collections to get notified of updates.                    Like
 #. Twitter followers.
+#. People "follow" collections to get notified of updates.
 #. Like Twitter followers.
-#: src/olympia/bandwagon/templates/bandwagon/collection_listing_items.html:10
-#: src/olympia/bandwagon/templates/bandwagon/impala/collection_listing_items.html:18
+#: src/olympia/bandwagon/templates/bandwagon/collection_listing_items.html:10 src/olympia/bandwagon/templates/bandwagon/impala/collection_listing_items.html:18
 #, python-format
 msgid "%(num)s weekly follower"
 msgid_plural "%(num)s weekly followers"
 msgstr[0] "%(num)s seguidor semanal"
 msgstr[1] "%(num)s seguidores semanais"
 
-#. People "follow" collections to get notified of updates.
-#. Like
+#. People "follow" collections to get notified of updates.                    Like
 #. Twitter followers.
 #: src/olympia/bandwagon/templates/bandwagon/collection_listing_items.html:18
 #, python-format
@@ -3111,32 +2461,28 @@ msgid_plural "%(num)s monthly followers"
 msgstr[0] "%(num)s seguidor mensal"
 msgstr[1] "%(num)s seguidores mensais"
 
-#. People "follow" collections to get notified of updates.
-#. Like
+#. People "follow" collections to get notified of updates.                    Like
 #. Twitter followers.
+#. People "follow" collections to get notified of updates.
 #. Like Twitter followers.
-#: src/olympia/bandwagon/templates/bandwagon/collection_listing_items.html:26
-#: src/olympia/bandwagon/templates/bandwagon/impala/collection_listing_items.html:26
+#: src/olympia/bandwagon/templates/bandwagon/collection_listing_items.html:26 src/olympia/bandwagon/templates/bandwagon/impala/collection_listing_items.html:26
 #, python-format
 msgid "%(num)s follower"
 msgid_plural "%(num)s followers"
 msgstr[0] "%(num)s seguidor"
 msgstr[1] "%(num)s seguidores"
 
-#: src/olympia/bandwagon/templates/bandwagon/collection_listing_items.html:56
-#: src/olympia/bandwagon/templates/bandwagon/impala/collection_listing_items.html:9
+#: src/olympia/bandwagon/templates/bandwagon/collection_listing_items.html:56 src/olympia/bandwagon/templates/bandwagon/impala/collection_listing_items.html:9
 #: src/olympia/devhub/templates/devhub/personas/edit.html:27
 msgid "by {0}"
 msgstr "por {0}"
 
-#: src/olympia/bandwagon/templates/bandwagon/collection_widgets.html:5
-#: src/olympia/bandwagon/templates/bandwagon/collection_widgets.html:7
+#: src/olympia/bandwagon/templates/bandwagon/collection_widgets.html:5 src/olympia/bandwagon/templates/bandwagon/collection_widgets.html:7
 #: src/olympia/bandwagon/templates/bandwagon/impala/collection_listing_items.html:53
 msgid "Stop Following"
 msgstr "Deixar de seguir"
 
-#: src/olympia/bandwagon/templates/bandwagon/collection_widgets.html:6
-#: src/olympia/bandwagon/templates/bandwagon/collection_widgets.html:7
+#: src/olympia/bandwagon/templates/bandwagon/collection_widgets.html:6 src/olympia/bandwagon/templates/bandwagon/collection_widgets.html:7
 #: src/olympia/bandwagon/templates/bandwagon/impala/collection_listing_items.html:53
 msgid "Follow this Collection"
 msgstr "Siga esta coleção"
@@ -3146,16 +2492,12 @@ msgid "Edit this Collection"
 msgstr "Editar esta coleção"
 
 #. %s is the name of the collection.
-#: src/olympia/bandwagon/templates/bandwagon/delete.html:4
-#: src/olympia/bandwagon/templates/bandwagon/delete.html:15
+#: src/olympia/bandwagon/templates/bandwagon/delete.html:4 src/olympia/bandwagon/templates/bandwagon/delete.html:15
 msgid "Delete {0}"
 msgstr "Eliminar {0}"
 
-#: src/olympia/bandwagon/templates/bandwagon/delete.html:13
-#: src/olympia/devhub/templates/devhub/addons/listing/item_actions.html:14
-#: src/olympia/devhub/templates/devhub/addons/listing/item_actions_theme.html:28
-#: src/olympia/devhub/templates/devhub/versions/list.html:131
-#: src/olympia/devhub/templates/devhub/versions/list.html:149
+#: src/olympia/bandwagon/templates/bandwagon/delete.html:13 src/olympia/devhub/templates/devhub/addons/listing/item_actions.html:14
+#: src/olympia/devhub/templates/devhub/addons/listing/item_actions_theme.html:28 src/olympia/devhub/templates/devhub/versions/list.html:131 src/olympia/devhub/templates/devhub/versions/list.html:149
 #: src/olympia/devhub/templates/devhub/versions/list.html:166
 msgid "Delete"
 msgstr "Apagar"
@@ -3164,35 +2506,24 @@ msgstr "Apagar"
 msgid "Are you sure?"
 msgstr "Tem a certeza?"
 
-#: src/olympia/bandwagon/templates/bandwagon/delete.html:21
-#: src/olympia/devhub/templates/devhub/personas/edit.html:131
-#: src/olympia/devhub/templates/devhub/personas/edit.html:152
-#: src/olympia/devhub/templates/devhub/personas/edit.html:173
-#: src/olympia/devhub/templates/devhub/personas/submit.html:77
-#: src/olympia/devhub/templates/devhub/personas/submit.html:98
+#: src/olympia/bandwagon/templates/bandwagon/delete.html:21 src/olympia/devhub/templates/devhub/personas/edit.html:131 src/olympia/devhub/templates/devhub/personas/edit.html:152
+#: src/olympia/devhub/templates/devhub/personas/edit.html:173 src/olympia/devhub/templates/devhub/personas/submit.html:77 src/olympia/devhub/templates/devhub/personas/submit.html:98
 #: src/olympia/devhub/templates/devhub/personas/submit.html:119
 msgid "Yes"
 msgstr "Sim"
 
-#: src/olympia/bandwagon/templates/bandwagon/delete.html:22
-#: src/olympia/devhub/templates/devhub/personas/edit.html:140
-#: src/olympia/devhub/templates/devhub/personas/edit.html:161
-#: src/olympia/devhub/templates/devhub/personas/edit.html:191
-#: src/olympia/devhub/templates/devhub/personas/submit.html:86
-#: src/olympia/devhub/templates/devhub/personas/submit.html:107
+#: src/olympia/bandwagon/templates/bandwagon/delete.html:22 src/olympia/devhub/templates/devhub/personas/edit.html:140 src/olympia/devhub/templates/devhub/personas/edit.html:161
+#: src/olympia/devhub/templates/devhub/personas/edit.html:191 src/olympia/devhub/templates/devhub/personas/submit.html:86 src/olympia/devhub/templates/devhub/personas/submit.html:107
 #: src/olympia/devhub/templates/devhub/personas/submit.html:137
 msgid "No"
 msgstr "Não"
 
 #. {0} is the name of the collection.
-#: src/olympia/bandwagon/templates/bandwagon/edit.html:5
-#: src/olympia/bandwagon/templates/bandwagon/edit.html:21
+#: src/olympia/bandwagon/templates/bandwagon/edit.html:5 src/olympia/bandwagon/templates/bandwagon/edit.html:21
 msgid "Edit {0}"
 msgstr "Editar {0}"
 
-#: src/olympia/bandwagon/templates/bandwagon/edit.html:29
-#: src/olympia/devhub/templates/devhub/addons/edit/details.html:20
-#: src/olympia/editors/templates/editors/themes/themes.html:62
+#: src/olympia/bandwagon/templates/bandwagon/edit.html:29 src/olympia/devhub/templates/devhub/addons/edit/details.html:20 src/olympia/editors/templates/editors/themes/themes.html:62
 msgid "Description"
 msgstr "Descrição"
 
@@ -3200,32 +2531,18 @@ msgstr "Descrição"
 msgid "Contributors & More"
 msgstr "Contribuintes e Mais"
 
-#: src/olympia/bandwagon/templates/bandwagon/edit.html:54
-#: src/olympia/bandwagon/templates/bandwagon/edit.html:67
-#: src/olympia/bandwagon/templates/bandwagon/edit.html:82
-#: src/olympia/devhub/templates/devhub/addons/ajax_compat_update.html:35
-#: src/olympia/devhub/templates/devhub/addons/owner.html:59
-#: src/olympia/devhub/templates/devhub/addons/profile.html:42
-#: src/olympia/devhub/templates/devhub/addons/edit/admin.html:101
-#: src/olympia/devhub/templates/devhub/addons/edit/basic.html:152
-#: src/olympia/devhub/templates/devhub/addons/edit/details.html:85
-#: src/olympia/devhub/templates/devhub/addons/edit/support.html:67
-#: src/olympia/devhub/templates/devhub/addons/edit/technical.html:166
-#: src/olympia/devhub/templates/devhub/addons/forms_shared/media.html:149
-#: src/olympia/devhub/templates/devhub/payments/voluntary.html:64
-#: src/olympia/devhub/templates/devhub/personas/edit.html:35
-#: src/olympia/devhub/templates/devhub/personas/edit.html:304
-#: src/olympia/devhub/templates/devhub/versions/edit.html:139
-#: src/olympia/translations/templates/translations/trans-menu.html:48
+#: src/olympia/bandwagon/templates/bandwagon/edit.html:54 src/olympia/bandwagon/templates/bandwagon/edit.html:67 src/olympia/bandwagon/templates/bandwagon/edit.html:82
+#: src/olympia/devhub/templates/devhub/addons/ajax_compat_update.html:35 src/olympia/devhub/templates/devhub/addons/owner.html:59 src/olympia/devhub/templates/devhub/addons/profile.html:42
+#: src/olympia/devhub/templates/devhub/addons/edit/admin.html:101 src/olympia/devhub/templates/devhub/addons/edit/basic.html:152 src/olympia/devhub/templates/devhub/addons/edit/details.html:85
+#: src/olympia/devhub/templates/devhub/addons/edit/support.html:67 src/olympia/devhub/templates/devhub/addons/edit/technical.html:166
+#: src/olympia/devhub/templates/devhub/addons/forms_shared/media.html:149 src/olympia/devhub/templates/devhub/payments/voluntary.html:64 src/olympia/devhub/templates/devhub/personas/edit.html:35
+#: src/olympia/devhub/templates/devhub/personas/edit.html:304 src/olympia/devhub/templates/devhub/versions/edit.html:139 src/olympia/translations/templates/translations/trans-menu.html:48
 msgid "Save Changes"
 msgstr "Guardar alterações"
 
 # <option> text in a <select> for Author role in an add-on.
-#: src/olympia/bandwagon/templates/bandwagon/edit_contributors.html:9
-#: src/olympia/bandwagon/templates/bandwagon/edit_contributors.html:12
-#: src/olympia/bandwagon/templates/bandwagon/edit_contributors.html:17
-#: src/olympia/bandwagon/templates/bandwagon/edit_contributors.html:58
-#: src/olympia/constants/base.py:134
+#: src/olympia/bandwagon/templates/bandwagon/edit_contributors.html:9 src/olympia/bandwagon/templates/bandwagon/edit_contributors.html:12
+#: src/olympia/bandwagon/templates/bandwagon/edit_contributors.html:17 src/olympia/bandwagon/templates/bandwagon/edit_contributors.html:58 src/olympia/constants/base.py:134
 msgid "Owner"
 msgstr "Proprietário"
 
@@ -3237,10 +2554,8 @@ msgstr "Tornar proprietário"
 msgid "Remove this user as a contributor"
 msgstr "Remover este utilizador como contribuinte"
 
-#: src/olympia/bandwagon/templates/bandwagon/edit_contributors.html:18
-#: src/olympia/bandwagon/templates/bandwagon/edit_contributors.html:43
-#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:20
-#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:48
+#: src/olympia/bandwagon/templates/bandwagon/edit_contributors.html:18 src/olympia/bandwagon/templates/bandwagon/edit_contributors.html:43
+#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:18 src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:46
 #: src/olympia/devhub/templates/devhub/addons/ajax_compat_update.html:19
 msgid "Remove"
 msgstr "Remover"
@@ -3251,24 +2566,15 @@ msgstr "Contribuintes da coleção"
 
 #: src/olympia/bandwagon/templates/bandwagon/edit_contributors.html:26
 msgid ""
-"You can add multiple contributors to this collection.  A contributor can add"
-" and remove add-ons from this collection, but cannot change its name or "
-"description.  To add a contributor, enter their email in the box below. "
-"Contributors must have a Mozilla Add-ons account."
+"You can add multiple contributors to this collection.  A contributor can add and remove add-ons from this collection, but cannot change its name or description.  To add a contributor, enter their "
+"email in the box below. Contributors must have a Mozilla Add-ons account."
 msgstr ""
-"Pode adicionar múltiplos contribuintes a esta coleção. Um contribuinte pode "
-"adicionar e remover extras nesta coleção, mas não pode alternar o nome ou "
-"descrição da mesma. Para adicionar um contribuinte, introduza o respetivo "
-"email na caixa em baixo. Os contribuintes têm de ter uma conta de extras da "
-"Mozilla."
 
 #: src/olympia/bandwagon/templates/bandwagon/edit_contributors.html:40
 msgid "User"
 msgstr "Utilizador"
 
-#: src/olympia/bandwagon/templates/bandwagon/edit_contributors.html:41
-#: src/olympia/devhub/templates/devhub/addons/edit/support.html:20
-#: src/olympia/users/templates/users/delete.html:49
+#: src/olympia/bandwagon/templates/bandwagon/edit_contributors.html:41 src/olympia/devhub/templates/devhub/addons/edit/support.html:20 src/olympia/users/templates/users/delete.html:49
 msgid "Email"
 msgstr "Email"
 
@@ -3294,27 +2600,14 @@ msgid "Admin Settings"
 msgstr "Definições de administrador"
 
 #: src/olympia/bandwagon/templates/bandwagon/edit_contributors.html:76
-msgid ""
-"<b>Warning:</b> By changing the owner of this collection, you will no longer"
-" be able to edit it. You will only be able to add and remove add-ons from "
-"it."
-msgstr ""
-"<b>Aviso:</b> Ao alterar o proprietário desta coleção, já não a poderá "
-"editar. Apenas poderá adicionar ou remover extras."
+msgid "<b>Warning:</b> By changing the owner of this collection, you will no longer be able to edit it. You will only be able to add and remove add-ons from it."
+msgstr "<b>Aviso:</b> Ao alterar o proprietário desta coleção, já não a poderá editar. Apenas poderá adicionar ou remover extras."
 
-#: src/olympia/bandwagon/templates/bandwagon/edit_contributors.html:83
-#: src/olympia/devhub/templates/devhub/addons/forms_shared/media.html:157
-#: src/olympia/devhub/templates/devhub/addons/submit/describe.html:69
-#: src/olympia/devhub/templates/devhub/addons/submit/license.html:60
-#: src/olympia/devhub/templates/devhub/addons/submit/upload.html:78
-#: src/olympia/devhub/templates/devhub/payments/tier.html:17
-#: src/olympia/editors/templates/editors/themes/themes.html:111
-#: src/olympia/editors/templates/editors/themes/themes.html:128
-#: src/olympia/editors/templates/editors/themes/themes.html:134
-#: src/olympia/editors/templates/editors/themes/themes.html:141
-#: src/olympia/users/templates/users/fxa_migration_prompt_content.html:10
-#: src/olympia/users/templates/users/login_form.html:42
-#: src/olympia/users/templates/users/mobile/login.html:57
+#: src/olympia/bandwagon/templates/bandwagon/edit_contributors.html:83 src/olympia/devhub/templates/devhub/addons/forms_shared/media.html:157
+#: src/olympia/devhub/templates/devhub/addons/submit/describe.html:69 src/olympia/devhub/templates/devhub/addons/submit/license.html:60 src/olympia/devhub/templates/devhub/addons/submit/upload.html:70
+#: src/olympia/devhub/templates/devhub/payments/tier.html:17 src/olympia/editors/templates/editors/themes/themes.html:111 src/olympia/editors/templates/editors/themes/themes.html:128
+#: src/olympia/editors/templates/editors/themes/themes.html:134 src/olympia/editors/templates/editors/themes/themes.html:141 src/olympia/users/templates/users/fxa_migration_prompt_content.html:10
+#: src/olympia/users/templates/users/login_form.html:42 src/olympia/users/templates/users/mobile/login.html:57
 msgid "Continue"
 msgstr "Continuar"
 
@@ -3353,18 +2646,10 @@ msgstr "Coleções recentemente populares"
 
 #: src/olympia/bandwagon/templates/bandwagon/impala/collection_listing.html:28
 #, python-format
-msgid ""
-"Collections are groups of related add-ons that anyone can create and share. "
-"Explore collections created by other users or <a href=\"%(url)s\">create "
-"your own</a>."
-msgstr ""
-"As coleções são grupos de extras relacionados que qualquer um pode criar e "
-"partilhar. Explore as coleções criadas por outros utilizadores ou <a "
-"href=\"%(url)s\">crie a sua</a>."
+msgid "Collections are groups of related add-ons that anyone can create and share. Explore collections created by other users or <a href=\"%(url)s\">create your own</a>."
+msgstr "As coleções são grupos de extras relacionados que qualquer um pode criar e partilhar. Explore as coleções criadas por outros utilizadores ou <a href=\"%(url)s\">crie a sua</a>."
 
-#: src/olympia/bandwagon/templates/bandwagon/impala/collection_listing.html:37
-#: src/olympia/browse/templates/browse/extensions.html:13
-#: src/olympia/browse/templates/browse/themes.html:14
+#: src/olympia/bandwagon/templates/bandwagon/impala/collection_listing.html:37 src/olympia/browse/templates/browse/extensions.html:13 src/olympia/browse/templates/browse/themes.html:14
 msgid "Subscribe"
 msgstr "Subscrever"
 
@@ -3372,20 +2657,14 @@ msgstr "Subscrever"
 msgid "Following"
 msgstr "Seguinte"
 
-#: src/olympia/bandwagon/templates/bandwagon/impala/collection_sidebar.html:22
-#: src/olympia/bandwagon/templates/bandwagon/impala/collection_sidebar.html:28
+#: src/olympia/bandwagon/templates/bandwagon/impala/collection_sidebar.html:22 src/olympia/bandwagon/templates/bandwagon/impala/collection_sidebar.html:28
 #: src/olympia/bandwagon/templates/bandwagon/includes/collection_sidebar.html:32
 msgid "Create a Collection"
 msgstr "Criar uma coleção"
 
-#: src/olympia/bandwagon/templates/bandwagon/impala/collection_sidebar.html:23
-#: src/olympia/bandwagon/templates/bandwagon/includes/collection_sidebar.html:27
-msgid ""
-"Collections make it easy to keep track of favorite add-ons and share your "
-"perfectly customized browser with others."
-msgstr ""
-"As coleções tornam mais fácil seguir os extras favoritos e partilham o seu "
-"navegador completamente personalizado com os outros."
+#: src/olympia/bandwagon/templates/bandwagon/impala/collection_sidebar.html:23 src/olympia/bandwagon/templates/bandwagon/includes/collection_sidebar.html:27
+msgid "Collections make it easy to keep track of favorite add-ons and share your perfectly customized browser with others."
+msgstr "As coleções tornam mais fácil seguir os extras favoritos e partilham o seu navegador completamente personalizado com os outros."
 
 #: src/olympia/bandwagon/templates/bandwagon/includes/addedit.html:42
 msgid "Collection Icon"
@@ -3397,51 +2676,42 @@ msgstr "Repor"
 
 #: src/olympia/bandwagon/templates/bandwagon/includes/addedit.html:53
 msgid "PNG and JPG supported.  Image will be resized to 32x32."
-msgstr "São suportados PNG e JPG.  A imagem será redimensionada para 32x32."
+msgstr ""
 
 #: src/olympia/bandwagon/templates/bandwagon/includes/addedit_errors.html:3
 msgid "There are errors in this form.  Please correct them below."
-msgstr "Existem erros neste formulário. Por favor, corrija-os em baixo."
+msgstr ""
 
 #: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:2
 msgid "Add-ons in Your Collection"
 msgstr "Extras na sua coleção"
 
 #: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:4
-msgid ""
-"To include an add-on in this collection, enter its name in the box below and"
-" hit enter.  You can also use the <strong>Add to Collection</strong> links "
-"throughout the site to include add-ons later."
+msgid "To include an add-on in this collection, enter its name in the box below and hit enter."
 msgstr ""
-"Para incluir um extra nesta coleção, introduza o nome do mesmo na caixa em "
-"baixo e carregue no enter. Pode também utilizar as ligações "
-"<strong>Adicionar à coleção</strong> dispostas no site para incluir extras "
-"mais tarde."
 
-#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:17
-#: src/olympia/constants/base.py:400
-#: src/olympia/devhub/templates/devhub/addons/activity.html:62
+#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:15 src/olympia/constants/base.py:400 src/olympia/devhub/templates/devhub/addons/activity.html:62
+#: src/olympia/editors/helpers.py:273 src/olympia/editors/helpers.py:360
 msgid "Add-on"
 msgstr "Extra"
 
-#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:26
+#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:24
 msgid "Enter the name of the add-on to include"
 msgstr "Insira o nome do extra a incluir"
 
-#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:28
+#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:26
 msgid "Add to Collection"
 msgstr "Adicionar à coleção"
 
-#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:45
-#: src/olympia/editors/helpers.py:936 src/olympia/editors/helpers.py:956
+#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:43 src/olympia/editors/helpers.py:1016 src/olympia/editors/helpers.py:1036
 msgid "Pending"
 msgstr "Em espera"
 
-#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:47
+#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:45
 msgid "Add a comment"
 msgstr "Adicionar um comentário"
 
-#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:48
+#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:46
 msgid "Remove this add-on from the collection"
 msgstr "Remover este extra da coleção"
 
@@ -3453,14 +2723,11 @@ msgstr "COLEÇÕES"
 msgid "Groups of related add-ons that anyone can create."
 msgstr "Grupos de extras relacionados que qualquer um pode criar."
 
-#: src/olympia/blocklist/templates/blocklist/blocked_detail.html:3
-#: src/olympia/blocklist/templates/blocklist/blocked_list.html:3
-#: src/olympia/blocklist/templates/blocklist/blocked_list.html:10
+#: src/olympia/blocklist/templates/blocklist/blocked_detail.html:3 src/olympia/blocklist/templates/blocklist/blocked_list.html:3 src/olympia/blocklist/templates/blocklist/blocked_list.html:10
 msgid "Blocked Add-ons"
 msgstr "Extras bloqueados"
 
-#: src/olympia/blocklist/templates/blocklist/blocked_detail.html:8
-#: src/olympia/blocklist/templates/blocklist/blocked_list.html:6
+#: src/olympia/blocklist/templates/blocklist/blocked_detail.html:8 src/olympia/blocklist/templates/blocklist/blocked_list.html:6
 msgid "Blocklist"
 msgstr "Lista de bloqueio"
 
@@ -3482,37 +2749,19 @@ msgid "What does this mean?"
 msgstr "O que é que isto significa?"
 
 #: src/olympia/blocklist/templates/blocklist/blocked_detail.html:22
-msgid ""
-"Users are strongly encouraged to disable the problematic add-on or plugin, "
-"but may choose to continue using it if they accept the risks described."
-msgstr ""
-"Os utilizadores são fortemente encorajados a desativar os extras ou plugins "
-"problemáticos, mas podem optar por continuar a usá-los se aceitarem os "
-"riscos descritos."
+msgid "Users are strongly encouraged to disable the problematic add-on or plugin, but may choose to continue using it if they accept the risks described."
+msgstr "Os utilizadores são fortemente encorajados a desativar os extras ou plugins problemáticos, mas podem optar por continuar a usá-los se aceitarem os riscos descritos."
 
 #: src/olympia/blocklist/templates/blocklist/blocked_detail.html:27
-msgid ""
-"The problematic add-on or plugin will be automatically disabled and no "
-"longer usable."
-msgstr ""
-"Os extras ou plugins problemáticos serão automaticamente desativados e não "
-"poderão ser utilizados."
+msgid "The problematic add-on or plugin will be automatically disabled and no longer usable."
+msgstr "Os extras ou plugins problemáticos serão automaticamente desativados e não poderão ser utilizados."
 
 #: src/olympia/blocklist/templates/blocklist/blocked_detail.html:33
 #, python-format
 msgid ""
-"When Mozilla becomes aware of add-ons, plugins, or other third-party "
-"software that seriously compromises %(app)s security, stability, or "
-"performance and meets <a href=\"%(criteria)s\">certain criteria</a>, the "
-"software may be blocked from general use.  For more information, please read"
-" <a href=\"%(support)s\">this support article</a>."
+"When Mozilla becomes aware of add-ons, plugins, or other third-party software that seriously compromises %(app)s security, stability, or performance and meets <a href=\"%(criteria)s\">certain "
+"criteria</a>, the software may be blocked from general use.  For more information, please read <a href=\"%(support)s\">this support article</a>."
 msgstr ""
-"Quando a Mozilla toma conhecimento de extras, plugins ou outro software de "
-"terceiros que comprometa seriamente a segurança, estabilidade ou desempenho "
-"do %(app)s e que cumpra <a href=\"%(criteria)s\">determinados critérios</a>,"
-" o software pode ser bloqueado de uma utilização geral. Para mais "
-"informações, por favor leia <a href=\"%(support)s\">este artigo de "
-"apoio</a>."
 
 #: src/olympia/blocklist/templates/blocklist/blocked_detail.html:44
 #, python-format
@@ -3525,12 +2774,8 @@ msgid "Blocked on %(date)s."
 msgstr "Bloqueado em %(date)s."
 
 #: src/olympia/blocklist/templates/blocklist/blocked_list.html:11
-msgid ""
-"The following software is known to cause serious security, stability, or "
-"performance issues with {app}."
-msgstr ""
-"O seguinte software é conhecido por causar problemas graves de segurança, "
-"estabilidade ou de desempenho com o {app}."
+msgid "The following software is known to cause serious security, stability, or performance issues with {app}."
+msgstr "O seguinte software é conhecido por causar problemas graves de segurança, estabilidade ou de desempenho com o {app}."
 
 #. L10n: %s is a category name.
 #: src/olympia/browse/feeds.py:76 src/olympia/browse/feeds.py:98
@@ -3552,11 +2797,8 @@ msgstr "Extras em destaque :: %s"
 #. L10n: %s is an app name.
 #: src/olympia/browse/feeds.py:138
 #, python-format
-msgid ""
-"Here's a few of our favorite add-ons to help you get started customizing %s."
-msgstr ""
-"Aqui estão alguns dos nossos extras favoritos para o ajudar a começar a "
-"personalizar o %s."
+msgid "Here's a few of our favorite add-ons to help you get started customizing %s."
+msgstr "Aqui estão alguns dos nossos extras favoritos para o ajudar a começar a personalizar o %s."
 
 #. L10n: %s is a category name.
 #: src/olympia/browse/feeds.py:157
@@ -3572,43 +2814,28 @@ msgstr "Ferramentas de pesquisa e extensões relacionadas com pesquisas"
 msgid "Search tools"
 msgstr "Ferramentas de pesquisa"
 
-#: src/olympia/browse/views.py:55 src/olympia/browse/views.py:65
-#: src/olympia/search/forms.py:85
+#: src/olympia/browse/views.py:55 src/olympia/browse/views.py:65 src/olympia/search/forms.py:85
 msgid "Most Users"
 msgstr "Maior número de utilizadores"
 
-#: src/olympia/browse/views.py:61 src/olympia/browse/views.py:72
-#: src/olympia/browse/views.py:279
-#: src/olympia/browse/templates/browse/personas/mobile/category_landing.html:63
-#: src/olympia/discovery/templates/discovery/pane.html:67
-#: src/olympia/search/forms.py:92
+#: src/olympia/browse/views.py:61 src/olympia/browse/views.py:72 src/olympia/browse/views.py:246 src/olympia/browse/templates/browse/personas/mobile/category_landing.html:63
+#: src/olympia/discovery/templates/discovery/pane.html:67 src/olympia/search/forms.py:92
 msgid "Up & Coming"
 msgstr "Futuramente"
 
-#: src/olympia/browse/views.py:460 src/olympia/devhub/views.py:76
-#: src/olympia/devhub/views.py:83
-#: src/olympia/discovery/templates/discovery/addons/detail.html:66
+#: src/olympia/browse/views.py:427 src/olympia/devhub/views.py:74 src/olympia/devhub/views.py:81 src/olympia/discovery/templates/discovery/addons/detail.html:66
 msgid "Created"
 msgstr "Criado"
 
 #. {0} is the category name. Ex: Sports
-#: src/olympia/browse/templates/browse/creatured.html:5
-#: src/olympia/browse/templates/browse/creatured.html:13
+#: src/olympia/browse/templates/browse/creatured.html:5 src/olympia/browse/templates/browse/creatured.html:13
 msgid "{0}: Featured Add-ons"
 msgstr "{0}: Extras em destaque"
 
-#: src/olympia/browse/templates/browse/creatured.html:12
-#: src/olympia/browse/templates/browse/featured.html:4
-#: src/olympia/browse/templates/browse/featured.html:12
-#: src/olympia/browse/templates/browse/featured.html:13
-#: src/olympia/devhub/templates/devhub/docs/policies-recommended.html:3
-#: src/olympia/devhub/templates/devhub/docs/policies-recommended.html:7
-#: src/olympia/devhub/templates/devhub/docs/policies-recommended.html:9
-#: src/olympia/devhub/templates/devhub/docs/policies.html:21
-#: src/olympia/devhub/templates/devhub/docs/policies.html:90
-#: src/olympia/discovery/modules.py:341
-#: src/olympia/discovery/templates/discovery/pane.html:52
-#: src/olympia/templates/menu_links.html:7
+#: src/olympia/browse/templates/browse/creatured.html:12 src/olympia/browse/templates/browse/featured.html:4 src/olympia/browse/templates/browse/featured.html:12
+#: src/olympia/browse/templates/browse/featured.html:13 src/olympia/devhub/templates/devhub/docs/policies-recommended.html:3 src/olympia/devhub/templates/devhub/docs/policies-recommended.html:7
+#: src/olympia/devhub/templates/devhub/docs/policies-recommended.html:9 src/olympia/devhub/templates/devhub/docs/policies.html:21 src/olympia/devhub/templates/devhub/docs/policies.html:90
+#: src/olympia/discovery/modules.py:341 src/olympia/discovery/templates/discovery/pane.html:52 src/olympia/templates/menu_links.html:7
 msgid "Featured Add-ons"
 msgstr "Extras em destaque"
 
@@ -3619,12 +2846,8 @@ msgstr "Sem extras em destaque para {0}."
 
 #: src/olympia/browse/templates/browse/featured.html:15
 #, python-format
-msgid ""
-"Here's a few of our favorite add-ons to help you get started customizing "
-"%(app)s."
-msgstr ""
-"Aqui estão alguns dos nossos extras favoritos para o ajudar a começar a "
-"personalizar %(app)s."
+msgid "Here's a few of our favorite add-ons to help you get started customizing %(app)s."
+msgstr "Aqui estão alguns dos nossos extras favoritos para o ajudar a começar a personalizar %(app)s."
 
 #: src/olympia/browse/templates/browse/language_tools.html:9
 msgid "Install Dictionary"
@@ -3650,19 +2873,15 @@ msgstr "Disponível no seu idioma"
 msgid "List of language packs and dictionaries available in your locale."
 msgstr "Lista de pacotes de idioma e dicionários disponíveis no seu idioma."
 
-#: src/olympia/browse/templates/browse/language_tools.html:41
-#: src/olympia/browse/templates/browse/language_tools.html:63
+#: src/olympia/browse/templates/browse/language_tools.html:41 src/olympia/browse/templates/browse/language_tools.html:63
 msgid "Language"
 msgstr "Idioma"
 
-#: src/olympia/browse/templates/browse/language_tools.html:42
-#: src/olympia/browse/templates/browse/language_tools.html:64
-#: src/olympia/constants/base.py:162
+#: src/olympia/browse/templates/browse/language_tools.html:42 src/olympia/browse/templates/browse/language_tools.html:64 src/olympia/constants/base.py:162
 msgid "Dictionary"
 msgstr "Dicionário"
 
-#: src/olympia/browse/templates/browse/language_tools.html:43
-#: src/olympia/browse/templates/browse/language_tools.html:65
+#: src/olympia/browse/templates/browse/language_tools.html:43 src/olympia/browse/templates/browse/language_tools.html:65
 msgid "Language Pack"
 msgstr "Pacote de Idioma"
 
@@ -3680,8 +2899,7 @@ msgid "{0} :: Search Tools"
 msgstr "{0} :: Ferramentas de pesquisa"
 
 #. {0} is an integer.
-#: src/olympia/browse/templates/browse/search_tools.html:39
-#: src/olympia/devhub/templates/devhub/addons/dashboard.html:17
+#: src/olympia/browse/templates/browse/search_tools.html:39 src/olympia/devhub/templates/devhub/addons/dashboard.html:17
 msgid "<b>{0}</b> add-on"
 msgid_plural "<b>{0}</b> add-ons"
 msgstr[0] "<b>{0}</b> extra"
@@ -3709,35 +2927,18 @@ msgstr "Recursos adicionais"
 
 #. {0} is an app name, like Firefox.
 #: src/olympia/browse/templates/browse/search_tools.html:93
-msgid ""
-"Learn more about the <a "
-"href=\"http://support.mozilla.com/kb/Search+bar\">search bar</a> in {0}"
-msgstr ""
-"Saiba mais sobre a <a "
-"href=\"http://support.mozilla.com/kb/Search+bar\">Barra de pesquisa</a> em "
-"{0}"
+msgid "Learn more about the <a href=\"http://support.mozilla.com/kb/Search+bar\">search bar</a> in {0}"
+msgstr "Saiba mais sobre a <a href=\"http://support.mozilla.com/kb/Search+bar\">Barra de pesquisa</a> em {0}"
 
 #: src/olympia/browse/templates/browse/search_tools.html:94
-msgid ""
-"Browse through even more search providers at <a "
-"href=\"http://mycroft.mozdev.org/\">mycroft.mozdev.org</a>"
-msgstr ""
-"Navegue através de mais fornecedores de pesquisa em <a "
-"href=\"http://mycroft.mozdev.org/\">mycroft.mozdev.org</a>"
+msgid "Browse through even more search providers at <a href=\"http://mycroft.mozdev.org/\">mycroft.mozdev.org</a>"
+msgstr "Navegue através de mais fornecedores de pesquisa em <a href=\"http://mycroft.mozdev.org/\">mycroft.mozdev.org</a>"
 
 #: src/olympia/browse/templates/browse/search_tools.html:95
-msgid ""
-"<a "
-"href=\"https://developer.mozilla.org/en/Creating_OpenSearch_plugins_for_Firefox\">Make"
-" your own</a> search tool"
-msgstr ""
-"<a "
-"href=\"https://developer.mozilla.org/en/Creating_OpenSearch_plugins_for_Firefox\">Faça"
-" a sua própria</a> ferramenta de pesquisa"
+msgid "<a href=\"https://developer.mozilla.org/en/Creating_OpenSearch_plugins_for_Firefox\">Make your own</a> search tool"
+msgstr "<a href=\"https://developer.mozilla.org/en/Creating_OpenSearch_plugins_for_Firefox\">Faça a sua própria</a> ferramenta de pesquisa"
 
-#: src/olympia/browse/templates/browse/themes.html:6
-#: src/olympia/browse/templates/browse/themes.html:9
-#: src/olympia/constants/base.py:174
+#: src/olympia/browse/templates/browse/themes.html:6 src/olympia/browse/templates/browse/themes.html:9 src/olympia/constants/base.py:174
 msgid "Complete Themes"
 msgstr "Temas completos"
 
@@ -3810,24 +3011,17 @@ msgid_plural "See all %(cnt)s extensions in %(name)s &raquo;"
 msgstr[0] "Ver a %(cnt)s extensão em %(name)s &raquo;"
 msgstr[1] "Ver todas as %(cnt)s extensões em %(name)s &raquo;"
 
-#: src/olympia/browse/templates/browse/mobile/extensions.html:13
-#: src/olympia/compat/templates/compat/index.html:82
-#: src/olympia/devhub/templates/devhub/devhub_search.html:24
-#: src/olympia/devhub/templates/devhub/addons/activity.html:47
-#: src/olympia/search/templates/search/no_results.html:4
-#: src/olympia/search/templates/search/mobile/results.html:36
+#: src/olympia/browse/templates/browse/mobile/extensions.html:13 src/olympia/devhub/templates/devhub/devhub_search.html:24 src/olympia/devhub/templates/devhub/addons/activity.html:47
+#: src/olympia/search/templates/search/no_results.html:4 src/olympia/search/templates/search/mobile/results.html:36
 msgid "No results found."
 msgstr "Nenhum resultado encontrado."
 
-#: src/olympia/browse/templates/browse/personas/base.html:6
-#: src/olympia/browse/templates/browse/personas/mobile/base.html:7
+#: src/olympia/browse/templates/browse/personas/base.html:6 src/olympia/browse/templates/browse/personas/mobile/base.html:7
 msgid "{0} Themes"
 msgstr "{0} Temas"
 
 #. {0} is a user's name.
-#: src/olympia/browse/templates/browse/personas/base.html:15
-#: src/olympia/browse/templates/browse/personas/base.html:40
-#: src/olympia/browse/templates/browse/personas/grid.html:8
+#: src/olympia/browse/templates/browse/personas/base.html:15 src/olympia/browse/templates/browse/personas/base.html:40 src/olympia/browse/templates/browse/personas/grid.html:8
 msgid "{0}'s Themes"
 msgstr "Temas {0}"
 
@@ -3847,31 +3041,22 @@ msgstr "O seu navegador, o seu estilo! Vista-o com um design seu!"
 msgid "Learn more"
 msgstr "Saber mais"
 
-#: src/olympia/browse/templates/browse/personas/category_landing.html:6
-#: src/olympia/browse/templates/browse/personas/mobile/category_landing.html:5
+#: src/olympia/browse/templates/browse/personas/category_landing.html:6 src/olympia/browse/templates/browse/personas/mobile/category_landing.html:5
 msgid "View All Recently Added"
 msgstr "Ver todos os adicionados recentemente"
 
-#: src/olympia/browse/templates/browse/personas/category_landing.html:7
-#: src/olympia/browse/templates/browse/personas/mobile/category_landing.html:6
+#: src/olympia/browse/templates/browse/personas/category_landing.html:7 src/olympia/browse/templates/browse/personas/mobile/category_landing.html:6
 msgid "View All Most Popular"
 msgstr "Ver os mais populares"
 
-#: src/olympia/browse/templates/browse/personas/category_landing.html:8
-#: src/olympia/browse/templates/browse/personas/mobile/category_landing.html:7
+#: src/olympia/browse/templates/browse/personas/category_landing.html:8 src/olympia/browse/templates/browse/personas/mobile/category_landing.html:7
 msgid "View All Top Rated"
 msgstr "Ver todas as avaliações"
 
 #: src/olympia/browse/templates/browse/personas/category_landing.html:40
 #, python-format
-msgid ""
-"Over 300,000 designs to personalize your browser! Move your mouse over a "
-"Background Theme to try it on. <a href=\"%(url)s\" class=\"more-info\">Start"
-" exploring</a>"
-msgstr ""
-"Mais de 300000 aparências para personalizar o seu navegador! Desloque o rato"
-" sobre um tema de fundo para o experimentar. <a href=\"%(url)s\" class"
-"=\"more-info\">Comece a explorar</a>"
+msgid "Over 300,000 designs to personalize your browser! Move your mouse over a Background Theme to try it on. <a href=\"%(url)s\" class=\"more-info\">Start exploring</a>"
+msgstr "Mais de 300000 aparências para personalizar o seu navegador! Desloque o rato sobre um tema de fundo para o experimentar. <a href=\"%(url)s\" class=\"more-info\">Comece a explorar</a>"
 
 #: src/olympia/browse/templates/browse/personas/category_landing.html:47
 msgid "Want more personalization?"
@@ -3881,14 +3066,10 @@ msgstr "Quer mais personalização?"
 #. theme.
 #: src/olympia/browse/templates/browse/personas/category_landing.html:50
 #, python-format
-msgid ""
-"Complete Themes transform the look of your browser with styles for the "
-"window frame, address bar, buttons, tabs, and menus. <a href=\"%(url)s\" "
-"class=\"more-info\">Start exploring</a>"
+msgid "Complete Themes transform the look of your browser with styles for the window frame, address bar, buttons, tabs, and menus. <a href=\"%(url)s\" class=\"more-info\">Start exploring</a>"
 msgstr ""
-"Os temas completos transformam a aparência do seu navegador com estilos para"
-" a moldura da janela, barra de endereço, botões, separadores e menus. <a "
-"href=\"%(url)s\" class=\"more-info\">Comece a explorar</a>"
+"Os temas completos transformam a aparência do seu navegador com estilos para a moldura da janela, barra de endereço, botões, separadores e menus. <a href=\"%(url)s\" class=\"more-info\">Comece a "
+"explorar</a>"
 
 #: src/olympia/browse/templates/browse/personas/category_landing.html:76
 msgid "Up & Coming Themes"
@@ -3918,7 +3099,7 @@ msgstr "&laquo; Todos os temas"
 msgid "All"
 msgstr "Tudo"
 
-#: src/olympia/compat/forms.py:22 src/olympia/search/views.py:525
+#: src/olympia/compat/forms.py:22 src/olympia/editors/templates/editors/base.html:69 src/olympia/search/views.py:518
 msgid "All Add-ons"
 msgstr "Todos os extras"
 
@@ -3930,93 +3111,32 @@ msgstr "Binário"
 msgid "Non-binary"
 msgstr "Não-binário"
 
-#. Review points sources other than add-ons and themes.
-#: src/olympia/compat/views.py:87 src/olympia/constants/base.py:388
-#: src/olympia/devhub/forms.py:162
-#: src/olympia/editors/templates/editors/performance.html:75
-msgid "Other"
-msgstr "Outro"
-
-#: src/olympia/compat/templates/compat/index.html:4
-msgid "Add-on Compatibility Report for {app} {version}"
-msgstr "Relatório de compatibilidade do extra para {app} {version}"
-
-#: src/olympia/compat/templates/compat/index.html:11
-msgid "{app} {version} Compatibility"
-msgstr "Compatibilidade {app} {version}"
-
-#: src/olympia/compat/templates/compat/index.html:17
-#, python-format
-msgid "Top 95%% compatible with previous version"
-msgstr "Top 95%% compatíveis com a versão anterior"
-
-#: src/olympia/compat/templates/compat/index.html:18
-#, python-format
-msgid "Top 95%% of all add-ons"
-msgstr "Top 95%% de todos os extras"
-
-#: src/olympia/compat/templates/compat/index.html:19
-msgid "All active add-ons"
-msgstr "Todos os extras activos"
-
-#: src/olympia/compat/templates/compat/index.html:23
-#: src/olympia/constants/base.py:401
-msgid "App"
-msgstr "App"
-
-#: src/olympia/compat/templates/compat/index.html:55
-msgid "Details for add-ons compatible with previous version:"
-msgstr "Detalhes dos extras compatíveis com a versão anterior:"
-
-#: src/olympia/compat/templates/compat/index.html:57
-msgid "Show all versions"
-msgstr "Mostrar todas as versões"
-
-#: src/olympia/compat/templates/compat/index.html:59
-msgid "Details for add-ons compatible with all versions:"
-msgstr "Detalhes para extras compatíveis com todas as versões:"
-
-#: src/olympia/compat/templates/compat/index.html:61
-msgid "Show previous version only"
-msgstr "Mostrar apenas a versão anterior"
-
 #: src/olympia/compat/templates/compat/reporter.html:3
 msgid "Add-on Compatibility Reports"
 msgstr "Relatórios de compatibilidade do extra"
 
-#: src/olympia/compat/templates/compat/reporter.html:11
-#: src/olympia/compat/templates/compat/reporter_detail.html:35
+#: src/olympia/compat/templates/compat/reporter.html:11 src/olympia/compat/templates/compat/reporter_detail.html:35
 #, python-format
 msgid ""
-"<p> Reports submitted to us through the <a href=\"%(url_)s\">Add-on "
-"Compatibility Reporter</a> are collected here for developers to view. These "
-"reports help us determine which add-ons will need help supporting an "
-"upcoming Firefox version. </p>"
+"<p> Reports submitted to us through the <a href=\"%(url_)s\">Add-on Compatibility Reporter</a> are collected here for developers to view. These reports help us determine which add-ons will need "
+"help supporting an upcoming Firefox version. </p>"
 msgstr ""
-"<p> Os relatórios que nos são submetidos através do <a "
-"href=\"%(url_)s\">relator de compatibilidade de extra</a> são guardados aqui"
-" para que os programadores os vejam. Estes relatórios ajudam-nos a "
-"determinar que extras necessitam de ajuda para suportarem a próxima versão "
-"do Firefox. </p>"
+"<p> Os relatórios que nos são submetidos através do <a href=\"%(url_)s\">relator de compatibilidade de extra</a> são guardados aqui para que os programadores os vejam. Estes relatórios ajudam-nos a "
+"determinar que extras necessitam de ajuda para suportarem a próxima versão do Firefox. </p>"
 
 #: src/olympia/compat/templates/compat/reporter.html:18
 msgid "Reports for your Add-ons"
 msgstr "Relatórios para os seus extras"
 
-#: src/olympia/compat/templates/compat/reporter.html:30
-#: src/olympia/compat/templates/compat/reporter_detail.html:9
+#: src/olympia/compat/templates/compat/reporter.html:30 src/olympia/compat/templates/compat/reporter_detail.html:9
 msgid "Add-on Compatibility Center"
 msgstr "Centro de compatibilidade dos extras"
 
 #: src/olympia/compat/templates/compat/reporter.html:34
 msgid "Enter the GUID of an add-on below to view any reports we've received."
-msgstr ""
-"Escreva o GUID de um extra em baixo para ver qualquer relatório que tenhamos"
-" recebido."
+msgstr "Escreva o GUID de um extra em baixo para ver qualquer relatório que tenhamos recebido."
 
-#: src/olympia/compat/templates/compat/reporter_detail.html:3
-#: src/olympia/compat/templates/compat/reporter_detail.html:10
-#: src/olympia/compat/templates/compat/reporter_detail.html:25
+#: src/olympia/compat/templates/compat/reporter_detail.html:3 src/olympia/compat/templates/compat/reporter_detail.html:10 src/olympia/compat/templates/compat/reporter_detail.html:25
 msgid "{addon} Compatibility Reports"
 msgstr "{addon} Relatórios de compatibilidade"
 
@@ -4032,8 +3152,7 @@ msgid_plural "{0} problem reports"
 msgstr[0] "{0} relatório com problema"
 msgstr[1] "{0} relatório com problemas"
 
-#: src/olympia/compat/templates/compat/reporter_detail.html:21
-#: src/olympia/users/templates/users/profile.html:70
+#: src/olympia/compat/templates/compat/reporter_detail.html:21 src/olympia/users/templates/users/profile.html:70
 msgid "View all"
 msgstr "Ver todas"
 
@@ -4045,10 +3164,8 @@ msgstr "Filtrar por aplicação"
 msgid "Report Type"
 msgstr "Tipo de relatório"
 
-#: src/olympia/compat/templates/compat/reporter_detail.html:47
-#: src/olympia/devhub/forms.py:784
-#: src/olympia/devhub/templates/devhub/addons/ajax_compat_update.html:17
-#: src/olympia/editors/forms.py:108 src/olympia/zadmin/forms.py:45
+#: src/olympia/compat/templates/compat/reporter_detail.html:47 src/olympia/devhub/forms.py:785 src/olympia/devhub/templates/devhub/addons/ajax_compat_update.html:17 src/olympia/editors/forms.py:108
+#: src/olympia/editors/forms.py:248 src/olympia/zadmin/forms.py:45
 msgid "Application"
 msgstr "Aplicação"
 
@@ -4060,8 +3177,7 @@ msgstr "Versão da aplicação"
 msgid "Platform"
 msgstr "Platform"
 
-#: src/olympia/compat/templates/compat/reporter_detail.html:50
-#: src/olympia/editors/templates/editors/themes/themes.html:40
+#: src/olympia/compat/templates/compat/reporter_detail.html:50 src/olympia/editors/templates/editors/themes/themes.html:40
 msgid "Submitted"
 msgstr "Submetido"
 
@@ -4089,8 +3205,7 @@ msgstr "Thunderbird"
 msgid "SeaMonkey"
 msgstr "SeaMonkey"
 
-#: src/olympia/constants/applications.py:75
-#: src/olympia/pages/templates/pages/sunbird.html:4
+#: src/olympia/constants/applications.py:75 src/olympia/pages/templates/pages/sunbird.html:4
 msgid "Sunbird"
 msgstr "Sunbird"
 
@@ -4139,7 +3254,7 @@ msgid "Preliminarily Reviewed and Awaiting Full Review"
 msgstr "Analisado preliminarmente e aguarda a análise completa"
 
 # 85%
-#: src/olympia/constants/base.py:33 src/olympia/editors/helpers.py:924
+#: src/olympia/constants/base.py:33 src/olympia/editors/forms.py:258 src/olympia/editors/helpers.py:73 src/olympia/editors/helpers.py:1004
 #: src/olympia/editors/templates/editors/themes/history_table.html:34
 msgid "Deleted"
 msgstr "Excluído"
@@ -4173,13 +3288,11 @@ msgstr "Programador"
 msgid "Viewer"
 msgstr "Visualizador"
 
-#: src/olympia/constants/base.py:137
-#: src/olympia/templates/mobile/header.html:7
+#: src/olympia/constants/base.py:137 src/olympia/templates/mobile/header.html:7
 msgid "Support"
 msgstr "Suporte"
 
-#: src/olympia/constants/base.py:159 src/olympia/constants/base.py:172
-#: src/olympia/constants/platforms.py:10
+#: src/olympia/constants/base.py:159 src/olympia/constants/base.py:172 src/olympia/constants/platforms.py:10
 msgid "Any"
 msgstr "Qualquer"
 
@@ -4207,11 +3320,8 @@ msgstr "Pacote de idioma (extra)"
 msgid "Plugin"
 msgstr "Plugin"
 
-#: src/olympia/constants/base.py:167
-#: src/olympia/editors/templates/editors/includes/search_results_themes.html:5
-#: src/olympia/editors/templates/editors/themes/deleted.html:18
-#: src/olympia/editors/templates/editors/themes/history_table.html:8
-#: src/olympia/editors/templates/editors/themes/logs.html:17
+#: src/olympia/constants/base.py:167 src/olympia/editors/templates/editors/includes/search_results_themes.html:5 src/olympia/editors/templates/editors/themes/deleted.html:18
+#: src/olympia/editors/templates/editors/themes/history_table.html:8 src/olympia/editors/templates/editors/themes/logs.html:17
 msgid "Theme"
 msgstr "Tema"
 
@@ -4239,12 +3349,16 @@ msgstr "Pedir apenas na página deste extra e no perfil do programador"
 
 #: src/olympia/constants/base.py:272
 msgid "Ask after users start downloading this add-on"
-msgstr ""
-"Perguntar depois de os utilizadores começarem a descarregar este extra"
+msgstr "Perguntar depois de os utilizadores começarem a descarregar este extra"
 
 #: src/olympia/constants/base.py:273
 msgid "Ask before users can download this add-on"
 msgstr "Perguntar antes que os utilizadores descarreguem este extra"
+
+#. Review points sources other than add-ons and themes.
+#: src/olympia/constants/base.py:388 src/olympia/devhub/forms.py:162 src/olympia/editors/templates/editors/performance.html:75
+msgid "Other"
+msgstr "Outro"
 
 #: src/olympia/constants/base.py:389
 msgid "Exception"
@@ -4257,6 +3371,10 @@ msgstr "Lançamento"
 #: src/olympia/constants/base.py:391
 msgid "Change"
 msgstr "Alterar"
+
+#: src/olympia/constants/base.py:401
+msgid "App"
+msgstr "App"
 
 #: src/olympia/constants/base.py:402
 msgid "Persona"
@@ -4394,32 +3512,23 @@ msgstr "Sinalizado para análise completa"
 msgid "Signed of a preliminary review"
 msgstr "Sinalizado para análise preliminar"
 
-#: src/olympia/constants/editors.py:14
-#: src/olympia/editors/templates/editors/themes/queue.html:76
-#: src/olympia/editors/templates/editors/themes/themes.html:87
+#: src/olympia/constants/editors.py:14 src/olympia/editors/templates/editors/themes/queue.html:76 src/olympia/editors/templates/editors/themes/themes.html:87
 msgid "Request More Info"
 msgstr "Solicitar mais informações"
 
-#: src/olympia/constants/editors.py:15
-#: src/olympia/editors/templates/editors/themes/queue.html:74
-#: src/olympia/editors/templates/editors/themes/themes.html:91
+#: src/olympia/constants/editors.py:15 src/olympia/editors/templates/editors/themes/queue.html:74 src/olympia/editors/templates/editors/themes/themes.html:91
 msgid "Flag"
 msgstr "Sinalizar"
 
-#: src/olympia/constants/editors.py:16
-#: src/olympia/editors/templates/editors/themes/queue.html:72
-#: src/olympia/editors/templates/editors/themes/themes.html:93
+#: src/olympia/constants/editors.py:16 src/olympia/editors/templates/editors/themes/queue.html:72 src/olympia/editors/templates/editors/themes/themes.html:93
 msgid "Duplicate"
 msgstr "Duplicar"
 
-#: src/olympia/constants/editors.py:17 src/olympia/editors/helpers.py:502
-#: src/olympia/editors/templates/editors/themes/queue.html:71
-#: src/olympia/editors/templates/editors/themes/themes.html:94
+#: src/olympia/constants/editors.py:17 src/olympia/editors/helpers.py:575 src/olympia/editors/templates/editors/themes/queue.html:71 src/olympia/editors/templates/editors/themes/themes.html:94
 msgid "Reject"
 msgstr "Rejeitar"
 
-#: src/olympia/constants/editors.py:18
-#: src/olympia/editors/templates/editors/themes/queue.html:70
+#: src/olympia/constants/editors.py:18 src/olympia/editors/templates/editors/themes/queue.html:70
 msgid "Approve"
 msgstr "Aprovar"
 
@@ -4515,7 +3624,7 @@ msgstr "Solaris"
 msgid "Android"
 msgstr "Android"
 
-#: src/olympia/core/apps.py:19
+#: src/olympia/core/apps.py:21
 msgid "Core"
 msgstr "Núcleo"
 
@@ -4552,9 +3661,7 @@ msgstr "Objeto JSON inválido"
 msgid "Message not eligible for annotation"
 msgstr "Mensagem não elegível para anotação"
 
-#: src/olympia/devhub/forms.py:124
-#: src/olympia/devhub/templates/devhub/versions/edit.html:94
-#: src/olympia/users/templates/users/edit.html:150
+#: src/olympia/devhub/forms.py:124 src/olympia/devhub/templates/devhub/versions/edit.html:94 src/olympia/users/templates/users/edit.html:150
 msgid "Details"
 msgstr "Detalhes"
 
@@ -4576,9 +3683,7 @@ msgstr "Este extra tem um acordo de licença para o utilizador final"
 
 #: src/olympia/devhub/forms.py:234
 msgid "Please specify your add-on's End-User License Agreement:"
-msgstr ""
-"Por favor, especifique o acordo de licença para o utilizador final para o "
-"extra:"
+msgstr "Por favor, especifique o acordo de licença para o utilizador final para o extra:"
 
 #: src/olympia/devhub/forms.py:237
 msgid "This add-on has a Privacy Policy"
@@ -4626,8 +3731,7 @@ msgstr "Não foi possível validar o id do PayPal."
 
 #: src/olympia/devhub/forms.py:388
 msgid "Unsupported file type, please upload an archive file {extensions}."
-msgstr ""
-"Tipo de ficheiro não suportado, por favor envie um arquivo {extensions}."
+msgstr "Tipo de ficheiro não suportado, por favor envie um arquivo {extensions}."
 
 #: src/olympia/devhub/forms.py:407
 msgid "View current"
@@ -4654,39 +3758,26 @@ msgid "Submit my add-on for manual review."
 msgstr "Enviar o meu extra para revisão manual."
 
 #: src/olympia/devhub/forms.py:537
-msgid "Do not list my add-on on this site (beta)"
-msgstr "Não listar o meu extra neste site (beta)"
+msgid "Do not list my add-on on this site"
+msgstr ""
 
 #: src/olympia/devhub/forms.py:538
-msgid ""
-"Check this option if you intend to distribute your add-on on your own and "
-"only need it to be signed by Mozilla."
-msgstr ""
-"Marque esta opção se pretender distribuir o seu extra pelos seus próprios "
-"meios e apenas precisa que o mesmo esteja assinado pela Mozilla."
+msgid "Check this option if you intend to distribute your add-on on your own and only need it to be signed by Mozilla."
+msgstr "Marque esta opção se pretender distribuir o seu extra pelos seus próprios meios e apenas precisa que o mesmo esteja assinado pela Mozilla."
 
 #: src/olympia/devhub/forms.py:544
 msgid "This add-on will be bundled with an application installer."
 msgstr "Este extra será incorporado com um instalador de aplicação."
 
 #: src/olympia/devhub/forms.py:546
-msgid ""
-"Add-ons that are bundled with application installers will be code reviewed "
-"by Mozilla before they are signed and are held to a higher quality standard."
-msgstr ""
-"Os extras que são incorporados com instaladores de aplicações terão o código"
-" revisto pela Mozilla antes de serem assinados e são acompanhados de um "
-"padrão de qualidade superior."
+msgid "Add-ons that are bundled with application installers will be code reviewed by Mozilla before they are signed and are held to a higher quality standard."
+msgstr "Os extras que são incorporados com instaladores de aplicações terão o código revisto pela Mozilla antes de serem assinados e são acompanhados de um padrão de qualidade superior."
 
-#: src/olympia/devhub/forms.py:565
-#: src/olympia/devhub/templates/devhub/addons/submit/select-review.html:24
-#: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:42
+#: src/olympia/devhub/forms.py:565 src/olympia/devhub/templates/devhub/addons/submit/select-review.html:24 src/olympia/devhub/templates/devhub/docs/policies-reviews.html:42
 msgid "Full Review"
 msgstr "Revisão completa"
 
-#: src/olympia/devhub/forms.py:566
-#: src/olympia/devhub/templates/devhub/addons/submit/select-review.html:47
-#: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:153
+#: src/olympia/devhub/forms.py:566 src/olympia/devhub/templates/devhub/addons/submit/select-review.html:47 src/olympia/devhub/templates/devhub/docs/policies-reviews.html:153
 msgid "Preliminary Review"
 msgstr "Revisão preliminar"
 
@@ -4695,67 +3786,51 @@ msgid "Please choose a review nomination type"
 msgstr "Por favor, escolha um tipo de nomeação para a revisão"
 
 #: src/olympia/devhub/forms.py:574
-msgid ""
-"A file with a version ending with a|alpha|b|beta|pre|rc and an optional "
-"number is detected as beta."
-msgstr ""
-"Um ficheiro com uma versão terminada com a|alpha|b|beta|pre|rc e com um "
-"número opcional, é detetada como beta."
+msgid "A file with a version ending with a|alpha|b|beta|pre|rc and an optional number is detected as beta."
+msgstr "Um ficheiro com uma versão terminada com a|alpha|b|beta|pre|rc e com um número opcional, é detetada como beta."
 
 #: src/olympia/devhub/forms.py:592
 #, python-format
-msgid "Version %s already exists"
-msgstr "A versão %s já existe"
-
-#: src/olympia/devhub/forms.py:604
-msgid ""
-"Select a valid choice. That choice is not one of the available choices."
+msgid "Version %s already exists, or was uploaded before."
 msgstr ""
-"Escolha uma opção válida. Essa escolha não é uma das escolhas disponíveis."
 
-#: src/olympia/devhub/forms.py:610
-msgid ""
-"A file with a version ending with a|alpha|b|beta and an optional number is "
-"detected as beta."
-msgstr ""
-"Um ficheiro com uma versão que termine com a|alpha|b|beta e um número "
-"opcional é detetado como beta."
+#: src/olympia/devhub/forms.py:605
+msgid "Select a valid choice. That choice is not one of the available choices."
+msgstr "Escolha uma opção válida. Essa escolha não é uma das escolhas disponíveis."
 
-#: src/olympia/devhub/forms.py:633
+#: src/olympia/devhub/forms.py:611
+msgid "A file with a version ending with a|alpha|b|beta and an optional number is detected as beta."
+msgstr "Um ficheiro com uma versão que termine com a|alpha|b|beta e um número opcional é detetado como beta."
+
+#: src/olympia/devhub/forms.py:634
 msgid "You cannot upload any more files for this version."
 msgstr "Não pode carregar mais ficheiros para esta versão."
 
-#: src/olympia/devhub/forms.py:639
+#: src/olympia/devhub/forms.py:640
 msgid "Version doesn't match"
 msgstr "A versão não corresponde."
 
-#: src/olympia/devhub/forms.py:668
-msgid ""
-"You cannot delete a file once the review process has started.  You must "
-"delete the whole version."
+#: src/olympia/devhub/forms.py:669
+msgid "You cannot delete a file once the review process has started.  You must delete the whole version."
 msgstr ""
-"Não pode eliminar um ficheiro depois do processo de revisão começar. Deve "
-"eliminar completamente a versão."
 
-#: src/olympia/devhub/forms.py:688
+#: src/olympia/devhub/forms.py:689
 msgid "The platform All cannot be combined with specific platforms."
-msgstr ""
-"A plataforma todos não pode ser combinada com plataformas específicas."
+msgstr "A plataforma todos não pode ser combinada com plataformas específicas."
 
-#: src/olympia/devhub/forms.py:693
+#: src/olympia/devhub/forms.py:694
 msgid "A platform can only be chosen once."
 msgstr "Apenas pode escolher a plataforma uma vez."
 
-#: src/olympia/devhub/forms.py:706
+#: src/olympia/devhub/forms.py:707
 msgid "A review type must be selected."
 msgstr "Tem de ser selecionado um tipo de comentário."
 
-#: src/olympia/devhub/forms.py:788 src/olympia/editors/forms.py:114
-#: src/olympia/zadmin/forms.py:49 src/olympia/zadmin/forms.py:52
+#: src/olympia/devhub/forms.py:789 src/olympia/editors/forms.py:114 src/olympia/editors/forms.py:254 src/olympia/zadmin/forms.py:49 src/olympia/zadmin/forms.py:52
 msgid "Select an application first"
 msgstr "Primeiro selecione uma aplicação"
 
-#: src/olympia/devhub/forms.py:840
+#: src/olympia/devhub/forms.py:841
 msgid "There cannot be more than 3 required add-ons."
 msgstr "Não pode haver mais do que 3 extras pedidos."
 
@@ -4785,89 +3860,80 @@ msgid_plural "{0} warnings"
 msgstr[0] "{0} aviso"
 msgstr[1] "{0} avisos"
 
-#: src/olympia/devhub/models.py:375
-#: src/olympia/reviews/templates/reviews/add.html:58
+#: src/olympia/devhub/models.py:375 src/olympia/reviews/templates/reviews/add.html:58
 msgid "Review"
 msgstr "Comentário"
 
-#: src/olympia/devhub/tasks.py:551
+#: src/olympia/devhub/tasks.py:583
 #, python-format
 msgid "%s responded with %s (%s)."
 msgstr "%s respondeu com %s (%s)."
 
-#: src/olympia/devhub/tasks.py:555
+#: src/olympia/devhub/tasks.py:587
 #, python-format
 msgid "Connection to \"%s\" timed out."
 msgstr "A ligação a \"%s\" expirou."
 
-#: src/olympia/devhub/tasks.py:557
+#: src/olympia/devhub/tasks.py:589
 #, python-format
 msgid "Could not contact host at \"%s\"."
 msgstr "Não foi possível contactar o servidor em  \"%s\" ."
 
-#: src/olympia/devhub/utils.py:104
+#: src/olympia/devhub/utils.py:105
 #, python-format
-msgid ""
-"Validation generated too many errors/warnings so %s messages were truncated."
-" After addressing the visible messages, you'll be able to see the others."
-msgstr ""
-"A validação gerou muitos erros/alertas então %s mensagens foram truncadas. "
-"Após corrigir as mensagens visíveis, poderá ver as outras."
+msgid "Validation generated too many errors/warnings so %s messages were truncated. After addressing the visible messages, you'll be able to see the others."
+msgstr "A validação gerou muitos erros/alertas então %s mensagens foram truncadas. Após corrigir as mensagens visíveis, poderá ver as outras."
 
-#: src/olympia/devhub/views.py:183
+#: src/olympia/devhub/views.py:181
 msgid "All My Add-ons"
 msgstr "Todos os meus extras"
 
-#: src/olympia/devhub/views.py:210
+#: src/olympia/devhub/views.py:208
 msgid "All Activity"
 msgstr "Toda a actividade"
 
-#: src/olympia/devhub/views.py:211
+#: src/olympia/devhub/views.py:209
 msgid "Add-on Updates"
 msgstr "Atualizações do extra"
 
-#: src/olympia/devhub/views.py:212
+#: src/olympia/devhub/views.py:210
 msgid "Add-on Status"
 msgstr "Estado do extra"
 
-#: src/olympia/devhub/views.py:213
+#: src/olympia/devhub/views.py:211
 msgid "User Collections"
 msgstr "Coleções do utilizador"
 
-#: src/olympia/devhub/views.py:214
-#: src/olympia/devhub/templates/devhub/docs/policies-maintenance.html:68
-#: src/olympia/pages/templates/pages/dev_faq.html:38
+#: src/olympia/devhub/views.py:212 src/olympia/devhub/templates/devhub/docs/policies-maintenance.html:68 src/olympia/pages/templates/pages/dev_faq.html:38
 #: src/olympia/pages/templates/pages/dev_faq.html:484
 msgid "User Reviews"
 msgstr "Comentários do utilizador"
 
-#: src/olympia/devhub/views.py:327 src/olympia/devhub/views.py:331
-#: src/olympia/devhub/views.py:484 src/olympia/devhub/views.py:513
-#: src/olympia/devhub/views.py:564 src/olympia/devhub/views.py:1150
+#: src/olympia/devhub/views.py:325 src/olympia/devhub/views.py:329 src/olympia/devhub/views.py:484 src/olympia/devhub/views.py:513 src/olympia/devhub/views.py:564 src/olympia/devhub/views.py:1156
 msgid "Changes successfully saved."
 msgstr "Alterações guardadas com sucesso."
 
-#: src/olympia/devhub/views.py:334 src/olympia/devhub/views.py:1631
+#: src/olympia/devhub/views.py:332 src/olympia/devhub/views.py:1637
 msgid "Please check the form for errors."
 msgstr "Por favor, verifique se o formulário tem erros."
 
-#: src/olympia/devhub/views.py:346
+#: src/olympia/devhub/views.py:344
 msgid "Add-on cannot be deleted. Disable this add-on instead."
 msgstr "O extra não pode ser eliminado. Em alternativa desativar este extra."
 
-#: src/olympia/devhub/views.py:356
+#: src/olympia/devhub/views.py:354
 msgid "Theme deleted."
 msgstr "Tema eliminado."
 
-#: src/olympia/devhub/views.py:356
+#: src/olympia/devhub/views.py:354
 msgid "Add-on deleted."
 msgstr "Extra eliminado."
 
-#: src/olympia/devhub/views.py:362
+#: src/olympia/devhub/views.py:360
 msgid "URL name was incorrect. Theme was not deleted."
 msgstr "O nome de URL estava incorreto. O tema não foi eliminado."
 
-#: src/olympia/devhub/views.py:367
+#: src/olympia/devhub/views.py:365
 msgid "URL name was incorrect. Add-on was not deleted."
 msgstr "O nome de URL estava incorreto. O extra não foi eliminado."
 
@@ -4895,7 +3961,7 @@ msgstr "Validar extra"
 msgid "Check Add-on Compatibility"
 msgstr "Verifique a compatibilidade do extra"
 
-#: src/olympia/devhub/views.py:808 src/olympia/signing/views.py:90
+#: src/olympia/devhub/views.py:808 src/olympia/signing/views.py:95
 msgid "You cannot submit this type of add-on"
 msgstr "Não pode submeter este tipo de extras"
 
@@ -4919,61 +3985,46 @@ msgstr "As imagens não podem ser maiores que %dKB."
 #. L10n: {0} is an image width (in pixels), {1} is a height.
 #: src/olympia/devhub/views.py:1080
 msgid "Image must be exactly {0} pixels wide and {1} pixels tall."
-msgstr ""
-"A imagem tem de ter exactamente {0} pixéis de largura e {1} pixéis de "
-"altura."
+msgstr "A imagem tem de ter exactamente {0} pixéis de largura e {1} pixéis de altura."
 
 #: src/olympia/devhub/views.py:1087
 msgid "There was an error uploading your preview."
 msgstr "Houve um erro ao carregar a sua pré-visualização."
 
-#: src/olympia/devhub/views.py:1189
+#: src/olympia/devhub/views.py:1195
 #, python-format
 msgid "Version %s disabled."
 msgstr "Versão %s desativada."
 
-#: src/olympia/devhub/views.py:1193
+#: src/olympia/devhub/views.py:1199
 #, python-format
 msgid "Version %s deleted."
 msgstr "Versão %s eliminado."
 
-#: src/olympia/devhub/views.py:1203
-msgid ""
-"This upload has failed validation, and may lack complete validation results."
-" Please take due care when reviewing it."
-msgstr ""
-"Este envio falhou a validação e pode não ter os resultados completos da "
-"validação. Por favor tenha atenção na sua revisão."
+#: src/olympia/devhub/views.py:1209
+msgid "This upload has failed validation, and may lack complete validation results. Please take due care when reviewing it."
+msgstr "Este envio falhou a validação e pode não ter os resultados completos da validação. Por favor tenha atenção na sua revisão."
 
-#: src/olympia/devhub/views.py:1677
+#: src/olympia/devhub/views.py:1683
 msgid "Preliminary Review Requested."
 msgstr "Revisão preliminar pedida."
 
-#: src/olympia/devhub/views.py:1678
+#: src/olympia/devhub/views.py:1684
 msgid "Full Review Requested."
 msgstr "Revisão completa pedida."
 
-#: src/olympia/devhub/views.py:1779
-msgid ""
-"Your old credentials were revoked and are no longer valid. Be sure to update"
-" all API clients with the new credentials."
-msgstr ""
-"As suas credenciais antigas foram revogadas e já não são válidas. Atualize "
-"todos os clientes da API com as novas credenciais."
+#: src/olympia/devhub/views.py:1783
+msgid "Your old credentials were revoked and are no longer valid. Be sure to update all API clients with the new credentials."
+msgstr "As suas credenciais antigas foram revogadas e já não são válidas. Atualize todos os clientes da API com as novas credenciais."
 
-#: src/olympia/devhub/views.py:1797
+#: src/olympia/devhub/views.py:1801
 msgid "New API key created"
 msgstr "Nova chave de API criada"
 
 #: src/olympia/devhub/templates/devhub/agreement.html:2
-msgid ""
-"Before starting, please read and accept our Firefox Add-on Distribution "
-"Agreement. It also links to our Privacy Notice which explains how we handle "
-"your information."
+msgid "Before starting, please read and accept our Firefox Add-on Distribution Agreement. It also links to our Privacy Notice which explains how we handle your information."
 msgstr ""
-"Antes de começar, por favor leia e aceite o nosso acordo de distribuição de "
-"extras do Firefox. Também tem uma ligação para a nossa Política de "
-"Privacidade que explica como gerimos a sua informação."
+"Antes de começar, por favor leia e aceite o nosso acordo de distribuição de extras do Firefox. Também tem uma ligação para a nossa Política de Privacidade que explica como gerimos a sua informação."
 
 #: src/olympia/devhub/templates/devhub/agreement.html:13
 msgid "Printable Version"
@@ -4987,44 +4038,30 @@ msgstr "Eu aceito este acordo"
 msgid "or <a href=\"{0}\">Cancel</a>"
 msgstr "ou <a href=\"{0}\">Cancelar</a>"
 
-#: src/olympia/devhub/templates/devhub/base.html:23
-#: src/olympia/devhub/templates/devhub/base_impala.html:20
-#: src/olympia/discovery/templates/discovery/addons/base.html:17
+#: src/olympia/devhub/templates/devhub/base.html:23 src/olympia/devhub/templates/devhub/base_impala.html:20 src/olympia/discovery/templates/discovery/addons/base.html:17
 msgid "Back to Add-ons"
 msgstr "Voltar aos extras"
 
 #. {0} is a search term, such as Firebug.
 #. {0} is a search query.
-#: src/olympia/devhub/templates/devhub/devhub_search.html:4
-#: src/olympia/search/templates/search/results.html:9
-#: src/olympia/search/templates/search/mobile/results.html:6
+#: src/olympia/devhub/templates/devhub/devhub_search.html:4 src/olympia/search/templates/search/results.html:9 src/olympia/search/templates/search/mobile/results.html:6
 msgid "{0} :: Search"
 msgstr "{0} :: Pesquisar"
 
-#: src/olympia/devhub/templates/devhub/devhub_search.html:6
-#: src/olympia/devhub/templates/devhub/search.html:8
-#: src/olympia/editors/forms.py:435 src/olympia/editors/forms.py:437
-#: src/olympia/editors/templates/editors/queue.html:27
-#: src/olympia/editors/templates/editors/themes/queue_list.html:14
-#: src/olympia/search/templates/search/collections.html:17
-#: src/olympia/search/templates/search/personas.html:18
-#: src/olympia/search/templates/search/results.html:18
-#: src/olympia/search/templates/search/mobile/results.html:8
-#: src/olympia/templates/search.html:14
-#: src/olympia/templates/impala/search.html:18
+#: src/olympia/devhub/templates/devhub/devhub_search.html:6 src/olympia/devhub/templates/devhub/search.html:8 src/olympia/editors/forms.py:534 src/olympia/editors/forms.py:536
+#: src/olympia/editors/templates/editors/queue.html:27 src/olympia/editors/templates/editors/themes/queue_list.html:14 src/olympia/search/templates/search/collections.html:17
+#: src/olympia/search/templates/search/personas.html:18 src/olympia/search/templates/search/results.html:18 src/olympia/search/templates/search/mobile/results.html:8
+#: src/olympia/templates/search.html:14 src/olympia/templates/impala/search.html:18
 msgid "Search"
 msgstr "Pesquisar"
 
-#: src/olympia/devhub/templates/devhub/devhub_search.html:11
-#: src/olympia/devhub/templates/devhub/devhub_search.html:15
-#: src/olympia/search/templates/search/collections.html:18
+#: src/olympia/devhub/templates/devhub/devhub_search.html:11 src/olympia/devhub/templates/devhub/devhub_search.html:15 src/olympia/search/templates/search/collections.html:18
 #: src/olympia/search/templates/search/personas.html:20
 msgid "Search Results"
 msgstr "Resultados da pesquisa"
 
 #. {0} is a search term, such as Firebug.
-#: src/olympia/devhub/templates/devhub/devhub_search.html:13
-#: src/olympia/search/templates/search/results.html:11
+#: src/olympia/devhub/templates/devhub/devhub_search.html:13 src/olympia/search/templates/search/results.html:11
 msgid "Search Results for \"{0}\""
 msgstr "Resultados da pesquisa para \"{0}\""
 
@@ -5045,12 +4082,8 @@ msgid "AMO Reviewers"
 msgstr "Revisores AMO"
 
 #: src/olympia/devhub/templates/devhub/index.html:29
-msgid ""
-"Get ahead! Become an AMO Reviewer today and get your add-ons reviewed "
-"faster."
-msgstr ""
-"Força! Torne-se um revisor AMO hoje e tenha os seus extras revistos mais "
-"depressa."
+msgid "Get ahead! Become an AMO Reviewer today and get your add-ons reviewed faster."
+msgstr "Força! Torne-se um revisor AMO hoje e tenha os seus extras revistos mais depressa."
 
 #: src/olympia/devhub/templates/devhub/index.html:32
 msgid "Become an AMO Reviewer"
@@ -5062,42 +4095,28 @@ msgstr "Saber tudo sobre extras"
 
 #: src/olympia/devhub/templates/devhub/index.html:41
 msgid ""
-"Add-ons let millions of Firefox users enhance and customize their browsing "
-"experience. If you're a Web developer and know <a "
-"href=\"https://developer.mozilla.org/docs/Web/HTML\">HTML</a>, <a "
-"href=\"https://developer.mozilla.org/docs/Web/JavaScript\">JavaScript</a>, "
-"and <a href=\"https://developer.mozilla.org/docs/Web/CSS\">CSS</a>, you "
-"already have all the necessary skills to make a great add-on."
+"Add-ons let millions of Firefox users enhance and customize their browsing experience. If you're a Web developer and know <a href=\"https://developer.mozilla.org/docs/Web/HTML\">HTML</a>, <a href="
+"\"https://developer.mozilla.org/docs/Web/JavaScript\">JavaScript</a>, and <a href=\"https://developer.mozilla.org/docs/Web/CSS\">CSS</a>, you already have all the necessary skills to make a great "
+"add-on."
 msgstr ""
-"Os extras permitem que milhões de utilizadores do Firefox melhorem e "
-"personalizem a sua experiência de navegação. Se é um programador web e sabe "
-"<a href=\"https://developer.mozilla.org/docs/Web/HTML\">HTML</a>, <a "
-"href=\"https://developer.mozilla.org/docs/Web/JavaScript\">JavaScript</a> e "
-"<a href=\"https://developer.mozilla.org/docs/Web/CSS\">CSS</a>, então já tem"
-" todas as capacidades necessárias para fazer um ótimo extra."
+"Os extras permitem que milhões de utilizadores do Firefox melhorem e personalizem a sua experiência de navegação. Se é um programador web e sabe <a href=\"https://developer.mozilla.org/docs/Web/HTML"
+"\">HTML</a>, <a href=\"https://developer.mozilla.org/docs/Web/JavaScript\">JavaScript</a> e <a href=\"https://developer.mozilla.org/docs/Web/CSS\">CSS</a>, então já tem todas as capacidades "
+"necessárias para fazer um ótimo extra."
 
 #: src/olympia/devhub/templates/devhub/index.html:51
-msgid ""
-"Head over to the <a href=\"https://developer.mozilla.org/Add-ons\">Mozilla "
-"Developer Network</a> to learn everything you need to know to get started."
-msgstr ""
-"Visite a <a href=\"https://developer.mozilla.org/Add-ons\">Rede de "
-"Programadores da Mozilla</a> para aprender tudo o que precisa de saber para "
-"começar."
+msgid "Head over to the <a href=\"https://developer.mozilla.org/Add-ons\">Mozilla Developer Network</a> to learn everything you need to know to get started."
+msgstr "Visite a <a href=\"https://developer.mozilla.org/Add-ons\">Rede de Programadores da Mozilla</a> para aprender tudo o que precisa de saber para começar."
 
 #: src/olympia/devhub/templates/devhub/index.html:58
 msgid "Start Making Add-ons"
 msgstr "Começar a fazer extras"
 
-#: src/olympia/devhub/templates/devhub/index.html:86
-#: src/olympia/devhub/templates/devhub/addons/listing/items.html:25
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:15
+#: src/olympia/devhub/templates/devhub/index.html:86 src/olympia/devhub/templates/devhub/addons/listing/items.html:25 src/olympia/devhub/templates/devhub/includes/addon_details.html:20
 #: src/olympia/devhub/templates/devhub/personas/edit.html:43
 msgid "Status:"
 msgstr "Estado:"
 
-#: src/olympia/devhub/templates/devhub/index.html:90
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:100
+#: src/olympia/devhub/templates/devhub/index.html:90 src/olympia/devhub/templates/devhub/includes/addon_details.html:87
 msgid "Visibility:"
 msgstr "Visibilidade:"
 
@@ -5105,22 +4124,17 @@ msgstr "Visibilidade:"
 msgid "Latest Version:"
 msgstr "Versão mais recente:"
 
-#: src/olympia/devhub/templates/devhub/index.html:109
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:145
-#: src/olympia/devhub/templates/devhub/personas/edit.html:49
+#: src/olympia/devhub/templates/devhub/index.html:109 src/olympia/devhub/templates/devhub/includes/addon_details.html:131 src/olympia/devhub/templates/devhub/personas/edit.html:49
 msgid "Queue Position:"
 msgstr "Posição na fila:"
 
-#: src/olympia/devhub/templates/devhub/index.html:110
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:146
-#: src/olympia/devhub/templates/devhub/personas/edit.html:50
+#: src/olympia/devhub/templates/devhub/index.html:110 src/olympia/devhub/templates/devhub/includes/addon_details.html:132 src/olympia/devhub/templates/devhub/personas/edit.html:50
 #, python-format
 msgid "%(position)s of %(total)s"
 msgstr "%(position)s de %(total)s"
 
 # 90%
-#: src/olympia/devhub/templates/devhub/index.html:120
-#: src/olympia/devhub/templates/devhub/includes/addons_edit_nav.html:19
+#: src/olympia/devhub/templates/devhub/index.html:120 src/olympia/devhub/templates/devhub/includes/addons_edit_nav.html:19
 msgid "Upload New Version"
 msgstr "Carregar Versão Nova"
 
@@ -5134,12 +4148,8 @@ msgstr "Publicar os seus extras!"
 
 #: src/olympia/devhub/templates/devhub/index.html:136
 #, python-format
-msgid ""
-"Upload an <a href=\"%(addon_url)s\">add-on</a> or <a "
-"href=\"%(theme_url)s\">theme</a> to get started!"
-msgstr ""
-"Envie um <a href=\"%(addon_url)s\">extra</a> ou um <a "
-"href=\"%(theme_url)s\">tema</a> para começar!"
+msgid "Upload an <a href=\"%(addon_url)s\">add-on</a> or <a href=\"%(theme_url)s\">theme</a> to get started!"
+msgstr "Envie um <a href=\"%(addon_url)s\">extra</a> ou um <a href=\"%(theme_url)s\">tema</a> para começar!"
 
 #: src/olympia/devhub/templates/devhub/nav.html:2
 msgid "Return to the DevHub homepage"
@@ -5166,17 +4176,10 @@ msgstr "Desenvolvimento de extensões"
 msgid "Lightweight Themes"
 msgstr "Temas leves"
 
-#: src/olympia/devhub/templates/devhub/nav.html:39
-#: src/olympia/devhub/templates/devhub/docs/policies-agreement.html:6
-#: src/olympia/devhub/templates/devhub/docs/policies-contact.html:6
-#: src/olympia/devhub/templates/devhub/docs/policies-maintenance.html:6
-#: src/olympia/devhub/templates/devhub/docs/policies-recommended.html:6
-#: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:6
-#: src/olympia/devhub/templates/devhub/docs/policies-submission.html:6
-#: src/olympia/devhub/templates/devhub/docs/policies.html:3
-#: src/olympia/devhub/templates/devhub/docs/policies.html:9
-#: src/olympia/devhub/templates/devhub/docs/policies.html:38
-#: src/olympia/devhub/templates/devhub/docs/policies.html:39
+#: src/olympia/devhub/templates/devhub/nav.html:39 src/olympia/devhub/templates/devhub/docs/policies-agreement.html:6 src/olympia/devhub/templates/devhub/docs/policies-contact.html:6
+#: src/olympia/devhub/templates/devhub/docs/policies-maintenance.html:6 src/olympia/devhub/templates/devhub/docs/policies-recommended.html:6
+#: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:6 src/olympia/devhub/templates/devhub/docs/policies-submission.html:6 src/olympia/devhub/templates/devhub/docs/policies.html:3
+#: src/olympia/devhub/templates/devhub/docs/policies.html:9 src/olympia/devhub/templates/devhub/docs/policies.html:38 src/olympia/devhub/templates/devhub/docs/policies.html:39
 msgid "Add-on Policies"
 msgstr "Políticas do extra"
 
@@ -5217,46 +4220,16 @@ msgid "Use the field below to upload your add-on package."
 msgstr "Use o campo em baixo para carregar o seu pacote do extra."
 
 #: src/olympia/devhub/templates/devhub/validate_addon.html:19
-msgid ""
-"After upload, a series of automated validation tests will run to check "
-"compatibility with the following application version:"
-msgstr ""
-"Depois de carregar, uma série de testes de validação automáticos serão "
-"executados para verificar a compatibilidade com a seguinte versão da "
-"aplicação:"
+msgid "After upload, a series of automated validation tests will run to check compatibility with the following application version:"
+msgstr "Depois de carregar, uma série de testes de validação automáticos serão executados para verificar a compatibilidade com a seguinte versão da aplicação:"
 
 #: src/olympia/devhub/templates/devhub/validate_addon.html:34
-msgid ""
-"After upload, a series of automated validation tests will be run on your "
-"file."
-msgstr ""
-"Depois de carregar, uma série de testes de validação automáticos serão "
-"executados no seu ficheiro."
+msgid "After upload, a series of automated validation tests will be run on your file."
+msgstr "Depois de carregar, uma série de testes de validação automáticos serão executados no seu ficheiro."
 
-#: src/olympia/devhub/templates/devhub/validate_addon.html:42
-#: src/olympia/devhub/templates/devhub/addons/submit/upload.html:23
+#: src/olympia/devhub/templates/devhub/validate_addon.html:42 src/olympia/devhub/templates/devhub/addons/submit/upload.html:23
 msgid "Do you want your add-on to be distributed on this site?"
 msgstr "Gostaria que o seu extra fosse distribuído neste site?"
-
-#: src/olympia/devhub/templates/devhub/validate_addon.html:49
-#: src/olympia/devhub/templates/devhub/addons/submit/upload.html:30
-#: src/olympia/devhub/templates/devhub/versions/add_file_modal.html:14
-#: src/olympia/devhub/templates/devhub/versions/add_file_modal.html:53
-#: src/olympia/devhub/templates/devhub/versions/list.html:298
-msgid "Warning:"
-msgstr "Aviso:"
-
-#: src/olympia/devhub/templates/devhub/validate_addon.html:50
-#: src/olympia/devhub/templates/devhub/addons/submit/upload.html:31
-#, python-format
-msgid ""
-"Submission of unlisted add-ons for signing is currently in an open beta. "
-"Please <a href=\"%(url)s\" target=\"_blank\">report any bugs</a> that you "
-"encounter."
-msgstr ""
-"A submissão de extras não listados para assinatura está atualmente numa beta"
-" aberta. Por favor <a href=\"%(url)s\" target=\"_blank\">reporte quaisquer "
-"bugs</a> que encontre."
 
 #. first parameter is a filename like lorem-ipsum-1.0.2.xpi
 #: src/olympia/devhub/templates/devhub/validation.html:5
@@ -5275,14 +4248,11 @@ msgstr "Validado a:"
 msgid "Tested for compatibility against:"
 msgstr "Testado para compatibilidade contra:"
 
-#: src/olympia/devhub/templates/devhub/addons/activity.html:4
-#: src/olympia/devhub/templates/devhub/addons/activity.html:20
+#: src/olympia/devhub/templates/devhub/addons/activity.html:4 src/olympia/devhub/templates/devhub/addons/activity.html:20
 msgid "Recent Activity for My Add-ons"
 msgstr "Atividade recente para os meus extras"
 
-#: src/olympia/devhub/templates/devhub/addons/activity.html:14
-#: src/olympia/devhub/templates/devhub/addons/activity.html:19
-#: src/olympia/devhub/templates/devhub/addons/dashboard.html:33
+#: src/olympia/devhub/templates/devhub/addons/activity.html:14 src/olympia/devhub/templates/devhub/addons/activity.html:19 src/olympia/devhub/templates/devhub/addons/dashboard.html:33
 msgid "Recent Activity"
 msgstr "Atividade recente"
 
@@ -5304,44 +4274,34 @@ msgstr "Refinar atividade"
 msgid "Activity"
 msgstr "Atividade"
 
-#: src/olympia/devhub/templates/devhub/addons/activity.html:83
-#: src/olympia/devhub/templates/devhub/addons/dashboard.html:34
-#: src/olympia/devhub/templates/devhub/addons/dashboard.html:35
-#: src/olympia/devhub/templates/devhub/includes/blog_posts.html:4
-#: src/olympia/devhub/templates/devhub/includes/blog_posts.html:6
+#: src/olympia/devhub/templates/devhub/addons/activity.html:83 src/olympia/devhub/templates/devhub/addons/dashboard.html:34 src/olympia/devhub/templates/devhub/addons/dashboard.html:35
+#: src/olympia/devhub/templates/devhub/includes/blog_posts.html:4 src/olympia/devhub/templates/devhub/includes/blog_posts.html:6
 msgid "Subscribe to this feed"
 msgstr "Subscrever esta fonte"
 
 #: src/olympia/devhub/templates/devhub/addons/ajax_compat_error.html:7
 #, python-format
 msgid ""
-"This add-on is incompatible with <b>%(app_name)s %(app_version)s</b>, the "
-"latest release of %(app_name)s. Please consider updating your add-on's "
-"compatibility info, or uploading a newer version of this add-on."
+"This add-on is incompatible with <b>%(app_name)s %(app_version)s</b>, the latest release of %(app_name)s. Please consider updating your add-on's compatibility info, or uploading a newer version of "
+"this add-on."
 msgstr ""
-"Este extra é incompatível com <b>%(app_name)s %(app_version)s</b>, a última "
-"versão do %(app_name)s. Por favor, considere em atualizar a info de "
-"compatibilidade do seu extra, ou carregue uma nova versão."
+"Este extra é incompatível com <b>%(app_name)s %(app_version)s</b>, a última versão do %(app_name)s. Por favor, considere em atualizar a info de compatibilidade do seu extra, ou carregue uma nova "
+"versão."
 
 #: src/olympia/devhub/templates/devhub/addons/ajax_compat_error.html:15
 #, python-format
 msgid ""
-"<a href=\"#\" class=\"button compat-update\" data-"
-"updateurl=\"%(update_url)s\">Update Compatibility</a> <a "
-"href=\"%(version_url)s\" class=\"button\">Upload New Version</a> or <a "
-"href=\"#\" class=\"close\">Ignore</a>"
+"<a href=\"#\" class=\"button compat-update\" data-updateurl=\"%(update_url)s\">Update Compatibility</a> <a href=\"%(version_url)s\" class=\"button\">Upload New Version</a> or <a href=\"#\" class="
+"\"close\">Ignore</a>"
 msgstr ""
-"<a href=\"#\" class=\"button compat-update\" data-"
-"updateurl=\"%(update_url)s\">Atualização de compatibilidade</a> <a "
-"href=\"%(version_url)s\" class=\"button\">Carregar nova versão</a> ou <a "
-"href=\"#\" class=\"close\">Ignorar</a>"
+"<a href=\"#\" class=\"button compat-update\" data-updateurl=\"%(update_url)s\">Atualização de compatibilidade</a> <a href=\"%(version_url)s\" class=\"button\">Carregar nova versão</a> ou <a href=\"#"
+"\" class=\"close\">Ignorar</a>"
 
 #: src/olympia/devhub/templates/devhub/addons/ajax_compat_status.html:5
 msgid "View and update application compatibility ranges."
 msgstr "Ver e atualizar o intervalo de compatibilidade da aplicação."
 
-#: src/olympia/devhub/templates/devhub/addons/ajax_compat_status.html:6
-#: src/olympia/devhub/templates/devhub/versions/edit.html:44
+#: src/olympia/devhub/templates/devhub/addons/ajax_compat_status.html:6 src/olympia/devhub/templates/devhub/versions/edit.html:44
 msgid "Compatibility"
 msgstr "Compatibilidade"
 
@@ -5349,39 +4309,25 @@ msgstr "Compatibilidade"
 msgid "Update Compatibility"
 msgstr "Atualizar compatibilidade"
 
-#: src/olympia/devhub/templates/devhub/addons/ajax_compat_update.html:4
-msgid ""
-"Adjusting application information here will allow users to install your add-"
-"on even if the install manifest in the package indicates that the add-on is "
-"incompatible."
-msgstr ""
-"Ajustar aqui a informação da aplicação permite aos utilizadores instalar o "
-"seu extra mesmo que o manifesto de instalação do pacote indique que o extra "
-"é incompatível."
+#: src/olympia/devhub/templates/devhub/addons/ajax_compat_update.html:4 src/olympia/devhub/templates/devhub/versions/edit.html:45
+msgid "Adjusting application information here will allow users to install your add-on even if the install manifest in the package indicates that the add-on is incompatible."
+msgstr "Ajustar aqui a informação da aplicação permite aos utilizadores instalar o seu extra mesmo que o manifesto de instalação do pacote indique que o extra é incompatível."
 
 #: src/olympia/devhub/templates/devhub/addons/ajax_compat_update.html:18
 msgid "Supported Versions"
 msgstr "Versões suportadas"
 
-#: src/olympia/devhub/templates/devhub/addons/ajax_compat_update.html:31
-#: src/olympia/devhub/templates/devhub/versions/edit.html:63
+#: src/olympia/devhub/templates/devhub/addons/ajax_compat_update.html:31 src/olympia/devhub/templates/devhub/versions/edit.html:63
 msgid "Add Another Application&hellip;"
 msgstr "Adicionar outra aplicação&hellip;"
 
-#: src/olympia/devhub/templates/devhub/addons/ajax_compat_update.html:38
-#: src/olympia/devhub/templates/devhub/addons/owner.html:86
-#: src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:46
-#: src/olympia/devhub/templates/devhub/versions/list.html:351
-#: src/olympia/devhub/templates/devhub/versions/list.html:353
-#: src/olympia/templates/impala/base.html:132
-#: src/olympia/templates/impala/base.html:143
-#: src/olympia/templates/impala/base.html:161
-#: src/olympia/templates/impala/base.html:171
+#: src/olympia/devhub/templates/devhub/addons/ajax_compat_update.html:38 src/olympia/devhub/templates/devhub/addons/owner.html:86 src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:45
+#: src/olympia/devhub/templates/devhub/versions/list.html:349 src/olympia/devhub/templates/devhub/versions/list.html:351 src/olympia/templates/impala/base.html:129
+#: src/olympia/templates/impala/base.html:140 src/olympia/templates/impala/base.html:158 src/olympia/templates/impala/base.html:168
 msgid "Close"
 msgstr "Fechar"
 
-#: src/olympia/devhub/templates/devhub/addons/dashboard.html:43
-#: src/olympia/zadmin/templates/zadmin/index.html:22
+#: src/olympia/devhub/templates/devhub/addons/dashboard.html:43 src/olympia/zadmin/templates/zadmin/index.html:22
 #, python-format
 msgid "%(ago)s by %(user)s"
 msgstr "%(ago)s por %(user)s"
@@ -5397,29 +4343,21 @@ msgid_plural "<b>{0}</b> themes"
 msgstr[0] "<b>{0}</b> tema"
 msgstr[1] "<b>{0}</b> temas"
 
-#: src/olympia/devhub/templates/devhub/addons/edit.html:3
-#: src/olympia/devhub/templates/devhub/addons/listing/item_actions.html:25
-#: src/olympia/devhub/templates/devhub/addons/listing/item_actions_theme.html:7
-#: src/olympia/devhub/templates/devhub/includes/addons_edit_nav.html:2
-#: src/olympia/devhub/templates/devhub/personas/edit.html:6
-#: src/olympia/editors/templates/editors/themes/single.html:37
+#: src/olympia/devhub/templates/devhub/addons/edit.html:3 src/olympia/devhub/templates/devhub/addons/listing/item_actions.html:25
+#: src/olympia/devhub/templates/devhub/addons/listing/item_actions_theme.html:7 src/olympia/devhub/templates/devhub/includes/addons_edit_nav.html:2
+#: src/olympia/devhub/templates/devhub/personas/edit.html:6 src/olympia/editors/templates/editors/themes/single.html:37
 msgid "Edit Listing"
 msgstr "Editar listagem"
 
-#: src/olympia/devhub/templates/devhub/addons/edit.html:13
-#: src/olympia/devhub/templates/devhub/includes/macros.html:18
-#: src/olympia/translations/templates/translations/all-locales.html:6
+#: src/olympia/devhub/templates/devhub/addons/edit.html:13 src/olympia/devhub/templates/devhub/includes/macros.html:18 src/olympia/translations/templates/translations/all-locales.html:6
 msgid "None"
 msgstr "Nenhum"
 
-#: src/olympia/devhub/templates/devhub/addons/owner.html:4
-#: src/olympia/devhub/templates/devhub/addons/listing/item_actions.html:52
-#: src/olympia/devhub/templates/devhub/includes/addons_edit_nav.html:3
+#: src/olympia/devhub/templates/devhub/addons/owner.html:4 src/olympia/devhub/templates/devhub/addons/listing/item_actions.html:52 src/olympia/devhub/templates/devhub/includes/addons_edit_nav.html:3
 msgid "Manage Authors & License"
 msgstr "Gerir autores e licença"
 
-#: src/olympia/devhub/templates/devhub/addons/owner.html:29
-#: src/olympia/editors/templates/editors/review.html:270
+#: src/olympia/devhub/templates/devhub/addons/owner.html:29 src/olympia/editors/helpers.py:362 src/olympia/editors/templates/editors/review.html:270
 msgid "Authors"
 msgstr "Autores"
 
@@ -5429,35 +4367,22 @@ msgstr "Sobre o papel do autor"
 
 #: src/olympia/devhub/templates/devhub/addons/owner.html:78
 msgid ""
-"<p>Add-ons can have any number of authors with 3 possible roles:</p> <ul> "
-"<li><b>Owner:</b> Can manage all aspects of the add-on's listing, including "
-"adding and removing other authors</li> <li><b>Developer:</b> Can manage all "
-"aspects of the add-on's listing, except for adding and removing other "
-"authors and managing payments</li> <li><b>Viewer:</b> Can view the add-on's "
-"settings and statistics, but cannot make any changes</li> </ul>"
+"<p>Add-ons can have any number of authors with 3 possible roles:</p> <ul> <li><b>Owner:</b> Can manage all aspects of the add-on's listing, including adding and removing other authors</li> "
+"<li><b>Developer:</b> Can manage all aspects of the add-on's listing, except for adding and removing other authors and managing payments</li> <li><b>Viewer:</b> Can view the add-on's settings and "
+"statistics, but cannot make any changes</li> </ul>"
 msgstr ""
-"<p>Extras podem ter qualquer número de autores com 3 possíveis funções:</p> "
-"<ul> <li><b>Proprietário:</b> pode gerir todos os detalhes do extra, "
-"incluindo adicionar e remover outros autores</li> <li><b>Programador:</b> "
-"pode gerir todos os detalhes do extra, exceto adicionar ou remover outros "
-"autores e gerir pagamentos</li> <li><b>Visualizador:</b> pode ver as "
-"configurações e estatísticas do extra, mas não pode fazer nenhuma "
-"alteração</li> </ul>"
+"<p>Extras podem ter qualquer número de autores com 3 possíveis funções:</p> <ul> <li><b>Proprietário:</b> pode gerir todos os detalhes do extra, incluindo adicionar e remover outros autores</li> "
+"<li><b>Programador:</b> pode gerir todos os detalhes do extra, exceto adicionar ou remover outros autores e gerir pagamentos</li> <li><b>Visualizador:</b> pode ver as configurações e estatísticas "
+"do extra, mas não pode fazer nenhuma alteração</li> </ul>"
 
-#: src/olympia/devhub/templates/devhub/addons/profile.html:3
-#: src/olympia/devhub/templates/devhub/addons/listing/item_actions.html:53
-#: src/olympia/devhub/templates/devhub/includes/addons_edit_nav.html:4
+#: src/olympia/devhub/templates/devhub/addons/profile.html:3 src/olympia/devhub/templates/devhub/addons/listing/item_actions.html:53 src/olympia/devhub/templates/devhub/includes/addons_edit_nav.html:4
 msgid "Manage Developer Profile"
 msgstr "Gerir o perfil do programador"
 
 #: src/olympia/devhub/templates/devhub/addons/profile.html:16
 #, python-format
-msgid ""
-"Your <a href=\"%(url)s\">developer profile</a> is currently "
-"<strong>public</strong> and <strong>required</strong> for contributions."
-msgstr ""
-"O seu <a href=\"%(url)s\">perfil de programador</a> atual é "
-"<strong>público</strong> e <strong>requer</strong> contribuições."
+msgid "Your <a href=\"%(url)s\">developer profile</a> is currently <strong>public</strong> and <strong>required</strong> for contributions."
+msgstr "O seu <a href=\"%(url)s\">perfil de programador</a> atual é <strong>público</strong> e <strong>requer</strong> contribuições."
 
 #: src/olympia/devhub/templates/devhub/addons/profile.html:22
 msgid "Remove Both"
@@ -5465,12 +4390,8 @@ msgstr "Remover ambos"
 
 #: src/olympia/devhub/templates/devhub/addons/profile.html:27
 #, python-format
-msgid ""
-"Your <a href=\"%(url)s\">developer profile</a> is currently "
-"<strong>public</strong>."
-msgstr ""
-"O seu <a href=\"%(url)s\">perfil de programador</a> atualmente é "
-"<strong>público</strong>."
+msgid "Your <a href=\"%(url)s\">developer profile</a> is currently <strong>public</strong>."
+msgstr "O seu <a href=\"%(url)s\">perfil de programador</a> atualmente é <strong>público</strong>."
 
 #: src/olympia/devhub/templates/devhub/addons/profile.html:33
 msgid "Remove Profile"
@@ -5497,11 +4418,8 @@ msgstr "URL do extra"
 msgid "Choose a short, unique URL slug for your add-on."
 msgstr "Escolha um pequeno e único URL para o seu extra."
 
-#: src/olympia/devhub/templates/devhub/addons/edit/basic.html:43
-#: src/olympia/devhub/templates/devhub/includes/addons_edit_nav.html:35
-#: src/olympia/devhub/templates/devhub/personas/edit.html:56
-#: src/olympia/editors/templates/editors/review.html:255
-#: src/olympia/editors/templates/editors/themes/single.html:33
+#: src/olympia/devhub/templates/devhub/addons/edit/basic.html:43 src/olympia/devhub/templates/devhub/includes/addons_edit_nav.html:35 src/olympia/devhub/templates/devhub/personas/edit.html:56
+#: src/olympia/editors/templates/editors/review.html:255 src/olympia/editors/templates/editors/themes/single.html:33
 msgid "View Listing"
 msgstr "Ver listagem"
 
@@ -5511,10 +4429,7 @@ msgstr "Sumário"
 
 #: src/olympia/devhub/templates/devhub/addons/edit/basic.html:52
 msgid ""
-"A short explanation of your add-on's basic\n"
-"                          functionality that is displayed in search and browse\n"
-"                          listings, as well as at the top of your add-on's\n"
-"                          details page. It is only relevant for listed add-ons."
+"A short explanation of your add-on's basic functionality that is displayed in search and browse listings, as well as at the top of your add-on's details page. It is only relevant for listed add-ons."
 msgstr ""
 "Uma explicação curta da funcionalidade\n"
 "                          básica do seu extra que é apresentada em listas de pesquisa\n"
@@ -5522,10 +4437,7 @@ msgstr ""
 "                          do seu extra. Isto apenas é relevante para extras listados."
 
 #: src/olympia/devhub/templates/devhub/addons/edit/basic.html:73
-msgid ""
-"Categories are the primary way users browse through add-ons.\n"
-"                        Choose any that fit your add-on's functionality for the most\n"
-"                        exposure. It is only relevant for listed add-ons."
+msgid "Categories are the primary way users browse through add-ons. Choose any that fit your add-on's functionality for the most exposure. It is only relevant for listed add-ons."
 msgstr ""
 "As categorias são a forma principal que os utilizadores utilizam para navegar pelos extras.\n"
 "                        Escolha qualquer uma que se enquadre na funcionalidade do seu extra para uma maior\n"
@@ -5534,38 +4446,26 @@ msgstr ""
 #: src/olympia/devhub/templates/devhub/addons/edit/basic.html:90
 #, python-format
 msgid ""
-"Categories cannot be changed while your add-on is featured for this "
-"application. Please email <a href=\"mailto:%(email)s\">%(email)s</a> if "
-"there is a reason you need to modify your categories."
+"Categories cannot be changed while your add-on is featured for this application. Please email <a href=\"mailto:%(email)s\">%(email)s</a> if there is a reason you need to modify your categories."
 msgstr ""
-"As categorias não podem ser alteradas enquanto o seu extra estiver indicado "
-"para esta aplicação. Por favor, envie um email para <a "
-"href=\"mailto:%(email)s\">%(email)s</a> se houver uma razão em que necessite"
-" de modificar as suas categorias."
+"As categorias não podem ser alteradas enquanto o seu extra estiver indicado para esta aplicação. Por favor, envie um email para <a href=\"mailto:%(email)s\">%(email)s</a> se houver uma razão em que "
+"necessite de modificar as suas categorias."
 
 #: src/olympia/devhub/templates/devhub/addons/edit/basic.html:119
-msgid ""
-"Tags help users find your add-on and should be short\n"
-"                        descriptors such as tabs, toolbar, or twitter.  You\n"
-"                        may have a maximum of {0} tags. It is only relevant\n"
-"                        for listed add-ons."
+msgid "Tags help users find your add-on and should be short descriptors such as tabs, toolbar, or twitter. You may have a maximum of {0} tags. It is only relevant for listed add-ons."
 msgstr ""
 "As etiquetas ajudam os utilizadores a encontrar o seu extra e devem ser descrições\n"
 "                        curtas tais como separadores, barra de ferramentas ou twitter. Deve\n"
 "                        ter um máximo de {0} etiquetas. Isto apenas é relevante\n"
 "                        para extras listados."
 
-#: src/olympia/devhub/templates/devhub/addons/edit/basic.html:129
-#: src/olympia/devhub/templates/devhub/personas/edit.html:97
-#: src/olympia/devhub/templates/devhub/personas/submit.html:46
+#: src/olympia/devhub/templates/devhub/addons/edit/basic.html:129 src/olympia/devhub/templates/devhub/personas/edit.html:97 src/olympia/devhub/templates/devhub/personas/submit.html:46
 msgid "Comma-separated, minimum of {0} character."
 msgid_plural "Comma-separated, minimum of {0} characters."
 msgstr[0] "Separado por vírgulas, mínimo de {0} caractere."
 msgstr[1] "Separado por vírgulas, mínimo de {0} caracteres."
 
-#: src/olympia/devhub/templates/devhub/addons/edit/basic.html:132
-#: src/olympia/devhub/templates/devhub/personas/edit.html:100
-#: src/olympia/devhub/templates/devhub/personas/submit.html:49
+#: src/olympia/devhub/templates/devhub/addons/edit/basic.html:132 src/olympia/devhub/templates/devhub/personas/edit.html:100 src/olympia/devhub/templates/devhub/personas/submit.html:49
 msgid "Example: dark, cinema, noir. Limit 20."
 msgstr "Exemplo: escuro, cinema, preto. Limite 20."
 
@@ -5584,46 +4484,33 @@ msgid "Add-on Details for {0}"
 msgstr "Detalhes do extra para {0}"
 
 #: src/olympia/devhub/templates/devhub/addons/edit/details.html:22
-msgid ""
-"A longer explanation of features,\n"
-"                          functionality, and other relevant information. This\n"
-"                          field is only displayed on the add-on's details\n"
-"                          page. It is only relevant for listed add-ons."
+msgid "A longer explanation of features, functionality, and other relevant information. This field is only displayed on the add-on's details page. It is only relevant for listed add-ons."
 msgstr ""
 "Uma explicação mais longa de funcionalidades\n"
 "                          e outras informações relevantes. Este campo\n"
 "                          apenas é apresentado na página de detalhes\n"
 "                          do extra. Apenas é relevante para extras listados."
 
-#: src/olympia/devhub/templates/devhub/addons/edit/details.html:44
-#: src/olympia/translations/templates/translations/trans-menu.html:13
+#: src/olympia/devhub/templates/devhub/addons/edit/details.html:44 src/olympia/translations/templates/translations/trans-menu.html:13
 msgid "Default Locale"
 msgstr "Idioma por defeito"
 
 #: src/olympia/devhub/templates/devhub/addons/edit/details.html:45
-msgid ""
-"Information about your add-on is displayed in this locale\n"
-"                        unless you override it with a locale-specific translation.\n"
-"                        It is only relevant for listed add-ons."
+msgid "Information about your add-on is displayed in this locale unless you override it with a locale-specific translation. It is only relevant for listed add-ons."
 msgstr ""
 "A informação sobre o seu extra é apresentada neste idioma\n"
 "                        a menos que a sobreponha com uma tradução específica de um idioma.\n"
 "                        Isto apenas é relevante para extras listados."
 
-#: src/olympia/devhub/templates/devhub/addons/edit/details.html:61
-#: src/olympia/users/forms.py:311
-#: src/olympia/users/templates/users/edit.html:122
-#: src/olympia/users/templates/users/register.html:57
+#: src/olympia/devhub/templates/devhub/addons/edit/details.html:61 src/olympia/users/forms.py:311 src/olympia/users/templates/users/edit.html:122 src/olympia/users/templates/users/register.html:57
 #: src/olympia/users/templates/users/vcard.html:22
 msgid "Homepage"
 msgstr "Página inicial"
 
 #: src/olympia/devhub/templates/devhub/addons/edit/details.html:63
 msgid ""
-"If your add-on has another homepage, enter its\n"
-"                          address here. If your website is localized into other\n"
-"                          languages multiple translations of this field can be\n"
-"                          added. It is only relevant for listed add-ons."
+"If your add-on has another homepage, enter its address here. If your website is localized into other languages multiple translations of this field can be added. It is only relevant for listed add-"
+"ons."
 msgstr ""
 "Se o seu extra tem outra página, introduza o seu endereço\n"
 "                          aqui. Se o seu website estiver traduzido em outros idiomas,\n"
@@ -5645,11 +4532,8 @@ msgstr "Informação de suporte para {0}"
 
 #: src/olympia/devhub/templates/devhub/addons/edit/support.html:22
 msgid ""
-"If you wish to display an e-mail address for support\n"
-"                          inquiries, enter it here. If you have different\n"
-"                          addresses for each language multiple translations of\n"
-"                          this field can be added. It is only relevant for\n"
-"                          listed add-ons."
+"If you wish to display an e-mail address for support inquiries, enter it here. If you have different addresses for each language multiple translations of this field can be added. It is only "
+"relevant for listed add-ons."
 msgstr ""
 "Se quiser apresentar um endereço de e-mail para questões de apoio,\n"
 "                          insira-o aqui. Se tiver diferentes endereços para cada\n"
@@ -5659,10 +4543,8 @@ msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/support.html:45
 msgid ""
-"If your add-on has a support website or forum, enter\n"
-"                          its address here. If your website is localized into\n"
-"                          other languages, multiple translations of this field can\n"
-"                          be added. It is only relevant for listed add-ons."
+"If your add-on has a support website or forum, enter its address here. If your website is localized into other languages, multiple translations of this field can be added. It is only relevant for "
+"listed add-ons."
 msgstr ""
 "Se o seu extra tem um website ou fórum de apoio, introduza\n"
 "                          o respetivo endereço aqui. Se o seu website está traduzido\n"
@@ -5680,11 +4562,8 @@ msgstr "Detalhes técnicos para {0}"
 
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:23
 msgid ""
-"Any information end users may want to know that isn't\n"
-"                          necessarily applicable to the add-on summary or description.\n"
-"                          Common uses include listing known major bugs, information on\n"
-"                          how to report bugs, anticipated release date of a new version,\n"
-"                          etc. It is only relevant for listed add-ons."
+"Any information end users may want to know that isn't necessarily applicable to the add-on summary or description. Common uses include listing known major bugs, information on how to report bugs, "
+"anticipated release date of a new version, etc. It is only relevant for listed add-ons."
 msgstr ""
 "Quaisquer informações que utilizadores finais possam querer saber que não\n"
 "                          necessariamente aplicáveis no resumo ou descrição do extra.\n"
@@ -5701,9 +4580,7 @@ msgid "Add-on Flags"
 msgstr "Etiquetas do extra"
 
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:69
-msgid ""
-"These flags are used to classify add-ons. It is only\n"
-"                        relevant for listed add-ons."
+msgid "These flags are used to classify add-ons. It is only relevant for listed add-ons."
 msgstr ""
 "Estes sinalizadores são utilizados para classificar extras. \n"
 "                        Isto apenas é relevante para extras listados."
@@ -5721,9 +4598,7 @@ msgid "View Source?"
 msgstr "Ver fonte?"
 
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:90
-msgid ""
-"Whether the source of your add-on can be displayed in our\n"
-"                        online viewer. It is only relevant for listed add-ons."
+msgid "Whether the source of your add-on can be displayed in our online viewer. It is only relevant for listed add-ons."
 msgstr ""
 "Se a fonte do seu extra pode ser apresentada no nosso\n"
 "                        visualizador online. Isto apenas é relevante para extras listados."
@@ -5741,10 +4616,7 @@ msgid "Public Stats?"
 msgstr "Estatísticas públicas?"
 
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:102
-msgid ""
-"Whether the download and usage stats of your add-on can\n"
-"                        be displayed in our online viewer.\n"
-"                        It is only relevant for listed add-ons."
+msgid "Whether the download and usage stats of your add-on can be displayed in our online viewer. It is only relevant for listed add-ons."
 msgstr ""
 "Se as estatísticas de utilização e transferências do seu extra podem\n"
 "                        ser apresentadas no nosso visualizador online.\n"
@@ -5765,22 +4637,15 @@ msgid "Upgrade SDK?"
 msgstr "Atualizar SDK?"
 
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:116
-msgid ""
-"If selected, we will try to automatically upgrade your\n"
-"                        add-on when a new version of the SDK is released.\n"
-"                        It is only relevant for listed add-ons."
+msgid "If selected, we will try to automatically upgrade your add-on when a new version of the SDK is released. It is only relevant for listed add-ons."
 msgstr ""
 "Se selecionado, nós tentaremos atualizar automaticamente o seu\n"
 "                        extra quando uma nova versão do SDK for lançada.\n"
 "                        Isto apenas é relevante para extras listados."
 
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:121
-msgid ""
-"This add-on will be automatically upgraded to new versions of the Add-on "
-"SDK."
-msgstr ""
-"Este extra vai ser atualizado automaticamente para as novas versões de SDK "
-"do extra."
+msgid "This add-on will be automatically upgraded to new versions of the Add-on SDK."
+msgstr "Este extra vai ser atualizado automaticamente para as novas versões de SDK do extra."
 
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:123
 msgid "No, this add-on will be upgraded manually."
@@ -5795,29 +4660,20 @@ msgid "UUID"
 msgstr "UUID"
 
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:132
-msgid ""
-"The UUID of your add-on is specified in its install manifest and uniquely "
-"identifies it. You cannot change your UUID once it has been submitted."
-msgstr ""
-"O uuid do seu extra é especificada no install manifest e identifica-o de uma"
-" forma única. Não pode alterar o UUID depois de o submeter."
+msgid "The UUID of your add-on is specified in its install manifest and uniquely identifies it. You cannot change your UUID once it has been submitted."
+msgstr "O uuid do seu extra é especificada no install manifest e identifica-o de uma forma única. Não pode alterar o UUID depois de o submeter."
 
-#: src/olympia/devhub/templates/devhub/addons/edit/technical.html:143
-#: src/olympia/devhub/templates/devhub/addons/edit/technical.html:144
+#: src/olympia/devhub/templates/devhub/addons/edit/technical.html:143 src/olympia/devhub/templates/devhub/addons/edit/technical.html:144
 msgid "Whiteboard"
 msgstr "Quadro branco"
 
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:146
 msgid ""
-"The whiteboard is the place to provide information relevant to your addon, "
-"whatever the version, to the editor. Use it to provide ways to test the "
-"addon, and any additional information that may help. This whiteboard is also"
-" editable by editors."
+"The whiteboard is the place to provide information relevant to your addon, whatever the version, to the editor. Use it to provide ways to test the addon, and any additional information that may "
+"help. This whiteboard is also editable by editors."
 msgstr ""
-"O quadro branco é o sítio para fornecer informação relevante ao editor para "
-"o seu extra, qualquer que seja a versão. Utilize-o para fornecer formas de "
-"testar o extra, bem como qualquer informação adicional que possa ajudar. O "
-"quadro branco é também editável pelos editores."
+"O quadro branco é o sítio para fornecer informação relevante ao editor para o seu extra, qualquer que seja a versão. Utilize-o para fornecer formas de testar o extra, bem como qualquer informação "
+"adicional que possa ajudar. O quadro branco é também editável pelos editores."
 
 #: src/olympia/devhub/templates/devhub/addons/edit/technical_dependencies.html:9
 msgid "Remove this dependent add-on"
@@ -5837,10 +4693,8 @@ msgstr "Ícone do extra"
 
 #: src/olympia/devhub/templates/devhub/addons/forms_shared/media.html:16
 msgid ""
-"Upload an icon for your add-on or choose from one of ours. The\n"
-"                      icon is displayed nearly everywhere your add-on is. Uploaded images\n"
-"                      must be one of the following image types: .png, .jpg.\n"
-"                      It is only relevant for listed add-ons."
+"Upload an icon for your add-on or choose from one of ours. The icon is displayed nearly everywhere your add-on is. Uploaded images must be one of the following image types: .png, .jpg. It is only "
+"relevant for listed add-ons."
 msgstr ""
 "Envie um ícone para o seu extra ou escolha um dos nossos. O\n"
 "                      ícone é apresentado em praticamente em todo o lado. As imagens enviadas\n"
@@ -5857,9 +4711,7 @@ msgid "32x32px"
 msgstr "32x32px"
 
 #: src/olympia/devhub/templates/devhub/addons/forms_shared/media.html:39
-msgid ""
-"Used in listings of add-ons, like search results\n"
-"                            and featured add-ons."
+msgid "Used in listings of add-ons, like search results and featured add-ons."
 msgstr ""
 "Utilizado em listas de extras, tais como resultados de pesquisas\n"
 "                            e extras destacados."
@@ -5879,8 +4731,7 @@ msgstr "Carragar um ícone personalizado..."
 
 #: src/olympia/devhub/templates/devhub/addons/forms_shared/media.html:65
 msgid "PNG and JPG supported. Icons resized to 64x64 pixels if larger."
-msgstr ""
-"PNG e JPG suportados. Ícones redimensionados para 64x64 pixéis ou maior."
+msgstr "PNG e JPG suportados. Ícones redimensionados para 64x64 pixéis ou maior."
 
 #: src/olympia/devhub/templates/devhub/addons/forms_shared/media.html:83
 msgid "Screenshots"
@@ -5902,60 +4753,49 @@ msgstr "Adicionar um Screenshot ..."
 msgid "Tests"
 msgstr "Testes"
 
-#: src/olympia/devhub/templates/devhub/addons/includes/validation_compat_test_results.html:25
-#: src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:5
+#: src/olympia/devhub/templates/devhub/addons/includes/validation_compat_test_results.html:25 src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:5
 #: src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:53
 msgid "General Tests"
 msgstr "Testes gerais"
 
-#: src/olympia/devhub/templates/devhub/addons/includes/validation_compat_test_results.html:32
-#: src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:9
+#: src/olympia/devhub/templates/devhub/addons/includes/validation_compat_test_results.html:32 src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:9
 #: src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:67
 msgid "Security Tests"
 msgstr "Testes de segurança"
 
-#: src/olympia/devhub/templates/devhub/addons/includes/validation_compat_test_results.html:39
-#: src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:13
+#: src/olympia/devhub/templates/devhub/addons/includes/validation_compat_test_results.html:39 src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:13
 #: src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:80
 msgid "Extension Tests"
 msgstr "Testes da extensão"
 
-#: src/olympia/devhub/templates/devhub/addons/includes/validation_compat_test_results.html:46
-#: src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:17
+#: src/olympia/devhub/templates/devhub/addons/includes/validation_compat_test_results.html:46 src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:17
 #: src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:93
 msgid "Localization Tests"
 msgstr "Testes de tradução"
 
-#: src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:21
-#: src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:106
+#: src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:21 src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:106
 msgid "Compatibility Tests"
 msgstr "Testes de compatibilidade"
 
-#: src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:29
-#: src/olympia/files/templates/files/viewer.html:142
+#: src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:29 src/olympia/files/templates/files/viewer.html:142
 msgid "Hide messages not required for automated signing"
 msgstr "Ocultar mensagens não necessárias para a assinatura automática"
 
-#: src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:35
-#: src/olympia/files/templates/files/viewer.html:150
+#: src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:35 src/olympia/files/templates/files/viewer.html:150
 msgid "Hide messages present in previous version and ignored"
 msgstr "Ocultar mensagens presentes na versão anterior e ignorada"
 
-#: src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:50
-#: src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:64
-#: src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:77
-#: src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:90
+#: src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:50 src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:64
+#: src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:77 src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:90
 #: src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:103
 msgid "Top"
 msgstr "Topo"
 
-#: src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:2
-#: src/olympia/devhub/templates/devhub/personas/edit.html:63
+#: src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:2 src/olympia/devhub/templates/devhub/personas/edit.html:63
 msgid "Delete Theme"
 msgstr "Eliminar tema"
 
-#: src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:2
-#: src/olympia/devhub/templates/devhub/versions/list.html:117
+#: src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:2 src/olympia/devhub/templates/devhub/versions/list.html:117
 msgid "Delete Add-on"
 msgstr "Eliminar extra"
 
@@ -5964,31 +4804,24 @@ msgid "Deleting your theme will permanently remove it from the site."
 msgstr "Eliminar o seu tema irá removê-lo permanentemente do site."
 
 #: src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:14
-msgid ""
-"Deleting your add-on will permanently remove it from the site and prevent "
-"its GUID from being submitted again by others."
-msgstr ""
-"Ao eliminar o seu extra irá removê-lo de forma permanente do site e impedir "
-"que o respetivo GUID seja novamente submetido por outros."
+msgid "Deleting your add-on will permanently remove it from the site and prevent its GUID from being submitted again by others."
+msgstr "Ao eliminar o seu extra irá removê-lo de forma permanente do site e impedir que o respetivo GUID seja novamente submetido por outros."
 
 #: src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:24
-msgid ""
-"Enter the following text confirm your decision:\n"
-"           {slug}"
+msgid "Enter the following text confirm your decision: {slug}"
 msgstr ""
 "Introduza um seguinte texto para confirmar a sua decisão:\n"
 "           {slug}"
 
-#: src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:34
+#: src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:33
 msgid "Please tell us why you are deleting your theme:"
 msgstr "Por favor, diga-nos porque está a eliminar o seu tema:"
 
-#: src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:36
+#: src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:35
 msgid "Please tell us why you are deleting your add-on:"
 msgstr "Por favor, diga-nos porque está a eliminar o seu extra:"
 
-#: src/olympia/devhub/templates/devhub/addons/listing/item_actions.html:1
-#: src/olympia/devhub/templates/devhub/addons/listing/item_actions_theme.html:1
+#: src/olympia/devhub/templates/devhub/addons/listing/item_actions.html:1 src/olympia/devhub/templates/devhub/addons/listing/item_actions_theme.html:1
 #: src/olympia/editors/templates/editors/review.html:253
 msgid "Actions"
 msgstr "Ações"
@@ -6021,22 +4854,17 @@ msgstr "Nova versão"
 msgid "Daily statistics on downloads and users."
 msgstr "Estatísticas diárias sobre descargas e utilizadores."
 
-#: src/olympia/devhub/templates/devhub/addons/listing/item_actions.html:45
-#: src/olympia/stats/templates/stats/stats.html:75
-#: src/olympia/stats/templates/stats/stats.html:79
-#: src/olympia/stats/templates/stats/stats.html:81
+#: src/olympia/devhub/templates/devhub/addons/listing/item_actions.html:45 src/olympia/stats/templates/stats/stats.html:31 src/olympia/stats/templates/stats/stats.html:35
+#: src/olympia/stats/templates/stats/stats.html:37
 msgid "Statistics"
 msgstr "Estatísticas"
 
-#: src/olympia/devhub/templates/devhub/addons/listing/item_actions.html:54
-#: src/olympia/devhub/templates/devhub/includes/addons_edit_nav.html:5
-#: src/olympia/devhub/templates/devhub/payments/payments.html:3
-#: src/olympia/devhub/templates/devhub/payments/tier.html:4
+#: src/olympia/devhub/templates/devhub/addons/listing/item_actions.html:54 src/olympia/devhub/templates/devhub/includes/addons_edit_nav.html:5
+#: src/olympia/devhub/templates/devhub/payments/payments.html:3 src/olympia/devhub/templates/devhub/payments/tier.html:4
 msgid "Manage Payments"
 msgstr "Gerir pagamentos"
 
-#: src/olympia/devhub/templates/devhub/addons/listing/item_actions.html:55
-#: src/olympia/devhub/templates/devhub/includes/addons_edit_nav.html:6
+#: src/olympia/devhub/templates/devhub/addons/listing/item_actions.html:55 src/olympia/devhub/templates/devhub/includes/addons_edit_nav.html:6
 msgid "Manage Status & Versions"
 msgstr "Gerir o estado e a versão"
 
@@ -6044,10 +4872,8 @@ msgstr "Gerir o estado e a versão"
 msgid "View Add-on Listing"
 msgstr "Ver lista de extras"
 
-#: src/olympia/devhub/templates/devhub/addons/listing/item_actions.html:64
-#: src/olympia/devhub/templates/devhub/addons/listing/item_actions_theme.html:12
-#: src/olympia/devhub/templates/devhub/includes/addons_edit_nav.html:37
-#: src/olympia/devhub/templates/devhub/personas/edit.html:58
+#: src/olympia/devhub/templates/devhub/addons/listing/item_actions.html:64 src/olympia/devhub/templates/devhub/addons/listing/item_actions_theme.html:12
+#: src/olympia/devhub/templates/devhub/includes/addons_edit_nav.html:37 src/olympia/devhub/templates/devhub/personas/edit.html:58
 msgid "View Recent Changes"
 msgstr "Ver alterados recentemente"
 
@@ -6072,12 +4898,8 @@ msgid "Delete this theme."
 msgstr "Eliminar este tema."
 
 #: src/olympia/devhub/templates/devhub/addons/listing/items.html:10
-msgid ""
-"This add-on will be deleted automatically after a few days if the submission"
-" process is not completed."
-msgstr ""
-"Este extra será excluído automaticamente após alguns dias caso o processo de"
-" envio não seja completado."
+msgid "This add-on will be deleted automatically after a few days if the submission process is not completed."
+msgstr "Este extra será excluído automaticamente após alguns dias caso o processo de envio não seja completado."
 
 #: src/olympia/devhub/templates/devhub/addons/listing/items.html:27
 msgid "Disabled"
@@ -6115,13 +4937,9 @@ msgstr "Nome e versão:"
 msgid "The detail page will be:"
 msgstr "A página de detalhes será:"
 
-#: src/olympia/devhub/templates/devhub/addons/submit/describe.html:24
-#: src/olympia/devhub/templates/devhub/personas/edit.html:89
-#: src/olympia/devhub/templates/devhub/personas/submit.html:38
+#: src/olympia/devhub/templates/devhub/addons/submit/describe.html:24 src/olympia/devhub/templates/devhub/personas/edit.html:89 src/olympia/devhub/templates/devhub/personas/submit.html:38
 msgid "Please use only letters, numbers, underscores, and dashes in your URL."
-msgstr ""
-"Por favor, utilize apenas letras, números, underscores e hífenes  na sua "
-"URL. "
+msgstr "Por favor, utilize apenas letras, números, underscores e hífenes  na sua URL. "
 
 #: src/olympia/devhub/templates/devhub/addons/submit/describe.html:34
 msgid "Provide a brief summary:"
@@ -6139,14 +4957,11 @@ msgstr "Forneça uma descrição mais detalhada:"
 msgid "The description will appear on the detail page."
 msgstr "A descrição aparecerá na página de detalhes."
 
-#: src/olympia/devhub/templates/devhub/addons/submit/done.html:4
-#: src/olympia/devhub/templates/devhub/personas/submit_done.html:4
+#: src/olympia/devhub/templates/devhub/addons/submit/done.html:4 src/olympia/devhub/templates/devhub/personas/submit_done.html:4
 msgid "Submission Complete"
 msgstr "Submissão finalizada."
 
-#: src/olympia/devhub/templates/devhub/addons/submit/done.html:8
-#: src/olympia/devhub/templates/devhub/addons/submit/sidebar.html:13
-#: src/olympia/devhub/templates/devhub/personas/submit_done.html:8
+#: src/olympia/devhub/templates/devhub/addons/submit/done.html:8 src/olympia/devhub/templates/devhub/addons/submit/sidebar.html:13 src/olympia/devhub/templates/devhub/personas/submit_done.html:8
 msgid "You're done!"
 msgstr "Está feito!"
 
@@ -6159,50 +4974,33 @@ msgid "Your add-on has been submitted to the Full Review queue."
 msgstr "O seu extra foi submetido para a lista de revisão completa."
 
 #: src/olympia/devhub/templates/devhub/addons/submit/done.html:18
-msgid ""
-"You'll receive an email once it has been reviewed by an editor. In\n"
-"          the meantime, you and your friends can install it directly from its\n"
-"          details page:"
+msgid "You'll receive an email once it has been reviewed by an editor. In the meantime, you and your friends can install it directly from its details page:"
 msgstr ""
 "Irá receber um email depois deste ser revisto por um editor. Entretanto, \n"
 "          você e os seus amigos podem instalá-lo diretamente a partir da\n"
 "          sua página de detalhes:"
 
-#: src/olympia/devhub/templates/devhub/addons/submit/done.html:27
-#: src/olympia/devhub/templates/devhub/addons/submit/done.html:77
-#: src/olympia/devhub/templates/devhub/personas/submit_done.html:16
+#: src/olympia/devhub/templates/devhub/addons/submit/done.html:27 src/olympia/devhub/templates/devhub/addons/submit/done.html:77 src/olympia/devhub/templates/devhub/personas/submit_done.html:16
 msgid "Next steps:"
 msgstr "Passos seguintes:"
 
-#: src/olympia/devhub/templates/devhub/addons/submit/done.html:32
-#: src/olympia/devhub/templates/devhub/addons/submit/done.html:82
+#: src/olympia/devhub/templates/devhub/addons/submit/done.html:32 src/olympia/devhub/templates/devhub/addons/submit/done.html:82
 msgid "<a href=\"{0}\">Upload</a> another platform-specific file to this version."
-msgstr ""
-"<a href=\"{0}\">Carregar</a> outro ficheiro de uma plataforma específica "
-"para esta versão."
+msgstr "<a href=\"{0}\">Carregar</a> outro ficheiro de uma plataforma específica para esta versão."
 
 #: src/olympia/devhub/templates/devhub/addons/submit/done.html:34
 msgid "Provide more details by <a href=\"{0}\">editing its listing</a>."
 msgstr "Forneça mais informações <a href=\"{0}\">editando os seus detalhes</a>."
 
 #: src/olympia/devhub/templates/devhub/addons/submit/done.html:35
-msgid ""
-"Tell your users why you created this in your <a href=\"{0}\">Developer "
-"Profile</a>."
-msgstr ""
-"Conte aos seus utilizadores por que criou isto no seu <a href=\"{0}\">Perfil"
-" de programador</a>."
+msgid "Tell your users why you created this in your <a href=\"{0}\">Developer Profile</a>."
+msgstr "Conte aos seus utilizadores por que criou isto no seu <a href=\"{0}\">Perfil de programador</a>."
 
 #: src/olympia/devhub/templates/devhub/addons/submit/done.html:36
-msgid ""
-"View and subscribe to your add-on's <a href=\"{0}\">activity feed</a> to "
-"stay updated on reviews, collections, and more."
-msgstr ""
-"Ver e subscrever à <a href=\"{0}\">fonte de atividade</a> do seu extra para "
-"se manter atualizado sobre revisões, coleções e muito mais."
+msgid "View and subscribe to your add-on's <a href=\"{0}\">activity feed</a> to stay updated on reviews, collections, and more."
+msgstr "Ver e subscrever à <a href=\"{0}\">fonte de atividade</a> do seu extra para se manter atualizado sobre revisões, coleções e muito mais."
 
-#: src/olympia/devhub/templates/devhub/addons/submit/done.html:37
-#: src/olympia/devhub/templates/devhub/addons/submit/done.html:86
+#: src/olympia/devhub/templates/devhub/addons/submit/done.html:37 src/olympia/devhub/templates/devhub/addons/submit/done.html:86
 msgid "View approximate review queue <a href=\"{0}\">wait times</a>."
 msgstr "Ver a lista de <a href=\"{0}\">espera</a> aproximada da revisão."
 
@@ -6212,45 +5010,31 @@ msgstr "Passar à frente na fila de revisão!"
 
 #: src/olympia/devhub/templates/devhub/addons/submit/done.html:45
 msgid "Become an AMO Reviewer today and get your add-ons reviewed faster."
-msgstr ""
-"Torne-se num revisor AMO hoje e tenha os seus extras revistos mais "
-"rapidamente."
+msgstr "Torne-se num revisor AMO hoje e tenha os seus extras revistos mais rapidamente."
 
 #: src/olympia/devhub/templates/devhub/addons/submit/done.html:54
-msgid ""
-"Your add-on has been signed and it's ready to use. You can download it here:"
-msgstr ""
-"O seu extra foi assinado e está pronto a ser utilizado. Pode descarregá-lo "
-"aqui:"
+msgid "Your add-on has been signed and it's ready to use. You can download it here:"
+msgstr "O seu extra foi assinado e está pronto a ser utilizado. Pode descarregá-lo aqui:"
 
 #: src/olympia/devhub/templates/devhub/addons/submit/done.html:64
-msgid ""
-"Your add-on has been submitted to the Unlisted Preliminary Review queue."
-msgstr ""
-"O seu extra foi submetido para a fila de revisão preliminar não listada."
+msgid "Your add-on has been submitted to the Unlisted Preliminary Review queue."
+msgstr "O seu extra foi submetido para a fila de revisão preliminar não listada."
 
 #: src/olympia/devhub/templates/devhub/addons/submit/done.html:66
 msgid "Your add-on has been submitted to the Unlisted Full Review queue."
-msgstr ""
-"O seu extra foi submetido para a fila de revisão completa não listada."
+msgstr "O seu extra foi submetido para a fila de revisão completa não listada."
 
 #: src/olympia/devhub/templates/devhub/addons/submit/done.html:70
-msgid ""
-"You'll receive an email once it has been reviewed by an editor and signed."
-msgstr ""
-"Irá receber um email assim que este for revisto e assinado por um editor."
+msgid "You'll receive an email once it has been reviewed by an editor and signed."
+msgstr "Irá receber um email assim que este for revisto e assinado por um editor."
 
 #: src/olympia/devhub/templates/devhub/addons/submit/done.html:74
 msgid "Your add-on will not be publicly available on this website."
 msgstr "O seu extra não estará disponível publicamente neste website."
 
 #: src/olympia/devhub/templates/devhub/addons/submit/done.html:84
-msgid ""
-"You can upload new versions of your add-on in the <a href=\"{0}\">add-on's "
-"developer page</a>."
-msgstr ""
-"Pode enviar novas versões do seu extra na <a href=\"{0}\">página do "
-"programador do extra</a>."
+msgid "You can upload new versions of your add-on in the <a href=\"{0}\">add-on's developer page</a>."
+msgstr "Pode enviar novas versões do seu extra na <a href=\"{0}\">página do programador do extra</a>."
 
 #: src/olympia/devhub/templates/devhub/addons/submit/license.html:4
 msgid "Step 5"
@@ -6261,14 +5045,8 @@ msgid "Step 5. Select a License"
 msgstr "Passo 5. Selecione uma licença"
 
 #: src/olympia/devhub/templates/devhub/addons/submit/license.html:9
-msgid ""
-"We require all add-ons to indicate the terms under which their source code "
-"is licensed. Please select a license from the list below or enter a custom "
-"license."
-msgstr ""
-"Necessitamos que todos os extras indiquem os termos sobre qual o código "
-"fonte é licenciado. Por favor selecione a licença da lista em baixo ou "
-"escreva a sua licença personalizada."
+msgid "We require all add-ons to indicate the terms under which their source code is licensed. Please select a license from the list below or enter a custom license."
+msgstr "Necessitamos que todos os extras indiquem os termos sobre qual o código fonte é licenciado. Por favor selecione a licença da lista em baixo ou escreva a sua licença personalizada."
 
 #: src/olympia/devhub/templates/devhub/addons/submit/license.html:18
 msgid "Select a license for your add-on:"
@@ -6284,14 +5062,11 @@ msgstr "Passo 4. Adicionar imagens"
 
 #: src/olympia/devhub/templates/devhub/addons/submit/media.html:9
 msgid ""
-"Custom icons and screenshots draw attention and help users understand what "
-"it does. We strongly recommend uploading a custom icon, as in some areas of "
-"the website, only the icon and name will appear."
+"Custom icons and screenshots draw attention and help users understand what it does. We strongly recommend uploading a custom icon, as in some areas of the website, only the icon and name will "
+"appear."
 msgstr ""
-"Ícones e capturas de tela personalizadas chamam a atenção e ajudam os "
-"utilizadores a entender o que seu extra faz. Nós recomendamos veemente que "
-"adicione um ícone personalizado, já que em algumas áreas do site somente o "
-"ícone e o nome serão apresentados."
+"Ícones e capturas de tela personalizadas chamam a atenção e ajudam os utilizadores a entender o que seu extra faz. Nós recomendamos veemente que adicione um ícone personalizado, já que em algumas "
+"áreas do site somente o ícone e o nome serão apresentados."
 
 #: src/olympia/devhub/templates/devhub/addons/submit/select-review.html:5
 msgid "Step 6"
@@ -6303,24 +5078,16 @@ msgstr "Passo 6. Selecione um processo de revisão"
 
 #: src/olympia/devhub/templates/devhub/addons/submit/select-review.html:10
 msgid ""
-"All add-ons hosted in our gallery must be reviewed by an editor before they "
-"appear in categories or search results. While waiting for review, your add-"
-"on can still be accessed through its direct URL. Please choose the review "
-"process below that best fits your add-on."
+"All add-ons hosted in our gallery must be reviewed by an editor before they appear in categories or search results. While waiting for review, your add-on can still be accessed through its direct "
+"URL. Please choose the review process below that best fits your add-on."
 msgstr ""
-"Todos os extras alojados na nossa galeria têm de ser revistos por um editor "
-"antes de aparecer nas categorias ou pesquisa de resultados. Enquanto espera "
-"pela revisão, o seu extra pode ser acedido através do URL directo. Por favor"
-" escolha o processo de revisão em baixo que melhor se adequa ao seu extra."
+"Todos os extras alojados na nossa galeria têm de ser revistos por um editor antes de aparecer nas categorias ou pesquisa de resultados. Enquanto espera pela revisão, o seu extra pode ser acedido "
+"através do URL directo. Por favor escolha o processo de revisão em baixo que melhor se adequa ao seu extra."
 
 #: src/olympia/devhub/templates/devhub/addons/submit/select-review.html:26
 #, python-format
-msgid ""
-"A complete review of your add-on's source and functionality. <a "
-"href=\"%(url)s\">Learn more&hellip;</a>"
-msgstr ""
-"Uma revisão completa da fonte e funcionalidade do seu extray. <a "
-"href=\"%(url)s\">Saber mais&hellip;</a>"
+msgid "A complete review of your add-on's source and functionality. <a href=\"%(url)s\">Learn more&hellip;</a>"
+msgstr "Uma revisão completa da fonte e funcionalidade do seu extray. <a href=\"%(url)s\">Saber mais&hellip;</a>"
 
 #: src/olympia/devhub/templates/devhub/addons/submit/select-review.html:32
 msgid "Appropriate for polished add-ons"
@@ -6348,12 +5115,8 @@ msgstr "Escolher revisão completa"
 
 #: src/olympia/devhub/templates/devhub/addons/submit/select-review.html:49
 #, python-format
-msgid ""
-"A faster review of your add-on's source for any major problems. <a "
-"href=\"%(url)s\">Learn more&hellip;</a>"
-msgstr ""
-"Uma revisão rápida de qualquer problema da fonte do seu extra. <a "
-"href=\"%(url)s\">Saber mais&hellip;</a>"
+msgid "A faster review of your add-on's source for any major problems. <a href=\"%(url)s\">Learn more&hellip;</a>"
+msgstr "Uma revisão rápida de qualquer problema da fonte do seu extra. <a href=\"%(url)s\">Saber mais&hellip;</a>"
 
 #: src/olympia/devhub/templates/devhub/addons/submit/select-review.html:55
 msgid "Appropriate for experimental add-ons"
@@ -6399,10 +5162,8 @@ msgstr "Selecione uma licença"
 msgid "Select a review process"
 msgstr "Selecione um processo de revisão"
 
-#: src/olympia/devhub/templates/devhub/addons/submit/sidebar.html:18
-#: src/olympia/devhub/templates/devhub/docs/policies-submission.html:3
-#: src/olympia/devhub/templates/devhub/docs/policies-submission.html:7
-#: src/olympia/devhub/templates/devhub/docs/policies-submission.html:9
+#: src/olympia/devhub/templates/devhub/addons/submit/sidebar.html:18 src/olympia/devhub/templates/devhub/docs/policies-submission.html:3
+#: src/olympia/devhub/templates/devhub/docs/policies-submission.html:7 src/olympia/devhub/templates/devhub/docs/policies-submission.html:9
 msgid "Submission Process"
 msgstr "Processo de submissão"
 
@@ -6423,27 +5184,18 @@ msgid "Step 2. Upload Your Add-on"
 msgstr "Passo 2. Carregue o seu extra"
 
 #: src/olympia/devhub/templates/devhub/addons/submit/upload.html:11
-msgid ""
-"Use the fields below to upload your add-on package and select any platform "
-"restrictions. After upload, a series of automated validation tests will be "
-"run on your file."
-msgstr ""
-"Use os campos em baixo para carregar o pacote do seu extra e selecionar "
-"restrições de plataformas. Após carregar. uma série de testes automatizados "
-"irão ser executados no seu ficheiro."
+msgid "Use the fields below to upload your add-on package and select any platform restrictions. After upload, a series of automated validation tests will be run on your file."
+msgstr "Use os campos em baixo para carregar o pacote do seu extra e selecionar restrições de plataformas. Após carregar. uma série de testes automatizados irão ser executados no seu ficheiro."
 
-#: src/olympia/devhub/templates/devhub/addons/submit/upload.html:59
-#: src/olympia/devhub/templates/devhub/versions/add_file_modal.html:39
+#: src/olympia/devhub/templates/devhub/addons/submit/upload.html:51 src/olympia/devhub/templates/devhub/versions/add_file_modal.html:28
 msgid "Which platforms is this file compatible with?"
 msgstr "Com que plataformas é este ficheiro compatível?"
 
-#: src/olympia/devhub/templates/devhub/addons/submit/upload.html:67
-#: src/olympia/devhub/templates/devhub/versions/add_file_modal.html:65
+#: src/olympia/devhub/templates/devhub/addons/submit/upload.html:59 src/olympia/devhub/templates/devhub/versions/add_file_modal.html:45
 msgid "Administrative overrides"
 msgstr "Sobreposições administrativas"
 
-#: src/olympia/devhub/templates/devhub/api/agreement.html:3
-#: src/olympia/devhub/templates/devhub/api/agreement.html:11
+#: src/olympia/devhub/templates/devhub/api/agreement.html:3 src/olympia/devhub/templates/devhub/api/agreement.html:11
 msgid "Firefox Add-on Distribution Agreement"
 msgstr "Acordo de distribuição de extras do Firefox"
 
@@ -6453,12 +5205,8 @@ msgstr "Credenciais da API"
 
 #: src/olympia/devhub/templates/devhub/api/key.html:20
 #, python-format
-msgid ""
-"For detailed instructions, consult the <a href=\"%(docs_url)s\">API "
-"documentation</a>."
-msgstr ""
-"Para instruções detalhadas, consulte a <a href=\"%(docs_url)s\">documentação"
-" da API</a>."
+msgid "For detailed instructions, consult the <a href=\"%(docs_url)s\">API documentation</a>."
+msgstr "Para instruções detalhadas, consulte a <a href=\"%(docs_url)s\">documentação da API</a>."
 
 #: src/olympia/devhub/templates/devhub/api/key.html:28
 msgid "JWT issuer"
@@ -6471,15 +5219,11 @@ msgstr "Segredo JWT"
 #: src/olympia/devhub/templates/devhub/api/key.html:37
 #, python-format
 msgid ""
-"To make API requests, send a <a href=\"%(jwt_url)s\">JSON Web Token "
-"(JWT)</a> as the authorization header. You'll need to generate a JWT for "
-"every request as explained in the <a href=\"%(docs_url)s\">API "
-"documentation</a>."
+"To make API requests, send a <a href=\"%(jwt_url)s\">JSON Web Token (JWT)</a> as the authorization header. You'll need to generate a JWT for every request as explained in the <a href=\"%(docs_url)s"
+"\">API documentation</a>."
 msgstr ""
-"Para fazer pedidos à API, envie um <a href=\"%(jwt_url)s\">Token Web JSON "
-"(JWT)</a> como o cabeçalho da autorização. Precisa de gerar um JWT para cada"
-" pedido tal como é explicado na <a href=\"%(docs_url)s\">documentação da "
-"API</a>."
+"Para fazer pedidos à API, envie um <a href=\"%(jwt_url)s\">Token Web JSON (JWT)</a> como o cabeçalho da autorização. Precisa de gerar um JWT para cada pedido tal como é explicado na <a href="
+"\"%(docs_url)s\">documentação da API</a>."
 
 #: src/olympia/devhub/templates/devhub/api/key.html:47
 msgid "You don't have any API credentials yet."
@@ -6487,12 +5231,8 @@ msgstr "Ainda não tem quaisquer credenciais de API."
 
 #: src/olympia/devhub/templates/devhub/api/key.html:53
 #, python-format
-msgid ""
-"This feature is under active development. If you find a problem please <a "
-"target=\"_blank\" href=\"%(bug_link)s\">report a bug</a>."
-msgstr ""
-"Esta funcionalidade está em desenvolvimento. Se encontrar um problema, por "
-"favor <a target=\"_blank\" href=\"%(bug_link)s\">reporte um bug</a>."
+msgid "This feature is under active development. If you find a problem please <a target=\"_blank\" href=\"%(bug_link)s\">report a bug</a>."
+msgstr "Esta funcionalidade está em desenvolvimento. Se encontrar um problema, por favor <a target=\"_blank\" href=\"%(bug_link)s\">reporte um bug</a>."
 
 #: src/olympia/devhub/templates/devhub/api/key.html:61
 msgid "Revoke and regenerate credentials"
@@ -6502,30 +5242,19 @@ msgstr "Revogue e regenere as credenciais"
 msgid "Generate new credentials"
 msgstr "Gerar novas credenciais"
 
-#: src/olympia/devhub/templates/devhub/docs/policies-agreement.html:3
-#: src/olympia/devhub/templates/devhub/docs/policies-agreement.html:7
-#: src/olympia/devhub/templates/devhub/docs/policies-agreement.html:9
-#: src/olympia/devhub/templates/devhub/docs/policies.html:24
-#: src/olympia/devhub/templates/devhub/docs/policies.html:103
+#: src/olympia/devhub/templates/devhub/docs/policies-agreement.html:3 src/olympia/devhub/templates/devhub/docs/policies-agreement.html:7
+#: src/olympia/devhub/templates/devhub/docs/policies-agreement.html:9 src/olympia/devhub/templates/devhub/docs/policies.html:24 src/olympia/devhub/templates/devhub/docs/policies.html:103
 msgid "Developer Agreement"
 msgstr "Acordo do programador"
 
-#: src/olympia/devhub/templates/devhub/docs/policies-contact.html:3
-#: src/olympia/devhub/templates/devhub/docs/policies-contact.html:7
-#: src/olympia/devhub/templates/devhub/docs/policies-contact.html:9
-#: src/olympia/devhub/templates/devhub/docs/policies.html:27
-#: src/olympia/devhub/templates/devhub/docs/policies.html:115
+#: src/olympia/devhub/templates/devhub/docs/policies-contact.html:3 src/olympia/devhub/templates/devhub/docs/policies-contact.html:7 src/olympia/devhub/templates/devhub/docs/policies-contact.html:9
+#: src/olympia/devhub/templates/devhub/docs/policies.html:27 src/olympia/devhub/templates/devhub/docs/policies.html:115
 msgid "Contacting Us"
 msgstr "Contactar-nos"
 
 #: src/olympia/devhub/templates/devhub/docs/policies-contact.html:12
-msgid ""
-"Thanks for your interest in contacting the Mozilla Add-ons team. Please read"
-" this page carefully to ensure your request goes to the right place."
-msgstr ""
-"Obrigado pelo seu interesse em entrar em contacto com a equipa do Mozilla "
-"Firefox. Por favor, leia este documento cuidadosamente para garantir que o "
-"seu pedido vai para o lugar certo."
+msgid "Thanks for your interest in contacting the Mozilla Add-ons team. Please read this page carefully to ensure your request goes to the right place."
+msgstr "Obrigado pelo seu interesse em entrar em contacto com a equipa do Mozilla Firefox. Por favor, leia este documento cuidadosamente para garantir que o seu pedido vai para o lugar certo."
 
 #: src/olympia/devhub/templates/devhub/docs/policies-contact.html:17
 msgid "Add-on Support"
@@ -6533,15 +5262,11 @@ msgstr "Ajuda do extra"
 
 #: src/olympia/devhub/templates/devhub/docs/policies-contact.html:19
 msgid ""
-"If you have a support question about a particular add-on, such as \"how do I"
-" use this add-on?\" or \"why doesn't this work properly?\", please contact "
-"that add-on's author through the support channels listed on the add-on's "
-"listing page."
+"If you have a support question about a particular add-on, such as \"how do I use this add-on?\" or \"why doesn't this work properly?\", please contact that add-on's author through the support "
+"channels listed on the add-on's listing page."
 msgstr ""
-"Se você tiver uma pergunta sobre um determinado extra, como \"como faço para"
-" usar esse extra?\" ou \"por que é que não funciona corretamente?\", entre "
-"em contacto com o autor através dos canais de suporte listados na página de "
-"listagem do extra."
+"Se você tiver uma pergunta sobre um determinado extra, como \"como faço para usar esse extra?\" ou \"por que é que não funciona corretamente?\", entre em contacto com o autor através dos canais de "
+"suporte listados na página de listagem do extra."
 
 #: src/olympia/devhub/templates/devhub/docs/policies-contact.html:24
 msgid "Add-on Editorial Concerns"
@@ -6554,18 +5279,11 @@ msgstr "amo-editors at mozilla dot org"
 #: src/olympia/devhub/templates/devhub/docs/policies-contact.html:26
 #, python-format
 msgid ""
-"If you have a question about an Editor's review of an add-on or want to "
-"report a policy violation, please email %(mail_editors)s. <strong>Almost all"
-" add-on reports fall under this category.</strong> Please be sure to include"
-" a link to the add-on in question and a detailed description of your "
-"question or comment."
+"If you have a question about an Editor's review of an add-on or want to report a policy violation, please email %(mail_editors)s. <strong>Almost all add-on reports fall under this category.</"
+"strong> Please be sure to include a link to the add-on in question and a detailed description of your question or comment."
 msgstr ""
-"Se tiver uma pergunta sobre um comentário do editor de um extra ou quer "
-"denunciar uma violação da política, por favor envie um email para "
-"%(mail_editors)s. <strong>Quase todos os relatórios de extra se enquadram "
-"nesta categoria.</strong> Por favor não se esqueça de incluir uma ligação "
-"para o extra em questão e uma descrição detalhada da sua pergunta ou "
-"comentário."
+"Se tiver uma pergunta sobre um comentário do editor de um extra ou quer denunciar uma violação da política, por favor envie um email para %(mail_editors)s. <strong>Quase todos os relatórios de "
+"extra se enquadram nesta categoria.</strong> Por favor não se esqueça de incluir uma ligação para o extra em questão e uma descrição detalhada da sua pergunta ou comentário."
 
 #: src/olympia/devhub/templates/devhub/docs/policies-contact.html:31
 msgid "Add-on Security Vulnerabilities"
@@ -6578,22 +5296,13 @@ msgstr "amo-admins arroba mozilla ponto org"
 #: src/olympia/devhub/templates/devhub/docs/policies-contact.html:36
 #, python-format
 msgid ""
-"If you have discovered a security vulnerability in an add-on, even if it is "
-"not hosted here, Mozilla is very interested in your discovery and will work "
-"with the add-on developer to correct the issue as soon as possible. Add-on "
-"security issues can be reported <a "
-"href=\"http://www.mozilla.org/projects/security/security-bugs-"
-"policy.html\">confidentially</a> in <a "
-"href=\"%(link_bugzilla)s\">Bugzilla</a> or by emailing %(mail_admins)s."
+"If you have discovered a security vulnerability in an add-on, even if it is not hosted here, Mozilla is very interested in your discovery and will work with the add-on developer to correct the "
+"issue as soon as possible. Add-on security issues can be reported <a href=\"http://www.mozilla.org/projects/security/security-bugs-policy.html\">confidentially</a> in <a href=\"%(link_bugzilla)s"
+"\">Bugzilla</a> or by emailing %(mail_admins)s."
 msgstr ""
-"Se descobriu uma vulnerabilidade de segurança num extra, mesmo que não "
-"esteja alojado aqui, a Mozilla está muito interessada na sua descoberta e "
-"vai trabalhar com o programador do extra para corrigir o problema o mais "
-"rapidamente possível. Problemas de segurança de extras podem ser reportados "
-"<a href=\"http://www.mozilla.org/projects/security/security-bugs-"
-"policy.html\">confidencialmente</a> no <a "
-"href=\"%(link_bugzilla)s\">Bugzilla</a> ou enviando um email para "
-"%(mail_admins)s."
+"Se descobriu uma vulnerabilidade de segurança num extra, mesmo que não esteja alojado aqui, a Mozilla está muito interessada na sua descoberta e vai trabalhar com o programador do extra para "
+"corrigir o problema o mais rapidamente possível. Problemas de segurança de extras podem ser reportados <a href=\"http://www.mozilla.org/projects/security/security-bugs-policy.html"
+"\">confidencialmente</a> no <a href=\"%(link_bugzilla)s\">Bugzilla</a> ou enviando um email para %(mail_admins)s."
 
 #: src/olympia/devhub/templates/devhub/docs/policies-contact.html:42
 msgid "Website Functionality & Development"
@@ -6601,17 +5310,11 @@ msgstr "Desenvolvimento e funcionalidade do website"
 
 #: src/olympia/devhub/templates/devhub/docs/policies-contact.html:44
 msgid ""
-"If you've found a problem with the site, we'd love to fix it. Please <a "
-"href=\"https://github.com/mozilla/olympia/issues\">file a bug report</a> in "
-"GitHub, including the location of the problem and how you encountered it."
+"If you've found a problem with the site, we'd love to fix it. Please <a href=\"https://github.com/mozilla/addons/issues/new\">file a bug report</a> in GitHub, including the location of the problem "
+"and how you encountered it."
 msgstr ""
-"Se encontrou um problema com o site, nós gostaríamos de o resolver. Por "
-"favor <a href=\"https://github.com/mozilla/olympia/issues\">submeta um "
-"relatório de erro</a> no GitHub, incluindo a localização do problema e como "
-"o encontrou."
 
-#: src/olympia/devhub/templates/devhub/docs/policies-maintenance.html:3
-#: src/olympia/devhub/templates/devhub/docs/policies-maintenance.html:7
+#: src/olympia/devhub/templates/devhub/docs/policies-maintenance.html:3 src/olympia/devhub/templates/devhub/docs/policies-maintenance.html:7
 #: src/olympia/devhub/templates/devhub/docs/policies-maintenance.html:8
 msgid "Maintaining Your Add-ons"
 msgstr "Manter os seus extras"
@@ -6622,32 +5325,17 @@ msgstr "Submeter novas versões do seu extra"
 
 #: src/olympia/devhub/templates/devhub/docs/policies-maintenance.html:12
 msgid ""
-"Developers are encouraged to submit updates to their add-ons to fix bugs, "
-"add features, and otherwise improve their product. New versions of an add-on"
-" must have a <a "
-"href=\"https://developer.mozilla.org/en/Toolkit_version_format\">higher "
-"version number</a> and can be submitted through the Developer Tools "
-"provided. There is no limit to the number of versions that can be submitted,"
-" but please remember that versions must be reviewed by an editor."
+"Developers are encouraged to submit updates to their add-ons to fix bugs, add features, and otherwise improve their product. New versions of an add-on must have a <a href=\"https://developer."
+"mozilla.org/en/Toolkit_version_format\">higher version number</a> and can be submitted through the Developer Tools provided. There is no limit to the number of versions that can be submitted, but "
+"please remember that versions must be reviewed by an editor."
 msgstr ""
-"Os programadores são encorajados a apresentar atualizações para os seus "
-"extras para corrigir bugs, adicionar funcionalidades e, também, melhorar o "
-"seu produto. Novas versões de um extra devem ter um <a "
-"href=\"https://developer.mozilla.org/en/Toolkit_version_format\">número de "
-"versão maior</a> e podem ser enviados através das \"Ferramentas do "
-"programador\" fornecidas. Não há limite para o número de versões que podem "
-"ser enviadas, mas lembre-se que as versões devem ser revistas ​​por um "
-"editor."
+"Os programadores são encorajados a apresentar atualizações para os seus extras para corrigir bugs, adicionar funcionalidades e, também, melhorar o seu produto. Novas versões de um extra devem ter "
+"um <a href=\"https://developer.mozilla.org/en/Toolkit_version_format\">número de versão maior</a> e podem ser enviados através das \"Ferramentas do programador\" fornecidas. Não há limite para o "
+"número de versões que podem ser enviadas, mas lembre-se que as versões devem ser revistas ​​por um editor."
 
 #: src/olympia/devhub/templates/devhub/docs/policies-maintenance.html:18
-msgid ""
-"New versions will be added to a pending review queue, and any additional "
-"versions submitted before the review is completed will move that version to "
-"the end of the queue."
-msgstr ""
-"Novas versões serão adicionados a uma fila de revisão pendente, e todas as "
-"versões adicionais apresentadas antes que a revisão esteja concluída vai "
-"passar essa versão para o final da fila."
+msgid "New versions will be added to a pending review queue, and any additional versions submitted before the review is completed will move that version to the end of the queue."
+msgstr "Novas versões serão adicionados a uma fila de revisão pendente, e todas as versões adicionais apresentadas antes que a revisão esteja concluída vai passar essa versão para o final da fila."
 
 #: src/olympia/devhub/templates/devhub/docs/policies-maintenance.html:23
 msgid "How do I submit a Beta add-on?"
@@ -6655,57 +5343,35 @@ msgstr "Como submeto um extra Beta?"
 
 #: src/olympia/devhub/templates/devhub/docs/policies-maintenance.html:25
 msgid "Beta channels are only available to fully-reviewed add-ons."
-msgstr ""
-"Os canais Beta apenas estão disponíveis para extras revistos na totalidade."
+msgstr "Os canais Beta apenas estão disponíveis para extras revistos na totalidade."
 
 #: src/olympia/devhub/templates/devhub/docs/policies-maintenance.html:31
 msgid ""
-"To create a beta channel, upload a file with a unique version string that "
-"contains any of the following strings: <code>a,b,alpha,beta,pre,rc</code>, "
-"with an optional number at the end. This text must come at the end of the "
-"version string. If you understand regex format, here's what we look for in "
-"the version number: <code>\"(a|alpha|b|beta|pre|rc)\\d*$\"</code>."
+"To create a beta channel, upload a file with a unique version string that contains any of the following strings: <code>a,b,alpha,beta,pre,rc</code>, with an optional number at the end. This text "
+"must come at the end of the version string. If you understand regex format, here's what we look for in the version number: <code>\"(a|alpha|b|beta|pre|rc)\\d*$\"</code>."
 msgstr ""
-"Para criar um canal beta, fazer upload de um ficheiro com um string de "
-"versão único que contenha qualquer um dos seguintes textos: "
-"<code>a,b,alpha,beta,pre,rc</code>, com um número opcional no final. Este "
-"texto deve vir no final do string da versão. Se compreender o formato regex,"
-" aqui está o que procuramos no número da versão: "
-"<code>\"(a|alpha|b|beta|pre|rc)\\d*$\"</code>."
+"Para criar um canal beta, fazer upload de um ficheiro com um string de versão único que contenha qualquer um dos seguintes textos: <code>a,b,alpha,beta,pre,rc</code>, com um número opcional no "
+"final. Este texto deve vir no final do string da versão. Se compreender o formato regex, aqui está o que procuramos no número da versão: <code>\"(a|alpha|b|beta|pre|rc)\\d*$\"</code>."
 
 #: src/olympia/devhub/templates/devhub/docs/policies-maintenance.html:37
 msgid ""
-"Once a file meeting this criteria is uploaded to AMO, it will automatically "
-"be marked as a beta version. Users of add-ons with these unique version "
-"numbers will automatically be served the newest beta updates."
+"Once a file meeting this criteria is uploaded to AMO, it will automatically be marked as a beta version. Users of add-ons with these unique version numbers will automatically be served the newest "
+"beta updates."
 msgstr ""
-"Uma vez que um ficheiro cumpra os critérios é carregado para AMO, ele será "
-"automaticamente marcado como uma versão beta. Utilizadores de extras com "
-"estes números de versão original serão automaticamente atualizados para a "
-"nova versão beta."
+"Uma vez que um ficheiro cumpra os critérios é carregado para AMO, ele será automaticamente marcado como uma versão beta. Utilizadores de extras com estes números de versão original serão "
+"automaticamente atualizados para a nova versão beta."
 
 #: src/olympia/devhub/templates/devhub/docs/policies-maintenance.html:43
 msgid ""
-"While we call these \"Beta versions\", you can use this channel for "
-"nightlies, or alphas, or prerelease versions as you wish. Please note that "
-"there is only one channel for this purpose and all of your users on this "
-"channel will receive the latest add-ons submitted. For instance, if you "
-"upload <code>1.0beta1</code> to the release channel and then upload "
-"<code>1.1alpha1</code>, all users of <code>1.0beta1</code> will be offered "
-"an upgrade to <code>1.1alpha1</code>. Updates are pushed by submission date "
-"and not version number, so users will always get the most recent channel "
-"update regardless of any kind of alphabetical sorting."
+"While we call these \"Beta versions\", you can use this channel for nightlies, or alphas, or prerelease versions as you wish. Please note that there is only one channel for this purpose and all of "
+"your users on this channel will receive the latest add-ons submitted. For instance, if you upload <code>1.0beta1</code> to the release channel and then upload <code>1.1alpha1</code>, all users of "
+"<code>1.0beta1</code> will be offered an upgrade to <code>1.1alpha1</code>. Updates are pushed by submission date and not version number, so users will always get the most recent channel update "
+"regardless of any kind of alphabetical sorting."
 msgstr ""
-"Enquanto nós chamamos \"versões Beta\", pode usar este canal para nightlies,"
-" ou alphas, ou versões de pré-lançamento como desejar. Por favor, note que "
-"há apenas um canal para este fim e todos os seus utilizadores deste canal "
-"irão receber os últimas extras submetidos. Por exemplo, se você carregar "
-"<code>1.0beta1</code> para o canal de lançamento e em seguida carregar "
-"<code>1.1alpha1</code>, todos os utilizadores de <code>1.0beta1</code> terão"
-" uma atualização para <code>1.1alpha1</code>. As atualizações são enviadas "
-"por data de submissão e não pelo número da versão, para que os utilizadores "
-"obtenham sempre a atualização mais recente do canal, independentemente de "
-"qualquer tipo de ordenação alfabética."
+"Enquanto nós chamamos \"versões Beta\", pode usar este canal para nightlies, ou alphas, ou versões de pré-lançamento como desejar. Por favor, note que há apenas um canal para este fim e todos os "
+"seus utilizadores deste canal irão receber os últimas extras submetidos. Por exemplo, se você carregar <code>1.0beta1</code> para o canal de lançamento e em seguida carregar <code>1.1alpha1</code>, "
+"todos os utilizadores de <code>1.0beta1</code> terão uma atualização para <code>1.1alpha1</code>. As atualizações são enviadas por data de submissão e não pelo número da versão, para que os "
+"utilizadores obtenham sempre a atualização mais recente do canal, independentemente de qualquer tipo de ordenação alfabética."
 
 #: src/olympia/devhub/templates/devhub/docs/policies-maintenance.html:48
 msgid "Required Updates"
@@ -6713,22 +5379,13 @@ msgstr "Atualizações necessárias"
 
 #: src/olympia/devhub/templates/devhub/docs/policies-maintenance.html:50
 msgid ""
-"Certain situations may arise in which Mozilla requests that an add-on "
-"developer update their add-on within a given time period to address a major "
-"security issue or policy violation. We work with developers to reasonably "
-"accommodate their own schedules, but if the issue is of a serious enough "
-"nature, add-ons that cannot issue an update with the requested fix may be "
-"demoted from fully-reviewed status, disabled, or permanently removed from "
-"the site."
+"Certain situations may arise in which Mozilla requests that an add-on developer update their add-on within a given time period to address a major security issue or policy violation. We work with "
+"developers to reasonably accommodate their own schedules, but if the issue is of a serious enough nature, add-ons that cannot issue an update with the requested fix may be demoted from fully-"
+"reviewed status, disabled, or permanently removed from the site."
 msgstr ""
-"Podem surgir situações em que a Mozilla pode pedir a um programador de "
-"extras para atualizar os seus extras dentro de um determinado período de "
-"tempo para resolver um grande problema de segurança ou uma violação de "
-"política. Nós trabalhamos com os programadores para definir os seus próprios"
-" horários, mas se o problema for de natureza suficientemente grave, os "
-"extras que não lançarem uma atualização com a correção necessária podem ser "
-"despromovidos de estarem totalmente revistos, serem desativados ou removidos"
-" de forma permanente do site."
+"Podem surgir situações em que a Mozilla pode pedir a um programador de extras para atualizar os seus extras dentro de um determinado período de tempo para resolver um grande problema de segurança "
+"ou uma violação de política. Nós trabalhamos com os programadores para definir os seus próprios horários, mas se o problema for de natureza suficientemente grave, os extras que não lançarem uma "
+"atualização com a correção necessária podem ser despromovidos de estarem totalmente revistos, serem desativados ou removidos de forma permanente do site."
 
 #: src/olympia/devhub/templates/devhub/docs/policies-maintenance.html:55
 msgid "Transfer of Ownership"
@@ -6736,66 +5393,41 @@ msgstr "Transferência de propriedade"
 
 #: src/olympia/devhub/templates/devhub/docs/policies-maintenance.html:57
 msgid ""
-"Add-ons can have multiple users with permission to update and manage the "
-"listing. Existing authors of an add-on can transfer ownership and add "
-"additional developers to an add-on's listing through the Developer Tools "
-"provided. No interaction with Mozilla representatives is necessary for a "
-"transfer of ownership."
+"Add-ons can have multiple users with permission to update and manage the listing. Existing authors of an add-on can transfer ownership and add additional developers to an add-on's listing through "
+"the Developer Tools provided. No interaction with Mozilla representatives is necessary for a transfer of ownership."
 msgstr ""
-"Os extras podem ter vários utilizadores com permissão para atualizar e gerir"
-" a listagem. Os autores existentes de um extra podem transferir a "
-"propriedade e adicionar programadores adicionais para uma listagem do extra "
-"através das Ferramentas do programador fornecidas. Nenhuma interação com "
-"representantes da Mozilla é necessária para uma transferência de "
-"propriedade."
+"Os extras podem ter vários utilizadores com permissão para atualizar e gerir a listagem. Os autores existentes de um extra podem transferir a propriedade e adicionar programadores adicionais para "
+"uma listagem do extra através das Ferramentas do programador fornecidas. Nenhuma interação com representantes da Mozilla é necessária para uma transferência de propriedade."
 
 #: src/olympia/devhub/templates/devhub/docs/policies-maintenance.html:63
 #, python-format
-msgid ""
-"Mozilla can assist with granting additional permissions of an add-on's "
-"listing if <a href=\"%(link_contact)s\">contacted</a> by the add-on's "
-"current owner."
-msgstr ""
-"A Mozilla pode ajudar com a concessão de permissões adicionais de uma lista "
-"de extras, se for <a href=\"%(link_contact)s\">contactada</a> pelo "
-"proprietário atual do extra."
+msgid "Mozilla can assist with granting additional permissions of an add-on's listing if <a href=\"%(link_contact)s\">contacted</a> by the add-on's current owner."
+msgstr "A Mozilla pode ajudar com a concessão de permissões adicionais de uma lista de extras, se for <a href=\"%(link_contact)s\">contactada</a> pelo proprietário atual do extra."
 
 #: src/olympia/devhub/templates/devhub/docs/policies-maintenance.html:70
 msgid ""
-"Mozilla encourages its users to offer feedback on their experiences when "
-"using an add-on. This allows other users to determine if the add-on is "
-"stable and useful. It also provides valuable feedback to developers, "
-"allowing them to continuously improve their add-on to meet user needs."
+"Mozilla encourages its users to offer feedback on their experiences when using an add-on. This allows other users to determine if the add-on is stable and useful. It also provides valuable feedback "
+"to developers, allowing them to continuously improve their add-on to meet user needs."
 msgstr ""
-"A Mozilla incentiva os seus utilizadores a oferecer feedback sobre as suas "
-"experiências ao utilizar um extra. Isto permite que outros utilizadores "
-"determinem se o extra é estável e útil. Também fornece informações valiosas "
-"para os programadores, permitindo-lhes melhorar continuamente os seus extra "
-"para atender às necessidades do utilizador."
+"A Mozilla incentiva os seus utilizadores a oferecer feedback sobre as suas experiências ao utilizar um extra. Isto permite que outros utilizadores determinem se o extra é estável e útil. Também "
+"fornece informações valiosas para os programadores, permitindo-lhes melhorar continuamente os seus extra para atender às necessidades do utilizador."
 
 #: src/olympia/devhub/templates/devhub/docs/policies-maintenance.html:76
 #, python-format
 msgid ""
-"Reviews must follow the <a href=\"%(link_guidelines)s\">review "
-"guidelines</a>. Reviews that do not meet these guidelines may be flagged for"
-" moderation, but negative reviews will not be removed unless they provide "
-"false information."
+"Reviews must follow the <a href=\"%(link_guidelines)s\">review guidelines</a>. Reviews that do not meet these guidelines may be flagged for moderation, but negative reviews will not be removed "
+"unless they provide false information."
 msgstr ""
-"Os comentários devem seguir as <a href=\"%(link_guidelines)s\">diretrizes de"
-" comentários</a>. Os comentários que não cumprirem estas diretrizes pode ser"
-" marcadas para moderação, mas comentários negativos não serão removidos a "
-"menos que forneça informações falsas."
+"Os comentários devem seguir as <a href=\"%(link_guidelines)s\">diretrizes de comentários</a>. Os comentários que não cumprirem estas diretrizes pode ser marcadas para moderação, mas comentários "
+"negativos não serão removidos a menos que forneça informações falsas."
 
 #: src/olympia/devhub/templates/devhub/docs/policies-maintenance.html:82
 msgid ""
-"Many developers provide a support mechanism, such as a forum, discussion "
-"group, or email address. It is recommended that support questions be posted "
-"via those mediums instead of in an add-on's review section."
+"Many developers provide a support mechanism, such as a forum, discussion group, or email address. It is recommended that support questions be posted via those mediums instead of in an add-on's "
+"review section."
 msgstr ""
-"Muitos programadores fornecem um mecanismo de suporte, tais como fóruns, "
-"grupos de discussão ou um endereço de email. É recomendável que questões de "
-"suporte sejam colocadas através destes canais em vez da secção de análises "
-"do extra."
+"Muitos programadores fornecem um mecanismo de suporte, tais como fóruns, grupos de discussão ou um endereço de email. É recomendável que questões de suporte sejam colocadas através destes canais em "
+"vez da secção de análises do extra."
 
 #: src/olympia/devhub/templates/devhub/docs/policies-maintenance.html:87
 msgid "Code Disputes"
@@ -6803,44 +5435,25 @@ msgstr "Disputas de código"
 
 #: src/olympia/devhub/templates/devhub/docs/policies-maintenance.html:90
 msgid ""
-"Many add-ons allow their source code to be openly viewed. This does not mean"
-" that the source code is open source or available for use in another add-on."
-" The original author of an add-on retains copyright of their work unless "
-"otherwise noted in the add-on's license."
+"Many add-ons allow their source code to be openly viewed. This does not mean that the source code is open source or available for use in another add-on. The original author of an add-on retains "
+"copyright of their work unless otherwise noted in the add-on's license."
 msgstr ""
-"Muitos extras permitem que o seu código-fonte possa ser visto abertamente. "
-"Isso não significa que o código fonte é open source ou esteja disponível "
-"para uso noutro extra. O autor original de um extra retém os  direitos de "
-"autor de seu trabalho salvo indicação em contrário na licença do extra."
+"Muitos extras permitem que o seu código-fonte possa ser visto abertamente. Isso não significa que o código fonte é open source ou esteja disponível para uso noutro extra. O autor original de um "
+"extra retém os  direitos de autor de seu trabalho salvo indicação em contrário na licença do extra."
 
 #: src/olympia/devhub/templates/devhub/docs/policies-maintenance.html:96
 msgid ""
-"In the event that we're notified of a copyright or license infringement, we "
-"will take steps to review the situation and determine if an actual "
-"infringement has occurred. If we determine that there is an infringement, we"
-" will remove the offending add-on and contact the author. New add-on "
-"submissions (including updates) containing infringing code will be denied "
-"approval for public status."
+"In the event that we're notified of a copyright or license infringement, we will take steps to review the situation and determine if an actual infringement has occurred. If we determine that there "
+"is an infringement, we will remove the offending add-on and contact the author. New add-on submissions (including updates) containing infringing code will be denied approval for public status."
 msgstr ""
-"No caso de sermos notificados de uma violação de direitos de autor ou "
-"licença, tomaremos medidas para rever a situação e determinar se ocorreu uma"
-" violação. Se se determinar que existe uma infração, vamos remover o extra "
-"em causa e contactar o autor. Novas submissões do extra (incluindo "
-"atualizações) contendo o código infrator terão a aprovação de estatuto "
-"público negada."
+"No caso de sermos notificados de uma violação de direitos de autor ou licença, tomaremos medidas para rever a situação e determinar se ocorreu uma violação. Se se determinar que existe uma "
+"infração, vamos remover o extra em causa e contactar o autor. Novas submissões do extra (incluindo atualizações) contendo o código infrator terão a aprovação de estatuto público negada."
 
 #: src/olympia/devhub/templates/devhub/docs/policies-maintenance.html:102
-msgid ""
-"If you are unsure of the current copyright status of an add-on's source "
-"code, you must contact the original author and receive explicit permission "
-"before using the source code."
-msgstr ""
-"Se você não tiver certeza do estado de copyright atual de um código fonte de"
-" um extra, você deve contactar o autor original e receber permissão "
-"explícita antes de usar o código fonte."
+msgid "If you are unsure of the current copyright status of an add-on's source code, you must contact the original author and receive explicit permission before using the source code."
+msgstr "Se você não tiver certeza do estado de copyright atual de um código fonte de um extra, você deve contactar o autor original e receber permissão explícita antes de usar o código fonte."
 
-#: src/olympia/devhub/templates/devhub/docs/policies-maintenance.html:107
-#: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:306
+#: src/olympia/devhub/templates/devhub/docs/policies-maintenance.html:107 src/olympia/devhub/templates/devhub/docs/policies-reviews.html:306
 #: src/olympia/devhub/templates/devhub/docs/policies-submission.html:97
 msgid "Last updated: January 13, 2011"
 msgstr "Última atualização: 13 de Janeiro de 2011"
@@ -6848,54 +5461,35 @@ msgstr "Última atualização: 13 de Janeiro de 2011"
 #: src/olympia/devhub/templates/devhub/docs/policies-recommended.html:13
 #, python-format
 msgid ""
-"Featured add-ons are top-quality extensions and themes highlighted on <a "
-"href=\"%(link_gallery)s\">AMO</a>, Firefox's Add-ons Manager, and across "
-"other Mozilla websites. These add-ons showcase the power of Firefox "
-"customization and are useful to a wide audience."
+"Featured add-ons are top-quality extensions and themes highlighted on <a href=\"%(link_gallery)s\">AMO</a>, Firefox's Add-ons Manager, and across other Mozilla websites. These add-ons showcase the "
+"power of Firefox customization and are useful to a wide audience."
 msgstr ""
-"Extras em destaque são extensões e temas de qualidade superior destacados no"
-" <a href=\"%(link_gallery)s\">AMO</a>, o Gestor de extras do Firefox, e "
-"outros sites web da Mozilla. Estes extras mostram o poder da personalização "
-"do Firefox e são úteis para uma audiência mais ampla."
+"Extras em destaque são extensões e temas de qualidade superior destacados no <a href=\"%(link_gallery)s\">AMO</a>, o Gestor de extras do Firefox, e outros sites web da Mozilla. Estes extras mostram "
+"o poder da personalização do Firefox e são úteis para uma audiência mais ampla."
 
 #: src/olympia/devhub/templates/devhub/docs/policies-recommended.html:19
 msgid ""
-"Featured add-ons are chosen by the Featured Add-ons Advisory Board, a small "
-"group of add-on developers and fans from the Mozilla community who have "
-"volunteered to review and vote on nominations."
+"Featured add-ons are chosen by the Featured Add-ons Advisory Board, a small group of add-on developers and fans from the Mozilla community who have volunteered to review and vote on nominations."
 msgstr ""
-"Os extras em destaque são escolhidos pelo Conselho Consultivo de Extras em "
-"Destaque, um pequeno grupo de programadores e fãs de extras da comunidade "
-"Mozilla que se voluntariaram para rever e votar em nomeados."
+"Os extras em destaque são escolhidos pelo Conselho Consultivo de Extras em Destaque, um pequeno grupo de programadores e fãs de extras da comunidade Mozilla que se voluntariaram para rever e votar "
+"em nomeados."
 
 #: src/olympia/devhub/templates/devhub/docs/policies-recommended.html:25
 #, python-format
-msgid ""
-"<a href=\"%(link_featured)s\">Featured extensions</a> are chosen every "
-"month, and <a href=\"%(link_themes)s\">featured complete themes</a> are "
-"chosen every quarter."
-msgstr ""
-"<a href=\"%(link_featured)s\">Extensões em destaque</a> são escolhidos todos"
-" os meses e <a href=\"%(link_themes)s\">temas completos em destaque</a> são "
-"escolhidos todos os trimestres."
+msgid "<a href=\"%(link_featured)s\">Featured extensions</a> are chosen every month, and <a href=\"%(link_themes)s\">featured complete themes</a> are chosen every quarter."
+msgstr "<a href=\"%(link_featured)s\">Extensões em destaque</a> são escolhidos todos os meses e <a href=\"%(link_themes)s\">temas completos em destaque</a> são escolhidos todos os trimestres."
 
 #: src/olympia/devhub/templates/devhub/docs/policies-recommended.html:30
 msgid "Criteria for Featured Add-ons"
 msgstr "Critério para extras em destaque"
 
 #: src/olympia/devhub/templates/devhub/docs/policies-recommended.html:33
-msgid ""
-"Before nominating an add-on to be featured, please ensure it meets the "
-"following criteria:"
-msgstr ""
-"Antes de nomear um extra para ser destacado, por favor garanta que cumpre os"
-" seguintes critérios:"
+msgid "Before nominating an add-on to be featured, please ensure it meets the following criteria:"
+msgstr "Antes de nomear um extra para ser destacado, por favor garanta que cumpre os seguintes critérios:"
 
 #: src/olympia/devhub/templates/devhub/docs/policies-recommended.html:39
-msgid ""
-"The add-on must have a complete and informative listing on AMO. This means:"
-msgstr ""
-"O extra deve ter uma listagem completa e informativa na AMO. Isto significa:"
+msgid "The add-on must have a complete and informative listing on AMO. This means:"
+msgstr "O extra deve ter uma listagem completa e informativa na AMO. Isto significa:"
 
 #: src/olympia/devhub/templates/devhub/docs/policies-recommended.html:41
 msgid "a 64-pixel custom icon"
@@ -6918,44 +5512,28 @@ msgid "updated screenshots of the add-on's functionality"
 msgstr "miniaturas atualizadas da funcionalidade do extra"
 
 #: src/olympia/devhub/templates/devhub/docs/policies-recommended.html:46
-msgid ""
-"must be fully approved by AMO editors (no preliminarily reviewed entries)"
-msgstr ""
-"tem de ser totalmente aprovado pelos editores da AMO (sem entradas de "
-"revisão preliminares)"
+msgid "must be fully approved by AMO editors (no preliminarily reviewed entries)"
+msgstr "tem de ser totalmente aprovado pelos editores da AMO (sem entradas de revisão preliminares)"
 
 #: src/olympia/devhub/templates/devhub/docs/policies-recommended.html:48
-msgid ""
-"The add-on must have excellent user reviews and any problems or support "
-"requests must be promptly addressed by the developer."
-msgstr ""
-"O extra deve ter comentários excelentes e quaisquer problemas ou pedidos de "
-"apoio devem ser prontamente resolvidos pelo programador."
+msgid "The add-on must have excellent user reviews and any problems or support requests must be promptly addressed by the developer."
+msgstr "O extra deve ter comentários excelentes e quaisquer problemas ou pedidos de apoio devem ser prontamente resolvidos pelo programador."
 
 #: src/olympia/devhub/templates/devhub/docs/policies-recommended.html:49
 msgid "The add-on must have a minimum of 2,000 users."
 msgstr "O extra tem de ter um mínimo de 2000 utilizadores."
 
 #: src/olympia/devhub/templates/devhub/docs/policies-recommended.html:50
-msgid ""
-"The add-on must be compatible with the latest release of Firefox and must be"
-" compatible with beta versions 4 weeks before their final release."
-msgstr ""
-"O extra deve ser compatível com a última versão do Firefox e deve ser "
-"compatível com as versões beta, 4 semanas antes do seu lançamento final."
+msgid "The add-on must be compatible with the latest release of Firefox and must be compatible with beta versions 4 weeks before their final release."
+msgstr "O extra deve ser compatível com a última versão do Firefox e deve ser compatível com as versões beta, 4 semanas antes do seu lançamento final."
 
 #: src/olympia/devhub/templates/devhub/docs/policies-recommended.html:51
 msgid ""
-"<strong>Most importantly</strong>, the add-on must have wide consumer appeal"
-" to Firefox's users and be outstanding in nearly every way: user experience,"
-" performance, security, and usefulness or entertainment value. Featured "
-"complete themes must also be visually appealing."
+"<strong>Most importantly</strong>, the add-on must have wide consumer appeal to Firefox's users and be outstanding in nearly every way: user experience, performance, security, and usefulness or "
+"entertainment value. Featured complete themes must also be visually appealing."
 msgstr ""
-"<strong>Mais importante</strong>, o extra tem de ser apelativo para um "
-"grande número de utilizadores do FIrefox e ser excecional em quase todos os "
-"aspetos: experiência do utilizador, performance, segurança e utilidade ou "
-"valor lúdico. Os temas completos em destaque devem ainda ser apelativos "
-"visualmente."
+"<strong>Mais importante</strong>, o extra tem de ser apelativo para um grande número de utilizadores do FIrefox e ser excecional em quase todos os aspetos: experiência do utilizador, performance, "
+"segurança e utilidade ou valor lúdico. Os temas completos em destaque devem ainda ser apelativos visualmente."
 
 #: src/olympia/devhub/templates/devhub/docs/policies-recommended.html:54
 msgid "Nominating an Add-on"
@@ -6967,272 +5545,163 @@ msgstr "em destaque na amo em mozilla dot org"
 
 #: src/olympia/devhub/templates/devhub/docs/policies-recommended.html:57
 #, python-format
-msgid ""
-"If you wish to nominate an add-on to be featured and it meets the criteria "
-"above, send an email to %(mail_featured)s with:"
-msgstr ""
-"Se deseja nomear um extra para ser apresentado e que atenda aos critérios "
-"acima, envie um email para %(mail_featured)s com:"
+msgid "If you wish to nominate an add-on to be featured and it meets the criteria above, send an email to %(mail_featured)s with:"
+msgstr "Se deseja nomear um extra para ser apresentado e que atenda aos critérios acima, envie um email para %(mail_featured)s com:"
 
 #: src/olympia/devhub/templates/devhub/docs/policies-recommended.html:62
 msgid "the add-on name, URL, and whether you are its developer"
 msgstr "o nome do extra, URL, e se é você o respetivo programador"
 
 #: src/olympia/devhub/templates/devhub/docs/policies-recommended.html:63
-msgid ""
-"a short explanation of why the add-on has wide appeal and should be featured"
-msgstr ""
-"uma explicação curta sobre o porquê do extra ser apelativo e os motivos "
-"pelos quais deve ser destacado"
+msgid "a short explanation of why the add-on has wide appeal and should be featured"
+msgstr "uma explicação curta sobre o porquê do extra ser apelativo e os motivos pelos quais deve ser destacado"
 
 #: src/olympia/devhub/templates/devhub/docs/policies-recommended.html:64
-msgid ""
-"optionally, links to any external reviews or articles mentioning the add-on"
-msgstr ""
-"opcionalmente, ligações para quaisquer revisões externas ou artigos "
-"mencionando o extra"
+msgid "optionally, links to any external reviews or articles mentioning the add-on"
+msgstr "opcionalmente, ligações para quaisquer revisões externas ou artigos mencionando o extra"
 
 #: src/olympia/devhub/templates/devhub/docs/policies-recommended.html:68
 msgid ""
-"Add-on nominations are reviewed by the Advisory Board once a month (once "
-"every 3 months for complete theme nominations). Common reasons for rejection"
-" include lacking wide appeal to consumers, a suboptimal user experience, "
-"quality or security issues, incompatibility, and similarity to another "
-"featured add-on. Rejected add-ons cannot be re-nominated within 3 months."
+"Add-on nominations are reviewed by the Advisory Board once a month (once every 3 months for complete theme nominations). Common reasons for rejection include lacking wide appeal to consumers, a "
+"suboptimal user experience, quality or security issues, incompatibility, and similarity to another featured add-on. Rejected add-ons cannot be re-nominated within 3 months."
 msgstr ""
-"As nomeações de extras são revistas pelo Conselho Consultivo uma vez por mês"
-" (uma todos os 3 meses para nomeações de tema completas). As razões mais "
-"comuns de rejeição incluem falta de apelo aos consumidores, experiência de "
-"utilizador não ideal, qualidade ou problemas de segurança, incompatibilidade"
-" e semelhanças com outro extra destacado. Extras rejeitados não podem ser "
-"re-nomeados durante 3 meses. "
+"As nomeações de extras são revistas pelo Conselho Consultivo uma vez por mês (uma todos os 3 meses para nomeações de tema completas). As razões mais comuns de rejeição incluem falta de apelo aos "
+"consumidores, experiência de utilizador não ideal, qualidade ou problemas de segurança, incompatibilidade e semelhanças com outro extra destacado. Extras rejeitados não podem ser re-nomeados "
+"durante 3 meses. "
 
 #: src/olympia/devhub/templates/devhub/docs/policies-recommended.html:73
 msgid "Rotating Featured Add-ons"
 msgstr "Rodar extras em destaque"
 
 #: src/olympia/devhub/templates/devhub/docs/policies-recommended.html:76
-msgid ""
-"Mozilla and the Featured Add-ons Advisory Board regularly evaluate and "
-"rotate out featured add-ons. Some of the most common reasons for add-ons "
-"being removed from the featured list are:"
-msgstr ""
-"A Mozilla e o Conselho de Extras em Destaque reavaliam e renovam os extras "
-"em destaque. Algumas das razões mais comuns para um extra deixar de estar em"
-" destaque são:"
+msgid "Mozilla and the Featured Add-ons Advisory Board regularly evaluate and rotate out featured add-ons. Some of the most common reasons for add-ons being removed from the featured list are:"
+msgstr "A Mozilla e o Conselho de Extras em Destaque reavaliam e renovam os extras em destaque. Algumas das razões mais comuns para um extra deixar de estar em destaque são:"
 
 #: src/olympia/devhub/templates/devhub/docs/policies-recommended.html:83
 msgid ""
-"Lack of growth &mdash; Add-ons that are featured typically experience a "
-"substantial gain in both downloads and active users. If an add-on is not "
-"demonstrating growth in any substantial way, that's a good indicator the "
-"add-on may not be very useful to our users."
+"Lack of growth &mdash; Add-ons that are featured typically experience a substantial gain in both downloads and active users. If an add-on is not demonstrating growth in any substantial way, that's "
+"a good indicator the add-on may not be very useful to our users."
 msgstr ""
-"Falta de crescimento &mdash; Extras que são destacados, tipicamente "
-"experimentam um crescimento exponencial em número de descargas e "
-"utilizadores ativos. Se um extra não demonstra crescimento de um modo "
-"substancial, isso é um bom indicador de que o extra não é muito útil para os"
-" nossos utilizadores."
+"Falta de crescimento &mdash; Extras que são destacados, tipicamente experimentam um crescimento exponencial em número de descargas e utilizadores ativos. Se um extra não demonstra crescimento de um "
+"modo substancial, isso é um bom indicador de que o extra não é muito útil para os nossos utilizadores."
 
 #: src/olympia/devhub/templates/devhub/docs/policies-recommended.html:88
-msgid ""
-"Negative reviews &mdash; Featured add-ons should have a great experience and"
-" very few bugs, so add-ons with many negative reviews may be reconsidered."
-msgstr ""
-"Opiniões negativas &mdash; Os extras em destaque devem ter uma grande "
-"experiência e muito poucos erros, assim os extras com muitos comentários "
-"negativos podem ser reconsiderados."
+msgid "Negative reviews &mdash; Featured add-ons should have a great experience and very few bugs, so add-ons with many negative reviews may be reconsidered."
+msgstr "Opiniões negativas &mdash; Os extras em destaque devem ter uma grande experiência e muito poucos erros, assim os extras com muitos comentários negativos podem ser reconsiderados."
 
 #: src/olympia/devhub/templates/devhub/docs/policies-recommended.html:93
 msgid ""
-"Incompatibility with upcoming Firefox versions &mdash; Featured add-ons are "
-"expected to be compatible with stable and beta versions of Firefox. Add-ons "
-"not yet compatible with a Beta version of Firefox four weeks before its "
-"expected release will lose their featured status."
+"Incompatibility with upcoming Firefox versions &mdash; Featured add-ons are expected to be compatible with stable and beta versions of Firefox. Add-ons not yet compatible with a Beta version of "
+"Firefox four weeks before its expected release will lose their featured status."
 msgstr ""
-"Incompatibilidade com as próximas versões do Firefox &mdash; Espera-se que "
-"os extras em destaque sejam compatíveis com as versões estável e Beta do "
-"Firefox. Extras que ainda não são compatíveis quatro semanas antes com uma "
-"versão Beta do Firefox perdem o seu estatuto de destaque."
+"Incompatibilidade com as próximas versões do Firefox &mdash; Espera-se que os extras em destaque sejam compatíveis com as versões estável e Beta do Firefox. Extras que ainda não são compatíveis "
+"quatro semanas antes com uma versão Beta do Firefox perdem o seu estatuto de destaque."
 
 #: src/olympia/devhub/templates/devhub/docs/policies-recommended.html:99
 msgid "Joining the Featured Add-ons Advisory Board"
 msgstr "Juntar-se ao conselho consultivo dos extras"
 
 #: src/olympia/devhub/templates/devhub/docs/policies-recommended.html:102
-msgid ""
-"Every six months a new Advisory Board is chosen based on applications from "
-"the add-ons community. Members must:"
-msgstr ""
-"Todos os semestres o novo Conselho Consultivo é escolhido com base em "
-"aplicações da comunidade de extras. Os membros devem:"
+msgid "Every six months a new Advisory Board is chosen based on applications from the add-ons community. Members must:"
+msgstr "Todos os semestres o novo Conselho Consultivo é escolhido com base em aplicações da comunidade de extras. Os membros devem:"
 
 #: src/olympia/devhub/templates/devhub/docs/policies-recommended.html:108
-msgid ""
-"be active members of the add-ons community, whether as a developer, "
-"evangelist, or fan"
-msgstr ""
-"ser membros ativos da comunidade dos extras, seja como programador, "
-"evangelista, ou fã"
+msgid "be active members of the add-ons community, whether as a developer, evangelist, or fan"
+msgstr "ser membros ativos da comunidade dos extras, seja como programador, evangelista, ou fã"
 
 #: src/olympia/devhub/templates/devhub/docs/policies-recommended.html:109
-msgid ""
-"commit to trying all the nominations submitted, giving their feedback, and "
-"casting their votes every month"
-msgstr ""
-"comprometer-se a testar todas as nomeações submetidas, dando a sua opinião e"
-" submetendo os seus votos todos os meses"
+msgid "commit to trying all the nominations submitted, giving their feedback, and casting their votes every month"
+msgstr "comprometer-se a testar todas as nomeações submetidas, dando a sua opinião e submetendo os seus votos todos os meses"
 
 #: src/olympia/devhub/templates/devhub/docs/policies-recommended.html:110
-msgid ""
-"abstain from voting on add-ons that they have any business or personal "
-"affiliations with, as well as direct competitors of any such add-ons"
-msgstr ""
-"abster-se de votar em extras em que eles têm um negócio ou afiliações "
-"pessoais, assim como os concorrentes diretos desses extras"
+msgid "abstain from voting on add-ons that they have any business or personal affiliations with, as well as direct competitors of any such add-ons"
+msgstr "abster-se de votar em extras em que eles têm um negócio ou afiliações pessoais, assim como os concorrentes diretos desses extras"
 
 #: src/olympia/devhub/templates/devhub/docs/policies-recommended.html:114
 msgid ""
-"Members of the Mozilla Add-ons team may veto any add-on's selection because "
-"of security, privacy, compatibility, or any other reason, but in general it "
-"is up to the Board to select add-ons to feature."
+"Members of the Mozilla Add-ons team may veto any add-on's selection because of security, privacy, compatibility, or any other reason, but in general it is up to the Board to select add-ons to "
+"feature."
 msgstr ""
-"Os membros da equipa de extras da Mozilla por vetar a seleção de qualquer "
-"extra devido à segurança, privacidade, compatibilidade ou qualquer outra "
-"razão, mas no geral cabe ao Conselho selecionar que extras devem ser "
-"destacados."
+"Os membros da equipa de extras da Mozilla por vetar a seleção de qualquer extra devido à segurança, privacidade, compatibilidade ou qualquer outra razão, mas no geral cabe ao Conselho selecionar "
+"que extras devem ser destacados."
 
 #: src/olympia/devhub/templates/devhub/docs/policies-recommended.html:120
 msgid ""
-"This featured policy only applies to the addons.mozilla.org global list of "
-"featured add-ons. Add-ons featured in other locations are often pulled from "
-"this list, but Mozilla may feature any add-on in other locations without the"
-" Board's consent. Additionally, locale-specific features override the global"
-" defaults, so if a locale has opted to select its own features, some or all "
-"of the global features may not appear in that locale."
+"This featured policy only applies to the addons.mozilla.org global list of featured add-ons. Add-ons featured in other locations are often pulled from this list, but Mozilla may feature any add-on "
+"in other locations without the Board's consent. Additionally, locale-specific features override the global defaults, so if a locale has opted to select its own features, some or all of the global "
+"features may not appear in that locale."
 msgstr ""
-"Esta política de destaques apenas se aplica à lista global de extras "
-"destacados de addons.mozilla.org. Extras destacados noutras localizações são"
-" muitas vezes escolhidos desta lista, mas a Mozilla pode destacar qualquer "
-"extra em outras localizações sem o consentimento do Conselho. "
-"Adicionalmente, destaques específicos em determinados locais sobrepõem-se "
-"aos destaques globais por omissão, pelo que se uma região optar por "
-"selecionar os seus próprios destaques, alguns ou todos os destaques globais "
-"podem não ser apresentados para uma determinada região."
+"Esta política de destaques apenas se aplica à lista global de extras destacados de addons.mozilla.org. Extras destacados noutras localizações são muitas vezes escolhidos desta lista, mas a Mozilla "
+"pode destacar qualquer extra em outras localizações sem o consentimento do Conselho. Adicionalmente, destaques específicos em determinados locais sobrepõem-se aos destaques globais por omissão, "
+"pelo que se uma região optar por selecionar os seus próprios destaques, alguns ou todos os destaques globais podem não ser apresentados para uma determinada região."
 
 #: src/olympia/devhub/templates/devhub/docs/policies-recommended.html:126
 #, python-format
-msgid ""
-"Follow the <a href=\"%(link_blog)s\">Add-ons Blog</a> or <a "
-"href=\"%(link_twitter)s\">@mozamo</a> on Twitter to learn when the next "
-"application period opens."
-msgstr ""
-"Subscreva ao <a href=\"%(link_blog)s\">blogue dos extras</a> ou <a "
-"href=\"%(link_twitter)s\">@mozamo</a> no Twitter para saber quando é que o "
-"próximo período de candidatura começa."
+msgid "Follow the <a href=\"%(link_blog)s\">Add-ons Blog</a> or <a href=\"%(link_twitter)s\">@mozamo</a> on Twitter to learn when the next application period opens."
+msgstr "Subscreva ao <a href=\"%(link_blog)s\">blogue dos extras</a> ou <a href=\"%(link_twitter)s\">@mozamo</a> no Twitter para saber quando é que o próximo período de candidatura começa."
 
 #: src/olympia/devhub/templates/devhub/docs/policies-recommended.html:131
 msgid "Last updated: January 31, 2013"
 msgstr "Última atualização: 31 de Janeiro de 2013"
 
-#: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:3
-#: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:7
-#: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:8
-#: src/olympia/devhub/templates/devhub/docs/policies.html:15
-#: src/olympia/devhub/templates/devhub/docs/policies.html:64
+#: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:3 src/olympia/devhub/templates/devhub/docs/policies-reviews.html:7 src/olympia/devhub/templates/devhub/docs/policies-reviews.html:8
+#: src/olympia/devhub/templates/devhub/docs/policies.html:15 src/olympia/devhub/templates/devhub/docs/policies.html:64
 msgid "Review Process"
 msgstr "Processo de revisão"
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:12
 msgid ""
-"In order to ensure all add-ons hosted in our gallery are safe for users to "
-"install, Mozilla will begin requiring all hosted add-ons to undergo review. "
-"We offer two types of review and developers are free to choose the best fit "
-"for their add-on."
+"In order to ensure all add-ons hosted in our gallery are safe for users to install, Mozilla will begin requiring all hosted add-ons to undergo review. We offer two types of review and developers "
+"are free to choose the best fit for their add-on."
 msgstr ""
-"Com o objetivo de garantir que todos os extras alojados na nossa galeria são"
-" seguros para serem instalados pelos utilizadores, a Mozilla começará a "
-"exigir que todos os extras alojados sejam submetidos a uma revisão. Nós "
-"oferecemos dois tipos de revisão e os programadores são livres para escolher"
-" o que melhor se enquadra no seu extra."
+"Com o objetivo de garantir que todos os extras alojados na nossa galeria são seguros para serem instalados pelos utilizadores, a Mozilla começará a exigir que todos os extras alojados sejam "
+"submetidos a uma revisão. Nós oferecemos dois tipos de revisão e os programadores são livres para escolher o que melhor se enquadra no seu extra."
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:19
 msgid ""
-"<strong><a href=\"#full\">Full Review</a></strong> &mdash; a thorough "
-"functional and code review of the add-on, appropriate for add-ons ready for "
-"distribution to the masses. All site features are available to these add-"
-"ons."
+"<strong><a href=\"#full\">Full Review</a></strong> &mdash; a thorough functional and code review of the add-on, appropriate for add-ons ready for distribution to the masses. All site features are "
+"available to these add-ons."
 msgstr ""
-"<strong><a href=\"#full\">Análise completa</a></strong> &mdash; uma análise "
-"completa do código-fonte e funcionalidades do extra, adequada para extras "
-"prontos para a distribuição em massa. Todos os recursos do sitio estão "
-"disponíveis para esses extras."
+"<strong><a href=\"#full\">Análise completa</a></strong> &mdash; uma análise completa do código-fonte e funcionalidades do extra, adequada para extras prontos para a distribuição em massa. Todos os "
+"recursos do sitio estão disponíveis para esses extras."
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:24
 msgid ""
-"<strong><a href=\"#preliminary\">Preliminary Review</a></strong> &mdash; a "
-"faster review intended for experimental add-ons. Preliminary reviews do not "
-"check for functionality or full policy compliance, but the reviewed add-ons "
-"have install button cautions and some feature limitations."
+"<strong><a href=\"#preliminary\">Preliminary Review</a></strong> &mdash; a faster review intended for experimental add-ons. Preliminary reviews do not check for functionality or full policy "
+"compliance, but the reviewed add-ons have install button cautions and some feature limitations."
 msgstr ""
-"<strong><a href=\"#preliminary\">Análise preliminar</a></strong> &mdash; uma"
-" análise mais rápida destinada a extras experimentais. Análises preliminares"
-" não verificam funcionalidades ou o cumprimento pleno de nossas políticas, "
-"mas os extras analisados dessa forma exibem alertas na hora de sua "
-"instalação e possuem limites nos recursos disponíveis no sitio."
+"<strong><a href=\"#preliminary\">Análise preliminar</a></strong> &mdash; uma análise mais rápida destinada a extras experimentais. Análises preliminares não verificam funcionalidades ou o "
+"cumprimento pleno de nossas políticas, mas os extras analisados dessa forma exibem alertas na hora de sua instalação e possuem limites nos recursos disponíveis no sitio."
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:31
 msgid ""
-"Detailed descriptions of each option are below. After selecting a review "
-"process at submission, the add-on will be placed in the queue. Add-ons are "
-"reviewed by the <a href=\"https://wiki.mozilla.org/AMO:Editors\">AMO "
-"Editors</a>, a group of talented developers that volunteer to help the "
-"Mozilla project by reviewing add-ons to ensure a stable and safe experience "
-"for users. Developers will receive an email with any updates throughout the "
-"review process."
+"Detailed descriptions of each option are below. After selecting a review process at submission, the add-on will be placed in the queue. Add-ons are reviewed by the <a href=\"https://wiki.mozilla."
+"org/AMO:Editors\">AMO Editors</a>, a group of talented developers that volunteer to help the Mozilla project by reviewing add-ons to ensure a stable and safe experience for users. Developers will "
+"receive an email with any updates throughout the review process."
 msgstr ""
-"Descrições detalhadas de cada opção estão disponíveis abaixo. Após "
-"selecionar um processo de revisão, o extra será posicionado na fila de "
-"revisão. Os extras são revistos pelos <a "
-"href=\"https://wiki.mozilla.org/AMO:Editors\">Editores do AMO</a>, um grupo "
-"de talentosos programadores que são voluntários para ajudar o projeto "
-"Mozilla a analisar os extras e assegurar-se de que estes oferecem uma "
-"experiência estável e segura aos utilizadores. Os programadores irão receber"
-" uma mensagem com quaisquer atualizações durante o processo de revisão."
+"Descrições detalhadas de cada opção estão disponíveis abaixo. Após selecionar um processo de revisão, o extra será posicionado na fila de revisão. Os extras são revistos pelos <a href=\"https://"
+"wiki.mozilla.org/AMO:Editors\">Editores do AMO</a>, um grupo de talentosos programadores que são voluntários para ajudar o projeto Mozilla a analisar os extras e assegurar-se de que estes oferecem "
+"uma experiência estável e segura aos utilizadores. Os programadores irão receber uma mensagem com quaisquer atualizações durante o processo de revisão."
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:37
 msgid ""
-"While waiting for review, add-ons will not appear anywhere in the gallery "
-"publicly, but direct links to the add-on's details page will work. This "
-"allows the author to blog or share the link with friends, inviting them to "
-"try it out, even when not yet reviewed."
+"While waiting for review, add-ons will not appear anywhere in the gallery publicly, but direct links to the add-on's details page will work. This allows the author to blog or share the link with "
+"friends, inviting them to try it out, even when not yet reviewed."
 msgstr ""
-"Enquanto espera pela revisão, os extras não aparecem em qualquer lugar da "
-"galeria pública, mas as ligações diretas para a página de detalhes do extra "
-"irá funcionar. Isto permite ao autor de escrever no blog ou partilhar a "
-"ligação com os amigos, convidando-os a experimentá-lo, mesmo quando ainda "
-"não está revisto."
+"Enquanto espera pela revisão, os extras não aparecem em qualquer lugar da galeria pública, mas as ligações diretas para a página de detalhes do extra irá funcionar. Isto permite ao autor de "
+"escrever no blog ou partilhar a ligação com os amigos, convidando-os a experimentá-lo, mesmo quando ainda não está revisto."
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:44
 msgid ""
-"Full reviews are appropriate for add-ons that are well-tested, stable, fast,"
-" and have wide appeal to our users. If you aren't confident that your add-on"
-" meets that criteria, please consider working out the kinks while in "
-"preliminary review and accumulating user feedback first."
+"Full reviews are appropriate for add-ons that are well-tested, stable, fast, and have wide appeal to our users. If you aren't confident that your add-on meets that criteria, please consider working "
+"out the kinks while in preliminary review and accumulating user feedback first."
 msgstr ""
-"As revisões completas são adequadas para extras bem testados, estáveis, "
-"rápidos e que possuem um grande apelo aos nossos utilizadores. Se você não "
-"tem certeza que o seu extra atende a esses critérios, considere corrigir "
-"estes problemas durante a revisão preliminar e reunir opiniões dos seus "
-"utilizadores antes."
+"As revisões completas são adequadas para extras bem testados, estáveis, rápidos e que possuem um grande apelo aos nossos utilizadores. Se você não tem certeza que o seu extra atende a esses "
+"critérios, considere corrigir estes problemas durante a revisão preliminar e reunir opiniões dos seus utilizadores antes."
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:50
-msgid ""
-"We aim to perform full reviews in under 10 days, though most add-ons are "
-"reviewed in much less time."
-msgstr ""
-"O nosso objetivo é realizar revisões completas em menos de 10 dias, embora a"
-" maioria dos extras sejam revistos em muito menos tempo."
+msgid "We aim to perform full reviews in under 10 days, though most add-ons are reviewed in much less time."
+msgstr "O nosso objetivo é realizar revisões completas em menos de 10 dias, embora a maioria dos extras sejam revistos em muito menos tempo."
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:55
 msgid "Testing Methods &amp; Common Issues"
@@ -7243,62 +5712,36 @@ msgid "When performing a full review, editors will:"
 msgstr "Ao efectuar uma revisão completa os editores farão:"
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:64
-msgid ""
-"install the add-on, making sure it functions as described and is free of "
-"major defects"
-msgstr ""
-"a intalação do extra, vendo que funciona como está descrito e está livre da "
-"maioria de erros"
+msgid "install the add-on, making sure it functions as described and is free of major defects"
+msgstr "a intalação do extra, vendo que funciona como está descrito e está livre da maioria de erros"
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:69
-msgid ""
-"perform a source code review, looking for performance and security best "
-"practices"
-msgstr ""
-"a revisão do código fonte, procurando as boas práticas relativas a "
-"desempenho e segurança"
+msgid "perform a source code review, looking for performance and security best practices"
+msgstr "a revisão do código fonte, procurando as boas práticas relativas a desempenho e segurança"
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:74
 msgid "ensure the add-on's privacy policy is in line with its functionality"
-msgstr ""
-"a verificação que a política de privacidade está em linha com a sua "
-"funcionalidade"
+msgstr "a verificação que a política de privacidade está em linha com a sua funcionalidade"
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:79
-msgid ""
-"look for compliance with all of Mozilla's policies, detailed in these "
-"documents"
-msgstr ""
-"verifique a conformidade com todas as políticas da Mozilla, detalhadas "
-"nestes documentos"
+msgid "look for compliance with all of Mozilla's policies, detailed in these documents"
+msgstr "verifique a conformidade com todas as políticas da Mozilla, detalhadas nestes documentos"
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:86
-msgid ""
-"Some of the most common issues we see when performing these reviews are:"
-msgstr ""
-"Alguns dos problemas mais comuns que vemos durante a execução dessas "
-"análises são:"
+msgid "Some of the most common issues we see when performing these reviews are:"
+msgstr "Alguns dos problemas mais comuns que vemos durante a execução dessas análises são:"
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:93
 msgid ""
-"<strong>JavaScript namespace pollution</strong> &mdash; the most common "
-"violation. Be sure to <a "
-"href=\"https://developer.mozilla.org/en/XUL_School/JavaScript_Object_Management\">wrap"
-" your loose variables</a>"
+"<strong>JavaScript namespace pollution</strong> &mdash; the most common violation. Be sure to <a href=\"https://developer.mozilla.org/en/XUL_School/JavaScript_Object_Management\">wrap your loose "
+"variables</a>"
 msgstr ""
-"<strong>JavaScript namespace pollution</strong> &mdash; a violação mais "
-"comum. Tenha a certeza de <a "
-"href=\"https://developer.mozilla.org/en/XUL_School/JavaScript_Object_Management\">proteger"
-" as variáveis perdidas</a>"
+"<strong>JavaScript namespace pollution</strong> &mdash; a violação mais comum. Tenha a certeza de <a href=\"https://developer.mozilla.org/en/XUL_School/JavaScript_Object_Management\">proteger as "
+"variáveis perdidas</a>"
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:99
-msgid ""
-"proper preference naming - all preference names should begin with "
-"\"extensions.\", followed by the add-on name or some other unique identifier"
-msgstr ""
-"preferência adequada de nomeação - todos os nomes de preferência deve "
-"começar com \"extensions.\", seguido pelo nome do extra ou qualquer outro "
-"identificador único"
+msgid "proper preference naming - all preference names should begin with \"extensions.\", followed by the add-on name or some other unique identifier"
+msgstr "preferência adequada de nomeação - todos os nomes de preferência deve começar com \"extensions.\", seguido pelo nome do extra ou qualquer outro identificador único"
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:103
 msgid "remote JavaScript execution or injection"
@@ -7343,101 +5786,65 @@ msgstr "início da aplicação ou página de degradação do desempenho de carga
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:117
 #, python-format
 msgid ""
-"For information on how to avoid these problems, please see our <a "
-"href=\"%(link_howto)s\">How-to Library</a>. Some of these practices, such as"
-" binary or obfuscated code, are allowed under certain conditions outlined "
-"below."
+"For information on how to avoid these problems, please see our <a href=\"%(link_howto)s\">How-to Library</a>. Some of these practices, such as binary or obfuscated code, are allowed under certain "
+"conditions outlined below."
 msgstr ""
-"Para mais informações sobre como evitar esses problemas, leia a nossa <a "
-"href=\"%(link_howto)s\">Biblioteca de tutoriais</a>. Algumas dessas "
-"práticas, como código binário ou ofuscado, são permitidas sob certas "
-"condições destacadas abaixo."
+"Para mais informações sobre como evitar esses problemas, leia a nossa <a href=\"%(link_howto)s\">Biblioteca de tutoriais</a>. Algumas dessas práticas, como código binário ou ofuscado, são "
+"permitidas sob certas condições destacadas abaixo."
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:123
 #, python-format
 msgid ""
-"Many of the above restrictions are tested automatically by an extension "
-"scanner that will flag suspicious add-ons for editor review. You can read "
-"more about this scanner in the <a href=\"%(link_validation)s\">Validation "
-"Help</a> document."
+"Many of the above restrictions are tested automatically by an extension scanner that will flag suspicious add-ons for editor review. You can read more about this scanner in the <a href="
+"\"%(link_validation)s\">Validation Help</a> document."
 msgstr ""
-"Muitas das restrições acima são testadas automaticamente por um script que "
-"sinalizará extras suspeitos para uma análise de um editor. Você pode ler "
-"mais sobre esse script na documentação de <a "
-"href=\"%(link_validation)s\">Ajuda da validação</a>."
+"Muitas das restrições acima são testadas automaticamente por um script que sinalizará extras suspeitos para uma análise de um editor. Você pode ler mais sobre esse script na documentação de <a href="
+"\"%(link_validation)s\">Ajuda da validação</a>."
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:129
 msgid ""
-"If the add-on is site-specific, it is recommended that a test account is "
-"provided for use during the review process. Additionally, including detailed"
-" testing instructions will allow an editor to better understand how the add-"
-"on functions and expedite the testing process. This information can be "
-"placed in the Notes to Reviewer field when editing a version in the "
-"Developer Hub."
+"If the add-on is site-specific, it is recommended that a test account is provided for use during the review process. Additionally, including detailed testing instructions will allow an editor to "
+"better understand how the add-on functions and expedite the testing process. This information can be placed in the Notes to Reviewer field when editing a version in the Developer Hub."
 msgstr ""
-"Se o extra funcionar com um site específico, é recomendado que uma conta de "
-"testes seja fornecida para ser utilizada durante o processo de revisão. "
-"Adicionalmente, a inclusão de instruções detalhadas de teste permitirão que "
-"o Editor entenda melhor como o extra funciona e agilizarão o processo de "
-"testes. Estas informações podem ser incluídas no campo Comentários ao editor"
-" ao editar uma versão na Central do programador."
+"Se o extra funcionar com um site específico, é recomendado que uma conta de testes seja fornecida para ser utilizada durante o processo de revisão. Adicionalmente, a inclusão de instruções "
+"detalhadas de teste permitirão que o Editor entenda melhor como o extra funciona e agilizarão o processo de testes. Estas informações podem ser incluídas no campo Comentários ao editor ao editar "
+"uma versão na Central do programador."
 
-#: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:134
-#: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:168
+#: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:134 src/olympia/devhub/templates/devhub/docs/policies-reviews.html:168
 msgid "After the Review"
 msgstr "Após a revisão"
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:136
 msgid ""
-"Once an add-on is granted full review, it will immediately be available in "
-"the gallery, showing in browse and search results with a warning-free "
-"install button. All features, including voluntary contributions and beta "
-"channels will be available."
+"Once an add-on is granted full review, it will immediately be available in the gallery, showing in browse and search results with a warning-free install button. All features, including voluntary "
+"contributions and beta channels will be available."
 msgstr ""
-"Assim que o extra for aprovado na análise completa, ele será disponibilizado"
-" na galeria, sendo exibido na navegação e resultados de pesquisa sem alertas"
-" ao ser instalado. Todos os recursos, incluindo doações voluntárias e canais"
-" beta, estarão disponíveis."
+"Assim que o extra for aprovado na análise completa, ele será disponibilizado na galeria, sendo exibido na navegação e resultados de pesquisa sem alertas ao ser instalado. Todos os recursos, "
+"incluindo doações voluntárias e canais beta, estarão disponíveis."
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:142
 msgid ""
-"Subsequent versions of the add-on will automatically be placed in the full "
-"review queue. Until the review is completed, the new version will only be "
-"displayed on the Version History page of the add-on. Once reviewed, the "
-"version will be updated across the site and deployed through the automatic "
-"update service."
+"Subsequent versions of the add-on will automatically be placed in the full review queue. Until the review is completed, the new version will only be displayed on the Version History page of the add-"
+"on. Once reviewed, the version will be updated across the site and deployed through the automatic update service."
 msgstr ""
-"Versões posteriores do extra serão posicionadas automaticamente na fila de "
-"espera de análises completas. Até que a análise seja completada, a nova "
-"versão será exibida somente no histórico de versões do extra. Assim que for "
-"analisada, a versão será atualizada no site e distribuída pelo serviço de "
-"atualizações automáticas."
+"Versões posteriores do extra serão posicionadas automaticamente na fila de espera de análises completas. Até que a análise seja completada, a nova versão será exibida somente no histórico de "
+"versões do extra. Assim que for analisada, a versão será atualizada no site e distribuída pelo serviço de atualizações automáticas."
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:148
 msgid ""
-"If a version does not meet the criteria for full review, it can either be "
-"granted preliminary review or disabled if there is a security concern. The "
-"author will receive an email explaining the action taken and how to fix it. "
-"In most cases, the developer can simply fix the problem and re-submit for "
-"full review."
+"If a version does not meet the criteria for full review, it can either be granted preliminary review or disabled if there is a security concern. The author will receive an email explaining the "
+"action taken and how to fix it. In most cases, the developer can simply fix the problem and re-submit for full review."
 msgstr ""
-"Se uma versão não atender aos critérios de revisão completa, ela poderá "
-"obter o estado de revisão preliminar ou ser desativada, caso haja "
-"preocupações com a segurança. O autor receberá uma mensagem explicando a "
-"ação tomada e como a corrigir. Na maioria dos casos, o programador pode "
-"simplesmente corrigir o problema e reenviar a versão para uma nova revisão "
-"completa."
+"Se uma versão não atender aos critérios de revisão completa, ela poderá obter o estado de revisão preliminar ou ser desativada, caso haja preocupações com a segurança. O autor receberá uma mensagem "
+"explicando a ação tomada e como a corrigir. Na maioria dos casos, o programador pode simplesmente corrigir o problema e reenviar a versão para uma nova revisão completa."
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:155
 msgid ""
-"Preliminary reviews are appropriate for experimental add-ons and provide a "
-"way to get user testing and feedback without going through the longer, more "
-"thorough review process. We aim to complete these reviews in under 3 days."
+"Preliminary reviews are appropriate for experimental add-ons and provide a way to get user testing and feedback without going through the longer, more thorough review process. We aim to complete "
+"these reviews in under 3 days."
 msgstr ""
-"As revisões preliminares são adequadas para extras experimentais e oferecem "
-"uma maneira para os utilizadores testarem e enviarem as suas opiniões sem "
-"passar pelo processo de revisão mais longo e detalhado. A nossa meta é "
-"completar essas revisões em até 3 dias."
+"As revisões preliminares são adequadas para extras experimentais e oferecem uma maneira para os utilizadores testarem e enviarem as suas opiniões sem passar pelo processo de revisão mais longo e "
+"detalhado. A nossa meta é completar essas revisões em até 3 dias."
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:160
 msgid "Testing Methods"
@@ -7445,57 +5852,33 @@ msgstr "Métodos de teste"
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:162
 msgid ""
-"When performing a preliminary review, editors will review the source code "
-"for security issues and major policy violations, but will not install the "
-"add-on to test functionality in most cases. Preliminary review will be "
-"granted unless a security vulnerability or major policy violation is "
-"discovered."
+"When performing a preliminary review, editors will review the source code for security issues and major policy violations, but will not install the add-on to test functionality in most cases. "
+"Preliminary review will be granted unless a security vulnerability or major policy violation is discovered."
 msgstr ""
-"Ao realizar uma análise preliminar, os editores analisarão o código-fonte "
-"buscando problemas de segurança e violações graves das nossas políticas, mas"
-" não instalarão o add-on na maioria dos casos. Análises preliminares serão "
-"aprovadas a menos que uma vulnerabilidade de segurança ou violação grave de "
-"nossas políticas sejam encontradas."
+"Ao realizar uma análise preliminar, os editores analisarão o código-fonte buscando problemas de segurança e violações graves das nossas políticas, mas não instalarão o add-on na maioria dos casos. "
+"Análises preliminares serão aprovadas a menos que uma vulnerabilidade de segurança ou violação grave de nossas políticas sejam encontradas."
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:171
 msgid ""
-"Once preliminary review is granted, the add-on will be immediately available"
-" in the gallery, showing in browse and search results but ranked lower than "
-"fully-reviewed add-ons. Install buttons will have caution stripes and a "
-"notice that the add-on is experimental and not fully reviewed by Mozilla, "
-"though no click-through is required. Additionally, these add-ons cannot use "
-"the voluntary contributions and beta channel features."
+"Once preliminary review is granted, the add-on will be immediately available in the gallery, showing in browse and search results but ranked lower than fully-reviewed add-ons. Install buttons will "
+"have caution stripes and a notice that the add-on is experimental and not fully reviewed by Mozilla, though no click-through is required. Additionally, these add-ons cannot use the voluntary "
+"contributions and beta channel features."
 msgstr ""
-"Assim que o extra for aprovado na revisão preliminar será disponibilizado na"
-" galeria, sendo exibido na navegação e resultados de pesquisa, porém em "
-"posições posteriores aos extras com a revisão completa. O seu botão de "
-"instalação exibirá listras de alerta e uma notificação a informar que o "
-"extra é experimental e não foi completamente revisto pela Mozilla. Além "
-"disso, estes extras não podem receber doações voluntárias ou usar "
-"funcionalidades do canal beta."
+"Assim que o extra for aprovado na revisão preliminar será disponibilizado na galeria, sendo exibido na navegação e resultados de pesquisa, porém em posições posteriores aos extras com a revisão "
+"completa. O seu botão de instalação exibirá listras de alerta e uma notificação a informar que o extra é experimental e não foi completamente revisto pela Mozilla. Além disso, estes extras não "
+"podem receber doações voluntárias ou usar funcionalidades do canal beta."
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:177
-msgid ""
-"After being granted preliminary review, Mozilla may later revoke the review "
-"if other serious problems are reported to us by users."
-msgstr ""
-"Depois de ser concedida revisão preliminar, a Mozilla pode mais tarde "
-"revogar a revisão se outros problemas graves nos forem relatados pelos "
-"utilizadores."
+msgid "After being granted preliminary review, Mozilla may later revoke the review if other serious problems are reported to us by users."
+msgstr "Depois de ser concedida revisão preliminar, a Mozilla pode mais tarde revogar a revisão se outros problemas graves nos forem relatados pelos utilizadores."
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:183
 msgid ""
-"Subsequent versions of the add-on will automatically be placed in the "
-"preliminary review queue. Until the review is completed, the new version "
-"will only be displayed on the Version History page of the add-on. Once "
-"reviewed, the version will be updated across the site and deployed through "
-"the automatic update service."
+"Subsequent versions of the add-on will automatically be placed in the preliminary review queue. Until the review is completed, the new version will only be displayed on the Version History page of "
+"the add-on. Once reviewed, the version will be updated across the site and deployed through the automatic update service."
 msgstr ""
-"Versões posteriores do extra serão posicionadas automaticamente na fila de "
-"espera de análises preliminares. Até que a análise seja completada, a nova "
-"versão será exibida somente no histórico de versões do extra. Assim que for "
-"analisada, a versão será atualizada no sitio e distribuída pelo serviço de "
-"atualizações automáticas."
+"Versões posteriores do extra serão posicionadas automaticamente na fila de espera de análises preliminares. Até que a análise seja completada, a nova versão será exibida somente no histórico de "
+"versões do extra. Assim que for analisada, a versão será atualizada no sitio e distribuída pelo serviço de atualizações automáticas."
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:188
 msgid "Policies on Specific Add-on Practices"
@@ -7510,63 +5893,36 @@ msgid "The following add-ons are not permitted in any form:"
 msgstr "Os seguintes extras não são permitidos de maneira nenhuma:"
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:194
-msgid ""
-"Add-ons that embed known <a "
-"href=\"http://en.wikipedia.org/wiki/Spyware\">spyware</a> or <a "
-"href=\"http://en.wikipedia.org/wiki/Malware\">malware</a>"
-msgstr ""
-"Extras que tenham <a "
-"href=\"http://en.wikipedia.org/wiki/Spyware\">spyware</a> conhecido ou <a "
-"href=\"http://en.wikipedia.org/wiki/Malware\">malware</a>"
+msgid "Add-ons that embed known <a href=\"http://en.wikipedia.org/wiki/Spyware\">spyware</a> or <a href=\"http://en.wikipedia.org/wiki/Malware\">malware</a>"
+msgstr "Extras que tenham <a href=\"http://en.wikipedia.org/wiki/Spyware\">spyware</a> conhecido ou <a href=\"http://en.wikipedia.org/wiki/Malware\">malware</a>"
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:199
 msgid ""
-"Illegal and criminal add-ons, such as <a "
-"href=\"http://en.wikipedia.org/wiki/Click_fraud\">click fraud</a> "
-"generators, <a href=\"http://en.wikipedia.org/wiki/Warez\">warez</a> "
-"download and directory assistants, child pornography finders, etc."
+"Illegal and criminal add-ons, such as <a href=\"http://en.wikipedia.org/wiki/Click_fraud\">click fraud</a> generators, <a href=\"http://en.wikipedia.org/wiki/Warez\">warez</a> download and "
+"directory assistants, child pornography finders, etc."
 msgstr ""
-"Extras ilegais e criminosos, como <a "
-"href=\"http://pt.wikipedia.org/wiki/Click_fraud\">geradores de cliques "
-"falsos</a>, assistentes de download de <a "
-"href=\"http://pt.wikipedia.org/wiki/Warez\">warez</a>, localizadores de "
-"pornografia infantil, etc."
+"Extras ilegais e criminosos, como <a href=\"http://pt.wikipedia.org/wiki/Click_fraud\">geradores de cliques falsos</a>, assistentes de download de <a href=\"http://pt.wikipedia.org/wiki/Warez"
+"\">warez</a>, localizadores de pornografia infantil, etc."
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:204
-msgid ""
-"Add-ons whose main purpose is to facilitate access to pornographic material,"
-" or include references to this material in their descriptions"
-msgstr ""
-"Extras cuja finalidade principal é facilitar o acesso a material "
-"pornográfico ou incluir referências a este material nas suas descrições"
+msgid "Add-ons whose main purpose is to facilitate access to pornographic material, or include references to this material in their descriptions"
+msgstr "Extras cuja finalidade principal é facilitar o acesso a material pornográfico ou incluir referências a este material nas suas descrições"
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:210
-msgid ""
-"Add-ons that, upon installation, auto-install or launch installers of non-"
-"Firefox software"
-msgstr ""
-"Extras que, após a instalação, auto-instalem ou lancem instaladores de "
-"software não-Firefox"
+msgid "Add-ons that, upon installation, auto-install or launch installers of non-Firefox software"
+msgstr "Extras que, após a instalação, auto-instalem ou lancem instaladores de software não-Firefox"
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:215
-msgid ""
-"Add-ons that provide their own update mechanism for code or search engines"
-msgstr ""
-"Extras que forneçam os seus próprios mecanismo de atualização para código ou"
-" motores de pesquisa"
+msgid "Add-ons that provide their own update mechanism for code or search engines"
+msgstr "Extras que forneçam os seus próprios mecanismo de atualização para código ou motores de pesquisa"
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:220
-msgid ""
-"Add-ons that make changes to web content in ways that are non-obvious or "
-"difficult to trace by their users"
-msgstr ""
-"Extras que façam alterações no conteúdo web de forma que não sejam óbvios ou"
-" difíceis de detectar pelos seus utilizadores"
+msgid "Add-ons that make changes to web content in ways that are non-obvious or difficult to trace by their users"
+msgstr "Extras que façam alterações no conteúdo web de forma que não sejam óbvios ou difíceis de detectar pelos seus utilizadores"
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:225
 msgid "Add-ons that snoop on or intercept the network traffic of other users"
-msgstr ""
-"Extras que espionam ou interceptam tráfego de rede de outros utilizadores"
+msgstr "Extras que espionam ou interceptam tráfego de rede de outros utilizadores"
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:230
 msgid "Conduit-based toolbars without explicit pre-approval"
@@ -7578,68 +5934,35 @@ msgstr "Mudança de pré-definições e funcionalidades inesperadas"
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:238
 msgid ""
-"Surprises can be appropriate in many situations, but they are not welcome "
-"when user security, privacy, and control are at stake. It is extremely "
-"important to be as transparent as possible when submitting an add-on for "
-"hosting on this site. A Mozilla user should be able to easily discern what "
-"the functionality of an add-on is and not be presented with unexpected "
-"experiences post-install."
+"Surprises can be appropriate in many situations, but they are not welcome when user security, privacy, and control are at stake. It is extremely important to be as transparent as possible when "
+"submitting an add-on for hosting on this site. A Mozilla user should be able to easily discern what the functionality of an add-on is and not be presented with unexpected experiences post-install."
 msgstr ""
-"As surpresas podem ser agradáveis em muitas situações, mas elas não são bem-"
-"vindas quando se trata do controlo, segurança e privacidade dos "
-"utilizadores. É extremamente importante ser o mais transparente possível ao "
-"enviar um extra para ser alojado neste site. Um utilizador da Mozilla deve "
-"ser capaz de discernir facilmente qual é função do extra e não deve ter "
-"experiências inesperadas após instalar um extra."
+"As surpresas podem ser agradáveis em muitas situações, mas elas não são bem-vindas quando se trata do controlo, segurança e privacidade dos utilizadores. É extremamente importante ser o mais "
+"transparente possível ao enviar um extra para ser alojado neste site. Um utilizador da Mozilla deve ser capaz de discernir facilmente qual é função do extra e não deve ter experiências inesperadas "
+"após instalar um extra."
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:243
 msgid ""
-"<p> Whenever an add-on includes any unexpected* feature that </p> <ul> "
-"<li>compromises user privacy or security (like sending data to third "
-"parties),</li> <li>changes default settings like the homepage or search "
-"engine, or</li> <li>changes settings or features in other add-ons or "
-"deactivates them altogether</li> </ul> <p>the features must adhere to the "
-"following requirements:</p> <ul> <li>The add-on description must clearly "
-"state what changes the add-on makes.</li> <li>All changes must be opt-in, "
-"meaning the user must take non-default action to enact the change.</li> "
-"<li>The opt-in dialog must clearly state the name of the add-on requesting "
-"the change.</li> <li>Uninstalling the add-on restores the user's original "
-"settings if they were changed.</li> </ul> <p>*Unexpected features are those "
-"that are unrelated to the add-on's primary function.</p>"
+"<p> Whenever an add-on includes any unexpected* feature that </p> <ul> <li>compromises user privacy or security (like sending data to third parties),</li> <li>changes default settings like the "
+"homepage or search engine, or</li> <li>changes settings or features in other add-ons or deactivates them altogether</li> </ul> <p>the features must adhere to the following requirements:</p> <ul> "
+"<li>The add-on description must clearly state what changes the add-on makes.</li> <li>All changes must be opt-in, meaning the user must take non-default action to enact the change.</li> <li>The opt-"
+"in dialog must clearly state the name of the add-on requesting the change.</li> <li>Uninstalling the add-on restores the user's original settings if they were changed.</li> </ul> <p>*Unexpected "
+"features are those that are unrelated to the add-on's primary function.</p>"
 msgstr ""
-"<p> Sempre que um extra incluir um recurso inesperado* que </p> <ul> "
-"<li>afete a privacidade ou segurança do utilizador (por exemplo, enviando "
-"dados para terceiros),</li> <li>altere configurações predefinidas como a "
-"página inicial ou motor de pesquisa ou</li> <li>altere configurações e "
-"funcionalidades de outros extra ou os desative completamente,</li> </ul> "
-"<p>esse recurso deve atender aos seguintes requisitos:</p> <ul> <li>A "
-"descrição do extra deve listar claramente quais alterações serão feitas pelo"
-" extra.</li> <li>Todas as alterações deverão ser opcionais, ou seja, o "
-"utilizador deve ativar ou solicitar as alterações manualmente, sem nenhuma "
-"alteração automática.</li> <li>O diálogo de ativação deve deixar claro qual "
-"extra está a solicitar as alterações.</li> <li>A desinstalação do extra "
-"deverá restaurar as configurações originais do utilizador caso elas tenham "
-"sido alteradas.</li> </ul> <p>*Recursos inesperados são aqueles que não "
-"estão relacionados à função primária do extra.</p>"
+"<p> Sempre que um extra incluir um recurso inesperado* que </p> <ul> <li>afete a privacidade ou segurança do utilizador (por exemplo, enviando dados para terceiros),</li> <li>altere configurações "
+"predefinidas como a página inicial ou motor de pesquisa ou</li> <li>altere configurações e funcionalidades de outros extra ou os desative completamente,</li> </ul> <p>esse recurso deve atender aos "
+"seguintes requisitos:</p> <ul> <li>A descrição do extra deve listar claramente quais alterações serão feitas pelo extra.</li> <li>Todas as alterações deverão ser opcionais, ou seja, o utilizador "
+"deve ativar ou solicitar as alterações manualmente, sem nenhuma alteração automática.</li> <li>O diálogo de ativação deve deixar claro qual extra está a solicitar as alterações.</li> <li>A "
+"desinstalação do extra deverá restaurar as configurações originais do utilizador caso elas tenham sido alteradas.</li> </ul> <p>*Recursos inesperados são aqueles que não estão relacionados à função "
+"primária do extra.</p>"
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:268
-msgid ""
-"These features cannot be introduced into an update of a fully-reviewed add-"
-"on; the opt-in change process must be part of the initial review."
-msgstr ""
-"Estas funcionalidades não podem ser introduzidas numa atualização de um "
-"extra revisto completamente; o processo de mudança de opt-in deve fazer "
-"parte da revisão inicial."
+msgid "These features cannot be introduced into an update of a fully-reviewed add-on; the opt-in change process must be part of the initial review."
+msgstr "Estas funcionalidades não podem ser introduzidas numa atualização de um extra revisto completamente; o processo de mudança de opt-in deve fazer parte da revisão inicial."
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:274
-msgid ""
-"These are minimum requirements and not a guarantee that the add-on will be "
-"approved. This section applies to all add-ons hosted on the site, including "
-"preliminarily reviewed add-ons."
-msgstr ""
-"Estes são os requisitos mínimos e não uma garantia de que o extra será "
-"aprovado. Esta secção aplica-se a todos os extras alojados no site, "
-"incluindo extras preliminarmente revistos."
+msgid "These are minimum requirements and not a guarantee that the add-on will be approved. This section applies to all add-ons hosted on the site, including preliminarily reviewed add-ons."
+msgstr "Estes são os requisitos mínimos e não uma garantia de que o extra será aprovado. Esta secção aplica-se a todos os extras alojados no site, incluindo extras preliminarmente revistos."
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:279
 msgid "Private Browsing Mode"
@@ -7647,18 +5970,11 @@ msgstr "Modo de navegação privada"
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:282
 msgid ""
-"Add-ons that store or otherwise handle browsing data must support <a "
-"href=\"https://developer.mozilla.org/En/Supporting_private_browsing_mode\">Private"
-" Browsing Mode</a>.  During a Private Browsing session, no browsing data can"
-" be written to disk, and all of this data must be cleared when Firefox quits"
-" or the Private Browsing session ends."
+"Add-ons that store or otherwise handle browsing data must support <a href=\"https://developer.mozilla.org/En/Supporting_private_browsing_mode\">Private Browsing Mode</a>. During a Private Browsing "
+"session, no browsing data can be written to disk, and all of this data must be cleared when Firefox quits or the Private Browsing session ends."
 msgstr ""
-"Extras que armazenem ou façam a gestão de dados de navegação devem suportar "
-"o <a "
-"href=\"https://developer.mozilla.org/En/Supporting_private_browsing_mode\">modo"
-" de navegação privada</a>.  Durante uma sessão de navegação privada, nenhuma"
-" informação de navegação pode ser escrita para o disco e todos estes dados "
-"devem ser limpos quando o Firefox encerra ou a sessão de navegação privada "
+"Extras que armazenem ou façam a gestão de dados de navegação devem suportar o <a href=\"https://developer.mozilla.org/En/Supporting_private_browsing_mode\">modo de navegação privada</a>.  Durante "
+"uma sessão de navegação privada, nenhuma informação de navegação pode ser escrita para o disco e todos estes dados devem ser limpos quando o Firefox encerra ou a sessão de navegação privada "
 "terminar."
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:287
@@ -7667,42 +5983,26 @@ msgstr "Componentes binários e código ofuscado"
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:289
 msgid ""
-"Add-ons may contain binary, obfuscated and minified source code, but Mozilla"
-" must be allowed to review a copy of the human-readable source code of each "
-"version of an add-on submitted for review. These add-ons are ineligible for "
-"preliminary review and must choose the full review process."
+"Add-ons may contain binary, obfuscated and minified source code, but Mozilla must be allowed to review a copy of the human-readable source code of each version of an add-on submitted for review. "
+"These add-ons are ineligible for preliminary review and must choose the full review process."
 msgstr ""
-"Extras podem conter código-fonte binário, ofuscado ou minimizado, mas a "
-"Mozilla deve ter permissão para analisar uma cópia legível do código-fonte "
-"de cada versão de um extra enviada para análise. Esses extras não podem "
-"pedir uma análise preliminar e devem selecionar o processo de análise "
-"completa."
+"Extras podem conter código-fonte binário, ofuscado ou minimizado, mas a Mozilla deve ter permissão para analisar uma cópia legível do código-fonte de cada versão de um extra enviada para análise. "
+"Esses extras não podem pedir uma análise preliminar e devem selecionar o processo de análise completa."
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:295
 msgid ""
-"If an add-on contains binary or obfuscated source code, the author will "
-"receive a message when the add-on is reviewed indicating whom to contact at "
-"Mozilla to coordinate review of the source code. This code will be reviewed "
-"by an administrator and will not be shared or redistributed in any way. The "
-"code will only be used for the purpose of reviewing the add-on."
+"If an add-on contains binary or obfuscated source code, the author will receive a message when the add-on is reviewed indicating whom to contact at Mozilla to coordinate review of the source code. "
+"This code will be reviewed by an administrator and will not be shared or redistributed in any way. The code will only be used for the purpose of reviewing the add-on."
 msgstr ""
-"Se um extra contiver código-fonte binário ou ofuscado, o autor receberá uma "
-"mensagem quando o extra for analisado indicando como contatar a Mozilla para"
-" coordenar a análise do código-fonte. Esse código será analisado por um "
-"administrador e não será compartilhado ou redistribuído de maneira alguma. O"
-" código será usado somente com o propósito de analisar o extra."
+"Se um extra contiver código-fonte binário ou ofuscado, o autor receberá uma mensagem quando o extra for analisado indicando como contatar a Mozilla para coordenar a análise do código-fonte. Esse "
+"código será analisado por um administrador e não será compartilhado ou redistribuído de maneira alguma. O código será usado somente com o propósito de analisar o extra."
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:301
 #, python-format
-msgid ""
-"If your add-on contains binary or obfuscated code that you don't own or "
-"can't get the source code for, you may <a href=\"%(link_contact)s\">contact "
-"us</a> for information on how to proceed."
+msgid "If your add-on contains binary or obfuscated code that you don't own or can't get the source code for, you may <a href=\"%(link_contact)s\">contact us</a> for information on how to proceed."
 msgstr ""
-"Se o seu extra contém código binário ou ofuscado do qual você não é o "
-"proprietário ou não pode obter o código fonte, você pode <a "
-"href=\"%(link_contact)s\">entrar em contato connosco</a> para informações "
-"sobre como prosseguir."
+"Se o seu extra contém código binário ou ofuscado do qual você não é o proprietário ou não pode obter o código fonte, você pode <a href=\"%(link_contact)s\">entrar em contato connosco</a> para "
+"informações sobre como prosseguir."
 
 #: src/olympia/devhub/templates/devhub/docs/policies-submission.html:11
 msgid "Criteria for Submission"
@@ -7710,233 +6010,127 @@ msgstr "Critérios para submissão"
 
 #: src/olympia/devhub/templates/devhub/docs/policies-submission.html:13
 msgid ""
-"Add-ons hosted on Mozilla Add-ons should be of high quality and give users "
-"an improved web experience. We look for the following things when deciding "
-"whether an add-on is appropriate to be public and unrestricted:"
+"Add-ons hosted on Mozilla Add-ons should be of high quality and give users an improved web experience. We look for the following things when deciding whether an add-on is appropriate to be public "
+"and unrestricted:"
 msgstr ""
-"Os extras alojados nos Extras da Mozilla devem ter uma qualidade elevada e "
-"melhorar a experiência de navegação dos utilizadores. Para decidir se um "
-"extra é adequado para ser público e sem restrições, nós avaliamos o "
-"seguinte:"
+"Os extras alojados nos Extras da Mozilla devem ter uma qualidade elevada e melhorar a experiência de navegação dos utilizadores. Para decidir se um extra é adequado para ser público e sem "
+"restrições, nós avaliamos o seguinte:"
 
 #: src/olympia/devhub/templates/devhub/docs/policies-submission.html:19
 msgid ""
-"<strong>Are you responsive?</strong> We expect that an author who is "
-"promoting their add-on to our applications' many users is responsive to "
-"problem reports, maintains their contact information, and updates their add-"
-"on promptly to keep current with Firefox releases and changes in our "
-"policies. This doesn't mean that you have to reply to every question that "
-"someone posts in the discussions, or that you even need to fix every bug, "
-"but we do expect that you will respond to issues in a manner that's "
-"appropriate to the severity of the issue in question."
+"<strong>Are you responsive?</strong> We expect that an author who is promoting their add-on to our applications' many users is responsive to problem reports, maintains their contact information, "
+"and updates their add-on promptly to keep current with Firefox releases and changes in our policies. This doesn't mean that you have to reply to every question that someone posts in the "
+"discussions, or that you even need to fix every bug, but we do expect that you will respond to issues in a manner that's appropriate to the severity of the issue in question."
 msgstr ""
-"<strong>Você é reativo?</strong> Nós esperamos que um autor que esteja a "
-"promover o seu extra para os muitos utilizadores das nossas aplicações "
-"esteja disponível para responder aos registos de problemas, mantenha suas "
-"informações de contacto atualizadas e atualize seu extra prontamente para o "
-"manter compatível com as versões mais recentes do Firefox e com as "
-"alterações nas nossas políticas. Isso não significa que terá que responder a"
-" todas as perguntas que alguém colocar em discussões sobre o extra, ou que "
-"você precisa corrigir cada bug, mas esperamos que responda aos problemas de "
-"maneira apropriada à severidade do problema em questão."
+"<strong>Você é reativo?</strong> Nós esperamos que um autor que esteja a promover o seu extra para os muitos utilizadores das nossas aplicações esteja disponível para responder aos registos de "
+"problemas, mantenha suas informações de contacto atualizadas e atualize seu extra prontamente para o manter compatível com as versões mais recentes do Firefox e com as alterações nas nossas "
+"políticas. Isso não significa que terá que responder a todas as perguntas que alguém colocar em discussões sobre o extra, ou que você precisa corrigir cada bug, mas esperamos que responda aos "
+"problemas de maneira apropriada à severidade do problema em questão."
 
 #: src/olympia/devhub/templates/devhub/docs/policies-submission.html:25
 msgid ""
-"<strong>Is the add-on clearly and accurately described?</strong> It's of the"
-" utmost importance to us that users get what they expect when they try a new"
-" add-on. Your add-on name should be clear and concise, and you should "
-"refrain from using special characters or numbers to get higher search "
-"rankings or for decorative purposes. Your description should provide details"
-" about what the add-on does, how a user should take advantage of it, and "
-"what the user should expect when they install it. Links to external "
-"documents for detailed instructions are fine, but the description itself "
-"should cover the basics and leave users confident that they know what "
-"they'll get. Also, it is important that you maintain version notes "
-"appropriately as you improve and change your add-on. Users should be able to"
-" see what's new in an add-on they may have tried previously, and should be "
-"made aware of changes that might affect their current use of the add-on when"
-" they update."
+"<strong>Is the add-on clearly and accurately described?</strong> It's of the utmost importance to us that users get what they expect when they try a new add-on. Your add-on name should be clear and "
+"concise, and you should refrain from using special characters or numbers to get higher search rankings or for decorative purposes. Your description should provide details about what the add-on "
+"does, how a user should take advantage of it, and what the user should expect when they install it. Links to external documents for detailed instructions are fine, but the description itself should "
+"cover the basics and leave users confident that they know what they'll get. Also, it is important that you maintain version notes appropriately as you improve and change your add-on. Users should "
+"be able to see what's new in an add-on they may have tried previously, and should be made aware of changes that might affect their current use of the add-on when they update."
 msgstr ""
-"<strong>A descrição do extra é clara e precisa?</strong> É da mais alta "
-"importância para nós que os utilizadores encontrem o que esperam ao "
-"experimentar um novo extra. O nome do seu extra deve ser claro e conciso e "
-"deve evitar o uso de caracteres especiais ou números para obter posições "
-"melhores nas pesquisas ou para propósitos decorativos. Sua descrição deve "
-"fornecer detalhes sobre o que o extra faz, como um utilizador pode "
-"beneficiar do mesmo e o que o utilizador deve esperar ao proceder à sua "
-"instalação. Podem ser utilizadas ligações para documentação externa com "
-"instruções detalhadas, mas a descrição em si deve conter o básico e deixar "
-"os utilizadores confiantes do que vão obter. Além disso, é importante que "
-"mantenha as notas de versão ao realizar melhorias e alterações ao seu extra."
-" Os utilizadores devem ser capazes de ver o que há de novo num extra que "
-"eles já podem ter experimentado e devem estar cientes das alterações que "
-"podem afetar a utilização normal do extra ao procederem à sua atualização."
+"<strong>A descrição do extra é clara e precisa?</strong> É da mais alta importância para nós que os utilizadores encontrem o que esperam ao experimentar um novo extra. O nome do seu extra deve ser "
+"claro e conciso e deve evitar o uso de caracteres especiais ou números para obter posições melhores nas pesquisas ou para propósitos decorativos. Sua descrição deve fornecer detalhes sobre o que o "
+"extra faz, como um utilizador pode beneficiar do mesmo e o que o utilizador deve esperar ao proceder à sua instalação. Podem ser utilizadas ligações para documentação externa com instruções "
+"detalhadas, mas a descrição em si deve conter o básico e deixar os utilizadores confiantes do que vão obter. Além disso, é importante que mantenha as notas de versão ao realizar melhorias e "
+"alterações ao seu extra. Os utilizadores devem ser capazes de ver o que há de novo num extra que eles já podem ter experimentado e devem estar cientes das alterações que podem afetar a utilização "
+"normal do extra ao procederem à sua atualização."
 
 #: src/olympia/devhub/templates/devhub/docs/policies-submission.html:31
 msgid ""
-"<strong>Are all privacy and security concerns clearly spelled out?</strong> "
-"This is an aspect of a clear and accurate description, but such an important"
-" one that we feel it deserves specific mention. Many very useful and well-"
-"written add-ons manipulate some form of user data, or can present security "
-"hazards if misused; they are welcome on the site, but they must make it very"
-" clear to users what risks they might encounter, and what they can do to "
-"protect themselves."
+"<strong>Are all privacy and security concerns clearly spelled out?</strong> This is an aspect of a clear and accurate description, but such an important one that we feel it deserves specific "
+"mention. Many very useful and well-written add-ons manipulate some form of user data, or can present security hazards if misused; they are welcome on the site, but they must make it very clear to "
+"users what risks they might encounter, and what they can do to protect themselves."
 msgstr ""
-"<strong>Todas as questões relacionadas a privacidade e segurança estão "
-"claramente indicadas?</strong> Esta preocupação faz parte de uma descrição "
-"clara e precisa, mas é tão importante que preferimos mencionar "
-"separadamente. Muitos extras úteis e bem escritos manipulam dados do "
-"utilizador de alguma forma ou podem apresentar riscos de segurança se mal "
-"utilizados; eles são bem-vindos ao site, mas devem deixar claro aos "
-"utilizadores os riscos que eles podem correr e o que podem fazer para se "
-"proteger."
+"<strong>Todas as questões relacionadas a privacidade e segurança estão claramente indicadas?</strong> Esta preocupação faz parte de uma descrição clara e precisa, mas é tão importante que "
+"preferimos mencionar separadamente. Muitos extras úteis e bem escritos manipulam dados do utilizador de alguma forma ou podem apresentar riscos de segurança se mal utilizados; eles são bem-vindos "
+"ao site, mas devem deixar claro aos utilizadores os riscos que eles podem correr e o que podem fazer para se proteger."
 
 #: src/olympia/devhub/templates/devhub/docs/policies-submission.html:37
 msgid ""
-"<strong>Has the add-on been well-tested, and is it free of obvious or "
-"serious defects?</strong> One important thing that we look for when "
-"considering an add-on is whether its user reviews indicate that it has "
-"received thorough testing, and that it doesn't have serious problems or "
-"negative impacts on the browser. If reviewers report problems such as major "
-"performance issues, crashes, frequent problems using the functions of the "
-"add-on, or spamming of messages to the error console, you should take those "
-"reports to heart, and re-submit your add-on after you've addressed them as "
-"best you can. We don't expect you to perfectly optimize or have zero bugs "
-"&mdash; Firefox itself undergoes constant improvement in these areas &mdash;"
-" but we do want you to take reasonable efforts to minimize downsides, and to"
-" clearly call out cases where users may be surprised by those that remain."
+"<strong>Has the add-on been well-tested, and is it free of obvious or serious defects?</strong> One important thing that we look for when considering an add-on is whether its user reviews indicate "
+"that it has received thorough testing, and that it doesn't have serious problems or negative impacts on the browser. If reviewers report problems such as major performance issues, crashes, frequent "
+"problems using the functions of the add-on, or spamming of messages to the error console, you should take those reports to heart, and re-submit your add-on after you've addressed them as best you "
+"can. We don't expect you to perfectly optimize or have zero bugs &mdash; Firefox itself undergoes constant improvement in these areas &mdash; but we do want you to take reasonable efforts to "
+"minimize downsides, and to clearly call out cases where users may be surprised by those that remain."
 msgstr ""
-"<strong>O extra foi bem testado e está livre de falhas óbvias ou "
-"graves?</strong> Uma coisa importante que procuramos ao considerar um extra "
-"é se os comentários dos utilizadores indicam que o extra foi testado "
-"completamente e que ele não tem problemas sérios ou impactos negativos sob o"
-" navegador. Se os comentários dos utilizadores relatarem problemas graves de"
-" desempenho, bloqueios, problemas frequentes ao usar funções do extra ou "
-"excesso de mensagens na consola de erros, você deve considerar estes "
-"comentários com carinho e reenviar seu extra depois de o melhorar o máximo "
-"que puder. Não esperamos que você o otimize perfeitamente ou que ele não "
-"tenha nenhum bug &mdash; o próprio Firefox passa por melhorias constantes "
-"nesses quesitos &mdash; mas queremos que tome as medidas razoáveis para "
-"minimizar os aspetos negativos e anunciar claramente os casos em que o "
-"utilizador possa ser surpreendido pelos problemas remanescentes."
+"<strong>O extra foi bem testado e está livre de falhas óbvias ou graves?</strong> Uma coisa importante que procuramos ao considerar um extra é se os comentários dos utilizadores indicam que o extra "
+"foi testado completamente e que ele não tem problemas sérios ou impactos negativos sob o navegador. Se os comentários dos utilizadores relatarem problemas graves de desempenho, bloqueios, problemas "
+"frequentes ao usar funções do extra ou excesso de mensagens na consola de erros, você deve considerar estes comentários com carinho e reenviar seu extra depois de o melhorar o máximo que puder. Não "
+"esperamos que você o otimize perfeitamente ou que ele não tenha nenhum bug &mdash; o próprio Firefox passa por melhorias constantes nesses quesitos &mdash; mas queremos que tome as medidas "
+"razoáveis para minimizar os aspetos negativos e anunciar claramente os casos em que o utilizador possa ser surpreendido pelos problemas remanescentes."
 
 #: src/olympia/devhub/templates/devhub/docs/policies-submission.html:43
 msgid ""
-"<strong>Do the add-on and add-on author both treat the user "
-"respectfully?</strong> Your software should not intrude on the user "
-"unnecessarily, try to trick the user, or conceal any of its activities from "
-"the user. Users (or even non-users) are sometimes rude in their comments, "
-"and while we will do our best to filter out inaccurate reviews as they're "
-"reported to us, we do expect that authors will avoid retaliating with "
-"rudeness of their own."
+"<strong>Do the add-on and add-on author both treat the user respectfully?</strong> Your software should not intrude on the user unnecessarily, try to trick the user, or conceal any of its "
+"activities from the user. Users (or even non-users) are sometimes rude in their comments, and while we will do our best to filter out inaccurate reviews as they're reported to us, we do expect that "
+"authors will avoid retaliating with rudeness of their own."
 msgstr ""
-"<strong>O extra e o respetivo autor tratam o utilizador com "
-"respeito?</strong> O seu software não se deve intrometer na experiência do "
-"utilizador de forma desnecessária, tentar enganá-lo ou esconder quaisquer "
-"atividades do utilizador. Os utilizadores (ou mesmo não-utilizadores) "
-"algumas vezes são rudes nos seus comentários e, enquanto fazemos o nosso "
-"melhor para filtrar análises imprecisas assim que são enviadas, esperamos "
-"que os autores evitem retaliar de forma rude por conta própria."
+"<strong>O extra e o respetivo autor tratam o utilizador com respeito?</strong> O seu software não se deve intrometer na experiência do utilizador de forma desnecessária, tentar enganá-lo ou "
+"esconder quaisquer atividades do utilizador. Os utilizadores (ou mesmo não-utilizadores) algumas vezes são rudes nos seus comentários e, enquanto fazemos o nosso melhor para filtrar análises "
+"imprecisas assim que são enviadas, esperamos que os autores evitem retaliar de forma rude por conta própria."
 
 #: src/olympia/devhub/templates/devhub/docs/policies-submission.html:49
 msgid ""
-"<strong>Is the add-on useful to an appropriately wide portion of Firefox's "
-"users?</strong> Your add-on doesn't need to be the next Greasemonkey or "
-"Firebug, but if it is only useful to people at your company or who are part "
-"of a small web community, we may feel that it's not yet appropriate to put "
-"it in front of all of our users."
+"<strong>Is the add-on useful to an appropriately wide portion of Firefox's users?</strong> Your add-on doesn't need to be the next Greasemonkey or Firebug, but if it is only useful to people at "
+"your company or who are part of a small web community, we may feel that it's not yet appropriate to put it in front of all of our users."
 msgstr ""
-"<strong>O extra é útil para uma boa parte dos utilizadores do "
-"Firefox?</strong> O seu extra não precisa ser o próximo Greasemonkey ou "
-"Firebug, mas se ele só é útil para pessoas da sua empresa ou para quem é "
-"parte de uma pequena comunidade, nós podemos achar que ele não é adequado "
-"para ser disponibilizado para todos os utilizadores."
+"<strong>O extra é útil para uma boa parte dos utilizadores do Firefox?</strong> O seu extra não precisa ser o próximo Greasemonkey ou Firebug, mas se ele só é útil para pessoas da sua empresa ou "
+"para quem é parte de uma pequena comunidade, nós podemos achar que ele não é adequado para ser disponibilizado para todos os utilizadores."
 
 #: src/olympia/devhub/templates/devhub/docs/policies-submission.html:55
 msgid ""
-"We are constantly looking at ways to improve the organization of the site to"
-" better accommodate add-ons that are exemplary in other ways, but are aimed "
-"at only a small community of potential users. Correctly categorizing and "
-"maintaining the metadata of your add-on will help us figure out how we can "
-"surface more of those sorts of add-ons to people who are most likely to "
-"benefit from them."
+"We are constantly looking at ways to improve the organization of the site to better accommodate add-ons that are exemplary in other ways, but are aimed at only a small community of potential users. "
+"Correctly categorizing and maintaining the metadata of your add-on will help us figure out how we can surface more of those sorts of add-ons to people who are most likely to benefit from them."
 msgstr ""
-"Estamos constantemente à procura de formas de melhorar a organização do site"
-" para melhor acomodar extras que são exemplos de outras formas mas "
-"destinados apenas a uma pequena comunidade de potenciais utilizadores. "
-"Manter e categorizar corretamente os meta-dados do seu extra irá ajudar-nos "
-"a perceber como podemos destacar este tipo de extras para pessoas que "
-"provavelmente iriam beneficiar mais deles."
+"Estamos constantemente à procura de formas de melhorar a organização do site para melhor acomodar extras que são exemplos de outras formas mas destinados apenas a uma pequena comunidade de "
+"potenciais utilizadores. Manter e categorizar corretamente os meta-dados do seu extra irá ajudar-nos a perceber como podemos destacar este tipo de extras para pessoas que provavelmente iriam "
+"beneficiar mais deles."
 
 #: src/olympia/devhub/templates/devhub/docs/policies-submission.html:61
 msgid ""
-"If your add-on just provides bookmarks or other simple access points to your"
-" site, it's probably not appropriate for the gallery. Like the rest of the "
-"Mozilla project, we love web applications and new web services, but Firefox "
-"add-ons should provide an improved browsing experience for the user and not "
-"just be a way to promote a new site or service through a Mozilla Add-ons "
-"listing."
+"If your add-on just provides bookmarks or other simple access points to your site, it's probably not appropriate for the gallery. Like the rest of the Mozilla project, we love web applications and "
+"new web services, but Firefox add-ons should provide an improved browsing experience for the user and not just be a way to promote a new site or service through a Mozilla Add-ons listing."
 msgstr ""
-"Se o seu extra apenas oferece favoritos ou outros atalhos de acesso ao seu "
-"site, é provável que ele não seja adequado para a galeria. Como o restante "
-"do projeto Mozilla, nós amamos aplicações web e novos serviços web, mas os "
-"extras para o Firefox devem oferecer uma experiência melhorada para os "
-"utilizadores e não apenas uma maneira de promover um novo site ou serviço "
-"através da galeria dos Extras da Mozilla."
+"Se o seu extra apenas oferece favoritos ou outros atalhos de acesso ao seu site, é provável que ele não seja adequado para a galeria. Como o restante do projeto Mozilla, nós amamos aplicações web e "
+"novos serviços web, mas os extras para o Firefox devem oferecer uma experiência melhorada para os utilizadores e não apenas uma maneira de promover um novo site ou serviço através da galeria dos "
+"Extras da Mozilla."
 
 #: src/olympia/devhub/templates/devhub/docs/policies-submission.html:67
 msgid ""
-"<strong>Is the add-on free of unlicensed trademarks and copyrights?</strong>"
-" Though you may mean no harm to the holder of a trademark, or the owner of a"
-" copyrighted work, we can't host add-ons that infringe on trademarks or "
-"copyrights. If you don't have permission to use a trademarked name or image,"
-" please do not submit your add-on to us. If your add-on includes code that "
-"is copyrighted by someone else, and is not licensed to you to use in your "
-"add-on, please do not submit your add-on to us."
+"<strong>Is the add-on free of unlicensed trademarks and copyrights?</strong> Though you may mean no harm to the holder of a trademark, or the owner of a copyrighted work, we can't host add-ons that "
+"infringe on trademarks or copyrights. If you don't have permission to use a trademarked name or image, please do not submit your add-on to us. If your add-on includes code that is copyrighted by "
+"someone else, and is not licensed to you to use in your add-on, please do not submit your add-on to us."
 msgstr ""
-"<strong>O extra está livre de marcas e direitos de autor não "
-"licenciados?</strong> Mesmo que você não tenha nenhuma má intenção para com "
-"o detentor de uma marca registada ou dono de um trabalho com direitos "
-"reservados, não podemos alojar extras que infrinjam marcas registadas ou "
-"direitos de autor. Se você não tem permissão para usar um nome ou imagem de "
-"uma marca registada, por favor, não envie seu extra para nós. Se seu extra "
-"incluir código com direitos reservados que pertencem outra pessoa e não for "
-"licenciado, por favor, não envie seu extra para nós."
+"<strong>O extra está livre de marcas e direitos de autor não licenciados?</strong> Mesmo que você não tenha nenhuma má intenção para com o detentor de uma marca registada ou dono de um trabalho com "
+"direitos reservados, não podemos alojar extras que infrinjam marcas registadas ou direitos de autor. Se você não tem permissão para usar um nome ou imagem de uma marca registada, por favor, não "
+"envie seu extra para nós. Se seu extra incluir código com direitos reservados que pertencem outra pessoa e não for licenciado, por favor, não envie seu extra para nós."
 
 #: src/olympia/devhub/templates/devhub/docs/policies-submission.html:73
 msgid ""
-"In terms of reuse of source code from other add-ons, if the author has not "
-"clearly stated that you are permitted to use his or her code in your own "
-"work &mdash; such as by placing it under an open source license &mdash; then"
-" you should assume that you do not have the right to do so. You can contact "
-"the author to seek such permission, but we can't provide you with any "
-"special rights to it just because it's listed on the site, or because the "
-"author isn't responding to your request."
+"In terms of reuse of source code from other add-ons, if the author has not clearly stated that you are permitted to use his or her code in your own work &mdash; such as by placing it under an open "
+"source license &mdash; then you should assume that you do not have the right to do so. You can contact the author to seek such permission, but we can't provide you with any special rights to it "
+"just because it's listed on the site, or because the author isn't responding to your request."
 msgstr ""
-"Em termos de reuso de código de outros extras, se o autor não indicou "
-"claramente que você tem permissão para utilizar o código do autor em seu "
-"próprio trabalho &mdash; licenciando-o sob uma licença livre, por exemplo "
-"&mdash; então você deve assumir que você não tem o direito de fazê-lo. Você "
-"pode entrar em contato com o autor para conseguir tal permissão, mas nós não"
-" podemos fornecer quaisquer direitos especiais para seu extra apenas porque "
-"ele está listado no site ou porque o autor não está a responder à sua "
-"solicitação."
+"Em termos de reuso de código de outros extras, se o autor não indicou claramente que você tem permissão para utilizar o código do autor em seu próprio trabalho &mdash; licenciando-o sob uma licença "
+"livre, por exemplo &mdash; então você deve assumir que você não tem o direito de fazê-lo. Você pode entrar em contato com o autor para conseguir tal permissão, mas nós não podemos fornecer "
+"quaisquer direitos especiais para seu extra apenas porque ele está listado no site ou porque o autor não está a responder à sua solicitação."
 
 #: src/olympia/devhub/templates/devhub/docs/policies-submission.html:79
 msgid ""
-"This applies to the Mozilla Foundation's trademarks as well, including "
-"\"Mozilla\", \"Firefox\", and \"Thunderbird\". The Mozilla policy on "
-"trademark use is designed to protect against confusion, and prevent the "
-"trademarks from being overturned due to lack of protection; please respect "
-"the need for such protection, and help us preserve some of the most valuable"
-" assets of the Mozilla Foundation."
+"This applies to the Mozilla Foundation's trademarks as well, including \"Mozilla\", \"Firefox\", and \"Thunderbird\". The Mozilla policy on trademark use is designed to protect against confusion, "
+"and prevent the trademarks from being overturned due to lack of protection; please respect the need for such protection, and help us preserve some of the most valuable assets of the Mozilla "
+"Foundation."
 msgstr ""
-"Isto também se aplica a marcas registadas da Fundação Mozilla, incluindo "
-"\"Mozilla\", \"Firefox\" e \"Thunderbird\". A política sobre o uso de marca "
-"da Mozilla foi criada para proteger contra a confusão, e evitar que as "
-"marcas registadas sejam anuladas devido à falta de proteção; por favor "
-"respeite a necessidade de tal proteção, e ajude-nos a preservar alguns dos "
-"bens mais valiosos da Fundação Mozilla."
+"Isto também se aplica a marcas registadas da Fundação Mozilla, incluindo \"Mozilla\", \"Firefox\" e \"Thunderbird\". A política sobre o uso de marca da Mozilla foi criada para proteger contra a "
+"confusão, e evitar que as marcas registadas sejam anuladas devido à falta de proteção; por favor respeite a necessidade de tal proteção, e ajude-nos a preservar alguns dos bens mais valiosos da "
+"Fundação Mozilla."
 
 #: src/olympia/devhub/templates/devhub/docs/policies-submission.html:84
 msgid "Licensing"
@@ -7944,258 +6138,179 @@ msgstr "licenciamento"
 
 #: src/olympia/devhub/templates/devhub/docs/policies-submission.html:86
 msgid ""
-"Selecting an appropriate license for your add-on is a very important step in"
-" the submission process. A license specifies the rights you grant on your "
-"source code and is important in protecting your intellectual property."
+"Selecting an appropriate license for your add-on is a very important step in the submission process. A license specifies the rights you grant on your source code and is important in protecting your "
+"intellectual property."
 msgstr ""
-"Selecionar uma licença adequada para o seu extra é um passo muito importante"
-" do processo de envio. Uma licença especifica os direitos que você garante "
-"ao seu código-fonte e é importante na proteção da sua propriedade "
-"intelectual."
+"Selecionar uma licença adequada para o seu extra é um passo muito importante do processo de envio. Uma licença especifica os direitos que você garante ao seu código-fonte e é importante na proteção "
+"da sua propriedade intelectual."
 
 #: src/olympia/devhub/templates/devhub/docs/policies-submission.html:92
 msgid ""
-"During the add-on submission process, you will be presented with a list of "
-"popular licenses to choose from, as well as the ability to specify your own "
-"license. It is best to consult with a legal professional about which license"
-" option is best for you. Choosing the right license for your source code "
-"will help to prevent confusion and code conflicts in the future."
+"During the add-on submission process, you will be presented with a list of popular licenses to choose from, as well as the ability to specify your own license. It is best to consult with a legal "
+"professional about which license option is best for you. Choosing the right license for your source code will help to prevent confusion and code conflicts in the future."
 msgstr ""
-"Durante o processo de envio de extras, será apresentada uma lista de "
-"licenças populares para que você possa escolher entre uma delas, além de "
-"poder especificar sua própria licença. É melhor consultar um profissional de"
-" direito legal para aconselhá-lo sobre a melhor opção de licença para si. "
-"Escolher a licença correta para o seu código fonte irá ajudá-lo a evitar "
-"confusão e conflitos no futuro."
+"Durante o processo de envio de extras, será apresentada uma lista de licenças populares para que você possa escolher entre uma delas, além de poder especificar sua própria licença. É melhor "
+"consultar um profissional de direito legal para aconselhá-lo sobre a melhor opção de licença para si. Escolher a licença correta para o seu código fonte irá ajudá-lo a evitar confusão e conflitos "
+"no futuro."
 
-#: src/olympia/devhub/templates/devhub/docs/policies.html:12
-#: src/olympia/devhub/templates/devhub/docs/policies.html:52
+#: src/olympia/devhub/templates/devhub/docs/policies.html:12 src/olympia/devhub/templates/devhub/docs/policies.html:52
 msgid "Add-on Submission"
 msgstr "Submeter extra"
 
-#: src/olympia/devhub/templates/devhub/docs/policies.html:18
-#: src/olympia/devhub/templates/devhub/docs/policies.html:78
+#: src/olympia/devhub/templates/devhub/docs/policies.html:18 src/olympia/devhub/templates/devhub/docs/policies.html:78
 msgid "Maintaining Your Add-on"
 msgstr "Manutenção do seu extra"
 
 #: src/olympia/devhub/templates/devhub/docs/policies.html:43
-msgid ""
-"Mozilla is committed to ensuring a great add-ons experience for our users "
-"and developers. Please review the policies below before submitting your add-"
-"on."
-msgstr ""
-"A Mozilla está empenhada em garantir uma excelente experiência com extras "
-"para nossos utilizadores e programadores. Por favor, reveja as políticas "
-"abaixo antes de enviar seu extra."
+msgid "Mozilla is committed to ensuring a great add-ons experience for our users and developers. Please review the policies below before submitting your add-on."
+msgstr "A Mozilla está empenhada em garantir uma excelente experiência com extras para nossos utilizadores e programadores. Por favor, reveja as políticas abaixo antes de enviar seu extra."
 
 #: src/olympia/devhub/templates/devhub/docs/policies.html:55
-msgid ""
-"Find out what is expected of add-ons we host and our policies on specific "
-"add-on practices."
-msgstr ""
-"Descubra o que é esperado dos extras que alojamos e as nossas políticas "
-"específicas sobre práticas dos extras."
+msgid "Find out what is expected of add-ons we host and our policies on specific add-on practices."
+msgstr "Descubra o que é esperado dos extras que alojamos e as nossas políticas específicas sobre práticas dos extras."
 
 #: src/olympia/devhub/templates/devhub/docs/policies.html:67
-msgid ""
-"What happens after your add-on is submitted? Learn about how our Editors "
-"review submissions."
-msgstr ""
-"O que acontece após o extra ser apresentado? Saiba mais sobre como os nossos"
-" editores avaliam uma submissão."
+msgid "What happens after your add-on is submitted? Learn about how our Editors review submissions."
+msgstr "O que acontece após o extra ser apresentado? Saiba mais sobre como os nossos editores avaliam uma submissão."
 
 #: src/olympia/devhub/templates/devhub/docs/policies.html:81
-msgid ""
-"Add-on updates, transferring ownership, user reviews, and what to expect "
-"once your add-on is approved."
-msgstr ""
-"Atualizações de extras, transferência de propriedade, comentários do "
-"utilizador, e o que esperar quando o seu extra for aprovado."
+msgid "Add-on updates, transferring ownership, user reviews, and what to expect once your add-on is approved."
+msgstr "Atualizações de extras, transferência de propriedade, comentários do utilizador, e o que esperar quando o seu extra for aprovado."
 
 #: src/olympia/devhub/templates/devhub/docs/policies.html:93
-msgid ""
-"How up-and-coming add-ons become featured and what&#039;s involved in the "
-"process."
-msgstr ""
-"Como é que extras futuros ficam em destaque e o que está envolvido no "
-"processo."
+msgid "How up-and-coming add-ons become featured and what&#039;s involved in the process."
+msgstr "Como é que extras futuros ficam em destaque e o que está envolvido no processo."
 
 #: src/olympia/devhub/templates/devhub/docs/policies.html:106
-msgid ""
-"Terms of Service for submitting your work to our site. Developers are "
-"required to accept this agreement before submission."
-msgstr ""
-"Termos do Serviço para a submissão do seu trabalho no nosso site. Os "
-"programadores são obrigados a aceitar este acordo antes da submissão."
+msgid "Terms of Service for submitting your work to our site. Developers are required to accept this agreement before submission."
+msgstr "Termos do Serviço para a submissão do seu trabalho no nosso site. Os programadores são obrigados a aceitar este acordo antes da submissão."
 
 #: src/olympia/devhub/templates/devhub/docs/policies.html:118
 msgid "How to get in touch with us regarding these policies or your add-on."
-msgstr ""
-"Como entrar em contacto connosco a respeito destas políticas ou do seu "
-"extra."
+msgstr "Como entrar em contacto connosco a respeito destas políticas ou do seu extra."
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:6
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:10
 msgid "You have disabled this add-on"
 msgstr "Desativou este extra"
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:20
-msgid ""
-"Your add-on's listing is disabled and is not showing\n"
-"                             anywhere in our gallery or update service."
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:24
+msgid "Your add-on's listing is disabled and is not showing anywhere in our gallery or update service."
 msgstr ""
 "A apresentação do seu extra em listas está desativada e não será\n"
 "                             apresentado em qualquer área da nossa galeria ou serviço de atualização."
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:25
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:27
 msgid "Please complete your add-on."
 msgstr "Por favor, complete o seu extra."
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:29
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:30
 msgid "You will receive an email when the review is complete."
 msgstr "Irá receber um email quando a análise estiver completa."
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:34
-msgid ""
-"You will receive an email when the review is complete. Until\n"
-"                             then, your add-on is not listed in our gallery but can be\n"
-"                             accessed directly from its details page."
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:33
+msgid "You will receive an email when the review is complete. Until then, your add-on is not listed in our gallery but can be accessed directly from its details page."
 msgstr ""
 "Irá receber um email quando a análise estiver concluída. Até lá, \n"
 "                             o seu extra não aparecerá listado na nossa galeria mas poderá\n"
 "                             ser acedido diretamente através da página de detalhes."
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:38
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:48
-msgid ""
-"You will receive an email when the review is\n"
-"                             complete and your add-on is signed."
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:37 src/olympia/devhub/templates/devhub/includes/addon_details.html:45
+msgid "You will receive an email when the review is complete and your add-on is signed."
 msgstr ""
 "Irá receber um email quando a revisão estiver \n"
 "                             concluída e o seu extra assinado."
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:44
-msgid ""
-"You will receive an email when the review is complete. Until\n"
-"                             then, your add-on is not listed in our gallery but can be\n"
-"                             accessed directly from its details page. "
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:41
+msgid "You will receive an email when the review is complete. Until then, your add-on is not listed in our gallery but can be accessed directly from its details page. "
 msgstr ""
-"Irá receber um email quando a revisão estiver concluída. Até lá, \n"
-"                             o seu extra não estará listado na nossa galeria mas poderá ser \n"
-"                             acedido diretamente através da sua página de detalhes. "
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:54
-msgid ""
-"Your add-on is displayed in our gallery and users are\n"
-"                             receiving automatic updates."
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:49
+msgid "Your add-on is displayed in our gallery and users are receiving automatic updates."
 msgstr ""
 "O seu extra é apresentado na nossa galeria e os utilizadores estão a \n"
 "                             receber atualizações automáticas."
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:57
-msgid ""
-"Your add-on has been signed and can be bundled with an\n"
-"                             application installer."
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:52
+msgid "Your add-on has been signed and can be bundled with an application installer."
 msgstr ""
 "O seu extra foi assinado e pode ser incorporado com um \n"
 "                             instalador de aplicações."
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:63
-msgid ""
-"Your add-on was disabled by a site administrator and is no\n"
-"                             longer shown in our gallery. If you have any questions,\n"
-"                             please email amo-admins@mozilla.org."
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:56
+msgid "Your add-on was disabled by a site administrator and is no longer shown in our gallery. If you have any questions, please email amo-admins@mozilla.org."
 msgstr ""
 "O seu extra foi desativado por um administrador do site e deixou de \n"
 "                             ser apresentado na nossa galeria. Se tiver quaisquer questões, \n"
 "                             por favor, envie um email para amo-admins@mozilla.org."
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:70
-msgid ""
-"Your add-on is displayed in our gallery as experimental\n"
-"                             and users are receiving automatic updates. Some features\n"
-"                             are unavailable to your add-on."
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:62
+msgid "Your add-on is displayed in our gallery as experimental and users are receiving automatic updates. Some features are unavailable to your add-on."
 msgstr ""
 "O seu extra está a ser apresentado na nossa galeria como experimental \n"
 "                             e os utilizadores estão a receber atualizações automaticamente. Algumas funcionalidades \n"
 "                             não estão disponíveis para o seu extra."
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:74
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:66
 msgid "Your add-on has been signed."
 msgstr "O seu extra foi assinado."
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:79
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:69
 msgid ""
-"You will receive an email when the full review is complete.\n"
-"                             Until then, your add-on is displayed in our gallery as\n"
-"                             experimental and users are receiving automatic updates.\n"
-"                             Some features are unavailable to your add-on."
+"You will receive an email when the full review is complete. Until then, your add-on is displayed in our gallery as experimental and users are receiving automatic updates. Some features are "
+"unavailable to your add-on."
 msgstr ""
 "Irá receber um email quando a revisão completa estiver concluída.\n"
 "                             Até lá, o seu extra é apresentado na nossa galeria como \n"
 "                             experimental e os utilizadores estão a receber atualizações automaticamente.\n"
 "                             Algumas funcionalidades não estão disponíveis para o seu extra."
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:84
-msgid ""
-"You will receive an email when the full review is\n"
-"                             complete, making you able to bundle your add-on with an\n"
-"                             application installer."
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:74
+msgid "You will receive an email when the full review is complete, making you able to bundle your add-on with an application installer."
 msgstr ""
 "Irá receber um email com a revisão completa estiver \n"
 "                             completa, fazendo com que possa incorporar o seu extra com um \n"
 "                             instalador de aplicação."
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:91
-msgid ""
-"All add-ons hosted in our gallery must now be reviewed by an\n"
-"                             editor. If you wish to continue hosting your add-on, please\n"
-"                             click to select a review process."
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:79
+msgid "All add-ons hosted in our gallery must now be reviewed by an editor. If you wish to continue hosting your add-on, please click to select a review process."
 msgstr ""
 "Todos os extras alojados na nossa galeria devem agora ser revistos por um \n"
 "                             editor. Se quiser continuar a alojar o seu extra, por favor, \n"
 "                             clique para escolher um processo de revisão."
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:113
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:100
 msgid "Current Version:"
 msgstr "Versão atual:"
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:115
-msgid ""
-"This is the version of your add-on that will\n"
-"                                           be installed if someone clicks the Install\n"
-"                                           button on addons.mozilla.org. It is only\n"
-"                                           relevant for listed add-ons."
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:102
+msgid "This is the version of your add-on that will be installed if someone clicks the Install button on addons.mozilla.org. It is only relevant for listed add-ons."
 msgstr ""
 "Esta é a versão do seu extra que irá ser instalada \n"
 "                                           se alguém clicar no botão Instalar \n"
 "                                           em addons.mozilla.org. Isto apenas \n"
 "                                           é relevante para extras listados."
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:123
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:110
 msgid "Created:"
 msgstr "Criado:"
 
 #. {0} is a date. dennis-ignore: E201
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:125
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:131
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:112 src/olympia/devhub/templates/devhub/includes/addon_details.html:118
 #, python-format
 msgid "%%b %%e, %%Y"
 msgstr "%%e de %%b, %%Y"
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:136
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:123
 msgid "Next Version:"
 msgstr "Próxima versão:"
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:138
-msgid ""
-"This is the newest uploaded version, however\n"
-"                                           it isn’t live on the site yet."
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:125
+msgid "This is the newest uploaded version, however it isn’t live on the site yet."
 msgstr ""
 "Esta é a versão carregada mais recentemente, no entanto \n"
 "                                           ainda não está publicamente ativa no site."
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:144
-#: src/olympia/devhub/templates/devhub/versions/list.html:30
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:130 src/olympia/devhub/templates/devhub/versions/list.html:30
 msgid "Queues are not reviewed strictly in order"
 msgstr "As filas não são revistas numa ordem rigorosa"
 
@@ -8213,15 +6328,11 @@ msgstr "Criar um perfil de programador"
 
 #: src/olympia/devhub/templates/devhub/includes/addons_create_profile.html:24
 msgid ""
-"Your developer profile will tell users about you, why you made this add-on, "
-"and what's next for the add-on. This profile is required for add-ons "
-"requesting contributions, but can be useful for any developer interested in "
-"connecting with users."
+"Your developer profile will tell users about you, why you made this add-on, and what's next for the add-on. This profile is required for add-ons requesting contributions, but can be useful for any "
+"developer interested in connecting with users."
 msgstr ""
-"O seu perfil de programador vai dar informações aos utilizadores sobre si, "
-"porque é que fez este extra e o futuro do seu extra. Este perfil é "
-"necessário para extras que pedem contribuições, mas pode ser interessante "
-"para qualquer programador que queira comunicar com os utilizadores."
+"O seu perfil de programador vai dar informações aos utilizadores sobre si, porque é que fez este extra e o futuro do seu extra. Este perfil é necessário para extras que pedem contribuições, mas "
+"pode ser interessante para qualquer programador que queira comunicar com os utilizadores."
 
 #: src/olympia/devhub/templates/devhub/includes/addons_create_profile.html:32
 msgid "Make sure your user profile is up to date."
@@ -8230,22 +6341,14 @@ msgstr "Verifique se o seu perfil está atualizado."
 #: src/olympia/devhub/templates/devhub/includes/addons_create_profile.html:34
 #, python-format
 msgid "<a href=\"%(url)s\"><strong>Update your user profile.</strong></a>"
-msgstr ""
-"<a href=\"%(url)s\"><strong>Atualize o seu perfil de "
-"utilizador.</strong></a>"
+msgstr "<a href=\"%(url)s\"><strong>Atualize o seu perfil de utilizador.</strong></a>"
 
 #: src/olympia/devhub/templates/devhub/includes/addons_create_profile.html:45
-msgid ""
-"Whether it was an idea while in line at the grocery store or the solution to"
-" one of life's great problems, share your story."
-msgstr ""
-"Seja uma ideia que teve enquantoestava na fila do supermercado ou a solução "
-"para um dos problemas da vida, partilhe a sua história."
+msgid "Whether it was an idea while in line at the grocery store or the solution to one of life's great problems, share your story."
+msgstr "Seja uma ideia que teve enquantoestava na fila do supermercado ou a solução para um dos problemas da vida, partilhe a sua história."
 
 #: src/olympia/devhub/templates/devhub/includes/addons_create_profile.html:61
-msgid ""
-"Telling your users what's coming soon will give them something to look "
-"forward to."
+msgid "Telling your users what's coming soon will give them something to look forward to."
 msgstr "Dizer aos seus utilizadores o que aí vem irá dar-lhes algo para ver."
 
 #: src/olympia/devhub/templates/devhub/includes/addons_edit_nav.html:23
@@ -8279,9 +6382,7 @@ msgid "View the blog &#9658;"
 msgstr "Ver o blog &#9658;"
 
 #: src/olympia/devhub/templates/devhub/includes/license_form.html:6
-msgid ""
-"Please choose a license appropriate for the rights you grant on your source code.\n"
-"                  It is only relevant for listed add-ons."
+msgid "Please choose a license appropriate for the rights you grant on your source code. It is only relevant for listed add-ons."
 msgstr ""
 "Por favor escolha uma licença apropriada para os direitos que concede no seu código fonte.\n"
 "                  Apenas é relevante para extras listados."
@@ -8299,8 +6400,7 @@ msgstr "Suportado algum HTML."
 msgid "Remove this application"
 msgstr "Remover esta aplicação"
 
-#. {0} is the maximum number of add-on categories allowed.                {1}
-#. is
+#. {0} is the maximum number of add-on categories allowed.                {1} is
 #. the application name.
 #: src/olympia/devhub/templates/devhub/includes/macros.html:70
 msgid "Select <b>up to {0}</b> {1} category for this add-on:"
@@ -8310,39 +6410,27 @@ msgstr[1] "Selecione <b>até {0}</b> categorias do {1} para este extra:"
 
 #: src/olympia/devhub/templates/devhub/includes/policy_form.html:4
 msgid ""
-"Users will be required to accept the following End-User License Agreement (EULA) prior to installing your add-on. The presence of a EULA significantly affects the number of downloads an add-on receives. Please note that a EULA is not the same as a code license, such as the GPL or MPL.\n"
-"                It is only relevant for listed add-ons."
+"Users will be required to accept the following End-User License Agreement (EULA) prior to installing your add-on. The presence of a EULA significantly affects the number of downloads an add-on "
+"receives. Please note that a EULA is not the same as a code license, such as the GPL or MPL.It is only relevant for listed add-ons."
 msgstr ""
-"Os utilizadores terão de aceitar o acordo de utilizador final (EULA) antes de instalar o seu extra. A presença de um EULA afeta significativamente o número de transferências que um extra recebe. Por favor note que, um EULA não é o mesmo que uma licença de código como a GPL ou a MPL.\n"
-"                Isto apenas é relevante para extras listados."
 
-#: src/olympia/devhub/templates/devhub/includes/policy_form.html:21
-msgid ""
-"If your add-on transmits any data from the user's computer, a privacy policy is required that explains what data is sent and how it is used.\n"
-"                It is only relevant for listed add-ons."
+#: src/olympia/devhub/templates/devhub/includes/policy_form.html:24
+msgid "If your add-on transmits any data from the user's computer, a privacy policy is required that explains what data is sent and how it is used. It is only relevant for listed add-ons."
 msgstr ""
 "Se o seu extra transmite quaisquer dados do computador do utilizador, é necessária uma política de privacidade que explique que dados são enviados e como estes são utilizados. \n"
 "                Isto apenas é relevante para extras listados."
 
 #: src/olympia/devhub/templates/devhub/includes/source_form_field.html:2
-msgid ""
-"If your add-on contains binary or obfuscated code other than known "
-"libraries, upload its sources for review."
-msgstr ""
-"Se o seu extra contem código binário ou ofuscado para além de bibliotecas "
-"conhecidas, envie as respetivas fontes para revisão."
+msgid "If your add-on contains binary or obfuscated code other than known libraries, upload its sources for review."
+msgstr "Se o seu extra contem código binário ou ofuscado para além de bibliotecas conhecidas, envie as respetivas fontes para revisão."
 
 #: src/olympia/devhub/templates/devhub/includes/source_form_field.html:3
 msgid "Read more about the source code review policy."
 msgstr "Saiba mais sobre a política de revisão de código."
 
 #: src/olympia/devhub/templates/devhub/includes/version_file.html:20
-msgid ""
-"You cannot remove an individual file after the review process has begun. You"
-" must delete the entire version."
-msgstr ""
-"Você não pode remover um ficheiro individual, após o processo de revisão "
-"iniciado. Deve excluir a versão inteira."
+msgid "You cannot remove an individual file after the review process has begun. You must delete the entire version."
+msgstr "Você não pode remover um ficheiro individual, após o processo de revisão iniciado. Deve excluir a versão inteira."
 
 #: src/olympia/devhub/templates/devhub/includes/version_file.html:36
 msgid "This file will be deleted on save."
@@ -8370,30 +6458,20 @@ msgid "Voluntary Contributions"
 msgstr "Doações voluntárias"
 
 #: src/olympia/devhub/templates/devhub/payments/payments.html:38
-msgid ""
-"Add-ons enrolled in our contributions program can request voluntary "
-"financial support from users."
-msgstr ""
-"Extras inscritos no nosso programa de contribuições podem solicitar apoio "
-"financeiro voluntário dos utilizadores."
+msgid "Add-ons enrolled in our contributions program can request voluntary financial support from users."
+msgstr "Extras inscritos no nosso programa de contribuições podem solicitar apoio financeiro voluntário dos utilizadores."
 
 #: src/olympia/devhub/templates/devhub/payments/payments.html:40
 msgid "Encourage users to support your add-on through your Developer Profile"
-msgstr ""
-"Incentive os utilizadores a apoiar o seu extra através do seu perfil de "
-"programador"
+msgstr "Incentive os utilizadores a apoiar o seu extra através do seu perfil de programador"
 
 #: src/olympia/devhub/templates/devhub/payments/payments.html:41
 msgid "Choose when and how users are asked to contribute"
 msgstr "Escolher como e quando pedir doações aos utilizadores"
 
 #: src/olympia/devhub/templates/devhub/payments/payments.html:42
-msgid ""
-"Receive contributions in your PayPal account or send them to an organization"
-" of your choice"
-msgstr ""
-"Receber contribuições na sua conta PayPal ou enviá-las para uma organização "
-"à sua escolha"
+msgid "Receive contributions in your PayPal account or send them to an organization of your choice"
+msgstr "Receber contribuições na sua conta PayPal ou enviá-las para uma organização à sua escolha"
 
 #: src/olympia/devhub/templates/devhub/payments/payments.html:46
 msgid "Contributions are only available for listed add-ons."
@@ -8401,20 +6479,14 @@ msgstr "As contribuições apenas estão disponíveis para extras listados."
 
 #: src/olympia/devhub/templates/devhub/payments/payments.html:53
 #, python-format
-msgid ""
-"Contributions are only available for add-ons with a <a "
-"href=\"%(url)s\">completed developer profile</a>."
-msgstr ""
-"As contribuições só estão disponíveis para extras com um <a "
-"href=\"%(url)s\">perfil de programador completo</a>."
+msgid "Contributions are only available for add-ons with a <a href=\"%(url)s\">completed developer profile</a>."
+msgstr "As contribuições só estão disponíveis para extras com um <a href=\"%(url)s\">perfil de programador completo</a>."
 
 #: src/olympia/devhub/templates/devhub/payments/payments.html:59
 msgid "Contributions are only available for fully reviewed add-ons."
-msgstr ""
-"As contribuições apenas estão disponíveis a extras revistos completamente."
+msgstr "As contribuições apenas estão disponíveis a extras revistos completamente."
 
-#: src/olympia/devhub/templates/devhub/payments/payments.html:65
-#: src/olympia/devhub/templates/devhub/payments/voluntary.html:2
+#: src/olympia/devhub/templates/devhub/payments/payments.html:65 src/olympia/devhub/templates/devhub/payments/voluntary.html:2
 msgid "Set up Contributions"
 msgstr "Configurar contribuições"
 
@@ -8427,18 +6499,13 @@ msgstr "Passo 2. Prço e disponibilidade"
 msgid "or <a href=\"%(cancel)s\">Cancel</a>"
 msgstr "ou <a href=\"%(cancel)s\">Cancelar</a>"
 
-#: src/olympia/devhub/templates/devhub/payments/voluntary.html:2
-#: src/olympia/stats/templates/stats/addon_report_menu.html:39
+#: src/olympia/devhub/templates/devhub/payments/voluntary.html:2 src/olympia/stats/templates/stats/addon_report_menu.html:39
 msgid "Contributions"
 msgstr "Contribuições"
 
 #: src/olympia/devhub/templates/devhub/payments/voluntary.html:3
-msgid ""
-"Fill in the fields below to begin asking for voluntary contributions from "
-"users."
-msgstr ""
-"Preencha os campos abaixo para começar a pedir contribuições voluntárias aos"
-" utilizadores."
+msgid "Fill in the fields below to begin asking for voluntary contributions from users."
+msgstr "Preencha os campos abaixo para começar a pedir contribuições voluntárias aos utilizadores."
 
 #: src/olympia/devhub/templates/devhub/payments/voluntary.html:11
 msgid "Who will receive contributions to this add-on?"
@@ -8481,22 +6548,16 @@ msgid "Send a thank-you note?"
 msgstr "Enviar uma nota de obrigado?"
 
 #: src/olympia/devhub/templates/devhub/payments/voluntary.html:47
-msgid ""
-"We'll automatically email users who contribute to your add-on with this "
-"message."
-msgstr ""
-"Iremos enviar um email automaticamente aos utilizadores que contribuíram "
-"para o seu extra."
+msgid "We'll automatically email users who contribute to your add-on with this message."
+msgstr "Iremos enviar um email automaticamente aos utilizadores que contribuíram para o seu extra."
 
 #: src/olympia/devhub/templates/devhub/payments/voluntary.html:49
 msgid ""
-"We recommend thanking the user and telling them how much you appreciate "
-"their support. You might also want to tell them about what's next for your "
-"add-on and about any other add-ons you've made for them to try."
+"We recommend thanking the user and telling them how much you appreciate their support. You might also want to tell them about what's next for your add-on and about any other add-ons you've made for "
+"them to try."
 msgstr ""
-"Recomendamos agradecer ao utilizador e dizer-lhe o quanto gostou da ajuda "
-"dele. Pode também querer dizer-lhes o que vem a seguir para o seu extra e "
-"outros extras que tenha feito para que eles os possam experimentar."
+"Recomendamos agradecer ao utilizador e dizer-lhe o quanto gostou da ajuda dele. Pode também querer dizer-lhes o que vem a seguir para o seu extra e outros extras que tenha feito para que eles os "
+"possam experimentar."
 
 #: src/olympia/devhub/templates/devhub/payments/voluntary.html:64
 msgid "Activate Contributions"
@@ -8510,157 +6571,104 @@ msgstr "ou <a id=\"setup-cancel\" href=\"#\">Cancelar</a>"
 msgid "Transfer ownership"
 msgstr "Transferir propriedade"
 
-#: src/olympia/devhub/templates/devhub/personas/edit.html:77
-#: src/olympia/devhub/templates/devhub/personas/submit.html:31
+#: src/olympia/devhub/templates/devhub/personas/edit.html:77 src/olympia/devhub/templates/devhub/personas/submit.html:31
 msgid "Theme Details"
 msgstr "Detalhes do Tema"
 
-#: src/olympia/devhub/templates/devhub/personas/edit.html:87
-#: src/olympia/devhub/templates/devhub/personas/submit.html:36
+#: src/olympia/devhub/templates/devhub/personas/edit.html:87 src/olympia/devhub/templates/devhub/personas/submit.html:36
 msgid "Supply a pretty URL for your detail page."
 msgstr "Forneça uma URL amigável para a sua página de detalhe."
 
 # 86%
-#: src/olympia/devhub/templates/devhub/personas/edit.html:92
-#: src/olympia/devhub/templates/devhub/personas/submit.html:41
+#: src/olympia/devhub/templates/devhub/personas/edit.html:92 src/olympia/devhub/templates/devhub/personas/submit.html:41
 msgid "Select the category that best describes your Theme."
 msgstr "Selecione a categoria que descreva melhor o teu Tema."
 
-#: src/olympia/devhub/templates/devhub/personas/edit.html:95
-#: src/olympia/devhub/templates/devhub/personas/submit.html:44
+#: src/olympia/devhub/templates/devhub/personas/edit.html:95 src/olympia/devhub/templates/devhub/personas/submit.html:44
 msgid "Add some tags to describe your Theme."
 msgstr "Adicione algumas etiquetas para descrever o seu tema."
 
-#: src/olympia/devhub/templates/devhub/personas/edit.html:106
-msgid ""
-"A short explanation of your theme's\n"
-"                                basic functionality that is displayed in\n"
-"                                search and browse listings, as well as at\n"
-"                                the top of your theme's details page."
+#: src/olympia/devhub/templates/devhub/personas/edit.html:106 src/olympia/devhub/templates/devhub/personas/submit.html:54
+msgid "A short explanation of your theme's basic functionality that is displayed in search and browse listings, as well as at the top of your theme's details page."
 msgstr ""
 "Uma explicação curta das funcionalidades básicas \n"
 "                                do seu tema e que é apresentada em \n"
 "                                listagens de pesquisas e de navegação, bem como no\n"
 "                                topo da página de detalhes do seu tema."
 
-#: src/olympia/devhub/templates/devhub/personas/edit.html:122
-#: src/olympia/devhub/templates/devhub/personas/submit.html:68
+#: src/olympia/devhub/templates/devhub/personas/edit.html:122 src/olympia/devhub/templates/devhub/personas/submit.html:68
 msgid "Theme License"
 msgstr "Licença do tema"
 
 # 88%
-#: src/olympia/devhub/templates/devhub/personas/edit.html:126
-#: src/olympia/devhub/templates/devhub/personas/submit.html:72
+#: src/olympia/devhub/templates/devhub/personas/edit.html:126 src/olympia/devhub/templates/devhub/personas/submit.html:72
 msgid "Can others share your Theme, as long as you're given credit?"
-msgstr ""
-"Outras pessoas podem compartilhar teu tema, desde que dando crédito a você?"
+msgstr "Outras pessoas podem compartilhar teu tema, desde que dando crédito a você?"
 
-#: src/olympia/devhub/templates/devhub/personas/edit.html:132
-#: src/olympia/devhub/templates/devhub/personas/edit.html:153
-#: src/olympia/devhub/templates/devhub/personas/submit.html:78
+#: src/olympia/devhub/templates/devhub/personas/edit.html:132 src/olympia/devhub/templates/devhub/personas/edit.html:153 src/olympia/devhub/templates/devhub/personas/submit.html:78
 #: src/olympia/devhub/templates/devhub/personas/submit.html:99
-msgid ""
-"The licensor permits others to copy, distribute, display, and perform the "
-"work, including for commercial purposes."
-msgstr ""
-"O licenciador permite que outros possam copiar, distribuir, mostrar e "
-"destacar o trabalho, incluindo fins comerciais."
+msgid "The licensor permits others to copy, distribute, display, and perform the work, including for commercial purposes."
+msgstr "O licenciador permite que outros possam copiar, distribuir, mostrar e destacar o trabalho, incluindo fins comerciais."
 
-#: src/olympia/devhub/templates/devhub/personas/edit.html:141
-#: src/olympia/devhub/templates/devhub/personas/edit.html:162
-#: src/olympia/devhub/templates/devhub/personas/submit.html:87
+#: src/olympia/devhub/templates/devhub/personas/edit.html:141 src/olympia/devhub/templates/devhub/personas/edit.html:162 src/olympia/devhub/templates/devhub/personas/submit.html:87
 #: src/olympia/devhub/templates/devhub/personas/submit.html:108
-msgid ""
-"The licensor permits others to copy, distribute, display, and perform the "
-"work for non-commercial purposes only."
-msgstr ""
-"o licenciador permite que outros copiem, distribuam e efectuem trabalho "
-"apenas para fins não comerciais."
+msgid "The licensor permits others to copy, distribute, display, and perform the work for non-commercial purposes only."
+msgstr "o licenciador permite que outros copiem, distribuam e efectuem trabalho apenas para fins não comerciais."
 
 # 85%
-#: src/olympia/devhub/templates/devhub/personas/edit.html:147
-#: src/olympia/devhub/templates/devhub/personas/submit.html:93
+#: src/olympia/devhub/templates/devhub/personas/edit.html:147 src/olympia/devhub/templates/devhub/personas/submit.html:93
 msgid "Can others make commercial use of your Theme?"
 msgstr "Outras pessoas podem usar seu tema comercialmente?"
 
 # 86%
-#: src/olympia/devhub/templates/devhub/personas/edit.html:168
-#: src/olympia/devhub/templates/devhub/personas/submit.html:114
+#: src/olympia/devhub/templates/devhub/personas/edit.html:168 src/olympia/devhub/templates/devhub/personas/submit.html:114
 msgid "Can others create derivative works from your Theme?"
 msgstr "Outras pessoas podem criar outros trabalhos derivados do seu tema?"
 
-#: src/olympia/devhub/templates/devhub/personas/edit.html:174
-#: src/olympia/devhub/templates/devhub/personas/submit.html:120
-msgid ""
-"The licensor permits others to copy, distribute, display and perform the "
-"work, as well as make derivative works based on it."
-msgstr ""
-"O licenciador permite que outros copiem, distribuam,mostrem e executem o "
-"trabalho, bem como criar trabalhos derivados com base nele."
+#: src/olympia/devhub/templates/devhub/personas/edit.html:174 src/olympia/devhub/templates/devhub/personas/submit.html:120
+msgid "The licensor permits others to copy, distribute, display and perform the work, as well as make derivative works based on it."
+msgstr "O licenciador permite que outros copiem, distribuam,mostrem e executem o trabalho, bem como criar trabalhos derivados com base nele."
 
-#: src/olympia/devhub/templates/devhub/personas/edit.html:182
-#: src/olympia/devhub/templates/devhub/personas/submit.html:128
+#: src/olympia/devhub/templates/devhub/personas/edit.html:182 src/olympia/devhub/templates/devhub/personas/submit.html:128
 msgid "Yes, as long as they share alike"
 msgstr "Sim, desde que o partilhem"
 
-#: src/olympia/devhub/templates/devhub/personas/edit.html:183
-#: src/olympia/devhub/templates/devhub/personas/submit.html:129
-msgid ""
-"The licensor permits others to distribute derivativeworks only under the "
-"same license or one compatible with the one that governs the licensor's "
-"work."
-msgstr ""
-"O licenciador permite que outros distrinuam trabalhos derivados apenas sob a"
-" mesma licença ou uma compatível com a que governa o trabalho do "
-"licenciante."
+#: src/olympia/devhub/templates/devhub/personas/edit.html:183 src/olympia/devhub/templates/devhub/personas/submit.html:129
+msgid "The licensor permits others to distribute derivativeworks only under the same license or one compatible with the one that governs the licensor's work."
+msgstr "O licenciador permite que outros distrinuam trabalhos derivados apenas sob a mesma licença ou uma compatível com a que governa o trabalho do licenciante."
 
-#: src/olympia/devhub/templates/devhub/personas/edit.html:192
-#: src/olympia/devhub/templates/devhub/personas/submit.html:138
-msgid ""
-"The licensor permits others to copy, distribute and transmit only unaltered "
-"copies of the work — not derivative works based on it."
-msgstr ""
-"O licenciador permite que outros copiem, distribuam e transmitam apenas "
-"cópias inalteradas do trabalho - não trabalhos derivados com base nele."
+#: src/olympia/devhub/templates/devhub/personas/edit.html:192 src/olympia/devhub/templates/devhub/personas/submit.html:138
+msgid "The licensor permits others to copy, distribute and transmit only unaltered copies of the work — not derivative works based on it."
+msgstr "O licenciador permite que outros copiem, distribuam e transmitam apenas cópias inalteradas do trabalho - não trabalhos derivados com base nele."
 
 # 87%
-#: src/olympia/devhub/templates/devhub/personas/edit.html:199
-#: src/olympia/devhub/templates/devhub/personas/submit.html:145
+#: src/olympia/devhub/templates/devhub/personas/edit.html:199 src/olympia/devhub/templates/devhub/personas/submit.html:145
 msgid "Your Theme will be released under the following license:"
 msgstr "O seu tema será lançado sob a seguinte licença:"
 
-#: src/olympia/devhub/templates/devhub/personas/edit.html:202
-#: src/olympia/devhub/templates/devhub/personas/submit.html:148
+#: src/olympia/devhub/templates/devhub/personas/edit.html:202 src/olympia/devhub/templates/devhub/personas/submit.html:148
 msgid "Select a different license."
 msgstr "Selecione uma licença diferente."
 
-#: src/olympia/devhub/templates/devhub/personas/edit.html:207
-#: src/olympia/devhub/templates/devhub/personas/submit.html:153
+#: src/olympia/devhub/templates/devhub/personas/edit.html:207 src/olympia/devhub/templates/devhub/personas/submit.html:153
 msgid "Select a license for your Theme."
 msgstr "Selecione uma licença para o seu tema."
 
-#: src/olympia/devhub/templates/devhub/personas/edit.html:217
-#: src/olympia/devhub/templates/devhub/personas/submit.html:163
+#: src/olympia/devhub/templates/devhub/personas/edit.html:217 src/olympia/devhub/templates/devhub/personas/submit.html:163
 msgid "Theme Design"
 msgstr "Design do tema"
 
-#: src/olympia/devhub/templates/devhub/personas/edit.html:221
-#: src/olympia/devhub/templates/devhub/personas/edit.html:224
+#: src/olympia/devhub/templates/devhub/personas/edit.html:221 src/olympia/devhub/templates/devhub/personas/edit.html:224
 msgid "Upload New Design"
 msgstr "Enviar um novo design"
 
 #: src/olympia/devhub/templates/devhub/personas/edit.html:226
-msgid ""
-"Upon upload and form submission, the AMO Team will review your updated "
-"design. Your current design will still be public in the meantime."
-msgstr ""
-"Após envio e submissão do formulário, a equipa do AMO irá rever o seu design"
-" atualizado. Durante este processo o design atual continuará a ser público."
+msgid "Upon upload and form submission, the AMO Team will review your updated design. Your current design will still be public in the meantime."
+msgstr "Após envio e submissão do formulário, a equipa do AMO irá rever o seu design atualizado. Durante este processo o design atual continuará a ser público."
 
 #: src/olympia/devhub/templates/devhub/personas/edit.html:241
-msgid "Your previously resubmitted design,  which is under pending review."
-msgstr ""
-"O seu design anteriormente resubmetido,  que está sob uma revisão pendente."
+msgid "Your previously resubmitted design, which is under pending review."
+msgstr "O seu design anteriormente resubmetido,  que está sob uma revisão pendente."
 
 #: src/olympia/devhub/templates/devhub/personas/edit.html:245
 msgid "Pending Header"
@@ -8682,43 +6690,35 @@ msgstr "Cabeçalho"
 msgid "Footer"
 msgstr "Rodapé"
 
-#: src/olympia/devhub/templates/devhub/personas/edit.html:274
-#: src/olympia/devhub/templates/devhub/personas/submit.html:167
+#: src/olympia/devhub/templates/devhub/personas/edit.html:274 src/olympia/devhub/templates/devhub/personas/submit.html:167
 msgid "Select colors for your Theme."
 msgstr "Selecione as cores para o seu tema."
 
-#: src/olympia/devhub/templates/devhub/personas/edit.html:276
-#: src/olympia/devhub/templates/devhub/personas/submit.html:169
+#: src/olympia/devhub/templates/devhub/personas/edit.html:276 src/olympia/devhub/templates/devhub/personas/submit.html:169
 msgid "Foreground Text"
 msgstr "Texto de fundo"
 
-#: src/olympia/devhub/templates/devhub/personas/edit.html:277
-#: src/olympia/devhub/templates/devhub/personas/submit.html:170
+#: src/olympia/devhub/templates/devhub/personas/edit.html:277 src/olympia/devhub/templates/devhub/personas/submit.html:170
 msgid "This is the color of the tab text."
 msgstr "ESta é a cor do texto do separador."
 
-#: src/olympia/devhub/templates/devhub/personas/edit.html:279
-#: src/olympia/devhub/templates/devhub/personas/submit.html:172
+#: src/olympia/devhub/templates/devhub/personas/edit.html:279 src/olympia/devhub/templates/devhub/personas/submit.html:172
 msgid "Background"
 msgstr "Fundo"
 
-#: src/olympia/devhub/templates/devhub/personas/edit.html:280
-#: src/olympia/devhub/templates/devhub/personas/submit.html:173
+#: src/olympia/devhub/templates/devhub/personas/edit.html:280 src/olympia/devhub/templates/devhub/personas/submit.html:173
 msgid "This is the color of the tabs."
 msgstr "Esta é a cor dos separadores."
 
-#: src/olympia/devhub/templates/devhub/personas/edit.html:285
-#: src/olympia/devhub/templates/devhub/personas/submit.html:178
+#: src/olympia/devhub/templates/devhub/personas/edit.html:285 src/olympia/devhub/templates/devhub/personas/submit.html:178
 msgid "Preview"
 msgstr "Pré-visualizar"
 
-#: src/olympia/devhub/templates/devhub/personas/edit.html:291
-#: src/olympia/devhub/templates/devhub/personas/submit.html:183
+#: src/olympia/devhub/templates/devhub/personas/edit.html:291 src/olympia/devhub/templates/devhub/personas/submit.html:183
 msgid "Your Theme's Name"
 msgstr "Nome do seu tema"
 
-#: src/olympia/devhub/templates/devhub/personas/edit.html:294
-#: src/olympia/devhub/templates/devhub/personas/submit.html:186
+#: src/olympia/devhub/templates/devhub/personas/edit.html:294 src/olympia/devhub/templates/devhub/personas/submit.html:186
 #, python-format
 msgid "by <a href=\"%(profile_url)s\" target=\"_blank\">%(user)s</a>"
 msgstr "por <a href=\"%(profile_url)s\" target=\"_blank\">%(user)s</a>"
@@ -8729,74 +6729,39 @@ msgstr "Criar um novo tema"
 
 #: src/olympia/devhub/templates/devhub/personas/submit.html:18
 #, python-format
-msgid ""
-"Background themes let you easily personalize the look of your Firefox. "
-"Submit your own design below, or <a href=\"%(submit_url)s\">learn how to "
-"create one</a>!"
-msgstr ""
-"Os temas de fundo permitem-lhe personalizar facilmente a aparência do seu "
-"Firefox. Submeta o seu próprio design em baixo, ou <a "
-"href=\"%(submit_url)s\">aprenda a criar um</a>!"
+msgid "Background themes let you easily personalize the look of your Firefox. Submit your own design below, or <a href=\"%(submit_url)s\">learn how to create one</a>!"
+msgstr "Os temas de fundo permitem-lhe personalizar facilmente a aparência do seu Firefox. Submeta o seu próprio design em baixo, ou <a href=\"%(submit_url)s\">aprenda a criar um</a>!"
 
 #: src/olympia/devhub/templates/devhub/personas/submit.html:33
 msgid "Give your Theme a name."
 msgstr "Dê um nome ao seu tema."
 
-#: src/olympia/devhub/templates/devhub/personas/submit.html:54
-msgid ""
-"A short explanation of your theme's\n"
-"                                      basic functionality that is displayed in\n"
-"                                      search and browse listings, as well as at\n"
-"                                      the top of your theme's details page."
-msgstr ""
-"Uma explicação curta das funcionalidades básicas \n"
-"                                      do seu tema e que é apresentada em \n"
-"                                      listagens de pesquisas e de navegação, bem como no \n"
-"                                      topo da página de detalhes do seu tema."
-
 #: src/olympia/devhub/templates/devhub/personas/submit.html:198
 #, python-format
 msgid ""
-"I agree to the <a href=\"%(agreement_url)s\" target=\"_blank\">Firefox Add-"
-"on Distribution Agreement</a> and to my information being handled as "
-"described in the <a href=\"%(privacy_notice_url)s\" "
+"I agree to the <a href=\"%(agreement_url)s\" target=\"_blank\">Firefox Add-on Distribution Agreement</a> and to my information being handled as described in the <a href=\"%(privacy_notice_url)s\" "
 "target=\"_blank\">Websites, Communications and Cookies Privacy Notice</a>."
 msgstr ""
-"Eu concordo com o <a href=\"%(agreement_url)s\" target=\"_blank\">acordo de "
-"distribuição de extra do Firefox</a> e com o facto da minha informação ser "
-"gerida tal como descrito na <a href=\"%(privacy_notice_url)s\" "
-"target=\"_blank\">política de privacidade para websites, comunicações e "
-"cookies</a>."
+"Eu concordo com o <a href=\"%(agreement_url)s\" target=\"_blank\">acordo de distribuição de extra do Firefox</a> e com o facto da minha informação ser gerida tal como descrito na <a href="
+"\"%(privacy_notice_url)s\" target=\"_blank\">política de privacidade para websites, comunicações e cookies</a>."
 
 #: src/olympia/devhub/templates/devhub/personas/submit.html:205
 msgid "Submit Theme"
 msgstr "Enviar tema"
 
 #: src/olympia/devhub/templates/devhub/personas/submit_done.html:11
-msgid ""
-"Your theme has been submitted to the Review Queue. You'll receive an email "
-"once it has been reviewed, typically within 24 hours."
-msgstr ""
-"O seu tema foi submetido para a fila de revisão. Irá receber um email assim "
-"que este estiver revisto, tipicamente num período de 24 horas."
+msgid "Your theme has been submitted to the Review Queue. You'll receive an email once it has been reviewed, typically within 24 hours."
+msgstr "O seu tema foi submetido para a fila de revisão. Irá receber um email assim que este estiver revisto, tipicamente num período de 24 horas."
 
 #: src/olympia/devhub/templates/devhub/personas/submit_done.html:19
 #, python-format
-msgid ""
-"Provide more details about your theme by <a href=\"%(edit_url)s\">editing "
-"its listing</a>."
-msgstr ""
-"Forneça mais detalhes sobre o seu tema <a href=\"%(edit_url)s\">editando a "
-"sua listagem</a>."
+msgid "Provide more details about your theme by <a href=\"%(edit_url)s\">editing its listing</a>."
+msgstr "Forneça mais detalhes sobre o seu tema <a href=\"%(edit_url)s\">editando a sua listagem</a>."
 
 #: src/olympia/devhub/templates/devhub/personas/submit_done.html:25
 #, python-format
-msgid ""
-"View and subscribe to your theme's <a href=\"%(feed_url)s\">activity "
-"feed</a> to stay updated on reviews, collections, and more."
-msgstr ""
-"Veja e subscreva ao <a href=\"%(feed_url)s\">registo de atividade</a> do seu"
-" tema para se manter a par das revisões, coleções e muito mais."
+msgid "View and subscribe to your theme's <a href=\"%(feed_url)s\">activity feed</a> to stay updated on reviews, collections, and more."
+msgstr "Veja e subscreva ao <a href=\"%(feed_url)s\">registo de atividade</a> do seu tema para se manter a par das revisões, coleções e muito mais."
 
 #: src/olympia/devhub/templates/devhub/personas/submit_done.html:32
 #, python-format
@@ -8812,13 +6777,11 @@ msgstr "Selecione uma imagem para o cabeçalho do seu tema."
 msgid "3000 &times; 200 pixels"
 msgstr "3000 &vezes; 200 pixéis"
 
-#: src/olympia/devhub/templates/devhub/personas/includes/theme_design.html:9
-#: src/olympia/devhub/templates/devhub/personas/includes/theme_design.html:25
+#: src/olympia/devhub/templates/devhub/personas/includes/theme_design.html:9 src/olympia/devhub/templates/devhub/personas/includes/theme_design.html:25
 msgid "300 KB max"
 msgstr "300 KB máx"
 
-#: src/olympia/devhub/templates/devhub/personas/includes/theme_design.html:10
-#: src/olympia/devhub/templates/devhub/personas/includes/theme_design.html:26
+#: src/olympia/devhub/templates/devhub/personas/includes/theme_design.html:10 src/olympia/devhub/templates/devhub/personas/includes/theme_design.html:26
 msgid "PNG or JPG"
 msgstr "PNG ou JPG"
 
@@ -8848,65 +6811,31 @@ msgid "Select a different footer image"
 msgstr "Selecione uma imagem de rodapé diferente"
 
 #: src/olympia/devhub/templates/devhub/versions/add_file_modal.html:8
-msgid ""
-"Files added to reviewed versions must be reviewed before they will be "
-"available for download."
-msgstr ""
-"Ficheiros adicionados a versões já revistas têm de ser novamente revistas "
-"antes de ficarem disponíveis para descarregar."
+msgid "Files added to reviewed versions must be reviewed before they will be available for download."
+msgstr "Ficheiros adicionados a versões já revistas têm de ser novamente revistas antes de ficarem disponíveis para descarregar."
 
-#: src/olympia/devhub/templates/devhub/versions/add_file_modal.html:15
-#, python-format
-msgid ""
-"Submission of updates to unlisted add-ons for signing is currently in an "
-"open beta. Manual review may still be required for a large number of add-"
-"ons. Please <a href=\"%(url)s\" target=\"_blank\">report any bugs</a> that "
-"you encounter."
-msgstr ""
-"A submissão de atualizações para extras não listados para assinatura está "
-"atualmente numa beta aberta. A revisão manual pode ainda ser necessária para"
-" um grande número de extras. Por favor <a href=\"%(url)s\" "
-"target=\"_blank\">reporte quaisquer bugs</a> que encontre."
-
-#: src/olympia/devhub/templates/devhub/versions/add_file_modal.html:35
+#: src/olympia/devhub/templates/devhub/versions/add_file_modal.html:24
 msgid "Select the target platform for this file."
 msgstr "Selecione a plataforma de destino para este ficheiro."
 
-#: src/olympia/devhub/templates/devhub/versions/add_file_modal.html:46
+#: src/olympia/devhub/templates/devhub/versions/add_file_modal.html:35
 msgid "Which review type would you like to nominate for?"
 msgstr "Para que tipo de revisão gostaria de nomear?"
 
-#: src/olympia/devhub/templates/devhub/versions/add_file_modal.html:51
+#: src/olympia/devhub/templates/devhub/versions/add_file_modal.html:40
 msgid "Only publish this version to my beta channel."
 msgstr "Publicar esta versão apenas para o meu canal beta."
-
-#: src/olympia/devhub/templates/devhub/versions/add_file_modal.html:54
-#, python-format
-msgid ""
-"The behavior of the beta channel has changed to accommodate <a "
-"href=\"%(addon_signing_url)s\" target=\"_blank\">mandatory add-on "
-"signing</a>. The new process is currently in an open beta, and may change "
-"significantly in the near future. Please <a href=\"%(issues_url)s\" "
-"target=\"_blank\">report any bugs</a> that you encounter."
-msgstr ""
-"O comportamento do canal beta foi alterado para acomodar a <a "
-"href=\"%(addon_signing_url)s\" target=\"_blank\">assinatura obrigatória de "
-"extras</a>. O novo processo está atualmente numa beta aberta e pode ser "
-"significativamente alterado num futuro próximo. Por favor <a "
-"href=\"%(issues_url)s\" target=\"_blank\">reporte quaisquer bugs</a> que "
-"encontre."
 
 #: src/olympia/devhub/templates/devhub/versions/edit.html:5
 msgid "Manage Version {0}"
 msgstr "Gerir versão {0}"
 
-#: src/olympia/devhub/templates/devhub/versions/edit.html:12
-#: src/olympia/devhub/templates/devhub/versions/list.html:3
+#: src/olympia/devhub/templates/devhub/versions/edit.html:12 src/olympia/devhub/templates/devhub/versions/list.html:3
 msgid "Status & Versions"
 msgstr "Estado & versões"
 
-#. {0} is an add-on name.
 # {0} is the name of the collection
+#. {0} is an add-on name.
 #: src/olympia/devhub/templates/devhub/versions/edit.html:16
 msgid "Manage {0}"
 msgstr "Gerir {0}"
@@ -8919,22 +6848,10 @@ msgstr "Ficheiros"
 msgid "Upload Another File"
 msgstr "Carregar outro ficheiro"
 
-#: src/olympia/devhub/templates/devhub/versions/edit.html:45
-msgid ""
-"Adjusting application information here will allow users to install your\n"
-"                          add-on even if the install manifest in the package indicates that the\n"
-"                          add-on is incompatible."
-msgstr ""
-"Ajustar a informação da aplicação aqui irá permitir que os utilizadores instalem o seu \n"
-"                          extra mesmo que o manifesto de instalação no pacote indique que o \n"
-"                          extra é incompatível."
-
 #: src/olympia/devhub/templates/devhub/versions/edit.html:74
 msgid ""
-"Information about changes in this release, new features,\n"
-"                              known bugs, and other useful information specific to this\n"
-"                              release/version. This information is also shown in the\n"
-"                              Add-ons Manager when updating."
+"Information about changes in this release, new features, known bugs, and other useful information specific to this release/version. This information is also shown in the Add-ons Manager when "
+"updating."
 msgstr ""
 "Informação sobre alterações neste lançamento, novas funcionalidades, \n"
 "                              bugs conhecidos e outras informações específicas úteis para este \n"
@@ -8945,16 +6862,12 @@ msgstr ""
 msgid "Approval Status"
 msgstr "Estado da aprovação"
 
-#: src/olympia/devhub/templates/devhub/versions/edit.html:113
-#: src/olympia/editors/templates/editors/review.html:108
+#: src/olympia/devhub/templates/devhub/versions/edit.html:113 src/olympia/editors/templates/editors/review.html:108
 msgid "Notes for Reviewers"
 msgstr "Nota para revisores"
 
 #: src/olympia/devhub/templates/devhub/versions/edit.html:114
-msgid ""
-"Optionally, enter any information that may be useful\n"
-"                              to the Editor reviewing this add-on, such as test\n"
-"                              account information."
+msgid "Optionally, enter any information that may be useful to the Editor reviewing this add-on, such as test account information."
 msgstr ""
 "Opcionalmente, introduza qualquer informação que possa ser útil ao \n"
 "                              Editor a rever este extra, tal como a informação da \n"
@@ -8965,15 +6878,10 @@ msgid "Source code"
 msgstr "Código fonte"
 
 #: src/olympia/devhub/templates/devhub/versions/edit.html:128
-msgid ""
-"If your add-on contain binary or obfuscated code, make the source available "
-"here for reviewers."
-msgstr ""
-"Se o seu extra contem código binário ou código ofuscado, disponibilize o "
-"código aqui para os revisores."
+msgid "If your add-on contain binary or obfuscated code, make the source available here for reviewers."
+msgstr "Se o seu extra contem código binário ou código ofuscado, disponibilize o código aqui para os revisores."
 
-#: src/olympia/devhub/templates/devhub/versions/edit.html:145
-#: src/olympia/devhub/templates/devhub/versions/edit.html:149
+#: src/olympia/devhub/templates/devhub/versions/edit.html:145 src/olympia/devhub/templates/devhub/versions/edit.html:149
 msgid "Upload a new file"
 msgstr "Carregar um novo ficheiro"
 
@@ -9040,9 +6948,7 @@ msgstr "Pedir revisão completa"
 msgid "Request Preliminary Review"
 msgstr "Pedir revicão preliminar"
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:80
-#: src/olympia/devhub/templates/devhub/versions/list.html:327
-#: src/olympia/devhub/templates/devhub/versions/list.html:350
+#: src/olympia/devhub/templates/devhub/versions/list.html:80 src/olympia/devhub/templates/devhub/versions/list.html:325 src/olympia/devhub/templates/devhub/versions/list.html:348
 msgid "Cancel Review Request"
 msgstr "Cancelar pedido de revisão"
 
@@ -9055,35 +6961,24 @@ msgid "Listed:"
 msgstr "Listado:"
 
 #: src/olympia/devhub/templates/devhub/versions/list.html:102
-msgid ""
-"Visible to everyone on {0} and included in search results and listing pages"
-msgstr ""
-"Visível para todos no {0} e incluído nos resultados de pesquisas e listagens"
-" em páginas"
+msgid "Visible to everyone on {0} and included in search results and listing pages"
+msgstr "Visível para todos no {0} e incluído nos resultados de pesquisas e listagens em páginas"
 
 #: src/olympia/devhub/templates/devhub/versions/list.html:108
 msgid "Hidden:"
 msgstr "Oculto:"
 
 #: src/olympia/devhub/templates/devhub/versions/list.html:108
-msgid ""
-"Hosted on {0}, but hidden to anyone but authors. Used to temporarily hide "
-"listings or discontinue them."
-msgstr ""
-"Alojado no {0}, mas oculto para todos exceto os autores. Utilizado para "
-"ocultar temporariamente listagens ou para as descontinuar."
+msgid "Hosted on {0}, but hidden to anyone but authors. Used to temporarily hide listings or discontinue them."
+msgstr "Alojado no {0}, mas oculto para todos exceto os autores. Utilizado para ocultar temporariamente listagens ou para as descontinuar."
 
 #: src/olympia/devhub/templates/devhub/versions/list.html:114
 msgid "Unlisted:"
 msgstr "Não-listado:"
 
 #: src/olympia/devhub/templates/devhub/versions/list.html:114
-msgid ""
-"Not distributed on {0}. Developers will upload new versions for signing and "
-"distribute the add-ons on their own. (beta)"
+msgid "Not distributed on {0}. Developers will upload new versions for signing and distribute the add-ons on their own."
 msgstr ""
-"Não distribuído em {0}. Os programadores irão enviar novas versões para "
-"serem assinadas e distribuir os extras utilizando meios próprios. (beta)"
 
 #: src/olympia/devhub/templates/devhub/versions/list.html:122
 msgid "Current versions"
@@ -9093,18 +6988,13 @@ msgstr "Versões atuais"
 msgid "Currently on AMO"
 msgstr "Atualmente no AMO"
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:129
-#: src/olympia/devhub/templates/devhub/versions/list.html:147
-#: src/olympia/devhub/templates/devhub/versions/list.html:164
-#: src/olympia/editors/templates/editors/includes/search_results_themes.html:7
-#: src/olympia/editors/templates/editors/themes/queue_list.html:50
+#: src/olympia/devhub/templates/devhub/versions/list.html:129 src/olympia/devhub/templates/devhub/versions/list.html:147 src/olympia/devhub/templates/devhub/versions/list.html:164
+#: src/olympia/editors/templates/editors/includes/search_results_themes.html:7 src/olympia/editors/templates/editors/themes/queue_list.html:50
 msgid "Status"
 msgstr "Estado"
 
 # Header for a column in a table
-#: src/olympia/devhub/templates/devhub/versions/list.html:130
-#: src/olympia/devhub/templates/devhub/versions/list.html:148
-#: src/olympia/devhub/templates/devhub/versions/list.html:165
+#: src/olympia/devhub/templates/devhub/versions/list.html:130 src/olympia/devhub/templates/devhub/versions/list.html:148 src/olympia/devhub/templates/devhub/versions/list.html:165
 #: src/olympia/editors/templates/editors/includes/files_view.html:11
 msgid "Validation"
 msgstr "Validação"
@@ -9126,15 +7016,10 @@ msgid "Full review may not be required"
 msgstr "Revisão completa pode não ser necessária"
 
 #: src/olympia/devhub/templates/devhub/versions/list.html:201
-msgid ""
-"Unlisted add-ons don't need Full Review unless they are distributed as part "
-"of an application installer. Read <a href=\"{link}\" target=\"_blank\">this "
-"documentation</a> for more information."
+msgid "Unlisted add-ons don't need Full Review unless they are distributed as part of an application installer. Read <a href=\"{link}\" target=\"_blank\">this documentation</a> for more information."
 msgstr ""
-"Extras não listados não precisam de Revisões Completas a menos que sejam "
-"distribuídas como uma parte de um instalador de aplicações. Leia <a "
-"href=\"{link}\" target=\"_blank\">esta documentação</a> para mais "
-"informação."
+"Extras não listados não precisam de Revisões Completas a menos que sejam distribuídas como uma parte de um instalador de aplicações. Leia <a href=\"{link}\" target=\"_blank\">esta documentação</a> "
+"para mais informação."
 
 #: src/olympia/devhub/templates/devhub/versions/list.html:209
 msgid "Request full review"
@@ -9146,138 +7031,89 @@ msgstr "Eliminar versão {version}"
 
 #: src/olympia/devhub/templates/devhub/versions/list.html:218
 msgid ""
-"You are about to delete the current version of your add-on. This may cause "
-"your add-on status to change, or your listing to lose public visibility, if "
-"this is the only public version of your add-on."
+"You are about to delete the current version of your add-on. This may cause your add-on status to change, or your listing to lose public visibility, if this is the only public version of your add-on."
 msgstr ""
-"Está a eliminar a versão atual deste extra. Isto pode fazer com que o estado"
-" do seu extra mude ou que a sua listagem perca visibilidade pública, se esta"
-" for a única versão pública do seu extra."
+"Está a eliminar a versão atual deste extra. Isto pode fazer com que o estado do seu extra mude ou que a sua listagem perca visibilidade pública, se esta for a única versão pública do seu extra."
 
 #: src/olympia/devhub/templates/devhub/versions/list.html:219
 msgid "Deleting this version will permanently delete:"
 msgstr "Eliminar esta versão vai eliminar permanentemente:"
 
 #: src/olympia/devhub/templates/devhub/versions/list.html:225
-msgid ""
-"<strong>Important:</strong> Once a version has been deleted, you may not "
-"upload a new version with the same version number."
-msgstr ""
-"<strong>Importante:</strong> Assim que uma versão for eliminada, não poderá "
-"enviar uma nova versão com o mesmo número de versão."
+msgid "<strong>Important:</strong> Once a version has been deleted, you may not upload a new version with the same version number."
+msgstr "<strong>Importante:</strong> Assim que uma versão for eliminada, não poderá enviar uma nova versão com o mesmo número de versão."
 
 #: src/olympia/devhub/templates/devhub/versions/list.html:230
-msgid ""
-"Deleting a version which has already been reviewed\n"
-"               may also cause a significant delay in the review of\n"
-"               your next update."
-msgstr ""
-"Eliminar uma versão que já foi revista pode \n"
-"               significar um atraso significativo na revisão da sua \n"
-"               próxima atualização."
-
-#: src/olympia/devhub/templates/devhub/versions/list.html:233
 msgid "Are you sure you wish to delete this version?"
 msgstr "Tem a certeza que deseja eliminar esta versão?"
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:238
+#: src/olympia/devhub/templates/devhub/versions/list.html:235
 msgid "Delete Version"
 msgstr "Eliminar versão"
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:240
+#: src/olympia/devhub/templates/devhub/versions/list.html:237
 msgid "Disable Version"
 msgstr "Desativar versão"
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:247
+#: src/olympia/devhub/templates/devhub/versions/list.html:244
 msgid "Add a new Version"
 msgstr "Adicionar nova versão"
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:249
+#: src/olympia/devhub/templates/devhub/versions/list.html:246
 msgid "Add Version"
 msgstr "Adicionar versão"
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:256
-#: src/olympia/devhub/templates/devhub/versions/list.html:274
+#: src/olympia/devhub/templates/devhub/versions/list.html:253 src/olympia/devhub/templates/devhub/versions/list.html:279
 msgid "Hide Add-on"
 msgstr "Ocultar extra"
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:259
-msgid ""
-"Hiding your add-on will prevent it from appearing anywhere in our gallery "
-"and will stop users from receiving automatic updates."
-msgstr ""
-"Ocultar o seu extra irá impedir que o mesmo seja apresentado em qualquer "
-"lugar na nossa galeria e irá impedir que os utilizadores possam receber "
-"atualizações automáticas."
+#: src/olympia/devhub/templates/devhub/versions/list.html:256
+msgid "Hiding your add-on will prevent it from appearing anywhere in our gallery and will stop users from receiving automatic updates."
+msgstr "Ocultar o seu extra irá impedir que o mesmo seja apresentado em qualquer lugar na nossa galeria e irá impedir que os utilizadores possam receber atualizações automáticas."
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:265
+#: src/olympia/devhub/templates/devhub/versions/list.html:263
+msgid "The files awaiting review will be disabled and you will need to upload new versions."
+msgstr ""
+
+#: src/olympia/devhub/templates/devhub/versions/list.html:270
 msgid "Are you sure you wish to hide your add-on?"
 msgstr "Tem a certeza que pretende ocultar o seu extra?"
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:286
-#: src/olympia/devhub/templates/devhub/versions/list.html:315
+#: src/olympia/devhub/templates/devhub/versions/list.html:291 src/olympia/devhub/templates/devhub/versions/list.html:313
 msgid "Unlist Add-on"
 msgstr "Não listar extra"
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:289
+#: src/olympia/devhub/templates/devhub/versions/list.html:294
 #, python-format
 msgid ""
-"Unlisting your add-on will make it (and each of its versions/files) "
-"invisible on this website. It won't show up in searches, won't have a public"
-" facing page, and won't be updated automatically for current users.  It is "
-"recommended for unlisted add-ons to provide a custom <a "
-"href=\"%(update_url)s\" target=\"_blank\">updateURL</a> in their manifest "
-"file for automatic updates."
+"Unlisting your add-on will make it (and each of its versions/files) invisible on this website. It won't show up in searches, won't have a public facing page, and won't be updated automatically for "
+"current users. It is recommended for unlisted add-ons to provide a custom <a href=\"%(update_url)s\" target=\"_blank\">updateURL</a> in their manifest file for automatic updates."
 msgstr ""
-"Anular a listagem do seu extra irá torná-lo (e cada uma das suas "
-"versões/ficheiros) invisível neste website. Não irá ser apresentado em "
-"pesquisas, não irá ter uma página pública principal e não será "
-"automaticamente atualizado para os utilizadores atuais. É recomendável que "
-"os extras não-listados forneçam um <a href=\"%(update_url)s\" "
-"target=\"_blank\">updateURL</a> personalizado no seu ficheiro de manifesto "
-"para atualizações automáticas."
+"Anular a listagem do seu extra irá torná-lo (e cada uma das suas versões/ficheiros) invisível neste website. Não irá ser apresentado em pesquisas, não irá ter uma página pública principal e não "
+"será automaticamente atualizado para os utilizadores atuais. É recomendável que os extras não-listados forneçam um <a href=\"%(update_url)s\" target=\"_blank\">updateURL</a> personalizado no seu "
+"ficheiro de manifesto para atualizações automáticas."
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:299
-#, python-format
-msgid ""
-"Switching add-ons to unlisted is currently in an open beta. Please <a "
-"href=\"%(url)s\" target=\"_blank\">report any bugs</a> that you encounter."
-msgstr ""
-"Alterar extras para não listados está atualmente numa beta aberta. Por favor"
-" <a href=\"%(url)s\" target=\"_blank\">reporte quaisquer bugs</a> que "
-"encontre."
-
-#: src/olympia/devhub/templates/devhub/versions/list.html:305
+#: src/olympia/devhub/templates/devhub/versions/list.html:303
 msgid "Unlisting an add-on is irreversible!"
 msgstr "A não-listagem de um extra é irreversível!"
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:305
+#: src/olympia/devhub/templates/devhub/versions/list.html:303
 msgid "An unlisted add-on cannot be switched to be listed."
 msgstr "Um extra não-listado não pode ser modificado para ser listado."
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:307
+#: src/olympia/devhub/templates/devhub/versions/list.html:305
 msgid "Are you sure you wish to unlist your add-on?"
 msgstr "Tem a certeza que pretende não listar o seu extra?"
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:330
-msgid ""
-"Canceling your review request will leave your add-on as preliminarily "
-"reviewed."
-msgstr ""
-"Cancelar o seu pedido de revisão vai deixar o extra como revisto "
-"preliminarmente."
+#: src/olympia/devhub/templates/devhub/versions/list.html:328
+msgid "Canceling your review request will leave your add-on as preliminarily reviewed."
+msgstr "Cancelar o seu pedido de revisão vai deixar o extra como revisto preliminarmente."
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:335
-msgid ""
-"Canceling your review request will mark your add-on incomplete. If you do "
-"not complete your add-on after several days by re-requesting review, it will"
-" be deleted."
-msgstr ""
-"Cancelar o seu pedido de revisão vai marcar o seu extra como incompleto. Se "
-"não completar o seu extra passados alguns dias pedindo uma revisão, ele será"
-" eliminado."
+#: src/olympia/devhub/templates/devhub/versions/list.html:333
+msgid "Canceling your review request will mark your add-on incomplete. If you do not complete your add-on after several days by re-requesting review, it will be deleted."
+msgstr "Cancelar o seu pedido de revisão vai marcar o seu extra como incompleto. Se não completar o seu extra passados alguns dias pedindo uma revisão, ele será eliminado."
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:343
+#: src/olympia/devhub/templates/devhub/versions/list.html:341
 msgid "Are you sure you wish to cancel your review request?"
 msgstr "Tem a certeza que deseja cancelar o seu pedido de revisão?"
 
@@ -9310,18 +7146,12 @@ msgid "Translate content on the web from and into over 40 languages."
 msgstr "Traduza conteúdo na web em mais de 40 idiomas."
 
 #: src/olympia/discovery/modules.py:171
-msgid ""
-"Easily connect to your social networks, and share or comment on the page "
-"you're visiting."
-msgstr ""
-"Ligue-se facilmente às redes sociais e partilhe ou comente a página que está"
-" a visitar."
+msgid "Easily connect to your social networks, and share or comment on the page you're visiting."
+msgstr "Ligue-se facilmente às redes sociais e partilhe ou comente a página que está a visitar."
 
 #: src/olympia/discovery/modules.py:173
-msgid ""
-"A quick view to compare prices when you shop online or search for flights."
-msgstr ""
-"Uma visão rápida para comparar preços ao fazer compras ou pesquisar voos."
+msgid "A quick view to compare prices when you shop online or search for flights."
+msgstr "Uma visão rápida para comparar preços ao fazer compras ou pesquisar voos."
 
 #: src/olympia/discovery/modules.py:183
 msgid "Firefox 4 Collection"
@@ -9364,24 +7194,16 @@ msgid "Add-ons that help you on your travels!"
 msgstr "Extras que o ajudam nas suas viagens!"
 
 #: src/olympia/discovery/modules.py:226
-msgid ""
-"Displays a country flag depicting the location of the current website's "
-"server and more."
-msgstr ""
-"Exibe uma bandeira referente à localização do servidor do sitio visitado e "
-"mais."
+msgid "Displays a country flag depicting the location of the current website's server and more."
+msgstr "Exibe uma bandeira referente à localização do servidor do sitio visitado e mais."
 
 #: src/olympia/discovery/modules.py:228
 msgid "FoxClocks let you keep an eye on the time around the world."
 msgstr "FoxClocks deixa-o ver as horas em todo o mundo."
 
 #: src/olympia/discovery/modules.py:230
-msgid ""
-"Automatically get the lowest price when you shop online or search for "
-"flights."
-msgstr ""
-"Obtenha automaticamente o menor preço quando faz compras online ou procura "
-"vôos."
+msgid "Automatically get the lowest price when you shop online or search for flights."
+msgstr "Obtenha automaticamente o menor preço quando faz compras online ou procura vôos."
 
 #: src/olympia/discovery/modules.py:240
 msgid "A+ add-ons for School"
@@ -9420,13 +7242,8 @@ msgid "Put a Theme on It!"
 msgstr "Ponha um tema nisso!"
 
 #: src/olympia/discovery/modules.py:281
-msgid ""
-"Visit addons.mozilla.org from Firefox for Android and dress up your mobile "
-"browser to match your style, mood, or the season."
-msgstr ""
-"Visite addons.mozilla.org no Firefox para Android e altere a aparência do "
-"seu navegador móvel para combinar com o seu estilo, estado de espírito ou "
-"estação."
+msgid "Visit addons.mozilla.org from Firefox for Android and dress up your mobile browser to match your style, mood, or the season."
+msgstr "Visite addons.mozilla.org no Firefox para Android e altere a aparência do seu navegador móvel para combinar com o seu estilo, estado de espírito ou estação."
 
 #: src/olympia/discovery/modules.py:290
 msgid "Get up and move!"
@@ -9453,12 +7270,8 @@ msgid "Protect your privacy online with the add-ons in this collection."
 msgstr "Proteja a sua privacidade online com os extras desta coleção."
 
 #: src/olympia/discovery/modules.py:342
-msgid ""
-"Great add-ons for work, fun, privacy, productivity&hellip; just about "
-"anything!"
-msgstr ""
-"Ótimos extras para trabalho, diversão, privacidade, produtividade&hellip; "
-"enfim, extras para quase tudo!"
+msgid "Great add-ons for work, fun, privacy, productivity&hellip; just about anything!"
+msgstr "Ótimos extras para trabalho, diversão, privacidade, produtividade&hellip; enfim, extras para quase tudo!"
 
 #: src/olympia/discovery/modules.py:350
 msgid "Add-ons for Australis Contest Winners"
@@ -9478,22 +7291,16 @@ msgstr "O que são extras?"
 
 #: src/olympia/discovery/templates/discovery/pane.html:28
 #, python-format
-msgid ""
-"Add-ons are applications that let you personalize %(app)s with extra "
-"functionality or style. Try a time-saving sidebar, a weather notifier, or a "
-"themed look to make %(app)s your own."
+msgid "Add-ons are applications that let you personalize %(app)s with extra functionality or style. Try a time-saving sidebar, a weather notifier, or a themed look to make %(app)s your own."
 msgstr ""
-"Os extras são aplicações que permitem personalizar o %(app)s com "
-"funcionalidades extra ou estilo. Experimente uma barra lateral de poupança "
-"de tempo, um notificador sobre o tempo, ou um tema para tornar o %(app)s só "
-"seu."
+"Os extras são aplicações que permitem personalizar o %(app)s com funcionalidades extra ou estilo. Experimente uma barra lateral de poupança de tempo, um notificador sobre o tempo, ou um tema para "
+"tornar o %(app)s só seu."
 
 #: src/olympia/discovery/templates/discovery/pane.html:62
 msgid "Learn More About Add-ons"
 msgstr "Saiba mais sobre os extras"
 
-#: src/olympia/discovery/templates/discovery/pane.html:66
-#: src/olympia/discovery/templates/discovery/pane.html:73
+#: src/olympia/discovery/templates/discovery/pane.html:66 src/olympia/discovery/templates/discovery/pane.html:73
 msgid "See all"
 msgstr "Ver tudo"
 
@@ -9515,8 +7322,7 @@ msgstr "Fechar vídeo"
 
 #: src/olympia/discovery/templates/discovery/pane.html:94
 msgid "While the video plays, the add-ons being mentioned will appear here."
-msgstr ""
-"Enquanto o vídeo é reproduzido, o extra sendo mencionado aparecerá aqui."
+msgstr "Enquanto o vídeo é reproduzido, o extra sendo mencionado aparecerá aqui."
 
 #. {0} is the user's login name.
 #: src/olympia/discovery/templates/discovery/pane_account.html:6
@@ -9525,12 +7331,8 @@ msgstr "Olá, {0}"
 
 #: src/olympia/discovery/templates/discovery/pane_account.html:17
 #, python-format
-msgid ""
-"Thanks for using %(app)s and supporting <a href=\"%(url)s\">Mozilla's "
-"mission</a>!"
-msgstr ""
-"Obrigado por usar o %(app)s e ajudar a <a href=\"%(url)s\">missão da "
-"Mozilla</a>!"
+msgid "Thanks for using %(app)s and supporting <a href=\"%(url)s\">Mozilla's mission</a>!"
+msgstr "Obrigado por usar o %(app)s e ajudar a <a href=\"%(url)s\">missão da Mozilla</a>!"
 
 #: src/olympia/discovery/templates/discovery/pane_account.html:23
 msgid "Add-ons downloaded:"
@@ -9554,15 +7356,10 @@ msgstr "Obter extras imediatamente"
 
 #: src/olympia/discovery/templates/discovery/modules/go-mobile.html:8
 #, python-format
-msgid ""
-"Visit <a href=\"%(url)s\">firefox.com/m</a> to get Firefox on your phone and"
-" personalize your browser anytime, anywhere. Easily discover and install "
-"add-ons from the mobile Add-ons Manager."
+msgid "Visit <a href=\"%(url)s\">firefox.com/m</a> to get Firefox on your phone and personalize your browser anytime, anywhere. Easily discover and install add-ons from the mobile Add-ons Manager."
 msgstr ""
-"Visite <a href=\"%(url)s\">firefox.com/m</a> para obter o Firefox no seu "
-"telefone e personalizar o seu navegador a qualquer altura, em qualquer "
-"altura. Descubra e instale facilmente extras a partir do gestor de extras do"
-" Mobile."
+"Visite <a href=\"%(url)s\">firefox.com/m</a> para obter o Firefox no seu telefone e personalizar o seu navegador a qualquer altura, em qualquer altura. Descubra e instale facilmente extras a partir "
+"do gestor de extras do Mobile."
 
 #: src/olympia/discovery/templates/discovery/modules/go-mobile.html:13
 msgid "Get Mobile Add-ons"
@@ -9577,20 +7374,12 @@ msgid "Find great add-ons to help you with all your holiday shopping needs."
 msgstr "Encontre ótimos extras para o ajudar com todas as suas compras."
 
 #: src/olympia/discovery/templates/discovery/modules/holiday.html:13
-msgid ""
-"Install the Amazon Browser Apps and receive special Amazon features right at"
-" your fingertips."
-msgstr ""
-"Instale o navegador de aplicações da Amazon e tenha funcionalidades "
-"especiais da Amazon na ponta dos seus dedos."
+msgid "Install the Amazon Browser Apps and receive special Amazon features right at your fingertips."
+msgstr "Instale o navegador de aplicações da Amazon e tenha funcionalidades especiais da Amazon na ponta dos seus dedos."
 
 #: src/olympia/discovery/templates/discovery/modules/holiday.html:22
-msgid ""
-"Keep an eye on your eBay activity wherever you are on the web when you "
-"install the eBay Sidebar for Firefox."
-msgstr ""
-"Acompanhe a sua atividade no eBay sempre que estiver na web quando instalar "
-"a barra lateral do eBay para o Firefox."
+msgid "Keep an eye on your eBay activity wherever you are on the web when you install the eBay Sidebar for Firefox."
+msgstr "Acompanhe a sua atividade no eBay sempre que estiver na web quando instalar a barra lateral do eBay para o Firefox."
 
 #: src/olympia/discovery/templates/discovery/modules/holiday.html:31
 msgid "See the entire holiday shopping add-on collection."
@@ -9667,19 +7456,19 @@ msgstr "extra, editor ou comentário"
 msgid "Search by add-on name / author email"
 msgstr "Procurar por nome do extra / email do autor"
 
-#: src/olympia/editors/forms.py:103
+#: src/olympia/editors/forms.py:103 src/olympia/editors/forms.py:244 src/olympia/editors/forms.py:257
 msgid "yes"
 msgstr "sim"
 
-#: src/olympia/editors/forms.py:104
+#: src/olympia/editors/forms.py:104 src/olympia/editors/forms.py:244 src/olympia/editors/forms.py:257
 msgid "no"
 msgstr "não"
 
-#: src/olympia/editors/forms.py:105
+#: src/olympia/editors/forms.py:105 src/olympia/editors/forms.py:245
 msgid "Admin Flag"
 msgstr "Etiqueta do Admin"
 
-#: src/olympia/editors/forms.py:113
+#: src/olympia/editors/forms.py:113 src/olympia/editors/forms.py:253
 msgid "Max. Version"
 msgstr "Versão máx."
 
@@ -9691,59 +7480,59 @@ msgstr "Dias desde a submissão"
 msgid "Add-on Types"
 msgstr "Tipos de extras"
 
-#: src/olympia/editors/forms.py:126 src/olympia/editors/helpers.py:267
+#: src/olympia/editors/forms.py:126 src/olympia/editors/helpers.py:279
 msgid "Platforms"
 msgstr "Plataformas"
 
+#: src/olympia/editors/forms.py:237
+msgid "Search by add-on name / author email / guid"
+msgstr ""
+
 #. L10n: 0 = platform, 1 = filename, 2 = status message
-#: src/olympia/editors/forms.py:238
+#: src/olympia/editors/forms.py:342
 #, python-format
 msgid "<strong>%s</strong> &middot; %s &middot; %s"
 msgstr "<strong>%s</strong> &middot; %s &middot; %s"
 
-#: src/olympia/editors/forms.py:252
+#: src/olympia/editors/forms.py:356
 msgid "Comments:"
 msgstr "Comentários:"
 
-#: src/olympia/editors/forms.py:256
+#: src/olympia/editors/forms.py:360
 msgid "Operating systems:"
 msgstr "Sistemas operativos:"
 
-#: src/olympia/editors/forms.py:258
+#: src/olympia/editors/forms.py:362
 msgid "Applications:"
 msgstr "Aplicações:"
 
-#: src/olympia/editors/forms.py:260
-msgid ""
-"Notify me the next time this add-on is updated. (Subsequent updates will not"
-" generate an email)"
-msgstr ""
-"Notificar-me da próxima vez que este extra for atualizado. (As atualizações "
-"seguintes não vão gerar um email)"
+#: src/olympia/editors/forms.py:364
+msgid "Notify me the next time this add-on is updated. (Subsequent updates will not generate an email)"
+msgstr "Notificar-me da próxima vez que este extra for atualizado. (As atualizações seguintes não vão gerar um email)"
 
-#: src/olympia/editors/forms.py:265
+#: src/olympia/editors/forms.py:369
 msgid "Clear Admin Review Flag"
 msgstr "Limpar propriedade de administração"
 
-#: src/olympia/editors/forms.py:267
+#: src/olympia/editors/forms.py:371
 msgid "Clear more info requested flag"
 msgstr "Limpar a etiqueta de mais informação solicitada"
 
-#: src/olympia/editors/forms.py:281
+#: src/olympia/editors/forms.py:385
 msgid "Choose a canned response..."
 msgstr "Escolha um modelo de resposta ..."
 
 #. L10n: Description of what can be searched for.
-#: src/olympia/editors/forms.py:324
+#: src/olympia/editors/forms.py:423
 msgid "theme name"
 msgstr "nome do tema"
 
-#: src/olympia/editors/forms.py:350
+#: src/olympia/editors/forms.py:449
 msgid "Someone else is reviewing this theme."
 msgstr "Outra pessoa está analisando este tema."
 
 #. L10n: Description of what can be searched for.
-#: src/olympia/editors/forms.py:447
+#: src/olympia/editors/forms.py:546
 msgid "app, reviewer, or comment"
 msgstr "aplicativo, revisor, ou comentário"
 
@@ -9759,291 +7548,267 @@ msgstr "Aguarda análise preliminar"
 msgid "Rejected or Unreviewed"
 msgstr "Rejeitado ou não revisto"
 
-#: src/olympia/editors/helpers.py:123 src/olympia/editors/helpers.py:136
+#: src/olympia/editors/helpers.py:125 src/olympia/editors/helpers.py:138
 msgid "Queue"
 msgstr "Fila"
 
-#: src/olympia/editors/helpers.py:124
-#: src/olympia/editors/templates/editors/base.html:50
-#: src/olympia/editors/templates/editors/base.html:65
+#: src/olympia/editors/helpers.py:126 src/olympia/editors/templates/editors/base.html:50 src/olympia/editors/templates/editors/base.html:65
 msgid "Pending Updates"
 msgstr "Atualizações pendentes"
 
-#: src/olympia/editors/helpers.py:125
-#: src/olympia/editors/templates/editors/base.html:48
-#: src/olympia/editors/templates/editors/base.html:63
+#: src/olympia/editors/helpers.py:127 src/olympia/editors/templates/editors/base.html:48 src/olympia/editors/templates/editors/base.html:63
 msgid "Full Reviews"
 msgstr "Revisões completas"
 
-#: src/olympia/editors/helpers.py:126
-#: src/olympia/editors/templates/editors/base.html:52
-#: src/olympia/editors/templates/editors/base.html:67
+#: src/olympia/editors/helpers.py:128 src/olympia/editors/templates/editors/base.html:52 src/olympia/editors/templates/editors/base.html:67
 msgid "Preliminary Reviews"
 msgstr "Revisões preliminares"
 
-#: src/olympia/editors/helpers.py:127
-#: src/olympia/editors/templates/editors/base.html:54
+#: src/olympia/editors/helpers.py:129 src/olympia/editors/templates/editors/base.html:54
 msgid "Moderated Reviews"
 msgstr "Revisões moderadas"
 
-#: src/olympia/editors/helpers.py:128
-#: src/olympia/editors/templates/editors/base.html:46
+#: src/olympia/editors/helpers.py:130 src/olympia/editors/templates/editors/base.html:46
 msgid "Fast Track"
 msgstr "Fast Track"
 
-#: src/olympia/editors/helpers.py:130
+#: src/olympia/editors/helpers.py:132
 msgid "Pending Themes"
 msgstr "Temas pendentes"
 
-#: src/olympia/editors/helpers.py:131
-#: src/olympia/editors/templates/editors/themes/queue.html:4
+#: src/olympia/editors/helpers.py:133 src/olympia/editors/templates/editors/themes/queue.html:4
 msgid "Flagged Themes"
 msgstr "Temas marcados"
 
-#: src/olympia/editors/helpers.py:132
+#: src/olympia/editors/helpers.py:134
 msgid "Update Themes"
 msgstr "Atualizar temas"
 
-#: src/olympia/editors/helpers.py:137
+#: src/olympia/editors/helpers.py:139
 msgid "Unlisted Pending Updates"
 msgstr "Atualizações pendentes não-listadas"
 
-#: src/olympia/editors/helpers.py:138
+#: src/olympia/editors/helpers.py:140
 msgid "Unlisted Full Reviews"
 msgstr "Análise completas não-listadas"
 
-#: src/olympia/editors/helpers.py:139
+#: src/olympia/editors/helpers.py:141
 msgid "Unlisted Preliminary Reviews"
 msgstr "Análises preliminares não-listadas"
 
-#: src/olympia/editors/helpers.py:170
+#: src/olympia/editors/helpers.py:142
+msgid "Unlisted All Add-ons"
+msgstr ""
+
+#: src/olympia/editors/helpers.py:173
 msgid "Fast Track ({0})"
 msgid_plural "Fast Track ({0})"
 msgstr[0] "Fast Track ({0})"
 msgstr[1] "Fast Track ({0})"
 
-#: src/olympia/editors/helpers.py:175
+#: src/olympia/editors/helpers.py:178
 msgid "Full Review ({0})"
 msgid_plural "Full Reviews ({0})"
 msgstr[0] "Revisão completa ({0})"
 msgstr[1] "Revisões completas ({0})"
 
-#: src/olympia/editors/helpers.py:180
+#: src/olympia/editors/helpers.py:183
 msgid "Pending Update ({0})"
 msgid_plural "Pending Updates ({0})"
 msgstr[0] "Atualização em falta ({0})"
 msgstr[1] "Atualizações em falta ({0})"
 
-#: src/olympia/editors/helpers.py:185
+#: src/olympia/editors/helpers.py:188
 msgid "Preliminary Review ({0})"
 msgid_plural "Preliminary Reviews ({0})"
 msgstr[0] "Revisão preliminar ({0})"
 msgstr[1] "Revisões preliminares ({0})"
 
-#: src/olympia/editors/helpers.py:190
+#: src/olympia/editors/helpers.py:193
 msgid "Moderated Review ({0})"
 msgid_plural "Moderated Reviews ({0})"
 msgstr[0] "Revisão moderada ({0})"
 msgstr[1] "Revisões moderadas ({0})"
 
-#: src/olympia/editors/helpers.py:196
+#: src/olympia/editors/helpers.py:199
 msgid "Unlisted Full Review ({0})"
 msgid_plural "Unlisted Full Reviews ({0})"
 msgstr[0] "Revisão completa não-listada ({0})"
 msgstr[1] "Revisões completas não-listadas ({0})"
 
-#: src/olympia/editors/helpers.py:201
+#: src/olympia/editors/helpers.py:204
 msgid "Unlisted Pending Update ({0})"
 msgid_plural "Unlisted Pending Updates ({0})"
 msgstr[0] "Atualização pendente não-listada ({0})"
 msgstr[1] "Atualizações pendentes não-listadas ({0})"
 
-#: src/olympia/editors/helpers.py:206
+#: src/olympia/editors/helpers.py:209
 msgid "Unlisted Preliminary Review ({0})"
 msgid_plural "Unlisted Preliminary Reviews ({0})"
 msgstr[0] "Revisão preliminar não-listada ({0})"
 msgstr[1] "Revisões preliminares não-listadas ({0})"
 
-#: src/olympia/editors/helpers.py:261
-msgid "Addon"
-msgstr "Extra"
+#: src/olympia/editors/helpers.py:214
+msgid "Unlisted All Add-ons ({0})"
+msgid_plural "Unlisted All Add-ons ({0})"
+msgstr[0] ""
+msgstr[1] ""
 
-#: src/olympia/editors/helpers.py:262
+#: src/olympia/editors/helpers.py:274
 msgid "Type"
 msgstr "Tipo"
 
-#: src/olympia/editors/helpers.py:263
+#: src/olympia/editors/helpers.py:275
 msgid "Waiting Time"
 msgstr "Tempo de espera"
 
-#: src/olympia/editors/helpers.py:264
-#: src/olympia/editors/templates/editors/review.html:285
+#: src/olympia/editors/helpers.py:276 src/olympia/editors/templates/editors/review.html:285
 msgid "Flags"
 msgstr "Etiquetas"
 
-#: src/olympia/editors/helpers.py:265
+#: src/olympia/editors/helpers.py:277
 msgid "Applications"
 msgstr "Aplicações"
 
-#: src/olympia/editors/helpers.py:270
+#: src/olympia/editors/helpers.py:282
 msgid "Additional"
 msgstr "Adicional"
 
-#: src/olympia/editors/helpers.py:285
+#: src/olympia/editors/helpers.py:302
 msgid "Site Specific"
 msgstr "Específico do site"
 
-#: src/olympia/editors/helpers.py:287
+#: src/olympia/editors/helpers.py:304
 msgid "Requires External Software"
 msgstr "Necessita de software externo"
 
-#: src/olympia/editors/helpers.py:289
+#: src/olympia/editors/helpers.py:306
 msgid "Binary Components"
 msgstr "Componentes binários"
 
-#: src/olympia/editors/helpers.py:313
+#: src/olympia/editors/helpers.py:339
 msgid "moments ago"
 msgstr "à instantes"
 
 #. L10n: first argument is number of minutes
-#: src/olympia/editors/helpers.py:316
+#: src/olympia/editors/helpers.py:342
 msgid "{0} minute"
 msgid_plural "{0} minutes"
 msgstr[0] "{0} minuto"
 msgstr[1] "{0} minutos"
 
 #. L10n: first argument is number of hours
-#: src/olympia/editors/helpers.py:320
+#: src/olympia/editors/helpers.py:346
 msgid "{0} hour"
 msgid_plural "{0} hours"
 msgstr[0] "{0} hora"
 msgstr[1] "{0} horas"
 
 #. L10n: first argument is number of days
-#: src/olympia/editors/helpers.py:324
+#: src/olympia/editors/helpers.py:350
 msgid "{0} day"
 msgid_plural "{0} days"
 msgstr[0] "{0} dia"
 msgstr[1] "{0} dias"
 
-#: src/olympia/editors/helpers.py:488
+#: src/olympia/editors/helpers.py:364
+msgid "Last Review"
+msgstr ""
+
+#: src/olympia/editors/helpers.py:366
+msgid "Last Update"
+msgstr ""
+
+#: src/olympia/editors/helpers.py:387
+msgid "No Reviews"
+msgstr ""
+
+#: src/olympia/editors/helpers.py:561
 msgid "Push to public"
 msgstr "Enviar para o público"
 
-#: src/olympia/editors/helpers.py:490
+#: src/olympia/editors/helpers.py:563
 msgid "Grant full review"
 msgstr "Atribuir revisão completa"
 
-#: src/olympia/editors/helpers.py:505
+#: src/olympia/editors/helpers.py:578
 msgid "Request more information"
 msgstr "Pedir mais informação"
 
-#: src/olympia/editors/helpers.py:508
+#: src/olympia/editors/helpers.py:581
 msgid "Request super-review"
 msgstr "Pedir super-revisão"
 
-#: src/olympia/editors/helpers.py:519
+#: src/olympia/editors/helpers.py:592
 msgid "Grant preliminary review"
 msgstr "Permitir revisão preliminar"
 
-#: src/olympia/editors/helpers.py:520
+#: src/olympia/editors/helpers.py:593
 msgid "This will mark the files as preliminarily reviewed."
 msgstr "Isto irá marcar os ficheiros como preliminarmente revistos."
 
-#: src/olympia/editors/helpers.py:522
-msgid ""
-"Use this form to request more information from the author. They will receive"
-" an email and be able to answer here. You will be notified by email when "
-"they reply."
-msgstr ""
-"Utilize este formulário para solicitar mais informações do autor. Ele irá "
-"receber um email e será capaz de responder aqui. Você será notificado por "
-"email quando o mesmo responder."
+#: src/olympia/editors/helpers.py:595
+msgid "Use this form to request more information from the author. They will receive an email and be able to answer here. You will be notified by email when they reply."
+msgstr "Utilize este formulário para solicitar mais informações do autor. Ele irá receber um email e será capaz de responder aqui. Você será notificado por email quando o mesmo responder."
 
-#: src/olympia/editors/helpers.py:526
+#: src/olympia/editors/helpers.py:599
 msgid ""
-"If you have concerns about this add-on's security, copyright issues, or "
-"other concerns that an administrator should look into, enter your comments "
-"in the area below. They will be sent to administrators, not the author."
+"If you have concerns about this add-on's security, copyright issues, or other concerns that an administrator should look into, enter your comments in the area below. They will be sent to "
+"administrators, not the author."
 msgstr ""
-"Se tiver dúvidas sobre a segurança deste extra, questões de direitos autor, "
-"ou outras preocupações que um administrador deva considerar, introduza os "
-"seus comentários no espaço abaixo. Eles serão enviados para os "
-"administradores, não o autor."
+"Se tiver dúvidas sobre a segurança deste extra, questões de direitos autor, ou outras preocupações que um administrador deva considerar, introduza os seus comentários no espaço abaixo. Eles serão "
+"enviados para os administradores, não o autor."
 
-#: src/olympia/editors/helpers.py:532
+#: src/olympia/editors/helpers.py:605
 msgid "This will reject the add-on and remove it from the review queue."
 msgstr "Isto vai rejeitar o extra e removê-lo da espera de revisão."
 
-#: src/olympia/editors/helpers.py:534
-msgid "Make a comment on this version.  The author won't be able to see this."
+#: src/olympia/editors/helpers.py:607
+msgid "Make a comment on this version. The author won't be able to see this."
 msgstr "Faça um comentário a esta versão.  O autor não poderá ver isto."
 
-#: src/olympia/editors/helpers.py:538
+#: src/olympia/editors/helpers.py:611
 msgid "This will reject the files and remove them from the review queue."
 msgstr "Isto vai rejeitar os ficheiros e removê-los da espera de revisão."
 
-#: src/olympia/editors/helpers.py:542
-msgid ""
-"This will mark the add-on as preliminarily reviewed. Future versions will "
-"undergo preliminary review."
-msgstr ""
-"Isto vai marcar o extra como preliminarmente revisto. Versões futuras irão "
-"ter uma revisão prelimar."
+#: src/olympia/editors/helpers.py:615
+msgid "This will mark the add-on as preliminarily reviewed. Future versions will undergo preliminary review."
+msgstr "Isto vai marcar o extra como preliminarmente revisto. Versões futuras irão ter uma revisão prelimar."
 
-#: src/olympia/editors/helpers.py:547
-msgid ""
-"This will mark the files as preliminarily reviewed. Future versions will "
-"undergo preliminary review."
-msgstr ""
-"Isto vai marcar os ficheiros como preliminarmente revistos. Versões futuras "
-"irão ter uma revisão prelimar."
+#: src/olympia/editors/helpers.py:620
+msgid "This will mark the files as preliminarily reviewed. Future versions will undergo preliminary review."
+msgstr "Isto vai marcar os ficheiros como preliminarmente revistos. Versões futuras irão ter uma revisão prelimar."
 
-#: src/olympia/editors/helpers.py:552
+#: src/olympia/editors/helpers.py:625
 msgid "Retain preliminary review"
 msgstr "Reter revisão preliminar"
 
-#: src/olympia/editors/helpers.py:553
-msgid ""
-"This will retain the add-on as preliminarily reviewed. Future versions will "
-"undergo preliminary review."
-msgstr ""
-"Isto vai manter o extra como preliminarmente revisto. Versões futuras irão "
-"ter uma revisão prelimar."
+#: src/olympia/editors/helpers.py:626
+msgid "This will retain the add-on as preliminarily reviewed. Future versions will undergo preliminary review."
+msgstr "Isto vai manter o extra como preliminarmente revisto. Versões futuras irão ter uma revisão prelimar."
 
-#: src/olympia/editors/helpers.py:558
-msgid ""
-"This will approve a sandboxed version of a public add-on to appear on the "
-"public side."
-msgstr ""
-"Isto irá aprovar uma versão em modo seguro de um extra público para aparecer"
-" do lado do público."
+#: src/olympia/editors/helpers.py:631
+msgid "This will approve a sandboxed version of a public add-on to appear on the public side."
+msgstr "Isto irá aprovar uma versão em modo seguro de um extra público para aparecer do lado do público."
 
-#: src/olympia/editors/helpers.py:561
-msgid ""
-"This will reject a version of a public add-on and remove it from the queue."
+#: src/olympia/editors/helpers.py:634
+msgid "This will reject a version of a public add-on and remove it from the queue."
 msgstr "Isto vai rejeitar a versão de um extra público e remove-lo da lista."
 
-#: src/olympia/editors/helpers.py:564
-msgid ""
-"This will mark the add-on and its most recent version and files as public. "
-"Future versions will go into the sandbox until they are reviewed by an "
-"editor."
-msgstr ""
-"Isto irá marcar o extra e os seus ficheiros e a sua versão mais recente "
-"públicos. Versões futuras vão para o sandbox até que sejam revistos ​​por um"
-" editor."
-
 #: src/olympia/editors/helpers.py:637
+msgid "This will mark the add-on and its most recent version and files as public. Future versions will go into the sandbox until they are reviewed by an editor."
+msgstr "Isto irá marcar o extra e os seus ficheiros e a sua versão mais recente públicos. Versões futuras vão para o sandbox até que sejam revistos ​​por um editor."
+
+#: src/olympia/editors/helpers.py:714
 msgid "add-on"
 msgstr "extra"
 
-#: src/olympia/editors/helpers.py:940 src/olympia/editors/helpers.py:960
+#: src/olympia/editors/helpers.py:1020 src/olympia/editors/helpers.py:1040
 msgid "Flagged"
 msgstr "Marcado"
 
 # 85%
-#: src/olympia/editors/helpers.py:944 src/olympia/editors/helpers.py:963
+#: src/olympia/editors/helpers.py:1024 src/olympia/editors/helpers.py:1043
 msgid "Updates"
 msgstr "Atualizações"
 
@@ -10095,77 +7860,69 @@ msgstr "Envio de tema marcado para revisão"
 msgid "A question about your Theme submission"
 msgstr "Uma questão sobre a submissão do seu tema"
 
-#: src/olympia/editors/views.py:144
+#: src/olympia/editors/views.py:146
 msgid "New Add-ons (Under 5 days)"
 msgstr "Novos extras (até 5 dias)"
 
-#: src/olympia/editors/views.py:145
+#: src/olympia/editors/views.py:147
 msgid "Passable (5 to 10 days)"
 msgstr "Razoável (5 a 10 dias)"
 
-#: src/olympia/editors/views.py:146
+#: src/olympia/editors/views.py:148
 msgid "Overdue (Over 10 days)"
 msgstr "Antigos (mais de 10 dias)"
 
-#: src/olympia/editors/views.py:532
+#: src/olympia/editors/views.py:539
 msgid "An unknown error occurred"
 msgstr "Ocorreu um erro desconhecido"
 
-#: src/olympia/editors/views.py:587
+#: src/olympia/editors/views.py:592
 msgid "Self-reviews are not allowed."
 msgstr "Não são permitidas auto-revisões."
 
-#: src/olympia/editors/views.py:609
+#: src/olympia/editors/views.py:613
 msgid "Review successfully processed."
 msgstr "Revisão processada com sucesso."
 
-#: src/olympia/editors/views.py:807
+#: src/olympia/editors/views.py:812
 msgid "was approved"
 msgstr "foi aprovado"
 
-#: src/olympia/editors/views.py:808
+#: src/olympia/editors/views.py:813
 msgid "given preliminary review"
 msgstr "dado comentário preliminar"
 
-#: src/olympia/editors/views.py:809
+#: src/olympia/editors/views.py:814
 msgid "rejected"
 msgstr "rejeitado"
 
-#: src/olympia/editors/views.py:810
+#: src/olympia/editors/views.py:815
 msgctxt "editors_review_history_nominated_adminreview"
 msgid "escalated"
 msgstr "escalado"
 
-#: src/olympia/editors/views.py:812
+#: src/olympia/editors/views.py:817
 msgid "needs more information"
 msgstr "necessita de mais informação"
 
-#: src/olympia/editors/views.py:813
+#: src/olympia/editors/views.py:818
 msgid "needs super review"
 msgstr "necessita de super revisão"
 
-#: src/olympia/editors/views.py:814
+#: src/olympia/editors/views.py:819
 msgid "commented"
 msgstr "comentado"
 
 #: src/olympia/editors/views_themes.py:326
 msgid "{0} theme review successfully processed (+{1} points, {2} total)."
-msgid_plural ""
-"{0} theme reviews successfully processed (+{1} points, {2} total)."
-msgstr[0] ""
-"{0} revisão de tema processada com sucesso (+{1} pontos, {2} total)."
-msgstr[1] ""
-"{0} revisões de temas processadas com sucesso (+{1} pontos, {2} total)."
+msgid_plural "{0} theme reviews successfully processed (+{1} points, {2} total)."
+msgstr[0] "{0} revisão de tema processada com sucesso (+{1} pontos, {2} total)."
+msgstr[1] "{0} revisões de temas processadas com sucesso (+{1} pontos, {2} total)."
 
 #: src/olympia/editors/views_themes.py:341
-msgid ""
-"Your theme locks have successfully been released. Other reviewers may now "
-"review those released themes. You may have to refresh the page to see the "
-"changes reflected in the table below."
+msgid "Your theme locks have successfully been released. Other reviewers may now review those released themes. You may have to refresh the page to see the changes reflected in the table below."
 msgstr ""
-"Os bloqueios ao seu tema foram libertados com sucesso. Outros revisores "
-"podem agora rever os temas libertados. Pode ter de atualizar a página para "
-"ver as alterações refletidas na tabela em baixo."
+"Os bloqueios ao seu tema foram libertados com sucesso. Outros revisores podem agora rever os temas libertados. Pode ter de atualizar a página para ver as alterações refletidas na tabela em baixo."
 
 #: src/olympia/editors/templates/editors/abuse_reports.html:4
 msgid "{addon} :: Abuse Reports"
@@ -10189,9 +7946,7 @@ msgstr "<i>anônimo</i> em %(date)s [%(ip_address)s]"
 msgid "Return to the Editor Tools homepage"
 msgstr "Voltar à página inicial das ferramentas do editor"
 
-#: src/olympia/editors/templates/editors/base.html:43
-#: src/olympia/editors/templates/editors/themes/base.html:14
-#: src/olympia/editors/templates/editors/themes/base.html:28
+#: src/olympia/editors/templates/editors/base.html:43 src/olympia/editors/templates/editors/themes/base.html:14 src/olympia/editors/templates/editors/themes/base.html:28
 #: src/olympia/editors/templates/editors/themes/queue.html:25
 msgid "Queues"
 msgstr "Esperas"
@@ -10200,71 +7955,51 @@ msgstr "Esperas"
 msgid "Unlisted Queues"
 msgstr "Filas não-listadas"
 
-#: src/olympia/editors/templates/editors/base.html:72
-#: src/olympia/editors/templates/editors/performance.html:6
+#: src/olympia/editors/templates/editors/base.html:74 src/olympia/editors/templates/editors/performance.html:6
 msgid "Performance"
 msgstr "Desempenho"
 
-#: src/olympia/editors/templates/editors/base.html:75
-#: src/olympia/editors/templates/editors/themes/base.html:19
-#: src/olympia/editors/templates/editors/themes/base.html:38
+#: src/olympia/editors/templates/editors/base.html:77 src/olympia/editors/templates/editors/themes/base.html:19 src/olympia/editors/templates/editors/themes/base.html:38
 msgid "Logs"
 msgstr "Registos"
 
-#: src/olympia/editors/templates/editors/base.html:78
-#: src/olympia/editors/templates/editors/reviewlog.html:4
-#: src/olympia/editors/templates/editors/reviewlog.html:27
+#: src/olympia/editors/templates/editors/base.html:80 src/olympia/editors/templates/editors/reviewlog.html:4 src/olympia/editors/templates/editors/reviewlog.html:27
 msgid "Add-on Review Log"
 msgstr "Registo da revisão do extra"
 
-#: src/olympia/editors/templates/editors/base.html:80
-#: src/olympia/editors/templates/editors/eventlog.html:4
-#: src/olympia/editors/templates/editors/eventlog.html:8
+#: src/olympia/editors/templates/editors/base.html:82 src/olympia/editors/templates/editors/eventlog.html:4 src/olympia/editors/templates/editors/eventlog.html:8
 #: src/olympia/editors/templates/editors/eventlog_detail.html:4
 msgid "Moderated Review Log"
 msgstr "Registo da moderação da revisão "
 
-#: src/olympia/editors/templates/editors/base.html:82
-#: src/olympia/editors/templates/editors/beta_signed_log.html:4
-#: src/olympia/editors/templates/editors/beta_signed_log.html:8
+#: src/olympia/editors/templates/editors/base.html:84 src/olympia/editors/templates/editors/beta_signed_log.html:4 src/olympia/editors/templates/editors/beta_signed_log.html:8
 msgid "Signed Beta Files Log"
 msgstr "Registo de ficheiros beta assinados"
 
-#: src/olympia/editors/templates/editors/base.html:87
-#: src/olympia/editors/templates/editors/includes/daily-message.html:4
+#: src/olympia/editors/templates/editors/base.html:89 src/olympia/editors/templates/editors/includes/daily-message.html:4
 msgid "Announcement"
 msgstr "Anúncio"
 
 #. "Filter" is a button label (verb)
-#: src/olympia/editors/templates/editors/beta_signed_log.html:17
-#: src/olympia/editors/templates/editors/eventlog.html:24
-#: src/olympia/editors/templates/editors/reviewlog.html:21
-#: src/olympia/editors/templates/editors/themes/macros.html:45
-#: src/olympia/editors/templates/editors/themes/includes/logs_filter_deleted.html:12
+#: src/olympia/editors/templates/editors/beta_signed_log.html:17 src/olympia/editors/templates/editors/eventlog.html:24 src/olympia/editors/templates/editors/reviewlog.html:21
+#: src/olympia/editors/templates/editors/themes/macros.html:45 src/olympia/editors/templates/editors/themes/includes/logs_filter_deleted.html:12
 msgid "Filter"
 msgstr "Filtro"
 
-#: src/olympia/editors/templates/editors/beta_signed_log.html:23
-#: src/olympia/editors/templates/editors/eventlog.html:30
-#: src/olympia/editors/templates/editors/reviewlog.html:34
+#: src/olympia/editors/templates/editors/beta_signed_log.html:23 src/olympia/editors/templates/editors/eventlog.html:30 src/olympia/editors/templates/editors/reviewlog.html:34
 #: src/olympia/editors/templates/editors/themes/logs.html:16
 msgid "Date"
 msgstr "Data"
 
-#: src/olympia/editors/templates/editors/beta_signed_log.html:24
-#: src/olympia/editors/templates/editors/eventlog.html:31
-#: src/olympia/editors/templates/editors/reviewlog.html:35
+#: src/olympia/editors/templates/editors/beta_signed_log.html:24 src/olympia/editors/templates/editors/eventlog.html:31 src/olympia/editors/templates/editors/reviewlog.html:35
 msgid "Event"
 msgstr "Evento"
 
-#: src/olympia/editors/templates/editors/beta_signed_log.html:37
-#: src/olympia/editors/templates/editors/eventlog.html:44
-#: src/olympia/editors/templates/editors/home.html:180
+#: src/olympia/editors/templates/editors/beta_signed_log.html:37 src/olympia/editors/templates/editors/eventlog.html:44 src/olympia/editors/templates/editors/home.html:180
 msgid "More details."
 msgstr "Mais detalhes"
 
-#: src/olympia/editors/templates/editors/beta_signed_log.html:46
-#: src/olympia/editors/templates/editors/eventlog.html:53
+#: src/olympia/editors/templates/editors/beta_signed_log.html:46 src/olympia/editors/templates/editors/eventlog.html:53
 msgid "No events found for this period."
 msgstr "Sem eventos encontrados para este período."
 
@@ -10314,20 +8049,17 @@ msgid_plural "Preliminary Reviews ({num})"
 msgstr[0] "Revisão preliminar ({num})"
 msgstr[1] "Revisões preliminares ({num})"
 
-#: src/olympia/editors/templates/editors/home.html:36
-#: src/olympia/editors/templates/editors/home.html:86
+#: src/olympia/editors/templates/editors/home.html:36 src/olympia/editors/templates/editors/home.html:86
 msgid "Current waiting times:"
 msgstr "Tempos de espera atuais:"
 
-#: src/olympia/editors/templates/editors/home.html:44
-#: src/olympia/editors/templates/editors/home.html:94
+#: src/olympia/editors/templates/editors/home.html:44 src/olympia/editors/templates/editors/home.html:94
 msgid "{0} add-on"
 msgid_plural "{0} add-ons"
 msgstr[0] "{0} extra"
 msgstr[1] "{0} extras"
 
-#: src/olympia/editors/templates/editors/home.html:45
-#: src/olympia/editors/templates/editors/home.html:95
+#: src/olympia/editors/templates/editors/home.html:45 src/olympia/editors/templates/editors/home.html:95
 #, python-format
 msgid "{0}%%"
 msgstr "{0}%%"
@@ -10350,14 +8082,11 @@ msgid_plural "Unlisted Preliminary Reviews ({num})"
 msgstr[0] "Análise preliminar não-listada ({num})"
 msgstr[1] "Análises preliminares não-listadas ({num})"
 
-#: src/olympia/editors/templates/editors/home.html:109
-#: src/olympia/editors/templates/editors/performance.html:37
-#: src/olympia/editors/templates/editors/themes/home.html:54
+#: src/olympia/editors/templates/editors/home.html:109 src/olympia/editors/templates/editors/performance.html:37 src/olympia/editors/templates/editors/themes/home.html:54
 msgid "Total Reviews"
 msgstr "Total de revisões"
 
-#: src/olympia/editors/templates/editors/home.html:110
-#: src/olympia/editors/templates/editors/themes/home.html:55
+#: src/olympia/editors/templates/editors/home.html:110 src/olympia/editors/templates/editors/themes/home.html:55
 msgid "Reviews This Month"
 msgstr "Revisões deste mês"
 
@@ -10365,8 +8094,7 @@ msgstr "Revisões deste mês"
 msgid "New Editors"
 msgstr "Novos editores"
 
-#: src/olympia/editors/templates/editors/home.html:126
-#: src/olympia/editors/templates/editors/home.html:141
+#: src/olympia/editors/templates/editors/home.html:126 src/olympia/editors/templates/editors/home.html:141
 msgid "You're #{0} with {1} reviews"
 msgstr "Você está na posição #{0} com {1} revisões"
 
@@ -10377,13 +8105,11 @@ msgid_plural "Moderated Reviews ({num})"
 msgstr[0] "Revisão moderada ({num})"
 msgstr[1] "Revisões moderadas ({num})"
 
-#: src/olympia/editors/templates/editors/leaderboard.html:3
-#: src/olympia/editors/templates/editors/includes/reviewers_score_bar.html:56
+#: src/olympia/editors/templates/editors/leaderboard.html:3 src/olympia/editors/templates/editors/includes/reviewers_score_bar.html:56
 msgid "Reviewer Leaderboard"
 msgstr "Tabela de classificações dos revisores"
 
-#: src/olympia/editors/templates/editors/leaderboard.html:18
-#: src/olympia/editors/templates/editors/performance.html:65
+#: src/olympia/editors/templates/editors/leaderboard.html:18 src/olympia/editors/templates/editors/performance.html:65
 msgid "No review points awarded yet."
 msgstr "Nenhum ponto recebido ainda."
 
@@ -10403,8 +8129,7 @@ msgstr "Mensagem do dia"
 msgid "Update message of the day"
 msgstr "Atualizar mensagem do dia"
 
-#: src/olympia/editors/templates/editors/motd.html:15
-#: src/olympia/editors/templates/editors/review.html:224
+#: src/olympia/editors/templates/editors/motd.html:15 src/olympia/editors/templates/editors/review.html:224
 msgid "Save"
 msgstr "Guardar"
 
@@ -10473,51 +8198,45 @@ msgstr "Pesquisa avançada"
 msgid "clear search"
 msgstr "limpar pesquisa"
 
-#: src/olympia/editors/templates/editors/queue.html:72
-#: src/olympia/editors/templates/editors/queue.html:122
+#: src/olympia/editors/templates/editors/queue.html:78 src/olympia/editors/templates/editors/queue.html:128
 msgid "Process Reviews"
 msgstr "Processar revisões"
 
-#: src/olympia/editors/templates/editors/queue.html:80
+#: src/olympia/editors/templates/editors/queue.html:86
 msgid "Moderation actions:"
 msgstr "Ações de moderação:"
 
-#: src/olympia/editors/templates/editors/queue.html:90
+#: src/olympia/editors/templates/editors/queue.html:96
 #, python-format
 msgid "by %(user)s on %(date)s %(stars)s (%(locale)s)"
 msgstr "por %(user)s em %(date)s %(stars)s (%(locale)s)"
 
-#: src/olympia/editors/templates/editors/queue.html:106
+#: src/olympia/editors/templates/editors/queue.html:112
 #, python-format
-msgid ""
-"<strong>%(reason)s</strong> <span class=\"light\">Flagged by %(user)s on "
-"%(date)s</span>"
-msgstr ""
-"<strong>%(reason)s</strong> <span class=\"light\">Etiquetado por %(user)s em"
-" %(date)s</span>"
+msgid "<strong>%(reason)s</strong> <span class=\"light\">Flagged by %(user)s on %(date)s</span>"
+msgstr "<strong>%(reason)s</strong> <span class=\"light\">Etiquetado por %(user)s em %(date)s</span>"
 
-#: src/olympia/editors/templates/editors/queue.html:119
-msgid "All reviews have been moderated.  Good work!"
+#: src/olympia/editors/templates/editors/queue.html:125
+msgid "All reviews have been moderated. Good work!"
 msgstr "Todas as revisões foram moderadas.  Bom trabalho!"
 
-#: src/olympia/editors/templates/editors/queue.html:161
+#: src/olympia/editors/templates/editors/queue.html:167
 msgid "Version Notes / Notes for Reviewer"
 msgstr "Notas da versão / Notas para o revisor"
 
-#: src/olympia/editors/templates/editors/queue.html:169
+#: src/olympia/editors/templates/editors/queue.html:175
 msgid "There are currently no add-ons of this type to review."
 msgstr "De momento não existem extras deste tipo para rever"
 
-#: src/olympia/editors/templates/editors/queue.html:181
-#: src/olympia/editors/templates/editors/themes/queue_list.html:85
+#: src/olympia/editors/templates/editors/queue.html:187 src/olympia/editors/templates/editors/themes/queue_list.html:85
 msgid "Helpful Links:"
 msgstr "Ligações de ajuda:"
 
-#: src/olympia/editors/templates/editors/queue.html:182
+#: src/olympia/editors/templates/editors/queue.html:188
 msgid "Add-on Policy"
 msgstr "Política do extra"
 
-#: src/olympia/editors/templates/editors/queue.html:184
+#: src/olympia/editors/templates/editors/queue.html:190
 msgid "Editors' Guide"
 msgstr "Guia do editor"
 
@@ -10530,19 +8249,14 @@ msgstr "Revisão {0}"
 msgid "Add-on user change history"
 msgstr "Histórico de alterações do utilizador para o extra"
 
-#: src/olympia/editors/templates/editors/review.html:52
-#: src/olympia/editors/templates/editors/review.html:266
+#: src/olympia/editors/templates/editors/review.html:52 src/olympia/editors/templates/editors/review.html:266
 msgid "Add-on History"
 msgstr "Histórico do extra"
 
 #: src/olympia/editors/templates/editors/review.html:64
 #, python-format
-msgid ""
-"Version %(version)s &middot; %(created)s <span class=\"light\">&middot; "
-"%(version_status)s</span>"
-msgstr ""
-"Versão %(version)s &middot; %(created)s <span class=\"light\">&middot; "
-"%(version_status)s</span>"
+msgid "Version %(version)s &middot; %(created)s <span class=\"light\">&middot; %(version_status)s</span>"
+msgstr "Versão %(version)s &middot; %(created)s <span class=\"light\">&middot; %(version_status)s</span>"
 
 #: src/olympia/editors/templates/editors/review.html:73
 msgid "Compatibility:"
@@ -10565,19 +8279,14 @@ msgid "This version has not been reviewed."
 msgstr "Esta versão ainda não foi revista."
 
 #: src/olympia/editors/templates/editors/review.html:154
-msgid ""
-"You can still submit this form, however only do so if you know it won't "
-"conflict."
-msgstr ""
-"Pode, ainda assim, submeter este formulário, no entanto, faça-o apenas se "
-"souber que não entra em conflito."
+msgid "You can still submit this form, however only do so if you know it won't conflict."
+msgstr "Pode, ainda assim, submeter este formulário, no entanto, faça-o apenas se souber que não entra em conflito."
 
 #: src/olympia/editors/templates/editors/review.html:161
 msgid "Insert canned response..."
 msgstr "Inserir modelo de resposta ..."
 
-#: src/olympia/editors/templates/editors/review.html:167
-#: src/olympia/files/templates/files/viewer.html:54
+#: src/olympia/editors/templates/editors/review.html:167 src/olympia/files/templates/files/viewer.html:54
 msgid "Files:"
 msgstr "Ficheiros:"
 
@@ -10586,17 +8295,11 @@ msgid "Tested on:"
 msgstr "Testado em:"
 
 #: src/olympia/editors/templates/editors/review.html:220
-msgid ""
-"<strong>Warning!</strong> Another user was viewing this page before you."
-msgstr ""
-"<strong>Aviso!</strong> Outro utilizador estava a visualizar esta página "
-"antes de si."
+msgid "<strong>Warning!</strong> Another user was viewing this page before you."
+msgstr "<strong>Aviso!</strong> Outro utilizador estava a visualizar esta página antes de si."
 
 #: src/olympia/editors/templates/editors/review.html:237
-msgid ""
-"The whiteboard is the place to exchange information relevant to\n"
-"               this addon (whatever the version), between the developer and the\n"
-"               editor. This is visible and editable by both."
+msgid "The whiteboard is the place to exchange information relevant to this addon (whatever the version), between the developer and the editor. This is visible and editable by both."
 msgstr ""
 "O quadro branco é o local para trocar informação relevante a\n"
 "               este extra (qualquer que seja a versão), entre o programador e o\n"
@@ -10606,8 +8309,7 @@ msgstr ""
 msgid "Update the whiteboard"
 msgstr "Atualizar o quadro branco"
 
-#: src/olympia/editors/templates/editors/review.html:257
-#: src/olympia/editors/templates/editors/review.html:258
+#: src/olympia/editors/templates/editors/review.html:257 src/olympia/editors/templates/editors/review.html:258
 msgid "(admin)"
 msgstr "(admin)"
 
@@ -10635,18 +8337,15 @@ msgstr "Editor"
 msgid "Add-on has been deleted."
 msgstr "O extra foi eliminado."
 
-#: src/olympia/editors/templates/editors/reviewlog.html:59
-#: src/olympia/editors/templates/editors/themes/logs.html:36
+#: src/olympia/editors/templates/editors/reviewlog.html:59 src/olympia/editors/templates/editors/themes/logs.html:36
 msgid "Show Comments"
 msgstr "Mostrar comentários"
 
-#: src/olympia/editors/templates/editors/reviewlog.html:60
-#: src/olympia/editors/templates/editors/themes/logs.html:37
+#: src/olympia/editors/templates/editors/reviewlog.html:60 src/olympia/editors/templates/editors/themes/logs.html:37
 msgid "Hide Comments"
 msgstr "Ocultar comentários"
 
-#: src/olympia/editors/templates/editors/reviewlog.html:72
-#: src/olympia/editors/templates/editors/themes/logs.html:54
+#: src/olympia/editors/templates/editors/reviewlog.html:72 src/olympia/editors/templates/editors/themes/logs.html:54
 msgid "No reviews found for this period."
 msgstr "Nenhuma revisão encontrada para este período."
 
@@ -10704,11 +8403,8 @@ msgstr "Desde sempre"
 msgid "You have <span>{0}</span> points."
 msgstr "Você possui <span>{0}</span> pontos."
 
-#: src/olympia/editors/templates/editors/includes/search_results_themes.html:6
-#: src/olympia/editors/templates/editors/themes/history_table.html:7
-#: src/olympia/editors/templates/editors/themes/logs.html:19
-#: src/olympia/editors/templates/editors/themes/queue_list.html:49
-#: src/olympia/editors/templates/editors/themes/single.html:26
+#: src/olympia/editors/templates/editors/includes/search_results_themes.html:6 src/olympia/editors/templates/editors/themes/history_table.html:7
+#: src/olympia/editors/templates/editors/themes/logs.html:19 src/olympia/editors/templates/editors/themes/queue_list.html:49 src/olympia/editors/templates/editors/themes/single.html:26
 #: src/olympia/editors/templates/editors/themes/themes.html:45
 msgid "Reviewer"
 msgstr "Revisor"
@@ -10734,8 +8430,7 @@ msgid "Review Date"
 msgstr "Data da Revisão"
 
 # 85%
-#: src/olympia/editors/templates/editors/themes/history_table.html:9
-#: src/olympia/editors/templates/editors/themes/logs.html:18
+#: src/olympia/editors/templates/editors/themes/history_table.html:9 src/olympia/editors/templates/editors/themes/logs.html:18
 msgid "Action"
 msgstr "Ação"
 
@@ -10882,7 +8577,7 @@ msgstr "Fazer uma pergunta ao artista"
 msgid "Describe your reason for flagging"
 msgstr "Descreva o motivo da sua marcação"
 
-#: src/olympia/files/forms.py:88
+#: src/olympia/files/forms.py:90
 msgid "Cannot diff a version against itself"
 msgstr "Não é possível comparar uma versão consigo própria"
 
@@ -10900,12 +8595,8 @@ msgid "Problems decoding {0}."
 msgstr "Problemas ao decodificar {0}."
 
 #: src/olympia/files/helpers.py:186
-msgid ""
-"This file is not viewable online. Please download the file to view the "
-"contents."
-msgstr ""
-"Este ficheiro não é visível online. Por favor, descarregue o ficheiro para "
-"ver o conteúdo."
+msgid "This file is not viewable online. Please download the file to view the contents."
+msgstr "Este ficheiro não é visível online. Por favor, descarregue o ficheiro para ver o conteúdo."
 
 #: src/olympia/files/helpers.py:194
 msgid "This file is a directory."
@@ -10921,55 +8612,51 @@ msgstr "Houve um erro ao aceder ao ficheiro %s. %s."
 msgid "There was an error accessing file %s."
 msgstr "Houve um erro ao aceder ao ficheiro %s."
 
-#: src/olympia/files/utils.py:343
+#: src/olympia/files/utils.py:340
 msgid "Could not parse uploaded file."
 msgstr "Não foi possível analisar o ficheiro carregado."
 
-#: src/olympia/files/utils.py:380
+#: src/olympia/files/utils.py:377
 msgid "Invalid file name in archive: {0}"
 msgstr "Nome de ficheiro inválido no arquivo: {0}"
 
-#: src/olympia/files/utils.py:388
+#: src/olympia/files/utils.py:385
 msgid "File exceeding size limit in archive: {0}"
 msgstr "Ficheiro que excede o limite de tamanho no arquivo: {0}"
 
-#: src/olympia/files/utils.py:439
+#: src/olympia/files/utils.py:436
 msgid "Invalid archive."
 msgstr "Arquivo inválido."
 
-#: src/olympia/files/utils.py:529 src/olympia/files/utils.py:532
+#: src/olympia/files/utils.py:526 src/olympia/files/utils.py:529
 msgid "Could not parse the manifest file."
 msgstr "Não foi possível analisar o ficheiro manifest."
 
-#: src/olympia/files/utils.py:551
+#: src/olympia/files/utils.py:548
 msgid "Could not find an add-on ID."
 msgstr "Não foi possível encontrar um ID do extra."
 
-#: src/olympia/files/utils.py:554
+#: src/olympia/files/utils.py:551
 msgid "Add-on ID must be 64 characters or less."
 msgstr "O ID do extra deve ter no 64 caracteres ou menos."
 
-#: src/olympia/files/utils.py:556
+#: src/olympia/files/utils.py:553
 msgid "Add-on ID doesn't match add-on."
 msgstr "O ID do extra não coincide com o extra."
 
-#: src/olympia/files/utils.py:564
+#: src/olympia/files/utils.py:561
 msgid "Duplicate add-on ID found."
 msgstr "Foi encontrado um ID de extra duplicado."
 
-#: src/olympia/files/utils.py:567
+#: src/olympia/files/utils.py:564
 msgid "Version numbers should have fewer than 32 characters."
 msgstr "Os números de versão deve ter menos de 32 caracteres."
 
-#: src/olympia/files/utils.py:570
-msgid ""
-"Version numbers should only contain letters, numbers, and these punctuation "
-"characters: +*.-_."
-msgstr ""
-"Os números de versão deve conter apenas letras, números e estes caracteres "
-"de pontuação: +*.-_."
+#: src/olympia/files/utils.py:567
+msgid "Version numbers should only contain letters, numbers, and these punctuation characters: +*.-_."
+msgstr "Os números de versão deve conter apenas letras, números e estes caracteres de pontuação: +*.-_."
 
-#: src/olympia/files/utils.py:587
+#: src/olympia/files/utils.py:584
 msgid "<em:type> doesn't match add-on"
 msgstr "<em:type> não corresponde ao extra"
 
@@ -10987,12 +8674,8 @@ msgstr "Descarregar {0}"
 
 #: src/olympia/files/templates/files/file.html:4
 #, python-format
-msgid ""
-"Version: %(version)s &bull; Size: %(size)s &bull; MD5 hash: %(md5)s &bull; "
-"Mimetype: %(mimetype)s"
-msgstr ""
-"Versão: %(version)s &bull; Tamanho: %(size)s &bull; MD5 hash: %(md5)s &bull;"
-" Mimetype: %(mimetype)s"
+msgid "Version: %(version)s &bull; Size: %(size)s &bull; MD5 hash: %(md5)s &bull; Mimetype: %(mimetype)s"
+msgstr "Versão: %(version)s &bull; Tamanho: %(size)s &bull; MD5 hash: %(md5)s &bull; Mimetype: %(mimetype)s"
 
 #: src/olympia/files/templates/files/viewer.html:4
 msgid "File Compare :: Editor tools"
@@ -11030,48 +8713,39 @@ msgstr "Versão do Add-on SDK:"
 msgid "Tab stops:"
 msgstr "O separador pára:"
 
-#: src/olympia/files/templates/files/viewer.html:79
-#: src/olympia/files/templates/files/viewer.html:80
+#: src/olympia/files/templates/files/viewer.html:79 src/olympia/files/templates/files/viewer.html:80
 msgid "Up file"
 msgstr "Subir o ficheiro"
 
-#: src/olympia/files/templates/files/viewer.html:84
-#: src/olympia/files/templates/files/viewer.html:85
+#: src/olympia/files/templates/files/viewer.html:84 src/olympia/files/templates/files/viewer.html:85
 msgid "Down file"
 msgstr "Baixar o ficheiro"
 
-#: src/olympia/files/templates/files/viewer.html:90
-#: src/olympia/files/templates/files/viewer.html:91
+#: src/olympia/files/templates/files/viewer.html:90 src/olympia/files/templates/files/viewer.html:91
 msgid "Previous diff"
 msgstr "Diff anterior"
 
-#: src/olympia/files/templates/files/viewer.html:93
-#: src/olympia/files/templates/files/viewer.html:94
+#: src/olympia/files/templates/files/viewer.html:93 src/olympia/files/templates/files/viewer.html:94
 msgid "Previous note"
 msgstr "Nota anterior"
 
-#: src/olympia/files/templates/files/viewer.html:100
-#: src/olympia/files/templates/files/viewer.html:101
+#: src/olympia/files/templates/files/viewer.html:100 src/olympia/files/templates/files/viewer.html:101
 msgid "Next diff"
 msgstr "Próximo diff"
 
-#: src/olympia/files/templates/files/viewer.html:103
-#: src/olympia/files/templates/files/viewer.html:104
+#: src/olympia/files/templates/files/viewer.html:103 src/olympia/files/templates/files/viewer.html:104
 msgid "Next note"
 msgstr "Próxima nota"
 
-#: src/olympia/files/templates/files/viewer.html:109
-#: src/olympia/files/templates/files/viewer.html:110
+#: src/olympia/files/templates/files/viewer.html:109 src/olympia/files/templates/files/viewer.html:110
 msgid "Expand all"
 msgstr "Expandir tudo"
 
-#: src/olympia/files/templates/files/viewer.html:114
-#: src/olympia/files/templates/files/viewer.html:115
+#: src/olympia/files/templates/files/viewer.html:114 src/olympia/files/templates/files/viewer.html:115
 msgid "Hide or unhide tree"
 msgstr "Mostrar ou ocultar árvore"
 
-#: src/olympia/files/templates/files/viewer.html:119
-#: src/olympia/files/templates/files/viewer.html:120
+#: src/olympia/files/templates/files/viewer.html:119 src/olympia/files/templates/files/viewer.html:120
 msgid "Wrap or unwrap text"
 msgstr "Mostrar ou não mostrar o texto"
 
@@ -11082,6 +8756,10 @@ msgstr "Não há ficheiros no arquivo carregado."
 #: src/olympia/files/templates/files/viewer.html:134
 msgid "Fetching file."
 msgstr "A procurar ficheiro."
+
+#: src/olympia/legacy_api/views.py:255
+msgid "Not implemented yet."
+msgstr "Ainda não implementado."
 
 #: src/olympia/lib/constants.py:6
 msgid "United Arab Emirates Dirham"
@@ -11739,12 +9417,7 @@ msgstr "Kwacha da Zâmbia"
 msgid "Zimbabwe Dollar"
 msgstr "Dólar do Zimbabué"
 
-#: src/olympia/lib/video/ffmpeg.py:112 src/olympia/lib/video/totem.py:81
-msgid "Videos must be in WebM."
-msgstr "Os vídeos precisam de ser em WebM."
-
-#: src/olympia/pages/templates/pages/about.lhtml:3
-#: src/olympia/pages/templates/pages/about.lhtml:10
+#: src/olympia/pages/templates/pages/about.lhtml:3 src/olympia/pages/templates/pages/about.lhtml:10
 msgid "About Mozilla Add-ons"
 msgstr "Sobre os Extras da Mozilla"
 
@@ -11754,17 +9427,11 @@ msgstr "O que é este website?"
 
 #: src/olympia/pages/templates/pages/about.lhtml:13
 msgid ""
-"addons.mozilla.org, commonly known as \"AMO\", is Mozilla's official site "
-"for add-ons to Mozilla software, such as Firefox, Thunderbird, and "
-"SeaMonkey. Add-ons let you add new features and change the way your browser "
-"or application works.  Take a look around and explore the thousands of ways "
-"to customize the way you do things online."
+"addons.mozilla.org, commonly known as \"AMO\", is Mozilla's official site for add-ons to Mozilla software, such as Firefox, Thunderbird, and SeaMonkey. Add-ons let you add new features and change "
+"the way your browser or application works. Take a look around and explore the thousands of ways to customize the way you do things online."
 msgstr ""
-"addons.mozilla.org, vulgarmente conhecida como \"AMO\", é o site oficial "
-"para extras para o software da Mozilla, tal como o Firefox, Thunderbird e "
-"SeaMonkey. Os extras permitem adicionar novas funcionalidade e alterar a "
-"forma como o seu navegador ou aplicação funcionam. Dê uma vista de olhos e "
-"explore milhares de formas de personalizar o modo como faz as coisas online."
+"addons.mozilla.org, vulgarmente conhecida como \"AMO\", é o site oficial para extras para o software da Mozilla, tal como o Firefox, Thunderbird e SeaMonkey. Os extras permitem adicionar novas "
+"funcionalidade e alterar a forma como o seu navegador ou aplicação funcionam. Dê uma vista de olhos e explore milhares de formas de personalizar o modo como faz as coisas online."
 
 #: src/olympia/pages/templates/pages/about.lhtml:19
 msgid "Who creates these add-ons?"
@@ -11772,104 +9439,66 @@ msgstr "Quem cria estes extras?"
 
 #: src/olympia/pages/templates/pages/about.lhtml:20
 msgid ""
-"The add-ons listed here have been created by thousands of developers from "
-"our community, ranging from individual hobbyists to large corporations. All "
-"publicly listed add-ons are reviewed by a team of editors before being "
-"released. Add-ons marked as Experimental have not been reviewed and should "
-"only be installed with caution."
+"The add-ons listed here have been created by thousands of developers from our community, ranging from individual hobbyists to large corporations. All publicly listed add-ons are reviewed by a team "
+"of editors before being released. Add-ons marked as Experimental have not been reviewed and should only be installed with caution."
 msgstr ""
-"Os extras listados aqui foram criados por milhares de programadores da nossa"
-" comunidade, que vão desde indivíduos a grandes empresas. Todos os extras "
-"publicamente listados são revistos por uma equipa de editores antes de serem"
-" lançados. Extras marcados como experimentais não foram revistos e devem ser"
-" instalados com precaução."
+"Os extras listados aqui foram criados por milhares de programadores da nossa comunidade, que vão desde indivíduos a grandes empresas. Todos os extras publicamente listados são revistos por uma "
+"equipa de editores antes de serem lançados. Extras marcados como experimentais não foram revistos e devem ser instalados com precaução."
 
 #: src/olympia/pages/templates/pages/about.lhtml:26
 msgid "How do I keep up with what's happening at AMO?"
 msgstr "Como posso acompanhar o que se está a passar com o AMO?"
 
 #: src/olympia/pages/templates/pages/about.lhtml:27
-msgid ""
-"There are several ways to find out the latest news from the world of add-"
-"ons:"
-msgstr ""
-"Existem várias formas de saber as últimas notícias do mundo dos extras:"
+msgid "There are several ways to find out the latest news from the world of add-ons:"
+msgstr "Existem várias formas de saber as últimas notícias do mundo dos extras:"
 
 #: src/olympia/pages/templates/pages/about.lhtml:29
 #, python-format
-msgid ""
-"Our <a href=\"%(url)s\">Add-ons Blog</a> is regularly updated with "
-"information for both add-on enthusiasts and developers."
-msgstr ""
-"O nosso <a href=\"%(url)s\">blogue de extras</a> é atualizado regularmente "
-"com informação para entusiastas e programadores de extras."
+msgid "Our <a href=\"%(url)s\">Add-ons Blog</a> is regularly updated with information for both add-on enthusiasts and developers."
+msgstr "O nosso <a href=\"%(url)s\">blogue de extras</a> é atualizado regularmente com informação para entusiastas e programadores de extras."
 
 #: src/olympia/pages/templates/pages/about.lhtml:32
 #, python-format
-msgid ""
-"We often post news, tips, and tricks to our Twitter account, <a "
-"href=\"%(url)s\">mozamo</a>"
-msgstr ""
-"Muitas vezes publicamos notícias, truques e dicas na nossa conta <a "
-"href=\"%(url)s\">mozamo</a> no Twitter."
+msgid "We often post news, tips, and tricks to our Twitter account, <a href=\"%(url)s\">mozamo</a>"
+msgstr "Muitas vezes publicamos notícias, truques e dicas na nossa conta <a href=\"%(url)s\">mozamo</a> no Twitter."
 
 #: src/olympia/pages/templates/pages/about.lhtml:34
 #, python-format
-msgid ""
-"Our <a href=\"%(url)s\">forums</a> are a good place to interact with the "
-"add-ons community and discuss upcoming changes to AMO."
-msgstr ""
-"Os nossos <a href=\"%(url)s\">fóruns</a> são um ótimo sítio para interagir "
-"com a comunidade de extras e discutir as futuras alterações ao AMO."
+msgid "Our <a href=\"%(url)s\">forums</a> are a good place to interact with the add-ons community and discuss upcoming changes to AMO."
+msgstr "Os nossos <a href=\"%(url)s\">fóruns</a> são um ótimo sítio para interagir com a comunidade de extras e discutir as futuras alterações ao AMO."
 
 #: src/olympia/pages/templates/pages/about.lhtml:39
 msgid "This sounds great! How can I get involved?"
 msgstr "Isto parece ótimo! Como posso envolver-me?"
 
 #: src/olympia/pages/templates/pages/about.lhtml:40
-msgid ""
-"There are plenty of ways to get involved. If you're on the technical side:"
+msgid "There are plenty of ways to get involved. If you're on the technical side:"
 msgstr "Existem várias formas de se envolver. Se estiver no lado técnico:"
 
 #: src/olympia/pages/templates/pages/about.lhtml:42
 #, python-format
-msgid ""
-"<a href=\"%(url)s\">Make your own add-on</a>. We provide free hosting and "
-"update services and can help you reach a large audience of users."
-msgstr ""
-"<a href=\"%(url)s\">Faça o seu próprio extra</a>. Nós fornecemos serviços de"
-" alojamento e atualização gratuitos e podemos ajudá-lo a atingir uma maior "
-"audiência de utilizadores."
+msgid "<a href=\"%(url)s\">Make your own add-on</a>. We provide free hosting and update services and can help you reach a large audience of users."
+msgstr "<a href=\"%(url)s\">Faça o seu próprio extra</a>. Nós fornecemos serviços de alojamento e atualização gratuitos e podemos ajudá-lo a atingir uma maior audiência de utilizadores."
 
 #: src/olympia/pages/templates/pages/about.lhtml:45
 #, python-format
-msgid ""
-"If you have add-on development experience, <a href=\"%(url)s\"> become an "
-"editor</a>! Our editors are add-on fans with a technical background who "
-"review add-ons for code quality and stability."
+msgid "If you have add-on development experience, <a href=\"%(url)s\"> become an editor</a>! Our editors are add-on fans with a technical background who review add-ons for code quality and stability."
 msgstr ""
-"Se tiver experiência no desenvolvimento de extras, <a href=\"%(url)s"
-"\">torne-se num editor</a>! Os nossos editores são fãs de extras com "
-"experiência técnica que revêm a qualidade e estabilidade de extras."
+"Se tiver experiência no desenvolvimento de extras, <a href=\"%(url)s\">torne-se num editor</a>! Os nossos editores são fãs de extras com experiência técnica que revêm a qualidade e estabilidade de "
+"extras."
 
 #: src/olympia/pages/templates/pages/about.lhtml:49
 #, python-format
 msgid ""
-"Help improve this website. It's open source, and you can file bugs and "
-"submit patches. <a href=\"%(url)s\"> GitHub</a> contains all of our current "
-"bugs, legacy bugs can still be found in Bugzilla."
+"Help improve this website. It's open source, and you can file bugs and submit patches. <a href=\"%(url)s\"> GitHub</a> contains all of our current bugs, legacy bugs can still be found in Bugzilla."
 msgstr ""
-"Ajude-nos a melhorar este site. É código-aberto e pode reportar bugs ou "
-"enviar correções. O <a href=\"%(url)s\">GitHub</a> contém todos os nossos "
-"bugs atuais; bugs mais antigos podem ainda ser encontrados no Bugzilla."
+"Ajude-nos a melhorar este site. É código-aberto e pode reportar bugs ou enviar correções. O <a href=\"%(url)s\">GitHub</a> contém todos os nossos bugs atuais; bugs mais antigos podem ainda ser "
+"encontrados no Bugzilla."
 
 #: src/olympia/pages/templates/pages/about.lhtml:55
-msgid ""
-"If you're interested in add-ons but not quite as technical, there are still "
-"ways to help:"
-msgstr ""
-"Se estiver interessado em extras mas não de uma forma tão técnica, existem "
-"outras formas de ajudar:"
+msgid "If you're interested in add-ons but not quite as technical, there are still ways to help:"
+msgstr "Se estiver interessado em extras mas não de uma forma tão técnica, existem outras formas de ajudar:"
 
 #: src/olympia/pages/templates/pages/about.lhtml:58
 msgid "Tell your friends! Let people know which add-ons you use."
@@ -11881,12 +9510,8 @@ msgid "Participate in our <a href=\"%(url)s\">forums</a>."
 msgstr "Participe nos nossos <a href=\"%(url)s\">fóruns</a>."
 
 #: src/olympia/pages/templates/pages/about.lhtml:61
-msgid ""
-"Review add-ons on the site. Add-on authors are more likely to improve their "
-"add-ons and write new ones when they know people appreciate their work."
-msgstr ""
-"Reveja extras no site. Os autores de extras tenderão a melhorar os seus "
-"extras e escrever novos quando sabem que as pessoas apreciam o seu trabalho."
+msgid "Review add-ons on the site. Add-on authors are more likely to improve their add-ons and write new ones when they know people appreciate their work."
+msgstr "Reveja extras no site. Os autores de extras tenderão a melhorar os seus extras e escrever novos quando sabem que as pessoas apreciam o seu trabalho."
 
 #: src/olympia/pages/templates/pages/about.lhtml:66
 msgid "I have a question"
@@ -11895,23 +9520,16 @@ msgstr "Eu tenho uma questão"
 #: src/olympia/pages/templates/pages/about.lhtml:67
 #, python-format
 msgid ""
-"A good place to start is our <a href=\"%(faq_url)s\"><abbr "
-"title=\"Frequently Asked Questions\">FAQ</abbr></a>. If you don't find an "
-"answer there, you can <a href=\"%(forum_url)s\"> ask on our forums</a>."
+"A good place to start is our <a href=\"%(faq_url)s\"><abbr title=\"Frequently Asked Questions\">FAQ</abbr></a>. If you don't find an answer there, you can <a href=\"%(forum_url)s\"> ask on our "
+"forums</a>."
 msgstr ""
-"Um bom sítio para começar é na nossa página de <a "
-"href=\"%(faq_url)s\">perguntas frequentes (<abbr title=\"Frequently Asked "
-"Questions\" lang=\"en\">FAQ</abbr>)</a>. Se não encontrar uma resposta aqui "
-"pode <a href=\"%(forum_url)s\">perguntar nos nossos fóruns</a>."
+"Um bom sítio para começar é na nossa página de <a href=\"%(faq_url)s\">perguntas frequentes (<abbr title=\"Frequently Asked Questions\" lang=\"en\">FAQ</abbr>)</a>. Se não encontrar uma resposta "
+"aqui pode <a href=\"%(forum_url)s\">perguntar nos nossos fóruns</a>."
 
 #: src/olympia/pages/templates/pages/about.lhtml:72
 #, python-format
-msgid ""
-"If you really need to contact someone from the Mozilla team, please see our "
-"<a href=\"%(url)s\"> contact information</a> page."
-msgstr ""
-"Se precisar mesmo de contactar alguém na equipa da Mozilla, por favor visite"
-" a nossa página de <a href=\"%(url)s\">informações de contacto</a>"
+msgid "If you really need to contact someone from the Mozilla team, please see our <a href=\"%(url)s\"> contact information</a> page."
+msgstr "Se precisar mesmo de contactar alguém na equipa da Mozilla, por favor visite a nossa página de <a href=\"%(url)s\">informações de contacto</a>"
 
 #: src/olympia/pages/templates/pages/about.lhtml:76
 msgid "Who works on this website?"
@@ -11920,15 +9538,11 @@ msgstr "Quem trabalha neste website?"
 #: src/olympia/pages/templates/pages/about.lhtml:77
 #, python-format
 msgid ""
-"Over the years, many people have contributed to this website, including both"
-" volunteers from the community and a dedicated AMO team. A list of "
-"significant contributors can be found on our <a href=\"%(url)s\"> Site "
-"Credits</a> page."
+"Over the years, many people have contributed to this website, including both volunteers from the community and a dedicated AMO team. A list of significant contributors can be found on our <a href="
+"\"%(url)s\"> Site Credits</a> page."
 msgstr ""
-"Ao longo dos anos, muitas pessoas contribuíram para este website, incluindo "
-"voluntários da comunidade e uma equipa dedicada do AMO. Uma lista dos "
-"colaboradores mais significativos pode ser encontrada na nossa página de <a "
-"href=\"%(url)s\">créditos do site</a>."
+"Ao longo dos anos, muitas pessoas contribuíram para este website, incluindo voluntários da comunidade e uma equipa dedicada do AMO. Uma lista dos colaboradores mais significativos pode ser "
+"encontrada na nossa página de <a href=\"%(url)s\">créditos do site</a>."
 
 # 93%
 #: src/olympia/pages/templates/pages/acr_firstrun.html:4
@@ -11940,12 +9554,8 @@ msgid "Add-on Compatibility Reporter has been installed"
 msgstr "O Extra Compatibility Reporter foi instalado"
 
 #: src/olympia/pages/templates/pages/acr_firstrun.html:28
-msgid ""
-"It’s easy to help us make sure add-ons are updated in time for the release "
-"of the next version of Firefox."
-msgstr ""
-"É fácil nos ajudar a garantir que os extras sejam atualizados a tempo quando"
-" uma nova versão do Firefox for lançada."
+msgid "It’s easy to help us make sure add-ons are updated in time for the release of the next version of Firefox."
+msgstr "É fácil nos ajudar a garantir que os extras sejam atualizados a tempo quando uma nova versão do Firefox for lançada."
 
 #: src/olympia/pages/templates/pages/acr_firstrun.html:35
 msgid "Here’s how to get started reporting add-on compatibility:"
@@ -11953,54 +9563,37 @@ msgstr "Aqui está como nos ajudar a relatar a compatibilidade dos extras:"
 
 #: src/olympia/pages/templates/pages/acr_firstrun.html:40
 msgid ""
-"As you start browsing and using your add-ons, take careful note of anything "
-"that seems different from when you last used the extension. This might be a "
-"display glitch, such as a menu item missing, or something more serious, like"
-" the add-on not working at all or showing errors."
+"As you start browsing and using your add-ons, take careful note of anything that seems different from when you last used the extension. This might be a display glitch, such as a menu item missing, "
+"or something more serious, like the add-on not working at all or showing errors."
 msgstr ""
-"Ao navegar e usar seus extras, observe cuidadosamente qualquer comportamento"
-" que pareça diferente da última vez em que você usou a extensão. Poderia ser"
-" um erro de exibição, como um item de menu faltando, ou algo mais sério, "
-"como o extra deixar de funcionar completamente ou exibindo erros."
+"Ao navegar e usar seus extras, observe cuidadosamente qualquer comportamento que pareça diferente da última vez em que você usou a extensão. Poderia ser um erro de exibição, como um item de menu "
+"faltando, ou algo mais sério, como o extra deixar de funcionar completamente ou exibindo erros."
 
 #: src/olympia/pages/templates/pages/acr_firstrun.html:49
 msgid ""
-"Once you know whether a particular add-on works properly or has problems, "
-"open the Add-ons Manager and click Compatibility next to the add-on to let "
-"Mozilla know what you found in your testing. Submitting a report will help "
-"us tell the add-on developer whether their add-on is working properly in "
-"this version or might need some fixes."
+"Once you know whether a particular add-on works properly or has problems, open the Add-ons Manager and click Compatibility next to the add-on to let Mozilla know what you found in your testing. "
+"Submitting a report will help us tell the add-on developer whether their add-on is working properly in this version or might need some fixes."
 msgstr ""
-"Assim que tiver certeza que um extra específico esteja a funcionar "
-"corretamente ou que esteja a ter algum problema, abra o Gestor de extras e "
-"clique no botão de compatibilidade junto ao extra e deixe a Mozilla saber o "
-"que você encontrou nos seus testes. Enviar o relatório irá ajudar-nos a "
-"informar o programador se o seu extra está funcionar corretamente nesta "
-"versão ou se precisa de correções."
+"Assim que tiver certeza que um extra específico esteja a funcionar corretamente ou que esteja a ter algum problema, abra o Gestor de extras e clique no botão de compatibilidade junto ao extra e "
+"deixe a Mozilla saber o que você encontrou nos seus testes. Enviar o relatório irá ajudar-nos a informar o programador se o seu extra está funcionar corretamente nesta versão ou se precisa de "
+"correções."
 
 #: src/olympia/pages/templates/pages/acr_firstrun.html:61
 #, python-format
 msgid ""
-"If you upgrade to a new version of Firefox or update your add-ons, your "
-"reports for the old versions will be hidden to allow you to test the new "
-"version. If you have any questions, please ask in <a href=\"%(url)s\">our "
-"forums</a>."
+"If you upgrade to a new version of Firefox or update your add-ons, your reports for the old versions will be hidden to allow you to test the new version. If you have any questions, please ask in <a "
+"href=\"%(url)s\">our forums</a>."
 msgstr ""
-"Se você atualizar para uma nova versão do Firefox ou atualizar o "
-"complemento, seus relatórios para as versões antigas não serão exibidos para"
-" que você possa testar a nova versão. Se você tiver dúvidas, por favor, "
-"pergunte nos <a href=\"%(url)s\">nossos fóruns</a>."
+"Se você atualizar para uma nova versão do Firefox ou atualizar o complemento, seus relatórios para as versões antigas não serão exibidos para que você possa testar a nova versão. Se você tiver "
+"dúvidas, por favor, pergunte nos <a href=\"%(url)s\">nossos fóruns</a>."
 
 #: src/olympia/pages/templates/pages/acr_firstrun.html:69
 msgid ""
-"Thousands of add-ons are made by our community every year, and your "
-"assistance with compatibility testing helps us make sure these add-ons stay "
-"useful as we strive to provide a great user experience."
+"Thousands of add-ons are made by our community every year, and your assistance with compatibility testing helps us make sure these add-ons stay useful as we strive to provide a great user "
+"experience."
 msgstr ""
-"Milhares de extras são criados pela nossa comunidade todos os anos e a sua "
-"assistência para testar a compatibilidade ajuda-nos a garantir que esses "
-"extras continuam a ser úteis, impulsionando os nossos esforços em oferecer "
-"uma excelente experiência ao utilizador."
+"Milhares de extras são criados pela nossa comunidade todos os anos e a sua assistência para testar a compatibilidade ajuda-nos a garantir que esses extras continuam a ser úteis, impulsionando os "
+"nossos esforços em oferecer uma excelente experiência ao utilizador."
 
 #: src/olympia/pages/templates/pages/acr_firstrun.html:75
 msgid "Thank you!"
@@ -12011,12 +9604,8 @@ msgid "Site Credits"
 msgstr "Créditos do sitio"
 
 #: src/olympia/pages/templates/pages/credits.html:12
-msgid ""
-"Mozilla would like to thank the following people for their contributions to "
-"the addons.mozilla.org project over the years:"
-msgstr ""
-"A mozilla gostaria de agradecer às seguintes pessoas por suas colaborações "
-"ao projeto addons.mozilla.org ao longo dos anos:"
+msgid "Mozilla would like to thank the following people for their contributions to the addons.mozilla.org project over the years:"
+msgstr "A mozilla gostaria de agradecer às seguintes pessoas por suas colaborações ao projeto addons.mozilla.org ao longo dos anos:"
 
 #: src/olympia/pages/templates/pages/credits.html:18
 msgid "Developers &amp; Administrators"
@@ -12050,52 +9639,32 @@ msgstr "Software e imagens"
 
 #: src/olympia/pages/templates/pages/credits.html:59
 msgid ""
-"Some icons used are from the <a "
-"href=\"http://www.famfamfam.com/lab/icons/silk/\">famfamfam Silk Icon "
-"Set</a>, licensed under a <a "
-"href=\"http://creativecommons.org/licenses/by/2.5/\">Creative Commons "
-"Attribution 2.5 License</a>."
+"Some icons used are from the <a href=\"http://www.famfamfam.com/lab/icons/silk/\">famfamfam Silk Icon Set</a>, licensed under a <a href=\"http://creativecommons.org/licenses/by/2.5/\">Creative "
+"Commons Attribution 2.5 License</a>."
 msgstr ""
-"Alguns ícones usados são do conjunto de ícones <a "
-"href=\"http://www.famfamfam.com/lab/icons/silk/\">famfamfam Silk</a>, "
-"licenciado sob uma licença <a "
-"href=\"http://creativecommons.org/licenses/by/2.5/deed.pt\">Creative Commons"
-" Atribuição 2.5 Genérica</a>."
+"Alguns ícones usados são do conjunto de ícones <a href=\"http://www.famfamfam.com/lab/icons/silk/\">famfamfam Silk</a>, licenciado sob uma licença <a href=\"http://creativecommons.org/licenses/"
+"by/2.5/deed.pt\">Creative Commons Atribuição 2.5 Genérica</a>."
 
 #: src/olympia/pages/templates/pages/credits.html:60
 msgid ""
-"Some icons used are from the <a href=\"http://www.fatcow.com/free-"
-"icons/\">FatCow Farm-Fresh Web Icons Set</a>, licensed under a <a "
-"href=\"http://creativecommons.org/licenses/by/3.0/us/\">Creative Commons "
-"Attribution 3.0 License</a>."
+"Some icons used are from the <a href=\"http://www.fatcow.com/free-icons/\">FatCow Farm-Fresh Web Icons Set</a>, licensed under a <a href=\"http://creativecommons.org/licenses/by/3.0/us/\">Creative "
+"Commons Attribution 3.0 License</a>."
 msgstr ""
-"Alguns ícones usados são do conjunto de ícones <a "
-"href=\"http://www.fatcow.com/free-icons/\">FatCow Farm-Fresh Web</a>, "
-"licenciado sob uma licença <a "
-"href=\"http://creativecommons.org/licenses/by/3.0/deed.pt\">Creative Commons"
-" Atribuição 3.0 Não Adaptada</a>."
+"Alguns ícones usados são do conjunto de ícones <a href=\"http://www.fatcow.com/free-icons/\">FatCow Farm-Fresh Web</a>, licenciado sob uma licença <a href=\"http://creativecommons.org/licenses/"
+"by/3.0/deed.pt\">Creative Commons Atribuição 3.0 Não Adaptada</a>."
 
 #: src/olympia/pages/templates/pages/credits.html:61
 msgid ""
-"Some pages use elements of <a "
-"href=\"http://shop.highsoft.com/highcharts.html\">Highcharts</a> (non-"
-"commercial), licensed under a <a href=\"http://creativecommons.org/licenses"
-"/by-nc/3.0/\">Creative Commons Attribution-NonCommercial 3.0 License</a>."
+"Some pages use elements of <a href=\"http://shop.highsoft.com/highcharts.html\">Highcharts</a> (non-commercial), licensed under a <a href=\"http://creativecommons.org/licenses/by-nc/3.0/\">Creative "
+"Commons Attribution-NonCommercial 3.0 License</a>."
 msgstr ""
-"Algumas páginas usam elementos do <a "
-"href=\"http://shop.highsoft.com/highcharts.html\">Highcharts</a> (não-"
-"comercial), licenciado sob uma licença <a "
-"href=\"http://creativecommons.org/licenses/by-nc/3.0/deed.pt\">Creative "
-"Commons Atribuição-NãoComercial 3.0 Não Adaptada</a>."
+"Algumas páginas usam elementos do <a href=\"http://shop.highsoft.com/highcharts.html\">Highcharts</a> (não-comercial), licenciado sob uma licença <a href=\"http://creativecommons.org/licenses/by-"
+"nc/3.0/deed.pt\">Creative Commons Atribuição-NãoComercial 3.0 Não Adaptada</a>."
 
 #: src/olympia/pages/templates/pages/credits.html:65
 #, python-format
-msgid ""
-"For information on contributing, please see our <a href=\"%(url)s\">wiki "
-"page</a>."
-msgstr ""
-"Para informações sobre colaboração, por favor, visite nossa <a "
-"href=\"%(url)s\">página wiki</a>."
+msgid "For information on contributing, please see our <a href=\"%(url)s\">wiki page</a>."
+msgstr "Para informações sobre colaboração, por favor, visite nossa <a href=\"%(url)s\">página wiki</a>."
 
 # 76%
 #: src/olympia/pages/templates/pages/dev_faq.html:4
@@ -12103,40 +9672,33 @@ msgid "Developer FAQ"
 msgstr "FAQ do programador"
 
 # 75%
-#: src/olympia/pages/templates/pages/dev_faq.html:31
-#: src/olympia/pages/templates/pages/review_guide.html:33
+#: src/olympia/pages/templates/pages/dev_faq.html:31 src/olympia/pages/templates/pages/review_guide.html:33
 msgid "Sections"
 msgstr "Seções"
 
-#: src/olympia/pages/templates/pages/dev_faq.html:33
-#: src/olympia/pages/templates/pages/dev_faq.html:45
+#: src/olympia/pages/templates/pages/dev_faq.html:33 src/olympia/pages/templates/pages/dev_faq.html:45
 msgid "Developing an Add-on"
 msgstr "Desenvolvendo um extra"
 
 #. Heading for a list of resources for developers
-#: src/olympia/pages/templates/pages/dev_faq.html:34
-#: src/olympia/pages/templates/pages/dev_faq.html:208
+#: src/olympia/pages/templates/pages/dev_faq.html:34 src/olympia/pages/templates/pages/dev_faq.html:208
 msgid "Support Resources"
 msgstr "Recursos de Suporte"
 
-#: src/olympia/pages/templates/pages/dev_faq.html:35
-#: src/olympia/pages/templates/pages/dev_faq.html:261
+#: src/olympia/pages/templates/pages/dev_faq.html:35 src/olympia/pages/templates/pages/dev_faq.html:261
 msgid "Contributing your Add-on"
 msgstr "Colaborando com o seu extra"
 
-#: src/olympia/pages/templates/pages/dev_faq.html:36
-#: src/olympia/pages/templates/pages/dev_faq.html:381
+#: src/olympia/pages/templates/pages/dev_faq.html:36 src/olympia/pages/templates/pages/dev_faq.html:381
 msgid "Add-on Review Process"
 msgstr "Processo de análise de extras"
 
 # 82%
-#: src/olympia/pages/templates/pages/dev_faq.html:37
-#: src/olympia/pages/templates/pages/dev_faq.html:444
+#: src/olympia/pages/templates/pages/dev_faq.html:37 src/olympia/pages/templates/pages/dev_faq.html:444
 msgid "Managing Your Add-on"
 msgstr "Gerenciando seu extra"
 
-#: src/olympia/pages/templates/pages/dev_faq.html:39
-#: src/olympia/pages/templates/pages/dev_faq.html:528
+#: src/olympia/pages/templates/pages/dev_faq.html:39 src/olympia/pages/templates/pages/dev_faq.html:528
 msgid "References for Open Source Licenses"
 msgstr "Referências de licenças de código aberto"
 
@@ -12148,14 +9710,8 @@ msgstr "FAQ do programador de extra"
 
 #: src/olympia/pages/templates/pages/dev_faq.html:47
 #, python-format
-msgid ""
-"<h3>How do I build an Add-on?</h3> <p> Mozilla provides documentation on how"
-" to build an add-on via the <a href=\"%(url)s\">Mozilla Developer "
-"Network</a>. </p>"
-msgstr ""
-"<h3>Como construo um Extra?</h3> <p> A Mozilla fornece documentação sobre "
-"como construir um extra na <a href=\"%(url)s\">Rede de Programadores da "
-"Mozilla</a>. </p>"
+msgid "<h3>How do I build an Add-on?</h3> <p> Mozilla provides documentation on how to build an add-on via the <a href=\"%(url)s\">Mozilla Developer Network</a>. </p>"
+msgstr "<h3>Como construo um Extra?</h3> <p> A Mozilla fornece documentação sobre como construir um extra na <a href=\"%(url)s\">Rede de Programadores da Mozilla</a>. </p>"
 
 #: src/olympia/pages/templates/pages/dev_faq.html:55
 msgid "Other resources include:"
@@ -12163,8 +9719,7 @@ msgstr "Outros recursos incluem:"
 
 #: src/olympia/pages/templates/pages/dev_faq.html:59
 msgid "\"How to develop a Firefox extension\" post in the Add-ons Blog"
-msgstr ""
-"Artigo \"Como desenvolver uma extensão para o Firefox\" no blogue de Extras"
+msgstr "Artigo \"Como desenvolver uma extensão para o Firefox\" no blogue de Extras"
 
 #: src/olympia/pages/templates/pages/dev_faq.html:62
 msgid "Mozilla Add-ons Blog"
@@ -12176,14 +9731,11 @@ msgstr "Quais ferramentas eu preciso para poder criar um extra?"
 
 #: src/olympia/pages/templates/pages/dev_faq.html:68
 msgid ""
-"You will need to have a version of the Mozilla software that you're building"
-" the add-on for and a code editor of your choice. Add-ons can be built for "
-"almost all Mozilla software but are primarily targeted for:"
+"You will need to have a version of the Mozilla software that you're building the add-on for and a code editor of your choice. Add-ons can be built for almost all Mozilla software but are primarily "
+"targeted for:"
 msgstr ""
-"Você precisará de uma versão da aplicação Mozilla para a qual você está "
-"criando um extra e um editor de código da sua escolha. Extras podem ser "
-"criados para quase todas as aplicações baseadas na tecnologia Mozilla, mas o"
-" foco primário é:"
+"Você precisará de uma versão da aplicação Mozilla para a qual você está criando um extra e um editor de código da sua escolha. Extras podem ser criados para quase todas as aplicações baseadas na "
+"tecnologia Mozilla, mas o foco primário é:"
 
 #: src/olympia/pages/templates/pages/dev_faq.html:82
 msgid "Popular code editors include:"
@@ -12192,37 +9744,24 @@ msgstr "Editores de código populares incluem:"
 #. This is a list of popular code editors.  Feel free to adjust as you like.
 #: src/olympia/pages/templates/pages/dev_faq.html:85
 msgid ""
-"<li><a href=\"http://komodoide.com/komodo-edit/\">Komodo Edit</a></li> "
-"<li><a href=\"http://macromates.com/\">TextMate</a></li> <li><a href=\"http"
-"://notepad-plus-plus.org/\">Notepad++</a></li> <li><a "
-"href=\"http://www.eclipse.org/\">Eclipse IDE</a></li>"
+"<li><a href=\"http://komodoide.com/komodo-edit/\">Komodo Edit</a></li> <li><a href=\"http://macromates.com/\">TextMate</a></li> <li><a href=\"http://notepad-plus-plus.org/\">Notepad++</a></li> "
+"<li><a href=\"http://www.eclipse.org/\">Eclipse IDE</a></li>"
 msgstr ""
-"<li><a href=\"http://komodoide.com/komodo-edit/\">Komodo Edit</a></li> "
-"<li><a href=\"http://macromates.com/\">TextMate</a></li> <li><a href=\"http"
-"://notepad-plus-plus.org/\">Notepad++</a></li> <li><a "
-"href=\"http://www.eclipse.org/\">Eclipse IDE</a></li>"
+"<li><a href=\"http://komodoide.com/komodo-edit/\">Komodo Edit</a></li> <li><a href=\"http://macromates.com/\">TextMate</a></li> <li><a href=\"http://notepad-plus-plus.org/\">Notepad++</a></li> "
+"<li><a href=\"http://www.eclipse.org/\">Eclipse IDE</a></li>"
 
 #: src/olympia/pages/templates/pages/dev_faq.html:94
 #, python-format
-msgid ""
-"You can also learn more about setting up your development environment via "
-"the MDN article <a href=\"%(url)s\">Setting up extension development "
-"environment</a>"
-msgstr ""
-"Pode saber mais sobre como configurar o seu ambiente de desenvolvimento "
-"através do artigo da MDN <a href=\"%(url)s\">Configurar o ambiente de "
-"desenvolvimento de extensões</a>"
+msgid "You can also learn more about setting up your development environment via the MDN article <a href=\"%(url)s\">Setting up extension development environment</a>"
+msgstr "Pode saber mais sobre como configurar o seu ambiente de desenvolvimento através do artigo da MDN <a href=\"%(url)s\">Configurar o ambiente de desenvolvimento de extensões</a>"
 
 #: src/olympia/pages/templates/pages/dev_faq.html:100
 msgid "What is a \".xpi\" file?"
 msgstr "O que é um arquivo \".xpi\"?"
 
 #: src/olympia/pages/templates/pages/dev_faq.html:102
-msgid ""
-"Extensions are packaged and distributed in ZIP files or Bundles, with the "
-"XPI (pronounced \"zippy\") file extension."
-msgstr ""
-"Extensões são empacotadas e distribuídas em arquivos ZIP com a extensão XPI."
+msgid "Extensions are packaged and distributed in ZIP files or Bundles, with the XPI (pronounced \"zippy\") file extension."
+msgstr "Extensões são empacotadas e distribuídas em arquivos ZIP com a extensão XPI."
 
 #: src/olympia/pages/templates/pages/dev_faq.html:108
 msgid "What is XUL?"
@@ -12230,17 +9769,11 @@ msgstr "O que é XUL?"
 
 #: src/olympia/pages/templates/pages/dev_faq.html:110
 msgid ""
-"XUL (XML User Interface Language) is Mozilla's XML-based language that lets "
-"you build feature-rich cross platform applications. It provides user "
-"interface widgets like buttons, menus, toolbars, trees, etc that can be used"
-" to enhance add-ons by modifying parts of the browser UI."
+"XUL (XML User Interface Language) is Mozilla's XML-based language that lets you build feature-rich cross platform applications. It provides user interface widgets like buttons, menus, toolbars, "
+"trees, etc that can be used to enhance add-ons by modifying parts of the browser UI."
 msgstr ""
-"XUL (XML User Interface Language, linguagem de interface XML) é uma "
-"linguagem da Mozilla baseada em XML que permite construir interfaces ricas "
-"compatíveis com diversas aplicações multiplataforma. Ela oferece widgets de "
-"interface como botões, barras de ferramentas, árvores, entre outros, que "
-"podem ser usados para melhorar os extras modificando partes da interface do "
-"navegador."
+"XUL (XML User Interface Language, linguagem de interface XML) é uma linguagem da Mozilla baseada em XML que permite construir interfaces ricas compatíveis com diversas aplicações multiplataforma. "
+"Ela oferece widgets de interface como botões, barras de ferramentas, árvores, entre outros, que podem ser usados para melhorar os extras modificando partes da interface do navegador."
 
 #: src/olympia/pages/templates/pages/dev_faq.html:119
 msgid "What is the \"install.rdf\" file used for?"
@@ -12249,35 +9782,21 @@ msgstr "Para que serve o arquivo \"install.rdf\"?"
 #: src/olympia/pages/templates/pages/dev_faq.html:121
 #, python-format
 msgid ""
-"This file, called an <a href=\"%(url)s\">Install Manifest</a>, is used by "
-"Add-on Manager-enabled XUL applications to determine information about an "
-"add-on as it is being installed. It contains metadata identifying the add-"
-"on, providing information about who created it, where more information can "
-"be found about it, which versions of what applications it is compatible "
-"with, how it should be updated, and so on. The format of the Install "
-"Manifest is RDF/XML."
+"This file, called an <a href=\"%(url)s\">Install Manifest</a>, is used by Add-on Manager-enabled XUL applications to determine information about an add-on as it is being installed. It contains "
+"metadata identifying the add-on, providing information about who created it, where more information can be found about it, which versions of what applications it is compatible with, how it should "
+"be updated, and so on. The format of the Install Manifest is RDF/XML."
 msgstr ""
-"Este ficheiro, denominado por <a href=\"%(url)s\">manifesto de "
-"instalação</a>, é utilizado por aplicações de gestão de extras baseados em "
-"XUL para obter informações sobre um extra enquanto este é instalado. Contem "
-"meta-dados que identificam o extra, fornecendo informação sobre quem o "
-"criou, onde pode ser encontrada mais informação sobre ele, com que versões e"
-" aplicações é compatível, como deve ser atualizado, etc. O formato do "
-"manifesto de instalação é RDF/XML."
+"Este ficheiro, denominado por <a href=\"%(url)s\">manifesto de instalação</a>, é utilizado por aplicações de gestão de extras baseados em XUL para obter informações sobre um extra enquanto este é "
+"instalado. Contem meta-dados que identificam o extra, fornecendo informação sobre quem o criou, onde pode ser encontrada mais informação sobre ele, com que versões e aplicações é compatível, como "
+"deve ser atualizado, etc. O formato do manifesto de instalação é RDF/XML."
 
 #: src/olympia/pages/templates/pages/dev_faq.html:132
 msgid "What does \"maxVersion\" mean?"
 msgstr "O que significa \"maxVersion\"?"
 
 #: src/olympia/pages/templates/pages/dev_faq.html:134
-msgid ""
-"This determines the maximum version of Firefox you're saying this extension "
-"will work with. Set this to be no newer than the newest currently available "
-"version!"
-msgstr ""
-"Essa propriedade determina a versão máxima do Firefox com a qual você afirma"
-" que seu extra vai funcionar. Defina um valor que não seja maior que a "
-"versão mais recente atualmente!"
+msgid "This determines the maximum version of Firefox you're saying this extension will work with. Set this to be no newer than the newest currently available version!"
+msgstr "Essa propriedade determina a versão máxima do Firefox com a qual você afirma que seu extra vai funcionar. Defina um valor que não seja maior que a versão mais recente atualmente!"
 
 #: src/olympia/pages/templates/pages/dev_faq.html:141
 msgid "Can my add-on contain binary components?"
@@ -12286,42 +9805,25 @@ msgstr "O meu extra pode conter componentes binários?"
 #: src/olympia/pages/templates/pages/dev_faq.html:143
 #, python-format
 msgid ""
-"Yes. You can use Mozilla's <a href=\"%(url)s\">XPCOM component object "
-"model</a> to enhance your add-ons. XPCOM components be used and implemented "
-"in JavaScript, Java, and Python in addition to C++."
+"Yes. You can use Mozilla's <a href=\"%(url)s\">XPCOM component object model</a> to enhance your add-ons. XPCOM components be used and implemented in JavaScript, Java, and Python in addition to C++."
 msgstr ""
-"Sim. Você pode usar o <a href=\"%(url)s\">XPCOM</a>, modelo de componentes e"
-" objetos da Mozilla, para melhorar seus extras. Os componentes XPCOM podem "
-"ser usados e implementados em Javascript, Java e Python, além de C++."
+"Sim. Você pode usar o <a href=\"%(url)s\">XPCOM</a>, modelo de componentes e objetos da Mozilla, para melhorar seus extras. Os componentes XPCOM podem ser usados e implementados em Javascript, Java "
+"e Python, além de C++."
 
 #: src/olympia/pages/templates/pages/dev_faq.html:150
-msgid ""
-"Can I use a JavaScript library like jQuery, MooTools or Prototype to build "
-"my add-on?"
-msgstr ""
-"Eu posso usar uma biblioteca JavaScript como jQuery, MooTools ou Prototype "
-"para criar meu extra?"
+msgid "Can I use a JavaScript library like jQuery, MooTools or Prototype to build my add-on?"
+msgstr "Eu posso usar uma biblioteca JavaScript como jQuery, MooTools ou Prototype para criar meu extra?"
 
 #: src/olympia/pages/templates/pages/dev_faq.html:152
 msgid ""
-"Yes. It's possible, but some of the functionality provided by these "
-"libraries are available through XPCOM, XUL, and JavaScript. In addition, "
-"authors should take care if libraries modify primitive object prototypes "
-"(String.prototype, Date.prototype, etc.) and/or define global functions (eg."
-" the $ function). These are prone to cause conflict with other add-ons, in "
-"particular if different add-ons use different versions of libraries and so "
-"on. Developers need to be very, very careful with using them.  Mozilla does "
-"not offer documentation on using them to build add-ons."
+"Yes. It's possible, but some of the functionality provided by these libraries are available through XPCOM, XUL, and JavaScript. In addition, authors should take care if libraries modify primitive "
+"object prototypes (String.prototype, Date.prototype, etc.) and/or define global functions (eg. the $ function). These are prone to cause conflict with other add-ons, in particular if different add-"
+"ons use different versions of libraries and so on. Developers need to be very, very careful with using them. Mozilla does not offer documentation on using them to build add-ons."
 msgstr ""
-"Sim, é possível, mas alguma da funcionalidade fornecida por estas "
-"bibliotecas está disponível através do XPCOM, XUL e JavaScript. Por outro "
-"lado, os autores devem ter cuidado se as bibliotecas modificarem protótipos "
-"de objetos primitivos (String.prototype, Date.prototype, etc.) e/ou definem "
-"funções globais (por exemplo, a função $). Estas modificações são "
-"suscetíveis de causar conflitos com outros extras, em particular se "
-"diferentes extras utilizam diferentes versões das bibliotecas, etc. Os "
-"programadores devem ter muito, muito cuidado quando as utilizam. A Mozilla "
-"não fornece documentação sobre como as utilizar para construir extras."
+"Sim, é possível, mas alguma da funcionalidade fornecida por estas bibliotecas está disponível através do XPCOM, XUL e JavaScript. Por outro lado, os autores devem ter cuidado se as bibliotecas "
+"modificarem protótipos de objetos primitivos (String.prototype, Date.prototype, etc.) e/ou definem funções globais (por exemplo, a função $). Estas modificações são suscetíveis de causar conflitos "
+"com outros extras, em particular se diferentes extras utilizam diferentes versões das bibliotecas, etc. Os programadores devem ter muito, muito cuidado quando as utilizam. A Mozilla não fornece "
+"documentação sobre como as utilizar para construir extras."
 
 #: src/olympia/pages/templates/pages/dev_faq.html:165
 msgid "How do I debug my add-on?"
@@ -12333,32 +9835,19 @@ msgid "You can use the <a href=\"%(url)s\">Add-on Debugger</a>."
 msgstr "Pode utilizar o <a href=\"%(url)s\">Depurador de Extras</a>."
 
 #: src/olympia/pages/templates/pages/dev_faq.html:172
-msgid ""
-"How do I test for compatibility with the latest version of Mozilla software?"
-msgstr ""
-"Como eu posso testar a compatibilidade com as versões mais recentes dos "
-"aplicativos Mozilla?"
+msgid "How do I test for compatibility with the latest version of Mozilla software?"
+msgstr "Como eu posso testar a compatibilidade com as versões mais recentes dos aplicativos Mozilla?"
 
 #: src/olympia/pages/templates/pages/dev_faq.html:174
 msgid ""
-"To ensure compatibility with the latest Mozilla software, it's important to "
-"download updates as they become available and test your add-on to ensure "
-"that it is still functioning as expected. In many cases, the latest version "
-"of Mozilla software may be a beta release. Since these releases at times "
-"introduce architectural changes that may impact the functionality of your "
-"add-on, it's important to be actively involved in the beta process to ensure"
-" that your add-on users are not negatively impacted upon final release of "
-"Mozilla software."
+"To ensure compatibility with the latest Mozilla software, it's important to download updates as they become available and test your add-on to ensure that it is still functioning as expected. In "
+"many cases, the latest version of Mozilla software may be a beta release. Since these releases at times introduce architectural changes that may impact the functionality of your add-on, it's "
+"important to be actively involved in the beta process to ensure that your add-on users are not negatively impacted upon final release of Mozilla software."
 msgstr ""
-"Para garantir a compatibilidade com as últimas versões do software da "
-"Mozilla, é importante descarregar atualizações assim que estas são "
-"disponibilizadas e testar o seu extra para garantir que ainda funciona como "
-"esperado. Em muitos casos a última versão do software da Mozilla pode ser um"
-" lançamento beta. Dado que estes lançamentos podem por vezes apresentar "
-"alterações arquiteturais, que podem ter impacto na funcionalidade do seu "
-"extra, é importante estar envolvido ativamente no processo beta para "
-"garantir que os utilizadores do seu extra não são negativamente afetados "
-"após o lançamento do software da Mozilla."
+"Para garantir a compatibilidade com as últimas versões do software da Mozilla, é importante descarregar atualizações assim que estas são disponibilizadas e testar o seu extra para garantir que "
+"ainda funciona como esperado. Em muitos casos a última versão do software da Mozilla pode ser um lançamento beta. Dado que estes lançamentos podem por vezes apresentar alterações arquiteturais, que "
+"podem ter impacto na funcionalidade do seu extra, é importante estar envolvido ativamente no processo beta para garantir que os utilizadores do seu extra não são negativamente afetados após o "
+"lançamento do software da Mozilla."
 
 #: src/olympia/pages/templates/pages/dev_faq.html:185
 msgid "How to improve the performance of my add-on?"
@@ -12367,17 +9856,11 @@ msgstr "Como melhorar o desempenho do meu extra?"
 #: src/olympia/pages/templates/pages/dev_faq.html:187
 #, python-format
 msgid ""
-"Poorly written extensions can have a severe impact on the browsing "
-"experience, including on the overall performance of Firefox itself. The "
-"following page contains many good <a href=\"%(url)s\">guides</a> that help "
-"you improve performance, whether you're developing core Mozilla code or an "
-"add-on."
+"Poorly written extensions can have a severe impact on the browsing experience, including on the overall performance of Firefox itself. The following page contains many good <a href=\"%(url)s"
+"\">guides</a> that help you improve performance, whether you're developing core Mozilla code or an add-on."
 msgstr ""
-"Extensões mal escritas podem ter um impacto significativo na experiência de "
-"navegação, incluindo na performance geral do próprio Firefox. A página "
-"seguinte contém <a href=\"%(url)s\">guias</a> muito bons que podem ajudá-lo "
-"a melhorar o desempenho, quer esteja a desenvolver código central para a "
-"Mozilla ou um extra."
+"Extensões mal escritas podem ter um impacto significativo na experiência de navegação, incluindo na performance geral do próprio Firefox. A página seguinte contém <a href=\"%(url)s\">guias</a> "
+"muito bons que podem ajudá-lo a melhorar o desempenho, quer esteja a desenvolver código central para a Mozilla ou um extra."
 
 #: src/olympia/pages/templates/pages/dev_faq.html:195
 msgid "Can my add-on support multiple locales?"
@@ -12386,21 +9869,15 @@ msgstr "O meu extra pode suportar mais de um idioma?"
 #: src/olympia/pages/templates/pages/dev_faq.html:197
 #, python-format
 msgid ""
-"Yes. Details on localizing your add-on can be found in the the <a "
-"href=\"%(l10n_url)s\">Mozilla Developer Network Localization page</a>. <a "
-"href=\"%(bz_url)s\">The BabelZilla project</a> is also a great resource for "
-"learning about localization and volunteering to help translate add-ons."
+"Yes. Details on localizing your add-on can be found in the the <a href=\"%(l10n_url)s\">Mozilla Developer Network Localization page</a>. <a href=\"%(bz_url)s\">The BabelZilla project</a> is also a "
+"great resource for learning about localization and volunteering to help translate add-ons."
 msgstr ""
-"Sim. Detalhes sobre como traduzir o seu extra podem ser encontrados na <a "
-"href=\"%(l10n_url)s\">página de Tradução da Central de Programadores da "
-"Mozilla</a>. <a href=\"%(bz_url)s\">O projeto BabelZilla</a> é também um "
-"ótimo recurso para saber mais sobre tradução e contribuir com a tradução de "
-"extras."
+"Sim. Detalhes sobre como traduzir o seu extra podem ser encontrados na <a href=\"%(l10n_url)s\">página de Tradução da Central de Programadores da Mozilla</a>. <a href=\"%(bz_url)s\">O projeto "
+"BabelZilla</a> é também um ótimo recurso para saber mais sobre tradução e contribuir com a tradução de extras."
 
 #: src/olympia/pages/templates/pages/dev_faq.html:210
 msgid "I need some advice building my add-on. Where can I find help?"
-msgstr ""
-"Eu preciso de dicas para criar meu extra. Onde eu posso encontrar ajuda?"
+msgstr "Eu preciso de dicas para criar meu extra. Onde eu posso encontrar ajuda?"
 
 #. #extdev is the name of the IRC channel.  do not change.
 #: src/olympia/pages/templates/pages/dev_faq.html:216
@@ -12414,12 +9891,8 @@ msgstr "#amo (para suporte relacionado à hospedagem do seu extra no AMO)"
 
 #. #jetpack is the name of the IRC channel.  do not change.
 #: src/olympia/pages/templates/pages/dev_faq.html:220
-msgid ""
-"#jetpack (for discussions about the Add-ons SDK and cfx/jpm - formerly known"
-" as Jetpack)"
-msgstr ""
-"#jetpack (para discussões sobre o SDK de Extras e cfx/jpm - anteriormente "
-"conhecido por Jetpack)"
+msgid "#jetpack (for discussions about the Add-ons SDK and cfx/jpm - formerly known as Jetpack)"
+msgstr "#jetpack (para discussões sobre o SDK de Extras e cfx/jpm - anteriormente conhecido por Jetpack)"
 
 #. Label for a link to the extension developers mailing list
 #: src/olympia/pages/templates/pages/dev_faq.html:225
@@ -12454,24 +9927,16 @@ msgstr "Não."
 
 #: src/olympia/pages/templates/pages/dev_faq.html:246
 msgid "Are there 3rd party developers that I can hire to build my add-on?"
-msgstr ""
-"Existem outros programadores que posso contratar para construirem o meu "
-"extra?"
+msgstr "Existem outros programadores que posso contratar para construirem o meu extra?"
 
 #: src/olympia/pages/templates/pages/dev_faq.html:248
 #, python-format
 msgid ""
-"Yes. You may find 3rd party developers via the <a href=\"%(forum_url)s"
-"\">Add-ons forum</a>, <a href=\"%(list_url)s\">mozilla.jobs list</a>, <a "
-"href=\"%(mz_url)s\">mozillaZine forums</a> or <a href=\"%(wiki_url)s\">the "
-"Mozilla Wiki</a>. Please note that Mozilla does not offer developer "
-"recommendations."
+"Yes. You may find 3rd party developers via the <a href=\"%(forum_url)s\">Add-ons forum</a>, <a href=\"%(list_url)s\">mozilla.jobs list</a>, <a href=\"%(mz_url)s\">mozillaZine forums</a> or <a href="
+"\"%(wiki_url)s\">the Mozilla Wiki</a>. Please note that Mozilla does not offer developer recommendations."
 msgstr ""
-"Sim. Pode encontrar outros programadores através do <a "
-"href=\"%(forum_url)s\">fórum de Extras</a>, <a href=\"%(list_url)s\">lista "
-"mozilla.jobs</a>, <a href=\"%(mz_url)s\">fóruns mozillaZine</a> ou <a "
-"href=\"%(wiki_url)s\">na Wiki da Mozilla</a>. Tenha em consideração que a "
-"Mozilla não fornece recomendações para programadores."
+"Sim. Pode encontrar outros programadores através do <a href=\"%(forum_url)s\">fórum de Extras</a>, <a href=\"%(list_url)s\">lista mozilla.jobs</a>, <a href=\"%(mz_url)s\">fóruns mozillaZine</a> ou "
+"<a href=\"%(wiki_url)s\">na Wiki da Mozilla</a>. Tenha em consideração que a Mozilla não fornece recomendações para programadores."
 
 #: src/olympia/pages/templates/pages/dev_faq.html:263
 msgid "Can I host my own add-on?"
@@ -12480,22 +9945,13 @@ msgstr "Posso alojar o meu próprio extra?"
 #: src/olympia/pages/templates/pages/dev_faq.html:265
 #, python-format
 msgid ""
-"Yes. Many developers choose to host their own add-ons. Choosing to host your"
-" add-on on <a href=\"%(amo_url)s\">Mozilla's add-on site</a>, though, allows"
-" for much greater exposure to your add-on due to the large volume of "
-"visitors to the site.  <a href=\"%(md_url)s\">mozdev.org</a> offers free "
-"project hosting for Mozilla applications and extensions providing developers"
-" with tools to help manage source code, version control, bug tracking and "
-"documentation."
+"Yes. Many developers choose to host their own add-ons. Choosing to host your add-on on <a href=\"%(amo_url)s\">Mozilla's add-on site</a>, though, allows for much greater exposure to your add-on due "
+"to the large volume of visitors to the site. <a href=\"%(md_url)s\">mozdev.org</a> offers free project hosting for Mozilla applications and extensions providing developers with tools to help manage "
+"source code, version control, bug tracking and documentation."
 msgstr ""
-"Sim. Muitos programadores optam por alojar por si próprios os extras. No "
-"entanto, optar por alojar o seu extra no <a href=\"%(amo_url)s\">site de "
-"extras da Mozilla</a> dá uma visibilidade maior ao seu extra devido ao "
-"grande número de visitantes do site.  O <a "
-"href=\"%(md_url)s\">mozdev.org</a> oferece alojamento gratuito de projetos "
-"para aplicações da Mozilla e extensões, fornecendo aos programadores as "
-"ferramentas para ajudar a gerir o código fonte, controlo de versões, "
-"acompanhamento de bugs e documentação."
+"Sim. Muitos programadores optam por alojar por si próprios os extras. No entanto, optar por alojar o seu extra no <a href=\"%(amo_url)s\">site de extras da Mozilla</a> dá uma visibilidade maior ao "
+"seu extra devido ao grande número de visitantes do site.  O <a href=\"%(md_url)s\">mozdev.org</a> oferece alojamento gratuito de projetos para aplicações da Mozilla e extensões, fornecendo aos "
+"programadores as ferramentas para ajudar a gerir o código fonte, controlo de versões, acompanhamento de bugs e documentação."
 
 #: src/olympia/pages/templates/pages/dev_faq.html:277
 msgid "Can Mozilla host my add-on?"
@@ -12503,12 +9959,8 @@ msgstr "A Mozilla pode hospedar o meu extra?"
 
 #: src/olympia/pages/templates/pages/dev_faq.html:279
 #, python-format
-msgid ""
-"Yes. You can host your add-on on <a href=\"%(url)s\">Mozilla's add-on "
-"website</a>."
-msgstr ""
-"Sim. O seu extra pode ser hospedado no site <a href=\"%(url)s\">Mozilla Add-"
-"ons</a>."
+msgid "Yes. You can host your add-on on <a href=\"%(url)s\">Mozilla's add-on website</a>."
+msgstr "Sim. O seu extra pode ser hospedado no site <a href=\"%(url)s\">Mozilla Add-ons</a>."
 
 #: src/olympia/pages/templates/pages/dev_faq.html:284
 msgid "What is AMO?"
@@ -12516,19 +9968,11 @@ msgstr "O que é AMO?"
 
 #: src/olympia/pages/templates/pages/dev_faq.html:286
 msgid ""
-"Mozilla's AMO (<a "
-"href=\"https://addons.mozilla.org\">https://addons.mozilla.org</a>) is the "
-"incubator that helps developers build, distribute, and support fantastic "
-"consumer products powered by Mozilla. It provides you the tools and "
-"infrastructure necessary to manage, host and expose your add-on to a massive"
-" base of Mozilla users."
+"Mozilla's AMO (<a href=\"https://addons.mozilla.org\">https://addons.mozilla.org</a>) is the incubator that helps developers build, distribute, and support fantastic consumer products powered by "
+"Mozilla. It provides you the tools and infrastructure necessary to manage, host and expose your add-on to a massive base of Mozilla users."
 msgstr ""
-"O AMO da Mozilla (<a "
-"href=\"https://addons.mozilla.org\">https://addons.mozilla.org</a>) é a "
-"incubadora que ajuda os programadores a construir, distribuir e suportar "
-"produtos fantásticos de consumo potenciados pela Mozilla. Fornece as "
-"ferramentas e infraestrutura necessária para gerir, alojar e expor o seu "
-"extra a uma base massiva de utilizadores Mozilla."
+"O AMO da Mozilla (<a href=\"https://addons.mozilla.org\">https://addons.mozilla.org</a>) é a incubadora que ajuda os programadores a construir, distribuir e suportar produtos fantásticos de consumo "
+"potenciados pela Mozilla. Fornece as ferramentas e infraestrutura necessária para gerir, alojar e expor o seu extra a uma base massiva de utilizadores Mozilla."
 
 #: src/olympia/pages/templates/pages/dev_faq.html:295
 msgid "Does Mozilla keep my account information private?"
@@ -12536,12 +9980,8 @@ msgstr "A Mozilla mantém em segredo as informações da minha conta?"
 
 #: src/olympia/pages/templates/pages/dev_faq.html:297
 #, python-format
-msgid ""
-"Yes. Our <a href=\"%(url)s\">Privacy Policy</a> describes how your "
-"information is managed by Mozilla."
-msgstr ""
-"Sim. Nossa <a href=\"%(url)s\">Política de privacidade</a> descreve como "
-"suas informações são gerenciadas pela Mozilla."
+msgid "Yes. Our <a href=\"%(url)s\">Privacy Policy</a> describes how your information is managed by Mozilla."
+msgstr "Sim. Nossa <a href=\"%(url)s\">Política de privacidade</a> descreve como suas informações são gerenciadas pela Mozilla."
 
 #: src/olympia/pages/templates/pages/dev_faq.html:302
 msgid "What are the \"developer tools\" listed on AMO?"
@@ -12549,38 +9989,24 @@ msgstr "O que são as \"ferramentas do programador\" listadas no AMO?"
 
 #: src/olympia/pages/templates/pages/dev_faq.html:304
 msgid ""
-"The \"Developer Tools\" dashboard is the area that provides you the tools to"
-" successfully manage your add-ons. It provides the functionality necessary "
-"to submit your add-ons to AMO, manage add-on information, and review "
-"statistics."
+"The \"Developer Tools\" dashboard is the area that provides you the tools to successfully manage your add-ons. It provides the functionality necessary to submit your add-ons to AMO, manage add-on "
+"information, and review statistics."
 msgstr ""
-"A página \"Meus extras\" é a área que oferece ferramentas para gerenciar "
-"seus extras. Ele fornece as funcionalidades necessárias para enviar seu "
-"extra para o AMO, gerenciar as informações do extra e acompanhar "
-"estatísticas."
+"A página \"Meus extras\" é a área que oferece ferramentas para gerenciar seus extras. Ele fornece as funcionalidades necessárias para enviar seu extra para o AMO, gerenciar as informações do extra "
+"e acompanhar estatísticas."
 
 #: src/olympia/pages/templates/pages/dev_faq.html:312
-msgid ""
-"Does Mozilla have a policy in place as to what is an acceptable submission?"
-msgstr ""
-"A Mozilla possui uma política em vigor que descreva os critérios de envio de"
-" extras?"
+msgid "Does Mozilla have a policy in place as to what is an acceptable submission?"
+msgstr "A Mozilla possui uma política em vigor que descreva os critérios de envio de extras?"
 
 #: src/olympia/pages/templates/pages/dev_faq.html:314
 #, python-format
 msgid ""
-"Yes. Mozilla's <a href=\"%(p_url)s\">Add-on Policy</a> describes what is an "
-"acceptable submission. This policy is subject to change without notice.  In "
-"addition, the AMO editorial team uses the <a href=\"%(g_url)s\">Editors "
-"Reviewing Guide</a> to ensure that your add-on meets specific guidelines for"
-" functionality and security."
+"Yes. Mozilla's <a href=\"%(p_url)s\">Add-on Policy</a> describes what is an acceptable submission. This policy is subject to change without notice. In addition, the AMO editorial team uses the <a "
+"href=\"%(g_url)s\">Editors Reviewing Guide</a> to ensure that your add-on meets specific guidelines for functionality and security."
 msgstr ""
-"Sim. A <a href=\"%(p_url)s\">política de extras</a> da Mozilla descreve o "
-"que é uma submissão aceitável. Esta política pode ser alterada sem aviso "
-"prévio. Para além disto, a equipa editorial do AMO utiliza o <a "
-"href=\"%(g_url)s\">guia de revisão para editores</a> para garantir que o seu"
-" extra cumpre as linhas orientadoras específicas para funcionalidade e "
-"segurança."
+"Sim. A <a href=\"%(p_url)s\">política de extras</a> da Mozilla descreve o que é uma submissão aceitável. Esta política pode ser alterada sem aviso prévio. Para além disto, a equipa editorial do AMO "
+"utiliza o <a href=\"%(g_url)s\">guia de revisão para editores</a> para garantir que o seu extra cumpre as linhas orientadoras específicas para funcionalidade e segurança."
 
 #: src/olympia/pages/templates/pages/dev_faq.html:324
 msgid "How do I submit my add-on for review?"
@@ -12589,29 +10015,19 @@ msgstr "Como eu envio meu extra para análise?"
 #: src/olympia/pages/templates/pages/dev_faq.html:326
 #, python-format
 msgid ""
-"The Developer Tools dashboard will allow you to upload and submit add-ons to"
-" AMO. You must be a registered AMO users before you can submit an add-on. "
-"Before submitting your add-on be sure to you have read the AMO <a "
-"href=\"%(url)s\">Editors Reviewing Guide</a> to ensure that your add-on has "
-"met the guidelines used by editors to review add-ons."
+"The Developer Tools dashboard will allow you to upload and submit add-ons to AMO. You must be a registered AMO users before you can submit an add-on. Before submitting your add-on be sure to you "
+"have read the AMO <a href=\"%(url)s\">Editors Reviewing Guide</a> to ensure that your add-on has met the guidelines used by editors to review add-ons."
 msgstr ""
-"O painel de Ferramentas do programador permite que envie e submeta extras "
-"para o AMO. Deve ser um utilizador registado no AMO antes de poder enviar um"
-" extra. Antes de enviar o seu extra, tenha certeza de que leu o <a "
-"href=\"%(url)s\">Guia de revisão para editores</a> da Mozilla para garantir "
-"que seu extra atende aos critérios usados pelos editores para rever extras."
+"O painel de Ferramentas do programador permite que envie e submeta extras para o AMO. Deve ser um utilizador registado no AMO antes de poder enviar um extra. Antes de enviar o seu extra, tenha "
+"certeza de que leu o <a href=\"%(url)s\">Guia de revisão para editores</a> da Mozilla para garantir que seu extra atende aos critérios usados pelos editores para rever extras."
 
 #: src/olympia/pages/templates/pages/dev_faq.html:336
 msgid "What operating system do I choose for my add-on?"
 msgstr "Que sistema operacional eu escolho para meu extra?"
 
 #: src/olympia/pages/templates/pages/dev_faq.html:338
-msgid ""
-"You must choose the operating systems on which your add-on will successfully"
-" function."
-msgstr ""
-"Você deve escolher os sistemas operacionais nos quais o seu extra funcionará"
-" com sucesso."
+msgid "You must choose the operating systems on which your add-on will successfully function."
+msgstr "Você deve escolher os sistemas operacionais nos quais o seu extra funcionará com sucesso."
 
 #: src/olympia/pages/templates/pages/dev_faq.html:344
 msgid "What category do I choose for my add-on?"
@@ -12619,57 +10035,36 @@ msgstr "Que categoria eu devo escolher para o meu extra?"
 
 #: src/olympia/pages/templates/pages/dev_faq.html:346
 msgid ""
-"The choice of category is dependent on what type of audience you are "
-"targeting and the functionality of your add-on. If you're unsure of which "
-"category your add-on falls into, please choose \"Other\". The AMO team may "
-"re-categorize your add-on if it's determined that it's better suited in a "
-"different category."
+"The choice of category is dependent on what type of audience you are targeting and the functionality of your add-on. If you're unsure of which category your add-on falls into, please choose \"Other"
+"\". The AMO team may re-categorize your add-on if it's determined that it's better suited in a different category."
 msgstr ""
-"A escolha da categoria depende do tipo de audiência que você deseja alcançar"
-" e a funcionalidade do seu extra. Se você não tiver certeza de qual "
-"categoria você deve selecionar para seu extra, selecione \"Outros\". A "
-"equipe do AMO poderá recategorizar seu extra se for determinado que ele se "
-"encaixa melhor em uma categoria diferente."
+"A escolha da categoria depende do tipo de audiência que você deseja alcançar e a funcionalidade do seu extra. Se você não tiver certeza de qual categoria você deve selecionar para seu extra, "
+"selecione \"Outros\". A equipe do AMO poderá recategorizar seu extra se for determinado que ele se encaixa melhor em uma categoria diferente."
 
 #: src/olympia/pages/templates/pages/dev_faq.html:355
 msgid "What does \"nominating\" my add-on mean?"
 msgstr "O que significa \"indicar\" meu extra?"
 
 #: src/olympia/pages/templates/pages/dev_faq.html:357
-msgid ""
-"Nominated add-ons are new add-ons that the author has nominated to become "
-"public via the Developer Tools."
-msgstr ""
-"Os extras nomeados são extras que o autor nomeou para se tornarem públicos "
-"através das Ferramentas do programador."
+msgid "Nominated add-ons are new add-ons that the author has nominated to become public via the Developer Tools."
+msgstr "Os extras nomeados são extras que o autor nomeou para se tornarem públicos através das Ferramentas do programador."
 
 #: src/olympia/pages/templates/pages/dev_faq.html:363
 msgid "Can I specify a license agreement for using my add-on?"
 msgstr "Eu posso especificar um acordo de licença para usar com meu extra?"
 
 #: src/olympia/pages/templates/pages/dev_faq.html:365
-msgid ""
-"Yes. You can specify a license agreement when submitting your add-on. You "
-"can also add or update a license agreement via the Developer Tools dashboard"
-" after your add-on has been submitted."
-msgstr ""
-"Sim. Você pode especificar um acordo de licença ao enviar um extra. Você "
-"também pode adicionar ou atualizar um acordo de licença usando a página Meus"
-" extras após o envio do seu extra."
+msgid "Yes. You can specify a license agreement when submitting your add-on. You can also add or update a license agreement via the Developer Tools dashboard after your add-on has been submitted."
+msgstr "Sim. Você pode especificar um acordo de licença ao enviar um extra. Você também pode adicionar ou atualizar um acordo de licença usando a página Meus extras após o envio do seu extra."
 
 #: src/olympia/pages/templates/pages/dev_faq.html:372
 msgid "Can I include a privacy policy for my add-on?"
 msgstr "Eu posso incluir uma política de privacidade no meu extra?"
 
 #: src/olympia/pages/templates/pages/dev_faq.html:374
-msgid ""
-"Yes. You can specify a privacy policy when submitting your add-on. You can "
-"also add or update a privacy policy via the Developer Tools dashboard after "
-"your add-on has been submitted."
+msgid "Yes. You can specify a privacy policy when submitting your add-on. You can also add or update a privacy policy via the Developer Tools dashboard after your add-on has been submitted."
 msgstr ""
-"Sim. Você pode especificar uma política de privacidade ao enviar um extra. "
-"Você também pode adicionar ou atualizar uma política de privacidade usando a"
-" página Meus extras após o envio do seu extra."
+"Sim. Você pode especificar uma política de privacidade ao enviar um extra. Você também pode adicionar ou atualizar uma política de privacidade usando a página Meus extras após o envio do seu extra."
 
 #: src/olympia/pages/templates/pages/dev_faq.html:383
 msgid "Why must my add-on be reviewed?"
@@ -12678,16 +10073,11 @@ msgstr "Porque é que o meu extra tem de ser revisto?"
 #: src/olympia/pages/templates/pages/dev_faq.html:385
 #, python-format
 msgid ""
-"All add-ons submitted, whether new or updated, are reviewed to ensure that "
-"Mozilla users have a stable and safe experience. All add-ons submissions are"
-" reviewed using the guidelines outlined in the <a href=\"%(url)s\">Editors "
-"Reviewing Guide</a>."
+"All add-ons submitted, whether new or updated, are reviewed to ensure that Mozilla users have a stable and safe experience. All add-ons submissions are reviewed using the guidelines outlined in the "
+"<a href=\"%(url)s\">Editors Reviewing Guide</a>."
 msgstr ""
-"Todos os extras submetidos, sejam novos ou atualizações, são revistos para "
-"assegurar que os utilizadores da Mozilla têm uma experiência estável e "
-"segura. Todas as submissões de extras são revistas de acordo com as "
-"diretrizes descritas no <a href=\"%(url)s\">guia de revisão para "
-"editores</a>."
+"Todos os extras submetidos, sejam novos ou atualizações, são revistos para assegurar que os utilizadores da Mozilla têm uma experiência estável e segura. Todas as submissões de extras são revistas "
+"de acordo com as diretrizes descritas no <a href=\"%(url)s\">guia de revisão para editores</a>."
 
 #: src/olympia/pages/templates/pages/dev_faq.html:393
 msgid "Who reviews my add-on?"
@@ -12696,20 +10086,13 @@ msgstr "Quem analisa meu extra?"
 #: src/olympia/pages/templates/pages/dev_faq.html:395
 #, python-format
 msgid ""
-"Add-ons are reviewed by the AMO Editors, a group of talented developers that"
-" volunteer to help the Mozilla project by reviewing add-ons to ensure a "
-"stable and safe experience for Mozilla users. When communicating with "
-"editors, please be courteous, patient and respectful as they are working "
-"hard to ensure that your add-on is set up correctly and follows the "
-"guidelines outlined in the <a href=\"%(url)s\">Editors Reviewing Guide</a>."
+"Add-ons are reviewed by the AMO Editors, a group of talented developers that volunteer to help the Mozilla project by reviewing add-ons to ensure a stable and safe experience for Mozilla users. "
+"When communicating with editors, please be courteous, patient and respectful as they are working hard to ensure that your add-on is set up correctly and follows the guidelines outlined in the <a "
+"href=\"%(url)s\">Editors Reviewing Guide</a>."
 msgstr ""
-"Os extras são revistos pelos editores AMO, um grupo de talentosos "
-"programadores que se voluntariam para ajudar no projeto Mozilla revendo "
-"extras para garantir uma experiência estável e segura para os utilizadores "
-"da Mozilla. Quando comunicar com os editores, por favor seja cordial, "
-"paciente e respeitador pois eles estão a trabalhar arduamente para garantir "
-"que o seu extra está corretamente construído e segue as diretrizes descritas"
-" no <a href=\"%(url)s\">guia de revisão para editores</a>."
+"Os extras são revistos pelos editores AMO, um grupo de talentosos programadores que se voluntariam para ajudar no projeto Mozilla revendo extras para garantir uma experiência estável e segura para "
+"os utilizadores da Mozilla. Quando comunicar com os editores, por favor seja cordial, paciente e respeitador pois eles estão a trabalhar arduamente para garantir que o seu extra está corretamente "
+"construído e segue as diretrizes descritas no <a href=\"%(url)s\">guia de revisão para editores</a>."
 
 #: src/olympia/pages/templates/pages/dev_faq.html:406
 msgid "What are the guidelines used to review my add-on?"
@@ -12718,29 +10101,19 @@ msgstr "Quais são os critérios usados para analisar o meu extra?"
 #: src/olympia/pages/templates/pages/dev_faq.html:408
 #, python-format
 msgid ""
-"The Mozilla editorial team follows the <a href=\"%(url)s\">Editors Reviewing"
-" Guide</a> when testing an add-on for acceptance onto AMO. It is important "
-"that add-on developers review this guide to ensure that common problem areas"
-" are addressed prior to submitting their add-on for review. This will "
-"greatly assist in expediting the review process."
+"The Mozilla editorial team follows the <a href=\"%(url)s\">Editors Reviewing Guide</a> when testing an add-on for acceptance onto AMO. It is important that add-on developers review this guide to "
+"ensure that common problem areas are addressed prior to submitting their add-on for review. This will greatly assist in expediting the review process."
 msgstr ""
-"A equipa editorial da Mozilla segue o <a href=\"%(url)s\">guia de revisão "
-"para editores</a> ao testar um extra para aceitação no AMO. É importante que"
-" os programadores de extras analisem este guia para garantir que áreas "
-"problemáticas frequentes são trabalhadas antes de submeter os seus extras "
-"para revisão. Isto irá tornar o processo de revisão mais expedito."
+"A equipa editorial da Mozilla segue o <a href=\"%(url)s\">guia de revisão para editores</a> ao testar um extra para aceitação no AMO. É importante que os programadores de extras analisem este guia "
+"para garantir que áreas problemáticas frequentes são trabalhadas antes de submeter os seus extras para revisão. Isto irá tornar o processo de revisão mais expedito."
 
 #: src/olympia/pages/templates/pages/dev_faq.html:418
 msgid "How long will it take for my add-on to be reviewed?"
 msgstr "Quanto tempo levará para o meu extra ser analisado?"
 
 #: src/olympia/pages/templates/pages/dev_faq.html:420
-msgid ""
-"We cannot give a time estimate as to how long it will take before an add-on "
-"is reviewed. Many factors affect the time including the:"
-msgstr ""
-"Nós não podemos informar um tempo estimado de espera até seu complemento ser"
-" analisado. Muitos fatores afetam o tempo de espera, incluindo:"
+msgid "We cannot give a time estimate as to how long it will take before an add-on is reviewed. Many factors affect the time including the:"
+msgstr "Nós não podemos informar um tempo estimado de espera até seu complemento ser analisado. Muitos fatores afetam o tempo de espera, incluindo:"
 
 #. part of a list (<li>)
 #: src/olympia/pages/templates/pages/dev_faq.html:427
@@ -12760,61 +10133,38 @@ msgstr "número de problemas descobertos"
 #: src/olympia/pages/templates/pages/dev_faq.html:434
 #, python-format
 msgid ""
-"This is why it's very important to read the <a href=\"%(g_url)s\">Editors "
-"Reviewing Guide</a> to ensure that your add-on is setup as expected.  It's "
-"also a good idea to read the blog post, <a "
-"href=\"%(blog_url)s\">Successfully Getting your Add-on Reviewed</a> which "
-"provides excellent insight into ensuring a smooth review of your add-on."
+"This is why it's very important to read the <a href=\"%(g_url)s\">Editors Reviewing Guide</a> to ensure that your add-on is setup as expected. It's also a good idea to read the blog post, <a href="
+"\"%(blog_url)s\">Successfully Getting your Add-on Reviewed</a> which provides excellent insight into ensuring a smooth review of your add-on."
 msgstr ""
-"É por isto que é muito importante ler o <a href=\"%(g_url)s\">guia de "
-"revisão para editores</a> para garantir que o seu extra está de acordo com o"
-" que é esperado. Também é uma boa ideia ler o artigo do blogue, <a "
-"href=\"%(blog_url)s\">ter sucesso na revisão do seu extra</a> que dá uma "
-"ideia sobre uma revisão do seu extra sem sobressaltos."
+"É por isto que é muito importante ler o <a href=\"%(g_url)s\">guia de revisão para editores</a> para garantir que o seu extra está de acordo com o que é esperado. Também é uma boa ideia ler o "
+"artigo do blogue, <a href=\"%(blog_url)s\">ter sucesso na revisão do seu extra</a> que dá uma ideia sobre uma revisão do seu extra sem sobressaltos."
 
 #: src/olympia/pages/templates/pages/dev_faq.html:446
 msgid "How can I see how many times my add-on has been downloaded?"
 msgstr "Como posso ver quantas vezes o meu extra foi descarregado?"
 
 #: src/olympia/pages/templates/pages/dev_faq.html:448
-msgid ""
-"The Statistics Dashboard found in the Developer Tools dashboard provides "
-"information that can help you determine your add-on downloads since you've "
-"submitted it to AMO."
-msgstr ""
-"O painel de estatísticas encontrado na página Meus extras oferece "
-"informações que podem ajudá-lo a determinar o número de downloads desde a "
-"data de envio do extra para o AMO."
+msgid "The Statistics Dashboard found in the Developer Tools dashboard provides information that can help you determine your add-on downloads since you've submitted it to AMO."
+msgstr "O painel de estatísticas encontrado na página Meus extras oferece informações que podem ajudá-lo a determinar o número de downloads desde a data de envio do extra para o AMO."
 
 #: src/olympia/pages/templates/pages/dev_faq.html:455
 msgid "How can I see how many active users are using my add-on?"
-msgstr ""
-"Como posso ver quantos utilizadores ativos estão a utilizar o meu extra?"
+msgstr "Como posso ver quantos utilizadores ativos estão a utilizar o meu extra?"
 
 #: src/olympia/pages/templates/pages/dev_faq.html:457
 msgid ""
-"The Statistics Dashboard found in the Developer Tools dashboard provides "
-"information that can help you determine how many users have been actively "
-"using your add-on since you've submitted it to AMO."
+"The Statistics Dashboard found in the Developer Tools dashboard provides information that can help you determine how many users have been actively using your add-on since you've submitted it to AMO."
 msgstr ""
-"O painel de estatísticas disponível na página de Ferramentas do programador,"
-" fornece informações que podem ajudá-lo a determinar quantos utilizadores "
-"estão a utilizar o seu extra ativamente desde a data de envio do mesmo para "
-"o AMO."
+"O painel de estatísticas disponível na página de Ferramentas do programador, fornece informações que podem ajudá-lo a determinar quantos utilizadores estão a utilizar o seu extra ativamente desde a "
+"data de envio do mesmo para o AMO."
 
 #: src/olympia/pages/templates/pages/dev_faq.html:464
 msgid "How do I submit an update for my add-on?"
 msgstr "Como submeto uma atualização para o meu extra?"
 
 #: src/olympia/pages/templates/pages/dev_faq.html:466
-msgid ""
-"You can submit an update for your add-on via the Developer Tools dashboard "
-"by choosing the option \"Upload a new version\" and uploading a new .xpi "
-"file for your add-on."
-msgstr ""
-"Você pode enviar uma atualização do seu extra pela página \"Meus extras\" "
-"escolhendo a opção \"Enviar uma nova versão\" e enviando um novo arquivo "
-".xpi para o seu extra."
+msgid "You can submit an update for your add-on via the Developer Tools dashboard by choosing the option \"Upload a new version\" and uploading a new .xpi file for your add-on."
+msgstr "Você pode enviar uma atualização do seu extra pela página \"Meus extras\" escolhendo a opção \"Enviar uma nova versão\" e enviando um novo arquivo .xpi para o seu extra."
 
 #: src/olympia/pages/templates/pages/dev_faq.html:473
 msgid "Does my update need to be reviewed by editors?"
@@ -12822,50 +10172,32 @@ msgstr "A minha atualização precisa ser analisada pelos editores?"
 
 #: src/olympia/pages/templates/pages/dev_faq.html:475
 msgid ""
-"That depends. If you are simply changing a description of your add-on or "
-"updating a \"maxVersion\" to ensure compatibility with a new Mozilla "
-"software update, then your add-on does not need to be reviewed again. If, "
-"however, you submit a new updated file, then your add-on update will need to"
-" be reviewed by an editor."
+"That depends. If you are simply changing a description of your add-on or updating a \"maxVersion\" to ensure compatibility with a new Mozilla software update, then your add-on does not need to be "
+"reviewed again. If, however, you submit a new updated file, then your add-on update will need to be reviewed by an editor."
 msgstr ""
-"Depende. Se você estiver simplesmente alterando a descrição do seu extra ou "
-"atualizando a propriedade \"maxVersion\" para assegurar compatibilidade com "
-"novas versões das aplicações Mozilla, então seu extra não precisa ser "
-"analisado novamente. Entretanto, se você enviar um novo arquivo de "
-"atualização, então a atualização do seu extra deverá ser analisada por um "
-"editor."
+"Depende. Se você estiver simplesmente alterando a descrição do seu extra ou atualizando a propriedade \"maxVersion\" para assegurar compatibilidade com novas versões das aplicações Mozilla, então "
+"seu extra não precisa ser analisado novamente. Entretanto, se você enviar um novo arquivo de atualização, então a atualização do seu extra deverá ser analisada por um editor."
 
 #: src/olympia/pages/templates/pages/dev_faq.html:486
-msgid ""
-"How do I reply to a user who has posted a negative review of my add-on?"
-msgstr ""
-"Como eu posso responder a um utilizador que publicou uma análise negativa do"
-" meu extra?"
+msgid "How do I reply to a user who has posted a negative review of my add-on?"
+msgstr "Como eu posso responder a um utilizador que publicou uma análise negativa do meu extra?"
 
 #: src/olympia/pages/templates/pages/dev_faq.html:488
-msgid ""
-"A developer may reply to any review posted to their add-on as long as they "
-"are logged into AMO. In addition, any user can flag a review as:"
-msgstr ""
-"Um programador pode responder qualquer análise publicada para o seu extra "
-"desde que esteja identificado no AMO. Além disso, qualquer utilizador pode "
-"denunciar uma análise como:"
+msgid "A developer may reply to any review posted to their add-on as long as they are logged into AMO. In addition, any user can flag a review as:"
+msgstr "Um programador pode responder qualquer análise publicada para o seu extra desde que esteja identificado no AMO. Além disso, qualquer utilizador pode denunciar uma análise como:"
 
 #. part of a list (<li>)
-#: src/olympia/pages/templates/pages/dev_faq.html:495
-#: src/olympia/reviews/models.py:159
+#: src/olympia/pages/templates/pages/dev_faq.html:495 src/olympia/reviews/models.py:159
 msgid "Spam or otherwise non-review content"
 msgstr "Spam ou caso contrário conteúdo não revisto"
 
 #. part of a list (<li>)
-#: src/olympia/pages/templates/pages/dev_faq.html:497
-#: src/olympia/reviews/models.py:160
+#: src/olympia/pages/templates/pages/dev_faq.html:497 src/olympia/reviews/models.py:160
 msgid "Inappropriate language/dialog"
 msgstr "Idioma/diálogo inapropriado"
 
 #. part of a list (<li>)
-#: src/olympia/pages/templates/pages/dev_faq.html:499
-#: src/olympia/reviews/models.py:161
+#: src/olympia/pages/templates/pages/dev_faq.html:499 src/olympia/reviews/models.py:161
 msgid "Misplaced bug report or support request"
 msgstr "Relatório de erro mal colocado ou pedido de ajuda"
 
@@ -12875,130 +10207,72 @@ msgid "Other (provides a pop-up prompt for information)"
 msgstr "Outro (você poderá fornecer mais informações)"
 
 #: src/olympia/pages/templates/pages/dev_faq.html:504
-msgid ""
-"Currently, AMO does not provide a mechanism to directly communicate with a "
-"reviewer but this feature is being investigated and considered for a future "
-"update."
-msgstr ""
-"Atualmente o AMO não fornece um mecanismo de comunicação direta com o autor "
-"da análise, mas esse recurso está a ser considerado para uma atualização "
-"futura."
+msgid "Currently, AMO does not provide a mechanism to directly communicate with a reviewer but this feature is being investigated and considered for a future update."
+msgstr "Atualmente o AMO não fornece um mecanismo de comunicação direta com o autor da análise, mas esse recurso está a ser considerado para uma atualização futura."
 
 #: src/olympia/pages/templates/pages/dev_faq.html:511
 msgid "Can I request that a review be removed if the review is negative?"
-msgstr ""
-"Eu posso solicitar que uma análise seja removida caso ela seja negativa?"
+msgstr "Eu posso solicitar que uma análise seja removida caso ela seja negativa?"
 
 #: src/olympia/pages/templates/pages/dev_faq.html:513
-msgid ""
-"No. We do not remove negative reviews from add-ons unless they are found to "
-"be false."
-msgstr ""
-"Não. Nós não removemos análises negativas dos extras a menos que provem ser "
-"falsas."
+msgid "No. We do not remove negative reviews from add-ons unless they are found to be false."
+msgstr "Não. Nós não removemos análises negativas dos extras a menos que provem ser falsas."
 
 #: src/olympia/pages/templates/pages/dev_faq.html:519
 msgid "Can I request that a review be removed if the review is inaccurate?"
-msgstr ""
-"Eu posso solicitar que uma análise seja removida caso ela seja imprecisa?"
+msgstr "Eu posso solicitar que uma análise seja removida caso ela seja imprecisa?"
 
 #: src/olympia/pages/templates/pages/dev_faq.html:521
-msgid ""
-"If an author contacts us and asks for a review containing false or "
-"inaccurate information to be removed, we will review the post and consider "
-"removing it."
-msgstr ""
-"Se um autor entrar em contato conosco e pedir que uma análise contendo "
-"informações falsas ou imprecisas seja removida, nós analisaremos a postagem "
-"e consideraremos sua remoção."
+msgid "If an author contacts us and asks for a review containing false or inaccurate information to be removed, we will review the post and consider removing it."
+msgstr "Se um autor entrar em contato conosco e pedir que uma análise contendo informações falsas ou imprecisas seja removida, nós analisaremos a postagem e consideraremos sua remoção."
 
 #: src/olympia/pages/templates/pages/dev_faq.html:530
 msgid ""
-"Do you need more information about the various open source licenses? Are you"
-" confused as to which license you should select? What rights does a specific"
-" license grant? While nothing replaces reading the full terms of a license, "
-"below are some sites that contain information about some of the key open "
-"source licenses that may help you sort out the differences between them. "
-"These sites are being provided solely for your convenience and as a "
-"reference for your personal use. These resources do not constitute legal "
-"advice nor should they be used in lieu of such advice. Mozilla neither "
-"guarantees nor is responsible for the content of these sites or your "
-"reliance on such content."
+"Do you need more information about the various open source licenses? Are you confused as to which license you should select? What rights does a specific license grant? While nothing replaces "
+"reading the full terms of a license, below are some sites that contain information about some of the key open source licenses that may help you sort out the differences between them. These sites "
+"are being provided solely for your convenience and as a reference for your personal use. These resources do not constitute legal advice nor should they be used in lieu of such advice. Mozilla "
+"neither guarantees nor is responsible for the content of these sites or your reliance on such content."
 msgstr ""
-"Precisa de mais informação sobre os vários tipos de licença de código "
-"aberto? Não sabe qual a licença que deve escolher? Que direitos uma licença "
-"especifica garante? Apesar de nada substituir a leitura de todos os termos "
-"de uma licença, em baixo estão alguns sites que contêm informação sobre "
-"algumas das licenças chave de código aberto, que podem ajudar a encontrar as"
-" diferenças entre as várias licenças. Estes sites são fornecidos apenas para"
-" sua conveniência e como uma referência para uso pessoal. Estes recursos não"
-" constituem aconselhamento legal nem devem ser utilizados como substituto "
-"desse aconselhamento. A Mozilla não garante nem é responsável pelo conteúdo "
-"destes sites ou pela sua confiança neste conteúdo."
+"Precisa de mais informação sobre os vários tipos de licença de código aberto? Não sabe qual a licença que deve escolher? Que direitos uma licença especifica garante? Apesar de nada substituir a "
+"leitura de todos os termos de uma licença, em baixo estão alguns sites que contêm informação sobre algumas das licenças chave de código aberto, que podem ajudar a encontrar as diferenças entre as "
+"várias licenças. Estes sites são fornecidos apenas para sua conveniência e como uma referência para uso pessoal. Estes recursos não constituem aconselhamento legal nem devem ser utilizados como "
+"substituto desse aconselhamento. A Mozilla não garante nem é responsável pelo conteúdo destes sites ou pela sua confiança neste conteúdo."
 
 #: src/olympia/pages/templates/pages/dev_faq.html:545
 msgid ""
-"In addition to the full text of the Mozilla Public License(\"MPL\"), this "
-"also provides an annotated version of the MPL and an <abbr "
-"title=\"Frequently Asked Questions\">FAQ</abbr> to help you if you want to "
-"use or distribute code licensed under it."
+"In addition to the full text of the Mozilla Public License(\"MPL\"), this also provides an annotated version of the MPL and an <abbr title=\"Frequently Asked Questions\">FAQ</abbr> to help you if "
+"you want to use or distribute code licensed under it."
 msgstr ""
-"Além do texto integral da Licença Pública Mozilla (\"MLP\"), isso também "
-"oferece uma versão comentada da MPL e um <abbr title=\"Frequently Asked "
-"Questions\">FAQ</abbr> para ajudá-lo caso você queira usar ou distribuir "
-"código licenciado sob a MPL."
+"Além do texto integral da Licença Pública Mozilla (\"MLP\"), isso também oferece uma versão comentada da MPL e um <abbr title=\"Frequently Asked Questions\">FAQ</abbr> para ajudá-lo caso você "
+"queira usar ou distribuir código licenciado sob a MPL."
 
 #: src/olympia/pages/templates/pages/dev_faq.html:559
-msgid ""
-"A table summarizing and comparing how some of the key open source licenses "
-"treat distributions, proprietary software linking, and redistribution of "
-"code with changes."
-msgstr ""
-"Uma tabela resumindo e comparando a distribuição, vinculação de software "
-"proprietário e redistribuição de código com alterações de algumas das "
-"principais licenças de código aberto."
+msgid "A table summarizing and comparing how some of the key open source licenses treat distributions, proprietary software linking, and redistribution of code with changes."
+msgstr "Uma tabela resumindo e comparando a distribuição, vinculação de software proprietário e redistribuição de código com alterações de algumas das principais licenças de código aberto."
 
 #: src/olympia/pages/templates/pages/dev_faq.html:572
 msgid ""
-"Free Software Foundation provides short summaries of the key open source "
-"licenses, including whether the license qualifies as a free software license"
-" or a copyleft license.  Also includes a discussion of what constitutes a "
-"free software license or a copyleft license (e.g., a Copyleft license is a "
-"general method for making a program or other work free, and requiring all "
-"modified and extended versions of the program to be free as well.)"
+"Free Software Foundation provides short summaries of the key open source licenses, including whether the license qualifies as a free software license or a copyleft license. Also includes a "
+"discussion of what constitutes a free software license or a copyleft license (e.g., a Copyleft license is a general method for making a program or other work free, and requiring all modified and "
+"extended versions of the program to be free as well.)"
 msgstr ""
-"A Free Software Foundation fornece resumos curtos das licenças de código "
-"aberto chave, incluindo se a licença se qualifica como uma licença de "
-"software gratuito ou licença de permissão de cópia (copyleft). Também inclui"
-" uma discussão sobre o que constitui uma licença de software gratuito ou uma"
-" licença de permissão de cópia (por exemplo, uma licença de permissão de "
-"cópia é um método geral para tornar um programa ou outro trabalho gratuito e"
-" requerer que todas as versões modificadas ou estendidas do programa sejam "
-"também gratuitas.)"
+"A Free Software Foundation fornece resumos curtos das licenças de código aberto chave, incluindo se a licença se qualifica como uma licença de software gratuito ou licença de permissão de cópia "
+"(copyleft). Também inclui uma discussão sobre o que constitui uma licença de software gratuito ou uma licença de permissão de cópia (por exemplo, uma licença de permissão de cópia é um método geral "
+"para tornar um programa ou outro trabalho gratuito e requerer que todas as versões modificadas ou estendidas do programa sejam também gratuitas.)"
 
 #: src/olympia/pages/templates/pages/dev_faq.html:589
-msgid ""
-"Open Source Initiative provides the terms of some of the key open source "
-"licenses."
-msgstr ""
-"A Open Source Initiative fornece os termos de algumas das principais "
-"licenças de código aberto."
+msgid "Open Source Initiative provides the terms of some of the key open source licenses."
+msgstr "A Open Source Initiative fornece os termos de algumas das principais licenças de código aberto."
 
 #: src/olympia/pages/templates/pages/dev_faq.html:599
 msgid "A comparison of known open source licenses on Wikipedia."
 msgstr "Uma comparação de licenças de código aberto conhecidas na Wikipédia."
 
 #: src/olympia/pages/templates/pages/dev_faq.html:605
-msgid ""
-"A site to provide non-judgmental guidance on choosing a license for your "
-"open source project."
-msgstr ""
-"Um site para fornecer indicações sem juízos de valor sobre a escolha da "
-"licença para o seu projeto de código aberto."
+msgid "A site to provide non-judgmental guidance on choosing a license for your open source project."
+msgstr "Um site para fornecer indicações sem juízos de valor sobre a escolha da licença para o seu projeto de código aberto."
 
-#: src/olympia/pages/templates/pages/faq.html:3
-#: src/olympia/pages/templates/pages/faq.html:9
-#: src/olympia/pages/templates/pages/faq.html:10
+#: src/olympia/pages/templates/pages/faq.html:3 src/olympia/pages/templates/pages/faq.html:9 src/olympia/pages/templates/pages/faq.html:10
 msgid "Frequently Asked Questions"
 msgstr "Perguntas frequentes"
 
@@ -13013,19 +10287,11 @@ msgstr "O que é um extra?"
 #: src/olympia/pages/templates/pages/faq.html:16
 #, python-format
 msgid ""
-"Add-ons are small pieces of software that add new features or functionality "
-"to your installation of %(app_name)s. Add-ons can augment %(app_name)s with "
-"new features, foreign language dictionaries, or change its visual "
-"appearance. Through add-ons, you can customize %(app_name)s to meet your "
-"needs and tastes. <a href=\"%(learnmore_url)s\">Learn more about "
-"customization</a>"
+"Add-ons are small pieces of software that add new features or functionality to your installation of %(app_name)s. Add-ons can augment %(app_name)s with new features, foreign language dictionaries, "
+"or change its visual appearance. Through add-ons, you can customize %(app_name)s to meet your needs and tastes. <a href=\"%(learnmore_url)s\">Learn more about customization</a>"
 msgstr ""
-"Os extras são pequenos pedaços de software que adicionam novas "
-"funcionalidades à sua instalação do %(app_name)s. Os extras podem aumentar o"
-" %(app_name)s com novas funcionalidades, dicionários de idiomas estrangeiros"
-" ou alterar o visual. Através dos extras, pode personalizar o %(app_name)s "
-"conforme a sua necessidade e gosto. <a href=\"%(learnmore_url)s\">Saber mais"
-" sobre a personalização</a>"
+"Os extras são pequenos pedaços de software que adicionam novas funcionalidades à sua instalação do %(app_name)s. Os extras podem aumentar o %(app_name)s com novas funcionalidades, dicionários de "
+"idiomas estrangeiros ou alterar o visual. Através dos extras, pode personalizar o %(app_name)s conforme a sua necessidade e gosto. <a href=\"%(learnmore_url)s\">Saber mais sobre a personalização</a>"
 
 #: src/olympia/pages/templates/pages/faq.html:26
 msgid "Will add-ons work with my web browser or application?"
@@ -13034,25 +10300,13 @@ msgstr "Os extras funcionam com o meu navegador web ou aplicação?"
 #: src/olympia/pages/templates/pages/faq.html:27
 #, python-format
 msgid ""
-"Add-ons listed in this gallery only work with Mozilla-based applications, "
-"such as <a href=\"%(getfirefox_url)s\">Firefox</a>, <a "
-"href=\"%(getmobile_url)s\">Firefox Mobile</a>, <a "
-"href=\"%(getseamonkey_url)s\">SeaMonkey</a>, and <a "
-"href=\"%(getthunderbird_url)s\">Thunderbird</a>. However, not all add-ons "
-"work with each of those applications or every version of those applications."
-" Each add-on specifies which applications and versions it works with, such "
-"as Firefox 2.0 - 3.6.*. For Firefox add-ons, the install buttons will "
-"indicate whether the add-on is compatible or not."
+"Add-ons listed in this gallery only work with Mozilla-based applications, such as <a href=\"%(getfirefox_url)s\">Firefox</a>, <a href=\"%(getmobile_url)s\">Firefox Mobile</a>, <a href="
+"\"%(getseamonkey_url)s\">SeaMonkey</a>, and <a href=\"%(getthunderbird_url)s\">Thunderbird</a>. However, not all add-ons work with each of those applications or every version of those applications. "
+"Each add-on specifies which applications and versions it works with, such as Firefox 2.0 - 3.6.*. For Firefox add-ons, the install buttons will indicate whether the add-on is compatible or not."
 msgstr ""
-"Os extras listados nesta galeria apenas funcionam com aplicações baseados na"
-" Mozilla, tais como <a href=\"%(getfirefox_url)s\">Firefox</a>, <a "
-"href=\"%(getmobile_url)s\">Firefox Mobile</a>, <a "
-"href=\"%(getseamonkey_url)s\">SeaMonkey</a>, and <a "
-"href=\"%(getthunderbird_url)s\">Thunderbird</a>. No entanto, nem todos os "
-"extras funcionam com cada uma dessas aplicações ou em qualquer versão das "
-"mesmas. Cada extra especifica quais as aplicações com que funcionam, tipo "
-"Firefox 2.0 - 3.6.*. Para extras do Firefox, o botão instalar indica se é "
-"compatível ou não."
+"Os extras listados nesta galeria apenas funcionam com aplicações baseados na Mozilla, tais como <a href=\"%(getfirefox_url)s\">Firefox</a>, <a href=\"%(getmobile_url)s\">Firefox Mobile</a>, <a href="
+"\"%(getseamonkey_url)s\">SeaMonkey</a>, and <a href=\"%(getthunderbird_url)s\">Thunderbird</a>. No entanto, nem todos os extras funcionam com cada uma dessas aplicações ou em qualquer versão das "
+"mesmas. Cada extra especifica quais as aplicações com que funcionam, tipo Firefox 2.0 - 3.6.*. Para extras do Firefox, o botão instalar indica se é compatível ou não."
 
 #: src/olympia/pages/templates/pages/faq.html:42
 msgid "What are the different types of add-ons?"
@@ -13060,79 +10314,43 @@ msgstr "Quais são os diferentes tipos de extras?"
 
 #: src/olympia/pages/templates/pages/faq.html:43
 #, python-format
-msgid ""
-"There are several kinds of add-ons that customize %(app_name)s in different "
-"ways:"
-msgstr ""
-"Existem diversos tipos de extras que personalizam o %(app_name)s de "
-"diferentes maneiras:"
+msgid "There are several kinds of add-ons that customize %(app_name)s in different ways:"
+msgstr "Existem diversos tipos de extras que personalizam o %(app_name)s de diferentes maneiras:"
 
 #: src/olympia/pages/templates/pages/faq.html:47
 #, python-format
 msgid ""
-"<strong><a href=\"%(browse_url)s\">Extensions</a></strong> add new features "
-"to %(app_name)s or modify existing functionality. There are extensions that "
-"allow you to block advertisements, download videos from websites, integrate "
-"more closely with social websites, and add features you see in other "
-"applications."
+"<strong><a href=\"%(browse_url)s\">Extensions</a></strong> add new features to %(app_name)s or modify existing functionality. There are extensions that allow you to block advertisements, download "
+"videos from websites, integrate more closely with social websites, and add features you see in other applications."
 msgstr ""
-"<strong><a href=\"%(browse_url)s\">Extensões</a></strong> adicionam novas "
-"funcionalidades ao %(app_name)s ou modificam uma funcionalidade existente. "
-"Existem extensões que lhe permitem bloquear anúncios, descarregar vídeos de "
-"websites, integrar de uma melhor maneira os websites sociais e adicionar "
-"funcionalidades que vê noutras aplicações."
+"<strong><a href=\"%(browse_url)s\">Extensões</a></strong> adicionam novas funcionalidades ao %(app_name)s ou modificam uma funcionalidade existente. Existem extensões que lhe permitem bloquear "
+"anúncios, descarregar vídeos de websites, integrar de uma melhor maneira os websites sociais e adicionar funcionalidades que vê noutras aplicações."
 
 #: src/olympia/pages/templates/pages/faq.html:55
 #, python-format
-msgid ""
-"<strong><a href=\"%(browse_url)s\">Complete Themes</a></strong> change the "
-"entire appearance of %(app_name)s, usually including icons, colors, dialogs,"
-" and other visual styles."
-msgstr ""
-"Os <strong><a href=\"%(browse_url)s\">temas completos</a></strong> alteram "
-"completamente a aparência do %(app_name)s, o que geralmente inclui ícones, "
-"cores, janelas e outros estilos visuais."
+msgid "<strong><a href=\"%(browse_url)s\">Complete Themes</a></strong> change the entire appearance of %(app_name)s, usually including icons, colors, dialogs, and other visual styles."
+msgstr "Os <strong><a href=\"%(browse_url)s\">temas completos</a></strong> alteram completamente a aparência do %(app_name)s, o que geralmente inclui ícones, cores, janelas e outros estilos visuais."
 
 #: src/olympia/pages/templates/pages/faq.html:61
 #, python-format
-msgid ""
-"<strong><a href=\"%(browse_url)s\">Themes</a></strong> are lightweight "
-"themes that use background images to customize your %(app_name)s toolbars."
-msgstr ""
-"Os <strong><a href=\"%(browse_url)s\">temas</a></strong> são temas mais "
-"simples que utilizam imagens de fundo para personalizar as barras de "
-"ferramentas do seu %(app_name)s."
+msgid "<strong><a href=\"%(browse_url)s\">Themes</a></strong> are lightweight themes that use background images to customize your %(app_name)s toolbars."
+msgstr "Os <strong><a href=\"%(browse_url)s\">temas</a></strong> são temas mais simples que utilizam imagens de fundo para personalizar as barras de ferramentas do seu %(app_name)s."
 
 #: src/olympia/pages/templates/pages/faq.html:66
 #, python-format
-msgid ""
-"<strong><a href=\"%(browse_url)s\">Search Providers</a> </strong> add "
-"additional choices to the search box dropdown. These providers allow you to "
-"quickly search any website."
+msgid "<strong><a href=\"%(browse_url)s\">Search Providers</a> </strong> add additional choices to the search box dropdown. These providers allow you to quickly search any website."
 msgstr ""
-"<strong><a href=\"%(browse_url)s\">Fornecedores de pesquisa</a> </strong> "
-"adicionam escolhas adicionais à caixa de pesquisa. Estes fornecedores "
-"permitem-lhe uma pesquisa rápida a qualquer website."
+"<strong><a href=\"%(browse_url)s\">Fornecedores de pesquisa</a> </strong> adicionam escolhas adicionais à caixa de pesquisa. Estes fornecedores permitem-lhe uma pesquisa rápida a qualquer website."
 
 #: src/olympia/pages/templates/pages/faq.html:72
 #, python-format
-msgid ""
-"<strong><a href=\"%(browse_url)s\">Dictionaries & Language "
-"Packs</a></strong> add support for additional languages to %(app_name)s."
-msgstr ""
-"<strong><a href=\"%(browse_url)s\">Dicionários e Pacotes de "
-"idiomas</a></strong> adicionam ao %(app_name)s suporte a idiomas adicionais."
+msgid "<strong><a href=\"%(browse_url)s\">Dictionaries & Language Packs</a></strong> add support for additional languages to %(app_name)s."
+msgstr "<strong><a href=\"%(browse_url)s\">Dicionários e Pacotes de idiomas</a></strong> adicionam ao %(app_name)s suporte a idiomas adicionais."
 
 #: src/olympia/pages/templates/pages/faq.html:77
 #, python-format
-msgid ""
-"<strong><a href=\"%(browse_url)s\">Plugins</a></strong> help %(app_name)s "
-"display or understand different types of media, such as Adobe Flash or Apple"
-" Quicktime."
-msgstr ""
-"<strong><a href=\"%(browse_url)s\">Plugins</a></strong> ajudam o "
-"%(app_name)s a mostrar ou compreender diferentes tipos de média, tais como o"
-" Adobe Flash ou Apple Quicktime."
+msgid "<strong><a href=\"%(browse_url)s\">Plugins</a></strong> help %(app_name)s display or understand different types of media, such as Adobe Flash or Apple Quicktime."
+msgstr "<strong><a href=\"%(browse_url)s\">Plugins</a></strong> ajudam o %(app_name)s a mostrar ou compreender diferentes tipos de média, tais como o Adobe Flash ou Apple Quicktime."
 
 #: src/olympia/pages/templates/pages/faq.html:85
 msgid "How do I install, manage, or remove an add-on?"
@@ -13141,22 +10359,13 @@ msgstr "Como é que instalo, giro ou removo extras?"
 #: src/olympia/pages/templates/pages/faq.html:86
 #, python-format
 msgid ""
-"In most cases, add-ons can be installed by simply clicking the install "
-"button provided. Add-ons can be managed, disabled, or uninstalled from the "
-"Add-ons Manager in %(app_name)s. For more detailed instructions, read <a "
-"href=\"%(extension_url)s\">this article on extensions</a> or <a "
-"href=\"%(theme_url)s\">this one for Themes and Complete Themes</a>. If you "
-"have difficulty installing add-ons, see <a "
-"href=\"%(troubleshooting_url)s\">Troubleshooting Extensions and Themes</a>."
+"In most cases, add-ons can be installed by simply clicking the install button provided. Add-ons can be managed, disabled, or uninstalled from the Add-ons Manager in %(app_name)s. For more detailed "
+"instructions, read <a href=\"%(extension_url)s\">this article on extensions</a> or <a href=\"%(theme_url)s\">this one for Themes and Complete Themes</a>. If you have difficulty installing add-ons, "
+"see <a href=\"%(troubleshooting_url)s\">Troubleshooting Extensions and Themes</a>."
 msgstr ""
-"Na maioria dos casos, extras podem ser instalados simplesmente ao clicar no "
-"botão instalar fornecido. Os extras podem ser geridos, desativados ou "
-"removidos no gestor de extras do %(app_name)s. Para instruções mais "
-"detalhadas, leia <a href=\"%(extension_url)s\">este artigo sobre "
-"extensões</a> ou <a href=\"%(theme_url)s\">este para temas e temas "
-"completos</a>. Se tiver dificuldades a instalar extras, consulte <a "
-"href=\"%(troubleshooting_url)s\">resolver problemas com extensões e "
-"temas</a>."
+"Na maioria dos casos, extras podem ser instalados simplesmente ao clicar no botão instalar fornecido. Os extras podem ser geridos, desativados ou removidos no gestor de extras do %(app_name)s. Para "
+"instruções mais detalhadas, leia <a href=\"%(extension_url)s\">este artigo sobre extensões</a> ou <a href=\"%(theme_url)s\">este para temas e temas completos</a>. Se tiver dificuldades a instalar "
+"extras, consulte <a href=\"%(troubleshooting_url)s\">resolver problemas com extensões e temas</a>."
 
 #: src/olympia/pages/templates/pages/faq.html:100
 msgid "How do I install add-ons without restarting Firefox?"
@@ -13165,17 +10374,11 @@ msgstr "Como é que instalo extras sem reiniciar o Firefox?"
 #: src/olympia/pages/templates/pages/faq.html:101
 #, python-format
 msgid ""
-"In Firefox, add-ons marked with \"No restart required\" can be installed "
-"without restarting. These add-ons have been created using the <a "
-"href=\"%(sdk_url)s\">Add-on SDK</a> or <a "
-"href=\"%(bootstrap_url)s\">bootstrapping</a>. Other add-ons will still "
-"require a restart before you can use them."
+"In Firefox, add-ons marked with \"No restart required\" can be installed without restarting. These add-ons have been created using the <a href=\"%(sdk_url)s\">Add-on SDK</a> or <a href="
+"\"%(bootstrap_url)s\">bootstrapping</a>. Other add-ons will still require a restart before you can use them."
 msgstr ""
-"No Firefox, extras marcados com \"Não necessita de reiniciar\" podem ser "
-"instalados sem reiniciá-lo. Esses extras foram criados usando o <a "
-"href=\"%(sdk_url)s\">Add-on SDK</a> ou <a "
-"href=\"%(bootstrap_url)s\">bootstrapping</a>. Outros extras ainda requerem o"
-" reinício antes de poder usá-los."
+"No Firefox, extras marcados com \"Não necessita de reiniciar\" podem ser instalados sem reiniciá-lo. Esses extras foram criados usando o <a href=\"%(sdk_url)s\">Add-on SDK</a> ou <a href="
+"\"%(bootstrap_url)s\">bootstrapping</a>. Outros extras ainda requerem o reinício antes de poder usá-los."
 
 #: src/olympia/pages/templates/pages/faq.html:110
 msgid "How do I keep add-ons up-to-date?"
@@ -13184,22 +10387,13 @@ msgstr "Como mantenho os extras atualizados?"
 #: src/olympia/pages/templates/pages/faq.html:111
 #, python-format
 msgid ""
-"Add-ons, unlike plugins, are automatically checked for updates once every "
-"day. In Firefox, updates are automatically installed by default. Versions of"
-" Firefox prior to 4 (and other applications) will alert you that updates to "
-"your add-ons are available. <a href=\"%(plugin_url)s\">Plugins</a> are not "
-"currently automatically checked for updates, so be sure to regularly visit "
-"the <a href=\"%(plugincheck_url)s\">Plugin Check</a> page to stay up-to-"
-"date."
+"Add-ons, unlike plugins, are automatically checked for updates once every day. In Firefox, updates are automatically installed by default. Versions of Firefox prior to 4 (and other applications) "
+"will alert you that updates to your add-ons are available. <a href=\"%(plugin_url)s\">Plugins</a> are not currently automatically checked for updates, so be sure to regularly visit the <a href="
+"\"%(plugincheck_url)s\">Plugin Check</a> page to stay up-to-date."
 msgstr ""
-"Extras, diferentemente dos plugins, são verificados automaticamente à "
-"procura de atualizações uma vez por dia. No Firefox, as atualizações são "
-"instaladas automaticamente por padrão. Versões do Firefox a partir da versão"
-" 4 (e outras aplicações) alertarão quando houver atualizações disponíveis "
-"para seus extras. <a href=\"%(plugin_url)s\">Plugins</a> não são verificados"
-" automaticamente à procura de atualizações atualmente, então lembre-se de "
-"visitar regularmente a página <a href=\"%(plugincheck_url)s\">Verificação de"
-" plugins</a> para mantê-los atualizados."
+"Extras, diferentemente dos plugins, são verificados automaticamente à procura de atualizações uma vez por dia. No Firefox, as atualizações são instaladas automaticamente por padrão. Versões do "
+"Firefox a partir da versão 4 (e outras aplicações) alertarão quando houver atualizações disponíveis para seus extras. <a href=\"%(plugin_url)s\">Plugins</a> não são verificados automaticamente à "
+"procura de atualizações atualmente, então lembre-se de visitar regularmente a página <a href=\"%(plugincheck_url)s\">Verificação de plugins</a> para mantê-los atualizados."
 
 #: src/olympia/pages/templates/pages/faq.html:122
 msgid "Are add-ons safe to install?"
@@ -13208,21 +10402,13 @@ msgstr "É seguro instalar extras?"
 #: src/olympia/pages/templates/pages/faq.html:123
 #, python-format
 msgid ""
-"Unless clearly marked otherwise, add-ons available from this gallery have "
-"been checked and approved by Mozilla's team of editors and are safe to "
-"install. We recommend that you only install approved add-ons. If you wish to"
-" install unapproved add-ons or add-ons from third-party websites, use "
-"caution as these add-ons may harm your computer or violate your privacy. <a "
-"href=\"%(learnmore_url)s\">Learn more about our approval process</a>"
+"Unless clearly marked otherwise, add-ons available from this gallery have been checked and approved by Mozilla's team of editors and are safe to install. We recommend that you only install approved "
+"add-ons. If you wish to install unapproved add-ons or add-ons from third-party websites, use caution as these add-ons may harm your computer or violate your privacy. <a href=\"%(learnmore_url)s"
+"\">Learn more about our approval process</a>"
 msgstr ""
-"A menos que seja claramente indicado o contrário, os extras presentes nesta "
-"galeria foram verificados e aprovados pela equipa de editores da Mozilla e a"
-" sua instalação é considerada segura. Recomendamos que instale apenas extras"
-" que tenham sido aprovados. Se desejar instalar extras não aprovados a "
-"partir de outros websites, tenha cuidado pois estes extras podem danificar o"
-" seu computador ou violar a sua privacidade. <a "
-"href=\"%(learnmore_url)s\">Saiba mais sobre o nosso processo de "
-"aprovação</a>"
+"A menos que seja claramente indicado o contrário, os extras presentes nesta galeria foram verificados e aprovados pela equipa de editores da Mozilla e a sua instalação é considerada segura. "
+"Recomendamos que instale apenas extras que tenham sido aprovados. Se desejar instalar extras não aprovados a partir de outros websites, tenha cuidado pois estes extras podem danificar o seu "
+"computador ou violar a sua privacidade. <a href=\"%(learnmore_url)s\">Saiba mais sobre o nosso processo de aprovação</a>"
 
 #: src/olympia/pages/templates/pages/faq.html:133
 #, python-format
@@ -13232,47 +10418,28 @@ msgstr "Os extras podem tornar o %(app_name)s mais lento?"
 #: src/olympia/pages/templates/pages/faq.html:135
 #, python-format
 msgid ""
-"Most add-ons do not cause a perceivable performance decrease in "
-"%(app_name)s, though installing an excessive number may have adverse "
-"effects. If you suspect an add-on is causing %(app_name)s to be slow, try "
-"disabling it."
+"Most add-ons do not cause a perceivable performance decrease in %(app_name)s, though installing an excessive number may have adverse effects. If you suspect an add-on is causing %(app_name)s to be "
+"slow, try disabling it."
 msgstr ""
-"A maioria dos extras não causam uma diminuição no desempenho percetível no "
-"%(app_name)s, no entanto instalar um número excessivo poderá ter efeitos "
-"adversos. Se suspeita que um extra está a causar lentidão no %(app_name)s, "
-"tente desativá-lo."
+"A maioria dos extras não causam uma diminuição no desempenho percetível no %(app_name)s, no entanto instalar um número excessivo poderá ter efeitos adversos. Se suspeita que um extra está a causar "
+"lentidão no %(app_name)s, tente desativá-lo."
 
 #: src/olympia/pages/templates/pages/faq.html:141
 #, python-format
-msgid ""
-"%(app_name)s told me an add-on isn't compatible. Is there a way I can still "
-"use it?"
-msgstr ""
-"%(app_name)s informou-me que um extra não é compatível. Existe alguma "
-"maneira para mesmo assim o utilizar?"
+msgid "%(app_name)s told me an add-on isn't compatible. Is there a way I can still use it?"
+msgstr "%(app_name)s informou-me que um extra não é compatível. Existe alguma maneira para mesmo assim o utilizar?"
 
 #: src/olympia/pages/templates/pages/faq.html:144
 #, python-format
 msgid ""
-"If an add-on isn't compatible with your version of %(app_name)s, it is "
-"usually either because your version of %(app_name)s is outdated or the add-"
-"on author has not yet updated the add-on to be compatible with a newer "
-"version you are using. Mozilla does not recommend trying to circumvent these"
-" compatibility checks, as they can lead to browser instability or in some "
-"cases loss of data. For users who are testing out alpha or beta versions of "
-"Firefox, we offer the <a href=\"%(acr_url)s\">Add-on Compatibility "
-"Reporter</a> to help add-on developers update their compatibility."
+"If an add-on isn't compatible with your version of %(app_name)s, it is usually either because your version of %(app_name)s is outdated or the add-on author has not yet updated the add-on to be "
+"compatible with a newer version you are using. Mozilla does not recommend trying to circumvent these compatibility checks, as they can lead to browser instability or in some cases loss of data. For "
+"users who are testing out alpha or beta versions of Firefox, we offer the <a href=\"%(acr_url)s\">Add-on Compatibility Reporter</a> to help add-on developers update their compatibility."
 msgstr ""
-"Se um extra não for compatível com a sua versão do %(app_name)s, isto "
-"geralmente acontece devido ou à sua versão do %(app_name)s estar "
-"desatualizada ou pelo facto do autor do extra ainda não ter atualizado o "
-"extra para ser compatível com a versão mais recente que está a usar. A "
-"Mozilla não recomenda tentar ultrapassar estas verificações de "
-"compatibilidade, pois podem levar à instabilidade do navegador e em alguns "
-"casos à perda de dados. Para utilizadores que estejam a testar versões alfa "
-"ou beta do Firefox, oferecemos o <a href=\"%(acr_url)s\">relator de "
-"compatibilidade de extras</a> para ajudar os programadores a atualizar a "
-"compatibilidade dos seus extras."
+"Se um extra não for compatível com a sua versão do %(app_name)s, isto geralmente acontece devido ou à sua versão do %(app_name)s estar desatualizada ou pelo facto do autor do extra ainda não ter "
+"atualizado o extra para ser compatível com a versão mais recente que está a usar. A Mozilla não recomenda tentar ultrapassar estas verificações de compatibilidade, pois podem levar à instabilidade "
+"do navegador e em alguns casos à perda de dados. Para utilizadores que estejam a testar versões alfa ou beta do Firefox, oferecemos o <a href=\"%(acr_url)s\">relator de compatibilidade de extras</"
+"a> para ajudar os programadores a atualizar a compatibilidade dos seus extras."
 
 #: src/olympia/pages/templates/pages/faq.html:156
 msgid "What if I have problems with an add-on?"
@@ -13281,40 +10448,28 @@ msgstr "O que acontece se tiver problemas com um extra?"
 #: src/olympia/pages/templates/pages/faq.html:157
 #, python-format
 msgid ""
-"Add-ons are usually created by third-party developers from around the world,"
-" so the best way to get help with an add-on is to look for support links on "
-"the add-on's homepage or contact the developer. If you are having issues "
-"with %(app_name)s that you suspect are related to add-ons you have "
-"installed, <a href=\"%(troubleshooting_url)s\">visit this support "
-"article</a> for troubleshooting tips."
+"Add-ons are usually created by third-party developers from around the world, so the best way to get help with an add-on is to look for support links on the add-on's homepage or contact the "
+"developer. If you are having issues with %(app_name)s that you suspect are related to add-ons you have installed, <a href=\"%(troubleshooting_url)s\">visit this support article</a> for "
+"troubleshooting tips."
 msgstr ""
-"Os extras são normalmente criados por programadores de todo o mundo, por "
-"isso a melhor maneira de obter ajuda com um extra é procurando ligações de "
-"apoio na página inicial do extra ou então contactar o programador. Se "
-"estiver a ter problemas com o %(app_name)s que suspeite terem origem em "
-"extras que tenha instalado, <a href=\"%(troubleshooting_url)s\">visite o "
-"artigo de apoio</a> para dicas de resolução de problemas."
+"Os extras são normalmente criados por programadores de todo o mundo, por isso a melhor maneira de obter ajuda com um extra é procurando ligações de apoio na página inicial do extra ou então "
+"contactar o programador. Se estiver a ter problemas com o %(app_name)s que suspeite terem origem em extras que tenha instalado, <a href=\"%(troubleshooting_url)s\">visite o artigo de apoio</a> para "
+"dicas de resolução de problemas."
 
 #: src/olympia/pages/templates/pages/faq.html:169
 msgid "Add-on Gallery"
 msgstr "Galeria de extras"
 
 #: src/olympia/pages/templates/pages/faq.html:171
-msgid ""
-"How do I choose between add-ons that seem to do the same\n"
-"    thing?"
+msgid "How do I choose between add-ons that seem to do the same thing?"
 msgstr ""
 "Como escolho entre extras que parecem fazer a mesma\n"
 "    coisa?"
 
-#: src/olympia/pages/templates/pages/faq.html:173
+#: src/olympia/pages/templates/pages/faq.html:172
 msgid ""
-"There are often several add-ons that have similar features. To\n"
-"    figure out which is right for you, read the entire description of the\n"
-"    add-on and view its screenshots. If there are still several in the running,\n"
-"    read through the add-on's ratings, user reviews, and statistics to see\n"
-"    which is most liked by other users. Remember that you can also just try\n"
-"    out both and see which you like better."
+"There are often several add-ons that have similar features. To figure out which is right for you, read the entire description of the add-on and view its screenshots. If there are still several in "
+"the running, read through the add-on's ratings, user reviews, and statistics to see which is most liked by other users. Remember that you can also just try out both and see which you like better."
 msgstr ""
 "Existem frequentemente vários extras que têm funcionalidades similares. Para\n"
 "    descobrir qual é o certo para si, leia a descrição na integra do\n"
@@ -13330,36 +10485,24 @@ msgstr "E se não conseguir encontra o extra que procuro?"
 #: src/olympia/pages/templates/pages/faq.html:181
 #, python-format
 msgid ""
-"With thousands of add-ons available, there's something for everyone. But if "
-"you're looking for a particular add-on and can't find it, you might try "
-"searching on other sites or posting about it in our <a href=\"%(forum_url)s"
-"\">Add-ons </a>forum."
+"With thousands of add-ons available, there's something for everyone. But if you're looking for a particular add-on and can't find it, you might try searching on other sites or posting about it in "
+"our <a href=\"%(forum_url)s\">Add-ons </a>forum."
 msgstr ""
-"Com milhares de extras disponíveis, existe sempre algo para toda a gente. "
-"Mas se está à procura de um extra específico e não o consegue encontrar, "
-"pode tentar procurar em outros sites ou fazer uma entrada no nosso fórum de "
-"<a href=\"%(forum_url)s\">Extras</a>."
+"Com milhares de extras disponíveis, existe sempre algo para toda a gente. Mas se está à procura de um extra específico e não o consegue encontrar, pode tentar procurar em outros sites ou fazer uma "
+"entrada no nosso fórum de <a href=\"%(forum_url)s\">Extras</a>."
 
 #: src/olympia/pages/templates/pages/faq.html:187
-msgid ""
-"What does it mean if an add-on is \"experimental\" or \"preliminarily "
-"reviewed\"?"
+msgid "What does it mean if an add-on is \"experimental\" or \"preliminarily reviewed\"?"
 msgstr "O que significa um extra ser \"experimental\" ou \"preliminarmente revisto\"?"
 
 #: src/olympia/pages/templates/pages/faq.html:188
 #, python-format
 msgid ""
-"Experimental add-ons have been checked by our editors to make sure they "
-"don't have security problems, but they may still have bugs or not work "
-"properly. Use caution when installing experimental add-ons and uninstall the"
-" add-on immediately if you notice problems. <a href=\"%(url)s\">Learn more "
-"about our review process</a></dd>"
+"Experimental add-ons have been checked by our editors to make sure they don't have security problems, but they may still have bugs or not work properly. Use caution when installing experimental add-"
+"ons and uninstall the add-on immediately if you notice problems. <a href=\"%(url)s\">Learn more about our review process</a></dd>"
 msgstr ""
-"Extras experimentais foram verificados pelos nossos editores para se "
-"certificarem de que não têm problemas de segurança, mas eles podem ainda ter"
-" erros ou não funcionar corretamente. Tenha cuidado ao instalar extras "
-"experimentais e desinstale o extra imediatamente se notar problemas. <a "
-"href=\"%(url)s\">Saiba mais sobre o processo de revisão</a></dd>"
+"Extras experimentais foram verificados pelos nossos editores para se certificarem de que não têm problemas de segurança, mas eles podem ainda ter erros ou não funcionar corretamente. Tenha cuidado "
+"ao instalar extras experimentais e desinstale o extra imediatamente se notar problemas. <a href=\"%(url)s\">Saiba mais sobre o processo de revisão</a></dd>"
 
 #: src/olympia/pages/templates/pages/faq.html:196
 msgid "What does it mean if an add-on is \"not reviewed\"?"
@@ -13368,264 +10511,198 @@ msgstr "Qual o significado de um extra \"não revisto\"?"
 #: src/olympia/pages/templates/pages/faq.html:197
 #, python-format
 msgid ""
-"While all add-ons publicly available in our gallery are reviewed by an "
-"editor, you may receive a direct link to an add-on that hasn't yet been "
-"reviewed. Use caution when installing these add-ons, as they could harm your"
-" computer or violate your privacy. We recommend that you only install "
-"reviewed add-ons. <a href=\"%(url)s\">Learn more about our review "
-"process</a></dd>"
+"While all add-ons publicly available in our gallery are reviewed by an editor, you may receive a direct link to an add-on that hasn't yet been reviewed. Use caution when installing these add-ons, "
+"as they could harm your computer or violate your privacy. We recommend that you only install reviewed add-ons. <a href=\"%(url)s\">Learn more about our review process</a></dd>"
 msgstr ""
-"Embora todos os extras disponíveis publicamente na nossa galeria são "
-"revistos por um editor, poderá receber uma ligação direta para um extra que "
-"ainda não foi revisto. Tenha cuidado ao instalar estes extras, pois eles "
-"podem danificar o seu computador ou violar sua privacidade. Recomendamos que"
-" você instale apenas extras revistos. <a href=\"%(url)s\">Saiba mais sobre o"
-" nosso processo de revisão</a></dd>"
+"Embora todos os extras disponíveis publicamente na nossa galeria são revistos por um editor, poderá receber uma ligação direta para um extra que ainda não foi revisto. Tenha cuidado ao instalar "
+"estes extras, pois eles podem danificar o seu computador ou violar sua privacidade. Recomendamos que você instale apenas extras revistos. <a href=\"%(url)s\">Saiba mais sobre o nosso processo de "
+"revisão</a></dd>"
 
 #: src/olympia/pages/templates/pages/faq.html:206
 msgid "How much do add-ons cost to purchase?"
 msgstr "Quanto custam os extras?"
 
 #: src/olympia/pages/templates/pages/faq.html:207
-msgid ""
-"Add-ons hosted in our gallery are free unless clearly marked\n"
-"    otherwise."
+msgid "Add-ons hosted in our gallery are free unless clearly marked otherwise."
 msgstr ""
 "Os extras hospedados na nossa galeria são gratuitos salvo indicação\n"
 "    contrária."
 
-#: src/olympia/pages/templates/pages/faq.html:210
+#: src/olympia/pages/templates/pages/faq.html:209
 msgid "What does it mean when an add-on asks for contributions?"
 msgstr "O que significa quando um extra pede contribuições?"
 
-#: src/olympia/pages/templates/pages/faq.html:211
+#: src/olympia/pages/templates/pages/faq.html:210
 msgid ""
-"Some add-on authors request users who enjoy an add-on to\n"
-"        contribute to its development by making a monetary contribution. These\n"
-"        contributions go directly to the developer unless a third party is\n"
-"        indicated, such as the non-profit Mozilla Foundation."
+"Some add-on authors request users who enjoy an add-on to contribute to its development by making a monetary contribution. These contributions go directly to the developer unless a third party is "
+"indicated, such as the non-profit Mozilla Foundation."
 msgstr ""
 "Alguns autores de extras solicitam aos utilizadores que desfrutam de um extra para\n"
 "        contribuírem ao seu seu desenvolvimento fazendo uma contribuição monetária. Estas\n"
 "        contribuições vão diretamente para o programador a menos que um terceiro seja\n"
 "        indicado, como a Fundação Mozilla sem fins lucrativos."
 
-#: src/olympia/pages/templates/pages/faq.html:216
+#: src/olympia/pages/templates/pages/faq.html:215
 msgid "What are beta add-ons?"
 msgstr "O que são extras beta?"
 
-#: src/olympia/pages/templates/pages/faq.html:218
+#: src/olympia/pages/templates/pages/faq.html:217
 msgid ""
-"Beta add-ons are unreviewed versions which represent the\n"
-"        latest work of an add-on author. While different authors have different\n"
-"        standards for beta code quality, you should assume that these add-ons\n"
-"        are less stable than the general add-on releases."
+"Beta add-ons are unreviewed versions which represent the latest work of an add-on author. While different authors have different standards for beta code quality, you should assume that these add-"
+"ons are less stable than the general add-on releases."
 msgstr ""
 "Extras em beta são versões não revistas que representam o\n"
 "        último trabalho de um autor de extras. Embora diferentes autores têm diferentes\n"
 "        padrões para a qualidade do código beta, deve assumir que esses extras\n"
 "        são menos estáveis que os lançamentos de extras gerais."
 
-#: src/olympia/pages/templates/pages/faq.html:222
+#: src/olympia/pages/templates/pages/faq.html:221
 msgid ""
-"Please note that when you install an add-on from the \"Beta Version\" "
-"section of an add-on's listing, you will continue to receive updates for "
-"that add-on as they become available. Like the initial version you "
-"installed, all beta releases are unreviewed by Mozilla and may harm your "
-"computer."
+"Please note that when you install an add-on from the \"Beta Version\" section of an add-on's listing, you will continue to receive updates for that add-on as they become available. Like the initial "
+"version you installed, all beta releases are unreviewed by Mozilla and may harm your computer."
 msgstr ""
-"Tenha em atenção que quando instala extras da secção \"versão Beta\" de uma "
-"listagem de extras, continua a receber atualizações assim que estejam "
-"disponíveis. Tal como a versão que instalou, todos os lançamentos beta não "
-"são revistos pela Mozilla e podem danificar o seu computador."
+"Tenha em atenção que quando instala extras da secção \"versão Beta\" de uma listagem de extras, continua a receber atualizações assim que estejam disponíveis. Tal como a versão que instalou, todos "
+"os lançamentos beta não são revistos pela Mozilla e podem danificar o seu computador."
 
-#: src/olympia/pages/templates/pages/faq.html:229
-msgid ""
-"What does it mean when an add-on is flagged as\n"
-"    slow?"
+#: src/olympia/pages/templates/pages/faq.html:228
+msgid "What does it mean when an add-on is flagged as slow?"
 msgstr ""
 "O que significa quando um extra é sinalizado como\n"
 "    lento?"
 
-#: src/olympia/pages/templates/pages/faq.html:231
-msgid ""
-"Most add-ons load code and resources at the same time Firefox\n"
-"        is starting up. In most cases the impact in start-up time is minimal,\n"
-"        but some add-ons can cause a noticeable slowdown."
+#: src/olympia/pages/templates/pages/faq.html:229
+msgid "Most add-ons load code and resources at the same time Firefox is starting up. In most cases the impact in start-up time is minimal, but some add-ons can cause a noticeable slowdown."
 msgstr ""
 "A maioria dos extras carrega código e recursos ao mesmo tempo que o Firefox\n"
 "        está a arrancar. Na maioria dos casos o impacto no tempo de arranque é mínimo,\n"
 "        mas alguns extras podem causar uma lentidão percetível."
 
-#: src/olympia/pages/templates/pages/faq.html:236
+#: src/olympia/pages/templates/pages/faq.html:234
 msgid "How do I report an inappropriate or spam user review?"
-msgstr ""
-"Como é que reporto uma revisão de um utilizador inapropriada ou de spam?"
+msgstr "Como é que reporto uma revisão de um utilizador inapropriada ou de spam?"
 
-#: src/olympia/pages/templates/pages/faq.html:237
+#: src/olympia/pages/templates/pages/faq.html:235
 msgid ""
-"To report a user review of an add-on, log in with your account\n"
-"    and visit the add-on's reviews page. Find the review you wish to report,\n"
-"    click \"Report this review\" and select a reason. Our editorial team will\n"
-"    investigate the review and take appropriate action."
+"To report a user review of an add-on, log in with your account and visit the add-on's reviews page. Find the review you wish to report, click \"Report this review\" and select a reason. Our "
+"editorial team will investigate the review and take appropriate action."
 msgstr ""
 "Para reportar uma revisão de utilizador de um extra, inicie sessão com a sua conta\n"
 "    e visite a página de revisões do extra. Encontre a revisão que pretende reportar,\n"
 "    clique \"Reportar esta revisão\" e selecione uma razão. A nossa equipa editorial irá\n"
 "    investigar a revisão e tomar a ação apropriada."
 
-#: src/olympia/pages/templates/pages/faq.html:242
+#: src/olympia/pages/templates/pages/faq.html:240
 msgid "How do I report a bug or contact the Mozilla Add-ons team?"
 msgstr "Como é que reporto um bug ou contacto a equipa dos extras da Mozilla?"
 
-#: src/olympia/pages/templates/pages/faq.html:243
+#: src/olympia/pages/templates/pages/faq.html:241
 #, python-format
 msgid "Please visit our <a href=\"%(contact_url)s\">Contact page</a>."
-msgstr ""
-"Por favor visite a nossa <a href=\"%(contact_url)s\">página de contacto</a>."
+msgstr "Por favor visite a nossa <a href=\"%(contact_url)s\">página de contacto</a>."
 
-#: src/olympia/pages/templates/pages/faq.html:246
+#: src/olympia/pages/templates/pages/faq.html:244
 msgid "What is a Source Code License?"
 msgstr "O que é uma licença de código fonte?"
 
-#: src/olympia/pages/templates/pages/faq.html:247
+#: src/olympia/pages/templates/pages/faq.html:245
 #, python-format
 msgid ""
-"The source code used to create an add-on is an exclusive copyright of the "
-"add-on author, unless otherwise declared in a source code license. Many add-"
-"ons on this site have <a href=\"%(url)s\" lang=\"en\">open source "
-"licenses</a> that make the source code publicly available for copy and reuse"
-" under conditions determined by the author. Most authors choose widely known"
-" open source licenses like the GPL or BSD licenses instead of making up "
-"their own."
+"The source code used to create an add-on is an exclusive copyright of the add-on author, unless otherwise declared in a source code license. Many add-ons on this site have <a href=\"%(url)s\" lang="
+"\"en\">open source licenses</a> that make the source code publicly available for copy and reuse under conditions determined by the author. Most authors choose widely known open source licenses like "
+"the GPL or BSD licenses instead of making up their own."
 msgstr ""
-"O código fonte usado para criar um extra é um direito registado e exclusivo "
-"do autor do extra, a menos que indicado na licença do código fonte. Muitos "
-"extras deste site têm <a href=\"%(url)s\" lang=\"en\">licenças de código "
-"aberto</a> que fazem com que o código fonte esteja disponível para copiar e "
-"reutilizar sob condições determinadas pelo autor. Muitos autores escolhem "
-"licenças de código aberto muito conhecidas como as licenças GPL ou BSD em "
-"vez de fazerem a sua própria licença."
+"O código fonte usado para criar um extra é um direito registado e exclusivo do autor do extra, a menos que indicado na licença do código fonte. Muitos extras deste site têm <a href=\"%(url)s\" lang="
+"\"en\">licenças de código aberto</a> que fazem com que o código fonte esteja disponível para copiar e reutilizar sob condições determinadas pelo autor. Muitos autores escolhem licenças de código "
+"aberto muito conhecidas como as licenças GPL ou BSD em vez de fazerem a sua própria licença."
 
-#: src/olympia/pages/templates/pages/faq.html:256
+#: src/olympia/pages/templates/pages/faq.html:254
 #, python-format
-msgid ""
-"Firefox and other Mozilla software are <a href=\"%(url)s\">open source</a>."
-msgstr ""
-"O Firefox e outro software da Mozilla são de <a href=\"%(url)s\">código "
-"aberto</a>."
+msgid "Firefox and other Mozilla software are <a href=\"%(url)s\">open source</a>."
+msgstr "O Firefox e outro software da Mozilla são de <a href=\"%(url)s\">código aberto</a>."
 
-#: src/olympia/pages/templates/pages/faq.html:264
+#: src/olympia/pages/templates/pages/faq.html:262
 msgid "Collections and Favorites"
 msgstr "Coleções e favoritos"
 
-#: src/olympia/pages/templates/pages/faq.html:267
+#: src/olympia/pages/templates/pages/faq.html:265
 msgid "What is a collection?"
 msgstr "O que é uma coleção?"
 
-#: src/olympia/pages/templates/pages/faq.html:268
+#: src/olympia/pages/templates/pages/faq.html:266
 msgid "Collections are groups of related add-ons created by users to share."
-msgstr ""
-"As coleções são grupos de extras criados pelos utilizadores para partilha."
+msgstr "As coleções são grupos de extras criados pelos utilizadores para partilha."
 
-#: src/olympia/pages/templates/pages/faq.html:270
+#: src/olympia/pages/templates/pages/faq.html:268
 msgid "What is the My Favorites collection?"
 msgstr "Qual é a minha coleção favorita?"
 
-#: src/olympia/pages/templates/pages/faq.html:271
-msgid ""
-"Favorite add-ons are add-ons that you have bookmarked to easily get back to "
-"later. You can add an add-on to your favorites collection by clicking \"Add "
-"to favorites\" on its details page."
+#: src/olympia/pages/templates/pages/faq.html:269
+msgid "Favorite add-ons are add-ons that you have bookmarked to easily get back to later. You can add an add-on to your favorites collection by clicking \"Add to favorites\" on its details page."
 msgstr ""
-"Extras favoritos são extras que adicionou aos marcadores para voltar "
-"facilmente mais tarde. Pode adicionar um extra à sua coleção de favoritos "
-"clicando em \"Adicionar aos favoritos\" na página de detalhes."
+"Extras favoritos são extras que adicionou aos marcadores para voltar facilmente mais tarde. Pode adicionar um extra à sua coleção de favoritos clicando em \"Adicionar aos favoritos\" na página de "
+"detalhes."
 
-#: src/olympia/pages/templates/pages/faq.html:275
-#: src/olympia/templates/menu_links.html:13
-#: src/olympia/templates/impala/header_title.html:17
+#: src/olympia/pages/templates/pages/faq.html:273 src/olympia/templates/menu_links.html:13 src/olympia/templates/impala/header_title.html:17
 msgid "Mobile Add-ons"
 msgstr "Extras do Mobile"
 
-#: src/olympia/pages/templates/pages/faq.html:278
+#: src/olympia/pages/templates/pages/faq.html:276
 msgid "What are mobile add-ons?"
 msgstr "O que são extras móveis?"
 
-#: src/olympia/pages/templates/pages/faq.html:279
+#: src/olympia/pages/templates/pages/faq.html:277
 #, python-format
 msgid ""
-"Mobile add-ons work with <a href=\"%(mobile_url)s\">Firefox for Mobile</a> "
-"and add or modify functionality just like desktop add-ons. You can find add-"
-"ons that work with Firefox for Mobile in our <a "
-"href=\"%(gallery_url)s\">gallery</a>."
+"Mobile add-ons work with <a href=\"%(mobile_url)s\">Firefox for Mobile</a> and add or modify functionality just like desktop add-ons. You can find add-ons that work with Firefox for Mobile in our "
+"<a href=\"%(gallery_url)s\">gallery</a>."
 msgstr ""
-"Os extras do Mobile funcionam com o <a href=\"%(mobile_url)s\">Firefox para "
-"o Mobile</a> e adicionam ou modificam funcionalidades tal como os extras do "
-"computador de secretária. Pode encontrar extras que funcionam com o Firefox "
-"para Mobile na nossa <a href=\"%(gallery_url)s\">galeria</a>."
+"Os extras do Mobile funcionam com o <a href=\"%(mobile_url)s\">Firefox para o Mobile</a> e adicionam ou modificam funcionalidades tal como os extras do computador de secretária. Pode encontrar "
+"extras que funcionam com o Firefox para Mobile na nossa <a href=\"%(gallery_url)s\">galeria</a>."
 
-#: src/olympia/pages/templates/pages/faq.html:288
+#: src/olympia/pages/templates/pages/faq.html:286
 msgid "Developer Topics"
 msgstr "Tópicos do programador"
 
-#: src/olympia/pages/templates/pages/faq.html:289
+#: src/olympia/pages/templates/pages/faq.html:287
 #, python-format
-msgid ""
-"Please see our <a href=\"%(faq_url)s\">Developer FAQ</a> and <a "
-"href=\"%(hub_url)s\">Developer Hub</a> for answers to add-on developer-"
-"related questions."
+msgid "Please see our <a href=\"%(faq_url)s\">Developer FAQ</a> and <a href=\"%(hub_url)s\">Developer Hub</a> for answers to add-on developer-related questions."
 msgstr ""
-"Por favor consulte a nossa <a href=\"%(faq_url)s\">FAQ do programador</a> e "
-"a <a href=\"%(hub_url)s\">Central do programador</a> para respostas a "
-"questões relacionadas com o desenvolvimento de extras."
+"Por favor consulte a nossa <a href=\"%(faq_url)s\">FAQ do programador</a> e a <a href=\"%(hub_url)s\">Central do programador</a> para respostas a questões relacionadas com o desenvolvimento de "
+"extras."
 
-#: src/olympia/pages/templates/pages/faq.html:294
+#: src/olympia/pages/templates/pages/faq.html:292
 msgid "Still have questions?"
 msgstr "Ainda tem perguntas?"
 
-#: src/olympia/pages/templates/pages/faq.html:295
+#: src/olympia/pages/templates/pages/faq.html:293
 #, python-format
-msgid ""
-"For general Firefox support, visit our <a href=\"%(sumo_url)s\">support "
-"website</a>. For general add-on and website questions, visit our <a "
-"href=\"%(forum_url)s\">forum</a>."
+msgid "For general Firefox support, visit our <a href=\"%(sumo_url)s\">support website</a>. For general add-on and website questions, visit our <a href=\"%(forum_url)s\">forum</a>."
 msgstr ""
-"Para ajuda geral do Firefox, visite o nosso <a href=\"%(sumo_url)s\">website"
-" de apoio</a>. Para questões gerais sobre extras ou sobre o website, visite "
-"o nosso <a href=\"%(forum_url)s\">fórum</a>."
+"Para ajuda geral do Firefox, visite o nosso <a href=\"%(sumo_url)s\">website de apoio</a>. Para questões gerais sobre extras ou sobre o website, visite o nosso <a href=\"%(forum_url)s\">fórum</a>."
 
-#: src/olympia/pages/templates/pages/review_guide.html:36
-#: src/olympia/pages/templates/pages/review_guide.html:51
+#: src/olympia/pages/templates/pages/review_guide.html:36 src/olympia/pages/templates/pages/review_guide.html:51
 msgid "Some tips for writing a great review"
 msgstr "Algumas dicas para escrever uma excelente análise"
 
-#: src/olympia/pages/templates/pages/review_guide.html:39
-#: src/olympia/pages/templates/pages/review_guide.html:131
+#: src/olympia/pages/templates/pages/review_guide.html:39 src/olympia/pages/templates/pages/review_guide.html:131
 msgid "Frequently Asked Questions about Reviews"
 msgstr "Dúvidas comuns sobre análises"
 
 #: src/olympia/pages/templates/pages/review_guide.html:46
 msgid ""
-"Add-on reviews are a way for you to share your opinions about the add-ons "
-"you’ve installed and used. Our review moderation team reserves the right to "
-"refuse or remove any review that does not comply with these guidelines."
+"Add-on reviews are a way for you to share your opinions about the add-ons you’ve installed and used. Our review moderation team reserves the right to refuse or remove any review that does not "
+"comply with these guidelines."
 msgstr ""
-"As análises de extras são uma forma de você partilhar as suas opiniões sobre"
-" os extras que instalou e utilizou. A nossa equipa de moderação reserva-se "
-"ao direito de recusar ou de remover qualquer análise que não cumpra estas "
-"orientações."
+"As análises de extras são uma forma de você partilhar as suas opiniões sobre os extras que instalou e utilizou. A nossa equipa de moderação reserva-se ao direito de recusar ou de remover qualquer "
+"análise que não cumpra estas orientações."
 
 #: src/olympia/pages/templates/pages/review_guide.html:53
 msgid "Do:"
 msgstr "Fazer:"
 
 #: src/olympia/pages/templates/pages/review_guide.html:56
-msgid ""
-"Write like you are telling a friend about your experience with the add-on."
-msgstr ""
-"Escreva como se estivesse a partilhar com um amigo a sua experiência com o "
-"extra."
+msgid "Write like you are telling a friend about your experience with the add-on."
+msgstr "Escreva como se estivesse a partilhar com um amigo a sua experiência com o extra."
 
 #: src/olympia/pages/templates/pages/review_guide.html:61
 msgid "Keep reviews concise and easy to understand."
@@ -13656,11 +10733,8 @@ msgid "Will you continue to use this add-on?"
 msgstr "Você continuará usando este extra?"
 
 #: src/olympia/pages/templates/pages/review_guide.html:73
-msgid ""
-"Take a moment to read your review before submitting it to minimize typos."
-msgstr ""
-"Leia novamente a sua análise antes de a enviar para minimizar erros "
-"ortográficos."
+msgid "Take a moment to read your review before submitting it to minimize typos."
+msgstr "Leia novamente a sua análise antes de a enviar para minimizar erros ortográficos."
 
 #: src/olympia/pages/templates/pages/review_guide.html:79
 msgid "Don’t:"
@@ -13668,73 +10742,47 @@ msgstr "O que não fazer:"
 
 #: src/olympia/pages/templates/pages/review_guide.html:82
 msgid "Submit one-word reviews such as \"Great!\", \"wonderful,\" or \"bad.\""
-msgstr ""
-"Submeter análises com uma palavra, tais como \"Ótimo!\", \"maravilhoso\" ou "
-"\"mau\"."
+msgstr "Submeter análises com uma palavra, tais como \"Ótimo!\", \"maravilhoso\" ou \"mau\"."
 
 #: src/olympia/pages/templates/pages/review_guide.html:87
 msgid ""
-"Post technical issues, support requests, or feature suggestions. Use the "
-"available support options for each add-on, if available. You can find them "
-"in the side column next to the About this Add-on section."
+"Post technical issues, support requests, or feature suggestions. Use the available support options for each add-on, if available. You can find them in the side column next to the About this Add-on "
+"section."
 msgstr ""
-"Colocar problemas técnicos, pedidos de apoio ou sugestões de "
-"funcionalidades. Se disponível, utilize as opções de apoio disponíveis para "
-"cada extra. Pode encontrá-las na coluna lateral perto da secção Sobre este "
-"extra."
+"Colocar problemas técnicos, pedidos de apoio ou sugestões de funcionalidades. Se disponível, utilize as opções de apoio disponíveis para cada extra. Pode encontrá-las na coluna lateral perto da "
+"secção Sobre este extra."
 
 #: src/olympia/pages/templates/pages/review_guide.html:92
 msgid "Write reviews for add-ons which you have not personally used."
 msgstr "Escreva análises para extras que não utilizou pessoalmente."
 
 #: src/olympia/pages/templates/pages/review_guide.html:97
-msgid ""
-"Use profanity, sexual language or language that can be construed as hateful."
-msgstr ""
-"Não use linguagem inadequada, de conteúdo sexual ou que pode ser considerada"
-" odiosa."
+msgid "Use profanity, sexual language or language that can be construed as hateful."
+msgstr "Não use linguagem inadequada, de conteúdo sexual ou que pode ser considerada odiosa."
 
 #: src/olympia/pages/templates/pages/review_guide.html:103
-msgid ""
-"Include HTML, links, source code or code snippets. Reviews are meant to be "
-"text only."
-msgstr ""
-"Incluir HTML, ligações, código fonte ou pedaços de código. As análises devem"
-" ser apenas texto."
+msgid "Include HTML, links, source code or code snippets. Reviews are meant to be text only."
+msgstr "Incluir HTML, ligações, código fonte ou pedaços de código. As análises devem ser apenas texto."
 
 #: src/olympia/pages/templates/pages/review_guide.html:108
-msgid ""
-"Make false statements, disparage add-on authors or personally insult them."
-msgstr ""
-"Faça afirmações falsas, rebaixe autores de extras ou insulte-os "
-"pessoalmente."
+msgid "Make false statements, disparage add-on authors or personally insult them."
+msgstr "Faça afirmações falsas, rebaixe autores de extras ou insulte-os pessoalmente."
 
 #: src/olympia/pages/templates/pages/review_guide.html:114
-msgid ""
-"Include your own or anyone else’s email, phone number, or other personal "
-"details."
-msgstr ""
-"Incluir o seu email, número de telefone ou quaisquer outros dados ou os de "
-"qualquer outra pessoa."
+msgid "Include your own or anyone else’s email, phone number, or other personal details."
+msgstr "Incluir o seu email, número de telefone ou quaisquer outros dados ou os de qualquer outra pessoa."
 
 #: src/olympia/pages/templates/pages/review_guide.html:119
-msgid ""
-"Post reviews for an add-on you or your organization wrote or represent."
-msgstr ""
-"Publicar análises para um extra que você ou a sua organização escreveu ou "
-"representa."
+msgid "Post reviews for an add-on you or your organization wrote or represent."
+msgstr "Publicar análises para um extra que você ou a sua organização escreveu ou representa."
 
 #: src/olympia/pages/templates/pages/review_guide.html:125
 msgid ""
-"Criticize an add-on for something it’s intended to do. For example, leaving "
-"a negative review of an add-on for displaying ads or requiring data "
-"gathering, when that is the intended purpose of the add-on, or the add-on "
-"requires gathering data to function."
+"Criticize an add-on for something it’s intended to do. For example, leaving a negative review of an add-on for displaying ads or requiring data gathering, when that is the intended purpose of the "
+"add-on, or the add-on requires gathering data to function."
 msgstr ""
-"Criticar um extra por algo que é suposto fazer. Por exemplo, deixar uma "
-"análise negativa de um extra por apresentar publicidade ou necessitar de "
-"recolher dados, quando este é o objetivo do extra, ou se o extra necessita "
-"de recolher dados para funcionar."
+"Criticar um extra por algo que é suposto fazer. Por exemplo, deixar uma análise negativa de um extra por apresentar publicidade ou necessitar de recolher dados, quando este é o objetivo do extra, "
+"ou se o extra necessita de recolher dados para funcionar."
 
 #: src/olympia/pages/templates/pages/review_guide.html:133
 msgid "How can I report a problematic review?"
@@ -13742,15 +10790,11 @@ msgstr "Como eu posso denunciar uma análise problemática?"
 
 #: src/olympia/pages/templates/pages/review_guide.html:135
 msgid ""
-"Please report or flag any questionable reviews by clicking the \"Report this"
-" review\" and it will be submitted to the site for moderation. Our "
-"moderation team will use the Review Guidelines to evaluate whether or not to"
-" delete the review or restore it back to the site."
+"Please report or flag any questionable reviews by clicking the \"Report this review\" and it will be submitted to the site for moderation. Our moderation team will use the Review Guidelines to "
+"evaluate whether or not to delete the review or restore it back to the site."
 msgstr ""
-"Por favor denuncie ou reporte quaisquer análises questionáveis clicando em "
-"\"Reportar esta análise\" e esta será submetida para o site para moderação. "
-"A nossa equipa de moderação irá utilizar as linhas orientadoras de revisão "
-"para avaliar se a análise deve ser eliminada ou reposta para o site."
+"Por favor denuncie ou reporte quaisquer análises questionáveis clicando em \"Reportar esta análise\" e esta será submetida para o site para moderação. A nossa equipa de moderação irá utilizar as "
+"linhas orientadoras de revisão para avaliar se a análise deve ser eliminada ou reposta para o site."
 
 #: src/olympia/pages/templates/pages/review_guide.html:140
 msgid "I’m an add-on author, can I respond to reviews?"
@@ -13758,35 +10802,20 @@ msgstr "Eu sou um autor de extras, eu posso responder análises?"
 
 #: src/olympia/pages/templates/pages/review_guide.html:142
 #, python-format
-msgid ""
-"Yes, add-on authors can provide a single response to a review. You can set "
-"up a discussion topic in our <a href=\"%(forum_url)s\">forum</a> to engage "
-"in additional discussion or follow-up."
-msgstr ""
-"Sim, os autores de um extra podem fornecer uma única resposta a uma análise."
-" Pode colocar um tópico de discussão no nosso <a "
-"href=\"%(forum_url)s\">fórum</a> para continuar a discussão."
+msgid "Yes, add-on authors can provide a single response to a review. You can set up a discussion topic in our <a href=\"%(forum_url)s\">forum</a> to engage in additional discussion or follow-up."
+msgstr "Sim, os autores de um extra podem fornecer uma única resposta a uma análise. Pode colocar um tópico de discussão no nosso <a href=\"%(forum_url)s\">fórum</a> para continuar a discussão."
 
 #: src/olympia/pages/templates/pages/review_guide.html:149
 msgid "I’m an add-on author, can I delete unfavorable reviews or ratings?"
-msgstr ""
-"Eu sou um autor de um extra, posso eliminar análises ou classificações "
-"desfavoráveis?"
+msgstr "Eu sou um autor de um extra, posso eliminar análises ou classificações desfavoráveis?"
 
 #: src/olympia/pages/templates/pages/review_guide.html:151
 msgid ""
-"In general, no. But if the review did not meet the review guidelines "
-"outlined above, you can click \"Report this review\" and have it moderated. "
-"If a review included a complaint that is no longer valid due to a new "
-"release of your add-on, we may consider deleting the review. Submit your "
-"detailed request to amo-editors@mozilla.org."
+"In general, no. But if the review did not meet the review guidelines outlined above, you can click \"Report this review\" and have it moderated. If a review included a complaint that is no longer "
+"valid due to a new release of your add-on, we may consider deleting the review. Submit your detailed request to amo-editors@mozilla.org."
 msgstr ""
-"No geral, não. Mas se análise não cumprir com as linhas orientadoras de "
-"análise descritas acima, pode clicar em \"Reportar esta análise\" para que a"
-" mesma seja moderada. Se uma análise tiver uma reclamação que já não seja "
-"válida devido ao lançamento de uma nova versão do extra, podemos considerar "
-"eliminar a análise. Submeta o seu pedido detalhado para amo-"
-"editors@mozilla.org."
+"No geral, não. Mas se análise não cumprir com as linhas orientadoras de análise descritas acima, pode clicar em \"Reportar esta análise\" para que a mesma seja moderada. Se uma análise tiver uma "
+"reclamação que já não seja válida devido ao lançamento de uma nova versão do extra, podemos considerar eliminar a análise. Submeta o seu pedido detalhado para amo-editors@mozilla.org."
 
 #: src/olympia/pages/templates/pages/sunbird.html:26
 msgid "Sunbird has retired"
@@ -13794,24 +10823,16 @@ msgstr "O Sunbird se aposentou"
 
 #: src/olympia/pages/templates/pages/sunbird.html:29
 msgid ""
-"Development on the Sunbird project has halted and its final release was on "
-"March 30, 2010.  We've been proud to host Sunbird add-ons on this site but "
-"as the project is no longer maintained we have disabled our support for the "
-"add-ons."
+"Development on the Sunbird project has halted and its final release was on March 30, 2010. We've been proud to host Sunbird add-ons on this site but as the project is no longer maintained we have "
+"disabled our support for the add-ons."
 msgstr ""
-"O desenvolvimento no projeto Sunbird foi interrompido e o seu último "
-"lançamento foi a 30 de março de 2010.  Estivemos orgulhosos de hospedar os "
-"extras do Sunbird neste site mas, como o projeto já não é mantido, "
-"desativamos o suporte para os extras."
+"O desenvolvimento no projeto Sunbird foi interrompido e o seu último lançamento foi a 30 de março de 2010.  Estivemos orgulhosos de hospedar os extras do Sunbird neste site mas, como o projeto já "
+"não é mantido, desativamos o suporte para os extras."
 
 #: src/olympia/pages/templates/pages/sunbird.html:38
 #, python-format
-msgid ""
-"We recommend upgrading to <a href=\"%(tb_url)s\">Thunderbird</a> and <a "
-"href=\"%(lightning_url)s\">Lightning</a>."
-msgstr ""
-"Nós recomendamos migrar para o <a href=\"%(tb_url)s\">Thunderbird</a> e <a "
-"href=\"%(lightning_url)s\">Lightning</a>."
+msgid "We recommend upgrading to <a href=\"%(tb_url)s\">Thunderbird</a> and <a href=\"%(lightning_url)s\">Lightning</a>."
+msgstr "Nós recomendamos migrar para o <a href=\"%(tb_url)s\">Thunderbird</a> e <a href=\"%(lightning_url)s\">Lightning</a>."
 
 #: src/olympia/pages/templates/pages/sunbird.html:45
 msgid "Read more about Sunbird"
@@ -13827,8 +10848,7 @@ msgstr "Existiu um erro com esta moeda."
 
 #: src/olympia/paypal/__init__.py:68
 msgid "The amount is too small for conversion into the receiver's currency."
-msgstr ""
-"A quantidade é muito pequena para a conversão para a moeda do destinatário."
+msgstr "A quantidade é muito pequena para a conversão para a moeda do destinatário."
 
 #: src/olympia/paypal/__init__.py:70
 msgid "The buyer and seller must have different PayPal accounts."
@@ -13863,8 +10883,7 @@ msgstr "Manter revisão; remover etiquetas"
 msgid "Skip for now"
 msgstr "Saltar por agora"
 
-#: src/olympia/reviews/forms.py:151
-#: src/olympia/reviews/templates/reviews/review.html:107
+#: src/olympia/reviews/forms.py:151 src/olympia/reviews/templates/reviews/review.html:107
 msgid "Delete review"
 msgstr "Eliminar comentário"
 
@@ -13883,42 +10902,24 @@ msgstr "Adicionar comentário a {0}"
 #: src/olympia/reviews/templates/reviews/add.html:26
 #, python-format
 msgid ""
-"<h2>Keep these tips in mind:</h2> <ul> <li> Write like you're telling a "
-"friend about your experience with the add-on. Give specifics and helpful "
-"details, such as what features you liked and/or disliked, how easy to use it"
-" is, and any disadvantages it has.  Avoid generic language such as calling "
-"it \"Great\" or \"Bad\" unless you can give reasons why you believe this is "
-"so. </li> <li> Please do not post bug reports in reviews. We do not make "
-"your email address available to add-on developers and they may need to "
-"contact you to help resolve your issue. See the <a "
-"href=\"%(support)s\">support section</a> to find out where to get assistance"
-" for this add-on. </li> <li>Please keep reviews clean, avoid the use of "
-"improper language and do not post any personal information. </li> </ul> "
-"<p>Please read the <a href=\"%(guide)s\" target=\"_blank\">Review "
-"Guidelines</a> for more detail about user add-on reviews.</p>"
+"<h2>Keep these tips in mind:</h2> <ul> <li> Write like you're telling a friend about your experience with the add-on. Give specifics and helpful details, such as what features you liked and/or "
+"disliked, how easy to use it is, and any disadvantages it has. Avoid generic language such as calling it \"Great\" or \"Bad\" unless you can give reasons why you believe this is so. </li> <li> "
+"Please do not post bug reports in reviews. We do not make your email address available to add-on developers and they may need to contact you to help resolve your issue. See the <a href=\"%(support)s"
+"\">support section</a> to find out where to get assistance for this add-on. </li> <li>Please keep reviews clean, avoid the use of improper language and do not post any personal information. </li> </"
+"ul> <p>Please read the <a href=\"%(guide)s\" target=\"_blank\">Review Guidelines</a> for more detail about user add-on reviews.</p>"
 msgstr ""
-"<h2>Mantenha estas dicas em mente:</h2> <ul> <li> Escreva como se estivesse "
-"a descrever a um amigo a sua experiência com o extra. Forneça detalhes e "
-"informações úteis, tais como as funcionalidades de que gostou e as que não "
-"gostou, quão fácil foi utilizá-lo e quaisquer outras desvantagens que tenha."
-" Evite linguagem genérica como dizer que é \"Fantástico\" ou \"Mau\" a menos"
-" que dê razões que justifiquem a sua opinião. </li> <li> Por favor, não "
-"coloque relatórios de falhas nas análises. Nós não fornecemos o seu endereço"
-" de email aos programadores e estes podem ter necessidade de o contactar "
-"para poderem resolver o seu problema. Consulte a <a "
-"href=\"%(support)s\">secção de apoio</a> para saber onde obter assistência "
-"para este extra. </li> <li>Mantenha as análises limpas, evite a utilização "
-"de linguagem imprópria e não coloque qualquer informação pessoal. </li> "
-"</ul> <p>Por favor, leia as <a href=\"%(guide)s\" target=\"_blank\">linhas "
-"orientadoras de revisão</a> para mais detalhes sobre as análises de extras "
-"feitas pelos utilizadores.</p>"
+"<h2>Mantenha estas dicas em mente:</h2> <ul> <li> Escreva como se estivesse a descrever a um amigo a sua experiência com o extra. Forneça detalhes e informações úteis, tais como as funcionalidades "
+"de que gostou e as que não gostou, quão fácil foi utilizá-lo e quaisquer outras desvantagens que tenha. Evite linguagem genérica como dizer que é \"Fantástico\" ou \"Mau\" a menos que dê razões que "
+"justifiquem a sua opinião. </li> <li> Por favor, não coloque relatórios de falhas nas análises. Nós não fornecemos o seu endereço de email aos programadores e estes podem ter necessidade de o "
+"contactar para poderem resolver o seu problema. Consulte a <a href=\"%(support)s\">secção de apoio</a> para saber onde obter assistência para este extra. </li> <li>Mantenha as análises limpas, "
+"evite a utilização de linguagem imprópria e não coloque qualquer informação pessoal. </li> </ul> <p>Por favor, leia as <a href=\"%(guide)s\" target=\"_blank\">linhas orientadoras de revisão</a> "
+"para mais detalhes sobre as análises de extras feitas pelos utilizadores.</p>"
 
 #: src/olympia/reviews/templates/reviews/reply.html:4
 msgid "Reply to review by {0}"
 msgstr "Responder ao comentário de {0}"
 
-#: src/olympia/reviews/templates/reviews/reply.html:15
-#: src/olympia/reviews/templates/reviews/reply.html:31
+#: src/olympia/reviews/templates/reviews/reply.html:15 src/olympia/reviews/templates/reviews/reply.html:31
 msgid "Reply"
 msgstr "Responder"
 
@@ -13926,8 +10927,7 @@ msgstr "Responder"
 msgid "Write a Reply"
 msgstr "Escrever uma resposta"
 
-#: src/olympia/reviews/templates/reviews/reply.html:36
-#: src/olympia/reviews/templates/reviews/report_review.html:12
+#: src/olympia/reviews/templates/reviews/reply.html:36 src/olympia/reviews/templates/reviews/report_review.html:12
 msgid "Submit"
 msgstr "Submeter"
 
@@ -13947,34 +10947,21 @@ msgid "by %(user)s <b>(Developer)</b> on %(date)s"
 msgstr "por %(user)s <b>(Programador)</b> em %(date)s"
 
 #. {0} is a version number (like 1.01)
-#: src/olympia/reviews/templates/reviews/review.html:50
-#: src/olympia/reviews/templates/reviews/mobile/review_list.html:41
+#: src/olympia/reviews/templates/reviews/review.html:50 src/olympia/reviews/templates/reviews/mobile/review_list.html:41
 msgid "This review is for a previous version of the add-on ({0})."
 msgstr "Esta avaliação é para uma versão anterior do extra ({0})."
 
 #: src/olympia/reviews/templates/reviews/review.html:56
 #, python-format
-msgid ""
-"This user has a <a href=\"%(user_review_url)s\">previous review</a> of this "
-"add-on."
-msgid_plural ""
-"This user has <a href=\"%(user_review_url)s\">%(cnt)s previous reviews</a> "
-"of this add-on."
-msgstr[0] ""
-"Este utilizador tem uma <a href=\"%(user_review_url)s\">revisão anterior</a>"
-" deste extra."
-msgstr[1] ""
-"Este utilizador tem <a href=\"%(user_review_url)s\">%(cnt)s revisões "
-"anteriores</a> deste extra."
+msgid "This user has a <a href=\"%(user_review_url)s\">previous review</a> of this add-on."
+msgid_plural "This user has <a href=\"%(user_review_url)s\">%(cnt)s previous reviews</a> of this add-on."
+msgstr[0] "Este utilizador tem uma <a href=\"%(user_review_url)s\">revisão anterior</a> deste extra."
+msgstr[1] "Este utilizador tem <a href=\"%(user_review_url)s\">%(cnt)s revisões anteriores</a> deste extra."
 
 #: src/olympia/reviews/templates/reviews/review.html:62
 #, python-format
-msgid ""
-"This user has <a href=\"%(user_review_url)s\">other reviews</a> of this add-"
-"on."
-msgstr ""
-"Este utilizador tem <a href=\"%(user_review_url)s\">outras revisões</a> "
-"deste extra."
+msgid "This user has <a href=\"%(user_review_url)s\">other reviews</a> of this add-on."
+msgstr "Este utilizador tem <a href=\"%(user_review_url)s\">outras revisões</a> deste extra."
 
 #: src/olympia/reviews/templates/reviews/review.html:72
 msgid "Flagged for review"
@@ -14006,9 +10993,7 @@ msgid "{0} :: Reviews"
 msgstr "{0} :: Avaliações"
 
 #. {0} is an addon name.
-#: src/olympia/reviews/templates/reviews/review_list.html:24
-#: src/olympia/reviews/templates/reviews/mobile/add.html:4
-#: src/olympia/reviews/templates/reviews/mobile/review_list.html:4
+#: src/olympia/reviews/templates/reviews/review_list.html:24 src/olympia/reviews/templates/reviews/mobile/add.html:4 src/olympia/reviews/templates/reviews/mobile/review_list.html:4
 msgid "Reviews for {0}"
 msgstr "Comentários para {0}"
 
@@ -14044,8 +11029,7 @@ msgstr "<strong>Média</strong> (%(total)s)"
 msgid "Write a New Review"
 msgstr "Escrever uma nova avaliação"
 
-#: src/olympia/reviews/templates/reviews/review_list.html:81
-#: src/olympia/reviews/templates/reviews/mobile/reviews_link.html:15
+#: src/olympia/reviews/templates/reviews/review_list.html:81 src/olympia/reviews/templates/reviews/mobile/reviews_link.html:15
 msgid "Be the first to write a review."
 msgstr "Seja o primeiro a escrever um comentário"
 
@@ -14066,8 +11050,7 @@ msgid "Rated %(rating)s out of 5 stars"
 msgstr "Classificado com %(rating)s de 5 estrelas"
 
 # 75%
-#: src/olympia/reviews/templates/reviews/mobile/add_form.html:3
-#: src/olympia/reviews/templates/reviews/mobile/add_form.html:8
+#: src/olympia/reviews/templates/reviews/mobile/add_form.html:3 src/olympia/reviews/templates/reviews/mobile/add_form.html:8
 msgid "Add a Review"
 msgstr "Adicionar uma Análise"
 
@@ -14138,10 +11121,8 @@ msgid "Relevance"
 msgstr "Relevância"
 
 #: src/olympia/search/helpers.py:24
-msgid ""
-"Results <strong>{0}</strong>-<strong>{1}</strong> of <strong>{2}</strong>"
-msgstr ""
-"Resultados <strong>{0}</strong>-<strong>{1}</strong> de <strong>{2}</strong>"
+msgid "Results <strong>{0}</strong>-<strong>{1}</strong> of <strong>{2}</strong>"
+msgstr "Resultados <strong>{0}</strong>-<strong>{1}</strong> de <strong>{2}</strong>"
 
 # {0} is a number
 # {1} is a number
@@ -14149,12 +11130,8 @@ msgstr ""
 # {3} is the word the person is searching for
 # {4} is a word (the add-on is tagged with it)
 #: src/olympia/search/helpers.py:44
-msgid ""
-"Showing {0} - {1} of {2} results for <strong>{3}</strong> tagged with "
-"<strong>{4}</strong>"
-msgstr ""
-"A mostrar {0} - {1} de {2} resultados para <strong>{3}</strong>etiquetados "
-"com <strong>{4}</strong>"
+msgid "Showing {0} - {1} of {2} results for <strong>{3}</strong> tagged with <strong>{4}</strong>"
+msgstr "A mostrar {0} - {1} de {2} resultados para <strong>{3}</strong>etiquetados com <strong>{4}</strong>"
 
 # {0} is a number
 # {1} is a number
@@ -14170,8 +11147,7 @@ msgstr "A mostrar {0} - {1} de {2} resultados para <strong>{3}</strong>"
 # {3} is a word (the add-on is tagged with it)
 #: src/olympia/search/helpers.py:52
 msgid "Showing {0} - {1} of {2} results tagged with <strong>{3}</strong>"
-msgstr ""
-"A mostrar {0} - {1} de {2} resultados etiquetados com <strong>{3}</strong>"
+msgstr "A mostrar {0} - {1} de {2} resultados etiquetados com <strong>{3}</strong>"
 
 # {0} is a number
 # {1} is a number
@@ -14181,24 +11157,22 @@ msgid "Showing {0} - {1} of {2} results"
 msgstr "A mostrar {0} - {1} de {2} resultados"
 
 #. {0} is an application, like Firefox.
-#: src/olympia/search/views.py:264 src/olympia/templates/base.html:17
-#: src/olympia/templates/impala/base.html:17
-#: src/olympia/templates/mobile/base_addons.html:17
+#: src/olympia/search/views.py:264 src/olympia/templates/base.html:17 src/olympia/templates/impala/base.html:17 src/olympia/templates/mobile/base_addons.html:17
 msgid "{0} Add-ons"
 msgstr "{0} extras"
 
 #. L10n: {0} is an application, such as Firefox. This means "any version of
 #. Firefox."
-#: src/olympia/search/views.py:554
+#: src/olympia/search/views.py:547
 msgid "Any {0}"
 msgstr "Qualquer {0}"
 
 #. L10n: "All Systems" means show everything regardless of platform.
-#: src/olympia/search/views.py:589
+#: src/olympia/search/views.py:582
 msgid "All Systems"
 msgstr "Todos os sistemas"
 
-#: src/olympia/search/views.py:600
+#: src/olympia/search/views.py:593
 msgid "All Tags"
 msgstr "Todas as etiquetas"
 
@@ -14217,9 +11191,7 @@ msgstr "Pesquisa Indisponível"
 
 #: src/olympia/search/templates/search/down.html:6
 msgid "Search is temporarily unavailable. Please try again in a few minutes."
-msgstr ""
-"A pesquisa está temporariamente indisponível. Por favor, tente novamente "
-"dentro de alguns minutos."
+msgstr "A pesquisa está temporariamente indisponível. Por favor, tente novamente dentro de alguns minutos."
 
 #. {0} is the string the user was searching for
 #: src/olympia/search/templates/search/personas.html:9
@@ -14235,8 +11207,8 @@ msgstr "Resultados da pesquisa por temas"
 msgid "{0} :: Tag"
 msgstr "{0} :: Etiqueta"
 
-#. {0} is a tag, such as jetpack.
 # 85%
+#. {0} is a tag, such as jetpack.
 #: src/olympia/search/templates/search/results.html:16
 msgid "Search Results for tag \"{0}\""
 msgstr "Resultados da pesquisa para a etiqueta \"{0}\""
@@ -14375,37 +11347,31 @@ msgstr "Partilhar este extra"
 msgid "Share this Collection"
 msgstr "Partilhar esta coleção"
 
-#: src/olympia/signing/views.py:30 src/olympia/templates/base.html:75
-#: src/olympia/templates/impala/base.html:115
-msgid ""
-"Some features are temporarily disabled while we perform website maintenance."
-" We'll be back to full capacity shortly."
-msgstr ""
-"Algumas funcionalidades estão temporariamente desativadas enquanto efetuamos"
-" uma manutenção ao website. Voltamos dentro de alguns momentos com todas as "
-"funcionalidades."
+#: src/olympia/signing/views.py:33 src/olympia/templates/base.html:71 src/olympia/templates/impala/base.html:112
+msgid "Some features are temporarily disabled while we perform website maintenance. We'll be back to full capacity shortly."
+msgstr "Algumas funcionalidades estão temporariamente desativadas enquanto efetuamos uma manutenção ao website. Voltamos dentro de alguns momentos com todas as funcionalidades."
 
-#: src/olympia/signing/views.py:53
+#: src/olympia/signing/views.py:56
 msgid "Could not find add-on with id \"{}\"."
 msgstr "Não foi possível encontrar um extra com o id \"{}\"."
 
-#: src/olympia/signing/views.py:67
+#: src/olympia/signing/views.py:70
 msgid "You do not own this addon."
 msgstr "Não é proprietário deste extra."
 
-#: src/olympia/signing/views.py:82
+#: src/olympia/signing/views.py:87
 msgid "Missing \"upload\" key in multipart file data."
 msgstr "Chave \"upload\" em falta nos dados multi-parte do ficheiro."
 
-#: src/olympia/signing/views.py:96
+#: src/olympia/signing/views.py:101
 msgid "Version does not match the manifest file."
 msgstr "A versão não corresponde ao ficheiro manifest."
 
-#: src/olympia/signing/views.py:100
+#: src/olympia/signing/views.py:105
 msgid "Version already exists."
 msgstr "A versão já existe."
 
-#: src/olympia/signing/views.py:136
+#: src/olympia/signing/views.py:141
 msgid "No uploaded file for that addon and version."
 msgstr "Não existe um ficheiro enviado para esse extra e versão."
 
@@ -14500,8 +11466,7 @@ msgstr "De"
 msgid "To"
 msgstr "Para"
 
-#: src/olympia/stats/templates/stats/popup.html:27
-#: src/olympia/users/templates/users/pwreset_confirm.html:38
+#: src/olympia/stats/templates/stats/popup.html:27 src/olympia/users/templates/users/pwreset_confirm.html:38
 msgid "Update"
 msgstr "Atualizar"
 
@@ -14523,98 +11488,91 @@ msgstr "{0} :: Painel de estatísticas"
 msgid "Statistics Dashboard :: Add-ons for {0}"
 msgstr "Painel de estatísticas :: Extras para {0}"
 
-#: src/olympia/stats/templates/stats/stats.html:30
-msgid "Controls:"
-msgstr "Controlos:"
-
-#: src/olympia/stats/templates/stats/stats.html:33
-msgid "reset zoom"
-msgstr "repor zoom"
-
-#: src/olympia/stats/templates/stats/stats.html:40
-msgid "Group by:"
-msgstr "Agrupar por:"
-
-#: src/olympia/stats/templates/stats/stats.html:42
-msgid "day"
-msgstr "dia"
-
-#: src/olympia/stats/templates/stats/stats.html:45
-msgid "week"
-msgstr "semana"
-
-#: src/olympia/stats/templates/stats/stats.html:48
-msgid "month"
-msgstr "mês"
-
-#: src/olympia/stats/templates/stats/stats.html:54
-msgid "For last:"
-msgstr "Por último:"
-
-#: src/olympia/stats/templates/stats/stats.html:57
-msgid "7 days"
-msgstr "7 dias"
-
-#: src/olympia/stats/templates/stats/stats.html:60
-msgid "30 days"
-msgstr "30 dias"
-
-#: src/olympia/stats/templates/stats/stats.html:63
-msgid "90 days"
-msgstr "90 dias"
-
-#: src/olympia/stats/templates/stats/stats.html:66
-msgid "365 days"
-msgstr "365 dias"
-
-#: src/olympia/stats/templates/stats/stats.html:69
-msgid "Custom..."
-msgstr "Personalizar..."
-
 #. {0} is an add-on name
-#: src/olympia/stats/templates/stats/stats.html:88
-#: src/olympia/stats/templates/stats/stats.html:91
+#: src/olympia/stats/templates/stats/stats.html:44 src/olympia/stats/templates/stats/stats.html:47
 msgid "Statistics for {0}"
 msgstr "Estatísticas para {0}"
 
-#: src/olympia/stats/templates/stats/stats.html:94
+#: src/olympia/stats/templates/stats/stats.html:50
 msgid "Statistics Dashboard"
 msgstr "Painel de estatísticas"
 
-#: src/olympia/stats/templates/stats/stats.html:104
-msgid ""
-"Statistics processing is currently disabled, so recent data is unavailable. "
-"The statistics are still being collected and this page will be updated soon "
-"with the missing data."
-msgstr ""
-"O processamento de estatísticas está, neste momento, desativado, pelo que "
-"não existem dados recentes disponíveis. As estatísticas continuam a ser "
-"recolhidas e esta página será atualizada em breve com os dados em falta."
+#: src/olympia/stats/templates/stats/stats.html:57
+msgid "Controls:"
+msgstr "Controlos:"
 
-#: src/olympia/stats/templates/stats/stats.html:110
+#: src/olympia/stats/templates/stats/stats.html:60
+msgid "reset zoom"
+msgstr "repor zoom"
+
+#: src/olympia/stats/templates/stats/stats.html:67
+msgid "Group by:"
+msgstr "Agrupar por:"
+
+#: src/olympia/stats/templates/stats/stats.html:69
+msgid "day"
+msgstr "dia"
+
+#: src/olympia/stats/templates/stats/stats.html:72
+msgid "week"
+msgstr "semana"
+
+#: src/olympia/stats/templates/stats/stats.html:75
+msgid "month"
+msgstr "mês"
+
+#: src/olympia/stats/templates/stats/stats.html:81
+msgid "For last:"
+msgstr "Por último:"
+
+#: src/olympia/stats/templates/stats/stats.html:84
+msgid "7 days"
+msgstr "7 dias"
+
+#: src/olympia/stats/templates/stats/stats.html:87
+msgid "30 days"
+msgstr "30 dias"
+
+#: src/olympia/stats/templates/stats/stats.html:90
+msgid "90 days"
+msgstr "90 dias"
+
+#: src/olympia/stats/templates/stats/stats.html:93
+msgid "365 days"
+msgstr "365 dias"
+
+#: src/olympia/stats/templates/stats/stats.html:96
+msgid "Custom..."
+msgstr "Personalizar..."
+
+#: src/olympia/stats/templates/stats/stats.html:106
+msgid "Statistics processing is currently disabled, so recent data is unavailable. The statistics are still being collected and this page will be updated soon with the missing data."
+msgstr ""
+"O processamento de estatísticas está, neste momento, desativado, pelo que não existem dados recentes disponíveis. As estatísticas continuam a ser recolhidas e esta página será atualizada em breve "
+"com os dados em falta."
+
+#: src/olympia/stats/templates/stats/stats.html:112
 msgid "Loading the latest data&hellip;"
 msgstr "A carregar os últimos dados&hellip;"
 
-#: src/olympia/stats/templates/stats/stats.html:142
-#: src/olympia/stats/templates/stats/reports/overview.html:25
-#: src/olympia/stats/templates/stats/reports/overview.html:37
+#: src/olympia/stats/templates/stats/stats.html:144 src/olympia/stats/templates/stats/reports/overview.html:25 src/olympia/stats/templates/stats/reports/overview.html:37
 #: src/olympia/stats/templates/stats/reports/overview.html:49
 msgid "No data available."
 msgstr "Sem dados disponíveis."
 
-#: src/olympia/stats/templates/stats/stats.html:177
+#: src/olympia/stats/templates/stats/stats.html:179
 msgid "This dashboard is currently <b>public</b>."
 msgstr "Este quadro de momento é <b>público</b>."
 
-#: src/olympia/stats/templates/stats/stats.html:179
+#: src/olympia/stats/templates/stats/stats.html:181
 msgid "Contribution stats are currently <b>private</b>."
 msgstr "As estatísticas de contribuição são atualmente <b>privadas</b>."
 
-#: src/olympia/stats/templates/stats/stats.html:182
+#: src/olympia/stats/templates/stats/stats.html:184
 msgid "This dashboard is currently <b>private</b>."
 msgstr "Este painel de momento é <b>privado</b>."
 
-#: src/olympia/stats/templates/stats/stats.html:185
+#: src/olympia/stats/templates/stats/stats.html:187
 msgid "Change settings."
 msgstr "Alterar definições."
 
@@ -14656,14 +11614,11 @@ msgstr "Como é que as descargas são contabilizadas?"
 
 #: src/olympia/stats/templates/stats/reports/downloads.html:10
 msgid ""
-"<h2>How are downloads counted?</h2> <p> Download counts are updated every "
-"evening and only include original add-on downloads, not updates. Downloads "
-"can be broken down by the specific source referring the download. </p>"
+"<h2>How are downloads counted?</h2> <p> Download counts are updated every evening and only include original add-on downloads, not updates. Downloads can be broken down by the specific source "
+"referring the download. </p>"
 msgstr ""
-"<h2>Como é que as descargas são contabilizadas?</h2> <p> O número de "
-"descargas é atualizado todas as noites e apenas inclui descargas originais "
-"de extras e não atualizações. As descargas podem ser decompostas pela fonte "
-"específica que referenciou a descarga. </p>"
+"<h2>Como é que as descargas são contabilizadas?</h2> <p> O número de descargas é atualizado todas as noites e apenas inclui descargas originais de extras e não atualizações. As descargas podem ser "
+"decompostas pela fonte específica que referenciou a descarga. </p>"
 
 #: src/olympia/stats/templates/stats/reports/locales.html:3
 msgid "User languages by Date"
@@ -14677,8 +11632,7 @@ msgstr "Utilização da plataforma por data"
 msgid "<b>{0}</b> Downloads"
 msgstr "<b>{0}</b> descargas"
 
-#: src/olympia/stats/templates/stats/reports/overview.html:9
-#: src/olympia/stats/templates/stats/reports/overview.html:13
+#: src/olympia/stats/templates/stats/reports/overview.html:9 src/olympia/stats/templates/stats/reports/overview.html:13
 msgid "Loading..."
 msgstr "A carregar..."
 
@@ -14729,34 +11683,18 @@ msgstr "Sobre o monitoramento de fontes externas..."
 #: src/olympia/stats/templates/stats/reports/sources.html:10
 #, python-format
 msgid ""
-"<h2>Tracking external sources</h2> <p> If you link to your add-on's details "
-"page or directly to its file from an external site, such as your blog or "
-"website, you can append a parameter to be tracked as an additional download "
-"source on this page. For example, the following links would appear as "
-"sourced by your blog: <dl> <dt>Add-on Details Page</dt> "
-"<dd>https://addons.mozilla.org/addon/%(slug)s?src=<b>external-blog</b></dd> "
-"<dt>Direct File Link</dt> "
-"<dd>https://addons.mozilla.org/downloads/latest/%(id)s/addon-%(id)s-latest.xpi?src=<b"
-">external-blog</b></dd> </dl> <p> Only src parameters that begin with "
-"\"external-\" will be tracked, up to 61 additional characters. Any text "
-"after \"external-\" can be used to describe the source, such as \"external-"
-"blog\", \"external-sidebar\", \"external-campaign225\", etc. The following "
-"URL-safe characters are allowed: <code>a-z A-Z - . _ ~ %% +</code>"
+"<h2>Tracking external sources</h2> <p> If you link to your add-on's details page or directly to its file from an external site, such as your blog or website, you can append a parameter to be "
+"tracked as an additional download source on this page. For example, the following links would appear as sourced by your blog: <dl> <dt>Add-on Details Page</dt> <dd>https://addons.mozilla.org/addon/"
+"%(slug)s?src=<b>external-blog</b></dd> <dt>Direct File Link</dt> <dd>https://addons.mozilla.org/downloads/latest/%(id)s/addon-%(id)s-latest.xpi?src=<b>external-blog</b></dd> </dl> <p> Only src "
+"parameters that begin with \"external-\" will be tracked, up to 61 additional characters. Any text after \"external-\" can be used to describe the source, such as \"external-blog\", \"external-"
+"sidebar\", \"external-campaign225\", etc. The following URL-safe characters are allowed: <code>a-z A-Z - . _ ~ %% +</code>"
 msgstr ""
-"<h2>Monitorização de fontes externas</h2> <p> Se ligou a página de detalhes "
-"do extra ou diretamente o seu ficheiro a partir de um site externo, tal como"
-" o seu blogue ou website, pode adicionar um parâmetro para ser referenciado "
-"como uma fonte adicional de descarga nesta página. Por exemplo, as ligações "
-"seguintes iriam aparecer classificadas como o seu blogue: <dl> <dt>Página de"
-" detalhes do extra</dt> <dd>https://addons.mozilla.org/addon/%(slug)s?src=<b"
-">external-blog</b></dd> <dt>Ligação direta ao ficheiro</dt> "
-"<dd>https://addons.mozilla.org/downloads/latest/%(id)s/addon-%(id)s-latest.xpi?src=<b"
-">external-blog</b></dd> </dl> <p> Apenas os parâmetros src que começam com "
-"\"external-\" serão monitorizados, até 61 carateres adicionais. Qualquer "
-"texto depois de \"external-\" pode ser utilizado para descrever a fonte, "
-"tais como \"external-blog\", \"external-sidebar\", \"external-campaign225\","
-" etc. Os seguintes caracteres, seguros para URLs, são permitidos: <code>a-z "
-"A-Z - . _ ~ %% +</code>"
+"<h2>Monitorização de fontes externas</h2> <p> Se ligou a página de detalhes do extra ou diretamente o seu ficheiro a partir de um site externo, tal como o seu blogue ou website, pode adicionar um "
+"parâmetro para ser referenciado como uma fonte adicional de descarga nesta página. Por exemplo, as ligações seguintes iriam aparecer classificadas como o seu blogue: <dl> <dt>Página de detalhes do "
+"extra</dt> <dd>https://addons.mozilla.org/addon/%(slug)s?src=<b>external-blog</b></dd> <dt>Ligação direta ao ficheiro</dt> <dd>https://addons.mozilla.org/downloads/latest/%(id)s/addon-%(id)s-latest."
+"xpi?src=<b>external-blog</b></dd> </dl> <p> Apenas os parâmetros src que começam com \"external-\" serão monitorizados, até 61 carateres adicionais. Qualquer texto depois de \"external-\" pode ser "
+"utilizado para descrever a fonte, tais como \"external-blog\", \"external-sidebar\", \"external-campaign225\", etc. Os seguintes caracteres, seguros para URLs, são permitidos: <code>a-z A-Z - . _ ~ "
+"%% +</code>"
 
 #: src/olympia/stats/templates/stats/reports/statuses.html:3
 msgid "Add-on Status by Date"
@@ -14776,28 +11714,19 @@ msgstr "O que são utilizadoes diários?"
 
 #: src/olympia/stats/templates/stats/reports/usage.html:11
 msgid ""
-"<h2>What are daily users?</h2> <p> Themes installed from this site check for"
-" updates once per day. The total number of these update pings is known as "
-"Active Daily Users, or the total number of people using your theme by day. "
-"</p>"
+"<h2>What are daily users?</h2> <p> Themes installed from this site check for updates once per day. The total number of these update pings is known as Active Daily Users, or the total number of "
+"people using your theme by day. </p>"
 msgstr ""
-"<h2>O que são utilizadores diários?</h2> <p> Os temas instalados a partir "
-"deste site procuram por atualizações diariamente. O número total destas "
-"verificações por atualizações são conhecidas como utilizadores diários "
-"ativos, ou o número de pessoas a utilizar o tema por dia. </p>"
+"<h2>O que são utilizadores diários?</h2> <p> Os temas instalados a partir deste site procuram por atualizações diariamente. O número total destas verificações por atualizações são conhecidas como "
+"utilizadores diários ativos, ou o número de pessoas a utilizar o tema por dia. </p>"
 
 #: src/olympia/stats/templates/stats/reports/usage.html:20
 msgid ""
-"<h2>What are daily users?</h2> <p> Add-ons downloaded from this site check "
-"for updates once per day. The total number of these update pings is known as"
-" Active Daily Users. Daily users can be broken down by add-on version, "
-"operating system, add-on status, application, and locale. </p>"
+"<h2>What are daily users?</h2> <p> Add-ons downloaded from this site check for updates once per day. The total number of these update pings is known as Active Daily Users. Daily users can be broken "
+"down by add-on version, operating system, add-on status, application, and locale. </p>"
 msgstr ""
-"<h2>O que são utilizadores diários?</h2> <p> Os extras instalados a partir "
-"deste site procuram por atualizações diariamente. O número total destas "
-"verificações por atualizações são conhecidas como utilizadores diários "
-"ativos. Os utilizadores diários podem ser decompostos por versão do extra, "
-"sistema operativo, estado do extra, aplicação e idioma. </p>"
+"<h2>O que são utilizadores diários?</h2> <p> Os extras instalados a partir deste site procuram por atualizações diariamente. O número total destas verificações por atualizações são conhecidas como "
+"utilizadores diários ativos. Os utilizadores diários podem ser decompostos por versão do extra, sistema operativo, estado do extra, aplicação e idioma. </p>"
 
 #: src/olympia/stats/templates/stats/reports/users_created.html:3
 msgid "User Signups by Date"
@@ -14807,45 +11736,27 @@ msgstr "Cadastros por Data"
 msgid "Application versions by Date"
 msgstr "Versões da aplicação por data"
 
-#: src/olympia/tags/templates/tags/top_cloud.html:4
-msgid "Top {0} Tags"
-msgstr "Top {0} de etiquetas"
-
-#. {0} is the current application name
-#: src/olympia/tags/templates/tags/top_cloud.html:14
-msgid "{0} Top Tags"
-msgstr "Top de etiquetas do {0}"
-
-#: src/olympia/templates/amo_footer.html:6
-#: src/olympia/templates/includes/lang_switcher.html:2
+#: src/olympia/templates/amo_footer.html:6 src/olympia/templates/includes/lang_switcher.html:2
 msgid "Other languages"
 msgstr "Outros idiomas"
 
-#: src/olympia/templates/base.html:9 src/olympia/templates/impala/base.html:9
-#: src/olympia/templates/mobile/base_addons.html:9
+#: src/olympia/templates/base.html:9 src/olympia/templates/impala/base.html:9 src/olympia/templates/mobile/base_addons.html:9
 msgid "Mozilla Add-ons"
 msgstr "Extras da Mozilla"
 
-#: src/olympia/templates/base.html:91
-#: src/olympia/templates/impala/base.html:81
+#: src/olympia/templates/base.html:89 src/olympia/templates/impala/base.html:78
 msgid "Find add-ons for other applications"
 msgstr "Procure extras para outras aplicações"
 
-#: src/olympia/templates/base.html:92
-#: src/olympia/templates/impala/base.html:81
+#: src/olympia/templates/base.html:90 src/olympia/templates/impala/base.html:78
 msgid "Other Applications"
 msgstr "Outras aplicações"
 
-#: src/olympia/templates/base.html:141
-#: src/olympia/templates/impala/base.html:194
-msgid ""
-"To create your own collections, you must have a Mozilla Add-ons account."
-msgstr ""
-"Para criar as suas próprias coleções, tem de ter uma conta dos extras da "
-"Mozilla."
+#: src/olympia/templates/base.html:141 src/olympia/templates/impala/base.html:194
+msgid "To create your own collections, you must have a Mozilla Add-ons account."
+msgstr "Para criar as suas próprias coleções, tem de ter uma conta dos extras da Mozilla."
 
-#: src/olympia/templates/base.html:168
-#: src/olympia/templates/impala/base.html:215
+#: src/olympia/templates/base.html:168 src/olympia/templates/impala/base.html:215
 msgid "Footer logo"
 msgstr "Logótipo do rodapé"
 
@@ -14862,21 +11773,19 @@ msgid "View Mobile Site"
 msgstr "Ver site móvel"
 
 #: src/olympia/templates/copyright.html:7
-msgid "Site Status "
+msgid "Site Status"
 msgstr "Estado do site "
 
 #: src/olympia/templates/footer.html:3
 msgid "get to know <b>add-ons</b>"
 msgstr "conheça os <b>extras</b>"
 
-#: src/olympia/templates/footer.html:4
-#: src/olympia/templates/menu_links.html:20
+#: src/olympia/templates/footer.html:4 src/olympia/templates/menu_links.html:20
 msgid "About"
 msgstr "Sobre"
 
 # Link text to the AMO blog.
-#: src/olympia/templates/footer.html:5
-#: src/olympia/templates/menu_links.html:32
+#: src/olympia/templates/footer.html:5 src/olympia/templates/menu_links.html:32
 msgid "Blog"
 msgstr "Blog"
 
@@ -14953,9 +11862,7 @@ msgstr "Legal"
 msgid "Contact Us"
 msgstr "Contacte-nos"
 
-#: src/olympia/templates/user_login.html:22
-#: src/olympia/users/templates/users/edit.html:31
-#: src/olympia/users/templates/users/includes/navigation.html:12
+#: src/olympia/templates/user_login.html:22 src/olympia/users/templates/users/edit.html:31 src/olympia/users/templates/users/includes/navigation.html:12
 msgid "My Account"
 msgstr "A Minha Conta"
 
@@ -14963,66 +11870,48 @@ msgstr "A Minha Conta"
 msgid "Welcome, {0}"
 msgstr "Bem-vindo, {0}"
 
-#: src/olympia/templates/user_login.html:41
-#: src/olympia/templates/impala/user_login.html:20
+#: src/olympia/templates/user_login.html:41 src/olympia/templates/impala/user_login.html:20
 #, python-format
 msgid "<a href=\"%(reg)s\">Register</a> or <a href=\"%(login)s\">Log in</a>"
 msgstr "<a href=\"%(reg)s\">Registe-se</a> ou <a href=\"%(login)s\">Inicie sessão</a>"
 
-#: src/olympia/templates/impala/base.html:126
+#: src/olympia/templates/impala/base.html:123
 #, python-format
-msgid ""
-"To try the thousands of add-ons available here, download <a "
-"href=\"%(url)s\">Mozilla Firefox</a>, a fast, free way to surf the Web!"
-msgstr ""
-"Para experimentar as centenas de extras aqui disponíveis, descarregue o <a "
-"href=\"%(url)s\">Mozilla Firefox</a>, uma maneira fácil e gratuita de "
-"navegar na Web!"
+msgid "To try the thousands of add-ons available here, download <a href=\"%(url)s\">Mozilla Firefox</a>, a fast, free way to surf the Web!"
+msgstr "Para experimentar as centenas de extras aqui disponíveis, descarregue o <a href=\"%(url)s\">Mozilla Firefox</a>, uma maneira fácil e gratuita de navegar na Web!"
 
-#: src/olympia/templates/impala/base.html:138
+#: src/olympia/templates/impala/base.html:135
 #, python-format
-msgid ""
-"Add-ons is switching to Firefox Accounts for login. <a href=\"%(url)s\" "
-"class=\"fxa-login\">Sign in now to transfer your account.</a>"
-msgstr ""
-"Extras está a mudar-se para as Contas Firefox para o início de sessão. <a "
-"href=\"%(url)s\" class=\"fxa-login\">Inicie sessão agora para transferir a "
-"sua conta.</a>"
+msgid "Add-ons is switching to Firefox Accounts for login. <a href=\"%(url)s\" class=\"fxa-login\">Sign in now to transfer your account.</a>"
+msgstr "Extras está a mudar-se para as Contas Firefox para o início de sessão. <a href=\"%(url)s\" class=\"fxa-login\">Inicie sessão agora para transferir a sua conta.</a>"
 
 #. {0} is an application, such as Firefox.
-#: src/olympia/templates/impala/base.html:148
+#: src/olympia/templates/impala/base.html:145
 msgid "Welcome to {0} Add-ons."
 msgstr "Bem-vindo aos extras do {0}."
 
-#: src/olympia/templates/impala/base.html:151
-msgid ""
-"Choose from thousands of extra features and styles to make Firefox your own."
-msgstr ""
-"Escolha a partir de centenas de funcionalidades e estilos extra para tornar "
-"o Firefox só seu."
+#: src/olympia/templates/impala/base.html:148
+msgid "Choose from thousands of extra features and styles to make Firefox your own."
+msgstr "Escolha a partir de centenas de funcionalidades e estilos extra para tornar o Firefox só seu."
 
-#: src/olympia/templates/impala/base.html:156
+#: src/olympia/templates/impala/base.html:153
 #, python-format
 msgid "Add extra features and styles to make %(app)s your own."
-msgstr ""
-"Adicione funcionalidades e estilos extra para tornar o %(app)s só seu."
+msgstr "Adicione funcionalidades e estilos extra para tornar o %(app)s só seu."
 
-#: src/olympia/templates/impala/base.html:164
+#: src/olympia/templates/impala/base.html:161
 msgid "On the go?"
 msgstr "Em qualquer lugar?"
 
-#: src/olympia/templates/impala/base.html:166
+#: src/olympia/templates/impala/base.html:163
 msgid "Check out our <a class=\"mobile-link\" href=\"#\">Mobile Add-ons site</a>."
-msgstr ""
-"Veja o nosso <a class=\"mobile-link\" href=\"#\">site de extras para "
-"dispositivos móveis</a>."
+msgstr "Veja o nosso <a class=\"mobile-link\" href=\"#\">site de extras para dispositivos móveis</a>."
 
 #: src/olympia/templates/impala/header_title.html:21
 msgid "Android Add-ons"
 msgstr "Extras para Android"
 
-#: src/olympia/templates/includes/forms.html:2
-#: src/olympia/templates/includes/forms.html:6
+#: src/olympia/templates/includes/forms.html:2 src/olympia/templates/includes/forms.html:6
 msgid "required"
 msgstr "necessário"
 
@@ -15067,15 +11956,11 @@ msgstr "Visite a Mozilla"
 msgid "menu"
 msgstr "menu"
 
-#: src/olympia/templates/mobile/header_auth.html:7
-#: src/olympia/users/templates/users/register.html:41
-#: src/olympia/users/templates/users/register.html:89
+#: src/olympia/templates/mobile/header_auth.html:7 src/olympia/users/templates/users/register.html:41 src/olympia/users/templates/users/register.html:89
 msgid "Register"
 msgstr "Registar"
 
-#: src/olympia/templates/mobile/header_auth.html:8
-#: src/olympia/users/templates/users/login_form.html:41
-#: src/olympia/users/templates/users/pwreset_complete.html:15
+#: src/olympia/templates/mobile/header_auth.html:8 src/olympia/users/templates/users/login_form.html:41 src/olympia/users/templates/users/pwreset_complete.html:15
 #: src/olympia/users/templates/users/mobile/login.html:56
 msgid "Log in"
 msgstr "Iniciar sessão"
@@ -15086,8 +11971,7 @@ msgstr "Iniciar sessão"
 msgid "Localize for: <a id=\"change-locale\" href=\"#\">%(dl)s</a>"
 msgstr "Localizar: <a id=\"change-locale\" href=\"#\">%(dl)s</a>"
 
-#: src/olympia/translations/templates/translations/trans-menu.html:16
-#: src/olympia/translations/templates/translations/trans-menu.html:29
+#: src/olympia/translations/templates/translations/trans-menu.html:16 src/olympia/translations/templates/translations/trans-menu.html:29
 #, python-format
 msgid "%(title)s <em>&middot; %(lang)s</em>"
 msgstr "%(title)s <em>&middot; %(lang)s</em>"
@@ -15102,12 +11986,8 @@ msgstr "Novos idiomas"
 
 #. {0} is a language name, like 'French'
 #: src/olympia/translations/templates/translations/trans-menu.html:42
-msgid ""
-"You have unsaved changes in the <b>{0}</b> locale. Would you like to save "
-"your changes before switching locales?"
-msgstr ""
-"Tem alterações não guardadas no idioma <b>{0}</b>. Deseja guardar as suas "
-"alterações antes de trocar de idioma?"
+msgid "You have unsaved changes in the <b>{0}</b> locale. Would you like to save your changes before switching locales?"
+msgstr "Tem alterações não guardadas no idioma <b>{0}</b>. Deseja guardar as suas alterações antes de trocar de idioma?"
 
 #: src/olympia/translations/templates/translations/trans-menu.html:49
 msgid "Discard Changes"
@@ -15115,12 +11995,8 @@ msgstr "Ignorar alterações"
 
 #. {0} is a language name, like 'French'
 #: src/olympia/translations/templates/translations/trans-menu.html:56
-msgid ""
-"Are you sure you want to remove all <b>{0}</b> translations? This cannot be "
-"undone."
-msgstr ""
-"Tem a certeza que deseja remover todas as <b>{0}</b> traduções? Isto não "
-"poderá ser anulado."
+msgid "Are you sure you want to remove all <b>{0}</b> translations? This cannot be undone."
+msgstr "Tem a certeza que deseja remover todas as <b>{0}</b> traduções? Isto não poderá ser anulado."
 
 #: src/olympia/translations/templates/translations/trans-menu.html:61
 msgid "Delete Locale"
@@ -15141,25 +12017,16 @@ msgstr "Essa palavra-passe não é permitida."
 
 #: src/olympia/users/forms.py:90
 #, python-format
-msgid ""
-"As part of our new password policy, your password must be %s characters or "
-"more. Please update your password by <a href=\"%s\">issuing a password "
-"reset</a>."
+msgid "As part of our new password policy, your password must be %s characters or more. Please update your password by <a href=\"%s\">issuing a password reset</a>."
 msgstr ""
-"Como parte da nossa nova política de palavras-passe, a sua palavra-passe "
-"deve ter pelo menos %s caracteres. Por favor atualize a sua palavra-passe <a"
-" href=\"%s\">solicitando uma reposição de palavra-passe</a>."
+"Como parte da nossa nova política de palavras-passe, a sua palavra-passe deve ter pelo menos %s caracteres. Por favor atualize a sua palavra-passe <a href=\"%s\">solicitando uma reposição de "
+"palavra-passe</a>."
 
 #: src/olympia/users/forms.py:115
-msgid ""
-"You must recover your password through Firefox Accounts. Try logging in "
-"instead."
-msgstr ""
-"Necessita de recuperar a sua palavra-passe através do Contas Firefox. Tente "
-"iniciar sessão."
+msgid "You must recover your password through Firefox Accounts. Try logging in instead."
+msgstr "Necessita de recuperar a sua palavra-passe através do Contas Firefox. Tente iniciar sessão."
 
-#: src/olympia/users/forms.py:206
-#: src/olympia/users/templates/users/pwreset_confirm.html:24
+#: src/olympia/users/forms.py:206 src/olympia/users/templates/users/pwreset_confirm.html:24
 msgid "New password"
 msgstr "Nova palavra-passe"
 
@@ -15172,12 +12039,8 @@ msgid "Usernames cannot contain only digits."
 msgstr "Nomes de utilizador não podem conter apenas dígitos."
 
 #: src/olympia/users/forms.py:274
-msgid ""
-"Enter a valid username consisting of letters, numbers, underscores or "
-"hyphens."
-msgstr ""
-"Digite um nome de utilizador válido constituído por letras, números, traços "
-"inferiores ou hífenes."
+msgid "Enter a valid username consisting of letters, numbers, underscores or hyphens."
+msgstr "Digite um nome de utilizador válido constituído por letras, números, traços inferiores ou hífenes."
 
 #: src/olympia/users/forms.py:277
 msgid "This username cannot be used."
@@ -15187,38 +12050,25 @@ msgstr "Este nome de utilizador não pode ser utilizado."
 msgid "This username is already in use."
 msgstr "Este nome de utilizador já está a ser utilizado."
 
-#: src/olympia/users/forms.py:296
-#: src/olympia/users/templates/users/edit.html:107
+#: src/olympia/users/forms.py:296 src/olympia/users/templates/users/edit.html:107
 msgid "Display Name"
 msgstr "Nome a mostrar"
 
-#: src/olympia/users/forms.py:298
-#: src/olympia/users/templates/users/edit.html:112
-#: src/olympia/users/templates/users/vcard.html:10
+#: src/olympia/users/forms.py:298 src/olympia/users/templates/users/edit.html:112 src/olympia/users/templates/users/vcard.html:10
 msgid "Location"
 msgstr "Localização"
 
-#: src/olympia/users/forms.py:300
-#: src/olympia/users/templates/users/edit.html:117
-#: src/olympia/users/templates/users/vcard.html:16
+#: src/olympia/users/forms.py:300 src/olympia/users/templates/users/edit.html:117 src/olympia/users/templates/users/vcard.html:16
 msgid "Occupation"
 msgstr "Ocupação"
 
 #: src/olympia/users/forms.py:329
-msgid ""
-"This URL has an invalid format. Valid URLs look like "
-"http://example.com/my_page."
-msgstr ""
-"Este URL tem um formato inválido. URLs válidos são do tipo "
-"http://example.com/my_page."
+msgid "This URL has an invalid format. Valid URLs look like http://example.com/my_page."
+msgstr "Este URL tem um formato inválido. URLs válidos são do tipo http://example.com/my_page."
 
 #: src/olympia/users/forms.py:337
-msgid ""
-"Please use an email address from a different provider to complete your "
-"registration."
-msgstr ""
-"Por favor use um endereço de email de outro fornecedor para finalizar o seu "
-"registo."
+msgid "Please use an email address from a different provider to complete your registration."
+msgstr "Por favor use um endereço de email de outro fornecedor para finalizar o seu registo."
 
 #: src/olympia/users/forms.py:345
 msgid "This display name cannot be used."
@@ -15228,21 +12078,17 @@ msgstr "Este nome de apresentação não pode ser utilizado."
 msgid "The passwords did not match."
 msgstr "As palavras-passe não coincidem."
 
-#: src/olympia/users/forms.py:377
-#: src/olympia/users/templates/users/edit.html:128
+#: src/olympia/users/forms.py:377 src/olympia/users/templates/users/edit.html:128
 msgid "Profile Photo"
 msgstr "Fotografia do perfil"
 
-#: src/olympia/users/forms.py:385
-#: src/olympia/users/templates/users/edit.html:142
+#: src/olympia/users/forms.py:385 src/olympia/users/templates/users/edit.html:142
 msgid "Default locale"
 msgstr "Idioma por omissão"
 
 #: src/olympia/users/forms.py:412
 msgid "Firefox Accounts users cannot currently change their email address."
-msgstr ""
-"Os utilizadores das Contas Firefox atualmente não podem alterar o seu "
-"endereço de e-mail."
+msgstr "Os utilizadores das Contas Firefox atualmente não podem alterar o seu endereço de e-mail."
 
 #: src/olympia/users/forms.py:446
 msgid "Wrong password entered!"
@@ -15253,12 +12099,8 @@ msgid "Email cannot be changed."
 msgstr "O e-mail não pode ser alterado."
 
 #: src/olympia/users/forms.py:541
-msgid ""
-"To anonymize, enter a reason for the change but do not change any other "
-"field."
-msgstr ""
-"Para ficar anónimo, escreva uma razão para a alteração mas não altere nenhum"
-" outro campo."
+msgid "To anonymize, enter a reason for the change but do not change any other field."
+msgstr "Para ficar anónimo, escreva uma razão para a alteração mas não altere nenhum outro campo."
 
 #: src/olympia/users/forms.py:587
 msgid "Please enter at least one name to blacklist."
@@ -15287,19 +12129,19 @@ msgstr "Nenhum utilizador com esse email."
 
 #. L10n: {id} will be something like "13ad6a", just a random number
 #. to differentiate this user from other anonymous users.
-#: src/olympia/users/models.py:353
+#: src/olympia/users/models.py:362
 msgid "Anonymous user {id}"
 msgstr "Utilizador anónimo {id}"
 
-#: src/olympia/users/models.py:410
+#: src/olympia/users/models.py:419
 msgid "Your account has been restricted"
 msgstr "A sua conta foi restringida"
 
-#: src/olympia/users/models.py:480
+#: src/olympia/users/models.py:489
 msgid "Please confirm your email address"
 msgstr "Confirme o seu endereço de email"
 
-#: src/olympia/users/models.py:506
+#: src/olympia/users/models.py:515
 msgid "My Mobile Add-ons"
 msgstr "Os meus extras do Mobile"
 
@@ -15367,16 +12209,12 @@ msgid "Mozilla needs to contact me about my individual app"
 msgstr "Mozilla precisa entrar em contato sobre meu aplicativo"
 
 #: src/olympia/users/notifications.py:139
-msgid ""
-"Mozilla wants to contact me about relevant App Developer news and surveys"
-msgstr ""
-"A Mozilla quer contactar-me para notícias e inquéritos relevantes para "
-"programadores de aplicações"
+msgid "Mozilla wants to contact me about relevant App Developer news and surveys"
+msgstr "A Mozilla quer contactar-me para notícias e inquéritos relevantes para programadores de aplicações"
 
 #: src/olympia/users/notifications.py:150
 msgid "Mozilla wants to contact me about new regions added to the Marketplace"
-msgstr ""
-"A Mozilla quer contactar-me sobre novas regiões adicionadas ao Marketplace"
+msgstr "A Mozilla quer contactar-me sobre novas regiões adicionadas ao Marketplace"
 
 #: src/olympia/users/notifications.py:158
 msgid "User Notifications"
@@ -15399,14 +12237,8 @@ msgid "Successfully verified!"
 msgstr "Verificado com Sucesso!"
 
 #: src/olympia/users/views.py:132
-msgid ""
-"An email has been sent to your address to confirm your account. Before you "
-"can log in, you have to activate your account by clicking on the link "
-"provided in this email."
-msgstr ""
-"Foi enviado um email para o seu endereço para confirmar a sua conta. Antes "
-"de iniciar sessão, deve ativar a sua conta clicando na ligação fornecida "
-"neste email."
+msgid "An email has been sent to your address to confirm your account. Before you can log in, you have to activate your account by clicking on the link provided in this email."
+msgstr "Foi enviado um email para o seu endereço para confirmar a sua conta. Antes de iniciar sessão, deve ativar a sua conta clicando na ligação fornecida neste email."
 
 #: src/olympia/users/views.py:136 src/olympia/users/views.py:619
 msgid "Confirmation Email Sent"
@@ -15430,13 +12262,11 @@ msgstr "Mensagem de confirmação enviada"
 
 #: src/olympia/users/views.py:197
 msgid ""
-"An email has been sent to {0} to confirm your new email address. For the "
-"change to take effect, you need to click on the link provided in this email."
-" Until then, you can keep logging in with your current email address."
+"An email has been sent to {0} to confirm your new email address. For the change to take effect, you need to click on the link provided in this email. Until then, you can keep logging in with your "
+"current email address."
 msgstr ""
-"Foi enviado um email para {0} para confirmar o seu novo endereço. Para a "
-"alteração ter efeito, tem de clicar na ligação incluída nesse email. Até lá,"
-" pode continuar a entrar com o seu endereço de email atual."
+"Foi enviado um email para {0} para confirmar o seu novo endereço. Para a alteração ter efeito, tem de clicar na ligação incluída nesse email. Até lá, pode continuar a entrar com o seu endereço de "
+"email atual."
 
 #: src/olympia/users/views.py:210
 #, python-format
@@ -15448,16 +12278,12 @@ msgid "Errors Found"
 msgstr "Erros encontrados"
 
 #: src/olympia/users/views.py:225
-msgid ""
-"There were errors in the changes you made. Please correct them and resubmit."
-msgstr ""
-"Houve erros nas alterações que efetuou. Corrija-os e volte a submeter."
+msgid "There were errors in the changes you made. Please correct them and resubmit."
+msgstr "Houve erros nas alterações que efetuou. Corrija-os e volte a submeter."
 
 #: src/olympia/users/views.py:273
-msgid ""
-"We're sorry, but you are not eligible to request a t-shirt at this time."
-msgstr ""
-"Pedimos desculpa, mas não é elegível a solicitar uma t-shirt neste momento."
+msgid "We're sorry, but you are not eligible to request a t-shirt at this time."
+msgstr "Pedimos desculpa, mas não é elegível a solicitar uma t-shirt neste momento."
 
 #: src/olympia/users/views.py:329
 msgid "Your email address was changed successfully"
@@ -15472,25 +12298,17 @@ msgid "Wrong email address or password!"
 msgstr "Palavra-passe ou endereço de email errados!"
 
 #: src/olympia/users/views.py:434
-msgid ""
-"A link to activate your user account was sent by email to your address {0}. "
-"You have to click it before you can log in."
-msgstr ""
-"Uma ligação para ativar a sua conta foi enviada por email para o endereço "
-"{0}. Tem de clicar nele antes de iniciar sessão."
+msgid "A link to activate your user account was sent by email to your address {0}. You have to click it before you can log in."
+msgstr "Uma ligação para ativar a sua conta foi enviada por email para o endereço {0}. Tem de clicar nele antes de iniciar sessão."
 
 #: src/olympia/users/views.py:439
 #, python-format
 msgid ""
-"If you did not receive the confirmation email, make sure your email service "
-"did not mark it as \"junk mail\" or \"spam\". If you need to, you can have "
-"us <a href=\"%s\">resend the confirmation message</a> to your email address "
-"mentioned above."
+"If you did not receive the confirmation email, make sure your email service did not mark it as \"junk mail\" or \"spam\". If you need to, you can have us <a href=\"%s\">resend the confirmation "
+"message</a> to your email address mentioned above."
 msgstr ""
-"Se não recebeu um email de confirmação, tenha certeza de que seu serviço de "
-"email não marcou a mensagem como \"Lixo\" ou \"Spam\". Se precisar, podemos "
-"<a href=\"%s\">reenviar a mensagem de confirmação</a> para o seu endereço de"
-" email mencionado acima."
+"Se não recebeu um email de confirmação, tenha certeza de que seu serviço de email não marcou a mensagem como \"Lixo\" ou \"Spam\". Se precisar, podemos <a href=\"%s\">reenviar a mensagem de "
+"confirmação</a> para o seu endereço de email mencionado acima."
 
 #: src/olympia/users/views.py:444
 msgid "Activation Email Sent"
@@ -15510,13 +12328,8 @@ msgstr "Parabéns! A sua conta de utilizador foi criada com sucesso."
 
 # %1 is the user's email address
 #: src/olympia/users/views.py:615
-msgid ""
-"An email has been sent to your address {0} to confirm your account. Before "
-"you can log in, you have to activate your account by clicking on the link "
-"provided in this email."
-msgstr ""
-"Foi enviado um email a {0} para confirmar a sua conta. Antes de poder "
-"entrar, tem de ativar a sua conta clicando na ligação fornecida neste email."
+msgid "An email has been sent to your address {0} to confirm your account. Before you can log in, you have to activate your account by clicking on the link provided in this email."
+msgstr "Foi enviado um email a {0} para confirmar a sua conta. Antes de poder entrar, tem de ativar a sua conta clicando na ligação fornecida neste email."
 
 #: src/olympia/users/views.py:639
 msgid "There are errors in this form"
@@ -15534,31 +12347,22 @@ msgstr "Utilizador reportado."
 msgid "new"
 msgstr "novo"
 
-#: src/olympia/users/templates/users/delete.html:4
-#: src/olympia/users/templates/users/delete.html:10
+#: src/olympia/users/templates/users/delete.html:4 src/olympia/users/templates/users/delete.html:10
 msgid "Delete User Account"
 msgstr "Eliminar conta de utilizador"
 
 #: src/olympia/users/templates/users/delete.html:14
 #, python-format
 msgid ""
-"You cannot delete your account if you are listed as an <a href=\"%(link)s\">"
-" author of any add-ons</a>. To delete your account, please have another "
-"person in your development group delete you from the list of authors for "
-"your add-ons. Afterwards you will be able to delete your account here."
+"You cannot delete your account if you are listed as an <a href=\"%(link)s\"> author of any add-ons</a>. To delete your account, please have another person in your development group delete you from "
+"the list of authors for your add-ons. Afterwards you will be able to delete your account here."
 msgstr ""
-"Não pode eliminar a sua conta se tiver listado como um <a href=\"%(link)s\">"
-" autor de extras</a>. Para eliminar a sua conta, peça a outra pessoa no seu "
-"grupo de desenvolvimento para o eliminar da lista de autores dos seus "
-"extras. Depois já poderá eliminar aqui a sua conta."
+"Não pode eliminar a sua conta se tiver listado como um <a href=\"%(link)s\"> autor de extras</a>. Para eliminar a sua conta, peça a outra pessoa no seu grupo de desenvolvimento para o eliminar da "
+"lista de autores dos seus extras. Depois já poderá eliminar aqui a sua conta."
 
 #: src/olympia/users/templates/users/delete.html:29
-msgid ""
-"By clicking \"delete\" your account is going to be <strong>permanently "
-"removed</strong>. That means:"
-msgstr ""
-"Ao clicar \"eliminar\", a sua conta será <strong>permanentemente "
-"removida</strong>. Isto significa:"
+msgid "By clicking \"delete\" your account is going to be <strong>permanently removed</strong>. That means:"
+msgstr "Ao clicar \"eliminar\", a sua conta será <strong>permanentemente removida</strong>. Isto significa:"
 
 #: src/olympia/users/templates/users/delete.html:35
 #, python-format
@@ -15566,12 +12370,8 @@ msgid "You will not be able to log into %(site)s anymore."
 msgstr "Deixará de conseguir iniciar sessão em %(site)s."
 
 #: src/olympia/users/templates/users/delete.html:40
-msgid ""
-"Your reviews and ratings will not be deleted, but they will no longer be "
-"associated with you."
-msgstr ""
-"As suas análises e classificações não serão eliminadas, mas deixaram de "
-"estar associadas a si."
+msgid "Your reviews and ratings will not be deleted, but they will no longer be associated with you."
+msgstr "As suas análises e classificações não serão eliminadas, mas deixaram de estar associadas a si."
 
 #: src/olympia/users/templates/users/delete.html:46
 msgid "Confirm account deletion"
@@ -15585,8 +12385,7 @@ msgstr "Eu compreendo que este passo não pode ser anulado"
 msgid "Delete my user account now"
 msgstr "Eliminar agora a minha conta de utilizador"
 
-#: src/olympia/users/templates/users/delete_photo.html:3
-#: src/olympia/users/templates/users/delete_photo.html:9
+#: src/olympia/users/templates/users/delete_photo.html:3 src/olympia/users/templates/users/delete_photo.html:9
 msgid "Delete User Photo"
 msgstr "Eliminar fotografia do utilizador"
 
@@ -15599,27 +12398,18 @@ msgid "Please set your display name"
 msgstr "Por favor, defina o seu nome de apresentação"
 
 #: src/olympia/users/templates/users/edit.html:21
-msgid ""
-"Please set your display name or username to complete the registration "
-"process."
-msgstr ""
-"Por favor, defina o seu nome de apresentação ou nome de utilizador para "
-"concluir o processo de registo."
+msgid "Please set your display name or username to complete the registration process."
+msgstr "Por favor, defina o seu nome de apresentação ou nome de utilizador para concluir o processo de registo."
 
 #: src/olympia/users/templates/users/edit.html:33
 msgid "Manage basic account information, such as username and email address."
-msgstr ""
-"Faça a gestão da informação da conta, como o nome de utilizador e o endereço"
-" de email."
+msgstr "Faça a gestão da informação da conta, como o nome de utilizador e o endereço de email."
 
-#: src/olympia/users/templates/users/edit.html:39
-#: src/olympia/users/templates/users/register.html:47
+#: src/olympia/users/templates/users/edit.html:39 src/olympia/users/templates/users/register.html:47
 msgid "Username"
 msgstr "Nome de utilizador"
 
-#: src/olympia/users/templates/users/edit.html:45
-#: src/olympia/users/templates/users/pwreset_request.html:21
-#: src/olympia/users/templates/users/register.html:62
+#: src/olympia/users/templates/users/edit.html:45 src/olympia/users/templates/users/pwreset_request.html:21 src/olympia/users/templates/users/register.html:62
 msgid "Email Address"
 msgstr "Endereço de email"
 
@@ -15631,21 +12421,15 @@ msgstr "Gerir a Conta Firefox..."
 msgid "Change Password"
 msgstr "Alterar palavra-passe"
 
-#: src/olympia/users/templates/users/edit.html:68
-#: src/olympia/users/templates/users/login_form.html:22
-#: src/olympia/users/templates/users/register.html:67
+#: src/olympia/users/templates/users/edit.html:68 src/olympia/users/templates/users/login_form.html:22 src/olympia/users/templates/users/register.html:67
 #: src/olympia/users/templates/users/mobile/login.html:37
 msgid "Password"
 msgstr "Palavra-passe"
 
 #: src/olympia/users/templates/users/edit.html:70
 #, python-format
-msgid ""
-"Change your password.  If you forgot your password, you can <a "
-"href=\"%(reset_url)s\">use the reset form</a>."
-msgstr ""
-"Altere a sua palavra-passe.  Se se esqueceu da sua palavra-passe, pode <a "
-"href=\"%(reset_url)s\">utilizar o formulário de reposição</a>."
+msgid "Change your password. If you forgot your password, you can <a href=\"%(reset_url)s\">use the reset form</a>."
+msgstr "Altere a sua palavra-passe.  Se se esqueceu da sua palavra-passe, pode <a href=\"%(reset_url)s\">utilizar o formulário de reposição</a>."
 
 #: src/olympia/users/templates/users/edit.html:76
 msgid "Old Password"
@@ -15664,12 +12448,8 @@ msgid "Profile"
 msgstr "Perfil"
 
 #: src/olympia/users/templates/users/edit.html:100
-msgid ""
-"Give us a bit more information about yourself.  All these fields are "
-"optional, but they'll help other users get to know you better."
-msgstr ""
-"Dê-nos um pouco mais de informação acerca de si.  Todos estes campos são "
-"opcionais, mas irão ajudar outros utilizadores a chegar a conhecê-lo melhor."
+msgid "Give us a bit more information about yourself. All these fields are optional, but they'll help other users get to know you better."
+msgstr "Dê-nos um pouco mais de informação acerca de si.  Todos estes campos são opcionais, mas irão ajudar outros utilizadores a chegar a conhecê-lo melhor."
 
 #: src/olympia/users/templates/users/edit.html:124
 msgid "This URL will only be visible if you are a developer."
@@ -15684,20 +12464,12 @@ msgid "Delete current photo"
 msgstr "Eliminar foto atual"
 
 #: src/olympia/users/templates/users/edit.html:144
-msgid ""
-"This is the default locale used to display information about you (like your "
-"description)."
-msgstr ""
-"Este é o idioma por omissão utilizado para apresentar informações sobre si "
-"(como por exemplo, a descrição)."
+msgid "This is the default locale used to display information about you (like your description)."
+msgstr "Este é o idioma por omissão utilizado para apresentar informações sobre si (como por exemplo, a descrição)."
 
 #: src/olympia/users/templates/users/edit.html:152
-msgid ""
-"Introduce yourself to the community, if you like! This text will appear "
-"publicly on your user info page."
-msgstr ""
-"Apresente-se à comunidade, se desejar! Este texto irá aparecer publicamente "
-"na informação da sua página de utilizador."
+msgid "Introduce yourself to the community, if you like! This text will appear publicly on your user info page."
+msgstr "Apresente-se à comunidade, se desejar! Este texto irá aparecer publicamente na informação da sua página de utilizador."
 
 #: src/olympia/users/templates/users/edit.html:161
 msgid "Allowed HTML: {0}. Links are forbidden."
@@ -15724,21 +12496,12 @@ msgid "Notifications"
 msgstr "Notificações"
 
 #: src/olympia/users/templates/users/edit.html:195
-msgid ""
-"From time to time, Mozilla may send you email about upcoming releases and "
-"add-on events. Please select the topics you are interested in."
-msgstr ""
-"De tempo a tempo, a Mozilla poderá enviar-lhe um email sobre os próximos "
-"lançamentos e eventos sobre extras. Por favor, selecione os tópicos de "
-"interesse."
+msgid "From time to time, Mozilla may send you email about upcoming releases and add-on events. Please select the topics you are interested in."
+msgstr "De tempo a tempo, a Mozilla poderá enviar-lhe um email sobre os próximos lançamentos e eventos sobre extras. Por favor, selecione os tópicos de interesse."
 
 #: src/olympia/users/templates/users/edit.html:205
-msgid ""
-"Mozilla reserves the right to contact you individually about specific "
-"concerns with your hosted add-ons."
-msgstr ""
-"A Mozilla reserva o direito de o contactar individualmente sobre "
-"preocupações específicas sobre os extras hospedados."
+msgid "Mozilla reserves the right to contact you individually about specific concerns with your hosted add-ons."
+msgstr "A Mozilla reserva o direito de o contactar individualmente sobre preocupações específicas sobre os extras hospedados."
 
 #: src/olympia/users/templates/users/edit.html:215
 msgid "Admin"
@@ -15760,63 +12523,49 @@ msgstr "nenhum"
 msgid "all"
 msgstr "tudo"
 
-#: src/olympia/users/templates/users/fxa_migration.html:3
-#: src/olympia/users/templates/users/fxa_migration.html:11
-#: src/olympia/users/templates/users/mobile/fxa_migration.html:3
+#: src/olympia/users/templates/users/fxa_migration.html:3 src/olympia/users/templates/users/fxa_migration.html:11 src/olympia/users/templates/users/mobile/fxa_migration.html:3
 #: src/olympia/users/templates/users/mobile/fxa_migration.html:8
 msgid "Migrate to Firefox Accounts"
 msgstr "Migrar para Contas Firefox"
 
 #: src/olympia/users/templates/users/fxa_migration_prompt_content.html:3
-msgid ""
-"Mozilla Add-ons has transitioned to Firefox Accounts for login. Continue to "
-"complete the simple upgrade process."
-msgstr ""
-"Extras do Firefox transitou para Contas Firefox para início de sessão. "
-"Continue para completar o processo de atualização simples."
+msgid "Mozilla Add-ons has transitioned to Firefox Accounts for login. Continue to complete the simple upgrade process."
+msgstr "Extras do Firefox transitou para Contas Firefox para início de sessão. Continue para completar o processo de atualização simples."
 
 #: src/olympia/users/templates/users/fxa_migration_prompt_content.html:14
 msgid "Skip"
 msgstr "Saltar"
 
-#: src/olympia/users/templates/users/login.html:3
-#: src/olympia/users/templates/users/mobile/login.html:3
+#: src/olympia/users/templates/users/login.html:3 src/olympia/users/templates/users/mobile/login.html:3
 msgid "User Login"
 msgstr "Início de sessão"
 
-#: src/olympia/users/templates/users/login.html:13
-#: src/olympia/users/templates/users/mobile/login.html:21
+#: src/olympia/users/templates/users/login.html:13 src/olympia/users/templates/users/mobile/login.html:21
 msgid "Enter your email"
 msgstr "Introduza o seu e-mail"
 
-#: src/olympia/users/templates/users/login.html:15
-#: src/olympia/users/templates/users/mobile/login.html:23
+#: src/olympia/users/templates/users/login.html:15 src/olympia/users/templates/users/mobile/login.html:23
 msgid "Log In"
 msgstr "Iniciar sessão"
 
-#: src/olympia/users/templates/users/login_form.html:17
-#: src/olympia/users/templates/users/mobile/login.html:32
+#: src/olympia/users/templates/users/login_form.html:17 src/olympia/users/templates/users/mobile/login.html:32
 msgid "Email address"
 msgstr "Endereço de email"
 
-#: src/olympia/users/templates/users/login_form.html:30
-#: src/olympia/users/templates/users/mobile/login.html:44
+#: src/olympia/users/templates/users/login_form.html:30 src/olympia/users/templates/users/mobile/login.html:44
 msgid "Remember me on this device"
 msgstr "Memorizar-me neste dispositivo"
 
 # This is a header for additional help options
-#: src/olympia/users/templates/users/login_help.html:3
-#: src/olympia/users/templates/users/mobile/login.html:63
+#: src/olympia/users/templates/users/login_help.html:3 src/olympia/users/templates/users/mobile/login.html:63
 msgid "Login Problems?"
 msgstr "Problemas de início de sessão?"
 
-#: src/olympia/users/templates/users/login_help.html:5
-#: src/olympia/users/templates/users/mobile/login.html:65
+#: src/olympia/users/templates/users/login_help.html:5 src/olympia/users/templates/users/mobile/login.html:65
 msgid "I don't have an account."
 msgstr "Não tenho uma conta."
 
-#: src/olympia/users/templates/users/login_help.html:6
-#: src/olympia/users/templates/users/mobile/login.html:66
+#: src/olympia/users/templates/users/login_help.html:6 src/olympia/users/templates/users/mobile/login.html:66
 msgid "I forgot my password."
 msgstr "Eu esqueci-me da minha palavra-passe."
 
@@ -15825,15 +12574,9 @@ msgstr "Eu esqueci-me da minha palavra-passe."
 msgid "You are now logged in as <strong>%(user_email)s</strong>!"
 msgstr "Está ligado como <strong>%(user_email)s</strong>!"
 
-#: src/olympia/users/templates/users/newpw_sent.html:3
-#: src/olympia/users/templates/users/newpw_sent.html:8
-#: src/olympia/users/templates/users/pwreset_complete.html:3
-#: src/olympia/users/templates/users/pwreset_confirm.html:4
-#: src/olympia/users/templates/users/pwreset_confirm.html:18
-#: src/olympia/users/templates/users/pwreset_request.html:4
-#: src/olympia/users/templates/users/pwreset_request.html:10
-#: src/olympia/users/templates/users/pwreset_sent.html:3
-#: src/olympia/users/templates/users/pwreset_sent.html:8
+#: src/olympia/users/templates/users/newpw_sent.html:3 src/olympia/users/templates/users/newpw_sent.html:8 src/olympia/users/templates/users/pwreset_complete.html:3
+#: src/olympia/users/templates/users/pwreset_confirm.html:4 src/olympia/users/templates/users/pwreset_confirm.html:18 src/olympia/users/templates/users/pwreset_request.html:4
+#: src/olympia/users/templates/users/pwreset_request.html:10 src/olympia/users/templates/users/pwreset_sent.html:3 src/olympia/users/templates/users/pwreset_sent.html:8
 msgid "Password Reset"
 msgstr "Reposição de palavra-passe"
 
@@ -15849,8 +12592,7 @@ msgstr "Editar perfil"
 msgid "Manage user"
 msgstr "Gerir utilizador"
 
-#: src/olympia/users/templates/users/profile.html:18
-#: src/olympia/users/templates/users/report_abuse_full.html:9
+#: src/olympia/users/templates/users/profile.html:18 src/olympia/users/templates/users/report_abuse_full.html:9
 msgid "Report user"
 msgstr "Reportar utilizador"
 
@@ -15913,39 +12655,25 @@ msgstr "Sucesso!"
 msgid "Password successfully reset."
 msgstr "Palavra-passe reposta com sucesso."
 
-#: src/olympia/users/templates/users/pwreset_confirm.html:13
-#: src/olympia/users/templates/users/pwreset_confirm.html:46
+#: src/olympia/users/templates/users/pwreset_confirm.html:13 src/olympia/users/templates/users/pwreset_confirm.html:46
 msgid "Password reset unsuccessful"
 msgstr "A reposição da palavra-passe falhou"
 
 #: src/olympia/users/templates/users/pwreset_confirm.html:14
-msgid ""
-"You have migrated to Firefox Accounts. You can no longer change your "
-"password here."
-msgstr ""
-"Migrou para o Contas Firefox. Já não poderá alterar a sua palavra-passe "
-"aqui."
+msgid "You have migrated to Firefox Accounts. You can no longer change your password here."
+msgstr "Migrou para o Contas Firefox. Já não poderá alterar a sua palavra-passe aqui."
 
-#: src/olympia/users/templates/users/pwreset_confirm.html:31
-#: src/olympia/users/templates/users/register.html:72
+#: src/olympia/users/templates/users/pwreset_confirm.html:31 src/olympia/users/templates/users/register.html:72
 msgid "Confirm password"
 msgstr "Confirmar palavra-passe"
 
 #: src/olympia/users/templates/users/pwreset_confirm.html:47
-msgid ""
-"The password reset link was invalid, possibly because it has already been "
-"used.  Please request a new password reset."
-msgstr ""
-"A ligação da reposição de palavra-passe era inválida, possivelmente porque "
-"já foi utilizada.  Por favor solicite uma nova reposição de palavra-passe."
+msgid "The password reset link was invalid, possibly because it has already been used. Please request a new password reset."
+msgstr "A ligação da reposição de palavra-passe era inválida, possivelmente porque já foi utilizada.  Por favor solicite uma nova reposição de palavra-passe."
 
 #: src/olympia/users/templates/users/pwreset_request.html:15
-msgid ""
-"Forgotten your password? Enter your e-mail address below, and we'll e-mail "
-"instructions for setting a new one."
-msgstr ""
-"Esqueceu-se da sua palavra-passe? Escreva o seu endereço de e-mail abaixo, e"
-" nós enviar-lhe-emos instruções para definir uma nova."
+msgid "Forgotten your password? Enter your e-mail address below, and we'll e-mail instructions for setting a new one."
+msgstr "Esqueceu-se da sua palavra-passe? Escreva o seu endereço de e-mail abaixo, e nós enviar-lhe-emos instruções para definir uma nova."
 
 #: src/olympia/users/templates/users/pwreset_request.html:25
 msgid "Send password reset link"
@@ -15953,13 +12681,8 @@ msgstr "Enviar ligação de reposição da palavra-passe"
 
 #: src/olympia/users/templates/users/pwreset_sent.html:10
 msgid ""
-"An email has been sent to the requested account with further information. If"
-" you do not receive an email then please confirm you have entered the same "
-"email address used during account registration."
-msgstr ""
-"Foi enviado um email com mais informação. Se não receber o email por favor "
-"veja se escreveu o mesmo endereço de email que usou durante a criação da "
-"conta."
+"An email has been sent to the requested account with further information. If you do not receive an email then please confirm you have entered the same email address used during account registration."
+msgstr "Foi enviado um email com mais informação. Se não receber o email por favor veja se escreveu o mesmo endereço de email que usou durante a criação da conta."
 
 #: src/olympia/users/templates/users/register.html:4
 msgid "New User Registration"
@@ -15970,12 +12693,8 @@ msgid "Why register?"
 msgstr "Porquê registar-se?"
 
 #: src/olympia/users/templates/users/register.html:14
-msgid ""
-"Registration on AMO is <strong>not required</strong> if you simply want to "
-"download and install public add-ons."
-msgstr ""
-"O registo no AMO <strong>não é obrigatório</strong> se apenas quiser "
-"descarregar e instalar extras públicos."
+msgid "Registration on AMO is <strong>not required</strong> if you simply want to download and install public add-ons."
+msgstr "O registo no AMO <strong>não é obrigatório</strong> se apenas quiser descarregar e instalar extras públicos."
 
 #: src/olympia/users/templates/users/register.html:16
 msgid "You only need to register if:"
@@ -15986,53 +12705,29 @@ msgid "You want to submit reviews for add-ons"
 msgstr "Quiser submeter análises para extras"
 
 #: src/olympia/users/templates/users/register.html:19
-msgid ""
-"You want to keep track of your favorite add-on collections or create one "
-"yourself"
-msgstr ""
-"Quiser manter um registo das suas coleções favoritas de extras ou criar uma "
-"nova coleção"
+msgid "You want to keep track of your favorite add-on collections or create one yourself"
+msgstr "Quiser manter um registo das suas coleções favoritas de extras ou criar uma nova coleção"
 
 #: src/olympia/users/templates/users/register.html:20
-msgid ""
-"You are an add-on developer and want to upload your add-on for hosting on "
-"AMO"
-msgstr ""
-"Se for um programador de extras e quiser enviar o seu extra para ser "
-"disponibilizado no AMO"
+msgid "You are an add-on developer and want to upload your add-on for hosting on AMO"
+msgstr "Se for um programador de extras e quiser enviar o seu extra para ser disponibilizado no AMO"
 
 #: src/olympia/users/templates/users/register.html:23
-msgid ""
-"Upon successful registration, you will be sent a confirmation email to the "
-"address you provided. Please follow the instructions there to confirm your "
-"account."
-msgstr ""
-"Após um registo bem sucedido, será enviado um email de confirmação para o "
-"endereço que forneceu. Por favor, siga as instruções dessa mensagem para "
-"confirmar a sua conta."
+msgid "Upon successful registration, you will be sent a confirmation email to the address you provided. Please follow the instructions there to confirm your account."
+msgstr "Após um registo bem sucedido, será enviado um email de confirmação para o endereço que forneceu. Por favor, siga as instruções dessa mensagem para confirmar a sua conta."
 
 #: src/olympia/users/templates/users/register.html:30
 #, python-format
-msgid ""
-"If you like, you can read our <a href=\"%(legal)s\" title=\"Legal "
-"Notices\">Legal Notices</a> and <a href=\"%(privacy)s\" title=\"Privacy "
-"Policy\">Privacy Policy</a>."
-msgstr ""
-"Se quiser, pode ler os nossos <a href=\"%(legal)s\" title=\"Avisos "
-"legais\">Avisos legais</a> e <a href=\"%(privacy)s\" title=\"Política de "
-"privacidade\">Política de privacidade</a>."
+msgid "If you like, you can read our <a href=\"%(legal)s\" title=\"Legal Notices\">Legal Notices</a> and <a href=\"%(privacy)s\" title=\"Privacy Policy\">Privacy Policy</a>."
+msgstr "Se quiser, pode ler os nossos <a href=\"%(legal)s\" title=\"Avisos legais\">Avisos legais</a> e <a href=\"%(privacy)s\" title=\"Política de privacidade\">Política de privacidade</a>."
 
 #: src/olympia/users/templates/users/register.html:52
 msgid "Display name"
 msgstr "Nome a mostrar"
 
 #: src/olympia/users/templates/users/report_abuse.html:7
-msgid ""
-"Please describe why you are reporting this user, such as for spam or an "
-"inappropriate picture."
-msgstr ""
-"Por favor, descreva porque está a reportar este utilizador, como por spam ou"
-" uma imagem inapropriada."
+msgid "Please describe why you are reporting this user, such as for spam or an inappropriate picture."
+msgstr "Por favor, descreva porque está a reportar este utilizador, como por spam ou uma imagem inapropriada."
 
 #: src/olympia/users/templates/users/report_abuse_full.html:3
 msgid "Report user {0}"
@@ -16046,42 +12741,25 @@ msgstr "Pedido de t-shirt"
 msgid "Special Edition Add-on Creator T-shirt"
 msgstr "T-shirt especial, edição para criadores de extras"
 
-#: src/olympia/users/templates/users/t-shirt.html:14
-#: src/olympia/users/templates/users/t-shirt.html:120
+#: src/olympia/users/templates/users/t-shirt.html:14 src/olympia/users/templates/users/t-shirt.html:120
 msgid "Note:"
 msgstr "Nota:"
 
 #: src/olympia/users/templates/users/t-shirt.html:15
-msgid ""
-"You have already submitted a request for a t-shirt. You may re-submit this "
-"form to update your information, but you will only receive one shirt."
-msgstr ""
-"Já submeteu um pedido para uma t-shirt. Pode reenviar este formulário para "
-"atualizar a sua informação, mas apenas irá receber uma t-shirt."
+msgid "You have already submitted a request for a t-shirt. You may re-submit this form to update your information, but you will only receive one shirt."
+msgstr "Já submeteu um pedido para uma t-shirt. Pode reenviar este formulário para atualizar a sua informação, mas apenas irá receber uma t-shirt."
 
 #: src/olympia/users/templates/users/t-shirt.html:26
-msgid ""
-"Thank you for helping to make Firefox the most extensible browser available!"
-msgstr ""
-"Obrigado por ajudar a tornar o Firefox o navegador mais extensível "
-"disponível!"
+msgid "Thank you for helping to make Firefox the most extensible browser available!"
+msgstr "Obrigado por ajudar a tornar o Firefox o navegador mais extensível disponível!"
 
 #: src/olympia/users/templates/users/t-shirt.html:33
-msgid ""
-"As a thank you gift, we'd like to send you a special-edition, community-"
-"designed t-shirt. To receive your shirt, please fill out the form below."
-msgstr ""
-"Como prenda de agradecimento, gostaríamos de lhe enviar uma t-shirt "
-"especial, desenhada pela comunidade. Para receber a sua t-shirt, por favor "
-"preencha o formulário abaixo."
+msgid "As a thank you gift, we'd like to send you a special-edition, community-designed t-shirt. To receive your shirt, please fill out the form below."
+msgstr "Como prenda de agradecimento, gostaríamos de lhe enviar uma t-shirt especial, desenhada pela comunidade. Para receber a sua t-shirt, por favor preencha o formulário abaixo."
 
 #: src/olympia/users/templates/users/t-shirt.html:41
-msgid ""
-"Your contact information will only be used by Mozilla to ship this special "
-"edition t-shirt."
-msgstr ""
-"Os seus dados de contacto apenas serão utilizados pela Mozilla para lhe "
-"enviar esta t-shirt especial."
+msgid "Your contact information will only be used by Mozilla to ship this special edition t-shirt."
+msgstr "Os seus dados de contacto apenas serão utilizados pela Mozilla para lhe enviar esta t-shirt especial."
 
 #: src/olympia/users/templates/users/t-shirt.html:60
 msgid "Mailing Address"
@@ -16137,23 +12815,15 @@ msgstr "Solicitar t-shirt"
 
 #: src/olympia/users/templates/users/t-shirt.html:137
 msgid ""
-"We're sorry, but in order to qualify for our special edition t-shirt, you "
-"must be an add-on developer with at least one listed add-on, one unlisted "
-"but signed add-on, or any number of background themes with a combined total "
-"of 10,000 average daily users."
+"We're sorry, but in order to qualify for our special edition t-shirt, you must be an add-on developer with at least one listed add-on, one unlisted but signed add-on, or any number of background "
+"themes with a combined total of 10,000 average daily users."
 msgstr ""
-"Lamentamos, para se candidatar a nossa edição especial desta t-shirt, deve "
-"ser um programador de extras com pelo menos um extra listado, um extra não-"
-"listado mas assinado ou um qualquer número de temas de fundo com uma média "
-"total combinada de 10000 utilizadores diários."
+"Lamentamos, para se candidatar a nossa edição especial desta t-shirt, deve ser um programador de extras com pelo menos um extra listado, um extra não-listado mas assinado ou um qualquer número de "
+"temas de fundo com uma média total combinada de 10000 utilizadores diários."
 
 #: src/olympia/users/templates/users/tougher_password.html:2
-msgid ""
-"For your account a password must contain at least 8 characters including "
-"letters and numbers."
-msgstr ""
-"Para a sua conta, uma palavra-passe tem de conter, pelo menos, 8 caracteres "
-"incluindo letras e números."
+msgid "For your account a password must contain at least 8 characters including letters and numbers."
+msgstr "Para a sua conta, uma palavra-passe tem de conter, pelo menos, 8 caracteres incluindo letras e números."
 
 #: src/olympia/users/templates/users/unsubscribe.html:2
 msgid "Unsubscribe"
@@ -16165,11 +12835,8 @@ msgstr "Des-subscrição efectuada com sucesso!"
 
 #: src/olympia/users/templates/users/unsubscribe.html:10
 #, python-format
-msgid ""
-"The email address <strong>%(email)s</strong> will no longer get messages "
-"when:"
-msgstr ""
-"O endereço <strong>%(email)s</strong> deixará de receber mensagens quando:"
+msgid "The email address <strong>%(email)s</strong> will no longer get messages when:"
+msgstr "O endereço <strong>%(email)s</strong> deixará de receber mensagens quando:"
 
 #: src/olympia/users/templates/users/unsubscribe.html:20
 msgid "More Actions:"
@@ -16189,14 +12856,8 @@ msgstr "Não conseguimos des-subscrevê-lo"
 
 #: src/olympia/users/templates/users/unsubscribe.html:30
 #, python-format
-msgid ""
-"Unfortunately, we weren't able to unsubscribe you.  The link you clicked is "
-"invalid. However, you can unsubscribe still unsubscribe on your <a "
-"href=\"%(edit_url)s\">edit profile page</a>."
-msgstr ""
-"Infelizmente, não conseguimos cancelar a sua subscrição.  A ligação que "
-"clicou é inválida. Contudo, pode cancelar a subscrição na sua <a "
-"href=\"%(edit_url)s\">página de edição de perfil</a>."
+msgid "Unfortunately, we weren't able to unsubscribe you. The link you clicked is invalid. However, you can unsubscribe still unsubscribe on your <a href=\"%(edit_url)s\">edit profile page</a>."
+msgstr "Infelizmente, não conseguimos cancelar a sua subscrição.  A ligação que clicou é inválida. Contudo, pode cancelar a subscrição na sua <a href=\"%(edit_url)s\">página de edição de perfil</a>."
 
 #: src/olympia/users/templates/users/vcard.html:2
 msgid "Developer Information"
@@ -16249,15 +12910,15 @@ msgstr "Histórico de versões de %s"
 msgid "Version History with Changelogs"
 msgstr "Histórico de versões com registo de alterações"
 
-#: src/olympia/versions/models.py:314
+#: src/olympia/versions/models.py:313
 msgid "Add-on uses binary components."
 msgstr "O extra usa componentes binários."
 
-#: src/olympia/versions/models.py:317
+#: src/olympia/versions/models.py:316
 msgid "Add-on has opted into strict compatibility checking."
 msgstr "O extra optou pela verificação de compatibilidade estrita."
 
-#: src/olympia/versions/models.py:715
+#: src/olympia/versions/models.py:711
 msgid "{app} {min} and later"
 msgstr "{app} {min} e superiores"
 
@@ -16274,9 +12935,7 @@ msgstr "Lançado {0}"
 #: src/olympia/versions/templates/versions/version.html:39
 #, python-format
 msgid "Source code released under <a target=\"_blank\" href=\"%(url)s\">%(name)s</a>"
-msgstr ""
-"Código-fonte disponibilizado sob <a target=\"_blank\" "
-"href=\"%(url)s\">%(name)s</a>"
+msgstr "Código-fonte disponibilizado sob <a target=\"_blank\" href=\"%(url)s\">%(name)s</a>"
 
 # 77%
 #: src/olympia/versions/templates/versions/version.html:44
@@ -16288,8 +12947,8 @@ msgstr "Código-fonte disponibilizado sob <a href=\"%(url)s\">%(name)s</a>"
 msgid "View the source"
 msgstr "Ver a fonte"
 
-#. {0} is an add-on name.
 # {0} is the add-on name
+#. {0} is an add-on name.
 #: src/olympia/versions/templates/versions/version_list.html:26
 msgid "{0} Version History"
 msgstr "Histórico de versões de {0}"
@@ -16301,20 +12960,14 @@ msgid_plural "<b>{0}</b> versions"
 msgstr[0] "<b>{0}</b> versão"
 msgstr[1] "<b>{0}</b> versões"
 
-#: src/olympia/versions/templates/versions/version_list.html:35
-#: src/olympia/versions/templates/versions/mobile/version_list.html:14
+#: src/olympia/versions/templates/versions/version_list.html:35 src/olympia/versions/templates/versions/mobile/version_list.html:14
 msgid "Be careful with old versions!"
 msgstr "Tenha cuidado com extras antigos!"
 
-#: src/olympia/versions/templates/versions/version_list.html:36
-#: src/olympia/versions/templates/versions/mobile/version_list.html:15
+#: src/olympia/versions/templates/versions/version_list.html:36 src/olympia/versions/templates/versions/mobile/version_list.html:15
 #, python-format
-msgid ""
-"These versions are displayed for reference and testing purposes. You should "
-"always use the <a href=\"%(url)s\">latest version</a> of an add-on."
-msgstr ""
-"Estas versões são apresentadas para referência e fins de teste. Deve sempre "
-"utilizar a <a href=\"%(url)s\">última versão</a> de um extra."
+msgid "These versions are displayed for reference and testing purposes. You should always use the <a href=\"%(url)s\">latest version</a> of an add-on."
+msgstr "Estas versões são apresentadas para referência e fins de teste. Deve sempre utilizar a <a href=\"%(url)s\">última versão</a> de um extra."
 
 #: src/olympia/versions/templates/versions/mobile/version.html:4
 msgid "Beta Version {0}"
@@ -16344,3 +12997,7 @@ msgstr "Envie um email quando terminar"
 #: src/olympia/zadmin/forms.py:105
 msgid "Log emails instead of sending"
 msgstr "Registar emails em vez de enviar"
+
+#: src/olympia/zadmin/forms.py:215
+msgid "Deleted versions can`t be changed."
+msgstr ""

--- a/locale/pt_PT/LC_MESSAGES/djangojs.po
+++ b/locale/pt_PT/LC_MESSAGES/djangojs.po
@@ -1,1269 +1,1240 @@
-# 
+#
 msgid ""
 msgstr ""
 "Project-Id-Version: AMO-JS 0.1\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2016-02-24 21:23+0000\n"
+"POT-Creation-Date: 2016-04-18 15:47+0000\n"
 "PO-Revision-Date: 2016-04-14 01:27+0000\n"
 "Last-Translator: Rodrigo <rodrigo.mcunha@hotmail.com>\n"
 "Language-Team: \n"
-"Language: pt_PT\n"
+"Language: \n"
 "MIME-Version: 1.0\n"
-"Content-Type: text/plain; charset=utf-8\n"
+"Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 "Generated-By: Babel 2.2.0\n"
-"X-Generator: Pontoon\n"
 
-#: static/js/common/ratingwidget.js:31
-msgid "{0} star"
-msgid_plural "{0} stars"
-msgstr[0] "{0} estrela"
-msgstr[1] "{0} estrelas"
-
-#: static/js/common/upload-addon.js:41 static/js/common/upload-image.js:128
-msgid "There was a problem contacting the server."
-msgstr "Ocorreu um problema ao contactar o servidor."
-
-#: static/js/common/upload-addon.js:69
-msgid "Select a file..."
-msgstr "Selecione um ficheiro..."
-
-#: static/js/common/upload-addon.js:70
-msgid "Your add-on should end with .xpi, .jar or .xml"
-msgstr "O seu extra deve terminar com .xpi, .jar ou .xml"
-
-#. L10n: {0} is the percent of the file that has been uploaded.
-#: static/js/common/upload-addon.js:104
-#, python-format
-msgid "{0}% complete"
-msgstr "{0}% completo"
-
-#. L10n: "{bytes uploaded} of {total filesize}".
-#: static/js/common/upload-addon.js:107
-msgid "{0} of {1}"
-msgstr "{0} de {1}"
-
-#: static/js/common/upload-addon.js:140
-msgid "Cancel"
-msgstr "Cancelar"
-
-#: static/js/common/upload-addon.js:162
-msgid "Uploading {0}"
-msgstr "A carregar {0}"
-
-#: static/js/common/upload-addon.js:189
-msgid "Error with {0}"
-msgstr "Erro com {0}"
-
-#: static/js/common/upload-addon.js:194
-msgid "Your add-on failed validation with {0} error."
-msgid_plural "Your add-on failed validation with {0} errors."
-msgstr[0] "O seu extra falhou a validação com {0} erro."
-msgstr[1] "O seu extra falhou a validação com {0} erros."
-
-#: static/js/common/upload-addon.js:208
-msgid "&hellip;and {0} more"
-msgid_plural "&hellip;and {0} more"
-msgstr[0] "&hellip;e mais {0}"
-msgstr[1] "&hellip;e mais {0}"
-
-#: static/js/common/upload-addon.js:222 static/js/common/upload-addon.js:512
-msgid "See full validation report"
-msgstr "Ver relatório de validação completo"
-
-#: static/js/common/upload-addon.js:234
-msgid "Validating {0}"
-msgstr "A validar {0}"
-
-#. L10n: first argument is an HTTP status code
-#: static/js/common/upload-addon.js:273
-msgid "Received an empty response from the server; status: {0}"
-msgstr "Recebida resposta vazia do servidor; estado: {0}"
-
-#: static/js/common/upload-addon.js:373
-msgid "Unexpected server error while validating."
-msgstr "Erro inesperado do servidor enquanto validava."
-
-#: static/js/common/upload-addon.js:412
-msgid "Finished validating {0}"
-msgstr "Validação de {0} terminada"
-
-#: static/js/common/upload-addon.js:418
-msgid "Your add-on validation timed out, it will be manually reviewed."
-msgstr "A validação do seu extra expirou; será revisto manualmente."
-
-#: static/js/common/upload-addon.js:421
-msgid "Your add-on was validated with no errors and {0} warning."
-msgid_plural "Your add-on was validated with no errors and {0} warnings."
-msgstr[0] "O seu extra foi validado sem erros e com {0} aviso."
-msgstr[1] "O seu extra foi validado sem erros e com {0} avisos."
-
-#: static/js/common/upload-addon.js:426
-msgid "Your add-on was validated with no errors and {0} message."
-msgid_plural "Your add-on was validated with no errors and {0} messages."
-msgstr[0] "O seu extra foi validado sem erros e com {0} mensagem."
-msgstr[1] "O seu extra foi validado sem erros e com {0} mensagens."
-
-#: static/js/common/upload-addon.js:431
-msgid "Your add-on was validated with no errors or warnings."
-msgstr "O seu extra foi validado sem erros ou avisos."
-
-#: static/js/common/upload-addon.js:446
-msgid "Your submission will be automatically signed."
-msgstr "A sua submissão será assinada automaticamente."
-
-#: static/js/common/upload-addon.js:465
-msgid "Include detailed version notes (this can be done in the next step)."
-msgstr ""
-"Inclua notas detalhadas da versão (isto pode ser feito no próximo passo)."
-
-#: static/js/common/upload-addon.js:466
-msgid ""
-"If your add-on requires an account to a website in order to be fully tested,"
-" include a test username and password in the Notes to Reviewer (this can be "
-"done in the next step)."
-msgstr ""
-"Se para ser completamente testado, o seu extra requer uma conta para um "
-"website, inclua um nome de utilizador e palavra-passe de teste nas Notas ao "
-"Revisor (isto pode ser feito no próximo passo)."
-
-#: static/js/common/upload-addon.js:467
-msgid ""
-"If your add-on is intended for a limited audience you should choose "
-"Preliminary Review instead of Full Review."
-msgstr ""
-"Se o seu extra está direcionado para uma audiência limitada, deve escolher "
-"Revisão Preliminar em vez de Revisão Completa."
-
-#: static/js/common/upload-addon.js:480
-msgid "Add-on submission checklist"
-msgstr "Lista de controlo de submissão de extras"
-
-#: static/js/common/upload-addon.js:481
-msgid ""
-"Please verify the following points before finalizing your submission. This "
-"will minimize delays or misunderstanding during the review process:"
-msgstr ""
-"Por favor, confirme os pontos seguintes antes de finalizar a sua submissão. "
-"Isto irá minimizar atrasos ou lapsos durante o processo de revisão:"
-
-#: static/js/common/upload-addon.js:483
-msgid ""
-"Compiled binaries, as well as minified or obfuscated scripts (excluding "
-"known libraries) need to have their sources submitted separately for review."
-" Make sure that you use the source code upload field to avoid having your "
-"submission rejected."
-msgstr ""
-"Os binários compilados, bem como os scripts reduzidos ou ofuscados "
-"(excluindo as bibliotecas conhecidas) devem ter as suas fontes submetidas "
-"separadamente para revisão. Certifique-se que utiliza o campo de envio do "
-"código fonte para evitar que a sua submissão seja rejeitada."
-
-#: static/js/common/upload-addon.js:501
-msgid "The validation process found these issues that can lead to rejections:"
-msgstr ""
-"O processo de validação encontrou estes problemas que podem levar a "
-"rejeições:"
-
-#: static/js/common/upload-addon.js:518
-msgid ""
-"If you are unfamiliar with the add-ons review process, you can read about it"
-" here."
-msgstr ""
-"Se não está familiarizado com o processo de revisão de extras, pode ler mais"
-" aqui sobre este processo."
-
-#: static/js/common/upload-addon.js:555
-msgid "Sorry, no supported platform has been found."
-msgstr "Lamentamos, mas não foi encontrada nenhuma plataforma suportada."
-
-#: static/js/common/upload-base.js:57
-msgid "The filetype you uploaded isn't recognized."
-msgstr "O tipo de ficheiro que carregou não é reconhecido."
-
-#: static/js/common/upload-base.js:79
-msgid "You cancelled the upload."
-msgstr "Você cancelou o carregamento."
-
-#: static/js/common/upload-image.js:97 static/js/impala/users.js:51
-msgid "Images must be either PNG or JPG."
-msgstr "As imagens têm de ser PNG ou JPG."
-
-#: static/js/common/upload-image.js:101
-msgid "Videos must be in WebM."
-msgstr "Os vídeos devem estar no formato WebM."
-
-#: static/js/impala/collections.js:10 static/js/zamboni/collections.js:595
-msgid "Follow this Collection"
-msgstr "Seguir esta coleção"
-
-#: static/js/impala/collections.js:19
-msgid "Stop Following"
-msgstr "Deixar de seguir"
-
-#: static/js/impala/collections.js:20
-msgid "Following"
-msgstr "A seguir"
-
-#. L10n: {0} is an app name.
-#: static/js/impala/listing.js:11 static/js/zamboni/themes.js:13
-msgid "This theme is incompatible with your version of {0}"
-msgstr "Este tema é incompatível com a sua versão do {0}"
-
-#: static/js/impala/persona_creation.js:60
-msgid "All Rights Reserved"
-msgstr "Todos os direitos reservados"
-
-#: static/js/impala/persona_creation.js:64
-msgid "Creative Commons Attribution 3.0"
-msgstr "Creative Commons Attribution 3.0"
-
-#: static/js/impala/persona_creation.js:69
-msgid "Creative Commons Attribution-NonCommercial 3.0"
-msgstr "Creative Commons Attribution-NonCommercial 3.0"
-
-#: static/js/impala/persona_creation.js:74
-msgid "Creative Commons Attribution-NonCommercial-NoDerivs 3.0"
-msgstr "Creative Commons Attribution-NonCommercial-NoDerivs 3.0"
-
-#: static/js/impala/persona_creation.js:79
-msgid "Creative Commons Attribution-NonCommercial-Share Alike 3.0"
-msgstr "Creative Commons Attribution-NonCommercial-Share Alike 3.0"
-
-#: static/js/impala/persona_creation.js:84
-msgid "Creative Commons Attribution-NoDerivs 3.0"
-msgstr "Creative Commons Attribution-NoDerivs 3.0"
-
-#: static/js/impala/persona_creation.js:89
-msgid "Creative Commons Attribution-ShareAlike 3.0"
-msgstr "Creative Commons Attribution-ShareAlike 3.0"
-
-#: static/js/impala/persona_creation.js:292
-msgid "Your Theme's Name"
-msgstr "Nome do seu tema"
-
-#: static/js/impala/reviews.js:23 static/js/zamboni/reviews.js:18
-msgid "Flagged for review"
-msgstr "Marcada para análise"
-
-#: static/js/impala/reviews.js:40 static/js/zamboni/reviews.js:34
-msgid "Your input is required"
-msgstr "É necessária a sua entrada"
-
-#: static/js/impala/reviews.js:152 static/js/zamboni/reviews.js:103
-msgid "Marked for deletion"
-msgstr "Marcado para eliminar"
-
-#: static/js/impala/search.js:114
-msgid "Updating results&hellip;"
-msgstr "A atualizar resultados:"
-
-#: static/js/impala/site_suggestions.js:46
-msgid "Category"
-msgstr "Categoria"
-
-#: static/js/impala/suggestions.js:39
-msgid "Search themes for <b>{0}</b>"
-msgstr "Procurar temas para <b>{0}</b>"
-
-#: static/js/impala/suggestions.js:41
-msgid "Search apps for <b>{0}</b>"
-msgstr "Procurar apps para o <b>{0}</b>"
-
-#: static/js/impala/suggestions.js:43
-msgid "Search add-ons for <b>{0}</b>"
-msgstr "Procurar extras para o <b>{0}</b>"
-
-#: static/js/impala/users.js:33
-msgid "use original"
-msgstr "usar original"
-
-#: static/js/impala/stats/chart.js:267
-msgid "Week of {0}"
-msgstr "Semana de {0}"
-
-#: static/js/impala/stats/chart.js:269
-msgid " downloads"
-msgstr " descargas"
-
-#: static/js/impala/stats/chart.js:270
-msgid "{0} users"
-msgstr "{0} utilizadores"
-
-#: static/js/impala/stats/chart.js:271
-msgid "{0} add-ons"
-msgstr "{0} extras"
-
-#: static/js/impala/stats/chart.js:272
-msgid "{0} collections"
-msgstr "{0} coleções"
-
-#: static/js/impala/stats/chart.js:273
-msgid "{0} reviews"
-msgstr "{0} revisões"
-
-#: static/js/impala/stats/chart.js:275
-msgid "{0} sales"
-msgstr "{0} vendas"
-
-#: static/js/impala/stats/chart.js:276
-msgid "{0} refunds"
-msgstr "{0} devoluções"
-
-#: static/js/impala/stats/chart.js:277
-msgid "{0} installs"
-msgstr "{0} instalações"
-
-#: static/js/impala/stats/chart.js:369 static/js/impala/stats/csv_keys.js:3
-#: static/js/impala/stats/csv_keys.js:109
-msgid "Downloads"
-msgstr "Descargas"
-
-#: static/js/impala/stats/chart.js:379 static/js/impala/stats/csv_keys.js:6
-#: static/js/impala/stats/csv_keys.js:110
-msgid "Daily Users"
-msgstr "Utilizadores diários"
-
-#: static/js/impala/stats/chart.js:410
-msgid "Amount, in USD"
-msgstr "Quantia, em USD"
-
-#: static/js/impala/stats/chart.js:421 static/js/impala/stats/csv_keys.js:104
-msgid "Number of Contributions"
-msgstr "Número de contribuições"
-
-#: static/js/impala/stats/chart.js:447
-msgid "More Info..."
-msgstr "Mais info..."
-
-#. L10n: {0} is an ISO-formatted date.
-#: static/js/impala/stats/chart.js:451
-msgid "Details for {0}"
-msgstr "Detalhes para {0}"
-
-#: static/js/impala/stats/csv_keys.js:9
-msgid "Collections Created"
-msgstr "Coleções criadas"
-
-#: static/js/impala/stats/csv_keys.js:12
-msgid "Add-ons in Use"
-msgstr "Extras em uso"
-
-#: static/js/impala/stats/csv_keys.js:15
-msgid "Add-ons Created"
-msgstr "Extras criados"
-
-#: static/js/impala/stats/csv_keys.js:18
-msgid "Add-ons Downloaded"
-msgstr "Extras descarregados"
-
-#: static/js/impala/stats/csv_keys.js:21
-msgid "Add-ons Updated"
-msgstr "Extras atualizados"
-
-#: static/js/impala/stats/csv_keys.js:24
-msgid "Reviews Written"
-msgstr "Revisões escritas"
-
-#: static/js/impala/stats/csv_keys.js:27
-msgid "User Signups"
-msgstr "Subscrições de utilizadores"
-
-#: static/js/impala/stats/csv_keys.js:30
-msgid "Subscribers"
-msgstr "Subscritores"
-
-#: static/js/impala/stats/csv_keys.js:33
-msgid "Ratings"
-msgstr "Avaliações"
-
-#: static/js/impala/stats/csv_keys.js:36
-#: static/js/impala/stats/csv_keys.js:114
-msgid "Sales"
-msgstr "Vendas"
-
-#: static/js/impala/stats/csv_keys.js:39
-#: static/js/impala/stats/csv_keys.js:113
-msgid "Installs"
-msgstr "Instalações"
-
-#: static/js/impala/stats/csv_keys.js:42
-msgid "Unknown"
-msgstr "Desconhecido"
-
-#: static/js/impala/stats/csv_keys.js:43
-msgid "Add-ons Manager"
-msgstr "Gestor de Extras"
-
-#: static/js/impala/stats/csv_keys.js:44
-msgid "Add-ons Manager Promo"
-msgstr "Gestor de Promoção de Extras"
-
-#: static/js/impala/stats/csv_keys.js:45
-msgid "Add-ons Manager Featured"
-msgstr "Gestor de Destaques de Extras"
-
-#: static/js/impala/stats/csv_keys.js:46
-msgid "Add-ons Manager Learn More"
-msgstr "Gestor de Saber Mais sobre Extras"
-
-#: static/js/impala/stats/csv_keys.js:47
-msgid "Search Suggestions"
-msgstr "Sugestões de Pesquisa"
-
-#: static/js/impala/stats/csv_keys.js:48
-msgid "Search Results"
-msgstr "Resultados da pesquisa"
-
-#: static/js/impala/stats/csv_keys.js:49 static/js/impala/stats/csv_keys.js:50
-#: static/js/impala/stats/csv_keys.js:51
-msgid "Homepage Promo"
-msgstr "Promo da página inicial"
-
-#: static/js/impala/stats/csv_keys.js:52 static/js/impala/stats/csv_keys.js:53
-msgid "Homepage Featured"
-msgstr "Em destaque na página inicial"
-
-#: static/js/impala/stats/csv_keys.js:54 static/js/impala/stats/csv_keys.js:55
-msgid "Homepage Up and Coming"
-msgstr "Brevemente na página inicial"
-
-#: static/js/impala/stats/csv_keys.js:56
-msgid "Homepage Most Popular"
-msgstr "Mais populares na página inicial"
-
-#: static/js/impala/stats/csv_keys.js:57 static/js/impala/stats/csv_keys.js:59
-msgid "Detail Page"
-msgstr "Página de detalhes"
-
-#: static/js/impala/stats/csv_keys.js:58 static/js/impala/stats/csv_keys.js:60
-msgid "Detail Page (bottom)"
-msgstr "Página de detalhes (fundo)"
-
-#: static/js/impala/stats/csv_keys.js:61
-msgid "Detail Page (Development Channel)"
-msgstr "Página de detalhes (canal de desenvolvimento)"
-
-#: static/js/impala/stats/csv_keys.js:62 static/js/impala/stats/csv_keys.js:63
-#: static/js/impala/stats/csv_keys.js:64
-msgid "Often Used With"
-msgstr "Normalmente usado com"
-
-#: static/js/impala/stats/csv_keys.js:65 static/js/impala/stats/csv_keys.js:66
-msgid "Others By Author"
-msgstr "Outros pelo autor"
-
-#: static/js/impala/stats/csv_keys.js:67 static/js/impala/stats/csv_keys.js:68
-msgid "Dependencies"
-msgstr "Dependências"
-
-#: static/js/impala/stats/csv_keys.js:69 static/js/impala/stats/csv_keys.js:70
-msgid "Upsell"
-msgstr "Upsell"
-
-#: static/js/impala/stats/csv_keys.js:71
-msgid "Meet the Developer"
-msgstr "Conheça o programador"
-
-#: static/js/impala/stats/csv_keys.js:72
-msgid "User Profile"
-msgstr "Perfil do utilizador"
-
-#: static/js/impala/stats/csv_keys.js:73
-msgid "Version History"
-msgstr "Histórico de versões"
-
-#: static/js/impala/stats/csv_keys.js:75
-msgid "Sharing"
-msgstr "Partilha"
-
-#: static/js/impala/stats/csv_keys.js:76
-msgid "Category Pages"
-msgstr "Páginas de categorias"
-
-#: static/js/impala/stats/csv_keys.js:77
-msgid "Collections"
-msgstr "Coleções"
-
-#: static/js/impala/stats/csv_keys.js:78 static/js/impala/stats/csv_keys.js:79
-msgid "Category Landing Featured Carousel"
-msgstr "Categoria de funcionalidades carousel"
-
-#: static/js/impala/stats/csv_keys.js:80 static/js/impala/stats/csv_keys.js:81
-msgid "Category Landing Top Rated"
-msgstr "Categoria dos mais avaliados"
-
-#: static/js/impala/stats/csv_keys.js:82 static/js/impala/stats/csv_keys.js:83
-msgid "Category Landing Most Popular"
-msgstr "Categoria mais populares"
-
-#: static/js/impala/stats/csv_keys.js:84 static/js/impala/stats/csv_keys.js:85
-msgid "Category Landing Recently Added"
-msgstr "Categoria dos adicionados recentemente"
-
-#: static/js/impala/stats/csv_keys.js:86 static/js/impala/stats/csv_keys.js:87
-msgid "Browse Listing Featured Sort"
-msgstr "Navegar na listagem ordenada em destaque"
-
-#: static/js/impala/stats/csv_keys.js:88 static/js/impala/stats/csv_keys.js:89
-msgid "Browse Listing Users Sort"
-msgstr "Navegar na listagem ordenada de utilizadores"
-
-#: static/js/impala/stats/csv_keys.js:90 static/js/impala/stats/csv_keys.js:91
-msgid "Browse Listing Rating Sort"
-msgstr "Navegar na listagem ordenada por avaliações"
-
-#: static/js/impala/stats/csv_keys.js:92 static/js/impala/stats/csv_keys.js:93
-msgid "Browse Listing Created Sort"
-msgstr "Navegar na listagem ordenada criada"
-
-#: static/js/impala/stats/csv_keys.js:94 static/js/impala/stats/csv_keys.js:95
-msgid "Browse Listing Name Sort"
-msgstr "Navegar na listagem ordenada por nome"
-
-#: static/js/impala/stats/csv_keys.js:96 static/js/impala/stats/csv_keys.js:97
-msgid "Browse Listing Popular Sort"
-msgstr "Navegar na listagem ordenada por popularidade"
-
-#: static/js/impala/stats/csv_keys.js:98 static/js/impala/stats/csv_keys.js:99
-msgid "Browse Listing Updated Sort"
-msgstr "Navegar na listagem ordenada por popularidade"
-
-#: static/js/impala/stats/csv_keys.js:100
-#: static/js/impala/stats/csv_keys.js:101
-msgid "Browse Listing Up and Coming Sort"
-msgstr "Navegar na listagem deos próximos lançamentos"
-
-#: static/js/impala/stats/csv_keys.js:105
-msgid "Total Amount Contributed"
-msgstr "Montante total de contribuições"
-
-#: static/js/impala/stats/csv_keys.js:106
-msgid "Average Contribution"
-msgstr "Contribuição média"
-
-#: static/js/impala/stats/csv_keys.js:115
-msgid "Usage"
-msgstr "Utilização"
-
-#: static/js/impala/stats/csv_keys.js:118
-msgid "Firefox"
-msgstr "Firefox"
-
-#: static/js/impala/stats/csv_keys.js:119
-msgid "Mozilla"
-msgstr "Mozilla"
-
-#: static/js/impala/stats/csv_keys.js:120
-msgid "Thunderbird"
-msgstr "Thunderbird"
-
-#: static/js/impala/stats/csv_keys.js:121
-msgid "Sunbird"
-msgstr "Sunbird"
-
-#: static/js/impala/stats/csv_keys.js:122
-msgid "SeaMonkey"
-msgstr "SeaMonkey"
-
-#: static/js/impala/stats/csv_keys.js:123
-msgid "Fennec"
-msgstr "Fennec"
-
-#: static/js/impala/stats/csv_keys.js:124
-msgid "Android"
-msgstr "Android"
-
-#. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:129
-msgid "Downloads and Daily Users, last {0} days"
-msgstr "Descargas e utilizadores diários, últimos {0} dias"
-
-#. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:131
-msgid "Downloads and Daily Users from {0} to {1}"
-msgstr "Descargas e utilizadores diários de {0} a {1}"
-
-#. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:135
-msgid "Installs and Daily Users, last {0} days"
-msgstr "Instalações e utilizadores diários, últimos {0} dias"
-
-#. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:137
-msgid "Installs and Daily Users from {0} to {1}"
-msgstr "Instalações e utilizadores diários de {0} a {1}"
-
-#. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:141
-msgid "Downloads, last {0} days"
-msgstr "Descargas, últimos {0} dias"
-
-#. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:143
-msgid "Downloads from {0} to {1}"
-msgstr "Descargas de {0} a {1}"
-
-#. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:147
-msgid "Daily Users, last {0} days"
-msgstr "Utilizadores diários, últimos {0} dias"
-
-#. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:149
-msgid "Daily Users from {0} to {1}"
-msgstr "Utilizadores diários de {0} a {1}"
-
-#. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:153
-msgid "Applications, last {0} days"
-msgstr "Aplicações, últimos {0} dias"
-
-#. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:155
-msgid "Applications from {0} to {1}"
-msgstr "Aplicações de {0} a {1}"
-
-#. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:159
-msgid "Platforms, last {0} days"
-msgstr "Plataformas, últimos {0} dias"
-
-#. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:161
-msgid "Platforms from {0} to {1}"
-msgstr "Plataformas de {0} a {1}"
-
-#. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:165
-msgid "Languages, last {0} days"
-msgstr "Idiomas, últimos {0} dias"
-
-#. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:167
-msgid "Languages from {0} to {1}"
-msgstr "Idiomas de {0} a {1}"
-
-#. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:171
-msgid "Add-on Versions, last {0} days"
-msgstr "Versões do extra, últimos {0} dias"
-
-#. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:173
-msgid "Add-on Versions from {0} to {1}"
-msgstr "Versões do extra de {0} a {1}"
-
-#. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:177
-msgid "Add-on Status, last {0} days"
-msgstr "Estado do extra, últimos {0} dias"
-
-#. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:179
-msgid "Add-on Status from {0} to {1}"
-msgstr "Estado do extra de {0} a {1}"
-
-#. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:183
-msgid "Download Sources, last {0} days"
-msgstr "Fontes das descargas, últimos {0} dias"
-
-#. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:185
-msgid "Download Sources from {0} to {1}"
-msgstr "Fontes das descargas de {0} a {1}"
-
-#. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:189
-msgid "Contributions, last {0} days"
-msgstr "Contribuições, últimos {0} dias"
-
-#. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:191
-msgid "Contributions from {0} to {1}"
-msgstr "Contribuições de {0} a {1}"
-
-#. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:195
-msgid "Site Metrics, last {0} days"
-msgstr "Medições do site , últimos {0} dias"
-
-#. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:197
-msgid "Site Metrics from {0} to {1}"
-msgstr "Medições do site de {0} a {1}"
-
-#. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:201
-msgid "Add-ons in Use, last {0} days"
-msgstr "Extras em uso, últimos {0} dias"
-
-#. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:203
-msgid "Add-ons in Use from {0} to {1}"
-msgstr "Extras em utilização de {0} a {1}"
-
-#. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:207
-msgid "Add-ons Downloaded, last {0} days"
-msgstr "Extras descarregados, últimos {0} dias"
-
-#. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:209
-msgid "Add-ons Downloaded from {0} to {1}"
-msgstr "Extras descarregados de {0} a {1}"
-
-#. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:213
-msgid "Add-ons Created, last {0} days"
-msgstr "Extras criados, últimos{ 0} dias"
-
-#. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:215
-msgid "Add-ons Created from {0} to {1}"
-msgstr "Extras criados de {0} a {1}"
-
-#. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:219
-msgid "Add-ons Updated, last {0} days"
-msgstr "Extras atualizados, últimos {0} dias"
-
-#. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:221
-msgid "Add-ons Updated from {0} to {1}"
-msgstr "Extras atualizados de {0} a {1}"
-
-#. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:225
-msgid "Reviews Written, last {0} days"
-msgstr "Revisões escritas, últimos {0} dias"
-
-#. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:227
-msgid "Reviews Written from {0} to {1}"
-msgstr "Revisões escritas de {0} a {1}"
-
-#. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:231
-msgid "User Signups, last {0} days"
-msgstr "Subscrição de utilizadores, últimos {0} dias"
-
-#. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:233
-msgid "User Signups from {0} to {1}"
-msgstr "Subscrições de utilizadores de {0} a {1}"
-
-#. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:237
-msgid "Collections Created, last {0} days"
-msgstr "Coleções criadas, últimos {0} dias"
-
-#. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:239
-msgid "Collections Created from {0} to {1}"
-msgstr "Coleções criadas de {0} a {1}"
-
-#. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:243
-msgid "Subscribers, last {0} days"
-msgstr "Subscritores, últimos {0} dias"
-
-#. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:245
-msgid "Subscribers from {0} to {1}"
-msgstr "Subscritores de {0} a {1}"
-
-#. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:249
-msgid "Ratings, last {0} days"
-msgstr "Avaliações, últimos {0} dias"
-
-#. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:251
-msgid "Ratings from {0} to {1}"
-msgstr "Avaliações de {0} a {1}"
-
-#. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:255
-msgid "Sales, last {0} days"
-msgstr "Vendas, últimos {0} dias"
-
-#. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:257
-msgid "Sales from {0} to {1}"
-msgstr "Vendas de {0} a {1}"
-
-#. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:261
-msgid "Installs, last {0} days"
-msgstr "Instalações, últimos {0} dias"
-
-#. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:263
-msgid "Installs from {0} to {1}"
-msgstr "Instalações de {0} a {1}"
-
-#. L10n: {0} and {1} are integers.
-#: static/js/impala/stats/csv_keys.js:269
-msgid "<b>{0}</b> in last {1} days"
-msgstr "<b>{0}</b> nos últimos {1} dias"
-
-#. L10n: {0} is an integer and {1} and {2} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:271
-#: static/js/impala/stats/csv_keys.js:277
-msgid "<b>{0}</b> from {1} to {2}"
-msgstr "<b>{0}</b> de {1} a {2}"
-
-#. L10n: {0} and {1} are integers.
-#: static/js/impala/stats/csv_keys.js:275
-msgid "<b>{0}</b> average in last {1} days"
-msgstr "<b>{0}</b> média nos últimos {1} dias"
-
-#: static/js/impala/stats/overview.js:19
-msgid "No data available."
-msgstr "Sem dados disponíveis."
-
-#: static/js/impala/stats/table.js:74
-msgid "Date"
-msgstr "Data"
-
-#: static/js/impala/stats/topchart.js:96
-msgid "Other"
-msgstr "Outro"
-
-#: static/js/zamboni/admin_validation.js:24 static/js/zamboni/devhub.js:1229
-#: static/js/zamboni/editors.js:295
-msgid "Select an application first"
-msgstr "Primeiro selecione uma aplicação"
-
-#: static/js/zamboni/admin_validation.js:51
-msgid "Set {0} add-on to a max version of {1} and email the author."
-msgid_plural "Set {0} add-ons to a max version of {1} and email the authors."
-msgstr[0] ""
-"Definir {0} extra para a versão máxima de {1} e enviar mensagem ao autor."
-msgstr[1] ""
-"Definir {0} extras para a versão máxima de {1} e enviar mensagens aos "
-"autores."
-
-#: static/js/zamboni/admin_validation.js:54
-msgid "Email author of {2} add-on which failed validation."
-msgid_plural "Email authors of {2} add-ons which failed validation."
-msgstr[0] "Email do autor do extra {2} que falhou a validação."
-msgstr[1] "E-mail dos autores do extra {2} que falhou a validação."
+#: static/js/common-all.js:1426 static/js/impala-all.js:1511 static/js/zamboni/discovery-all.js:12598 static/js/zamboni/init.js:28 static/js/zamboni/mobile-all.js:14945
+msgid "This feature is temporarily disabled while we perform website maintenance. Please check back a little later."
+msgstr "Esta funcionalidade está temporariamente desativada enquanto procedemos à manutenção do website. Por favor, volte mais tarde."
 
 #. L10n: {0} is an app name like Firefox.
-#: static/js/zamboni/buttons.js:66
+#: static/js/common-all.js:1837 static/js/impala-all.js:1922 static/js/zamboni/buttons.js:73 static/js/zamboni/discovery-all.js:13108
 msgid "Accept and Install"
 msgstr "Aceitar e instalar"
 
-#: static/js/zamboni/buttons.js:66
+#: static/js/common-all.js:1837 static/js/impala-all.js:1922 static/js/zamboni/buttons.js:73 static/js/zamboni/discovery-all.js:13108
 msgid "Add to {0}"
 msgstr "Adicionar ao {0}"
 
-#: static/js/zamboni/buttons.js:71
+#: static/js/common-all.js:1842 static/js/impala-all.js:1927 static/js/zamboni/buttons.js:78 static/js/zamboni/discovery-all.js:13113
 msgid "Download Now"
 msgstr "Descarregar agora"
 
-#: static/js/zamboni/buttons.js:112
+#: static/js/common-all.js:1883 static/js/impala-all.js:1968 static/js/zamboni/buttons.js:119 static/js/zamboni/discovery-all.js:13154
 msgid "Add-on has not been updated to support default-to-compatible."
-msgstr ""
-"O extra não foi atualizado para suportar a compatibilidade por predefinição."
+msgstr "O extra não foi atualizado para suportar a compatibilidade por predefinição."
 
-#: static/js/zamboni/buttons.js:117
+#: static/js/common-all.js:1888 static/js/impala-all.js:1973 static/js/zamboni/buttons.js:124 static/js/zamboni/discovery-all.js:13159
 msgid "You need to be using Firefox 10.0 or higher."
 msgstr "Precisa de estar a utilizar o Firefox 10.0 ou superior."
 
-#: static/js/zamboni/buttons.js:129
-msgid ""
-"Mozilla has marked this version as incompatible with your Firefox version."
-msgstr ""
-"A Mozilla marcou esta versão como incompatível com a sua versão do Firefox."
+#: static/js/common-all.js:1900 static/js/impala-all.js:1985 static/js/zamboni/buttons.js:136 static/js/zamboni/discovery-all.js:13171
+msgid "Mozilla has marked this version as incompatible with your Firefox version."
+msgstr "A Mozilla marcou esta versão como incompatível com a sua versão do Firefox."
 
 #. L10n: {0} is an platform like Windows or Linux.
-#: static/js/zamboni/buttons.js:210
+#: static/js/common-all.js:1981 static/js/impala-all.js:2066 static/js/zamboni/buttons.js:217 static/js/zamboni/discovery-all.js:13252
 msgid "Install for {0} anyway"
 msgstr "Instalar para o {0} de qualquer maneira"
 
-#: static/js/zamboni/buttons.js:210
+#: static/js/common-all.js:1981 static/js/impala-all.js:2066 static/js/zamboni/buttons.js:217 static/js/zamboni/discovery-all.js:13252
 msgid "Download for {0} anyway"
 msgstr "Descarregar para o {0} de qualquer maneira"
 
-#: static/js/zamboni/buttons.js:267
+#: static/js/common-all.js:2038 static/js/impala-all.js:2123 static/js/zamboni/buttons.js:274 static/js/zamboni/discovery-all.js:13309
 msgid "Not available for your platform"
 msgstr "Não está disponível para a sua plataforma"
 
 #. L10n: {0} is an app name, {1} is the app version.
-#: static/js/zamboni/buttons.js:278 static/js/zamboni/buttons.js:315
+#: static/js/common-all.js:2049 static/js/common-all.js:2086 static/js/impala-all.js:2134 static/js/impala-all.js:2171 static/js/zamboni/buttons.js:286 static/js/zamboni/buttons.js:324
+#: static/js/zamboni/discovery-all.js:13320 static/js/zamboni/discovery-all.js:13357
 msgid "Not available for {0} {1}"
 msgstr "Não está disponível para {0} {1}"
 
-#: static/js/zamboni/buttons.js:341
+#: static/js/common-all.js:2112 static/js/impala-all.js:2197 static/js/zamboni/buttons.js:351 static/js/zamboni/discovery-all.js:13383
 msgid "Works with {app} {min} - {max}"
 msgstr "Funciona com {app} {min} - {max}"
 
-#: static/js/zamboni/buttons.js:343
+#: static/js/common-all.js:2114 static/js/impala-all.js:2199 static/js/zamboni/buttons.js:353 static/js/zamboni/discovery-all.js:13385
 msgid "View other versions"
 msgstr "Ver outras versões"
 
-#: static/js/zamboni/buttons.js:391
+#: static/js/common-all.js:2162 static/js/impala-all.js:2247 static/js/zamboni/buttons.js:401 static/js/zamboni/discovery-all.js:13433
 msgid "Only with Firefox — Get Firefox Now!"
 msgstr "Apenas com o Firefox — Obter o Firefox agora!"
 
-#: static/js/zamboni/buttons.js:507 static/js/zamboni/mobile/buttons.js:43
-msgid ""
-"Sorry, you need a Mozilla-based browser (such as Firefox) to install a "
-"search plugin."
-msgstr ""
-"Desculpe, mas precisa de um navegador baseado na Mozilla (como o Firefox) "
-"para instalar um plugin de pesquisa."
+#: static/js/common-all.js:2278 static/js/impala-all.js:2363 static/js/zamboni/buttons.js:517 static/js/zamboni/discovery-all.js:13549 static/js/zamboni/mobile-all.js:15177
+#: static/js/zamboni/mobile/buttons.js:43
+msgid "Sorry, you need a Mozilla-based browser (such as Firefox) to install a search plugin."
+msgstr "Desculpe, mas precisa de um navegador baseado na Mozilla (como o Firefox) para instalar um plugin de pesquisa."
 
-#: static/js/zamboni/collections.js:229
-msgid "Adding to Favorites&hellip;"
-msgstr "A adicionar aos favoritos&hellip;"
-
-#: static/js/zamboni/collections.js:232
-msgid "Removing Favorite&hellip;"
-msgstr "A remover favoritos"
-
-#: static/js/zamboni/collections.js:235
-msgid "Add to Favorites"
-msgstr "Adicionar aos favoritos"
-
-#: static/js/zamboni/collections.js:238
-msgid "Remove from Favorites"
-msgstr "Remover dos favoritos"
-
-#: static/js/zamboni/collections.js:303
-msgid "Pending"
-msgstr "Em espera"
-
-#: static/js/zamboni/collections.js:304
-msgid "Add a comment"
-msgstr "Adicionar um comentário"
-
-#: static/js/zamboni/collections.js:304
-msgid "Comment"
-msgstr "Comentário"
-
-#: static/js/zamboni/collections.js:305
-msgid "Remove this add-on from the collection"
-msgstr "Remover este extra da coleção"
-
-#: static/js/zamboni/collections.js:305 static/js/zamboni/collections.js:334
-msgid "Remove"
-msgstr "Remover"
-
-#: static/js/zamboni/collections.js:334
-msgid "Remove this user as a contributor"
-msgstr "Remover este utilizador como colaborador"
-
-#: static/js/zamboni/collections.js:346
-msgid "An email address is required."
-msgstr "É necessário um endereço de email."
-
-#: static/js/zamboni/collections.js:364
-msgid "You cannot add yourself as a contributor."
-msgstr "Não se pode adicionar a si próprio como um colaborador."
-
-#: static/js/zamboni/collections.js:366
-msgid "You have already added that user."
-msgstr "Já adicionou este utilizador."
-
-#: static/js/zamboni/collections.js:573
-msgid "Add to favorites"
-msgstr "Adicionar aos favoritos"
-
-#: static/js/zamboni/collections.js:577
-msgid "Remove from favorites"
-msgstr "Remover dos favoritos"
-
-#: static/js/zamboni/collections.js:604
-msgid "Stop following"
-msgstr "Parar o seguimento"
-
-#: static/js/zamboni/devhub.js:110
-msgid "Your browser does not support the video tag"
-msgstr "O seu navegador não suporta a etiqueta de vídeo"
-
-#: static/js/zamboni/devhub.js:371
-msgid "Changes Saved"
-msgstr "Alterações guardadas"
-
-#: static/js/zamboni/devhub.js:387
-msgid "Enter a new author's email address"
-msgstr "Escreva o novo endereço de email do autor"
-
-#: static/js/zamboni/devhub.js:536
-msgid "There was an error uploading your file."
-msgstr "Houve um erro ao carregar o seu ficheiro."
-
-#: static/js/zamboni/devhub.js:681
-msgid "{files} file"
-msgid_plural "{files} files"
-msgstr[0] "{files} ficheiro"
-msgstr[1] "{files} ficheiros"
-
-#: static/js/zamboni/devhub.js:684
-msgid "{reviews} user review"
-msgid_plural "{reviews} user reviews"
-msgstr[0] "{reviews} análise do utilizador"
-msgstr[1] "{reviews} análises do utilizador"
-
-#: static/js/zamboni/devhub.js:796
-msgid "Learn more"
-msgstr "Saber mais"
-
-#: static/js/zamboni/devhub.js:800
-msgid "Example"
-msgstr "Exemplo"
-
-#: static/js/zamboni/devhub.js:1130
-msgid "Image changes being processed"
-msgstr "Alterações de imagens em processamento"
-
-#: static/js/zamboni/devhub.js:1280
-msgid "Must be a valid e-mail address."
-msgstr "É necessário um endereço de e-mail válido."
-
-#: static/js/zamboni/devhub_search.js:8
-msgid "No results found."
-msgstr "Nenhum resultado encontrado."
-
-#: static/js/zamboni/editors.js:121
-msgid "{name} was viewing this page first."
-msgstr "{name} estava a ver esta página primeiro."
-
-#: static/js/zamboni/editors.js:171
-msgid "Receipt checked by app."
-msgstr "Recibo verificado pela aplicação."
-
-#: static/js/zamboni/editors.js:173
-msgid "Receipt was not checked by app."
-msgstr "O recibo não foi verificado pela aplicação."
-
-#: static/js/zamboni/editors.js:244
-msgid "{name} was viewing this add-on first."
-msgstr "{name} estava a ver primeiro este extra."
-
-#: static/js/zamboni/editors.js:255
-msgid "Loading&hellip;"
-msgstr "A carregar"
-
-#: static/js/zamboni/editors.js:260
-msgid "Version Notes"
-msgstr "Notas da versão"
-
-#: static/js/zamboni/editors.js:265
-msgid "Notes for Reviewers"
-msgstr "Notas para os revisores"
-
-#: static/js/zamboni/editors.js:270
-msgid "No version notes found"
-msgstr "Nenhumas notas de versão encontradas"
-
-#: static/js/zamboni/editors.js:330
-msgid "Average Reviews"
-msgstr "Pontuação média"
-
-#: static/js/zamboni/editors.js:386
-msgid "Number of Reviews"
-msgstr "Número de análises"
-
-#: static/js/zamboni/editors.js:445
-msgid "Error loading translation"
-msgstr "Erro ao carregar a tradução"
-
-#: static/js/zamboni/files.js:411 static/js/zamboni/validator.js:261
-msgid "Ignore this message in future updates"
-msgstr "Ignorar esta mensagem em futuras atualizações"
-
-#: static/js/zamboni/files.js:417 static/js/zamboni/validator.js:284
-msgid "Severity for automated signing:"
-msgstr "Severidade para sinalização automática:"
-
-#: static/js/zamboni/global.js:410
+#: static/js/common-all.js:9088 static/js/impala-all.js:9649 static/js/zamboni/global.js:410
 msgid "Loading..."
 msgstr "A carregar..."
 
 #. L10n: {0} is the number of characters left.
-#: static/js/zamboni/global.js:474
+#: static/js/common-all.js:9152 static/js/impala-all.js:9713 static/js/zamboni/global.js:474
 msgid "<b>{0}</b> character left."
 msgid_plural "<b>{0}</b> characters left."
 msgstr[0] "Falta <b>{0}</b> caráter."
 msgstr[1] "Faltam <b>{0}</b> caracteres."
 
-#: static/js/zamboni/init.js:28
-msgid ""
-"This feature is temporarily disabled while we perform website maintenance. "
-"Please check back a little later."
-msgstr ""
-"Esta funcionalidade está temporariamente desativada enquanto procedemos à "
-"manutenção do website. Por favor, volte mais tarde."
+#: static/js/common-all.js:9589 static/js/common-min.js:6 static/js/impala-all.js:10052 static/js/impala-min.js:6 static/js/common/ratingwidget.js:31 static/js/zamboni/mobile-all.js:16123
+#: static/js/zamboni/mobile-min.js:6
+msgid "{0} star"
+msgid_plural "{0} stars"
+msgstr[0] "{0} estrela"
+msgstr[1] "{0} estrelas"
 
-#: static/js/zamboni/l10n.js:45
+#: static/js/common-all.js:9676 static/js/common-min.js:6 static/js/impala-all.js:10139 static/js/impala-min.js:6 static/js/zamboni/l10n.js:45
 msgid "Remove this localization"
 msgstr "Remover esta tradução"
 
-#: static/js/zamboni/password-strength.js:20
+#: static/js/common-all.js:10193 static/js/common-min.js:6 static/js/impala-all.js:10674 static/js/impala-min.js:6 static/js/zamboni/discovery-all.js:13678
+msgid "close"
+msgstr ""
+
+#: static/js/common-all.js:10860 static/js/common-min.js:6 static/js/impala-all.js:11481 static/js/impala-min.js:6 static/js/impala/reviews.js:23 static/js/zamboni/reviews.js:18
+msgid "Flagged for review"
+msgstr "Marcada para análise"
+
+#: static/js/common-all.js:10876 static/js/common-min.js:6 static/js/impala-all.js:11498 static/js/impala-min.js:6 static/js/impala/reviews.js:40 static/js/zamboni/reviews.js:34
+msgid "Your input is required"
+msgstr "É necessária a sua entrada"
+
+#: static/js/common-all.js:10945 static/js/common-min.js:6 static/js/impala-all.js:11610 static/js/impala-min.js:7 static/js/impala/reviews.js:152 static/js/zamboni/reviews.js:103
+msgid "Marked for deletion"
+msgstr "Marcado para eliminar"
+
+#: static/js/common-all.js:11573 static/js/common-min.js:7 static/js/impala-all.js:13809 static/js/impala-min.js:8 static/js/zamboni/collections.js:229
+msgid "Adding to Favorites&hellip;"
+msgstr "A adicionar aos favoritos&hellip;"
+
+#: static/js/common-all.js:11576 static/js/common-min.js:7 static/js/impala-all.js:13812 static/js/impala-min.js:8 static/js/zamboni/collections.js:232
+msgid "Removing Favorite&hellip;"
+msgstr "A remover favoritos"
+
+#: static/js/common-all.js:11579 static/js/common-min.js:7 static/js/impala-all.js:13815 static/js/impala-min.js:8 static/js/zamboni/collections.js:235
+msgid "Add to Favorites"
+msgstr "Adicionar aos favoritos"
+
+#: static/js/common-all.js:11582 static/js/common-min.js:7 static/js/impala-all.js:13818 static/js/impala-min.js:8 static/js/zamboni/collections.js:238
+msgid "Remove from Favorites"
+msgstr "Remover dos favoritos"
+
+#: static/js/common-all.js:11647 static/js/common-min.js:7 static/js/impala-all.js:13883 static/js/impala-min.js:8 static/js/zamboni/collections.js:303
+msgid "Pending"
+msgstr "Em espera"
+
+#: static/js/common-all.js:11648 static/js/common-min.js:7 static/js/impala-all.js:13884 static/js/impala-min.js:8 static/js/zamboni/collections.js:304
+msgid "Add a comment"
+msgstr "Adicionar um comentário"
+
+#: static/js/common-all.js:11648 static/js/common-min.js:7 static/js/impala-all.js:13884 static/js/impala-min.js:8 static/js/zamboni/collections.js:304
+msgid "Comment"
+msgstr "Comentário"
+
+#: static/js/common-all.js:11649 static/js/common-min.js:7 static/js/impala-all.js:13885 static/js/impala-min.js:8 static/js/zamboni/collections.js:305
+msgid "Remove this add-on from the collection"
+msgstr "Remover este extra da coleção"
+
+#: static/js/common-all.js:11649 static/js/common-all.js:11678 static/js/common-min.js:7 static/js/impala-all.js:13885 static/js/impala-all.js:13914 static/js/impala-min.js:8
+#: static/js/zamboni/collections.js:305 static/js/zamboni/collections.js:334
+msgid "Remove"
+msgstr "Remover"
+
+#: static/js/common-all.js:11678 static/js/common-min.js:7 static/js/impala-all.js:13914 static/js/impala-min.js:8 static/js/zamboni/collections.js:334
+msgid "Remove this user as a contributor"
+msgstr "Remover este utilizador como colaborador"
+
+#: static/js/common-all.js:11690 static/js/common-min.js:7 static/js/impala-all.js:13926 static/js/impala-min.js:8 static/js/zamboni/collections.js:346
+msgid "An email address is required."
+msgstr "É necessário um endereço de email."
+
+#: static/js/common-all.js:11708 static/js/common-min.js:7 static/js/impala-all.js:13944 static/js/impala-min.js:8 static/js/zamboni/collections.js:364
+msgid "You cannot add yourself as a contributor."
+msgstr "Não se pode adicionar a si próprio como um colaborador."
+
+#: static/js/common-all.js:11710 static/js/common-min.js:7 static/js/impala-all.js:13946 static/js/impala-min.js:8 static/js/zamboni/collections.js:366
+msgid "You have already added that user."
+msgstr "Já adicionou este utilizador."
+
+#: static/js/common-all.js:11917 static/js/common-min.js:7 static/js/impala-all.js:14153 static/js/impala-min.js:8 static/js/zamboni/collections.js:573
+msgid "Add to favorites"
+msgstr "Adicionar aos favoritos"
+
+#: static/js/common-all.js:11921 static/js/common-min.js:7 static/js/impala-all.js:14157 static/js/impala-min.js:8 static/js/zamboni/collections.js:577
+msgid "Remove from favorites"
+msgstr "Remover dos favoritos"
+
+#: static/js/common-all.js:11939 static/js/common-min.js:7 static/js/impala-all.js:14175 static/js/impala-all.js:14233 static/js/impala-min.js:8 static/js/impala/collections.js:10
+#: static/js/zamboni/collections.js:595
+msgid "Follow this Collection"
+msgstr "Seguir esta coleção"
+
+#: static/js/common-all.js:11948 static/js/common-min.js:7 static/js/impala-all.js:14184 static/js/impala-min.js:8 static/js/zamboni/collections.js:604
+msgid "Stop following"
+msgstr "Parar o seguimento"
+
+#: static/js/common-all.js:12096 static/js/common-min.js:7 static/js/zamboni/password-strength.js:20
 msgid "Password strength:"
 msgstr "Força da palavra-passe:"
 
-#: static/js/zamboni/password-strength.js:26
+#: static/js/common-all.js:12102 static/js/common-min.js:7 static/js/zamboni/password-strength.js:26
 msgid "At least {0} character left."
 msgid_plural "At least {0} characters left."
 msgstr[0] "Falta pelo menos {0} caráter."
 msgstr[1] "Faltam pelo menos {0} caracteres."
 
-#: static/js/zamboni/themes_review.js:176
-msgid "Requested Info"
-msgstr "Solicitadas mais informações"
+#: static/js/common-all.js:12286 static/js/common-min.js:7 static/js/impala-all.js:14632 static/js/impala-min.js:8 static/js/impala/suggestions.js:39
+msgid "Search themes for <b>{0}</b>"
+msgstr "Procurar temas para <b>{0}</b>"
 
-#: static/js/zamboni/themes_review.js:177
-msgid "Flagged"
-msgstr "Marcado"
+#: static/js/common-all.js:12288 static/js/common-min.js:7 static/js/impala-all.js:14634 static/js/impala-min.js:8 static/js/impala/suggestions.js:41
+msgid "Search apps for <b>{0}</b>"
+msgstr "Procurar apps para o <b>{0}</b>"
 
-#: static/js/zamboni/themes_review.js:178
-msgid "Duplicate"
-msgstr "Duplicado"
+#: static/js/common-all.js:12290 static/js/common-min.js:7 static/js/impala-all.js:14636 static/js/impala-min.js:8 static/js/impala/suggestions.js:43
+msgid "Search add-ons for <b>{0}</b>"
+msgstr "Procurar extras para o <b>{0}</b>"
 
-#: static/js/zamboni/themes_review.js:179
-msgid "Rejected"
-msgstr "Rejeitado"
+#: static/js/common-all.js:12521 static/js/common-min.js:7 static/js/impala-all.js:14867 static/js/impala-min.js:8 static/js/impala/site_suggestions.js:46
+msgid "Category"
+msgstr "Categoria"
 
-#: static/js/zamboni/themes_review.js:180
-msgid "Approved"
-msgstr "Aprovado"
+#. L10n: {0} is an app name.
+#: static/js/impala-all.js:11632 static/js/impala-min.js:7 static/js/impala/listing.js:11 static/js/zamboni/themes.js:13
+msgid "This theme is incompatible with your version of {0}"
+msgstr "Este tema é incompatível com a sua versão do {0}"
 
-#: static/js/zamboni/themes_review.js:424
-msgid "No results found"
-msgstr "Não foram encontrados resultados"
+#: static/js/impala-all.js:12146 static/js/impala-all.js:14331 static/js/impala-min.js:7 static/js/impala-min.js:8 static/js/common/upload-image.js:97 static/js/impala/users.js:51
+#: static/js/zamboni/devhub-all.js:894 static/js/zamboni/devhub-min.js:1
+msgid "Images must be either PNG or JPG."
+msgstr "As imagens têm de ser PNG ou JPG."
 
-#: static/js/zamboni/themes_review_templates.js:31
-msgid "Theme"
-msgstr "Tema"
+#: static/js/impala-all.js:12150 static/js/impala-min.js:7 static/js/common/upload-image.js:101 static/js/zamboni/devhub-all.js:898 static/js/zamboni/devhub-min.js:1
+msgid "Videos must be in WebM."
+msgstr "Os vídeos devem estar no formato WebM."
 
-#: static/js/zamboni/themes_review_templates.js:33
-msgid "Reviewer"
-msgstr "Revisor"
+#: static/js/impala-all.js:12177 static/js/impala-min.js:7 static/js/common/upload-addon.js:41 static/js/common/upload-image.js:128 static/js/zamboni/devhub-all.js:272
+#: static/js/zamboni/devhub-all.js:925 static/js/zamboni/devhub-min.js:1
+msgid "There was a problem contacting the server."
+msgstr "Ocorreu um problema ao contactar o servidor."
 
-#: static/js/zamboni/themes_review_templates.js:35
-msgid "Status"
-msgstr "Estado"
+#: static/js/impala-all.js:13298 static/js/impala-min.js:7 static/js/impala/persona_creation.js:60
+msgid "All Rights Reserved"
+msgstr "Todos os direitos reservados"
 
-#: static/js/zamboni/validator.js:80
+#: static/js/impala-all.js:13302 static/js/impala-min.js:7 static/js/impala/persona_creation.js:64
+msgid "Creative Commons Attribution 3.0"
+msgstr "Creative Commons Attribution 3.0"
+
+#: static/js/impala-all.js:13307 static/js/impala-min.js:7 static/js/impala/persona_creation.js:69
+msgid "Creative Commons Attribution-NonCommercial 3.0"
+msgstr "Creative Commons Attribution-NonCommercial 3.0"
+
+#: static/js/impala-all.js:13312 static/js/impala-min.js:7 static/js/impala/persona_creation.js:74
+msgid "Creative Commons Attribution-NonCommercial-NoDerivs 3.0"
+msgstr "Creative Commons Attribution-NonCommercial-NoDerivs 3.0"
+
+#: static/js/impala-all.js:13317 static/js/impala-min.js:7 static/js/impala/persona_creation.js:79
+msgid "Creative Commons Attribution-NonCommercial-Share Alike 3.0"
+msgstr "Creative Commons Attribution-NonCommercial-Share Alike 3.0"
+
+#: static/js/impala-all.js:13322 static/js/impala-min.js:7 static/js/impala/persona_creation.js:84
+msgid "Creative Commons Attribution-NoDerivs 3.0"
+msgstr "Creative Commons Attribution-NoDerivs 3.0"
+
+#: static/js/impala-all.js:13327 static/js/impala-min.js:7 static/js/impala/persona_creation.js:89
+msgid "Creative Commons Attribution-ShareAlike 3.0"
+msgstr "Creative Commons Attribution-ShareAlike 3.0"
+
+#: static/js/impala-all.js:13530 static/js/impala-min.js:7 static/js/impala/persona_creation.js:292
+msgid "Your Theme's Name"
+msgstr "Nome do seu tema"
+
+#: static/js/impala-all.js:14242 static/js/impala-min.js:8 static/js/impala/collections.js:19
+msgid "Stop Following"
+msgstr "Deixar de seguir"
+
+#: static/js/impala-all.js:14243 static/js/impala-min.js:8 static/js/impala/collections.js:20
+msgid "Following"
+msgstr "A seguir"
+
+#: static/js/impala-all.js:14313 static/js/impala-min.js:8 static/js/impala/users.js:33
+msgid "use original"
+msgstr "usar original"
+
+#: static/js/impala-all.js:14523 static/js/impala-min.js:8 static/js/impala/search.js:114
+msgid "Updating results&hellip;"
+msgstr "A atualizar resultados:"
+
+#: static/js/common/upload-addon.js:69 static/js/zamboni/devhub-all.js:300 static/js/zamboni/devhub-min.js:1
+msgid "Select a file..."
+msgstr "Selecione um ficheiro..."
+
+#: static/js/common/upload-addon.js:70 static/js/zamboni/devhub-all.js:301 static/js/zamboni/devhub-min.js:1
+msgid "Your add-on should end with .xpi, .jar or .xml"
+msgstr "O seu extra deve terminar com .xpi, .jar ou .xml"
+
+#. L10n: {0} is the percent of the file that has been uploaded.
+#: static/js/common/upload-addon.js:104 static/js/zamboni/devhub-all.js:335 static/js/zamboni/devhub-min.js:1
+#, python-format
+msgid "{0}% complete"
+msgstr "{0}% completo"
+
+#. L10n: "{bytes uploaded} of {total filesize}".
+#: static/js/common/upload-addon.js:107 static/js/zamboni/devhub-all.js:338 static/js/zamboni/devhub-min.js:1
+msgid "{0} of {1}"
+msgstr "{0} de {1}"
+
+#: static/js/common/upload-addon.js:140 static/js/zamboni/devhub-all.js:371 static/js/zamboni/devhub-min.js:1
+msgid "Cancel"
+msgstr "Cancelar"
+
+#: static/js/common/upload-addon.js:162 static/js/zamboni/devhub-all.js:393 static/js/zamboni/devhub-min.js:1
+msgid "Uploading {0}"
+msgstr "A carregar {0}"
+
+#: static/js/common/upload-addon.js:189 static/js/zamboni/devhub-all.js:420 static/js/zamboni/devhub-min.js:1
+msgid "Error with {0}"
+msgstr "Erro com {0}"
+
+#: static/js/common/upload-addon.js:194 static/js/zamboni/devhub-all.js:425 static/js/zamboni/devhub-min.js:1
+msgid "Your add-on failed validation with {0} error."
+msgid_plural "Your add-on failed validation with {0} errors."
+msgstr[0] "O seu extra falhou a validação com {0} erro."
+msgstr[1] "O seu extra falhou a validação com {0} erros."
+
+#: static/js/common/upload-addon.js:208 static/js/zamboni/devhub-all.js:439 static/js/zamboni/devhub-min.js:1
+msgid "&hellip;and {0} more"
+msgid_plural "&hellip;and {0} more"
+msgstr[0] "&hellip;e mais {0}"
+msgstr[1] "&hellip;e mais {0}"
+
+#: static/js/common/upload-addon.js:222 static/js/common/upload-addon.js:497 static/js/zamboni/devhub-all.js:453 static/js/zamboni/devhub-all.js:743 static/js/zamboni/devhub-min.js:1
+msgid "See full validation report"
+msgstr "Ver relatório de validação completo"
+
+#: static/js/common/upload-addon.js:234 static/js/zamboni/devhub-all.js:465 static/js/zamboni/devhub-min.js:1
+msgid "Validating {0}"
+msgstr "A validar {0}"
+
+#. L10n: first argument is an HTTP status code
+#: static/js/common/upload-addon.js:273 static/js/zamboni/devhub-all.js:504 static/js/zamboni/devhub-min.js:1
+msgid "Received an empty response from the server; status: {0}"
+msgstr "Recebida resposta vazia do servidor; estado: {0}"
+
+#: static/js/common/upload-addon.js:370 static/js/zamboni/devhub-all.js:604 static/js/zamboni/devhub-min.js:1
+msgid "Unexpected server error while validating."
+msgstr "Erro inesperado do servidor enquanto validava."
+
+#: static/js/common/upload-addon.js:409 static/js/zamboni/devhub-all.js:643 static/js/zamboni/devhub-min.js:1
+msgid "Finished validating {0}"
+msgstr "Validação de {0} terminada"
+
+#: static/js/common/upload-addon.js:415 static/js/zamboni/devhub-all.js:649 static/js/zamboni/devhub-min.js:1
+msgid "Your add-on validation timed out, it will be manually reviewed."
+msgstr "A validação do seu extra expirou; será revisto manualmente."
+
+#: static/js/common/upload-addon.js:418 static/js/zamboni/devhub-all.js:652 static/js/zamboni/devhub-min.js:1
+msgid "Your add-on was validated with no errors and {0} warning."
+msgid_plural "Your add-on was validated with no errors and {0} warnings."
+msgstr[0] "O seu extra foi validado sem erros e com {0} aviso."
+msgstr[1] "O seu extra foi validado sem erros e com {0} avisos."
+
+#: static/js/common/upload-addon.js:423 static/js/zamboni/devhub-all.js:657 static/js/zamboni/devhub-min.js:1
+msgid "Your add-on was validated with no errors and {0} message."
+msgid_plural "Your add-on was validated with no errors and {0} messages."
+msgstr[0] "O seu extra foi validado sem erros e com {0} mensagem."
+msgstr[1] "O seu extra foi validado sem erros e com {0} mensagens."
+
+#: static/js/common/upload-addon.js:428 static/js/zamboni/devhub-all.js:662 static/js/zamboni/devhub-min.js:1
+msgid "Your add-on was validated with no errors or warnings."
+msgstr "O seu extra foi validado sem erros ou avisos."
+
+#: static/js/common/upload-addon.js:443 static/js/zamboni/devhub-all.js:677 static/js/zamboni/devhub-min.js:1
+msgid "Your submission will be automatically signed."
+msgstr "A sua submissão será assinada automaticamente."
+
+#: static/js/common/upload-addon.js:450 static/js/zamboni/devhub-all.js:696 static/js/zamboni/devhub-min.js:1
+msgid "Include detailed version notes (this can be done in the next step)."
+msgstr "Inclua notas detalhadas da versão (isto pode ser feito no próximo passo)."
+
+#: static/js/common/upload-addon.js:451 static/js/zamboni/devhub-all.js:697 static/js/zamboni/devhub-min.js:1
+msgid "If your add-on requires an account to a website in order to be fully tested, include a test username and password in the Notes to Reviewer (this can be done in the next step)."
+msgstr ""
+"Se para ser completamente testado, o seu extra requer uma conta para um website, inclua um nome de utilizador e palavra-passe de teste nas Notas ao Revisor (isto pode ser feito no próximo passo)."
+
+#: static/js/common/upload-addon.js:452 static/js/zamboni/devhub-all.js:698 static/js/zamboni/devhub-min.js:1
+msgid "If your add-on is intended for a limited audience you should choose Preliminary Review instead of Full Review."
+msgstr "Se o seu extra está direcionado para uma audiência limitada, deve escolher Revisão Preliminar em vez de Revisão Completa."
+
+#: static/js/common/upload-addon.js:465 static/js/zamboni/devhub-all.js:711 static/js/zamboni/devhub-min.js:1
+msgid "Add-on submission checklist"
+msgstr "Lista de controlo de submissão de extras"
+
+#: static/js/common/upload-addon.js:466 static/js/zamboni/devhub-all.js:712 static/js/zamboni/devhub-min.js:1
+msgid "Please verify the following points before finalizing your submission. This will minimize delays or misunderstanding during the review process:"
+msgstr "Por favor, confirme os pontos seguintes antes de finalizar a sua submissão. Isto irá minimizar atrasos ou lapsos durante o processo de revisão:"
+
+#: static/js/common/upload-addon.js:468 static/js/zamboni/devhub-all.js:714 static/js/zamboni/devhub-min.js:1
+msgid ""
+"Compiled binaries, as well as minified or obfuscated scripts (excluding known libraries) need to have their sources submitted separately for review. Make sure that you use the source code upload "
+"field to avoid having your submission rejected."
+msgstr ""
+"Os binários compilados, bem como os scripts reduzidos ou ofuscados (excluindo as bibliotecas conhecidas) devem ter as suas fontes submetidas separadamente para revisão. Certifique-se que utiliza o "
+"campo de envio do código fonte para evitar que a sua submissão seja rejeitada."
+
+#: static/js/common/upload-addon.js:486 static/js/zamboni/devhub-all.js:732 static/js/zamboni/devhub-min.js:1
+msgid "The validation process found these issues that can lead to rejections:"
+msgstr "O processo de validação encontrou estes problemas que podem levar a rejeições:"
+
+#: static/js/common/upload-addon.js:503 static/js/zamboni/devhub-all.js:749 static/js/zamboni/devhub-min.js:1
+msgid "If you are unfamiliar with the add-ons review process, you can read about it here."
+msgstr "Se não está familiarizado com o processo de revisão de extras, pode ler mais aqui sobre este processo."
+
+#: static/js/common/upload-addon.js:540 static/js/zamboni/devhub-all.js:786 static/js/zamboni/devhub-min.js:1
+msgid "Sorry, no supported platform has been found."
+msgstr "Lamentamos, mas não foi encontrada nenhuma plataforma suportada."
+
+#: static/js/common/upload-base.js:57 static/js/zamboni/devhub-all.js:187 static/js/zamboni/devhub-min.js:1
+msgid "The filetype you uploaded isn't recognized."
+msgstr "O tipo de ficheiro que carregou não é reconhecido."
+
+#: static/js/common/upload-base.js:79 static/js/zamboni/devhub-all.js:209 static/js/zamboni/devhub-min.js:1
+msgid "You cancelled the upload."
+msgstr "Você cancelou o carregamento."
+
+#: static/js/impala/stats/chart.js:267 static/js/zamboni/stats-all.js:16898 static/js/zamboni/stats-min.js:5
+msgid "Week of {0}"
+msgstr "Semana de {0}"
+
+#: static/js/impala/stats/chart.js:269 static/js/zamboni/stats-all.js:16900 static/js/zamboni/stats-min.js:5
+msgid " downloads"
+msgstr ""
+
+#: static/js/impala/stats/chart.js:270 static/js/zamboni/stats-all.js:16901 static/js/zamboni/stats-min.js:5
+msgid "{0} users"
+msgstr "{0} utilizadores"
+
+#: static/js/impala/stats/chart.js:271 static/js/zamboni/stats-all.js:16902 static/js/zamboni/stats-min.js:5
+msgid "{0} add-ons"
+msgstr "{0} extras"
+
+#: static/js/impala/stats/chart.js:272 static/js/zamboni/stats-all.js:16903 static/js/zamboni/stats-min.js:5
+msgid "{0} collections"
+msgstr "{0} coleções"
+
+#: static/js/impala/stats/chart.js:273 static/js/zamboni/stats-all.js:16904 static/js/zamboni/stats-min.js:5
+msgid "{0} reviews"
+msgstr "{0} revisões"
+
+#: static/js/impala/stats/chart.js:275 static/js/zamboni/stats-all.js:16906 static/js/zamboni/stats-min.js:5
+msgid "{0} sales"
+msgstr "{0} vendas"
+
+#: static/js/impala/stats/chart.js:276 static/js/zamboni/stats-all.js:16907 static/js/zamboni/stats-min.js:5
+msgid "{0} refunds"
+msgstr "{0} devoluções"
+
+#: static/js/impala/stats/chart.js:277 static/js/zamboni/stats-all.js:16908 static/js/zamboni/stats-min.js:5
+msgid "{0} installs"
+msgstr "{0} instalações"
+
+#: static/js/impala/stats/chart.js:369 static/js/impala/stats/csv_keys.js:3 static/js/impala/stats/csv_keys.js:109 static/js/zamboni/stats-all.js:15284 static/js/zamboni/stats-all.js:15390
+#: static/js/zamboni/stats-all.js:17000 static/js/zamboni/stats-min.js:4 static/js/zamboni/stats-min.js:5
+msgid "Downloads"
+msgstr "Descargas"
+
+#: static/js/impala/stats/chart.js:379 static/js/impala/stats/csv_keys.js:6 static/js/impala/stats/csv_keys.js:110 static/js/zamboni/stats-all.js:15287 static/js/zamboni/stats-all.js:15391
+#: static/js/zamboni/stats-all.js:17010 static/js/zamboni/stats-min.js:4 static/js/zamboni/stats-min.js:5
+msgid "Daily Users"
+msgstr "Utilizadores diários"
+
+#: static/js/impala/stats/chart.js:410 static/js/zamboni/stats-all.js:17041 static/js/zamboni/stats-min.js:5
+msgid "Amount, in USD"
+msgstr "Quantia, em USD"
+
+#: static/js/impala/stats/chart.js:421 static/js/impala/stats/csv_keys.js:104 static/js/zamboni/stats-all.js:15385 static/js/zamboni/stats-all.js:17052 static/js/zamboni/stats-min.js:5
+msgid "Number of Contributions"
+msgstr "Número de contribuições"
+
+#: static/js/impala/stats/chart.js:447 static/js/zamboni/stats-all.js:17078 static/js/zamboni/stats-min.js:5
+msgid "More Info..."
+msgstr "Mais info..."
+
+#. L10n: {0} is an ISO-formatted date.
+#: static/js/impala/stats/chart.js:451 static/js/zamboni/stats-all.js:17082 static/js/zamboni/stats-min.js:5
+msgid "Details for {0}"
+msgstr "Detalhes para {0}"
+
+#: static/js/impala/stats/csv_keys.js:9 static/js/zamboni/stats-all.js:15290 static/js/zamboni/stats-min.js:4
+msgid "Collections Created"
+msgstr "Coleções criadas"
+
+#: static/js/impala/stats/csv_keys.js:12 static/js/zamboni/stats-all.js:15293 static/js/zamboni/stats-min.js:4
+msgid "Add-ons in Use"
+msgstr "Extras em uso"
+
+#: static/js/impala/stats/csv_keys.js:15 static/js/zamboni/stats-all.js:15296 static/js/zamboni/stats-min.js:4
+msgid "Add-ons Created"
+msgstr "Extras criados"
+
+#: static/js/impala/stats/csv_keys.js:18 static/js/zamboni/stats-all.js:15299 static/js/zamboni/stats-min.js:4
+msgid "Add-ons Downloaded"
+msgstr "Extras descarregados"
+
+#: static/js/impala/stats/csv_keys.js:21 static/js/zamboni/stats-all.js:15302 static/js/zamboni/stats-min.js:4
+msgid "Add-ons Updated"
+msgstr "Extras atualizados"
+
+#: static/js/impala/stats/csv_keys.js:24 static/js/zamboni/stats-all.js:15305 static/js/zamboni/stats-min.js:4
+msgid "Reviews Written"
+msgstr "Revisões escritas"
+
+#: static/js/impala/stats/csv_keys.js:27 static/js/zamboni/stats-all.js:15308 static/js/zamboni/stats-min.js:4
+msgid "User Signups"
+msgstr "Subscrições de utilizadores"
+
+#: static/js/impala/stats/csv_keys.js:30 static/js/zamboni/stats-all.js:15311 static/js/zamboni/stats-min.js:4
+msgid "Subscribers"
+msgstr "Subscritores"
+
+#: static/js/impala/stats/csv_keys.js:33 static/js/zamboni/stats-all.js:15314 static/js/zamboni/stats-min.js:4
+msgid "Ratings"
+msgstr "Avaliações"
+
+#: static/js/impala/stats/csv_keys.js:36 static/js/impala/stats/csv_keys.js:114 static/js/zamboni/stats-all.js:15317 static/js/zamboni/stats-all.js:15395 static/js/zamboni/stats-min.js:4
+#: static/js/zamboni/stats-min.js:5
+msgid "Sales"
+msgstr "Vendas"
+
+#: static/js/impala/stats/csv_keys.js:39 static/js/impala/stats/csv_keys.js:113 static/js/zamboni/stats-all.js:15320 static/js/zamboni/stats-all.js:15394 static/js/zamboni/stats-min.js:4
+#: static/js/zamboni/stats-min.js:5
+msgid "Installs"
+msgstr "Instalações"
+
+#: static/js/impala/stats/csv_keys.js:42 static/js/zamboni/stats-all.js:15323 static/js/zamboni/stats-min.js:4
+msgid "Unknown"
+msgstr "Desconhecido"
+
+#: static/js/impala/stats/csv_keys.js:43 static/js/zamboni/stats-all.js:15324 static/js/zamboni/stats-min.js:4
+msgid "Add-ons Manager"
+msgstr "Gestor de Extras"
+
+#: static/js/impala/stats/csv_keys.js:44 static/js/zamboni/stats-all.js:15325 static/js/zamboni/stats-min.js:4
+msgid "Add-ons Manager Promo"
+msgstr "Gestor de Promoção de Extras"
+
+#: static/js/impala/stats/csv_keys.js:45 static/js/zamboni/stats-all.js:15326 static/js/zamboni/stats-min.js:4
+msgid "Add-ons Manager Featured"
+msgstr "Gestor de Destaques de Extras"
+
+#: static/js/impala/stats/csv_keys.js:46 static/js/zamboni/stats-all.js:15327 static/js/zamboni/stats-min.js:4
+msgid "Add-ons Manager Learn More"
+msgstr "Gestor de Saber Mais sobre Extras"
+
+#: static/js/impala/stats/csv_keys.js:47 static/js/zamboni/stats-all.js:15328 static/js/zamboni/stats-min.js:4
+msgid "Search Suggestions"
+msgstr "Sugestões de Pesquisa"
+
+#: static/js/impala/stats/csv_keys.js:48 static/js/zamboni/stats-all.js:15329 static/js/zamboni/stats-min.js:4
+msgid "Search Results"
+msgstr "Resultados da pesquisa"
+
+#: static/js/impala/stats/csv_keys.js:49 static/js/impala/stats/csv_keys.js:50 static/js/impala/stats/csv_keys.js:51 static/js/zamboni/stats-all.js:15330 static/js/zamboni/stats-all.js:15331
+#: static/js/zamboni/stats-all.js:15332 static/js/zamboni/stats-min.js:4
+msgid "Homepage Promo"
+msgstr "Promo da página inicial"
+
+#: static/js/impala/stats/csv_keys.js:52 static/js/impala/stats/csv_keys.js:53 static/js/zamboni/stats-all.js:15333 static/js/zamboni/stats-all.js:15334 static/js/zamboni/stats-min.js:4
+msgid "Homepage Featured"
+msgstr "Em destaque na página inicial"
+
+#: static/js/impala/stats/csv_keys.js:54 static/js/impala/stats/csv_keys.js:55 static/js/zamboni/stats-all.js:15335 static/js/zamboni/stats-all.js:15336 static/js/zamboni/stats-min.js:4
+msgid "Homepage Up and Coming"
+msgstr "Brevemente na página inicial"
+
+#: static/js/impala/stats/csv_keys.js:56 static/js/zamboni/stats-all.js:15337 static/js/zamboni/stats-min.js:4
+msgid "Homepage Most Popular"
+msgstr "Mais populares na página inicial"
+
+#: static/js/impala/stats/csv_keys.js:57 static/js/impala/stats/csv_keys.js:59 static/js/zamboni/stats-all.js:15338 static/js/zamboni/stats-all.js:15340 static/js/zamboni/stats-min.js:4
+msgid "Detail Page"
+msgstr "Página de detalhes"
+
+#: static/js/impala/stats/csv_keys.js:58 static/js/impala/stats/csv_keys.js:60 static/js/zamboni/stats-all.js:15339 static/js/zamboni/stats-all.js:15341 static/js/zamboni/stats-min.js:4
+msgid "Detail Page (bottom)"
+msgstr "Página de detalhes (fundo)"
+
+#: static/js/impala/stats/csv_keys.js:61 static/js/zamboni/stats-all.js:15342 static/js/zamboni/stats-min.js:4
+msgid "Detail Page (Development Channel)"
+msgstr "Página de detalhes (canal de desenvolvimento)"
+
+#: static/js/impala/stats/csv_keys.js:62 static/js/impala/stats/csv_keys.js:63 static/js/impala/stats/csv_keys.js:64 static/js/zamboni/stats-all.js:15343 static/js/zamboni/stats-all.js:15344
+#: static/js/zamboni/stats-all.js:15345 static/js/zamboni/stats-min.js:4
+msgid "Often Used With"
+msgstr "Normalmente usado com"
+
+#: static/js/impala/stats/csv_keys.js:65 static/js/impala/stats/csv_keys.js:66 static/js/zamboni/stats-all.js:15346 static/js/zamboni/stats-all.js:15347 static/js/zamboni/stats-min.js:4
+msgid "Others By Author"
+msgstr "Outros pelo autor"
+
+#: static/js/impala/stats/csv_keys.js:67 static/js/impala/stats/csv_keys.js:68 static/js/zamboni/stats-all.js:15348 static/js/zamboni/stats-all.js:15349 static/js/zamboni/stats-min.js:4
+msgid "Dependencies"
+msgstr "Dependências"
+
+#: static/js/impala/stats/csv_keys.js:69 static/js/impala/stats/csv_keys.js:70 static/js/zamboni/stats-all.js:15350 static/js/zamboni/stats-all.js:15351 static/js/zamboni/stats-min.js:4
+msgid "Upsell"
+msgstr "Upsell"
+
+#: static/js/impala/stats/csv_keys.js:71 static/js/zamboni/stats-all.js:15352 static/js/zamboni/stats-min.js:4
+msgid "Meet the Developer"
+msgstr "Conheça o programador"
+
+#: static/js/impala/stats/csv_keys.js:72 static/js/zamboni/stats-all.js:15353 static/js/zamboni/stats-min.js:4
+msgid "User Profile"
+msgstr "Perfil do utilizador"
+
+#: static/js/impala/stats/csv_keys.js:73 static/js/zamboni/stats-all.js:15354 static/js/zamboni/stats-min.js:4
+msgid "Version History"
+msgstr "Histórico de versões"
+
+#: static/js/impala/stats/csv_keys.js:75 static/js/zamboni/stats-all.js:15356 static/js/zamboni/stats-min.js:4
+msgid "Sharing"
+msgstr "Partilha"
+
+#: static/js/impala/stats/csv_keys.js:76 static/js/zamboni/stats-all.js:15357 static/js/zamboni/stats-min.js:4
+msgid "Category Pages"
+msgstr "Páginas de categorias"
+
+#: static/js/impala/stats/csv_keys.js:77 static/js/zamboni/stats-all.js:15358 static/js/zamboni/stats-min.js:4
+msgid "Collections"
+msgstr "Coleções"
+
+#: static/js/impala/stats/csv_keys.js:78 static/js/impala/stats/csv_keys.js:79 static/js/zamboni/stats-all.js:15359 static/js/zamboni/stats-all.js:15360 static/js/zamboni/stats-min.js:4
+msgid "Category Landing Featured Carousel"
+msgstr "Categoria de funcionalidades carousel"
+
+#: static/js/impala/stats/csv_keys.js:80 static/js/impala/stats/csv_keys.js:81 static/js/zamboni/stats-all.js:15361 static/js/zamboni/stats-all.js:15362 static/js/zamboni/stats-min.js:4
+msgid "Category Landing Top Rated"
+msgstr "Categoria dos mais avaliados"
+
+#: static/js/impala/stats/csv_keys.js:82 static/js/impala/stats/csv_keys.js:83 static/js/zamboni/stats-all.js:15363 static/js/zamboni/stats-all.js:15364 static/js/zamboni/stats-min.js:5
+msgid "Category Landing Most Popular"
+msgstr "Categoria mais populares"
+
+#: static/js/impala/stats/csv_keys.js:84 static/js/impala/stats/csv_keys.js:85 static/js/zamboni/stats-all.js:15365 static/js/zamboni/stats-all.js:15366 static/js/zamboni/stats-min.js:5
+msgid "Category Landing Recently Added"
+msgstr "Categoria dos adicionados recentemente"
+
+#: static/js/impala/stats/csv_keys.js:86 static/js/impala/stats/csv_keys.js:87 static/js/zamboni/stats-all.js:15367 static/js/zamboni/stats-all.js:15368 static/js/zamboni/stats-min.js:5
+msgid "Browse Listing Featured Sort"
+msgstr "Navegar na listagem ordenada em destaque"
+
+#: static/js/impala/stats/csv_keys.js:88 static/js/impala/stats/csv_keys.js:89 static/js/zamboni/stats-all.js:15369 static/js/zamboni/stats-all.js:15370 static/js/zamboni/stats-min.js:5
+msgid "Browse Listing Users Sort"
+msgstr "Navegar na listagem ordenada de utilizadores"
+
+#: static/js/impala/stats/csv_keys.js:90 static/js/impala/stats/csv_keys.js:91 static/js/zamboni/stats-all.js:15371 static/js/zamboni/stats-all.js:15372 static/js/zamboni/stats-min.js:5
+msgid "Browse Listing Rating Sort"
+msgstr "Navegar na listagem ordenada por avaliações"
+
+#: static/js/impala/stats/csv_keys.js:92 static/js/impala/stats/csv_keys.js:93 static/js/zamboni/stats-all.js:15373 static/js/zamboni/stats-all.js:15374 static/js/zamboni/stats-min.js:5
+msgid "Browse Listing Created Sort"
+msgstr "Navegar na listagem ordenada criada"
+
+#: static/js/impala/stats/csv_keys.js:94 static/js/impala/stats/csv_keys.js:95 static/js/zamboni/stats-all.js:15375 static/js/zamboni/stats-all.js:15376 static/js/zamboni/stats-min.js:5
+msgid "Browse Listing Name Sort"
+msgstr "Navegar na listagem ordenada por nome"
+
+#: static/js/impala/stats/csv_keys.js:96 static/js/impala/stats/csv_keys.js:97 static/js/zamboni/stats-all.js:15377 static/js/zamboni/stats-all.js:15378 static/js/zamboni/stats-min.js:5
+msgid "Browse Listing Popular Sort"
+msgstr "Navegar na listagem ordenada por popularidade"
+
+#: static/js/impala/stats/csv_keys.js:98 static/js/impala/stats/csv_keys.js:99 static/js/zamboni/stats-all.js:15379 static/js/zamboni/stats-all.js:15380 static/js/zamboni/stats-min.js:5
+msgid "Browse Listing Updated Sort"
+msgstr "Navegar na listagem ordenada por popularidade"
+
+#: static/js/impala/stats/csv_keys.js:100 static/js/impala/stats/csv_keys.js:101 static/js/zamboni/stats-all.js:15381 static/js/zamboni/stats-all.js:15382 static/js/zamboni/stats-min.js:5
+msgid "Browse Listing Up and Coming Sort"
+msgstr "Navegar na listagem deos próximos lançamentos"
+
+#: static/js/impala/stats/csv_keys.js:105 static/js/zamboni/stats-all.js:15386 static/js/zamboni/stats-min.js:5
+msgid "Total Amount Contributed"
+msgstr "Montante total de contribuições"
+
+#: static/js/impala/stats/csv_keys.js:106 static/js/zamboni/stats-all.js:15387 static/js/zamboni/stats-min.js:5
+msgid "Average Contribution"
+msgstr "Contribuição média"
+
+#: static/js/impala/stats/csv_keys.js:115 static/js/zamboni/stats-all.js:15396 static/js/zamboni/stats-min.js:5
+msgid "Usage"
+msgstr "Utilização"
+
+#: static/js/impala/stats/csv_keys.js:118 static/js/zamboni/stats-all.js:15399 static/js/zamboni/stats-min.js:5
+msgid "Firefox"
+msgstr "Firefox"
+
+#: static/js/impala/stats/csv_keys.js:119 static/js/zamboni/stats-all.js:15400 static/js/zamboni/stats-min.js:5
+msgid "Mozilla"
+msgstr "Mozilla"
+
+#: static/js/impala/stats/csv_keys.js:120 static/js/zamboni/stats-all.js:15401 static/js/zamboni/stats-min.js:5
+msgid "Thunderbird"
+msgstr "Thunderbird"
+
+#: static/js/impala/stats/csv_keys.js:121 static/js/zamboni/stats-all.js:15402 static/js/zamboni/stats-min.js:5
+msgid "Sunbird"
+msgstr "Sunbird"
+
+#: static/js/impala/stats/csv_keys.js:122 static/js/zamboni/stats-all.js:15403 static/js/zamboni/stats-min.js:5
+msgid "SeaMonkey"
+msgstr "SeaMonkey"
+
+#: static/js/impala/stats/csv_keys.js:123 static/js/zamboni/stats-all.js:15404 static/js/zamboni/stats-min.js:5
+msgid "Fennec"
+msgstr "Fennec"
+
+#: static/js/impala/stats/csv_keys.js:124 static/js/zamboni/stats-all.js:15405 static/js/zamboni/stats-min.js:5
+msgid "Android"
+msgstr "Android"
+
+#. L10n: {0} is an integer.
+#: static/js/impala/stats/csv_keys.js:129 static/js/zamboni/stats-all.js:15410 static/js/zamboni/stats-min.js:5
+msgid "Downloads and Daily Users, last {0} days"
+msgstr "Descargas e utilizadores diários, últimos {0} dias"
+
+#. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
+#: static/js/impala/stats/csv_keys.js:131 static/js/zamboni/stats-all.js:15412 static/js/zamboni/stats-min.js:5
+msgid "Downloads and Daily Users from {0} to {1}"
+msgstr "Descargas e utilizadores diários de {0} a {1}"
+
+#. L10n: {0} is an integer.
+#: static/js/impala/stats/csv_keys.js:135 static/js/zamboni/stats-all.js:15416 static/js/zamboni/stats-min.js:5
+msgid "Installs and Daily Users, last {0} days"
+msgstr "Instalações e utilizadores diários, últimos {0} dias"
+
+#. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
+#: static/js/impala/stats/csv_keys.js:137 static/js/zamboni/stats-all.js:15418 static/js/zamboni/stats-min.js:5
+msgid "Installs and Daily Users from {0} to {1}"
+msgstr "Instalações e utilizadores diários de {0} a {1}"
+
+#. L10n: {0} is an integer.
+#: static/js/impala/stats/csv_keys.js:141 static/js/zamboni/stats-all.js:15422 static/js/zamboni/stats-min.js:5
+msgid "Downloads, last {0} days"
+msgstr "Descargas, últimos {0} dias"
+
+#. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
+#: static/js/impala/stats/csv_keys.js:143 static/js/zamboni/stats-all.js:15424 static/js/zamboni/stats-min.js:5
+msgid "Downloads from {0} to {1}"
+msgstr "Descargas de {0} a {1}"
+
+#. L10n: {0} is an integer.
+#: static/js/impala/stats/csv_keys.js:147 static/js/zamboni/stats-all.js:15428 static/js/zamboni/stats-min.js:5
+msgid "Daily Users, last {0} days"
+msgstr "Utilizadores diários, últimos {0} dias"
+
+#. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
+#: static/js/impala/stats/csv_keys.js:149 static/js/zamboni/stats-all.js:15430 static/js/zamboni/stats-min.js:5
+msgid "Daily Users from {0} to {1}"
+msgstr "Utilizadores diários de {0} a {1}"
+
+#. L10n: {0} is an integer.
+#: static/js/impala/stats/csv_keys.js:153 static/js/zamboni/stats-all.js:15434 static/js/zamboni/stats-min.js:5
+msgid "Applications, last {0} days"
+msgstr "Aplicações, últimos {0} dias"
+
+#. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
+#: static/js/impala/stats/csv_keys.js:155 static/js/zamboni/stats-all.js:15436 static/js/zamboni/stats-min.js:5
+msgid "Applications from {0} to {1}"
+msgstr "Aplicações de {0} a {1}"
+
+#. L10n: {0} is an integer.
+#: static/js/impala/stats/csv_keys.js:159 static/js/zamboni/stats-all.js:15440 static/js/zamboni/stats-min.js:5
+msgid "Platforms, last {0} days"
+msgstr "Plataformas, últimos {0} dias"
+
+#. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
+#: static/js/impala/stats/csv_keys.js:161 static/js/zamboni/stats-all.js:15442 static/js/zamboni/stats-min.js:5
+msgid "Platforms from {0} to {1}"
+msgstr "Plataformas de {0} a {1}"
+
+#. L10n: {0} is an integer.
+#: static/js/impala/stats/csv_keys.js:165 static/js/zamboni/stats-all.js:15446 static/js/zamboni/stats-min.js:5
+msgid "Languages, last {0} days"
+msgstr "Idiomas, últimos {0} dias"
+
+#. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
+#: static/js/impala/stats/csv_keys.js:167 static/js/zamboni/stats-all.js:15448 static/js/zamboni/stats-min.js:5
+msgid "Languages from {0} to {1}"
+msgstr "Idiomas de {0} a {1}"
+
+#. L10n: {0} is an integer.
+#: static/js/impala/stats/csv_keys.js:171 static/js/zamboni/stats-all.js:15452 static/js/zamboni/stats-min.js:5
+msgid "Add-on Versions, last {0} days"
+msgstr "Versões do extra, últimos {0} dias"
+
+#. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
+#: static/js/impala/stats/csv_keys.js:173 static/js/zamboni/stats-all.js:15454 static/js/zamboni/stats-min.js:5
+msgid "Add-on Versions from {0} to {1}"
+msgstr "Versões do extra de {0} a {1}"
+
+#. L10n: {0} is an integer.
+#: static/js/impala/stats/csv_keys.js:177 static/js/zamboni/stats-all.js:15458 static/js/zamboni/stats-min.js:5
+msgid "Add-on Status, last {0} days"
+msgstr "Estado do extra, últimos {0} dias"
+
+#. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
+#: static/js/impala/stats/csv_keys.js:179 static/js/zamboni/stats-all.js:15460 static/js/zamboni/stats-min.js:5
+msgid "Add-on Status from {0} to {1}"
+msgstr "Estado do extra de {0} a {1}"
+
+#. L10n: {0} is an integer.
+#: static/js/impala/stats/csv_keys.js:183 static/js/zamboni/stats-all.js:15464 static/js/zamboni/stats-min.js:5
+msgid "Download Sources, last {0} days"
+msgstr "Fontes das descargas, últimos {0} dias"
+
+#. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
+#: static/js/impala/stats/csv_keys.js:185 static/js/zamboni/stats-all.js:15466 static/js/zamboni/stats-min.js:5
+msgid "Download Sources from {0} to {1}"
+msgstr "Fontes das descargas de {0} a {1}"
+
+#. L10n: {0} is an integer.
+#: static/js/impala/stats/csv_keys.js:189 static/js/zamboni/stats-all.js:15470 static/js/zamboni/stats-min.js:5
+msgid "Contributions, last {0} days"
+msgstr "Contribuições, últimos {0} dias"
+
+#. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
+#: static/js/impala/stats/csv_keys.js:191 static/js/zamboni/stats-all.js:15472 static/js/zamboni/stats-min.js:5
+msgid "Contributions from {0} to {1}"
+msgstr "Contribuições de {0} a {1}"
+
+#. L10n: {0} is an integer.
+#: static/js/impala/stats/csv_keys.js:195 static/js/zamboni/stats-all.js:15476 static/js/zamboni/stats-min.js:5
+msgid "Site Metrics, last {0} days"
+msgstr "Medições do site , últimos {0} dias"
+
+#. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
+#: static/js/impala/stats/csv_keys.js:197 static/js/zamboni/stats-all.js:15478 static/js/zamboni/stats-min.js:5
+msgid "Site Metrics from {0} to {1}"
+msgstr "Medições do site de {0} a {1}"
+
+#. L10n: {0} is an integer.
+#: static/js/impala/stats/csv_keys.js:201 static/js/zamboni/stats-all.js:15482 static/js/zamboni/stats-min.js:5
+msgid "Add-ons in Use, last {0} days"
+msgstr "Extras em uso, últimos {0} dias"
+
+#. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
+#: static/js/impala/stats/csv_keys.js:203 static/js/zamboni/stats-all.js:15484 static/js/zamboni/stats-min.js:5
+msgid "Add-ons in Use from {0} to {1}"
+msgstr "Extras em utilização de {0} a {1}"
+
+#. L10n: {0} is an integer.
+#: static/js/impala/stats/csv_keys.js:207 static/js/zamboni/stats-all.js:15488 static/js/zamboni/stats-min.js:5
+msgid "Add-ons Downloaded, last {0} days"
+msgstr "Extras descarregados, últimos {0} dias"
+
+#. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
+#: static/js/impala/stats/csv_keys.js:209 static/js/zamboni/stats-all.js:15490 static/js/zamboni/stats-min.js:5
+msgid "Add-ons Downloaded from {0} to {1}"
+msgstr "Extras descarregados de {0} a {1}"
+
+#. L10n: {0} is an integer.
+#: static/js/impala/stats/csv_keys.js:213 static/js/zamboni/stats-all.js:15494 static/js/zamboni/stats-min.js:5
+msgid "Add-ons Created, last {0} days"
+msgstr "Extras criados, últimos{ 0} dias"
+
+#. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
+#: static/js/impala/stats/csv_keys.js:215 static/js/zamboni/stats-all.js:15496 static/js/zamboni/stats-min.js:5
+msgid "Add-ons Created from {0} to {1}"
+msgstr "Extras criados de {0} a {1}"
+
+#. L10n: {0} is an integer.
+#: static/js/impala/stats/csv_keys.js:219 static/js/zamboni/stats-all.js:15500 static/js/zamboni/stats-min.js:5
+msgid "Add-ons Updated, last {0} days"
+msgstr "Extras atualizados, últimos {0} dias"
+
+#. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
+#: static/js/impala/stats/csv_keys.js:221 static/js/zamboni/stats-all.js:15502 static/js/zamboni/stats-min.js:5
+msgid "Add-ons Updated from {0} to {1}"
+msgstr "Extras atualizados de {0} a {1}"
+
+#. L10n: {0} is an integer.
+#: static/js/impala/stats/csv_keys.js:225 static/js/zamboni/stats-all.js:15506 static/js/zamboni/stats-min.js:5
+msgid "Reviews Written, last {0} days"
+msgstr "Revisões escritas, últimos {0} dias"
+
+#. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
+#: static/js/impala/stats/csv_keys.js:227 static/js/zamboni/stats-all.js:15508 static/js/zamboni/stats-min.js:5
+msgid "Reviews Written from {0} to {1}"
+msgstr "Revisões escritas de {0} a {1}"
+
+#. L10n: {0} is an integer.
+#: static/js/impala/stats/csv_keys.js:231 static/js/zamboni/stats-all.js:15512 static/js/zamboni/stats-min.js:5
+msgid "User Signups, last {0} days"
+msgstr "Subscrição de utilizadores, últimos {0} dias"
+
+#. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
+#: static/js/impala/stats/csv_keys.js:233 static/js/zamboni/stats-all.js:15514 static/js/zamboni/stats-min.js:5
+msgid "User Signups from {0} to {1}"
+msgstr "Subscrições de utilizadores de {0} a {1}"
+
+#. L10n: {0} is an integer.
+#: static/js/impala/stats/csv_keys.js:237 static/js/zamboni/stats-all.js:15518 static/js/zamboni/stats-min.js:5
+msgid "Collections Created, last {0} days"
+msgstr "Coleções criadas, últimos {0} dias"
+
+#. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
+#: static/js/impala/stats/csv_keys.js:239 static/js/zamboni/stats-all.js:15520 static/js/zamboni/stats-min.js:5
+msgid "Collections Created from {0} to {1}"
+msgstr "Coleções criadas de {0} a {1}"
+
+#. L10n: {0} is an integer.
+#: static/js/impala/stats/csv_keys.js:243 static/js/zamboni/stats-all.js:15524 static/js/zamboni/stats-min.js:5
+msgid "Subscribers, last {0} days"
+msgstr "Subscritores, últimos {0} dias"
+
+#. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
+#: static/js/impala/stats/csv_keys.js:245 static/js/zamboni/stats-all.js:15526 static/js/zamboni/stats-min.js:5
+msgid "Subscribers from {0} to {1}"
+msgstr "Subscritores de {0} a {1}"
+
+#. L10n: {0} is an integer.
+#: static/js/impala/stats/csv_keys.js:249 static/js/zamboni/stats-all.js:15530 static/js/zamboni/stats-min.js:5
+msgid "Ratings, last {0} days"
+msgstr "Avaliações, últimos {0} dias"
+
+#. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
+#: static/js/impala/stats/csv_keys.js:251 static/js/zamboni/stats-all.js:15532 static/js/zamboni/stats-min.js:5
+msgid "Ratings from {0} to {1}"
+msgstr "Avaliações de {0} a {1}"
+
+#. L10n: {0} is an integer.
+#: static/js/impala/stats/csv_keys.js:255 static/js/zamboni/stats-all.js:15536 static/js/zamboni/stats-min.js:5
+msgid "Sales, last {0} days"
+msgstr "Vendas, últimos {0} dias"
+
+#. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
+#: static/js/impala/stats/csv_keys.js:257 static/js/zamboni/stats-all.js:15538 static/js/zamboni/stats-min.js:5
+msgid "Sales from {0} to {1}"
+msgstr "Vendas de {0} a {1}"
+
+#. L10n: {0} is an integer.
+#: static/js/impala/stats/csv_keys.js:261 static/js/zamboni/stats-all.js:15542 static/js/zamboni/stats-min.js:5
+msgid "Installs, last {0} days"
+msgstr "Instalações, últimos {0} dias"
+
+#. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
+#: static/js/impala/stats/csv_keys.js:263 static/js/zamboni/stats-all.js:15544 static/js/zamboni/stats-min.js:5
+msgid "Installs from {0} to {1}"
+msgstr "Instalações de {0} a {1}"
+
+#. L10n: {0} and {1} are integers.
+#: static/js/impala/stats/csv_keys.js:269 static/js/zamboni/stats-all.js:15550 static/js/zamboni/stats-min.js:5
+msgid "<b>{0}</b> in last {1} days"
+msgstr "<b>{0}</b> nos últimos {1} dias"
+
+#. L10n: {0} is an integer and {1} and {2} are dates in YYYY-MM-DD format.
+#: static/js/impala/stats/csv_keys.js:271 static/js/impala/stats/csv_keys.js:277 static/js/zamboni/stats-all.js:15552 static/js/zamboni/stats-all.js:15558 static/js/zamboni/stats-min.js:5
+msgid "<b>{0}</b> from {1} to {2}"
+msgstr "<b>{0}</b> de {1} a {2}"
+
+#. L10n: {0} and {1} are integers.
+#: static/js/impala/stats/csv_keys.js:275 static/js/zamboni/stats-all.js:15556 static/js/zamboni/stats-min.js:5
+msgid "<b>{0}</b> average in last {1} days"
+msgstr "<b>{0}</b> média nos últimos {1} dias"
+
+#: static/js/impala/stats/overview.js:19 static/js/zamboni/stats-all.js:16469 static/js/zamboni/stats-min.js:5
+msgid "No data available."
+msgstr "Sem dados disponíveis."
+
+#: static/js/impala/stats/table.js:74 static/js/zamboni/stats-all.js:17209 static/js/zamboni/stats-min.js:5
+msgid "Date"
+msgstr "Data"
+
+#: static/js/impala/stats/topchart.js:96 static/js/zamboni/stats-all.js:16600 static/js/zamboni/stats-min.js:5
+msgid "Other"
+msgstr "Outro"
+
+#: static/js/zamboni/admin-all.js:180 static/js/zamboni/admin-min.js:1 static/js/zamboni/admin_validation.js:24 static/js/zamboni/devhub-all.js:2408 static/js/zamboni/devhub-min.js:2
+#: static/js/zamboni/devhub.js:1229 static/js/zamboni/editors-all.js:15576 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:295
+msgid "Select an application first"
+msgstr "Primeiro selecione uma aplicação"
+
+#: static/js/zamboni/admin-all.js:207 static/js/zamboni/admin-min.js:1 static/js/zamboni/admin_validation.js:51
+msgid "Set {0} add-on to a max version of {1} and email the author."
+msgid_plural "Set {0} add-ons to a max version of {1} and email the authors."
+msgstr[0] "Definir {0} extra para a versão máxima de {1} e enviar mensagem ao autor."
+msgstr[1] "Definir {0} extras para a versão máxima de {1} e enviar mensagens aos autores."
+
+#: static/js/zamboni/admin-all.js:210 static/js/zamboni/admin-min.js:1 static/js/zamboni/admin_validation.js:54
+msgid "Email author of {2} add-on which failed validation."
+msgid_plural "Email authors of {2} add-ons which failed validation."
+msgstr[0] "Email do autor do extra {2} que falhou a validação."
+msgstr[1] "E-mail dos autores do extra {2} que falhou a validação."
+
+#: static/js/zamboni/devhub-all.js:1289 static/js/zamboni/devhub-min.js:1 static/js/zamboni/devhub.js:110
+msgid "Your browser does not support the video tag"
+msgstr "O seu navegador não suporta a etiqueta de vídeo"
+
+#: static/js/zamboni/devhub-all.js:1550 static/js/zamboni/devhub-min.js:1 static/js/zamboni/devhub.js:371
+msgid "Changes Saved"
+msgstr "Alterações guardadas"
+
+#: static/js/zamboni/devhub-all.js:1566 static/js/zamboni/devhub-min.js:1 static/js/zamboni/devhub.js:387
+msgid "Enter a new author's email address"
+msgstr "Escreva o novo endereço de email do autor"
+
+#: static/js/zamboni/devhub-all.js:1715 static/js/zamboni/devhub-min.js:1 static/js/zamboni/devhub.js:536
+msgid "There was an error uploading your file."
+msgstr "Houve um erro ao carregar o seu ficheiro."
+
+#: static/js/zamboni/devhub-all.js:1860 static/js/zamboni/devhub-min.js:1 static/js/zamboni/devhub.js:681
+msgid "{files} file"
+msgid_plural "{files} files"
+msgstr[0] "{files} ficheiro"
+msgstr[1] "{files} ficheiros"
+
+#: static/js/zamboni/devhub-all.js:1863 static/js/zamboni/devhub-min.js:1 static/js/zamboni/devhub.js:684
+msgid "{reviews} user review"
+msgid_plural "{reviews} user reviews"
+msgstr[0] "{reviews} análise do utilizador"
+msgstr[1] "{reviews} análises do utilizador"
+
+#: static/js/zamboni/devhub-all.js:1975 static/js/zamboni/devhub-min.js:2 static/js/zamboni/devhub.js:796
+msgid "Learn more"
+msgstr "Saber mais"
+
+#: static/js/zamboni/devhub-all.js:1979 static/js/zamboni/devhub-min.js:2 static/js/zamboni/devhub.js:800
+msgid "Example"
+msgstr "Exemplo"
+
+#: static/js/zamboni/devhub-all.js:2309 static/js/zamboni/devhub-min.js:2 static/js/zamboni/devhub.js:1130
+msgid "Image changes being processed"
+msgstr "Alterações de imagens em processamento"
+
+#: static/js/zamboni/devhub-all.js:2459 static/js/zamboni/devhub-min.js:2 static/js/zamboni/devhub.js:1280
+msgid "Must be a valid e-mail address."
+msgstr "É necessário um endereço de e-mail válido."
+
+#: static/js/zamboni/devhub-all.js:2613 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:80
 msgid "All tests passed successfully."
 msgstr "Todos os testes passaram com sucesso."
 
-#: static/js/zamboni/validator.js:83 static/js/zamboni/validator.js:478
+#: static/js/zamboni/devhub-all.js:2616 static/js/zamboni/devhub-all.js:3011 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:83 static/js/zamboni/validator.js:478
 msgid "These tests were not run."
 msgstr "Estes testes não foram executados."
 
-#: static/js/zamboni/validator.js:131 static/js/zamboni/validator.js:144
+#: static/js/zamboni/devhub-all.js:2664 static/js/zamboni/devhub-all.js:2677 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:131 static/js/zamboni/validator.js:144
 msgid "Tests"
 msgstr "Testes"
 
-#: static/js/zamboni/validator.js:246 static/js/zamboni/validator.js:575
-#: static/js/zamboni/validator.js:594
+#: static/js/zamboni/devhub-all.js:2779 static/js/zamboni/devhub-all.js:3108 static/js/zamboni/devhub-all.js:3127 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:246
+#: static/js/zamboni/validator.js:575 static/js/zamboni/validator.js:594
 msgid "Error"
 msgstr "Erro"
 
-#: static/js/zamboni/validator.js:247
+#: static/js/zamboni/devhub-all.js:2780 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:247
 msgid "Warning"
 msgstr "Aviso"
 
-#: static/js/zamboni/validator.js:299
+#: static/js/zamboni/devhub-all.js:2794 static/js/zamboni/devhub-min.js:2 static/js/zamboni/files-all.js:5657 static/js/zamboni/files-min.js:3 static/js/zamboni/files.js:411
+#: static/js/zamboni/validator.js:261
+msgid "Ignore this message in future updates"
+msgstr "Ignorar esta mensagem em futuras atualizações"
+
+#: static/js/zamboni/devhub-all.js:2817 static/js/zamboni/devhub-min.js:2 static/js/zamboni/files-all.js:5663 static/js/zamboni/files-min.js:3 static/js/zamboni/files.js:417
+#: static/js/zamboni/validator.js:284
+msgid "Severity for automated signing:"
+msgstr "Severidade para sinalização automática:"
+
+#: static/js/zamboni/devhub-all.js:2832 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:299
 msgid "Suggestions for passing automated signing:"
 msgstr "Sugestões para passar a assinatura automática:"
 
-#: static/js/zamboni/validator.js:387
+#: static/js/zamboni/devhub-all.js:2920 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:387
 msgid "Compatibility Tests"
 msgstr "Testes de compatibilidade"
 
-#: static/js/zamboni/validator.js:466
+#: static/js/zamboni/devhub-all.js:2999 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:466
 msgid "Add-on failed validation."
 msgstr "O extra falhou a validação."
 
-#: static/js/zamboni/validator.js:468
+#: static/js/zamboni/devhub-all.js:3001 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:468
 msgid "Add-on passed validation."
 msgstr "O extra passou a validação."
 
-#: static/js/zamboni/validator.js:481
+#: static/js/zamboni/devhub-all.js:3014 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:481
 msgid "{0} error"
 msgid_plural "{0} errors"
 msgstr[0] "{0} erro"
 msgstr[1] "{0} erros"
 
-#: static/js/zamboni/validator.js:483
+#: static/js/zamboni/devhub-all.js:3016 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:483
 msgid "{0} warning"
 msgid_plural "{0} warnings"
 msgstr[0] "{0} aviso"
 msgstr[1] "{0} avisos"
 
-#: static/js/zamboni/validator.js:485
+#: static/js/zamboni/devhub-all.js:3018 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:485
 msgid "{0} notice"
 msgid_plural "{0} notices"
 msgstr[0] "{0} nota"
 msgstr[1] "{0} notas"
 
-#: static/js/zamboni/validator.js:577
+#: static/js/zamboni/devhub-all.js:3110 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:577
 msgid "Validation task could not complete or completed with errors"
 msgstr "A tarefa de validação não foi concluída ou foi concluída com erros"
 
-#: static/js/zamboni/validator.js:595
+#: static/js/zamboni/devhub-all.js:3128 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:595
 msgid "Internal server error"
 msgstr "Erro interno do servidor"
 
-#: static/js/zamboni/mobile/buttons.js:52
+#: static/js/zamboni/devhub_search.js:8
+msgid "No results found."
+msgstr "Nenhum resultado encontrado."
+
+#: static/js/zamboni/editors-all.js:15402 static/js/zamboni/editors-min.js:4 static/js/zamboni/editors.js:121
+msgid "{name} was viewing this page first."
+msgstr "{name} estava a ver esta página primeiro."
+
+#: static/js/zamboni/editors-all.js:15452 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:171
+msgid "Receipt checked by app."
+msgstr "Recibo verificado pela aplicação."
+
+#: static/js/zamboni/editors-all.js:15454 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:173
+msgid "Receipt was not checked by app."
+msgstr "O recibo não foi verificado pela aplicação."
+
+#: static/js/zamboni/editors-all.js:15525 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:244
+msgid "{name} was viewing this add-on first."
+msgstr "{name} estava a ver primeiro este extra."
+
+#: static/js/zamboni/editors-all.js:15536 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:255
+msgid "Loading&hellip;"
+msgstr "A carregar"
+
+#: static/js/zamboni/editors-all.js:15541 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:260
+msgid "Version Notes"
+msgstr "Notas da versão"
+
+#: static/js/zamboni/editors-all.js:15546 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:265
+msgid "Notes for Reviewers"
+msgstr "Notas para os revisores"
+
+#: static/js/zamboni/editors-all.js:15551 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:270
+msgid "No version notes found"
+msgstr "Nenhumas notas de versão encontradas"
+
+#: static/js/zamboni/editors-all.js:15611 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:330
+msgid "Average Reviews"
+msgstr "Pontuação média"
+
+#: static/js/zamboni/editors-all.js:15667 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:386
+msgid "Number of Reviews"
+msgstr "Número de análises"
+
+#: static/js/zamboni/editors-all.js:15726 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:445
+msgid "Error loading translation"
+msgstr "Erro ao carregar a tradução"
+
+#: static/js/zamboni/editors-all.js:15975 static/js/zamboni/editors-min.js:5 static/js/zamboni/themes_review_templates.js:31
+msgid "Theme"
+msgstr "Tema"
+
+#: static/js/zamboni/editors-all.js:15977 static/js/zamboni/editors-min.js:5 static/js/zamboni/themes_review_templates.js:33
+msgid "Reviewer"
+msgstr "Revisor"
+
+#: static/js/zamboni/editors-all.js:15979 static/js/zamboni/editors-min.js:5 static/js/zamboni/themes_review_templates.js:35
+msgid "Status"
+msgstr "Estado"
+
+#: static/js/zamboni/editors-all.js:16196 static/js/zamboni/editors-min.js:5 static/js/zamboni/themes_review.js:176
+msgid "Requested Info"
+msgstr "Solicitadas mais informações"
+
+#: static/js/zamboni/editors-all.js:16197 static/js/zamboni/editors-min.js:5 static/js/zamboni/themes_review.js:177
+msgid "Flagged"
+msgstr "Marcado"
+
+#: static/js/zamboni/editors-all.js:16198 static/js/zamboni/editors-min.js:5 static/js/zamboni/themes_review.js:178
+msgid "Duplicate"
+msgstr "Duplicado"
+
+#: static/js/zamboni/editors-all.js:16199 static/js/zamboni/editors-min.js:5 static/js/zamboni/themes_review.js:179
+msgid "Rejected"
+msgstr "Rejeitado"
+
+#: static/js/zamboni/editors-all.js:16200 static/js/zamboni/editors-min.js:5 static/js/zamboni/themes_review.js:180
+msgid "Approved"
+msgstr "Aprovado"
+
+#: static/js/zamboni/editors-all.js:16444 static/js/zamboni/editors-min.js:5 static/js/zamboni/themes_review.js:424
+msgid "No results found"
+msgstr "Não foram encontrados resultados"
+
+#: static/js/zamboni/mobile-all.js:15186 static/js/zamboni/mobile/buttons.js:52
 msgid "Not Updated for {0} {1}"
 msgstr "Não atualizado para {0} {1}"
 
-#: static/js/zamboni/mobile/buttons.js:53
+#: static/js/zamboni/mobile-all.js:15187 static/js/zamboni/mobile/buttons.js:53
 msgid "Requires Newer Version of {0}"
 msgstr "Necessita da versão mais recente do {0}"
 
-#: static/js/zamboni/mobile/buttons.js:54
+#: static/js/zamboni/mobile-all.js:15188 static/js/zamboni/mobile/buttons.js:54
 msgid "Unreviewed"
 msgstr "Não revisto"
 
-#: static/js/zamboni/mobile/buttons.js:55
+#: static/js/zamboni/mobile-all.js:15189 static/js/zamboni/mobile/buttons.js:55
 msgid "Experimental <span>(Learn More)</span>"
 msgstr "Experimental <span>(Saber mais)</span>"
 
-#: static/js/zamboni/mobile/buttons.js:56
-#: static/js/zamboni/mobile/buttons.js:57
+#: static/js/zamboni/mobile-all.js:15190 static/js/zamboni/mobile-all.js:15191 static/js/zamboni/mobile/buttons.js:56 static/js/zamboni/mobile/buttons.js:57
 msgid "Not Available for {0}"
 msgstr "Não disponível para {0}"
 
-#: static/js/zamboni/mobile/buttons.js:58
+#: static/js/zamboni/mobile-all.js:15192 static/js/zamboni/mobile/buttons.js:58
 msgid "Experimental"
 msgstr "Experimental"
 
-#: static/js/zamboni/mobile/buttons.js:59
+#: static/js/zamboni/mobile-all.js:15193 static/js/zamboni/mobile/buttons.js:59
 msgid "Themes Require Newer Version of {0}"
 msgstr "Os temas requerem uma versão mais recente do {0}"
 
-#: static/js/zamboni/mobile/buttons.js:60
+#: static/js/zamboni/mobile-all.js:15194 static/js/zamboni/mobile/buttons.js:60
 msgid "Themes Require {0}"
 msgstr "Os temas requerem {0}"
 
-#: static/js/zamboni/mobile/buttons.js:105
+#: static/js/zamboni/mobile-all.js:15239 static/js/zamboni/mobile/buttons.js:105
 msgid "Installing..."
 msgstr "A instalar..."
 
-#: static/js/zamboni/mobile/buttons.js:125
+#: static/js/zamboni/mobile-all.js:15259 static/js/zamboni/mobile/buttons.js:125
 msgid "This add-on has been preliminarily reviewed by Mozilla."
 msgstr "Este extra foi revisto preliminarmente pela Mozilla."
 
-#: static/js/zamboni/mobile/buttons.js:250
+#: static/js/zamboni/mobile-all.js:15384 static/js/zamboni/mobile/buttons.js:250
 msgid "Keep it"
 msgstr "Manter"
 
-#: static/js/zamboni/mobile/general.js:344
+#: static/js/zamboni/mobile-all.js:16049 static/js/zamboni/mobile-min.js:6 static/js/zamboni/mobile/general.js:344
 msgid "You're trying it on!"
 msgstr "Você está a experimentá-lo!"
 
-#: static/js/zamboni/mobile/general.js:356
+#: static/js/zamboni/mobile-all.js:16061 static/js/zamboni/mobile-min.js:6 static/js/zamboni/mobile/general.js:356
 msgid "Added to Firefox"
 msgstr "Adicionado ao Firefox"

--- a/locale/ro/LC_MESSAGES/django.po
+++ b/locale/ro/LC_MESSAGES/django.po
@@ -3,69 +3,70 @@ msgid ""
 msgstr ""
 "Project-Id-Version:  addons.mozilla.org\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2016-02-24 21:23+0000\n"
+"POT-Creation-Date: 2016-04-18 15:47+0000\n"
 "PO-Revision-Date: 2015-08-30 16:32+0000\n"
 "Last-Translator: Cristian Silaghi <cristian.silaghi@mozilla.ro>\n"
 "Language-Team: Romanian <LL@li.org>\n"
+"Language: ro\n"
 "MIME-Version: 1.0\n"
-"Content-Type: text/plain; charset=utf-8\n"
+"Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Generated-By: Babel 2.2.0\n"
 
-#: src/olympia/accounts/views.py:52
+#: src/olympia/accounts/views.py:54
 msgid "Your log in attempt could not be parsed. Please try again."
 msgstr ""
 
-#: src/olympia/accounts/views.py:54
+#: src/olympia/accounts/views.py:56
 msgid "Your Firefox Account could not be found. Please try again."
 msgstr ""
 
-#: src/olympia/accounts/views.py:55
+#: src/olympia/accounts/views.py:57
 msgid "You could not be logged in. Please try again."
 msgstr ""
 
-#: src/olympia/accounts/views.py:57
+#: src/olympia/accounts/views.py:59
 msgid "Your account has already been migrated to Firefox Accounts."
 msgstr ""
 
-#: src/olympia/accounts/views.py:59
+#: src/olympia/accounts/views.py:61
 msgid "Your Firefox Account already exists on this site."
 msgstr ""
 
-#: src/olympia/accounts/views.py:108
+#: src/olympia/accounts/views.py:110
 msgid "Great job!"
 msgstr ""
 
-#: src/olympia/accounts/views.py:109
+#: src/olympia/accounts/views.py:111
 msgid "You can now log in to Add-ons with your Firefox Account."
 msgstr ""
 
-#: src/olympia/accounts/views.py:121
+#: src/olympia/accounts/views.py:123
 msgid "Need help?"
 msgstr ""
 
-#: src/olympia/addons/buttons.py:180
+#: src/olympia/addons/buttons.py:177
 msgid "Download Now"
 msgstr ""
 
-#: src/olympia/addons/buttons.py:182
+#: src/olympia/addons/buttons.py:179
 msgid "Download"
 msgstr ""
 
 #. L10n: please keep &nbsp; in the string so &rarr; does not wrap.
-#: src/olympia/addons/buttons.py:186
+#: src/olympia/addons/buttons.py:183
 msgid "Continue to Download&nbsp;&rarr;"
 msgstr ""
 
-#: src/olympia/addons/buttons.py:202 src/olympia/addons/helpers.py:35 src/olympia/addons/views.py:319 src/olympia/addons/templates/addons/impala/details.html:114
+#: src/olympia/addons/buttons.py:199 src/olympia/addons/helpers.py:35 src/olympia/addons/views.py:333 src/olympia/addons/templates/addons/impala/details.html:111
 #: src/olympia/addons/templates/addons/impala/listing/items.html:17 src/olympia/addons/templates/addons/mobile/home.html:40 src/olympia/amo/templates/amo/side_nav.html:6
-#: src/olympia/amo/templates/amo/side_nav.html:10 src/olympia/amo/templates/amo/site_nav.html:2 src/olympia/amo/templates/amo/site_nav.html:55 src/olympia/bandwagon/views.py:95
-#: src/olympia/browse/views.py:54 src/olympia/browse/views.py:68 src/olympia/browse/views.py:235 src/olympia/browse/templates/browse/impala/category_landing.html:22
+#: src/olympia/amo/templates/amo/side_nav.html:10 src/olympia/amo/templates/amo/site_nav.html:2 src/olympia/amo/templates/amo/site_nav.html:53 src/olympia/bandwagon/views.py:95
+#: src/olympia/browse/views.py:54 src/olympia/browse/views.py:68 src/olympia/browse/views.py:202 src/olympia/browse/templates/browse/impala/category_landing.html:22
 #: src/olympia/browse/templates/browse/personas/mobile/category_landing.html:26
 msgid "Featured"
 msgstr ""
 
-#: src/olympia/addons/buttons.py:221
+#: src/olympia/addons/buttons.py:218
 msgid "Add to {0}"
 msgstr ""
 
@@ -88,7 +89,6 @@ msgid "Invalid tag: {0}"
 msgid_plural "Invalid tags: {0}"
 msgstr[0] ""
 msgstr[1] ""
-msgstr[2] ""
 
 #. L10n: {0} is a single tag or a comma-separated list of tags.
 #: src/olympia/addons/forms.py:103
@@ -96,14 +96,12 @@ msgid "\"{0}\" is a reserved tag and cannot be used."
 msgid_plural "\"{0}\" are reserved tags and cannot be used."
 msgstr[0] ""
 msgstr[1] ""
-msgstr[2] ""
 
 #: src/olympia/addons/forms.py:111
 msgid "You have {0} too many tags."
 msgid_plural "You have {0} too many tags."
 msgstr[0] ""
 msgstr[1] ""
-msgstr[2] ""
 
 #: src/olympia/addons/forms.py:117
 #, python-format
@@ -115,42 +113,40 @@ msgid "All tags must be at least {0} character."
 msgid_plural "All tags must be at least {0} characters."
 msgstr[0] ""
 msgstr[1] ""
-msgstr[2] ""
 
-#: src/olympia/addons/forms.py:234
+#: src/olympia/addons/forms.py:238
 msgid "Categories cannot be changed while your add-on is featured for this application."
 msgstr ""
 
 #. L10n: {0} is the number of categories.
-#: src/olympia/addons/forms.py:238
+#: src/olympia/addons/forms.py:242
 msgid "You can have only {0} category."
 msgid_plural "You can have only {0} categories."
 msgstr[0] ""
 msgstr[1] ""
-msgstr[2] ""
 
-#: src/olympia/addons/forms.py:246
+#: src/olympia/addons/forms.py:250
 msgid "The miscellaneous category cannot be combined with additional categories."
 msgstr ""
 
-#: src/olympia/addons/forms.py:369
+#: src/olympia/addons/forms.py:374
 #, python-format
 msgid "Before changing your default locale you must have a name, summary, and description in that locale. You are missing %s."
 msgstr ""
 
-#: src/olympia/addons/forms.py:484 src/olympia/addons/forms.py:575
+#: src/olympia/addons/forms.py:455 src/olympia/addons/forms.py:546
 msgid "A license must be selected."
 msgstr ""
 
-#: src/olympia/addons/forms.py:556
+#: src/olympia/addons/forms.py:527
 msgid "Give Your Theme a Name."
 msgstr ""
 
-#: src/olympia/addons/forms.py:562 src/olympia/devhub/templates/devhub/personas/submit.html:53
+#: src/olympia/addons/forms.py:533 src/olympia/devhub/templates/devhub/personas/submit.html:53
 msgid "Describe your Theme."
 msgstr ""
 
-#: src/olympia/addons/forms.py:704
+#: src/olympia/addons/forms.py:675
 msgid "Enter a new author's email address"
 msgstr ""
 
@@ -158,40 +154,40 @@ msgstr ""
 msgid "Not Reviewed"
 msgstr ""
 
-#: src/olympia/addons/models.py:301
+#: src/olympia/addons/models.py:298
 #, fuzzy
 msgid "Users have the option of contributing more or less than this amount."
 msgstr "Users have the option of contributing more or less than this amount."
 
-#: src/olympia/addons/models.py:309
-msgid "Users will always be asked in the Add-ons Manager (Firefox 4 and above)"
+#: src/olympia/addons/models.py:306
+msgid "Users will always be asked in the Add-ons Manager (Firefox 4 and above). Only applies to desktop."
 msgstr ""
 
-#: src/olympia/addons/models.py:1804 src/olympia/addons/templates/addons/details_box.html:55 src/olympia/devhub/templates/devhub/index.html:92
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:102
+#: src/olympia/addons/models.py:1802 src/olympia/addons/templates/addons/details_box.html:55 src/olympia/devhub/templates/devhub/index.html:92
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:89
 msgid "Listed"
 msgstr ""
 
-#: src/olympia/addons/views.py:320 src/olympia/browse/templates/browse/personas/mobile/category_landing.html:27
+#: src/olympia/addons/views.py:334 src/olympia/browse/templates/browse/personas/mobile/category_landing.html:27
 msgid "Popular"
 msgstr ""
 
-#: src/olympia/addons/views.py:321 src/olympia/browse/views.py:238 src/olympia/browse/views.py:280 src/olympia/browse/views.py:482
+#: src/olympia/addons/views.py:335 src/olympia/browse/views.py:205 src/olympia/browse/views.py:247 src/olympia/browse/views.py:449
 msgid "Recently Added"
 msgstr ""
 
-#: src/olympia/addons/views.py:322 src/olympia/bandwagon/views.py:99 src/olympia/browse/views.py:60 src/olympia/browse/views.py:71 src/olympia/search/forms.py:16 src/olympia/search/forms.py:91
+#: src/olympia/addons/views.py:336 src/olympia/bandwagon/views.py:99 src/olympia/browse/views.py:60 src/olympia/browse/views.py:71 src/olympia/search/forms.py:16 src/olympia/search/forms.py:91
 msgid "Recently Updated"
 msgstr ""
 
 # %1 is an add-on name.
 #. l10n: {0} is the addon name
-#: src/olympia/addons/views.py:520
+#: src/olympia/addons/views.py:534
 #, fuzzy
 msgid "Contribution for {0}"
 msgstr "Contribution for {0}"
 
-#: src/olympia/addons/views.py:613
+#: src/olympia/addons/views.py:627
 msgid "Abuse reported."
 msgstr ""
 
@@ -263,9 +259,9 @@ msgstr "Contribute"
 #: src/olympia/devhub/templates/devhub/addons/ajax_compat_update.html:36 src/olympia/devhub/templates/devhub/addons/profile.html:44 src/olympia/devhub/templates/devhub/addons/edit/admin.html:101
 #: src/olympia/devhub/templates/devhub/addons/edit/basic.html:152 src/olympia/devhub/templates/devhub/addons/edit/details.html:85 src/olympia/devhub/templates/devhub/addons/edit/support.html:67
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:166 src/olympia/devhub/templates/devhub/addons/forms_shared/media.html:149
-#: src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:44 src/olympia/devhub/templates/devhub/versions/add_file_modal.html:78 src/olympia/devhub/templates/devhub/versions/edit.html:139
-#: src/olympia/devhub/templates/devhub/versions/list.html:242 src/olympia/devhub/templates/devhub/versions/list.html:276 src/olympia/devhub/templates/devhub/versions/list.html:317
-#: src/olympia/devhub/templates/devhub/versions/list.html:351 src/olympia/reviews/templates/reviews/edit_review.html:16 src/olympia/translations/templates/translations/trans-menu.html:50
+#: src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:43 src/olympia/devhub/templates/devhub/versions/add_file_modal.html:58 src/olympia/devhub/templates/devhub/versions/edit.html:139
+#: src/olympia/devhub/templates/devhub/versions/list.html:239 src/olympia/devhub/templates/devhub/versions/list.html:281 src/olympia/devhub/templates/devhub/versions/list.html:315
+#: src/olympia/devhub/templates/devhub/versions/list.html:349 src/olympia/reviews/templates/reviews/edit_review.html:16 src/olympia/translations/templates/translations/trans-menu.html:50
 #: src/olympia/translations/templates/translations/trans-menu.html:62
 #, fuzzy
 msgid "or"
@@ -378,7 +374,7 @@ msgid "Add-on Information for {0}"
 msgstr ""
 
 #: src/olympia/addons/templates/addons/details_box.html:30 src/olympia/addons/templates/addons/persona_detail_table.html:3 src/olympia/addons/templates/addons/mobile/details.html:63
-#: src/olympia/addons/templates/addons/mobile/persona_detail_table.html:7 src/olympia/browse/views.py:459 src/olympia/devhub/views.py:75
+#: src/olympia/addons/templates/addons/mobile/persona_detail_table.html:7 src/olympia/browse/views.py:426 src/olympia/devhub/views.py:73
 msgid "Updated"
 msgstr "Actualizat"
 
@@ -398,11 +394,11 @@ msgstr "Works with"
 msgid "Visibility"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/details_box.html:57 src/olympia/devhub/templates/devhub/index.html:94 src/olympia/devhub/templates/devhub/includes/addon_details.html:104
+#: src/olympia/addons/templates/addons/details_box.html:57 src/olympia/devhub/templates/devhub/index.html:94 src/olympia/devhub/templates/devhub/includes/addon_details.html:91
 msgid "Hidden"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/details_box.html:59 src/olympia/devhub/templates/devhub/index.html:96 src/olympia/devhub/templates/devhub/includes/addon_details.html:106
+#: src/olympia/addons/templates/addons/details_box.html:59 src/olympia/devhub/templates/devhub/index.html:96 src/olympia/devhub/templates/devhub/includes/addon_details.html:93
 msgid "Unlisted"
 msgstr ""
 
@@ -410,13 +406,13 @@ msgstr ""
 msgid "Required Add-ons"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/details_box.html:81 src/olympia/addons/templates/addons/persona_detail_table.html:15 src/olympia/browse/views.py:462 src/olympia/devhub/views.py:78
-#: src/olympia/devhub/views.py:85 src/olympia/discovery/templates/discovery/addons/detail.html:57 src/olympia/reviews/forms.py:62 src/olympia/reviews/templates/reviews/add.html:57
+#: src/olympia/addons/templates/addons/details_box.html:81 src/olympia/addons/templates/addons/persona_detail_table.html:15 src/olympia/browse/views.py:429 src/olympia/devhub/views.py:76
+#: src/olympia/devhub/views.py:83 src/olympia/discovery/templates/discovery/addons/detail.html:57 src/olympia/reviews/forms.py:62 src/olympia/reviews/templates/reviews/add.html:57
 #: src/olympia/reviews/templates/reviews/mobile/review_list.html:18
 msgid "Rating"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/details_box.html:85 src/olympia/browse/views.py:461 src/olympia/devhub/views.py:77 src/olympia/devhub/views.py:84
+#: src/olympia/addons/templates/addons/details_box.html:85 src/olympia/browse/views.py:428 src/olympia/devhub/views.py:75 src/olympia/devhub/views.py:82
 #: src/olympia/stats/templates/stats/addon_report_menu.html:8 src/olympia/stats/templates/stats/collection_report_menu.html:18
 msgid "Downloads"
 msgstr ""
@@ -436,7 +432,7 @@ msgstr ""
 
 #. The Privacy Policy for this add-on.
 #: src/olympia/addons/templates/addons/details_box.html:121 src/olympia/addons/templates/addons/privacy.html:19 src/olympia/addons/templates/addons/privacy.html:23
-#: src/olympia/addons/templates/addons/impala/button.html:43 src/olympia/addons/templates/addons/impala/details.html:307 src/olympia/devhub/templates/devhub/includes/policy_form.html:20
+#: src/olympia/addons/templates/addons/impala/button.html:43 src/olympia/addons/templates/addons/impala/details.html:312 src/olympia/devhub/templates/devhub/includes/policy_form.html:23
 #: src/olympia/templates/mobile/base_addons.html:87
 msgid "Privacy Policy"
 msgstr ""
@@ -463,7 +459,7 @@ msgstr "Image Gallery"
 msgid "Developer Comments"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/details_box.html:199 src/olympia/addons/templates/addons/impala/details.html:259
+#: src/olympia/addons/templates/addons/details_box.html:199 src/olympia/addons/templates/addons/impala/details.html:264
 msgid "Development Channel"
 msgstr ""
 
@@ -483,7 +479,7 @@ msgid ""
 "developer. To stop receiving development updates, reinstall the default version from the link above."
 msgstr ""
 
-#: src/olympia/addons/templates/addons/details_box.html:220 src/olympia/addons/templates/addons/impala/details.html:278
+#: src/olympia/addons/templates/addons/details_box.html:220 src/olympia/addons/templates/addons/impala/details.html:283
 msgid "Version {0}:"
 msgstr ""
 
@@ -502,7 +498,7 @@ msgid "End-User License Agreement for {0}"
 msgstr ""
 
 #: src/olympia/addons/templates/addons/eula.html:17 src/olympia/addons/templates/addons/eula.html:21 src/olympia/addons/templates/addons/impala/button.html:48
-#: src/olympia/addons/templates/addons/impala/details.html:316 src/olympia/devhub/templates/devhub/includes/policy_form.html:3 src/olympia/discovery/templates/discovery/addons/eula.html:11
+#: src/olympia/addons/templates/addons/impala/details.html:321 src/olympia/devhub/templates/devhub/includes/policy_form.html:3 src/olympia/discovery/templates/discovery/addons/eula.html:11
 msgid "End-User License Agreement"
 msgstr "Acord de licențiere cu utilizatorul"
 
@@ -522,7 +518,7 @@ msgstr ""
 msgid "Add-ons for {0}"
 msgstr "Suplimente {0}"
 
-#: src/olympia/addons/templates/addons/home.html:10 src/olympia/addons/templates/addons/home.html:51 src/olympia/browse/templates/browse/impala/base_listing.html:11
+#: src/olympia/addons/templates/addons/home.html:10 src/olympia/addons/templates/addons/home.html:53 src/olympia/browse/templates/browse/impala/base_listing.html:11
 msgid "Featured Extensions"
 msgstr ""
 
@@ -530,29 +526,29 @@ msgstr ""
 msgid "Popular Extensions"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/home.html:42 src/olympia/amo/templates/amo/side_nav.html:3 src/olympia/amo/templates/amo/side_nav.html:11 src/olympia/amo/templates/amo/site_nav.html:3
-#: src/olympia/amo/templates/amo/site_nav.html:25 src/olympia/browse/views.py:236 src/olympia/browse/views.py:281 src/olympia/browse/views.py:481
+#: src/olympia/addons/templates/addons/home.html:44 src/olympia/amo/templates/amo/side_nav.html:3 src/olympia/amo/templates/amo/side_nav.html:11 src/olympia/amo/templates/amo/site_nav.html:3
+#: src/olympia/amo/templates/amo/site_nav.html:25 src/olympia/browse/views.py:203 src/olympia/browse/views.py:248 src/olympia/browse/views.py:448
 msgid "Most Popular"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/home.html:43
+#: src/olympia/addons/templates/addons/home.html:45
 msgid "All »"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/home.html:52 src/olympia/addons/templates/addons/home.html:61 src/olympia/addons/templates/addons/home.html:70 src/olympia/addons/templates/addons/home.html:78
+#: src/olympia/addons/templates/addons/home.html:54 src/olympia/addons/templates/addons/home.html:63 src/olympia/addons/templates/addons/home.html:72 src/olympia/addons/templates/addons/home.html:80
 #: src/olympia/browse/templates/browse/impala/category_landing.html:36
 msgid "See all »"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/home.html:60
+#: src/olympia/addons/templates/addons/home.html:62
 msgid "Up &amp; Coming Extensions"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/home.html:69 src/olympia/browse/templates/browse/personas/category_landing.html:61 src/olympia/discovery/templates/discovery/pane.html:74
+#: src/olympia/addons/templates/addons/home.html:71 src/olympia/browse/templates/browse/personas/category_landing.html:61 src/olympia/discovery/templates/discovery/pane.html:74
 msgid "Featured Themes"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/home.html:77 src/olympia/bandwagon/templates/bandwagon/impala/collection_listing.html:5
+#: src/olympia/addons/templates/addons/home.html:79 src/olympia/bandwagon/templates/bandwagon/impala/collection_listing.html:5
 msgid "Featured Collections"
 msgstr ""
 
@@ -570,7 +566,7 @@ msgid "Updated {0}"
 msgstr ""
 
 #. {0} is a date.
-#: src/olympia/addons/templates/addons/macros.html:10 src/olympia/addons/templates/addons/macros.html:69 src/olympia/addons/templates/addons/persona_preview.html:21
+#: src/olympia/addons/templates/addons/macros.html:10 src/olympia/addons/templates/addons/macros.html:69 src/olympia/addons/templates/addons/persona_preview.html:22
 #: src/olympia/addons/templates/addons/listing/items_mobile.html:44 src/olympia/addons/templates/addons/listing/macros.html:39
 #: src/olympia/bandwagon/templates/bandwagon/collection_listing_items.html:37 src/olympia/bandwagon/templates/bandwagon/impala/collection_listing_items.html:37
 msgid "Added {0}"
@@ -582,7 +578,6 @@ msgid "%(num)s weekly download"
 msgid_plural "%(num)s weekly downloads"
 msgstr[0] ""
 msgstr[1] ""
-msgstr[2] ""
 
 #: src/olympia/addons/templates/addons/macros.html:28
 #, python-format
@@ -590,24 +585,20 @@ msgid "%(num)s user"
 msgid_plural "%(num)s users"
 msgstr[0] ""
 msgstr[1] ""
-msgstr[2] ""
 
 #. {0} is the number of downloads.
-#: src/olympia/addons/templates/addons/macros.html:53 src/olympia/addons/templates/addons/impala/details.html:61
+#: src/olympia/addons/templates/addons/macros.html:53 src/olympia/addons/templates/addons/impala/details.html:59
 msgid "{0} weekly download"
 msgid_plural "{0} weekly downloads"
 msgstr[0] ""
 msgstr[1] ""
-msgstr[2] ""
 
 #. {0} is the number of users.
-#: src/olympia/addons/templates/addons/macros.html:61 src/olympia/addons/templates/addons/impala/details.html:54 src/olympia/compat/templates/compat/index.html:71
-#: src/olympia/zadmin/templates/zadmin/compat.html:67
+#: src/olympia/addons/templates/addons/macros.html:61 src/olympia/addons/templates/addons/impala/details.html:52 src/olympia/zadmin/templates/zadmin/compat.html:67
 msgid "{0} user"
 msgid_plural "{0} users"
 msgstr[0] ""
 msgstr[1] ""
-msgstr[2] ""
 
 #: src/olympia/addons/templates/addons/paypal_result.html:12
 msgid "Payment cancelled"
@@ -621,7 +612,7 @@ msgstr ""
 msgid "Return to the addon."
 msgstr ""
 
-#: src/olympia/addons/templates/addons/persona_detail.html:17 src/olympia/addons/templates/addons/impala/details.html:106 src/olympia/addons/templates/addons/mobile/details.html:23
+#: src/olympia/addons/templates/addons/persona_detail.html:17 src/olympia/addons/templates/addons/impala/details.html:103 src/olympia/addons/templates/addons/mobile/details.html:23
 #: src/olympia/addons/templates/addons/mobile/persona_detail.html:21 src/olympia/discovery/templates/discovery/addons/base.html:27 src/olympia/editors/templates/editors/review.html:31
 msgid "by"
 msgstr "de"
@@ -665,35 +656,35 @@ msgstr ""
 msgid "License"
 msgstr "Licență"
 
-#: src/olympia/addons/templates/addons/persona_preview.html:12 src/olympia/constants/base.py:48
+#: src/olympia/addons/templates/addons/persona_preview.html:13 src/olympia/constants/base.py:48
 msgid "Awaiting Review"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/persona_preview.html:14 src/olympia/amo/log.py:180 src/olympia/constants/base.py:42 src/olympia/editors/helpers.py:62
+#: src/olympia/addons/templates/addons/persona_preview.html:15 src/olympia/amo/log.py:180 src/olympia/constants/base.py:42 src/olympia/editors/helpers.py:62
 msgid "Rejected"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/persona_preview.html:16 src/olympia/amo/log.py:159
+#: src/olympia/addons/templates/addons/persona_preview.html:17 src/olympia/amo/log.py:159
 msgid "Approved"
 msgstr ""
 
 #. {0} is the number of users.
-#: src/olympia/addons/templates/addons/persona_preview.html:26 src/olympia/addons/templates/addons/listing/items_mobile.html:36 src/olympia/addons/templates/addons/listing/macros.html:31
+#: src/olympia/addons/templates/addons/persona_preview.html:27 src/olympia/addons/templates/addons/listing/items_mobile.html:36 src/olympia/addons/templates/addons/listing/macros.html:31
 msgid "<strong>{0}</strong> user"
 msgid_plural "<strong>{0}</strong> users"
 msgstr[0] ""
 msgstr[1] ""
-msgstr[2] ""
 
-#: src/olympia/addons/templates/addons/persona_preview.html:40
+#: src/olympia/addons/templates/addons/persona_preview.html:41
 msgid "Hover to Preview"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/persona_preview.html:46 src/olympia/addons/templates/addons/persona_preview.html:48 src/olympia/reviews/templates/reviews/add.html:15
+#: src/olympia/addons/templates/addons/persona_preview.html:47 src/olympia/addons/templates/addons/persona_preview.html:49 src/olympia/addons/templates/addons/persona_preview.html:97
+#: src/olympia/reviews/templates/reviews/add.html:15
 msgid "Add"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/persona_preview.html:57 src/olympia/bandwagon/templates/bandwagon/ajax_new.html:16 src/olympia/bandwagon/templates/bandwagon/edit.html:19
+#: src/olympia/addons/templates/addons/persona_preview.html:58 src/olympia/bandwagon/templates/bandwagon/ajax_new.html:16 src/olympia/bandwagon/templates/bandwagon/edit.html:19
 #: src/olympia/bandwagon/templates/bandwagon/includes/addedit.html:19 src/olympia/devhub/templates/devhub/addons/edit/admin.html:13 src/olympia/devhub/templates/devhub/addons/edit/basic.html:10
 #: src/olympia/devhub/templates/devhub/addons/edit/details.html:8 src/olympia/devhub/templates/devhub/addons/edit/media.html:6 src/olympia/devhub/templates/devhub/addons/edit/support.html:8
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:9 src/olympia/devhub/templates/devhub/addons/submit/describe.html:29 src/olympia/editors/templates/editors/review.html:257
@@ -702,21 +693,21 @@ msgstr ""
 
 #. For datetime formatting, see the table on
 #. http://docs.python.org/library/datetime.html#strftime-and-strptime-behavior
-#: src/olympia/addons/templates/addons/persona_preview.html:66
+#: src/olympia/addons/templates/addons/persona_preview.html:67
 #, python-format
 msgid "%%Y-%%m-%%d"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/persona_preview.html:67
+#: src/olympia/addons/templates/addons/persona_preview.html:68
 msgid "by {0} on {1}"
 msgstr "de {0} în {1}"
 
-#: src/olympia/addons/templates/addons/persona_preview.html:75 src/olympia/reviews/helpers.py:17 src/olympia/reviews/templates/reviews/review_list.html:63
+#: src/olympia/addons/templates/addons/persona_preview.html:76 src/olympia/reviews/helpers.py:17 src/olympia/reviews/templates/reviews/review_list.html:63
 #: src/olympia/reviews/templates/reviews/reviews_link.html:21 src/olympia/reviews/templates/reviews/impala/reviews_link.html:16
 msgid "Not yet rated"
 msgstr "Neevaluat încă"
 
-#: src/olympia/addons/templates/addons/persona_preview.html:78
+#: src/olympia/addons/templates/addons/persona_preview.html:79
 msgid "<b>{0}</b> users"
 msgstr ""
 
@@ -729,7 +720,7 @@ msgid "Learn more about Firefox"
 msgstr ""
 
 #: src/olympia/addons/templates/addons/popups.html:22
-msgid "or <b><a class=\"installer\" href=\"{url}\">download anyway</a></b>"
+msgid "or <b><a class=\"button installer\" href=\"{url}\">download anyway</a></b>"
 msgstr ""
 
 #: src/olympia/addons/templates/addons/popups.html:26
@@ -828,7 +819,7 @@ msgid ""
 msgstr ""
 
 #: src/olympia/addons/templates/addons/report_abuse.html:6 src/olympia/addons/templates/addons/report_abuse_full.html:10 src/olympia/addons/templates/addons/impala/details-more.html:23
-#: src/olympia/addons/templates/addons/impala/details.html:328
+#: src/olympia/addons/templates/addons/impala/details.html:333
 msgid "Report Abuse"
 msgstr ""
 
@@ -847,9 +838,9 @@ msgstr ""
 #: src/olympia/devhub/templates/devhub/addons/ajax_compat_update.html:36 src/olympia/devhub/templates/devhub/addons/profile.html:44 src/olympia/devhub/templates/devhub/addons/edit/admin.html:104
 #: src/olympia/devhub/templates/devhub/addons/edit/basic.html:155 src/olympia/devhub/templates/devhub/addons/edit/details.html:88 src/olympia/devhub/templates/devhub/addons/edit/support.html:70
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:169 src/olympia/devhub/templates/devhub/addons/forms_shared/media.html:152
-#: src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:44 src/olympia/devhub/templates/devhub/personas/edit.html:222 src/olympia/devhub/templates/devhub/versions/add_file_modal.html:79
-#: src/olympia/devhub/templates/devhub/versions/edit.html:140 src/olympia/devhub/templates/devhub/versions/list.html:208 src/olympia/devhub/templates/devhub/versions/list.html:242
-#: src/olympia/devhub/templates/devhub/versions/list.html:276 src/olympia/devhub/templates/devhub/versions/list.html:317 src/olympia/reviews/templates/reviews/edit_review.html:16
+#: src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:43 src/olympia/devhub/templates/devhub/personas/edit.html:222 src/olympia/devhub/templates/devhub/versions/add_file_modal.html:59
+#: src/olympia/devhub/templates/devhub/versions/edit.html:140 src/olympia/devhub/templates/devhub/versions/list.html:208 src/olympia/devhub/templates/devhub/versions/list.html:239
+#: src/olympia/devhub/templates/devhub/versions/list.html:281 src/olympia/devhub/templates/devhub/versions/list.html:315 src/olympia/reviews/templates/reviews/edit_review.html:16
 #: src/olympia/translations/templates/translations/trans-menu.html:50 src/olympia/translations/templates/translations/trans-menu.html:62 src/olympia/zadmin/templates/zadmin/validation.html:105
 msgid "Cancel"
 msgstr ""
@@ -894,7 +885,7 @@ msgstr ""
 msgid "Review Guidelines"
 msgstr "Ghid pentru recenzii"
 
-#: src/olympia/addons/templates/addons/review_list_box.html:5 src/olympia/addons/templates/addons/impala/details-more.html:27 src/olympia/editors/helpers.py:921
+#: src/olympia/addons/templates/addons/review_list_box.html:5 src/olympia/addons/templates/addons/impala/details-more.html:27 src/olympia/editors/helpers.py:1001
 #: src/olympia/reviews/templates/reviews/add.html:14 src/olympia/reviews/templates/reviews/reply.html:14 src/olympia/reviews/templates/reviews/review_list.html:19
 #: src/olympia/reviews/templates/reviews/mobile/review_list.html:26
 msgid "Reviews"
@@ -915,7 +906,6 @@ msgid "See all reviews of this add-on"
 msgid_plural "See all %(cnt)s reviews of this add-on"
 msgstr[0] ""
 msgstr[1] ""
-msgstr[2] ""
 
 #: src/olympia/addons/templates/addons/tags_box.html:3 src/olympia/devhub/templates/devhub/addons/edit/basic.html:118
 msgid "Tags"
@@ -985,125 +975,122 @@ msgid "Other add-ons by %(author)s"
 msgid_plural "Other add-ons by these authors"
 msgstr[0] ""
 msgstr[1] ""
-msgstr[2] ""
 
-#: src/olympia/addons/templates/addons/impala/details.html:41
+#: src/olympia/addons/templates/addons/impala/details.html:39
 #, python-format
 msgid "<span itemprop=\"ratingCount\">%(num)s</span> user review"
 msgid_plural "<span itemprop=\"ratingCount\">%(num)s</span> user reviews"
 msgstr[0] ""
 msgstr[1] ""
-msgstr[2] ""
 
-#: src/olympia/addons/templates/addons/impala/details.html:69
+#: src/olympia/addons/templates/addons/impala/details.html:66
 msgid "View statistics"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/impala/details.html:84
+#: src/olympia/addons/templates/addons/impala/details.html:81
 msgid "Manage"
 msgstr ""
 
 #. {0} is an add-on name.
-#: src/olympia/addons/templates/addons/impala/details.html:96
+#: src/olympia/addons/templates/addons/impala/details.html:93
 msgid "Icon of {0}"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/impala/details.html:103 src/olympia/addons/templates/addons/impala/listing/items.html:14
+#: src/olympia/addons/templates/addons/impala/details.html:100 src/olympia/addons/templates/addons/impala/listing/items.html:14
 msgid "No Restart"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/impala/details.html:127
+#: src/olympia/addons/templates/addons/impala/details.html:124
 #, python-format
 msgid "Meet the Developer: <a href=\"%(url)s\">%(name)s</a>"
 msgid_plural "<a href=\"%(url)s\">Meet the Developers</a>"
 msgstr[0] ""
 msgstr[1] ""
-msgstr[2] ""
 
 # {0} is an add-on name.
-#: src/olympia/addons/templates/addons/impala/details.html:137
+#: src/olympia/addons/templates/addons/impala/details.html:134
 #, fuzzy
 msgid "Learn why {0} was created and find out what's next for this add-on."
 msgstr "Learn why {0} was created and find out what's next for this add-on."
 
 #. {0} is an index.
-#: src/olympia/addons/templates/addons/impala/details.html:156
+#: src/olympia/addons/templates/addons/impala/details.html:161
 msgid "Add-on screenshot #{0}"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/impala/details.html:182
+#: src/olympia/addons/templates/addons/impala/details.html:187
 msgid "Add-on home page"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/impala/details.html:185
+#: src/olympia/addons/templates/addons/impala/details.html:190
 msgid "Support site"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/impala/details.html:189
+#: src/olympia/addons/templates/addons/impala/details.html:194
 msgid "Support E-mail"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/impala/details.html:194 src/olympia/devhub/models.py:378 src/olympia/devhub/templates/devhub/versions/list.html:12
+#: src/olympia/addons/templates/addons/impala/details.html:199 src/olympia/devhub/models.py:378 src/olympia/devhub/templates/devhub/versions/list.html:12
 #: src/olympia/versions/templates/versions/version.html:6 src/olympia/versions/templates/versions/mobile/version.html:6
 msgid "Version {0}"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/impala/details.html:194
+#: src/olympia/addons/templates/addons/impala/details.html:199
 msgid "Info"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/impala/details.html:195 src/olympia/devhub/templates/devhub/includes/addon_details.html:129
+#: src/olympia/addons/templates/addons/impala/details.html:200 src/olympia/devhub/templates/devhub/includes/addon_details.html:116
 msgid "Last Updated:"
-msgstr ""
-
-#: src/olympia/addons/templates/addons/impala/details.html:200
-#, python-format
-msgid "Released under <a target=\"_blank\" href=\"%(url)s\">%(name)s</a>"
-msgstr ""
-
-#: src/olympia/addons/templates/addons/impala/details.html:201 src/olympia/addons/templates/addons/impala/details.html:206 src/olympia/amo/helpers.py:398 src/olympia/devhub/forms.py:142
-#: src/olympia/devhub/forms.py:173 src/olympia/versions/templates/versions/version.html:40 src/olympia/versions/templates/versions/version.html:45
-msgid "Custom License"
 msgstr ""
 
 #: src/olympia/addons/templates/addons/impala/details.html:205
 #, python-format
+msgid "Released under <a target=\"_blank\" href=\"%(url)s\">%(name)s</a>"
+msgstr ""
+
+#: src/olympia/addons/templates/addons/impala/details.html:206 src/olympia/addons/templates/addons/impala/details.html:211 src/olympia/amo/helpers.py:398 src/olympia/devhub/forms.py:142
+#: src/olympia/devhub/forms.py:173 src/olympia/versions/templates/versions/version.html:40 src/olympia/versions/templates/versions/version.html:45
+msgid "Custom License"
+msgstr ""
+
+#: src/olympia/addons/templates/addons/impala/details.html:210
+#, python-format
 msgid "Released under <a href=\"%(url)s\">%(name)s</a>"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/impala/details.html:217
+#: src/olympia/addons/templates/addons/impala/details.html:222
 msgid "About this Add-on"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/impala/details.html:233
+#: src/olympia/addons/templates/addons/impala/details.html:238
 msgid "Developer’s Comments"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/impala/details.html:243
+#: src/olympia/addons/templates/addons/impala/details.html:248
 msgid "Version Information"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/impala/details.html:250
+#: src/olympia/addons/templates/addons/impala/details.html:255
 msgid "See complete version history"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/impala/details.html:262
+#: src/olympia/addons/templates/addons/impala/details.html:267
 msgid ""
 "The Development Channel lets you test an experimental new version of this add-on before it's released to the general public. Once you install the development version, you will continue to get "
 "updates from this channel. To stop receiving development updates, reinstall the default version from the link above."
 msgstr ""
 
-#: src/olympia/addons/templates/addons/impala/details.html:272
+#: src/olympia/addons/templates/addons/impala/details.html:277
 msgid "<strong>Caution:</strong> Development versions of this add-on have not been reviewed by Mozilla."
 msgstr ""
 
-#: src/olympia/addons/templates/addons/impala/details.html:287
+#: src/olympia/addons/templates/addons/impala/details.html:292
 msgid "See complete development channel history"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/impala/details.html:306 src/olympia/addons/templates/addons/impala/details.html:315 src/olympia/addons/templates/addons/impala/details.html:327
+#: src/olympia/addons/templates/addons/impala/details.html:311 src/olympia/addons/templates/addons/impala/details.html:320 src/olympia/addons/templates/addons/impala/details.html:332
 #: src/olympia/addons/templates/addons/impala/review_add_box.html:4 src/olympia/stats/templates/stats/popup.html:2 src/olympia/stats/templates/stats/popup.html:8
-#: src/olympia/stats/templates/stats/stats.html:202 src/olympia/users/templates/users/profile.html:119
+#: src/olympia/stats/templates/stats/stats.html:204 src/olympia/users/templates/users/profile.html:119
 msgid "close"
 msgstr ""
 
@@ -1141,7 +1128,6 @@ msgid "About the Developer"
 msgid_plural "About the Developers"
 msgstr[0] ""
 msgstr[1] ""
-msgstr[2] ""
 
 #: src/olympia/addons/templates/addons/impala/developers.html:96 src/olympia/users/templates/users/edit.html:130 src/olympia/users/templates/users/profile.html:26
 msgid "No Photo"
@@ -1167,15 +1153,11 @@ msgstr ""
 msgid "Source Code License"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/impala/persona_grid.html:16 src/olympia/addons/templates/addons/impala/toplist.html:6
-msgid "{0} users"
-msgstr ""
-
 #: src/olympia/addons/templates/addons/impala/review_list_box.html:19 src/olympia/reviews/templates/reviews/review.html:40
 msgid "permalink"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/impala/review_list_box.html:23 src/olympia/editors/templates/editors/queue.html:98 src/olympia/reviews/templates/reviews/review.html:44
+#: src/olympia/addons/templates/addons/impala/review_list_box.html:23 src/olympia/editors/templates/editors/queue.html:104 src/olympia/reviews/templates/reviews/review.html:44
 msgid "translate"
 msgstr ""
 
@@ -1185,7 +1167,6 @@ msgid "See all user reviews"
 msgid_plural "See all %(cnt)s user reviews"
 msgstr[0] ""
 msgstr[1] ""
-msgstr[2] ""
 
 #: src/olympia/addons/templates/addons/impala/review_list_box.html:47 src/olympia/reviews/templates/reviews/review_list.html:84
 msgid "This add-on has not yet been reviewed."
@@ -1193,6 +1174,10 @@ msgstr ""
 
 #: src/olympia/addons/templates/addons/impala/review_list_box.html:50
 msgid "Be the first!"
+msgstr ""
+
+#: src/olympia/addons/templates/addons/impala/toplist.html:6
+msgid "{0} users"
 msgstr ""
 
 #: src/olympia/addons/templates/addons/impala/listing/sorter.html:14 src/olympia/devhub/templates/devhub/addons/listing/item_actions.html:49
@@ -1207,7 +1192,7 @@ msgstr ""
 msgid "My Add-ons"
 msgstr "Suplimentele mele"
 
-#: src/olympia/addons/templates/addons/includes/dashboard_tabs.html:6 src/olympia/amo/context_processors.py:51
+#: src/olympia/addons/templates/addons/includes/dashboard_tabs.html:6 src/olympia/amo/context_processors.py:50
 msgid "My Themes"
 msgstr ""
 
@@ -1249,7 +1234,6 @@ msgid "<strong>{0}</strong> weekly download"
 msgid_plural "<strong>{0}</strong> weekly downloads"
 msgstr[0] ""
 msgstr[1] ""
-msgstr[2] ""
 
 #: src/olympia/addons/templates/addons/mobile/details.html:32
 msgid "Read More"
@@ -1263,7 +1247,7 @@ msgstr ""
 msgid "Weekly Downloads"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/mobile/details.html:99 src/olympia/compat/templates/compat/reporter_detail.html:46 src/olympia/devhub/forms.py:787
+#: src/olympia/addons/templates/addons/mobile/details.html:99 src/olympia/compat/templates/compat/reporter_detail.html:46 src/olympia/devhub/forms.py:788
 #: src/olympia/devhub/templates/devhub/versions/list.html:163
 msgid "Version"
 msgstr "Versiune"
@@ -1348,7 +1332,7 @@ msgstr ""
 #: src/olympia/browse/templates/browse/personas/category_landing.html:21 src/olympia/browse/templates/browse/personas/category_landing.html:23
 #: src/olympia/browse/templates/browse/personas/category_landing.html:38 src/olympia/browse/templates/browse/personas/grid.html:7 src/olympia/browse/templates/browse/personas/grid.html:11
 #: src/olympia/browse/templates/browse/personas/mobile/base.html:7 src/olympia/browse/templates/browse/personas/mobile/category_landing.html:19 src/olympia/constants/base.py:180
-#: src/olympia/devhub/templates/devhub/personas/submit.html:13 src/olympia/editors/helpers.py:105 src/olympia/editors/templates/editors/base.html:26
+#: src/olympia/devhub/templates/devhub/personas/submit.html:13 src/olympia/editors/helpers.py:107 src/olympia/editors/templates/editors/base.html:26
 #: src/olympia/editors/templates/editors/performance.html:73 src/olympia/search/templates/search/personas.html:39 src/olympia/templates/menu_links.html:9
 msgid "Themes"
 msgstr ""
@@ -1369,7 +1353,7 @@ msgstr ""
 msgid "Highest Rated"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/mobile/home.html:74 src/olympia/amo/templates/amo/side_nav.html:5 src/olympia/amo/templates/amo/site_nav.html:27 src/olympia/amo/templates/amo/site_nav.html:57
+#: src/olympia/addons/templates/addons/mobile/home.html:74 src/olympia/amo/templates/amo/side_nav.html:5 src/olympia/amo/templates/amo/site_nav.html:27 src/olympia/amo/templates/amo/site_nav.html:55
 #: src/olympia/bandwagon/views.py:97 src/olympia/browse/views.py:57 src/olympia/browse/views.py:67 src/olympia/browse/templates/browse/personas/mobile/category_landing.html:65
 #: src/olympia/search/forms.py:15 src/olympia/search/forms.py:87
 msgid "Newest"
@@ -1383,91 +1367,91 @@ msgstr ""
 msgid "Theme Info &raquo;"
 msgstr ""
 
-#: src/olympia/amo/context_processors.py:39 src/olympia/devhub/templates/devhub/nav.html:43
+#: src/olympia/amo/context_processors.py:37 src/olympia/devhub/templates/devhub/nav.html:43
 msgid "Tools"
 msgstr "Unelte"
 
-#: src/olympia/amo/context_processors.py:48 src/olympia/discovery/templates/discovery/pane_account.html:8 src/olympia/users/templates/users/includes/navigation.html:2
+#: src/olympia/amo/context_processors.py:47 src/olympia/discovery/templates/discovery/pane_account.html:8 src/olympia/users/templates/users/includes/navigation.html:2
 msgid "My Profile"
 msgstr ""
 
-#: src/olympia/amo/context_processors.py:54 src/olympia/users/templates/users/edit.html:5 src/olympia/users/templates/users/includes/navigation.html:3
+#: src/olympia/amo/context_processors.py:53 src/olympia/users/templates/users/edit.html:5 src/olympia/users/templates/users/includes/navigation.html:3
 msgid "Account Settings"
 msgstr ""
 
-#: src/olympia/amo/context_processors.py:57 src/olympia/discovery/templates/discovery/pane_account.html:11 src/olympia/users/templates/users/profile.html:83
+#: src/olympia/amo/context_processors.py:56 src/olympia/discovery/templates/discovery/pane_account.html:11 src/olympia/users/templates/users/profile.html:83
 #: src/olympia/users/templates/users/includes/navigation.html:4
 msgid "My Collections"
 msgstr "Colecțiile mele"
 
-#: src/olympia/amo/context_processors.py:62 src/olympia/discovery/templates/discovery/pane_account.html:10 src/olympia/users/templates/users/includes/navigation.html:7
+#: src/olympia/amo/context_processors.py:61 src/olympia/discovery/templates/discovery/pane_account.html:10 src/olympia/users/templates/users/includes/navigation.html:7
 msgid "My Favorites"
 msgstr "Favoritele mele"
 
-#: src/olympia/amo/context_processors.py:67 src/olympia/discovery/templates/discovery/pane_account.html:13 src/olympia/templates/impala/user_login.html:14
+#: src/olympia/amo/context_processors.py:66 src/olympia/discovery/templates/discovery/pane_account.html:13 src/olympia/templates/impala/user_login.html:14
 #: src/olympia/templates/mobile/header_auth.html:5
 msgid "Log out"
 msgstr "Ieșire"
 
-#: src/olympia/amo/context_processors.py:72 src/olympia/devhub/templates/devhub/addons/dashboard.html:4
+#: src/olympia/amo/context_processors.py:71 src/olympia/devhub/templates/devhub/addons/dashboard.html:4
 msgid "Manage My Submissions"
 msgstr ""
 
-#: src/olympia/amo/context_processors.py:75 src/olympia/devhub/templates/devhub/nav.html:27 src/olympia/devhub/templates/devhub/addons/dashboard.html:25
+#: src/olympia/amo/context_processors.py:74 src/olympia/devhub/templates/devhub/nav.html:27 src/olympia/devhub/templates/devhub/addons/dashboard.html:25
 #: src/olympia/devhub/templates/devhub/addons/submit/base.html:4
 msgid "Submit a New Add-on"
 msgstr ""
 
-#: src/olympia/amo/context_processors.py:77 src/olympia/browse/templates/browse/personas/base.html:50 src/olympia/devhub/templates/devhub/index.html:24
+#: src/olympia/amo/context_processors.py:76 src/olympia/browse/templates/browse/personas/base.html:50 src/olympia/devhub/templates/devhub/index.html:24
 #: src/olympia/devhub/templates/devhub/addons/dashboard.html:29
 msgid "Submit a New Theme"
 msgstr ""
 
-#: src/olympia/amo/context_processors.py:79 src/olympia/amo/templates/amo/site_nav.html:87 src/olympia/devhub/helpers.py:36 src/olympia/devhub/helpers.py:68 src/olympia/devhub/helpers.py:102
+#: src/olympia/amo/context_processors.py:78 src/olympia/amo/templates/amo/site_nav.html:85 src/olympia/devhub/helpers.py:36 src/olympia/devhub/helpers.py:68 src/olympia/devhub/helpers.py:102
 #: src/olympia/templates/footer.html:6 src/olympia/templates/menu_links.html:14
 msgid "Developer Hub"
 msgstr ""
 
-#: src/olympia/amo/context_processors.py:83 src/olympia/devhub/views.py:1792
+#: src/olympia/amo/context_processors.py:81 src/olympia/devhub/views.py:1796
 msgid "Manage API Keys"
 msgstr ""
 
-#: src/olympia/amo/context_processors.py:88 src/olympia/editors/helpers.py:82 src/olympia/editors/helpers.py:102 src/olympia/editors/templates/editors/base.html:10
+#: src/olympia/amo/context_processors.py:86 src/olympia/editors/helpers.py:84 src/olympia/editors/helpers.py:104 src/olympia/editors/templates/editors/base.html:10
 msgid "Editor Tools"
 msgstr ""
 
-#: src/olympia/amo/context_processors.py:92
+#: src/olympia/amo/context_processors.py:90
 msgid "Admin Tools"
 msgstr ""
 
-#: src/olympia/amo/fields.py:15
+#: src/olympia/amo/fields.py:20
 msgid "Incorrect, please try again."
 msgstr ""
 
-#: src/olympia/amo/fields.py:16
+#: src/olympia/amo/fields.py:21
 msgid "Error verifying input, please try again."
 msgstr ""
 
-#: src/olympia/amo/fields.py:32
+#: src/olympia/amo/fields.py:37
 msgid "This must be a valid hex color code, such as #000000."
 msgstr ""
 
-#: src/olympia/amo/fields.py:58
+#: src/olympia/amo/fields.py:63
 msgid "Enter at least one value."
 msgstr ""
 
-#: src/olympia/amo/helpers.py:162 src/olympia/amo/templates/amo/site_nav.html:61 src/olympia/bandwagon/templates/bandwagon/add.html:9
+#: src/olympia/amo/helpers.py:162 src/olympia/amo/templates/amo/site_nav.html:59 src/olympia/bandwagon/templates/bandwagon/add.html:9
 #: src/olympia/bandwagon/templates/bandwagon/collection_detail.html:15 src/olympia/bandwagon/templates/bandwagon/delete.html:9 src/olympia/bandwagon/templates/bandwagon/edit.html:15
 #: src/olympia/bandwagon/templates/bandwagon/user_listing.html:18 src/olympia/bandwagon/templates/bandwagon/user_listing.html:21
 #: src/olympia/bandwagon/templates/bandwagon/impala/collection_listing.html:12 src/olympia/bandwagon/templates/bandwagon/impala/collection_listing.html:20
 #: src/olympia/bandwagon/templates/bandwagon/impala/collection_listing.html:24 src/olympia/bandwagon/templates/bandwagon/impala/collection_sidebar.html:3
 #: src/olympia/bandwagon/templates/bandwagon/includes/collection_sidebar.html:2 src/olympia/bandwagon/templates/bandwagon/mobile/collection_listing.html:3
-#: src/olympia/stats/templates/stats/stats.html:77 src/olympia/templates/menu_links.html:12
+#: src/olympia/stats/templates/stats/stats.html:33 src/olympia/templates/menu_links.html:12
 #, fuzzy
 msgid "Collections"
 msgstr "Colecții"
 
-#: src/olympia/amo/helpers.py:171 src/olympia/amo/templates/amo/site_nav.html:85 src/olympia/browse/templates/browse/language_tools.html:3
+#: src/olympia/amo/helpers.py:171 src/olympia/amo/templates/amo/site_nav.html:83 src/olympia/browse/templates/browse/language_tools.html:3
 msgid "Dictionaries & Language Packs"
 msgstr ""
 
@@ -1619,8 +1603,8 @@ msgstr ""
 msgid "Comment on {addon} {version}."
 msgstr ""
 
-#: src/olympia/amo/log.py:236 src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:19 src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:47
-#: src/olympia/editors/helpers.py:511 src/olympia/editors/templates/editors/themes/history_table.html:11
+#: src/olympia/amo/log.py:236 src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:17 src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:45
+#: src/olympia/editors/helpers.py:584 src/olympia/editors/templates/editors/themes/history_table.html:11
 msgid "Comment"
 msgstr ""
 
@@ -1943,7 +1927,7 @@ msgstr "Înapoi"
 #: src/olympia/amo/templates/amo/mobile/paginator.html:14 src/olympia/amo/templates/amo/mobile/paginator.html:16 src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:51
 #: src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:65 src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:78
 #: src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:91 src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:104
-#: src/olympia/discovery/templates/discovery/pane.html:45 src/olympia/discovery/templates/discovery/addons/detail.html:39 src/olympia/stats/templates/stats/stats.html:167
+#: src/olympia/discovery/templates/discovery/pane.html:45 src/olympia/discovery/templates/discovery/addons/detail.html:39 src/olympia/stats/templates/stats/stats.html:169
 msgid "Next"
 msgstr "Înainte"
 
@@ -1975,7 +1959,7 @@ msgid ""
 msgstr ""
 
 #: src/olympia/amo/templates/amo/side_nav.html:4 src/olympia/amo/templates/amo/side_nav.html:12 src/olympia/amo/templates/amo/site_nav.html:4 src/olympia/amo/templates/amo/site_nav.html:26
-#: src/olympia/browse/views.py:56 src/olympia/browse/views.py:66 src/olympia/browse/views.py:237 src/olympia/browse/views.py:282 src/olympia/search/forms.py:86
+#: src/olympia/browse/views.py:56 src/olympia/browse/views.py:66 src/olympia/browse/views.py:204 src/olympia/browse/views.py:249 src/olympia/search/forms.py:86
 msgid "Top Rated"
 msgstr ""
 
@@ -1990,38 +1974,38 @@ msgstr ""
 msgid "Extensions"
 msgstr "Extensii"
 
-#: src/olympia/amo/templates/amo/site_nav.html:45
+#: src/olympia/amo/templates/amo/site_nav.html:44
 msgid "Want more customization? Try <b>Complete Themes</b>"
 msgstr ""
 
-#: src/olympia/amo/templates/amo/site_nav.html:56 src/olympia/bandwagon/views.py:96
+#: src/olympia/amo/templates/amo/site_nav.html:54 src/olympia/bandwagon/views.py:96
 msgid "Most Followers"
 msgstr ""
 
-#: src/olympia/amo/templates/amo/site_nav.html:68 src/olympia/bandwagon/templates/bandwagon/impala/collection_sidebar.html:16
+#: src/olympia/amo/templates/amo/site_nav.html:66 src/olympia/bandwagon/templates/bandwagon/impala/collection_sidebar.html:16
 #: src/olympia/bandwagon/templates/bandwagon/includes/collection_sidebar.html:18
 msgid "Collections I've Made"
 msgstr ""
 
-#: src/olympia/amo/templates/amo/site_nav.html:70 src/olympia/bandwagon/templates/bandwagon/user_listing.html:4 src/olympia/bandwagon/templates/bandwagon/impala/collection_sidebar.html:13
+#: src/olympia/amo/templates/amo/site_nav.html:68 src/olympia/bandwagon/templates/bandwagon/user_listing.html:4 src/olympia/bandwagon/templates/bandwagon/impala/collection_sidebar.html:13
 #: src/olympia/bandwagon/templates/bandwagon/includes/collection_sidebar.html:15
 msgid "Collections I'm Following"
 msgstr ""
 
-#: src/olympia/amo/templates/amo/site_nav.html:73 src/olympia/bandwagon/templates/bandwagon/impala/collection_sidebar.html:18
-#: src/olympia/bandwagon/templates/bandwagon/includes/collection_sidebar.html:20 src/olympia/users/models.py:512
+#: src/olympia/amo/templates/amo/site_nav.html:71 src/olympia/bandwagon/templates/bandwagon/impala/collection_sidebar.html:18
+#: src/olympia/bandwagon/templates/bandwagon/includes/collection_sidebar.html:20 src/olympia/users/models.py:521
 msgid "My Favorite Add-ons"
 msgstr ""
 
-#: src/olympia/amo/templates/amo/site_nav.html:78
+#: src/olympia/amo/templates/amo/site_nav.html:76
 msgid "More&hellip;"
 msgstr ""
 
-#: src/olympia/amo/templates/amo/site_nav.html:82
+#: src/olympia/amo/templates/amo/site_nav.html:80
 msgid "Add-ons for Mobile"
 msgstr ""
 
-#: src/olympia/amo/templates/amo/site_nav.html:86 src/olympia/browse/feeds.py:207 src/olympia/browse/templates/browse/search_tools.html:3 src/olympia/constants/base.py:176
+#: src/olympia/amo/templates/amo/site_nav.html:84 src/olympia/browse/feeds.py:207 src/olympia/browse/templates/browse/search_tools.html:3 src/olympia/constants/base.py:176
 #: src/olympia/templates/menu_links.html:10
 msgid "Search Tools"
 msgstr ""
@@ -2037,7 +2021,7 @@ msgid "Jump to first page"
 msgstr ""
 
 #: src/olympia/amo/templates/amo/impala/paginator.html:22 src/olympia/amo/templates/amo/mobile/impala_paginator.html:12 src/olympia/discovery/templates/discovery/pane.html:44
-#: src/olympia/discovery/templates/discovery/addons/detail.html:38 src/olympia/stats/templates/stats/stats.html:164
+#: src/olympia/discovery/templates/discovery/addons/detail.html:38 src/olympia/stats/templates/stats/stats.html:166
 msgid "Previous"
 msgstr ""
 
@@ -2059,32 +2043,50 @@ msgid "Page {n}"
 msgid_plural "Page {n}"
 msgstr[0] ""
 msgstr[1] ""
-msgstr[2] ""
 
-#: src/olympia/amo/templates/services/install.html:38
-#, python-format
-msgid "If you are not prompted to install %(addon_name)s in a moment, please <a href=\"%(addon_xpi)s\">click here</a>."
-msgstr ""
-
-#: src/olympia/amo/tests/test_messages.py:57 src/olympia/amo/tests/test_messages.py:58 src/olympia/reviews/forms.py:25 src/olympia/reviews/forms.py:50 src/olympia/reviews/templates/reviews/add.html:56
+#: src/olympia/amo/tests/test_messages.py:56 src/olympia/amo/tests/test_messages.py:57 src/olympia/reviews/forms.py:25 src/olympia/reviews/forms.py:50 src/olympia/reviews/templates/reviews/add.html:56
 #: src/olympia/reviews/templates/reviews/reply.html:30
 msgid "Title"
 msgstr ""
 
-#: src/olympia/amo/tests/test_messages.py:57 src/olympia/amo/tests/test_messages.py:58
+#: src/olympia/amo/tests/test_messages.py:56 src/olympia/amo/tests/test_messages.py:57
 msgid "Body"
 msgstr ""
 
-#: src/olympia/amo/tests/test_messages.py:59
+#: src/olympia/amo/tests/test_messages.py:58
 msgid "Another Title"
 msgstr ""
 
-#: src/olympia/amo/tests/test_messages.py:59
+#: src/olympia/amo/tests/test_messages.py:58
 msgid "Another Body"
 msgstr ""
 
-#: src/olympia/api/views.py:255
-msgid "Not implemented yet."
+#: src/olympia/api/authentication.py:76
+msgid "Signature has expired."
+msgstr ""
+
+#: src/olympia/api/authentication.py:79
+msgid "Error decoding signature."
+msgstr ""
+
+#: src/olympia/api/authentication.py:82
+msgid "Invalid JWT Token."
+msgstr ""
+
+#: src/olympia/api/authentication.py:130
+msgid "Invalid Authorization header. No credentials provided."
+msgstr ""
+
+#: src/olympia/api/authentication.py:133
+msgid "Invalid Authorization header. Credentials string should not contain spaces."
+msgstr ""
+
+#: src/olympia/api/fields.py:29
+msgid "The field must have a length of at least {num} characters."
+msgstr ""
+
+#: src/olympia/api/fields.py:31
+msgid "The language code {lang_code} is invalid."
 msgstr ""
 
 #: src/olympia/applications/views.py:39 src/olympia/applications/templates/applications/appversions.html:3
@@ -2103,7 +2105,7 @@ msgstr "Versiuni valide de aplicație"
 msgid "Add-ons submitted to Mozilla Add-ons must have a manifest file with at least one of the below applications supported. Only the versions listed below are allowed for these applications."
 msgstr ""
 
-#: src/olympia/applications/templates/applications/appversions.html:25
+#: src/olympia/applications/templates/applications/appversions.html:25 src/olympia/editors/helpers.py:361
 msgid "GUID"
 msgstr "GUID"
 
@@ -2221,8 +2223,8 @@ msgstr ""
 msgid "Remove from favorites"
 msgstr ""
 
-#: src/olympia/bandwagon/views.py:98 src/olympia/bandwagon/views.py:191 src/olympia/browse/views.py:58 src/olympia/browse/views.py:69 src/olympia/browse/views.py:458 src/olympia/devhub/views.py:74
-#: src/olympia/devhub/views.py:82 src/olympia/devhub/templates/devhub/addons/edit/basic.html:20 src/olympia/editors/templates/editors/leaderboard.html:24
+#: src/olympia/bandwagon/views.py:98 src/olympia/bandwagon/views.py:191 src/olympia/browse/views.py:58 src/olympia/browse/views.py:69 src/olympia/browse/views.py:425 src/olympia/devhub/views.py:72
+#: src/olympia/devhub/views.py:80 src/olympia/devhub/templates/devhub/addons/edit/basic.html:20 src/olympia/editors/templates/editors/leaderboard.html:24
 #: src/olympia/editors/templates/editors/themes/queue_list.html:48 src/olympia/search/forms.py:17 src/olympia/search/forms.py:89 src/olympia/users/templates/users/vcard.html:5
 msgid "Name"
 msgstr ""
@@ -2231,7 +2233,7 @@ msgstr ""
 msgid "Recently Popular"
 msgstr ""
 
-#: src/olympia/bandwagon/views.py:189 src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:18
+#: src/olympia/bandwagon/views.py:189 src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:16
 msgid "Added"
 msgstr ""
 
@@ -2245,7 +2247,7 @@ msgstr ""
 
 #: src/olympia/bandwagon/views.py:316
 #, python-format
-msgid "Your new collection is shown below. You can <ahref=\"%(url)s\">edit additional settings</a> if you'dlike."
+msgid "Your new collection is shown below. You can <a href=\"%(url)s\">edit additional settings</a> if you'd like."
 msgstr ""
 
 #: src/olympia/bandwagon/views.py:322
@@ -2326,7 +2328,6 @@ msgid "<span>%(num)s</span> follower"
 msgid_plural "<span>%(num)s</span> followers"
 msgstr[0] ""
 msgstr[1] ""
-msgstr[2] ""
 
 #: src/olympia/bandwagon/templates/bandwagon/collection_detail.html:54
 msgid "About this Collection"
@@ -2366,7 +2367,6 @@ msgid "%(num)s Theme in this Collection"
 msgid_plural "%(num)s Themes in this Collection"
 msgstr[0] ""
 msgstr[1] ""
-msgstr[2] ""
 
 #: src/olympia/bandwagon/templates/bandwagon/collection_detail.html:111
 #, python-format
@@ -2374,10 +2374,9 @@ msgid "%(num)s Add-on in this Collection"
 msgid_plural "%(num)s Add-ons in this Collection"
 msgstr[0] ""
 msgstr[1] ""
-msgstr[2] ""
 
-#: src/olympia/bandwagon/templates/bandwagon/collection_detail.html:125 src/olympia/compat/templates/compat/index.html:25 src/olympia/compat/templates/compat/reporter_detail.html:29
-#: src/olympia/files/templates/files/viewer.html:29 src/olympia/templates/amo_footer.html:17 src/olympia/templates/includes/lang_switcher.html:10
+#: src/olympia/bandwagon/templates/bandwagon/collection_detail.html:125 src/olympia/compat/templates/compat/reporter_detail.html:29 src/olympia/files/templates/files/viewer.html:29
+#: src/olympia/templates/amo_footer.html:17 src/olympia/templates/includes/lang_switcher.html:10
 msgid "Go"
 msgstr ""
 
@@ -2423,7 +2422,6 @@ msgid "<span>%(addons)s</span> add-on"
 msgid_plural "<span>%(addons)s</span> add-ons"
 msgstr[0] ""
 msgstr[1] ""
-msgstr[2] ""
 
 #: src/olympia/bandwagon/templates/bandwagon/collection_grid.html:32
 #, python-format
@@ -2431,7 +2429,6 @@ msgid "<span>%(followers)s</span> follower"
 msgid_plural "<span>%(followers)s</span> followers"
 msgstr[0] ""
 msgstr[1] ""
-msgstr[2] ""
 
 #. People "follow" collections to get notified of updates.                    Like
 #. Twitter followers.
@@ -2443,7 +2440,6 @@ msgid "%(num)s weekly follower"
 msgid_plural "%(num)s weekly followers"
 msgstr[0] ""
 msgstr[1] ""
-msgstr[2] ""
 
 #. People "follow" collections to get notified of updates.                    Like
 #. Twitter followers.
@@ -2453,7 +2449,6 @@ msgid "%(num)s monthly follower"
 msgid_plural "%(num)s monthly followers"
 msgstr[0] ""
 msgstr[1] ""
-msgstr[2] ""
 
 #. People "follow" collections to get notified of updates.                    Like
 #. Twitter followers.
@@ -2465,7 +2460,6 @@ msgid "%(num)s follower"
 msgid_plural "%(num)s followers"
 msgstr[0] ""
 msgstr[1] ""
-msgstr[2] ""
 
 #: src/olympia/bandwagon/templates/bandwagon/collection_listing_items.html:56 src/olympia/bandwagon/templates/bandwagon/impala/collection_listing_items.html:9
 #: src/olympia/devhub/templates/devhub/personas/edit.html:27
@@ -2550,7 +2544,7 @@ msgid "Remove this user as a contributor"
 msgstr ""
 
 #: src/olympia/bandwagon/templates/bandwagon/edit_contributors.html:18 src/olympia/bandwagon/templates/bandwagon/edit_contributors.html:43
-#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:20 src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:48
+#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:18 src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:46
 #: src/olympia/devhub/templates/devhub/addons/ajax_compat_update.html:19
 msgid "Remove"
 msgstr ""
@@ -2599,7 +2593,7 @@ msgid "<b>Warning:</b> By changing the owner of this collection, you will no lon
 msgstr ""
 
 #: src/olympia/bandwagon/templates/bandwagon/edit_contributors.html:83 src/olympia/devhub/templates/devhub/addons/forms_shared/media.html:157
-#: src/olympia/devhub/templates/devhub/addons/submit/describe.html:69 src/olympia/devhub/templates/devhub/addons/submit/license.html:60 src/olympia/devhub/templates/devhub/addons/submit/upload.html:78
+#: src/olympia/devhub/templates/devhub/addons/submit/describe.html:69 src/olympia/devhub/templates/devhub/addons/submit/license.html:60 src/olympia/devhub/templates/devhub/addons/submit/upload.html:70
 #: src/olympia/devhub/templates/devhub/payments/tier.html:17 src/olympia/editors/templates/editors/themes/themes.html:111 src/olympia/editors/templates/editors/themes/themes.html:128
 #: src/olympia/editors/templates/editors/themes/themes.html:134 src/olympia/editors/templates/editors/themes/themes.html:141 src/olympia/users/templates/users/fxa_migration_prompt_content.html:10
 #: src/olympia/users/templates/users/login_form.html:42 src/olympia/users/templates/users/mobile/login.html:57
@@ -2684,31 +2678,31 @@ msgid "Add-ons in Your Collection"
 msgstr ""
 
 #: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:4
-msgid ""
-"To include an add-on in this collection, enter its name in the box below and hit enter.  You can also use the <strong>Add to Collection</strong> links throughout the site to include add-ons later."
+msgid "To include an add-on in this collection, enter its name in the box below and hit enter."
 msgstr ""
 
-#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:17 src/olympia/constants/base.py:400 src/olympia/devhub/templates/devhub/addons/activity.html:62
+#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:15 src/olympia/constants/base.py:400 src/olympia/devhub/templates/devhub/addons/activity.html:62
+#: src/olympia/editors/helpers.py:273 src/olympia/editors/helpers.py:360
 msgid "Add-on"
 msgstr ""
 
-#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:26
+#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:24
 msgid "Enter the name of the add-on to include"
 msgstr ""
 
-#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:28
+#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:26
 msgid "Add to Collection"
 msgstr ""
 
-#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:45 src/olympia/editors/helpers.py:936 src/olympia/editors/helpers.py:956
+#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:43 src/olympia/editors/helpers.py:1016 src/olympia/editors/helpers.py:1036
 msgid "Pending"
 msgstr ""
 
-#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:47
+#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:45
 msgid "Add a comment"
 msgstr ""
 
-#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:48
+#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:46
 msgid "Remove this add-on from the collection"
 msgstr ""
 
@@ -2815,12 +2809,12 @@ msgstr ""
 msgid "Most Users"
 msgstr ""
 
-#: src/olympia/browse/views.py:61 src/olympia/browse/views.py:72 src/olympia/browse/views.py:279 src/olympia/browse/templates/browse/personas/mobile/category_landing.html:63
+#: src/olympia/browse/views.py:61 src/olympia/browse/views.py:72 src/olympia/browse/views.py:246 src/olympia/browse/templates/browse/personas/mobile/category_landing.html:63
 #: src/olympia/discovery/templates/discovery/pane.html:67 src/olympia/search/forms.py:92
 msgid "Up & Coming"
 msgstr ""
 
-#: src/olympia/browse/views.py:460 src/olympia/devhub/views.py:76 src/olympia/devhub/views.py:83 src/olympia/discovery/templates/discovery/addons/detail.html:66
+#: src/olympia/browse/views.py:427 src/olympia/devhub/views.py:74 src/olympia/devhub/views.py:81 src/olympia/discovery/templates/discovery/addons/detail.html:66
 msgid "Created"
 msgstr "Creat"
 
@@ -2901,7 +2895,6 @@ msgid "<b>{0}</b> add-on"
 msgid_plural "<b>{0}</b> add-ons"
 msgstr[0] ""
 msgstr[1] ""
-msgstr[2] ""
 
 #: src/olympia/browse/templates/browse/search_tools.html:61
 msgid "Search Extensions"
@@ -3008,10 +3001,9 @@ msgid "See the %(cnt)s extension in %(name)s &raquo;"
 msgid_plural "See all %(cnt)s extensions in %(name)s &raquo;"
 msgstr[0] ""
 msgstr[1] ""
-msgstr[2] ""
 
-#: src/olympia/browse/templates/browse/mobile/extensions.html:13 src/olympia/compat/templates/compat/index.html:82 src/olympia/devhub/templates/devhub/devhub_search.html:24
-#: src/olympia/devhub/templates/devhub/addons/activity.html:47 src/olympia/search/templates/search/no_results.html:4 src/olympia/search/templates/search/mobile/results.html:36
+#: src/olympia/browse/templates/browse/mobile/extensions.html:13 src/olympia/devhub/templates/devhub/devhub_search.html:24 src/olympia/devhub/templates/devhub/addons/activity.html:47
+#: src/olympia/search/templates/search/no_results.html:4 src/olympia/search/templates/search/mobile/results.html:36
 msgid "No results found."
 msgstr "Niciun rezultat găsit."
 
@@ -3096,7 +3088,7 @@ msgstr ""
 msgid "All"
 msgstr ""
 
-#: src/olympia/compat/forms.py:22 src/olympia/search/views.py:525
+#: src/olympia/compat/forms.py:22 src/olympia/editors/templates/editors/base.html:69 src/olympia/search/views.py:518
 msgid "All Add-ons"
 msgstr ""
 
@@ -3106,53 +3098,6 @@ msgstr ""
 
 #: src/olympia/compat/forms.py:24
 msgid "Non-binary"
-msgstr ""
-
-#. Review points sources other than add-ons and themes.
-#: src/olympia/compat/views.py:87 src/olympia/constants/base.py:388 src/olympia/devhub/forms.py:162 src/olympia/editors/templates/editors/performance.html:75
-msgid "Other"
-msgstr "Alta"
-
-#: src/olympia/compat/templates/compat/index.html:4
-msgid "Add-on Compatibility Report for {app} {version}"
-msgstr ""
-
-#: src/olympia/compat/templates/compat/index.html:11
-msgid "{app} {version} Compatibility"
-msgstr ""
-
-#: src/olympia/compat/templates/compat/index.html:17
-#, python-format
-msgid "Top 95%% compatible with previous version"
-msgstr ""
-
-#: src/olympia/compat/templates/compat/index.html:18
-#, python-format
-msgid "Top 95%% of all add-ons"
-msgstr ""
-
-#: src/olympia/compat/templates/compat/index.html:19
-msgid "All active add-ons"
-msgstr ""
-
-#: src/olympia/compat/templates/compat/index.html:23 src/olympia/constants/base.py:401
-msgid "App"
-msgstr ""
-
-#: src/olympia/compat/templates/compat/index.html:55
-msgid "Details for add-ons compatible with previous version:"
-msgstr ""
-
-#: src/olympia/compat/templates/compat/index.html:57
-msgid "Show all versions"
-msgstr ""
-
-#: src/olympia/compat/templates/compat/index.html:59
-msgid "Details for add-ons compatible with all versions:"
-msgstr ""
-
-#: src/olympia/compat/templates/compat/index.html:61
-msgid "Show previous version only"
 msgstr ""
 
 #: src/olympia/compat/templates/compat/reporter.html:3
@@ -3187,14 +3132,12 @@ msgid "{0} success report"
 msgid_plural "{0} success reports"
 msgstr[0] ""
 msgstr[1] ""
-msgstr[2] ""
 
 #: src/olympia/compat/templates/compat/reporter_detail.html:17
 msgid "{0} problem report"
 msgid_plural "{0} problem reports"
 msgstr[0] ""
 msgstr[1] ""
-msgstr[2] ""
 
 #: src/olympia/compat/templates/compat/reporter_detail.html:21 src/olympia/users/templates/users/profile.html:70
 msgid "View all"
@@ -3208,8 +3151,8 @@ msgstr ""
 msgid "Report Type"
 msgstr ""
 
-#: src/olympia/compat/templates/compat/reporter_detail.html:47 src/olympia/devhub/forms.py:784 src/olympia/devhub/templates/devhub/addons/ajax_compat_update.html:17 src/olympia/editors/forms.py:108
-#: src/olympia/zadmin/forms.py:45
+#: src/olympia/compat/templates/compat/reporter_detail.html:47 src/olympia/devhub/forms.py:785 src/olympia/devhub/templates/devhub/addons/ajax_compat_update.html:17 src/olympia/editors/forms.py:108
+#: src/olympia/editors/forms.py:248 src/olympia/zadmin/forms.py:45
 msgid "Application"
 msgstr ""
 
@@ -3297,7 +3240,8 @@ msgstr ""
 msgid "Preliminarily Reviewed and Awaiting Full Review"
 msgstr ""
 
-#: src/olympia/constants/base.py:33 src/olympia/editors/helpers.py:924 src/olympia/editors/templates/editors/themes/history_table.html:34
+#: src/olympia/constants/base.py:33 src/olympia/editors/forms.py:258 src/olympia/editors/helpers.py:73 src/olympia/editors/helpers.py:1004
+#: src/olympia/editors/templates/editors/themes/history_table.html:34
 msgid "Deleted"
 msgstr ""
 
@@ -3398,6 +3342,11 @@ msgstr ""
 msgid "Ask before users can download this add-on"
 msgstr ""
 
+#. Review points sources other than add-ons and themes.
+#: src/olympia/constants/base.py:388 src/olympia/devhub/forms.py:162 src/olympia/editors/templates/editors/performance.html:75
+msgid "Other"
+msgstr "Alta"
+
 #: src/olympia/constants/base.py:389
 msgid "Exception"
 msgstr ""
@@ -3408,6 +3357,10 @@ msgstr ""
 
 #: src/olympia/constants/base.py:391
 msgid "Change"
+msgstr ""
+
+#: src/olympia/constants/base.py:401
+msgid "App"
 msgstr ""
 
 #: src/olympia/constants/base.py:402
@@ -3558,7 +3511,7 @@ msgstr ""
 msgid "Duplicate"
 msgstr ""
 
-#: src/olympia/constants/editors.py:17 src/olympia/editors/helpers.py:502 src/olympia/editors/templates/editors/themes/queue.html:71 src/olympia/editors/templates/editors/themes/themes.html:94
+#: src/olympia/constants/editors.py:17 src/olympia/editors/helpers.py:575 src/olympia/editors/templates/editors/themes/queue.html:71 src/olympia/editors/templates/editors/themes/themes.html:94
 msgid "Reject"
 msgstr ""
 
@@ -3658,7 +3611,7 @@ msgstr ""
 msgid "Android"
 msgstr ""
 
-#: src/olympia/core/apps.py:19
+#: src/olympia/core/apps.py:21
 msgid "Core"
 msgstr ""
 
@@ -3793,7 +3746,7 @@ msgid "Submit my add-on for manual review."
 msgstr ""
 
 #: src/olympia/devhub/forms.py:537
-msgid "Do not list my add-on on this site (beta)"
+msgid "Do not list my add-on on this site"
 msgstr ""
 
 #: src/olympia/devhub/forms.py:538
@@ -3826,46 +3779,46 @@ msgstr ""
 
 #: src/olympia/devhub/forms.py:592
 #, python-format
-msgid "Version %s already exists"
+msgid "Version %s already exists, or was uploaded before."
 msgstr ""
 
-#: src/olympia/devhub/forms.py:604
+#: src/olympia/devhub/forms.py:605
 msgid "Select a valid choice. That choice is not one of the available choices."
 msgstr ""
 
-#: src/olympia/devhub/forms.py:610
+#: src/olympia/devhub/forms.py:611
 msgid "A file with a version ending with a|alpha|b|beta and an optional number is detected as beta."
 msgstr ""
 
-#: src/olympia/devhub/forms.py:633
+#: src/olympia/devhub/forms.py:634
 msgid "You cannot upload any more files for this version."
 msgstr ""
 
-#: src/olympia/devhub/forms.py:639
+#: src/olympia/devhub/forms.py:640
 msgid "Version doesn't match"
 msgstr ""
 
-#: src/olympia/devhub/forms.py:668
+#: src/olympia/devhub/forms.py:669
 msgid "You cannot delete a file once the review process has started.  You must delete the whole version."
 msgstr ""
 
-#: src/olympia/devhub/forms.py:688
+#: src/olympia/devhub/forms.py:689
 msgid "The platform All cannot be combined with specific platforms."
 msgstr ""
 
-#: src/olympia/devhub/forms.py:693
+#: src/olympia/devhub/forms.py:694
 msgid "A platform can only be chosen once."
 msgstr ""
 
-#: src/olympia/devhub/forms.py:706
+#: src/olympia/devhub/forms.py:707
 msgid "A review type must be selected."
 msgstr ""
 
-#: src/olympia/devhub/forms.py:788 src/olympia/editors/forms.py:114 src/olympia/zadmin/forms.py:49 src/olympia/zadmin/forms.py:52
+#: src/olympia/devhub/forms.py:789 src/olympia/editors/forms.py:114 src/olympia/editors/forms.py:254 src/olympia/zadmin/forms.py:49 src/olympia/zadmin/forms.py:52
 msgid "Select an application first"
 msgstr ""
 
-#: src/olympia/devhub/forms.py:840
+#: src/olympia/devhub/forms.py:841
 msgid "There cannot be more than 3 required add-ons."
 msgstr ""
 
@@ -3888,7 +3841,6 @@ msgid "{0} error"
 msgid_plural "{0} errors"
 msgstr[0] "{0} eroare"
 msgstr[1] "{0} erori"
-msgstr[2] "{0} erori"
 
 # {0} is a number
 #. L10n: first parameter is the number of warnings
@@ -3897,83 +3849,82 @@ msgid "{0} warning"
 msgid_plural "{0} warnings"
 msgstr[0] "{0} avertisment"
 msgstr[1] "{0} avertismente"
-msgstr[2] "{0} avertismente"
 
 #: src/olympia/devhub/models.py:375 src/olympia/reviews/templates/reviews/add.html:58
 #, fuzzy
 msgid "Review"
 msgstr "Review"
 
-#: src/olympia/devhub/tasks.py:551
+#: src/olympia/devhub/tasks.py:583
 #, python-format
 msgid "%s responded with %s (%s)."
 msgstr ""
 
-#: src/olympia/devhub/tasks.py:555
+#: src/olympia/devhub/tasks.py:587
 #, python-format
 msgid "Connection to \"%s\" timed out."
 msgstr ""
 
-#: src/olympia/devhub/tasks.py:557
+#: src/olympia/devhub/tasks.py:589
 #, python-format
 msgid "Could not contact host at \"%s\"."
 msgstr ""
 
-#: src/olympia/devhub/utils.py:104
+#: src/olympia/devhub/utils.py:105
 #, python-format
 msgid "Validation generated too many errors/warnings so %s messages were truncated. After addressing the visible messages, you'll be able to see the others."
 msgstr ""
 
-#: src/olympia/devhub/views.py:183
+#: src/olympia/devhub/views.py:181
 msgid "All My Add-ons"
 msgstr ""
 
-#: src/olympia/devhub/views.py:210
+#: src/olympia/devhub/views.py:208
 msgid "All Activity"
 msgstr ""
 
-#: src/olympia/devhub/views.py:211
+#: src/olympia/devhub/views.py:209
 msgid "Add-on Updates"
 msgstr ""
 
-#: src/olympia/devhub/views.py:212
+#: src/olympia/devhub/views.py:210
 msgid "Add-on Status"
 msgstr ""
 
-#: src/olympia/devhub/views.py:213
+#: src/olympia/devhub/views.py:211
 msgid "User Collections"
 msgstr ""
 
-#: src/olympia/devhub/views.py:214 src/olympia/devhub/templates/devhub/docs/policies-maintenance.html:68 src/olympia/pages/templates/pages/dev_faq.html:38
+#: src/olympia/devhub/views.py:212 src/olympia/devhub/templates/devhub/docs/policies-maintenance.html:68 src/olympia/pages/templates/pages/dev_faq.html:38
 #: src/olympia/pages/templates/pages/dev_faq.html:484
 msgid "User Reviews"
 msgstr ""
 
-#: src/olympia/devhub/views.py:327 src/olympia/devhub/views.py:331 src/olympia/devhub/views.py:484 src/olympia/devhub/views.py:513 src/olympia/devhub/views.py:564 src/olympia/devhub/views.py:1150
+#: src/olympia/devhub/views.py:325 src/olympia/devhub/views.py:329 src/olympia/devhub/views.py:484 src/olympia/devhub/views.py:513 src/olympia/devhub/views.py:564 src/olympia/devhub/views.py:1156
 msgid "Changes successfully saved."
 msgstr ""
 
-#: src/olympia/devhub/views.py:334 src/olympia/devhub/views.py:1631
+#: src/olympia/devhub/views.py:332 src/olympia/devhub/views.py:1637
 msgid "Please check the form for errors."
 msgstr ""
 
-#: src/olympia/devhub/views.py:346
+#: src/olympia/devhub/views.py:344
 msgid "Add-on cannot be deleted. Disable this add-on instead."
 msgstr ""
 
-#: src/olympia/devhub/views.py:356
+#: src/olympia/devhub/views.py:354
 msgid "Theme deleted."
 msgstr ""
 
-#: src/olympia/devhub/views.py:356
+#: src/olympia/devhub/views.py:354
 msgid "Add-on deleted."
 msgstr ""
 
-#: src/olympia/devhub/views.py:362
+#: src/olympia/devhub/views.py:360
 msgid "URL name was incorrect. Theme was not deleted."
 msgstr ""
 
-#: src/olympia/devhub/views.py:367
+#: src/olympia/devhub/views.py:365
 msgid "URL name was incorrect. Add-on was not deleted."
 msgstr ""
 
@@ -4001,7 +3952,7 @@ msgstr ""
 msgid "Check Add-on Compatibility"
 msgstr ""
 
-#: src/olympia/devhub/views.py:808 src/olympia/signing/views.py:90
+#: src/olympia/devhub/views.py:808 src/olympia/signing/views.py:95
 msgid "You cannot submit this type of add-on"
 msgstr ""
 
@@ -4031,33 +3982,33 @@ msgstr ""
 msgid "There was an error uploading your preview."
 msgstr ""
 
-#: src/olympia/devhub/views.py:1189
+#: src/olympia/devhub/views.py:1195
 #, python-format
 msgid "Version %s disabled."
 msgstr ""
 
-#: src/olympia/devhub/views.py:1193
+#: src/olympia/devhub/views.py:1199
 #, python-format
 msgid "Version %s deleted."
 msgstr ""
 
-#: src/olympia/devhub/views.py:1203
+#: src/olympia/devhub/views.py:1209
 msgid "This upload has failed validation, and may lack complete validation results. Please take due care when reviewing it."
 msgstr ""
 
-#: src/olympia/devhub/views.py:1677
+#: src/olympia/devhub/views.py:1683
 msgid "Preliminary Review Requested."
 msgstr ""
 
-#: src/olympia/devhub/views.py:1678
+#: src/olympia/devhub/views.py:1684
 msgid "Full Review Requested."
 msgstr ""
 
-#: src/olympia/devhub/views.py:1779
+#: src/olympia/devhub/views.py:1783
 msgid "Your old credentials were revoked and are no longer valid. Be sure to update all API clients with the new credentials."
 msgstr ""
 
-#: src/olympia/devhub/views.py:1797
+#: src/olympia/devhub/views.py:1801
 msgid "New API key created"
 msgstr ""
 
@@ -4087,7 +4038,7 @@ msgstr ""
 msgid "{0} :: Search"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/devhub_search.html:6 src/olympia/devhub/templates/devhub/search.html:8 src/olympia/editors/forms.py:435 src/olympia/editors/forms.py:437
+#: src/olympia/devhub/templates/devhub/devhub_search.html:6 src/olympia/devhub/templates/devhub/search.html:8 src/olympia/editors/forms.py:534 src/olympia/editors/forms.py:536
 #: src/olympia/editors/templates/editors/queue.html:27 src/olympia/editors/templates/editors/themes/queue_list.html:14 src/olympia/search/templates/search/collections.html:17
 #: src/olympia/search/templates/search/personas.html:18 src/olympia/search/templates/search/results.html:18 src/olympia/search/templates/search/mobile/results.html:8
 #: src/olympia/templates/search.html:14 src/olympia/templates/impala/search.html:18
@@ -4147,12 +4098,12 @@ msgstr ""
 msgid "Start Making Add-ons"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/index.html:86 src/olympia/devhub/templates/devhub/addons/listing/items.html:25 src/olympia/devhub/templates/devhub/includes/addon_details.html:15
+#: src/olympia/devhub/templates/devhub/index.html:86 src/olympia/devhub/templates/devhub/addons/listing/items.html:25 src/olympia/devhub/templates/devhub/includes/addon_details.html:20
 #: src/olympia/devhub/templates/devhub/personas/edit.html:43
 msgid "Status:"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/index.html:90 src/olympia/devhub/templates/devhub/includes/addon_details.html:100
+#: src/olympia/devhub/templates/devhub/index.html:90 src/olympia/devhub/templates/devhub/includes/addon_details.html:87
 msgid "Visibility:"
 msgstr ""
 
@@ -4160,11 +4111,11 @@ msgstr ""
 msgid "Latest Version:"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/index.html:109 src/olympia/devhub/templates/devhub/includes/addon_details.html:145 src/olympia/devhub/templates/devhub/personas/edit.html:49
+#: src/olympia/devhub/templates/devhub/index.html:109 src/olympia/devhub/templates/devhub/includes/addon_details.html:131 src/olympia/devhub/templates/devhub/personas/edit.html:49
 msgid "Queue Position:"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/index.html:110 src/olympia/devhub/templates/devhub/includes/addon_details.html:146 src/olympia/devhub/templates/devhub/personas/edit.html:50
+#: src/olympia/devhub/templates/devhub/index.html:110 src/olympia/devhub/templates/devhub/includes/addon_details.html:132 src/olympia/devhub/templates/devhub/personas/edit.html:50
 #, python-format
 msgid "%(position)s of %(total)s"
 msgstr ""
@@ -4266,16 +4217,6 @@ msgstr ""
 msgid "Do you want your add-on to be distributed on this site?"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/validate_addon.html:49 src/olympia/devhub/templates/devhub/addons/submit/upload.html:30 src/olympia/devhub/templates/devhub/versions/add_file_modal.html:14
-#: src/olympia/devhub/templates/devhub/versions/add_file_modal.html:53 src/olympia/devhub/templates/devhub/versions/list.html:298
-msgid "Warning:"
-msgstr ""
-
-#: src/olympia/devhub/templates/devhub/validate_addon.html:50 src/olympia/devhub/templates/devhub/addons/submit/upload.html:31
-#, python-format
-msgid "Submission of unlisted add-ons for signing is currently in an open beta. Please <a href=\"%(url)s\" target=\"_blank\">report any bugs</a> that you encounter."
-msgstr ""
-
 #. first parameter is a filename like lorem-ipsum-1.0.2.xpi
 #: src/olympia/devhub/templates/devhub/validation.html:5
 msgid "Validation Results for {0}"
@@ -4350,7 +4291,7 @@ msgstr ""
 msgid "Update Compatibility"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/addons/ajax_compat_update.html:4
+#: src/olympia/devhub/templates/devhub/addons/ajax_compat_update.html:4 src/olympia/devhub/templates/devhub/versions/edit.html:45
 msgid "Adjusting application information here will allow users to install your add-on even if the install manifest in the package indicates that the add-on is incompatible."
 msgstr ""
 
@@ -4362,9 +4303,9 @@ msgstr ""
 msgid "Add Another Application&hellip;"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/addons/ajax_compat_update.html:38 src/olympia/devhub/templates/devhub/addons/owner.html:86 src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:46
-#: src/olympia/devhub/templates/devhub/versions/list.html:351 src/olympia/devhub/templates/devhub/versions/list.html:353 src/olympia/templates/impala/base.html:132
-#: src/olympia/templates/impala/base.html:143 src/olympia/templates/impala/base.html:161 src/olympia/templates/impala/base.html:171
+#: src/olympia/devhub/templates/devhub/addons/ajax_compat_update.html:38 src/olympia/devhub/templates/devhub/addons/owner.html:86 src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:45
+#: src/olympia/devhub/templates/devhub/versions/list.html:349 src/olympia/devhub/templates/devhub/versions/list.html:351 src/olympia/templates/impala/base.html:129
+#: src/olympia/templates/impala/base.html:140 src/olympia/templates/impala/base.html:158 src/olympia/templates/impala/base.html:168
 msgid "Close"
 msgstr ""
 
@@ -4383,7 +4324,6 @@ msgid "<b>{0}</b> theme"
 msgid_plural "<b>{0}</b> themes"
 msgstr[0] ""
 msgstr[1] ""
-msgstr[2] ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit.html:3 src/olympia/devhub/templates/devhub/addons/listing/item_actions.html:25
 #: src/olympia/devhub/templates/devhub/addons/listing/item_actions_theme.html:7 src/olympia/devhub/templates/devhub/includes/addons_edit_nav.html:2
@@ -4399,7 +4339,7 @@ msgstr ""
 msgid "Manage Authors & License"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/addons/owner.html:29 src/olympia/editors/templates/editors/review.html:270
+#: src/olympia/devhub/templates/devhub/addons/owner.html:29 src/olympia/editors/helpers.py:362 src/olympia/editors/templates/editors/review.html:270
 msgid "Authors"
 msgstr "Autori"
 
@@ -4469,17 +4409,11 @@ msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/basic.html:52
 msgid ""
-"A short explanation of your add-on's basic\n"
-"                          functionality that is displayed in search and browse\n"
-"                          listings, as well as at the top of your add-on's\n"
-"                          details page. It is only relevant for listed add-ons."
+"A short explanation of your add-on's basic functionality that is displayed in search and browse listings, as well as at the top of your add-on's details page. It is only relevant for listed add-ons."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/basic.html:73
-msgid ""
-"Categories are the primary way users browse through add-ons.\n"
-"                        Choose any that fit your add-on's functionality for the most\n"
-"                        exposure. It is only relevant for listed add-ons."
+msgid "Categories are the primary way users browse through add-ons. Choose any that fit your add-on's functionality for the most exposure. It is only relevant for listed add-ons."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/basic.html:90
@@ -4489,11 +4423,7 @@ msgid ""
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/basic.html:119
-msgid ""
-"Tags help users find your add-on and should be short\n"
-"                        descriptors such as tabs, toolbar, or twitter.  You\n"
-"                        may have a maximum of {0} tags. It is only relevant\n"
-"                        for listed add-ons."
+msgid "Tags help users find your add-on and should be short descriptors such as tabs, toolbar, or twitter. You may have a maximum of {0} tags. It is only relevant for listed add-ons."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/basic.html:129 src/olympia/devhub/templates/devhub/personas/edit.html:97 src/olympia/devhub/templates/devhub/personas/submit.html:46
@@ -4501,7 +4431,6 @@ msgid "Comma-separated, minimum of {0} character."
 msgid_plural "Comma-separated, minimum of {0} characters."
 msgstr[0] ""
 msgstr[1] ""
-msgstr[2] ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/basic.html:132 src/olympia/devhub/templates/devhub/personas/edit.html:100 src/olympia/devhub/templates/devhub/personas/submit.html:49
 msgid "Example: dark, cinema, noir. Limit 20."
@@ -4512,7 +4441,6 @@ msgid "Reserved tag:"
 msgid_plural "Reserved tags:"
 msgstr[0] ""
 msgstr[1] ""
-msgstr[2] ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/details.html:5
 msgid "Add-on Details"
@@ -4523,11 +4451,7 @@ msgid "Add-on Details for {0}"
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/details.html:22
-msgid ""
-"A longer explanation of features,\n"
-"                          functionality, and other relevant information. This\n"
-"                          field is only displayed on the add-on's details\n"
-"                          page. It is only relevant for listed add-ons."
+msgid "A longer explanation of features, functionality, and other relevant information. This field is only displayed on the add-on's details page. It is only relevant for listed add-ons."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/details.html:44 src/olympia/translations/templates/translations/trans-menu.html:13
@@ -4535,10 +4459,7 @@ msgid "Default Locale"
 msgstr "Limba implicită"
 
 #: src/olympia/devhub/templates/devhub/addons/edit/details.html:45
-msgid ""
-"Information about your add-on is displayed in this locale\n"
-"                        unless you override it with a locale-specific translation.\n"
-"                        It is only relevant for listed add-ons."
+msgid "Information about your add-on is displayed in this locale unless you override it with a locale-specific translation. It is only relevant for listed add-ons."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/details.html:61 src/olympia/users/forms.py:311 src/olympia/users/templates/users/edit.html:122 src/olympia/users/templates/users/register.html:57
@@ -4548,10 +4469,8 @@ msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/details.html:63
 msgid ""
-"If your add-on has another homepage, enter its\n"
-"                          address here. If your website is localized into other\n"
-"                          languages multiple translations of this field can be\n"
-"                          added. It is only relevant for listed add-ons."
+"If your add-on has another homepage, enter its address here. If your website is localized into other languages multiple translations of this field can be added. It is only relevant for listed add-"
+"ons."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/media.html:3
@@ -4569,19 +4488,14 @@ msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/support.html:22
 msgid ""
-"If you wish to display an e-mail address for support\n"
-"                          inquiries, enter it here. If you have different\n"
-"                          addresses for each language multiple translations of\n"
-"                          this field can be added. It is only relevant for\n"
-"                          listed add-ons."
+"If you wish to display an e-mail address for support inquiries, enter it here. If you have different addresses for each language multiple translations of this field can be added. It is only "
+"relevant for listed add-ons."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/support.html:45
 msgid ""
-"If your add-on has a support website or forum, enter\n"
-"                          its address here. If your website is localized into\n"
-"                          other languages, multiple translations of this field can\n"
-"                          be added. It is only relevant for listed add-ons."
+"If your add-on has a support website or forum, enter its address here. If your website is localized into other languages, multiple translations of this field can be added. It is only relevant for "
+"listed add-ons."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:6
@@ -4595,11 +4509,8 @@ msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:23
 msgid ""
-"Any information end users may want to know that isn't\n"
-"                          necessarily applicable to the add-on summary or description.\n"
-"                          Common uses include listing known major bugs, information on\n"
-"                          how to report bugs, anticipated release date of a new version,\n"
-"                          etc. It is only relevant for listed add-ons."
+"Any information end users may want to know that isn't necessarily applicable to the add-on summary or description. Common uses include listing known major bugs, information on how to report bugs, "
+"anticipated release date of a new version, etc. It is only relevant for listed add-ons."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:46
@@ -4611,9 +4522,7 @@ msgid "Add-on Flags"
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:69
-msgid ""
-"These flags are used to classify add-ons. It is only\n"
-"                        relevant for listed add-ons."
+msgid "These flags are used to classify add-ons. It is only relevant for listed add-ons."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:74
@@ -4629,9 +4538,7 @@ msgid "View Source?"
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:90
-msgid ""
-"Whether the source of your add-on can be displayed in our\n"
-"                        online viewer. It is only relevant for listed add-ons."
+msgid "Whether the source of your add-on can be displayed in our online viewer. It is only relevant for listed add-ons."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:94
@@ -4647,10 +4554,7 @@ msgid "Public Stats?"
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:102
-msgid ""
-"Whether the download and usage stats of your add-on can\n"
-"                        be displayed in our online viewer.\n"
-"                        It is only relevant for listed add-ons."
+msgid "Whether the download and usage stats of your add-on can be displayed in our online viewer. It is only relevant for listed add-ons."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:107
@@ -4666,10 +4570,7 @@ msgid "Upgrade SDK?"
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:116
-msgid ""
-"If selected, we will try to automatically upgrade your\n"
-"                        add-on when a new version of the SDK is released.\n"
-"                        It is only relevant for listed add-ons."
+msgid "If selected, we will try to automatically upgrade your add-on when a new version of the SDK is released. It is only relevant for listed add-ons."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:121
@@ -4720,10 +4621,8 @@ msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/forms_shared/media.html:16
 msgid ""
-"Upload an icon for your add-on or choose from one of ours. The\n"
-"                      icon is displayed nearly everywhere your add-on is. Uploaded images\n"
-"                      must be one of the following image types: .png, .jpg.\n"
-"                      It is only relevant for listed add-ons."
+"Upload an icon for your add-on or choose from one of ours. The icon is displayed nearly everywhere your add-on is. Uploaded images must be one of the following image types: .png, .jpg. It is only "
+"relevant for listed add-ons."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/forms_shared/media.html:25
@@ -4736,9 +4635,7 @@ msgid "32x32px"
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/forms_shared/media.html:39
-msgid ""
-"Used in listings of add-ons, like search results\n"
-"                            and featured add-ons."
+msgid "Used in listings of add-ons, like search results and featured add-ons."
 msgstr ""
 
 #. The size of the icon
@@ -4833,16 +4730,14 @@ msgid "Deleting your add-on will permanently remove it from the site and prevent
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:24
-msgid ""
-"Enter the following text confirm your decision:\n"
-"           {slug}"
+msgid "Enter the following text confirm your decision: {slug}"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:34
+#: src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:33
 msgid "Please tell us why you are deleting your theme:"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:36
+#: src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:35
 msgid "Please tell us why you are deleting your add-on:"
 msgstr ""
 
@@ -4879,8 +4774,8 @@ msgstr "Versiune nouă"
 msgid "Daily statistics on downloads and users."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/addons/listing/item_actions.html:45 src/olympia/stats/templates/stats/stats.html:75 src/olympia/stats/templates/stats/stats.html:79
-#: src/olympia/stats/templates/stats/stats.html:81
+#: src/olympia/devhub/templates/devhub/addons/listing/item_actions.html:45 src/olympia/stats/templates/stats/stats.html:31 src/olympia/stats/templates/stats/stats.html:35
+#: src/olympia/stats/templates/stats/stats.html:37
 #, fuzzy
 msgid "Statistics"
 msgstr "Statistics"
@@ -4942,7 +4837,6 @@ msgid "<strong>{0}</strong> active user"
 msgid_plural "<strong>{0}</strong> active users"
 msgstr[0] ""
 msgstr[1] ""
-msgstr[2] ""
 
 #: src/olympia/devhub/templates/devhub/addons/submit/base.html:11
 msgid "Submit Add-on"
@@ -5001,10 +4895,7 @@ msgid "Your add-on has been submitted to the Full Review queue."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/submit/done.html:18
-msgid ""
-"You'll receive an email once it has been reviewed by an editor. In\n"
-"          the meantime, you and your friends can install it directly from its\n"
-"          details page:"
+msgid "You'll receive an email once it has been reviewed by an editor. In the meantime, you and your friends can install it directly from its details page:"
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/submit/done.html:27 src/olympia/devhub/templates/devhub/addons/submit/done.html:77 src/olympia/devhub/templates/devhub/personas/submit_done.html:16
@@ -5210,11 +5101,11 @@ msgstr ""
 msgid "Use the fields below to upload your add-on package and select any platform restrictions. After upload, a series of automated validation tests will be run on your file."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/addons/submit/upload.html:59 src/olympia/devhub/templates/devhub/versions/add_file_modal.html:39
+#: src/olympia/devhub/templates/devhub/addons/submit/upload.html:51 src/olympia/devhub/templates/devhub/versions/add_file_modal.html:28
 msgid "Which platforms is this file compatible with?"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/addons/submit/upload.html:67 src/olympia/devhub/templates/devhub/versions/add_file_modal.html:65
+#: src/olympia/devhub/templates/devhub/addons/submit/upload.html:59 src/olympia/devhub/templates/devhub/versions/add_file_modal.html:45
 msgid "Administrative overrides"
 msgstr ""
 
@@ -5324,8 +5215,8 @@ msgstr ""
 
 #: src/olympia/devhub/templates/devhub/docs/policies-contact.html:44
 msgid ""
-"If you've found a problem with the site, we'd love to fix it. Please <a href=\"https://github.com/mozilla/olympia/issues\">file a bug report</a> in GitHub, including the location of the problem and "
-"how you encountered it."
+"If you've found a problem with the site, we'd love to fix it. Please <a href=\"https://github.com/mozilla/addons/issues/new\">file a bug report</a> in GitHub, including the location of the problem "
+"and how you encountered it."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/docs/policies-maintenance.html:3 src/olympia/devhub/templates/devhub/docs/policies-maintenance.html:7
@@ -5892,7 +5783,7 @@ msgstr ""
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:282
 msgid ""
-"Add-ons that store or otherwise handle browsing data must support <a href=\"https://developer.mozilla.org/En/Supporting_private_browsing_mode\">Private Browsing Mode</a>.  During a Private Browsing "
+"Add-ons that store or otherwise handle browsing data must support <a href=\"https://developer.mozilla.org/En/Supporting_private_browsing_mode\">Private Browsing Mode</a>. During a Private Browsing "
 "session, no browsing data can be written to disk, and all of this data must be cleared when Firefox quits or the Private Browsing session ends."
 msgstr ""
 
@@ -6057,129 +5948,95 @@ msgstr ""
 msgid "How to get in touch with us regarding these policies or your add-on."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:6
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:10
 msgid "You have disabled this add-on"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:20
-msgid ""
-"Your add-on's listing is disabled and is not showing\n"
-"                             anywhere in our gallery or update service."
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:24
+msgid "Your add-on's listing is disabled and is not showing anywhere in our gallery or update service."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:25
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:27
 msgid "Please complete your add-on."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:29
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:30
 msgid "You will receive an email when the review is complete."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:34
-msgid ""
-"You will receive an email when the review is complete. Until\n"
-"                             then, your add-on is not listed in our gallery but can be\n"
-"                             accessed directly from its details page."
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:33
+msgid "You will receive an email when the review is complete. Until then, your add-on is not listed in our gallery but can be accessed directly from its details page."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:38 src/olympia/devhub/templates/devhub/includes/addon_details.html:48
-msgid ""
-"You will receive an email when the review is\n"
-"                             complete and your add-on is signed."
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:37 src/olympia/devhub/templates/devhub/includes/addon_details.html:45
+msgid "You will receive an email when the review is complete and your add-on is signed."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:44
-msgid ""
-"You will receive an email when the review is complete. Until\n"
-"                             then, your add-on is not listed in our gallery but can be\n"
-"                             accessed directly from its details page. "
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:41
+msgid "You will receive an email when the review is complete. Until then, your add-on is not listed in our gallery but can be accessed directly from its details page. "
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:54
-msgid ""
-"Your add-on is displayed in our gallery and users are\n"
-"                             receiving automatic updates."
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:49
+msgid "Your add-on is displayed in our gallery and users are receiving automatic updates."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:57
-msgid ""
-"Your add-on has been signed and can be bundled with an\n"
-"                             application installer."
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:52
+msgid "Your add-on has been signed and can be bundled with an application installer."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:63
-msgid ""
-"Your add-on was disabled by a site administrator and is no\n"
-"                             longer shown in our gallery. If you have any questions,\n"
-"                             please email amo-admins@mozilla.org."
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:56
+msgid "Your add-on was disabled by a site administrator and is no longer shown in our gallery. If you have any questions, please email amo-admins@mozilla.org."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:70
-msgid ""
-"Your add-on is displayed in our gallery as experimental\n"
-"                             and users are receiving automatic updates. Some features\n"
-"                             are unavailable to your add-on."
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:62
+msgid "Your add-on is displayed in our gallery as experimental and users are receiving automatic updates. Some features are unavailable to your add-on."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:74
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:66
 msgid "Your add-on has been signed."
 msgstr ""
 
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:69
+msgid ""
+"You will receive an email when the full review is complete. Until then, your add-on is displayed in our gallery as experimental and users are receiving automatic updates. Some features are "
+"unavailable to your add-on."
+msgstr ""
+
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:74
+msgid "You will receive an email when the full review is complete, making you able to bundle your add-on with an application installer."
+msgstr ""
+
 #: src/olympia/devhub/templates/devhub/includes/addon_details.html:79
-msgid ""
-"You will receive an email when the full review is complete.\n"
-"                             Until then, your add-on is displayed in our gallery as\n"
-"                             experimental and users are receiving automatic updates.\n"
-"                             Some features are unavailable to your add-on."
+msgid "All add-ons hosted in our gallery must now be reviewed by an editor. If you wish to continue hosting your add-on, please click to select a review process."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:84
-msgid ""
-"You will receive an email when the full review is\n"
-"                             complete, making you able to bundle your add-on with an\n"
-"                             application installer."
-msgstr ""
-
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:91
-msgid ""
-"All add-ons hosted in our gallery must now be reviewed by an\n"
-"                             editor. If you wish to continue hosting your add-on, please\n"
-"                             click to select a review process."
-msgstr ""
-
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:113
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:100
 msgid "Current Version:"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:115
-msgid ""
-"This is the version of your add-on that will\n"
-"                                           be installed if someone clicks the Install\n"
-"                                           button on addons.mozilla.org. It is only\n"
-"                                           relevant for listed add-ons."
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:102
+msgid "This is the version of your add-on that will be installed if someone clicks the Install button on addons.mozilla.org. It is only relevant for listed add-ons."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:123
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:110
 msgid "Created:"
 msgstr ""
 
 #. {0} is a date. dennis-ignore: E201
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:125 src/olympia/devhub/templates/devhub/includes/addon_details.html:131
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:112 src/olympia/devhub/templates/devhub/includes/addon_details.html:118
 #, python-format
 msgid "%%b %%e, %%Y"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:136
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:123
 msgid "Next Version:"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:138
-msgid ""
-"This is the newest uploaded version, however\n"
-"                                           it isn’t live on the site yet."
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:125
+msgid "This is the newest uploaded version, however it isn’t live on the site yet."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:144 src/olympia/devhub/templates/devhub/versions/list.html:30
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:130 src/olympia/devhub/templates/devhub/versions/list.html:30
 msgid "Queues are not reviewed strictly in order"
 msgstr ""
 
@@ -6247,9 +6104,7 @@ msgid "View the blog &#9658;"
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/includes/license_form.html:6
-msgid ""
-"Please choose a license appropriate for the rights you grant on your source code.\n"
-"                  It is only relevant for listed add-ons."
+msgid "Please choose a license appropriate for the rights you grant on your source code. It is only relevant for listed add-ons."
 msgstr ""
 
 #. {0} is a list of HTML tags.
@@ -6272,19 +6127,15 @@ msgid "Select <b>up to {0}</b> {1} category for this add-on:"
 msgid_plural "Select <b>up to {0}</b> {1} categories for this add-on:"
 msgstr[0] ""
 msgstr[1] ""
-msgstr[2] ""
 
 #: src/olympia/devhub/templates/devhub/includes/policy_form.html:4
 msgid ""
 "Users will be required to accept the following End-User License Agreement (EULA) prior to installing your add-on. The presence of a EULA significantly affects the number of downloads an add-on "
-"receives. Please note that a EULA is not the same as a code license, such as the GPL or MPL.\n"
-"                It is only relevant for listed add-ons."
+"receives. Please note that a EULA is not the same as a code license, such as the GPL or MPL.It is only relevant for listed add-ons."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/policy_form.html:21
-msgid ""
-"If your add-on transmits any data from the user's computer, a privacy policy is required that explains what data is sent and how it is used.\n"
-"                It is only relevant for listed add-ons."
+#: src/olympia/devhub/templates/devhub/includes/policy_form.html:24
+msgid "If your add-on transmits any data from the user's computer, a privacy policy is required that explains what data is sent and how it is used. It is only relevant for listed add-ons."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/includes/source_form_field.html:2
@@ -6453,12 +6304,8 @@ msgstr ""
 msgid "Add some tags to describe your Theme."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/personas/edit.html:106
-msgid ""
-"A short explanation of your theme's\n"
-"                                basic functionality that is displayed in\n"
-"                                search and browse listings, as well as at\n"
-"                                the top of your theme's details page."
+#: src/olympia/devhub/templates/devhub/personas/edit.html:106 src/olympia/devhub/templates/devhub/personas/submit.html:54
+msgid "A short explanation of your theme's basic functionality that is displayed in search and browse listings, as well as at the top of your theme's details page."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/personas/edit.html:122 src/olympia/devhub/templates/devhub/personas/submit.html:68
@@ -6528,7 +6375,7 @@ msgid "Upon upload and form submission, the AMO Team will review your updated de
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/personas/edit.html:241
-msgid "Your previously resubmitted design,  which is under pending review."
+msgid "Your previously resubmitted design, which is under pending review."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/personas/edit.html:245
@@ -6595,14 +6442,6 @@ msgstr ""
 
 #: src/olympia/devhub/templates/devhub/personas/submit.html:33
 msgid "Give your Theme a name."
-msgstr ""
-
-#: src/olympia/devhub/templates/devhub/personas/submit.html:54
-msgid ""
-"A short explanation of your theme's\n"
-"                                      basic functionality that is displayed in\n"
-"                                      search and browse listings, as well as at\n"
-"                                      the top of your theme's details page."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/personas/submit.html:198
@@ -6679,30 +6518,16 @@ msgstr ""
 msgid "Files added to reviewed versions must be reviewed before they will be available for download."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/add_file_modal.html:15
-#, python-format
-msgid ""
-"Submission of updates to unlisted add-ons for signing is currently in an open beta. Manual review may still be required for a large number of add-ons. Please <a href=\"%(url)s\" target=\"_blank"
-"\">report any bugs</a> that you encounter."
-msgstr ""
-
-#: src/olympia/devhub/templates/devhub/versions/add_file_modal.html:35
+#: src/olympia/devhub/templates/devhub/versions/add_file_modal.html:24
 msgid "Select the target platform for this file."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/add_file_modal.html:46
+#: src/olympia/devhub/templates/devhub/versions/add_file_modal.html:35
 msgid "Which review type would you like to nominate for?"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/add_file_modal.html:51
+#: src/olympia/devhub/templates/devhub/versions/add_file_modal.html:40
 msgid "Only publish this version to my beta channel."
-msgstr ""
-
-#: src/olympia/devhub/templates/devhub/versions/add_file_modal.html:54
-#, python-format
-msgid ""
-"The behavior of the beta channel has changed to accommodate <a href=\"%(addon_signing_url)s\" target=\"_blank\">mandatory add-on signing</a>. The new process is currently in an open beta, and may "
-"change significantly in the near future. Please <a href=\"%(issues_url)s\" target=\"_blank\">report any bugs</a> that you encounter."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/versions/edit.html:5
@@ -6727,19 +6552,10 @@ msgstr ""
 msgid "Upload Another File"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/edit.html:45
-msgid ""
-"Adjusting application information here will allow users to install your\n"
-"                          add-on even if the install manifest in the package indicates that the\n"
-"                          add-on is incompatible."
-msgstr ""
-
 #: src/olympia/devhub/templates/devhub/versions/edit.html:74
 msgid ""
-"Information about changes in this release, new features,\n"
-"                              known bugs, and other useful information specific to this\n"
-"                              release/version. This information is also shown in the\n"
-"                              Add-ons Manager when updating."
+"Information about changes in this release, new features, known bugs, and other useful information specific to this release/version. This information is also shown in the Add-ons Manager when "
+"updating."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/versions/edit.html:99
@@ -6751,10 +6567,7 @@ msgid "Notes for Reviewers"
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/versions/edit.html:114
-msgid ""
-"Optionally, enter any information that may be useful\n"
-"                              to the Editor reviewing this add-on, such as test\n"
-"                              account information."
+msgid "Optionally, enter any information that may be useful to the Editor reviewing this add-on, such as test account information."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/versions/edit.html:127
@@ -6806,7 +6619,6 @@ msgid "{0} file"
 msgid_plural "{0} files"
 msgstr[0] ""
 msgstr[1] ""
-msgstr[2] ""
 
 #: src/olympia/devhub/templates/devhub/versions/list.html:25
 msgid "0 files"
@@ -6833,7 +6645,7 @@ msgstr ""
 msgid "Request Preliminary Review"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:80 src/olympia/devhub/templates/devhub/versions/list.html:327 src/olympia/devhub/templates/devhub/versions/list.html:350
+#: src/olympia/devhub/templates/devhub/versions/list.html:80 src/olympia/devhub/templates/devhub/versions/list.html:325 src/olympia/devhub/templates/devhub/versions/list.html:348
 msgid "Cancel Review Request"
 msgstr ""
 
@@ -6862,7 +6674,7 @@ msgid "Unlisted:"
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/versions/list.html:114
-msgid "Not distributed on {0}. Developers will upload new versions for signing and distribute the add-ons on their own. (beta)"
+msgid "Not distributed on {0}. Developers will upload new versions for signing and distribute the add-ons on their own."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/versions/list.html:122
@@ -6927,81 +6739,73 @@ msgid "<strong>Important:</strong> Once a version has been deleted, you may not 
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/versions/list.html:230
-msgid ""
-"Deleting a version which has already been reviewed\n"
-"               may also cause a significant delay in the review of\n"
-"               your next update."
-msgstr ""
-
-#: src/olympia/devhub/templates/devhub/versions/list.html:233
 msgid "Are you sure you wish to delete this version?"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:238
+#: src/olympia/devhub/templates/devhub/versions/list.html:235
 msgid "Delete Version"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:240
+#: src/olympia/devhub/templates/devhub/versions/list.html:237
 msgid "Disable Version"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:247
+#: src/olympia/devhub/templates/devhub/versions/list.html:244
 msgid "Add a new Version"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:249
+#: src/olympia/devhub/templates/devhub/versions/list.html:246
 msgid "Add Version"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:256 src/olympia/devhub/templates/devhub/versions/list.html:274
+#: src/olympia/devhub/templates/devhub/versions/list.html:253 src/olympia/devhub/templates/devhub/versions/list.html:279
 msgid "Hide Add-on"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:259
+#: src/olympia/devhub/templates/devhub/versions/list.html:256
 msgid "Hiding your add-on will prevent it from appearing anywhere in our gallery and will stop users from receiving automatic updates."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:265
+#: src/olympia/devhub/templates/devhub/versions/list.html:263
+msgid "The files awaiting review will be disabled and you will need to upload new versions."
+msgstr ""
+
+#: src/olympia/devhub/templates/devhub/versions/list.html:270
 msgid "Are you sure you wish to hide your add-on?"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:286 src/olympia/devhub/templates/devhub/versions/list.html:315
+#: src/olympia/devhub/templates/devhub/versions/list.html:291 src/olympia/devhub/templates/devhub/versions/list.html:313
 msgid "Unlist Add-on"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:289
+#: src/olympia/devhub/templates/devhub/versions/list.html:294
 #, python-format
 msgid ""
 "Unlisting your add-on will make it (and each of its versions/files) invisible on this website. It won't show up in searches, won't have a public facing page, and won't be updated automatically for "
-"current users.  It is recommended for unlisted add-ons to provide a custom <a href=\"%(update_url)s\" target=\"_blank\">updateURL</a> in their manifest file for automatic updates."
+"current users. It is recommended for unlisted add-ons to provide a custom <a href=\"%(update_url)s\" target=\"_blank\">updateURL</a> in their manifest file for automatic updates."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:299
-#, python-format
-msgid "Switching add-ons to unlisted is currently in an open beta. Please <a href=\"%(url)s\" target=\"_blank\">report any bugs</a> that you encounter."
-msgstr ""
-
-#: src/olympia/devhub/templates/devhub/versions/list.html:305
+#: src/olympia/devhub/templates/devhub/versions/list.html:303
 msgid "Unlisting an add-on is irreversible!"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:305
+#: src/olympia/devhub/templates/devhub/versions/list.html:303
 msgid "An unlisted add-on cannot be switched to be listed."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:307
+#: src/olympia/devhub/templates/devhub/versions/list.html:305
 msgid "Are you sure you wish to unlist your add-on?"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:330
+#: src/olympia/devhub/templates/devhub/versions/list.html:328
 msgid "Canceling your review request will leave your add-on as preliminarily reviewed."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:335
+#: src/olympia/devhub/templates/devhub/versions/list.html:333
 msgid "Canceling your review request will mark your add-on incomplete. If you do not complete your add-on after several days by re-requesting review, it will be deleted."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:343
+#: src/olympia/devhub/templates/devhub/versions/list.html:341
 msgid "Are you sure you wish to cancel your review request?"
 msgstr ""
 
@@ -7340,19 +7144,19 @@ msgstr ""
 msgid "Search by add-on name / author email"
 msgstr ""
 
-#: src/olympia/editors/forms.py:103
+#: src/olympia/editors/forms.py:103 src/olympia/editors/forms.py:244 src/olympia/editors/forms.py:257
 msgid "yes"
 msgstr ""
 
-#: src/olympia/editors/forms.py:104
+#: src/olympia/editors/forms.py:104 src/olympia/editors/forms.py:244 src/olympia/editors/forms.py:257
 msgid "no"
 msgstr ""
 
-#: src/olympia/editors/forms.py:105
+#: src/olympia/editors/forms.py:105 src/olympia/editors/forms.py:245
 msgid "Admin Flag"
 msgstr ""
 
-#: src/olympia/editors/forms.py:113
+#: src/olympia/editors/forms.py:113 src/olympia/editors/forms.py:253
 msgid "Max. Version"
 msgstr ""
 
@@ -7364,55 +7168,59 @@ msgstr ""
 msgid "Add-on Types"
 msgstr ""
 
-#: src/olympia/editors/forms.py:126 src/olympia/editors/helpers.py:267
+#: src/olympia/editors/forms.py:126 src/olympia/editors/helpers.py:279
 msgid "Platforms"
 msgstr "Platforme"
 
+#: src/olympia/editors/forms.py:237
+msgid "Search by add-on name / author email / guid"
+msgstr ""
+
 #. L10n: 0 = platform, 1 = filename, 2 = status message
-#: src/olympia/editors/forms.py:238
+#: src/olympia/editors/forms.py:342
 #, python-format
 msgid "<strong>%s</strong> &middot; %s &middot; %s"
 msgstr ""
 
-#: src/olympia/editors/forms.py:252
+#: src/olympia/editors/forms.py:356
 msgid "Comments:"
 msgstr ""
 
-#: src/olympia/editors/forms.py:256
+#: src/olympia/editors/forms.py:360
 msgid "Operating systems:"
 msgstr ""
 
-#: src/olympia/editors/forms.py:258
+#: src/olympia/editors/forms.py:362
 msgid "Applications:"
 msgstr ""
 
-#: src/olympia/editors/forms.py:260
+#: src/olympia/editors/forms.py:364
 msgid "Notify me the next time this add-on is updated. (Subsequent updates will not generate an email)"
 msgstr ""
 
-#: src/olympia/editors/forms.py:265
+#: src/olympia/editors/forms.py:369
 msgid "Clear Admin Review Flag"
 msgstr ""
 
-#: src/olympia/editors/forms.py:267
+#: src/olympia/editors/forms.py:371
 msgid "Clear more info requested flag"
 msgstr ""
 
-#: src/olympia/editors/forms.py:281
+#: src/olympia/editors/forms.py:385
 msgid "Choose a canned response..."
 msgstr ""
 
 #. L10n: Description of what can be searched for.
-#: src/olympia/editors/forms.py:324
+#: src/olympia/editors/forms.py:423
 msgid "theme name"
 msgstr ""
 
-#: src/olympia/editors/forms.py:350
+#: src/olympia/editors/forms.py:449
 msgid "Someone else is reviewing this theme."
 msgstr ""
 
 #. L10n: Description of what can be searched for.
-#: src/olympia/editors/forms.py:447
+#: src/olympia/editors/forms.py:546
 msgid "app, reviewer, or comment"
 msgstr ""
 
@@ -7428,257 +7236,264 @@ msgstr ""
 msgid "Rejected or Unreviewed"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:123 src/olympia/editors/helpers.py:136
+#: src/olympia/editors/helpers.py:125 src/olympia/editors/helpers.py:138
 msgid "Queue"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:124 src/olympia/editors/templates/editors/base.html:50 src/olympia/editors/templates/editors/base.html:65
+#: src/olympia/editors/helpers.py:126 src/olympia/editors/templates/editors/base.html:50 src/olympia/editors/templates/editors/base.html:65
 msgid "Pending Updates"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:125 src/olympia/editors/templates/editors/base.html:48 src/olympia/editors/templates/editors/base.html:63
+#: src/olympia/editors/helpers.py:127 src/olympia/editors/templates/editors/base.html:48 src/olympia/editors/templates/editors/base.html:63
 msgid "Full Reviews"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:126 src/olympia/editors/templates/editors/base.html:52 src/olympia/editors/templates/editors/base.html:67
+#: src/olympia/editors/helpers.py:128 src/olympia/editors/templates/editors/base.html:52 src/olympia/editors/templates/editors/base.html:67
 msgid "Preliminary Reviews"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:127 src/olympia/editors/templates/editors/base.html:54
+#: src/olympia/editors/helpers.py:129 src/olympia/editors/templates/editors/base.html:54
 msgid "Moderated Reviews"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:128 src/olympia/editors/templates/editors/base.html:46
+#: src/olympia/editors/helpers.py:130 src/olympia/editors/templates/editors/base.html:46
 msgid "Fast Track"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:130
+#: src/olympia/editors/helpers.py:132
 msgid "Pending Themes"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:131 src/olympia/editors/templates/editors/themes/queue.html:4
+#: src/olympia/editors/helpers.py:133 src/olympia/editors/templates/editors/themes/queue.html:4
 msgid "Flagged Themes"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:132
+#: src/olympia/editors/helpers.py:134
 msgid "Update Themes"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:137
+#: src/olympia/editors/helpers.py:139
 msgid "Unlisted Pending Updates"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:138
+#: src/olympia/editors/helpers.py:140
 msgid "Unlisted Full Reviews"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:139
+#: src/olympia/editors/helpers.py:141
 msgid "Unlisted Preliminary Reviews"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:170
+#: src/olympia/editors/helpers.py:142
+msgid "Unlisted All Add-ons"
+msgstr ""
+
+#: src/olympia/editors/helpers.py:173
 msgid "Fast Track ({0})"
 msgid_plural "Fast Track ({0})"
 msgstr[0] ""
 msgstr[1] ""
-msgstr[2] ""
 
-#: src/olympia/editors/helpers.py:175
+#: src/olympia/editors/helpers.py:178
 msgid "Full Review ({0})"
 msgid_plural "Full Reviews ({0})"
 msgstr[0] ""
 msgstr[1] ""
-msgstr[2] ""
 
-#: src/olympia/editors/helpers.py:180
+#: src/olympia/editors/helpers.py:183
 msgid "Pending Update ({0})"
 msgid_plural "Pending Updates ({0})"
 msgstr[0] ""
 msgstr[1] ""
-msgstr[2] ""
 
-#: src/olympia/editors/helpers.py:185
+#: src/olympia/editors/helpers.py:188
 msgid "Preliminary Review ({0})"
 msgid_plural "Preliminary Reviews ({0})"
 msgstr[0] ""
 msgstr[1] ""
-msgstr[2] ""
 
-#: src/olympia/editors/helpers.py:190
+#: src/olympia/editors/helpers.py:193
 msgid "Moderated Review ({0})"
 msgid_plural "Moderated Reviews ({0})"
 msgstr[0] ""
 msgstr[1] ""
-msgstr[2] ""
 
-#: src/olympia/editors/helpers.py:196
+#: src/olympia/editors/helpers.py:199
 msgid "Unlisted Full Review ({0})"
 msgid_plural "Unlisted Full Reviews ({0})"
 msgstr[0] ""
 msgstr[1] ""
-msgstr[2] ""
 
-#: src/olympia/editors/helpers.py:201
+#: src/olympia/editors/helpers.py:204
 msgid "Unlisted Pending Update ({0})"
 msgid_plural "Unlisted Pending Updates ({0})"
 msgstr[0] ""
 msgstr[1] ""
-msgstr[2] ""
 
-#: src/olympia/editors/helpers.py:206
+#: src/olympia/editors/helpers.py:209
 msgid "Unlisted Preliminary Review ({0})"
 msgid_plural "Unlisted Preliminary Reviews ({0})"
 msgstr[0] ""
 msgstr[1] ""
-msgstr[2] ""
 
-#: src/olympia/editors/helpers.py:261
-msgid "Addon"
-msgstr ""
+#: src/olympia/editors/helpers.py:214
+msgid "Unlisted All Add-ons ({0})"
+msgid_plural "Unlisted All Add-ons ({0})"
+msgstr[0] ""
+msgstr[1] ""
 
-#: src/olympia/editors/helpers.py:262
+#: src/olympia/editors/helpers.py:274
 msgid "Type"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:263
+#: src/olympia/editors/helpers.py:275
 msgid "Waiting Time"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:264 src/olympia/editors/templates/editors/review.html:285
+#: src/olympia/editors/helpers.py:276 src/olympia/editors/templates/editors/review.html:285
 msgid "Flags"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:265
+#: src/olympia/editors/helpers.py:277
 msgid "Applications"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:270
+#: src/olympia/editors/helpers.py:282
 msgid "Additional"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:285
+#: src/olympia/editors/helpers.py:302
 msgid "Site Specific"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:287
+#: src/olympia/editors/helpers.py:304
 msgid "Requires External Software"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:289
+#: src/olympia/editors/helpers.py:306
 msgid "Binary Components"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:313
+#: src/olympia/editors/helpers.py:339
 msgid "moments ago"
 msgstr ""
 
 #. L10n: first argument is number of minutes
-#: src/olympia/editors/helpers.py:316
+#: src/olympia/editors/helpers.py:342
 msgid "{0} minute"
 msgid_plural "{0} minutes"
 msgstr[0] ""
 msgstr[1] ""
-msgstr[2] ""
 
 #. L10n: first argument is number of hours
-#: src/olympia/editors/helpers.py:320
+#: src/olympia/editors/helpers.py:346
 msgid "{0} hour"
 msgid_plural "{0} hours"
 msgstr[0] ""
 msgstr[1] ""
-msgstr[2] ""
 
 #. L10n: first argument is number of days
-#: src/olympia/editors/helpers.py:324
+#: src/olympia/editors/helpers.py:350
 msgid "{0} day"
 msgid_plural "{0} days"
 msgstr[0] ""
 msgstr[1] ""
-msgstr[2] ""
 
-#: src/olympia/editors/helpers.py:488
+#: src/olympia/editors/helpers.py:364
+msgid "Last Review"
+msgstr ""
+
+#: src/olympia/editors/helpers.py:366
+msgid "Last Update"
+msgstr ""
+
+#: src/olympia/editors/helpers.py:387
+msgid "No Reviews"
+msgstr ""
+
+#: src/olympia/editors/helpers.py:561
 msgid "Push to public"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:490
+#: src/olympia/editors/helpers.py:563
 msgid "Grant full review"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:505
+#: src/olympia/editors/helpers.py:578
 msgid "Request more information"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:508
+#: src/olympia/editors/helpers.py:581
 msgid "Request super-review"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:519
+#: src/olympia/editors/helpers.py:592
 msgid "Grant preliminary review"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:520
+#: src/olympia/editors/helpers.py:593
 msgid "This will mark the files as preliminarily reviewed."
 msgstr ""
 
-#: src/olympia/editors/helpers.py:522
+#: src/olympia/editors/helpers.py:595
 msgid "Use this form to request more information from the author. They will receive an email and be able to answer here. You will be notified by email when they reply."
 msgstr ""
 
-#: src/olympia/editors/helpers.py:526
+#: src/olympia/editors/helpers.py:599
 msgid ""
 "If you have concerns about this add-on's security, copyright issues, or other concerns that an administrator should look into, enter your comments in the area below. They will be sent to "
 "administrators, not the author."
 msgstr ""
 
-#: src/olympia/editors/helpers.py:532
+#: src/olympia/editors/helpers.py:605
 msgid "This will reject the add-on and remove it from the review queue."
 msgstr ""
 
-#: src/olympia/editors/helpers.py:534
-msgid "Make a comment on this version.  The author won't be able to see this."
+#: src/olympia/editors/helpers.py:607
+msgid "Make a comment on this version. The author won't be able to see this."
 msgstr ""
 
-#: src/olympia/editors/helpers.py:538
+#: src/olympia/editors/helpers.py:611
 msgid "This will reject the files and remove them from the review queue."
 msgstr ""
 
-#: src/olympia/editors/helpers.py:542
+#: src/olympia/editors/helpers.py:615
 msgid "This will mark the add-on as preliminarily reviewed. Future versions will undergo preliminary review."
 msgstr ""
 
-#: src/olympia/editors/helpers.py:547
+#: src/olympia/editors/helpers.py:620
 msgid "This will mark the files as preliminarily reviewed. Future versions will undergo preliminary review."
 msgstr ""
 
-#: src/olympia/editors/helpers.py:552
+#: src/olympia/editors/helpers.py:625
 msgid "Retain preliminary review"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:553
+#: src/olympia/editors/helpers.py:626
 msgid "This will retain the add-on as preliminarily reviewed. Future versions will undergo preliminary review."
 msgstr ""
 
-#: src/olympia/editors/helpers.py:558
+#: src/olympia/editors/helpers.py:631
 msgid "This will approve a sandboxed version of a public add-on to appear on the public side."
 msgstr ""
 
-#: src/olympia/editors/helpers.py:561
+#: src/olympia/editors/helpers.py:634
 msgid "This will reject a version of a public add-on and remove it from the queue."
 msgstr ""
 
-#: src/olympia/editors/helpers.py:564
+#: src/olympia/editors/helpers.py:637
 msgid "This will mark the add-on and its most recent version and files as public. Future versions will go into the sandbox until they are reviewed by an editor."
 msgstr ""
 
-#: src/olympia/editors/helpers.py:637
+#: src/olympia/editors/helpers.py:714
 msgid "add-on"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:940 src/olympia/editors/helpers.py:960
+#: src/olympia/editors/helpers.py:1020 src/olympia/editors/helpers.py:1040
 msgid "Flagged"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:944 src/olympia/editors/helpers.py:963
+#: src/olympia/editors/helpers.py:1024 src/olympia/editors/helpers.py:1043
 msgid "Updates"
 msgstr ""
 
@@ -7730,56 +7545,56 @@ msgstr ""
 msgid "A question about your Theme submission"
 msgstr ""
 
-#: src/olympia/editors/views.py:144
+#: src/olympia/editors/views.py:146
 msgid "New Add-ons (Under 5 days)"
 msgstr ""
 
-#: src/olympia/editors/views.py:145
+#: src/olympia/editors/views.py:147
 msgid "Passable (5 to 10 days)"
 msgstr ""
 
-#: src/olympia/editors/views.py:146
+#: src/olympia/editors/views.py:148
 msgid "Overdue (Over 10 days)"
 msgstr ""
 
-#: src/olympia/editors/views.py:532
+#: src/olympia/editors/views.py:539
 msgid "An unknown error occurred"
 msgstr ""
 
-#: src/olympia/editors/views.py:587
+#: src/olympia/editors/views.py:592
 msgid "Self-reviews are not allowed."
 msgstr ""
 
-#: src/olympia/editors/views.py:609
+#: src/olympia/editors/views.py:613
 msgid "Review successfully processed."
 msgstr ""
 
-#: src/olympia/editors/views.py:807
+#: src/olympia/editors/views.py:812
 msgid "was approved"
 msgstr ""
 
-#: src/olympia/editors/views.py:808
+#: src/olympia/editors/views.py:813
 msgid "given preliminary review"
 msgstr ""
 
-#: src/olympia/editors/views.py:809
+#: src/olympia/editors/views.py:814
 msgid "rejected"
 msgstr ""
 
-#: src/olympia/editors/views.py:810
+#: src/olympia/editors/views.py:815
 msgctxt "editors_review_history_nominated_adminreview"
 msgid "escalated"
 msgstr ""
 
-#: src/olympia/editors/views.py:812
+#: src/olympia/editors/views.py:817
 msgid "needs more information"
 msgstr ""
 
-#: src/olympia/editors/views.py:813
+#: src/olympia/editors/views.py:818
 msgid "needs super review"
 msgstr ""
 
-#: src/olympia/editors/views.py:814
+#: src/olympia/editors/views.py:819
 msgid "commented"
 msgstr ""
 
@@ -7788,7 +7603,6 @@ msgid "{0} theme review successfully processed (+{1} points, {2} total)."
 msgid_plural "{0} theme reviews successfully processed (+{1} points, {2} total)."
 msgstr[0] ""
 msgstr[1] ""
-msgstr[2] ""
 
 #: src/olympia/editors/views_themes.py:341
 msgid "Your theme locks have successfully been released. Other reviewers may now review those released themes. You may have to refresh the page to see the changes reflected in the table below."
@@ -7825,29 +7639,29 @@ msgstr ""
 msgid "Unlisted Queues"
 msgstr ""
 
-#: src/olympia/editors/templates/editors/base.html:72 src/olympia/editors/templates/editors/performance.html:6
+#: src/olympia/editors/templates/editors/base.html:74 src/olympia/editors/templates/editors/performance.html:6
 #, fuzzy
 msgid "Performance"
 msgstr "Performance"
 
-#: src/olympia/editors/templates/editors/base.html:75 src/olympia/editors/templates/editors/themes/base.html:19 src/olympia/editors/templates/editors/themes/base.html:38
+#: src/olympia/editors/templates/editors/base.html:77 src/olympia/editors/templates/editors/themes/base.html:19 src/olympia/editors/templates/editors/themes/base.html:38
 msgid "Logs"
 msgstr ""
 
-#: src/olympia/editors/templates/editors/base.html:78 src/olympia/editors/templates/editors/reviewlog.html:4 src/olympia/editors/templates/editors/reviewlog.html:27
+#: src/olympia/editors/templates/editors/base.html:80 src/olympia/editors/templates/editors/reviewlog.html:4 src/olympia/editors/templates/editors/reviewlog.html:27
 msgid "Add-on Review Log"
 msgstr ""
 
-#: src/olympia/editors/templates/editors/base.html:80 src/olympia/editors/templates/editors/eventlog.html:4 src/olympia/editors/templates/editors/eventlog.html:8
+#: src/olympia/editors/templates/editors/base.html:82 src/olympia/editors/templates/editors/eventlog.html:4 src/olympia/editors/templates/editors/eventlog.html:8
 #: src/olympia/editors/templates/editors/eventlog_detail.html:4
 msgid "Moderated Review Log"
 msgstr ""
 
-#: src/olympia/editors/templates/editors/base.html:82 src/olympia/editors/templates/editors/beta_signed_log.html:4 src/olympia/editors/templates/editors/beta_signed_log.html:8
+#: src/olympia/editors/templates/editors/base.html:84 src/olympia/editors/templates/editors/beta_signed_log.html:4 src/olympia/editors/templates/editors/beta_signed_log.html:8
 msgid "Signed Beta Files Log"
 msgstr ""
 
-#: src/olympia/editors/templates/editors/base.html:87 src/olympia/editors/templates/editors/includes/daily-message.html:4
+#: src/olympia/editors/templates/editors/base.html:89 src/olympia/editors/templates/editors/includes/daily-message.html:4
 msgid "Announcement"
 msgstr ""
 
@@ -7907,21 +7721,18 @@ msgid "Full Review ({num})"
 msgid_plural "Full Reviews ({num})"
 msgstr[0] ""
 msgstr[1] ""
-msgstr[2] ""
 
 #: src/olympia/editors/templates/editors/home.html:18
 msgid "Pending Update ({num})"
 msgid_plural "Pending Updates ({num})"
 msgstr[0] ""
 msgstr[1] ""
-msgstr[2] ""
 
 #: src/olympia/editors/templates/editors/home.html:25
 msgid "Preliminary Review ({num})"
 msgid_plural "Preliminary Reviews ({num})"
 msgstr[0] ""
 msgstr[1] ""
-msgstr[2] ""
 
 #: src/olympia/editors/templates/editors/home.html:36 src/olympia/editors/templates/editors/home.html:86
 msgid "Current waiting times:"
@@ -7932,7 +7743,6 @@ msgid "{0} add-on"
 msgid_plural "{0} add-ons"
 msgstr[0] ""
 msgstr[1] ""
-msgstr[2] ""
 
 #: src/olympia/editors/templates/editors/home.html:45 src/olympia/editors/templates/editors/home.html:95
 #, python-format
@@ -7944,21 +7754,18 @@ msgid "Unlisted Full Review ({num})"
 msgid_plural "Unlisted Full Reviews ({num})"
 msgstr[0] ""
 msgstr[1] ""
-msgstr[2] ""
 
 #: src/olympia/editors/templates/editors/home.html:68
 msgid "Unlisted Pending Update ({num})"
 msgid_plural "Unlisted Pending Updates ({num})"
 msgstr[0] ""
 msgstr[1] ""
-msgstr[2] ""
 
 #: src/olympia/editors/templates/editors/home.html:75
 msgid "Unlisted Preliminary Review ({num})"
 msgid_plural "Unlisted Preliminary Reviews ({num})"
 msgstr[0] ""
 msgstr[1] ""
-msgstr[2] ""
 
 #: src/olympia/editors/templates/editors/home.html:109 src/olympia/editors/templates/editors/performance.html:37 src/olympia/editors/templates/editors/themes/home.html:54
 msgid "Total Reviews"
@@ -7982,7 +7789,6 @@ msgid "Moderated Review ({num})"
 msgid_plural "Moderated Reviews ({num})"
 msgstr[0] ""
 msgstr[1] ""
-msgstr[2] ""
 
 #: src/olympia/editors/templates/editors/leaderboard.html:3 src/olympia/editors/templates/editors/includes/reviewers_score_bar.html:56
 msgid "Reviewer Leaderboard"
@@ -8076,45 +7882,45 @@ msgstr ""
 msgid "clear search"
 msgstr ""
 
-#: src/olympia/editors/templates/editors/queue.html:72 src/olympia/editors/templates/editors/queue.html:122
+#: src/olympia/editors/templates/editors/queue.html:78 src/olympia/editors/templates/editors/queue.html:128
 msgid "Process Reviews"
 msgstr ""
 
-#: src/olympia/editors/templates/editors/queue.html:80
+#: src/olympia/editors/templates/editors/queue.html:86
 msgid "Moderation actions:"
 msgstr ""
 
-#: src/olympia/editors/templates/editors/queue.html:90
+#: src/olympia/editors/templates/editors/queue.html:96
 #, python-format
 msgid "by %(user)s on %(date)s %(stars)s (%(locale)s)"
 msgstr ""
 
-#: src/olympia/editors/templates/editors/queue.html:106
+#: src/olympia/editors/templates/editors/queue.html:112
 #, python-format
 msgid "<strong>%(reason)s</strong> <span class=\"light\">Flagged by %(user)s on %(date)s</span>"
 msgstr ""
 
-#: src/olympia/editors/templates/editors/queue.html:119
-msgid "All reviews have been moderated.  Good work!"
+#: src/olympia/editors/templates/editors/queue.html:125
+msgid "All reviews have been moderated. Good work!"
 msgstr ""
 
-#: src/olympia/editors/templates/editors/queue.html:161
+#: src/olympia/editors/templates/editors/queue.html:167
 msgid "Version Notes / Notes for Reviewer"
 msgstr ""
 
-#: src/olympia/editors/templates/editors/queue.html:169
+#: src/olympia/editors/templates/editors/queue.html:175
 msgid "There are currently no add-ons of this type to review."
 msgstr ""
 
-#: src/olympia/editors/templates/editors/queue.html:181 src/olympia/editors/templates/editors/themes/queue_list.html:85
+#: src/olympia/editors/templates/editors/queue.html:187 src/olympia/editors/templates/editors/themes/queue_list.html:85
 msgid "Helpful Links:"
 msgstr ""
 
-#: src/olympia/editors/templates/editors/queue.html:182
+#: src/olympia/editors/templates/editors/queue.html:188
 msgid "Add-on Policy"
 msgstr ""
 
-#: src/olympia/editors/templates/editors/queue.html:184
+#: src/olympia/editors/templates/editors/queue.html:190
 msgid "Editors' Guide"
 msgstr ""
 
@@ -8177,10 +7983,7 @@ msgid "<strong>Warning!</strong> Another user was viewing this page before you."
 msgstr ""
 
 #: src/olympia/editors/templates/editors/review.html:237
-msgid ""
-"The whiteboard is the place to exchange information relevant to\n"
-"               this addon (whatever the version), between the developer and the\n"
-"               editor. This is visible and editable by both."
+msgid "The whiteboard is the place to exchange information relevant to this addon (whatever the version), between the developer and the editor. This is visible and editable by both."
 msgstr ""
 
 #: src/olympia/editors/templates/editors/review.html:241
@@ -8324,21 +8127,18 @@ msgid "{num} Pending Theme Review"
 msgid_plural "{num} Pending Theme Reviews"
 msgstr[0] ""
 msgstr[1] ""
-msgstr[2] ""
 
 #: src/olympia/editors/templates/editors/themes/home.html:27
 msgid "{num} Flagged Review"
 msgid_plural "{num} Flagged Reviews"
 msgstr[0] ""
 msgstr[1] ""
-msgstr[2] ""
 
 #: src/olympia/editors/templates/editors/themes/home.html:34
 msgid "{num} Update"
 msgid_plural "{num} Updates"
 msgstr[0] ""
 msgstr[1] ""
-msgstr[2] ""
 
 #: src/olympia/editors/templates/editors/themes/logs.html:4
 msgid "Theme Review Log"
@@ -8457,7 +8257,7 @@ msgstr ""
 msgid "Describe your reason for flagging"
 msgstr ""
 
-#: src/olympia/files/forms.py:88
+#: src/olympia/files/forms.py:90
 msgid "Cannot diff a version against itself"
 msgstr ""
 
@@ -8492,51 +8292,51 @@ msgstr ""
 msgid "There was an error accessing file %s."
 msgstr ""
 
-#: src/olympia/files/utils.py:343
+#: src/olympia/files/utils.py:340
 msgid "Could not parse uploaded file."
 msgstr ""
 
-#: src/olympia/files/utils.py:380
+#: src/olympia/files/utils.py:377
 msgid "Invalid file name in archive: {0}"
 msgstr ""
 
-#: src/olympia/files/utils.py:388
+#: src/olympia/files/utils.py:385
 msgid "File exceeding size limit in archive: {0}"
 msgstr ""
 
-#: src/olympia/files/utils.py:439
+#: src/olympia/files/utils.py:436
 msgid "Invalid archive."
 msgstr ""
 
-#: src/olympia/files/utils.py:529 src/olympia/files/utils.py:532
+#: src/olympia/files/utils.py:526 src/olympia/files/utils.py:529
 msgid "Could not parse the manifest file."
 msgstr ""
 
-#: src/olympia/files/utils.py:551
+#: src/olympia/files/utils.py:548
 msgid "Could not find an add-on ID."
 msgstr ""
 
-#: src/olympia/files/utils.py:554
+#: src/olympia/files/utils.py:551
 msgid "Add-on ID must be 64 characters or less."
 msgstr ""
 
-#: src/olympia/files/utils.py:556
+#: src/olympia/files/utils.py:553
 msgid "Add-on ID doesn't match add-on."
 msgstr ""
 
-#: src/olympia/files/utils.py:564
+#: src/olympia/files/utils.py:561
 msgid "Duplicate add-on ID found."
 msgstr ""
 
-#: src/olympia/files/utils.py:567
+#: src/olympia/files/utils.py:564
 msgid "Version numbers should have fewer than 32 characters."
 msgstr ""
 
-#: src/olympia/files/utils.py:570
+#: src/olympia/files/utils.py:567
 msgid "Version numbers should only contain letters, numbers, and these punctuation characters: +*.-_."
 msgstr ""
 
-#: src/olympia/files/utils.py:587
+#: src/olympia/files/utils.py:584
 msgid "<em:type> doesn't match add-on"
 msgstr ""
 
@@ -8635,6 +8435,10 @@ msgstr ""
 
 #: src/olympia/files/templates/files/viewer.html:134
 msgid "Fetching file."
+msgstr ""
+
+#: src/olympia/legacy_api/views.py:255
+msgid "Not implemented yet."
 msgstr ""
 
 #: src/olympia/lib/constants.py:6
@@ -9293,10 +9097,6 @@ msgstr ""
 msgid "Zimbabwe Dollar"
 msgstr ""
 
-#: src/olympia/lib/video/ffmpeg.py:112 src/olympia/lib/video/totem.py:81
-msgid "Videos must be in WebM."
-msgstr ""
-
 #: src/olympia/pages/templates/pages/about.lhtml:3 src/olympia/pages/templates/pages/about.lhtml:10
 msgid "About Mozilla Add-ons"
 msgstr ""
@@ -9308,7 +9108,7 @@ msgstr ""
 #: src/olympia/pages/templates/pages/about.lhtml:13
 msgid ""
 "addons.mozilla.org, commonly known as \"AMO\", is Mozilla's official site for add-ons to Mozilla software, such as Firefox, Thunderbird, and SeaMonkey. Add-ons let you add new features and change "
-"the way your browser or application works.  Take a look around and explore the thousands of ways to customize the way you do things online."
+"the way your browser or application works. Take a look around and explore the thousands of ways to customize the way you do things online."
 msgstr ""
 
 #: src/olympia/pages/templates/pages/about.lhtml:19
@@ -9653,7 +9453,7 @@ msgstr ""
 msgid ""
 "Yes. It's possible, but some of the functionality provided by these libraries are available through XPCOM, XUL, and JavaScript. In addition, authors should take care if libraries modify primitive "
 "object prototypes (String.prototype, Date.prototype, etc.) and/or define global functions (eg. the $ function). These are prone to cause conflict with other add-ons, in particular if different add-"
-"ons use different versions of libraries and so on. Developers need to be very, very careful with using them.  Mozilla does not offer documentation on using them to build add-ons."
+"ons use different versions of libraries and so on. Developers need to be very, very careful with using them. Mozilla does not offer documentation on using them to build add-ons."
 msgstr ""
 
 #: src/olympia/pages/templates/pages/dev_faq.html:165
@@ -9767,8 +9567,8 @@ msgstr ""
 #, python-format
 msgid ""
 "Yes. Many developers choose to host their own add-ons. Choosing to host your add-on on <a href=\"%(amo_url)s\">Mozilla's add-on site</a>, though, allows for much greater exposure to your add-on due "
-"to the large volume of visitors to the site.  <a href=\"%(md_url)s\">mozdev.org</a> offers free project hosting for Mozilla applications and extensions providing developers with tools to help "
-"manage source code, version control, bug tracking and documentation."
+"to the large volume of visitors to the site. <a href=\"%(md_url)s\">mozdev.org</a> offers free project hosting for Mozilla applications and extensions providing developers with tools to help manage "
+"source code, version control, bug tracking and documentation."
 msgstr ""
 
 #: src/olympia/pages/templates/pages/dev_faq.html:277
@@ -9816,7 +9616,7 @@ msgstr ""
 #: src/olympia/pages/templates/pages/dev_faq.html:314
 #, python-format
 msgid ""
-"Yes. Mozilla's <a href=\"%(p_url)s\">Add-on Policy</a> describes what is an acceptable submission. This policy is subject to change without notice.  In addition, the AMO editorial team uses the <a "
+"Yes. Mozilla's <a href=\"%(p_url)s\">Add-on Policy</a> describes what is an acceptable submission. This policy is subject to change without notice. In addition, the AMO editorial team uses the <a "
 "href=\"%(g_url)s\">Editors Reviewing Guide</a> to ensure that your add-on meets specific guidelines for functionality and security."
 msgstr ""
 
@@ -9933,7 +9733,7 @@ msgstr ""
 #: src/olympia/pages/templates/pages/dev_faq.html:434
 #, python-format
 msgid ""
-"This is why it's very important to read the <a href=\"%(g_url)s\">Editors Reviewing Guide</a> to ensure that your add-on is setup as expected.  It's also a good idea to read the blog post, <a href="
+"This is why it's very important to read the <a href=\"%(g_url)s\">Editors Reviewing Guide</a> to ensure that your add-on is setup as expected. It's also a good idea to read the blog post, <a href="
 "\"%(blog_url)s\">Successfully Getting your Add-on Reviewed</a> which provides excellent insight into ensuring a smooth review of your add-on."
 msgstr ""
 
@@ -10040,7 +9840,7 @@ msgstr ""
 
 #: src/olympia/pages/templates/pages/dev_faq.html:572
 msgid ""
-"Free Software Foundation provides short summaries of the key open source licenses, including whether the license qualifies as a free software license or a copyleft license.  Also includes a "
+"Free Software Foundation provides short summaries of the key open source licenses, including whether the license qualifies as a free software license or a copyleft license. Also includes a "
 "discussion of what constitutes a free software license or a copyleft license (e.g., a Copyleft license is a general method for making a program or other work free, and requiring all modified and "
 "extended versions of the program to be free as well.)"
 msgstr ""
@@ -10218,19 +10018,13 @@ msgid "Add-on Gallery"
 msgstr ""
 
 #: src/olympia/pages/templates/pages/faq.html:171
-msgid ""
-"How do I choose between add-ons that seem to do the same\n"
-"    thing?"
+msgid "How do I choose between add-ons that seem to do the same thing?"
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:173
+#: src/olympia/pages/templates/pages/faq.html:172
 msgid ""
-"There are often several add-ons that have similar features. To\n"
-"    figure out which is right for you, read the entire description of the\n"
-"    add-on and view its screenshots. If there are still several in the running,\n"
-"    read through the add-on's ratings, user reviews, and statistics to see\n"
-"    which is most liked by other users. Remember that you can also just try\n"
-"    out both and see which you like better."
+"There are often several add-ons that have similar features. To figure out which is right for you, read the entire description of the add-on and view its screenshots. If there are still several in "
+"the running, read through the add-on's ratings, user reviews, and statistics to see which is most liked by other users. Remember that you can also just try out both and see which you like better."
 msgstr ""
 
 #: src/olympia/pages/templates/pages/faq.html:180
@@ -10271,80 +10065,67 @@ msgid "How much do add-ons cost to purchase?"
 msgstr ""
 
 #: src/olympia/pages/templates/pages/faq.html:207
-msgid ""
-"Add-ons hosted in our gallery are free unless clearly marked\n"
-"    otherwise."
+msgid "Add-ons hosted in our gallery are free unless clearly marked otherwise."
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:210
+#: src/olympia/pages/templates/pages/faq.html:209
 msgid "What does it mean when an add-on asks for contributions?"
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:211
+#: src/olympia/pages/templates/pages/faq.html:210
 msgid ""
-"Some add-on authors request users who enjoy an add-on to\n"
-"        contribute to its development by making a monetary contribution. These\n"
-"        contributions go directly to the developer unless a third party is\n"
-"        indicated, such as the non-profit Mozilla Foundation."
+"Some add-on authors request users who enjoy an add-on to contribute to its development by making a monetary contribution. These contributions go directly to the developer unless a third party is "
+"indicated, such as the non-profit Mozilla Foundation."
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:216
+#: src/olympia/pages/templates/pages/faq.html:215
 msgid "What are beta add-ons?"
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:218
+#: src/olympia/pages/templates/pages/faq.html:217
 msgid ""
-"Beta add-ons are unreviewed versions which represent the\n"
-"        latest work of an add-on author. While different authors have different\n"
-"        standards for beta code quality, you should assume that these add-ons\n"
-"        are less stable than the general add-on releases."
+"Beta add-ons are unreviewed versions which represent the latest work of an add-on author. While different authors have different standards for beta code quality, you should assume that these add-"
+"ons are less stable than the general add-on releases."
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:222
+#: src/olympia/pages/templates/pages/faq.html:221
 msgid ""
 "Please note that when you install an add-on from the \"Beta Version\" section of an add-on's listing, you will continue to receive updates for that add-on as they become available. Like the initial "
 "version you installed, all beta releases are unreviewed by Mozilla and may harm your computer."
 msgstr ""
 
+#: src/olympia/pages/templates/pages/faq.html:228
+msgid "What does it mean when an add-on is flagged as slow?"
+msgstr ""
+
 #: src/olympia/pages/templates/pages/faq.html:229
-msgid ""
-"What does it mean when an add-on is flagged as\n"
-"    slow?"
+msgid "Most add-ons load code and resources at the same time Firefox is starting up. In most cases the impact in start-up time is minimal, but some add-ons can cause a noticeable slowdown."
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:231
-msgid ""
-"Most add-ons load code and resources at the same time Firefox\n"
-"        is starting up. In most cases the impact in start-up time is minimal,\n"
-"        but some add-ons can cause a noticeable slowdown."
-msgstr ""
-
-#: src/olympia/pages/templates/pages/faq.html:236
+#: src/olympia/pages/templates/pages/faq.html:234
 msgid "How do I report an inappropriate or spam user review?"
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:237
+#: src/olympia/pages/templates/pages/faq.html:235
 msgid ""
-"To report a user review of an add-on, log in with your account\n"
-"    and visit the add-on's reviews page. Find the review you wish to report,\n"
-"    click \"Report this review\" and select a reason. Our editorial team will\n"
-"    investigate the review and take appropriate action."
+"To report a user review of an add-on, log in with your account and visit the add-on's reviews page. Find the review you wish to report, click \"Report this review\" and select a reason. Our "
+"editorial team will investigate the review and take appropriate action."
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:242
+#: src/olympia/pages/templates/pages/faq.html:240
 msgid "How do I report a bug or contact the Mozilla Add-ons team?"
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:243
+#: src/olympia/pages/templates/pages/faq.html:241
 #, python-format
 msgid "Please visit our <a href=\"%(contact_url)s\">Contact page</a>."
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:246
+#: src/olympia/pages/templates/pages/faq.html:244
 msgid "What is a Source Code License?"
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:247
+#: src/olympia/pages/templates/pages/faq.html:245
 #, python-format
 msgid ""
 "The source code used to create an add-on is an exclusive copyright of the add-on author, unless otherwise declared in a source code license. Many add-ons on this site have <a href=\"%(url)s\" lang="
@@ -10352,60 +10133,60 @@ msgid ""
 "the GPL or BSD licenses instead of making up their own."
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:256
+#: src/olympia/pages/templates/pages/faq.html:254
 #, python-format
 msgid "Firefox and other Mozilla software are <a href=\"%(url)s\">open source</a>."
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:264
+#: src/olympia/pages/templates/pages/faq.html:262
 msgid "Collections and Favorites"
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:267
+#: src/olympia/pages/templates/pages/faq.html:265
 msgid "What is a collection?"
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:268
+#: src/olympia/pages/templates/pages/faq.html:266
 msgid "Collections are groups of related add-ons created by users to share."
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:270
+#: src/olympia/pages/templates/pages/faq.html:268
 msgid "What is the My Favorites collection?"
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:271
+#: src/olympia/pages/templates/pages/faq.html:269
 msgid "Favorite add-ons are add-ons that you have bookmarked to easily get back to later. You can add an add-on to your favorites collection by clicking \"Add to favorites\" on its details page."
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:275 src/olympia/templates/menu_links.html:13 src/olympia/templates/impala/header_title.html:17
+#: src/olympia/pages/templates/pages/faq.html:273 src/olympia/templates/menu_links.html:13 src/olympia/templates/impala/header_title.html:17
 msgid "Mobile Add-ons"
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:278
+#: src/olympia/pages/templates/pages/faq.html:276
 msgid "What are mobile add-ons?"
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:279
+#: src/olympia/pages/templates/pages/faq.html:277
 #, python-format
 msgid ""
 "Mobile add-ons work with <a href=\"%(mobile_url)s\">Firefox for Mobile</a> and add or modify functionality just like desktop add-ons. You can find add-ons that work with Firefox for Mobile in our "
 "<a href=\"%(gallery_url)s\">gallery</a>."
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:288
+#: src/olympia/pages/templates/pages/faq.html:286
 msgid "Developer Topics"
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:289
+#: src/olympia/pages/templates/pages/faq.html:287
 #, python-format
 msgid "Please see our <a href=\"%(faq_url)s\">Developer FAQ</a> and <a href=\"%(hub_url)s\">Developer Hub</a> for answers to add-on developer-related questions."
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:294
+#: src/olympia/pages/templates/pages/faq.html:292
 msgid "Still have questions?"
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:295
+#: src/olympia/pages/templates/pages/faq.html:293
 #, python-format
 msgid "For general Firefox support, visit our <a href=\"%(sumo_url)s\">support website</a>. For general add-on and website questions, visit our <a href=\"%(forum_url)s\">forum</a>."
 msgstr ""
@@ -10543,7 +10324,7 @@ msgstr ""
 
 #: src/olympia/pages/templates/pages/sunbird.html:29
 msgid ""
-"Development on the Sunbird project has halted and its final release was on March 30, 2010.  We've been proud to host Sunbird add-ons on this site but as the project is no longer maintained we have "
+"Development on the Sunbird project has halted and its final release was on March 30, 2010. We've been proud to host Sunbird add-ons on this site but as the project is no longer maintained we have "
 "disabled our support for the add-ons."
 msgstr ""
 
@@ -10621,7 +10402,7 @@ msgstr ""
 #, python-format
 msgid ""
 "<h2>Keep these tips in mind:</h2> <ul> <li> Write like you're telling a friend about your experience with the add-on. Give specifics and helpful details, such as what features you liked and/or "
-"disliked, how easy to use it is, and any disadvantages it has.  Avoid generic language such as calling it \"Great\" or \"Bad\" unless you can give reasons why you believe this is so. </li> <li> "
+"disliked, how easy to use it is, and any disadvantages it has. Avoid generic language such as calling it \"Great\" or \"Bad\" unless you can give reasons why you believe this is so. </li> <li> "
 "Please do not post bug reports in reviews. We do not make your email address available to add-on developers and they may need to contact you to help resolve your issue. See the <a href=\"%(support)s"
 "\">support section</a> to find out where to get assistance for this add-on. </li> <li>Please keep reviews clean, avoid the use of improper language and do not post any personal information. </li> </"
 "ul> <p>Please read the <a href=\"%(guide)s\" target=\"_blank\">Review Guidelines</a> for more detail about user add-on reviews.</p>"
@@ -10669,7 +10450,6 @@ msgid "This user has a <a href=\"%(user_review_url)s\">previous review</a> of th
 msgid_plural "This user has <a href=\"%(user_review_url)s\">%(cnt)s previous reviews</a> of this add-on."
 msgstr[0] ""
 msgstr[1] ""
-msgstr[2] ""
 
 #: src/olympia/reviews/templates/reviews/review.html:62
 #, python-format
@@ -10716,7 +10496,6 @@ msgid "<b>{0}</b> review for this add-on"
 msgid_plural "<b>{0}</b> reviews for this add-on"
 msgstr[0] ""
 msgstr[1] ""
-msgstr[2] ""
 
 #. {0} is a developer's name.
 #: src/olympia/reviews/templates/reviews/review_list.html:33
@@ -10729,7 +10508,6 @@ msgid "Review for %(addon)s by %(user)s"
 msgid_plural "Reviews for %(addon)s by %(user)s"
 msgstr[0] ""
 msgstr[1] ""
-msgstr[2] ""
 
 #: src/olympia/reviews/templates/reviews/review_list.html:42
 msgid "No reviews found."
@@ -10753,7 +10531,6 @@ msgid "{num} review"
 msgid_plural "{num} reviews"
 msgstr[0] ""
 msgstr[1] ""
-msgstr[2] ""
 
 #: src/olympia/reviews/templates/reviews/impala/reviews_rating.html:1
 msgid "Rated {0} out of 5 stars"
@@ -10781,7 +10558,6 @@ msgid "Average from {0} Rating"
 msgid_plural "Average from {0} Ratings"
 msgstr[0] ""
 msgstr[1] ""
-msgstr[2] ""
 
 #: src/olympia/reviews/templates/reviews/mobile/review_list.html:34
 #, python-format
@@ -10798,7 +10574,6 @@ msgid "See All Reviews"
 msgid_plural "See All %(cnt)s Reviews"
 msgstr[0] ""
 msgstr[1] ""
-msgstr[2] ""
 
 #: src/olympia/search/forms.py:11
 msgid "Most popular this week"
@@ -10883,16 +10658,16 @@ msgstr ""
 
 #. L10n: {0} is an application, such as Firefox. This means "any version of
 #. Firefox."
-#: src/olympia/search/views.py:554
+#: src/olympia/search/views.py:547
 msgid "Any {0}"
 msgstr ""
 
 #. L10n: "All Systems" means show everything regardless of platform.
-#: src/olympia/search/views.py:589
+#: src/olympia/search/views.py:582
 msgid "All Systems"
 msgstr ""
 
-#: src/olympia/search/views.py:600
+#: src/olympia/search/views.py:593
 msgid "All Tags"
 msgstr ""
 
@@ -10937,7 +10712,6 @@ msgid "<b>{0}</b> matching result"
 msgid_plural "<b>{0}</b> matching results"
 msgstr[0] ""
 msgstr[1] ""
-msgstr[2] ""
 
 #: src/olympia/search/templates/search/results.html:67
 msgid "Filter Results"
@@ -10961,7 +10735,6 @@ msgid "{0} post"
 msgid_plural "{0} posts"
 msgstr[0] ""
 msgstr[1] ""
-msgstr[2] ""
 
 #: src/olympia/sharing/__init__.py:20
 msgid "Post to Facebook"
@@ -10972,7 +10745,6 @@ msgid "{0} Like"
 msgid_plural "{0} Likes"
 msgstr[0] ""
 msgstr[1] ""
-msgstr[2] ""
 
 #: src/olympia/sharing/__init__.py:30
 msgid "Tweet on Twitter"
@@ -10983,7 +10755,6 @@ msgid "{0} tweet"
 msgid_plural "{0} tweets"
 msgstr[0] ""
 msgstr[1] ""
-msgstr[2] ""
 
 #: src/olympia/sharing/__init__.py:40
 msgid "Share on g+"
@@ -11018,7 +10789,6 @@ msgid "{0} post on localservice1"
 msgid_plural "{0} posts on localservice1"
 msgstr[0] ""
 msgstr[1] ""
-msgstr[2] ""
 
 #. L10n: Only change if you have reason! wiki.mozilla.org/AMO:Localizers
 #: src/olympia/sharing/__init__.py:76
@@ -11041,7 +10811,6 @@ msgid "{0} post on localservice2"
 msgid_plural "{0} posts on localservice2"
 msgstr[0] ""
 msgstr[1] ""
-msgstr[2] ""
 
 #. L10n: Only change if you have reason! wiki.mozilla.org/AMO:Localizers
 #: src/olympia/sharing/__init__.py:91
@@ -11064,7 +10833,6 @@ msgid "{0} post on localservice3"
 msgid_plural "{0} posts on localservice3"
 msgstr[0] ""
 msgstr[1] ""
-msgstr[2] ""
 
 #: src/olympia/sharing/templates/sharing/sharing_widget.html:2
 #, fuzzy
@@ -11076,31 +10844,31 @@ msgstr "Share this Add-on"
 msgid "Share this Collection"
 msgstr "Ce sunt colecțiile?"
 
-#: src/olympia/signing/views.py:30 src/olympia/templates/base.html:75 src/olympia/templates/impala/base.html:115
+#: src/olympia/signing/views.py:33 src/olympia/templates/base.html:71 src/olympia/templates/impala/base.html:112
 msgid "Some features are temporarily disabled while we perform website maintenance. We'll be back to full capacity shortly."
 msgstr ""
 
-#: src/olympia/signing/views.py:53
+#: src/olympia/signing/views.py:56
 msgid "Could not find add-on with id \"{}\"."
 msgstr ""
 
-#: src/olympia/signing/views.py:67
+#: src/olympia/signing/views.py:70
 msgid "You do not own this addon."
 msgstr ""
 
-#: src/olympia/signing/views.py:82
+#: src/olympia/signing/views.py:87
 msgid "Missing \"upload\" key in multipart file data."
 msgstr ""
 
-#: src/olympia/signing/views.py:96
+#: src/olympia/signing/views.py:101
 msgid "Version does not match the manifest file."
 msgstr ""
 
-#: src/olympia/signing/views.py:100
+#: src/olympia/signing/views.py:105
 msgid "Version already exists."
 msgstr ""
 
-#: src/olympia/signing/views.py:136
+#: src/olympia/signing/views.py:141
 msgid "No uploaded file for that addon and version."
 msgstr ""
 
@@ -11213,89 +10981,89 @@ msgstr ""
 msgid "Statistics Dashboard :: Add-ons for {0}"
 msgstr ""
 
-#: src/olympia/stats/templates/stats/stats.html:30
-msgid "Controls:"
-msgstr ""
-
-#: src/olympia/stats/templates/stats/stats.html:33
-msgid "reset zoom"
-msgstr ""
-
-#: src/olympia/stats/templates/stats/stats.html:40
-msgid "Group by:"
-msgstr ""
-
-#: src/olympia/stats/templates/stats/stats.html:42
-msgid "day"
-msgstr ""
-
-#: src/olympia/stats/templates/stats/stats.html:45
-msgid "week"
-msgstr ""
-
-#: src/olympia/stats/templates/stats/stats.html:48
-msgid "month"
-msgstr ""
-
-#: src/olympia/stats/templates/stats/stats.html:54
-msgid "For last:"
-msgstr ""
-
-#: src/olympia/stats/templates/stats/stats.html:57
-msgid "7 days"
-msgstr ""
-
-#: src/olympia/stats/templates/stats/stats.html:60
-msgid "30 days"
-msgstr ""
-
-#: src/olympia/stats/templates/stats/stats.html:63
-msgid "90 days"
-msgstr ""
-
-#: src/olympia/stats/templates/stats/stats.html:66
-msgid "365 days"
-msgstr ""
-
-#: src/olympia/stats/templates/stats/stats.html:69
-msgid "Custom..."
-msgstr ""
-
 #. {0} is an add-on name
-#: src/olympia/stats/templates/stats/stats.html:88 src/olympia/stats/templates/stats/stats.html:91
+#: src/olympia/stats/templates/stats/stats.html:44 src/olympia/stats/templates/stats/stats.html:47
 msgid "Statistics for {0}"
 msgstr "Statistici pentru {0}"
 
-#: src/olympia/stats/templates/stats/stats.html:94
+#: src/olympia/stats/templates/stats/stats.html:50
 msgid "Statistics Dashboard"
 msgstr ""
 
-#: src/olympia/stats/templates/stats/stats.html:104
+#: src/olympia/stats/templates/stats/stats.html:57
+msgid "Controls:"
+msgstr ""
+
+#: src/olympia/stats/templates/stats/stats.html:60
+msgid "reset zoom"
+msgstr ""
+
+#: src/olympia/stats/templates/stats/stats.html:67
+msgid "Group by:"
+msgstr ""
+
+#: src/olympia/stats/templates/stats/stats.html:69
+msgid "day"
+msgstr ""
+
+#: src/olympia/stats/templates/stats/stats.html:72
+msgid "week"
+msgstr ""
+
+#: src/olympia/stats/templates/stats/stats.html:75
+msgid "month"
+msgstr ""
+
+#: src/olympia/stats/templates/stats/stats.html:81
+msgid "For last:"
+msgstr ""
+
+#: src/olympia/stats/templates/stats/stats.html:84
+msgid "7 days"
+msgstr ""
+
+#: src/olympia/stats/templates/stats/stats.html:87
+msgid "30 days"
+msgstr ""
+
+#: src/olympia/stats/templates/stats/stats.html:90
+msgid "90 days"
+msgstr ""
+
+#: src/olympia/stats/templates/stats/stats.html:93
+msgid "365 days"
+msgstr ""
+
+#: src/olympia/stats/templates/stats/stats.html:96
+msgid "Custom..."
+msgstr ""
+
+#: src/olympia/stats/templates/stats/stats.html:106
 msgid "Statistics processing is currently disabled, so recent data is unavailable. The statistics are still being collected and this page will be updated soon with the missing data."
 msgstr ""
 
-#: src/olympia/stats/templates/stats/stats.html:110
+#: src/olympia/stats/templates/stats/stats.html:112
 msgid "Loading the latest data&hellip;"
 msgstr ""
 
-#: src/olympia/stats/templates/stats/stats.html:142 src/olympia/stats/templates/stats/reports/overview.html:25 src/olympia/stats/templates/stats/reports/overview.html:37
+#: src/olympia/stats/templates/stats/stats.html:144 src/olympia/stats/templates/stats/reports/overview.html:25 src/olympia/stats/templates/stats/reports/overview.html:37
 #: src/olympia/stats/templates/stats/reports/overview.html:49
 msgid "No data available."
 msgstr ""
 
-#: src/olympia/stats/templates/stats/stats.html:177
+#: src/olympia/stats/templates/stats/stats.html:179
 msgid "This dashboard is currently <b>public</b>."
 msgstr ""
 
-#: src/olympia/stats/templates/stats/stats.html:179
+#: src/olympia/stats/templates/stats/stats.html:181
 msgid "Contribution stats are currently <b>private</b>."
 msgstr ""
 
-#: src/olympia/stats/templates/stats/stats.html:182
+#: src/olympia/stats/templates/stats/stats.html:184
 msgid "This dashboard is currently <b>private</b>."
 msgstr ""
 
-#: src/olympia/stats/templates/stats/stats.html:185
+#: src/olympia/stats/templates/stats/stats.html:187
 msgid "Change settings."
 msgstr ""
 
@@ -11447,17 +11215,6 @@ msgstr ""
 msgid "Application versions by Date"
 msgstr ""
 
-# {0} is a number
-#: src/olympia/tags/templates/tags/top_cloud.html:4
-#, fuzzy
-msgid "Top {0} Tags"
-msgstr "Top {0} Tags"
-
-#. {0} is the current application name
-#: src/olympia/tags/templates/tags/top_cloud.html:14
-msgid "{0} Top Tags"
-msgstr ""
-
 #: src/olympia/templates/amo_footer.html:6 src/olympia/templates/includes/lang_switcher.html:2
 msgid "Other languages"
 msgstr ""
@@ -11466,11 +11223,11 @@ msgstr ""
 msgid "Mozilla Add-ons"
 msgstr ""
 
-#: src/olympia/templates/base.html:91 src/olympia/templates/impala/base.html:81
+#: src/olympia/templates/base.html:89 src/olympia/templates/impala/base.html:78
 msgid "Find add-ons for other applications"
 msgstr "Găsește suplimente pentru alte aplicații"
 
-#: src/olympia/templates/base.html:92 src/olympia/templates/impala/base.html:81
+#: src/olympia/templates/base.html:90 src/olympia/templates/impala/base.html:78
 msgid "Other Applications"
 msgstr "Alte aplicații"
 
@@ -11495,7 +11252,7 @@ msgid "View Mobile Site"
 msgstr ""
 
 #: src/olympia/templates/copyright.html:7
-msgid "Site Status "
+msgid "Site Status"
 msgstr ""
 
 #: src/olympia/templates/footer.html:3
@@ -11597,35 +11354,35 @@ msgstr ""
 msgid "<a href=\"%(reg)s\">Register</a> or <a href=\"%(login)s\">Log in</a>"
 msgstr ""
 
-#: src/olympia/templates/impala/base.html:126
+#: src/olympia/templates/impala/base.html:123
 #, python-format
 msgid "To try the thousands of add-ons available here, download <a href=\"%(url)s\">Mozilla Firefox</a>, a fast, free way to surf the Web!"
 msgstr ""
 
-#: src/olympia/templates/impala/base.html:138
+#: src/olympia/templates/impala/base.html:135
 #, python-format
 msgid "Add-ons is switching to Firefox Accounts for login. <a href=\"%(url)s\" class=\"fxa-login\">Sign in now to transfer your account.</a>"
 msgstr ""
 
 #. {0} is an application, such as Firefox.
-#: src/olympia/templates/impala/base.html:148
+#: src/olympia/templates/impala/base.html:145
 msgid "Welcome to {0} Add-ons."
 msgstr ""
 
-#: src/olympia/templates/impala/base.html:151
+#: src/olympia/templates/impala/base.html:148
 msgid "Choose from thousands of extra features and styles to make Firefox your own."
 msgstr ""
 
-#: src/olympia/templates/impala/base.html:156
+#: src/olympia/templates/impala/base.html:153
 #, python-format
 msgid "Add extra features and styles to make %(app)s your own."
 msgstr ""
 
-#: src/olympia/templates/impala/base.html:164
+#: src/olympia/templates/impala/base.html:161
 msgid "On the go?"
 msgstr ""
 
-#: src/olympia/templates/impala/base.html:166
+#: src/olympia/templates/impala/base.html:163
 msgid "Check out our <a class=\"mobile-link\" href=\"#\">Mobile Add-ons site</a>."
 msgstr ""
 
@@ -11849,19 +11606,19 @@ msgstr ""
 
 #. L10n: {id} will be something like "13ad6a", just a random number
 #. to differentiate this user from other anonymous users.
-#: src/olympia/users/models.py:353
+#: src/olympia/users/models.py:362
 msgid "Anonymous user {id}"
 msgstr ""
 
-#: src/olympia/users/models.py:410
+#: src/olympia/users/models.py:419
 msgid "Your account has been restricted"
 msgstr ""
 
-#: src/olympia/users/models.py:480
+#: src/olympia/users/models.py:489
 msgid "Please confirm your email address"
 msgstr ""
 
-#: src/olympia/users/models.py:506
+#: src/olympia/users/models.py:515
 msgid "My Mobile Add-ons"
 msgstr ""
 
@@ -12139,7 +11896,7 @@ msgstr "Parolă"
 
 #: src/olympia/users/templates/users/edit.html:70
 #, python-format
-msgid "Change your password.  If you forgot your password, you can <a href=\"%(reset_url)s\">use the reset form</a>."
+msgid "Change your password. If you forgot your password, you can <a href=\"%(reset_url)s\">use the reset form</a>."
 msgstr ""
 
 #: src/olympia/users/templates/users/edit.html:76
@@ -12159,7 +11916,7 @@ msgid "Profile"
 msgstr ""
 
 #: src/olympia/users/templates/users/edit.html:100
-msgid "Give us a bit more information about yourself.  All these fields are optional, but they'll help other users get to know you better."
+msgid "Give us a bit more information about yourself. All these fields are optional, but they'll help other users get to know you better."
 msgstr ""
 
 #: src/olympia/users/templates/users/edit.html:124
@@ -12386,7 +12143,7 @@ msgid "Confirm password"
 msgstr "Confirmare parolă"
 
 #: src/olympia/users/templates/users/pwreset_confirm.html:47
-msgid "The password reset link was invalid, possibly because it has already been used.  Please request a new password reset."
+msgid "The password reset link was invalid, possibly because it has already been used. Please request a new password reset."
 msgstr ""
 
 #: src/olympia/users/templates/users/pwreset_request.html:15
@@ -12572,7 +12329,7 @@ msgstr ""
 
 #: src/olympia/users/templates/users/unsubscribe.html:30
 #, python-format
-msgid "Unfortunately, we weren't able to unsubscribe you.  The link you clicked is invalid. However, you can unsubscribe still unsubscribe on your <a href=\"%(edit_url)s\">edit profile page</a>."
+msgid "Unfortunately, we weren't able to unsubscribe you. The link you clicked is invalid. However, you can unsubscribe still unsubscribe on your <a href=\"%(edit_url)s\">edit profile page</a>."
 msgstr ""
 
 #: src/olympia/users/templates/users/vcard.html:2
@@ -12607,7 +12364,6 @@ msgid "%(num)s theme"
 msgid_plural "%(num)s themes"
 msgstr[0] ""
 msgstr[1] ""
-msgstr[2] ""
 
 #: src/olympia/users/templates/users/vcard.html:62
 #, python-format
@@ -12615,7 +12371,6 @@ msgid "%(num)s add-on"
 msgid_plural "%(num)s add-ons"
 msgstr[0] ""
 msgstr[1] ""
-msgstr[2] ""
 
 #: src/olympia/users/templates/users/vcard.html:75
 msgid "Average rating of developer's add-ons"
@@ -12630,15 +12385,15 @@ msgstr ""
 msgid "Version History with Changelogs"
 msgstr "Istoria versiunilor și a modificărilor"
 
-#: src/olympia/versions/models.py:314
+#: src/olympia/versions/models.py:313
 msgid "Add-on uses binary components."
 msgstr ""
 
-#: src/olympia/versions/models.py:317
+#: src/olympia/versions/models.py:316
 msgid "Add-on has opted into strict compatibility checking."
 msgstr ""
 
-#: src/olympia/versions/models.py:715
+#: src/olympia/versions/models.py:711
 msgid "{app} {min} and later"
 msgstr ""
 
@@ -12677,7 +12432,6 @@ msgid "<b>{0}</b> version"
 msgid_plural "<b>{0}</b> versions"
 msgstr[0] ""
 msgstr[1] ""
-msgstr[2] ""
 
 #: src/olympia/versions/templates/versions/version_list.html:35 src/olympia/versions/templates/versions/mobile/version_list.html:14
 msgid "Be careful with old versions!"
@@ -12715,4 +12469,8 @@ msgstr ""
 
 #: src/olympia/zadmin/forms.py:105
 msgid "Log emails instead of sending"
+msgstr ""
+
+#: src/olympia/zadmin/forms.py:215
+msgid "Deleted versions can`t be changed."
 msgstr ""

--- a/locale/ro/LC_MESSAGES/djangojs.po
+++ b/locale/ro/LC_MESSAGES/djangojs.po
@@ -3,1227 +3,1234 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2016-02-24 21:23+0000\n"
+"POT-Creation-Date: 2016-04-18 15:47+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
+"Language: \n"
 "MIME-Version: 1.0\n"
-"Content-Type: text/plain; charset=utf-8\n"
+"Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Generated-By: Babel 2.2.0\n"
 
-#: static/js/common/ratingwidget.js:31
+#: static/js/common-all.js:1426 static/js/impala-all.js:1511 static/js/zamboni/discovery-all.js:12598 static/js/zamboni/init.js:28 static/js/zamboni/mobile-all.js:14945
+msgid "This feature is temporarily disabled while we perform website maintenance. Please check back a little later."
+msgstr ""
+
+#. L10n: {0} is an app name like Firefox.
+#: static/js/common-all.js:1837 static/js/impala-all.js:1922 static/js/zamboni/buttons.js:73 static/js/zamboni/discovery-all.js:13108
+msgid "Accept and Install"
+msgstr ""
+
+#: static/js/common-all.js:1837 static/js/impala-all.js:1922 static/js/zamboni/buttons.js:73 static/js/zamboni/discovery-all.js:13108
+msgid "Add to {0}"
+msgstr ""
+
+#: static/js/common-all.js:1842 static/js/impala-all.js:1927 static/js/zamboni/buttons.js:78 static/js/zamboni/discovery-all.js:13113
+msgid "Download Now"
+msgstr ""
+
+#: static/js/common-all.js:1883 static/js/impala-all.js:1968 static/js/zamboni/buttons.js:119 static/js/zamboni/discovery-all.js:13154
+msgid "Add-on has not been updated to support default-to-compatible."
+msgstr ""
+
+#: static/js/common-all.js:1888 static/js/impala-all.js:1973 static/js/zamboni/buttons.js:124 static/js/zamboni/discovery-all.js:13159
+msgid "You need to be using Firefox 10.0 or higher."
+msgstr ""
+
+#: static/js/common-all.js:1900 static/js/impala-all.js:1985 static/js/zamboni/buttons.js:136 static/js/zamboni/discovery-all.js:13171
+msgid "Mozilla has marked this version as incompatible with your Firefox version."
+msgstr ""
+
+#. L10n: {0} is an platform like Windows or Linux.
+#: static/js/common-all.js:1981 static/js/impala-all.js:2066 static/js/zamboni/buttons.js:217 static/js/zamboni/discovery-all.js:13252
+msgid "Install for {0} anyway"
+msgstr ""
+
+#: static/js/common-all.js:1981 static/js/impala-all.js:2066 static/js/zamboni/buttons.js:217 static/js/zamboni/discovery-all.js:13252
+msgid "Download for {0} anyway"
+msgstr ""
+
+#: static/js/common-all.js:2038 static/js/impala-all.js:2123 static/js/zamboni/buttons.js:274 static/js/zamboni/discovery-all.js:13309
+msgid "Not available for your platform"
+msgstr ""
+
+#. L10n: {0} is an app name, {1} is the app version.
+#: static/js/common-all.js:2049 static/js/common-all.js:2086 static/js/impala-all.js:2134 static/js/impala-all.js:2171 static/js/zamboni/buttons.js:286 static/js/zamboni/buttons.js:324
+#: static/js/zamboni/discovery-all.js:13320 static/js/zamboni/discovery-all.js:13357
+msgid "Not available for {0} {1}"
+msgstr ""
+
+#: static/js/common-all.js:2112 static/js/impala-all.js:2197 static/js/zamboni/buttons.js:351 static/js/zamboni/discovery-all.js:13383
+msgid "Works with {app} {min} - {max}"
+msgstr ""
+
+#: static/js/common-all.js:2114 static/js/impala-all.js:2199 static/js/zamboni/buttons.js:353 static/js/zamboni/discovery-all.js:13385
+msgid "View other versions"
+msgstr ""
+
+#: static/js/common-all.js:2162 static/js/impala-all.js:2247 static/js/zamboni/buttons.js:401 static/js/zamboni/discovery-all.js:13433
+msgid "Only with Firefox — Get Firefox Now!"
+msgstr ""
+
+#: static/js/common-all.js:2278 static/js/impala-all.js:2363 static/js/zamboni/buttons.js:517 static/js/zamboni/discovery-all.js:13549 static/js/zamboni/mobile-all.js:15177
+#: static/js/zamboni/mobile/buttons.js:43
+msgid "Sorry, you need a Mozilla-based browser (such as Firefox) to install a search plugin."
+msgstr ""
+
+#: static/js/common-all.js:9088 static/js/impala-all.js:9649 static/js/zamboni/global.js:410
+msgid "Loading..."
+msgstr ""
+
+#. L10n: {0} is the number of characters left.
+#: static/js/common-all.js:9152 static/js/impala-all.js:9713 static/js/zamboni/global.js:474
+msgid "<b>{0}</b> character left."
+msgid_plural "<b>{0}</b> characters left."
+msgstr[0] ""
+msgstr[1] ""
+
+#: static/js/common-all.js:9589 static/js/common-min.js:6 static/js/impala-all.js:10052 static/js/impala-min.js:6 static/js/common/ratingwidget.js:31 static/js/zamboni/mobile-all.js:16123
+#: static/js/zamboni/mobile-min.js:6
 msgid "{0} star"
 msgid_plural "{0} stars"
 msgstr[0] ""
 msgstr[1] ""
-msgstr[2] ""
 
-#: static/js/common/upload-addon.js:41 static/js/common/upload-image.js:128
+#: static/js/common-all.js:9676 static/js/common-min.js:6 static/js/impala-all.js:10139 static/js/impala-min.js:6 static/js/zamboni/l10n.js:45
+msgid "Remove this localization"
+msgstr ""
+
+#: static/js/common-all.js:10193 static/js/common-min.js:6 static/js/impala-all.js:10674 static/js/impala-min.js:6 static/js/zamboni/discovery-all.js:13678
+msgid "close"
+msgstr ""
+
+#: static/js/common-all.js:10860 static/js/common-min.js:6 static/js/impala-all.js:11481 static/js/impala-min.js:6 static/js/impala/reviews.js:23 static/js/zamboni/reviews.js:18
+msgid "Flagged for review"
+msgstr ""
+
+#: static/js/common-all.js:10876 static/js/common-min.js:6 static/js/impala-all.js:11498 static/js/impala-min.js:6 static/js/impala/reviews.js:40 static/js/zamboni/reviews.js:34
+msgid "Your input is required"
+msgstr ""
+
+#: static/js/common-all.js:10945 static/js/common-min.js:6 static/js/impala-all.js:11610 static/js/impala-min.js:7 static/js/impala/reviews.js:152 static/js/zamboni/reviews.js:103
+msgid "Marked for deletion"
+msgstr ""
+
+#: static/js/common-all.js:11573 static/js/common-min.js:7 static/js/impala-all.js:13809 static/js/impala-min.js:8 static/js/zamboni/collections.js:229
+msgid "Adding to Favorites&hellip;"
+msgstr ""
+
+#: static/js/common-all.js:11576 static/js/common-min.js:7 static/js/impala-all.js:13812 static/js/impala-min.js:8 static/js/zamboni/collections.js:232
+msgid "Removing Favorite&hellip;"
+msgstr ""
+
+#: static/js/common-all.js:11579 static/js/common-min.js:7 static/js/impala-all.js:13815 static/js/impala-min.js:8 static/js/zamboni/collections.js:235
+msgid "Add to Favorites"
+msgstr ""
+
+#: static/js/common-all.js:11582 static/js/common-min.js:7 static/js/impala-all.js:13818 static/js/impala-min.js:8 static/js/zamboni/collections.js:238
+msgid "Remove from Favorites"
+msgstr ""
+
+#: static/js/common-all.js:11647 static/js/common-min.js:7 static/js/impala-all.js:13883 static/js/impala-min.js:8 static/js/zamboni/collections.js:303
+msgid "Pending"
+msgstr ""
+
+#: static/js/common-all.js:11648 static/js/common-min.js:7 static/js/impala-all.js:13884 static/js/impala-min.js:8 static/js/zamboni/collections.js:304
+msgid "Add a comment"
+msgstr ""
+
+#: static/js/common-all.js:11648 static/js/common-min.js:7 static/js/impala-all.js:13884 static/js/impala-min.js:8 static/js/zamboni/collections.js:304
+msgid "Comment"
+msgstr ""
+
+#: static/js/common-all.js:11649 static/js/common-min.js:7 static/js/impala-all.js:13885 static/js/impala-min.js:8 static/js/zamboni/collections.js:305
+msgid "Remove this add-on from the collection"
+msgstr ""
+
+#: static/js/common-all.js:11649 static/js/common-all.js:11678 static/js/common-min.js:7 static/js/impala-all.js:13885 static/js/impala-all.js:13914 static/js/impala-min.js:8
+#: static/js/zamboni/collections.js:305 static/js/zamboni/collections.js:334
+msgid "Remove"
+msgstr ""
+
+#: static/js/common-all.js:11678 static/js/common-min.js:7 static/js/impala-all.js:13914 static/js/impala-min.js:8 static/js/zamboni/collections.js:334
+msgid "Remove this user as a contributor"
+msgstr ""
+
+#: static/js/common-all.js:11690 static/js/common-min.js:7 static/js/impala-all.js:13926 static/js/impala-min.js:8 static/js/zamboni/collections.js:346
+msgid "An email address is required."
+msgstr ""
+
+#: static/js/common-all.js:11708 static/js/common-min.js:7 static/js/impala-all.js:13944 static/js/impala-min.js:8 static/js/zamboni/collections.js:364
+msgid "You cannot add yourself as a contributor."
+msgstr ""
+
+#: static/js/common-all.js:11710 static/js/common-min.js:7 static/js/impala-all.js:13946 static/js/impala-min.js:8 static/js/zamboni/collections.js:366
+msgid "You have already added that user."
+msgstr ""
+
+#: static/js/common-all.js:11917 static/js/common-min.js:7 static/js/impala-all.js:14153 static/js/impala-min.js:8 static/js/zamboni/collections.js:573
+msgid "Add to favorites"
+msgstr ""
+
+#: static/js/common-all.js:11921 static/js/common-min.js:7 static/js/impala-all.js:14157 static/js/impala-min.js:8 static/js/zamboni/collections.js:577
+msgid "Remove from favorites"
+msgstr ""
+
+#: static/js/common-all.js:11939 static/js/common-min.js:7 static/js/impala-all.js:14175 static/js/impala-all.js:14233 static/js/impala-min.js:8 static/js/impala/collections.js:10
+#: static/js/zamboni/collections.js:595
+msgid "Follow this Collection"
+msgstr ""
+
+#: static/js/common-all.js:11948 static/js/common-min.js:7 static/js/impala-all.js:14184 static/js/impala-min.js:8 static/js/zamboni/collections.js:604
+msgid "Stop following"
+msgstr ""
+
+#: static/js/common-all.js:12096 static/js/common-min.js:7 static/js/zamboni/password-strength.js:20
+msgid "Password strength:"
+msgstr ""
+
+#: static/js/common-all.js:12102 static/js/common-min.js:7 static/js/zamboni/password-strength.js:26
+msgid "At least {0} character left."
+msgid_plural "At least {0} characters left."
+msgstr[0] ""
+msgstr[1] ""
+
+#: static/js/common-all.js:12286 static/js/common-min.js:7 static/js/impala-all.js:14632 static/js/impala-min.js:8 static/js/impala/suggestions.js:39
+msgid "Search themes for <b>{0}</b>"
+msgstr ""
+
+#: static/js/common-all.js:12288 static/js/common-min.js:7 static/js/impala-all.js:14634 static/js/impala-min.js:8 static/js/impala/suggestions.js:41
+msgid "Search apps for <b>{0}</b>"
+msgstr ""
+
+#: static/js/common-all.js:12290 static/js/common-min.js:7 static/js/impala-all.js:14636 static/js/impala-min.js:8 static/js/impala/suggestions.js:43
+msgid "Search add-ons for <b>{0}</b>"
+msgstr ""
+
+#: static/js/common-all.js:12521 static/js/common-min.js:7 static/js/impala-all.js:14867 static/js/impala-min.js:8 static/js/impala/site_suggestions.js:46
+msgid "Category"
+msgstr ""
+
+#. L10n: {0} is an app name.
+#: static/js/impala-all.js:11632 static/js/impala-min.js:7 static/js/impala/listing.js:11 static/js/zamboni/themes.js:13
+msgid "This theme is incompatible with your version of {0}"
+msgstr ""
+
+#: static/js/impala-all.js:12146 static/js/impala-all.js:14331 static/js/impala-min.js:7 static/js/impala-min.js:8 static/js/common/upload-image.js:97 static/js/impala/users.js:51
+#: static/js/zamboni/devhub-all.js:894 static/js/zamboni/devhub-min.js:1
+msgid "Images must be either PNG or JPG."
+msgstr ""
+
+#: static/js/impala-all.js:12150 static/js/impala-min.js:7 static/js/common/upload-image.js:101 static/js/zamboni/devhub-all.js:898 static/js/zamboni/devhub-min.js:1
+msgid "Videos must be in WebM."
+msgstr ""
+
+#: static/js/impala-all.js:12177 static/js/impala-min.js:7 static/js/common/upload-addon.js:41 static/js/common/upload-image.js:128 static/js/zamboni/devhub-all.js:272
+#: static/js/zamboni/devhub-all.js:925 static/js/zamboni/devhub-min.js:1
 msgid "There was a problem contacting the server."
 msgstr ""
 
-#: static/js/common/upload-addon.js:69
+#: static/js/impala-all.js:13298 static/js/impala-min.js:7 static/js/impala/persona_creation.js:60
+msgid "All Rights Reserved"
+msgstr ""
+
+#: static/js/impala-all.js:13302 static/js/impala-min.js:7 static/js/impala/persona_creation.js:64
+msgid "Creative Commons Attribution 3.0"
+msgstr ""
+
+#: static/js/impala-all.js:13307 static/js/impala-min.js:7 static/js/impala/persona_creation.js:69
+msgid "Creative Commons Attribution-NonCommercial 3.0"
+msgstr ""
+
+#: static/js/impala-all.js:13312 static/js/impala-min.js:7 static/js/impala/persona_creation.js:74
+msgid "Creative Commons Attribution-NonCommercial-NoDerivs 3.0"
+msgstr ""
+
+#: static/js/impala-all.js:13317 static/js/impala-min.js:7 static/js/impala/persona_creation.js:79
+msgid "Creative Commons Attribution-NonCommercial-Share Alike 3.0"
+msgstr ""
+
+#: static/js/impala-all.js:13322 static/js/impala-min.js:7 static/js/impala/persona_creation.js:84
+msgid "Creative Commons Attribution-NoDerivs 3.0"
+msgstr ""
+
+#: static/js/impala-all.js:13327 static/js/impala-min.js:7 static/js/impala/persona_creation.js:89
+msgid "Creative Commons Attribution-ShareAlike 3.0"
+msgstr ""
+
+#: static/js/impala-all.js:13530 static/js/impala-min.js:7 static/js/impala/persona_creation.js:292
+msgid "Your Theme's Name"
+msgstr ""
+
+#: static/js/impala-all.js:14242 static/js/impala-min.js:8 static/js/impala/collections.js:19
+msgid "Stop Following"
+msgstr ""
+
+#: static/js/impala-all.js:14243 static/js/impala-min.js:8 static/js/impala/collections.js:20
+msgid "Following"
+msgstr ""
+
+#: static/js/impala-all.js:14313 static/js/impala-min.js:8 static/js/impala/users.js:33
+msgid "use original"
+msgstr ""
+
+#: static/js/impala-all.js:14523 static/js/impala-min.js:8 static/js/impala/search.js:114
+msgid "Updating results&hellip;"
+msgstr ""
+
+#: static/js/common/upload-addon.js:69 static/js/zamboni/devhub-all.js:300 static/js/zamboni/devhub-min.js:1
 msgid "Select a file..."
 msgstr ""
 
-#: static/js/common/upload-addon.js:70
+#: static/js/common/upload-addon.js:70 static/js/zamboni/devhub-all.js:301 static/js/zamboni/devhub-min.js:1
 msgid "Your add-on should end with .xpi, .jar or .xml"
 msgstr ""
 
 #. L10n: {0} is the percent of the file that has been uploaded.
-#: static/js/common/upload-addon.js:104
+#: static/js/common/upload-addon.js:104 static/js/zamboni/devhub-all.js:335 static/js/zamboni/devhub-min.js:1
 #, python-format
 msgid "{0}% complete"
 msgstr ""
 
 #. L10n: "{bytes uploaded} of {total filesize}".
-#: static/js/common/upload-addon.js:107
+#: static/js/common/upload-addon.js:107 static/js/zamboni/devhub-all.js:338 static/js/zamboni/devhub-min.js:1
 msgid "{0} of {1}"
 msgstr ""
 
-#: static/js/common/upload-addon.js:140
+#: static/js/common/upload-addon.js:140 static/js/zamboni/devhub-all.js:371 static/js/zamboni/devhub-min.js:1
 msgid "Cancel"
 msgstr ""
 
-#: static/js/common/upload-addon.js:162
+#: static/js/common/upload-addon.js:162 static/js/zamboni/devhub-all.js:393 static/js/zamboni/devhub-min.js:1
 msgid "Uploading {0}"
 msgstr ""
 
-#: static/js/common/upload-addon.js:189
+#: static/js/common/upload-addon.js:189 static/js/zamboni/devhub-all.js:420 static/js/zamboni/devhub-min.js:1
 msgid "Error with {0}"
 msgstr ""
 
-#: static/js/common/upload-addon.js:194
+#: static/js/common/upload-addon.js:194 static/js/zamboni/devhub-all.js:425 static/js/zamboni/devhub-min.js:1
 msgid "Your add-on failed validation with {0} error."
 msgid_plural "Your add-on failed validation with {0} errors."
 msgstr[0] ""
 msgstr[1] ""
-msgstr[2] ""
 
-#: static/js/common/upload-addon.js:208
+#: static/js/common/upload-addon.js:208 static/js/zamboni/devhub-all.js:439 static/js/zamboni/devhub-min.js:1
 msgid "&hellip;and {0} more"
 msgid_plural "&hellip;and {0} more"
 msgstr[0] ""
 msgstr[1] ""
-msgstr[2] ""
 
-#: static/js/common/upload-addon.js:222 static/js/common/upload-addon.js:512
+#: static/js/common/upload-addon.js:222 static/js/common/upload-addon.js:497 static/js/zamboni/devhub-all.js:453 static/js/zamboni/devhub-all.js:743 static/js/zamboni/devhub-min.js:1
 msgid "See full validation report"
 msgstr ""
 
-#: static/js/common/upload-addon.js:234
+#: static/js/common/upload-addon.js:234 static/js/zamboni/devhub-all.js:465 static/js/zamboni/devhub-min.js:1
 msgid "Validating {0}"
 msgstr ""
 
 #. L10n: first argument is an HTTP status code
-#: static/js/common/upload-addon.js:273
+#: static/js/common/upload-addon.js:273 static/js/zamboni/devhub-all.js:504 static/js/zamboni/devhub-min.js:1
 msgid "Received an empty response from the server; status: {0}"
 msgstr ""
 
-#: static/js/common/upload-addon.js:373
+#: static/js/common/upload-addon.js:370 static/js/zamboni/devhub-all.js:604 static/js/zamboni/devhub-min.js:1
 msgid "Unexpected server error while validating."
 msgstr ""
 
-#: static/js/common/upload-addon.js:412
+#: static/js/common/upload-addon.js:409 static/js/zamboni/devhub-all.js:643 static/js/zamboni/devhub-min.js:1
 msgid "Finished validating {0}"
 msgstr ""
 
-#: static/js/common/upload-addon.js:418
+#: static/js/common/upload-addon.js:415 static/js/zamboni/devhub-all.js:649 static/js/zamboni/devhub-min.js:1
 msgid "Your add-on validation timed out, it will be manually reviewed."
 msgstr ""
 
-#: static/js/common/upload-addon.js:421
+#: static/js/common/upload-addon.js:418 static/js/zamboni/devhub-all.js:652 static/js/zamboni/devhub-min.js:1
 msgid "Your add-on was validated with no errors and {0} warning."
 msgid_plural "Your add-on was validated with no errors and {0} warnings."
 msgstr[0] ""
 msgstr[1] ""
-msgstr[2] ""
 
-#: static/js/common/upload-addon.js:426
+#: static/js/common/upload-addon.js:423 static/js/zamboni/devhub-all.js:657 static/js/zamboni/devhub-min.js:1
 msgid "Your add-on was validated with no errors and {0} message."
 msgid_plural "Your add-on was validated with no errors and {0} messages."
 msgstr[0] ""
 msgstr[1] ""
-msgstr[2] ""
 
-#: static/js/common/upload-addon.js:431
+#: static/js/common/upload-addon.js:428 static/js/zamboni/devhub-all.js:662 static/js/zamboni/devhub-min.js:1
 msgid "Your add-on was validated with no errors or warnings."
 msgstr ""
 
-#: static/js/common/upload-addon.js:446
+#: static/js/common/upload-addon.js:443 static/js/zamboni/devhub-all.js:677 static/js/zamboni/devhub-min.js:1
 msgid "Your submission will be automatically signed."
 msgstr ""
 
-#: static/js/common/upload-addon.js:465
+#: static/js/common/upload-addon.js:450 static/js/zamboni/devhub-all.js:696 static/js/zamboni/devhub-min.js:1
 msgid "Include detailed version notes (this can be done in the next step)."
 msgstr ""
 
-#: static/js/common/upload-addon.js:466
+#: static/js/common/upload-addon.js:451 static/js/zamboni/devhub-all.js:697 static/js/zamboni/devhub-min.js:1
 msgid "If your add-on requires an account to a website in order to be fully tested, include a test username and password in the Notes to Reviewer (this can be done in the next step)."
 msgstr ""
 
-#: static/js/common/upload-addon.js:467
+#: static/js/common/upload-addon.js:452 static/js/zamboni/devhub-all.js:698 static/js/zamboni/devhub-min.js:1
 msgid "If your add-on is intended for a limited audience you should choose Preliminary Review instead of Full Review."
 msgstr ""
 
-#: static/js/common/upload-addon.js:480
+#: static/js/common/upload-addon.js:465 static/js/zamboni/devhub-all.js:711 static/js/zamboni/devhub-min.js:1
 msgid "Add-on submission checklist"
 msgstr ""
 
-#: static/js/common/upload-addon.js:481
+#: static/js/common/upload-addon.js:466 static/js/zamboni/devhub-all.js:712 static/js/zamboni/devhub-min.js:1
 msgid "Please verify the following points before finalizing your submission. This will minimize delays or misunderstanding during the review process:"
 msgstr ""
 
-#: static/js/common/upload-addon.js:483
+#: static/js/common/upload-addon.js:468 static/js/zamboni/devhub-all.js:714 static/js/zamboni/devhub-min.js:1
 msgid ""
 "Compiled binaries, as well as minified or obfuscated scripts (excluding known libraries) need to have their sources submitted separately for review. Make sure that you use the source code upload "
 "field to avoid having your submission rejected."
 msgstr ""
 
-#: static/js/common/upload-addon.js:501
+#: static/js/common/upload-addon.js:486 static/js/zamboni/devhub-all.js:732 static/js/zamboni/devhub-min.js:1
 msgid "The validation process found these issues that can lead to rejections:"
 msgstr ""
 
-#: static/js/common/upload-addon.js:518
+#: static/js/common/upload-addon.js:503 static/js/zamboni/devhub-all.js:749 static/js/zamboni/devhub-min.js:1
 msgid "If you are unfamiliar with the add-ons review process, you can read about it here."
 msgstr ""
 
-#: static/js/common/upload-addon.js:555
+#: static/js/common/upload-addon.js:540 static/js/zamboni/devhub-all.js:786 static/js/zamboni/devhub-min.js:1
 msgid "Sorry, no supported platform has been found."
 msgstr ""
 
-#: static/js/common/upload-base.js:57
+#: static/js/common/upload-base.js:57 static/js/zamboni/devhub-all.js:187 static/js/zamboni/devhub-min.js:1
 msgid "The filetype you uploaded isn't recognized."
 msgstr ""
 
-#: static/js/common/upload-base.js:79
+#: static/js/common/upload-base.js:79 static/js/zamboni/devhub-all.js:209 static/js/zamboni/devhub-min.js:1
 msgid "You cancelled the upload."
 msgstr ""
 
-#: static/js/common/upload-image.js:97 static/js/impala/users.js:51
-msgid "Images must be either PNG or JPG."
-msgstr ""
-
-#: static/js/common/upload-image.js:101
-msgid "Videos must be in WebM."
-msgstr ""
-
-#: static/js/impala/collections.js:10 static/js/zamboni/collections.js:595
-msgid "Follow this Collection"
-msgstr ""
-
-#: static/js/impala/collections.js:19
-msgid "Stop Following"
-msgstr ""
-
-#: static/js/impala/collections.js:20
-msgid "Following"
-msgstr ""
-
-#. L10n: {0} is an app name.
-#: static/js/impala/listing.js:11 static/js/zamboni/themes.js:13
-msgid "This theme is incompatible with your version of {0}"
-msgstr ""
-
-#: static/js/impala/persona_creation.js:60
-msgid "All Rights Reserved"
-msgstr ""
-
-#: static/js/impala/persona_creation.js:64
-msgid "Creative Commons Attribution 3.0"
-msgstr ""
-
-#: static/js/impala/persona_creation.js:69
-msgid "Creative Commons Attribution-NonCommercial 3.0"
-msgstr ""
-
-#: static/js/impala/persona_creation.js:74
-msgid "Creative Commons Attribution-NonCommercial-NoDerivs 3.0"
-msgstr ""
-
-#: static/js/impala/persona_creation.js:79
-msgid "Creative Commons Attribution-NonCommercial-Share Alike 3.0"
-msgstr ""
-
-#: static/js/impala/persona_creation.js:84
-msgid "Creative Commons Attribution-NoDerivs 3.0"
-msgstr ""
-
-#: static/js/impala/persona_creation.js:89
-msgid "Creative Commons Attribution-ShareAlike 3.0"
-msgstr ""
-
-#: static/js/impala/persona_creation.js:292
-msgid "Your Theme's Name"
-msgstr ""
-
-#: static/js/impala/reviews.js:23 static/js/zamboni/reviews.js:18
-msgid "Flagged for review"
-msgstr ""
-
-#: static/js/impala/reviews.js:40 static/js/zamboni/reviews.js:34
-msgid "Your input is required"
-msgstr ""
-
-#: static/js/impala/reviews.js:152 static/js/zamboni/reviews.js:103
-msgid "Marked for deletion"
-msgstr ""
-
-#: static/js/impala/search.js:114
-msgid "Updating results&hellip;"
-msgstr ""
-
-#: static/js/impala/site_suggestions.js:46
-msgid "Category"
-msgstr ""
-
-#: static/js/impala/suggestions.js:39
-msgid "Search themes for <b>{0}</b>"
-msgstr ""
-
-#: static/js/impala/suggestions.js:41
-msgid "Search apps for <b>{0}</b>"
-msgstr ""
-
-#: static/js/impala/suggestions.js:43
-msgid "Search add-ons for <b>{0}</b>"
-msgstr ""
-
-#: static/js/impala/users.js:33
-msgid "use original"
-msgstr ""
-
-#: static/js/impala/stats/chart.js:267
+#: static/js/impala/stats/chart.js:267 static/js/zamboni/stats-all.js:16898 static/js/zamboni/stats-min.js:5
 msgid "Week of {0}"
 msgstr ""
 
-#: static/js/impala/stats/chart.js:269
+#: static/js/impala/stats/chart.js:269 static/js/zamboni/stats-all.js:16900 static/js/zamboni/stats-min.js:5
 msgid " downloads"
 msgstr ""
 
-#: static/js/impala/stats/chart.js:270
+#: static/js/impala/stats/chart.js:270 static/js/zamboni/stats-all.js:16901 static/js/zamboni/stats-min.js:5
 msgid "{0} users"
 msgstr ""
 
-#: static/js/impala/stats/chart.js:271
+#: static/js/impala/stats/chart.js:271 static/js/zamboni/stats-all.js:16902 static/js/zamboni/stats-min.js:5
 msgid "{0} add-ons"
 msgstr ""
 
-#: static/js/impala/stats/chart.js:272
+#: static/js/impala/stats/chart.js:272 static/js/zamboni/stats-all.js:16903 static/js/zamboni/stats-min.js:5
 msgid "{0} collections"
 msgstr ""
 
-#: static/js/impala/stats/chart.js:273
+#: static/js/impala/stats/chart.js:273 static/js/zamboni/stats-all.js:16904 static/js/zamboni/stats-min.js:5
 msgid "{0} reviews"
 msgstr ""
 
-#: static/js/impala/stats/chart.js:275
+#: static/js/impala/stats/chart.js:275 static/js/zamboni/stats-all.js:16906 static/js/zamboni/stats-min.js:5
 msgid "{0} sales"
 msgstr ""
 
-#: static/js/impala/stats/chart.js:276
+#: static/js/impala/stats/chart.js:276 static/js/zamboni/stats-all.js:16907 static/js/zamboni/stats-min.js:5
 msgid "{0} refunds"
 msgstr ""
 
-#: static/js/impala/stats/chart.js:277
+#: static/js/impala/stats/chart.js:277 static/js/zamboni/stats-all.js:16908 static/js/zamboni/stats-min.js:5
 msgid "{0} installs"
 msgstr ""
 
-#: static/js/impala/stats/chart.js:369 static/js/impala/stats/csv_keys.js:3 static/js/impala/stats/csv_keys.js:109
+#: static/js/impala/stats/chart.js:369 static/js/impala/stats/csv_keys.js:3 static/js/impala/stats/csv_keys.js:109 static/js/zamboni/stats-all.js:15284 static/js/zamboni/stats-all.js:15390
+#: static/js/zamboni/stats-all.js:17000 static/js/zamboni/stats-min.js:4 static/js/zamboni/stats-min.js:5
 msgid "Downloads"
 msgstr ""
 
-#: static/js/impala/stats/chart.js:379 static/js/impala/stats/csv_keys.js:6 static/js/impala/stats/csv_keys.js:110
+#: static/js/impala/stats/chart.js:379 static/js/impala/stats/csv_keys.js:6 static/js/impala/stats/csv_keys.js:110 static/js/zamboni/stats-all.js:15287 static/js/zamboni/stats-all.js:15391
+#: static/js/zamboni/stats-all.js:17010 static/js/zamboni/stats-min.js:4 static/js/zamboni/stats-min.js:5
 msgid "Daily Users"
 msgstr ""
 
-#: static/js/impala/stats/chart.js:410
+#: static/js/impala/stats/chart.js:410 static/js/zamboni/stats-all.js:17041 static/js/zamboni/stats-min.js:5
 msgid "Amount, in USD"
 msgstr ""
 
-#: static/js/impala/stats/chart.js:421 static/js/impala/stats/csv_keys.js:104
+#: static/js/impala/stats/chart.js:421 static/js/impala/stats/csv_keys.js:104 static/js/zamboni/stats-all.js:15385 static/js/zamboni/stats-all.js:17052 static/js/zamboni/stats-min.js:5
 msgid "Number of Contributions"
 msgstr ""
 
-#: static/js/impala/stats/chart.js:447
+#: static/js/impala/stats/chart.js:447 static/js/zamboni/stats-all.js:17078 static/js/zamboni/stats-min.js:5
 msgid "More Info..."
 msgstr ""
 
 #. L10n: {0} is an ISO-formatted date.
-#: static/js/impala/stats/chart.js:451
+#: static/js/impala/stats/chart.js:451 static/js/zamboni/stats-all.js:17082 static/js/zamboni/stats-min.js:5
 msgid "Details for {0}"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:9
+#: static/js/impala/stats/csv_keys.js:9 static/js/zamboni/stats-all.js:15290 static/js/zamboni/stats-min.js:4
 msgid "Collections Created"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:12
+#: static/js/impala/stats/csv_keys.js:12 static/js/zamboni/stats-all.js:15293 static/js/zamboni/stats-min.js:4
 msgid "Add-ons in Use"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:15
+#: static/js/impala/stats/csv_keys.js:15 static/js/zamboni/stats-all.js:15296 static/js/zamboni/stats-min.js:4
 msgid "Add-ons Created"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:18
+#: static/js/impala/stats/csv_keys.js:18 static/js/zamboni/stats-all.js:15299 static/js/zamboni/stats-min.js:4
 msgid "Add-ons Downloaded"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:21
+#: static/js/impala/stats/csv_keys.js:21 static/js/zamboni/stats-all.js:15302 static/js/zamboni/stats-min.js:4
 msgid "Add-ons Updated"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:24
+#: static/js/impala/stats/csv_keys.js:24 static/js/zamboni/stats-all.js:15305 static/js/zamboni/stats-min.js:4
 msgid "Reviews Written"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:27
+#: static/js/impala/stats/csv_keys.js:27 static/js/zamboni/stats-all.js:15308 static/js/zamboni/stats-min.js:4
 msgid "User Signups"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:30
+#: static/js/impala/stats/csv_keys.js:30 static/js/zamboni/stats-all.js:15311 static/js/zamboni/stats-min.js:4
 msgid "Subscribers"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:33
+#: static/js/impala/stats/csv_keys.js:33 static/js/zamboni/stats-all.js:15314 static/js/zamboni/stats-min.js:4
 msgid "Ratings"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:36 static/js/impala/stats/csv_keys.js:114
+#: static/js/impala/stats/csv_keys.js:36 static/js/impala/stats/csv_keys.js:114 static/js/zamboni/stats-all.js:15317 static/js/zamboni/stats-all.js:15395 static/js/zamboni/stats-min.js:4
+#: static/js/zamboni/stats-min.js:5
 msgid "Sales"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:39 static/js/impala/stats/csv_keys.js:113
+#: static/js/impala/stats/csv_keys.js:39 static/js/impala/stats/csv_keys.js:113 static/js/zamboni/stats-all.js:15320 static/js/zamboni/stats-all.js:15394 static/js/zamboni/stats-min.js:4
+#: static/js/zamboni/stats-min.js:5
 msgid "Installs"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:42
+#: static/js/impala/stats/csv_keys.js:42 static/js/zamboni/stats-all.js:15323 static/js/zamboni/stats-min.js:4
 msgid "Unknown"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:43
+#: static/js/impala/stats/csv_keys.js:43 static/js/zamboni/stats-all.js:15324 static/js/zamboni/stats-min.js:4
 msgid "Add-ons Manager"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:44
+#: static/js/impala/stats/csv_keys.js:44 static/js/zamboni/stats-all.js:15325 static/js/zamboni/stats-min.js:4
 msgid "Add-ons Manager Promo"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:45
+#: static/js/impala/stats/csv_keys.js:45 static/js/zamboni/stats-all.js:15326 static/js/zamboni/stats-min.js:4
 msgid "Add-ons Manager Featured"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:46
+#: static/js/impala/stats/csv_keys.js:46 static/js/zamboni/stats-all.js:15327 static/js/zamboni/stats-min.js:4
 msgid "Add-ons Manager Learn More"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:47
+#: static/js/impala/stats/csv_keys.js:47 static/js/zamboni/stats-all.js:15328 static/js/zamboni/stats-min.js:4
 msgid "Search Suggestions"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:48
+#: static/js/impala/stats/csv_keys.js:48 static/js/zamboni/stats-all.js:15329 static/js/zamboni/stats-min.js:4
 msgid "Search Results"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:49 static/js/impala/stats/csv_keys.js:50 static/js/impala/stats/csv_keys.js:51
+#: static/js/impala/stats/csv_keys.js:49 static/js/impala/stats/csv_keys.js:50 static/js/impala/stats/csv_keys.js:51 static/js/zamboni/stats-all.js:15330 static/js/zamboni/stats-all.js:15331
+#: static/js/zamboni/stats-all.js:15332 static/js/zamboni/stats-min.js:4
 msgid "Homepage Promo"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:52 static/js/impala/stats/csv_keys.js:53
+#: static/js/impala/stats/csv_keys.js:52 static/js/impala/stats/csv_keys.js:53 static/js/zamboni/stats-all.js:15333 static/js/zamboni/stats-all.js:15334 static/js/zamboni/stats-min.js:4
 msgid "Homepage Featured"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:54 static/js/impala/stats/csv_keys.js:55
+#: static/js/impala/stats/csv_keys.js:54 static/js/impala/stats/csv_keys.js:55 static/js/zamboni/stats-all.js:15335 static/js/zamboni/stats-all.js:15336 static/js/zamboni/stats-min.js:4
 msgid "Homepage Up and Coming"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:56
+#: static/js/impala/stats/csv_keys.js:56 static/js/zamboni/stats-all.js:15337 static/js/zamboni/stats-min.js:4
 msgid "Homepage Most Popular"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:57 static/js/impala/stats/csv_keys.js:59
+#: static/js/impala/stats/csv_keys.js:57 static/js/impala/stats/csv_keys.js:59 static/js/zamboni/stats-all.js:15338 static/js/zamboni/stats-all.js:15340 static/js/zamboni/stats-min.js:4
 msgid "Detail Page"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:58 static/js/impala/stats/csv_keys.js:60
+#: static/js/impala/stats/csv_keys.js:58 static/js/impala/stats/csv_keys.js:60 static/js/zamboni/stats-all.js:15339 static/js/zamboni/stats-all.js:15341 static/js/zamboni/stats-min.js:4
 msgid "Detail Page (bottom)"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:61
+#: static/js/impala/stats/csv_keys.js:61 static/js/zamboni/stats-all.js:15342 static/js/zamboni/stats-min.js:4
 msgid "Detail Page (Development Channel)"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:62 static/js/impala/stats/csv_keys.js:63 static/js/impala/stats/csv_keys.js:64
+#: static/js/impala/stats/csv_keys.js:62 static/js/impala/stats/csv_keys.js:63 static/js/impala/stats/csv_keys.js:64 static/js/zamboni/stats-all.js:15343 static/js/zamboni/stats-all.js:15344
+#: static/js/zamboni/stats-all.js:15345 static/js/zamboni/stats-min.js:4
 msgid "Often Used With"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:65 static/js/impala/stats/csv_keys.js:66
+#: static/js/impala/stats/csv_keys.js:65 static/js/impala/stats/csv_keys.js:66 static/js/zamboni/stats-all.js:15346 static/js/zamboni/stats-all.js:15347 static/js/zamboni/stats-min.js:4
 msgid "Others By Author"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:67 static/js/impala/stats/csv_keys.js:68
+#: static/js/impala/stats/csv_keys.js:67 static/js/impala/stats/csv_keys.js:68 static/js/zamboni/stats-all.js:15348 static/js/zamboni/stats-all.js:15349 static/js/zamboni/stats-min.js:4
 msgid "Dependencies"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:69 static/js/impala/stats/csv_keys.js:70
+#: static/js/impala/stats/csv_keys.js:69 static/js/impala/stats/csv_keys.js:70 static/js/zamboni/stats-all.js:15350 static/js/zamboni/stats-all.js:15351 static/js/zamboni/stats-min.js:4
 msgid "Upsell"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:71
+#: static/js/impala/stats/csv_keys.js:71 static/js/zamboni/stats-all.js:15352 static/js/zamboni/stats-min.js:4
 msgid "Meet the Developer"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:72
+#: static/js/impala/stats/csv_keys.js:72 static/js/zamboni/stats-all.js:15353 static/js/zamboni/stats-min.js:4
 msgid "User Profile"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:73
+#: static/js/impala/stats/csv_keys.js:73 static/js/zamboni/stats-all.js:15354 static/js/zamboni/stats-min.js:4
 msgid "Version History"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:75
+#: static/js/impala/stats/csv_keys.js:75 static/js/zamboni/stats-all.js:15356 static/js/zamboni/stats-min.js:4
 msgid "Sharing"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:76
+#: static/js/impala/stats/csv_keys.js:76 static/js/zamboni/stats-all.js:15357 static/js/zamboni/stats-min.js:4
 msgid "Category Pages"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:77
+#: static/js/impala/stats/csv_keys.js:77 static/js/zamboni/stats-all.js:15358 static/js/zamboni/stats-min.js:4
 msgid "Collections"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:78 static/js/impala/stats/csv_keys.js:79
+#: static/js/impala/stats/csv_keys.js:78 static/js/impala/stats/csv_keys.js:79 static/js/zamboni/stats-all.js:15359 static/js/zamboni/stats-all.js:15360 static/js/zamboni/stats-min.js:4
 msgid "Category Landing Featured Carousel"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:80 static/js/impala/stats/csv_keys.js:81
+#: static/js/impala/stats/csv_keys.js:80 static/js/impala/stats/csv_keys.js:81 static/js/zamboni/stats-all.js:15361 static/js/zamboni/stats-all.js:15362 static/js/zamboni/stats-min.js:4
 msgid "Category Landing Top Rated"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:82 static/js/impala/stats/csv_keys.js:83
+#: static/js/impala/stats/csv_keys.js:82 static/js/impala/stats/csv_keys.js:83 static/js/zamboni/stats-all.js:15363 static/js/zamboni/stats-all.js:15364 static/js/zamboni/stats-min.js:5
 msgid "Category Landing Most Popular"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:84 static/js/impala/stats/csv_keys.js:85
+#: static/js/impala/stats/csv_keys.js:84 static/js/impala/stats/csv_keys.js:85 static/js/zamboni/stats-all.js:15365 static/js/zamboni/stats-all.js:15366 static/js/zamboni/stats-min.js:5
 msgid "Category Landing Recently Added"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:86 static/js/impala/stats/csv_keys.js:87
+#: static/js/impala/stats/csv_keys.js:86 static/js/impala/stats/csv_keys.js:87 static/js/zamboni/stats-all.js:15367 static/js/zamboni/stats-all.js:15368 static/js/zamboni/stats-min.js:5
 msgid "Browse Listing Featured Sort"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:88 static/js/impala/stats/csv_keys.js:89
+#: static/js/impala/stats/csv_keys.js:88 static/js/impala/stats/csv_keys.js:89 static/js/zamboni/stats-all.js:15369 static/js/zamboni/stats-all.js:15370 static/js/zamboni/stats-min.js:5
 msgid "Browse Listing Users Sort"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:90 static/js/impala/stats/csv_keys.js:91
+#: static/js/impala/stats/csv_keys.js:90 static/js/impala/stats/csv_keys.js:91 static/js/zamboni/stats-all.js:15371 static/js/zamboni/stats-all.js:15372 static/js/zamboni/stats-min.js:5
 msgid "Browse Listing Rating Sort"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:92 static/js/impala/stats/csv_keys.js:93
+#: static/js/impala/stats/csv_keys.js:92 static/js/impala/stats/csv_keys.js:93 static/js/zamboni/stats-all.js:15373 static/js/zamboni/stats-all.js:15374 static/js/zamboni/stats-min.js:5
 msgid "Browse Listing Created Sort"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:94 static/js/impala/stats/csv_keys.js:95
+#: static/js/impala/stats/csv_keys.js:94 static/js/impala/stats/csv_keys.js:95 static/js/zamboni/stats-all.js:15375 static/js/zamboni/stats-all.js:15376 static/js/zamboni/stats-min.js:5
 msgid "Browse Listing Name Sort"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:96 static/js/impala/stats/csv_keys.js:97
+#: static/js/impala/stats/csv_keys.js:96 static/js/impala/stats/csv_keys.js:97 static/js/zamboni/stats-all.js:15377 static/js/zamboni/stats-all.js:15378 static/js/zamboni/stats-min.js:5
 msgid "Browse Listing Popular Sort"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:98 static/js/impala/stats/csv_keys.js:99
+#: static/js/impala/stats/csv_keys.js:98 static/js/impala/stats/csv_keys.js:99 static/js/zamboni/stats-all.js:15379 static/js/zamboni/stats-all.js:15380 static/js/zamboni/stats-min.js:5
 msgid "Browse Listing Updated Sort"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:100 static/js/impala/stats/csv_keys.js:101
+#: static/js/impala/stats/csv_keys.js:100 static/js/impala/stats/csv_keys.js:101 static/js/zamboni/stats-all.js:15381 static/js/zamboni/stats-all.js:15382 static/js/zamboni/stats-min.js:5
 msgid "Browse Listing Up and Coming Sort"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:105
+#: static/js/impala/stats/csv_keys.js:105 static/js/zamboni/stats-all.js:15386 static/js/zamboni/stats-min.js:5
 msgid "Total Amount Contributed"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:106
+#: static/js/impala/stats/csv_keys.js:106 static/js/zamboni/stats-all.js:15387 static/js/zamboni/stats-min.js:5
 msgid "Average Contribution"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:115
+#: static/js/impala/stats/csv_keys.js:115 static/js/zamboni/stats-all.js:15396 static/js/zamboni/stats-min.js:5
 msgid "Usage"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:118
+#: static/js/impala/stats/csv_keys.js:118 static/js/zamboni/stats-all.js:15399 static/js/zamboni/stats-min.js:5
 msgid "Firefox"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:119
+#: static/js/impala/stats/csv_keys.js:119 static/js/zamboni/stats-all.js:15400 static/js/zamboni/stats-min.js:5
 msgid "Mozilla"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:120
+#: static/js/impala/stats/csv_keys.js:120 static/js/zamboni/stats-all.js:15401 static/js/zamboni/stats-min.js:5
 msgid "Thunderbird"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:121
+#: static/js/impala/stats/csv_keys.js:121 static/js/zamboni/stats-all.js:15402 static/js/zamboni/stats-min.js:5
 msgid "Sunbird"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:122
+#: static/js/impala/stats/csv_keys.js:122 static/js/zamboni/stats-all.js:15403 static/js/zamboni/stats-min.js:5
 msgid "SeaMonkey"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:123
+#: static/js/impala/stats/csv_keys.js:123 static/js/zamboni/stats-all.js:15404 static/js/zamboni/stats-min.js:5
 msgid "Fennec"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:124
+#: static/js/impala/stats/csv_keys.js:124 static/js/zamboni/stats-all.js:15405 static/js/zamboni/stats-min.js:5
 msgid "Android"
 msgstr ""
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:129
+#: static/js/impala/stats/csv_keys.js:129 static/js/zamboni/stats-all.js:15410 static/js/zamboni/stats-min.js:5
 msgid "Downloads and Daily Users, last {0} days"
 msgstr ""
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:131
+#: static/js/impala/stats/csv_keys.js:131 static/js/zamboni/stats-all.js:15412 static/js/zamboni/stats-min.js:5
 msgid "Downloads and Daily Users from {0} to {1}"
 msgstr ""
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:135
+#: static/js/impala/stats/csv_keys.js:135 static/js/zamboni/stats-all.js:15416 static/js/zamboni/stats-min.js:5
 msgid "Installs and Daily Users, last {0} days"
 msgstr ""
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:137
+#: static/js/impala/stats/csv_keys.js:137 static/js/zamboni/stats-all.js:15418 static/js/zamboni/stats-min.js:5
 msgid "Installs and Daily Users from {0} to {1}"
 msgstr ""
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:141
+#: static/js/impala/stats/csv_keys.js:141 static/js/zamboni/stats-all.js:15422 static/js/zamboni/stats-min.js:5
 msgid "Downloads, last {0} days"
 msgstr ""
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:143
+#: static/js/impala/stats/csv_keys.js:143 static/js/zamboni/stats-all.js:15424 static/js/zamboni/stats-min.js:5
 msgid "Downloads from {0} to {1}"
 msgstr ""
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:147
+#: static/js/impala/stats/csv_keys.js:147 static/js/zamboni/stats-all.js:15428 static/js/zamboni/stats-min.js:5
 msgid "Daily Users, last {0} days"
 msgstr ""
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:149
+#: static/js/impala/stats/csv_keys.js:149 static/js/zamboni/stats-all.js:15430 static/js/zamboni/stats-min.js:5
 msgid "Daily Users from {0} to {1}"
 msgstr ""
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:153
+#: static/js/impala/stats/csv_keys.js:153 static/js/zamboni/stats-all.js:15434 static/js/zamboni/stats-min.js:5
 msgid "Applications, last {0} days"
 msgstr ""
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:155
+#: static/js/impala/stats/csv_keys.js:155 static/js/zamboni/stats-all.js:15436 static/js/zamboni/stats-min.js:5
 msgid "Applications from {0} to {1}"
 msgstr ""
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:159
+#: static/js/impala/stats/csv_keys.js:159 static/js/zamboni/stats-all.js:15440 static/js/zamboni/stats-min.js:5
 msgid "Platforms, last {0} days"
 msgstr ""
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:161
+#: static/js/impala/stats/csv_keys.js:161 static/js/zamboni/stats-all.js:15442 static/js/zamboni/stats-min.js:5
 msgid "Platforms from {0} to {1}"
 msgstr ""
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:165
+#: static/js/impala/stats/csv_keys.js:165 static/js/zamboni/stats-all.js:15446 static/js/zamboni/stats-min.js:5
 msgid "Languages, last {0} days"
 msgstr ""
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:167
+#: static/js/impala/stats/csv_keys.js:167 static/js/zamboni/stats-all.js:15448 static/js/zamboni/stats-min.js:5
 msgid "Languages from {0} to {1}"
 msgstr ""
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:171
+#: static/js/impala/stats/csv_keys.js:171 static/js/zamboni/stats-all.js:15452 static/js/zamboni/stats-min.js:5
 msgid "Add-on Versions, last {0} days"
 msgstr ""
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:173
+#: static/js/impala/stats/csv_keys.js:173 static/js/zamboni/stats-all.js:15454 static/js/zamboni/stats-min.js:5
 msgid "Add-on Versions from {0} to {1}"
 msgstr ""
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:177
+#: static/js/impala/stats/csv_keys.js:177 static/js/zamboni/stats-all.js:15458 static/js/zamboni/stats-min.js:5
 msgid "Add-on Status, last {0} days"
 msgstr ""
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:179
+#: static/js/impala/stats/csv_keys.js:179 static/js/zamboni/stats-all.js:15460 static/js/zamboni/stats-min.js:5
 msgid "Add-on Status from {0} to {1}"
 msgstr ""
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:183
+#: static/js/impala/stats/csv_keys.js:183 static/js/zamboni/stats-all.js:15464 static/js/zamboni/stats-min.js:5
 msgid "Download Sources, last {0} days"
 msgstr ""
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:185
+#: static/js/impala/stats/csv_keys.js:185 static/js/zamboni/stats-all.js:15466 static/js/zamboni/stats-min.js:5
 msgid "Download Sources from {0} to {1}"
 msgstr ""
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:189
+#: static/js/impala/stats/csv_keys.js:189 static/js/zamboni/stats-all.js:15470 static/js/zamboni/stats-min.js:5
 msgid "Contributions, last {0} days"
 msgstr ""
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:191
+#: static/js/impala/stats/csv_keys.js:191 static/js/zamboni/stats-all.js:15472 static/js/zamboni/stats-min.js:5
 msgid "Contributions from {0} to {1}"
 msgstr ""
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:195
+#: static/js/impala/stats/csv_keys.js:195 static/js/zamboni/stats-all.js:15476 static/js/zamboni/stats-min.js:5
 msgid "Site Metrics, last {0} days"
 msgstr ""
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:197
+#: static/js/impala/stats/csv_keys.js:197 static/js/zamboni/stats-all.js:15478 static/js/zamboni/stats-min.js:5
 msgid "Site Metrics from {0} to {1}"
 msgstr ""
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:201
+#: static/js/impala/stats/csv_keys.js:201 static/js/zamboni/stats-all.js:15482 static/js/zamboni/stats-min.js:5
 msgid "Add-ons in Use, last {0} days"
 msgstr ""
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:203
+#: static/js/impala/stats/csv_keys.js:203 static/js/zamboni/stats-all.js:15484 static/js/zamboni/stats-min.js:5
 msgid "Add-ons in Use from {0} to {1}"
 msgstr ""
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:207
+#: static/js/impala/stats/csv_keys.js:207 static/js/zamboni/stats-all.js:15488 static/js/zamboni/stats-min.js:5
 msgid "Add-ons Downloaded, last {0} days"
 msgstr ""
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:209
+#: static/js/impala/stats/csv_keys.js:209 static/js/zamboni/stats-all.js:15490 static/js/zamboni/stats-min.js:5
 msgid "Add-ons Downloaded from {0} to {1}"
 msgstr ""
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:213
+#: static/js/impala/stats/csv_keys.js:213 static/js/zamboni/stats-all.js:15494 static/js/zamboni/stats-min.js:5
 msgid "Add-ons Created, last {0} days"
 msgstr ""
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:215
+#: static/js/impala/stats/csv_keys.js:215 static/js/zamboni/stats-all.js:15496 static/js/zamboni/stats-min.js:5
 msgid "Add-ons Created from {0} to {1}"
 msgstr ""
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:219
+#: static/js/impala/stats/csv_keys.js:219 static/js/zamboni/stats-all.js:15500 static/js/zamboni/stats-min.js:5
 msgid "Add-ons Updated, last {0} days"
 msgstr ""
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:221
+#: static/js/impala/stats/csv_keys.js:221 static/js/zamboni/stats-all.js:15502 static/js/zamboni/stats-min.js:5
 msgid "Add-ons Updated from {0} to {1}"
 msgstr ""
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:225
+#: static/js/impala/stats/csv_keys.js:225 static/js/zamboni/stats-all.js:15506 static/js/zamboni/stats-min.js:5
 msgid "Reviews Written, last {0} days"
 msgstr ""
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:227
+#: static/js/impala/stats/csv_keys.js:227 static/js/zamboni/stats-all.js:15508 static/js/zamboni/stats-min.js:5
 msgid "Reviews Written from {0} to {1}"
 msgstr ""
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:231
+#: static/js/impala/stats/csv_keys.js:231 static/js/zamboni/stats-all.js:15512 static/js/zamboni/stats-min.js:5
 msgid "User Signups, last {0} days"
 msgstr ""
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:233
+#: static/js/impala/stats/csv_keys.js:233 static/js/zamboni/stats-all.js:15514 static/js/zamboni/stats-min.js:5
 msgid "User Signups from {0} to {1}"
 msgstr ""
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:237
+#: static/js/impala/stats/csv_keys.js:237 static/js/zamboni/stats-all.js:15518 static/js/zamboni/stats-min.js:5
 msgid "Collections Created, last {0} days"
 msgstr ""
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:239
+#: static/js/impala/stats/csv_keys.js:239 static/js/zamboni/stats-all.js:15520 static/js/zamboni/stats-min.js:5
 msgid "Collections Created from {0} to {1}"
 msgstr ""
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:243
+#: static/js/impala/stats/csv_keys.js:243 static/js/zamboni/stats-all.js:15524 static/js/zamboni/stats-min.js:5
 msgid "Subscribers, last {0} days"
 msgstr ""
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:245
+#: static/js/impala/stats/csv_keys.js:245 static/js/zamboni/stats-all.js:15526 static/js/zamboni/stats-min.js:5
 msgid "Subscribers from {0} to {1}"
 msgstr ""
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:249
+#: static/js/impala/stats/csv_keys.js:249 static/js/zamboni/stats-all.js:15530 static/js/zamboni/stats-min.js:5
 msgid "Ratings, last {0} days"
 msgstr ""
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:251
+#: static/js/impala/stats/csv_keys.js:251 static/js/zamboni/stats-all.js:15532 static/js/zamboni/stats-min.js:5
 msgid "Ratings from {0} to {1}"
 msgstr ""
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:255
+#: static/js/impala/stats/csv_keys.js:255 static/js/zamboni/stats-all.js:15536 static/js/zamboni/stats-min.js:5
 msgid "Sales, last {0} days"
 msgstr ""
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:257
+#: static/js/impala/stats/csv_keys.js:257 static/js/zamboni/stats-all.js:15538 static/js/zamboni/stats-min.js:5
 msgid "Sales from {0} to {1}"
 msgstr ""
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:261
+#: static/js/impala/stats/csv_keys.js:261 static/js/zamboni/stats-all.js:15542 static/js/zamboni/stats-min.js:5
 msgid "Installs, last {0} days"
 msgstr ""
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:263
+#: static/js/impala/stats/csv_keys.js:263 static/js/zamboni/stats-all.js:15544 static/js/zamboni/stats-min.js:5
 msgid "Installs from {0} to {1}"
 msgstr ""
 
 #. L10n: {0} and {1} are integers.
-#: static/js/impala/stats/csv_keys.js:269
+#: static/js/impala/stats/csv_keys.js:269 static/js/zamboni/stats-all.js:15550 static/js/zamboni/stats-min.js:5
 msgid "<b>{0}</b> in last {1} days"
 msgstr ""
 
 #. L10n: {0} is an integer and {1} and {2} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:271 static/js/impala/stats/csv_keys.js:277
+#: static/js/impala/stats/csv_keys.js:271 static/js/impala/stats/csv_keys.js:277 static/js/zamboni/stats-all.js:15552 static/js/zamboni/stats-all.js:15558 static/js/zamboni/stats-min.js:5
 msgid "<b>{0}</b> from {1} to {2}"
 msgstr ""
 
 #. L10n: {0} and {1} are integers.
-#: static/js/impala/stats/csv_keys.js:275
+#: static/js/impala/stats/csv_keys.js:275 static/js/zamboni/stats-all.js:15556 static/js/zamboni/stats-min.js:5
 msgid "<b>{0}</b> average in last {1} days"
 msgstr ""
 
-#: static/js/impala/stats/overview.js:19
+#: static/js/impala/stats/overview.js:19 static/js/zamboni/stats-all.js:16469 static/js/zamboni/stats-min.js:5
 msgid "No data available."
 msgstr ""
 
-#: static/js/impala/stats/table.js:74
+#: static/js/impala/stats/table.js:74 static/js/zamboni/stats-all.js:17209 static/js/zamboni/stats-min.js:5
 msgid "Date"
 msgstr ""
 
-#: static/js/impala/stats/topchart.js:96
+#: static/js/impala/stats/topchart.js:96 static/js/zamboni/stats-all.js:16600 static/js/zamboni/stats-min.js:5
 msgid "Other"
 msgstr ""
 
-#: static/js/zamboni/admin_validation.js:24 static/js/zamboni/devhub.js:1229 static/js/zamboni/editors.js:295
+#: static/js/zamboni/admin-all.js:180 static/js/zamboni/admin-min.js:1 static/js/zamboni/admin_validation.js:24 static/js/zamboni/devhub-all.js:2408 static/js/zamboni/devhub-min.js:2
+#: static/js/zamboni/devhub.js:1229 static/js/zamboni/editors-all.js:15576 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:295
 msgid "Select an application first"
 msgstr ""
 
-#: static/js/zamboni/admin_validation.js:51
+#: static/js/zamboni/admin-all.js:207 static/js/zamboni/admin-min.js:1 static/js/zamboni/admin_validation.js:51
 msgid "Set {0} add-on to a max version of {1} and email the author."
 msgid_plural "Set {0} add-ons to a max version of {1} and email the authors."
 msgstr[0] ""
 msgstr[1] ""
-msgstr[2] ""
 
-#: static/js/zamboni/admin_validation.js:54
+#: static/js/zamboni/admin-all.js:210 static/js/zamboni/admin-min.js:1 static/js/zamboni/admin_validation.js:54
 msgid "Email author of {2} add-on which failed validation."
 msgid_plural "Email authors of {2} add-ons which failed validation."
 msgstr[0] ""
 msgstr[1] ""
-msgstr[2] ""
 
-#. L10n: {0} is an app name like Firefox.
-#: static/js/zamboni/buttons.js:66
-msgid "Accept and Install"
-msgstr ""
-
-#: static/js/zamboni/buttons.js:66
-msgid "Add to {0}"
-msgstr ""
-
-#: static/js/zamboni/buttons.js:71
-msgid "Download Now"
-msgstr ""
-
-#: static/js/zamboni/buttons.js:112
-msgid "Add-on has not been updated to support default-to-compatible."
-msgstr ""
-
-#: static/js/zamboni/buttons.js:117
-msgid "You need to be using Firefox 10.0 or higher."
-msgstr ""
-
-#: static/js/zamboni/buttons.js:129
-msgid "Mozilla has marked this version as incompatible with your Firefox version."
-msgstr ""
-
-#. L10n: {0} is an platform like Windows or Linux.
-#: static/js/zamboni/buttons.js:210
-msgid "Install for {0} anyway"
-msgstr ""
-
-#: static/js/zamboni/buttons.js:210
-msgid "Download for {0} anyway"
-msgstr ""
-
-#: static/js/zamboni/buttons.js:267
-msgid "Not available for your platform"
-msgstr ""
-
-#. L10n: {0} is an app name, {1} is the app version.
-#: static/js/zamboni/buttons.js:278 static/js/zamboni/buttons.js:315
-msgid "Not available for {0} {1}"
-msgstr ""
-
-#: static/js/zamboni/buttons.js:341
-msgid "Works with {app} {min} - {max}"
-msgstr ""
-
-#: static/js/zamboni/buttons.js:343
-msgid "View other versions"
-msgstr ""
-
-#: static/js/zamboni/buttons.js:391
-msgid "Only with Firefox — Get Firefox Now!"
-msgstr ""
-
-#: static/js/zamboni/buttons.js:507 static/js/zamboni/mobile/buttons.js:43
-msgid "Sorry, you need a Mozilla-based browser (such as Firefox) to install a search plugin."
-msgstr ""
-
-#: static/js/zamboni/collections.js:229
-msgid "Adding to Favorites&hellip;"
-msgstr ""
-
-#: static/js/zamboni/collections.js:232
-msgid "Removing Favorite&hellip;"
-msgstr ""
-
-#: static/js/zamboni/collections.js:235
-msgid "Add to Favorites"
-msgstr ""
-
-#: static/js/zamboni/collections.js:238
-msgid "Remove from Favorites"
-msgstr ""
-
-#: static/js/zamboni/collections.js:303
-msgid "Pending"
-msgstr ""
-
-#: static/js/zamboni/collections.js:304
-msgid "Add a comment"
-msgstr ""
-
-#: static/js/zamboni/collections.js:304
-msgid "Comment"
-msgstr ""
-
-#: static/js/zamboni/collections.js:305
-msgid "Remove this add-on from the collection"
-msgstr ""
-
-#: static/js/zamboni/collections.js:305 static/js/zamboni/collections.js:334
-msgid "Remove"
-msgstr ""
-
-#: static/js/zamboni/collections.js:334
-msgid "Remove this user as a contributor"
-msgstr ""
-
-#: static/js/zamboni/collections.js:346
-msgid "An email address is required."
-msgstr ""
-
-#: static/js/zamboni/collections.js:364
-msgid "You cannot add yourself as a contributor."
-msgstr ""
-
-#: static/js/zamboni/collections.js:366
-msgid "You have already added that user."
-msgstr ""
-
-#: static/js/zamboni/collections.js:573
-msgid "Add to favorites"
-msgstr ""
-
-#: static/js/zamboni/collections.js:577
-msgid "Remove from favorites"
-msgstr ""
-
-#: static/js/zamboni/collections.js:604
-msgid "Stop following"
-msgstr ""
-
-#: static/js/zamboni/devhub.js:110
+#: static/js/zamboni/devhub-all.js:1289 static/js/zamboni/devhub-min.js:1 static/js/zamboni/devhub.js:110
 msgid "Your browser does not support the video tag"
 msgstr ""
 
-#: static/js/zamboni/devhub.js:371
+#: static/js/zamboni/devhub-all.js:1550 static/js/zamboni/devhub-min.js:1 static/js/zamboni/devhub.js:371
 msgid "Changes Saved"
 msgstr ""
 
-#: static/js/zamboni/devhub.js:387
+#: static/js/zamboni/devhub-all.js:1566 static/js/zamboni/devhub-min.js:1 static/js/zamboni/devhub.js:387
 msgid "Enter a new author's email address"
 msgstr ""
 
-#: static/js/zamboni/devhub.js:536
+#: static/js/zamboni/devhub-all.js:1715 static/js/zamboni/devhub-min.js:1 static/js/zamboni/devhub.js:536
 msgid "There was an error uploading your file."
 msgstr ""
 
-#: static/js/zamboni/devhub.js:681
+#: static/js/zamboni/devhub-all.js:1860 static/js/zamboni/devhub-min.js:1 static/js/zamboni/devhub.js:681
 msgid "{files} file"
 msgid_plural "{files} files"
 msgstr[0] ""
 msgstr[1] ""
-msgstr[2] ""
 
-#: static/js/zamboni/devhub.js:684
+#: static/js/zamboni/devhub-all.js:1863 static/js/zamboni/devhub-min.js:1 static/js/zamboni/devhub.js:684
 msgid "{reviews} user review"
 msgid_plural "{reviews} user reviews"
 msgstr[0] ""
 msgstr[1] ""
-msgstr[2] ""
 
-#: static/js/zamboni/devhub.js:796
+#: static/js/zamboni/devhub-all.js:1975 static/js/zamboni/devhub-min.js:2 static/js/zamboni/devhub.js:796
 msgid "Learn more"
 msgstr ""
 
-#: static/js/zamboni/devhub.js:800
+#: static/js/zamboni/devhub-all.js:1979 static/js/zamboni/devhub-min.js:2 static/js/zamboni/devhub.js:800
 msgid "Example"
 msgstr ""
 
-#: static/js/zamboni/devhub.js:1130
+#: static/js/zamboni/devhub-all.js:2309 static/js/zamboni/devhub-min.js:2 static/js/zamboni/devhub.js:1130
 msgid "Image changes being processed"
 msgstr ""
 
-#: static/js/zamboni/devhub.js:1280
+#: static/js/zamboni/devhub-all.js:2459 static/js/zamboni/devhub-min.js:2 static/js/zamboni/devhub.js:1280
 msgid "Must be a valid e-mail address."
+msgstr ""
+
+#: static/js/zamboni/devhub-all.js:2613 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:80
+msgid "All tests passed successfully."
+msgstr ""
+
+#: static/js/zamboni/devhub-all.js:2616 static/js/zamboni/devhub-all.js:3011 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:83 static/js/zamboni/validator.js:478
+msgid "These tests were not run."
+msgstr ""
+
+#: static/js/zamboni/devhub-all.js:2664 static/js/zamboni/devhub-all.js:2677 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:131 static/js/zamboni/validator.js:144
+msgid "Tests"
+msgstr ""
+
+#: static/js/zamboni/devhub-all.js:2779 static/js/zamboni/devhub-all.js:3108 static/js/zamboni/devhub-all.js:3127 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:246
+#: static/js/zamboni/validator.js:575 static/js/zamboni/validator.js:594
+msgid "Error"
+msgstr ""
+
+#: static/js/zamboni/devhub-all.js:2780 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:247
+msgid "Warning"
+msgstr ""
+
+#: static/js/zamboni/devhub-all.js:2794 static/js/zamboni/devhub-min.js:2 static/js/zamboni/files-all.js:5657 static/js/zamboni/files-min.js:3 static/js/zamboni/files.js:411
+#: static/js/zamboni/validator.js:261
+msgid "Ignore this message in future updates"
+msgstr ""
+
+#: static/js/zamboni/devhub-all.js:2817 static/js/zamboni/devhub-min.js:2 static/js/zamboni/files-all.js:5663 static/js/zamboni/files-min.js:3 static/js/zamboni/files.js:417
+#: static/js/zamboni/validator.js:284
+msgid "Severity for automated signing:"
+msgstr ""
+
+#: static/js/zamboni/devhub-all.js:2832 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:299
+msgid "Suggestions for passing automated signing:"
+msgstr ""
+
+#: static/js/zamboni/devhub-all.js:2920 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:387
+msgid "Compatibility Tests"
+msgstr ""
+
+#: static/js/zamboni/devhub-all.js:2999 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:466
+msgid "Add-on failed validation."
+msgstr ""
+
+#: static/js/zamboni/devhub-all.js:3001 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:468
+msgid "Add-on passed validation."
+msgstr ""
+
+#: static/js/zamboni/devhub-all.js:3014 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:481
+msgid "{0} error"
+msgid_plural "{0} errors"
+msgstr[0] ""
+msgstr[1] ""
+
+#: static/js/zamboni/devhub-all.js:3016 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:483
+msgid "{0} warning"
+msgid_plural "{0} warnings"
+msgstr[0] ""
+msgstr[1] ""
+
+#: static/js/zamboni/devhub-all.js:3018 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:485
+msgid "{0} notice"
+msgid_plural "{0} notices"
+msgstr[0] ""
+msgstr[1] ""
+
+#: static/js/zamboni/devhub-all.js:3110 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:577
+msgid "Validation task could not complete or completed with errors"
+msgstr ""
+
+#: static/js/zamboni/devhub-all.js:3128 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:595
+msgid "Internal server error"
 msgstr ""
 
 #: static/js/zamboni/devhub_search.js:8
 msgid "No results found."
 msgstr ""
 
-#: static/js/zamboni/editors.js:121
+#: static/js/zamboni/editors-all.js:15402 static/js/zamboni/editors-min.js:4 static/js/zamboni/editors.js:121
 msgid "{name} was viewing this page first."
 msgstr ""
 
-#: static/js/zamboni/editors.js:171
+#: static/js/zamboni/editors-all.js:15452 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:171
 msgid "Receipt checked by app."
 msgstr ""
 
-#: static/js/zamboni/editors.js:173
+#: static/js/zamboni/editors-all.js:15454 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:173
 msgid "Receipt was not checked by app."
 msgstr ""
 
-#: static/js/zamboni/editors.js:244
+#: static/js/zamboni/editors-all.js:15525 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:244
 msgid "{name} was viewing this add-on first."
 msgstr ""
 
-#: static/js/zamboni/editors.js:255
+#: static/js/zamboni/editors-all.js:15536 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:255
 msgid "Loading&hellip;"
 msgstr ""
 
-#: static/js/zamboni/editors.js:260
+#: static/js/zamboni/editors-all.js:15541 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:260
 msgid "Version Notes"
 msgstr ""
 
-#: static/js/zamboni/editors.js:265
+#: static/js/zamboni/editors-all.js:15546 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:265
 msgid "Notes for Reviewers"
 msgstr ""
 
-#: static/js/zamboni/editors.js:270
+#: static/js/zamboni/editors-all.js:15551 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:270
 msgid "No version notes found"
 msgstr ""
 
-#: static/js/zamboni/editors.js:330
+#: static/js/zamboni/editors-all.js:15611 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:330
 msgid "Average Reviews"
 msgstr ""
 
-#: static/js/zamboni/editors.js:386
+#: static/js/zamboni/editors-all.js:15667 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:386
 msgid "Number of Reviews"
 msgstr ""
 
-#: static/js/zamboni/editors.js:445
+#: static/js/zamboni/editors-all.js:15726 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:445
 msgid "Error loading translation"
 msgstr ""
 
-#: static/js/zamboni/files.js:411 static/js/zamboni/validator.js:261
-msgid "Ignore this message in future updates"
-msgstr ""
-
-#: static/js/zamboni/files.js:417 static/js/zamboni/validator.js:284
-msgid "Severity for automated signing:"
-msgstr ""
-
-#: static/js/zamboni/global.js:410
-msgid "Loading..."
-msgstr ""
-
-#. L10n: {0} is the number of characters left.
-#: static/js/zamboni/global.js:474
-msgid "<b>{0}</b> character left."
-msgid_plural "<b>{0}</b> characters left."
-msgstr[0] ""
-msgstr[1] ""
-msgstr[2] ""
-
-#: static/js/zamboni/init.js:28
-msgid "This feature is temporarily disabled while we perform website maintenance. Please check back a little later."
-msgstr ""
-
-#: static/js/zamboni/l10n.js:45
-msgid "Remove this localization"
-msgstr ""
-
-#: static/js/zamboni/password-strength.js:20
-msgid "Password strength:"
-msgstr ""
-
-#: static/js/zamboni/password-strength.js:26
-msgid "At least {0} character left."
-msgid_plural "At least {0} characters left."
-msgstr[0] ""
-msgstr[1] ""
-msgstr[2] ""
-
-#: static/js/zamboni/themes_review.js:176
-msgid "Requested Info"
-msgstr ""
-
-#: static/js/zamboni/themes_review.js:177
-msgid "Flagged"
-msgstr ""
-
-#: static/js/zamboni/themes_review.js:178
-msgid "Duplicate"
-msgstr ""
-
-#: static/js/zamboni/themes_review.js:179
-msgid "Rejected"
-msgstr ""
-
-#: static/js/zamboni/themes_review.js:180
-msgid "Approved"
-msgstr ""
-
-#: static/js/zamboni/themes_review.js:424
-msgid "No results found"
-msgstr ""
-
-#: static/js/zamboni/themes_review_templates.js:31
+#: static/js/zamboni/editors-all.js:15975 static/js/zamboni/editors-min.js:5 static/js/zamboni/themes_review_templates.js:31
 msgid "Theme"
 msgstr ""
 
-#: static/js/zamboni/themes_review_templates.js:33
+#: static/js/zamboni/editors-all.js:15977 static/js/zamboni/editors-min.js:5 static/js/zamboni/themes_review_templates.js:33
 msgid "Reviewer"
 msgstr ""
 
-#: static/js/zamboni/themes_review_templates.js:35
+#: static/js/zamboni/editors-all.js:15979 static/js/zamboni/editors-min.js:5 static/js/zamboni/themes_review_templates.js:35
 msgid "Status"
 msgstr ""
 
-#: static/js/zamboni/validator.js:80
-msgid "All tests passed successfully."
+#: static/js/zamboni/editors-all.js:16196 static/js/zamboni/editors-min.js:5 static/js/zamboni/themes_review.js:176
+msgid "Requested Info"
 msgstr ""
 
-#: static/js/zamboni/validator.js:83 static/js/zamboni/validator.js:478
-msgid "These tests were not run."
+#: static/js/zamboni/editors-all.js:16197 static/js/zamboni/editors-min.js:5 static/js/zamboni/themes_review.js:177
+msgid "Flagged"
 msgstr ""
 
-#: static/js/zamboni/validator.js:131 static/js/zamboni/validator.js:144
-msgid "Tests"
+#: static/js/zamboni/editors-all.js:16198 static/js/zamboni/editors-min.js:5 static/js/zamboni/themes_review.js:178
+msgid "Duplicate"
 msgstr ""
 
-#: static/js/zamboni/validator.js:246 static/js/zamboni/validator.js:575 static/js/zamboni/validator.js:594
-msgid "Error"
+#: static/js/zamboni/editors-all.js:16199 static/js/zamboni/editors-min.js:5 static/js/zamboni/themes_review.js:179
+msgid "Rejected"
 msgstr ""
 
-#: static/js/zamboni/validator.js:247
-msgid "Warning"
+#: static/js/zamboni/editors-all.js:16200 static/js/zamboni/editors-min.js:5 static/js/zamboni/themes_review.js:180
+msgid "Approved"
 msgstr ""
 
-#: static/js/zamboni/validator.js:299
-msgid "Suggestions for passing automated signing:"
+#: static/js/zamboni/editors-all.js:16444 static/js/zamboni/editors-min.js:5 static/js/zamboni/themes_review.js:424
+msgid "No results found"
 msgstr ""
 
-#: static/js/zamboni/validator.js:387
-msgid "Compatibility Tests"
-msgstr ""
-
-#: static/js/zamboni/validator.js:466
-msgid "Add-on failed validation."
-msgstr ""
-
-#: static/js/zamboni/validator.js:468
-msgid "Add-on passed validation."
-msgstr ""
-
-#: static/js/zamboni/validator.js:481
-msgid "{0} error"
-msgid_plural "{0} errors"
-msgstr[0] ""
-msgstr[1] ""
-msgstr[2] ""
-
-#: static/js/zamboni/validator.js:483
-msgid "{0} warning"
-msgid_plural "{0} warnings"
-msgstr[0] ""
-msgstr[1] ""
-msgstr[2] ""
-
-#: static/js/zamboni/validator.js:485
-msgid "{0} notice"
-msgid_plural "{0} notices"
-msgstr[0] ""
-msgstr[1] ""
-msgstr[2] ""
-
-#: static/js/zamboni/validator.js:577
-msgid "Validation task could not complete or completed with errors"
-msgstr ""
-
-#: static/js/zamboni/validator.js:595
-msgid "Internal server error"
-msgstr ""
-
-#: static/js/zamboni/mobile/buttons.js:52
+#: static/js/zamboni/mobile-all.js:15186 static/js/zamboni/mobile/buttons.js:52
 msgid "Not Updated for {0} {1}"
 msgstr ""
 
-#: static/js/zamboni/mobile/buttons.js:53
+#: static/js/zamboni/mobile-all.js:15187 static/js/zamboni/mobile/buttons.js:53
 msgid "Requires Newer Version of {0}"
 msgstr ""
 
-#: static/js/zamboni/mobile/buttons.js:54
+#: static/js/zamboni/mobile-all.js:15188 static/js/zamboni/mobile/buttons.js:54
 msgid "Unreviewed"
 msgstr ""
 
-#: static/js/zamboni/mobile/buttons.js:55
+#: static/js/zamboni/mobile-all.js:15189 static/js/zamboni/mobile/buttons.js:55
 msgid "Experimental <span>(Learn More)</span>"
 msgstr ""
 
-#: static/js/zamboni/mobile/buttons.js:56 static/js/zamboni/mobile/buttons.js:57
+#: static/js/zamboni/mobile-all.js:15190 static/js/zamboni/mobile-all.js:15191 static/js/zamboni/mobile/buttons.js:56 static/js/zamboni/mobile/buttons.js:57
 msgid "Not Available for {0}"
 msgstr ""
 
-#: static/js/zamboni/mobile/buttons.js:58
+#: static/js/zamboni/mobile-all.js:15192 static/js/zamboni/mobile/buttons.js:58
 msgid "Experimental"
 msgstr ""
 
-#: static/js/zamboni/mobile/buttons.js:59
+#: static/js/zamboni/mobile-all.js:15193 static/js/zamboni/mobile/buttons.js:59
 msgid "Themes Require Newer Version of {0}"
 msgstr ""
 
-#: static/js/zamboni/mobile/buttons.js:60
+#: static/js/zamboni/mobile-all.js:15194 static/js/zamboni/mobile/buttons.js:60
 msgid "Themes Require {0}"
 msgstr ""
 
-#: static/js/zamboni/mobile/buttons.js:105
+#: static/js/zamboni/mobile-all.js:15239 static/js/zamboni/mobile/buttons.js:105
 msgid "Installing..."
 msgstr ""
 
-#: static/js/zamboni/mobile/buttons.js:125
+#: static/js/zamboni/mobile-all.js:15259 static/js/zamboni/mobile/buttons.js:125
 msgid "This add-on has been preliminarily reviewed by Mozilla."
 msgstr ""
 
-#: static/js/zamboni/mobile/buttons.js:250
+#: static/js/zamboni/mobile-all.js:15384 static/js/zamboni/mobile/buttons.js:250
 msgid "Keep it"
 msgstr ""
 
-#: static/js/zamboni/mobile/general.js:344
+#: static/js/zamboni/mobile-all.js:16049 static/js/zamboni/mobile-min.js:6 static/js/zamboni/mobile/general.js:344
 msgid "You're trying it on!"
 msgstr ""
 
-#: static/js/zamboni/mobile/general.js:356
+#: static/js/zamboni/mobile-all.js:16061 static/js/zamboni/mobile-min.js:6 static/js/zamboni/mobile/general.js:356
 msgid "Added to Firefox"
 msgstr ""
-

--- a/locale/ru/LC_MESSAGES/django.po
+++ b/locale/ru/LC_MESSAGES/django.po
@@ -9,81 +9,71 @@ msgid ""
 msgstr ""
 "Project-Id-Version: REMORA 0.1\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2016-02-24 21:23+0000\n"
+"POT-Creation-Date: 2016-04-18 15:47+0000\n"
 "PO-Revision-Date: 2016-03-26 18:22+0000\n"
 "Last-Translator: Alexander Slovesnik <unghost@mozilla-russia.org>\n"
 "Language-Team: Russian <ru@li.org>\n"
 "Language: ru\n"
 "MIME-Version: 1.0\n"
-"Content-Type: text/plain; charset=utf-8\n"
+"Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=3; plural=(n%10==1 && n%100!=11 ? 0 : n%10>=2 && n%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2);\n"
 "Generated-By: Babel 2.2.0\n"
-"X-Generator: Pontoon\n"
-
-#: src/olympia/accounts/views.py:52
-msgid "Your log in attempt could not be parsed. Please try again."
-msgstr ""
-"Ваша попытка входа не может быть обработана. Пожалуйста, попробуйте снова."
 
 #: src/olympia/accounts/views.py:54
+msgid "Your log in attempt could not be parsed. Please try again."
+msgstr "Ваша попытка входа не может быть обработана. Пожалуйста, попробуйте снова."
+
+#: src/olympia/accounts/views.py:56
 msgid "Your Firefox Account could not be found. Please try again."
 msgstr "Ваш Firefox аккаунт не найден. Пожалуйста, попробуйте снова."
 
-#: src/olympia/accounts/views.py:55
+#: src/olympia/accounts/views.py:57
 msgid "You could not be logged in. Please try again."
 msgstr "Не удалось войти. Пожалуйста, попробуйте снова."
 
-#: src/olympia/accounts/views.py:57
+#: src/olympia/accounts/views.py:59
 msgid "Your account has already been migrated to Firefox Accounts."
 msgstr "Ваш аккаунт уже перенесён в Firefox аккаунты."
 
-#: src/olympia/accounts/views.py:59
+#: src/olympia/accounts/views.py:61
 msgid "Your Firefox Account already exists on this site."
 msgstr "Ваш Firefox аккаунт уже есть на этом сайте."
 
-#: src/olympia/accounts/views.py:108
+#: src/olympia/accounts/views.py:110
 msgid "Great job!"
 msgstr "Отличная работа!"
 
-#: src/olympia/accounts/views.py:109
+#: src/olympia/accounts/views.py:111
 msgid "You can now log in to Add-ons with your Firefox Account."
 msgstr "Сейчас вы можете войти в дополнения через ваш Firefox аккаунт."
 
-#: src/olympia/accounts/views.py:121
+#: src/olympia/accounts/views.py:123
 msgid "Need help?"
 msgstr "Нужна помощь?"
 
-#: src/olympia/addons/buttons.py:180
+#: src/olympia/addons/buttons.py:177
 msgid "Download Now"
 msgstr "Загрузить сейчас"
 
-#: src/olympia/addons/buttons.py:182
+#: src/olympia/addons/buttons.py:179
 msgid "Download"
 msgstr "Загрузить"
 
 #. L10n: please keep &nbsp; in the string so &rarr; does not wrap.
-#: src/olympia/addons/buttons.py:186
+#: src/olympia/addons/buttons.py:183
 msgid "Continue to Download&nbsp;&rarr;"
 msgstr "Перейти к загрузке&nbsp;&rarr;"
 
-#: src/olympia/addons/buttons.py:202 src/olympia/addons/helpers.py:35
-#: src/olympia/addons/views.py:319
-#: src/olympia/addons/templates/addons/impala/details.html:114
-#: src/olympia/addons/templates/addons/impala/listing/items.html:17
-#: src/olympia/addons/templates/addons/mobile/home.html:40
-#: src/olympia/amo/templates/amo/side_nav.html:6
-#: src/olympia/amo/templates/amo/side_nav.html:10
-#: src/olympia/amo/templates/amo/site_nav.html:2
-#: src/olympia/amo/templates/amo/site_nav.html:55
-#: src/olympia/bandwagon/views.py:95 src/olympia/browse/views.py:54
-#: src/olympia/browse/views.py:68 src/olympia/browse/views.py:235
-#: src/olympia/browse/templates/browse/impala/category_landing.html:22
+#: src/olympia/addons/buttons.py:199 src/olympia/addons/helpers.py:35 src/olympia/addons/views.py:333 src/olympia/addons/templates/addons/impala/details.html:111
+#: src/olympia/addons/templates/addons/impala/listing/items.html:17 src/olympia/addons/templates/addons/mobile/home.html:40 src/olympia/amo/templates/amo/side_nav.html:6
+#: src/olympia/amo/templates/amo/side_nav.html:10 src/olympia/amo/templates/amo/site_nav.html:2 src/olympia/amo/templates/amo/site_nav.html:53 src/olympia/bandwagon/views.py:95
+#: src/olympia/browse/views.py:54 src/olympia/browse/views.py:68 src/olympia/browse/views.py:202 src/olympia/browse/templates/browse/impala/category_landing.html:22
 #: src/olympia/browse/templates/browse/personas/mobile/category_landing.html:26
 msgid "Featured"
 msgstr "Избранное"
 
-#: src/olympia/addons/buttons.py:221
+#: src/olympia/addons/buttons.py:218
 msgid "Add to {0}"
 msgstr "Добавить в {0}"
 
@@ -106,86 +96,64 @@ msgid "Invalid tag: {0}"
 msgid_plural "Invalid tags: {0}"
 msgstr[0] "Неверная метка: {0}"
 msgstr[1] "Неверные метки: {0}"
-msgstr[2] "Неверные метки: {0}"
 
 #. L10n: {0} is a single tag or a comma-separated list of tags.
 #: src/olympia/addons/forms.py:103
 msgid "\"{0}\" is a reserved tag and cannot be used."
 msgid_plural "\"{0}\" are reserved tags and cannot be used."
-msgstr[0] ""
-"\"{0}\" является зарезервированной меткой и не может быть использована."
-msgstr[1] ""
-"\"{0}\" являются зарезервированными метками и не могут быть использованы."
-msgstr[2] ""
-"\"{0}\" являются зарезервированными метками и не могут быть использованы."
+msgstr[0] "\"{0}\" является зарезервированной меткой и не может быть использована."
+msgstr[1] "\"{0}\" являются зарезервированными метками и не могут быть использованы."
 
 #: src/olympia/addons/forms.py:111
 msgid "You have {0} too many tags."
 msgid_plural "You have {0} too many tags."
 msgstr[0] "У вас на {0} метку больше, чем это допустимо."
 msgstr[1] "У вас на {0} метки больше, чем это допустимо."
-msgstr[2] "У вас на {0} меток больше, чем это допустимо."
 
 #: src/olympia/addons/forms.py:117
 #, python-format
-msgid ""
-"All tags must be %s characters or less after invalid characters are removed."
-msgstr ""
-"Длина любой метки не может превышать %s символов после удаления запрещённых "
-"символов."
+msgid "All tags must be %s characters or less after invalid characters are removed."
+msgstr "Длина любой метки не может превышать %s символов после удаления запрещённых символов."
 
 #: src/olympia/addons/forms.py:121
 msgid "All tags must be at least {0} character."
 msgid_plural "All tags must be at least {0} characters."
 msgstr[0] "Длина любой метки должна быть не менее {0} символа."
 msgstr[1] "Длина любой метки должна быть не менее {0} символов."
-msgstr[2] "Длина любой метки должна быть не менее {0} символов."
 
-#: src/olympia/addons/forms.py:234
-msgid ""
-"Categories cannot be changed while your add-on is featured for this "
-"application."
-msgstr ""
-"Категории не могут быть изменены, пока ваше дополнение избрано для этого "
-"приложения."
+#: src/olympia/addons/forms.py:238
+msgid "Categories cannot be changed while your add-on is featured for this application."
+msgstr "Категории не могут быть изменены, пока ваше дополнение избрано для этого приложения."
 
 #. L10n: {0} is the number of categories.
-#: src/olympia/addons/forms.py:238
+#: src/olympia/addons/forms.py:242
 msgid "You can have only {0} category."
 msgid_plural "You can have only {0} categories."
 msgstr[0] "У вас может быть только {0} категория."
 msgstr[1] "У вас может быть только {0} категории."
-msgstr[2] "У вас может быть только {0} категорий."
 
-#: src/olympia/addons/forms.py:246
-msgid ""
-"The miscellaneous category cannot be combined with additional categories."
-msgstr ""
-"Категория Разное не может быть скомбинирована с дополнительными категориями."
+#: src/olympia/addons/forms.py:250
+msgid "The miscellaneous category cannot be combined with additional categories."
+msgstr "Категория Разное не может быть скомбинирована с дополнительными категориями."
 
-#: src/olympia/addons/forms.py:369
+#: src/olympia/addons/forms.py:374
 #, python-format
-msgid ""
-"Before changing your default locale you must have a name, summary, and "
-"description in that locale. You are missing %s."
-msgstr ""
-"Перед изменением вашей локали по умолчанию, вы должны иметь имя, сводку и "
-"описание на этой локали. Вам недостаёт %s."
+msgid "Before changing your default locale you must have a name, summary, and description in that locale. You are missing %s."
+msgstr "Перед изменением вашей локали по умолчанию, вы должны иметь имя, сводку и описание на этой локали. Вам недостаёт %s."
 
-#: src/olympia/addons/forms.py:484 src/olympia/addons/forms.py:575
+#: src/olympia/addons/forms.py:455 src/olympia/addons/forms.py:546
 msgid "A license must be selected."
 msgstr "Должен быть выбрана лицензия."
 
-#: src/olympia/addons/forms.py:556
+#: src/olympia/addons/forms.py:527
 msgid "Give Your Theme a Name."
 msgstr "Дайте вашей теме имя."
 
-#: src/olympia/addons/forms.py:562
-#: src/olympia/devhub/templates/devhub/personas/submit.html:53
+#: src/olympia/addons/forms.py:533 src/olympia/devhub/templates/devhub/personas/submit.html:53
 msgid "Describe your Theme."
 msgstr "Опишите вашу тему."
 
-#: src/olympia/addons/forms.py:704
+#: src/olympia/addons/forms.py:675
 msgid "Enter a new author's email address"
 msgstr "Введите новый адрес эл. почты автора"
 
@@ -193,47 +161,39 @@ msgstr "Введите новый адрес эл. почты автора"
 msgid "Not Reviewed"
 msgstr "Не проверено"
 
-#: src/olympia/addons/models.py:301
+#: src/olympia/addons/models.py:298
 msgid "Users have the option of contributing more or less than this amount."
 msgstr "Пользователи могут решить внести больше или меньше этой суммы."
 
-#: src/olympia/addons/models.py:309
-msgid ""
-"Users will always be asked in the Add-ons Manager (Firefox 4 and above)"
+#: src/olympia/addons/models.py:306
+msgid "Users will always be asked in the Add-ons Manager (Firefox 4 and above). Only applies to desktop."
 msgstr ""
-"Пользователей всегда будут просить в менеджере дополнений (Firefox 4 и выше)"
 
 # Column name in a table.
-#: src/olympia/addons/models.py:1804
-#: src/olympia/addons/templates/addons/details_box.html:55
-#: src/olympia/devhub/templates/devhub/index.html:92
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:102
+#: src/olympia/addons/models.py:1802 src/olympia/addons/templates/addons/details_box.html:55 src/olympia/devhub/templates/devhub/index.html:92
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:89
 msgid "Listed"
 msgstr "В списке"
 
-#: src/olympia/addons/views.py:320
-#: src/olympia/browse/templates/browse/personas/mobile/category_landing.html:27
+#: src/olympia/addons/views.py:334 src/olympia/browse/templates/browse/personas/mobile/category_landing.html:27
 msgid "Popular"
 msgstr "Популярные"
 
-#: src/olympia/addons/views.py:321 src/olympia/browse/views.py:238
-#: src/olympia/browse/views.py:280 src/olympia/browse/views.py:482
+#: src/olympia/addons/views.py:335 src/olympia/browse/views.py:205 src/olympia/browse/views.py:247 src/olympia/browse/views.py:449
 msgid "Recently Added"
 msgstr "Недавно добавленные"
 
-#: src/olympia/addons/views.py:322 src/olympia/bandwagon/views.py:99
-#: src/olympia/browse/views.py:60 src/olympia/browse/views.py:71
-#: src/olympia/search/forms.py:16 src/olympia/search/forms.py:91
+#: src/olympia/addons/views.py:336 src/olympia/bandwagon/views.py:99 src/olympia/browse/views.py:60 src/olympia/browse/views.py:71 src/olympia/search/forms.py:16 src/olympia/search/forms.py:91
 msgid "Recently Updated"
 msgstr "Недавно обновлённые"
 
-#. l10n: {0} is the addon name
 # %1 is an add-on name.
-#: src/olympia/addons/views.py:520
+#. l10n: {0} is the addon name
+#: src/olympia/addons/views.py:534
 msgid "Contribution for {0}"
 msgstr "Взнос для {0}"
 
-#: src/olympia/addons/views.py:613
+#: src/olympia/addons/views.py:627
 msgid "Abuse reported."
 msgstr "О злоупотреблении сообщено."
 
@@ -241,116 +201,70 @@ msgstr "О злоупотреблении сообщено."
 msgid "My add-on doesn't fit into any of the categories"
 msgstr "Мое дополнение не подходит ни под одну из категорий"
 
-#: src/olympia/addons/templates/addons/button.html:27
-#: src/olympia/addons/templates/addons/impala/button.html:11
-#: src/olympia/addons/templates/addons/mobile/button.html:11
+#: src/olympia/addons/templates/addons/button.html:27 src/olympia/addons/templates/addons/impala/button.html:11 src/olympia/addons/templates/addons/mobile/button.html:11
 msgid "No compatible versions"
 msgstr "Нет совместимых версий"
 
-#: src/olympia/addons/templates/addons/button.html:35
-#: src/olympia/addons/templates/addons/impala/button.html:19
+#: src/olympia/addons/templates/addons/button.html:35 src/olympia/addons/templates/addons/impala/button.html:19
 msgid "Added to Mobile"
 msgstr "Добавлено в Mobile"
 
-#: src/olympia/addons/templates/addons/button.html:37
-#: src/olympia/addons/templates/addons/impala/button.html:21
+#: src/olympia/addons/templates/addons/button.html:37 src/olympia/addons/templates/addons/impala/button.html:21
 msgid "Add to Mobile"
 msgstr "Добавить в Mobile"
 
 #. {0} is a platform name like Windows or Mac OS X.
-#: src/olympia/addons/templates/addons/button.html:66
-#: src/olympia/addons/templates/addons/includes/install_button.html:19
+#: src/olympia/addons/templates/addons/button.html:66 src/olympia/addons/templates/addons/includes/install_button.html:19
 msgid "for {0}"
 msgstr "для {0}"
 
-#: src/olympia/addons/templates/addons/button.html:82
-#: src/olympia/addons/templates/addons/mobile/button.html:23
+#: src/olympia/addons/templates/addons/button.html:82 src/olympia/addons/templates/addons/mobile/button.html:23
 msgid "View privacy policy"
 msgstr "Просмотреть политику приватности"
 
-#: src/olympia/addons/templates/addons/button.html:87
-#: src/olympia/addons/templates/addons/details_box.html:133
-#: src/olympia/addons/templates/addons/mobile/button.html:28
+#: src/olympia/addons/templates/addons/button.html:87 src/olympia/addons/templates/addons/details_box.html:133 src/olympia/addons/templates/addons/mobile/button.html:28
 #: src/olympia/discovery/templates/discovery/addons/detail.html:28
 msgid "View End-User License Agreement"
 msgstr "Просмотр лицензионного соглашения"
 
-#: src/olympia/addons/templates/addons/button.html:92
-#: src/olympia/addons/templates/addons/impala/button.html:54
+#: src/olympia/addons/templates/addons/button.html:92 src/olympia/addons/templates/addons/impala/button.html:54
 #, python-format
-msgid ""
-"This add-on has not been reviewed by Mozilla. <a href=\"%(url)s\">Learn "
-"more</a>"
-msgstr ""
-"Это дополнение не был проверено Mozilla. <a href=\"%(url)s\">Узнайте "
-"больше</a>"
+msgid "This add-on has not been reviewed by Mozilla. <a href=\"%(url)s\">Learn more</a>"
+msgstr "Это дополнение не был проверено Mozilla. <a href=\"%(url)s\">Узнайте больше</a>"
 
-#: src/olympia/addons/templates/addons/button.html:97
-#: src/olympia/addons/templates/addons/impala/button.html:60
+#: src/olympia/addons/templates/addons/button.html:97 src/olympia/addons/templates/addons/impala/button.html:60
 #, python-format
-msgid ""
-"This add-on has been preliminarily reviewed by Mozilla. <a "
-"href=\"%(url)s\">Learn more</a>"
-msgstr ""
-"Это дополнение прошло предварительную проверку Mozilla. <a "
-"href=\"%(url)s\">Узнайте больше</a>"
+msgid "This add-on has been preliminarily reviewed by Mozilla. <a href=\"%(url)s\">Learn more</a>"
+msgstr "Это дополнение прошло предварительную проверку Mozilla. <a href=\"%(url)s\">Узнайте больше</a>"
 
-#: src/olympia/addons/templates/addons/contribution.html:11
-#: src/olympia/addons/templates/addons/impala/developers.html:44
-msgid ""
-"The developer of this add-on asks that you help support its continued "
-"development by making a small contribution."
-msgstr ""
-"Разработчик этого дополнения просит вас помочь поддержать его дальнейшее "
-"развитие, сделав небольшой взнос."
+#: src/olympia/addons/templates/addons/contribution.html:11 src/olympia/addons/templates/addons/impala/developers.html:44
+msgid "The developer of this add-on asks that you help support its continued development by making a small contribution."
+msgstr "Разработчик этого дополнения просит вас помочь поддержать его дальнейшее развитие, сделав небольшой взнос."
 
 #: src/olympia/addons/templates/addons/contribution.html:14
 #, python-format
-msgid ""
-"The developer of this add-on asks that you show your support by making a "
-"donation to the <a href=\"%(charity_url)s\">%(charity_name)s</a>."
-msgstr ""
-"Разработчик этого дополнения просит вас показать вашу поддержку, сделав "
-"взнос в пользу <a href=\"%(charity_url)s\">%(charity_name)s</a>."
+msgid "The developer of this add-on asks that you show your support by making a donation to the <a href=\"%(charity_url)s\">%(charity_name)s</a>."
+msgstr "Разработчик этого дополнения просит вас показать вашу поддержку, сделав взнос в пользу <a href=\"%(charity_url)s\">%(charity_name)s</a>."
 
 #: src/olympia/addons/templates/addons/contribution.html:19
 #, python-format
-msgid ""
-"The developer of this add-on asks that you show your support by making a "
-"small contribution to <a href=\"%(charity_url)s\">%(charity_name)s</a>."
-msgstr ""
-"Разработчик этого дополнения просит вас показать вашу поддержку, сделав "
-"небольшой взнос в пользу <a href=\"%(charity_url)s\">%(charity_name)s</a>."
+msgid "The developer of this add-on asks that you show your support by making a small contribution to <a href=\"%(charity_url)s\">%(charity_name)s</a>."
+msgstr "Разработчик этого дополнения просит вас показать вашу поддержку, сделав небольшой взнос в пользу <a href=\"%(charity_url)s\">%(charity_name)s</a>."
 
-#: src/olympia/addons/templates/addons/contribution.html:30
-#: src/olympia/addons/templates/addons/impala/contribution.html:18
-#: src/olympia/templates/menu_links.html:25
+#: src/olympia/addons/templates/addons/contribution.html:30 src/olympia/addons/templates/addons/impala/contribution.html:18 src/olympia/templates/menu_links.html:25
 msgid "Contribute"
 msgstr "Сделайте взнос"
 
-#. Click Contribute button OR Install button
 # This is a separator between the graphical [contribute] button and the
 # graphical [download now] button
-#: src/olympia/addons/templates/addons/contribution.html:34
-#: src/olympia/addons/templates/addons/report_abuse.html:26
-#: src/olympia/addons/templates/addons/impala/contribution.html:32
-#: src/olympia/devhub/templates/devhub/addons/ajax_compat_update.html:36
-#: src/olympia/devhub/templates/devhub/addons/profile.html:44
-#: src/olympia/devhub/templates/devhub/addons/edit/admin.html:101
-#: src/olympia/devhub/templates/devhub/addons/edit/basic.html:152
-#: src/olympia/devhub/templates/devhub/addons/edit/details.html:85
-#: src/olympia/devhub/templates/devhub/addons/edit/support.html:67
-#: src/olympia/devhub/templates/devhub/addons/edit/technical.html:166
-#: src/olympia/devhub/templates/devhub/addons/forms_shared/media.html:149
-#: src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:44
-#: src/olympia/devhub/templates/devhub/versions/add_file_modal.html:78
-#: src/olympia/devhub/templates/devhub/versions/edit.html:139
-#: src/olympia/devhub/templates/devhub/versions/list.html:242
-#: src/olympia/devhub/templates/devhub/versions/list.html:276
-#: src/olympia/devhub/templates/devhub/versions/list.html:317
-#: src/olympia/devhub/templates/devhub/versions/list.html:351
-#: src/olympia/reviews/templates/reviews/edit_review.html:16
-#: src/olympia/translations/templates/translations/trans-menu.html:50
+#. Click Contribute button OR Install button
+#: src/olympia/addons/templates/addons/contribution.html:34 src/olympia/addons/templates/addons/report_abuse.html:26 src/olympia/addons/templates/addons/impala/contribution.html:32
+#: src/olympia/devhub/templates/devhub/addons/ajax_compat_update.html:36 src/olympia/devhub/templates/devhub/addons/profile.html:44 src/olympia/devhub/templates/devhub/addons/edit/admin.html:101
+#: src/olympia/devhub/templates/devhub/addons/edit/basic.html:152 src/olympia/devhub/templates/devhub/addons/edit/details.html:85 src/olympia/devhub/templates/devhub/addons/edit/support.html:67
+#: src/olympia/devhub/templates/devhub/addons/edit/technical.html:166 src/olympia/devhub/templates/devhub/addons/forms_shared/media.html:149
+#: src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:43 src/olympia/devhub/templates/devhub/versions/add_file_modal.html:58 src/olympia/devhub/templates/devhub/versions/edit.html:139
+#: src/olympia/devhub/templates/devhub/versions/list.html:239 src/olympia/devhub/templates/devhub/versions/list.html:281 src/olympia/devhub/templates/devhub/versions/list.html:315
+#: src/olympia/devhub/templates/devhub/versions/list.html:349 src/olympia/reviews/templates/reviews/edit_review.html:16 src/olympia/translations/templates/translations/trans-menu.html:50
 #: src/olympia/translations/templates/translations/trans-menu.html:62
 msgid "or"
 msgstr "или"
@@ -359,41 +273,23 @@ msgstr "или"
 msgid "Suggested Contribution: {0}"
 msgstr "Предложенная сумма взноса:  {0}"
 
-#: src/olympia/addons/templates/addons/contribution.html:48
-#: src/olympia/amo/templates/amo/recaptcha.html:5
-#: src/olympia/versions/templates/versions/version.html:52
+#: src/olympia/addons/templates/addons/contribution.html:48 src/olympia/amo/templates/amo/recaptcha.html:5 src/olympia/versions/templates/versions/version.html:52
 msgid "What's this?"
 msgstr "Что это?"
 
 #: src/olympia/addons/templates/addons/contribution.html:63
 #, python-format
-msgid ""
-"The developer of this add-on would like you to consider making a donation to"
-" the <a href=\"%(charity_url)s\">%(charity_name)s</a> if you enjoy using it."
-msgstr ""
-"Разработчик этого дополнения хотел бы, чтобы вы сделали взнос в пользу <a "
-"href=\"%(charity_url)s\">%(charity_name)s</a>, если вам нравится "
-"использовать это дополнение."
+msgid "The developer of this add-on would like you to consider making a donation to the <a href=\"%(charity_url)s\">%(charity_name)s</a> if you enjoy using it."
+msgstr "Разработчик этого дополнения хотел бы, чтобы вы сделали взнос в пользу <a href=\"%(charity_url)s\">%(charity_name)s</a>, если вам нравится использовать это дополнение."
 
 #: src/olympia/addons/templates/addons/contribution.html:69
 #, python-format
-msgid ""
-"The developer of this add-on would like you to consider making a small "
-"contribution to <a href=\"%(charity_url)s\">%(charity_name)s</a> if you "
-"enjoy using it."
-msgstr ""
-"Разработчик этого дополнения хотел бы, чтобы вы сделали небольшой взнос в "
-"пользу <a href=\"%(charity_url)s\">%(charity_name)s</a>, если вам нравится "
-"использовать это дополнение."
+msgid "The developer of this add-on would like you to consider making a small contribution to <a href=\"%(charity_url)s\">%(charity_name)s</a> if you enjoy using it."
+msgstr "Разработчик этого дополнения хотел бы, чтобы вы сделали небольшой взнос в пользу <a href=\"%(charity_url)s\">%(charity_name)s</a>, если вам нравится использовать это дополнение."
 
 #: src/olympia/addons/templates/addons/contribution.html:76
-msgid ""
-"Mozilla is committed to supporting a vibrant and healthy developer "
-"ecosystem. Your optional contribution helps sustain further development of "
-"this add-on."
-msgstr ""
-"Mozilla обещает поддерживать здоровую экосистему разработки. Ваше "
-"добровольный взнос поможет поддержать дальнейшее развитие этого дополнения."
+msgid "Mozilla is committed to supporting a vibrant and healthy developer ecosystem. Your optional contribution helps sustain further development of this add-on."
+msgstr "Mozilla обещает поддерживать здоровую экосистему разработки. Ваше добровольный взнос поможет поддержать дальнейшее развитие этого дополнения."
 
 #: src/olympia/addons/templates/addons/contributions_lightbox.html:5
 msgid "Make a Contribution"
@@ -401,36 +297,24 @@ msgstr "Сделать взнос"
 
 #: src/olympia/addons/templates/addons/contributions_lightbox.html:9
 #, python-format
-msgid ""
-"Help support the continued development of <strong>%(addon_name)s</strong> by"
-" making a small contribution through <a href=\"%(paypal_url)s\">PayPal</a>."
-msgstr ""
-"Помогите поддержать продолжение разработки <strong>%(addon_name)s</strong> "
-"внеся небольшой взнос через <a href=\"%(paypal_url)s\">PayPal</a>."
+msgid "Help support the continued development of <strong>%(addon_name)s</strong> by making a small contribution through <a href=\"%(paypal_url)s\">PayPal</a>."
+msgstr "Помогите поддержать продолжение разработки <strong>%(addon_name)s</strong> внеся небольшой взнос через <a href=\"%(paypal_url)s\">PayPal</a>."
 
 #: src/olympia/addons/templates/addons/contributions_lightbox.html:15
 #, python-format
 msgid ""
-"To show your support for <b>%(addon_name)s</b>, the developer asks that you "
-"make a donation to the <a href=\"%(charity_url)s\">%(charity_name)s</a> "
-"through <a href=\"%(paypal_url)s\">PayPal</a>."
+"To show your support for <b>%(addon_name)s</b>, the developer asks that you make a donation to the <a href=\"%(charity_url)s\">%(charity_name)s</a> through <a href=\"%(paypal_url)s\">PayPal</a>."
 msgstr ""
-"Чтобы показать свою поддержку <b>%(addon_name)s</b>, разработчик просит вас "
-"сделать взнос в пользу <a href=\"%(charity_url)s\">%(charity_name)s</a> "
-"через <a href=\"%(paypal_url)s\">PayPal</a>."
+"Чтобы показать свою поддержку <b>%(addon_name)s</b>, разработчик просит вас сделать взнос в пользу <a href=\"%(charity_url)s\">%(charity_name)s</a> через <a href=\"%(paypal_url)s\">PayPal</a>."
 
 #: src/olympia/addons/templates/addons/contributions_lightbox.html:21
 #, python-format
 msgid ""
-"To show your support for <b>%(addon_name)s</b>, the developer asks that you "
-"make a small contribution to <a "
-"href=\"%(charity_url)s\">%(charity_name)s</a> through <a "
-"href=\"%(paypal_url)s\">PayPal</a>."
+"To show your support for <b>%(addon_name)s</b>, the developer asks that you make a small contribution to <a href=\"%(charity_url)s\">%(charity_name)s</a> through <a href=\"%(paypal_url)s\">PayPal</"
+"a>."
 msgstr ""
-"Чтобы показать свою поддержку <b>%(addon_name)s</b>, разработчик просит вас "
-"сделать небольшой взнос в пользу <a "
-"href=\"%(charity_url)s\">%(charity_name)s</a> через <a "
-"href=\"%(paypal_url)s\">PayPal</a>."
+"Чтобы показать свою поддержку <b>%(addon_name)s</b>, разработчик просит вас сделать небольшой взнос в пользу <a href=\"%(charity_url)s\">%(charity_name)s</a> через <a href=\"%(paypal_url)s"
+"\">PayPal</a>."
 
 #: src/olympia/addons/templates/addons/contributions_lightbox.html:30
 msgid "How much would you like to contribute?"
@@ -453,8 +337,7 @@ msgstr "Сумма взноса должна быть числом."
 msgid "A one-time suggested contribution of {0}"
 msgstr "Одноразовый предложенный взнос в размере {0}"
 
-#. {0} is a currency symbol (e.g., $),                    {1} is an amount
-#. input
+#. {0} is a currency symbol (e.g., $),                    {1} is an amount input
 #. field
 #: src/olympia/addons/templates/addons/contributions_lightbox.html:64
 msgid "A one-time contribution of {0} {1}"
@@ -464,11 +347,8 @@ msgstr "Однократный взнос в {0} {1}"
 msgid "Leave a comment or request with your contribution."
 msgstr "Оставьте вместе с вашим взносом комментарий или запрос."
 
-#: src/olympia/addons/templates/addons/contributions_lightbox.html:74
-#: src/olympia/bandwagon/templates/bandwagon/ajax_new.html:20
-#: src/olympia/bandwagon/templates/bandwagon/includes/addedit.html:37
-#: src/olympia/reviews/templates/reviews/mobile/add_form.html:13
-#: src/olympia/templates/includes/forms.html:10
+#: src/olympia/addons/templates/addons/contributions_lightbox.html:74 src/olympia/bandwagon/templates/bandwagon/ajax_new.html:20 src/olympia/bandwagon/templates/bandwagon/includes/addedit.html:37
+#: src/olympia/reviews/templates/reviews/mobile/add_form.html:13 src/olympia/templates/includes/forms.html:10
 msgid "(optional)"
 msgstr "(необязательно)"
 
@@ -488,36 +368,27 @@ msgstr "Нет, спасибо"
 msgid "Contribution made, thank you."
 msgstr "Спасибо, взнос сделан."
 
-#: src/olympia/addons/templates/addons/details_box.html:10
-#: src/olympia/discovery/templates/discovery/addons/detail.html:19
+#: src/olympia/addons/templates/addons/details_box.html:10 src/olympia/discovery/templates/discovery/addons/detail.html:19
 msgid "No restart required"
 msgstr "Не требует перезапуска"
 
 #. This is a caption for a table. {0} is an add-on name.
-#: src/olympia/addons/templates/addons/details_box.html:26
-#: src/olympia/addons/templates/addons/includes/persona.html:9
+#: src/olympia/addons/templates/addons/details_box.html:26 src/olympia/addons/templates/addons/includes/persona.html:9
 msgid "Add-on Information for {0}"
 msgstr "Информация о дополнении для {0}"
 
-#: src/olympia/addons/templates/addons/details_box.html:30
-#: src/olympia/addons/templates/addons/persona_detail_table.html:3
-#: src/olympia/addons/templates/addons/mobile/details.html:63
-#: src/olympia/addons/templates/addons/mobile/persona_detail_table.html:7
-#: src/olympia/browse/views.py:459 src/olympia/devhub/views.py:75
+#: src/olympia/addons/templates/addons/details_box.html:30 src/olympia/addons/templates/addons/persona_detail_table.html:3 src/olympia/addons/templates/addons/mobile/details.html:63
+#: src/olympia/addons/templates/addons/mobile/persona_detail_table.html:7 src/olympia/browse/views.py:426 src/olympia/devhub/views.py:73
 msgid "Updated"
 msgstr "Обновлено"
 
-#: src/olympia/addons/templates/addons/details_box.html:38
-#: src/olympia/addons/templates/addons/mobile/details.html:71
-#: src/olympia/devhub/templates/devhub/addons/edit/support.html:43
+#: src/olympia/addons/templates/addons/details_box.html:38 src/olympia/addons/templates/addons/mobile/details.html:71 src/olympia/devhub/templates/devhub/addons/edit/support.html:43
 #: src/olympia/discovery/templates/discovery/addons/detail.html:77
 msgid "Website"
 msgstr "Веб-сайт"
 
 #. This refers to this version's compatible applications, such as Firefox 8.0
-#: src/olympia/addons/templates/addons/details_box.html:47
-#: src/olympia/addons/templates/addons/mobile/details.html:80
-#: src/olympia/search/templates/search/results.html:72
+#: src/olympia/addons/templates/addons/details_box.html:47 src/olympia/addons/templates/addons/mobile/details.html:80 src/olympia/search/templates/search/results.html:72
 #: src/olympia/versions/templates/versions/version.html:21
 msgid "Works with"
 msgstr "Работает с"
@@ -526,45 +397,30 @@ msgstr "Работает с"
 msgid "Visibility"
 msgstr "Видимость"
 
-#: src/olympia/addons/templates/addons/details_box.html:57
-#: src/olympia/devhub/templates/devhub/index.html:94
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:104
+#: src/olympia/addons/templates/addons/details_box.html:57 src/olympia/devhub/templates/devhub/index.html:94 src/olympia/devhub/templates/devhub/includes/addon_details.html:91
 msgid "Hidden"
 msgstr "Скрыто"
 
-#: src/olympia/addons/templates/addons/details_box.html:59
-#: src/olympia/devhub/templates/devhub/index.html:96
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:106
+#: src/olympia/addons/templates/addons/details_box.html:59 src/olympia/devhub/templates/devhub/index.html:96 src/olympia/devhub/templates/devhub/includes/addon_details.html:93
 msgid "Unlisted"
 msgstr "Не в списке"
 
-#: src/olympia/addons/templates/addons/details_box.html:67
-#: src/olympia/devhub/templates/devhub/addons/edit/technical.html:44
+#: src/olympia/addons/templates/addons/details_box.html:67 src/olympia/devhub/templates/devhub/addons/edit/technical.html:44
 msgid "Required Add-ons"
 msgstr "Требуемые дополнения"
 
-#: src/olympia/addons/templates/addons/details_box.html:81
-#: src/olympia/addons/templates/addons/persona_detail_table.html:15
-#: src/olympia/browse/views.py:462 src/olympia/devhub/views.py:78
-#: src/olympia/devhub/views.py:85
-#: src/olympia/discovery/templates/discovery/addons/detail.html:57
-#: src/olympia/reviews/forms.py:62
-#: src/olympia/reviews/templates/reviews/add.html:57
+#: src/olympia/addons/templates/addons/details_box.html:81 src/olympia/addons/templates/addons/persona_detail_table.html:15 src/olympia/browse/views.py:429 src/olympia/devhub/views.py:76
+#: src/olympia/devhub/views.py:83 src/olympia/discovery/templates/discovery/addons/detail.html:57 src/olympia/reviews/forms.py:62 src/olympia/reviews/templates/reviews/add.html:57
 #: src/olympia/reviews/templates/reviews/mobile/review_list.html:18
 msgid "Rating"
 msgstr "Рейтинг"
 
-#: src/olympia/addons/templates/addons/details_box.html:85
-#: src/olympia/browse/views.py:461 src/olympia/devhub/views.py:77
-#: src/olympia/devhub/views.py:84
-#: src/olympia/stats/templates/stats/addon_report_menu.html:8
-#: src/olympia/stats/templates/stats/collection_report_menu.html:18
+#: src/olympia/addons/templates/addons/details_box.html:85 src/olympia/browse/views.py:428 src/olympia/devhub/views.py:75 src/olympia/devhub/views.py:82
+#: src/olympia/stats/templates/stats/addon_report_menu.html:8 src/olympia/stats/templates/stats/collection_report_menu.html:18
 msgid "Downloads"
 msgstr "Загрузки"
 
-#: src/olympia/addons/templates/addons/details_box.html:91
-#: src/olympia/addons/templates/addons/details_box.html:103
-#: src/olympia/devhub/templates/devhub/addons/listing/item_actions_theme.html:17
+#: src/olympia/addons/templates/addons/details_box.html:91 src/olympia/addons/templates/addons/details_box.html:103 src/olympia/devhub/templates/devhub/addons/listing/item_actions_theme.html:17
 #: src/olympia/devhub/templates/devhub/personas/edit.html:60
 msgid "View Statistics"
 msgstr "Просмотреть статистику"
@@ -578,18 +434,13 @@ msgid "Abuse Reports"
 msgstr "Отчёты о нарушениях"
 
 #. The Privacy Policy for this add-on.
-#: src/olympia/addons/templates/addons/details_box.html:121
-#: src/olympia/addons/templates/addons/privacy.html:19
-#: src/olympia/addons/templates/addons/privacy.html:23
-#: src/olympia/addons/templates/addons/impala/button.html:43
-#: src/olympia/addons/templates/addons/impala/details.html:307
-#: src/olympia/devhub/templates/devhub/includes/policy_form.html:20
+#: src/olympia/addons/templates/addons/details_box.html:121 src/olympia/addons/templates/addons/privacy.html:19 src/olympia/addons/templates/addons/privacy.html:23
+#: src/olympia/addons/templates/addons/impala/button.html:43 src/olympia/addons/templates/addons/impala/details.html:312 src/olympia/devhub/templates/devhub/includes/policy_form.html:23
 #: src/olympia/templates/mobile/base_addons.html:87
 msgid "Privacy Policy"
 msgstr "Политика приватности"
 
-#: src/olympia/addons/templates/addons/details_box.html:124
-#: src/olympia/discovery/templates/discovery/addons/detail.html:24
+#: src/olympia/addons/templates/addons/details_box.html:124 src/olympia/discovery/templates/discovery/addons/detail.html:24
 msgid "View Privacy Policy"
 msgstr "Просмотреть политику приватности"
 
@@ -597,8 +448,7 @@ msgstr "Просмотреть политику приватности"
 msgid "EULA"
 msgstr "Лицензионное соглашение с конечным пользователем (EULA)"
 
-#: src/olympia/addons/templates/addons/details_box.html:171
-#: src/olympia/addons/templates/addons/details_box.html:231
+#: src/olympia/addons/templates/addons/details_box.html:171 src/olympia/addons/templates/addons/details_box.html:231
 msgid "More about this add-on"
 msgstr "Подробнее об этом дополнении"
 
@@ -606,27 +456,21 @@ msgstr "Подробнее об этом дополнении"
 msgid "Image Gallery"
 msgstr "Галерея скриншотов"
 
-#: src/olympia/addons/templates/addons/details_box.html:190
-#: src/olympia/devhub/templates/devhub/addons/edit/technical.html:21
+#: src/olympia/addons/templates/addons/details_box.html:190 src/olympia/devhub/templates/devhub/addons/edit/technical.html:21
 msgid "Developer Comments"
 msgstr "Комментарии разработчика"
 
-#: src/olympia/addons/templates/addons/details_box.html:199
-#: src/olympia/addons/templates/addons/impala/details.html:259
+#: src/olympia/addons/templates/addons/details_box.html:199 src/olympia/addons/templates/addons/impala/details.html:264
 msgid "Development Channel"
 msgstr "Канал разработки"
 
-#: src/olympia/addons/templates/addons/details_box.html:202
-#: src/olympia/addons/templates/addons/mobile/details.html:124
+#: src/olympia/addons/templates/addons/details_box.html:202 src/olympia/addons/templates/addons/mobile/details.html:124
 msgid ""
-"The Development Channel lets you test an experimental new version of this "
-"add-on before it's released to the general public. Once you install the "
-"development version, you will continue to get updates from this channel."
+"The Development Channel lets you test an experimental new version of this add-on before it's released to the general public. Once you install the development version, you will continue to get "
+"updates from this channel."
 msgstr ""
-"Канал разработки позволяет вам тестировать экспериментальную новую версию "
-"этого дополнения перед его выпуском для всех пользователей. Как только вы "
-"установите разрабатываемую версию, вы будете получать обновления по этому "
-"каналу."
+"Канал разработки позволяет вам тестировать экспериментальную новую версию этого дополнения перед его выпуском для всех пользователей. Как только вы установите разрабатываемую версию, вы будете "
+"получать обновления по этому каналу."
 
 #: src/olympia/addons/templates/addons/details_box.html:207
 msgid "Install development version"
@@ -634,76 +478,52 @@ msgstr "Установить разрабатываемую версию"
 
 #: src/olympia/addons/templates/addons/details_box.html:211
 msgid ""
-"<strong>Caution:</strong> Development versions of this add-on have not been "
-"reviewed by Mozilla. Once you install a development version you will "
-"continue to receive development updates from this developer. To stop "
-"receiving development updates, reinstall the default version from the link "
-"above."
+"<strong>Caution:</strong> Development versions of this add-on have not been reviewed by Mozilla. Once you install a development version you will continue to receive development updates from this "
+"developer. To stop receiving development updates, reinstall the default version from the link above."
 msgstr ""
-"<strong>Осторожно:</strong> Разрабатываемые версии этого дополнения не были "
-"проверены Mozilla. Как только вы установите разрабатываемую версию, вы "
-"будете получать обновления разрабатываемой версии от этого разработчика. "
-"Чтобы перестать получать обновления разрабатываемой версии, переустановите "
-"версию по умолчанию с расположенной выше ссылки."
+"<strong>Осторожно:</strong> Разрабатываемые версии этого дополнения не были проверены Mozilla. Как только вы установите разрабатываемую версию, вы будете получать обновления разрабатываемой версии "
+"от этого разработчика. Чтобы перестать получать обновления разрабатываемой версии, переустановите версию по умолчанию с расположенной выше ссылки."
 
-#: src/olympia/addons/templates/addons/details_box.html:220
-#: src/olympia/addons/templates/addons/impala/details.html:278
+#: src/olympia/addons/templates/addons/details_box.html:220 src/olympia/addons/templates/addons/impala/details.html:283
 msgid "Version {0}:"
 msgstr "Версия {0}:"
 
 #: src/olympia/addons/templates/addons/details_box.html:234
 msgid "Nothing to see here!  The developer did not include any details."
-msgstr "Здесь нечего смотреть!  Разработчик не добавил никаких деталей."
+msgstr ""
 
-#: src/olympia/addons/templates/addons/details_box.html:251
-#: src/olympia/devhub/templates/devhub/versions/edit.html:73
-#: src/olympia/editors/templates/editors/review.html:98
+#: src/olympia/addons/templates/addons/details_box.html:251 src/olympia/devhub/templates/devhub/versions/edit.html:73 src/olympia/editors/templates/editors/review.html:98
 msgid "Version Notes"
 msgstr "Примечания к версии"
 
 #. {0} is the name of the add-on.
 #. {0} is the name of the add-on
-#: src/olympia/addons/templates/addons/eula.html:6
-#: src/olympia/discovery/templates/discovery/addons/eula.html:5
+#: src/olympia/addons/templates/addons/eula.html:6 src/olympia/discovery/templates/discovery/addons/eula.html:5
 msgid "End-User License Agreement for {0}"
 msgstr "Лицензионное соглашение с конечным пользователем для {0}"
 
-#: src/olympia/addons/templates/addons/eula.html:17
-#: src/olympia/addons/templates/addons/eula.html:21
-#: src/olympia/addons/templates/addons/impala/button.html:48
-#: src/olympia/addons/templates/addons/impala/details.html:316
-#: src/olympia/devhub/templates/devhub/includes/policy_form.html:3
-#: src/olympia/discovery/templates/discovery/addons/eula.html:11
+#: src/olympia/addons/templates/addons/eula.html:17 src/olympia/addons/templates/addons/eula.html:21 src/olympia/addons/templates/addons/impala/button.html:48
+#: src/olympia/addons/templates/addons/impala/details.html:321 src/olympia/devhub/templates/devhub/includes/policy_form.html:3 src/olympia/discovery/templates/discovery/addons/eula.html:11
 msgid "End-User License Agreement"
 msgstr "Лицензионное соглашение с конечным пользователем"
 
-#: src/olympia/addons/templates/addons/eula.html:23
-#: src/olympia/discovery/templates/discovery/addons/eula.html:13
+#: src/olympia/addons/templates/addons/eula.html:23 src/olympia/discovery/templates/discovery/addons/eula.html:13
 #, python-format
-msgid ""
-"%(addon_name)s requires that you accept the following End-User License "
-"Agreement before installation can proceed:"
-msgstr ""
-"%(addon_name)s требует чтобы вы приняли следующее соглашение конечного "
-"пользователя перед началом его установки:"
+msgid "%(addon_name)s requires that you accept the following End-User License Agreement before installation can proceed:"
+msgstr "%(addon_name)s требует чтобы вы приняли следующее соглашение конечного пользователя перед началом его установки:"
 
-#: src/olympia/addons/templates/addons/eula.html:34
-#: src/olympia/addons/templates/addons/privacy.html:26
+#: src/olympia/addons/templates/addons/eula.html:34 src/olympia/addons/templates/addons/privacy.html:26
 msgid "Back to {0}…"
 msgstr "Вернуться к {0}…"
 
 # {0} is the application the user is browsing.  Examples:  Thunderbird,
 # Firefox,
 # Sunbird
-#: src/olympia/addons/templates/addons/home.html:3
-#: src/olympia/addons/templates/addons/mobile/home.html:3
-#: src/olympia/amo/helpers.py:235
+#: src/olympia/addons/templates/addons/home.html:3 src/olympia/addons/templates/addons/mobile/home.html:3 src/olympia/amo/helpers.py:235
 msgid "Add-ons for {0}"
 msgstr "Дополнения {0}"
 
-#: src/olympia/addons/templates/addons/home.html:10
-#: src/olympia/addons/templates/addons/home.html:51
-#: src/olympia/browse/templates/browse/impala/base_listing.html:11
+#: src/olympia/addons/templates/addons/home.html:10 src/olympia/addons/templates/addons/home.html:53 src/olympia/browse/templates/browse/impala/base_listing.html:11
 msgid "Featured Extensions"
 msgstr "Избранные расширения"
 
@@ -711,70 +531,49 @@ msgstr "Избранные расширения"
 msgid "Popular Extensions"
 msgstr "Популярные расширения"
 
-#: src/olympia/addons/templates/addons/home.html:42
-#: src/olympia/amo/templates/amo/side_nav.html:3
-#: src/olympia/amo/templates/amo/side_nav.html:11
-#: src/olympia/amo/templates/amo/site_nav.html:3
-#: src/olympia/amo/templates/amo/site_nav.html:25
-#: src/olympia/browse/views.py:236 src/olympia/browse/views.py:281
-#: src/olympia/browse/views.py:481
+#: src/olympia/addons/templates/addons/home.html:44 src/olympia/amo/templates/amo/side_nav.html:3 src/olympia/amo/templates/amo/side_nav.html:11 src/olympia/amo/templates/amo/site_nav.html:3
+#: src/olympia/amo/templates/amo/site_nav.html:25 src/olympia/browse/views.py:203 src/olympia/browse/views.py:248 src/olympia/browse/views.py:448
 msgid "Most Popular"
 msgstr "Самые популярные"
 
-#: src/olympia/addons/templates/addons/home.html:43
+#: src/olympia/addons/templates/addons/home.html:45
 msgid "All »"
 msgstr "Все »"
 
-#: src/olympia/addons/templates/addons/home.html:52
-#: src/olympia/addons/templates/addons/home.html:61
-#: src/olympia/addons/templates/addons/home.html:70
-#: src/olympia/addons/templates/addons/home.html:78
+#: src/olympia/addons/templates/addons/home.html:54 src/olympia/addons/templates/addons/home.html:63 src/olympia/addons/templates/addons/home.html:72 src/olympia/addons/templates/addons/home.html:80
 #: src/olympia/browse/templates/browse/impala/category_landing.html:36
 msgid "See all »"
 msgstr "Посмотреть все »"
 
-#: src/olympia/addons/templates/addons/home.html:60
+#: src/olympia/addons/templates/addons/home.html:62
 msgid "Up &amp; Coming Extensions"
 msgstr "Набирающие популярность расширения"
 
-#: src/olympia/addons/templates/addons/home.html:69
-#: src/olympia/browse/templates/browse/personas/category_landing.html:61
-#: src/olympia/discovery/templates/discovery/pane.html:74
+#: src/olympia/addons/templates/addons/home.html:71 src/olympia/browse/templates/browse/personas/category_landing.html:61 src/olympia/discovery/templates/discovery/pane.html:74
 msgid "Featured Themes"
 msgstr "Избранные темы"
 
-#: src/olympia/addons/templates/addons/home.html:77
-#: src/olympia/bandwagon/templates/bandwagon/impala/collection_listing.html:5
+#: src/olympia/addons/templates/addons/home.html:79 src/olympia/bandwagon/templates/bandwagon/impala/collection_listing.html:5
 msgid "Featured Collections"
 msgstr "Избранные подборки"
 
-#: src/olympia/addons/templates/addons/listing_header.html:3
-#: src/olympia/addons/templates/addons/impala/listing/sorter.html:2
-#: src/olympia/amo/templates/amo/mobile/sort_by.html:2
+#: src/olympia/addons/templates/addons/listing_header.html:3 src/olympia/addons/templates/addons/impala/listing/sorter.html:2 src/olympia/amo/templates/amo/mobile/sort_by.html:2
 #: src/olympia/bandwagon/templates/bandwagon/collection_detail.html:118
 msgid "Sort by:"
 msgstr "Сортировать по:"
 
 #. {0} is a date.
 #. {0} is a date
-#: src/olympia/addons/templates/addons/macros.html:7
-#: src/olympia/addons/templates/addons/macros.html:72
-#: src/olympia/addons/templates/addons/listing/items_mobile.html:48
-#: src/olympia/addons/templates/addons/listing/macros.html:42
-#: src/olympia/bandwagon/templates/bandwagon/collection_detail.html:50
-#: src/olympia/bandwagon/templates/bandwagon/collection_listing_items.html:40
-#: src/olympia/bandwagon/templates/bandwagon/impala/collection_listing_items.html:40
+#: src/olympia/addons/templates/addons/macros.html:7 src/olympia/addons/templates/addons/macros.html:72 src/olympia/addons/templates/addons/listing/items_mobile.html:48
+#: src/olympia/addons/templates/addons/listing/macros.html:42 src/olympia/bandwagon/templates/bandwagon/collection_detail.html:50
+#: src/olympia/bandwagon/templates/bandwagon/collection_listing_items.html:40 src/olympia/bandwagon/templates/bandwagon/impala/collection_listing_items.html:40
 msgid "Updated {0}"
 msgstr "Обновлено {0}"
 
 #. {0} is a date.
-#: src/olympia/addons/templates/addons/macros.html:10
-#: src/olympia/addons/templates/addons/macros.html:69
-#: src/olympia/addons/templates/addons/persona_preview.html:21
-#: src/olympia/addons/templates/addons/listing/items_mobile.html:44
-#: src/olympia/addons/templates/addons/listing/macros.html:39
-#: src/olympia/bandwagon/templates/bandwagon/collection_listing_items.html:37
-#: src/olympia/bandwagon/templates/bandwagon/impala/collection_listing_items.html:37
+#: src/olympia/addons/templates/addons/macros.html:10 src/olympia/addons/templates/addons/macros.html:69 src/olympia/addons/templates/addons/persona_preview.html:22
+#: src/olympia/addons/templates/addons/listing/items_mobile.html:44 src/olympia/addons/templates/addons/listing/macros.html:39
+#: src/olympia/bandwagon/templates/bandwagon/collection_listing_items.html:37 src/olympia/bandwagon/templates/bandwagon/impala/collection_listing_items.html:37
 msgid "Added {0}"
 msgstr "Добавлено {0}"
 
@@ -784,7 +583,6 @@ msgid "%(num)s weekly download"
 msgid_plural "%(num)s weekly downloads"
 msgstr[0] "%(num)s загрузка за неделю"
 msgstr[1] "%(num)s загрузки за неделю"
-msgstr[2] "%(num)s загрузок за неделю"
 
 #: src/olympia/addons/templates/addons/macros.html:28
 #, python-format
@@ -792,27 +590,20 @@ msgid "%(num)s user"
 msgid_plural "%(num)s users"
 msgstr[0] "%(num)s пользователь"
 msgstr[1] "%(num)s пользователя"
-msgstr[2] "%(num)s пользователей"
 
 #. {0} is the number of downloads.
-#: src/olympia/addons/templates/addons/macros.html:53
-#: src/olympia/addons/templates/addons/impala/details.html:61
+#: src/olympia/addons/templates/addons/macros.html:53 src/olympia/addons/templates/addons/impala/details.html:59
 msgid "{0} weekly download"
 msgid_plural "{0} weekly downloads"
 msgstr[0] "{0} загрузка за неделю"
 msgstr[1] "{0} загрузки за неделю"
-msgstr[2] "{0} загрузок за неделю"
 
 #. {0} is the number of users.
-#: src/olympia/addons/templates/addons/macros.html:61
-#: src/olympia/addons/templates/addons/impala/details.html:54
-#: src/olympia/compat/templates/compat/index.html:71
-#: src/olympia/zadmin/templates/zadmin/compat.html:67
+#: src/olympia/addons/templates/addons/macros.html:61 src/olympia/addons/templates/addons/impala/details.html:52 src/olympia/zadmin/templates/zadmin/compat.html:67
 msgid "{0} user"
 msgid_plural "{0} users"
 msgstr[0] "{0} пользователь"
 msgstr[1] "{0} пользователя"
-msgstr[2] "{0} пользователей"
 
 #: src/olympia/addons/templates/addons/paypal_result.html:12
 msgid "Payment cancelled"
@@ -826,12 +617,8 @@ msgstr "Платёж завершён"
 msgid "Return to the addon."
 msgstr "Возвратиться к дополнению."
 
-#: src/olympia/addons/templates/addons/persona_detail.html:17
-#: src/olympia/addons/templates/addons/impala/details.html:106
-#: src/olympia/addons/templates/addons/mobile/details.html:23
-#: src/olympia/addons/templates/addons/mobile/persona_detail.html:21
-#: src/olympia/discovery/templates/discovery/addons/base.html:27
-#: src/olympia/editors/templates/editors/review.html:31
+#: src/olympia/addons/templates/addons/persona_detail.html:17 src/olympia/addons/templates/addons/impala/details.html:103 src/olympia/addons/templates/addons/mobile/details.html:23
+#: src/olympia/addons/templates/addons/mobile/persona_detail.html:21 src/olympia/discovery/templates/discovery/addons/base.html:27 src/olympia/editors/templates/editors/review.html:31
 msgid "by"
 msgstr "автор"
 
@@ -841,8 +628,7 @@ msgid "More {0} Themes"
 msgstr "Другие темы в разделе {0}"
 
 #. {0} is a category name, such as Nature
-#: src/olympia/addons/templates/addons/persona_detail.html:39
-#: src/olympia/addons/templates/addons/mobile/persona_detail.html:66
+#: src/olympia/addons/templates/addons/persona_detail.html:39 src/olympia/addons/templates/addons/mobile/persona_detail.html:66
 msgid "See all {0} Themes"
 msgstr "Просмотреть все темы в разделе {0}"
 
@@ -850,185 +636,129 @@ msgstr "Просмотреть все темы в разделе {0}"
 msgid "More by this Artist"
 msgstr "Ещё от этого художника"
 
-#: src/olympia/addons/templates/addons/persona_detail.html:52
-#: src/olympia/addons/templates/addons/mobile/persona_detail.html:49
+#: src/olympia/addons/templates/addons/persona_detail.html:52 src/olympia/addons/templates/addons/mobile/persona_detail.html:49
 msgid "See all Themes by this Artist"
 msgstr "Просмотреть все темы от этого художника"
 
-#: src/olympia/addons/templates/addons/persona_detail.html:71
-#: src/olympia/addons/templates/addons/mobile/home.html:42
-#: src/olympia/amo/templates/amo/side_nav.html:22
-#: src/olympia/browse/templates/browse/personas/mobile/category_landing.html:28
-#: src/olympia/devhub/templates/devhub/addons/edit/basic.html:72
-#: src/olympia/editors/templates/editors/review.html:277
-#: src/olympia/editors/templates/editors/themes/themes.html:34
-#: src/olympia/templates/categories.html:7
+#: src/olympia/addons/templates/addons/persona_detail.html:71 src/olympia/addons/templates/addons/mobile/home.html:42 src/olympia/amo/templates/amo/side_nav.html:22
+#: src/olympia/browse/templates/browse/personas/mobile/category_landing.html:28 src/olympia/devhub/templates/devhub/addons/edit/basic.html:72 src/olympia/editors/templates/editors/review.html:277
+#: src/olympia/editors/templates/editors/themes/themes.html:34 src/olympia/templates/categories.html:7
 msgid "Categories"
 msgstr "Категории"
 
-#: src/olympia/addons/templates/addons/persona_detail_table.html:10
-#: src/olympia/addons/templates/addons/mobile/persona_detail_table.html:3
-#: src/olympia/editors/templates/editors/themes/deleted.html:19
+#: src/olympia/addons/templates/addons/persona_detail_table.html:10 src/olympia/addons/templates/addons/mobile/persona_detail_table.html:3 src/olympia/editors/templates/editors/themes/deleted.html:19
 #: src/olympia/editors/templates/editors/themes/themes.html:25
 msgid "Artist"
 msgstr "Художник"
 
-#: src/olympia/addons/templates/addons/persona_detail_table.html:19
-#: src/olympia/addons/templates/addons/mobile/persona_detail_table.html:14
-#: src/olympia/stats/templates/stats/addon_report_menu.html:17
+#: src/olympia/addons/templates/addons/persona_detail_table.html:19 src/olympia/addons/templates/addons/mobile/persona_detail_table.html:14 src/olympia/stats/templates/stats/addon_report_menu.html:17
 msgid "Daily Users"
 msgstr "Ежедневные пользователи"
 
 #. The License for this add-on.
-#: src/olympia/addons/templates/addons/persona_detail_table.html:26
-#: src/olympia/addons/templates/addons/impala/license.html:17
-#: src/olympia/addons/templates/addons/mobile/persona_detail_table.html:21
-#: src/olympia/devhub/templates/devhub/includes/license_form.html:5
-#: src/olympia/devhub/templates/devhub/versions/edit.html:89
-#: src/olympia/editors/templates/editors/themes/themes.html:41
+#: src/olympia/addons/templates/addons/persona_detail_table.html:26 src/olympia/addons/templates/addons/impala/license.html:17 src/olympia/addons/templates/addons/mobile/persona_detail_table.html:21
+#: src/olympia/devhub/templates/devhub/includes/license_form.html:5 src/olympia/devhub/templates/devhub/versions/edit.html:89 src/olympia/editors/templates/editors/themes/themes.html:41
 msgid "License"
 msgstr "Лицензия"
 
-#: src/olympia/addons/templates/addons/persona_preview.html:12
-#: src/olympia/constants/base.py:48
+#: src/olympia/addons/templates/addons/persona_preview.html:13 src/olympia/constants/base.py:48
 msgid "Awaiting Review"
 msgstr "Ожидает проверки"
 
-#: src/olympia/addons/templates/addons/persona_preview.html:14
-#: src/olympia/amo/log.py:180 src/olympia/constants/base.py:42
-#: src/olympia/editors/helpers.py:62
+#: src/olympia/addons/templates/addons/persona_preview.html:15 src/olympia/amo/log.py:180 src/olympia/constants/base.py:42 src/olympia/editors/helpers.py:62
 msgid "Rejected"
 msgstr "Отклонено"
 
-#: src/olympia/addons/templates/addons/persona_preview.html:16
-#: src/olympia/amo/log.py:159
+#: src/olympia/addons/templates/addons/persona_preview.html:17 src/olympia/amo/log.py:159
 msgid "Approved"
 msgstr "Одобрено"
 
 #. {0} is the number of users.
-#: src/olympia/addons/templates/addons/persona_preview.html:26
-#: src/olympia/addons/templates/addons/listing/items_mobile.html:36
-#: src/olympia/addons/templates/addons/listing/macros.html:31
+#: src/olympia/addons/templates/addons/persona_preview.html:27 src/olympia/addons/templates/addons/listing/items_mobile.html:36 src/olympia/addons/templates/addons/listing/macros.html:31
 msgid "<strong>{0}</strong> user"
 msgid_plural "<strong>{0}</strong> users"
 msgstr[0] "<strong>{0}</strong> пользователь"
 msgstr[1] "<strong>{0}</strong> пользователя"
-msgstr[2] "<strong>{0}</strong> пользователей"
 
-#: src/olympia/addons/templates/addons/persona_preview.html:40
+#: src/olympia/addons/templates/addons/persona_preview.html:41
 msgid "Hover to Preview"
 msgstr "Парить над предпросмотром"
 
-#: src/olympia/addons/templates/addons/persona_preview.html:46
-#: src/olympia/addons/templates/addons/persona_preview.html:48
+#: src/olympia/addons/templates/addons/persona_preview.html:47 src/olympia/addons/templates/addons/persona_preview.html:49 src/olympia/addons/templates/addons/persona_preview.html:97
 #: src/olympia/reviews/templates/reviews/add.html:15
 msgid "Add"
 msgstr "Добавить"
 
-#: src/olympia/addons/templates/addons/persona_preview.html:57
-#: src/olympia/bandwagon/templates/bandwagon/ajax_new.html:16
-#: src/olympia/bandwagon/templates/bandwagon/edit.html:19
-#: src/olympia/bandwagon/templates/bandwagon/includes/addedit.html:19
-#: src/olympia/devhub/templates/devhub/addons/edit/admin.html:13
-#: src/olympia/devhub/templates/devhub/addons/edit/basic.html:10
-#: src/olympia/devhub/templates/devhub/addons/edit/details.html:8
-#: src/olympia/devhub/templates/devhub/addons/edit/media.html:6
-#: src/olympia/devhub/templates/devhub/addons/edit/support.html:8
-#: src/olympia/devhub/templates/devhub/addons/edit/technical.html:9
-#: src/olympia/devhub/templates/devhub/addons/submit/describe.html:29
-#: src/olympia/editors/templates/editors/review.html:257
+#: src/olympia/addons/templates/addons/persona_preview.html:58 src/olympia/bandwagon/templates/bandwagon/ajax_new.html:16 src/olympia/bandwagon/templates/bandwagon/edit.html:19
+#: src/olympia/bandwagon/templates/bandwagon/includes/addedit.html:19 src/olympia/devhub/templates/devhub/addons/edit/admin.html:13 src/olympia/devhub/templates/devhub/addons/edit/basic.html:10
+#: src/olympia/devhub/templates/devhub/addons/edit/details.html:8 src/olympia/devhub/templates/devhub/addons/edit/media.html:6 src/olympia/devhub/templates/devhub/addons/edit/support.html:8
+#: src/olympia/devhub/templates/devhub/addons/edit/technical.html:9 src/olympia/devhub/templates/devhub/addons/submit/describe.html:29 src/olympia/editors/templates/editors/review.html:257
 msgid "Edit"
 msgstr "Правка"
 
 #. For datetime formatting, see the table on
 #. http://docs.python.org/library/datetime.html#strftime-and-strptime-behavior
-#: src/olympia/addons/templates/addons/persona_preview.html:66
+#: src/olympia/addons/templates/addons/persona_preview.html:67
 #, python-format
 msgid "%%Y-%%m-%%d"
 msgstr "%%d.%%m.%%Y"
 
-#: src/olympia/addons/templates/addons/persona_preview.html:67
+#: src/olympia/addons/templates/addons/persona_preview.html:68
 msgid "by {0} on {1}"
 msgstr "от {0} созданы {1}"
 
-#: src/olympia/addons/templates/addons/persona_preview.html:75
-#: src/olympia/reviews/helpers.py:17
-#: src/olympia/reviews/templates/reviews/review_list.html:63
-#: src/olympia/reviews/templates/reviews/reviews_link.html:21
-#: src/olympia/reviews/templates/reviews/impala/reviews_link.html:16
+#: src/olympia/addons/templates/addons/persona_preview.html:76 src/olympia/reviews/helpers.py:17 src/olympia/reviews/templates/reviews/review_list.html:63
+#: src/olympia/reviews/templates/reviews/reviews_link.html:21 src/olympia/reviews/templates/reviews/impala/reviews_link.html:16
 msgid "Not yet rated"
 msgstr "Пока не оценено"
 
-#: src/olympia/addons/templates/addons/persona_preview.html:78
+#: src/olympia/addons/templates/addons/persona_preview.html:79
 msgid "<b>{0}</b> users"
 msgstr "<b>{0}</b> пользователя"
 
 #: src/olympia/addons/templates/addons/popups.html:17
-msgid ""
-"To install this add-on and thousands more, <b>get Firefox</b>, a free and "
-"open web browser from Mozilla."
-msgstr ""
-"Чтобы установить это дополнение и тысячи других, <b>загрузите Firefox</b>, "
-"свободный и открытый веб-браузер от Mozilla."
+msgid "To install this add-on and thousands more, <b>get Firefox</b>, a free and open web browser from Mozilla."
+msgstr "Чтобы установить это дополнение и тысячи других, <b>загрузите Firefox</b>, свободный и открытый веб-браузер от Mozilla."
 
-#: src/olympia/addons/templates/addons/popups.html:21
-#: src/olympia/addons/templates/addons/popups.html:52
+#: src/olympia/addons/templates/addons/popups.html:21 src/olympia/addons/templates/addons/popups.html:52
 msgid "Learn more about Firefox"
 msgstr "Узнать больше о Firefox"
 
 #: src/olympia/addons/templates/addons/popups.html:22
-msgid "or <b><a class=\"installer\" href=\"{url}\">download anyway</a></b>"
-msgstr "или <b><a class=\"installer\" href=\"{url}\">всё равно загрузить</a></b>"
+msgid "or <b><a class=\"button installer\" href=\"{url}\">download anyway</a></b>"
+msgstr ""
 
 #: src/olympia/addons/templates/addons/popups.html:26
 msgid ""
-"<strong>How to Install in Thunderbird</strong> <ol> <li>Download and save "
-"the file to your hard disk.</li> <li>In Mozilla Thunderbird, open Add-ons "
-"from the Tools menu.</li> <li>From the options button next to the add-on "
-"search field, select \"Install Add-on From File...\" and locate the "
-"downloaded add-on.</li> </ol>"
+"<strong>How to Install in Thunderbird</strong> <ol> <li>Download and save the file to your hard disk.</li> <li>In Mozilla Thunderbird, open Add-ons from the Tools menu.</li> <li>From the options "
+"button next to the add-on search field, select \"Install Add-on From File...\" and locate the downloaded add-on.</li> </ol>"
 msgstr ""
-"<strong>Как установить в Thunderbird</strong> <ol> <li>Загрузите и сохраните"
-" файл на ваш жёсткий диск.</li> <li>В Mozilla Thunderbird откройте меню "
-"Инструменты и выберите пункт Дополнения.</li> <li>Из меню кнопки настроек, "
-"расположенной рядом с полем поиска дополнений, выберите \"Установить "
-"дополнение из файла...\" и найдите загруженное дополнение.</li> </ol>"
+"<strong>Как установить в Thunderbird</strong> <ol> <li>Загрузите и сохраните файл на ваш жёсткий диск.</li> <li>В Mozilla Thunderbird откройте меню Инструменты и выберите пункт Дополнения.</li> "
+"<li>Из меню кнопки настроек, расположенной рядом с полем поиска дополнений, выберите \"Установить дополнение из файла...\" и найдите загруженное дополнение.</li> </ol>"
 
 #: src/olympia/addons/templates/addons/popups.html:41
-msgid ""
-"To install this Theme, <b>get Thunderbird</b>, a free and open source email "
-"client from Mozilla Messaging and install the Personas Plus add-on."
-msgstr ""
-"Чтобы установить эту тему, <b>загрузите Thunderbird</b>, свободный и "
-"открытый почтовый клиент от Mozilla Messaging и установите в него дополнение"
-" Personas Plus."
+msgid "To install this Theme, <b>get Thunderbird</b>, a free and open source email client from Mozilla Messaging and install the Personas Plus add-on."
+msgstr "Чтобы установить эту тему, <b>загрузите Thunderbird</b>, свободный и открытый почтовый клиент от Mozilla Messaging и установите в него дополнение Personas Plus."
 
 #: src/olympia/addons/templates/addons/popups.html:46
 msgid "Learn more about Thunderbird"
 msgstr "Узнайте больше о Thunderbird"
 
 #: src/olympia/addons/templates/addons/popups.html:48
-msgid ""
-"To install this Theme and thousands more, <b>get Firefox</b>, a free and "
-"open web browser from Mozilla."
-msgstr ""
-"Чтобы установить эту тему и тысячи других, <b>загрузите Firefox</b>, "
-"свободный и открытый веб-браузер от Mozilla."
+msgid "To install this Theme and thousands more, <b>get Firefox</b>, a free and open web browser from Mozilla."
+msgstr "Чтобы установить эту тему и тысячи других, <b>загрузите Firefox</b>, свободный и открытый веб-браузер от Mozilla."
 
 #: src/olympia/addons/templates/addons/popups.html:60
 #, python-format
 msgid "This add-on has not been updated to work with your version of %(app)s."
 msgstr "Это дополнение не было обновлено для работы с вашей версией %(app)s."
 
-#: src/olympia/addons/templates/addons/popups.html:63
-#: src/olympia/addons/templates/addons/popups.html:140
-#: src/olympia/addons/templates/addons/popups.html:150
+#: src/olympia/addons/templates/addons/popups.html:63 src/olympia/addons/templates/addons/popups.html:140 src/olympia/addons/templates/addons/popups.html:150
 msgid "Install Anyway"
 msgstr "Всё равно установить"
 
 #: src/olympia/addons/templates/addons/popups.html:71
-msgid ""
-"This add-on requires a version of Firefox that has not been released yet."
+msgid "This add-on requires a version of Firefox that has not been released yet."
 msgstr "Это дополнение требует версию Firefox, которая ещё не была выпущена."
 
 #: src/olympia/addons/templates/addons/popups.html:74
@@ -1037,62 +767,40 @@ msgstr "Помогите протестировать новые версии Fi
 
 #: src/olympia/addons/templates/addons/popups.html:77
 #, python-format
-msgid ""
-"This add-on requires %(app)s {new_version}. You are currently using %(app)s "
-"{old_version}."
-msgstr ""
-"Это дополнение требует %(app)s {new_version}. В данный момент вы используете"
-" %(app)s {old_version}."
+msgid "This add-on requires %(app)s {new_version}. You are currently using %(app)s {old_version}."
+msgstr "Это дополнение требует %(app)s {new_version}. В данный момент вы используете %(app)s {old_version}."
 
 #. {0} is an app name, like Firefox.
-#: src/olympia/addons/templates/addons/popups.html:82
-#: src/olympia/addons/templates/addons/popups.html:101
+#: src/olympia/addons/templates/addons/popups.html:82 src/olympia/addons/templates/addons/popups.html:101
 msgid "Upgrade {0}"
 msgstr "Обновите {0}"
 
 #: src/olympia/addons/templates/addons/popups.html:85
 #, python-format
 msgid "or view <a href=\"%(href)s\">older versions of this add-on</a>."
-msgstr ""
-"или посмотрите на <a href=\"%(href)s\">старые версии этого дополнения</a>."
+msgstr "или посмотрите на <a href=\"%(href)s\">старые версии этого дополнения</a>."
 
 #: src/olympia/addons/templates/addons/popups.html:96
 #, python-format
-msgid ""
-"This Persona requires %(app)s %(new_version)s. You are currently using "
-"%(app)s {old_version}."
-msgstr ""
-"Эти обои требуют %(app)s %(new_version)s. В данный момент вы используете "
-"%(app)s {old_version}."
+msgid "This Persona requires %(app)s %(new_version)s. You are currently using %(app)s {old_version}."
+msgstr "Эти обои требуют %(app)s %(new_version)s. В данный момент вы используете %(app)s {old_version}."
 
 #: src/olympia/addons/templates/addons/popups.html:108
 msgid ""
-"<strong>Caution:</strong> This add-on has not been reviewed by Mozilla and "
-"can't be installed on release versions of Firefox 43 and above.  Be careful "
-"when installing third-party software that might harm your computer."
+"<strong>Caution:</strong> This add-on has not been reviewed by Mozilla and can't be installed on release versions of Firefox 43 and above.  Be careful when installing third-party software that "
+"might harm your computer."
 msgstr ""
-"<strong>Внимание:</strong> Это обновление не было проверено Mozilla и не "
-"может быть установлено на версию Firefox 43 и выше. Будьте осторожны при "
-"установке ПО от третьих сторон, оно может повредить ваш компьютер."
 
 #: src/olympia/addons/templates/addons/popups.html:120
-msgid ""
-"<strong>Please note:</strong> This add-on is not compatible with your "
-"operating system."
-msgstr ""
-"<strong>Обратите внимание:</strong> Это дополнение несовместимо с вашей "
-"операционной системой."
+msgid "<strong>Please note:</strong> This add-on is not compatible with your operating system."
+msgstr "<strong>Обратите внимание:</strong> Это дополнение несовместимо с вашей операционной системой."
 
-#: src/olympia/addons/templates/addons/popups.html:136
-#: src/olympia/addons/templates/addons/impala/button.html:70
+#: src/olympia/addons/templates/addons/popups.html:136 src/olympia/addons/templates/addons/impala/button.html:70
 #, python-format
-msgid ""
-"This add-on is not compatible with your version of %(app)s because of the "
-"following:"
+msgid "This add-on is not compatible with your version of %(app)s because of the following:"
 msgstr "Это дополнение не совместимо с вашей версией %(app)s так как:"
 
-#: src/olympia/addons/templates/addons/popups.html:141
-#: src/olympia/addons/templates/addons/popups.html:151
+#: src/olympia/addons/templates/addons/popups.html:141 src/olympia/addons/templates/addons/popups.html:151
 msgid "View other versions"
 msgstr "Просмотреть другие версии"
 
@@ -1116,144 +824,89 @@ msgid ""
 "  to your phone.  (You'll need a QR reader.  Search your phone's marketplace if\n"
 "  don't have one.)"
 msgstr ""
-"Хотите установить {0} в ваш мобильный Firefox?  Отсканируйте этот QR-код для установки прямо\n"
-"  в свой телефон.  (Вам понадобится QR-ридер.  Поищите в магазине приложений вашего телефона, если\n"
-"  у вас его нет.)"
 
-#: src/olympia/addons/templates/addons/report_abuse.html:6
-#: src/olympia/addons/templates/addons/report_abuse_full.html:10
-#: src/olympia/addons/templates/addons/impala/details-more.html:23
-#: src/olympia/addons/templates/addons/impala/details.html:328
+#: src/olympia/addons/templates/addons/report_abuse.html:6 src/olympia/addons/templates/addons/report_abuse_full.html:10 src/olympia/addons/templates/addons/impala/details-more.html:23
+#: src/olympia/addons/templates/addons/impala/details.html:333
 msgid "Report Abuse"
 msgstr "Сообщить о злоупотреблении"
 
 #: src/olympia/addons/templates/addons/report_abuse.html:10
 #, python-format
 msgid ""
-"If you suspect this add-on violates <a href=\"%(url)s\">our policies</a> or "
-"has security or privacy issues, please use the form below to describe your "
-"concerns. Please do not use this form for any other reason."
+"If you suspect this add-on violates <a href=\"%(url)s\">our policies</a> or has security or privacy issues, please use the form below to describe your concerns. Please do not use this form for any "
+"other reason."
 msgstr ""
-"Если вы подозреваете, что это дополнение нарушает <a href=\"%(url)s\">наши "
-"политики</a> или имеет проблемы с безопасностью или приватностью, "
-"пожалуйста, используйте расположенную ниже форму, чтобы выразить вашу "
-"озабоченность. Пожалуйста, не используйте эту форму для любых других целей."
+"Если вы подозреваете, что это дополнение нарушает <a href=\"%(url)s\">наши политики</a> или имеет проблемы с безопасностью или приватностью, пожалуйста, используйте расположенную ниже форму, чтобы "
+"выразить вашу озабоченность. Пожалуйста, не используйте эту форму для любых других целей."
 
-#: src/olympia/addons/templates/addons/report_abuse.html:24
-#: src/olympia/users/templates/users/report_abuse.html:19
+#: src/olympia/addons/templates/addons/report_abuse.html:24 src/olympia/users/templates/users/report_abuse.html:19
 msgid "Send Report"
 msgstr "Отправить сообщение"
 
-#: src/olympia/addons/templates/addons/report_abuse.html:26
-#: src/olympia/addons/templates/addons/mobile/eula.html:16
-#: src/olympia/addons/templates/addons/mobile/persona_confirm.html:7
-#: src/olympia/devhub/templates/devhub/addons/ajax_compat_update.html:36
-#: src/olympia/devhub/templates/devhub/addons/profile.html:44
-#: src/olympia/devhub/templates/devhub/addons/edit/admin.html:104
-#: src/olympia/devhub/templates/devhub/addons/edit/basic.html:155
-#: src/olympia/devhub/templates/devhub/addons/edit/details.html:88
-#: src/olympia/devhub/templates/devhub/addons/edit/support.html:70
-#: src/olympia/devhub/templates/devhub/addons/edit/technical.html:169
-#: src/olympia/devhub/templates/devhub/addons/forms_shared/media.html:152
-#: src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:44
-#: src/olympia/devhub/templates/devhub/personas/edit.html:222
-#: src/olympia/devhub/templates/devhub/versions/add_file_modal.html:79
-#: src/olympia/devhub/templates/devhub/versions/edit.html:140
-#: src/olympia/devhub/templates/devhub/versions/list.html:208
-#: src/olympia/devhub/templates/devhub/versions/list.html:242
-#: src/olympia/devhub/templates/devhub/versions/list.html:276
-#: src/olympia/devhub/templates/devhub/versions/list.html:317
-#: src/olympia/reviews/templates/reviews/edit_review.html:16
-#: src/olympia/translations/templates/translations/trans-menu.html:50
-#: src/olympia/translations/templates/translations/trans-menu.html:62
-#: src/olympia/zadmin/templates/zadmin/validation.html:105
+#: src/olympia/addons/templates/addons/report_abuse.html:26 src/olympia/addons/templates/addons/mobile/eula.html:16 src/olympia/addons/templates/addons/mobile/persona_confirm.html:7
+#: src/olympia/devhub/templates/devhub/addons/ajax_compat_update.html:36 src/olympia/devhub/templates/devhub/addons/profile.html:44 src/olympia/devhub/templates/devhub/addons/edit/admin.html:104
+#: src/olympia/devhub/templates/devhub/addons/edit/basic.html:155 src/olympia/devhub/templates/devhub/addons/edit/details.html:88 src/olympia/devhub/templates/devhub/addons/edit/support.html:70
+#: src/olympia/devhub/templates/devhub/addons/edit/technical.html:169 src/olympia/devhub/templates/devhub/addons/forms_shared/media.html:152
+#: src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:43 src/olympia/devhub/templates/devhub/personas/edit.html:222 src/olympia/devhub/templates/devhub/versions/add_file_modal.html:59
+#: src/olympia/devhub/templates/devhub/versions/edit.html:140 src/olympia/devhub/templates/devhub/versions/list.html:208 src/olympia/devhub/templates/devhub/versions/list.html:239
+#: src/olympia/devhub/templates/devhub/versions/list.html:281 src/olympia/devhub/templates/devhub/versions/list.html:315 src/olympia/reviews/templates/reviews/edit_review.html:16
+#: src/olympia/translations/templates/translations/trans-menu.html:50 src/olympia/translations/templates/translations/trans-menu.html:62 src/olympia/zadmin/templates/zadmin/validation.html:105
 msgid "Cancel"
 msgstr "Отменить"
 
-#: src/olympia/addons/templates/addons/review_add_box.html:3
-#: src/olympia/addons/templates/addons/impala/review_add_box.html:5
+#: src/olympia/addons/templates/addons/review_add_box.html:3 src/olympia/addons/templates/addons/impala/review_add_box.html:5
 msgid "What do you think?"
 msgstr "Что вы думаете?"
 
-#: src/olympia/addons/templates/addons/review_add_box.html:7
-#: src/olympia/addons/templates/addons/impala/review_add_box.html:9
+#: src/olympia/addons/templates/addons/review_add_box.html:7 src/olympia/addons/templates/addons/impala/review_add_box.html:9
 #, python-format
 msgid "Please <a href=\"%(login)s\">log in</a> to submit a review"
 msgstr "Пожалуйста, <a href=\"%(login)s\">войдите</a>, чтобы оставить отзыв"
 
-#: src/olympia/addons/templates/addons/review_add_box.html:16
-#: src/olympia/addons/templates/addons/impala/review_add_box.html:18
-#: src/olympia/reviews/templates/reviews/mobile/add_form.html:13
+#: src/olympia/addons/templates/addons/review_add_box.html:16 src/olympia/addons/templates/addons/impala/review_add_box.html:18 src/olympia/reviews/templates/reviews/mobile/add_form.html:13
 msgid "Title:"
 msgstr "Заголовок:"
 
-#: src/olympia/addons/templates/addons/review_add_box.html:17
-#: src/olympia/addons/templates/addons/impala/review_add_box.html:19
-#: src/olympia/reviews/templates/reviews/mobile/add_form.html:17
+#: src/olympia/addons/templates/addons/review_add_box.html:17 src/olympia/addons/templates/addons/impala/review_add_box.html:19 src/olympia/reviews/templates/reviews/mobile/add_form.html:17
 msgid "Review:"
 msgstr "Отзыв:"
 
-#: src/olympia/addons/templates/addons/review_add_box.html:18
-#: src/olympia/addons/templates/addons/impala/review_add_box.html:20
-#: src/olympia/reviews/templates/reviews/mobile/add_form.html:16
+#: src/olympia/addons/templates/addons/review_add_box.html:18 src/olympia/addons/templates/addons/impala/review_add_box.html:20 src/olympia/reviews/templates/reviews/mobile/add_form.html:16
 msgid "Rating:"
 msgstr "Рейтинг:"
 
-#: src/olympia/addons/templates/addons/review_add_box.html:19
-#: src/olympia/addons/templates/addons/impala/review_add_box.html:21
-#: src/olympia/reviews/templates/reviews/add.html:63
-#: src/olympia/reviews/templates/reviews/edit_review.html:15
-#: src/olympia/reviews/templates/reviews/mobile/add_form.html:18
+#: src/olympia/addons/templates/addons/review_add_box.html:19 src/olympia/addons/templates/addons/impala/review_add_box.html:21 src/olympia/reviews/templates/reviews/add.html:63
+#: src/olympia/reviews/templates/reviews/edit_review.html:15 src/olympia/reviews/templates/reviews/mobile/add_form.html:18
 msgid "Submit review"
 msgstr "Отправить отзыв"
 
-#: src/olympia/addons/templates/addons/review_add_box.html:24
-#: src/olympia/addons/templates/addons/impala/review_add_box.html:26
-msgid ""
-"Please do not post bug reports in reviews. We do not make your email address"
-" available to add-on developers and they may need to contact you to help "
-"resolve your issue."
+#: src/olympia/addons/templates/addons/review_add_box.html:24 src/olympia/addons/templates/addons/impala/review_add_box.html:26
+msgid "Please do not post bug reports in reviews. We do not make your email address available to add-on developers and they may need to contact you to help resolve your issue."
 msgstr ""
-"Пожалуйста не оставляйте в отзывах сообщения об ошибках. Мы не сообщаем ваш "
-"почтовый адрес разработчикам дополнений, а им может потребоваться связаться "
-"с вами, чтобы помочь решить вашу проблему."
+"Пожалуйста не оставляйте в отзывах сообщения об ошибках. Мы не сообщаем ваш почтовый адрес разработчикам дополнений, а им может потребоваться связаться с вами, чтобы помочь решить вашу проблему."
 
-#: src/olympia/addons/templates/addons/review_add_box.html:32
-#: src/olympia/addons/templates/addons/impala/review_add_box.html:35
+#: src/olympia/addons/templates/addons/review_add_box.html:32 src/olympia/addons/templates/addons/impala/review_add_box.html:35
 #, python-format
-msgid ""
-"See the <a href=\"%(support)s\">support section</a> to find out where to get"
-" assistance for this add-on."
-msgstr ""
-"Для получения сведений о том, как получить помощь по работе с этим "
-"дополнением, обратитесь в <a href=\"%(support)s\">раздел поддержки</a>."
+msgid "See the <a href=\"%(support)s\">support section</a> to find out where to get assistance for this add-on."
+msgstr "Для получения сведений о том, как получить помощь по работе с этим дополнением, обратитесь в <a href=\"%(support)s\">раздел поддержки</a>."
 
-#: src/olympia/addons/templates/addons/review_add_box.html:38
-#: src/olympia/addons/templates/addons/impala/review_add_box.html:42
-#: src/olympia/pages/templates/pages/review_guide.html:3
+#: src/olympia/addons/templates/addons/review_add_box.html:38 src/olympia/addons/templates/addons/impala/review_add_box.html:42 src/olympia/pages/templates/pages/review_guide.html:3
 #: src/olympia/pages/templates/pages/review_guide.html:44
 msgid "Review Guidelines"
 msgstr "Чем следует руководствоваться при написании отзывов"
 
-#: src/olympia/addons/templates/addons/review_list_box.html:5
-#: src/olympia/addons/templates/addons/impala/details-more.html:27
-#: src/olympia/editors/helpers.py:921
-#: src/olympia/reviews/templates/reviews/add.html:14
-#: src/olympia/reviews/templates/reviews/reply.html:14
-#: src/olympia/reviews/templates/reviews/review_list.html:19
+#: src/olympia/addons/templates/addons/review_list_box.html:5 src/olympia/addons/templates/addons/impala/details-more.html:27 src/olympia/editors/helpers.py:1001
+#: src/olympia/reviews/templates/reviews/add.html:14 src/olympia/reviews/templates/reviews/reply.html:14 src/olympia/reviews/templates/reviews/review_list.html:19
 #: src/olympia/reviews/templates/reviews/mobile/review_list.html:26
 msgid "Reviews"
 msgstr "Отзывы"
 
-#: src/olympia/addons/templates/addons/review_list_box.html:14
-#: src/olympia/addons/templates/addons/impala/review_list_box.html:14
-#: src/olympia/reviews/templates/reviews/review.html:30
+#: src/olympia/addons/templates/addons/review_list_box.html:14 src/olympia/addons/templates/addons/impala/review_list_box.html:14 src/olympia/reviews/templates/reviews/review.html:30
 #, python-format
 msgid "by %(user)s on %(date)s"
 msgstr "от %(user)s %(date)s"
 
-#: src/olympia/addons/templates/addons/review_list_box.html:19
-#: src/olympia/addons/templates/addons/impala/review_list_box.html:29
+#: src/olympia/addons/templates/addons/review_list_box.html:19 src/olympia/addons/templates/addons/impala/review_list_box.html:29
 msgid "Show the developer's reply to this review"
 msgstr "Показать ответ разработчика на этот отзыв"
 
@@ -1263,23 +916,17 @@ msgid "See all reviews of this add-on"
 msgid_plural "See all %(cnt)s reviews of this add-on"
 msgstr[0] "Просмотреть все отзывы на это дополнение"
 msgstr[1] "Просмотреть все %(cnt)s отзыва на это дополнение"
-msgstr[2] "Просмотреть все %(cnt)s отзывов на это дополнение"
 
-#: src/olympia/addons/templates/addons/tags_box.html:3
-#: src/olympia/devhub/templates/devhub/addons/edit/basic.html:118
+#: src/olympia/addons/templates/addons/tags_box.html:3 src/olympia/devhub/templates/devhub/addons/edit/basic.html:118
 msgid "Tags"
 msgstr "Метки"
 
-#: src/olympia/addons/templates/addons/impala/addon_hovercard.html:7
-#: src/olympia/addons/templates/addons/impala/addon_hovercard.html:9
+#: src/olympia/addons/templates/addons/impala/addon_hovercard.html:7 src/olympia/addons/templates/addons/impala/addon_hovercard.html:9
 msgid "Icon for {0}"
 msgstr "Значок для {0}"
 
-#: src/olympia/addons/templates/addons/impala/addon_hovercard.html:34
-#: src/olympia/addons/templates/addons/impala/featured_grid.html:26
-#: src/olympia/addons/templates/addons/impala/theme_grid.html:22
-#: src/olympia/bandwagon/templates/bandwagon/collection_detail.html:31
-#: src/olympia/users/templates/users/helpers/addon_users_list.html:7
+#: src/olympia/addons/templates/addons/impala/addon_hovercard.html:34 src/olympia/addons/templates/addons/impala/featured_grid.html:26 src/olympia/addons/templates/addons/impala/theme_grid.html:22
+#: src/olympia/bandwagon/templates/bandwagon/collection_detail.html:31 src/olympia/users/templates/users/helpers/addon_users_list.html:7
 #, python-format
 msgid "by %(users)s"
 msgstr "от %(users)s"
@@ -1299,39 +946,22 @@ msgstr "Нравится это дополнение?"
 
 #: src/olympia/addons/templates/addons/impala/contribution.html:43
 #, python-format
-msgid ""
-"The <a href=\"%(meet_url)s\">developer of this add-on</a> asks that you help"
-" support its continued development by making a small contribution."
-msgstr ""
-"<a href=\"%(meet_url)s\">Разработчик этого дополнения</a> просит вас помочь "
-"поддержать его дальнейшее развитие, сделав небольшой взнос."
+msgid "The <a href=\"%(meet_url)s\">developer of this add-on</a> asks that you help support its continued development by making a small contribution."
+msgstr "<a href=\"%(meet_url)s\">Разработчик этого дополнения</a> просит вас помочь поддержать его дальнейшее развитие, сделав небольшой взнос."
 
 #: src/olympia/addons/templates/addons/impala/contribution.html:48
 #, python-format
-msgid ""
-"The <a href=\"%(meet_url)s\">developer of this add-on</a> asks that you show"
-" your support by making a donation to the <a "
-"href=\"%(charity_url)s\">%(charity_name)s</a>."
-msgstr ""
-"<a href=\"%(meet_url)s\">Разработчик этого дополнения</a> просит вас "
-"показать вашу поддержку, сделав взнос в пользу <a "
-"href=\"%(charity_url)s\">%(charity_name)s</a>."
+msgid "The <a href=\"%(meet_url)s\">developer of this add-on</a> asks that you show your support by making a donation to the <a href=\"%(charity_url)s\">%(charity_name)s</a>."
+msgstr "<a href=\"%(meet_url)s\">Разработчик этого дополнения</a> просит вас показать вашу поддержку, сделав взнос в пользу <a href=\"%(charity_url)s\">%(charity_name)s</a>."
 
 #: src/olympia/addons/templates/addons/impala/contribution.html:53
 #, python-format
-msgid ""
-"The <a href=\"%(meet_url)s\">developer of this add-on</a> asks that you show"
-" your support by making a small contribution to <a "
-"href=\"%(charity_url)s\">%(charity_name)s</a>."
-msgstr ""
-"<a href=\"%(meet_url)s\">Разработчик этого дополнения</a> просит вас "
-"показать свою поддержку, сделав небольшой взнос в пользу <a "
-"href=\"%(charity_url)s\">%(charity_name)s</a>."
+msgid "The <a href=\"%(meet_url)s\">developer of this add-on</a> asks that you show your support by making a small contribution to <a href=\"%(charity_url)s\">%(charity_name)s</a>."
+msgstr "<a href=\"%(meet_url)s\">Разработчик этого дополнения</a> просит вас показать свою поддержку, сделав небольшой взнос в пользу <a href=\"%(charity_url)s\">%(charity_name)s</a>."
 
 #: src/olympia/addons/templates/addons/impala/dependencies_note.html:4
 msgid "This add-on requires the following add-ons to work properly:"
-msgstr ""
-"Для корректной работы этого дополнения необходимы следующие дополнения:"
+msgstr "Для корректной работы этого дополнения необходимы следующие дополнения:"
 
 #: src/olympia/addons/templates/addons/impala/details-more.html:13
 msgid "Average"
@@ -1355,151 +985,123 @@ msgid "Other add-ons by %(author)s"
 msgid_plural "Other add-ons by these authors"
 msgstr[0] "Другие дополнения от %(author)s"
 msgstr[1] "Другие дополнения от этих разработчиков"
-msgstr[2] "Другие дополнения от этих разработчиков"
 
-#: src/olympia/addons/templates/addons/impala/details.html:41
+#: src/olympia/addons/templates/addons/impala/details.html:39
 #, python-format
 msgid "<span itemprop=\"ratingCount\">%(num)s</span> user review"
 msgid_plural "<span itemprop=\"ratingCount\">%(num)s</span> user reviews"
 msgstr[0] "<span itemprop=\"ratingCount\">%(num)s</span> отзыв пользователя"
 msgstr[1] "<span itemprop=\"ratingCount\">%(num)s</span> отзыва пользователей"
-msgstr[2] "<span itemprop=\"ratingCount\">%(num)s</span> отзывов пользователей"
 
-#: src/olympia/addons/templates/addons/impala/details.html:69
+#: src/olympia/addons/templates/addons/impala/details.html:66
 msgid "View statistics"
 msgstr "Просмотреть статистику"
 
-#: src/olympia/addons/templates/addons/impala/details.html:84
+#: src/olympia/addons/templates/addons/impala/details.html:81
 msgid "Manage"
 msgstr "Управлять"
 
 #. {0} is an add-on name.
-#: src/olympia/addons/templates/addons/impala/details.html:96
+#: src/olympia/addons/templates/addons/impala/details.html:93
 msgid "Icon of {0}"
 msgstr "Значок {0}"
 
-#: src/olympia/addons/templates/addons/impala/details.html:103
-#: src/olympia/addons/templates/addons/impala/listing/items.html:14
+#: src/olympia/addons/templates/addons/impala/details.html:100 src/olympia/addons/templates/addons/impala/listing/items.html:14
 msgid "No Restart"
 msgstr "Без перезапуска"
 
-#: src/olympia/addons/templates/addons/impala/details.html:127
+#: src/olympia/addons/templates/addons/impala/details.html:124
 #, python-format
 msgid "Meet the Developer: <a href=\"%(url)s\">%(name)s</a>"
 msgid_plural "<a href=\"%(url)s\">Meet the Developers</a>"
 msgstr[0] "Познакомьтесь с разработчиком: <a href=\"%(url)s\">%(name)s</a>"
 msgstr[1] "<a href=\"%(url)s\">Познакомьтесь с разработчиками</a>"
-msgstr[2] "<a href=\"%(url)s\">Познакомьтесь с разработчиками</a>"
 
 # {0} is an add-on name.
-#: src/olympia/addons/templates/addons/impala/details.html:137
+#: src/olympia/addons/templates/addons/impala/details.html:134
 msgid "Learn why {0} was created and find out what's next for this add-on."
-msgstr ""
-"Узнайте, почему был создан {0}, и выясните планы развития этого дополнения."
+msgstr "Узнайте, почему был создан {0}, и выясните планы развития этого дополнения."
 
 #. {0} is an index.
-#: src/olympia/addons/templates/addons/impala/details.html:156
+#: src/olympia/addons/templates/addons/impala/details.html:161
 msgid "Add-on screenshot #{0}"
 msgstr "Скриншот дополнения #{0}"
 
-#: src/olympia/addons/templates/addons/impala/details.html:182
+#: src/olympia/addons/templates/addons/impala/details.html:187
 msgid "Add-on home page"
 msgstr "Домашняя страница дополнения"
 
-#: src/olympia/addons/templates/addons/impala/details.html:185
+#: src/olympia/addons/templates/addons/impala/details.html:190
 msgid "Support site"
 msgstr "Сайт поддержки"
 
-#: src/olympia/addons/templates/addons/impala/details.html:189
+#: src/olympia/addons/templates/addons/impala/details.html:194
 msgid "Support E-mail"
 msgstr "Адрес эл. почты поддержки"
 
-#: src/olympia/addons/templates/addons/impala/details.html:194
-#: src/olympia/devhub/models.py:378
-#: src/olympia/devhub/templates/devhub/versions/list.html:12
-#: src/olympia/versions/templates/versions/version.html:6
-#: src/olympia/versions/templates/versions/mobile/version.html:6
+#: src/olympia/addons/templates/addons/impala/details.html:199 src/olympia/devhub/models.py:378 src/olympia/devhub/templates/devhub/versions/list.html:12
+#: src/olympia/versions/templates/versions/version.html:6 src/olympia/versions/templates/versions/mobile/version.html:6
 msgid "Version {0}"
 msgstr "Версия {0}"
 
-#: src/olympia/addons/templates/addons/impala/details.html:194
+#: src/olympia/addons/templates/addons/impala/details.html:199
 msgid "Info"
 msgstr "Информация"
 
-#: src/olympia/addons/templates/addons/impala/details.html:195
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:129
+#: src/olympia/addons/templates/addons/impala/details.html:200 src/olympia/devhub/templates/devhub/includes/addon_details.html:116
 msgid "Last Updated:"
 msgstr "Последнее обновление:"
 
-#: src/olympia/addons/templates/addons/impala/details.html:200
+#: src/olympia/addons/templates/addons/impala/details.html:205
 #, python-format
 msgid "Released under <a target=\"_blank\" href=\"%(url)s\">%(name)s</a>"
 msgstr "Выпущено на условиях <a target=\"_blank\" href=\"%(url)s\">%(name)s</a>"
 
-#: src/olympia/addons/templates/addons/impala/details.html:201
-#: src/olympia/addons/templates/addons/impala/details.html:206
-#: src/olympia/amo/helpers.py:398 src/olympia/devhub/forms.py:142
-#: src/olympia/devhub/forms.py:173
-#: src/olympia/versions/templates/versions/version.html:40
-#: src/olympia/versions/templates/versions/version.html:45
+#: src/olympia/addons/templates/addons/impala/details.html:206 src/olympia/addons/templates/addons/impala/details.html:211 src/olympia/amo/helpers.py:398 src/olympia/devhub/forms.py:142
+#: src/olympia/devhub/forms.py:173 src/olympia/versions/templates/versions/version.html:40 src/olympia/versions/templates/versions/version.html:45
 msgid "Custom License"
 msgstr "Своя лицензия"
 
-#: src/olympia/addons/templates/addons/impala/details.html:205
+#: src/olympia/addons/templates/addons/impala/details.html:210
 #, python-format
 msgid "Released under <a href=\"%(url)s\">%(name)s</a>"
 msgstr "Выпущено под <a href=\"%(url)s\">%(name)s</a>"
 
-#: src/olympia/addons/templates/addons/impala/details.html:217
+#: src/olympia/addons/templates/addons/impala/details.html:222
 msgid "About this Add-on"
 msgstr "Об этом дополнении"
 
-#: src/olympia/addons/templates/addons/impala/details.html:233
+#: src/olympia/addons/templates/addons/impala/details.html:238
 msgid "Developer’s Comments"
 msgstr "Комментарии разработчика"
 
-#: src/olympia/addons/templates/addons/impala/details.html:243
+#: src/olympia/addons/templates/addons/impala/details.html:248
 msgid "Version Information"
 msgstr "Информация о версии "
 
-#: src/olympia/addons/templates/addons/impala/details.html:250
+#: src/olympia/addons/templates/addons/impala/details.html:255
 msgid "See complete version history"
 msgstr "Показать всю историю версий"
 
-#: src/olympia/addons/templates/addons/impala/details.html:262
+#: src/olympia/addons/templates/addons/impala/details.html:267
 msgid ""
-"The Development Channel lets you test an experimental new version of this "
-"add-on before it's released to the general public. Once you install the "
-"development version, you will continue to get updates from this channel. To "
-"stop receiving development updates, reinstall the default version from the "
-"link above."
+"The Development Channel lets you test an experimental new version of this add-on before it's released to the general public. Once you install the development version, you will continue to get "
+"updates from this channel. To stop receiving development updates, reinstall the default version from the link above."
 msgstr ""
-"Канал разработки позволяет вам тестировать экспериментальную новую версию "
-"этого дополнения перед его релизом для широкой публики. После установки вами"
-" разрабатываемой версии, вы будете продолжать получать обновления по этому "
-"каналу. Чтобы перестать получать обновления разрабатываемой версии, "
-"переустановите версию по умолчанию по ссылке выше."
+"Канал разработки позволяет вам тестировать экспериментальную новую версию этого дополнения перед его релизом для широкой публики. После установки вами разрабатываемой версии, вы будете продолжать "
+"получать обновления по этому каналу. Чтобы перестать получать обновления разрабатываемой версии, переустановите версию по умолчанию по ссылке выше."
 
-#: src/olympia/addons/templates/addons/impala/details.html:272
-msgid ""
-"<strong>Caution:</strong> Development versions of this add-on have not been "
-"reviewed by Mozilla."
-msgstr ""
-"<strong>Внимание:</strong> Разрабатываемые версии этого дополнения не были "
-"проверены Mozilla."
+#: src/olympia/addons/templates/addons/impala/details.html:277
+msgid "<strong>Caution:</strong> Development versions of this add-on have not been reviewed by Mozilla."
+msgstr "<strong>Внимание:</strong> Разрабатываемые версии этого дополнения не были проверены Mozilla."
 
-#: src/olympia/addons/templates/addons/impala/details.html:287
+#: src/olympia/addons/templates/addons/impala/details.html:292
 msgid "See complete development channel history"
 msgstr "Показать всю историю канала разработки"
 
-#: src/olympia/addons/templates/addons/impala/details.html:306
-#: src/olympia/addons/templates/addons/impala/details.html:315
-#: src/olympia/addons/templates/addons/impala/details.html:327
-#: src/olympia/addons/templates/addons/impala/review_add_box.html:4
-#: src/olympia/stats/templates/stats/popup.html:2
-#: src/olympia/stats/templates/stats/popup.html:8
-#: src/olympia/stats/templates/stats/stats.html:202
-#: src/olympia/users/templates/users/profile.html:119
+#: src/olympia/addons/templates/addons/impala/details.html:311 src/olympia/addons/templates/addons/impala/details.html:320 src/olympia/addons/templates/addons/impala/details.html:332
+#: src/olympia/addons/templates/addons/impala/review_add_box.html:4 src/olympia/stats/templates/stats/popup.html:2 src/olympia/stats/templates/stats/popup.html:8
+#: src/olympia/stats/templates/stats/stats.html:204 src/olympia/users/templates/users/profile.html:119
 msgid "close"
 msgstr "закрыть"
 
@@ -1508,19 +1110,15 @@ msgstr "закрыть"
 msgid "Thank you for installing {0}"
 msgstr "Благодарим вас за установку {0}"
 
-#. {0} is an add-on name.
 # %1 is an add-on name.
+#. {0} is an add-on name.
 #: src/olympia/addons/templates/addons/impala/developers.html:12
 msgid "Meet the {0} Developer"
 msgstr "Познакомьтесь с разработчиком {0}"
 
 #: src/olympia/addons/templates/addons/impala/developers.html:41
-msgid ""
-"Before downloading this add-on, please consider supporting the development "
-"of this add-on by making a small contribution."
-msgstr ""
-"Перед загрузкой этого дополнения, пожалуйста, по возможности поддержите "
-"развитие этого дополнения, сделав небольшой взнос."
+msgid "Before downloading this add-on, please consider supporting the development of this add-on by making a small contribution."
+msgstr "Перед загрузкой этого дополнения, пожалуйста, по возможности поддержите развитие этого дополнения, сделав небольшой взнос."
 
 # %1 is an add-on name.
 #: src/olympia/addons/templates/addons/impala/developers.html:80
@@ -1537,11 +1135,8 @@ msgid "About the Developer"
 msgid_plural "About the Developers"
 msgstr[0] "О разработчике"
 msgstr[1] "О разработчиках"
-msgstr[2] "О разработчиках"
 
-#: src/olympia/addons/templates/addons/impala/developers.html:96
-#: src/olympia/users/templates/users/edit.html:130
-#: src/olympia/users/templates/users/profile.html:26
+#: src/olympia/addons/templates/addons/impala/developers.html:96 src/olympia/users/templates/users/edit.html:130 src/olympia/users/templates/users/profile.html:26
 msgid "No Photo"
 msgstr "Нет фото"
 
@@ -1561,24 +1156,15 @@ msgstr "Это дополнение было отключено админист
 msgid "Source Code License for {addon}"
 msgstr "Лицензия исходного кода для {addon}"
 
-#: src/olympia/addons/templates/addons/impala/license.html:21
-#: src/olympia/versions/templates/versions/mobile/version.html:18
+#: src/olympia/addons/templates/addons/impala/license.html:21 src/olympia/versions/templates/versions/mobile/version.html:18
 msgid "Source Code License"
 msgstr "Лицензия исходного кода"
 
-#: src/olympia/addons/templates/addons/impala/persona_grid.html:16
-#: src/olympia/addons/templates/addons/impala/toplist.html:6
-msgid "{0} users"
-msgstr "{0} пользователей"
-
-#: src/olympia/addons/templates/addons/impala/review_list_box.html:19
-#: src/olympia/reviews/templates/reviews/review.html:40
+#: src/olympia/addons/templates/addons/impala/review_list_box.html:19 src/olympia/reviews/templates/reviews/review.html:40
 msgid "permalink"
 msgstr "permalink"
 
-#: src/olympia/addons/templates/addons/impala/review_list_box.html:23
-#: src/olympia/editors/templates/editors/queue.html:98
-#: src/olympia/reviews/templates/reviews/review.html:44
+#: src/olympia/addons/templates/addons/impala/review_list_box.html:23 src/olympia/editors/templates/editors/queue.html:104 src/olympia/reviews/templates/reviews/review.html:44
 msgid "translate"
 msgstr "перевести"
 
@@ -1588,10 +1174,8 @@ msgid "See all user reviews"
 msgid_plural "See all %(cnt)s user reviews"
 msgstr[0] "Просмотреть все %(cnt)s отзыва пользователей"
 msgstr[1] "Просмотреть все %(cnt)s отзыва пользователей"
-msgstr[2] "Просмотреть все %(cnt)s отзывов пользователей"
 
-#: src/olympia/addons/templates/addons/impala/review_list_box.html:47
-#: src/olympia/reviews/templates/reviews/review_list.html:84
+#: src/olympia/addons/templates/addons/impala/review_list_box.html:47 src/olympia/reviews/templates/reviews/review_list.html:84
 msgid "This add-on has not yet been reviewed."
 msgstr "Это дополнение ещё не было оценено."
 
@@ -1599,24 +1183,23 @@ msgstr "Это дополнение ещё не было оценено."
 msgid "Be the first!"
 msgstr "Будьте первым!"
 
-#: src/olympia/addons/templates/addons/impala/listing/sorter.html:14
-#: src/olympia/devhub/templates/devhub/addons/listing/item_actions.html:49
+#: src/olympia/addons/templates/addons/impala/toplist.html:6
+msgid "{0} users"
+msgstr "{0} пользователей"
+
+#: src/olympia/addons/templates/addons/impala/listing/sorter.html:14 src/olympia/devhub/templates/devhub/addons/listing/item_actions.html:49
 msgid "More"
 msgstr "Ещё"
 
-#: src/olympia/addons/templates/addons/includes/collection_add_widget.html:7
-#: src/olympia/addons/templates/addons/includes/collection_add_widget.html:10
+#: src/olympia/addons/templates/addons/includes/collection_add_widget.html:7 src/olympia/addons/templates/addons/includes/collection_add_widget.html:10
 msgid "Add to collection"
 msgstr "Добавить в подборку"
 
-#: src/olympia/addons/templates/addons/includes/dashboard_tabs.html:4
-#: src/olympia/devhub/templates/devhub/index.html:73
-#: src/olympia/devhub/templates/devhub/nav.html:14
+#: src/olympia/addons/templates/addons/includes/dashboard_tabs.html:4 src/olympia/devhub/templates/devhub/index.html:73 src/olympia/devhub/templates/devhub/nav.html:14
 msgid "My Add-ons"
 msgstr "Мои дополнения"
 
-#: src/olympia/addons/templates/addons/includes/dashboard_tabs.html:6
-#: src/olympia/amo/context_processors.py:51
+#: src/olympia/addons/templates/addons/includes/dashboard_tabs.html:6 src/olympia/amo/context_processors.py:50
 msgid "My Themes"
 msgstr "Мои темы"
 
@@ -1632,15 +1215,13 @@ msgstr "Редактировать тему"
 msgid "Approve / Reject"
 msgstr "Одобрить / Отвергнуть"
 
-#: src/olympia/addons/templates/addons/includes/persona.html:25
-#: src/olympia/editors/templates/editors/themes/single.html:43
+#: src/olympia/addons/templates/addons/includes/persona.html:25 src/olympia/editors/templates/editors/themes/single.html:43
 msgid "Review History"
 msgstr "История проверок"
 
 #: src/olympia/addons/templates/addons/includes/persona_pending_notice.html:3
 msgid "Sorry, this theme is pending. Please come back later."
-msgstr ""
-"К сожалению, эта тема находится на проверке. Пожалуйста, зайдите позже."
+msgstr "К сожалению, эта тема находится на проверке. Пожалуйста, зайдите позже."
 
 #: src/olympia/addons/templates/addons/includes/persona_pending_notice.html:8
 msgid "This theme is pending. It is invisible to everyone but you."
@@ -1655,14 +1236,11 @@ msgid "Not Yet Rated"
 msgstr "Пока не оценено"
 
 #. {0} is the number of downloads.
-#: src/olympia/addons/templates/addons/listing/items_mobile.html:27
-#: src/olympia/addons/templates/addons/listing/macros.html:24
-#: src/olympia/devhub/templates/devhub/addons/listing/macros.html:15
+#: src/olympia/addons/templates/addons/listing/items_mobile.html:27 src/olympia/addons/templates/addons/listing/macros.html:24 src/olympia/devhub/templates/devhub/addons/listing/macros.html:15
 msgid "<strong>{0}</strong> weekly download"
 msgid_plural "<strong>{0}</strong> weekly downloads"
 msgstr[0] "<strong>{0}</strong> загрузка за неделю"
 msgstr[1] "<strong>{0}</strong> загрузки за неделю"
-msgstr[2] "<strong>{0}</strong> загрузок за неделю"
 
 #: src/olympia/addons/templates/addons/mobile/details.html:32
 msgid "Read More"
@@ -1672,15 +1250,11 @@ msgstr "Подробнее"
 msgid "Users"
 msgstr "Пользователи"
 
-#: src/olympia/addons/templates/addons/mobile/details.html:92
-#: src/olympia/browse/views.py:59 src/olympia/browse/views.py:70
-#: src/olympia/search/forms.py:90
+#: src/olympia/addons/templates/addons/mobile/details.html:92 src/olympia/browse/views.py:59 src/olympia/browse/views.py:70 src/olympia/search/forms.py:90
 msgid "Weekly Downloads"
 msgstr "Еженедельные загрузки"
 
-#: src/olympia/addons/templates/addons/mobile/details.html:99
-#: src/olympia/compat/templates/compat/reporter_detail.html:46
-#: src/olympia/devhub/forms.py:787
+#: src/olympia/addons/templates/addons/mobile/details.html:99 src/olympia/compat/templates/compat/reporter_detail.html:46 src/olympia/devhub/forms.py:788
 #: src/olympia/devhub/templates/devhub/versions/list.html:163
 msgid "Version"
 msgstr "Версия"
@@ -1716,50 +1290,30 @@ msgstr "Лицензионное соглашение"
 
 #: src/olympia/addons/templates/addons/mobile/eula.html:5
 #, python-format
-msgid ""
-"%(name)s requires that you accept the following End-User License Agreement "
-"before installation can proceed:"
-msgstr ""
-"%(name)s требует, чтобы вы приняли следующее соглашение конечного "
-"пользователя перед началом его установки:"
+msgid "%(name)s requires that you accept the following End-User License Agreement before installation can proceed:"
+msgstr "%(name)s требует, чтобы вы приняли следующее соглашение конечного пользователя перед началом его установки:"
 
 #: src/olympia/addons/templates/addons/mobile/eula.html:15
 msgid "Accept"
 msgstr "Принять"
 
-#: src/olympia/addons/templates/addons/mobile/home.html:10
-#: src/olympia/templates/mobile/base_addons.html:53
+#: src/olympia/addons/templates/addons/mobile/home.html:10 src/olympia/templates/mobile/base_addons.html:53
 msgid "Add-ons are not currently available on Firefox for iOS."
 msgstr "В данное время дополнения не доступны в Firefox для iOS."
 
-#: src/olympia/addons/templates/addons/mobile/home.html:12
-#: src/olympia/templates/mobile/base_addons.html:55
-msgid ""
-"You need Firefox to install add-ons. <a "
-"href=\"http://mozilla.com/mobile\">Learn More&nbsp;&raquo;</a>"
-msgstr ""
-"Для установки дополнений вам потребуется Firefox. <a "
-"href=\"http://mozilla.com/mobile\">Подробнее&nbsp;&raquo;</a>"
+#: src/olympia/addons/templates/addons/mobile/home.html:12 src/olympia/templates/mobile/base_addons.html:55
+msgid "You need Firefox to install add-ons. <a href=\"http://mozilla.com/mobile\">Learn More&nbsp;&raquo;</a>"
+msgstr "Для установки дополнений вам потребуется Firefox. <a href=\"http://mozilla.com/mobile\">Подробнее&nbsp;&raquo;</a>"
 
 # {0} is the application name.  Example:  Firefox
-#: src/olympia/addons/templates/addons/mobile/home.html:19
-#: src/olympia/templates/header_title.html:4
-#: src/olympia/templates/impala/header_title.html:3
+#: src/olympia/addons/templates/addons/mobile/home.html:19 src/olympia/templates/header_title.html:4 src/olympia/templates/impala/header_title.html:3
 msgid "Return to the {0} Add-ons homepage"
 msgstr "Вернуться на домашнюю страницу дополнений {0}"
 
-#: src/olympia/addons/templates/addons/mobile/home.html:21
-#: src/olympia/amo/helpers.py:237
-#: src/olympia/bandwagon/templates/bandwagon/edit.html:34
-#: src/olympia/discovery/templates/discovery/pane.html:92
-#: src/olympia/editors/templates/editors/base.html:21
-#: src/olympia/editors/templates/editors/performance.html:72
-#: src/olympia/templates/menu_links.html:4
-#: src/olympia/templates/impala/header_title.html:13
-#: src/olympia/templates/impala/header_title.html:15
-#: src/olympia/templates/impala/header_title.html:19
-#: src/olympia/templates/impala/header_title.html:23
-#: src/olympia/templates/mobile/base_addons.html:47
+#: src/olympia/addons/templates/addons/mobile/home.html:21 src/olympia/amo/helpers.py:237 src/olympia/bandwagon/templates/bandwagon/edit.html:34 src/olympia/discovery/templates/discovery/pane.html:92
+#: src/olympia/editors/templates/editors/base.html:21 src/olympia/editors/templates/editors/performance.html:72 src/olympia/templates/menu_links.html:4
+#: src/olympia/templates/impala/header_title.html:13 src/olympia/templates/impala/header_title.html:15 src/olympia/templates/impala/header_title.html:19
+#: src/olympia/templates/impala/header_title.html:23 src/olympia/templates/mobile/base_addons.html:47
 msgid "Add-ons"
 msgstr "Дополнения"
 
@@ -1767,48 +1321,28 @@ msgstr "Дополнения"
 msgid "Easy ways to personalize."
 msgstr "Легкие способы персонализации."
 
-#: src/olympia/addons/templates/addons/mobile/home.html:24
-#: src/olympia/devhub/templates/devhub/addons/submit/done.html:47
-#: src/olympia/discovery/templates/discovery/pane.html:34
-#: src/olympia/discovery/templates/discovery/addons/detail.html:16
-#: src/olympia/discovery/templates/discovery/modules/featured.html:21
-#: src/olympia/discovery/templates/discovery/modules/monthly.html:22
+#: src/olympia/addons/templates/addons/mobile/home.html:24 src/olympia/devhub/templates/devhub/addons/submit/done.html:47 src/olympia/discovery/templates/discovery/pane.html:34
+#: src/olympia/discovery/templates/discovery/addons/detail.html:16 src/olympia/discovery/templates/discovery/modules/featured.html:21 src/olympia/discovery/templates/discovery/modules/monthly.html:22
 msgid "Learn More"
 msgstr "Подробнее"
 
 #: src/olympia/addons/templates/addons/mobile/home.html:26
 msgid ""
-"Add-ons are applications that let you personalize Firefox with extra "
-"functionality and style. Whether you mistype the name of a website or can't "
-"read a busy page, there's an add-on to improve your on-the-go browsing."
+"Add-ons are applications that let you personalize Firefox with extra functionality and style. Whether you mistype the name of a website or can't read a busy page, there's an add-on to improve your "
+"on-the-go browsing."
 msgstr ""
-"Дополнения это приложения, которые позволяют добавить в Firefox "
-"дополнительные функции или стиль, настроив его по вашему вкусу. Если вы "
-"ошиблись при наборе имени сайта или не можете прочесть переполненную "
-"страницу, всегда найдется дополнение, которое сможет вам помочь."
+"Дополнения это приложения, которые позволяют добавить в Firefox дополнительные функции или стиль, настроив его по вашему вкусу. Если вы ошиблись при наборе имени сайта или не можете прочесть "
+"переполненную страницу, всегда найдется дополнение, которое сможет вам помочь."
 
 #. {0} is a category name. Ex: "Sports"
 #. {0} is a category name, such as Nature.
-#: src/olympia/addons/templates/addons/mobile/home.html:43
-#: src/olympia/amo/templates/amo/site_nav.html:32
-#: src/olympia/browse/feeds.py:107
-#: src/olympia/browse/templates/browse/impala/base_listing.html:38
-#: src/olympia/browse/templates/browse/personas/base.html:6
-#: src/olympia/browse/templates/browse/personas/base.html:42
-#: src/olympia/browse/templates/browse/personas/category_landing.html:21
-#: src/olympia/browse/templates/browse/personas/category_landing.html:23
-#: src/olympia/browse/templates/browse/personas/category_landing.html:38
-#: src/olympia/browse/templates/browse/personas/grid.html:7
-#: src/olympia/browse/templates/browse/personas/grid.html:11
-#: src/olympia/browse/templates/browse/personas/mobile/base.html:7
-#: src/olympia/browse/templates/browse/personas/mobile/category_landing.html:19
-#: src/olympia/constants/base.py:180
-#: src/olympia/devhub/templates/devhub/personas/submit.html:13
-#: src/olympia/editors/helpers.py:105
-#: src/olympia/editors/templates/editors/base.html:26
-#: src/olympia/editors/templates/editors/performance.html:73
-#: src/olympia/search/templates/search/personas.html:39
-#: src/olympia/templates/menu_links.html:9
+#: src/olympia/addons/templates/addons/mobile/home.html:43 src/olympia/amo/templates/amo/site_nav.html:32 src/olympia/browse/feeds.py:107
+#: src/olympia/browse/templates/browse/impala/base_listing.html:38 src/olympia/browse/templates/browse/personas/base.html:6 src/olympia/browse/templates/browse/personas/base.html:42
+#: src/olympia/browse/templates/browse/personas/category_landing.html:21 src/olympia/browse/templates/browse/personas/category_landing.html:23
+#: src/olympia/browse/templates/browse/personas/category_landing.html:38 src/olympia/browse/templates/browse/personas/grid.html:7 src/olympia/browse/templates/browse/personas/grid.html:11
+#: src/olympia/browse/templates/browse/personas/mobile/base.html:7 src/olympia/browse/templates/browse/personas/mobile/category_landing.html:19 src/olympia/constants/base.py:180
+#: src/olympia/devhub/templates/devhub/personas/submit.html:13 src/olympia/editors/helpers.py:107 src/olympia/editors/templates/editors/base.html:26
+#: src/olympia/editors/templates/editors/performance.html:73 src/olympia/search/templates/search/personas.html:39 src/olympia/templates/menu_links.html:9
 msgid "Themes"
 msgstr "Темы"
 
@@ -1824,19 +1358,12 @@ msgstr "Просмотреть все популярные дополнения"
 msgid "More Add-ons"
 msgstr "Ещё дополнения"
 
-#: src/olympia/addons/templates/addons/mobile/home.html:72
-#: src/olympia/browse/templates/browse/personas/mobile/category_landing.html:64
-#: src/olympia/search/forms.py:14
+#: src/olympia/addons/templates/addons/mobile/home.html:72 src/olympia/browse/templates/browse/personas/mobile/category_landing.html:64 src/olympia/search/forms.py:14
 msgid "Highest Rated"
 msgstr "Лидеры рейтинга"
 
-#: src/olympia/addons/templates/addons/mobile/home.html:74
-#: src/olympia/amo/templates/amo/side_nav.html:5
-#: src/olympia/amo/templates/amo/site_nav.html:27
-#: src/olympia/amo/templates/amo/site_nav.html:57
-#: src/olympia/bandwagon/views.py:97 src/olympia/browse/views.py:57
-#: src/olympia/browse/views.py:67
-#: src/olympia/browse/templates/browse/personas/mobile/category_landing.html:65
+#: src/olympia/addons/templates/addons/mobile/home.html:74 src/olympia/amo/templates/amo/side_nav.html:5 src/olympia/amo/templates/amo/site_nav.html:27 src/olympia/amo/templates/amo/site_nav.html:55
+#: src/olympia/bandwagon/views.py:97 src/olympia/browse/views.py:57 src/olympia/browse/views.py:67 src/olympia/browse/templates/browse/personas/mobile/category_landing.html:65
 #: src/olympia/search/forms.py:15 src/olympia/search/forms.py:87
 msgid "Newest"
 msgstr "Новейшие"
@@ -1849,124 +1376,90 @@ msgstr "Попробуйте их!"
 msgid "Theme Info &raquo;"
 msgstr "Информация об теме &raquo;"
 
-#: src/olympia/amo/context_processors.py:39
-#: src/olympia/devhub/templates/devhub/nav.html:43
+#: src/olympia/amo/context_processors.py:37 src/olympia/devhub/templates/devhub/nav.html:43
 msgid "Tools"
 msgstr "Инструменты"
 
-#: src/olympia/amo/context_processors.py:48
-#: src/olympia/discovery/templates/discovery/pane_account.html:8
-#: src/olympia/users/templates/users/includes/navigation.html:2
+#: src/olympia/amo/context_processors.py:47 src/olympia/discovery/templates/discovery/pane_account.html:8 src/olympia/users/templates/users/includes/navigation.html:2
 msgid "My Profile"
 msgstr "Мой Профиль"
 
-#: src/olympia/amo/context_processors.py:54
-#: src/olympia/users/templates/users/edit.html:5
-#: src/olympia/users/templates/users/includes/navigation.html:3
+#: src/olympia/amo/context_processors.py:53 src/olympia/users/templates/users/edit.html:5 src/olympia/users/templates/users/includes/navigation.html:3
 msgid "Account Settings"
 msgstr "Настройки учётной записи"
 
-#: src/olympia/amo/context_processors.py:57
-#: src/olympia/discovery/templates/discovery/pane_account.html:11
-#: src/olympia/users/templates/users/profile.html:83
+#: src/olympia/amo/context_processors.py:56 src/olympia/discovery/templates/discovery/pane_account.html:11 src/olympia/users/templates/users/profile.html:83
 #: src/olympia/users/templates/users/includes/navigation.html:4
 msgid "My Collections"
 msgstr "Мои подборки"
 
-#: src/olympia/amo/context_processors.py:62
-#: src/olympia/discovery/templates/discovery/pane_account.html:10
-#: src/olympia/users/templates/users/includes/navigation.html:7
+#: src/olympia/amo/context_processors.py:61 src/olympia/discovery/templates/discovery/pane_account.html:10 src/olympia/users/templates/users/includes/navigation.html:7
 msgid "My Favorites"
 msgstr "Мои любимые"
 
-#: src/olympia/amo/context_processors.py:67
-#: src/olympia/discovery/templates/discovery/pane_account.html:13
-#: src/olympia/templates/impala/user_login.html:14
+#: src/olympia/amo/context_processors.py:66 src/olympia/discovery/templates/discovery/pane_account.html:13 src/olympia/templates/impala/user_login.html:14
 #: src/olympia/templates/mobile/header_auth.html:5
 msgid "Log out"
 msgstr "Выйти"
 
-#: src/olympia/amo/context_processors.py:72
-#: src/olympia/devhub/templates/devhub/addons/dashboard.html:4
+#: src/olympia/amo/context_processors.py:71 src/olympia/devhub/templates/devhub/addons/dashboard.html:4
 msgid "Manage My Submissions"
 msgstr "Управление моими представлениями"
 
-#: src/olympia/amo/context_processors.py:75
-#: src/olympia/devhub/templates/devhub/nav.html:27
-#: src/olympia/devhub/templates/devhub/addons/dashboard.html:25
+#: src/olympia/amo/context_processors.py:74 src/olympia/devhub/templates/devhub/nav.html:27 src/olympia/devhub/templates/devhub/addons/dashboard.html:25
 #: src/olympia/devhub/templates/devhub/addons/submit/base.html:4
 msgid "Submit a New Add-on"
 msgstr "Отправить новое дополнение"
 
-#: src/olympia/amo/context_processors.py:77
-#: src/olympia/browse/templates/browse/personas/base.html:50
-#: src/olympia/devhub/templates/devhub/index.html:24
+#: src/olympia/amo/context_processors.py:76 src/olympia/browse/templates/browse/personas/base.html:50 src/olympia/devhub/templates/devhub/index.html:24
 #: src/olympia/devhub/templates/devhub/addons/dashboard.html:29
 msgid "Submit a New Theme"
 msgstr "Представить новую тему"
 
-#: src/olympia/amo/context_processors.py:79
-#: src/olympia/amo/templates/amo/site_nav.html:87
-#: src/olympia/devhub/helpers.py:36 src/olympia/devhub/helpers.py:68
-#: src/olympia/devhub/helpers.py:102 src/olympia/templates/footer.html:6
-#: src/olympia/templates/menu_links.html:14
+#: src/olympia/amo/context_processors.py:78 src/olympia/amo/templates/amo/site_nav.html:85 src/olympia/devhub/helpers.py:36 src/olympia/devhub/helpers.py:68 src/olympia/devhub/helpers.py:102
+#: src/olympia/templates/footer.html:6 src/olympia/templates/menu_links.html:14
 msgid "Developer Hub"
 msgstr "Центр разработки"
 
-#: src/olympia/amo/context_processors.py:83 src/olympia/devhub/views.py:1792
+#: src/olympia/amo/context_processors.py:81 src/olympia/devhub/views.py:1796
 msgid "Manage API Keys"
 msgstr "Управление API-ключами."
 
-#: src/olympia/amo/context_processors.py:88 src/olympia/editors/helpers.py:82
-#: src/olympia/editors/helpers.py:102
-#: src/olympia/editors/templates/editors/base.html:10
+#: src/olympia/amo/context_processors.py:86 src/olympia/editors/helpers.py:84 src/olympia/editors/helpers.py:104 src/olympia/editors/templates/editors/base.html:10
 msgid "Editor Tools"
 msgstr "Инструменты редактора"
 
-#: src/olympia/amo/context_processors.py:92
+#: src/olympia/amo/context_processors.py:90
 msgid "Admin Tools"
 msgstr "Инструменты админа"
 
-#: src/olympia/amo/fields.py:15
+#: src/olympia/amo/fields.py:20
 msgid "Incorrect, please try again."
 msgstr "Некорректно, пожалуйста, попробуйте снова."
 
-#: src/olympia/amo/fields.py:16
+#: src/olympia/amo/fields.py:21
 msgid "Error verifying input, please try again."
 msgstr "Ошибка проверки ввода, пожалуйста, попробуйте снова."
 
-#: src/olympia/amo/fields.py:32
+#: src/olympia/amo/fields.py:37
 msgid "This must be a valid hex color code, such as #000000."
-msgstr ""
-"Это должен быть действительный шестнадцатеричный код цвета, например "
-"#000000."
+msgstr "Это должен быть действительный шестнадцатеричный код цвета, например #000000."
 
-#: src/olympia/amo/fields.py:58
+#: src/olympia/amo/fields.py:63
 msgid "Enter at least one value."
 msgstr "Введите по меньшей мере одно значение."
 
-#: src/olympia/amo/helpers.py:162
-#: src/olympia/amo/templates/amo/site_nav.html:61
-#: src/olympia/bandwagon/templates/bandwagon/add.html:9
-#: src/olympia/bandwagon/templates/bandwagon/collection_detail.html:15
-#: src/olympia/bandwagon/templates/bandwagon/delete.html:9
-#: src/olympia/bandwagon/templates/bandwagon/edit.html:15
-#: src/olympia/bandwagon/templates/bandwagon/user_listing.html:18
-#: src/olympia/bandwagon/templates/bandwagon/user_listing.html:21
-#: src/olympia/bandwagon/templates/bandwagon/impala/collection_listing.html:12
-#: src/olympia/bandwagon/templates/bandwagon/impala/collection_listing.html:20
-#: src/olympia/bandwagon/templates/bandwagon/impala/collection_listing.html:24
-#: src/olympia/bandwagon/templates/bandwagon/impala/collection_sidebar.html:3
-#: src/olympia/bandwagon/templates/bandwagon/includes/collection_sidebar.html:2
-#: src/olympia/bandwagon/templates/bandwagon/mobile/collection_listing.html:3
-#: src/olympia/stats/templates/stats/stats.html:77
-#: src/olympia/templates/menu_links.html:12
+#: src/olympia/amo/helpers.py:162 src/olympia/amo/templates/amo/site_nav.html:59 src/olympia/bandwagon/templates/bandwagon/add.html:9
+#: src/olympia/bandwagon/templates/bandwagon/collection_detail.html:15 src/olympia/bandwagon/templates/bandwagon/delete.html:9 src/olympia/bandwagon/templates/bandwagon/edit.html:15
+#: src/olympia/bandwagon/templates/bandwagon/user_listing.html:18 src/olympia/bandwagon/templates/bandwagon/user_listing.html:21
+#: src/olympia/bandwagon/templates/bandwagon/impala/collection_listing.html:12 src/olympia/bandwagon/templates/bandwagon/impala/collection_listing.html:20
+#: src/olympia/bandwagon/templates/bandwagon/impala/collection_listing.html:24 src/olympia/bandwagon/templates/bandwagon/impala/collection_sidebar.html:3
+#: src/olympia/bandwagon/templates/bandwagon/includes/collection_sidebar.html:2 src/olympia/bandwagon/templates/bandwagon/mobile/collection_listing.html:3
+#: src/olympia/stats/templates/stats/stats.html:33 src/olympia/templates/menu_links.html:12
 msgid "Collections"
 msgstr "Подборки"
 
-#: src/olympia/amo/helpers.py:171
-#: src/olympia/amo/templates/amo/site_nav.html:85
-#: src/olympia/browse/templates/browse/language_tools.html:3
+#: src/olympia/amo/helpers.py:171 src/olympia/amo/templates/amo/site_nav.html:83 src/olympia/browse/templates/browse/language_tools.html:3
 msgid "Dictionaries & Language Packs"
 msgstr "Словари и локализации"
 
@@ -2118,11 +1611,8 @@ msgstr "Запрошена суперрецензия"
 msgid "Comment on {addon} {version}."
 msgstr "Коментарий о {addon} {version}."
 
-#: src/olympia/amo/log.py:236
-#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:19
-#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:47
-#: src/olympia/editors/helpers.py:511
-#: src/olympia/editors/templates/editors/themes/history_table.html:11
+#: src/olympia/amo/log.py:236 src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:17 src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:45
+#: src/olympia/editors/helpers.py:584 src/olympia/editors/templates/editors/themes/history_table.html:11
 msgid "Comment"
 msgstr "Комментарий"
 
@@ -2260,8 +1750,7 @@ msgstr "Приложение отключено"
 
 #: src/olympia/amo/log.py:425
 msgid "{addon} escalated because of high number of abuse reports."
-msgstr ""
-"{addon} передано наверх из-за большого числа сообщений о злоупотреблении."
+msgstr "{addon} передано наверх из-за большого числа сообщений о злоупотреблении."
 
 #: src/olympia/amo/log.py:426
 msgid "High Abuse Reports"
@@ -2277,7 +1766,7 @@ msgstr "Эскалация проверки"
 
 #: src/olympia/amo/log.py:442
 msgid "Video removed from {addon} because of a problem with the video. "
-msgstr "Видео удалено из {addon} из-за проблемы с видео. "
+msgstr ""
 
 #: src/olympia/amo/log.py:444
 msgid "Video removed"
@@ -2381,10 +1870,7 @@ msgstr "Рейтинг содержания {addon} изменился."
 msgid "{addon} unlisted."
 msgstr "{addon} убрано из списка."
 
-#: src/olympia/amo/log.py:592 src/olympia/amo/log.py:598
-#: src/olympia/amo/log.py:612 src/olympia/amo/log.py:618
-#: src/olympia/amo/log.py:624 src/olympia/amo/log.py:630
-#: src/olympia/amo/log.py:636
+#: src/olympia/amo/log.py:592 src/olympia/amo/log.py:598 src/olympia/amo/log.py:612 src/olympia/amo/log.py:618 src/olympia/amo/log.py:624 src/olympia/amo/log.py:630 src/olympia/amo/log.py:636
 msgid "{file} was signed."
 msgstr "{file} был подписан."
 
@@ -2398,20 +1884,12 @@ msgid "Not allowed"
 msgstr "Не разрешено"
 
 #: src/olympia/amo/templates/amo/403.html:7
-msgid ""
-"<h1>Oops! Not allowed.</h1> <p>You tried to do something that you weren't "
-"allowed to.</p>"
-msgstr ""
-"<h1>Ой! Не разрешено.</h1> <p>Вы попытались сделать что-то, что вам не "
-"разрешено.</p>"
+msgid "<h1>Oops! Not allowed.</h1> <p>You tried to do something that you weren't allowed to.</p>"
+msgstr "<h1>Ой! Не разрешено.</h1> <p>Вы попытались сделать что-то, что вам не разрешено.</p>"
 
 #: src/olympia/amo/templates/amo/403.html:12
-msgid ""
-"<p>Try going back to the previous page, refreshing and then trying "
-"again.</p>"
-msgstr ""
-"<p>Попробуйте вернуться на предыдущую страницу, обновите, а затем попробуйте"
-" снова.</p>"
+msgid "<p>Try going back to the previous page, refreshing and then trying again.</p>"
+msgstr "<p>Попробуйте вернуться на предыдущую страницу, обновите, а затем попробуйте снова.</p>"
 
 #: src/olympia/amo/templates/amo/404.html:3
 msgid "Not Found"
@@ -2420,37 +1898,19 @@ msgstr "Не найдено"
 #: src/olympia/amo/templates/amo/404.html:6
 #, python-format
 msgid ""
-"<h1>We're sorry, but we can't find what you're looking for.</h1> <p> The "
-"page or file you requested wasn't found on our site. It's possible that you "
-"clicked a link that's out of date, or typed in the address incorrectly. </p>"
-" <ul> <li>If you typed in the address, please double check the "
-"spelling.</li> <li> If you followed a link from somewhere, please let us "
-"know at <a href=\"mailto:webmaster@mozilla.com\">webmaster@mozilla.com</a>. "
-"Tell us where you came from and what you were looking for, and we'll do our "
-"best to fix it. </li> </ul> <p>Or you can just jump over to some of the "
-"popular pages on our website.</p> <ul> <li>Are you interested in a <a "
-"href=\"%(rec)s\">list of featured add-ons</a>?</li> <li> Do you want to <a "
-"href=\"%(search)s\">search for add-ons</a>? You may go to the <a "
-"href=\"%(search)s\">search page</a> or just use the search field above. "
-"</li> <li> If you prefer to start over, just go to the <a href=\"%(home)s"
-"\">add-ons front page</a>. </li> </ul>"
+"<h1>We're sorry, but we can't find what you're looking for.</h1> <p> The page or file you requested wasn't found on our site. It's possible that you clicked a link that's out of date, or typed in "
+"the address incorrectly. </p> <ul> <li>If you typed in the address, please double check the spelling.</li> <li> If you followed a link from somewhere, please let us know at <a href=\"mailto:"
+"webmaster@mozilla.com\">webmaster@mozilla.com</a>. Tell us where you came from and what you were looking for, and we'll do our best to fix it. </li> </ul> <p>Or you can just jump over to some of "
+"the popular pages on our website.</p> <ul> <li>Are you interested in a <a href=\"%(rec)s\">list of featured add-ons</a>?</li> <li> Do you want to <a href=\"%(search)s\">search for add-ons</a>? You "
+"may go to the <a href=\"%(search)s\">search page</a> or just use the search field above. </li> <li> If you prefer to start over, just go to the <a href=\"%(home)s\">add-ons front page</a>. </li> </"
+"ul>"
 msgstr ""
-"<h1>Извините, но мы не можем найти то, что вы ищете.</h1> <p>Страница или "
-"файл, который вы запросили, не найден на нашем сайте. Вполне возможно, что "
-"вы нажали на ссылку, которая устарела, или неправильно набрали адрес. "
-"</p><ul><li> Если вы набрали адрес, пожалуйста, проверьте правильность его "
-"написания.</li> <li> Если вы откуда-либо проследовали по ссылке, пожалуйста,"
-" сообщите нам об этом по адресу <a "
-"href=\"mailto:webmaster@mozilla.com\">webmaster@mozilla.com</a>. Сообщите "
-"нам, откуда вы пришли и что вы ищете, и мы сделаем все возможное, чтобы это "
-"исправить. </li></ul> <p>Или же вы можете просто перепрыгнуть на некоторые "
-"из популярных страниц нашего сайта.</p> <ul> <li> Возможно вы заинтересованы"
-" в <a href=\"%(rec)s\">списке избранных дополнений</a>? </li> <li> Или вы "
-"хотите <a href=\"%(search)s\">найти дополнение</a>? Вы можете перейти к <a "
-"href=\"%(search)s\">странице поиска</a> или просто использовать поле поиска,"
-" расположенное выше. </li> <li> Если вы хотите начать сначала, просто "
-"перейдите на <a href=\"%(home)s\">начальную страницу дополнений</a>. </li> "
-"</ul>"
+"<h1>Извините, но мы не можем найти то, что вы ищете.</h1> <p>Страница или файл, который вы запросили, не найден на нашем сайте. Вполне возможно, что вы нажали на ссылку, которая устарела, или "
+"неправильно набрали адрес. </p><ul><li> Если вы набрали адрес, пожалуйста, проверьте правильность его написания.</li> <li> Если вы откуда-либо проследовали по ссылке, пожалуйста, сообщите нам об "
+"этом по адресу <a href=\"mailto:webmaster@mozilla.com\">webmaster@mozilla.com</a>. Сообщите нам, откуда вы пришли и что вы ищете, и мы сделаем все возможное, чтобы это исправить. </li></ul> <p>Или "
+"же вы можете просто перепрыгнуть на некоторые из популярных страниц нашего сайта.</p> <ul> <li> Возможно вы заинтересованы в <a href=\"%(rec)s\">списке избранных дополнений</a>? </li> <li> Или вы "
+"хотите <a href=\"%(search)s\">найти дополнение</a>? Вы можете перейти к <a href=\"%(search)s\">странице поиска</a> или просто использовать поле поиска, расположенное выше. </li> <li> Если вы хотите "
+"начать сначала, просто перейдите на <a href=\"%(home)s\">начальную страницу дополнений</a>. </li> </ul>"
 
 #: src/olympia/amo/templates/amo/500.html:3
 msgid "Oops"
@@ -2458,82 +1918,49 @@ msgstr "Ой"
 
 #: src/olympia/amo/templates/amo/500.html:6
 #, python-format
-msgid ""
-"<h1>Oops!  We had an error.</h1> <p>We'll get to fixing that soon.</p> <p> "
-"You can try refreshing the page, or head back to the <a href=\"%(home)s"
-"\">Add-ons homepage</a>. </p>"
+msgid "<h1>Oops!  We had an error.</h1> <p>We'll get to fixing that soon.</p> <p> You can try refreshing the page, or head back to the <a href=\"%(home)s\">Add-ons homepage</a>. </p>"
 msgstr ""
-"<h1>Ой!  У нас ошибка.</h1> <p>Мы скоро это починим.</p> <p> Попробуйте "
-"обновить страницу или вернуться на <a href=\"%(home)s\">домашнюю страницу "
-"дополнений</a>. </p>"
 
 #: src/olympia/amo/templates/amo/license_link.html:10
 msgid "Some rights reserved"
 msgstr "Некоторые права защищены"
 
-#: src/olympia/amo/templates/amo/no_results.html:1
-#: src/olympia/editors/templates/editors/includes/search_results_themes.html:26
+#: src/olympia/amo/templates/amo/no_results.html:1 src/olympia/editors/templates/editors/includes/search_results_themes.html:26
 msgid "No results found"
 msgstr "Результатов не найдено"
 
 #. abbreviation of 'previous'
-#: src/olympia/amo/templates/amo/paginator.html:6
-#: src/olympia/amo/templates/amo/mobile/paginator.html:4
-#: src/olympia/amo/templates/amo/mobile/paginator.html:6
-#: src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:49
-#: src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:63
-#: src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:76
-#: src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:89
+#: src/olympia/amo/templates/amo/paginator.html:6 src/olympia/amo/templates/amo/mobile/paginator.html:4 src/olympia/amo/templates/amo/mobile/paginator.html:6
+#: src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:49 src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:63
+#: src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:76 src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:89
 #: src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:102
 msgid "Prev"
 msgstr "Предыдущее"
 
-#: src/olympia/amo/templates/amo/paginator.html:26
-#: src/olympia/amo/templates/amo/impala/paginator.html:26
-#: src/olympia/amo/templates/amo/mobile/impala_paginator.html:16
-#: src/olympia/amo/templates/amo/mobile/paginator.html:14
-#: src/olympia/amo/templates/amo/mobile/paginator.html:16
-#: src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:51
-#: src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:65
-#: src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:78
-#: src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:91
-#: src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:104
-#: src/olympia/discovery/templates/discovery/pane.html:45
-#: src/olympia/discovery/templates/discovery/addons/detail.html:39
-#: src/olympia/stats/templates/stats/stats.html:167
+#: src/olympia/amo/templates/amo/paginator.html:26 src/olympia/amo/templates/amo/impala/paginator.html:26 src/olympia/amo/templates/amo/mobile/impala_paginator.html:16
+#: src/olympia/amo/templates/amo/mobile/paginator.html:14 src/olympia/amo/templates/amo/mobile/paginator.html:16 src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:51
+#: src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:65 src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:78
+#: src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:91 src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:104
+#: src/olympia/discovery/templates/discovery/pane.html:45 src/olympia/discovery/templates/discovery/addons/detail.html:39 src/olympia/stats/templates/stats/stats.html:169
 msgid "Next"
 msgstr "Следующее"
 
-#: src/olympia/amo/templates/amo/paginator.html:32
-#: src/olympia/editors/templates/editors/includes/paginator_history.html:11
+#: src/olympia/amo/templates/amo/paginator.html:32 src/olympia/editors/templates/editors/includes/paginator_history.html:11
 #, python-format
-msgid ""
-"Results <strong>%(begin)s</strong>&ndash;<strong>%(end)s</strong> of "
-"<strong>%(count)s</strong>"
-msgstr ""
-"Результаты <strong>%(begin)s</strong>&ndash;<strong>%(end)s</strong> из "
-"<strong>%(count)s</strong>"
+msgid "Results <strong>%(begin)s</strong>&ndash;<strong>%(end)s</strong> of <strong>%(count)s</strong>"
+msgstr "Результаты <strong>%(begin)s</strong>&ndash;<strong>%(end)s</strong> из <strong>%(count)s</strong>"
 
-#: src/olympia/amo/templates/amo/read-only.html:3
-#: src/olympia/amo/templates/amo/read-only.html:7
+#: src/olympia/amo/templates/amo/read-only.html:3 src/olympia/amo/templates/amo/read-only.html:7
 msgid "Maintenance in progress"
 msgstr "Происходит техническое обслуживание"
 
 #: src/olympia/amo/templates/amo/read-only.html:9
-msgid ""
-"This feature is temporarily disabled while we perform website maintenance. "
-"Please use your browser's Back button and try again a little later."
-msgstr ""
-"Эта функция временно отключена, пока мы проводим техническое обслуживание "
-"сайта. Пожалуйста, используйте браузера кнопку \"Назад\" и попробуйте позже."
+msgid "This feature is temporarily disabled while we perform website maintenance. Please use your browser's Back button and try again a little later."
+msgstr "Эта функция временно отключена, пока мы проводим техническое обслуживание сайта. Пожалуйста, используйте браузера кнопку \"Назад\" и попробуйте позже."
 
 #: src/olympia/amo/templates/amo/read-only.html:14
-msgid ""
-"Some features on this page are temporarily disabled while we perform website"
-" maintenance. Please try again a little later."
-msgstr ""
-"Некоторые функции на этой странице временно отключены, пока мы проводим "
-"техническое обслуживание сайта. Пожалуйста, повторите попытку позже."
+msgid "Some features on this page are temporarily disabled while we perform website maintenance. Please try again a little later."
+msgstr "Некоторые функции на этой странице временно отключены, пока мы проводим техническое обслуживание сайта. Пожалуйста, повторите попытку позже."
 
 #: src/olympia/amo/templates/amo/recaptcha.html:4
 msgid "Are you human?"
@@ -2541,25 +1968,14 @@ msgstr "Вы человек?"
 
 #: src/olympia/amo/templates/amo/recaptcha.html:8
 msgid ""
-"<p> Please enter <strong>all the words</strong> below, <strong>separated by "
-"a space if necessary</strong>. </p> <p> If this is hard to read, you can <a "
-"href=\"#\" id=\"recaptcha_different\">try different words</a> or <a "
-"href=\"#\" id=\"recaptcha_audio\">try a different type of challenge</a> "
-"instead. </p>"
+"<p> Please enter <strong>all the words</strong> below, <strong>separated by a space if necessary</strong>. </p> <p> If this is hard to read, you can <a href=\"#\" id=\"recaptcha_different\">try "
+"different words</a> or <a href=\"#\" id=\"recaptcha_audio\">try a different type of challenge</a> instead. </p>"
 msgstr ""
-"<p> Пожалуйста, введите ниже <strong>все слова</strong>, <strong>при "
-"необходимости разделяя их пробелом</strong>. </p> <p> Если их трудно "
-"прочесть, вы можете <a href=\"#\" id=\"recaptcha_different\">попробовать "
-"другие слова</a> или вместо слов <a href=\"#\" "
-"id=\"recaptcha_audio\">попробовать другой тип проверки</a>. </p>"
+"<p> Пожалуйста, введите ниже <strong>все слова</strong>, <strong>при необходимости разделяя их пробелом</strong>. </p> <p> Если их трудно прочесть, вы можете <a href=\"#\" id=\"recaptcha_different"
+"\">попробовать другие слова</a> или вместо слов <a href=\"#\" id=\"recaptcha_audio\">попробовать другой тип проверки</a>. </p>"
 
-#: src/olympia/amo/templates/amo/side_nav.html:4
-#: src/olympia/amo/templates/amo/side_nav.html:12
-#: src/olympia/amo/templates/amo/site_nav.html:4
-#: src/olympia/amo/templates/amo/site_nav.html:26
-#: src/olympia/browse/views.py:56 src/olympia/browse/views.py:66
-#: src/olympia/browse/views.py:237 src/olympia/browse/views.py:282
-#: src/olympia/search/forms.py:86
+#: src/olympia/amo/templates/amo/side_nav.html:4 src/olympia/amo/templates/amo/side_nav.html:12 src/olympia/amo/templates/amo/site_nav.html:4 src/olympia/amo/templates/amo/site_nav.html:26
+#: src/olympia/browse/views.py:56 src/olympia/browse/views.py:66 src/olympia/browse/views.py:204 src/olympia/browse/views.py:249 src/olympia/search/forms.py:86
 msgid "Top Rated"
 msgstr "Лидеры рейтинга"
 
@@ -2568,81 +1984,60 @@ msgid "Explore"
 msgstr "Просмотреть"
 
 # Plural in this context means many of the add-on type
-#: src/olympia/amo/templates/amo/site_nav.html:23
-#: src/olympia/browse/feeds.py:65 src/olympia/browse/feeds.py:78
-#: src/olympia/browse/feeds.py:92 src/olympia/browse/feeds.py:100
-#: src/olympia/browse/templates/browse/base_listing.html:7
-#: src/olympia/browse/templates/browse/creatured.html:10
-#: src/olympia/browse/templates/browse/impala/base_listing.html:37
+#: src/olympia/amo/templates/amo/site_nav.html:23 src/olympia/browse/feeds.py:65 src/olympia/browse/feeds.py:78 src/olympia/browse/feeds.py:92 src/olympia/browse/feeds.py:100
+#: src/olympia/browse/templates/browse/base_listing.html:7 src/olympia/browse/templates/browse/creatured.html:10 src/olympia/browse/templates/browse/impala/base_listing.html:37
 #: src/olympia/constants/base.py:173 src/olympia/templates/menu_links.html:8
 msgid "Extensions"
 msgstr "Расширения"
 
-#: src/olympia/amo/templates/amo/site_nav.html:45
+#: src/olympia/amo/templates/amo/site_nav.html:44
 msgid "Want more customization? Try <b>Complete Themes</b>"
 msgstr "Хотите больше настроек? Попробуйте <b>готовые темы</b>"
 
-#: src/olympia/amo/templates/amo/site_nav.html:56
-#: src/olympia/bandwagon/views.py:96
+#: src/olympia/amo/templates/amo/site_nav.html:54 src/olympia/bandwagon/views.py:96
 msgid "Most Followers"
 msgstr "Чаще всего отслеживаемые"
 
-#: src/olympia/amo/templates/amo/site_nav.html:68
-#: src/olympia/bandwagon/templates/bandwagon/impala/collection_sidebar.html:16
+#: src/olympia/amo/templates/amo/site_nav.html:66 src/olympia/bandwagon/templates/bandwagon/impala/collection_sidebar.html:16
 #: src/olympia/bandwagon/templates/bandwagon/includes/collection_sidebar.html:18
 msgid "Collections I've Made"
 msgstr "Созданные мной подборки"
 
-#: src/olympia/amo/templates/amo/site_nav.html:70
-#: src/olympia/bandwagon/templates/bandwagon/user_listing.html:4
-#: src/olympia/bandwagon/templates/bandwagon/impala/collection_sidebar.html:13
+#: src/olympia/amo/templates/amo/site_nav.html:68 src/olympia/bandwagon/templates/bandwagon/user_listing.html:4 src/olympia/bandwagon/templates/bandwagon/impala/collection_sidebar.html:13
 #: src/olympia/bandwagon/templates/bandwagon/includes/collection_sidebar.html:15
 msgid "Collections I'm Following"
 msgstr "Подборки, за которыми я слежу"
 
-#: src/olympia/amo/templates/amo/site_nav.html:73
-#: src/olympia/bandwagon/templates/bandwagon/impala/collection_sidebar.html:18
-#: src/olympia/bandwagon/templates/bandwagon/includes/collection_sidebar.html:20
-#: src/olympia/users/models.py:512
+#: src/olympia/amo/templates/amo/site_nav.html:71 src/olympia/bandwagon/templates/bandwagon/impala/collection_sidebar.html:18
+#: src/olympia/bandwagon/templates/bandwagon/includes/collection_sidebar.html:20 src/olympia/users/models.py:521
 msgid "My Favorite Add-ons"
 msgstr "Мои любимые дополнения"
 
-#: src/olympia/amo/templates/amo/site_nav.html:78
+#: src/olympia/amo/templates/amo/site_nav.html:76
 msgid "More&hellip;"
 msgstr "Ещё&hellip;"
 
-#: src/olympia/amo/templates/amo/site_nav.html:82
+#: src/olympia/amo/templates/amo/site_nav.html:80
 msgid "Add-ons for Mobile"
 msgstr "Мобильные дополнения"
 
-#: src/olympia/amo/templates/amo/site_nav.html:86
-#: src/olympia/browse/feeds.py:207
-#: src/olympia/browse/templates/browse/search_tools.html:3
-#: src/olympia/constants/base.py:176 src/olympia/templates/menu_links.html:10
+#: src/olympia/amo/templates/amo/site_nav.html:84 src/olympia/browse/feeds.py:207 src/olympia/browse/templates/browse/search_tools.html:3 src/olympia/constants/base.py:176
+#: src/olympia/templates/menu_links.html:10
 msgid "Search Tools"
 msgstr "Инструменты поиска"
 
 #. This is a page range (e.g., Page 1 of 50).
-#: src/olympia/amo/templates/amo/impala/paginator.html:5
-#: src/olympia/amo/templates/amo/mobile/impala_paginator.html:26
+#: src/olympia/amo/templates/amo/impala/paginator.html:5 src/olympia/amo/templates/amo/mobile/impala_paginator.html:26
 #, python-format
-msgid ""
-"Page <a href=\"%(current_pg_url)s\">%(current_pg)s</a> of <a "
-"href=\"%(last_pg_url)s\">%(last_pg)s</a>"
-msgstr ""
-"Страница <a href=\"%(current_pg_url)s\">%(current_pg)s</a> из <a "
-"href=\"%(last_pg_url)s\">%(last_pg)s</a>"
+msgid "Page <a href=\"%(current_pg_url)s\">%(current_pg)s</a> of <a href=\"%(last_pg_url)s\">%(last_pg)s</a>"
+msgstr "Страница <a href=\"%(current_pg_url)s\">%(current_pg)s</a> из <a href=\"%(last_pg_url)s\">%(last_pg)s</a>"
 
-#: src/olympia/amo/templates/amo/impala/paginator.html:16
-#: src/olympia/amo/templates/amo/mobile/impala_paginator.html:6
+#: src/olympia/amo/templates/amo/impala/paginator.html:16 src/olympia/amo/templates/amo/mobile/impala_paginator.html:6
 msgid "Jump to first page"
 msgstr "Перейти на первую страницу"
 
-#: src/olympia/amo/templates/amo/impala/paginator.html:22
-#: src/olympia/amo/templates/amo/mobile/impala_paginator.html:12
-#: src/olympia/discovery/templates/discovery/pane.html:44
-#: src/olympia/discovery/templates/discovery/addons/detail.html:38
-#: src/olympia/stats/templates/stats/stats.html:164
+#: src/olympia/amo/templates/amo/impala/paginator.html:22 src/olympia/amo/templates/amo/mobile/impala_paginator.html:12 src/olympia/discovery/templates/discovery/pane.html:44
+#: src/olympia/discovery/templates/discovery/addons/detail.html:38 src/olympia/stats/templates/stats/stats.html:166
 msgid "Previous"
 msgstr "Предыдущее"
 
@@ -2652,10 +2047,9 @@ msgstr "Перейти на последнюю страницу"
 
 #. First and second arguments are the result range (e.g., 1-20);
 #. third argument is the number of total results (e.g., 1,000).
-#. third
+#. First and second arguments are the result range (e.g., 1-20);              third
 #. argument is the number of total results (e.g., 1,000).
-#: src/olympia/amo/templates/amo/impala/paginator.html:36
-#: src/olympia/amo/templates/amo/mobile/impala_paginator.html:38
+#: src/olympia/amo/templates/amo/impala/paginator.html:36 src/olympia/amo/templates/amo/mobile/impala_paginator.html:38
 #, python-format
 msgid "Showing <b>%(begin)s</b>&ndash;<b>%(end)s</b> of <b>%(count)s</b>"
 msgstr "Показано <b>%(begin)s</b>&ndash;<b>%(end)s</b> из <b>%(count)s</b>"
@@ -2665,44 +2059,53 @@ msgid "Page {n}"
 msgid_plural "Page {n}"
 msgstr[0] "Страница {n}"
 msgstr[1] "Страница {n}"
-msgstr[2] "Страница {n}"
 
-#: src/olympia/amo/templates/services/install.html:38
-#, python-format
-msgid ""
-"If you are not prompted to install %(addon_name)s in a moment, please <a "
-"href=\"%(addon_xpi)s\">click here</a>."
-msgstr ""
-"Если вам не будет предложено установить сейчас %(addon_name)s, пожалуйста, "
-"<a href=\"%(addon_xpi)s\">нажмите здесь</a>."
-
-#: src/olympia/amo/tests/test_messages.py:57
-#: src/olympia/amo/tests/test_messages.py:58 src/olympia/reviews/forms.py:25
-#: src/olympia/reviews/forms.py:50
-#: src/olympia/reviews/templates/reviews/add.html:56
+#: src/olympia/amo/tests/test_messages.py:56 src/olympia/amo/tests/test_messages.py:57 src/olympia/reviews/forms.py:25 src/olympia/reviews/forms.py:50 src/olympia/reviews/templates/reviews/add.html:56
 #: src/olympia/reviews/templates/reviews/reply.html:30
 msgid "Title"
 msgstr "Заголовок"
 
-#: src/olympia/amo/tests/test_messages.py:57
-#: src/olympia/amo/tests/test_messages.py:58
+#: src/olympia/amo/tests/test_messages.py:56 src/olympia/amo/tests/test_messages.py:57
 msgid "Body"
 msgstr "Тело"
 
-#: src/olympia/amo/tests/test_messages.py:59
+#: src/olympia/amo/tests/test_messages.py:58
 msgid "Another Title"
 msgstr "Другой заголовок"
 
-#: src/olympia/amo/tests/test_messages.py:59
+#: src/olympia/amo/tests/test_messages.py:58
 msgid "Another Body"
 msgstr "Другое тело"
 
-#: src/olympia/api/views.py:255
-msgid "Not implemented yet."
-msgstr "Пока не реализовано."
+#: src/olympia/api/authentication.py:76
+msgid "Signature has expired."
+msgstr ""
 
-#: src/olympia/applications/views.py:39
-#: src/olympia/applications/templates/applications/appversions.html:3
+#: src/olympia/api/authentication.py:79
+msgid "Error decoding signature."
+msgstr ""
+
+#: src/olympia/api/authentication.py:82
+msgid "Invalid JWT Token."
+msgstr ""
+
+#: src/olympia/api/authentication.py:130
+msgid "Invalid Authorization header. No credentials provided."
+msgstr ""
+
+#: src/olympia/api/authentication.py:133
+msgid "Invalid Authorization header. Credentials string should not contain spaces."
+msgstr ""
+
+#: src/olympia/api/fields.py:29
+msgid "The field must have a length of at least {num} characters."
+msgstr ""
+
+#: src/olympia/api/fields.py:31
+msgid "The language code {lang_code} is invalid."
+msgstr ""
+
+#: src/olympia/applications/views.py:39 src/olympia/applications/templates/applications/appversions.html:3
 msgid "Application Versions"
 msgstr "Версии приложения"
 
@@ -2715,22 +2118,17 @@ msgid "Valid Application Versions"
 msgstr "Доступные версии приложений"
 
 #: src/olympia/applications/templates/applications/appversions.html:12
-msgid ""
-"Add-ons submitted to Mozilla Add-ons must have a manifest file with at least"
-" one of the below applications supported. Only the versions listed below are"
-" allowed for these applications."
+msgid "Add-ons submitted to Mozilla Add-ons must have a manifest file with at least one of the below applications supported. Only the versions listed below are allowed for these applications."
 msgstr ""
-"Дополнения, представляемые на сайт дополнений Mozilla, должны иметь файл "
-"манифеста с по крайней мере одним из поддерживаемых приложений. Для этих "
-"приложений разрешены только перечисленные ниже версии."
+"Дополнения, представляемые на сайт дополнений Mozilla, должны иметь файл манифеста с по крайней мере одним из поддерживаемых приложений. Для этих приложений разрешены только перечисленные ниже "
+"версии."
 
-#: src/olympia/applications/templates/applications/appversions.html:25
+#: src/olympia/applications/templates/applications/appversions.html:25 src/olympia/editors/helpers.py:361
 msgid "GUID"
 msgstr "GUID"
 
 #. {0} is an add-on name.
-#: src/olympia/applications/templates/applications/appversions.html:26
-#: src/olympia/versions/templates/versions/version_list.html:23
+#: src/olympia/applications/templates/applications/appversions.html:26 src/olympia/versions/templates/versions/version_list.html:23
 msgid "Versions"
 msgstr "Версии"
 
@@ -2740,14 +2138,8 @@ msgstr "http://developer.mozilla.org/en/docs/Install_Manifests"
 
 #: src/olympia/applications/templates/applications/appversions.html:31
 #, python-format
-msgid ""
-"If your supported application does not require a manifest file, you still "
-"must include one with the required properties as specified <a "
-"href=\"%(url)s\">here</a>."
-msgstr ""
-"Даже если поддерживаемое вами приложение не требует файл манифеста, вы всё "
-"же должны включить его с указанными <a href=\"%(url)s\">здесь</a> требуемыми"
-" свойствами."
+msgid "If your supported application does not require a manifest file, you still must include one with the required properties as specified <a href=\"%(url)s\">here</a>."
+msgstr "Даже если поддерживаемое вами приложение не требует файл манифеста, вы всё же должны включить его с указанными <a href=\"%(url)s\">здесь</a> требуемыми свойствами."
 
 #. L10n: {0} is 'Add-ons for <app>'.
 #: src/olympia/bandwagon/feeds.py:44
@@ -2755,13 +2147,9 @@ msgstr ""
 msgid "Collections :: %s"
 msgstr "Подборки :: %s"
 
-#: src/olympia/bandwagon/feeds.py:50
-#: src/olympia/bandwagon/templates/bandwagon/collection_detail.html:137
-msgid ""
-"Collections are groups of related add-ons that anyone can create and share."
-msgstr ""
-"Подборки представляют собой группы связанных дополнений. Любой может "
-"создавать и делиться подборками."
+#: src/olympia/bandwagon/feeds.py:50 src/olympia/bandwagon/templates/bandwagon/collection_detail.html:137
+msgid "Collections are groups of related add-ons that anyone can create and share."
+msgstr "Подборки представляют собой группы связанных дополнений. Любой может создавать и делиться подборками."
 
 #. L10n: {0} is a collection name, {1} is 'Add-ons for <app>'.
 #: src/olympia/bandwagon/feeds.py:70
@@ -2798,8 +2186,7 @@ msgstr "Значок"
 
 #: src/olympia/bandwagon/forms.py:143
 msgid "Please don't fill out this field, it's used to catch bots"
-msgstr ""
-"Пожалуйста, не заполняйте это поле, оно используется, чтобы ловить ботов"
+msgstr "Пожалуйста, не заполняйте это поле, оно используется, чтобы ловить ботов"
 
 #: src/olympia/bandwagon/forms.py:167
 msgid "This name cannot be used."
@@ -2817,8 +2204,7 @@ msgstr "Эта ссылка уже используется другой под�
 msgid "Icons must be either PNG or JPG."
 msgstr "Значки могут быть либо в PNG либо в JPG."
 
-#: src/olympia/bandwagon/forms.py:202 src/olympia/devhub/views.py:1067
-#: src/olympia/users/forms.py:476
+#: src/olympia/bandwagon/forms.py:202 src/olympia/devhub/views.py:1067 src/olympia/users/forms.py:476
 #, python-format
 msgid "Please use images smaller than %dMB."
 msgstr "Пожалуйста, используйте изображения менее %dМБ."
@@ -2839,8 +2225,7 @@ msgstr "Отозвать мой голос за эту подборку"
 msgid "Log in to vote for this collection"
 msgstr "Войти чтобы проголосовать за эту подборку"
 
-#: src/olympia/bandwagon/helpers.py:123
-#: src/olympia/bandwagon/templates/bandwagon/favorites_widget.html:2
+#: src/olympia/bandwagon/helpers.py:123 src/olympia/bandwagon/templates/bandwagon/favorites_widget.html:2
 msgid "Add to favorites"
 msgstr "Добавить в избранное"
 
@@ -2848,20 +2233,13 @@ msgstr "Добавить в избранное"
 msgid "Favorite"
 msgstr "Избранное"
 
-#: src/olympia/bandwagon/helpers.py:124
-#: src/olympia/bandwagon/templates/bandwagon/favorites_widget.html:2
+#: src/olympia/bandwagon/helpers.py:124 src/olympia/bandwagon/templates/bandwagon/favorites_widget.html:2
 msgid "Remove from favorites"
 msgstr "Удалить из избранного"
 
-#: src/olympia/bandwagon/views.py:98 src/olympia/bandwagon/views.py:191
-#: src/olympia/browse/views.py:58 src/olympia/browse/views.py:69
-#: src/olympia/browse/views.py:458 src/olympia/devhub/views.py:74
-#: src/olympia/devhub/views.py:82
-#: src/olympia/devhub/templates/devhub/addons/edit/basic.html:20
-#: src/olympia/editors/templates/editors/leaderboard.html:24
-#: src/olympia/editors/templates/editors/themes/queue_list.html:48
-#: src/olympia/search/forms.py:17 src/olympia/search/forms.py:89
-#: src/olympia/users/templates/users/vcard.html:5
+#: src/olympia/bandwagon/views.py:98 src/olympia/bandwagon/views.py:191 src/olympia/browse/views.py:58 src/olympia/browse/views.py:69 src/olympia/browse/views.py:425 src/olympia/devhub/views.py:72
+#: src/olympia/devhub/views.py:80 src/olympia/devhub/templates/devhub/addons/edit/basic.html:20 src/olympia/editors/templates/editors/leaderboard.html:24
+#: src/olympia/editors/templates/editors/themes/queue_list.html:48 src/olympia/search/forms.py:17 src/olympia/search/forms.py:89 src/olympia/users/templates/users/vcard.html:5
 msgid "Name"
 msgstr "Имя"
 
@@ -2869,8 +2247,7 @@ msgstr "Имя"
 msgid "Recently Popular"
 msgstr "Недавно популярные"
 
-#: src/olympia/bandwagon/views.py:189
-#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:18
+#: src/olympia/bandwagon/views.py:189 src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:16
 msgid "Added"
 msgstr "Добавлено"
 
@@ -2884,12 +2261,8 @@ msgstr "Подборка создана!"
 
 #: src/olympia/bandwagon/views.py:316
 #, python-format
-msgid ""
-"Your new collection is shown below. You can <ahref=\"%(url)s\">edit "
-"additional settings</a> if you'dlike."
+msgid "Your new collection is shown below. You can <a href=\"%(url)s\">edit additional settings</a> if you'd like."
 msgstr ""
-"Ваша новая подборка показана ниже. Если хотите, вы можете <a "
-"href=\"%(url)s\">изменить дополнительные настройки</a>."
 
 #: src/olympia/bandwagon/views.py:322
 msgid "Collection updated!"
@@ -2898,39 +2271,26 @@ msgstr "Подборка обновлена!"
 #: src/olympia/bandwagon/views.py:323
 #, python-format
 msgid "<a href=\"%(url)s\">View your collection</a> to see the changes."
-msgstr ""
-"<a href=\"%(url)s\">Просмотреть вашу подборку</a>, чтобы посмотреть "
-"изменения."
+msgstr "<a href=\"%(url)s\">Просмотреть вашу подборку</a>, чтобы посмотреть изменения."
 
 #: src/olympia/bandwagon/views.py:579
 msgid "Icon Deleted"
 msgstr "Значок удалён"
 
-#: src/olympia/bandwagon/templates/bandwagon/add.html:3
-#: src/olympia/bandwagon/templates/bandwagon/add.html:11
-#: src/olympia/bandwagon/templates/bandwagon/includes/collection_sidebar.html:26
+#: src/olympia/bandwagon/templates/bandwagon/add.html:3 src/olympia/bandwagon/templates/bandwagon/add.html:11 src/olympia/bandwagon/templates/bandwagon/includes/collection_sidebar.html:26
 msgid "Create a New Collection"
 msgstr "Создать новую коллекцию"
 
-#: src/olympia/bandwagon/templates/bandwagon/add.html:9
-#: src/olympia/devhub/templates/devhub/personas/submit.html:14
+#: src/olympia/bandwagon/templates/bandwagon/add.html:9 src/olympia/devhub/templates/devhub/personas/submit.html:14
 msgid "Create"
 msgstr "Создать"
 
-#: src/olympia/bandwagon/templates/bandwagon/add.html:24
-#: src/olympia/bandwagon/templates/bandwagon/ajax_new.html:28
+#: src/olympia/bandwagon/templates/bandwagon/add.html:24 src/olympia/bandwagon/templates/bandwagon/ajax_new.html:28
 #, python-format
-msgid ""
-"As noted in our <a href=\"%(legal)s\">Legal Notices</a>, individual "
-"collection arrangements are governed by the Creative Commons Attribution "
-"Share-Alike License"
-msgstr ""
-"Как отмечено в наших <a href=\"%(legal)s\">Правовых уведомлениях</a>, "
-"соглашения индивидуальных подборок регулируются лицензией Creative Commons "
-"Атрибуция — С сохранением условий"
+msgid "As noted in our <a href=\"%(legal)s\">Legal Notices</a>, individual collection arrangements are governed by the Creative Commons Attribution Share-Alike License"
+msgstr "Как отмечено в наших <a href=\"%(legal)s\">Правовых уведомлениях</a>, соглашения индивидуальных подборок регулируются лицензией Creative Commons Атрибуция — С сохранением условий"
 
-#: src/olympia/bandwagon/templates/bandwagon/add.html:33
-#: src/olympia/bandwagon/templates/bandwagon/ajax_new.html:38
+#: src/olympia/bandwagon/templates/bandwagon/add.html:33 src/olympia/bandwagon/templates/bandwagon/ajax_new.html:38
 msgid "Create Collection"
 msgstr "Создать подборку"
 
@@ -2946,8 +2306,7 @@ msgstr "Создать новую подборку..."
 msgid "Start a New Collection"
 msgstr "Создать новую подборку"
 
-#: src/olympia/bandwagon/templates/bandwagon/ajax_new.html:6
-#: src/olympia/bandwagon/templates/bandwagon/includes/addedit.html:7
+#: src/olympia/bandwagon/templates/bandwagon/ajax_new.html:6 src/olympia/bandwagon/templates/bandwagon/includes/addedit.html:7
 msgid "Name:"
 msgstr "Имя:"
 
@@ -2958,19 +2317,13 @@ msgstr "или <a id=\"collections-new-cancel\" href=\"#\">Отменить</a>"
 #. Link to remove a collection vote
 #: src/olympia/bandwagon/templates/bandwagon/barometer.html:15
 msgid "To rate collections, you must have an add-ons account."
-msgstr ""
-"Чтобы оценивать подборки, у вас должна иметься учетная запись на сайте "
-"дополнений."
+msgstr "Чтобы оценивать подборки, у вас должна иметься учетная запись на сайте дополнений."
 
-#: src/olympia/bandwagon/templates/bandwagon/barometer.html:18
-#: src/olympia/templates/base.html:145
-#: src/olympia/templates/impala/base.html:198
+#: src/olympia/bandwagon/templates/bandwagon/barometer.html:18 src/olympia/templates/base.html:145 src/olympia/templates/impala/base.html:198
 msgid "Create an Add-ons Account"
 msgstr "Создать учётную запись дополнения"
 
-#: src/olympia/bandwagon/templates/bandwagon/barometer.html:21
-#: src/olympia/templates/base.html:148
-#: src/olympia/templates/impala/base.html:201
+#: src/olympia/bandwagon/templates/bandwagon/barometer.html:21 src/olympia/templates/base.html:148 src/olympia/templates/impala/base.html:201
 #, python-format
 msgid "or <a href=\"%(login)s\">log in to your current account</a>"
 msgstr "или <a href=\"%(login)s\">войдите в свою учётную запись</a>"
@@ -2983,14 +2336,12 @@ msgstr "{0} :: Подборки"
 msgid "private"
 msgstr "приватный"
 
-#: src/olympia/bandwagon/templates/bandwagon/collection_detail.html:45
-#: src/olympia/bandwagon/templates/bandwagon/mobile/listing_items.html:9
+#: src/olympia/bandwagon/templates/bandwagon/collection_detail.html:45 src/olympia/bandwagon/templates/bandwagon/mobile/listing_items.html:9
 #, python-format
 msgid "<span>%(num)s</span> follower"
 msgid_plural "<span>%(num)s</span> followers"
 msgstr[0] "<span>%(num)s</span> последователь"
 msgstr[1] "<span>%(num)s</span> последователя"
-msgstr[2] "<span>%(num)s</span> последователей"
 
 #: src/olympia/bandwagon/templates/bandwagon/collection_detail.html:54
 msgid "About this Collection"
@@ -3020,8 +2371,7 @@ msgstr "Другие настройки:"
 msgid "Edit Collection"
 msgstr "Редактировать подборку"
 
-#: src/olympia/bandwagon/templates/bandwagon/collection_detail.html:88
-#: src/olympia/bandwagon/templates/bandwagon/includes/delete.html:3
+#: src/olympia/bandwagon/templates/bandwagon/collection_detail.html:88 src/olympia/bandwagon/templates/bandwagon/includes/delete.html:3
 msgid "Delete Collection"
 msgstr "Удалить подборку"
 
@@ -3031,7 +2381,6 @@ msgid "%(num)s Theme in this Collection"
 msgid_plural "%(num)s Themes in this Collection"
 msgstr[0] "%(num)s тема в этой подборке"
 msgstr[1] "%(num)s темы в этой подборке"
-msgstr[2] "%(num)s тем в этой подборке"
 
 #: src/olympia/bandwagon/templates/bandwagon/collection_detail.html:111
 #, python-format
@@ -3039,14 +2388,9 @@ msgid "%(num)s Add-on in this Collection"
 msgid_plural "%(num)s Add-ons in this Collection"
 msgstr[0] "%(num)s дополнение в этой подборке"
 msgstr[1] "%(num)s дополнения в этой подборке"
-msgstr[2] "%(num)s дополнений в этой подборке"
 
-#: src/olympia/bandwagon/templates/bandwagon/collection_detail.html:125
-#: src/olympia/compat/templates/compat/index.html:25
-#: src/olympia/compat/templates/compat/reporter_detail.html:29
-#: src/olympia/files/templates/files/viewer.html:29
-#: src/olympia/templates/amo_footer.html:17
-#: src/olympia/templates/includes/lang_switcher.html:10
+#: src/olympia/bandwagon/templates/bandwagon/collection_detail.html:125 src/olympia/compat/templates/compat/reporter_detail.html:29 src/olympia/files/templates/files/viewer.html:29
+#: src/olympia/templates/amo_footer.html:17 src/olympia/templates/includes/lang_switcher.html:10
 msgid "Go"
 msgstr "Перейти"
 
@@ -3072,28 +2416,17 @@ msgstr "Посмотрите все подборки от этого польз�
 
 #: src/olympia/bandwagon/templates/bandwagon/collection_detail.html:179
 msgid ""
-"Add-ons that you mark as favorites using the <b>Add to Favorites</b> feature"
-" appear below. This collection is currently <b>public</b>, which means "
-"everyone can see it. If you would like to hide it from public view, click "
-"the button below to make it private."
+"Add-ons that you mark as favorites using the <b>Add to Favorites</b> feature appear below. This collection is currently <b>public</b>, which means everyone can see it. If you would like to hide it "
+"from public view, click the button below to make it private."
 msgstr ""
-"Дополнения, которые вы отметите как избранные используя функцию <b>Добавить "
-"в Избранное</b>, появятся в расположенном ниже поле. Эта подборка в "
-"настоящее время является <b>публичной</b>, что означает, что любой может её "
-"увидеть. Если вы хотите скрыть её от публичного просмотра, нажмите "
-"расположенную ниже кнопку, чтобы сделать её приватной."
+"Дополнения, которые вы отметите как избранные используя функцию <b>Добавить в Избранное</b>, появятся в расположенном ниже поле. Эта подборка в настоящее время является <b>публичной</b>, что "
+"означает, что любой может её увидеть. Если вы хотите скрыть её от публичного просмотра, нажмите расположенную ниже кнопку, чтобы сделать её приватной."
 
 #: src/olympia/bandwagon/templates/bandwagon/collection_detail.html:186
 msgid ""
-"Add-ons that you mark as favorites using the <b>Add to Favorites</b> feature"
-" appear below. This collection is currently <b>private</b>, which means only"
-" you can see it.  If you would like everyone to be able to see your "
-"favorites, click the button below to make it public."
+"Add-ons that you mark as favorites using the <b>Add to Favorites</b> feature appear below. This collection is currently <b>private</b>, which means only you can see it.  If you would like everyone "
+"to be able to see your favorites, click the button below to make it public."
 msgstr ""
-"Дополнения, которые вы отметите как любимые, используя <b>Добавить в "
-"избранное</b>, появятся ниже. Эта подборка сейчас является <b>приватной</b>,"
-" что значит, что только вы можете её видеть. Если вы хотите, чтобы все могли"
-" видеть, что вы добавили в избранное, нажмите на кнопку ниже."
 
 #: src/olympia/bandwagon/templates/bandwagon/collection_detail.html:196
 msgid "My favorite add-ons"
@@ -3105,7 +2438,6 @@ msgid "<span>%(addons)s</span> add-on"
 msgid_plural "<span>%(addons)s</span> add-ons"
 msgstr[0] "<span>%(addons)s</span> дополнение"
 msgstr[1] "<span>%(addons)s</span> дополнения"
-msgstr[2] "<span>%(addons)s</span> дополнений"
 
 #: src/olympia/bandwagon/templates/bandwagon/collection_grid.html:32
 #, python-format
@@ -3113,23 +2445,19 @@ msgid "<span>%(followers)s</span> follower"
 msgid_plural "<span>%(followers)s</span> followers"
 msgstr[0] "<span>%(followers)s</span> последователь"
 msgstr[1] "<span>%(followers)s</span> последователя"
-msgstr[2] "<span>%(followers)s</span> последователей"
 
-#. People "follow" collections to get notified of updates.
-#. Like
+#. People "follow" collections to get notified of updates.                    Like
 #. Twitter followers.
+#. People "follow" collections to get notified of updates.
 #. Like Twitter followers.
-#: src/olympia/bandwagon/templates/bandwagon/collection_listing_items.html:10
-#: src/olympia/bandwagon/templates/bandwagon/impala/collection_listing_items.html:18
+#: src/olympia/bandwagon/templates/bandwagon/collection_listing_items.html:10 src/olympia/bandwagon/templates/bandwagon/impala/collection_listing_items.html:18
 #, python-format
 msgid "%(num)s weekly follower"
 msgid_plural "%(num)s weekly followers"
 msgstr[0] "%(num)s еженедельный последователь"
 msgstr[1] "%(num)s еженедельных последователя"
-msgstr[2] "%(num)s еженедельных последователей"
 
-#. People "follow" collections to get notified of updates.
-#. Like
+#. People "follow" collections to get notified of updates.                    Like
 #. Twitter followers.
 #: src/olympia/bandwagon/templates/bandwagon/collection_listing_items.html:18
 #, python-format
@@ -3137,35 +2465,29 @@ msgid "%(num)s monthly follower"
 msgid_plural "%(num)s monthly followers"
 msgstr[0] "%(num)s ежемесячный читатель"
 msgstr[1] "%(num)s ежемесячных читателя"
-msgstr[2] "%(num)s ежемесячных читателей"
 
-#. People "follow" collections to get notified of updates.
-#. Like
+#. People "follow" collections to get notified of updates.                    Like
 #. Twitter followers.
+#. People "follow" collections to get notified of updates.
 #. Like Twitter followers.
-#: src/olympia/bandwagon/templates/bandwagon/collection_listing_items.html:26
-#: src/olympia/bandwagon/templates/bandwagon/impala/collection_listing_items.html:26
+#: src/olympia/bandwagon/templates/bandwagon/collection_listing_items.html:26 src/olympia/bandwagon/templates/bandwagon/impala/collection_listing_items.html:26
 #, python-format
 msgid "%(num)s follower"
 msgid_plural "%(num)s followers"
 msgstr[0] "%(num)s последователь"
 msgstr[1] "%(num)s последователя"
-msgstr[2] "%(num)s последователей"
 
-#: src/olympia/bandwagon/templates/bandwagon/collection_listing_items.html:56
-#: src/olympia/bandwagon/templates/bandwagon/impala/collection_listing_items.html:9
+#: src/olympia/bandwagon/templates/bandwagon/collection_listing_items.html:56 src/olympia/bandwagon/templates/bandwagon/impala/collection_listing_items.html:9
 #: src/olympia/devhub/templates/devhub/personas/edit.html:27
 msgid "by {0}"
 msgstr "от {0}"
 
-#: src/olympia/bandwagon/templates/bandwagon/collection_widgets.html:5
-#: src/olympia/bandwagon/templates/bandwagon/collection_widgets.html:7
+#: src/olympia/bandwagon/templates/bandwagon/collection_widgets.html:5 src/olympia/bandwagon/templates/bandwagon/collection_widgets.html:7
 #: src/olympia/bandwagon/templates/bandwagon/impala/collection_listing_items.html:53
 msgid "Stop Following"
 msgstr "Перестать следовать"
 
-#: src/olympia/bandwagon/templates/bandwagon/collection_widgets.html:6
-#: src/olympia/bandwagon/templates/bandwagon/collection_widgets.html:7
+#: src/olympia/bandwagon/templates/bandwagon/collection_widgets.html:6 src/olympia/bandwagon/templates/bandwagon/collection_widgets.html:7
 #: src/olympia/bandwagon/templates/bandwagon/impala/collection_listing_items.html:53
 msgid "Follow this Collection"
 msgstr "Следовать за этой подборкой"
@@ -3175,16 +2497,12 @@ msgid "Edit this Collection"
 msgstr "Редактировать эту подборку"
 
 #. %s is the name of the collection.
-#: src/olympia/bandwagon/templates/bandwagon/delete.html:4
-#: src/olympia/bandwagon/templates/bandwagon/delete.html:15
+#: src/olympia/bandwagon/templates/bandwagon/delete.html:4 src/olympia/bandwagon/templates/bandwagon/delete.html:15
 msgid "Delete {0}"
 msgstr "Удалить {0}"
 
-#: src/olympia/bandwagon/templates/bandwagon/delete.html:13
-#: src/olympia/devhub/templates/devhub/addons/listing/item_actions.html:14
-#: src/olympia/devhub/templates/devhub/addons/listing/item_actions_theme.html:28
-#: src/olympia/devhub/templates/devhub/versions/list.html:131
-#: src/olympia/devhub/templates/devhub/versions/list.html:149
+#: src/olympia/bandwagon/templates/bandwagon/delete.html:13 src/olympia/devhub/templates/devhub/addons/listing/item_actions.html:14
+#: src/olympia/devhub/templates/devhub/addons/listing/item_actions_theme.html:28 src/olympia/devhub/templates/devhub/versions/list.html:131 src/olympia/devhub/templates/devhub/versions/list.html:149
 #: src/olympia/devhub/templates/devhub/versions/list.html:166
 msgid "Delete"
 msgstr "Удалить"
@@ -3193,35 +2511,24 @@ msgstr "Удалить"
 msgid "Are you sure?"
 msgstr "Вы уверены?"
 
-#: src/olympia/bandwagon/templates/bandwagon/delete.html:21
-#: src/olympia/devhub/templates/devhub/personas/edit.html:131
-#: src/olympia/devhub/templates/devhub/personas/edit.html:152
-#: src/olympia/devhub/templates/devhub/personas/edit.html:173
-#: src/olympia/devhub/templates/devhub/personas/submit.html:77
-#: src/olympia/devhub/templates/devhub/personas/submit.html:98
+#: src/olympia/bandwagon/templates/bandwagon/delete.html:21 src/olympia/devhub/templates/devhub/personas/edit.html:131 src/olympia/devhub/templates/devhub/personas/edit.html:152
+#: src/olympia/devhub/templates/devhub/personas/edit.html:173 src/olympia/devhub/templates/devhub/personas/submit.html:77 src/olympia/devhub/templates/devhub/personas/submit.html:98
 #: src/olympia/devhub/templates/devhub/personas/submit.html:119
 msgid "Yes"
 msgstr "Да"
 
-#: src/olympia/bandwagon/templates/bandwagon/delete.html:22
-#: src/olympia/devhub/templates/devhub/personas/edit.html:140
-#: src/olympia/devhub/templates/devhub/personas/edit.html:161
-#: src/olympia/devhub/templates/devhub/personas/edit.html:191
-#: src/olympia/devhub/templates/devhub/personas/submit.html:86
-#: src/olympia/devhub/templates/devhub/personas/submit.html:107
+#: src/olympia/bandwagon/templates/bandwagon/delete.html:22 src/olympia/devhub/templates/devhub/personas/edit.html:140 src/olympia/devhub/templates/devhub/personas/edit.html:161
+#: src/olympia/devhub/templates/devhub/personas/edit.html:191 src/olympia/devhub/templates/devhub/personas/submit.html:86 src/olympia/devhub/templates/devhub/personas/submit.html:107
 #: src/olympia/devhub/templates/devhub/personas/submit.html:137
 msgid "No"
 msgstr "Нет"
 
 #. {0} is the name of the collection.
-#: src/olympia/bandwagon/templates/bandwagon/edit.html:5
-#: src/olympia/bandwagon/templates/bandwagon/edit.html:21
+#: src/olympia/bandwagon/templates/bandwagon/edit.html:5 src/olympia/bandwagon/templates/bandwagon/edit.html:21
 msgid "Edit {0}"
 msgstr "Редактировать {0}"
 
-#: src/olympia/bandwagon/templates/bandwagon/edit.html:29
-#: src/olympia/devhub/templates/devhub/addons/edit/details.html:20
-#: src/olympia/editors/templates/editors/themes/themes.html:62
+#: src/olympia/bandwagon/templates/bandwagon/edit.html:29 src/olympia/devhub/templates/devhub/addons/edit/details.html:20 src/olympia/editors/templates/editors/themes/themes.html:62
 msgid "Description"
 msgstr "Описание"
 
@@ -3229,32 +2536,18 @@ msgstr "Описание"
 msgid "Contributors & More"
 msgstr "Помощники и другое"
 
-#: src/olympia/bandwagon/templates/bandwagon/edit.html:54
-#: src/olympia/bandwagon/templates/bandwagon/edit.html:67
-#: src/olympia/bandwagon/templates/bandwagon/edit.html:82
-#: src/olympia/devhub/templates/devhub/addons/ajax_compat_update.html:35
-#: src/olympia/devhub/templates/devhub/addons/owner.html:59
-#: src/olympia/devhub/templates/devhub/addons/profile.html:42
-#: src/olympia/devhub/templates/devhub/addons/edit/admin.html:101
-#: src/olympia/devhub/templates/devhub/addons/edit/basic.html:152
-#: src/olympia/devhub/templates/devhub/addons/edit/details.html:85
-#: src/olympia/devhub/templates/devhub/addons/edit/support.html:67
-#: src/olympia/devhub/templates/devhub/addons/edit/technical.html:166
-#: src/olympia/devhub/templates/devhub/addons/forms_shared/media.html:149
-#: src/olympia/devhub/templates/devhub/payments/voluntary.html:64
-#: src/olympia/devhub/templates/devhub/personas/edit.html:35
-#: src/olympia/devhub/templates/devhub/personas/edit.html:304
-#: src/olympia/devhub/templates/devhub/versions/edit.html:139
-#: src/olympia/translations/templates/translations/trans-menu.html:48
+#: src/olympia/bandwagon/templates/bandwagon/edit.html:54 src/olympia/bandwagon/templates/bandwagon/edit.html:67 src/olympia/bandwagon/templates/bandwagon/edit.html:82
+#: src/olympia/devhub/templates/devhub/addons/ajax_compat_update.html:35 src/olympia/devhub/templates/devhub/addons/owner.html:59 src/olympia/devhub/templates/devhub/addons/profile.html:42
+#: src/olympia/devhub/templates/devhub/addons/edit/admin.html:101 src/olympia/devhub/templates/devhub/addons/edit/basic.html:152 src/olympia/devhub/templates/devhub/addons/edit/details.html:85
+#: src/olympia/devhub/templates/devhub/addons/edit/support.html:67 src/olympia/devhub/templates/devhub/addons/edit/technical.html:166
+#: src/olympia/devhub/templates/devhub/addons/forms_shared/media.html:149 src/olympia/devhub/templates/devhub/payments/voluntary.html:64 src/olympia/devhub/templates/devhub/personas/edit.html:35
+#: src/olympia/devhub/templates/devhub/personas/edit.html:304 src/olympia/devhub/templates/devhub/versions/edit.html:139 src/olympia/translations/templates/translations/trans-menu.html:48
 msgid "Save Changes"
 msgstr "Сохранить изменения"
 
 # <option> text in a <select> for Author role in an add-on.
-#: src/olympia/bandwagon/templates/bandwagon/edit_contributors.html:9
-#: src/olympia/bandwagon/templates/bandwagon/edit_contributors.html:12
-#: src/olympia/bandwagon/templates/bandwagon/edit_contributors.html:17
-#: src/olympia/bandwagon/templates/bandwagon/edit_contributors.html:58
-#: src/olympia/constants/base.py:134
+#: src/olympia/bandwagon/templates/bandwagon/edit_contributors.html:9 src/olympia/bandwagon/templates/bandwagon/edit_contributors.html:12
+#: src/olympia/bandwagon/templates/bandwagon/edit_contributors.html:17 src/olympia/bandwagon/templates/bandwagon/edit_contributors.html:58 src/olympia/constants/base.py:134
 msgid "Owner"
 msgstr "Владелец"
 
@@ -3266,10 +2559,8 @@ msgstr "Сделать владельцем"
 msgid "Remove this user as a contributor"
 msgstr "Удалить этого пользователя как помощника"
 
-#: src/olympia/bandwagon/templates/bandwagon/edit_contributors.html:18
-#: src/olympia/bandwagon/templates/bandwagon/edit_contributors.html:43
-#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:20
-#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:48
+#: src/olympia/bandwagon/templates/bandwagon/edit_contributors.html:18 src/olympia/bandwagon/templates/bandwagon/edit_contributors.html:43
+#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:18 src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:46
 #: src/olympia/devhub/templates/devhub/addons/ajax_compat_update.html:19
 msgid "Remove"
 msgstr "Удалить"
@@ -3280,24 +2571,15 @@ msgstr "Помощники в создании подборки"
 
 #: src/olympia/bandwagon/templates/bandwagon/edit_contributors.html:26
 msgid ""
-"You can add multiple contributors to this collection.  A contributor can add"
-" and remove add-ons from this collection, but cannot change its name or "
-"description.  To add a contributor, enter their email in the box below. "
-"Contributors must have a Mozilla Add-ons account."
+"You can add multiple contributors to this collection.  A contributor can add and remove add-ons from this collection, but cannot change its name or description.  To add a contributor, enter their "
+"email in the box below. Contributors must have a Mozilla Add-ons account."
 msgstr ""
-"Вы можете добавить несколько участников в эту подборку.  Участник может "
-"добавлять и удалять дополнения из подборки, но не может изменять их имена и "
-"описания.  Чтобы добавить участника, введите его адрес электронной почты в "
-"поле ниже. У участников должен быть учётная запись на сайте дополнений "
-"Mozilla."
 
 #: src/olympia/bandwagon/templates/bandwagon/edit_contributors.html:40
 msgid "User"
 msgstr "Пользователь"
 
-#: src/olympia/bandwagon/templates/bandwagon/edit_contributors.html:41
-#: src/olympia/devhub/templates/devhub/addons/edit/support.html:20
-#: src/olympia/users/templates/users/delete.html:49
+#: src/olympia/bandwagon/templates/bandwagon/edit_contributors.html:41 src/olympia/devhub/templates/devhub/addons/edit/support.html:20 src/olympia/users/templates/users/delete.html:49
 msgid "Email"
 msgstr "Адрес эл. почты"
 
@@ -3323,27 +2605,14 @@ msgid "Admin Settings"
 msgstr "Настройки администратора"
 
 #: src/olympia/bandwagon/templates/bandwagon/edit_contributors.html:76
-msgid ""
-"<b>Warning:</b> By changing the owner of this collection, you will no longer"
-" be able to edit it. You will only be able to add and remove add-ons from "
-"it."
-msgstr ""
-"<b>Внимание:</b> При изменении владельца этой подборки, вы больше не сможете"
-" её редактировать. Вы сможете только добавлять и удалять из неё дополнения."
+msgid "<b>Warning:</b> By changing the owner of this collection, you will no longer be able to edit it. You will only be able to add and remove add-ons from it."
+msgstr "<b>Внимание:</b> При изменении владельца этой подборки, вы больше не сможете её редактировать. Вы сможете только добавлять и удалять из неё дополнения."
 
-#: src/olympia/bandwagon/templates/bandwagon/edit_contributors.html:83
-#: src/olympia/devhub/templates/devhub/addons/forms_shared/media.html:157
-#: src/olympia/devhub/templates/devhub/addons/submit/describe.html:69
-#: src/olympia/devhub/templates/devhub/addons/submit/license.html:60
-#: src/olympia/devhub/templates/devhub/addons/submit/upload.html:78
-#: src/olympia/devhub/templates/devhub/payments/tier.html:17
-#: src/olympia/editors/templates/editors/themes/themes.html:111
-#: src/olympia/editors/templates/editors/themes/themes.html:128
-#: src/olympia/editors/templates/editors/themes/themes.html:134
-#: src/olympia/editors/templates/editors/themes/themes.html:141
-#: src/olympia/users/templates/users/fxa_migration_prompt_content.html:10
-#: src/olympia/users/templates/users/login_form.html:42
-#: src/olympia/users/templates/users/mobile/login.html:57
+#: src/olympia/bandwagon/templates/bandwagon/edit_contributors.html:83 src/olympia/devhub/templates/devhub/addons/forms_shared/media.html:157
+#: src/olympia/devhub/templates/devhub/addons/submit/describe.html:69 src/olympia/devhub/templates/devhub/addons/submit/license.html:60 src/olympia/devhub/templates/devhub/addons/submit/upload.html:70
+#: src/olympia/devhub/templates/devhub/payments/tier.html:17 src/olympia/editors/templates/editors/themes/themes.html:111 src/olympia/editors/templates/editors/themes/themes.html:128
+#: src/olympia/editors/templates/editors/themes/themes.html:134 src/olympia/editors/templates/editors/themes/themes.html:141 src/olympia/users/templates/users/fxa_migration_prompt_content.html:10
+#: src/olympia/users/templates/users/login_form.html:42 src/olympia/users/templates/users/mobile/login.html:57
 msgid "Continue"
 msgstr "Продолжить"
 
@@ -3382,18 +2651,12 @@ msgstr "Недавно популярные подборки"
 
 #: src/olympia/bandwagon/templates/bandwagon/impala/collection_listing.html:28
 #, python-format
-msgid ""
-"Collections are groups of related add-ons that anyone can create and share. "
-"Explore collections created by other users or <a href=\"%(url)s\">create "
-"your own</a>."
+msgid "Collections are groups of related add-ons that anyone can create and share. Explore collections created by other users or <a href=\"%(url)s\">create your own</a>."
 msgstr ""
-"Подборки это группы связанных дополнений, которые каждый может создавать и "
-"делить с другими. Откройте для себя подборки, созданные другими "
-"пользователями, или <a href=\"%(url)s\">создайте собственную</a>."
+"Подборки это группы связанных дополнений, которые каждый может создавать и делить с другими. Откройте для себя подборки, созданные другими пользователями, или <a href=\"%(url)s\">создайте "
+"собственную</a>."
 
-#: src/olympia/bandwagon/templates/bandwagon/impala/collection_listing.html:37
-#: src/olympia/browse/templates/browse/extensions.html:13
-#: src/olympia/browse/templates/browse/themes.html:14
+#: src/olympia/bandwagon/templates/bandwagon/impala/collection_listing.html:37 src/olympia/browse/templates/browse/extensions.html:13 src/olympia/browse/templates/browse/themes.html:14
 msgid "Subscribe"
 msgstr "Подписаться"
 
@@ -3401,20 +2664,14 @@ msgstr "Подписаться"
 msgid "Following"
 msgstr "Следую"
 
-#: src/olympia/bandwagon/templates/bandwagon/impala/collection_sidebar.html:22
-#: src/olympia/bandwagon/templates/bandwagon/impala/collection_sidebar.html:28
+#: src/olympia/bandwagon/templates/bandwagon/impala/collection_sidebar.html:22 src/olympia/bandwagon/templates/bandwagon/impala/collection_sidebar.html:28
 #: src/olympia/bandwagon/templates/bandwagon/includes/collection_sidebar.html:32
 msgid "Create a Collection"
 msgstr "Создать подборку"
 
-#: src/olympia/bandwagon/templates/bandwagon/impala/collection_sidebar.html:23
-#: src/olympia/bandwagon/templates/bandwagon/includes/collection_sidebar.html:27
-msgid ""
-"Collections make it easy to keep track of favorite add-ons and share your "
-"perfectly customized browser with others."
-msgstr ""
-"Подборки позволяют легко отслеживать любимые дополнения и поделиться с "
-"другими вашим прекрасно настроенным браузером."
+#: src/olympia/bandwagon/templates/bandwagon/impala/collection_sidebar.html:23 src/olympia/bandwagon/templates/bandwagon/includes/collection_sidebar.html:27
+msgid "Collections make it easy to keep track of favorite add-ons and share your perfectly customized browser with others."
+msgstr "Подборки позволяют легко отслеживать любимые дополнения и поделиться с другими вашим прекрасно настроенным браузером."
 
 #: src/olympia/bandwagon/templates/bandwagon/includes/addedit.html:42
 msgid "Collection Icon"
@@ -3426,50 +2683,42 @@ msgstr "Сбросить"
 
 #: src/olympia/bandwagon/templates/bandwagon/includes/addedit.html:53
 msgid "PNG and JPG supported.  Image will be resized to 32x32."
-msgstr "Поддерживаются PNG и JPG. Изображения должны быть размером 32x32."
+msgstr ""
 
 #: src/olympia/bandwagon/templates/bandwagon/includes/addedit_errors.html:3
 msgid "There are errors in this form.  Please correct them below."
-msgstr "В этой форме есть ошибки.  Пожалуйста, исправьте их."
+msgstr ""
 
 #: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:2
 msgid "Add-ons in Your Collection"
 msgstr "Дополнения в вашей подборке"
 
 #: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:4
-msgid ""
-"To include an add-on in this collection, enter its name in the box below and"
-" hit enter.  You can also use the <strong>Add to Collection</strong> links "
-"throughout the site to include add-ons later."
+msgid "To include an add-on in this collection, enter its name in the box below and hit enter."
 msgstr ""
-"Чтобы добавить дополнение в подборку введите её имя в поле ниже и нажмите "
-"enter.  Также вы можете использовать ссылки <strong>Добавить в "
-"подборку</strong> на сайте, чтобы добавить дополнения позже."
 
-#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:17
-#: src/olympia/constants/base.py:400
-#: src/olympia/devhub/templates/devhub/addons/activity.html:62
+#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:15 src/olympia/constants/base.py:400 src/olympia/devhub/templates/devhub/addons/activity.html:62
+#: src/olympia/editors/helpers.py:273 src/olympia/editors/helpers.py:360
 msgid "Add-on"
 msgstr "Дополнение"
 
-#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:26
+#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:24
 msgid "Enter the name of the add-on to include"
 msgstr "Введите имя включаемого дополнения"
 
-#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:28
+#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:26
 msgid "Add to Collection"
 msgstr "Добавить в подборку"
 
-#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:45
-#: src/olympia/editors/helpers.py:936 src/olympia/editors/helpers.py:956
+#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:43 src/olympia/editors/helpers.py:1016 src/olympia/editors/helpers.py:1036
 msgid "Pending"
 msgstr "В ожидании"
 
-#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:47
+#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:45
 msgid "Add a comment"
 msgstr "Добавить комментарий"
 
-#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:48
+#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:46
 msgid "Remove this add-on from the collection"
 msgstr "Удалить это дополнение из подборки"
 
@@ -3481,14 +2730,11 @@ msgstr "ПОДБОРКИ"
 msgid "Groups of related add-ons that anyone can create."
 msgstr "Группы родственных дополнений, которые может создавать любой."
 
-#: src/olympia/blocklist/templates/blocklist/blocked_detail.html:3
-#: src/olympia/blocklist/templates/blocklist/blocked_list.html:3
-#: src/olympia/blocklist/templates/blocklist/blocked_list.html:10
+#: src/olympia/blocklist/templates/blocklist/blocked_detail.html:3 src/olympia/blocklist/templates/blocklist/blocked_list.html:3 src/olympia/blocklist/templates/blocklist/blocked_list.html:10
 msgid "Blocked Add-ons"
 msgstr "Заблокированные дополнения"
 
-#: src/olympia/blocklist/templates/blocklist/blocked_detail.html:8
-#: src/olympia/blocklist/templates/blocklist/blocked_list.html:6
+#: src/olympia/blocklist/templates/blocklist/blocked_detail.html:8 src/olympia/blocklist/templates/blocklist/blocked_list.html:6
 msgid "Blocklist"
 msgstr "Чёрный список"
 
@@ -3510,44 +2756,24 @@ msgid "What does this mean?"
 msgstr "Что это значит?"
 
 #: src/olympia/blocklist/templates/blocklist/blocked_detail.html:22
-msgid ""
-"Users are strongly encouraged to disable the problematic add-on or plugin, "
-"but may choose to continue using it if they accept the risks described."
-msgstr ""
-"Пользователям настоятельно рекомендуется отключить вызывающее проблемы "
-"дополнение или плагин. Они могут продолжать использовать его, если они "
-"принимают на себя описанный здесь риск."
+msgid "Users are strongly encouraged to disable the problematic add-on or plugin, but may choose to continue using it if they accept the risks described."
+msgstr "Пользователям настоятельно рекомендуется отключить вызывающее проблемы дополнение или плагин. Они могут продолжать использовать его, если они принимают на себя описанный здесь риск."
 
 #: src/olympia/blocklist/templates/blocklist/blocked_detail.html:27
-msgid ""
-"The problematic add-on or plugin will be automatically disabled and no "
-"longer usable."
-msgstr ""
-"Вызывающее проблемы дополнение или плагин будет автоматически отключено и "
-"больше не может быть использовано."
+msgid "The problematic add-on or plugin will be automatically disabled and no longer usable."
+msgstr "Вызывающее проблемы дополнение или плагин будет автоматически отключено и больше не может быть использовано."
 
 #: src/olympia/blocklist/templates/blocklist/blocked_detail.html:33
 #, python-format
 msgid ""
-"When Mozilla becomes aware of add-ons, plugins, or other third-party "
-"software that seriously compromises %(app)s security, stability, or "
-"performance and meets <a href=\"%(criteria)s\">certain criteria</a>, the "
-"software may be blocked from general use.  For more information, please read"
-" <a href=\"%(support)s\">this support article</a>."
+"When Mozilla becomes aware of add-ons, plugins, or other third-party software that seriously compromises %(app)s security, stability, or performance and meets <a href=\"%(criteria)s\">certain "
+"criteria</a>, the software may be blocked from general use.  For more information, please read <a href=\"%(support)s\">this support article</a>."
 msgstr ""
-"Когда Mozilla становится известно о дополнениях, плагинах или другом ПО "
-"сторонних производителей, серьезно компрометирующем безопасность, "
-"стабильность или производительность %(app)s и соответствующему <a "
-"href=\"%(criteria)s\">определенным критериям</a>, то такое программное "
-"обеспечение может быть заблокировано.  Для дополнительной информации, "
-"пожалуйста, прочитайте <a href=\"%(support)s\">эту статью в поддержке</a>."
 
 #: src/olympia/blocklist/templates/blocklist/blocked_detail.html:44
 #, python-format
 msgid "Blocked on %(date)s. <a href=\"%(link)s\">View block request</a>."
-msgstr ""
-"Заблокировано %(date)s. <a href=\"%(link)s\">Посмотреть запрос на "
-"блокировку</a>."
+msgstr "Заблокировано %(date)s. <a href=\"%(link)s\">Посмотреть запрос на блокировку</a>."
 
 #: src/olympia/blocklist/templates/blocklist/blocked_detail.html:48
 #, python-format
@@ -3555,12 +2781,8 @@ msgid "Blocked on %(date)s."
 msgstr "Заблокировано %(date)s."
 
 #: src/olympia/blocklist/templates/blocklist/blocked_list.html:11
-msgid ""
-"The following software is known to cause serious security, stability, or "
-"performance issues with {app}."
-msgstr ""
-"Известно, что следующие программы вызывают серьезные проблемы с "
-"безопасностью, стабильностью или производительностью {app}."
+msgid "The following software is known to cause serious security, stability, or performance issues with {app}."
+msgstr "Известно, что следующие программы вызывают серьезные проблемы с безопасностью, стабильностью или производительностью {app}."
 
 #. L10n: %s is a category name.
 #: src/olympia/browse/feeds.py:76 src/olympia/browse/feeds.py:98
@@ -3582,11 +2804,8 @@ msgstr "Избранные Дополнения :: %s"
 #. L10n: %s is an app name.
 #: src/olympia/browse/feeds.py:138
 #, python-format
-msgid ""
-"Here's a few of our favorite add-ons to help you get started customizing %s."
-msgstr ""
-"Вот несколько из наших любимых дополнений, которые помогут вам начать "
-"настраивать %s."
+msgid "Here's a few of our favorite add-ons to help you get started customizing %s."
+msgstr "Вот несколько из наших любимых дополнений, которые помогут вам начать настраивать %s."
 
 #. L10n: %s is a category name.
 #: src/olympia/browse/feeds.py:157
@@ -3602,43 +2821,28 @@ msgstr "Инструменты поиска и связанные с поиск�
 msgid "Search tools"
 msgstr "Инструменты поиска"
 
-#: src/olympia/browse/views.py:55 src/olympia/browse/views.py:65
-#: src/olympia/search/forms.py:85
+#: src/olympia/browse/views.py:55 src/olympia/browse/views.py:65 src/olympia/search/forms.py:85
 msgid "Most Users"
 msgstr "Число пользователей"
 
-#: src/olympia/browse/views.py:61 src/olympia/browse/views.py:72
-#: src/olympia/browse/views.py:279
-#: src/olympia/browse/templates/browse/personas/mobile/category_landing.html:63
-#: src/olympia/discovery/templates/discovery/pane.html:67
-#: src/olympia/search/forms.py:92
+#: src/olympia/browse/views.py:61 src/olympia/browse/views.py:72 src/olympia/browse/views.py:246 src/olympia/browse/templates/browse/personas/mobile/category_landing.html:63
+#: src/olympia/discovery/templates/discovery/pane.html:67 src/olympia/search/forms.py:92
 msgid "Up & Coming"
 msgstr "Набирающие популярность"
 
-#: src/olympia/browse/views.py:460 src/olympia/devhub/views.py:76
-#: src/olympia/devhub/views.py:83
-#: src/olympia/discovery/templates/discovery/addons/detail.html:66
+#: src/olympia/browse/views.py:427 src/olympia/devhub/views.py:74 src/olympia/devhub/views.py:81 src/olympia/discovery/templates/discovery/addons/detail.html:66
 msgid "Created"
 msgstr "Создано"
 
 #. {0} is the category name. Ex: Sports
-#: src/olympia/browse/templates/browse/creatured.html:5
-#: src/olympia/browse/templates/browse/creatured.html:13
+#: src/olympia/browse/templates/browse/creatured.html:5 src/olympia/browse/templates/browse/creatured.html:13
 msgid "{0}: Featured Add-ons"
 msgstr "{0}: Избранные дополнения"
 
-#: src/olympia/browse/templates/browse/creatured.html:12
-#: src/olympia/browse/templates/browse/featured.html:4
-#: src/olympia/browse/templates/browse/featured.html:12
-#: src/olympia/browse/templates/browse/featured.html:13
-#: src/olympia/devhub/templates/devhub/docs/policies-recommended.html:3
-#: src/olympia/devhub/templates/devhub/docs/policies-recommended.html:7
-#: src/olympia/devhub/templates/devhub/docs/policies-recommended.html:9
-#: src/olympia/devhub/templates/devhub/docs/policies.html:21
-#: src/olympia/devhub/templates/devhub/docs/policies.html:90
-#: src/olympia/discovery/modules.py:341
-#: src/olympia/discovery/templates/discovery/pane.html:52
-#: src/olympia/templates/menu_links.html:7
+#: src/olympia/browse/templates/browse/creatured.html:12 src/olympia/browse/templates/browse/featured.html:4 src/olympia/browse/templates/browse/featured.html:12
+#: src/olympia/browse/templates/browse/featured.html:13 src/olympia/devhub/templates/devhub/docs/policies-recommended.html:3 src/olympia/devhub/templates/devhub/docs/policies-recommended.html:7
+#: src/olympia/devhub/templates/devhub/docs/policies-recommended.html:9 src/olympia/devhub/templates/devhub/docs/policies.html:21 src/olympia/devhub/templates/devhub/docs/policies.html:90
+#: src/olympia/discovery/modules.py:341 src/olympia/discovery/templates/discovery/pane.html:52 src/olympia/templates/menu_links.html:7
 msgid "Featured Add-ons"
 msgstr "Избранные Дополнения"
 
@@ -3649,12 +2853,8 @@ msgstr "В {0} нет избранных дополнений."
 
 #: src/olympia/browse/templates/browse/featured.html:15
 #, python-format
-msgid ""
-"Here's a few of our favorite add-ons to help you get started customizing "
-"%(app)s."
-msgstr ""
-"Вот несколько из наших любимых дополнений, которые помогут вам начать "
-"настраивать %(app)s."
+msgid "Here's a few of our favorite add-ons to help you get started customizing %(app)s."
+msgstr "Вот несколько из наших любимых дополнений, которые помогут вам начать настраивать %(app)s."
 
 #: src/olympia/browse/templates/browse/language_tools.html:9
 msgid "Install Dictionary"
@@ -3680,19 +2880,15 @@ msgstr "Доступно на вашем языке"
 msgid "List of language packs and dictionaries available in your locale."
 msgstr "Список локализаций и словарей, доступных для вашего языка."
 
-#: src/olympia/browse/templates/browse/language_tools.html:41
-#: src/olympia/browse/templates/browse/language_tools.html:63
+#: src/olympia/browse/templates/browse/language_tools.html:41 src/olympia/browse/templates/browse/language_tools.html:63
 msgid "Language"
 msgstr "Язык"
 
-#: src/olympia/browse/templates/browse/language_tools.html:42
-#: src/olympia/browse/templates/browse/language_tools.html:64
-#: src/olympia/constants/base.py:162
+#: src/olympia/browse/templates/browse/language_tools.html:42 src/olympia/browse/templates/browse/language_tools.html:64 src/olympia/constants/base.py:162
 msgid "Dictionary"
 msgstr "Словарь"
 
-#: src/olympia/browse/templates/browse/language_tools.html:43
-#: src/olympia/browse/templates/browse/language_tools.html:65
+#: src/olympia/browse/templates/browse/language_tools.html:43 src/olympia/browse/templates/browse/language_tools.html:65
 msgid "Language Pack"
 msgstr "Локализация"
 
@@ -3710,13 +2906,11 @@ msgid "{0} :: Search Tools"
 msgstr "{0} :: Инструменты поиска"
 
 #. {0} is an integer.
-#: src/olympia/browse/templates/browse/search_tools.html:39
-#: src/olympia/devhub/templates/devhub/addons/dashboard.html:17
+#: src/olympia/browse/templates/browse/search_tools.html:39 src/olympia/devhub/templates/devhub/addons/dashboard.html:17
 msgid "<b>{0}</b> add-on"
 msgid_plural "<b>{0}</b> add-ons"
 msgstr[0] "<b>{0}</b> дополнение"
 msgstr[1] "<b>{0}</b> дополнения"
-msgstr[2] "<b>{0}</b> дополнений"
 
 #: src/olympia/browse/templates/browse/search_tools.html:61
 msgid "Search Extensions"
@@ -3740,34 +2934,18 @@ msgstr "Дополнительные ресурсы"
 
 #. {0} is an app name, like Firefox.
 #: src/olympia/browse/templates/browse/search_tools.html:93
-msgid ""
-"Learn more about the <a "
-"href=\"http://support.mozilla.com/kb/Search+bar\">search bar</a> in {0}"
-msgstr ""
-"Узнайте больше о <a href=\"http://support.mozilla.com/kb/Search+bar\">панели"
-" поиска</a> в {0}"
+msgid "Learn more about the <a href=\"http://support.mozilla.com/kb/Search+bar\">search bar</a> in {0}"
+msgstr "Узнайте больше о <a href=\"http://support.mozilla.com/kb/Search+bar\">панели поиска</a> в {0}"
 
 #: src/olympia/browse/templates/browse/search_tools.html:94
-msgid ""
-"Browse through even more search providers at <a "
-"href=\"http://mycroft.mozdev.org/\">mycroft.mozdev.org</a>"
-msgstr ""
-"Найдите ещё больше провайдеров поиска на сайте <a "
-"href=\"http://mycroft.mozdev.org/\">mycroft.mozdev.org</a>"
+msgid "Browse through even more search providers at <a href=\"http://mycroft.mozdev.org/\">mycroft.mozdev.org</a>"
+msgstr "Найдите ещё больше провайдеров поиска на сайте <a href=\"http://mycroft.mozdev.org/\">mycroft.mozdev.org</a>"
 
 #: src/olympia/browse/templates/browse/search_tools.html:95
-msgid ""
-"<a "
-"href=\"https://developer.mozilla.org/en/Creating_OpenSearch_plugins_for_Firefox\">Make"
-" your own</a> search tool"
-msgstr ""
-"<a "
-"href=\"https://developer.mozilla.org/ru/docs/Creating_OpenSearch_plugins_for_Firefox\">Создайте"
-" свой</a> поисковый инструмент"
+msgid "<a href=\"https://developer.mozilla.org/en/Creating_OpenSearch_plugins_for_Firefox\">Make your own</a> search tool"
+msgstr "<a href=\"https://developer.mozilla.org/ru/docs/Creating_OpenSearch_plugins_for_Firefox\">Создайте свой</a> поисковый инструмент"
 
-#: src/olympia/browse/templates/browse/themes.html:6
-#: src/olympia/browse/templates/browse/themes.html:9
-#: src/olympia/constants/base.py:174
+#: src/olympia/browse/templates/browse/themes.html:6 src/olympia/browse/templates/browse/themes.html:9 src/olympia/constants/base.py:174
 msgid "Complete Themes"
 msgstr "Полные темы"
 
@@ -3839,26 +3017,18 @@ msgid "See the %(cnt)s extension in %(name)s &raquo;"
 msgid_plural "See all %(cnt)s extensions in %(name)s &raquo;"
 msgstr[0] "Показать %(cnt)s расширение в %(name)s &raquo;"
 msgstr[1] "Показать все %(cnt)s расширения в %(name)s &raquo;"
-msgstr[2] "Показать все %(cnt)s расширений в %(name)s &raquo;"
 
-#: src/olympia/browse/templates/browse/mobile/extensions.html:13
-#: src/olympia/compat/templates/compat/index.html:82
-#: src/olympia/devhub/templates/devhub/devhub_search.html:24
-#: src/olympia/devhub/templates/devhub/addons/activity.html:47
-#: src/olympia/search/templates/search/no_results.html:4
-#: src/olympia/search/templates/search/mobile/results.html:36
+#: src/olympia/browse/templates/browse/mobile/extensions.html:13 src/olympia/devhub/templates/devhub/devhub_search.html:24 src/olympia/devhub/templates/devhub/addons/activity.html:47
+#: src/olympia/search/templates/search/no_results.html:4 src/olympia/search/templates/search/mobile/results.html:36
 msgid "No results found."
 msgstr "Поиск не дал результатов."
 
-#: src/olympia/browse/templates/browse/personas/base.html:6
-#: src/olympia/browse/templates/browse/personas/mobile/base.html:7
+#: src/olympia/browse/templates/browse/personas/base.html:6 src/olympia/browse/templates/browse/personas/mobile/base.html:7
 msgid "{0} Themes"
 msgstr "{0} :: Темы"
 
 #. {0} is a user's name.
-#: src/olympia/browse/templates/browse/personas/base.html:15
-#: src/olympia/browse/templates/browse/personas/base.html:40
-#: src/olympia/browse/templates/browse/personas/grid.html:8
+#: src/olympia/browse/templates/browse/personas/base.html:15 src/olympia/browse/templates/browse/personas/base.html:40 src/olympia/browse/templates/browse/personas/grid.html:8
 msgid "{0}'s Themes"
 msgstr "Темы {0}"
 
@@ -3872,38 +3042,28 @@ msgstr "Создать свою собственную тему"
 
 #: src/olympia/browse/templates/browse/personas/base.html:46
 msgid "Your browser, your style! Dress it up with a design of your own!"
-msgstr ""
-"Ваш браузер в вашем стиле! Используйте для него свой собственный дизайн!"
+msgstr "Ваш браузер в вашем стиле! Используйте для него свой собственный дизайн!"
 
 #: src/olympia/browse/templates/browse/personas/base.html:51
 msgid "Learn more"
 msgstr "Узнать больше"
 
-#: src/olympia/browse/templates/browse/personas/category_landing.html:6
-#: src/olympia/browse/templates/browse/personas/mobile/category_landing.html:5
+#: src/olympia/browse/templates/browse/personas/category_landing.html:6 src/olympia/browse/templates/browse/personas/mobile/category_landing.html:5
 msgid "View All Recently Added"
 msgstr "Просмотреть все по дате добавления"
 
-#: src/olympia/browse/templates/browse/personas/category_landing.html:7
-#: src/olympia/browse/templates/browse/personas/mobile/category_landing.html:6
+#: src/olympia/browse/templates/browse/personas/category_landing.html:7 src/olympia/browse/templates/browse/personas/mobile/category_landing.html:6
 msgid "View All Most Popular"
 msgstr "Просмотреть все по популярности"
 
-#: src/olympia/browse/templates/browse/personas/category_landing.html:8
-#: src/olympia/browse/templates/browse/personas/mobile/category_landing.html:7
+#: src/olympia/browse/templates/browse/personas/category_landing.html:8 src/olympia/browse/templates/browse/personas/mobile/category_landing.html:7
 msgid "View All Top Rated"
 msgstr "Просмотреть все по рейтингу"
 
 #: src/olympia/browse/templates/browse/personas/category_landing.html:40
 #, python-format
-msgid ""
-"Over 300,000 designs to personalize your browser! Move your mouse over a "
-"Background Theme to try it on. <a href=\"%(url)s\" class=\"more-info\">Start"
-" exploring</a>"
-msgstr ""
-"Более 300 000 дизайнов для настройки под себя вашего браузера! Наведите "
-"курсор на фоновую тему, чтобы её попробовать. <a href=\"%(url)s\" class"
-"=\"more-info\">Начните изучать</a>"
+msgid "Over 300,000 designs to personalize your browser! Move your mouse over a Background Theme to try it on. <a href=\"%(url)s\" class=\"more-info\">Start exploring</a>"
+msgstr "Более 300 000 дизайнов для настройки под себя вашего браузера! Наведите курсор на фоновую тему, чтобы её попробовать. <a href=\"%(url)s\" class=\"more-info\">Начните изучать</a>"
 
 #: src/olympia/browse/templates/browse/personas/category_landing.html:47
 msgid "Want more personalization?"
@@ -3913,14 +3073,9 @@ msgstr "Нужна большая персонализация?"
 #. theme.
 #: src/olympia/browse/templates/browse/personas/category_landing.html:50
 #, python-format
-msgid ""
-"Complete Themes transform the look of your browser with styles for the "
-"window frame, address bar, buttons, tabs, and menus. <a href=\"%(url)s\" "
-"class=\"more-info\">Start exploring</a>"
+msgid "Complete Themes transform the look of your browser with styles for the window frame, address bar, buttons, tabs, and menus. <a href=\"%(url)s\" class=\"more-info\">Start exploring</a>"
 msgstr ""
-"Полные темы трансформируют внешний вид вашего браузера, используя стили для "
-"рамки окна, адресной строки, кнопок, вкладок и меню. <a href=\"%(url)s\" "
-"class=\"more-info\">Начните исследовать</a>"
+"Полные темы трансформируют внешний вид вашего браузера, используя стили для рамки окна, адресной строки, кнопок, вкладок и меню. <a href=\"%(url)s\" class=\"more-info\">Начните исследовать</a>"
 
 #: src/olympia/browse/templates/browse/personas/category_landing.html:76
 msgid "Up & Coming Themes"
@@ -3950,7 +3105,7 @@ msgstr "&laquo; Все темы"
 msgid "All"
 msgstr "Все"
 
-#: src/olympia/compat/forms.py:22 src/olympia/search/views.py:525
+#: src/olympia/compat/forms.py:22 src/olympia/editors/templates/editors/base.html:69 src/olympia/search/views.py:518
 msgid "All Add-ons"
 msgstr "Все дополнения"
 
@@ -3962,92 +3117,32 @@ msgstr "Бинарные"
 msgid "Non-binary"
 msgstr "Не бинарные"
 
-#. Review points sources other than add-ons and themes.
-#: src/olympia/compat/views.py:87 src/olympia/constants/base.py:388
-#: src/olympia/devhub/forms.py:162
-#: src/olympia/editors/templates/editors/performance.html:75
-msgid "Other"
-msgstr "Другое"
-
-#: src/olympia/compat/templates/compat/index.html:4
-msgid "Add-on Compatibility Report for {app} {version}"
-msgstr "Отчёт о совместимости дополнений для {app} {version}"
-
-#: src/olympia/compat/templates/compat/index.html:11
-msgid "{app} {version} Compatibility"
-msgstr "Совместимость с {app} {version}"
-
-#: src/olympia/compat/templates/compat/index.html:17
-#, python-format
-msgid "Top 95%% compatible with previous version"
-msgstr "Топ из 95%% совместимых с предыдущей версией"
-
-#: src/olympia/compat/templates/compat/index.html:18
-#, python-format
-msgid "Top 95%% of all add-ons"
-msgstr "Топ из 95%% всех дополнений"
-
-#: src/olympia/compat/templates/compat/index.html:19
-msgid "All active add-ons"
-msgstr "Все активные дополнения"
-
-#: src/olympia/compat/templates/compat/index.html:23
-#: src/olympia/constants/base.py:401
-msgid "App"
-msgstr "Прил."
-
-#: src/olympia/compat/templates/compat/index.html:55
-msgid "Details for add-ons compatible with previous version:"
-msgstr "Подробности о дополнениях, совместимых с предыдущей версией:"
-
-#: src/olympia/compat/templates/compat/index.html:57
-msgid "Show all versions"
-msgstr "Показать все версии"
-
-#: src/olympia/compat/templates/compat/index.html:59
-msgid "Details for add-ons compatible with all versions:"
-msgstr "Подробнее о дополнениях, совместимых со всеми версиями:"
-
-#: src/olympia/compat/templates/compat/index.html:61
-msgid "Show previous version only"
-msgstr "Показать только предыдущую версию"
-
 #: src/olympia/compat/templates/compat/reporter.html:3
 msgid "Add-on Compatibility Reports"
 msgstr "Отчёты совместимости дополнения"
 
-#: src/olympia/compat/templates/compat/reporter.html:11
-#: src/olympia/compat/templates/compat/reporter_detail.html:35
+#: src/olympia/compat/templates/compat/reporter.html:11 src/olympia/compat/templates/compat/reporter_detail.html:35
 #, python-format
 msgid ""
-"<p> Reports submitted to us through the <a href=\"%(url_)s\">Add-on "
-"Compatibility Reporter</a> are collected here for developers to view. These "
-"reports help us determine which add-ons will need help supporting an "
-"upcoming Firefox version. </p>"
+"<p> Reports submitted to us through the <a href=\"%(url_)s\">Add-on Compatibility Reporter</a> are collected here for developers to view. These reports help us determine which add-ons will need "
+"help supporting an upcoming Firefox version. </p>"
 msgstr ""
-"<p> Отчёты, отправляемые нам через <a href=\"%(url_)s\">Add-on Compatibility"
-" Reporter</a>, собираются здесь для просмотра их разработчиками. Эти отчёты "
-"помогают нам определить, каким дополнениям потребуется помощь в поддержке "
-"будущей версии Firefox. </p>"
+"<p> Отчёты, отправляемые нам через <a href=\"%(url_)s\">Add-on Compatibility Reporter</a>, собираются здесь для просмотра их разработчиками. Эти отчёты помогают нам определить, каким дополнениям "
+"потребуется помощь в поддержке будущей версии Firefox. </p>"
 
 #: src/olympia/compat/templates/compat/reporter.html:18
 msgid "Reports for your Add-ons"
 msgstr "Отчёты для ваших дополнений"
 
-#: src/olympia/compat/templates/compat/reporter.html:30
-#: src/olympia/compat/templates/compat/reporter_detail.html:9
+#: src/olympia/compat/templates/compat/reporter.html:30 src/olympia/compat/templates/compat/reporter_detail.html:9
 msgid "Add-on Compatibility Center"
 msgstr "Центр совместимости дополнений"
 
 #: src/olympia/compat/templates/compat/reporter.html:34
 msgid "Enter the GUID of an add-on below to view any reports we've received."
-msgstr ""
-"Введите ниже GUID дополнения, чтобы просмотреть все отчёты, которые мы "
-"получили."
+msgstr "Введите ниже GUID дополнения, чтобы просмотреть все отчёты, которые мы получили."
 
-#: src/olympia/compat/templates/compat/reporter_detail.html:3
-#: src/olympia/compat/templates/compat/reporter_detail.html:10
-#: src/olympia/compat/templates/compat/reporter_detail.html:25
+#: src/olympia/compat/templates/compat/reporter_detail.html:3 src/olympia/compat/templates/compat/reporter_detail.html:10 src/olympia/compat/templates/compat/reporter_detail.html:25
 msgid "{addon} Compatibility Reports"
 msgstr "Отчёты совместимости для {addon}"
 
@@ -4056,17 +3151,14 @@ msgid "{0} success report"
 msgid_plural "{0} success reports"
 msgstr[0] "{0} сообщение о успехе"
 msgstr[1] "{0} сообщения о успехе"
-msgstr[2] "{0} сообщений о успехе"
 
 #: src/olympia/compat/templates/compat/reporter_detail.html:17
 msgid "{0} problem report"
 msgid_plural "{0} problem reports"
 msgstr[0] "{0} сообщение о проблеме"
 msgstr[1] "{0} сообщения о проблеме"
-msgstr[2] "{0} сообщений о проблеме"
 
-#: src/olympia/compat/templates/compat/reporter_detail.html:21
-#: src/olympia/users/templates/users/profile.html:70
+#: src/olympia/compat/templates/compat/reporter_detail.html:21 src/olympia/users/templates/users/profile.html:70
 msgid "View all"
 msgstr "Просмотреть все"
 
@@ -4078,10 +3170,8 @@ msgstr "Фильтр по приложению"
 msgid "Report Type"
 msgstr "Тип отчёта"
 
-#: src/olympia/compat/templates/compat/reporter_detail.html:47
-#: src/olympia/devhub/forms.py:784
-#: src/olympia/devhub/templates/devhub/addons/ajax_compat_update.html:17
-#: src/olympia/editors/forms.py:108 src/olympia/zadmin/forms.py:45
+#: src/olympia/compat/templates/compat/reporter_detail.html:47 src/olympia/devhub/forms.py:785 src/olympia/devhub/templates/devhub/addons/ajax_compat_update.html:17 src/olympia/editors/forms.py:108
+#: src/olympia/editors/forms.py:248 src/olympia/zadmin/forms.py:45
 msgid "Application"
 msgstr "Приложение"
 
@@ -4093,8 +3183,7 @@ msgstr "Сборка приложения"
 msgid "Platform"
 msgstr "Платформа"
 
-#: src/olympia/compat/templates/compat/reporter_detail.html:50
-#: src/olympia/editors/templates/editors/themes/themes.html:40
+#: src/olympia/compat/templates/compat/reporter_detail.html:50 src/olympia/editors/templates/editors/themes/themes.html:40
 msgid "Submitted"
 msgstr "Отправлено"
 
@@ -4122,8 +3211,7 @@ msgstr "Thunderbird"
 msgid "SeaMonkey"
 msgstr "SeaMonkey"
 
-#: src/olympia/constants/applications.py:75
-#: src/olympia/pages/templates/pages/sunbird.html:4
+#: src/olympia/constants/applications.py:75 src/olympia/pages/templates/pages/sunbird.html:4
 msgid "Sunbird"
 msgstr "Sunbird"
 
@@ -4171,7 +3259,7 @@ msgstr "Предварительно проверено"
 msgid "Preliminarily Reviewed and Awaiting Full Review"
 msgstr "Предварительно проверено и ожидает полной проверки"
 
-#: src/olympia/constants/base.py:33 src/olympia/editors/helpers.py:924
+#: src/olympia/constants/base.py:33 src/olympia/editors/forms.py:258 src/olympia/editors/helpers.py:73 src/olympia/editors/helpers.py:1004
 #: src/olympia/editors/templates/editors/themes/history_table.html:34
 msgid "Deleted"
 msgstr "Удалено"
@@ -4205,13 +3293,11 @@ msgstr "Разработчик"
 msgid "Viewer"
 msgstr "Наблюдатель"
 
-#: src/olympia/constants/base.py:137
-#: src/olympia/templates/mobile/header.html:7
+#: src/olympia/constants/base.py:137 src/olympia/templates/mobile/header.html:7
 msgid "Support"
 msgstr "Поддержка"
 
-#: src/olympia/constants/base.py:159 src/olympia/constants/base.py:172
-#: src/olympia/constants/platforms.py:10
+#: src/olympia/constants/base.py:159 src/olympia/constants/base.py:172 src/olympia/constants/platforms.py:10
 msgid "Any"
 msgstr "Любая"
 
@@ -4239,11 +3325,8 @@ msgstr "Локализация (дополнение)"
 msgid "Plugin"
 msgstr "Плагин"
 
-#: src/olympia/constants/base.py:167
-#: src/olympia/editors/templates/editors/includes/search_results_themes.html:5
-#: src/olympia/editors/templates/editors/themes/deleted.html:18
-#: src/olympia/editors/templates/editors/themes/history_table.html:8
-#: src/olympia/editors/templates/editors/themes/logs.html:17
+#: src/olympia/constants/base.py:167 src/olympia/editors/templates/editors/includes/search_results_themes.html:5 src/olympia/editors/templates/editors/themes/deleted.html:18
+#: src/olympia/editors/templates/editors/themes/history_table.html:8 src/olympia/editors/templates/editors/themes/logs.html:17
 msgid "Theme"
 msgstr "Тема"
 
@@ -4277,6 +3360,11 @@ msgstr "Спросите после того как пользователи н�
 msgid "Ask before users can download this add-on"
 msgstr "Спросите перед тем как пользователи смогут загрузить это дополнение"
 
+#. Review points sources other than add-ons and themes.
+#: src/olympia/constants/base.py:388 src/olympia/devhub/forms.py:162 src/olympia/editors/templates/editors/performance.html:75
+msgid "Other"
+msgstr "Другое"
+
 #: src/olympia/constants/base.py:389
 msgid "Exception"
 msgstr "Исключение"
@@ -4288,6 +3376,10 @@ msgstr "Выпуск"
 #: src/olympia/constants/base.py:391
 msgid "Change"
 msgstr "Изменить"
+
+#: src/olympia/constants/base.py:401
+msgid "App"
+msgstr "Прил."
 
 #: src/olympia/constants/base.py:402
 msgid "Persona"
@@ -4425,32 +3517,23 @@ msgstr "Подписался на полную проверку"
 msgid "Signed of a preliminary review"
 msgstr "Подписался на предварительную проверку"
 
-#: src/olympia/constants/editors.py:14
-#: src/olympia/editors/templates/editors/themes/queue.html:76
-#: src/olympia/editors/templates/editors/themes/themes.html:87
+#: src/olympia/constants/editors.py:14 src/olympia/editors/templates/editors/themes/queue.html:76 src/olympia/editors/templates/editors/themes/themes.html:87
 msgid "Request More Info"
 msgstr "Запросить дополнительную информацию"
 
-#: src/olympia/constants/editors.py:15
-#: src/olympia/editors/templates/editors/themes/queue.html:74
-#: src/olympia/editors/templates/editors/themes/themes.html:91
+#: src/olympia/constants/editors.py:15 src/olympia/editors/templates/editors/themes/queue.html:74 src/olympia/editors/templates/editors/themes/themes.html:91
 msgid "Flag"
 msgstr "Флаг"
 
-#: src/olympia/constants/editors.py:16
-#: src/olympia/editors/templates/editors/themes/queue.html:72
-#: src/olympia/editors/templates/editors/themes/themes.html:93
+#: src/olympia/constants/editors.py:16 src/olympia/editors/templates/editors/themes/queue.html:72 src/olympia/editors/templates/editors/themes/themes.html:93
 msgid "Duplicate"
 msgstr "Дубликат"
 
-#: src/olympia/constants/editors.py:17 src/olympia/editors/helpers.py:502
-#: src/olympia/editors/templates/editors/themes/queue.html:71
-#: src/olympia/editors/templates/editors/themes/themes.html:94
+#: src/olympia/constants/editors.py:17 src/olympia/editors/helpers.py:575 src/olympia/editors/templates/editors/themes/queue.html:71 src/olympia/editors/templates/editors/themes/themes.html:94
 msgid "Reject"
 msgstr "Отклонить"
 
-#: src/olympia/constants/editors.py:18
-#: src/olympia/editors/templates/editors/themes/queue.html:70
+#: src/olympia/constants/editors.py:18 src/olympia/editors/templates/editors/themes/queue.html:70
 msgid "Approve"
 msgstr "Одобрить"
 
@@ -4504,15 +3587,11 @@ msgstr "Creative Commons Атрибуция — Некоммерческое и�
 
 #: src/olympia/constants/licenses.py:36
 msgid "Creative Commons Attribution-NonCommercial-NoDerivs 3.0"
-msgstr ""
-"Creative Commons Атрибуция — Некоммерческое использование — Без производных "
-"произведений 3.0"
+msgstr "Creative Commons Атрибуция — Некоммерческое использование — Без производных произведений 3.0"
 
 #: src/olympia/constants/licenses.py:43
 msgid "Creative Commons Attribution-NonCommercial-Share Alike 3.0"
-msgstr ""
-"Creative Commons Атрибуция — Некоммерческое использование — С сохранением "
-"условий 3.0"
+msgstr "Creative Commons Атрибуция — Некоммерческое использование — С сохранением условий 3.0"
 
 #: src/olympia/constants/licenses.py:50
 msgid "Creative Commons Attribution-NoDerivs 3.0"
@@ -4550,7 +3629,7 @@ msgstr "Solaris"
 msgid "Android"
 msgstr "Android"
 
-#: src/olympia/core/apps.py:19
+#: src/olympia/core/apps.py:21
 msgid "Core"
 msgstr "Ядро"
 
@@ -4587,9 +3666,7 @@ msgstr "Неверный объект JSON"
 msgid "Message not eligible for annotation"
 msgstr "Сообщение не доступно для аннотирования"
 
-#: src/olympia/devhub/forms.py:124
-#: src/olympia/devhub/templates/devhub/versions/edit.html:94
-#: src/olympia/users/templates/users/edit.html:150
+#: src/olympia/devhub/forms.py:124 src/olympia/devhub/templates/devhub/versions/edit.html:94 src/olympia/users/templates/users/edit.html:150
 msgid "Details"
 msgstr "Подробности"
 
@@ -4659,9 +3736,7 @@ msgstr "Не удалось проверить PayPal id."
 
 #: src/olympia/devhub/forms.py:388
 msgid "Unsupported file type, please upload an archive file {extensions}."
-msgstr ""
-"Неподдерживаемый тип файла, пожалуйста, загрузите архивный файл "
-"{extensions}."
+msgstr "Неподдерживаемый тип файла, пожалуйста, загрузите архивный файл {extensions}."
 
 #: src/olympia/devhub/forms.py:407
 msgid "View current"
@@ -4677,8 +3752,7 @@ msgstr "Нужна по крайней мере одно совместимое 
 
 #: src/olympia/devhub/forms.py:501 src/olympia/devhub/forms.py:522
 msgid "There was an error with your upload. Please try again."
-msgstr ""
-"В процессе вашей загрузки произошла ошибка. Пожалуйста, попробуйте снова."
+msgstr "В процессе вашей загрузки произошла ошибка. Пожалуйста, попробуйте снова."
 
 #: src/olympia/devhub/forms.py:506
 msgid "Override failed validation"
@@ -4689,39 +3763,26 @@ msgid "Submit my add-on for manual review."
 msgstr "Представить мое дополнение на проверку вручную."
 
 #: src/olympia/devhub/forms.py:537
-msgid "Do not list my add-on on this site (beta)"
-msgstr "Не вносить в список моё дополнение на данном сайте (бета)"
+msgid "Do not list my add-on on this site"
+msgstr ""
 
 #: src/olympia/devhub/forms.py:538
-msgid ""
-"Check this option if you intend to distribute your add-on on your own and "
-"only need it to be signed by Mozilla."
-msgstr ""
-"Отметьте данную опцию, если намереваетесь самостоятельно распространять своё"
-" дополнение и вам необходимо только подписать его компанией Mozilla."
+msgid "Check this option if you intend to distribute your add-on on your own and only need it to be signed by Mozilla."
+msgstr "Отметьте данную опцию, если намереваетесь самостоятельно распространять своё дополнение и вам необходимо только подписать его компанией Mozilla."
 
 #: src/olympia/devhub/forms.py:544
 msgid "This add-on will be bundled with an application installer."
 msgstr "Это дополнение будет встроено в инсталлятор приложения."
 
 #: src/olympia/devhub/forms.py:546
-msgid ""
-"Add-ons that are bundled with application installers will be code reviewed "
-"by Mozilla before they are signed and are held to a higher quality standard."
-msgstr ""
-"Дополнения, упакованные с установщиком приложений, будут проверены Mozilla "
-"до того, как будут подписаны, и должны соответствовать лучшим стандартам "
-"качества."
+msgid "Add-ons that are bundled with application installers will be code reviewed by Mozilla before they are signed and are held to a higher quality standard."
+msgstr "Дополнения, упакованные с установщиком приложений, будут проверены Mozilla до того, как будут подписаны, и должны соответствовать лучшим стандартам качества."
 
-#: src/olympia/devhub/forms.py:565
-#: src/olympia/devhub/templates/devhub/addons/submit/select-review.html:24
-#: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:42
+#: src/olympia/devhub/forms.py:565 src/olympia/devhub/templates/devhub/addons/submit/select-review.html:24 src/olympia/devhub/templates/devhub/docs/policies-reviews.html:42
 msgid "Full Review"
 msgstr "Полная проверка"
 
-#: src/olympia/devhub/forms.py:566
-#: src/olympia/devhub/templates/devhub/addons/submit/select-review.html:47
-#: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:153
+#: src/olympia/devhub/forms.py:566 src/olympia/devhub/templates/devhub/addons/submit/select-review.html:47 src/olympia/devhub/templates/devhub/docs/policies-reviews.html:153
 msgid "Preliminary Review"
 msgstr "Предварительная проверка"
 
@@ -4730,68 +3791,51 @@ msgid "Please choose a review nomination type"
 msgstr "Пожалуйста, выберите тип номинации на проверку"
 
 #: src/olympia/devhub/forms.py:574
-msgid ""
-"A file with a version ending with a|alpha|b|beta|pre|rc and an optional "
-"number is detected as beta."
-msgstr ""
-"Файл с версией, заканчивающейся на a|alpha|b|beta|pre|rc и необязательным "
-"числом, определяется как бета."
+msgid "A file with a version ending with a|alpha|b|beta|pre|rc and an optional number is detected as beta."
+msgstr "Файл с версией, заканчивающейся на a|alpha|b|beta|pre|rc и необязательным числом, определяется как бета."
 
 #: src/olympia/devhub/forms.py:592
 #, python-format
-msgid "Version %s already exists"
-msgstr "Версия %s уже существует"
-
-#: src/olympia/devhub/forms.py:604
-msgid ""
-"Select a valid choice. That choice is not one of the available choices."
+msgid "Version %s already exists, or was uploaded before."
 msgstr ""
-"Сделайте правильный выбор. Это выбор не является одним из возможных "
-"вариантов."
 
-#: src/olympia/devhub/forms.py:610
-msgid ""
-"A file with a version ending with a|alpha|b|beta and an optional number is "
-"detected as beta."
-msgstr ""
-"Файл с версией, заканчивающейся на a|alpha|b|beta и необязательным числом, "
-"определяется как бета."
+#: src/olympia/devhub/forms.py:605
+msgid "Select a valid choice. That choice is not one of the available choices."
+msgstr "Сделайте правильный выбор. Это выбор не является одним из возможных вариантов."
 
-#: src/olympia/devhub/forms.py:633
+#: src/olympia/devhub/forms.py:611
+msgid "A file with a version ending with a|alpha|b|beta and an optional number is detected as beta."
+msgstr "Файл с версией, заканчивающейся на a|alpha|b|beta и необязательным числом, определяется как бета."
+
+#: src/olympia/devhub/forms.py:634
 msgid "You cannot upload any more files for this version."
 msgstr "Вы не можете загрузить больше файлов для этой версии."
 
-#: src/olympia/devhub/forms.py:639
+#: src/olympia/devhub/forms.py:640
 msgid "Version doesn't match"
 msgstr "Версия не подходит"
 
-#: src/olympia/devhub/forms.py:668
-msgid ""
-"You cannot delete a file once the review process has started.  You must "
-"delete the whole version."
+#: src/olympia/devhub/forms.py:669
+msgid "You cannot delete a file once the review process has started.  You must delete the whole version."
 msgstr ""
-"Вы не можете удалить файл после начала процесса проверки.  Вы должны удалить"
-" версию целиком."
 
-#: src/olympia/devhub/forms.py:688
+#: src/olympia/devhub/forms.py:689
 msgid "The platform All cannot be combined with specific platforms."
-msgstr ""
-"Платформа Все не может быть скомбинирована со специфичными платформами."
+msgstr "Платформа Все не может быть скомбинирована со специфичными платформами."
 
-#: src/olympia/devhub/forms.py:693
+#: src/olympia/devhub/forms.py:694
 msgid "A platform can only be chosen once."
 msgstr "Платформа может быть выбрана только один раз."
 
-#: src/olympia/devhub/forms.py:706
+#: src/olympia/devhub/forms.py:707
 msgid "A review type must be selected."
 msgstr "Должен быть выбран тип проверки."
 
-#: src/olympia/devhub/forms.py:788 src/olympia/editors/forms.py:114
-#: src/olympia/zadmin/forms.py:49 src/olympia/zadmin/forms.py:52
+#: src/olympia/devhub/forms.py:789 src/olympia/editors/forms.py:114 src/olympia/editors/forms.py:254 src/olympia/zadmin/forms.py:49 src/olympia/zadmin/forms.py:52
 msgid "Select an application first"
 msgstr "Сначала выберите приложение"
 
-#: src/olympia/devhub/forms.py:840
+#: src/olympia/devhub/forms.py:841
 msgid "There cannot be more than 3 required add-ons."
 msgstr "Число требуемых дополнений не может превышать 3-х."
 
@@ -4807,109 +3851,96 @@ msgstr "Мои представления"
 msgid "Developer Docs"
 msgstr "Документация разработчика"
 
-#. L10n: first parameter is the number of errors
 # {0} is a number
+#. L10n: first parameter is the number of errors
 #: src/olympia/devhub/helpers.py:200
 msgid "{0} error"
 msgid_plural "{0} errors"
 msgstr[0] "{0} ошибка"
 msgstr[1] "{0} ошибки"
-msgstr[2] "{0} ошибок"
 
-#. L10n: first parameter is the number of warnings
 # {0} is a number
+#. L10n: first parameter is the number of warnings
 #: src/olympia/devhub/helpers.py:203
 msgid "{0} warning"
 msgid_plural "{0} warnings"
 msgstr[0] "{0} предупреждение"
 msgstr[1] "{0} предупреждения"
-msgstr[2] "{0} предупреждений"
 
-#: src/olympia/devhub/models.py:375
-#: src/olympia/reviews/templates/reviews/add.html:58
+#: src/olympia/devhub/models.py:375 src/olympia/reviews/templates/reviews/add.html:58
 msgid "Review"
 msgstr "Отзыв"
 
-#: src/olympia/devhub/tasks.py:551
+#: src/olympia/devhub/tasks.py:583
 #, python-format
 msgid "%s responded with %s (%s)."
 msgstr "%s ответил с %s (%s)."
 
-#: src/olympia/devhub/tasks.py:555
+#: src/olympia/devhub/tasks.py:587
 #, python-format
 msgid "Connection to \"%s\" timed out."
 msgstr "Время ожидание соединения с \"%s\" истекло."
 
-#: src/olympia/devhub/tasks.py:557
+#: src/olympia/devhub/tasks.py:589
 #, python-format
 msgid "Could not contact host at \"%s\"."
 msgstr "Не удалось связаться с хостом на \"%s\"."
 
-#: src/olympia/devhub/utils.py:104
+#: src/olympia/devhub/utils.py:105
 #, python-format
-msgid ""
-"Validation generated too many errors/warnings so %s messages were truncated."
-" After addressing the visible messages, you'll be able to see the others."
-msgstr ""
-"Валидайия сгенерировала слишком много ошибок и предупреждений, поэтому %s "
-"сообщений было не отображено. После устранения видимых сообщений, вы сможете"
-" увидеть другие."
+msgid "Validation generated too many errors/warnings so %s messages were truncated. After addressing the visible messages, you'll be able to see the others."
+msgstr "Валидайия сгенерировала слишком много ошибок и предупреждений, поэтому %s сообщений было не отображено. После устранения видимых сообщений, вы сможете увидеть другие."
 
-#: src/olympia/devhub/views.py:183
+#: src/olympia/devhub/views.py:181
 msgid "All My Add-ons"
 msgstr "Все мои дополнения"
 
-#: src/olympia/devhub/views.py:210
+#: src/olympia/devhub/views.py:208
 msgid "All Activity"
 msgstr "Вся активность"
 
-#: src/olympia/devhub/views.py:211
+#: src/olympia/devhub/views.py:209
 msgid "Add-on Updates"
 msgstr "Обновления дополнения"
 
-#: src/olympia/devhub/views.py:212
+#: src/olympia/devhub/views.py:210
 msgid "Add-on Status"
 msgstr "Статус дополнения"
 
-#: src/olympia/devhub/views.py:213
+#: src/olympia/devhub/views.py:211
 msgid "User Collections"
 msgstr "Подборки пользователя"
 
-#: src/olympia/devhub/views.py:214
-#: src/olympia/devhub/templates/devhub/docs/policies-maintenance.html:68
-#: src/olympia/pages/templates/pages/dev_faq.html:38
+#: src/olympia/devhub/views.py:212 src/olympia/devhub/templates/devhub/docs/policies-maintenance.html:68 src/olympia/pages/templates/pages/dev_faq.html:38
 #: src/olympia/pages/templates/pages/dev_faq.html:484
 msgid "User Reviews"
 msgstr "Отзывы пользователей"
 
-#: src/olympia/devhub/views.py:327 src/olympia/devhub/views.py:331
-#: src/olympia/devhub/views.py:484 src/olympia/devhub/views.py:513
-#: src/olympia/devhub/views.py:564 src/olympia/devhub/views.py:1150
+#: src/olympia/devhub/views.py:325 src/olympia/devhub/views.py:329 src/olympia/devhub/views.py:484 src/olympia/devhub/views.py:513 src/olympia/devhub/views.py:564 src/olympia/devhub/views.py:1156
 msgid "Changes successfully saved."
 msgstr "Изменения успешно сохранены."
 
-#: src/olympia/devhub/views.py:334 src/olympia/devhub/views.py:1631
+#: src/olympia/devhub/views.py:332 src/olympia/devhub/views.py:1637
 msgid "Please check the form for errors."
 msgstr "Пожалуйста, проверьте форму на наличие ошибок."
 
-#: src/olympia/devhub/views.py:346
+#: src/olympia/devhub/views.py:344
 msgid "Add-on cannot be deleted. Disable this add-on instead."
-msgstr ""
-"Дополнение не может быть удалено. Вместо этого отключите это дополнение."
+msgstr "Дополнение не может быть удалено. Вместо этого отключите это дополнение."
 
-#: src/olympia/devhub/views.py:356
+#: src/olympia/devhub/views.py:354
 msgid "Theme deleted."
 msgstr "Тема удалена."
 
-#: src/olympia/devhub/views.py:356
+#: src/olympia/devhub/views.py:354
 msgid "Add-on deleted."
 msgstr "Дополнение удалено."
 
-#: src/olympia/devhub/views.py:362
+#: src/olympia/devhub/views.py:360
 msgid "URL name was incorrect. Theme was not deleted."
 msgstr "URL имя некорректно. Тема не была удалена."
 
-#: src/olympia/devhub/views.py:367
+#: src/olympia/devhub/views.py:365
 msgid "URL name was incorrect. Add-on was not deleted."
 msgstr "URL имя некорректно. Дополнение не было удалено."
 
@@ -4937,7 +3968,7 @@ msgstr "Валидировать дополнение"
 msgid "Check Add-on Compatibility"
 msgstr "Проверка совместимости дополнений"
 
-#: src/olympia/devhub/views.py:808 src/olympia/signing/views.py:90
+#: src/olympia/devhub/views.py:808 src/olympia/signing/views.py:95
 msgid "You cannot submit this type of add-on"
 msgstr "Вы не можете загрузить этот тип дополнения"
 
@@ -4961,62 +3992,47 @@ msgstr "Изображения не могут быть больше %dKB."
 #. L10n: {0} is an image width (in pixels), {1} is a height.
 #: src/olympia/devhub/views.py:1080
 msgid "Image must be exactly {0} pixels wide and {1} pixels tall."
-msgstr ""
-"Изображение должно быть в точности {0} пикселей в ширину и {1} пикселей в "
-"высоту."
+msgstr "Изображение должно быть в точности {0} пикселей в ширину и {1} пикселей в высоту."
 
 #: src/olympia/devhub/views.py:1087
 msgid "There was an error uploading your preview."
 msgstr "Ошибка при загрузке вашего предпросмотра."
 
-#: src/olympia/devhub/views.py:1189
+#: src/olympia/devhub/views.py:1195
 #, python-format
 msgid "Version %s disabled."
 msgstr "Версия %s отключена."
 
-#: src/olympia/devhub/views.py:1193
+#: src/olympia/devhub/views.py:1199
 #, python-format
 msgid "Version %s deleted."
 msgstr "Версия %s удалена."
 
-#: src/olympia/devhub/views.py:1203
-msgid ""
-"This upload has failed validation, and may lack complete validation results."
-" Please take due care when reviewing it."
-msgstr ""
-"Это загрузка не прошла валидацию и в ней могут отсутствовать результаты "
-"полной валидации. Пожалуйста, будьте внимательны при его проверке."
+#: src/olympia/devhub/views.py:1209
+msgid "This upload has failed validation, and may lack complete validation results. Please take due care when reviewing it."
+msgstr "Это загрузка не прошла валидацию и в ней могут отсутствовать результаты полной валидации. Пожалуйста, будьте внимательны при его проверке."
 
-#: src/olympia/devhub/views.py:1677
+#: src/olympia/devhub/views.py:1683
 msgid "Preliminary Review Requested."
 msgstr "Запрошена предварительная проверка."
 
-#: src/olympia/devhub/views.py:1678
+#: src/olympia/devhub/views.py:1684
 msgid "Full Review Requested."
 msgstr "Запрошена полная проверка."
 
-#: src/olympia/devhub/views.py:1779
-msgid ""
-"Your old credentials were revoked and are no longer valid. Be sure to update"
-" all API clients with the new credentials."
-msgstr ""
-"Ваши старые полномочия были отозваны и больше не действуют. Убедитесь, что "
-"обновили все API клиентов на новые полномочия."
+#: src/olympia/devhub/views.py:1783
+msgid "Your old credentials were revoked and are no longer valid. Be sure to update all API clients with the new credentials."
+msgstr "Ваши старые полномочия были отозваны и больше не действуют. Убедитесь, что обновили все API клиентов на новые полномочия."
 
-#: src/olympia/devhub/views.py:1797
+#: src/olympia/devhub/views.py:1801
 msgid "New API key created"
 msgstr "Создан новый ключ API"
 
 #: src/olympia/devhub/templates/devhub/agreement.html:2
-msgid ""
-"Before starting, please read and accept our Firefox Add-on Distribution "
-"Agreement. It also links to our Privacy Notice which explains how we handle "
-"your information."
+msgid "Before starting, please read and accept our Firefox Add-on Distribution Agreement. It also links to our Privacy Notice which explains how we handle your information."
 msgstr ""
-"Перед началом, пожалуйста прочтите и примите наше Соглашение по "
-"распространению дополнений Firefox. Оно также ссылается на Уведомление об "
-"использовании конфиденциальной информации, которое объясняет, как мы "
-"обрабатываем вашу информацию."
+"Перед началом, пожалуйста прочтите и примите наше Соглашение по распространению дополнений Firefox. Оно также ссылается на Уведомление об использовании конфиденциальной информации, которое "
+"объясняет, как мы обрабатываем вашу информацию."
 
 #: src/olympia/devhub/templates/devhub/agreement.html:13
 msgid "Printable Version"
@@ -5030,44 +4046,30 @@ msgstr "Я принимаю это соглашение"
 msgid "or <a href=\"{0}\">Cancel</a>"
 msgstr "или<a href=\"{0}\">Отменить</a>"
 
-#: src/olympia/devhub/templates/devhub/base.html:23
-#: src/olympia/devhub/templates/devhub/base_impala.html:20
-#: src/olympia/discovery/templates/discovery/addons/base.html:17
+#: src/olympia/devhub/templates/devhub/base.html:23 src/olympia/devhub/templates/devhub/base_impala.html:20 src/olympia/discovery/templates/discovery/addons/base.html:17
 msgid "Back to Add-ons"
 msgstr "Назад к дополнениям"
 
 #. {0} is a search term, such as Firebug.
 #. {0} is a search query.
-#: src/olympia/devhub/templates/devhub/devhub_search.html:4
-#: src/olympia/search/templates/search/results.html:9
-#: src/olympia/search/templates/search/mobile/results.html:6
+#: src/olympia/devhub/templates/devhub/devhub_search.html:4 src/olympia/search/templates/search/results.html:9 src/olympia/search/templates/search/mobile/results.html:6
 msgid "{0} :: Search"
 msgstr "{0} :: Поиск"
 
-#: src/olympia/devhub/templates/devhub/devhub_search.html:6
-#: src/olympia/devhub/templates/devhub/search.html:8
-#: src/olympia/editors/forms.py:435 src/olympia/editors/forms.py:437
-#: src/olympia/editors/templates/editors/queue.html:27
-#: src/olympia/editors/templates/editors/themes/queue_list.html:14
-#: src/olympia/search/templates/search/collections.html:17
-#: src/olympia/search/templates/search/personas.html:18
-#: src/olympia/search/templates/search/results.html:18
-#: src/olympia/search/templates/search/mobile/results.html:8
-#: src/olympia/templates/search.html:14
-#: src/olympia/templates/impala/search.html:18
+#: src/olympia/devhub/templates/devhub/devhub_search.html:6 src/olympia/devhub/templates/devhub/search.html:8 src/olympia/editors/forms.py:534 src/olympia/editors/forms.py:536
+#: src/olympia/editors/templates/editors/queue.html:27 src/olympia/editors/templates/editors/themes/queue_list.html:14 src/olympia/search/templates/search/collections.html:17
+#: src/olympia/search/templates/search/personas.html:18 src/olympia/search/templates/search/results.html:18 src/olympia/search/templates/search/mobile/results.html:8
+#: src/olympia/templates/search.html:14 src/olympia/templates/impala/search.html:18
 msgid "Search"
 msgstr "Поиск"
 
-#: src/olympia/devhub/templates/devhub/devhub_search.html:11
-#: src/olympia/devhub/templates/devhub/devhub_search.html:15
-#: src/olympia/search/templates/search/collections.html:18
+#: src/olympia/devhub/templates/devhub/devhub_search.html:11 src/olympia/devhub/templates/devhub/devhub_search.html:15 src/olympia/search/templates/search/collections.html:18
 #: src/olympia/search/templates/search/personas.html:20
 msgid "Search Results"
 msgstr "Результаты поиска"
 
 #. {0} is a search term, such as Firebug.
-#: src/olympia/devhub/templates/devhub/devhub_search.html:13
-#: src/olympia/search/templates/search/results.html:11
+#: src/olympia/devhub/templates/devhub/devhub_search.html:13 src/olympia/search/templates/search/results.html:11
 msgid "Search Results for \"{0}\""
 msgstr "Результаты поиска для \"{0}\""
 
@@ -5088,9 +4090,7 @@ msgid "AMO Reviewers"
 msgstr "Рецензенты AMO"
 
 #: src/olympia/devhub/templates/devhub/index.html:29
-msgid ""
-"Get ahead! Become an AMO Reviewer today and get your add-ons reviewed "
-"faster."
+msgid "Get ahead! Become an AMO Reviewer today and get your add-ons reviewed faster."
 msgstr "Вперёд! Станьте рецензентом AMO и ускорьте проверку ваших дополнений."
 
 #: src/olympia/devhub/templates/devhub/index.html:32
@@ -5103,41 +4103,28 @@ msgstr "Узнайте всё о дополнениях"
 
 #: src/olympia/devhub/templates/devhub/index.html:41
 msgid ""
-"Add-ons let millions of Firefox users enhance and customize their browsing "
-"experience. If you're a Web developer and know <a "
-"href=\"https://developer.mozilla.org/docs/Web/HTML\">HTML</a>, <a "
-"href=\"https://developer.mozilla.org/docs/Web/JavaScript\">JavaScript</a>, "
-"and <a href=\"https://developer.mozilla.org/docs/Web/CSS\">CSS</a>, you "
-"already have all the necessary skills to make a great add-on."
+"Add-ons let millions of Firefox users enhance and customize their browsing experience. If you're a Web developer and know <a href=\"https://developer.mozilla.org/docs/Web/HTML\">HTML</a>, <a href="
+"\"https://developer.mozilla.org/docs/Web/JavaScript\">JavaScript</a>, and <a href=\"https://developer.mozilla.org/docs/Web/CSS\">CSS</a>, you already have all the necessary skills to make a great "
+"add-on."
 msgstr ""
-"Дополнения позволяют миллионам пользователей Firefox расширять и настраивать"
-" свою среду для работы в Интернете. Если вы веб-разработчик и знаете <a "
-"href=\"https://developer.mozilla.org/docs/Web/HTML\">HTML</a>, <a "
-"href=\"https://developer.mozilla.org/docs/Web/JavaScript\">JavaScript</a> и "
-"<a href=\"https://developer.mozilla.org/docs/Web/CSS\">CSS</a>, у вас уже "
-"есть все необходимые навыки, чтобы сделать отличное дополнение."
+"Дополнения позволяют миллионам пользователей Firefox расширять и настраивать свою среду для работы в Интернете. Если вы веб-разработчик и знаете <a href=\"https://developer.mozilla.org/docs/Web/HTML"
+"\">HTML</a>, <a href=\"https://developer.mozilla.org/docs/Web/JavaScript\">JavaScript</a> и <a href=\"https://developer.mozilla.org/docs/Web/CSS\">CSS</a>, у вас уже есть все необходимые навыки, "
+"чтобы сделать отличное дополнение."
 
 #: src/olympia/devhub/templates/devhub/index.html:51
-msgid ""
-"Head over to the <a href=\"https://developer.mozilla.org/Add-ons\">Mozilla "
-"Developer Network</a> to learn everything you need to know to get started."
-msgstr ""
-"Зайдите в <a href=\"https://developer.mozilla.org/Add-ons\">Сеть "
-"разработчиков Mozilla</a>, чтобы узнать всё, что нужно, чтобы начать работу."
+msgid "Head over to the <a href=\"https://developer.mozilla.org/Add-ons\">Mozilla Developer Network</a> to learn everything you need to know to get started."
+msgstr "Зайдите в <a href=\"https://developer.mozilla.org/Add-ons\">Сеть разработчиков Mozilla</a>, чтобы узнать всё, что нужно, чтобы начать работу."
 
 #: src/olympia/devhub/templates/devhub/index.html:58
 msgid "Start Making Add-ons"
 msgstr "Начать создавать дополнения"
 
-#: src/olympia/devhub/templates/devhub/index.html:86
-#: src/olympia/devhub/templates/devhub/addons/listing/items.html:25
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:15
+#: src/olympia/devhub/templates/devhub/index.html:86 src/olympia/devhub/templates/devhub/addons/listing/items.html:25 src/olympia/devhub/templates/devhub/includes/addon_details.html:20
 #: src/olympia/devhub/templates/devhub/personas/edit.html:43
 msgid "Status:"
 msgstr "Статус:"
 
-#: src/olympia/devhub/templates/devhub/index.html:90
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:100
+#: src/olympia/devhub/templates/devhub/index.html:90 src/olympia/devhub/templates/devhub/includes/addon_details.html:87
 msgid "Visibility:"
 msgstr "Видимость:"
 
@@ -5145,21 +4132,16 @@ msgstr "Видимость:"
 msgid "Latest Version:"
 msgstr "Последняя версия:"
 
-#: src/olympia/devhub/templates/devhub/index.html:109
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:145
-#: src/olympia/devhub/templates/devhub/personas/edit.html:49
+#: src/olympia/devhub/templates/devhub/index.html:109 src/olympia/devhub/templates/devhub/includes/addon_details.html:131 src/olympia/devhub/templates/devhub/personas/edit.html:49
 msgid "Queue Position:"
 msgstr "Позиция в очереди:"
 
-#: src/olympia/devhub/templates/devhub/index.html:110
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:146
-#: src/olympia/devhub/templates/devhub/personas/edit.html:50
+#: src/olympia/devhub/templates/devhub/index.html:110 src/olympia/devhub/templates/devhub/includes/addon_details.html:132 src/olympia/devhub/templates/devhub/personas/edit.html:50
 #, python-format
 msgid "%(position)s of %(total)s"
 msgstr "%(position)s из %(total)s"
 
-#: src/olympia/devhub/templates/devhub/index.html:120
-#: src/olympia/devhub/templates/devhub/includes/addons_edit_nav.html:19
+#: src/olympia/devhub/templates/devhub/index.html:120 src/olympia/devhub/templates/devhub/includes/addons_edit_nav.html:19
 msgid "Upload New Version"
 msgstr "Загрузить новую версию"
 
@@ -5173,12 +4155,8 @@ msgstr "Публикуйте ваши дополнения!"
 
 #: src/olympia/devhub/templates/devhub/index.html:136
 #, python-format
-msgid ""
-"Upload an <a href=\"%(addon_url)s\">add-on</a> or <a "
-"href=\"%(theme_url)s\">theme</a> to get started!"
-msgstr ""
-"Чтобы начать, загрузите <a href=\"%(addon_url)s\">дополнение</a> или <a "
-"href=\"%(theme_url)s\">тему</a>!"
+msgid "Upload an <a href=\"%(addon_url)s\">add-on</a> or <a href=\"%(theme_url)s\">theme</a> to get started!"
+msgstr "Чтобы начать, загрузите <a href=\"%(addon_url)s\">дополнение</a> или <a href=\"%(theme_url)s\">тему</a>!"
 
 #: src/olympia/devhub/templates/devhub/nav.html:2
 msgid "Return to the DevHub homepage"
@@ -5205,17 +4183,10 @@ msgstr "Разработка расширения"
 msgid "Lightweight Themes"
 msgstr "Лёгкие темы"
 
-#: src/olympia/devhub/templates/devhub/nav.html:39
-#: src/olympia/devhub/templates/devhub/docs/policies-agreement.html:6
-#: src/olympia/devhub/templates/devhub/docs/policies-contact.html:6
-#: src/olympia/devhub/templates/devhub/docs/policies-maintenance.html:6
-#: src/olympia/devhub/templates/devhub/docs/policies-recommended.html:6
-#: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:6
-#: src/olympia/devhub/templates/devhub/docs/policies-submission.html:6
-#: src/olympia/devhub/templates/devhub/docs/policies.html:3
-#: src/olympia/devhub/templates/devhub/docs/policies.html:9
-#: src/olympia/devhub/templates/devhub/docs/policies.html:38
-#: src/olympia/devhub/templates/devhub/docs/policies.html:39
+#: src/olympia/devhub/templates/devhub/nav.html:39 src/olympia/devhub/templates/devhub/docs/policies-agreement.html:6 src/olympia/devhub/templates/devhub/docs/policies-contact.html:6
+#: src/olympia/devhub/templates/devhub/docs/policies-maintenance.html:6 src/olympia/devhub/templates/devhub/docs/policies-recommended.html:6
+#: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:6 src/olympia/devhub/templates/devhub/docs/policies-submission.html:6 src/olympia/devhub/templates/devhub/docs/policies.html:3
+#: src/olympia/devhub/templates/devhub/docs/policies.html:9 src/olympia/devhub/templates/devhub/docs/policies.html:38 src/olympia/devhub/templates/devhub/docs/policies.html:39
 msgid "Add-on Policies"
 msgstr "Политики дополнения"
 
@@ -5253,49 +4224,19 @@ msgstr "Поиск документации для разработчиков"
 
 #: src/olympia/devhub/templates/devhub/validate_addon.html:13
 msgid "Use the field below to upload your add-on package."
-msgstr ""
-"Используйте расположенное ниже поле, чтобы загрузить свой пакет дополнения."
+msgstr "Используйте расположенное ниже поле, чтобы загрузить свой пакет дополнения."
 
 #: src/olympia/devhub/templates/devhub/validate_addon.html:19
-msgid ""
-"After upload, a series of automated validation tests will run to check "
-"compatibility with the following application version:"
-msgstr ""
-"После загрузки будет запущена серия автоматических валидирующих тестов, "
-"которые проверят совместимость со следующей версией приложения:"
+msgid "After upload, a series of automated validation tests will run to check compatibility with the following application version:"
+msgstr "После загрузки будет запущена серия автоматических валидирующих тестов, которые проверят совместимость со следующей версией приложения:"
 
 #: src/olympia/devhub/templates/devhub/validate_addon.html:34
-msgid ""
-"After upload, a series of automated validation tests will be run on your "
-"file."
-msgstr ""
-"После загрузки над вашим файлом будет проведена серия автоматических "
-"валидирующих тестов."
+msgid "After upload, a series of automated validation tests will be run on your file."
+msgstr "После загрузки над вашим файлом будет проведена серия автоматических валидирующих тестов."
 
-#: src/olympia/devhub/templates/devhub/validate_addon.html:42
-#: src/olympia/devhub/templates/devhub/addons/submit/upload.html:23
+#: src/olympia/devhub/templates/devhub/validate_addon.html:42 src/olympia/devhub/templates/devhub/addons/submit/upload.html:23
 msgid "Do you want your add-on to be distributed on this site?"
 msgstr "Вы хотите распространять своё дополнение с этого сайта?"
-
-#: src/olympia/devhub/templates/devhub/validate_addon.html:49
-#: src/olympia/devhub/templates/devhub/addons/submit/upload.html:30
-#: src/olympia/devhub/templates/devhub/versions/add_file_modal.html:14
-#: src/olympia/devhub/templates/devhub/versions/add_file_modal.html:53
-#: src/olympia/devhub/templates/devhub/versions/list.html:298
-msgid "Warning:"
-msgstr "Внимание:"
-
-#: src/olympia/devhub/templates/devhub/validate_addon.html:50
-#: src/olympia/devhub/templates/devhub/addons/submit/upload.html:31
-#, python-format
-msgid ""
-"Submission of unlisted add-ons for signing is currently in an open beta. "
-"Please <a href=\"%(url)s\" target=\"_blank\">report any bugs</a> that you "
-"encounter."
-msgstr ""
-"Подписывание неподписанных дополнений в настоящее время находится в открытом"
-" бета-тестировании. Пожалуйста, <a href=\"%(url)s\" "
-"target=\"_blank\">сообщайте о любых найденных вами ошибках</a>."
 
 #. first parameter is a filename like lorem-ipsum-1.0.2.xpi
 #: src/olympia/devhub/templates/devhub/validation.html:5
@@ -5314,14 +4255,11 @@ msgstr "Валидировано в:"
 msgid "Tested for compatibility against:"
 msgstr "Протестировано на совместимость на:"
 
-#: src/olympia/devhub/templates/devhub/addons/activity.html:4
-#: src/olympia/devhub/templates/devhub/addons/activity.html:20
+#: src/olympia/devhub/templates/devhub/addons/activity.html:4 src/olympia/devhub/templates/devhub/addons/activity.html:20
 msgid "Recent Activity for My Add-ons"
 msgstr "Последние действия для моих дополнений"
 
-#: src/olympia/devhub/templates/devhub/addons/activity.html:14
-#: src/olympia/devhub/templates/devhub/addons/activity.html:19
-#: src/olympia/devhub/templates/devhub/addons/dashboard.html:33
+#: src/olympia/devhub/templates/devhub/addons/activity.html:14 src/olympia/devhub/templates/devhub/addons/activity.html:19 src/olympia/devhub/templates/devhub/addons/dashboard.html:33
 msgid "Recent Activity"
 msgstr "Последние действия"
 
@@ -5343,45 +4281,34 @@ msgstr "Уточнить активность"
 msgid "Activity"
 msgstr "Активность"
 
-#: src/olympia/devhub/templates/devhub/addons/activity.html:83
-#: src/olympia/devhub/templates/devhub/addons/dashboard.html:34
-#: src/olympia/devhub/templates/devhub/addons/dashboard.html:35
-#: src/olympia/devhub/templates/devhub/includes/blog_posts.html:4
-#: src/olympia/devhub/templates/devhub/includes/blog_posts.html:6
+#: src/olympia/devhub/templates/devhub/addons/activity.html:83 src/olympia/devhub/templates/devhub/addons/dashboard.html:34 src/olympia/devhub/templates/devhub/addons/dashboard.html:35
+#: src/olympia/devhub/templates/devhub/includes/blog_posts.html:4 src/olympia/devhub/templates/devhub/includes/blog_posts.html:6
 msgid "Subscribe to this feed"
 msgstr "Подписаться на эту ленту"
 
 #: src/olympia/devhub/templates/devhub/addons/ajax_compat_error.html:7
 #, python-format
 msgid ""
-"This add-on is incompatible with <b>%(app_name)s %(app_version)s</b>, the "
-"latest release of %(app_name)s. Please consider updating your add-on's "
-"compatibility info, or uploading a newer version of this add-on."
+"This add-on is incompatible with <b>%(app_name)s %(app_version)s</b>, the latest release of %(app_name)s. Please consider updating your add-on's compatibility info, or uploading a newer version of "
+"this add-on."
 msgstr ""
-"Это дополнение несовместимо с <b>%(app_name)s %(app_version)s</b>, последней"
-" версией %(app_name)s. Просьба рассмотреть вопрос об обновлении информации о"
-" совместимости вашего дополнения, или загрузки новой версии этого "
-"дополнения."
+"Это дополнение несовместимо с <b>%(app_name)s %(app_version)s</b>, последней версией %(app_name)s. Просьба рассмотреть вопрос об обновлении информации о совместимости вашего дополнения, или "
+"загрузки новой версии этого дополнения."
 
 #: src/olympia/devhub/templates/devhub/addons/ajax_compat_error.html:15
 #, python-format
 msgid ""
-"<a href=\"#\" class=\"button compat-update\" data-"
-"updateurl=\"%(update_url)s\">Update Compatibility</a> <a "
-"href=\"%(version_url)s\" class=\"button\">Upload New Version</a> or <a "
-"href=\"#\" class=\"close\">Ignore</a>"
+"<a href=\"#\" class=\"button compat-update\" data-updateurl=\"%(update_url)s\">Update Compatibility</a> <a href=\"%(version_url)s\" class=\"button\">Upload New Version</a> or <a href=\"#\" class="
+"\"close\">Ignore</a>"
 msgstr ""
-"<a href=\"#\" class=\"button compat-update\" data-"
-"updateurl=\"%(update_url)s\">Обновить совместимость</a> <a "
-"href=\"%(version_url)s\" class=\"button\">Загрузить новую версию</a> или <a "
-"href=\"#\" class=\"close\">Игнорировать</a>"
+"<a href=\"#\" class=\"button compat-update\" data-updateurl=\"%(update_url)s\">Обновить совместимость</a> <a href=\"%(version_url)s\" class=\"button\">Загрузить новую версию</a> или <a href=\"#\" "
+"class=\"close\">Игнорировать</a>"
 
 #: src/olympia/devhub/templates/devhub/addons/ajax_compat_status.html:5
 msgid "View and update application compatibility ranges."
 msgstr "Просмотреть и обновить диапазоны совместимости приложений."
 
-#: src/olympia/devhub/templates/devhub/addons/ajax_compat_status.html:6
-#: src/olympia/devhub/templates/devhub/versions/edit.html:44
+#: src/olympia/devhub/templates/devhub/addons/ajax_compat_status.html:6 src/olympia/devhub/templates/devhub/versions/edit.html:44
 msgid "Compatibility"
 msgstr "Совместимость"
 
@@ -5389,39 +4316,25 @@ msgstr "Совместимость"
 msgid "Update Compatibility"
 msgstr "Обновить совместимость"
 
-#: src/olympia/devhub/templates/devhub/addons/ajax_compat_update.html:4
-msgid ""
-"Adjusting application information here will allow users to install your add-"
-"on even if the install manifest in the package indicates that the add-on is "
-"incompatible."
-msgstr ""
-"Настройка здесь информации о приложении позволит пользователям установить "
-"ваше дополнение, даже если манифест установки в пакете указывает, что "
-"дополнение несовместимо."
+#: src/olympia/devhub/templates/devhub/addons/ajax_compat_update.html:4 src/olympia/devhub/templates/devhub/versions/edit.html:45
+msgid "Adjusting application information here will allow users to install your add-on even if the install manifest in the package indicates that the add-on is incompatible."
+msgstr "Настройка здесь информации о приложении позволит пользователям установить ваше дополнение, даже если манифест установки в пакете указывает, что дополнение несовместимо."
 
 #: src/olympia/devhub/templates/devhub/addons/ajax_compat_update.html:18
 msgid "Supported Versions"
 msgstr "Поддерживаемые версии"
 
-#: src/olympia/devhub/templates/devhub/addons/ajax_compat_update.html:31
-#: src/olympia/devhub/templates/devhub/versions/edit.html:63
+#: src/olympia/devhub/templates/devhub/addons/ajax_compat_update.html:31 src/olympia/devhub/templates/devhub/versions/edit.html:63
 msgid "Add Another Application&hellip;"
 msgstr "Добавить другое приложение&hellip;"
 
-#: src/olympia/devhub/templates/devhub/addons/ajax_compat_update.html:38
-#: src/olympia/devhub/templates/devhub/addons/owner.html:86
-#: src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:46
-#: src/olympia/devhub/templates/devhub/versions/list.html:351
-#: src/olympia/devhub/templates/devhub/versions/list.html:353
-#: src/olympia/templates/impala/base.html:132
-#: src/olympia/templates/impala/base.html:143
-#: src/olympia/templates/impala/base.html:161
-#: src/olympia/templates/impala/base.html:171
+#: src/olympia/devhub/templates/devhub/addons/ajax_compat_update.html:38 src/olympia/devhub/templates/devhub/addons/owner.html:86 src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:45
+#: src/olympia/devhub/templates/devhub/versions/list.html:349 src/olympia/devhub/templates/devhub/versions/list.html:351 src/olympia/templates/impala/base.html:129
+#: src/olympia/templates/impala/base.html:140 src/olympia/templates/impala/base.html:158 src/olympia/templates/impala/base.html:168
 msgid "Close"
 msgstr "Закрыть"
 
-#: src/olympia/devhub/templates/devhub/addons/dashboard.html:43
-#: src/olympia/zadmin/templates/zadmin/index.html:22
+#: src/olympia/devhub/templates/devhub/addons/dashboard.html:43 src/olympia/zadmin/templates/zadmin/index.html:22
 #, python-format
 msgid "%(ago)s by %(user)s"
 msgstr "%(ago)s от %(user)s"
@@ -5436,31 +4349,22 @@ msgid "<b>{0}</b> theme"
 msgid_plural "<b>{0}</b> themes"
 msgstr[0] "<b>{0}</b> тема"
 msgstr[1] "<b>{0}</b> темы"
-msgstr[2] "<b>{0}</b> тем"
 
-#: src/olympia/devhub/templates/devhub/addons/edit.html:3
-#: src/olympia/devhub/templates/devhub/addons/listing/item_actions.html:25
-#: src/olympia/devhub/templates/devhub/addons/listing/item_actions_theme.html:7
-#: src/olympia/devhub/templates/devhub/includes/addons_edit_nav.html:2
-#: src/olympia/devhub/templates/devhub/personas/edit.html:6
-#: src/olympia/editors/templates/editors/themes/single.html:37
+#: src/olympia/devhub/templates/devhub/addons/edit.html:3 src/olympia/devhub/templates/devhub/addons/listing/item_actions.html:25
+#: src/olympia/devhub/templates/devhub/addons/listing/item_actions_theme.html:7 src/olympia/devhub/templates/devhub/includes/addons_edit_nav.html:2
+#: src/olympia/devhub/templates/devhub/personas/edit.html:6 src/olympia/editors/templates/editors/themes/single.html:37
 msgid "Edit Listing"
 msgstr "Редактировать страницу"
 
-#: src/olympia/devhub/templates/devhub/addons/edit.html:13
-#: src/olympia/devhub/templates/devhub/includes/macros.html:18
-#: src/olympia/translations/templates/translations/all-locales.html:6
+#: src/olympia/devhub/templates/devhub/addons/edit.html:13 src/olympia/devhub/templates/devhub/includes/macros.html:18 src/olympia/translations/templates/translations/all-locales.html:6
 msgid "None"
 msgstr "Нет"
 
-#: src/olympia/devhub/templates/devhub/addons/owner.html:4
-#: src/olympia/devhub/templates/devhub/addons/listing/item_actions.html:52
-#: src/olympia/devhub/templates/devhub/includes/addons_edit_nav.html:3
+#: src/olympia/devhub/templates/devhub/addons/owner.html:4 src/olympia/devhub/templates/devhub/addons/listing/item_actions.html:52 src/olympia/devhub/templates/devhub/includes/addons_edit_nav.html:3
 msgid "Manage Authors & License"
 msgstr "Управление авторами и лицензией"
 
-#: src/olympia/devhub/templates/devhub/addons/owner.html:29
-#: src/olympia/editors/templates/editors/review.html:270
+#: src/olympia/devhub/templates/devhub/addons/owner.html:29 src/olympia/editors/helpers.py:362 src/olympia/editors/templates/editors/review.html:270
 msgid "Authors"
 msgstr "Авторы"
 
@@ -5470,35 +4374,22 @@ msgstr "О ролях автора"
 
 #: src/olympia/devhub/templates/devhub/addons/owner.html:78
 msgid ""
-"<p>Add-ons can have any number of authors with 3 possible roles:</p> <ul> "
-"<li><b>Owner:</b> Can manage all aspects of the add-on's listing, including "
-"adding and removing other authors</li> <li><b>Developer:</b> Can manage all "
-"aspects of the add-on's listing, except for adding and removing other "
-"authors and managing payments</li> <li><b>Viewer:</b> Can view the add-on's "
-"settings and statistics, but cannot make any changes</li> </ul>"
+"<p>Add-ons can have any number of authors with 3 possible roles:</p> <ul> <li><b>Owner:</b> Can manage all aspects of the add-on's listing, including adding and removing other authors</li> "
+"<li><b>Developer:</b> Can manage all aspects of the add-on's listing, except for adding and removing other authors and managing payments</li> <li><b>Viewer:</b> Can view the add-on's settings and "
+"statistics, but cannot make any changes</li> </ul>"
 msgstr ""
-"<p>Дополнения могут иметь любое количество авторов с 3 возможными "
-"ролями:</p> <ul> <li><b>Владелец:</b> Может управлять всеми аспектами "
-"размещения дополнения, включая добавление и удаление других авторов</li> "
-"<li><b>Разработчик:</b> Может управлять всеми аспектами размещения  "
-"дополнения, кроме добавления и удаления других авторов и управления "
-"платежами</li> <li><b>Просматривающий:</b> Может просматривать настройки и "
-"статистику дополнения, но не может вносить никаких изменений</li></ul>"
+"<p>Дополнения могут иметь любое количество авторов с 3 возможными ролями:</p> <ul> <li><b>Владелец:</b> Может управлять всеми аспектами размещения дополнения, включая добавление и удаление других "
+"авторов</li> <li><b>Разработчик:</b> Может управлять всеми аспектами размещения  дополнения, кроме добавления и удаления других авторов и управления платежами</li> <li><b>Просматривающий:</b> Может "
+"просматривать настройки и статистику дополнения, но не может вносить никаких изменений</li></ul>"
 
-#: src/olympia/devhub/templates/devhub/addons/profile.html:3
-#: src/olympia/devhub/templates/devhub/addons/listing/item_actions.html:53
-#: src/olympia/devhub/templates/devhub/includes/addons_edit_nav.html:4
+#: src/olympia/devhub/templates/devhub/addons/profile.html:3 src/olympia/devhub/templates/devhub/addons/listing/item_actions.html:53 src/olympia/devhub/templates/devhub/includes/addons_edit_nav.html:4
 msgid "Manage Developer Profile"
 msgstr "Управление профилем разработчика"
 
 #: src/olympia/devhub/templates/devhub/addons/profile.html:16
 #, python-format
-msgid ""
-"Your <a href=\"%(url)s\">developer profile</a> is currently "
-"<strong>public</strong> and <strong>required</strong> for contributions."
-msgstr ""
-"Ваш <a href=\"%(url)s\">профиль разработчика</a> в настоящее время является "
-"<strong>публичным</strong> и <strong>требуется</strong> для сбора взносов."
+msgid "Your <a href=\"%(url)s\">developer profile</a> is currently <strong>public</strong> and <strong>required</strong> for contributions."
+msgstr "Ваш <a href=\"%(url)s\">профиль разработчика</a> в настоящее время является <strong>публичным</strong> и <strong>требуется</strong> для сбора взносов."
 
 #: src/olympia/devhub/templates/devhub/addons/profile.html:22
 msgid "Remove Both"
@@ -5506,12 +4397,8 @@ msgstr "Удалить оба"
 
 #: src/olympia/devhub/templates/devhub/addons/profile.html:27
 #, python-format
-msgid ""
-"Your <a href=\"%(url)s\">developer profile</a> is currently "
-"<strong>public</strong>."
-msgstr ""
-"Ваш <a href=\"%(url)s\">профиль разработчика</a> в настоящее время является "
-"<strong>публичным</strong>."
+msgid "Your <a href=\"%(url)s\">developer profile</a> is currently <strong>public</strong>."
+msgstr "Ваш <a href=\"%(url)s\">профиль разработчика</a> в настоящее время является <strong>публичным</strong>."
 
 #: src/olympia/devhub/templates/devhub/addons/profile.html:33
 msgid "Remove Profile"
@@ -5538,11 +4425,8 @@ msgstr "URL дополнения"
 msgid "Choose a short, unique URL slug for your add-on."
 msgstr "Выберите короткий, уникальный URL slug для вашего дополнения."
 
-#: src/olympia/devhub/templates/devhub/addons/edit/basic.html:43
-#: src/olympia/devhub/templates/devhub/includes/addons_edit_nav.html:35
-#: src/olympia/devhub/templates/devhub/personas/edit.html:56
-#: src/olympia/editors/templates/editors/review.html:255
-#: src/olympia/editors/templates/editors/themes/single.html:33
+#: src/olympia/devhub/templates/devhub/addons/edit/basic.html:43 src/olympia/devhub/templates/devhub/includes/addons_edit_nav.html:35 src/olympia/devhub/templates/devhub/personas/edit.html:56
+#: src/olympia/editors/templates/editors/review.html:255 src/olympia/editors/templates/editors/themes/single.html:33
 msgid "View Listing"
 msgstr "Просмотреть его страницу"
 
@@ -5552,10 +4436,7 @@ msgstr "Сводка"
 
 #: src/olympia/devhub/templates/devhub/addons/edit/basic.html:52
 msgid ""
-"A short explanation of your add-on's basic\n"
-"                          functionality that is displayed in search and browse\n"
-"                          listings, as well as at the top of your add-on's\n"
-"                          details page. It is only relevant for listed add-ons."
+"A short explanation of your add-on's basic functionality that is displayed in search and browse listings, as well as at the top of your add-on's details page. It is only relevant for listed add-ons."
 msgstr ""
 "Короткое объяснение базовой функциональности вашего\n"
 "                          дополнения, которое отображается в поиске и страницах,\n"
@@ -5563,10 +4444,7 @@ msgstr ""
 "                          Это относится только к опубликованным дополнениям."
 
 #: src/olympia/devhub/templates/devhub/addons/edit/basic.html:73
-msgid ""
-"Categories are the primary way users browse through add-ons.\n"
-"                        Choose any that fit your add-on's functionality for the most\n"
-"                        exposure. It is only relevant for listed add-ons."
+msgid "Categories are the primary way users browse through add-ons. Choose any that fit your add-on's functionality for the most exposure. It is only relevant for listed add-ons."
 msgstr ""
 "Категории - основной критерий, по которому пользователи просматривают дополнения.\n"
 "                        Выберите любую, которая наилучшим образом соответствует функциональности\n"
@@ -5575,37 +4453,24 @@ msgstr ""
 #: src/olympia/devhub/templates/devhub/addons/edit/basic.html:90
 #, python-format
 msgid ""
-"Categories cannot be changed while your add-on is featured for this "
-"application. Please email <a href=\"mailto:%(email)s\">%(email)s</a> if "
-"there is a reason you need to modify your categories."
+"Categories cannot be changed while your add-on is featured for this application. Please email <a href=\"mailto:%(email)s\">%(email)s</a> if there is a reason you need to modify your categories."
 msgstr ""
-"Если ваше дополнение для этого приложения является Избранным, его категории "
-"не могут быть изменены. Если у вас есть причина, по которой вам нужно "
-"изменить ваши категории, пожалуйста, напишите по <a "
+"Если ваше дополнение для этого приложения является Избранным, его категории не могут быть изменены. Если у вас есть причина, по которой вам нужно изменить ваши категории, пожалуйста, напишите по <a "
 "href=\"mailto:%(email)s\">%(email)s</a>."
 
 #: src/olympia/devhub/templates/devhub/addons/edit/basic.html:119
-msgid ""
-"Tags help users find your add-on and should be short descriptors such as "
-"tabs, toolbar, or twitter. You may have a maximum of {0} tags. It is only "
-"relevant for listed add-ons."
+msgid "Tags help users find your add-on and should be short descriptors such as tabs, toolbar, or twitter. You may have a maximum of {0} tags. It is only relevant for listed add-ons."
 msgstr ""
-"Метки помогают пользователям найти ваше дополнение и должны быть кратким "
-"описанием, таким как вкладки, панели или твиттер. Вы можете иметь максимум "
-"{0} меток. Это относится только к дополнениям, находящимся в списке."
+"Метки помогают пользователям найти ваше дополнение и должны быть кратким описанием, таким как вкладки, панели или твиттер. Вы можете иметь максимум {0} меток. Это относится только к дополнениям, "
+"находящимся в списке."
 
-#: src/olympia/devhub/templates/devhub/addons/edit/basic.html:129
-#: src/olympia/devhub/templates/devhub/personas/edit.html:97
-#: src/olympia/devhub/templates/devhub/personas/submit.html:46
+#: src/olympia/devhub/templates/devhub/addons/edit/basic.html:129 src/olympia/devhub/templates/devhub/personas/edit.html:97 src/olympia/devhub/templates/devhub/personas/submit.html:46
 msgid "Comma-separated, minimum of {0} character."
 msgid_plural "Comma-separated, minimum of {0} characters."
 msgstr[0] "Разделённые запятыми, не менее {0} символа."
 msgstr[1] "Разделённые запятыми, не менее {0} символов."
-msgstr[2] "Разделённые запятыми, не менее {0} символов."
 
-#: src/olympia/devhub/templates/devhub/addons/edit/basic.html:132
-#: src/olympia/devhub/templates/devhub/personas/edit.html:100
-#: src/olympia/devhub/templates/devhub/personas/submit.html:49
+#: src/olympia/devhub/templates/devhub/addons/edit/basic.html:132 src/olympia/devhub/templates/devhub/personas/edit.html:100 src/olympia/devhub/templates/devhub/personas/submit.html:49
 msgid "Example: dark, cinema, noir. Limit 20."
 msgstr "Пример: темное, кино, нуар. Предел 20."
 
@@ -5614,7 +4479,6 @@ msgid "Reserved tag:"
 msgid_plural "Reserved tags:"
 msgstr[0] "Зарезервированная метка:"
 msgstr[1] "Зарезервированные метки:"
-msgstr[2] "Зарезервированные метки:"
 
 #: src/olympia/devhub/templates/devhub/addons/edit/details.html:5
 msgid "Add-on Details"
@@ -5625,46 +4489,33 @@ msgid "Add-on Details for {0}"
 msgstr "Информация о дополнении для {0}"
 
 #: src/olympia/devhub/templates/devhub/addons/edit/details.html:22
-msgid ""
-"A longer explanation of features,\n"
-"                          functionality, and other relevant information. This\n"
-"                          field is only displayed on the add-on's details\n"
-"                          page. It is only relevant for listed add-ons."
+msgid "A longer explanation of features, functionality, and other relevant information. This field is only displayed on the add-on's details page. It is only relevant for listed add-ons."
 msgstr ""
 "Длинное описание возможностей,\n"
 "                          функциональности, и другой релеватной информации.\n"
 "                          Это поле отображается только на странице деталей дополнения.\n"
 "                          Это относится только к опубликованным дополнениям."
 
-#: src/olympia/devhub/templates/devhub/addons/edit/details.html:44
-#: src/olympia/translations/templates/translations/trans-menu.html:13
+#: src/olympia/devhub/templates/devhub/addons/edit/details.html:44 src/olympia/translations/templates/translations/trans-menu.html:13
 msgid "Default Locale"
 msgstr "Локаль по умолчанию"
 
 #: src/olympia/devhub/templates/devhub/addons/edit/details.html:45
-msgid ""
-"Information about your add-on is displayed in this locale\n"
-"                        unless you override it with a locale-specific translation.\n"
-"                        It is only relevant for listed add-ons."
+msgid "Information about your add-on is displayed in this locale unless you override it with a locale-specific translation. It is only relevant for listed add-ons."
 msgstr ""
 "Информация о вашем дополнении, отображаемая в этой локали,\n"
 "                        хотя вы можете переопределять её переводом на другой язык.\n"
 "                        Это относится только к опубликованным дополнениям."
 
-#: src/olympia/devhub/templates/devhub/addons/edit/details.html:61
-#: src/olympia/users/forms.py:311
-#: src/olympia/users/templates/users/edit.html:122
-#: src/olympia/users/templates/users/register.html:57
+#: src/olympia/devhub/templates/devhub/addons/edit/details.html:61 src/olympia/users/forms.py:311 src/olympia/users/templates/users/edit.html:122 src/olympia/users/templates/users/register.html:57
 #: src/olympia/users/templates/users/vcard.html:22
 msgid "Homepage"
 msgstr "Домашняя страница"
 
 #: src/olympia/devhub/templates/devhub/addons/edit/details.html:63
 msgid ""
-"If your add-on has another homepage, enter its\n"
-"                          address here. If your website is localized into other\n"
-"                          languages multiple translations of this field can be\n"
-"                          added. It is only relevant for listed add-ons."
+"If your add-on has another homepage, enter its address here. If your website is localized into other languages multiple translations of this field can be added. It is only relevant for listed add-"
+"ons."
 msgstr ""
 "Если у вашего дополнения другая домашняя страница, введите её\n"
 "                          адрес здесь. Если ваш сайт переведён на другие\n"
@@ -5686,11 +4537,8 @@ msgstr "Информация о поддержке для {0}"
 
 #: src/olympia/devhub/templates/devhub/addons/edit/support.html:22
 msgid ""
-"If you wish to display an e-mail address for support\n"
-"                          inquiries, enter it here. If you have different\n"
-"                          addresses for each language multiple translations of\n"
-"                          this field can be added. It is only relevant for\n"
-"                          listed add-ons."
+"If you wish to display an e-mail address for support inquiries, enter it here. If you have different addresses for each language multiple translations of this field can be added. It is only "
+"relevant for listed add-ons."
 msgstr ""
 "Если вы хотите отобразить адрес электронной почты для поддержки,\n"
 "                          введите его здесь. Если у вас есть различные адреса\n"
@@ -5700,10 +4548,8 @@ msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/support.html:45
 msgid ""
-"If your add-on has a support website or forum, enter\n"
-"                          its address here. If your website is localized into\n"
-"                          other languages, multiple translations of this field can\n"
-"                          be added. It is only relevant for listed add-ons."
+"If your add-on has a support website or forum, enter its address here. If your website is localized into other languages, multiple translations of this field can be added. It is only relevant for "
+"listed add-ons."
 msgstr ""
 "Если у вашего дополнения есть сайт поддержки или форум, введите\n"
 "                          его адрес здесь. Если ваш сайт переведён на\n"
@@ -5721,16 +4567,11 @@ msgstr "Технические детали для {0}"
 
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:23
 msgid ""
-"Any information end users may want to know that isn't necessarily applicable"
-" to the add-on summary or description. Common uses include listing known "
-"major bugs, information on how to report bugs, anticipated release date of a"
-" new version, etc. It is only relevant for listed add-ons."
+"Any information end users may want to know that isn't necessarily applicable to the add-on summary or description. Common uses include listing known major bugs, information on how to report bugs, "
+"anticipated release date of a new version, etc. It is only relevant for listed add-ons."
 msgstr ""
-"Любая информация, которую возможно захотят узнать конечные пользователи, но "
-"которой не место в сводке или описании дополнения. Обычно используется для "
-"сведений о серьёзных ошибках, о том как сообщать об ошибках, предполагаемой "
-"дате выпуска новой версии и т.д. Это относится только к дополнениям, "
-"находящимся в списке."
+"Любая информация, которую возможно захотят узнать конечные пользователи, но которой не место в сводке или описании дополнения. Обычно используется для сведений о серьёзных ошибках, о том как "
+"сообщать об ошибках, предполагаемой дате выпуска новой версии и т.д. Это относится только к дополнениям, находящимся в списке."
 
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:46
 msgid "Limit 3"
@@ -5741,9 +4582,7 @@ msgid "Add-on Flags"
 msgstr "Флаги дополнения"
 
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:69
-msgid ""
-"These flags are used to classify add-ons. It is only\n"
-"                        relevant for listed add-ons."
+msgid "These flags are used to classify add-ons. It is only relevant for listed add-ons."
 msgstr ""
 "Эти флаги используются для классификации дополнений. Это относится только\n"
 "                         к дополнениям, видным на сайте."
@@ -5761,9 +4600,7 @@ msgid "View Source?"
 msgstr "Показывать исходник?"
 
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:90
-msgid ""
-"Whether the source of your add-on can be displayed in our\n"
-"                        online viewer. It is only relevant for listed add-ons."
+msgid "Whether the source of your add-on can be displayed in our online viewer. It is only relevant for listed add-ons."
 msgstr ""
 "Может ли источник вашего дополнения отображаться в нашем\n"
 "                        средстве онлайн-просмотра. Это относится только к дополнениям, видным на сайте."
@@ -5781,14 +4618,8 @@ msgid "Public Stats?"
 msgstr "Публичная статистика?"
 
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:102
-msgid ""
-"Whether the download and usage stats of your add-on can\n"
-"                        be displayed in our online viewer.\n"
-"                        It is only relevant for listed add-ons."
-msgstr ""
-"Может ли статистика загрузок или использования вашего дополнения "
-"отображаться в нашем средстве онлайн-просмотра. Это относится только к "
-"дополнениям, видным на сайте."
+msgid "Whether the download and usage stats of your add-on can be displayed in our online viewer. It is only relevant for listed add-ons."
+msgstr "Может ли статистика загрузок или использования вашего дополнения отображаться в нашем средстве онлайн-просмотра. Это относится только к дополнениям, видным на сайте."
 
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:107
 msgid "This add-on's stats are publicly viewable."
@@ -5796,29 +4627,22 @@ msgstr "Статистика этого дополнения доступна д
 
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:109
 msgid "No, this add-on's stats are not publicly viewable."
-msgstr ""
-"Нет, статистика этого дополнения не доступна для публичного просмотра."
+msgstr "Нет, статистика этого дополнения не доступна для публичного просмотра."
 
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:115
 msgid "Upgrade SDK?"
 msgstr "Обновлять SDK?"
 
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:116
-msgid ""
-"If selected, we will try to automatically upgrade your\n"
-"                        add-on when a new version of the SDK is released.\n"
-"                        It is only relevant for listed add-ons."
+msgid "If selected, we will try to automatically upgrade your add-on when a new version of the SDK is released. It is only relevant for listed add-ons."
 msgstr ""
 "Если выбрано, мы попытаемся автоматически обновить ваше\n"
 "                        дополнение при выходе новой версии SDK.\n"
 "                        Это относится только к опубликованным дополнениям."
 
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:121
-msgid ""
-"This add-on will be automatically upgraded to new versions of the Add-on "
-"SDK."
-msgstr ""
-"Это дополнение будет автоматически обновлено на новые версии SDL дополнений."
+msgid "This add-on will be automatically upgraded to new versions of the Add-on SDK."
+msgstr "Это дополнение будет автоматически обновлено на новые версии SDL дополнений."
 
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:123
 msgid "No, this add-on will be upgraded manually."
@@ -5833,30 +4657,20 @@ msgid "UUID"
 msgstr "UUID"
 
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:132
-msgid ""
-"The UUID of your add-on is specified in its install manifest and uniquely "
-"identifies it. You cannot change your UUID once it has been submitted."
-msgstr ""
-"UUID вашего дополнения указан в его манифесте установки и является его "
-"уникальным идентификатором. После его отправки вы не сможете изменить UUID."
+msgid "The UUID of your add-on is specified in its install manifest and uniquely identifies it. You cannot change your UUID once it has been submitted."
+msgstr "UUID вашего дополнения указан в его манифесте установки и является его уникальным идентификатором. После его отправки вы не сможете изменить UUID."
 
-#: src/olympia/devhub/templates/devhub/addons/edit/technical.html:143
-#: src/olympia/devhub/templates/devhub/addons/edit/technical.html:144
+#: src/olympia/devhub/templates/devhub/addons/edit/technical.html:143 src/olympia/devhub/templates/devhub/addons/edit/technical.html:144
 msgid "Whiteboard"
 msgstr "Белая доска"
 
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:146
 msgid ""
-"The whiteboard is the place to provide information relevant to your addon, "
-"whatever the version, to the editor. Use it to provide ways to test the "
-"addon, and any additional information that may help. This whiteboard is also"
-" editable by editors."
+"The whiteboard is the place to provide information relevant to your addon, whatever the version, to the editor. Use it to provide ways to test the addon, and any additional information that may "
+"help. This whiteboard is also editable by editors."
 msgstr ""
-"Белая доска является местом для предоставления информации, относящейся к "
-"вашему дополнению, независимо от версии, редактору. Используйте её, чтобы "
-"обеспечить тестирование дополнения, и для размещения любой дополнительной "
-"информации, которая может помочь. Эта доска может также редактироваться "
-"редакторами."
+"Белая доска является местом для предоставления информации, относящейся к вашему дополнению, независимо от версии, редактору. Используйте её, чтобы обеспечить тестирование дополнения, и для "
+"размещения любой дополнительной информации, которая может помочь. Эта доска может также редактироваться редакторами."
 
 #: src/olympia/devhub/templates/devhub/addons/edit/technical_dependencies.html:9
 msgid "Remove this dependent add-on"
@@ -5876,10 +4690,8 @@ msgstr "Значок дополнения"
 
 #: src/olympia/devhub/templates/devhub/addons/forms_shared/media.html:16
 msgid ""
-"Upload an icon for your add-on or choose from one of ours. The\n"
-"                      icon is displayed nearly everywhere your add-on is. Uploaded images\n"
-"                      must be one of the following image types: .png, .jpg.\n"
-"                      It is only relevant for listed add-ons."
+"Upload an icon for your add-on or choose from one of ours. The icon is displayed nearly everywhere your add-on is. Uploaded images must be one of the following image types: .png, .jpg. It is only "
+"relevant for listed add-ons."
 msgstr ""
 "Загрузите иконку вашего дополнения или выберите одну из наших.\n"
 "                      Иконка отображается везде рядом с вашим дополнением. Загружаемые изображения\n"
@@ -5896,9 +4708,7 @@ msgid "32x32px"
 msgstr "32x32px"
 
 #: src/olympia/devhub/templates/devhub/addons/forms_shared/media.html:39
-msgid ""
-"Used in listings of add-ons, like search results\n"
-"                            and featured add-ons."
+msgid "Used in listings of add-ons, like search results and featured add-ons."
 msgstr ""
 "Используется в листингах дополнений, таких как результаты поиска\n"
 "                            и избранные дополнения."
@@ -5918,9 +4728,7 @@ msgstr "Загрузить другую иконку..."
 
 #: src/olympia/devhub/templates/devhub/addons/forms_shared/media.html:65
 msgid "PNG and JPG supported. Icons resized to 64x64 pixels if larger."
-msgstr ""
-"Поддерживается PNG и JPG. При необходимости размер значков будет уменьшен до"
-" 64x64 пикселей."
+msgstr "Поддерживается PNG и JPG. При необходимости размер значков будет уменьшен до 64x64 пикселей."
 
 #: src/olympia/devhub/templates/devhub/addons/forms_shared/media.html:83
 msgid "Screenshots"
@@ -5928,8 +4736,7 @@ msgstr "Скриншоты"
 
 #: src/olympia/devhub/templates/devhub/addons/forms_shared/media.html:89
 msgid "Please provide at least one screen shot of your add-on:"
-msgstr ""
-"Пожалуйста, предоставьте по крайней мере один скриншот вашего дополнения:"
+msgstr "Пожалуйста, предоставьте по крайней мере один скриншот вашего дополнения:"
 
 #: src/olympia/devhub/templates/devhub/addons/forms_shared/media.html:114
 msgid "Please provide a caption for this screenshot:"
@@ -5943,61 +4750,49 @@ msgstr "Добавить скриншот..."
 msgid "Tests"
 msgstr "Тесты"
 
-#: src/olympia/devhub/templates/devhub/addons/includes/validation_compat_test_results.html:25
-#: src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:5
+#: src/olympia/devhub/templates/devhub/addons/includes/validation_compat_test_results.html:25 src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:5
 #: src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:53
 msgid "General Tests"
 msgstr "Общие тесты"
 
-#: src/olympia/devhub/templates/devhub/addons/includes/validation_compat_test_results.html:32
-#: src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:9
+#: src/olympia/devhub/templates/devhub/addons/includes/validation_compat_test_results.html:32 src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:9
 #: src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:67
 msgid "Security Tests"
 msgstr "Тесты безопасности"
 
-#: src/olympia/devhub/templates/devhub/addons/includes/validation_compat_test_results.html:39
-#: src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:13
+#: src/olympia/devhub/templates/devhub/addons/includes/validation_compat_test_results.html:39 src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:13
 #: src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:80
 msgid "Extension Tests"
 msgstr "Тесты расширения"
 
-#: src/olympia/devhub/templates/devhub/addons/includes/validation_compat_test_results.html:46
-#: src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:17
+#: src/olympia/devhub/templates/devhub/addons/includes/validation_compat_test_results.html:46 src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:17
 #: src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:93
 msgid "Localization Tests"
 msgstr "Тесты локализации"
 
-#: src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:21
-#: src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:106
+#: src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:21 src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:106
 msgid "Compatibility Tests"
 msgstr "Тесты совместимости"
 
-#: src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:29
-#: src/olympia/files/templates/files/viewer.html:142
+#: src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:29 src/olympia/files/templates/files/viewer.html:142
 msgid "Hide messages not required for automated signing"
 msgstr "Скрыть сообщения, не требующие автоматизированного подписания."
 
-#: src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:35
-#: src/olympia/files/templates/files/viewer.html:150
+#: src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:35 src/olympia/files/templates/files/viewer.html:150
 msgid "Hide messages present in previous version and ignored"
-msgstr ""
-"Скрыть сообщения, присутствовавшие в предыдущей версии и проигнорированные"
+msgstr "Скрыть сообщения, присутствовавшие в предыдущей версии и проигнорированные"
 
-#: src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:50
-#: src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:64
-#: src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:77
-#: src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:90
+#: src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:50 src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:64
+#: src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:77 src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:90
 #: src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:103
 msgid "Top"
 msgstr "Наверх"
 
-#: src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:2
-#: src/olympia/devhub/templates/devhub/personas/edit.html:63
+#: src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:2 src/olympia/devhub/templates/devhub/personas/edit.html:63
 msgid "Delete Theme"
 msgstr "Удалить тему"
 
-#: src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:2
-#: src/olympia/devhub/templates/devhub/versions/list.html:117
+#: src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:2 src/olympia/devhub/templates/devhub/versions/list.html:117
 msgid "Delete Add-on"
 msgstr "Удалить дополнение"
 
@@ -6006,31 +4801,24 @@ msgid "Deleting your theme will permanently remove it from the site."
 msgstr "Удаление вашей темы навсегда удалит его с сайта."
 
 #: src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:14
-msgid ""
-"Deleting your add-on will permanently remove it from the site and prevent "
-"its GUID from being submitted again by others."
-msgstr ""
-"Удаление вашего дополнения навсегда удалит его с сайта и предотвратит в "
-"будущем загрузку другими его GUID."
+msgid "Deleting your add-on will permanently remove it from the site and prevent its GUID from being submitted again by others."
+msgstr "Удаление вашего дополнения навсегда удалит его с сайта и предотвратит в будущем загрузку другими его GUID."
 
 #: src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:24
-msgid ""
-"Enter the following text confirm your decision:\n"
-"           {slug}"
+msgid "Enter the following text confirm your decision: {slug}"
 msgstr ""
 "Введите следующий текст, чтобы подтвердить ваше решение:\n"
 "           {slug}"
 
-#: src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:34
+#: src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:33
 msgid "Please tell us why you are deleting your theme:"
 msgstr "Пожалуйста, расскажите нам, почему вы удаляете вашу тему:"
 
-#: src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:36
+#: src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:35
 msgid "Please tell us why you are deleting your add-on:"
 msgstr "Пожалуйста, расскажите нам, почему вы удаляете ваше дополнение:"
 
-#: src/olympia/devhub/templates/devhub/addons/listing/item_actions.html:1
-#: src/olympia/devhub/templates/devhub/addons/listing/item_actions_theme.html:1
+#: src/olympia/devhub/templates/devhub/addons/listing/item_actions.html:1 src/olympia/devhub/templates/devhub/addons/listing/item_actions_theme.html:1
 #: src/olympia/editors/templates/editors/review.html:253
 msgid "Actions"
 msgstr "Действия"
@@ -6063,22 +4851,17 @@ msgstr "Новая версия"
 msgid "Daily statistics on downloads and users."
 msgstr "Ежедневная статистика по загрузкам и пользователям."
 
-#: src/olympia/devhub/templates/devhub/addons/listing/item_actions.html:45
-#: src/olympia/stats/templates/stats/stats.html:75
-#: src/olympia/stats/templates/stats/stats.html:79
-#: src/olympia/stats/templates/stats/stats.html:81
+#: src/olympia/devhub/templates/devhub/addons/listing/item_actions.html:45 src/olympia/stats/templates/stats/stats.html:31 src/olympia/stats/templates/stats/stats.html:35
+#: src/olympia/stats/templates/stats/stats.html:37
 msgid "Statistics"
 msgstr "Статистика"
 
-#: src/olympia/devhub/templates/devhub/addons/listing/item_actions.html:54
-#: src/olympia/devhub/templates/devhub/includes/addons_edit_nav.html:5
-#: src/olympia/devhub/templates/devhub/payments/payments.html:3
-#: src/olympia/devhub/templates/devhub/payments/tier.html:4
+#: src/olympia/devhub/templates/devhub/addons/listing/item_actions.html:54 src/olympia/devhub/templates/devhub/includes/addons_edit_nav.html:5
+#: src/olympia/devhub/templates/devhub/payments/payments.html:3 src/olympia/devhub/templates/devhub/payments/tier.html:4
 msgid "Manage Payments"
 msgstr "Управление платежами"
 
-#: src/olympia/devhub/templates/devhub/addons/listing/item_actions.html:55
-#: src/olympia/devhub/templates/devhub/includes/addons_edit_nav.html:6
+#: src/olympia/devhub/templates/devhub/addons/listing/item_actions.html:55 src/olympia/devhub/templates/devhub/includes/addons_edit_nav.html:6
 msgid "Manage Status & Versions"
 msgstr "Управление статусом и версиями"
 
@@ -6086,10 +4869,8 @@ msgstr "Управление статусом и версиями"
 msgid "View Add-on Listing"
 msgstr "Показать страницу дополнения"
 
-#: src/olympia/devhub/templates/devhub/addons/listing/item_actions.html:64
-#: src/olympia/devhub/templates/devhub/addons/listing/item_actions_theme.html:12
-#: src/olympia/devhub/templates/devhub/includes/addons_edit_nav.html:37
-#: src/olympia/devhub/templates/devhub/personas/edit.html:58
+#: src/olympia/devhub/templates/devhub/addons/listing/item_actions.html:64 src/olympia/devhub/templates/devhub/addons/listing/item_actions_theme.html:12
+#: src/olympia/devhub/templates/devhub/includes/addons_edit_nav.html:37 src/olympia/devhub/templates/devhub/personas/edit.html:58
 msgid "View Recent Changes"
 msgstr "Просмотреть последние изменения"
 
@@ -6114,12 +4895,8 @@ msgid "Delete this theme."
 msgstr "Удалить эту тему."
 
 #: src/olympia/devhub/templates/devhub/addons/listing/items.html:10
-msgid ""
-"This add-on will be deleted automatically after a few days if the submission"
-" process is not completed."
-msgstr ""
-"Это дополнение будет автоматически удалено через несколько дней, если "
-"процесс представления не будет завершён."
+msgid "This add-on will be deleted automatically after a few days if the submission process is not completed."
+msgstr "Это дополнение будет автоматически удалено через несколько дней, если процесс представления не будет завершён."
 
 #: src/olympia/devhub/templates/devhub/addons/listing/items.html:27
 msgid "Disabled"
@@ -6136,7 +4913,6 @@ msgid "<strong>{0}</strong> active user"
 msgid_plural "<strong>{0}</strong> active users"
 msgstr[0] "<strong>{0}</strong> активный пользователь"
 msgstr[1] "<strong>{0}</strong> активных пользователя"
-msgstr[2] "<strong>{0}</strong> активных пользователей"
 
 #: src/olympia/devhub/templates/devhub/addons/submit/base.html:11
 msgid "Submit Add-on"
@@ -6158,13 +4934,9 @@ msgstr "Имя и версия:"
 msgid "The detail page will be:"
 msgstr "Страницей информации будет:"
 
-#: src/olympia/devhub/templates/devhub/addons/submit/describe.html:24
-#: src/olympia/devhub/templates/devhub/personas/edit.html:89
-#: src/olympia/devhub/templates/devhub/personas/submit.html:38
+#: src/olympia/devhub/templates/devhub/addons/submit/describe.html:24 src/olympia/devhub/templates/devhub/personas/edit.html:89 src/olympia/devhub/templates/devhub/personas/submit.html:38
 msgid "Please use only letters, numbers, underscores, and dashes in your URL."
-msgstr ""
-"Пожалуйста, используйте в вашем URL только буквы, цифры, подчеркивания и "
-"тире."
+msgstr "Пожалуйста, используйте в вашем URL только буквы, цифры, подчеркивания и тире."
 
 #: src/olympia/devhub/templates/devhub/addons/submit/describe.html:34
 msgid "Provide a brief summary:"
@@ -6182,79 +4954,52 @@ msgstr "Введите более подробное описание:"
 msgid "The description will appear on the detail page."
 msgstr "Описание появится на странице информации."
 
-#: src/olympia/devhub/templates/devhub/addons/submit/done.html:4
-#: src/olympia/devhub/templates/devhub/personas/submit_done.html:4
+#: src/olympia/devhub/templates/devhub/addons/submit/done.html:4 src/olympia/devhub/templates/devhub/personas/submit_done.html:4
 msgid "Submission Complete"
 msgstr "Отправка завершена"
 
-#: src/olympia/devhub/templates/devhub/addons/submit/done.html:8
-#: src/olympia/devhub/templates/devhub/addons/submit/sidebar.html:13
-#: src/olympia/devhub/templates/devhub/personas/submit_done.html:8
+#: src/olympia/devhub/templates/devhub/addons/submit/done.html:8 src/olympia/devhub/templates/devhub/addons/submit/sidebar.html:13 src/olympia/devhub/templates/devhub/personas/submit_done.html:8
 msgid "You're done!"
 msgstr "Вы закончили!"
 
 #: src/olympia/devhub/templates/devhub/addons/submit/done.html:12
 msgid "Your add-on has been submitted to the Preliminary Review queue."
-msgstr ""
-"Ваше дополнение был отправлено в очередь на проведение предварительной "
-"проверки."
+msgstr "Ваше дополнение был отправлено в очередь на проведение предварительной проверки."
 
 #: src/olympia/devhub/templates/devhub/addons/submit/done.html:14
 msgid "Your add-on has been submitted to the Full Review queue."
-msgstr ""
-"Ваше дополнение был отправлено в очередь на проведение полной проверки."
+msgstr "Ваше дополнение был отправлено в очередь на проведение полной проверки."
 
 #: src/olympia/devhub/templates/devhub/addons/submit/done.html:18
-msgid ""
-"You'll receive an email once it has been reviewed by an editor. In\n"
-"          the meantime, you and your friends can install it directly from its\n"
-"          details page:"
+msgid "You'll receive an email once it has been reviewed by an editor. In the meantime, you and your friends can install it directly from its details page:"
 msgstr ""
 "Вы получите письмо по электронной почте, как только оно будет проверено редактором.\n"
 "          Тем временем, вы и ваши друзья могут установить его\n"
 "          прямо со страницы:"
 
-#: src/olympia/devhub/templates/devhub/addons/submit/done.html:27
-#: src/olympia/devhub/templates/devhub/addons/submit/done.html:77
-#: src/olympia/devhub/templates/devhub/personas/submit_done.html:16
+#: src/olympia/devhub/templates/devhub/addons/submit/done.html:27 src/olympia/devhub/templates/devhub/addons/submit/done.html:77 src/olympia/devhub/templates/devhub/personas/submit_done.html:16
 msgid "Next steps:"
 msgstr "Следующие шаги:"
 
-#: src/olympia/devhub/templates/devhub/addons/submit/done.html:32
-#: src/olympia/devhub/templates/devhub/addons/submit/done.html:82
+#: src/olympia/devhub/templates/devhub/addons/submit/done.html:32 src/olympia/devhub/templates/devhub/addons/submit/done.html:82
 msgid "<a href=\"{0}\">Upload</a> another platform-specific file to this version."
-msgstr ""
-"<a href=\"{0}\">Загрузите</a> в эту версию другой специфичный для платформы "
-"файл."
+msgstr "<a href=\"{0}\">Загрузите</a> в эту версию другой специфичный для платформы файл."
 
 #: src/olympia/devhub/templates/devhub/addons/submit/done.html:34
 msgid "Provide more details by <a href=\"{0}\">editing its listing</a>."
-msgstr ""
-"Предоставьте больше информации, <a href=\"{0}\">отредактировав его "
-"страницу</a>."
+msgstr "Предоставьте больше информации, <a href=\"{0}\">отредактировав его страницу</a>."
 
 #: src/olympia/devhub/templates/devhub/addons/submit/done.html:35
-msgid ""
-"Tell your users why you created this in your <a href=\"{0}\">Developer "
-"Profile</a>."
-msgstr ""
-"Расскажите своим пользователям, почему вы его создали, в вашем <a "
-"href=\"{0}\">профиле разработчика</a>."
+msgid "Tell your users why you created this in your <a href=\"{0}\">Developer Profile</a>."
+msgstr "Расскажите своим пользователям, почему вы его создали, в вашем <a href=\"{0}\">профиле разработчика</a>."
 
 #: src/olympia/devhub/templates/devhub/addons/submit/done.html:36
-msgid ""
-"View and subscribe to your add-on's <a href=\"{0}\">activity feed</a> to "
-"stay updated on reviews, collections, and more."
-msgstr ""
-"Просмотрите и подпишитесь на <a href=\"{0}\">ленту активности</a> вашего "
-"дополнения, чтобы быть в курсе отзывов, подборок и многого другого."
+msgid "View and subscribe to your add-on's <a href=\"{0}\">activity feed</a> to stay updated on reviews, collections, and more."
+msgstr "Просмотрите и подпишитесь на <a href=\"{0}\">ленту активности</a> вашего дополнения, чтобы быть в курсе отзывов, подборок и многого другого."
 
-#: src/olympia/devhub/templates/devhub/addons/submit/done.html:37
-#: src/olympia/devhub/templates/devhub/addons/submit/done.html:86
+#: src/olympia/devhub/templates/devhub/addons/submit/done.html:37 src/olympia/devhub/templates/devhub/addons/submit/done.html:86
 msgid "View approximate review queue <a href=\"{0}\">wait times</a>."
-msgstr ""
-"Показать приблизительное <a href=\"{0}\">время ожидания</a> в очереди на "
-"проведение проверки."
+msgstr "Показать приблизительное <a href=\"{0}\">время ожидания</a> в очереди на проведение проверки."
 
 #: src/olympia/devhub/templates/devhub/addons/submit/done.html:42
 msgid "Get Ahead in the Review Queue!"
@@ -6265,43 +5010,28 @@ msgid "Become an AMO Reviewer today and get your add-ons reviewed faster."
 msgstr "Станьте рецензентом AMO и ускорьте проверку ваших дополнений."
 
 #: src/olympia/devhub/templates/devhub/addons/submit/done.html:54
-msgid ""
-"Your add-on has been signed and it's ready to use. You can download it here:"
-msgstr ""
-"Ваше дополнение было подписано и готово к использованию. Вы можете загрузить"
-" его здесь:"
+msgid "Your add-on has been signed and it's ready to use. You can download it here:"
+msgstr "Ваше дополнение было подписано и готово к использованию. Вы можете загрузить его здесь:"
 
 #: src/olympia/devhub/templates/devhub/addons/submit/done.html:64
-msgid ""
-"Your add-on has been submitted to the Unlisted Preliminary Review queue."
-msgstr ""
-"Ваше дополнение был отправлено в очередь на проведение Предварительной "
-"Проверки Неотображаемых."
+msgid "Your add-on has been submitted to the Unlisted Preliminary Review queue."
+msgstr "Ваше дополнение был отправлено в очередь на проведение Предварительной Проверки Неотображаемых."
 
 #: src/olympia/devhub/templates/devhub/addons/submit/done.html:66
 msgid "Your add-on has been submitted to the Unlisted Full Review queue."
-msgstr ""
-"Ваше дополнение был отправлено в очередь на проведение Полной Проверки "
-"Неотображаемых."
+msgstr "Ваше дополнение был отправлено в очередь на проведение Полной Проверки Неотображаемых."
 
 #: src/olympia/devhub/templates/devhub/addons/submit/done.html:70
-msgid ""
-"You'll receive an email once it has been reviewed by an editor and signed."
-msgstr ""
-"Вы получите письмо по электронной почте, как только оно будет проверено "
-"редактором и подписано."
+msgid "You'll receive an email once it has been reviewed by an editor and signed."
+msgstr "Вы получите письмо по электронной почте, как только оно будет проверено редактором и подписано."
 
 #: src/olympia/devhub/templates/devhub/addons/submit/done.html:74
 msgid "Your add-on will not be publicly available on this website."
 msgstr "Ваше дополнение не будет доступно для публики на этом веб-сайте."
 
 #: src/olympia/devhub/templates/devhub/addons/submit/done.html:84
-msgid ""
-"You can upload new versions of your add-on in the <a href=\"{0}\">add-on's "
-"developer page</a>."
-msgstr ""
-"Вы можете выгружать новые версии вашего дополнения на <a "
-"href=\"{0}\">странице разработчика дополнения</a>."
+msgid "You can upload new versions of your add-on in the <a href=\"{0}\">add-on's developer page</a>."
+msgstr "Вы можете выгружать новые версии вашего дополнения на <a href=\"{0}\">странице разработчика дополнения</a>."
 
 #: src/olympia/devhub/templates/devhub/addons/submit/license.html:4
 msgid "Step 5"
@@ -6312,14 +5042,8 @@ msgid "Step 5. Select a License"
 msgstr "Шаг 5. Выберите лицензию"
 
 #: src/olympia/devhub/templates/devhub/addons/submit/license.html:9
-msgid ""
-"We require all add-ons to indicate the terms under which their source code "
-"is licensed. Please select a license from the list below or enter a custom "
-"license."
-msgstr ""
-"Мы требуем от всех дополнений указывать лицензию их исходного кода. "
-"Пожалуйста, выберите лицензию из размещённого ниже списка или введите свою "
-"лицензию."
+msgid "We require all add-ons to indicate the terms under which their source code is licensed. Please select a license from the list below or enter a custom license."
+msgstr "Мы требуем от всех дополнений указывать лицензию их исходного кода. Пожалуйста, выберите лицензию из размещённого ниже списка или введите свою лицензию."
 
 #: src/olympia/devhub/templates/devhub/addons/submit/license.html:18
 msgid "Select a license for your add-on:"
@@ -6335,13 +5059,11 @@ msgstr "Шаг 4. Добавить изображения"
 
 #: src/olympia/devhub/templates/devhub/addons/submit/media.html:9
 msgid ""
-"Custom icons and screenshots draw attention and help users understand what "
-"it does. We strongly recommend uploading a custom icon, as in some areas of "
-"the website, only the icon and name will appear."
+"Custom icons and screenshots draw attention and help users understand what it does. We strongly recommend uploading a custom icon, as in some areas of the website, only the icon and name will "
+"appear."
 msgstr ""
-"Свои значки и скриншоты привлекают внимание и помогают пользователям понять,"
-" что оно делает. Мы настоятельно рекомендуем загрузить свой значок, так как "
-"в некоторых областях веб-сайта появится только имя и значок."
+"Свои значки и скриншоты привлекают внимание и помогают пользователям понять, что оно делает. Мы настоятельно рекомендуем загрузить свой значок, так как в некоторых областях веб-сайта появится "
+"только имя и значок."
 
 #: src/olympia/devhub/templates/devhub/addons/submit/select-review.html:5
 msgid "Step 6"
@@ -6353,25 +5075,16 @@ msgstr "Шаг 6. Выберите процесс проверки"
 
 #: src/olympia/devhub/templates/devhub/addons/submit/select-review.html:10
 msgid ""
-"All add-ons hosted in our gallery must be reviewed by an editor before they "
-"appear in categories or search results. While waiting for review, your add-"
-"on can still be accessed through its direct URL. Please choose the review "
-"process below that best fits your add-on."
+"All add-ons hosted in our gallery must be reviewed by an editor before they appear in categories or search results. While waiting for review, your add-on can still be accessed through its direct "
+"URL. Please choose the review process below that best fits your add-on."
 msgstr ""
-"Все дополнения, размещённые в нашей галерее, должны быть рассмотрены "
-"редактором, прежде чем они появятся в категориях или в результатах поиска. В"
-" ожидании рассмотрения ваше дополнение может быть доступно для установки по "
-"его прямой ссылке. Пожалуйста, выберите ниже процесс проверки, который лучше"
-" всего подходит для вашего дополнения."
+"Все дополнения, размещённые в нашей галерее, должны быть рассмотрены редактором, прежде чем они появятся в категориях или в результатах поиска. В ожидании рассмотрения ваше дополнение может быть "
+"доступно для установки по его прямой ссылке. Пожалуйста, выберите ниже процесс проверки, который лучше всего подходит для вашего дополнения."
 
 #: src/olympia/devhub/templates/devhub/addons/submit/select-review.html:26
 #, python-format
-msgid ""
-"A complete review of your add-on's source and functionality. <a "
-"href=\"%(url)s\">Learn more&hellip;</a>"
-msgstr ""
-"Полная проверка исходного кода и функциональности вашего дополнения. <a "
-"href=\"%(url)s\">Узнать больше&hellip;</a>"
+msgid "A complete review of your add-on's source and functionality. <a href=\"%(url)s\">Learn more&hellip;</a>"
+msgstr "Полная проверка исходного кода и функциональности вашего дополнения. <a href=\"%(url)s\">Узнать больше&hellip;</a>"
 
 #: src/olympia/devhub/templates/devhub/addons/submit/select-review.html:32
 msgid "Appropriate for polished add-ons"
@@ -6399,12 +5112,8 @@ msgstr "Выбрать полную проверку"
 
 #: src/olympia/devhub/templates/devhub/addons/submit/select-review.html:49
 #, python-format
-msgid ""
-"A faster review of your add-on's source for any major problems. <a "
-"href=\"%(url)s\">Learn more&hellip;</a>"
-msgstr ""
-"Быстрая проверка исходного кода вашего дополнения на предмет выявления "
-"каких-либо серьезных проблем. <a href=\"%(url)s\">Узнать больше&hellip;</a>"
+msgid "A faster review of your add-on's source for any major problems. <a href=\"%(url)s\">Learn more&hellip;</a>"
+msgstr "Быстрая проверка исходного кода вашего дополнения на предмет выявления каких-либо серьезных проблем. <a href=\"%(url)s\">Узнать больше&hellip;</a>"
 
 #: src/olympia/devhub/templates/devhub/addons/submit/select-review.html:55
 msgid "Appropriate for experimental add-ons"
@@ -6450,10 +5159,8 @@ msgstr "Выберите лицензию"
 msgid "Select a review process"
 msgstr "Выберите процесс проверки"
 
-#: src/olympia/devhub/templates/devhub/addons/submit/sidebar.html:18
-#: src/olympia/devhub/templates/devhub/docs/policies-submission.html:3
-#: src/olympia/devhub/templates/devhub/docs/policies-submission.html:7
-#: src/olympia/devhub/templates/devhub/docs/policies-submission.html:9
+#: src/olympia/devhub/templates/devhub/addons/submit/sidebar.html:18 src/olympia/devhub/templates/devhub/docs/policies-submission.html:3
+#: src/olympia/devhub/templates/devhub/docs/policies-submission.html:7 src/olympia/devhub/templates/devhub/docs/policies-submission.html:9
 msgid "Submission Process"
 msgstr "Процесс отправки"
 
@@ -6474,27 +5181,20 @@ msgid "Step 2. Upload Your Add-on"
 msgstr "Шаг 2. Загрузите ваше дополнение"
 
 #: src/olympia/devhub/templates/devhub/addons/submit/upload.html:11
-msgid ""
-"Use the fields below to upload your add-on package and select any platform "
-"restrictions. After upload, a series of automated validation tests will be "
-"run on your file."
+msgid "Use the fields below to upload your add-on package and select any platform restrictions. After upload, a series of automated validation tests will be run on your file."
 msgstr ""
-"Для загрузки своего пакета дополнения и выбора ограничений по платформе "
-"используйте расположенные ниже поля. После загрузки ваш файл будет проверен "
-"с использованием серии автоматических тестов валидации."
+"Для загрузки своего пакета дополнения и выбора ограничений по платформе используйте расположенные ниже поля. После загрузки ваш файл будет проверен с использованием серии автоматических тестов "
+"валидации."
 
-#: src/olympia/devhub/templates/devhub/addons/submit/upload.html:59
-#: src/olympia/devhub/templates/devhub/versions/add_file_modal.html:39
+#: src/olympia/devhub/templates/devhub/addons/submit/upload.html:51 src/olympia/devhub/templates/devhub/versions/add_file_modal.html:28
 msgid "Which platforms is this file compatible with?"
 msgstr "С какими платформами совместим этот файл?"
 
-#: src/olympia/devhub/templates/devhub/addons/submit/upload.html:67
-#: src/olympia/devhub/templates/devhub/versions/add_file_modal.html:65
+#: src/olympia/devhub/templates/devhub/addons/submit/upload.html:59 src/olympia/devhub/templates/devhub/versions/add_file_modal.html:45
 msgid "Administrative overrides"
 msgstr "Административные действия"
 
-#: src/olympia/devhub/templates/devhub/api/agreement.html:3
-#: src/olympia/devhub/templates/devhub/api/agreement.html:11
+#: src/olympia/devhub/templates/devhub/api/agreement.html:3 src/olympia/devhub/templates/devhub/api/agreement.html:11
 msgid "Firefox Add-on Distribution Agreement"
 msgstr "Соглашение распространения дополнения Firefox"
 
@@ -6504,12 +5204,8 @@ msgstr "API Credentials"
 
 #: src/olympia/devhub/templates/devhub/api/key.html:20
 #, python-format
-msgid ""
-"For detailed instructions, consult the <a href=\"%(docs_url)s\">API "
-"documentation</a>."
-msgstr ""
-"Для подробных инструкций обратитесь к <a href=\"%(docs_url)s\">документации "
-"по API</a>."
+msgid "For detailed instructions, consult the <a href=\"%(docs_url)s\">API documentation</a>."
+msgstr "Для подробных инструкций обратитесь к <a href=\"%(docs_url)s\">документации по API</a>."
 
 #: src/olympia/devhub/templates/devhub/api/key.html:28
 msgid "JWT issuer"
@@ -6522,14 +5218,11 @@ msgstr "Секрет JWT"
 #: src/olympia/devhub/templates/devhub/api/key.html:37
 #, python-format
 msgid ""
-"To make API requests, send a <a href=\"%(jwt_url)s\">JSON Web Token "
-"(JWT)</a> as the authorization header. You'll need to generate a JWT for "
-"every request as explained in the <a href=\"%(docs_url)s\">API "
-"documentation</a>."
+"To make API requests, send a <a href=\"%(jwt_url)s\">JSON Web Token (JWT)</a> as the authorization header. You'll need to generate a JWT for every request as explained in the <a href=\"%(docs_url)s"
+"\">API documentation</a>."
 msgstr ""
-"Чтобы делать запросы к API, отправьте <a href=\"%(jwt_url)s\">JWT (JSON Web "
-"Token)</a> как авторизационный заголовок. Вам нужно будет сгенерировать JWT "
-"для каждого запроса, как в <a href=\"%(docs_url)s\">документации по API</a>."
+"Чтобы делать запросы к API, отправьте <a href=\"%(jwt_url)s\">JWT (JSON Web Token)</a> как авторизационный заголовок. Вам нужно будет сгенерировать JWT для каждого запроса, как в <a href="
+"\"%(docs_url)s\">документации по API</a>."
 
 #: src/olympia/devhub/templates/devhub/api/key.html:47
 msgid "You don't have any API credentials yet."
@@ -6537,13 +5230,8 @@ msgstr "У вас ещё нет никаких полномочий API."
 
 #: src/olympia/devhub/templates/devhub/api/key.html:53
 #, python-format
-msgid ""
-"This feature is under active development. If you find a problem please <a "
-"target=\"_blank\" href=\"%(bug_link)s\">report a bug</a>."
-msgstr ""
-"Эта функция находится в активной разработке. Если вы нашли проблему, "
-"пожалуйста, <a target=\"_blank\" href=\"%(bug_link)s\">сообщите об "
-"ошибке</a>."
+msgid "This feature is under active development. If you find a problem please <a target=\"_blank\" href=\"%(bug_link)s\">report a bug</a>."
+msgstr "Эта функция находится в активной разработке. Если вы нашли проблему, пожалуйста, <a target=\"_blank\" href=\"%(bug_link)s\">сообщите об ошибке</a>."
 
 #: src/olympia/devhub/templates/devhub/api/key.html:61
 msgid "Revoke and regenerate credentials"
@@ -6553,30 +5241,19 @@ msgstr "Отозвать и заново создать полномочия"
 msgid "Generate new credentials"
 msgstr "Создать новые полномочия"
 
-#: src/olympia/devhub/templates/devhub/docs/policies-agreement.html:3
-#: src/olympia/devhub/templates/devhub/docs/policies-agreement.html:7
-#: src/olympia/devhub/templates/devhub/docs/policies-agreement.html:9
-#: src/olympia/devhub/templates/devhub/docs/policies.html:24
-#: src/olympia/devhub/templates/devhub/docs/policies.html:103
+#: src/olympia/devhub/templates/devhub/docs/policies-agreement.html:3 src/olympia/devhub/templates/devhub/docs/policies-agreement.html:7
+#: src/olympia/devhub/templates/devhub/docs/policies-agreement.html:9 src/olympia/devhub/templates/devhub/docs/policies.html:24 src/olympia/devhub/templates/devhub/docs/policies.html:103
 msgid "Developer Agreement"
 msgstr "Соглашение разработчика"
 
-#: src/olympia/devhub/templates/devhub/docs/policies-contact.html:3
-#: src/olympia/devhub/templates/devhub/docs/policies-contact.html:7
-#: src/olympia/devhub/templates/devhub/docs/policies-contact.html:9
-#: src/olympia/devhub/templates/devhub/docs/policies.html:27
-#: src/olympia/devhub/templates/devhub/docs/policies.html:115
+#: src/olympia/devhub/templates/devhub/docs/policies-contact.html:3 src/olympia/devhub/templates/devhub/docs/policies-contact.html:7 src/olympia/devhub/templates/devhub/docs/policies-contact.html:9
+#: src/olympia/devhub/templates/devhub/docs/policies.html:27 src/olympia/devhub/templates/devhub/docs/policies.html:115
 msgid "Contacting Us"
 msgstr "Связь с нами"
 
 #: src/olympia/devhub/templates/devhub/docs/policies-contact.html:12
-msgid ""
-"Thanks for your interest in contacting the Mozilla Add-ons team. Please read"
-" this page carefully to ensure your request goes to the right place."
-msgstr ""
-"Спасибо за ваш интерес в контакте с командой дополнений Mozilla. Пожалуйста,"
-" внимательно прочитайте эту страницу, чтобы убедиться, что ваш запрос уйдёт "
-"в нужное место."
+msgid "Thanks for your interest in contacting the Mozilla Add-ons team. Please read this page carefully to ensure your request goes to the right place."
+msgstr "Спасибо за ваш интерес в контакте с командой дополнений Mozilla. Пожалуйста, внимательно прочитайте эту страницу, чтобы убедиться, что ваш запрос уйдёт в нужное место."
 
 #: src/olympia/devhub/templates/devhub/docs/policies-contact.html:17
 msgid "Add-on Support"
@@ -6584,15 +5261,11 @@ msgstr "Поддержка дополнения"
 
 #: src/olympia/devhub/templates/devhub/docs/policies-contact.html:19
 msgid ""
-"If you have a support question about a particular add-on, such as \"how do I"
-" use this add-on?\" or \"why doesn't this work properly?\", please contact "
-"that add-on's author through the support channels listed on the add-on's "
-"listing page."
+"If you have a support question about a particular add-on, such as \"how do I use this add-on?\" or \"why doesn't this work properly?\", please contact that add-on's author through the support "
+"channels listed on the add-on's listing page."
 msgstr ""
-"Если у вас есть вопрос по работе с конкретным дополнением, такой как \"как "
-"мне использовать это дополнение?\" или \"почему оно не работает как надо?\","
-" пожалуйста, свяжитесь с автором дополнения через каналы поддержки, "
-"перечисленные на странице информации о дополнении."
+"Если у вас есть вопрос по работе с конкретным дополнением, такой как \"как мне использовать это дополнение?\" или \"почему оно не работает как надо?\", пожалуйста, свяжитесь с автором дополнения "
+"через каналы поддержки, перечисленные на странице информации о дополнении."
 
 #: src/olympia/devhub/templates/devhub/docs/policies-contact.html:24
 msgid "Add-on Editorial Concerns"
@@ -6605,17 +5278,11 @@ msgstr "amo-editors at mozilla dot org"
 #: src/olympia/devhub/templates/devhub/docs/policies-contact.html:26
 #, python-format
 msgid ""
-"If you have a question about an Editor's review of an add-on or want to "
-"report a policy violation, please email %(mail_editors)s. <strong>Almost all"
-" add-on reports fall under this category.</strong> Please be sure to include"
-" a link to the add-on in question and a detailed description of your "
-"question or comment."
+"If you have a question about an Editor's review of an add-on or want to report a policy violation, please email %(mail_editors)s. <strong>Almost all add-on reports fall under this category.</"
+"strong> Please be sure to include a link to the add-on in question and a detailed description of your question or comment."
 msgstr ""
-"Если у вас есть вопрос по поводу рецензии редактора на дополнение или вы "
-"хотите сообщить о нарушении политики, пожалуйста, напишите %(mail_editors)s."
-" <strong>Почти все сообщения о дополнениях попадают в эту "
-"категорию.</strong> Пожалуйста, не забудьте включить ссылку на дополнение, о"
-" котором идёт речь, и подробное описание вашего вопроса или комментария."
+"Если у вас есть вопрос по поводу рецензии редактора на дополнение или вы хотите сообщить о нарушении политики, пожалуйста, напишите %(mail_editors)s. <strong>Почти все сообщения о дополнениях "
+"попадают в эту категорию.</strong> Пожалуйста, не забудьте включить ссылку на дополнение, о котором идёт речь, и подробное описание вашего вопроса или комментария."
 
 #: src/olympia/devhub/templates/devhub/docs/policies-contact.html:31
 msgid "Add-on Security Vulnerabilities"
@@ -6628,22 +5295,13 @@ msgstr "amo-admins at mozilla dot org"
 #: src/olympia/devhub/templates/devhub/docs/policies-contact.html:36
 #, python-format
 msgid ""
-"If you have discovered a security vulnerability in an add-on, even if it is "
-"not hosted here, Mozilla is very interested in your discovery and will work "
-"with the add-on developer to correct the issue as soon as possible. Add-on "
-"security issues can be reported <a "
-"href=\"http://www.mozilla.org/projects/security/security-bugs-"
-"policy.html\">confidentially</a> in <a "
-"href=\"%(link_bugzilla)s\">Bugzilla</a> or by emailing %(mail_admins)s."
+"If you have discovered a security vulnerability in an add-on, even if it is not hosted here, Mozilla is very interested in your discovery and will work with the add-on developer to correct the "
+"issue as soon as possible. Add-on security issues can be reported <a href=\"http://www.mozilla.org/projects/security/security-bugs-policy.html\">confidentially</a> in <a href=\"%(link_bugzilla)s"
+"\">Bugzilla</a> or by emailing %(mail_admins)s."
 msgstr ""
-"Если вы обнаружили уязвимость в безопасности дополнения, даже если оно "
-"размещено не здесь, Mozilla будет очень заинтересована вашим открытием и "
-"станет работать вместе с разработчиком  дополнения над наискорейшим "
-"устранением проблемы. О проблемах в безопасности дополнений можно <a "
-"href=\"http://www.mozilla.org/projects/security/security-bugs-"
-"policy.html\">конфиденциально</a> сообщить в <a "
-"href=\"%(link_bugzilla)s\">Bugzilla</a> или по электронной почте "
-"%(mail_admins)s."
+"Если вы обнаружили уязвимость в безопасности дополнения, даже если оно размещено не здесь, Mozilla будет очень заинтересована вашим открытием и станет работать вместе с разработчиком  дополнения "
+"над наискорейшим устранением проблемы. О проблемах в безопасности дополнений можно <a href=\"http://www.mozilla.org/projects/security/security-bugs-policy.html\">конфиденциально</a> сообщить в <a "
+"href=\"%(link_bugzilla)s\">Bugzilla</a> или по электронной почте %(mail_admins)s."
 
 #: src/olympia/devhub/templates/devhub/docs/policies-contact.html:42
 msgid "Website Functionality & Development"
@@ -6651,17 +5309,11 @@ msgstr "Функциональность и разработка веб-сайт
 
 #: src/olympia/devhub/templates/devhub/docs/policies-contact.html:44
 msgid ""
-"If you've found a problem with the site, we'd love to fix it. Please <a "
-"href=\"https://github.com/mozilla/olympia/issues\">file a bug report</a> in "
-"GitHub, including the location of the problem and how you encountered it."
+"If you've found a problem with the site, we'd love to fix it. Please <a href=\"https://github.com/mozilla/addons/issues/new\">file a bug report</a> in GitHub, including the location of the problem "
+"and how you encountered it."
 msgstr ""
-"Если вы обнаружили проблему с сайтом, мы с радостью её исправим. Пожалуйста,"
-" <a href=\"https://github.com/mozilla/olympia/issues\">отправьте сообщение "
-"об ошибке</a> на GitHub, включив в него расположение проблемы и как вы с ней"
-" столкнулись."
 
-#: src/olympia/devhub/templates/devhub/docs/policies-maintenance.html:3
-#: src/olympia/devhub/templates/devhub/docs/policies-maintenance.html:7
+#: src/olympia/devhub/templates/devhub/docs/policies-maintenance.html:3 src/olympia/devhub/templates/devhub/docs/policies-maintenance.html:7
 #: src/olympia/devhub/templates/devhub/docs/policies-maintenance.html:8
 msgid "Maintaining Your Add-ons"
 msgstr "Обслуживание ваших дополнений"
@@ -6672,32 +5324,17 @@ msgstr "Представление новых версий вашего допо
 
 #: src/olympia/devhub/templates/devhub/docs/policies-maintenance.html:12
 msgid ""
-"Developers are encouraged to submit updates to their add-ons to fix bugs, "
-"add features, and otherwise improve their product. New versions of an add-on"
-" must have a <a "
-"href=\"https://developer.mozilla.org/en/Toolkit_version_format\">higher "
-"version number</a> and can be submitted through the Developer Tools "
-"provided. There is no limit to the number of versions that can be submitted,"
-" but please remember that versions must be reviewed by an editor."
+"Developers are encouraged to submit updates to their add-ons to fix bugs, add features, and otherwise improve their product. New versions of an add-on must have a <a href=\"https://developer."
+"mozilla.org/en/Toolkit_version_format\">higher version number</a> and can be submitted through the Developer Tools provided. There is no limit to the number of versions that can be submitted, but "
+"please remember that versions must be reviewed by an editor."
 msgstr ""
-"Разработчикам предлагается представлять обновления для своих дополнений, "
-"исправляющих ошибки, добавляющих новые функции и вносящих другие "
-"исправления. Новые версии дополнения должны иметь <a "
-"href=\"https://developer.mozilla.org/en/Toolkit_version_format\">более "
-"высокий номер версии</a> и могут быть представлены через имеющиеся "
-"Инструменты Разработчика. Не существует никаких ограничений на число "
-"представляемых версий, но пожалуйста, помните, что версии должны быть "
-"проверены редактором."
+"Разработчикам предлагается представлять обновления для своих дополнений, исправляющих ошибки, добавляющих новые функции и вносящих другие исправления. Новые версии дополнения должны иметь <a href="
+"\"https://developer.mozilla.org/en/Toolkit_version_format\">более высокий номер версии</a> и могут быть представлены через имеющиеся Инструменты Разработчика. Не существует никаких ограничений на "
+"число представляемых версий, но пожалуйста, помните, что версии должны быть проверены редактором."
 
 #: src/olympia/devhub/templates/devhub/docs/policies-maintenance.html:18
-msgid ""
-"New versions will be added to a pending review queue, and any additional "
-"versions submitted before the review is completed will move that version to "
-"the end of the queue."
-msgstr ""
-"Новые версии будут добавлены в очередь ожидания проверки, и любые "
-"дополнительные версии, отправленные до завершения проверки, передвинут эту "
-"версию в конец очереди."
+msgid "New versions will be added to a pending review queue, and any additional versions submitted before the review is completed will move that version to the end of the queue."
+msgstr "Новые версии будут добавлены в очередь ожидания проверки, и любые дополнительные версии, отправленные до завершения проверки, передвинут эту версию в конец очереди."
 
 #: src/olympia/devhub/templates/devhub/docs/policies-maintenance.html:23
 msgid "How do I submit a Beta add-on?"
@@ -6709,52 +5346,31 @@ msgstr "Бета-каналы доступны только для полнос�
 
 #: src/olympia/devhub/templates/devhub/docs/policies-maintenance.html:31
 msgid ""
-"To create a beta channel, upload a file with a unique version string that "
-"contains any of the following strings: <code>a,b,alpha,beta,pre,rc</code>, "
-"with an optional number at the end. This text must come at the end of the "
-"version string. If you understand regex format, here's what we look for in "
-"the version number: <code>\"(a|alpha|b|beta|pre|rc)\\d*$\"</code>."
+"To create a beta channel, upload a file with a unique version string that contains any of the following strings: <code>a,b,alpha,beta,pre,rc</code>, with an optional number at the end. This text "
+"must come at the end of the version string. If you understand regex format, here's what we look for in the version number: <code>\"(a|alpha|b|beta|pre|rc)\\d*$\"</code>."
 msgstr ""
-"Чтобы создать бета-канал, загрузите файл со строкой уникальной версии, "
-"содержащей любую из следующих строк: <code>a,b,alpha,beta,pre,rc</code>, с "
-"опциональным числом на конце. Этот текст должен быть в конце строки версии. "
-"Если вы понимаете формат regex, вот то, что мы ищем в номере версии: "
-"<code>\"(a|alpha|b|beta|pre|rc)\\d*$\"</code>."
+"Чтобы создать бета-канал, загрузите файл со строкой уникальной версии, содержащей любую из следующих строк: <code>a,b,alpha,beta,pre,rc</code>, с опциональным числом на конце. Этот текст должен "
+"быть в конце строки версии. Если вы понимаете формат regex, вот то, что мы ищем в номере версии: <code>\"(a|alpha|b|beta|pre|rc)\\d*$\"</code>."
 
 #: src/olympia/devhub/templates/devhub/docs/policies-maintenance.html:37
 msgid ""
-"Once a file meeting this criteria is uploaded to AMO, it will automatically "
-"be marked as a beta version. Users of add-ons with these unique version "
-"numbers will automatically be served the newest beta updates."
+"Once a file meeting this criteria is uploaded to AMO, it will automatically be marked as a beta version. Users of add-ons with these unique version numbers will automatically be served the newest "
+"beta updates."
 msgstr ""
-"Как только файл, подходящий под эти критерии, будет загружен на АМО, он "
-"автоматически будет помечен как бета-версия. Пользователям дополнений с "
-"этими уникальными номерами версии будут автоматически отправляться новейшие "
-"обновления бета-версии."
+"Как только файл, подходящий под эти критерии, будет загружен на АМО, он автоматически будет помечен как бета-версия. Пользователям дополнений с этими уникальными номерами версии будут автоматически "
+"отправляться новейшие обновления бета-версии."
 
 #: src/olympia/devhub/templates/devhub/docs/policies-maintenance.html:43
 msgid ""
-"While we call these \"Beta versions\", you can use this channel for "
-"nightlies, or alphas, or prerelease versions as you wish. Please note that "
-"there is only one channel for this purpose and all of your users on this "
-"channel will receive the latest add-ons submitted. For instance, if you "
-"upload <code>1.0beta1</code> to the release channel and then upload "
-"<code>1.1alpha1</code>, all users of <code>1.0beta1</code> will be offered "
-"an upgrade to <code>1.1alpha1</code>. Updates are pushed by submission date "
-"and not version number, so users will always get the most recent channel "
-"update regardless of any kind of alphabetical sorting."
+"While we call these \"Beta versions\", you can use this channel for nightlies, or alphas, or prerelease versions as you wish. Please note that there is only one channel for this purpose and all of "
+"your users on this channel will receive the latest add-ons submitted. For instance, if you upload <code>1.0beta1</code> to the release channel and then upload <code>1.1alpha1</code>, all users of "
+"<code>1.0beta1</code> will be offered an upgrade to <code>1.1alpha1</code>. Updates are pushed by submission date and not version number, so users will always get the most recent channel update "
+"regardless of any kind of alphabetical sorting."
 msgstr ""
-"Хотя мы называем это \"Бета-версии\", вы можете использовать этот канал для "
-"ночных сборок, или альф, или предварительных версий, как вы того хотите. "
-"Пожалуйста, обратите внимание, что для этой цели есть только один канал и "
-"все ваши пользователи на этом канале будут получать самые последние "
-"представленные дополнения. Например, если вы загружаете "
-"<code>1.0beta1</code> в канал релизов, а затем загружаете "
-"<code>1.1alpha1</code>, всем пользователям <code>1.0beta1</code> будет "
-"предлагаться обновление до <code>1.1alpha1</code>. Обновления "
-"распространяются по дате представления, а не по номеру версии, так что "
-"пользователи всегда будут получать самое последнее обновление канала, "
-"независимо от какой-либо сортировки по алфавиту."
+"Хотя мы называем это \"Бета-версии\", вы можете использовать этот канал для ночных сборок, или альф, или предварительных версий, как вы того хотите. Пожалуйста, обратите внимание, что для этой цели "
+"есть только один канал и все ваши пользователи на этом канале будут получать самые последние представленные дополнения. Например, если вы загружаете <code>1.0beta1</code> в канал релизов, а затем "
+"загружаете <code>1.1alpha1</code>, всем пользователям <code>1.0beta1</code> будет предлагаться обновление до <code>1.1alpha1</code>. Обновления распространяются по дате представления, а не по "
+"номеру версии, так что пользователи всегда будут получать самое последнее обновление канала, независимо от какой-либо сортировки по алфавиту."
 
 #: src/olympia/devhub/templates/devhub/docs/policies-maintenance.html:48
 msgid "Required Updates"
@@ -6762,22 +5378,13 @@ msgstr "Требуемые обновления"
 
 #: src/olympia/devhub/templates/devhub/docs/policies-maintenance.html:50
 msgid ""
-"Certain situations may arise in which Mozilla requests that an add-on "
-"developer update their add-on within a given time period to address a major "
-"security issue or policy violation. We work with developers to reasonably "
-"accommodate their own schedules, but if the issue is of a serious enough "
-"nature, add-ons that cannot issue an update with the requested fix may be "
-"demoted from fully-reviewed status, disabled, or permanently removed from "
-"the site."
+"Certain situations may arise in which Mozilla requests that an add-on developer update their add-on within a given time period to address a major security issue or policy violation. We work with "
+"developers to reasonably accommodate their own schedules, but if the issue is of a serious enough nature, add-ons that cannot issue an update with the requested fix may be demoted from fully-"
+"reviewed status, disabled, or permanently removed from the site."
 msgstr ""
-"Могут возникнуть определённые ситуации, при которых Mozilla просит "
-"разработчика дополнения обновить своё дополнение в течение определённого "
-"периода времени, чтобы решить серьёзную проблему безопасности или исправить "
-"нарушение политики. Мы работаем с разработчиками, чтобы по возможности "
-"согласовать это с их собственными графиками, но если вопрос носит достаточно"
-" серьезный характер, то дополнения, которые не могут выпустить обновления с "
-"запрошенным исправлением, могут быть понижены в статусе с полностью "
-"проверенного, отключены или навсегда удалены с сайта."
+"Могут возникнуть определённые ситуации, при которых Mozilla просит разработчика дополнения обновить своё дополнение в течение определённого периода времени, чтобы решить серьёзную проблему "
+"безопасности или исправить нарушение политики. Мы работаем с разработчиками, чтобы по возможности согласовать это с их собственными графиками, но если вопрос носит достаточно серьезный характер, то "
+"дополнения, которые не могут выпустить обновления с запрошенным исправлением, могут быть понижены в статусе с полностью проверенного, отключены или навсегда удалены с сайта."
 
 #: src/olympia/devhub/templates/devhub/docs/policies-maintenance.html:55
 msgid "Transfer of Ownership"
@@ -6785,64 +5392,41 @@ msgstr "Передача владения"
 
 #: src/olympia/devhub/templates/devhub/docs/policies-maintenance.html:57
 msgid ""
-"Add-ons can have multiple users with permission to update and manage the "
-"listing. Existing authors of an add-on can transfer ownership and add "
-"additional developers to an add-on's listing through the Developer Tools "
-"provided. No interaction with Mozilla representatives is necessary for a "
-"transfer of ownership."
+"Add-ons can have multiple users with permission to update and manage the listing. Existing authors of an add-on can transfer ownership and add additional developers to an add-on's listing through "
+"the Developer Tools provided. No interaction with Mozilla representatives is necessary for a transfer of ownership."
 msgstr ""
-"Дополнения могут иметь несколько пользователей, которым разрешено обновлять "
-"и управлять его страницу. Существующие авторы дополнения может передавать "
-"право собственности и добавлять дополнительных разработчиков на страницу "
-"дополнения, доступную из Инструментов Разработчика. Для передачи права "
-"собственности взаимодействие с представителями Mozilla не требуется."
+"Дополнения могут иметь несколько пользователей, которым разрешено обновлять и управлять его страницу. Существующие авторы дополнения может передавать право собственности и добавлять дополнительных "
+"разработчиков на страницу дополнения, доступную из Инструментов Разработчика. Для передачи права собственности взаимодействие с представителями Mozilla не требуется."
 
 #: src/olympia/devhub/templates/devhub/docs/policies-maintenance.html:63
 #, python-format
-msgid ""
-"Mozilla can assist with granting additional permissions of an add-on's "
-"listing if <a href=\"%(link_contact)s\">contacted</a> by the add-on's "
-"current owner."
-msgstr ""
-"Mozilla может помочь с предоставлением дополнительных разрешений на страницу"
-" дополнения, если <a href=\"%(link_contact)s\">с ней свяжется</a> текущий "
-"владелец дополнения."
+msgid "Mozilla can assist with granting additional permissions of an add-on's listing if <a href=\"%(link_contact)s\">contacted</a> by the add-on's current owner."
+msgstr "Mozilla может помочь с предоставлением дополнительных разрешений на страницу дополнения, если <a href=\"%(link_contact)s\">с ней свяжется</a> текущий владелец дополнения."
 
 #: src/olympia/devhub/templates/devhub/docs/policies-maintenance.html:70
 msgid ""
-"Mozilla encourages its users to offer feedback on their experiences when "
-"using an add-on. This allows other users to determine if the add-on is "
-"stable and useful. It also provides valuable feedback to developers, "
-"allowing them to continuously improve their add-on to meet user needs."
+"Mozilla encourages its users to offer feedback on their experiences when using an add-on. This allows other users to determine if the add-on is stable and useful. It also provides valuable feedback "
+"to developers, allowing them to continuously improve their add-on to meet user needs."
 msgstr ""
-"Mozilla рекомендует своим пользователям высказывать мнение о своем опыте "
-"использования дополнения. Это позволяет другим пользователям определить, "
-"является ли дополнение стабильным и полезным. Это также предоставляет ценную"
-" информацию для разработчиков, позволяя им постоянно совершенствовать свои "
-"дополнения для удовлетворения потребностей пользователей."
+"Mozilla рекомендует своим пользователям высказывать мнение о своем опыте использования дополнения. Это позволяет другим пользователям определить, является ли дополнение стабильным и полезным. Это "
+"также предоставляет ценную информацию для разработчиков, позволяя им постоянно совершенствовать свои дополнения для удовлетворения потребностей пользователей."
 
 #: src/olympia/devhub/templates/devhub/docs/policies-maintenance.html:76
 #, python-format
 msgid ""
-"Reviews must follow the <a href=\"%(link_guidelines)s\">review "
-"guidelines</a>. Reviews that do not meet these guidelines may be flagged for"
-" moderation, but negative reviews will not be removed unless they provide "
-"false information."
+"Reviews must follow the <a href=\"%(link_guidelines)s\">review guidelines</a>. Reviews that do not meet these guidelines may be flagged for moderation, but negative reviews will not be removed "
+"unless they provide false information."
 msgstr ""
-"Отзывы должны соответствовать <a href=\"%(link_guidelines)s\">определённым "
-"требованиям</a>. Отзывы, не соответствующие указанным требованиям, могут "
-"быть помечены для модерации, но негативные отзывы не будут удаляться, если "
-"только они не содержат ложную информацию."
+"Отзывы должны соответствовать <a href=\"%(link_guidelines)s\">определённым требованиям</a>. Отзывы, не соответствующие указанным требованиям, могут быть помечены для модерации, но негативные отзывы "
+"не будут удаляться, если только они не содержат ложную информацию."
 
 #: src/olympia/devhub/templates/devhub/docs/policies-maintenance.html:82
 msgid ""
-"Many developers provide a support mechanism, such as a forum, discussion "
-"group, or email address. It is recommended that support questions be posted "
-"via those mediums instead of in an add-on's review section."
+"Many developers provide a support mechanism, such as a forum, discussion group, or email address. It is recommended that support questions be posted via those mediums instead of in an add-on's "
+"review section."
 msgstr ""
-"Многие разработчики предоставляют механизм поддержки, такие как форум, "
-"дискусионная группа или адрес электронной почты. Мы рекомендуем размещать "
-"вопросы по поддержке в этих средах вместо раздела отзывов на дополнение."
+"Многие разработчики предоставляют механизм поддержки, такие как форум, дискусионная группа или адрес электронной почты. Мы рекомендуем размещать вопросы по поддержке в этих средах вместо раздела "
+"отзывов на дополнение."
 
 #: src/olympia/devhub/templates/devhub/docs/policies-maintenance.html:87
 msgid "Code Disputes"
@@ -6850,44 +5434,27 @@ msgstr "Оспаривание кода"
 
 #: src/olympia/devhub/templates/devhub/docs/policies-maintenance.html:90
 msgid ""
-"Many add-ons allow their source code to be openly viewed. This does not mean"
-" that the source code is open source or available for use in another add-on."
-" The original author of an add-on retains copyright of their work unless "
-"otherwise noted in the add-on's license."
+"Many add-ons allow their source code to be openly viewed. This does not mean that the source code is open source or available for use in another add-on. The original author of an add-on retains "
+"copyright of their work unless otherwise noted in the add-on's license."
 msgstr ""
-"Многие дополнения позволяют открыто просмотреть их исходный код. Это не "
-"означает, что их исходный код является свободным или доступен для "
-"использования в другом дополнении. Первоначальный автор дополнения сохраняет"
-" авторские права на свою работу, если иное не указано в лицензии дополнения."
+"Многие дополнения позволяют открыто просмотреть их исходный код. Это не означает, что их исходный код является свободным или доступен для использования в другом дополнении. Первоначальный автор "
+"дополнения сохраняет авторские права на свою работу, если иное не указано в лицензии дополнения."
 
 #: src/olympia/devhub/templates/devhub/docs/policies-maintenance.html:96
 msgid ""
-"In the event that we're notified of a copyright or license infringement, we "
-"will take steps to review the situation and determine if an actual "
-"infringement has occurred. If we determine that there is an infringement, we"
-" will remove the offending add-on and contact the author. New add-on "
-"submissions (including updates) containing infringing code will be denied "
-"approval for public status."
+"In the event that we're notified of a copyright or license infringement, we will take steps to review the situation and determine if an actual infringement has occurred. If we determine that there "
+"is an infringement, we will remove the offending add-on and contact the author. New add-on submissions (including updates) containing infringing code will be denied approval for public status."
 msgstr ""
-"В случае, если мы будем уведомлены о нарушении авторских прав или лицензии, "
-"мы предпримем шаги для анализа ситуации и определения того, произошло ли "
-"фактическое нарушение. Если мы определим, что произошло нарушение, мы удалим"
-" это дополнение и свяжемся с автором. Новым представлениям дополнений "
-"(включая обновления), содержащим код, нарушающий законодательство, будет "
-"отказано в предоставлении публичного статуса."
+"В случае, если мы будем уведомлены о нарушении авторских прав или лицензии, мы предпримем шаги для анализа ситуации и определения того, произошло ли фактическое нарушение. Если мы определим, что "
+"произошло нарушение, мы удалим это дополнение и свяжемся с автором. Новым представлениям дополнений (включая обновления), содержащим код, нарушающий законодательство, будет отказано в "
+"предоставлении публичного статуса."
 
 #: src/olympia/devhub/templates/devhub/docs/policies-maintenance.html:102
-msgid ""
-"If you are unsure of the current copyright status of an add-on's source "
-"code, you must contact the original author and receive explicit permission "
-"before using the source code."
+msgid "If you are unsure of the current copyright status of an add-on's source code, you must contact the original author and receive explicit permission before using the source code."
 msgstr ""
-"Если вы не уверены в текущем состоянии авторских прав на исходный код "
-"дополнения, вы должны связаться с первоначальным автором и получить явное "
-"разрешение, прежде чем использовать исходный код."
+"Если вы не уверены в текущем состоянии авторских прав на исходный код дополнения, вы должны связаться с первоначальным автором и получить явное разрешение, прежде чем использовать исходный код."
 
-#: src/olympia/devhub/templates/devhub/docs/policies-maintenance.html:107
-#: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:306
+#: src/olympia/devhub/templates/devhub/docs/policies-maintenance.html:107 src/olympia/devhub/templates/devhub/docs/policies-reviews.html:306
 #: src/olympia/devhub/templates/devhub/docs/policies-submission.html:97
 msgid "Last updated: January 13, 2011"
 msgstr "Последнее обновление: 13 января 2011"
@@ -6895,56 +5462,35 @@ msgstr "Последнее обновление: 13 января 2011"
 #: src/olympia/devhub/templates/devhub/docs/policies-recommended.html:13
 #, python-format
 msgid ""
-"Featured add-ons are top-quality extensions and themes highlighted on <a "
-"href=\"%(link_gallery)s\">AMO</a>, Firefox's Add-ons Manager, and across "
-"other Mozilla websites. These add-ons showcase the power of Firefox "
-"customization and are useful to a wide audience."
+"Featured add-ons are top-quality extensions and themes highlighted on <a href=\"%(link_gallery)s\">AMO</a>, Firefox's Add-ons Manager, and across other Mozilla websites. These add-ons showcase the "
+"power of Firefox customization and are useful to a wide audience."
 msgstr ""
-"Рекомендуемые дополнения являются высококачественными расширениями и темами,"
-" выделенными на <a href=\"%(link_gallery)s\">AMO</a>, менеджере дополнений "
-"Firefox и других веб-сайтах Mozilla. Эти дополнения демонстрируют силу "
-"настраиваемости Firefox и полезны для широкой аудитории."
+"Рекомендуемые дополнения являются высококачественными расширениями и темами, выделенными на <a href=\"%(link_gallery)s\">AMO</a>, менеджере дополнений Firefox и других веб-сайтах Mozilla. Эти "
+"дополнения демонстрируют силу настраиваемости Firefox и полезны для широкой аудитории."
 
 #: src/olympia/devhub/templates/devhub/docs/policies-recommended.html:19
 msgid ""
-"Featured add-ons are chosen by the Featured Add-ons Advisory Board, a small "
-"group of add-on developers and fans from the Mozilla community who have "
-"volunteered to review and vote on nominations."
+"Featured add-ons are chosen by the Featured Add-ons Advisory Board, a small group of add-on developers and fans from the Mozilla community who have volunteered to review and vote on nominations."
 msgstr ""
-"Избранные дополнения выбираются каждый месяц Консультативным Советом по "
-"Избранным дополнениям, небольшой группой разработчиков дополнений и "
-"поклонников из сообщества Mozilla, которые вызвались рассмотреть кандидатов "
-"и проголосовать по номинациям."
+"Избранные дополнения выбираются каждый месяц Консультативным Советом по Избранным дополнениям, небольшой группой разработчиков дополнений и поклонников из сообщества Mozilla, которые вызвались "
+"рассмотреть кандидатов и проголосовать по номинациям."
 
 #: src/olympia/devhub/templates/devhub/docs/policies-recommended.html:25
 #, python-format
-msgid ""
-"<a href=\"%(link_featured)s\">Featured extensions</a> are chosen every "
-"month, and <a href=\"%(link_themes)s\">featured complete themes</a> are "
-"chosen every quarter."
-msgstr ""
-"<a href=\"%(link_featured)s\">Избранные расширения</a> выбираются каждый "
-"месяц, а <a href=\"%(link_themes)s\">избранные полные темы</a> выбираются "
-"раз в квартал."
+msgid "<a href=\"%(link_featured)s\">Featured extensions</a> are chosen every month, and <a href=\"%(link_themes)s\">featured complete themes</a> are chosen every quarter."
+msgstr "<a href=\"%(link_featured)s\">Избранные расширения</a> выбираются каждый месяц, а <a href=\"%(link_themes)s\">избранные полные темы</a> выбираются раз в квартал."
 
 #: src/olympia/devhub/templates/devhub/docs/policies-recommended.html:30
 msgid "Criteria for Featured Add-ons"
 msgstr "Критерии для избранных дополнений"
 
 #: src/olympia/devhub/templates/devhub/docs/policies-recommended.html:33
-msgid ""
-"Before nominating an add-on to be featured, please ensure it meets the "
-"following criteria:"
-msgstr ""
-"Перед номинацией дополнения в избранные убедитесь, что оно соответствует "
-"следующим критериям:"
+msgid "Before nominating an add-on to be featured, please ensure it meets the following criteria:"
+msgstr "Перед номинацией дополнения в избранные убедитесь, что оно соответствует следующим критериям:"
 
 #: src/olympia/devhub/templates/devhub/docs/policies-recommended.html:39
-msgid ""
-"The add-on must have a complete and informative listing on AMO. This means:"
-msgstr ""
-"Дополнение должно иметь полную и информативную страницу на AMO. Это "
-"означает:"
+msgid "The add-on must have a complete and informative listing on AMO. This means:"
+msgstr "Дополнение должно иметь полную и информативную страницу на AMO. Это означает:"
 
 #: src/olympia/devhub/templates/devhub/docs/policies-recommended.html:41
 msgid "a 64-pixel custom icon"
@@ -6967,44 +5513,28 @@ msgid "updated screenshots of the add-on's functionality"
 msgstr "обновленные скриншоты функциональности дополнения"
 
 #: src/olympia/devhub/templates/devhub/docs/policies-recommended.html:46
-msgid ""
-"must be fully approved by AMO editors (no preliminarily reviewed entries)"
-msgstr ""
-"должно быть полностью одобрено редакторами АМО (нет записей предварительной "
-"проверки)"
+msgid "must be fully approved by AMO editors (no preliminarily reviewed entries)"
+msgstr "должно быть полностью одобрено редакторами АМО (нет записей предварительной проверки)"
 
 #: src/olympia/devhub/templates/devhub/docs/policies-recommended.html:48
-msgid ""
-"The add-on must have excellent user reviews and any problems or support "
-"requests must be promptly addressed by the developer."
-msgstr ""
-"Дополнения должны иметь отличные отзывы пользователей, а любые проблемы или "
-"запросы на поддержку должны быть незамедлительно рассмотрены разработчиком."
+msgid "The add-on must have excellent user reviews and any problems or support requests must be promptly addressed by the developer."
+msgstr "Дополнения должны иметь отличные отзывы пользователей, а любые проблемы или запросы на поддержку должны быть незамедлительно рассмотрены разработчиком."
 
 #: src/olympia/devhub/templates/devhub/docs/policies-recommended.html:49
 msgid "The add-on must have a minimum of 2,000 users."
 msgstr "Дополнения должны иметь не менее 2000 пользователей."
 
 #: src/olympia/devhub/templates/devhub/docs/policies-recommended.html:50
-msgid ""
-"The add-on must be compatible with the latest release of Firefox and must be"
-" compatible with beta versions 4 weeks before their final release."
-msgstr ""
-"Дополнения должны быть совместимы с последней версии Firefox и должны быть "
-"совместимы с бета-версиями за 4 недели до их финального релиза."
+msgid "The add-on must be compatible with the latest release of Firefox and must be compatible with beta versions 4 weeks before their final release."
+msgstr "Дополнения должны быть совместимы с последней версии Firefox и должны быть совместимы с бета-версиями за 4 недели до их финального релиза."
 
 #: src/olympia/devhub/templates/devhub/docs/policies-recommended.html:51
 msgid ""
-"<strong>Most importantly</strong>, the add-on must have wide consumer appeal"
-" to Firefox's users and be outstanding in nearly every way: user experience,"
-" performance, security, and usefulness or entertainment value. Featured "
-"complete themes must also be visually appealing."
+"<strong>Most importantly</strong>, the add-on must have wide consumer appeal to Firefox's users and be outstanding in nearly every way: user experience, performance, security, and usefulness or "
+"entertainment value. Featured complete themes must also be visually appealing."
 msgstr ""
-"<strong>Самое важное</strong> - дополнение должно вызывать широкий интерес "
-"со стороны пользователей Firefox и быть выдающимся почти во всех отношениях:"
-" пользовательский интерфейс, производительность, безопасность, быть полезным"
-" или развлекательным. Избранные полные темы также должны быть визуально "
-"привлекательными."
+"<strong>Самое важное</strong> - дополнение должно вызывать широкий интерес со стороны пользователей Firefox и быть выдающимся почти во всех отношениях: пользовательский интерфейс, "
+"производительность, безопасность, быть полезным или развлекательным. Избранные полные темы также должны быть визуально привлекательными."
 
 #: src/olympia/devhub/templates/devhub/docs/policies-recommended.html:54
 msgid "Nominating an Add-on"
@@ -7016,268 +5546,167 @@ msgstr "amo-featured at mozilla dot org"
 
 #: src/olympia/devhub/templates/devhub/docs/policies-recommended.html:57
 #, python-format
-msgid ""
-"If you wish to nominate an add-on to be featured and it meets the criteria "
-"above, send an email to %(mail_featured)s with:"
-msgstr ""
-"Если вы хотите номинировать дополнение в избранные, и оно отвечает "
-"перечисленным выше критериям, отправьте письмо по электронной почте "
-"%(mail_featured)s с:"
+msgid "If you wish to nominate an add-on to be featured and it meets the criteria above, send an email to %(mail_featured)s with:"
+msgstr "Если вы хотите номинировать дополнение в избранные, и оно отвечает перечисленным выше критериям, отправьте письмо по электронной почте %(mail_featured)s с:"
 
 #: src/olympia/devhub/templates/devhub/docs/policies-recommended.html:62
 msgid "the add-on name, URL, and whether you are its developer"
 msgstr "названием дополнения, URL, и являетесь ли вы его разработчиком"
 
 #: src/olympia/devhub/templates/devhub/docs/policies-recommended.html:63
-msgid ""
-"a short explanation of why the add-on has wide appeal and should be featured"
-msgstr ""
-"короткое объяснение, почему дополнение вызывает большой интерес и должно "
-"быть избрано"
+msgid "a short explanation of why the add-on has wide appeal and should be featured"
+msgstr "короткое объяснение, почему дополнение вызывает большой интерес и должно быть избрано"
 
 #: src/olympia/devhub/templates/devhub/docs/policies-recommended.html:64
-msgid ""
-"optionally, links to any external reviews or articles mentioning the add-on"
-msgstr ""
-"опционально, ссылки на любые внешние обзоры и статьи, упоминающие дополнение"
+msgid "optionally, links to any external reviews or articles mentioning the add-on"
+msgstr "опционально, ссылки на любые внешние обзоры и статьи, упоминающие дополнение"
 
 #: src/olympia/devhub/templates/devhub/docs/policies-recommended.html:68
 msgid ""
-"Add-on nominations are reviewed by the Advisory Board once a month (once "
-"every 3 months for complete theme nominations). Common reasons for rejection"
-" include lacking wide appeal to consumers, a suboptimal user experience, "
-"quality or security issues, incompatibility, and similarity to another "
-"featured add-on. Rejected add-ons cannot be re-nominated within 3 months."
+"Add-on nominations are reviewed by the Advisory Board once a month (once every 3 months for complete theme nominations). Common reasons for rejection include lacking wide appeal to consumers, a "
+"suboptimal user experience, quality or security issues, incompatibility, and similarity to another featured add-on. Rejected add-ons cannot be re-nominated within 3 months."
 msgstr ""
-"Номинации дополнений рассматриваются нашим Консультативным советом один раз "
-"в месяц (раз в 3 месяца для номинаций полных тем). Типичными причинами "
-"отклонения являются отсутствие большого интереса пользователей, "
-"неоптимальный пользовательский интерфейс, проблемы с качеством или "
-"безопасностью, несовместимость и сходство с другим избранным дополнением. "
-"Отклоненные дополнения не могут быть снова номинированы в течение 3 месяцев."
+"Номинации дополнений рассматриваются нашим Консультативным советом один раз в месяц (раз в 3 месяца для номинаций полных тем). Типичными причинами отклонения являются отсутствие большого интереса "
+"пользователей, неоптимальный пользовательский интерфейс, проблемы с качеством или безопасностью, несовместимость и сходство с другим избранным дополнением. Отклоненные дополнения не могут быть "
+"снова номинированы в течение 3 месяцев."
 
 #: src/olympia/devhub/templates/devhub/docs/policies-recommended.html:73
 msgid "Rotating Featured Add-ons"
 msgstr "Ротация избранных дополнений"
 
 #: src/olympia/devhub/templates/devhub/docs/policies-recommended.html:76
-msgid ""
-"Mozilla and the Featured Add-ons Advisory Board regularly evaluate and "
-"rotate out featured add-ons. Some of the most common reasons for add-ons "
-"being removed from the featured list are:"
+msgid "Mozilla and the Featured Add-ons Advisory Board regularly evaluate and rotate out featured add-ons. Some of the most common reasons for add-ons being removed from the featured list are:"
 msgstr ""
-"Mozilla и Консультативный совет по Избранным дополнениям регулярно "
-"производят оценку и ротацию избранных дополнений. Некоторыми из наиболее "
-"распространенных причин, по которым дополнения удаляются из списка "
-"избранных, являются:"
+"Mozilla и Консультативный совет по Избранным дополнениям регулярно производят оценку и ротацию избранных дополнений. Некоторыми из наиболее распространенных причин, по которым дополнения удаляются "
+"из списка избранных, являются:"
 
 #: src/olympia/devhub/templates/devhub/docs/policies-recommended.html:83
 msgid ""
-"Lack of growth &mdash; Add-ons that are featured typically experience a "
-"substantial gain in both downloads and active users. If an add-on is not "
-"demonstrating growth in any substantial way, that's a good indicator the "
-"add-on may not be very useful to our users."
+"Lack of growth &mdash; Add-ons that are featured typically experience a substantial gain in both downloads and active users. If an add-on is not demonstrating growth in any substantial way, that's "
+"a good indicator the add-on may not be very useful to our users."
 msgstr ""
-"Отсутствие роста &mdash; Дополнения, попавшие в избранные, как правило "
-"испытывают существенный рост загрузок и активных пользователей. Если "
-"дополнение не демонстрирует существенного роста, это является хорошим "
-"индикатором, что оно может быть не очень полезно для пользователей."
+"Отсутствие роста &mdash; Дополнения, попавшие в избранные, как правило испытывают существенный рост загрузок и активных пользователей. Если дополнение не демонстрирует существенного роста, это "
+"является хорошим индикатором, что оно может быть не очень полезно для пользователей."
 
 #: src/olympia/devhub/templates/devhub/docs/policies-recommended.html:88
-msgid ""
-"Negative reviews &mdash; Featured add-ons should have a great experience and"
-" very few bugs, so add-ons with many negative reviews may be reconsidered."
+msgid "Negative reviews &mdash; Featured add-ons should have a great experience and very few bugs, so add-ons with many negative reviews may be reconsidered."
 msgstr ""
-"Отрицательные отзывы &mdash; Избранные дополнения должны отлично работать и "
-"иметь очень мало ошибок, так что решение в отношение дополнений с большим "
-"количеством отрицательных отзывов может быть пересмотрено."
+"Отрицательные отзывы &mdash; Избранные дополнения должны отлично работать и иметь очень мало ошибок, так что решение в отношение дополнений с большим количеством отрицательных отзывов может быть "
+"пересмотрено."
 
 #: src/olympia/devhub/templates/devhub/docs/policies-recommended.html:93
 msgid ""
-"Incompatibility with upcoming Firefox versions &mdash; Featured add-ons are "
-"expected to be compatible with stable and beta versions of Firefox. Add-ons "
-"not yet compatible with a Beta version of Firefox four weeks before its "
-"expected release will lose their featured status."
+"Incompatibility with upcoming Firefox versions &mdash; Featured add-ons are expected to be compatible with stable and beta versions of Firefox. Add-ons not yet compatible with a Beta version of "
+"Firefox four weeks before its expected release will lose their featured status."
 msgstr ""
-"Несовместимость со скоро выходящими версиями Firefox &mdash; Ожидается, что "
-"избранные дополнения должны быть совместимы со стабильными и бета-версиями "
-"Firefox. Дополнения, ещё не совместимые с бета-версией Firefox за четыре "
-"недели до его ожидаемого релиза, потеряют свой статус избранного."
+"Несовместимость со скоро выходящими версиями Firefox &mdash; Ожидается, что избранные дополнения должны быть совместимы со стабильными и бета-версиями Firefox. Дополнения, ещё не совместимые с бета-"
+"версией Firefox за четыре недели до его ожидаемого релиза, потеряют свой статус избранного."
 
 #: src/olympia/devhub/templates/devhub/docs/policies-recommended.html:99
 msgid "Joining the Featured Add-ons Advisory Board"
 msgstr "Присоединение к консультативному совету по избранным дополнениям"
 
 #: src/olympia/devhub/templates/devhub/docs/policies-recommended.html:102
-msgid ""
-"Every six months a new Advisory Board is chosen based on applications from "
-"the add-ons community. Members must:"
-msgstr ""
-"Каждые шесть месяцев на основе заявок от сообщества дополнений выбирается "
-"новый Консультативный совет. Участники должны:"
+msgid "Every six months a new Advisory Board is chosen based on applications from the add-ons community. Members must:"
+msgstr "Каждые шесть месяцев на основе заявок от сообщества дополнений выбирается новый Консультативный совет. Участники должны:"
 
 #: src/olympia/devhub/templates/devhub/docs/policies-recommended.html:108
-msgid ""
-"be active members of the add-ons community, whether as a developer, "
-"evangelist, or fan"
-msgstr ""
-"быть активными членами сообщества дополнений, независимо от того, являются "
-"ли они разработчиками, евангелистами, или фанами"
+msgid "be active members of the add-ons community, whether as a developer, evangelist, or fan"
+msgstr "быть активными членами сообщества дополнений, независимо от того, являются ли они разработчиками, евангелистами, или фанами"
 
 #: src/olympia/devhub/templates/devhub/docs/policies-recommended.html:109
-msgid ""
-"commit to trying all the nominations submitted, giving their feedback, and "
-"casting their votes every month"
-msgstr ""
-"обязуется попробовать все представленные номинации, отправить свои отзывы и "
-"голосовать каждый месяц"
+msgid "commit to trying all the nominations submitted, giving their feedback, and casting their votes every month"
+msgstr "обязуется попробовать все представленные номинации, отправить свои отзывы и голосовать каждый месяц"
 
 #: src/olympia/devhub/templates/devhub/docs/policies-recommended.html:110
-msgid ""
-"abstain from voting on add-ons that they have any business or personal "
-"affiliations with, as well as direct competitors of any such add-ons"
-msgstr ""
-"воздержаться от голосования по дополнениям, с которыми у них есть деловые "
-"или личные отношения, а также по прямым конкурентам любых таких дополнений"
+msgid "abstain from voting on add-ons that they have any business or personal affiliations with, as well as direct competitors of any such add-ons"
+msgstr "воздержаться от голосования по дополнениям, с которыми у них есть деловые или личные отношения, а также по прямым конкурентам любых таких дополнений"
 
 #: src/olympia/devhub/templates/devhub/docs/policies-recommended.html:114
 msgid ""
-"Members of the Mozilla Add-ons team may veto any add-on's selection because "
-"of security, privacy, compatibility, or any other reason, but in general it "
-"is up to the Board to select add-ons to feature."
+"Members of the Mozilla Add-ons team may veto any add-on's selection because of security, privacy, compatibility, or any other reason, but in general it is up to the Board to select add-ons to "
+"feature."
 msgstr ""
-"Члены команды дополнений Mozilla могут наложить вето на выбор любого "
-"дополнения из-за безопасности, приватности, совместимости или по любой "
-"другой причине, но в целом выбор избранных дополнений зависит от Совета."
+"Члены команды дополнений Mozilla могут наложить вето на выбор любого дополнения из-за безопасности, приватности, совместимости или по любой другой причине, но в целом выбор избранных дополнений "
+"зависит от Совета."
 
 #: src/olympia/devhub/templates/devhub/docs/policies-recommended.html:120
 msgid ""
-"This featured policy only applies to the addons.mozilla.org global list of "
-"featured add-ons. Add-ons featured in other locations are often pulled from "
-"this list, but Mozilla may feature any add-on in other locations without the"
-" Board's consent. Additionally, locale-specific features override the global"
-" defaults, so if a locale has opted to select its own features, some or all "
-"of the global features may not appear in that locale."
+"This featured policy only applies to the addons.mozilla.org global list of featured add-ons. Add-ons featured in other locations are often pulled from this list, but Mozilla may feature any add-on "
+"in other locations without the Board's consent. Additionally, locale-specific features override the global defaults, so if a locale has opted to select its own features, some or all of the global "
+"features may not appear in that locale."
 msgstr ""
-"Эта политика избранных дополнений применяется только к глобальному списку "
-"избранных дополнений addons.mozilla.org. Дополнения, избранные в других "
-"местах, часто берутся из этого списка, но Mozilla могут избирать любые "
-"дополнения в других местах без согласия Совета. Кроме того избранные, "
-"специфичные для локали, имеют приоритет над глобальным списком по умолчанию,"
-" так что если локаль решила выбрать свои избранные дополнения, некоторые или"
-" все из глобального списка избранных могут не отображаться в этой локали."
+"Эта политика избранных дополнений применяется только к глобальному списку избранных дополнений addons.mozilla.org. Дополнения, избранные в других местах, часто берутся из этого списка, но Mozilla "
+"могут избирать любые дополнения в других местах без согласия Совета. Кроме того избранные, специфичные для локали, имеют приоритет над глобальным списком по умолчанию, так что если локаль решила "
+"выбрать свои избранные дополнения, некоторые или все из глобального списка избранных могут не отображаться в этой локали."
 
 #: src/olympia/devhub/templates/devhub/docs/policies-recommended.html:126
 #, python-format
-msgid ""
-"Follow the <a href=\"%(link_blog)s\">Add-ons Blog</a> or <a "
-"href=\"%(link_twitter)s\">@mozamo</a> on Twitter to learn when the next "
-"application period opens."
-msgstr ""
-"Следуйте за <a href=\"%(link_blog)s\">Блогом Дополнений</a> или <a "
-"href=\"%(link_twitter)s\">@mozamo</a> в Твиттере, чтобы узнать, когда "
-"откроется следующий период номинаций."
+msgid "Follow the <a href=\"%(link_blog)s\">Add-ons Blog</a> or <a href=\"%(link_twitter)s\">@mozamo</a> on Twitter to learn when the next application period opens."
+msgstr "Следуйте за <a href=\"%(link_blog)s\">Блогом Дополнений</a> или <a href=\"%(link_twitter)s\">@mozamo</a> в Твиттере, чтобы узнать, когда откроется следующий период номинаций."
 
 #: src/olympia/devhub/templates/devhub/docs/policies-recommended.html:131
 msgid "Last updated: January 31, 2013"
 msgstr "Последнее обновление: 31 января 2013"
 
-#: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:3
-#: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:7
-#: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:8
-#: src/olympia/devhub/templates/devhub/docs/policies.html:15
-#: src/olympia/devhub/templates/devhub/docs/policies.html:64
+#: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:3 src/olympia/devhub/templates/devhub/docs/policies-reviews.html:7 src/olympia/devhub/templates/devhub/docs/policies-reviews.html:8
+#: src/olympia/devhub/templates/devhub/docs/policies.html:15 src/olympia/devhub/templates/devhub/docs/policies.html:64
 msgid "Review Process"
 msgstr "Процесс проверки"
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:12
 msgid ""
-"In order to ensure all add-ons hosted in our gallery are safe for users to "
-"install, Mozilla will begin requiring all hosted add-ons to undergo review. "
-"We offer two types of review and developers are free to choose the best fit "
-"for their add-on."
+"In order to ensure all add-ons hosted in our gallery are safe for users to install, Mozilla will begin requiring all hosted add-ons to undergo review. We offer two types of review and developers "
+"are free to choose the best fit for their add-on."
 msgstr ""
-"Для того, чтобы убедиться, что все дополнения, размещённые в нашей галерее, "
-"безопасны для установки пользователями, Mozilla начнёт требовать, чтобы все "
-"размещённые дополнения прошли проверку. Мы предлагаем два типа проверки и "
-"разработчики вольны выбирать наиболее подходящий вариант для их дополнения."
+"Для того, чтобы убедиться, что все дополнения, размещённые в нашей галерее, безопасны для установки пользователями, Mozilla начнёт требовать, чтобы все размещённые дополнения прошли проверку. Мы "
+"предлагаем два типа проверки и разработчики вольны выбирать наиболее подходящий вариант для их дополнения."
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:19
 msgid ""
-"<strong><a href=\"#full\">Full Review</a></strong> &mdash; a thorough "
-"functional and code review of the add-on, appropriate for add-ons ready for "
-"distribution to the masses. All site features are available to these add-"
-"ons."
+"<strong><a href=\"#full\">Full Review</a></strong> &mdash; a thorough functional and code review of the add-on, appropriate for add-ons ready for distribution to the masses. All site features are "
+"available to these add-ons."
 msgstr ""
-"<strong><a href=\"#full\">Полная проверка</a></strong> &mdash; тщательная "
-"проверка функций и кода дополнения, подходит для дополнений, готовых для "
-"массовому распространению. Для этих дополнений доступны все возможности "
-"сайта."
+"<strong><a href=\"#full\">Полная проверка</a></strong> &mdash; тщательная проверка функций и кода дополнения, подходит для дополнений, готовых для массовому распространению. Для этих дополнений "
+"доступны все возможности сайта."
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:24
 msgid ""
-"<strong><a href=\"#preliminary\">Preliminary Review</a></strong> &mdash; a "
-"faster review intended for experimental add-ons. Preliminary reviews do not "
-"check for functionality or full policy compliance, but the reviewed add-ons "
-"have install button cautions and some feature limitations."
+"<strong><a href=\"#preliminary\">Preliminary Review</a></strong> &mdash; a faster review intended for experimental add-ons. Preliminary reviews do not check for functionality or full policy "
+"compliance, but the reviewed add-ons have install button cautions and some feature limitations."
 msgstr ""
-"<strong><a href=\"#preliminary\">Предварительная проверка</a></strong> "
-"&mdash; более быстрая проверка, предназначенная для экспериментальных "
-"дополнений. Предварительные проверки не проверяют функциональность и полное "
-"соответствие политике, Проверенные таким образом дополнения выдают при "
-"установке предупреждения и имеют некоторые ограничения в возможностях."
+"<strong><a href=\"#preliminary\">Предварительная проверка</a></strong> &mdash; более быстрая проверка, предназначенная для экспериментальных дополнений. Предварительные проверки не проверяют "
+"функциональность и полное соответствие политике, Проверенные таким образом дополнения выдают при установке предупреждения и имеют некоторые ограничения в возможностях."
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:31
 msgid ""
-"Detailed descriptions of each option are below. After selecting a review "
-"process at submission, the add-on will be placed in the queue. Add-ons are "
-"reviewed by the <a href=\"https://wiki.mozilla.org/AMO:Editors\">AMO "
-"Editors</a>, a group of talented developers that volunteer to help the "
-"Mozilla project by reviewing add-ons to ensure a stable and safe experience "
-"for users. Developers will receive an email with any updates throughout the "
-"review process."
+"Detailed descriptions of each option are below. After selecting a review process at submission, the add-on will be placed in the queue. Add-ons are reviewed by the <a href=\"https://wiki.mozilla."
+"org/AMO:Editors\">AMO Editors</a>, a group of talented developers that volunteer to help the Mozilla project by reviewing add-ons to ensure a stable and safe experience for users. Developers will "
+"receive an email with any updates throughout the review process."
 msgstr ""
-"Ниже приведены подробные описания каждого варианта. После выбора при "
-"представлении процесса проверки дополнение будет помещено в очередь. "
-"Дополнения рассматриваются <a "
-"href=\"https://wiki.mozilla.org/AMO:Editors\">Редакторами АМО</a> - группой "
-"талантливых разработчиков, которые добровольно помогают проекту Mozilla, "
-"проверяя дополнения, чтобы убедиться, что они обеспечивают стабильную и "
-"безопасную работу пользователей. Разработчики будут получать письма по "
-"электронной почте, отражающие любые обновления в процессе проверки."
+"Ниже приведены подробные описания каждого варианта. После выбора при представлении процесса проверки дополнение будет помещено в очередь. Дополнения рассматриваются <a href=\"https://wiki.mozilla."
+"org/AMO:Editors\">Редакторами АМО</a> - группой талантливых разработчиков, которые добровольно помогают проекту Mozilla, проверяя дополнения, чтобы убедиться, что они обеспечивают стабильную и "
+"безопасную работу пользователей. Разработчики будут получать письма по электронной почте, отражающие любые обновления в процессе проверки."
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:37
 msgid ""
-"While waiting for review, add-ons will not appear anywhere in the gallery "
-"publicly, but direct links to the add-on's details page will work. This "
-"allows the author to blog or share the link with friends, inviting them to "
-"try it out, even when not yet reviewed."
+"While waiting for review, add-ons will not appear anywhere in the gallery publicly, but direct links to the add-on's details page will work. This allows the author to blog or share the link with "
+"friends, inviting them to try it out, even when not yet reviewed."
 msgstr ""
-"При ожидании проверки дополнение не будет появляться где-либо в публичной "
-"галерее, но прямые ссылки на страницу дополнения работать будут. Это "
-"позволит автору разместить пост в блоге или поделиться ссылкой с друзьями, "
-"приглашая их попробовать его, даже если оно ещё не проверено."
+"При ожидании проверки дополнение не будет появляться где-либо в публичной галерее, но прямые ссылки на страницу дополнения работать будут. Это позволит автору разместить пост в блоге или поделиться "
+"ссылкой с друзьями, приглашая их попробовать его, даже если оно ещё не проверено."
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:44
 msgid ""
-"Full reviews are appropriate for add-ons that are well-tested, stable, fast,"
-" and have wide appeal to our users. If you aren't confident that your add-on"
-" meets that criteria, please consider working out the kinks while in "
-"preliminary review and accumulating user feedback first."
+"Full reviews are appropriate for add-ons that are well-tested, stable, fast, and have wide appeal to our users. If you aren't confident that your add-on meets that criteria, please consider working "
+"out the kinks while in preliminary review and accumulating user feedback first."
 msgstr ""
-"Полные проверки подходят для хорошо протестированных, стабильных и быстрых "
-"дополнений, интересующих широкий круг пользователей. Если вы не уверены, что"
-" ваше дополнение подходит под эти критерии, пожалуйста, подумайте над "
-"устранением проблем, пока дополнение находится в стадии предварительной "
-"проверки и собирает отзывы пользователей."
+"Полные проверки подходят для хорошо протестированных, стабильных и быстрых дополнений, интересующих широкий круг пользователей. Если вы не уверены, что ваше дополнение подходит под эти критерии, "
+"пожалуйста, подумайте над устранением проблем, пока дополнение находится в стадии предварительной проверки и собирает отзывы пользователей."
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:50
-msgid ""
-"We aim to perform full reviews in under 10 days, though most add-ons are "
-"reviewed in much less time."
-msgstr ""
-"Мы стремимся выполнять полные проверки в течение не более 10 дней, хотя "
-"большинство дополнений проверяются в течение гораздо меньшего времени."
+msgid "We aim to perform full reviews in under 10 days, though most add-ons are reviewed in much less time."
+msgstr "Мы стремимся выполнять полные проверки в течение не более 10 дней, хотя большинство дополнений проверяются в течение гораздо меньшего времени."
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:55
 msgid "Testing Methods &amp; Common Issues"
@@ -7288,61 +5717,36 @@ msgid "When performing a full review, editors will:"
 msgstr "При выполнении полной проверки, редакторы:"
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:64
-msgid ""
-"install the add-on, making sure it functions as described and is free of "
-"major defects"
-msgstr ""
-"установите дополнение, убедитесь, что оно работает так, как оно описано, и "
-"свободно от значительных дефектов"
+msgid "install the add-on, making sure it functions as described and is free of major defects"
+msgstr "установите дополнение, убедитесь, что оно работает так, как оно описано, и свободно от значительных дефектов"
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:69
-msgid ""
-"perform a source code review, looking for performance and security best "
-"practices"
-msgstr ""
-"произведите проверку исходного кода, ища соответствие рекомендациям по "
-"производительности и безопасности"
+msgid "perform a source code review, looking for performance and security best practices"
+msgstr "произведите проверку исходного кода, ища соответствие рекомендациям по производительности и безопасности"
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:74
 msgid "ensure the add-on's privacy policy is in line with its functionality"
-msgstr ""
-"убедитесь, что политика приватности дополнения соответствует его "
-"функциональности"
+msgstr "убедитесь, что политика приватности дополнения соответствует его функциональности"
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:79
-msgid ""
-"look for compliance with all of Mozilla's policies, detailed in these "
-"documents"
-msgstr ""
-"проверьте соблюдение всех политик Mozilla, изложенных в этих документах"
+msgid "look for compliance with all of Mozilla's policies, detailed in these documents"
+msgstr "проверьте соблюдение всех политик Mozilla, изложенных в этих документах"
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:86
-msgid ""
-"Some of the most common issues we see when performing these reviews are:"
-msgstr ""
-"Некоторые из наиболее распространенных проблем, которые мы видим при "
-"выполнении этих проверок:"
+msgid "Some of the most common issues we see when performing these reviews are:"
+msgstr "Некоторые из наиболее распространенных проблем, которые мы видим при выполнении этих проверок:"
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:93
 msgid ""
-"<strong>JavaScript namespace pollution</strong> &mdash; the most common "
-"violation. Be sure to <a "
-"href=\"https://developer.mozilla.org/en/XUL_School/JavaScript_Object_Management\">wrap"
-" your loose variables</a>"
+"<strong>JavaScript namespace pollution</strong> &mdash; the most common violation. Be sure to <a href=\"https://developer.mozilla.org/en/XUL_School/JavaScript_Object_Management\">wrap your loose "
+"variables</a>"
 msgstr ""
-"<strong>Загрязнение пространства имен JavaScript</strong> &mdash; наиболее "
-"распространенное нарушение. Не забудьте <a "
-"href=\"https://developer.mozilla.org/en/XUL_School/JavaScript_Object_Management\">обернуть"
-" свои свободные переменные</a>"
+"<strong>Загрязнение пространства имен JavaScript</strong> &mdash; наиболее распространенное нарушение. Не забудьте <a href=\"https://developer.mozilla.org/en/XUL_School/JavaScript_Object_Management"
+"\">обернуть свои свободные переменные</a>"
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:99
-msgid ""
-"proper preference naming - all preference names should begin with "
-"\"extensions.\", followed by the add-on name or some other unique identifier"
-msgstr ""
-"надлежащее наименование настроек - все имена настроек следует начинать с "
-"\"extensions.\", за которым следует имя дополнения или другой уникальный "
-"идентификатор"
+msgid "proper preference naming - all preference names should begin with \"extensions.\", followed by the add-on name or some other unique identifier"
+msgstr "надлежащее наименование настроек - все имена настроек следует начинать с \"extensions.\", за которым следует имя дополнения или другой уникальный идентификатор"
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:103
 msgid "remote JavaScript execution or injection"
@@ -7387,101 +5791,65 @@ msgstr "деградация скорости запуска приложени�
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:117
 #, python-format
 msgid ""
-"For information on how to avoid these problems, please see our <a "
-"href=\"%(link_howto)s\">How-to Library</a>. Some of these practices, such as"
-" binary or obfuscated code, are allowed under certain conditions outlined "
-"below."
+"For information on how to avoid these problems, please see our <a href=\"%(link_howto)s\">How-to Library</a>. Some of these practices, such as binary or obfuscated code, are allowed under certain "
+"conditions outlined below."
 msgstr ""
-"Для получения информации о том, как избежать этих проблем, ознакомьтесь с <a"
-" href=\"%(link_howto)s\">Библиотекой инструкций</a>. Некоторые из этих "
-"методов, например, бинарный или запутанный код, разрешается при соблюдении "
-"описанных ниже определенных условий."
+"Для получения информации о том, как избежать этих проблем, ознакомьтесь с <a href=\"%(link_howto)s\">Библиотекой инструкций</a>. Некоторые из этих методов, например, бинарный или запутанный код, "
+"разрешается при соблюдении описанных ниже определенных условий."
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:123
 #, python-format
 msgid ""
-"Many of the above restrictions are tested automatically by an extension "
-"scanner that will flag suspicious add-ons for editor review. You can read "
-"more about this scanner in the <a href=\"%(link_validation)s\">Validation "
-"Help</a> document."
+"Many of the above restrictions are tested automatically by an extension scanner that will flag suspicious add-ons for editor review. You can read more about this scanner in the <a href="
+"\"%(link_validation)s\">Validation Help</a> document."
 msgstr ""
-"Многие из указанных выше ограничений проверяются автоматически сканером "
-"расширений, который будет отмечать подозрительные дополнения для проверки "
-"редактором. Вы можете узнать больше об этом сканере в документе <a "
-"href=\"%(link_validation)s\">Справка по валидации</a>."
+"Многие из указанных выше ограничений проверяются автоматически сканером расширений, который будет отмечать подозрительные дополнения для проверки редактором. Вы можете узнать больше об этом сканере "
+"в документе <a href=\"%(link_validation)s\">Справка по валидации</a>."
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:129
 msgid ""
-"If the add-on is site-specific, it is recommended that a test account is "
-"provided for use during the review process. Additionally, including detailed"
-" testing instructions will allow an editor to better understand how the add-"
-"on functions and expedite the testing process. This information can be "
-"placed in the Notes to Reviewer field when editing a version in the "
-"Developer Hub."
+"If the add-on is site-specific, it is recommended that a test account is provided for use during the review process. Additionally, including detailed testing instructions will allow an editor to "
+"better understand how the add-on functions and expedite the testing process. This information can be placed in the Notes to Reviewer field when editing a version in the Developer Hub."
 msgstr ""
-"Если дополнение специфично для сайта, мы рекомендуем вам предоставить "
-"тестовую учётную запись для использования в процессе проверки. Кроме того, "
-"включив подробные инструкции по тестированию, вы поможете редактору лучше "
-"понять, как работает дополнение и ускорить процесс тестирования. Эта "
-"информация может быть размещена в поле Примечания для проверяющих при "
-"редактировании версии в Центре разработки."
+"Если дополнение специфично для сайта, мы рекомендуем вам предоставить тестовую учётную запись для использования в процессе проверки. Кроме того, включив подробные инструкции по тестированию, вы "
+"поможете редактору лучше понять, как работает дополнение и ускорить процесс тестирования. Эта информация может быть размещена в поле Примечания для проверяющих при редактировании версии в Центре "
+"разработки."
 
-#: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:134
-#: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:168
+#: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:134 src/olympia/devhub/templates/devhub/docs/policies-reviews.html:168
 msgid "After the Review"
 msgstr "После проверки"
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:136
 msgid ""
-"Once an add-on is granted full review, it will immediately be available in "
-"the gallery, showing in browse and search results with a warning-free "
-"install button. All features, including voluntary contributions and beta "
-"channels will be available."
+"Once an add-on is granted full review, it will immediately be available in the gallery, showing in browse and search results with a warning-free install button. All features, including voluntary "
+"contributions and beta channels will be available."
 msgstr ""
-"Как только дополнение пройдёт полную проверку, оно будет немедленно доступно"
-" в галерее, будет отображено при просмотре сайта и в результатах поиска с "
-"кнопкой установки, не имеющей предупреждения. Все функции, включая "
-"добровольные взносы и бета-каналы будут доступны."
+"Как только дополнение пройдёт полную проверку, оно будет немедленно доступно в галерее, будет отображено при просмотре сайта и в результатах поиска с кнопкой установки, не имеющей предупреждения. "
+"Все функции, включая добровольные взносы и бета-каналы будут доступны."
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:142
 msgid ""
-"Subsequent versions of the add-on will automatically be placed in the full "
-"review queue. Until the review is completed, the new version will only be "
-"displayed on the Version History page of the add-on. Once reviewed, the "
-"version will be updated across the site and deployed through the automatic "
-"update service."
+"Subsequent versions of the add-on will automatically be placed in the full review queue. Until the review is completed, the new version will only be displayed on the Version History page of the add-"
+"on. Once reviewed, the version will be updated across the site and deployed through the automatic update service."
 msgstr ""
-"Последующие версии дополнения будут автоматически размещаться в очереди на "
-"полную проверку. До завершения проверки, новая версия будет отображаться "
-"только на странице истории версий дополнения. По завершении проверки, версия"
-" будет обновлена на сайте и развернута через службу автоматического "
-"обновления."
+"Последующие версии дополнения будут автоматически размещаться в очереди на полную проверку. До завершения проверки, новая версия будет отображаться только на странице истории версий дополнения. По "
+"завершении проверки, версия будет обновлена на сайте и развернута через службу автоматического обновления."
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:148
 msgid ""
-"If a version does not meet the criteria for full review, it can either be "
-"granted preliminary review or disabled if there is a security concern. The "
-"author will receive an email explaining the action taken and how to fix it. "
-"In most cases, the developer can simply fix the problem and re-submit for "
-"full review."
+"If a version does not meet the criteria for full review, it can either be granted preliminary review or disabled if there is a security concern. The author will receive an email explaining the "
+"action taken and how to fix it. In most cases, the developer can simply fix the problem and re-submit for full review."
 msgstr ""
-"Если версия не соответствует критериям полной проверки, она может либо "
-"пройти предварительную проверку, либо быть отключена, если возникла проблема"
-" с безопасностью. Автор получит электронное письмо, объясняющее принятые "
-"меры и то, как исправить эту ситуацию. В большинстве случаев разработчик "
-"может просто исправить проблему и вновь представить версию для полной "
-"проверки."
+"Если версия не соответствует критериям полной проверки, она может либо пройти предварительную проверку, либо быть отключена, если возникла проблема с безопасностью. Автор получит электронное "
+"письмо, объясняющее принятые меры и то, как исправить эту ситуацию. В большинстве случаев разработчик может просто исправить проблему и вновь представить версию для полной проверки."
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:155
 msgid ""
-"Preliminary reviews are appropriate for experimental add-ons and provide a "
-"way to get user testing and feedback without going through the longer, more "
-"thorough review process. We aim to complete these reviews in under 3 days."
+"Preliminary reviews are appropriate for experimental add-ons and provide a way to get user testing and feedback without going through the longer, more thorough review process. We aim to complete "
+"these reviews in under 3 days."
 msgstr ""
-"Предварительные проверки подходят для экспериментальных дополнений и "
-"обеспечивают тестирования пользователями и обратную связь, без прохождения "
-"более долгого, более тщательного процесса проверки. Мы стремимся завершать "
-"эти проверки в течение 3 дней."
+"Предварительные проверки подходят для экспериментальных дополнений и обеспечивают тестирования пользователями и обратную связь, без прохождения более долгого, более тщательного процесса проверки. "
+"Мы стремимся завершать эти проверки в течение 3 дней."
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:160
 msgid "Testing Methods"
@@ -7489,57 +5857,33 @@ msgstr "Методы тестирования"
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:162
 msgid ""
-"When performing a preliminary review, editors will review the source code "
-"for security issues and major policy violations, but will not install the "
-"add-on to test functionality in most cases. Preliminary review will be "
-"granted unless a security vulnerability or major policy violation is "
-"discovered."
+"When performing a preliminary review, editors will review the source code for security issues and major policy violations, but will not install the add-on to test functionality in most cases. "
+"Preliminary review will be granted unless a security vulnerability or major policy violation is discovered."
 msgstr ""
-"При проведении предварительной проверки, редакторы проверят исходный код на "
-"наличие проблем безопасности и серьезных нарушений политики, но в "
-"большинстве случаев не будут устанавливать дополнение для проверки его "
-"функциональности. Предварительная проверка будет пройдена, если не будет "
-"обнаружена уязвимость в системе безопасности или грубое нарушение политики."
+"При проведении предварительной проверки, редакторы проверят исходный код на наличие проблем безопасности и серьезных нарушений политики, но в большинстве случаев не будут устанавливать дополнение "
+"для проверки его функциональности. Предварительная проверка будет пройдена, если не будет обнаружена уязвимость в системе безопасности или грубое нарушение политики."
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:171
 msgid ""
-"Once preliminary review is granted, the add-on will be immediately available"
-" in the gallery, showing in browse and search results but ranked lower than "
-"fully-reviewed add-ons. Install buttons will have caution stripes and a "
-"notice that the add-on is experimental and not fully reviewed by Mozilla, "
-"though no click-through is required. Additionally, these add-ons cannot use "
-"the voluntary contributions and beta channel features."
+"Once preliminary review is granted, the add-on will be immediately available in the gallery, showing in browse and search results but ranked lower than fully-reviewed add-ons. Install buttons will "
+"have caution stripes and a notice that the add-on is experimental and not fully reviewed by Mozilla, though no click-through is required. Additionally, these add-ons cannot use the voluntary "
+"contributions and beta channel features."
 msgstr ""
-"После успешного прохождения предварительной проверки, дополнение сразу же "
-"станет доступно в галерее, будет показано в просмотре и результатах поиска, "
-"но будет иметь более низкий статус, чем полностью проверенные дополнения. "
-"Кнопки установки будут иметь предупреждающие полосы и уведомление, что "
-"дополнение является экспериментальным и не полностью проверено Mozilla, "
-"однако прощёлкивание сквозь экраны не требуется. Кроме того, эти дополнения "
-"не могут использовать добровольные взносы и функции бета-каналов."
+"После успешного прохождения предварительной проверки, дополнение сразу же станет доступно в галерее, будет показано в просмотре и результатах поиска, но будет иметь более низкий статус, чем "
+"полностью проверенные дополнения. Кнопки установки будут иметь предупреждающие полосы и уведомление, что дополнение является экспериментальным и не полностью проверено Mozilla, однако прощёлкивание "
+"сквозь экраны не требуется. Кроме того, эти дополнения не могут использовать добровольные взносы и функции бета-каналов."
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:177
-msgid ""
-"After being granted preliminary review, Mozilla may later revoke the review "
-"if other serious problems are reported to us by users."
-msgstr ""
-"После успешного прохождения предварительной проверки, Mozilla впоследствии "
-"может отозвать своё одобрение, если пользователи сообщат нам о других "
-"серьезных проблемах."
+msgid "After being granted preliminary review, Mozilla may later revoke the review if other serious problems are reported to us by users."
+msgstr "После успешного прохождения предварительной проверки, Mozilla впоследствии может отозвать своё одобрение, если пользователи сообщат нам о других серьезных проблемах."
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:183
 msgid ""
-"Subsequent versions of the add-on will automatically be placed in the "
-"preliminary review queue. Until the review is completed, the new version "
-"will only be displayed on the Version History page of the add-on. Once "
-"reviewed, the version will be updated across the site and deployed through "
-"the automatic update service."
+"Subsequent versions of the add-on will automatically be placed in the preliminary review queue. Until the review is completed, the new version will only be displayed on the Version History page of "
+"the add-on. Once reviewed, the version will be updated across the site and deployed through the automatic update service."
 msgstr ""
-"Последующие версии дополнения будут автоматически размещаться в очереди на "
-"предварительную проверку. До завершения проверки, новая версия будет "
-"отображаться только на странице истории версий дополнения. По завершении "
-"проверки, версия будет обновлена на сайте и развернута через службу "
-"автоматического обновления."
+"Последующие версии дополнения будут автоматически размещаться в очереди на предварительную проверку. До завершения проверки, новая версия будет отображаться только на странице истории версий "
+"дополнения. По завершении проверки, версия будет обновлена на сайте и развернута через службу автоматического обновления."
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:188
 msgid "Policies on Specific Add-on Practices"
@@ -7554,70 +5898,40 @@ msgid "The following add-ons are not permitted in any form:"
 msgstr "Следующие дополнения не разрешаются ни в какой форме:"
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:194
-msgid ""
-"Add-ons that embed known <a "
-"href=\"http://en.wikipedia.org/wiki/Spyware\">spyware</a> or <a "
-"href=\"http://en.wikipedia.org/wiki/Malware\">malware</a>"
-msgstr ""
-"Дополнения, включающие известные <a "
-"href=\"http://en.wikipedia.org/wiki/Spyware\">шпионские</a> или <a "
-"href=\"http://en.wikipedia.org/wiki/Malware\">вредоносные</a> программы"
+msgid "Add-ons that embed known <a href=\"http://en.wikipedia.org/wiki/Spyware\">spyware</a> or <a href=\"http://en.wikipedia.org/wiki/Malware\">malware</a>"
+msgstr "Дополнения, включающие известные <a href=\"http://en.wikipedia.org/wiki/Spyware\">шпионские</a> или <a href=\"http://en.wikipedia.org/wiki/Malware\">вредоносные</a> программы"
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:199
 msgid ""
-"Illegal and criminal add-ons, such as <a "
-"href=\"http://en.wikipedia.org/wiki/Click_fraud\">click fraud</a> "
-"generators, <a href=\"http://en.wikipedia.org/wiki/Warez\">warez</a> "
-"download and directory assistants, child pornography finders, etc."
+"Illegal and criminal add-ons, such as <a href=\"http://en.wikipedia.org/wiki/Click_fraud\">click fraud</a> generators, <a href=\"http://en.wikipedia.org/wiki/Warez\">warez</a> download and "
+"directory assistants, child pornography finders, etc."
 msgstr ""
-"Незаконные и преступные дополнения, такие как генераторы <a "
-"href=\"http://en.wikipedia.org/wiki/Click_fraud\">клик-фрода</a>, загрузки "
-"<a href=\"http://en.wikipedia.org/wiki/Warez\">вареза</a> и каталоги-"
-"помощники, поисковики детской порнографии, и т.д."
+"Незаконные и преступные дополнения, такие как генераторы <a href=\"http://en.wikipedia.org/wiki/Click_fraud\">клик-фрода</a>, загрузки <a href=\"http://en.wikipedia.org/wiki/Warez\">вареза</a> и "
+"каталоги-помощники, поисковики детской порнографии, и т.д."
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:204
-msgid ""
-"Add-ons whose main purpose is to facilitate access to pornographic material,"
-" or include references to this material in their descriptions"
-msgstr ""
-"Дополнения, главная цель которых заключается в облегчении доступа к "
-"порнографическим материалам, или содержащие в своих описаниях ссылки на эти "
-"материалы"
+msgid "Add-ons whose main purpose is to facilitate access to pornographic material, or include references to this material in their descriptions"
+msgstr "Дополнения, главная цель которых заключается в облегчении доступа к порнографическим материалам, или содержащие в своих описаниях ссылки на эти материалы"
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:210
-msgid ""
-"Add-ons that, upon installation, auto-install or launch installers of non-"
-"Firefox software"
-msgstr ""
-"Дополнения, которые, после своей установки, автоматически устанавливают или "
-"запускают инсталляторы программного обеспечения, не относящегося к Firefox"
+msgid "Add-ons that, upon installation, auto-install or launch installers of non-Firefox software"
+msgstr "Дополнения, которые, после своей установки, автоматически устанавливают или запускают инсталляторы программного обеспечения, не относящегося к Firefox"
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:215
-msgid ""
-"Add-ons that provide their own update mechanism for code or search engines"
-msgstr ""
-"Дополнения, которые содержат свой собственный механизм обновления для кода "
-"или поисковых систем"
+msgid "Add-ons that provide their own update mechanism for code or search engines"
+msgstr "Дополнения, которые содержат свой собственный механизм обновления для кода или поисковых систем"
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:220
-msgid ""
-"Add-ons that make changes to web content in ways that are non-obvious or "
-"difficult to trace by their users"
-msgstr ""
-"Дополнения, которые вносят изменения в веб-содержимое неочевидными или "
-"трудно отслеживаемыми для пользователей способами "
+msgid "Add-ons that make changes to web content in ways that are non-obvious or difficult to trace by their users"
+msgstr "Дополнения, которые вносят изменения в веб-содержимое неочевидными или трудно отслеживаемыми для пользователей способами "
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:225
 msgid "Add-ons that snoop on or intercept the network traffic of other users"
-msgstr ""
-"Дополнения, которые подглядывают или перехватывают сетевой трафик других "
-"пользователей"
+msgstr "Дополнения, которые подглядывают или перехватывают сетевой трафик других пользователей"
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:230
 msgid "Conduit-based toolbars without explicit pre-approval"
-msgstr ""
-"Основанные на Conduit панели инструментов без явного предварительного "
-"одобрения"
+msgstr "Основанные на Conduit панели инструментов без явного предварительного одобрения"
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:236
 msgid "Changing of Defaults and Unexpected Features"
@@ -7625,69 +5939,36 @@ msgstr "Изменяющие значения по умолчанию и име�
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:238
 msgid ""
-"Surprises can be appropriate in many situations, but they are not welcome "
-"when user security, privacy, and control are at stake. It is extremely "
-"important to be as transparent as possible when submitting an add-on for "
-"hosting on this site. A Mozilla user should be able to easily discern what "
-"the functionality of an add-on is and not be presented with unexpected "
-"experiences post-install."
+"Surprises can be appropriate in many situations, but they are not welcome when user security, privacy, and control are at stake. It is extremely important to be as transparent as possible when "
+"submitting an add-on for hosting on this site. A Mozilla user should be able to easily discern what the functionality of an add-on is and not be presented with unexpected experiences post-install."
 msgstr ""
-"Сюрпризы могут быть уместны в различных ситуациях, но они не приветствуются,"
-" когда на кону стоит безопасность и приватность пользователь или его "
-"контроль за ситуацией. При отправке дополнения для размещения на этом сайте "
-"чрезвычайно важно соблюдать максимальную прозрачность. Пользователь Mozilla "
-"должен иметь возможность легко распознать, что является функциональностью "
-"дополнения и не встречаться с неожиданными сюрпризами после установки."
+"Сюрпризы могут быть уместны в различных ситуациях, но они не приветствуются, когда на кону стоит безопасность и приватность пользователь или его контроль за ситуацией. При отправке дополнения для "
+"размещения на этом сайте чрезвычайно важно соблюдать максимальную прозрачность. Пользователь Mozilla должен иметь возможность легко распознать, что является функциональностью дополнения и не "
+"встречаться с неожиданными сюрпризами после установки."
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:243
 msgid ""
-"<p> Whenever an add-on includes any unexpected* feature that </p> <ul> "
-"<li>compromises user privacy or security (like sending data to third "
-"parties),</li> <li>changes default settings like the homepage or search "
-"engine, or</li> <li>changes settings or features in other add-ons or "
-"deactivates them altogether</li> </ul> <p>the features must adhere to the "
-"following requirements:</p> <ul> <li>The add-on description must clearly "
-"state what changes the add-on makes.</li> <li>All changes must be opt-in, "
-"meaning the user must take non-default action to enact the change.</li> "
-"<li>The opt-in dialog must clearly state the name of the add-on requesting "
-"the change.</li> <li>Uninstalling the add-on restores the user's original "
-"settings if they were changed.</li> </ul> <p>*Unexpected features are those "
-"that are unrelated to the add-on's primary function.</p>"
+"<p> Whenever an add-on includes any unexpected* feature that </p> <ul> <li>compromises user privacy or security (like sending data to third parties),</li> <li>changes default settings like the "
+"homepage or search engine, or</li> <li>changes settings or features in other add-ons or deactivates them altogether</li> </ul> <p>the features must adhere to the following requirements:</p> <ul> "
+"<li>The add-on description must clearly state what changes the add-on makes.</li> <li>All changes must be opt-in, meaning the user must take non-default action to enact the change.</li> <li>The opt-"
+"in dialog must clearly state the name of the add-on requesting the change.</li> <li>Uninstalling the add-on restores the user's original settings if they were changed.</li> </ul> <p>*Unexpected "
+"features are those that are unrelated to the add-on's primary function.</p>"
 msgstr ""
-"<p> Всякий раз, когда дополнение включает в себя какую-либо неожиданную* "
-"функцию, которая </p> <ul> <li>компрометирует приватность или безопасность "
-"пользователя (например передаёт данные третьим лицам),</li> <li>изменяет "
-"настройки по умолчанию, например домашнюю страницу или поисковую систему, "
-"или</li> <li>изменяет настройки или функции в других дополнениях или "
-"деактивирует их целиком</li></ul><p>функции должны соответствовать следующим"
-" требованиям:</p> <ul> <li> Описание дополнения должно четко указывать "
-"производимые дополнением изменения.</li> <li>Пользователь должен в явном "
-"виде согласиться принять все изменения, то есть пользователь должен "
-"произвести нестандартные действия по принятию изменений.</li> <li>В "
-"диалоговом окне произведения изменений должно быть четко указано имя "
-"дополнения, запрашивающего изменение.</li> <li>Удаление дополнения должно "
-"восстанавливать первоначальные настройки пользователя, если они были "
-"изменены.</li> </ul> <p> *Неожиданными функциями являются те, которые не "
-"имеют отношения к основной функции дополнения.</p>"
+"<p> Всякий раз, когда дополнение включает в себя какую-либо неожиданную* функцию, которая </p> <ul> <li>компрометирует приватность или безопасность пользователя (например передаёт данные третьим "
+"лицам),</li> <li>изменяет настройки по умолчанию, например домашнюю страницу или поисковую систему, или</li> <li>изменяет настройки или функции в других дополнениях или деактивирует их целиком</"
+"li></ul><p>функции должны соответствовать следующим требованиям:</p> <ul> <li> Описание дополнения должно четко указывать производимые дополнением изменения.</li> <li>Пользователь должен в явном "
+"виде согласиться принять все изменения, то есть пользователь должен произвести нестандартные действия по принятию изменений.</li> <li>В диалоговом окне произведения изменений должно быть четко "
+"указано имя дополнения, запрашивающего изменение.</li> <li>Удаление дополнения должно восстанавливать первоначальные настройки пользователя, если они были изменены.</li> </ul> <p> *Неожиданными "
+"функциями являются те, которые не имеют отношения к основной функции дополнения.</p>"
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:268
-msgid ""
-"These features cannot be introduced into an update of a fully-reviewed add-"
-"on; the opt-in change process must be part of the initial review."
-msgstr ""
-"Эти функции не могут быть введены в обновление полностью проверенного "
-"дополнения; изменение процесса получения согласия должно быть частью "
-"первоначальной проверки."
+msgid "These features cannot be introduced into an update of a fully-reviewed add-on; the opt-in change process must be part of the initial review."
+msgstr "Эти функции не могут быть введены в обновление полностью проверенного дополнения; изменение процесса получения согласия должно быть частью первоначальной проверки."
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:274
-msgid ""
-"These are minimum requirements and not a guarantee that the add-on will be "
-"approved. This section applies to all add-ons hosted on the site, including "
-"preliminarily reviewed add-ons."
+msgid "These are minimum requirements and not a guarantee that the add-on will be approved. This section applies to all add-ons hosted on the site, including preliminarily reviewed add-ons."
 msgstr ""
-"Это минимальные требования и не гарантируют того, что дополнение будет "
-"одобрено. Этот раздел относится ко всем дополнениям, размещенным на сайте, в"
-" том числе предварительно одобренным дополнениям."
+"Это минимальные требования и не гарантируют того, что дополнение будет одобрено. Этот раздел относится ко всем дополнениям, размещенным на сайте, в том числе предварительно одобренным дополнениям."
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:279
 msgid "Private Browsing Mode"
@@ -7695,18 +5976,11 @@ msgstr "Режим приватного просмотра"
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:282
 msgid ""
-"Add-ons that store or otherwise handle browsing data must support <a "
-"href=\"https://developer.mozilla.org/En/Supporting_private_browsing_mode\">Private"
-" Browsing Mode</a>.  During a Private Browsing session, no browsing data can"
-" be written to disk, and all of this data must be cleared when Firefox quits"
-" or the Private Browsing session ends."
+"Add-ons that store or otherwise handle browsing data must support <a href=\"https://developer.mozilla.org/En/Supporting_private_browsing_mode\">Private Browsing Mode</a>. During a Private Browsing "
+"session, no browsing data can be written to disk, and all of this data must be cleared when Firefox quits or the Private Browsing session ends."
 msgstr ""
-"Дополнения, которые хранят и обрабатывают данные просмотра должны "
-"поддерживать <a "
-"href=\"https://developer.mozilla.org/ru/docs/Supporting_private_browsing_mode\">режим"
-" Приватного просмотра</a>.  В этом режиме, никакие данные не должны "
-"записываться на диск, а все данные должны удаляться при выходе из Firefox "
-"или Приватного просмотра."
+"Дополнения, которые хранят и обрабатывают данные просмотра должны поддерживать <a href=\"https://developer.mozilla.org/ru/docs/Supporting_private_browsing_mode\">режим Приватного просмотра</a>.  В "
+"этом режиме, никакие данные не должны записываться на диск, а все данные должны удаляться при выходе из Firefox или Приватного просмотра."
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:287
 msgid "Binary Components & Obfuscated Code"
@@ -7714,42 +5988,26 @@ msgstr "Бинарные компоненты и обфусцированный 
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:289
 msgid ""
-"Add-ons may contain binary, obfuscated and minified source code, but Mozilla"
-" must be allowed to review a copy of the human-readable source code of each "
-"version of an add-on submitted for review. These add-ons are ineligible for "
-"preliminary review and must choose the full review process."
+"Add-ons may contain binary, obfuscated and minified source code, but Mozilla must be allowed to review a copy of the human-readable source code of each version of an add-on submitted for review. "
+"These add-ons are ineligible for preliminary review and must choose the full review process."
 msgstr ""
-"Дополнения могут содержать бинарный, запутанный и минимизированный исходный "
-"код, но для Mozilla должна быть предоставлена ​​возможность проверки "
-"доступной для человеческого понимания копии исходного кода для каждой версии"
-" дополнения, представленного для проверки. Эти дополнения не имеют права на "
-"процесс предварительной проверки и должны выбрать процесс полной проверки."
+"Дополнения могут содержать бинарный, запутанный и минимизированный исходный код, но для Mozilla должна быть предоставлена ​​возможность проверки доступной для человеческого понимания копии исходного "
+"кода для каждой версии дополнения, представленного для проверки. Эти дополнения не имеют права на процесс предварительной проверки и должны выбрать процесс полной проверки."
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:295
 msgid ""
-"If an add-on contains binary or obfuscated source code, the author will "
-"receive a message when the add-on is reviewed indicating whom to contact at "
-"Mozilla to coordinate review of the source code. This code will be reviewed "
-"by an administrator and will not be shared or redistributed in any way. The "
-"code will only be used for the purpose of reviewing the add-on."
+"If an add-on contains binary or obfuscated source code, the author will receive a message when the add-on is reviewed indicating whom to contact at Mozilla to coordinate review of the source code. "
+"This code will be reviewed by an administrator and will not be shared or redistributed in any way. The code will only be used for the purpose of reviewing the add-on."
 msgstr ""
-"Если дополнение содержит бинарный или запутанный исходный код, при проверке "
-"дополнения автор получит сообщение, указывающее, с кем из Mozilla ему надо "
-"связаться для координации проверки исходного кода. Этот код будет проверен "
-"администратором и не будет передаваться или распространяться каким-либо "
-"образом. Код будет использован только в целях проверки дополнения."
+"Если дополнение содержит бинарный или запутанный исходный код, при проверке дополнения автор получит сообщение, указывающее, с кем из Mozilla ему надо связаться для координации проверки исходного "
+"кода. Этот код будет проверен администратором и не будет передаваться или распространяться каким-либо образом. Код будет использован только в целях проверки дополнения."
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:301
 #, python-format
-msgid ""
-"If your add-on contains binary or obfuscated code that you don't own or "
-"can't get the source code for, you may <a href=\"%(link_contact)s\">contact "
-"us</a> for information on how to proceed."
+msgid "If your add-on contains binary or obfuscated code that you don't own or can't get the source code for, you may <a href=\"%(link_contact)s\">contact us</a> for information on how to proceed."
 msgstr ""
-"Если ваше дополнение содержит двоичный или запутанный код, который вам не "
-"принадлежит или для которого вы не можете получить исходный код, вы можете "
-"<a href=\"%(link_contact)s\">связаться с нами</a> для получения информации о"
-" дальнейших действиях."
+"Если ваше дополнение содержит двоичный или запутанный код, который вам не принадлежит или для которого вы не можете получить исходный код, вы можете <a href=\"%(link_contact)s\">связаться с нами</"
+"a> для получения информации о дальнейших действиях."
 
 #: src/olympia/devhub/templates/devhub/docs/policies-submission.html:11
 msgid "Criteria for Submission"
@@ -7757,237 +6015,128 @@ msgstr "Критерий представления"
 
 #: src/olympia/devhub/templates/devhub/docs/policies-submission.html:13
 msgid ""
-"Add-ons hosted on Mozilla Add-ons should be of high quality and give users "
-"an improved web experience. We look for the following things when deciding "
-"whether an add-on is appropriate to be public and unrestricted:"
+"Add-ons hosted on Mozilla Add-ons should be of high quality and give users an improved web experience. We look for the following things when deciding whether an add-on is appropriate to be public "
+"and unrestricted:"
 msgstr ""
-"Дополнения, размещенные на сайте дополнений Mozilla должны иметь высокое "
-"качество и улучшать для пользователей работу в Интернете. При принятии "
-"решения, может ли дополнение быть публичным и неограниченным в "
-"распространении мы смотрим на следующее:"
+"Дополнения, размещенные на сайте дополнений Mozilla должны иметь высокое качество и улучшать для пользователей работу в Интернете. При принятии решения, может ли дополнение быть публичным и "
+"неограниченным в распространении мы смотрим на следующее:"
 
 #: src/olympia/devhub/templates/devhub/docs/policies-submission.html:19
 msgid ""
-"<strong>Are you responsive?</strong> We expect that an author who is "
-"promoting their add-on to our applications' many users is responsive to "
-"problem reports, maintains their contact information, and updates their add-"
-"on promptly to keep current with Firefox releases and changes in our "
-"policies. This doesn't mean that you have to reply to every question that "
-"someone posts in the discussions, or that you even need to fix every bug, "
-"but we do expect that you will respond to issues in a manner that's "
-"appropriate to the severity of the issue in question."
+"<strong>Are you responsive?</strong> We expect that an author who is promoting their add-on to our applications' many users is responsive to problem reports, maintains their contact information, "
+"and updates their add-on promptly to keep current with Firefox releases and changes in our policies. This doesn't mean that you have to reply to every question that someone posts in the "
+"discussions, or that you even need to fix every bug, but we do expect that you will respond to issues in a manner that's appropriate to the severity of the issue in question."
 msgstr ""
-"<strong>Вы отзывчивы?</strong> Мы ожидаем, что автор, продвигающий своё "
-"дополнение для множества пользователей наших приложений, будет реагировать "
-"на сообщения о проблемах, иметь актуальные контактные данные и оперативно "
-"обновлять своё дополнение, не отставая от релизов Firefox и изменений в "
-"наших политиках. Это не означает, что вы должны отвечать на каждый вопрос, "
-"задаваемый кем-либо в ходе обсуждения, или даже что вам нужно исправлять "
-"каждую ошибку, но мы ожидаем, что вы будете реагировать на проблемы в "
-"соответствии с серьёзностью возникшей проблемы."
+"<strong>Вы отзывчивы?</strong> Мы ожидаем, что автор, продвигающий своё дополнение для множества пользователей наших приложений, будет реагировать на сообщения о проблемах, иметь актуальные "
+"контактные данные и оперативно обновлять своё дополнение, не отставая от релизов Firefox и изменений в наших политиках. Это не означает, что вы должны отвечать на каждый вопрос, задаваемый кем-либо "
+"в ходе обсуждения, или даже что вам нужно исправлять каждую ошибку, но мы ожидаем, что вы будете реагировать на проблемы в соответствии с серьёзностью возникшей проблемы."
 
 #: src/olympia/devhub/templates/devhub/docs/policies-submission.html:25
 msgid ""
-"<strong>Is the add-on clearly and accurately described?</strong> It's of the"
-" utmost importance to us that users get what they expect when they try a new"
-" add-on. Your add-on name should be clear and concise, and you should "
-"refrain from using special characters or numbers to get higher search "
-"rankings or for decorative purposes. Your description should provide details"
-" about what the add-on does, how a user should take advantage of it, and "
-"what the user should expect when they install it. Links to external "
-"documents for detailed instructions are fine, but the description itself "
-"should cover the basics and leave users confident that they know what "
-"they'll get. Also, it is important that you maintain version notes "
-"appropriately as you improve and change your add-on. Users should be able to"
-" see what's new in an add-on they may have tried previously, and should be "
-"made aware of changes that might affect their current use of the add-on when"
-" they update."
+"<strong>Is the add-on clearly and accurately described?</strong> It's of the utmost importance to us that users get what they expect when they try a new add-on. Your add-on name should be clear and "
+"concise, and you should refrain from using special characters or numbers to get higher search rankings or for decorative purposes. Your description should provide details about what the add-on "
+"does, how a user should take advantage of it, and what the user should expect when they install it. Links to external documents for detailed instructions are fine, but the description itself should "
+"cover the basics and leave users confident that they know what they'll get. Also, it is important that you maintain version notes appropriately as you improve and change your add-on. Users should "
+"be able to see what's new in an add-on they may have tried previously, and should be made aware of changes that might affect their current use of the add-on when they update."
 msgstr ""
-"<strong>Дополнение чётко и аккуратно описано?</strong> Для нас крайне важно,"
-" чтобы пользователи получали то, что они ожидают, когда они испытывают в "
-"работе новое дополнение. Имя вашего дополнения должно быть чётким и ясным, и"
-" вам следует воздерживаться от использования специальных символов или цифр "
-"для получения более высокого поискового рейтинга или в декоративных целях. "
-"Ваше описание должно предоставлять информацию о том, что делает дополнение, "
-"как его может использовать пользователь и что должен ожидать пользователь "
-"после его установки. Вы можете приводить ссылки на внешние документы, в "
-"которых даны подробные инструкции, но само описание должно содержать основы,"
-" чтобы дать пользователям уверенность, что они знают, что они получат. Кроме"
-" того, важно, что вы вели примечания к новым версиям по мере того, как вы "
-"улучшаете и изменяете ваше дополнение. Пользователи должны иметь возможность"
-" видеть, что нового появилось в ранее используемом ими дополнении, и должны "
-"быть в курсе изменений, которые могут повлиять на их текущую работу с "
-"дополнением после того, как они его обновят."
+"<strong>Дополнение чётко и аккуратно описано?</strong> Для нас крайне важно, чтобы пользователи получали то, что они ожидают, когда они испытывают в работе новое дополнение. Имя вашего дополнения "
+"должно быть чётким и ясным, и вам следует воздерживаться от использования специальных символов или цифр для получения более высокого поискового рейтинга или в декоративных целях. Ваше описание "
+"должно предоставлять информацию о том, что делает дополнение, как его может использовать пользователь и что должен ожидать пользователь после его установки. Вы можете приводить ссылки на внешние "
+"документы, в которых даны подробные инструкции, но само описание должно содержать основы, чтобы дать пользователям уверенность, что они знают, что они получат. Кроме того, важно, что вы вели "
+"примечания к новым версиям по мере того, как вы улучшаете и изменяете ваше дополнение. Пользователи должны иметь возможность видеть, что нового появилось в ранее используемом ими дополнении, и "
+"должны быть в курсе изменений, которые могут повлиять на их текущую работу с дополнением после того, как они его обновят."
 
 #: src/olympia/devhub/templates/devhub/docs/policies-submission.html:31
 msgid ""
-"<strong>Are all privacy and security concerns clearly spelled out?</strong> "
-"This is an aspect of a clear and accurate description, but such an important"
-" one that we feel it deserves specific mention. Many very useful and well-"
-"written add-ons manipulate some form of user data, or can present security "
-"hazards if misused; they are welcome on the site, but they must make it very"
-" clear to users what risks they might encounter, and what they can do to "
-"protect themselves."
+"<strong>Are all privacy and security concerns clearly spelled out?</strong> This is an aspect of a clear and accurate description, but such an important one that we feel it deserves specific "
+"mention. Many very useful and well-written add-ons manipulate some form of user data, or can present security hazards if misused; they are welcome on the site, but they must make it very clear to "
+"users what risks they might encounter, and what they can do to protect themselves."
 msgstr ""
-"<strong>Все вопросы приватности и безопасности чётко прописаны?</strong> Это"
-" является аспектом чёткого и точного описания, но настолько важным, что мы "
-"чувствуем, что он заслуживает особого упоминания. Многие очень полезные и "
-"хорошо написанные дополнения манипулируют той или иной формой данных "
-"пользователя или могут представлять угрозу безопасности при их неправильном "
-"использовании; мы приветствуем их на нашем сайте, но они должны очень чётко "
-"довести до пользователей, с какими рисками они могут столкнуться, и что они "
-"могут сделать для своей защиты."
+"<strong>Все вопросы приватности и безопасности чётко прописаны?</strong> Это является аспектом чёткого и точного описания, но настолько важным, что мы чувствуем, что он заслуживает особого "
+"упоминания. Многие очень полезные и хорошо написанные дополнения манипулируют той или иной формой данных пользователя или могут представлять угрозу безопасности при их неправильном использовании; "
+"мы приветствуем их на нашем сайте, но они должны очень чётко довести до пользователей, с какими рисками они могут столкнуться, и что они могут сделать для своей защиты."
 
 #: src/olympia/devhub/templates/devhub/docs/policies-submission.html:37
 msgid ""
-"<strong>Has the add-on been well-tested, and is it free of obvious or "
-"serious defects?</strong> One important thing that we look for when "
-"considering an add-on is whether its user reviews indicate that it has "
-"received thorough testing, and that it doesn't have serious problems or "
-"negative impacts on the browser. If reviewers report problems such as major "
-"performance issues, crashes, frequent problems using the functions of the "
-"add-on, or spamming of messages to the error console, you should take those "
-"reports to heart, and re-submit your add-on after you've addressed them as "
-"best you can. We don't expect you to perfectly optimize or have zero bugs "
-"&mdash; Firefox itself undergoes constant improvement in these areas &mdash;"
-" but we do want you to take reasonable efforts to minimize downsides, and to"
-" clearly call out cases where users may be surprised by those that remain."
+"<strong>Has the add-on been well-tested, and is it free of obvious or serious defects?</strong> One important thing that we look for when considering an add-on is whether its user reviews indicate "
+"that it has received thorough testing, and that it doesn't have serious problems or negative impacts on the browser. If reviewers report problems such as major performance issues, crashes, frequent "
+"problems using the functions of the add-on, or spamming of messages to the error console, you should take those reports to heart, and re-submit your add-on after you've addressed them as best you "
+"can. We don't expect you to perfectly optimize or have zero bugs &mdash; Firefox itself undergoes constant improvement in these areas &mdash; but we do want you to take reasonable efforts to "
+"minimize downsides, and to clearly call out cases where users may be surprised by those that remain."
 msgstr ""
-"<strong>Было ли дополнение хорошо протестировано и свободно ли оно от явных "
-"или серьезных дефектов?</strong> Одной очень важной вещью, на которую мы "
-"смотрим при рассмотрении дополнения — показывают ли отзывы пользователей, "
-"что оно прошло тщательное тестирование, и не имеет ли оно серьёзных проблем "
-"или негативного влияния на браузер. Если в отзывах сообщается о серьёзных "
-"проблемах с производительностью, падениях, частых проблемах при "
-"использовании функций дополнения или множестве сообщений на консоли ошибок, "
-"вы должны тщательно рассмотреть эти сообщения, и вновь представить ваше "
-"дополнение после того, как вы по максимуму устранили эти проблемы. Мы не "
-"ожидаем, что вы добъётесь максимальной оптимизации или полного устранения "
-"ошибок &mdash; в этих областях Firefox сам подвергается постоянным "
-"усовершенствованиям &mdash; но мы хотим, чтобы вы предприняли разумные "
-"усилия по минимизации недостатков и четко обозначили те случаи, в которых "
-"пользователи могут встретить не ожидаемые ими оставшиеся проблемы."
+"<strong>Было ли дополнение хорошо протестировано и свободно ли оно от явных или серьезных дефектов?</strong> Одной очень важной вещью, на которую мы смотрим при рассмотрении дополнения — показывают "
+"ли отзывы пользователей, что оно прошло тщательное тестирование, и не имеет ли оно серьёзных проблем или негативного влияния на браузер. Если в отзывах сообщается о серьёзных проблемах с "
+"производительностью, падениях, частых проблемах при использовании функций дополнения или множестве сообщений на консоли ошибок, вы должны тщательно рассмотреть эти сообщения, и вновь представить "
+"ваше дополнение после того, как вы по максимуму устранили эти проблемы. Мы не ожидаем, что вы добъётесь максимальной оптимизации или полного устранения ошибок &mdash; в этих областях Firefox сам "
+"подвергается постоянным усовершенствованиям &mdash; но мы хотим, чтобы вы предприняли разумные усилия по минимизации недостатков и четко обозначили те случаи, в которых пользователи могут встретить "
+"не ожидаемые ими оставшиеся проблемы."
 
 #: src/olympia/devhub/templates/devhub/docs/policies-submission.html:43
 msgid ""
-"<strong>Do the add-on and add-on author both treat the user "
-"respectfully?</strong> Your software should not intrude on the user "
-"unnecessarily, try to trick the user, or conceal any of its activities from "
-"the user. Users (or even non-users) are sometimes rude in their comments, "
-"and while we will do our best to filter out inaccurate reviews as they're "
-"reported to us, we do expect that authors will avoid retaliating with "
-"rudeness of their own."
+"<strong>Do the add-on and add-on author both treat the user respectfully?</strong> Your software should not intrude on the user unnecessarily, try to trick the user, or conceal any of its "
+"activities from the user. Users (or even non-users) are sometimes rude in their comments, and while we will do our best to filter out inaccurate reviews as they're reported to us, we do expect that "
+"authors will avoid retaliating with rudeness of their own."
 msgstr ""
-"<strong>Относится ли дополнение или автор дополнения с уважением к "
-"пользователю?</strong> Ваша программа не должна без необходимости "
-"вмешиваться в работу пользователя, пытаться обмануть пользователя или "
-"скрывать какие-либо свои действия от пользователя. Пользователи (или даже не"
-" пользователи) иногда грубят в своих комментариях, и пока мы сделаем всё "
-"возможное, чтобы отфильтровать некорректные отзывы, мы ожидаем от авторов, "
-"что они не будут отвечать грубостью на грубость."
+"<strong>Относится ли дополнение или автор дополнения с уважением к пользователю?</strong> Ваша программа не должна без необходимости вмешиваться в работу пользователя, пытаться обмануть "
+"пользователя или скрывать какие-либо свои действия от пользователя. Пользователи (или даже не пользователи) иногда грубят в своих комментариях, и пока мы сделаем всё возможное, чтобы отфильтровать "
+"некорректные отзывы, мы ожидаем от авторов, что они не будут отвечать грубостью на грубость."
 
 #: src/olympia/devhub/templates/devhub/docs/policies-submission.html:49
 msgid ""
-"<strong>Is the add-on useful to an appropriately wide portion of Firefox's "
-"users?</strong> Your add-on doesn't need to be the next Greasemonkey or "
-"Firebug, but if it is only useful to people at your company or who are part "
-"of a small web community, we may feel that it's not yet appropriate to put "
-"it in front of all of our users."
+"<strong>Is the add-on useful to an appropriately wide portion of Firefox's users?</strong> Your add-on doesn't need to be the next Greasemonkey or Firebug, but if it is only useful to people at "
+"your company or who are part of a small web community, we may feel that it's not yet appropriate to put it in front of all of our users."
 msgstr ""
-"<strong>Является ли дополнение полезным для более-менее широкой части "
-"пользователей Firefox?</strong> Вашему дополнению не обязательно быть "
-"следующим Greasemonkey или Firebug, но если оно полезно только людям в вашей"
-" компании или тем, кто является частью небольшого веб-сообщества, мы можем "
-"прийти к мысли, что оно не подходит размещения перед всеми нашими "
-"пользователями."
+"<strong>Является ли дополнение полезным для более-менее широкой части пользователей Firefox?</strong> Вашему дополнению не обязательно быть следующим Greasemonkey или Firebug, но если оно полезно "
+"только людям в вашей компании или тем, кто является частью небольшого веб-сообщества, мы можем прийти к мысли, что оно не подходит размещения перед всеми нашими пользователями."
 
 #: src/olympia/devhub/templates/devhub/docs/policies-submission.html:55
 msgid ""
-"We are constantly looking at ways to improve the organization of the site to"
-" better accommodate add-ons that are exemplary in other ways, but are aimed "
-"at only a small community of potential users. Correctly categorizing and "
-"maintaining the metadata of your add-on will help us figure out how we can "
-"surface more of those sorts of add-ons to people who are most likely to "
-"benefit from them."
+"We are constantly looking at ways to improve the organization of the site to better accommodate add-ons that are exemplary in other ways, but are aimed at only a small community of potential users. "
+"Correctly categorizing and maintaining the metadata of your add-on will help us figure out how we can surface more of those sorts of add-ons to people who are most likely to benefit from them."
 msgstr ""
-"Мы постоянно ищем пути улучшения организации сайта для лучшего размещения "
-"дополнений, которые хотя и являются образцовыми по исполнению, но нацелены "
-"лишь на небольшое сообщество потенциальных пользователей. Правильная "
-"категоризация и управление метаданными вашего дополнения помогут нам понять,"
-" каким образом мы можем вывести больше дополнений подобного типа к людям, "
-"которым они могут принести наибольшую пользу."
+"Мы постоянно ищем пути улучшения организации сайта для лучшего размещения дополнений, которые хотя и являются образцовыми по исполнению, но нацелены лишь на небольшое сообщество потенциальных "
+"пользователей. Правильная категоризация и управление метаданными вашего дополнения помогут нам понять, каким образом мы можем вывести больше дополнений подобного типа к людям, которым они могут "
+"принести наибольшую пользу."
 
 #: src/olympia/devhub/templates/devhub/docs/policies-submission.html:61
 msgid ""
-"If your add-on just provides bookmarks or other simple access points to your"
-" site, it's probably not appropriate for the gallery. Like the rest of the "
-"Mozilla project, we love web applications and new web services, but Firefox "
-"add-ons should provide an improved browsing experience for the user and not "
-"just be a way to promote a new site or service through a Mozilla Add-ons "
-"listing."
+"If your add-on just provides bookmarks or other simple access points to your site, it's probably not appropriate for the gallery. Like the rest of the Mozilla project, we love web applications and "
+"new web services, but Firefox add-ons should provide an improved browsing experience for the user and not just be a way to promote a new site or service through a Mozilla Add-ons listing."
 msgstr ""
-"Если ваше дополнение просто предоставляет закладки и другие простые точки "
-"доступа на ваш сайт, то, вероятно, оно не подходит для галереи. Как всему "
-"проекту Mozilla, так и нам, нравятся веб-приложения и новые веб-сервисы, но "
-"дополнения Firefox должны обеспечивать улучшение веб-сёрфинга для "
-"пользователя, а не являться просто способом продвижения нового сайта или "
-"услуги через страницы дополнений Mozilla."
+"Если ваше дополнение просто предоставляет закладки и другие простые точки доступа на ваш сайт, то, вероятно, оно не подходит для галереи. Как всему проекту Mozilla, так и нам, нравятся веб-"
+"приложения и новые веб-сервисы, но дополнения Firefox должны обеспечивать улучшение веб-сёрфинга для пользователя, а не являться просто способом продвижения нового сайта или услуги через страницы "
+"дополнений Mozilla."
 
 #: src/olympia/devhub/templates/devhub/docs/policies-submission.html:67
 msgid ""
-"<strong>Is the add-on free of unlicensed trademarks and copyrights?</strong>"
-" Though you may mean no harm to the holder of a trademark, or the owner of a"
-" copyrighted work, we can't host add-ons that infringe on trademarks or "
-"copyrights. If you don't have permission to use a trademarked name or image,"
-" please do not submit your add-on to us. If your add-on includes code that "
-"is copyrighted by someone else, and is not licensed to you to use in your "
-"add-on, please do not submit your add-on to us."
+"<strong>Is the add-on free of unlicensed trademarks and copyrights?</strong> Though you may mean no harm to the holder of a trademark, or the owner of a copyrighted work, we can't host add-ons that "
+"infringe on trademarks or copyrights. If you don't have permission to use a trademarked name or image, please do not submit your add-on to us. If your add-on includes code that is copyrighted by "
+"someone else, and is not licensed to you to use in your add-on, please do not submit your add-on to us."
 msgstr ""
-"<strong>Отсутствуют ли в дополнении нелицензированные торговые марки и "
-"авторские права?</strong> Хотя возможно вы не хотите причинить какой-либо "
-"вред владельцу товарного знака или владельцу охраняемой авторским правом "
-"работы, мы не можем размещать дополнения, которые посягают на товарные знаки"
-" или авторские права. Если у вас нет разрешения на использование названия "
-"или изображения, являющегося торговой марки, пожалуйста, не отправляйте нам "
-"ваши дополнения. Если ваше дополнение включает в себя код, на который "
-"распространяется чужое авторское право, и вы не имеете лицензии на "
-"использование его в вашем дополнений, пожалуйста, не отправляйте нам ваши "
-"дополнения."
+"<strong>Отсутствуют ли в дополнении нелицензированные торговые марки и авторские права?</strong> Хотя возможно вы не хотите причинить какой-либо вред владельцу товарного знака или владельцу "
+"охраняемой авторским правом работы, мы не можем размещать дополнения, которые посягают на товарные знаки или авторские права. Если у вас нет разрешения на использование названия или изображения, "
+"являющегося торговой марки, пожалуйста, не отправляйте нам ваши дополнения. Если ваше дополнение включает в себя код, на который распространяется чужое авторское право, и вы не имеете лицензии на "
+"использование его в вашем дополнений, пожалуйста, не отправляйте нам ваши дополнения."
 
 #: src/olympia/devhub/templates/devhub/docs/policies-submission.html:73
 msgid ""
-"In terms of reuse of source code from other add-ons, if the author has not "
-"clearly stated that you are permitted to use his or her code in your own "
-"work &mdash; such as by placing it under an open source license &mdash; then"
-" you should assume that you do not have the right to do so. You can contact "
-"the author to seek such permission, but we can't provide you with any "
-"special rights to it just because it's listed on the site, or because the "
-"author isn't responding to your request."
+"In terms of reuse of source code from other add-ons, if the author has not clearly stated that you are permitted to use his or her code in your own work &mdash; such as by placing it under an open "
+"source license &mdash; then you should assume that you do not have the right to do so. You can contact the author to seek such permission, but we can't provide you with any special rights to it "
+"just because it's listed on the site, or because the author isn't responding to your request."
 msgstr ""
-"С точки зрения повторного использования исходного кода из других дополнений,"
-" если автор не указал в явном виде, что вы имеете право использовать его или"
-" её код в вашей работе &mdash; например, разместив его под открытой "
-"лицензией &mdash; то вы должны предположить, что вы не имеете право это "
-"делать. Вы можете связаться с автором, чтобы запросить такое разрешение, но "
-"мы не можем предоставить вам на него какие-либо специальные права только "
-"потому, что это размещено на сайте, или потому, что автор не отвечает на ваш"
-" запрос."
+"С точки зрения повторного использования исходного кода из других дополнений, если автор не указал в явном виде, что вы имеете право использовать его или её код в вашей работе &mdash; например, "
+"разместив его под открытой лицензией &mdash; то вы должны предположить, что вы не имеете право это делать. Вы можете связаться с автором, чтобы запросить такое разрешение, но мы не можем "
+"предоставить вам на него какие-либо специальные права только потому, что это размещено на сайте, или потому, что автор не отвечает на ваш запрос."
 
 #: src/olympia/devhub/templates/devhub/docs/policies-submission.html:79
 msgid ""
-"This applies to the Mozilla Foundation's trademarks as well, including "
-"\"Mozilla\", \"Firefox\", and \"Thunderbird\". The Mozilla policy on "
-"trademark use is designed to protect against confusion, and prevent the "
-"trademarks from being overturned due to lack of protection; please respect "
-"the need for such protection, and help us preserve some of the most valuable"
-" assets of the Mozilla Foundation."
+"This applies to the Mozilla Foundation's trademarks as well, including \"Mozilla\", \"Firefox\", and \"Thunderbird\". The Mozilla policy on trademark use is designed to protect against confusion, "
+"and prevent the trademarks from being overturned due to lack of protection; please respect the need for such protection, and help us preserve some of the most valuable assets of the Mozilla "
+"Foundation."
 msgstr ""
-"Это применяется также к товарным знакам Mozilla Foundation, включая "
-"\"Mozilla\", \"Firefox\", и \"Thunderbird\". Политика использование товарных"
-" знаков Mozilla разработана для защиты от путаницы и для предотвращения "
-"отзыва прав на товарные знаки вследствие отсутствия их защиты; пожалуйста, "
-"уважайте необходимость такой защиты, и помогите нам сохранить некоторые из "
-"наиболее ценных активов Mozilla Foundation."
+"Это применяется также к товарным знакам Mozilla Foundation, включая \"Mozilla\", \"Firefox\", и \"Thunderbird\". Политика использование товарных знаков Mozilla разработана для защиты от путаницы и "
+"для предотвращения отзыва прав на товарные знаки вследствие отсутствия их защиты; пожалуйста, уважайте необходимость такой защиты, и помогите нам сохранить некоторые из наиболее ценных активов "
+"Mozilla Foundation."
 
 #: src/olympia/devhub/templates/devhub/docs/policies-submission.html:84
 msgid "Licensing"
@@ -7995,255 +6144,176 @@ msgstr "Лицензирование"
 
 #: src/olympia/devhub/templates/devhub/docs/policies-submission.html:86
 msgid ""
-"Selecting an appropriate license for your add-on is a very important step in"
-" the submission process. A license specifies the rights you grant on your "
-"source code and is important in protecting your intellectual property."
+"Selecting an appropriate license for your add-on is a very important step in the submission process. A license specifies the rights you grant on your source code and is important in protecting your "
+"intellectual property."
 msgstr ""
-"Выбор подходящей лицензии для вашего дополнения является очень важным шагом "
-"в процессе представления. Лицензия определяет права, которые вы "
-"предоставляете на ваш исходный код, и играет важную роль в защите вашей "
-"интеллектуальной собственности."
+"Выбор подходящей лицензии для вашего дополнения является очень важным шагом в процессе представления. Лицензия определяет права, которые вы предоставляете на ваш исходный код, и играет важную роль "
+"в защите вашей интеллектуальной собственности."
 
 #: src/olympia/devhub/templates/devhub/docs/policies-submission.html:92
 msgid ""
-"During the add-on submission process, you will be presented with a list of "
-"popular licenses to choose from, as well as the ability to specify your own "
-"license. It is best to consult with a legal professional about which license"
-" option is best for you. Choosing the right license for your source code "
-"will help to prevent confusion and code conflicts in the future."
+"During the add-on submission process, you will be presented with a list of popular licenses to choose from, as well as the ability to specify your own license. It is best to consult with a legal "
+"professional about which license option is best for you. Choosing the right license for your source code will help to prevent confusion and code conflicts in the future."
 msgstr ""
-"В процессе представления дополнения, вам будет представлен на выбор список "
-"популярных лицензий, а также дана возможность указать свою собственную "
-"лицензию. Чтобы узнать, какой вариант лицензии лучше вам подходит, вам лучше"
-" всего проконсультироваться с юристом. Выбор правильной лицензии для вашего "
-"исходного кода поможет избежать путаницы и конфликтов кода в будущем."
+"В процессе представления дополнения, вам будет представлен на выбор список популярных лицензий, а также дана возможность указать свою собственную лицензию. Чтобы узнать, какой вариант лицензии "
+"лучше вам подходит, вам лучше всего проконсультироваться с юристом. Выбор правильной лицензии для вашего исходного кода поможет избежать путаницы и конфликтов кода в будущем."
 
-#: src/olympia/devhub/templates/devhub/docs/policies.html:12
-#: src/olympia/devhub/templates/devhub/docs/policies.html:52
+#: src/olympia/devhub/templates/devhub/docs/policies.html:12 src/olympia/devhub/templates/devhub/docs/policies.html:52
 msgid "Add-on Submission"
 msgstr "Представление дополнения"
 
-#: src/olympia/devhub/templates/devhub/docs/policies.html:18
-#: src/olympia/devhub/templates/devhub/docs/policies.html:78
+#: src/olympia/devhub/templates/devhub/docs/policies.html:18 src/olympia/devhub/templates/devhub/docs/policies.html:78
 msgid "Maintaining Your Add-on"
 msgstr "Обслуживание вашего дополнения"
 
 #: src/olympia/devhub/templates/devhub/docs/policies.html:43
-msgid ""
-"Mozilla is committed to ensuring a great add-ons experience for our users "
-"and developers. Please review the policies below before submitting your add-"
-"on."
-msgstr ""
-"Mozilla стремится обеспечить отличную работу дополнений для наших "
-"пользователей и разработчиков. Пожалуйста, ознакомьтесь с приведенным ниже "
-"правилами, перед отправкой дополнения."
+msgid "Mozilla is committed to ensuring a great add-ons experience for our users and developers. Please review the policies below before submitting your add-on."
+msgstr "Mozilla стремится обеспечить отличную работу дополнений для наших пользователей и разработчиков. Пожалуйста, ознакомьтесь с приведенным ниже правилами, перед отправкой дополнения."
 
 #: src/olympia/devhub/templates/devhub/docs/policies.html:55
-msgid ""
-"Find out what is expected of add-ons we host and our policies on specific "
-"add-on practices."
-msgstr ""
-"Узнайте, что ожидается от размещаемых нами дополнений, и каковы наши "
-"политики по специфичным практикам используемым дополнениями."
+msgid "Find out what is expected of add-ons we host and our policies on specific add-on practices."
+msgstr "Узнайте, что ожидается от размещаемых нами дополнений, и каковы наши политики по специфичным практикам используемым дополнениями."
 
 #: src/olympia/devhub/templates/devhub/docs/policies.html:67
-msgid ""
-"What happens after your add-on is submitted? Learn about how our Editors "
-"review submissions."
-msgstr ""
-"Что происходит после представления вашего дополнения? Узнайте о том, как "
-"наши редакторы проверяют представления."
+msgid "What happens after your add-on is submitted? Learn about how our Editors review submissions."
+msgstr "Что происходит после представления вашего дополнения? Узнайте о том, как наши редакторы проверяют представления."
 
 #: src/olympia/devhub/templates/devhub/docs/policies.html:81
-msgid ""
-"Add-on updates, transferring ownership, user reviews, and what to expect "
-"once your add-on is approved."
-msgstr ""
-"Обновления дополнений, передача владения, отзывы пользователей, и чего "
-"ожидать после одобрения вашего дополнения."
+msgid "Add-on updates, transferring ownership, user reviews, and what to expect once your add-on is approved."
+msgstr "Обновления дополнений, передача владения, отзывы пользователей, и чего ожидать после одобрения вашего дополнения."
 
 #: src/olympia/devhub/templates/devhub/docs/policies.html:93
-msgid ""
-"How up-and-coming add-ons become featured and what&#039;s involved in the "
-"process."
-msgstr ""
-"Как перспективные дополнения становятся избранными и что вовлечено в этот "
-"процесс."
+msgid "How up-and-coming add-ons become featured and what&#039;s involved in the process."
+msgstr "Как перспективные дополнения становятся избранными и что вовлечено в этот процесс."
 
 #: src/olympia/devhub/templates/devhub/docs/policies.html:106
-msgid ""
-"Terms of Service for submitting your work to our site. Developers are "
-"required to accept this agreement before submission."
-msgstr ""
-"Условия предоставления услуг для представления ваших работ на нашем сайте. "
-"Разработчики должны принять это соглашение перед представлением."
+msgid "Terms of Service for submitting your work to our site. Developers are required to accept this agreement before submission."
+msgstr "Условия предоставления услуг для представления ваших работ на нашем сайте. Разработчики должны принять это соглашение перед представлением."
 
 #: src/olympia/devhub/templates/devhub/docs/policies.html:118
 msgid "How to get in touch with us regarding these policies or your add-on."
 msgstr "Как связаться с нами по поводу этих политик или вашего дополнения."
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:6
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:10
 msgid "You have disabled this add-on"
 msgstr "Вы отключили это дополнение"
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:20
-msgid ""
-"Your add-on's listing is disabled and is not showing anywhere in our gallery"
-" or update service."
-msgstr ""
-"Страница вашего дополнения отключена и не отображается ни в нашей галерее ни"
-" в службе обновления."
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:24
+msgid "Your add-on's listing is disabled and is not showing anywhere in our gallery or update service."
+msgstr "Страница вашего дополнения отключена и не отображается ни в нашей галерее ни в службе обновления."
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:25
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:27
 msgid "Please complete your add-on."
 msgstr "Пожалуйста, завершите ваше дополнение."
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:29
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:30
 msgid "You will receive an email when the review is complete."
 msgstr "По завершении процесса проверки вы получите письмо."
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:34
-msgid ""
-"You will receive an email when the review is complete. Until\n"
-"                             then, your add-on is not listed in our gallery but can be\n"
-"                             accessed directly from its details page."
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:33
+msgid "You will receive an email when the review is complete. Until then, your add-on is not listed in our gallery but can be accessed directly from its details page."
 msgstr ""
 "Вы получите письмо, когда проверка будет завершена. До этого,\n"
 "                             ваше дополнение не будет отображаться в нашей галерее, но к нему\n"
 "                             можно получить доступ непосредственно с его страницы."
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:38
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:48
-msgid ""
-"You will receive an email when the review is\n"
-"                             complete and your add-on is signed."
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:37 src/olympia/devhub/templates/devhub/includes/addon_details.html:45
+msgid "You will receive an email when the review is complete and your add-on is signed."
 msgstr ""
 "Вы получите письмо после завершения\n"
 "                             проверки и подписи вашего дополнения."
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:44
-msgid ""
-"You will receive an email when the review is complete. Until\n"
-"                             then, your add-on is not listed in our gallery but can be\n"
-"                             accessed directly from its details page. "
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:41
+msgid "You will receive an email when the review is complete. Until then, your add-on is not listed in our gallery but can be accessed directly from its details page. "
 msgstr ""
-"Вы получите письмо, когда проверка будет завершена. До этого,\n"
-"                             ваше дополнение не будет отображаться в нашей галерее, но к нему\n"
-"                             можно получить доступ непосредственно с его страницы. "
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:54
-msgid ""
-"Your add-on is displayed in our gallery and users are\n"
-"                             receiving automatic updates."
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:49
+msgid "Your add-on is displayed in our gallery and users are receiving automatic updates."
 msgstr ""
 "Ваше дополнение отображается в нашей галерее и пользователи\n"
 "                             получают автоматические обновления."
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:57
-msgid ""
-"Your add-on has been signed and can be bundled with an\n"
-"                             application installer."
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:52
+msgid "Your add-on has been signed and can be bundled with an application installer."
 msgstr ""
 "Ваше дополнение подписано и может быть упаковано с\n"
 "                             установщиком приложения."
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:63
-msgid ""
-"Your add-on was disabled by a site administrator and is no\n"
-"                             longer shown in our gallery. If you have any questions,\n"
-"                             please email amo-admins@mozilla.org."
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:56
+msgid "Your add-on was disabled by a site administrator and is no longer shown in our gallery. If you have any questions, please email amo-admins@mozilla.org."
 msgstr ""
 "Ваше дополнение отключено администратором сайта и\n"
 "                             более не показывается в нашей галерее. Если у вам есть какие-либо вопросы,\n"
 "                             пожалуйста, напишите на amo-admins@mozilla.org."
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:70
-msgid ""
-"Your add-on is displayed in our gallery as experimental\n"
-"                             and users are receiving automatic updates. Some features\n"
-"                             are unavailable to your add-on."
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:62
+msgid "Your add-on is displayed in our gallery as experimental and users are receiving automatic updates. Some features are unavailable to your add-on."
 msgstr ""
 "Ваше дополнение показывается в нашей галерее как экспериментальное,\n"
 "                             а пользователи получают автоматические обновления. Некоторые\n"
 "                             возможности для вашего дополнения недоступны."
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:74
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:66
 msgid "Your add-on has been signed."
 msgstr "Ваше дополнение было подписано."
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:79
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:69
 msgid ""
-"You will receive an email when the full review is complete.\n"
-"                             Until then, your add-on is displayed in our gallery as\n"
-"                             experimental and users are receiving automatic updates.\n"
-"                             Some features are unavailable to your add-on."
+"You will receive an email when the full review is complete. Until then, your add-on is displayed in our gallery as experimental and users are receiving automatic updates. Some features are "
+"unavailable to your add-on."
 msgstr ""
 "Вы получите письмо, когда полная проверка будет завершена.\n"
 "                             До этого, ваше дополнение будет показываться в нашей галерее как\n"
 "                             экспериментальное и пользователи смогут получать автоматические обновления.\n"
 "                             Некоторые возможности для вашего дополнения будут недоступны."
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:84
-msgid ""
-"You will receive an email when the full review is\n"
-"                             complete, making you able to bundle your add-on with an\n"
-"                             application installer."
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:74
+msgid "You will receive an email when the full review is complete, making you able to bundle your add-on with an application installer."
 msgstr ""
 "Вы получите письмо, когда полная проверка будет\n"
 "                             завершена, дав вам возможность упаковать ваше дополнение\n"
 "                             с установщиком."
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:91
-msgid ""
-"All add-ons hosted in our gallery must now be reviewed by an\n"
-"                             editor. If you wish to continue hosting your add-on, please\n"
-"                             click to select a review process."
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:79
+msgid "All add-ons hosted in our gallery must now be reviewed by an editor. If you wish to continue hosting your add-on, please click to select a review process."
 msgstr ""
 "Все дополнения, хранимые в нашей галереи, должны быть проверены\n"
 "                             редактором. Если вы хотите продолжать хостить ваше дополнение, пожалуйста,\n"
 "                             щёлкните, чтобы выбрать процесс проверки."
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:113
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:100
 msgid "Current Version:"
 msgstr "Текущая версия:"
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:115
-msgid ""
-"This is the version of your add-on that will\n"
-"                                           be installed if someone clicks the Install\n"
-"                                           button on addons.mozilla.org. It is only\n"
-"                                           relevant for listed add-ons."
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:102
+msgid "This is the version of your add-on that will be installed if someone clicks the Install button on addons.mozilla.org. It is only relevant for listed add-ons."
 msgstr ""
 "Это версия вашего дополнения, которая может\n"
 "                                           быть установлена любым, кто нажмёт на кнопку\n"
 "                                           Установить на addons.mozilla,org. Это относится\n"
 "                                           только к опубликованным дополнениям."
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:123
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:110
 msgid "Created:"
 msgstr "Создано:"
 
 #. {0} is a date. dennis-ignore: E201
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:125
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:131
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:112 src/olympia/devhub/templates/devhub/includes/addon_details.html:118
 #, python-format
 msgid "%%b %%e, %%Y"
 msgstr "%%e %%b %%Y"
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:136
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:123
 msgid "Next Version:"
 msgstr "Следующая версия:"
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:138
-msgid ""
-"This is the newest uploaded version, however\n"
-"                                           it isn’t live on the site yet."
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:125
+msgid "This is the newest uploaded version, however it isn’t live on the site yet."
 msgstr ""
 "Это новейшая загруженная версия, однако\n"
 "                                           она ещё не на сайте."
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:144
-#: src/olympia/devhub/templates/devhub/versions/list.html:30
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:130 src/olympia/devhub/templates/devhub/versions/list.html:30
 msgid "Queues are not reviewed strictly in order"
 msgstr "Очереди не проверяются строго по порядку"
 
@@ -8261,16 +6331,11 @@ msgstr "Создать профиль разработчика"
 
 #: src/olympia/devhub/templates/devhub/includes/addons_create_profile.html:24
 msgid ""
-"Your developer profile will tell users about you, why you made this add-on, "
-"and what's next for the add-on. This profile is required for add-ons "
-"requesting contributions, but can be useful for any developer interested in "
-"connecting with users."
+"Your developer profile will tell users about you, why you made this add-on, and what's next for the add-on. This profile is required for add-ons requesting contributions, but can be useful for any "
+"developer interested in connecting with users."
 msgstr ""
-"Ваш профиль разработчика расскажет пользователям о вас, о том почему вы "
-"сделали это дополнение, и что запланировано для дополнения. Профиль "
-"требуется для дополнений с просьбой внести взносы, но может быть полезным "
-"для любого разработчика, заинтересованного в установлении взаимоотношений с "
-"пользователями."
+"Ваш профиль разработчика расскажет пользователям о вас, о том почему вы сделали это дополнение, и что запланировано для дополнения. Профиль требуется для дополнений с просьбой внести взносы, но "
+"может быть полезным для любого разработчика, заинтересованного в установлении взаимоотношений с пользователями."
 
 #: src/olympia/devhub/templates/devhub/includes/addons_create_profile.html:32
 msgid "Make sure your user profile is up to date."
@@ -8279,24 +6344,15 @@ msgstr "Убедитесь, что ваш пользовательский пр�
 #: src/olympia/devhub/templates/devhub/includes/addons_create_profile.html:34
 #, python-format
 msgid "<a href=\"%(url)s\"><strong>Update your user profile.</strong></a>"
-msgstr ""
-"<a href=\"%(url)s\"><strong>Обновите ваш профиль пользователя.</strong></a>"
+msgstr "<a href=\"%(url)s\"><strong>Обновите ваш профиль пользователя.</strong></a>"
 
 #: src/olympia/devhub/templates/devhub/includes/addons_create_profile.html:45
-msgid ""
-"Whether it was an idea while in line at the grocery store or the solution to"
-" one of life's great problems, share your story."
-msgstr ""
-"Было ли это идея пришедшая вам в голову в очереди в магазине или решение "
-"одной из больших жизненных проблем, поделитесь своей историей."
+msgid "Whether it was an idea while in line at the grocery store or the solution to one of life's great problems, share your story."
+msgstr "Было ли это идея пришедшая вам в голову в очереди в магазине или решение одной из больших жизненных проблем, поделитесь своей историей."
 
 #: src/olympia/devhub/templates/devhub/includes/addons_create_profile.html:61
-msgid ""
-"Telling your users what's coming soon will give them something to look "
-"forward to."
-msgstr ""
-"Рассказав своим пользователям, что произойдёт в ближайшее время, вы дадите "
-"им представление, чего можно ждать."
+msgid "Telling your users what's coming soon will give them something to look forward to."
+msgstr "Рассказав своим пользователям, что произойдёт в ближайшее время, вы дадите им представление, чего можно ждать."
 
 #: src/olympia/devhub/templates/devhub/includes/addons_edit_nav.html:23
 msgid "View All"
@@ -8327,9 +6383,7 @@ msgid "View the blog &#9658;"
 msgstr "Прочесть блог &#9658;"
 
 #: src/olympia/devhub/templates/devhub/includes/license_form.html:6
-msgid ""
-"Please choose a license appropriate for the rights you grant on your source code.\n"
-"                  It is only relevant for listed add-ons."
+msgid "Please choose a license appropriate for the rights you grant on your source code. It is only relevant for listed add-ons."
 msgstr ""
 "Пожалуйста, выберите лицензию, подходящую для прав, предоставляемых вами на ваш исходный код.\n"
 "                  Это относится только к дополнениям, видным на сайте."
@@ -8347,57 +6401,37 @@ msgstr "Кое-что из HTML поддерживается."
 msgid "Remove this application"
 msgstr "Удалить это приложение"
 
-#. {0} is the maximum number of add-on categories allowed.                {1}
-#. is
+#. {0} is the maximum number of add-on categories allowed.                {1} is
 #. the application name.
 #: src/olympia/devhub/templates/devhub/includes/macros.html:70
 msgid "Select <b>up to {0}</b> {1} category for this add-on:"
 msgid_plural "Select <b>up to {0}</b> {1} categories for this add-on:"
 msgstr[0] "Выберите <b>не более {0}</b> {1} категории для этого дополнения:"
 msgstr[1] "Выберите <b>не более {0}</b> {1} категорий для этого дополнения:"
-msgstr[2] "Выберите <b>не более {0}</b> {1} категорий для этого дополнения:"
 
 #: src/olympia/devhub/templates/devhub/includes/policy_form.html:4
 msgid ""
-"Users will be required to accept the following End-User License Agreement "
-"(EULA) prior to installing your add-on. The presence of a EULA significantly"
-" affects the number of downloads an add-on receives. Please note that a EULA"
-" is not the same as a code license, such as the GPL or MPL. It is only "
-"relevant for listed add-ons."
+"Users will be required to accept the following End-User License Agreement (EULA) prior to installing your add-on. The presence of a EULA significantly affects the number of downloads an add-on "
+"receives. Please note that a EULA is not the same as a code license, such as the GPL or MPL.It is only relevant for listed add-ons."
 msgstr ""
-"Перед установкой вашего дополнения пользователи должны будут принять "
-"следующее Лицензионное Соглашение Конечного Пользователя (EULA). Присутствие"
-" EULA значительно влияет на число загрузок дополнения. Пожалуйста, обратите "
-"внимание, что EULA не то же самое, что лицензия на код, такая как GPL или "
-"MPL. Это относится только к дополнениям, находящимся в списке."
 
-#: src/olympia/devhub/templates/devhub/includes/policy_form.html:21
-msgid ""
-"If your add-on transmits any data from the user's computer, a privacy policy is required that explains what data is sent and how it is used.\n"
-"                It is only relevant for listed add-ons."
+#: src/olympia/devhub/templates/devhub/includes/policy_form.html:24
+msgid "If your add-on transmits any data from the user's computer, a privacy policy is required that explains what data is sent and how it is used. It is only relevant for listed add-ons."
 msgstr ""
 "Если ваше дополнение передаёт какие-либо данные с компьютера пользователя, необходимо иметь политику приватности, которая объясняет, какие данные отправляются и как они используются.\n"
 "                Это относится только к опубликованным дополнениям."
 
 #: src/olympia/devhub/templates/devhub/includes/source_form_field.html:2
-msgid ""
-"If your add-on contains binary or obfuscated code other than known "
-"libraries, upload its sources for review."
-msgstr ""
-"Если ваше дополнение содержит бинарный или обфусцированный код, не считая "
-"известных библиотек, загрузите его исходники для проверки."
+msgid "If your add-on contains binary or obfuscated code other than known libraries, upload its sources for review."
+msgstr "Если ваше дополнение содержит бинарный или обфусцированный код, не считая известных библиотек, загрузите его исходники для проверки."
 
 #: src/olympia/devhub/templates/devhub/includes/source_form_field.html:3
 msgid "Read more about the source code review policy."
 msgstr "Узнайте больше о политике проверки исходного кода."
 
 #: src/olympia/devhub/templates/devhub/includes/version_file.html:20
-msgid ""
-"You cannot remove an individual file after the review process has begun. You"
-" must delete the entire version."
-msgstr ""
-"Вы не можете удалить отдельный файл после начала процесса проверки. Вы "
-"должны удалить версию целиком."
+msgid "You cannot remove an individual file after the review process has begun. You must delete the entire version."
+msgstr "Вы не можете удалить отдельный файл после начала процесса проверки. Вы должны удалить версию целиком."
 
 #: src/olympia/devhub/templates/devhub/includes/version_file.html:36
 msgid "This file will be deleted on save."
@@ -8425,30 +6459,20 @@ msgid "Voluntary Contributions"
 msgstr "Добровольные взносы"
 
 #: src/olympia/devhub/templates/devhub/payments/payments.html:38
-msgid ""
-"Add-ons enrolled in our contributions program can request voluntary "
-"financial support from users."
-msgstr ""
-"Дополнения, участвующие в нашей программе взносов, могут просить "
-"пользователей оказывать добровольную финансовую поддержку."
+msgid "Add-ons enrolled in our contributions program can request voluntary financial support from users."
+msgstr "Дополнения, участвующие в нашей программе взносов, могут просить пользователей оказывать добровольную финансовую поддержку."
 
 #: src/olympia/devhub/templates/devhub/payments/payments.html:40
 msgid "Encourage users to support your add-on through your Developer Profile"
-msgstr ""
-"Попросите пользователей поддержать ваше дополнение через ваш Профиль "
-"разработчика"
+msgstr "Попросите пользователей поддержать ваше дополнение через ваш Профиль разработчика"
 
 #: src/olympia/devhub/templates/devhub/payments/payments.html:41
 msgid "Choose when and how users are asked to contribute"
 msgstr "Выберите, когда и как просить пользователей сделать взнос"
 
 #: src/olympia/devhub/templates/devhub/payments/payments.html:42
-msgid ""
-"Receive contributions in your PayPal account or send them to an organization"
-" of your choice"
-msgstr ""
-"Получать взносы на ваш счёт в PayPal или отправлять их в организацию по "
-"своему выбору"
+msgid "Receive contributions in your PayPal account or send them to an organization of your choice"
+msgstr "Получать взносы на ваш счёт в PayPal или отправлять их в организацию по своему выбору"
 
 #: src/olympia/devhub/templates/devhub/payments/payments.html:46
 msgid "Contributions are only available for listed add-ons."
@@ -8456,19 +6480,14 @@ msgstr "Взносы доступны только для дополнений, 
 
 #: src/olympia/devhub/templates/devhub/payments/payments.html:53
 #, python-format
-msgid ""
-"Contributions are only available for add-ons with a <a "
-"href=\"%(url)s\">completed developer profile</a>."
-msgstr ""
-"Взносы доступны только для дополнений с <a href=\"%(url)s\">заполненным "
-"профилем разработчика</a>."
+msgid "Contributions are only available for add-ons with a <a href=\"%(url)s\">completed developer profile</a>."
+msgstr "Взносы доступны только для дополнений с <a href=\"%(url)s\">заполненным профилем разработчика</a>."
 
 #: src/olympia/devhub/templates/devhub/payments/payments.html:59
 msgid "Contributions are only available for fully reviewed add-ons."
 msgstr "Взносы доступны только для полностью проверенных дополнений."
 
-#: src/olympia/devhub/templates/devhub/payments/payments.html:65
-#: src/olympia/devhub/templates/devhub/payments/voluntary.html:2
+#: src/olympia/devhub/templates/devhub/payments/payments.html:65 src/olympia/devhub/templates/devhub/payments/voluntary.html:2
 msgid "Set up Contributions"
 msgstr "Настройка взносов"
 
@@ -8481,18 +6500,13 @@ msgstr "Шаг 2. Цена и доступность"
 msgid "or <a href=\"%(cancel)s\">Cancel</a>"
 msgstr "или <a href=\"%(cancel)s\">Отмена</a>"
 
-#: src/olympia/devhub/templates/devhub/payments/voluntary.html:2
-#: src/olympia/stats/templates/stats/addon_report_menu.html:39
+#: src/olympia/devhub/templates/devhub/payments/voluntary.html:2 src/olympia/stats/templates/stats/addon_report_menu.html:39
 msgid "Contributions"
 msgstr "Взносы"
 
 #: src/olympia/devhub/templates/devhub/payments/voluntary.html:3
-msgid ""
-"Fill in the fields below to begin asking for voluntary contributions from "
-"users."
-msgstr ""
-"Заполните расположенные ниже поля, чтобы начать просить пользователей внести"
-" добровольные взносы."
+msgid "Fill in the fields below to begin asking for voluntary contributions from users."
+msgstr "Заполните расположенные ниже поля, чтобы начать просить пользователей внести добровольные взносы."
 
 #: src/olympia/devhub/templates/devhub/payments/voluntary.html:11
 msgid "Who will receive contributions to this add-on?"
@@ -8535,23 +6549,16 @@ msgid "Send a thank-you note?"
 msgstr "Отправить благодарственное письмо?"
 
 #: src/olympia/devhub/templates/devhub/payments/voluntary.html:47
-msgid ""
-"We'll automatically email users who contribute to your add-on with this "
-"message."
-msgstr ""
-"Мы автоматически отправим по электронной почте, пользователям, которые "
-"сделали взнос, письмо с этим сообщением."
+msgid "We'll automatically email users who contribute to your add-on with this message."
+msgstr "Мы автоматически отправим по электронной почте, пользователям, которые сделали взнос, письмо с этим сообщением."
 
 #: src/olympia/devhub/templates/devhub/payments/voluntary.html:49
 msgid ""
-"We recommend thanking the user and telling them how much you appreciate "
-"their support. You might also want to tell them about what's next for your "
-"add-on and about any other add-ons you've made for them to try."
+"We recommend thanking the user and telling them how much you appreciate their support. You might also want to tell them about what's next for your add-on and about any other add-ons you've made for "
+"them to try."
 msgstr ""
-"Мы рекомендуем поблагодарить пользователей и написать им, насколько вы "
-"цените их поддержку. Вы также можете рассказать им о планах развития вашего "
-"дополнения и о любых других сделанных вами дополнениях, которые вы "
-"рекомендуете попробовать."
+"Мы рекомендуем поблагодарить пользователей и написать им, насколько вы цените их поддержку. Вы также можете рассказать им о планах развития вашего дополнения и о любых других сделанных вами "
+"дополнениях, которые вы рекомендуете попробовать."
 
 #: src/olympia/devhub/templates/devhub/payments/voluntary.html:64
 msgid "Activate Contributions"
@@ -8565,147 +6572,94 @@ msgstr "или <a id=\"setup-cancel\" href=\"#\">Отменить</a>"
 msgid "Transfer ownership"
 msgstr "Передача владения"
 
-#: src/olympia/devhub/templates/devhub/personas/edit.html:77
-#: src/olympia/devhub/templates/devhub/personas/submit.html:31
+#: src/olympia/devhub/templates/devhub/personas/edit.html:77 src/olympia/devhub/templates/devhub/personas/submit.html:31
 msgid "Theme Details"
 msgstr "Информация об теме"
 
-#: src/olympia/devhub/templates/devhub/personas/edit.html:87
-#: src/olympia/devhub/templates/devhub/personas/submit.html:36
+#: src/olympia/devhub/templates/devhub/personas/edit.html:87 src/olympia/devhub/templates/devhub/personas/submit.html:36
 msgid "Supply a pretty URL for your detail page."
 msgstr "Указать красивый URL для вашей страницы со сведеними."
 
-#: src/olympia/devhub/templates/devhub/personas/edit.html:92
-#: src/olympia/devhub/templates/devhub/personas/submit.html:41
+#: src/olympia/devhub/templates/devhub/personas/edit.html:92 src/olympia/devhub/templates/devhub/personas/submit.html:41
 msgid "Select the category that best describes your Theme."
 msgstr "Выберите категорию, которая лучше всего описывает вашу тему."
 
-#: src/olympia/devhub/templates/devhub/personas/edit.html:95
-#: src/olympia/devhub/templates/devhub/personas/submit.html:44
+#: src/olympia/devhub/templates/devhub/personas/edit.html:95 src/olympia/devhub/templates/devhub/personas/submit.html:44
 msgid "Add some tags to describe your Theme."
 msgstr "Добавьте метки для описания вашей темы."
 
-#: src/olympia/devhub/templates/devhub/personas/edit.html:106
-msgid ""
-"A short explanation of your theme's basic functionality that is displayed in"
-" search and browse listings, as well as at the top of your theme's details "
-"page."
-msgstr ""
-"Краткое объяснение основных функций вашей темы, которые отображаются в "
-"списках поиска и просмотра, а также в верхней части страницы вашей темы."
+#: src/olympia/devhub/templates/devhub/personas/edit.html:106 src/olympia/devhub/templates/devhub/personas/submit.html:54
+msgid "A short explanation of your theme's basic functionality that is displayed in search and browse listings, as well as at the top of your theme's details page."
+msgstr "Краткое объяснение основных функций вашей темы, которые отображаются в списках поиска и просмотра, а также в верхней части страницы вашей темы."
 
-#: src/olympia/devhub/templates/devhub/personas/edit.html:122
-#: src/olympia/devhub/templates/devhub/personas/submit.html:68
+#: src/olympia/devhub/templates/devhub/personas/edit.html:122 src/olympia/devhub/templates/devhub/personas/submit.html:68
 msgid "Theme License"
 msgstr "Лицензия темы"
 
-#: src/olympia/devhub/templates/devhub/personas/edit.html:126
-#: src/olympia/devhub/templates/devhub/personas/submit.html:72
+#: src/olympia/devhub/templates/devhub/personas/edit.html:126 src/olympia/devhub/templates/devhub/personas/submit.html:72
 msgid "Can others share your Theme, as long as you're given credit?"
-msgstr ""
-"Могут ли другие делиться вашей темой, если вас указывают в качестве автора?"
+msgstr "Могут ли другие делиться вашей темой, если вас указывают в качестве автора?"
 
-#: src/olympia/devhub/templates/devhub/personas/edit.html:132
-#: src/olympia/devhub/templates/devhub/personas/edit.html:153
-#: src/olympia/devhub/templates/devhub/personas/submit.html:78
+#: src/olympia/devhub/templates/devhub/personas/edit.html:132 src/olympia/devhub/templates/devhub/personas/edit.html:153 src/olympia/devhub/templates/devhub/personas/submit.html:78
 #: src/olympia/devhub/templates/devhub/personas/submit.html:99
-msgid ""
-"The licensor permits others to copy, distribute, display, and perform the "
-"work, including for commercial purposes."
-msgstr ""
-"Лицензиар позволяет другим копировать, распространять, отображать, а также "
-"выполнять работу, в том числе в коммерческих целях."
+msgid "The licensor permits others to copy, distribute, display, and perform the work, including for commercial purposes."
+msgstr "Лицензиар позволяет другим копировать, распространять, отображать, а также выполнять работу, в том числе в коммерческих целях."
 
-#: src/olympia/devhub/templates/devhub/personas/edit.html:141
-#: src/olympia/devhub/templates/devhub/personas/edit.html:162
-#: src/olympia/devhub/templates/devhub/personas/submit.html:87
+#: src/olympia/devhub/templates/devhub/personas/edit.html:141 src/olympia/devhub/templates/devhub/personas/edit.html:162 src/olympia/devhub/templates/devhub/personas/submit.html:87
 #: src/olympia/devhub/templates/devhub/personas/submit.html:108
-msgid ""
-"The licensor permits others to copy, distribute, display, and perform the "
-"work for non-commercial purposes only."
-msgstr ""
-"Лицензиар позволяет другим копировать, распространять, отображать, а также "
-"выполнять работу только в некоммерческих целях."
+msgid "The licensor permits others to copy, distribute, display, and perform the work for non-commercial purposes only."
+msgstr "Лицензиар позволяет другим копировать, распространять, отображать, а также выполнять работу только в некоммерческих целях."
 
-#: src/olympia/devhub/templates/devhub/personas/edit.html:147
-#: src/olympia/devhub/templates/devhub/personas/submit.html:93
+#: src/olympia/devhub/templates/devhub/personas/edit.html:147 src/olympia/devhub/templates/devhub/personas/submit.html:93
 msgid "Can others make commercial use of your Theme?"
 msgstr "Могут ли другие использовать вашу тему в коммерческих целях?"
 
-#: src/olympia/devhub/templates/devhub/personas/edit.html:168
-#: src/olympia/devhub/templates/devhub/personas/submit.html:114
+#: src/olympia/devhub/templates/devhub/personas/edit.html:168 src/olympia/devhub/templates/devhub/personas/submit.html:114
 msgid "Can others create derivative works from your Theme?"
 msgstr "Могут ли другие создавать производные работы на основе вашей темы?"
 
-#: src/olympia/devhub/templates/devhub/personas/edit.html:174
-#: src/olympia/devhub/templates/devhub/personas/submit.html:120
-msgid ""
-"The licensor permits others to copy, distribute, display and perform the "
-"work, as well as make derivative works based on it."
-msgstr ""
-"Лицензиар позволяет другим копировать, распространять, показывать и "
-"выполнять работу, а также создавать на его основе производные работы."
+#: src/olympia/devhub/templates/devhub/personas/edit.html:174 src/olympia/devhub/templates/devhub/personas/submit.html:120
+msgid "The licensor permits others to copy, distribute, display and perform the work, as well as make derivative works based on it."
+msgstr "Лицензиар позволяет другим копировать, распространять, показывать и выполнять работу, а также создавать на его основе производные работы."
 
-#: src/olympia/devhub/templates/devhub/personas/edit.html:182
-#: src/olympia/devhub/templates/devhub/personas/submit.html:128
+#: src/olympia/devhub/templates/devhub/personas/edit.html:182 src/olympia/devhub/templates/devhub/personas/submit.html:128
 msgid "Yes, as long as they share alike"
 msgstr "Да, если они так же делятся"
 
-#: src/olympia/devhub/templates/devhub/personas/edit.html:183
-#: src/olympia/devhub/templates/devhub/personas/submit.html:129
-msgid ""
-"The licensor permits others to distribute derivativeworks only under the "
-"same license or one compatible with the one that governs the licensor's "
-"work."
-msgstr ""
-"Лицензиар позволяет другим распространять производные работы только по той "
-"же лицензии или лицензии совместимой с той, под которой распространяется "
-"работа лицензиара."
+#: src/olympia/devhub/templates/devhub/personas/edit.html:183 src/olympia/devhub/templates/devhub/personas/submit.html:129
+msgid "The licensor permits others to distribute derivativeworks only under the same license or one compatible with the one that governs the licensor's work."
+msgstr "Лицензиар позволяет другим распространять производные работы только по той же лицензии или лицензии совместимой с той, под которой распространяется работа лицензиара."
 
-#: src/olympia/devhub/templates/devhub/personas/edit.html:192
-#: src/olympia/devhub/templates/devhub/personas/submit.html:138
-msgid ""
-"The licensor permits others to copy, distribute and transmit only unaltered "
-"copies of the work — not derivative works based on it."
-msgstr ""
-"Лицензиар позволяет другим копировать, распространять и передавать только "
-"неизменённые копии работ — не производные работы на его основе."
+#: src/olympia/devhub/templates/devhub/personas/edit.html:192 src/olympia/devhub/templates/devhub/personas/submit.html:138
+msgid "The licensor permits others to copy, distribute and transmit only unaltered copies of the work — not derivative works based on it."
+msgstr "Лицензиар позволяет другим копировать, распространять и передавать только неизменённые копии работ — не производные работы на его основе."
 
-#: src/olympia/devhub/templates/devhub/personas/edit.html:199
-#: src/olympia/devhub/templates/devhub/personas/submit.html:145
+#: src/olympia/devhub/templates/devhub/personas/edit.html:199 src/olympia/devhub/templates/devhub/personas/submit.html:145
 msgid "Your Theme will be released under the following license:"
 msgstr "Ваша тема будет выпущена на условиях следующей лицензии:"
 
-#: src/olympia/devhub/templates/devhub/personas/edit.html:202
-#: src/olympia/devhub/templates/devhub/personas/submit.html:148
+#: src/olympia/devhub/templates/devhub/personas/edit.html:202 src/olympia/devhub/templates/devhub/personas/submit.html:148
 msgid "Select a different license."
 msgstr "Выберите другую лицензию."
 
-#: src/olympia/devhub/templates/devhub/personas/edit.html:207
-#: src/olympia/devhub/templates/devhub/personas/submit.html:153
+#: src/olympia/devhub/templates/devhub/personas/edit.html:207 src/olympia/devhub/templates/devhub/personas/submit.html:153
 msgid "Select a license for your Theme."
 msgstr "Выберите лицензию для вашей темы."
 
-#: src/olympia/devhub/templates/devhub/personas/edit.html:217
-#: src/olympia/devhub/templates/devhub/personas/submit.html:163
+#: src/olympia/devhub/templates/devhub/personas/edit.html:217 src/olympia/devhub/templates/devhub/personas/submit.html:163
 msgid "Theme Design"
 msgstr "Дизайн темы"
 
-#: src/olympia/devhub/templates/devhub/personas/edit.html:221
-#: src/olympia/devhub/templates/devhub/personas/edit.html:224
+#: src/olympia/devhub/templates/devhub/personas/edit.html:221 src/olympia/devhub/templates/devhub/personas/edit.html:224
 msgid "Upload New Design"
 msgstr "Загрузить новый дизайн"
 
 #: src/olympia/devhub/templates/devhub/personas/edit.html:226
-msgid ""
-"Upon upload and form submission, the AMO Team will review your updated "
-"design. Your current design will still be public in the meantime."
-msgstr ""
-"После загрузки и отправки формы команда AMO рассмотрит ваш обновленный "
-"дизайн. Пока что для публики будет показан ваш текущий дизайн."
+msgid "Upon upload and form submission, the AMO Team will review your updated design. Your current design will still be public in the meantime."
+msgstr "После загрузки и отправки формы команда AMO рассмотрит ваш обновленный дизайн. Пока что для публики будет показан ваш текущий дизайн."
 
 #: src/olympia/devhub/templates/devhub/personas/edit.html:241
-msgid "Your previously resubmitted design,  which is under pending review."
+msgid "Your previously resubmitted design, which is under pending review."
 msgstr "Ваш ранее представленный дизайн,  который ожидает проверки."
 
 #: src/olympia/devhub/templates/devhub/personas/edit.html:245
@@ -8718,9 +6672,7 @@ msgstr "Ожидающее нижнее изображение"
 
 #: src/olympia/devhub/templates/devhub/personas/edit.html:259
 msgid "You may update your theme design here once it has been approved."
-msgstr ""
-"Вы можете обновить дизайн вашей темы здесь после того, как она будет "
-"одобрена."
+msgstr "Вы можете обновить дизайн вашей темы здесь после того, как она будет одобрена."
 
 #: src/olympia/devhub/templates/devhub/personas/edit.html:264
 msgid "Header"
@@ -8730,43 +6682,35 @@ msgstr "Верхнее изображение"
 msgid "Footer"
 msgstr "Нижнее изображение"
 
-#: src/olympia/devhub/templates/devhub/personas/edit.html:274
-#: src/olympia/devhub/templates/devhub/personas/submit.html:167
+#: src/olympia/devhub/templates/devhub/personas/edit.html:274 src/olympia/devhub/templates/devhub/personas/submit.html:167
 msgid "Select colors for your Theme."
 msgstr "Выберите цвета для вашей темы."
 
-#: src/olympia/devhub/templates/devhub/personas/edit.html:276
-#: src/olympia/devhub/templates/devhub/personas/submit.html:169
+#: src/olympia/devhub/templates/devhub/personas/edit.html:276 src/olympia/devhub/templates/devhub/personas/submit.html:169
 msgid "Foreground Text"
 msgstr "Текст переднего плана"
 
-#: src/olympia/devhub/templates/devhub/personas/edit.html:277
-#: src/olympia/devhub/templates/devhub/personas/submit.html:170
+#: src/olympia/devhub/templates/devhub/personas/edit.html:277 src/olympia/devhub/templates/devhub/personas/submit.html:170
 msgid "This is the color of the tab text."
 msgstr "Это цвет текста вкладки."
 
-#: src/olympia/devhub/templates/devhub/personas/edit.html:279
-#: src/olympia/devhub/templates/devhub/personas/submit.html:172
+#: src/olympia/devhub/templates/devhub/personas/edit.html:279 src/olympia/devhub/templates/devhub/personas/submit.html:172
 msgid "Background"
 msgstr "Фон"
 
-#: src/olympia/devhub/templates/devhub/personas/edit.html:280
-#: src/olympia/devhub/templates/devhub/personas/submit.html:173
+#: src/olympia/devhub/templates/devhub/personas/edit.html:280 src/olympia/devhub/templates/devhub/personas/submit.html:173
 msgid "This is the color of the tabs."
 msgstr "Это цвет вкладок."
 
-#: src/olympia/devhub/templates/devhub/personas/edit.html:285
-#: src/olympia/devhub/templates/devhub/personas/submit.html:178
+#: src/olympia/devhub/templates/devhub/personas/edit.html:285 src/olympia/devhub/templates/devhub/personas/submit.html:178
 msgid "Preview"
 msgstr "Предпросмотр"
 
-#: src/olympia/devhub/templates/devhub/personas/edit.html:291
-#: src/olympia/devhub/templates/devhub/personas/submit.html:183
+#: src/olympia/devhub/templates/devhub/personas/edit.html:291 src/olympia/devhub/templates/devhub/personas/submit.html:183
 msgid "Your Theme's Name"
 msgstr "Имя вашей темы"
 
-#: src/olympia/devhub/templates/devhub/personas/edit.html:294
-#: src/olympia/devhub/templates/devhub/personas/submit.html:186
+#: src/olympia/devhub/templates/devhub/personas/edit.html:294 src/olympia/devhub/templates/devhub/personas/submit.html:186
 #, python-format
 msgid "by <a href=\"%(profile_url)s\" target=\"_blank\">%(user)s</a>"
 msgstr "от <a href=\"%(profile_url)s\" target=\"_blank\">%(user)s</a>"
@@ -8777,78 +6721,44 @@ msgstr "Создать новую тему"
 
 #: src/olympia/devhub/templates/devhub/personas/submit.html:18
 #, python-format
-msgid ""
-"Background themes let you easily personalize the look of your Firefox. "
-"Submit your own design below, or <a href=\"%(submit_url)s\">learn how to "
-"create one</a>!"
-msgstr ""
-"Фоновые темы позволяют легко персонализировать внешний вид вашего Firefox. "
-"Представьте ниже свой собственный дизайн, или <a "
-"href=\"%(submit_url)s\">узнайте, как создать его</a>!"
+msgid "Background themes let you easily personalize the look of your Firefox. Submit your own design below, or <a href=\"%(submit_url)s\">learn how to create one</a>!"
+msgstr "Фоновые темы позволяют легко персонализировать внешний вид вашего Firefox. Представьте ниже свой собственный дизайн, или <a href=\"%(submit_url)s\">узнайте, как создать его</a>!"
 
 #: src/olympia/devhub/templates/devhub/personas/submit.html:33
 msgid "Give your Theme a name."
 msgstr "Дайте вашей теме имя."
 
-#: src/olympia/devhub/templates/devhub/personas/submit.html:54
-msgid ""
-"A short explanation of your theme's basic functionality that is displayed in"
-" search and browse listings, as well as at the top of your theme's details "
-"page."
-msgstr ""
-"Краткое объяснение основных функций вашей темы, которые отображаются в "
-"списках поиска и просмотра, а также в верхней части страницы вашей темы."
-
 #: src/olympia/devhub/templates/devhub/personas/submit.html:198
 #, python-format
 msgid ""
-"I agree to the <a href=\"%(agreement_url)s\" target=\"_blank\">Firefox Add-"
-"on Distribution Agreement</a> and to my information being handled as "
-"described in the <a href=\"%(privacy_notice_url)s\" "
+"I agree to the <a href=\"%(agreement_url)s\" target=\"_blank\">Firefox Add-on Distribution Agreement</a> and to my information being handled as described in the <a href=\"%(privacy_notice_url)s\" "
 "target=\"_blank\">Websites, Communications and Cookies Privacy Notice</a>."
 msgstr ""
-"Я принимаю <a href=\"%(agreement_url)s\" target=\"_blank\">Соглашение по "
-"распространению дополнений Firefox</a>, и соглашаюсь с обработкой моей "
-"информации так, как это описано в <a href=\"%(privacy_notice_url)s\" "
-"target=\"_blank\">Уведомлении об использовании конфиденциальной информации в"
-" отношении веб-сайтов, способов коммуникации и куки-файлов</a>"
+"Я принимаю <a href=\"%(agreement_url)s\" target=\"_blank\">Соглашение по распространению дополнений Firefox</a>, и соглашаюсь с обработкой моей информации так, как это описано в <a href="
+"\"%(privacy_notice_url)s\" target=\"_blank\">Уведомлении об использовании конфиденциальной информации в отношении веб-сайтов, способов коммуникации и куки-файлов</a>"
 
 #: src/olympia/devhub/templates/devhub/personas/submit.html:205
 msgid "Submit Theme"
 msgstr "Представить тему"
 
 #: src/olympia/devhub/templates/devhub/personas/submit_done.html:11
-msgid ""
-"Your theme has been submitted to the Review Queue. You'll receive an email "
-"once it has been reviewed, typically within 24 hours."
-msgstr ""
-"Ваша тема была отправлена в очередь на проверку. Вы получите письмо по "
-"электронной почте после того, как она будет проверена, обычно в течение 24 "
-"часов."
+msgid "Your theme has been submitted to the Review Queue. You'll receive an email once it has been reviewed, typically within 24 hours."
+msgstr "Ваша тема была отправлена в очередь на проверку. Вы получите письмо по электронной почте после того, как она будет проверена, обычно в течение 24 часов."
 
 #: src/olympia/devhub/templates/devhub/personas/submit_done.html:19
 #, python-format
-msgid ""
-"Provide more details about your theme by <a href=\"%(edit_url)s\">editing "
-"its listing</a>."
-msgstr ""
-"Предоставьте более подробную информацию о вашей теме, <a "
-"href=\"%(edit_url)s\">отредактировав её страницу</a>."
+msgid "Provide more details about your theme by <a href=\"%(edit_url)s\">editing its listing</a>."
+msgstr "Предоставьте более подробную информацию о вашей теме, <a href=\"%(edit_url)s\">отредактировав её страницу</a>."
 
 #: src/olympia/devhub/templates/devhub/personas/submit_done.html:25
 #, python-format
-msgid ""
-"View and subscribe to your theme's <a href=\"%(feed_url)s\">activity "
-"feed</a> to stay updated on reviews, collections, and more."
-msgstr ""
-"Просмотрите и подпишитесь на <a href=\"%(feed_url)s\">ленту активности</a> "
-"вашей темы, чтобы быть в курсе отзывов, подборок и многого другого."
+msgid "View and subscribe to your theme's <a href=\"%(feed_url)s\">activity feed</a> to stay updated on reviews, collections, and more."
+msgstr "Просмотрите и подпишитесь на <a href=\"%(feed_url)s\">ленту активности</a> вашей темы, чтобы быть в курсе отзывов, подборок и многого другого."
 
 #: src/olympia/devhub/templates/devhub/personas/submit_done.html:32
 #, python-format
 msgid "Join the conversation in our <a href=\"%(forum_url)s\">forums</a>."
-msgstr ""
-"Присоединяйтесь к разговору на наших <a href=\"%(forum_url)s\">форумах</a>."
+msgstr "Присоединяйтесь к разговору на наших <a href=\"%(forum_url)s\">форумах</a>."
 
 #: src/olympia/devhub/templates/devhub/personas/includes/theme_design.html:3
 msgid "Select a header image for your Theme."
@@ -8858,13 +6768,11 @@ msgstr "Выберите верхнее изображение для вашей
 msgid "3000 &times; 200 pixels"
 msgstr "3000 &times; 200 пикселей"
 
-#: src/olympia/devhub/templates/devhub/personas/includes/theme_design.html:9
-#: src/olympia/devhub/templates/devhub/personas/includes/theme_design.html:25
+#: src/olympia/devhub/templates/devhub/personas/includes/theme_design.html:9 src/olympia/devhub/templates/devhub/personas/includes/theme_design.html:25
 msgid "300 KB max"
 msgstr "Максимум 300 КБ"
 
-#: src/olympia/devhub/templates/devhub/personas/includes/theme_design.html:10
-#: src/olympia/devhub/templates/devhub/personas/includes/theme_design.html:26
+#: src/olympia/devhub/templates/devhub/personas/includes/theme_design.html:10 src/olympia/devhub/templates/devhub/personas/includes/theme_design.html:26
 msgid "PNG or JPG"
 msgstr "PNG или JPG"
 
@@ -8893,66 +6801,31 @@ msgid "Select a different footer image"
 msgstr "Выберите другое нижнее изображение."
 
 #: src/olympia/devhub/templates/devhub/versions/add_file_modal.html:8
-msgid ""
-"Files added to reviewed versions must be reviewed before they will be "
-"available for download."
-msgstr ""
-"Файлы, добавленные в проверенные версии, должны быть проверены перед тем как"
-" они будут доступны для загрузки."
+msgid "Files added to reviewed versions must be reviewed before they will be available for download."
+msgstr "Файлы, добавленные в проверенные версии, должны быть проверены перед тем как они будут доступны для загрузки."
 
-#: src/olympia/devhub/templates/devhub/versions/add_file_modal.html:15
-#, python-format
-msgid ""
-"Submission of updates to unlisted add-ons for signing is currently in an "
-"open beta. Manual review may still be required for a large number of add-"
-"ons. Please <a href=\"%(url)s\" target=\"_blank\">report any bugs</a> that "
-"you encounter."
-msgstr ""
-"Представление на подпись не находящихся в списке дополнений в настоящее "
-"время находится в открытом бета-тестировании. Для большого числа дополнений "
-"все еще может быть необходима проверка вручную. Пожалуйста, <a "
-"href=\"%(url)s\" target=\"_blank\">сообщайте о любых найденных вами "
-"ошибках</a>."
-
-#: src/olympia/devhub/templates/devhub/versions/add_file_modal.html:35
+#: src/olympia/devhub/templates/devhub/versions/add_file_modal.html:24
 msgid "Select the target platform for this file."
 msgstr "Выберите платформу для этого файла."
 
-#: src/olympia/devhub/templates/devhub/versions/add_file_modal.html:46
+#: src/olympia/devhub/templates/devhub/versions/add_file_modal.html:35
 msgid "Which review type would you like to nominate for?"
 msgstr "На какой тип проверки вы хотели бы её номинировать?"
 
-#: src/olympia/devhub/templates/devhub/versions/add_file_modal.html:51
+#: src/olympia/devhub/templates/devhub/versions/add_file_modal.html:40
 msgid "Only publish this version to my beta channel."
 msgstr "Опубликовать эту версию только на моём бета-канале."
-
-#: src/olympia/devhub/templates/devhub/versions/add_file_modal.html:54
-#, python-format
-msgid ""
-"The behavior of the beta channel has changed to accommodate <a "
-"href=\"%(addon_signing_url)s\" target=\"_blank\">mandatory add-on "
-"signing</a>. The new process is currently in an open beta, and may change "
-"significantly in the near future. Please <a href=\"%(issues_url)s\" "
-"target=\"_blank\">report any bugs</a> that you encounter."
-msgstr ""
-"Поведение бета-канала изменилось, чтобы приспособиться к <a "
-"href=\"%(addon_signing_url)s\" target=\"_blank\">обязательной подписи "
-"дополнений</a>. Новый процесс в настоящее время находится в открытом бета-"
-"тестировании, и может существенно измениться в ближайшем будущем. "
-"Пожалуйста, <a href=\"%(issues_url)s\" target=\"_blank\">сообщайте о любых "
-"наденных вами ошибках</a>."
 
 #: src/olympia/devhub/templates/devhub/versions/edit.html:5
 msgid "Manage Version {0}"
 msgstr "Управление версией {0}"
 
-#: src/olympia/devhub/templates/devhub/versions/edit.html:12
-#: src/olympia/devhub/templates/devhub/versions/list.html:3
+#: src/olympia/devhub/templates/devhub/versions/edit.html:12 src/olympia/devhub/templates/devhub/versions/list.html:3
 msgid "Status & Versions"
 msgstr "Статус и версии"
 
-#. {0} is an add-on name.
 # {0} is the name of the collection
+#. {0} is an add-on name.
 #: src/olympia/devhub/templates/devhub/versions/edit.html:16
 msgid "Manage {0}"
 msgstr "Управлять {0}"
@@ -8965,22 +6838,10 @@ msgstr "Файлы"
 msgid "Upload Another File"
 msgstr "Загрузить другой файл"
 
-#: src/olympia/devhub/templates/devhub/versions/edit.html:45
-msgid ""
-"Adjusting application information here will allow users to install your\n"
-"                          add-on even if the install manifest in the package indicates that the\n"
-"                          add-on is incompatible."
-msgstr ""
-"Настройка информации о расширении позволит пользователям устанавливать\n"
-"                          ваше дополнение, даже если в его манифесте указано, что\n"
-"                          дополнение несовместимо."
-
 #: src/olympia/devhub/templates/devhub/versions/edit.html:74
 msgid ""
-"Information about changes in this release, new features,\n"
-"                              known bugs, and other useful information specific to this\n"
-"                              release/version. This information is also shown in the\n"
-"                              Add-ons Manager when updating."
+"Information about changes in this release, new features, known bugs, and other useful information specific to this release/version. This information is also shown in the Add-ons Manager when "
+"updating."
 msgstr ""
 "Информация об изменениях в этом релизе, новые возможности,\n"
 "                              известные баги, и другая полезная информация, относящаяся к\n"
@@ -8991,16 +6852,12 @@ msgstr ""
 msgid "Approval Status"
 msgstr "Статус одобрения"
 
-#: src/olympia/devhub/templates/devhub/versions/edit.html:113
-#: src/olympia/editors/templates/editors/review.html:108
+#: src/olympia/devhub/templates/devhub/versions/edit.html:113 src/olympia/editors/templates/editors/review.html:108
 msgid "Notes for Reviewers"
 msgstr "Примечания для проверяющих"
 
 #: src/olympia/devhub/templates/devhub/versions/edit.html:114
-msgid ""
-"Optionally, enter any information that may be useful\n"
-"                              to the Editor reviewing this add-on, such as test\n"
-"                              account information."
+msgid "Optionally, enter any information that may be useful to the Editor reviewing this add-on, such as test account information."
 msgstr ""
 "При желании, введите любую информацию, которая может быть полезна\n"
 "                              для редактора, проверяющего это дополнение, такую как\n"
@@ -9011,15 +6868,10 @@ msgid "Source code"
 msgstr "Исходный код"
 
 #: src/olympia/devhub/templates/devhub/versions/edit.html:128
-msgid ""
-"If your add-on contain binary or obfuscated code, make the source available "
-"here for reviewers."
-msgstr ""
-"Если ваше дополнение содержит бинарный или обфусцированный код, дайте здесь "
-"проверяющим доступ к исходникам."
+msgid "If your add-on contain binary or obfuscated code, make the source available here for reviewers."
+msgstr "Если ваше дополнение содержит бинарный или обфусцированный код, дайте здесь проверяющим доступ к исходникам."
 
-#: src/olympia/devhub/templates/devhub/versions/edit.html:145
-#: src/olympia/devhub/templates/devhub/versions/edit.html:149
+#: src/olympia/devhub/templates/devhub/versions/edit.html:145 src/olympia/devhub/templates/devhub/versions/edit.html:149
 msgid "Upload a new file"
 msgstr "Загрузить новый файл"
 
@@ -9060,7 +6912,6 @@ msgid "{0} file"
 msgid_plural "{0} files"
 msgstr[0] "{0} файл"
 msgstr[1] "{0} файла"
-msgstr[2] "{0} файлов"
 
 #: src/olympia/devhub/templates/devhub/versions/list.html:25
 msgid "0 files"
@@ -9087,9 +6938,7 @@ msgstr "Запросить полную проверку"
 msgid "Request Preliminary Review"
 msgstr "Запросить предварительную проверку"
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:80
-#: src/olympia/devhub/templates/devhub/versions/list.html:327
-#: src/olympia/devhub/templates/devhub/versions/list.html:350
+#: src/olympia/devhub/templates/devhub/versions/list.html:80 src/olympia/devhub/templates/devhub/versions/list.html:325 src/olympia/devhub/templates/devhub/versions/list.html:348
 msgid "Cancel Review Request"
 msgstr "Отменить запрос на отзыв"
 
@@ -9102,8 +6951,7 @@ msgid "Listed:"
 msgstr "Отображаемо:"
 
 #: src/olympia/devhub/templates/devhub/versions/list.html:102
-msgid ""
-"Visible to everyone on {0} and included in search results and listing pages"
+msgid "Visible to everyone on {0} and included in search results and listing pages"
 msgstr "Видимо всем на {0} и включено в результаты поиска и страницы листинга"
 
 #: src/olympia/devhub/templates/devhub/versions/list.html:108
@@ -9111,24 +6959,16 @@ msgid "Hidden:"
 msgstr "Скрыто:"
 
 #: src/olympia/devhub/templates/devhub/versions/list.html:108
-msgid ""
-"Hosted on {0}, but hidden to anyone but authors. Used to temporarily hide "
-"listings or discontinue them."
-msgstr ""
-"Размещено на {0}, но скрыто для всех, кроме авторов. Используется, чтобы "
-"временно скрыть листинги или прекратить их размещение."
+msgid "Hosted on {0}, but hidden to anyone but authors. Used to temporarily hide listings or discontinue them."
+msgstr "Размещено на {0}, но скрыто для всех, кроме авторов. Используется, чтобы временно скрыть листинги или прекратить их размещение."
 
 #: src/olympia/devhub/templates/devhub/versions/list.html:114
 msgid "Unlisted:"
 msgstr "Неотображаемо:"
 
 #: src/olympia/devhub/templates/devhub/versions/list.html:114
-msgid ""
-"Not distributed on {0}. Developers will upload new versions for signing and "
-"distribute the add-ons on their own. (beta)"
+msgid "Not distributed on {0}. Developers will upload new versions for signing and distribute the add-ons on their own."
 msgstr ""
-"Не распространяется через {0}. Разработчики будут загружать новые версии для"
-" подписи и потом сами распространять дополнения. (бета)"
 
 #: src/olympia/devhub/templates/devhub/versions/list.html:122
 msgid "Current versions"
@@ -9138,18 +6978,13 @@ msgstr "Текущие версии"
 msgid "Currently on AMO"
 msgstr "Сейчас на AMO"
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:129
-#: src/olympia/devhub/templates/devhub/versions/list.html:147
-#: src/olympia/devhub/templates/devhub/versions/list.html:164
-#: src/olympia/editors/templates/editors/includes/search_results_themes.html:7
-#: src/olympia/editors/templates/editors/themes/queue_list.html:50
+#: src/olympia/devhub/templates/devhub/versions/list.html:129 src/olympia/devhub/templates/devhub/versions/list.html:147 src/olympia/devhub/templates/devhub/versions/list.html:164
+#: src/olympia/editors/templates/editors/includes/search_results_themes.html:7 src/olympia/editors/templates/editors/themes/queue_list.html:50
 msgid "Status"
 msgstr "Состояние"
 
 # Header for a column in a table
-#: src/olympia/devhub/templates/devhub/versions/list.html:130
-#: src/olympia/devhub/templates/devhub/versions/list.html:148
-#: src/olympia/devhub/templates/devhub/versions/list.html:165
+#: src/olympia/devhub/templates/devhub/versions/list.html:130 src/olympia/devhub/templates/devhub/versions/list.html:148 src/olympia/devhub/templates/devhub/versions/list.html:165
 #: src/olympia/editors/templates/editors/includes/files_view.html:11
 msgid "Validation"
 msgstr "Валидация"
@@ -9171,15 +7006,10 @@ msgid "Full review may not be required"
 msgstr "Полная проверка может не требоваться"
 
 #: src/olympia/devhub/templates/devhub/versions/list.html:201
-msgid ""
-"Unlisted add-ons don't need Full Review unless they are distributed as part "
-"of an application installer. Read <a href=\"{link}\" target=\"_blank\">this "
-"documentation</a> for more information."
+msgid "Unlisted add-ons don't need Full Review unless they are distributed as part of an application installer. Read <a href=\"{link}\" target=\"_blank\">this documentation</a> for more information."
 msgstr ""
-"Не находящимся в списке дополнениям не нужна Полная проверка, если только "
-"они не распространяются как часть инсталлятора приложения.  Для получения "
-"дополнительной информации прочитайте <a href=\"{link}\" "
-"target=\"_blank\">эту документацию</a>."
+"Не находящимся в списке дополнениям не нужна Полная проверка, если только они не распространяются как часть инсталлятора приложения.  Для получения дополнительной информации прочитайте <a href="
+"\"{link}\" target=\"_blank\">эту документацию</a>."
 
 #: src/olympia/devhub/templates/devhub/versions/list.html:209
 msgid "Request full review"
@@ -9191,138 +7021,91 @@ msgstr "Удалить версию {version}"
 
 #: src/olympia/devhub/templates/devhub/versions/list.html:218
 msgid ""
-"You are about to delete the current version of your add-on. This may cause "
-"your add-on status to change, or your listing to lose public visibility, if "
-"this is the only public version of your add-on."
+"You are about to delete the current version of your add-on. This may cause your add-on status to change, or your listing to lose public visibility, if this is the only public version of your add-on."
 msgstr ""
-"Вы собираетесь удалить текущую версию вашего дополнения. Это может привести "
-"к изменению статуса дополнения, или потере видимости его страницы для "
-"публики, если это единственная публичная версия вашего дополнения."
+"Вы собираетесь удалить текущую версию вашего дополнения. Это может привести к изменению статуса дополнения, или потере видимости его страницы для публики, если это единственная публичная версия "
+"вашего дополнения."
 
 #: src/olympia/devhub/templates/devhub/versions/list.html:219
 msgid "Deleting this version will permanently delete:"
 msgstr "Удаление этой версии навсегда удалит:"
 
 #: src/olympia/devhub/templates/devhub/versions/list.html:225
-msgid ""
-"<strong>Important:</strong> Once a version has been deleted, you may not "
-"upload a new version with the same version number."
-msgstr ""
-"<strong>Важно:</strong> Как только версия была удалена, вы не сможете "
-"загрузить новую версию с тем же номером версии."
+msgid "<strong>Important:</strong> Once a version has been deleted, you may not upload a new version with the same version number."
+msgstr "<strong>Важно:</strong> Как только версия была удалена, вы не сможете загрузить новую версию с тем же номером версии."
 
 #: src/olympia/devhub/templates/devhub/versions/list.html:230
-msgid ""
-"Deleting a version which has already been reviewed\n"
-"               may also cause a significant delay in the review of\n"
-"               your next update."
-msgstr ""
-"Удаление версии, которая уже была проверена,\n"
-"               также может вызвать значительную задержку при проверке\n"
-"               вашего следующего обновления."
-
-#: src/olympia/devhub/templates/devhub/versions/list.html:233
 msgid "Are you sure you wish to delete this version?"
 msgstr "Вы уверены что хотите удалить эту версию?"
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:238
+#: src/olympia/devhub/templates/devhub/versions/list.html:235
 msgid "Delete Version"
 msgstr "Удалить версию"
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:240
+#: src/olympia/devhub/templates/devhub/versions/list.html:237
 msgid "Disable Version"
 msgstr "Отключить версию"
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:247
+#: src/olympia/devhub/templates/devhub/versions/list.html:244
 msgid "Add a new Version"
 msgstr "Добавить новую версию"
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:249
+#: src/olympia/devhub/templates/devhub/versions/list.html:246
 msgid "Add Version"
 msgstr "Добавить версию"
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:256
-#: src/olympia/devhub/templates/devhub/versions/list.html:274
+#: src/olympia/devhub/templates/devhub/versions/list.html:253 src/olympia/devhub/templates/devhub/versions/list.html:279
 msgid "Hide Add-on"
 msgstr "Скрыть дополнение"
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:259
-msgid ""
-"Hiding your add-on will prevent it from appearing anywhere in our gallery "
-"and will stop users from receiving automatic updates."
-msgstr ""
-"Скрытие вашего дополнения приведёт к его удалению из нашей галереи и "
-"отключит для пользователей автоматические обновления."
+#: src/olympia/devhub/templates/devhub/versions/list.html:256
+msgid "Hiding your add-on will prevent it from appearing anywhere in our gallery and will stop users from receiving automatic updates."
+msgstr "Скрытие вашего дополнения приведёт к его удалению из нашей галереи и отключит для пользователей автоматические обновления."
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:265
+#: src/olympia/devhub/templates/devhub/versions/list.html:263
+msgid "The files awaiting review will be disabled and you will need to upload new versions."
+msgstr ""
+
+#: src/olympia/devhub/templates/devhub/versions/list.html:270
 msgid "Are you sure you wish to hide your add-on?"
 msgstr "Вы уверены, что хотите скрыть свое дополнение?"
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:286
-#: src/olympia/devhub/templates/devhub/versions/list.html:315
+#: src/olympia/devhub/templates/devhub/versions/list.html:291 src/olympia/devhub/templates/devhub/versions/list.html:313
 msgid "Unlist Add-on"
 msgstr "Убрать дополнение из списка"
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:289
+#: src/olympia/devhub/templates/devhub/versions/list.html:294
 #, python-format
 msgid ""
-"Unlisting your add-on will make it (and each of its versions/files) "
-"invisible on this website. It won't show up in searches, won't have a public"
-" facing page, and won't be updated automatically for current users.  It is "
-"recommended for unlisted add-ons to provide a custom <a "
-"href=\"%(update_url)s\" target=\"_blank\">updateURL</a> in their manifest "
-"file for automatic updates."
+"Unlisting your add-on will make it (and each of its versions/files) invisible on this website. It won't show up in searches, won't have a public facing page, and won't be updated automatically for "
+"current users. It is recommended for unlisted add-ons to provide a custom <a href=\"%(update_url)s\" target=\"_blank\">updateURL</a> in their manifest file for automatic updates."
 msgstr ""
-"Скрытие вашего дополнения сделает его (и каждую его версию/файлы) не "
-"видимыми на этом сайте. Оно не будет отображаться в поиске, у него не будет "
-"страницы и оно не будет автоматически обновляться у пользователей.  Это "
-"рекомендуется для скрытых дополнений, предоставляющих свой <a "
-"href=\"%(update_url)s\" target=\"_blank\">updateURL</a> в их манифесте для "
-"автоматических обновлений."
+"Скрытие вашего дополнения сделает его (и каждую его версию/файлы) не видимыми на этом сайте. Оно не будет отображаться в поиске, у него не будет страницы и оно не будет автоматически обновляться у "
+"пользователей.  Это рекомендуется для скрытых дополнений, предоставляющих свой <a href=\"%(update_url)s\" target=\"_blank\">updateURL</a> в их манифесте для автоматических обновлений."
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:299
-#, python-format
-msgid ""
-"Switching add-ons to unlisted is currently in an open beta. Please <a "
-"href=\"%(url)s\" target=\"_blank\">report any bugs</a> that you encounter."
-msgstr ""
-"Перевод дополнений в статус не находящихся в списке в настоящее время "
-"находится в открытом бета-тестировании. Пожалуйста, <a href=\"%(url)s\" "
-"target=\"_blank\">сообщайте о любых найденных вами ошибках</a>."
-
-#: src/olympia/devhub/templates/devhub/versions/list.html:305
+#: src/olympia/devhub/templates/devhub/versions/list.html:303
 msgid "Unlisting an add-on is irreversible!"
 msgstr "Удаление дополнения из списка является необратимым!"
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:305
+#: src/olympia/devhub/templates/devhub/versions/list.html:303
 msgid "An unlisted add-on cannot be switched to be listed."
-msgstr ""
-"Не находящиеся в списке дополнения не могут быть переведены в статус "
-"находящихся в списке."
+msgstr "Не находящиеся в списке дополнения не могут быть переведены в статус находящихся в списке."
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:307
+#: src/olympia/devhub/templates/devhub/versions/list.html:305
 msgid "Are you sure you wish to unlist your add-on?"
 msgstr "Вы уверены, что хотите убрать ваше дополнение из списка?"
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:330
-msgid ""
-"Canceling your review request will leave your add-on as preliminarily "
-"reviewed."
-msgstr ""
-"Отмена вашего запроса на проверку оставит ваше дополнение как предварительно"
-" проверенное."
+#: src/olympia/devhub/templates/devhub/versions/list.html:328
+msgid "Canceling your review request will leave your add-on as preliminarily reviewed."
+msgstr "Отмена вашего запроса на проверку оставит ваше дополнение как предварительно проверенное."
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:335
-msgid ""
-"Canceling your review request will mark your add-on incomplete. If you do "
-"not complete your add-on after several days by re-requesting review, it will"
-" be deleted."
+#: src/olympia/devhub/templates/devhub/versions/list.html:333
+msgid "Canceling your review request will mark your add-on incomplete. If you do not complete your add-on after several days by re-requesting review, it will be deleted."
 msgstr ""
-"Отмена вашего запроса на проверку пометит ваше дополнение как незавершённое."
-" Если вы не завершите ваше дополнение в течение нескольких дней путём "
-"отправки повторного запроса на проверку, оно будет удалено."
+"Отмена вашего запроса на проверку пометит ваше дополнение как незавершённое. Если вы не завершите ваше дополнение в течение нескольких дней путём отправки повторного запроса на проверку, оно будет "
+"удалено."
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:343
+#: src/olympia/devhub/templates/devhub/versions/list.html:341
 msgid "Are you sure you wish to cancel your review request?"
 msgstr "Вы уверены, что хотите отменить свой запрос на отзыв?"
 
@@ -9332,8 +7115,7 @@ msgstr "Лёгкий Шоппинг"
 
 #: src/olympia/discovery/modules.py:141
 msgid "Save on your favorite items from the comfort of your browser."
-msgstr ""
-"Экономьте деньги на покупке ваших любимых вещей из комфорта вашего браузера."
+msgstr "Экономьте деньги на покупке ваших любимых вещей из комфорта вашего браузера."
 
 #: src/olympia/discovery/modules.py:149
 msgid "Build the perfect website"
@@ -9356,19 +7138,12 @@ msgid "Translate content on the web from and into over 40 languages."
 msgstr "Переводите веб-страницы более чем с 40 языков."
 
 #: src/olympia/discovery/modules.py:171
-msgid ""
-"Easily connect to your social networks, and share or comment on the page "
-"you're visiting."
-msgstr ""
-"Легко подключайтесь к вашим социальным сетям, оставляйте комментарии на "
-"посещаемых вами страницах или делитесь ими."
+msgid "Easily connect to your social networks, and share or comment on the page you're visiting."
+msgstr "Легко подключайтесь к вашим социальным сетям, оставляйте комментарии на посещаемых вами страницах или делитесь ими."
 
 #: src/olympia/discovery/modules.py:173
-msgid ""
-"A quick view to compare prices when you shop online or search for flights."
-msgstr ""
-"Быстро сравните цены при покупках в Интернете или бронировании билетов на "
-"самолёт."
+msgid "A quick view to compare prices when you shop online or search for flights."
+msgstr "Быстро сравните цены при покупках в Интернете или бронировании билетов на самолёт."
 
 #: src/olympia/discovery/modules.py:183
 msgid "Firefox 4 Collection"
@@ -9411,24 +7186,16 @@ msgid "Add-ons that help you on your travels!"
 msgstr "Дополнения, которые помогут вам в дороге!"
 
 #: src/olympia/discovery/modules.py:226
-msgid ""
-"Displays a country flag depicting the location of the current website's "
-"server and more."
-msgstr ""
-"Отображает флаг страны, в которой располагается сервер текущего веб-сайта и "
-"многое другое."
+msgid "Displays a country flag depicting the location of the current website's server and more."
+msgstr "Отображает флаг страны, в которой располагается сервер текущего веб-сайта и многое другое."
 
 #: src/olympia/discovery/modules.py:228
 msgid "FoxClocks let you keep an eye on the time around the world."
 msgstr "FoxClocks позволяет вам следить за временем по всему миру."
 
 #: src/olympia/discovery/modules.py:230
-msgid ""
-"Automatically get the lowest price when you shop online or search for "
-"flights."
-msgstr ""
-"Автоматически получайте самую низкую цену, когда вы делаете покупки в "
-"онлайне или ищете авиабилеты."
+msgid "Automatically get the lowest price when you shop online or search for flights."
+msgstr "Автоматически получайте самую низкую цену, когда вы делаете покупки в онлайне или ищете авиабилеты."
 
 #: src/olympia/discovery/modules.py:240
 msgid "A+ add-ons for School"
@@ -9436,8 +7203,7 @@ msgstr "Дополнения на 5+"
 
 #: src/olympia/discovery/modules.py:241
 msgid "Add-ons for teachers, parents, and students heading back to school."
-msgstr ""
-"Дополнения для учителей, родителей и учащихся, возвращающихся в школу."
+msgstr "Дополнения для учителей, родителей и учащихся, возвращающихся в школу."
 
 #: src/olympia/discovery/modules.py:246
 msgid "Would you like to know which websites you can trust?"
@@ -9468,12 +7234,8 @@ msgid "Put a Theme on It!"
 msgstr "Украсьте его темой!"
 
 #: src/olympia/discovery/modules.py:281
-msgid ""
-"Visit addons.mozilla.org from Firefox for Android and dress up your mobile "
-"browser to match your style, mood, or the season."
-msgstr ""
-"Посетите addons.mozilla.org из Firefox для Android и оденьте ваш мобильный "
-"браузер под ваш стиль, настроение или сезон."
+msgid "Visit addons.mozilla.org from Firefox for Android and dress up your mobile browser to match your style, mood, or the season."
+msgstr "Посетите addons.mozilla.org из Firefox для Android и оденьте ваш мобильный браузер под ваш стиль, настроение или сезон."
 
 #: src/olympia/discovery/modules.py:290
 msgid "Get up and move!"
@@ -9481,8 +7243,7 @@ msgstr "Вставайте и двигайтесь!"
 
 #: src/olympia/discovery/modules.py:291
 msgid "Install these fitness add-ons to keep you active and healthy."
-msgstr ""
-"Установите эти дополнения для фитнесса, чтобы быть активным и здоровым"
+msgstr "Установите эти дополнения для фитнесса, чтобы быть активным и здоровым"
 
 #: src/olympia/discovery/modules.py:299
 msgid "New &amp; Now"
@@ -9501,12 +7262,8 @@ msgid "Protect your privacy online with the add-ons in this collection."
 msgstr "Защитите вашу приватность в Интернете дополнениями из этой подборки"
 
 #: src/olympia/discovery/modules.py:342
-msgid ""
-"Great add-ons for work, fun, privacy, productivity&hellip; just about "
-"anything!"
-msgstr ""
-"Отличные дополнения для работы, развлечений, защиты приватности, ускорения "
-"работы&hellip; просто для чего угодно!"
+msgid "Great add-ons for work, fun, privacy, productivity&hellip; just about anything!"
+msgstr "Отличные дополнения для работы, развлечений, защиты приватности, ускорения работы&hellip; просто для чего угодно!"
 
 #: src/olympia/discovery/modules.py:350
 msgid "Add-ons for Australis Contest Winners"
@@ -9526,23 +7283,16 @@ msgstr "Что такое дополнения?"
 
 #: src/olympia/discovery/templates/discovery/pane.html:28
 #, python-format
-msgid ""
-"Add-ons are applications that let you personalize %(app)s with extra "
-"functionality or style. Try a time-saving sidebar, a weather notifier, or a "
-"themed look to make %(app)s your own."
+msgid "Add-ons are applications that let you personalize %(app)s with extra functionality or style. Try a time-saving sidebar, a weather notifier, or a themed look to make %(app)s your own."
 msgstr ""
-"Дополнения — это приложения, которые позволяют вам настроить %(app)s по "
-"своему вкусу, добавив в него дополнительные функции или придав ему свой "
-"стиль. Попробуйте использовать экономящую время боковую панель, настройте "
-"уведомление о прогнозе погоды или измените его внешний вид, чтобы сделать "
-"%(app)s именно таким, каким вы желаете."
+"Дополнения — это приложения, которые позволяют вам настроить %(app)s по своему вкусу, добавив в него дополнительные функции или придав ему свой стиль. Попробуйте использовать экономящую время "
+"боковую панель, настройте уведомление о прогнозе погоды или измените его внешний вид, чтобы сделать %(app)s именно таким, каким вы желаете."
 
 #: src/olympia/discovery/templates/discovery/pane.html:62
 msgid "Learn More About Add-ons"
 msgstr "Подробнее о дополнениях"
 
-#: src/olympia/discovery/templates/discovery/pane.html:66
-#: src/olympia/discovery/templates/discovery/pane.html:73
+#: src/olympia/discovery/templates/discovery/pane.html:66 src/olympia/discovery/templates/discovery/pane.html:73
 msgid "See all"
 msgstr "Показать всё"
 
@@ -9573,12 +7323,8 @@ msgstr "Привет, {0}"
 
 #: src/olympia/discovery/templates/discovery/pane_account.html:17
 #, python-format
-msgid ""
-"Thanks for using %(app)s and supporting <a href=\"%(url)s\">Mozilla's "
-"mission</a>!"
-msgstr ""
-"Спасибо за использование %(app)s и поддержку <a href=\"%(url)s\">миссии "
-"Mozilla</a>!"
+msgid "Thanks for using %(app)s and supporting <a href=\"%(url)s\">Mozilla's mission</a>!"
+msgstr "Спасибо за использование %(app)s и поддержку <a href=\"%(url)s\">миссии Mozilla</a>!"
 
 #: src/olympia/discovery/templates/discovery/pane_account.html:23
 msgid "Add-ons downloaded:"
@@ -9602,15 +7348,10 @@ msgstr "Загружайте дополнения откуда угодно"
 
 #: src/olympia/discovery/templates/discovery/modules/go-mobile.html:8
 #, python-format
-msgid ""
-"Visit <a href=\"%(url)s\">firefox.com/m</a> to get Firefox on your phone and"
-" personalize your browser anytime, anywhere. Easily discover and install "
-"add-ons from the mobile Add-ons Manager."
+msgid "Visit <a href=\"%(url)s\">firefox.com/m</a> to get Firefox on your phone and personalize your browser anytime, anywhere. Easily discover and install add-ons from the mobile Add-ons Manager."
 msgstr ""
-"Посетите <a href=\"%(url)s\">firefox.com/m</a>, чтобы загрузить Firefox на "
-"ваш телефон и настроить свой браузер под себя в любое время и в любом месте."
-" С лёгкостью ищите и устанавливайте дополнения из мобильного менеджера "
-"дополнений."
+"Посетите <a href=\"%(url)s\">firefox.com/m</a>, чтобы загрузить Firefox на ваш телефон и настроить свой браузер под себя в любое время и в любом месте. С лёгкостью ищите и устанавливайте дополнения "
+"из мобильного менеджера дополнений."
 
 #: src/olympia/discovery/templates/discovery/modules/go-mobile.html:13
 msgid "Get Mobile Add-ons"
@@ -9622,24 +7363,15 @@ msgstr "Умный Шоппинг в этот праздничный сезон"
 
 #: src/olympia/discovery/templates/discovery/modules/holiday.html:5
 msgid "Find great add-ons to help you with all your holiday shopping needs."
-msgstr ""
-"Откройте отличные дополнения, которые помогут вам в покупках на праздники"
+msgstr "Откройте отличные дополнения, которые помогут вам в покупках на праздники"
 
 #: src/olympia/discovery/templates/discovery/modules/holiday.html:13
-msgid ""
-"Install the Amazon Browser Apps and receive special Amazon features right at"
-" your fingertips."
-msgstr ""
-"Установите браузерные приложения Amazon и получите прямо в свои руки "
-"специальные возможности от Amazon."
+msgid "Install the Amazon Browser Apps and receive special Amazon features right at your fingertips."
+msgstr "Установите браузерные приложения Amazon и получите прямо в свои руки специальные возможности от Amazon."
 
 #: src/olympia/discovery/templates/discovery/modules/holiday.html:22
-msgid ""
-"Keep an eye on your eBay activity wherever you are on the web when you "
-"install the eBay Sidebar for Firefox."
-msgstr ""
-"Будьте в курсе активности на eBay из любого места Интернета, установив eBay "
-"Sidebar для Firefox."
+msgid "Keep an eye on your eBay activity wherever you are on the web when you install the eBay Sidebar for Firefox."
+msgstr "Будьте в курсе активности на eBay из любого места Интернета, установив eBay Sidebar для Firefox."
 
 #: src/olympia/discovery/templates/discovery/modules/holiday.html:31
 msgid "See the entire holiday shopping add-on collection."
@@ -9716,19 +7448,19 @@ msgstr "дополнение, проверяющий или комментари
 msgid "Search by add-on name / author email"
 msgstr "Поиск по имени дополнения/адресу автора"
 
-#: src/olympia/editors/forms.py:103
+#: src/olympia/editors/forms.py:103 src/olympia/editors/forms.py:244 src/olympia/editors/forms.py:257
 msgid "yes"
 msgstr "да"
 
-#: src/olympia/editors/forms.py:104
+#: src/olympia/editors/forms.py:104 src/olympia/editors/forms.py:244 src/olympia/editors/forms.py:257
 msgid "no"
 msgstr "нет"
 
-#: src/olympia/editors/forms.py:105
+#: src/olympia/editors/forms.py:105 src/olympia/editors/forms.py:245
 msgid "Admin Flag"
 msgstr "Флаг админа"
 
-#: src/olympia/editors/forms.py:113
+#: src/olympia/editors/forms.py:113 src/olympia/editors/forms.py:253
 msgid "Max. Version"
 msgstr "Макс. версия"
 
@@ -9740,59 +7472,59 @@ msgstr "Дней с момента представления"
 msgid "Add-on Types"
 msgstr "Типы дополнений"
 
-#: src/olympia/editors/forms.py:126 src/olympia/editors/helpers.py:267
+#: src/olympia/editors/forms.py:126 src/olympia/editors/helpers.py:279
 msgid "Platforms"
 msgstr "Платформы"
 
+#: src/olympia/editors/forms.py:237
+msgid "Search by add-on name / author email / guid"
+msgstr ""
+
 #. L10n: 0 = platform, 1 = filename, 2 = status message
-#: src/olympia/editors/forms.py:238
+#: src/olympia/editors/forms.py:342
 #, python-format
 msgid "<strong>%s</strong> &middot; %s &middot; %s"
 msgstr "<strong>%s</strong> &middot; %s &middot; %s"
 
-#: src/olympia/editors/forms.py:252
+#: src/olympia/editors/forms.py:356
 msgid "Comments:"
 msgstr "Комментарии:"
 
-#: src/olympia/editors/forms.py:256
+#: src/olympia/editors/forms.py:360
 msgid "Operating systems:"
 msgstr "Операционные системы:"
 
-#: src/olympia/editors/forms.py:258
+#: src/olympia/editors/forms.py:362
 msgid "Applications:"
 msgstr "Приложения:"
 
-#: src/olympia/editors/forms.py:260
-msgid ""
-"Notify me the next time this add-on is updated. (Subsequent updates will not"
-" generate an email)"
-msgstr ""
-"Уведомить меня при следующем обновлении этого дополнения. (Последующие "
-"обновления не приведут к отправке письма)"
+#: src/olympia/editors/forms.py:364
+msgid "Notify me the next time this add-on is updated. (Subsequent updates will not generate an email)"
+msgstr "Уведомить меня при следующем обновлении этого дополнения. (Последующие обновления не приведут к отправке письма)"
 
-#: src/olympia/editors/forms.py:265
+#: src/olympia/editors/forms.py:369
 msgid "Clear Admin Review Flag"
 msgstr "Снять флаг проверки админом"
 
-#: src/olympia/editors/forms.py:267
+#: src/olympia/editors/forms.py:371
 msgid "Clear more info requested flag"
 msgstr "Снять флаг \"запрошено больше информации\""
 
-#: src/olympia/editors/forms.py:281
+#: src/olympia/editors/forms.py:385
 msgid "Choose a canned response..."
 msgstr "Выберите стандартный ответ..."
 
 #. L10n: Description of what can be searched for.
-#: src/olympia/editors/forms.py:324
+#: src/olympia/editors/forms.py:423
 msgid "theme name"
 msgstr "имя темы"
 
-#: src/olympia/editors/forms.py:350
+#: src/olympia/editors/forms.py:449
 msgid "Someone else is reviewing this theme."
 msgstr "Кто-то ещё проверяет эту тему."
 
 #. L10n: Description of what can be searched for.
-#: src/olympia/editors/forms.py:447
+#: src/olympia/editors/forms.py:546
 msgid "app, reviewer, or comment"
 msgstr "дополнение, оставивший отзыв или комментарий"
 
@@ -9808,301 +7540,266 @@ msgstr "Ожидает предварительного одобрения"
 msgid "Rejected or Unreviewed"
 msgstr "Отклонено или не проверено"
 
-#: src/olympia/editors/helpers.py:123 src/olympia/editors/helpers.py:136
+#: src/olympia/editors/helpers.py:125 src/olympia/editors/helpers.py:138
 msgid "Queue"
 msgstr "Очередь"
 
-#: src/olympia/editors/helpers.py:124
-#: src/olympia/editors/templates/editors/base.html:50
-#: src/olympia/editors/templates/editors/base.html:65
+#: src/olympia/editors/helpers.py:126 src/olympia/editors/templates/editors/base.html:50 src/olympia/editors/templates/editors/base.html:65
 msgid "Pending Updates"
 msgstr "Ждущие обновления"
 
-#: src/olympia/editors/helpers.py:125
-#: src/olympia/editors/templates/editors/base.html:48
-#: src/olympia/editors/templates/editors/base.html:63
+#: src/olympia/editors/helpers.py:127 src/olympia/editors/templates/editors/base.html:48 src/olympia/editors/templates/editors/base.html:63
 msgid "Full Reviews"
 msgstr "Полные проверки"
 
-#: src/olympia/editors/helpers.py:126
-#: src/olympia/editors/templates/editors/base.html:52
-#: src/olympia/editors/templates/editors/base.html:67
+#: src/olympia/editors/helpers.py:128 src/olympia/editors/templates/editors/base.html:52 src/olympia/editors/templates/editors/base.html:67
 msgid "Preliminary Reviews"
 msgstr "Предварительные проверки"
 
-#: src/olympia/editors/helpers.py:127
-#: src/olympia/editors/templates/editors/base.html:54
+#: src/olympia/editors/helpers.py:129 src/olympia/editors/templates/editors/base.html:54
 msgid "Moderated Reviews"
 msgstr "Модерируемые проверки"
 
-#: src/olympia/editors/helpers.py:128
-#: src/olympia/editors/templates/editors/base.html:46
+#: src/olympia/editors/helpers.py:130 src/olympia/editors/templates/editors/base.html:46
 msgid "Fast Track"
 msgstr "Быстрое отслеживание"
 
-#: src/olympia/editors/helpers.py:130
+#: src/olympia/editors/helpers.py:132
 msgid "Pending Themes"
 msgstr "Ожидающие темы"
 
-#: src/olympia/editors/helpers.py:131
-#: src/olympia/editors/templates/editors/themes/queue.html:4
+#: src/olympia/editors/helpers.py:133 src/olympia/editors/templates/editors/themes/queue.html:4
 msgid "Flagged Themes"
 msgstr "Отмеченные темы"
 
-#: src/olympia/editors/helpers.py:132
+#: src/olympia/editors/helpers.py:134
 msgid "Update Themes"
 msgstr "Обновить темы"
 
-#: src/olympia/editors/helpers.py:137
+#: src/olympia/editors/helpers.py:139
 msgid "Unlisted Pending Updates"
 msgstr "Ожидающие обновлений неотображаемые"
 
-#: src/olympia/editors/helpers.py:138
+#: src/olympia/editors/helpers.py:140
 msgid "Unlisted Full Reviews"
 msgstr "Полные проверки неотображаемых"
 
-#: src/olympia/editors/helpers.py:139
+#: src/olympia/editors/helpers.py:141
 msgid "Unlisted Preliminary Reviews"
 msgstr "Предварительные проверки неотображаемых"
 
-#: src/olympia/editors/helpers.py:170
+#: src/olympia/editors/helpers.py:142
+msgid "Unlisted All Add-ons"
+msgstr ""
+
+#: src/olympia/editors/helpers.py:173
 msgid "Fast Track ({0})"
 msgid_plural "Fast Track ({0})"
 msgstr[0] "Быстрое отслеживание ({0})"
 msgstr[1] "Быстрое отслеживание ({0})"
-msgstr[2] "Быстрое отслеживание ({0})"
 
-#: src/olympia/editors/helpers.py:175
+#: src/olympia/editors/helpers.py:178
 msgid "Full Review ({0})"
 msgid_plural "Full Reviews ({0})"
 msgstr[0] "Полная проверка ({0})"
 msgstr[1] "Полные проверки ({0})"
-msgstr[2] "Полные проверки ({0})"
 
-#: src/olympia/editors/helpers.py:180
+#: src/olympia/editors/helpers.py:183
 msgid "Pending Update ({0})"
 msgid_plural "Pending Updates ({0})"
 msgstr[0] "Ожидающее обновление ({0})"
 msgstr[1] "Ожидающие обновления ({0})"
-msgstr[2] "Ожидающих обновлений ({0})"
 
-#: src/olympia/editors/helpers.py:185
+#: src/olympia/editors/helpers.py:188
 msgid "Preliminary Review ({0})"
 msgid_plural "Preliminary Reviews ({0})"
 msgstr[0] "Предварительная проверка ({0})"
 msgstr[1] "Предварительные проверки ({0})"
-msgstr[2] "Предварительные проверки ({0})"
 
-#: src/olympia/editors/helpers.py:190
+#: src/olympia/editors/helpers.py:193
 msgid "Moderated Review ({0})"
 msgid_plural "Moderated Reviews ({0})"
 msgstr[0] "Модерируемая проверка ({0})"
 msgstr[1] "Модерируемые проверки ({0})"
-msgstr[2] "Модерируемые проверки ({0})"
 
-#: src/olympia/editors/helpers.py:196
+#: src/olympia/editors/helpers.py:199
 msgid "Unlisted Full Review ({0})"
 msgid_plural "Unlisted Full Reviews ({0})"
 msgstr[0] "Полная проверка неотображаемых ({0})"
 msgstr[1] "Полные проверки неотображаемых ({0})"
-msgstr[2] "Полные проверки неотображаемых ({0})"
 
-#: src/olympia/editors/helpers.py:201
+#: src/olympia/editors/helpers.py:204
 msgid "Unlisted Pending Update ({0})"
 msgid_plural "Unlisted Pending Updates ({0})"
 msgstr[0] "Ожидающее обновления неотображаемое ({0})"
 msgstr[1] "Ожидающие обновлений неотображаемые ({0})"
-msgstr[2] "Ожидающие обновлений неотображаемые ({0})"
 
-#: src/olympia/editors/helpers.py:206
+#: src/olympia/editors/helpers.py:209
 msgid "Unlisted Preliminary Review ({0})"
 msgid_plural "Unlisted Preliminary Reviews ({0})"
 msgstr[0] "Предварительная проверка неотображаемых ({0})"
 msgstr[1] "Предварительные проверки неотображаемых ({0})"
-msgstr[2] "Предварительные проверки неотображаемых ({0})"
 
-#: src/olympia/editors/helpers.py:261
-msgid "Addon"
-msgstr "Дополнение"
+#: src/olympia/editors/helpers.py:214
+msgid "Unlisted All Add-ons ({0})"
+msgid_plural "Unlisted All Add-ons ({0})"
+msgstr[0] ""
+msgstr[1] ""
 
-#: src/olympia/editors/helpers.py:262
+#: src/olympia/editors/helpers.py:274
 msgid "Type"
 msgstr "Тип"
 
-#: src/olympia/editors/helpers.py:263
+#: src/olympia/editors/helpers.py:275
 msgid "Waiting Time"
 msgstr "Время ожидания"
 
-#: src/olympia/editors/helpers.py:264
-#: src/olympia/editors/templates/editors/review.html:285
+#: src/olympia/editors/helpers.py:276 src/olympia/editors/templates/editors/review.html:285
 msgid "Flags"
 msgstr "Флаги"
 
-#: src/olympia/editors/helpers.py:265
+#: src/olympia/editors/helpers.py:277
 msgid "Applications"
 msgstr "Приложения"
 
-#: src/olympia/editors/helpers.py:270
+#: src/olympia/editors/helpers.py:282
 msgid "Additional"
 msgstr "Дополнительно"
 
-#: src/olympia/editors/helpers.py:285
+#: src/olympia/editors/helpers.py:302
 msgid "Site Specific"
 msgstr "Специфичные для сайта"
 
-#: src/olympia/editors/helpers.py:287
+#: src/olympia/editors/helpers.py:304
 msgid "Requires External Software"
 msgstr "Требует стороннего ПО"
 
-#: src/olympia/editors/helpers.py:289
+#: src/olympia/editors/helpers.py:306
 msgid "Binary Components"
 msgstr "Бинарные компоненты"
 
-#: src/olympia/editors/helpers.py:313
+#: src/olympia/editors/helpers.py:339
 msgid "moments ago"
 msgstr "мгновения назад "
 
 #. L10n: first argument is number of minutes
-#: src/olympia/editors/helpers.py:316
+#: src/olympia/editors/helpers.py:342
 msgid "{0} minute"
 msgid_plural "{0} minutes"
 msgstr[0] "{0} минута"
 msgstr[1] "{0} минуты"
-msgstr[2] "{0} минут"
 
 #. L10n: first argument is number of hours
-#: src/olympia/editors/helpers.py:320
+#: src/olympia/editors/helpers.py:346
 msgid "{0} hour"
 msgid_plural "{0} hours"
 msgstr[0] "{0} час"
 msgstr[1] "{0} часа"
-msgstr[2] "{0} часов"
 
 #. L10n: first argument is number of days
-#: src/olympia/editors/helpers.py:324
+#: src/olympia/editors/helpers.py:350
 msgid "{0} day"
 msgid_plural "{0} days"
 msgstr[0] "{0} день"
 msgstr[1] "{0} дня"
-msgstr[2] "{0} дней"
 
-#: src/olympia/editors/helpers.py:488
+#: src/olympia/editors/helpers.py:364
+msgid "Last Review"
+msgstr ""
+
+#: src/olympia/editors/helpers.py:366
+msgid "Last Update"
+msgstr ""
+
+#: src/olympia/editors/helpers.py:387
+msgid "No Reviews"
+msgstr ""
+
+#: src/olympia/editors/helpers.py:561
 msgid "Push to public"
 msgstr "Поместить в общий доступ"
 
-#: src/olympia/editors/helpers.py:490
+#: src/olympia/editors/helpers.py:563
 msgid "Grant full review"
 msgstr "Одобрить полную проверку"
 
-#: src/olympia/editors/helpers.py:505
+#: src/olympia/editors/helpers.py:578
 msgid "Request more information"
 msgstr "Запросить дополнительную информацию"
 
-#: src/olympia/editors/helpers.py:508
+#: src/olympia/editors/helpers.py:581
 msgid "Request super-review"
 msgstr "Запросить суперрецензию"
 
-#: src/olympia/editors/helpers.py:519
+#: src/olympia/editors/helpers.py:592
 msgid "Grant preliminary review"
 msgstr "Дать предварительное одобрение"
 
-#: src/olympia/editors/helpers.py:520
+#: src/olympia/editors/helpers.py:593
 msgid "This will mark the files as preliminarily reviewed."
 msgstr "Это отметит файлы как предварительно проверенные."
 
-#: src/olympia/editors/helpers.py:522
-msgid ""
-"Use this form to request more information from the author. They will receive"
-" an email and be able to answer here. You will be notified by email when "
-"they reply."
-msgstr ""
-"Используйте эту форму, чтобы запросить у авторов более подробную информацию."
-" Они получат письмо по эл. почте и смогут тут ответить. Когда они ответят, "
-"вас уведомят по эл. почте."
+#: src/olympia/editors/helpers.py:595
+msgid "Use this form to request more information from the author. They will receive an email and be able to answer here. You will be notified by email when they reply."
+msgstr "Используйте эту форму, чтобы запросить у авторов более подробную информацию. Они получат письмо по эл. почте и смогут тут ответить. Когда они ответят, вас уведомят по эл. почте."
 
-#: src/olympia/editors/helpers.py:526
+#: src/olympia/editors/helpers.py:599
 msgid ""
-"If you have concerns about this add-on's security, copyright issues, or "
-"other concerns that an administrator should look into, enter your comments "
-"in the area below. They will be sent to administrators, not the author."
+"If you have concerns about this add-on's security, copyright issues, or other concerns that an administrator should look into, enter your comments in the area below. They will be sent to "
+"administrators, not the author."
 msgstr ""
-"Если у вас есть сомнения насчет безопасности этого дополнения, проблем с "
-"авторскими правами или других проблем, требующих изучения администратора, "
-"введите ваши комментарии в расположенное ниже поле. Они будут отосланы "
-"администраторам, а не автору."
+"Если у вас есть сомнения насчет безопасности этого дополнения, проблем с авторскими правами или других проблем, требующих изучения администратора, введите ваши комментарии в расположенное ниже "
+"поле. Они будут отосланы администраторам, а не автору."
 
-#: src/olympia/editors/helpers.py:532
+#: src/olympia/editors/helpers.py:605
 msgid "This will reject the add-on and remove it from the review queue."
 msgstr "Это отклонит дополнение и удалить его из очереди проверки."
 
-#: src/olympia/editors/helpers.py:534
-msgid "Make a comment on this version.  The author won't be able to see this."
+#: src/olympia/editors/helpers.py:607
+msgid "Make a comment on this version. The author won't be able to see this."
 msgstr "Прокомментируйте эту версию.  Автор не сможет это увидеть."
 
-#: src/olympia/editors/helpers.py:538
+#: src/olympia/editors/helpers.py:611
 msgid "This will reject the files and remove them from the review queue."
 msgstr "Это отклонит файлы и удалить их из очереди проверки."
 
-#: src/olympia/editors/helpers.py:542
-msgid ""
-"This will mark the add-on as preliminarily reviewed. Future versions will "
-"undergo preliminary review."
-msgstr ""
-"Это отметит дополнение как предварительно проверенное. Будущие версии будут "
-"подвергаться предварительной проверке."
+#: src/olympia/editors/helpers.py:615
+msgid "This will mark the add-on as preliminarily reviewed. Future versions will undergo preliminary review."
+msgstr "Это отметит дополнение как предварительно проверенное. Будущие версии будут подвергаться предварительной проверке."
 
-#: src/olympia/editors/helpers.py:547
-msgid ""
-"This will mark the files as preliminarily reviewed. Future versions will "
-"undergo preliminary review."
-msgstr ""
-"Это отметит файлы как предварительно проверенные. Будущие версии будут "
-"подвергаться предварительной проверке."
+#: src/olympia/editors/helpers.py:620
+msgid "This will mark the files as preliminarily reviewed. Future versions will undergo preliminary review."
+msgstr "Это отметит файлы как предварительно проверенные. Будущие версии будут подвергаться предварительной проверке."
 
-#: src/olympia/editors/helpers.py:552
+#: src/olympia/editors/helpers.py:625
 msgid "Retain preliminary review"
 msgstr "Оставить предварительное одобрение"
 
-#: src/olympia/editors/helpers.py:553
-msgid ""
-"This will retain the add-on as preliminarily reviewed. Future versions will "
-"undergo preliminary review."
-msgstr ""
-"Это оставит дополнение в статусе предварительно проверенного. Будущие версии"
-" будут подвергаться предварительной проверке."
+#: src/olympia/editors/helpers.py:626
+msgid "This will retain the add-on as preliminarily reviewed. Future versions will undergo preliminary review."
+msgstr "Это оставит дополнение в статусе предварительно проверенного. Будущие версии будут подвергаться предварительной проверке."
 
-#: src/olympia/editors/helpers.py:558
-msgid ""
-"This will approve a sandboxed version of a public add-on to appear on the "
-"public side."
-msgstr ""
-"Это одобрит размещённую в «песочнице» версию публичного дополнения, которая "
-"появится в общем доступе."
+#: src/olympia/editors/helpers.py:631
+msgid "This will approve a sandboxed version of a public add-on to appear on the public side."
+msgstr "Это одобрит размещённую в «песочнице» версию публичного дополнения, которая появится в общем доступе."
 
-#: src/olympia/editors/helpers.py:561
-msgid ""
-"This will reject a version of a public add-on and remove it from the queue."
+#: src/olympia/editors/helpers.py:634
+msgid "This will reject a version of a public add-on and remove it from the queue."
 msgstr "Это отвергнет версию публичного дополнения и удалит его из очереди."
 
-#: src/olympia/editors/helpers.py:564
-msgid ""
-"This will mark the add-on and its most recent version and files as public. "
-"Future versions will go into the sandbox until they are reviewed by an "
-"editor."
-msgstr ""
-"Это пометит дополнение и его самую последнюю версию и файлы как "
-"общедоступные. Будущие версии будут попадать в «песочницу», пока они не "
-"будут проверены редактором."
-
 #: src/olympia/editors/helpers.py:637
+msgid "This will mark the add-on and its most recent version and files as public. Future versions will go into the sandbox until they are reviewed by an editor."
+msgstr "Это пометит дополнение и его самую последнюю версию и файлы как общедоступные. Будущие версии будут попадать в «песочницу», пока они не будут проверены редактором."
+
+#: src/olympia/editors/helpers.py:714
 msgid "add-on"
 msgstr "дополнение"
 
-#: src/olympia/editors/helpers.py:940 src/olympia/editors/helpers.py:960
+#: src/olympia/editors/helpers.py:1020 src/olympia/editors/helpers.py:1040
 msgid "Flagged"
 msgstr "Отмечено"
 
-#: src/olympia/editors/helpers.py:944 src/olympia/editors/helpers.py:963
+#: src/olympia/editors/helpers.py:1024 src/olympia/editors/helpers.py:1043
 msgid "Updates"
 msgstr "Обновления"
 
@@ -10154,76 +7851,68 @@ msgstr "Представленная тема отмечена для прове
 msgid "A question about your Theme submission"
 msgstr "Вопрос о представлении вашей темы"
 
-#: src/olympia/editors/views.py:144
+#: src/olympia/editors/views.py:146
 msgid "New Add-ons (Under 5 days)"
 msgstr "Новые дополнения (менее 5 дней)"
 
-#: src/olympia/editors/views.py:145
+#: src/olympia/editors/views.py:147
 msgid "Passable (5 to 10 days)"
 msgstr "Сносно (от 5 до 10 дней)"
 
-#: src/olympia/editors/views.py:146
+#: src/olympia/editors/views.py:148
 msgid "Overdue (Over 10 days)"
 msgstr "Просрочено (более 10 дней)"
 
-#: src/olympia/editors/views.py:532
+#: src/olympia/editors/views.py:539
 msgid "An unknown error occurred"
 msgstr "Произошла неизвестная ошибка"
 
-#: src/olympia/editors/views.py:587
+#: src/olympia/editors/views.py:592
 msgid "Self-reviews are not allowed."
 msgstr "Самопроверка не разрешена."
 
-#: src/olympia/editors/views.py:609
+#: src/olympia/editors/views.py:613
 msgid "Review successfully processed."
 msgstr "Проверка успешно обработана."
 
-#: src/olympia/editors/views.py:807
+#: src/olympia/editors/views.py:812
 msgid "was approved"
 msgstr "было одобрено"
 
-#: src/olympia/editors/views.py:808
+#: src/olympia/editors/views.py:813
 msgid "given preliminary review"
 msgstr "дано предварительное одобрение"
 
-#: src/olympia/editors/views.py:809
+#: src/olympia/editors/views.py:814
 msgid "rejected"
 msgstr "отвергнуто"
 
-#: src/olympia/editors/views.py:810
+#: src/olympia/editors/views.py:815
 msgctxt "editors_review_history_nominated_adminreview"
 msgid "escalated"
 msgstr "отправлено наверх"
 
-#: src/olympia/editors/views.py:812
+#: src/olympia/editors/views.py:817
 msgid "needs more information"
 msgstr "необходимо больше информации"
 
-#: src/olympia/editors/views.py:813
+#: src/olympia/editors/views.py:818
 msgid "needs super review"
 msgstr "необходимо super review"
 
-#: src/olympia/editors/views.py:814
+#: src/olympia/editors/views.py:819
 msgid "commented"
 msgstr "прокомментировано"
 
 #: src/olympia/editors/views_themes.py:326
 msgid "{0} theme review successfully processed (+{1} points, {2} total)."
-msgid_plural ""
-"{0} theme reviews successfully processed (+{1} points, {2} total)."
+msgid_plural "{0} theme reviews successfully processed (+{1} points, {2} total)."
 msgstr[0] "успешно произведена {0} проверка темы (+{1} очков, всего - {2})."
 msgstr[1] "успешно произведено {0} проверки тем (+{1} очков, всего - {2})."
-msgstr[2] "успешно произведено {0} проверок тем (+{1} очков, всего - {2})."
 
 #: src/olympia/editors/views_themes.py:341
-msgid ""
-"Your theme locks have successfully been released. Other reviewers may now "
-"review those released themes. You may have to refresh the page to see the "
-"changes reflected in the table below."
-msgstr ""
-"Ваши блокировки тем были успешно сняты. Другие рецензенты теперь могут "
-"проверить эти разблокированные темы. Возможно, вам надо обновить страницу, "
-"чтобы увидеть внизу изменения в таблице."
+msgid "Your theme locks have successfully been released. Other reviewers may now review those released themes. You may have to refresh the page to see the changes reflected in the table below."
+msgstr "Ваши блокировки тем были успешно сняты. Другие рецензенты теперь могут проверить эти разблокированные темы. Возможно, вам надо обновить страницу, чтобы увидеть внизу изменения в таблице."
 
 #: src/olympia/editors/templates/editors/abuse_reports.html:4
 msgid "{addon} :: Abuse Reports"
@@ -10247,9 +7936,7 @@ msgstr "<i>anonymous</i> в %(date)s [%(ip_address)s]"
 msgid "Return to the Editor Tools homepage"
 msgstr "Вернуться на страницу инструментов проверяющего"
 
-#: src/olympia/editors/templates/editors/base.html:43
-#: src/olympia/editors/templates/editors/themes/base.html:14
-#: src/olympia/editors/templates/editors/themes/base.html:28
+#: src/olympia/editors/templates/editors/base.html:43 src/olympia/editors/templates/editors/themes/base.html:14 src/olympia/editors/templates/editors/themes/base.html:28
 #: src/olympia/editors/templates/editors/themes/queue.html:25
 msgid "Queues"
 msgstr "Очереди"
@@ -10258,71 +7945,51 @@ msgstr "Очереди"
 msgid "Unlisted Queues"
 msgstr "Очереди неотображаемых"
 
-#: src/olympia/editors/templates/editors/base.html:72
-#: src/olympia/editors/templates/editors/performance.html:6
+#: src/olympia/editors/templates/editors/base.html:74 src/olympia/editors/templates/editors/performance.html:6
 msgid "Performance"
 msgstr "Производительность"
 
-#: src/olympia/editors/templates/editors/base.html:75
-#: src/olympia/editors/templates/editors/themes/base.html:19
-#: src/olympia/editors/templates/editors/themes/base.html:38
+#: src/olympia/editors/templates/editors/base.html:77 src/olympia/editors/templates/editors/themes/base.html:19 src/olympia/editors/templates/editors/themes/base.html:38
 msgid "Logs"
 msgstr "Логи"
 
-#: src/olympia/editors/templates/editors/base.html:78
-#: src/olympia/editors/templates/editors/reviewlog.html:4
-#: src/olympia/editors/templates/editors/reviewlog.html:27
+#: src/olympia/editors/templates/editors/base.html:80 src/olympia/editors/templates/editors/reviewlog.html:4 src/olympia/editors/templates/editors/reviewlog.html:27
 msgid "Add-on Review Log"
 msgstr "Журнал проверок дополнений"
 
-#: src/olympia/editors/templates/editors/base.html:80
-#: src/olympia/editors/templates/editors/eventlog.html:4
-#: src/olympia/editors/templates/editors/eventlog.html:8
+#: src/olympia/editors/templates/editors/base.html:82 src/olympia/editors/templates/editors/eventlog.html:4 src/olympia/editors/templates/editors/eventlog.html:8
 #: src/olympia/editors/templates/editors/eventlog_detail.html:4
 msgid "Moderated Review Log"
 msgstr "Журнал модерируемых проверок"
 
-#: src/olympia/editors/templates/editors/base.html:82
-#: src/olympia/editors/templates/editors/beta_signed_log.html:4
-#: src/olympia/editors/templates/editors/beta_signed_log.html:8
+#: src/olympia/editors/templates/editors/base.html:84 src/olympia/editors/templates/editors/beta_signed_log.html:4 src/olympia/editors/templates/editors/beta_signed_log.html:8
 msgid "Signed Beta Files Log"
 msgstr "Лог подписанных файлов беты"
 
-#: src/olympia/editors/templates/editors/base.html:87
-#: src/olympia/editors/templates/editors/includes/daily-message.html:4
+#: src/olympia/editors/templates/editors/base.html:89 src/olympia/editors/templates/editors/includes/daily-message.html:4
 msgid "Announcement"
 msgstr "Объявление"
 
 #. "Filter" is a button label (verb)
-#: src/olympia/editors/templates/editors/beta_signed_log.html:17
-#: src/olympia/editors/templates/editors/eventlog.html:24
-#: src/olympia/editors/templates/editors/reviewlog.html:21
-#: src/olympia/editors/templates/editors/themes/macros.html:45
-#: src/olympia/editors/templates/editors/themes/includes/logs_filter_deleted.html:12
+#: src/olympia/editors/templates/editors/beta_signed_log.html:17 src/olympia/editors/templates/editors/eventlog.html:24 src/olympia/editors/templates/editors/reviewlog.html:21
+#: src/olympia/editors/templates/editors/themes/macros.html:45 src/olympia/editors/templates/editors/themes/includes/logs_filter_deleted.html:12
 msgid "Filter"
 msgstr "Фильтр"
 
-#: src/olympia/editors/templates/editors/beta_signed_log.html:23
-#: src/olympia/editors/templates/editors/eventlog.html:30
-#: src/olympia/editors/templates/editors/reviewlog.html:34
+#: src/olympia/editors/templates/editors/beta_signed_log.html:23 src/olympia/editors/templates/editors/eventlog.html:30 src/olympia/editors/templates/editors/reviewlog.html:34
 #: src/olympia/editors/templates/editors/themes/logs.html:16
 msgid "Date"
 msgstr "Дата"
 
-#: src/olympia/editors/templates/editors/beta_signed_log.html:24
-#: src/olympia/editors/templates/editors/eventlog.html:31
-#: src/olympia/editors/templates/editors/reviewlog.html:35
+#: src/olympia/editors/templates/editors/beta_signed_log.html:24 src/olympia/editors/templates/editors/eventlog.html:31 src/olympia/editors/templates/editors/reviewlog.html:35
 msgid "Event"
 msgstr "Событие"
 
-#: src/olympia/editors/templates/editors/beta_signed_log.html:37
-#: src/olympia/editors/templates/editors/eventlog.html:44
-#: src/olympia/editors/templates/editors/home.html:180
+#: src/olympia/editors/templates/editors/beta_signed_log.html:37 src/olympia/editors/templates/editors/eventlog.html:44 src/olympia/editors/templates/editors/home.html:180
 msgid "More details."
 msgstr "Подробнее."
 
-#: src/olympia/editors/templates/editors/beta_signed_log.html:46
-#: src/olympia/editors/templates/editors/eventlog.html:53
+#: src/olympia/editors/templates/editors/beta_signed_log.html:46 src/olympia/editors/templates/editors/eventlog.html:53
 msgid "No events found for this period."
 msgstr "События за этот период не найдены."
 
@@ -10359,37 +8026,30 @@ msgid "Full Review ({num})"
 msgid_plural "Full Reviews ({num})"
 msgstr[0] "Полная проверка ({num})"
 msgstr[1] "Полные проверки ({num})"
-msgstr[2] "Полные проверки ({num})"
 
 #: src/olympia/editors/templates/editors/home.html:18
 msgid "Pending Update ({num})"
 msgid_plural "Pending Updates ({num})"
 msgstr[0] "Ожидающее обновления ({num})"
 msgstr[1] "Ожидающие обновления ({num})"
-msgstr[2] "Ожидающие обновления ({num})"
 
 #: src/olympia/editors/templates/editors/home.html:25
 msgid "Preliminary Review ({num})"
 msgid_plural "Preliminary Reviews ({num})"
 msgstr[0] "Предварительная проверка ({num})"
 msgstr[1] "Предварительные проверки ({num})"
-msgstr[2] "Предварительные проверки ({num})"
 
-#: src/olympia/editors/templates/editors/home.html:36
-#: src/olympia/editors/templates/editors/home.html:86
+#: src/olympia/editors/templates/editors/home.html:36 src/olympia/editors/templates/editors/home.html:86
 msgid "Current waiting times:"
 msgstr "Текущее время ожидания:"
 
-#: src/olympia/editors/templates/editors/home.html:44
-#: src/olympia/editors/templates/editors/home.html:94
+#: src/olympia/editors/templates/editors/home.html:44 src/olympia/editors/templates/editors/home.html:94
 msgid "{0} add-on"
 msgid_plural "{0} add-ons"
 msgstr[0] "{0} дополнение"
 msgstr[1] "{0} дополнения"
-msgstr[2] "{0} дополнений"
 
-#: src/olympia/editors/templates/editors/home.html:45
-#: src/olympia/editors/templates/editors/home.html:95
+#: src/olympia/editors/templates/editors/home.html:45 src/olympia/editors/templates/editors/home.html:95
 #, python-format
 msgid "{0}%%"
 msgstr "{0}%%"
@@ -10399,30 +8059,24 @@ msgid "Unlisted Full Review ({num})"
 msgid_plural "Unlisted Full Reviews ({num})"
 msgstr[0] "Полная проверка неотображаемых ({num})"
 msgstr[1] "Полные проверки неотображаемых ({num})"
-msgstr[2] "Полные проверки неотображаемых ({num})"
 
 #: src/olympia/editors/templates/editors/home.html:68
 msgid "Unlisted Pending Update ({num})"
 msgid_plural "Unlisted Pending Updates ({num})"
 msgstr[0] "Ожидающее обновления неотображаемое ({num})"
 msgstr[1] "Ожидающие обновления неотображаемые ({num})"
-msgstr[2] "Ожидающие обновления неотображаемые ({num})"
 
 #: src/olympia/editors/templates/editors/home.html:75
 msgid "Unlisted Preliminary Review ({num})"
 msgid_plural "Unlisted Preliminary Reviews ({num})"
 msgstr[0] "Предварительная проверка неотображаемых ({num})"
 msgstr[1] "Предварительные проверки неотображаемых ({num})"
-msgstr[2] "Предварительные проверки неотображаемых ({num})"
 
-#: src/olympia/editors/templates/editors/home.html:109
-#: src/olympia/editors/templates/editors/performance.html:37
-#: src/olympia/editors/templates/editors/themes/home.html:54
+#: src/olympia/editors/templates/editors/home.html:109 src/olympia/editors/templates/editors/performance.html:37 src/olympia/editors/templates/editors/themes/home.html:54
 msgid "Total Reviews"
 msgstr "Всего проверок"
 
-#: src/olympia/editors/templates/editors/home.html:110
-#: src/olympia/editors/templates/editors/themes/home.html:55
+#: src/olympia/editors/templates/editors/home.html:110 src/olympia/editors/templates/editors/themes/home.html:55
 msgid "Reviews This Month"
 msgstr "Проверки за этот месяц"
 
@@ -10430,8 +8084,7 @@ msgstr "Проверки за этот месяц"
 msgid "New Editors"
 msgstr "Новые редакторы"
 
-#: src/olympia/editors/templates/editors/home.html:126
-#: src/olympia/editors/templates/editors/home.html:141
+#: src/olympia/editors/templates/editors/home.html:126 src/olympia/editors/templates/editors/home.html:141
 msgid "You're #{0} with {1} reviews"
 msgstr "Вы #{0} с {1} проверками"
 
@@ -10441,15 +8094,12 @@ msgid "Moderated Review ({num})"
 msgid_plural "Moderated Reviews ({num})"
 msgstr[0] "Модерируемая проверка ({num})"
 msgstr[1] "Модерируемые проверки ({num})"
-msgstr[2] "Модерируемые проверки ({num})"
 
-#: src/olympia/editors/templates/editors/leaderboard.html:3
-#: src/olympia/editors/templates/editors/includes/reviewers_score_bar.html:56
+#: src/olympia/editors/templates/editors/leaderboard.html:3 src/olympia/editors/templates/editors/includes/reviewers_score_bar.html:56
 msgid "Reviewer Leaderboard"
 msgstr "Панель лидера редакторов"
 
-#: src/olympia/editors/templates/editors/leaderboard.html:18
-#: src/olympia/editors/templates/editors/performance.html:65
+#: src/olympia/editors/templates/editors/leaderboard.html:18 src/olympia/editors/templates/editors/performance.html:65
 msgid "No review points awarded yet."
 msgstr "Очков за проверки пока не начислено."
 
@@ -10469,8 +8119,7 @@ msgstr "Сообщение дня"
 msgid "Update message of the day"
 msgstr "Обновить послание дня"
 
-#: src/olympia/editors/templates/editors/motd.html:15
-#: src/olympia/editors/templates/editors/review.html:224
+#: src/olympia/editors/templates/editors/motd.html:15 src/olympia/editors/templates/editors/review.html:224
 msgid "Save"
 msgstr "Сохранить"
 
@@ -10538,51 +8187,45 @@ msgstr "Продвинутый поиск"
 msgid "clear search"
 msgstr "очистить поиск"
 
-#: src/olympia/editors/templates/editors/queue.html:72
-#: src/olympia/editors/templates/editors/queue.html:122
+#: src/olympia/editors/templates/editors/queue.html:78 src/olympia/editors/templates/editors/queue.html:128
 msgid "Process Reviews"
 msgstr "Обработать рецензии"
 
-#: src/olympia/editors/templates/editors/queue.html:80
+#: src/olympia/editors/templates/editors/queue.html:86
 msgid "Moderation actions:"
 msgstr "Действия для модерации:"
 
-#: src/olympia/editors/templates/editors/queue.html:90
+#: src/olympia/editors/templates/editors/queue.html:96
 #, python-format
 msgid "by %(user)s on %(date)s %(stars)s (%(locale)s)"
 msgstr "от %(user)s на %(date)s %(stars)s (%(locale)s)"
 
-#: src/olympia/editors/templates/editors/queue.html:106
+#: src/olympia/editors/templates/editors/queue.html:112
 #, python-format
-msgid ""
-"<strong>%(reason)s</strong> <span class=\"light\">Flagged by %(user)s on "
-"%(date)s</span>"
-msgstr ""
-"<strong>%(reason)s</strong> <span class=\"light\">Отмечено %(user)s  в "
-"%(date)s</span>"
+msgid "<strong>%(reason)s</strong> <span class=\"light\">Flagged by %(user)s on %(date)s</span>"
+msgstr "<strong>%(reason)s</strong> <span class=\"light\">Отмечено %(user)s  в %(date)s</span>"
 
-#: src/olympia/editors/templates/editors/queue.html:119
-msgid "All reviews have been moderated.  Good work!"
+#: src/olympia/editors/templates/editors/queue.html:125
+msgid "All reviews have been moderated. Good work!"
 msgstr "Все отзывы проверены.  Хорошая работа!"
 
-#: src/olympia/editors/templates/editors/queue.html:161
+#: src/olympia/editors/templates/editors/queue.html:167
 msgid "Version Notes / Notes for Reviewer"
 msgstr "Примечания к версии / Замечания для проверяющего"
 
-#: src/olympia/editors/templates/editors/queue.html:169
+#: src/olympia/editors/templates/editors/queue.html:175
 msgid "There are currently no add-ons of this type to review."
 msgstr "В настоящее время нет дополнений данного типа ждущих проверки."
 
-#: src/olympia/editors/templates/editors/queue.html:181
-#: src/olympia/editors/templates/editors/themes/queue_list.html:85
+#: src/olympia/editors/templates/editors/queue.html:187 src/olympia/editors/templates/editors/themes/queue_list.html:85
 msgid "Helpful Links:"
 msgstr "Полезные ссылки:"
 
-#: src/olympia/editors/templates/editors/queue.html:182
+#: src/olympia/editors/templates/editors/queue.html:188
 msgid "Add-on Policy"
 msgstr "Политика дополнений"
 
-#: src/olympia/editors/templates/editors/queue.html:184
+#: src/olympia/editors/templates/editors/queue.html:190
 msgid "Editors' Guide"
 msgstr "Руководство редактора"
 
@@ -10595,19 +8238,14 @@ msgstr "Проверить {0}"
 msgid "Add-on user change history"
 msgstr "История изменений пользователя дополнения"
 
-#: src/olympia/editors/templates/editors/review.html:52
-#: src/olympia/editors/templates/editors/review.html:266
+#: src/olympia/editors/templates/editors/review.html:52 src/olympia/editors/templates/editors/review.html:266
 msgid "Add-on History"
 msgstr "История дополнения"
 
 #: src/olympia/editors/templates/editors/review.html:64
 #, python-format
-msgid ""
-"Version %(version)s &middot; %(created)s <span class=\"light\">&middot; "
-"%(version_status)s</span>"
-msgstr ""
-"Версия %(version)s &middot; %(created)s <span class=\"light\">&middot; "
-"%(version_status)s</span>"
+msgid "Version %(version)s &middot; %(created)s <span class=\"light\">&middot; %(version_status)s</span>"
+msgstr "Версия %(version)s &middot; %(created)s <span class=\"light\">&middot; %(version_status)s</span>"
 
 #: src/olympia/editors/templates/editors/review.html:73
 msgid "Compatibility:"
@@ -10630,19 +8268,14 @@ msgid "This version has not been reviewed."
 msgstr "Эта версия не была проверена."
 
 #: src/olympia/editors/templates/editors/review.html:154
-msgid ""
-"You can still submit this form, however only do so if you know it won't "
-"conflict."
-msgstr ""
-"Вы все ещё можете отправить эту форму, но делайте это, только если вы "
-"уверены, что это не вызовет конфликт."
+msgid "You can still submit this form, however only do so if you know it won't conflict."
+msgstr "Вы все ещё можете отправить эту форму, но делайте это, только если вы уверены, что это не вызовет конфликт."
 
 #: src/olympia/editors/templates/editors/review.html:161
 msgid "Insert canned response..."
 msgstr "Вставить стандартный ответ..."
 
-#: src/olympia/editors/templates/editors/review.html:167
-#: src/olympia/files/templates/files/viewer.html:54
+#: src/olympia/editors/templates/editors/review.html:167 src/olympia/files/templates/files/viewer.html:54
 msgid "Files:"
 msgstr "Файлы:"
 
@@ -10651,28 +8284,18 @@ msgid "Tested on:"
 msgstr "Протестировано на:"
 
 #: src/olympia/editors/templates/editors/review.html:220
-msgid ""
-"<strong>Warning!</strong> Another user was viewing this page before you."
-msgstr ""
-"<strong>Предупреждение!</strong> До вас другой пользователь просматривал эту"
-" страницу."
+msgid "<strong>Warning!</strong> Another user was viewing this page before you."
+msgstr "<strong>Предупреждение!</strong> До вас другой пользователь просматривал эту страницу."
 
 #: src/olympia/editors/templates/editors/review.html:237
-msgid ""
-"The whiteboard is the place to exchange information relevant to this addon "
-"(whatever the version), between the developer and the editor. This is "
-"visible and editable by both."
-msgstr ""
-"Белая доска является местом для обмена информацией, относящейся к этому "
-"дополнению (независимо от версии), между разработчиком и редактором. Она "
-"видима и редактируема ими обоими."
+msgid "The whiteboard is the place to exchange information relevant to this addon (whatever the version), between the developer and the editor. This is visible and editable by both."
+msgstr "Белая доска является местом для обмена информацией, относящейся к этому дополнению (независимо от версии), между разработчиком и редактором. Она видима и редактируема ими обоими."
 
 #: src/olympia/editors/templates/editors/review.html:241
 msgid "Update the whiteboard"
 msgstr "Обновить белую доску"
 
-#: src/olympia/editors/templates/editors/review.html:257
-#: src/olympia/editors/templates/editors/review.html:258
+#: src/olympia/editors/templates/editors/review.html:257 src/olympia/editors/templates/editors/review.html:258
 msgid "(admin)"
 msgstr "(админ)"
 
@@ -10700,18 +8323,15 @@ msgstr "Редактор"
 msgid "Add-on has been deleted."
 msgstr "Дополнение было удалено."
 
-#: src/olympia/editors/templates/editors/reviewlog.html:59
-#: src/olympia/editors/templates/editors/themes/logs.html:36
+#: src/olympia/editors/templates/editors/reviewlog.html:59 src/olympia/editors/templates/editors/themes/logs.html:36
 msgid "Show Comments"
 msgstr "Показать комментарии"
 
-#: src/olympia/editors/templates/editors/reviewlog.html:60
-#: src/olympia/editors/templates/editors/themes/logs.html:37
+#: src/olympia/editors/templates/editors/reviewlog.html:60 src/olympia/editors/templates/editors/themes/logs.html:37
 msgid "Hide Comments"
 msgstr "Скрыть комментарии"
 
-#: src/olympia/editors/templates/editors/reviewlog.html:72
-#: src/olympia/editors/templates/editors/themes/logs.html:54
+#: src/olympia/editors/templates/editors/reviewlog.html:72 src/olympia/editors/templates/editors/themes/logs.html:54
 msgid "No reviews found for this period."
 msgstr "Отзывы за этот период не найдены."
 
@@ -10769,11 +8389,8 @@ msgstr "Всё время"
 msgid "You have <span>{0}</span> points."
 msgstr "У вас <span>{0}</span> очков."
 
-#: src/olympia/editors/templates/editors/includes/search_results_themes.html:6
-#: src/olympia/editors/templates/editors/themes/history_table.html:7
-#: src/olympia/editors/templates/editors/themes/logs.html:19
-#: src/olympia/editors/templates/editors/themes/queue_list.html:49
-#: src/olympia/editors/templates/editors/themes/single.html:26
+#: src/olympia/editors/templates/editors/includes/search_results_themes.html:6 src/olympia/editors/templates/editors/themes/history_table.html:7
+#: src/olympia/editors/templates/editors/themes/logs.html:19 src/olympia/editors/templates/editors/themes/queue_list.html:49 src/olympia/editors/templates/editors/themes/single.html:26
 #: src/olympia/editors/templates/editors/themes/themes.html:45
 msgid "Reviewer"
 msgstr "Редактор"
@@ -10798,8 +8415,7 @@ msgstr "Журнал проверки темы {0}"
 msgid "Review Date"
 msgstr "Дата проверки"
 
-#: src/olympia/editors/templates/editors/themes/history_table.html:9
-#: src/olympia/editors/templates/editors/themes/logs.html:18
+#: src/olympia/editors/templates/editors/themes/history_table.html:9 src/olympia/editors/templates/editors/themes/logs.html:18
 msgid "Action"
 msgstr "Действие"
 
@@ -10816,21 +8432,18 @@ msgid "{num} Pending Theme Review"
 msgid_plural "{num} Pending Theme Reviews"
 msgstr[0] "{num} тема ожидающая проверки"
 msgstr[1] "{num} темы ожидающих проверки"
-msgstr[2] "{num} тем ожидающих проверки"
 
 #: src/olympia/editors/templates/editors/themes/home.html:27
 msgid "{num} Flagged Review"
 msgid_plural "{num} Flagged Reviews"
 msgstr[0] "{num} проверка с флагом"
 msgstr[1] "{num} проверки с флагом"
-msgstr[2] "{num} проверок с флагом"
 
 #: src/olympia/editors/templates/editors/themes/home.html:34
 msgid "{num} Update"
 msgid_plural "{num} Updates"
 msgstr[0] "{num} Обновление"
 msgstr[1] "{num} Обновления"
-msgstr[2] "{num} Обновлений"
 
 #: src/olympia/editors/templates/editors/themes/logs.html:4
 msgid "Theme Review Log"
@@ -10949,7 +8562,7 @@ msgstr "Задайте вопрос художнику"
 msgid "Describe your reason for flagging"
 msgstr "Опишите вашу причину для отметки флагом "
 
-#: src/olympia/files/forms.py:88
+#: src/olympia/files/forms.py:90
 msgid "Cannot diff a version against itself"
 msgstr "Нельзя сделать diff версии против самой себя"
 
@@ -10967,12 +8580,8 @@ msgid "Problems decoding {0}."
 msgstr "Проблемы декодирования {0}."
 
 #: src/olympia/files/helpers.py:186
-msgid ""
-"This file is not viewable online. Please download the file to view the "
-"contents."
-msgstr ""
-"Этот файл невозможно просмотреть в Интернете. Пожалуйста, загрузите файл для"
-" просмотра содержимого."
+msgid "This file is not viewable online. Please download the file to view the contents."
+msgstr "Этот файл невозможно просмотреть в Интернете. Пожалуйста, загрузите файл для просмотра содержимого."
 
 #: src/olympia/files/helpers.py:194
 msgid "This file is a directory."
@@ -10988,55 +8597,51 @@ msgstr "Ошибка при доступе к файлу %s. %s."
 msgid "There was an error accessing file %s."
 msgstr "Ошибка при доступе к файлу %s."
 
-#: src/olympia/files/utils.py:343
+#: src/olympia/files/utils.py:340
 msgid "Could not parse uploaded file."
 msgstr "Не удалось распарсить загруженный файл."
 
-#: src/olympia/files/utils.py:380
+#: src/olympia/files/utils.py:377
 msgid "Invalid file name in archive: {0}"
 msgstr "Недопустимое имя файла в архиве: {0}"
 
-#: src/olympia/files/utils.py:388
+#: src/olympia/files/utils.py:385
 msgid "File exceeding size limit in archive: {0}"
 msgstr "Размер файла в архиве превышает лимит: {0}"
 
-#: src/olympia/files/utils.py:439
+#: src/olympia/files/utils.py:436
 msgid "Invalid archive."
 msgstr "Некорректный архив."
 
-#: src/olympia/files/utils.py:529 src/olympia/files/utils.py:532
+#: src/olympia/files/utils.py:526 src/olympia/files/utils.py:529
 msgid "Could not parse the manifest file."
 msgstr "Не удалось распарсить файл манифеста."
 
-#: src/olympia/files/utils.py:551
+#: src/olympia/files/utils.py:548
 msgid "Could not find an add-on ID."
 msgstr "Не удалось найти ID дополнения."
 
-#: src/olympia/files/utils.py:554
+#: src/olympia/files/utils.py:551
 msgid "Add-on ID must be 64 characters or less."
 msgstr "Длина ID дополнения не должна превышать 64 символа."
 
-#: src/olympia/files/utils.py:556
+#: src/olympia/files/utils.py:553
 msgid "Add-on ID doesn't match add-on."
 msgstr "ID дополнения не соответствует дополнению."
 
-#: src/olympia/files/utils.py:564
+#: src/olympia/files/utils.py:561
 msgid "Duplicate add-on ID found."
 msgstr "Найден дублирующийся ID дополнения."
 
-#: src/olympia/files/utils.py:567
+#: src/olympia/files/utils.py:564
 msgid "Version numbers should have fewer than 32 characters."
 msgstr "Номера версий должны иметь менее 32-х символов."
 
-#: src/olympia/files/utils.py:570
-msgid ""
-"Version numbers should only contain letters, numbers, and these punctuation "
-"characters: +*.-_."
-msgstr ""
-"Номера версий могут состоять только из букв, цифр и следующих знаков "
-"препинания: +*.-_."
+#: src/olympia/files/utils.py:567
+msgid "Version numbers should only contain letters, numbers, and these punctuation characters: +*.-_."
+msgstr "Номера версий могут состоять только из букв, цифр и следующих знаков препинания: +*.-_."
 
-#: src/olympia/files/utils.py:587
+#: src/olympia/files/utils.py:584
 msgid "<em:type> doesn't match add-on"
 msgstr "<em:type> не соответствует дополнению"
 
@@ -11054,12 +8659,8 @@ msgstr "Загрузить {0}"
 
 #: src/olympia/files/templates/files/file.html:4
 #, python-format
-msgid ""
-"Version: %(version)s &bull; Size: %(size)s &bull; MD5 hash: %(md5)s &bull; "
-"Mimetype: %(mimetype)s"
-msgstr ""
-"Версия: %(version)s &bull; Размер: %(size)s &bull; Хэш MD5: %(md5)s &bull; "
-"Тип MIME: %(mimetype)s"
+msgid "Version: %(version)s &bull; Size: %(size)s &bull; MD5 hash: %(md5)s &bull; Mimetype: %(mimetype)s"
+msgstr "Версия: %(version)s &bull; Размер: %(size)s &bull; Хэш MD5: %(md5)s &bull; Тип MIME: %(mimetype)s"
 
 #: src/olympia/files/templates/files/viewer.html:4
 msgid "File Compare :: Editor tools"
@@ -11097,48 +8698,39 @@ msgstr "Версия Add-on SDK:"
 msgid "Tab stops:"
 msgstr "Позиции табуляции:"
 
-#: src/olympia/files/templates/files/viewer.html:79
-#: src/olympia/files/templates/files/viewer.html:80
+#: src/olympia/files/templates/files/viewer.html:79 src/olympia/files/templates/files/viewer.html:80
 msgid "Up file"
 msgstr "Файл выше"
 
-#: src/olympia/files/templates/files/viewer.html:84
-#: src/olympia/files/templates/files/viewer.html:85
+#: src/olympia/files/templates/files/viewer.html:84 src/olympia/files/templates/files/viewer.html:85
 msgid "Down file"
 msgstr "Файл ниже"
 
-#: src/olympia/files/templates/files/viewer.html:90
-#: src/olympia/files/templates/files/viewer.html:91
+#: src/olympia/files/templates/files/viewer.html:90 src/olympia/files/templates/files/viewer.html:91
 msgid "Previous diff"
 msgstr "Предыдущее изменение"
 
-#: src/olympia/files/templates/files/viewer.html:93
-#: src/olympia/files/templates/files/viewer.html:94
+#: src/olympia/files/templates/files/viewer.html:93 src/olympia/files/templates/files/viewer.html:94
 msgid "Previous note"
 msgstr "Предыдущее примечание"
 
-#: src/olympia/files/templates/files/viewer.html:100
-#: src/olympia/files/templates/files/viewer.html:101
+#: src/olympia/files/templates/files/viewer.html:100 src/olympia/files/templates/files/viewer.html:101
 msgid "Next diff"
 msgstr "Следующее изменение"
 
-#: src/olympia/files/templates/files/viewer.html:103
-#: src/olympia/files/templates/files/viewer.html:104
+#: src/olympia/files/templates/files/viewer.html:103 src/olympia/files/templates/files/viewer.html:104
 msgid "Next note"
 msgstr "Следующее примечание"
 
-#: src/olympia/files/templates/files/viewer.html:109
-#: src/olympia/files/templates/files/viewer.html:110
+#: src/olympia/files/templates/files/viewer.html:109 src/olympia/files/templates/files/viewer.html:110
 msgid "Expand all"
 msgstr "Развернуть всё"
 
-#: src/olympia/files/templates/files/viewer.html:114
-#: src/olympia/files/templates/files/viewer.html:115
+#: src/olympia/files/templates/files/viewer.html:114 src/olympia/files/templates/files/viewer.html:115
 msgid "Hide or unhide tree"
 msgstr "Скрыть или показать дерево"
 
-#: src/olympia/files/templates/files/viewer.html:119
-#: src/olympia/files/templates/files/viewer.html:120
+#: src/olympia/files/templates/files/viewer.html:119 src/olympia/files/templates/files/viewer.html:120
 msgid "Wrap or unwrap text"
 msgstr "Завернуть или развернуть текст"
 
@@ -11149,6 +8741,10 @@ msgstr "В загруженном файле нет файлов."
 #: src/olympia/files/templates/files/viewer.html:134
 msgid "Fetching file."
 msgstr "Получение файла."
+
+#: src/olympia/legacy_api/views.py:255
+msgid "Not implemented yet."
+msgstr "Пока не реализовано."
 
 #: src/olympia/lib/constants.py:6
 msgid "United Arab Emirates Dirham"
@@ -11806,12 +9402,7 @@ msgstr "Замбийская квача"
 msgid "Zimbabwe Dollar"
 msgstr "Доллар Зимбабве"
 
-#: src/olympia/lib/video/ffmpeg.py:112 src/olympia/lib/video/totem.py:81
-msgid "Videos must be in WebM."
-msgstr "Видео должно быть в формате WebM."
-
-#: src/olympia/pages/templates/pages/about.lhtml:3
-#: src/olympia/pages/templates/pages/about.lhtml:10
+#: src/olympia/pages/templates/pages/about.lhtml:3 src/olympia/pages/templates/pages/about.lhtml:10
 msgid "About Mozilla Add-ons"
 msgstr "О дополнениях Mozilla"
 
@@ -11821,17 +9412,11 @@ msgstr "Что это за веб-сайт?"
 
 #: src/olympia/pages/templates/pages/about.lhtml:13
 msgid ""
-"addons.mozilla.org, commonly known as \"AMO\", is Mozilla's official site "
-"for add-ons to Mozilla software, such as Firefox, Thunderbird, and "
-"SeaMonkey. Add-ons let you add new features and change the way your browser "
-"or application works.  Take a look around and explore the thousands of ways "
-"to customize the way you do things online."
+"addons.mozilla.org, commonly known as \"AMO\", is Mozilla's official site for add-ons to Mozilla software, such as Firefox, Thunderbird, and SeaMonkey. Add-ons let you add new features and change "
+"the way your browser or application works. Take a look around and explore the thousands of ways to customize the way you do things online."
 msgstr ""
-"addons.mozilla.org, широко известный как \"AMO\" является официальным сайтом"
-" Mozilla для дополнений ПО Mozilla, такого как Firefox, Thunderbird и "
-"SeaMonkey. Дополнения позволяют добавить новые возможности и улучшить работу"
-" вашего браузера.  Оглянитесь вокруг и исследуйте тысячи способов настроить "
-"то, как вы работаете в Интернете."
+"addons.mozilla.org, широко известный как \"AMO\" является официальным сайтом Mozilla для дополнений ПО Mozilla, такого как Firefox, Thunderbird и SeaMonkey. Дополнения позволяют добавить новые "
+"возможности и улучшить работу вашего браузера.  Оглянитесь вокруг и исследуйте тысячи способов настроить то, как вы работаете в Интернете."
 
 #: src/olympia/pages/templates/pages/about.lhtml:19
 msgid "Who creates these add-ons?"
@@ -11839,111 +9424,70 @@ msgstr "Кто создает эти дополнения?"
 
 #: src/olympia/pages/templates/pages/about.lhtml:20
 msgid ""
-"The add-ons listed here have been created by thousands of developers from "
-"our community, ranging from individual hobbyists to large corporations. All "
-"publicly listed add-ons are reviewed by a team of editors before being "
-"released. Add-ons marked as Experimental have not been reviewed and should "
-"only be installed with caution."
+"The add-ons listed here have been created by thousands of developers from our community, ranging from individual hobbyists to large corporations. All publicly listed add-ons are reviewed by a team "
+"of editors before being released. Add-ons marked as Experimental have not been reviewed and should only be installed with caution."
 msgstr ""
-"Расположенные здесь дополнения были созданы тысячами разработчиков из нашего"
-" сообщества, начиная от отдельных любителей и заканчивая крупными "
-"корпорациями. Все доступные для публики дополнения были проверены командой "
-"редакторов перед их выпуском. Дополнения, помеченные как Экспериментальные, "
-"не были проверены, и при их установке нужно соблюдать осторожность."
+"Расположенные здесь дополнения были созданы тысячами разработчиков из нашего сообщества, начиная от отдельных любителей и заканчивая крупными корпорациями. Все доступные для публики дополнения были "
+"проверены командой редакторов перед их выпуском. Дополнения, помеченные как Экспериментальные, не были проверены, и при их установке нужно соблюдать осторожность."
 
 #: src/olympia/pages/templates/pages/about.lhtml:26
 msgid "How do I keep up with what's happening at AMO?"
 msgstr "Как мне быть в курсе того, что происходит на AMO?"
 
 #: src/olympia/pages/templates/pages/about.lhtml:27
-msgid ""
-"There are several ways to find out the latest news from the world of add-"
-"ons:"
-msgstr ""
-"Есть несколько способов быть в курсе последних новостей из мира дополнений:"
+msgid "There are several ways to find out the latest news from the world of add-ons:"
+msgstr "Есть несколько способов быть в курсе последних новостей из мира дополнений:"
 
 #: src/olympia/pages/templates/pages/about.lhtml:29
 #, python-format
-msgid ""
-"Our <a href=\"%(url)s\">Add-ons Blog</a> is regularly updated with "
-"information for both add-on enthusiasts and developers."
-msgstr ""
-"Наш <a href=\"%(url)s\">блог дополнений</a> регулярно пополняется "
-"информацией как от любителей, так и разработчиков дополнений."
+msgid "Our <a href=\"%(url)s\">Add-ons Blog</a> is regularly updated with information for both add-on enthusiasts and developers."
+msgstr "Наш <a href=\"%(url)s\">блог дополнений</a> регулярно пополняется информацией как от любителей, так и разработчиков дополнений."
 
 #: src/olympia/pages/templates/pages/about.lhtml:32
 #, python-format
-msgid ""
-"We often post news, tips, and tricks to our Twitter account, <a "
-"href=\"%(url)s\">mozamo</a>"
-msgstr ""
-"Мы часто публикуем новости, советы и хитрости в нашей учётной записи в "
-"Твиттере, <a href=\"%(url)s\">mozamo</a>"
+msgid "We often post news, tips, and tricks to our Twitter account, <a href=\"%(url)s\">mozamo</a>"
+msgstr "Мы часто публикуем новости, советы и хитрости в нашей учётной записи в Твиттере, <a href=\"%(url)s\">mozamo</a>"
 
 #: src/olympia/pages/templates/pages/about.lhtml:34
 #, python-format
-msgid ""
-"Our <a href=\"%(url)s\">forums</a> are a good place to interact with the "
-"add-ons community and discuss upcoming changes to AMO."
-msgstr ""
-"Наши <a href=\"%(url)s\">форумы</a> являются хорошим местом для "
-"взаимодействия с сообществом дополнений и обсуждения предстоящих изменений "
-"на AMO."
+msgid "Our <a href=\"%(url)s\">forums</a> are a good place to interact with the add-ons community and discuss upcoming changes to AMO."
+msgstr "Наши <a href=\"%(url)s\">форумы</a> являются хорошим местом для взаимодействия с сообществом дополнений и обсуждения предстоящих изменений на AMO."
 
 #: src/olympia/pages/templates/pages/about.lhtml:39
 msgid "This sounds great! How can I get involved?"
 msgstr "Это звучит здорово! Как я могу принять участие?"
 
 #: src/olympia/pages/templates/pages/about.lhtml:40
-msgid ""
-"There are plenty of ways to get involved. If you're on the technical side:"
+msgid "There are plenty of ways to get involved. If you're on the technical side:"
 msgstr "Есть много способов принять участие. Если вы знакомы с технологиями:"
 
 #: src/olympia/pages/templates/pages/about.lhtml:42
 #, python-format
-msgid ""
-"<a href=\"%(url)s\">Make your own add-on</a>. We provide free hosting and "
-"update services and can help you reach a large audience of users."
-msgstr ""
-"<a href=\"%(url)s\">Создайте своё собственное дополнение</a>. Мы "
-"предоставляем бесплатный хостинг и службу обновлений и может помочь вам "
-"охватить большое число пользователей."
+msgid "<a href=\"%(url)s\">Make your own add-on</a>. We provide free hosting and update services and can help you reach a large audience of users."
+msgstr "<a href=\"%(url)s\">Создайте своё собственное дополнение</a>. Мы предоставляем бесплатный хостинг и службу обновлений и может помочь вам охватить большое число пользователей."
 
 #: src/olympia/pages/templates/pages/about.lhtml:45
 #, python-format
-msgid ""
-"If you have add-on development experience, <a href=\"%(url)s\"> become an "
-"editor</a>! Our editors are add-on fans with a technical background who "
-"review add-ons for code quality and stability."
+msgid "If you have add-on development experience, <a href=\"%(url)s\"> become an editor</a>! Our editors are add-on fans with a technical background who review add-ons for code quality and stability."
 msgstr ""
-"Если у вас есть опыт разработки дополнения, <a href=\"%(url)s\"> станьте "
-"редактором </a>! Наши редакторы - это фанаты дополнений с технической "
-"подготовкой, которые проверяют качество и стабильность кода дополнений."
+"Если у вас есть опыт разработки дополнения, <a href=\"%(url)s\"> станьте редактором </a>! Наши редакторы - это фанаты дополнений с технической подготовкой, которые проверяют качество и стабильность "
+"кода дополнений."
 
 #: src/olympia/pages/templates/pages/about.lhtml:49
 #, python-format
 msgid ""
-"Help improve this website. It's open source, and you can file bugs and "
-"submit patches. <a href=\"%(url)s\"> GitHub</a> contains all of our current "
-"bugs, legacy bugs can still be found in Bugzilla."
+"Help improve this website. It's open source, and you can file bugs and submit patches. <a href=\"%(url)s\"> GitHub</a> contains all of our current bugs, legacy bugs can still be found in Bugzilla."
 msgstr ""
-"Помогите улучшить этот сайт. Его исходный код открыт, и вы можете "
-"регистрировать ошибки и отправлять патчи. <a href=\"%(url)s\"> GitHub</a> "
-"содержит все наши текущие ошибки, старые ошибки еще можно найти в Bugzilla."
+"Помогите улучшить этот сайт. Его исходный код открыт, и вы можете регистрировать ошибки и отправлять патчи. <a href=\"%(url)s\"> GitHub</a> содержит все наши текущие ошибки, старые ошибки еще можно "
+"найти в Bugzilla."
 
 #: src/olympia/pages/templates/pages/about.lhtml:55
-msgid ""
-"If you're interested in add-ons but not quite as technical, there are still "
-"ways to help:"
-msgstr ""
-"Если вы заинтересованы в дополнениях, но не совсем дружите с технологиями, у"
-" вас всё же есть способы помочь:"
+msgid "If you're interested in add-ons but not quite as technical, there are still ways to help:"
+msgstr "Если вы заинтересованы в дополнениях, но не совсем дружите с технологиями, у вас всё же есть способы помочь:"
 
 #: src/olympia/pages/templates/pages/about.lhtml:58
 msgid "Tell your friends! Let people know which add-ons you use."
-msgstr ""
-"Расскажите своим друзьям! Дайте людям знать, какие дополнения вы "
-"используете."
+msgstr "Расскажите своим друзьям! Дайте людям знать, какие дополнения вы используете."
 
 #: src/olympia/pages/templates/pages/about.lhtml:59
 #, python-format
@@ -11951,13 +9495,8 @@ msgid "Participate in our <a href=\"%(url)s\">forums</a>."
 msgstr "Участвуйте в наших <a href=\"%(url)s\">форумах</a>."
 
 #: src/olympia/pages/templates/pages/about.lhtml:61
-msgid ""
-"Review add-ons on the site. Add-on authors are more likely to improve their "
-"add-ons and write new ones when they know people appreciate their work."
-msgstr ""
-"Оставляйте на сайте отзывы на дополнения. Авторы дополнений более склонны "
-"улучшать свои дополнения и писать новые, если они знают, что люди ценят их "
-"работу."
+msgid "Review add-ons on the site. Add-on authors are more likely to improve their add-ons and write new ones when they know people appreciate their work."
+msgstr "Оставляйте на сайте отзывы на дополнения. Авторы дополнений более склонны улучшать свои дополнения и писать новые, если они знают, что люди ценят их работу."
 
 #: src/olympia/pages/templates/pages/about.lhtml:66
 msgid "I have a question"
@@ -11966,23 +9505,16 @@ msgstr "У меня есть вопрос"
 #: src/olympia/pages/templates/pages/about.lhtml:67
 #, python-format
 msgid ""
-"A good place to start is our <a href=\"%(faq_url)s\"><abbr "
-"title=\"Frequently Asked Questions\">FAQ</abbr></a>. If you don't find an "
-"answer there, you can <a href=\"%(forum_url)s\"> ask on our forums</a>."
+"A good place to start is our <a href=\"%(faq_url)s\"><abbr title=\"Frequently Asked Questions\">FAQ</abbr></a>. If you don't find an answer there, you can <a href=\"%(forum_url)s\"> ask on our "
+"forums</a>."
 msgstr ""
-"Для начала загляните в наш <a href=\"%(faq_url)s\"><abbr title=\"Часто "
-"задаваемые вопросы\">FAQ</abbr></a>. Если вы не нашли там ответа, вы можете "
-"<a href=\"%(forum_url)s\">задать вопрос на нашем форуме</a>."
+"Для начала загляните в наш <a href=\"%(faq_url)s\"><abbr title=\"Часто задаваемые вопросы\">FAQ</abbr></a>. Если вы не нашли там ответа, вы можете <a href=\"%(forum_url)s\">задать вопрос на нашем "
+"форуме</a>."
 
 #: src/olympia/pages/templates/pages/about.lhtml:72
 #, python-format
-msgid ""
-"If you really need to contact someone from the Mozilla team, please see our "
-"<a href=\"%(url)s\"> contact information</a> page."
-msgstr ""
-"Если вам действительно нужно связаться с кем-то из команды Mozilla, "
-"пожалуйста, обратитесь к нашей странице с <a href=\"%(url)s\"> контактной "
-"информацией</a>."
+msgid "If you really need to contact someone from the Mozilla team, please see our <a href=\"%(url)s\"> contact information</a> page."
+msgstr "Если вам действительно нужно связаться с кем-то из команды Mozilla, пожалуйста, обратитесь к нашей странице с <a href=\"%(url)s\"> контактной информацией</a>."
 
 #: src/olympia/pages/templates/pages/about.lhtml:76
 msgid "Who works on this website?"
@@ -11991,14 +9523,10 @@ msgstr "Кто работает над этим веб-сайтом?"
 #: src/olympia/pages/templates/pages/about.lhtml:77
 #, python-format
 msgid ""
-"Over the years, many people have contributed to this website, including both"
-" volunteers from the community and a dedicated AMO team. A list of "
-"significant contributors can be found on our <a href=\"%(url)s\"> Site "
-"Credits</a> page."
+"Over the years, many people have contributed to this website, including both volunteers from the community and a dedicated AMO team. A list of significant contributors can be found on our <a href="
+"\"%(url)s\"> Site Credits</a> page."
 msgstr ""
-"На протяжении лет многие люди внесли вклад в этот веб-сайт - как добровольцы"
-" из сообщества, так и отдельная команда AMO. Список тех, кто внёс "
-"существенный вклад, можно найти на нашей странице <a "
+"На протяжении лет многие люди внесли вклад в этот веб-сайт - как добровольцы из сообщества, так и отдельная команда AMO. Список тех, кто внёс существенный вклад, можно найти на нашей странице <a "
 "href=\"%(url)s\">авторов сайта</a>."
 
 #: src/olympia/pages/templates/pages/acr_firstrun.html:4
@@ -12010,12 +9538,8 @@ msgid "Add-on Compatibility Reporter has been installed"
 msgstr "Был установлен Add-on Compatibility Reporter"
 
 #: src/olympia/pages/templates/pages/acr_firstrun.html:28
-msgid ""
-"It’s easy to help us make sure add-ons are updated in time for the release "
-"of the next version of Firefox."
-msgstr ""
-"Можно легко помочь нам убедиться, что при выпуске следующей версии Firefox "
-"дополнения обновляются в срок."
+msgid "It’s easy to help us make sure add-ons are updated in time for the release of the next version of Firefox."
+msgstr "Можно легко помочь нам убедиться, что при выпуске следующей версии Firefox дополнения обновляются в срок."
 
 #: src/olympia/pages/templates/pages/acr_firstrun.html:35
 msgid "Here’s how to get started reporting add-on compatibility:"
@@ -12023,55 +9547,37 @@ msgstr "Вот как можно начать сообщать о совмест
 
 #: src/olympia/pages/templates/pages/acr_firstrun.html:40
 msgid ""
-"As you start browsing and using your add-ons, take careful note of anything "
-"that seems different from when you last used the extension. This might be a "
-"display glitch, such as a menu item missing, or something more serious, like"
-" the add-on not working at all or showing errors."
+"As you start browsing and using your add-ons, take careful note of anything that seems different from when you last used the extension. This might be a display glitch, such as a menu item missing, "
+"or something more serious, like the add-on not working at all or showing errors."
 msgstr ""
-"При начале веб-серфинга с использованием своих дополнений обращайте внимание"
-" на все отличия, появившиеся с прошлого раза, когды вы использовали это "
-"расширение. Это может быть сбой при отображении, например отсутствие пункта "
-"меню, или что-то более серьезное, как например полный отказ в работе или "
-"работа с ошибками."
+"При начале веб-серфинга с использованием своих дополнений обращайте внимание на все отличия, появившиеся с прошлого раза, когды вы использовали это расширение. Это может быть сбой при отображении, "
+"например отсутствие пункта меню, или что-то более серьезное, как например полный отказ в работе или работа с ошибками."
 
 #: src/olympia/pages/templates/pages/acr_firstrun.html:49
 msgid ""
-"Once you know whether a particular add-on works properly or has problems, "
-"open the Add-ons Manager and click Compatibility next to the add-on to let "
-"Mozilla know what you found in your testing. Submitting a report will help "
-"us tell the add-on developer whether their add-on is working properly in "
-"this version or might need some fixes."
+"Once you know whether a particular add-on works properly or has problems, open the Add-ons Manager and click Compatibility next to the add-on to let Mozilla know what you found in your testing. "
+"Submitting a report will help us tell the add-on developer whether their add-on is working properly in this version or might need some fixes."
 msgstr ""
-"Как только вы убедились, что конкретное дополнение либо корректно работает, "
-"либо имеет проблемы, откройте окно управления дополнениями и нажмите рядом с"
-" дополнением слово Compatibility, чтобы сообщить в Mozilla то, что вы узнали"
-" в процессе тестирования. Отправив сообщение, вы поможете нам сообщить "
-"разработчику дополнений, работает ли его дополнение в этой версии должным "
-"образом или может потребоваться внести несколько исправлений."
+"Как только вы убедились, что конкретное дополнение либо корректно работает, либо имеет проблемы, откройте окно управления дополнениями и нажмите рядом с дополнением слово Compatibility, чтобы "
+"сообщить в Mozilla то, что вы узнали в процессе тестирования. Отправив сообщение, вы поможете нам сообщить разработчику дополнений, работает ли его дополнение в этой версии должным образом или "
+"может потребоваться внести несколько исправлений."
 
 #: src/olympia/pages/templates/pages/acr_firstrun.html:61
 #, python-format
 msgid ""
-"If you upgrade to a new version of Firefox or update your add-ons, your "
-"reports for the old versions will be hidden to allow you to test the new "
-"version. If you have any questions, please ask in <a href=\"%(url)s\">our "
-"forums</a>."
+"If you upgrade to a new version of Firefox or update your add-ons, your reports for the old versions will be hidden to allow you to test the new version. If you have any questions, please ask in <a "
+"href=\"%(url)s\">our forums</a>."
 msgstr ""
-"Если вы обновитесь на новую версию Firefox или обновите свои дополнения, "
-"ваши отчеты для старых версий будет скрыты, чтобы позволить вам "
-"протестировать новую версию. Если у вас есть какие-либо вопросы, пожалуйста,"
-" задайте их на <a href=\"%(url)s\">наших форумах</a>."
+"Если вы обновитесь на новую версию Firefox или обновите свои дополнения, ваши отчеты для старых версий будет скрыты, чтобы позволить вам протестировать новую версию. Если у вас есть какие-либо "
+"вопросы, пожалуйста, задайте их на <a href=\"%(url)s\">наших форумах</a>."
 
 #: src/olympia/pages/templates/pages/acr_firstrun.html:69
 msgid ""
-"Thousands of add-ons are made by our community every year, and your "
-"assistance with compatibility testing helps us make sure these add-ons stay "
-"useful as we strive to provide a great user experience."
+"Thousands of add-ons are made by our community every year, and your assistance with compatibility testing helps us make sure these add-ons stay useful as we strive to provide a great user "
+"experience."
 msgstr ""
-"Наше сообщество создает каждый год тысячи дополнений, и ваша помощь в "
-"тестировании совместимости помогает нам удостовериться, что эти дополнения "
-"будут им полезны, так как мы стремимся обеспечить для пользователей "
-"максмимальный комфорт при работе."
+"Наше сообщество создает каждый год тысячи дополнений, и ваша помощь в тестировании совместимости помогает нам удостовериться, что эти дополнения будут им полезны, так как мы стремимся обеспечить "
+"для пользователей максмимальный комфорт при работе."
 
 #: src/olympia/pages/templates/pages/acr_firstrun.html:75
 msgid "Thank you!"
@@ -12082,12 +9588,8 @@ msgid "Site Credits"
 msgstr "Авторы сайта"
 
 #: src/olympia/pages/templates/pages/credits.html:12
-msgid ""
-"Mozilla would like to thank the following people for their contributions to "
-"the addons.mozilla.org project over the years:"
-msgstr ""
-"Mozilla хотела бы поблагодарить следующих людей за их вклад в проект "
-"addons.mozilla.org на протяжении всех этих лет:"
+msgid "Mozilla would like to thank the following people for their contributions to the addons.mozilla.org project over the years:"
+msgstr "Mozilla хотела бы поблагодарить следующих людей за их вклад в проект addons.mozilla.org на протяжении всех этих лет:"
 
 #: src/olympia/pages/templates/pages/credits.html:18
 msgid "Developers &amp; Administrators"
@@ -12120,90 +9622,63 @@ msgstr "Программы и изображения"
 
 #: src/olympia/pages/templates/pages/credits.html:59
 msgid ""
-"Some icons used are from the <a "
-"href=\"http://www.famfamfam.com/lab/icons/silk/\">famfamfam Silk Icon "
-"Set</a>, licensed under a <a "
-"href=\"http://creativecommons.org/licenses/by/2.5/\">Creative Commons "
-"Attribution 2.5 License</a>."
+"Some icons used are from the <a href=\"http://www.famfamfam.com/lab/icons/silk/\">famfamfam Silk Icon Set</a>, licensed under a <a href=\"http://creativecommons.org/licenses/by/2.5/\">Creative "
+"Commons Attribution 2.5 License</a>."
 msgstr ""
-"Некоторые использованные значки входят в <a "
-"href=\"http://www.famfamfam.com/lab/icons/silk/\">набор иконок famfamfam "
-"Silk</a>, лицензированный на условиях <a "
-"href=\"http://creativecommons.org/licenses/by/2.5/deed.ru\">лицензии "
-"Creative Commons Атрибуция версии 2.5</a>."
+"Некоторые использованные значки входят в <a href=\"http://www.famfamfam.com/lab/icons/silk/\">набор иконок famfamfam Silk</a>, лицензированный на условиях <a href=\"http://creativecommons.org/"
+"licenses/by/2.5/deed.ru\">лицензии Creative Commons Атрибуция версии 2.5</a>."
 
 #: src/olympia/pages/templates/pages/credits.html:60
 msgid ""
-"Some icons used are from the <a href=\"http://www.fatcow.com/free-"
-"icons/\">FatCow Farm-Fresh Web Icons Set</a>, licensed under a <a "
-"href=\"http://creativecommons.org/licenses/by/3.0/us/\">Creative Commons "
-"Attribution 3.0 License</a>."
+"Some icons used are from the <a href=\"http://www.fatcow.com/free-icons/\">FatCow Farm-Fresh Web Icons Set</a>, licensed under a <a href=\"http://creativecommons.org/licenses/by/3.0/us/\">Creative "
+"Commons Attribution 3.0 License</a>."
 msgstr ""
-"Некоторые использованные значки входят в <a href=\"http://www.fatcow.com"
-"/free-icons/\">набор веб-значков FatCow Farm-Fresh</a>, лицензированный на "
-"условиях <a "
-"href=\"http://creativecommons.org/licenses/by/3.0/us/deed.ru\">лицензии "
-"Creative Commons Атрибуция версии 3.0</a>."
+"Некоторые использованные значки входят в <a href=\"http://www.fatcow.com/free-icons/\">набор веб-значков FatCow Farm-Fresh</a>, лицензированный на условиях <a href=\"http://creativecommons.org/"
+"licenses/by/3.0/us/deed.ru\">лицензии Creative Commons Атрибуция версии 3.0</a>."
 
 #: src/olympia/pages/templates/pages/credits.html:61
 msgid ""
-"Some pages use elements of <a "
-"href=\"http://shop.highsoft.com/highcharts.html\">Highcharts</a> (non-"
-"commercial), licensed under a <a href=\"http://creativecommons.org/licenses"
-"/by-nc/3.0/\">Creative Commons Attribution-NonCommercial 3.0 License</a>."
+"Some pages use elements of <a href=\"http://shop.highsoft.com/highcharts.html\">Highcharts</a> (non-commercial), licensed under a <a href=\"http://creativecommons.org/licenses/by-nc/3.0/\">Creative "
+"Commons Attribution-NonCommercial 3.0 License</a>."
 msgstr ""
-"Некоторые страницы используют элементы из <a "
-"href=\"http://shop.highsoft.com/highcharts.html\">Highcharts</a> "
-"(некоммерческая), лицензированной на условиях <a "
-"href=\"http://creativecommons.org/licenses/by-nc/3.0/deed.ru\">лицензии "
-"Creative Commons Атрибуция-Некоммерческое использование версии 3.0</a>."
+"Некоторые страницы используют элементы из <a href=\"http://shop.highsoft.com/highcharts.html\">Highcharts</a> (некоммерческая), лицензированной на условиях <a href=\"http://creativecommons.org/"
+"licenses/by-nc/3.0/deed.ru\">лицензии Creative Commons Атрибуция-Некоммерческое использование версии 3.0</a>."
 
 #: src/olympia/pages/templates/pages/credits.html:65
 #, python-format
-msgid ""
-"For information on contributing, please see our <a href=\"%(url)s\">wiki "
-"page</a>."
-msgstr ""
-"Для получения информации об участии, прочтите нашу <a "
-"href=\"%(url)s\">страницу в вики</a>."
+msgid "For information on contributing, please see our <a href=\"%(url)s\">wiki page</a>."
+msgstr "Для получения информации об участии, прочтите нашу <a href=\"%(url)s\">страницу в вики</a>."
 
 #: src/olympia/pages/templates/pages/dev_faq.html:4
 msgid "Developer FAQ"
 msgstr "FAQ разработчика"
 
-#: src/olympia/pages/templates/pages/dev_faq.html:31
-#: src/olympia/pages/templates/pages/review_guide.html:33
+#: src/olympia/pages/templates/pages/dev_faq.html:31 src/olympia/pages/templates/pages/review_guide.html:33
 msgid "Sections"
 msgstr "Секции"
 
-#: src/olympia/pages/templates/pages/dev_faq.html:33
-#: src/olympia/pages/templates/pages/dev_faq.html:45
+#: src/olympia/pages/templates/pages/dev_faq.html:33 src/olympia/pages/templates/pages/dev_faq.html:45
 msgid "Developing an Add-on"
 msgstr "Разработка дополнения"
 
 #. Heading for a list of resources for developers
-#: src/olympia/pages/templates/pages/dev_faq.html:34
-#: src/olympia/pages/templates/pages/dev_faq.html:208
+#: src/olympia/pages/templates/pages/dev_faq.html:34 src/olympia/pages/templates/pages/dev_faq.html:208
 msgid "Support Resources"
 msgstr "Ресурсы поддержки"
 
-#: src/olympia/pages/templates/pages/dev_faq.html:35
-#: src/olympia/pages/templates/pages/dev_faq.html:261
+#: src/olympia/pages/templates/pages/dev_faq.html:35 src/olympia/pages/templates/pages/dev_faq.html:261
 msgid "Contributing your Add-on"
 msgstr "Внесение вашего дополнения"
 
-#: src/olympia/pages/templates/pages/dev_faq.html:36
-#: src/olympia/pages/templates/pages/dev_faq.html:381
+#: src/olympia/pages/templates/pages/dev_faq.html:36 src/olympia/pages/templates/pages/dev_faq.html:381
 msgid "Add-on Review Process"
 msgstr "Процесс проверки дополнений"
 
-#: src/olympia/pages/templates/pages/dev_faq.html:37
-#: src/olympia/pages/templates/pages/dev_faq.html:444
+#: src/olympia/pages/templates/pages/dev_faq.html:37 src/olympia/pages/templates/pages/dev_faq.html:444
 msgid "Managing Your Add-on"
 msgstr "Управление вашим дополнением"
 
-#: src/olympia/pages/templates/pages/dev_faq.html:39
-#: src/olympia/pages/templates/pages/dev_faq.html:528
+#: src/olympia/pages/templates/pages/dev_faq.html:39 src/olympia/pages/templates/pages/dev_faq.html:528
 msgid "References for Open Source Licenses"
 msgstr "Ссылки на лицензии для Открытого Исходного Кода"
 
@@ -12213,14 +9688,8 @@ msgstr "FAQ разработчика дополнений "
 
 #: src/olympia/pages/templates/pages/dev_faq.html:47
 #, python-format
-msgid ""
-"<h3>How do I build an Add-on?</h3> <p> Mozilla provides documentation on how"
-" to build an add-on via the <a href=\"%(url)s\">Mozilla Developer "
-"Network</a>. </p>"
-msgstr ""
-"<h3> Как мне создать дополнение?</h3> <p> Mozilla предоставляет документацию"
-" по тому, как создать дополнение, через <a href=\"%(url)s\">Сеть разработки "
-"Mozilla</a>. </p>"
+msgid "<h3>How do I build an Add-on?</h3> <p> Mozilla provides documentation on how to build an add-on via the <a href=\"%(url)s\">Mozilla Developer Network</a>. </p>"
+msgstr "<h3> Как мне создать дополнение?</h3> <p> Mozilla предоставляет документацию по тому, как создать дополнение, через <a href=\"%(url)s\">Сеть разработки Mozilla</a>. </p>"
 
 #: src/olympia/pages/templates/pages/dev_faq.html:55
 msgid "Other resources include:"
@@ -12240,13 +9709,11 @@ msgstr "Что мне понадобится для создания допол�
 
 #: src/olympia/pages/templates/pages/dev_faq.html:68
 msgid ""
-"You will need to have a version of the Mozilla software that you're building"
-" the add-on for and a code editor of your choice. Add-ons can be built for "
-"almost all Mozilla software but are primarily targeted for:"
+"You will need to have a version of the Mozilla software that you're building the add-on for and a code editor of your choice. Add-ons can be built for almost all Mozilla software but are primarily "
+"targeted for:"
 msgstr ""
-"Вам будет нужно иметь версию программы Mozilla, для которого вы создаете "
-"дополнение, и редактор кода по вашему выбору. Дополнения могут быть созданы "
-"почти для всех программ Mozilla, но в основном предназначены для:"
+"Вам будет нужно иметь версию программы Mozilla, для которого вы создаете дополнение, и редактор кода по вашему выбору. Дополнения могут быть созданы почти для всех программ Mozilla, но в основном "
+"предназначены для:"
 
 #: src/olympia/pages/templates/pages/dev_faq.html:82
 msgid "Popular code editors include:"
@@ -12255,37 +9722,24 @@ msgstr "Популярные редакторы кода:"
 #. This is a list of popular code editors.  Feel free to adjust as you like.
 #: src/olympia/pages/templates/pages/dev_faq.html:85
 msgid ""
-"<li><a href=\"http://komodoide.com/komodo-edit/\">Komodo Edit</a></li> "
-"<li><a href=\"http://macromates.com/\">TextMate</a></li> <li><a href=\"http"
-"://notepad-plus-plus.org/\">Notepad++</a></li> <li><a "
-"href=\"http://www.eclipse.org/\">Eclipse IDE</a></li>"
+"<li><a href=\"http://komodoide.com/komodo-edit/\">Komodo Edit</a></li> <li><a href=\"http://macromates.com/\">TextMate</a></li> <li><a href=\"http://notepad-plus-plus.org/\">Notepad++</a></li> "
+"<li><a href=\"http://www.eclipse.org/\">Eclipse IDE</a></li>"
 msgstr ""
-"<li><a href=\"http://komodoide.com/komodo-edit/\">Komodo Edit</a></li> "
-"<li><a href=\"http://macromates.com/\">TextMate</a></li> <li><a href=\"http"
-"://notepad-plus-plus.org/\">Notepad++</a></li> <li><a "
-"href=\"http://www.eclipse.org/\">Eclipse IDE</a></li>"
+"<li><a href=\"http://komodoide.com/komodo-edit/\">Komodo Edit</a></li> <li><a href=\"http://macromates.com/\">TextMate</a></li> <li><a href=\"http://notepad-plus-plus.org/\">Notepad++</a></li> "
+"<li><a href=\"http://www.eclipse.org/\">Eclipse IDE</a></li>"
 
 #: src/olympia/pages/templates/pages/dev_faq.html:94
 #, python-format
-msgid ""
-"You can also learn more about setting up your development environment via "
-"the MDN article <a href=\"%(url)s\">Setting up extension development "
-"environment</a>"
-msgstr ""
-"Вы можете также узнать больше о настройке среды разработки, прочитав статью "
-"в MDN <a href=\"%(url)s\">Настройка среды разработки расширений</a>"
+msgid "You can also learn more about setting up your development environment via the MDN article <a href=\"%(url)s\">Setting up extension development environment</a>"
+msgstr "Вы можете также узнать больше о настройке среды разработки, прочитав статью в MDN <a href=\"%(url)s\">Настройка среды разработки расширений</a>"
 
 #: src/olympia/pages/templates/pages/dev_faq.html:100
 msgid "What is a \".xpi\" file?"
 msgstr "Что такое файл \".xpi\"?"
 
 #: src/olympia/pages/templates/pages/dev_faq.html:102
-msgid ""
-"Extensions are packaged and distributed in ZIP files or Bundles, with the "
-"XPI (pronounced \"zippy\") file extension."
-msgstr ""
-"Расширения упаковываются и распространяются в ZIP-файлах или пакетах, с "
-"файловым расширением XPI (произносится как «зиппи»)."
+msgid "Extensions are packaged and distributed in ZIP files or Bundles, with the XPI (pronounced \"zippy\") file extension."
+msgstr "Расширения упаковываются и распространяются в ZIP-файлах или пакетах, с файловым расширением XPI (произносится как «зиппи»)."
 
 #: src/olympia/pages/templates/pages/dev_faq.html:108
 msgid "What is XUL?"
@@ -12293,17 +9747,12 @@ msgstr "Что такое XUL?"
 
 #: src/olympia/pages/templates/pages/dev_faq.html:110
 msgid ""
-"XUL (XML User Interface Language) is Mozilla's XML-based language that lets "
-"you build feature-rich cross platform applications. It provides user "
-"interface widgets like buttons, menus, toolbars, trees, etc that can be used"
-" to enhance add-ons by modifying parts of the browser UI."
+"XUL (XML User Interface Language) is Mozilla's XML-based language that lets you build feature-rich cross platform applications. It provides user interface widgets like buttons, menus, toolbars, "
+"trees, etc that can be used to enhance add-ons by modifying parts of the browser UI."
 msgstr ""
-"XUL (XML-язык интерфейса пользователя) это язык на основе Mozilla XML, "
-"который позволяет вам создавать кроссплатформенные приложения с расширенной "
-"функциональностью. Он обеспечивает виджеты интерфейса пользователя, такие "
-"как кнопки, меню, панели инструментов, деревья, и т.д., которые могут "
-"использоваться для расширения возможностей дополнений путем изменения частей"
-" интерфейса пользователя браузера."
+"XUL (XML-язык интерфейса пользователя) это язык на основе Mozilla XML, который позволяет вам создавать кроссплатформенные приложения с расширенной функциональностью. Он обеспечивает виджеты "
+"интерфейса пользователя, такие как кнопки, меню, панели инструментов, деревья, и т.д., которые могут использоваться для расширения возможностей дополнений путем изменения частей интерфейса "
+"пользователя браузера."
 
 #: src/olympia/pages/templates/pages/dev_faq.html:119
 msgid "What is the \"install.rdf\" file used for?"
@@ -12312,35 +9761,21 @@ msgstr "Для чего используется файл \"install.rdf\"?"
 #: src/olympia/pages/templates/pages/dev_faq.html:121
 #, python-format
 msgid ""
-"This file, called an <a href=\"%(url)s\">Install Manifest</a>, is used by "
-"Add-on Manager-enabled XUL applications to determine information about an "
-"add-on as it is being installed. It contains metadata identifying the add-"
-"on, providing information about who created it, where more information can "
-"be found about it, which versions of what applications it is compatible "
-"with, how it should be updated, and so on. The format of the Install "
-"Manifest is RDF/XML."
+"This file, called an <a href=\"%(url)s\">Install Manifest</a>, is used by Add-on Manager-enabled XUL applications to determine information about an add-on as it is being installed. It contains "
+"metadata identifying the add-on, providing information about who created it, where more information can be found about it, which versions of what applications it is compatible with, how it should "
+"be updated, and so on. The format of the Install Manifest is RDF/XML."
 msgstr ""
-"Этот файл, называемый <a href=\"%(url)s\">Манифестом установки</a>, "
-"используется приложениями XUL, включающими в себя Менеджер дополнений, для "
-"получения информации о дополнении в процессе его установки. Он содержит "
-"метаданные, идентифицирующие дополнение, предоставляющие информацию о его "
-"авторе, о том, где можно найти о нем больше информации, с какими версиями "
-"приложений оно совместимо, как его следует обновлять, и так далее. Форматом "
-"файла манифеста установки является RDF/XML."
+"Этот файл, называемый <a href=\"%(url)s\">Манифестом установки</a>, используется приложениями XUL, включающими в себя Менеджер дополнений, для получения информации о дополнении в процессе его "
+"установки. Он содержит метаданные, идентифицирующие дополнение, предоставляющие информацию о его авторе, о том, где можно найти о нем больше информации, с какими версиями приложений оно совместимо, "
+"как его следует обновлять, и так далее. Форматом файла манифеста установки является RDF/XML."
 
 #: src/olympia/pages/templates/pages/dev_faq.html:132
 msgid "What does \"maxVersion\" mean?"
 msgstr "Что значит \"maxVersion\"?"
 
 #: src/olympia/pages/templates/pages/dev_faq.html:134
-msgid ""
-"This determines the maximum version of Firefox you're saying this extension "
-"will work with. Set this to be no newer than the newest currently available "
-"version!"
-msgstr ""
-"Это определяет максимальную версию Firefox, с которой, как вы говорите, "
-"будет работать это расширение. Установите её в значение не выше, чем номер "
-"новейшей текущей версии!"
+msgid "This determines the maximum version of Firefox you're saying this extension will work with. Set this to be no newer than the newest currently available version!"
+msgstr "Это определяет максимальную версию Firefox, с которой, как вы говорите, будет работать это расширение. Установите её в значение не выше, чем номер новейшей текущей версии!"
 
 #: src/olympia/pages/templates/pages/dev_faq.html:141
 msgid "Can my add-on contain binary components?"
@@ -12349,42 +9784,25 @@ msgstr "Может ли мое дополнение содержать бина�
 #: src/olympia/pages/templates/pages/dev_faq.html:143
 #, python-format
 msgid ""
-"Yes. You can use Mozilla's <a href=\"%(url)s\">XPCOM component object "
-"model</a> to enhance your add-ons. XPCOM components be used and implemented "
-"in JavaScript, Java, and Python in addition to C++."
+"Yes. You can use Mozilla's <a href=\"%(url)s\">XPCOM component object model</a> to enhance your add-ons. XPCOM components be used and implemented in JavaScript, Java, and Python in addition to C++."
 msgstr ""
-"Да. Вы можете использовать <a href=\"%(url)s\">объектную модель компонент "
-"XPCOM</a> Mozilla для повышения мощи ваших дополнений. Помимо C++, XPCOM "
-"компоненты используются и разрабатываются на JavaScript, Java и Python."
+"Да. Вы можете использовать <a href=\"%(url)s\">объектную модель компонент XPCOM</a> Mozilla для повышения мощи ваших дополнений. Помимо C++, XPCOM компоненты используются и разрабатываются на "
+"JavaScript, Java и Python."
 
 #: src/olympia/pages/templates/pages/dev_faq.html:150
-msgid ""
-"Can I use a JavaScript library like jQuery, MooTools or Prototype to build "
-"my add-on?"
-msgstr ""
-"Могу ли я использовать для создания моего дополнения использовать библиотеки"
-" JavaScript, такие как jQuery, MooTools или Prototype?"
+msgid "Can I use a JavaScript library like jQuery, MooTools or Prototype to build my add-on?"
+msgstr "Могу ли я использовать для создания моего дополнения использовать библиотеки JavaScript, такие как jQuery, MooTools или Prototype?"
 
 #: src/olympia/pages/templates/pages/dev_faq.html:152
 msgid ""
-"Yes. It's possible, but some of the functionality provided by these "
-"libraries are available through XPCOM, XUL, and JavaScript. In addition, "
-"authors should take care if libraries modify primitive object prototypes "
-"(String.prototype, Date.prototype, etc.) and/or define global functions (eg."
-" the $ function). These are prone to cause conflict with other add-ons, in "
-"particular if different add-ons use different versions of libraries and so "
-"on. Developers need to be very, very careful with using them. Mozilla does "
-"not offer documentation on using them to build add-ons."
+"Yes. It's possible, but some of the functionality provided by these libraries are available through XPCOM, XUL, and JavaScript. In addition, authors should take care if libraries modify primitive "
+"object prototypes (String.prototype, Date.prototype, etc.) and/or define global functions (eg. the $ function). These are prone to cause conflict with other add-ons, in particular if different add-"
+"ons use different versions of libraries and so on. Developers need to be very, very careful with using them. Mozilla does not offer documentation on using them to build add-ons."
 msgstr ""
-"Да. Это возможно, но некоторые из функций, обеспечиваемых этими "
-"библиотеками, доступны через XPCOM, XUL и JavaScript. Кроме того, авторы "
-"должны быть осторожны в случае, если библиотеки изменяют прототипы "
-"примитивных объектов (String.prototype, Date.prototype и т.д.) и/или "
-"определяют глобальные функции (напр. $ функцию). Подобное поведение склонно "
-"вызывать конфликт с другими дополнениями, особенно если различные дополнения"
-" используют разные версии библиотек и так далее. Разработчики должны быть "
-"очень, очень осторожны при их использовании. Mozilla не предоставляет "
-"документацию по их использованию для создания дополнений."
+"Да. Это возможно, но некоторые из функций, обеспечиваемых этими библиотеками, доступны через XPCOM, XUL и JavaScript. Кроме того, авторы должны быть осторожны в случае, если библиотеки изменяют "
+"прототипы примитивных объектов (String.prototype, Date.prototype и т.д.) и/или определяют глобальные функции (напр. $ функцию). Подобное поведение склонно вызывать конфликт с другими дополнениями, "
+"особенно если различные дополнения используют разные версии библиотек и так далее. Разработчики должны быть очень, очень осторожны при их использовании. Mozilla не предоставляет документацию по их "
+"использованию для создания дополнений."
 
 #: src/olympia/pages/templates/pages/dev_faq.html:165
 msgid "How do I debug my add-on?"
@@ -12396,32 +9814,19 @@ msgid "You can use the <a href=\"%(url)s\">Add-on Debugger</a>."
 msgstr "Вы можете использовать <a href=\"%(url)s\">Отладчик дополнений</a>."
 
 #: src/olympia/pages/templates/pages/dev_faq.html:172
-msgid ""
-"How do I test for compatibility with the latest version of Mozilla software?"
-msgstr ""
-"Как мне произвести тестирование на совместимость с новейшей версией "
-"программы Mozilla?"
+msgid "How do I test for compatibility with the latest version of Mozilla software?"
+msgstr "Как мне произвести тестирование на совместимость с новейшей версией программы Mozilla?"
 
 #: src/olympia/pages/templates/pages/dev_faq.html:174
 msgid ""
-"To ensure compatibility with the latest Mozilla software, it's important to "
-"download updates as they become available and test your add-on to ensure "
-"that it is still functioning as expected. In many cases, the latest version "
-"of Mozilla software may be a beta release. Since these releases at times "
-"introduce architectural changes that may impact the functionality of your "
-"add-on, it's important to be actively involved in the beta process to ensure"
-" that your add-on users are not negatively impacted upon final release of "
-"Mozilla software."
+"To ensure compatibility with the latest Mozilla software, it's important to download updates as they become available and test your add-on to ensure that it is still functioning as expected. In "
+"many cases, the latest version of Mozilla software may be a beta release. Since these releases at times introduce architectural changes that may impact the functionality of your add-on, it's "
+"important to be actively involved in the beta process to ensure that your add-on users are not negatively impacted upon final release of Mozilla software."
 msgstr ""
-"Для обеспечения совместимости с новейшими программами Mozilla важно "
-"загружать обновления, как только они станут доступны, и проводит "
-"тестирование своего дополнения, чтобы убедиться, что оно по-прежнему "
-"работает так, как ожидалось. Во многих случаях, последняя версия программы "
-"Mozilla может быть бета-версией. Так как порой в этих релизах появляются "
-"архитектурные изменения, которые могут повлиять на функциональность вашего "
-"дополнения, важно принимать активное участие в процессе работы над бета-"
-"версией, чтобы убедиться, что пользователи вашего дополнения не пострадают "
-"при выходе финального релиза программы Mozilla."
+"Для обеспечения совместимости с новейшими программами Mozilla важно загружать обновления, как только они станут доступны, и проводит тестирование своего дополнения, чтобы убедиться, что оно по-"
+"прежнему работает так, как ожидалось. Во многих случаях, последняя версия программы Mozilla может быть бета-версией. Так как порой в этих релизах появляются архитектурные изменения, которые могут "
+"повлиять на функциональность вашего дополнения, важно принимать активное участие в процессе работы над бета-версией, чтобы убедиться, что пользователи вашего дополнения не пострадают при выходе "
+"финального релиза программы Mozilla."
 
 #: src/olympia/pages/templates/pages/dev_faq.html:185
 msgid "How to improve the performance of my add-on?"
@@ -12430,17 +9835,11 @@ msgstr "Как мне повысить производительность мо
 #: src/olympia/pages/templates/pages/dev_faq.html:187
 #, python-format
 msgid ""
-"Poorly written extensions can have a severe impact on the browsing "
-"experience, including on the overall performance of Firefox itself. The "
-"following page contains many good <a href=\"%(url)s\">guides</a> that help "
-"you improve performance, whether you're developing core Mozilla code or an "
-"add-on."
+"Poorly written extensions can have a severe impact on the browsing experience, including on the overall performance of Firefox itself. The following page contains many good <a href=\"%(url)s"
+"\">guides</a> that help you improve performance, whether you're developing core Mozilla code or an add-on."
 msgstr ""
-"Плохо написанные расширения могут серьезно повлиять на работу в Интернете, в"
-" том числе на общую производительность самого Firefox. Следующая страница "
-"содержит много хороших <a href=\"%(url)s\">руководств</a>, которые помогут "
-"вам повысить производительность, независимо от того, что вы разрабатываете "
-"основной код Mozilla или дополнение."
+"Плохо написанные расширения могут серьезно повлиять на работу в Интернете, в том числе на общую производительность самого Firefox. Следующая страница содержит много хороших <a href=\"%(url)s"
+"\">руководств</a>, которые помогут вам повысить производительность, независимо от того, что вы разрабатываете основной код Mozilla или дополнение."
 
 #: src/olympia/pages/templates/pages/dev_faq.html:195
 msgid "Can my add-on support multiple locales?"
@@ -12449,21 +9848,15 @@ msgstr "Может ли мое дополнение поддерживать н�
 #: src/olympia/pages/templates/pages/dev_faq.html:197
 #, python-format
 msgid ""
-"Yes. Details on localizing your add-on can be found in the the <a "
-"href=\"%(l10n_url)s\">Mozilla Developer Network Localization page</a>. <a "
-"href=\"%(bz_url)s\">The BabelZilla project</a> is also a great resource for "
-"learning about localization and volunteering to help translate add-ons."
+"Yes. Details on localizing your add-on can be found in the the <a href=\"%(l10n_url)s\">Mozilla Developer Network Localization page</a>. <a href=\"%(bz_url)s\">The BabelZilla project</a> is also a "
+"great resource for learning about localization and volunteering to help translate add-ons."
 msgstr ""
-"Да. Подробную информацию о локализации вашего дополнения можно найти на <a "
-"href=\"%(l10n_url)s\">Странице локализации Сети разработчиков Mozilla</a>. "
-"<a href=\"%(bz_url)s\">Проект BabelZilla</a> также является отличным "
-"ресурсом, где вы можете больше узнать о локализации и помочь в переводе "
-"дополнений."
+"Да. Подробную информацию о локализации вашего дополнения можно найти на <a href=\"%(l10n_url)s\">Странице локализации Сети разработчиков Mozilla</a>. <a href=\"%(bz_url)s\">Проект BabelZilla</a> "
+"также является отличным ресурсом, где вы можете больше узнать о локализации и помочь в переводе дополнений."
 
 #: src/olympia/pages/templates/pages/dev_faq.html:210
 msgid "I need some advice building my add-on. Where can I find help?"
-msgstr ""
-"Мне нужен совет по созданию моего дополнения. Где я могу найти помощь?"
+msgstr "Мне нужен совет по созданию моего дополнения. Где я могу найти помощь?"
 
 #. #extdev is the name of the IRC channel.  do not change.
 #: src/olympia/pages/templates/pages/dev_faq.html:216
@@ -12473,18 +9866,12 @@ msgstr "#extdev (для обсуждения разработки дополне
 #. #amo is the name of the IRC channel.  do not change.
 #: src/olympia/pages/templates/pages/dev_faq.html:218
 msgid "#amo (for support relating to hosting your add-on on AMO)"
-msgstr ""
-"#amo (для вопросов по поддержке, связанных с хостингом вашего дополнения на "
-"АМО)"
+msgstr "#amo (для вопросов по поддержке, связанных с хостингом вашего дополнения на АМО)"
 
 #. #jetpack is the name of the IRC channel.  do not change.
 #: src/olympia/pages/templates/pages/dev_faq.html:220
-msgid ""
-"#jetpack (for discussions about the Add-ons SDK and cfx/jpm - formerly known"
-" as Jetpack)"
-msgstr ""
-"#jetpack (для обсуждения Add-ons SDK и cfx/jpm - ранее известного как "
-"Jetpack)"
+msgid "#jetpack (for discussions about the Add-ons SDK and cfx/jpm - formerly known as Jetpack)"
+msgstr "#jetpack (для обсуждения Add-ons SDK и cfx/jpm - ранее известного как Jetpack)"
 
 #. Label for a link to the extension developers mailing list
 #: src/olympia/pages/templates/pages/dev_faq.html:225
@@ -12519,24 +9906,16 @@ msgstr "Нет."
 
 #: src/olympia/pages/templates/pages/dev_faq.html:246
 msgid "Are there 3rd party developers that I can hire to build my add-on?"
-msgstr ""
-"Есть ли сторонние разработчики, которых я могу нанять для создания моего "
-"дополнения?"
+msgstr "Есть ли сторонние разработчики, которых я могу нанять для создания моего дополнения?"
 
 #: src/olympia/pages/templates/pages/dev_faq.html:248
 #, python-format
 msgid ""
-"Yes. You may find 3rd party developers via the <a href=\"%(forum_url)s"
-"\">Add-ons forum</a>, <a href=\"%(list_url)s\">mozilla.jobs list</a>, <a "
-"href=\"%(mz_url)s\">mozillaZine forums</a> or <a href=\"%(wiki_url)s\">the "
-"Mozilla Wiki</a>. Please note that Mozilla does not offer developer "
-"recommendations."
+"Yes. You may find 3rd party developers via the <a href=\"%(forum_url)s\">Add-ons forum</a>, <a href=\"%(list_url)s\">mozilla.jobs list</a>, <a href=\"%(mz_url)s\">mozillaZine forums</a> or <a href="
+"\"%(wiki_url)s\">the Mozilla Wiki</a>. Please note that Mozilla does not offer developer recommendations."
 msgstr ""
-"Да. Вы можете найти сторонних разработчиков через <a "
-"href=\"%(forum_url)s\">форум дополнений</a>, <a href=\"%(list_url)s\">список"
-" mozilla.jobs</a>, <a href=\"%(mz_url)s\">форум MozillaZine</a> или <a "
-"href=\"%(wiki_url)s\">в Mozilla Wiki</a>. Пожалуйста, обратите внимание, что"
-" Mozilla не предоставляет рекомендации разработчиков."
+"Да. Вы можете найти сторонних разработчиков через <a href=\"%(forum_url)s\">форум дополнений</a>, <a href=\"%(list_url)s\">список mozilla.jobs</a>, <a href=\"%(mz_url)s\">форум MozillaZine</a> или "
+"<a href=\"%(wiki_url)s\">в Mozilla Wiki</a>. Пожалуйста, обратите внимание, что Mozilla не предоставляет рекомендации разработчиков."
 
 #: src/olympia/pages/templates/pages/dev_faq.html:263
 msgid "Can I host my own add-on?"
@@ -12545,22 +9924,13 @@ msgstr "Где я могу разместить мое дополнение?"
 #: src/olympia/pages/templates/pages/dev_faq.html:265
 #, python-format
 msgid ""
-"Yes. Many developers choose to host their own add-ons. Choosing to host your"
-" add-on on <a href=\"%(amo_url)s\">Mozilla's add-on site</a>, though, allows"
-" for much greater exposure to your add-on due to the large volume of "
-"visitors to the site. <a href=\"%(md_url)s\">mozdev.org</a> offers free "
-"project hosting for Mozilla applications and extensions providing developers"
-" with tools to help manage source code, version control, bug tracking and "
-"documentation."
+"Yes. Many developers choose to host their own add-ons. Choosing to host your add-on on <a href=\"%(amo_url)s\">Mozilla's add-on site</a>, though, allows for much greater exposure to your add-on due "
+"to the large volume of visitors to the site. <a href=\"%(md_url)s\">mozdev.org</a> offers free project hosting for Mozilla applications and extensions providing developers with tools to help manage "
+"source code, version control, bug tracking and documentation."
 msgstr ""
-"Да. Многие разработчики предпочитают самостоятельно хостить свои собственные"
-" дополнения. Тем не менее, выбрав для размещения своего дополнения <a "
-"href=\"%(amo_url)s\">Сайт дополнений Mozilla</a>, вы сможете представить "
-"свое дополнение гораздо более широкой аудитории, так как его посещает "
-"большое число людей. <a href=\"%(md_url)s\">mozdev.org</a> предоставляет "
-"бесплатный хостинг для приложений и расширений Mozilla , предоставляя "
-"разработчикам инструменты по управлению исходным кодом, контроль версий, "
-"отслеживание ошибок и документацию."
+"Да. Многие разработчики предпочитают самостоятельно хостить свои собственные дополнения. Тем не менее, выбрав для размещения своего дополнения <a href=\"%(amo_url)s\">Сайт дополнений Mozilla</a>, "
+"вы сможете представить свое дополнение гораздо более широкой аудитории, так как его посещает большое число людей. <a href=\"%(md_url)s\">mozdev.org</a> предоставляет бесплатный хостинг для "
+"приложений и расширений Mozilla , предоставляя разработчикам инструменты по управлению исходным кодом, контроль версий, отслеживание ошибок и документацию."
 
 #: src/olympia/pages/templates/pages/dev_faq.html:277
 msgid "Can Mozilla host my add-on?"
@@ -12568,12 +9938,8 @@ msgstr "Может ли Mozilla разместить мое дополнение
 
 #: src/olympia/pages/templates/pages/dev_faq.html:279
 #, python-format
-msgid ""
-"Yes. You can host your add-on on <a href=\"%(url)s\">Mozilla's add-on "
-"website</a>."
-msgstr ""
-"Да. Вы можете разместить свое дополнение на <a href=\"%(url)s\">веб-сайте "
-"дополнений Mozilla</a>."
+msgid "Yes. You can host your add-on on <a href=\"%(url)s\">Mozilla's add-on website</a>."
+msgstr "Да. Вы можете разместить свое дополнение на <a href=\"%(url)s\">веб-сайте дополнений Mozilla</a>."
 
 #: src/olympia/pages/templates/pages/dev_faq.html:284
 msgid "What is AMO?"
@@ -12581,20 +9947,11 @@ msgstr "Что такое AMO?"
 
 #: src/olympia/pages/templates/pages/dev_faq.html:286
 msgid ""
-"Mozilla's AMO (<a "
-"href=\"https://addons.mozilla.org\">https://addons.mozilla.org</a>) is the "
-"incubator that helps developers build, distribute, and support fantastic "
-"consumer products powered by Mozilla. It provides you the tools and "
-"infrastructure necessary to manage, host and expose your add-on to a massive"
-" base of Mozilla users."
+"Mozilla's AMO (<a href=\"https://addons.mozilla.org\">https://addons.mozilla.org</a>) is the incubator that helps developers build, distribute, and support fantastic consumer products powered by "
+"Mozilla. It provides you the tools and infrastructure necessary to manage, host and expose your add-on to a massive base of Mozilla users."
 msgstr ""
-"Mozilla АМО (<a "
-"href=\"https://addons.mozilla.org\">https://addons.mozilla.org</a>) это "
-"инкубатор, который помогает разработчикам создавать, распространять и "
-"поддерживать фантастические продукты, основанные на коде от Mozilla. Он "
-"предоставляет вам инструменты и необходимую инфраструктуру для управления, "
-"размещения и распространения вашего дополнения среди широких масс "
-"пользователей Mozilla."
+"Mozilla АМО (<a href=\"https://addons.mozilla.org\">https://addons.mozilla.org</a>) это инкубатор, который помогает разработчикам создавать, распространять и поддерживать фантастические продукты, "
+"основанные на коде от Mozilla. Он предоставляет вам инструменты и необходимую инфраструктуру для управления, размещения и распространения вашего дополнения среди широких масс пользователей Mozilla."
 
 #: src/olympia/pages/templates/pages/dev_faq.html:295
 msgid "Does Mozilla keep my account information private?"
@@ -12602,12 +9959,8 @@ msgstr "Держит ли Mozilla информацию о моем счете в
 
 #: src/olympia/pages/templates/pages/dev_faq.html:297
 #, python-format
-msgid ""
-"Yes. Our <a href=\"%(url)s\">Privacy Policy</a> describes how your "
-"information is managed by Mozilla."
-msgstr ""
-"Да. Наша <a href=\"%(url)s\">политика приватности</a> описывает, каким "
-"образом ваша информация обрабатывается Mozilla."
+msgid "Yes. Our <a href=\"%(url)s\">Privacy Policy</a> describes how your information is managed by Mozilla."
+msgstr "Да. Наша <a href=\"%(url)s\">политика приватности</a> описывает, каким образом ваша информация обрабатывается Mozilla."
 
 #: src/olympia/pages/templates/pages/dev_faq.html:302
 msgid "What are the \"developer tools\" listed on AMO?"
@@ -12615,38 +9968,24 @@ msgstr "Что такое «инструменты разработчика», �
 
 #: src/olympia/pages/templates/pages/dev_faq.html:304
 msgid ""
-"The \"Developer Tools\" dashboard is the area that provides you the tools to"
-" successfully manage your add-ons. It provides the functionality necessary "
-"to submit your add-ons to AMO, manage add-on information, and review "
-"statistics."
+"The \"Developer Tools\" dashboard is the area that provides you the tools to successfully manage your add-ons. It provides the functionality necessary to submit your add-ons to AMO, manage add-on "
+"information, and review statistics."
 msgstr ""
-"Панель «Инструменты разработчика» — это область, которая предоставляет вам "
-"инструменты для успешного управлением вашими дополнениями. Она обеспечивает "
-"функциональность, необходимую для представления ваших дополнений на АМО, "
-"управлению информацией о дополнениях и статистикой отзывов."
+"Панель «Инструменты разработчика» — это область, которая предоставляет вам инструменты для успешного управлением вашими дополнениями. Она обеспечивает функциональность, необходимую для "
+"представления ваших дополнений на АМО, управлению информацией о дополнениях и статистикой отзывов."
 
 #: src/olympia/pages/templates/pages/dev_faq.html:312
-msgid ""
-"Does Mozilla have a policy in place as to what is an acceptable submission?"
-msgstr ""
-"Имеет ли Mozilla политику, определяющую, что является приемлемым "
-"представлением?"
+msgid "Does Mozilla have a policy in place as to what is an acceptable submission?"
+msgstr "Имеет ли Mozilla политику, определяющую, что является приемлемым представлением?"
 
 #: src/olympia/pages/templates/pages/dev_faq.html:314
 #, python-format
 msgid ""
-"Yes. Mozilla's <a href=\"%(p_url)s\">Add-on Policy</a> describes what is an "
-"acceptable submission. This policy is subject to change without notice. In "
-"addition, the AMO editorial team uses the <a href=\"%(g_url)s\">Editors "
-"Reviewing Guide</a> to ensure that your add-on meets specific guidelines for"
-" functionality and security."
+"Yes. Mozilla's <a href=\"%(p_url)s\">Add-on Policy</a> describes what is an acceptable submission. This policy is subject to change without notice. In addition, the AMO editorial team uses the <a "
+"href=\"%(g_url)s\">Editors Reviewing Guide</a> to ensure that your add-on meets specific guidelines for functionality and security."
 msgstr ""
-"Да. <a href=\"%(p_url)s\">Политика дополнений</a> Mozilla описывает, что "
-"является приемлемым представлением. Эта политика может быть изменена без "
-"предварительного уведомления. Кроме того, группа редакторов АМО использует "
-"<a href=\"%(g_url)s\">Руководство редакторов по проверке</a>, чтобы "
-"убедиться, что ваше дополнение отвечает специфичным требованиям по "
-"функциональности и безопасности."
+"Да. <a href=\"%(p_url)s\">Политика дополнений</a> Mozilla описывает, что является приемлемым представлением. Эта политика может быть изменена без предварительного уведомления. Кроме того, группа "
+"редакторов АМО использует <a href=\"%(g_url)s\">Руководство редакторов по проверке</a>, чтобы убедиться, что ваше дополнение отвечает специфичным требованиям по функциональности и безопасности."
 
 #: src/olympia/pages/templates/pages/dev_faq.html:324
 msgid "How do I submit my add-on for review?"
@@ -12655,30 +9994,20 @@ msgstr "Как мне отправить мое дополнение для пр
 #: src/olympia/pages/templates/pages/dev_faq.html:326
 #, python-format
 msgid ""
-"The Developer Tools dashboard will allow you to upload and submit add-ons to"
-" AMO. You must be a registered AMO users before you can submit an add-on. "
-"Before submitting your add-on be sure to you have read the AMO <a "
-"href=\"%(url)s\">Editors Reviewing Guide</a> to ensure that your add-on has "
-"met the guidelines used by editors to review add-ons."
+"The Developer Tools dashboard will allow you to upload and submit add-ons to AMO. You must be a registered AMO users before you can submit an add-on. Before submitting your add-on be sure to you "
+"have read the AMO <a href=\"%(url)s\">Editors Reviewing Guide</a> to ensure that your add-on has met the guidelines used by editors to review add-ons."
 msgstr ""
-"Панель Инструментов разработчика позволяет вам загружать и представлять "
-"дополнения на АМО. Перед тем, как вы сможете представить дополнение на AMO, "
-"вы должны на нем зарегистрироваться. Перед представлением вашего дополнения "
-"обязательно прочтите <a href=\"%(url)s\">Руководство редакторов АМО по "
-"проверке</a>, чтобы убедиться, что ваше дополнение соответствует "
-"требованиям, используемым редакторами при проверке дополнений."
+"Панель Инструментов разработчика позволяет вам загружать и представлять дополнения на АМО. Перед тем, как вы сможете представить дополнение на AMO, вы должны на нем зарегистрироваться. Перед "
+"представлением вашего дополнения обязательно прочтите <a href=\"%(url)s\">Руководство редакторов АМО по проверке</a>, чтобы убедиться, что ваше дополнение соответствует требованиям, используемым "
+"редакторами при проверке дополнений."
 
 #: src/olympia/pages/templates/pages/dev_faq.html:336
 msgid "What operating system do I choose for my add-on?"
 msgstr "Какую операционную систему мне выбрать для моего дополнения?"
 
 #: src/olympia/pages/templates/pages/dev_faq.html:338
-msgid ""
-"You must choose the operating systems on which your add-on will successfully"
-" function."
-msgstr ""
-"Вы должны выбрать те операционные системы, на которых будет успешно "
-"функционировать ваше дополнение."
+msgid "You must choose the operating systems on which your add-on will successfully function."
+msgstr "Вы должны выбрать те операционные системы, на которых будет успешно функционировать ваше дополнение."
 
 #: src/olympia/pages/templates/pages/dev_faq.html:344
 msgid "What category do I choose for my add-on?"
@@ -12686,59 +10015,39 @@ msgstr "Какую категорию мне выбрать для моего д
 
 #: src/olympia/pages/templates/pages/dev_faq.html:346
 msgid ""
-"The choice of category is dependent on what type of audience you are "
-"targeting and the functionality of your add-on. If you're unsure of which "
-"category your add-on falls into, please choose \"Other\". The AMO team may "
-"re-categorize your add-on if it's determined that it's better suited in a "
-"different category."
+"The choice of category is dependent on what type of audience you are targeting and the functionality of your add-on. If you're unsure of which category your add-on falls into, please choose \"Other"
+"\". The AMO team may re-categorize your add-on if it's determined that it's better suited in a different category."
 msgstr ""
-"Выбор категории зависит от типа вашей целевой аудитории и функциональности "
-"вашего дополнения. Если вы не уверены, под какую категорию подпадает ваше "
-"дополнение, пожалуйста выберите «Другое». Команда АМО может в дальнейшем "
-"изменить категорию вашего дополнения, если будет очевидно, что оно больше "
-"подходит под другую категорию."
+"Выбор категории зависит от типа вашей целевой аудитории и функциональности вашего дополнения. Если вы не уверены, под какую категорию подпадает ваше дополнение, пожалуйста выберите «Другое». "
+"Команда АМО может в дальнейшем изменить категорию вашего дополнения, если будет очевидно, что оно больше подходит под другую категорию."
 
 #: src/olympia/pages/templates/pages/dev_faq.html:355
 msgid "What does \"nominating\" my add-on mean?"
 msgstr "Что значит «номинация» моего дополнения?"
 
 #: src/olympia/pages/templates/pages/dev_faq.html:357
-msgid ""
-"Nominated add-ons are new add-ons that the author has nominated to become "
-"public via the Developer Tools."
-msgstr ""
-"Номинированные дополнения это новые дополнения, номинированные автором для "
-"представления публике через Инструменты разработчика."
+msgid "Nominated add-ons are new add-ons that the author has nominated to become public via the Developer Tools."
+msgstr "Номинированные дополнения это новые дополнения, номинированные автором для представления публике через Инструменты разработчика."
 
 #: src/olympia/pages/templates/pages/dev_faq.html:363
 msgid "Can I specify a license agreement for using my add-on?"
-msgstr ""
-"Могу ли я указать лицензионное соглашение на использование моего дополнения?"
+msgstr "Могу ли я указать лицензионное соглашение на использование моего дополнения?"
 
 #: src/olympia/pages/templates/pages/dev_faq.html:365
-msgid ""
-"Yes. You can specify a license agreement when submitting your add-on. You "
-"can also add or update a license agreement via the Developer Tools dashboard"
-" after your add-on has been submitted."
+msgid "Yes. You can specify a license agreement when submitting your add-on. You can also add or update a license agreement via the Developer Tools dashboard after your add-on has been submitted."
 msgstr ""
-"Да. Вы можете указать лицензионное соглашение при представлении вашего "
-"дополнения. Вы также можете добавить или обновить лицензионное соглашение "
-"через панель Инструментов Разработчика после представления вашего "
-"дополнения."
+"Да. Вы можете указать лицензионное соглашение при представлении вашего дополнения. Вы также можете добавить или обновить лицензионное соглашение через панель Инструментов Разработчика после "
+"представления вашего дополнения."
 
 #: src/olympia/pages/templates/pages/dev_faq.html:372
 msgid "Can I include a privacy policy for my add-on?"
 msgstr "Могу ли я включить для моего дополнения политику приватности?"
 
 #: src/olympia/pages/templates/pages/dev_faq.html:374
-msgid ""
-"Yes. You can specify a privacy policy when submitting your add-on. You can "
-"also add or update a privacy policy via the Developer Tools dashboard after "
-"your add-on has been submitted."
+msgid "Yes. You can specify a privacy policy when submitting your add-on. You can also add or update a privacy policy via the Developer Tools dashboard after your add-on has been submitted."
 msgstr ""
-"Да. Вы можете указать политику приватности при представлении вашего "
-"дополнения. Вы также можете добавить или обновить политику приватности через"
-" панель Инструментов Разработчика после представления вашего дополнения."
+"Да. Вы можете указать политику приватности при представлении вашего дополнения. Вы также можете добавить или обновить политику приватности через панель Инструментов Разработчика после представления "
+"вашего дополнения."
 
 #: src/olympia/pages/templates/pages/dev_faq.html:383
 msgid "Why must my add-on be reviewed?"
@@ -12747,16 +10056,11 @@ msgstr "Почему мое дополнение должно быть пров�
 #: src/olympia/pages/templates/pages/dev_faq.html:385
 #, python-format
 msgid ""
-"All add-ons submitted, whether new or updated, are reviewed to ensure that "
-"Mozilla users have a stable and safe experience. All add-ons submissions are"
-" reviewed using the guidelines outlined in the <a href=\"%(url)s\">Editors "
-"Reviewing Guide</a>."
+"All add-ons submitted, whether new or updated, are reviewed to ensure that Mozilla users have a stable and safe experience. All add-ons submissions are reviewed using the guidelines outlined in the "
+"<a href=\"%(url)s\">Editors Reviewing Guide</a>."
 msgstr ""
-"Все представленные дополнения, как новые так и обновленные, подвергаются "
-"проверке, чтобы убедиться в их стабильной и безопасной работе для "
-"пользователей Mozilla. Все представленные дополнения проверяются в "
-"соответствии с принципами, изложенными в <a href=\"%(url)s\">Руководстве "
-"редакторов по проверке</a>."
+"Все представленные дополнения, как новые так и обновленные, подвергаются проверке, чтобы убедиться в их стабильной и безопасной работе для пользователей Mozilla. Все представленные дополнения "
+"проверяются в соответствии с принципами, изложенными в <a href=\"%(url)s\">Руководстве редакторов по проверке</a>."
 
 #: src/olympia/pages/templates/pages/dev_faq.html:393
 msgid "Who reviews my add-on?"
@@ -12765,20 +10069,13 @@ msgstr "Кто проверяет моё дополнение?"
 #: src/olympia/pages/templates/pages/dev_faq.html:395
 #, python-format
 msgid ""
-"Add-ons are reviewed by the AMO Editors, a group of talented developers that"
-" volunteer to help the Mozilla project by reviewing add-ons to ensure a "
-"stable and safe experience for Mozilla users. When communicating with "
-"editors, please be courteous, patient and respectful as they are working "
-"hard to ensure that your add-on is set up correctly and follows the "
-"guidelines outlined in the <a href=\"%(url)s\">Editors Reviewing Guide</a>."
+"Add-ons are reviewed by the AMO Editors, a group of talented developers that volunteer to help the Mozilla project by reviewing add-ons to ensure a stable and safe experience for Mozilla users. "
+"When communicating with editors, please be courteous, patient and respectful as they are working hard to ensure that your add-on is set up correctly and follows the guidelines outlined in the <a "
+"href=\"%(url)s\">Editors Reviewing Guide</a>."
 msgstr ""
-"Дополнения проверяются редакторами АМО - группой талантливых разработчиков, "
-"которые добровольно помогают проекту Mozilla в проверке дополнений, чтобы "
-"обеспечить стабильную и безопасную работу пользователей Mozilla. При общении"
-" с редакторами, пожалуйста, будьте вежливы, терпеливы и уважительны, так как"
-" они упорно работают над тем, чтобы удостовериться, что ваше дополнение "
-"работает правильно и следует принципам изложенным в <a "
-"href=\"%(url)s\">Руководстве редакторов по проверке</a>."
+"Дополнения проверяются редакторами АМО - группой талантливых разработчиков, которые добровольно помогают проекту Mozilla в проверке дополнений, чтобы обеспечить стабильную и безопасную работу "
+"пользователей Mozilla. При общении с редакторами, пожалуйста, будьте вежливы, терпеливы и уважительны, так как они упорно работают над тем, чтобы удостовериться, что ваше дополнение работает "
+"правильно и следует принципам изложенным в <a href=\"%(url)s\">Руководстве редакторов по проверке</a>."
 
 #: src/olympia/pages/templates/pages/dev_faq.html:406
 msgid "What are the guidelines used to review my add-on?"
@@ -12787,30 +10084,20 @@ msgstr "Какие принципы используются при провер
 #: src/olympia/pages/templates/pages/dev_faq.html:408
 #, python-format
 msgid ""
-"The Mozilla editorial team follows the <a href=\"%(url)s\">Editors Reviewing"
-" Guide</a> when testing an add-on for acceptance onto AMO. It is important "
-"that add-on developers review this guide to ensure that common problem areas"
-" are addressed prior to submitting their add-on for review. This will "
-"greatly assist in expediting the review process."
+"The Mozilla editorial team follows the <a href=\"%(url)s\">Editors Reviewing Guide</a> when testing an add-on for acceptance onto AMO. It is important that add-on developers review this guide to "
+"ensure that common problem areas are addressed prior to submitting their add-on for review. This will greatly assist in expediting the review process."
 msgstr ""
-"Команда редакторов Mozilla следует <a href=\"%(url)s\">Руководству "
-"редакторов по проверке</a> при тестировании дополнения на предмет его "
-"размещения на AMO. Важно, чтобы разработчики дополнения просмотрели это "
-"руководство, чтобы убедиться в отсутствии у дополнения типичных проблем "
-"перед тем, как представлять его на проверку. Это значительно поспособствует "
-"ускорению процесса проверки дополнения."
+"Команда редакторов Mozilla следует <a href=\"%(url)s\">Руководству редакторов по проверке</a> при тестировании дополнения на предмет его размещения на AMO. Важно, чтобы разработчики дополнения "
+"просмотрели это руководство, чтобы убедиться в отсутствии у дополнения типичных проблем перед тем, как представлять его на проверку. Это значительно поспособствует ускорению процесса проверки "
+"дополнения."
 
 #: src/olympia/pages/templates/pages/dev_faq.html:418
 msgid "How long will it take for my add-on to be reviewed?"
 msgstr "Сколько времени займет проверка моего дополнения?"
 
 #: src/olympia/pages/templates/pages/dev_faq.html:420
-msgid ""
-"We cannot give a time estimate as to how long it will take before an add-on "
-"is reviewed. Many factors affect the time including the:"
-msgstr ""
-"Мы не можем оценить время, которое займет проверка дополнения. На "
-"длительность проверки влияют многие факторы, в том числе:"
+msgid "We cannot give a time estimate as to how long it will take before an add-on is reviewed. Many factors affect the time including the:"
+msgstr "Мы не можем оценить время, которое займет проверка дополнения. На длительность проверки влияют многие факторы, в том числе:"
 
 #. part of a list (<li>)
 #: src/olympia/pages/templates/pages/dev_faq.html:427
@@ -12830,62 +10117,41 @@ msgstr "число обнаруженных проблемных областе�
 #: src/olympia/pages/templates/pages/dev_faq.html:434
 #, python-format
 msgid ""
-"This is why it's very important to read the <a href=\"%(g_url)s\">Editors "
-"Reviewing Guide</a> to ensure that your add-on is setup as expected. It's "
-"also a good idea to read the blog post, <a "
-"href=\"%(blog_url)s\">Successfully Getting your Add-on Reviewed</a> which "
-"provides excellent insight into ensuring a smooth review of your add-on."
+"This is why it's very important to read the <a href=\"%(g_url)s\">Editors Reviewing Guide</a> to ensure that your add-on is setup as expected. It's also a good idea to read the blog post, <a href="
+"\"%(blog_url)s\">Successfully Getting your Add-on Reviewed</a> which provides excellent insight into ensuring a smooth review of your add-on."
 msgstr ""
-"Вот почему очень важно прочесть <a href=\"%(g_url)s\">Руководство редакторов"
-" по проверке</a>, чтобы убедиться, что ваше дополнение настроено так, как "
-"нужно. Также хорошей идеей является прочесть пост в блоге, <a "
-"href=\"%(blog_url)s\">Как успешно пройти проверку для вашего дополнения</a>,"
-" в котором отлично описано то, что нужно сделать, чтобы обеспечить "
-"беспроблемную проверку для вашего дополнения."
+"Вот почему очень важно прочесть <a href=\"%(g_url)s\">Руководство редакторов по проверке</a>, чтобы убедиться, что ваше дополнение настроено так, как нужно. Также хорошей идеей является прочесть "
+"пост в блоге, <a href=\"%(blog_url)s\">Как успешно пройти проверку для вашего дополнения</a>, в котором отлично описано то, что нужно сделать, чтобы обеспечить беспроблемную проверку для вашего "
+"дополнения."
 
 #: src/olympia/pages/templates/pages/dev_faq.html:446
 msgid "How can I see how many times my add-on has been downloaded?"
 msgstr "Как я могу увидеть сколько раз был загружено мое дополнение?"
 
 #: src/olympia/pages/templates/pages/dev_faq.html:448
-msgid ""
-"The Statistics Dashboard found in the Developer Tools dashboard provides "
-"information that can help you determine your add-on downloads since you've "
-"submitted it to AMO."
+msgid "The Statistics Dashboard found in the Developer Tools dashboard provides information that can help you determine your add-on downloads since you've submitted it to AMO."
 msgstr ""
-"Панель статистики, размещенная в панели Инструменты разработчика, "
-"предоставляет информацию, которая может помочь вам определить число загрузок"
-" вашего дополнения с того момента, как вы представили его на AMO."
+"Панель статистики, размещенная в панели Инструменты разработчика, предоставляет информацию, которая может помочь вам определить число загрузок вашего дополнения с того момента, как вы представили "
+"его на AMO."
 
 #: src/olympia/pages/templates/pages/dev_faq.html:455
 msgid "How can I see how many active users are using my add-on?"
-msgstr ""
-"Как я могу увидеть сколько активных пользователей используют мое дополнение?"
+msgstr "Как я могу увидеть сколько активных пользователей используют мое дополнение?"
 
 #: src/olympia/pages/templates/pages/dev_faq.html:457
 msgid ""
-"The Statistics Dashboard found in the Developer Tools dashboard provides "
-"information that can help you determine how many users have been actively "
-"using your add-on since you've submitted it to AMO."
+"The Statistics Dashboard found in the Developer Tools dashboard provides information that can help you determine how many users have been actively using your add-on since you've submitted it to AMO."
 msgstr ""
-"Панель статистики, размещенная в панели Инструменты разработчика, "
-"предоставляет информацию, которая может помочь вам определить число "
-"пользователей, активно использующих ваше дополнение, с того момента, как вы "
-"представили его на AMO."
+"Панель статистики, размещенная в панели Инструменты разработчика, предоставляет информацию, которая может помочь вам определить число пользователей, активно использующих ваше дополнение, с того "
+"момента, как вы представили его на AMO."
 
 #: src/olympia/pages/templates/pages/dev_faq.html:464
 msgid "How do I submit an update for my add-on?"
 msgstr "Как мне отправить обновление для моего дополнения?"
 
 #: src/olympia/pages/templates/pages/dev_faq.html:466
-msgid ""
-"You can submit an update for your add-on via the Developer Tools dashboard "
-"by choosing the option \"Upload a new version\" and uploading a new .xpi "
-"file for your add-on."
-msgstr ""
-"Вы можете представить обновление для вашего дополнения через панель "
-"Инструменты разработчика, выбрав опцию «Загрузить новую версию» и загрузив "
-"новый файл вашего дополнения с расширением .xpi."
+msgid "You can submit an update for your add-on via the Developer Tools dashboard by choosing the option \"Upload a new version\" and uploading a new .xpi file for your add-on."
+msgstr "Вы можете представить обновление для вашего дополнения через панель Инструменты разработчика, выбрав опцию «Загрузить новую версию» и загрузив новый файл вашего дополнения с расширением .xpi."
 
 #: src/olympia/pages/templates/pages/dev_faq.html:473
 msgid "Does my update need to be reviewed by editors?"
@@ -12893,53 +10159,34 @@ msgstr "Мое обновление должно быть проверено р�
 
 #: src/olympia/pages/templates/pages/dev_faq.html:475
 msgid ""
-"That depends. If you are simply changing a description of your add-on or "
-"updating a \"maxVersion\" to ensure compatibility with a new Mozilla "
-"software update, then your add-on does not need to be reviewed again. If, "
-"however, you submit a new updated file, then your add-on update will need to"
-" be reviewed by an editor."
+"That depends. If you are simply changing a description of your add-on or updating a \"maxVersion\" to ensure compatibility with a new Mozilla software update, then your add-on does not need to be "
+"reviewed again. If, however, you submit a new updated file, then your add-on update will need to be reviewed by an editor."
 msgstr ""
-"Когда как. Если вы просто изменяете описание вашего дополнения или "
-"обновляете «maxVersion», чтобы обеспечить совместимость с новой версией "
-"программного обеспечения Mozilla, то повторная проверка вашего дополнения не"
-" требуется. Однако, если вы представляете новый обновленный файл, то "
-"обновление вашего дополнения должно быть проверено редактором."
+"Когда как. Если вы просто изменяете описание вашего дополнения или обновляете «maxVersion», чтобы обеспечить совместимость с новой версией программного обеспечения Mozilla, то повторная проверка "
+"вашего дополнения не требуется. Однако, если вы представляете новый обновленный файл, то обновление вашего дополнения должно быть проверено редактором."
 
 #: src/olympia/pages/templates/pages/dev_faq.html:486
-msgid ""
-"How do I reply to a user who has posted a negative review of my add-on?"
-msgstr ""
-"Как мне ответить пользователю, который разместил негативный отзыв на моё "
-"дополнение?"
+msgid "How do I reply to a user who has posted a negative review of my add-on?"
+msgstr "Как мне ответить пользователю, который разместил негативный отзыв на моё дополнение?"
 
 #: src/olympia/pages/templates/pages/dev_faq.html:488
-msgid ""
-"A developer may reply to any review posted to their add-on as long as they "
-"are logged into AMO. In addition, any user can flag a review as:"
-msgstr ""
-"Разработчик может ответить на любой отзыв, оставленный на его дополнение, "
-"если он залогинен на АМО. Кроме того, любой пользователь может отметить "
-"отзыв как:"
+msgid "A developer may reply to any review posted to their add-on as long as they are logged into AMO. In addition, any user can flag a review as:"
+msgstr "Разработчик может ответить на любой отзыв, оставленный на его дополнение, если он залогинен на АМО. Кроме того, любой пользователь может отметить отзыв как:"
 
 #. part of a list (<li>)
-#: src/olympia/pages/templates/pages/dev_faq.html:495
-#: src/olympia/reviews/models.py:159
+#: src/olympia/pages/templates/pages/dev_faq.html:495 src/olympia/reviews/models.py:159
 msgid "Spam or otherwise non-review content"
 msgstr "Спам или другое несоответствующее содержимое"
 
 #. part of a list (<li>)
-#: src/olympia/pages/templates/pages/dev_faq.html:497
-#: src/olympia/reviews/models.py:160
+#: src/olympia/pages/templates/pages/dev_faq.html:497 src/olympia/reviews/models.py:160
 msgid "Inappropriate language/dialog"
 msgstr "Неприемлемые выражения/перебранка"
 
 #. part of a list (<li>)
-#: src/olympia/pages/templates/pages/dev_faq.html:499
-#: src/olympia/reviews/models.py:161
+#: src/olympia/pages/templates/pages/dev_faq.html:499 src/olympia/reviews/models.py:161
 msgid "Misplaced bug report or support request"
-msgstr ""
-"Отправленное не по назначению сообщение об ошибке или просьба оказать "
-"поддержку"
+msgstr "Отправленное не по назначению сообщение об ошибке или просьба оказать поддержку"
 
 #. part of a list (<li>)
 #: src/olympia/pages/templates/pages/dev_faq.html:501
@@ -12947,131 +10194,74 @@ msgid "Other (provides a pop-up prompt for information)"
 msgstr "Другие (предоставляет всплывающий запрос для ввода информации)"
 
 #: src/olympia/pages/templates/pages/dev_faq.html:504
-msgid ""
-"Currently, AMO does not provide a mechanism to directly communicate with a "
-"reviewer but this feature is being investigated and considered for a future "
-"update."
-msgstr ""
-"В настоящее время AMO не предоставляет механизма прямой связи с рецензентом,"
-" но эта возможность сейчас рассматривается для включение в будущее "
-"обновление."
+msgid "Currently, AMO does not provide a mechanism to directly communicate with a reviewer but this feature is being investigated and considered for a future update."
+msgstr "В настоящее время AMO не предоставляет механизма прямой связи с рецензентом, но эта возможность сейчас рассматривается для включение в будущее обновление."
 
 #: src/olympia/pages/templates/pages/dev_faq.html:511
 msgid "Can I request that a review be removed if the review is negative?"
 msgstr "Могу ли я попросить удалить отзыв, если он является негативным?"
 
 #: src/olympia/pages/templates/pages/dev_faq.html:513
-msgid ""
-"No. We do not remove negative reviews from add-ons unless they are found to "
-"be false."
-msgstr ""
-"Нет. Мы не удаляет негативные отзывы на дополнения, если только они не будут"
-" признаны ложными."
+msgid "No. We do not remove negative reviews from add-ons unless they are found to be false."
+msgstr "Нет. Мы не удаляет негативные отзывы на дополнения, если только они не будут признаны ложными."
 
 #: src/olympia/pages/templates/pages/dev_faq.html:519
 msgid "Can I request that a review be removed if the review is inaccurate?"
 msgstr "Могу ли я попросить удалить отзыв, если он является некорректным?"
 
 #: src/olympia/pages/templates/pages/dev_faq.html:521
-msgid ""
-"If an author contacts us and asks for a review containing false or "
-"inaccurate information to be removed, we will review the post and consider "
-"removing it."
-msgstr ""
-"Если автор связывается с нами и просит удалить отзыв, содержащий ложную или "
-"неточную информацию, мы проверяем отзыв и, по результатам проверки, можем "
-"его удалить."
+msgid "If an author contacts us and asks for a review containing false or inaccurate information to be removed, we will review the post and consider removing it."
+msgstr "Если автор связывается с нами и просит удалить отзыв, содержащий ложную или неточную информацию, мы проверяем отзыв и, по результатам проверки, можем его удалить."
 
 #: src/olympia/pages/templates/pages/dev_faq.html:530
 msgid ""
-"Do you need more information about the various open source licenses? Are you"
-" confused as to which license you should select? What rights does a specific"
-" license grant? While nothing replaces reading the full terms of a license, "
-"below are some sites that contain information about some of the key open "
-"source licenses that may help you sort out the differences between them. "
-"These sites are being provided solely for your convenience and as a "
-"reference for your personal use. These resources do not constitute legal "
-"advice nor should they be used in lieu of such advice. Mozilla neither "
-"guarantees nor is responsible for the content of these sites or your "
-"reliance on such content."
+"Do you need more information about the various open source licenses? Are you confused as to which license you should select? What rights does a specific license grant? While nothing replaces "
+"reading the full terms of a license, below are some sites that contain information about some of the key open source licenses that may help you sort out the differences between them. These sites "
+"are being provided solely for your convenience and as a reference for your personal use. These resources do not constitute legal advice nor should they be used in lieu of such advice. Mozilla "
+"neither guarantees nor is responsible for the content of these sites or your reliance on such content."
 msgstr ""
-"Нужны дополнительные сведения о различных лицензиях для открытого исходного "
-"кода? Не знаете какую лицензию следуте выбрать? Хотите знать какие права "
-"предоставляет какая-либо лицензия? Хотя ничто не заменит чтения всех условий"
-" лицензии, ниже перечислены некоторые сайты, которые содержат сведения о "
-"некоторых из ключевых лицензий для открытого исходного кода, которые могут "
-"помочь вам разобраться в их различиях. Эти сайты предоставляются "
-"исключительно для вашего удобства в качестве рекомендации для вашего личного"
-" пользования. Данные ресурсы не являются юридической консультацией и не "
-"должны использоваться вместо подобных консультаций. Mozilla не гарантирует и"
-" не несет ответственность за содержание этих сайтов или за использованием "
-"вами этого содержания."
+"Нужны дополнительные сведения о различных лицензиях для открытого исходного кода? Не знаете какую лицензию следуте выбрать? Хотите знать какие права предоставляет какая-либо лицензия? Хотя ничто не "
+"заменит чтения всех условий лицензии, ниже перечислены некоторые сайты, которые содержат сведения о некоторых из ключевых лицензий для открытого исходного кода, которые могут помочь вам разобраться "
+"в их различиях. Эти сайты предоставляются исключительно для вашего удобства в качестве рекомендации для вашего личного пользования. Данные ресурсы не являются юридической консультацией и не должны "
+"использоваться вместо подобных консультаций. Mozilla не гарантирует и не несет ответственность за содержание этих сайтов или за использованием вами этого содержания."
 
 #: src/olympia/pages/templates/pages/dev_faq.html:545
 msgid ""
-"In addition to the full text of the Mozilla Public License(\"MPL\"), this "
-"also provides an annotated version of the MPL and an <abbr "
-"title=\"Frequently Asked Questions\">FAQ</abbr> to help you if you want to "
-"use or distribute code licensed under it."
+"In addition to the full text of the Mozilla Public License(\"MPL\"), this also provides an annotated version of the MPL and an <abbr title=\"Frequently Asked Questions\">FAQ</abbr> to help you if "
+"you want to use or distribute code licensed under it."
 msgstr ""
-"В дополнение к полному тексту Mozilla Public License(\"MPL\"), мы также "
-"предоставляем аннотированную версию MPL и <abbr title=\"Ответы на часто "
-"задаваемые вопросы\">Ответы на часто задаваемые вопросы</abbr>, которые "
-"помогут вам, если вы захотите использовать или распространять код на её "
-"условиях."
+"В дополнение к полному тексту Mozilla Public License(\"MPL\"), мы также предоставляем аннотированную версию MPL и <abbr title=\"Ответы на часто задаваемые вопросы\">Ответы на часто задаваемые "
+"вопросы</abbr>, которые помогут вам, если вы захотите использовать или распространять код на её условиях."
 
 #: src/olympia/pages/templates/pages/dev_faq.html:559
-msgid ""
-"A table summarizing and comparing how some of the key open source licenses "
-"treat distributions, proprietary software linking, and redistribution of "
-"code with changes."
+msgid "A table summarizing and comparing how some of the key open source licenses treat distributions, proprietary software linking, and redistribution of code with changes."
 msgstr ""
-"Таблица, суммирующая и сравнивающая позиции, занимаемые некоторыми из "
-"ключевых лицензий для открытого исходного кода, в отношении дистрибуции, "
-"связывания с проприетарным программным обеспечением и распространения кода с"
-" изменениями."
+"Таблица, суммирующая и сравнивающая позиции, занимаемые некоторыми из ключевых лицензий для открытого исходного кода, в отношении дистрибуции, связывания с проприетарным программным обеспечением и "
+"распространения кода с изменениями."
 
 #: src/olympia/pages/templates/pages/dev_faq.html:572
 msgid ""
-"Free Software Foundation provides short summaries of the key open source "
-"licenses, including whether the license qualifies as a free software license"
-" or a copyleft license. Also includes a discussion of what constitutes a "
-"free software license or a copyleft license (e.g., a Copyleft license is a "
-"general method for making a program or other work free, and requiring all "
-"modified and extended versions of the program to be free as well.)"
+"Free Software Foundation provides short summaries of the key open source licenses, including whether the license qualifies as a free software license or a copyleft license. Also includes a "
+"discussion of what constitutes a free software license or a copyleft license (e.g., a Copyleft license is a general method for making a program or other work free, and requiring all modified and "
+"extended versions of the program to be free as well.)"
 msgstr ""
-"Free Software Foundation предоставляет краткие описания ключевых лицензий "
-"для открытого исходного кода, в том числе, является ли лицензия free "
-"software лицензией или copyleft лицензией. Также там располагается "
-"обсуждение того, что составляет собой free software лицензия или copyleft "
-"лицензия (например, Copyleft лицензия - это типичный метод перевода программ"
-" или других работ в разряд бесплатных, требующий, чтобы все изменённые и "
-"расширенные версии программ также были бесплатны)."
+"Free Software Foundation предоставляет краткие описания ключевых лицензий для открытого исходного кода, в том числе, является ли лицензия free software лицензией или copyleft лицензией. Также там "
+"располагается обсуждение того, что составляет собой free software лицензия или copyleft лицензия (например, Copyleft лицензия - это типичный метод перевода программ или других работ в разряд "
+"бесплатных, требующий, чтобы все изменённые и расширенные версии программ также были бесплатны)."
 
 #: src/olympia/pages/templates/pages/dev_faq.html:589
-msgid ""
-"Open Source Initiative provides the terms of some of the key open source "
-"licenses."
-msgstr ""
-"Open Source Initiative предоставляет условия некоторых из ключевых лицензий "
-"для открытого исходного кода."
+msgid "Open Source Initiative provides the terms of some of the key open source licenses."
+msgstr "Open Source Initiative предоставляет условия некоторых из ключевых лицензий для открытого исходного кода."
 
 #: src/olympia/pages/templates/pages/dev_faq.html:599
 msgid "A comparison of known open source licenses on Wikipedia."
-msgstr ""
-"Сравнение известных лицензий для открытого исходного кода в Википедии."
+msgstr "Сравнение известных лицензий для открытого исходного кода в Википедии."
 
 #: src/olympia/pages/templates/pages/dev_faq.html:605
-msgid ""
-"A site to provide non-judgmental guidance on choosing a license for your "
-"open source project."
-msgstr ""
-"Сайт, предоставляющий непредвзятое руководство по выбору лицензии для вашего"
-" проекта с открытым исходным кодом."
+msgid "A site to provide non-judgmental guidance on choosing a license for your open source project."
+msgstr "Сайт, предоставляющий непредвзятое руководство по выбору лицензии для вашего проекта с открытым исходным кодом."
 
-#: src/olympia/pages/templates/pages/faq.html:3
-#: src/olympia/pages/templates/pages/faq.html:9
-#: src/olympia/pages/templates/pages/faq.html:10
+#: src/olympia/pages/templates/pages/faq.html:3 src/olympia/pages/templates/pages/faq.html:9 src/olympia/pages/templates/pages/faq.html:10
 msgid "Frequently Asked Questions"
 msgstr "Часто задаваемые вопросы"
 
@@ -13086,19 +10276,12 @@ msgstr "Что такое дополнение? "
 #: src/olympia/pages/templates/pages/faq.html:16
 #, python-format
 msgid ""
-"Add-ons are small pieces of software that add new features or functionality "
-"to your installation of %(app_name)s. Add-ons can augment %(app_name)s with "
-"new features, foreign language dictionaries, or change its visual "
-"appearance. Through add-ons, you can customize %(app_name)s to meet your "
-"needs and tastes. <a href=\"%(learnmore_url)s\">Learn more about "
-"customization</a>"
+"Add-ons are small pieces of software that add new features or functionality to your installation of %(app_name)s. Add-ons can augment %(app_name)s with new features, foreign language dictionaries, "
+"or change its visual appearance. Through add-ons, you can customize %(app_name)s to meet your needs and tastes. <a href=\"%(learnmore_url)s\">Learn more about customization</a>"
 msgstr ""
-"Дополнения это небольшие программы, которые добавляют новые возможности или "
-"функциональность в установленный у вас %(app_name)s. Дополнения могут "
-"дополнять %(app_name)s новыми функциями, добавлять словари иностранного "
-"языка или изменять его внешний вид. Через дополнения вы можете настроить "
-"%(app_name)s по своему вкусу, чтобы удовлетворить свои потребности. <a "
-"href=\"%(learnmore_url)s\">Узнайте больше о настройке</a>"
+"Дополнения это небольшие программы, которые добавляют новые возможности или функциональность в установленный у вас %(app_name)s. Дополнения могут дополнять %(app_name)s новыми функциями, добавлять "
+"словари иностранного языка или изменять его внешний вид. Через дополнения вы можете настроить %(app_name)s по своему вкусу, чтобы удовлетворить свои потребности. <a href=\"%(learnmore_url)s"
+"\">Узнайте больше о настройке</a>"
 
 #: src/olympia/pages/templates/pages/faq.html:26
 msgid "Will add-ons work with my web browser or application?"
@@ -13107,25 +10290,14 @@ msgstr "Будут ли дополнения работать в моём веб
 #: src/olympia/pages/templates/pages/faq.html:27
 #, python-format
 msgid ""
-"Add-ons listed in this gallery only work with Mozilla-based applications, "
-"such as <a href=\"%(getfirefox_url)s\">Firefox</a>, <a "
-"href=\"%(getmobile_url)s\">Firefox Mobile</a>, <a "
-"href=\"%(getseamonkey_url)s\">SeaMonkey</a>, and <a "
-"href=\"%(getthunderbird_url)s\">Thunderbird</a>. However, not all add-ons "
-"work with each of those applications or every version of those applications."
-" Each add-on specifies which applications and versions it works with, such "
-"as Firefox 2.0 - 3.6.*. For Firefox add-ons, the install buttons will "
-"indicate whether the add-on is compatible or not."
+"Add-ons listed in this gallery only work with Mozilla-based applications, such as <a href=\"%(getfirefox_url)s\">Firefox</a>, <a href=\"%(getmobile_url)s\">Firefox Mobile</a>, <a href="
+"\"%(getseamonkey_url)s\">SeaMonkey</a>, and <a href=\"%(getthunderbird_url)s\">Thunderbird</a>. However, not all add-ons work with each of those applications or every version of those applications. "
+"Each add-on specifies which applications and versions it works with, such as Firefox 2.0 - 3.6.*. For Firefox add-ons, the install buttons will indicate whether the add-on is compatible or not."
 msgstr ""
-"Дополнения, показанные в этой галерее, работают только с приложениями на "
-"основе Mozilla, такими как <a href=\"%(getfirefox_url)s\">Firefox</a>, <a "
-"href=\"%(getmobile_url)s\">мобильный Firefox </a>, <a "
-"href=\"%(getseamonkey_url)s\">SeaMonkey</a> и <a "
-"href=\"%(getthunderbird_url)s\">Thunderbird</a>. Однако, не все дополнения "
-"работают с каждым из этих приложений или любой версией этих приложений. В "
-"каждом дополнении указано, с какими приложениями и версиями оно работает, "
-"например, Firefox 2.0 - 3.6 .*. Для дополнений Firefox кнопки установки "
-"будут указывать, совместимо ли дополнение или нет."
+"Дополнения, показанные в этой галерее, работают только с приложениями на основе Mozilla, такими как <a href=\"%(getfirefox_url)s\">Firefox</a>, <a href=\"%(getmobile_url)s\">мобильный Firefox </a>, "
+"<a href=\"%(getseamonkey_url)s\">SeaMonkey</a> и <a href=\"%(getthunderbird_url)s\">Thunderbird</a>. Однако, не все дополнения работают с каждым из этих приложений или любой версией этих "
+"приложений. В каждом дополнении указано, с какими приложениями и версиями оно работает, например, Firefox 2.0 - 3.6 .*. Для дополнений Firefox кнопки установки будут указывать, совместимо ли "
+"дополнение или нет."
 
 #: src/olympia/pages/templates/pages/faq.html:42
 msgid "What are the different types of add-ons?"
@@ -13133,78 +10305,44 @@ msgstr "Почему существуют разные типы дополнен
 
 #: src/olympia/pages/templates/pages/faq.html:43
 #, python-format
-msgid ""
-"There are several kinds of add-ons that customize %(app_name)s in different "
-"ways:"
-msgstr ""
-"Есть несколько типов дополнений по разному настраивающих %(app_name)s:"
+msgid "There are several kinds of add-ons that customize %(app_name)s in different ways:"
+msgstr "Есть несколько типов дополнений по разному настраивающих %(app_name)s:"
 
 #: src/olympia/pages/templates/pages/faq.html:47
 #, python-format
 msgid ""
-"<strong><a href=\"%(browse_url)s\">Extensions</a></strong> add new features "
-"to %(app_name)s or modify existing functionality. There are extensions that "
-"allow you to block advertisements, download videos from websites, integrate "
-"more closely with social websites, and add features you see in other "
-"applications."
+"<strong><a href=\"%(browse_url)s\">Extensions</a></strong> add new features to %(app_name)s or modify existing functionality. There are extensions that allow you to block advertisements, download "
+"videos from websites, integrate more closely with social websites, and add features you see in other applications."
 msgstr ""
-"<strong><a href=\"%(browse_url)s\">Расширения</a></strong> добавляют новые "
-"функции в %(app_name)s или изменяют существующую функциональность. "
-"Существуют расширения, которые позволяют блокировать рекламу, загружать "
-"видео с веб-сайтов, более тесно интегрироваться с социальными сетями и "
-"добавлять функции, которые вы видите в других приложениях."
+"<strong><a href=\"%(browse_url)s\">Расширения</a></strong> добавляют новые функции в %(app_name)s или изменяют существующую функциональность. Существуют расширения, которые позволяют блокировать "
+"рекламу, загружать видео с веб-сайтов, более тесно интегрироваться с социальными сетями и добавлять функции, которые вы видите в других приложениях."
 
 #: src/olympia/pages/templates/pages/faq.html:55
 #, python-format
-msgid ""
-"<strong><a href=\"%(browse_url)s\">Complete Themes</a></strong> change the "
-"entire appearance of %(app_name)s, usually including icons, colors, dialogs,"
-" and other visual styles."
-msgstr ""
-"<strong><a href=\"%(browse_url)s\">Полные темы</a></strong> целиком меняют "
-"внешний вид %(app_name)s, включая, как правило, значки, цвета, диалоговые "
-"окна и другие визуальные стили."
+msgid "<strong><a href=\"%(browse_url)s\">Complete Themes</a></strong> change the entire appearance of %(app_name)s, usually including icons, colors, dialogs, and other visual styles."
+msgstr "<strong><a href=\"%(browse_url)s\">Полные темы</a></strong> целиком меняют внешний вид %(app_name)s, включая, как правило, значки, цвета, диалоговые окна и другие визуальные стили."
 
 #: src/olympia/pages/templates/pages/faq.html:61
 #, python-format
-msgid ""
-"<strong><a href=\"%(browse_url)s\">Themes</a></strong> are lightweight "
-"themes that use background images to customize your %(app_name)s toolbars."
-msgstr ""
-"<strong><a href=\"%(browse_url)s\">Темы</a></strong> это легкие темы, "
-"которые используют фоновые изображения для настройки панелей инструментов "
-"вашего %(app_name)s."
+msgid "<strong><a href=\"%(browse_url)s\">Themes</a></strong> are lightweight themes that use background images to customize your %(app_name)s toolbars."
+msgstr "<strong><a href=\"%(browse_url)s\">Темы</a></strong> это легкие темы, которые используют фоновые изображения для настройки панелей инструментов вашего %(app_name)s."
 
 #: src/olympia/pages/templates/pages/faq.html:66
 #, python-format
-msgid ""
-"<strong><a href=\"%(browse_url)s\">Search Providers</a> </strong> add "
-"additional choices to the search box dropdown. These providers allow you to "
-"quickly search any website."
+msgid "<strong><a href=\"%(browse_url)s\">Search Providers</a> </strong> add additional choices to the search box dropdown. These providers allow you to quickly search any website."
 msgstr ""
-"<strong><a href=\"%(browse_url)s\">Инструменты поиска</a> </strong> "
-"добавляют дополнительные варианты в выпадающий список панели поиска. Эти "
-"инструменты позволяют вам быстро произвести поиск на любом веб-сайте."
+"<strong><a href=\"%(browse_url)s\">Инструменты поиска</a> </strong> добавляют дополнительные варианты в выпадающий список панели поиска. Эти инструменты позволяют вам быстро произвести поиск на "
+"любом веб-сайте."
 
 #: src/olympia/pages/templates/pages/faq.html:72
 #, python-format
-msgid ""
-"<strong><a href=\"%(browse_url)s\">Dictionaries & Language "
-"Packs</a></strong> add support for additional languages to %(app_name)s."
-msgstr ""
-"<strong><a href=\"%(browse_url)s\">Словари и локализации</a></strong> "
-"добавляют поддержку дополнительных языков в %(app_name)s."
+msgid "<strong><a href=\"%(browse_url)s\">Dictionaries & Language Packs</a></strong> add support for additional languages to %(app_name)s."
+msgstr "<strong><a href=\"%(browse_url)s\">Словари и локализации</a></strong> добавляют поддержку дополнительных языков в %(app_name)s."
 
 #: src/olympia/pages/templates/pages/faq.html:77
 #, python-format
-msgid ""
-"<strong><a href=\"%(browse_url)s\">Plugins</a></strong> help %(app_name)s "
-"display or understand different types of media, such as Adobe Flash or Apple"
-" Quicktime."
-msgstr ""
-"<strong><a href=\"%(browse_url)s\">Плагины</a></strong> помогают "
-"%(app_name)s отображать или понимать различные типы медиа, такие как Adobe "
-"Flash или Apple Quicktime."
+msgid "<strong><a href=\"%(browse_url)s\">Plugins</a></strong> help %(app_name)s display or understand different types of media, such as Adobe Flash or Apple Quicktime."
+msgstr "<strong><a href=\"%(browse_url)s\">Плагины</a></strong> помогают %(app_name)s отображать или понимать различные типы медиа, такие как Adobe Flash или Apple Quicktime."
 
 #: src/olympia/pages/templates/pages/faq.html:85
 msgid "How do I install, manage, or remove an add-on?"
@@ -13213,22 +10351,13 @@ msgstr "Как мне устанавливать, управлять или уд
 #: src/olympia/pages/templates/pages/faq.html:86
 #, python-format
 msgid ""
-"In most cases, add-ons can be installed by simply clicking the install "
-"button provided. Add-ons can be managed, disabled, or uninstalled from the "
-"Add-ons Manager in %(app_name)s. For more detailed instructions, read <a "
-"href=\"%(extension_url)s\">this article on extensions</a> or <a "
-"href=\"%(theme_url)s\">this one for Themes and Complete Themes</a>. If you "
-"have difficulty installing add-ons, see <a "
-"href=\"%(troubleshooting_url)s\">Troubleshooting Extensions and Themes</a>."
+"In most cases, add-ons can be installed by simply clicking the install button provided. Add-ons can be managed, disabled, or uninstalled from the Add-ons Manager in %(app_name)s. For more detailed "
+"instructions, read <a href=\"%(extension_url)s\">this article on extensions</a> or <a href=\"%(theme_url)s\">this one for Themes and Complete Themes</a>. If you have difficulty installing add-ons, "
+"see <a href=\"%(troubleshooting_url)s\">Troubleshooting Extensions and Themes</a>."
 msgstr ""
-"В большинстве случаев дополнения можно установить, просто щёлкнув по кнопке "
-"установки. Дополнениями можно управлять, отключать или удалять через окно "
-"управления Дополнениями в %(app_name)s. Для получения более подробных "
-"инструкций, прочтите <a href=\"%(extension_url)s\">эту статью по "
-"расширениям</a> или <a href=\"%(theme_url)s\">эту по темам и полным "
-"темам</a>. Если у вас возникли трудности при установке дополнений, прочтите "
-"статью <a href=\"%(troubleshooting_url)s\">Решение проблем с расширениями и "
-"темами</a>."
+"В большинстве случаев дополнения можно установить, просто щёлкнув по кнопке установки. Дополнениями можно управлять, отключать или удалять через окно управления Дополнениями в %(app_name)s. Для "
+"получения более подробных инструкций, прочтите <a href=\"%(extension_url)s\">эту статью по расширениям</a> или <a href=\"%(theme_url)s\">эту по темам и полным темам</a>. Если у вас возникли "
+"трудности при установке дополнений, прочтите статью <a href=\"%(troubleshooting_url)s\">Решение проблем с расширениями и темами</a>."
 
 #: src/olympia/pages/templates/pages/faq.html:100
 msgid "How do I install add-ons without restarting Firefox?"
@@ -13237,17 +10366,11 @@ msgstr "Как мне установить дополнения не перез�
 #: src/olympia/pages/templates/pages/faq.html:101
 #, python-format
 msgid ""
-"In Firefox, add-ons marked with \"No restart required\" can be installed "
-"without restarting. These add-ons have been created using the <a "
-"href=\"%(sdk_url)s\">Add-on SDK</a> or <a "
-"href=\"%(bootstrap_url)s\">bootstrapping</a>. Other add-ons will still "
-"require a restart before you can use them."
+"In Firefox, add-ons marked with \"No restart required\" can be installed without restarting. These add-ons have been created using the <a href=\"%(sdk_url)s\">Add-on SDK</a> or <a href="
+"\"%(bootstrap_url)s\">bootstrapping</a>. Other add-ons will still require a restart before you can use them."
 msgstr ""
-"В Firefox, дополнения с меткой \"Не требует перезапуска\" могут быть "
-"установлены без перезапуска браузера. Эти дополнения были созданы с помощью "
-"<a href=\"%(sdk_url)s\">Add-on SDK</a> или <a "
-"href=\"%(bootstrap_url)s\">bootstrapping</a>. Другие дополнения по-прежнему "
-"будут требовать перезапуска перед тем, как вы сможете их использовать."
+"В Firefox, дополнения с меткой \"Не требует перезапуска\" могут быть установлены без перезапуска браузера. Эти дополнения были созданы с помощью <a href=\"%(sdk_url)s\">Add-on SDK</a> или <a href="
+"\"%(bootstrap_url)s\">bootstrapping</a>. Другие дополнения по-прежнему будут требовать перезапуска перед тем, как вы сможете их использовать."
 
 #: src/olympia/pages/templates/pages/faq.html:110
 msgid "How do I keep add-ons up-to-date?"
@@ -13256,22 +10379,13 @@ msgstr "Как мне всегда иметь свежие версии допо
 #: src/olympia/pages/templates/pages/faq.html:111
 #, python-format
 msgid ""
-"Add-ons, unlike plugins, are automatically checked for updates once every "
-"day. In Firefox, updates are automatically installed by default. Versions of"
-" Firefox prior to 4 (and other applications) will alert you that updates to "
-"your add-ons are available. <a href=\"%(plugin_url)s\">Plugins</a> are not "
-"currently automatically checked for updates, so be sure to regularly visit "
-"the <a href=\"%(plugincheck_url)s\">Plugin Check</a> page to stay up-to-"
-"date."
+"Add-ons, unlike plugins, are automatically checked for updates once every day. In Firefox, updates are automatically installed by default. Versions of Firefox prior to 4 (and other applications) "
+"will alert you that updates to your add-ons are available. <a href=\"%(plugin_url)s\">Plugins</a> are not currently automatically checked for updates, so be sure to regularly visit the <a href="
+"\"%(plugincheck_url)s\">Plugin Check</a> page to stay up-to-date."
 msgstr ""
-"Дополнения, в отличие от плагинов, автоматически проверяются на наличие "
-"обновлений один раз в день. По умолчанию в Firefox обновления "
-"устанавливаются автоматически. Firefox с версией ниже 4 (и другие "
-"приложения) будут уведомлять вас, что для ваших дополнений доступны "
-"обновления. <a href=\"%(plugin_url)s\">Плагины</a> в настоящее время не "
-"проверяются автоматически на наличие обновлений, поэтому вам следует "
-"регулярно посещать страницу <a href=\"%(plugincheck_url)s\">Проверки "
-"плагинов</a> для поддержания их в актуальном состоянии."
+"Дополнения, в отличие от плагинов, автоматически проверяются на наличие обновлений один раз в день. По умолчанию в Firefox обновления устанавливаются автоматически. Firefox с версией ниже 4 (и "
+"другие приложения) будут уведомлять вас, что для ваших дополнений доступны обновления. <a href=\"%(plugin_url)s\">Плагины</a> в настоящее время не проверяются автоматически на наличие обновлений, "
+"поэтому вам следует регулярно посещать страницу <a href=\"%(plugincheck_url)s\">Проверки плагинов</a> для поддержания их в актуальном состоянии."
 
 #: src/olympia/pages/templates/pages/faq.html:122
 msgid "Are add-ons safe to install?"
@@ -13280,20 +10394,13 @@ msgstr "Безопасно ли устанавливать дополнения?
 #: src/olympia/pages/templates/pages/faq.html:123
 #, python-format
 msgid ""
-"Unless clearly marked otherwise, add-ons available from this gallery have "
-"been checked and approved by Mozilla's team of editors and are safe to "
-"install. We recommend that you only install approved add-ons. If you wish to"
-" install unapproved add-ons or add-ons from third-party websites, use "
-"caution as these add-ons may harm your computer or violate your privacy. <a "
-"href=\"%(learnmore_url)s\">Learn more about our approval process</a>"
+"Unless clearly marked otherwise, add-ons available from this gallery have been checked and approved by Mozilla's team of editors and are safe to install. We recommend that you only install approved "
+"add-ons. If you wish to install unapproved add-ons or add-ons from third-party websites, use caution as these add-ons may harm your computer or violate your privacy. <a href=\"%(learnmore_url)s"
+"\">Learn more about our approval process</a>"
 msgstr ""
-"Если явно не указано обратное, дополнения, доступные в этой галерее были "
-"проверены и одобрены командой редакторов Mozilla и безопасны для установки. "
-"Мы рекомендуем вам устанавливать только одобренные дополнения. Если вы "
-"хотите установить неодобренные дополнения или дополнения со сторонних веб-"
-"сайтов, соблюдайте осторожность, так как эти дополнения могут нанести вред "
-"вашему компьютеру или нарушить вашу приватность. <a "
-"href=\"%(learnmore_url)s\">Узнайте больше о нашем процессе проверки</a>"
+"Если явно не указано обратное, дополнения, доступные в этой галерее были проверены и одобрены командой редакторов Mozilla и безопасны для установки. Мы рекомендуем вам устанавливать только "
+"одобренные дополнения. Если вы хотите установить неодобренные дополнения или дополнения со сторонних веб-сайтов, соблюдайте осторожность, так как эти дополнения могут нанести вред вашему компьютеру "
+"или нарушить вашу приватность. <a href=\"%(learnmore_url)s\">Узнайте больше о нашем процессе проверки</a>"
 
 #: src/olympia/pages/templates/pages/faq.html:133
 #, python-format
@@ -13303,46 +10410,28 @@ msgstr "Могут ли дополнения замедлить работу %(a
 #: src/olympia/pages/templates/pages/faq.html:135
 #, python-format
 msgid ""
-"Most add-ons do not cause a perceivable performance decrease in "
-"%(app_name)s, though installing an excessive number may have adverse "
-"effects. If you suspect an add-on is causing %(app_name)s to be slow, try "
-"disabling it."
+"Most add-ons do not cause a perceivable performance decrease in %(app_name)s, though installing an excessive number may have adverse effects. If you suspect an add-on is causing %(app_name)s to be "
+"slow, try disabling it."
 msgstr ""
-"Большинство дополнений не вызывают явного уменьшения производительности "
-"%(app_name)s, хотя установка их чрезмерного количества может иметь "
-"неблагоприятные последствия. Если вы подозреваете, что дополнение замедляет "
-"%(app_name)s, попробуйте его отключить."
+"Большинство дополнений не вызывают явного уменьшения производительности %(app_name)s, хотя установка их чрезмерного количества может иметь неблагоприятные последствия. Если вы подозреваете, что "
+"дополнение замедляет %(app_name)s, попробуйте его отключить."
 
 #: src/olympia/pages/templates/pages/faq.html:141
 #, python-format
-msgid ""
-"%(app_name)s told me an add-on isn't compatible. Is there a way I can still "
-"use it?"
-msgstr ""
-"%(app_name)s сказал мне, что дополнение не совместимо. Могу ли я как-то "
-"продолжить его использовать?"
+msgid "%(app_name)s told me an add-on isn't compatible. Is there a way I can still use it?"
+msgstr "%(app_name)s сказал мне, что дополнение не совместимо. Могу ли я как-то продолжить его использовать?"
 
 #: src/olympia/pages/templates/pages/faq.html:144
 #, python-format
 msgid ""
-"If an add-on isn't compatible with your version of %(app_name)s, it is "
-"usually either because your version of %(app_name)s is outdated or the add-"
-"on author has not yet updated the add-on to be compatible with a newer "
-"version you are using. Mozilla does not recommend trying to circumvent these"
-" compatibility checks, as they can lead to browser instability or in some "
-"cases loss of data. For users who are testing out alpha or beta versions of "
-"Firefox, we offer the <a href=\"%(acr_url)s\">Add-on Compatibility "
-"Reporter</a> to help add-on developers update their compatibility."
+"If an add-on isn't compatible with your version of %(app_name)s, it is usually either because your version of %(app_name)s is outdated or the add-on author has not yet updated the add-on to be "
+"compatible with a newer version you are using. Mozilla does not recommend trying to circumvent these compatibility checks, as they can lead to browser instability or in some cases loss of data. For "
+"users who are testing out alpha or beta versions of Firefox, we offer the <a href=\"%(acr_url)s\">Add-on Compatibility Reporter</a> to help add-on developers update their compatibility."
 msgstr ""
-"Если дополнение не совместимо с вашей версией %(app_name)s, то как правило "
-"это означает, что либо ваша версия %(app_name)s устарела, либо автор "
-"дополнения ещё не обновил дополнение, добавив в него совместимость с "
-"используемой вами новой версией. Mozilla не рекомендует пытаться обойти эти "
-"проверки совместимости, так как это может привести к нестабильности браузера"
-" или в некоторых случаях к потере данных. Для пользователей, которые "
-"тестируют альфа или бета версии Firefox, мы предлагаем установить <a "
-"href=\"%(acr_url)s\">Add-on Compatibility Reporter</a>, чтобы помочь "
-"разработчикам дополнений обновить их совместимость."
+"Если дополнение не совместимо с вашей версией %(app_name)s, то как правило это означает, что либо ваша версия %(app_name)s устарела, либо автор дополнения ещё не обновил дополнение, добавив в него "
+"совместимость с используемой вами новой версией. Mozilla не рекомендует пытаться обойти эти проверки совместимости, так как это может привести к нестабильности браузера или в некоторых случаях к "
+"потере данных. Для пользователей, которые тестируют альфа или бета версии Firefox, мы предлагаем установить <a href=\"%(acr_url)s\">Add-on Compatibility Reporter</a>, чтобы помочь разработчикам "
+"дополнений обновить их совместимость."
 
 #: src/olympia/pages/templates/pages/faq.html:156
 msgid "What if I have problems with an add-on?"
@@ -13351,49 +10440,32 @@ msgstr "Что если у меня возникла проблема с доп�
 #: src/olympia/pages/templates/pages/faq.html:157
 #, python-format
 msgid ""
-"Add-ons are usually created by third-party developers from around the world,"
-" so the best way to get help with an add-on is to look for support links on "
-"the add-on's homepage or contact the developer. If you are having issues "
-"with %(app_name)s that you suspect are related to add-ons you have "
-"installed, <a href=\"%(troubleshooting_url)s\">visit this support "
-"article</a> for troubleshooting tips."
+"Add-ons are usually created by third-party developers from around the world, so the best way to get help with an add-on is to look for support links on the add-on's homepage or contact the "
+"developer. If you are having issues with %(app_name)s that you suspect are related to add-ons you have installed, <a href=\"%(troubleshooting_url)s\">visit this support article</a> for "
+"troubleshooting tips."
 msgstr ""
-"Дополнения, как правило, создаются сторонними разработчиками со всего мира, "
-"поэтому наилучший способ получить помощь по дополнению это поискать ссылки "
-"для получения поддержки на домашней странице дополнения или связаться с "
-"разработчиком. Если у вас возникли проблемы с %(app_name)s, которые, как вы "
-"подозреваете, относятся к установленным у вас дополнениям, <a "
-"href=\"%(troubleshooting_url)s\">прочтите эту статью поддержки</a>, чтобы "
-"получить советы по устранению неполадок."
+"Дополнения, как правило, создаются сторонними разработчиками со всего мира, поэтому наилучший способ получить помощь по дополнению это поискать ссылки для получения поддержки на домашней странице "
+"дополнения или связаться с разработчиком. Если у вас возникли проблемы с %(app_name)s, которые, как вы подозреваете, относятся к установленным у вас дополнениям, <a href=\"%(troubleshooting_url)s"
+"\">прочтите эту статью поддержки</a>, чтобы получить советы по устранению неполадок."
 
 #: src/olympia/pages/templates/pages/faq.html:169
 msgid "Add-on Gallery"
 msgstr "Галерея дополнений"
 
 #: src/olympia/pages/templates/pages/faq.html:171
-msgid ""
-"How do I choose between add-ons that seem to do the same\n"
-"    thing?"
+msgid "How do I choose between add-ons that seem to do the same thing?"
 msgstr ""
 "Как мне выбрать между дополнениями, которые похоже делают\n"
 "    одно и то же?"
 
-#: src/olympia/pages/templates/pages/faq.html:173
+#: src/olympia/pages/templates/pages/faq.html:172
 msgid ""
-"There are often several add-ons that have similar features. To figure out "
-"which is right for you, read the entire description of the add-on and view "
-"its screenshots. If there are still several in the running, read through the"
-" add-on's ratings, user reviews, and statistics to see which is most liked "
-"by other users. Remember that you can also just try out both and see which "
-"you like better."
+"There are often several add-ons that have similar features. To figure out which is right for you, read the entire description of the add-on and view its screenshots. If there are still several in "
+"the running, read through the add-on's ratings, user reviews, and statistics to see which is most liked by other users. Remember that you can also just try out both and see which you like better."
 msgstr ""
-"Часто существуют несколько дополнений, имеющих схожие функции. Чтобы "
-"выяснить, какое из них вам больше подходит, прочтите полное описание "
-"дополнений и просмотрите их скриншоты. Если у вас ещё осталось несколько "
-"кандидатов, просмотрите рейтинги дополнений, отзывы пользователей и данные "
-"статистики, чтобы узнать какое из них больше всего нравится другим "
-"пользователям. Помните, что вы также можете просто попробовать оба и "
-"посмотреть, какое из них вам больше нравится."
+"Часто существуют несколько дополнений, имеющих схожие функции. Чтобы выяснить, какое из них вам больше подходит, прочтите полное описание дополнений и просмотрите их скриншоты. Если у вас ещё "
+"осталось несколько кандидатов, просмотрите рейтинги дополнений, отзывы пользователей и данные статистики, чтобы узнать какое из них больше всего нравится другим пользователям. Помните, что вы также "
+"можете просто попробовать оба и посмотреть, какое из них вам больше нравится."
 
 #: src/olympia/pages/templates/pages/faq.html:180
 msgid "What if I can't find an add-on I'm looking for?"
@@ -13402,39 +10474,24 @@ msgstr "Что если я не могу найти дополнение кот�
 #: src/olympia/pages/templates/pages/faq.html:181
 #, python-format
 msgid ""
-"With thousands of add-ons available, there's something for everyone. But if "
-"you're looking for a particular add-on and can't find it, you might try "
-"searching on other sites or posting about it in our <a href=\"%(forum_url)s"
-"\">Add-ons </a>forum."
+"With thousands of add-ons available, there's something for everyone. But if you're looking for a particular add-on and can't find it, you might try searching on other sites or posting about it in "
+"our <a href=\"%(forum_url)s\">Add-ons </a>forum."
 msgstr ""
-"С тысячами доступных дополнений, что-нибудь найдется для каждого. Но если вы"
-" ищете конкретное дополнение и не может его найти, вы можете попытаться "
-"найти его на других сайтах или написать о нём на нашем форуме <a "
-"href=\"%(forum_url)s\">Дополнения</a>."
+"С тысячами доступных дополнений, что-нибудь найдется для каждого. Но если вы ищете конкретное дополнение и не может его найти, вы можете попытаться найти его на других сайтах или написать о нём на "
+"нашем форуме <a href=\"%(forum_url)s\">Дополнения</a>."
 
 #: src/olympia/pages/templates/pages/faq.html:187
-msgid ""
-"What does it mean if an add-on is \"experimental\" or \"preliminarily "
-"reviewed\"?"
-msgstr ""
-"Что это значит когда дополнение \"экспериментальное\" или \"предварительно "
-"проверенное\"?"
+msgid "What does it mean if an add-on is \"experimental\" or \"preliminarily reviewed\"?"
+msgstr "Что это значит когда дополнение \"экспериментальное\" или \"предварительно проверенное\"?"
 
 #: src/olympia/pages/templates/pages/faq.html:188
 #, python-format
 msgid ""
-"Experimental add-ons have been checked by our editors to make sure they "
-"don't have security problems, but they may still have bugs or not work "
-"properly. Use caution when installing experimental add-ons and uninstall the"
-" add-on immediately if you notice problems. <a href=\"%(url)s\">Learn more "
-"about our review process</a></dd>"
+"Experimental add-ons have been checked by our editors to make sure they don't have security problems, but they may still have bugs or not work properly. Use caution when installing experimental add-"
+"ons and uninstall the add-on immediately if you notice problems. <a href=\"%(url)s\">Learn more about our review process</a></dd>"
 msgstr ""
-"Экспериментальные дополнения были проверены нашими редакторами, чтобы "
-"убедиться, что они не имеют проблем с безопасностью, но всё же они могут "
-"содержать ошибки или не работать должным образом. Будьте осторожны при "
-"установке экспериментальных дополнений и немедленно удаляйте дополнения, "
-"если вы заметите проблемы. <a href=\"%(url)s\">Узнайте больше о нашем "
-"процессе проверки</a></dd>"
+"Экспериментальные дополнения были проверены нашими редакторами, чтобы убедиться, что они не имеют проблем с безопасностью, но всё же они могут содержать ошибки или не работать должным образом. "
+"Будьте осторожны при установке экспериментальных дополнений и немедленно удаляйте дополнения, если вы заметите проблемы. <a href=\"%(url)s\">Узнайте больше о нашем процессе проверки</a></dd>"
 
 #: src/olympia/pages/templates/pages/faq.html:196
 msgid "What does it mean if an add-on is \"not reviewed\"?"
@@ -13443,273 +10500,191 @@ msgstr "Что это значит когда дополнение \"не про
 #: src/olympia/pages/templates/pages/faq.html:197
 #, python-format
 msgid ""
-"While all add-ons publicly available in our gallery are reviewed by an "
-"editor, you may receive a direct link to an add-on that hasn't yet been "
-"reviewed. Use caution when installing these add-ons, as they could harm your"
-" computer or violate your privacy. We recommend that you only install "
-"reviewed add-ons. <a href=\"%(url)s\">Learn more about our review "
-"process</a></dd>"
+"While all add-ons publicly available in our gallery are reviewed by an editor, you may receive a direct link to an add-on that hasn't yet been reviewed. Use caution when installing these add-ons, "
+"as they could harm your computer or violate your privacy. We recommend that you only install reviewed add-ons. <a href=\"%(url)s\">Learn more about our review process</a></dd>"
 msgstr ""
-"Хотя все дополнения, публично доступные в нашей галерее, были проверены "
-"редакторами, вы всё же можете получить прямую ссылку на дополнение, которое "
-"пока не было проверено. Будьте осторожны при установке этих дополнений, так "
-"как они могут нанести вред вашему компьютеру или нарушить вашу приватность. "
-"Мы рекомендуем вам устанавливать только проверенные дополнения. <a "
-"href=\"%(url)s\">Узнайте больше о нашем процессе проверки</a></dd>"
+"Хотя все дополнения, публично доступные в нашей галерее, были проверены редакторами, вы всё же можете получить прямую ссылку на дополнение, которое пока не было проверено. Будьте осторожны при "
+"установке этих дополнений, так как они могут нанести вред вашему компьютеру или нарушить вашу приватность. Мы рекомендуем вам устанавливать только проверенные дополнения. <a href=\"%(url)s"
+"\">Узнайте больше о нашем процессе проверки</a></dd>"
 
 #: src/olympia/pages/templates/pages/faq.html:206
 msgid "How much do add-ons cost to purchase?"
 msgstr "Сколько стоят дополнения?"
 
 #: src/olympia/pages/templates/pages/faq.html:207
-msgid ""
-"Add-ons hosted in our gallery are free unless clearly marked\n"
-"    otherwise."
+msgid "Add-ons hosted in our gallery are free unless clearly marked otherwise."
 msgstr ""
 "Дополнения, размещённые в нашей галерее, бесплатны, если явно не указано\n"
 "    обратное."
 
-#: src/olympia/pages/templates/pages/faq.html:210
+#: src/olympia/pages/templates/pages/faq.html:209
 msgid "What does it mean when an add-on asks for contributions?"
 msgstr "Что это значит когда дополнение просит сделать взнос?"
 
-#: src/olympia/pages/templates/pages/faq.html:211
+#: src/olympia/pages/templates/pages/faq.html:210
 msgid ""
-"Some add-on authors request users who enjoy an add-on to contribute to its "
-"development by making a monetary contribution. These contributions go "
-"directly to the developer unless a third party is indicated, such as the "
-"non-profit Mozilla Foundation."
+"Some add-on authors request users who enjoy an add-on to contribute to its development by making a monetary contribution. These contributions go directly to the developer unless a third party is "
+"indicated, such as the non-profit Mozilla Foundation."
 msgstr ""
-"Некоторые авторы дополнений просят пользователей, которым нравится их "
-"дополнения, внести свой вклад в его развитие, сделав денежный взнос. Эти "
-"взносы идут напрямую разработчику, если только не указана третья сторона, "
-"такая как некоммерческая Mozilla Foundation."
+"Некоторые авторы дополнений просят пользователей, которым нравится их дополнения, внести свой вклад в его развитие, сделав денежный взнос. Эти взносы идут напрямую разработчику, если только не "
+"указана третья сторона, такая как некоммерческая Mozilla Foundation."
 
-#: src/olympia/pages/templates/pages/faq.html:216
+#: src/olympia/pages/templates/pages/faq.html:215
 msgid "What are beta add-ons?"
 msgstr "Что такое бета-дополнения?"
 
-#: src/olympia/pages/templates/pages/faq.html:218
+#: src/olympia/pages/templates/pages/faq.html:217
 msgid ""
-"Beta add-ons are unreviewed versions which represent the latest work of an "
-"add-on author. While different authors have different standards for beta "
-"code quality, you should assume that these add-ons are less stable than the "
-"general add-on releases."
+"Beta add-ons are unreviewed versions which represent the latest work of an add-on author. While different authors have different standards for beta code quality, you should assume that these add-"
+"ons are less stable than the general add-on releases."
 msgstr ""
-"Бета-версии дополнений это непроверенные версии дополнений, которые "
-"представляют собой последнюю сборку выпущенную автором дополнения. Хотя "
-"разные авторы имеют разные стандарты качества для кода бета-версии, вам "
-"следует предполагать, что эти дополнения менее стабильны, чем обычные релизы"
-" дополнений."
+"Бета-версии дополнений это непроверенные версии дополнений, которые представляют собой последнюю сборку выпущенную автором дополнения. Хотя разные авторы имеют разные стандарты качества для кода "
+"бета-версии, вам следует предполагать, что эти дополнения менее стабильны, чем обычные релизы дополнений."
 
-#: src/olympia/pages/templates/pages/faq.html:222
+#: src/olympia/pages/templates/pages/faq.html:221
 msgid ""
-"Please note that when you install an add-on from the \"Beta Version\" "
-"section of an add-on's listing, you will continue to receive updates for "
-"that add-on as they become available. Like the initial version you "
-"installed, all beta releases are unreviewed by Mozilla and may harm your "
-"computer."
+"Please note that when you install an add-on from the \"Beta Version\" section of an add-on's listing, you will continue to receive updates for that add-on as they become available. Like the initial "
+"version you installed, all beta releases are unreviewed by Mozilla and may harm your computer."
 msgstr ""
-"Пожалуйста, обратите внимание, что когда вы устанавливаете дополнение из "
-"раздела \"Бета-версия\" страницы дополнения, вы будете продолжать получать "
-"обновления для этого дополнения, как только они станут доступны. Как и в "
-"случае первоначальной установленной вами версии, все бета-версии не "
-"проверены Mozilla и могут нанести вред вашему компьютеру."
+"Пожалуйста, обратите внимание, что когда вы устанавливаете дополнение из раздела \"Бета-версия\" страницы дополнения, вы будете продолжать получать обновления для этого дополнения, как только они "
+"станут доступны. Как и в случае первоначальной установленной вами версии, все бета-версии не проверены Mozilla и могут нанести вред вашему компьютеру."
 
-#: src/olympia/pages/templates/pages/faq.html:229
-msgid ""
-"What does it mean when an add-on is flagged as\n"
-"    slow?"
+#: src/olympia/pages/templates/pages/faq.html:228
+msgid "What does it mean when an add-on is flagged as slow?"
 msgstr ""
 "Что значит, когда дополнение отмечено как\n"
 "    медленное?"
 
-#: src/olympia/pages/templates/pages/faq.html:231
-msgid ""
-"Most add-ons load code and resources at the same time Firefox\n"
-"        is starting up. In most cases the impact in start-up time is minimal,\n"
-"        but some add-ons can cause a noticeable slowdown."
+#: src/olympia/pages/templates/pages/faq.html:229
+msgid "Most add-ons load code and resources at the same time Firefox is starting up. In most cases the impact in start-up time is minimal, but some add-ons can cause a noticeable slowdown."
 msgstr ""
 "Многие дополнения загружают код и ресурсы во время\n"
 "        запуска Firefox. В большинстве случаев их воздействие на запуск минимально,\n"
 "        но некоторые дополнения могут быть причиной заметного замедления."
 
-#: src/olympia/pages/templates/pages/faq.html:236
+#: src/olympia/pages/templates/pages/faq.html:234
 msgid "How do I report an inappropriate or spam user review?"
 msgstr "Как мне сообщить о неприемлемом отзыве пользователя или спаме?"
 
-#: src/olympia/pages/templates/pages/faq.html:237
+#: src/olympia/pages/templates/pages/faq.html:235
 msgid ""
-"To report a user review of an add-on, log in with your account and visit the"
-" add-on's reviews page. Find the review you wish to report, click \"Report "
-"this review\" and select a reason. Our editorial team will investigate the "
-"review and take appropriate action."
+"To report a user review of an add-on, log in with your account and visit the add-on's reviews page. Find the review you wish to report, click \"Report this review\" and select a reason. Our "
+"editorial team will investigate the review and take appropriate action."
 msgstr ""
-"Чтобы сообщить об отзыве пользователя на дополнение, войдите в систему под "
-"своей учетной записью и посетите страницу отзывов на дополнение. Найти "
-"отзыв, о котором вы хотите сообщить, щёлкните по ссылке \"Сообщить об этом "
-"отзыве\" и выберите причину. Наша команда редакторов рассмотрит отзыв и "
-"примет соответствующие меры."
+"Чтобы сообщить об отзыве пользователя на дополнение, войдите в систему под своей учетной записью и посетите страницу отзывов на дополнение. Найти отзыв, о котором вы хотите сообщить, щёлкните по "
+"ссылке \"Сообщить об этом отзыве\" и выберите причину. Наша команда редакторов рассмотрит отзыв и примет соответствующие меры."
 
-#: src/olympia/pages/templates/pages/faq.html:242
+#: src/olympia/pages/templates/pages/faq.html:240
 msgid "How do I report a bug or contact the Mozilla Add-ons team?"
-msgstr ""
-"Как мне сообщить об ошибке или связаться с командой сайта дополнений "
-"Mozilla?"
+msgstr "Как мне сообщить об ошибке или связаться с командой сайта дополнений Mozilla?"
 
-#: src/olympia/pages/templates/pages/faq.html:243
+#: src/olympia/pages/templates/pages/faq.html:241
 #, python-format
 msgid "Please visit our <a href=\"%(contact_url)s\">Contact page</a>."
-msgstr ""
-"Пожалуйста, посетите нашу <a href=\"%(contact_url)s\">Страницу с контактной "
-"информацией</a>."
+msgstr "Пожалуйста, посетите нашу <a href=\"%(contact_url)s\">Страницу с контактной информацией</a>."
 
-#: src/olympia/pages/templates/pages/faq.html:246
+#: src/olympia/pages/templates/pages/faq.html:244
 msgid "What is a Source Code License?"
 msgstr "Что такое лицензия на исходный код?"
 
-#: src/olympia/pages/templates/pages/faq.html:247
+#: src/olympia/pages/templates/pages/faq.html:245
 #, python-format
 msgid ""
-"The source code used to create an add-on is an exclusive copyright of the "
-"add-on author, unless otherwise declared in a source code license. Many add-"
-"ons on this site have <a href=\"%(url)s\" lang=\"en\">open source "
-"licenses</a> that make the source code publicly available for copy and reuse"
-" under conditions determined by the author. Most authors choose widely known"
-" open source licenses like the GPL or BSD licenses instead of making up "
-"their own."
+"The source code used to create an add-on is an exclusive copyright of the add-on author, unless otherwise declared in a source code license. Many add-ons on this site have <a href=\"%(url)s\" lang="
+"\"en\">open source licenses</a> that make the source code publicly available for copy and reuse under conditions determined by the author. Most authors choose widely known open source licenses like "
+"the GPL or BSD licenses instead of making up their own."
 msgstr ""
-"Автор дополнения имеет эксклюзивное авторское право на исходный код, "
-"использованный для создания дополнения, если иное не объявлено в лицензии "
-"исходного кода. Многие дополнения на этом сайте выложены под <a "
-"href=\"%(url)s\" lang=\"en\">лицензиями открытого исходного кода</a>, что "
-"делает исходный код публично доступным для копирования и повторного "
-"использования на условиях, установленных автором. Большинство авторов "
-"выбирают широко известные открытые лицензии, такие как лицензии GPL или BSD,"
-" вместо того, чтобы изобретать свои собственные лицензии."
+"Автор дополнения имеет эксклюзивное авторское право на исходный код, использованный для создания дополнения, если иное не объявлено в лицензии исходного кода. Многие дополнения на этом сайте "
+"выложены под <a href=\"%(url)s\" lang=\"en\">лицензиями открытого исходного кода</a>, что делает исходный код публично доступным для копирования и повторного использования на условиях, "
+"установленных автором. Большинство авторов выбирают широко известные открытые лицензии, такие как лицензии GPL или BSD, вместо того, чтобы изобретать свои собственные лицензии."
 
-#: src/olympia/pages/templates/pages/faq.html:256
+#: src/olympia/pages/templates/pages/faq.html:254
 #, python-format
-msgid ""
-"Firefox and other Mozilla software are <a href=\"%(url)s\">open source</a>."
-msgstr ""
-"Firefox и другие программы Mozilla являются программами с <a "
-"href=\"%(url)s\">открытым исходным кодом</a>."
+msgid "Firefox and other Mozilla software are <a href=\"%(url)s\">open source</a>."
+msgstr "Firefox и другие программы Mozilla являются программами с <a href=\"%(url)s\">открытым исходным кодом</a>."
 
-#: src/olympia/pages/templates/pages/faq.html:264
+#: src/olympia/pages/templates/pages/faq.html:262
 msgid "Collections and Favorites"
 msgstr "Подборки и избранные"
 
-#: src/olympia/pages/templates/pages/faq.html:267
+#: src/olympia/pages/templates/pages/faq.html:265
 msgid "What is a collection?"
 msgstr "Что такое подборка?"
 
-#: src/olympia/pages/templates/pages/faq.html:268
+#: src/olympia/pages/templates/pages/faq.html:266
 msgid "Collections are groups of related add-ons created by users to share."
-msgstr ""
-"Подборки это группы связанных дополнений, созданные пользователями, чтобы "
-"ими делиться."
+msgstr "Подборки это группы связанных дополнений, созданные пользователями, чтобы ими делиться."
 
-#: src/olympia/pages/templates/pages/faq.html:270
+#: src/olympia/pages/templates/pages/faq.html:268
 msgid "What is the My Favorites collection?"
 msgstr "Что такое подборка Моё Избранное?"
 
-#: src/olympia/pages/templates/pages/faq.html:271
-msgid ""
-"Favorite add-ons are add-ons that you have bookmarked to easily get back to "
-"later. You can add an add-on to your favorites collection by clicking \"Add "
-"to favorites\" on its details page."
+#: src/olympia/pages/templates/pages/faq.html:269
+msgid "Favorite add-ons are add-ons that you have bookmarked to easily get back to later. You can add an add-on to your favorites collection by clicking \"Add to favorites\" on its details page."
 msgstr ""
-"Любимые дополнения это дополнения, которые вы добавили в закладки, чтобы с "
-"легкостью вернуться к ним позже. Вы можете добавить дополнение в вашу "
-"коллекцию избранного, нажав на кнопку \"Добавить в избранное\" на странице с"
-" его описанием."
+"Любимые дополнения это дополнения, которые вы добавили в закладки, чтобы с легкостью вернуться к ним позже. Вы можете добавить дополнение в вашу коллекцию избранного, нажав на кнопку \"Добавить в "
+"избранное\" на странице с его описанием."
 
-#: src/olympia/pages/templates/pages/faq.html:275
-#: src/olympia/templates/menu_links.html:13
-#: src/olympia/templates/impala/header_title.html:17
+#: src/olympia/pages/templates/pages/faq.html:273 src/olympia/templates/menu_links.html:13 src/olympia/templates/impala/header_title.html:17
 msgid "Mobile Add-ons"
 msgstr "Мобильные дополнения"
 
-#: src/olympia/pages/templates/pages/faq.html:278
+#: src/olympia/pages/templates/pages/faq.html:276
 msgid "What are mobile add-ons?"
 msgstr "Что такое мобильные дополнения?"
 
-#: src/olympia/pages/templates/pages/faq.html:279
+#: src/olympia/pages/templates/pages/faq.html:277
 #, python-format
 msgid ""
-"Mobile add-ons work with <a href=\"%(mobile_url)s\">Firefox for Mobile</a> "
-"and add or modify functionality just like desktop add-ons. You can find add-"
-"ons that work with Firefox for Mobile in our <a "
-"href=\"%(gallery_url)s\">gallery</a>."
+"Mobile add-ons work with <a href=\"%(mobile_url)s\">Firefox for Mobile</a> and add or modify functionality just like desktop add-ons. You can find add-ons that work with Firefox for Mobile in our "
+"<a href=\"%(gallery_url)s\">gallery</a>."
 msgstr ""
-"Мобильные дополнения работают с <a href=\"%(mobile_url)s\">Firefox для "
-"мобильных устройств</a> и добавляют или изменяют функциональность, также как"
-" и дополнения для настольных компьютеров. Вы можете найти дополнения, "
-"которые работают с Firefox для мобильных устройств, в нашей <a "
-"href=\"%(gallery_url)s\">галерее</a>."
+"Мобильные дополнения работают с <a href=\"%(mobile_url)s\">Firefox для мобильных устройств</a> и добавляют или изменяют функциональность, также как и дополнения для настольных компьютеров. Вы "
+"можете найти дополнения, которые работают с Firefox для мобильных устройств, в нашей <a href=\"%(gallery_url)s\">галерее</a>."
 
-#: src/olympia/pages/templates/pages/faq.html:288
+#: src/olympia/pages/templates/pages/faq.html:286
 msgid "Developer Topics"
 msgstr "Информация для разработчиков"
 
-#: src/olympia/pages/templates/pages/faq.html:289
+#: src/olympia/pages/templates/pages/faq.html:287
 #, python-format
-msgid ""
-"Please see our <a href=\"%(faq_url)s\">Developer FAQ</a> and <a "
-"href=\"%(hub_url)s\">Developer Hub</a> for answers to add-on developer-"
-"related questions."
-msgstr ""
-"Пожалуйста, прочтите наш <a href=\"%(faq_url)s\">Developer FAQ</a> and <a "
-"href=\"%(hub_url)s\">Developer Hub</a>, чтобы получить ответы на вопросы "
-"относящиеся к разработке дополнений."
+msgid "Please see our <a href=\"%(faq_url)s\">Developer FAQ</a> and <a href=\"%(hub_url)s\">Developer Hub</a> for answers to add-on developer-related questions."
+msgstr "Пожалуйста, прочтите наш <a href=\"%(faq_url)s\">Developer FAQ</a> and <a href=\"%(hub_url)s\">Developer Hub</a>, чтобы получить ответы на вопросы относящиеся к разработке дополнений."
 
-#: src/olympia/pages/templates/pages/faq.html:294
+#: src/olympia/pages/templates/pages/faq.html:292
 msgid "Still have questions?"
 msgstr "Все еще есть вопросы?"
 
-#: src/olympia/pages/templates/pages/faq.html:295
+#: src/olympia/pages/templates/pages/faq.html:293
 #, python-format
-msgid ""
-"For general Firefox support, visit our <a href=\"%(sumo_url)s\">support "
-"website</a>. For general add-on and website questions, visit our <a "
-"href=\"%(forum_url)s\">forum</a>."
+msgid "For general Firefox support, visit our <a href=\"%(sumo_url)s\">support website</a>. For general add-on and website questions, visit our <a href=\"%(forum_url)s\">forum</a>."
 msgstr ""
-"Для получения общей поддержки по Firefox, посетите наш <a "
-"href=\"%(sumo_url)s\">веб-сайт поддержки</a>. Для общих вопросов по "
-"дополнениям и веб-сайту, посетите наш <a href=\"%(forum_url)s\">форум</a>."
+"Для получения общей поддержки по Firefox, посетите наш <a href=\"%(sumo_url)s\">веб-сайт поддержки</a>. Для общих вопросов по дополнениям и веб-сайту, посетите наш <a href=\"%(forum_url)s\">форум</"
+"a>."
 
-#: src/olympia/pages/templates/pages/review_guide.html:36
-#: src/olympia/pages/templates/pages/review_guide.html:51
+#: src/olympia/pages/templates/pages/review_guide.html:36 src/olympia/pages/templates/pages/review_guide.html:51
 msgid "Some tips for writing a great review"
 msgstr "Некоторые советы по написанию хороших отзывов"
 
-#: src/olympia/pages/templates/pages/review_guide.html:39
-#: src/olympia/pages/templates/pages/review_guide.html:131
+#: src/olympia/pages/templates/pages/review_guide.html:39 src/olympia/pages/templates/pages/review_guide.html:131
 msgid "Frequently Asked Questions about Reviews"
 msgstr "Часто задаваемые вопросы об отзывах"
 
 #: src/olympia/pages/templates/pages/review_guide.html:46
 msgid ""
-"Add-on reviews are a way for you to share your opinions about the add-ons "
-"you’ve installed and used. Our review moderation team reserves the right to "
-"refuse or remove any review that does not comply with these guidelines."
+"Add-on reviews are a way for you to share your opinions about the add-ons you’ve installed and used. Our review moderation team reserves the right to refuse or remove any review that does not "
+"comply with these guidelines."
 msgstr ""
-"Отзывы на дополнения являются для вас способом поделиться своим мнением о "
-"дополнениях, которые вы установили и использовали. Наша команда модерации "
-"отзывов оставляет за собой право отказать или удалить любой отзыв, который "
-"не соответствует этим принципам."
+"Отзывы на дополнения являются для вас способом поделиться своим мнением о дополнениях, которые вы установили и использовали. Наша команда модерации отзывов оставляет за собой право отказать или "
+"удалить любой отзыв, который не соответствует этим принципам."
 
 #: src/olympia/pages/templates/pages/review_guide.html:53
 msgid "Do:"
 msgstr "Вам следует:"
 
 #: src/olympia/pages/templates/pages/review_guide.html:56
-msgid ""
-"Write like you are telling a friend about your experience with the add-on."
-msgstr ""
-"Писать так, как будто вы рассказываете другу о своем опыте работы с "
-"дополнением."
+msgid "Write like you are telling a friend about your experience with the add-on."
+msgstr "Писать так, как будто вы рассказываете другу о своем опыте работы с дополнением."
 
 #: src/olympia/pages/templates/pages/review_guide.html:61
 msgid "Keep reviews concise and easy to understand."
@@ -13740,11 +10715,8 @@ msgid "Will you continue to use this add-on?"
 msgstr "Будете ли вы продолжать использовать это дополнение?"
 
 #: src/olympia/pages/templates/pages/review_guide.html:73
-msgid ""
-"Take a moment to read your review before submitting it to minimize typos."
-msgstr ""
-"Найдите немного времени, чтобы прочитать свой отзыв перед отправкой, чтобы "
-"минимизировать опечатки."
+msgid "Take a moment to read your review before submitting it to minimize typos."
+msgstr "Найдите немного времени, чтобы прочитать свой отзыв перед отправкой, чтобы минимизировать опечатки."
 
 #: src/olympia/pages/templates/pages/review_guide.html:79
 msgid "Don’t:"
@@ -13752,72 +10724,47 @@ msgstr "Вам не следует:"
 
 #: src/olympia/pages/templates/pages/review_guide.html:82
 msgid "Submit one-word reviews such as \"Great!\", \"wonderful,\" or \"bad.\""
-msgstr ""
-"Отправлять односложные отзывы такие, как «Отлично!», «замечательно» или "
-"«плохо»."
+msgstr "Отправлять односложные отзывы такие, как «Отлично!», «замечательно» или «плохо»."
 
 #: src/olympia/pages/templates/pages/review_guide.html:87
 msgid ""
-"Post technical issues, support requests, or feature suggestions. Use the "
-"available support options for each add-on, if available. You can find them "
-"in the side column next to the About this Add-on section."
+"Post technical issues, support requests, or feature suggestions. Use the available support options for each add-on, if available. You can find them in the side column next to the About this Add-on "
+"section."
 msgstr ""
-"Задавать технические вопросы, вопросы поддержки или предлагать новые "
-"функции. Используйте доступные варианты поддержки для каждого дополнения, "
-"если они есть. Вы можете найти их в боковом столбце рядом с разделом Об этом"
-" дополнении."
+"Задавать технические вопросы, вопросы поддержки или предлагать новые функции. Используйте доступные варианты поддержки для каждого дополнения, если они есть. Вы можете найти их в боковом столбце "
+"рядом с разделом Об этом дополнении."
 
 #: src/olympia/pages/templates/pages/review_guide.html:92
 msgid "Write reviews for add-ons which you have not personally used."
 msgstr "Писать отзывы на дополнения, которые вы лично не использовали."
 
 #: src/olympia/pages/templates/pages/review_guide.html:97
-msgid ""
-"Use profanity, sexual language or language that can be construed as hateful."
-msgstr ""
-"Использовать ненормативную лексику, непристойные выражения или слова, "
-"которые могут быть истолкованы как ненависть."
+msgid "Use profanity, sexual language or language that can be construed as hateful."
+msgstr "Использовать ненормативную лексику, непристойные выражения или слова, которые могут быть истолкованы как ненависть."
 
 #: src/olympia/pages/templates/pages/review_guide.html:103
-msgid ""
-"Include HTML, links, source code or code snippets. Reviews are meant to be "
-"text only."
-msgstr ""
-"Включать HTML, ссылки, исходный код или фрагменты кода. Отзывы должны "
-"содержать только текст."
+msgid "Include HTML, links, source code or code snippets. Reviews are meant to be text only."
+msgstr "Включать HTML, ссылки, исходный код или фрагменты кода. Отзывы должны содержать только текст."
 
 #: src/olympia/pages/templates/pages/review_guide.html:108
-msgid ""
-"Make false statements, disparage add-on authors or personally insult them."
-msgstr ""
-"Делать ложные заявления, унижать или лично оскорблять авторов дополнений."
+msgid "Make false statements, disparage add-on authors or personally insult them."
+msgstr "Делать ложные заявления, унижать или лично оскорблять авторов дополнений."
 
 #: src/olympia/pages/templates/pages/review_guide.html:114
-msgid ""
-"Include your own or anyone else’s email, phone number, or other personal "
-"details."
-msgstr ""
-"Включать ваши собственные или чьи-либо еще адреса эл. почты, номера "
-"телефонов или другие персональные данные."
+msgid "Include your own or anyone else’s email, phone number, or other personal details."
+msgstr "Включать ваши собственные или чьи-либо еще адреса эл. почты, номера телефонов или другие персональные данные."
 
 #: src/olympia/pages/templates/pages/review_guide.html:119
-msgid ""
-"Post reviews for an add-on you or your organization wrote or represent."
-msgstr ""
-"Размещать отзывы на дополнение, написанное или представленное вами или вашей"
-" организацией."
+msgid "Post reviews for an add-on you or your organization wrote or represent."
+msgstr "Размещать отзывы на дополнение, написанное или представленное вами или вашей организацией."
 
 #: src/olympia/pages/templates/pages/review_guide.html:125
 msgid ""
-"Criticize an add-on for something it’s intended to do. For example, leaving "
-"a negative review of an add-on for displaying ads or requiring data "
-"gathering, when that is the intended purpose of the add-on, or the add-on "
-"requires gathering data to function."
+"Criticize an add-on for something it’s intended to do. For example, leaving a negative review of an add-on for displaying ads or requiring data gathering, when that is the intended purpose of the "
+"add-on, or the add-on requires gathering data to function."
 msgstr ""
-"Критиковать дополнение за что-то, что оно предназначено делать. Например, "
-"оставлять отрицательный отзыв на дополнение за показ рекламы или требование "
-"сбора данных, когда это является целью этого дополнения, или дополнению "
-"необходим сбор данных для его работы."
+"Критиковать дополнение за что-то, что оно предназначено делать. Например, оставлять отрицательный отзыв на дополнение за показ рекламы или требование сбора данных, когда это является целью этого "
+"дополнения, или дополнению необходим сбор данных для его работы."
 
 #: src/olympia/pages/templates/pages/review_guide.html:133
 msgid "How can I report a problematic review?"
@@ -13825,15 +10772,11 @@ msgstr "Как мне сообщить о некорректном отзыве?
 
 #: src/olympia/pages/templates/pages/review_guide.html:135
 msgid ""
-"Please report or flag any questionable reviews by clicking the \"Report this"
-" review\" and it will be submitted to the site for moderation. Our "
-"moderation team will use the Review Guidelines to evaluate whether or not to"
-" delete the review or restore it back to the site."
+"Please report or flag any questionable reviews by clicking the \"Report this review\" and it will be submitted to the site for moderation. Our moderation team will use the Review Guidelines to "
+"evaluate whether or not to delete the review or restore it back to the site."
 msgstr ""
-"Пожалуйста, сообщайте или отмечайте флагом любые сомнительные отзывы, "
-"щёлкнув по \"Сообщить об этом отзыве\" и он будет отправлен на сайт для "
-"модерации. Наша команда модераторов будет использовать Руководство по "
-"отзывам, чтобы решить, удалить ли отзыв или восстановить его на сайте."
+"Пожалуйста, сообщайте или отмечайте флагом любые сомнительные отзывы, щёлкнув по \"Сообщить об этом отзыве\" и он будет отправлен на сайт для модерации. Наша команда модераторов будет использовать "
+"Руководство по отзывам, чтобы решить, удалить ли отзыв или восстановить его на сайте."
 
 #: src/olympia/pages/templates/pages/review_guide.html:140
 msgid "I’m an add-on author, can I respond to reviews?"
@@ -13841,34 +10784,23 @@ msgstr "Я автор дополнения, могу ли я отвечать н
 
 #: src/olympia/pages/templates/pages/review_guide.html:142
 #, python-format
-msgid ""
-"Yes, add-on authors can provide a single response to a review. You can set "
-"up a discussion topic in our <a href=\"%(forum_url)s\">forum</a> to engage "
-"in additional discussion or follow-up."
+msgid "Yes, add-on authors can provide a single response to a review. You can set up a discussion topic in our <a href=\"%(forum_url)s\">forum</a> to engage in additional discussion or follow-up."
 msgstr ""
-"Да, авторы дополнений могут написать один ответ на отзыв. Вы можете создать "
-"тему для обсуждения на нашем <a href=\"%(forum_url)s\">форуме</a>, чтобы "
-"принять участие в дополнительной или последующей дискуссии."
+"Да, авторы дополнений могут написать один ответ на отзыв. Вы можете создать тему для обсуждения на нашем <a href=\"%(forum_url)s\">форуме</a>, чтобы принять участие в дополнительной или последующей "
+"дискуссии."
 
 #: src/olympia/pages/templates/pages/review_guide.html:149
 msgid "I’m an add-on author, can I delete unfavorable reviews or ratings?"
-msgstr ""
-"Я автор дополнения, могу ли я удалять нелицеприятные отзывы или рейтинги?"
+msgstr "Я автор дополнения, могу ли я удалять нелицеприятные отзывы или рейтинги?"
 
 #: src/olympia/pages/templates/pages/review_guide.html:151
 msgid ""
-"In general, no. But if the review did not meet the review guidelines "
-"outlined above, you can click \"Report this review\" and have it moderated. "
-"If a review included a complaint that is no longer valid due to a new "
-"release of your add-on, we may consider deleting the review. Submit your "
-"detailed request to amo-editors@mozilla.org."
+"In general, no. But if the review did not meet the review guidelines outlined above, you can click \"Report this review\" and have it moderated. If a review included a complaint that is no longer "
+"valid due to a new release of your add-on, we may consider deleting the review. Submit your detailed request to amo-editors@mozilla.org."
 msgstr ""
-"В общем случае, нет. Но если отзыв не соответствует изложенным выше "
-"требованиям к отзывам, вы можете щёлкнуть по ссылке \"Сообщить об этом "
-"отзыве\" и он будет отмодерирован. Если отзыв содержит жалобу, который более"
-" не является актуальной в связи с выходом новой версии вашего дополнения, мы"
-" можем рассмотреть возможность удаления отзыва. Отправьте свой подробный "
-"запрос на адрес amo-editors@mozilla.org."
+"В общем случае, нет. Но если отзыв не соответствует изложенным выше требованиям к отзывам, вы можете щёлкнуть по ссылке \"Сообщить об этом отзыве\" и он будет отмодерирован. Если отзыв содержит "
+"жалобу, который более не является актуальной в связи с выходом новой версии вашего дополнения, мы можем рассмотреть возможность удаления отзыва. Отправьте свой подробный запрос на адрес amo-"
+"editors@mozilla.org."
 
 #: src/olympia/pages/templates/pages/sunbird.html:26
 msgid "Sunbird has retired"
@@ -13876,24 +10808,16 @@ msgstr "Sunbird более не развивается"
 
 #: src/olympia/pages/templates/pages/sunbird.html:29
 msgid ""
-"Development on the Sunbird project has halted and its final release was on "
-"March 30, 2010. We've been proud to host Sunbird add-ons on this site but as"
-" the project is no longer maintained we have disabled our support for the "
-"add-ons."
+"Development on the Sunbird project has halted and its final release was on March 30, 2010. We've been proud to host Sunbird add-ons on this site but as the project is no longer maintained we have "
+"disabled our support for the add-ons."
 msgstr ""
-"Разработка проекта Sunbird прекращена и его последний релиз состоялся 30 "
-"марта 2010 года. Мы были горды тем, что размещали дополнения Sunbird на этом"
-" сайте, но так как этот проект больше не развивается, мы отключили поддержку"
-" этих дополнений."
+"Разработка проекта Sunbird прекращена и его последний релиз состоялся 30 марта 2010 года. Мы были горды тем, что размещали дополнения Sunbird на этом сайте, но так как этот проект больше не "
+"развивается, мы отключили поддержку этих дополнений."
 
 #: src/olympia/pages/templates/pages/sunbird.html:38
 #, python-format
-msgid ""
-"We recommend upgrading to <a href=\"%(tb_url)s\">Thunderbird</a> and <a "
-"href=\"%(lightning_url)s\">Lightning</a>."
-msgstr ""
-"Мы рекомендуем обновиться на <a href=\"%(tb_url)s\">Thunderbird</a> и <a "
-"href=\"%(lightning_url)s\">Lightning</a>."
+msgid "We recommend upgrading to <a href=\"%(tb_url)s\">Thunderbird</a> and <a href=\"%(lightning_url)s\">Lightning</a>."
+msgstr "Мы рекомендуем обновиться на <a href=\"%(tb_url)s\">Thunderbird</a> и <a href=\"%(lightning_url)s\">Lightning</a>."
 
 #: src/olympia/pages/templates/pages/sunbird.html:45
 msgid "Read more about Sunbird"
@@ -13901,9 +10825,7 @@ msgstr "Узнайте больше о Sunbird"
 
 #: src/olympia/paypal/__init__.py:25
 msgid "There was an error communicating with PayPal. Please try again later."
-msgstr ""
-"При соединении с PayPal произошла ошибка. Пожалуйста, повторите попытку "
-"позже."
+msgstr "При соединении с PayPal произошла ошибка. Пожалуйста, повторите попытку позже."
 
 #: src/olympia/paypal/__init__.py:50
 msgid "There was an error with this currency."
@@ -13946,8 +10868,7 @@ msgstr "Удержать рецензию; удалить флаги"
 msgid "Skip for now"
 msgstr "Пока пропустить"
 
-#: src/olympia/reviews/forms.py:151
-#: src/olympia/reviews/templates/reviews/review.html:107
+#: src/olympia/reviews/forms.py:151 src/olympia/reviews/templates/reviews/review.html:107
 msgid "Delete review"
 msgstr "Удалить отзыв"
 
@@ -13966,43 +10887,24 @@ msgstr "Добавить отзыв на {0}"
 #: src/olympia/reviews/templates/reviews/add.html:26
 #, python-format
 msgid ""
-"<h2>Keep these tips in mind:</h2> <ul> <li> Write like you're telling a "
-"friend about your experience with the add-on. Give specifics and helpful "
-"details, such as what features you liked and/or disliked, how easy to use it"
-" is, and any disadvantages it has. Avoid generic language such as calling it"
-" \"Great\" or \"Bad\" unless you can give reasons why you believe this is "
-"so. </li> <li> Please do not post bug reports in reviews. We do not make "
-"your email address available to add-on developers and they may need to "
-"contact you to help resolve your issue. See the <a "
-"href=\"%(support)s\">support section</a> to find out where to get assistance"
-" for this add-on. </li> <li>Please keep reviews clean, avoid the use of "
-"improper language and do not post any personal information. </li> </ul> "
-"<p>Please read the <a href=\"%(guide)s\" target=\"_blank\">Review "
-"Guidelines</a> for more detail about user add-on reviews.</p>"
+"<h2>Keep these tips in mind:</h2> <ul> <li> Write like you're telling a friend about your experience with the add-on. Give specifics and helpful details, such as what features you liked and/or "
+"disliked, how easy to use it is, and any disadvantages it has. Avoid generic language such as calling it \"Great\" or \"Bad\" unless you can give reasons why you believe this is so. </li> <li> "
+"Please do not post bug reports in reviews. We do not make your email address available to add-on developers and they may need to contact you to help resolve your issue. See the <a href=\"%(support)s"
+"\">support section</a> to find out where to get assistance for this add-on. </li> <li>Please keep reviews clean, avoid the use of improper language and do not post any personal information. </li> </"
+"ul> <p>Please read the <a href=\"%(guide)s\" target=\"_blank\">Review Guidelines</a> for more detail about user add-on reviews.</p>"
 msgstr ""
-"<h2>Примите во внимание эти советы:</h2> <ul> <li> Пишите так, как будто вы "
-"рассказываете другу о своем опыте работы с дополнением. Приводите специфику "
-"и полезные подробности, например, какие функции вам понравились и/или не "
-"понравилось, насколько легко его использовать и какие недостатки оно имеет. "
-"Избегайте обобщений, таких как название его \"Отличным\" или \"Плохим\", "
-"если вы не можете привести веских на то причин. </li> <li> Пожалуйста, не "
-"оставляйте в обзорах сообщения об ошибках. Мы не сообщаем ваш адрес "
-"электронной почты разработчикам дополнений, а им может потребоваться "
-"связаться с вами, чтобы помочь решить вашу проблему. Чтобы узнать, как "
-"получить помощь для этого дополнения, обратитесь в <a "
-"href=\"%(support)s\">раздел поддержки</a>. </li> <li>Пожалуйста, оставляйте "
-"корректные отзывы, избегайте использовать неприличные выражения и не "
-"размещайте какие-либо личную информацию. </li> </ul> <p>Пожалуйста, прочтите"
-" <a href=\"%(guide)s\" target=\"_blank\">руководство по составлению "
-"отзывов</a> для получения более подробной информации об отзывах "
-"пользователей на дополнения.</p>"
+"<h2>Примите во внимание эти советы:</h2> <ul> <li> Пишите так, как будто вы рассказываете другу о своем опыте работы с дополнением. Приводите специфику и полезные подробности, например, какие "
+"функции вам понравились и/или не понравилось, насколько легко его использовать и какие недостатки оно имеет. Избегайте обобщений, таких как название его \"Отличным\" или \"Плохим\", если вы не "
+"можете привести веских на то причин. </li> <li> Пожалуйста, не оставляйте в обзорах сообщения об ошибках. Мы не сообщаем ваш адрес электронной почты разработчикам дополнений, а им может "
+"потребоваться связаться с вами, чтобы помочь решить вашу проблему. Чтобы узнать, как получить помощь для этого дополнения, обратитесь в <a href=\"%(support)s\">раздел поддержки</a>. </li> "
+"<li>Пожалуйста, оставляйте корректные отзывы, избегайте использовать неприличные выражения и не размещайте какие-либо личную информацию. </li> </ul> <p>Пожалуйста, прочтите <a href=\"%(guide)s\" "
+"target=\"_blank\">руководство по составлению отзывов</a> для получения более подробной информации об отзывах пользователей на дополнения.</p>"
 
 #: src/olympia/reviews/templates/reviews/reply.html:4
 msgid "Reply to review by {0}"
 msgstr "Ответить на отзыв от {0}."
 
-#: src/olympia/reviews/templates/reviews/reply.html:15
-#: src/olympia/reviews/templates/reviews/reply.html:31
+#: src/olympia/reviews/templates/reviews/reply.html:15 src/olympia/reviews/templates/reviews/reply.html:31
 msgid "Reply"
 msgstr "Ответить"
 
@@ -14010,8 +10912,7 @@ msgstr "Ответить"
 msgid "Write a Reply"
 msgstr "Написать ответ"
 
-#: src/olympia/reviews/templates/reviews/reply.html:36
-#: src/olympia/reviews/templates/reviews/report_review.html:12
+#: src/olympia/reviews/templates/reviews/reply.html:36 src/olympia/reviews/templates/reviews/report_review.html:12
 msgid "Submit"
 msgstr "Отправить"
 
@@ -14031,37 +10932,21 @@ msgid "by %(user)s <b>(Developer)</b> on %(date)s"
 msgstr "от %(user)s <b>(Разработчик)</b> на %(date)s"
 
 #. {0} is a version number (like 1.01)
-#: src/olympia/reviews/templates/reviews/review.html:50
-#: src/olympia/reviews/templates/reviews/mobile/review_list.html:41
+#: src/olympia/reviews/templates/reviews/review.html:50 src/olympia/reviews/templates/reviews/mobile/review_list.html:41
 msgid "This review is for a previous version of the add-on ({0})."
 msgstr "Это отзыв для предыдущей версии этого дополнения ({0})."
 
 #: src/olympia/reviews/templates/reviews/review.html:56
 #, python-format
-msgid ""
-"This user has a <a href=\"%(user_review_url)s\">previous review</a> of this "
-"add-on."
-msgid_plural ""
-"This user has <a href=\"%(user_review_url)s\">%(cnt)s previous reviews</a> "
-"of this add-on."
-msgstr[0] ""
-"Этот пользователь ранее оставил <a href=\"%(user_review_url)s\">%(cnt)s "
-"отзыв</a> на это дополнение."
-msgstr[1] ""
-"Этот пользователь ранее оставил <a href=\"%(user_review_url)s\">%(cnt)s "
-"отзыва</a> на это дополнение."
-msgstr[2] ""
-"Этот пользователь ранее оставил <a href=\"%(user_review_url)s\">%(cnt)s "
-"отзывов</a> на это дополнение."
+msgid "This user has a <a href=\"%(user_review_url)s\">previous review</a> of this add-on."
+msgid_plural "This user has <a href=\"%(user_review_url)s\">%(cnt)s previous reviews</a> of this add-on."
+msgstr[0] "Этот пользователь ранее оставил <a href=\"%(user_review_url)s\">%(cnt)s отзыв</a> на это дополнение."
+msgstr[1] "Этот пользователь ранее оставил <a href=\"%(user_review_url)s\">%(cnt)s отзыва</a> на это дополнение."
 
 #: src/olympia/reviews/templates/reviews/review.html:62
 #, python-format
-msgid ""
-"This user has <a href=\"%(user_review_url)s\">other reviews</a> of this add-"
-"on."
-msgstr ""
-"Этот пользователь оставил <a href=\"%(user_review_url)s\">другие отзывы</a> "
-"на это дополнение."
+msgid "This user has <a href=\"%(user_review_url)s\">other reviews</a> of this add-on."
+msgstr "Этот пользователь оставил <a href=\"%(user_review_url)s\">другие отзывы</a> на это дополнение."
 
 #: src/olympia/reviews/templates/reviews/review.html:72
 msgid "Flagged for review"
@@ -14093,9 +10978,7 @@ msgid "{0} :: Reviews"
 msgstr "{0} :: Отзывы"
 
 #. {0} is an addon name.
-#: src/olympia/reviews/templates/reviews/review_list.html:24
-#: src/olympia/reviews/templates/reviews/mobile/add.html:4
-#: src/olympia/reviews/templates/reviews/mobile/review_list.html:4
+#: src/olympia/reviews/templates/reviews/review_list.html:24 src/olympia/reviews/templates/reviews/mobile/add.html:4 src/olympia/reviews/templates/reviews/mobile/review_list.html:4
 msgid "Reviews for {0}"
 msgstr "Отзывы на {0}"
 
@@ -14105,7 +10988,6 @@ msgid "<b>{0}</b> review for this add-on"
 msgid_plural "<b>{0}</b> reviews for this add-on"
 msgstr[0] "<b>{0}</b> отзыв на это дополнение"
 msgstr[1] "<b>{0}</b> отзыва на это дополнение"
-msgstr[2] "<b>{0}</b> отзывов на это дополнение"
 
 #. {0} is a developer's name.
 #: src/olympia/reviews/templates/reviews/review_list.html:33
@@ -14118,7 +11000,6 @@ msgid "Review for %(addon)s by %(user)s"
 msgid_plural "Reviews for %(addon)s by %(user)s"
 msgstr[0] "Отзыв на %(addon)s от %(user)s"
 msgstr[1] "Отзывы на %(addon)s от %(user)s"
-msgstr[2] "Отзывы на %(addon)s от %(user)s"
 
 #: src/olympia/reviews/templates/reviews/review_list.html:42
 msgid "No reviews found."
@@ -14133,8 +11014,7 @@ msgstr "<strong>Средний</strong> (%(total)s)"
 msgid "Write a New Review"
 msgstr "Написать новый отзыв"
 
-#: src/olympia/reviews/templates/reviews/review_list.html:81
-#: src/olympia/reviews/templates/reviews/mobile/reviews_link.html:15
+#: src/olympia/reviews/templates/reviews/review_list.html:81 src/olympia/reviews/templates/reviews/mobile/reviews_link.html:15
 msgid "Be the first to write a review."
 msgstr "Напишите первый отзыв."
 
@@ -14143,7 +11023,6 @@ msgid "{num} review"
 msgid_plural "{num} reviews"
 msgstr[0] "{num} отзыв"
 msgstr[1] "{num} отзыва"
-msgstr[2] "{num} отзывов"
 
 #: src/olympia/reviews/templates/reviews/impala/reviews_rating.html:1
 msgid "Rated {0} out of 5 stars"
@@ -14154,8 +11033,7 @@ msgstr "Рейтинг {0} из 5 звёзд"
 msgid "Rated %(rating)s out of 5 stars"
 msgstr "Оценено на %(rating)s из 5 звёзд"
 
-#: src/olympia/reviews/templates/reviews/mobile/add_form.html:3
-#: src/olympia/reviews/templates/reviews/mobile/add_form.html:8
+#: src/olympia/reviews/templates/reviews/mobile/add_form.html:3 src/olympia/reviews/templates/reviews/mobile/add_form.html:8
 msgid "Add a Review"
 msgstr "Добавить отзыв"
 
@@ -14172,7 +11050,6 @@ msgid "Average from {0} Rating"
 msgid_plural "Average from {0} Ratings"
 msgstr[0] "Среднее из {0} рейтинга"
 msgstr[1] "Среднее из {0} рейтингов"
-msgstr[2] "Среднее из {0} рейтингов"
 
 #: src/olympia/reviews/templates/reviews/mobile/review_list.html:34
 #, python-format
@@ -14189,7 +11066,6 @@ msgid "See All Reviews"
 msgid_plural "See All %(cnt)s Reviews"
 msgstr[0] "Просмотреть все отзывы"
 msgstr[1] "Просмотреть все %(cnt)s отзыва"
-msgstr[2] "Просмотреть все %(cnt)s отзывов"
 
 #: src/olympia/search/forms.py:11
 msgid "Most popular this week"
@@ -14228,10 +11104,8 @@ msgid "Relevance"
 msgstr "Релевантность"
 
 #: src/olympia/search/helpers.py:24
-msgid ""
-"Results <strong>{0}</strong>-<strong>{1}</strong> of <strong>{2}</strong>"
-msgstr ""
-"Результаты <strong>{0}</strong>-<strong>{1}</strong> из <strong>{2}</strong>"
+msgid "Results <strong>{0}</strong>-<strong>{1}</strong> of <strong>{2}</strong>"
+msgstr "Результаты <strong>{0}</strong>-<strong>{1}</strong> из <strong>{2}</strong>"
 
 # {0} is a number
 # {1} is a number
@@ -14239,12 +11113,8 @@ msgstr ""
 # {3} is the word the person is searching for
 # {4} is a word (the add-on is tagged with it)
 #: src/olympia/search/helpers.py:44
-msgid ""
-"Showing {0} - {1} of {2} results for <strong>{3}</strong> tagged with "
-"<strong>{4}</strong>"
-msgstr ""
-"Показываю {0} - {1} из {2} результатов для <strong>{3}</strong> отмеченных "
-"как <strong>{4}</strong>"
+msgid "Showing {0} - {1} of {2} results for <strong>{3}</strong> tagged with <strong>{4}</strong>"
+msgstr "Показываю {0} - {1} из {2} результатов для <strong>{3}</strong> отмеченных как <strong>{4}</strong>"
 
 # {0} is a number
 # {1} is a number
@@ -14260,8 +11130,7 @@ msgstr "Показываю {0} - {1} из {2} результатов для <str
 # {3} is a word (the add-on is tagged with it)
 #: src/olympia/search/helpers.py:52
 msgid "Showing {0} - {1} of {2} results tagged with <strong>{3}</strong>"
-msgstr ""
-"Показываю {0} - {1} из {2} результатов отмеченных как <strong>{3}</strong>"
+msgstr "Показываю {0} - {1} из {2} результатов отмеченных как <strong>{3}</strong>"
 
 # {0} is a number
 # {1} is a number
@@ -14271,24 +11140,22 @@ msgid "Showing {0} - {1} of {2} results"
 msgstr "Показываю {0} - {1} из {2} результатов"
 
 #. {0} is an application, like Firefox.
-#: src/olympia/search/views.py:264 src/olympia/templates/base.html:17
-#: src/olympia/templates/impala/base.html:17
-#: src/olympia/templates/mobile/base_addons.html:17
+#: src/olympia/search/views.py:264 src/olympia/templates/base.html:17 src/olympia/templates/impala/base.html:17 src/olympia/templates/mobile/base_addons.html:17
 msgid "{0} Add-ons"
 msgstr "{0} Дополнения"
 
 #. L10n: {0} is an application, such as Firefox. This means "any version of
 #. Firefox."
-#: src/olympia/search/views.py:554
+#: src/olympia/search/views.py:547
 msgid "Any {0}"
 msgstr "Любая {0}"
 
 #. L10n: "All Systems" means show everything regardless of platform.
-#: src/olympia/search/views.py:589
+#: src/olympia/search/views.py:582
 msgid "All Systems"
 msgstr "Все системы"
 
-#: src/olympia/search/views.py:600
+#: src/olympia/search/views.py:593
 msgid "All Tags"
 msgstr "Все метки"
 
@@ -14307,9 +11174,7 @@ msgstr "Поиск недоступен"
 
 #: src/olympia/search/templates/search/down.html:6
 msgid "Search is temporarily unavailable. Please try again in a few minutes."
-msgstr ""
-"Поиск временно недоступен. Пожалуйста, попробуйте снова через несколько "
-"минут."
+msgstr "Поиск временно недоступен. Пожалуйста, попробуйте снова через несколько минут."
 
 #. {0} is the string the user was searching for
 #: src/olympia/search/templates/search/personas.html:9
@@ -14335,7 +11200,6 @@ msgid "<b>{0}</b> matching result"
 msgid_plural "<b>{0}</b> matching results"
 msgstr[0] "<b>{0}</b> подходящий результат"
 msgstr[1] "<b>{0}</b> подходящих результата"
-msgstr[2] "<b>{0}</b> подходящих результатов"
 
 #: src/olympia/search/templates/search/results.html:67
 msgid "Filter Results"
@@ -14358,7 +11222,6 @@ msgid "{0} post"
 msgid_plural "{0} posts"
 msgstr[0] "{0} пост"
 msgstr[1] "{0} поста"
-msgstr[2] "{0} постов"
 
 #: src/olympia/sharing/__init__.py:20
 msgid "Post to Facebook"
@@ -14369,7 +11232,6 @@ msgid "{0} Like"
 msgid_plural "{0} Likes"
 msgstr[0] "{0} лайк"
 msgstr[1] "{0} лайка"
-msgstr[2] "{0} лайков"
 
 #: src/olympia/sharing/__init__.py:30
 msgid "Tweet on Twitter"
@@ -14380,7 +11242,6 @@ msgid "{0} tweet"
 msgid_plural "{0} tweets"
 msgstr[0] "{0} твит"
 msgstr[1] "{0} твита"
-msgstr[2] "{0} твитов"
 
 #: src/olympia/sharing/__init__.py:40
 msgid "Share on g+"
@@ -14415,7 +11276,6 @@ msgid "{0} post on localservice1"
 msgid_plural "{0} posts on localservice1"
 msgstr[0] "на Яндекс поделился {0} человек"
 msgstr[1] "на Яндекс поделилось {0} человека"
-msgstr[2] "на Яндекс поделилось {0} человек"
 
 #. L10n: Only change if you have reason! wiki.mozilla.org/AMO:Localizers
 #: src/olympia/sharing/__init__.py:76
@@ -14438,7 +11298,6 @@ msgid "{0} post on localservice2"
 msgid_plural "{0} posts on localservice2"
 msgstr[0] "ВКонтакте опубликовал {0} человек"
 msgstr[1] "ВКонтакте опубликовало {0} человека"
-msgstr[2] "ВКонтакте опубликовало {0} человек"
 
 #. L10n: Only change if you have reason! wiki.mozilla.org/AMO:Localizers
 #: src/olympia/sharing/__init__.py:91
@@ -14461,7 +11320,6 @@ msgid "{0} post on localservice3"
 msgid_plural "{0} posts on localservice3"
 msgstr[0] "{0} человек опубликовал в Facebook"
 msgstr[1] "{0} человека опубликовало в Facebook"
-msgstr[2] "{0} человек опубликовало в Facebook"
 
 #: src/olympia/sharing/templates/sharing/sharing_widget.html:2
 msgid "Share this Add-on"
@@ -14471,36 +11329,31 @@ msgstr "Поделиться этим дополнением"
 msgid "Share this Collection"
 msgstr "Поделиться этой подборкой"
 
-#: src/olympia/signing/views.py:30 src/olympia/templates/base.html:75
-#: src/olympia/templates/impala/base.html:115
-msgid ""
-"Some features are temporarily disabled while we perform website maintenance."
-" We'll be back to full capacity shortly."
-msgstr ""
-"Некоторые функции временно отключены, пока мы проводим техническое "
-"обслуживание сайта. Мы вернемся на полную мощность в ближайшее время."
+#: src/olympia/signing/views.py:33 src/olympia/templates/base.html:71 src/olympia/templates/impala/base.html:112
+msgid "Some features are temporarily disabled while we perform website maintenance. We'll be back to full capacity shortly."
+msgstr "Некоторые функции временно отключены, пока мы проводим техническое обслуживание сайта. Мы вернемся на полную мощность в ближайшее время."
 
-#: src/olympia/signing/views.py:53
+#: src/olympia/signing/views.py:56
 msgid "Could not find add-on with id \"{}\"."
 msgstr "Не удалось найти дополнение с идентификатором \"{}\"."
 
-#: src/olympia/signing/views.py:67
+#: src/olympia/signing/views.py:70
 msgid "You do not own this addon."
 msgstr "Вы не владете этим дополнением."
 
-#: src/olympia/signing/views.py:82
+#: src/olympia/signing/views.py:87
 msgid "Missing \"upload\" key in multipart file data."
 msgstr "Отстуствует ключ \"upload\" при отправке файла."
 
-#: src/olympia/signing/views.py:96
+#: src/olympia/signing/views.py:101
 msgid "Version does not match the manifest file."
 msgstr "Версия не соответсвует манифесту."
 
-#: src/olympia/signing/views.py:100
+#: src/olympia/signing/views.py:105
 msgid "Version already exists."
 msgstr "Версия уже существует."
 
-#: src/olympia/signing/views.py:136
+#: src/olympia/signing/views.py:141
 msgid "No uploaded file for that addon and version."
 msgstr "Нет загруженного файла для этого дополнения и версии."
 
@@ -14592,8 +11445,7 @@ msgstr "От"
 msgid "To"
 msgstr "До"
 
-#: src/olympia/stats/templates/stats/popup.html:27
-#: src/olympia/users/templates/users/pwreset_confirm.html:38
+#: src/olympia/stats/templates/stats/popup.html:27 src/olympia/users/templates/users/pwreset_confirm.html:38
 msgid "Update"
 msgstr "Обновить"
 
@@ -14614,98 +11466,89 @@ msgstr "{0} :: Панель статистики"
 msgid "Statistics Dashboard :: Add-ons for {0}"
 msgstr "Панель статистики :: Дополнения для {0}"
 
-#: src/olympia/stats/templates/stats/stats.html:30
-msgid "Controls:"
-msgstr "Управление:"
-
-#: src/olympia/stats/templates/stats/stats.html:33
-msgid "reset zoom"
-msgstr "сброс масштаба"
-
-#: src/olympia/stats/templates/stats/stats.html:40
-msgid "Group by:"
-msgstr "Группировать по:"
-
-#: src/olympia/stats/templates/stats/stats.html:42
-msgid "day"
-msgstr "день"
-
-#: src/olympia/stats/templates/stats/stats.html:45
-msgid "week"
-msgstr "неделя"
-
-#: src/olympia/stats/templates/stats/stats.html:48
-msgid "month"
-msgstr "месяц"
-
-#: src/olympia/stats/templates/stats/stats.html:54
-msgid "For last:"
-msgstr "За последние:"
-
-#: src/olympia/stats/templates/stats/stats.html:57
-msgid "7 days"
-msgstr "7 дней"
-
-#: src/olympia/stats/templates/stats/stats.html:60
-msgid "30 days"
-msgstr "30 дней"
-
-#: src/olympia/stats/templates/stats/stats.html:63
-msgid "90 days"
-msgstr "90 дней"
-
-#: src/olympia/stats/templates/stats/stats.html:66
-msgid "365 days"
-msgstr "365 дней"
-
-#: src/olympia/stats/templates/stats/stats.html:69
-msgid "Custom..."
-msgstr "Настроить..."
-
 #. {0} is an add-on name
-#: src/olympia/stats/templates/stats/stats.html:88
-#: src/olympia/stats/templates/stats/stats.html:91
+#: src/olympia/stats/templates/stats/stats.html:44 src/olympia/stats/templates/stats/stats.html:47
 msgid "Statistics for {0}"
 msgstr "Статистика для {0}"
 
-#: src/olympia/stats/templates/stats/stats.html:94
+#: src/olympia/stats/templates/stats/stats.html:50
 msgid "Statistics Dashboard"
 msgstr "Панель статистики"
 
-#: src/olympia/stats/templates/stats/stats.html:104
-msgid ""
-"Statistics processing is currently disabled, so recent data is unavailable. "
-"The statistics are still being collected and this page will be updated soon "
-"with the missing data."
-msgstr ""
-"Обработка статистики в настоящее время отключена, поэтому последние данные "
-"недоступны. Статистические данные по-прежнему собираются, и эта страница с "
-"отсутствующими данными скоро обновится."
+#: src/olympia/stats/templates/stats/stats.html:57
+msgid "Controls:"
+msgstr "Управление:"
 
-#: src/olympia/stats/templates/stats/stats.html:110
+#: src/olympia/stats/templates/stats/stats.html:60
+msgid "reset zoom"
+msgstr "сброс масштаба"
+
+#: src/olympia/stats/templates/stats/stats.html:67
+msgid "Group by:"
+msgstr "Группировать по:"
+
+#: src/olympia/stats/templates/stats/stats.html:69
+msgid "day"
+msgstr "день"
+
+#: src/olympia/stats/templates/stats/stats.html:72
+msgid "week"
+msgstr "неделя"
+
+#: src/olympia/stats/templates/stats/stats.html:75
+msgid "month"
+msgstr "месяц"
+
+#: src/olympia/stats/templates/stats/stats.html:81
+msgid "For last:"
+msgstr "За последние:"
+
+#: src/olympia/stats/templates/stats/stats.html:84
+msgid "7 days"
+msgstr "7 дней"
+
+#: src/olympia/stats/templates/stats/stats.html:87
+msgid "30 days"
+msgstr "30 дней"
+
+#: src/olympia/stats/templates/stats/stats.html:90
+msgid "90 days"
+msgstr "90 дней"
+
+#: src/olympia/stats/templates/stats/stats.html:93
+msgid "365 days"
+msgstr "365 дней"
+
+#: src/olympia/stats/templates/stats/stats.html:96
+msgid "Custom..."
+msgstr "Настроить..."
+
+#: src/olympia/stats/templates/stats/stats.html:106
+msgid "Statistics processing is currently disabled, so recent data is unavailable. The statistics are still being collected and this page will be updated soon with the missing data."
+msgstr "Обработка статистики в настоящее время отключена, поэтому последние данные недоступны. Статистические данные по-прежнему собираются, и эта страница с отсутствующими данными скоро обновится."
+
+#: src/olympia/stats/templates/stats/stats.html:112
 msgid "Loading the latest data&hellip;"
 msgstr "Загрузка последних данных&hellip;"
 
-#: src/olympia/stats/templates/stats/stats.html:142
-#: src/olympia/stats/templates/stats/reports/overview.html:25
-#: src/olympia/stats/templates/stats/reports/overview.html:37
+#: src/olympia/stats/templates/stats/stats.html:144 src/olympia/stats/templates/stats/reports/overview.html:25 src/olympia/stats/templates/stats/reports/overview.html:37
 #: src/olympia/stats/templates/stats/reports/overview.html:49
 msgid "No data available."
 msgstr "Данные отсутствуют"
 
-#: src/olympia/stats/templates/stats/stats.html:177
+#: src/olympia/stats/templates/stats/stats.html:179
 msgid "This dashboard is currently <b>public</b>."
 msgstr "Эта панель сейчас является <b>публичной</b>."
 
-#: src/olympia/stats/templates/stats/stats.html:179
+#: src/olympia/stats/templates/stats/stats.html:181
 msgid "Contribution stats are currently <b>private</b>."
 msgstr "Статистика взносов сейчас является <b>приватной</b>."
 
-#: src/olympia/stats/templates/stats/stats.html:182
+#: src/olympia/stats/templates/stats/stats.html:184
 msgid "This dashboard is currently <b>private</b>."
 msgstr "Эта панель сейчас является <b>приватной</b>."
 
-#: src/olympia/stats/templates/stats/stats.html:185
+#: src/olympia/stats/templates/stats/stats.html:187
 msgid "Change settings."
 msgstr "Изменить настройки."
 
@@ -14747,14 +11590,11 @@ msgstr "Как подсчитываются загрузки?"
 
 #: src/olympia/stats/templates/stats/reports/downloads.html:10
 msgid ""
-"<h2>How are downloads counted?</h2> <p> Download counts are updated every "
-"evening and only include original add-on downloads, not updates. Downloads "
-"can be broken down by the specific source referring the download. </p>"
+"<h2>How are downloads counted?</h2> <p> Download counts are updated every evening and only include original add-on downloads, not updates. Downloads can be broken down by the specific source "
+"referring the download. </p>"
 msgstr ""
-"<h2>Как подсчитываются загрузки?</h2> <p> Число загрузок обновляется каждый "
-"вечер и включает в себя только новые загрузки дополнения, а не обновления. "
-"Загрузки могут быть разбиты по конкретным источникам, ссылающимся на "
-"загрузку. </p>"
+"<h2>Как подсчитываются загрузки?</h2> <p> Число загрузок обновляется каждый вечер и включает в себя только новые загрузки дополнения, а не обновления. Загрузки могут быть разбиты по конкретным "
+"источникам, ссылающимся на загрузку. </p>"
 
 #: src/olympia/stats/templates/stats/reports/locales.html:3
 msgid "User languages by Date"
@@ -14768,8 +11608,7 @@ msgstr "Использование платформ по дате"
 msgid "<b>{0}</b> Downloads"
 msgstr "<b>{0}</b> загрузок"
 
-#: src/olympia/stats/templates/stats/reports/overview.html:9
-#: src/olympia/stats/templates/stats/reports/overview.html:13
+#: src/olympia/stats/templates/stats/reports/overview.html:9 src/olympia/stats/templates/stats/reports/overview.html:13
 msgid "Loading..."
 msgstr "Загрузка..."
 
@@ -14820,35 +11659,18 @@ msgstr "Об отслеживании внешних источников..."
 #: src/olympia/stats/templates/stats/reports/sources.html:10
 #, python-format
 msgid ""
-"<h2>Tracking external sources</h2> <p> If you link to your add-on's details "
-"page or directly to its file from an external site, such as your blog or "
-"website, you can append a parameter to be tracked as an additional download "
-"source on this page. For example, the following links would appear as "
-"sourced by your blog: <dl> <dt>Add-on Details Page</dt> "
-"<dd>https://addons.mozilla.org/addon/%(slug)s?src=<b>external-blog</b></dd> "
-"<dt>Direct File Link</dt> "
-"<dd>https://addons.mozilla.org/downloads/latest/%(id)s/addon-%(id)s-latest.xpi?src=<b"
-">external-blog</b></dd> </dl> <p> Only src parameters that begin with "
-"\"external-\" will be tracked, up to 61 additional characters. Any text "
-"after \"external-\" can be used to describe the source, such as \"external-"
-"blog\", \"external-sidebar\", \"external-campaign225\", etc. The following "
-"URL-safe characters are allowed: <code>a-z A-Z - . _ ~ %% +</code>"
+"<h2>Tracking external sources</h2> <p> If you link to your add-on's details page or directly to its file from an external site, such as your blog or website, you can append a parameter to be "
+"tracked as an additional download source on this page. For example, the following links would appear as sourced by your blog: <dl> <dt>Add-on Details Page</dt> <dd>https://addons.mozilla.org/addon/"
+"%(slug)s?src=<b>external-blog</b></dd> <dt>Direct File Link</dt> <dd>https://addons.mozilla.org/downloads/latest/%(id)s/addon-%(id)s-latest.xpi?src=<b>external-blog</b></dd> </dl> <p> Only src "
+"parameters that begin with \"external-\" will be tracked, up to 61 additional characters. Any text after \"external-\" can be used to describe the source, such as \"external-blog\", \"external-"
+"sidebar\", \"external-campaign225\", etc. The following URL-safe characters are allowed: <code>a-z A-Z - . _ ~ %% +</code>"
 msgstr ""
-"<h2>Отслеживание внешних источников</h2> <p> Если вы дали ссылку на страницу"
-" информации о вашем дополнении или непосредственно на его файл с внешнего "
-"сайта, такого как ваш блог или веб-сайт, вы можете добавить параметр для "
-"отслеживания дополнительных источников загрузки на этой странице. Например, "
-"следующие ссылки появятся как исходящие с вашего блога: <dl> <dt>Страница "
-"информации о дополнении</dt> "
-"<dd>https://addons.mozilla.org/addon/%(slug)s?src=<b>external-blog</b></dd> "
-"<dt>Прямая ссылка на файл</dt> "
-"<dd>https://addons.mozilla.org/downloads/latest/%(id)s/addon-%(id)s-latest.xpi?src=<b"
-">external-blog</b></dd> </dl> <p> Будут отслеживаться только параметры src "
-"начинающиеся с \"external-\", длиной до 61 дополнительного символа. Любой "
-"текст после \"external-\" может быть использован для описания источника, "
-"например \"external-blog\", \"external-sidebar\", \"external-campaign225\", "
-"и т.д. Разрешены следующие безопасные для создания URL символы: <code>a-z "
-"A-Z - . _ ~ %% +</code>"
+"<h2>Отслеживание внешних источников</h2> <p> Если вы дали ссылку на страницу информации о вашем дополнении или непосредственно на его файл с внешнего сайта, такого как ваш блог или веб-сайт, вы "
+"можете добавить параметр для отслеживания дополнительных источников загрузки на этой странице. Например, следующие ссылки появятся как исходящие с вашего блога: <dl> <dt>Страница информации о "
+"дополнении</dt> <dd>https://addons.mozilla.org/addon/%(slug)s?src=<b>external-blog</b></dd> <dt>Прямая ссылка на файл</dt> <dd>https://addons.mozilla.org/downloads/latest/%(id)s/addon-%(id)s-latest."
+"xpi?src=<b>external-blog</b></dd> </dl> <p> Будут отслеживаться только параметры src начинающиеся с \"external-\", длиной до 61 дополнительного символа. Любой текст после \"external-\" может быть "
+"использован для описания источника, например \"external-blog\", \"external-sidebar\", \"external-campaign225\", и т.д. Разрешены следующие безопасные для создания URL символы: <code>a-z A-Z - . _ ~ "
+"%% +</code>"
 
 #: src/olympia/stats/templates/stats/reports/statuses.html:3
 msgid "Add-on Status by Date"
@@ -14868,27 +11690,19 @@ msgstr "Что такое ежедневные пользователи?"
 
 #: src/olympia/stats/templates/stats/reports/usage.html:11
 msgid ""
-"<h2>What are daily users?</h2> <p> Themes installed from this site check for"
-" updates once per day. The total number of these update pings is known as "
-"Active Daily Users, or the total number of people using your theme by day. "
-"</p>"
+"<h2>What are daily users?</h2> <p> Themes installed from this site check for updates once per day. The total number of these update pings is known as Active Daily Users, or the total number of "
+"people using your theme by day. </p>"
 msgstr ""
-"<h2>Что такое ежедневные пользователи?</h2> <p> Темы, установленные с этого "
-"сайта, проверяют наличие обновлений один раз в день. Общее число таких "
-"проверок на обновления известно как Активные Ежедневные Пользователи, или "
-"общее число людей, использующих вашу тему за день. </p>"
+"<h2>Что такое ежедневные пользователи?</h2> <p> Темы, установленные с этого сайта, проверяют наличие обновлений один раз в день. Общее число таких проверок на обновления известно как Активные "
+"Ежедневные Пользователи, или общее число людей, использующих вашу тему за день. </p>"
 
 #: src/olympia/stats/templates/stats/reports/usage.html:20
 msgid ""
-"<h2>What are daily users?</h2> <p> Add-ons downloaded from this site check "
-"for updates once per day. The total number of these update pings is known as"
-" Active Daily Users. Daily users can be broken down by add-on version, "
-"operating system, add-on status, application, and locale. </p>"
+"<h2>What are daily users?</h2> <p> Add-ons downloaded from this site check for updates once per day. The total number of these update pings is known as Active Daily Users. Daily users can be broken "
+"down by add-on version, operating system, add-on status, application, and locale. </p>"
 msgstr ""
-"<h2>Что такое ежедневные пользователи?</h2> <p> Темы, установленные с этого "
-"сайта, проверяют наличие обновлений один раз в день. Общее число таких "
-"проверок на обновления известно как Активные Ежедневные Пользователи, или "
-"общее число людей, использующих вашу тему за день. </p>"
+"<h2>Что такое ежедневные пользователи?</h2> <p> Темы, установленные с этого сайта, проверяют наличие обновлений один раз в день. Общее число таких проверок на обновления известно как Активные "
+"Ежедневные Пользователи, или общее число людей, использующих вашу тему за день. </p>"
 
 #: src/olympia/stats/templates/stats/reports/users_created.html:3
 msgid "User Signups by Date"
@@ -14898,46 +11712,27 @@ msgstr "Пользователей зарегистрировано, по дат
 msgid "Application versions by Date"
 msgstr "Версии приложения по дате"
 
-# {0} is a number
-#: src/olympia/tags/templates/tags/top_cloud.html:4
-msgid "Top {0} Tags"
-msgstr "{0} самых популярных меток"
-
-#. {0} is the current application name
-#: src/olympia/tags/templates/tags/top_cloud.html:14
-msgid "{0} Top Tags"
-msgstr "Самые популярные метки {0}"
-
-#: src/olympia/templates/amo_footer.html:6
-#: src/olympia/templates/includes/lang_switcher.html:2
+#: src/olympia/templates/amo_footer.html:6 src/olympia/templates/includes/lang_switcher.html:2
 msgid "Other languages"
 msgstr "Другие языки"
 
-#: src/olympia/templates/base.html:9 src/olympia/templates/impala/base.html:9
-#: src/olympia/templates/mobile/base_addons.html:9
+#: src/olympia/templates/base.html:9 src/olympia/templates/impala/base.html:9 src/olympia/templates/mobile/base_addons.html:9
 msgid "Mozilla Add-ons"
 msgstr "Дополнения Mozilla"
 
-#: src/olympia/templates/base.html:91
-#: src/olympia/templates/impala/base.html:81
+#: src/olympia/templates/base.html:89 src/olympia/templates/impala/base.html:78
 msgid "Find add-ons for other applications"
 msgstr "Найти дополнения для других приложений"
 
-#: src/olympia/templates/base.html:92
-#: src/olympia/templates/impala/base.html:81
+#: src/olympia/templates/base.html:90 src/olympia/templates/impala/base.html:78
 msgid "Other Applications"
 msgstr "Другие приложения"
 
-#: src/olympia/templates/base.html:141
-#: src/olympia/templates/impala/base.html:194
-msgid ""
-"To create your own collections, you must have a Mozilla Add-ons account."
-msgstr ""
-"Для создания своих подборок вам необходимо иметь учётную запись на сайте "
-"дополнений Mozilla."
+#: src/olympia/templates/base.html:141 src/olympia/templates/impala/base.html:194
+msgid "To create your own collections, you must have a Mozilla Add-ons account."
+msgstr "Для создания своих подборок вам необходимо иметь учётную запись на сайте дополнений Mozilla."
 
-#: src/olympia/templates/base.html:168
-#: src/olympia/templates/impala/base.html:215
+#: src/olympia/templates/base.html:168 src/olympia/templates/impala/base.html:215
 msgid "Footer logo"
 msgstr "Логотип внизу"
 
@@ -14954,21 +11749,19 @@ msgid "View Mobile Site"
 msgstr "Посетите мобильный сайт"
 
 #: src/olympia/templates/copyright.html:7
-msgid "Site Status "
+msgid "Site Status"
 msgstr "Статус сайта "
 
 #: src/olympia/templates/footer.html:3
 msgid "get to know <b>add-ons</b>"
 msgstr "узнайте о <b>дополнениях</b>"
 
-#: src/olympia/templates/footer.html:4
-#: src/olympia/templates/menu_links.html:20
+#: src/olympia/templates/footer.html:4 src/olympia/templates/menu_links.html:20
 msgid "About"
 msgstr "О сайте"
 
 # Link text to the AMO blog.
-#: src/olympia/templates/footer.html:5
-#: src/olympia/templates/menu_links.html:32
+#: src/olympia/templates/footer.html:5 src/olympia/templates/menu_links.html:32
 msgid "Blog"
 msgstr "Блог"
 
@@ -15045,9 +11838,7 @@ msgstr "Права"
 msgid "Contact Us"
 msgstr "Свяжитесь с нами"
 
-#: src/olympia/templates/user_login.html:22
-#: src/olympia/users/templates/users/edit.html:31
-#: src/olympia/users/templates/users/includes/navigation.html:12
+#: src/olympia/templates/user_login.html:22 src/olympia/users/templates/users/edit.html:31 src/olympia/users/templates/users/includes/navigation.html:12
 msgid "My Account"
 msgstr "Моя учётная запись"
 
@@ -15055,69 +11846,48 @@ msgstr "Моя учётная запись"
 msgid "Welcome, {0}"
 msgstr "Добро пожаловать, {0}"
 
-#: src/olympia/templates/user_login.html:41
-#: src/olympia/templates/impala/user_login.html:20
+#: src/olympia/templates/user_login.html:41 src/olympia/templates/impala/user_login.html:20
 #, python-format
 msgid "<a href=\"%(reg)s\">Register</a> or <a href=\"%(login)s\">Log in</a>"
-msgstr ""
-"<a href=\"%(reg)s\">Зарегистрируйтесь</a> или <a "
-"href=\"%(login)s\">Войдите</a>"
+msgstr "<a href=\"%(reg)s\">Зарегистрируйтесь</a> или <a href=\"%(login)s\">Войдите</a>"
 
-#: src/olympia/templates/impala/base.html:126
+#: src/olympia/templates/impala/base.html:123
 #, python-format
-msgid ""
-"To try the thousands of add-ons available here, download <a "
-"href=\"%(url)s\">Mozilla Firefox</a>, a fast, free way to surf the Web!"
-msgstr ""
-"Чтобы попробовать тысячи доступных здесь дополнений, загрузите <a "
-"href=\"%(url)s\">Mozilla Firefox</a>, быстрый, бесплатный способ веб-"
-"сёрфинга!"
+msgid "To try the thousands of add-ons available here, download <a href=\"%(url)s\">Mozilla Firefox</a>, a fast, free way to surf the Web!"
+msgstr "Чтобы попробовать тысячи доступных здесь дополнений, загрузите <a href=\"%(url)s\">Mozilla Firefox</a>, быстрый, бесплатный способ веб-сёрфинга!"
 
-#: src/olympia/templates/impala/base.html:138
+#: src/olympia/templates/impala/base.html:135
 #, python-format
-msgid ""
-"Add-ons is switching to Firefox Accounts for login. <a href=\"%(url)s\" "
-"class=\"fxa-login\">Sign in now to transfer your account.</a>"
-msgstr ""
-"Система входа на Дополнения переходит на Аккаунты Firefox. <a "
-"href=\"%(url)s\" class=\"fxa-login\">Войдите сейчас, чтобы перенести свою "
-"учетную запись.</a>"
+msgid "Add-ons is switching to Firefox Accounts for login. <a href=\"%(url)s\" class=\"fxa-login\">Sign in now to transfer your account.</a>"
+msgstr "Система входа на Дополнения переходит на Аккаунты Firefox. <a href=\"%(url)s\" class=\"fxa-login\">Войдите сейчас, чтобы перенести свою учетную запись.</a>"
 
 #. {0} is an application, such as Firefox.
-#: src/olympia/templates/impala/base.html:148
+#: src/olympia/templates/impala/base.html:145
 msgid "Welcome to {0} Add-ons."
 msgstr "Добро пожаловать в дополнения {0}."
 
-#: src/olympia/templates/impala/base.html:151
-msgid ""
-"Choose from thousands of extra features and styles to make Firefox your own."
-msgstr ""
-"Выбирайте из тысяч дополнительных функций и стилей, чтобы настроить Firefox "
-"по своему вкусу."
+#: src/olympia/templates/impala/base.html:148
+msgid "Choose from thousands of extra features and styles to make Firefox your own."
+msgstr "Выбирайте из тысяч дополнительных функций и стилей, чтобы настроить Firefox по своему вкусу."
 
-#: src/olympia/templates/impala/base.html:156
+#: src/olympia/templates/impala/base.html:153
 #, python-format
 msgid "Add extra features and styles to make %(app)s your own."
-msgstr ""
-"Добавляйте дополнительные функции и стили, чтобы настроить %(app)s по своему"
-" вкусу."
+msgstr "Добавляйте дополнительные функции и стили, чтобы настроить %(app)s по своему вкусу."
 
-#: src/olympia/templates/impala/base.html:164
+#: src/olympia/templates/impala/base.html:161
 msgid "On the go?"
 msgstr "В пути?"
 
-#: src/olympia/templates/impala/base.html:166
+#: src/olympia/templates/impala/base.html:163
 msgid "Check out our <a class=\"mobile-link\" href=\"#\">Mobile Add-ons site</a>."
-msgstr ""
-"Зайдите на наш <a class=\"mobile-link\" href=\"#\">сайт мобильных "
-"дополнений</a> ."
+msgstr "Зайдите на наш <a class=\"mobile-link\" href=\"#\">сайт мобильных дополнений</a> ."
 
 #: src/olympia/templates/impala/header_title.html:21
 msgid "Android Add-ons"
 msgstr "Дополнения Android"
 
-#: src/olympia/templates/includes/forms.html:2
-#: src/olympia/templates/includes/forms.html:6
+#: src/olympia/templates/includes/forms.html:2 src/olympia/templates/includes/forms.html:6
 msgid "required"
 msgstr "требуется"
 
@@ -15162,15 +11932,11 @@ msgstr "Посетить Mozilla"
 msgid "menu"
 msgstr "меню"
 
-#: src/olympia/templates/mobile/header_auth.html:7
-#: src/olympia/users/templates/users/register.html:41
-#: src/olympia/users/templates/users/register.html:89
+#: src/olympia/templates/mobile/header_auth.html:7 src/olympia/users/templates/users/register.html:41 src/olympia/users/templates/users/register.html:89
 msgid "Register"
 msgstr "Регистрация"
 
-#: src/olympia/templates/mobile/header_auth.html:8
-#: src/olympia/users/templates/users/login_form.html:41
-#: src/olympia/users/templates/users/pwreset_complete.html:15
+#: src/olympia/templates/mobile/header_auth.html:8 src/olympia/users/templates/users/login_form.html:41 src/olympia/users/templates/users/pwreset_complete.html:15
 #: src/olympia/users/templates/users/mobile/login.html:56
 msgid "Log in"
 msgstr "Войти"
@@ -15181,8 +11947,7 @@ msgstr "Войти"
 msgid "Localize for: <a id=\"change-locale\" href=\"#\">%(dl)s</a>"
 msgstr "Локализовать на: <a id=\"change-locale\" href=\"#\">%(dl)s</a>"
 
-#: src/olympia/translations/templates/translations/trans-menu.html:16
-#: src/olympia/translations/templates/translations/trans-menu.html:29
+#: src/olympia/translations/templates/translations/trans-menu.html:16 src/olympia/translations/templates/translations/trans-menu.html:29
 #, python-format
 msgid "%(title)s <em>&middot; %(lang)s</em>"
 msgstr "%(title)s <em>&middot; %(lang)s</em>"
@@ -15197,12 +11962,8 @@ msgstr "Новые локализации"
 
 #. {0} is a language name, like 'French'
 #: src/olympia/translations/templates/translations/trans-menu.html:42
-msgid ""
-"You have unsaved changes in the <b>{0}</b> locale. Would you like to save "
-"your changes before switching locales?"
-msgstr ""
-"У вас имеются несохранённые изменения в <b>{0}</b> локали. Вы хотите "
-"сохранить изменения перед переключением локалей?"
+msgid "You have unsaved changes in the <b>{0}</b> locale. Would you like to save your changes before switching locales?"
+msgstr "У вас имеются несохранённые изменения в <b>{0}</b> локали. Вы хотите сохранить изменения перед переключением локалей?"
 
 #: src/olympia/translations/templates/translations/trans-menu.html:49
 msgid "Discard Changes"
@@ -15210,12 +11971,8 @@ msgstr "Отменить изменения"
 
 #. {0} is a language name, like 'French'
 #: src/olympia/translations/templates/translations/trans-menu.html:56
-msgid ""
-"Are you sure you want to remove all <b>{0}</b> translations? This cannot be "
-"undone."
-msgstr ""
-"Вы уверены что вы хотите удалить все <b>{0}</b> переводов? Это не может быть"
-" отменено."
+msgid "Are you sure you want to remove all <b>{0}</b> translations? This cannot be undone."
+msgstr "Вы уверены что вы хотите удалить все <b>{0}</b> переводов? Это не может быть отменено."
 
 #: src/olympia/translations/templates/translations/trans-menu.html:61
 msgid "Delete Locale"
@@ -15236,25 +11993,14 @@ msgstr "Этот пароль не разрешён."
 
 #: src/olympia/users/forms.py:90
 #, python-format
-msgid ""
-"As part of our new password policy, your password must be %s characters or "
-"more. Please update your password by <a href=\"%s\">issuing a password "
-"reset</a>."
-msgstr ""
-"В рамках нашей новой политики паролей, длина вашего пароля должна быть не "
-"менее %s символов. Пожалуйста, обновите свой ​​пароль, <a "
-"href=\"%s\">выполнив сброс пароля</a>."
+msgid "As part of our new password policy, your password must be %s characters or more. Please update your password by <a href=\"%s\">issuing a password reset</a>."
+msgstr "В рамках нашей новой политики паролей, длина вашего пароля должна быть не менее %s символов. Пожалуйста, обновите свой ​​пароль, <a href=\"%s\">выполнив сброс пароля</a>."
 
 #: src/olympia/users/forms.py:115
-msgid ""
-"You must recover your password through Firefox Accounts. Try logging in "
-"instead."
-msgstr ""
-"Вы должны восстанавливать пароль через аккаунт Firefox. Попробуйте войти "
-"вместо этого."
+msgid "You must recover your password through Firefox Accounts. Try logging in instead."
+msgstr "Вы должны восстанавливать пароль через аккаунт Firefox. Попробуйте войти вместо этого."
 
-#: src/olympia/users/forms.py:206
-#: src/olympia/users/templates/users/pwreset_confirm.html:24
+#: src/olympia/users/forms.py:206 src/olympia/users/templates/users/pwreset_confirm.html:24
 msgid "New password"
 msgstr "Новый пароль"
 
@@ -15267,12 +12013,8 @@ msgid "Usernames cannot contain only digits."
 msgstr "Имена пользователей не могут содержать только цифры."
 
 #: src/olympia/users/forms.py:274
-msgid ""
-"Enter a valid username consisting of letters, numbers, underscores or "
-"hyphens."
-msgstr ""
-"Введите корректное имя пользователя, состоящее из букв, цифр, подчеркиваний "
-"или дефисов."
+msgid "Enter a valid username consisting of letters, numbers, underscores or hyphens."
+msgstr "Введите корректное имя пользователя, состоящее из букв, цифр, подчеркиваний или дефисов."
 
 #: src/olympia/users/forms.py:277
 msgid "This username cannot be used."
@@ -15282,38 +12024,25 @@ msgstr "Это имя пользователя не может быть испо
 msgid "This username is already in use."
 msgstr "Это имя пользователя уже используется."
 
-#: src/olympia/users/forms.py:296
-#: src/olympia/users/templates/users/edit.html:107
+#: src/olympia/users/forms.py:296 src/olympia/users/templates/users/edit.html:107
 msgid "Display Name"
 msgstr "Отображаемое имя"
 
-#: src/olympia/users/forms.py:298
-#: src/olympia/users/templates/users/edit.html:112
-#: src/olympia/users/templates/users/vcard.html:10
+#: src/olympia/users/forms.py:298 src/olympia/users/templates/users/edit.html:112 src/olympia/users/templates/users/vcard.html:10
 msgid "Location"
 msgstr "Местонахождение"
 
-#: src/olympia/users/forms.py:300
-#: src/olympia/users/templates/users/edit.html:117
-#: src/olympia/users/templates/users/vcard.html:16
+#: src/olympia/users/forms.py:300 src/olympia/users/templates/users/edit.html:117 src/olympia/users/templates/users/vcard.html:16
 msgid "Occupation"
 msgstr "Род деятельности"
 
 #: src/olympia/users/forms.py:329
-msgid ""
-"This URL has an invalid format. Valid URLs look like "
-"http://example.com/my_page."
-msgstr ""
-"Этот URL имеет неверный формат. Правильные URL имеют вид "
-"http://example.com/my_page."
+msgid "This URL has an invalid format. Valid URLs look like http://example.com/my_page."
+msgstr "Этот URL имеет неверный формат. Правильные URL имеют вид http://example.com/my_page."
 
 #: src/olympia/users/forms.py:337
-msgid ""
-"Please use an email address from a different provider to complete your "
-"registration."
-msgstr ""
-"Пожалуйста, используйте адрес электронной почты от другого провайдера, чтобы"
-" завершить вашу регистрацию."
+msgid "Please use an email address from a different provider to complete your registration."
+msgstr "Пожалуйста, используйте адрес электронной почты от другого провайдера, чтобы завершить вашу регистрацию."
 
 #: src/olympia/users/forms.py:345
 msgid "This display name cannot be used."
@@ -15323,21 +12052,17 @@ msgstr "Это отображаемое имя не может быть испо
 msgid "The passwords did not match."
 msgstr "Пароли не совпадают."
 
-#: src/olympia/users/forms.py:377
-#: src/olympia/users/templates/users/edit.html:128
+#: src/olympia/users/forms.py:377 src/olympia/users/templates/users/edit.html:128
 msgid "Profile Photo"
 msgstr "Фото профиля"
 
-#: src/olympia/users/forms.py:385
-#: src/olympia/users/templates/users/edit.html:142
+#: src/olympia/users/forms.py:385 src/olympia/users/templates/users/edit.html:142
 msgid "Default locale"
 msgstr "Локаль по умолчанию"
 
 #: src/olympia/users/forms.py:412
 msgid "Firefox Accounts users cannot currently change their email address."
-msgstr ""
-"Пользователи Firefox аккаунтов в настоящий момент не могут изменять их "
-"адреса электронной почты."
+msgstr "Пользователи Firefox аккаунтов в настоящий момент не могут изменять их адреса электронной почты."
 
 #: src/olympia/users/forms.py:446
 msgid "Wrong password entered!"
@@ -15348,12 +12073,8 @@ msgid "Email cannot be changed."
 msgstr "Адрес электронной почты не может быть изменён."
 
 #: src/olympia/users/forms.py:541
-msgid ""
-"To anonymize, enter a reason for the change but do not change any other "
-"field."
-msgstr ""
-"Для анонимизации, введите причину изменения, но не изменяйте никакое другое "
-"поле."
+msgid "To anonymize, enter a reason for the change but do not change any other field."
+msgstr "Для анонимизации, введите причину изменения, но не изменяйте никакое другое поле."
 
 #: src/olympia/users/forms.py:587
 msgid "Please enter at least one name to blacklist."
@@ -15382,19 +12103,19 @@ msgstr "Нет пользователя с таким почтовым адре�
 
 #. L10n: {id} will be something like "13ad6a", just a random number
 #. to differentiate this user from other anonymous users.
-#: src/olympia/users/models.py:353
+#: src/olympia/users/models.py:362
 msgid "Anonymous user {id}"
 msgstr "Анонимный пользователь {id}"
 
-#: src/olympia/users/models.py:410
+#: src/olympia/users/models.py:419
 msgid "Your account has been restricted"
 msgstr "Ваша учётная запись была ограничена"
 
-#: src/olympia/users/models.py:480
+#: src/olympia/users/models.py:489
 msgid "Please confirm your email address"
 msgstr "Пожалуйста, подтвердите свой адрес электронной почты"
 
-#: src/olympia/users/models.py:506
+#: src/olympia/users/models.py:515
 msgid "My Mobile Add-ons"
 msgstr "Мои мобильные дополнения"
 
@@ -15448,8 +12169,7 @@ msgstr "моё дополнение проверено редактором"
 
 #: src/olympia/users/notifications.py:117
 msgid "Mozilla needs to contact me about my individual add-on"
-msgstr ""
-"Mozilla необходимо связаться по поводу моего индивидуального дополнения"
+msgstr "Mozilla необходимо связаться по поводу моего индивидуального дополнения"
 
 #: src/olympia/users/notifications.py:126
 msgid "my app is reviewed by an editor"
@@ -15460,17 +12180,12 @@ msgid "Mozilla needs to contact me about my individual app"
 msgstr "Mozilla необходимо связаться со мной по поводу моего приложения"
 
 #: src/olympia/users/notifications.py:139
-msgid ""
-"Mozilla wants to contact me about relevant App Developer news and surveys"
-msgstr ""
-"Mozilla хочет связаться со мной по поводу новостей и опросов для "
-"Разработчиков Приложений"
+msgid "Mozilla wants to contact me about relevant App Developer news and surveys"
+msgstr "Mozilla хочет связаться со мной по поводу новостей и опросов для Разработчиков Приложений"
 
 #: src/olympia/users/notifications.py:150
 msgid "Mozilla wants to contact me about new regions added to the Marketplace"
-msgstr ""
-"Mozilla хочет связаться со мной по поводу новых регионов, добавленных на "
-"Marketplace"
+msgstr "Mozilla хочет связаться со мной по поводу новых регионов, добавленных на Marketplace"
 
 #: src/olympia/users/notifications.py:158
 msgid "User Notifications"
@@ -15493,14 +12208,8 @@ msgid "Successfully verified!"
 msgstr "Проверка успешно завершена!"
 
 #: src/olympia/users/views.py:132
-msgid ""
-"An email has been sent to your address to confirm your account. Before you "
-"can log in, you have to activate your account by clicking on the link "
-"provided in this email."
-msgstr ""
-"Для подтверждения создания аккаунта на вашу электронную почту было "
-"отправлено письмо. Перед тем как войти, вы должны активировать учётную "
-"запись, щёлкнув по ссылке, находящейся в этом письме."
+msgid "An email has been sent to your address to confirm your account. Before you can log in, you have to activate your account by clicking on the link provided in this email."
+msgstr "Для подтверждения создания аккаунта на вашу электронную почту было отправлено письмо. Перед тем как войти, вы должны активировать учётную запись, щёлкнув по ссылке, находящейся в этом письме."
 
 #: src/olympia/users/views.py:136 src/olympia/users/views.py:619
 msgid "Confirmation Email Sent"
@@ -15524,37 +12233,28 @@ msgstr "Запрос на подтверждение отправлен в пи�
 
 #: src/olympia/users/views.py:197
 msgid ""
-"An email has been sent to {0} to confirm your new email address. For the "
-"change to take effect, you need to click on the link provided in this email."
-" Until then, you can keep logging in with your current email address."
+"An email has been sent to {0} to confirm your new email address. For the change to take effect, you need to click on the link provided in this email. Until then, you can keep logging in with your "
+"current email address."
 msgstr ""
-"Для подтверждения вашего нового адреса эл. почты на адрес {0} было "
-"отправлено письмо. Для произведения смены, вам необходимо щёлкнуть по "
-"ссылке, указанной в этом письме. До тех пор вы можете входить, используя ваш"
-" текущий адрес эл. почты."
+"Для подтверждения вашего нового адреса эл. почты на адрес {0} было отправлено письмо. Для произведения смены, вам необходимо щёлкнуть по ссылке, указанной в этом письме. До тех пор вы можете "
+"входить, используя ваш текущий адрес эл. почты."
 
 #: src/olympia/users/views.py:210
 #, python-format
 msgid "Please confirm your email address change at %s"
-msgstr ""
-"Пожалуйста, подтвердите изменение своего адреса электронной почты на %s"
+msgstr "Пожалуйста, подтвердите изменение своего адреса электронной почты на %s"
 
 #: src/olympia/users/views.py:224
 msgid "Errors Found"
 msgstr "Найдены ошибки"
 
 #: src/olympia/users/views.py:225
-msgid ""
-"There were errors in the changes you made. Please correct them and resubmit."
-msgstr ""
-"В изменениях, которые вы сделали, имеются ошибки. Исправьте их и отправьте "
-"данные заново…"
+msgid "There were errors in the changes you made. Please correct them and resubmit."
+msgstr "В изменениях, которые вы сделали, имеются ошибки. Исправьте их и отправьте данные заново…"
 
 #: src/olympia/users/views.py:273
-msgid ""
-"We're sorry, but you are not eligible to request a t-shirt at this time."
-msgstr ""
-"Мы сожалеем, но в данное время у вас отсутствует право на запрос футболки."
+msgid "We're sorry, but you are not eligible to request a t-shirt at this time."
+msgstr "Мы сожалеем, но в данное время у вас отсутствует право на запрос футболки."
 
 #: src/olympia/users/views.py:329
 msgid "Your email address was changed successfully"
@@ -15569,25 +12269,17 @@ msgid "Wrong email address or password!"
 msgstr "Неверный почтовый адрес или пароль!"
 
 #: src/olympia/users/views.py:434
-msgid ""
-"A link to activate your user account was sent by email to your address {0}. "
-"You have to click it before you can log in."
-msgstr ""
-"Ссылка для активации вашей учётной записи была отправлена по почте на ваш "
-"адрес {0}. Вы должны щёлкнуть по ней перед тем, как сможете войти на сайт."
+msgid "A link to activate your user account was sent by email to your address {0}. You have to click it before you can log in."
+msgstr "Ссылка для активации вашей учётной записи была отправлена по почте на ваш адрес {0}. Вы должны щёлкнуть по ней перед тем, как сможете войти на сайт."
 
 #: src/olympia/users/views.py:439
 #, python-format
 msgid ""
-"If you did not receive the confirmation email, make sure your email service "
-"did not mark it as \"junk mail\" or \"spam\". If you need to, you can have "
-"us <a href=\"%s\">resend the confirmation message</a> to your email address "
-"mentioned above."
+"If you did not receive the confirmation email, make sure your email service did not mark it as \"junk mail\" or \"spam\". If you need to, you can have us <a href=\"%s\">resend the confirmation "
+"message</a> to your email address mentioned above."
 msgstr ""
-"Если вы не получили письмо с подтверждением, убедитесь, что ваша почтовая "
-"служба не пометила его как \"нежелательная почта\" или \"спам\". Если нужно,"
-" мы можем <a href=\"%s\">повторно послать сообщение с подтверждением</a> на "
-"ваш адрес эл. почты, упомянутый выше."
+"Если вы не получили письмо с подтверждением, убедитесь, что ваша почтовая служба не пометила его как \"нежелательная почта\" или \"спам\". Если нужно, мы можем <a href=\"%s\">повторно послать "
+"сообщение с подтверждением</a> на ваш адрес эл. почты, упомянутый выше."
 
 #: src/olympia/users/views.py:444
 msgid "Activation Email Sent"
@@ -15607,14 +12299,8 @@ msgstr "Поздравляем! Ваша учётная запись успеш�
 
 # %1 is the user's email address
 #: src/olympia/users/views.py:615
-msgid ""
-"An email has been sent to your address {0} to confirm your account. Before "
-"you can log in, you have to activate your account by clicking on the link "
-"provided in this email."
-msgstr ""
-"Для подтверждения создания учётной записи по адресу {0} было отправлено "
-"письмо. Перед тем как войти, вы должны активировать учётную запись, щёлкнув "
-"по ссылке, находящейся в этом письме."
+msgid "An email has been sent to your address {0} to confirm your account. Before you can log in, you have to activate your account by clicking on the link provided in this email."
+msgstr "Для подтверждения создания учётной записи по адресу {0} было отправлено письмо. Перед тем как войти, вы должны активировать учётную запись, щёлкнув по ссылке, находящейся в этом письме."
 
 #: src/olympia/users/views.py:639
 msgid "There are errors in this form"
@@ -15632,32 +12318,22 @@ msgstr "О пользователе сообщено."
 msgid "new"
 msgstr "новое"
 
-#: src/olympia/users/templates/users/delete.html:4
-#: src/olympia/users/templates/users/delete.html:10
+#: src/olympia/users/templates/users/delete.html:4 src/olympia/users/templates/users/delete.html:10
 msgid "Delete User Account"
 msgstr "Удаление учётной записи"
 
 #: src/olympia/users/templates/users/delete.html:14
 #, python-format
 msgid ""
-"You cannot delete your account if you are listed as an <a href=\"%(link)s\">"
-" author of any add-ons</a>. To delete your account, please have another "
-"person in your development group delete you from the list of authors for "
-"your add-ons. Afterwards you will be able to delete your account here."
+"You cannot delete your account if you are listed as an <a href=\"%(link)s\"> author of any add-ons</a>. To delete your account, please have another person in your development group delete you from "
+"the list of authors for your add-ons. Afterwards you will be able to delete your account here."
 msgstr ""
-"Вы не можете удалить свою учётную запись, если вы указаны как <a "
-"href=\"%(link)s\">автор какого-либо из дополнений</a>. Чтобы удалить свою "
-"учётную запись, пожалуйста, попросите кого-нибудь из вашей группы "
-"разработчиков удалить вас из списка авторов в ваших дополнениях. После этого"
-" вы сможете удалить здесь свою учётную запись."
+"Вы не можете удалить свою учётную запись, если вы указаны как <a href=\"%(link)s\">автор какого-либо из дополнений</a>. Чтобы удалить свою учётную запись, пожалуйста, попросите кого-нибудь из вашей "
+"группы разработчиков удалить вас из списка авторов в ваших дополнениях. После этого вы сможете удалить здесь свою учётную запись."
 
 #: src/olympia/users/templates/users/delete.html:29
-msgid ""
-"By clicking \"delete\" your account is going to be <strong>permanently "
-"removed</strong>. That means:"
-msgstr ""
-"Щелчок по \"удалить\" приведёт к <strong>полному удалению</strong> вашей "
-"учётной записи. Это означает, что:"
+msgid "By clicking \"delete\" your account is going to be <strong>permanently removed</strong>. That means:"
+msgstr "Щелчок по \"удалить\" приведёт к <strong>полному удалению</strong> вашей учётной записи. Это означает, что:"
 
 #: src/olympia/users/templates/users/delete.html:35
 #, python-format
@@ -15665,12 +12341,8 @@ msgid "You will not be able to log into %(site)s anymore."
 msgstr "Вы больше не сможете войти на %(site)s."
 
 #: src/olympia/users/templates/users/delete.html:40
-msgid ""
-"Your reviews and ratings will not be deleted, but they will no longer be "
-"associated with you."
-msgstr ""
-"Ваши отзывы и рейтинги не будут удалены, но они больше не будут связаны с "
-"вами."
+msgid "Your reviews and ratings will not be deleted, but they will no longer be associated with you."
+msgstr "Ваши отзывы и рейтинги не будут удалены, но они больше не будут связаны с вами."
 
 #: src/olympia/users/templates/users/delete.html:46
 msgid "Confirm account deletion"
@@ -15684,8 +12356,7 @@ msgstr "Я понимаю, что этот шаг не может быть от�
 msgid "Delete my user account now"
 msgstr "Удалить мою учётную запись"
 
-#: src/olympia/users/templates/users/delete_photo.html:3
-#: src/olympia/users/templates/users/delete_photo.html:9
+#: src/olympia/users/templates/users/delete_photo.html:3 src/olympia/users/templates/users/delete_photo.html:9
 msgid "Delete User Photo"
 msgstr "Удалить фото пользователя"
 
@@ -15698,27 +12369,18 @@ msgid "Please set your display name"
 msgstr "Пожалуйста, введите свое отображаемое имя"
 
 #: src/olympia/users/templates/users/edit.html:21
-msgid ""
-"Please set your display name or username to complete the registration "
-"process."
-msgstr ""
-"Пожалуйста, введите отображаемое имя или имя пользователя, чтобы завершить "
-"процесс регистрации."
+msgid "Please set your display name or username to complete the registration process."
+msgstr "Пожалуйста, введите отображаемое имя или имя пользователя, чтобы завершить процесс регистрации."
 
 #: src/olympia/users/templates/users/edit.html:33
 msgid "Manage basic account information, such as username and email address."
-msgstr ""
-"Управление базовой информацией учетной записи, такой как имя пользователя и "
-"адрес электронной почты."
+msgstr "Управление базовой информацией учетной записи, такой как имя пользователя и адрес электронной почты."
 
-#: src/olympia/users/templates/users/edit.html:39
-#: src/olympia/users/templates/users/register.html:47
+#: src/olympia/users/templates/users/edit.html:39 src/olympia/users/templates/users/register.html:47
 msgid "Username"
 msgstr "Имя пользователя"
 
-#: src/olympia/users/templates/users/edit.html:45
-#: src/olympia/users/templates/users/pwreset_request.html:21
-#: src/olympia/users/templates/users/register.html:62
+#: src/olympia/users/templates/users/edit.html:45 src/olympia/users/templates/users/pwreset_request.html:21 src/olympia/users/templates/users/register.html:62
 msgid "Email Address"
 msgstr "Адрес эл. почты"
 
@@ -15730,21 +12392,15 @@ msgstr "Управление аккаунтом Firefox..."
 msgid "Change Password"
 msgstr "Сменить пароль"
 
-#: src/olympia/users/templates/users/edit.html:68
-#: src/olympia/users/templates/users/login_form.html:22
-#: src/olympia/users/templates/users/register.html:67
+#: src/olympia/users/templates/users/edit.html:68 src/olympia/users/templates/users/login_form.html:22 src/olympia/users/templates/users/register.html:67
 #: src/olympia/users/templates/users/mobile/login.html:37
 msgid "Password"
 msgstr "Пароль"
 
 #: src/olympia/users/templates/users/edit.html:70
 #, python-format
-msgid ""
-"Change your password.  If you forgot your password, you can <a "
-"href=\"%(reset_url)s\">use the reset form</a>."
-msgstr ""
-"Измените ваш пароль.  Если вы забыли свой ​​пароль, вы можете <a "
-"href=\"%(reset_url)s\">использовать форму сброса</a>."
+msgid "Change your password. If you forgot your password, you can <a href=\"%(reset_url)s\">use the reset form</a>."
+msgstr "Измените ваш пароль.  Если вы забыли свой ​​пароль, вы можете <a href=\"%(reset_url)s\">использовать форму сброса</a>."
 
 #: src/olympia/users/templates/users/edit.html:76
 msgid "Old Password"
@@ -15763,12 +12419,8 @@ msgid "Profile"
 msgstr "Профиль"
 
 #: src/olympia/users/templates/users/edit.html:100
-msgid ""
-"Give us a bit more information about yourself.  All these fields are "
-"optional, but they'll help other users get to know you better."
-msgstr ""
-"Сообщите немного больше информации о себе.  Все эти поля являются "
-"необязательными, но они помогут другим пользователям лучше узнать вас."
+msgid "Give us a bit more information about yourself. All these fields are optional, but they'll help other users get to know you better."
+msgstr "Сообщите немного больше информации о себе.  Все эти поля являются необязательными, но они помогут другим пользователям лучше узнать вас."
 
 #: src/olympia/users/templates/users/edit.html:124
 msgid "This URL will only be visible if you are a developer."
@@ -15783,20 +12435,12 @@ msgid "Delete current photo"
 msgstr "Удалить текущее фото"
 
 #: src/olympia/users/templates/users/edit.html:144
-msgid ""
-"This is the default locale used to display information about you (like your "
-"description)."
-msgstr ""
-"Это локаль по умолчанию, используемая для отображения информации о вас "
-"(например, вашего описания)."
+msgid "This is the default locale used to display information about you (like your description)."
+msgstr "Это локаль по умолчанию, используемая для отображения информации о вас (например, вашего описания)."
 
 #: src/olympia/users/templates/users/edit.html:152
-msgid ""
-"Introduce yourself to the community, if you like! This text will appear "
-"publicly on your user info page."
-msgstr ""
-"Представьте себя сообществу, если хотите! Этот текст будет публично доступен"
-" на вашей странице информации пользователя."
+msgid "Introduce yourself to the community, if you like! This text will appear publicly on your user info page."
+msgstr "Представьте себя сообществу, если хотите! Этот текст будет публично доступен на вашей странице информации пользователя."
 
 #: src/olympia/users/templates/users/edit.html:161
 msgid "Allowed HTML: {0}. Links are forbidden."
@@ -15823,21 +12467,12 @@ msgid "Notifications"
 msgstr "Уведомления"
 
 #: src/olympia/users/templates/users/edit.html:195
-msgid ""
-"From time to time, Mozilla may send you email about upcoming releases and "
-"add-on events. Please select the topics you are interested in."
-msgstr ""
-"Время от времени Mozilla может посылать вам письма о выходящих вскоре "
-"релизах и событиях, касающихся дополнений. Пожалуйста, выберите темы, в "
-"которых вы заинтересованы:"
+msgid "From time to time, Mozilla may send you email about upcoming releases and add-on events. Please select the topics you are interested in."
+msgstr "Время от времени Mozilla может посылать вам письма о выходящих вскоре релизах и событиях, касающихся дополнений. Пожалуйста, выберите темы, в которых вы заинтересованы:"
 
 #: src/olympia/users/templates/users/edit.html:205
-msgid ""
-"Mozilla reserves the right to contact you individually about specific "
-"concerns with your hosted add-ons."
-msgstr ""
-"Mozilla оставляет за собой право связаться с вами лично, в случае, если "
-"возникнут вопросы по размещенным вами дополнениям."
+msgid "Mozilla reserves the right to contact you individually about specific concerns with your hosted add-ons."
+msgstr "Mozilla оставляет за собой право связаться с вами лично, в случае, если возникнут вопросы по размещенным вами дополнениям."
 
 #: src/olympia/users/templates/users/edit.html:215
 msgid "Admin"
@@ -15859,63 +12494,49 @@ msgstr "нет"
 msgid "all"
 msgstr "все"
 
-#: src/olympia/users/templates/users/fxa_migration.html:3
-#: src/olympia/users/templates/users/fxa_migration.html:11
-#: src/olympia/users/templates/users/mobile/fxa_migration.html:3
+#: src/olympia/users/templates/users/fxa_migration.html:3 src/olympia/users/templates/users/fxa_migration.html:11 src/olympia/users/templates/users/mobile/fxa_migration.html:3
 #: src/olympia/users/templates/users/mobile/fxa_migration.html:8
 msgid "Migrate to Firefox Accounts"
 msgstr "Переход на Firefox аккаунты"
 
 #: src/olympia/users/templates/users/fxa_migration_prompt_content.html:3
-msgid ""
-"Mozilla Add-ons has transitioned to Firefox Accounts for login. Continue to "
-"complete the simple upgrade process."
-msgstr ""
-"Сайт дополнений Mozilla теперь использует для входа учетную запись Firefox. "
-"Продолжите для завершения этого простого процесса обновления."
+msgid "Mozilla Add-ons has transitioned to Firefox Accounts for login. Continue to complete the simple upgrade process."
+msgstr "Сайт дополнений Mozilla теперь использует для входа учетную запись Firefox. Продолжите для завершения этого простого процесса обновления."
 
 #: src/olympia/users/templates/users/fxa_migration_prompt_content.html:14
 msgid "Skip"
 msgstr "Пропустить"
 
-#: src/olympia/users/templates/users/login.html:3
-#: src/olympia/users/templates/users/mobile/login.html:3
+#: src/olympia/users/templates/users/login.html:3 src/olympia/users/templates/users/mobile/login.html:3
 msgid "User Login"
 msgstr "Вход пользователя"
 
-#: src/olympia/users/templates/users/login.html:13
-#: src/olympia/users/templates/users/mobile/login.html:21
+#: src/olympia/users/templates/users/login.html:13 src/olympia/users/templates/users/mobile/login.html:21
 msgid "Enter your email"
 msgstr "Введите ваш адрес электронной почты"
 
-#: src/olympia/users/templates/users/login.html:15
-#: src/olympia/users/templates/users/mobile/login.html:23
+#: src/olympia/users/templates/users/login.html:15 src/olympia/users/templates/users/mobile/login.html:23
 msgid "Log In"
 msgstr "Войти"
 
-#: src/olympia/users/templates/users/login_form.html:17
-#: src/olympia/users/templates/users/mobile/login.html:32
+#: src/olympia/users/templates/users/login_form.html:17 src/olympia/users/templates/users/mobile/login.html:32
 msgid "Email address"
 msgstr "Адрес эл. почты"
 
-#: src/olympia/users/templates/users/login_form.html:30
-#: src/olympia/users/templates/users/mobile/login.html:44
+#: src/olympia/users/templates/users/login_form.html:30 src/olympia/users/templates/users/mobile/login.html:44
 msgid "Remember me on this device"
 msgstr "Запомнить меня на этом устройстве"
 
 # This is a header for additional help options
-#: src/olympia/users/templates/users/login_help.html:3
-#: src/olympia/users/templates/users/mobile/login.html:63
+#: src/olympia/users/templates/users/login_help.html:3 src/olympia/users/templates/users/mobile/login.html:63
 msgid "Login Problems?"
 msgstr "Проблемы со входом?"
 
-#: src/olympia/users/templates/users/login_help.html:5
-#: src/olympia/users/templates/users/mobile/login.html:65
+#: src/olympia/users/templates/users/login_help.html:5 src/olympia/users/templates/users/mobile/login.html:65
 msgid "I don't have an account."
 msgstr "У меня нет учётной записи."
 
-#: src/olympia/users/templates/users/login_help.html:6
-#: src/olympia/users/templates/users/mobile/login.html:66
+#: src/olympia/users/templates/users/login_help.html:6 src/olympia/users/templates/users/mobile/login.html:66
 msgid "I forgot my password."
 msgstr "Я забыл свой пароль."
 
@@ -15924,15 +12545,9 @@ msgstr "Я забыл свой пароль."
 msgid "You are now logged in as <strong>%(user_email)s</strong>!"
 msgstr "Вы вошли сейчас как <strong>%(user_email)s</strong>!"
 
-#: src/olympia/users/templates/users/newpw_sent.html:3
-#: src/olympia/users/templates/users/newpw_sent.html:8
-#: src/olympia/users/templates/users/pwreset_complete.html:3
-#: src/olympia/users/templates/users/pwreset_confirm.html:4
-#: src/olympia/users/templates/users/pwreset_confirm.html:18
-#: src/olympia/users/templates/users/pwreset_request.html:4
-#: src/olympia/users/templates/users/pwreset_request.html:10
-#: src/olympia/users/templates/users/pwreset_sent.html:3
-#: src/olympia/users/templates/users/pwreset_sent.html:8
+#: src/olympia/users/templates/users/newpw_sent.html:3 src/olympia/users/templates/users/newpw_sent.html:8 src/olympia/users/templates/users/pwreset_complete.html:3
+#: src/olympia/users/templates/users/pwreset_confirm.html:4 src/olympia/users/templates/users/pwreset_confirm.html:18 src/olympia/users/templates/users/pwreset_request.html:4
+#: src/olympia/users/templates/users/pwreset_request.html:10 src/olympia/users/templates/users/pwreset_sent.html:3 src/olympia/users/templates/users/pwreset_sent.html:8
 msgid "Password Reset"
 msgstr "Сброс пароля"
 
@@ -15948,8 +12563,7 @@ msgstr "Изменить профиль"
 msgid "Manage user"
 msgstr "Управление пользователем"
 
-#: src/olympia/users/templates/users/profile.html:18
-#: src/olympia/users/templates/users/report_abuse_full.html:9
+#: src/olympia/users/templates/users/profile.html:18 src/olympia/users/templates/users/report_abuse_full.html:9
 msgid "Report user"
 msgstr "Пожаловаться на пользователя"
 
@@ -16012,39 +12626,25 @@ msgstr "Успех!"
 msgid "Password successfully reset."
 msgstr "Пароль успешно сброшен."
 
-#: src/olympia/users/templates/users/pwreset_confirm.html:13
-#: src/olympia/users/templates/users/pwreset_confirm.html:46
+#: src/olympia/users/templates/users/pwreset_confirm.html:13 src/olympia/users/templates/users/pwreset_confirm.html:46
 msgid "Password reset unsuccessful"
 msgstr "Неудачный сброс пароля "
 
 #: src/olympia/users/templates/users/pwreset_confirm.html:14
-msgid ""
-"You have migrated to Firefox Accounts. You can no longer change your "
-"password here."
-msgstr ""
-"Вы перешли на аккаунты Firefox. Вы больше не сможете менять свой пароль "
-"здесь."
+msgid "You have migrated to Firefox Accounts. You can no longer change your password here."
+msgstr "Вы перешли на аккаунты Firefox. Вы больше не сможете менять свой пароль здесь."
 
-#: src/olympia/users/templates/users/pwreset_confirm.html:31
-#: src/olympia/users/templates/users/register.html:72
+#: src/olympia/users/templates/users/pwreset_confirm.html:31 src/olympia/users/templates/users/register.html:72
 msgid "Confirm password"
 msgstr "Подтвердить пароль"
 
 #: src/olympia/users/templates/users/pwreset_confirm.html:47
-msgid ""
-"The password reset link was invalid, possibly because it has already been "
-"used.  Please request a new password reset."
-msgstr ""
-"Ссылка на сброс пароля неверна, вероятно потому, что она уже была "
-"использована.  Пожалуйста, запросите новый сброс пароля."
+msgid "The password reset link was invalid, possibly because it has already been used. Please request a new password reset."
+msgstr "Ссылка на сброс пароля неверна, вероятно потому, что она уже была использована.  Пожалуйста, запросите новый сброс пароля."
 
 #: src/olympia/users/templates/users/pwreset_request.html:15
-msgid ""
-"Forgotten your password? Enter your e-mail address below, and we'll e-mail "
-"instructions for setting a new one."
-msgstr ""
-"Забыли свой пароль? Введите ниже свой адрес электронной почты и мы отправим "
-"вам инструкции по установке нового пароля."
+msgid "Forgotten your password? Enter your e-mail address below, and we'll e-mail instructions for setting a new one."
+msgstr "Забыли свой пароль? Введите ниже свой адрес электронной почты и мы отправим вам инструкции по установке нового пароля."
 
 #: src/olympia/users/templates/users/pwreset_request.html:25
 msgid "Send password reset link"
@@ -16052,14 +12652,10 @@ msgstr "Отправить ссылку для сброса пароля"
 
 #: src/olympia/users/templates/users/pwreset_sent.html:10
 msgid ""
-"An email has been sent to the requested account with further information. If"
-" you do not receive an email then please confirm you have entered the same "
-"email address used during account registration."
+"An email has been sent to the requested account with further information. If you do not receive an email then please confirm you have entered the same email address used during account registration."
 msgstr ""
-"На запрошенную учетную запись было отправлено электронное письмо с "
-"дополнительной информацией. Если вы не получили письмо, то пожалуйста, "
-"подтвердите, что вы ввели тот же адрес электронной почты, который был указан"
-" при регистрации."
+"На запрошенную учетную запись было отправлено электронное письмо с дополнительной информацией. Если вы не получили письмо, то пожалуйста, подтвердите, что вы ввели тот же адрес электронной почты, "
+"который был указан при регистрации."
 
 #: src/olympia/users/templates/users/register.html:4
 msgid "New User Registration"
@@ -16070,12 +12666,8 @@ msgid "Why register?"
 msgstr "Зачем регистрироваться?"
 
 #: src/olympia/users/templates/users/register.html:14
-msgid ""
-"Registration on AMO is <strong>not required</strong> if you simply want to "
-"download and install public add-ons."
-msgstr ""
-"Регистрация на AMO <strong>не требуется</strong>, если вы просто хотите "
-"загрузить и установить публичные дополнения."
+msgid "Registration on AMO is <strong>not required</strong> if you simply want to download and install public add-ons."
+msgstr "Регистрация на AMO <strong>не требуется</strong>, если вы просто хотите загрузить и установить публичные дополнения."
 
 #: src/olympia/users/templates/users/register.html:16
 msgid "You only need to register if:"
@@ -16086,53 +12678,29 @@ msgid "You want to submit reviews for add-ons"
 msgstr "Вы хотите отправлять отзывы на дополнения"
 
 #: src/olympia/users/templates/users/register.html:19
-msgid ""
-"You want to keep track of your favorite add-on collections or create one "
-"yourself"
-msgstr ""
-"Вы хотите отслеживать подборки ваших любимых дополнений или создать свою "
-"подборку"
+msgid "You want to keep track of your favorite add-on collections or create one yourself"
+msgstr "Вы хотите отслеживать подборки ваших любимых дополнений или создать свою подборку"
 
 #: src/olympia/users/templates/users/register.html:20
-msgid ""
-"You are an add-on developer and want to upload your add-on for hosting on "
-"AMO"
-msgstr ""
-"Вы являетесь разработчиком дополнения и хотите загрузить ваше дополнение для"
-" размещения на AMO"
+msgid "You are an add-on developer and want to upload your add-on for hosting on AMO"
+msgstr "Вы являетесь разработчиком дополнения и хотите загрузить ваше дополнение для размещения на AMO"
 
 #: src/olympia/users/templates/users/register.html:23
-msgid ""
-"Upon successful registration, you will be sent a confirmation email to the "
-"address you provided. Please follow the instructions there to confirm your "
-"account."
-msgstr ""
-"После успешной регистрации вам будет отправлено подтверждение по эл. почте "
-"на указанный вами адрес. Пожалуйста, следуйте приведённым в нём инструкциям "
-"для подтверждения вашей учетной записи."
+msgid "Upon successful registration, you will be sent a confirmation email to the address you provided. Please follow the instructions there to confirm your account."
+msgstr "После успешной регистрации вам будет отправлено подтверждение по эл. почте на указанный вами адрес. Пожалуйста, следуйте приведённым в нём инструкциям для подтверждения вашей учетной записи."
 
 #: src/olympia/users/templates/users/register.html:30
 #, python-format
-msgid ""
-"If you like, you can read our <a href=\"%(legal)s\" title=\"Legal "
-"Notices\">Legal Notices</a> and <a href=\"%(privacy)s\" title=\"Privacy "
-"Policy\">Privacy Policy</a>."
-msgstr ""
-"Если вы хотите, вы можете прочитать наши<a href=\"%(legal)s\" title=\"Legal "
-"Notices\">Юридические уведомления</a> и <a href=\"%(privacy)s\" "
-"title=\"Privacy Policy\">Политику Приватности</a>."
+msgid "If you like, you can read our <a href=\"%(legal)s\" title=\"Legal Notices\">Legal Notices</a> and <a href=\"%(privacy)s\" title=\"Privacy Policy\">Privacy Policy</a>."
+msgstr "Если вы хотите, вы можете прочитать наши<a href=\"%(legal)s\" title=\"Legal Notices\">Юридические уведомления</a> и <a href=\"%(privacy)s\" title=\"Privacy Policy\">Политику Приватности</a>."
 
 #: src/olympia/users/templates/users/register.html:52
 msgid "Display name"
 msgstr "Отображаемое имя"
 
 #: src/olympia/users/templates/users/report_abuse.html:7
-msgid ""
-"Please describe why you are reporting this user, such as for spam or an "
-"inappropriate picture."
-msgstr ""
-"Пожулуйста, опишите, почему вы сообщаете об этом пользователе, например за "
-"спам или за неуместную фотографию."
+msgid "Please describe why you are reporting this user, such as for spam or an inappropriate picture."
+msgstr "Пожулуйста, опишите, почему вы сообщаете об этом пользователе, например за спам или за неуместную фотографию."
 
 #: src/olympia/users/templates/users/report_abuse_full.html:3
 msgid "Report user {0}"
@@ -16146,42 +12714,25 @@ msgstr "Заказ футболки"
 msgid "Special Edition Add-on Creator T-shirt"
 msgstr "Футболка Создателя Дополнений - Специальное издание"
 
-#: src/olympia/users/templates/users/t-shirt.html:14
-#: src/olympia/users/templates/users/t-shirt.html:120
+#: src/olympia/users/templates/users/t-shirt.html:14 src/olympia/users/templates/users/t-shirt.html:120
 msgid "Note:"
 msgstr "Замечание:"
 
 #: src/olympia/users/templates/users/t-shirt.html:15
-msgid ""
-"You have already submitted a request for a t-shirt. You may re-submit this "
-"form to update your information, but you will only receive one shirt."
-msgstr ""
-"Вы уже отправили заявку на футболку. Вы можете повторно отправить эту форму,"
-" чтобы обновить информацию, но вы получите только одну футболку."
+msgid "You have already submitted a request for a t-shirt. You may re-submit this form to update your information, but you will only receive one shirt."
+msgstr "Вы уже отправили заявку на футболку. Вы можете повторно отправить эту форму, чтобы обновить информацию, но вы получите только одну футболку."
 
 #: src/olympia/users/templates/users/t-shirt.html:26
-msgid ""
-"Thank you for helping to make Firefox the most extensible browser available!"
-msgstr ""
-"Спасибо, что помогли сделать Firefox самым расширяемым из доступных "
-"браузеров!"
+msgid "Thank you for helping to make Firefox the most extensible browser available!"
+msgstr "Спасибо, что помогли сделать Firefox самым расширяемым из доступных браузеров!"
 
 #: src/olympia/users/templates/users/t-shirt.html:33
-msgid ""
-"As a thank you gift, we'd like to send you a special-edition, community-"
-"designed t-shirt. To receive your shirt, please fill out the form below."
-msgstr ""
-"В качестве благодарности мы бы хотели отправить вам разработанную "
-"сообществом футболку из специального выпуска. Чтобы получить футболку, "
-"пожалуйста, заполните расположенную ниже форму."
+msgid "As a thank you gift, we'd like to send you a special-edition, community-designed t-shirt. To receive your shirt, please fill out the form below."
+msgstr "В качестве благодарности мы бы хотели отправить вам разработанную сообществом футболку из специального выпуска. Чтобы получить футболку, пожалуйста, заполните расположенную ниже форму."
 
 #: src/olympia/users/templates/users/t-shirt.html:41
-msgid ""
-"Your contact information will only be used by Mozilla to ship this special "
-"edition t-shirt."
-msgstr ""
-"Ваша контактная информация будет использоваться только Mozilla для отправки "
-"этой футболки из специального выпуска."
+msgid "Your contact information will only be used by Mozilla to ship this special edition t-shirt."
+msgstr "Ваша контактная информация будет использоваться только Mozilla для отправки этой футболки из специального выпуска."
 
 #: src/olympia/users/templates/users/t-shirt.html:60
 msgid "Mailing Address"
@@ -16237,24 +12788,15 @@ msgstr "Запросить футболку"
 
 #: src/olympia/users/templates/users/t-shirt.html:137
 msgid ""
-"We're sorry, but in order to qualify for our special edition t-shirt, you "
-"must be an add-on developer with at least one listed add-on, one unlisted "
-"but signed add-on, or any number of background themes with a combined total "
-"of 10,000 average daily users."
+"We're sorry, but in order to qualify for our special edition t-shirt, you must be an add-on developer with at least one listed add-on, one unlisted but signed add-on, or any number of background "
+"themes with a combined total of 10,000 average daily users."
 msgstr ""
-"Мы сожалеем, но для того, чтобы претендовать на нашу футболку из "
-"специального выпуска, вы должны быть разработчиком дополнения с по крайней "
-"мере одним дополнением находящимся в списке, одним не находящимся в списке, "
-"но подписанным дополнением, или любым числом фоновых тем с 10000 ежедневных "
-"пользователей в общей сложности."
+"Мы сожалеем, но для того, чтобы претендовать на нашу футболку из специального выпуска, вы должны быть разработчиком дополнения с по крайней мере одним дополнением находящимся в списке, одним не "
+"находящимся в списке, но подписанным дополнением, или любым числом фоновых тем с 10000 ежедневных пользователей в общей сложности."
 
 #: src/olympia/users/templates/users/tougher_password.html:2
-msgid ""
-"For your account a password must contain at least 8 characters including "
-"letters and numbers."
-msgstr ""
-"Пароль вашей учётной записи должен быть не менее 8 символов и включать буквы"
-" и цифры."
+msgid "For your account a password must contain at least 8 characters including letters and numbers."
+msgstr "Пароль вашей учётной записи должен быть не менее 8 символов и включать буквы и цифры."
 
 #: src/olympia/users/templates/users/unsubscribe.html:2
 msgid "Unsubscribe"
@@ -16266,12 +12808,8 @@ msgstr "Вы были успешно отписаны!"
 
 #: src/olympia/users/templates/users/unsubscribe.html:10
 #, python-format
-msgid ""
-"The email address <strong>%(email)s</strong> will no longer get messages "
-"when:"
-msgstr ""
-"Адрес эл. почты <strong>%(email)s</strong> больше не будет получать "
-"сообщения, когда:"
+msgid "The email address <strong>%(email)s</strong> will no longer get messages when:"
+msgstr "Адрес эл. почты <strong>%(email)s</strong> больше не будет получать сообщения, когда:"
 
 #: src/olympia/users/templates/users/unsubscribe.html:20
 msgid "More Actions:"
@@ -16291,14 +12829,8 @@ msgstr "Мы не смогли вас отписать"
 
 #: src/olympia/users/templates/users/unsubscribe.html:30
 #, python-format
-msgid ""
-"Unfortunately, we weren't able to unsubscribe you.  The link you clicked is "
-"invalid. However, you can unsubscribe still unsubscribe on your <a "
-"href=\"%(edit_url)s\">edit profile page</a>."
-msgstr ""
-"К сожалению, мы не можем отписать вас.  Ссылка, по которой вы щёлкнули, "
-"некорректна. Однако, вы можете отписаться на вашей <a "
-"href=\"%(edit_url)s\">странице настроек профиля</a>."
+msgid "Unfortunately, we weren't able to unsubscribe you. The link you clicked is invalid. However, you can unsubscribe still unsubscribe on your <a href=\"%(edit_url)s\">edit profile page</a>."
+msgstr "К сожалению, мы не можем отписать вас.  Ссылка, по которой вы щёлкнули, некорректна. Однако, вы можете отписаться на вашей <a href=\"%(edit_url)s\">странице настроек профиля</a>."
 
 #: src/olympia/users/templates/users/vcard.html:2
 msgid "Developer Information"
@@ -16330,7 +12862,6 @@ msgid "%(num)s theme"
 msgid_plural "%(num)s themes"
 msgstr[0] "%(num)s тема"
 msgstr[1] "%(num)s темы"
-msgstr[2] "%(num)s тем"
 
 #: src/olympia/users/templates/users/vcard.html:62
 #, python-format
@@ -16338,7 +12869,6 @@ msgid "%(num)s add-on"
 msgid_plural "%(num)s add-ons"
 msgstr[0] "%(num)s дополнение"
 msgstr[1] "%(num)s дополнения"
-msgstr[2] "%(num)s дополнений"
 
 #: src/olympia/users/templates/users/vcard.html:75
 msgid "Average rating of developer's add-ons"
@@ -16353,15 +12883,15 @@ msgstr "История версий %s"
 msgid "Version History with Changelogs"
 msgstr "История версий со списком изменений"
 
-#: src/olympia/versions/models.py:314
+#: src/olympia/versions/models.py:313
 msgid "Add-on uses binary components."
 msgstr "Дополнение содержит бинарные компоненты."
 
-#: src/olympia/versions/models.py:317
+#: src/olympia/versions/models.py:316
 msgid "Add-on has opted into strict compatibility checking."
 msgstr "Дополнение выбрало строгую проверку совместимости."
 
-#: src/olympia/versions/models.py:715
+#: src/olympia/versions/models.py:711
 msgid "{app} {min} and later"
 msgstr "{app} {min} и выше"
 
@@ -16377,9 +12907,7 @@ msgstr "Выпущено {0}"
 #: src/olympia/versions/templates/versions/version.html:39
 #, python-format
 msgid "Source code released under <a target=\"_blank\" href=\"%(url)s\">%(name)s</a>"
-msgstr ""
-"Исходный код выпущен на условиях <a target=\"_blank\" "
-"href=\"%(url)s\">%(name)s</a>"
+msgstr "Исходный код выпущен на условиях <a target=\"_blank\" href=\"%(url)s\">%(name)s</a>"
 
 #: src/olympia/versions/templates/versions/version.html:44
 #, python-format
@@ -16390,8 +12918,8 @@ msgstr "Исходный код выпущен на условиях <a href=\"%
 msgid "View the source"
 msgstr "Просмотреть исходный текст"
 
-#. {0} is an add-on name.
 # {0} is the add-on name
+#. {0} is an add-on name.
 #: src/olympia/versions/templates/versions/version_list.html:26
 msgid "{0} Version History"
 msgstr "История версий {0}"
@@ -16402,23 +12930,15 @@ msgid "<b>{0}</b> version"
 msgid_plural "<b>{0}</b> versions"
 msgstr[0] "<b>{0}</b> версия"
 msgstr[1] "<b>{0}</b> версии"
-msgstr[2] "<b>{0}</b> версий"
 
-#: src/olympia/versions/templates/versions/version_list.html:35
-#: src/olympia/versions/templates/versions/mobile/version_list.html:14
+#: src/olympia/versions/templates/versions/version_list.html:35 src/olympia/versions/templates/versions/mobile/version_list.html:14
 msgid "Be careful with old versions!"
 msgstr "Будьте осторожны со старыми версиями!"
 
-#: src/olympia/versions/templates/versions/version_list.html:36
-#: src/olympia/versions/templates/versions/mobile/version_list.html:15
+#: src/olympia/versions/templates/versions/version_list.html:36 src/olympia/versions/templates/versions/mobile/version_list.html:15
 #, python-format
-msgid ""
-"These versions are displayed for reference and testing purposes. You should "
-"always use the <a href=\"%(url)s\">latest version</a> of an add-on."
-msgstr ""
-"Эти версии отображаются только для сведения и в целях тестирования. Вам "
-"следует всегда использовать <a href=\"%(url)s\">последнюю версию</a> "
-"дополнения."
+msgid "These versions are displayed for reference and testing purposes. You should always use the <a href=\"%(url)s\">latest version</a> of an add-on."
+msgstr "Эти версии отображаются только для сведения и в целях тестирования. Вам следует всегда использовать <a href=\"%(url)s\">последнюю версию</a> дополнения."
 
 #: src/olympia/versions/templates/versions/mobile/version.html:4
 msgid "Beta Version {0}"
@@ -16448,3 +12968,7 @@ msgstr "Отправить письмо по завершении"
 #: src/olympia/zadmin/forms.py:105
 msgid "Log emails instead of sending"
 msgstr "Вести лог электронной почты вместо её отправки"
+
+#: src/olympia/zadmin/forms.py:215
+msgid "Deleted versions can`t be changed."
+msgstr ""

--- a/locale/ru/LC_MESSAGES/djangojs.po
+++ b/locale/ru/LC_MESSAGES/djangojs.po
@@ -3,139 +3,391 @@ msgid ""
 msgstr ""
 "Project-Id-Version: REMORA 0.1\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2016-02-24 21:23+0000\n"
+"POT-Creation-Date: 2016-04-18 15:47+0000\n"
 "PO-Revision-Date: 2015-12-01 12:49+0000\n"
 "Last-Translator: bychek.ru <a@bychek.ru>\n"
 "Language-Team: Russian <ru@li.org>\n"
+"Language: ru\n"
 "MIME-Version: 1.0\n"
-"Content-Type: text/plain; charset=utf-8\n"
+"Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Generated-By: Babel 2.2.0\n"
 
-#: static/js/common/ratingwidget.js:31
+#: static/js/common-all.js:1426 static/js/impala-all.js:1511 static/js/zamboni/discovery-all.js:12598 static/js/zamboni/init.js:28 static/js/zamboni/mobile-all.js:14945
+msgid "This feature is temporarily disabled while we perform website maintenance. Please check back a little later."
+msgstr "Пока мы производим техническое обслуживание веб-сайта, эта возможность временно отключена. Пожалуйста, зайдите попозже."
+
+#. L10n: {0} is an app name like Firefox.
+#: static/js/common-all.js:1837 static/js/impala-all.js:1922 static/js/zamboni/buttons.js:73 static/js/zamboni/discovery-all.js:13108
+msgid "Accept and Install"
+msgstr "Принять и установить"
+
+#: static/js/common-all.js:1837 static/js/impala-all.js:1922 static/js/zamboni/buttons.js:73 static/js/zamboni/discovery-all.js:13108
+msgid "Add to {0}"
+msgstr "Добавить в {0}"
+
+#: static/js/common-all.js:1842 static/js/impala-all.js:1927 static/js/zamboni/buttons.js:78 static/js/zamboni/discovery-all.js:13113
+msgid "Download Now"
+msgstr "Загрузить сейчас"
+
+#: static/js/common-all.js:1883 static/js/impala-all.js:1968 static/js/zamboni/buttons.js:119 static/js/zamboni/discovery-all.js:13154
+msgid "Add-on has not been updated to support default-to-compatible."
+msgstr "Дополнение не было обновлено для поддержки совместимости-по-умолчанию."
+
+#: static/js/common-all.js:1888 static/js/impala-all.js:1973 static/js/zamboni/buttons.js:124 static/js/zamboni/discovery-all.js:13159
+msgid "You need to be using Firefox 10.0 or higher."
+msgstr "Вам необходимо использовать Firefox 10.0 или выше."
+
+#: static/js/common-all.js:1900 static/js/impala-all.js:1985 static/js/zamboni/buttons.js:136 static/js/zamboni/discovery-all.js:13171
+msgid "Mozilla has marked this version as incompatible with your Firefox version."
+msgstr "Mozilla отметила эту версию как несовместимую с вашей версией Firefox."
+
+#. L10n: {0} is an platform like Windows or Linux.
+#: static/js/common-all.js:1981 static/js/impala-all.js:2066 static/js/zamboni/buttons.js:217 static/js/zamboni/discovery-all.js:13252
+msgid "Install for {0} anyway"
+msgstr "Всё равно установить для {0}"
+
+#: static/js/common-all.js:1981 static/js/impala-all.js:2066 static/js/zamboni/buttons.js:217 static/js/zamboni/discovery-all.js:13252
+msgid "Download for {0} anyway"
+msgstr "Всё равно загрузить для {0}"
+
+#: static/js/common-all.js:2038 static/js/impala-all.js:2123 static/js/zamboni/buttons.js:274 static/js/zamboni/discovery-all.js:13309
+msgid "Not available for your platform"
+msgstr "Недоступно для вашей платформы"
+
+#. L10n: {0} is an app name, {1} is the app version.
+#: static/js/common-all.js:2049 static/js/common-all.js:2086 static/js/impala-all.js:2134 static/js/impala-all.js:2171 static/js/zamboni/buttons.js:286 static/js/zamboni/buttons.js:324
+#: static/js/zamboni/discovery-all.js:13320 static/js/zamboni/discovery-all.js:13357
+msgid "Not available for {0} {1}"
+msgstr "Недоступно для {0} {1}"
+
+#: static/js/common-all.js:2112 static/js/impala-all.js:2197 static/js/zamboni/buttons.js:351 static/js/zamboni/discovery-all.js:13383
+msgid "Works with {app} {min} - {max}"
+msgstr "Работает с {app} {min} - {max}"
+
+#: static/js/common-all.js:2114 static/js/impala-all.js:2199 static/js/zamboni/buttons.js:353 static/js/zamboni/discovery-all.js:13385
+msgid "View other versions"
+msgstr "Просмотреть другие версии"
+
+#: static/js/common-all.js:2162 static/js/impala-all.js:2247 static/js/zamboni/buttons.js:401 static/js/zamboni/discovery-all.js:13433
+msgid "Only with Firefox — Get Firefox Now!"
+msgstr "Только в Firefox — Скачать Firefox!"
+
+#: static/js/common-all.js:2278 static/js/impala-all.js:2363 static/js/zamboni/buttons.js:517 static/js/zamboni/discovery-all.js:13549 static/js/zamboni/mobile-all.js:15177
+#: static/js/zamboni/mobile/buttons.js:43
+msgid "Sorry, you need a Mozilla-based browser (such as Firefox) to install a search plugin."
+msgstr "Извините, для установки поискового плагина вам нужен браузер из семейства Mozilla (например, Firefox)."
+
+#: static/js/common-all.js:9088 static/js/impala-all.js:9649 static/js/zamboni/global.js:410
+msgid "Loading..."
+msgstr "Загрузка..."
+
+#. L10n: {0} is the number of characters left.
+#: static/js/common-all.js:9152 static/js/impala-all.js:9713 static/js/zamboni/global.js:474
+msgid "<b>{0}</b> character left."
+msgid_plural "<b>{0}</b> characters left."
+msgstr[0] "остался <b>{0}</b> символ."
+msgstr[1] "осталось <b>{0}</b> символа."
+
+#: static/js/common-all.js:9589 static/js/common-min.js:6 static/js/impala-all.js:10052 static/js/impala-min.js:6 static/js/common/ratingwidget.js:31 static/js/zamboni/mobile-all.js:16123
+#: static/js/zamboni/mobile-min.js:6
 msgid "{0} star"
 msgid_plural "{0} stars"
 msgstr[0] "{0} звезда"
 msgstr[1] "{0} звезды"
-msgstr[2] "{0} звёзд"
 
-#: static/js/common/upload-addon.js:41 static/js/common/upload-image.js:128
+#: static/js/common-all.js:9676 static/js/common-min.js:6 static/js/impala-all.js:10139 static/js/impala-min.js:6 static/js/zamboni/l10n.js:45
+msgid "Remove this localization"
+msgstr "Удалить эту локализацию"
+
+#: static/js/common-all.js:10193 static/js/common-min.js:6 static/js/impala-all.js:10674 static/js/impala-min.js:6 static/js/zamboni/discovery-all.js:13678
+msgid "close"
+msgstr ""
+
+#: static/js/common-all.js:10860 static/js/common-min.js:6 static/js/impala-all.js:11481 static/js/impala-min.js:6 static/js/impala/reviews.js:23 static/js/zamboni/reviews.js:18
+msgid "Flagged for review"
+msgstr "Отмечено для проверки"
+
+#: static/js/common-all.js:10876 static/js/common-min.js:6 static/js/impala-all.js:11498 static/js/impala-min.js:6 static/js/impala/reviews.js:40 static/js/zamboni/reviews.js:34
+msgid "Your input is required"
+msgstr "Требуется ваш отзыв"
+
+#: static/js/common-all.js:10945 static/js/common-min.js:6 static/js/impala-all.js:11610 static/js/impala-min.js:7 static/js/impala/reviews.js:152 static/js/zamboni/reviews.js:103
+msgid "Marked for deletion"
+msgstr "Помечено для удаления"
+
+#: static/js/common-all.js:11573 static/js/common-min.js:7 static/js/impala-all.js:13809 static/js/impala-min.js:8 static/js/zamboni/collections.js:229
+msgid "Adding to Favorites&hellip;"
+msgstr "Добавляю в Избранное&hellip;"
+
+#: static/js/common-all.js:11576 static/js/common-min.js:7 static/js/impala-all.js:13812 static/js/impala-min.js:8 static/js/zamboni/collections.js:232
+msgid "Removing Favorite&hellip;"
+msgstr "Удаляю из Избранного&hellip;"
+
+#: static/js/common-all.js:11579 static/js/common-min.js:7 static/js/impala-all.js:13815 static/js/impala-min.js:8 static/js/zamboni/collections.js:235
+msgid "Add to Favorites"
+msgstr "Добавить в избранное"
+
+#: static/js/common-all.js:11582 static/js/common-min.js:7 static/js/impala-all.js:13818 static/js/impala-min.js:8 static/js/zamboni/collections.js:238
+msgid "Remove from Favorites"
+msgstr "Удалить из избранного"
+
+#: static/js/common-all.js:11647 static/js/common-min.js:7 static/js/impala-all.js:13883 static/js/impala-min.js:8 static/js/zamboni/collections.js:303
+msgid "Pending"
+msgstr "В ожидании"
+
+#: static/js/common-all.js:11648 static/js/common-min.js:7 static/js/impala-all.js:13884 static/js/impala-min.js:8 static/js/zamboni/collections.js:304
+msgid "Add a comment"
+msgstr "Добавить комментарий"
+
+#: static/js/common-all.js:11648 static/js/common-min.js:7 static/js/impala-all.js:13884 static/js/impala-min.js:8 static/js/zamboni/collections.js:304
+msgid "Comment"
+msgstr "Комментарий"
+
+#: static/js/common-all.js:11649 static/js/common-min.js:7 static/js/impala-all.js:13885 static/js/impala-min.js:8 static/js/zamboni/collections.js:305
+msgid "Remove this add-on from the collection"
+msgstr "Удалить это дополнение из подборки"
+
+#: static/js/common-all.js:11649 static/js/common-all.js:11678 static/js/common-min.js:7 static/js/impala-all.js:13885 static/js/impala-all.js:13914 static/js/impala-min.js:8
+#: static/js/zamboni/collections.js:305 static/js/zamboni/collections.js:334
+msgid "Remove"
+msgstr "Удалить"
+
+#: static/js/common-all.js:11678 static/js/common-min.js:7 static/js/impala-all.js:13914 static/js/impala-min.js:8 static/js/zamboni/collections.js:334
+msgid "Remove this user as a contributor"
+msgstr "Удалить этого пользователя как помощника"
+
+#: static/js/common-all.js:11690 static/js/common-min.js:7 static/js/impala-all.js:13926 static/js/impala-min.js:8 static/js/zamboni/collections.js:346
+msgid "An email address is required."
+msgstr "Требуется адрес электронной почты."
+
+#: static/js/common-all.js:11708 static/js/common-min.js:7 static/js/impala-all.js:13944 static/js/impala-min.js:8 static/js/zamboni/collections.js:364
+msgid "You cannot add yourself as a contributor."
+msgstr "Вы не можете добавить себя как помощника."
+
+#: static/js/common-all.js:11710 static/js/common-min.js:7 static/js/impala-all.js:13946 static/js/impala-min.js:8 static/js/zamboni/collections.js:366
+msgid "You have already added that user."
+msgstr "Вы уже добавили этого пользователя."
+
+#: static/js/common-all.js:11917 static/js/common-min.js:7 static/js/impala-all.js:14153 static/js/impala-min.js:8 static/js/zamboni/collections.js:573
+msgid "Add to favorites"
+msgstr "Добавить в избранное"
+
+#: static/js/common-all.js:11921 static/js/common-min.js:7 static/js/impala-all.js:14157 static/js/impala-min.js:8 static/js/zamboni/collections.js:577
+msgid "Remove from favorites"
+msgstr "Удалить из избранного"
+
+#: static/js/common-all.js:11939 static/js/common-min.js:7 static/js/impala-all.js:14175 static/js/impala-all.js:14233 static/js/impala-min.js:8 static/js/impala/collections.js:10
+#: static/js/zamboni/collections.js:595
+msgid "Follow this Collection"
+msgstr "Следовать за этой подборкой"
+
+#: static/js/common-all.js:11948 static/js/common-min.js:7 static/js/impala-all.js:14184 static/js/impala-min.js:8 static/js/zamboni/collections.js:604
+msgid "Stop following"
+msgstr "Перестать следовать"
+
+#: static/js/common-all.js:12096 static/js/common-min.js:7 static/js/zamboni/password-strength.js:20
+msgid "Password strength:"
+msgstr "Стойкость пароля:"
+
+#: static/js/common-all.js:12102 static/js/common-min.js:7 static/js/zamboni/password-strength.js:26
+msgid "At least {0} character left."
+msgid_plural "At least {0} characters left."
+msgstr[0] "Остался по меньшей мере {0} символ."
+msgstr[1] "Осталось по меньшей мере {0} символа."
+
+#: static/js/common-all.js:12286 static/js/common-min.js:7 static/js/impala-all.js:14632 static/js/impala-min.js:8 static/js/impala/suggestions.js:39
+msgid "Search themes for <b>{0}</b>"
+msgstr "Поиск <b>{0}</b>  в темах"
+
+#: static/js/common-all.js:12288 static/js/common-min.js:7 static/js/impala-all.js:14634 static/js/impala-min.js:8 static/js/impala/suggestions.js:41
+msgid "Search apps for <b>{0}</b>"
+msgstr "Искать в приложениях <b>{0}</b>"
+
+#: static/js/common-all.js:12290 static/js/common-min.js:7 static/js/impala-all.js:14636 static/js/impala-min.js:8 static/js/impala/suggestions.js:43
+msgid "Search add-ons for <b>{0}</b>"
+msgstr "Искать в дополнениях <b>{0}</b>"
+
+#: static/js/common-all.js:12521 static/js/common-min.js:7 static/js/impala-all.js:14867 static/js/impala-min.js:8 static/js/impala/site_suggestions.js:46
+msgid "Category"
+msgstr "Категория"
+
+#. L10n: {0} is an app name.
+#: static/js/impala-all.js:11632 static/js/impala-min.js:7 static/js/impala/listing.js:11 static/js/zamboni/themes.js:13
+msgid "This theme is incompatible with your version of {0}"
+msgstr "Эта тема несовместима с вашей версией {0}"
+
+#: static/js/impala-all.js:12146 static/js/impala-all.js:14331 static/js/impala-min.js:7 static/js/impala-min.js:8 static/js/common/upload-image.js:97 static/js/impala/users.js:51
+#: static/js/zamboni/devhub-all.js:894 static/js/zamboni/devhub-min.js:1
+msgid "Images must be either PNG or JPG."
+msgstr "Изображения должны быть в PNG или JPG."
+
+#: static/js/impala-all.js:12150 static/js/impala-min.js:7 static/js/common/upload-image.js:101 static/js/zamboni/devhub-all.js:898 static/js/zamboni/devhub-min.js:1
+msgid "Videos must be in WebM."
+msgstr "Видео должно быть в формате WebM."
+
+#: static/js/impala-all.js:12177 static/js/impala-min.js:7 static/js/common/upload-addon.js:41 static/js/common/upload-image.js:128 static/js/zamboni/devhub-all.js:272
+#: static/js/zamboni/devhub-all.js:925 static/js/zamboni/devhub-min.js:1
 msgid "There was a problem contacting the server."
 msgstr "Проблема связи с сервером."
 
-#: static/js/common/upload-addon.js:69
+#: static/js/impala-all.js:13298 static/js/impala-min.js:7 static/js/impala/persona_creation.js:60
+msgid "All Rights Reserved"
+msgstr "Все права защищены"
+
+#: static/js/impala-all.js:13302 static/js/impala-min.js:7 static/js/impala/persona_creation.js:64
+msgid "Creative Commons Attribution 3.0"
+msgstr "Creative Commons Атрибуция 3.0"
+
+#: static/js/impala-all.js:13307 static/js/impala-min.js:7 static/js/impala/persona_creation.js:69
+msgid "Creative Commons Attribution-NonCommercial 3.0"
+msgstr "Creative Commons Атрибуция — Некоммерческое использование 3.0"
+
+#: static/js/impala-all.js:13312 static/js/impala-min.js:7 static/js/impala/persona_creation.js:74
+msgid "Creative Commons Attribution-NonCommercial-NoDerivs 3.0"
+msgstr "Creative Commons Атрибуция — Некоммерческое использование — Без производных произведений 3.0"
+
+#: static/js/impala-all.js:13317 static/js/impala-min.js:7 static/js/impala/persona_creation.js:79
+msgid "Creative Commons Attribution-NonCommercial-Share Alike 3.0"
+msgstr "Creative Commons Атрибуция — Некоммерческое использование — С сохранением условий 3.0"
+
+#: static/js/impala-all.js:13322 static/js/impala-min.js:7 static/js/impala/persona_creation.js:84
+msgid "Creative Commons Attribution-NoDerivs 3.0"
+msgstr "Creative Commons Атрибуция — Без производных произведений 3.0"
+
+#: static/js/impala-all.js:13327 static/js/impala-min.js:7 static/js/impala/persona_creation.js:89
+msgid "Creative Commons Attribution-ShareAlike 3.0"
+msgstr "Creative Commons Атрибуция — С сохранением условий 3.0"
+
+#: static/js/impala-all.js:13530 static/js/impala-min.js:7 static/js/impala/persona_creation.js:292
+msgid "Your Theme's Name"
+msgstr "Имя вашей темы"
+
+#: static/js/impala-all.js:14242 static/js/impala-min.js:8 static/js/impala/collections.js:19
+msgid "Stop Following"
+msgstr "Перестать следовать"
+
+#: static/js/impala-all.js:14243 static/js/impala-min.js:8 static/js/impala/collections.js:20
+msgid "Following"
+msgstr "Следовать"
+
+#: static/js/impala-all.js:14313 static/js/impala-min.js:8 static/js/impala/users.js:33
+msgid "use original"
+msgstr "использовать оригинал"
+
+#: static/js/impala-all.js:14523 static/js/impala-min.js:8 static/js/impala/search.js:114
+msgid "Updating results&hellip;"
+msgstr "Обновление результатов&hellip;"
+
+#: static/js/common/upload-addon.js:69 static/js/zamboni/devhub-all.js:300 static/js/zamboni/devhub-min.js:1
 msgid "Select a file..."
 msgstr "Выбрать файл..."
 
-#: static/js/common/upload-addon.js:70
+#: static/js/common/upload-addon.js:70 static/js/zamboni/devhub-all.js:301 static/js/zamboni/devhub-min.js:1
 msgid "Your add-on should end with .xpi, .jar or .xml"
 msgstr "Ваше дополнение должно заканчиваться на .xpi, .jar или .xml"
 
 #. L10n: {0} is the percent of the file that has been uploaded.
-#: static/js/common/upload-addon.js:104
+#: static/js/common/upload-addon.js:104 static/js/zamboni/devhub-all.js:335 static/js/zamboni/devhub-min.js:1
 #, python-format
 msgid "{0}% complete"
 msgstr "{0}% завершено"
 
 #. L10n: "{bytes uploaded} of {total filesize}".
-#: static/js/common/upload-addon.js:107
+#: static/js/common/upload-addon.js:107 static/js/zamboni/devhub-all.js:338 static/js/zamboni/devhub-min.js:1
 msgid "{0} of {1}"
 msgstr "{0} из {1}"
 
-#: static/js/common/upload-addon.js:140
+#: static/js/common/upload-addon.js:140 static/js/zamboni/devhub-all.js:371 static/js/zamboni/devhub-min.js:1
 msgid "Cancel"
 msgstr "Отмена"
 
-#: static/js/common/upload-addon.js:162
+#: static/js/common/upload-addon.js:162 static/js/zamboni/devhub-all.js:393 static/js/zamboni/devhub-min.js:1
 msgid "Uploading {0}"
 msgstr "Загрузка {0}"
 
-#: static/js/common/upload-addon.js:189
+#: static/js/common/upload-addon.js:189 static/js/zamboni/devhub-all.js:420 static/js/zamboni/devhub-min.js:1
 msgid "Error with {0}"
 msgstr "Ошибка с {0}"
 
-#: static/js/common/upload-addon.js:194
+#: static/js/common/upload-addon.js:194 static/js/zamboni/devhub-all.js:425 static/js/zamboni/devhub-min.js:1
 msgid "Your add-on failed validation with {0} error."
 msgid_plural "Your add-on failed validation with {0} errors."
 msgstr[0] "Ваше дополнение не смогло пройти валидацию, в нём найдена {0} ошибка."
 msgstr[1] "Ваше дополнение не смогло пройти валидацию, в нём найдено {0} ошибки."
-msgstr[2] "Ваше дополнение не смогло пройти валидацию, в нём найдено {0} ошибок."
 
-#: static/js/common/upload-addon.js:208
+#: static/js/common/upload-addon.js:208 static/js/zamboni/devhub-all.js:439 static/js/zamboni/devhub-min.js:1
 msgid "&hellip;and {0} more"
 msgid_plural "&hellip;and {0} more"
 msgstr[0] "&hellip;и ещё {0}"
 msgstr[1] "&hellip;и ещё {0}"
-msgstr[2] "&hellip;и ещё {0}"
 
-#: static/js/common/upload-addon.js:222 static/js/common/upload-addon.js:512
+#: static/js/common/upload-addon.js:222 static/js/common/upload-addon.js:497 static/js/zamboni/devhub-all.js:453 static/js/zamboni/devhub-all.js:743 static/js/zamboni/devhub-min.js:1
 msgid "See full validation report"
 msgstr "Прочесть весь отчёт о валидации"
 
-#: static/js/common/upload-addon.js:234
+#: static/js/common/upload-addon.js:234 static/js/zamboni/devhub-all.js:465 static/js/zamboni/devhub-min.js:1
 msgid "Validating {0}"
 msgstr "Валидация {0}"
 
 #. L10n: first argument is an HTTP status code
-#: static/js/common/upload-addon.js:273
+#: static/js/common/upload-addon.js:273 static/js/zamboni/devhub-all.js:504 static/js/zamboni/devhub-min.js:1
 msgid "Received an empty response from the server; status: {0}"
 msgstr "Получен пустой ответ от сервера; статус: {0}"
 
-#: static/js/common/upload-addon.js:373
+#: static/js/common/upload-addon.js:370 static/js/zamboni/devhub-all.js:604 static/js/zamboni/devhub-min.js:1
 msgid "Unexpected server error while validating."
 msgstr "При валидации произошла неожиданная ошибка сервера."
 
-#: static/js/common/upload-addon.js:412
+#: static/js/common/upload-addon.js:409 static/js/zamboni/devhub-all.js:643 static/js/zamboni/devhub-min.js:1
 msgid "Finished validating {0}"
 msgstr "Закончена валидация {0}"
 
-#: static/js/common/upload-addon.js:418
+#: static/js/common/upload-addon.js:415 static/js/zamboni/devhub-all.js:649 static/js/zamboni/devhub-min.js:1
 msgid "Your add-on validation timed out, it will be manually reviewed."
 msgstr "Время ожидания валидации вашего дополнения истекло, оно будет проверено вручную."
 
-#: static/js/common/upload-addon.js:421
+#: static/js/common/upload-addon.js:418 static/js/zamboni/devhub-all.js:652 static/js/zamboni/devhub-min.js:1
 msgid "Your add-on was validated with no errors and {0} warning."
 msgid_plural "Your add-on was validated with no errors and {0} warnings."
 msgstr[0] "Ваше дополнение прошло валидацию без ошибок и с {0} предупреждением."
 msgstr[1] "Ваше дополнение прошло валидацию без ошибок и с {0} предупреждениями."
-msgstr[2] "Ваше дополнение прошло валидацию без ошибок и с {0} предупреждениями."
 
-#: static/js/common/upload-addon.js:426
+#: static/js/common/upload-addon.js:423 static/js/zamboni/devhub-all.js:657 static/js/zamboni/devhub-min.js:1
 msgid "Your add-on was validated with no errors and {0} message."
 msgid_plural "Your add-on was validated with no errors and {0} messages."
 msgstr[0] "Ваше дополнение прошло валидацию без ошибок и c {0} сообщением."
 msgstr[1] "Ваше дополнение прошло валидацию без ошибок и c {0} сообщениями."
-msgstr[2] "Ваше дополнение прошло валидацию без ошибок и c {0} сообщениями."
 
-#: static/js/common/upload-addon.js:431
+#: static/js/common/upload-addon.js:428 static/js/zamboni/devhub-all.js:662 static/js/zamboni/devhub-min.js:1
 msgid "Your add-on was validated with no errors or warnings."
 msgstr "Ваше дополнение прошло валидацию без ошибок или предупреждений."
 
-#: static/js/common/upload-addon.js:446
+#: static/js/common/upload-addon.js:443 static/js/zamboni/devhub-all.js:677 static/js/zamboni/devhub-min.js:1
 msgid "Your submission will be automatically signed."
 msgstr "Ваш материал будет автоматически утвержден."
 
-#: static/js/common/upload-addon.js:465
+#: static/js/common/upload-addon.js:450 static/js/zamboni/devhub-all.js:696 static/js/zamboni/devhub-min.js:1
 msgid "Include detailed version notes (this can be done in the next step)."
 msgstr "Включить подробные примечания к версии (это может быть сделано в следующем шаге)."
 
-#: static/js/common/upload-addon.js:466
+#: static/js/common/upload-addon.js:451 static/js/zamboni/devhub-all.js:697 static/js/zamboni/devhub-min.js:1
 msgid "If your add-on requires an account to a website in order to be fully tested, include a test username and password in the Notes to Reviewer (this can be done in the next step)."
 msgstr "Если для полного тестирования дополнения неоходима учётная запись на веб-сайте, укажите тестовый логин и пароль в примечаниях для проверяющего (это может быть сделано в следующем шаге)."
 
-#: static/js/common/upload-addon.js:467
+#: static/js/common/upload-addon.js:452 static/js/zamboni/devhub-all.js:698 static/js/zamboni/devhub-min.js:1
 msgid "If your add-on is intended for a limited audience you should choose Preliminary Review instead of Full Review."
 msgstr "Если ваше дополнение предназначено для ограниченной аудитории, вам следует выбрать Предварительную проверку вместо Полной проверки."
 
-#: static/js/common/upload-addon.js:480
+#: static/js/common/upload-addon.js:465 static/js/zamboni/devhub-all.js:711 static/js/zamboni/devhub-min.js:1
 msgid "Add-on submission checklist"
 msgstr "Контрольный перечень при представлении дополнения"
 
-#: static/js/common/upload-addon.js:481
+#: static/js/common/upload-addon.js:466 static/js/zamboni/devhub-all.js:712 static/js/zamboni/devhub-min.js:1
 msgid "Please verify the following points before finalizing your submission. This will minimize delays or misunderstanding during the review process:"
 msgstr "Пожалуйста, проверьте выполнение следующих пунктов перед завершением вашего представления. Это позволит свести к минимуму задержки или недоразумения в процессе его проверки:"
 
-#: static/js/common/upload-addon.js:483
+#: static/js/common/upload-addon.js:468 static/js/zamboni/devhub-all.js:714 static/js/zamboni/devhub-min.js:1
 msgid ""
 "Compiled binaries, as well as minified or obfuscated scripts (excluding known libraries) need to have their sources submitted separately for review. Make sure that you use the source code upload "
 "field to avoid having your submission rejected."
@@ -143,1089 +395,844 @@ msgstr ""
 "Исходные коды скомпилированных бинарников, а также минифицированных или обфусцированных скриптов (за исключением известных библиотек) необходимо представлять для проверки отдельно. Убедитесь, что "
 "вы используете поле загрузки исходного кода, чтобы избежать отклонения вашей заявки."
 
-#: static/js/common/upload-addon.js:501
+#: static/js/common/upload-addon.js:486 static/js/zamboni/devhub-all.js:732 static/js/zamboni/devhub-min.js:1
 msgid "The validation process found these issues that can lead to rejections:"
 msgstr "Процесс валидации нашёл следующие проблемы, которые могут привести к отклонению:"
 
-#: static/js/common/upload-addon.js:518
+#: static/js/common/upload-addon.js:503 static/js/zamboni/devhub-all.js:749 static/js/zamboni/devhub-min.js:1
 msgid "If you are unfamiliar with the add-ons review process, you can read about it here."
 msgstr "Если вы не знакомы с процессом проверки дополнения, вы можете прочитать об этом здесь."
 
-#: static/js/common/upload-addon.js:555
+#: static/js/common/upload-addon.js:540 static/js/zamboni/devhub-all.js:786 static/js/zamboni/devhub-min.js:1
 msgid "Sorry, no supported platform has been found."
 msgstr "К сожалению поддерживаемых платформ не найдено."
 
-#: static/js/common/upload-base.js:57
+#: static/js/common/upload-base.js:57 static/js/zamboni/devhub-all.js:187 static/js/zamboni/devhub-min.js:1
 msgid "The filetype you uploaded isn't recognized."
 msgstr "Тип загруженного вами файла не распознан."
 
-#: static/js/common/upload-base.js:79
+#: static/js/common/upload-base.js:79 static/js/zamboni/devhub-all.js:209 static/js/zamboni/devhub-min.js:1
 msgid "You cancelled the upload."
 msgstr "Вы отменили загрузку."
 
-#: static/js/common/upload-image.js:97 static/js/impala/users.js:51
-msgid "Images must be either PNG or JPG."
-msgstr "Изображения должны быть в PNG или JPG."
-
-#: static/js/common/upload-image.js:101
-msgid "Videos must be in WebM."
-msgstr "Видео должно быть в формате WebM."
-
-#: static/js/impala/collections.js:10 static/js/zamboni/collections.js:595
-msgid "Follow this Collection"
-msgstr "Следовать за этой подборкой"
-
-#: static/js/impala/collections.js:19
-msgid "Stop Following"
-msgstr "Перестать следовать"
-
-#: static/js/impala/collections.js:20
-msgid "Following"
-msgstr "Следовать"
-
-#. L10n: {0} is an app name.
-#: static/js/impala/listing.js:11 static/js/zamboni/themes.js:13
-msgid "This theme is incompatible with your version of {0}"
-msgstr "Эта тема несовместима с вашей версией {0}"
-
-#: static/js/impala/persona_creation.js:60
-msgid "All Rights Reserved"
-msgstr "Все права защищены"
-
-#: static/js/impala/persona_creation.js:64
-msgid "Creative Commons Attribution 3.0"
-msgstr "Creative Commons Атрибуция 3.0"
-
-#: static/js/impala/persona_creation.js:69
-msgid "Creative Commons Attribution-NonCommercial 3.0"
-msgstr "Creative Commons Атрибуция — Некоммерческое использование 3.0"
-
-#: static/js/impala/persona_creation.js:74
-msgid "Creative Commons Attribution-NonCommercial-NoDerivs 3.0"
-msgstr "Creative Commons Атрибуция — Некоммерческое использование — Без производных произведений 3.0"
-
-#: static/js/impala/persona_creation.js:79
-msgid "Creative Commons Attribution-NonCommercial-Share Alike 3.0"
-msgstr "Creative Commons Атрибуция — Некоммерческое использование — С сохранением условий 3.0"
-
-#: static/js/impala/persona_creation.js:84
-msgid "Creative Commons Attribution-NoDerivs 3.0"
-msgstr "Creative Commons Атрибуция — Без производных произведений 3.0"
-
-#: static/js/impala/persona_creation.js:89
-msgid "Creative Commons Attribution-ShareAlike 3.0"
-msgstr "Creative Commons Атрибуция — С сохранением условий 3.0"
-
-#: static/js/impala/persona_creation.js:292
-msgid "Your Theme's Name"
-msgstr "Имя вашей темы"
-
-#: static/js/impala/reviews.js:23 static/js/zamboni/reviews.js:18
-msgid "Flagged for review"
-msgstr "Отмечено для проверки"
-
-#: static/js/impala/reviews.js:40 static/js/zamboni/reviews.js:34
-msgid "Your input is required"
-msgstr "Требуется ваш отзыв"
-
-#: static/js/impala/reviews.js:152 static/js/zamboni/reviews.js:103
-msgid "Marked for deletion"
-msgstr "Помечено для удаления"
-
-#: static/js/impala/search.js:114
-msgid "Updating results&hellip;"
-msgstr "Обновление результатов&hellip;"
-
-#: static/js/impala/site_suggestions.js:46
-msgid "Category"
-msgstr "Категория"
-
-#: static/js/impala/suggestions.js:39
-msgid "Search themes for <b>{0}</b>"
-msgstr "Поиск <b>{0}</b>  в темах"
-
-#: static/js/impala/suggestions.js:41
-msgid "Search apps for <b>{0}</b>"
-msgstr "Искать в приложениях <b>{0}</b>"
-
-#: static/js/impala/suggestions.js:43
-msgid "Search add-ons for <b>{0}</b>"
-msgstr "Искать в дополнениях <b>{0}</b>"
-
-#: static/js/impala/users.js:33
-msgid "use original"
-msgstr "использовать оригинал"
-
-#: static/js/impala/stats/chart.js:267
+#: static/js/impala/stats/chart.js:267 static/js/zamboni/stats-all.js:16898 static/js/zamboni/stats-min.js:5
 msgid "Week of {0}"
 msgstr "{0} неделя"
 
-#: static/js/impala/stats/chart.js:269
+#: static/js/impala/stats/chart.js:269 static/js/zamboni/stats-all.js:16900 static/js/zamboni/stats-min.js:5
 msgid " downloads"
-msgstr "загрузки"
+msgstr ""
 
-#: static/js/impala/stats/chart.js:270
+#: static/js/impala/stats/chart.js:270 static/js/zamboni/stats-all.js:16901 static/js/zamboni/stats-min.js:5
 msgid "{0} users"
 msgstr "{0} пользователей"
 
-#: static/js/impala/stats/chart.js:271
+#: static/js/impala/stats/chart.js:271 static/js/zamboni/stats-all.js:16902 static/js/zamboni/stats-min.js:5
 msgid "{0} add-ons"
 msgstr "{0} дополнений"
 
-#: static/js/impala/stats/chart.js:272
+#: static/js/impala/stats/chart.js:272 static/js/zamboni/stats-all.js:16903 static/js/zamboni/stats-min.js:5
 msgid "{0} collections"
 msgstr "{0} подборок"
 
-#: static/js/impala/stats/chart.js:273
+#: static/js/impala/stats/chart.js:273 static/js/zamboni/stats-all.js:16904 static/js/zamboni/stats-min.js:5
 msgid "{0} reviews"
 msgstr "{0} отзывов"
 
-#: static/js/impala/stats/chart.js:275
+#: static/js/impala/stats/chart.js:275 static/js/zamboni/stats-all.js:16906 static/js/zamboni/stats-min.js:5
 msgid "{0} sales"
 msgstr "{0} продаж"
 
-#: static/js/impala/stats/chart.js:276
+#: static/js/impala/stats/chart.js:276 static/js/zamboni/stats-all.js:16907 static/js/zamboni/stats-min.js:5
 msgid "{0} refunds"
 msgstr "{0} возмещений"
 
-#: static/js/impala/stats/chart.js:277
+#: static/js/impala/stats/chart.js:277 static/js/zamboni/stats-all.js:16908 static/js/zamboni/stats-min.js:5
 msgid "{0} installs"
 msgstr "{0} установок"
 
-#: static/js/impala/stats/chart.js:369 static/js/impala/stats/csv_keys.js:3 static/js/impala/stats/csv_keys.js:109
+#: static/js/impala/stats/chart.js:369 static/js/impala/stats/csv_keys.js:3 static/js/impala/stats/csv_keys.js:109 static/js/zamboni/stats-all.js:15284 static/js/zamboni/stats-all.js:15390
+#: static/js/zamboni/stats-all.js:17000 static/js/zamboni/stats-min.js:4 static/js/zamboni/stats-min.js:5
 msgid "Downloads"
 msgstr "Загрузки"
 
-#: static/js/impala/stats/chart.js:379 static/js/impala/stats/csv_keys.js:6 static/js/impala/stats/csv_keys.js:110
+#: static/js/impala/stats/chart.js:379 static/js/impala/stats/csv_keys.js:6 static/js/impala/stats/csv_keys.js:110 static/js/zamboni/stats-all.js:15287 static/js/zamboni/stats-all.js:15391
+#: static/js/zamboni/stats-all.js:17010 static/js/zamboni/stats-min.js:4 static/js/zamboni/stats-min.js:5
 msgid "Daily Users"
 msgstr "Ежедневные пользователи"
 
-#: static/js/impala/stats/chart.js:410
+#: static/js/impala/stats/chart.js:410 static/js/zamboni/stats-all.js:17041 static/js/zamboni/stats-min.js:5
 msgid "Amount, in USD"
 msgstr "Сумма, в долларах США"
 
-#: static/js/impala/stats/chart.js:421 static/js/impala/stats/csv_keys.js:104
+#: static/js/impala/stats/chart.js:421 static/js/impala/stats/csv_keys.js:104 static/js/zamboni/stats-all.js:15385 static/js/zamboni/stats-all.js:17052 static/js/zamboni/stats-min.js:5
 msgid "Number of Contributions"
 msgstr "Число взносов"
 
-#: static/js/impala/stats/chart.js:447
+#: static/js/impala/stats/chart.js:447 static/js/zamboni/stats-all.js:17078 static/js/zamboni/stats-min.js:5
 msgid "More Info..."
 msgstr "Подробнее..."
 
 #. L10n: {0} is an ISO-formatted date.
-#: static/js/impala/stats/chart.js:451
+#: static/js/impala/stats/chart.js:451 static/js/zamboni/stats-all.js:17082 static/js/zamboni/stats-min.js:5
 msgid "Details for {0}"
 msgstr "Подробности для {0}"
 
-#: static/js/impala/stats/csv_keys.js:9
+#: static/js/impala/stats/csv_keys.js:9 static/js/zamboni/stats-all.js:15290 static/js/zamboni/stats-min.js:4
 msgid "Collections Created"
 msgstr "Подборок создано"
 
-#: static/js/impala/stats/csv_keys.js:12
+#: static/js/impala/stats/csv_keys.js:12 static/js/zamboni/stats-all.js:15293 static/js/zamboni/stats-min.js:4
 msgid "Add-ons in Use"
 msgstr "Дополнений используется"
 
-#: static/js/impala/stats/csv_keys.js:15
+#: static/js/impala/stats/csv_keys.js:15 static/js/zamboni/stats-all.js:15296 static/js/zamboni/stats-min.js:4
 msgid "Add-ons Created"
 msgstr "Дополнений создано"
 
-#: static/js/impala/stats/csv_keys.js:18
+#: static/js/impala/stats/csv_keys.js:18 static/js/zamboni/stats-all.js:15299 static/js/zamboni/stats-min.js:4
 msgid "Add-ons Downloaded"
 msgstr "Дополнений загружено"
 
-#: static/js/impala/stats/csv_keys.js:21
+#: static/js/impala/stats/csv_keys.js:21 static/js/zamboni/stats-all.js:15302 static/js/zamboni/stats-min.js:4
 msgid "Add-ons Updated"
 msgstr "Дополнений обновлено"
 
-#: static/js/impala/stats/csv_keys.js:24
+#: static/js/impala/stats/csv_keys.js:24 static/js/zamboni/stats-all.js:15305 static/js/zamboni/stats-min.js:4
 msgid "Reviews Written"
 msgstr "Отзывов написано"
 
-#: static/js/impala/stats/csv_keys.js:27
+#: static/js/impala/stats/csv_keys.js:27 static/js/zamboni/stats-all.js:15308 static/js/zamboni/stats-min.js:4
 msgid "User Signups"
 msgstr "Пользователей зарегистрировано"
 
-#: static/js/impala/stats/csv_keys.js:30
+#: static/js/impala/stats/csv_keys.js:30 static/js/zamboni/stats-all.js:15311 static/js/zamboni/stats-min.js:4
 msgid "Subscribers"
 msgstr "Подписчики"
 
-#: static/js/impala/stats/csv_keys.js:33
+#: static/js/impala/stats/csv_keys.js:33 static/js/zamboni/stats-all.js:15314 static/js/zamboni/stats-min.js:4
 msgid "Ratings"
 msgstr "Рейтинги"
 
-#: static/js/impala/stats/csv_keys.js:36 static/js/impala/stats/csv_keys.js:114
+#: static/js/impala/stats/csv_keys.js:36 static/js/impala/stats/csv_keys.js:114 static/js/zamboni/stats-all.js:15317 static/js/zamboni/stats-all.js:15395 static/js/zamboni/stats-min.js:4
+#: static/js/zamboni/stats-min.js:5
 msgid "Sales"
 msgstr "Продажи"
 
-#: static/js/impala/stats/csv_keys.js:39 static/js/impala/stats/csv_keys.js:113
+#: static/js/impala/stats/csv_keys.js:39 static/js/impala/stats/csv_keys.js:113 static/js/zamboni/stats-all.js:15320 static/js/zamboni/stats-all.js:15394 static/js/zamboni/stats-min.js:4
+#: static/js/zamboni/stats-min.js:5
 msgid "Installs"
 msgstr "Установки"
 
-#: static/js/impala/stats/csv_keys.js:42
+#: static/js/impala/stats/csv_keys.js:42 static/js/zamboni/stats-all.js:15323 static/js/zamboni/stats-min.js:4
 msgid "Unknown"
 msgstr "Неизвестно"
 
-#: static/js/impala/stats/csv_keys.js:43
+#: static/js/impala/stats/csv_keys.js:43 static/js/zamboni/stats-all.js:15324 static/js/zamboni/stats-min.js:4
 msgid "Add-ons Manager"
 msgstr "Управление дополнениями"
 
-#: static/js/impala/stats/csv_keys.js:44
+#: static/js/impala/stats/csv_keys.js:44 static/js/zamboni/stats-all.js:15325 static/js/zamboni/stats-min.js:4
 msgid "Add-ons Manager Promo"
 msgstr "Промо Менеджера дополнений"
 
-#: static/js/impala/stats/csv_keys.js:45
+#: static/js/impala/stats/csv_keys.js:45 static/js/zamboni/stats-all.js:15326 static/js/zamboni/stats-min.js:4
 msgid "Add-ons Manager Featured"
 msgstr "Избранное Менеджера дополнений"
 
-#: static/js/impala/stats/csv_keys.js:46
+#: static/js/impala/stats/csv_keys.js:46 static/js/zamboni/stats-all.js:15327 static/js/zamboni/stats-min.js:4
 msgid "Add-ons Manager Learn More"
 msgstr "Подробнее Менеджера дополнений"
 
-#: static/js/impala/stats/csv_keys.js:47
+#: static/js/impala/stats/csv_keys.js:47 static/js/zamboni/stats-all.js:15328 static/js/zamboni/stats-min.js:4
 msgid "Search Suggestions"
 msgstr "Поисковые предложения"
 
-#: static/js/impala/stats/csv_keys.js:48
+#: static/js/impala/stats/csv_keys.js:48 static/js/zamboni/stats-all.js:15329 static/js/zamboni/stats-min.js:4
 msgid "Search Results"
 msgstr "Результаты поиска"
 
-#: static/js/impala/stats/csv_keys.js:49 static/js/impala/stats/csv_keys.js:50 static/js/impala/stats/csv_keys.js:51
+#: static/js/impala/stats/csv_keys.js:49 static/js/impala/stats/csv_keys.js:50 static/js/impala/stats/csv_keys.js:51 static/js/zamboni/stats-all.js:15330 static/js/zamboni/stats-all.js:15331
+#: static/js/zamboni/stats-all.js:15332 static/js/zamboni/stats-min.js:4
 msgid "Homepage Promo"
 msgstr "Промо домашней страницы"
 
-#: static/js/impala/stats/csv_keys.js:52 static/js/impala/stats/csv_keys.js:53
+#: static/js/impala/stats/csv_keys.js:52 static/js/impala/stats/csv_keys.js:53 static/js/zamboni/stats-all.js:15333 static/js/zamboni/stats-all.js:15334 static/js/zamboni/stats-min.js:4
 msgid "Homepage Featured"
 msgstr "Избранные домашней страницы"
 
-#: static/js/impala/stats/csv_keys.js:54 static/js/impala/stats/csv_keys.js:55
+#: static/js/impala/stats/csv_keys.js:54 static/js/impala/stats/csv_keys.js:55 static/js/zamboni/stats-all.js:15335 static/js/zamboni/stats-all.js:15336 static/js/zamboni/stats-min.js:4
 msgid "Homepage Up and Coming"
 msgstr "Набирающие популярность домашней страницы"
 
-#: static/js/impala/stats/csv_keys.js:56
+#: static/js/impala/stats/csv_keys.js:56 static/js/zamboni/stats-all.js:15337 static/js/zamboni/stats-min.js:4
 msgid "Homepage Most Popular"
 msgstr "Самые популярные домашней страницы"
 
-#: static/js/impala/stats/csv_keys.js:57 static/js/impala/stats/csv_keys.js:59
+#: static/js/impala/stats/csv_keys.js:57 static/js/impala/stats/csv_keys.js:59 static/js/zamboni/stats-all.js:15338 static/js/zamboni/stats-all.js:15340 static/js/zamboni/stats-min.js:4
 msgid "Detail Page"
 msgstr "Страница информации"
 
-#: static/js/impala/stats/csv_keys.js:58 static/js/impala/stats/csv_keys.js:60
+#: static/js/impala/stats/csv_keys.js:58 static/js/impala/stats/csv_keys.js:60 static/js/zamboni/stats-all.js:15339 static/js/zamboni/stats-all.js:15341 static/js/zamboni/stats-min.js:4
 msgid "Detail Page (bottom)"
 msgstr "Страница информации (внизу)"
 
-#: static/js/impala/stats/csv_keys.js:61
+#: static/js/impala/stats/csv_keys.js:61 static/js/zamboni/stats-all.js:15342 static/js/zamboni/stats-min.js:4
 msgid "Detail Page (Development Channel)"
 msgstr "Страница информации (канал разработки)"
 
-#: static/js/impala/stats/csv_keys.js:62 static/js/impala/stats/csv_keys.js:63 static/js/impala/stats/csv_keys.js:64
+#: static/js/impala/stats/csv_keys.js:62 static/js/impala/stats/csv_keys.js:63 static/js/impala/stats/csv_keys.js:64 static/js/zamboni/stats-all.js:15343 static/js/zamboni/stats-all.js:15344
+#: static/js/zamboni/stats-all.js:15345 static/js/zamboni/stats-min.js:4
 msgid "Often Used With"
 msgstr "Часто используется с"
 
-#: static/js/impala/stats/csv_keys.js:65 static/js/impala/stats/csv_keys.js:66
+#: static/js/impala/stats/csv_keys.js:65 static/js/impala/stats/csv_keys.js:66 static/js/zamboni/stats-all.js:15346 static/js/zamboni/stats-all.js:15347 static/js/zamboni/stats-min.js:4
 msgid "Others By Author"
 msgstr "Другие от автора"
 
-#: static/js/impala/stats/csv_keys.js:67 static/js/impala/stats/csv_keys.js:68
+#: static/js/impala/stats/csv_keys.js:67 static/js/impala/stats/csv_keys.js:68 static/js/zamboni/stats-all.js:15348 static/js/zamboni/stats-all.js:15349 static/js/zamboni/stats-min.js:4
 msgid "Dependencies"
 msgstr "Зависимости"
 
-#: static/js/impala/stats/csv_keys.js:69 static/js/impala/stats/csv_keys.js:70
+#: static/js/impala/stats/csv_keys.js:69 static/js/impala/stats/csv_keys.js:70 static/js/zamboni/stats-all.js:15350 static/js/zamboni/stats-all.js:15351 static/js/zamboni/stats-min.js:4
 msgid "Upsell"
 msgstr "Upsell"
 
-#: static/js/impala/stats/csv_keys.js:71
+#: static/js/impala/stats/csv_keys.js:71 static/js/zamboni/stats-all.js:15352 static/js/zamboni/stats-min.js:4
 msgid "Meet the Developer"
 msgstr "Познакомьтесь с разработчиком"
 
-#: static/js/impala/stats/csv_keys.js:72
+#: static/js/impala/stats/csv_keys.js:72 static/js/zamboni/stats-all.js:15353 static/js/zamboni/stats-min.js:4
 msgid "User Profile"
 msgstr "Профиль пользователя"
 
-#: static/js/impala/stats/csv_keys.js:73
+#: static/js/impala/stats/csv_keys.js:73 static/js/zamboni/stats-all.js:15354 static/js/zamboni/stats-min.js:4
 msgid "Version History"
 msgstr "История версий"
 
-#: static/js/impala/stats/csv_keys.js:75
+#: static/js/impala/stats/csv_keys.js:75 static/js/zamboni/stats-all.js:15356 static/js/zamboni/stats-min.js:4
 msgid "Sharing"
 msgstr "Разделение"
 
-#: static/js/impala/stats/csv_keys.js:76
+#: static/js/impala/stats/csv_keys.js:76 static/js/zamboni/stats-all.js:15357 static/js/zamboni/stats-min.js:4
 msgid "Category Pages"
 msgstr "Страницы категорий"
 
-#: static/js/impala/stats/csv_keys.js:77
+#: static/js/impala/stats/csv_keys.js:77 static/js/zamboni/stats-all.js:15358 static/js/zamboni/stats-min.js:4
 msgid "Collections"
 msgstr "Подборки"
 
-#: static/js/impala/stats/csv_keys.js:78 static/js/impala/stats/csv_keys.js:79
+#: static/js/impala/stats/csv_keys.js:78 static/js/impala/stats/csv_keys.js:79 static/js/zamboni/stats-all.js:15359 static/js/zamboni/stats-all.js:15360 static/js/zamboni/stats-min.js:4
 msgid "Category Landing Featured Carousel"
 msgstr "Размещение в категории Карусель избранных"
 
-#: static/js/impala/stats/csv_keys.js:80 static/js/impala/stats/csv_keys.js:81
+#: static/js/impala/stats/csv_keys.js:80 static/js/impala/stats/csv_keys.js:81 static/js/zamboni/stats-all.js:15361 static/js/zamboni/stats-all.js:15362 static/js/zamboni/stats-min.js:4
 msgid "Category Landing Top Rated"
 msgstr "Размещение в категории Самая рейтинговая"
 
-#: static/js/impala/stats/csv_keys.js:82 static/js/impala/stats/csv_keys.js:83
+#: static/js/impala/stats/csv_keys.js:82 static/js/impala/stats/csv_keys.js:83 static/js/zamboni/stats-all.js:15363 static/js/zamboni/stats-all.js:15364 static/js/zamboni/stats-min.js:5
 msgid "Category Landing Most Popular"
 msgstr "Размещение в категории Наиболее популярная"
 
-#: static/js/impala/stats/csv_keys.js:84 static/js/impala/stats/csv_keys.js:85
+#: static/js/impala/stats/csv_keys.js:84 static/js/impala/stats/csv_keys.js:85 static/js/zamboni/stats-all.js:15365 static/js/zamboni/stats-all.js:15366 static/js/zamboni/stats-min.js:5
 msgid "Category Landing Recently Added"
 msgstr "Размещение в категории Недавно добавленная"
 
-#: static/js/impala/stats/csv_keys.js:86 static/js/impala/stats/csv_keys.js:87
+#: static/js/impala/stats/csv_keys.js:86 static/js/impala/stats/csv_keys.js:87 static/js/zamboni/stats-all.js:15367 static/js/zamboni/stats-all.js:15368 static/js/zamboni/stats-min.js:5
 msgid "Browse Listing Featured Sort"
 msgstr "Обзор дополнений Сортировка по избранным"
 
-#: static/js/impala/stats/csv_keys.js:88 static/js/impala/stats/csv_keys.js:89
+#: static/js/impala/stats/csv_keys.js:88 static/js/impala/stats/csv_keys.js:89 static/js/zamboni/stats-all.js:15369 static/js/zamboni/stats-all.js:15370 static/js/zamboni/stats-min.js:5
 msgid "Browse Listing Users Sort"
 msgstr "Обзор дополнений Сортировка по пользователям"
 
-#: static/js/impala/stats/csv_keys.js:90 static/js/impala/stats/csv_keys.js:91
+#: static/js/impala/stats/csv_keys.js:90 static/js/impala/stats/csv_keys.js:91 static/js/zamboni/stats-all.js:15371 static/js/zamboni/stats-all.js:15372 static/js/zamboni/stats-min.js:5
 msgid "Browse Listing Rating Sort"
 msgstr "Обзор дополнений Сортировка по рейтингу"
 
-#: static/js/impala/stats/csv_keys.js:92 static/js/impala/stats/csv_keys.js:93
+#: static/js/impala/stats/csv_keys.js:92 static/js/impala/stats/csv_keys.js:93 static/js/zamboni/stats-all.js:15373 static/js/zamboni/stats-all.js:15374 static/js/zamboni/stats-min.js:5
 msgid "Browse Listing Created Sort"
 msgstr "Обзор дополнений Сортировка по дате создания"
 
-#: static/js/impala/stats/csv_keys.js:94 static/js/impala/stats/csv_keys.js:95
+#: static/js/impala/stats/csv_keys.js:94 static/js/impala/stats/csv_keys.js:95 static/js/zamboni/stats-all.js:15375 static/js/zamboni/stats-all.js:15376 static/js/zamboni/stats-min.js:5
 msgid "Browse Listing Name Sort"
 msgstr "Обзор дополнений Сортировка по имени"
 
-#: static/js/impala/stats/csv_keys.js:96 static/js/impala/stats/csv_keys.js:97
+#: static/js/impala/stats/csv_keys.js:96 static/js/impala/stats/csv_keys.js:97 static/js/zamboni/stats-all.js:15377 static/js/zamboni/stats-all.js:15378 static/js/zamboni/stats-min.js:5
 msgid "Browse Listing Popular Sort"
 msgstr "Обзор дополнений Сортировка по популярности"
 
-#: static/js/impala/stats/csv_keys.js:98 static/js/impala/stats/csv_keys.js:99
+#: static/js/impala/stats/csv_keys.js:98 static/js/impala/stats/csv_keys.js:99 static/js/zamboni/stats-all.js:15379 static/js/zamboni/stats-all.js:15380 static/js/zamboni/stats-min.js:5
 msgid "Browse Listing Updated Sort"
 msgstr "Обзор дополнений Сортировка по дате обновления"
 
-#: static/js/impala/stats/csv_keys.js:100 static/js/impala/stats/csv_keys.js:101
+#: static/js/impala/stats/csv_keys.js:100 static/js/impala/stats/csv_keys.js:101 static/js/zamboni/stats-all.js:15381 static/js/zamboni/stats-all.js:15382 static/js/zamboni/stats-min.js:5
 msgid "Browse Listing Up and Coming Sort"
 msgstr "Обзор дополнений Сортировка по набору популярности"
 
-#: static/js/impala/stats/csv_keys.js:105
+#: static/js/impala/stats/csv_keys.js:105 static/js/zamboni/stats-all.js:15386 static/js/zamboni/stats-min.js:5
 msgid "Total Amount Contributed"
 msgstr "Общая сумма взносов"
 
-#: static/js/impala/stats/csv_keys.js:106
+#: static/js/impala/stats/csv_keys.js:106 static/js/zamboni/stats-all.js:15387 static/js/zamboni/stats-min.js:5
 msgid "Average Contribution"
 msgstr "Средний взнос"
 
-#: static/js/impala/stats/csv_keys.js:115
+#: static/js/impala/stats/csv_keys.js:115 static/js/zamboni/stats-all.js:15396 static/js/zamboni/stats-min.js:5
 msgid "Usage"
 msgstr "Использование"
 
-#: static/js/impala/stats/csv_keys.js:118
+#: static/js/impala/stats/csv_keys.js:118 static/js/zamboni/stats-all.js:15399 static/js/zamboni/stats-min.js:5
 msgid "Firefox"
 msgstr "Firefox"
 
-#: static/js/impala/stats/csv_keys.js:119
+#: static/js/impala/stats/csv_keys.js:119 static/js/zamboni/stats-all.js:15400 static/js/zamboni/stats-min.js:5
 msgid "Mozilla"
 msgstr "Mozilla"
 
-#: static/js/impala/stats/csv_keys.js:120
+#: static/js/impala/stats/csv_keys.js:120 static/js/zamboni/stats-all.js:15401 static/js/zamboni/stats-min.js:5
 msgid "Thunderbird"
 msgstr "Thunderbird"
 
-#: static/js/impala/stats/csv_keys.js:121
+#: static/js/impala/stats/csv_keys.js:121 static/js/zamboni/stats-all.js:15402 static/js/zamboni/stats-min.js:5
 msgid "Sunbird"
 msgstr "Sunbird"
 
-#: static/js/impala/stats/csv_keys.js:122
+#: static/js/impala/stats/csv_keys.js:122 static/js/zamboni/stats-all.js:15403 static/js/zamboni/stats-min.js:5
 msgid "SeaMonkey"
 msgstr "SeaMonkey"
 
-#: static/js/impala/stats/csv_keys.js:123
+#: static/js/impala/stats/csv_keys.js:123 static/js/zamboni/stats-all.js:15404 static/js/zamboni/stats-min.js:5
 msgid "Fennec"
 msgstr "Fennec"
 
-#: static/js/impala/stats/csv_keys.js:124
+#: static/js/impala/stats/csv_keys.js:124 static/js/zamboni/stats-all.js:15405 static/js/zamboni/stats-min.js:5
 msgid "Android"
 msgstr "Android"
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:129
+#: static/js/impala/stats/csv_keys.js:129 static/js/zamboni/stats-all.js:15410 static/js/zamboni/stats-min.js:5
 msgid "Downloads and Daily Users, last {0} days"
 msgstr "Загрузки и ежедневные пользователи, последние {0} дней"
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:131
+#: static/js/impala/stats/csv_keys.js:131 static/js/zamboni/stats-all.js:15412 static/js/zamboni/stats-min.js:5
 msgid "Downloads and Daily Users from {0} to {1}"
 msgstr "Загрузки и ежедневные пользователи, с {0} по {1}"
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:135
+#: static/js/impala/stats/csv_keys.js:135 static/js/zamboni/stats-all.js:15416 static/js/zamboni/stats-min.js:5
 msgid "Installs and Daily Users, last {0} days"
 msgstr "Установки и ежедневные пользователи, последние {0} дней"
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:137
+#: static/js/impala/stats/csv_keys.js:137 static/js/zamboni/stats-all.js:15418 static/js/zamboni/stats-min.js:5
 msgid "Installs and Daily Users from {0} to {1}"
 msgstr "Установки и ежедневные пользователи, с {0} по {1}"
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:141
+#: static/js/impala/stats/csv_keys.js:141 static/js/zamboni/stats-all.js:15422 static/js/zamboni/stats-min.js:5
 msgid "Downloads, last {0} days"
 msgstr "Загрузки, последние {0} дней"
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:143
+#: static/js/impala/stats/csv_keys.js:143 static/js/zamboni/stats-all.js:15424 static/js/zamboni/stats-min.js:5
 msgid "Downloads from {0} to {1}"
 msgstr "Загрузки, с {0} по {1}"
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:147
+#: static/js/impala/stats/csv_keys.js:147 static/js/zamboni/stats-all.js:15428 static/js/zamboni/stats-min.js:5
 msgid "Daily Users, last {0} days"
 msgstr "Ежедневные пользователи, последние {0} дней"
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:149
+#: static/js/impala/stats/csv_keys.js:149 static/js/zamboni/stats-all.js:15430 static/js/zamboni/stats-min.js:5
 msgid "Daily Users from {0} to {1}"
 msgstr "Ежедневные пользователи, с {0} по {1}"
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:153
+#: static/js/impala/stats/csv_keys.js:153 static/js/zamboni/stats-all.js:15434 static/js/zamboni/stats-min.js:5
 msgid "Applications, last {0} days"
 msgstr "Приложения, последние {0} дней"
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:155
+#: static/js/impala/stats/csv_keys.js:155 static/js/zamboni/stats-all.js:15436 static/js/zamboni/stats-min.js:5
 msgid "Applications from {0} to {1}"
 msgstr "Приложения, с {0} по {1}"
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:159
+#: static/js/impala/stats/csv_keys.js:159 static/js/zamboni/stats-all.js:15440 static/js/zamboni/stats-min.js:5
 msgid "Platforms, last {0} days"
 msgstr "Платформы, последние {0} дней"
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:161
+#: static/js/impala/stats/csv_keys.js:161 static/js/zamboni/stats-all.js:15442 static/js/zamboni/stats-min.js:5
 msgid "Platforms from {0} to {1}"
 msgstr "Платформы, с {0} по {1}"
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:165
+#: static/js/impala/stats/csv_keys.js:165 static/js/zamboni/stats-all.js:15446 static/js/zamboni/stats-min.js:5
 msgid "Languages, last {0} days"
 msgstr "Языки, последние {0} дней"
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:167
+#: static/js/impala/stats/csv_keys.js:167 static/js/zamboni/stats-all.js:15448 static/js/zamboni/stats-min.js:5
 msgid "Languages from {0} to {1}"
 msgstr "Языки, с {0} по {1}"
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:171
+#: static/js/impala/stats/csv_keys.js:171 static/js/zamboni/stats-all.js:15452 static/js/zamboni/stats-min.js:5
 msgid "Add-on Versions, last {0} days"
 msgstr "Версии дополнения, последние {0} дней"
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:173
+#: static/js/impala/stats/csv_keys.js:173 static/js/zamboni/stats-all.js:15454 static/js/zamboni/stats-min.js:5
 msgid "Add-on Versions from {0} to {1}"
 msgstr "Версии дополнения, с {0} по {1}"
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:177
+#: static/js/impala/stats/csv_keys.js:177 static/js/zamboni/stats-all.js:15458 static/js/zamboni/stats-min.js:5
 msgid "Add-on Status, last {0} days"
 msgstr "Статус дополнения, последние {0} дней"
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:179
+#: static/js/impala/stats/csv_keys.js:179 static/js/zamboni/stats-all.js:15460 static/js/zamboni/stats-min.js:5
 msgid "Add-on Status from {0} to {1}"
 msgstr "Статус дополнения, с {0} по {1}"
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:183
+#: static/js/impala/stats/csv_keys.js:183 static/js/zamboni/stats-all.js:15464 static/js/zamboni/stats-min.js:5
 msgid "Download Sources, last {0} days"
 msgstr "Источники загрузок, последние {0} дней"
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:185
+#: static/js/impala/stats/csv_keys.js:185 static/js/zamboni/stats-all.js:15466 static/js/zamboni/stats-min.js:5
 msgid "Download Sources from {0} to {1}"
 msgstr "Источники загрузок, с {0} по {1}"
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:189
+#: static/js/impala/stats/csv_keys.js:189 static/js/zamboni/stats-all.js:15470 static/js/zamboni/stats-min.js:5
 msgid "Contributions, last {0} days"
 msgstr "Взносы, последние {0} дней"
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:191
+#: static/js/impala/stats/csv_keys.js:191 static/js/zamboni/stats-all.js:15472 static/js/zamboni/stats-min.js:5
 msgid "Contributions from {0} to {1}"
 msgstr "Взносы, с {0} по {1}"
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:195
+#: static/js/impala/stats/csv_keys.js:195 static/js/zamboni/stats-all.js:15476 static/js/zamboni/stats-min.js:5
 msgid "Site Metrics, last {0} days"
 msgstr "Статистика сайта, последние {0} дней"
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:197
+#: static/js/impala/stats/csv_keys.js:197 static/js/zamboni/stats-all.js:15478 static/js/zamboni/stats-min.js:5
 msgid "Site Metrics from {0} to {1}"
 msgstr "Статистика сайта, с {0} по {1}"
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:201
+#: static/js/impala/stats/csv_keys.js:201 static/js/zamboni/stats-all.js:15482 static/js/zamboni/stats-min.js:5
 msgid "Add-ons in Use, last {0} days"
 msgstr "Дополнений используется, последние {0} дней"
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:203
+#: static/js/impala/stats/csv_keys.js:203 static/js/zamboni/stats-all.js:15484 static/js/zamboni/stats-min.js:5
 msgid "Add-ons in Use from {0} to {1}"
 msgstr "Дополнений используется, с {0} по {1}"
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:207
+#: static/js/impala/stats/csv_keys.js:207 static/js/zamboni/stats-all.js:15488 static/js/zamboni/stats-min.js:5
 msgid "Add-ons Downloaded, last {0} days"
 msgstr "Дополнений загружено, последние {0} дней"
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:209
+#: static/js/impala/stats/csv_keys.js:209 static/js/zamboni/stats-all.js:15490 static/js/zamboni/stats-min.js:5
 msgid "Add-ons Downloaded from {0} to {1}"
 msgstr "Дополнений загружено, с {0} по {1}"
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:213
+#: static/js/impala/stats/csv_keys.js:213 static/js/zamboni/stats-all.js:15494 static/js/zamboni/stats-min.js:5
 msgid "Add-ons Created, last {0} days"
 msgstr "Дополнений создано, последние {0} дней"
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:215
+#: static/js/impala/stats/csv_keys.js:215 static/js/zamboni/stats-all.js:15496 static/js/zamboni/stats-min.js:5
 msgid "Add-ons Created from {0} to {1}"
 msgstr "Дополнений создано, с {0} по {1}"
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:219
+#: static/js/impala/stats/csv_keys.js:219 static/js/zamboni/stats-all.js:15500 static/js/zamboni/stats-min.js:5
 msgid "Add-ons Updated, last {0} days"
 msgstr "Дополнений обновлено, последние {0} дней"
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:221
+#: static/js/impala/stats/csv_keys.js:221 static/js/zamboni/stats-all.js:15502 static/js/zamboni/stats-min.js:5
 msgid "Add-ons Updated from {0} to {1}"
 msgstr "Дополнений обновлено, с {0} по {1}"
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:225
+#: static/js/impala/stats/csv_keys.js:225 static/js/zamboni/stats-all.js:15506 static/js/zamboni/stats-min.js:5
 msgid "Reviews Written, last {0} days"
 msgstr "Отзывов написано, последние {0} дней"
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:227
+#: static/js/impala/stats/csv_keys.js:227 static/js/zamboni/stats-all.js:15508 static/js/zamboni/stats-min.js:5
 msgid "Reviews Written from {0} to {1}"
 msgstr "Отзывов написано, с {0} по {1}"
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:231
+#: static/js/impala/stats/csv_keys.js:231 static/js/zamboni/stats-all.js:15512 static/js/zamboni/stats-min.js:5
 msgid "User Signups, last {0} days"
 msgstr "Пользователей зарегистрировано, последние {0} дней"
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:233
+#: static/js/impala/stats/csv_keys.js:233 static/js/zamboni/stats-all.js:15514 static/js/zamboni/stats-min.js:5
 msgid "User Signups from {0} to {1}"
 msgstr "Пользователей зарегистрировано, с {0} по {1}"
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:237
+#: static/js/impala/stats/csv_keys.js:237 static/js/zamboni/stats-all.js:15518 static/js/zamboni/stats-min.js:5
 msgid "Collections Created, last {0} days"
 msgstr "Подборок создано, последние {0} дней"
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:239
+#: static/js/impala/stats/csv_keys.js:239 static/js/zamboni/stats-all.js:15520 static/js/zamboni/stats-min.js:5
 msgid "Collections Created from {0} to {1}"
 msgstr "Подборок создано, с {0} по {1}"
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:243
+#: static/js/impala/stats/csv_keys.js:243 static/js/zamboni/stats-all.js:15524 static/js/zamboni/stats-min.js:5
 msgid "Subscribers, last {0} days"
 msgstr "Подписчики, последние {0} дней"
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:245
+#: static/js/impala/stats/csv_keys.js:245 static/js/zamboni/stats-all.js:15526 static/js/zamboni/stats-min.js:5
 msgid "Subscribers from {0} to {1}"
 msgstr "Подписчики, с {0} по {1}"
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:249
+#: static/js/impala/stats/csv_keys.js:249 static/js/zamboni/stats-all.js:15530 static/js/zamboni/stats-min.js:5
 msgid "Ratings, last {0} days"
 msgstr "Рейтинги, последние {0} дней"
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:251
+#: static/js/impala/stats/csv_keys.js:251 static/js/zamboni/stats-all.js:15532 static/js/zamboni/stats-min.js:5
 msgid "Ratings from {0} to {1}"
 msgstr "Рейтинги, с {0} по {1}"
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:255
+#: static/js/impala/stats/csv_keys.js:255 static/js/zamboni/stats-all.js:15536 static/js/zamboni/stats-min.js:5
 msgid "Sales, last {0} days"
 msgstr "Продажи, последние {0} дней"
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:257
+#: static/js/impala/stats/csv_keys.js:257 static/js/zamboni/stats-all.js:15538 static/js/zamboni/stats-min.js:5
 msgid "Sales from {0} to {1}"
 msgstr "Продажи, с {0} по {1}"
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:261
+#: static/js/impala/stats/csv_keys.js:261 static/js/zamboni/stats-all.js:15542 static/js/zamboni/stats-min.js:5
 msgid "Installs, last {0} days"
 msgstr "Установки, последние {0} дней"
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:263
+#: static/js/impala/stats/csv_keys.js:263 static/js/zamboni/stats-all.js:15544 static/js/zamboni/stats-min.js:5
 msgid "Installs from {0} to {1}"
 msgstr "Установки, с {0} по {1}"
 
 #. L10n: {0} and {1} are integers.
-#: static/js/impala/stats/csv_keys.js:269
+#: static/js/impala/stats/csv_keys.js:269 static/js/zamboni/stats-all.js:15550 static/js/zamboni/stats-min.js:5
 msgid "<b>{0}</b> in last {1} days"
 msgstr "<b>{0}</b> за последние {1} дней"
 
 #. L10n: {0} is an integer and {1} and {2} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:271 static/js/impala/stats/csv_keys.js:277
+#: static/js/impala/stats/csv_keys.js:271 static/js/impala/stats/csv_keys.js:277 static/js/zamboni/stats-all.js:15552 static/js/zamboni/stats-all.js:15558 static/js/zamboni/stats-min.js:5
 msgid "<b>{0}</b> from {1} to {2}"
 msgstr "<b>{0}</b>, с {1} по {2}"
 
 #. L10n: {0} and {1} are integers.
-#: static/js/impala/stats/csv_keys.js:275
+#: static/js/impala/stats/csv_keys.js:275 static/js/zamboni/stats-all.js:15556 static/js/zamboni/stats-min.js:5
 msgid "<b>{0}</b> average in last {1} days"
 msgstr "в среднем <b>{0}</b> за последние {1} дней"
 
-#: static/js/impala/stats/overview.js:19
+#: static/js/impala/stats/overview.js:19 static/js/zamboni/stats-all.js:16469 static/js/zamboni/stats-min.js:5
 msgid "No data available."
 msgstr "Данные недоступны."
 
-#: static/js/impala/stats/table.js:74
+#: static/js/impala/stats/table.js:74 static/js/zamboni/stats-all.js:17209 static/js/zamboni/stats-min.js:5
 msgid "Date"
 msgstr "Дата"
 
-#: static/js/impala/stats/topchart.js:96
+#: static/js/impala/stats/topchart.js:96 static/js/zamboni/stats-all.js:16600 static/js/zamboni/stats-min.js:5
 msgid "Other"
 msgstr "Другое"
 
-#: static/js/zamboni/admin_validation.js:24 static/js/zamboni/devhub.js:1229 static/js/zamboni/editors.js:295
+#: static/js/zamboni/admin-all.js:180 static/js/zamboni/admin-min.js:1 static/js/zamboni/admin_validation.js:24 static/js/zamboni/devhub-all.js:2408 static/js/zamboni/devhub-min.js:2
+#: static/js/zamboni/devhub.js:1229 static/js/zamboni/editors-all.js:15576 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:295
 msgid "Select an application first"
 msgstr "Сначала выберите приложение"
 
-#: static/js/zamboni/admin_validation.js:51
+#: static/js/zamboni/admin-all.js:207 static/js/zamboni/admin-min.js:1 static/js/zamboni/admin_validation.js:51
 msgid "Set {0} add-on to a max version of {1} and email the author."
 msgid_plural "Set {0} add-ons to a max version of {1} and email the authors."
 msgstr[0] "Установить для {0} дополнения максимальную версию {1} и отправить письмо автору."
 msgstr[1] "Установить для {0} дополнений максимальную версию {1} и отправить письмо авторам."
-msgstr[2] "Установить для {0} дополнений максимальную версию {1} и отправить письмо авторам."
 
-#: static/js/zamboni/admin_validation.js:54
+#: static/js/zamboni/admin-all.js:210 static/js/zamboni/admin-min.js:1 static/js/zamboni/admin_validation.js:54
 msgid "Email author of {2} add-on which failed validation."
 msgid_plural "Email authors of {2} add-ons which failed validation."
 msgstr[0] "Написать автору {2} дополнения, которое не прошло валидацию."
 msgstr[1] "Написать авторам {2} дополнений, которые не прошли валидацию."
-msgstr[2] "Написать авторам {2} дополнений, которые не прошли валидацию."
 
-#. L10n: {0} is an app name like Firefox.
-#: static/js/zamboni/buttons.js:66
-msgid "Accept and Install"
-msgstr "Принять и установить"
-
-#: static/js/zamboni/buttons.js:66
-msgid "Add to {0}"
-msgstr "Добавить в {0}"
-
-#: static/js/zamboni/buttons.js:71
-msgid "Download Now"
-msgstr "Загрузить сейчас"
-
-#: static/js/zamboni/buttons.js:112
-msgid "Add-on has not been updated to support default-to-compatible."
-msgstr "Дополнение не было обновлено для поддержки совместимости-по-умолчанию."
-
-#: static/js/zamboni/buttons.js:117
-msgid "You need to be using Firefox 10.0 or higher."
-msgstr "Вам необходимо использовать Firefox 10.0 или выше."
-
-#: static/js/zamboni/buttons.js:129
-msgid "Mozilla has marked this version as incompatible with your Firefox version."
-msgstr "Mozilla отметила эту версию как несовместимую с вашей версией Firefox."
-
-#. L10n: {0} is an platform like Windows or Linux.
-#: static/js/zamboni/buttons.js:210
-msgid "Install for {0} anyway"
-msgstr "Всё равно установить для {0}"
-
-#: static/js/zamboni/buttons.js:210
-msgid "Download for {0} anyway"
-msgstr "Всё равно загрузить для {0}"
-
-#: static/js/zamboni/buttons.js:267
-msgid "Not available for your platform"
-msgstr "Недоступно для вашей платформы"
-
-#. L10n: {0} is an app name, {1} is the app version.
-#: static/js/zamboni/buttons.js:278 static/js/zamboni/buttons.js:315
-msgid "Not available for {0} {1}"
-msgstr "Недоступно для {0} {1}"
-
-#: static/js/zamboni/buttons.js:341
-msgid "Works with {app} {min} - {max}"
-msgstr "Работает с {app} {min} - {max}"
-
-#: static/js/zamboni/buttons.js:343
-msgid "View other versions"
-msgstr "Просмотреть другие версии"
-
-#: static/js/zamboni/buttons.js:391
-msgid "Only with Firefox — Get Firefox Now!"
-msgstr "Только в Firefox — Скачать Firefox!"
-
-#: static/js/zamboni/buttons.js:507 static/js/zamboni/mobile/buttons.js:43
-msgid "Sorry, you need a Mozilla-based browser (such as Firefox) to install a search plugin."
-msgstr "Извините, для установки поискового плагина вам нужен браузер из семейства Mozilla (например, Firefox)."
-
-#: static/js/zamboni/collections.js:229
-msgid "Adding to Favorites&hellip;"
-msgstr "Добавляю в Избранное&hellip;"
-
-#: static/js/zamboni/collections.js:232
-msgid "Removing Favorite&hellip;"
-msgstr "Удаляю из Избранного&hellip;"
-
-#: static/js/zamboni/collections.js:235
-msgid "Add to Favorites"
-msgstr "Добавить в избранное"
-
-#: static/js/zamboni/collections.js:238
-msgid "Remove from Favorites"
-msgstr "Удалить из избранного"
-
-#: static/js/zamboni/collections.js:303
-msgid "Pending"
-msgstr "В ожидании"
-
-#: static/js/zamboni/collections.js:304
-msgid "Add a comment"
-msgstr "Добавить комментарий"
-
-#: static/js/zamboni/collections.js:304
-msgid "Comment"
-msgstr "Комментарий"
-
-#: static/js/zamboni/collections.js:305
-msgid "Remove this add-on from the collection"
-msgstr "Удалить это дополнение из подборки"
-
-#: static/js/zamboni/collections.js:305 static/js/zamboni/collections.js:334
-msgid "Remove"
-msgstr "Удалить"
-
-#: static/js/zamboni/collections.js:334
-msgid "Remove this user as a contributor"
-msgstr "Удалить этого пользователя как помощника"
-
-#: static/js/zamboni/collections.js:346
-msgid "An email address is required."
-msgstr "Требуется адрес электронной почты."
-
-#: static/js/zamboni/collections.js:364
-msgid "You cannot add yourself as a contributor."
-msgstr "Вы не можете добавить себя как помощника."
-
-#: static/js/zamboni/collections.js:366
-msgid "You have already added that user."
-msgstr "Вы уже добавили этого пользователя."
-
-#: static/js/zamboni/collections.js:573
-msgid "Add to favorites"
-msgstr "Добавить в избранное"
-
-#: static/js/zamboni/collections.js:577
-msgid "Remove from favorites"
-msgstr "Удалить из избранного"
-
-#: static/js/zamboni/collections.js:604
-msgid "Stop following"
-msgstr "Перестать следовать"
-
-#: static/js/zamboni/devhub.js:110
+#: static/js/zamboni/devhub-all.js:1289 static/js/zamboni/devhub-min.js:1 static/js/zamboni/devhub.js:110
 msgid "Your browser does not support the video tag"
 msgstr "Ваш браузер не поддерживает тег видео"
 
-#: static/js/zamboni/devhub.js:371
+#: static/js/zamboni/devhub-all.js:1550 static/js/zamboni/devhub-min.js:1 static/js/zamboni/devhub.js:371
 msgid "Changes Saved"
 msgstr "Изменения сохранены"
 
-#: static/js/zamboni/devhub.js:387
+#: static/js/zamboni/devhub-all.js:1566 static/js/zamboni/devhub-min.js:1 static/js/zamboni/devhub.js:387
 msgid "Enter a new author's email address"
 msgstr "Введите новый адрес эл. почты автора"
 
-#: static/js/zamboni/devhub.js:536
+#: static/js/zamboni/devhub-all.js:1715 static/js/zamboni/devhub-min.js:1 static/js/zamboni/devhub.js:536
 msgid "There was an error uploading your file."
 msgstr "При загрузке вашего файла произошла ошибка."
 
-#: static/js/zamboni/devhub.js:681
+#: static/js/zamboni/devhub-all.js:1860 static/js/zamboni/devhub-min.js:1 static/js/zamboni/devhub.js:681
 msgid "{files} file"
 msgid_plural "{files} files"
 msgstr[0] "{files} файл"
 msgstr[1] "{files} файла"
-msgstr[2] "{files} файлов"
 
-#: static/js/zamboni/devhub.js:684
+#: static/js/zamboni/devhub-all.js:1863 static/js/zamboni/devhub-min.js:1 static/js/zamboni/devhub.js:684
 msgid "{reviews} user review"
 msgid_plural "{reviews} user reviews"
 msgstr[0] "{reviews} отзыв пользователей"
 msgstr[1] "{reviews} отзыва пользователей"
-msgstr[2] "{reviews} отзывов пользователей"
 
-#: static/js/zamboni/devhub.js:796
+#: static/js/zamboni/devhub-all.js:1975 static/js/zamboni/devhub-min.js:2 static/js/zamboni/devhub.js:796
 msgid "Learn more"
 msgstr "Подробнее"
 
-#: static/js/zamboni/devhub.js:800
+#: static/js/zamboni/devhub-all.js:1979 static/js/zamboni/devhub-min.js:2 static/js/zamboni/devhub.js:800
 msgid "Example"
 msgstr "Пример"
 
-#: static/js/zamboni/devhub.js:1130
+#: static/js/zamboni/devhub-all.js:2309 static/js/zamboni/devhub-min.js:2 static/js/zamboni/devhub.js:1130
 msgid "Image changes being processed"
 msgstr "Обработка изменений изображения"
 
-#: static/js/zamboni/devhub.js:1280
+#: static/js/zamboni/devhub-all.js:2459 static/js/zamboni/devhub-min.js:2 static/js/zamboni/devhub.js:1280
 msgid "Must be a valid e-mail address."
 msgstr "Должен быть корректным адресом эл. почты."
+
+#: static/js/zamboni/devhub-all.js:2613 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:80
+msgid "All tests passed successfully."
+msgstr "Все тесты пройдены успешно."
+
+#: static/js/zamboni/devhub-all.js:2616 static/js/zamboni/devhub-all.js:3011 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:83 static/js/zamboni/validator.js:478
+msgid "These tests were not run."
+msgstr "Эти тесты не были запущены."
+
+#: static/js/zamboni/devhub-all.js:2664 static/js/zamboni/devhub-all.js:2677 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:131 static/js/zamboni/validator.js:144
+msgid "Tests"
+msgstr "Тесты"
+
+#: static/js/zamboni/devhub-all.js:2779 static/js/zamboni/devhub-all.js:3108 static/js/zamboni/devhub-all.js:3127 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:246
+#: static/js/zamboni/validator.js:575 static/js/zamboni/validator.js:594
+msgid "Error"
+msgstr "Ошибка"
+
+#: static/js/zamboni/devhub-all.js:2780 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:247
+msgid "Warning"
+msgstr "Предупреждение"
+
+#: static/js/zamboni/devhub-all.js:2794 static/js/zamboni/devhub-min.js:2 static/js/zamboni/files-all.js:5657 static/js/zamboni/files-min.js:3 static/js/zamboni/files.js:411
+#: static/js/zamboni/validator.js:261
+msgid "Ignore this message in future updates"
+msgstr "Игнорировать это сообщение в будущих обновлениях"
+
+#: static/js/zamboni/devhub-all.js:2817 static/js/zamboni/devhub-min.js:2 static/js/zamboni/files-all.js:5663 static/js/zamboni/files-min.js:3 static/js/zamboni/files.js:417
+#: static/js/zamboni/validator.js:284
+msgid "Severity for automated signing:"
+msgstr "Критичность для автоматического подписания:"
+
+#: static/js/zamboni/devhub-all.js:2832 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:299
+msgid "Suggestions for passing automated signing:"
+msgstr "Предложения для прохождения автоматизированного подписания:"
+
+#: static/js/zamboni/devhub-all.js:2920 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:387
+msgid "Compatibility Tests"
+msgstr "Тесты совместимости"
+
+#: static/js/zamboni/devhub-all.js:2999 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:466
+msgid "Add-on failed validation."
+msgstr "Дополнение не прошло валидацию."
+
+#: static/js/zamboni/devhub-all.js:3001 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:468
+msgid "Add-on passed validation."
+msgstr "Дополнение прошло валидацию."
+
+#: static/js/zamboni/devhub-all.js:3014 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:481
+msgid "{0} error"
+msgid_plural "{0} errors"
+msgstr[0] "{0} ошибка"
+msgstr[1] "{0} ошибки"
+
+#: static/js/zamboni/devhub-all.js:3016 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:483
+msgid "{0} warning"
+msgid_plural "{0} warnings"
+msgstr[0] "{0} предупреждение"
+msgstr[1] "{0} предупреждения"
+
+#: static/js/zamboni/devhub-all.js:3018 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:485
+msgid "{0} notice"
+msgid_plural "{0} notices"
+msgstr[0] "{0} замечание"
+msgstr[1] "{0} замечания"
+
+#: static/js/zamboni/devhub-all.js:3110 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:577
+msgid "Validation task could not complete or completed with errors"
+msgstr "Валидация не смогла завершиться или завершилась с ошибками"
+
+#: static/js/zamboni/devhub-all.js:3128 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:595
+msgid "Internal server error"
+msgstr "Внутренняя ошибка сервера"
 
 #: static/js/zamboni/devhub_search.js:8
 msgid "No results found."
 msgstr "Результаты не найдены."
 
-#: static/js/zamboni/editors.js:121
+#: static/js/zamboni/editors-all.js:15402 static/js/zamboni/editors-min.js:4 static/js/zamboni/editors.js:121
 msgid "{name} was viewing this page first."
 msgstr "{name} просматривал эту страницу первым."
 
-#: static/js/zamboni/editors.js:171
+#: static/js/zamboni/editors-all.js:15452 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:171
 msgid "Receipt checked by app."
 msgstr "Квитанция была проверена приложением."
 
-#: static/js/zamboni/editors.js:173
+#: static/js/zamboni/editors-all.js:15454 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:173
 msgid "Receipt was not checked by app."
 msgstr "Квитанция не была проверена приложением."
 
-#: static/js/zamboni/editors.js:244
+#: static/js/zamboni/editors-all.js:15525 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:244
 msgid "{name} was viewing this add-on first."
 msgstr "{name} просматривал это дополнение первым."
 
-#: static/js/zamboni/editors.js:255
+#: static/js/zamboni/editors-all.js:15536 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:255
 msgid "Loading&hellip;"
 msgstr "Загрузка&hellip;"
 
-#: static/js/zamboni/editors.js:260
+#: static/js/zamboni/editors-all.js:15541 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:260
 msgid "Version Notes"
 msgstr "Примечания к версии"
 
-#: static/js/zamboni/editors.js:265
+#: static/js/zamboni/editors-all.js:15546 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:265
 msgid "Notes for Reviewers"
 msgstr "Примечания для проверяющих"
 
-#: static/js/zamboni/editors.js:270
+#: static/js/zamboni/editors-all.js:15551 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:270
 msgid "No version notes found"
 msgstr "Примечаний к версии не найдено"
 
-#: static/js/zamboni/editors.js:330
+#: static/js/zamboni/editors-all.js:15611 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:330
 msgid "Average Reviews"
 msgstr "Средняя оценка"
 
-#: static/js/zamboni/editors.js:386
+#: static/js/zamboni/editors-all.js:15667 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:386
 msgid "Number of Reviews"
 msgstr "Количество отзывов"
 
-#: static/js/zamboni/editors.js:445
+#: static/js/zamboni/editors-all.js:15726 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:445
 msgid "Error loading translation"
 msgstr "Ошибка при загрузке перевода"
 
-#: static/js/zamboni/files.js:411 static/js/zamboni/validator.js:261
-msgid "Ignore this message in future updates"
-msgstr "Игнорировать это сообщение в будущих обновлениях"
-
-#: static/js/zamboni/files.js:417 static/js/zamboni/validator.js:284
-msgid "Severity for automated signing:"
-msgstr "Критичность для автоматического подписания:"
-
-#: static/js/zamboni/global.js:410
-msgid "Loading..."
-msgstr "Загрузка..."
-
-#. L10n: {0} is the number of characters left.
-#: static/js/zamboni/global.js:474
-msgid "<b>{0}</b> character left."
-msgid_plural "<b>{0}</b> characters left."
-msgstr[0] "остался <b>{0}</b> символ."
-msgstr[1] "осталось <b>{0}</b> символа."
-msgstr[2] "осталось <b>{0}</b> символов."
-
-#: static/js/zamboni/init.js:28
-msgid "This feature is temporarily disabled while we perform website maintenance. Please check back a little later."
-msgstr "Пока мы производим техническое обслуживание веб-сайта, эта возможность временно отключена. Пожалуйста, зайдите попозже."
-
-#: static/js/zamboni/l10n.js:45
-msgid "Remove this localization"
-msgstr "Удалить эту локализацию"
-
-#: static/js/zamboni/password-strength.js:20
-msgid "Password strength:"
-msgstr "Стойкость пароля:"
-
-#: static/js/zamboni/password-strength.js:26
-msgid "At least {0} character left."
-msgid_plural "At least {0} characters left."
-msgstr[0] "Остался по меньшей мере {0} символ."
-msgstr[1] "Осталось по меньшей мере {0} символа."
-msgstr[2] "Осталось по меньшей мере {0} символов."
-
-#: static/js/zamboni/themes_review.js:176
-msgid "Requested Info"
-msgstr "Требуемая информация"
-
-#: static/js/zamboni/themes_review.js:177
-msgid "Flagged"
-msgstr "Отмечено"
-
-#: static/js/zamboni/themes_review.js:178
-msgid "Duplicate"
-msgstr "Дубликат"
-
-#: static/js/zamboni/themes_review.js:179
-msgid "Rejected"
-msgstr "Отклонено"
-
-#: static/js/zamboni/themes_review.js:180
-msgid "Approved"
-msgstr "Одобрено"
-
-#: static/js/zamboni/themes_review.js:424
-msgid "No results found"
-msgstr "Результаты не найдены"
-
-#: static/js/zamboni/themes_review_templates.js:31
+#: static/js/zamboni/editors-all.js:15975 static/js/zamboni/editors-min.js:5 static/js/zamboni/themes_review_templates.js:31
 msgid "Theme"
 msgstr "Тема"
 
-#: static/js/zamboni/themes_review_templates.js:33
+#: static/js/zamboni/editors-all.js:15977 static/js/zamboni/editors-min.js:5 static/js/zamboni/themes_review_templates.js:33
 msgid "Reviewer"
 msgstr "Редактор"
 
-#: static/js/zamboni/themes_review_templates.js:35
+#: static/js/zamboni/editors-all.js:15979 static/js/zamboni/editors-min.js:5 static/js/zamboni/themes_review_templates.js:35
 msgid "Status"
 msgstr "Статус"
 
-#: static/js/zamboni/validator.js:80
-msgid "All tests passed successfully."
-msgstr "Все тесты пройдены успешно."
+#: static/js/zamboni/editors-all.js:16196 static/js/zamboni/editors-min.js:5 static/js/zamboni/themes_review.js:176
+msgid "Requested Info"
+msgstr "Требуемая информация"
 
-#: static/js/zamboni/validator.js:83 static/js/zamboni/validator.js:478
-msgid "These tests were not run."
-msgstr "Эти тесты не были запущены."
+#: static/js/zamboni/editors-all.js:16197 static/js/zamboni/editors-min.js:5 static/js/zamboni/themes_review.js:177
+msgid "Flagged"
+msgstr "Отмечено"
 
-#: static/js/zamboni/validator.js:131 static/js/zamboni/validator.js:144
-msgid "Tests"
-msgstr "Тесты"
+#: static/js/zamboni/editors-all.js:16198 static/js/zamboni/editors-min.js:5 static/js/zamboni/themes_review.js:178
+msgid "Duplicate"
+msgstr "Дубликат"
 
-#: static/js/zamboni/validator.js:246 static/js/zamboni/validator.js:575 static/js/zamboni/validator.js:594
-msgid "Error"
-msgstr "Ошибка"
+#: static/js/zamboni/editors-all.js:16199 static/js/zamboni/editors-min.js:5 static/js/zamboni/themes_review.js:179
+msgid "Rejected"
+msgstr "Отклонено"
 
-#: static/js/zamboni/validator.js:247
-msgid "Warning"
-msgstr "Предупреждение"
+#: static/js/zamboni/editors-all.js:16200 static/js/zamboni/editors-min.js:5 static/js/zamboni/themes_review.js:180
+msgid "Approved"
+msgstr "Одобрено"
 
-#: static/js/zamboni/validator.js:299
-msgid "Suggestions for passing automated signing:"
-msgstr "Предложения для прохождения автоматизированного подписания:"
+#: static/js/zamboni/editors-all.js:16444 static/js/zamboni/editors-min.js:5 static/js/zamboni/themes_review.js:424
+msgid "No results found"
+msgstr "Результаты не найдены"
 
-#: static/js/zamboni/validator.js:387
-msgid "Compatibility Tests"
-msgstr "Тесты совместимости"
-
-#: static/js/zamboni/validator.js:466
-msgid "Add-on failed validation."
-msgstr "Дополнение не прошло валидацию."
-
-#: static/js/zamboni/validator.js:468
-msgid "Add-on passed validation."
-msgstr "Дополнение прошло валидацию."
-
-#: static/js/zamboni/validator.js:481
-msgid "{0} error"
-msgid_plural "{0} errors"
-msgstr[0] "{0} ошибка"
-msgstr[1] "{0} ошибки"
-msgstr[2] "{0} ошибок"
-
-#: static/js/zamboni/validator.js:483
-msgid "{0} warning"
-msgid_plural "{0} warnings"
-msgstr[0] "{0} предупреждение"
-msgstr[1] "{0} предупреждения"
-msgstr[2] "{0} предупреждений"
-
-#: static/js/zamboni/validator.js:485
-msgid "{0} notice"
-msgid_plural "{0} notices"
-msgstr[0] "{0} замечание"
-msgstr[1] "{0} замечания"
-msgstr[2] "{0} замечаний"
-
-#: static/js/zamboni/validator.js:577
-msgid "Validation task could not complete or completed with errors"
-msgstr "Валидация не смогла завершиться или завершилась с ошибками"
-
-#: static/js/zamboni/validator.js:595
-msgid "Internal server error"
-msgstr "Внутренняя ошибка сервера"
-
-#: static/js/zamboni/mobile/buttons.js:52
+#: static/js/zamboni/mobile-all.js:15186 static/js/zamboni/mobile/buttons.js:52
 msgid "Not Updated for {0} {1}"
 msgstr "Не обновлено для {0} {1}"
 
-#: static/js/zamboni/mobile/buttons.js:53
+#: static/js/zamboni/mobile-all.js:15187 static/js/zamboni/mobile/buttons.js:53
 msgid "Requires Newer Version of {0}"
 msgstr "Требует новой версии {0}"
 
-#: static/js/zamboni/mobile/buttons.js:54
+#: static/js/zamboni/mobile-all.js:15188 static/js/zamboni/mobile/buttons.js:54
 msgid "Unreviewed"
 msgstr "Не проверено"
 
-#: static/js/zamboni/mobile/buttons.js:55
+#: static/js/zamboni/mobile-all.js:15189 static/js/zamboni/mobile/buttons.js:55
 msgid "Experimental <span>(Learn More)</span>"
 msgstr "Экспериментальное <span>(Подробнее)</span>"
 
-#: static/js/zamboni/mobile/buttons.js:56 static/js/zamboni/mobile/buttons.js:57
+#: static/js/zamboni/mobile-all.js:15190 static/js/zamboni/mobile-all.js:15191 static/js/zamboni/mobile/buttons.js:56 static/js/zamboni/mobile/buttons.js:57
 msgid "Not Available for {0}"
 msgstr "Недоступно для {0}"
 
-#: static/js/zamboni/mobile/buttons.js:58
+#: static/js/zamboni/mobile-all.js:15192 static/js/zamboni/mobile/buttons.js:58
 msgid "Experimental"
 msgstr "Экспериментальное"
 
-#: static/js/zamboni/mobile/buttons.js:59
+#: static/js/zamboni/mobile-all.js:15193 static/js/zamboni/mobile/buttons.js:59
 msgid "Themes Require Newer Version of {0}"
 msgstr "Для тем необходима более новая версия {0}"
 
-#: static/js/zamboni/mobile/buttons.js:60
+#: static/js/zamboni/mobile-all.js:15194 static/js/zamboni/mobile/buttons.js:60
 msgid "Themes Require {0}"
 msgstr "Для тем необходим {0}"
 
-#: static/js/zamboni/mobile/buttons.js:105
+#: static/js/zamboni/mobile-all.js:15239 static/js/zamboni/mobile/buttons.js:105
 msgid "Installing..."
 msgstr "Установка..."
 
-#: static/js/zamboni/mobile/buttons.js:125
+#: static/js/zamboni/mobile-all.js:15259 static/js/zamboni/mobile/buttons.js:125
 msgid "This add-on has been preliminarily reviewed by Mozilla."
 msgstr "Это дополнение было предварительно проверено Mozilla."
 
-#: static/js/zamboni/mobile/buttons.js:250
+#: static/js/zamboni/mobile-all.js:15384 static/js/zamboni/mobile/buttons.js:250
 msgid "Keep it"
 msgstr "Оставить их"
 
-#: static/js/zamboni/mobile/general.js:344
+#: static/js/zamboni/mobile-all.js:16049 static/js/zamboni/mobile-min.js:6 static/js/zamboni/mobile/general.js:344
 msgid "You're trying it on!"
 msgstr "Сейчас вы её пробуете!"
 
-#: static/js/zamboni/mobile/general.js:356
+#: static/js/zamboni/mobile-all.js:16061 static/js/zamboni/mobile-min.js:6 static/js/zamboni/mobile/general.js:356
 msgid "Added to Firefox"
 msgstr "Добавлено в Firefox"
-

--- a/locale/si/LC_MESSAGES/django.po
+++ b/locale/si/LC_MESSAGES/django.po
@@ -3,69 +3,70 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2016-02-24 21:23+0000\n"
+"POT-Creation-Date: 2016-04-18 15:47+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
+"Language: \n"
 "MIME-Version: 1.0\n"
-"Content-Type: text/plain; charset=utf-8\n"
+"Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Generated-By: Babel 2.2.0\n"
 
-#: src/olympia/accounts/views.py:52
+#: src/olympia/accounts/views.py:54
 msgid "Your log in attempt could not be parsed. Please try again."
 msgstr ""
 
-#: src/olympia/accounts/views.py:54
+#: src/olympia/accounts/views.py:56
 msgid "Your Firefox Account could not be found. Please try again."
 msgstr ""
 
-#: src/olympia/accounts/views.py:55
+#: src/olympia/accounts/views.py:57
 msgid "You could not be logged in. Please try again."
 msgstr ""
 
-#: src/olympia/accounts/views.py:57
+#: src/olympia/accounts/views.py:59
 msgid "Your account has already been migrated to Firefox Accounts."
 msgstr ""
 
-#: src/olympia/accounts/views.py:59
+#: src/olympia/accounts/views.py:61
 msgid "Your Firefox Account already exists on this site."
 msgstr ""
 
-#: src/olympia/accounts/views.py:108
+#: src/olympia/accounts/views.py:110
 msgid "Great job!"
 msgstr ""
 
-#: src/olympia/accounts/views.py:109
+#: src/olympia/accounts/views.py:111
 msgid "You can now log in to Add-ons with your Firefox Account."
 msgstr ""
 
-#: src/olympia/accounts/views.py:121
+#: src/olympia/accounts/views.py:123
 msgid "Need help?"
 msgstr ""
 
-#: src/olympia/addons/buttons.py:180
+#: src/olympia/addons/buttons.py:177
 msgid "Download Now"
 msgstr ""
 
-#: src/olympia/addons/buttons.py:182
+#: src/olympia/addons/buttons.py:179
 msgid "Download"
 msgstr ""
 
 #. L10n: please keep &nbsp; in the string so &rarr; does not wrap.
-#: src/olympia/addons/buttons.py:186
+#: src/olympia/addons/buttons.py:183
 msgid "Continue to Download&nbsp;&rarr;"
 msgstr ""
 
-#: src/olympia/addons/buttons.py:202 src/olympia/addons/helpers.py:35 src/olympia/addons/views.py:319 src/olympia/addons/templates/addons/impala/details.html:114
+#: src/olympia/addons/buttons.py:199 src/olympia/addons/helpers.py:35 src/olympia/addons/views.py:333 src/olympia/addons/templates/addons/impala/details.html:111
 #: src/olympia/addons/templates/addons/impala/listing/items.html:17 src/olympia/addons/templates/addons/mobile/home.html:40 src/olympia/amo/templates/amo/side_nav.html:6
-#: src/olympia/amo/templates/amo/side_nav.html:10 src/olympia/amo/templates/amo/site_nav.html:2 src/olympia/amo/templates/amo/site_nav.html:55 src/olympia/bandwagon/views.py:95
-#: src/olympia/browse/views.py:54 src/olympia/browse/views.py:68 src/olympia/browse/views.py:235 src/olympia/browse/templates/browse/impala/category_landing.html:22
+#: src/olympia/amo/templates/amo/side_nav.html:10 src/olympia/amo/templates/amo/site_nav.html:2 src/olympia/amo/templates/amo/site_nav.html:53 src/olympia/bandwagon/views.py:95
+#: src/olympia/browse/views.py:54 src/olympia/browse/views.py:68 src/olympia/browse/views.py:202 src/olympia/browse/templates/browse/impala/category_landing.html:22
 #: src/olympia/browse/templates/browse/personas/mobile/category_landing.html:26
 msgid "Featured"
 msgstr ""
 
-#: src/olympia/addons/buttons.py:221
+#: src/olympia/addons/buttons.py:218
 msgid "Add to {0}"
 msgstr ""
 
@@ -113,39 +114,39 @@ msgid_plural "All tags must be at least {0} characters."
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/olympia/addons/forms.py:234
+#: src/olympia/addons/forms.py:238
 msgid "Categories cannot be changed while your add-on is featured for this application."
 msgstr ""
 
 #. L10n: {0} is the number of categories.
-#: src/olympia/addons/forms.py:238
+#: src/olympia/addons/forms.py:242
 msgid "You can have only {0} category."
 msgid_plural "You can have only {0} categories."
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/olympia/addons/forms.py:246
+#: src/olympia/addons/forms.py:250
 msgid "The miscellaneous category cannot be combined with additional categories."
 msgstr ""
 
-#: src/olympia/addons/forms.py:369
+#: src/olympia/addons/forms.py:374
 #, python-format
 msgid "Before changing your default locale you must have a name, summary, and description in that locale. You are missing %s."
 msgstr ""
 
-#: src/olympia/addons/forms.py:484 src/olympia/addons/forms.py:575
+#: src/olympia/addons/forms.py:455 src/olympia/addons/forms.py:546
 msgid "A license must be selected."
 msgstr ""
 
-#: src/olympia/addons/forms.py:556
+#: src/olympia/addons/forms.py:527
 msgid "Give Your Theme a Name."
 msgstr ""
 
-#: src/olympia/addons/forms.py:562 src/olympia/devhub/templates/devhub/personas/submit.html:53
+#: src/olympia/addons/forms.py:533 src/olympia/devhub/templates/devhub/personas/submit.html:53
 msgid "Describe your Theme."
 msgstr ""
 
-#: src/olympia/addons/forms.py:704
+#: src/olympia/addons/forms.py:675
 msgid "Enter a new author's email address"
 msgstr ""
 
@@ -153,37 +154,37 @@ msgstr ""
 msgid "Not Reviewed"
 msgstr ""
 
-#: src/olympia/addons/models.py:301
+#: src/olympia/addons/models.py:298
 msgid "Users have the option of contributing more or less than this amount."
 msgstr ""
 
-#: src/olympia/addons/models.py:309
-msgid "Users will always be asked in the Add-ons Manager (Firefox 4 and above)"
+#: src/olympia/addons/models.py:306
+msgid "Users will always be asked in the Add-ons Manager (Firefox 4 and above). Only applies to desktop."
 msgstr ""
 
-#: src/olympia/addons/models.py:1804 src/olympia/addons/templates/addons/details_box.html:55 src/olympia/devhub/templates/devhub/index.html:92
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:102
+#: src/olympia/addons/models.py:1802 src/olympia/addons/templates/addons/details_box.html:55 src/olympia/devhub/templates/devhub/index.html:92
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:89
 msgid "Listed"
 msgstr ""
 
-#: src/olympia/addons/views.py:320 src/olympia/browse/templates/browse/personas/mobile/category_landing.html:27
+#: src/olympia/addons/views.py:334 src/olympia/browse/templates/browse/personas/mobile/category_landing.html:27
 msgid "Popular"
 msgstr ""
 
-#: src/olympia/addons/views.py:321 src/olympia/browse/views.py:238 src/olympia/browse/views.py:280 src/olympia/browse/views.py:482
+#: src/olympia/addons/views.py:335 src/olympia/browse/views.py:205 src/olympia/browse/views.py:247 src/olympia/browse/views.py:449
 msgid "Recently Added"
 msgstr ""
 
-#: src/olympia/addons/views.py:322 src/olympia/bandwagon/views.py:99 src/olympia/browse/views.py:60 src/olympia/browse/views.py:71 src/olympia/search/forms.py:16 src/olympia/search/forms.py:91
+#: src/olympia/addons/views.py:336 src/olympia/bandwagon/views.py:99 src/olympia/browse/views.py:60 src/olympia/browse/views.py:71 src/olympia/search/forms.py:16 src/olympia/search/forms.py:91
 msgid "Recently Updated"
 msgstr ""
 
 #. l10n: {0} is the addon name
-#: src/olympia/addons/views.py:520
+#: src/olympia/addons/views.py:534
 msgid "Contribution for {0}"
 msgstr ""
 
-#: src/olympia/addons/views.py:613
+#: src/olympia/addons/views.py:627
 msgid "Abuse reported."
 msgstr ""
 
@@ -250,9 +251,9 @@ msgstr ""
 #: src/olympia/devhub/templates/devhub/addons/ajax_compat_update.html:36 src/olympia/devhub/templates/devhub/addons/profile.html:44 src/olympia/devhub/templates/devhub/addons/edit/admin.html:101
 #: src/olympia/devhub/templates/devhub/addons/edit/basic.html:152 src/olympia/devhub/templates/devhub/addons/edit/details.html:85 src/olympia/devhub/templates/devhub/addons/edit/support.html:67
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:166 src/olympia/devhub/templates/devhub/addons/forms_shared/media.html:149
-#: src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:44 src/olympia/devhub/templates/devhub/versions/add_file_modal.html:78 src/olympia/devhub/templates/devhub/versions/edit.html:139
-#: src/olympia/devhub/templates/devhub/versions/list.html:242 src/olympia/devhub/templates/devhub/versions/list.html:276 src/olympia/devhub/templates/devhub/versions/list.html:317
-#: src/olympia/devhub/templates/devhub/versions/list.html:351 src/olympia/reviews/templates/reviews/edit_review.html:16 src/olympia/translations/templates/translations/trans-menu.html:50
+#: src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:43 src/olympia/devhub/templates/devhub/versions/add_file_modal.html:58 src/olympia/devhub/templates/devhub/versions/edit.html:139
+#: src/olympia/devhub/templates/devhub/versions/list.html:239 src/olympia/devhub/templates/devhub/versions/list.html:281 src/olympia/devhub/templates/devhub/versions/list.html:315
+#: src/olympia/devhub/templates/devhub/versions/list.html:349 src/olympia/reviews/templates/reviews/edit_review.html:16 src/olympia/translations/templates/translations/trans-menu.html:50
 #: src/olympia/translations/templates/translations/trans-menu.html:62
 msgid "or"
 msgstr ""
@@ -363,7 +364,7 @@ msgid "Add-on Information for {0}"
 msgstr ""
 
 #: src/olympia/addons/templates/addons/details_box.html:30 src/olympia/addons/templates/addons/persona_detail_table.html:3 src/olympia/addons/templates/addons/mobile/details.html:63
-#: src/olympia/addons/templates/addons/mobile/persona_detail_table.html:7 src/olympia/browse/views.py:459 src/olympia/devhub/views.py:75
+#: src/olympia/addons/templates/addons/mobile/persona_detail_table.html:7 src/olympia/browse/views.py:426 src/olympia/devhub/views.py:73
 msgid "Updated"
 msgstr ""
 
@@ -382,11 +383,11 @@ msgstr ""
 msgid "Visibility"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/details_box.html:57 src/olympia/devhub/templates/devhub/index.html:94 src/olympia/devhub/templates/devhub/includes/addon_details.html:104
+#: src/olympia/addons/templates/addons/details_box.html:57 src/olympia/devhub/templates/devhub/index.html:94 src/olympia/devhub/templates/devhub/includes/addon_details.html:91
 msgid "Hidden"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/details_box.html:59 src/olympia/devhub/templates/devhub/index.html:96 src/olympia/devhub/templates/devhub/includes/addon_details.html:106
+#: src/olympia/addons/templates/addons/details_box.html:59 src/olympia/devhub/templates/devhub/index.html:96 src/olympia/devhub/templates/devhub/includes/addon_details.html:93
 msgid "Unlisted"
 msgstr ""
 
@@ -394,13 +395,13 @@ msgstr ""
 msgid "Required Add-ons"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/details_box.html:81 src/olympia/addons/templates/addons/persona_detail_table.html:15 src/olympia/browse/views.py:462 src/olympia/devhub/views.py:78
-#: src/olympia/devhub/views.py:85 src/olympia/discovery/templates/discovery/addons/detail.html:57 src/olympia/reviews/forms.py:62 src/olympia/reviews/templates/reviews/add.html:57
+#: src/olympia/addons/templates/addons/details_box.html:81 src/olympia/addons/templates/addons/persona_detail_table.html:15 src/olympia/browse/views.py:429 src/olympia/devhub/views.py:76
+#: src/olympia/devhub/views.py:83 src/olympia/discovery/templates/discovery/addons/detail.html:57 src/olympia/reviews/forms.py:62 src/olympia/reviews/templates/reviews/add.html:57
 #: src/olympia/reviews/templates/reviews/mobile/review_list.html:18
 msgid "Rating"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/details_box.html:85 src/olympia/browse/views.py:461 src/olympia/devhub/views.py:77 src/olympia/devhub/views.py:84
+#: src/olympia/addons/templates/addons/details_box.html:85 src/olympia/browse/views.py:428 src/olympia/devhub/views.py:75 src/olympia/devhub/views.py:82
 #: src/olympia/stats/templates/stats/addon_report_menu.html:8 src/olympia/stats/templates/stats/collection_report_menu.html:18
 msgid "Downloads"
 msgstr ""
@@ -420,7 +421,7 @@ msgstr ""
 
 #. The Privacy Policy for this add-on.
 #: src/olympia/addons/templates/addons/details_box.html:121 src/olympia/addons/templates/addons/privacy.html:19 src/olympia/addons/templates/addons/privacy.html:23
-#: src/olympia/addons/templates/addons/impala/button.html:43 src/olympia/addons/templates/addons/impala/details.html:307 src/olympia/devhub/templates/devhub/includes/policy_form.html:20
+#: src/olympia/addons/templates/addons/impala/button.html:43 src/olympia/addons/templates/addons/impala/details.html:312 src/olympia/devhub/templates/devhub/includes/policy_form.html:23
 #: src/olympia/templates/mobile/base_addons.html:87
 msgid "Privacy Policy"
 msgstr ""
@@ -445,7 +446,7 @@ msgstr ""
 msgid "Developer Comments"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/details_box.html:199 src/olympia/addons/templates/addons/impala/details.html:259
+#: src/olympia/addons/templates/addons/details_box.html:199 src/olympia/addons/templates/addons/impala/details.html:264
 msgid "Development Channel"
 msgstr ""
 
@@ -465,7 +466,7 @@ msgid ""
 "developer. To stop receiving development updates, reinstall the default version from the link above."
 msgstr ""
 
-#: src/olympia/addons/templates/addons/details_box.html:220 src/olympia/addons/templates/addons/impala/details.html:278
+#: src/olympia/addons/templates/addons/details_box.html:220 src/olympia/addons/templates/addons/impala/details.html:283
 msgid "Version {0}:"
 msgstr ""
 
@@ -484,7 +485,7 @@ msgid "End-User License Agreement for {0}"
 msgstr ""
 
 #: src/olympia/addons/templates/addons/eula.html:17 src/olympia/addons/templates/addons/eula.html:21 src/olympia/addons/templates/addons/impala/button.html:48
-#: src/olympia/addons/templates/addons/impala/details.html:316 src/olympia/devhub/templates/devhub/includes/policy_form.html:3 src/olympia/discovery/templates/discovery/addons/eula.html:11
+#: src/olympia/addons/templates/addons/impala/details.html:321 src/olympia/devhub/templates/devhub/includes/policy_form.html:3 src/olympia/discovery/templates/discovery/addons/eula.html:11
 msgid "End-User License Agreement"
 msgstr ""
 
@@ -501,7 +502,7 @@ msgstr ""
 msgid "Add-ons for {0}"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/home.html:10 src/olympia/addons/templates/addons/home.html:51 src/olympia/browse/templates/browse/impala/base_listing.html:11
+#: src/olympia/addons/templates/addons/home.html:10 src/olympia/addons/templates/addons/home.html:53 src/olympia/browse/templates/browse/impala/base_listing.html:11
 msgid "Featured Extensions"
 msgstr ""
 
@@ -509,29 +510,29 @@ msgstr ""
 msgid "Popular Extensions"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/home.html:42 src/olympia/amo/templates/amo/side_nav.html:3 src/olympia/amo/templates/amo/side_nav.html:11 src/olympia/amo/templates/amo/site_nav.html:3
-#: src/olympia/amo/templates/amo/site_nav.html:25 src/olympia/browse/views.py:236 src/olympia/browse/views.py:281 src/olympia/browse/views.py:481
+#: src/olympia/addons/templates/addons/home.html:44 src/olympia/amo/templates/amo/side_nav.html:3 src/olympia/amo/templates/amo/side_nav.html:11 src/olympia/amo/templates/amo/site_nav.html:3
+#: src/olympia/amo/templates/amo/site_nav.html:25 src/olympia/browse/views.py:203 src/olympia/browse/views.py:248 src/olympia/browse/views.py:448
 msgid "Most Popular"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/home.html:43
+#: src/olympia/addons/templates/addons/home.html:45
 msgid "All »"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/home.html:52 src/olympia/addons/templates/addons/home.html:61 src/olympia/addons/templates/addons/home.html:70 src/olympia/addons/templates/addons/home.html:78
+#: src/olympia/addons/templates/addons/home.html:54 src/olympia/addons/templates/addons/home.html:63 src/olympia/addons/templates/addons/home.html:72 src/olympia/addons/templates/addons/home.html:80
 #: src/olympia/browse/templates/browse/impala/category_landing.html:36
 msgid "See all »"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/home.html:60
+#: src/olympia/addons/templates/addons/home.html:62
 msgid "Up &amp; Coming Extensions"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/home.html:69 src/olympia/browse/templates/browse/personas/category_landing.html:61 src/olympia/discovery/templates/discovery/pane.html:74
+#: src/olympia/addons/templates/addons/home.html:71 src/olympia/browse/templates/browse/personas/category_landing.html:61 src/olympia/discovery/templates/discovery/pane.html:74
 msgid "Featured Themes"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/home.html:77 src/olympia/bandwagon/templates/bandwagon/impala/collection_listing.html:5
+#: src/olympia/addons/templates/addons/home.html:79 src/olympia/bandwagon/templates/bandwagon/impala/collection_listing.html:5
 msgid "Featured Collections"
 msgstr ""
 
@@ -549,7 +550,7 @@ msgid "Updated {0}"
 msgstr ""
 
 #. {0} is a date.
-#: src/olympia/addons/templates/addons/macros.html:10 src/olympia/addons/templates/addons/macros.html:69 src/olympia/addons/templates/addons/persona_preview.html:21
+#: src/olympia/addons/templates/addons/macros.html:10 src/olympia/addons/templates/addons/macros.html:69 src/olympia/addons/templates/addons/persona_preview.html:22
 #: src/olympia/addons/templates/addons/listing/items_mobile.html:44 src/olympia/addons/templates/addons/listing/macros.html:39
 #: src/olympia/bandwagon/templates/bandwagon/collection_listing_items.html:37 src/olympia/bandwagon/templates/bandwagon/impala/collection_listing_items.html:37
 msgid "Added {0}"
@@ -570,15 +571,14 @@ msgstr[0] ""
 msgstr[1] ""
 
 #. {0} is the number of downloads.
-#: src/olympia/addons/templates/addons/macros.html:53 src/olympia/addons/templates/addons/impala/details.html:61
+#: src/olympia/addons/templates/addons/macros.html:53 src/olympia/addons/templates/addons/impala/details.html:59
 msgid "{0} weekly download"
 msgid_plural "{0} weekly downloads"
 msgstr[0] ""
 msgstr[1] ""
 
 #. {0} is the number of users.
-#: src/olympia/addons/templates/addons/macros.html:61 src/olympia/addons/templates/addons/impala/details.html:54 src/olympia/compat/templates/compat/index.html:71
-#: src/olympia/zadmin/templates/zadmin/compat.html:67
+#: src/olympia/addons/templates/addons/macros.html:61 src/olympia/addons/templates/addons/impala/details.html:52 src/olympia/zadmin/templates/zadmin/compat.html:67
 msgid "{0} user"
 msgid_plural "{0} users"
 msgstr[0] ""
@@ -596,7 +596,7 @@ msgstr ""
 msgid "Return to the addon."
 msgstr ""
 
-#: src/olympia/addons/templates/addons/persona_detail.html:17 src/olympia/addons/templates/addons/impala/details.html:106 src/olympia/addons/templates/addons/mobile/details.html:23
+#: src/olympia/addons/templates/addons/persona_detail.html:17 src/olympia/addons/templates/addons/impala/details.html:103 src/olympia/addons/templates/addons/mobile/details.html:23
 #: src/olympia/addons/templates/addons/mobile/persona_detail.html:21 src/olympia/discovery/templates/discovery/addons/base.html:27 src/olympia/editors/templates/editors/review.html:31
 msgid "by"
 msgstr ""
@@ -640,34 +640,35 @@ msgstr ""
 msgid "License"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/persona_preview.html:12 src/olympia/constants/base.py:48
+#: src/olympia/addons/templates/addons/persona_preview.html:13 src/olympia/constants/base.py:48
 msgid "Awaiting Review"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/persona_preview.html:14 src/olympia/amo/log.py:180 src/olympia/constants/base.py:42 src/olympia/editors/helpers.py:62
+#: src/olympia/addons/templates/addons/persona_preview.html:15 src/olympia/amo/log.py:180 src/olympia/constants/base.py:42 src/olympia/editors/helpers.py:62
 msgid "Rejected"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/persona_preview.html:16 src/olympia/amo/log.py:159
+#: src/olympia/addons/templates/addons/persona_preview.html:17 src/olympia/amo/log.py:159
 msgid "Approved"
 msgstr ""
 
 #. {0} is the number of users.
-#: src/olympia/addons/templates/addons/persona_preview.html:26 src/olympia/addons/templates/addons/listing/items_mobile.html:36 src/olympia/addons/templates/addons/listing/macros.html:31
+#: src/olympia/addons/templates/addons/persona_preview.html:27 src/olympia/addons/templates/addons/listing/items_mobile.html:36 src/olympia/addons/templates/addons/listing/macros.html:31
 msgid "<strong>{0}</strong> user"
 msgid_plural "<strong>{0}</strong> users"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/olympia/addons/templates/addons/persona_preview.html:40
+#: src/olympia/addons/templates/addons/persona_preview.html:41
 msgid "Hover to Preview"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/persona_preview.html:46 src/olympia/addons/templates/addons/persona_preview.html:48 src/olympia/reviews/templates/reviews/add.html:15
+#: src/olympia/addons/templates/addons/persona_preview.html:47 src/olympia/addons/templates/addons/persona_preview.html:49 src/olympia/addons/templates/addons/persona_preview.html:97
+#: src/olympia/reviews/templates/reviews/add.html:15
 msgid "Add"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/persona_preview.html:57 src/olympia/bandwagon/templates/bandwagon/ajax_new.html:16 src/olympia/bandwagon/templates/bandwagon/edit.html:19
+#: src/olympia/addons/templates/addons/persona_preview.html:58 src/olympia/bandwagon/templates/bandwagon/ajax_new.html:16 src/olympia/bandwagon/templates/bandwagon/edit.html:19
 #: src/olympia/bandwagon/templates/bandwagon/includes/addedit.html:19 src/olympia/devhub/templates/devhub/addons/edit/admin.html:13 src/olympia/devhub/templates/devhub/addons/edit/basic.html:10
 #: src/olympia/devhub/templates/devhub/addons/edit/details.html:8 src/olympia/devhub/templates/devhub/addons/edit/media.html:6 src/olympia/devhub/templates/devhub/addons/edit/support.html:8
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:9 src/olympia/devhub/templates/devhub/addons/submit/describe.html:29 src/olympia/editors/templates/editors/review.html:257
@@ -676,21 +677,21 @@ msgstr ""
 
 #. For datetime formatting, see the table on
 #. http://docs.python.org/library/datetime.html#strftime-and-strptime-behavior
-#: src/olympia/addons/templates/addons/persona_preview.html:66
+#: src/olympia/addons/templates/addons/persona_preview.html:67
 #, python-format
 msgid "%%Y-%%m-%%d"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/persona_preview.html:67
+#: src/olympia/addons/templates/addons/persona_preview.html:68
 msgid "by {0} on {1}"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/persona_preview.html:75 src/olympia/reviews/helpers.py:17 src/olympia/reviews/templates/reviews/review_list.html:63
+#: src/olympia/addons/templates/addons/persona_preview.html:76 src/olympia/reviews/helpers.py:17 src/olympia/reviews/templates/reviews/review_list.html:63
 #: src/olympia/reviews/templates/reviews/reviews_link.html:21 src/olympia/reviews/templates/reviews/impala/reviews_link.html:16
 msgid "Not yet rated"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/persona_preview.html:78
+#: src/olympia/addons/templates/addons/persona_preview.html:79
 msgid "<b>{0}</b> users"
 msgstr ""
 
@@ -703,7 +704,7 @@ msgid "Learn more about Firefox"
 msgstr ""
 
 #: src/olympia/addons/templates/addons/popups.html:22
-msgid "or <b><a class=\"installer\" href=\"{url}\">download anyway</a></b>"
+msgid "or <b><a class=\"button installer\" href=\"{url}\">download anyway</a></b>"
 msgstr ""
 
 #: src/olympia/addons/templates/addons/popups.html:26
@@ -802,7 +803,7 @@ msgid ""
 msgstr ""
 
 #: src/olympia/addons/templates/addons/report_abuse.html:6 src/olympia/addons/templates/addons/report_abuse_full.html:10 src/olympia/addons/templates/addons/impala/details-more.html:23
-#: src/olympia/addons/templates/addons/impala/details.html:328
+#: src/olympia/addons/templates/addons/impala/details.html:333
 msgid "Report Abuse"
 msgstr ""
 
@@ -821,9 +822,9 @@ msgstr ""
 #: src/olympia/devhub/templates/devhub/addons/ajax_compat_update.html:36 src/olympia/devhub/templates/devhub/addons/profile.html:44 src/olympia/devhub/templates/devhub/addons/edit/admin.html:104
 #: src/olympia/devhub/templates/devhub/addons/edit/basic.html:155 src/olympia/devhub/templates/devhub/addons/edit/details.html:88 src/olympia/devhub/templates/devhub/addons/edit/support.html:70
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:169 src/olympia/devhub/templates/devhub/addons/forms_shared/media.html:152
-#: src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:44 src/olympia/devhub/templates/devhub/personas/edit.html:222 src/olympia/devhub/templates/devhub/versions/add_file_modal.html:79
-#: src/olympia/devhub/templates/devhub/versions/edit.html:140 src/olympia/devhub/templates/devhub/versions/list.html:208 src/olympia/devhub/templates/devhub/versions/list.html:242
-#: src/olympia/devhub/templates/devhub/versions/list.html:276 src/olympia/devhub/templates/devhub/versions/list.html:317 src/olympia/reviews/templates/reviews/edit_review.html:16
+#: src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:43 src/olympia/devhub/templates/devhub/personas/edit.html:222 src/olympia/devhub/templates/devhub/versions/add_file_modal.html:59
+#: src/olympia/devhub/templates/devhub/versions/edit.html:140 src/olympia/devhub/templates/devhub/versions/list.html:208 src/olympia/devhub/templates/devhub/versions/list.html:239
+#: src/olympia/devhub/templates/devhub/versions/list.html:281 src/olympia/devhub/templates/devhub/versions/list.html:315 src/olympia/reviews/templates/reviews/edit_review.html:16
 #: src/olympia/translations/templates/translations/trans-menu.html:50 src/olympia/translations/templates/translations/trans-menu.html:62 src/olympia/zadmin/templates/zadmin/validation.html:105
 msgid "Cancel"
 msgstr ""
@@ -868,7 +869,7 @@ msgstr ""
 msgid "Review Guidelines"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/review_list_box.html:5 src/olympia/addons/templates/addons/impala/details-more.html:27 src/olympia/editors/helpers.py:921
+#: src/olympia/addons/templates/addons/review_list_box.html:5 src/olympia/addons/templates/addons/impala/details-more.html:27 src/olympia/editors/helpers.py:1001
 #: src/olympia/reviews/templates/reviews/add.html:14 src/olympia/reviews/templates/reviews/reply.html:14 src/olympia/reviews/templates/reviews/review_list.html:19
 #: src/olympia/reviews/templates/reviews/mobile/review_list.html:26
 msgid "Reviews"
@@ -959,119 +960,119 @@ msgid_plural "Other add-ons by these authors"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/olympia/addons/templates/addons/impala/details.html:41
+#: src/olympia/addons/templates/addons/impala/details.html:39
 #, python-format
 msgid "<span itemprop=\"ratingCount\">%(num)s</span> user review"
 msgid_plural "<span itemprop=\"ratingCount\">%(num)s</span> user reviews"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/olympia/addons/templates/addons/impala/details.html:69
+#: src/olympia/addons/templates/addons/impala/details.html:66
 msgid "View statistics"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/impala/details.html:84
+#: src/olympia/addons/templates/addons/impala/details.html:81
 msgid "Manage"
 msgstr ""
 
 #. {0} is an add-on name.
-#: src/olympia/addons/templates/addons/impala/details.html:96
+#: src/olympia/addons/templates/addons/impala/details.html:93
 msgid "Icon of {0}"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/impala/details.html:103 src/olympia/addons/templates/addons/impala/listing/items.html:14
+#: src/olympia/addons/templates/addons/impala/details.html:100 src/olympia/addons/templates/addons/impala/listing/items.html:14
 msgid "No Restart"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/impala/details.html:127
+#: src/olympia/addons/templates/addons/impala/details.html:124
 #, python-format
 msgid "Meet the Developer: <a href=\"%(url)s\">%(name)s</a>"
 msgid_plural "<a href=\"%(url)s\">Meet the Developers</a>"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/olympia/addons/templates/addons/impala/details.html:137
+#: src/olympia/addons/templates/addons/impala/details.html:134
 msgid "Learn why {0} was created and find out what's next for this add-on."
 msgstr ""
 
 #. {0} is an index.
-#: src/olympia/addons/templates/addons/impala/details.html:156
+#: src/olympia/addons/templates/addons/impala/details.html:161
 msgid "Add-on screenshot #{0}"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/impala/details.html:182
+#: src/olympia/addons/templates/addons/impala/details.html:187
 msgid "Add-on home page"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/impala/details.html:185
+#: src/olympia/addons/templates/addons/impala/details.html:190
 msgid "Support site"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/impala/details.html:189
+#: src/olympia/addons/templates/addons/impala/details.html:194
 msgid "Support E-mail"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/impala/details.html:194 src/olympia/devhub/models.py:378 src/olympia/devhub/templates/devhub/versions/list.html:12
+#: src/olympia/addons/templates/addons/impala/details.html:199 src/olympia/devhub/models.py:378 src/olympia/devhub/templates/devhub/versions/list.html:12
 #: src/olympia/versions/templates/versions/version.html:6 src/olympia/versions/templates/versions/mobile/version.html:6
 msgid "Version {0}"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/impala/details.html:194
+#: src/olympia/addons/templates/addons/impala/details.html:199
 msgid "Info"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/impala/details.html:195 src/olympia/devhub/templates/devhub/includes/addon_details.html:129
+#: src/olympia/addons/templates/addons/impala/details.html:200 src/olympia/devhub/templates/devhub/includes/addon_details.html:116
 msgid "Last Updated:"
-msgstr ""
-
-#: src/olympia/addons/templates/addons/impala/details.html:200
-#, python-format
-msgid "Released under <a target=\"_blank\" href=\"%(url)s\">%(name)s</a>"
-msgstr ""
-
-#: src/olympia/addons/templates/addons/impala/details.html:201 src/olympia/addons/templates/addons/impala/details.html:206 src/olympia/amo/helpers.py:398 src/olympia/devhub/forms.py:142
-#: src/olympia/devhub/forms.py:173 src/olympia/versions/templates/versions/version.html:40 src/olympia/versions/templates/versions/version.html:45
-msgid "Custom License"
 msgstr ""
 
 #: src/olympia/addons/templates/addons/impala/details.html:205
 #, python-format
+msgid "Released under <a target=\"_blank\" href=\"%(url)s\">%(name)s</a>"
+msgstr ""
+
+#: src/olympia/addons/templates/addons/impala/details.html:206 src/olympia/addons/templates/addons/impala/details.html:211 src/olympia/amo/helpers.py:398 src/olympia/devhub/forms.py:142
+#: src/olympia/devhub/forms.py:173 src/olympia/versions/templates/versions/version.html:40 src/olympia/versions/templates/versions/version.html:45
+msgid "Custom License"
+msgstr ""
+
+#: src/olympia/addons/templates/addons/impala/details.html:210
+#, python-format
 msgid "Released under <a href=\"%(url)s\">%(name)s</a>"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/impala/details.html:217
+#: src/olympia/addons/templates/addons/impala/details.html:222
 msgid "About this Add-on"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/impala/details.html:233
+#: src/olympia/addons/templates/addons/impala/details.html:238
 msgid "Developer’s Comments"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/impala/details.html:243
+#: src/olympia/addons/templates/addons/impala/details.html:248
 msgid "Version Information"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/impala/details.html:250
+#: src/olympia/addons/templates/addons/impala/details.html:255
 msgid "See complete version history"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/impala/details.html:262
+#: src/olympia/addons/templates/addons/impala/details.html:267
 msgid ""
 "The Development Channel lets you test an experimental new version of this add-on before it's released to the general public. Once you install the development version, you will continue to get "
 "updates from this channel. To stop receiving development updates, reinstall the default version from the link above."
 msgstr ""
 
-#: src/olympia/addons/templates/addons/impala/details.html:272
+#: src/olympia/addons/templates/addons/impala/details.html:277
 msgid "<strong>Caution:</strong> Development versions of this add-on have not been reviewed by Mozilla."
 msgstr ""
 
-#: src/olympia/addons/templates/addons/impala/details.html:287
+#: src/olympia/addons/templates/addons/impala/details.html:292
 msgid "See complete development channel history"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/impala/details.html:306 src/olympia/addons/templates/addons/impala/details.html:315 src/olympia/addons/templates/addons/impala/details.html:327
+#: src/olympia/addons/templates/addons/impala/details.html:311 src/olympia/addons/templates/addons/impala/details.html:320 src/olympia/addons/templates/addons/impala/details.html:332
 #: src/olympia/addons/templates/addons/impala/review_add_box.html:4 src/olympia/stats/templates/stats/popup.html:2 src/olympia/stats/templates/stats/popup.html:8
-#: src/olympia/stats/templates/stats/stats.html:202 src/olympia/users/templates/users/profile.html:119
+#: src/olympia/stats/templates/stats/stats.html:204 src/olympia/users/templates/users/profile.html:119
 msgid "close"
 msgstr ""
 
@@ -1127,15 +1128,11 @@ msgstr ""
 msgid "Source Code License"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/impala/persona_grid.html:16 src/olympia/addons/templates/addons/impala/toplist.html:6
-msgid "{0} users"
-msgstr ""
-
 #: src/olympia/addons/templates/addons/impala/review_list_box.html:19 src/olympia/reviews/templates/reviews/review.html:40
 msgid "permalink"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/impala/review_list_box.html:23 src/olympia/editors/templates/editors/queue.html:98 src/olympia/reviews/templates/reviews/review.html:44
+#: src/olympia/addons/templates/addons/impala/review_list_box.html:23 src/olympia/editors/templates/editors/queue.html:104 src/olympia/reviews/templates/reviews/review.html:44
 msgid "translate"
 msgstr ""
 
@@ -1154,6 +1151,10 @@ msgstr ""
 msgid "Be the first!"
 msgstr ""
 
+#: src/olympia/addons/templates/addons/impala/toplist.html:6
+msgid "{0} users"
+msgstr ""
+
 #: src/olympia/addons/templates/addons/impala/listing/sorter.html:14 src/olympia/devhub/templates/devhub/addons/listing/item_actions.html:49
 msgid "More"
 msgstr ""
@@ -1166,7 +1167,7 @@ msgstr ""
 msgid "My Add-ons"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/includes/dashboard_tabs.html:6 src/olympia/amo/context_processors.py:51
+#: src/olympia/addons/templates/addons/includes/dashboard_tabs.html:6 src/olympia/amo/context_processors.py:50
 msgid "My Themes"
 msgstr ""
 
@@ -1221,7 +1222,7 @@ msgstr ""
 msgid "Weekly Downloads"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/mobile/details.html:99 src/olympia/compat/templates/compat/reporter_detail.html:46 src/olympia/devhub/forms.py:787
+#: src/olympia/addons/templates/addons/mobile/details.html:99 src/olympia/compat/templates/compat/reporter_detail.html:46 src/olympia/devhub/forms.py:788
 #: src/olympia/devhub/templates/devhub/versions/list.html:163
 msgid "Version"
 msgstr ""
@@ -1305,7 +1306,7 @@ msgstr ""
 #: src/olympia/browse/templates/browse/personas/category_landing.html:21 src/olympia/browse/templates/browse/personas/category_landing.html:23
 #: src/olympia/browse/templates/browse/personas/category_landing.html:38 src/olympia/browse/templates/browse/personas/grid.html:7 src/olympia/browse/templates/browse/personas/grid.html:11
 #: src/olympia/browse/templates/browse/personas/mobile/base.html:7 src/olympia/browse/templates/browse/personas/mobile/category_landing.html:19 src/olympia/constants/base.py:180
-#: src/olympia/devhub/templates/devhub/personas/submit.html:13 src/olympia/editors/helpers.py:105 src/olympia/editors/templates/editors/base.html:26
+#: src/olympia/devhub/templates/devhub/personas/submit.html:13 src/olympia/editors/helpers.py:107 src/olympia/editors/templates/editors/base.html:26
 #: src/olympia/editors/templates/editors/performance.html:73 src/olympia/search/templates/search/personas.html:39 src/olympia/templates/menu_links.html:9
 msgid "Themes"
 msgstr ""
@@ -1326,7 +1327,7 @@ msgstr ""
 msgid "Highest Rated"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/mobile/home.html:74 src/olympia/amo/templates/amo/side_nav.html:5 src/olympia/amo/templates/amo/site_nav.html:27 src/olympia/amo/templates/amo/site_nav.html:57
+#: src/olympia/addons/templates/addons/mobile/home.html:74 src/olympia/amo/templates/amo/side_nav.html:5 src/olympia/amo/templates/amo/site_nav.html:27 src/olympia/amo/templates/amo/site_nav.html:55
 #: src/olympia/bandwagon/views.py:97 src/olympia/browse/views.py:57 src/olympia/browse/views.py:67 src/olympia/browse/templates/browse/personas/mobile/category_landing.html:65
 #: src/olympia/search/forms.py:15 src/olympia/search/forms.py:87
 msgid "Newest"
@@ -1340,90 +1341,90 @@ msgstr ""
 msgid "Theme Info &raquo;"
 msgstr ""
 
-#: src/olympia/amo/context_processors.py:39 src/olympia/devhub/templates/devhub/nav.html:43
+#: src/olympia/amo/context_processors.py:37 src/olympia/devhub/templates/devhub/nav.html:43
 msgid "Tools"
 msgstr ""
 
-#: src/olympia/amo/context_processors.py:48 src/olympia/discovery/templates/discovery/pane_account.html:8 src/olympia/users/templates/users/includes/navigation.html:2
+#: src/olympia/amo/context_processors.py:47 src/olympia/discovery/templates/discovery/pane_account.html:8 src/olympia/users/templates/users/includes/navigation.html:2
 msgid "My Profile"
 msgstr ""
 
-#: src/olympia/amo/context_processors.py:54 src/olympia/users/templates/users/edit.html:5 src/olympia/users/templates/users/includes/navigation.html:3
+#: src/olympia/amo/context_processors.py:53 src/olympia/users/templates/users/edit.html:5 src/olympia/users/templates/users/includes/navigation.html:3
 msgid "Account Settings"
 msgstr ""
 
-#: src/olympia/amo/context_processors.py:57 src/olympia/discovery/templates/discovery/pane_account.html:11 src/olympia/users/templates/users/profile.html:83
+#: src/olympia/amo/context_processors.py:56 src/olympia/discovery/templates/discovery/pane_account.html:11 src/olympia/users/templates/users/profile.html:83
 #: src/olympia/users/templates/users/includes/navigation.html:4
 msgid "My Collections"
 msgstr ""
 
-#: src/olympia/amo/context_processors.py:62 src/olympia/discovery/templates/discovery/pane_account.html:10 src/olympia/users/templates/users/includes/navigation.html:7
+#: src/olympia/amo/context_processors.py:61 src/olympia/discovery/templates/discovery/pane_account.html:10 src/olympia/users/templates/users/includes/navigation.html:7
 msgid "My Favorites"
 msgstr ""
 
-#: src/olympia/amo/context_processors.py:67 src/olympia/discovery/templates/discovery/pane_account.html:13 src/olympia/templates/impala/user_login.html:14
+#: src/olympia/amo/context_processors.py:66 src/olympia/discovery/templates/discovery/pane_account.html:13 src/olympia/templates/impala/user_login.html:14
 #: src/olympia/templates/mobile/header_auth.html:5
 msgid "Log out"
 msgstr ""
 
-#: src/olympia/amo/context_processors.py:72 src/olympia/devhub/templates/devhub/addons/dashboard.html:4
+#: src/olympia/amo/context_processors.py:71 src/olympia/devhub/templates/devhub/addons/dashboard.html:4
 msgid "Manage My Submissions"
 msgstr ""
 
-#: src/olympia/amo/context_processors.py:75 src/olympia/devhub/templates/devhub/nav.html:27 src/olympia/devhub/templates/devhub/addons/dashboard.html:25
+#: src/olympia/amo/context_processors.py:74 src/olympia/devhub/templates/devhub/nav.html:27 src/olympia/devhub/templates/devhub/addons/dashboard.html:25
 #: src/olympia/devhub/templates/devhub/addons/submit/base.html:4
 msgid "Submit a New Add-on"
 msgstr ""
 
-#: src/olympia/amo/context_processors.py:77 src/olympia/browse/templates/browse/personas/base.html:50 src/olympia/devhub/templates/devhub/index.html:24
+#: src/olympia/amo/context_processors.py:76 src/olympia/browse/templates/browse/personas/base.html:50 src/olympia/devhub/templates/devhub/index.html:24
 #: src/olympia/devhub/templates/devhub/addons/dashboard.html:29
 msgid "Submit a New Theme"
 msgstr ""
 
-#: src/olympia/amo/context_processors.py:79 src/olympia/amo/templates/amo/site_nav.html:87 src/olympia/devhub/helpers.py:36 src/olympia/devhub/helpers.py:68 src/olympia/devhub/helpers.py:102
+#: src/olympia/amo/context_processors.py:78 src/olympia/amo/templates/amo/site_nav.html:85 src/olympia/devhub/helpers.py:36 src/olympia/devhub/helpers.py:68 src/olympia/devhub/helpers.py:102
 #: src/olympia/templates/footer.html:6 src/olympia/templates/menu_links.html:14
 msgid "Developer Hub"
 msgstr ""
 
-#: src/olympia/amo/context_processors.py:83 src/olympia/devhub/views.py:1792
+#: src/olympia/amo/context_processors.py:81 src/olympia/devhub/views.py:1796
 msgid "Manage API Keys"
 msgstr ""
 
-#: src/olympia/amo/context_processors.py:88 src/olympia/editors/helpers.py:82 src/olympia/editors/helpers.py:102 src/olympia/editors/templates/editors/base.html:10
+#: src/olympia/amo/context_processors.py:86 src/olympia/editors/helpers.py:84 src/olympia/editors/helpers.py:104 src/olympia/editors/templates/editors/base.html:10
 msgid "Editor Tools"
 msgstr ""
 
-#: src/olympia/amo/context_processors.py:92
+#: src/olympia/amo/context_processors.py:90
 msgid "Admin Tools"
 msgstr ""
 
-#: src/olympia/amo/fields.py:15
+#: src/olympia/amo/fields.py:20
 msgid "Incorrect, please try again."
 msgstr ""
 
-#: src/olympia/amo/fields.py:16
+#: src/olympia/amo/fields.py:21
 msgid "Error verifying input, please try again."
 msgstr ""
 
-#: src/olympia/amo/fields.py:32
+#: src/olympia/amo/fields.py:37
 msgid "This must be a valid hex color code, such as #000000."
 msgstr ""
 
-#: src/olympia/amo/fields.py:58
+#: src/olympia/amo/fields.py:63
 msgid "Enter at least one value."
 msgstr ""
 
-#: src/olympia/amo/helpers.py:162 src/olympia/amo/templates/amo/site_nav.html:61 src/olympia/bandwagon/templates/bandwagon/add.html:9
+#: src/olympia/amo/helpers.py:162 src/olympia/amo/templates/amo/site_nav.html:59 src/olympia/bandwagon/templates/bandwagon/add.html:9
 #: src/olympia/bandwagon/templates/bandwagon/collection_detail.html:15 src/olympia/bandwagon/templates/bandwagon/delete.html:9 src/olympia/bandwagon/templates/bandwagon/edit.html:15
 #: src/olympia/bandwagon/templates/bandwagon/user_listing.html:18 src/olympia/bandwagon/templates/bandwagon/user_listing.html:21
 #: src/olympia/bandwagon/templates/bandwagon/impala/collection_listing.html:12 src/olympia/bandwagon/templates/bandwagon/impala/collection_listing.html:20
 #: src/olympia/bandwagon/templates/bandwagon/impala/collection_listing.html:24 src/olympia/bandwagon/templates/bandwagon/impala/collection_sidebar.html:3
 #: src/olympia/bandwagon/templates/bandwagon/includes/collection_sidebar.html:2 src/olympia/bandwagon/templates/bandwagon/mobile/collection_listing.html:3
-#: src/olympia/stats/templates/stats/stats.html:77 src/olympia/templates/menu_links.html:12
+#: src/olympia/stats/templates/stats/stats.html:33 src/olympia/templates/menu_links.html:12
 msgid "Collections"
 msgstr ""
 
-#: src/olympia/amo/helpers.py:171 src/olympia/amo/templates/amo/site_nav.html:85 src/olympia/browse/templates/browse/language_tools.html:3
+#: src/olympia/amo/helpers.py:171 src/olympia/amo/templates/amo/site_nav.html:83 src/olympia/browse/templates/browse/language_tools.html:3
 msgid "Dictionaries & Language Packs"
 msgstr ""
 
@@ -1575,8 +1576,8 @@ msgstr ""
 msgid "Comment on {addon} {version}."
 msgstr ""
 
-#: src/olympia/amo/log.py:236 src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:19 src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:47
-#: src/olympia/editors/helpers.py:511 src/olympia/editors/templates/editors/themes/history_table.html:11
+#: src/olympia/amo/log.py:236 src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:17 src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:45
+#: src/olympia/editors/helpers.py:584 src/olympia/editors/templates/editors/themes/history_table.html:11
 msgid "Comment"
 msgstr ""
 
@@ -1899,7 +1900,7 @@ msgstr ""
 #: src/olympia/amo/templates/amo/mobile/paginator.html:14 src/olympia/amo/templates/amo/mobile/paginator.html:16 src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:51
 #: src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:65 src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:78
 #: src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:91 src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:104
-#: src/olympia/discovery/templates/discovery/pane.html:45 src/olympia/discovery/templates/discovery/addons/detail.html:39 src/olympia/stats/templates/stats/stats.html:167
+#: src/olympia/discovery/templates/discovery/pane.html:45 src/olympia/discovery/templates/discovery/addons/detail.html:39 src/olympia/stats/templates/stats/stats.html:169
 msgid "Next"
 msgstr ""
 
@@ -1931,7 +1932,7 @@ msgid ""
 msgstr ""
 
 #: src/olympia/amo/templates/amo/side_nav.html:4 src/olympia/amo/templates/amo/side_nav.html:12 src/olympia/amo/templates/amo/site_nav.html:4 src/olympia/amo/templates/amo/site_nav.html:26
-#: src/olympia/browse/views.py:56 src/olympia/browse/views.py:66 src/olympia/browse/views.py:237 src/olympia/browse/views.py:282 src/olympia/search/forms.py:86
+#: src/olympia/browse/views.py:56 src/olympia/browse/views.py:66 src/olympia/browse/views.py:204 src/olympia/browse/views.py:249 src/olympia/search/forms.py:86
 msgid "Top Rated"
 msgstr ""
 
@@ -1945,38 +1946,38 @@ msgstr ""
 msgid "Extensions"
 msgstr ""
 
-#: src/olympia/amo/templates/amo/site_nav.html:45
+#: src/olympia/amo/templates/amo/site_nav.html:44
 msgid "Want more customization? Try <b>Complete Themes</b>"
 msgstr ""
 
-#: src/olympia/amo/templates/amo/site_nav.html:56 src/olympia/bandwagon/views.py:96
+#: src/olympia/amo/templates/amo/site_nav.html:54 src/olympia/bandwagon/views.py:96
 msgid "Most Followers"
 msgstr ""
 
-#: src/olympia/amo/templates/amo/site_nav.html:68 src/olympia/bandwagon/templates/bandwagon/impala/collection_sidebar.html:16
+#: src/olympia/amo/templates/amo/site_nav.html:66 src/olympia/bandwagon/templates/bandwagon/impala/collection_sidebar.html:16
 #: src/olympia/bandwagon/templates/bandwagon/includes/collection_sidebar.html:18
 msgid "Collections I've Made"
 msgstr ""
 
-#: src/olympia/amo/templates/amo/site_nav.html:70 src/olympia/bandwagon/templates/bandwagon/user_listing.html:4 src/olympia/bandwagon/templates/bandwagon/impala/collection_sidebar.html:13
+#: src/olympia/amo/templates/amo/site_nav.html:68 src/olympia/bandwagon/templates/bandwagon/user_listing.html:4 src/olympia/bandwagon/templates/bandwagon/impala/collection_sidebar.html:13
 #: src/olympia/bandwagon/templates/bandwagon/includes/collection_sidebar.html:15
 msgid "Collections I'm Following"
 msgstr ""
 
-#: src/olympia/amo/templates/amo/site_nav.html:73 src/olympia/bandwagon/templates/bandwagon/impala/collection_sidebar.html:18
-#: src/olympia/bandwagon/templates/bandwagon/includes/collection_sidebar.html:20 src/olympia/users/models.py:512
+#: src/olympia/amo/templates/amo/site_nav.html:71 src/olympia/bandwagon/templates/bandwagon/impala/collection_sidebar.html:18
+#: src/olympia/bandwagon/templates/bandwagon/includes/collection_sidebar.html:20 src/olympia/users/models.py:521
 msgid "My Favorite Add-ons"
 msgstr ""
 
-#: src/olympia/amo/templates/amo/site_nav.html:78
+#: src/olympia/amo/templates/amo/site_nav.html:76
 msgid "More&hellip;"
 msgstr ""
 
-#: src/olympia/amo/templates/amo/site_nav.html:82
+#: src/olympia/amo/templates/amo/site_nav.html:80
 msgid "Add-ons for Mobile"
 msgstr ""
 
-#: src/olympia/amo/templates/amo/site_nav.html:86 src/olympia/browse/feeds.py:207 src/olympia/browse/templates/browse/search_tools.html:3 src/olympia/constants/base.py:176
+#: src/olympia/amo/templates/amo/site_nav.html:84 src/olympia/browse/feeds.py:207 src/olympia/browse/templates/browse/search_tools.html:3 src/olympia/constants/base.py:176
 #: src/olympia/templates/menu_links.html:10
 msgid "Search Tools"
 msgstr ""
@@ -1992,7 +1993,7 @@ msgid "Jump to first page"
 msgstr ""
 
 #: src/olympia/amo/templates/amo/impala/paginator.html:22 src/olympia/amo/templates/amo/mobile/impala_paginator.html:12 src/olympia/discovery/templates/discovery/pane.html:44
-#: src/olympia/discovery/templates/discovery/addons/detail.html:38 src/olympia/stats/templates/stats/stats.html:164
+#: src/olympia/discovery/templates/discovery/addons/detail.html:38 src/olympia/stats/templates/stats/stats.html:166
 msgid "Previous"
 msgstr ""
 
@@ -2015,30 +2016,49 @@ msgid_plural "Page {n}"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/olympia/amo/templates/services/install.html:38
-#, python-format
-msgid "If you are not prompted to install %(addon_name)s in a moment, please <a href=\"%(addon_xpi)s\">click here</a>."
-msgstr ""
-
-#: src/olympia/amo/tests/test_messages.py:57 src/olympia/amo/tests/test_messages.py:58 src/olympia/reviews/forms.py:25 src/olympia/reviews/forms.py:50 src/olympia/reviews/templates/reviews/add.html:56
+#: src/olympia/amo/tests/test_messages.py:56 src/olympia/amo/tests/test_messages.py:57 src/olympia/reviews/forms.py:25 src/olympia/reviews/forms.py:50 src/olympia/reviews/templates/reviews/add.html:56
 #: src/olympia/reviews/templates/reviews/reply.html:30
 msgid "Title"
 msgstr ""
 
-#: src/olympia/amo/tests/test_messages.py:57 src/olympia/amo/tests/test_messages.py:58
+#: src/olympia/amo/tests/test_messages.py:56 src/olympia/amo/tests/test_messages.py:57
 msgid "Body"
 msgstr ""
 
-#: src/olympia/amo/tests/test_messages.py:59
+#: src/olympia/amo/tests/test_messages.py:58
 msgid "Another Title"
 msgstr ""
 
-#: src/olympia/amo/tests/test_messages.py:59
+#: src/olympia/amo/tests/test_messages.py:58
 msgid "Another Body"
 msgstr ""
 
-#: src/olympia/api/views.py:255
-msgid "Not implemented yet."
+#: src/olympia/api/authentication.py:76
+msgid "Signature has expired."
+msgstr ""
+
+#: src/olympia/api/authentication.py:79
+msgid "Error decoding signature."
+msgstr ""
+
+#: src/olympia/api/authentication.py:82
+msgid "Invalid JWT Token."
+msgstr ""
+
+#: src/olympia/api/authentication.py:130
+msgid "Invalid Authorization header. No credentials provided."
+msgstr ""
+
+#: src/olympia/api/authentication.py:133
+msgid "Invalid Authorization header. Credentials string should not contain spaces."
+msgstr ""
+
+#: src/olympia/api/fields.py:29
+msgid "The field must have a length of at least {num} characters."
+msgstr ""
+
+#: src/olympia/api/fields.py:31
+msgid "The language code {lang_code} is invalid."
 msgstr ""
 
 #: src/olympia/applications/views.py:39 src/olympia/applications/templates/applications/appversions.html:3
@@ -2057,7 +2077,7 @@ msgstr ""
 msgid "Add-ons submitted to Mozilla Add-ons must have a manifest file with at least one of the below applications supported. Only the versions listed below are allowed for these applications."
 msgstr ""
 
-#: src/olympia/applications/templates/applications/appversions.html:25
+#: src/olympia/applications/templates/applications/appversions.html:25 src/olympia/editors/helpers.py:361
 msgid "GUID"
 msgstr ""
 
@@ -2171,8 +2191,8 @@ msgstr ""
 msgid "Remove from favorites"
 msgstr ""
 
-#: src/olympia/bandwagon/views.py:98 src/olympia/bandwagon/views.py:191 src/olympia/browse/views.py:58 src/olympia/browse/views.py:69 src/olympia/browse/views.py:458 src/olympia/devhub/views.py:74
-#: src/olympia/devhub/views.py:82 src/olympia/devhub/templates/devhub/addons/edit/basic.html:20 src/olympia/editors/templates/editors/leaderboard.html:24
+#: src/olympia/bandwagon/views.py:98 src/olympia/bandwagon/views.py:191 src/olympia/browse/views.py:58 src/olympia/browse/views.py:69 src/olympia/browse/views.py:425 src/olympia/devhub/views.py:72
+#: src/olympia/devhub/views.py:80 src/olympia/devhub/templates/devhub/addons/edit/basic.html:20 src/olympia/editors/templates/editors/leaderboard.html:24
 #: src/olympia/editors/templates/editors/themes/queue_list.html:48 src/olympia/search/forms.py:17 src/olympia/search/forms.py:89 src/olympia/users/templates/users/vcard.html:5
 msgid "Name"
 msgstr ""
@@ -2181,7 +2201,7 @@ msgstr ""
 msgid "Recently Popular"
 msgstr ""
 
-#: src/olympia/bandwagon/views.py:189 src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:18
+#: src/olympia/bandwagon/views.py:189 src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:16
 msgid "Added"
 msgstr ""
 
@@ -2195,7 +2215,7 @@ msgstr ""
 
 #: src/olympia/bandwagon/views.py:316
 #, python-format
-msgid "Your new collection is shown below. You can <ahref=\"%(url)s\">edit additional settings</a> if you'dlike."
+msgid "Your new collection is shown below. You can <a href=\"%(url)s\">edit additional settings</a> if you'd like."
 msgstr ""
 
 #: src/olympia/bandwagon/views.py:322
@@ -2323,8 +2343,8 @@ msgid_plural "%(num)s Add-ons in this Collection"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/olympia/bandwagon/templates/bandwagon/collection_detail.html:125 src/olympia/compat/templates/compat/index.html:25 src/olympia/compat/templates/compat/reporter_detail.html:29
-#: src/olympia/files/templates/files/viewer.html:29 src/olympia/templates/amo_footer.html:17 src/olympia/templates/includes/lang_switcher.html:10
+#: src/olympia/bandwagon/templates/bandwagon/collection_detail.html:125 src/olympia/compat/templates/compat/reporter_detail.html:29 src/olympia/files/templates/files/viewer.html:29
+#: src/olympia/templates/amo_footer.html:17 src/olympia/templates/includes/lang_switcher.html:10
 msgid "Go"
 msgstr ""
 
@@ -2491,7 +2511,7 @@ msgid "Remove this user as a contributor"
 msgstr ""
 
 #: src/olympia/bandwagon/templates/bandwagon/edit_contributors.html:18 src/olympia/bandwagon/templates/bandwagon/edit_contributors.html:43
-#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:20 src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:48
+#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:18 src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:46
 #: src/olympia/devhub/templates/devhub/addons/ajax_compat_update.html:19
 msgid "Remove"
 msgstr ""
@@ -2539,7 +2559,7 @@ msgid "<b>Warning:</b> By changing the owner of this collection, you will no lon
 msgstr ""
 
 #: src/olympia/bandwagon/templates/bandwagon/edit_contributors.html:83 src/olympia/devhub/templates/devhub/addons/forms_shared/media.html:157
-#: src/olympia/devhub/templates/devhub/addons/submit/describe.html:69 src/olympia/devhub/templates/devhub/addons/submit/license.html:60 src/olympia/devhub/templates/devhub/addons/submit/upload.html:78
+#: src/olympia/devhub/templates/devhub/addons/submit/describe.html:69 src/olympia/devhub/templates/devhub/addons/submit/license.html:60 src/olympia/devhub/templates/devhub/addons/submit/upload.html:70
 #: src/olympia/devhub/templates/devhub/payments/tier.html:17 src/olympia/editors/templates/editors/themes/themes.html:111 src/olympia/editors/templates/editors/themes/themes.html:128
 #: src/olympia/editors/templates/editors/themes/themes.html:134 src/olympia/editors/templates/editors/themes/themes.html:141 src/olympia/users/templates/users/fxa_migration_prompt_content.html:10
 #: src/olympia/users/templates/users/login_form.html:42 src/olympia/users/templates/users/mobile/login.html:57
@@ -2622,31 +2642,31 @@ msgid "Add-ons in Your Collection"
 msgstr ""
 
 #: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:4
-msgid ""
-"To include an add-on in this collection, enter its name in the box below and hit enter.  You can also use the <strong>Add to Collection</strong> links throughout the site to include add-ons later."
+msgid "To include an add-on in this collection, enter its name in the box below and hit enter."
 msgstr ""
 
-#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:17 src/olympia/constants/base.py:400 src/olympia/devhub/templates/devhub/addons/activity.html:62
+#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:15 src/olympia/constants/base.py:400 src/olympia/devhub/templates/devhub/addons/activity.html:62
+#: src/olympia/editors/helpers.py:273 src/olympia/editors/helpers.py:360
 msgid "Add-on"
 msgstr ""
 
-#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:26
+#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:24
 msgid "Enter the name of the add-on to include"
 msgstr ""
 
-#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:28
+#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:26
 msgid "Add to Collection"
 msgstr ""
 
-#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:45 src/olympia/editors/helpers.py:936 src/olympia/editors/helpers.py:956
+#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:43 src/olympia/editors/helpers.py:1016 src/olympia/editors/helpers.py:1036
 msgid "Pending"
 msgstr ""
 
-#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:47
+#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:45
 msgid "Add a comment"
 msgstr ""
 
-#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:48
+#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:46
 msgid "Remove this add-on from the collection"
 msgstr ""
 
@@ -2753,12 +2773,12 @@ msgstr ""
 msgid "Most Users"
 msgstr ""
 
-#: src/olympia/browse/views.py:61 src/olympia/browse/views.py:72 src/olympia/browse/views.py:279 src/olympia/browse/templates/browse/personas/mobile/category_landing.html:63
+#: src/olympia/browse/views.py:61 src/olympia/browse/views.py:72 src/olympia/browse/views.py:246 src/olympia/browse/templates/browse/personas/mobile/category_landing.html:63
 #: src/olympia/discovery/templates/discovery/pane.html:67 src/olympia/search/forms.py:92
 msgid "Up & Coming"
 msgstr ""
 
-#: src/olympia/browse/views.py:460 src/olympia/devhub/views.py:76 src/olympia/devhub/views.py:83 src/olympia/discovery/templates/discovery/addons/detail.html:66
+#: src/olympia/browse/views.py:427 src/olympia/devhub/views.py:74 src/olympia/devhub/views.py:81 src/olympia/discovery/templates/discovery/addons/detail.html:66
 msgid "Created"
 msgstr ""
 
@@ -2946,8 +2966,8 @@ msgid_plural "See all %(cnt)s extensions in %(name)s &raquo;"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/olympia/browse/templates/browse/mobile/extensions.html:13 src/olympia/compat/templates/compat/index.html:82 src/olympia/devhub/templates/devhub/devhub_search.html:24
-#: src/olympia/devhub/templates/devhub/addons/activity.html:47 src/olympia/search/templates/search/no_results.html:4 src/olympia/search/templates/search/mobile/results.html:36
+#: src/olympia/browse/templates/browse/mobile/extensions.html:13 src/olympia/devhub/templates/devhub/devhub_search.html:24 src/olympia/devhub/templates/devhub/addons/activity.html:47
+#: src/olympia/search/templates/search/no_results.html:4 src/olympia/search/templates/search/mobile/results.html:36
 msgid "No results found."
 msgstr ""
 
@@ -3032,7 +3052,7 @@ msgstr ""
 msgid "All"
 msgstr ""
 
-#: src/olympia/compat/forms.py:22 src/olympia/search/views.py:525
+#: src/olympia/compat/forms.py:22 src/olympia/editors/templates/editors/base.html:69 src/olympia/search/views.py:518
 msgid "All Add-ons"
 msgstr ""
 
@@ -3042,53 +3062,6 @@ msgstr ""
 
 #: src/olympia/compat/forms.py:24
 msgid "Non-binary"
-msgstr ""
-
-#. Review points sources other than add-ons and themes.
-#: src/olympia/compat/views.py:87 src/olympia/constants/base.py:388 src/olympia/devhub/forms.py:162 src/olympia/editors/templates/editors/performance.html:75
-msgid "Other"
-msgstr ""
-
-#: src/olympia/compat/templates/compat/index.html:4
-msgid "Add-on Compatibility Report for {app} {version}"
-msgstr ""
-
-#: src/olympia/compat/templates/compat/index.html:11
-msgid "{app} {version} Compatibility"
-msgstr ""
-
-#: src/olympia/compat/templates/compat/index.html:17
-#, python-format
-msgid "Top 95%% compatible with previous version"
-msgstr ""
-
-#: src/olympia/compat/templates/compat/index.html:18
-#, python-format
-msgid "Top 95%% of all add-ons"
-msgstr ""
-
-#: src/olympia/compat/templates/compat/index.html:19
-msgid "All active add-ons"
-msgstr ""
-
-#: src/olympia/compat/templates/compat/index.html:23 src/olympia/constants/base.py:401
-msgid "App"
-msgstr ""
-
-#: src/olympia/compat/templates/compat/index.html:55
-msgid "Details for add-ons compatible with previous version:"
-msgstr ""
-
-#: src/olympia/compat/templates/compat/index.html:57
-msgid "Show all versions"
-msgstr ""
-
-#: src/olympia/compat/templates/compat/index.html:59
-msgid "Details for add-ons compatible with all versions:"
-msgstr ""
-
-#: src/olympia/compat/templates/compat/index.html:61
-msgid "Show previous version only"
 msgstr ""
 
 #: src/olympia/compat/templates/compat/reporter.html:3
@@ -3142,8 +3115,8 @@ msgstr ""
 msgid "Report Type"
 msgstr ""
 
-#: src/olympia/compat/templates/compat/reporter_detail.html:47 src/olympia/devhub/forms.py:784 src/olympia/devhub/templates/devhub/addons/ajax_compat_update.html:17 src/olympia/editors/forms.py:108
-#: src/olympia/zadmin/forms.py:45
+#: src/olympia/compat/templates/compat/reporter_detail.html:47 src/olympia/devhub/forms.py:785 src/olympia/devhub/templates/devhub/addons/ajax_compat_update.html:17 src/olympia/editors/forms.py:108
+#: src/olympia/editors/forms.py:248 src/olympia/zadmin/forms.py:45
 msgid "Application"
 msgstr ""
 
@@ -3231,7 +3204,8 @@ msgstr ""
 msgid "Preliminarily Reviewed and Awaiting Full Review"
 msgstr ""
 
-#: src/olympia/constants/base.py:33 src/olympia/editors/helpers.py:924 src/olympia/editors/templates/editors/themes/history_table.html:34
+#: src/olympia/constants/base.py:33 src/olympia/editors/forms.py:258 src/olympia/editors/helpers.py:73 src/olympia/editors/helpers.py:1004
+#: src/olympia/editors/templates/editors/themes/history_table.html:34
 msgid "Deleted"
 msgstr ""
 
@@ -3328,6 +3302,11 @@ msgstr ""
 msgid "Ask before users can download this add-on"
 msgstr ""
 
+#. Review points sources other than add-ons and themes.
+#: src/olympia/constants/base.py:388 src/olympia/devhub/forms.py:162 src/olympia/editors/templates/editors/performance.html:75
+msgid "Other"
+msgstr ""
+
 #: src/olympia/constants/base.py:389
 msgid "Exception"
 msgstr ""
@@ -3338,6 +3317,10 @@ msgstr ""
 
 #: src/olympia/constants/base.py:391
 msgid "Change"
+msgstr ""
+
+#: src/olympia/constants/base.py:401
+msgid "App"
 msgstr ""
 
 #: src/olympia/constants/base.py:402
@@ -3488,7 +3471,7 @@ msgstr ""
 msgid "Duplicate"
 msgstr ""
 
-#: src/olympia/constants/editors.py:17 src/olympia/editors/helpers.py:502 src/olympia/editors/templates/editors/themes/queue.html:71 src/olympia/editors/templates/editors/themes/themes.html:94
+#: src/olympia/constants/editors.py:17 src/olympia/editors/helpers.py:575 src/olympia/editors/templates/editors/themes/queue.html:71 src/olympia/editors/templates/editors/themes/themes.html:94
 msgid "Reject"
 msgstr ""
 
@@ -3588,7 +3571,7 @@ msgstr ""
 msgid "Android"
 msgstr ""
 
-#: src/olympia/core/apps.py:19
+#: src/olympia/core/apps.py:21
 msgid "Core"
 msgstr ""
 
@@ -3722,7 +3705,7 @@ msgid "Submit my add-on for manual review."
 msgstr ""
 
 #: src/olympia/devhub/forms.py:537
-msgid "Do not list my add-on on this site (beta)"
+msgid "Do not list my add-on on this site"
 msgstr ""
 
 #: src/olympia/devhub/forms.py:538
@@ -3755,46 +3738,46 @@ msgstr ""
 
 #: src/olympia/devhub/forms.py:592
 #, python-format
-msgid "Version %s already exists"
+msgid "Version %s already exists, or was uploaded before."
 msgstr ""
 
-#: src/olympia/devhub/forms.py:604
+#: src/olympia/devhub/forms.py:605
 msgid "Select a valid choice. That choice is not one of the available choices."
 msgstr ""
 
-#: src/olympia/devhub/forms.py:610
+#: src/olympia/devhub/forms.py:611
 msgid "A file with a version ending with a|alpha|b|beta and an optional number is detected as beta."
 msgstr ""
 
-#: src/olympia/devhub/forms.py:633
+#: src/olympia/devhub/forms.py:634
 msgid "You cannot upload any more files for this version."
 msgstr ""
 
-#: src/olympia/devhub/forms.py:639
+#: src/olympia/devhub/forms.py:640
 msgid "Version doesn't match"
 msgstr ""
 
-#: src/olympia/devhub/forms.py:668
+#: src/olympia/devhub/forms.py:669
 msgid "You cannot delete a file once the review process has started.  You must delete the whole version."
 msgstr ""
 
-#: src/olympia/devhub/forms.py:688
+#: src/olympia/devhub/forms.py:689
 msgid "The platform All cannot be combined with specific platforms."
 msgstr ""
 
-#: src/olympia/devhub/forms.py:693
+#: src/olympia/devhub/forms.py:694
 msgid "A platform can only be chosen once."
 msgstr ""
 
-#: src/olympia/devhub/forms.py:706
+#: src/olympia/devhub/forms.py:707
 msgid "A review type must be selected."
 msgstr ""
 
-#: src/olympia/devhub/forms.py:788 src/olympia/editors/forms.py:114 src/olympia/zadmin/forms.py:49 src/olympia/zadmin/forms.py:52
+#: src/olympia/devhub/forms.py:789 src/olympia/editors/forms.py:114 src/olympia/editors/forms.py:254 src/olympia/zadmin/forms.py:49 src/olympia/zadmin/forms.py:52
 msgid "Select an application first"
 msgstr ""
 
-#: src/olympia/devhub/forms.py:840
+#: src/olympia/devhub/forms.py:841
 msgid "There cannot be more than 3 required add-ons."
 msgstr ""
 
@@ -3828,76 +3811,76 @@ msgstr[1] ""
 msgid "Review"
 msgstr ""
 
-#: src/olympia/devhub/tasks.py:551
+#: src/olympia/devhub/tasks.py:583
 #, python-format
 msgid "%s responded with %s (%s)."
 msgstr ""
 
-#: src/olympia/devhub/tasks.py:555
+#: src/olympia/devhub/tasks.py:587
 #, python-format
 msgid "Connection to \"%s\" timed out."
 msgstr ""
 
-#: src/olympia/devhub/tasks.py:557
+#: src/olympia/devhub/tasks.py:589
 #, python-format
 msgid "Could not contact host at \"%s\"."
 msgstr ""
 
-#: src/olympia/devhub/utils.py:104
+#: src/olympia/devhub/utils.py:105
 #, python-format
 msgid "Validation generated too many errors/warnings so %s messages were truncated. After addressing the visible messages, you'll be able to see the others."
 msgstr ""
 
-#: src/olympia/devhub/views.py:183
+#: src/olympia/devhub/views.py:181
 msgid "All My Add-ons"
 msgstr ""
 
-#: src/olympia/devhub/views.py:210
+#: src/olympia/devhub/views.py:208
 msgid "All Activity"
 msgstr ""
 
-#: src/olympia/devhub/views.py:211
+#: src/olympia/devhub/views.py:209
 msgid "Add-on Updates"
 msgstr ""
 
-#: src/olympia/devhub/views.py:212
+#: src/olympia/devhub/views.py:210
 msgid "Add-on Status"
 msgstr ""
 
-#: src/olympia/devhub/views.py:213
+#: src/olympia/devhub/views.py:211
 msgid "User Collections"
 msgstr ""
 
-#: src/olympia/devhub/views.py:214 src/olympia/devhub/templates/devhub/docs/policies-maintenance.html:68 src/olympia/pages/templates/pages/dev_faq.html:38
+#: src/olympia/devhub/views.py:212 src/olympia/devhub/templates/devhub/docs/policies-maintenance.html:68 src/olympia/pages/templates/pages/dev_faq.html:38
 #: src/olympia/pages/templates/pages/dev_faq.html:484
 msgid "User Reviews"
 msgstr ""
 
-#: src/olympia/devhub/views.py:327 src/olympia/devhub/views.py:331 src/olympia/devhub/views.py:484 src/olympia/devhub/views.py:513 src/olympia/devhub/views.py:564 src/olympia/devhub/views.py:1150
+#: src/olympia/devhub/views.py:325 src/olympia/devhub/views.py:329 src/olympia/devhub/views.py:484 src/olympia/devhub/views.py:513 src/olympia/devhub/views.py:564 src/olympia/devhub/views.py:1156
 msgid "Changes successfully saved."
 msgstr ""
 
-#: src/olympia/devhub/views.py:334 src/olympia/devhub/views.py:1631
+#: src/olympia/devhub/views.py:332 src/olympia/devhub/views.py:1637
 msgid "Please check the form for errors."
 msgstr ""
 
-#: src/olympia/devhub/views.py:346
+#: src/olympia/devhub/views.py:344
 msgid "Add-on cannot be deleted. Disable this add-on instead."
 msgstr ""
 
-#: src/olympia/devhub/views.py:356
+#: src/olympia/devhub/views.py:354
 msgid "Theme deleted."
 msgstr ""
 
-#: src/olympia/devhub/views.py:356
+#: src/olympia/devhub/views.py:354
 msgid "Add-on deleted."
 msgstr ""
 
-#: src/olympia/devhub/views.py:362
+#: src/olympia/devhub/views.py:360
 msgid "URL name was incorrect. Theme was not deleted."
 msgstr ""
 
-#: src/olympia/devhub/views.py:367
+#: src/olympia/devhub/views.py:365
 msgid "URL name was incorrect. Add-on was not deleted."
 msgstr ""
 
@@ -3925,7 +3908,7 @@ msgstr ""
 msgid "Check Add-on Compatibility"
 msgstr ""
 
-#: src/olympia/devhub/views.py:808 src/olympia/signing/views.py:90
+#: src/olympia/devhub/views.py:808 src/olympia/signing/views.py:95
 msgid "You cannot submit this type of add-on"
 msgstr ""
 
@@ -3955,33 +3938,33 @@ msgstr ""
 msgid "There was an error uploading your preview."
 msgstr ""
 
-#: src/olympia/devhub/views.py:1189
+#: src/olympia/devhub/views.py:1195
 #, python-format
 msgid "Version %s disabled."
 msgstr ""
 
-#: src/olympia/devhub/views.py:1193
+#: src/olympia/devhub/views.py:1199
 #, python-format
 msgid "Version %s deleted."
 msgstr ""
 
-#: src/olympia/devhub/views.py:1203
+#: src/olympia/devhub/views.py:1209
 msgid "This upload has failed validation, and may lack complete validation results. Please take due care when reviewing it."
 msgstr ""
 
-#: src/olympia/devhub/views.py:1677
+#: src/olympia/devhub/views.py:1683
 msgid "Preliminary Review Requested."
 msgstr ""
 
-#: src/olympia/devhub/views.py:1678
+#: src/olympia/devhub/views.py:1684
 msgid "Full Review Requested."
 msgstr ""
 
-#: src/olympia/devhub/views.py:1779
+#: src/olympia/devhub/views.py:1783
 msgid "Your old credentials were revoked and are no longer valid. Be sure to update all API clients with the new credentials."
 msgstr ""
 
-#: src/olympia/devhub/views.py:1797
+#: src/olympia/devhub/views.py:1801
 msgid "New API key created"
 msgstr ""
 
@@ -4011,7 +3994,7 @@ msgstr ""
 msgid "{0} :: Search"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/devhub_search.html:6 src/olympia/devhub/templates/devhub/search.html:8 src/olympia/editors/forms.py:435 src/olympia/editors/forms.py:437
+#: src/olympia/devhub/templates/devhub/devhub_search.html:6 src/olympia/devhub/templates/devhub/search.html:8 src/olympia/editors/forms.py:534 src/olympia/editors/forms.py:536
 #: src/olympia/editors/templates/editors/queue.html:27 src/olympia/editors/templates/editors/themes/queue_list.html:14 src/olympia/search/templates/search/collections.html:17
 #: src/olympia/search/templates/search/personas.html:18 src/olympia/search/templates/search/results.html:18 src/olympia/search/templates/search/mobile/results.html:8
 #: src/olympia/templates/search.html:14 src/olympia/templates/impala/search.html:18
@@ -4071,12 +4054,12 @@ msgstr ""
 msgid "Start Making Add-ons"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/index.html:86 src/olympia/devhub/templates/devhub/addons/listing/items.html:25 src/olympia/devhub/templates/devhub/includes/addon_details.html:15
+#: src/olympia/devhub/templates/devhub/index.html:86 src/olympia/devhub/templates/devhub/addons/listing/items.html:25 src/olympia/devhub/templates/devhub/includes/addon_details.html:20
 #: src/olympia/devhub/templates/devhub/personas/edit.html:43
 msgid "Status:"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/index.html:90 src/olympia/devhub/templates/devhub/includes/addon_details.html:100
+#: src/olympia/devhub/templates/devhub/index.html:90 src/olympia/devhub/templates/devhub/includes/addon_details.html:87
 msgid "Visibility:"
 msgstr ""
 
@@ -4084,11 +4067,11 @@ msgstr ""
 msgid "Latest Version:"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/index.html:109 src/olympia/devhub/templates/devhub/includes/addon_details.html:145 src/olympia/devhub/templates/devhub/personas/edit.html:49
+#: src/olympia/devhub/templates/devhub/index.html:109 src/olympia/devhub/templates/devhub/includes/addon_details.html:131 src/olympia/devhub/templates/devhub/personas/edit.html:49
 msgid "Queue Position:"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/index.html:110 src/olympia/devhub/templates/devhub/includes/addon_details.html:146 src/olympia/devhub/templates/devhub/personas/edit.html:50
+#: src/olympia/devhub/templates/devhub/index.html:110 src/olympia/devhub/templates/devhub/includes/addon_details.html:132 src/olympia/devhub/templates/devhub/personas/edit.html:50
 #, python-format
 msgid "%(position)s of %(total)s"
 msgstr ""
@@ -4190,16 +4173,6 @@ msgstr ""
 msgid "Do you want your add-on to be distributed on this site?"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/validate_addon.html:49 src/olympia/devhub/templates/devhub/addons/submit/upload.html:30 src/olympia/devhub/templates/devhub/versions/add_file_modal.html:14
-#: src/olympia/devhub/templates/devhub/versions/add_file_modal.html:53 src/olympia/devhub/templates/devhub/versions/list.html:298
-msgid "Warning:"
-msgstr ""
-
-#: src/olympia/devhub/templates/devhub/validate_addon.html:50 src/olympia/devhub/templates/devhub/addons/submit/upload.html:31
-#, python-format
-msgid "Submission of unlisted add-ons for signing is currently in an open beta. Please <a href=\"%(url)s\" target=\"_blank\">report any bugs</a> that you encounter."
-msgstr ""
-
 #. first parameter is a filename like lorem-ipsum-1.0.2.xpi
 #: src/olympia/devhub/templates/devhub/validation.html:5
 msgid "Validation Results for {0}"
@@ -4274,7 +4247,7 @@ msgstr ""
 msgid "Update Compatibility"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/addons/ajax_compat_update.html:4
+#: src/olympia/devhub/templates/devhub/addons/ajax_compat_update.html:4 src/olympia/devhub/templates/devhub/versions/edit.html:45
 msgid "Adjusting application information here will allow users to install your add-on even if the install manifest in the package indicates that the add-on is incompatible."
 msgstr ""
 
@@ -4286,9 +4259,9 @@ msgstr ""
 msgid "Add Another Application&hellip;"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/addons/ajax_compat_update.html:38 src/olympia/devhub/templates/devhub/addons/owner.html:86 src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:46
-#: src/olympia/devhub/templates/devhub/versions/list.html:351 src/olympia/devhub/templates/devhub/versions/list.html:353 src/olympia/templates/impala/base.html:132
-#: src/olympia/templates/impala/base.html:143 src/olympia/templates/impala/base.html:161 src/olympia/templates/impala/base.html:171
+#: src/olympia/devhub/templates/devhub/addons/ajax_compat_update.html:38 src/olympia/devhub/templates/devhub/addons/owner.html:86 src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:45
+#: src/olympia/devhub/templates/devhub/versions/list.html:349 src/olympia/devhub/templates/devhub/versions/list.html:351 src/olympia/templates/impala/base.html:129
+#: src/olympia/templates/impala/base.html:140 src/olympia/templates/impala/base.html:158 src/olympia/templates/impala/base.html:168
 msgid "Close"
 msgstr ""
 
@@ -4322,7 +4295,7 @@ msgstr ""
 msgid "Manage Authors & License"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/addons/owner.html:29 src/olympia/editors/templates/editors/review.html:270
+#: src/olympia/devhub/templates/devhub/addons/owner.html:29 src/olympia/editors/helpers.py:362 src/olympia/editors/templates/editors/review.html:270
 msgid "Authors"
 msgstr ""
 
@@ -4391,17 +4364,11 @@ msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/basic.html:52
 msgid ""
-"A short explanation of your add-on's basic\n"
-"                          functionality that is displayed in search and browse\n"
-"                          listings, as well as at the top of your add-on's\n"
-"                          details page. It is only relevant for listed add-ons."
+"A short explanation of your add-on's basic functionality that is displayed in search and browse listings, as well as at the top of your add-on's details page. It is only relevant for listed add-ons."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/basic.html:73
-msgid ""
-"Categories are the primary way users browse through add-ons.\n"
-"                        Choose any that fit your add-on's functionality for the most\n"
-"                        exposure. It is only relevant for listed add-ons."
+msgid "Categories are the primary way users browse through add-ons. Choose any that fit your add-on's functionality for the most exposure. It is only relevant for listed add-ons."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/basic.html:90
@@ -4411,11 +4378,7 @@ msgid ""
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/basic.html:119
-msgid ""
-"Tags help users find your add-on and should be short\n"
-"                        descriptors such as tabs, toolbar, or twitter.  You\n"
-"                        may have a maximum of {0} tags. It is only relevant\n"
-"                        for listed add-ons."
+msgid "Tags help users find your add-on and should be short descriptors such as tabs, toolbar, or twitter. You may have a maximum of {0} tags. It is only relevant for listed add-ons."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/basic.html:129 src/olympia/devhub/templates/devhub/personas/edit.html:97 src/olympia/devhub/templates/devhub/personas/submit.html:46
@@ -4443,11 +4406,7 @@ msgid "Add-on Details for {0}"
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/details.html:22
-msgid ""
-"A longer explanation of features,\n"
-"                          functionality, and other relevant information. This\n"
-"                          field is only displayed on the add-on's details\n"
-"                          page. It is only relevant for listed add-ons."
+msgid "A longer explanation of features, functionality, and other relevant information. This field is only displayed on the add-on's details page. It is only relevant for listed add-ons."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/details.html:44 src/olympia/translations/templates/translations/trans-menu.html:13
@@ -4455,10 +4414,7 @@ msgid "Default Locale"
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/details.html:45
-msgid ""
-"Information about your add-on is displayed in this locale\n"
-"                        unless you override it with a locale-specific translation.\n"
-"                        It is only relevant for listed add-ons."
+msgid "Information about your add-on is displayed in this locale unless you override it with a locale-specific translation. It is only relevant for listed add-ons."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/details.html:61 src/olympia/users/forms.py:311 src/olympia/users/templates/users/edit.html:122 src/olympia/users/templates/users/register.html:57
@@ -4468,10 +4424,8 @@ msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/details.html:63
 msgid ""
-"If your add-on has another homepage, enter its\n"
-"                          address here. If your website is localized into other\n"
-"                          languages multiple translations of this field can be\n"
-"                          added. It is only relevant for listed add-ons."
+"If your add-on has another homepage, enter its address here. If your website is localized into other languages multiple translations of this field can be added. It is only relevant for listed add-"
+"ons."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/media.html:3
@@ -4489,19 +4443,14 @@ msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/support.html:22
 msgid ""
-"If you wish to display an e-mail address for support\n"
-"                          inquiries, enter it here. If you have different\n"
-"                          addresses for each language multiple translations of\n"
-"                          this field can be added. It is only relevant for\n"
-"                          listed add-ons."
+"If you wish to display an e-mail address for support inquiries, enter it here. If you have different addresses for each language multiple translations of this field can be added. It is only "
+"relevant for listed add-ons."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/support.html:45
 msgid ""
-"If your add-on has a support website or forum, enter\n"
-"                          its address here. If your website is localized into\n"
-"                          other languages, multiple translations of this field can\n"
-"                          be added. It is only relevant for listed add-ons."
+"If your add-on has a support website or forum, enter its address here. If your website is localized into other languages, multiple translations of this field can be added. It is only relevant for "
+"listed add-ons."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:6
@@ -4515,11 +4464,8 @@ msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:23
 msgid ""
-"Any information end users may want to know that isn't\n"
-"                          necessarily applicable to the add-on summary or description.\n"
-"                          Common uses include listing known major bugs, information on\n"
-"                          how to report bugs, anticipated release date of a new version,\n"
-"                          etc. It is only relevant for listed add-ons."
+"Any information end users may want to know that isn't necessarily applicable to the add-on summary or description. Common uses include listing known major bugs, information on how to report bugs, "
+"anticipated release date of a new version, etc. It is only relevant for listed add-ons."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:46
@@ -4531,9 +4477,7 @@ msgid "Add-on Flags"
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:69
-msgid ""
-"These flags are used to classify add-ons. It is only\n"
-"                        relevant for listed add-ons."
+msgid "These flags are used to classify add-ons. It is only relevant for listed add-ons."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:74
@@ -4549,9 +4493,7 @@ msgid "View Source?"
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:90
-msgid ""
-"Whether the source of your add-on can be displayed in our\n"
-"                        online viewer. It is only relevant for listed add-ons."
+msgid "Whether the source of your add-on can be displayed in our online viewer. It is only relevant for listed add-ons."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:94
@@ -4567,10 +4509,7 @@ msgid "Public Stats?"
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:102
-msgid ""
-"Whether the download and usage stats of your add-on can\n"
-"                        be displayed in our online viewer.\n"
-"                        It is only relevant for listed add-ons."
+msgid "Whether the download and usage stats of your add-on can be displayed in our online viewer. It is only relevant for listed add-ons."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:107
@@ -4586,10 +4525,7 @@ msgid "Upgrade SDK?"
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:116
-msgid ""
-"If selected, we will try to automatically upgrade your\n"
-"                        add-on when a new version of the SDK is released.\n"
-"                        It is only relevant for listed add-ons."
+msgid "If selected, we will try to automatically upgrade your add-on when a new version of the SDK is released. It is only relevant for listed add-ons."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:121
@@ -4640,10 +4576,8 @@ msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/forms_shared/media.html:16
 msgid ""
-"Upload an icon for your add-on or choose from one of ours. The\n"
-"                      icon is displayed nearly everywhere your add-on is. Uploaded images\n"
-"                      must be one of the following image types: .png, .jpg.\n"
-"                      It is only relevant for listed add-ons."
+"Upload an icon for your add-on or choose from one of ours. The icon is displayed nearly everywhere your add-on is. Uploaded images must be one of the following image types: .png, .jpg. It is only "
+"relevant for listed add-ons."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/forms_shared/media.html:25
@@ -4656,9 +4590,7 @@ msgid "32x32px"
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/forms_shared/media.html:39
-msgid ""
-"Used in listings of add-ons, like search results\n"
-"                            and featured add-ons."
+msgid "Used in listings of add-ons, like search results and featured add-ons."
 msgstr ""
 
 #. The size of the icon
@@ -4753,16 +4685,14 @@ msgid "Deleting your add-on will permanently remove it from the site and prevent
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:24
-msgid ""
-"Enter the following text confirm your decision:\n"
-"           {slug}"
+msgid "Enter the following text confirm your decision: {slug}"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:34
+#: src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:33
 msgid "Please tell us why you are deleting your theme:"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:36
+#: src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:35
 msgid "Please tell us why you are deleting your add-on:"
 msgstr ""
 
@@ -4799,8 +4729,8 @@ msgstr ""
 msgid "Daily statistics on downloads and users."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/addons/listing/item_actions.html:45 src/olympia/stats/templates/stats/stats.html:75 src/olympia/stats/templates/stats/stats.html:79
-#: src/olympia/stats/templates/stats/stats.html:81
+#: src/olympia/devhub/templates/devhub/addons/listing/item_actions.html:45 src/olympia/stats/templates/stats/stats.html:31 src/olympia/stats/templates/stats/stats.html:35
+#: src/olympia/stats/templates/stats/stats.html:37
 msgid "Statistics"
 msgstr ""
 
@@ -4919,10 +4849,7 @@ msgid "Your add-on has been submitted to the Full Review queue."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/submit/done.html:18
-msgid ""
-"You'll receive an email once it has been reviewed by an editor. In\n"
-"          the meantime, you and your friends can install it directly from its\n"
-"          details page:"
+msgid "You'll receive an email once it has been reviewed by an editor. In the meantime, you and your friends can install it directly from its details page:"
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/submit/done.html:27 src/olympia/devhub/templates/devhub/addons/submit/done.html:77 src/olympia/devhub/templates/devhub/personas/submit_done.html:16
@@ -5128,11 +5055,11 @@ msgstr ""
 msgid "Use the fields below to upload your add-on package and select any platform restrictions. After upload, a series of automated validation tests will be run on your file."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/addons/submit/upload.html:59 src/olympia/devhub/templates/devhub/versions/add_file_modal.html:39
+#: src/olympia/devhub/templates/devhub/addons/submit/upload.html:51 src/olympia/devhub/templates/devhub/versions/add_file_modal.html:28
 msgid "Which platforms is this file compatible with?"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/addons/submit/upload.html:67 src/olympia/devhub/templates/devhub/versions/add_file_modal.html:65
+#: src/olympia/devhub/templates/devhub/addons/submit/upload.html:59 src/olympia/devhub/templates/devhub/versions/add_file_modal.html:45
 msgid "Administrative overrides"
 msgstr ""
 
@@ -5242,8 +5169,8 @@ msgstr ""
 
 #: src/olympia/devhub/templates/devhub/docs/policies-contact.html:44
 msgid ""
-"If you've found a problem with the site, we'd love to fix it. Please <a href=\"https://github.com/mozilla/olympia/issues\">file a bug report</a> in GitHub, including the location of the problem and "
-"how you encountered it."
+"If you've found a problem with the site, we'd love to fix it. Please <a href=\"https://github.com/mozilla/addons/issues/new\">file a bug report</a> in GitHub, including the location of the problem "
+"and how you encountered it."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/docs/policies-maintenance.html:3 src/olympia/devhub/templates/devhub/docs/policies-maintenance.html:7
@@ -5810,7 +5737,7 @@ msgstr ""
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:282
 msgid ""
-"Add-ons that store or otherwise handle browsing data must support <a href=\"https://developer.mozilla.org/En/Supporting_private_browsing_mode\">Private Browsing Mode</a>.  During a Private Browsing "
+"Add-ons that store or otherwise handle browsing data must support <a href=\"https://developer.mozilla.org/En/Supporting_private_browsing_mode\">Private Browsing Mode</a>. During a Private Browsing "
 "session, no browsing data can be written to disk, and all of this data must be cleared when Firefox quits or the Private Browsing session ends."
 msgstr ""
 
@@ -5975,129 +5902,95 @@ msgstr ""
 msgid "How to get in touch with us regarding these policies or your add-on."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:6
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:10
 msgid "You have disabled this add-on"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:20
-msgid ""
-"Your add-on's listing is disabled and is not showing\n"
-"                             anywhere in our gallery or update service."
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:24
+msgid "Your add-on's listing is disabled and is not showing anywhere in our gallery or update service."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:25
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:27
 msgid "Please complete your add-on."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:29
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:30
 msgid "You will receive an email when the review is complete."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:34
-msgid ""
-"You will receive an email when the review is complete. Until\n"
-"                             then, your add-on is not listed in our gallery but can be\n"
-"                             accessed directly from its details page."
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:33
+msgid "You will receive an email when the review is complete. Until then, your add-on is not listed in our gallery but can be accessed directly from its details page."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:38 src/olympia/devhub/templates/devhub/includes/addon_details.html:48
-msgid ""
-"You will receive an email when the review is\n"
-"                             complete and your add-on is signed."
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:37 src/olympia/devhub/templates/devhub/includes/addon_details.html:45
+msgid "You will receive an email when the review is complete and your add-on is signed."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:44
-msgid ""
-"You will receive an email when the review is complete. Until\n"
-"                             then, your add-on is not listed in our gallery but can be\n"
-"                             accessed directly from its details page. "
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:41
+msgid "You will receive an email when the review is complete. Until then, your add-on is not listed in our gallery but can be accessed directly from its details page. "
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:54
-msgid ""
-"Your add-on is displayed in our gallery and users are\n"
-"                             receiving automatic updates."
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:49
+msgid "Your add-on is displayed in our gallery and users are receiving automatic updates."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:57
-msgid ""
-"Your add-on has been signed and can be bundled with an\n"
-"                             application installer."
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:52
+msgid "Your add-on has been signed and can be bundled with an application installer."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:63
-msgid ""
-"Your add-on was disabled by a site administrator and is no\n"
-"                             longer shown in our gallery. If you have any questions,\n"
-"                             please email amo-admins@mozilla.org."
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:56
+msgid "Your add-on was disabled by a site administrator and is no longer shown in our gallery. If you have any questions, please email amo-admins@mozilla.org."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:70
-msgid ""
-"Your add-on is displayed in our gallery as experimental\n"
-"                             and users are receiving automatic updates. Some features\n"
-"                             are unavailable to your add-on."
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:62
+msgid "Your add-on is displayed in our gallery as experimental and users are receiving automatic updates. Some features are unavailable to your add-on."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:74
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:66
 msgid "Your add-on has been signed."
 msgstr ""
 
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:69
+msgid ""
+"You will receive an email when the full review is complete. Until then, your add-on is displayed in our gallery as experimental and users are receiving automatic updates. Some features are "
+"unavailable to your add-on."
+msgstr ""
+
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:74
+msgid "You will receive an email when the full review is complete, making you able to bundle your add-on with an application installer."
+msgstr ""
+
 #: src/olympia/devhub/templates/devhub/includes/addon_details.html:79
-msgid ""
-"You will receive an email when the full review is complete.\n"
-"                             Until then, your add-on is displayed in our gallery as\n"
-"                             experimental and users are receiving automatic updates.\n"
-"                             Some features are unavailable to your add-on."
+msgid "All add-ons hosted in our gallery must now be reviewed by an editor. If you wish to continue hosting your add-on, please click to select a review process."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:84
-msgid ""
-"You will receive an email when the full review is\n"
-"                             complete, making you able to bundle your add-on with an\n"
-"                             application installer."
-msgstr ""
-
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:91
-msgid ""
-"All add-ons hosted in our gallery must now be reviewed by an\n"
-"                             editor. If you wish to continue hosting your add-on, please\n"
-"                             click to select a review process."
-msgstr ""
-
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:113
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:100
 msgid "Current Version:"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:115
-msgid ""
-"This is the version of your add-on that will\n"
-"                                           be installed if someone clicks the Install\n"
-"                                           button on addons.mozilla.org. It is only\n"
-"                                           relevant for listed add-ons."
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:102
+msgid "This is the version of your add-on that will be installed if someone clicks the Install button on addons.mozilla.org. It is only relevant for listed add-ons."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:123
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:110
 msgid "Created:"
 msgstr ""
 
 #. {0} is a date. dennis-ignore: E201
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:125 src/olympia/devhub/templates/devhub/includes/addon_details.html:131
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:112 src/olympia/devhub/templates/devhub/includes/addon_details.html:118
 #, python-format
 msgid "%%b %%e, %%Y"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:136
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:123
 msgid "Next Version:"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:138
-msgid ""
-"This is the newest uploaded version, however\n"
-"                                           it isn’t live on the site yet."
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:125
+msgid "This is the newest uploaded version, however it isn’t live on the site yet."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:144 src/olympia/devhub/templates/devhub/versions/list.html:30
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:130 src/olympia/devhub/templates/devhub/versions/list.html:30
 msgid "Queues are not reviewed strictly in order"
 msgstr ""
 
@@ -6165,9 +6058,7 @@ msgid "View the blog &#9658;"
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/includes/license_form.html:6
-msgid ""
-"Please choose a license appropriate for the rights you grant on your source code.\n"
-"                  It is only relevant for listed add-ons."
+msgid "Please choose a license appropriate for the rights you grant on your source code. It is only relevant for listed add-ons."
 msgstr ""
 
 #. {0} is a list of HTML tags.
@@ -6194,14 +6085,11 @@ msgstr[1] ""
 #: src/olympia/devhub/templates/devhub/includes/policy_form.html:4
 msgid ""
 "Users will be required to accept the following End-User License Agreement (EULA) prior to installing your add-on. The presence of a EULA significantly affects the number of downloads an add-on "
-"receives. Please note that a EULA is not the same as a code license, such as the GPL or MPL.\n"
-"                It is only relevant for listed add-ons."
+"receives. Please note that a EULA is not the same as a code license, such as the GPL or MPL.It is only relevant for listed add-ons."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/policy_form.html:21
-msgid ""
-"If your add-on transmits any data from the user's computer, a privacy policy is required that explains what data is sent and how it is used.\n"
-"                It is only relevant for listed add-ons."
+#: src/olympia/devhub/templates/devhub/includes/policy_form.html:24
+msgid "If your add-on transmits any data from the user's computer, a privacy policy is required that explains what data is sent and how it is used. It is only relevant for listed add-ons."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/includes/source_form_field.html:2
@@ -6369,12 +6257,8 @@ msgstr ""
 msgid "Add some tags to describe your Theme."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/personas/edit.html:106
-msgid ""
-"A short explanation of your theme's\n"
-"                                basic functionality that is displayed in\n"
-"                                search and browse listings, as well as at\n"
-"                                the top of your theme's details page."
+#: src/olympia/devhub/templates/devhub/personas/edit.html:106 src/olympia/devhub/templates/devhub/personas/submit.html:54
+msgid "A short explanation of your theme's basic functionality that is displayed in search and browse listings, as well as at the top of your theme's details page."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/personas/edit.html:122 src/olympia/devhub/templates/devhub/personas/submit.html:68
@@ -6444,7 +6328,7 @@ msgid "Upon upload and form submission, the AMO Team will review your updated de
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/personas/edit.html:241
-msgid "Your previously resubmitted design,  which is under pending review."
+msgid "Your previously resubmitted design, which is under pending review."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/personas/edit.html:245
@@ -6511,14 +6395,6 @@ msgstr ""
 
 #: src/olympia/devhub/templates/devhub/personas/submit.html:33
 msgid "Give your Theme a name."
-msgstr ""
-
-#: src/olympia/devhub/templates/devhub/personas/submit.html:54
-msgid ""
-"A short explanation of your theme's\n"
-"                                      basic functionality that is displayed in\n"
-"                                      search and browse listings, as well as at\n"
-"                                      the top of your theme's details page."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/personas/submit.html:198
@@ -6595,30 +6471,16 @@ msgstr ""
 msgid "Files added to reviewed versions must be reviewed before they will be available for download."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/add_file_modal.html:15
-#, python-format
-msgid ""
-"Submission of updates to unlisted add-ons for signing is currently in an open beta. Manual review may still be required for a large number of add-ons. Please <a href=\"%(url)s\" target=\"_blank"
-"\">report any bugs</a> that you encounter."
-msgstr ""
-
-#: src/olympia/devhub/templates/devhub/versions/add_file_modal.html:35
+#: src/olympia/devhub/templates/devhub/versions/add_file_modal.html:24
 msgid "Select the target platform for this file."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/add_file_modal.html:46
+#: src/olympia/devhub/templates/devhub/versions/add_file_modal.html:35
 msgid "Which review type would you like to nominate for?"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/add_file_modal.html:51
+#: src/olympia/devhub/templates/devhub/versions/add_file_modal.html:40
 msgid "Only publish this version to my beta channel."
-msgstr ""
-
-#: src/olympia/devhub/templates/devhub/versions/add_file_modal.html:54
-#, python-format
-msgid ""
-"The behavior of the beta channel has changed to accommodate <a href=\"%(addon_signing_url)s\" target=\"_blank\">mandatory add-on signing</a>. The new process is currently in an open beta, and may "
-"change significantly in the near future. Please <a href=\"%(issues_url)s\" target=\"_blank\">report any bugs</a> that you encounter."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/versions/edit.html:5
@@ -6642,19 +6504,10 @@ msgstr ""
 msgid "Upload Another File"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/edit.html:45
-msgid ""
-"Adjusting application information here will allow users to install your\n"
-"                          add-on even if the install manifest in the package indicates that the\n"
-"                          add-on is incompatible."
-msgstr ""
-
 #: src/olympia/devhub/templates/devhub/versions/edit.html:74
 msgid ""
-"Information about changes in this release, new features,\n"
-"                              known bugs, and other useful information specific to this\n"
-"                              release/version. This information is also shown in the\n"
-"                              Add-ons Manager when updating."
+"Information about changes in this release, new features, known bugs, and other useful information specific to this release/version. This information is also shown in the Add-ons Manager when "
+"updating."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/versions/edit.html:99
@@ -6666,10 +6519,7 @@ msgid "Notes for Reviewers"
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/versions/edit.html:114
-msgid ""
-"Optionally, enter any information that may be useful\n"
-"                              to the Editor reviewing this add-on, such as test\n"
-"                              account information."
+msgid "Optionally, enter any information that may be useful to the Editor reviewing this add-on, such as test account information."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/versions/edit.html:127
@@ -6747,7 +6597,7 @@ msgstr ""
 msgid "Request Preliminary Review"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:80 src/olympia/devhub/templates/devhub/versions/list.html:327 src/olympia/devhub/templates/devhub/versions/list.html:350
+#: src/olympia/devhub/templates/devhub/versions/list.html:80 src/olympia/devhub/templates/devhub/versions/list.html:325 src/olympia/devhub/templates/devhub/versions/list.html:348
 msgid "Cancel Review Request"
 msgstr ""
 
@@ -6776,7 +6626,7 @@ msgid "Unlisted:"
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/versions/list.html:114
-msgid "Not distributed on {0}. Developers will upload new versions for signing and distribute the add-ons on their own. (beta)"
+msgid "Not distributed on {0}. Developers will upload new versions for signing and distribute the add-ons on their own."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/versions/list.html:122
@@ -6839,81 +6689,73 @@ msgid "<strong>Important:</strong> Once a version has been deleted, you may not 
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/versions/list.html:230
-msgid ""
-"Deleting a version which has already been reviewed\n"
-"               may also cause a significant delay in the review of\n"
-"               your next update."
-msgstr ""
-
-#: src/olympia/devhub/templates/devhub/versions/list.html:233
 msgid "Are you sure you wish to delete this version?"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:238
+#: src/olympia/devhub/templates/devhub/versions/list.html:235
 msgid "Delete Version"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:240
+#: src/olympia/devhub/templates/devhub/versions/list.html:237
 msgid "Disable Version"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:247
+#: src/olympia/devhub/templates/devhub/versions/list.html:244
 msgid "Add a new Version"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:249
+#: src/olympia/devhub/templates/devhub/versions/list.html:246
 msgid "Add Version"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:256 src/olympia/devhub/templates/devhub/versions/list.html:274
+#: src/olympia/devhub/templates/devhub/versions/list.html:253 src/olympia/devhub/templates/devhub/versions/list.html:279
 msgid "Hide Add-on"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:259
+#: src/olympia/devhub/templates/devhub/versions/list.html:256
 msgid "Hiding your add-on will prevent it from appearing anywhere in our gallery and will stop users from receiving automatic updates."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:265
+#: src/olympia/devhub/templates/devhub/versions/list.html:263
+msgid "The files awaiting review will be disabled and you will need to upload new versions."
+msgstr ""
+
+#: src/olympia/devhub/templates/devhub/versions/list.html:270
 msgid "Are you sure you wish to hide your add-on?"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:286 src/olympia/devhub/templates/devhub/versions/list.html:315
+#: src/olympia/devhub/templates/devhub/versions/list.html:291 src/olympia/devhub/templates/devhub/versions/list.html:313
 msgid "Unlist Add-on"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:289
+#: src/olympia/devhub/templates/devhub/versions/list.html:294
 #, python-format
 msgid ""
 "Unlisting your add-on will make it (and each of its versions/files) invisible on this website. It won't show up in searches, won't have a public facing page, and won't be updated automatically for "
-"current users.  It is recommended for unlisted add-ons to provide a custom <a href=\"%(update_url)s\" target=\"_blank\">updateURL</a> in their manifest file for automatic updates."
+"current users. It is recommended for unlisted add-ons to provide a custom <a href=\"%(update_url)s\" target=\"_blank\">updateURL</a> in their manifest file for automatic updates."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:299
-#, python-format
-msgid "Switching add-ons to unlisted is currently in an open beta. Please <a href=\"%(url)s\" target=\"_blank\">report any bugs</a> that you encounter."
-msgstr ""
-
-#: src/olympia/devhub/templates/devhub/versions/list.html:305
+#: src/olympia/devhub/templates/devhub/versions/list.html:303
 msgid "Unlisting an add-on is irreversible!"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:305
+#: src/olympia/devhub/templates/devhub/versions/list.html:303
 msgid "An unlisted add-on cannot be switched to be listed."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:307
+#: src/olympia/devhub/templates/devhub/versions/list.html:305
 msgid "Are you sure you wish to unlist your add-on?"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:330
+#: src/olympia/devhub/templates/devhub/versions/list.html:328
 msgid "Canceling your review request will leave your add-on as preliminarily reviewed."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:335
+#: src/olympia/devhub/templates/devhub/versions/list.html:333
 msgid "Canceling your review request will mark your add-on incomplete. If you do not complete your add-on after several days by re-requesting review, it will be deleted."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:343
+#: src/olympia/devhub/templates/devhub/versions/list.html:341
 msgid "Are you sure you wish to cancel your review request?"
 msgstr ""
 
@@ -7252,19 +7094,19 @@ msgstr ""
 msgid "Search by add-on name / author email"
 msgstr ""
 
-#: src/olympia/editors/forms.py:103
+#: src/olympia/editors/forms.py:103 src/olympia/editors/forms.py:244 src/olympia/editors/forms.py:257
 msgid "yes"
 msgstr ""
 
-#: src/olympia/editors/forms.py:104
+#: src/olympia/editors/forms.py:104 src/olympia/editors/forms.py:244 src/olympia/editors/forms.py:257
 msgid "no"
 msgstr ""
 
-#: src/olympia/editors/forms.py:105
+#: src/olympia/editors/forms.py:105 src/olympia/editors/forms.py:245
 msgid "Admin Flag"
 msgstr ""
 
-#: src/olympia/editors/forms.py:113
+#: src/olympia/editors/forms.py:113 src/olympia/editors/forms.py:253
 msgid "Max. Version"
 msgstr ""
 
@@ -7276,55 +7118,59 @@ msgstr ""
 msgid "Add-on Types"
 msgstr ""
 
-#: src/olympia/editors/forms.py:126 src/olympia/editors/helpers.py:267
+#: src/olympia/editors/forms.py:126 src/olympia/editors/helpers.py:279
 msgid "Platforms"
 msgstr ""
 
+#: src/olympia/editors/forms.py:237
+msgid "Search by add-on name / author email / guid"
+msgstr ""
+
 #. L10n: 0 = platform, 1 = filename, 2 = status message
-#: src/olympia/editors/forms.py:238
+#: src/olympia/editors/forms.py:342
 #, python-format
 msgid "<strong>%s</strong> &middot; %s &middot; %s"
 msgstr ""
 
-#: src/olympia/editors/forms.py:252
+#: src/olympia/editors/forms.py:356
 msgid "Comments:"
 msgstr ""
 
-#: src/olympia/editors/forms.py:256
+#: src/olympia/editors/forms.py:360
 msgid "Operating systems:"
 msgstr ""
 
-#: src/olympia/editors/forms.py:258
+#: src/olympia/editors/forms.py:362
 msgid "Applications:"
 msgstr ""
 
-#: src/olympia/editors/forms.py:260
+#: src/olympia/editors/forms.py:364
 msgid "Notify me the next time this add-on is updated. (Subsequent updates will not generate an email)"
 msgstr ""
 
-#: src/olympia/editors/forms.py:265
+#: src/olympia/editors/forms.py:369
 msgid "Clear Admin Review Flag"
 msgstr ""
 
-#: src/olympia/editors/forms.py:267
+#: src/olympia/editors/forms.py:371
 msgid "Clear more info requested flag"
 msgstr ""
 
-#: src/olympia/editors/forms.py:281
+#: src/olympia/editors/forms.py:385
 msgid "Choose a canned response..."
 msgstr ""
 
 #. L10n: Description of what can be searched for.
-#: src/olympia/editors/forms.py:324
+#: src/olympia/editors/forms.py:423
 msgid "theme name"
 msgstr ""
 
-#: src/olympia/editors/forms.py:350
+#: src/olympia/editors/forms.py:449
 msgid "Someone else is reviewing this theme."
 msgstr ""
 
 #. L10n: Description of what can be searched for.
-#: src/olympia/editors/forms.py:447
+#: src/olympia/editors/forms.py:546
 msgid "app, reviewer, or comment"
 msgstr ""
 
@@ -7340,246 +7186,264 @@ msgstr ""
 msgid "Rejected or Unreviewed"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:123 src/olympia/editors/helpers.py:136
+#: src/olympia/editors/helpers.py:125 src/olympia/editors/helpers.py:138
 msgid "Queue"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:124 src/olympia/editors/templates/editors/base.html:50 src/olympia/editors/templates/editors/base.html:65
+#: src/olympia/editors/helpers.py:126 src/olympia/editors/templates/editors/base.html:50 src/olympia/editors/templates/editors/base.html:65
 msgid "Pending Updates"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:125 src/olympia/editors/templates/editors/base.html:48 src/olympia/editors/templates/editors/base.html:63
+#: src/olympia/editors/helpers.py:127 src/olympia/editors/templates/editors/base.html:48 src/olympia/editors/templates/editors/base.html:63
 msgid "Full Reviews"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:126 src/olympia/editors/templates/editors/base.html:52 src/olympia/editors/templates/editors/base.html:67
+#: src/olympia/editors/helpers.py:128 src/olympia/editors/templates/editors/base.html:52 src/olympia/editors/templates/editors/base.html:67
 msgid "Preliminary Reviews"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:127 src/olympia/editors/templates/editors/base.html:54
+#: src/olympia/editors/helpers.py:129 src/olympia/editors/templates/editors/base.html:54
 msgid "Moderated Reviews"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:128 src/olympia/editors/templates/editors/base.html:46
+#: src/olympia/editors/helpers.py:130 src/olympia/editors/templates/editors/base.html:46
 msgid "Fast Track"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:130
+#: src/olympia/editors/helpers.py:132
 msgid "Pending Themes"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:131 src/olympia/editors/templates/editors/themes/queue.html:4
+#: src/olympia/editors/helpers.py:133 src/olympia/editors/templates/editors/themes/queue.html:4
 msgid "Flagged Themes"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:132
+#: src/olympia/editors/helpers.py:134
 msgid "Update Themes"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:137
+#: src/olympia/editors/helpers.py:139
 msgid "Unlisted Pending Updates"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:138
+#: src/olympia/editors/helpers.py:140
 msgid "Unlisted Full Reviews"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:139
+#: src/olympia/editors/helpers.py:141
 msgid "Unlisted Preliminary Reviews"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:170
+#: src/olympia/editors/helpers.py:142
+msgid "Unlisted All Add-ons"
+msgstr ""
+
+#: src/olympia/editors/helpers.py:173
 msgid "Fast Track ({0})"
 msgid_plural "Fast Track ({0})"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/olympia/editors/helpers.py:175
+#: src/olympia/editors/helpers.py:178
 msgid "Full Review ({0})"
 msgid_plural "Full Reviews ({0})"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/olympia/editors/helpers.py:180
+#: src/olympia/editors/helpers.py:183
 msgid "Pending Update ({0})"
 msgid_plural "Pending Updates ({0})"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/olympia/editors/helpers.py:185
+#: src/olympia/editors/helpers.py:188
 msgid "Preliminary Review ({0})"
 msgid_plural "Preliminary Reviews ({0})"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/olympia/editors/helpers.py:190
+#: src/olympia/editors/helpers.py:193
 msgid "Moderated Review ({0})"
 msgid_plural "Moderated Reviews ({0})"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/olympia/editors/helpers.py:196
+#: src/olympia/editors/helpers.py:199
 msgid "Unlisted Full Review ({0})"
 msgid_plural "Unlisted Full Reviews ({0})"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/olympia/editors/helpers.py:201
+#: src/olympia/editors/helpers.py:204
 msgid "Unlisted Pending Update ({0})"
 msgid_plural "Unlisted Pending Updates ({0})"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/olympia/editors/helpers.py:206
+#: src/olympia/editors/helpers.py:209
 msgid "Unlisted Preliminary Review ({0})"
 msgid_plural "Unlisted Preliminary Reviews ({0})"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/olympia/editors/helpers.py:261
-msgid "Addon"
-msgstr ""
+#: src/olympia/editors/helpers.py:214
+msgid "Unlisted All Add-ons ({0})"
+msgid_plural "Unlisted All Add-ons ({0})"
+msgstr[0] ""
+msgstr[1] ""
 
-#: src/olympia/editors/helpers.py:262
+#: src/olympia/editors/helpers.py:274
 msgid "Type"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:263
+#: src/olympia/editors/helpers.py:275
 msgid "Waiting Time"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:264 src/olympia/editors/templates/editors/review.html:285
+#: src/olympia/editors/helpers.py:276 src/olympia/editors/templates/editors/review.html:285
 msgid "Flags"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:265
+#: src/olympia/editors/helpers.py:277
 msgid "Applications"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:270
+#: src/olympia/editors/helpers.py:282
 msgid "Additional"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:285
+#: src/olympia/editors/helpers.py:302
 msgid "Site Specific"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:287
+#: src/olympia/editors/helpers.py:304
 msgid "Requires External Software"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:289
+#: src/olympia/editors/helpers.py:306
 msgid "Binary Components"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:313
+#: src/olympia/editors/helpers.py:339
 msgid "moments ago"
 msgstr ""
 
 #. L10n: first argument is number of minutes
-#: src/olympia/editors/helpers.py:316
+#: src/olympia/editors/helpers.py:342
 msgid "{0} minute"
 msgid_plural "{0} minutes"
 msgstr[0] ""
 msgstr[1] ""
 
 #. L10n: first argument is number of hours
-#: src/olympia/editors/helpers.py:320
+#: src/olympia/editors/helpers.py:346
 msgid "{0} hour"
 msgid_plural "{0} hours"
 msgstr[0] ""
 msgstr[1] ""
 
 #. L10n: first argument is number of days
-#: src/olympia/editors/helpers.py:324
+#: src/olympia/editors/helpers.py:350
 msgid "{0} day"
 msgid_plural "{0} days"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/olympia/editors/helpers.py:488
+#: src/olympia/editors/helpers.py:364
+msgid "Last Review"
+msgstr ""
+
+#: src/olympia/editors/helpers.py:366
+msgid "Last Update"
+msgstr ""
+
+#: src/olympia/editors/helpers.py:387
+msgid "No Reviews"
+msgstr ""
+
+#: src/olympia/editors/helpers.py:561
 msgid "Push to public"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:490
+#: src/olympia/editors/helpers.py:563
 msgid "Grant full review"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:505
+#: src/olympia/editors/helpers.py:578
 msgid "Request more information"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:508
+#: src/olympia/editors/helpers.py:581
 msgid "Request super-review"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:519
+#: src/olympia/editors/helpers.py:592
 msgid "Grant preliminary review"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:520
+#: src/olympia/editors/helpers.py:593
 msgid "This will mark the files as preliminarily reviewed."
 msgstr ""
 
-#: src/olympia/editors/helpers.py:522
+#: src/olympia/editors/helpers.py:595
 msgid "Use this form to request more information from the author. They will receive an email and be able to answer here. You will be notified by email when they reply."
 msgstr ""
 
-#: src/olympia/editors/helpers.py:526
+#: src/olympia/editors/helpers.py:599
 msgid ""
 "If you have concerns about this add-on's security, copyright issues, or other concerns that an administrator should look into, enter your comments in the area below. They will be sent to "
 "administrators, not the author."
 msgstr ""
 
-#: src/olympia/editors/helpers.py:532
+#: src/olympia/editors/helpers.py:605
 msgid "This will reject the add-on and remove it from the review queue."
 msgstr ""
 
-#: src/olympia/editors/helpers.py:534
-msgid "Make a comment on this version.  The author won't be able to see this."
+#: src/olympia/editors/helpers.py:607
+msgid "Make a comment on this version. The author won't be able to see this."
 msgstr ""
 
-#: src/olympia/editors/helpers.py:538
+#: src/olympia/editors/helpers.py:611
 msgid "This will reject the files and remove them from the review queue."
 msgstr ""
 
-#: src/olympia/editors/helpers.py:542
+#: src/olympia/editors/helpers.py:615
 msgid "This will mark the add-on as preliminarily reviewed. Future versions will undergo preliminary review."
 msgstr ""
 
-#: src/olympia/editors/helpers.py:547
+#: src/olympia/editors/helpers.py:620
 msgid "This will mark the files as preliminarily reviewed. Future versions will undergo preliminary review."
 msgstr ""
 
-#: src/olympia/editors/helpers.py:552
+#: src/olympia/editors/helpers.py:625
 msgid "Retain preliminary review"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:553
+#: src/olympia/editors/helpers.py:626
 msgid "This will retain the add-on as preliminarily reviewed. Future versions will undergo preliminary review."
 msgstr ""
 
-#: src/olympia/editors/helpers.py:558
+#: src/olympia/editors/helpers.py:631
 msgid "This will approve a sandboxed version of a public add-on to appear on the public side."
 msgstr ""
 
-#: src/olympia/editors/helpers.py:561
+#: src/olympia/editors/helpers.py:634
 msgid "This will reject a version of a public add-on and remove it from the queue."
 msgstr ""
 
-#: src/olympia/editors/helpers.py:564
+#: src/olympia/editors/helpers.py:637
 msgid "This will mark the add-on and its most recent version and files as public. Future versions will go into the sandbox until they are reviewed by an editor."
 msgstr ""
 
-#: src/olympia/editors/helpers.py:637
+#: src/olympia/editors/helpers.py:714
 msgid "add-on"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:940 src/olympia/editors/helpers.py:960
+#: src/olympia/editors/helpers.py:1020 src/olympia/editors/helpers.py:1040
 msgid "Flagged"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:944 src/olympia/editors/helpers.py:963
+#: src/olympia/editors/helpers.py:1024 src/olympia/editors/helpers.py:1043
 msgid "Updates"
 msgstr ""
 
@@ -7631,56 +7495,56 @@ msgstr ""
 msgid "A question about your Theme submission"
 msgstr ""
 
-#: src/olympia/editors/views.py:144
+#: src/olympia/editors/views.py:146
 msgid "New Add-ons (Under 5 days)"
 msgstr ""
 
-#: src/olympia/editors/views.py:145
+#: src/olympia/editors/views.py:147
 msgid "Passable (5 to 10 days)"
 msgstr ""
 
-#: src/olympia/editors/views.py:146
+#: src/olympia/editors/views.py:148
 msgid "Overdue (Over 10 days)"
 msgstr ""
 
-#: src/olympia/editors/views.py:532
+#: src/olympia/editors/views.py:539
 msgid "An unknown error occurred"
 msgstr ""
 
-#: src/olympia/editors/views.py:587
+#: src/olympia/editors/views.py:592
 msgid "Self-reviews are not allowed."
 msgstr ""
 
-#: src/olympia/editors/views.py:609
+#: src/olympia/editors/views.py:613
 msgid "Review successfully processed."
 msgstr ""
 
-#: src/olympia/editors/views.py:807
+#: src/olympia/editors/views.py:812
 msgid "was approved"
 msgstr ""
 
-#: src/olympia/editors/views.py:808
+#: src/olympia/editors/views.py:813
 msgid "given preliminary review"
 msgstr ""
 
-#: src/olympia/editors/views.py:809
+#: src/olympia/editors/views.py:814
 msgid "rejected"
 msgstr ""
 
-#: src/olympia/editors/views.py:810
+#: src/olympia/editors/views.py:815
 msgctxt "editors_review_history_nominated_adminreview"
 msgid "escalated"
 msgstr ""
 
-#: src/olympia/editors/views.py:812
+#: src/olympia/editors/views.py:817
 msgid "needs more information"
 msgstr ""
 
-#: src/olympia/editors/views.py:813
+#: src/olympia/editors/views.py:818
 msgid "needs super review"
 msgstr ""
 
-#: src/olympia/editors/views.py:814
+#: src/olympia/editors/views.py:819
 msgid "commented"
 msgstr ""
 
@@ -7725,28 +7589,28 @@ msgstr ""
 msgid "Unlisted Queues"
 msgstr ""
 
-#: src/olympia/editors/templates/editors/base.html:72 src/olympia/editors/templates/editors/performance.html:6
+#: src/olympia/editors/templates/editors/base.html:74 src/olympia/editors/templates/editors/performance.html:6
 msgid "Performance"
 msgstr ""
 
-#: src/olympia/editors/templates/editors/base.html:75 src/olympia/editors/templates/editors/themes/base.html:19 src/olympia/editors/templates/editors/themes/base.html:38
+#: src/olympia/editors/templates/editors/base.html:77 src/olympia/editors/templates/editors/themes/base.html:19 src/olympia/editors/templates/editors/themes/base.html:38
 msgid "Logs"
 msgstr ""
 
-#: src/olympia/editors/templates/editors/base.html:78 src/olympia/editors/templates/editors/reviewlog.html:4 src/olympia/editors/templates/editors/reviewlog.html:27
+#: src/olympia/editors/templates/editors/base.html:80 src/olympia/editors/templates/editors/reviewlog.html:4 src/olympia/editors/templates/editors/reviewlog.html:27
 msgid "Add-on Review Log"
 msgstr ""
 
-#: src/olympia/editors/templates/editors/base.html:80 src/olympia/editors/templates/editors/eventlog.html:4 src/olympia/editors/templates/editors/eventlog.html:8
+#: src/olympia/editors/templates/editors/base.html:82 src/olympia/editors/templates/editors/eventlog.html:4 src/olympia/editors/templates/editors/eventlog.html:8
 #: src/olympia/editors/templates/editors/eventlog_detail.html:4
 msgid "Moderated Review Log"
 msgstr ""
 
-#: src/olympia/editors/templates/editors/base.html:82 src/olympia/editors/templates/editors/beta_signed_log.html:4 src/olympia/editors/templates/editors/beta_signed_log.html:8
+#: src/olympia/editors/templates/editors/base.html:84 src/olympia/editors/templates/editors/beta_signed_log.html:4 src/olympia/editors/templates/editors/beta_signed_log.html:8
 msgid "Signed Beta Files Log"
 msgstr ""
 
-#: src/olympia/editors/templates/editors/base.html:87 src/olympia/editors/templates/editors/includes/daily-message.html:4
+#: src/olympia/editors/templates/editors/base.html:89 src/olympia/editors/templates/editors/includes/daily-message.html:4
 msgid "Announcement"
 msgstr ""
 
@@ -7967,45 +7831,45 @@ msgstr ""
 msgid "clear search"
 msgstr ""
 
-#: src/olympia/editors/templates/editors/queue.html:72 src/olympia/editors/templates/editors/queue.html:122
+#: src/olympia/editors/templates/editors/queue.html:78 src/olympia/editors/templates/editors/queue.html:128
 msgid "Process Reviews"
 msgstr ""
 
-#: src/olympia/editors/templates/editors/queue.html:80
+#: src/olympia/editors/templates/editors/queue.html:86
 msgid "Moderation actions:"
 msgstr ""
 
-#: src/olympia/editors/templates/editors/queue.html:90
+#: src/olympia/editors/templates/editors/queue.html:96
 #, python-format
 msgid "by %(user)s on %(date)s %(stars)s (%(locale)s)"
 msgstr ""
 
-#: src/olympia/editors/templates/editors/queue.html:106
+#: src/olympia/editors/templates/editors/queue.html:112
 #, python-format
 msgid "<strong>%(reason)s</strong> <span class=\"light\">Flagged by %(user)s on %(date)s</span>"
 msgstr ""
 
-#: src/olympia/editors/templates/editors/queue.html:119
-msgid "All reviews have been moderated.  Good work!"
+#: src/olympia/editors/templates/editors/queue.html:125
+msgid "All reviews have been moderated. Good work!"
 msgstr ""
 
-#: src/olympia/editors/templates/editors/queue.html:161
+#: src/olympia/editors/templates/editors/queue.html:167
 msgid "Version Notes / Notes for Reviewer"
 msgstr ""
 
-#: src/olympia/editors/templates/editors/queue.html:169
+#: src/olympia/editors/templates/editors/queue.html:175
 msgid "There are currently no add-ons of this type to review."
 msgstr ""
 
-#: src/olympia/editors/templates/editors/queue.html:181 src/olympia/editors/templates/editors/themes/queue_list.html:85
+#: src/olympia/editors/templates/editors/queue.html:187 src/olympia/editors/templates/editors/themes/queue_list.html:85
 msgid "Helpful Links:"
 msgstr ""
 
-#: src/olympia/editors/templates/editors/queue.html:182
+#: src/olympia/editors/templates/editors/queue.html:188
 msgid "Add-on Policy"
 msgstr ""
 
-#: src/olympia/editors/templates/editors/queue.html:184
+#: src/olympia/editors/templates/editors/queue.html:190
 msgid "Editors' Guide"
 msgstr ""
 
@@ -8068,10 +7932,7 @@ msgid "<strong>Warning!</strong> Another user was viewing this page before you."
 msgstr ""
 
 #: src/olympia/editors/templates/editors/review.html:237
-msgid ""
-"The whiteboard is the place to exchange information relevant to\n"
-"               this addon (whatever the version), between the developer and the\n"
-"               editor. This is visible and editable by both."
+msgid "The whiteboard is the place to exchange information relevant to this addon (whatever the version), between the developer and the editor. This is visible and editable by both."
 msgstr ""
 
 #: src/olympia/editors/templates/editors/review.html:241
@@ -8345,7 +8206,7 @@ msgstr ""
 msgid "Describe your reason for flagging"
 msgstr ""
 
-#: src/olympia/files/forms.py:88
+#: src/olympia/files/forms.py:90
 msgid "Cannot diff a version against itself"
 msgstr ""
 
@@ -8380,51 +8241,51 @@ msgstr ""
 msgid "There was an error accessing file %s."
 msgstr ""
 
-#: src/olympia/files/utils.py:343
+#: src/olympia/files/utils.py:340
 msgid "Could not parse uploaded file."
 msgstr ""
 
-#: src/olympia/files/utils.py:380
+#: src/olympia/files/utils.py:377
 msgid "Invalid file name in archive: {0}"
 msgstr ""
 
-#: src/olympia/files/utils.py:388
+#: src/olympia/files/utils.py:385
 msgid "File exceeding size limit in archive: {0}"
 msgstr ""
 
-#: src/olympia/files/utils.py:439
+#: src/olympia/files/utils.py:436
 msgid "Invalid archive."
 msgstr ""
 
-#: src/olympia/files/utils.py:529 src/olympia/files/utils.py:532
+#: src/olympia/files/utils.py:526 src/olympia/files/utils.py:529
 msgid "Could not parse the manifest file."
 msgstr ""
 
-#: src/olympia/files/utils.py:551
+#: src/olympia/files/utils.py:548
 msgid "Could not find an add-on ID."
 msgstr ""
 
-#: src/olympia/files/utils.py:554
+#: src/olympia/files/utils.py:551
 msgid "Add-on ID must be 64 characters or less."
 msgstr ""
 
-#: src/olympia/files/utils.py:556
+#: src/olympia/files/utils.py:553
 msgid "Add-on ID doesn't match add-on."
 msgstr ""
 
-#: src/olympia/files/utils.py:564
+#: src/olympia/files/utils.py:561
 msgid "Duplicate add-on ID found."
 msgstr ""
 
-#: src/olympia/files/utils.py:567
+#: src/olympia/files/utils.py:564
 msgid "Version numbers should have fewer than 32 characters."
 msgstr ""
 
-#: src/olympia/files/utils.py:570
+#: src/olympia/files/utils.py:567
 msgid "Version numbers should only contain letters, numbers, and these punctuation characters: +*.-_."
 msgstr ""
 
-#: src/olympia/files/utils.py:587
+#: src/olympia/files/utils.py:584
 msgid "<em:type> doesn't match add-on"
 msgstr ""
 
@@ -8523,6 +8384,10 @@ msgstr ""
 
 #: src/olympia/files/templates/files/viewer.html:134
 msgid "Fetching file."
+msgstr ""
+
+#: src/olympia/legacy_api/views.py:255
+msgid "Not implemented yet."
 msgstr ""
 
 #: src/olympia/lib/constants.py:6
@@ -9181,10 +9046,6 @@ msgstr ""
 msgid "Zimbabwe Dollar"
 msgstr ""
 
-#: src/olympia/lib/video/ffmpeg.py:112 src/olympia/lib/video/totem.py:81
-msgid "Videos must be in WebM."
-msgstr ""
-
 #: src/olympia/pages/templates/pages/about.lhtml:3 src/olympia/pages/templates/pages/about.lhtml:10
 msgid "About Mozilla Add-ons"
 msgstr ""
@@ -9196,7 +9057,7 @@ msgstr ""
 #: src/olympia/pages/templates/pages/about.lhtml:13
 msgid ""
 "addons.mozilla.org, commonly known as \"AMO\", is Mozilla's official site for add-ons to Mozilla software, such as Firefox, Thunderbird, and SeaMonkey. Add-ons let you add new features and change "
-"the way your browser or application works.  Take a look around and explore the thousands of ways to customize the way you do things online."
+"the way your browser or application works. Take a look around and explore the thousands of ways to customize the way you do things online."
 msgstr ""
 
 #: src/olympia/pages/templates/pages/about.lhtml:19
@@ -9541,7 +9402,7 @@ msgstr ""
 msgid ""
 "Yes. It's possible, but some of the functionality provided by these libraries are available through XPCOM, XUL, and JavaScript. In addition, authors should take care if libraries modify primitive "
 "object prototypes (String.prototype, Date.prototype, etc.) and/or define global functions (eg. the $ function). These are prone to cause conflict with other add-ons, in particular if different add-"
-"ons use different versions of libraries and so on. Developers need to be very, very careful with using them.  Mozilla does not offer documentation on using them to build add-ons."
+"ons use different versions of libraries and so on. Developers need to be very, very careful with using them. Mozilla does not offer documentation on using them to build add-ons."
 msgstr ""
 
 #: src/olympia/pages/templates/pages/dev_faq.html:165
@@ -9655,8 +9516,8 @@ msgstr ""
 #, python-format
 msgid ""
 "Yes. Many developers choose to host their own add-ons. Choosing to host your add-on on <a href=\"%(amo_url)s\">Mozilla's add-on site</a>, though, allows for much greater exposure to your add-on due "
-"to the large volume of visitors to the site.  <a href=\"%(md_url)s\">mozdev.org</a> offers free project hosting for Mozilla applications and extensions providing developers with tools to help "
-"manage source code, version control, bug tracking and documentation."
+"to the large volume of visitors to the site. <a href=\"%(md_url)s\">mozdev.org</a> offers free project hosting for Mozilla applications and extensions providing developers with tools to help manage "
+"source code, version control, bug tracking and documentation."
 msgstr ""
 
 #: src/olympia/pages/templates/pages/dev_faq.html:277
@@ -9704,7 +9565,7 @@ msgstr ""
 #: src/olympia/pages/templates/pages/dev_faq.html:314
 #, python-format
 msgid ""
-"Yes. Mozilla's <a href=\"%(p_url)s\">Add-on Policy</a> describes what is an acceptable submission. This policy is subject to change without notice.  In addition, the AMO editorial team uses the <a "
+"Yes. Mozilla's <a href=\"%(p_url)s\">Add-on Policy</a> describes what is an acceptable submission. This policy is subject to change without notice. In addition, the AMO editorial team uses the <a "
 "href=\"%(g_url)s\">Editors Reviewing Guide</a> to ensure that your add-on meets specific guidelines for functionality and security."
 msgstr ""
 
@@ -9821,7 +9682,7 @@ msgstr ""
 #: src/olympia/pages/templates/pages/dev_faq.html:434
 #, python-format
 msgid ""
-"This is why it's very important to read the <a href=\"%(g_url)s\">Editors Reviewing Guide</a> to ensure that your add-on is setup as expected.  It's also a good idea to read the blog post, <a href="
+"This is why it's very important to read the <a href=\"%(g_url)s\">Editors Reviewing Guide</a> to ensure that your add-on is setup as expected. It's also a good idea to read the blog post, <a href="
 "\"%(blog_url)s\">Successfully Getting your Add-on Reviewed</a> which provides excellent insight into ensuring a smooth review of your add-on."
 msgstr ""
 
@@ -9928,7 +9789,7 @@ msgstr ""
 
 #: src/olympia/pages/templates/pages/dev_faq.html:572
 msgid ""
-"Free Software Foundation provides short summaries of the key open source licenses, including whether the license qualifies as a free software license or a copyleft license.  Also includes a "
+"Free Software Foundation provides short summaries of the key open source licenses, including whether the license qualifies as a free software license or a copyleft license. Also includes a "
 "discussion of what constitutes a free software license or a copyleft license (e.g., a Copyleft license is a general method for making a program or other work free, and requiring all modified and "
 "extended versions of the program to be free as well.)"
 msgstr ""
@@ -10106,19 +9967,13 @@ msgid "Add-on Gallery"
 msgstr ""
 
 #: src/olympia/pages/templates/pages/faq.html:171
-msgid ""
-"How do I choose between add-ons that seem to do the same\n"
-"    thing?"
+msgid "How do I choose between add-ons that seem to do the same thing?"
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:173
+#: src/olympia/pages/templates/pages/faq.html:172
 msgid ""
-"There are often several add-ons that have similar features. To\n"
-"    figure out which is right for you, read the entire description of the\n"
-"    add-on and view its screenshots. If there are still several in the running,\n"
-"    read through the add-on's ratings, user reviews, and statistics to see\n"
-"    which is most liked by other users. Remember that you can also just try\n"
-"    out both and see which you like better."
+"There are often several add-ons that have similar features. To figure out which is right for you, read the entire description of the add-on and view its screenshots. If there are still several in "
+"the running, read through the add-on's ratings, user reviews, and statistics to see which is most liked by other users. Remember that you can also just try out both and see which you like better."
 msgstr ""
 
 #: src/olympia/pages/templates/pages/faq.html:180
@@ -10159,80 +10014,67 @@ msgid "How much do add-ons cost to purchase?"
 msgstr ""
 
 #: src/olympia/pages/templates/pages/faq.html:207
-msgid ""
-"Add-ons hosted in our gallery are free unless clearly marked\n"
-"    otherwise."
+msgid "Add-ons hosted in our gallery are free unless clearly marked otherwise."
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:210
+#: src/olympia/pages/templates/pages/faq.html:209
 msgid "What does it mean when an add-on asks for contributions?"
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:211
+#: src/olympia/pages/templates/pages/faq.html:210
 msgid ""
-"Some add-on authors request users who enjoy an add-on to\n"
-"        contribute to its development by making a monetary contribution. These\n"
-"        contributions go directly to the developer unless a third party is\n"
-"        indicated, such as the non-profit Mozilla Foundation."
+"Some add-on authors request users who enjoy an add-on to contribute to its development by making a monetary contribution. These contributions go directly to the developer unless a third party is "
+"indicated, such as the non-profit Mozilla Foundation."
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:216
+#: src/olympia/pages/templates/pages/faq.html:215
 msgid "What are beta add-ons?"
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:218
+#: src/olympia/pages/templates/pages/faq.html:217
 msgid ""
-"Beta add-ons are unreviewed versions which represent the\n"
-"        latest work of an add-on author. While different authors have different\n"
-"        standards for beta code quality, you should assume that these add-ons\n"
-"        are less stable than the general add-on releases."
+"Beta add-ons are unreviewed versions which represent the latest work of an add-on author. While different authors have different standards for beta code quality, you should assume that these add-"
+"ons are less stable than the general add-on releases."
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:222
+#: src/olympia/pages/templates/pages/faq.html:221
 msgid ""
 "Please note that when you install an add-on from the \"Beta Version\" section of an add-on's listing, you will continue to receive updates for that add-on as they become available. Like the initial "
 "version you installed, all beta releases are unreviewed by Mozilla and may harm your computer."
 msgstr ""
 
+#: src/olympia/pages/templates/pages/faq.html:228
+msgid "What does it mean when an add-on is flagged as slow?"
+msgstr ""
+
 #: src/olympia/pages/templates/pages/faq.html:229
-msgid ""
-"What does it mean when an add-on is flagged as\n"
-"    slow?"
+msgid "Most add-ons load code and resources at the same time Firefox is starting up. In most cases the impact in start-up time is minimal, but some add-ons can cause a noticeable slowdown."
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:231
-msgid ""
-"Most add-ons load code and resources at the same time Firefox\n"
-"        is starting up. In most cases the impact in start-up time is minimal,\n"
-"        but some add-ons can cause a noticeable slowdown."
-msgstr ""
-
-#: src/olympia/pages/templates/pages/faq.html:236
+#: src/olympia/pages/templates/pages/faq.html:234
 msgid "How do I report an inappropriate or spam user review?"
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:237
+#: src/olympia/pages/templates/pages/faq.html:235
 msgid ""
-"To report a user review of an add-on, log in with your account\n"
-"    and visit the add-on's reviews page. Find the review you wish to report,\n"
-"    click \"Report this review\" and select a reason. Our editorial team will\n"
-"    investigate the review and take appropriate action."
+"To report a user review of an add-on, log in with your account and visit the add-on's reviews page. Find the review you wish to report, click \"Report this review\" and select a reason. Our "
+"editorial team will investigate the review and take appropriate action."
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:242
+#: src/olympia/pages/templates/pages/faq.html:240
 msgid "How do I report a bug or contact the Mozilla Add-ons team?"
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:243
+#: src/olympia/pages/templates/pages/faq.html:241
 #, python-format
 msgid "Please visit our <a href=\"%(contact_url)s\">Contact page</a>."
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:246
+#: src/olympia/pages/templates/pages/faq.html:244
 msgid "What is a Source Code License?"
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:247
+#: src/olympia/pages/templates/pages/faq.html:245
 #, python-format
 msgid ""
 "The source code used to create an add-on is an exclusive copyright of the add-on author, unless otherwise declared in a source code license. Many add-ons on this site have <a href=\"%(url)s\" lang="
@@ -10240,60 +10082,60 @@ msgid ""
 "the GPL or BSD licenses instead of making up their own."
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:256
+#: src/olympia/pages/templates/pages/faq.html:254
 #, python-format
 msgid "Firefox and other Mozilla software are <a href=\"%(url)s\">open source</a>."
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:264
+#: src/olympia/pages/templates/pages/faq.html:262
 msgid "Collections and Favorites"
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:267
+#: src/olympia/pages/templates/pages/faq.html:265
 msgid "What is a collection?"
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:268
+#: src/olympia/pages/templates/pages/faq.html:266
 msgid "Collections are groups of related add-ons created by users to share."
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:270
+#: src/olympia/pages/templates/pages/faq.html:268
 msgid "What is the My Favorites collection?"
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:271
+#: src/olympia/pages/templates/pages/faq.html:269
 msgid "Favorite add-ons are add-ons that you have bookmarked to easily get back to later. You can add an add-on to your favorites collection by clicking \"Add to favorites\" on its details page."
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:275 src/olympia/templates/menu_links.html:13 src/olympia/templates/impala/header_title.html:17
+#: src/olympia/pages/templates/pages/faq.html:273 src/olympia/templates/menu_links.html:13 src/olympia/templates/impala/header_title.html:17
 msgid "Mobile Add-ons"
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:278
+#: src/olympia/pages/templates/pages/faq.html:276
 msgid "What are mobile add-ons?"
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:279
+#: src/olympia/pages/templates/pages/faq.html:277
 #, python-format
 msgid ""
 "Mobile add-ons work with <a href=\"%(mobile_url)s\">Firefox for Mobile</a> and add or modify functionality just like desktop add-ons. You can find add-ons that work with Firefox for Mobile in our "
 "<a href=\"%(gallery_url)s\">gallery</a>."
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:288
+#: src/olympia/pages/templates/pages/faq.html:286
 msgid "Developer Topics"
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:289
+#: src/olympia/pages/templates/pages/faq.html:287
 #, python-format
 msgid "Please see our <a href=\"%(faq_url)s\">Developer FAQ</a> and <a href=\"%(hub_url)s\">Developer Hub</a> for answers to add-on developer-related questions."
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:294
+#: src/olympia/pages/templates/pages/faq.html:292
 msgid "Still have questions?"
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:295
+#: src/olympia/pages/templates/pages/faq.html:293
 #, python-format
 msgid "For general Firefox support, visit our <a href=\"%(sumo_url)s\">support website</a>. For general add-on and website questions, visit our <a href=\"%(forum_url)s\">forum</a>."
 msgstr ""
@@ -10431,7 +10273,7 @@ msgstr ""
 
 #: src/olympia/pages/templates/pages/sunbird.html:29
 msgid ""
-"Development on the Sunbird project has halted and its final release was on March 30, 2010.  We've been proud to host Sunbird add-ons on this site but as the project is no longer maintained we have "
+"Development on the Sunbird project has halted and its final release was on March 30, 2010. We've been proud to host Sunbird add-ons on this site but as the project is no longer maintained we have "
 "disabled our support for the add-ons."
 msgstr ""
 
@@ -10509,7 +10351,7 @@ msgstr ""
 #, python-format
 msgid ""
 "<h2>Keep these tips in mind:</h2> <ul> <li> Write like you're telling a friend about your experience with the add-on. Give specifics and helpful details, such as what features you liked and/or "
-"disliked, how easy to use it is, and any disadvantages it has.  Avoid generic language such as calling it \"Great\" or \"Bad\" unless you can give reasons why you believe this is so. </li> <li> "
+"disliked, how easy to use it is, and any disadvantages it has. Avoid generic language such as calling it \"Great\" or \"Bad\" unless you can give reasons why you believe this is so. </li> <li> "
 "Please do not post bug reports in reviews. We do not make your email address available to add-on developers and they may need to contact you to help resolve your issue. See the <a href=\"%(support)s"
 "\">support section</a> to find out where to get assistance for this add-on. </li> <li>Please keep reviews clean, avoid the use of improper language and do not post any personal information. </li> </"
 "ul> <p>Please read the <a href=\"%(guide)s\" target=\"_blank\">Review Guidelines</a> for more detail about user add-on reviews.</p>"
@@ -10745,16 +10587,16 @@ msgstr ""
 
 #. L10n: {0} is an application, such as Firefox. This means "any version of
 #. Firefox."
-#: src/olympia/search/views.py:554
+#: src/olympia/search/views.py:547
 msgid "Any {0}"
 msgstr ""
 
 #. L10n: "All Systems" means show everything regardless of platform.
-#: src/olympia/search/views.py:589
+#: src/olympia/search/views.py:582
 msgid "All Systems"
 msgstr ""
 
-#: src/olympia/search/views.py:600
+#: src/olympia/search/views.py:593
 msgid "All Tags"
 msgstr ""
 
@@ -10928,31 +10770,31 @@ msgstr ""
 msgid "Share this Collection"
 msgstr ""
 
-#: src/olympia/signing/views.py:30 src/olympia/templates/base.html:75 src/olympia/templates/impala/base.html:115
+#: src/olympia/signing/views.py:33 src/olympia/templates/base.html:71 src/olympia/templates/impala/base.html:112
 msgid "Some features are temporarily disabled while we perform website maintenance. We'll be back to full capacity shortly."
 msgstr ""
 
-#: src/olympia/signing/views.py:53
+#: src/olympia/signing/views.py:56
 msgid "Could not find add-on with id \"{}\"."
 msgstr ""
 
-#: src/olympia/signing/views.py:67
+#: src/olympia/signing/views.py:70
 msgid "You do not own this addon."
 msgstr ""
 
-#: src/olympia/signing/views.py:82
+#: src/olympia/signing/views.py:87
 msgid "Missing \"upload\" key in multipart file data."
 msgstr ""
 
-#: src/olympia/signing/views.py:96
+#: src/olympia/signing/views.py:101
 msgid "Version does not match the manifest file."
 msgstr ""
 
-#: src/olympia/signing/views.py:100
+#: src/olympia/signing/views.py:105
 msgid "Version already exists."
 msgstr ""
 
-#: src/olympia/signing/views.py:136
+#: src/olympia/signing/views.py:141
 msgid "No uploaded file for that addon and version."
 msgstr ""
 
@@ -11065,89 +10907,89 @@ msgstr ""
 msgid "Statistics Dashboard :: Add-ons for {0}"
 msgstr ""
 
-#: src/olympia/stats/templates/stats/stats.html:30
-msgid "Controls:"
-msgstr ""
-
-#: src/olympia/stats/templates/stats/stats.html:33
-msgid "reset zoom"
-msgstr ""
-
-#: src/olympia/stats/templates/stats/stats.html:40
-msgid "Group by:"
-msgstr ""
-
-#: src/olympia/stats/templates/stats/stats.html:42
-msgid "day"
-msgstr ""
-
-#: src/olympia/stats/templates/stats/stats.html:45
-msgid "week"
-msgstr ""
-
-#: src/olympia/stats/templates/stats/stats.html:48
-msgid "month"
-msgstr ""
-
-#: src/olympia/stats/templates/stats/stats.html:54
-msgid "For last:"
-msgstr ""
-
-#: src/olympia/stats/templates/stats/stats.html:57
-msgid "7 days"
-msgstr ""
-
-#: src/olympia/stats/templates/stats/stats.html:60
-msgid "30 days"
-msgstr ""
-
-#: src/olympia/stats/templates/stats/stats.html:63
-msgid "90 days"
-msgstr ""
-
-#: src/olympia/stats/templates/stats/stats.html:66
-msgid "365 days"
-msgstr ""
-
-#: src/olympia/stats/templates/stats/stats.html:69
-msgid "Custom..."
-msgstr ""
-
 #. {0} is an add-on name
-#: src/olympia/stats/templates/stats/stats.html:88 src/olympia/stats/templates/stats/stats.html:91
+#: src/olympia/stats/templates/stats/stats.html:44 src/olympia/stats/templates/stats/stats.html:47
 msgid "Statistics for {0}"
 msgstr ""
 
-#: src/olympia/stats/templates/stats/stats.html:94
+#: src/olympia/stats/templates/stats/stats.html:50
 msgid "Statistics Dashboard"
 msgstr ""
 
-#: src/olympia/stats/templates/stats/stats.html:104
+#: src/olympia/stats/templates/stats/stats.html:57
+msgid "Controls:"
+msgstr ""
+
+#: src/olympia/stats/templates/stats/stats.html:60
+msgid "reset zoom"
+msgstr ""
+
+#: src/olympia/stats/templates/stats/stats.html:67
+msgid "Group by:"
+msgstr ""
+
+#: src/olympia/stats/templates/stats/stats.html:69
+msgid "day"
+msgstr ""
+
+#: src/olympia/stats/templates/stats/stats.html:72
+msgid "week"
+msgstr ""
+
+#: src/olympia/stats/templates/stats/stats.html:75
+msgid "month"
+msgstr ""
+
+#: src/olympia/stats/templates/stats/stats.html:81
+msgid "For last:"
+msgstr ""
+
+#: src/olympia/stats/templates/stats/stats.html:84
+msgid "7 days"
+msgstr ""
+
+#: src/olympia/stats/templates/stats/stats.html:87
+msgid "30 days"
+msgstr ""
+
+#: src/olympia/stats/templates/stats/stats.html:90
+msgid "90 days"
+msgstr ""
+
+#: src/olympia/stats/templates/stats/stats.html:93
+msgid "365 days"
+msgstr ""
+
+#: src/olympia/stats/templates/stats/stats.html:96
+msgid "Custom..."
+msgstr ""
+
+#: src/olympia/stats/templates/stats/stats.html:106
 msgid "Statistics processing is currently disabled, so recent data is unavailable. The statistics are still being collected and this page will be updated soon with the missing data."
 msgstr ""
 
-#: src/olympia/stats/templates/stats/stats.html:110
+#: src/olympia/stats/templates/stats/stats.html:112
 msgid "Loading the latest data&hellip;"
 msgstr ""
 
-#: src/olympia/stats/templates/stats/stats.html:142 src/olympia/stats/templates/stats/reports/overview.html:25 src/olympia/stats/templates/stats/reports/overview.html:37
+#: src/olympia/stats/templates/stats/stats.html:144 src/olympia/stats/templates/stats/reports/overview.html:25 src/olympia/stats/templates/stats/reports/overview.html:37
 #: src/olympia/stats/templates/stats/reports/overview.html:49
 msgid "No data available."
 msgstr ""
 
-#: src/olympia/stats/templates/stats/stats.html:177
+#: src/olympia/stats/templates/stats/stats.html:179
 msgid "This dashboard is currently <b>public</b>."
 msgstr ""
 
-#: src/olympia/stats/templates/stats/stats.html:179
+#: src/olympia/stats/templates/stats/stats.html:181
 msgid "Contribution stats are currently <b>private</b>."
 msgstr ""
 
-#: src/olympia/stats/templates/stats/stats.html:182
+#: src/olympia/stats/templates/stats/stats.html:184
 msgid "This dashboard is currently <b>private</b>."
 msgstr ""
 
-#: src/olympia/stats/templates/stats/stats.html:185
+#: src/olympia/stats/templates/stats/stats.html:187
 msgid "Change settings."
 msgstr ""
 
@@ -11299,15 +11141,6 @@ msgstr ""
 msgid "Application versions by Date"
 msgstr ""
 
-#: src/olympia/tags/templates/tags/top_cloud.html:4
-msgid "Top {0} Tags"
-msgstr ""
-
-#. {0} is the current application name
-#: src/olympia/tags/templates/tags/top_cloud.html:14
-msgid "{0} Top Tags"
-msgstr ""
-
 #: src/olympia/templates/amo_footer.html:6 src/olympia/templates/includes/lang_switcher.html:2
 msgid "Other languages"
 msgstr ""
@@ -11316,11 +11149,11 @@ msgstr ""
 msgid "Mozilla Add-ons"
 msgstr ""
 
-#: src/olympia/templates/base.html:91 src/olympia/templates/impala/base.html:81
+#: src/olympia/templates/base.html:89 src/olympia/templates/impala/base.html:78
 msgid "Find add-ons for other applications"
 msgstr ""
 
-#: src/olympia/templates/base.html:92 src/olympia/templates/impala/base.html:81
+#: src/olympia/templates/base.html:90 src/olympia/templates/impala/base.html:78
 msgid "Other Applications"
 msgstr ""
 
@@ -11345,7 +11178,7 @@ msgid "View Mobile Site"
 msgstr ""
 
 #: src/olympia/templates/copyright.html:7
-msgid "Site Status "
+msgid "Site Status"
 msgstr ""
 
 #: src/olympia/templates/footer.html:3
@@ -11445,35 +11278,35 @@ msgstr ""
 msgid "<a href=\"%(reg)s\">Register</a> or <a href=\"%(login)s\">Log in</a>"
 msgstr ""
 
-#: src/olympia/templates/impala/base.html:126
+#: src/olympia/templates/impala/base.html:123
 #, python-format
 msgid "To try the thousands of add-ons available here, download <a href=\"%(url)s\">Mozilla Firefox</a>, a fast, free way to surf the Web!"
 msgstr ""
 
-#: src/olympia/templates/impala/base.html:138
+#: src/olympia/templates/impala/base.html:135
 #, python-format
 msgid "Add-ons is switching to Firefox Accounts for login. <a href=\"%(url)s\" class=\"fxa-login\">Sign in now to transfer your account.</a>"
 msgstr ""
 
 #. {0} is an application, such as Firefox.
-#: src/olympia/templates/impala/base.html:148
+#: src/olympia/templates/impala/base.html:145
 msgid "Welcome to {0} Add-ons."
 msgstr ""
 
-#: src/olympia/templates/impala/base.html:151
+#: src/olympia/templates/impala/base.html:148
 msgid "Choose from thousands of extra features and styles to make Firefox your own."
 msgstr ""
 
-#: src/olympia/templates/impala/base.html:156
+#: src/olympia/templates/impala/base.html:153
 #, python-format
 msgid "Add extra features and styles to make %(app)s your own."
 msgstr ""
 
-#: src/olympia/templates/impala/base.html:164
+#: src/olympia/templates/impala/base.html:161
 msgid "On the go?"
 msgstr ""
 
-#: src/olympia/templates/impala/base.html:166
+#: src/olympia/templates/impala/base.html:163
 msgid "Check out our <a class=\"mobile-link\" href=\"#\">Mobile Add-ons site</a>."
 msgstr ""
 
@@ -11697,19 +11530,19 @@ msgstr ""
 
 #. L10n: {id} will be something like "13ad6a", just a random number
 #. to differentiate this user from other anonymous users.
-#: src/olympia/users/models.py:353
+#: src/olympia/users/models.py:362
 msgid "Anonymous user {id}"
 msgstr ""
 
-#: src/olympia/users/models.py:410
+#: src/olympia/users/models.py:419
 msgid "Your account has been restricted"
 msgstr ""
 
-#: src/olympia/users/models.py:480
+#: src/olympia/users/models.py:489
 msgid "Please confirm your email address"
 msgstr ""
 
-#: src/olympia/users/models.py:506
+#: src/olympia/users/models.py:515
 msgid "My Mobile Add-ons"
 msgstr ""
 
@@ -11986,7 +11819,7 @@ msgstr ""
 
 #: src/olympia/users/templates/users/edit.html:70
 #, python-format
-msgid "Change your password.  If you forgot your password, you can <a href=\"%(reset_url)s\">use the reset form</a>."
+msgid "Change your password. If you forgot your password, you can <a href=\"%(reset_url)s\">use the reset form</a>."
 msgstr ""
 
 #: src/olympia/users/templates/users/edit.html:76
@@ -12006,7 +11839,7 @@ msgid "Profile"
 msgstr ""
 
 #: src/olympia/users/templates/users/edit.html:100
-msgid "Give us a bit more information about yourself.  All these fields are optional, but they'll help other users get to know you better."
+msgid "Give us a bit more information about yourself. All these fields are optional, but they'll help other users get to know you better."
 msgstr ""
 
 #: src/olympia/users/templates/users/edit.html:124
@@ -12222,7 +12055,7 @@ msgid "Confirm password"
 msgstr ""
 
 #: src/olympia/users/templates/users/pwreset_confirm.html:47
-msgid "The password reset link was invalid, possibly because it has already been used.  Please request a new password reset."
+msgid "The password reset link was invalid, possibly because it has already been used. Please request a new password reset."
 msgstr ""
 
 #: src/olympia/users/templates/users/pwreset_request.html:15
@@ -12408,7 +12241,7 @@ msgstr ""
 
 #: src/olympia/users/templates/users/unsubscribe.html:30
 #, python-format
-msgid "Unfortunately, we weren't able to unsubscribe you.  The link you clicked is invalid. However, you can unsubscribe still unsubscribe on your <a href=\"%(edit_url)s\">edit profile page</a>."
+msgid "Unfortunately, we weren't able to unsubscribe you. The link you clicked is invalid. However, you can unsubscribe still unsubscribe on your <a href=\"%(edit_url)s\">edit profile page</a>."
 msgstr ""
 
 #: src/olympia/users/templates/users/vcard.html:2
@@ -12462,15 +12295,15 @@ msgstr ""
 msgid "Version History with Changelogs"
 msgstr ""
 
-#: src/olympia/versions/models.py:314
+#: src/olympia/versions/models.py:313
 msgid "Add-on uses binary components."
 msgstr ""
 
-#: src/olympia/versions/models.py:317
+#: src/olympia/versions/models.py:316
 msgid "Add-on has opted into strict compatibility checking."
 msgstr ""
 
-#: src/olympia/versions/models.py:715
+#: src/olympia/versions/models.py:711
 msgid "{app} {min} and later"
 msgstr ""
 
@@ -12545,4 +12378,8 @@ msgstr ""
 
 #: src/olympia/zadmin/forms.py:105
 msgid "Log emails instead of sending"
+msgstr ""
+
+#: src/olympia/zadmin/forms.py:215
+msgid "Deleted versions can`t be changed."
 msgstr ""

--- a/locale/si/LC_MESSAGES/djangojs.po
+++ b/locale/si/LC_MESSAGES/djangojs.po
@@ -1,1216 +1,1236 @@
-
 #, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2016-02-24 21:23+0000\n"
+"POT-Creation-Date: 2016-04-18 15:47+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
+"Language: \n"
 "MIME-Version: 1.0\n"
-"Content-Type: text/plain; charset=utf-8\n"
+"Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Generated-By: Babel 2.2.0\n"
 
-#: static/js/common/ratingwidget.js:31
+#: static/js/common-all.js:1426 static/js/impala-all.js:1511 static/js/zamboni/discovery-all.js:12598 static/js/zamboni/init.js:28 static/js/zamboni/mobile-all.js:14945
+msgid "This feature is temporarily disabled while we perform website maintenance. Please check back a little later."
+msgstr ""
+
+#. L10n: {0} is an app name like Firefox.
+#: static/js/common-all.js:1837 static/js/impala-all.js:1922 static/js/zamboni/buttons.js:73 static/js/zamboni/discovery-all.js:13108
+msgid "Accept and Install"
+msgstr ""
+
+#: static/js/common-all.js:1837 static/js/impala-all.js:1922 static/js/zamboni/buttons.js:73 static/js/zamboni/discovery-all.js:13108
+msgid "Add to {0}"
+msgstr ""
+
+#: static/js/common-all.js:1842 static/js/impala-all.js:1927 static/js/zamboni/buttons.js:78 static/js/zamboni/discovery-all.js:13113
+msgid "Download Now"
+msgstr ""
+
+#: static/js/common-all.js:1883 static/js/impala-all.js:1968 static/js/zamboni/buttons.js:119 static/js/zamboni/discovery-all.js:13154
+msgid "Add-on has not been updated to support default-to-compatible."
+msgstr ""
+
+#: static/js/common-all.js:1888 static/js/impala-all.js:1973 static/js/zamboni/buttons.js:124 static/js/zamboni/discovery-all.js:13159
+msgid "You need to be using Firefox 10.0 or higher."
+msgstr ""
+
+#: static/js/common-all.js:1900 static/js/impala-all.js:1985 static/js/zamboni/buttons.js:136 static/js/zamboni/discovery-all.js:13171
+msgid "Mozilla has marked this version as incompatible with your Firefox version."
+msgstr ""
+
+#. L10n: {0} is an platform like Windows or Linux.
+#: static/js/common-all.js:1981 static/js/impala-all.js:2066 static/js/zamboni/buttons.js:217 static/js/zamboni/discovery-all.js:13252
+msgid "Install for {0} anyway"
+msgstr ""
+
+#: static/js/common-all.js:1981 static/js/impala-all.js:2066 static/js/zamboni/buttons.js:217 static/js/zamboni/discovery-all.js:13252
+msgid "Download for {0} anyway"
+msgstr ""
+
+#: static/js/common-all.js:2038 static/js/impala-all.js:2123 static/js/zamboni/buttons.js:274 static/js/zamboni/discovery-all.js:13309
+msgid "Not available for your platform"
+msgstr ""
+
+#. L10n: {0} is an app name, {1} is the app version.
+#: static/js/common-all.js:2049 static/js/common-all.js:2086 static/js/impala-all.js:2134 static/js/impala-all.js:2171 static/js/zamboni/buttons.js:286 static/js/zamboni/buttons.js:324
+#: static/js/zamboni/discovery-all.js:13320 static/js/zamboni/discovery-all.js:13357
+msgid "Not available for {0} {1}"
+msgstr ""
+
+#: static/js/common-all.js:2112 static/js/impala-all.js:2197 static/js/zamboni/buttons.js:351 static/js/zamboni/discovery-all.js:13383
+msgid "Works with {app} {min} - {max}"
+msgstr ""
+
+#: static/js/common-all.js:2114 static/js/impala-all.js:2199 static/js/zamboni/buttons.js:353 static/js/zamboni/discovery-all.js:13385
+msgid "View other versions"
+msgstr ""
+
+#: static/js/common-all.js:2162 static/js/impala-all.js:2247 static/js/zamboni/buttons.js:401 static/js/zamboni/discovery-all.js:13433
+msgid "Only with Firefox — Get Firefox Now!"
+msgstr ""
+
+#: static/js/common-all.js:2278 static/js/impala-all.js:2363 static/js/zamboni/buttons.js:517 static/js/zamboni/discovery-all.js:13549 static/js/zamboni/mobile-all.js:15177
+#: static/js/zamboni/mobile/buttons.js:43
+msgid "Sorry, you need a Mozilla-based browser (such as Firefox) to install a search plugin."
+msgstr ""
+
+#: static/js/common-all.js:9088 static/js/impala-all.js:9649 static/js/zamboni/global.js:410
+msgid "Loading..."
+msgstr ""
+
+#. L10n: {0} is the number of characters left.
+#: static/js/common-all.js:9152 static/js/impala-all.js:9713 static/js/zamboni/global.js:474
+msgid "<b>{0}</b> character left."
+msgid_plural "<b>{0}</b> characters left."
+msgstr[0] ""
+msgstr[1] ""
+
+#: static/js/common-all.js:9589 static/js/common-min.js:6 static/js/impala-all.js:10052 static/js/impala-min.js:6 static/js/common/ratingwidget.js:31 static/js/zamboni/mobile-all.js:16123
+#: static/js/zamboni/mobile-min.js:6
 msgid "{0} star"
 msgid_plural "{0} stars"
 msgstr[0] ""
 msgstr[1] ""
 
-#: static/js/common/upload-addon.js:41 static/js/common/upload-image.js:128
+#: static/js/common-all.js:9676 static/js/common-min.js:6 static/js/impala-all.js:10139 static/js/impala-min.js:6 static/js/zamboni/l10n.js:45
+msgid "Remove this localization"
+msgstr ""
+
+#: static/js/common-all.js:10193 static/js/common-min.js:6 static/js/impala-all.js:10674 static/js/impala-min.js:6 static/js/zamboni/discovery-all.js:13678
+msgid "close"
+msgstr ""
+
+#: static/js/common-all.js:10860 static/js/common-min.js:6 static/js/impala-all.js:11481 static/js/impala-min.js:6 static/js/impala/reviews.js:23 static/js/zamboni/reviews.js:18
+msgid "Flagged for review"
+msgstr ""
+
+#: static/js/common-all.js:10876 static/js/common-min.js:6 static/js/impala-all.js:11498 static/js/impala-min.js:6 static/js/impala/reviews.js:40 static/js/zamboni/reviews.js:34
+msgid "Your input is required"
+msgstr ""
+
+#: static/js/common-all.js:10945 static/js/common-min.js:6 static/js/impala-all.js:11610 static/js/impala-min.js:7 static/js/impala/reviews.js:152 static/js/zamboni/reviews.js:103
+msgid "Marked for deletion"
+msgstr ""
+
+#: static/js/common-all.js:11573 static/js/common-min.js:7 static/js/impala-all.js:13809 static/js/impala-min.js:8 static/js/zamboni/collections.js:229
+msgid "Adding to Favorites&hellip;"
+msgstr ""
+
+#: static/js/common-all.js:11576 static/js/common-min.js:7 static/js/impala-all.js:13812 static/js/impala-min.js:8 static/js/zamboni/collections.js:232
+msgid "Removing Favorite&hellip;"
+msgstr ""
+
+#: static/js/common-all.js:11579 static/js/common-min.js:7 static/js/impala-all.js:13815 static/js/impala-min.js:8 static/js/zamboni/collections.js:235
+msgid "Add to Favorites"
+msgstr ""
+
+#: static/js/common-all.js:11582 static/js/common-min.js:7 static/js/impala-all.js:13818 static/js/impala-min.js:8 static/js/zamboni/collections.js:238
+msgid "Remove from Favorites"
+msgstr ""
+
+#: static/js/common-all.js:11647 static/js/common-min.js:7 static/js/impala-all.js:13883 static/js/impala-min.js:8 static/js/zamboni/collections.js:303
+msgid "Pending"
+msgstr ""
+
+#: static/js/common-all.js:11648 static/js/common-min.js:7 static/js/impala-all.js:13884 static/js/impala-min.js:8 static/js/zamboni/collections.js:304
+msgid "Add a comment"
+msgstr ""
+
+#: static/js/common-all.js:11648 static/js/common-min.js:7 static/js/impala-all.js:13884 static/js/impala-min.js:8 static/js/zamboni/collections.js:304
+msgid "Comment"
+msgstr ""
+
+#: static/js/common-all.js:11649 static/js/common-min.js:7 static/js/impala-all.js:13885 static/js/impala-min.js:8 static/js/zamboni/collections.js:305
+msgid "Remove this add-on from the collection"
+msgstr ""
+
+#: static/js/common-all.js:11649 static/js/common-all.js:11678 static/js/common-min.js:7 static/js/impala-all.js:13885 static/js/impala-all.js:13914 static/js/impala-min.js:8
+#: static/js/zamboni/collections.js:305 static/js/zamboni/collections.js:334
+msgid "Remove"
+msgstr ""
+
+#: static/js/common-all.js:11678 static/js/common-min.js:7 static/js/impala-all.js:13914 static/js/impala-min.js:8 static/js/zamboni/collections.js:334
+msgid "Remove this user as a contributor"
+msgstr ""
+
+#: static/js/common-all.js:11690 static/js/common-min.js:7 static/js/impala-all.js:13926 static/js/impala-min.js:8 static/js/zamboni/collections.js:346
+msgid "An email address is required."
+msgstr ""
+
+#: static/js/common-all.js:11708 static/js/common-min.js:7 static/js/impala-all.js:13944 static/js/impala-min.js:8 static/js/zamboni/collections.js:364
+msgid "You cannot add yourself as a contributor."
+msgstr ""
+
+#: static/js/common-all.js:11710 static/js/common-min.js:7 static/js/impala-all.js:13946 static/js/impala-min.js:8 static/js/zamboni/collections.js:366
+msgid "You have already added that user."
+msgstr ""
+
+#: static/js/common-all.js:11917 static/js/common-min.js:7 static/js/impala-all.js:14153 static/js/impala-min.js:8 static/js/zamboni/collections.js:573
+msgid "Add to favorites"
+msgstr ""
+
+#: static/js/common-all.js:11921 static/js/common-min.js:7 static/js/impala-all.js:14157 static/js/impala-min.js:8 static/js/zamboni/collections.js:577
+msgid "Remove from favorites"
+msgstr ""
+
+#: static/js/common-all.js:11939 static/js/common-min.js:7 static/js/impala-all.js:14175 static/js/impala-all.js:14233 static/js/impala-min.js:8 static/js/impala/collections.js:10
+#: static/js/zamboni/collections.js:595
+msgid "Follow this Collection"
+msgstr ""
+
+#: static/js/common-all.js:11948 static/js/common-min.js:7 static/js/impala-all.js:14184 static/js/impala-min.js:8 static/js/zamboni/collections.js:604
+msgid "Stop following"
+msgstr ""
+
+#: static/js/common-all.js:12096 static/js/common-min.js:7 static/js/zamboni/password-strength.js:20
+msgid "Password strength:"
+msgstr ""
+
+#: static/js/common-all.js:12102 static/js/common-min.js:7 static/js/zamboni/password-strength.js:26
+msgid "At least {0} character left."
+msgid_plural "At least {0} characters left."
+msgstr[0] ""
+msgstr[1] ""
+
+#: static/js/common-all.js:12286 static/js/common-min.js:7 static/js/impala-all.js:14632 static/js/impala-min.js:8 static/js/impala/suggestions.js:39
+msgid "Search themes for <b>{0}</b>"
+msgstr ""
+
+#: static/js/common-all.js:12288 static/js/common-min.js:7 static/js/impala-all.js:14634 static/js/impala-min.js:8 static/js/impala/suggestions.js:41
+msgid "Search apps for <b>{0}</b>"
+msgstr ""
+
+#: static/js/common-all.js:12290 static/js/common-min.js:7 static/js/impala-all.js:14636 static/js/impala-min.js:8 static/js/impala/suggestions.js:43
+msgid "Search add-ons for <b>{0}</b>"
+msgstr ""
+
+#: static/js/common-all.js:12521 static/js/common-min.js:7 static/js/impala-all.js:14867 static/js/impala-min.js:8 static/js/impala/site_suggestions.js:46
+msgid "Category"
+msgstr ""
+
+#. L10n: {0} is an app name.
+#: static/js/impala-all.js:11632 static/js/impala-min.js:7 static/js/impala/listing.js:11 static/js/zamboni/themes.js:13
+msgid "This theme is incompatible with your version of {0}"
+msgstr ""
+
+#: static/js/impala-all.js:12146 static/js/impala-all.js:14331 static/js/impala-min.js:7 static/js/impala-min.js:8 static/js/common/upload-image.js:97 static/js/impala/users.js:51
+#: static/js/zamboni/devhub-all.js:894 static/js/zamboni/devhub-min.js:1
+msgid "Images must be either PNG or JPG."
+msgstr ""
+
+#: static/js/impala-all.js:12150 static/js/impala-min.js:7 static/js/common/upload-image.js:101 static/js/zamboni/devhub-all.js:898 static/js/zamboni/devhub-min.js:1
+msgid "Videos must be in WebM."
+msgstr ""
+
+#: static/js/impala-all.js:12177 static/js/impala-min.js:7 static/js/common/upload-addon.js:41 static/js/common/upload-image.js:128 static/js/zamboni/devhub-all.js:272
+#: static/js/zamboni/devhub-all.js:925 static/js/zamboni/devhub-min.js:1
 msgid "There was a problem contacting the server."
 msgstr ""
 
-#: static/js/common/upload-addon.js:69
+#: static/js/impala-all.js:13298 static/js/impala-min.js:7 static/js/impala/persona_creation.js:60
+msgid "All Rights Reserved"
+msgstr ""
+
+#: static/js/impala-all.js:13302 static/js/impala-min.js:7 static/js/impala/persona_creation.js:64
+msgid "Creative Commons Attribution 3.0"
+msgstr ""
+
+#: static/js/impala-all.js:13307 static/js/impala-min.js:7 static/js/impala/persona_creation.js:69
+msgid "Creative Commons Attribution-NonCommercial 3.0"
+msgstr ""
+
+#: static/js/impala-all.js:13312 static/js/impala-min.js:7 static/js/impala/persona_creation.js:74
+msgid "Creative Commons Attribution-NonCommercial-NoDerivs 3.0"
+msgstr ""
+
+#: static/js/impala-all.js:13317 static/js/impala-min.js:7 static/js/impala/persona_creation.js:79
+msgid "Creative Commons Attribution-NonCommercial-Share Alike 3.0"
+msgstr ""
+
+#: static/js/impala-all.js:13322 static/js/impala-min.js:7 static/js/impala/persona_creation.js:84
+msgid "Creative Commons Attribution-NoDerivs 3.0"
+msgstr ""
+
+#: static/js/impala-all.js:13327 static/js/impala-min.js:7 static/js/impala/persona_creation.js:89
+msgid "Creative Commons Attribution-ShareAlike 3.0"
+msgstr ""
+
+#: static/js/impala-all.js:13530 static/js/impala-min.js:7 static/js/impala/persona_creation.js:292
+msgid "Your Theme's Name"
+msgstr ""
+
+#: static/js/impala-all.js:14242 static/js/impala-min.js:8 static/js/impala/collections.js:19
+msgid "Stop Following"
+msgstr ""
+
+#: static/js/impala-all.js:14243 static/js/impala-min.js:8 static/js/impala/collections.js:20
+msgid "Following"
+msgstr ""
+
+#: static/js/impala-all.js:14313 static/js/impala-min.js:8 static/js/impala/users.js:33
+msgid "use original"
+msgstr ""
+
+#: static/js/impala-all.js:14523 static/js/impala-min.js:8 static/js/impala/search.js:114
+msgid "Updating results&hellip;"
+msgstr ""
+
+#: static/js/common/upload-addon.js:69 static/js/zamboni/devhub-all.js:300 static/js/zamboni/devhub-min.js:1
 msgid "Select a file..."
 msgstr ""
 
-#: static/js/common/upload-addon.js:70
+#: static/js/common/upload-addon.js:70 static/js/zamboni/devhub-all.js:301 static/js/zamboni/devhub-min.js:1
 msgid "Your add-on should end with .xpi, .jar or .xml"
 msgstr ""
 
 #. L10n: {0} is the percent of the file that has been uploaded.
-#: static/js/common/upload-addon.js:104
+#: static/js/common/upload-addon.js:104 static/js/zamboni/devhub-all.js:335 static/js/zamboni/devhub-min.js:1
 #, python-format
 msgid "{0}% complete"
 msgstr ""
 
 #. L10n: "{bytes uploaded} of {total filesize}".
-#: static/js/common/upload-addon.js:107
+#: static/js/common/upload-addon.js:107 static/js/zamboni/devhub-all.js:338 static/js/zamboni/devhub-min.js:1
 msgid "{0} of {1}"
 msgstr ""
 
-#: static/js/common/upload-addon.js:140
+#: static/js/common/upload-addon.js:140 static/js/zamboni/devhub-all.js:371 static/js/zamboni/devhub-min.js:1
 msgid "Cancel"
 msgstr ""
 
-#: static/js/common/upload-addon.js:162
+#: static/js/common/upload-addon.js:162 static/js/zamboni/devhub-all.js:393 static/js/zamboni/devhub-min.js:1
 msgid "Uploading {0}"
 msgstr ""
 
-#: static/js/common/upload-addon.js:189
+#: static/js/common/upload-addon.js:189 static/js/zamboni/devhub-all.js:420 static/js/zamboni/devhub-min.js:1
 msgid "Error with {0}"
 msgstr ""
 
-#: static/js/common/upload-addon.js:194
+#: static/js/common/upload-addon.js:194 static/js/zamboni/devhub-all.js:425 static/js/zamboni/devhub-min.js:1
 msgid "Your add-on failed validation with {0} error."
 msgid_plural "Your add-on failed validation with {0} errors."
 msgstr[0] ""
 msgstr[1] ""
 
-#: static/js/common/upload-addon.js:208
+#: static/js/common/upload-addon.js:208 static/js/zamboni/devhub-all.js:439 static/js/zamboni/devhub-min.js:1
 msgid "&hellip;and {0} more"
 msgid_plural "&hellip;and {0} more"
 msgstr[0] ""
 msgstr[1] ""
 
-#: static/js/common/upload-addon.js:222 static/js/common/upload-addon.js:512
+#: static/js/common/upload-addon.js:222 static/js/common/upload-addon.js:497 static/js/zamboni/devhub-all.js:453 static/js/zamboni/devhub-all.js:743 static/js/zamboni/devhub-min.js:1
 msgid "See full validation report"
 msgstr ""
 
-#: static/js/common/upload-addon.js:234
+#: static/js/common/upload-addon.js:234 static/js/zamboni/devhub-all.js:465 static/js/zamboni/devhub-min.js:1
 msgid "Validating {0}"
 msgstr ""
 
 #. L10n: first argument is an HTTP status code
-#: static/js/common/upload-addon.js:273
+#: static/js/common/upload-addon.js:273 static/js/zamboni/devhub-all.js:504 static/js/zamboni/devhub-min.js:1
 msgid "Received an empty response from the server; status: {0}"
 msgstr ""
 
-#: static/js/common/upload-addon.js:373
+#: static/js/common/upload-addon.js:370 static/js/zamboni/devhub-all.js:604 static/js/zamboni/devhub-min.js:1
 msgid "Unexpected server error while validating."
 msgstr ""
 
-#: static/js/common/upload-addon.js:412
+#: static/js/common/upload-addon.js:409 static/js/zamboni/devhub-all.js:643 static/js/zamboni/devhub-min.js:1
 msgid "Finished validating {0}"
 msgstr ""
 
-#: static/js/common/upload-addon.js:418
+#: static/js/common/upload-addon.js:415 static/js/zamboni/devhub-all.js:649 static/js/zamboni/devhub-min.js:1
 msgid "Your add-on validation timed out, it will be manually reviewed."
 msgstr ""
 
-#: static/js/common/upload-addon.js:421
+#: static/js/common/upload-addon.js:418 static/js/zamboni/devhub-all.js:652 static/js/zamboni/devhub-min.js:1
 msgid "Your add-on was validated with no errors and {0} warning."
 msgid_plural "Your add-on was validated with no errors and {0} warnings."
 msgstr[0] ""
 msgstr[1] ""
 
-#: static/js/common/upload-addon.js:426
+#: static/js/common/upload-addon.js:423 static/js/zamboni/devhub-all.js:657 static/js/zamboni/devhub-min.js:1
 msgid "Your add-on was validated with no errors and {0} message."
 msgid_plural "Your add-on was validated with no errors and {0} messages."
 msgstr[0] ""
 msgstr[1] ""
 
-#: static/js/common/upload-addon.js:431
+#: static/js/common/upload-addon.js:428 static/js/zamboni/devhub-all.js:662 static/js/zamboni/devhub-min.js:1
 msgid "Your add-on was validated with no errors or warnings."
 msgstr ""
 
-#: static/js/common/upload-addon.js:446
+#: static/js/common/upload-addon.js:443 static/js/zamboni/devhub-all.js:677 static/js/zamboni/devhub-min.js:1
 msgid "Your submission will be automatically signed."
 msgstr ""
 
-#: static/js/common/upload-addon.js:465
+#: static/js/common/upload-addon.js:450 static/js/zamboni/devhub-all.js:696 static/js/zamboni/devhub-min.js:1
 msgid "Include detailed version notes (this can be done in the next step)."
 msgstr ""
 
-#: static/js/common/upload-addon.js:466
+#: static/js/common/upload-addon.js:451 static/js/zamboni/devhub-all.js:697 static/js/zamboni/devhub-min.js:1
 msgid "If your add-on requires an account to a website in order to be fully tested, include a test username and password in the Notes to Reviewer (this can be done in the next step)."
 msgstr ""
 
-#: static/js/common/upload-addon.js:467
+#: static/js/common/upload-addon.js:452 static/js/zamboni/devhub-all.js:698 static/js/zamboni/devhub-min.js:1
 msgid "If your add-on is intended for a limited audience you should choose Preliminary Review instead of Full Review."
 msgstr ""
 
-#: static/js/common/upload-addon.js:480
+#: static/js/common/upload-addon.js:465 static/js/zamboni/devhub-all.js:711 static/js/zamboni/devhub-min.js:1
 msgid "Add-on submission checklist"
 msgstr ""
 
-#: static/js/common/upload-addon.js:481
+#: static/js/common/upload-addon.js:466 static/js/zamboni/devhub-all.js:712 static/js/zamboni/devhub-min.js:1
 msgid "Please verify the following points before finalizing your submission. This will minimize delays or misunderstanding during the review process:"
 msgstr ""
 
-#: static/js/common/upload-addon.js:483
+#: static/js/common/upload-addon.js:468 static/js/zamboni/devhub-all.js:714 static/js/zamboni/devhub-min.js:1
 msgid ""
 "Compiled binaries, as well as minified or obfuscated scripts (excluding known libraries) need to have their sources submitted separately for review. Make sure that you use the source code upload "
 "field to avoid having your submission rejected."
 msgstr ""
 
-#: static/js/common/upload-addon.js:501
+#: static/js/common/upload-addon.js:486 static/js/zamboni/devhub-all.js:732 static/js/zamboni/devhub-min.js:1
 msgid "The validation process found these issues that can lead to rejections:"
 msgstr ""
 
-#: static/js/common/upload-addon.js:518
+#: static/js/common/upload-addon.js:503 static/js/zamboni/devhub-all.js:749 static/js/zamboni/devhub-min.js:1
 msgid "If you are unfamiliar with the add-ons review process, you can read about it here."
 msgstr ""
 
-#: static/js/common/upload-addon.js:555
+#: static/js/common/upload-addon.js:540 static/js/zamboni/devhub-all.js:786 static/js/zamboni/devhub-min.js:1
 msgid "Sorry, no supported platform has been found."
 msgstr ""
 
-#: static/js/common/upload-base.js:57
+#: static/js/common/upload-base.js:57 static/js/zamboni/devhub-all.js:187 static/js/zamboni/devhub-min.js:1
 msgid "The filetype you uploaded isn't recognized."
 msgstr ""
 
-#: static/js/common/upload-base.js:79
+#: static/js/common/upload-base.js:79 static/js/zamboni/devhub-all.js:209 static/js/zamboni/devhub-min.js:1
 msgid "You cancelled the upload."
 msgstr ""
 
-#: static/js/common/upload-image.js:97 static/js/impala/users.js:51
-msgid "Images must be either PNG or JPG."
-msgstr ""
-
-#: static/js/common/upload-image.js:101
-msgid "Videos must be in WebM."
-msgstr ""
-
-#: static/js/impala/collections.js:10 static/js/zamboni/collections.js:595
-msgid "Follow this Collection"
-msgstr ""
-
-#: static/js/impala/collections.js:19
-msgid "Stop Following"
-msgstr ""
-
-#: static/js/impala/collections.js:20
-msgid "Following"
-msgstr ""
-
-#. L10n: {0} is an app name.
-#: static/js/impala/listing.js:11 static/js/zamboni/themes.js:13
-msgid "This theme is incompatible with your version of {0}"
-msgstr ""
-
-#: static/js/impala/persona_creation.js:60
-msgid "All Rights Reserved"
-msgstr ""
-
-#: static/js/impala/persona_creation.js:64
-msgid "Creative Commons Attribution 3.0"
-msgstr ""
-
-#: static/js/impala/persona_creation.js:69
-msgid "Creative Commons Attribution-NonCommercial 3.0"
-msgstr ""
-
-#: static/js/impala/persona_creation.js:74
-msgid "Creative Commons Attribution-NonCommercial-NoDerivs 3.0"
-msgstr ""
-
-#: static/js/impala/persona_creation.js:79
-msgid "Creative Commons Attribution-NonCommercial-Share Alike 3.0"
-msgstr ""
-
-#: static/js/impala/persona_creation.js:84
-msgid "Creative Commons Attribution-NoDerivs 3.0"
-msgstr ""
-
-#: static/js/impala/persona_creation.js:89
-msgid "Creative Commons Attribution-ShareAlike 3.0"
-msgstr ""
-
-#: static/js/impala/persona_creation.js:292
-msgid "Your Theme's Name"
-msgstr ""
-
-#: static/js/impala/reviews.js:23 static/js/zamboni/reviews.js:18
-msgid "Flagged for review"
-msgstr ""
-
-#: static/js/impala/reviews.js:40 static/js/zamboni/reviews.js:34
-msgid "Your input is required"
-msgstr ""
-
-#: static/js/impala/reviews.js:152 static/js/zamboni/reviews.js:103
-msgid "Marked for deletion"
-msgstr ""
-
-#: static/js/impala/search.js:114
-msgid "Updating results&hellip;"
-msgstr ""
-
-#: static/js/impala/site_suggestions.js:46
-msgid "Category"
-msgstr ""
-
-#: static/js/impala/suggestions.js:39
-msgid "Search themes for <b>{0}</b>"
-msgstr ""
-
-#: static/js/impala/suggestions.js:41
-msgid "Search apps for <b>{0}</b>"
-msgstr ""
-
-#: static/js/impala/suggestions.js:43
-msgid "Search add-ons for <b>{0}</b>"
-msgstr ""
-
-#: static/js/impala/users.js:33
-msgid "use original"
-msgstr ""
-
-#: static/js/impala/stats/chart.js:267
+#: static/js/impala/stats/chart.js:267 static/js/zamboni/stats-all.js:16898 static/js/zamboni/stats-min.js:5
 msgid "Week of {0}"
 msgstr ""
 
-#: static/js/impala/stats/chart.js:269
+#: static/js/impala/stats/chart.js:269 static/js/zamboni/stats-all.js:16900 static/js/zamboni/stats-min.js:5
 msgid " downloads"
 msgstr ""
 
-#: static/js/impala/stats/chart.js:270
+#: static/js/impala/stats/chart.js:270 static/js/zamboni/stats-all.js:16901 static/js/zamboni/stats-min.js:5
 msgid "{0} users"
 msgstr ""
 
-#: static/js/impala/stats/chart.js:271
+#: static/js/impala/stats/chart.js:271 static/js/zamboni/stats-all.js:16902 static/js/zamboni/stats-min.js:5
 msgid "{0} add-ons"
 msgstr ""
 
-#: static/js/impala/stats/chart.js:272
+#: static/js/impala/stats/chart.js:272 static/js/zamboni/stats-all.js:16903 static/js/zamboni/stats-min.js:5
 msgid "{0} collections"
 msgstr ""
 
-#: static/js/impala/stats/chart.js:273
+#: static/js/impala/stats/chart.js:273 static/js/zamboni/stats-all.js:16904 static/js/zamboni/stats-min.js:5
 msgid "{0} reviews"
 msgstr ""
 
-#: static/js/impala/stats/chart.js:275
+#: static/js/impala/stats/chart.js:275 static/js/zamboni/stats-all.js:16906 static/js/zamboni/stats-min.js:5
 msgid "{0} sales"
 msgstr ""
 
-#: static/js/impala/stats/chart.js:276
+#: static/js/impala/stats/chart.js:276 static/js/zamboni/stats-all.js:16907 static/js/zamboni/stats-min.js:5
 msgid "{0} refunds"
 msgstr ""
 
-#: static/js/impala/stats/chart.js:277
+#: static/js/impala/stats/chart.js:277 static/js/zamboni/stats-all.js:16908 static/js/zamboni/stats-min.js:5
 msgid "{0} installs"
 msgstr ""
 
-#: static/js/impala/stats/chart.js:369 static/js/impala/stats/csv_keys.js:3 static/js/impala/stats/csv_keys.js:109
+#: static/js/impala/stats/chart.js:369 static/js/impala/stats/csv_keys.js:3 static/js/impala/stats/csv_keys.js:109 static/js/zamboni/stats-all.js:15284 static/js/zamboni/stats-all.js:15390
+#: static/js/zamboni/stats-all.js:17000 static/js/zamboni/stats-min.js:4 static/js/zamboni/stats-min.js:5
 msgid "Downloads"
 msgstr ""
 
-#: static/js/impala/stats/chart.js:379 static/js/impala/stats/csv_keys.js:6 static/js/impala/stats/csv_keys.js:110
+#: static/js/impala/stats/chart.js:379 static/js/impala/stats/csv_keys.js:6 static/js/impala/stats/csv_keys.js:110 static/js/zamboni/stats-all.js:15287 static/js/zamboni/stats-all.js:15391
+#: static/js/zamboni/stats-all.js:17010 static/js/zamboni/stats-min.js:4 static/js/zamboni/stats-min.js:5
 msgid "Daily Users"
 msgstr ""
 
-#: static/js/impala/stats/chart.js:410
+#: static/js/impala/stats/chart.js:410 static/js/zamboni/stats-all.js:17041 static/js/zamboni/stats-min.js:5
 msgid "Amount, in USD"
 msgstr ""
 
-#: static/js/impala/stats/chart.js:421 static/js/impala/stats/csv_keys.js:104
+#: static/js/impala/stats/chart.js:421 static/js/impala/stats/csv_keys.js:104 static/js/zamboni/stats-all.js:15385 static/js/zamboni/stats-all.js:17052 static/js/zamboni/stats-min.js:5
 msgid "Number of Contributions"
 msgstr ""
 
-#: static/js/impala/stats/chart.js:447
+#: static/js/impala/stats/chart.js:447 static/js/zamboni/stats-all.js:17078 static/js/zamboni/stats-min.js:5
 msgid "More Info..."
 msgstr ""
 
 #. L10n: {0} is an ISO-formatted date.
-#: static/js/impala/stats/chart.js:451
+#: static/js/impala/stats/chart.js:451 static/js/zamboni/stats-all.js:17082 static/js/zamboni/stats-min.js:5
 msgid "Details for {0}"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:9
+#: static/js/impala/stats/csv_keys.js:9 static/js/zamboni/stats-all.js:15290 static/js/zamboni/stats-min.js:4
 msgid "Collections Created"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:12
+#: static/js/impala/stats/csv_keys.js:12 static/js/zamboni/stats-all.js:15293 static/js/zamboni/stats-min.js:4
 msgid "Add-ons in Use"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:15
+#: static/js/impala/stats/csv_keys.js:15 static/js/zamboni/stats-all.js:15296 static/js/zamboni/stats-min.js:4
 msgid "Add-ons Created"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:18
+#: static/js/impala/stats/csv_keys.js:18 static/js/zamboni/stats-all.js:15299 static/js/zamboni/stats-min.js:4
 msgid "Add-ons Downloaded"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:21
+#: static/js/impala/stats/csv_keys.js:21 static/js/zamboni/stats-all.js:15302 static/js/zamboni/stats-min.js:4
 msgid "Add-ons Updated"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:24
+#: static/js/impala/stats/csv_keys.js:24 static/js/zamboni/stats-all.js:15305 static/js/zamboni/stats-min.js:4
 msgid "Reviews Written"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:27
+#: static/js/impala/stats/csv_keys.js:27 static/js/zamboni/stats-all.js:15308 static/js/zamboni/stats-min.js:4
 msgid "User Signups"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:30
+#: static/js/impala/stats/csv_keys.js:30 static/js/zamboni/stats-all.js:15311 static/js/zamboni/stats-min.js:4
 msgid "Subscribers"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:33
+#: static/js/impala/stats/csv_keys.js:33 static/js/zamboni/stats-all.js:15314 static/js/zamboni/stats-min.js:4
 msgid "Ratings"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:36 static/js/impala/stats/csv_keys.js:114
+#: static/js/impala/stats/csv_keys.js:36 static/js/impala/stats/csv_keys.js:114 static/js/zamboni/stats-all.js:15317 static/js/zamboni/stats-all.js:15395 static/js/zamboni/stats-min.js:4
+#: static/js/zamboni/stats-min.js:5
 msgid "Sales"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:39 static/js/impala/stats/csv_keys.js:113
+#: static/js/impala/stats/csv_keys.js:39 static/js/impala/stats/csv_keys.js:113 static/js/zamboni/stats-all.js:15320 static/js/zamboni/stats-all.js:15394 static/js/zamboni/stats-min.js:4
+#: static/js/zamboni/stats-min.js:5
 msgid "Installs"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:42
+#: static/js/impala/stats/csv_keys.js:42 static/js/zamboni/stats-all.js:15323 static/js/zamboni/stats-min.js:4
 msgid "Unknown"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:43
+#: static/js/impala/stats/csv_keys.js:43 static/js/zamboni/stats-all.js:15324 static/js/zamboni/stats-min.js:4
 msgid "Add-ons Manager"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:44
+#: static/js/impala/stats/csv_keys.js:44 static/js/zamboni/stats-all.js:15325 static/js/zamboni/stats-min.js:4
 msgid "Add-ons Manager Promo"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:45
+#: static/js/impala/stats/csv_keys.js:45 static/js/zamboni/stats-all.js:15326 static/js/zamboni/stats-min.js:4
 msgid "Add-ons Manager Featured"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:46
+#: static/js/impala/stats/csv_keys.js:46 static/js/zamboni/stats-all.js:15327 static/js/zamboni/stats-min.js:4
 msgid "Add-ons Manager Learn More"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:47
+#: static/js/impala/stats/csv_keys.js:47 static/js/zamboni/stats-all.js:15328 static/js/zamboni/stats-min.js:4
 msgid "Search Suggestions"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:48
+#: static/js/impala/stats/csv_keys.js:48 static/js/zamboni/stats-all.js:15329 static/js/zamboni/stats-min.js:4
 msgid "Search Results"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:49 static/js/impala/stats/csv_keys.js:50 static/js/impala/stats/csv_keys.js:51
+#: static/js/impala/stats/csv_keys.js:49 static/js/impala/stats/csv_keys.js:50 static/js/impala/stats/csv_keys.js:51 static/js/zamboni/stats-all.js:15330 static/js/zamboni/stats-all.js:15331
+#: static/js/zamboni/stats-all.js:15332 static/js/zamboni/stats-min.js:4
 msgid "Homepage Promo"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:52 static/js/impala/stats/csv_keys.js:53
+#: static/js/impala/stats/csv_keys.js:52 static/js/impala/stats/csv_keys.js:53 static/js/zamboni/stats-all.js:15333 static/js/zamboni/stats-all.js:15334 static/js/zamboni/stats-min.js:4
 msgid "Homepage Featured"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:54 static/js/impala/stats/csv_keys.js:55
+#: static/js/impala/stats/csv_keys.js:54 static/js/impala/stats/csv_keys.js:55 static/js/zamboni/stats-all.js:15335 static/js/zamboni/stats-all.js:15336 static/js/zamboni/stats-min.js:4
 msgid "Homepage Up and Coming"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:56
+#: static/js/impala/stats/csv_keys.js:56 static/js/zamboni/stats-all.js:15337 static/js/zamboni/stats-min.js:4
 msgid "Homepage Most Popular"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:57 static/js/impala/stats/csv_keys.js:59
+#: static/js/impala/stats/csv_keys.js:57 static/js/impala/stats/csv_keys.js:59 static/js/zamboni/stats-all.js:15338 static/js/zamboni/stats-all.js:15340 static/js/zamboni/stats-min.js:4
 msgid "Detail Page"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:58 static/js/impala/stats/csv_keys.js:60
+#: static/js/impala/stats/csv_keys.js:58 static/js/impala/stats/csv_keys.js:60 static/js/zamboni/stats-all.js:15339 static/js/zamboni/stats-all.js:15341 static/js/zamboni/stats-min.js:4
 msgid "Detail Page (bottom)"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:61
+#: static/js/impala/stats/csv_keys.js:61 static/js/zamboni/stats-all.js:15342 static/js/zamboni/stats-min.js:4
 msgid "Detail Page (Development Channel)"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:62 static/js/impala/stats/csv_keys.js:63 static/js/impala/stats/csv_keys.js:64
+#: static/js/impala/stats/csv_keys.js:62 static/js/impala/stats/csv_keys.js:63 static/js/impala/stats/csv_keys.js:64 static/js/zamboni/stats-all.js:15343 static/js/zamboni/stats-all.js:15344
+#: static/js/zamboni/stats-all.js:15345 static/js/zamboni/stats-min.js:4
 msgid "Often Used With"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:65 static/js/impala/stats/csv_keys.js:66
+#: static/js/impala/stats/csv_keys.js:65 static/js/impala/stats/csv_keys.js:66 static/js/zamboni/stats-all.js:15346 static/js/zamboni/stats-all.js:15347 static/js/zamboni/stats-min.js:4
 msgid "Others By Author"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:67 static/js/impala/stats/csv_keys.js:68
+#: static/js/impala/stats/csv_keys.js:67 static/js/impala/stats/csv_keys.js:68 static/js/zamboni/stats-all.js:15348 static/js/zamboni/stats-all.js:15349 static/js/zamboni/stats-min.js:4
 msgid "Dependencies"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:69 static/js/impala/stats/csv_keys.js:70
+#: static/js/impala/stats/csv_keys.js:69 static/js/impala/stats/csv_keys.js:70 static/js/zamboni/stats-all.js:15350 static/js/zamboni/stats-all.js:15351 static/js/zamboni/stats-min.js:4
 msgid "Upsell"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:71
+#: static/js/impala/stats/csv_keys.js:71 static/js/zamboni/stats-all.js:15352 static/js/zamboni/stats-min.js:4
 msgid "Meet the Developer"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:72
+#: static/js/impala/stats/csv_keys.js:72 static/js/zamboni/stats-all.js:15353 static/js/zamboni/stats-min.js:4
 msgid "User Profile"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:73
+#: static/js/impala/stats/csv_keys.js:73 static/js/zamboni/stats-all.js:15354 static/js/zamboni/stats-min.js:4
 msgid "Version History"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:75
+#: static/js/impala/stats/csv_keys.js:75 static/js/zamboni/stats-all.js:15356 static/js/zamboni/stats-min.js:4
 msgid "Sharing"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:76
+#: static/js/impala/stats/csv_keys.js:76 static/js/zamboni/stats-all.js:15357 static/js/zamboni/stats-min.js:4
 msgid "Category Pages"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:77
+#: static/js/impala/stats/csv_keys.js:77 static/js/zamboni/stats-all.js:15358 static/js/zamboni/stats-min.js:4
 msgid "Collections"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:78 static/js/impala/stats/csv_keys.js:79
+#: static/js/impala/stats/csv_keys.js:78 static/js/impala/stats/csv_keys.js:79 static/js/zamboni/stats-all.js:15359 static/js/zamboni/stats-all.js:15360 static/js/zamboni/stats-min.js:4
 msgid "Category Landing Featured Carousel"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:80 static/js/impala/stats/csv_keys.js:81
+#: static/js/impala/stats/csv_keys.js:80 static/js/impala/stats/csv_keys.js:81 static/js/zamboni/stats-all.js:15361 static/js/zamboni/stats-all.js:15362 static/js/zamboni/stats-min.js:4
 msgid "Category Landing Top Rated"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:82 static/js/impala/stats/csv_keys.js:83
+#: static/js/impala/stats/csv_keys.js:82 static/js/impala/stats/csv_keys.js:83 static/js/zamboni/stats-all.js:15363 static/js/zamboni/stats-all.js:15364 static/js/zamboni/stats-min.js:5
 msgid "Category Landing Most Popular"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:84 static/js/impala/stats/csv_keys.js:85
+#: static/js/impala/stats/csv_keys.js:84 static/js/impala/stats/csv_keys.js:85 static/js/zamboni/stats-all.js:15365 static/js/zamboni/stats-all.js:15366 static/js/zamboni/stats-min.js:5
 msgid "Category Landing Recently Added"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:86 static/js/impala/stats/csv_keys.js:87
+#: static/js/impala/stats/csv_keys.js:86 static/js/impala/stats/csv_keys.js:87 static/js/zamboni/stats-all.js:15367 static/js/zamboni/stats-all.js:15368 static/js/zamboni/stats-min.js:5
 msgid "Browse Listing Featured Sort"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:88 static/js/impala/stats/csv_keys.js:89
+#: static/js/impala/stats/csv_keys.js:88 static/js/impala/stats/csv_keys.js:89 static/js/zamboni/stats-all.js:15369 static/js/zamboni/stats-all.js:15370 static/js/zamboni/stats-min.js:5
 msgid "Browse Listing Users Sort"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:90 static/js/impala/stats/csv_keys.js:91
+#: static/js/impala/stats/csv_keys.js:90 static/js/impala/stats/csv_keys.js:91 static/js/zamboni/stats-all.js:15371 static/js/zamboni/stats-all.js:15372 static/js/zamboni/stats-min.js:5
 msgid "Browse Listing Rating Sort"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:92 static/js/impala/stats/csv_keys.js:93
+#: static/js/impala/stats/csv_keys.js:92 static/js/impala/stats/csv_keys.js:93 static/js/zamboni/stats-all.js:15373 static/js/zamboni/stats-all.js:15374 static/js/zamboni/stats-min.js:5
 msgid "Browse Listing Created Sort"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:94 static/js/impala/stats/csv_keys.js:95
+#: static/js/impala/stats/csv_keys.js:94 static/js/impala/stats/csv_keys.js:95 static/js/zamboni/stats-all.js:15375 static/js/zamboni/stats-all.js:15376 static/js/zamboni/stats-min.js:5
 msgid "Browse Listing Name Sort"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:96 static/js/impala/stats/csv_keys.js:97
+#: static/js/impala/stats/csv_keys.js:96 static/js/impala/stats/csv_keys.js:97 static/js/zamboni/stats-all.js:15377 static/js/zamboni/stats-all.js:15378 static/js/zamboni/stats-min.js:5
 msgid "Browse Listing Popular Sort"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:98 static/js/impala/stats/csv_keys.js:99
+#: static/js/impala/stats/csv_keys.js:98 static/js/impala/stats/csv_keys.js:99 static/js/zamboni/stats-all.js:15379 static/js/zamboni/stats-all.js:15380 static/js/zamboni/stats-min.js:5
 msgid "Browse Listing Updated Sort"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:100 static/js/impala/stats/csv_keys.js:101
+#: static/js/impala/stats/csv_keys.js:100 static/js/impala/stats/csv_keys.js:101 static/js/zamboni/stats-all.js:15381 static/js/zamboni/stats-all.js:15382 static/js/zamboni/stats-min.js:5
 msgid "Browse Listing Up and Coming Sort"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:105
+#: static/js/impala/stats/csv_keys.js:105 static/js/zamboni/stats-all.js:15386 static/js/zamboni/stats-min.js:5
 msgid "Total Amount Contributed"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:106
+#: static/js/impala/stats/csv_keys.js:106 static/js/zamboni/stats-all.js:15387 static/js/zamboni/stats-min.js:5
 msgid "Average Contribution"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:115
+#: static/js/impala/stats/csv_keys.js:115 static/js/zamboni/stats-all.js:15396 static/js/zamboni/stats-min.js:5
 msgid "Usage"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:118
+#: static/js/impala/stats/csv_keys.js:118 static/js/zamboni/stats-all.js:15399 static/js/zamboni/stats-min.js:5
 msgid "Firefox"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:119
+#: static/js/impala/stats/csv_keys.js:119 static/js/zamboni/stats-all.js:15400 static/js/zamboni/stats-min.js:5
 msgid "Mozilla"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:120
+#: static/js/impala/stats/csv_keys.js:120 static/js/zamboni/stats-all.js:15401 static/js/zamboni/stats-min.js:5
 msgid "Thunderbird"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:121
+#: static/js/impala/stats/csv_keys.js:121 static/js/zamboni/stats-all.js:15402 static/js/zamboni/stats-min.js:5
 msgid "Sunbird"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:122
+#: static/js/impala/stats/csv_keys.js:122 static/js/zamboni/stats-all.js:15403 static/js/zamboni/stats-min.js:5
 msgid "SeaMonkey"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:123
+#: static/js/impala/stats/csv_keys.js:123 static/js/zamboni/stats-all.js:15404 static/js/zamboni/stats-min.js:5
 msgid "Fennec"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:124
+#: static/js/impala/stats/csv_keys.js:124 static/js/zamboni/stats-all.js:15405 static/js/zamboni/stats-min.js:5
 msgid "Android"
 msgstr ""
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:129
+#: static/js/impala/stats/csv_keys.js:129 static/js/zamboni/stats-all.js:15410 static/js/zamboni/stats-min.js:5
 msgid "Downloads and Daily Users, last {0} days"
 msgstr ""
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:131
+#: static/js/impala/stats/csv_keys.js:131 static/js/zamboni/stats-all.js:15412 static/js/zamboni/stats-min.js:5
 msgid "Downloads and Daily Users from {0} to {1}"
 msgstr ""
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:135
+#: static/js/impala/stats/csv_keys.js:135 static/js/zamboni/stats-all.js:15416 static/js/zamboni/stats-min.js:5
 msgid "Installs and Daily Users, last {0} days"
 msgstr ""
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:137
+#: static/js/impala/stats/csv_keys.js:137 static/js/zamboni/stats-all.js:15418 static/js/zamboni/stats-min.js:5
 msgid "Installs and Daily Users from {0} to {1}"
 msgstr ""
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:141
+#: static/js/impala/stats/csv_keys.js:141 static/js/zamboni/stats-all.js:15422 static/js/zamboni/stats-min.js:5
 msgid "Downloads, last {0} days"
 msgstr ""
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:143
+#: static/js/impala/stats/csv_keys.js:143 static/js/zamboni/stats-all.js:15424 static/js/zamboni/stats-min.js:5
 msgid "Downloads from {0} to {1}"
 msgstr ""
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:147
+#: static/js/impala/stats/csv_keys.js:147 static/js/zamboni/stats-all.js:15428 static/js/zamboni/stats-min.js:5
 msgid "Daily Users, last {0} days"
 msgstr ""
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:149
+#: static/js/impala/stats/csv_keys.js:149 static/js/zamboni/stats-all.js:15430 static/js/zamboni/stats-min.js:5
 msgid "Daily Users from {0} to {1}"
 msgstr ""
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:153
+#: static/js/impala/stats/csv_keys.js:153 static/js/zamboni/stats-all.js:15434 static/js/zamboni/stats-min.js:5
 msgid "Applications, last {0} days"
 msgstr ""
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:155
+#: static/js/impala/stats/csv_keys.js:155 static/js/zamboni/stats-all.js:15436 static/js/zamboni/stats-min.js:5
 msgid "Applications from {0} to {1}"
 msgstr ""
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:159
+#: static/js/impala/stats/csv_keys.js:159 static/js/zamboni/stats-all.js:15440 static/js/zamboni/stats-min.js:5
 msgid "Platforms, last {0} days"
 msgstr ""
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:161
+#: static/js/impala/stats/csv_keys.js:161 static/js/zamboni/stats-all.js:15442 static/js/zamboni/stats-min.js:5
 msgid "Platforms from {0} to {1}"
 msgstr ""
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:165
+#: static/js/impala/stats/csv_keys.js:165 static/js/zamboni/stats-all.js:15446 static/js/zamboni/stats-min.js:5
 msgid "Languages, last {0} days"
 msgstr ""
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:167
+#: static/js/impala/stats/csv_keys.js:167 static/js/zamboni/stats-all.js:15448 static/js/zamboni/stats-min.js:5
 msgid "Languages from {0} to {1}"
 msgstr ""
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:171
+#: static/js/impala/stats/csv_keys.js:171 static/js/zamboni/stats-all.js:15452 static/js/zamboni/stats-min.js:5
 msgid "Add-on Versions, last {0} days"
 msgstr ""
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:173
+#: static/js/impala/stats/csv_keys.js:173 static/js/zamboni/stats-all.js:15454 static/js/zamboni/stats-min.js:5
 msgid "Add-on Versions from {0} to {1}"
 msgstr ""
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:177
+#: static/js/impala/stats/csv_keys.js:177 static/js/zamboni/stats-all.js:15458 static/js/zamboni/stats-min.js:5
 msgid "Add-on Status, last {0} days"
 msgstr ""
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:179
+#: static/js/impala/stats/csv_keys.js:179 static/js/zamboni/stats-all.js:15460 static/js/zamboni/stats-min.js:5
 msgid "Add-on Status from {0} to {1}"
 msgstr ""
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:183
+#: static/js/impala/stats/csv_keys.js:183 static/js/zamboni/stats-all.js:15464 static/js/zamboni/stats-min.js:5
 msgid "Download Sources, last {0} days"
 msgstr ""
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:185
+#: static/js/impala/stats/csv_keys.js:185 static/js/zamboni/stats-all.js:15466 static/js/zamboni/stats-min.js:5
 msgid "Download Sources from {0} to {1}"
 msgstr ""
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:189
+#: static/js/impala/stats/csv_keys.js:189 static/js/zamboni/stats-all.js:15470 static/js/zamboni/stats-min.js:5
 msgid "Contributions, last {0} days"
 msgstr ""
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:191
+#: static/js/impala/stats/csv_keys.js:191 static/js/zamboni/stats-all.js:15472 static/js/zamboni/stats-min.js:5
 msgid "Contributions from {0} to {1}"
 msgstr ""
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:195
+#: static/js/impala/stats/csv_keys.js:195 static/js/zamboni/stats-all.js:15476 static/js/zamboni/stats-min.js:5
 msgid "Site Metrics, last {0} days"
 msgstr ""
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:197
+#: static/js/impala/stats/csv_keys.js:197 static/js/zamboni/stats-all.js:15478 static/js/zamboni/stats-min.js:5
 msgid "Site Metrics from {0} to {1}"
 msgstr ""
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:201
+#: static/js/impala/stats/csv_keys.js:201 static/js/zamboni/stats-all.js:15482 static/js/zamboni/stats-min.js:5
 msgid "Add-ons in Use, last {0} days"
 msgstr ""
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:203
+#: static/js/impala/stats/csv_keys.js:203 static/js/zamboni/stats-all.js:15484 static/js/zamboni/stats-min.js:5
 msgid "Add-ons in Use from {0} to {1}"
 msgstr ""
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:207
+#: static/js/impala/stats/csv_keys.js:207 static/js/zamboni/stats-all.js:15488 static/js/zamboni/stats-min.js:5
 msgid "Add-ons Downloaded, last {0} days"
 msgstr ""
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:209
+#: static/js/impala/stats/csv_keys.js:209 static/js/zamboni/stats-all.js:15490 static/js/zamboni/stats-min.js:5
 msgid "Add-ons Downloaded from {0} to {1}"
 msgstr ""
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:213
+#: static/js/impala/stats/csv_keys.js:213 static/js/zamboni/stats-all.js:15494 static/js/zamboni/stats-min.js:5
 msgid "Add-ons Created, last {0} days"
 msgstr ""
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:215
+#: static/js/impala/stats/csv_keys.js:215 static/js/zamboni/stats-all.js:15496 static/js/zamboni/stats-min.js:5
 msgid "Add-ons Created from {0} to {1}"
 msgstr ""
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:219
+#: static/js/impala/stats/csv_keys.js:219 static/js/zamboni/stats-all.js:15500 static/js/zamboni/stats-min.js:5
 msgid "Add-ons Updated, last {0} days"
 msgstr ""
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:221
+#: static/js/impala/stats/csv_keys.js:221 static/js/zamboni/stats-all.js:15502 static/js/zamboni/stats-min.js:5
 msgid "Add-ons Updated from {0} to {1}"
 msgstr ""
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:225
+#: static/js/impala/stats/csv_keys.js:225 static/js/zamboni/stats-all.js:15506 static/js/zamboni/stats-min.js:5
 msgid "Reviews Written, last {0} days"
 msgstr ""
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:227
+#: static/js/impala/stats/csv_keys.js:227 static/js/zamboni/stats-all.js:15508 static/js/zamboni/stats-min.js:5
 msgid "Reviews Written from {0} to {1}"
 msgstr ""
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:231
+#: static/js/impala/stats/csv_keys.js:231 static/js/zamboni/stats-all.js:15512 static/js/zamboni/stats-min.js:5
 msgid "User Signups, last {0} days"
 msgstr ""
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:233
+#: static/js/impala/stats/csv_keys.js:233 static/js/zamboni/stats-all.js:15514 static/js/zamboni/stats-min.js:5
 msgid "User Signups from {0} to {1}"
 msgstr ""
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:237
+#: static/js/impala/stats/csv_keys.js:237 static/js/zamboni/stats-all.js:15518 static/js/zamboni/stats-min.js:5
 msgid "Collections Created, last {0} days"
 msgstr ""
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:239
+#: static/js/impala/stats/csv_keys.js:239 static/js/zamboni/stats-all.js:15520 static/js/zamboni/stats-min.js:5
 msgid "Collections Created from {0} to {1}"
 msgstr ""
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:243
+#: static/js/impala/stats/csv_keys.js:243 static/js/zamboni/stats-all.js:15524 static/js/zamboni/stats-min.js:5
 msgid "Subscribers, last {0} days"
 msgstr ""
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:245
+#: static/js/impala/stats/csv_keys.js:245 static/js/zamboni/stats-all.js:15526 static/js/zamboni/stats-min.js:5
 msgid "Subscribers from {0} to {1}"
 msgstr ""
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:249
+#: static/js/impala/stats/csv_keys.js:249 static/js/zamboni/stats-all.js:15530 static/js/zamboni/stats-min.js:5
 msgid "Ratings, last {0} days"
 msgstr ""
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:251
+#: static/js/impala/stats/csv_keys.js:251 static/js/zamboni/stats-all.js:15532 static/js/zamboni/stats-min.js:5
 msgid "Ratings from {0} to {1}"
 msgstr ""
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:255
+#: static/js/impala/stats/csv_keys.js:255 static/js/zamboni/stats-all.js:15536 static/js/zamboni/stats-min.js:5
 msgid "Sales, last {0} days"
 msgstr ""
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:257
+#: static/js/impala/stats/csv_keys.js:257 static/js/zamboni/stats-all.js:15538 static/js/zamboni/stats-min.js:5
 msgid "Sales from {0} to {1}"
 msgstr ""
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:261
+#: static/js/impala/stats/csv_keys.js:261 static/js/zamboni/stats-all.js:15542 static/js/zamboni/stats-min.js:5
 msgid "Installs, last {0} days"
 msgstr ""
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:263
+#: static/js/impala/stats/csv_keys.js:263 static/js/zamboni/stats-all.js:15544 static/js/zamboni/stats-min.js:5
 msgid "Installs from {0} to {1}"
 msgstr ""
 
 #. L10n: {0} and {1} are integers.
-#: static/js/impala/stats/csv_keys.js:269
+#: static/js/impala/stats/csv_keys.js:269 static/js/zamboni/stats-all.js:15550 static/js/zamboni/stats-min.js:5
 msgid "<b>{0}</b> in last {1} days"
 msgstr ""
 
 #. L10n: {0} is an integer and {1} and {2} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:271 static/js/impala/stats/csv_keys.js:277
+#: static/js/impala/stats/csv_keys.js:271 static/js/impala/stats/csv_keys.js:277 static/js/zamboni/stats-all.js:15552 static/js/zamboni/stats-all.js:15558 static/js/zamboni/stats-min.js:5
 msgid "<b>{0}</b> from {1} to {2}"
 msgstr ""
 
 #. L10n: {0} and {1} are integers.
-#: static/js/impala/stats/csv_keys.js:275
+#: static/js/impala/stats/csv_keys.js:275 static/js/zamboni/stats-all.js:15556 static/js/zamboni/stats-min.js:5
 msgid "<b>{0}</b> average in last {1} days"
 msgstr ""
 
-#: static/js/impala/stats/overview.js:19
+#: static/js/impala/stats/overview.js:19 static/js/zamboni/stats-all.js:16469 static/js/zamboni/stats-min.js:5
 msgid "No data available."
 msgstr ""
 
-#: static/js/impala/stats/table.js:74
+#: static/js/impala/stats/table.js:74 static/js/zamboni/stats-all.js:17209 static/js/zamboni/stats-min.js:5
 msgid "Date"
 msgstr ""
 
-#: static/js/impala/stats/topchart.js:96
+#: static/js/impala/stats/topchart.js:96 static/js/zamboni/stats-all.js:16600 static/js/zamboni/stats-min.js:5
 msgid "Other"
 msgstr ""
 
-#: static/js/zamboni/admin_validation.js:24 static/js/zamboni/devhub.js:1229 static/js/zamboni/editors.js:295
+#: static/js/zamboni/admin-all.js:180 static/js/zamboni/admin-min.js:1 static/js/zamboni/admin_validation.js:24 static/js/zamboni/devhub-all.js:2408 static/js/zamboni/devhub-min.js:2
+#: static/js/zamboni/devhub.js:1229 static/js/zamboni/editors-all.js:15576 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:295
 msgid "Select an application first"
 msgstr ""
 
-#: static/js/zamboni/admin_validation.js:51
+#: static/js/zamboni/admin-all.js:207 static/js/zamboni/admin-min.js:1 static/js/zamboni/admin_validation.js:51
 msgid "Set {0} add-on to a max version of {1} and email the author."
 msgid_plural "Set {0} add-ons to a max version of {1} and email the authors."
 msgstr[0] ""
 msgstr[1] ""
 
-#: static/js/zamboni/admin_validation.js:54
+#: static/js/zamboni/admin-all.js:210 static/js/zamboni/admin-min.js:1 static/js/zamboni/admin_validation.js:54
 msgid "Email author of {2} add-on which failed validation."
 msgid_plural "Email authors of {2} add-ons which failed validation."
 msgstr[0] ""
 msgstr[1] ""
 
-#. L10n: {0} is an app name like Firefox.
-#: static/js/zamboni/buttons.js:66
-msgid "Accept and Install"
-msgstr ""
-
-#: static/js/zamboni/buttons.js:66
-msgid "Add to {0}"
-msgstr ""
-
-#: static/js/zamboni/buttons.js:71
-msgid "Download Now"
-msgstr ""
-
-#: static/js/zamboni/buttons.js:112
-msgid "Add-on has not been updated to support default-to-compatible."
-msgstr ""
-
-#: static/js/zamboni/buttons.js:117
-msgid "You need to be using Firefox 10.0 or higher."
-msgstr ""
-
-#: static/js/zamboni/buttons.js:129
-msgid "Mozilla has marked this version as incompatible with your Firefox version."
-msgstr ""
-
-#. L10n: {0} is an platform like Windows or Linux.
-#: static/js/zamboni/buttons.js:210
-msgid "Install for {0} anyway"
-msgstr ""
-
-#: static/js/zamboni/buttons.js:210
-msgid "Download for {0} anyway"
-msgstr ""
-
-#: static/js/zamboni/buttons.js:267
-msgid "Not available for your platform"
-msgstr ""
-
-#. L10n: {0} is an app name, {1} is the app version.
-#: static/js/zamboni/buttons.js:278 static/js/zamboni/buttons.js:315
-msgid "Not available for {0} {1}"
-msgstr ""
-
-#: static/js/zamboni/buttons.js:341
-msgid "Works with {app} {min} - {max}"
-msgstr ""
-
-#: static/js/zamboni/buttons.js:343
-msgid "View other versions"
-msgstr ""
-
-#: static/js/zamboni/buttons.js:391
-msgid "Only with Firefox — Get Firefox Now!"
-msgstr ""
-
-#: static/js/zamboni/buttons.js:507 static/js/zamboni/mobile/buttons.js:43
-msgid "Sorry, you need a Mozilla-based browser (such as Firefox) to install a search plugin."
-msgstr ""
-
-#: static/js/zamboni/collections.js:229
-msgid "Adding to Favorites&hellip;"
-msgstr ""
-
-#: static/js/zamboni/collections.js:232
-msgid "Removing Favorite&hellip;"
-msgstr ""
-
-#: static/js/zamboni/collections.js:235
-msgid "Add to Favorites"
-msgstr ""
-
-#: static/js/zamboni/collections.js:238
-msgid "Remove from Favorites"
-msgstr ""
-
-#: static/js/zamboni/collections.js:303
-msgid "Pending"
-msgstr ""
-
-#: static/js/zamboni/collections.js:304
-msgid "Add a comment"
-msgstr ""
-
-#: static/js/zamboni/collections.js:304
-msgid "Comment"
-msgstr ""
-
-#: static/js/zamboni/collections.js:305
-msgid "Remove this add-on from the collection"
-msgstr ""
-
-#: static/js/zamboni/collections.js:305 static/js/zamboni/collections.js:334
-msgid "Remove"
-msgstr ""
-
-#: static/js/zamboni/collections.js:334
-msgid "Remove this user as a contributor"
-msgstr ""
-
-#: static/js/zamboni/collections.js:346
-msgid "An email address is required."
-msgstr ""
-
-#: static/js/zamboni/collections.js:364
-msgid "You cannot add yourself as a contributor."
-msgstr ""
-
-#: static/js/zamboni/collections.js:366
-msgid "You have already added that user."
-msgstr ""
-
-#: static/js/zamboni/collections.js:573
-msgid "Add to favorites"
-msgstr ""
-
-#: static/js/zamboni/collections.js:577
-msgid "Remove from favorites"
-msgstr ""
-
-#: static/js/zamboni/collections.js:604
-msgid "Stop following"
-msgstr ""
-
-#: static/js/zamboni/devhub.js:110
+#: static/js/zamboni/devhub-all.js:1289 static/js/zamboni/devhub-min.js:1 static/js/zamboni/devhub.js:110
 msgid "Your browser does not support the video tag"
 msgstr ""
 
-#: static/js/zamboni/devhub.js:371
+#: static/js/zamboni/devhub-all.js:1550 static/js/zamboni/devhub-min.js:1 static/js/zamboni/devhub.js:371
 msgid "Changes Saved"
 msgstr ""
 
-#: static/js/zamboni/devhub.js:387
+#: static/js/zamboni/devhub-all.js:1566 static/js/zamboni/devhub-min.js:1 static/js/zamboni/devhub.js:387
 msgid "Enter a new author's email address"
 msgstr ""
 
-#: static/js/zamboni/devhub.js:536
+#: static/js/zamboni/devhub-all.js:1715 static/js/zamboni/devhub-min.js:1 static/js/zamboni/devhub.js:536
 msgid "There was an error uploading your file."
 msgstr ""
 
-#: static/js/zamboni/devhub.js:681
+#: static/js/zamboni/devhub-all.js:1860 static/js/zamboni/devhub-min.js:1 static/js/zamboni/devhub.js:681
 msgid "{files} file"
 msgid_plural "{files} files"
 msgstr[0] ""
 msgstr[1] ""
 
-#: static/js/zamboni/devhub.js:684
+#: static/js/zamboni/devhub-all.js:1863 static/js/zamboni/devhub-min.js:1 static/js/zamboni/devhub.js:684
 msgid "{reviews} user review"
 msgid_plural "{reviews} user reviews"
 msgstr[0] ""
 msgstr[1] ""
 
-#: static/js/zamboni/devhub.js:796
+#: static/js/zamboni/devhub-all.js:1975 static/js/zamboni/devhub-min.js:2 static/js/zamboni/devhub.js:796
 msgid "Learn more"
 msgstr ""
 
-#: static/js/zamboni/devhub.js:800
+#: static/js/zamboni/devhub-all.js:1979 static/js/zamboni/devhub-min.js:2 static/js/zamboni/devhub.js:800
 msgid "Example"
 msgstr ""
 
-#: static/js/zamboni/devhub.js:1130
+#: static/js/zamboni/devhub-all.js:2309 static/js/zamboni/devhub-min.js:2 static/js/zamboni/devhub.js:1130
 msgid "Image changes being processed"
 msgstr ""
 
-#: static/js/zamboni/devhub.js:1280
+#: static/js/zamboni/devhub-all.js:2459 static/js/zamboni/devhub-min.js:2 static/js/zamboni/devhub.js:1280
 msgid "Must be a valid e-mail address."
+msgstr ""
+
+#: static/js/zamboni/devhub-all.js:2613 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:80
+msgid "All tests passed successfully."
+msgstr ""
+
+#: static/js/zamboni/devhub-all.js:2616 static/js/zamboni/devhub-all.js:3011 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:83 static/js/zamboni/validator.js:478
+msgid "These tests were not run."
+msgstr ""
+
+#: static/js/zamboni/devhub-all.js:2664 static/js/zamboni/devhub-all.js:2677 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:131 static/js/zamboni/validator.js:144
+msgid "Tests"
+msgstr ""
+
+#: static/js/zamboni/devhub-all.js:2779 static/js/zamboni/devhub-all.js:3108 static/js/zamboni/devhub-all.js:3127 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:246
+#: static/js/zamboni/validator.js:575 static/js/zamboni/validator.js:594
+msgid "Error"
+msgstr ""
+
+#: static/js/zamboni/devhub-all.js:2780 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:247
+msgid "Warning"
+msgstr ""
+
+#: static/js/zamboni/devhub-all.js:2794 static/js/zamboni/devhub-min.js:2 static/js/zamboni/files-all.js:5657 static/js/zamboni/files-min.js:3 static/js/zamboni/files.js:411
+#: static/js/zamboni/validator.js:261
+msgid "Ignore this message in future updates"
+msgstr ""
+
+#: static/js/zamboni/devhub-all.js:2817 static/js/zamboni/devhub-min.js:2 static/js/zamboni/files-all.js:5663 static/js/zamboni/files-min.js:3 static/js/zamboni/files.js:417
+#: static/js/zamboni/validator.js:284
+msgid "Severity for automated signing:"
+msgstr ""
+
+#: static/js/zamboni/devhub-all.js:2832 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:299
+msgid "Suggestions for passing automated signing:"
+msgstr ""
+
+#: static/js/zamboni/devhub-all.js:2920 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:387
+msgid "Compatibility Tests"
+msgstr ""
+
+#: static/js/zamboni/devhub-all.js:2999 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:466
+msgid "Add-on failed validation."
+msgstr ""
+
+#: static/js/zamboni/devhub-all.js:3001 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:468
+msgid "Add-on passed validation."
+msgstr ""
+
+#: static/js/zamboni/devhub-all.js:3014 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:481
+msgid "{0} error"
+msgid_plural "{0} errors"
+msgstr[0] ""
+msgstr[1] ""
+
+#: static/js/zamboni/devhub-all.js:3016 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:483
+msgid "{0} warning"
+msgid_plural "{0} warnings"
+msgstr[0] ""
+msgstr[1] ""
+
+#: static/js/zamboni/devhub-all.js:3018 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:485
+msgid "{0} notice"
+msgid_plural "{0} notices"
+msgstr[0] ""
+msgstr[1] ""
+
+#: static/js/zamboni/devhub-all.js:3110 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:577
+msgid "Validation task could not complete or completed with errors"
+msgstr ""
+
+#: static/js/zamboni/devhub-all.js:3128 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:595
+msgid "Internal server error"
 msgstr ""
 
 #: static/js/zamboni/devhub_search.js:8
 msgid "No results found."
 msgstr ""
 
-#: static/js/zamboni/editors.js:121
+#: static/js/zamboni/editors-all.js:15402 static/js/zamboni/editors-min.js:4 static/js/zamboni/editors.js:121
 msgid "{name} was viewing this page first."
 msgstr ""
 
-#: static/js/zamboni/editors.js:171
+#: static/js/zamboni/editors-all.js:15452 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:171
 msgid "Receipt checked by app."
 msgstr ""
 
-#: static/js/zamboni/editors.js:173
+#: static/js/zamboni/editors-all.js:15454 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:173
 msgid "Receipt was not checked by app."
 msgstr ""
 
-#: static/js/zamboni/editors.js:244
+#: static/js/zamboni/editors-all.js:15525 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:244
 msgid "{name} was viewing this add-on first."
 msgstr ""
 
-#: static/js/zamboni/editors.js:255
+#: static/js/zamboni/editors-all.js:15536 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:255
 msgid "Loading&hellip;"
 msgstr ""
 
-#: static/js/zamboni/editors.js:260
+#: static/js/zamboni/editors-all.js:15541 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:260
 msgid "Version Notes"
 msgstr ""
 
-#: static/js/zamboni/editors.js:265
+#: static/js/zamboni/editors-all.js:15546 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:265
 msgid "Notes for Reviewers"
 msgstr ""
 
-#: static/js/zamboni/editors.js:270
+#: static/js/zamboni/editors-all.js:15551 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:270
 msgid "No version notes found"
 msgstr ""
 
-#: static/js/zamboni/editors.js:330
+#: static/js/zamboni/editors-all.js:15611 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:330
 msgid "Average Reviews"
 msgstr ""
 
-#: static/js/zamboni/editors.js:386
+#: static/js/zamboni/editors-all.js:15667 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:386
 msgid "Number of Reviews"
 msgstr ""
 
-#: static/js/zamboni/editors.js:445
+#: static/js/zamboni/editors-all.js:15726 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:445
 msgid "Error loading translation"
 msgstr ""
 
-#: static/js/zamboni/files.js:411 static/js/zamboni/validator.js:261
-msgid "Ignore this message in future updates"
-msgstr ""
-
-#: static/js/zamboni/files.js:417 static/js/zamboni/validator.js:284
-msgid "Severity for automated signing:"
-msgstr ""
-
-#: static/js/zamboni/global.js:410
-msgid "Loading..."
-msgstr ""
-
-#. L10n: {0} is the number of characters left.
-#: static/js/zamboni/global.js:474
-msgid "<b>{0}</b> character left."
-msgid_plural "<b>{0}</b> characters left."
-msgstr[0] ""
-msgstr[1] ""
-
-#: static/js/zamboni/init.js:28
-msgid "This feature is temporarily disabled while we perform website maintenance. Please check back a little later."
-msgstr ""
-
-#: static/js/zamboni/l10n.js:45
-msgid "Remove this localization"
-msgstr ""
-
-#: static/js/zamboni/password-strength.js:20
-msgid "Password strength:"
-msgstr ""
-
-#: static/js/zamboni/password-strength.js:26
-msgid "At least {0} character left."
-msgid_plural "At least {0} characters left."
-msgstr[0] ""
-msgstr[1] ""
-
-#: static/js/zamboni/themes_review.js:176
-msgid "Requested Info"
-msgstr ""
-
-#: static/js/zamboni/themes_review.js:177
-msgid "Flagged"
-msgstr ""
-
-#: static/js/zamboni/themes_review.js:178
-msgid "Duplicate"
-msgstr ""
-
-#: static/js/zamboni/themes_review.js:179
-msgid "Rejected"
-msgstr ""
-
-#: static/js/zamboni/themes_review.js:180
-msgid "Approved"
-msgstr ""
-
-#: static/js/zamboni/themes_review.js:424
-msgid "No results found"
-msgstr ""
-
-#: static/js/zamboni/themes_review_templates.js:31
+#: static/js/zamboni/editors-all.js:15975 static/js/zamboni/editors-min.js:5 static/js/zamboni/themes_review_templates.js:31
 msgid "Theme"
 msgstr ""
 
-#: static/js/zamboni/themes_review_templates.js:33
+#: static/js/zamboni/editors-all.js:15977 static/js/zamboni/editors-min.js:5 static/js/zamboni/themes_review_templates.js:33
 msgid "Reviewer"
 msgstr ""
 
-#: static/js/zamboni/themes_review_templates.js:35
+#: static/js/zamboni/editors-all.js:15979 static/js/zamboni/editors-min.js:5 static/js/zamboni/themes_review_templates.js:35
 msgid "Status"
 msgstr ""
 
-#: static/js/zamboni/validator.js:80
-msgid "All tests passed successfully."
+#: static/js/zamboni/editors-all.js:16196 static/js/zamboni/editors-min.js:5 static/js/zamboni/themes_review.js:176
+msgid "Requested Info"
 msgstr ""
 
-#: static/js/zamboni/validator.js:83 static/js/zamboni/validator.js:478
-msgid "These tests were not run."
+#: static/js/zamboni/editors-all.js:16197 static/js/zamboni/editors-min.js:5 static/js/zamboni/themes_review.js:177
+msgid "Flagged"
 msgstr ""
 
-#: static/js/zamboni/validator.js:131 static/js/zamboni/validator.js:144
-msgid "Tests"
+#: static/js/zamboni/editors-all.js:16198 static/js/zamboni/editors-min.js:5 static/js/zamboni/themes_review.js:178
+msgid "Duplicate"
 msgstr ""
 
-#: static/js/zamboni/validator.js:246 static/js/zamboni/validator.js:575 static/js/zamboni/validator.js:594
-msgid "Error"
+#: static/js/zamboni/editors-all.js:16199 static/js/zamboni/editors-min.js:5 static/js/zamboni/themes_review.js:179
+msgid "Rejected"
 msgstr ""
 
-#: static/js/zamboni/validator.js:247
-msgid "Warning"
+#: static/js/zamboni/editors-all.js:16200 static/js/zamboni/editors-min.js:5 static/js/zamboni/themes_review.js:180
+msgid "Approved"
 msgstr ""
 
-#: static/js/zamboni/validator.js:299
-msgid "Suggestions for passing automated signing:"
+#: static/js/zamboni/editors-all.js:16444 static/js/zamboni/editors-min.js:5 static/js/zamboni/themes_review.js:424
+msgid "No results found"
 msgstr ""
 
-#: static/js/zamboni/validator.js:387
-msgid "Compatibility Tests"
-msgstr ""
-
-#: static/js/zamboni/validator.js:466
-msgid "Add-on failed validation."
-msgstr ""
-
-#: static/js/zamboni/validator.js:468
-msgid "Add-on passed validation."
-msgstr ""
-
-#: static/js/zamboni/validator.js:481
-msgid "{0} error"
-msgid_plural "{0} errors"
-msgstr[0] ""
-msgstr[1] ""
-
-#: static/js/zamboni/validator.js:483
-msgid "{0} warning"
-msgid_plural "{0} warnings"
-msgstr[0] ""
-msgstr[1] ""
-
-#: static/js/zamboni/validator.js:485
-msgid "{0} notice"
-msgid_plural "{0} notices"
-msgstr[0] ""
-msgstr[1] ""
-
-#: static/js/zamboni/validator.js:577
-msgid "Validation task could not complete or completed with errors"
-msgstr ""
-
-#: static/js/zamboni/validator.js:595
-msgid "Internal server error"
-msgstr ""
-
-#: static/js/zamboni/mobile/buttons.js:52
+#: static/js/zamboni/mobile-all.js:15186 static/js/zamboni/mobile/buttons.js:52
 msgid "Not Updated for {0} {1}"
 msgstr ""
 
-#: static/js/zamboni/mobile/buttons.js:53
+#: static/js/zamboni/mobile-all.js:15187 static/js/zamboni/mobile/buttons.js:53
 msgid "Requires Newer Version of {0}"
 msgstr ""
 
-#: static/js/zamboni/mobile/buttons.js:54
+#: static/js/zamboni/mobile-all.js:15188 static/js/zamboni/mobile/buttons.js:54
 msgid "Unreviewed"
 msgstr ""
 
-#: static/js/zamboni/mobile/buttons.js:55
+#: static/js/zamboni/mobile-all.js:15189 static/js/zamboni/mobile/buttons.js:55
 msgid "Experimental <span>(Learn More)</span>"
 msgstr ""
 
-#: static/js/zamboni/mobile/buttons.js:56 static/js/zamboni/mobile/buttons.js:57
+#: static/js/zamboni/mobile-all.js:15190 static/js/zamboni/mobile-all.js:15191 static/js/zamboni/mobile/buttons.js:56 static/js/zamboni/mobile/buttons.js:57
 msgid "Not Available for {0}"
 msgstr ""
 
-#: static/js/zamboni/mobile/buttons.js:58
+#: static/js/zamboni/mobile-all.js:15192 static/js/zamboni/mobile/buttons.js:58
 msgid "Experimental"
 msgstr ""
 
-#: static/js/zamboni/mobile/buttons.js:59
+#: static/js/zamboni/mobile-all.js:15193 static/js/zamboni/mobile/buttons.js:59
 msgid "Themes Require Newer Version of {0}"
 msgstr ""
 
-#: static/js/zamboni/mobile/buttons.js:60
+#: static/js/zamboni/mobile-all.js:15194 static/js/zamboni/mobile/buttons.js:60
 msgid "Themes Require {0}"
 msgstr ""
 
-#: static/js/zamboni/mobile/buttons.js:105
+#: static/js/zamboni/mobile-all.js:15239 static/js/zamboni/mobile/buttons.js:105
 msgid "Installing..."
 msgstr ""
 
-#: static/js/zamboni/mobile/buttons.js:125
+#: static/js/zamboni/mobile-all.js:15259 static/js/zamboni/mobile/buttons.js:125
 msgid "This add-on has been preliminarily reviewed by Mozilla."
 msgstr ""
 
-#: static/js/zamboni/mobile/buttons.js:250
+#: static/js/zamboni/mobile-all.js:15384 static/js/zamboni/mobile/buttons.js:250
 msgid "Keep it"
 msgstr ""
 
-#: static/js/zamboni/mobile/general.js:344
+#: static/js/zamboni/mobile-all.js:16049 static/js/zamboni/mobile-min.js:6 static/js/zamboni/mobile/general.js:344
 msgid "You're trying it on!"
 msgstr ""
 
-#: static/js/zamboni/mobile/general.js:356
+#: static/js/zamboni/mobile-all.js:16061 static/js/zamboni/mobile-min.js:6 static/js/zamboni/mobile/general.js:356
 msgid "Added to Firefox"
 msgstr ""
-

--- a/locale/sk/LC_MESSAGES/django.po
+++ b/locale/sk/LC_MESSAGES/django.po
@@ -5,83 +5,70 @@ msgid ""
 msgstr ""
 "Project-Id-Version: REMORA 0.1\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2016-02-24 21:23+0000\n"
+"POT-Creation-Date: 2016-04-18 15:40+0000\n"
 "PO-Revision-Date: 2016-04-13 22:16+0000\n"
 "Last-Translator: Branislav Rozbora <rozbora@mozilla.sk>\n"
 "Language-Team: Mozilla.sk <l10n@mozilla.sk>\n"
-"Language: sk\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=3; plural=(n==1) ? 0 : (n>=2 && n<=4) ? 1 : 2;\n"
 "Generated-By: Babel 2.2.0\n"
-"X-Generator: Pontoon\n"
-
-#: src/olympia/accounts/views.py:52
-msgid "Your log in attempt could not be parsed. Please try again."
-msgstr ""
-"Váš pokus o prihlásenie sa nepodarilo spracovať. Skúste to prosím znovu."
 
 #: src/olympia/accounts/views.py:54
+msgid "Your log in attempt could not be parsed. Please try again."
+msgstr "Váš pokus o prihlásenie sa nepodarilo spracovať. Skúste to prosím znovu."
+
+#: src/olympia/accounts/views.py:56
 msgid "Your Firefox Account could not be found. Please try again."
 msgstr "Váš účet Firefox Account nebol nájdený. Skúste to prosím znovu."
 
-#: src/olympia/accounts/views.py:55
+#: src/olympia/accounts/views.py:57
 msgid "You could not be logged in. Please try again."
 msgstr "Prihlásenie sa nepodarilo. Skúste to prosím znovu."
 
-#: src/olympia/accounts/views.py:57
+#: src/olympia/accounts/views.py:59
 msgid "Your account has already been migrated to Firefox Accounts."
 msgstr "Váš účet bol už presunutý na účet Firefox Account."
 
-#: src/olympia/accounts/views.py:59
+#: src/olympia/accounts/views.py:61
 msgid "Your Firefox Account already exists on this site."
 msgstr "Váš účet Firefox Account sa už na tejto stránke používa."
 
-#: src/olympia/accounts/views.py:108
+#: src/olympia/accounts/views.py:110
 msgid "Great job!"
 msgstr "Dobrá práca!"
 
-#: src/olympia/accounts/views.py:109
+#: src/olympia/accounts/views.py:111
 msgid "You can now log in to Add-ons with your Firefox Account."
-msgstr ""
-"Teraz sa môžete na server s doplnkami prihlasovať pomocou svojho účtu "
-"Firefox Account."
+msgstr "Teraz sa môžete na server s doplnkami prihlasovať pomocou svojho účtu Firefox Account."
 
-#: src/olympia/accounts/views.py:121
+#: src/olympia/accounts/views.py:123
 msgid "Need help?"
 msgstr "Potrebujete pomoc?"
 
-#: src/olympia/addons/buttons.py:180
+#: src/olympia/addons/buttons.py:177
 msgid "Download Now"
 msgstr "Prevziať teraz"
 
-#: src/olympia/addons/buttons.py:182
+#: src/olympia/addons/buttons.py:179
 msgid "Download"
 msgstr "Prevziať"
 
 #. L10n: please keep &nbsp; in the string so &rarr; does not wrap.
-#: src/olympia/addons/buttons.py:186
+#: src/olympia/addons/buttons.py:183
 msgid "Continue to Download&nbsp;&rarr;"
 msgstr "Pokračovať na prevzatie&nbsp;&rarr;"
 
-#: src/olympia/addons/buttons.py:202 src/olympia/addons/helpers.py:35
-#: src/olympia/addons/views.py:319
-#: src/olympia/addons/templates/addons/impala/details.html:114
-#: src/olympia/addons/templates/addons/impala/listing/items.html:17
-#: src/olympia/addons/templates/addons/mobile/home.html:40
-#: src/olympia/amo/templates/amo/side_nav.html:6
-#: src/olympia/amo/templates/amo/side_nav.html:10
-#: src/olympia/amo/templates/amo/site_nav.html:2
-#: src/olympia/amo/templates/amo/site_nav.html:55
-#: src/olympia/bandwagon/views.py:95 src/olympia/browse/views.py:54
-#: src/olympia/browse/views.py:68 src/olympia/browse/views.py:235
-#: src/olympia/browse/templates/browse/impala/category_landing.html:22
+#: src/olympia/addons/buttons.py:199 src/olympia/addons/helpers.py:35 src/olympia/addons/views.py:333 src/olympia/addons/templates/addons/impala/details.html:111
+#: src/olympia/addons/templates/addons/impala/listing/items.html:17 src/olympia/addons/templates/addons/mobile/home.html:40 src/olympia/amo/templates/amo/side_nav.html:6
+#: src/olympia/amo/templates/amo/side_nav.html:10 src/olympia/amo/templates/amo/site_nav.html:2 src/olympia/amo/templates/amo/site_nav.html:53 src/olympia/bandwagon/views.py:95
+#: src/olympia/browse/views.py:54 src/olympia/browse/views.py:68 src/olympia/browse/views.py:202 src/olympia/browse/templates/browse/impala/category_landing.html:22
 #: src/olympia/browse/templates/browse/personas/mobile/category_landing.html:26
 msgid "Featured"
 msgstr "Odporúčané"
 
-#: src/olympia/addons/buttons.py:221
+#: src/olympia/addons/buttons.py:218
 msgid "Add to {0}"
 msgstr "Pridať do programu {0}"
 
@@ -104,7 +91,6 @@ msgid "Invalid tag: {0}"
 msgid_plural "Invalid tags: {0}"
 msgstr[0] "Neplatná značka: {0}"
 msgstr[1] "Neplatné značky: {0}"
-msgstr[2] "Neplatné značky: {0}"
 
 #. L10n: {0} is a single tag or a comma-separated list of tags.
 #: src/olympia/addons/forms.py:103
@@ -112,73 +98,57 @@ msgid "\"{0}\" is a reserved tag and cannot be used."
 msgid_plural "\"{0}\" are reserved tags and cannot be used."
 msgstr[0] "\"{0}\" je rezervovaná značka a nie je možné ju použiť."
 msgstr[1] "\"{0}\" sú rezervované značky a nie je možné ich použiť."
-msgstr[2] "\"{0}\" sú rezervované značky a nie je možné ich použiť."
 
 #: src/olympia/addons/forms.py:111
 msgid "You have {0} too many tags."
 msgid_plural "You have {0} too many tags."
 msgstr[0] "Máte {0} značku navyše."
 msgstr[1] "Máte {0} značky navyše."
-msgstr[2] "Máte {0} značiek navyše."
 
 #: src/olympia/addons/forms.py:117
 #, python-format
-msgid ""
-"All tags must be %s characters or less after invalid characters are removed."
-msgstr ""
-"Po odstránení neplatných znakov musia mať všetky značka najviac %s znakov."
+msgid "All tags must be %s characters or less after invalid characters are removed."
+msgstr "Po odstránení neplatných znakov musia mať všetky značka najviac %s znakov."
 
 #: src/olympia/addons/forms.py:121
 msgid "All tags must be at least {0} character."
 msgid_plural "All tags must be at least {0} characters."
 msgstr[0] "Každá značka musí mať aspoň {0} znak."
 msgstr[1] "Každá značka musí mať aspoň {0} znaky."
-msgstr[2] "Každá značka musí mať aspoň {0} znakov."
 
-#: src/olympia/addons/forms.py:234
-msgid ""
-"Categories cannot be changed while your add-on is featured for this "
-"application."
-msgstr ""
-"Pokiaľ je doplnok v zozname odporúčaných, nie je možné zmeniť jeho "
-"kategórie."
+#: src/olympia/addons/forms.py:238
+msgid "Categories cannot be changed while your add-on is featured for this application."
+msgstr "Pokiaľ je doplnok v zozname odporúčaných, nie je možné zmeniť jeho kategórie."
 
 #. L10n: {0} is the number of categories.
-#: src/olympia/addons/forms.py:238
+#: src/olympia/addons/forms.py:242
 msgid "You can have only {0} category."
 msgid_plural "You can have only {0} categories."
 msgstr[0] "Môžete zvoliť len {0} kategóriu."
 msgstr[1] "Môžete zvoliť len {0} kategórie."
-msgstr[2] "Môžete zvoliť len {0} kategórií."
 
-#: src/olympia/addons/forms.py:246
-msgid ""
-"The miscellaneous category cannot be combined with additional categories."
+#: src/olympia/addons/forms.py:250
+msgid "The miscellaneous category cannot be combined with additional categories."
 msgstr "Kategória Rôzne nemôže byť kombinovaná s inými kategóriami."
 
-#: src/olympia/addons/forms.py:369
+#: src/olympia/addons/forms.py:374
 #, python-format
-msgid ""
-"Before changing your default locale you must have a name, summary, and "
-"description in that locale. You are missing %s."
-msgstr ""
-"Pred zmenou predvoleného jazyka musíte mať vyplnený názov, súhrn a popis v "
-"tomto jazyku. Zatiaľ nemáte vyplnené: %s."
+msgid "Before changing your default locale you must have a name, summary, and description in that locale. You are missing %s."
+msgstr "Pred zmenou predvoleného jazyka musíte mať vyplnený názov, súhrn a popis v tomto jazyku. Zatiaľ nemáte vyplnené: %s."
 
-#: src/olympia/addons/forms.py:484 src/olympia/addons/forms.py:575
+#: src/olympia/addons/forms.py:455 src/olympia/addons/forms.py:546
 msgid "A license must be selected."
 msgstr "Musí byť zvolená licencia."
 
-#: src/olympia/addons/forms.py:556
+#: src/olympia/addons/forms.py:527
 msgid "Give Your Theme a Name."
 msgstr "Pomenujte svoju tému."
 
-#: src/olympia/addons/forms.py:562
-#: src/olympia/devhub/templates/devhub/personas/submit.html:53
+#: src/olympia/addons/forms.py:533 src/olympia/devhub/templates/devhub/personas/submit.html:53
 msgid "Describe your Theme."
 msgstr "Popíšte svoju tému."
 
-#: src/olympia/addons/forms.py:704
+#: src/olympia/addons/forms.py:675
 msgid "Enter a new author's email address"
 msgstr "Zadajte novú e-mailovú adresu autora"
 
@@ -186,49 +156,39 @@ msgstr "Zadajte novú e-mailovú adresu autora"
 msgid "Not Reviewed"
 msgstr "Neskontrolované"
 
-#: src/olympia/addons/models.py:301
+#: src/olympia/addons/models.py:298
 msgid "Users have the option of contributing more or less than this amount."
-msgstr ""
-"Používatelia môžu prispieť aj väčšou resp. menšou čiastkou ako je táto."
+msgstr "Používatelia môžu prispieť aj väčšou resp. menšou čiastkou ako je táto."
 
-#: src/olympia/addons/models.py:309
-msgid ""
-"Users will always be asked in the Add-ons Manager (Firefox 4 and above)"
+#: src/olympia/addons/models.py:306
+msgid "Users will always be asked in the Add-ons Manager (Firefox 4 and above). Only applies to desktop."
 msgstr ""
-"Používatelia budú vždy upozornení v okne Správcu doplnkov (Firefox 4 a "
-"vyššie)"
 
 # Column name in a table.
-#: src/olympia/addons/models.py:1804
-#: src/olympia/addons/templates/addons/details_box.html:55
-#: src/olympia/devhub/templates/devhub/index.html:92
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:102
+#: src/olympia/addons/models.py:1802 src/olympia/addons/templates/addons/details_box.html:55 src/olympia/devhub/templates/devhub/index.html:92
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:89
 msgid "Listed"
 msgstr "V zozname"
 
-#: src/olympia/addons/views.py:320
-#: src/olympia/browse/templates/browse/personas/mobile/category_landing.html:27
+#: src/olympia/addons/views.py:334 src/olympia/browse/templates/browse/personas/mobile/category_landing.html:27
 msgid "Popular"
 msgstr "Populárne"
 
-#: src/olympia/addons/views.py:321 src/olympia/browse/views.py:238
-#: src/olympia/browse/views.py:280 src/olympia/browse/views.py:482
+#: src/olympia/addons/views.py:335 src/olympia/browse/views.py:205 src/olympia/browse/views.py:247 src/olympia/browse/views.py:449
 msgid "Recently Added"
 msgstr "Naposledy pridané"
 
-#: src/olympia/addons/views.py:322 src/olympia/bandwagon/views.py:99
-#: src/olympia/browse/views.py:60 src/olympia/browse/views.py:71
-#: src/olympia/search/forms.py:16 src/olympia/search/forms.py:91
+#: src/olympia/addons/views.py:336 src/olympia/bandwagon/views.py:99 src/olympia/browse/views.py:60 src/olympia/browse/views.py:71 src/olympia/search/forms.py:16 src/olympia/search/forms.py:91
 msgid "Recently Updated"
 msgstr "Naposledy aktualizované"
 
-#. l10n: {0} is the addon name
 # %1 is an add-on name.
-#: src/olympia/addons/views.py:520
+#. l10n: {0} is the addon name
+#: src/olympia/addons/views.py:534
 msgid "Contribution for {0}"
 msgstr "Príspevok pre {0}"
 
-#: src/olympia/addons/views.py:613
+#: src/olympia/addons/views.py:627
 msgid "Abuse reported."
 msgstr "Zneužitie nahlásené."
 
@@ -236,115 +196,70 @@ msgstr "Zneužitie nahlásené."
 msgid "My add-on doesn't fit into any of the categories"
 msgstr "Môj doplnok nespadá ani do jednej z kategórií"
 
-#: src/olympia/addons/templates/addons/button.html:27
-#: src/olympia/addons/templates/addons/impala/button.html:11
-#: src/olympia/addons/templates/addons/mobile/button.html:11
+#: src/olympia/addons/templates/addons/button.html:27 src/olympia/addons/templates/addons/impala/button.html:11 src/olympia/addons/templates/addons/mobile/button.html:11
 msgid "No compatible versions"
 msgstr "Žiadne kompatibilné verzie"
 
-#: src/olympia/addons/templates/addons/button.html:35
-#: src/olympia/addons/templates/addons/impala/button.html:19
+#: src/olympia/addons/templates/addons/button.html:35 src/olympia/addons/templates/addons/impala/button.html:19
 msgid "Added to Mobile"
 msgstr "Pridané medzi mobilné"
 
-#: src/olympia/addons/templates/addons/button.html:37
-#: src/olympia/addons/templates/addons/impala/button.html:21
+#: src/olympia/addons/templates/addons/button.html:37 src/olympia/addons/templates/addons/impala/button.html:21
 msgid "Add to Mobile"
 msgstr "Pridať medzi mobilné"
 
 #. {0} is a platform name like Windows or Mac OS X.
-#: src/olympia/addons/templates/addons/button.html:66
-#: src/olympia/addons/templates/addons/includes/install_button.html:19
+#: src/olympia/addons/templates/addons/button.html:66 src/olympia/addons/templates/addons/includes/install_button.html:19
 msgid "for {0}"
 msgstr "pre {0}"
 
-#: src/olympia/addons/templates/addons/button.html:82
-#: src/olympia/addons/templates/addons/mobile/button.html:23
+#: src/olympia/addons/templates/addons/button.html:82 src/olympia/addons/templates/addons/mobile/button.html:23
 msgid "View privacy policy"
 msgstr "Zobraziť zásady ochrany súkromia"
 
-#: src/olympia/addons/templates/addons/button.html:87
-#: src/olympia/addons/templates/addons/details_box.html:133
-#: src/olympia/addons/templates/addons/mobile/button.html:28
+#: src/olympia/addons/templates/addons/button.html:87 src/olympia/addons/templates/addons/details_box.html:133 src/olympia/addons/templates/addons/mobile/button.html:28
 #: src/olympia/discovery/templates/discovery/addons/detail.html:28
 msgid "View End-User License Agreement"
 msgstr "Zobraziť licenčnú zmluvu koncového používateľa"
 
-#: src/olympia/addons/templates/addons/button.html:92
-#: src/olympia/addons/templates/addons/impala/button.html:54
+#: src/olympia/addons/templates/addons/button.html:92 src/olympia/addons/templates/addons/impala/button.html:54
 #, python-format
-msgid ""
-"This add-on has not been reviewed by Mozilla. <a href=\"%(url)s\">Learn "
-"more</a>"
-msgstr ""
-"Tento doplnok nebol skontrolovaný Mozillou. <a href=\"%(url)s\">Ďalšie "
-"informácie</a>"
+msgid "This add-on has not been reviewed by Mozilla. <a href=\"%(url)s\">Learn more</a>"
+msgstr "Tento doplnok nebol skontrolovaný Mozillou. <a href=\"%(url)s\">Ďalšie informácie</a>"
 
-#: src/olympia/addons/templates/addons/button.html:97
-#: src/olympia/addons/templates/addons/impala/button.html:60
+#: src/olympia/addons/templates/addons/button.html:97 src/olympia/addons/templates/addons/impala/button.html:60
 #, python-format
-msgid ""
-"This add-on has been preliminarily reviewed by Mozilla. <a "
-"href=\"%(url)s\">Learn more</a>"
-msgstr ""
-"Tento doplnok bol predbežne skontrolovaný Mozillou. <a "
-"href=\"%(url)s\">Ďalšie informácie</a>"
+msgid "This add-on has been preliminarily reviewed by Mozilla. <a href=\"%(url)s\">Learn more</a>"
+msgstr "Tento doplnok bol predbežne skontrolovaný Mozillou. <a href=\"%(url)s\">Ďalšie informácie</a>"
 
-#: src/olympia/addons/templates/addons/contribution.html:11
-#: src/olympia/addons/templates/addons/impala/developers.html:44
-msgid ""
-"The developer of this add-on asks that you help support its continued "
-"development by making a small contribution."
-msgstr ""
-"Autor tohto doplnku žiada o podporu v jeho vývoji zaslaním malého príspevku."
+#: src/olympia/addons/templates/addons/contribution.html:11 src/olympia/addons/templates/addons/impala/developers.html:44
+msgid "The developer of this add-on asks that you help support its continued development by making a small contribution."
+msgstr "Autor tohto doplnku žiada o podporu v jeho vývoji zaslaním malého príspevku."
 
 #: src/olympia/addons/templates/addons/contribution.html:14
 #, python-format
-msgid ""
-"The developer of this add-on asks that you show your support by making a "
-"donation to the <a href=\"%(charity_url)s\">%(charity_name)s</a>."
-msgstr ""
-"Autor tohto doplnku žiada o prejavenie podpory tým, že prispejete na <a "
-"href=\"%(charity_url)s\">%(charity_name)s</a>."
+msgid "The developer of this add-on asks that you show your support by making a donation to the <a href=\"%(charity_url)s\">%(charity_name)s</a>."
+msgstr "Autor tohto doplnku žiada o prejavenie podpory tým, že prispejete na <a href=\"%(charity_url)s\">%(charity_name)s</a>."
 
 #: src/olympia/addons/templates/addons/contribution.html:19
 #, python-format
-msgid ""
-"The developer of this add-on asks that you show your support by making a "
-"small contribution to <a href=\"%(charity_url)s\">%(charity_name)s</a>."
-msgstr ""
-"Autor tohto doplnku žiada o prejavenie podpory tým, že prispejete malou "
-"čiastkou na <a href=\"%(charity_url)s\">%(charity_name)s</a>."
+msgid "The developer of this add-on asks that you show your support by making a small contribution to <a href=\"%(charity_url)s\">%(charity_name)s</a>."
+msgstr "Autor tohto doplnku žiada o prejavenie podpory tým, že prispejete malou čiastkou na <a href=\"%(charity_url)s\">%(charity_name)s</a>."
 
-#: src/olympia/addons/templates/addons/contribution.html:30
-#: src/olympia/addons/templates/addons/impala/contribution.html:18
-#: src/olympia/templates/menu_links.html:25
+#: src/olympia/addons/templates/addons/contribution.html:30 src/olympia/addons/templates/addons/impala/contribution.html:18 src/olympia/templates/menu_links.html:25
 msgid "Contribute"
 msgstr "Prispieť"
 
-#. Click Contribute button OR Install button
 # This is a separator between the graphical [contribute] button and the
 # graphical [download now] button
-#: src/olympia/addons/templates/addons/contribution.html:34
-#: src/olympia/addons/templates/addons/report_abuse.html:26
-#: src/olympia/addons/templates/addons/impala/contribution.html:32
-#: src/olympia/devhub/templates/devhub/addons/ajax_compat_update.html:36
-#: src/olympia/devhub/templates/devhub/addons/profile.html:44
-#: src/olympia/devhub/templates/devhub/addons/edit/admin.html:101
-#: src/olympia/devhub/templates/devhub/addons/edit/basic.html:152
-#: src/olympia/devhub/templates/devhub/addons/edit/details.html:85
-#: src/olympia/devhub/templates/devhub/addons/edit/support.html:67
-#: src/olympia/devhub/templates/devhub/addons/edit/technical.html:166
-#: src/olympia/devhub/templates/devhub/addons/forms_shared/media.html:149
-#: src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:44
-#: src/olympia/devhub/templates/devhub/versions/add_file_modal.html:78
-#: src/olympia/devhub/templates/devhub/versions/edit.html:139
-#: src/olympia/devhub/templates/devhub/versions/list.html:242
-#: src/olympia/devhub/templates/devhub/versions/list.html:276
-#: src/olympia/devhub/templates/devhub/versions/list.html:317
-#: src/olympia/devhub/templates/devhub/versions/list.html:351
-#: src/olympia/reviews/templates/reviews/edit_review.html:16
-#: src/olympia/translations/templates/translations/trans-menu.html:50
+#. Click Contribute button OR Install button
+#: src/olympia/addons/templates/addons/contribution.html:34 src/olympia/addons/templates/addons/report_abuse.html:26 src/olympia/addons/templates/addons/impala/contribution.html:32
+#: src/olympia/devhub/templates/devhub/addons/ajax_compat_update.html:36 src/olympia/devhub/templates/devhub/addons/profile.html:44 src/olympia/devhub/templates/devhub/addons/edit/admin.html:101
+#: src/olympia/devhub/templates/devhub/addons/edit/basic.html:152 src/olympia/devhub/templates/devhub/addons/edit/details.html:85 src/olympia/devhub/templates/devhub/addons/edit/support.html:67
+#: src/olympia/devhub/templates/devhub/addons/edit/technical.html:166 src/olympia/devhub/templates/devhub/addons/forms_shared/media.html:149
+#: src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:43 src/olympia/devhub/templates/devhub/versions/add_file_modal.html:58 src/olympia/devhub/templates/devhub/versions/edit.html:139
+#: src/olympia/devhub/templates/devhub/versions/list.html:239 src/olympia/devhub/templates/devhub/versions/list.html:281 src/olympia/devhub/templates/devhub/versions/list.html:315
+#: src/olympia/devhub/templates/devhub/versions/list.html:349 src/olympia/reviews/templates/reviews/edit_review.html:16 src/olympia/translations/templates/translations/trans-menu.html:50
 #: src/olympia/translations/templates/translations/trans-menu.html:62
 msgid "or"
 msgstr "alebo"
@@ -353,39 +268,23 @@ msgstr "alebo"
 msgid "Suggested Contribution: {0}"
 msgstr "Navrhnutý príspevok: {0}"
 
-#: src/olympia/addons/templates/addons/contribution.html:48
-#: src/olympia/amo/templates/amo/recaptcha.html:5
-#: src/olympia/versions/templates/versions/version.html:52
+#: src/olympia/addons/templates/addons/contribution.html:48 src/olympia/amo/templates/amo/recaptcha.html:5 src/olympia/versions/templates/versions/version.html:52
 msgid "What's this?"
 msgstr "Čo je toto?"
 
 #: src/olympia/addons/templates/addons/contribution.html:63
 #, python-format
-msgid ""
-"The developer of this add-on would like you to consider making a donation to"
-" the <a href=\"%(charity_url)s\">%(charity_name)s</a> if you enjoy using it."
-msgstr ""
-"Ak sa Vám doplnok páči, vývojár tohto doplnku vás žiada o zváženie príspevku"
-" pre organizáciu <a href=\"%(charity_url)s\">%(charity_name)s</a>."
+msgid "The developer of this add-on would like you to consider making a donation to the <a href=\"%(charity_url)s\">%(charity_name)s</a> if you enjoy using it."
+msgstr "Ak sa Vám doplnok páči, vývojár tohto doplnku vás žiada o zváženie príspevku pre organizáciu <a href=\"%(charity_url)s\">%(charity_name)s</a>."
 
 #: src/olympia/addons/templates/addons/contribution.html:69
 #, python-format
-msgid ""
-"The developer of this add-on would like you to consider making a small "
-"contribution to <a href=\"%(charity_url)s\">%(charity_name)s</a> if you "
-"enjoy using it."
-msgstr ""
-"Ak sa Vám doplnok páči, vývojár tohto doplnku vás žiada o zváženie malého "
-"príspevku pre organizáciu <a href=\"%(charity_url)s\">%(charity_name)s</a>."
+msgid "The developer of this add-on would like you to consider making a small contribution to <a href=\"%(charity_url)s\">%(charity_name)s</a> if you enjoy using it."
+msgstr "Ak sa Vám doplnok páči, vývojár tohto doplnku vás žiada o zváženie malého príspevku pre organizáciu <a href=\"%(charity_url)s\">%(charity_name)s</a>."
 
 #: src/olympia/addons/templates/addons/contribution.html:76
-msgid ""
-"Mozilla is committed to supporting a vibrant and healthy developer "
-"ecosystem. Your optional contribution helps sustain further development of "
-"this add-on."
-msgstr ""
-"Mozilla má záujem podporovať pulzujúci a zdravý ekosystém vývojárov. Váš "
-"voliteľný príspevok pomôže zachovať ďalší vývoj tohto doplnku."
+msgid "Mozilla is committed to supporting a vibrant and healthy developer ecosystem. Your optional contribution helps sustain further development of this add-on."
+msgstr "Mozilla má záujem podporovať pulzujúci a zdravý ekosystém vývojárov. Váš voliteľný príspevok pomôže zachovať ďalší vývoj tohto doplnku."
 
 #: src/olympia/addons/templates/addons/contributions_lightbox.html:5
 msgid "Make a Contribution"
@@ -393,35 +292,24 @@ msgstr "Odoslanie príspevku"
 
 #: src/olympia/addons/templates/addons/contributions_lightbox.html:9
 #, python-format
-msgid ""
-"Help support the continued development of <strong>%(addon_name)s</strong> by"
-" making a small contribution through <a href=\"%(paypal_url)s\">PayPal</a>."
-msgstr ""
-"Pomôžte podporiť vývoj doplnku <strong>%(addon_name)s</strong> zaslaním "
-"malého príspevku pomocou služby <a href=\"%(paypal_url)s\">PayPal</a>."
+msgid "Help support the continued development of <strong>%(addon_name)s</strong> by making a small contribution through <a href=\"%(paypal_url)s\">PayPal</a>."
+msgstr "Pomôžte podporiť vývoj doplnku <strong>%(addon_name)s</strong> zaslaním malého príspevku pomocou služby <a href=\"%(paypal_url)s\">PayPal</a>."
 
 #: src/olympia/addons/templates/addons/contributions_lightbox.html:15
 #, python-format
-msgid ""
-"To show your support for <b>%(addon_name)s</b>, the developer asks that you "
-"make a donation to the <a href=\"%(charity_url)s\">%(charity_name)s</a> "
-"through <a href=\"%(paypal_url)s\">PayPal</a>."
+msgid "To show your support for <b>%(addon_name)s</b>, the developer asks that you make a donation to the <a href=\"%(charity_url)s\">%(charity_name)s</a> through <a href=\"%(paypal_url)s\">PayPal</a>."
 msgstr ""
-"Ak chcete vyjadriť podporu doplnku <b>%(addon_name)s</b>, vývojár Vás žiada "
-"o zaslanie príspevku cez službu <a href=\"%(paypal_url)s\">PayPal</a> v "
-"prospech <a href=\"%(charity_url)s\">%(charity_name)s</a>."
+"Ak chcete vyjadriť podporu doplnku <b>%(addon_name)s</b>, vývojár Vás žiada o zaslanie príspevku cez službu <a href=\"%(paypal_url)s\">PayPal</a> v prospech <a "
+"href=\"%(charity_url)s\">%(charity_name)s</a>."
 
 #: src/olympia/addons/templates/addons/contributions_lightbox.html:21
 #, python-format
 msgid ""
-"To show your support for <b>%(addon_name)s</b>, the developer asks that you "
-"make a small contribution to <a "
-"href=\"%(charity_url)s\">%(charity_name)s</a> through <a "
+"To show your support for <b>%(addon_name)s</b>, the developer asks that you make a small contribution to <a href=\"%(charity_url)s\">%(charity_name)s</a> through <a "
 "href=\"%(paypal_url)s\">PayPal</a>."
 msgstr ""
-"Ak chcete vyjadriť podporu doplnku <b>%(addon_name)s</b>, vývojár Vás žiada "
-"o zaslanie malého príspevku cez službu <a href=\"%(paypal_url)s\">PayPal</a>"
-" v prospech <a href=\"%(charity_url)s\">%(charity_name)s</a>."
+"Ak chcete vyjadriť podporu doplnku <b>%(addon_name)s</b>, vývojár Vás žiada o zaslanie malého príspevku cez službu <a href=\"%(paypal_url)s\">PayPal</a> v prospech <a "
+"href=\"%(charity_url)s\">%(charity_name)s</a>."
 
 #: src/olympia/addons/templates/addons/contributions_lightbox.html:30
 msgid "How much would you like to contribute?"
@@ -444,8 +332,7 @@ msgstr "Výška príspevku musí byť číslo."
 msgid "A one-time suggested contribution of {0}"
 msgstr "Jednorázový navrhnutý príspevok {0}"
 
-#. {0} is a currency symbol (e.g., $),                    {1} is an amount
-#. input
+#. {0} is a currency symbol (e.g., $),                    {1} is an amount input
 #. field
 #: src/olympia/addons/templates/addons/contributions_lightbox.html:64
 msgid "A one-time contribution of {0} {1}"
@@ -455,11 +342,8 @@ msgstr "Jednorázový príspevok: {1} {0}"
 msgid "Leave a comment or request with your contribution."
 msgstr "K príspevku môžete pripojiť komentár alebo prosbu."
 
-#: src/olympia/addons/templates/addons/contributions_lightbox.html:74
-#: src/olympia/bandwagon/templates/bandwagon/ajax_new.html:20
-#: src/olympia/bandwagon/templates/bandwagon/includes/addedit.html:37
-#: src/olympia/reviews/templates/reviews/mobile/add_form.html:13
-#: src/olympia/templates/includes/forms.html:10
+#: src/olympia/addons/templates/addons/contributions_lightbox.html:74 src/olympia/bandwagon/templates/bandwagon/ajax_new.html:20 src/olympia/bandwagon/templates/bandwagon/includes/addedit.html:37
+#: src/olympia/reviews/templates/reviews/mobile/add_form.html:13 src/olympia/templates/includes/forms.html:10
 msgid "(optional)"
 msgstr "(voliteľné)"
 
@@ -479,36 +363,27 @@ msgstr "Nie, ďakujem"
 msgid "Contribution made, thank you."
 msgstr "Príspevok odoslaný, ďakujeme."
 
-#: src/olympia/addons/templates/addons/details_box.html:10
-#: src/olympia/discovery/templates/discovery/addons/detail.html:19
+#: src/olympia/addons/templates/addons/details_box.html:10 src/olympia/discovery/templates/discovery/addons/detail.html:19
 msgid "No restart required"
 msgstr "Reštart nie je vyžadovaný"
 
 #. This is a caption for a table. {0} is an add-on name.
-#: src/olympia/addons/templates/addons/details_box.html:26
-#: src/olympia/addons/templates/addons/includes/persona.html:9
+#: src/olympia/addons/templates/addons/details_box.html:26 src/olympia/addons/templates/addons/includes/persona.html:9
 msgid "Add-on Information for {0}"
 msgstr "Informácie o doplnku {0}"
 
-#: src/olympia/addons/templates/addons/details_box.html:30
-#: src/olympia/addons/templates/addons/persona_detail_table.html:3
-#: src/olympia/addons/templates/addons/mobile/details.html:63
-#: src/olympia/addons/templates/addons/mobile/persona_detail_table.html:7
-#: src/olympia/browse/views.py:459 src/olympia/devhub/views.py:75
+#: src/olympia/addons/templates/addons/details_box.html:30 src/olympia/addons/templates/addons/persona_detail_table.html:3 src/olympia/addons/templates/addons/mobile/details.html:63
+#: src/olympia/addons/templates/addons/mobile/persona_detail_table.html:7 src/olympia/browse/views.py:426 src/olympia/devhub/views.py:74
 msgid "Updated"
 msgstr "Aktualizované"
 
-#: src/olympia/addons/templates/addons/details_box.html:38
-#: src/olympia/addons/templates/addons/mobile/details.html:71
-#: src/olympia/devhub/templates/devhub/addons/edit/support.html:43
+#: src/olympia/addons/templates/addons/details_box.html:38 src/olympia/addons/templates/addons/mobile/details.html:71 src/olympia/devhub/templates/devhub/addons/edit/support.html:43
 #: src/olympia/discovery/templates/discovery/addons/detail.html:77
 msgid "Website"
 msgstr "Webová stránka"
 
 #. This refers to this version's compatible applications, such as Firefox 8.0
-#: src/olympia/addons/templates/addons/details_box.html:47
-#: src/olympia/addons/templates/addons/mobile/details.html:80
-#: src/olympia/search/templates/search/results.html:72
+#: src/olympia/addons/templates/addons/details_box.html:47 src/olympia/addons/templates/addons/mobile/details.html:80 src/olympia/search/templates/search/results.html:72
 #: src/olympia/versions/templates/versions/version.html:21
 msgid "Works with"
 msgstr "Funguje s"
@@ -517,45 +392,30 @@ msgstr "Funguje s"
 msgid "Visibility"
 msgstr "Viditeľnosť"
 
-#: src/olympia/addons/templates/addons/details_box.html:57
-#: src/olympia/devhub/templates/devhub/index.html:94
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:104
+#: src/olympia/addons/templates/addons/details_box.html:57 src/olympia/devhub/templates/devhub/index.html:94 src/olympia/devhub/templates/devhub/includes/addon_details.html:91
 msgid "Hidden"
 msgstr "Skryté"
 
-#: src/olympia/addons/templates/addons/details_box.html:59
-#: src/olympia/devhub/templates/devhub/index.html:96
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:106
+#: src/olympia/addons/templates/addons/details_box.html:59 src/olympia/devhub/templates/devhub/index.html:96 src/olympia/devhub/templates/devhub/includes/addon_details.html:93
 msgid "Unlisted"
 msgstr "Mimo zoznamu"
 
-#: src/olympia/addons/templates/addons/details_box.html:67
-#: src/olympia/devhub/templates/devhub/addons/edit/technical.html:44
+#: src/olympia/addons/templates/addons/details_box.html:67 src/olympia/devhub/templates/devhub/addons/edit/technical.html:44
 msgid "Required Add-ons"
 msgstr "Požadované doplnky"
 
-#: src/olympia/addons/templates/addons/details_box.html:81
-#: src/olympia/addons/templates/addons/persona_detail_table.html:15
-#: src/olympia/browse/views.py:462 src/olympia/devhub/views.py:78
-#: src/olympia/devhub/views.py:85
-#: src/olympia/discovery/templates/discovery/addons/detail.html:57
-#: src/olympia/reviews/forms.py:62
-#: src/olympia/reviews/templates/reviews/add.html:57
+#: src/olympia/addons/templates/addons/details_box.html:81 src/olympia/addons/templates/addons/persona_detail_table.html:15 src/olympia/browse/views.py:429 src/olympia/devhub/views.py:77
+#: src/olympia/devhub/views.py:84 src/olympia/discovery/templates/discovery/addons/detail.html:57 src/olympia/reviews/forms.py:62 src/olympia/reviews/templates/reviews/add.html:57
 #: src/olympia/reviews/templates/reviews/mobile/review_list.html:18
 msgid "Rating"
 msgstr "Hodnotenie"
 
-#: src/olympia/addons/templates/addons/details_box.html:85
-#: src/olympia/browse/views.py:461 src/olympia/devhub/views.py:77
-#: src/olympia/devhub/views.py:84
-#: src/olympia/stats/templates/stats/addon_report_menu.html:8
-#: src/olympia/stats/templates/stats/collection_report_menu.html:18
+#: src/olympia/addons/templates/addons/details_box.html:85 src/olympia/browse/views.py:428 src/olympia/devhub/views.py:76 src/olympia/devhub/views.py:83
+#: src/olympia/stats/templates/stats/addon_report_menu.html:8 src/olympia/stats/templates/stats/collection_report_menu.html:18
 msgid "Downloads"
 msgstr "Prevzatí"
 
-#: src/olympia/addons/templates/addons/details_box.html:91
-#: src/olympia/addons/templates/addons/details_box.html:103
-#: src/olympia/devhub/templates/devhub/addons/listing/item_actions_theme.html:17
+#: src/olympia/addons/templates/addons/details_box.html:91 src/olympia/addons/templates/addons/details_box.html:103 src/olympia/devhub/templates/devhub/addons/listing/item_actions_theme.html:17
 #: src/olympia/devhub/templates/devhub/personas/edit.html:60
 msgid "View Statistics"
 msgstr "Zobraziť štatistiku"
@@ -569,18 +429,13 @@ msgid "Abuse Reports"
 msgstr "Hlásené zneužitia"
 
 #. The Privacy Policy for this add-on.
-#: src/olympia/addons/templates/addons/details_box.html:121
-#: src/olympia/addons/templates/addons/privacy.html:19
-#: src/olympia/addons/templates/addons/privacy.html:23
-#: src/olympia/addons/templates/addons/impala/button.html:43
-#: src/olympia/addons/templates/addons/impala/details.html:307
-#: src/olympia/devhub/templates/devhub/includes/policy_form.html:20
+#: src/olympia/addons/templates/addons/details_box.html:121 src/olympia/addons/templates/addons/privacy.html:19 src/olympia/addons/templates/addons/privacy.html:23
+#: src/olympia/addons/templates/addons/impala/button.html:43 src/olympia/addons/templates/addons/impala/details.html:312 src/olympia/devhub/templates/devhub/includes/policy_form.html:23
 #: src/olympia/templates/mobile/base_addons.html:87
 msgid "Privacy Policy"
 msgstr "Zásady ochrany súkromia"
 
-#: src/olympia/addons/templates/addons/details_box.html:124
-#: src/olympia/discovery/templates/discovery/addons/detail.html:24
+#: src/olympia/addons/templates/addons/details_box.html:124 src/olympia/discovery/templates/discovery/addons/detail.html:24
 msgid "View Privacy Policy"
 msgstr "Zobraziť zásady ochrany súkromia"
 
@@ -588,8 +443,7 @@ msgstr "Zobraziť zásady ochrany súkromia"
 msgid "EULA"
 msgstr "Licenčná zmluva"
 
-#: src/olympia/addons/templates/addons/details_box.html:171
-#: src/olympia/addons/templates/addons/details_box.html:231
+#: src/olympia/addons/templates/addons/details_box.html:171 src/olympia/addons/templates/addons/details_box.html:231
 msgid "More about this add-on"
 msgstr "Ďalšie informácie o tomto doplnku"
 
@@ -597,26 +451,21 @@ msgstr "Ďalšie informácie o tomto doplnku"
 msgid "Image Gallery"
 msgstr "Galéria obrázkov"
 
-#: src/olympia/addons/templates/addons/details_box.html:190
-#: src/olympia/devhub/templates/devhub/addons/edit/technical.html:21
+#: src/olympia/addons/templates/addons/details_box.html:190 src/olympia/devhub/templates/devhub/addons/edit/technical.html:21
 msgid "Developer Comments"
 msgstr "Komentáre vývojára"
 
-#: src/olympia/addons/templates/addons/details_box.html:199
-#: src/olympia/addons/templates/addons/impala/details.html:259
+#: src/olympia/addons/templates/addons/details_box.html:199 src/olympia/addons/templates/addons/impala/details.html:264
 msgid "Development Channel"
 msgstr "Vývojársky kanál"
 
-#: src/olympia/addons/templates/addons/details_box.html:202
-#: src/olympia/addons/templates/addons/mobile/details.html:124
+#: src/olympia/addons/templates/addons/details_box.html:202 src/olympia/addons/templates/addons/mobile/details.html:124
 msgid ""
-"The Development Channel lets you test an experimental new version of this "
-"add-on before it's released to the general public. Once you install the "
-"development version, you will continue to get updates from this channel."
+"The Development Channel lets you test an experimental new version of this add-on before it's released to the general public. Once you install the development version, you will continue to get "
+"updates from this channel."
 msgstr ""
-"Vývojársky kanál umožňuje testovať experimentálne nové verzie tohto doplnku "
-"pred jeho oficiálnym vydaním. Keď si nainštalujete vývojovú verziu, budete "
-"automaticky dostávať aktualizácie doplnku z toho kanála."
+"Vývojársky kanál umožňuje testovať experimentálne nové verzie tohto doplnku pred jeho oficiálnym vydaním. Keď si nainštalujete vývojovú verziu, budete automaticky dostávať aktualizácie doplnku z "
+"toho kanála."
 
 #: src/olympia/addons/templates/addons/details_box.html:207
 msgid "Install development version"
@@ -624,20 +473,13 @@ msgstr "Nainštalovať vývojovú verziu"
 
 #: src/olympia/addons/templates/addons/details_box.html:211
 msgid ""
-"<strong>Caution:</strong> Development versions of this add-on have not been "
-"reviewed by Mozilla. Once you install a development version you will "
-"continue to receive development updates from this developer. To stop "
-"receiving development updates, reinstall the default version from the link "
-"above."
+"<strong>Caution:</strong> Development versions of this add-on have not been reviewed by Mozilla. Once you install a development version you will continue to receive development updates from this "
+"developer. To stop receiving development updates, reinstall the default version from the link above."
 msgstr ""
-"<strong>Upozornenie:</strong> vývojové verzie tohto doplnku neboli "
-"prekontrolované Mozillou. Keď si nainštalujete vývojovú verziu, budete "
-"automaticky dostávať aktualizácie doplnku z toho kanála. Ak budete chcieť "
-"dostávať oficiálne verzie, opätovne si nainštalujte verziu dostupné na "
-"nižšie uvedenom odkaze."
+"<strong>Upozornenie:</strong> vývojové verzie tohto doplnku neboli prekontrolované Mozillou. Keď si nainštalujete vývojovú verziu, budete automaticky dostávať aktualizácie doplnku z toho kanála. Ak"
+" budete chcieť dostávať oficiálne verzie, opätovne si nainštalujte verziu dostupné na nižšie uvedenom odkaze."
 
-#: src/olympia/addons/templates/addons/details_box.html:220
-#: src/olympia/addons/templates/addons/impala/details.html:278
+#: src/olympia/addons/templates/addons/details_box.html:220 src/olympia/addons/templates/addons/impala/details.html:283
 msgid "Version {0}:"
 msgstr "Verzia {0}:"
 
@@ -645,55 +487,38 @@ msgstr "Verzia {0}:"
 msgid "Nothing to see here! The developer did not include any details."
 msgstr "Nič tu nie je. Vývojár doplnku nezadal žiadne informácie."
 
-#: src/olympia/addons/templates/addons/details_box.html:251
-#: src/olympia/devhub/templates/devhub/versions/edit.html:73
-#: src/olympia/editors/templates/editors/review.html:98
+#: src/olympia/addons/templates/addons/details_box.html:251 src/olympia/devhub/templates/devhub/versions/edit.html:73 src/olympia/editors/templates/editors/review.html:98
 msgid "Version Notes"
 msgstr "Poznámky k verzii"
 
 #. {0} is the name of the add-on.
 #. {0} is the name of the add-on
-#: src/olympia/addons/templates/addons/eula.html:6
-#: src/olympia/discovery/templates/discovery/addons/eula.html:5
+#: src/olympia/addons/templates/addons/eula.html:6 src/olympia/discovery/templates/discovery/addons/eula.html:5
 msgid "End-User License Agreement for {0}"
 msgstr "Licenčná zmluva s koncovým používateľom pre {0}"
 
-#: src/olympia/addons/templates/addons/eula.html:17
-#: src/olympia/addons/templates/addons/eula.html:21
-#: src/olympia/addons/templates/addons/impala/button.html:48
-#: src/olympia/addons/templates/addons/impala/details.html:316
-#: src/olympia/devhub/templates/devhub/includes/policy_form.html:3
-#: src/olympia/discovery/templates/discovery/addons/eula.html:11
+#: src/olympia/addons/templates/addons/eula.html:17 src/olympia/addons/templates/addons/eula.html:21 src/olympia/addons/templates/addons/impala/button.html:48
+#: src/olympia/addons/templates/addons/impala/details.html:321 src/olympia/devhub/templates/devhub/includes/policy_form.html:3 src/olympia/discovery/templates/discovery/addons/eula.html:11
 msgid "End-User License Agreement"
 msgstr "Licenčná zmluva s koncovým používateľom"
 
-#: src/olympia/addons/templates/addons/eula.html:23
-#: src/olympia/discovery/templates/discovery/addons/eula.html:13
+#: src/olympia/addons/templates/addons/eula.html:23 src/olympia/discovery/templates/discovery/addons/eula.html:13
 #, python-format
-msgid ""
-"%(addon_name)s requires that you accept the following End-User License "
-"Agreement before installation can proceed:"
-msgstr ""
-"Doplnok %(addon_name)s vyžaduje pred inštaláciou odsúhlasenie nasledujúcej "
-"licenčnej zmluvy:"
+msgid "%(addon_name)s requires that you accept the following End-User License Agreement before installation can proceed:"
+msgstr "Doplnok %(addon_name)s vyžaduje pred inštaláciou odsúhlasenie nasledujúcej licenčnej zmluvy:"
 
-#: src/olympia/addons/templates/addons/eula.html:34
-#: src/olympia/addons/templates/addons/privacy.html:26
+#: src/olympia/addons/templates/addons/eula.html:34 src/olympia/addons/templates/addons/privacy.html:26
 msgid "Back to {0}…"
 msgstr "Späť na {0}…"
 
 # {0} is the application the user is browsing.  Examples:  Thunderbird,
 # Firefox,
 # Sunbird
-#: src/olympia/addons/templates/addons/home.html:3
-#: src/olympia/addons/templates/addons/mobile/home.html:3
-#: src/olympia/amo/helpers.py:235
+#: src/olympia/addons/templates/addons/home.html:3 src/olympia/addons/templates/addons/mobile/home.html:3 src/olympia/amo/helpers.py:235
 msgid "Add-ons for {0}"
 msgstr "Doplnky pre {0}"
 
-#: src/olympia/addons/templates/addons/home.html:10
-#: src/olympia/addons/templates/addons/home.html:51
-#: src/olympia/browse/templates/browse/impala/base_listing.html:11
+#: src/olympia/addons/templates/addons/home.html:10 src/olympia/addons/templates/addons/home.html:53 src/olympia/browse/templates/browse/impala/base_listing.html:11
 msgid "Featured Extensions"
 msgstr "Odporúčané doplnky"
 
@@ -701,69 +526,48 @@ msgstr "Odporúčané doplnky"
 msgid "Popular Extensions"
 msgstr "Populárne doplnky"
 
-#: src/olympia/addons/templates/addons/home.html:42
-#: src/olympia/amo/templates/amo/side_nav.html:3
-#: src/olympia/amo/templates/amo/side_nav.html:11
-#: src/olympia/amo/templates/amo/site_nav.html:3
-#: src/olympia/amo/templates/amo/site_nav.html:25
-#: src/olympia/browse/views.py:236 src/olympia/browse/views.py:281
-#: src/olympia/browse/views.py:481
+#: src/olympia/addons/templates/addons/home.html:44 src/olympia/amo/templates/amo/side_nav.html:3 src/olympia/amo/templates/amo/side_nav.html:11 src/olympia/amo/templates/amo/site_nav.html:3
+#: src/olympia/amo/templates/amo/site_nav.html:25 src/olympia/browse/views.py:203 src/olympia/browse/views.py:248 src/olympia/browse/views.py:448
 msgid "Most Popular"
 msgstr "Najobľúbenejšie"
 
-#: src/olympia/addons/templates/addons/home.html:43
+#: src/olympia/addons/templates/addons/home.html:45
 msgid "All »"
 msgstr "Všetky »"
 
-#: src/olympia/addons/templates/addons/home.html:52
-#: src/olympia/addons/templates/addons/home.html:61
-#: src/olympia/addons/templates/addons/home.html:70
-#: src/olympia/addons/templates/addons/home.html:78
+#: src/olympia/addons/templates/addons/home.html:54 src/olympia/addons/templates/addons/home.html:63 src/olympia/addons/templates/addons/home.html:72 src/olympia/addons/templates/addons/home.html:80
 #: src/olympia/browse/templates/browse/impala/category_landing.html:36
 msgid "See all »"
 msgstr "Zobraziť všetky »"
 
-#: src/olympia/addons/templates/addons/home.html:60
+#: src/olympia/addons/templates/addons/home.html:62
 msgid "Up &amp; Coming Extensions"
 msgstr "Zaujímavé rozšírenia"
 
-#: src/olympia/addons/templates/addons/home.html:69
-#: src/olympia/browse/templates/browse/personas/category_landing.html:61
-#: src/olympia/discovery/templates/discovery/pane.html:74
+#: src/olympia/addons/templates/addons/home.html:71 src/olympia/browse/templates/browse/personas/category_landing.html:61 src/olympia/discovery/templates/discovery/pane.html:74
 msgid "Featured Themes"
 msgstr "Odporúčané témy"
 
-#: src/olympia/addons/templates/addons/home.html:77
-#: src/olympia/bandwagon/templates/bandwagon/impala/collection_listing.html:5
+#: src/olympia/addons/templates/addons/home.html:79 src/olympia/bandwagon/templates/bandwagon/impala/collection_listing.html:5
 msgid "Featured Collections"
 msgstr "Odporúčané kolekcie"
 
-#: src/olympia/addons/templates/addons/listing_header.html:3
-#: src/olympia/addons/templates/addons/impala/listing/sorter.html:2
-#: src/olympia/amo/templates/amo/mobile/sort_by.html:2
+#: src/olympia/addons/templates/addons/listing_header.html:3 src/olympia/addons/templates/addons/impala/listing/sorter.html:2 src/olympia/amo/templates/amo/mobile/sort_by.html:2
 #: src/olympia/bandwagon/templates/bandwagon/collection_detail.html:118
 msgid "Sort by:"
 msgstr "Zoradiť podľa:"
 
 #. {0} is a date.
 #. {0} is a date
-#: src/olympia/addons/templates/addons/macros.html:7
-#: src/olympia/addons/templates/addons/macros.html:72
-#: src/olympia/addons/templates/addons/listing/items_mobile.html:48
-#: src/olympia/addons/templates/addons/listing/macros.html:42
-#: src/olympia/bandwagon/templates/bandwagon/collection_detail.html:50
-#: src/olympia/bandwagon/templates/bandwagon/collection_listing_items.html:40
-#: src/olympia/bandwagon/templates/bandwagon/impala/collection_listing_items.html:40
+#: src/olympia/addons/templates/addons/macros.html:7 src/olympia/addons/templates/addons/macros.html:72 src/olympia/addons/templates/addons/listing/items_mobile.html:48
+#: src/olympia/addons/templates/addons/listing/macros.html:42 src/olympia/bandwagon/templates/bandwagon/collection_detail.html:50
+#: src/olympia/bandwagon/templates/bandwagon/collection_listing_items.html:40 src/olympia/bandwagon/templates/bandwagon/impala/collection_listing_items.html:40
 msgid "Updated {0}"
 msgstr "Aktualizované: {0}"
 
 #. {0} is a date.
-#: src/olympia/addons/templates/addons/macros.html:10
-#: src/olympia/addons/templates/addons/macros.html:69
-#: src/olympia/addons/templates/addons/persona_preview.html:21
-#: src/olympia/addons/templates/addons/listing/items_mobile.html:44
-#: src/olympia/addons/templates/addons/listing/macros.html:39
-#: src/olympia/bandwagon/templates/bandwagon/collection_listing_items.html:37
+#: src/olympia/addons/templates/addons/macros.html:10 src/olympia/addons/templates/addons/macros.html:69 src/olympia/addons/templates/addons/persona_preview.html:22
+#: src/olympia/addons/templates/addons/listing/items_mobile.html:44 src/olympia/addons/templates/addons/listing/macros.html:39 src/olympia/bandwagon/templates/bandwagon/collection_listing_items.html:37
 #: src/olympia/bandwagon/templates/bandwagon/impala/collection_listing_items.html:37
 msgid "Added {0}"
 msgstr "Pridané {0}"
@@ -774,7 +578,6 @@ msgid "%(num)s weekly download"
 msgid_plural "%(num)s weekly downloads"
 msgstr[0] "%(num)s prevzatie za týždeň"
 msgstr[1] "%(num)s prevzatia za týždeň"
-msgstr[2] "%(num)s prevzatí za týždeň"
 
 #: src/olympia/addons/templates/addons/macros.html:28
 #, python-format
@@ -782,27 +585,20 @@ msgid "%(num)s user"
 msgid_plural "%(num)s users"
 msgstr[0] "%(num)s používateľ"
 msgstr[1] "%(num)s používatelia"
-msgstr[2] "%(num)s používateľov"
 
 #. {0} is the number of downloads.
-#: src/olympia/addons/templates/addons/macros.html:53
-#: src/olympia/addons/templates/addons/impala/details.html:61
+#: src/olympia/addons/templates/addons/macros.html:53 src/olympia/addons/templates/addons/impala/details.html:59
 msgid "{0} weekly download"
 msgid_plural "{0} weekly downloads"
 msgstr[0] "Prevzatí za týždeň: {0}"
 msgstr[1] "Prevzatí za týždeň: {0}"
-msgstr[2] "Prevzatí za týždeň: {0}"
 
 #. {0} is the number of users.
-#: src/olympia/addons/templates/addons/macros.html:61
-#: src/olympia/addons/templates/addons/impala/details.html:54
-#: src/olympia/compat/templates/compat/index.html:71
-#: src/olympia/zadmin/templates/zadmin/compat.html:67
+#: src/olympia/addons/templates/addons/macros.html:61 src/olympia/addons/templates/addons/impala/details.html:52 src/olympia/zadmin/templates/zadmin/compat.html:67
 msgid "{0} user"
 msgid_plural "{0} users"
 msgstr[0] "{0} používateľ"
 msgstr[1] "{0} používatelia"
-msgstr[2] "{0} používateľov"
 
 #: src/olympia/addons/templates/addons/paypal_result.html:12
 msgid "Payment cancelled"
@@ -816,12 +612,8 @@ msgstr "Platba dokončená"
 msgid "Return to the addon."
 msgstr "Návrat na doplnok."
 
-#: src/olympia/addons/templates/addons/persona_detail.html:17
-#: src/olympia/addons/templates/addons/impala/details.html:106
-#: src/olympia/addons/templates/addons/mobile/details.html:23
-#: src/olympia/addons/templates/addons/mobile/persona_detail.html:21
-#: src/olympia/discovery/templates/discovery/addons/base.html:27
-#: src/olympia/editors/templates/editors/review.html:31
+#: src/olympia/addons/templates/addons/persona_detail.html:17 src/olympia/addons/templates/addons/impala/details.html:103 src/olympia/addons/templates/addons/mobile/details.html:23
+#: src/olympia/addons/templates/addons/mobile/persona_detail.html:21 src/olympia/discovery/templates/discovery/addons/base.html:27 src/olympia/editors/templates/editors/review.html:31
 msgid "by"
 msgstr "Autor:"
 
@@ -831,8 +623,7 @@ msgid "More {0} Themes"
 msgstr "Ďalšie témy v kategórii {0}"
 
 #. {0} is a category name, such as Nature
-#: src/olympia/addons/templates/addons/persona_detail.html:39
-#: src/olympia/addons/templates/addons/mobile/persona_detail.html:66
+#: src/olympia/addons/templates/addons/persona_detail.html:39 src/olympia/addons/templates/addons/mobile/persona_detail.html:66
 msgid "See all {0} Themes"
 msgstr "Zobraziť všetky témy v kategórii {0}"
 
@@ -840,189 +631,132 @@ msgstr "Zobraziť všetky témy v kategórii {0}"
 msgid "More by this Artist"
 msgstr "Ďalšie od tohto autora"
 
-#: src/olympia/addons/templates/addons/persona_detail.html:52
-#: src/olympia/addons/templates/addons/mobile/persona_detail.html:49
+#: src/olympia/addons/templates/addons/persona_detail.html:52 src/olympia/addons/templates/addons/mobile/persona_detail.html:49
 msgid "See all Themes by this Artist"
 msgstr "Zobraziť všetky témy tohto umelca"
 
-#: src/olympia/addons/templates/addons/persona_detail.html:71
-#: src/olympia/addons/templates/addons/mobile/home.html:42
-#: src/olympia/amo/templates/amo/side_nav.html:22
-#: src/olympia/browse/templates/browse/personas/mobile/category_landing.html:28
-#: src/olympia/devhub/templates/devhub/addons/edit/basic.html:72
-#: src/olympia/editors/templates/editors/review.html:277
-#: src/olympia/editors/templates/editors/themes/themes.html:34
-#: src/olympia/templates/categories.html:7
+#: src/olympia/addons/templates/addons/persona_detail.html:71 src/olympia/addons/templates/addons/mobile/home.html:42 src/olympia/amo/templates/amo/side_nav.html:22
+#: src/olympia/browse/templates/browse/personas/mobile/category_landing.html:28 src/olympia/devhub/templates/devhub/addons/edit/basic.html:72 src/olympia/editors/templates/editors/review.html:277
+#: src/olympia/editors/templates/editors/themes/themes.html:34 src/olympia/templates/categories.html:7
 msgid "Categories"
 msgstr "Kategórie"
 
-#: src/olympia/addons/templates/addons/persona_detail_table.html:10
-#: src/olympia/addons/templates/addons/mobile/persona_detail_table.html:3
-#: src/olympia/editors/templates/editors/themes/deleted.html:19
+#: src/olympia/addons/templates/addons/persona_detail_table.html:10 src/olympia/addons/templates/addons/mobile/persona_detail_table.html:3 src/olympia/editors/templates/editors/themes/deleted.html:19
 #: src/olympia/editors/templates/editors/themes/themes.html:25
 msgid "Artist"
 msgstr "Autor"
 
-#: src/olympia/addons/templates/addons/persona_detail_table.html:19
-#: src/olympia/addons/templates/addons/mobile/persona_detail_table.html:14
-#: src/olympia/stats/templates/stats/addon_report_menu.html:17
+#: src/olympia/addons/templates/addons/persona_detail_table.html:19 src/olympia/addons/templates/addons/mobile/persona_detail_table.html:14 src/olympia/stats/templates/stats/addon_report_menu.html:17
 msgid "Daily Users"
 msgstr "Denných používateľov"
 
 #. The License for this add-on.
-#: src/olympia/addons/templates/addons/persona_detail_table.html:26
-#: src/olympia/addons/templates/addons/impala/license.html:17
-#: src/olympia/addons/templates/addons/mobile/persona_detail_table.html:21
-#: src/olympia/devhub/templates/devhub/includes/license_form.html:5
-#: src/olympia/devhub/templates/devhub/versions/edit.html:89
-#: src/olympia/editors/templates/editors/themes/themes.html:41
+#: src/olympia/addons/templates/addons/persona_detail_table.html:26 src/olympia/addons/templates/addons/impala/license.html:17 src/olympia/addons/templates/addons/mobile/persona_detail_table.html:21
+#: src/olympia/devhub/templates/devhub/includes/license_form.html:5 src/olympia/devhub/templates/devhub/versions/edit.html:89 src/olympia/editors/templates/editors/themes/themes.html:41
 msgid "License"
 msgstr "Licencia"
 
-#: src/olympia/addons/templates/addons/persona_preview.html:12
-#: src/olympia/constants/base.py:48
+#: src/olympia/addons/templates/addons/persona_preview.html:13 src/olympia/constants/base.py:48
 msgid "Awaiting Review"
 msgstr "Čaká na kontrolu"
 
-#: src/olympia/addons/templates/addons/persona_preview.html:14
-#: src/olympia/amo/log.py:180 src/olympia/constants/base.py:42
-#: src/olympia/editors/helpers.py:62
+#: src/olympia/addons/templates/addons/persona_preview.html:15 src/olympia/amo/log.py:180 src/olympia/constants/base.py:42 src/olympia/editors/helpers.py:62
 msgid "Rejected"
 msgstr "Zamietnutý"
 
-#: src/olympia/addons/templates/addons/persona_preview.html:16
-#: src/olympia/amo/log.py:159
+#: src/olympia/addons/templates/addons/persona_preview.html:17 src/olympia/amo/log.py:159
 msgid "Approved"
 msgstr "Schválený"
 
 #. {0} is the number of users.
-#: src/olympia/addons/templates/addons/persona_preview.html:26
-#: src/olympia/addons/templates/addons/listing/items_mobile.html:36
-#: src/olympia/addons/templates/addons/listing/macros.html:31
+#: src/olympia/addons/templates/addons/persona_preview.html:27 src/olympia/addons/templates/addons/listing/items_mobile.html:36 src/olympia/addons/templates/addons/listing/macros.html:31
 msgid "<strong>{0}</strong> user"
 msgid_plural "<strong>{0}</strong> users"
 msgstr[0] "<strong>{0}</strong> používateľ"
 msgstr[1] "<strong>{0}</strong> používatelia"
-msgstr[2] "<strong>{0}</strong> používateľov"
 
-#: src/olympia/addons/templates/addons/persona_preview.html:40
+#: src/olympia/addons/templates/addons/persona_preview.html:41
 msgid "Hover to Preview"
 msgstr "Presunutím myši nad tému zobrazíte ukážku"
 
-#: src/olympia/addons/templates/addons/persona_preview.html:46
-#: src/olympia/addons/templates/addons/persona_preview.html:48
+#: src/olympia/addons/templates/addons/persona_preview.html:47 src/olympia/addons/templates/addons/persona_preview.html:49 src/olympia/addons/templates/addons/persona_preview.html:97
 #: src/olympia/reviews/templates/reviews/add.html:15
 msgid "Add"
 msgstr "Pridať"
 
-#: src/olympia/addons/templates/addons/persona_preview.html:57
-#: src/olympia/bandwagon/templates/bandwagon/ajax_new.html:16
-#: src/olympia/bandwagon/templates/bandwagon/edit.html:19
-#: src/olympia/bandwagon/templates/bandwagon/includes/addedit.html:19
-#: src/olympia/devhub/templates/devhub/addons/edit/admin.html:13
-#: src/olympia/devhub/templates/devhub/addons/edit/basic.html:10
-#: src/olympia/devhub/templates/devhub/addons/edit/details.html:8
-#: src/olympia/devhub/templates/devhub/addons/edit/media.html:6
-#: src/olympia/devhub/templates/devhub/addons/edit/support.html:8
-#: src/olympia/devhub/templates/devhub/addons/edit/technical.html:9
-#: src/olympia/devhub/templates/devhub/addons/submit/describe.html:29
-#: src/olympia/editors/templates/editors/review.html:257
+#: src/olympia/addons/templates/addons/persona_preview.html:58 src/olympia/bandwagon/templates/bandwagon/ajax_new.html:16 src/olympia/bandwagon/templates/bandwagon/edit.html:19
+#: src/olympia/bandwagon/templates/bandwagon/includes/addedit.html:19 src/olympia/devhub/templates/devhub/addons/edit/admin.html:13 src/olympia/devhub/templates/devhub/addons/edit/basic.html:10
+#: src/olympia/devhub/templates/devhub/addons/edit/details.html:8 src/olympia/devhub/templates/devhub/addons/edit/media.html:6 src/olympia/devhub/templates/devhub/addons/edit/support.html:8
+#: src/olympia/devhub/templates/devhub/addons/edit/technical.html:9 src/olympia/devhub/templates/devhub/addons/submit/describe.html:29 src/olympia/editors/templates/editors/review.html:257
 msgid "Edit"
 msgstr "Upraviť"
 
 #. For datetime formatting, see the table on
 #. http://docs.python.org/library/datetime.html#strftime-and-strptime-behavior
-#: src/olympia/addons/templates/addons/persona_preview.html:66
+#: src/olympia/addons/templates/addons/persona_preview.html:67
 #, python-format
 msgid "%%Y-%%m-%%d"
 msgstr "%%d.%%m.%%Y"
 
-#: src/olympia/addons/templates/addons/persona_preview.html:67
+#: src/olympia/addons/templates/addons/persona_preview.html:68
 msgid "by {0} on {1}"
 msgstr "od {0} dňa {1}"
 
-#: src/olympia/addons/templates/addons/persona_preview.html:75
-#: src/olympia/reviews/helpers.py:17
-#: src/olympia/reviews/templates/reviews/review_list.html:63
-#: src/olympia/reviews/templates/reviews/reviews_link.html:21
-#: src/olympia/reviews/templates/reviews/impala/reviews_link.html:16
+#: src/olympia/addons/templates/addons/persona_preview.html:76 src/olympia/reviews/helpers.py:17 src/olympia/reviews/templates/reviews/review_list.html:63
+#: src/olympia/reviews/templates/reviews/reviews_link.html:21 src/olympia/reviews/templates/reviews/impala/reviews_link.html:16
 msgid "Not yet rated"
 msgstr "Nehodnotené"
 
-#: src/olympia/addons/templates/addons/persona_preview.html:78
+#: src/olympia/addons/templates/addons/persona_preview.html:79
 msgid "<b>{0}</b> users"
 msgstr "<b>{0}</b> používateľov"
 
 #: src/olympia/addons/templates/addons/popups.html:17
-msgid ""
-"To install this add-on and thousands more, <b>get Firefox</b>, a free and "
-"open web browser from Mozilla."
-msgstr ""
-"Ak si chcete nainštalovať tento doplnok a tisíce ďalších, <b>nainštalujte si"
-" Firefox</b>, voľne dostupný a otvorený webový prehliadač od Mozilly."
+msgid "To install this add-on and thousands more, <b>get Firefox</b>, a free and open web browser from Mozilla."
+msgstr "Ak si chcete nainštalovať tento doplnok a tisíce ďalších, <b>nainštalujte si Firefox</b>, voľne dostupný a otvorený webový prehliadač od Mozilly."
 
-#: src/olympia/addons/templates/addons/popups.html:21
-#: src/olympia/addons/templates/addons/popups.html:52
+#: src/olympia/addons/templates/addons/popups.html:21 src/olympia/addons/templates/addons/popups.html:52
 msgid "Learn more about Firefox"
 msgstr "Ďalšie informácie o Firefoxe"
 
 #: src/olympia/addons/templates/addons/popups.html:22
-msgid "or <b><a class=\"installer\" href=\"{url}\">download anyway</a></b>"
-msgstr "alebo <b><a class=\"installer\" href=\"{url}\">napriek tomu prevziať</a></b>"
+msgid "or <b><a class=\"button installer\" href=\"{url}\">download anyway</a></b>"
+msgstr ""
 
 #: src/olympia/addons/templates/addons/popups.html:26
 msgid ""
-"<strong>How to Install in Thunderbird</strong> <ol> <li>Download and save "
-"the file to your hard disk.</li> <li>In Mozilla Thunderbird, open Add-ons "
-"from the Tools menu.</li> <li>From the options button next to the add-on "
-"search field, select \"Install Add-on From File...\" and locate the "
-"downloaded add-on.</li> </ol>"
+"<strong>How to Install in Thunderbird</strong> <ol> <li>Download and save the file to your hard disk.</li> <li>In Mozilla Thunderbird, open Add-ons from the Tools menu.</li> <li>From the options "
+"button next to the add-on search field, select \"Install Add-on From File...\" and locate the downloaded add-on.</li> </ol>"
 msgstr ""
-"<strong>Ako na inštaláciu v Thunderbirde</strong> <ol> <li>Prevezmite a "
-"uložte si súbor na vašom disku.</li> <li>V programe Mozilla Thunderbird "
-"rozbaľte ponuku Nástroje a zvoľte položku.</li> <li>Z ponuky vedľa "
-"vyhľadávacieho poľa zvoľte položku \"Nainštalovať doplnok zo súboru...\" a "
-"vyhľadajte svoj doplnok na disku.</li> </ol>"
+"<strong>Ako na inštaláciu v Thunderbirde</strong> <ol> <li>Prevezmite a uložte si súbor na vašom disku.</li> <li>V programe Mozilla Thunderbird rozbaľte ponuku Nástroje a zvoľte položku.</li> <li>Z"
+" ponuky vedľa vyhľadávacieho poľa zvoľte položku \"Nainštalovať doplnok zo súboru...\" a vyhľadajte svoj doplnok na disku.</li> </ol>"
 
 #: src/olympia/addons/templates/addons/popups.html:41
-msgid ""
-"To install this Theme, <b>get Thunderbird</b>, a free and open source email "
-"client from Mozilla Messaging and install the Personas Plus add-on."
+msgid "To install this Theme, <b>get Thunderbird</b>, a free and open source email client from Mozilla Messaging and install the Personas Plus add-on."
 msgstr ""
-"Ak chcete nainštalovať túto tému, <b>nainštalujte si Thunderbird</b>, voľne "
-"dostupný e-amilový klient s otvoreným zdrojovým kódom od Mozilla Messaging a"
-" do neho si nainštalujte doplnok Personas Plus."
+"Ak chcete nainštalovať túto tému, <b>nainštalujte si Thunderbird</b>, voľne dostupný e-amilový klient s otvoreným zdrojovým kódom od Mozilla Messaging a do neho si nainštalujte doplnok Personas "
+"Plus."
 
 #: src/olympia/addons/templates/addons/popups.html:46
 msgid "Learn more about Thunderbird"
 msgstr "Ďalšie informácie o Thunderbirde"
 
 #: src/olympia/addons/templates/addons/popups.html:48
-msgid ""
-"To install this Theme and thousands more, <b>get Firefox</b>, a free and "
-"open web browser from Mozilla."
-msgstr ""
-"Ak si chcete nainštalovať túto tému, <b>nainštalujte si Firefox</b>, voľne "
-"dostupný webový prehliadač od Mozilly."
+msgid "To install this Theme and thousands more, <b>get Firefox</b>, a free and open web browser from Mozilla."
+msgstr "Ak si chcete nainštalovať túto tému, <b>nainštalujte si Firefox</b>, voľne dostupný webový prehliadač od Mozilly."
 
 #: src/olympia/addons/templates/addons/popups.html:60
 #, python-format
 msgid "This add-on has not been updated to work with your version of %(app)s."
-msgstr ""
-"Tento doplnok nebol aktualizovaný, aby pracoval správne s vašou verziou "
-"aplikácie %(app)s."
+msgstr "Tento doplnok nebol aktualizovaný, aby pracoval správne s vašou verziou aplikácie %(app)s."
 
-#: src/olympia/addons/templates/addons/popups.html:63
-#: src/olympia/addons/templates/addons/popups.html:140
-#: src/olympia/addons/templates/addons/popups.html:150
+#: src/olympia/addons/templates/addons/popups.html:63 src/olympia/addons/templates/addons/popups.html:140 src/olympia/addons/templates/addons/popups.html:150
 msgid "Install Anyway"
 msgstr "Napriek tomu nainštalovať"
 
 #: src/olympia/addons/templates/addons/popups.html:71
-msgid ""
-"This add-on requires a version of Firefox that has not been released yet."
-msgstr ""
-"Tento doplnok vyžaduje verziu Firefoxu, ktorá ešte nebola sprístupnená."
+msgid "This add-on requires a version of Firefox that has not been released yet."
+msgstr "Tento doplnok vyžaduje verziu Firefoxu, ktorá ešte nebola sprístupnená."
 
 #: src/olympia/addons/templates/addons/popups.html:74
 msgid "Help test new Firefox Versions"
@@ -1030,16 +764,11 @@ msgstr "Pomôžte otestovať nové verzie Firefoxu"
 
 #: src/olympia/addons/templates/addons/popups.html:77
 #, python-format
-msgid ""
-"This add-on requires %(app)s {new_version}. You are currently using %(app)s "
-"{old_version}."
-msgstr ""
-"Tento doplnok vyžaduje %(app)s {new_version}. Aktuálne používate %(app)s "
-"{old_version}."
+msgid "This add-on requires %(app)s {new_version}. You are currently using %(app)s {old_version}."
+msgstr "Tento doplnok vyžaduje %(app)s {new_version}. Aktuálne používate %(app)s {old_version}."
 
 #. {0} is an app name, like Firefox.
-#: src/olympia/addons/templates/addons/popups.html:82
-#: src/olympia/addons/templates/addons/popups.html:101
+#: src/olympia/addons/templates/addons/popups.html:82 src/olympia/addons/templates/addons/popups.html:101
 msgid "Upgrade {0}"
 msgstr "Aktualizovať na {0}"
 
@@ -1050,44 +779,27 @@ msgstr "alebo zobraziť <a href=\"%(href)s\">staršie verzie tohto doplnku</a>."
 
 #: src/olympia/addons/templates/addons/popups.html:96
 #, python-format
-msgid ""
-"This Persona requires %(app)s %(new_version)s. You are currently using "
-"%(app)s {old_version}."
-msgstr ""
-"Táto téma Personas vyžaduje %(app)s %(new_version)s. Vy používate %(app)s "
-"{old_version}."
+msgid "This Persona requires %(app)s %(new_version)s. You are currently using %(app)s {old_version}."
+msgstr "Táto téma Personas vyžaduje %(app)s %(new_version)s. Vy používate %(app)s {old_version}."
 
 #: src/olympia/addons/templates/addons/popups.html:108
 msgid ""
-"<strong>Caution:</strong> This add-on has not been reviewed by Mozilla and "
-"can't be installed on release versions of Firefox 43 and above. Be careful "
-"when installing third-party software that might harm your computer."
+"<strong>Caution:</strong> This add-on has not been reviewed by Mozilla and can't be installed on release versions of Firefox 43 and above. Be careful when installing third-party software that might"
+" harm your computer."
 msgstr ""
-"<strong>Výstraha:</strong> Tento doplnok nebol skontrolovaný Mozillou a "
-"nemôže byť nainštalovaný na Firefox verzie 43 a vyššej. Pri inštalácii "
-"softvéru tretích strán buďte opatrný, nakoľko takýto softvér môže poškodiť "
-"váš počítač."
+"<strong>Výstraha:</strong> Tento doplnok nebol skontrolovaný Mozillou a nemôže byť nainštalovaný na Firefox verzie 43 a vyššej. Pri inštalácii softvéru tretích strán buďte opatrný, nakoľko takýto "
+"softvér môže poškodiť váš počítač."
 
 #: src/olympia/addons/templates/addons/popups.html:120
-msgid ""
-"<strong>Please note:</strong> This add-on is not compatible with your "
-"operating system."
-msgstr ""
-"<strong>Upozornenie:</strong> Tento doplnok nie je kompatibilný s vašim "
-"operačným systémom."
+msgid "<strong>Please note:</strong> This add-on is not compatible with your operating system."
+msgstr "<strong>Upozornenie:</strong> Tento doplnok nie je kompatibilný s vašim operačným systémom."
 
-#: src/olympia/addons/templates/addons/popups.html:136
-#: src/olympia/addons/templates/addons/impala/button.html:70
+#: src/olympia/addons/templates/addons/popups.html:136 src/olympia/addons/templates/addons/impala/button.html:70
 #, python-format
-msgid ""
-"This add-on is not compatible with your version of %(app)s because of the "
-"following:"
-msgstr ""
-"Tento doplnok nie je kompatibilný s vašou verziou aplikácie %(app)s z "
-"nasledujúceho dôvodu:"
+msgid "This add-on is not compatible with your version of %(app)s because of the following:"
+msgstr "Tento doplnok nie je kompatibilný s vašou verziou aplikácie %(app)s z nasledujúceho dôvodu:"
 
-#: src/olympia/addons/templates/addons/popups.html:141
-#: src/olympia/addons/templates/addons/popups.html:151
+#: src/olympia/addons/templates/addons/popups.html:141 src/olympia/addons/templates/addons/popups.html:151
 msgid "View other versions"
 msgstr "Zobraziť ďalšie verzie"
 
@@ -1106,149 +818,92 @@ msgid "QR code for add-on"
 msgstr "Kód QR pre tento doplnok"
 
 #: src/olympia/addons/templates/addons/qr_code.html:6
-msgid ""
-"Want {0} on your mobile Firefox? Scan this QR code to install directly to "
-"your phone. (You'll need a QR reader. Search your phone's marketplace if "
-"don't have one.)"
+msgid "Want {0} on your mobile Firefox? Scan this QR code to install directly to your phone. (You'll need a QR reader. Search your phone's marketplace if don't have one.)"
 msgstr ""
-"Chceli by ste {0} vo svojom mobilnom Firefoxe? Oskenujte si tento kód QR a "
-"nainštalujte si ho priamo do telefónu. (Budete potrebovať čítačku kódov QR. "
-"Ak ju nemáte, pohľadajte medzi aplikáciami dostupnými pre váš telefón.)"
+"Chceli by ste {0} vo svojom mobilnom Firefoxe? Oskenujte si tento kód QR a nainštalujte si ho priamo do telefónu. (Budete potrebovať čítačku kódov QR. Ak ju nemáte, pohľadajte medzi aplikáciami "
+"dostupnými pre váš telefón.)"
 
-#: src/olympia/addons/templates/addons/report_abuse.html:6
-#: src/olympia/addons/templates/addons/report_abuse_full.html:10
-#: src/olympia/addons/templates/addons/impala/details-more.html:23
-#: src/olympia/addons/templates/addons/impala/details.html:328
+#: src/olympia/addons/templates/addons/report_abuse.html:6 src/olympia/addons/templates/addons/report_abuse_full.html:10 src/olympia/addons/templates/addons/impala/details-more.html:23
+#: src/olympia/addons/templates/addons/impala/details.html:333
 msgid "Report Abuse"
 msgstr "Nahlásiť zneužitie"
 
 #: src/olympia/addons/templates/addons/report_abuse.html:10
 #, python-format
 msgid ""
-"If you suspect this add-on violates <a href=\"%(url)s\">our policies</a> or "
-"has security or privacy issues, please use the form below to describe your "
-"concerns. Please do not use this form for any other reason."
+"If you suspect this add-on violates <a href=\"%(url)s\">our policies</a> or has security or privacy issues, please use the form below to describe your concerns. Please do not use this form for any "
+"other reason."
 msgstr ""
-"Ak si myslíte, že tento doplnok porušuje <a href=\"%(url)s\">naše zásady</a>"
-" alebo má problémy s bezpečnosťou alebo ochranou súkromia, použite nižšie "
-"uvedený formulár a popíšte svoje námietky. Prosím, nepoužívajte tento "
-"formulár na iné účely."
+"Ak si myslíte, že tento doplnok porušuje <a href=\"%(url)s\">naše zásady</a> alebo má problémy s bezpečnosťou alebo ochranou súkromia, použite nižšie uvedený formulár a popíšte svoje námietky. "
+"Prosím, nepoužívajte tento formulár na iné účely."
 
-#: src/olympia/addons/templates/addons/report_abuse.html:24
-#: src/olympia/users/templates/users/report_abuse.html:19
+#: src/olympia/addons/templates/addons/report_abuse.html:24 src/olympia/users/templates/users/report_abuse.html:19
 msgid "Send Report"
 msgstr "Odoslať správu"
 
-#: src/olympia/addons/templates/addons/report_abuse.html:26
-#: src/olympia/addons/templates/addons/mobile/eula.html:16
-#: src/olympia/addons/templates/addons/mobile/persona_confirm.html:7
-#: src/olympia/devhub/templates/devhub/addons/ajax_compat_update.html:36
-#: src/olympia/devhub/templates/devhub/addons/profile.html:44
-#: src/olympia/devhub/templates/devhub/addons/edit/admin.html:104
-#: src/olympia/devhub/templates/devhub/addons/edit/basic.html:155
-#: src/olympia/devhub/templates/devhub/addons/edit/details.html:88
-#: src/olympia/devhub/templates/devhub/addons/edit/support.html:70
-#: src/olympia/devhub/templates/devhub/addons/edit/technical.html:169
-#: src/olympia/devhub/templates/devhub/addons/forms_shared/media.html:152
-#: src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:44
-#: src/olympia/devhub/templates/devhub/personas/edit.html:222
-#: src/olympia/devhub/templates/devhub/versions/add_file_modal.html:79
-#: src/olympia/devhub/templates/devhub/versions/edit.html:140
-#: src/olympia/devhub/templates/devhub/versions/list.html:208
-#: src/olympia/devhub/templates/devhub/versions/list.html:242
-#: src/olympia/devhub/templates/devhub/versions/list.html:276
-#: src/olympia/devhub/templates/devhub/versions/list.html:317
-#: src/olympia/reviews/templates/reviews/edit_review.html:16
-#: src/olympia/translations/templates/translations/trans-menu.html:50
-#: src/olympia/translations/templates/translations/trans-menu.html:62
-#: src/olympia/zadmin/templates/zadmin/validation.html:105
+#: src/olympia/addons/templates/addons/report_abuse.html:26 src/olympia/addons/templates/addons/mobile/eula.html:16 src/olympia/addons/templates/addons/mobile/persona_confirm.html:7
+#: src/olympia/devhub/templates/devhub/addons/ajax_compat_update.html:36 src/olympia/devhub/templates/devhub/addons/profile.html:44 src/olympia/devhub/templates/devhub/addons/edit/admin.html:104
+#: src/olympia/devhub/templates/devhub/addons/edit/basic.html:155 src/olympia/devhub/templates/devhub/addons/edit/details.html:88 src/olympia/devhub/templates/devhub/addons/edit/support.html:70
+#: src/olympia/devhub/templates/devhub/addons/edit/technical.html:169 src/olympia/devhub/templates/devhub/addons/forms_shared/media.html:152
+#: src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:43 src/olympia/devhub/templates/devhub/personas/edit.html:222 src/olympia/devhub/templates/devhub/versions/add_file_modal.html:59
+#: src/olympia/devhub/templates/devhub/versions/edit.html:140 src/olympia/devhub/templates/devhub/versions/list.html:208 src/olympia/devhub/templates/devhub/versions/list.html:239
+#: src/olympia/devhub/templates/devhub/versions/list.html:281 src/olympia/devhub/templates/devhub/versions/list.html:315 src/olympia/reviews/templates/reviews/edit_review.html:16
+#: src/olympia/translations/templates/translations/trans-menu.html:50 src/olympia/translations/templates/translations/trans-menu.html:62 src/olympia/zadmin/templates/zadmin/validation.html:105
 msgid "Cancel"
 msgstr "Zrušiť"
 
-#: src/olympia/addons/templates/addons/review_add_box.html:3
-#: src/olympia/addons/templates/addons/impala/review_add_box.html:5
+#: src/olympia/addons/templates/addons/review_add_box.html:3 src/olympia/addons/templates/addons/impala/review_add_box.html:5
 msgid "What do you think?"
 msgstr "Čo si myslíte?"
 
-#: src/olympia/addons/templates/addons/review_add_box.html:7
-#: src/olympia/addons/templates/addons/impala/review_add_box.html:9
+#: src/olympia/addons/templates/addons/review_add_box.html:7 src/olympia/addons/templates/addons/impala/review_add_box.html:9
 #, python-format
 msgid "Please <a href=\"%(login)s\">log in</a> to submit a review"
 msgstr "Ak chcete odoslať recenziu, musíte sa <a href=\"%(login)s\">prihlásiť</a>"
 
-#: src/olympia/addons/templates/addons/review_add_box.html:16
-#: src/olympia/addons/templates/addons/impala/review_add_box.html:18
-#: src/olympia/reviews/templates/reviews/mobile/add_form.html:13
+#: src/olympia/addons/templates/addons/review_add_box.html:16 src/olympia/addons/templates/addons/impala/review_add_box.html:18 src/olympia/reviews/templates/reviews/mobile/add_form.html:13
 msgid "Title:"
 msgstr "Nadpis:"
 
-#: src/olympia/addons/templates/addons/review_add_box.html:17
-#: src/olympia/addons/templates/addons/impala/review_add_box.html:19
-#: src/olympia/reviews/templates/reviews/mobile/add_form.html:17
+#: src/olympia/addons/templates/addons/review_add_box.html:17 src/olympia/addons/templates/addons/impala/review_add_box.html:19 src/olympia/reviews/templates/reviews/mobile/add_form.html:17
 msgid "Review:"
 msgstr "Recenzia:"
 
-#: src/olympia/addons/templates/addons/review_add_box.html:18
-#: src/olympia/addons/templates/addons/impala/review_add_box.html:20
-#: src/olympia/reviews/templates/reviews/mobile/add_form.html:16
+#: src/olympia/addons/templates/addons/review_add_box.html:18 src/olympia/addons/templates/addons/impala/review_add_box.html:20 src/olympia/reviews/templates/reviews/mobile/add_form.html:16
 msgid "Rating:"
 msgstr "Hodnotenie:"
 
-#: src/olympia/addons/templates/addons/review_add_box.html:19
-#: src/olympia/addons/templates/addons/impala/review_add_box.html:21
-#: src/olympia/reviews/templates/reviews/add.html:63
-#: src/olympia/reviews/templates/reviews/edit_review.html:15
-#: src/olympia/reviews/templates/reviews/mobile/add_form.html:18
+#: src/olympia/addons/templates/addons/review_add_box.html:19 src/olympia/addons/templates/addons/impala/review_add_box.html:21 src/olympia/reviews/templates/reviews/add.html:63
+#: src/olympia/reviews/templates/reviews/edit_review.html:15 src/olympia/reviews/templates/reviews/mobile/add_form.html:18
 msgid "Submit review"
 msgstr "Odoslať recenziu"
 
-#: src/olympia/addons/templates/addons/review_add_box.html:24
-#: src/olympia/addons/templates/addons/impala/review_add_box.html:26
-msgid ""
-"Please do not post bug reports in reviews. We do not make your email address"
-" available to add-on developers and they may need to contact you to help "
-"resolve your issue."
-msgstr ""
-"Prosím, do recenzií nepíšte záznamy o chybách. Nesprístupňujeme vašu "
-"e-mailovú adresu autorom rozšírení a tí vás môžu chcieť kontaktovať, aby ste"
-" im pomohli opraviť chyby."
+#: src/olympia/addons/templates/addons/review_add_box.html:24 src/olympia/addons/templates/addons/impala/review_add_box.html:26
+msgid "Please do not post bug reports in reviews. We do not make your email address available to add-on developers and they may need to contact you to help resolve your issue."
+msgstr "Prosím, do recenzií nepíšte záznamy o chybách. Nesprístupňujeme vašu e-mailovú adresu autorom rozšírení a tí vás môžu chcieť kontaktovať, aby ste im pomohli opraviť chyby."
 
-#: src/olympia/addons/templates/addons/review_add_box.html:32
-#: src/olympia/addons/templates/addons/impala/review_add_box.html:35
+#: src/olympia/addons/templates/addons/review_add_box.html:32 src/olympia/addons/templates/addons/impala/review_add_box.html:35
 #, python-format
-msgid ""
-"See the <a href=\"%(support)s\">support section</a> to find out where to get"
-" assistance for this add-on."
-msgstr ""
-"Informácie o asistencii k tomuto doplnku nájdete v <a "
-"href=\"%(support)s\">sekcii podpory</a>."
+msgid "See the <a href=\"%(support)s\">support section</a> to find out where to get assistance for this add-on."
+msgstr "Informácie o asistencii k tomuto doplnku nájdete v <a href=\"%(support)s\">sekcii podpory</a>."
 
-#: src/olympia/addons/templates/addons/review_add_box.html:38
-#: src/olympia/addons/templates/addons/impala/review_add_box.html:42
-#: src/olympia/pages/templates/pages/review_guide.html:3
+#: src/olympia/addons/templates/addons/review_add_box.html:38 src/olympia/addons/templates/addons/impala/review_add_box.html:42 src/olympia/pages/templates/pages/review_guide.html:3
 #: src/olympia/pages/templates/pages/review_guide.html:44
 msgid "Review Guidelines"
 msgstr "Sprievodca systémom kontroly"
 
-#: src/olympia/addons/templates/addons/review_list_box.html:5
-#: src/olympia/addons/templates/addons/impala/details-more.html:27
-#: src/olympia/editors/helpers.py:921
-#: src/olympia/reviews/templates/reviews/add.html:14
-#: src/olympia/reviews/templates/reviews/reply.html:14
-#: src/olympia/reviews/templates/reviews/review_list.html:19
+#: src/olympia/addons/templates/addons/review_list_box.html:5 src/olympia/addons/templates/addons/impala/details-more.html:27 src/olympia/editors/helpers.py:1001
+#: src/olympia/reviews/templates/reviews/add.html:14 src/olympia/reviews/templates/reviews/reply.html:14 src/olympia/reviews/templates/reviews/review_list.html:19
 #: src/olympia/reviews/templates/reviews/mobile/review_list.html:26
 msgid "Reviews"
 msgstr "Recenzie"
 
-#: src/olympia/addons/templates/addons/review_list_box.html:14
-#: src/olympia/addons/templates/addons/impala/review_list_box.html:14
-#: src/olympia/reviews/templates/reviews/review.html:30
+#: src/olympia/addons/templates/addons/review_list_box.html:14 src/olympia/addons/templates/addons/impala/review_list_box.html:14 src/olympia/reviews/templates/reviews/review.html:30
 #, python-format
 msgid "by %(user)s on %(date)s"
 msgstr "od %(user)s dňa %(date)s"
 
-#: src/olympia/addons/templates/addons/review_list_box.html:19
-#: src/olympia/addons/templates/addons/impala/review_list_box.html:29
+#: src/olympia/addons/templates/addons/review_list_box.html:19 src/olympia/addons/templates/addons/impala/review_list_box.html:29
 msgid "Show the developer's reply to this review"
 msgstr "Zobraziť odpoveď vývojára na túto recenziu"
 
@@ -1258,23 +913,17 @@ msgid "See all reviews of this add-on"
 msgid_plural "See all %(cnt)s reviews of this add-on"
 msgstr[0] "Zobraziť všetky recenzie tohto doplnku"
 msgstr[1] "Zobraziť všetky (%(cnt)s) recencie tohto doplnku"
-msgstr[2] "Zobraziť všetkých %(cnt)s recencií tohto doplnku"
 
-#: src/olympia/addons/templates/addons/tags_box.html:3
-#: src/olympia/devhub/templates/devhub/addons/edit/basic.html:118
+#: src/olympia/addons/templates/addons/tags_box.html:3 src/olympia/devhub/templates/devhub/addons/edit/basic.html:118
 msgid "Tags"
 msgstr "Značky"
 
-#: src/olympia/addons/templates/addons/impala/addon_hovercard.html:7
-#: src/olympia/addons/templates/addons/impala/addon_hovercard.html:9
+#: src/olympia/addons/templates/addons/impala/addon_hovercard.html:7 src/olympia/addons/templates/addons/impala/addon_hovercard.html:9
 msgid "Icon for {0}"
 msgstr "Ikona pre {0}"
 
-#: src/olympia/addons/templates/addons/impala/addon_hovercard.html:34
-#: src/olympia/addons/templates/addons/impala/featured_grid.html:26
-#: src/olympia/addons/templates/addons/impala/theme_grid.html:22
-#: src/olympia/bandwagon/templates/bandwagon/collection_detail.html:31
-#: src/olympia/users/templates/users/helpers/addon_users_list.html:7
+#: src/olympia/addons/templates/addons/impala/addon_hovercard.html:34 src/olympia/addons/templates/addons/impala/featured_grid.html:26 src/olympia/addons/templates/addons/impala/theme_grid.html:22
+#: src/olympia/bandwagon/templates/bandwagon/collection_detail.html:31 src/olympia/users/templates/users/helpers/addon_users_list.html:7
 #, python-format
 msgid "by %(users)s"
 msgstr "od %(users)s"
@@ -1294,39 +943,22 @@ msgstr "Páči sa vám tento doplnok?"
 
 #: src/olympia/addons/templates/addons/impala/contribution.html:43
 #, python-format
-msgid ""
-"The <a href=\"%(meet_url)s\">developer of this add-on</a> asks that you help"
-" support its continued development by making a small contribution."
-msgstr ""
-"<a href=\"%(meet_url)s\">Autor tohto doplnku</a> žiada o podporu v jeho "
-"vývoji zaslaním malého príspevku."
+msgid "The <a href=\"%(meet_url)s\">developer of this add-on</a> asks that you help support its continued development by making a small contribution."
+msgstr "<a href=\"%(meet_url)s\">Autor tohto doplnku</a> žiada o podporu v jeho vývoji zaslaním malého príspevku."
 
 #: src/olympia/addons/templates/addons/impala/contribution.html:48
 #, python-format
-msgid ""
-"The <a href=\"%(meet_url)s\">developer of this add-on</a> asks that you show"
-" your support by making a donation to the <a "
-"href=\"%(charity_url)s\">%(charity_name)s</a>."
-msgstr ""
-"<a href=\"%(meet_url)s\">Autor tohto doplnku</a> žiada o podporu zaslaním "
-"príspevku v prospech <a href=\"%(charity_url)s\">%(charity_name)s</a>."
+msgid "The <a href=\"%(meet_url)s\">developer of this add-on</a> asks that you show your support by making a donation to the <a href=\"%(charity_url)s\">%(charity_name)s</a>."
+msgstr "<a href=\"%(meet_url)s\">Autor tohto doplnku</a> žiada o podporu zaslaním príspevku v prospech <a href=\"%(charity_url)s\">%(charity_name)s</a>."
 
 #: src/olympia/addons/templates/addons/impala/contribution.html:53
 #, python-format
-msgid ""
-"The <a href=\"%(meet_url)s\">developer of this add-on</a> asks that you show"
-" your support by making a small contribution to <a "
-"href=\"%(charity_url)s\">%(charity_name)s</a>."
-msgstr ""
-"<a href=\"%(meet_url)s\">Autor tohto doplnku</a> žiada o podporu zaslaním "
-"malého príspevku v prospech <a "
-"href=\"%(charity_url)s\">%(charity_name)s</a>."
+msgid "The <a href=\"%(meet_url)s\">developer of this add-on</a> asks that you show your support by making a small contribution to <a href=\"%(charity_url)s\">%(charity_name)s</a>."
+msgstr "<a href=\"%(meet_url)s\">Autor tohto doplnku</a> žiada o podporu zaslaním malého príspevku v prospech <a href=\"%(charity_url)s\">%(charity_name)s</a>."
 
 #: src/olympia/addons/templates/addons/impala/dependencies_note.html:4
 msgid "This add-on requires the following add-ons to work properly:"
-msgstr ""
-"Aby tento doplnok pracoval správne, je nutné nainštalovať nasledovné "
-"doplnky:"
+msgstr "Aby tento doplnok pracoval správne, je nutné nainštalovať nasledovné doplnky:"
 
 #: src/olympia/addons/templates/addons/impala/details-more.html:13
 msgid "Average"
@@ -1350,150 +982,123 @@ msgid "Other add-ons by %(author)s"
 msgid_plural "Other add-ons by these authors"
 msgstr[0] "Ďalšie doplnky od %(author)s"
 msgstr[1] "Ďalšie doplnky od týchto autorov"
-msgstr[2] "Ďalšie doplnky od týchto autorov"
 
-#: src/olympia/addons/templates/addons/impala/details.html:41
+#: src/olympia/addons/templates/addons/impala/details.html:39
 #, python-format
 msgid "<span itemprop=\"ratingCount\">%(num)s</span> user review"
 msgid_plural "<span itemprop=\"ratingCount\">%(num)s</span> user reviews"
 msgstr[0] "<span itemprop=\"ratingCount\">%(num)s</span> recenzia"
 msgstr[1] "<span itemprop=\"ratingCount\">%(num)s</span> recenzie"
-msgstr[2] "<span itemprop=\"ratingCount\">%(num)s</span> recenzií"
 
-#: src/olympia/addons/templates/addons/impala/details.html:69
+#: src/olympia/addons/templates/addons/impala/details.html:66
 msgid "View statistics"
 msgstr "Zobraziť štatistiky"
 
-#: src/olympia/addons/templates/addons/impala/details.html:84
+#: src/olympia/addons/templates/addons/impala/details.html:81
 msgid "Manage"
 msgstr "Spravovať"
 
 #. {0} is an add-on name.
-#: src/olympia/addons/templates/addons/impala/details.html:96
+#: src/olympia/addons/templates/addons/impala/details.html:93
 msgid "Icon of {0}"
 msgstr "Ikona doplnku {0}"
 
-#: src/olympia/addons/templates/addons/impala/details.html:103
-#: src/olympia/addons/templates/addons/impala/listing/items.html:14
+#: src/olympia/addons/templates/addons/impala/details.html:100 src/olympia/addons/templates/addons/impala/listing/items.html:14
 msgid "No Restart"
 msgstr "Nevyžaduje reštart"
 
-#: src/olympia/addons/templates/addons/impala/details.html:127
+#: src/olympia/addons/templates/addons/impala/details.html:124
 #, python-format
 msgid "Meet the Developer: <a href=\"%(url)s\">%(name)s</a>"
 msgid_plural "<a href=\"%(url)s\">Meet the Developers</a>"
 msgstr[0] "Spoznajte vývojára: <a href=\"%(url)s\">%(name)s</a>"
 msgstr[1] "<a href=\"%(url)s\">Spoznajte vývojárov</a>"
-msgstr[2] "<a href=\"%(url)s\">Spoznajte vývojárov</a>"
 
 # {0} is an add-on name.
-#: src/olympia/addons/templates/addons/impala/details.html:137
+#: src/olympia/addons/templates/addons/impala/details.html:134
 msgid "Learn why {0} was created and find out what's next for this add-on."
 msgstr "Zistite, prečo bol doplnok {0} vytvorený a aké budú najbližšie zmeny."
 
 #. {0} is an index.
-#: src/olympia/addons/templates/addons/impala/details.html:156
+#: src/olympia/addons/templates/addons/impala/details.html:161
 msgid "Add-on screenshot #{0}"
 msgstr "Obrázok doplnku #{0}"
 
-#: src/olympia/addons/templates/addons/impala/details.html:182
+#: src/olympia/addons/templates/addons/impala/details.html:187
 msgid "Add-on home page"
 msgstr "Domovská stránka doplnku"
 
-#: src/olympia/addons/templates/addons/impala/details.html:185
+#: src/olympia/addons/templates/addons/impala/details.html:190
 msgid "Support site"
 msgstr "Stránka podpory"
 
-#: src/olympia/addons/templates/addons/impala/details.html:189
+#: src/olympia/addons/templates/addons/impala/details.html:194
 msgid "Support E-mail"
 msgstr "E-mail na podporu"
 
-#: src/olympia/addons/templates/addons/impala/details.html:194
-#: src/olympia/devhub/models.py:378
-#: src/olympia/devhub/templates/devhub/versions/list.html:12
-#: src/olympia/versions/templates/versions/version.html:6
-#: src/olympia/versions/templates/versions/mobile/version.html:6
+#: src/olympia/addons/templates/addons/impala/details.html:199 src/olympia/devhub/models.py:378 src/olympia/devhub/templates/devhub/versions/list.html:12
+#: src/olympia/versions/templates/versions/version.html:6 src/olympia/versions/templates/versions/mobile/version.html:6
 msgid "Version {0}"
 msgstr "Verzia {0}"
 
-#: src/olympia/addons/templates/addons/impala/details.html:194
+#: src/olympia/addons/templates/addons/impala/details.html:199
 msgid "Info"
 msgstr "Informácie"
 
-#: src/olympia/addons/templates/addons/impala/details.html:195
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:129
+#: src/olympia/addons/templates/addons/impala/details.html:200 src/olympia/devhub/templates/devhub/includes/addon_details.html:116
 msgid "Last Updated:"
 msgstr "Posledná aktualizácia:"
 
-#: src/olympia/addons/templates/addons/impala/details.html:200
+#: src/olympia/addons/templates/addons/impala/details.html:205
 #, python-format
 msgid "Released under <a target=\"_blank\" href=\"%(url)s\">%(name)s</a>"
 msgstr "Vydané pod licenciou <a target=\"_blank\" href=\"%(url)s\">%(name)s</a>"
 
-#: src/olympia/addons/templates/addons/impala/details.html:201
-#: src/olympia/addons/templates/addons/impala/details.html:206
-#: src/olympia/amo/helpers.py:398 src/olympia/devhub/forms.py:142
-#: src/olympia/devhub/forms.py:173
-#: src/olympia/versions/templates/versions/version.html:40
-#: src/olympia/versions/templates/versions/version.html:45
+#: src/olympia/addons/templates/addons/impala/details.html:206 src/olympia/addons/templates/addons/impala/details.html:211 src/olympia/amo/helpers.py:398 src/olympia/devhub/forms.py:142
+#: src/olympia/devhub/forms.py:173 src/olympia/versions/templates/versions/version.html:40 src/olympia/versions/templates/versions/version.html:45
 msgid "Custom License"
 msgstr "Vlastná licencia"
 
-#: src/olympia/addons/templates/addons/impala/details.html:205
+#: src/olympia/addons/templates/addons/impala/details.html:210
 #, python-format
 msgid "Released under <a href=\"%(url)s\">%(name)s</a>"
 msgstr "Sprístupnené pod licenciou <a href=\"%(url)s\">%(name)s</a>"
 
-#: src/olympia/addons/templates/addons/impala/details.html:217
+#: src/olympia/addons/templates/addons/impala/details.html:222
 msgid "About this Add-on"
 msgstr "O tomto doplnku"
 
-#: src/olympia/addons/templates/addons/impala/details.html:233
+#: src/olympia/addons/templates/addons/impala/details.html:238
 msgid "Developer’s Comments"
 msgstr "Komentáre vývojára"
 
-#: src/olympia/addons/templates/addons/impala/details.html:243
+#: src/olympia/addons/templates/addons/impala/details.html:248
 msgid "Version Information"
 msgstr "Informácie o verzii"
 
-#: src/olympia/addons/templates/addons/impala/details.html:250
+#: src/olympia/addons/templates/addons/impala/details.html:255
 msgid "See complete version history"
 msgstr "Zobraziť celú históriu verzií"
 
-#: src/olympia/addons/templates/addons/impala/details.html:262
+#: src/olympia/addons/templates/addons/impala/details.html:267
 msgid ""
-"The Development Channel lets you test an experimental new version of this "
-"add-on before it's released to the general public. Once you install the "
-"development version, you will continue to get updates from this channel. To "
-"stop receiving development updates, reinstall the default version from the "
-"link above."
+"The Development Channel lets you test an experimental new version of this add-on before it's released to the general public. Once you install the development version, you will continue to get "
+"updates from this channel. To stop receiving development updates, reinstall the default version from the link above."
 msgstr ""
-"Kanál vývojových verzií vám umožňuje testovať experimentálne nové verzie "
-"tohto doplnku skôr ako budú verejne dostupné. Akonáhle nainštalujete "
-"vývojovú verziu, budete naďalej dostávať aktualizácie z tohto kanála. Na "
-"ukončenie získavania vývojových verzií si nainštalujte stabilnú verziu "
-"doplnku."
+"Kanál vývojových verzií vám umožňuje testovať experimentálne nové verzie tohto doplnku skôr ako budú verejne dostupné. Akonáhle nainštalujete vývojovú verziu, budete naďalej dostávať aktualizácie z"
+" tohto kanála. Na ukončenie získavania vývojových verzií si nainštalujte stabilnú verziu doplnku."
 
-#: src/olympia/addons/templates/addons/impala/details.html:272
-msgid ""
-"<strong>Caution:</strong> Development versions of this add-on have not been "
-"reviewed by Mozilla."
-msgstr ""
-"<strong>Upozornenie:</strong> Vývojové verzie tohto doplnku neboli "
-"skontrolované Mozillou."
+#: src/olympia/addons/templates/addons/impala/details.html:277
+msgid "<strong>Caution:</strong> Development versions of this add-on have not been reviewed by Mozilla."
+msgstr "<strong>Upozornenie:</strong> Vývojové verzie tohto doplnku neboli skontrolované Mozillou."
 
-#: src/olympia/addons/templates/addons/impala/details.html:287
+#: src/olympia/addons/templates/addons/impala/details.html:292
 msgid "See complete development channel history"
 msgstr "Zobraziť celú históriu vývojových verzií"
 
-#: src/olympia/addons/templates/addons/impala/details.html:306
-#: src/olympia/addons/templates/addons/impala/details.html:315
-#: src/olympia/addons/templates/addons/impala/details.html:327
-#: src/olympia/addons/templates/addons/impala/review_add_box.html:4
-#: src/olympia/stats/templates/stats/popup.html:2
-#: src/olympia/stats/templates/stats/popup.html:8
-#: src/olympia/stats/templates/stats/stats.html:202
-#: src/olympia/users/templates/users/profile.html:119
+#: src/olympia/addons/templates/addons/impala/details.html:311 src/olympia/addons/templates/addons/impala/details.html:320 src/olympia/addons/templates/addons/impala/details.html:332
+#: src/olympia/addons/templates/addons/impala/review_add_box.html:4 src/olympia/stats/templates/stats/popup.html:2 src/olympia/stats/templates/stats/popup.html:8
+#: src/olympia/stats/templates/stats/stats.html:204 src/olympia/users/templates/users/profile.html:119
 msgid "close"
 msgstr "zavrieť"
 
@@ -1502,19 +1107,15 @@ msgstr "zavrieť"
 msgid "Thank you for installing {0}"
 msgstr "Ďakujeme za nainštalovanie doplnku {0}"
 
-#. {0} is an add-on name.
 # %1 is an add-on name.
+#. {0} is an add-on name.
 #: src/olympia/addons/templates/addons/impala/developers.html:12
 msgid "Meet the {0} Developer"
 msgstr "Spoznajte vývojára doplnku {0}"
 
 #: src/olympia/addons/templates/addons/impala/developers.html:41
-msgid ""
-"Before downloading this add-on, please consider supporting the development "
-"of this add-on by making a small contribution."
-msgstr ""
-"Pred prevzatím tohto doplnku, prosím, zvážte možnosť podporiť jeho vývoj "
-"zaslaním malého príspevku."
+msgid "Before downloading this add-on, please consider supporting the development of this add-on by making a small contribution."
+msgstr "Pred prevzatím tohto doplnku, prosím, zvážte možnosť podporiť jeho vývoj zaslaním malého príspevku."
 
 # %1 is an add-on name.
 #: src/olympia/addons/templates/addons/impala/developers.html:80
@@ -1531,11 +1132,8 @@ msgid "About the Developer"
 msgid_plural "About the Developers"
 msgstr[0] "O vývojárovi"
 msgstr[1] "O vývojároch"
-msgstr[2] "O vývojároch"
 
-#: src/olympia/addons/templates/addons/impala/developers.html:96
-#: src/olympia/users/templates/users/edit.html:130
-#: src/olympia/users/templates/users/profile.html:26
+#: src/olympia/addons/templates/addons/impala/developers.html:96 src/olympia/users/templates/users/edit.html:130 src/olympia/users/templates/users/profile.html:26
 msgid "No Photo"
 msgstr "Bez fotografie"
 
@@ -1555,24 +1153,15 @@ msgstr "Tento doplnok bol zakázaný administrátorom."
 msgid "Source Code License for {addon}"
 msgstr "Licencia pre zdrojový kód doplnku {addon}"
 
-#: src/olympia/addons/templates/addons/impala/license.html:21
-#: src/olympia/versions/templates/versions/mobile/version.html:18
+#: src/olympia/addons/templates/addons/impala/license.html:21 src/olympia/versions/templates/versions/mobile/version.html:18
 msgid "Source Code License"
 msgstr "Licencia pre zdrojový kód"
 
-#: src/olympia/addons/templates/addons/impala/persona_grid.html:16
-#: src/olympia/addons/templates/addons/impala/toplist.html:6
-msgid "{0} users"
-msgstr "{0} používateľov"
-
-#: src/olympia/addons/templates/addons/impala/review_list_box.html:19
-#: src/olympia/reviews/templates/reviews/review.html:40
+#: src/olympia/addons/templates/addons/impala/review_list_box.html:19 src/olympia/reviews/templates/reviews/review.html:40
 msgid "permalink"
 msgstr "permanentný odkaz"
 
-#: src/olympia/addons/templates/addons/impala/review_list_box.html:23
-#: src/olympia/editors/templates/editors/queue.html:98
-#: src/olympia/reviews/templates/reviews/review.html:44
+#: src/olympia/addons/templates/addons/impala/review_list_box.html:23 src/olympia/editors/templates/editors/queue.html:104 src/olympia/reviews/templates/reviews/review.html:44
 msgid "translate"
 msgstr "preložiť"
 
@@ -1582,10 +1171,8 @@ msgid "See all user reviews"
 msgid_plural "See all %(cnt)s user reviews"
 msgstr[0] "Zobraziť všetky recenzie používateľov"
 msgstr[1] "Zobraziť všetky %(cnt)s recenzie používateľov"
-msgstr[2] "Zobraziť všetkých %(cnt)s recenzií používateľov"
 
-#: src/olympia/addons/templates/addons/impala/review_list_box.html:47
-#: src/olympia/reviews/templates/reviews/review_list.html:84
+#: src/olympia/addons/templates/addons/impala/review_list_box.html:47 src/olympia/reviews/templates/reviews/review_list.html:84
 msgid "This add-on has not yet been reviewed."
 msgstr "Tento doplnok ešte nebol skontrolovaný."
 
@@ -1593,24 +1180,23 @@ msgstr "Tento doplnok ešte nebol skontrolovaný."
 msgid "Be the first!"
 msgstr "Buďte prvý!"
 
-#: src/olympia/addons/templates/addons/impala/listing/sorter.html:14
-#: src/olympia/devhub/templates/devhub/addons/listing/item_actions.html:49
+#: src/olympia/addons/templates/addons/impala/toplist.html:6
+msgid "{0} users"
+msgstr "{0} používateľov"
+
+#: src/olympia/addons/templates/addons/impala/listing/sorter.html:14 src/olympia/devhub/templates/devhub/addons/listing/item_actions.html:49
 msgid "More"
 msgstr "Viac"
 
-#: src/olympia/addons/templates/addons/includes/collection_add_widget.html:7
-#: src/olympia/addons/templates/addons/includes/collection_add_widget.html:10
+#: src/olympia/addons/templates/addons/includes/collection_add_widget.html:7 src/olympia/addons/templates/addons/includes/collection_add_widget.html:10
 msgid "Add to collection"
 msgstr "Pridať do kolekcie"
 
-#: src/olympia/addons/templates/addons/includes/dashboard_tabs.html:4
-#: src/olympia/devhub/templates/devhub/index.html:73
-#: src/olympia/devhub/templates/devhub/nav.html:14
+#: src/olympia/addons/templates/addons/includes/dashboard_tabs.html:4 src/olympia/devhub/templates/devhub/index.html:73 src/olympia/devhub/templates/devhub/nav.html:14
 msgid "My Add-ons"
 msgstr "Moje doplnky"
 
-#: src/olympia/addons/templates/addons/includes/dashboard_tabs.html:6
-#: src/olympia/amo/context_processors.py:51
+#: src/olympia/addons/templates/addons/includes/dashboard_tabs.html:6 src/olympia/amo/context_processors.py:52
 msgid "My Themes"
 msgstr "Moje témy"
 
@@ -1626,8 +1212,7 @@ msgstr "Upraviť tému"
 msgid "Approve / Reject"
 msgstr "Schváliť / Zamietnuť"
 
-#: src/olympia/addons/templates/addons/includes/persona.html:25
-#: src/olympia/editors/templates/editors/themes/single.html:43
+#: src/olympia/addons/templates/addons/includes/persona.html:25 src/olympia/editors/templates/editors/themes/single.html:43
 msgid "Review History"
 msgstr "História kontrol"
 
@@ -1648,14 +1233,11 @@ msgid "Not Yet Rated"
 msgstr "Zatiaľ nehodnotené"
 
 #. {0} is the number of downloads.
-#: src/olympia/addons/templates/addons/listing/items_mobile.html:27
-#: src/olympia/addons/templates/addons/listing/macros.html:24
-#: src/olympia/devhub/templates/devhub/addons/listing/macros.html:15
+#: src/olympia/addons/templates/addons/listing/items_mobile.html:27 src/olympia/addons/templates/addons/listing/macros.html:24 src/olympia/devhub/templates/devhub/addons/listing/macros.html:15
 msgid "<strong>{0}</strong> weekly download"
 msgid_plural "<strong>{0}</strong> weekly downloads"
 msgstr[0] "Prevzatí za týždeň: <strong>{0}</strong>"
 msgstr[1] "Prevzatí za týždeň: <strong>{0}</strong>"
-msgstr[2] "Prevzatí za týždeň: <strong>{0}</strong>"
 
 #: src/olympia/addons/templates/addons/mobile/details.html:32
 msgid "Read More"
@@ -1665,15 +1247,11 @@ msgstr "Ďalšie informácie"
 msgid "Users"
 msgstr "Používatelia"
 
-#: src/olympia/addons/templates/addons/mobile/details.html:92
-#: src/olympia/browse/views.py:59 src/olympia/browse/views.py:70
-#: src/olympia/search/forms.py:90
+#: src/olympia/addons/templates/addons/mobile/details.html:92 src/olympia/browse/views.py:59 src/olympia/browse/views.py:70 src/olympia/search/forms.py:90
 msgid "Weekly Downloads"
 msgstr "Prevzatí za týždeň"
 
-#: src/olympia/addons/templates/addons/mobile/details.html:99
-#: src/olympia/compat/templates/compat/reporter_detail.html:46
-#: src/olympia/devhub/forms.py:787
+#: src/olympia/addons/templates/addons/mobile/details.html:99 src/olympia/compat/templates/compat/reporter_detail.html:46 src/olympia/devhub/forms.py:788
 #: src/olympia/devhub/templates/devhub/versions/list.html:163
 msgid "Version"
 msgstr "Verzia"
@@ -1709,50 +1287,29 @@ msgstr "Licenčné ujednanie"
 
 #: src/olympia/addons/templates/addons/mobile/eula.html:5
 #, python-format
-msgid ""
-"%(name)s requires that you accept the following End-User License Agreement "
-"before installation can proceed:"
-msgstr ""
-"Doplnok %(name)s vyžaduje pred inštaláciou odsúhlasenie nasledujúcej "
-"licenčnej zmluvy:"
+msgid "%(name)s requires that you accept the following End-User License Agreement before installation can proceed:"
+msgstr "Doplnok %(name)s vyžaduje pred inštaláciou odsúhlasenie nasledujúcej licenčnej zmluvy:"
 
 #: src/olympia/addons/templates/addons/mobile/eula.html:15
 msgid "Accept"
 msgstr "Prijať"
 
-#: src/olympia/addons/templates/addons/mobile/home.html:10
-#: src/olympia/templates/mobile/base_addons.html:53
+#: src/olympia/addons/templates/addons/mobile/home.html:10 src/olympia/templates/mobile/base_addons.html:53
 msgid "Add-ons are not currently available on Firefox for iOS."
 msgstr "Doplnky nie sú momentálne dostupné na Firefoxe pre iOS."
 
-#: src/olympia/addons/templates/addons/mobile/home.html:12
-#: src/olympia/templates/mobile/base_addons.html:55
-msgid ""
-"You need Firefox to install add-ons. <a "
-"href=\"http://mozilla.com/mobile\">Learn More&nbsp;&raquo;</a>"
-msgstr ""
-"Na inštaláciu doplnkov musíte používať prehliadač Firefox. <a "
-"href=\"http://mozilla.com/mobile\">Ďalšie informácie&nbsp;&raquo;</a>"
+#: src/olympia/addons/templates/addons/mobile/home.html:12 src/olympia/templates/mobile/base_addons.html:55
+msgid "You need Firefox to install add-ons. <a href=\"http://mozilla.com/mobile\">Learn More&nbsp;&raquo;</a>"
+msgstr "Na inštaláciu doplnkov musíte používať prehliadač Firefox. <a href=\"http://mozilla.com/mobile\">Ďalšie informácie&nbsp;&raquo;</a>"
 
 # {0} is the application name.  Example:  Firefox
-#: src/olympia/addons/templates/addons/mobile/home.html:19
-#: src/olympia/templates/header_title.html:4
-#: src/olympia/templates/impala/header_title.html:3
+#: src/olympia/addons/templates/addons/mobile/home.html:19 src/olympia/templates/header_title.html:4 src/olympia/templates/impala/header_title.html:3
 msgid "Return to the {0} Add-ons homepage"
 msgstr "Návrat na úvodnú stránku {0} Add-ons"
 
-#: src/olympia/addons/templates/addons/mobile/home.html:21
-#: src/olympia/amo/helpers.py:237
-#: src/olympia/bandwagon/templates/bandwagon/edit.html:34
-#: src/olympia/discovery/templates/discovery/pane.html:92
-#: src/olympia/editors/templates/editors/base.html:21
-#: src/olympia/editors/templates/editors/performance.html:72
-#: src/olympia/templates/menu_links.html:4
-#: src/olympia/templates/impala/header_title.html:13
-#: src/olympia/templates/impala/header_title.html:15
-#: src/olympia/templates/impala/header_title.html:19
-#: src/olympia/templates/impala/header_title.html:23
-#: src/olympia/templates/mobile/base_addons.html:47
+#: src/olympia/addons/templates/addons/mobile/home.html:21 src/olympia/amo/helpers.py:237 src/olympia/bandwagon/templates/bandwagon/edit.html:34 src/olympia/discovery/templates/discovery/pane.html:92
+#: src/olympia/editors/templates/editors/base.html:21 src/olympia/editors/templates/editors/performance.html:72 src/olympia/templates/menu_links.html:4 src/olympia/templates/impala/header_title.html:13
+#: src/olympia/templates/impala/header_title.html:15 src/olympia/templates/impala/header_title.html:19 src/olympia/templates/impala/header_title.html:23 src/olympia/templates/mobile/base_addons.html:47
 msgid "Add-ons"
 msgstr "Doplnky"
 
@@ -1760,48 +1317,27 @@ msgstr "Doplnky"
 msgid "Easy ways to personalize."
 msgstr "Jednoduché prispôsobenie"
 
-#: src/olympia/addons/templates/addons/mobile/home.html:24
-#: src/olympia/devhub/templates/devhub/addons/submit/done.html:47
-#: src/olympia/discovery/templates/discovery/pane.html:34
-#: src/olympia/discovery/templates/discovery/addons/detail.html:16
-#: src/olympia/discovery/templates/discovery/modules/featured.html:21
-#: src/olympia/discovery/templates/discovery/modules/monthly.html:22
+#: src/olympia/addons/templates/addons/mobile/home.html:24 src/olympia/devhub/templates/devhub/addons/submit/done.html:47 src/olympia/discovery/templates/discovery/pane.html:34
+#: src/olympia/discovery/templates/discovery/addons/detail.html:16 src/olympia/discovery/templates/discovery/modules/featured.html:21 src/olympia/discovery/templates/discovery/modules/monthly.html:22
 msgid "Learn More"
 msgstr "Ďalšie informácie"
 
 #: src/olympia/addons/templates/addons/mobile/home.html:26
 msgid ""
-"Add-ons are applications that let you personalize Firefox with extra "
-"functionality and style. Whether you mistype the name of a website or can't "
-"read a busy page, there's an add-on to improve your on-the-go browsing."
+"Add-ons are applications that let you personalize Firefox with extra functionality and style. Whether you mistype the name of a website or can't read a busy page, there's an add-on to improve your "
+"on-the-go browsing."
 msgstr ""
-"Doplnky sú aplikácie, ktoré umožňujú prispôsobiť si Firefox pridaním nových "
-"funkcií alebo zmenou vzhľadu. Či už nesprávne napíšete meno alebo nemáte čas"
-" na čítanie dlhých stránok, vždy sa nájde doplnok, ktorý vám prehliadanie "
-"uľahčí."
+"Doplnky sú aplikácie, ktoré umožňujú prispôsobiť si Firefox pridaním nových funkcií alebo zmenou vzhľadu. Či už nesprávne napíšete meno alebo nemáte čas na čítanie dlhých stránok, vždy sa nájde "
+"doplnok, ktorý vám prehliadanie uľahčí."
 
 #. {0} is a category name. Ex: "Sports"
 #. {0} is a category name, such as Nature.
-#: src/olympia/addons/templates/addons/mobile/home.html:43
-#: src/olympia/amo/templates/amo/site_nav.html:32
-#: src/olympia/browse/feeds.py:107
-#: src/olympia/browse/templates/browse/impala/base_listing.html:38
-#: src/olympia/browse/templates/browse/personas/base.html:6
-#: src/olympia/browse/templates/browse/personas/base.html:42
-#: src/olympia/browse/templates/browse/personas/category_landing.html:21
-#: src/olympia/browse/templates/browse/personas/category_landing.html:23
-#: src/olympia/browse/templates/browse/personas/category_landing.html:38
-#: src/olympia/browse/templates/browse/personas/grid.html:7
-#: src/olympia/browse/templates/browse/personas/grid.html:11
-#: src/olympia/browse/templates/browse/personas/mobile/base.html:7
-#: src/olympia/browse/templates/browse/personas/mobile/category_landing.html:19
-#: src/olympia/constants/base.py:180
-#: src/olympia/devhub/templates/devhub/personas/submit.html:13
-#: src/olympia/editors/helpers.py:105
-#: src/olympia/editors/templates/editors/base.html:26
-#: src/olympia/editors/templates/editors/performance.html:73
-#: src/olympia/search/templates/search/personas.html:39
-#: src/olympia/templates/menu_links.html:9
+#: src/olympia/addons/templates/addons/mobile/home.html:43 src/olympia/amo/templates/amo/site_nav.html:32 src/olympia/browse/feeds.py:107 src/olympia/browse/templates/browse/impala/base_listing.html:38
+#: src/olympia/browse/templates/browse/personas/base.html:6 src/olympia/browse/templates/browse/personas/base.html:42 src/olympia/browse/templates/browse/personas/category_landing.html:21
+#: src/olympia/browse/templates/browse/personas/category_landing.html:23 src/olympia/browse/templates/browse/personas/category_landing.html:38 src/olympia/browse/templates/browse/personas/grid.html:7
+#: src/olympia/browse/templates/browse/personas/grid.html:11 src/olympia/browse/templates/browse/personas/mobile/base.html:7 src/olympia/browse/templates/browse/personas/mobile/category_landing.html:19
+#: src/olympia/constants/base.py:180 src/olympia/devhub/templates/devhub/personas/submit.html:13 src/olympia/editors/helpers.py:107 src/olympia/editors/templates/editors/base.html:26
+#: src/olympia/editors/templates/editors/performance.html:73 src/olympia/search/templates/search/personas.html:39 src/olympia/templates/menu_links.html:9
 msgid "Themes"
 msgstr "Témy"
 
@@ -1817,19 +1353,12 @@ msgstr "Zobraziť všetky obľúbené doplnky"
 msgid "More Add-ons"
 msgstr "Ďalšie doplnky"
 
-#: src/olympia/addons/templates/addons/mobile/home.html:72
-#: src/olympia/browse/templates/browse/personas/mobile/category_landing.html:64
-#: src/olympia/search/forms.py:14
+#: src/olympia/addons/templates/addons/mobile/home.html:72 src/olympia/browse/templates/browse/personas/mobile/category_landing.html:64 src/olympia/search/forms.py:14
 msgid "Highest Rated"
 msgstr "Najlepšie hodnotené"
 
-#: src/olympia/addons/templates/addons/mobile/home.html:74
-#: src/olympia/amo/templates/amo/side_nav.html:5
-#: src/olympia/amo/templates/amo/site_nav.html:27
-#: src/olympia/amo/templates/amo/site_nav.html:57
-#: src/olympia/bandwagon/views.py:97 src/olympia/browse/views.py:57
-#: src/olympia/browse/views.py:67
-#: src/olympia/browse/templates/browse/personas/mobile/category_landing.html:65
+#: src/olympia/addons/templates/addons/mobile/home.html:74 src/olympia/amo/templates/amo/side_nav.html:5 src/olympia/amo/templates/amo/site_nav.html:27 src/olympia/amo/templates/amo/site_nav.html:55
+#: src/olympia/bandwagon/views.py:97 src/olympia/browse/views.py:57 src/olympia/browse/views.py:67 src/olympia/browse/templates/browse/personas/mobile/category_landing.html:65
 #: src/olympia/search/forms.py:15 src/olympia/search/forms.py:87
 msgid "Newest"
 msgstr "Najnovšie"
@@ -1842,122 +1371,88 @@ msgstr "Vyskúšajte ju!"
 msgid "Theme Info &raquo;"
 msgstr "Informácie o téme &raquo;"
 
-#: src/olympia/amo/context_processors.py:39
-#: src/olympia/devhub/templates/devhub/nav.html:43
+#: src/olympia/amo/context_processors.py:39 src/olympia/devhub/templates/devhub/nav.html:43
 msgid "Tools"
 msgstr "Nástroje"
 
-#: src/olympia/amo/context_processors.py:48
-#: src/olympia/discovery/templates/discovery/pane_account.html:8
-#: src/olympia/users/templates/users/includes/navigation.html:2
+#: src/olympia/amo/context_processors.py:49 src/olympia/discovery/templates/discovery/pane_account.html:8 src/olympia/users/templates/users/includes/navigation.html:2
 msgid "My Profile"
 msgstr "Môj profil"
 
-#: src/olympia/amo/context_processors.py:54
-#: src/olympia/users/templates/users/edit.html:5
-#: src/olympia/users/templates/users/includes/navigation.html:3
+#: src/olympia/amo/context_processors.py:55 src/olympia/users/templates/users/edit.html:5 src/olympia/users/templates/users/includes/navigation.html:3
 msgid "Account Settings"
 msgstr "Nastavenia účtu"
 
-#: src/olympia/amo/context_processors.py:57
-#: src/olympia/discovery/templates/discovery/pane_account.html:11
-#: src/olympia/users/templates/users/profile.html:83
+#: src/olympia/amo/context_processors.py:58 src/olympia/discovery/templates/discovery/pane_account.html:11 src/olympia/users/templates/users/profile.html:83
 #: src/olympia/users/templates/users/includes/navigation.html:4
 msgid "My Collections"
 msgstr "Moje kolekcie"
 
-#: src/olympia/amo/context_processors.py:62
-#: src/olympia/discovery/templates/discovery/pane_account.html:10
-#: src/olympia/users/templates/users/includes/navigation.html:7
+#: src/olympia/amo/context_processors.py:63 src/olympia/discovery/templates/discovery/pane_account.html:10 src/olympia/users/templates/users/includes/navigation.html:7
 msgid "My Favorites"
 msgstr "Moje obľúbené"
 
-#: src/olympia/amo/context_processors.py:67
-#: src/olympia/discovery/templates/discovery/pane_account.html:13
-#: src/olympia/templates/impala/user_login.html:14
-#: src/olympia/templates/mobile/header_auth.html:5
+#: src/olympia/amo/context_processors.py:68 src/olympia/discovery/templates/discovery/pane_account.html:13 src/olympia/templates/impala/user_login.html:14 src/olympia/templates/mobile/header_auth.html:5
 msgid "Log out"
 msgstr "Odhlásiť sa"
 
-#: src/olympia/amo/context_processors.py:72
-#: src/olympia/devhub/templates/devhub/addons/dashboard.html:4
+#: src/olympia/amo/context_processors.py:73 src/olympia/devhub/templates/devhub/addons/dashboard.html:4
 msgid "Manage My Submissions"
 msgstr "Správa mnou odoslaných doplnkov"
 
-#: src/olympia/amo/context_processors.py:75
-#: src/olympia/devhub/templates/devhub/nav.html:27
-#: src/olympia/devhub/templates/devhub/addons/dashboard.html:25
+#: src/olympia/amo/context_processors.py:76 src/olympia/devhub/templates/devhub/nav.html:27 src/olympia/devhub/templates/devhub/addons/dashboard.html:25
 #: src/olympia/devhub/templates/devhub/addons/submit/base.html:4
 msgid "Submit a New Add-on"
 msgstr "Odoslať nový doplnok"
 
-#: src/olympia/amo/context_processors.py:77
-#: src/olympia/browse/templates/browse/personas/base.html:50
-#: src/olympia/devhub/templates/devhub/index.html:24
+#: src/olympia/amo/context_processors.py:78 src/olympia/browse/templates/browse/personas/base.html:50 src/olympia/devhub/templates/devhub/index.html:24
 #: src/olympia/devhub/templates/devhub/addons/dashboard.html:29
 msgid "Submit a New Theme"
 msgstr "Odoslať novú tému"
 
-#: src/olympia/amo/context_processors.py:79
-#: src/olympia/amo/templates/amo/site_nav.html:87
-#: src/olympia/devhub/helpers.py:36 src/olympia/devhub/helpers.py:68
-#: src/olympia/devhub/helpers.py:102 src/olympia/templates/footer.html:6
-#: src/olympia/templates/menu_links.html:14
+#: src/olympia/amo/context_processors.py:80 src/olympia/amo/templates/amo/site_nav.html:85 src/olympia/devhub/helpers.py:36 src/olympia/devhub/helpers.py:68 src/olympia/devhub/helpers.py:102
+#: src/olympia/templates/footer.html:6 src/olympia/templates/menu_links.html:14
 msgid "Developer Hub"
 msgstr "Centrum vývojárov"
 
-#: src/olympia/amo/context_processors.py:83 src/olympia/devhub/views.py:1792
+#: src/olympia/amo/context_processors.py:84 src/olympia/devhub/views.py:1799
 msgid "Manage API Keys"
 msgstr "Spravovať kľúče API"
 
-#: src/olympia/amo/context_processors.py:88 src/olympia/editors/helpers.py:82
-#: src/olympia/editors/helpers.py:102
-#: src/olympia/editors/templates/editors/base.html:10
+#: src/olympia/amo/context_processors.py:89 src/olympia/editors/helpers.py:84 src/olympia/editors/helpers.py:104 src/olympia/editors/templates/editors/base.html:10
 msgid "Editor Tools"
 msgstr "Nástroje editora"
 
-#: src/olympia/amo/context_processors.py:92
+#: src/olympia/amo/context_processors.py:93
 msgid "Admin Tools"
 msgstr "Nástroje správcu"
 
-#: src/olympia/amo/fields.py:15
+#: src/olympia/amo/fields.py:20
 msgid "Incorrect, please try again."
 msgstr "Nesprávne, skúste to znova."
 
-#: src/olympia/amo/fields.py:16
+#: src/olympia/amo/fields.py:21
 msgid "Error verifying input, please try again."
 msgstr "Chyba pri kontrole vstupu, skúste to prosím znovu."
 
-#: src/olympia/amo/fields.py:32
+#: src/olympia/amo/fields.py:37
 msgid "This must be a valid hex color code, such as #000000."
 msgstr "Toto musí byť platný hex kód farby, ako #000000."
 
-#: src/olympia/amo/fields.py:58
+#: src/olympia/amo/fields.py:63
 msgid "Enter at least one value."
 msgstr "Zadajte minimálne jednu hodnotu."
 
-#: src/olympia/amo/helpers.py:162
-#: src/olympia/amo/templates/amo/site_nav.html:61
-#: src/olympia/bandwagon/templates/bandwagon/add.html:9
-#: src/olympia/bandwagon/templates/bandwagon/collection_detail.html:15
-#: src/olympia/bandwagon/templates/bandwagon/delete.html:9
-#: src/olympia/bandwagon/templates/bandwagon/edit.html:15
-#: src/olympia/bandwagon/templates/bandwagon/user_listing.html:18
-#: src/olympia/bandwagon/templates/bandwagon/user_listing.html:21
-#: src/olympia/bandwagon/templates/bandwagon/impala/collection_listing.html:12
-#: src/olympia/bandwagon/templates/bandwagon/impala/collection_listing.html:20
-#: src/olympia/bandwagon/templates/bandwagon/impala/collection_listing.html:24
-#: src/olympia/bandwagon/templates/bandwagon/impala/collection_sidebar.html:3
-#: src/olympia/bandwagon/templates/bandwagon/includes/collection_sidebar.html:2
-#: src/olympia/bandwagon/templates/bandwagon/mobile/collection_listing.html:3
-#: src/olympia/stats/templates/stats/stats.html:77
-#: src/olympia/templates/menu_links.html:12
+#: src/olympia/amo/helpers.py:162 src/olympia/amo/templates/amo/site_nav.html:59 src/olympia/bandwagon/templates/bandwagon/add.html:9 src/olympia/bandwagon/templates/bandwagon/collection_detail.html:15
+#: src/olympia/bandwagon/templates/bandwagon/delete.html:9 src/olympia/bandwagon/templates/bandwagon/edit.html:15 src/olympia/bandwagon/templates/bandwagon/user_listing.html:18
+#: src/olympia/bandwagon/templates/bandwagon/user_listing.html:21 src/olympia/bandwagon/templates/bandwagon/impala/collection_listing.html:12
+#: src/olympia/bandwagon/templates/bandwagon/impala/collection_listing.html:20 src/olympia/bandwagon/templates/bandwagon/impala/collection_listing.html:24
+#: src/olympia/bandwagon/templates/bandwagon/impala/collection_sidebar.html:3 src/olympia/bandwagon/templates/bandwagon/includes/collection_sidebar.html:2
+#: src/olympia/bandwagon/templates/bandwagon/mobile/collection_listing.html:3 src/olympia/stats/templates/stats/stats.html:33 src/olympia/templates/menu_links.html:12
 msgid "Collections"
 msgstr "Kolekcie"
 
-#: src/olympia/amo/helpers.py:171
-#: src/olympia/amo/templates/amo/site_nav.html:85
-#: src/olympia/browse/templates/browse/language_tools.html:3
+#: src/olympia/amo/helpers.py:171 src/olympia/amo/templates/amo/site_nav.html:83 src/olympia/browse/templates/browse/language_tools.html:3
 msgid "Dictionaries & Language Packs"
 msgstr "Slovníky a jazykové balíky"
 
@@ -2109,11 +1604,8 @@ msgstr "Vyžiadaná super-kontrola"
 msgid "Comment on {addon} {version}."
 msgstr "Doplnok {addon} {version} bol okomentovaný."
 
-#: src/olympia/amo/log.py:236
-#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:19
-#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:47
-#: src/olympia/editors/helpers.py:511
-#: src/olympia/editors/templates/editors/themes/history_table.html:11
+#: src/olympia/amo/log.py:236 src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:17 src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:45
+#: src/olympia/editors/helpers.py:584 src/olympia/editors/templates/editors/themes/history_table.html:11
 msgid "Comment"
 msgstr "Komentár"
 
@@ -2219,9 +1711,7 @@ msgstr "Manifest doplnku {addon} bol aktualizovaný."
 
 #: src/olympia/amo/log.py:385
 msgid "{addon} {version} approved but waiting to be made public."
-msgstr ""
-"Doplnok {addon} {version} bol schválený, ale čaká na uverejnenie pre "
-"verejnosť."
+msgstr "Doplnok {addon} {version} bol schválený, ale čaká na uverejnenie pre verejnosť."
 
 #: src/olympia/amo/log.py:386
 msgid "Approved but waiting"
@@ -2253,9 +1743,7 @@ msgstr "Aplikácia zakázaná"
 
 #: src/olympia/amo/log.py:425
 msgid "{addon} escalated because of high number of abuse reports."
-msgstr ""
-"Doplnok {addon} bol eskalovaný na kontrolu, pretože bolo zaregistrované "
-"väčšie množstvo hlásení o zneužití."
+msgstr "Doplnok {addon} bol eskalovaný na kontrolu, pretože bolo zaregistrované väčšie množstvo hlásení o zneužití."
 
 #: src/olympia/amo/log.py:426
 msgid "High Abuse Reports"
@@ -2271,9 +1759,7 @@ msgstr "Postúpenie na detailnú kontrolu"
 
 #: src/olympia/amo/log.py:442
 msgid "Video removed from {addon} because of a problem with the video."
-msgstr ""
-"Video bolo odstránené z doplnku {addon}, pretože sa pri tomto videu vyskytol"
-" problém."
+msgstr "Video bolo odstránené z doplnku {addon}, pretože sa pri tomto videu vyskytol problém."
 
 #: src/olympia/amo/log.py:444
 msgid "Video removed"
@@ -2281,9 +1767,7 @@ msgstr "Video bolo odstránené"
 
 #: src/olympia/amo/log.py:449
 msgid "{addon} re-review because of new device(s) added."
-msgstr ""
-"Doplnok {addon} bude opäť skontrolovaný, pretože boli pridané nové "
-"zariadenia."
+msgstr "Doplnok {addon} bude opäť skontrolovaný, pretože boli pridané nové zariadenia."
 
 #: src/olympia/amo/log.py:450
 msgid "Device(s) Added"
@@ -2291,8 +1775,7 @@ msgstr "Boli pridané zariadenia"
 
 #: src/olympia/amo/log.py:457
 msgid "{addon} device support manually changed by reviewer."
-msgstr ""
-"Pri doplnku {addon} boli podporované zariadenia redaktorom ručne upravené."
+msgstr "Pri doplnku {addon} boli podporované zariadenia redaktorom ručne upravené."
 
 #: src/olympia/amo/log.py:458
 msgid "Device(s) Changed by Reviewer"
@@ -2344,8 +1827,7 @@ msgstr "Používateľ {0.name} odstránený zo skupiny {group}."
 
 #: src/olympia/amo/log.py:545
 msgid "{addon} minimum requirements manually changed by reviewer."
-msgstr ""
-"Minimálne požiadavky boli pri doplnku {addon} redaktorom ručne upravené."
+msgstr "Minimálne požiadavky boli pri doplnku {addon} redaktorom ručne upravené."
 
 #: src/olympia/amo/log.py:546
 msgid "Requirements Changed by Reviewer"
@@ -2367,8 +1849,7 @@ msgstr "Stav verzie {version} bol zmenený na {0}."
 #. L10n: {0} is the status
 #: src/olympia/amo/log.py:569
 msgid "User {0.name} {0.id} deleted via lookup tool."
-msgstr ""
-"Používateľ {0.name} {0.id} bol odstránený pomocou vyhľadávacieho nástroja."
+msgstr "Používateľ {0.name} {0.id} bol odstránený pomocou vyhľadávacieho nástroja."
 
 #: src/olympia/amo/log.py:575
 msgid "{addon} content rating changed to Adult."
@@ -2382,10 +1863,7 @@ msgstr "Hodnotenie doplnku {addon} bolo zmenené."
 msgid "{addon} unlisted."
 msgstr "{addon} je mimo zoznamu."
 
-#: src/olympia/amo/log.py:592 src/olympia/amo/log.py:598
-#: src/olympia/amo/log.py:612 src/olympia/amo/log.py:618
-#: src/olympia/amo/log.py:624 src/olympia/amo/log.py:630
-#: src/olympia/amo/log.py:636
+#: src/olympia/amo/log.py:592 src/olympia/amo/log.py:598 src/olympia/amo/log.py:612 src/olympia/amo/log.py:618 src/olympia/amo/log.py:624 src/olympia/amo/log.py:630 src/olympia/amo/log.py:636
 msgid "{file} was signed."
 msgstr "{file} bol podpísaný."
 
@@ -2399,20 +1877,12 @@ msgid "Not allowed"
 msgstr "Nepovolené"
 
 #: src/olympia/amo/templates/amo/403.html:7
-msgid ""
-"<h1>Oops! Not allowed.</h1> <p>You tried to do something that you weren't "
-"allowed to.</p>"
-msgstr ""
-"<h1>Ups! Nepovolená operácia.</h1> <p>Pokúsili ste sa urobiť niečo, na čo "
-"nemáte oprávnenie.</p>"
+msgid "<h1>Oops! Not allowed.</h1> <p>You tried to do something that you weren't allowed to.</p>"
+msgstr "<h1>Ups! Nepovolená operácia.</h1> <p>Pokúsili ste sa urobiť niečo, na čo nemáte oprávnenie.</p>"
 
 #: src/olympia/amo/templates/amo/403.html:12
-msgid ""
-"<p>Try going back to the previous page, refreshing and then trying "
-"again.</p>"
-msgstr ""
-"<p>Skúste prejsť na predchádzajúcu stránku, opätovne načítajte jej obsah a "
-"skúste to znova.</p>"
+msgid "<p>Try going back to the previous page, refreshing and then trying again.</p>"
+msgstr "<p>Skúste prejsť na predchádzajúcu stránku, opätovne načítajte jej obsah a skúste to znova.</p>"
 
 #: src/olympia/amo/templates/amo/404.html:3
 msgid "Not Found"
@@ -2421,36 +1891,19 @@ msgstr "Nebolo nájdené"
 #: src/olympia/amo/templates/amo/404.html:6
 #, python-format
 msgid ""
-"<h1>We're sorry, but we can't find what you're looking for.</h1> <p> The "
-"page or file you requested wasn't found on our site. It's possible that you "
-"clicked a link that's out of date, or typed in the address incorrectly. </p>"
-" <ul> <li>If you typed in the address, please double check the "
-"spelling.</li> <li> If you followed a link from somewhere, please let us "
-"know at <a href=\"mailto:webmaster@mozilla.com\">webmaster@mozilla.com</a>. "
-"Tell us where you came from and what you were looking for, and we'll do our "
-"best to fix it. </li> </ul> <p>Or you can just jump over to some of the "
-"popular pages on our website.</p> <ul> <li>Are you interested in a <a "
-"href=\"%(rec)s\">list of featured add-ons</a>?</li> <li> Do you want to <a "
-"href=\"%(search)s\">search for add-ons</a>? You may go to the <a "
-"href=\"%(search)s\">search page</a> or just use the search field above. "
-"</li> <li> If you prefer to start over, just go to the <a href=\"%(home)s"
-"\">add-ons front page</a>. </li> </ul>"
+"<h1>We're sorry, but we can't find what you're looking for.</h1> <p> The page or file you requested wasn't found on our site. It's possible that you clicked a link that's out of date, or typed in "
+"the address incorrectly. </p> <ul> <li>If you typed in the address, please double check the spelling.</li> <li> If you followed a link from somewhere, please let us know at <a "
+"href=\"mailto:webmaster@mozilla.com\">webmaster@mozilla.com</a>. Tell us where you came from and what you were looking for, and we'll do our best to fix it. </li> </ul> <p>Or you can just jump over"
+" to some of the popular pages on our website.</p> <ul> <li>Are you interested in a <a href=\"%(rec)s\">list of featured add-ons</a>?</li> <li> Do you want to <a href=\"%(search)s\">search for add-"
+"ons</a>? You may go to the <a href=\"%(search)s\">search page</a> or just use the search field above. </li> <li> If you prefer to start over, just go to the <a href=\"%(home)s\">add-ons front "
+"page</a>. </li> </ul>"
 msgstr ""
-"<h1>Ospravedlňujeme sa, ale nie je možné nájsť, čo ste hľadali.</h1> "
-"<p>Stránka alebo súbor, ktorý požadujete, sa na&nbsp;našej stránke nenašli. "
-"Je možné, že ste klikli na&nbsp;neplatný odkaz, alebo ste nesprávne zadali "
-"adresu.</p><ul><li>Ak ste adresu zadávali, skontrolujte dvakrát "
-"správnosť.</li><li>Ak ste niekde klikli na&nbsp;odkaz, dajte nám vedieť "
-"na&nbsp;adresu <a "
-"href=\"mailto:webmaster@mozilla.com\">webmaster@mozilla.com</a>. Oznámte "
-"nám, odkiaľ ste prišli a&nbsp;čo ste hľadali. Urobíme všetko "
-"pre&nbsp;nápravu.</li></ul><p>Prípadne prejdite na&nbsp;niektorú "
-"z&nbsp;obľúbených stránok na&nbsp;našom webe.</p><ul><li>Zaujíma vás <a "
-"href=\"%(rec)s\">zoznam odporúčaných doplnkov</a>?</li><li>Chcete<a "
-"href=\"%(search)s\">hľadať doplnok</a>? Môžete prejsť na&nbsp;<a "
-"href=\"%(search)s\">stránku vyhľadávania</a>, alebo jednoducho použite hore "
-"uvedené vyhľadávacie pole.</li><li>Ak chcete ísť na&nbsp;začiatok, prejdite "
-"na&nbsp;<a href=\"%(home)s\">úvodnú stránku doplnkov</a>.</li></ul>"
+"<h1>Ospravedlňujeme sa, ale nie je možné nájsť, čo ste hľadali.</h1> <p>Stránka alebo súbor, ktorý požadujete, sa na&nbsp;našej stránke nenašli. Je možné, že ste klikli na&nbsp;neplatný odkaz, "
+"alebo ste nesprávne zadali adresu.</p><ul><li>Ak ste adresu zadávali, skontrolujte dvakrát správnosť.</li><li>Ak ste niekde klikli na&nbsp;odkaz, dajte nám vedieť na&nbsp;adresu <a "
+"href=\"mailto:webmaster@mozilla.com\">webmaster@mozilla.com</a>. Oznámte nám, odkiaľ ste prišli a&nbsp;čo ste hľadali. Urobíme všetko pre&nbsp;nápravu.</li></ul><p>Prípadne prejdite "
+"na&nbsp;niektorú z&nbsp;obľúbených stránok na&nbsp;našom webe.</p><ul><li>Zaujíma vás <a href=\"%(rec)s\">zoznam odporúčaných doplnkov</a>?</li><li>Chcete<a href=\"%(search)s\">hľadať doplnok</a>? "
+"Môžete prejsť na&nbsp;<a href=\"%(search)s\">stránku vyhľadávania</a>, alebo jednoducho použite hore uvedené vyhľadávacie pole.</li><li>Ak chcete ísť na&nbsp;začiatok, prejdite na&nbsp;<a "
+"href=\"%(home)s\">úvodnú stránku doplnkov</a>.</li></ul>"
 
 #: src/olympia/amo/templates/amo/500.html:3
 msgid "Oops"
@@ -2458,82 +1911,49 @@ msgstr "Ups"
 
 #: src/olympia/amo/templates/amo/500.html:6
 #, python-format
-msgid ""
-"<h1>Oops! We had an error.</h1> <p>We'll get to fixing that soon.</p> <p> "
-"You can try refreshing the page, or head back to the <a href=\"%(home)s"
-"\">Add-ons homepage</a>. </p>"
-msgstr ""
-"<h1>Ups! Vyskytla sa chyba.</h1> <p>Pokúsime sa ju čím skôr opraviť.</p> "
-"<p>Môžete skúsiť znova načítať túto stránku alebo prejdite na <a "
-"href=\"%(home)s\">domovskú stránku Mozilla Add-ons</a>.</p>"
+msgid "<h1>Oops! We had an error.</h1> <p>We'll get to fixing that soon.</p> <p> You can try refreshing the page, or head back to the <a href=\"%(home)s\">Add-ons homepage</a>. </p>"
+msgstr "<h1>Ups! Vyskytla sa chyba.</h1> <p>Pokúsime sa ju čím skôr opraviť.</p> <p>Môžete skúsiť znova načítať túto stránku alebo prejdite na <a href=\"%(home)s\">domovskú stránku Mozilla Add-ons</a>.</p>"
 
 #: src/olympia/amo/templates/amo/license_link.html:10
 msgid "Some rights reserved"
 msgstr "Niektoré práva vyhradené"
 
-#: src/olympia/amo/templates/amo/no_results.html:1
-#: src/olympia/editors/templates/editors/includes/search_results_themes.html:26
+#: src/olympia/amo/templates/amo/no_results.html:1 src/olympia/editors/templates/editors/includes/search_results_themes.html:26
 msgid "No results found"
 msgstr "Neboli nájdené žiadne výsledky."
 
 #. abbreviation of 'previous'
-#: src/olympia/amo/templates/amo/paginator.html:6
-#: src/olympia/amo/templates/amo/mobile/paginator.html:4
-#: src/olympia/amo/templates/amo/mobile/paginator.html:6
-#: src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:49
-#: src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:63
-#: src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:76
-#: src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:89
+#: src/olympia/amo/templates/amo/paginator.html:6 src/olympia/amo/templates/amo/mobile/paginator.html:4 src/olympia/amo/templates/amo/mobile/paginator.html:6
+#: src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:49 src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:63
+#: src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:76 src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:89
 #: src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:102
 msgid "Prev"
 msgstr "Predchádzajúca"
 
-#: src/olympia/amo/templates/amo/paginator.html:26
-#: src/olympia/amo/templates/amo/impala/paginator.html:26
-#: src/olympia/amo/templates/amo/mobile/impala_paginator.html:16
-#: src/olympia/amo/templates/amo/mobile/paginator.html:14
-#: src/olympia/amo/templates/amo/mobile/paginator.html:16
-#: src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:51
-#: src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:65
-#: src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:78
-#: src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:91
-#: src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:104
-#: src/olympia/discovery/templates/discovery/pane.html:45
-#: src/olympia/discovery/templates/discovery/addons/detail.html:39
-#: src/olympia/stats/templates/stats/stats.html:167
+#: src/olympia/amo/templates/amo/paginator.html:26 src/olympia/amo/templates/amo/impala/paginator.html:26 src/olympia/amo/templates/amo/mobile/impala_paginator.html:16
+#: src/olympia/amo/templates/amo/mobile/paginator.html:14 src/olympia/amo/templates/amo/mobile/paginator.html:16 src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:51
+#: src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:65 src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:78
+#: src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:91 src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:104
+#: src/olympia/discovery/templates/discovery/pane.html:45 src/olympia/discovery/templates/discovery/addons/detail.html:39 src/olympia/stats/templates/stats/stats.html:169
 msgid "Next"
 msgstr "Ďalšia"
 
-#: src/olympia/amo/templates/amo/paginator.html:32
-#: src/olympia/editors/templates/editors/includes/paginator_history.html:11
+#: src/olympia/amo/templates/amo/paginator.html:32 src/olympia/editors/templates/editors/includes/paginator_history.html:11
 #, python-format
-msgid ""
-"Results <strong>%(begin)s</strong>&ndash;<strong>%(end)s</strong> of "
-"<strong>%(count)s</strong>"
-msgstr ""
-"Výsledky <strong>%(begin)s</strong>&ndash;<strong>%(end)s</strong> z "
-"<strong>%(count)s</strong>"
+msgid "Results <strong>%(begin)s</strong>&ndash;<strong>%(end)s</strong> of <strong>%(count)s</strong>"
+msgstr "Výsledky <strong>%(begin)s</strong>&ndash;<strong>%(end)s</strong> z <strong>%(count)s</strong>"
 
-#: src/olympia/amo/templates/amo/read-only.html:3
-#: src/olympia/amo/templates/amo/read-only.html:7
+#: src/olympia/amo/templates/amo/read-only.html:3 src/olympia/amo/templates/amo/read-only.html:7
 msgid "Maintenance in progress"
 msgstr "Práve prebieha údržba"
 
 #: src/olympia/amo/templates/amo/read-only.html:9
-msgid ""
-"This feature is temporarily disabled while we perform website maintenance. "
-"Please use your browser's Back button and try again a little later."
-msgstr ""
-"Táto funkcia je počas údržby stránok vypnutá. Prosím, použite v prehliadači "
-"tlačidlo Naspäť a skúste to znova neskôr."
+msgid "This feature is temporarily disabled while we perform website maintenance. Please use your browser's Back button and try again a little later."
+msgstr "Táto funkcia je počas údržby stránok vypnutá. Prosím, použite v prehliadači tlačidlo Naspäť a skúste to znova neskôr."
 
 #: src/olympia/amo/templates/amo/read-only.html:14
-msgid ""
-"Some features on this page are temporarily disabled while we perform website"
-" maintenance. Please try again a little later."
-msgstr ""
-"Niektoré funkcie sú na tejto stránke dočasne vypnuté kvôli údržbe. Prosím, "
-"skúste to znova neskôr."
+msgid "Some features on this page are temporarily disabled while we perform website maintenance. Please try again a little later."
+msgstr "Niektoré funkcie sú na tejto stránke dočasne vypnuté kvôli údržbe. Prosím, skúste to znova neskôr."
 
 #: src/olympia/amo/templates/amo/recaptcha.html:4
 msgid "Are you human?"
@@ -2541,24 +1961,14 @@ msgstr "Ste človek?"
 
 #: src/olympia/amo/templates/amo/recaptcha.html:8
 msgid ""
-"<p> Please enter <strong>all the words</strong> below, <strong>separated by "
-"a space if necessary</strong>. </p> <p> If this is hard to read, you can <a "
-"href=\"#\" id=\"recaptcha_different\">try different words</a> or <a "
-"href=\"#\" id=\"recaptcha_audio\">try a different type of challenge</a> "
-"instead. </p>"
+"<p> Please enter <strong>all the words</strong> below, <strong>separated by a space if necessary</strong>. </p> <p> If this is hard to read, you can <a href=\"#\" id=\"recaptcha_different\">try "
+"different words</a> or <a href=\"#\" id=\"recaptcha_audio\">try a different type of challenge</a> instead. </p>"
 msgstr ""
-"<p> Zadajte prosím <strong>všetky slová</strong> nižšie a <strong>oddeľte "
-"ich medzerami</strong>, ak je to nutné. </p> <p> Ak sa nedajú prečítať, "
-"môžete <a href=\"#\" id=\"recaptcha_different\">skúsiť iné slová</a> alebo "
-"<a href=\"#\" id=\"recaptcha_audio\">iný typ overenia</a>. </p>"
+"<p> Zadajte prosím <strong>všetky slová</strong> nižšie a <strong>oddeľte ich medzerami</strong>, ak je to nutné. </p> <p> Ak sa nedajú prečítať, môžete <a href=\"#\" "
+"id=\"recaptcha_different\">skúsiť iné slová</a> alebo <a href=\"#\" id=\"recaptcha_audio\">iný typ overenia</a>. </p>"
 
-#: src/olympia/amo/templates/amo/side_nav.html:4
-#: src/olympia/amo/templates/amo/side_nav.html:12
-#: src/olympia/amo/templates/amo/site_nav.html:4
-#: src/olympia/amo/templates/amo/site_nav.html:26
-#: src/olympia/browse/views.py:56 src/olympia/browse/views.py:66
-#: src/olympia/browse/views.py:237 src/olympia/browse/views.py:282
-#: src/olympia/search/forms.py:86
+#: src/olympia/amo/templates/amo/side_nav.html:4 src/olympia/amo/templates/amo/side_nav.html:12 src/olympia/amo/templates/amo/site_nav.html:4 src/olympia/amo/templates/amo/site_nav.html:26
+#: src/olympia/browse/views.py:56 src/olympia/browse/views.py:66 src/olympia/browse/views.py:204 src/olympia/browse/views.py:249 src/olympia/search/forms.py:86
 msgid "Top Rated"
 msgstr "Najlepšie hodnotené"
 
@@ -2567,81 +1977,59 @@ msgid "Explore"
 msgstr "Pozrite si"
 
 # Plural in this context means many of the add-on type
-#: src/olympia/amo/templates/amo/site_nav.html:23
-#: src/olympia/browse/feeds.py:65 src/olympia/browse/feeds.py:78
-#: src/olympia/browse/feeds.py:92 src/olympia/browse/feeds.py:100
-#: src/olympia/browse/templates/browse/base_listing.html:7
-#: src/olympia/browse/templates/browse/creatured.html:10
-#: src/olympia/browse/templates/browse/impala/base_listing.html:37
+#: src/olympia/amo/templates/amo/site_nav.html:23 src/olympia/browse/feeds.py:65 src/olympia/browse/feeds.py:78 src/olympia/browse/feeds.py:92 src/olympia/browse/feeds.py:100
+#: src/olympia/browse/templates/browse/base_listing.html:7 src/olympia/browse/templates/browse/creatured.html:10 src/olympia/browse/templates/browse/impala/base_listing.html:37
 #: src/olympia/constants/base.py:173 src/olympia/templates/menu_links.html:8
 msgid "Extensions"
 msgstr "Rozšírenia"
 
-#: src/olympia/amo/templates/amo/site_nav.html:45
+#: src/olympia/amo/templates/amo/site_nav.html:44
 msgid "Want more customization? Try <b>Complete Themes</b>"
 msgstr "Chcete viac prispôsobenia? Skúste <b>plné témy vzhľadu</b>"
 
-#: src/olympia/amo/templates/amo/site_nav.html:56
-#: src/olympia/bandwagon/views.py:96
+#: src/olympia/amo/templates/amo/site_nav.html:54 src/olympia/bandwagon/views.py:96
 msgid "Most Followers"
 msgstr "Najviac odberateľov"
 
-#: src/olympia/amo/templates/amo/site_nav.html:68
-#: src/olympia/bandwagon/templates/bandwagon/impala/collection_sidebar.html:16
-#: src/olympia/bandwagon/templates/bandwagon/includes/collection_sidebar.html:18
+#: src/olympia/amo/templates/amo/site_nav.html:66 src/olympia/bandwagon/templates/bandwagon/impala/collection_sidebar.html:16 src/olympia/bandwagon/templates/bandwagon/includes/collection_sidebar.html:18
 msgid "Collections I've Made"
 msgstr "Kolekcie, ktoré som vytvoril"
 
-#: src/olympia/amo/templates/amo/site_nav.html:70
-#: src/olympia/bandwagon/templates/bandwagon/user_listing.html:4
-#: src/olympia/bandwagon/templates/bandwagon/impala/collection_sidebar.html:13
+#: src/olympia/amo/templates/amo/site_nav.html:68 src/olympia/bandwagon/templates/bandwagon/user_listing.html:4 src/olympia/bandwagon/templates/bandwagon/impala/collection_sidebar.html:13
 #: src/olympia/bandwagon/templates/bandwagon/includes/collection_sidebar.html:15
 msgid "Collections I'm Following"
 msgstr "Kolekcie, ktoré odberám"
 
-#: src/olympia/amo/templates/amo/site_nav.html:73
-#: src/olympia/bandwagon/templates/bandwagon/impala/collection_sidebar.html:18
-#: src/olympia/bandwagon/templates/bandwagon/includes/collection_sidebar.html:20
-#: src/olympia/users/models.py:512
+#: src/olympia/amo/templates/amo/site_nav.html:71 src/olympia/bandwagon/templates/bandwagon/impala/collection_sidebar.html:18 src/olympia/bandwagon/templates/bandwagon/includes/collection_sidebar.html:20
+#: src/olympia/users/models.py:521
 msgid "My Favorite Add-ons"
 msgstr "Moje obľúbené doplnky"
 
-#: src/olympia/amo/templates/amo/site_nav.html:78
+#: src/olympia/amo/templates/amo/site_nav.html:76
 msgid "More&hellip;"
 msgstr "Ďalšie&hellip;"
 
-#: src/olympia/amo/templates/amo/site_nav.html:82
+#: src/olympia/amo/templates/amo/site_nav.html:80
 msgid "Add-ons for Mobile"
 msgstr "Doplnky pre mobilný Firefox"
 
-#: src/olympia/amo/templates/amo/site_nav.html:86
-#: src/olympia/browse/feeds.py:207
-#: src/olympia/browse/templates/browse/search_tools.html:3
-#: src/olympia/constants/base.py:176 src/olympia/templates/menu_links.html:10
+#: src/olympia/amo/templates/amo/site_nav.html:84 src/olympia/browse/feeds.py:207 src/olympia/browse/templates/browse/search_tools.html:3 src/olympia/constants/base.py:176
+#: src/olympia/templates/menu_links.html:10
 msgid "Search Tools"
 msgstr "Vyhľadávacie nástroje"
 
 #. This is a page range (e.g., Page 1 of 50).
-#: src/olympia/amo/templates/amo/impala/paginator.html:5
-#: src/olympia/amo/templates/amo/mobile/impala_paginator.html:26
+#: src/olympia/amo/templates/amo/impala/paginator.html:5 src/olympia/amo/templates/amo/mobile/impala_paginator.html:26
 #, python-format
-msgid ""
-"Page <a href=\"%(current_pg_url)s\">%(current_pg)s</a> of <a "
-"href=\"%(last_pg_url)s\">%(last_pg)s</a>"
-msgstr ""
-"Stránka <a href=\"%(current_pg_url)s\">%(current_pg)s</a> z <a "
-"href=\"%(last_pg_url)s\">%(last_pg)s</a>"
+msgid "Page <a href=\"%(current_pg_url)s\">%(current_pg)s</a> of <a href=\"%(last_pg_url)s\">%(last_pg)s</a>"
+msgstr "Stránka <a href=\"%(current_pg_url)s\">%(current_pg)s</a> z <a href=\"%(last_pg_url)s\">%(last_pg)s</a>"
 
-#: src/olympia/amo/templates/amo/impala/paginator.html:16
-#: src/olympia/amo/templates/amo/mobile/impala_paginator.html:6
+#: src/olympia/amo/templates/amo/impala/paginator.html:16 src/olympia/amo/templates/amo/mobile/impala_paginator.html:6
 msgid "Jump to first page"
 msgstr "Prejsť na prvú stránku"
 
-#: src/olympia/amo/templates/amo/impala/paginator.html:22
-#: src/olympia/amo/templates/amo/mobile/impala_paginator.html:12
-#: src/olympia/discovery/templates/discovery/pane.html:44
-#: src/olympia/discovery/templates/discovery/addons/detail.html:38
-#: src/olympia/stats/templates/stats/stats.html:164
+#: src/olympia/amo/templates/amo/impala/paginator.html:22 src/olympia/amo/templates/amo/mobile/impala_paginator.html:12 src/olympia/discovery/templates/discovery/pane.html:44
+#: src/olympia/discovery/templates/discovery/addons/detail.html:38 src/olympia/stats/templates/stats/stats.html:166
 msgid "Previous"
 msgstr "Predchádzajúce"
 
@@ -2651,59 +2039,65 @@ msgstr "Skok na poslednú stranu"
 
 #. First and second arguments are the result range (e.g., 1-20);
 #. third argument is the number of total results (e.g., 1,000).
-#. third
+#. First and second arguments are the result range (e.g., 1-20);              third
 #. argument is the number of total results (e.g., 1,000).
-#: src/olympia/amo/templates/amo/impala/paginator.html:36
-#: src/olympia/amo/templates/amo/mobile/impala_paginator.html:38
+#: src/olympia/amo/templates/amo/impala/paginator.html:36 src/olympia/amo/templates/amo/mobile/impala_paginator.html:38
 #, python-format
 msgid "Showing <b>%(begin)s</b>&ndash;<b>%(end)s</b> of <b>%(count)s</b>"
-msgstr ""
-"Zobrazujú sa výsledky <b>%(begin)s</b>&ndash;<b>%(end)s</b> z celkového "
-"počtu <b>%(count)s</b>"
+msgstr "Zobrazujú sa výsledky <b>%(begin)s</b>&ndash;<b>%(end)s</b> z celkového počtu <b>%(count)s</b>"
 
 #: src/olympia/amo/templates/amo/mobile/paginator.html:10
 msgid "Page {n}"
 msgid_plural "Page {n}"
 msgstr[0] "Strana {n}"
 msgstr[1] "Strana {n}"
-msgstr[2] "Strana {n}"
 
-#: src/olympia/amo/templates/services/install.html:38
-#, python-format
-msgid ""
-"If you are not prompted to install %(addon_name)s in a moment, please <a "
-"href=\"%(addon_xpi)s\">click here</a>."
-msgstr ""
-"Ak sa o chvíľu neobjaví okno inštalácie doplnku %(addon_name)s, <a "
-"href=\"%(addon_xpi)s\">kliknite sem</a>."
-
-#: src/olympia/amo/tests/test_messages.py:57
-#: src/olympia/amo/tests/test_messages.py:58 src/olympia/reviews/forms.py:25
-#: src/olympia/reviews/forms.py:50
-#: src/olympia/reviews/templates/reviews/add.html:56
+#: src/olympia/amo/tests/test_messages.py:56 src/olympia/amo/tests/test_messages.py:57 src/olympia/reviews/forms.py:25 src/olympia/reviews/forms.py:50 src/olympia/reviews/templates/reviews/add.html:56
 #: src/olympia/reviews/templates/reviews/reply.html:30
 msgid "Title"
 msgstr "Nadpis"
 
-#: src/olympia/amo/tests/test_messages.py:57
-#: src/olympia/amo/tests/test_messages.py:58
+#: src/olympia/amo/tests/test_messages.py:56 src/olympia/amo/tests/test_messages.py:57
 msgid "Body"
 msgstr "Telo"
 
-#: src/olympia/amo/tests/test_messages.py:59
+#: src/olympia/amo/tests/test_messages.py:58
 msgid "Another Title"
 msgstr "Ďalší nadpis"
 
-#: src/olympia/amo/tests/test_messages.py:59
+#: src/olympia/amo/tests/test_messages.py:58
 msgid "Another Body"
 msgstr "Ďalšie telo"
 
-#: src/olympia/api/views.py:255
-msgid "Not implemented yet."
-msgstr "Zatiaľ nie je implementované."
+#: src/olympia/api/authentication.py:76
+msgid "Signature has expired."
+msgstr ""
 
-#: src/olympia/applications/views.py:39
-#: src/olympia/applications/templates/applications/appversions.html:3
+#: src/olympia/api/authentication.py:79
+msgid "Error decoding signature."
+msgstr ""
+
+#: src/olympia/api/authentication.py:82
+msgid "Invalid JWT Token."
+msgstr ""
+
+#: src/olympia/api/authentication.py:130
+msgid "Invalid Authorization header. No credentials provided."
+msgstr ""
+
+#: src/olympia/api/authentication.py:133
+msgid "Invalid Authorization header. Credentials string should not contain spaces."
+msgstr ""
+
+#: src/olympia/api/fields.py:29
+msgid "The field must have a length of at least {num} characters."
+msgstr ""
+
+#: src/olympia/api/fields.py:31
+msgid "The language code {lang_code} is invalid."
+msgstr ""
+
+#: src/olympia/applications/views.py:39 src/olympia/applications/templates/applications/appversions.html:3
 msgid "Application Versions"
 msgstr "Verzie aplikácie"
 
@@ -2716,19 +2110,15 @@ msgid "Valid Application Versions"
 msgstr "Platné verzie aplikácie"
 
 #: src/olympia/applications/templates/applications/appversions.html:12
-msgid ""
-"Add-ons submitted to Mozilla Add-ons must have a manifest file with at least"
-" one of the below applications supported. Only the versions listed below are"
-" allowed for these applications."
+msgid "Add-ons submitted to Mozilla Add-ons must have a manifest file with at least one of the below applications supported. Only the versions listed below are allowed for these applications."
 msgstr ""
 
-#: src/olympia/applications/templates/applications/appversions.html:25
+#: src/olympia/applications/templates/applications/appversions.html:25 src/olympia/editors/helpers.py:361
 msgid "GUID"
 msgstr "Identifikátor GUID"
 
 #. {0} is an add-on name.
-#: src/olympia/applications/templates/applications/appversions.html:26
-#: src/olympia/versions/templates/versions/version_list.html:23
+#: src/olympia/applications/templates/applications/appversions.html:26 src/olympia/versions/templates/versions/version_list.html:23
 msgid "Versions"
 msgstr "Verzie"
 
@@ -2738,14 +2128,8 @@ msgstr "http://developer.mozilla.org/en/docs/Install_Manifests"
 
 #: src/olympia/applications/templates/applications/appversions.html:31
 #, python-format
-msgid ""
-"If your supported application does not require a manifest file, you still "
-"must include one with the required properties as specified <a "
-"href=\"%(url)s\">here</a>."
-msgstr ""
-"Ak vaša podporovaná aplikácia nevyžaduje súbor manifest, aj tak musíte "
-"zahrnúť tento súbor a uviesť požadované informácie tak ako je popísané <a "
-"href=\"%(url)s\">tu</a>."
+msgid "If your supported application does not require a manifest file, you still must include one with the required properties as specified <a href=\"%(url)s\">here</a>."
+msgstr "Ak vaša podporovaná aplikácia nevyžaduje súbor manifest, aj tak musíte zahrnúť tento súbor a uviesť požadované informácie tak ako je popísané <a href=\"%(url)s\">tu</a>."
 
 #. L10n: {0} is 'Add-ons for <app>'.
 #: src/olympia/bandwagon/feeds.py:44
@@ -2753,12 +2137,9 @@ msgstr ""
 msgid "Collections :: %s"
 msgstr "Kolekcie :: %s"
 
-#: src/olympia/bandwagon/feeds.py:50
-#: src/olympia/bandwagon/templates/bandwagon/collection_detail.html:137
-msgid ""
-"Collections are groups of related add-ons that anyone can create and share."
-msgstr ""
-"Kolekcie sú skupiny podobných doplnkov vytvárané a zdieľané používateľmi."
+#: src/olympia/bandwagon/feeds.py:50 src/olympia/bandwagon/templates/bandwagon/collection_detail.html:137
+msgid "Collections are groups of related add-ons that anyone can create and share."
+msgstr "Kolekcie sú skupiny podobných doplnkov vytvárané a zdieľané používateľmi."
 
 #. L10n: {0} is a collection name, {1} is 'Add-ons for <app>'.
 #: src/olympia/bandwagon/feeds.py:70
@@ -2809,12 +2190,11 @@ msgstr "Odkazy nie sú povolené."
 msgid "This url is already in use by another collection"
 msgstr "Táto adresa URL je už používaná inou kolekciou."
 
-#: src/olympia/bandwagon/forms.py:197 src/olympia/devhub/views.py:1049
+#: src/olympia/bandwagon/forms.py:197 src/olympia/devhub/views.py:1050
 msgid "Icons must be either PNG or JPG."
 msgstr "Ikony musia byť vo formáte .png alebo .jpg."
 
-#: src/olympia/bandwagon/forms.py:202 src/olympia/devhub/views.py:1067
-#: src/olympia/users/forms.py:476
+#: src/olympia/bandwagon/forms.py:202 src/olympia/devhub/views.py:1068 src/olympia/users/forms.py:476
 #, python-format
 msgid "Please use images smaller than %dMB."
 msgstr "Použite obrázky menšie ako %dMB."
@@ -2835,8 +2215,7 @@ msgstr "Odstrániť môj hlas pre túto kolekciu"
 msgid "Log in to vote for this collection"
 msgstr "Na pridanie hlasu sa musíte prihlásiť"
 
-#: src/olympia/bandwagon/helpers.py:123
-#: src/olympia/bandwagon/templates/bandwagon/favorites_widget.html:2
+#: src/olympia/bandwagon/helpers.py:123 src/olympia/bandwagon/templates/bandwagon/favorites_widget.html:2
 msgid "Add to favorites"
 msgstr "Pridať medzi obľúbené"
 
@@ -2844,20 +2223,13 @@ msgstr "Pridať medzi obľúbené"
 msgid "Favorite"
 msgstr "Obľúbené"
 
-#: src/olympia/bandwagon/helpers.py:124
-#: src/olympia/bandwagon/templates/bandwagon/favorites_widget.html:2
+#: src/olympia/bandwagon/helpers.py:124 src/olympia/bandwagon/templates/bandwagon/favorites_widget.html:2
 msgid "Remove from favorites"
 msgstr "Odstrániť z obľúbených"
 
-#: src/olympia/bandwagon/views.py:98 src/olympia/bandwagon/views.py:191
-#: src/olympia/browse/views.py:58 src/olympia/browse/views.py:69
-#: src/olympia/browse/views.py:458 src/olympia/devhub/views.py:74
-#: src/olympia/devhub/views.py:82
-#: src/olympia/devhub/templates/devhub/addons/edit/basic.html:20
-#: src/olympia/editors/templates/editors/leaderboard.html:24
-#: src/olympia/editors/templates/editors/themes/queue_list.html:48
-#: src/olympia/search/forms.py:17 src/olympia/search/forms.py:89
-#: src/olympia/users/templates/users/vcard.html:5
+#: src/olympia/bandwagon/views.py:98 src/olympia/bandwagon/views.py:191 src/olympia/browse/views.py:58 src/olympia/browse/views.py:69 src/olympia/browse/views.py:425 src/olympia/devhub/views.py:73
+#: src/olympia/devhub/views.py:81 src/olympia/devhub/templates/devhub/addons/edit/basic.html:20 src/olympia/editors/templates/editors/leaderboard.html:24
+#: src/olympia/editors/templates/editors/themes/queue_list.html:48 src/olympia/search/forms.py:17 src/olympia/search/forms.py:89 src/olympia/users/templates/users/vcard.html:5
 msgid "Name"
 msgstr "Názov"
 
@@ -2865,8 +2237,7 @@ msgstr "Názov"
 msgid "Recently Popular"
 msgstr "Aktuálne populárne"
 
-#: src/olympia/bandwagon/views.py:189
-#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:18
+#: src/olympia/bandwagon/views.py:189 src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:16
 msgid "Added"
 msgstr "Pridané"
 
@@ -2880,10 +2251,8 @@ msgstr "Kolekcia bola vytvorená!"
 
 #: src/olympia/bandwagon/views.py:316
 #, python-format
-msgid ""
-"Your new collection is shown below. You can <ahref=\"%(url)s\">edit "
-"additional settings</a> if you'dlike."
-msgstr ""
+msgid "Your new collection is shown below. You can <a href=\"%(url)s\">edit additional settings</a> if you'd like."
+msgstr "Nová kolekcia je zobrazená nižšie. Ak chcete, môžete <a href=\"%(url)s\">zmeniť niektoré jej nastavenia</a>."
 
 #: src/olympia/bandwagon/views.py:322
 msgid "Collection updated!"
@@ -2892,38 +2261,26 @@ msgstr "Kolekcia bola aktualizovaná!"
 #: src/olympia/bandwagon/views.py:323
 #, python-format
 msgid "<a href=\"%(url)s\">View your collection</a> to see the changes."
-msgstr ""
-"Ak chcete vidieť zmeny, <a href=\"%(url)s\">zobrazte si svoju kolekciu</a>."
+msgstr "Ak chcete vidieť zmeny, <a href=\"%(url)s\">zobrazte si svoju kolekciu</a>."
 
 #: src/olympia/bandwagon/views.py:579
 msgid "Icon Deleted"
 msgstr "Ikona bola odstránená"
 
-#: src/olympia/bandwagon/templates/bandwagon/add.html:3
-#: src/olympia/bandwagon/templates/bandwagon/add.html:11
-#: src/olympia/bandwagon/templates/bandwagon/includes/collection_sidebar.html:26
+#: src/olympia/bandwagon/templates/bandwagon/add.html:3 src/olympia/bandwagon/templates/bandwagon/add.html:11 src/olympia/bandwagon/templates/bandwagon/includes/collection_sidebar.html:26
 msgid "Create a New Collection"
 msgstr "Vytvorenie novej kolekcie"
 
-#: src/olympia/bandwagon/templates/bandwagon/add.html:9
-#: src/olympia/devhub/templates/devhub/personas/submit.html:14
+#: src/olympia/bandwagon/templates/bandwagon/add.html:9 src/olympia/devhub/templates/devhub/personas/submit.html:14
 msgid "Create"
 msgstr "Vytvoriť"
 
-#: src/olympia/bandwagon/templates/bandwagon/add.html:24
-#: src/olympia/bandwagon/templates/bandwagon/ajax_new.html:28
+#: src/olympia/bandwagon/templates/bandwagon/add.html:24 src/olympia/bandwagon/templates/bandwagon/ajax_new.html:28
 #, python-format
-msgid ""
-"As noted in our <a href=\"%(legal)s\">Legal Notices</a>, individual "
-"collection arrangements are governed by the Creative Commons Attribution "
-"Share-Alike License"
-msgstr ""
-"Ako je uvedené v sekcii <a href=\"%(legal)s\">Právne informácie</a>, "
-"jednotlivé kolekcie sú vedené pod licenciou Creative Commons Attribution "
-"Share-Alike License"
+msgid "As noted in our <a href=\"%(legal)s\">Legal Notices</a>, individual collection arrangements are governed by the Creative Commons Attribution Share-Alike License"
+msgstr "Ako je uvedené v sekcii <a href=\"%(legal)s\">Právne informácie</a>, jednotlivé kolekcie sú vedené pod licenciou Creative Commons Attribution Share-Alike License"
 
-#: src/olympia/bandwagon/templates/bandwagon/add.html:33
-#: src/olympia/bandwagon/templates/bandwagon/ajax_new.html:38
+#: src/olympia/bandwagon/templates/bandwagon/add.html:33 src/olympia/bandwagon/templates/bandwagon/ajax_new.html:38
 msgid "Create Collection"
 msgstr "Vytvoriť kolekciu"
 
@@ -2939,8 +2296,7 @@ msgstr "Založiť novú kolekciu..."
 msgid "Start a New Collection"
 msgstr "Založenie novej kolekcie"
 
-#: src/olympia/bandwagon/templates/bandwagon/ajax_new.html:6
-#: src/olympia/bandwagon/templates/bandwagon/includes/addedit.html:7
+#: src/olympia/bandwagon/templates/bandwagon/ajax_new.html:6 src/olympia/bandwagon/templates/bandwagon/includes/addedit.html:7
 msgid "Name:"
 msgstr "Názov:"
 
@@ -2953,15 +2309,11 @@ msgstr "alebo <a id=\"collections-new-cancel\" href=\"#\">Zrušiť</a>"
 msgid "To rate collections, you must have an add-ons account."
 msgstr "Ak chcete hodnotiť kolekcie, musíte ma účet na AMO."
 
-#: src/olympia/bandwagon/templates/bandwagon/barometer.html:18
-#: src/olympia/templates/base.html:145
-#: src/olympia/templates/impala/base.html:198
+#: src/olympia/bandwagon/templates/bandwagon/barometer.html:18 src/olympia/templates/base.html:145 src/olympia/templates/impala/base.html:198
 msgid "Create an Add-ons Account"
 msgstr "Vytvorte si účet na AMO"
 
-#: src/olympia/bandwagon/templates/bandwagon/barometer.html:21
-#: src/olympia/templates/base.html:148
-#: src/olympia/templates/impala/base.html:201
+#: src/olympia/bandwagon/templates/bandwagon/barometer.html:21 src/olympia/templates/base.html:148 src/olympia/templates/impala/base.html:201
 #, python-format
 msgid "or <a href=\"%(login)s\">log in to your current account</a>"
 msgstr "alebo sa <a href=\"%(login)s\">prihláste k existujúcemu účtu</a>"
@@ -2974,14 +2326,12 @@ msgstr "{0} :: Kolekcie"
 msgid "private"
 msgstr "súkromná"
 
-#: src/olympia/bandwagon/templates/bandwagon/collection_detail.html:45
-#: src/olympia/bandwagon/templates/bandwagon/mobile/listing_items.html:9
+#: src/olympia/bandwagon/templates/bandwagon/collection_detail.html:45 src/olympia/bandwagon/templates/bandwagon/mobile/listing_items.html:9
 #, python-format
 msgid "<span>%(num)s</span> follower"
 msgid_plural "<span>%(num)s</span> followers"
 msgstr[0] "<span>%(num)s</span> odberateľ"
 msgstr[1] "<span>%(num)s</span> odberatelia"
-msgstr[2] "<span>%(num)s</span> odberateľov"
 
 #: src/olympia/bandwagon/templates/bandwagon/collection_detail.html:54
 msgid "About this Collection"
@@ -3011,8 +2361,7 @@ msgstr "Ďalšie možnosti:"
 msgid "Edit Collection"
 msgstr "Upraviť kolekciu"
 
-#: src/olympia/bandwagon/templates/bandwagon/collection_detail.html:88
-#: src/olympia/bandwagon/templates/bandwagon/includes/delete.html:3
+#: src/olympia/bandwagon/templates/bandwagon/collection_detail.html:88 src/olympia/bandwagon/templates/bandwagon/includes/delete.html:3
 msgid "Delete Collection"
 msgstr "Odstrániť kolekciu"
 
@@ -3022,7 +2371,6 @@ msgid "%(num)s Theme in this Collection"
 msgid_plural "%(num)s Themes in this Collection"
 msgstr[0] "%(num)s téma v tejto kolekcii"
 msgstr[1] "%(num)s témy v tejto kolekcii"
-msgstr[2] "%(num)s tém v tejto kolekcii"
 
 #: src/olympia/bandwagon/templates/bandwagon/collection_detail.html:111
 #, python-format
@@ -3030,14 +2378,9 @@ msgid "%(num)s Add-on in this Collection"
 msgid_plural "%(num)s Add-ons in this Collection"
 msgstr[0] "%(num)s doplnok v tejto kolekcii"
 msgstr[1] "%(num)s doplnky v tejto kolekcii"
-msgstr[2] "%(num)s doplnkov v tejto kolekcii"
 
-#: src/olympia/bandwagon/templates/bandwagon/collection_detail.html:125
-#: src/olympia/compat/templates/compat/index.html:25
-#: src/olympia/compat/templates/compat/reporter_detail.html:29
-#: src/olympia/files/templates/files/viewer.html:29
-#: src/olympia/templates/amo_footer.html:17
-#: src/olympia/templates/includes/lang_switcher.html:10
+#: src/olympia/bandwagon/templates/bandwagon/collection_detail.html:125 src/olympia/compat/templates/compat/reporter_detail.html:29 src/olympia/files/templates/files/viewer.html:29
+#: src/olympia/templates/amo_footer.html:17 src/olympia/templates/includes/lang_switcher.html:10
 msgid "Go"
 msgstr "Prejsť"
 
@@ -3063,27 +2406,19 @@ msgstr "Zobraziť všetky kolekcie tohto používateľa"
 
 #: src/olympia/bandwagon/templates/bandwagon/collection_detail.html:179
 msgid ""
-"Add-ons that you mark as favorites using the <b>Add to Favorites</b> feature"
-" appear below. This collection is currently <b>public</b>, which means "
-"everyone can see it. If you would like to hide it from public view, click "
-"the button below to make it private."
+"Add-ons that you mark as favorites using the <b>Add to Favorites</b> feature appear below. This collection is currently <b>public</b>, which means everyone can see it. If you would like to hide it "
+"from public view, click the button below to make it private."
 msgstr ""
-"Tu sa objavia doplnky, ktoré označíte ako obľúbené pomocou funkcie <b>Pridať"
-" medzi obľúbené</b>. Táto kolekcia je momentálne <b>verejná</b>, čo znamená,"
-" že ju môže vidieť ktokoľvek. Ak nechcete, aby bola verejne dostupná, "
-"kliknite na tlačidlo zobrazené nižšie."
+"Tu sa objavia doplnky, ktoré označíte ako obľúbené pomocou funkcie <b>Pridať medzi obľúbené</b>. Táto kolekcia je momentálne <b>verejná</b>, čo znamená, že ju môže vidieť ktokoľvek. Ak nechcete, "
+"aby bola verejne dostupná, kliknite na tlačidlo zobrazené nižšie."
 
 #: src/olympia/bandwagon/templates/bandwagon/collection_detail.html:186
 msgid ""
-"Add-ons that you mark as favorites using the <b>Add to Favorites</b> feature"
-" appear below. This collection is currently <b>private</b>, which means only"
-" you can see it. If you would like everyone to be able to see your "
-"favorites, click the button below to make it public."
+"Add-ons that you mark as favorites using the <b>Add to Favorites</b> feature appear below. This collection is currently <b>private</b>, which means only you can see it. If you would like everyone "
+"to be able to see your favorites, click the button below to make it public."
 msgstr ""
-"Tu sa objavia doplnky, ktoré označíte ako obľúbené pomocou funkcie <b>Pridať"
-" medzi obľúbené</b>. Táto kolekcia je momentálne <b>súkromná</b>, čo "
-"znamená, že ju môže vidieť iba vy. Ak chcete, aby ju videli všetci, kliknite"
-" na tlačidlo zobrazené nižšie."
+"Tu sa objavia doplnky, ktoré označíte ako obľúbené pomocou funkcie <b>Pridať medzi obľúbené</b>. Táto kolekcia je momentálne <b>súkromná</b>, čo znamená, že ju môže vidieť iba vy. Ak chcete, aby ju"
+" videli všetci, kliknite na tlačidlo zobrazené nižšie."
 
 #: src/olympia/bandwagon/templates/bandwagon/collection_detail.html:196
 msgid "My favorite add-ons"
@@ -3095,7 +2430,6 @@ msgid "<span>%(addons)s</span> add-on"
 msgid_plural "<span>%(addons)s</span> add-ons"
 msgstr[0] "<span>%(addons)s</span> doplnok"
 msgstr[1] "<span>%(addons)s</span> doplnky"
-msgstr[2] "<span>%(addons)s</span> doplnkov"
 
 #: src/olympia/bandwagon/templates/bandwagon/collection_grid.html:32
 #, python-format
@@ -3103,23 +2437,19 @@ msgid "<span>%(followers)s</span> follower"
 msgid_plural "<span>%(followers)s</span> followers"
 msgstr[0] "<span>%(followers)s</span> odberateľ"
 msgstr[1] "<span>%(followers)s</span> odberatelia"
-msgstr[2] "<span>%(followers)s</span> odberateľov"
 
-#. People "follow" collections to get notified of updates.
-#. Like
+#. People "follow" collections to get notified of updates.                    Like
 #. Twitter followers.
+#. People "follow" collections to get notified of updates.
 #. Like Twitter followers.
-#: src/olympia/bandwagon/templates/bandwagon/collection_listing_items.html:10
-#: src/olympia/bandwagon/templates/bandwagon/impala/collection_listing_items.html:18
+#: src/olympia/bandwagon/templates/bandwagon/collection_listing_items.html:10 src/olympia/bandwagon/templates/bandwagon/impala/collection_listing_items.html:18
 #, python-format
 msgid "%(num)s weekly follower"
 msgid_plural "%(num)s weekly followers"
 msgstr[0] "%(num)s týždenný odberateľ"
 msgstr[1] "%(num)s týždenní odberatelia"
-msgstr[2] "%(num)s týždenných odberateľov"
 
-#. People "follow" collections to get notified of updates.
-#. Like
+#. People "follow" collections to get notified of updates.                    Like
 #. Twitter followers.
 #: src/olympia/bandwagon/templates/bandwagon/collection_listing_items.html:18
 #, python-format
@@ -3127,35 +2457,29 @@ msgid "%(num)s monthly follower"
 msgid_plural "%(num)s monthly followers"
 msgstr[0] "%(num)s mesačný odberateľ"
 msgstr[1] "%(num)s mesační odberatelia"
-msgstr[2] "%(num)s mesačných odberateľov"
 
-#. People "follow" collections to get notified of updates.
-#. Like
+#. People "follow" collections to get notified of updates.                    Like
 #. Twitter followers.
+#. People "follow" collections to get notified of updates.
 #. Like Twitter followers.
-#: src/olympia/bandwagon/templates/bandwagon/collection_listing_items.html:26
-#: src/olympia/bandwagon/templates/bandwagon/impala/collection_listing_items.html:26
+#: src/olympia/bandwagon/templates/bandwagon/collection_listing_items.html:26 src/olympia/bandwagon/templates/bandwagon/impala/collection_listing_items.html:26
 #, python-format
 msgid "%(num)s follower"
 msgid_plural "%(num)s followers"
 msgstr[0] "%(num)s odberateľ"
 msgstr[1] "%(num)s odberatelia"
-msgstr[2] "%(num)s odberateľov"
 
-#: src/olympia/bandwagon/templates/bandwagon/collection_listing_items.html:56
-#: src/olympia/bandwagon/templates/bandwagon/impala/collection_listing_items.html:9
+#: src/olympia/bandwagon/templates/bandwagon/collection_listing_items.html:56 src/olympia/bandwagon/templates/bandwagon/impala/collection_listing_items.html:9
 #: src/olympia/devhub/templates/devhub/personas/edit.html:27
 msgid "by {0}"
 msgstr "autor {0}"
 
-#: src/olympia/bandwagon/templates/bandwagon/collection_widgets.html:5
-#: src/olympia/bandwagon/templates/bandwagon/collection_widgets.html:7
+#: src/olympia/bandwagon/templates/bandwagon/collection_widgets.html:5 src/olympia/bandwagon/templates/bandwagon/collection_widgets.html:7
 #: src/olympia/bandwagon/templates/bandwagon/impala/collection_listing_items.html:53
 msgid "Stop Following"
 msgstr "Už nesledovať"
 
-#: src/olympia/bandwagon/templates/bandwagon/collection_widgets.html:6
-#: src/olympia/bandwagon/templates/bandwagon/collection_widgets.html:7
+#: src/olympia/bandwagon/templates/bandwagon/collection_widgets.html:6 src/olympia/bandwagon/templates/bandwagon/collection_widgets.html:7
 #: src/olympia/bandwagon/templates/bandwagon/impala/collection_listing_items.html:53
 msgid "Follow this Collection"
 msgstr "Sledovať túto kolekciu"
@@ -3165,16 +2489,12 @@ msgid "Edit this Collection"
 msgstr "Upraviť túto kolekciu"
 
 #. %s is the name of the collection.
-#: src/olympia/bandwagon/templates/bandwagon/delete.html:4
-#: src/olympia/bandwagon/templates/bandwagon/delete.html:15
+#: src/olympia/bandwagon/templates/bandwagon/delete.html:4 src/olympia/bandwagon/templates/bandwagon/delete.html:15
 msgid "Delete {0}"
 msgstr "Odstrániť {0}"
 
-#: src/olympia/bandwagon/templates/bandwagon/delete.html:13
-#: src/olympia/devhub/templates/devhub/addons/listing/item_actions.html:14
-#: src/olympia/devhub/templates/devhub/addons/listing/item_actions_theme.html:28
-#: src/olympia/devhub/templates/devhub/versions/list.html:131
-#: src/olympia/devhub/templates/devhub/versions/list.html:149
+#: src/olympia/bandwagon/templates/bandwagon/delete.html:13 src/olympia/devhub/templates/devhub/addons/listing/item_actions.html:14
+#: src/olympia/devhub/templates/devhub/addons/listing/item_actions_theme.html:28 src/olympia/devhub/templates/devhub/versions/list.html:131 src/olympia/devhub/templates/devhub/versions/list.html:149
 #: src/olympia/devhub/templates/devhub/versions/list.html:166
 msgid "Delete"
 msgstr "Odstrániť"
@@ -3183,35 +2503,24 @@ msgstr "Odstrániť"
 msgid "Are you sure?"
 msgstr "Ste si istý?"
 
-#: src/olympia/bandwagon/templates/bandwagon/delete.html:21
-#: src/olympia/devhub/templates/devhub/personas/edit.html:131
-#: src/olympia/devhub/templates/devhub/personas/edit.html:152
-#: src/olympia/devhub/templates/devhub/personas/edit.html:173
-#: src/olympia/devhub/templates/devhub/personas/submit.html:77
-#: src/olympia/devhub/templates/devhub/personas/submit.html:98
+#: src/olympia/bandwagon/templates/bandwagon/delete.html:21 src/olympia/devhub/templates/devhub/personas/edit.html:131 src/olympia/devhub/templates/devhub/personas/edit.html:152
+#: src/olympia/devhub/templates/devhub/personas/edit.html:173 src/olympia/devhub/templates/devhub/personas/submit.html:77 src/olympia/devhub/templates/devhub/personas/submit.html:98
 #: src/olympia/devhub/templates/devhub/personas/submit.html:119
 msgid "Yes"
 msgstr "Áno"
 
-#: src/olympia/bandwagon/templates/bandwagon/delete.html:22
-#: src/olympia/devhub/templates/devhub/personas/edit.html:140
-#: src/olympia/devhub/templates/devhub/personas/edit.html:161
-#: src/olympia/devhub/templates/devhub/personas/edit.html:191
-#: src/olympia/devhub/templates/devhub/personas/submit.html:86
-#: src/olympia/devhub/templates/devhub/personas/submit.html:107
+#: src/olympia/bandwagon/templates/bandwagon/delete.html:22 src/olympia/devhub/templates/devhub/personas/edit.html:140 src/olympia/devhub/templates/devhub/personas/edit.html:161
+#: src/olympia/devhub/templates/devhub/personas/edit.html:191 src/olympia/devhub/templates/devhub/personas/submit.html:86 src/olympia/devhub/templates/devhub/personas/submit.html:107
 #: src/olympia/devhub/templates/devhub/personas/submit.html:137
 msgid "No"
 msgstr "Nie"
 
 #. {0} is the name of the collection.
-#: src/olympia/bandwagon/templates/bandwagon/edit.html:5
-#: src/olympia/bandwagon/templates/bandwagon/edit.html:21
+#: src/olympia/bandwagon/templates/bandwagon/edit.html:5 src/olympia/bandwagon/templates/bandwagon/edit.html:21
 msgid "Edit {0}"
 msgstr "Upraviť {0}"
 
-#: src/olympia/bandwagon/templates/bandwagon/edit.html:29
-#: src/olympia/devhub/templates/devhub/addons/edit/details.html:20
-#: src/olympia/editors/templates/editors/themes/themes.html:62
+#: src/olympia/bandwagon/templates/bandwagon/edit.html:29 src/olympia/devhub/templates/devhub/addons/edit/details.html:20 src/olympia/editors/templates/editors/themes/themes.html:62
 msgid "Description"
 msgstr "Popis"
 
@@ -3219,32 +2528,18 @@ msgstr "Popis"
 msgid "Contributors & More"
 msgstr "Prispievatelia a iné"
 
-#: src/olympia/bandwagon/templates/bandwagon/edit.html:54
-#: src/olympia/bandwagon/templates/bandwagon/edit.html:67
-#: src/olympia/bandwagon/templates/bandwagon/edit.html:82
-#: src/olympia/devhub/templates/devhub/addons/ajax_compat_update.html:35
-#: src/olympia/devhub/templates/devhub/addons/owner.html:59
-#: src/olympia/devhub/templates/devhub/addons/profile.html:42
-#: src/olympia/devhub/templates/devhub/addons/edit/admin.html:101
-#: src/olympia/devhub/templates/devhub/addons/edit/basic.html:152
-#: src/olympia/devhub/templates/devhub/addons/edit/details.html:85
-#: src/olympia/devhub/templates/devhub/addons/edit/support.html:67
-#: src/olympia/devhub/templates/devhub/addons/edit/technical.html:166
-#: src/olympia/devhub/templates/devhub/addons/forms_shared/media.html:149
-#: src/olympia/devhub/templates/devhub/payments/voluntary.html:64
-#: src/olympia/devhub/templates/devhub/personas/edit.html:35
-#: src/olympia/devhub/templates/devhub/personas/edit.html:304
-#: src/olympia/devhub/templates/devhub/versions/edit.html:139
-#: src/olympia/translations/templates/translations/trans-menu.html:48
+#: src/olympia/bandwagon/templates/bandwagon/edit.html:54 src/olympia/bandwagon/templates/bandwagon/edit.html:67 src/olympia/bandwagon/templates/bandwagon/edit.html:82
+#: src/olympia/devhub/templates/devhub/addons/ajax_compat_update.html:35 src/olympia/devhub/templates/devhub/addons/owner.html:59 src/olympia/devhub/templates/devhub/addons/profile.html:42
+#: src/olympia/devhub/templates/devhub/addons/edit/admin.html:101 src/olympia/devhub/templates/devhub/addons/edit/basic.html:152 src/olympia/devhub/templates/devhub/addons/edit/details.html:85
+#: src/olympia/devhub/templates/devhub/addons/edit/support.html:67 src/olympia/devhub/templates/devhub/addons/edit/technical.html:166
+#: src/olympia/devhub/templates/devhub/addons/forms_shared/media.html:149 src/olympia/devhub/templates/devhub/payments/voluntary.html:64 src/olympia/devhub/templates/devhub/personas/edit.html:35
+#: src/olympia/devhub/templates/devhub/personas/edit.html:304 src/olympia/devhub/templates/devhub/versions/edit.html:139 src/olympia/translations/templates/translations/trans-menu.html:48
 msgid "Save Changes"
 msgstr "Uložiť zmeny"
 
 # <option> text in a <select> for Author role in an add-on.
-#: src/olympia/bandwagon/templates/bandwagon/edit_contributors.html:9
-#: src/olympia/bandwagon/templates/bandwagon/edit_contributors.html:12
-#: src/olympia/bandwagon/templates/bandwagon/edit_contributors.html:17
-#: src/olympia/bandwagon/templates/bandwagon/edit_contributors.html:58
-#: src/olympia/constants/base.py:134
+#: src/olympia/bandwagon/templates/bandwagon/edit_contributors.html:9 src/olympia/bandwagon/templates/bandwagon/edit_contributors.html:12
+#: src/olympia/bandwagon/templates/bandwagon/edit_contributors.html:17 src/olympia/bandwagon/templates/bandwagon/edit_contributors.html:58 src/olympia/constants/base.py:134
 msgid "Owner"
 msgstr "Vlastník"
 
@@ -3256,10 +2551,8 @@ msgstr "Nastaviť ako vlastníka"
 msgid "Remove this user as a contributor"
 msgstr "Odstrániť tohto používateľa ako prispievateľa"
 
-#: src/olympia/bandwagon/templates/bandwagon/edit_contributors.html:18
-#: src/olympia/bandwagon/templates/bandwagon/edit_contributors.html:43
-#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:20
-#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:48
+#: src/olympia/bandwagon/templates/bandwagon/edit_contributors.html:18 src/olympia/bandwagon/templates/bandwagon/edit_contributors.html:43
+#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:18 src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:46
 #: src/olympia/devhub/templates/devhub/addons/ajax_compat_update.html:19
 msgid "Remove"
 msgstr "Odstrániť"
@@ -3270,23 +2563,17 @@ msgstr "Prispievatelia kolekcie"
 
 #: src/olympia/bandwagon/templates/bandwagon/edit_contributors.html:26
 msgid ""
-"You can add multiple contributors to this collection. A contributor can add "
-"and remove add-ons from this collection, but cannot change its name or "
-"description. To add a contributor, enter their email in the box below. "
-"Contributors must have a Mozilla Add-ons account."
+"You can add multiple contributors to this collection. A contributor can add and remove add-ons from this collection, but cannot change its name or description. To add a contributor, enter their "
+"email in the box below. Contributors must have a Mozilla Add-ons account."
 msgstr ""
-"K tejto kolekcii môžete pridať viacerých prispievateľov. Prispievateľ môžete"
-" pridávať alebo odstraňovať doplnky z tejto kolekcie, ale nemôže meniť jej "
-"názov alebo popis. Ak chcete pridať prispievateľa, zadajte jeho e-mailovú "
-"adresu. Prispievatelia musia mať účet Mozilla Add-ons."
+"K tejto kolekcii môžete pridať viacerých prispievateľov. Prispievateľ môžete pridávať alebo odstraňovať doplnky z tejto kolekcie, ale nemôže meniť jej názov alebo popis. Ak chcete pridať "
+"prispievateľa, zadajte jeho e-mailovú adresu. Prispievatelia musia mať účet Mozilla Add-ons."
 
 #: src/olympia/bandwagon/templates/bandwagon/edit_contributors.html:40
 msgid "User"
 msgstr "Používateľ"
 
-#: src/olympia/bandwagon/templates/bandwagon/edit_contributors.html:41
-#: src/olympia/devhub/templates/devhub/addons/edit/support.html:20
-#: src/olympia/users/templates/users/delete.html:49
+#: src/olympia/bandwagon/templates/bandwagon/edit_contributors.html:41 src/olympia/devhub/templates/devhub/addons/edit/support.html:20 src/olympia/users/templates/users/delete.html:49
 msgid "Email"
 msgstr "E-mailová adresa"
 
@@ -3312,27 +2599,14 @@ msgid "Admin Settings"
 msgstr "Nastavenia administrátora"
 
 #: src/olympia/bandwagon/templates/bandwagon/edit_contributors.html:76
-msgid ""
-"<b>Warning:</b> By changing the owner of this collection, you will no longer"
-" be able to edit it. You will only be able to add and remove add-ons from "
-"it."
-msgstr ""
-"<b>Upozornenie:</b> po zmene vlastníka tejto kolekcie ju už nebudete môcť "
-"upravovať. Budete môcť len pridávať alebo odstraňovať jej doplnky."
+msgid "<b>Warning:</b> By changing the owner of this collection, you will no longer be able to edit it. You will only be able to add and remove add-ons from it."
+msgstr "<b>Upozornenie:</b> po zmene vlastníka tejto kolekcie ju už nebudete môcť upravovať. Budete môcť len pridávať alebo odstraňovať jej doplnky."
 
-#: src/olympia/bandwagon/templates/bandwagon/edit_contributors.html:83
-#: src/olympia/devhub/templates/devhub/addons/forms_shared/media.html:157
-#: src/olympia/devhub/templates/devhub/addons/submit/describe.html:69
-#: src/olympia/devhub/templates/devhub/addons/submit/license.html:60
-#: src/olympia/devhub/templates/devhub/addons/submit/upload.html:78
-#: src/olympia/devhub/templates/devhub/payments/tier.html:17
-#: src/olympia/editors/templates/editors/themes/themes.html:111
-#: src/olympia/editors/templates/editors/themes/themes.html:128
-#: src/olympia/editors/templates/editors/themes/themes.html:134
-#: src/olympia/editors/templates/editors/themes/themes.html:141
-#: src/olympia/users/templates/users/fxa_migration_prompt_content.html:10
-#: src/olympia/users/templates/users/login_form.html:42
-#: src/olympia/users/templates/users/mobile/login.html:57
+#: src/olympia/bandwagon/templates/bandwagon/edit_contributors.html:83 src/olympia/devhub/templates/devhub/addons/forms_shared/media.html:157
+#: src/olympia/devhub/templates/devhub/addons/submit/describe.html:69 src/olympia/devhub/templates/devhub/addons/submit/license.html:60 src/olympia/devhub/templates/devhub/addons/submit/upload.html:70
+#: src/olympia/devhub/templates/devhub/payments/tier.html:17 src/olympia/editors/templates/editors/themes/themes.html:111 src/olympia/editors/templates/editors/themes/themes.html:128
+#: src/olympia/editors/templates/editors/themes/themes.html:134 src/olympia/editors/templates/editors/themes/themes.html:141 src/olympia/users/templates/users/fxa_migration_prompt_content.html:10
+#: src/olympia/users/templates/users/login_form.html:42 src/olympia/users/templates/users/mobile/login.html:57
 msgid "Continue"
 msgstr "Pokračovať"
 
@@ -3371,18 +2645,10 @@ msgstr "Aktuálne populárne kolekcie"
 
 #: src/olympia/bandwagon/templates/bandwagon/impala/collection_listing.html:28
 #, python-format
-msgid ""
-"Collections are groups of related add-ons that anyone can create and share. "
-"Explore collections created by other users or <a href=\"%(url)s\">create "
-"your own</a>."
-msgstr ""
-"Kolekcie sú skupiny podobných doplnkov, ktoré môže vytvárať a zdieľať "
-"ktokoľvek. Pozrite si kolekcie od iných používateľov, alebo si <a "
-"href=\"%(url)s\">vytvorte vlastnú</a>."
+msgid "Collections are groups of related add-ons that anyone can create and share. Explore collections created by other users or <a href=\"%(url)s\">create your own</a>."
+msgstr "Kolekcie sú skupiny podobných doplnkov, ktoré môže vytvárať a zdieľať ktokoľvek. Pozrite si kolekcie od iných používateľov, alebo si <a href=\"%(url)s\">vytvorte vlastnú</a>."
 
-#: src/olympia/bandwagon/templates/bandwagon/impala/collection_listing.html:37
-#: src/olympia/browse/templates/browse/extensions.html:13
-#: src/olympia/browse/templates/browse/themes.html:14
+#: src/olympia/bandwagon/templates/bandwagon/impala/collection_listing.html:37 src/olympia/browse/templates/browse/extensions.html:13 src/olympia/browse/templates/browse/themes.html:14
 msgid "Subscribe"
 msgstr "Odoberať"
 
@@ -3390,20 +2656,14 @@ msgstr "Odoberať"
 msgid "Following"
 msgstr "Odberateľ"
 
-#: src/olympia/bandwagon/templates/bandwagon/impala/collection_sidebar.html:22
-#: src/olympia/bandwagon/templates/bandwagon/impala/collection_sidebar.html:28
+#: src/olympia/bandwagon/templates/bandwagon/impala/collection_sidebar.html:22 src/olympia/bandwagon/templates/bandwagon/impala/collection_sidebar.html:28
 #: src/olympia/bandwagon/templates/bandwagon/includes/collection_sidebar.html:32
 msgid "Create a Collection"
 msgstr "Vytvoriť kolekciu"
 
-#: src/olympia/bandwagon/templates/bandwagon/impala/collection_sidebar.html:23
-#: src/olympia/bandwagon/templates/bandwagon/includes/collection_sidebar.html:27
-msgid ""
-"Collections make it easy to keep track of favorite add-ons and share your "
-"perfectly customized browser with others."
-msgstr ""
-"Pomocou kolekcií môžete jednoducho sledovať obľúbené doplnky a zdieľať svoj "
-"perfektne upravený prehliadač s ostatnými."
+#: src/olympia/bandwagon/templates/bandwagon/impala/collection_sidebar.html:23 src/olympia/bandwagon/templates/bandwagon/includes/collection_sidebar.html:27
+msgid "Collections make it easy to keep track of favorite add-ons and share your perfectly customized browser with others."
+msgstr "Pomocou kolekcií môžete jednoducho sledovať obľúbené doplnky a zdieľať svoj perfektne upravený prehliadač s ostatnými."
 
 #: src/olympia/bandwagon/templates/bandwagon/includes/addedit.html:42
 msgid "Collection Icon"
@@ -3415,8 +2675,7 @@ msgstr "Vynulovať"
 
 #: src/olympia/bandwagon/templates/bandwagon/includes/addedit.html:53
 msgid "PNG and JPG supported. Image will be resized to 32x32."
-msgstr ""
-"Podporované formáty: PNG a JPG. Obrázok bude upravený na veľkosť 32x32."
+msgstr "Podporované formáty: PNG a JPG. Obrázok bude upravený na veľkosť 32x32."
 
 #: src/olympia/bandwagon/templates/bandwagon/includes/addedit_errors.html:3
 msgid "There are errors in this form. Please correct them below."
@@ -3427,40 +2686,31 @@ msgid "Add-ons in Your Collection"
 msgstr "Doplnky vo vašej kolekcii"
 
 #: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:4
-msgid ""
-"To include an add-on in this collection, enter its name in the box below and"
-" hit enter. You can also use the <strong>Add to Collection</strong> links "
-"throughout the site to include add-ons later."
+msgid "To include an add-on in this collection, enter its name in the box below and hit enter."
 msgstr ""
-"Ak chcete zahrnúť doplnok do tejto kolekcie, zadajte jeho názov do poľa "
-"uvedeného nižšie a stlačte enter. Na pridanie doplnku môžete použiť aj "
-"odkazy <strong>Pridať do kolekcie</strong> rozmiestnené na rôznych "
-"podstránkach tohto webu."
 
-#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:17
-#: src/olympia/constants/base.py:400
-#: src/olympia/devhub/templates/devhub/addons/activity.html:62
+#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:15 src/olympia/constants/base.py:400 src/olympia/devhub/templates/devhub/addons/activity.html:62
+#: src/olympia/editors/helpers.py:273 src/olympia/editors/helpers.py:360
 msgid "Add-on"
 msgstr "Doplnok"
 
-#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:26
+#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:24
 msgid "Enter the name of the add-on to include"
 msgstr "Zadajte názov doplnku, ktorý chcete pridať"
 
-#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:28
+#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:26
 msgid "Add to Collection"
 msgstr "Pridať do kolekcie"
 
-#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:45
-#: src/olympia/editors/helpers.py:936 src/olympia/editors/helpers.py:956
+#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:43 src/olympia/editors/helpers.py:1016 src/olympia/editors/helpers.py:1036
 msgid "Pending"
 msgstr "Čakajúci"
 
-#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:47
+#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:45
 msgid "Add a comment"
 msgstr "Pridať komentár"
 
-#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:48
+#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:46
 msgid "Remove this add-on from the collection"
 msgstr "Odstrániť tento doplnok z kolekcie"
 
@@ -3472,14 +2722,11 @@ msgstr "KOLEKCIE"
 msgid "Groups of related add-ons that anyone can create."
 msgstr "Skupiny príbuzných doplnkov, ktoré môže vytvárať ktokoľvek."
 
-#: src/olympia/blocklist/templates/blocklist/blocked_detail.html:3
-#: src/olympia/blocklist/templates/blocklist/blocked_list.html:3
-#: src/olympia/blocklist/templates/blocklist/blocked_list.html:10
+#: src/olympia/blocklist/templates/blocklist/blocked_detail.html:3 src/olympia/blocklist/templates/blocklist/blocked_list.html:3 src/olympia/blocklist/templates/blocklist/blocked_list.html:10
 msgid "Blocked Add-ons"
 msgstr "Blokované doplnky"
 
-#: src/olympia/blocklist/templates/blocklist/blocked_detail.html:8
-#: src/olympia/blocklist/templates/blocklist/blocked_list.html:6
+#: src/olympia/blocklist/templates/blocklist/blocked_detail.html:8 src/olympia/blocklist/templates/blocklist/blocked_list.html:6
 msgid "Blocklist"
 msgstr "Zoznam blokovaných"
 
@@ -3501,43 +2748,26 @@ msgid "What does this mean?"
 msgstr "Čo toto znamená?"
 
 #: src/olympia/blocklist/templates/blocklist/blocked_detail.html:22
-msgid ""
-"Users are strongly encouraged to disable the problematic add-on or plugin, "
-"but may choose to continue using it if they accept the risks described."
-msgstr ""
-"Používateľom odporúčame problematický doplnok či zásuvný modul zakázať. Ak "
-"beriete na vedomie popísané riziká, môžete takýto doplnok aj naďalej "
-"používať."
+msgid "Users are strongly encouraged to disable the problematic add-on or plugin, but may choose to continue using it if they accept the risks described."
+msgstr "Používateľom odporúčame problematický doplnok či zásuvný modul zakázať. Ak beriete na vedomie popísané riziká, môžete takýto doplnok aj naďalej používať."
 
 #: src/olympia/blocklist/templates/blocklist/blocked_detail.html:27
-msgid ""
-"The problematic add-on or plugin will be automatically disabled and no "
-"longer usable."
-msgstr ""
-"Problematický doplnok alebo zásuvný modul bude automaticky zakázaný a nebude"
-" už dostupný."
+msgid "The problematic add-on or plugin will be automatically disabled and no longer usable."
+msgstr "Problematický doplnok alebo zásuvný modul bude automaticky zakázaný a nebude už dostupný."
 
 #: src/olympia/blocklist/templates/blocklist/blocked_detail.html:33
 #, python-format
 msgid ""
-"When Mozilla becomes aware of add-ons, plugins, or other third-party "
-"software that seriously compromises %(app)s security, stability, or "
-"performance and meets <a href=\"%(criteria)s\">certain criteria</a>, the "
-"software may be blocked from general use. For more information, please read "
-"<a href=\"%(support)s\">this support article</a>."
+"When Mozilla becomes aware of add-ons, plugins, or other third-party software that seriously compromises %(app)s security, stability, or performance and meets <a href=\"%(criteria)s\">certain "
+"criteria</a>, the software may be blocked from general use. For more information, please read <a href=\"%(support)s\">this support article</a>."
 msgstr ""
-"Ak Mozilla zistí, že doplnok, zásuvný modul či softvér tretej strany "
-"spôsobuje vážne problémy v otázkach bezpečnosti, stability a výkonu "
-"aplikácie %(app)s a zároveň spĺňa <a href=\"%(criteria)s\">dané "
-"kritériá</a>, môže byť takýto softvér zablokovaný. Ďalšie informácie nájdete"
-" v <a href=\"%(support)s\">tomto článku podpory</a>."
+"Ak Mozilla zistí, že doplnok, zásuvný modul či softvér tretej strany spôsobuje vážne problémy v otázkach bezpečnosti, stability a výkonu aplikácie %(app)s a zároveň spĺňa <a "
+"href=\"%(criteria)s\">dané kritériá</a>, môže byť takýto softvér zablokovaný. Ďalšie informácie nájdete v <a href=\"%(support)s\">tomto článku podpory</a>."
 
 #: src/olympia/blocklist/templates/blocklist/blocked_detail.html:44
 #, python-format
 msgid "Blocked on %(date)s. <a href=\"%(link)s\">View block request</a>."
-msgstr ""
-"Zablokované dňa %(date)s. <a href=\"%(link)s\">Zobraziť požiadavku na "
-"zablokovanie</a>."
+msgstr "Zablokované dňa %(date)s. <a href=\"%(link)s\">Zobraziť požiadavku na zablokovanie</a>."
 
 #: src/olympia/blocklist/templates/blocklist/blocked_detail.html:48
 #, python-format
@@ -3545,13 +2775,8 @@ msgid "Blocked on %(date)s."
 msgstr "Zablokované dňa %(date)s."
 
 #: src/olympia/blocklist/templates/blocklist/blocked_list.html:11
-msgid ""
-"The following software is known to cause serious security, stability, or "
-"performance issues with {app}."
-msgstr ""
-"V prípade nasledujúceho softvéru je známe, že v kombinácii s aplikáciou "
-"{app} má vážny bezpečnostný problém, problém so stabilitou či problémy s "
-"výkonom."
+msgid "The following software is known to cause serious security, stability, or performance issues with {app}."
+msgstr "V prípade nasledujúceho softvéru je známe, že v kombinácii s aplikáciou {app} má vážny bezpečnostný problém, problém so stabilitou či problémy s výkonom."
 
 #. L10n: %s is a category name.
 #: src/olympia/browse/feeds.py:76 src/olympia/browse/feeds.py:98
@@ -3573,10 +2798,8 @@ msgstr "Odporúčané doplnky :: %s"
 #. L10n: %s is an app name.
 #: src/olympia/browse/feeds.py:138
 #, python-format
-msgid ""
-"Here's a few of our favorite add-ons to help you get started customizing %s."
-msgstr ""
-"Tu je niekoľko obľúbených doplnkov, pomocou ktorých si môžete upraviť %s."
+msgid "Here's a few of our favorite add-ons to help you get started customizing %s."
+msgstr "Tu je niekoľko obľúbených doplnkov, pomocou ktorých si môžete upraviť %s."
 
 #. L10n: %s is a category name.
 #: src/olympia/browse/feeds.py:157
@@ -3592,43 +2815,28 @@ msgstr "Vyhľadávacie nástroje alebo rozšírenia vzťahujúce k vyhľadávani
 msgid "Search tools"
 msgstr "Vyhľadávacie nástroje"
 
-#: src/olympia/browse/views.py:55 src/olympia/browse/views.py:65
-#: src/olympia/search/forms.py:85
+#: src/olympia/browse/views.py:55 src/olympia/browse/views.py:65 src/olympia/search/forms.py:85
 msgid "Most Users"
 msgstr "Najviac používateľov"
 
-#: src/olympia/browse/views.py:61 src/olympia/browse/views.py:72
-#: src/olympia/browse/views.py:279
-#: src/olympia/browse/templates/browse/personas/mobile/category_landing.html:63
-#: src/olympia/discovery/templates/discovery/pane.html:67
-#: src/olympia/search/forms.py:92
+#: src/olympia/browse/views.py:61 src/olympia/browse/views.py:72 src/olympia/browse/views.py:246 src/olympia/browse/templates/browse/personas/mobile/category_landing.html:63
+#: src/olympia/discovery/templates/discovery/pane.html:67 src/olympia/search/forms.py:92
 msgid "Up & Coming"
 msgstr "Zaujímavé"
 
-#: src/olympia/browse/views.py:460 src/olympia/devhub/views.py:76
-#: src/olympia/devhub/views.py:83
-#: src/olympia/discovery/templates/discovery/addons/detail.html:66
+#: src/olympia/browse/views.py:427 src/olympia/devhub/views.py:75 src/olympia/devhub/views.py:82 src/olympia/discovery/templates/discovery/addons/detail.html:66
 msgid "Created"
 msgstr "Vytvorené"
 
 #. {0} is the category name. Ex: Sports
-#: src/olympia/browse/templates/browse/creatured.html:5
-#: src/olympia/browse/templates/browse/creatured.html:13
+#: src/olympia/browse/templates/browse/creatured.html:5 src/olympia/browse/templates/browse/creatured.html:13
 msgid "{0}: Featured Add-ons"
 msgstr "{0}: odporúčané doplnky"
 
-#: src/olympia/browse/templates/browse/creatured.html:12
-#: src/olympia/browse/templates/browse/featured.html:4
-#: src/olympia/browse/templates/browse/featured.html:12
-#: src/olympia/browse/templates/browse/featured.html:13
-#: src/olympia/devhub/templates/devhub/docs/policies-recommended.html:3
-#: src/olympia/devhub/templates/devhub/docs/policies-recommended.html:7
-#: src/olympia/devhub/templates/devhub/docs/policies-recommended.html:9
-#: src/olympia/devhub/templates/devhub/docs/policies.html:21
-#: src/olympia/devhub/templates/devhub/docs/policies.html:90
-#: src/olympia/discovery/modules.py:341
-#: src/olympia/discovery/templates/discovery/pane.html:52
-#: src/olympia/templates/menu_links.html:7
+#: src/olympia/browse/templates/browse/creatured.html:12 src/olympia/browse/templates/browse/featured.html:4 src/olympia/browse/templates/browse/featured.html:12
+#: src/olympia/browse/templates/browse/featured.html:13 src/olympia/devhub/templates/devhub/docs/policies-recommended.html:3 src/olympia/devhub/templates/devhub/docs/policies-recommended.html:7
+#: src/olympia/devhub/templates/devhub/docs/policies-recommended.html:9 src/olympia/devhub/templates/devhub/docs/policies.html:21 src/olympia/devhub/templates/devhub/docs/policies.html:90
+#: src/olympia/discovery/modules.py:341 src/olympia/discovery/templates/discovery/pane.html:52 src/olympia/templates/menu_links.html:7
 msgid "Featured Add-ons"
 msgstr "Odporúčané doplnky"
 
@@ -3639,12 +2847,8 @@ msgstr "Žiadne odporúčané doplnky v {0}."
 
 #: src/olympia/browse/templates/browse/featured.html:15
 #, python-format
-msgid ""
-"Here's a few of our favorite add-ons to help you get started customizing "
-"%(app)s."
-msgstr ""
-"Tu je niekoľko obľúbených doplnkov, pomocou ktorých si môžete upraviť "
-"%(app)s."
+msgid "Here's a few of our favorite add-ons to help you get started customizing %(app)s."
+msgstr "Tu je niekoľko obľúbených doplnkov, pomocou ktorých si môžete upraviť %(app)s."
 
 #: src/olympia/browse/templates/browse/language_tools.html:9
 msgid "Install Dictionary"
@@ -3670,19 +2874,15 @@ msgstr "Dostupné vo vašom jazyku"
 msgid "List of language packs and dictionaries available in your locale."
 msgstr "Zoznam jazykových balíkov a slovníkov dostupných vo vašom jazyku."
 
-#: src/olympia/browse/templates/browse/language_tools.html:41
-#: src/olympia/browse/templates/browse/language_tools.html:63
+#: src/olympia/browse/templates/browse/language_tools.html:41 src/olympia/browse/templates/browse/language_tools.html:63
 msgid "Language"
 msgstr "Jazyk"
 
-#: src/olympia/browse/templates/browse/language_tools.html:42
-#: src/olympia/browse/templates/browse/language_tools.html:64
-#: src/olympia/constants/base.py:162
+#: src/olympia/browse/templates/browse/language_tools.html:42 src/olympia/browse/templates/browse/language_tools.html:64 src/olympia/constants/base.py:162
 msgid "Dictionary"
 msgstr "Slovník"
 
-#: src/olympia/browse/templates/browse/language_tools.html:43
-#: src/olympia/browse/templates/browse/language_tools.html:65
+#: src/olympia/browse/templates/browse/language_tools.html:43 src/olympia/browse/templates/browse/language_tools.html:65
 msgid "Language Pack"
 msgstr "Jazykový balík"
 
@@ -3700,13 +2900,11 @@ msgid "{0} :: Search Tools"
 msgstr "{0} :: Vyhľadávacie nástroje"
 
 #. {0} is an integer.
-#: src/olympia/browse/templates/browse/search_tools.html:39
-#: src/olympia/devhub/templates/devhub/addons/dashboard.html:17
+#: src/olympia/browse/templates/browse/search_tools.html:39 src/olympia/devhub/templates/devhub/addons/dashboard.html:17
 msgid "<b>{0}</b> add-on"
 msgid_plural "<b>{0}</b> add-ons"
 msgstr[0] "<b>{0}</b> doplnok"
 msgstr[1] "<b>{0}</b> doplnky"
-msgstr[2] "<b>{0}</b> doplnkov"
 
 #: src/olympia/browse/templates/browse/search_tools.html:61
 msgid "Search Extensions"
@@ -3730,35 +2928,18 @@ msgstr "Ďalšie zdroje"
 
 #. {0} is an app name, like Firefox.
 #: src/olympia/browse/templates/browse/search_tools.html:93
-msgid ""
-"Learn more about the <a "
-"href=\"http://support.mozilla.com/kb/Search+bar\">search bar</a> in {0}"
-msgstr ""
-"Ďalšie informácie o <a "
-"href=\"http://support.mozilla.com/kb/Search+bar\">paneli vyhľadávania</a> v "
-"aplikácii {0}"
+msgid "Learn more about the <a href=\"http://support.mozilla.com/kb/Search+bar\">search bar</a> in {0}"
+msgstr "Ďalšie informácie o <a href=\"http://support.mozilla.com/kb/Search+bar\">paneli vyhľadávania</a> v aplikácii {0}"
 
 #: src/olympia/browse/templates/browse/search_tools.html:94
-msgid ""
-"Browse through even more search providers at <a "
-"href=\"http://mycroft.mozdev.org/\">mycroft.mozdev.org</a>"
-msgstr ""
-"Ďalší poskytovatelia vyhľadávania sú dostupní na stránkach <a "
-"href=\"http://mycroft.mozdev.org/\">mycroft.mozdev.org</a>"
+msgid "Browse through even more search providers at <a href=\"http://mycroft.mozdev.org/\">mycroft.mozdev.org</a>"
+msgstr "Ďalší poskytovatelia vyhľadávania sú dostupní na stránkach <a href=\"http://mycroft.mozdev.org/\">mycroft.mozdev.org</a>"
 
 #: src/olympia/browse/templates/browse/search_tools.html:95
-msgid ""
-"<a "
-"href=\"https://developer.mozilla.org/en/Creating_OpenSearch_plugins_for_Firefox\">Make"
-" your own</a> search tool"
-msgstr ""
-"<a href=\"https://developer.mozilla.org/sk/Add-"
-"ons/Creating_OpenSearch_plugins_for_Firefox\">Vytvorte si vlastný</a> "
-"vyhľadávací modul"
+msgid "<a href=\"https://developer.mozilla.org/en/Creating_OpenSearch_plugins_for_Firefox\">Make your own</a> search tool"
+msgstr "<a href=\"https://developer.mozilla.org/sk/Add-ons/Creating_OpenSearch_plugins_for_Firefox\">Vytvorte si vlastný</a> vyhľadávací modul"
 
-#: src/olympia/browse/templates/browse/themes.html:6
-#: src/olympia/browse/templates/browse/themes.html:9
-#: src/olympia/constants/base.py:174
+#: src/olympia/browse/templates/browse/themes.html:6 src/olympia/browse/templates/browse/themes.html:9 src/olympia/constants/base.py:174
 msgid "Complete Themes"
 msgstr "Plné témy vzhľadu"
 
@@ -3830,26 +3011,18 @@ msgid "See the %(cnt)s extension in %(name)s &raquo;"
 msgid_plural "See all %(cnt)s extensions in %(name)s &raquo;"
 msgstr[0] "Zobraziť %(cnt)s rozšírenie v %(name)s &raquo;"
 msgstr[1] "Zobraziť %(cnt)s rozšírenia v %(name)s &raquo;"
-msgstr[2] "Zobraziť %(cnt)s rozšírení v %(name)s &raquo;"
 
-#: src/olympia/browse/templates/browse/mobile/extensions.html:13
-#: src/olympia/compat/templates/compat/index.html:82
-#: src/olympia/devhub/templates/devhub/devhub_search.html:24
-#: src/olympia/devhub/templates/devhub/addons/activity.html:47
-#: src/olympia/search/templates/search/no_results.html:4
-#: src/olympia/search/templates/search/mobile/results.html:36
+#: src/olympia/browse/templates/browse/mobile/extensions.html:13 src/olympia/devhub/templates/devhub/devhub_search.html:24 src/olympia/devhub/templates/devhub/addons/activity.html:47
+#: src/olympia/search/templates/search/no_results.html:4 src/olympia/search/templates/search/mobile/results.html:36
 msgid "No results found."
 msgstr "Nenašli sa žiadne výsledky."
 
-#: src/olympia/browse/templates/browse/personas/base.html:6
-#: src/olympia/browse/templates/browse/personas/mobile/base.html:7
+#: src/olympia/browse/templates/browse/personas/base.html:6 src/olympia/browse/templates/browse/personas/mobile/base.html:7
 msgid "{0} Themes"
 msgstr "{0} tém vzhľadu"
 
 #. {0} is a user's name.
-#: src/olympia/browse/templates/browse/personas/base.html:15
-#: src/olympia/browse/templates/browse/personas/base.html:40
-#: src/olympia/browse/templates/browse/personas/grid.html:8
+#: src/olympia/browse/templates/browse/personas/base.html:15 src/olympia/browse/templates/browse/personas/base.html:40 src/olympia/browse/templates/browse/personas/grid.html:8
 msgid "{0}'s Themes"
 msgstr "Témy používateľa {0}"
 
@@ -3863,38 +3036,30 @@ msgstr "Vytvorenie svojej vlastnej témy"
 
 #: src/olympia/browse/templates/browse/personas/base.html:46
 msgid "Your browser, your style! Dress it up with a design of your own!"
-msgstr ""
-"Váš prehliadač, váš štýl. Oblečte si Firefox do vzhľadu, ktorý sa páči Vám!"
+msgstr "Váš prehliadač, váš štýl. Oblečte si Firefox do vzhľadu, ktorý sa páči Vám!"
 
 #: src/olympia/browse/templates/browse/personas/base.html:51
 msgid "Learn more"
 msgstr "Ďalšie informácie"
 
-#: src/olympia/browse/templates/browse/personas/category_landing.html:6
-#: src/olympia/browse/templates/browse/personas/mobile/category_landing.html:5
+#: src/olympia/browse/templates/browse/personas/category_landing.html:6 src/olympia/browse/templates/browse/personas/mobile/category_landing.html:5
 msgid "View All Recently Added"
 msgstr "Zobraziť všetky nedávno pridané"
 
-#: src/olympia/browse/templates/browse/personas/category_landing.html:7
-#: src/olympia/browse/templates/browse/personas/mobile/category_landing.html:6
+#: src/olympia/browse/templates/browse/personas/category_landing.html:7 src/olympia/browse/templates/browse/personas/mobile/category_landing.html:6
 msgid "View All Most Popular"
 msgstr "Zobraziť všetky najpopulárnejšie"
 
-#: src/olympia/browse/templates/browse/personas/category_landing.html:8
-#: src/olympia/browse/templates/browse/personas/mobile/category_landing.html:7
+#: src/olympia/browse/templates/browse/personas/category_landing.html:8 src/olympia/browse/templates/browse/personas/mobile/category_landing.html:7
 msgid "View All Top Rated"
 msgstr "Zobraziť všetky najlepšie hodnotené"
 
 #: src/olympia/browse/templates/browse/personas/category_landing.html:40
 #, python-format
-msgid ""
-"Over 300,000 designs to personalize your browser! Move your mouse over a "
-"Background Theme to try it on. <a href=\"%(url)s\" class=\"more-info\">Start"
-" exploring</a>"
+msgid "Over 300,000 designs to personalize your browser! Move your mouse over a Background Theme to try it on. <a href=\"%(url)s\" class=\"more-info\">Start exploring</a>"
 msgstr ""
-"Cez 300 tisíc spôsobov, ako si prispôsobiť svoj prehliadač. Presuňte kurzor "
-"myši nad tému a uvidíte, ako téma vyzerá v priamo v prehliadači. <a "
-"href=\"%(url)s\" class=\"more-info\">Začnite objavovať</a>"
+"Cez 300 tisíc spôsobov, ako si prispôsobiť svoj prehliadač. Presuňte kurzor myši nad tému a uvidíte, ako téma vyzerá v priamo v prehliadači. <a href=\"%(url)s\" class=\"more-info\">Začnite "
+"objavovať</a>"
 
 #: src/olympia/browse/templates/browse/personas/category_landing.html:47
 msgid "Want more personalization?"
@@ -3904,14 +3069,8 @@ msgstr "Hľadáte ďalšie možnosti prispôsobenia?"
 #. theme.
 #: src/olympia/browse/templates/browse/personas/category_landing.html:50
 #, python-format
-msgid ""
-"Complete Themes transform the look of your browser with styles for the "
-"window frame, address bar, buttons, tabs, and menus. <a href=\"%(url)s\" "
-"class=\"more-info\">Start exploring</a>"
-msgstr ""
-"Plné témy vzhľadu menia vzhľad prehliadača, vrátane okrajov okna, panela s "
-"adresou, tlačidiel, kariet a ponúk. <a href=\"%(url)s\" class=\"more-"
-"info\">Začnite objavovať</a>"
+msgid "Complete Themes transform the look of your browser with styles for the window frame, address bar, buttons, tabs, and menus. <a href=\"%(url)s\" class=\"more-info\">Start exploring</a>"
+msgstr "Plné témy vzhľadu menia vzhľad prehliadača, vrátane okrajov okna, panela s adresou, tlačidiel, kariet a ponúk. <a href=\"%(url)s\" class=\"more-info\">Začnite objavovať</a>"
 
 #: src/olympia/browse/templates/browse/personas/category_landing.html:76
 msgid "Up & Coming Themes"
@@ -3941,7 +3100,7 @@ msgstr "&laquo; Všetky témy"
 msgid "All"
 msgstr "Všetko"
 
-#: src/olympia/compat/forms.py:22 src/olympia/search/views.py:525
+#: src/olympia/compat/forms.py:22 src/olympia/editors/templates/editors/base.html:69 src/olympia/search/views.py:518
 msgid "All Add-ons"
 msgstr "Všetky doplnky"
 
@@ -3953,94 +3112,32 @@ msgstr "Binárny"
 msgid "Non-binary"
 msgstr "Nebinárny"
 
-#. Review points sources other than add-ons and themes.
-#: src/olympia/compat/views.py:87 src/olympia/constants/base.py:388
-#: src/olympia/devhub/forms.py:162
-#: src/olympia/editors/templates/editors/performance.html:75
-msgid "Other"
-msgstr "Iná"
-
-#: src/olympia/compat/templates/compat/index.html:4
-msgid "Add-on Compatibility Report for {app} {version}"
-msgstr "Správa o kompatibilite doplnku pre {app} {version}"
-
-#: src/olympia/compat/templates/compat/index.html:11
-msgid "{app} {version} Compatibility"
-msgstr "Kompatibilita s aplikáciou {app} {version}"
-
-#: src/olympia/compat/templates/compat/index.html:17
-#, python-format
-msgid "Top 95%% compatible with previous version"
-msgstr "Top 95%% kompatibilných s predchádzajúcou verziou"
-
-#: src/olympia/compat/templates/compat/index.html:18
-#, python-format
-msgid "Top 95%% of all add-ons"
-msgstr "Top 95%% zo všetkých doplnkov"
-
-#: src/olympia/compat/templates/compat/index.html:19
-msgid "All active add-ons"
-msgstr "Všetky aktívne doplnky"
-
-#: src/olympia/compat/templates/compat/index.html:23
-#: src/olympia/constants/base.py:401
-msgid "App"
-msgstr "Aplikácia"
-
-#: src/olympia/compat/templates/compat/index.html:55
-msgid "Details for add-ons compatible with previous version:"
-msgstr ""
-"Detailné informácie pre doplnky, ktoré boli kompatibilné s predchádzajúcou "
-"verziou:"
-
-#: src/olympia/compat/templates/compat/index.html:57
-msgid "Show all versions"
-msgstr "Zobraziť všetky verzie"
-
-#: src/olympia/compat/templates/compat/index.html:59
-msgid "Details for add-ons compatible with all versions:"
-msgstr "Detaily pre doplnky, ktoré sú kompatibilné so všetkými verziami:"
-
-#: src/olympia/compat/templates/compat/index.html:61
-msgid "Show previous version only"
-msgstr "Zobraziť len predchádzajúcu verziu"
-
 #: src/olympia/compat/templates/compat/reporter.html:3
 msgid "Add-on Compatibility Reports"
 msgstr "Správy o kompatibilite doplnku"
 
-#: src/olympia/compat/templates/compat/reporter.html:11
-#: src/olympia/compat/templates/compat/reporter_detail.html:35
+#: src/olympia/compat/templates/compat/reporter.html:11 src/olympia/compat/templates/compat/reporter_detail.html:35
 #, python-format
 msgid ""
-"<p> Reports submitted to us through the <a href=\"%(url_)s\">Add-on "
-"Compatibility Reporter</a> are collected here for developers to view. These "
-"reports help us determine which add-ons will need help supporting an "
-"upcoming Firefox version. </p>"
+"<p> Reports submitted to us through the <a href=\"%(url_)s\">Add-on Compatibility Reporter</a> are collected here for developers to view. These reports help us determine which add-ons will need "
+"help supporting an upcoming Firefox version. </p>"
 msgstr ""
-"<p> Hlásenia, ktoré nám boli odoslané cez doplnok <a href=\"%(url_)s\">Add-"
-"on Compatibility Reporter</a>, sú tu dostupné pre vývojárov. Tieto hlásenia "
-"nám pomôžu rozpoznať, ktoré doplnky potrebujú pomoc s podporou pre "
-"nadchádzajúcu verziu Firefoxu. </p>"
+"<p> Hlásenia, ktoré nám boli odoslané cez doplnok <a href=\"%(url_)s\">Add-on Compatibility Reporter</a>, sú tu dostupné pre vývojárov. Tieto hlásenia nám pomôžu rozpoznať, ktoré doplnky potrebujú "
+"pomoc s podporou pre nadchádzajúcu verziu Firefoxu. </p>"
 
 #: src/olympia/compat/templates/compat/reporter.html:18
 msgid "Reports for your Add-ons"
 msgstr "Správy pre vaše doplnky"
 
-#: src/olympia/compat/templates/compat/reporter.html:30
-#: src/olympia/compat/templates/compat/reporter_detail.html:9
+#: src/olympia/compat/templates/compat/reporter.html:30 src/olympia/compat/templates/compat/reporter_detail.html:9
 msgid "Add-on Compatibility Center"
 msgstr "Centrum kompatibility doplnkov"
 
 #: src/olympia/compat/templates/compat/reporter.html:34
 msgid "Enter the GUID of an add-on below to view any reports we've received."
-msgstr ""
-"Zadaním identifikátora GUID zobrazíte správy, ktoré sme k danému doplnku "
-"obdržali."
+msgstr "Zadaním identifikátora GUID zobrazíte správy, ktoré sme k danému doplnku obdržali."
 
-#: src/olympia/compat/templates/compat/reporter_detail.html:3
-#: src/olympia/compat/templates/compat/reporter_detail.html:10
-#: src/olympia/compat/templates/compat/reporter_detail.html:25
+#: src/olympia/compat/templates/compat/reporter_detail.html:3 src/olympia/compat/templates/compat/reporter_detail.html:10 src/olympia/compat/templates/compat/reporter_detail.html:25
 msgid "{addon} Compatibility Reports"
 msgstr "Správy o kompatibilite doplnku {addon}"
 
@@ -4049,17 +3146,14 @@ msgid "{0} success report"
 msgid_plural "{0} success reports"
 msgstr[0] "{0} správa o bezproblémovom chode"
 msgstr[1] "{0} správy o bezproblémovom chode"
-msgstr[2] "{0} správ o bezproblémovom chode"
 
 #: src/olympia/compat/templates/compat/reporter_detail.html:17
 msgid "{0} problem report"
 msgid_plural "{0} problem reports"
 msgstr[0] "{0} správa o problémoch"
 msgstr[1] "{0} správy o problémoch"
-msgstr[2] "{0} správ o problémoch"
 
-#: src/olympia/compat/templates/compat/reporter_detail.html:21
-#: src/olympia/users/templates/users/profile.html:70
+#: src/olympia/compat/templates/compat/reporter_detail.html:21 src/olympia/users/templates/users/profile.html:70
 msgid "View all"
 msgstr "Zobraziť všetko"
 
@@ -4071,10 +3165,8 @@ msgstr "Filter podľa aplikácie"
 msgid "Report Type"
 msgstr "Typ správy"
 
-#: src/olympia/compat/templates/compat/reporter_detail.html:47
-#: src/olympia/devhub/forms.py:784
-#: src/olympia/devhub/templates/devhub/addons/ajax_compat_update.html:17
-#: src/olympia/editors/forms.py:108 src/olympia/zadmin/forms.py:45
+#: src/olympia/compat/templates/compat/reporter_detail.html:47 src/olympia/devhub/forms.py:785 src/olympia/devhub/templates/devhub/addons/ajax_compat_update.html:17 src/olympia/editors/forms.py:108
+#: src/olympia/editors/forms.py:248 src/olympia/zadmin/forms.py:45
 msgid "Application"
 msgstr "Aplikácia"
 
@@ -4086,8 +3178,7 @@ msgstr "Zostavenie aplikácie"
 msgid "Platform"
 msgstr "Platforma"
 
-#: src/olympia/compat/templates/compat/reporter_detail.html:50
-#: src/olympia/editors/templates/editors/themes/themes.html:40
+#: src/olympia/compat/templates/compat/reporter_detail.html:50 src/olympia/editors/templates/editors/themes/themes.html:40
 msgid "Submitted"
 msgstr "Odoslané"
 
@@ -4115,8 +3206,7 @@ msgstr "Thunderbird"
 msgid "SeaMonkey"
 msgstr "SeaMonkey"
 
-#: src/olympia/constants/applications.py:75
-#: src/olympia/pages/templates/pages/sunbird.html:4
+#: src/olympia/constants/applications.py:75 src/olympia/pages/templates/pages/sunbird.html:4
 msgid "Sunbird"
 msgstr "Sunbird"
 
@@ -4164,7 +3254,7 @@ msgstr "Predbežne skontrolovaný"
 msgid "Preliminarily Reviewed and Awaiting Full Review"
 msgstr "Predbežne skontrolovaný, čakajúci na riadnu kontrolu"
 
-#: src/olympia/constants/base.py:33 src/olympia/editors/helpers.py:924
+#: src/olympia/constants/base.py:33 src/olympia/editors/forms.py:258 src/olympia/editors/helpers.py:73 src/olympia/editors/helpers.py:1004
 #: src/olympia/editors/templates/editors/themes/history_table.html:34
 msgid "Deleted"
 msgstr "Odstránené"
@@ -4198,13 +3288,11 @@ msgstr "Vývojár"
 msgid "Viewer"
 msgstr "Divák"
 
-#: src/olympia/constants/base.py:137
-#: src/olympia/templates/mobile/header.html:7
+#: src/olympia/constants/base.py:137 src/olympia/templates/mobile/header.html:7
 msgid "Support"
 msgstr "Podpora"
 
-#: src/olympia/constants/base.py:159 src/olympia/constants/base.py:172
-#: src/olympia/constants/platforms.py:10
+#: src/olympia/constants/base.py:159 src/olympia/constants/base.py:172 src/olympia/constants/platforms.py:10
 msgid "Any"
 msgstr "Nezáleží"
 
@@ -4232,11 +3320,8 @@ msgstr "Jazykový balíček (doplnok)"
 msgid "Plugin"
 msgstr "Zásuvný modul"
 
-#: src/olympia/constants/base.py:167
-#: src/olympia/editors/templates/editors/includes/search_results_themes.html:5
-#: src/olympia/editors/templates/editors/themes/deleted.html:18
-#: src/olympia/editors/templates/editors/themes/history_table.html:8
-#: src/olympia/editors/templates/editors/themes/logs.html:17
+#: src/olympia/constants/base.py:167 src/olympia/editors/templates/editors/includes/search_results_themes.html:5 src/olympia/editors/templates/editors/themes/deleted.html:18
+#: src/olympia/editors/templates/editors/themes/history_table.html:8 src/olympia/editors/templates/editors/themes/logs.html:17
 msgid "Theme"
 msgstr "Téma"
 
@@ -4270,6 +3355,11 @@ msgstr "Pýtať po tom, ako sa začne doplnok preberať"
 msgid "Ask before users can download this add-on"
 msgstr "Pýtať pred prevzatím doplnku"
 
+#. Review points sources other than add-ons and themes.
+#: src/olympia/constants/base.py:388 src/olympia/devhub/forms.py:162 src/olympia/editors/templates/editors/performance.html:75
+msgid "Other"
+msgstr "Iná"
+
 #: src/olympia/constants/base.py:389
 msgid "Exception"
 msgstr "Výnimka"
@@ -4281,6 +3371,10 @@ msgstr "Vydanie"
 #: src/olympia/constants/base.py:391
 msgid "Change"
 msgstr "Zmeniť"
+
+#: src/olympia/constants/base.py:401
+msgid "App"
+msgstr "Aplikácia"
 
 #: src/olympia/constants/base.py:402
 msgid "Persona"
@@ -4418,32 +3512,23 @@ msgstr "Odoslané na kompletnú kontrolu"
 msgid "Signed of a preliminary review"
 msgstr "Odoslané na predbežnú kontrolu"
 
-#: src/olympia/constants/editors.py:14
-#: src/olympia/editors/templates/editors/themes/queue.html:76
-#: src/olympia/editors/templates/editors/themes/themes.html:87
+#: src/olympia/constants/editors.py:14 src/olympia/editors/templates/editors/themes/queue.html:76 src/olympia/editors/templates/editors/themes/themes.html:87
 msgid "Request More Info"
 msgstr "Požiadať doplnkové informácie"
 
-#: src/olympia/constants/editors.py:15
-#: src/olympia/editors/templates/editors/themes/queue.html:74
-#: src/olympia/editors/templates/editors/themes/themes.html:91
+#: src/olympia/constants/editors.py:15 src/olympia/editors/templates/editors/themes/queue.html:74 src/olympia/editors/templates/editors/themes/themes.html:91
 msgid "Flag"
 msgstr "Označiť"
 
-#: src/olympia/constants/editors.py:16
-#: src/olympia/editors/templates/editors/themes/queue.html:72
-#: src/olympia/editors/templates/editors/themes/themes.html:93
+#: src/olympia/constants/editors.py:16 src/olympia/editors/templates/editors/themes/queue.html:72 src/olympia/editors/templates/editors/themes/themes.html:93
 msgid "Duplicate"
 msgstr "Duplikovať"
 
-#: src/olympia/constants/editors.py:17 src/olympia/editors/helpers.py:502
-#: src/olympia/editors/templates/editors/themes/queue.html:71
-#: src/olympia/editors/templates/editors/themes/themes.html:94
+#: src/olympia/constants/editors.py:17 src/olympia/editors/helpers.py:575 src/olympia/editors/templates/editors/themes/queue.html:71 src/olympia/editors/templates/editors/themes/themes.html:94
 msgid "Reject"
 msgstr "Odmietnuť"
 
-#: src/olympia/constants/editors.py:18
-#: src/olympia/editors/templates/editors/themes/queue.html:70
+#: src/olympia/constants/editors.py:18 src/olympia/editors/templates/editors/themes/queue.html:70
 msgid "Approve"
 msgstr "Schváliť"
 
@@ -4539,7 +3624,7 @@ msgstr "Solaris"
 msgid "Android"
 msgstr "Android"
 
-#: src/olympia/core/apps.py:19
+#: src/olympia/core/apps.py:21
 msgid "Core"
 msgstr "Jadro"
 
@@ -4576,9 +3661,7 @@ msgstr "Neplatný JSON objekt"
 msgid "Message not eligible for annotation"
 msgstr ""
 
-#: src/olympia/devhub/forms.py:124
-#: src/olympia/devhub/templates/devhub/versions/edit.html:94
-#: src/olympia/users/templates/users/edit.html:150
+#: src/olympia/devhub/forms.py:124 src/olympia/devhub/templates/devhub/versions/edit.html:94 src/olympia/users/templates/users/edit.html:150
 msgid "Details"
 msgstr "Podrobnosti"
 
@@ -4648,8 +3731,7 @@ msgstr "Nepodarilo sa overiť PayPal ID."
 
 #: src/olympia/devhub/forms.py:388
 msgid "Unsupported file type, please upload an archive file {extensions}."
-msgstr ""
-"Nepodporovaný typ súboru. Nahrajte prosím súbor s archívom pre {extensions}."
+msgstr "Nepodporovaný typ súboru. Nahrajte prosím súbor s archívom pre {extensions}."
 
 #: src/olympia/devhub/forms.py:407
 msgid "View current"
@@ -4676,39 +3758,26 @@ msgid "Submit my add-on for manual review."
 msgstr "Odoslať doplnok na manuálnu kontrolu."
 
 #: src/olympia/devhub/forms.py:537
-msgid "Do not list my add-on on this site (beta)"
-msgstr "Nezverejňovať môj doplnok na tejto stránke (beta)"
+msgid "Do not list my add-on on this site"
+msgstr ""
 
 #: src/olympia/devhub/forms.py:538
-msgid ""
-"Check this option if you intend to distribute your add-on on your own and "
-"only need it to be signed by Mozilla."
-msgstr ""
-"Začiarknite, ak chcete doplnok distribuovať sami a len ho potrebujete "
-"Mozillou podpísať."
+msgid "Check this option if you intend to distribute your add-on on your own and only need it to be signed by Mozilla."
+msgstr "Začiarknite, ak chcete doplnok distribuovať sami a len ho potrebujete Mozillou podpísať."
 
 #: src/olympia/devhub/forms.py:544
 msgid "This add-on will be bundled with an application installer."
 msgstr "Tento doplnok bude pribalený k inštalátoru aplikácie."
 
 #: src/olympia/devhub/forms.py:546
-msgid ""
-"Add-ons that are bundled with application installers will be code reviewed "
-"by Mozilla before they are signed and are held to a higher quality standard."
-msgstr ""
-"Skôr ako môžu byť podpísané doplnky pribalené k inštalátoru aplikácie, musí "
-"byť ich kód skontrolovaný Mozillou. Takéto doplnky musia udržovať vyšší "
-"štandard kvality."
+msgid "Add-ons that are bundled with application installers will be code reviewed by Mozilla before they are signed and are held to a higher quality standard."
+msgstr "Skôr ako môžu byť podpísané doplnky pribalené k inštalátoru aplikácie, musí byť ich kód skontrolovaný Mozillou. Takéto doplnky musia udržovať vyšší štandard kvality."
 
-#: src/olympia/devhub/forms.py:565
-#: src/olympia/devhub/templates/devhub/addons/submit/select-review.html:24
-#: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:42
+#: src/olympia/devhub/forms.py:565 src/olympia/devhub/templates/devhub/addons/submit/select-review.html:24 src/olympia/devhub/templates/devhub/docs/policies-reviews.html:42
 msgid "Full Review"
 msgstr "Plná kontrola"
 
-#: src/olympia/devhub/forms.py:566
-#: src/olympia/devhub/templates/devhub/addons/submit/select-review.html:47
-#: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:153
+#: src/olympia/devhub/forms.py:566 src/olympia/devhub/templates/devhub/addons/submit/select-review.html:47 src/olympia/devhub/templates/devhub/docs/policies-reviews.html:153
 msgid "Preliminary Review"
 msgstr "Predbežná kontrola"
 
@@ -4717,66 +3786,51 @@ msgid "Please choose a review nomination type"
 msgstr "Zvoľte typ nominácie na kontrolu"
 
 #: src/olympia/devhub/forms.py:574
-msgid ""
-"A file with a version ending with a|alpha|b|beta|pre|rc and an optional "
-"number is detected as beta."
-msgstr ""
-"Súbory s verziou končiacou na a|alpha|b|beta|pre|rc a prípadne číslom sú "
-"považované ako betaverze."
+msgid "A file with a version ending with a|alpha|b|beta|pre|rc and an optional number is detected as beta."
+msgstr "Súbory s verziou končiacou na a|alpha|b|beta|pre|rc a prípadne číslom sú považované ako betaverze."
 
 #: src/olympia/devhub/forms.py:592
 #, python-format
-msgid "Version %s already exists"
-msgstr "Verzia %s už existuje"
-
-#: src/olympia/devhub/forms.py:604
-msgid ""
-"Select a valid choice. That choice is not one of the available choices."
+msgid "Version %s already exists, or was uploaded before."
 msgstr ""
-"Zvoľte platnú hodnotu. Táto voľba nie je žiadnou z dostupných možností."
 
-#: src/olympia/devhub/forms.py:610
-msgid ""
-"A file with a version ending with a|alpha|b|beta and an optional number is "
-"detected as beta."
-msgstr ""
-"Súbor s verziou, ktorá končí na a|alpha|b|beta a ľubovolným číslom je "
-"rozpoznaný ako betaverzia."
+#: src/olympia/devhub/forms.py:605
+msgid "Select a valid choice. That choice is not one of the available choices."
+msgstr "Zvoľte platnú hodnotu. Táto voľba nie je žiadnou z dostupných možností."
 
-#: src/olympia/devhub/forms.py:633
+#: src/olympia/devhub/forms.py:611
+msgid "A file with a version ending with a|alpha|b|beta and an optional number is detected as beta."
+msgstr "Súbor s verziou, ktorá končí na a|alpha|b|beta a ľubovolným číslom je rozpoznaný ako betaverzia."
+
+#: src/olympia/devhub/forms.py:634
 msgid "You cannot upload any more files for this version."
 msgstr "Pre túto verziu nemôžete odoslať žiadne ďalšie súbory."
 
-#: src/olympia/devhub/forms.py:639
+#: src/olympia/devhub/forms.py:640
 msgid "Version doesn't match"
 msgstr "Verzia sa nezhoduje"
 
-#: src/olympia/devhub/forms.py:668
-msgid ""
-"You cannot delete a file once the review process has started. You must "
-"delete the whole version."
-msgstr ""
-"Nemôžete odstrániť súbor v dobe, keď bol zahájený proces kontroly. Musíte "
-"odstrániť celú verziu."
+#: src/olympia/devhub/forms.py:669
+msgid "You cannot delete a file once the review process has started. You must delete the whole version."
+msgstr "Nemôžete odstrániť súbor v dobe, keď bol zahájený proces kontroly. Musíte odstrániť celú verziu."
 
-#: src/olympia/devhub/forms.py:688
+#: src/olympia/devhub/forms.py:689
 msgid "The platform All cannot be combined with specific platforms."
 msgstr "Platformu Všetky nie je možné kombinovať s inou platformou."
 
-#: src/olympia/devhub/forms.py:693
+#: src/olympia/devhub/forms.py:694
 msgid "A platform can only be chosen once."
 msgstr "Platformu je možné zvoliť len raz."
 
-#: src/olympia/devhub/forms.py:706
+#: src/olympia/devhub/forms.py:707
 msgid "A review type must be selected."
 msgstr "Musí byť zvolený typ kontroly."
 
-#: src/olympia/devhub/forms.py:788 src/olympia/editors/forms.py:114
-#: src/olympia/zadmin/forms.py:49 src/olympia/zadmin/forms.py:52
+#: src/olympia/devhub/forms.py:789 src/olympia/editors/forms.py:114 src/olympia/editors/forms.py:254 src/olympia/zadmin/forms.py:49 src/olympia/zadmin/forms.py:52
 msgid "Select an application first"
 msgstr "Najskôr zvoľte aplikáciu"
 
-#: src/olympia/devhub/forms.py:840
+#: src/olympia/devhub/forms.py:841
 msgid "There cannot be more than 3 required add-ons."
 msgstr "Nemôžete mať viac ako 3 vyžadované doplnky."
 
@@ -4792,205 +3846,185 @@ msgstr "Moje aplikácie"
 msgid "Developer Docs"
 msgstr "Dokumenty pre vývojárov"
 
-#. L10n: first parameter is the number of errors
 # {0} is a number
+#. L10n: first parameter is the number of errors
 #: src/olympia/devhub/helpers.py:200
 msgid "{0} error"
 msgid_plural "{0} errors"
 msgstr[0] "{0} chyba"
 msgstr[1] "{0} chyby"
-msgstr[2] "{0} chýb"
 
-#. L10n: first parameter is the number of warnings
 # {0} is a number
+#. L10n: first parameter is the number of warnings
 #: src/olympia/devhub/helpers.py:203
 msgid "{0} warning"
 msgid_plural "{0} warnings"
 msgstr[0] "{0} upozornenie"
 msgstr[1] "{0} upozornenia"
-msgstr[2] "{0} upozornení"
 
-#: src/olympia/devhub/models.py:375
-#: src/olympia/reviews/templates/reviews/add.html:58
+#: src/olympia/devhub/models.py:375 src/olympia/reviews/templates/reviews/add.html:58
 msgid "Review"
 msgstr "Recenzia"
 
-#: src/olympia/devhub/tasks.py:551
+#: src/olympia/devhub/tasks.py:583
 #, python-format
 msgid "%s responded with %s (%s)."
 msgstr "%s odpovedal: %s (%s)."
 
-#: src/olympia/devhub/tasks.py:555
+#: src/olympia/devhub/tasks.py:587
 #, python-format
 msgid "Connection to \"%s\" timed out."
 msgstr "Čas pripojenia k \"%s\" vypršal."
 
-#: src/olympia/devhub/tasks.py:557
+#: src/olympia/devhub/tasks.py:589
 #, python-format
 msgid "Could not contact host at \"%s\"."
 msgstr "Nebolo možné kontaktovať server \"%s\"."
 
-#: src/olympia/devhub/utils.py:104
+#: src/olympia/devhub/utils.py:105
 #, python-format
-msgid ""
-"Validation generated too many errors/warnings so %s messages were truncated."
-" After addressing the visible messages, you'll be able to see the others."
-msgstr ""
-"Kontrola vygenerovala príliš veľa chýb/varovaní. %s správ tak nie je "
-"zobrazených. Po opravení zobrazených nedostatkov budete môcť vidieť ďalšie."
+msgid "Validation generated too many errors/warnings so %s messages were truncated. After addressing the visible messages, you'll be able to see the others."
+msgstr "Kontrola vygenerovala príliš veľa chýb/varovaní. %s správ tak nie je zobrazených. Po opravení zobrazených nedostatkov budete môcť vidieť ďalšie."
 
-#: src/olympia/devhub/views.py:183
+#: src/olympia/devhub/views.py:182
 msgid "All My Add-ons"
 msgstr "Všetky moje doplnky"
 
-#: src/olympia/devhub/views.py:210
+#: src/olympia/devhub/views.py:209
 msgid "All Activity"
 msgstr "Všetky aktivity"
 
-#: src/olympia/devhub/views.py:211
+#: src/olympia/devhub/views.py:210
 msgid "Add-on Updates"
 msgstr "Aktualizácie doplnkov"
 
-#: src/olympia/devhub/views.py:212
+#: src/olympia/devhub/views.py:211
 msgid "Add-on Status"
 msgstr "Stav doplnku"
 
-#: src/olympia/devhub/views.py:213
+#: src/olympia/devhub/views.py:212
 msgid "User Collections"
 msgstr "Kolekcie používateľa"
 
-#: src/olympia/devhub/views.py:214
-#: src/olympia/devhub/templates/devhub/docs/policies-maintenance.html:68
-#: src/olympia/pages/templates/pages/dev_faq.html:38
+#: src/olympia/devhub/views.py:213 src/olympia/devhub/templates/devhub/docs/policies-maintenance.html:68 src/olympia/pages/templates/pages/dev_faq.html:38
 #: src/olympia/pages/templates/pages/dev_faq.html:484
 msgid "User Reviews"
 msgstr "Recenzie používateľa"
 
-#: src/olympia/devhub/views.py:327 src/olympia/devhub/views.py:331
-#: src/olympia/devhub/views.py:484 src/olympia/devhub/views.py:513
-#: src/olympia/devhub/views.py:564 src/olympia/devhub/views.py:1150
+#: src/olympia/devhub/views.py:326 src/olympia/devhub/views.py:330 src/olympia/devhub/views.py:485 src/olympia/devhub/views.py:514 src/olympia/devhub/views.py:565 src/olympia/devhub/views.py:1157
 msgid "Changes successfully saved."
 msgstr "Zmeny boli úspešne uložené."
 
-#: src/olympia/devhub/views.py:334 src/olympia/devhub/views.py:1631
+#: src/olympia/devhub/views.py:333 src/olympia/devhub/views.py:1638
 msgid "Please check the form for errors."
 msgstr "Skontrolujte prosím chyby vo formulári."
 
-#: src/olympia/devhub/views.py:346
+#: src/olympia/devhub/views.py:345
 msgid "Add-on cannot be deleted. Disable this add-on instead."
 msgstr "Doplněk nemôže byť odstránený. Namiesto toho ho zakážte."
 
-#: src/olympia/devhub/views.py:356
+#: src/olympia/devhub/views.py:355
 msgid "Theme deleted."
 msgstr "Téma odstránená."
 
-#: src/olympia/devhub/views.py:356
+#: src/olympia/devhub/views.py:355
 msgid "Add-on deleted."
 msgstr "Doplnok bol odstránený."
 
-#: src/olympia/devhub/views.py:362
+#: src/olympia/devhub/views.py:361
 msgid "URL name was incorrect. Theme was not deleted."
 msgstr "URL názov je nesprávny. Téma nebola odstránená."
 
-#: src/olympia/devhub/views.py:367
+#: src/olympia/devhub/views.py:366
 msgid "URL name was incorrect. Add-on was not deleted."
 msgstr "URL názov je nesprávny. Doplnok nebol odstránený."
 
-#: src/olympia/devhub/views.py:449
+#: src/olympia/devhub/views.py:450
 msgid "An author has been added to your add-on"
 msgstr "K vášmu doplnku bol pridaný autor"
 
-#: src/olympia/devhub/views.py:456
+#: src/olympia/devhub/views.py:457
 msgid "An author has a role changed on your add-on"
 msgstr "Pri vašom doplnku autor zmenil rolu"
 
-#: src/olympia/devhub/views.py:476
+#: src/olympia/devhub/views.py:477
 msgid "An author has been removed from your add-on"
 msgstr "Autor bol pri vašom doplnku odobraný"
 
-#: src/olympia/devhub/views.py:519
+#: src/olympia/devhub/views.py:520
 msgid "There were errors in your submission."
 msgstr "V odoslaných údajoch sa nachádzajú chyby."
 
-#: src/olympia/devhub/views.py:583
+#: src/olympia/devhub/views.py:584
 msgid "Validate Add-on"
 msgstr "Overiť doplnok"
 
-#: src/olympia/devhub/views.py:594
+#: src/olympia/devhub/views.py:595
 msgid "Check Add-on Compatibility"
 msgstr "Kontrola kompatibility doplnku"
 
-#: src/olympia/devhub/views.py:808 src/olympia/signing/views.py:90
+#: src/olympia/devhub/views.py:809 src/olympia/signing/views.py:95
 msgid "You cannot submit this type of add-on"
 msgstr "Pridávanie takéhoto typu doplnku nie je povolené"
 
-#: src/olympia/devhub/views.py:1051 src/olympia/users/forms.py:471
+#: src/olympia/devhub/views.py:1052 src/olympia/users/forms.py:471
 msgid "Images must be either PNG or JPG."
 msgstr "Obrázky musia byť vo formáte PNG alebo JPG."
 
-#: src/olympia/devhub/views.py:1055
+#: src/olympia/devhub/views.py:1056
 msgid "Icons cannot be animated."
 msgstr "Ikony nesmú byť animované."
 
-#: src/olympia/devhub/views.py:1057
+#: src/olympia/devhub/views.py:1058
 msgid "Images cannot be animated."
 msgstr "Obrázky nesmú byť animované."
 
-#: src/olympia/devhub/views.py:1070
+#: src/olympia/devhub/views.py:1071
 #, python-format
 msgid "Images cannot be larger than %dKB."
 msgstr "Obrázky nemôžu byť väčšie ako %d kb."
 
 #. L10n: {0} is an image width (in pixels), {1} is a height.
-#: src/olympia/devhub/views.py:1080
+#: src/olympia/devhub/views.py:1081
 msgid "Image must be exactly {0} pixels wide and {1} pixels tall."
 msgstr "Obrázok musí mať rozmery {0}x{1} bodov."
 
-#: src/olympia/devhub/views.py:1087
+#: src/olympia/devhub/views.py:1088
 msgid "There was an error uploading your preview."
 msgstr "Pri odosielaní ukážky sa vyskytla chyba."
 
-#: src/olympia/devhub/views.py:1189
+#: src/olympia/devhub/views.py:1196
 #, python-format
 msgid "Version %s disabled."
 msgstr "Verzia %s je zakázaná."
 
-#: src/olympia/devhub/views.py:1193
+#: src/olympia/devhub/views.py:1200
 #, python-format
 msgid "Version %s deleted."
 msgstr "Verzia %s bola odstránená."
 
-#: src/olympia/devhub/views.py:1203
-msgid ""
-"This upload has failed validation, and may lack complete validation results."
-" Please take due care when reviewing it."
-msgstr ""
-"Pri nahrávaní kontrola zlyhala a preto jej výsledky nemusia byť kompletné. "
-"Venujte tomu preto pri kontrole zvláštnu pozornosť."
+#: src/olympia/devhub/views.py:1210
+msgid "This upload has failed validation, and may lack complete validation results. Please take due care when reviewing it."
+msgstr "Pri nahrávaní kontrola zlyhala a preto jej výsledky nemusia byť kompletné. Venujte tomu preto pri kontrole zvláštnu pozornosť."
 
-#: src/olympia/devhub/views.py:1677
+#: src/olympia/devhub/views.py:1684
 msgid "Preliminary Review Requested."
 msgstr "Vyžiadaná predbežná kontrola."
 
-#: src/olympia/devhub/views.py:1678
+#: src/olympia/devhub/views.py:1685
 msgid "Full Review Requested."
 msgstr "Vyžiadaná plná kontrola."
 
-#: src/olympia/devhub/views.py:1779
-msgid ""
-"Your old credentials were revoked and are no longer valid. Be sure to update"
-" all API clients with the new credentials."
+#: src/olympia/devhub/views.py:1786
+msgid "Your old credentials were revoked and are no longer valid. Be sure to update all API clients with the new credentials."
 msgstr ""
 
-#: src/olympia/devhub/views.py:1797
+#: src/olympia/devhub/views.py:1804
 msgid "New API key created"
 msgstr "Nový kľúč API bol vytvorený."
 
 #: src/olympia/devhub/templates/devhub/agreement.html:2
-msgid ""
-"Before starting, please read and accept our Firefox Add-on Distribution "
-"Agreement. It also links to our Privacy Notice which explains how we handle "
-"your information."
+msgid "Before starting, please read and accept our Firefox Add-on Distribution Agreement. It also links to our Privacy Notice which explains how we handle your information."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/agreement.html:13
@@ -5005,44 +4039,30 @@ msgstr "Súhlasím s týmto ujednaním"
 msgid "or <a href=\"{0}\">Cancel</a>"
 msgstr "alebo <a href=\"{0}\">Zrušiť</a>"
 
-#: src/olympia/devhub/templates/devhub/base.html:23
-#: src/olympia/devhub/templates/devhub/base_impala.html:20
-#: src/olympia/discovery/templates/discovery/addons/base.html:17
+#: src/olympia/devhub/templates/devhub/base.html:23 src/olympia/devhub/templates/devhub/base_impala.html:20 src/olympia/discovery/templates/discovery/addons/base.html:17
 msgid "Back to Add-ons"
 msgstr "Naspäť na Doplnky"
 
 #. {0} is a search term, such as Firebug.
 #. {0} is a search query.
-#: src/olympia/devhub/templates/devhub/devhub_search.html:4
-#: src/olympia/search/templates/search/results.html:9
-#: src/olympia/search/templates/search/mobile/results.html:6
+#: src/olympia/devhub/templates/devhub/devhub_search.html:4 src/olympia/search/templates/search/results.html:9 src/olympia/search/templates/search/mobile/results.html:6
 msgid "{0} :: Search"
 msgstr "{0} :: Vyhľadávanie"
 
-#: src/olympia/devhub/templates/devhub/devhub_search.html:6
-#: src/olympia/devhub/templates/devhub/search.html:8
-#: src/olympia/editors/forms.py:435 src/olympia/editors/forms.py:437
-#: src/olympia/editors/templates/editors/queue.html:27
-#: src/olympia/editors/templates/editors/themes/queue_list.html:14
-#: src/olympia/search/templates/search/collections.html:17
-#: src/olympia/search/templates/search/personas.html:18
-#: src/olympia/search/templates/search/results.html:18
-#: src/olympia/search/templates/search/mobile/results.html:8
-#: src/olympia/templates/search.html:14
+#: src/olympia/devhub/templates/devhub/devhub_search.html:6 src/olympia/devhub/templates/devhub/search.html:8 src/olympia/editors/forms.py:534 src/olympia/editors/forms.py:536
+#: src/olympia/editors/templates/editors/queue.html:27 src/olympia/editors/templates/editors/themes/queue_list.html:14 src/olympia/search/templates/search/collections.html:17
+#: src/olympia/search/templates/search/personas.html:18 src/olympia/search/templates/search/results.html:18 src/olympia/search/templates/search/mobile/results.html:8 src/olympia/templates/search.html:14
 #: src/olympia/templates/impala/search.html:18
 msgid "Search"
 msgstr "Hľadať"
 
-#: src/olympia/devhub/templates/devhub/devhub_search.html:11
-#: src/olympia/devhub/templates/devhub/devhub_search.html:15
-#: src/olympia/search/templates/search/collections.html:18
+#: src/olympia/devhub/templates/devhub/devhub_search.html:11 src/olympia/devhub/templates/devhub/devhub_search.html:15 src/olympia/search/templates/search/collections.html:18
 #: src/olympia/search/templates/search/personas.html:20
 msgid "Search Results"
 msgstr "Výsledky vyhľadávania"
 
 #. {0} is a search term, such as Firebug.
-#: src/olympia/devhub/templates/devhub/devhub_search.html:13
-#: src/olympia/search/templates/search/results.html:11
+#: src/olympia/devhub/templates/devhub/devhub_search.html:13 src/olympia/search/templates/search/results.html:11
 msgid "Search Results for \"{0}\""
 msgstr "Výsledky vyhľadávania pre \"{0}\""
 
@@ -5064,12 +4084,8 @@ msgid "AMO Reviewers"
 msgstr "Redaktori AMO"
 
 #: src/olympia/devhub/templates/devhub/index.html:29
-msgid ""
-"Get ahead! Become an AMO Reviewer today and get your add-ons reviewed "
-"faster."
-msgstr ""
-"Zapojte sa! Staňte sa redaktorom na AMO ešte dnes a pomôžte s rýchlejšou "
-"kontrolou doplnkov."
+msgid "Get ahead! Become an AMO Reviewer today and get your add-ons reviewed faster."
+msgstr "Zapojte sa! Staňte sa redaktorom na AMO ešte dnes a pomôžte s rýchlejšou kontrolou doplnkov."
 
 #: src/olympia/devhub/templates/devhub/index.html:32
 msgid "Become an AMO Reviewer"
@@ -5081,33 +4097,25 @@ msgstr "Dozvedieť sa všetky informácie o doplnkoch"
 
 #: src/olympia/devhub/templates/devhub/index.html:41
 msgid ""
-"Add-ons let millions of Firefox users enhance and customize their browsing "
-"experience. If you're a Web developer and know <a "
-"href=\"https://developer.mozilla.org/docs/Web/HTML\">HTML</a>, <a "
-"href=\"https://developer.mozilla.org/docs/Web/JavaScript\">JavaScript</a>, "
-"and <a href=\"https://developer.mozilla.org/docs/Web/CSS\">CSS</a>, you "
-"already have all the necessary skills to make a great add-on."
+"Add-ons let millions of Firefox users enhance and customize their browsing experience. If you're a Web developer and know <a href=\"https://developer.mozilla.org/docs/Web/HTML\">HTML</a>, <a "
+"href=\"https://developer.mozilla.org/docs/Web/JavaScript\">JavaScript</a>, and <a href=\"https://developer.mozilla.org/docs/Web/CSS\">CSS</a>, you already have all the necessary skills to make a "
+"great add-on."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/index.html:51
-msgid ""
-"Head over to the <a href=\"https://developer.mozilla.org/Add-ons\">Mozilla "
-"Developer Network</a> to learn everything you need to know to get started."
+msgid "Head over to the <a href=\"https://developer.mozilla.org/Add-ons\">Mozilla Developer Network</a> to learn everything you need to know to get started."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/index.html:58
 msgid "Start Making Add-ons"
 msgstr "Začať s tvorbou doplnkov"
 
-#: src/olympia/devhub/templates/devhub/index.html:86
-#: src/olympia/devhub/templates/devhub/addons/listing/items.html:25
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:15
+#: src/olympia/devhub/templates/devhub/index.html:86 src/olympia/devhub/templates/devhub/addons/listing/items.html:25 src/olympia/devhub/templates/devhub/includes/addon_details.html:20
 #: src/olympia/devhub/templates/devhub/personas/edit.html:43
 msgid "Status:"
 msgstr "Stav:"
 
-#: src/olympia/devhub/templates/devhub/index.html:90
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:100
+#: src/olympia/devhub/templates/devhub/index.html:90 src/olympia/devhub/templates/devhub/includes/addon_details.html:87
 msgid "Visibility:"
 msgstr "Viditeľnosť:"
 
@@ -5115,21 +4123,16 @@ msgstr "Viditeľnosť:"
 msgid "Latest Version:"
 msgstr "Posledná verzia:"
 
-#: src/olympia/devhub/templates/devhub/index.html:109
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:145
-#: src/olympia/devhub/templates/devhub/personas/edit.html:49
+#: src/olympia/devhub/templates/devhub/index.html:109 src/olympia/devhub/templates/devhub/includes/addon_details.html:131 src/olympia/devhub/templates/devhub/personas/edit.html:49
 msgid "Queue Position:"
 msgstr "Pozícia vo fronte:"
 
-#: src/olympia/devhub/templates/devhub/index.html:110
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:146
-#: src/olympia/devhub/templates/devhub/personas/edit.html:50
+#: src/olympia/devhub/templates/devhub/index.html:110 src/olympia/devhub/templates/devhub/includes/addon_details.html:132 src/olympia/devhub/templates/devhub/personas/edit.html:50
 #, python-format
 msgid "%(position)s of %(total)s"
 msgstr "%(position)s z %(total)s"
 
-#: src/olympia/devhub/templates/devhub/index.html:120
-#: src/olympia/devhub/templates/devhub/includes/addons_edit_nav.html:19
+#: src/olympia/devhub/templates/devhub/index.html:120 src/olympia/devhub/templates/devhub/includes/addons_edit_nav.html:19
 msgid "Upload New Version"
 msgstr "Odoslať novú verziu"
 
@@ -5143,9 +4146,7 @@ msgstr "Publikujte svoj doplnok!"
 
 #: src/olympia/devhub/templates/devhub/index.html:136
 #, python-format
-msgid ""
-"Upload an <a href=\"%(addon_url)s\">add-on</a> or <a "
-"href=\"%(theme_url)s\">theme</a> to get started!"
+msgid "Upload an <a href=\"%(addon_url)s\">add-on</a> or <a href=\"%(theme_url)s\">theme</a> to get started!"
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/nav.html:2
@@ -5173,17 +4174,10 @@ msgstr "Vývoj doplnkov"
 msgid "Lightweight Themes"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/nav.html:39
-#: src/olympia/devhub/templates/devhub/docs/policies-agreement.html:6
-#: src/olympia/devhub/templates/devhub/docs/policies-contact.html:6
-#: src/olympia/devhub/templates/devhub/docs/policies-maintenance.html:6
-#: src/olympia/devhub/templates/devhub/docs/policies-recommended.html:6
-#: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:6
-#: src/olympia/devhub/templates/devhub/docs/policies-submission.html:6
-#: src/olympia/devhub/templates/devhub/docs/policies.html:3
-#: src/olympia/devhub/templates/devhub/docs/policies.html:9
-#: src/olympia/devhub/templates/devhub/docs/policies.html:38
-#: src/olympia/devhub/templates/devhub/docs/policies.html:39
+#: src/olympia/devhub/templates/devhub/nav.html:39 src/olympia/devhub/templates/devhub/docs/policies-agreement.html:6 src/olympia/devhub/templates/devhub/docs/policies-contact.html:6
+#: src/olympia/devhub/templates/devhub/docs/policies-maintenance.html:6 src/olympia/devhub/templates/devhub/docs/policies-recommended.html:6
+#: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:6 src/olympia/devhub/templates/devhub/docs/policies-submission.html:6 src/olympia/devhub/templates/devhub/docs/policies.html:3
+#: src/olympia/devhub/templates/devhub/docs/policies.html:9 src/olympia/devhub/templates/devhub/docs/policies.html:38 src/olympia/devhub/templates/devhub/docs/policies.html:39
 msgid "Add-on Policies"
 msgstr "Zásady tvorby a správy doplnkov"
 
@@ -5225,40 +4219,15 @@ msgid "Use the field below to upload your add-on package."
 msgstr "Pre načítanie vášho doplnku použite pole nižšie."
 
 #: src/olympia/devhub/templates/devhub/validate_addon.html:19
-msgid ""
-"After upload, a series of automated validation tests will run to check "
-"compatibility with the following application version:"
-msgstr ""
-"Po načítaní bude spustená sada automatizovaných testov, ktoré skontrolujú "
-"kompatibilitu s nasledujúcou verziou aplikácie:"
+msgid "After upload, a series of automated validation tests will run to check compatibility with the following application version:"
+msgstr "Po načítaní bude spustená sada automatizovaných testov, ktoré skontrolujú kompatibilitu s nasledujúcou verziou aplikácie:"
 
 #: src/olympia/devhub/templates/devhub/validate_addon.html:34
-msgid ""
-"After upload, a series of automated validation tests will be run on your "
-"file."
-msgstr ""
-"Po načítaní bude na vašom súbore spustená sada automatizovaných testov."
+msgid "After upload, a series of automated validation tests will be run on your file."
+msgstr "Po načítaní bude na vašom súbore spustená sada automatizovaných testov."
 
-#: src/olympia/devhub/templates/devhub/validate_addon.html:42
-#: src/olympia/devhub/templates/devhub/addons/submit/upload.html:23
+#: src/olympia/devhub/templates/devhub/validate_addon.html:42 src/olympia/devhub/templates/devhub/addons/submit/upload.html:23
 msgid "Do you want your add-on to be distributed on this site?"
-msgstr ""
-
-#: src/olympia/devhub/templates/devhub/validate_addon.html:49
-#: src/olympia/devhub/templates/devhub/addons/submit/upload.html:30
-#: src/olympia/devhub/templates/devhub/versions/add_file_modal.html:14
-#: src/olympia/devhub/templates/devhub/versions/add_file_modal.html:53
-#: src/olympia/devhub/templates/devhub/versions/list.html:298
-msgid "Warning:"
-msgstr "Varovanie:"
-
-#: src/olympia/devhub/templates/devhub/validate_addon.html:50
-#: src/olympia/devhub/templates/devhub/addons/submit/upload.html:31
-#, python-format
-msgid ""
-"Submission of unlisted add-ons for signing is currently in an open beta. "
-"Please <a href=\"%(url)s\" target=\"_blank\">report any bugs</a> that you "
-"encounter."
 msgstr ""
 
 #. first parameter is a filename like lorem-ipsum-1.0.2.xpi
@@ -5278,14 +4247,11 @@ msgstr "Overené dňa:"
 msgid "Tested for compatibility against:"
 msgstr "Kompatibilita otestovaná proti:"
 
-#: src/olympia/devhub/templates/devhub/addons/activity.html:4
-#: src/olympia/devhub/templates/devhub/addons/activity.html:20
+#: src/olympia/devhub/templates/devhub/addons/activity.html:4 src/olympia/devhub/templates/devhub/addons/activity.html:20
 msgid "Recent Activity for My Add-ons"
 msgstr "Posledná aktivita pre moje doplnky"
 
-#: src/olympia/devhub/templates/devhub/addons/activity.html:14
-#: src/olympia/devhub/templates/devhub/addons/activity.html:19
-#: src/olympia/devhub/templates/devhub/addons/dashboard.html:33
+#: src/olympia/devhub/templates/devhub/addons/activity.html:14 src/olympia/devhub/templates/devhub/addons/activity.html:19 src/olympia/devhub/templates/devhub/addons/dashboard.html:33
 msgid "Recent Activity"
 msgstr "Posledná aktivita"
 
@@ -5297,9 +4263,7 @@ msgstr "Posledná aktivita pre {0}"
 #: src/olympia/devhub/templates/devhub/addons/activity.html:36
 #, python-format
 msgid "<time datetime=\"%(iso)s\" title=\"%(pretty)s\">%(ago)s</time> by %(user)s"
-msgstr ""
-"<time datetime=\"%(iso)s\" title=\"%(pretty)s\">%(ago)s</time>, autor "
-"%(user)s"
+msgstr "<time datetime=\"%(iso)s\" title=\"%(pretty)s\">%(ago)s</time>, autor %(user)s"
 
 #: src/olympia/devhub/templates/devhub/addons/activity.html:59
 msgid "Refine Activity"
@@ -5309,44 +4273,32 @@ msgstr "Upresnenie aktivity"
 msgid "Activity"
 msgstr "Aktivita"
 
-#: src/olympia/devhub/templates/devhub/addons/activity.html:83
-#: src/olympia/devhub/templates/devhub/addons/dashboard.html:34
-#: src/olympia/devhub/templates/devhub/addons/dashboard.html:35
-#: src/olympia/devhub/templates/devhub/includes/blog_posts.html:4
-#: src/olympia/devhub/templates/devhub/includes/blog_posts.html:6
+#: src/olympia/devhub/templates/devhub/addons/activity.html:83 src/olympia/devhub/templates/devhub/addons/dashboard.html:34 src/olympia/devhub/templates/devhub/addons/dashboard.html:35
+#: src/olympia/devhub/templates/devhub/includes/blog_posts.html:4 src/olympia/devhub/templates/devhub/includes/blog_posts.html:6
 msgid "Subscribe to this feed"
 msgstr "Odoberať tento kanál"
 
 #: src/olympia/devhub/templates/devhub/addons/ajax_compat_error.html:7
 #, python-format
 msgid ""
-"This add-on is incompatible with <b>%(app_name)s %(app_version)s</b>, the "
-"latest release of %(app_name)s. Please consider updating your add-on's "
-"compatibility info, or uploading a newer version of this add-on."
-msgstr ""
-"Tento doplnok nie je kompatibilný s <b>%(app_name)s %(app_version)s</b>, "
-"najnovšou verziou aplikácie %(app_name)s. Zvážte aktualizáciu kompatibility "
-"doplnku alebo odošlite novú verziu tohto doplnku."
+"This add-on is incompatible with <b>%(app_name)s %(app_version)s</b>, the latest release of %(app_name)s. Please consider updating your add-on's compatibility info, or uploading a newer version of "
+"this add-on."
+msgstr "Tento doplnok nie je kompatibilný s <b>%(app_name)s %(app_version)s</b>, najnovšou verziou aplikácie %(app_name)s. Zvážte aktualizáciu kompatibility doplnku alebo odošlite novú verziu tohto doplnku."
 
 #: src/olympia/devhub/templates/devhub/addons/ajax_compat_error.html:15
 #, python-format
 msgid ""
-"<a href=\"#\" class=\"button compat-update\" data-"
-"updateurl=\"%(update_url)s\">Update Compatibility</a> <a "
-"href=\"%(version_url)s\" class=\"button\">Upload New Version</a> or <a "
-"href=\"#\" class=\"close\">Ignore</a>"
+"<a href=\"#\" class=\"button compat-update\" data-updateurl=\"%(update_url)s\">Update Compatibility</a> <a href=\"%(version_url)s\" class=\"button\">Upload New Version</a> or <a href=\"#\" "
+"class=\"close\">Ignore</a>"
 msgstr ""
-"<a href=\"#\" class=\"button compat-update\" data-"
-"updateurl=\"%(update_url)s\">Aktualizovať kompatibilitu</a> <a "
-"href=\"%(version_url)s\" class=\"button\">Odoslať novú verziu</a> alebo <a "
+"<a href=\"#\" class=\"button compat-update\" data-updateurl=\"%(update_url)s\">Aktualizovať kompatibilitu</a> <a href=\"%(version_url)s\" class=\"button\">Odoslať novú verziu</a> alebo <a "
 "href=\"#\" class=\"close\">Ignorovať</a>"
 
 #: src/olympia/devhub/templates/devhub/addons/ajax_compat_status.html:5
 msgid "View and update application compatibility ranges."
 msgstr "Zobraziť a aktualizovať rozsahy kompatibility aplikácií."
 
-#: src/olympia/devhub/templates/devhub/addons/ajax_compat_status.html:6
-#: src/olympia/devhub/templates/devhub/versions/edit.html:44
+#: src/olympia/devhub/templates/devhub/addons/ajax_compat_status.html:6 src/olympia/devhub/templates/devhub/versions/edit.html:44
 msgid "Compatibility"
 msgstr "Kompatibilita"
 
@@ -5354,39 +4306,25 @@ msgstr "Kompatibilita"
 msgid "Update Compatibility"
 msgstr "Aktualizovať kompatibilitu"
 
-#: src/olympia/devhub/templates/devhub/addons/ajax_compat_update.html:4
-msgid ""
-"Adjusting application information here will allow users to install your add-"
-"on even if the install manifest in the package indicates that the add-on is "
-"incompatible."
-msgstr ""
-"Tu zadané informácie o aplikácií umožňujú používateľom nainštalovať doplnok "
-"aj vtedy, keď inštalačný manifest v balíku uvádza, že doplnok nie je "
-"kompatibilný."
+#: src/olympia/devhub/templates/devhub/addons/ajax_compat_update.html:4 src/olympia/devhub/templates/devhub/versions/edit.html:45
+msgid "Adjusting application information here will allow users to install your add-on even if the install manifest in the package indicates that the add-on is incompatible."
+msgstr "Tu zadané informácie o aplikácií umožňujú používateľom nainštalovať doplnok aj vtedy, keď inštalačný manifest v balíku uvádza, že doplnok nie je kompatibilný."
 
 #: src/olympia/devhub/templates/devhub/addons/ajax_compat_update.html:18
 msgid "Supported Versions"
 msgstr "Podporované verzie"
 
-#: src/olympia/devhub/templates/devhub/addons/ajax_compat_update.html:31
-#: src/olympia/devhub/templates/devhub/versions/edit.html:63
+#: src/olympia/devhub/templates/devhub/addons/ajax_compat_update.html:31 src/olympia/devhub/templates/devhub/versions/edit.html:63
 msgid "Add Another Application&hellip;"
 msgstr "Pridať ďalšiu aplikáciu&hellip;"
 
-#: src/olympia/devhub/templates/devhub/addons/ajax_compat_update.html:38
-#: src/olympia/devhub/templates/devhub/addons/owner.html:86
-#: src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:46
-#: src/olympia/devhub/templates/devhub/versions/list.html:351
-#: src/olympia/devhub/templates/devhub/versions/list.html:353
-#: src/olympia/templates/impala/base.html:132
-#: src/olympia/templates/impala/base.html:143
-#: src/olympia/templates/impala/base.html:161
-#: src/olympia/templates/impala/base.html:171
+#: src/olympia/devhub/templates/devhub/addons/ajax_compat_update.html:38 src/olympia/devhub/templates/devhub/addons/owner.html:86 src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:45
+#: src/olympia/devhub/templates/devhub/versions/list.html:349 src/olympia/devhub/templates/devhub/versions/list.html:351 src/olympia/templates/impala/base.html:129
+#: src/olympia/templates/impala/base.html:140 src/olympia/templates/impala/base.html:158 src/olympia/templates/impala/base.html:168
 msgid "Close"
 msgstr "Zavrieť"
 
-#: src/olympia/devhub/templates/devhub/addons/dashboard.html:43
-#: src/olympia/zadmin/templates/zadmin/index.html:22
+#: src/olympia/devhub/templates/devhub/addons/dashboard.html:43 src/olympia/zadmin/templates/zadmin/index.html:22
 #, python-format
 msgid "%(ago)s by %(user)s"
 msgstr "%(ago)s, autor %(user)s"
@@ -5401,31 +4339,22 @@ msgid "<b>{0}</b> theme"
 msgid_plural "<b>{0}</b> themes"
 msgstr[0] "<b>{0}</b> téma vzhľadu"
 msgstr[1] "<b>{0}</b> témy vzhľadu"
-msgstr[2] "<b>{0}</b> tém vzhľadu"
 
-#: src/olympia/devhub/templates/devhub/addons/edit.html:3
-#: src/olympia/devhub/templates/devhub/addons/listing/item_actions.html:25
-#: src/olympia/devhub/templates/devhub/addons/listing/item_actions_theme.html:7
-#: src/olympia/devhub/templates/devhub/includes/addons_edit_nav.html:2
-#: src/olympia/devhub/templates/devhub/personas/edit.html:6
-#: src/olympia/editors/templates/editors/themes/single.html:37
+#: src/olympia/devhub/templates/devhub/addons/edit.html:3 src/olympia/devhub/templates/devhub/addons/listing/item_actions.html:25
+#: src/olympia/devhub/templates/devhub/addons/listing/item_actions_theme.html:7 src/olympia/devhub/templates/devhub/includes/addons_edit_nav.html:2
+#: src/olympia/devhub/templates/devhub/personas/edit.html:6 src/olympia/editors/templates/editors/themes/single.html:37
 msgid "Edit Listing"
 msgstr "Upraviť údaje"
 
-#: src/olympia/devhub/templates/devhub/addons/edit.html:13
-#: src/olympia/devhub/templates/devhub/includes/macros.html:18
-#: src/olympia/translations/templates/translations/all-locales.html:6
+#: src/olympia/devhub/templates/devhub/addons/edit.html:13 src/olympia/devhub/templates/devhub/includes/macros.html:18 src/olympia/translations/templates/translations/all-locales.html:6
 msgid "None"
 msgstr "Žiadne"
 
-#: src/olympia/devhub/templates/devhub/addons/owner.html:4
-#: src/olympia/devhub/templates/devhub/addons/listing/item_actions.html:52
-#: src/olympia/devhub/templates/devhub/includes/addons_edit_nav.html:3
+#: src/olympia/devhub/templates/devhub/addons/owner.html:4 src/olympia/devhub/templates/devhub/addons/listing/item_actions.html:52 src/olympia/devhub/templates/devhub/includes/addons_edit_nav.html:3
 msgid "Manage Authors & License"
 msgstr "Správa autorov a licencie"
 
-#: src/olympia/devhub/templates/devhub/addons/owner.html:29
-#: src/olympia/editors/templates/editors/review.html:270
+#: src/olympia/devhub/templates/devhub/addons/owner.html:29 src/olympia/editors/helpers.py:362 src/olympia/editors/templates/editors/review.html:270
 msgid "Authors"
 msgstr "Autori"
 
@@ -5435,34 +4364,22 @@ msgstr "O roliach autorov"
 
 #: src/olympia/devhub/templates/devhub/addons/owner.html:78
 msgid ""
-"<p>Add-ons can have any number of authors with 3 possible roles:</p> <ul> "
-"<li><b>Owner:</b> Can manage all aspects of the add-on's listing, including "
-"adding and removing other authors</li> <li><b>Developer:</b> Can manage all "
-"aspects of the add-on's listing, except for adding and removing other "
-"authors and managing payments</li> <li><b>Viewer:</b> Can view the add-on's "
-"settings and statistics, but cannot make any changes</li> </ul>"
+"<p>Add-ons can have any number of authors with 3 possible roles:</p> <ul> <li><b>Owner:</b> Can manage all aspects of the add-on's listing, including adding and removing other authors</li> "
+"<li><b>Developer:</b> Can manage all aspects of the add-on's listing, except for adding and removing other authors and managing payments</li> <li><b>Viewer:</b> Can view the add-on's settings and "
+"statistics, but cannot make any changes</li> </ul>"
 msgstr ""
-"<p>Doplnky môžu mať viac autorov a to v 3 definovaných roliach: </p><ul> "
-"<li><b>Vlastník:</b> Môže spravovať všetko, čo sa týka stránky doplnku, a "
-"pridávať či odoberať iných autorov.</li> <li><b>Vývojár</b> Môže spravovať "
-"všetko, čo sa týka stránky doplnku, s výnimkou pridávania/odoberania autorov"
-" a správy platieb.</li> <li><b>Pozorovateľ:</b> Môže zobraziť nastavenia "
-"doplnku a jeho štatistiky, ale nesmie robiť žiadne zmeny.</li> </ul>"
+"<p>Doplnky môžu mať viac autorov a to v 3 definovaných roliach: </p><ul> <li><b>Vlastník:</b> Môže spravovať všetko, čo sa týka stránky doplnku, a pridávať či odoberať iných autorov.</li> "
+"<li><b>Vývojár</b> Môže spravovať všetko, čo sa týka stránky doplnku, s výnimkou pridávania/odoberania autorov a správy platieb.</li> <li><b>Pozorovateľ:</b> Môže zobraziť nastavenia doplnku a jeho"
+" štatistiky, ale nesmie robiť žiadne zmeny.</li> </ul>"
 
-#: src/olympia/devhub/templates/devhub/addons/profile.html:3
-#: src/olympia/devhub/templates/devhub/addons/listing/item_actions.html:53
-#: src/olympia/devhub/templates/devhub/includes/addons_edit_nav.html:4
+#: src/olympia/devhub/templates/devhub/addons/profile.html:3 src/olympia/devhub/templates/devhub/addons/listing/item_actions.html:53 src/olympia/devhub/templates/devhub/includes/addons_edit_nav.html:4
 msgid "Manage Developer Profile"
 msgstr "Správa profilu vývojára"
 
 #: src/olympia/devhub/templates/devhub/addons/profile.html:16
 #, python-format
-msgid ""
-"Your <a href=\"%(url)s\">developer profile</a> is currently "
-"<strong>public</strong> and <strong>required</strong> for contributions."
-msgstr ""
-"Váš <a href=\"%(url)s\">profil vývojára</a> je momentálne "
-"<strong>verejný</strong> a <strong>vyžadovaný</strong> pre príspevky."
+msgid "Your <a href=\"%(url)s\">developer profile</a> is currently <strong>public</strong> and <strong>required</strong> for contributions."
+msgstr "Váš <a href=\"%(url)s\">profil vývojára</a> je momentálne <strong>verejný</strong> a <strong>vyžadovaný</strong> pre príspevky."
 
 #: src/olympia/devhub/templates/devhub/addons/profile.html:22
 msgid "Remove Both"
@@ -5470,12 +4387,8 @@ msgstr "Odstrániť obe"
 
 #: src/olympia/devhub/templates/devhub/addons/profile.html:27
 #, python-format
-msgid ""
-"Your <a href=\"%(url)s\">developer profile</a> is currently "
-"<strong>public</strong>."
-msgstr ""
-"Váš <a href=\"%(url)s\">profil vývojára</a> je momentálne "
-"<strong>verejný</strong>."
+msgid "Your <a href=\"%(url)s\">developer profile</a> is currently <strong>public</strong>."
+msgstr "Váš <a href=\"%(url)s\">profil vývojára</a> je momentálne <strong>verejný</strong>."
 
 #: src/olympia/devhub/templates/devhub/addons/profile.html:33
 msgid "Remove Profile"
@@ -5502,11 +4415,8 @@ msgstr "URL adresa doplnku"
 msgid "Choose a short, unique URL slug for your add-on."
 msgstr "Zvoľte krátku, unikátnu adresu URL pre svoj doplnok."
 
-#: src/olympia/devhub/templates/devhub/addons/edit/basic.html:43
-#: src/olympia/devhub/templates/devhub/includes/addons_edit_nav.html:35
-#: src/olympia/devhub/templates/devhub/personas/edit.html:56
-#: src/olympia/editors/templates/editors/review.html:255
-#: src/olympia/editors/templates/editors/themes/single.html:33
+#: src/olympia/devhub/templates/devhub/addons/edit/basic.html:43 src/olympia/devhub/templates/devhub/includes/addons_edit_nav.html:35 src/olympia/devhub/templates/devhub/personas/edit.html:56
+#: src/olympia/editors/templates/editors/review.html:255 src/olympia/editors/templates/editors/themes/single.html:33
 msgid "View Listing"
 msgstr "Zobraziť doplnok"
 
@@ -5515,51 +4425,31 @@ msgid "Summary"
 msgstr "Súhrn"
 
 #: src/olympia/devhub/templates/devhub/addons/edit/basic.html:52
-msgid ""
-"A short explanation of your add-on's basic\n"
-"                          functionality that is displayed in search and browse\n"
-"                          listings, as well as at the top of your add-on's\n"
-"                          details page. It is only relevant for listed add-ons."
+msgid "A short explanation of your add-on's basic functionality that is displayed in search and browse listings, as well as at the top of your add-on's details page. It is only relevant for listed add-ons."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/basic.html:73
-msgid ""
-"Categories are the primary way users browse through add-ons.\n"
-"                        Choose any that fit your add-on's functionality for the most\n"
-"                        exposure. It is only relevant for listed add-ons."
+msgid "Categories are the primary way users browse through add-ons. Choose any that fit your add-on's functionality for the most exposure. It is only relevant for listed add-ons."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/basic.html:90
 #, python-format
-msgid ""
-"Categories cannot be changed while your add-on is featured for this "
-"application. Please email <a href=\"mailto:%(email)s\">%(email)s</a> if "
-"there is a reason you need to modify your categories."
+msgid "Categories cannot be changed while your add-on is featured for this application. Please email <a href=\"mailto:%(email)s\">%(email)s</a> if there is a reason you need to modify your categories."
 msgstr ""
-"Ak je doplnok pre túto aplikáciu vedený ako odporúčaný, nemôžete meniť jeho "
-"umiestnenie v kategóriách. Ak máte dôvod, prečo chcete kategórie upraviť, "
-"napíšte nám na e-mail <a href=\"mailto:%(email)s\">%(email)s</a>."
+"Ak je doplnok pre túto aplikáciu vedený ako odporúčaný, nemôžete meniť jeho umiestnenie v kategóriách. Ak máte dôvod, prečo chcete kategórie upraviť, napíšte nám na e-mail <a "
+"href=\"mailto:%(email)s\">%(email)s</a>."
 
 #: src/olympia/devhub/templates/devhub/addons/edit/basic.html:119
-msgid ""
-"Tags help users find your add-on and should be short\n"
-"                        descriptors such as tabs, toolbar, or twitter.  You\n"
-"                        may have a maximum of {0} tags. It is only relevant\n"
-"                        for listed add-ons."
+msgid "Tags help users find your add-on and should be short descriptors such as tabs, toolbar, or twitter. You may have a maximum of {0} tags. It is only relevant for listed add-ons."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/addons/edit/basic.html:129
-#: src/olympia/devhub/templates/devhub/personas/edit.html:97
-#: src/olympia/devhub/templates/devhub/personas/submit.html:46
+#: src/olympia/devhub/templates/devhub/addons/edit/basic.html:129 src/olympia/devhub/templates/devhub/personas/edit.html:97 src/olympia/devhub/templates/devhub/personas/submit.html:46
 msgid "Comma-separated, minimum of {0} character."
 msgid_plural "Comma-separated, minimum of {0} characters."
 msgstr[0] "Oddelené čiarkou, minimálne {0} znak."
 msgstr[1] "Oddelené čiarkou, minimálne {0} znaky."
-msgstr[2] "Oddelené čiarkou, minimálne {0} znakov."
 
-#: src/olympia/devhub/templates/devhub/addons/edit/basic.html:132
-#: src/olympia/devhub/templates/devhub/personas/edit.html:100
-#: src/olympia/devhub/templates/devhub/personas/submit.html:49
+#: src/olympia/devhub/templates/devhub/addons/edit/basic.html:132 src/olympia/devhub/templates/devhub/personas/edit.html:100 src/olympia/devhub/templates/devhub/personas/submit.html:49
 msgid "Example: dark, cinema, noir. Limit 20."
 msgstr "Príklad: dark, cinema, noir. Maximálne 20."
 
@@ -5568,7 +4458,6 @@ msgid "Reserved tag:"
 msgid_plural "Reserved tags:"
 msgstr[0] "Rezervovaná značka:"
 msgstr[1] "Rezervované značky:"
-msgstr[2] "Rezervované značky:"
 
 #: src/olympia/devhub/templates/devhub/addons/edit/details.html:5
 msgid "Add-on Details"
@@ -5579,39 +4468,26 @@ msgid "Add-on Details for {0}"
 msgstr "Podrobnosti o doplnku {0}"
 
 #: src/olympia/devhub/templates/devhub/addons/edit/details.html:22
-msgid ""
-"A longer explanation of features,\n"
-"                          functionality, and other relevant information. This\n"
-"                          field is only displayed on the add-on's details\n"
-"                          page. It is only relevant for listed add-ons."
+msgid "A longer explanation of features, functionality, and other relevant information. This field is only displayed on the add-on's details page. It is only relevant for listed add-ons."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/addons/edit/details.html:44
-#: src/olympia/translations/templates/translations/trans-menu.html:13
+#: src/olympia/devhub/templates/devhub/addons/edit/details.html:44 src/olympia/translations/templates/translations/trans-menu.html:13
 msgid "Default Locale"
 msgstr "Predvolený jazyk"
 
 #: src/olympia/devhub/templates/devhub/addons/edit/details.html:45
-msgid ""
-"Information about your add-on is displayed in this locale\n"
-"                        unless you override it with a locale-specific translation.\n"
-"                        It is only relevant for listed add-ons."
+msgid "Information about your add-on is displayed in this locale unless you override it with a locale-specific translation. It is only relevant for listed add-ons."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/addons/edit/details.html:61
-#: src/olympia/users/forms.py:311
-#: src/olympia/users/templates/users/edit.html:122
-#: src/olympia/users/templates/users/register.html:57
+#: src/olympia/devhub/templates/devhub/addons/edit/details.html:61 src/olympia/users/forms.py:311 src/olympia/users/templates/users/edit.html:122 src/olympia/users/templates/users/register.html:57
 #: src/olympia/users/templates/users/vcard.html:22
 msgid "Homepage"
 msgstr "Domovská stránka"
 
 #: src/olympia/devhub/templates/devhub/addons/edit/details.html:63
 msgid ""
-"If your add-on has another homepage, enter its\n"
-"                          address here. If your website is localized into other\n"
-"                          languages multiple translations of this field can be\n"
-"                          added. It is only relevant for listed add-ons."
+"If your add-on has another homepage, enter its address here. If your website is localized into other languages multiple translations of this field can be added. It is only relevant for listed add-"
+"ons."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/media.html:3
@@ -5629,19 +4505,14 @@ msgstr "Informácie o podpore pre doplnok {0}"
 
 #: src/olympia/devhub/templates/devhub/addons/edit/support.html:22
 msgid ""
-"If you wish to display an e-mail address for support\n"
-"                          inquiries, enter it here. If you have different\n"
-"                          addresses for each language multiple translations of\n"
-"                          this field can be added. It is only relevant for\n"
-"                          listed add-ons."
+"If you wish to display an e-mail address for support inquiries, enter it here. If you have different addresses for each language multiple translations of this field can be added. It is only "
+"relevant for listed add-ons."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/support.html:45
 msgid ""
-"If your add-on has a support website or forum, enter\n"
-"                          its address here. If your website is localized into\n"
-"                          other languages, multiple translations of this field can\n"
-"                          be added. It is only relevant for listed add-ons."
+"If your add-on has a support website or forum, enter its address here. If your website is localized into other languages, multiple translations of this field can be added. It is only relevant for "
+"listed add-ons."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:6
@@ -5655,11 +4526,8 @@ msgstr "Technické podrobnosti pre {0}"
 
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:23
 msgid ""
-"Any information end users may want to know that isn't\n"
-"                          necessarily applicable to the add-on summary or description.\n"
-"                          Common uses include listing known major bugs, information on\n"
-"                          how to report bugs, anticipated release date of a new version,\n"
-"                          etc. It is only relevant for listed add-ons."
+"Any information end users may want to know that isn't necessarily applicable to the add-on summary or description. Common uses include listing known major bugs, information on how to report bugs, "
+"anticipated release date of a new version, etc. It is only relevant for listed add-ons."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:46
@@ -5671,9 +4539,7 @@ msgid "Add-on Flags"
 msgstr "Označenia doplnku"
 
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:69
-msgid ""
-"These flags are used to classify add-ons. It is only\n"
-"                        relevant for listed add-ons."
+msgid "These flags are used to classify add-ons. It is only relevant for listed add-ons."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:74
@@ -5689,9 +4555,7 @@ msgid "View Source?"
 msgstr "Zobraziť zdrojový kód?"
 
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:90
-msgid ""
-"Whether the source of your add-on can be displayed in our\n"
-"                        online viewer. It is only relevant for listed add-ons."
+msgid "Whether the source of your add-on can be displayed in our online viewer. It is only relevant for listed add-ons."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:94
@@ -5707,10 +4571,7 @@ msgid "Public Stats?"
 msgstr "Zverejniť štatistiky?"
 
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:102
-msgid ""
-"Whether the download and usage stats of your add-on can\n"
-"                        be displayed in our online viewer.\n"
-"                        It is only relevant for listed add-ons."
+msgid "Whether the download and usage stats of your add-on can be displayed in our online viewer. It is only relevant for listed add-ons."
 msgstr ""
 
 # 76%
@@ -5728,18 +4589,12 @@ msgid "Upgrade SDK?"
 msgstr "Aktualizovať SDK?"
 
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:116
-msgid ""
-"If selected, we will try to automatically upgrade your\n"
-"                        add-on when a new version of the SDK is released.\n"
-"                        It is only relevant for listed add-ons."
+msgid "If selected, we will try to automatically upgrade your add-on when a new version of the SDK is released. It is only relevant for listed add-ons."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:121
-msgid ""
-"This add-on will be automatically upgraded to new versions of the Add-on "
-"SDK."
-msgstr ""
-"Tento doplnok bude automaticky aktualizovaný na najnovšie verzie Add-on SDK."
+msgid "This add-on will be automatically upgraded to new versions of the Add-on SDK."
+msgstr "Tento doplnok bude automaticky aktualizovaný na najnovšie verzie Add-on SDK."
 
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:123
 msgid "No, this add-on will be upgraded manually."
@@ -5754,30 +4609,20 @@ msgid "UUID"
 msgstr "UUID"
 
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:132
-msgid ""
-"The UUID of your add-on is specified in its install manifest and uniquely "
-"identifies it. You cannot change your UUID once it has been submitted."
-msgstr ""
-"Identifikátor UUID vášho doplnku je zadaný v jeho inštalačnom manifeste a "
-"unikátne doplnok identifikuje. Po odoslaní doplnku nie je možné meniť jeho "
-"identifikátor UUID."
+msgid "The UUID of your add-on is specified in its install manifest and uniquely identifies it. You cannot change your UUID once it has been submitted."
+msgstr "Identifikátor UUID vášho doplnku je zadaný v jeho inštalačnom manifeste a unikátne doplnok identifikuje. Po odoslaní doplnku nie je možné meniť jeho identifikátor UUID."
 
-#: src/olympia/devhub/templates/devhub/addons/edit/technical.html:143
-#: src/olympia/devhub/templates/devhub/addons/edit/technical.html:144
+#: src/olympia/devhub/templates/devhub/addons/edit/technical.html:143 src/olympia/devhub/templates/devhub/addons/edit/technical.html:144
 msgid "Whiteboard"
 msgstr "Poznámka pre redaktora"
 
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:146
 msgid ""
-"The whiteboard is the place to provide information relevant to your addon, "
-"whatever the version, to the editor. Use it to provide ways to test the "
-"addon, and any additional information that may help. This whiteboard is also"
-" editable by editors."
+"The whiteboard is the place to provide information relevant to your addon, whatever the version, to the editor. Use it to provide ways to test the addon, and any additional information that may "
+"help. This whiteboard is also editable by editors."
 msgstr ""
-"Poznámka pre redaktora je miesto, kde môžete poskytnúť relevantné informácie"
-" o vašom doplnku redaktorovi. Používajte ho pre informácie typu, ako doplnok"
-" testovať a iné informácie, ktoré by mohli byť nápomocné. Túto poznámku môže"
-" redaktor upravovať."
+"Poznámka pre redaktora je miesto, kde môžete poskytnúť relevantné informácie o vašom doplnku redaktorovi. Používajte ho pre informácie typu, ako doplnok testovať a iné informácie, ktoré by mohli "
+"byť nápomocné. Túto poznámku môže redaktor upravovať."
 
 #: src/olympia/devhub/templates/devhub/addons/edit/technical_dependencies.html:9
 msgid "Remove this dependent add-on"
@@ -5797,10 +4642,8 @@ msgstr "Ikona doplnku"
 
 #: src/olympia/devhub/templates/devhub/addons/forms_shared/media.html:16
 msgid ""
-"Upload an icon for your add-on or choose from one of ours. The\n"
-"                      icon is displayed nearly everywhere your add-on is. Uploaded images\n"
-"                      must be one of the following image types: .png, .jpg.\n"
-"                      It is only relevant for listed add-ons."
+"Upload an icon for your add-on or choose from one of ours. The icon is displayed nearly everywhere your add-on is. Uploaded images must be one of the following image types: .png, .jpg. It is only "
+"relevant for listed add-ons."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/forms_shared/media.html:25
@@ -5814,9 +4657,7 @@ msgstr "32x32 bodov"
 
 #: src/olympia/devhub/templates/devhub/addons/forms_shared/media.html:39
 msgid "Used in listings of add-ons, like search results and featured add-ons."
-msgstr ""
-"Použitá v zoznamoch doplnkov, ako napr. výsledky vyhľadávania alebo zoznam "
-"odporúčaných doplnkov."
+msgstr "Použitá v zoznamoch doplnkov, ako napr. výsledky vyhľadávania alebo zoznam odporúčaných doplnkov."
 
 #. The size of the icon
 #: src/olympia/devhub/templates/devhub/addons/forms_shared/media.html:48
@@ -5833,9 +4674,7 @@ msgstr "Odoslať vlastnú ikonu..."
 
 #: src/olympia/devhub/templates/devhub/addons/forms_shared/media.html:65
 msgid "PNG and JPG supported. Icons resized to 64x64 pixels if larger."
-msgstr ""
-"Podporované formáty: PNG a JPG. Ikony budú zmenšené na 64x64 bodov v "
-"prípade, že sú väčšie."
+msgstr "Podporované formáty: PNG a JPG. Ikony budú zmenšené na 64x64 bodov v prípade, že sú väčšie."
 
 #: src/olympia/devhub/templates/devhub/addons/forms_shared/media.html:83
 msgid "Screenshots"
@@ -5857,60 +4696,49 @@ msgstr "Pridať ukážku..."
 msgid "Tests"
 msgstr "Testy"
 
-#: src/olympia/devhub/templates/devhub/addons/includes/validation_compat_test_results.html:25
-#: src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:5
+#: src/olympia/devhub/templates/devhub/addons/includes/validation_compat_test_results.html:25 src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:5
 #: src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:53
 msgid "General Tests"
 msgstr "Všeobecné testy"
 
-#: src/olympia/devhub/templates/devhub/addons/includes/validation_compat_test_results.html:32
-#: src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:9
+#: src/olympia/devhub/templates/devhub/addons/includes/validation_compat_test_results.html:32 src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:9
 #: src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:67
 msgid "Security Tests"
 msgstr "Bezpečnostné testy"
 
-#: src/olympia/devhub/templates/devhub/addons/includes/validation_compat_test_results.html:39
-#: src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:13
+#: src/olympia/devhub/templates/devhub/addons/includes/validation_compat_test_results.html:39 src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:13
 #: src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:80
 msgid "Extension Tests"
 msgstr "Testy rozšírenia"
 
-#: src/olympia/devhub/templates/devhub/addons/includes/validation_compat_test_results.html:46
-#: src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:17
+#: src/olympia/devhub/templates/devhub/addons/includes/validation_compat_test_results.html:46 src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:17
 #: src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:93
 msgid "Localization Tests"
 msgstr "Testy lokalizácie"
 
-#: src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:21
-#: src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:106
+#: src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:21 src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:106
 msgid "Compatibility Tests"
 msgstr "Testy kompatibility"
 
-#: src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:29
-#: src/olympia/files/templates/files/viewer.html:142
+#: src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:29 src/olympia/files/templates/files/viewer.html:142
 msgid "Hide messages not required for automated signing"
 msgstr "Skryť správy, ktoré nie sú dôležité pre automatické podpísanie"
 
-#: src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:35
-#: src/olympia/files/templates/files/viewer.html:150
+#: src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:35 src/olympia/files/templates/files/viewer.html:150
 msgid "Hide messages present in previous version and ignored"
 msgstr "Skryť správy ignorované v starších verziách"
 
-#: src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:50
-#: src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:64
-#: src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:77
-#: src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:90
+#: src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:50 src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:64
+#: src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:77 src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:90
 #: src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:103
 msgid "Top"
 msgstr "Prejsť hore"
 
-#: src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:2
-#: src/olympia/devhub/templates/devhub/personas/edit.html:63
+#: src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:2 src/olympia/devhub/templates/devhub/personas/edit.html:63
 msgid "Delete Theme"
 msgstr "Odstrániť tému"
 
-#: src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:2
-#: src/olympia/devhub/templates/devhub/versions/list.html:117
+#: src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:2 src/olympia/devhub/templates/devhub/versions/list.html:117
 msgid "Delete Add-on"
 msgstr "Odstrániť doplnok"
 
@@ -5919,27 +4747,22 @@ msgid "Deleting your theme will permanently remove it from the site."
 msgstr "Odstránením vašej témy ju trvalo odstránite z tohto webu."
 
 #: src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:14
-msgid ""
-"Deleting your add-on will permanently remove it from the site and prevent "
-"its GUID from being submitted again by others."
+msgid "Deleting your add-on will permanently remove it from the site and prevent its GUID from being submitted again by others."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:24
-msgid ""
-"Enter the following text confirm your decision:\n"
-"           {slug}"
+msgid "Enter the following text confirm your decision: {slug}"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:34
+#: src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:33
 msgid "Please tell us why you are deleting your theme:"
 msgstr "Povedzte nám, prečo odstraňujete vašu tému vzhľadu:"
 
-#: src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:36
+#: src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:35
 msgid "Please tell us why you are deleting your add-on:"
 msgstr "Povedzte nám, prečo odstraňujete váš doplnok:"
 
-#: src/olympia/devhub/templates/devhub/addons/listing/item_actions.html:1
-#: src/olympia/devhub/templates/devhub/addons/listing/item_actions_theme.html:1
+#: src/olympia/devhub/templates/devhub/addons/listing/item_actions.html:1 src/olympia/devhub/templates/devhub/addons/listing/item_actions_theme.html:1
 #: src/olympia/editors/templates/editors/review.html:253
 msgid "Actions"
 msgstr "Akcie"
@@ -5972,22 +4795,17 @@ msgstr "Nová verzia"
 msgid "Daily statistics on downloads and users."
 msgstr "Denné štatistiky prevzatí a počtov používateľov"
 
-#: src/olympia/devhub/templates/devhub/addons/listing/item_actions.html:45
-#: src/olympia/stats/templates/stats/stats.html:75
-#: src/olympia/stats/templates/stats/stats.html:79
-#: src/olympia/stats/templates/stats/stats.html:81
+#: src/olympia/devhub/templates/devhub/addons/listing/item_actions.html:45 src/olympia/stats/templates/stats/stats.html:31 src/olympia/stats/templates/stats/stats.html:35
+#: src/olympia/stats/templates/stats/stats.html:37
 msgid "Statistics"
 msgstr "Štatistika"
 
-#: src/olympia/devhub/templates/devhub/addons/listing/item_actions.html:54
-#: src/olympia/devhub/templates/devhub/includes/addons_edit_nav.html:5
-#: src/olympia/devhub/templates/devhub/payments/payments.html:3
+#: src/olympia/devhub/templates/devhub/addons/listing/item_actions.html:54 src/olympia/devhub/templates/devhub/includes/addons_edit_nav.html:5 src/olympia/devhub/templates/devhub/payments/payments.html:3
 #: src/olympia/devhub/templates/devhub/payments/tier.html:4
 msgid "Manage Payments"
 msgstr "Správa platieb"
 
-#: src/olympia/devhub/templates/devhub/addons/listing/item_actions.html:55
-#: src/olympia/devhub/templates/devhub/includes/addons_edit_nav.html:6
+#: src/olympia/devhub/templates/devhub/addons/listing/item_actions.html:55 src/olympia/devhub/templates/devhub/includes/addons_edit_nav.html:6
 msgid "Manage Status & Versions"
 msgstr "Správa stavu a verzií"
 
@@ -5995,10 +4813,8 @@ msgstr "Správa stavu a verzií"
 msgid "View Add-on Listing"
 msgstr "Zobraziť stránku doplnku"
 
-#: src/olympia/devhub/templates/devhub/addons/listing/item_actions.html:64
-#: src/olympia/devhub/templates/devhub/addons/listing/item_actions_theme.html:12
-#: src/olympia/devhub/templates/devhub/includes/addons_edit_nav.html:37
-#: src/olympia/devhub/templates/devhub/personas/edit.html:58
+#: src/olympia/devhub/templates/devhub/addons/listing/item_actions.html:64 src/olympia/devhub/templates/devhub/addons/listing/item_actions_theme.html:12
+#: src/olympia/devhub/templates/devhub/includes/addons_edit_nav.html:37 src/olympia/devhub/templates/devhub/personas/edit.html:58
 msgid "View Recent Changes"
 msgstr "Zobraziť posledné zmeny"
 
@@ -6023,12 +4839,8 @@ msgid "Delete this theme."
 msgstr "Odstrániť túto tému vzhľadu."
 
 #: src/olympia/devhub/templates/devhub/addons/listing/items.html:10
-msgid ""
-"This add-on will be deleted automatically after a few days if the submission"
-" process is not completed."
-msgstr ""
-"Tento doplnok bude automaticky odstránený po niekoľkých dňoch, ak nebude "
-"proces odoslania dokončený."
+msgid "This add-on will be deleted automatically after a few days if the submission process is not completed."
+msgstr "Tento doplnok bude automaticky odstránený po niekoľkých dňoch, ak nebude proces odoslania dokončený."
 
 #: src/olympia/devhub/templates/devhub/addons/listing/items.html:27
 msgid "Disabled"
@@ -6045,7 +4857,6 @@ msgid "<strong>{0}</strong> active user"
 msgid_plural "<strong>{0}</strong> active users"
 msgstr[0] "<strong>{0}</strong> aktívny používateľ"
 msgstr[1] "<strong>{0}</strong> aktívni používatelia"
-msgstr[2] "<strong>{0}</strong> aktívnych používateľov"
 
 #: src/olympia/devhub/templates/devhub/addons/submit/base.html:11
 msgid "Submit Add-on"
@@ -6067,9 +4878,7 @@ msgstr "Názov a verzia:"
 msgid "The detail page will be:"
 msgstr "Stránka s detailom bude:"
 
-#: src/olympia/devhub/templates/devhub/addons/submit/describe.html:24
-#: src/olympia/devhub/templates/devhub/personas/edit.html:89
-#: src/olympia/devhub/templates/devhub/personas/submit.html:38
+#: src/olympia/devhub/templates/devhub/addons/submit/describe.html:24 src/olympia/devhub/templates/devhub/personas/edit.html:89 src/olympia/devhub/templates/devhub/personas/submit.html:38
 msgid "Please use only letters, numbers, underscores, and dashes in your URL."
 msgstr "V URL adresách používajte len znaky, čísla, podčiarky a pomlčky."
 
@@ -6089,14 +4898,11 @@ msgstr "Poskytnite detailný popis aplikácie:"
 msgid "The description will appear on the detail page."
 msgstr "Popis bude viditeľný na stránke s aplikáciou."
 
-#: src/olympia/devhub/templates/devhub/addons/submit/done.html:4
-#: src/olympia/devhub/templates/devhub/personas/submit_done.html:4
+#: src/olympia/devhub/templates/devhub/addons/submit/done.html:4 src/olympia/devhub/templates/devhub/personas/submit_done.html:4
 msgid "Submission Complete"
 msgstr "Odoslanie dokončené"
 
-#: src/olympia/devhub/templates/devhub/addons/submit/done.html:8
-#: src/olympia/devhub/templates/devhub/addons/submit/sidebar.html:13
-#: src/olympia/devhub/templates/devhub/personas/submit_done.html:8
+#: src/olympia/devhub/templates/devhub/addons/submit/done.html:8 src/olympia/devhub/templates/devhub/addons/submit/sidebar.html:13 src/olympia/devhub/templates/devhub/personas/submit_done.html:8
 msgid "You're done!"
 msgstr "Hotovo!"
 
@@ -6110,55 +4916,32 @@ msgid "Your add-on has been submitted to the Full Review queue."
 msgstr "Váš doplnok bol odoslaný do fronty na detailnú kontrolu."
 
 #: src/olympia/devhub/templates/devhub/addons/submit/done.html:18
-msgid ""
-"You'll receive an email once it has been reviewed by an editor. In the "
-"meantime, you and your friends can install it directly from its details "
-"page:"
-msgstr ""
-"Okamžite ako bude doplnok redaktorom skontrolovaný, bude vám doručený "
-"e-mail. V medzičase si ho môžete vy a vaši priatelia nainštalovať priamo zo "
-"stránky detailov:"
+msgid "You'll receive an email once it has been reviewed by an editor. In the meantime, you and your friends can install it directly from its details page:"
+msgstr "Okamžite ako bude doplnok redaktorom skontrolovaný, bude vám doručený e-mail. V medzičase si ho môžete vy a vaši priatelia nainštalovať priamo zo stránky detailov:"
 
-#: src/olympia/devhub/templates/devhub/addons/submit/done.html:27
-#: src/olympia/devhub/templates/devhub/addons/submit/done.html:77
-#: src/olympia/devhub/templates/devhub/personas/submit_done.html:16
+#: src/olympia/devhub/templates/devhub/addons/submit/done.html:27 src/olympia/devhub/templates/devhub/addons/submit/done.html:77 src/olympia/devhub/templates/devhub/personas/submit_done.html:16
 msgid "Next steps:"
 msgstr "Ďalšie kroky:"
 
-#: src/olympia/devhub/templates/devhub/addons/submit/done.html:32
-#: src/olympia/devhub/templates/devhub/addons/submit/done.html:82
+#: src/olympia/devhub/templates/devhub/addons/submit/done.html:32 src/olympia/devhub/templates/devhub/addons/submit/done.html:82
 msgid "<a href=\"{0}\">Upload</a> another platform-specific file to this version."
-msgstr ""
-"<a href=\"{0}\">Odoslať</a> ďalší na platforme závislý súbor pre túto "
-"verziu."
+msgstr "<a href=\"{0}\">Odoslať</a> ďalší na platforme závislý súbor pre túto verziu."
 
 #: src/olympia/devhub/templates/devhub/addons/submit/done.html:34
 msgid "Provide more details by <a href=\"{0}\">editing its listing</a>."
 msgstr "Poskytnite viac informácií <a href=\"{0}\">úpravou stránky</a>."
 
 #: src/olympia/devhub/templates/devhub/addons/submit/done.html:35
-msgid ""
-"Tell your users why you created this in your <a href=\"{0}\">Developer "
-"Profile</a>."
-msgstr ""
-"Povedzte vašim používateľom vo svojom <a href=\"{0}\">profile vývojára</a> o"
-" tom, že ste tento doplnok vytvorili."
+msgid "Tell your users why you created this in your <a href=\"{0}\">Developer Profile</a>."
+msgstr "Povedzte vašim používateľom vo svojom <a href=\"{0}\">profile vývojára</a> o tom, že ste tento doplnok vytvorili."
 
 #: src/olympia/devhub/templates/devhub/addons/submit/done.html:36
-msgid ""
-"View and subscribe to your add-on's <a href=\"{0}\">activity feed</a> to "
-"stay updated on reviews, collections, and more."
-msgstr ""
-"Zobrazte, alebo odoberajte <a href=\"{0}\">informácie o nedávnej "
-"aktivite</a> pri svojom doplnku a zostaňte tak informovaný o recenziách, "
-"zbierkach a ďalších."
+msgid "View and subscribe to your add-on's <a href=\"{0}\">activity feed</a> to stay updated on reviews, collections, and more."
+msgstr "Zobrazte, alebo odoberajte <a href=\"{0}\">informácie o nedávnej aktivite</a> pri svojom doplnku a zostaňte tak informovaný o recenziách, zbierkach a ďalších."
 
-#: src/olympia/devhub/templates/devhub/addons/submit/done.html:37
-#: src/olympia/devhub/templates/devhub/addons/submit/done.html:86
+#: src/olympia/devhub/templates/devhub/addons/submit/done.html:37 src/olympia/devhub/templates/devhub/addons/submit/done.html:86
 msgid "View approximate review queue <a href=\"{0}\">wait times</a>."
-msgstr ""
-"Pozrite sa na približný <a href=\"{0}\">čas čakania</a> vo fronte na "
-"kontrolu."
+msgstr "Pozrite sa na približný <a href=\"{0}\">čas čakania</a> vo fronte na kontrolu."
 
 #: src/olympia/devhub/templates/devhub/addons/submit/done.html:42
 msgid "Get Ahead in the Review Queue!"
@@ -6166,31 +4949,22 @@ msgstr "Postúpte do fronty na kontrolu!"
 
 #: src/olympia/devhub/templates/devhub/addons/submit/done.html:45
 msgid "Become an AMO Reviewer today and get your add-ons reviewed faster."
-msgstr ""
-"Staňte sa redaktorom na AMO ešte dnes a pomôžte s rýchlejšou kontrolou "
-"doplnkov."
+msgstr "Staňte sa redaktorom na AMO ešte dnes a pomôžte s rýchlejšou kontrolou doplnkov."
 
 #: src/olympia/devhub/templates/devhub/addons/submit/done.html:54
-msgid ""
-"Your add-on has been signed and it's ready to use. You can download it here:"
+msgid "Your add-on has been signed and it's ready to use. You can download it here:"
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/submit/done.html:64
-msgid ""
-"Your add-on has been submitted to the Unlisted Preliminary Review queue."
-msgstr ""
-"Váš doplnok bol odoslaný do fronty na predbežnú kontrolu doplnkov, ktoré "
-"nebudú v zozname."
+msgid "Your add-on has been submitted to the Unlisted Preliminary Review queue."
+msgstr "Váš doplnok bol odoslaný do fronty na predbežnú kontrolu doplnkov, ktoré nebudú v zozname."
 
 #: src/olympia/devhub/templates/devhub/addons/submit/done.html:66
 msgid "Your add-on has been submitted to the Unlisted Full Review queue."
-msgstr ""
-"Váš doplnok bol odoslaný do fronty na detailnú kontrolu doplnkov, ktoré "
-"nebudú v zozname."
+msgstr "Váš doplnok bol odoslaný do fronty na detailnú kontrolu doplnkov, ktoré nebudú v zozname."
 
 #: src/olympia/devhub/templates/devhub/addons/submit/done.html:70
-msgid ""
-"You'll receive an email once it has been reviewed by an editor and signed."
+msgid "You'll receive an email once it has been reviewed by an editor and signed."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/submit/done.html:74
@@ -6198,9 +4972,7 @@ msgid "Your add-on will not be publicly available on this website."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/submit/done.html:84
-msgid ""
-"You can upload new versions of your add-on in the <a href=\"{0}\">add-on's "
-"developer page</a>."
+msgid "You can upload new versions of your add-on in the <a href=\"{0}\">add-on's developer page</a>."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/submit/license.html:4
@@ -6212,14 +4984,8 @@ msgid "Step 5. Select a License"
 msgstr "Krok 5. Voľba licencie"
 
 #: src/olympia/devhub/templates/devhub/addons/submit/license.html:9
-msgid ""
-"We require all add-ons to indicate the terms under which their source code "
-"is licensed. Please select a license from the list below or enter a custom "
-"license."
-msgstr ""
-"U všetkých doplnkov požadujeme, aby u nich bolo uvedené, pod akými "
-"podmienkami je ich zdrojový kód licencovaný. Zvoľte prosím jednu z licencií "
-"v zozname, alebo zadajte vlastnú."
+msgid "We require all add-ons to indicate the terms under which their source code is licensed. Please select a license from the list below or enter a custom license."
+msgstr "U všetkých doplnkov požadujeme, aby u nich bolo uvedené, pod akými podmienkami je ich zdrojový kód licencovaný. Zvoľte prosím jednu z licencií v zozname, alebo zadajte vlastnú."
 
 #: src/olympia/devhub/templates/devhub/addons/submit/license.html:18
 msgid "Select a license for your add-on:"
@@ -6235,13 +5001,9 @@ msgstr "Krok 4. Pridanie obrázkov"
 
 #: src/olympia/devhub/templates/devhub/addons/submit/media.html:9
 msgid ""
-"Custom icons and screenshots draw attention and help users understand what "
-"it does. We strongly recommend uploading a custom icon, as in some areas of "
-"the website, only the icon and name will appear."
-msgstr ""
-"Vlastné ikony a náhľady dajú používateľom prehľad a pomôžu im v pochopení, "
-"čo doplnok robí. Dôrazne odporúčame načítať vlastnú ikonu, lebo na "
-"niektorých miestach webu sa zobrazuje len táto ikona."
+"Custom icons and screenshots draw attention and help users understand what it does. We strongly recommend uploading a custom icon, as in some areas of the website, only the icon and name will "
+"appear."
+msgstr "Vlastné ikony a náhľady dajú používateľom prehľad a pomôžu im v pochopení, čo doplnok robí. Dôrazne odporúčame načítať vlastnú ikonu, lebo na niektorých miestach webu sa zobrazuje len táto ikona."
 
 #: src/olympia/devhub/templates/devhub/addons/submit/select-review.html:5
 msgid "Step 6"
@@ -6253,25 +5015,16 @@ msgstr "Krok 6. Voľba procesu kontroly"
 
 #: src/olympia/devhub/templates/devhub/addons/submit/select-review.html:10
 msgid ""
-"All add-ons hosted in our gallery must be reviewed by an editor before they "
-"appear in categories or search results. While waiting for review, your add-"
-"on can still be accessed through its direct URL. Please choose the review "
-"process below that best fits your add-on."
+"All add-ons hosted in our gallery must be reviewed by an editor before they appear in categories or search results. While waiting for review, your add-on can still be accessed through its direct "
+"URL. Please choose the review process below that best fits your add-on."
 msgstr ""
-"Všetky doplnky umiestnené v našej galérií musia byť pred tým, ako sa "
-"zobrazia v kategóriách a výsledkoch vyhľadávania skontrolované redaktorom. V"
-" čase, kedy čakáte na kontrolu je váš doplnok priamo dostupný na konkrétnej "
-"URL adrese. Nižšie si vyberte proces kontroly, ktorý vám najlepšie vyhovuje "
-"pre váš doplnok."
+"Všetky doplnky umiestnené v našej galérií musia byť pred tým, ako sa zobrazia v kategóriách a výsledkoch vyhľadávania skontrolované redaktorom. V čase, kedy čakáte na kontrolu je váš doplnok priamo"
+" dostupný na konkrétnej URL adrese. Nižšie si vyberte proces kontroly, ktorý vám najlepšie vyhovuje pre váš doplnok."
 
 #: src/olympia/devhub/templates/devhub/addons/submit/select-review.html:26
 #, python-format
-msgid ""
-"A complete review of your add-on's source and functionality. <a "
-"href=\"%(url)s\">Learn more&hellip;</a>"
-msgstr ""
-"Kompletná kontrola zdrojového kódu doplnku a jeho funkcionality. <a "
-"href=\"%(url)s\">Dozvedieť sa viac&hellip;</a>"
+msgid "A complete review of your add-on's source and functionality. <a href=\"%(url)s\">Learn more&hellip;</a>"
+msgstr "Kompletná kontrola zdrojového kódu doplnku a jeho funkcionality. <a href=\"%(url)s\">Dozvedieť sa viac&hellip;</a>"
 
 #: src/olympia/devhub/templates/devhub/addons/submit/select-review.html:32
 msgid "Appropriate for polished add-ons"
@@ -6299,12 +5052,8 @@ msgstr "Zvoľte riadnu kontrolu"
 
 #: src/olympia/devhub/templates/devhub/addons/submit/select-review.html:49
 #, python-format
-msgid ""
-"A faster review of your add-on's source for any major problems. <a "
-"href=\"%(url)s\">Learn more&hellip;</a>"
-msgstr ""
-"Rýchlejšia kontrola zdrojového kódu doplnku, či neobsahuje zásadné problémy."
-" <a href=\"%(url)s\">Dozvedieť sa viac&hellip;</a>"
+msgid "A faster review of your add-on's source for any major problems. <a href=\"%(url)s\">Learn more&hellip;</a>"
+msgstr "Rýchlejšia kontrola zdrojového kódu doplnku, či neobsahuje zásadné problémy. <a href=\"%(url)s\">Dozvedieť sa viac&hellip;</a>"
 
 #: src/olympia/devhub/templates/devhub/addons/submit/select-review.html:55
 msgid "Appropriate for experimental add-ons"
@@ -6350,10 +5099,8 @@ msgstr "Zvoľte licenciu"
 msgid "Select a review process"
 msgstr "Zvoľte proces kontroly"
 
-#: src/olympia/devhub/templates/devhub/addons/submit/sidebar.html:18
-#: src/olympia/devhub/templates/devhub/docs/policies-submission.html:3
-#: src/olympia/devhub/templates/devhub/docs/policies-submission.html:7
-#: src/olympia/devhub/templates/devhub/docs/policies-submission.html:9
+#: src/olympia/devhub/templates/devhub/addons/submit/sidebar.html:18 src/olympia/devhub/templates/devhub/docs/policies-submission.html:3
+#: src/olympia/devhub/templates/devhub/docs/policies-submission.html:7 src/olympia/devhub/templates/devhub/docs/policies-submission.html:9
 msgid "Submission Process"
 msgstr "Proces odoslania"
 
@@ -6375,27 +5122,18 @@ msgid "Step 2. Upload Your Add-on"
 msgstr "Krok 2. Odošlite svoj doplnok"
 
 #: src/olympia/devhub/templates/devhub/addons/submit/upload.html:11
-msgid ""
-"Use the fields below to upload your add-on package and select any platform "
-"restrictions. After upload, a series of automated validation tests will be "
-"run on your file."
-msgstr ""
-"Pre načítanie balíčka so svojim doplnkom a výber cieľových platforiem "
-"použite pole nižšie. Po načítaní bude spustená sada automatizovaných testov,"
-" ktoré váš balíček skontrolujú."
+msgid "Use the fields below to upload your add-on package and select any platform restrictions. After upload, a series of automated validation tests will be run on your file."
+msgstr "Pre načítanie balíčka so svojim doplnkom a výber cieľových platforiem použite pole nižšie. Po načítaní bude spustená sada automatizovaných testov, ktoré váš balíček skontrolujú."
 
-#: src/olympia/devhub/templates/devhub/addons/submit/upload.html:59
-#: src/olympia/devhub/templates/devhub/versions/add_file_modal.html:39
+#: src/olympia/devhub/templates/devhub/addons/submit/upload.html:51 src/olympia/devhub/templates/devhub/versions/add_file_modal.html:28
 msgid "Which platforms is this file compatible with?"
 msgstr "S ktorými platformami je tento súbor kompatibilný?"
 
-#: src/olympia/devhub/templates/devhub/addons/submit/upload.html:67
-#: src/olympia/devhub/templates/devhub/versions/add_file_modal.html:65
+#: src/olympia/devhub/templates/devhub/addons/submit/upload.html:59 src/olympia/devhub/templates/devhub/versions/add_file_modal.html:45
 msgid "Administrative overrides"
 msgstr "Zmeny pri administrácií"
 
-#: src/olympia/devhub/templates/devhub/api/agreement.html:3
-#: src/olympia/devhub/templates/devhub/api/agreement.html:11
+#: src/olympia/devhub/templates/devhub/api/agreement.html:3 src/olympia/devhub/templates/devhub/api/agreement.html:11
 msgid "Firefox Add-on Distribution Agreement"
 msgstr "Dohoda o distribúcií doplnkov pre Firefox"
 
@@ -6405,12 +5143,8 @@ msgstr "Prihlasovacie údaje k API"
 
 #: src/olympia/devhub/templates/devhub/api/key.html:20
 #, python-format
-msgid ""
-"For detailed instructions, consult the <a href=\"%(docs_url)s\">API "
-"documentation</a>."
-msgstr ""
-"Pre podrobnejšie inštrukcie nahliadnite do <a href=\"%(docs_url)s\">API "
-"dokumentácie</a>."
+msgid "For detailed instructions, consult the <a href=\"%(docs_url)s\">API documentation</a>."
+msgstr "Pre podrobnejšie inštrukcie nahliadnite do <a href=\"%(docs_url)s\">API dokumentácie</a>."
 
 #: src/olympia/devhub/templates/devhub/api/key.html:28
 msgid "JWT issuer"
@@ -6423,10 +5157,8 @@ msgstr ""
 #: src/olympia/devhub/templates/devhub/api/key.html:37
 #, python-format
 msgid ""
-"To make API requests, send a <a href=\"%(jwt_url)s\">JSON Web Token "
-"(JWT)</a> as the authorization header. You'll need to generate a JWT for "
-"every request as explained in the <a href=\"%(docs_url)s\">API "
-"documentation</a>."
+"To make API requests, send a <a href=\"%(jwt_url)s\">JSON Web Token (JWT)</a> as the authorization header. You'll need to generate a JWT for every request as explained in the <a "
+"href=\"%(docs_url)s\">API documentation</a>."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/api/key.html:47
@@ -6435,9 +5167,7 @@ msgstr ""
 
 #: src/olympia/devhub/templates/devhub/api/key.html:53
 #, python-format
-msgid ""
-"This feature is under active development. If you find a problem please <a "
-"target=\"_blank\" href=\"%(bug_link)s\">report a bug</a>."
+msgid "This feature is under active development. If you find a problem please <a target=\"_blank\" href=\"%(bug_link)s\">report a bug</a>."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/api/key.html:61
@@ -6448,30 +5178,19 @@ msgstr ""
 msgid "Generate new credentials"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/docs/policies-agreement.html:3
-#: src/olympia/devhub/templates/devhub/docs/policies-agreement.html:7
-#: src/olympia/devhub/templates/devhub/docs/policies-agreement.html:9
-#: src/olympia/devhub/templates/devhub/docs/policies.html:24
-#: src/olympia/devhub/templates/devhub/docs/policies.html:103
+#: src/olympia/devhub/templates/devhub/docs/policies-agreement.html:3 src/olympia/devhub/templates/devhub/docs/policies-agreement.html:7 src/olympia/devhub/templates/devhub/docs/policies-agreement.html:9
+#: src/olympia/devhub/templates/devhub/docs/policies.html:24 src/olympia/devhub/templates/devhub/docs/policies.html:103
 msgid "Developer Agreement"
 msgstr "Vývojárska zmluva"
 
-#: src/olympia/devhub/templates/devhub/docs/policies-contact.html:3
-#: src/olympia/devhub/templates/devhub/docs/policies-contact.html:7
-#: src/olympia/devhub/templates/devhub/docs/policies-contact.html:9
-#: src/olympia/devhub/templates/devhub/docs/policies.html:27
-#: src/olympia/devhub/templates/devhub/docs/policies.html:115
+#: src/olympia/devhub/templates/devhub/docs/policies-contact.html:3 src/olympia/devhub/templates/devhub/docs/policies-contact.html:7 src/olympia/devhub/templates/devhub/docs/policies-contact.html:9
+#: src/olympia/devhub/templates/devhub/docs/policies.html:27 src/olympia/devhub/templates/devhub/docs/policies.html:115
 msgid "Contacting Us"
 msgstr "Kontaktujte nás"
 
 #: src/olympia/devhub/templates/devhub/docs/policies-contact.html:12
-msgid ""
-"Thanks for your interest in contacting the Mozilla Add-ons team. Please read"
-" this page carefully to ensure your request goes to the right place."
-msgstr ""
-"Ďakujeme za váš záujem kontaktovať tím servera Mozilla Add-ons. Starostlivo "
-"si prosím prečítajte túto stránku a uistite sa, že svoju otázku smerujete "
-"správnym smerom."
+msgid "Thanks for your interest in contacting the Mozilla Add-ons team. Please read this page carefully to ensure your request goes to the right place."
+msgstr "Ďakujeme za váš záujem kontaktovať tím servera Mozilla Add-ons. Starostlivo si prosím prečítajte túto stránku a uistite sa, že svoju otázku smerujete správnym smerom."
 
 #: src/olympia/devhub/templates/devhub/docs/policies-contact.html:17
 msgid "Add-on Support"
@@ -6479,18 +5198,15 @@ msgstr "Podpora pre doplnok"
 
 #: src/olympia/devhub/templates/devhub/docs/policies-contact.html:19
 msgid ""
-"If you have a support question about a particular add-on, such as \"how do I"
-" use this add-on?\" or \"why doesn't this work properly?\", please contact "
-"that add-on's author through the support channels listed on the add-on's "
-"listing page."
+"If you have a support question about a particular add-on, such as \"how do I use this add-on?\" or \"why doesn't this work properly?\", please contact that add-on's author through the support "
+"channels listed on the add-on's listing page."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/docs/policies-contact.html:24
 msgid "Add-on Editorial Concerns"
 msgstr ""
-"Ak máte otázku ku konkrétnemu doplnku ako \"ako sa doplnok používa?\" alebo "
-"\"prečo nefunguje korektne?\", kontaktujte priamo autora doplnku. Kontaktné "
-"informácie nájdete priamo na stránke konkrétneho doplnku. "
+"Ak máte otázku ku konkrétnemu doplnku ako \"ako sa doplnok používa?\" alebo \"prečo nefunguje korektne?\", kontaktujte priamo autora doplnku. Kontaktné informácie nájdete priamo na stránke "
+"konkrétneho doplnku. "
 
 #: src/olympia/devhub/templates/devhub/docs/policies-contact.html:26
 msgid "amo-editors at mozilla dot org"
@@ -6499,18 +5215,11 @@ msgstr "amo-editors zavináč mozilla bodka org"
 #: src/olympia/devhub/templates/devhub/docs/policies-contact.html:26
 #, fuzzy, python-format
 msgid ""
-"If you have a question about an Editor's review of an add-on or want to "
-"report a policy violation, please email %(mail_editors)s. <strong>Almost all"
-" add-on reports fall under this category.</strong> Please be sure to include"
-" a link to the add-on in question and a detailed description of your "
-"question or comment."
+"If you have a question about an Editor's review of an add-on or want to report a policy violation, please email %(mail_editors)s. <strong>Almost all add-on reports fall under this "
+"category.</strong> Please be sure to include a link to the add-on in question and a detailed description of your question or comment."
 msgstr ""
-"Pokud máte dotaz ohledně kontroly doplňku redaktorem nebo chcete nahlásit "
-"zneužití zásad pro hostování doplňku, použijte prosím e-mail "
-"%(mail_editors)s. <strong>Téměř všechna hlášení ohledně doplňků spadají do "
-"této kategorie.</strong> Ujistěte se prosím, že ke své otázce přiložíte "
-"odkaz na doplněk, kterého se otázka týká, a nezapomenete na detailní popis "
-"otázky či komentáře."
+"Pokud máte dotaz ohledně kontroly doplňku redaktorem nebo chcete nahlásit zneužití zásad pro hostování doplňku, použijte prosím e-mail %(mail_editors)s. <strong>Téměř všechna hlášení ohledně "
+"doplňků spadají do této kategorie.</strong> Ujistěte se prosím, že ke své otázce přiložíte odkaz na doplněk, kterého se otázka týká, a nezapomenete na detailní popis otázky či komentáře."
 
 #: src/olympia/devhub/templates/devhub/docs/policies-contact.html:31
 msgid "Add-on Security Vulnerabilities"
@@ -6523,20 +5232,12 @@ msgstr ""
 #: src/olympia/devhub/templates/devhub/docs/policies-contact.html:36
 #, python-format
 msgid ""
-"If you have discovered a security vulnerability in an add-on, even if it is "
-"not hosted here, Mozilla is very interested in your discovery and will work "
-"with the add-on developer to correct the issue as soon as possible. Add-on "
-"security issues can be reported <a "
-"href=\"http://www.mozilla.org/projects/security/security-bugs-"
-"policy.html\">confidentially</a> in <a "
+"If you have discovered a security vulnerability in an add-on, even if it is not hosted here, Mozilla is very interested in your discovery and will work with the add-on developer to correct the "
+"issue as soon as possible. Add-on security issues can be reported <a href=\"http://www.mozilla.org/projects/security/security-bugs-policy.html\">confidentially</a> in <a "
 "href=\"%(link_bugzilla)s\">Bugzilla</a> or by emailing %(mail_admins)s."
 msgstr ""
-"Ak si myslíte, že ste našli bezpečnostnú chybu v doplnku (a to aj v prípade,"
-" že tu nie je umiestnený), bude Mozilla za túto informáciu povďačná a spolu "
-"s autorom zapracujú čo najrýchlejšie na oprave. Bezpečnostné chyby v "
-"doplnkoch môžu byť hlásené <a "
-"href=\"http://www.mozilla.org/projects/security/security-bugs-"
-"policy.html\">dôverne</a> cez <a href=\"%(link_bugzilla)s\">Bugzillu</a> "
+"Ak si myslíte, že ste našli bezpečnostnú chybu v doplnku (a to aj v prípade, že tu nie je umiestnený), bude Mozilla za túto informáciu povďačná a spolu s autorom zapracujú čo najrýchlejšie na "
+"oprave. Bezpečnostné chyby v doplnkoch môžu byť hlásené <a href=\"http://www.mozilla.org/projects/security/security-bugs-policy.html\">dôverne</a> cez <a href=\"%(link_bugzilla)s\">Bugzillu</a> "
 "alebo e-mailom na %(mail_admins)s."
 
 #: src/olympia/devhub/templates/devhub/docs/policies-contact.html:42
@@ -6545,13 +5246,11 @@ msgstr "Funkcionalita webu a vývoj"
 
 #: src/olympia/devhub/templates/devhub/docs/policies-contact.html:44
 msgid ""
-"If you've found a problem with the site, we'd love to fix it. Please <a "
-"href=\"https://github.com/mozilla/olympia/issues\">file a bug report</a> in "
-"GitHub, including the location of the problem and how you encountered it."
+"If you've found a problem with the site, we'd love to fix it. Please <a href=\"https://github.com/mozilla/addons/issues/new\">file a bug report</a> in GitHub, including the location of the problem "
+"and how you encountered it."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/docs/policies-maintenance.html:3
-#: src/olympia/devhub/templates/devhub/docs/policies-maintenance.html:7
+#: src/olympia/devhub/templates/devhub/docs/policies-maintenance.html:3 src/olympia/devhub/templates/devhub/docs/policies-maintenance.html:7
 #: src/olympia/devhub/templates/devhub/docs/policies-maintenance.html:8
 msgid "Maintaining Your Add-ons"
 msgstr "Spravovanie svojich doplnkov"
@@ -6563,31 +5262,17 @@ msgstr "Pridanie nových verzií vášho doplnku"
 #: src/olympia/devhub/templates/devhub/docs/policies-maintenance.html:12
 #, fuzzy
 msgid ""
-"Developers are encouraged to submit updates to their add-ons to fix bugs, "
-"add features, and otherwise improve their product. New versions of an add-on"
-" must have a <a "
-"href=\"https://developer.mozilla.org/en/Toolkit_version_format\">higher "
-"version number</a> and can be submitted through the Developer Tools "
-"provided. There is no limit to the number of versions that can be submitted,"
-" but please remember that versions must be reviewed by an editor."
+"Developers are encouraged to submit updates to their add-ons to fix bugs, add features, and otherwise improve their product. New versions of an add-on must have a <a "
+"href=\"https://developer.mozilla.org/en/Toolkit_version_format\">higher version number</a> and can be submitted through the Developer Tools provided. There is no limit to the number of versions "
+"that can be submitted, but please remember that versions must be reviewed by an editor."
 msgstr ""
-"Je dobré, pokud vývojáří zasílají aktualizace svých doplňků, které opravují "
-"chyby, přidávají nové vlastnosti a celkově vylepšují produkt. Nové verze "
-"doplňku musí mít <a "
-"href=\"https://developer.mozilla.org/en/Toolkit_version_format\">vyšší číslo"
-" verze</a> a mohou být odeslány skrze Centrum pro vývojáře. Neexistuje limit"
-" na počet verzí, které mohou být přidány, ale nezapomeňte prosím, že každá "
-"verze musí být zkontrolována redaktorem."
+"Je dobré, pokud vývojáří zasílají aktualizace svých doplňků, které opravují chyby, přidávají nové vlastnosti a celkově vylepšují produkt. Nové verze doplňku musí mít <a "
+"href=\"https://developer.mozilla.org/en/Toolkit_version_format\">vyšší číslo verze</a> a mohou být odeslány skrze Centrum pro vývojáře. Neexistuje limit na počet verzí, které mohou být přidány, ale"
+" nezapomeňte prosím, že každá verze musí být zkontrolována redaktorem."
 
 #: src/olympia/devhub/templates/devhub/docs/policies-maintenance.html:18
-msgid ""
-"New versions will be added to a pending review queue, and any additional "
-"versions submitted before the review is completed will move that version to "
-"the end of the queue."
-msgstr ""
-"Nové verzie budú zaradené do fronty na kontrolu a akékoľvek ďalšie odoslané "
-"verzie, ktoré budú pridané pred schválením tej predchádzajúcej, posunú "
-"verziu na koniec fronty."
+msgid "New versions will be added to a pending review queue, and any additional versions submitted before the review is completed will move that version to the end of the queue."
+msgstr "Nové verzie budú zaradené do fronty na kontrolu a akékoľvek ďalšie odoslané verzie, ktoré budú pridané pred schválením tej predchádzajúcej, posunú verziu na koniec fronty."
 
 #: src/olympia/devhub/templates/devhub/docs/policies-maintenance.html:23
 msgid "How do I submit a Beta add-on?"
@@ -6599,35 +5284,24 @@ msgstr "Kanály betaverzií sú dostupné len pre plne schválené doplnky."
 
 #: src/olympia/devhub/templates/devhub/docs/policies-maintenance.html:31
 msgid ""
-"To create a beta channel, upload a file with a unique version string that "
-"contains any of the following strings: <code>a,b,alpha,beta,pre,rc</code>, "
-"with an optional number at the end. This text must come at the end of the "
-"version string. If you understand regex format, here's what we look for in "
-"the version number: <code>\"(a|alpha|b|beta|pre|rc)\\d*$\"</code>."
+"To create a beta channel, upload a file with a unique version string that contains any of the following strings: <code>a,b,alpha,beta,pre,rc</code>, with an optional number at the end. This text "
+"must come at the end of the version string. If you understand regex format, here's what we look for in the version number: <code>\"(a|alpha|b|beta|pre|rc)\\d*$\"</code>."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/docs/policies-maintenance.html:37
 msgid ""
-"Once a file meeting this criteria is uploaded to AMO, it will automatically "
-"be marked as a beta version. Users of add-ons with these unique version "
-"numbers will automatically be served the newest beta updates."
+"Once a file meeting this criteria is uploaded to AMO, it will automatically be marked as a beta version. Users of add-ons with these unique version numbers will automatically be served the newest "
+"beta updates."
 msgstr ""
-"Okamžite, ako budú splnené kritériá pre pomenovanie súboru a ten bude "
-"nahraný na AMO, bude automaticky označený ako betaverzia. Používateľom "
-"doplnku s takto unikátnymi verziami budú automaticky betaverzie "
-"nainštalované."
+"Okamžite, ako budú splnené kritériá pre pomenovanie súboru a ten bude nahraný na AMO, bude automaticky označený ako betaverzia. Používateľom doplnku s takto unikátnymi verziami budú automaticky "
+"betaverzie nainštalované."
 
 #: src/olympia/devhub/templates/devhub/docs/policies-maintenance.html:43
 msgid ""
-"While we call these \"Beta versions\", you can use this channel for "
-"nightlies, or alphas, or prerelease versions as you wish. Please note that "
-"there is only one channel for this purpose and all of your users on this "
-"channel will receive the latest add-ons submitted. For instance, if you "
-"upload <code>1.0beta1</code> to the release channel and then upload "
-"<code>1.1alpha1</code>, all users of <code>1.0beta1</code> will be offered "
-"an upgrade to <code>1.1alpha1</code>. Updates are pushed by submission date "
-"and not version number, so users will always get the most recent channel "
-"update regardless of any kind of alphabetical sorting."
+"While we call these \"Beta versions\", you can use this channel for nightlies, or alphas, or prerelease versions as you wish. Please note that there is only one channel for this purpose and all of "
+"your users on this channel will receive the latest add-ons submitted. For instance, if you upload <code>1.0beta1</code> to the release channel and then upload <code>1.1alpha1</code>, all users of "
+"<code>1.0beta1</code> will be offered an upgrade to <code>1.1alpha1</code>. Updates are pushed by submission date and not version number, so users will always get the most recent channel update "
+"regardless of any kind of alphabetical sorting."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/docs/policies-maintenance.html:48
@@ -6636,13 +5310,9 @@ msgstr "Vyžadované aktualizácie"
 
 #: src/olympia/devhub/templates/devhub/docs/policies-maintenance.html:50
 msgid ""
-"Certain situations may arise in which Mozilla requests that an add-on "
-"developer update their add-on within a given time period to address a major "
-"security issue or policy violation. We work with developers to reasonably "
-"accommodate their own schedules, but if the issue is of a serious enough "
-"nature, add-ons that cannot issue an update with the requested fix may be "
-"demoted from fully-reviewed status, disabled, or permanently removed from "
-"the site."
+"Certain situations may arise in which Mozilla requests that an add-on developer update their add-on within a given time period to address a major security issue or policy violation. We work with "
+"developers to reasonably accommodate their own schedules, but if the issue is of a serious enough nature, add-ons that cannot issue an update with the requested fix may be demoted from fully-"
+"reviewed status, disabled, or permanently removed from the site."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/docs/policies-maintenance.html:55
@@ -6651,59 +5321,37 @@ msgstr "Presun vlastníctva"
 
 #: src/olympia/devhub/templates/devhub/docs/policies-maintenance.html:57
 msgid ""
-"Add-ons can have multiple users with permission to update and manage the "
-"listing. Existing authors of an add-on can transfer ownership and add "
-"additional developers to an add-on's listing through the Developer Tools "
-"provided. No interaction with Mozilla representatives is necessary for a "
-"transfer of ownership."
+"Add-ons can have multiple users with permission to update and manage the listing. Existing authors of an add-on can transfer ownership and add additional developers to an add-on's listing through "
+"the Developer Tools provided. No interaction with Mozilla representatives is necessary for a transfer of ownership."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/docs/policies-maintenance.html:63
 #, python-format
-msgid ""
-"Mozilla can assist with granting additional permissions of an add-on's "
-"listing if <a href=\"%(link_contact)s\">contacted</a> by the add-on's "
-"current owner."
-msgstr ""
-"Mozilla vám môže pomôcť s pridelením ďalších práv ku stránke doplnku, ak "
-"bude <a href=\"%(link_contact)s\">kontaktovaná</a> aktuálnym vlastníkom "
-"doplnku."
+msgid "Mozilla can assist with granting additional permissions of an add-on's listing if <a href=\"%(link_contact)s\">contacted</a> by the add-on's current owner."
+msgstr "Mozilla vám môže pomôcť s pridelením ďalších práv ku stránke doplnku, ak bude <a href=\"%(link_contact)s\">kontaktovaná</a> aktuálnym vlastníkom doplnku."
 
 #: src/olympia/devhub/templates/devhub/docs/policies-maintenance.html:70
 msgid ""
-"Mozilla encourages its users to offer feedback on their experiences when "
-"using an add-on. This allows other users to determine if the add-on is "
-"stable and useful. It also provides valuable feedback to developers, "
-"allowing them to continuously improve their add-on to meet user needs."
+"Mozilla encourages its users to offer feedback on their experiences when using an add-on. This allows other users to determine if the add-on is stable and useful. It also provides valuable feedback"
+" to developers, allowing them to continuously improve their add-on to meet user needs."
 msgstr ""
-"Mozilla podporuje používateľov v odosielaní reakcií a svojich skúseností s "
-"konkrétnymi doplnkami. Vďaka tomu môžu ďalší používatelia rozpoznať, či je "
-"doplnok stabilný a užitočný. Vývojári vďaka ohlasom získavajú užitočné "
-"reakcie, ktoré im umožňujú kontinuálne vylepšovanie svojich doplnkov tak, "
-"aby lepšie vyhovovali používateľom."
+"Mozilla podporuje používateľov v odosielaní reakcií a svojich skúseností s konkrétnymi doplnkami. Vďaka tomu môžu ďalší používatelia rozpoznať, či je doplnok stabilný a užitočný. Vývojári vďaka "
+"ohlasom získavajú užitočné reakcie, ktoré im umožňujú kontinuálne vylepšovanie svojich doplnkov tak, aby lepšie vyhovovali používateľom."
 
 #: src/olympia/devhub/templates/devhub/docs/policies-maintenance.html:76
 #, python-format
 msgid ""
-"Reviews must follow the <a href=\"%(link_guidelines)s\">review "
-"guidelines</a>. Reviews that do not meet these guidelines may be flagged for"
-" moderation, but negative reviews will not be removed unless they provide "
-"false information."
+"Reviews must follow the <a href=\"%(link_guidelines)s\">review guidelines</a>. Reviews that do not meet these guidelines may be flagged for moderation, but negative reviews will not be removed "
+"unless they provide false information."
 msgstr ""
-"Recenzie musia spĺňať <a href=\"%(link_guidelines)s\">pravidlá pre "
-"recenzie</a>. Recenzie, ktoré nespĺňajú pravidlá môžu byť označené na "
-"moderovanie, ale aj napriek tomu negatívne recenzie nie sú odstraňované, ak "
-"neobsahujú chybné informácie."
+"Recenzie musia spĺňať <a href=\"%(link_guidelines)s\">pravidlá pre recenzie</a>. Recenzie, ktoré nespĺňajú pravidlá môžu byť označené na moderovanie, ale aj napriek tomu negatívne recenzie nie sú "
+"odstraňované, ak neobsahujú chybné informácie."
 
 #: src/olympia/devhub/templates/devhub/docs/policies-maintenance.html:82
 msgid ""
-"Many developers provide a support mechanism, such as a forum, discussion "
-"group, or email address. It is recommended that support questions be posted "
-"via those mediums instead of in an add-on's review section."
-msgstr ""
-"Veľa vývojárov poskytuje podporu formou fóra, diskusnej skupiny alebo "
-"e-mailom. Je odporúčané, aby boli otázky podpory kladené na týchto miestach "
-"a nie v recenziách doplnku."
+"Many developers provide a support mechanism, such as a forum, discussion group, or email address. It is recommended that support questions be posted via those mediums instead of in an add-on's "
+"review section."
+msgstr "Veľa vývojárov poskytuje podporu formou fóra, diskusnej skupiny alebo e-mailom. Je odporúčané, aby boli otázky podpory kladené na týchto miestach a nie v recenziách doplnku."
 
 #: src/olympia/devhub/templates/devhub/docs/policies-maintenance.html:87
 msgid "Code Disputes"
@@ -6711,35 +5359,23 @@ msgstr "Otázky ku kódu"
 
 #: src/olympia/devhub/templates/devhub/docs/policies-maintenance.html:90
 msgid ""
-"Many add-ons allow their source code to be openly viewed. This does not mean"
-" that the source code is open source or available for use in another add-on."
-" The original author of an add-on retains copyright of their work unless "
-"otherwise noted in the add-on's license."
+"Many add-ons allow their source code to be openly viewed. This does not mean that the source code is open source or available for use in another add-on. The original author of an add-on retains "
+"copyright of their work unless otherwise noted in the add-on's license."
 msgstr ""
-"Veľa doplnkov umožňuje, aby bolo možné ich kód verejne zobraziť. Tento fakt "
-"však neznamená, že je daný kód open source, alebo je k dispozícií pre "
-"použitie v inom doplnku. Pôvodný autor si môže ponechať práva na svoju "
-"vlastnú prácu, ak to v licencii doplnku nie je definované inak."
+"Veľa doplnkov umožňuje, aby bolo možné ich kód verejne zobraziť. Tento fakt však neznamená, že je daný kód open source, alebo je k dispozícií pre použitie v inom doplnku. Pôvodný autor si môže "
+"ponechať práva na svoju vlastnú prácu, ak to v licencii doplnku nie je definované inak."
 
 #: src/olympia/devhub/templates/devhub/docs/policies-maintenance.html:96
 msgid ""
-"In the event that we're notified of a copyright or license infringement, we "
-"will take steps to review the situation and determine if an actual "
-"infringement has occurred. If we determine that there is an infringement, we"
-" will remove the offending add-on and contact the author. New add-on "
-"submissions (including updates) containing infringing code will be denied "
-"approval for public status."
+"In the event that we're notified of a copyright or license infringement, we will take steps to review the situation and determine if an actual infringement has occurred. If we determine that there "
+"is an infringement, we will remove the offending add-on and contact the author. New add-on submissions (including updates) containing infringing code will be denied approval for public status."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/docs/policies-maintenance.html:102
-msgid ""
-"If you are unsure of the current copyright status of an add-on's source "
-"code, you must contact the original author and receive explicit permission "
-"before using the source code."
+msgid "If you are unsure of the current copyright status of an add-on's source code, you must contact the original author and receive explicit permission before using the source code."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/docs/policies-maintenance.html:107
-#: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:306
+#: src/olympia/devhub/templates/devhub/docs/policies-maintenance.html:107 src/olympia/devhub/templates/devhub/docs/policies-reviews.html:306
 #: src/olympia/devhub/templates/devhub/docs/policies-submission.html:97
 msgid "Last updated: January 13, 2011"
 msgstr "Posledná aktualizácia: 13. januára 2011"
@@ -6747,47 +5383,30 @@ msgstr "Posledná aktualizácia: 13. januára 2011"
 #: src/olympia/devhub/templates/devhub/docs/policies-recommended.html:13
 #, python-format
 msgid ""
-"Featured add-ons are top-quality extensions and themes highlighted on <a "
-"href=\"%(link_gallery)s\">AMO</a>, Firefox's Add-ons Manager, and across "
-"other Mozilla websites. These add-ons showcase the power of Firefox "
-"customization and are useful to a wide audience."
+"Featured add-ons are top-quality extensions and themes highlighted on <a href=\"%(link_gallery)s\">AMO</a>, Firefox's Add-ons Manager, and across other Mozilla websites. These add-ons showcase the "
+"power of Firefox customization and are useful to a wide audience."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/docs/policies-recommended.html:19
-msgid ""
-"Featured add-ons are chosen by the Featured Add-ons Advisory Board, a small "
-"group of add-on developers and fans from the Mozilla community who have "
-"volunteered to review and vote on nominations."
+msgid "Featured add-ons are chosen by the Featured Add-ons Advisory Board, a small group of add-on developers and fans from the Mozilla community who have volunteered to review and vote on nominations."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/docs/policies-recommended.html:25
 #, python-format
-msgid ""
-"<a href=\"%(link_featured)s\">Featured extensions</a> are chosen every "
-"month, and <a href=\"%(link_themes)s\">featured complete themes</a> are "
-"chosen every quarter."
-msgstr ""
-"<a href=\"%(link_featured)s\">Propagované rozšírenia</a> sú vyberané každý "
-"mesiac, <a href=\"%(link_themes)s\">propagované plné témy</a> sú vyberané "
-"štvrťročne."
+msgid "<a href=\"%(link_featured)s\">Featured extensions</a> are chosen every month, and <a href=\"%(link_themes)s\">featured complete themes</a> are chosen every quarter."
+msgstr "<a href=\"%(link_featured)s\">Propagované rozšírenia</a> sú vyberané každý mesiac, <a href=\"%(link_themes)s\">propagované plné témy</a> sú vyberané štvrťročne."
 
 #: src/olympia/devhub/templates/devhub/docs/policies-recommended.html:30
 msgid "Criteria for Featured Add-ons"
 msgstr "Kritériá pre odporúčané doplnky"
 
 #: src/olympia/devhub/templates/devhub/docs/policies-recommended.html:33
-msgid ""
-"Before nominating an add-on to be featured, please ensure it meets the "
-"following criteria:"
-msgstr ""
-"Skôr ako odporúčate doplnok, aby bol odporúčaný, uistite sa, že spĺňa "
-"nasledovné kritériá:"
+msgid "Before nominating an add-on to be featured, please ensure it meets the following criteria:"
+msgstr "Skôr ako odporúčate doplnok, aby bol odporúčaný, uistite sa, že spĺňa nasledovné kritériá:"
 
 #: src/olympia/devhub/templates/devhub/docs/policies-recommended.html:39
-msgid ""
-"The add-on must have a complete and informative listing on AMO. This means:"
-msgstr ""
-"Doplnok musí mať kompletný a informačne užitočný popis na AMO. To znamená:"
+msgid "The add-on must have a complete and informative listing on AMO. This means:"
+msgstr "Doplnok musí mať kompletný a informačne užitočný popis na AMO. To znamená:"
 
 #: src/olympia/devhub/templates/devhub/docs/policies-recommended.html:41
 msgid "a 64-pixel custom icon"
@@ -6810,39 +5429,25 @@ msgid "updated screenshots of the add-on's functionality"
 msgstr "aktualizované obrázky funkcionality doplnku"
 
 #: src/olympia/devhub/templates/devhub/docs/policies-recommended.html:46
-msgid ""
-"must be fully approved by AMO editors (no preliminarily reviewed entries)"
-msgstr ""
-"musí byť plne schválený redaktorom AMO (predbežné kontroly nie sú "
-"dostatočné)"
+msgid "must be fully approved by AMO editors (no preliminarily reviewed entries)"
+msgstr "musí byť plne schválený redaktorom AMO (predbežné kontroly nie sú dostatočné)"
 
 #: src/olympia/devhub/templates/devhub/docs/policies-recommended.html:48
-msgid ""
-"The add-on must have excellent user reviews and any problems or support "
-"requests must be promptly addressed by the developer."
-msgstr ""
-"Doplnok musí mať výborné recenzie od používateľov a akékoľvek problémy alebo"
-" otázky na podporu musia byť vývojárom rýchlo riešené."
+msgid "The add-on must have excellent user reviews and any problems or support requests must be promptly addressed by the developer."
+msgstr "Doplnok musí mať výborné recenzie od používateľov a akékoľvek problémy alebo otázky na podporu musia byť vývojárom rýchlo riešené."
 
 #: src/olympia/devhub/templates/devhub/docs/policies-recommended.html:49
 msgid "The add-on must have a minimum of 2,000 users."
 msgstr "Doplnok musí mať minimálne 2000 používateľov."
 
 #: src/olympia/devhub/templates/devhub/docs/policies-recommended.html:50
-msgid ""
-"The add-on must be compatible with the latest release of Firefox and must be"
-" compatible with beta versions 4 weeks before their final release."
-msgstr ""
-"Doplnok musí byť kompatibilní s poslednou verziou Firefoxu a musí byť "
-"kompatibilní s betaverziou nasledujúcej verzie 4 týždne pred jej finálnym "
-"vydaním."
+msgid "The add-on must be compatible with the latest release of Firefox and must be compatible with beta versions 4 weeks before their final release."
+msgstr "Doplnok musí byť kompatibilní s poslednou verziou Firefoxu a musí byť kompatibilní s betaverziou nasledujúcej verzie 4 týždne pred jej finálnym vydaním."
 
 #: src/olympia/devhub/templates/devhub/docs/policies-recommended.html:51
 msgid ""
-"<strong>Most importantly</strong>, the add-on must have wide consumer appeal"
-" to Firefox's users and be outstanding in nearly every way: user experience,"
-" performance, security, and usefulness or entertainment value. Featured "
-"complete themes must also be visually appealing."
+"<strong>Most importantly</strong>, the add-on must have wide consumer appeal to Firefox's users and be outstanding in nearly every way: user experience, performance, security, and usefulness or "
+"entertainment value. Featured complete themes must also be visually appealing."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/docs/policies-recommended.html:54
@@ -6856,231 +5461,150 @@ msgstr "amo-featured zavináč mozilla bodka org"
 
 #: src/olympia/devhub/templates/devhub/docs/policies-recommended.html:57
 #, python-format
-msgid ""
-"If you wish to nominate an add-on to be featured and it meets the criteria "
-"above, send an email to %(mail_featured)s with:"
-msgstr ""
-"Ak chcete váš doplnok nominovať a splňuje kritériá uvedené vyššie, pošlite "
-"e-mail na adresu %(mail_featured)s s nasledujúcimi vecami:"
+msgid "If you wish to nominate an add-on to be featured and it meets the criteria above, send an email to %(mail_featured)s with:"
+msgstr "Ak chcete váš doplnok nominovať a splňuje kritériá uvedené vyššie, pošlite e-mail na adresu %(mail_featured)s s nasledujúcimi vecami:"
 
 #: src/olympia/devhub/templates/devhub/docs/policies-recommended.html:62
 msgid "the add-on name, URL, and whether you are its developer"
 msgstr "názov doplnku, jeho URL adresa a informácia, či ste jeho vývojárom"
 
 #: src/olympia/devhub/templates/devhub/docs/policies-recommended.html:63
-msgid ""
-"a short explanation of why the add-on has wide appeal and should be featured"
-msgstr ""
-"krátke vysvetlenie, prečo je doplnok určený pre široké spektrum používateľov"
-" a prečo by mal byť propagovaný"
+msgid "a short explanation of why the add-on has wide appeal and should be featured"
+msgstr "krátke vysvetlenie, prečo je doplnok určený pre široké spektrum používateľov a prečo by mal byť propagovaný"
 
 #: src/olympia/devhub/templates/devhub/docs/policies-recommended.html:64
-msgid ""
-"optionally, links to any external reviews or articles mentioning the add-on"
-msgstr ""
-"voliteľne, odkaz na akékoľvek externé recenzie, alebo články, ktoré o "
-"doplnku niečo píšu"
+msgid "optionally, links to any external reviews or articles mentioning the add-on"
+msgstr "voliteľne, odkaz na akékoľvek externé recenzie, alebo články, ktoré o doplnku niečo píšu"
 
 #: src/olympia/devhub/templates/devhub/docs/policies-recommended.html:68
 msgid ""
-"Add-on nominations are reviewed by the Advisory Board once a month (once "
-"every 3 months for complete theme nominations). Common reasons for rejection"
-" include lacking wide appeal to consumers, a suboptimal user experience, "
-"quality or security issues, incompatibility, and similarity to another "
-"featured add-on. Rejected add-ons cannot be re-nominated within 3 months."
+"Add-on nominations are reviewed by the Advisory Board once a month (once every 3 months for complete theme nominations). Common reasons for rejection include lacking wide appeal to consumers, a "
+"suboptimal user experience, quality or security issues, incompatibility, and similarity to another featured add-on. Rejected add-ons cannot be re-nominated within 3 months."
 msgstr ""
-"Nominované doplnky sú kontrolované skupinou Advisory Board raz za mesiac "
-"(každé tri mesiace pre témy). Bežné dôvody pre zamietnutie zahŕňajú úzke "
-"zameranie doplnkov, neoptimálne vyhotovenie, zlú kvalitu, bezpečnostné "
-"problémy, nekompatibilitu, alebo podobnosť s iným, už odporúčaným doplnkom. "
-"Zamietnuté doplnky nemôžu byť ďalšie tri mesiace znovu nominované."
+"Nominované doplnky sú kontrolované skupinou Advisory Board raz za mesiac (každé tri mesiace pre témy). Bežné dôvody pre zamietnutie zahŕňajú úzke zameranie doplnkov, neoptimálne vyhotovenie, zlú "
+"kvalitu, bezpečnostné problémy, nekompatibilitu, alebo podobnosť s iným, už odporúčaným doplnkom. Zamietnuté doplnky nemôžu byť ďalšie tri mesiace znovu nominované."
 
 #: src/olympia/devhub/templates/devhub/docs/policies-recommended.html:73
 msgid "Rotating Featured Add-ons"
 msgstr "Rotácia odporúčaných doplnkov"
 
 #: src/olympia/devhub/templates/devhub/docs/policies-recommended.html:76
-msgid ""
-"Mozilla and the Featured Add-ons Advisory Board regularly evaluate and "
-"rotate out featured add-ons. Some of the most common reasons for add-ons "
-"being removed from the featured list are:"
+msgid "Mozilla and the Featured Add-ons Advisory Board regularly evaluate and rotate out featured add-ons. Some of the most common reasons for add-ons being removed from the featured list are:"
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/docs/policies-recommended.html:83
 msgid ""
-"Lack of growth &mdash; Add-ons that are featured typically experience a "
-"substantial gain in both downloads and active users. If an add-on is not "
-"demonstrating growth in any substantial way, that's a good indicator the "
-"add-on may not be very useful to our users."
+"Lack of growth &mdash; Add-ons that are featured typically experience a substantial gain in both downloads and active users. If an add-on is not demonstrating growth in any substantial way, that's "
+"a good indicator the add-on may not be very useful to our users."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/docs/policies-recommended.html:88
-msgid ""
-"Negative reviews &mdash; Featured add-ons should have a great experience and"
-" very few bugs, so add-ons with many negative reviews may be reconsidered."
+msgid "Negative reviews &mdash; Featured add-ons should have a great experience and very few bugs, so add-ons with many negative reviews may be reconsidered."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/docs/policies-recommended.html:93
 #, fuzzy
 msgid ""
-"Incompatibility with upcoming Firefox versions &mdash; Featured add-ons are "
-"expected to be compatible with stable and beta versions of Firefox. Add-ons "
-"not yet compatible with a Beta version of Firefox four weeks before its "
-"expected release will lose their featured status."
+"Incompatibility with upcoming Firefox versions &mdash; Featured add-ons are expected to be compatible with stable and beta versions of Firefox. Add-ons not yet compatible with a Beta version of "
+"Firefox four weeks before its expected release will lose their featured status."
 msgstr ""
-"Nekompatibilita s nadcházejícími verzemi Firefoxu &mdash; Doporučené doplňky"
-" by měly být kompatibilní se stabilními verzemi i betaverzemi Firefoxu. "
-"Doplňky, které nejsou kompatibilní s betaverzí Firefoxu 4 týdny před "
-"předpokládaným vydáním, ztrácí svůj status doporučeného doplňku."
+"Nekompatibilita s nadcházejícími verzemi Firefoxu &mdash; Doporučené doplňky by měly být kompatibilní se stabilními verzemi i betaverzemi Firefoxu. Doplňky, které nejsou kompatibilní s betaverzí "
+"Firefoxu 4 týdny před předpokládaným vydáním, ztrácí svůj status doporučeného doplňku."
 
 #: src/olympia/devhub/templates/devhub/docs/policies-recommended.html:99
 msgid "Joining the Featured Add-ons Advisory Board"
 msgstr "Pripojenie sa k Featured Add-ons Advisory Board"
 
 #: src/olympia/devhub/templates/devhub/docs/policies-recommended.html:102
-msgid ""
-"Every six months a new Advisory Board is chosen based on applications from "
-"the add-ons community. Members must:"
-msgstr ""
-"Každých šesť mesiacov je ustanovený nový Advisory Board, ktorý je zostavený "
-"na základe žiadostí z našej komunity okolo doplnkov. Členovia musia:"
+msgid "Every six months a new Advisory Board is chosen based on applications from the add-ons community. Members must:"
+msgstr "Každých šesť mesiacov je ustanovený nový Advisory Board, ktorý je zostavený na základe žiadostí z našej komunity okolo doplnkov. Členovia musia:"
 
 #: src/olympia/devhub/templates/devhub/docs/policies-recommended.html:108
-msgid ""
-"be active members of the add-ons community, whether as a developer, "
-"evangelist, or fan"
-msgstr ""
-"byť aktívnym členom komunity doplnkov (nezáleží na tom, či je vývojár, "
-"evanjelista, alebo fanúšik)"
+msgid "be active members of the add-ons community, whether as a developer, evangelist, or fan"
+msgstr "byť aktívnym členom komunity doplnkov (nezáleží na tom, či je vývojár, evanjelista, alebo fanúšik)"
 
 #: src/olympia/devhub/templates/devhub/docs/policies-recommended.html:109
-msgid ""
-"commit to trying all the nominations submitted, giving their feedback, and "
-"casting their votes every month"
-msgstr ""
-"aktívne skúšať všetky nominované doplnky, poskytovať k nim reakcie a "
-"zúčastniť sa každý mesiac hlasovania"
+msgid "commit to trying all the nominations submitted, giving their feedback, and casting their votes every month"
+msgstr "aktívne skúšať všetky nominované doplnky, poskytovať k nim reakcie a zúčastniť sa každý mesiac hlasovania"
 
 #: src/olympia/devhub/templates/devhub/docs/policies-recommended.html:110
-msgid ""
-"abstain from voting on add-ons that they have any business or personal "
-"affiliations with, as well as direct competitors of any such add-ons"
-msgstr ""
-"nehlasovať pri doplnkoch, ktoré sú s nim nejako osobne, alebo obchodne "
-"spojené a rovnako tak nebude hlasovať pri svojej konkurencii"
+msgid "abstain from voting on add-ons that they have any business or personal affiliations with, as well as direct competitors of any such add-ons"
+msgstr "nehlasovať pri doplnkoch, ktoré sú s nim nejako osobne, alebo obchodne spojené a rovnako tak nebude hlasovať pri svojej konkurencii"
 
 #: src/olympia/devhub/templates/devhub/docs/policies-recommended.html:114
 msgid ""
-"Members of the Mozilla Add-ons team may veto any add-on's selection because "
-"of security, privacy, compatibility, or any other reason, but in general it "
-"is up to the Board to select add-ons to feature."
+"Members of the Mozilla Add-ons team may veto any add-on's selection because of security, privacy, compatibility, or any other reason, but in general it is up to the Board to select add-ons to "
+"feature."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/docs/policies-recommended.html:120
 msgid ""
-"This featured policy only applies to the addons.mozilla.org global list of "
-"featured add-ons. Add-ons featured in other locations are often pulled from "
-"this list, but Mozilla may feature any add-on in other locations without the"
-" Board's consent. Additionally, locale-specific features override the global"
-" defaults, so if a locale has opted to select its own features, some or all "
-"of the global features may not appear in that locale."
+"This featured policy only applies to the addons.mozilla.org global list of featured add-ons. Add-ons featured in other locations are often pulled from this list, but Mozilla may feature any add-on "
+"in other locations without the Board's consent. Additionally, locale-specific features override the global defaults, so if a locale has opted to select its own features, some or all of the global "
+"features may not appear in that locale."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/docs/policies-recommended.html:126
 #, python-format
-msgid ""
-"Follow the <a href=\"%(link_blog)s\">Add-ons Blog</a> or <a "
-"href=\"%(link_twitter)s\">@mozamo</a> on Twitter to learn when the next "
-"application period opens."
-msgstr ""
-"Pre informácie o ďalšej perióde sledujte <a href=\"%(link_blog)s\">blog "
-"Mozilla Add-ons</a> alebo <a href=\"%(link_twitter)s\">@mozamo</a> na "
-"Twitteri."
+msgid "Follow the <a href=\"%(link_blog)s\">Add-ons Blog</a> or <a href=\"%(link_twitter)s\">@mozamo</a> on Twitter to learn when the next application period opens."
+msgstr "Pre informácie o ďalšej perióde sledujte <a href=\"%(link_blog)s\">blog Mozilla Add-ons</a> alebo <a href=\"%(link_twitter)s\">@mozamo</a> na Twitteri."
 
 #: src/olympia/devhub/templates/devhub/docs/policies-recommended.html:131
 msgid "Last updated: January 31, 2013"
 msgstr "Posledná aktualizácia: 31. januára 2013"
 
-#: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:3
-#: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:7
-#: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:8
-#: src/olympia/devhub/templates/devhub/docs/policies.html:15
-#: src/olympia/devhub/templates/devhub/docs/policies.html:64
+#: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:3 src/olympia/devhub/templates/devhub/docs/policies-reviews.html:7 src/olympia/devhub/templates/devhub/docs/policies-reviews.html:8
+#: src/olympia/devhub/templates/devhub/docs/policies.html:15 src/olympia/devhub/templates/devhub/docs/policies.html:64
 msgid "Review Process"
 msgstr "Proces kontroly doplnku"
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:12
 #, fuzzy
 msgid ""
-"In order to ensure all add-ons hosted in our gallery are safe for users to "
-"install, Mozilla will begin requiring all hosted add-ons to undergo review. "
-"We offer two types of review and developers are free to choose the best fit "
-"for their add-on."
+"In order to ensure all add-ons hosted in our gallery are safe for users to install, Mozilla will begin requiring all hosted add-ons to undergo review. We offer two types of review and developers "
+"are free to choose the best fit for their add-on."
 msgstr ""
-"Protože se snažíme, aby všechny doplňky hostované v naší galerii byly "
-"bezpečné, začala Mozilla vyžadovat kontrolu u všech hostovaných doplňků. K "
-"dispozici jsou dva typy kontroly a je na vývojáři, kterou z nich zvolí, a o "
-"které si myslí, že lépe sedne vyvíjenému doplňku."
+"Protože se snažíme, aby všechny doplňky hostované v naší galerii byly bezpečné, začala Mozilla vyžadovat kontrolu u všech hostovaných doplňků. K dispozici jsou dva typy kontroly a je na vývojáři, "
+"kterou z nich zvolí, a o které si myslí, že lépe sedne vyvíjenému doplňku."
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:19
 msgid ""
-"<strong><a href=\"#full\">Full Review</a></strong> &mdash; a thorough "
-"functional and code review of the add-on, appropriate for add-ons ready for "
-"distribution to the masses. All site features are available to these add-"
-"ons."
+"<strong><a href=\"#full\">Full Review</a></strong> &mdash; a thorough functional and code review of the add-on, appropriate for add-ons ready for distribution to the masses. All site features are "
+"available to these add-ons."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:24
 msgid ""
-"<strong><a href=\"#preliminary\">Preliminary Review</a></strong> &mdash; a "
-"faster review intended for experimental add-ons. Preliminary reviews do not "
-"check for functionality or full policy compliance, but the reviewed add-ons "
-"have install button cautions and some feature limitations."
+"<strong><a href=\"#preliminary\">Preliminary Review</a></strong> &mdash; a faster review intended for experimental add-ons. Preliminary reviews do not check for functionality or full policy "
+"compliance, but the reviewed add-ons have install button cautions and some feature limitations."
 msgstr ""
-"<strong><a href=\"#preliminary\">Predbežná kontrola</a></strong> &mdash; "
-"jedná sa o rýchlejšiu kontrolu určenú hlavne pre experimentálne doplnky. V "
-"rámci predbežnej kontroly sa nekontroluje funkcionalita, plná zhoda zo "
-"zásadami pre doplnky a pri doplnku sa na webe zobrazuje varovanie. Funkcie "
-"webu sú pre takéto doplnky obmedzené."
+"<strong><a href=\"#preliminary\">Predbežná kontrola</a></strong> &mdash; jedná sa o rýchlejšiu kontrolu určenú hlavne pre experimentálne doplnky. V rámci predbežnej kontroly sa nekontroluje "
+"funkcionalita, plná zhoda zo zásadami pre doplnky a pri doplnku sa na webe zobrazuje varovanie. Funkcie webu sú pre takéto doplnky obmedzené."
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:31
 msgid ""
-"Detailed descriptions of each option are below. After selecting a review "
-"process at submission, the add-on will be placed in the queue. Add-ons are "
-"reviewed by the <a href=\"https://wiki.mozilla.org/AMO:Editors\">AMO "
-"Editors</a>, a group of talented developers that volunteer to help the "
-"Mozilla project by reviewing add-ons to ensure a stable and safe experience "
-"for users. Developers will receive an email with any updates throughout the "
-"review process."
+"Detailed descriptions of each option are below. After selecting a review process at submission, the add-on will be placed in the queue. Add-ons are reviewed by the <a "
+"href=\"https://wiki.mozilla.org/AMO:Editors\">AMO Editors</a>, a group of talented developers that volunteer to help the Mozilla project by reviewing add-ons to ensure a stable and safe experience "
+"for users. Developers will receive an email with any updates throughout the review process."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:37
 msgid ""
-"While waiting for review, add-ons will not appear anywhere in the gallery "
-"publicly, but direct links to the add-on's details page will work. This "
-"allows the author to blog or share the link with friends, inviting them to "
-"try it out, even when not yet reviewed."
+"While waiting for review, add-ons will not appear anywhere in the gallery publicly, but direct links to the add-on's details page will work. This allows the author to blog or share the link with "
+"friends, inviting them to try it out, even when not yet reviewed."
 msgstr ""
-"Počas dobu kontroly nie sú doplnky v galérií viditeľné, odkaz na stránku s "
-"detailom doplnku by ale mal fungovať. Autor tak môže na doplnok odkázať zo "
-"svojho blogu, alebo poslať odkaz známym, aby doplnok vyskúšali ešte skôr, "
-"ako bude skontrolovaný."
+"Počas dobu kontroly nie sú doplnky v galérií viditeľné, odkaz na stránku s detailom doplnku by ale mal fungovať. Autor tak môže na doplnok odkázať zo svojho blogu, alebo poslať odkaz známym, aby "
+"doplnok vyskúšali ešte skôr, ako bude skontrolovaný."
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:44
 msgid ""
-"Full reviews are appropriate for add-ons that are well-tested, stable, fast,"
-" and have wide appeal to our users. If you aren't confident that your add-on"
-" meets that criteria, please consider working out the kinks while in "
-"preliminary review and accumulating user feedback first."
+"Full reviews are appropriate for add-ons that are well-tested, stable, fast, and have wide appeal to our users. If you aren't confident that your add-on meets that criteria, please consider working"
+" out the kinks while in preliminary review and accumulating user feedback first."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:50
-msgid ""
-"We aim to perform full reviews in under 10 days, though most add-ons are "
-"reviewed in much less time."
-msgstr ""
-"Snažíme sa vykonávať plné kontroly do 10 dní. U väčšiny doplnkov je však "
-"tento čas kontroly oveľa kratší."
+msgid "We aim to perform full reviews in under 10 days, though most add-ons are reviewed in much less time."
+msgstr "Snažíme sa vykonávať plné kontroly do 10 dní. U väčšiny doplnkov je však tento čas kontroly oveľa kratší."
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:55
 msgid "Testing Methods &amp; Common Issues"
@@ -7091,51 +5615,33 @@ msgid "When performing a full review, editors will:"
 msgstr "V rámci kompletnej kontroly bude redaktor vykonávať:"
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:64
-msgid ""
-"install the add-on, making sure it functions as described and is free of "
-"major defects"
-msgstr ""
-"nainštalovať doplnok, vyskúšať jeho funkčnosť tak, ako je popísaná a "
-"skontrolovať, či nejaví problémy"
+msgid "install the add-on, making sure it functions as described and is free of major defects"
+msgstr "nainštalovať doplnok, vyskúšať jeho funkčnosť tak, ako je popísaná a skontrolovať, či nejaví problémy"
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:69
-msgid ""
-"perform a source code review, looking for performance and security best "
-"practices"
-msgstr ""
-"vykonať kontrolu zdrojového kódu a pozrieť, či spĺňa zásady pre výkon a "
-"bezpečnosť"
+msgid "perform a source code review, looking for performance and security best practices"
+msgstr "vykonať kontrolu zdrojového kódu a pozrieť, či spĺňa zásady pre výkon a bezpečnosť"
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:74
 msgid "ensure the add-on's privacy policy is in line with its functionality"
-msgstr ""
-"uistiť sa, či zásady ochrany súkromia odpovedajú tomu, ako sa doplnok správa"
+msgstr "uistiť sa, či zásady ochrany súkromia odpovedajú tomu, ako sa doplnok správa"
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:79
-msgid ""
-"look for compliance with all of Mozilla's policies, detailed in these "
-"documents"
-msgstr ""
-"pozrieť na možný rozpor s nejakými zásadami Mozilly, ktoré sú popísané v "
-"tomto dokumente"
+msgid "look for compliance with all of Mozilla's policies, detailed in these documents"
+msgstr "pozrieť na možný rozpor s nejakými zásadami Mozilly, ktoré sú popísané v tomto dokumente"
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:86
-msgid ""
-"Some of the most common issues we see when performing these reviews are:"
+msgid "Some of the most common issues we see when performing these reviews are:"
 msgstr "Najčastejšie problémy s ktorými sa v rámci kontroly stretávame:"
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:93
 msgid ""
-"<strong>JavaScript namespace pollution</strong> &mdash; the most common "
-"violation. Be sure to <a "
-"href=\"https://developer.mozilla.org/en/XUL_School/JavaScript_Object_Management\">wrap"
-" your loose variables</a>"
+"<strong>JavaScript namespace pollution</strong> &mdash; the most common violation. Be sure to <a href=\"https://developer.mozilla.org/en/XUL_School/JavaScript_Object_Management\">wrap your loose "
+"variables</a>"
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:99
-msgid ""
-"proper preference naming - all preference names should begin with "
-"\"extensions.\", followed by the add-on name or some other unique identifier"
+msgid "proper preference naming - all preference names should begin with \"extensions.\", followed by the add-on name or some other unique identifier"
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:103
@@ -7176,105 +5682,71 @@ msgstr "konflikt s inými doplnkami"
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:113
 msgid "application start-up or page load performance degradation"
-msgstr ""
-"výrazný vplyv na rýchlosť štartu aplikácie, alebo výrazný pokles výkonu"
+msgstr "výrazný vplyv na rýchlosť štartu aplikácie, alebo výrazný pokles výkonu"
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:117
 #, python-format
 msgid ""
-"For information on how to avoid these problems, please see our <a "
-"href=\"%(link_howto)s\">How-to Library</a>. Some of these practices, such as"
-" binary or obfuscated code, are allowed under certain conditions outlined "
-"below."
+"For information on how to avoid these problems, please see our <a href=\"%(link_howto)s\">How-to Library</a>. Some of these practices, such as binary or obfuscated code, are allowed under certain "
+"conditions outlined below."
 msgstr ""
-"Pre informácie, ako sa týmto problémom vyhnúť, sa pozrite do sekcie <a "
-"href=\"%(link_howto)s\">Databáza ukážok, ako na to</a>. Niektoré z vyššie "
-"uvedených bodov, ako napríklad binárny kód alebo kód je prejdený cez "
-"obfuskátor, sú povolené pod určitými podmienkami, ktoré sú popísané nižšie."
+"Pre informácie, ako sa týmto problémom vyhnúť, sa pozrite do sekcie <a href=\"%(link_howto)s\">Databáza ukážok, ako na to</a>. Niektoré z vyššie uvedených bodov, ako napríklad binárny kód alebo kód"
+" je prejdený cez obfuskátor, sú povolené pod určitými podmienkami, ktoré sú popísané nižšie."
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:123
 #, python-format
 msgid ""
-"Many of the above restrictions are tested automatically by an extension "
-"scanner that will flag suspicious add-ons for editor review. You can read "
-"more about this scanner in the <a href=\"%(link_validation)s\">Validation "
-"Help</a> document."
+"Many of the above restrictions are tested automatically by an extension scanner that will flag suspicious add-ons for editor review. You can read more about this scanner in the <a "
+"href=\"%(link_validation)s\">Validation Help</a> document."
 msgstr ""
-"Viacero z hore uvedených obmedzení je testovaných automaticky procesom "
-"kontroly doplnkov, ktorý na problémy upozorňuje redaktora pri kontrole. Viac"
-" informácií o tejto kontrole si môžete prečítať v dokumente <a "
-"href=\"%(link_validation)s\">pomoc pri kontrole</a>."
+"Viacero z hore uvedených obmedzení je testovaných automaticky procesom kontroly doplnkov, ktorý na problémy upozorňuje redaktora pri kontrole. Viac informácií o tejto kontrole si môžete prečítať v "
+"dokumente <a href=\"%(link_validation)s\">pomoc pri kontrole</a>."
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:129
 msgid ""
-"If the add-on is site-specific, it is recommended that a test account is "
-"provided for use during the review process. Additionally, including detailed"
-" testing instructions will allow an editor to better understand how the add-"
-"on functions and expedite the testing process. This information can be "
-"placed in the Notes to Reviewer field when editing a version in the "
-"Developer Hub."
+"If the add-on is site-specific, it is recommended that a test account is provided for use during the review process. Additionally, including detailed testing instructions will allow an editor to "
+"better understand how the add-on functions and expedite the testing process. This information can be placed in the Notes to Reviewer field when editing a version in the Developer Hub."
 msgstr ""
-"Ak je doplnok určený pre konkrétnu stránku, je odporúčané, aby bol v rámci "
-"kontroly poskytnutý testovací účet pre spomínanú stránku (ak je požadovaný)."
-" Tiež je dobré redaktorovi poskytnúť informácie, ktoré mu pomôžu lepšie "
-"pochopiť funkciu doplnku a tým mu zjednodušia aj proces kontroly. Takáto "
-"informácia môže byť vložená do poľa s poznámkou pre redaktora pri pridávaní "
-"novej verzie v rámci stránok pre vývojárov."
+"Ak je doplnok určený pre konkrétnu stránku, je odporúčané, aby bol v rámci kontroly poskytnutý testovací účet pre spomínanú stránku (ak je požadovaný). Tiež je dobré redaktorovi poskytnúť "
+"informácie, ktoré mu pomôžu lepšie pochopiť funkciu doplnku a tým mu zjednodušia aj proces kontroly. Takáto informácia môže byť vložená do poľa s poznámkou pre redaktora pri pridávaní novej verzie "
+"v rámci stránok pre vývojárov."
 
-#: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:134
-#: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:168
+#: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:134 src/olympia/devhub/templates/devhub/docs/policies-reviews.html:168
 msgid "After the Review"
 msgstr "Po kontrole"
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:136
 msgid ""
-"Once an add-on is granted full review, it will immediately be available in "
-"the gallery, showing in browse and search results with a warning-free "
-"install button. All features, including voluntary contributions and beta "
-"channels will be available."
+"Once an add-on is granted full review, it will immediately be available in the gallery, showing in browse and search results with a warning-free install button. All features, including voluntary "
+"contributions and beta channels will be available."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:142
 #, fuzzy
 msgid ""
-"Subsequent versions of the add-on will automatically be placed in the full "
-"review queue. Until the review is completed, the new version will only be "
-"displayed on the Version History page of the add-on. Once reviewed, the "
-"version will be updated across the site and deployed through the automatic "
-"update service."
+"Subsequent versions of the add-on will automatically be placed in the full review queue. Until the review is completed, the new version will only be displayed on the Version History page of the "
+"add-on. Once reviewed, the version will be updated across the site and deployed through the automatic update service."
 msgstr ""
-"Další verze doplňku budou automaticky umisťovány do fronty pro plnou "
-"kontrolu doplňku. Do doby, než bude kontrola dokončena, bude nová verze "
-"zobrazena pouze na stránce s historií verzí doplňku. Jakmile bude schválena,"
-" zobrazí se napříč webem a bude distribuována v rámci služby automatických "
-"aktualizací."
+"Další verze doplňku budou automaticky umisťovány do fronty pro plnou kontrolu doplňku. Do doby, než bude kontrola dokončena, bude nová verze zobrazena pouze na stránce s historií verzí doplňku. "
+"Jakmile bude schválena, zobrazí se napříč webem a bude distribuována v rámci služby automatických aktualizací."
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:148
 #, fuzzy
 msgid ""
-"If a version does not meet the criteria for full review, it can either be "
-"granted preliminary review or disabled if there is a security concern. The "
-"author will receive an email explaining the action taken and how to fix it. "
-"In most cases, the developer can simply fix the problem and re-submit for "
-"full review."
+"If a version does not meet the criteria for full review, it can either be granted preliminary review or disabled if there is a security concern. The author will receive an email explaining the "
+"action taken and how to fix it. In most cases, the developer can simply fix the problem and re-submit for full review."
 msgstr ""
-"Pokud verze nesplní kritéria pro plnou kontrolu, může jí být udělena "
-"předběžná kontrola nebo zakázána v případě, že je v ní bezpečnostní problém."
-" Autor obdrží e-mail s vysvětlením a informací, jak problém vyřešit. Ve "
-"většině případech vývojář jednoduše problém opraví a nahraje novou verzi "
-"doplňku k plné kontrole."
+"Pokud verze nesplní kritéria pro plnou kontrolu, může jí být udělena předběžná kontrola nebo zakázána v případě, že je v ní bezpečnostní problém. Autor obdrží e-mail s vysvětlením a informací, jak "
+"problém vyřešit. Ve většině případech vývojář jednoduše problém opraví a nahraje novou verzi doplňku k plné kontrole."
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:155
 #, fuzzy
 msgid ""
-"Preliminary reviews are appropriate for experimental add-ons and provide a "
-"way to get user testing and feedback without going through the longer, more "
-"thorough review process. We aim to complete these reviews in under 3 days."
+"Preliminary reviews are appropriate for experimental add-ons and provide a way to get user testing and feedback without going through the longer, more thorough review process. We aim to complete "
+"these reviews in under 3 days."
 msgstr ""
-"Předběžné kontroly jsou vhodné pro experimentální doplňky a poskytují "
-"způsob, jak získat zpětnou vazbu od uživatelů bez toho, aby doplněk "
-"procházel delším a podrobnějším procesem kontroly. Snažíme se, aby tyto "
-"kontroly byly do tří dní."
+"Předběžné kontroly jsou vhodné pro experimentální doplňky a poskytují způsob, jak získat zpětnou vazbu od uživatelů bez toho, aby doplněk procházel delším a podrobnějším procesem kontroly. Snažíme "
+"se, aby tyto kontroly byly do tří dní."
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:160
 msgid "Testing Methods"
@@ -7283,58 +5755,36 @@ msgstr "Testovacie metódy"
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:162
 #, fuzzy
 msgid ""
-"When performing a preliminary review, editors will review the source code "
-"for security issues and major policy violations, but will not install the "
-"add-on to test functionality in most cases. Preliminary review will be "
-"granted unless a security vulnerability or major policy violation is "
-"discovered."
+"When performing a preliminary review, editors will review the source code for security issues and major policy violations, but will not install the add-on to test functionality in most cases. "
+"Preliminary review will be granted unless a security vulnerability or major policy violation is discovered."
 msgstr ""
-"Při kontrole doplňku editorem bude zkontrolován jeho zdrojový kód, zda "
-"neobsahuje bezpečnostní problémy či vážná porušení zásad, ale ve většině "
-"případů nebude instalován a nebude ověřována jeho funkcionalita. Předběžná "
-"kontrola bude udělena, pokud nebude nalezen bezpečnostní problém či vážné "
-"porušení zásad."
+"Při kontrole doplňku editorem bude zkontrolován jeho zdrojový kód, zda neobsahuje bezpečnostní problémy či vážná porušení zásad, ale ve většině případů nebude instalován a nebude ověřována jeho "
+"funkcionalita. Předběžná kontrola bude udělena, pokud nebude nalezen bezpečnostní problém či vážné porušení zásad."
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:171
 #, fuzzy
 msgid ""
-"Once preliminary review is granted, the add-on will be immediately available"
-" in the gallery, showing in browse and search results but ranked lower than "
-"fully-reviewed add-ons. Install buttons will have caution stripes and a "
-"notice that the add-on is experimental and not fully reviewed by Mozilla, "
-"though no click-through is required. Additionally, these add-ons cannot use "
-"the voluntary contributions and beta channel features."
+"Once preliminary review is granted, the add-on will be immediately available in the gallery, showing in browse and search results but ranked lower than fully-reviewed add-ons. Install buttons will "
+"have caution stripes and a notice that the add-on is experimental and not fully reviewed by Mozilla, though no click-through is required. Additionally, these add-ons cannot use the voluntary "
+"contributions and beta channel features."
 msgstr ""
-"Jakmile bude udělena předběžná kontrola, bude doplněk okamžitě k dispozici v"
-" galerii, bude dostupný v kategoriích a výsledcích vyhledávání, ale jeho "
-"hodnocení bude nižší než u plně zkontrolovaných doplňků. Tlačítko pro "
-"instalaci bude obsahovat varování, že doplněk je experimentální a nebyl "
-"Mozillou plně zkontrolován. U takových doplňků nemůže být žádáno o "
-"dobrovolné příspěvky a funkce beta kanálu není dostupná."
+"Jakmile bude udělena předběžná kontrola, bude doplněk okamžitě k dispozici v galerii, bude dostupný v kategoriích a výsledcích vyhledávání, ale jeho hodnocení bude nižší než u plně zkontrolovaných "
+"doplňků. Tlačítko pro instalaci bude obsahovat varování, že doplněk je experimentální a nebyl Mozillou plně zkontrolován. U takových doplňků nemůže být žádáno o dobrovolné příspěvky a funkce beta "
+"kanálu není dostupná."
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:177
 #, fuzzy
-msgid ""
-"After being granted preliminary review, Mozilla may later revoke the review "
-"if other serious problems are reported to us by users."
-msgstr ""
-"Po udělení předběžné kontroly ji může Mozilla později zrušit, pokud se "
-"objeví závažný problém, který bude uživateli nahlášen."
+msgid "After being granted preliminary review, Mozilla may later revoke the review if other serious problems are reported to us by users."
+msgstr "Po udělení předběžné kontroly ji může Mozilla později zrušit, pokud se objeví závažný problém, který bude uživateli nahlášen."
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:183
 #, fuzzy
 msgid ""
-"Subsequent versions of the add-on will automatically be placed in the "
-"preliminary review queue. Until the review is completed, the new version "
-"will only be displayed on the Version History page of the add-on. Once "
-"reviewed, the version will be updated across the site and deployed through "
-"the automatic update service."
+"Subsequent versions of the add-on will automatically be placed in the preliminary review queue. Until the review is completed, the new version will only be displayed on the Version History page of "
+"the add-on. Once reviewed, the version will be updated across the site and deployed through the automatic update service."
 msgstr ""
-"Další verze doplňku budou automaticky umisťovány do fronty pro předběžnou "
-"kontrolu. Dokud nebude kontrola dokončena, bude nová verze zobrazena pouze "
-"na stránce s historií verzí doplňku. Jakmile bude zkontrolována, bude "
-"dostupná napříč webem a distribuována skrze službu automatických "
-"aktualizací."
+"Další verze doplňku budou automaticky umisťovány do fronty pro předběžnou kontrolu. Dokud nebude kontrola dokončena, bude nová verze zobrazena pouze na stránce s historií verzí doplňku. Jakmile "
+"bude zkontrolována, bude dostupná napříč webem a distribuována skrze službu automatických aktualizací."
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:188
 msgid "Policies on Specific Add-on Practices"
@@ -7349,70 +5799,40 @@ msgid "The following add-ons are not permitted in any form:"
 msgstr "Následujúce doplnky nie sú v žiadnej forme dovolené:"
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:194
-msgid ""
-"Add-ons that embed known <a "
-"href=\"http://en.wikipedia.org/wiki/Spyware\">spyware</a> or <a "
-"href=\"http://en.wikipedia.org/wiki/Malware\">malware</a>"
-msgstr ""
-"Doplnky, ktoré obsahujú známy <a "
-"href=\"http://sk.wikipedia.org/wiki/Spyware\">spyware</a> či <a "
-"href=\"http://sk.wikipedia.org/wiki/Malware\">malware</a>"
+msgid "Add-ons that embed known <a href=\"http://en.wikipedia.org/wiki/Spyware\">spyware</a> or <a href=\"http://en.wikipedia.org/wiki/Malware\">malware</a>"
+msgstr "Doplnky, ktoré obsahujú známy <a href=\"http://sk.wikipedia.org/wiki/Spyware\">spyware</a> či <a href=\"http://sk.wikipedia.org/wiki/Malware\">malware</a>"
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:199
 msgid ""
-"Illegal and criminal add-ons, such as <a "
-"href=\"http://en.wikipedia.org/wiki/Click_fraud\">click fraud</a> "
-"generators, <a href=\"http://en.wikipedia.org/wiki/Warez\">warez</a> "
-"download and directory assistants, child pornography finders, etc."
+"Illegal and criminal add-ons, such as <a href=\"http://en.wikipedia.org/wiki/Click_fraud\">click fraud</a> generators, <a href=\"http://en.wikipedia.org/wiki/Warez\">warez</a> download and "
+"directory assistants, child pornography finders, etc."
 msgstr ""
-"Nelegálne alebo kriminálne doplnky a doplnky, ktoré vytvárajú <a "
-"href=\"http://en.wikipedia.org/wiki/Click_fraud\">podvodné kliknutia</a>, "
-"umožňujú preberanie <a "
-"href=\"http://cs.wikipedia.org/wiki/Warez\">warezu</a>, pomáhajú vyhľadávať "
-"detskú pornografiu atď."
+"Nelegálne alebo kriminálne doplnky a doplnky, ktoré vytvárajú <a href=\"http://en.wikipedia.org/wiki/Click_fraud\">podvodné kliknutia</a>, umožňujú preberanie <a "
+"href=\"http://cs.wikipedia.org/wiki/Warez\">warezu</a>, pomáhajú vyhľadávať detskú pornografiu atď."
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:204
-msgid ""
-"Add-ons whose main purpose is to facilitate access to pornographic material,"
-" or include references to this material in their descriptions"
-msgstr ""
-"Doplnky, ktorých hlavnou funkciou je sprostredkovávať prístup k "
-"pornografickým materiálom, alebo sústrediť takýto materiál v ich popisoch. "
+msgid "Add-ons whose main purpose is to facilitate access to pornographic material, or include references to this material in their descriptions"
+msgstr "Doplnky, ktorých hlavnou funkciou je sprostredkovávať prístup k pornografickým materiálom, alebo sústrediť takýto materiál v ich popisoch. "
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:210
-msgid ""
-"Add-ons that, upon installation, auto-install or launch installers of non-"
-"Firefox software"
-msgstr ""
-"Doplnky, ktoré po inštalácií automaticky inštalujú, alebo spúšťajú "
-"inštalátory iného softvéru, ktorý nie je súčasťou Firefoxu."
+msgid "Add-ons that, upon installation, auto-install or launch installers of non-Firefox software"
+msgstr "Doplnky, ktoré po inštalácií automaticky inštalujú, alebo spúšťajú inštalátory iného softvéru, ktorý nie je súčasťou Firefoxu."
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:215
-msgid ""
-"Add-ons that provide their own update mechanism for code or search engines"
-msgstr ""
-"Doplnky, ktoré poskytujú vlastný aktualizačný mechanizmus pre kód a "
-"vyhľadávacie moduly."
+msgid "Add-ons that provide their own update mechanism for code or search engines"
+msgstr "Doplnky, ktoré poskytujú vlastný aktualizačný mechanizmus pre kód a vyhľadávacie moduly."
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:220
-msgid ""
-"Add-ons that make changes to web content in ways that are non-obvious or "
-"difficult to trace by their users"
-msgstr ""
-"Doplnky, ktoré menia webový obsah spôsobom, ktorý je neobvyklý, alebo ťažko "
-"rozpoznateľný používateľmi."
+msgid "Add-ons that make changes to web content in ways that are non-obvious or difficult to trace by their users"
+msgstr "Doplnky, ktoré menia webový obsah spôsobom, ktorý je neobvyklý, alebo ťažko rozpoznateľný používateľmi."
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:225
 msgid "Add-ons that snoop on or intercept the network traffic of other users"
-msgstr ""
-"Doplnky, ktoré špehujú alebo zachytávajú sieťovú prevádzku iných "
-"používateľov"
+msgstr "Doplnky, ktoré špehujú alebo zachytávajú sieťovú prevádzku iných používateľov"
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:230
 msgid "Conduit-based toolbars without explicit pre-approval"
-msgstr ""
-"Automaticky generované panely (Conduit), ktoré neboli skôr explicitne "
-"schválené"
+msgstr "Automaticky generované panely (Conduit), ktoré neboli skôr explicitne schválené"
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:236
 msgid "Changing of Defaults and Unexpected Features"
@@ -7421,52 +5841,28 @@ msgstr "Zmena východzích hodnôt, alebo neočakávané funkcie"
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:238
 #, fuzzy
 msgid ""
-"Surprises can be appropriate in many situations, but they are not welcome "
-"when user security, privacy, and control are at stake. It is extremely "
-"important to be as transparent as possible when submitting an add-on for "
-"hosting on this site. A Mozilla user should be able to easily discern what "
-"the functionality of an add-on is and not be presented with unexpected "
-"experiences post-install."
+"Surprises can be appropriate in many situations, but they are not welcome when user security, privacy, and control are at stake. It is extremely important to be as transparent as possible when "
+"submitting an add-on for hosting on this site. A Mozilla user should be able to easily discern what the functionality of an add-on is and not be presented with unexpected experiences post-install."
 msgstr ""
-"Překvapení může být přijatelné v řadě situací, ale nejsou vítána, když jde o"
-" bezpečnost uživatele, jeho soukromí či ovládání prohlížeče. Když přidávate "
-"doplněk na server, je extrémně důležité být transparentní jak jen to jde. "
-"Uživatel Mozilly by měl snadno poznat, jakou funkcionalitu doplněk poskytuje"
-" a ne být po instalaci překvapen nezvyklým chováním."
+"Překvapení může být přijatelné v řadě situací, ale nejsou vítána, když jde o bezpečnost uživatele, jeho soukromí či ovládání prohlížeče. Když přidávate doplněk na server, je extrémně důležité být "
+"transparentní jak jen to jde. Uživatel Mozilly by měl snadno poznat, jakou funkcionalitu doplněk poskytuje a ne být po instalaci překvapen nezvyklým chováním."
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:243
 msgid ""
-"<p> Whenever an add-on includes any unexpected* feature that </p> <ul> "
-"<li>compromises user privacy or security (like sending data to third "
-"parties),</li> <li>changes default settings like the homepage or search "
-"engine, or</li> <li>changes settings or features in other add-ons or "
-"deactivates them altogether</li> </ul> <p>the features must adhere to the "
-"following requirements:</p> <ul> <li>The add-on description must clearly "
-"state what changes the add-on makes.</li> <li>All changes must be opt-in, "
-"meaning the user must take non-default action to enact the change.</li> "
-"<li>The opt-in dialog must clearly state the name of the add-on requesting "
-"the change.</li> <li>Uninstalling the add-on restores the user's original "
-"settings if they were changed.</li> </ul> <p>*Unexpected features are those "
-"that are unrelated to the add-on's primary function.</p>"
+"<p> Whenever an add-on includes any unexpected* feature that </p> <ul> <li>compromises user privacy or security (like sending data to third parties),</li> <li>changes default settings like the "
+"homepage or search engine, or</li> <li>changes settings or features in other add-ons or deactivates them altogether</li> </ul> <p>the features must adhere to the following requirements:</p> <ul> "
+"<li>The add-on description must clearly state what changes the add-on makes.</li> <li>All changes must be opt-in, meaning the user must take non-default action to enact the change.</li> <li>The "
+"opt-in dialog must clearly state the name of the add-on requesting the change.</li> <li>Uninstalling the add-on restores the user's original settings if they were changed.</li> </ul> <p>*Unexpected"
+" features are those that are unrelated to the add-on's primary function.</p>"
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:268
-msgid ""
-"These features cannot be introduced into an update of a fully-reviewed add-"
-"on; the opt-in change process must be part of the initial review."
-msgstr ""
-"Takéto funkcie nemôžu byť zahrnuté do aktualizácie plne skontrolovaného "
-"doplnku, ale musia byť zahrnuté v úvodnej kontrole."
+msgid "These features cannot be introduced into an update of a fully-reviewed add-on; the opt-in change process must be part of the initial review."
+msgstr "Takéto funkcie nemôžu byť zahrnuté do aktualizácie plne skontrolovaného doplnku, ale musia byť zahrnuté v úvodnej kontrole."
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:274
-msgid ""
-"These are minimum requirements and not a guarantee that the add-on will be "
-"approved. This section applies to all add-ons hosted on the site, including "
-"preliminarily reviewed add-ons."
-msgstr ""
-"Jedná sa o minimálne požiadavky, ktoré negarantujú, že bude doplnok "
-"schválený. Táto sekcia je platná pre všetky doplnky umiestnené na tomto webe"
-" a to vrátane predbežne skontrolovaných doplnkov."
+msgid "These are minimum requirements and not a guarantee that the add-on will be approved. This section applies to all add-ons hosted on the site, including preliminarily reviewed add-ons."
+msgstr "Jedná sa o minimálne požiadavky, ktoré negarantujú, že bude doplnok schválený. Táto sekcia je platná pre všetky doplnky umiestnené na tomto webe a to vrátane predbežne skontrolovaných doplnkov."
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:279
 msgid "Private Browsing Mode"
@@ -7474,18 +5870,11 @@ msgstr "Režim súkromného prehliadania"
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:282
 msgid ""
-"Add-ons that store or otherwise handle browsing data must support <a "
-"href=\"https://developer.mozilla.org/En/Supporting_private_browsing_mode\">Private"
-" Browsing Mode</a>. During a Private Browsing session, no browsing data can "
-"be written to disk, and all of this data must be cleared when Firefox quits "
-"or the Private Browsing session ends."
+"Add-ons that store or otherwise handle browsing data must support <a href=\"https://developer.mozilla.org/En/Supporting_private_browsing_mode\">Private Browsing Mode</a>. During a Private Browsing "
+"session, no browsing data can be written to disk, and all of this data must be cleared when Firefox quits or the Private Browsing session ends."
 msgstr ""
-"Doplňky, které ukládají nebo jinak pracují s daty prohlížeče musí podporovat"
-" <a "
-"href=\"https://developer.mozilla.org/En/Supporting_private_browsing_mode\">Režim"
-" anonymního prohlížení</a>. Během relace anonymního prohlížení nemohou být "
-"taková data zapisována na disk a všechna taková data musí být smazána v "
-"situaci, kdy Firefox ukončuje relaci anonymního prohlížení."
+"Doplňky, které ukládají nebo jinak pracují s daty prohlížeče musí podporovat <a href=\"https://developer.mozilla.org/En/Supporting_private_browsing_mode\">Režim anonymního prohlížení</a>. Během "
+"relace anonymního prohlížení nemohou být taková data zapisována na disk a všechna taková data musí být smazána v situaci, kdy Firefox ukončuje relaci anonymního prohlížení."
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:287
 msgid "Binary Components & Obfuscated Code"
@@ -7494,37 +5883,24 @@ msgstr "Binárne komponenty a kód z obfuskátora"
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:289
 #, fuzzy
 msgid ""
-"Add-ons may contain binary, obfuscated and minified source code, but Mozilla"
-" must be allowed to review a copy of the human-readable source code of each "
-"version of an add-on submitted for review. These add-ons are ineligible for "
-"preliminary review and must choose the full review process."
+"Add-ons may contain binary, obfuscated and minified source code, but Mozilla must be allowed to review a copy of the human-readable source code of each version of an add-on submitted for review. "
+"These add-ons are ineligible for preliminary review and must choose the full review process."
 msgstr ""
-"Doplňky mohou obsahovat binární komponenty, kód z obfuskátoru a "
-"minimalizovaný kód, ale Mozille musí být dovoleno zkontrolovat kopii lidsky "
-"čitelného zdrojového kódu každé verze doplňku, která byla odeslána na "
-"kontrolu. Tyto doplňky nemohou být pouze předběžně zkontrolovány a musí "
-"projít plným procesem kontroly."
+"Doplňky mohou obsahovat binární komponenty, kód z obfuskátoru a minimalizovaný kód, ale Mozille musí být dovoleno zkontrolovat kopii lidsky čitelného zdrojového kódu každé verze doplňku, která byla"
+" odeslána na kontrolu. Tyto doplňky nemohou být pouze předběžně zkontrolovány a musí projít plným procesem kontroly."
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:295
 msgid ""
-"If an add-on contains binary or obfuscated source code, the author will "
-"receive a message when the add-on is reviewed indicating whom to contact at "
-"Mozilla to coordinate review of the source code. This code will be reviewed "
-"by an administrator and will not be shared or redistributed in any way. The "
-"code will only be used for the purpose of reviewing the add-on."
+"If an add-on contains binary or obfuscated source code, the author will receive a message when the add-on is reviewed indicating whom to contact at Mozilla to coordinate review of the source code. "
+"This code will be reviewed by an administrator and will not be shared or redistributed in any way. The code will only be used for the purpose of reviewing the add-on."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:301
 #, fuzzy, python-format
-msgid ""
-"If your add-on contains binary or obfuscated code that you don't own or "
-"can't get the source code for, you may <a href=\"%(link_contact)s\">contact "
-"us</a> for information on how to proceed."
+msgid "If your add-on contains binary or obfuscated code that you don't own or can't get the source code for, you may <a href=\"%(link_contact)s\">contact us</a> for information on how to proceed."
 msgstr ""
-"Pokud doplněk obsahuje binární komponentu nebo kód z obfuskátoru, který "
-"nevlastníte nebo k němu nemůžete poskytnout zdrojový kód, <a "
-"href=\"%(link_contact)s\">kontaktujte nás</a> pro více informací, jak tuto "
-"situaci vyřešit."
+"Pokud doplněk obsahuje binární komponentu nebo kód z obfuskátoru, který nevlastníte nebo k němu nemůžete poskytnout zdrojový kód, <a href=\"%(link_contact)s\">kontaktujte nás</a> pro více "
+"informací, jak tuto situaci vyřešit."
 
 #: src/olympia/devhub/templates/devhub/docs/policies-submission.html:11
 msgid "Criteria for Submission"
@@ -7533,200 +5909,115 @@ msgstr "Kritériá pre odoslanie doplnku"
 #: src/olympia/devhub/templates/devhub/docs/policies-submission.html:13
 #, fuzzy
 msgid ""
-"Add-ons hosted on Mozilla Add-ons should be of high quality and give users "
-"an improved web experience. We look for the following things when deciding "
-"whether an add-on is appropriate to be public and unrestricted:"
+"Add-ons hosted on Mozilla Add-ons should be of high quality and give users an improved web experience. We look for the following things when deciding whether an add-on is appropriate to be public "
+"and unrestricted:"
 msgstr ""
-"Doplňky hostované na serveru Doplňky Mozilly by měly mít odpovídající "
-"kvalitu a poskytovat uživatelům lepší zážitek z webu. Pro posouzení toho, "
-"zda má být doplněk schválen a veřejný, se díváme na následující kritéria:"
+"Doplňky hostované na serveru Doplňky Mozilly by měly mít odpovídající kvalitu a poskytovat uživatelům lepší zážitek z webu. Pro posouzení toho, zda má být doplněk schválen a veřejný, se díváme na "
+"následující kritéria:"
 
 #: src/olympia/devhub/templates/devhub/docs/policies-submission.html:19
 #, fuzzy
 msgid ""
-"<strong>Are you responsive?</strong> We expect that an author who is "
-"promoting their add-on to our applications' many users is responsive to "
-"problem reports, maintains their contact information, and updates their add-"
-"on promptly to keep current with Firefox releases and changes in our "
-"policies. This doesn't mean that you have to reply to every question that "
-"someone posts in the discussions, or that you even need to fix every bug, "
-"but we do expect that you will respond to issues in a manner that's "
-"appropriate to the severity of the issue in question."
+"<strong>Are you responsive?</strong> We expect that an author who is promoting their add-on to our applications' many users is responsive to problem reports, maintains their contact information, "
+"and updates their add-on promptly to keep current with Firefox releases and changes in our policies. This doesn't mean that you have to reply to every question that someone posts in the "
+"discussions, or that you even need to fix every bug, but we do expect that you will respond to issues in a manner that's appropriate to the severity of the issue in question."
 msgstr ""
-"<strong>Reagujete?</strong> Očekáváme, že autor, který propaguje své doplňky"
-" v rámci našich aplikací reaguje na problémy nahlášené uživateli, udržuje "
-"své kontaktní informace aktuální a aktualizuje své doplňky včas tak, aby "
-"byly aktuální vzhledem k posledním verzím Firefoxu a změnám v našich "
-"zásadách. To neznamená, že musíte odpovědět na každou otázku, kterou někdo "
-"přidá do diskuse nebo že musíte opravit každou chybu, ale očekáváme, že "
-"obecně budete reagovat na problémy a řešit jejich závažnost."
+"<strong>Reagujete?</strong> Očekáváme, že autor, který propaguje své doplňky v rámci našich aplikací reaguje na problémy nahlášené uživateli, udržuje své kontaktní informace aktuální a aktualizuje "
+"své doplňky včas tak, aby byly aktuální vzhledem k posledním verzím Firefoxu a změnám v našich zásadách. To neznamená, že musíte odpovědět na každou otázku, kterou někdo přidá do diskuse nebo že "
+"musíte opravit každou chybu, ale očekáváme, že obecně budete reagovat na problémy a řešit jejich závažnost."
 
 #: src/olympia/devhub/templates/devhub/docs/policies-submission.html:25
 msgid ""
-"<strong>Is the add-on clearly and accurately described?</strong> It's of the"
-" utmost importance to us that users get what they expect when they try a new"
-" add-on. Your add-on name should be clear and concise, and you should "
-"refrain from using special characters or numbers to get higher search "
-"rankings or for decorative purposes. Your description should provide details"
-" about what the add-on does, how a user should take advantage of it, and "
-"what the user should expect when they install it. Links to external "
-"documents for detailed instructions are fine, but the description itself "
-"should cover the basics and leave users confident that they know what "
-"they'll get. Also, it is important that you maintain version notes "
-"appropriately as you improve and change your add-on. Users should be able to"
-" see what's new in an add-on they may have tried previously, and should be "
-"made aware of changes that might affect their current use of the add-on when"
-" they update."
+"<strong>Is the add-on clearly and accurately described?</strong> It's of the utmost importance to us that users get what they expect when they try a new add-on. Your add-on name should be clear and"
+" concise, and you should refrain from using special characters or numbers to get higher search rankings or for decorative purposes. Your description should provide details about what the add-on "
+"does, how a user should take advantage of it, and what the user should expect when they install it. Links to external documents for detailed instructions are fine, but the description itself should"
+" cover the basics and leave users confident that they know what they'll get. Also, it is important that you maintain version notes appropriately as you improve and change your add-on. Users should "
+"be able to see what's new in an add-on they may have tried previously, and should be made aware of changes that might affect their current use of the add-on when they update."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/docs/policies-submission.html:31
 msgid ""
-"<strong>Are all privacy and security concerns clearly spelled out?</strong> "
-"This is an aspect of a clear and accurate description, but such an important"
-" one that we feel it deserves specific mention. Many very useful and well-"
-"written add-ons manipulate some form of user data, or can present security "
-"hazards if misused; they are welcome on the site, but they must make it very"
-" clear to users what risks they might encounter, and what they can do to "
-"protect themselves."
+"<strong>Are all privacy and security concerns clearly spelled out?</strong> This is an aspect of a clear and accurate description, but such an important one that we feel it deserves specific "
+"mention. Many very useful and well-written add-ons manipulate some form of user data, or can present security hazards if misused; they are welcome on the site, but they must make it very clear to "
+"users what risks they might encounter, and what they can do to protect themselves."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/docs/policies-submission.html:37
 msgid ""
-"<strong>Has the add-on been well-tested, and is it free of obvious or "
-"serious defects?</strong> One important thing that we look for when "
-"considering an add-on is whether its user reviews indicate that it has "
-"received thorough testing, and that it doesn't have serious problems or "
-"negative impacts on the browser. If reviewers report problems such as major "
-"performance issues, crashes, frequent problems using the functions of the "
-"add-on, or spamming of messages to the error console, you should take those "
-"reports to heart, and re-submit your add-on after you've addressed them as "
-"best you can. We don't expect you to perfectly optimize or have zero bugs "
-"&mdash; Firefox itself undergoes constant improvement in these areas &mdash;"
-" but we do want you to take reasonable efforts to minimize downsides, and to"
-" clearly call out cases where users may be surprised by those that remain."
+"<strong>Has the add-on been well-tested, and is it free of obvious or serious defects?</strong> One important thing that we look for when considering an add-on is whether its user reviews indicate "
+"that it has received thorough testing, and that it doesn't have serious problems or negative impacts on the browser. If reviewers report problems such as major performance issues, crashes, frequent"
+" problems using the functions of the add-on, or spamming of messages to the error console, you should take those reports to heart, and re-submit your add-on after you've addressed them as best you "
+"can. We don't expect you to perfectly optimize or have zero bugs &mdash; Firefox itself undergoes constant improvement in these areas &mdash; but we do want you to take reasonable efforts to "
+"minimize downsides, and to clearly call out cases where users may be surprised by those that remain."
 msgstr ""
-"<strong>Bol doplnok zodpovedne otestovaný a neobsahuje žiadne závažné "
-"problémy?</strong> Jedným z dôležitých bodov pre posudzovanie kvality "
-"doplnkov sú recenzie používateľov, ktoré indikujú, či bol doplnok otestovaný"
-" a či nemá vážne problémy, prípadne negatívny vplyv na prehliadač. Ak vám "
-"redaktor nahlási problémy ako je vážny vplyv na výkon, pády, časté problémy "
-"s funkcionalitou doplnku, spamovanie správ do chybovej konzoly, mali by ste "
-"si to vziať k srdcu a vytvoriť novú verziu doplnku, ktorá vyrieši maximum z "
-"týchto problémov. Neočakávame perfektnú optimalizáciu alebo nulové množstvo "
-"chýb &mdash; Firefox sám sa neustále zlepšuje &mdash; chceme ale, aby ste "
-"doplnok konštantne zlepšovali a minimalizovali situácie, kedy nefunguje "
-"podľa očakávaní používateľov. Zároveň prosíme, aby ste tieto situácie "
-"popísali, aby používatelia neboli prekvapení.   "
+"<strong>Bol doplnok zodpovedne otestovaný a neobsahuje žiadne závažné problémy?</strong> Jedným z dôležitých bodov pre posudzovanie kvality doplnkov sú recenzie používateľov, ktoré indikujú, či bol"
+" doplnok otestovaný a či nemá vážne problémy, prípadne negatívny vplyv na prehliadač. Ak vám redaktor nahlási problémy ako je vážny vplyv na výkon, pády, časté problémy s funkcionalitou doplnku, "
+"spamovanie správ do chybovej konzoly, mali by ste si to vziať k srdcu a vytvoriť novú verziu doplnku, ktorá vyrieši maximum z týchto problémov. Neočakávame perfektnú optimalizáciu alebo nulové "
+"množstvo chýb &mdash; Firefox sám sa neustále zlepšuje &mdash; chceme ale, aby ste doplnok konštantne zlepšovali a minimalizovali situácie, kedy nefunguje podľa očakávaní používateľov. Zároveň "
+"prosíme, aby ste tieto situácie popísali, aby používatelia neboli prekvapení.   "
 
 #: src/olympia/devhub/templates/devhub/docs/policies-submission.html:43
 msgid ""
-"<strong>Do the add-on and add-on author both treat the user "
-"respectfully?</strong> Your software should not intrude on the user "
-"unnecessarily, try to trick the user, or conceal any of its activities from "
-"the user. Users (or even non-users) are sometimes rude in their comments, "
-"and while we will do our best to filter out inaccurate reviews as they're "
-"reported to us, we do expect that authors will avoid retaliating with "
-"rudeness of their own."
+"<strong>Do the add-on and add-on author both treat the user respectfully?</strong> Your software should not intrude on the user unnecessarily, try to trick the user, or conceal any of its "
+"activities from the user. Users (or even non-users) are sometimes rude in their comments, and while we will do our best to filter out inaccurate reviews as they're reported to us, we do expect that"
+" authors will avoid retaliating with rudeness of their own."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/docs/policies-submission.html:49
 msgid ""
-"<strong>Is the add-on useful to an appropriately wide portion of Firefox's "
-"users?</strong> Your add-on doesn't need to be the next Greasemonkey or "
-"Firebug, but if it is only useful to people at your company or who are part "
-"of a small web community, we may feel that it's not yet appropriate to put "
-"it in front of all of our users."
+"<strong>Is the add-on useful to an appropriately wide portion of Firefox's users?</strong> Your add-on doesn't need to be the next Greasemonkey or Firebug, but if it is only useful to people at "
+"your company or who are part of a small web community, we may feel that it's not yet appropriate to put it in front of all of our users."
 msgstr ""
-"<strong>Je doplnok užitočný pre široké spektrum používateľov "
-"Firefoxu?</strong> Váš doplnok nemusí byť zrovna ďalší Greasemonkey či "
-"Firebug, ale ak je doplnok užitočný len pre zamestnancov vo vašej firme "
-"alebo pre tých, ktorí sú súčasťou malej webové komunity, tak možno cítite, "
-"že nie je vhodný pre široké spektrum používateľov Firefoxu."
+"<strong>Je doplnok užitočný pre široké spektrum používateľov Firefoxu?</strong> Váš doplnok nemusí byť zrovna ďalší Greasemonkey či Firebug, ale ak je doplnok užitočný len pre zamestnancov vo vašej"
+" firme alebo pre tých, ktorí sú súčasťou malej webové komunity, tak možno cítite, že nie je vhodný pre široké spektrum používateľov Firefoxu."
 
 #: src/olympia/devhub/templates/devhub/docs/policies-submission.html:55
 #, fuzzy
 msgid ""
-"We are constantly looking at ways to improve the organization of the site to"
-" better accommodate add-ons that are exemplary in other ways, but are aimed "
-"at only a small community of potential users. Correctly categorizing and "
-"maintaining the metadata of your add-on will help us figure out how we can "
-"surface more of those sorts of add-ons to people who are most likely to "
-"benefit from them."
+"We are constantly looking at ways to improve the organization of the site to better accommodate add-ons that are exemplary in other ways, but are aimed at only a small community of potential users."
+" Correctly categorizing and maintaining the metadata of your add-on will help us figure out how we can surface more of those sorts of add-ons to people who are most likely to benefit from them."
 msgstr ""
-"Neustále hledáme způsoby, jak vylepšit organizaci webu tak, aby lépe vyhověl"
-" doplňkům, které jsou v nějakém ohledu užitečné, ale jsou zaměřeny pouze na "
-"malou skupinu potenciálních uživatelů. Správa kategorizace a správa metadat "
-"vašeho doplňku nám pomůže rozpoznat, kam můžeme váš doplněk správně zařadit,"
-" aby jej uživatelé, kteří jej budou hledat, nalezli."
+"Neustále hledáme způsoby, jak vylepšit organizaci webu tak, aby lépe vyhověl doplňkům, které jsou v nějakém ohledu užitečné, ale jsou zaměřeny pouze na malou skupinu potenciálních uživatelů. Správa"
+" kategorizace a správa metadat vašeho doplňku nám pomůže rozpoznat, kam můžeme váš doplněk správně zařadit, aby jej uživatelé, kteří jej budou hledat, nalezli."
 
 #: src/olympia/devhub/templates/devhub/docs/policies-submission.html:61
 #, fuzzy
 msgid ""
-"If your add-on just provides bookmarks or other simple access points to your"
-" site, it's probably not appropriate for the gallery. Like the rest of the "
-"Mozilla project, we love web applications and new web services, but Firefox "
-"add-ons should provide an improved browsing experience for the user and not "
-"just be a way to promote a new site or service through a Mozilla Add-ons "
-"listing."
+"If your add-on just provides bookmarks or other simple access points to your site, it's probably not appropriate for the gallery. Like the rest of the Mozilla project, we love web applications and "
+"new web services, but Firefox add-ons should provide an improved browsing experience for the user and not just be a way to promote a new site or service through a Mozilla Add-ons listing."
 msgstr ""
-"Pokud váš doplněk poskytuje pouze záložky nebo jiný jednoduchý přístup k "
-"vašemu webu, není patrně vhodný pro přidání do naší galerie. Stejně jako "
-"zbytek projektu Mozilla, tak i my máme rádi webové aplikace a nové webové "
-"služby, ale doplňky pro Firefox by měly poskytovat lepší zážitek z "
-"prohlížení webu pro uživatele a ne být pouze způsobem pro propagaci "
-"vlastního webu skrze web Doplňky Mozilly."
+"Pokud váš doplněk poskytuje pouze záložky nebo jiný jednoduchý přístup k vašemu webu, není patrně vhodný pro přidání do naší galerie. Stejně jako zbytek projektu Mozilla, tak i my máme rádi webové "
+"aplikace a nové webové služby, ale doplňky pro Firefox by měly poskytovat lepší zážitek z prohlížení webu pro uživatele a ne být pouze způsobem pro propagaci vlastního webu skrze web Doplňky "
+"Mozilly."
 
 #: src/olympia/devhub/templates/devhub/docs/policies-submission.html:67
 msgid ""
-"<strong>Is the add-on free of unlicensed trademarks and copyrights?</strong>"
-" Though you may mean no harm to the holder of a trademark, or the owner of a"
-" copyrighted work, we can't host add-ons that infringe on trademarks or "
-"copyrights. If you don't have permission to use a trademarked name or image,"
-" please do not submit your add-on to us. If your add-on includes code that "
-"is copyrighted by someone else, and is not licensed to you to use in your "
-"add-on, please do not submit your add-on to us."
+"<strong>Is the add-on free of unlicensed trademarks and copyrights?</strong> Though you may mean no harm to the holder of a trademark, or the owner of a copyrighted work, we can't host add-ons that"
+" infringe on trademarks or copyrights. If you don't have permission to use a trademarked name or image, please do not submit your add-on to us. If your add-on includes code that is copyrighted by "
+"someone else, and is not licensed to you to use in your add-on, please do not submit your add-on to us."
 msgstr ""
-"<strong>Neobsahuje váš doplnok materiál porušujúci ochranné známky alebo "
-"copyright?</strong> Aj keď si myslíte, že váš doplnok nemôže držiteľovi "
-"ochrannej známky spôsobiť žiadnu škodu, nemôžeme ku nám umiestňovať doplnky,"
-" ktoré ochranné známky alebo copyright porušujú. Ak nemáte právo na "
-"používanie chráneného názvu či obrázka, prosíme, nepridávajte doplnok do "
-"galérie. Ak váš doplnok obsahuje kód, ktorý je vlastnený niekym iným a nie "
-"je licencovaný pre použitie vo vašom doplnku, prosíme, nepridávajte doplnok "
-"do galérie."
+"<strong>Neobsahuje váš doplnok materiál porušujúci ochranné známky alebo copyright?</strong> Aj keď si myslíte, že váš doplnok nemôže držiteľovi ochrannej známky spôsobiť žiadnu škodu, nemôžeme ku "
+"nám umiestňovať doplnky, ktoré ochranné známky alebo copyright porušujú. Ak nemáte právo na používanie chráneného názvu či obrázka, prosíme, nepridávajte doplnok do galérie. Ak váš doplnok obsahuje"
+" kód, ktorý je vlastnený niekym iným a nie je licencovaný pre použitie vo vašom doplnku, prosíme, nepridávajte doplnok do galérie."
 
 #: src/olympia/devhub/templates/devhub/docs/policies-submission.html:73
 msgid ""
-"In terms of reuse of source code from other add-ons, if the author has not "
-"clearly stated that you are permitted to use his or her code in your own "
-"work &mdash; such as by placing it under an open source license &mdash; then"
-" you should assume that you do not have the right to do so. You can contact "
-"the author to seek such permission, but we can't provide you with any "
-"special rights to it just because it's listed on the site, or because the "
-"author isn't responding to your request."
+"In terms of reuse of source code from other add-ons, if the author has not clearly stated that you are permitted to use his or her code in your own work &mdash; such as by placing it under an open "
+"source license &mdash; then you should assume that you do not have the right to do so. You can contact the author to seek such permission, but we can't provide you with any special rights to it "
+"just because it's listed on the site, or because the author isn't responding to your request."
 msgstr ""
-"Ak v súvislosti s využitím kódu z iných doplnkov ich autor jasne nepovedal, "
-"že môžete jeho kód vo svojej práci použiť (napr. definovaním, pod akou open "
-"source licenciou je dostupný), tak predpokladajte, že nemáte právo ho "
-"prevziať. Môžete ale autora takéhoto kódu kontaktovať a požiadať o "
-"dovolenie. My vám však nedávame žiadne špeciálne práva len pre to, že je "
-"doplnok umiestnený na našom webe, alebo ak autor neodpovedá na vašu "
-"požiadavku."
+"Ak v súvislosti s využitím kódu z iných doplnkov ich autor jasne nepovedal, že môžete jeho kód vo svojej práci použiť (napr. definovaním, pod akou open source licenciou je dostupný), tak "
+"predpokladajte, že nemáte právo ho prevziať. Môžete ale autora takéhoto kódu kontaktovať a požiadať o dovolenie. My vám však nedávame žiadne špeciálne práva len pre to, že je doplnok umiestnený na "
+"našom webe, alebo ak autor neodpovedá na vašu požiadavku."
 
 #: src/olympia/devhub/templates/devhub/docs/policies-submission.html:79
 msgid ""
-"This applies to the Mozilla Foundation's trademarks as well, including "
-"\"Mozilla\", \"Firefox\", and \"Thunderbird\". The Mozilla policy on "
-"trademark use is designed to protect against confusion, and prevent the "
-"trademarks from being overturned due to lack of protection; please respect "
-"the need for such protection, and help us preserve some of the most valuable"
-" assets of the Mozilla Foundation."
+"This applies to the Mozilla Foundation's trademarks as well, including \"Mozilla\", \"Firefox\", and \"Thunderbird\". The Mozilla policy on trademark use is designed to protect against confusion, "
+"and prevent the trademarks from being overturned due to lack of protection; please respect the need for such protection, and help us preserve some of the most valuable assets of the Mozilla "
+"Foundation."
 msgstr ""
-"To isté platí aj pre ochranné známky Mozilla Foundation ako sú \"Mozilla\", "
-"\"Firefox\" alebo \"Thunderbird\". Zásady ochrany ochranných známok Mozilly "
-"sú stanovené tak, aby zabraňovali zavádzaniu používateľov a zabraňujú ich "
-"zneužitiu. Rešpektujte prosím potrebu takejto ochrany a pomôžte nám ochrániť"
-" aktíva Mozilla Foundation."
+"To isté platí aj pre ochranné známky Mozilla Foundation ako sú \"Mozilla\", \"Firefox\" alebo \"Thunderbird\". Zásady ochrany ochranných známok Mozilly sú stanovené tak, aby zabraňovali zavádzaniu "
+"používateľov a zabraňujú ich zneužitiu. Rešpektujte prosím potrebu takejto ochrany a pomôžte nám ochrániť aktíva Mozilla Foundation."
 
 #: src/olympia/devhub/templates/devhub/docs/policies-submission.html:84
 msgid "Licensing"
@@ -7735,231 +6026,145 @@ msgstr "Licencovanie"
 #: src/olympia/devhub/templates/devhub/docs/policies-submission.html:86
 #, fuzzy
 msgid ""
-"Selecting an appropriate license for your add-on is a very important step in"
-" the submission process. A license specifies the rights you grant on your "
-"source code and is important in protecting your intellectual property."
+"Selecting an appropriate license for your add-on is a very important step in the submission process. A license specifies the rights you grant on your source code and is important in protecting your"
+" intellectual property."
 msgstr ""
-"Volba správné licence pro váš doplněk je velmi důležitý krok při procesu "
-"přidávání doplňku na server. Licence určuje, jaká práva dáváte ke svému "
-"zdrojovému kódu a je důležitá pro ochranu vašeho intelektuálního "
-"vlastnictví."
+"Volba správné licence pro váš doplněk je velmi důležitý krok při procesu přidávání doplňku na server. Licence určuje, jaká práva dáváte ke svému zdrojovému kódu a je důležitá pro ochranu vašeho "
+"intelektuálního vlastnictví."
 
 #: src/olympia/devhub/templates/devhub/docs/policies-submission.html:92
 msgid ""
-"During the add-on submission process, you will be presented with a list of "
-"popular licenses to choose from, as well as the ability to specify your own "
-"license. It is best to consult with a legal professional about which license"
-" option is best for you. Choosing the right license for your source code "
-"will help to prevent confusion and code conflicts in the future."
+"During the add-on submission process, you will be presented with a list of popular licenses to choose from, as well as the ability to specify your own license. It is best to consult with a legal "
+"professional about which license option is best for you. Choosing the right license for your source code will help to prevent confusion and code conflicts in the future."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/docs/policies.html:12
-#: src/olympia/devhub/templates/devhub/docs/policies.html:52
+#: src/olympia/devhub/templates/devhub/docs/policies.html:12 src/olympia/devhub/templates/devhub/docs/policies.html:52
 msgid "Add-on Submission"
 msgstr "Odoslanie doplnku"
 
-#: src/olympia/devhub/templates/devhub/docs/policies.html:18
-#: src/olympia/devhub/templates/devhub/docs/policies.html:78
+#: src/olympia/devhub/templates/devhub/docs/policies.html:18 src/olympia/devhub/templates/devhub/docs/policies.html:78
 msgid "Maintaining Your Add-on"
 msgstr "Spravovanie svojho doplnku"
 
 #: src/olympia/devhub/templates/devhub/docs/policies.html:43
-msgid ""
-"Mozilla is committed to ensuring a great add-ons experience for our users "
-"and developers. Please review the policies below before submitting your add-"
-"on."
-msgstr ""
-"Mozilla chce prispieť k zabezpečeniu skvelého zážitku z doplnkov pre našich "
-"používateľov a vývojárov. Pred odoslaním vášho doplnku si preto pozrite "
-"nižšie uvedené zásady tvorby a správy doplnkov."
+msgid "Mozilla is committed to ensuring a great add-ons experience for our users and developers. Please review the policies below before submitting your add-on."
+msgstr "Mozilla chce prispieť k zabezpečeniu skvelého zážitku z doplnkov pre našich používateľov a vývojárov. Pred odoslaním vášho doplnku si preto pozrite nižšie uvedené zásady tvorby a správy doplnkov."
 
 #: src/olympia/devhub/templates/devhub/docs/policies.html:55
-msgid ""
-"Find out what is expected of add-ons we host and our policies on specific "
-"add-on practices."
-msgstr ""
-"Pozrite sa, čo očakávame od tu umiestnených doplnkov a prečítajte si zásady "
-"pre špeciálne prípady doplnkov."
+msgid "Find out what is expected of add-ons we host and our policies on specific add-on practices."
+msgstr "Pozrite sa, čo očakávame od tu umiestnených doplnkov a prečítajte si zásady pre špeciálne prípady doplnkov."
 
 #: src/olympia/devhub/templates/devhub/docs/policies.html:67
-msgid ""
-"What happens after your add-on is submitted? Learn about how our Editors "
-"review submissions."
-msgstr ""
-"Čo sa deje po odoslaní doplnku? Pozrite sa, ako editori kontrolujú nové "
-"doplnky."
+msgid "What happens after your add-on is submitted? Learn about how our Editors review submissions."
+msgstr "Čo sa deje po odoslaní doplnku? Pozrite sa, ako editori kontrolujú nové doplnky."
 
 #: src/olympia/devhub/templates/devhub/docs/policies.html:81
-msgid ""
-"Add-on updates, transferring ownership, user reviews, and what to expect "
-"once your add-on is approved."
-msgstr ""
-"Aktualizácie doplnkov, zmena vlastníctva, recenzie od používateľov a čo "
-"očakávať po schválení doplnku."
+msgid "Add-on updates, transferring ownership, user reviews, and what to expect once your add-on is approved."
+msgstr "Aktualizácie doplnkov, zmena vlastníctva, recenzie od používateľov a čo očakávať po schválení doplnku."
 
 #: src/olympia/devhub/templates/devhub/docs/policies.html:93
-msgid ""
-"How up-and-coming add-ons become featured and what&#039;s involved in the "
-"process."
-msgstr ""
-"Ako sa môžu stať doplnky odporúčanými a čo všetko hrá rolu pri tomto "
-"procese."
+msgid "How up-and-coming add-ons become featured and what&#039;s involved in the process."
+msgstr "Ako sa môžu stať doplnky odporúčanými a čo všetko hrá rolu pri tomto procese."
 
 #: src/olympia/devhub/templates/devhub/docs/policies.html:106
-msgid ""
-"Terms of Service for submitting your work to our site. Developers are "
-"required to accept this agreement before submission."
-msgstr ""
-"Zásady používania Služby pre odoslanie vašej práce na tento server. Vývojári"
-" musia pred odoslaním súhlasiť s touto zmluvou."
+msgid "Terms of Service for submitting your work to our site. Developers are required to accept this agreement before submission."
+msgstr "Zásady používania Služby pre odoslanie vašej práce na tento server. Vývojári musia pred odoslaním súhlasiť s touto zmluvou."
 
 #: src/olympia/devhub/templates/devhub/docs/policies.html:118
 msgid "How to get in touch with us regarding these policies or your add-on."
-msgstr ""
-"Ako sa s nami spojiť v prípade otázok ohľadne týchto zásad alebo ohľadne "
-"vášho doplnku."
+msgstr "Ako sa s nami spojiť v prípade otázok ohľadne týchto zásad alebo ohľadne vášho doplnku."
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:6
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:10
 msgid "You have disabled this add-on"
 msgstr "Tento doplnok ste zakázali"
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:20
-msgid ""
-"Your add-on's listing is disabled and is not showing anywhere in our gallery"
-" or update service."
-msgstr ""
-"Stránka vášho doplnku je zakázaná a nie je tak k dispozícií kdekoľvek v "
-"našej galérií ani aktualizačnej službe."
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:24
+msgid "Your add-on's listing is disabled and is not showing anywhere in our gallery or update service."
+msgstr "Stránka vášho doplnku je zakázaná a nie je tak k dispozícií kdekoľvek v našej galérií ani aktualizačnej službe."
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:25
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:27
 msgid "Please complete your add-on."
 msgstr "Skompletizujte svoj doplnok."
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:29
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:30
 msgid "You will receive an email when the review is complete."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:34
-msgid ""
-"You will receive an email when the review is complete. Until then, your add-"
-"on is not listed in our gallery but can be accessed directly from its "
-"details page."
-msgstr ""
-"Až bude kontrola dokončena, bude vám zaslán e-mail. Do té doby není váš "
-"doplněk umístěn v seznamech doplňků, ale je dostupný přímo na stránce s "
-"informacemi o doplňku."
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:33
+msgid "You will receive an email when the review is complete. Until then, your add-on is not listed in our gallery but can be accessed directly from its details page."
+msgstr "Až bude kontrola dokončena, bude vám zaslán e-mail. Do té doby není váš doplněk umístěn v seznamech doplňků, ale je dostupný přímo na stránce s informacemi o doplňku."
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:38
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:48
-msgid ""
-"You will receive an email when the review is\n"
-"                             complete and your add-on is signed."
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:37 src/olympia/devhub/templates/devhub/includes/addon_details.html:45
+msgid "You will receive an email when the review is complete and your add-on is signed."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:44
-msgid ""
-"You will receive an email when the review is complete. Until then, your add-"
-"on is not listed in our gallery but can be accessed directly from its "
-"details page."
-msgstr ""
-"Až bude kontrola dokončena, bude vám zaslán e-mail. Do té doby není váš "
-"doplněk umístěn v seznamech doplňků, ale je dostupný přímo na stránce s "
-"informacemi o doplňku."
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:41
+msgid "You will receive an email when the review is complete. Until then, your add-on is not listed in our gallery but can be accessed directly from its details page."
+msgstr "Až bude kontrola dokončena, bude vám zaslán e-mail. Do té doby není váš doplněk umístěn v seznamech doplňků, ale je dostupný přímo na stránce s informacemi o doplňku."
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:54
-msgid ""
-"Your add-on is displayed in our gallery and users are receiving automatic "
-"updates."
-msgstr ""
-"Váš doplnok je zobrazený v našej galérii a používatelia automaticky "
-"prijímajú aktualizácie."
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:49
+msgid "Your add-on is displayed in our gallery and users are receiving automatic updates."
+msgstr "Váš doplnok je zobrazený v našej galérii a používatelia automaticky prijímajú aktualizácie."
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:57
-msgid ""
-"Your add-on has been signed and can be bundled with an\n"
-"                             application installer."
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:52
+msgid "Your add-on has been signed and can be bundled with an application installer."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:63
-msgid ""
-"Your add-on was disabled by a site administrator and is no\n"
-"                             longer shown in our gallery. If you have any questions,\n"
-"                             please email amo-admins@mozilla.org."
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:56
+msgid "Your add-on was disabled by a site administrator and is no longer shown in our gallery. If you have any questions, please email amo-admins@mozilla.org."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:70
-msgid ""
-"Your add-on is displayed in our gallery as experimental and users are "
-"receiving automatic updates. Some features are unavailable to your add-on."
-msgstr ""
-"Váš doplněk je zobrazen v naší galerii jako experimentální a uživatele k "
-"němu mohou získávat automatické aktualizace. Některé funkce však pro váš "
-"doplněk nejsou dostupné."
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:62
+msgid "Your add-on is displayed in our gallery as experimental and users are receiving automatic updates. Some features are unavailable to your add-on."
+msgstr "Váš doplněk je zobrazen v naší galerii jako experimentální a uživatele k němu mohou získávat automatické aktualizace. Některé funkce však pro váš doplněk nejsou dostupné."
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:74
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:66
 msgid "Your add-on has been signed."
 msgstr "Váš doplnok bol podpísaný."
 
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:69
+msgid ""
+"You will receive an email when the full review is complete. Until then, your add-on is displayed in our gallery as experimental and users are receiving automatic updates. Some features are "
+"unavailable to your add-on."
+msgstr ""
+"Jakmile bude plná kontrola hotova, obdržíte e-mail. Do té doby bude váš doplněk zobrazen v naší galerii jako experimentální a uživatelé k němu budou získávat aktualizace. Některé funkce však pro "
+"váš doplněk nebudou dostupné."
+
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:74
+msgid "You will receive an email when the full review is complete, making you able to bundle your add-on with an application installer."
+msgstr ""
+
 #: src/olympia/devhub/templates/devhub/includes/addon_details.html:79
-msgid ""
-"You will receive an email when the full review is complete. Until then, your"
-" add-on is displayed in our gallery as experimental and users are receiving "
-"automatic updates. Some features are unavailable to your add-on."
-msgstr ""
-"Jakmile bude plná kontrola hotova, obdržíte e-mail. Do té doby bude váš "
-"doplněk zobrazen v naší galerii jako experimentální a uživatelé k němu budou"
-" získávat aktualizace. Některé funkce však pro váš doplněk nebudou dostupné."
-
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:84
-msgid ""
-"You will receive an email when the full review is\n"
-"                             complete, making you able to bundle your add-on with an\n"
-"                             application installer."
+msgid "All add-ons hosted in our gallery must now be reviewed by an editor. If you wish to continue hosting your add-on, please click to select a review process."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:91
-msgid ""
-"All add-ons hosted in our gallery must now be reviewed by an\n"
-"                             editor. If you wish to continue hosting your add-on, please\n"
-"                             click to select a review process."
-msgstr ""
-
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:113
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:100
 msgid "Current Version:"
 msgstr "Aktuálna verzia:"
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:115
-msgid ""
-"This is the version of your add-on that will\n"
-"                                           be installed if someone clicks the Install\n"
-"                                           button on addons.mozilla.org. It is only\n"
-"                                           relevant for listed add-ons."
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:102
+msgid "This is the version of your add-on that will be installed if someone clicks the Install button on addons.mozilla.org. It is only relevant for listed add-ons."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:123
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:110
 msgid "Created:"
 msgstr "Vytvorené:"
 
 #. {0} is a date. dennis-ignore: E201
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:125
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:131
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:112 src/olympia/devhub/templates/devhub/includes/addon_details.html:118
 #, python-format
 msgid "%%b %%e, %%Y"
 msgstr "%%b. %%e %%Y"
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:136
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:123
 msgid "Next Version:"
 msgstr "Ďalšia verzia:"
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:138
-msgid ""
-"This is the newest uploaded version, however it isn’t live on the site yet."
-msgstr ""
-"Toto je najnovšia nahraná verzia, no napriek tomu ešte nebola na stránkach "
-"zverejnená."
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:125
+msgid "This is the newest uploaded version, however it isn’t live on the site yet."
+msgstr "Toto je najnovšia nahraná verzia, no napriek tomu ešte nebola na stránkach zverejnená."
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:144
-#: src/olympia/devhub/templates/devhub/versions/list.html:30
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:130 src/olympia/devhub/templates/devhub/versions/list.html:30
 msgid "Queues are not reviewed strictly in order"
 msgstr "Fronty nie sú striktne prechádzané podľa poradia"
 
@@ -7977,15 +6182,11 @@ msgstr "Vytvorenie profilu vývojára"
 
 #: src/olympia/devhub/templates/devhub/includes/addons_create_profile.html:24
 msgid ""
-"Your developer profile will tell users about you, why you made this add-on, "
-"and what's next for the add-on. This profile is required for add-ons "
-"requesting contributions, but can be useful for any developer interested in "
-"connecting with users."
+"Your developer profile will tell users about you, why you made this add-on, and what's next for the add-on. This profile is required for add-ons requesting contributions, but can be useful for any "
+"developer interested in connecting with users."
 msgstr ""
-"Z vášho profilu vývojára sa používatelia dozvedia informácie o vás, o tom, "
-"prečo ste svoj doplnok vytvorili a o chystaných novinkách. Tento profil je "
-"vyžadovaný pri žiadaní príspevkov na vývoj, ale môže užitočný aj pri "
-"komunikácii vývojára a používateľov."
+"Z vášho profilu vývojára sa používatelia dozvedia informácie o vás, o tom, prečo ste svoj doplnok vytvorili a o chystaných novinkách. Tento profil je vyžadovaný pri žiadaní príspevkov na vývoj, ale"
+" môže užitočný aj pri komunikácii vývojára a používateľov."
 
 #: src/olympia/devhub/templates/devhub/includes/addons_create_profile.html:32
 msgid "Make sure your user profile is up to date."
@@ -7994,22 +6195,14 @@ msgstr "Uistite sa, že váš používateľský profil je aktuálny."
 #: src/olympia/devhub/templates/devhub/includes/addons_create_profile.html:34
 #, python-format
 msgid "<a href=\"%(url)s\"><strong>Update your user profile.</strong></a>"
-msgstr ""
-"<a href=\"%(url)s\"><strong>Aktualizovať váš používateľský "
-"profil</strong></a>"
+msgstr "<a href=\"%(url)s\"><strong>Aktualizovať váš používateľský profil</strong></a>"
 
 #: src/olympia/devhub/templates/devhub/includes/addons_create_profile.html:45
-msgid ""
-"Whether it was an idea while in line at the grocery store or the solution to"
-" one of life's great problems, share your story."
-msgstr ""
-"Či už to bol nápad, na ktorý ste prišli počas čakania v rade v potravinách "
-"alebo riešenie jedného z vašich veľkých problémov, podeľte sa o svoj príbeh."
+msgid "Whether it was an idea while in line at the grocery store or the solution to one of life's great problems, share your story."
+msgstr "Či už to bol nápad, na ktorý ste prišli počas čakania v rade v potravinách alebo riešenie jedného z vašich veľkých problémov, podeľte sa o svoj príbeh."
 
 #: src/olympia/devhub/templates/devhub/includes/addons_create_profile.html:61
-msgid ""
-"Telling your users what's coming soon will give them something to look "
-"forward to."
+msgid "Telling your users what's coming soon will give them something to look forward to."
 msgstr "Povedzte svojim používateľom, čo chystáte a na čo sa môžu tešiť."
 
 #: src/olympia/devhub/templates/devhub/includes/addons_edit_nav.html:23
@@ -8042,9 +6235,7 @@ msgid "View the blog &#9658;"
 msgstr "Zobraziť blog &#9658;"
 
 #: src/olympia/devhub/templates/devhub/includes/license_form.html:6
-msgid ""
-"Please choose a license appropriate for the rights you grant on your source code.\n"
-"                  It is only relevant for listed add-ons."
+msgid "Please choose a license appropriate for the rights you grant on your source code. It is only relevant for listed add-ons."
 msgstr ""
 
 #. {0} is a list of HTML tags.
@@ -8060,49 +6251,35 @@ msgstr "Podporované sú niektoré značky HTML."
 msgid "Remove this application"
 msgstr "Odstrániť túto aplikáciu"
 
-#. {0} is the maximum number of add-on categories allowed.                {1}
-#. is
+#. {0} is the maximum number of add-on categories allowed.                {1} is
 #. the application name.
 #: src/olympia/devhub/templates/devhub/includes/macros.html:70
 msgid "Select <b>up to {0}</b> {1} category for this add-on:"
 msgid_plural "Select <b>up to {0}</b> {1} categories for this add-on:"
 msgstr[0] "Zvoľte <b>{0}</b> kategóriu aplikácie {1} pre tento doplnok:"
-msgstr[1] ""
-"Zvoľte <b>maximálne {0}</b> kategórie aplikácie {1} pre tento doplnok:"
-msgstr[2] ""
-"Zvoľte <b>maximálne {0}</b> kategórií aplikácie {1} pre tento doplnok:"
+msgstr[1] "Zvoľte <b>maximálne {0}</b> kategórie aplikácie {1} pre tento doplnok:"
 
 #: src/olympia/devhub/templates/devhub/includes/policy_form.html:4
 msgid ""
-"Users will be required to accept the following End-User License Agreement (EULA) prior to installing your add-on. The presence of a EULA significantly affects the number of downloads an add-on receives. Please note that a EULA is not the same as a code license, such as the GPL or MPL.\n"
-"                It is only relevant for listed add-ons."
+"Users will be required to accept the following End-User License Agreement (EULA) prior to installing your add-on. The presence of a EULA significantly affects the number of downloads an add-on "
+"receives. Please note that a EULA is not the same as a code license, such as the GPL or MPL.It is only relevant for listed add-ons."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/policy_form.html:21
-msgid ""
-"If your add-on transmits any data from the user's computer, a privacy policy is required that explains what data is sent and how it is used.\n"
-"                It is only relevant for listed add-ons."
+#: src/olympia/devhub/templates/devhub/includes/policy_form.html:24
+msgid "If your add-on transmits any data from the user's computer, a privacy policy is required that explains what data is sent and how it is used. It is only relevant for listed add-ons."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/includes/source_form_field.html:2
-msgid ""
-"If your add-on contains binary or obfuscated code other than known "
-"libraries, upload its sources for review."
-msgstr ""
-"Ak váš doplnok obsahuje binárny alebo obfuskovaný kód a nejedná sa o známu "
-"knižnicu, nahrajte pre kontrolu jeho zdrojový kód."
+msgid "If your add-on contains binary or obfuscated code other than known libraries, upload its sources for review."
+msgstr "Ak váš doplnok obsahuje binárny alebo obfuskovaný kód a nejedná sa o známu knižnicu, nahrajte pre kontrolu jeho zdrojový kód."
 
 #: src/olympia/devhub/templates/devhub/includes/source_form_field.html:3
 msgid "Read more about the source code review policy."
 msgstr "Prečítajte si viac o zásadách pre kontrolu zdrojového kódu."
 
 #: src/olympia/devhub/templates/devhub/includes/version_file.html:20
-msgid ""
-"You cannot remove an individual file after the review process has begun. You"
-" must delete the entire version."
-msgstr ""
-"Po zahájení procesu kontroly nemôžete odobrať konkrétny súbor. Musíte "
-"odstrániť celú verziu."
+msgid "You cannot remove an individual file after the review process has begun. You must delete the entire version."
+msgstr "Po zahájení procesu kontroly nemôžete odobrať konkrétny súbor. Musíte odstrániť celú verziu."
 
 #: src/olympia/devhub/templates/devhub/includes/version_file.html:36
 msgid "This file will be deleted on save."
@@ -8130,12 +6307,8 @@ msgid "Voluntary Contributions"
 msgstr "Dobrovoľné príspevky"
 
 #: src/olympia/devhub/templates/devhub/payments/payments.html:38
-msgid ""
-"Add-ons enrolled in our contributions program can request voluntary "
-"financial support from users."
-msgstr ""
-"Doplnok zahrnutý v našom programe pre príspevky môže žiadať od používateľov "
-"dobrovoľné finančné príspevky."
+msgid "Add-ons enrolled in our contributions program can request voluntary financial support from users."
+msgstr "Doplnok zahrnutý v našom programe pre príspevky môže žiadať od používateľov dobrovoľné finančné príspevky."
 
 #: src/olympia/devhub/templates/devhub/payments/payments.html:40
 msgid "Encourage users to support your add-on through your Developer Profile"
@@ -8146,12 +6319,8 @@ msgid "Choose when and how users are asked to contribute"
 msgstr "Zvoľte, kedy a ako budú používatelia požiadaní o príspevok"
 
 #: src/olympia/devhub/templates/devhub/payments/payments.html:42
-msgid ""
-"Receive contributions in your PayPal account or send them to an organization"
-" of your choice"
-msgstr ""
-"Prijímať príspevky na vašom účte PayPal alebo ich odosielať organizácii "
-"podľa vlastného výberu"
+msgid "Receive contributions in your PayPal account or send them to an organization of your choice"
+msgstr "Prijímať príspevky na vašom účte PayPal alebo ich odosielať organizácii podľa vlastného výberu"
 
 #: src/olympia/devhub/templates/devhub/payments/payments.html:46
 msgid "Contributions are only available for listed add-ons."
@@ -8159,19 +6328,14 @@ msgstr "Príspevky sú dostupné len pre zverejnené doplnky."
 
 #: src/olympia/devhub/templates/devhub/payments/payments.html:53
 #, python-format
-msgid ""
-"Contributions are only available for add-ons with a <a "
-"href=\"%(url)s\">completed developer profile</a>."
-msgstr ""
-"Príspevky sú dostupné len pre doplnky s <a href=\"%(url)s\">vyplneným "
-"profilom vývojára</a>."
+msgid "Contributions are only available for add-ons with a <a href=\"%(url)s\">completed developer profile</a>."
+msgstr "Príspevky sú dostupné len pre doplnky s <a href=\"%(url)s\">vyplneným profilom vývojára</a>."
 
 #: src/olympia/devhub/templates/devhub/payments/payments.html:59
 msgid "Contributions are only available for fully reviewed add-ons."
 msgstr "Príspevky sú dostupné len pre úplne skontrolované doplnky."
 
-#: src/olympia/devhub/templates/devhub/payments/payments.html:65
-#: src/olympia/devhub/templates/devhub/payments/voluntary.html:2
+#: src/olympia/devhub/templates/devhub/payments/payments.html:65 src/olympia/devhub/templates/devhub/payments/voluntary.html:2
 msgid "Set up Contributions"
 msgstr "Nastaviť príspevky"
 
@@ -8184,17 +6348,13 @@ msgstr "Krok 2: Ceny a dostupnosť"
 msgid "or <a href=\"%(cancel)s\">Cancel</a>"
 msgstr "alebo <a href=\"%(cancel)s\">Zrušiť</a>"
 
-#: src/olympia/devhub/templates/devhub/payments/voluntary.html:2
-#: src/olympia/stats/templates/stats/addon_report_menu.html:39
+#: src/olympia/devhub/templates/devhub/payments/voluntary.html:2 src/olympia/stats/templates/stats/addon_report_menu.html:39
 msgid "Contributions"
 msgstr "Príspevky"
 
 #: src/olympia/devhub/templates/devhub/payments/voluntary.html:3
-msgid ""
-"Fill in the fields below to begin asking for voluntary contributions from "
-"users."
-msgstr ""
-"Ak chcete začať požadovať príspevky od používateľov, vyplňte pole nižšie."
+msgid "Fill in the fields below to begin asking for voluntary contributions from users."
+msgstr "Ak chcete začať požadovať príspevky od používateľov, vyplňte pole nižšie."
 
 #: src/olympia/devhub/templates/devhub/payments/voluntary.html:11
 msgid "Who will receive contributions to this add-on?"
@@ -8238,22 +6398,14 @@ msgid "Send a thank-you note?"
 msgstr "Odoslať poznámku s poďakovaním?"
 
 #: src/olympia/devhub/templates/devhub/payments/voluntary.html:47
-msgid ""
-"We'll automatically email users who contribute to your add-on with this "
-"message."
-msgstr ""
-"Používateľom, ktorí prispejú na doplnok odošleme e-mail s nasledovným "
-"textom."
+msgid "We'll automatically email users who contribute to your add-on with this message."
+msgstr "Používateľom, ktorí prispejú na doplnok odošleme e-mail s nasledovným textom."
 
 #: src/olympia/devhub/templates/devhub/payments/voluntary.html:49
 msgid ""
-"We recommend thanking the user and telling them how much you appreciate "
-"their support. You might also want to tell them about what's next for your "
-"add-on and about any other add-ons you've made for them to try."
-msgstr ""
-"Odporúčame používateľovi poďakovať a povedať mu, ako moc si ceníte jeho "
-"podporu. Môžete mu tiež povedať, čo ďalšie s doplnkom plánujete, alebo aké "
-"iné doplnky ste vytvoril. "
+"We recommend thanking the user and telling them how much you appreciate their support. You might also want to tell them about what's next for your add-on and about any other add-ons you've made for"
+" them to try."
+msgstr "Odporúčame používateľovi poďakovať a povedať mu, ako moc si ceníte jeho podporu. Môžete mu tiež povedať, čo ďalšie s doplnkom plánujete, alebo aké iné doplnky ste vytvoril. "
 
 #: src/olympia/devhub/templates/devhub/payments/voluntary.html:64
 msgid "Activate Contributions"
@@ -8267,144 +6419,94 @@ msgstr "alebo <a id=\"setup-cancel\" href=\"#\">Zrušiť</a>"
 msgid "Transfer ownership"
 msgstr "Presun vlastníctva"
 
-#: src/olympia/devhub/templates/devhub/personas/edit.html:77
-#: src/olympia/devhub/templates/devhub/personas/submit.html:31
+#: src/olympia/devhub/templates/devhub/personas/edit.html:77 src/olympia/devhub/templates/devhub/personas/submit.html:31
 msgid "Theme Details"
 msgstr "Detaily o téme"
 
-#: src/olympia/devhub/templates/devhub/personas/edit.html:87
-#: src/olympia/devhub/templates/devhub/personas/submit.html:36
+#: src/olympia/devhub/templates/devhub/personas/edit.html:87 src/olympia/devhub/templates/devhub/personas/submit.html:36
 msgid "Supply a pretty URL for your detail page."
 msgstr "Nastavte si peknú URL adresu pre stránku detailu."
 
 # 86%
-#: src/olympia/devhub/templates/devhub/personas/edit.html:92
-#: src/olympia/devhub/templates/devhub/personas/submit.html:41
+#: src/olympia/devhub/templates/devhub/personas/edit.html:92 src/olympia/devhub/templates/devhub/personas/submit.html:41
 msgid "Select the category that best describes your Theme."
 msgstr "Zvoľte kategóriu, ktorá najlepšie popisuje vašu tému."
 
-#: src/olympia/devhub/templates/devhub/personas/edit.html:95
-#: src/olympia/devhub/templates/devhub/personas/submit.html:44
+#: src/olympia/devhub/templates/devhub/personas/edit.html:95 src/olympia/devhub/templates/devhub/personas/submit.html:44
 msgid "Add some tags to describe your Theme."
 msgstr "Pridajte značky, ktoré popisujú vašu tému."
 
-#: src/olympia/devhub/templates/devhub/personas/edit.html:106
-msgid ""
-"A short explanation of your theme's basic functionality that is displayed in"
-" search and browse listings, as well as at the top of your theme's details "
-"page."
-msgstr ""
-"Krátky popis vašej témy, ktorý je zobrazený vo vyhľadávaní, prehľade "
-"kategórií, alebo priamo na stránke s detailom témy."
+#: src/olympia/devhub/templates/devhub/personas/edit.html:106 src/olympia/devhub/templates/devhub/personas/submit.html:54
+msgid "A short explanation of your theme's basic functionality that is displayed in search and browse listings, as well as at the top of your theme's details page."
+msgstr "Krátky popis vašej témy, ktorý je zobrazený vo vyhľadávaní, prehľade kategórií, alebo priamo na stránke s detailom témy."
 
-#: src/olympia/devhub/templates/devhub/personas/edit.html:122
-#: src/olympia/devhub/templates/devhub/personas/submit.html:68
+#: src/olympia/devhub/templates/devhub/personas/edit.html:122 src/olympia/devhub/templates/devhub/personas/submit.html:68
 msgid "Theme License"
 msgstr "Licencia témy"
 
 # 88%
-#: src/olympia/devhub/templates/devhub/personas/edit.html:126
-#: src/olympia/devhub/templates/devhub/personas/submit.html:72
+#: src/olympia/devhub/templates/devhub/personas/edit.html:126 src/olympia/devhub/templates/devhub/personas/submit.html:72
 msgid "Can others share your Theme, as long as you're given credit?"
 msgstr "Môžu ďalší zdieľať vašu tému, ak vás uvedú ako autora?"
 
-#: src/olympia/devhub/templates/devhub/personas/edit.html:132
-#: src/olympia/devhub/templates/devhub/personas/edit.html:153
-#: src/olympia/devhub/templates/devhub/personas/submit.html:78
+#: src/olympia/devhub/templates/devhub/personas/edit.html:132 src/olympia/devhub/templates/devhub/personas/edit.html:153 src/olympia/devhub/templates/devhub/personas/submit.html:78
 #: src/olympia/devhub/templates/devhub/personas/submit.html:99
-msgid ""
-"The licensor permits others to copy, distribute, display, and perform the "
-"work, including for commercial purposes."
-msgstr ""
-"Autor dáva ďalším právo kopírovať, distribuovať, zobrazovať a upravovať. "
-"Tieto povolenia platia aj pre komerčné využívanie."
+msgid "The licensor permits others to copy, distribute, display, and perform the work, including for commercial purposes."
+msgstr "Autor dáva ďalším právo kopírovať, distribuovať, zobrazovať a upravovať. Tieto povolenia platia aj pre komerčné využívanie."
 
-#: src/olympia/devhub/templates/devhub/personas/edit.html:141
-#: src/olympia/devhub/templates/devhub/personas/edit.html:162
-#: src/olympia/devhub/templates/devhub/personas/submit.html:87
+#: src/olympia/devhub/templates/devhub/personas/edit.html:141 src/olympia/devhub/templates/devhub/personas/edit.html:162 src/olympia/devhub/templates/devhub/personas/submit.html:87
 #: src/olympia/devhub/templates/devhub/personas/submit.html:108
-msgid ""
-"The licensor permits others to copy, distribute, display, and perform the "
-"work for non-commercial purposes only."
-msgstr ""
-"Autor dáva ďalším právo kopírovať, distribuovať, zobrazovať a upravovať. "
-"Tieto povolenia neplatia pre komerčné využívanie."
+msgid "The licensor permits others to copy, distribute, display, and perform the work for non-commercial purposes only."
+msgstr "Autor dáva ďalším právo kopírovať, distribuovať, zobrazovať a upravovať. Tieto povolenia neplatia pre komerčné využívanie."
 
-#: src/olympia/devhub/templates/devhub/personas/edit.html:147
-#: src/olympia/devhub/templates/devhub/personas/submit.html:93
+#: src/olympia/devhub/templates/devhub/personas/edit.html:147 src/olympia/devhub/templates/devhub/personas/submit.html:93
 msgid "Can others make commercial use of your Theme?"
 msgstr "Môžu ďalší komerčne využívať vašu tému?"
 
-#: src/olympia/devhub/templates/devhub/personas/edit.html:168
-#: src/olympia/devhub/templates/devhub/personas/submit.html:114
+#: src/olympia/devhub/templates/devhub/personas/edit.html:168 src/olympia/devhub/templates/devhub/personas/submit.html:114
 msgid "Can others create derivative works from your Theme?"
 msgstr "Môžu ďalší vytvárať odvodené diela z vašej témy?"
 
-#: src/olympia/devhub/templates/devhub/personas/edit.html:174
-#: src/olympia/devhub/templates/devhub/personas/submit.html:120
-msgid ""
-"The licensor permits others to copy, distribute, display and perform the "
-"work, as well as make derivative works based on it."
-msgstr ""
-"Autor dáva ostatným právo kopírovať, distribuovať, zobrazovať a upravovať. "
-"Dáva tiež dovolenie na vytváranie odvodených diel."
+#: src/olympia/devhub/templates/devhub/personas/edit.html:174 src/olympia/devhub/templates/devhub/personas/submit.html:120
+msgid "The licensor permits others to copy, distribute, display and perform the work, as well as make derivative works based on it."
+msgstr "Autor dáva ostatným právo kopírovať, distribuovať, zobrazovať a upravovať. Dáva tiež dovolenie na vytváranie odvodených diel."
 
-#: src/olympia/devhub/templates/devhub/personas/edit.html:182
-#: src/olympia/devhub/templates/devhub/personas/submit.html:128
+#: src/olympia/devhub/templates/devhub/personas/edit.html:182 src/olympia/devhub/templates/devhub/personas/submit.html:128
 msgid "Yes, as long as they share alike"
 msgstr "Áno, ak je rešpektovaná pôvodná licencia"
 
-#: src/olympia/devhub/templates/devhub/personas/edit.html:183
-#: src/olympia/devhub/templates/devhub/personas/submit.html:129
-msgid ""
-"The licensor permits others to distribute derivativeworks only under the "
-"same license or one compatible with the one that governs the licensor's "
-"work."
-msgstr ""
-"Licencia umožňuje ostatným distribuovať odvodenú prácu len pod rovnakou "
-"licenciou, prípadne inou, ktorá je však zlúčiteľná s licenciou pôvodného "
-"diela."
+#: src/olympia/devhub/templates/devhub/personas/edit.html:183 src/olympia/devhub/templates/devhub/personas/submit.html:129
+msgid "The licensor permits others to distribute derivativeworks only under the same license or one compatible with the one that governs the licensor's work."
+msgstr "Licencia umožňuje ostatným distribuovať odvodenú prácu len pod rovnakou licenciou, prípadne inou, ktorá je však zlúčiteľná s licenciou pôvodného diela."
 
-#: src/olympia/devhub/templates/devhub/personas/edit.html:192
-#: src/olympia/devhub/templates/devhub/personas/submit.html:138
-msgid ""
-"The licensor permits others to copy, distribute and transmit only unaltered "
-"copies of the work — not derivative works based on it."
+#: src/olympia/devhub/templates/devhub/personas/edit.html:192 src/olympia/devhub/templates/devhub/personas/submit.html:138
+msgid "The licensor permits others to copy, distribute and transmit only unaltered copies of the work — not derivative works based on it."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/personas/edit.html:199
-#: src/olympia/devhub/templates/devhub/personas/submit.html:145
+#: src/olympia/devhub/templates/devhub/personas/edit.html:199 src/olympia/devhub/templates/devhub/personas/submit.html:145
 #, fuzzy
 msgid "Your Theme will be released under the following license:"
 msgstr "Váš motiv bude k dispozici pod následující licencí:"
 
-#: src/olympia/devhub/templates/devhub/personas/edit.html:202
-#: src/olympia/devhub/templates/devhub/personas/submit.html:148
+#: src/olympia/devhub/templates/devhub/personas/edit.html:202 src/olympia/devhub/templates/devhub/personas/submit.html:148
 msgid "Select a different license."
 msgstr "Zvoľte inú licenciu."
 
-#: src/olympia/devhub/templates/devhub/personas/edit.html:207
-#: src/olympia/devhub/templates/devhub/personas/submit.html:153
+#: src/olympia/devhub/templates/devhub/personas/edit.html:207 src/olympia/devhub/templates/devhub/personas/submit.html:153
 msgid "Select a license for your Theme."
 msgstr "Zvoľte licenciu vašej témy."
 
-#: src/olympia/devhub/templates/devhub/personas/edit.html:217
-#: src/olympia/devhub/templates/devhub/personas/submit.html:163
+#: src/olympia/devhub/templates/devhub/personas/edit.html:217 src/olympia/devhub/templates/devhub/personas/submit.html:163
 msgid "Theme Design"
 msgstr "Vzhľad témy"
 
-#: src/olympia/devhub/templates/devhub/personas/edit.html:221
-#: src/olympia/devhub/templates/devhub/personas/edit.html:224
+#: src/olympia/devhub/templates/devhub/personas/edit.html:221 src/olympia/devhub/templates/devhub/personas/edit.html:224
 msgid "Upload New Design"
 msgstr "Načítať nový návrh"
 
 #: src/olympia/devhub/templates/devhub/personas/edit.html:226
-msgid ""
-"Upon upload and form submission, the AMO Team will review your updated "
-"design. Your current design will still be public in the meantime."
-msgstr ""
-"Po načítaní a odoslaní vykoná tím AMO kontrolu vami aktualizovanej témy. "
-"Vaša aktuálna téma bude medzi tým stále k dispozícií na webe."
+msgid "Upon upload and form submission, the AMO Team will review your updated design. Your current design will still be public in the meantime."
+msgstr "Po načítaní a odoslaní vykoná tím AMO kontrolu vami aktualizovanej témy. Vaša aktuálna téma bude medzi tým stále k dispozícií na webe."
 
 #: src/olympia/devhub/templates/devhub/personas/edit.html:241
 msgid "Your previously resubmitted design, which is under pending review."
@@ -8430,43 +6532,35 @@ msgstr "Hlavička"
 msgid "Footer"
 msgstr "Päta"
 
-#: src/olympia/devhub/templates/devhub/personas/edit.html:274
-#: src/olympia/devhub/templates/devhub/personas/submit.html:167
+#: src/olympia/devhub/templates/devhub/personas/edit.html:274 src/olympia/devhub/templates/devhub/personas/submit.html:167
 msgid "Select colors for your Theme."
 msgstr "Zvoľte farby vašej témy."
 
-#: src/olympia/devhub/templates/devhub/personas/edit.html:276
-#: src/olympia/devhub/templates/devhub/personas/submit.html:169
+#: src/olympia/devhub/templates/devhub/personas/edit.html:276 src/olympia/devhub/templates/devhub/personas/submit.html:169
 msgid "Foreground Text"
 msgstr "Text popredia"
 
-#: src/olympia/devhub/templates/devhub/personas/edit.html:277
-#: src/olympia/devhub/templates/devhub/personas/submit.html:170
+#: src/olympia/devhub/templates/devhub/personas/edit.html:277 src/olympia/devhub/templates/devhub/personas/submit.html:170
 msgid "This is the color of the tab text."
 msgstr "Jedná sa o farbu textov na kartách."
 
-#: src/olympia/devhub/templates/devhub/personas/edit.html:279
-#: src/olympia/devhub/templates/devhub/personas/submit.html:172
+#: src/olympia/devhub/templates/devhub/personas/edit.html:279 src/olympia/devhub/templates/devhub/personas/submit.html:172
 msgid "Background"
 msgstr "Pozadie"
 
-#: src/olympia/devhub/templates/devhub/personas/edit.html:280
-#: src/olympia/devhub/templates/devhub/personas/submit.html:173
+#: src/olympia/devhub/templates/devhub/personas/edit.html:280 src/olympia/devhub/templates/devhub/personas/submit.html:173
 msgid "This is the color of the tabs."
 msgstr "Toto je farba kariet."
 
-#: src/olympia/devhub/templates/devhub/personas/edit.html:285
-#: src/olympia/devhub/templates/devhub/personas/submit.html:178
+#: src/olympia/devhub/templates/devhub/personas/edit.html:285 src/olympia/devhub/templates/devhub/personas/submit.html:178
 msgid "Preview"
 msgstr "Ukážka"
 
-#: src/olympia/devhub/templates/devhub/personas/edit.html:291
-#: src/olympia/devhub/templates/devhub/personas/submit.html:183
+#: src/olympia/devhub/templates/devhub/personas/edit.html:291 src/olympia/devhub/templates/devhub/personas/submit.html:183
 msgid "Your Theme's Name"
 msgstr "Názov vašej témy"
 
-#: src/olympia/devhub/templates/devhub/personas/edit.html:294
-#: src/olympia/devhub/templates/devhub/personas/submit.html:186
+#: src/olympia/devhub/templates/devhub/personas/edit.html:294 src/olympia/devhub/templates/devhub/personas/submit.html:186
 #, python-format
 msgid "by <a href=\"%(profile_url)s\" target=\"_blank\">%(user)s</a>"
 msgstr "autor: <a href=\"%(profile_url)s\" target=\"_blank\">%(user)s</a>"
@@ -8477,34 +6571,17 @@ msgstr "Vytvorenie novej témy"
 
 #: src/olympia/devhub/templates/devhub/personas/submit.html:18
 #, python-format
-msgid ""
-"Background themes let you easily personalize the look of your Firefox. "
-"Submit your own design below, or <a href=\"%(submit_url)s\">learn how to "
-"create one</a>!"
-msgstr ""
-"Témy vám dávajú možnosť jednoducho si prispôsobiť vzhľad vášho Firefoxu. "
-"Pridajte svoj vlastný motív nižšie alebo <a href=\"%(submit_url)s\">si "
-"prečítajte, ako vytvoriť nový</a>!"
+msgid "Background themes let you easily personalize the look of your Firefox. Submit your own design below, or <a href=\"%(submit_url)s\">learn how to create one</a>!"
+msgstr "Témy vám dávajú možnosť jednoducho si prispôsobiť vzhľad vášho Firefoxu. Pridajte svoj vlastný motív nižšie alebo <a href=\"%(submit_url)s\">si prečítajte, ako vytvoriť nový</a>!"
 
 #: src/olympia/devhub/templates/devhub/personas/submit.html:33
 msgid "Give your Theme a name."
 msgstr "Pomenujte vašu tému."
 
-#: src/olympia/devhub/templates/devhub/personas/submit.html:54
-msgid ""
-"A short explanation of your theme's basic functionality that is displayed in"
-" search and browse listings, as well as at the top of your theme's details "
-"page."
-msgstr ""
-"Krátky popis vašej témy, ktorý je zobrazený vo vyhľadávaní, prehľade "
-"kategórií, alebo priamo na stránke s detailom témy."
-
 #: src/olympia/devhub/templates/devhub/personas/submit.html:198
 #, python-format
 msgid ""
-"I agree to the <a href=\"%(agreement_url)s\" target=\"_blank\">Firefox Add-"
-"on Distribution Agreement</a> and to my information being handled as "
-"described in the <a href=\"%(privacy_notice_url)s\" "
+"I agree to the <a href=\"%(agreement_url)s\" target=\"_blank\">Firefox Add-on Distribution Agreement</a> and to my information being handled as described in the <a href=\"%(privacy_notice_url)s\" "
 "target=\"_blank\">Websites, Communications and Cookies Privacy Notice</a>."
 msgstr ""
 
@@ -8513,23 +6590,17 @@ msgid "Submit Theme"
 msgstr "Pridať tému"
 
 #: src/olympia/devhub/templates/devhub/personas/submit_done.html:11
-msgid ""
-"Your theme has been submitted to the Review Queue. You'll receive an email "
-"once it has been reviewed, typically within 24 hours."
+msgid "Your theme has been submitted to the Review Queue. You'll receive an email once it has been reviewed, typically within 24 hours."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/personas/submit_done.html:19
 #, python-format
-msgid ""
-"Provide more details about your theme by <a href=\"%(edit_url)s\">editing "
-"its listing</a>."
+msgid "Provide more details about your theme by <a href=\"%(edit_url)s\">editing its listing</a>."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/personas/submit_done.html:25
 #, python-format
-msgid ""
-"View and subscribe to your theme's <a href=\"%(feed_url)s\">activity "
-"feed</a> to stay updated on reviews, collections, and more."
+msgid "View and subscribe to your theme's <a href=\"%(feed_url)s\">activity feed</a> to stay updated on reviews, collections, and more."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/personas/submit_done.html:32
@@ -8545,13 +6616,11 @@ msgstr "Vyberte obrázok hlavičky pre vašu tému."
 msgid "3000 &times; 200 pixels"
 msgstr "3000 &times; 200 bodov"
 
-#: src/olympia/devhub/templates/devhub/personas/includes/theme_design.html:9
-#: src/olympia/devhub/templates/devhub/personas/includes/theme_design.html:25
+#: src/olympia/devhub/templates/devhub/personas/includes/theme_design.html:9 src/olympia/devhub/templates/devhub/personas/includes/theme_design.html:25
 msgid "300 KB max"
 msgstr "Maximálne 300 kB"
 
-#: src/olympia/devhub/templates/devhub/personas/includes/theme_design.html:10
-#: src/olympia/devhub/templates/devhub/personas/includes/theme_design.html:26
+#: src/olympia/devhub/templates/devhub/personas/includes/theme_design.html:10 src/olympia/devhub/templates/devhub/personas/includes/theme_design.html:26
 msgid "PNG or JPG"
 msgstr "PNG alebo JPG"
 
@@ -8580,55 +6649,31 @@ msgid "Select a different footer image"
 msgstr "Zvoľte iný obrázok päty"
 
 #: src/olympia/devhub/templates/devhub/versions/add_file_modal.html:8
-msgid ""
-"Files added to reviewed versions must be reviewed before they will be "
-"available for download."
-msgstr ""
-"Súbory pridané k overených verziám musia byť pred ich sprístupnením "
-"prekontrolované."
+msgid "Files added to reviewed versions must be reviewed before they will be available for download."
+msgstr "Súbory pridané k overených verziám musia byť pred ich sprístupnením prekontrolované."
 
-#: src/olympia/devhub/templates/devhub/versions/add_file_modal.html:15
-#, python-format
-msgid ""
-"Submission of updates to unlisted add-ons for signing is currently in an "
-"open beta. Manual review may still be required for a large number of add-"
-"ons. Please <a href=\"%(url)s\" target=\"_blank\">report any bugs</a> that "
-"you encounter."
-msgstr ""
-
-#: src/olympia/devhub/templates/devhub/versions/add_file_modal.html:35
+#: src/olympia/devhub/templates/devhub/versions/add_file_modal.html:24
 msgid "Select the target platform for this file."
 msgstr "Zvoľte cieľovú platformu pre tento súbor."
 
-#: src/olympia/devhub/templates/devhub/versions/add_file_modal.html:46
+#: src/olympia/devhub/templates/devhub/versions/add_file_modal.html:35
 msgid "Which review type would you like to nominate for?"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/add_file_modal.html:51
+#: src/olympia/devhub/templates/devhub/versions/add_file_modal.html:40
 msgid "Only publish this version to my beta channel."
 msgstr "Túto verziu publikovať len v mojom beta kanále."
-
-#: src/olympia/devhub/templates/devhub/versions/add_file_modal.html:54
-#, python-format
-msgid ""
-"The behavior of the beta channel has changed to accommodate <a "
-"href=\"%(addon_signing_url)s\" target=\"_blank\">mandatory add-on "
-"signing</a>. The new process is currently in an open beta, and may change "
-"significantly in the near future. Please <a href=\"%(issues_url)s\" "
-"target=\"_blank\">report any bugs</a> that you encounter."
-msgstr ""
 
 #: src/olympia/devhub/templates/devhub/versions/edit.html:5
 msgid "Manage Version {0}"
 msgstr "Správa verzie {0}"
 
-#: src/olympia/devhub/templates/devhub/versions/edit.html:12
-#: src/olympia/devhub/templates/devhub/versions/list.html:3
+#: src/olympia/devhub/templates/devhub/versions/edit.html:12 src/olympia/devhub/templates/devhub/versions/list.html:3
 msgid "Status & Versions"
 msgstr "Stav a verzie"
 
-#. {0} is an add-on name.
 # {0} is the name of the collection
+#. {0} is an add-on name.
 #: src/olympia/devhub/templates/devhub/versions/edit.html:16
 msgid "Manage {0}"
 msgstr "Spravovať kolekciu {0}"
@@ -8641,55 +6686,35 @@ msgstr "Súbory"
 msgid "Upload Another File"
 msgstr "Odoslať ďalší súbor"
 
-#: src/olympia/devhub/templates/devhub/versions/edit.html:45
-msgid ""
-"Adjusting application information here will allow users to install your add-"
-"on even if the install manifest in the package indicates that the add-on is "
-"incompatible."
-msgstr ""
-"Tu zadané informácie o aplikácií umožňujú používateľom nainštalovať doplnok "
-"aj vtedy, keď inštalačný manifest v balíku uvádza, že doplnok nie je "
-"kompatibilný."
-
 #: src/olympia/devhub/templates/devhub/versions/edit.html:74
 msgid ""
-"Information about changes in this release, new features, known bugs, and "
-"other useful information specific to this release/version. This information "
-"is also shown in the Add-ons Manager when updating."
+"Information about changes in this release, new features, known bugs, and other useful information specific to this release/version. This information is also shown in the Add-ons Manager when "
+"updating."
 msgstr ""
-"Informácie o zmenách v tejto vydaní, nové funkcie, známe chyby a ďalšie "
-"užitočné informácie špecifické pre toto vydanie/verziu. Tieto informácie sú "
-"zobrazované v okne Správcu doplnkov pri aktualizácii doplnku."
+"Informácie o zmenách v tejto vydaní, nové funkcie, známe chyby a ďalšie užitočné informácie špecifické pre toto vydanie/verziu. Tieto informácie sú zobrazované v okne Správcu doplnkov pri "
+"aktualizácii doplnku."
 
 #: src/olympia/devhub/templates/devhub/versions/edit.html:99
 msgid "Approval Status"
 msgstr "Stav schválenia"
 
-#: src/olympia/devhub/templates/devhub/versions/edit.html:113
-#: src/olympia/editors/templates/editors/review.html:108
+#: src/olympia/devhub/templates/devhub/versions/edit.html:113 src/olympia/editors/templates/editors/review.html:108
 msgid "Notes for Reviewers"
 msgstr "Poznámky ku kontrole"
 
 #: src/olympia/devhub/templates/devhub/versions/edit.html:114
-msgid ""
-"Optionally, enter any information that may be useful to the Editor reviewing"
-" this add-on, such as test account information."
-msgstr ""
-"Voliteľné, môžete zadať informácie, ktoré by mohli byť užitočné pre editora "
-"pri kontrole tohto doplnku, ako napríklad informácie o testovacom účte."
+msgid "Optionally, enter any information that may be useful to the Editor reviewing this add-on, such as test account information."
+msgstr "Voliteľné, môžete zadať informácie, ktoré by mohli byť užitočné pre editora pri kontrole tohto doplnku, ako napríklad informácie o testovacom účte."
 
 #: src/olympia/devhub/templates/devhub/versions/edit.html:127
 msgid "Source code"
 msgstr "Zdrojový kód"
 
 #: src/olympia/devhub/templates/devhub/versions/edit.html:128
-msgid ""
-"If your add-on contain binary or obfuscated code, make the source available "
-"here for reviewers."
+msgid "If your add-on contain binary or obfuscated code, make the source available here for reviewers."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/edit.html:145
-#: src/olympia/devhub/templates/devhub/versions/edit.html:149
+#: src/olympia/devhub/templates/devhub/versions/edit.html:145 src/olympia/devhub/templates/devhub/versions/edit.html:149
 msgid "Upload a new file"
 msgstr "Odoslať nový súbor"
 
@@ -8704,8 +6729,7 @@ msgstr "Súbor {file_id} ({platform})"
 #: src/olympia/devhub/templates/devhub/versions/file_status_message.html:5
 #, python-format
 msgid "Created on %(created)s and changed to %(status)s on %(status_date)s"
-msgstr ""
-"Vytvorené dňa %(created)s, dňa %(status_date)s zmenený stav na %(status)s"
+msgstr "Vytvorené dňa %(created)s, dňa %(status_date)s zmenený stav na %(status)s"
 
 #: src/olympia/devhub/templates/devhub/versions/file_status_message.html:9
 #, python-format
@@ -8731,7 +6755,6 @@ msgid "{0} file"
 msgid_plural "{0} files"
 msgstr[0] "{0} súbor"
 msgstr[1] "{0} súbory"
-msgstr[2] "{0} súborov"
 
 #: src/olympia/devhub/templates/devhub/versions/list.html:25
 msgid "0 files"
@@ -8758,9 +6781,7 @@ msgstr "Požiadať o riadnu kontrolu"
 msgid "Request Preliminary Review"
 msgstr "Požiadať o predbežnú kontrolu"
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:80
-#: src/olympia/devhub/templates/devhub/versions/list.html:327
-#: src/olympia/devhub/templates/devhub/versions/list.html:350
+#: src/olympia/devhub/templates/devhub/versions/list.html:80 src/olympia/devhub/templates/devhub/versions/list.html:325 src/olympia/devhub/templates/devhub/versions/list.html:348
 msgid "Cancel Review Request"
 msgstr "Zrušiť požiadavku o kontrolu"
 
@@ -8773,35 +6794,24 @@ msgid "Listed:"
 msgstr "V zozname:"
 
 #: src/olympia/devhub/templates/devhub/versions/list.html:102
-msgid ""
-"Visible to everyone on {0} and included in search results and listing pages"
-msgstr ""
-"Viditeľný pre každého na {0} a zobrazovaný vo výsledkoch vyhľadávania a v "
-"zoznamoch na stránkach"
+msgid "Visible to everyone on {0} and included in search results and listing pages"
+msgstr "Viditeľný pre každého na {0} a zobrazovaný vo výsledkoch vyhľadávania a v zoznamoch na stránkach"
 
 #: src/olympia/devhub/templates/devhub/versions/list.html:108
 msgid "Hidden:"
 msgstr "Skrytý:"
 
 #: src/olympia/devhub/templates/devhub/versions/list.html:108
-msgid ""
-"Hosted on {0}, but hidden to anyone but authors. Used to temporarily hide "
-"listings or discontinue them."
-msgstr ""
-"Umiestnený na {0}, ale skrytý pre všetkých okrem jeho autorov. Možno použiť "
-"pre dočasné odobranie zo zoznamu, alebo jeho úplne skrytie."
+msgid "Hosted on {0}, but hidden to anyone but authors. Used to temporarily hide listings or discontinue them."
+msgstr "Umiestnený na {0}, ale skrytý pre všetkých okrem jeho autorov. Možno použiť pre dočasné odobranie zo zoznamu, alebo jeho úplne skrytie."
 
 #: src/olympia/devhub/templates/devhub/versions/list.html:114
 msgid "Unlisted:"
 msgstr "Nezaradený:"
 
 #: src/olympia/devhub/templates/devhub/versions/list.html:114
-msgid ""
-"Not distributed on {0}. Developers will upload new versions for signing and "
-"distribute the add-ons on their own. (beta)"
+msgid "Not distributed on {0}. Developers will upload new versions for signing and distribute the add-ons on their own."
 msgstr ""
-"Nie je distribuovaný na {0}. Vývojári budú nahrávať nové verzie na podpis a "
-"budú distribuovať doplnok sami. (beta)"
 
 #: src/olympia/devhub/templates/devhub/versions/list.html:122
 msgid "Current versions"
@@ -8811,18 +6821,13 @@ msgstr "Aktuálna verzia"
 msgid "Currently on AMO"
 msgstr "Aktuálne na AMO"
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:129
-#: src/olympia/devhub/templates/devhub/versions/list.html:147
-#: src/olympia/devhub/templates/devhub/versions/list.html:164
-#: src/olympia/editors/templates/editors/includes/search_results_themes.html:7
-#: src/olympia/editors/templates/editors/themes/queue_list.html:50
+#: src/olympia/devhub/templates/devhub/versions/list.html:129 src/olympia/devhub/templates/devhub/versions/list.html:147 src/olympia/devhub/templates/devhub/versions/list.html:164
+#: src/olympia/editors/templates/editors/includes/search_results_themes.html:7 src/olympia/editors/templates/editors/themes/queue_list.html:50
 msgid "Status"
 msgstr "Stav"
 
 # Header for a column in a table
-#: src/olympia/devhub/templates/devhub/versions/list.html:130
-#: src/olympia/devhub/templates/devhub/versions/list.html:148
-#: src/olympia/devhub/templates/devhub/versions/list.html:165
+#: src/olympia/devhub/templates/devhub/versions/list.html:130 src/olympia/devhub/templates/devhub/versions/list.html:148 src/olympia/devhub/templates/devhub/versions/list.html:165
 #: src/olympia/editors/templates/editors/includes/files_view.html:11
 msgid "Validation"
 msgstr "Overenie"
@@ -8844,14 +6849,10 @@ msgid "Full review may not be required"
 msgstr "Kompletná kontrola nemusí byť nutná"
 
 #: src/olympia/devhub/templates/devhub/versions/list.html:201
-msgid ""
-"Unlisted add-ons don't need Full Review unless they are distributed as part "
-"of an application installer. Read <a href=\"{link}\" target=\"_blank\">this "
-"documentation</a> for more information."
+msgid "Unlisted add-ons don't need Full Review unless they are distributed as part of an application installer. Read <a href=\"{link}\" target=\"_blank\">this documentation</a> for more information."
 msgstr ""
-"Nezverejnené doplnky nepotrebujú kompletnú kontrolu, ak nie sú distribuované"
-" ako súčasť inštalátora aplikácií. Pre viac informácií si prečítajte <a "
-"href=\"{link}\" target=\"_blank\">túto dokumentáciu</a>."
+"Nezverejnené doplnky nepotrebujú kompletnú kontrolu, ak nie sú distribuované ako súčasť inštalátora aplikácií. Pre viac informácií si prečítajte <a href=\"{link}\" target=\"_blank\">túto "
+"dokumentáciu</a>."
 
 #: src/olympia/devhub/templates/devhub/versions/list.html:209
 msgid "Request full review"
@@ -8862,127 +6863,86 @@ msgid "Delete Version {version}"
 msgstr "Odstránenie verzie {version}"
 
 #: src/olympia/devhub/templates/devhub/versions/list.html:218
-msgid ""
-"You are about to delete the current version of your add-on. This may cause "
-"your add-on status to change, or your listing to lose public visibility, if "
-"this is the only public version of your add-on."
-msgstr ""
-"Chystáte sa odstrániť aktuálnu verziu svojho doplnku. Táto akcia môže "
-"vykonať zmenu stavu vášho doplnku, alebo skryť verejne dostupnú stránku "
-"doplnku, ak sa jedná o jedinú jeho verejnú verziu."
+msgid "You are about to delete the current version of your add-on. This may cause your add-on status to change, or your listing to lose public visibility, if this is the only public version of your add-on."
+msgstr "Chystáte sa odstrániť aktuálnu verziu svojho doplnku. Táto akcia môže vykonať zmenu stavu vášho doplnku, alebo skryť verejne dostupnú stránku doplnku, ak sa jedná o jedinú jeho verejnú verziu."
 
 #: src/olympia/devhub/templates/devhub/versions/list.html:219
 msgid "Deleting this version will permanently delete:"
 msgstr "Odstránením tejto verzie doplnku natrvalo odstránite:"
 
 #: src/olympia/devhub/templates/devhub/versions/list.html:225
-msgid ""
-"<strong>Important:</strong> Once a version has been deleted, you may not "
-"upload a new version with the same version number."
-msgstr ""
-"<strong>Dôležité:</strong> Okamžite ako je verzia odstránená, nemôžete "
-"nahrať novú verziu s rovnakým číslom verzie."
+msgid "<strong>Important:</strong> Once a version has been deleted, you may not upload a new version with the same version number."
+msgstr "<strong>Dôležité:</strong> Okamžite ako je verzia odstránená, nemôžete nahrať novú verziu s rovnakým číslom verzie."
 
 #: src/olympia/devhub/templates/devhub/versions/list.html:230
-msgid ""
-"Deleting a version which has already been reviewed may also cause a "
-"significant delay in the review of your next update."
-msgstr ""
-"Odstránením verzie, ktorá už bola skontrolovaná, môžete spôsobiť zdržanie "
-"pri kontrole vašej budúcej aktualizácie."
-
-#: src/olympia/devhub/templates/devhub/versions/list.html:233
 msgid "Are you sure you wish to delete this version?"
 msgstr "Naozaj chcete odstrániť túto verziu?"
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:238
+#: src/olympia/devhub/templates/devhub/versions/list.html:235
 msgid "Delete Version"
 msgstr "Odstrániť verziu"
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:240
+#: src/olympia/devhub/templates/devhub/versions/list.html:237
 msgid "Disable Version"
 msgstr "Zakázať verziu"
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:247
+#: src/olympia/devhub/templates/devhub/versions/list.html:244
 msgid "Add a new Version"
 msgstr "Pridanie novej verzie"
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:249
+#: src/olympia/devhub/templates/devhub/versions/list.html:246
 msgid "Add Version"
 msgstr "Pridať verziu"
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:256
-#: src/olympia/devhub/templates/devhub/versions/list.html:274
+#: src/olympia/devhub/templates/devhub/versions/list.html:253 src/olympia/devhub/templates/devhub/versions/list.html:279
 msgid "Hide Add-on"
 msgstr "Skryť doplnok"
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:259
-msgid ""
-"Hiding your add-on will prevent it from appearing anywhere in our gallery "
-"and will stop users from receiving automatic updates."
-msgstr ""
-"Skrytím svojho doplnku zabránite, aby sa zobrazoval kdekoľvek v našej "
-"galérii, a používateľom prestanú byť inštalované automatické aktualizácie."
+#: src/olympia/devhub/templates/devhub/versions/list.html:256
+msgid "Hiding your add-on will prevent it from appearing anywhere in our gallery and will stop users from receiving automatic updates."
+msgstr "Skrytím svojho doplnku zabránite, aby sa zobrazoval kdekoľvek v našej galérii, a používateľom prestanú byť inštalované automatické aktualizácie."
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:265
+#: src/olympia/devhub/templates/devhub/versions/list.html:263
+msgid "The files awaiting review will be disabled and you will need to upload new versions."
+msgstr ""
+
+#: src/olympia/devhub/templates/devhub/versions/list.html:270
 msgid "Are you sure you wish to hide your add-on?"
 msgstr "Naozaj chcete skryť svoj doplnok?"
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:286
-#: src/olympia/devhub/templates/devhub/versions/list.html:315
+#: src/olympia/devhub/templates/devhub/versions/list.html:291 src/olympia/devhub/templates/devhub/versions/list.html:313
 msgid "Unlist Add-on"
 msgstr "Zrušiť zverejnenie doplnku"
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:289
+#: src/olympia/devhub/templates/devhub/versions/list.html:294
 #, python-format
 msgid ""
-"Unlisting your add-on will make it (and each of its versions/files) "
-"invisible on this website. It won't show up in searches, won't have a public"
-" facing page, and won't be updated automatically for current users.  It is "
-"recommended for unlisted add-ons to provide a custom <a "
-"href=\"%(update_url)s\" target=\"_blank\">updateURL</a> in their manifest "
-"file for automatic updates."
+"Unlisting your add-on will make it (and each of its versions/files) invisible on this website. It won't show up in searches, won't have a public facing page, and won't be updated automatically for "
+"current users. It is recommended for unlisted add-ons to provide a custom <a href=\"%(update_url)s\" target=\"_blank\">updateURL</a> in their manifest file for automatic updates."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:299
-#, python-format
-msgid ""
-"Switching add-ons to unlisted is currently in an open beta. Please <a "
-"href=\"%(url)s\" target=\"_blank\">report any bugs</a> that you encounter."
-msgstr ""
-
-#: src/olympia/devhub/templates/devhub/versions/list.html:305
+#: src/olympia/devhub/templates/devhub/versions/list.html:303
 msgid "Unlisting an add-on is irreversible!"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:305
+#: src/olympia/devhub/templates/devhub/versions/list.html:303
 msgid "An unlisted add-on cannot be switched to be listed."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:307
+#: src/olympia/devhub/templates/devhub/versions/list.html:305
 msgid "Are you sure you wish to unlist your add-on?"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:330
-msgid ""
-"Canceling your review request will leave your add-on as preliminarily "
-"reviewed."
-msgstr ""
-"Zrušením vašej žiadosti o kontrolu ponecháte svoj doplnok predbežne "
-"skontrolovaným."
+#: src/olympia/devhub/templates/devhub/versions/list.html:328
+msgid "Canceling your review request will leave your add-on as preliminarily reviewed."
+msgstr "Zrušením vašej žiadosti o kontrolu ponecháte svoj doplnok predbežne skontrolovaným."
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:335
+#: src/olympia/devhub/templates/devhub/versions/list.html:333
 #, fuzzy
-msgid ""
-"Canceling your review request will mark your add-on incomplete. If you do "
-"not complete your add-on after several days by re-requesting review, it will"
-" be deleted."
-msgstr ""
-"Zrušením vaší žádosti o kontrolu označíte svůj doplněk jako nekompletní. "
-"Pokud svůj doplněk během několika dní nedokončíte opětovnou žádostí o "
-"kontrolu, bude smazán."
+msgid "Canceling your review request will mark your add-on incomplete. If you do not complete your add-on after several days by re-requesting review, it will be deleted."
+msgstr "Zrušením vaší žádosti o kontrolu označíte svůj doplněk jako nekompletní. Pokud svůj doplněk během několika dní nedokončíte opětovnou žádostí o kontrolu, bude smazán."
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:343
+#: src/olympia/devhub/templates/devhub/versions/list.html:341
 msgid "Are you sure you wish to cancel your review request?"
 msgstr "Naozaj chcete zrušiť vašu žiadosť o kontrolu?"
 
@@ -9015,16 +6975,11 @@ msgid "Translate content on the web from and into over 40 languages."
 msgstr "Preložte si obsah webu do viac ako 40 jazykov."
 
 #: src/olympia/discovery/modules.py:171
-msgid ""
-"Easily connect to your social networks, and share or comment on the page "
-"you're visiting."
-msgstr ""
-"Jednoducho prepojte svoje sociálne siete a zdieľajte alebo komentujte "
-"stránky, ktoré navštevujete."
+msgid "Easily connect to your social networks, and share or comment on the page you're visiting."
+msgstr "Jednoducho prepojte svoje sociálne siete a zdieľajte alebo komentujte stránky, ktoré navštevujete."
 
 #: src/olympia/discovery/modules.py:173
-msgid ""
-"A quick view to compare prices when you shop online or search for flights."
+msgid "A quick view to compare prices when you shop online or search for flights."
 msgstr "Rýchle porovnanie cien pri nakopovaní online alebo vyhľadávaní letov."
 
 #: src/olympia/discovery/modules.py:183
@@ -9068,24 +7023,16 @@ msgid "Add-ons that help you on your travels!"
 msgstr "Doplnky, ktoré pomáhajú pri vašich cestách."
 
 #: src/olympia/discovery/modules.py:226
-msgid ""
-"Displays a country flag depicting the location of the current website's "
-"server and more."
-msgstr ""
-"Zobrazuje vlajku krajiny, pomocou ktorej identifikujete umiestnenie servera "
-"aktuálnej webovej stránky."
+msgid "Displays a country flag depicting the location of the current website's server and more."
+msgstr "Zobrazuje vlajku krajiny, pomocou ktorej identifikujete umiestnenie servera aktuálnej webovej stránky."
 
 #: src/olympia/discovery/modules.py:228
 msgid "FoxClocks let you keep an eye on the time around the world."
 msgstr "FoxClocks zobrazuje aktuálny čas po celom svete."
 
 #: src/olympia/discovery/modules.py:230
-msgid ""
-"Automatically get the lowest price when you shop online or search for "
-"flights."
-msgstr ""
-"Automaticky nájdite najnižšiu cenu pri nakupovaní online alebo vyhľadávaní "
-"letov."
+msgid "Automatically get the lowest price when you shop online or search for flights."
+msgstr "Automaticky nájdite najnižšiu cenu pri nakupovaní online alebo vyhľadávaní letov."
 
 #: src/olympia/discovery/modules.py:240
 msgid "A+ add-ons for School"
@@ -9093,8 +7040,7 @@ msgstr "Najlepšie doplnky pre školu"
 
 #: src/olympia/discovery/modules.py:241
 msgid "Add-ons for teachers, parents, and students heading back to school."
-msgstr ""
-"Doplnky pre učiteľov, rodičov a študentov, ktorí mieria späť do školy."
+msgstr "Doplnky pre učiteľov, rodičov a študentov, ktorí mieria späť do školy."
 
 #: src/olympia/discovery/modules.py:246
 msgid "Would you like to know which websites you can trust?"
@@ -9125,12 +7071,8 @@ msgid "Put a Theme on It!"
 msgstr "A čo tak použiť tému!"
 
 #: src/olympia/discovery/modules.py:281
-msgid ""
-"Visit addons.mozilla.org from Firefox for Android and dress up your mobile "
-"browser to match your style, mood, or the season."
-msgstr ""
-"Navštívte addons.mozilla.org z Firefoxu pre Android a oblečte si svoj "
-"mobilný prehliadač podľa svojej chuti a aktuálnej nálady."
+msgid "Visit addons.mozilla.org from Firefox for Android and dress up your mobile browser to match your style, mood, or the season."
+msgstr "Navštívte addons.mozilla.org z Firefoxu pre Android a oblečte si svoj mobilný prehliadač podľa svojej chuti a aktuálnej nálady."
 
 #: src/olympia/discovery/modules.py:290
 msgid "Get up and move!"
@@ -9157,12 +7099,8 @@ msgid "Protect your privacy online with the add-ons in this collection."
 msgstr "Ochráňte vaše online súkromie pomocou doplnkov tejto kolekcie."
 
 #: src/olympia/discovery/modules.py:342
-msgid ""
-"Great add-ons for work, fun, privacy, productivity&hellip; just about "
-"anything!"
-msgstr ""
-"Výborné doplnky pre prácu, zábavu, súkromie, produktivitu&hellip; proste na "
-"všetko!"
+msgid "Great add-ons for work, fun, privacy, productivity&hellip; just about anything!"
+msgstr "Výborné doplnky pre prácu, zábavu, súkromie, produktivitu&hellip; proste na všetko!"
 
 #: src/olympia/discovery/modules.py:350
 msgid "Add-ons for Australis Contest Winners"
@@ -9182,22 +7120,16 @@ msgstr "Čo sú to doplnky?"
 
 #: src/olympia/discovery/templates/discovery/pane.html:28
 #, python-format
-msgid ""
-"Add-ons are applications that let you personalize %(app)s with extra "
-"functionality or style. Try a time-saving sidebar, a weather notifier, or a "
-"themed look to make %(app)s your own."
+msgid "Add-ons are applications that let you personalize %(app)s with extra functionality or style. Try a time-saving sidebar, a weather notifier, or a themed look to make %(app)s your own."
 msgstr ""
-"Doplnky sú aplikácie, ktoré umožňujú prispôsobiť si %(app)s pridaním nových "
-"funkcií alebo zmenou vzhľadu. Vyskúšajte čas šetriaci bočný panel, "
-"upozorňovanie na predpoveď počasia alebo nový tematický vzhľad a pretvorte "
-"si %(app)s podľa seba."
+"Doplnky sú aplikácie, ktoré umožňujú prispôsobiť si %(app)s pridaním nových funkcií alebo zmenou vzhľadu. Vyskúšajte čas šetriaci bočný panel, upozorňovanie na predpoveď počasia alebo nový "
+"tematický vzhľad a pretvorte si %(app)s podľa seba."
 
 #: src/olympia/discovery/templates/discovery/pane.html:62
 msgid "Learn More About Add-ons"
 msgstr "Ďalšie informácie o doplnkoch"
 
-#: src/olympia/discovery/templates/discovery/pane.html:66
-#: src/olympia/discovery/templates/discovery/pane.html:73
+#: src/olympia/discovery/templates/discovery/pane.html:66 src/olympia/discovery/templates/discovery/pane.html:73
 msgid "See all"
 msgstr "Zobraziť všetky"
 
@@ -9228,12 +7160,8 @@ msgstr "Vitajte, {0}"
 
 #: src/olympia/discovery/templates/discovery/pane_account.html:17
 #, python-format
-msgid ""
-"Thanks for using %(app)s and supporting <a href=\"%(url)s\">Mozilla's "
-"mission</a>!"
-msgstr ""
-"Ďakujeme, že používate %(app)s a podporujete <a href=\"%(url)s\">misiu "
-"Mozilly</a>!"
+msgid "Thanks for using %(app)s and supporting <a href=\"%(url)s\">Mozilla's mission</a>!"
+msgstr "Ďakujeme, že používate %(app)s a podporujete <a href=\"%(url)s\">misiu Mozilly</a>!"
 
 #: src/olympia/discovery/templates/discovery/pane_account.html:23
 msgid "Add-ons downloaded:"
@@ -9257,15 +7185,10 @@ msgstr "Vezmite si doplnky so sebou"
 
 #: src/olympia/discovery/templates/discovery/modules/go-mobile.html:8
 #, python-format
-msgid ""
-"Visit <a href=\"%(url)s\">firefox.com/m</a> to get Firefox on your phone and"
-" personalize your browser anytime, anywhere. Easily discover and install "
-"add-ons from the mobile Add-ons Manager."
+msgid "Visit <a href=\"%(url)s\">firefox.com/m</a> to get Firefox on your phone and personalize your browser anytime, anywhere. Easily discover and install add-ons from the mobile Add-ons Manager."
 msgstr ""
-"Navštívte <a href=\"%(url)s\">firefox.com/m</a>, získajte Firefox pre "
-"mobilné zariadenia a upravte si svoj prehliadač kedykoľvek a kdekoľvek. "
-"Doplnky si jednoducho vyhľadáte a nainštalujete pomocou zabudovaného Správcu"
-" doplnkov."
+"Navštívte <a href=\"%(url)s\">firefox.com/m</a>, získajte Firefox pre mobilné zariadenia a upravte si svoj prehliadač kedykoľvek a kdekoľvek. Doplnky si jednoducho vyhľadáte a nainštalujete pomocou"
+" zabudovaného Správcu doplnkov."
 
 #: src/olympia/discovery/templates/discovery/modules/go-mobile.html:13
 msgid "Get Mobile Add-ons"
@@ -9280,20 +7203,12 @@ msgid "Find great add-ons to help you with all your holiday shopping needs."
 msgstr "Pozrite sa na skvelé doplnky, ktoré vám pomôžu s vašim nakupovaním."
 
 #: src/olympia/discovery/templates/discovery/modules/holiday.html:13
-msgid ""
-"Install the Amazon Browser Apps and receive special Amazon features right at"
-" your fingertips."
-msgstr ""
-"Nainštalujte si aplikácie pre prehliadač týkajpúce sa Amazonu a budete mať "
-"všetky funckie Amazonu priamo pod svojimi prstami."
+msgid "Install the Amazon Browser Apps and receive special Amazon features right at your fingertips."
+msgstr "Nainštalujte si aplikácie pre prehliadač týkajpúce sa Amazonu a budete mať všetky funckie Amazonu priamo pod svojimi prstami."
 
 #: src/olympia/discovery/templates/discovery/modules/holiday.html:22
-msgid ""
-"Keep an eye on your eBay activity wherever you are on the web when you "
-"install the eBay Sidebar for Firefox."
-msgstr ""
-"Majte na očiach aktivity na eBay, kdekoľvek na webe práve ste. Nainštalujte "
-"si eBay Sidebar pre Firefox."
+msgid "Keep an eye on your eBay activity wherever you are on the web when you install the eBay Sidebar for Firefox."
+msgstr "Majte na očiach aktivity na eBay, kdekoľvek na webe práve ste. Nainštalujte si eBay Sidebar pre Firefox."
 
 #: src/olympia/discovery/templates/discovery/modules/holiday.html:31
 msgid "See the entire holiday shopping add-on collection."
@@ -9370,19 +7285,19 @@ msgstr "doplnok, editor alebo komentár"
 msgid "Search by add-on name / author email"
 msgstr "Hľadať podľa názvu doplnku alebo e-mailu autora"
 
-#: src/olympia/editors/forms.py:103
+#: src/olympia/editors/forms.py:103 src/olympia/editors/forms.py:244 src/olympia/editors/forms.py:257
 msgid "yes"
 msgstr "áno"
 
-#: src/olympia/editors/forms.py:104
+#: src/olympia/editors/forms.py:104 src/olympia/editors/forms.py:244 src/olympia/editors/forms.py:257
 msgid "no"
 msgstr "nie"
 
-#: src/olympia/editors/forms.py:105
+#: src/olympia/editors/forms.py:105 src/olympia/editors/forms.py:245
 msgid "Admin Flag"
 msgstr "Označenie administrátorom"
 
-#: src/olympia/editors/forms.py:113
+#: src/olympia/editors/forms.py:113 src/olympia/editors/forms.py:253
 msgid "Max. Version"
 msgstr "Max. verzia"
 
@@ -9394,59 +7309,59 @@ msgstr "Doba od odoslania (dni)"
 msgid "Add-on Types"
 msgstr "Typy doplnkov"
 
-#: src/olympia/editors/forms.py:126 src/olympia/editors/helpers.py:267
+#: src/olympia/editors/forms.py:126 src/olympia/editors/helpers.py:279
 msgid "Platforms"
 msgstr "Platformy"
 
+#: src/olympia/editors/forms.py:237
+msgid "Search by add-on name / author email / guid"
+msgstr ""
+
 #. L10n: 0 = platform, 1 = filename, 2 = status message
-#: src/olympia/editors/forms.py:238
+#: src/olympia/editors/forms.py:342
 #, python-format
 msgid "<strong>%s</strong> &middot; %s &middot; %s"
 msgstr "<strong>%s</strong> &middot; %s &middot; %s"
 
-#: src/olympia/editors/forms.py:252
+#: src/olympia/editors/forms.py:356
 msgid "Comments:"
 msgstr "Komentáre:"
 
-#: src/olympia/editors/forms.py:256
+#: src/olympia/editors/forms.py:360
 msgid "Operating systems:"
 msgstr "Operačné systémy:"
 
-#: src/olympia/editors/forms.py:258
+#: src/olympia/editors/forms.py:362
 msgid "Applications:"
 msgstr "Aplikácie:"
 
-#: src/olympia/editors/forms.py:260
-msgid ""
-"Notify me the next time this add-on is updated. (Subsequent updates will not"
-" generate an email)"
-msgstr ""
-"Upozorniť ma pri nasledujúcej aktualizácii tohto doplnku. (Ďalšie "
-"aktualizácie nevygenerujú e-mailovú správu)"
+#: src/olympia/editors/forms.py:364
+msgid "Notify me the next time this add-on is updated. (Subsequent updates will not generate an email)"
+msgstr "Upozorniť ma pri nasledujúcej aktualizácii tohto doplnku. (Ďalšie aktualizácie nevygenerujú e-mailovú správu)"
 
-#: src/olympia/editors/forms.py:265
+#: src/olympia/editors/forms.py:369
 msgid "Clear Admin Review Flag"
 msgstr "Vymazať príznak kontroly administrátorom"
 
-#: src/olympia/editors/forms.py:267
+#: src/olympia/editors/forms.py:371
 msgid "Clear more info requested flag"
 msgstr "Zrušiť požiadavku na viac informácií"
 
-#: src/olympia/editors/forms.py:281
+#: src/olympia/editors/forms.py:385
 msgid "Choose a canned response..."
 msgstr "Zvoľte pripravenú odpoveď..."
 
 #. L10n: Description of what can be searched for.
-#: src/olympia/editors/forms.py:324
+#: src/olympia/editors/forms.py:423
 msgid "theme name"
 msgstr "názov témy"
 
-#: src/olympia/editors/forms.py:350
+#: src/olympia/editors/forms.py:449
 msgid "Someone else is reviewing this theme."
 msgstr "Niekto iný aktuálne kontroluje túto tému."
 
 #. L10n: Description of what can be searched for.
-#: src/olympia/editors/forms.py:447
+#: src/olympia/editors/forms.py:546
 msgid "app, reviewer, or comment"
 msgstr "aplikácia, recenzia alebo komentár"
 
@@ -9462,303 +7377,270 @@ msgstr "Čakajúci na predbežnú kontrolu"
 msgid "Rejected or Unreviewed"
 msgstr "Zamietnuté a neskontrolované"
 
-#: src/olympia/editors/helpers.py:123 src/olympia/editors/helpers.py:136
+#: src/olympia/editors/helpers.py:125 src/olympia/editors/helpers.py:138
 msgid "Queue"
 msgstr "Fronta"
 
-#: src/olympia/editors/helpers.py:124
-#: src/olympia/editors/templates/editors/base.html:50
-#: src/olympia/editors/templates/editors/base.html:65
+#: src/olympia/editors/helpers.py:126 src/olympia/editors/templates/editors/base.html:50 src/olympia/editors/templates/editors/base.html:65
 msgid "Pending Updates"
 msgstr "Nevybavené aktualizácie"
 
-#: src/olympia/editors/helpers.py:125
-#: src/olympia/editors/templates/editors/base.html:48
-#: src/olympia/editors/templates/editors/base.html:63
+#: src/olympia/editors/helpers.py:127 src/olympia/editors/templates/editors/base.html:48 src/olympia/editors/templates/editors/base.html:63
 msgid "Full Reviews"
 msgstr "Riadne kontroly"
 
-#: src/olympia/editors/helpers.py:126
-#: src/olympia/editors/templates/editors/base.html:52
-#: src/olympia/editors/templates/editors/base.html:67
+#: src/olympia/editors/helpers.py:128 src/olympia/editors/templates/editors/base.html:52 src/olympia/editors/templates/editors/base.html:67
 msgid "Preliminary Reviews"
 msgstr "Predbežné kontroly"
 
-#: src/olympia/editors/helpers.py:127
-#: src/olympia/editors/templates/editors/base.html:54
+#: src/olympia/editors/helpers.py:129 src/olympia/editors/templates/editors/base.html:54
 msgid "Moderated Reviews"
 msgstr "Moderované recenzie"
 
-#: src/olympia/editors/helpers.py:128
-#: src/olympia/editors/templates/editors/base.html:46
+#: src/olympia/editors/helpers.py:130 src/olympia/editors/templates/editors/base.html:46
 msgid "Fast Track"
 msgstr "Rýchla kontrola"
 
-#: src/olympia/editors/helpers.py:130
+#: src/olympia/editors/helpers.py:132
 msgid "Pending Themes"
 msgstr "Čakajúce témy"
 
-#: src/olympia/editors/helpers.py:131
-#: src/olympia/editors/templates/editors/themes/queue.html:4
+#: src/olympia/editors/helpers.py:133 src/olympia/editors/templates/editors/themes/queue.html:4
 msgid "Flagged Themes"
 msgstr "Označené témy"
 
-#: src/olympia/editors/helpers.py:132
+#: src/olympia/editors/helpers.py:134
 msgid "Update Themes"
 msgstr "Aktualizované témy"
 
-#: src/olympia/editors/helpers.py:137
+#: src/olympia/editors/helpers.py:139
 msgid "Unlisted Pending Updates"
 msgstr "Čakajúce aktualizácie mimo zoznam"
 
-#: src/olympia/editors/helpers.py:138
+#: src/olympia/editors/helpers.py:140
 msgid "Unlisted Full Reviews"
 msgstr "Kompletné kontroly mimo zoznam"
 
-#: src/olympia/editors/helpers.py:139
+#: src/olympia/editors/helpers.py:141
 msgid "Unlisted Preliminary Reviews"
 msgstr "Predbežné kontroly mimo zoznam"
 
-#: src/olympia/editors/helpers.py:170
+#: src/olympia/editors/helpers.py:142
+msgid "Unlisted All Add-ons"
+msgstr ""
+
+#: src/olympia/editors/helpers.py:173
 msgid "Fast Track ({0})"
 msgid_plural "Fast Track ({0})"
 msgstr[0] "Rýchla kontrola ({0})"
 msgstr[1] "Rýchla kontrola ({0})"
-msgstr[2] "Rýchla kontrola ({0})"
 
-#: src/olympia/editors/helpers.py:175
+#: src/olympia/editors/helpers.py:178
 msgid "Full Review ({0})"
 msgid_plural "Full Reviews ({0})"
 msgstr[0] "Plná kontrola ({0})"
 msgstr[1] "Plné kontroly ({0})"
-msgstr[2] "Plné kontroly ({0})"
 
-#: src/olympia/editors/helpers.py:180
+#: src/olympia/editors/helpers.py:183
 msgid "Pending Update ({0})"
 msgid_plural "Pending Updates ({0})"
 msgstr[0] "Čakajúci na aktualizáciu ({0})"
 msgstr[1] "Čakajúce na aktualizáciu ({0})"
-msgstr[2] "Čakajúce na aktualizáciu ({0})"
 
 # 88%
-#: src/olympia/editors/helpers.py:185
+#: src/olympia/editors/helpers.py:188
 msgid "Preliminary Review ({0})"
 msgid_plural "Preliminary Reviews ({0})"
 msgstr[0] "Predbežná kontrola ({0})"
 msgstr[1] "Predbežné kontroly ({0})"
-msgstr[2] "Predbežné kontroly ({0})"
 
-#: src/olympia/editors/helpers.py:190
+#: src/olympia/editors/helpers.py:193
 msgid "Moderated Review ({0})"
 msgid_plural "Moderated Reviews ({0})"
 msgstr[0] "Moderovaná recenzia ({0})"
 msgstr[1] "Moderované recenzie ({0})"
-msgstr[2] "Moderované recenzie ({0})"
 
-#: src/olympia/editors/helpers.py:196
+#: src/olympia/editors/helpers.py:199
 msgid "Unlisted Full Review ({0})"
 msgid_plural "Unlisted Full Reviews ({0})"
 msgstr[0] "Kompletné kontroly mimo zoznam ({0})"
 msgstr[1] "Kompletné kontroly mimo zoznam ({0})"
-msgstr[2] "Kompletné kontroly mimo zoznam ({0})"
 
-#: src/olympia/editors/helpers.py:201
+#: src/olympia/editors/helpers.py:204
 msgid "Unlisted Pending Update ({0})"
 msgid_plural "Unlisted Pending Updates ({0})"
 msgstr[0] "Čakajúce aktualizácie mimo zoznam ({0})"
 msgstr[1] "Čakajúce aktualizácie mimo zoznam ({0})"
-msgstr[2] "Čakajúce aktualizácie mimo zoznam ({0})"
 
-#: src/olympia/editors/helpers.py:206
+#: src/olympia/editors/helpers.py:209
 msgid "Unlisted Preliminary Review ({0})"
 msgid_plural "Unlisted Preliminary Reviews ({0})"
 msgstr[0] "Predbežné kontroly mimo zoznam ({0})"
 msgstr[1] "Predbežné kontroly mimo zoznam ({0})"
-msgstr[2] "Predbežné kontroly mimo zoznam ({0})"
 
-#: src/olympia/editors/helpers.py:261
-msgid "Addon"
-msgstr "Doplnok"
+#: src/olympia/editors/helpers.py:214
+msgid "Unlisted All Add-ons ({0})"
+msgid_plural "Unlisted All Add-ons ({0})"
+msgstr[0] ""
+msgstr[1] ""
 
-#: src/olympia/editors/helpers.py:262
+#: src/olympia/editors/helpers.py:274
 msgid "Type"
 msgstr "Typ"
 
-#: src/olympia/editors/helpers.py:263
+#: src/olympia/editors/helpers.py:275
 msgid "Waiting Time"
 msgstr "Doba čakania"
 
-#: src/olympia/editors/helpers.py:264
-#: src/olympia/editors/templates/editors/review.html:285
+#: src/olympia/editors/helpers.py:276 src/olympia/editors/templates/editors/review.html:285
 msgid "Flags"
 msgstr "Označenia"
 
-#: src/olympia/editors/helpers.py:265
+#: src/olympia/editors/helpers.py:277
 msgid "Applications"
 msgstr "Aplikácie"
 
-#: src/olympia/editors/helpers.py:270
+#: src/olympia/editors/helpers.py:282
 msgid "Additional"
 msgstr "Ďalšie"
 
-#: src/olympia/editors/helpers.py:285
+#: src/olympia/editors/helpers.py:302
 msgid "Site Specific"
 msgstr "Pre špecifickú stránku"
 
-#: src/olympia/editors/helpers.py:287
+#: src/olympia/editors/helpers.py:304
 msgid "Requires External Software"
 msgstr "Vyžaduje externý softvér"
 
-#: src/olympia/editors/helpers.py:289
+#: src/olympia/editors/helpers.py:306
 msgid "Binary Components"
 msgstr "Binárne komponenty"
 
-#: src/olympia/editors/helpers.py:313
+#: src/olympia/editors/helpers.py:339
 msgid "moments ago"
 msgstr "pred chvíľou"
 
 #. L10n: first argument is number of minutes
-#: src/olympia/editors/helpers.py:316
+#: src/olympia/editors/helpers.py:342
 msgid "{0} minute"
 msgid_plural "{0} minutes"
 msgstr[0] "{0} minúta"
 msgstr[1] "{0} minúty"
-msgstr[2] "{0} minút"
 
 #. L10n: first argument is number of hours
-#: src/olympia/editors/helpers.py:320
+#: src/olympia/editors/helpers.py:346
 msgid "{0} hour"
 msgid_plural "{0} hours"
 msgstr[0] "{0} hodina"
 msgstr[1] "{0} hodiny"
-msgstr[2] "{0} hodín"
 
 #. L10n: first argument is number of days
-#: src/olympia/editors/helpers.py:324
+#: src/olympia/editors/helpers.py:350
 msgid "{0} day"
 msgid_plural "{0} days"
 msgstr[0] "{0} deň"
 msgstr[1] "{0} dni"
-msgstr[2] "{0} dní"
 
-#: src/olympia/editors/helpers.py:488
+#: src/olympia/editors/helpers.py:364
+msgid "Last Review"
+msgstr ""
+
+#: src/olympia/editors/helpers.py:366
+msgid "Last Update"
+msgstr ""
+
+#: src/olympia/editors/helpers.py:387
+msgid "No Reviews"
+msgstr ""
+
+#: src/olympia/editors/helpers.py:561
 msgid "Push to public"
 msgstr "Schváliť pre verejnosť"
 
-#: src/olympia/editors/helpers.py:490
+#: src/olympia/editors/helpers.py:563
 msgid "Grant full review"
 msgstr "Udeliť plnú kontrolu"
 
-#: src/olympia/editors/helpers.py:505
+#: src/olympia/editors/helpers.py:578
 msgid "Request more information"
 msgstr "Vyžiadať dodatočné informácie"
 
-#: src/olympia/editors/helpers.py:508
+#: src/olympia/editors/helpers.py:581
 msgid "Request super-review"
 msgstr "Požadovať super-recenziu"
 
 # 80%
-#: src/olympia/editors/helpers.py:519
+#: src/olympia/editors/helpers.py:592
 msgid "Grant preliminary review"
 msgstr "Udeliť predbežnú kontrolu"
 
-#: src/olympia/editors/helpers.py:520
+#: src/olympia/editors/helpers.py:593
 msgid "This will mark the files as preliminarily reviewed."
 msgstr "Označí súbory ako predbežne schválené."
 
-#: src/olympia/editors/helpers.py:522
-msgid ""
-"Use this form to request more information from the author. They will receive"
-" an email and be able to answer here. You will be notified by email when "
-"they reply."
-msgstr ""
-"Použite tento formulár na vyžiadanie dodatočných informácií od autora "
-"doplnku, ktorý obdrží e-mailovú správu a bude môcť tu odpovedať. Pri jeho "
-"odpovedi budete upozornený e-mailovou správou."
+#: src/olympia/editors/helpers.py:595
+msgid "Use this form to request more information from the author. They will receive an email and be able to answer here. You will be notified by email when they reply."
+msgstr "Použite tento formulár na vyžiadanie dodatočných informácií od autora doplnku, ktorý obdrží e-mailovú správu a bude môcť tu odpovedať. Pri jeho odpovedi budete upozornený e-mailovou správou."
 
-#: src/olympia/editors/helpers.py:526
+#: src/olympia/editors/helpers.py:599
 msgid ""
-"If you have concerns about this add-on's security, copyright issues, or "
-"other concerns that an administrator should look into, enter your comments "
-"in the area below. They will be sent to administrators, not the author."
+"If you have concerns about this add-on's security, copyright issues, or other concerns that an administrator should look into, enter your comments in the area below. They will be sent to "
+"administrators, not the author."
 msgstr ""
-"Ak máte pochybnosti o bezpečnosti tohto doplnku, problémoch s autorskými "
-"právami alebo iné, na ktoré by sa mal pozrieť správca, zadajte do dole "
-"uvedenej časti svoje komentáre. Budú odoslané správcom, nie autorovi."
+"Ak máte pochybnosti o bezpečnosti tohto doplnku, problémoch s autorskými právami alebo iné, na ktoré by sa mal pozrieť správca, zadajte do dole uvedenej časti svoje komentáre. Budú odoslané "
+"správcom, nie autorovi."
 
-#: src/olympia/editors/helpers.py:532
+#: src/olympia/editors/helpers.py:605
 msgid "This will reject the add-on and remove it from the review queue."
 msgstr "Zamietne doplnok a odstráni ho zo zoznamu na kontrolu."
 
-#: src/olympia/editors/helpers.py:534
+#: src/olympia/editors/helpers.py:607
 msgid "Make a comment on this version. The author won't be able to see this."
 msgstr "Pridajte komentár k tejto verzii. Autor ho nebude vidieť."
 
-#: src/olympia/editors/helpers.py:538
+#: src/olympia/editors/helpers.py:611
 msgid "This will reject the files and remove them from the review queue."
 msgstr "Zamietne súbory a odstráni ich zo zoznamu na kontrolu."
 
-#: src/olympia/editors/helpers.py:542
-msgid ""
-"This will mark the add-on as preliminarily reviewed. Future versions will "
-"undergo preliminary review."
-msgstr ""
-"Označí doplnok ako predbežne skontrolovaný. Ďalšie verzie budú opäť "
-"prechádzať predbežnou kontrolou."
+#: src/olympia/editors/helpers.py:615
+msgid "This will mark the add-on as preliminarily reviewed. Future versions will undergo preliminary review."
+msgstr "Označí doplnok ako predbežne skontrolovaný. Ďalšie verzie budú opäť prechádzať predbežnou kontrolou."
 
-#: src/olympia/editors/helpers.py:547
-msgid ""
-"This will mark the files as preliminarily reviewed. Future versions will "
-"undergo preliminary review."
-msgstr ""
-"Označí súbory ako predbežne skontrolované. Ďalšie verzie budú opäť "
-"prechádzať predbežnou kontrolou."
+#: src/olympia/editors/helpers.py:620
+msgid "This will mark the files as preliminarily reviewed. Future versions will undergo preliminary review."
+msgstr "Označí súbory ako predbežne skontrolované. Ďalšie verzie budú opäť prechádzať predbežnou kontrolou."
 
-#: src/olympia/editors/helpers.py:552
+#: src/olympia/editors/helpers.py:625
 msgid "Retain preliminary review"
 msgstr "Predbežná kontrola pozdržaná"
 
-#: src/olympia/editors/helpers.py:553
-msgid ""
-"This will retain the add-on as preliminarily reviewed. Future versions will "
-"undergo preliminary review."
-msgstr ""
-"Zamietne predbežnú kontrolu doplnku. Ďalšie verzie budú opäť prechádzať "
-"predbežnou kontrolou."
+#: src/olympia/editors/helpers.py:626
+msgid "This will retain the add-on as preliminarily reviewed. Future versions will undergo preliminary review."
+msgstr "Zamietne predbežnú kontrolu doplnku. Ďalšie verzie budú opäť prechádzať predbežnou kontrolou."
 
-#: src/olympia/editors/helpers.py:558
-msgid ""
-"This will approve a sandboxed version of a public add-on to appear on the "
-"public side."
-msgstr ""
-"Tým schválite verziu zo Sandboxu nominovanú na uverejnenie, aby sa objavila "
-"na verejnej stránke."
+#: src/olympia/editors/helpers.py:631
+msgid "This will approve a sandboxed version of a public add-on to appear on the public side."
+msgstr "Tým schválite verziu zo Sandboxu nominovanú na uverejnenie, aby sa objavila na verejnej stránke."
 
-#: src/olympia/editors/helpers.py:561
-msgid ""
-"This will reject a version of a public add-on and remove it from the queue."
+#: src/olympia/editors/helpers.py:634
+msgid "This will reject a version of a public add-on and remove it from the queue."
 msgstr "Zamietne verziu verejne dostupného doplnku a odstráni ho z fronty."
 
-#: src/olympia/editors/helpers.py:564
-msgid ""
-"This will mark the add-on and its most recent version and files as public. "
-"Future versions will go into the sandbox until they are reviewed by an "
-"editor."
-msgstr ""
-"Týmto označíte doplnok a jeho najnovšiu verziu a súbory ako verejné. Budúce "
-"verzie prejdú do Sandboxu, kým sa nepodrobia recenzii editorom."
+#: src/olympia/editors/helpers.py:637
+msgid "This will mark the add-on and its most recent version and files as public. Future versions will go into the sandbox until they are reviewed by an editor."
+msgstr "Týmto označíte doplnok a jeho najnovšiu verziu a súbory ako verejné. Budúce verzie prejdú do Sandboxu, kým sa nepodrobia recenzii editorom."
 
 # 83%
-#: src/olympia/editors/helpers.py:637
+#: src/olympia/editors/helpers.py:714
 msgid "add-on"
 msgstr "doplnok"
 
-#: src/olympia/editors/helpers.py:940 src/olympia/editors/helpers.py:960
+#: src/olympia/editors/helpers.py:1020 src/olympia/editors/helpers.py:1040
 msgid "Flagged"
 msgstr "Označené"
 
 # 85%
-#: src/olympia/editors/helpers.py:944 src/olympia/editors/helpers.py:963
+#: src/olympia/editors/helpers.py:1024 src/olympia/editors/helpers.py:1043
 msgid "Updates"
 msgstr "Aktualizácie"
 
@@ -9812,77 +7694,72 @@ msgstr "Odoslanie témy označené na kontrolu"
 msgid "A question about your Theme submission"
 msgstr "Při přidávání vašeho motivu nastal problém"
 
-#: src/olympia/editors/views.py:144
+#: src/olympia/editors/views.py:146
 msgid "New Add-ons (Under 5 days)"
 msgstr "Nové doplnky (za posledných 5 dní)"
 
-#: src/olympia/editors/views.py:145
+#: src/olympia/editors/views.py:147
 #, fuzzy
 msgid "Passable (5 to 10 days)"
 msgstr "Snesitelné (5 až 10 dní)"
 
-#: src/olympia/editors/views.py:146
+#: src/olympia/editors/views.py:148
 #, fuzzy
 msgid "Overdue (Over 10 days)"
 msgstr "S prodlevou (více než 10 dní)"
 
-#: src/olympia/editors/views.py:532
+#: src/olympia/editors/views.py:539
 msgid "An unknown error occurred"
 msgstr "Nastala neznáma chyba"
 
-#: src/olympia/editors/views.py:587
+#: src/olympia/editors/views.py:592
 msgid "Self-reviews are not allowed."
 msgstr "Recenzie samým sebou nie sú dovolené."
 
-#: src/olympia/editors/views.py:609
+#: src/olympia/editors/views.py:613
 msgid "Review successfully processed."
 msgstr "Recenzia úspešne spracovaná."
 
-#: src/olympia/editors/views.py:807
+#: src/olympia/editors/views.py:812
 msgid "was approved"
 msgstr "schválené"
 
 # 80%
-#: src/olympia/editors/views.py:808
+#: src/olympia/editors/views.py:813
 msgid "given preliminary review"
 msgstr "predbežne skontrolované"
 
 # 87%
-#: src/olympia/editors/views.py:809
+#: src/olympia/editors/views.py:814
 msgid "rejected"
 msgstr "zamietnuté"
 
 # 88%
-#: src/olympia/editors/views.py:810
+#: src/olympia/editors/views.py:815
 msgctxt "editors_review_history_nominated_adminreview"
 msgid "escalated"
 msgstr "bude detailne skontrolované"
 
-#: src/olympia/editors/views.py:812
+#: src/olympia/editors/views.py:817
 msgid "needs more information"
 msgstr "potrebuje dodatočné informácie"
 
-#: src/olympia/editors/views.py:813
+#: src/olympia/editors/views.py:818
 msgid "needs super review"
 msgstr "potrebuje super-kontrolu"
 
-#: src/olympia/editors/views.py:814
+#: src/olympia/editors/views.py:819
 msgid "commented"
 msgstr ""
 
 #: src/olympia/editors/views_themes.py:326
 msgid "{0} theme review successfully processed (+{1} points, {2} total)."
-msgid_plural ""
-"{0} theme reviews successfully processed (+{1} points, {2} total)."
+msgid_plural "{0} theme reviews successfully processed (+{1} points, {2} total)."
 msgstr[0] ""
 msgstr[1] ""
-msgstr[2] ""
 
 #: src/olympia/editors/views_themes.py:341
-msgid ""
-"Your theme locks have successfully been released. Other reviewers may now "
-"review those released themes. You may have to refresh the page to see the "
-"changes reflected in the table below."
+msgid "Your theme locks have successfully been released. Other reviewers may now review those released themes. You may have to refresh the page to see the changes reflected in the table below."
 msgstr ""
 
 #: src/olympia/editors/templates/editors/abuse_reports.html:4
@@ -9910,9 +7787,7 @@ msgstr "<i>anonymní</i> dne %(date)s [%(ip_address)s]"
 msgid "Return to the Editor Tools homepage"
 msgstr "Zpět na domovskou stránků Nástroje redaktora"
 
-#: src/olympia/editors/templates/editors/base.html:43
-#: src/olympia/editors/templates/editors/themes/base.html:14
-#: src/olympia/editors/templates/editors/themes/base.html:28
+#: src/olympia/editors/templates/editors/base.html:43 src/olympia/editors/templates/editors/themes/base.html:14 src/olympia/editors/templates/editors/themes/base.html:28
 #: src/olympia/editors/templates/editors/themes/queue.html:25
 msgid "Queues"
 msgstr "Fronty"
@@ -9921,74 +7796,54 @@ msgstr "Fronty"
 msgid "Unlisted Queues"
 msgstr ""
 
-#: src/olympia/editors/templates/editors/base.html:72
-#: src/olympia/editors/templates/editors/performance.html:6
+#: src/olympia/editors/templates/editors/base.html:74 src/olympia/editors/templates/editors/performance.html:6
 msgid "Performance"
 msgstr "Výkon"
 
-#: src/olympia/editors/templates/editors/base.html:75
-#: src/olympia/editors/templates/editors/themes/base.html:19
-#: src/olympia/editors/templates/editors/themes/base.html:38
+#: src/olympia/editors/templates/editors/base.html:77 src/olympia/editors/templates/editors/themes/base.html:19 src/olympia/editors/templates/editors/themes/base.html:38
 msgid "Logs"
 msgstr "Denníky"
 
-#: src/olympia/editors/templates/editors/base.html:78
-#: src/olympia/editors/templates/editors/reviewlog.html:4
-#: src/olympia/editors/templates/editors/reviewlog.html:27
+#: src/olympia/editors/templates/editors/base.html:80 src/olympia/editors/templates/editors/reviewlog.html:4 src/olympia/editors/templates/editors/reviewlog.html:27
 msgid "Add-on Review Log"
 msgstr "Záznam kontroly doplnku"
 
 # 80%
-#: src/olympia/editors/templates/editors/base.html:80
-#: src/olympia/editors/templates/editors/eventlog.html:4
-#: src/olympia/editors/templates/editors/eventlog.html:8
+#: src/olympia/editors/templates/editors/base.html:82 src/olympia/editors/templates/editors/eventlog.html:4 src/olympia/editors/templates/editors/eventlog.html:8
 #: src/olympia/editors/templates/editors/eventlog_detail.html:4
 #, fuzzy
 msgid "Moderated Review Log"
 msgstr "Seznam moderovaných recenzí"
 
-#: src/olympia/editors/templates/editors/base.html:82
-#: src/olympia/editors/templates/editors/beta_signed_log.html:4
-#: src/olympia/editors/templates/editors/beta_signed_log.html:8
+#: src/olympia/editors/templates/editors/base.html:84 src/olympia/editors/templates/editors/beta_signed_log.html:4 src/olympia/editors/templates/editors/beta_signed_log.html:8
 msgid "Signed Beta Files Log"
 msgstr ""
 
-#: src/olympia/editors/templates/editors/base.html:87
-#: src/olympia/editors/templates/editors/includes/daily-message.html:4
+#: src/olympia/editors/templates/editors/base.html:89 src/olympia/editors/templates/editors/includes/daily-message.html:4
 msgid "Announcement"
 msgstr "Oznámenie"
 
 #. "Filter" is a button label (verb)
-#: src/olympia/editors/templates/editors/beta_signed_log.html:17
-#: src/olympia/editors/templates/editors/eventlog.html:24
-#: src/olympia/editors/templates/editors/reviewlog.html:21
-#: src/olympia/editors/templates/editors/themes/macros.html:45
-#: src/olympia/editors/templates/editors/themes/includes/logs_filter_deleted.html:12
+#: src/olympia/editors/templates/editors/beta_signed_log.html:17 src/olympia/editors/templates/editors/eventlog.html:24 src/olympia/editors/templates/editors/reviewlog.html:21
+#: src/olympia/editors/templates/editors/themes/macros.html:45 src/olympia/editors/templates/editors/themes/includes/logs_filter_deleted.html:12
 msgid "Filter"
 msgstr "Filtrovať"
 
-#: src/olympia/editors/templates/editors/beta_signed_log.html:23
-#: src/olympia/editors/templates/editors/eventlog.html:30
-#: src/olympia/editors/templates/editors/reviewlog.html:34
+#: src/olympia/editors/templates/editors/beta_signed_log.html:23 src/olympia/editors/templates/editors/eventlog.html:30 src/olympia/editors/templates/editors/reviewlog.html:34
 #: src/olympia/editors/templates/editors/themes/logs.html:16
 msgid "Date"
 msgstr "Dátum"
 
-#: src/olympia/editors/templates/editors/beta_signed_log.html:24
-#: src/olympia/editors/templates/editors/eventlog.html:31
-#: src/olympia/editors/templates/editors/reviewlog.html:35
+#: src/olympia/editors/templates/editors/beta_signed_log.html:24 src/olympia/editors/templates/editors/eventlog.html:31 src/olympia/editors/templates/editors/reviewlog.html:35
 msgid "Event"
 msgstr "Udalosť"
 
-#: src/olympia/editors/templates/editors/beta_signed_log.html:37
-#: src/olympia/editors/templates/editors/eventlog.html:44
-#: src/olympia/editors/templates/editors/home.html:180
+#: src/olympia/editors/templates/editors/beta_signed_log.html:37 src/olympia/editors/templates/editors/eventlog.html:44 src/olympia/editors/templates/editors/home.html:180
 msgid "More details."
 msgstr "Ďalšie informácie"
 
 # 87%
-#: src/olympia/editors/templates/editors/beta_signed_log.html:46
-#: src/olympia/editors/templates/editors/eventlog.html:53
+#: src/olympia/editors/templates/editors/beta_signed_log.html:46 src/olympia/editors/templates/editors/eventlog.html:53
 #, fuzzy
 msgid "No events found for this period."
 msgstr "Pre tento časový úsek neboli nájdené žiadne udalosti."
@@ -10026,37 +7881,30 @@ msgid "Full Review ({num})"
 msgid_plural "Full Reviews ({num})"
 msgstr[0] "Plná kontrola ({num})"
 msgstr[1] "Plné kontroly ({num})"
-msgstr[2] "Plné kontroly ({num})"
 
 #: src/olympia/editors/templates/editors/home.html:18
 msgid "Pending Update ({num})"
 msgid_plural "Pending Updates ({num})"
 msgstr[0] "Čakajúci na aktualizáciu ({num})"
 msgstr[1] "Čakajúce na aktualizáciu ({num})"
-msgstr[2] "Čakajúce na aktualizáciu ({num})"
 
 #: src/olympia/editors/templates/editors/home.html:25
 msgid "Preliminary Review ({num})"
 msgid_plural "Preliminary Reviews ({num})"
 msgstr[0] "Čakajúci na predbežnú kontrolu ({num})"
 msgstr[1] "Čakajúci na predbežnú kontrolu ({num})"
-msgstr[2] "Čakajúci na predbežnú kontrolu ({num})"
 
-#: src/olympia/editors/templates/editors/home.html:36
-#: src/olympia/editors/templates/editors/home.html:86
+#: src/olympia/editors/templates/editors/home.html:36 src/olympia/editors/templates/editors/home.html:86
 msgid "Current waiting times:"
 msgstr "Aktuálna doba čakania:"
 
-#: src/olympia/editors/templates/editors/home.html:44
-#: src/olympia/editors/templates/editors/home.html:94
+#: src/olympia/editors/templates/editors/home.html:44 src/olympia/editors/templates/editors/home.html:94
 msgid "{0} add-on"
 msgid_plural "{0} add-ons"
 msgstr[0] "{0} doplnok"
 msgstr[1] "{0} doplnky"
-msgstr[2] "{0} doplnkov"
 
-#: src/olympia/editors/templates/editors/home.html:45
-#: src/olympia/editors/templates/editors/home.html:95
+#: src/olympia/editors/templates/editors/home.html:45 src/olympia/editors/templates/editors/home.html:95
 #, python-format
 msgid "{0}%%"
 msgstr ""
@@ -10066,30 +7914,24 @@ msgid "Unlisted Full Review ({num})"
 msgid_plural "Unlisted Full Reviews ({num})"
 msgstr[0] ""
 msgstr[1] ""
-msgstr[2] ""
 
 #: src/olympia/editors/templates/editors/home.html:68
 msgid "Unlisted Pending Update ({num})"
 msgid_plural "Unlisted Pending Updates ({num})"
 msgstr[0] ""
 msgstr[1] ""
-msgstr[2] ""
 
 #: src/olympia/editors/templates/editors/home.html:75
 msgid "Unlisted Preliminary Review ({num})"
 msgid_plural "Unlisted Preliminary Reviews ({num})"
 msgstr[0] ""
 msgstr[1] ""
-msgstr[2] ""
 
-#: src/olympia/editors/templates/editors/home.html:109
-#: src/olympia/editors/templates/editors/performance.html:37
-#: src/olympia/editors/templates/editors/themes/home.html:54
+#: src/olympia/editors/templates/editors/home.html:109 src/olympia/editors/templates/editors/performance.html:37 src/olympia/editors/templates/editors/themes/home.html:54
 msgid "Total Reviews"
 msgstr "Recenzie celkom"
 
-#: src/olympia/editors/templates/editors/home.html:110
-#: src/olympia/editors/templates/editors/themes/home.html:55
+#: src/olympia/editors/templates/editors/home.html:110 src/olympia/editors/templates/editors/themes/home.html:55
 #, fuzzy
 msgid "Reviews This Month"
 msgstr "Kontrol tento měsíc"
@@ -10098,8 +7940,7 @@ msgstr "Kontrol tento měsíc"
 msgid "New Editors"
 msgstr "Noví editori"
 
-#: src/olympia/editors/templates/editors/home.html:126
-#: src/olympia/editors/templates/editors/home.html:141
+#: src/olympia/editors/templates/editors/home.html:126 src/olympia/editors/templates/editors/home.html:141
 msgid "You're #{0} with {1} reviews"
 msgstr ""
 
@@ -10109,15 +7950,12 @@ msgid "Moderated Review ({num})"
 msgid_plural "Moderated Reviews ({num})"
 msgstr[0] "Moderovaná recenzia ({num})"
 msgstr[1] "Moderované recenzie ({num})"
-msgstr[2] "Moderované recenzie ({num})"
 
-#: src/olympia/editors/templates/editors/leaderboard.html:3
-#: src/olympia/editors/templates/editors/includes/reviewers_score_bar.html:56
+#: src/olympia/editors/templates/editors/leaderboard.html:3 src/olympia/editors/templates/editors/includes/reviewers_score_bar.html:56
 msgid "Reviewer Leaderboard"
 msgstr ""
 
-#: src/olympia/editors/templates/editors/leaderboard.html:18
-#: src/olympia/editors/templates/editors/performance.html:65
+#: src/olympia/editors/templates/editors/leaderboard.html:18 src/olympia/editors/templates/editors/performance.html:65
 msgid "No review points awarded yet."
 msgstr ""
 
@@ -10137,8 +7975,7 @@ msgstr "Správa dňa"
 msgid "Update message of the day"
 msgstr "Aktualizovať správu dňa"
 
-#: src/olympia/editors/templates/editors/motd.html:15
-#: src/olympia/editors/templates/editors/review.html:224
+#: src/olympia/editors/templates/editors/motd.html:15 src/olympia/editors/templates/editors/review.html:224
 msgid "Save"
 msgstr "Uložiť"
 
@@ -10206,51 +8043,45 @@ msgstr "Rozšírené vyhľadávanie"
 msgid "clear search"
 msgstr "vymazať vyhľadávanie"
 
-#: src/olympia/editors/templates/editors/queue.html:72
-#: src/olympia/editors/templates/editors/queue.html:122
+#: src/olympia/editors/templates/editors/queue.html:78 src/olympia/editors/templates/editors/queue.html:128
 msgid "Process Reviews"
 msgstr "Spracovať recenzie"
 
-#: src/olympia/editors/templates/editors/queue.html:80
+#: src/olympia/editors/templates/editors/queue.html:86
 msgid "Moderation actions:"
 msgstr "Kroky moderátora:"
 
-#: src/olympia/editors/templates/editors/queue.html:90
+#: src/olympia/editors/templates/editors/queue.html:96
 #, python-format
 msgid "by %(user)s on %(date)s %(stars)s (%(locale)s)"
 msgstr "od %(user)s dňa %(date)s %(stars)s (%(locale)s)"
 
-#: src/olympia/editors/templates/editors/queue.html:106
+#: src/olympia/editors/templates/editors/queue.html:112
 #, python-format
-msgid ""
-"<strong>%(reason)s</strong> <span class=\"light\">Flagged by %(user)s on "
-"%(date)s</span>"
-msgstr ""
-"<strong>%(reason)s</strong> <span class=\"light\">Označil %(user)s dňa "
-"%(date)s</span>"
+msgid "<strong>%(reason)s</strong> <span class=\"light\">Flagged by %(user)s on %(date)s</span>"
+msgstr "<strong>%(reason)s</strong> <span class=\"light\">Označil %(user)s dňa %(date)s</span>"
 
-#: src/olympia/editors/templates/editors/queue.html:119
+#: src/olympia/editors/templates/editors/queue.html:125
 msgid "All reviews have been moderated. Good work!"
 msgstr "Všetky recenzie boli skontrolované. Výborná práca!"
 
-#: src/olympia/editors/templates/editors/queue.html:161
+#: src/olympia/editors/templates/editors/queue.html:167
 msgid "Version Notes / Notes for Reviewer"
 msgstr "Poznámky k verzii / Poznámky pre redaktora"
 
-#: src/olympia/editors/templates/editors/queue.html:169
+#: src/olympia/editors/templates/editors/queue.html:175
 msgid "There are currently no add-ons of this type to review."
 msgstr "Momentálne nie je na recenziu žiadny doplnok tohto typu."
 
-#: src/olympia/editors/templates/editors/queue.html:181
-#: src/olympia/editors/templates/editors/themes/queue_list.html:85
+#: src/olympia/editors/templates/editors/queue.html:187 src/olympia/editors/templates/editors/themes/queue_list.html:85
 msgid "Helpful Links:"
 msgstr "Užitočné odkazy:"
 
-#: src/olympia/editors/templates/editors/queue.html:182
+#: src/olympia/editors/templates/editors/queue.html:188
 msgid "Add-on Policy"
 msgstr "Zásady ochrany súkromia doplnku"
 
-#: src/olympia/editors/templates/editors/queue.html:184
+#: src/olympia/editors/templates/editors/queue.html:190
 msgid "Editors' Guide"
 msgstr "Príručka editora"
 
@@ -10263,19 +8094,14 @@ msgstr "Recenzia {0}"
 msgid "Add-on user change history"
 msgstr "História zmien doplnku používateľom"
 
-#: src/olympia/editors/templates/editors/review.html:52
-#: src/olympia/editors/templates/editors/review.html:266
+#: src/olympia/editors/templates/editors/review.html:52 src/olympia/editors/templates/editors/review.html:266
 msgid "Add-on History"
 msgstr "História doplnku"
 
 #: src/olympia/editors/templates/editors/review.html:64
 #, python-format
-msgid ""
-"Version %(version)s &middot; %(created)s <span class=\"light\">&middot; "
-"%(version_status)s</span>"
-msgstr ""
-"Verzia %(version)s &middot; %(created)s <span class=\"light\">&middot; "
-"%(version_status)s</span>"
+msgid "Version %(version)s &middot; %(created)s <span class=\"light\">&middot; %(version_status)s</span>"
+msgstr "Verzia %(version)s &middot; %(created)s <span class=\"light\">&middot; %(version_status)s</span>"
 
 #: src/olympia/editors/templates/editors/review.html:73
 msgid "Compatibility:"
@@ -10298,19 +8124,14 @@ msgid "This version has not been reviewed."
 msgstr "Táto verzia nebola skontrolovaná."
 
 #: src/olympia/editors/templates/editors/review.html:154
-msgid ""
-"You can still submit this form, however only do so if you know it won't "
-"conflict."
-msgstr ""
-"Stále môžete tento formulár odoslať, ale urobte tak len vtedy, ak viete, že "
-"to nespôsobí konflikt."
+msgid "You can still submit this form, however only do so if you know it won't conflict."
+msgstr "Stále môžete tento formulár odoslať, ale urobte tak len vtedy, ak viete, že to nespôsobí konflikt."
 
 #: src/olympia/editors/templates/editors/review.html:161
 msgid "Insert canned response..."
 msgstr "Vyberte pripravenú odpoveď..."
 
-#: src/olympia/editors/templates/editors/review.html:167
-#: src/olympia/files/templates/files/viewer.html:54
+#: src/olympia/editors/templates/editors/review.html:167 src/olympia/files/templates/files/viewer.html:54
 msgid "Files:"
 msgstr "Súbory:"
 
@@ -10319,25 +8140,18 @@ msgid "Tested on:"
 msgstr "Testované na:"
 
 #: src/olympia/editors/templates/editors/review.html:220
-msgid ""
-"<strong>Warning!</strong> Another user was viewing this page before you."
-msgstr ""
-"<strong>Upozornenie!</strong> Iný používateľ pred vami túto stránku "
-"prezeral."
+msgid "<strong>Warning!</strong> Another user was viewing this page before you."
+msgstr "<strong>Upozornenie!</strong> Iný používateľ pred vami túto stránku prezeral."
 
 #: src/olympia/editors/templates/editors/review.html:237
-msgid ""
-"The whiteboard is the place to exchange information relevant to\n"
-"               this addon (whatever the version), between the developer and the\n"
-"               editor. This is visible and editable by both."
+msgid "The whiteboard is the place to exchange information relevant to this addon (whatever the version), between the developer and the editor. This is visible and editable by both."
 msgstr ""
 
 #: src/olympia/editors/templates/editors/review.html:241
 msgid "Update the whiteboard"
 msgstr "Aktualizovať poznámku pre redaktora"
 
-#: src/olympia/editors/templates/editors/review.html:257
-#: src/olympia/editors/templates/editors/review.html:258
+#: src/olympia/editors/templates/editors/review.html:257 src/olympia/editors/templates/editors/review.html:258
 msgid "(admin)"
 msgstr "(admin)"
 
@@ -10365,18 +8179,15 @@ msgstr "Editor"
 msgid "Add-on has been deleted."
 msgstr "Doplnok bol odstránený."
 
-#: src/olympia/editors/templates/editors/reviewlog.html:59
-#: src/olympia/editors/templates/editors/themes/logs.html:36
+#: src/olympia/editors/templates/editors/reviewlog.html:59 src/olympia/editors/templates/editors/themes/logs.html:36
 msgid "Show Comments"
 msgstr "Zobraziť komentáre"
 
-#: src/olympia/editors/templates/editors/reviewlog.html:60
-#: src/olympia/editors/templates/editors/themes/logs.html:37
+#: src/olympia/editors/templates/editors/reviewlog.html:60 src/olympia/editors/templates/editors/themes/logs.html:37
 msgid "Hide Comments"
 msgstr "Skryť komentáre"
 
-#: src/olympia/editors/templates/editors/reviewlog.html:72
-#: src/olympia/editors/templates/editors/themes/logs.html:54
+#: src/olympia/editors/templates/editors/reviewlog.html:72 src/olympia/editors/templates/editors/themes/logs.html:54
 msgid "No reviews found for this period."
 msgstr "Za toto obdobie neboli nájdené žiadne recenzie."
 
@@ -10434,12 +8245,8 @@ msgstr "Celý čas"
 msgid "You have <span>{0}</span> points."
 msgstr "Obdržali ste <span>{0}</span> bodov."
 
-#: src/olympia/editors/templates/editors/includes/search_results_themes.html:6
-#: src/olympia/editors/templates/editors/themes/history_table.html:7
-#: src/olympia/editors/templates/editors/themes/logs.html:19
-#: src/olympia/editors/templates/editors/themes/queue_list.html:49
-#: src/olympia/editors/templates/editors/themes/single.html:26
-#: src/olympia/editors/templates/editors/themes/themes.html:45
+#: src/olympia/editors/templates/editors/includes/search_results_themes.html:6 src/olympia/editors/templates/editors/themes/history_table.html:7 src/olympia/editors/templates/editors/themes/logs.html:19
+#: src/olympia/editors/templates/editors/themes/queue_list.html:49 src/olympia/editors/templates/editors/themes/single.html:26 src/olympia/editors/templates/editors/themes/themes.html:45
 msgid "Reviewer"
 msgstr "Recenzent"
 
@@ -10463,8 +8270,7 @@ msgstr "História kontrol tém pre {0}"
 msgid "Review Date"
 msgstr "Dátum kontroly"
 
-#: src/olympia/editors/templates/editors/themes/history_table.html:9
-#: src/olympia/editors/templates/editors/themes/logs.html:18
+#: src/olympia/editors/templates/editors/themes/history_table.html:9 src/olympia/editors/templates/editors/themes/logs.html:18
 msgid "Action"
 msgstr "Akcia"
 
@@ -10481,21 +8287,18 @@ msgid "{num} Pending Theme Review"
 msgid_plural "{num} Pending Theme Reviews"
 msgstr[0] ""
 msgstr[1] ""
-msgstr[2] ""
 
 #: src/olympia/editors/templates/editors/themes/home.html:27
 msgid "{num} Flagged Review"
 msgid_plural "{num} Flagged Reviews"
 msgstr[0] ""
 msgstr[1] ""
-msgstr[2] ""
 
 #: src/olympia/editors/templates/editors/themes/home.html:34
 msgid "{num} Update"
 msgid_plural "{num} Updates"
 msgstr[0] ""
 msgstr[1] ""
-msgstr[2] ""
 
 #: src/olympia/editors/templates/editors/themes/logs.html:4
 #, fuzzy
@@ -10619,7 +8422,7 @@ msgstr ""
 msgid "Describe your reason for flagging"
 msgstr "Popište důvod odmítnutí"
 
-#: src/olympia/files/forms.py:88
+#: src/olympia/files/forms.py:90
 msgid "Cannot diff a version against itself"
 msgstr ""
 
@@ -10637,12 +8440,8 @@ msgid "Problems decoding {0}."
 msgstr "Problémy s dekódovaním {0}."
 
 #: src/olympia/files/helpers.py:186
-msgid ""
-"This file is not viewable online. Please download the file to view the "
-"contents."
-msgstr ""
-"Tento súbor nie je možné zobraziť online. Súbor si môžete prevziať a "
-"zobraziť jeho obsah lokálne."
+msgid "This file is not viewable online. Please download the file to view the contents."
+msgstr "Tento súbor nie je možné zobraziť online. Súbor si môžete prevziať a zobraziť jeho obsah lokálne."
 
 #: src/olympia/files/helpers.py:194
 msgid "This file is a directory."
@@ -10658,54 +8457,51 @@ msgstr "Pri prístupe k súboru %s sa vyskytla chyba. %s."
 msgid "There was an error accessing file %s."
 msgstr "Pri prístupe k súboru %s sa vyskytla chyba."
 
-#: src/olympia/files/utils.py:343
+#: src/olympia/files/utils.py:340
 msgid "Could not parse uploaded file."
 msgstr "Odoslaný súbor nebolo možné spracovať."
 
-#: src/olympia/files/utils.py:380
+#: src/olympia/files/utils.py:377
 msgid "Invalid file name in archive: {0}"
 msgstr ""
 
-#: src/olympia/files/utils.py:388
+#: src/olympia/files/utils.py:385
 msgid "File exceeding size limit in archive: {0}"
 msgstr ""
 
-#: src/olympia/files/utils.py:439
+#: src/olympia/files/utils.py:436
 msgid "Invalid archive."
 msgstr "Neplatný archív."
 
-#: src/olympia/files/utils.py:529 src/olympia/files/utils.py:532
+#: src/olympia/files/utils.py:526 src/olympia/files/utils.py:529
 msgid "Could not parse the manifest file."
 msgstr ""
 
-#: src/olympia/files/utils.py:551
+#: src/olympia/files/utils.py:548
 msgid "Could not find an add-on ID."
 msgstr ""
 
-#: src/olympia/files/utils.py:554
+#: src/olympia/files/utils.py:551
 msgid "Add-on ID must be 64 characters or less."
 msgstr ""
 
-#: src/olympia/files/utils.py:556
+#: src/olympia/files/utils.py:553
 msgid "Add-on ID doesn't match add-on."
 msgstr ""
 
-#: src/olympia/files/utils.py:564
+#: src/olympia/files/utils.py:561
 msgid "Duplicate add-on ID found."
 msgstr ""
 
-#: src/olympia/files/utils.py:567
+#: src/olympia/files/utils.py:564
 msgid "Version numbers should have fewer than 32 characters."
 msgstr "Číslo verzie musí mať menej ako 32 znakov."
 
-#: src/olympia/files/utils.py:570
-msgid ""
-"Version numbers should only contain letters, numbers, and these punctuation "
-"characters: +*.-_."
-msgstr ""
-"Číslo verzie môže obsahovať len čísla, písmená a nasledovné znaky: +*.-_."
+#: src/olympia/files/utils.py:567
+msgid "Version numbers should only contain letters, numbers, and these punctuation characters: +*.-_."
+msgstr "Číslo verzie môže obsahovať len čísla, písmená a nasledovné znaky: +*.-_."
 
-#: src/olympia/files/utils.py:587
+#: src/olympia/files/utils.py:584
 msgid "<em:type> doesn't match add-on"
 msgstr "<em:type> sa nezhoduje s doplnkom"
 
@@ -10723,12 +8519,8 @@ msgstr "Prevziať {0}"
 
 #: src/olympia/files/templates/files/file.html:4
 #, python-format
-msgid ""
-"Version: %(version)s &bull; Size: %(size)s &bull; MD5 hash: %(md5)s &bull; "
-"Mimetype: %(mimetype)s"
-msgstr ""
-"Verzia: %(version)s &bull; Veľkosť: %(size)s &bull; MD5 hash: %(md5)s &bull;"
-" Typ mime: %(mimetype)s"
+msgid "Version: %(version)s &bull; Size: %(size)s &bull; MD5 hash: %(md5)s &bull; Mimetype: %(mimetype)s"
+msgstr "Verzia: %(version)s &bull; Veľkosť: %(size)s &bull; MD5 hash: %(md5)s &bull; Typ mime: %(mimetype)s"
 
 #: src/olympia/files/templates/files/viewer.html:4
 msgid "File Compare :: Editor tools"
@@ -10767,48 +8559,39 @@ msgstr "Verze Add-on SDK:"
 msgid "Tab stops:"
 msgstr "Tabulátory:"
 
-#: src/olympia/files/templates/files/viewer.html:79
-#: src/olympia/files/templates/files/viewer.html:80
+#: src/olympia/files/templates/files/viewer.html:79 src/olympia/files/templates/files/viewer.html:80
 msgid "Up file"
 msgstr "O súbor vyššie"
 
-#: src/olympia/files/templates/files/viewer.html:84
-#: src/olympia/files/templates/files/viewer.html:85
+#: src/olympia/files/templates/files/viewer.html:84 src/olympia/files/templates/files/viewer.html:85
 msgid "Down file"
 msgstr "O súbor nižšie"
 
-#: src/olympia/files/templates/files/viewer.html:90
-#: src/olympia/files/templates/files/viewer.html:91
+#: src/olympia/files/templates/files/viewer.html:90 src/olympia/files/templates/files/viewer.html:91
 msgid "Previous diff"
 msgstr "Predchádzajúci rozdiel"
 
-#: src/olympia/files/templates/files/viewer.html:93
-#: src/olympia/files/templates/files/viewer.html:94
+#: src/olympia/files/templates/files/viewer.html:93 src/olympia/files/templates/files/viewer.html:94
 msgid "Previous note"
 msgstr "Predchádzajúca poznámka"
 
-#: src/olympia/files/templates/files/viewer.html:100
-#: src/olympia/files/templates/files/viewer.html:101
+#: src/olympia/files/templates/files/viewer.html:100 src/olympia/files/templates/files/viewer.html:101
 msgid "Next diff"
 msgstr "Ďalší rozdiel"
 
-#: src/olympia/files/templates/files/viewer.html:103
-#: src/olympia/files/templates/files/viewer.html:104
+#: src/olympia/files/templates/files/viewer.html:103 src/olympia/files/templates/files/viewer.html:104
 msgid "Next note"
 msgstr "Ďalšia poznámka"
 
-#: src/olympia/files/templates/files/viewer.html:109
-#: src/olympia/files/templates/files/viewer.html:110
+#: src/olympia/files/templates/files/viewer.html:109 src/olympia/files/templates/files/viewer.html:110
 msgid "Expand all"
 msgstr "Rozbaliť všetko"
 
-#: src/olympia/files/templates/files/viewer.html:114
-#: src/olympia/files/templates/files/viewer.html:115
+#: src/olympia/files/templates/files/viewer.html:114 src/olympia/files/templates/files/viewer.html:115
 msgid "Hide or unhide tree"
 msgstr "Zobraziť alebo skryť strom"
 
-#: src/olympia/files/templates/files/viewer.html:119
-#: src/olympia/files/templates/files/viewer.html:120
+#: src/olympia/files/templates/files/viewer.html:119 src/olympia/files/templates/files/viewer.html:120
 msgid "Wrap or unwrap text"
 msgstr "Prepnúť zalomenie textu"
 
@@ -10819,6 +8602,10 @@ msgstr "V odoslanom archíve sa nenachádzajú žiadne súbory."
 #: src/olympia/files/templates/files/viewer.html:134
 msgid "Fetching file."
 msgstr "Získava sa súbor..."
+
+#: src/olympia/legacy_api/views.py:255
+msgid "Not implemented yet."
+msgstr "Zatiaľ nie je implementované."
 
 #: src/olympia/lib/constants.py:6
 msgid "United Arab Emirates Dirham"
@@ -11476,12 +9263,7 @@ msgstr ""
 msgid "Zimbabwe Dollar"
 msgstr ""
 
-#: src/olympia/lib/video/ffmpeg.py:112 src/olympia/lib/video/totem.py:81
-msgid "Videos must be in WebM."
-msgstr ""
-
-#: src/olympia/pages/templates/pages/about.lhtml:3
-#: src/olympia/pages/templates/pages/about.lhtml:10
+#: src/olympia/pages/templates/pages/about.lhtml:3 src/olympia/pages/templates/pages/about.lhtml:10
 msgid "About Mozilla Add-ons"
 msgstr ""
 
@@ -11491,11 +9273,8 @@ msgstr ""
 
 #: src/olympia/pages/templates/pages/about.lhtml:13
 msgid ""
-"addons.mozilla.org, commonly known as \"AMO\", is Mozilla's official site "
-"for add-ons to Mozilla software, such as Firefox, Thunderbird, and "
-"SeaMonkey. Add-ons let you add new features and change the way your browser "
-"or application works.  Take a look around and explore the thousands of ways "
-"to customize the way you do things online."
+"addons.mozilla.org, commonly known as \"AMO\", is Mozilla's official site for add-ons to Mozilla software, such as Firefox, Thunderbird, and SeaMonkey. Add-ons let you add new features and change "
+"the way your browser or application works. Take a look around and explore the thousands of ways to customize the way you do things online."
 msgstr ""
 
 #: src/olympia/pages/templates/pages/about.lhtml:19
@@ -11504,11 +9283,8 @@ msgstr ""
 
 #: src/olympia/pages/templates/pages/about.lhtml:20
 msgid ""
-"The add-ons listed here have been created by thousands of developers from "
-"our community, ranging from individual hobbyists to large corporations. All "
-"publicly listed add-ons are reviewed by a team of editors before being "
-"released. Add-ons marked as Experimental have not been reviewed and should "
-"only be installed with caution."
+"The add-ons listed here have been created by thousands of developers from our community, ranging from individual hobbyists to large corporations. All publicly listed add-ons are reviewed by a team "
+"of editors before being released. Add-ons marked as Experimental have not been reviewed and should only be installed with caution."
 msgstr ""
 
 #: src/olympia/pages/templates/pages/about.lhtml:26
@@ -11516,30 +9292,22 @@ msgid "How do I keep up with what's happening at AMO?"
 msgstr ""
 
 #: src/olympia/pages/templates/pages/about.lhtml:27
-msgid ""
-"There are several ways to find out the latest news from the world of add-"
-"ons:"
+msgid "There are several ways to find out the latest news from the world of add-ons:"
 msgstr ""
 
 #: src/olympia/pages/templates/pages/about.lhtml:29
 #, python-format
-msgid ""
-"Our <a href=\"%(url)s\">Add-ons Blog</a> is regularly updated with "
-"information for both add-on enthusiasts and developers."
+msgid "Our <a href=\"%(url)s\">Add-ons Blog</a> is regularly updated with information for both add-on enthusiasts and developers."
 msgstr ""
 
 #: src/olympia/pages/templates/pages/about.lhtml:32
 #, python-format
-msgid ""
-"We often post news, tips, and tricks to our Twitter account, <a "
-"href=\"%(url)s\">mozamo</a>"
+msgid "We often post news, tips, and tricks to our Twitter account, <a href=\"%(url)s\">mozamo</a>"
 msgstr ""
 
 #: src/olympia/pages/templates/pages/about.lhtml:34
 #, python-format
-msgid ""
-"Our <a href=\"%(url)s\">forums</a> are a good place to interact with the "
-"add-ons community and discuss upcoming changes to AMO."
+msgid "Our <a href=\"%(url)s\">forums</a> are a good place to interact with the add-ons community and discuss upcoming changes to AMO."
 msgstr ""
 
 #: src/olympia/pages/templates/pages/about.lhtml:39
@@ -11547,37 +9315,26 @@ msgid "This sounds great! How can I get involved?"
 msgstr ""
 
 #: src/olympia/pages/templates/pages/about.lhtml:40
-msgid ""
-"There are plenty of ways to get involved. If you're on the technical side:"
+msgid "There are plenty of ways to get involved. If you're on the technical side:"
 msgstr ""
 
 #: src/olympia/pages/templates/pages/about.lhtml:42
 #, python-format
-msgid ""
-"<a href=\"%(url)s\">Make your own add-on</a>. We provide free hosting and "
-"update services and can help you reach a large audience of users."
+msgid "<a href=\"%(url)s\">Make your own add-on</a>. We provide free hosting and update services and can help you reach a large audience of users."
 msgstr ""
 
 #: src/olympia/pages/templates/pages/about.lhtml:45
 #, python-format
-msgid ""
-"If you have add-on development experience, <a href=\"%(url)s\"> become an "
-"editor</a>! Our editors are add-on fans with a technical background who "
-"review add-ons for code quality and stability."
+msgid "If you have add-on development experience, <a href=\"%(url)s\"> become an editor</a>! Our editors are add-on fans with a technical background who review add-ons for code quality and stability."
 msgstr ""
 
 #: src/olympia/pages/templates/pages/about.lhtml:49
 #, python-format
-msgid ""
-"Help improve this website. It's open source, and you can file bugs and "
-"submit patches. <a href=\"%(url)s\"> GitHub</a> contains all of our current "
-"bugs, legacy bugs can still be found in Bugzilla."
+msgid "Help improve this website. It's open source, and you can file bugs and submit patches. <a href=\"%(url)s\"> GitHub</a> contains all of our current bugs, legacy bugs can still be found in Bugzilla."
 msgstr ""
 
 #: src/olympia/pages/templates/pages/about.lhtml:55
-msgid ""
-"If you're interested in add-ons but not quite as technical, there are still "
-"ways to help:"
+msgid "If you're interested in add-ons but not quite as technical, there are still ways to help:"
 msgstr ""
 
 #: src/olympia/pages/templates/pages/about.lhtml:58
@@ -11590,9 +9347,7 @@ msgid "Participate in our <a href=\"%(url)s\">forums</a>."
 msgstr ""
 
 #: src/olympia/pages/templates/pages/about.lhtml:61
-msgid ""
-"Review add-ons on the site. Add-on authors are more likely to improve their "
-"add-ons and write new ones when they know people appreciate their work."
+msgid "Review add-ons on the site. Add-on authors are more likely to improve their add-ons and write new ones when they know people appreciate their work."
 msgstr ""
 
 #: src/olympia/pages/templates/pages/about.lhtml:66
@@ -11602,16 +9357,13 @@ msgstr "Mám otázku"
 #: src/olympia/pages/templates/pages/about.lhtml:67
 #, python-format
 msgid ""
-"A good place to start is our <a href=\"%(faq_url)s\"><abbr "
-"title=\"Frequently Asked Questions\">FAQ</abbr></a>. If you don't find an "
-"answer there, you can <a href=\"%(forum_url)s\"> ask on our forums</a>."
+"A good place to start is our <a href=\"%(faq_url)s\"><abbr title=\"Frequently Asked Questions\">FAQ</abbr></a>. If you don't find an answer there, you can <a href=\"%(forum_url)s\"> ask on our "
+"forums</a>."
 msgstr ""
 
 #: src/olympia/pages/templates/pages/about.lhtml:72
 #, python-format
-msgid ""
-"If you really need to contact someone from the Mozilla team, please see our "
-"<a href=\"%(url)s\"> contact information</a> page."
+msgid "If you really need to contact someone from the Mozilla team, please see our <a href=\"%(url)s\"> contact information</a> page."
 msgstr ""
 
 #: src/olympia/pages/templates/pages/about.lhtml:76
@@ -11621,10 +9373,8 @@ msgstr ""
 #: src/olympia/pages/templates/pages/about.lhtml:77
 #, python-format
 msgid ""
-"Over the years, many people have contributed to this website, including both"
-" volunteers from the community and a dedicated AMO team. A list of "
-"significant contributors can be found on our <a href=\"%(url)s\"> Site "
-"Credits</a> page."
+"Over the years, many people have contributed to this website, including both volunteers from the community and a dedicated AMO team. A list of significant contributors can be found on our <a "
+"href=\"%(url)s\"> Site Credits</a> page."
 msgstr ""
 
 # 93%
@@ -11640,65 +9390,45 @@ msgstr "Add-on Compatibility Reporter byl nainstalován"
 
 #: src/olympia/pages/templates/pages/acr_firstrun.html:28
 #, fuzzy
-msgid ""
-"It’s easy to help us make sure add-ons are updated in time for the release "
-"of the next version of Firefox."
-msgstr ""
-"Je snadné nám pomoci se ujistit, že jsou doplňky v době vydání další verze "
-"Firefoxu aktualizované."
+msgid "It’s easy to help us make sure add-ons are updated in time for the release of the next version of Firefox."
+msgstr "Je snadné nám pomoci se ujistit, že jsou doplňky v době vydání další verze Firefoxu aktualizované."
 
 #: src/olympia/pages/templates/pages/acr_firstrun.html:35
 #, fuzzy
 msgid "Here’s how to get started reporting add-on compatibility:"
-msgstr ""
-"Zde si můžete přečíst, jak se zapojit do nahlašování kompatibility doplňků:"
+msgstr "Zde si můžete přečíst, jak se zapojit do nahlašování kompatibility doplňků:"
 
 #: src/olympia/pages/templates/pages/acr_firstrun.html:40
 #, fuzzy
 msgid ""
-"As you start browsing and using your add-ons, take careful note of anything "
-"that seems different from when you last used the extension. This might be a "
-"display glitch, such as a menu item missing, or something more serious, like"
-" the add-on not working at all or showing errors."
+"As you start browsing and using your add-ons, take careful note of anything that seems different from when you last used the extension. This might be a display glitch, such as a menu item missing, "
+"or something more serious, like the add-on not working at all or showing errors."
 msgstr ""
-"Jakmile začnete prohlížet web a používat vaše doplňky, všímejte si všech "
-"věcí, které jsou odlišné od situace, kdy jste naposledy rozšíření používali."
-" Mohou to být problémy se zobrazováním, některé položky nebudou vidět či "
-"dokonce závažnější věci - doplněk nefunguje či neustále zobrazuje chyby."
+"Jakmile začnete prohlížet web a používat vaše doplňky, všímejte si všech věcí, které jsou odlišné od situace, kdy jste naposledy rozšíření používali. Mohou to být problémy se zobrazováním, některé "
+"položky nebudou vidět či dokonce závažnější věci - doplněk nefunguje či neustále zobrazuje chyby."
 
 #: src/olympia/pages/templates/pages/acr_firstrun.html:49
 #, fuzzy
 msgid ""
-"Once you know whether a particular add-on works properly or has problems, "
-"open the Add-ons Manager and click Compatibility next to the add-on to let "
-"Mozilla know what you found in your testing. Submitting a report will help "
-"us tell the add-on developer whether their add-on is working properly in "
-"this version or might need some fixes."
+"Once you know whether a particular add-on works properly or has problems, open the Add-ons Manager and click Compatibility next to the add-on to let Mozilla know what you found in your testing. "
+"Submitting a report will help us tell the add-on developer whether their add-on is working properly in this version or might need some fixes."
 msgstr ""
-"Jakmile budete vědět, zda konkrétní doplněk funguje korektně či má problémy,"
-" otevřete Správce doplňků a klepněte na tlačítko Kompatibilita, které je "
-"umístěno u doplňku a dejte Mozille vědět, co jste při testování našli. "
-"Odeslání reportu nám pomůže říci vývojářům doplňků, zda jejich doplněk "
-"nefunguje v této verzi aplikace korektně či potřebuje některé opravy."
+"Jakmile budete vědět, zda konkrétní doplněk funguje korektně či má problémy, otevřete Správce doplňků a klepněte na tlačítko Kompatibilita, které je umístěno u doplňku a dejte Mozille vědět, co "
+"jste při testování našli. Odeslání reportu nám pomůže říci vývojářům doplňků, zda jejich doplněk nefunguje v této verzi aplikace korektně či potřebuje některé opravy."
 
 #: src/olympia/pages/templates/pages/acr_firstrun.html:61
 #, fuzzy, python-format
 msgid ""
-"If you upgrade to a new version of Firefox or update your add-ons, your "
-"reports for the old versions will be hidden to allow you to test the new "
-"version. If you have any questions, please ask in <a href=\"%(url)s\">our "
-"forums</a>."
+"If you upgrade to a new version of Firefox or update your add-ons, your reports for the old versions will be hidden to allow you to test the new version. If you have any questions, please ask in <a"
+" href=\"%(url)s\">our forums</a>."
 msgstr ""
-"Jakmile aktualizujete na novou verzi Firefoxu či aktualizujete svůj doplněk,"
-" vaše reporty pro staré verze budou skryté a vy budete moci vyzkoušet novou "
-"verzi. Pokud máte jakékoliv otázky, zeptejte se v <a href=\"%(url)s\">našem "
-"fóru</a>."
+"Jakmile aktualizujete na novou verzi Firefoxu či aktualizujete svůj doplněk, vaše reporty pro staré verze budou skryté a vy budete moci vyzkoušet novou verzi. Pokud máte jakékoliv otázky, zeptejte "
+"se v <a href=\"%(url)s\">našem fóru</a>."
 
 #: src/olympia/pages/templates/pages/acr_firstrun.html:69
 msgid ""
-"Thousands of add-ons are made by our community every year, and your "
-"assistance with compatibility testing helps us make sure these add-ons stay "
-"useful as we strive to provide a great user experience."
+"Thousands of add-ons are made by our community every year, and your assistance with compatibility testing helps us make sure these add-ons stay useful as we strive to provide a great user "
+"experience."
 msgstr ""
 
 #: src/olympia/pages/templates/pages/acr_firstrun.html:75
@@ -11710,12 +9440,8 @@ msgid "Site Credits"
 msgstr "Tvorcovia stránky"
 
 #: src/olympia/pages/templates/pages/credits.html:12
-msgid ""
-"Mozilla would like to thank the following people for their contributions to "
-"the addons.mozilla.org project over the years:"
-msgstr ""
-"Mozilla ďakuje nasledujúcim ľuďom za ich prácu na projekte "
-"addons.mozilla.org za posledných niekoľko rokov:"
+msgid "Mozilla would like to thank the following people for their contributions to the addons.mozilla.org project over the years:"
+msgstr "Mozilla ďakuje nasledujúcim ľuďom za ich prácu na projekte addons.mozilla.org za posledných niekoľko rokov:"
 
 #: src/olympia/pages/templates/pages/credits.html:18
 msgid "Developers &amp; Administrators"
@@ -11748,51 +9474,32 @@ msgstr "Softvér a obrázky"
 
 #: src/olympia/pages/templates/pages/credits.html:59
 msgid ""
-"Some icons used are from the <a "
-"href=\"http://www.famfamfam.com/lab/icons/silk/\">famfamfam Silk Icon "
-"Set</a>, licensed under a <a "
-"href=\"http://creativecommons.org/licenses/by/2.5/\">Creative Commons "
-"Attribution 2.5 License</a>."
+"Some icons used are from the <a href=\"http://www.famfamfam.com/lab/icons/silk/\">famfamfam Silk Icon Set</a>, licensed under a <a href=\"http://creativecommons.org/licenses/by/2.5/\">Creative "
+"Commons Attribution 2.5 License</a>."
 msgstr ""
-"Niektoré použité ikony pochádzajú zo <a "
-"href=\"http://www.famfamfam.com/lab/icons/silk/\">sady ikon famfamfam "
-"Silk</a>, uvoľnené pod licenciou <a "
-"href=\"http://creativecommons.org/licenses/by/2.5/\">Creative Commons "
-"Attribution 2.5</a>."
+"Niektoré použité ikony pochádzajú zo <a href=\"http://www.famfamfam.com/lab/icons/silk/\">sady ikon famfamfam Silk</a>, uvoľnené pod licenciou <a "
+"href=\"http://creativecommons.org/licenses/by/2.5/\">Creative Commons Attribution 2.5</a>."
 
 #: src/olympia/pages/templates/pages/credits.html:60
 msgid ""
-"Some icons used are from the <a href=\"http://www.fatcow.com/free-"
-"icons/\">FatCow Farm-Fresh Web Icons Set</a>, licensed under a <a "
-"href=\"http://creativecommons.org/licenses/by/3.0/us/\">Creative Commons "
-"Attribution 3.0 License</a>."
+"Some icons used are from the <a href=\"http://www.fatcow.com/free-icons/\">FatCow Farm-Fresh Web Icons Set</a>, licensed under a <a href=\"http://creativecommons.org/licenses/by/3.0/us/\">Creative "
+"Commons Attribution 3.0 License</a>."
 msgstr ""
-"Niektoré použité ikony pochádzajú zo <a href=\"http://www.fatcow.com/free-"
-"icons/\">sady webových ikon FatCow Farm-Fresh</a>, uvoľnené pod licenciou <a"
-" href=\"http://creativecommons.org/licenses/by/3.0/us/\">Creative Commons "
-"Attribution 3.0 License</a>."
+"Niektoré použité ikony pochádzajú zo <a href=\"http://www.fatcow.com/free-icons/\">sady webových ikon FatCow Farm-Fresh</a>, uvoľnené pod licenciou <a "
+"href=\"http://creativecommons.org/licenses/by/3.0/us/\">Creative Commons Attribution 3.0 License</a>."
 
 #: src/olympia/pages/templates/pages/credits.html:61
 msgid ""
-"Some pages use elements of <a "
-"href=\"http://shop.highsoft.com/highcharts.html\">Highcharts</a> (non-"
-"commercial), licensed under a <a href=\"http://creativecommons.org/licenses"
-"/by-nc/3.0/\">Creative Commons Attribution-NonCommercial 3.0 License</a>."
+"Some pages use elements of <a href=\"http://shop.highsoft.com/highcharts.html\">Highcharts</a> (non-commercial), licensed under a <a href=\"http://creativecommons.org/licenses/by-nc/3.0/\">Creative"
+" Commons Attribution-NonCommercial 3.0 License</a>."
 msgstr ""
-"Niektoré stránky používajú prvky <a "
-"href=\"http://shop.highsoft.com/highcharts.html\">Highcharts</a> "
-"(nekomerčné), uvoľnené pod licenciou <a "
-"href=\"http://creativecommons.org/licenses/by-nc/3.0/\">Creative Commons "
-"Attribution-NonCommercial 3.0 License</a>."
+"Niektoré stránky používajú prvky <a href=\"http://shop.highsoft.com/highcharts.html\">Highcharts</a> (nekomerčné), uvoľnené pod licenciou <a href=\"http://creativecommons.org/licenses/by-"
+"nc/3.0/\">Creative Commons Attribution-NonCommercial 3.0 License</a>."
 
 #: src/olympia/pages/templates/pages/credits.html:65
 #, python-format
-msgid ""
-"For information on contributing, please see our <a href=\"%(url)s\">wiki "
-"page</a>."
-msgstr ""
-"Ďalšie informácie o prispievaní do projektu nájdete na našej <a "
-"href=\"%(url)s\">wiki stránke</a>."
+msgid "For information on contributing, please see our <a href=\"%(url)s\">wiki page</a>."
+msgstr "Ďalšie informácie o prispievaní do projektu nájdete na našej <a href=\"%(url)s\">wiki stránke</a>."
 
 # 76%
 #: src/olympia/pages/templates/pages/dev_faq.html:4
@@ -11800,43 +9507,36 @@ msgid "Developer FAQ"
 msgstr "Často kladené otázky pre vývojárov"
 
 # 75%
-#: src/olympia/pages/templates/pages/dev_faq.html:31
-#: src/olympia/pages/templates/pages/review_guide.html:33
+#: src/olympia/pages/templates/pages/dev_faq.html:31 src/olympia/pages/templates/pages/review_guide.html:33
 msgid "Sections"
 msgstr "Sekcie"
 
-#: src/olympia/pages/templates/pages/dev_faq.html:33
-#: src/olympia/pages/templates/pages/dev_faq.html:45
+#: src/olympia/pages/templates/pages/dev_faq.html:33 src/olympia/pages/templates/pages/dev_faq.html:45
 msgid "Developing an Add-on"
 msgstr "Vývoj doplnkov"
 
 #. Heading for a list of resources for developers
-#: src/olympia/pages/templates/pages/dev_faq.html:34
-#: src/olympia/pages/templates/pages/dev_faq.html:208
+#: src/olympia/pages/templates/pages/dev_faq.html:34 src/olympia/pages/templates/pages/dev_faq.html:208
 msgid "Support Resources"
 msgstr "Kde hľadať podporu"
 
-#: src/olympia/pages/templates/pages/dev_faq.html:35
-#: src/olympia/pages/templates/pages/dev_faq.html:261
+#: src/olympia/pages/templates/pages/dev_faq.html:35 src/olympia/pages/templates/pages/dev_faq.html:261
 #, fuzzy
 msgid "Contributing your Add-on"
 msgstr "Přispívání svým doplňkem"
 
-#: src/olympia/pages/templates/pages/dev_faq.html:36
-#: src/olympia/pages/templates/pages/dev_faq.html:381
+#: src/olympia/pages/templates/pages/dev_faq.html:36 src/olympia/pages/templates/pages/dev_faq.html:381
 #, fuzzy
 msgid "Add-on Review Process"
 msgstr "Proces schvalování doplňku"
 
 # 82%
-#: src/olympia/pages/templates/pages/dev_faq.html:37
-#: src/olympia/pages/templates/pages/dev_faq.html:444
+#: src/olympia/pages/templates/pages/dev_faq.html:37 src/olympia/pages/templates/pages/dev_faq.html:444
 #, fuzzy
 msgid "Managing Your Add-on"
 msgstr "Správa svého doplňku"
 
-#: src/olympia/pages/templates/pages/dev_faq.html:39
-#: src/olympia/pages/templates/pages/dev_faq.html:528
+#: src/olympia/pages/templates/pages/dev_faq.html:39 src/olympia/pages/templates/pages/dev_faq.html:528
 #, fuzzy
 msgid "References for Open Source Licenses"
 msgstr "Odkazy na open source licence"
@@ -11849,10 +9549,7 @@ msgstr "Často kladené otázky pre vývojárov doplnkov"
 
 #: src/olympia/pages/templates/pages/dev_faq.html:47
 #, python-format
-msgid ""
-"<h3>How do I build an Add-on?</h3> <p> Mozilla provides documentation on how"
-" to build an add-on via the <a href=\"%(url)s\">Mozilla Developer "
-"Network</a>. </p>"
+msgid "<h3>How do I build an Add-on?</h3> <p> Mozilla provides documentation on how to build an add-on via the <a href=\"%(url)s\">Mozilla Developer Network</a>. </p>"
 msgstr ""
 
 #: src/olympia/pages/templates/pages/dev_faq.html:55
@@ -11875,13 +9572,9 @@ msgstr "Jaké nástroje pro vytvoření doplňku potřebuji?"
 #: src/olympia/pages/templates/pages/dev_faq.html:68
 #, fuzzy
 msgid ""
-"You will need to have a version of the Mozilla software that you're building"
-" the add-on for and a code editor of your choice. Add-ons can be built for "
-"almost all Mozilla software but are primarily targeted for:"
-msgstr ""
-"Budete potřebovat verzi aplikace Mozilla, pro kterou doplňek vytváříte a "
-"editor kódu dle vaší volby. Doplňky mohou být vytvořeny téměř pro každý "
-"software Mozilla, ale primárně jsou cíleny na:"
+"You will need to have a version of the Mozilla software that you're building the add-on for and a code editor of your choice. Add-ons can be built for almost all Mozilla software but are primarily "
+"targeted for:"
+msgstr "Budete potřebovat verzi aplikace Mozilla, pro kterou doplňek vytváříte a editor kódu dle vaší volby. Doplňky mohou být vytvořeny téměř pro každý software Mozilla, ale primárně jsou cíleny na:"
 
 #: src/olympia/pages/templates/pages/dev_faq.html:82
 msgid "Popular code editors include:"
@@ -11890,18 +9583,13 @@ msgstr "Medzi populárne editori kódu sa radia hlavne:"
 #. This is a list of popular code editors.  Feel free to adjust as you like.
 #: src/olympia/pages/templates/pages/dev_faq.html:85
 msgid ""
-"<li><a href=\"http://komodoide.com/komodo-edit/\">Komodo Edit</a></li> "
-"<li><a href=\"http://macromates.com/\">TextMate</a></li> <li><a href=\"http"
-"://notepad-plus-plus.org/\">Notepad++</a></li> <li><a "
-"href=\"http://www.eclipse.org/\">Eclipse IDE</a></li>"
+"<li><a href=\"http://komodoide.com/komodo-edit/\">Komodo Edit</a></li> <li><a href=\"http://macromates.com/\">TextMate</a></li> <li><a href=\"http://notepad-plus-plus.org/\">Notepad++</a></li> "
+"<li><a href=\"http://www.eclipse.org/\">Eclipse IDE</a></li>"
 msgstr ""
 
 #: src/olympia/pages/templates/pages/dev_faq.html:94
 #, python-format
-msgid ""
-"You can also learn more about setting up your development environment via "
-"the MDN article <a href=\"%(url)s\">Setting up extension development "
-"environment</a>"
+msgid "You can also learn more about setting up your development environment via the MDN article <a href=\"%(url)s\">Setting up extension development environment</a>"
 msgstr ""
 
 #: src/olympia/pages/templates/pages/dev_faq.html:100
@@ -11909,9 +9597,7 @@ msgid "What is a \".xpi\" file?"
 msgstr "Čo je súbor s koncovkou \".xpi\"?"
 
 #: src/olympia/pages/templates/pages/dev_faq.html:102
-msgid ""
-"Extensions are packaged and distributed in ZIP files or Bundles, with the "
-"XPI (pronounced \"zippy\") file extension."
+msgid "Extensions are packaged and distributed in ZIP files or Bundles, with the XPI (pronounced \"zippy\") file extension."
 msgstr ""
 
 #: src/olympia/pages/templates/pages/dev_faq.html:108
@@ -11920,10 +9606,8 @@ msgstr "Co je XUL?"
 
 #: src/olympia/pages/templates/pages/dev_faq.html:110
 msgid ""
-"XUL (XML User Interface Language) is Mozilla's XML-based language that lets "
-"you build feature-rich cross platform applications. It provides user "
-"interface widgets like buttons, menus, toolbars, trees, etc that can be used"
-" to enhance add-ons by modifying parts of the browser UI."
+"XUL (XML User Interface Language) is Mozilla's XML-based language that lets you build feature-rich cross platform applications. It provides user interface widgets like buttons, menus, toolbars, "
+"trees, etc that can be used to enhance add-ons by modifying parts of the browser UI."
 msgstr ""
 
 #: src/olympia/pages/templates/pages/dev_faq.html:119
@@ -11933,20 +9617,13 @@ msgstr "Na čo sa používa súbor \"install.rdf\"?"
 #: src/olympia/pages/templates/pages/dev_faq.html:121
 #, fuzzy, python-format
 msgid ""
-"This file, called an <a href=\"%(url)s\">Install Manifest</a>, is used by "
-"Add-on Manager-enabled XUL applications to determine information about an "
-"add-on as it is being installed. It contains metadata identifying the add-"
-"on, providing information about who created it, where more information can "
-"be found about it, which versions of what applications it is compatible "
-"with, how it should be updated, and so on. The format of the Install "
-"Manifest is RDF/XML."
+"This file, called an <a href=\"%(url)s\">Install Manifest</a>, is used by Add-on Manager-enabled XUL applications to determine information about an add-on as it is being installed. It contains "
+"metadata identifying the add-on, providing information about who created it, where more information can be found about it, which versions of what applications it is compatible with, how it should "
+"be updated, and so on. The format of the Install Manifest is RDF/XML."
 msgstr ""
-"Tento soubor, který je nazýván <a href=\"%(url)s\">instalační manifest</a>, "
-"je používán Správcem doplňků v aplikacích postavených na XUL k rozpoznání "
-"informací o doplňcích, které jsou nainstalovány. Obsahuje metadata "
-"identifikující doplněk, poskytuje informace o autorovi doplňku, více "
-"informací o doplňku jako je verze aplikací, s kterými je kompatibilní, jak "
-"by měl být aktualizován apod. Formát instalačního manifestu je RDF/XML."
+"Tento soubor, který je nazýván <a href=\"%(url)s\">instalační manifest</a>, je používán Správcem doplňků v aplikacích postavených na XUL k rozpoznání informací o doplňcích, které jsou "
+"nainstalovány. Obsahuje metadata identifikující doplněk, poskytuje informace o autorovi doplňku, více informací o doplňku jako je verze aplikací, s kterými je kompatibilní, jak by měl být "
+"aktualizován apod. Formát instalačního manifestu je RDF/XML."
 
 #: src/olympia/pages/templates/pages/dev_faq.html:132
 msgid "What does \"maxVersion\" mean?"
@@ -11954,14 +9631,8 @@ msgstr ""
 
 #: src/olympia/pages/templates/pages/dev_faq.html:134
 #, fuzzy
-msgid ""
-"This determines the maximum version of Firefox you're saying this extension "
-"will work with. Set this to be no newer than the newest currently available "
-"version!"
-msgstr ""
-"Slouží k rozpoznání maximální verze Firefoxu, se kterou je rozšíření "
-"kompatibilní. Nenastavujte tuto hodnotu na vyšší číslo než je aktuálně "
-"dostupná verze aplikace!"
+msgid "This determines the maximum version of Firefox you're saying this extension will work with. Set this to be no newer than the newest currently available version!"
+msgstr "Slouží k rozpoznání maximální verze Firefoxu, se kterou je rozšíření kompatibilní. Nenastavujte tuto hodnotu na vyšší číslo než je aktuálně dostupná verze aplikace!"
 
 #: src/olympia/pages/templates/pages/dev_faq.html:141
 #, fuzzy
@@ -11970,31 +9641,20 @@ msgstr "Může můj doplněk obsahovat binární komponenty?"
 
 #: src/olympia/pages/templates/pages/dev_faq.html:143
 #, fuzzy, python-format
-msgid ""
-"Yes. You can use Mozilla's <a href=\"%(url)s\">XPCOM component object "
-"model</a> to enhance your add-ons. XPCOM components be used and implemented "
-"in JavaScript, Java, and Python in addition to C++."
+msgid "Yes. You can use Mozilla's <a href=\"%(url)s\">XPCOM component object model</a> to enhance your add-ons. XPCOM components be used and implemented in JavaScript, Java, and Python in addition to C++."
 msgstr ""
-"Ano. Můžete použít <a href=\"%(url)s\">objektový komponentový model "
-"XPCOMl</a> od Mozilly a vylepšit tak své doplňky. Komponenty XPCOM jsou "
-"používány a implementovány v JavaScriptu, Javě, Pythonu či C++."
+"Ano. Můžete použít <a href=\"%(url)s\">objektový komponentový model XPCOMl</a> od Mozilly a vylepšit tak své doplňky. Komponenty XPCOM jsou používány a implementovány v JavaScriptu, Javě, Pythonu "
+"či C++."
 
 #: src/olympia/pages/templates/pages/dev_faq.html:150
-msgid ""
-"Can I use a JavaScript library like jQuery, MooTools or Prototype to build "
-"my add-on?"
+msgid "Can I use a JavaScript library like jQuery, MooTools or Prototype to build my add-on?"
 msgstr ""
 
 #: src/olympia/pages/templates/pages/dev_faq.html:152
 msgid ""
-"Yes. It's possible, but some of the functionality provided by these "
-"libraries are available through XPCOM, XUL, and JavaScript. In addition, "
-"authors should take care if libraries modify primitive object prototypes "
-"(String.prototype, Date.prototype, etc.) and/or define global functions (eg."
-" the $ function). These are prone to cause conflict with other add-ons, in "
-"particular if different add-ons use different versions of libraries and so "
-"on. Developers need to be very, very careful with using them.  Mozilla does "
-"not offer documentation on using them to build add-ons."
+"Yes. It's possible, but some of the functionality provided by these libraries are available through XPCOM, XUL, and JavaScript. In addition, authors should take care if libraries modify primitive "
+"object prototypes (String.prototype, Date.prototype, etc.) and/or define global functions (eg. the $ function). These are prone to cause conflict with other add-ons, in particular if different add-"
+"ons use different versions of libraries and so on. Developers need to be very, very careful with using them. Mozilla does not offer documentation on using them to build add-ons."
 msgstr ""
 
 #: src/olympia/pages/templates/pages/dev_faq.html:165
@@ -12008,21 +9668,14 @@ msgstr ""
 
 #: src/olympia/pages/templates/pages/dev_faq.html:172
 #, fuzzy
-msgid ""
-"How do I test for compatibility with the latest version of Mozilla software?"
-msgstr ""
-"Jak mohu otestovat kompatibilitu s poslední verzí software od Mozilly?"
+msgid "How do I test for compatibility with the latest version of Mozilla software?"
+msgstr "Jak mohu otestovat kompatibilitu s poslední verzí software od Mozilly?"
 
 #: src/olympia/pages/templates/pages/dev_faq.html:174
 msgid ""
-"To ensure compatibility with the latest Mozilla software, it's important to "
-"download updates as they become available and test your add-on to ensure "
-"that it is still functioning as expected. In many cases, the latest version "
-"of Mozilla software may be a beta release. Since these releases at times "
-"introduce architectural changes that may impact the functionality of your "
-"add-on, it's important to be actively involved in the beta process to ensure"
-" that your add-on users are not negatively impacted upon final release of "
-"Mozilla software."
+"To ensure compatibility with the latest Mozilla software, it's important to download updates as they become available and test your add-on to ensure that it is still functioning as expected. In "
+"many cases, the latest version of Mozilla software may be a beta release. Since these releases at times introduce architectural changes that may impact the functionality of your add-on, it's "
+"important to be actively involved in the beta process to ensure that your add-on users are not negatively impacted upon final release of Mozilla software."
 msgstr ""
 
 #: src/olympia/pages/templates/pages/dev_faq.html:185
@@ -12032,11 +9685,8 @@ msgstr ""
 #: src/olympia/pages/templates/pages/dev_faq.html:187
 #, python-format
 msgid ""
-"Poorly written extensions can have a severe impact on the browsing "
-"experience, including on the overall performance of Firefox itself. The "
-"following page contains many good <a href=\"%(url)s\">guides</a> that help "
-"you improve performance, whether you're developing core Mozilla code or an "
-"add-on."
+"Poorly written extensions can have a severe impact on the browsing experience, including on the overall performance of Firefox itself. The following page contains many good <a "
+"href=\"%(url)s\">guides</a> that help you improve performance, whether you're developing core Mozilla code or an add-on."
 msgstr ""
 
 #: src/olympia/pages/templates/pages/dev_faq.html:195
@@ -12047,10 +9697,8 @@ msgstr "Mohou mé doplňky podporovat více jazyků?"
 #: src/olympia/pages/templates/pages/dev_faq.html:197
 #, python-format
 msgid ""
-"Yes. Details on localizing your add-on can be found in the the <a "
-"href=\"%(l10n_url)s\">Mozilla Developer Network Localization page</a>. <a "
-"href=\"%(bz_url)s\">The BabelZilla project</a> is also a great resource for "
-"learning about localization and volunteering to help translate add-ons."
+"Yes. Details on localizing your add-on can be found in the the <a href=\"%(l10n_url)s\">Mozilla Developer Network Localization page</a>. <a href=\"%(bz_url)s\">The BabelZilla project</a> is also a "
+"great resource for learning about localization and volunteering to help translate add-ons."
 msgstr ""
 
 #: src/olympia/pages/templates/pages/dev_faq.html:210
@@ -12072,9 +9720,7 @@ msgstr "#amo (pro podporu související s hostováním doplňků na AMO)"
 
 #. #jetpack is the name of the IRC channel.  do not change.
 #: src/olympia/pages/templates/pages/dev_faq.html:220
-msgid ""
-"#jetpack (for discussions about the Add-ons SDK and cfx/jpm - formerly known"
-" as Jetpack)"
+msgid "#jetpack (for discussions about the Add-ons SDK and cfx/jpm - formerly known as Jetpack)"
 msgstr ""
 
 #. Label for a link to the extension developers mailing list
@@ -12114,18 +9760,13 @@ msgstr "Nie."
 #: src/olympia/pages/templates/pages/dev_faq.html:246
 #, fuzzy
 msgid "Are there 3rd party developers that I can hire to build my add-on?"
-msgstr ""
-"Jsou nějací vývojáři třetích stran, které mohu zaměstnat pro vývoj mého "
-"doplňku?"
+msgstr "Jsou nějací vývojáři třetích stran, které mohu zaměstnat pro vývoj mého doplňku?"
 
 #: src/olympia/pages/templates/pages/dev_faq.html:248
 #, python-format
 msgid ""
-"Yes. You may find 3rd party developers via the <a href=\"%(forum_url)s"
-"\">Add-ons forum</a>, <a href=\"%(list_url)s\">mozilla.jobs list</a>, <a "
-"href=\"%(mz_url)s\">mozillaZine forums</a> or <a href=\"%(wiki_url)s\">the "
-"Mozilla Wiki</a>. Please note that Mozilla does not offer developer "
-"recommendations."
+"Yes. You may find 3rd party developers via the <a href=\"%(forum_url)s\">Add-ons forum</a>, <a href=\"%(list_url)s\">mozilla.jobs list</a>, <a href=\"%(mz_url)s\">mozillaZine forums</a> or <a "
+"href=\"%(wiki_url)s\">the Mozilla Wiki</a>. Please note that Mozilla does not offer developer recommendations."
 msgstr ""
 
 #: src/olympia/pages/templates/pages/dev_faq.html:263
@@ -12136,13 +9777,9 @@ msgstr "Mohu zde hostovat svůj doplněk?"
 #: src/olympia/pages/templates/pages/dev_faq.html:265
 #, python-format
 msgid ""
-"Yes. Many developers choose to host their own add-ons. Choosing to host your"
-" add-on on <a href=\"%(amo_url)s\">Mozilla's add-on site</a>, though, allows"
-" for much greater exposure to your add-on due to the large volume of "
-"visitors to the site.  <a href=\"%(md_url)s\">mozdev.org</a> offers free "
-"project hosting for Mozilla applications and extensions providing developers"
-" with tools to help manage source code, version control, bug tracking and "
-"documentation."
+"Yes. Many developers choose to host their own add-ons. Choosing to host your add-on on <a href=\"%(amo_url)s\">Mozilla's add-on site</a>, though, allows for much greater exposure to your add-on due"
+" to the large volume of visitors to the site. <a href=\"%(md_url)s\">mozdev.org</a> offers free project hosting for Mozilla applications and extensions providing developers with tools to help "
+"manage source code, version control, bug tracking and documentation."
 msgstr ""
 
 #: src/olympia/pages/templates/pages/dev_faq.html:277
@@ -12152,12 +9789,8 @@ msgstr "Může Mozilla hostovat můj doplněk?"
 
 #: src/olympia/pages/templates/pages/dev_faq.html:279
 #, fuzzy, python-format
-msgid ""
-"Yes. You can host your add-on on <a href=\"%(url)s\">Mozilla's add-on "
-"website</a>."
-msgstr ""
-"Ano. Můžete hostovat svuj doplněk na webu <a href=\"%(url)s\">Doplňky "
-"Mozilly</a>."
+msgid "Yes. You can host your add-on on <a href=\"%(url)s\">Mozilla's add-on website</a>."
+msgstr "Ano. Můžete hostovat svuj doplněk na webu <a href=\"%(url)s\">Doplňky Mozilly</a>."
 
 #: src/olympia/pages/templates/pages/dev_faq.html:284
 msgid "What is AMO?"
@@ -12166,18 +9799,11 @@ msgstr "Čo je AMO?"
 #: src/olympia/pages/templates/pages/dev_faq.html:286
 #, fuzzy
 msgid ""
-"Mozilla's AMO (<a "
-"href=\"https://addons.mozilla.org\">https://addons.mozilla.org</a>) is the "
-"incubator that helps developers build, distribute, and support fantastic "
-"consumer products powered by Mozilla. It provides you the tools and "
-"infrastructure necessary to manage, host and expose your add-on to a massive"
-" base of Mozilla users."
+"Mozilla's AMO (<a href=\"https://addons.mozilla.org\">https://addons.mozilla.org</a>) is the incubator that helps developers build, distribute, and support fantastic consumer products powered by "
+"Mozilla. It provides you the tools and infrastructure necessary to manage, host and expose your add-on to a massive base of Mozilla users."
 msgstr ""
-"AMO (<a href=\"https://addons.mozilla.org\">https://addons.mozilla.org</a>) "
-"je inkubátor, který pomáhá vývojářům vytvářet, distribuovat a podporovat "
-"fantastické produkty založené na Mozille. Poskytuje jim nástroje a "
-"infrastrukturu nutnou pro správu, hostování a vystavování doplňků velkému "
-"množství uživatelů produktů Mozilla."
+"AMO (<a href=\"https://addons.mozilla.org\">https://addons.mozilla.org</a>) je inkubátor, který pomáhá vývojářům vytvářet, distribuovat a podporovat fantastické produkty založené na Mozille. "
+"Poskytuje jim nástroje a infrastrukturu nutnou pro správu, hostování a vystavování doplňků velkému množství uživatelů produktů Mozilla."
 
 #: src/olympia/pages/templates/pages/dev_faq.html:295
 #, fuzzy
@@ -12186,12 +9812,8 @@ msgstr "Bere Mozilla informace o mém účtu jako soukromé?"
 
 #: src/olympia/pages/templates/pages/dev_faq.html:297
 #, fuzzy, python-format
-msgid ""
-"Yes. Our <a href=\"%(url)s\">Privacy Policy</a> describes how your "
-"information is managed by Mozilla."
-msgstr ""
-"Ano. Naše <a href=\"%(url)s\">zásady na ochranu soukromí</a> popisují, jak "
-"jsou vaše informace Mozillou spravovány."
+msgid "Yes. Our <a href=\"%(url)s\">Privacy Policy</a> describes how your information is managed by Mozilla."
+msgstr "Ano. Naše <a href=\"%(url)s\">zásady na ochranu soukromí</a> popisují, jak jsou vaše informace Mozillou spravovány."
 
 #: src/olympia/pages/templates/pages/dev_faq.html:302
 #, fuzzy
@@ -12201,31 +9823,22 @@ msgstr "Co jsou \"nástroje pro vývojáře\" uvedené na AMO?"
 #: src/olympia/pages/templates/pages/dev_faq.html:304
 #, fuzzy
 msgid ""
-"The \"Developer Tools\" dashboard is the area that provides you the tools to"
-" successfully manage your add-ons. It provides the functionality necessary "
-"to submit your add-ons to AMO, manage add-on information, and review "
-"statistics."
+"The \"Developer Tools\" dashboard is the area that provides you the tools to successfully manage your add-ons. It provides the functionality necessary to submit your add-ons to AMO, manage add-on "
+"information, and review statistics."
 msgstr ""
-" \"Nástroje pro vývojáře\" je místo na webu, které vám poskytuje nástroje na"
-" správu vašich doplňků. Poskytuje funkcionalitu nutnou pro odeslání vašich "
-"doplňků na AMO, správu informací o nich a statistiky o recenzích."
+" \"Nástroje pro vývojáře\" je místo na webu, které vám poskytuje nástroje na správu vašich doplňků. Poskytuje funkcionalitu nutnou pro odeslání vašich doplňků na AMO, správu informací o nich a "
+"statistiky o recenzích."
 
 #: src/olympia/pages/templates/pages/dev_faq.html:312
 #, fuzzy
-msgid ""
-"Does Mozilla have a policy in place as to what is an acceptable submission?"
-msgstr ""
-"Má Mozilla někde uvedeny zásady, které musí splňovat doplněk, aby mohl být "
-"schválen?"
+msgid "Does Mozilla have a policy in place as to what is an acceptable submission?"
+msgstr "Má Mozilla někde uvedeny zásady, které musí splňovat doplněk, aby mohl být schválen?"
 
 #: src/olympia/pages/templates/pages/dev_faq.html:314
 #, python-format
 msgid ""
-"Yes. Mozilla's <a href=\"%(p_url)s\">Add-on Policy</a> describes what is an "
-"acceptable submission. This policy is subject to change without notice.  In "
-"addition, the AMO editorial team uses the <a href=\"%(g_url)s\">Editors "
-"Reviewing Guide</a> to ensure that your add-on meets specific guidelines for"
-" functionality and security."
+"Yes. Mozilla's <a href=\"%(p_url)s\">Add-on Policy</a> describes what is an acceptable submission. This policy is subject to change without notice. In addition, the AMO editorial team uses the <a "
+"href=\"%(g_url)s\">Editors Reviewing Guide</a> to ensure that your add-on meets specific guidelines for functionality and security."
 msgstr ""
 
 #: src/olympia/pages/templates/pages/dev_faq.html:324
@@ -12236,11 +9849,8 @@ msgstr "Jak odešlu můj doplněk na kontrolu?"
 #: src/olympia/pages/templates/pages/dev_faq.html:326
 #, python-format
 msgid ""
-"The Developer Tools dashboard will allow you to upload and submit add-ons to"
-" AMO. You must be a registered AMO users before you can submit an add-on. "
-"Before submitting your add-on be sure to you have read the AMO <a "
-"href=\"%(url)s\">Editors Reviewing Guide</a> to ensure that your add-on has "
-"met the guidelines used by editors to review add-ons."
+"The Developer Tools dashboard will allow you to upload and submit add-ons to AMO. You must be a registered AMO users before you can submit an add-on. Before submitting your add-on be sure to you "
+"have read the AMO <a href=\"%(url)s\">Editors Reviewing Guide</a> to ensure that your add-on has met the guidelines used by editors to review add-ons."
 msgstr ""
 
 #: src/olympia/pages/templates/pages/dev_faq.html:336
@@ -12250,12 +9860,8 @@ msgstr "Jaký operační systém mám pro můj doplněk zvolit?"
 
 #: src/olympia/pages/templates/pages/dev_faq.html:338
 #, fuzzy
-msgid ""
-"You must choose the operating systems on which your add-on will successfully"
-" function."
-msgstr ""
-"Musíte zvolit operační systémy, pod kterými bude váš doplněk úspěšně "
-"fungovat."
+msgid "You must choose the operating systems on which your add-on will successfully function."
+msgstr "Musíte zvolit operační systémy, pod kterými bude váš doplněk úspěšně fungovat."
 
 #: src/olympia/pages/templates/pages/dev_faq.html:344
 #, fuzzy
@@ -12264,11 +9870,8 @@ msgstr "Jakou kategorii mam pro svůj doplněk zvolit?"
 
 #: src/olympia/pages/templates/pages/dev_faq.html:346
 msgid ""
-"The choice of category is dependent on what type of audience you are "
-"targeting and the functionality of your add-on. If you're unsure of which "
-"category your add-on falls into, please choose \"Other\". The AMO team may "
-"re-categorize your add-on if it's determined that it's better suited in a "
-"different category."
+"The choice of category is dependent on what type of audience you are targeting and the functionality of your add-on. If you're unsure of which category your add-on falls into, please choose "
+"\"Other\". The AMO team may re-categorize your add-on if it's determined that it's better suited in a different category."
 msgstr ""
 
 #: src/olympia/pages/templates/pages/dev_faq.html:355
@@ -12277,12 +9880,8 @@ msgstr ""
 
 #: src/olympia/pages/templates/pages/dev_faq.html:357
 #, fuzzy
-msgid ""
-"Nominated add-ons are new add-ons that the author has nominated to become "
-"public via the Developer Tools."
-msgstr ""
-"Nominované doplňky jsou nové doplňky, které autor skrze nástroje pro "
-"vývojáře nominuje, aby se staly v rámci webu veřejnými."
+msgid "Nominated add-ons are new add-ons that the author has nominated to become public via the Developer Tools."
+msgstr "Nominované doplňky jsou nové doplňky, které autor skrze nástroje pro vývojáře nominuje, aby se staly v rámci webu veřejnými."
 
 #: src/olympia/pages/templates/pages/dev_faq.html:363
 #, fuzzy
@@ -12291,14 +9890,8 @@ msgstr "Mohu si pro svůj doplněk určit licenční ujednání?"
 
 #: src/olympia/pages/templates/pages/dev_faq.html:365
 #, fuzzy
-msgid ""
-"Yes. You can specify a license agreement when submitting your add-on. You "
-"can also add or update a license agreement via the Developer Tools dashboard"
-" after your add-on has been submitted."
-msgstr ""
-"Ano. Své vlastní licenční ujednání můžete určit při přidávání doplňku. Po "
-"přidání doplňků jej můžete kdykoliv přidat či aktualizovat na nástěnce "
-"nástrojů pro vývojáře."
+msgid "Yes. You can specify a license agreement when submitting your add-on. You can also add or update a license agreement via the Developer Tools dashboard after your add-on has been submitted."
+msgstr "Ano. Své vlastní licenční ujednání můžete určit při přidávání doplňku. Po přidání doplňků jej můžete kdykoliv přidat či aktualizovat na nástěnce nástrojů pro vývojáře."
 
 #: src/olympia/pages/templates/pages/dev_faq.html:372
 #, fuzzy
@@ -12307,14 +9900,8 @@ msgstr "Mohu u svého doplňku uvést zásady ochrany soukromí?"
 
 #: src/olympia/pages/templates/pages/dev_faq.html:374
 #, fuzzy
-msgid ""
-"Yes. You can specify a privacy policy when submitting your add-on. You can "
-"also add or update a privacy policy via the Developer Tools dashboard after "
-"your add-on has been submitted."
-msgstr ""
-"Ano. Přidejte svou verzi zásad ochrany soukromí při přidávání svého doplňku."
-" Můžete je též po přidání doplňku kdykoliv upravit v nástrojích pro "
-"vývojáře."
+msgid "Yes. You can specify a privacy policy when submitting your add-on. You can also add or update a privacy policy via the Developer Tools dashboard after your add-on has been submitted."
+msgstr "Ano. Přidejte svou verzi zásad ochrany soukromí při přidávání svého doplňku. Můžete je též po přidání doplňku kdykoliv upravit v nástrojích pro vývojáře."
 
 #: src/olympia/pages/templates/pages/dev_faq.html:383
 #, fuzzy
@@ -12324,15 +9911,11 @@ msgstr "Proč musí být můj doplněk zkontrolován?"
 #: src/olympia/pages/templates/pages/dev_faq.html:385
 #, fuzzy, python-format
 msgid ""
-"All add-ons submitted, whether new or updated, are reviewed to ensure that "
-"Mozilla users have a stable and safe experience. All add-ons submissions are"
-" reviewed using the guidelines outlined in the <a href=\"%(url)s\">Editors "
-"Reviewing Guide</a>."
+"All add-ons submitted, whether new or updated, are reviewed to ensure that Mozilla users have a stable and safe experience. All add-ons submissions are reviewed using the guidelines outlined in the"
+" <a href=\"%(url)s\">Editors Reviewing Guide</a>."
 msgstr ""
-"Všechny přidané doplňky, jedno zda nové či jen aktualizované, musí být "
-"zkontrolovány, aby se Mozilla ujistila, že jsou pro uživatele stabilní a "
-"bezpečné. Všechny přidané doplňky jsou zkontrolované proti dokumentu <a "
-"href=\"%(url)s\">Editors Reviewing Guide</a>."
+"Všechny přidané doplňky, jedno zda nové či jen aktualizované, musí být zkontrolovány, aby se Mozilla ujistila, že jsou pro uživatele stabilní a bezpečné. Všechny přidané doplňky jsou zkontrolované "
+"proti dokumentu <a href=\"%(url)s\">Editors Reviewing Guide</a>."
 
 #: src/olympia/pages/templates/pages/dev_faq.html:393
 #, fuzzy
@@ -12342,12 +9925,9 @@ msgstr "Kdo kontroluje můj doplněk?"
 #: src/olympia/pages/templates/pages/dev_faq.html:395
 #, python-format
 msgid ""
-"Add-ons are reviewed by the AMO Editors, a group of talented developers that"
-" volunteer to help the Mozilla project by reviewing add-ons to ensure a "
-"stable and safe experience for Mozilla users. When communicating with "
-"editors, please be courteous, patient and respectful as they are working "
-"hard to ensure that your add-on is set up correctly and follows the "
-"guidelines outlined in the <a href=\"%(url)s\">Editors Reviewing Guide</a>."
+"Add-ons are reviewed by the AMO Editors, a group of talented developers that volunteer to help the Mozilla project by reviewing add-ons to ensure a stable and safe experience for Mozilla users. "
+"When communicating with editors, please be courteous, patient and respectful as they are working hard to ensure that your add-on is set up correctly and follows the guidelines outlined in the <a "
+"href=\"%(url)s\">Editors Reviewing Guide</a>."
 msgstr ""
 
 #: src/olympia/pages/templates/pages/dev_faq.html:406
@@ -12358,11 +9938,8 @@ msgstr "Jaké body jsou kontrolovány u doplňku?"
 #: src/olympia/pages/templates/pages/dev_faq.html:408
 #, python-format
 msgid ""
-"The Mozilla editorial team follows the <a href=\"%(url)s\">Editors Reviewing"
-" Guide</a> when testing an add-on for acceptance onto AMO. It is important "
-"that add-on developers review this guide to ensure that common problem areas"
-" are addressed prior to submitting their add-on for review. This will "
-"greatly assist in expediting the review process."
+"The Mozilla editorial team follows the <a href=\"%(url)s\">Editors Reviewing Guide</a> when testing an add-on for acceptance onto AMO. It is important that add-on developers review this guide to "
+"ensure that common problem areas are addressed prior to submitting their add-on for review. This will greatly assist in expediting the review process."
 msgstr ""
 
 #: src/olympia/pages/templates/pages/dev_faq.html:418
@@ -12372,12 +9949,8 @@ msgstr "Za jak dlouho bude můj doplněk zkontrolován?"
 
 #: src/olympia/pages/templates/pages/dev_faq.html:420
 #, fuzzy
-msgid ""
-"We cannot give a time estimate as to how long it will take before an add-on "
-"is reviewed. Many factors affect the time including the:"
-msgstr ""
-"Nejsme schopni vám říci, za jak dlouho bude váš doplněk zkontrolován. Záleží"
-" na mnoha faktorech, jako například jsou:"
+msgid "We cannot give a time estimate as to how long it will take before an add-on is reviewed. Many factors affect the time including the:"
+msgstr "Nejsme schopni vám říci, za jak dlouho bude váš doplněk zkontrolován. Záleží na mnoha faktorech, jako například jsou:"
 
 #. part of a list (<li>)
 #: src/olympia/pages/templates/pages/dev_faq.html:427
@@ -12400,11 +9973,8 @@ msgstr "počet problémů, které se objeví"
 #: src/olympia/pages/templates/pages/dev_faq.html:434
 #, python-format
 msgid ""
-"This is why it's very important to read the <a href=\"%(g_url)s\">Editors "
-"Reviewing Guide</a> to ensure that your add-on is setup as expected.  It's "
-"also a good idea to read the blog post, <a "
-"href=\"%(blog_url)s\">Successfully Getting your Add-on Reviewed</a> which "
-"provides excellent insight into ensuring a smooth review of your add-on."
+"This is why it's very important to read the <a href=\"%(g_url)s\">Editors Reviewing Guide</a> to ensure that your add-on is setup as expected. It's also a good idea to read the blog post, <a "
+"href=\"%(blog_url)s\">Successfully Getting your Add-on Reviewed</a> which provides excellent insight into ensuring a smooth review of your add-on."
 msgstr ""
 
 #: src/olympia/pages/templates/pages/dev_faq.html:446
@@ -12413,10 +9983,7 @@ msgid "How can I see how many times my add-on has been downloaded?"
 msgstr "Kde mohu vidět, kolikrát byl můj doplněk stažen?"
 
 #: src/olympia/pages/templates/pages/dev_faq.html:448
-msgid ""
-"The Statistics Dashboard found in the Developer Tools dashboard provides "
-"information that can help you determine your add-on downloads since you've "
-"submitted it to AMO."
+msgid "The Statistics Dashboard found in the Developer Tools dashboard provides information that can help you determine your add-on downloads since you've submitted it to AMO."
 msgstr ""
 
 #: src/olympia/pages/templates/pages/dev_faq.html:455
@@ -12425,10 +9992,7 @@ msgid "How can I see how many active users are using my add-on?"
 msgstr "Jak se mohu podívat, kolik aktivních uživatelů používá můj doplněk?"
 
 #: src/olympia/pages/templates/pages/dev_faq.html:457
-msgid ""
-"The Statistics Dashboard found in the Developer Tools dashboard provides "
-"information that can help you determine how many users have been actively "
-"using your add-on since you've submitted it to AMO."
+msgid "The Statistics Dashboard found in the Developer Tools dashboard provides information that can help you determine how many users have been actively using your add-on since you've submitted it to AMO."
 msgstr ""
 
 #: src/olympia/pages/templates/pages/dev_faq.html:464
@@ -12437,10 +10001,7 @@ msgid "How do I submit an update for my add-on?"
 msgstr "Jak přidám aktualizaci mého doplňku?"
 
 #: src/olympia/pages/templates/pages/dev_faq.html:466
-msgid ""
-"You can submit an update for your add-on via the Developer Tools dashboard "
-"by choosing the option \"Upload a new version\" and uploading a new .xpi "
-"file for your add-on."
+msgid "You can submit an update for your add-on via the Developer Tools dashboard by choosing the option \"Upload a new version\" and uploading a new .xpi file for your add-on."
 msgstr ""
 
 #: src/olympia/pages/templates/pages/dev_faq.html:473
@@ -12450,44 +10011,32 @@ msgstr "Musí být aktualizace mého doplňku schválena redaktorem?"
 
 #: src/olympia/pages/templates/pages/dev_faq.html:475
 msgid ""
-"That depends. If you are simply changing a description of your add-on or "
-"updating a \"maxVersion\" to ensure compatibility with a new Mozilla "
-"software update, then your add-on does not need to be reviewed again. If, "
-"however, you submit a new updated file, then your add-on update will need to"
-" be reviewed by an editor."
+"That depends. If you are simply changing a description of your add-on or updating a \"maxVersion\" to ensure compatibility with a new Mozilla software update, then your add-on does not need to be "
+"reviewed again. If, however, you submit a new updated file, then your add-on update will need to be reviewed by an editor."
 msgstr ""
 
 #: src/olympia/pages/templates/pages/dev_faq.html:486
 #, fuzzy
-msgid ""
-"How do I reply to a user who has posted a negative review of my add-on?"
-msgstr ""
-"Jak mohu odpovědět uživateli, který přidal k mému doplňku negativní recenzi?"
+msgid "How do I reply to a user who has posted a negative review of my add-on?"
+msgstr "Jak mohu odpovědět uživateli, který přidal k mému doplňku negativní recenzi?"
 
 #: src/olympia/pages/templates/pages/dev_faq.html:488
 #, fuzzy
-msgid ""
-"A developer may reply to any review posted to their add-on as long as they "
-"are logged into AMO. In addition, any user can flag a review as:"
-msgstr ""
-"Vývojář může odpovědět na jakoukoliv recenzi přidanou k jeho doplňku v "
-"situaci, kdy je k AMO přihlášen. Navíc může jakoukoliv recenzi označit jako:"
+msgid "A developer may reply to any review posted to their add-on as long as they are logged into AMO. In addition, any user can flag a review as:"
+msgstr "Vývojář může odpovědět na jakoukoliv recenzi přidanou k jeho doplňku v situaci, kdy je k AMO přihlášen. Navíc může jakoukoliv recenzi označit jako:"
 
 #. part of a list (<li>)
-#: src/olympia/pages/templates/pages/dev_faq.html:495
-#: src/olympia/reviews/models.py:159
+#: src/olympia/pages/templates/pages/dev_faq.html:495 src/olympia/reviews/models.py:159
 msgid "Spam or otherwise non-review content"
 msgstr "Spam alebo iný neschválený obsah"
 
 #. part of a list (<li>)
-#: src/olympia/pages/templates/pages/dev_faq.html:497
-#: src/olympia/reviews/models.py:160
+#: src/olympia/pages/templates/pages/dev_faq.html:497 src/olympia/reviews/models.py:160
 msgid "Inappropriate language/dialog"
 msgstr "Nevhodný jazyk/dialóg"
 
 #. part of a list (<li>)
-#: src/olympia/pages/templates/pages/dev_faq.html:499
-#: src/olympia/reviews/models.py:161
+#: src/olympia/pages/templates/pages/dev_faq.html:499 src/olympia/reviews/models.py:161
 msgid "Misplaced bug report or support request"
 msgstr "Nevhodne umiestnená správa o chybe alebo žiadosť o podporu"
 
@@ -12499,22 +10048,15 @@ msgstr "Jiný (zobrazí se okno pro možnost zadání dalších informací)"
 
 #: src/olympia/pages/templates/pages/dev_faq.html:504
 #, fuzzy
-msgid ""
-"Currently, AMO does not provide a mechanism to directly communicate with a "
-"reviewer but this feature is being investigated and considered for a future "
-"update."
-msgstr ""
-"V současné době AMO nenabízí možnost přímé komunikace s redaktorem, ale tato"
-" funkčnost je zvažována a může se v budoucnu objevit."
+msgid "Currently, AMO does not provide a mechanism to directly communicate with a reviewer but this feature is being investigated and considered for a future update."
+msgstr "V současné době AMO nenabízí možnost přímé komunikace s redaktorem, ale tato funkčnost je zvažována a může se v budoucnu objevit."
 
 #: src/olympia/pages/templates/pages/dev_faq.html:511
 msgid "Can I request that a review be removed if the review is negative?"
 msgstr "Môžem požiadať o odstránenie recenzie, ak je negatívna?"
 
 #: src/olympia/pages/templates/pages/dev_faq.html:513
-msgid ""
-"No. We do not remove negative reviews from add-ons unless they are found to "
-"be false."
+msgid "No. We do not remove negative reviews from add-ons unless they are found to be false."
 msgstr ""
 
 #: src/olympia/pages/templates/pages/dev_faq.html:519
@@ -12523,89 +10065,53 @@ msgstr "Môžem požiadať o odstránenie recenzie, ktorá je nepravdivá?"
 
 #: src/olympia/pages/templates/pages/dev_faq.html:521
 #, fuzzy
-msgid ""
-"If an author contacts us and asks for a review containing false or "
-"inaccurate information to be removed, we will review the post and consider "
-"removing it."
-msgstr ""
-"Pokud nás autor kontaktuje s žádosti o kontrolu recenze, která obsahuje "
-"chybné či nepravdivé informace, provedeme její kontrolu a rozhodneme, zda ji"
-" smažeme či nikoliv."
+msgid "If an author contacts us and asks for a review containing false or inaccurate information to be removed, we will review the post and consider removing it."
+msgstr "Pokud nás autor kontaktuje s žádosti o kontrolu recenze, která obsahuje chybné či nepravdivé informace, provedeme její kontrolu a rozhodneme, zda ji smažeme či nikoliv."
 
 #: src/olympia/pages/templates/pages/dev_faq.html:530
 #, fuzzy
 msgid ""
-"Do you need more information about the various open source licenses? Are you"
-" confused as to which license you should select? What rights does a specific"
-" license grant? While nothing replaces reading the full terms of a license, "
-"below are some sites that contain information about some of the key open "
-"source licenses that may help you sort out the differences between them. "
-"These sites are being provided solely for your convenience and as a "
-"reference for your personal use. These resources do not constitute legal "
-"advice nor should they be used in lieu of such advice. Mozilla neither "
-"guarantees nor is responsible for the content of these sites or your "
-"reliance on such content."
+"Do you need more information about the various open source licenses? Are you confused as to which license you should select? What rights does a specific license grant? While nothing replaces "
+"reading the full terms of a license, below are some sites that contain information about some of the key open source licenses that may help you sort out the differences between them. These sites "
+"are being provided solely for your convenience and as a reference for your personal use. These resources do not constitute legal advice nor should they be used in lieu of such advice. Mozilla "
+"neither guarantees nor is responsible for the content of these sites or your reliance on such content."
 msgstr ""
-"Potřebujete více informací o různých open-source licencích? Nevíte, kterou "
-"licenci byste si měli zvolit? Jaká práva která licence poskytuje? Ačkoliv "
-"nic nenahradí kompletní přečtení licence, níže jsou některé weby, které "
-"obsahují informace o některých nejpoužívanějších open-source licencích, "
-"které vám mohou pomoci si zvolit tu správnou. Tyto stránky jsou odkazovány "
-"pro vaše pohodlí a jsou určeny pro vaše osobní použití. Tyto zdroje vám "
-"nedají odpovědi na konkrétní právní otázky, ty byste měli konzultovat s "
-"právníkem. Mozilla není odpovědná za obsah, které tyto weby nabízí."
+"Potřebujete více informací o různých open-source licencích? Nevíte, kterou licenci byste si měli zvolit? Jaká práva která licence poskytuje? Ačkoliv nic nenahradí kompletní přečtení licence, níže "
+"jsou některé weby, které obsahují informace o některých nejpoužívanějších open-source licencích, které vám mohou pomoci si zvolit tu správnou. Tyto stránky jsou odkazovány pro vaše pohodlí a jsou "
+"určeny pro vaše osobní použití. Tyto zdroje vám nedají odpovědi na konkrétní právní otázky, ty byste měli konzultovat s právníkem. Mozilla není odpovědná za obsah, které tyto weby nabízí."
 
 #: src/olympia/pages/templates/pages/dev_faq.html:545
 msgid ""
-"In addition to the full text of the Mozilla Public License(\"MPL\"), this "
-"also provides an annotated version of the MPL and an <abbr "
-"title=\"Frequently Asked Questions\">FAQ</abbr> to help you if you want to "
-"use or distribute code licensed under it."
+"In addition to the full text of the Mozilla Public License(\"MPL\"), this also provides an annotated version of the MPL and an <abbr title=\"Frequently Asked Questions\">FAQ</abbr> to help you if "
+"you want to use or distribute code licensed under it."
 msgstr ""
 
 #: src/olympia/pages/templates/pages/dev_faq.html:559
 #, fuzzy
-msgid ""
-"A table summarizing and comparing how some of the key open source licenses "
-"treat distributions, proprietary software linking, and redistribution of "
-"code with changes."
-msgstr ""
-"Tabulka, která shrnuje a porovnává některé klíčové open-source licence z "
-"hlediska distribuce, přibalování k proprietárnímu software a redistribuci "
-"kódu se změnami."
+msgid "A table summarizing and comparing how some of the key open source licenses treat distributions, proprietary software linking, and redistribution of code with changes."
+msgstr "Tabulka, která shrnuje a porovnává některé klíčové open-source licence z hlediska distribuce, přibalování k proprietárnímu software a redistribuci kódu se změnami."
 
 #: src/olympia/pages/templates/pages/dev_faq.html:572
 msgid ""
-"Free Software Foundation provides short summaries of the key open source "
-"licenses, including whether the license qualifies as a free software license"
-" or a copyleft license.  Also includes a discussion of what constitutes a "
-"free software license or a copyleft license (e.g., a Copyleft license is a "
-"general method for making a program or other work free, and requiring all "
-"modified and extended versions of the program to be free as well.)"
+"Free Software Foundation provides short summaries of the key open source licenses, including whether the license qualifies as a free software license or a copyleft license. Also includes a "
+"discussion of what constitutes a free software license or a copyleft license (e.g., a Copyleft license is a general method for making a program or other work free, and requiring all modified and "
+"extended versions of the program to be free as well.)"
 msgstr ""
 
 #: src/olympia/pages/templates/pages/dev_faq.html:589
 #, fuzzy
-msgid ""
-"Open Source Initiative provides the terms of some of the key open source "
-"licenses."
-msgstr ""
-"Open Source Initiative poskytuje informace o některých nejrozšířenějších "
-"open-source licencích."
+msgid "Open Source Initiative provides the terms of some of the key open source licenses."
+msgstr "Open Source Initiative poskytuje informace o některých nejrozšířenějších open-source licencích."
 
 #: src/olympia/pages/templates/pages/dev_faq.html:599
 msgid "A comparison of known open source licenses on Wikipedia."
 msgstr ""
 
 #: src/olympia/pages/templates/pages/dev_faq.html:605
-msgid ""
-"A site to provide non-judgmental guidance on choosing a license for your "
-"open source project."
+msgid "A site to provide non-judgmental guidance on choosing a license for your open source project."
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:3
-#: src/olympia/pages/templates/pages/faq.html:9
-#: src/olympia/pages/templates/pages/faq.html:10
+#: src/olympia/pages/templates/pages/faq.html:3 src/olympia/pages/templates/pages/faq.html:9 src/olympia/pages/templates/pages/faq.html:10
 msgid "Frequently Asked Questions"
 msgstr "Často kladené otázky"
 
@@ -12620,19 +10126,11 @@ msgstr "Čo sú to doplnky?"
 #: src/olympia/pages/templates/pages/faq.html:16
 #, fuzzy, python-format
 msgid ""
-"Add-ons are small pieces of software that add new features or functionality "
-"to your installation of %(app_name)s. Add-ons can augment %(app_name)s with "
-"new features, foreign language dictionaries, or change its visual "
-"appearance. Through add-ons, you can customize %(app_name)s to meet your "
-"needs and tastes. <a href=\"%(learnmore_url)s\">Learn more about "
-"customization</a>"
+"Add-ons are small pieces of software that add new features or functionality to your installation of %(app_name)s. Add-ons can augment %(app_name)s with new features, foreign language dictionaries, "
+"or change its visual appearance. Through add-ons, you can customize %(app_name)s to meet your needs and tastes. <a href=\"%(learnmore_url)s\">Learn more about customization</a>"
 msgstr ""
-"Doplňky jsou malé kousky software, které přidávají nové vlastnosti či funkce"
-" do vaší instalace aplikace %(app_name)s. Doplňky mohou rozšířit aplikaci "
-"%(app_name)s o nové vlastnosti, slovníky na kontrolu pravopisu či změnit "
-"její vzhled. Pomocí doplňků můžete přizpůsobit aplikaci %(app_name)s dle "
-"svých potřeb. <a href=\"%(learnmore_url)s\">Dozvědět se více o možnostech "
-"přizpůsobení</a>"
+"Doplňky jsou malé kousky software, které přidávají nové vlastnosti či funkce do vaší instalace aplikace %(app_name)s. Doplňky mohou rozšířit aplikaci %(app_name)s o nové vlastnosti, slovníky na "
+"kontrolu pravopisu či změnit její vzhled. Pomocí doplňků můžete přizpůsobit aplikaci %(app_name)s dle svých potřeb. <a href=\"%(learnmore_url)s\">Dozvědět se více o možnostech přizpůsobení</a>"
 
 #: src/olympia/pages/templates/pages/faq.html:26
 #, fuzzy
@@ -12642,15 +10140,10 @@ msgstr "Budou doplňky fungovat s mým webovým prohlížečem či aplikací?"
 #: src/olympia/pages/templates/pages/faq.html:27
 #, python-format
 msgid ""
-"Add-ons listed in this gallery only work with Mozilla-based applications, "
-"such as <a href=\"%(getfirefox_url)s\">Firefox</a>, <a "
-"href=\"%(getmobile_url)s\">Firefox Mobile</a>, <a "
-"href=\"%(getseamonkey_url)s\">SeaMonkey</a>, and <a "
-"href=\"%(getthunderbird_url)s\">Thunderbird</a>. However, not all add-ons "
-"work with each of those applications or every version of those applications."
-" Each add-on specifies which applications and versions it works with, such "
-"as Firefox 2.0 - 3.6.*. For Firefox add-ons, the install buttons will "
-"indicate whether the add-on is compatible or not."
+"Add-ons listed in this gallery only work with Mozilla-based applications, such as <a href=\"%(getfirefox_url)s\">Firefox</a>, <a href=\"%(getmobile_url)s\">Firefox Mobile</a>, <a "
+"href=\"%(getseamonkey_url)s\">SeaMonkey</a>, and <a href=\"%(getthunderbird_url)s\">Thunderbird</a>. However, not all add-ons work with each of those applications or every version of those "
+"applications. Each add-on specifies which applications and versions it works with, such as Firefox 2.0 - 3.6.*. For Firefox add-ons, the install buttons will indicate whether the add-on is "
+"compatible or not."
 msgstr ""
 
 #: src/olympia/pages/templates/pages/faq.html:42
@@ -12659,73 +10152,42 @@ msgstr "Aké typy doplnkov sú dostupné?"
 
 #: src/olympia/pages/templates/pages/faq.html:43
 #, python-format
-msgid ""
-"There are several kinds of add-ons that customize %(app_name)s in different "
-"ways:"
+msgid "There are several kinds of add-ons that customize %(app_name)s in different ways:"
 msgstr ""
 
 #: src/olympia/pages/templates/pages/faq.html:47
 #, fuzzy, python-format
 msgid ""
-"<strong><a href=\"%(browse_url)s\">Extensions</a></strong> add new features "
-"to %(app_name)s or modify existing functionality. There are extensions that "
-"allow you to block advertisements, download videos from websites, integrate "
-"more closely with social websites, and add features you see in other "
-"applications."
+"<strong><a href=\"%(browse_url)s\">Extensions</a></strong> add new features to %(app_name)s or modify existing functionality. There are extensions that allow you to block advertisements, download "
+"videos from websites, integrate more closely with social websites, and add features you see in other applications."
 msgstr ""
-"<strong><a href=\"%(browse_url)s\">Rozšíření</a></strong> přidávají do "
-"aplikace %(app_name)s nové funkce či upravují ty existující. Existují "
-"rozšíření, které vám umožňují blokovat reklamu, stahovat videa z webových "
-"stránek, provádí integraci se sociálními sítěmi a přidávají funkce, které "
-"jste viděli v jiných aplikacích."
+"<strong><a href=\"%(browse_url)s\">Rozšíření</a></strong> přidávají do aplikace %(app_name)s nové funkce či upravují ty existující. Existují rozšíření, které vám umožňují blokovat reklamu, stahovat"
+" videa z webových stránek, provádí integraci se sociálními sítěmi a přidávají funkce, které jste viděli v jiných aplikacích."
 
 #: src/olympia/pages/templates/pages/faq.html:55
 #, python-format
-msgid ""
-"<strong><a href=\"%(browse_url)s\">Complete Themes</a></strong> change the "
-"entire appearance of %(app_name)s, usually including icons, colors, dialogs,"
-" and other visual styles."
+msgid "<strong><a href=\"%(browse_url)s\">Complete Themes</a></strong> change the entire appearance of %(app_name)s, usually including icons, colors, dialogs, and other visual styles."
 msgstr ""
 
 #: src/olympia/pages/templates/pages/faq.html:61
 #, python-format
-msgid ""
-"<strong><a href=\"%(browse_url)s\">Themes</a></strong> are lightweight "
-"themes that use background images to customize your %(app_name)s toolbars."
-msgstr ""
-"<strong><a href=\"%(browse_url)s\">Témy</a></strong> sú odľahčené vzhľady, "
-"ktoré umožňujú zmeniť obrázok na pozadí panelov aplikácie %(app_name)s."
+msgid "<strong><a href=\"%(browse_url)s\">Themes</a></strong> are lightweight themes that use background images to customize your %(app_name)s toolbars."
+msgstr "<strong><a href=\"%(browse_url)s\">Témy</a></strong> sú odľahčené vzhľady, ktoré umožňujú zmeniť obrázok na pozadí panelov aplikácie %(app_name)s."
 
 #: src/olympia/pages/templates/pages/faq.html:66
 #, fuzzy, python-format
-msgid ""
-"<strong><a href=\"%(browse_url)s\">Search Providers</a> </strong> add "
-"additional choices to the search box dropdown. These providers allow you to "
-"quickly search any website."
-msgstr ""
-"<strong><a href=\"%(browse_url)s\">Vyhledávací moduly</a> </strong> "
-"přidávají další možnosti vyhledávání. Moduly umožňují rychle vyhledávat na "
-"libovolné webové stránce."
+msgid "<strong><a href=\"%(browse_url)s\">Search Providers</a> </strong> add additional choices to the search box dropdown. These providers allow you to quickly search any website."
+msgstr "<strong><a href=\"%(browse_url)s\">Vyhledávací moduly</a> </strong> přidávají další možnosti vyhledávání. Moduly umožňují rychle vyhledávat na libovolné webové stránce."
 
 #: src/olympia/pages/templates/pages/faq.html:72
 #, fuzzy, python-format
-msgid ""
-"<strong><a href=\"%(browse_url)s\">Dictionaries & Language "
-"Packs</a></strong> add support for additional languages to %(app_name)s."
-msgstr ""
-"<strong><a href=\"%(browse_url)s\">Slovníky a jazykové balíčky</a></strong> "
-"přidávají do aplikace %(app_name)s podporu pro další jazyky."
+msgid "<strong><a href=\"%(browse_url)s\">Dictionaries & Language Packs</a></strong> add support for additional languages to %(app_name)s."
+msgstr "<strong><a href=\"%(browse_url)s\">Slovníky a jazykové balíčky</a></strong> přidávají do aplikace %(app_name)s podporu pro další jazyky."
 
 #: src/olympia/pages/templates/pages/faq.html:77
 #, fuzzy, python-format
-msgid ""
-"<strong><a href=\"%(browse_url)s\">Plugins</a></strong> help %(app_name)s "
-"display or understand different types of media, such as Adobe Flash or Apple"
-" Quicktime."
-msgstr ""
-"<strong><a href=\"%(browse_url)s\">Zásuvné moduly</a></strong> pomáhají "
-"aplikaci %(app_name)s zobrazovat a rozumnět různým typům obsahu, jako je "
-"Adobe Flash či Apple Quicktime."
+msgid "<strong><a href=\"%(browse_url)s\">Plugins</a></strong> help %(app_name)s display or understand different types of media, such as Adobe Flash or Apple Quicktime."
+msgstr "<strong><a href=\"%(browse_url)s\">Zásuvné moduly</a></strong> pomáhají aplikaci %(app_name)s zobrazovat a rozumnět různým typům obsahu, jako je Adobe Flash či Apple Quicktime."
 
 #: src/olympia/pages/templates/pages/faq.html:85
 msgid "How do I install, manage, or remove an add-on?"
@@ -12734,13 +10196,9 @@ msgstr "Ako môžem nainštalovať, spravovať alebo odstrániť doplnok?"
 #: src/olympia/pages/templates/pages/faq.html:86
 #, python-format
 msgid ""
-"In most cases, add-ons can be installed by simply clicking the install "
-"button provided. Add-ons can be managed, disabled, or uninstalled from the "
-"Add-ons Manager in %(app_name)s. For more detailed instructions, read <a "
-"href=\"%(extension_url)s\">this article on extensions</a> or <a "
-"href=\"%(theme_url)s\">this one for Themes and Complete Themes</a>. If you "
-"have difficulty installing add-ons, see <a "
-"href=\"%(troubleshooting_url)s\">Troubleshooting Extensions and Themes</a>."
+"In most cases, add-ons can be installed by simply clicking the install button provided. Add-ons can be managed, disabled, or uninstalled from the Add-ons Manager in %(app_name)s. For more detailed "
+"instructions, read <a href=\"%(extension_url)s\">this article on extensions</a> or <a href=\"%(theme_url)s\">this one for Themes and Complete Themes</a>. If you have difficulty installing add-ons, "
+"see <a href=\"%(troubleshooting_url)s\">Troubleshooting Extensions and Themes</a>."
 msgstr ""
 
 #: src/olympia/pages/templates/pages/faq.html:100
@@ -12750,11 +10208,8 @@ msgstr "Ako môžem nainštalovať doplnky bez reštartu Firefoxu?"
 #: src/olympia/pages/templates/pages/faq.html:101
 #, python-format
 msgid ""
-"In Firefox, add-ons marked with \"No restart required\" can be installed "
-"without restarting. These add-ons have been created using the <a "
-"href=\"%(sdk_url)s\">Add-on SDK</a> or <a "
-"href=\"%(bootstrap_url)s\">bootstrapping</a>. Other add-ons will still "
-"require a restart before you can use them."
+"In Firefox, add-ons marked with \"No restart required\" can be installed without restarting. These add-ons have been created using the <a href=\"%(sdk_url)s\">Add-on SDK</a> or <a "
+"href=\"%(bootstrap_url)s\">bootstrapping</a>. Other add-ons will still require a restart before you can use them."
 msgstr ""
 
 #: src/olympia/pages/templates/pages/faq.html:110
@@ -12765,13 +10220,9 @@ msgstr "Jak zajistím, že budu mít doplňky aktuální?"
 #: src/olympia/pages/templates/pages/faq.html:111
 #, python-format
 msgid ""
-"Add-ons, unlike plugins, are automatically checked for updates once every "
-"day. In Firefox, updates are automatically installed by default. Versions of"
-" Firefox prior to 4 (and other applications) will alert you that updates to "
-"your add-ons are available. <a href=\"%(plugin_url)s\">Plugins</a> are not "
-"currently automatically checked for updates, so be sure to regularly visit "
-"the <a href=\"%(plugincheck_url)s\">Plugin Check</a> page to stay up-to-"
-"date."
+"Add-ons, unlike plugins, are automatically checked for updates once every day. In Firefox, updates are automatically installed by default. Versions of Firefox prior to 4 (and other applications) "
+"will alert you that updates to your add-ons are available. <a href=\"%(plugin_url)s\">Plugins</a> are not currently automatically checked for updates, so be sure to regularly visit the <a "
+"href=\"%(plugincheck_url)s\">Plugin Check</a> page to stay up-to-date."
 msgstr ""
 
 #: src/olympia/pages/templates/pages/faq.html:122
@@ -12782,20 +10233,13 @@ msgstr "Je bezpečné instalovat doplňky?"
 #: src/olympia/pages/templates/pages/faq.html:123
 #, fuzzy, python-format
 msgid ""
-"Unless clearly marked otherwise, add-ons available from this gallery have "
-"been checked and approved by Mozilla's team of editors and are safe to "
-"install. We recommend that you only install approved add-ons. If you wish to"
-" install unapproved add-ons or add-ons from third-party websites, use "
-"caution as these add-ons may harm your computer or violate your privacy. <a "
+"Unless clearly marked otherwise, add-ons available from this gallery have been checked and approved by Mozilla's team of editors and are safe to install. We recommend that you only install approved"
+" add-ons. If you wish to install unapproved add-ons or add-ons from third-party websites, use caution as these add-ons may harm your computer or violate your privacy. <a "
 "href=\"%(learnmore_url)s\">Learn more about our approval process</a>"
 msgstr ""
-"Pokud není řečeno jinak, jsou doplňky dostupné v galerii kontrolovány a "
-"schvalovány týmem redaktorů Mozilly a jsou tak bezpečné. Doporučujeme, "
-"abyste instalovali pouze schválené doplňky. Pokud si přejete instalovat "
-"neschválené doplňky či doplňky z webových stránek třetích stran, mějte na "
-"paměti, že tyto doplňky mohou poškodit váš počítač či ohrozit vaše soukromí."
-" <a href=\"%(learnmore_url)s\">Dozvědět se více o našem procesu "
-"schvalování</a>"
+"Pokud není řečeno jinak, jsou doplňky dostupné v galerii kontrolovány a schvalovány týmem redaktorů Mozilly a jsou tak bezpečné. Doporučujeme, abyste instalovali pouze schválené doplňky. Pokud si "
+"přejete instalovat neschválené doplňky či doplňky z webových stránek třetích stran, mějte na paměti, že tyto doplňky mohou poškodit váš počítač či ohrozit vaše soukromí. <a "
+"href=\"%(learnmore_url)s\">Dozvědět se více o našem procesu schvalování</a>"
 
 #: src/olympia/pages/templates/pages/faq.html:133
 #, python-format
@@ -12805,30 +10249,21 @@ msgstr "Môžu doplnky spomaliť %(app_name)s?"
 #: src/olympia/pages/templates/pages/faq.html:135
 #, python-format
 msgid ""
-"Most add-ons do not cause a perceivable performance decrease in "
-"%(app_name)s, though installing an excessive number may have adverse "
-"effects. If you suspect an add-on is causing %(app_name)s to be slow, try "
-"disabling it."
+"Most add-ons do not cause a perceivable performance decrease in %(app_name)s, though installing an excessive number may have adverse effects. If you suspect an add-on is causing %(app_name)s to be "
+"slow, try disabling it."
 msgstr ""
 
 #: src/olympia/pages/templates/pages/faq.html:141
 #, python-format
-msgid ""
-"%(app_name)s told me an add-on isn't compatible. Is there a way I can still "
-"use it?"
+msgid "%(app_name)s told me an add-on isn't compatible. Is there a way I can still use it?"
 msgstr ""
 
 #: src/olympia/pages/templates/pages/faq.html:144
 #, python-format
 msgid ""
-"If an add-on isn't compatible with your version of %(app_name)s, it is "
-"usually either because your version of %(app_name)s is outdated or the add-"
-"on author has not yet updated the add-on to be compatible with a newer "
-"version you are using. Mozilla does not recommend trying to circumvent these"
-" compatibility checks, as they can lead to browser instability or in some "
-"cases loss of data. For users who are testing out alpha or beta versions of "
-"Firefox, we offer the <a href=\"%(acr_url)s\">Add-on Compatibility "
-"Reporter</a> to help add-on developers update their compatibility."
+"If an add-on isn't compatible with your version of %(app_name)s, it is usually either because your version of %(app_name)s is outdated or the add-on author has not yet updated the add-on to be "
+"compatible with a newer version you are using. Mozilla does not recommend trying to circumvent these compatibility checks, as they can lead to browser instability or in some cases loss of data. For"
+" users who are testing out alpha or beta versions of Firefox, we offer the <a href=\"%(acr_url)s\">Add-on Compatibility Reporter</a> to help add-on developers update their compatibility."
 msgstr ""
 
 #: src/olympia/pages/templates/pages/faq.html:156
@@ -12838,12 +10273,9 @@ msgstr "Čo ak mám problémy s doplnkom?"
 #: src/olympia/pages/templates/pages/faq.html:157
 #, python-format
 msgid ""
-"Add-ons are usually created by third-party developers from around the world,"
-" so the best way to get help with an add-on is to look for support links on "
-"the add-on's homepage or contact the developer. If you are having issues "
-"with %(app_name)s that you suspect are related to add-ons you have "
-"installed, <a href=\"%(troubleshooting_url)s\">visit this support "
-"article</a> for troubleshooting tips."
+"Add-ons are usually created by third-party developers from around the world, so the best way to get help with an add-on is to look for support links on the add-on's homepage or contact the "
+"developer. If you are having issues with %(app_name)s that you suspect are related to add-ons you have installed, <a href=\"%(troubleshooting_url)s\">visit this support article</a> for "
+"troubleshooting tips."
 msgstr ""
 
 #: src/olympia/pages/templates/pages/faq.html:169
@@ -12854,14 +10286,10 @@ msgstr "Galéria doplnkov"
 msgid "How do I choose between add-ons that seem to do the same thing?"
 msgstr "Jak si mám vybrat mezi doplňky, které dělají tu samou věc?"
 
-#: src/olympia/pages/templates/pages/faq.html:173
+#: src/olympia/pages/templates/pages/faq.html:172
 msgid ""
-"There are often several add-ons that have similar features. To\n"
-"    figure out which is right for you, read the entire description of the\n"
-"    add-on and view its screenshots. If there are still several in the running,\n"
-"    read through the add-on's ratings, user reviews, and statistics to see\n"
-"    which is most liked by other users. Remember that you can also just try\n"
-"    out both and see which you like better."
+"There are often several add-ons that have similar features. To figure out which is right for you, read the entire description of the add-on and view its screenshots. If there are still several in "
+"the running, read through the add-on's ratings, user reviews, and statistics to see which is most liked by other users. Remember that you can also just try out both and see which you like better."
 msgstr ""
 
 #: src/olympia/pages/templates/pages/faq.html:180
@@ -12872,27 +10300,20 @@ msgstr "Co mám dělat, když nemohu nalézt doplněk, který hledám?"
 #: src/olympia/pages/templates/pages/faq.html:181
 #, python-format
 msgid ""
-"With thousands of add-ons available, there's something for everyone. But if "
-"you're looking for a particular add-on and can't find it, you might try "
-"searching on other sites or posting about it in our <a href=\"%(forum_url)s"
-"\">Add-ons </a>forum."
+"With thousands of add-ons available, there's something for everyone. But if you're looking for a particular add-on and can't find it, you might try searching on other sites or posting about it in "
+"our <a href=\"%(forum_url)s\">Add-ons </a>forum."
 msgstr ""
 
 #: src/olympia/pages/templates/pages/faq.html:187
 #, fuzzy
-msgid ""
-"What does it mean if an add-on is \"experimental\" or \"preliminarily "
-"reviewed\"?"
+msgid "What does it mean if an add-on is \"experimental\" or \"preliminarily reviewed\"?"
 msgstr "Co znamená, že je doplněk \"experimentální\" či \"předběžně zkontrolován\"?"
 
 #: src/olympia/pages/templates/pages/faq.html:188
 #, python-format
 msgid ""
-"Experimental add-ons have been checked by our editors to make sure they "
-"don't have security problems, but they may still have bugs or not work "
-"properly. Use caution when installing experimental add-ons and uninstall the"
-" add-on immediately if you notice problems. <a href=\"%(url)s\">Learn more "
-"about our review process</a></dd>"
+"Experimental add-ons have been checked by our editors to make sure they don't have security problems, but they may still have bugs or not work properly. Use caution when installing experimental "
+"add-ons and uninstall the add-on immediately if you notice problems. <a href=\"%(url)s\">Learn more about our review process</a></dd>"
 msgstr ""
 
 #: src/olympia/pages/templates/pages/faq.html:196
@@ -12903,12 +10324,8 @@ msgstr "Co znamená, pokud doplněk \"není zkontrolován\"?"
 #: src/olympia/pages/templates/pages/faq.html:197
 #, python-format
 msgid ""
-"While all add-ons publicly available in our gallery are reviewed by an "
-"editor, you may receive a direct link to an add-on that hasn't yet been "
-"reviewed. Use caution when installing these add-ons, as they could harm your"
-" computer or violate your privacy. We recommend that you only install "
-"reviewed add-ons. <a href=\"%(url)s\">Learn more about our review "
-"process</a></dd>"
+"While all add-ons publicly available in our gallery are reviewed by an editor, you may receive a direct link to an add-on that hasn't yet been reviewed. Use caution when installing these add-ons, "
+"as they could harm your computer or violate your privacy. We recommend that you only install reviewed add-ons. <a href=\"%(url)s\">Learn more about our review process</a></dd>"
 msgstr ""
 
 #: src/olympia/pages/templates/pages/faq.html:206
@@ -12917,214 +10334,159 @@ msgid "How much do add-ons cost to purchase?"
 msgstr "Kolik doplňky stojí?"
 
 #: src/olympia/pages/templates/pages/faq.html:207
-msgid ""
-"Add-ons hosted in our gallery are free unless clearly marked otherwise."
-msgstr ""
-"Pokud není jasně řečeno jinak, jsou hostované doplňky dostupné zdarma."
+msgid "Add-ons hosted in our gallery are free unless clearly marked otherwise."
+msgstr "Pokud není jasně řečeno jinak, jsou hostované doplňky dostupné zdarma."
 
-#: src/olympia/pages/templates/pages/faq.html:210
+#: src/olympia/pages/templates/pages/faq.html:209
 #, fuzzy
 msgid "What does it mean when an add-on asks for contributions?"
 msgstr "Co znamená, když autor doplňku žádá o příspěvek?"
 
-#: src/olympia/pages/templates/pages/faq.html:211
+#: src/olympia/pages/templates/pages/faq.html:210
 msgid ""
-"Some add-on authors request users who enjoy an add-on to\n"
-"        contribute to its development by making a monetary contribution. These\n"
-"        contributions go directly to the developer unless a third party is\n"
-"        indicated, such as the non-profit Mozilla Foundation."
+"Some add-on authors request users who enjoy an add-on to contribute to its development by making a monetary contribution. These contributions go directly to the developer unless a third party is "
+"indicated, such as the non-profit Mozilla Foundation."
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:216
+#: src/olympia/pages/templates/pages/faq.html:215
 msgid "What are beta add-ons?"
 msgstr "Čo sú to verzie beta?"
 
-#: src/olympia/pages/templates/pages/faq.html:218
+#: src/olympia/pages/templates/pages/faq.html:217
 msgid ""
-"Beta add-ons are unreviewed versions which represent the latest work of an "
-"add-on author. While different authors have different standards for beta "
-"code quality, you should assume that these add-ons are less stable than the "
-"general add-on releases."
+"Beta add-ons are unreviewed versions which represent the latest work of an add-on author. While different authors have different standards for beta code quality, you should assume that these add-"
+"ons are less stable than the general add-on releases."
 msgstr ""
-"Doplnky vo verzii beta sú neprekontrolované verzie, ktoré odrážajú najnovšiu"
-" prácu vývojára doplnku. Pretože autori majú rôzne nároky na kvalitu kódu vo"
-" verzii beta, mali by ste očakávať, že tieto doplnky budú menej stabilné ako"
-" ich finálne verzie."
+"Doplnky vo verzii beta sú neprekontrolované verzie, ktoré odrážajú najnovšiu prácu vývojára doplnku. Pretože autori majú rôzne nároky na kvalitu kódu vo verzii beta, mali by ste očakávať, že tieto "
+"doplnky budú menej stabilné ako ich finálne verzie."
 
-#: src/olympia/pages/templates/pages/faq.html:222
+#: src/olympia/pages/templates/pages/faq.html:221
 msgid ""
-"Please note that when you install an add-on from the \"Beta Version\" "
-"section of an add-on's listing, you will continue to receive updates for "
-"that add-on as they become available. Like the initial version you "
-"installed, all beta releases are unreviewed by Mozilla and may harm your "
-"computer."
+"Please note that when you install an add-on from the \"Beta Version\" section of an add-on's listing, you will continue to receive updates for that add-on as they become available. Like the initial"
+" version you installed, all beta releases are unreviewed by Mozilla and may harm your computer."
 msgstr ""
-"Zapamätajte si, že keď si nainštalujte doplnok vo \"verzii beta\", budete "
-"dostávať aj nasledujúce beta verzie daného doplnku, ak budú dostupné. Tak "
-"ako pôvodná verzia, ktorú si nainštalujete, aj všetky nasledujúce "
-"aktualizácie nebudú Mozillou prekontrolované a môžu spôsobiť poškodenie "
-"údajov vo vašom počítači."
+"Zapamätajte si, že keď si nainštalujte doplnok vo \"verzii beta\", budete dostávať aj nasledujúce beta verzie daného doplnku, ak budú dostupné. Tak ako pôvodná verzia, ktorú si nainštalujete, aj "
+"všetky nasledujúce aktualizácie nebudú Mozillou prekontrolované a môžu spôsobiť poškodenie údajov vo vašom počítači."
 
-#: src/olympia/pages/templates/pages/faq.html:229
+#: src/olympia/pages/templates/pages/faq.html:228
 msgid "What does it mean when an add-on is flagged as slow?"
 msgstr "Co znamená, když je doplněk označen jako pomalý?"
 
-#: src/olympia/pages/templates/pages/faq.html:231
-msgid ""
-"Most add-ons load code and resources at the same time Firefox\n"
-"        is starting up. In most cases the impact in start-up time is minimal,\n"
-"        but some add-ons can cause a noticeable slowdown."
+#: src/olympia/pages/templates/pages/faq.html:229
+msgid "Most add-ons load code and resources at the same time Firefox is starting up. In most cases the impact in start-up time is minimal, but some add-ons can cause a noticeable slowdown."
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:236
+#: src/olympia/pages/templates/pages/faq.html:234
 #, fuzzy
 msgid "How do I report an inappropriate or spam user review?"
-msgstr ""
-"Jak mohu nahlásit nevhodnou recenzi uživatele či nevyžádaný příspěvek?"
+msgstr "Jak mohu nahlásit nevhodnou recenzi uživatele či nevyžádaný příspěvek?"
 
-#: src/olympia/pages/templates/pages/faq.html:237
+#: src/olympia/pages/templates/pages/faq.html:235
 msgid ""
-"To report a user review of an add-on, log in with your account and visit the"
-" add-on's reviews page. Find the review you wish to report, click \"Report "
-"this review\" and select a reason. Our editorial team will investigate the "
-"review and take appropriate action."
+"To report a user review of an add-on, log in with your account and visit the add-on's reviews page. Find the review you wish to report, click \"Report this review\" and select a reason. Our "
+"editorial team will investigate the review and take appropriate action."
 msgstr ""
-"Pro nahlášení uživatelské recenze doplňku se přihlaste ke svému účtu a "
-"navštivte stránku s recenzemi doplňku. Nalezněte recenzi, kterou si přejete "
-"nahlásit, klepněte na odkaz \"Nahlásit recenzi\" a zvolte důvod. Náš tým "
-"redaktorů se poté bude touto recenzí zabývat a provede odpovídající reakci."
+"Pro nahlášení uživatelské recenze doplňku se přihlaste ke svému účtu a navštivte stránku s recenzemi doplňku. Nalezněte recenzi, kterou si přejete nahlásit, klepněte na odkaz \"Nahlásit recenzi\" a"
+" zvolte důvod. Náš tým redaktorů se poté bude touto recenzí zabývat a provede odpovídající reakci."
 
-#: src/olympia/pages/templates/pages/faq.html:242
+#: src/olympia/pages/templates/pages/faq.html:240
 #, fuzzy
 msgid "How do I report a bug or contact the Mozilla Add-ons team?"
 msgstr "Jak mohu nahlásit chybu či kontaktovat tým serveru Doplňky Mozilly?"
 
-#: src/olympia/pages/templates/pages/faq.html:243
+#: src/olympia/pages/templates/pages/faq.html:241
 #, fuzzy, python-format
 msgid "Please visit our <a href=\"%(contact_url)s\">Contact page</a>."
 msgstr "Navštivte prosím naši <a href=\"%(contact_url)s\">kontaktní stránku</a>."
 
-#: src/olympia/pages/templates/pages/faq.html:246
+#: src/olympia/pages/templates/pages/faq.html:244
 #, fuzzy
 msgid "What is a Source Code License?"
 msgstr "Pod jakou licencí je zdrojový kód dostupný?"
 
-#: src/olympia/pages/templates/pages/faq.html:247
+#: src/olympia/pages/templates/pages/faq.html:245
 #, python-format
 msgid ""
-"The source code used to create an add-on is an exclusive copyright of the "
-"add-on author, unless otherwise declared in a source code license. Many add-"
-"ons on this site have <a href=\"%(url)s\" lang=\"en\">open source "
-"licenses</a> that make the source code publicly available for copy and reuse"
-" under conditions determined by the author. Most authors choose widely known"
-" open source licenses like the GPL or BSD licenses instead of making up "
-"their own."
+"The source code used to create an add-on is an exclusive copyright of the add-on author, unless otherwise declared in a source code license. Many add-ons on this site have <a href=\"%(url)s\" "
+"lang=\"en\">open source licenses</a> that make the source code publicly available for copy and reuse under conditions determined by the author. Most authors choose widely known open source licenses"
+" like the GPL or BSD licenses instead of making up their own."
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:256
+#: src/olympia/pages/templates/pages/faq.html:254
 #, fuzzy, python-format
-msgid ""
-"Firefox and other Mozilla software are <a href=\"%(url)s\">open source</a>."
-msgstr ""
-"Firefox a ostatní aplikace Mozilla jsou <a href=\"%(url)s\">open source</a>."
+msgid "Firefox and other Mozilla software are <a href=\"%(url)s\">open source</a>."
+msgstr "Firefox a ostatní aplikace Mozilla jsou <a href=\"%(url)s\">open source</a>."
 
-#: src/olympia/pages/templates/pages/faq.html:264
+#: src/olympia/pages/templates/pages/faq.html:262
 msgid "Collections and Favorites"
 msgstr "Kolekcie a obľúbené"
 
-#: src/olympia/pages/templates/pages/faq.html:267
+#: src/olympia/pages/templates/pages/faq.html:265
 msgid "What is a collection?"
 msgstr "Čo je kolekcia?"
 
-#: src/olympia/pages/templates/pages/faq.html:268
+#: src/olympia/pages/templates/pages/faq.html:266
 msgid "Collections are groups of related add-ons created by users to share."
-msgstr ""
-"Kolekcie sú skupiny podobných doplnkov, ktoré boli vytvorené používateľmi za"
-" účelom ich zdieľania."
+msgstr "Kolekcie sú skupiny podobných doplnkov, ktoré boli vytvorené používateľmi za účelom ich zdieľania."
 
-#: src/olympia/pages/templates/pages/faq.html:270
+#: src/olympia/pages/templates/pages/faq.html:268
 msgid "What is the My Favorites collection?"
 msgstr "Čo je kolekcia Moje obľúbené doplnky?"
 
-#: src/olympia/pages/templates/pages/faq.html:271
+#: src/olympia/pages/templates/pages/faq.html:269
 #, fuzzy
-msgid ""
-"Favorite add-ons are add-ons that you have bookmarked to easily get back to "
-"later. You can add an add-on to your favorites collection by clicking \"Add "
-"to favorites\" on its details page."
-msgstr ""
-"Oblíbené doplňky jsou doplňky, které jste si přidali do záložek pro pozdější"
-" snadné nalezení. Doplněk můžete přidat do své oblíbené sbírky klepnutím na "
-"\"Přidat do oblíbených\" na stránce doplňku."
+msgid "Favorite add-ons are add-ons that you have bookmarked to easily get back to later. You can add an add-on to your favorites collection by clicking \"Add to favorites\" on its details page."
+msgstr "Oblíbené doplňky jsou doplňky, které jste si přidali do záložek pro pozdější snadné nalezení. Doplněk můžete přidat do své oblíbené sbírky klepnutím na \"Přidat do oblíbených\" na stránce doplňku."
 
-#: src/olympia/pages/templates/pages/faq.html:275
-#: src/olympia/templates/menu_links.html:13
-#: src/olympia/templates/impala/header_title.html:17
+#: src/olympia/pages/templates/pages/faq.html:273 src/olympia/templates/menu_links.html:13 src/olympia/templates/impala/header_title.html:17
 msgid "Mobile Add-ons"
 msgstr "Doplnky pre mobilný Firefox"
 
-#: src/olympia/pages/templates/pages/faq.html:278
+#: src/olympia/pages/templates/pages/faq.html:276
 msgid "What are mobile add-ons?"
 msgstr "Čo sú to mobilné doplnky?"
 
-#: src/olympia/pages/templates/pages/faq.html:279
+#: src/olympia/pages/templates/pages/faq.html:277
 #, fuzzy, python-format
 msgid ""
-"Mobile add-ons work with <a href=\"%(mobile_url)s\">Firefox for Mobile</a> "
-"and add or modify functionality just like desktop add-ons. You can find add-"
-"ons that work with Firefox for Mobile in our <a "
-"href=\"%(gallery_url)s\">gallery</a>."
+"Mobile add-ons work with <a href=\"%(mobile_url)s\">Firefox for Mobile</a> and add or modify functionality just like desktop add-ons. You can find add-ons that work with Firefox for Mobile in our "
+"<a href=\"%(gallery_url)s\">gallery</a>."
 msgstr ""
-"Mobilní doplňky fungují ve <a href=\"%(mobile_url)s\">Firefoxu pro mobilní "
-"zařízení</a> a přidávají či upravují funkcionalitu stejným způsobem, jako "
-"doplňky pro desktopovou verzi. Doplňky, které fungují ve Firefoxu pro "
-"mobilní zařízení, můžete nalézt v <a href=\"%(gallery_url)s\">naší "
-"galerii</a>."
+"Mobilní doplňky fungují ve <a href=\"%(mobile_url)s\">Firefoxu pro mobilní zařízení</a> a přidávají či upravují funkcionalitu stejným způsobem, jako doplňky pro desktopovou verzi. Doplňky, které "
+"fungují ve Firefoxu pro mobilní zařízení, můžete nalézt v <a href=\"%(gallery_url)s\">naší galerii</a>."
 
-#: src/olympia/pages/templates/pages/faq.html:288
+#: src/olympia/pages/templates/pages/faq.html:286
 msgid "Developer Topics"
 msgstr "Témy pre vývojárov"
 
-#: src/olympia/pages/templates/pages/faq.html:289
+#: src/olympia/pages/templates/pages/faq.html:287
 #, python-format
-msgid ""
-"Please see our <a href=\"%(faq_url)s\">Developer FAQ</a> and <a "
-"href=\"%(hub_url)s\">Developer Hub</a> for answers to add-on developer-"
-"related questions."
+msgid "Please see our <a href=\"%(faq_url)s\">Developer FAQ</a> and <a href=\"%(hub_url)s\">Developer Hub</a> for answers to add-on developer-related questions."
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:294
+#: src/olympia/pages/templates/pages/faq.html:292
 msgid "Still have questions?"
 msgstr "Máte ďalšie otázky?"
 
-#: src/olympia/pages/templates/pages/faq.html:295
+#: src/olympia/pages/templates/pages/faq.html:293
 #, fuzzy, python-format
-msgid ""
-"For general Firefox support, visit our <a href=\"%(sumo_url)s\">support "
-"website</a>. For general add-on and website questions, visit our <a "
-"href=\"%(forum_url)s\">forum</a>."
-msgstr ""
-"Pro obecnou podporu Firefoxu navšivte naše <a href=\"%(sumo_url)s\">stránky "
-"podpory</a>. Pro obecné otázky týkající se doplňků a tohoto webu navšivte <a"
-" href=\"%(forum_url)s\">naše fórum</a>."
+msgid "For general Firefox support, visit our <a href=\"%(sumo_url)s\">support website</a>. For general add-on and website questions, visit our <a href=\"%(forum_url)s\">forum</a>."
+msgstr "Pro obecnou podporu Firefoxu navšivte naše <a href=\"%(sumo_url)s\">stránky podpory</a>. Pro obecné otázky týkající se doplňků a tohoto webu navšivte <a href=\"%(forum_url)s\">naše fórum</a>."
 
-#: src/olympia/pages/templates/pages/review_guide.html:36
-#: src/olympia/pages/templates/pages/review_guide.html:51
+#: src/olympia/pages/templates/pages/review_guide.html:36 src/olympia/pages/templates/pages/review_guide.html:51
 #, fuzzy
 msgid "Some tips for writing a great review"
 msgstr "Několik tipů pro psaní skvělých recenzí"
 
-#: src/olympia/pages/templates/pages/review_guide.html:39
-#: src/olympia/pages/templates/pages/review_guide.html:131
+#: src/olympia/pages/templates/pages/review_guide.html:39 src/olympia/pages/templates/pages/review_guide.html:131
 #, fuzzy
 msgid "Frequently Asked Questions about Reviews"
 msgstr "Často kladené otázky k recenzím"
 
 #: src/olympia/pages/templates/pages/review_guide.html:46
 msgid ""
-"Add-on reviews are a way for you to share your opinions about the add-ons "
-"you’ve installed and used. Our review moderation team reserves the right to "
-"refuse or remove any review that does not comply with these guidelines."
+"Add-on reviews are a way for you to share your opinions about the add-ons you’ve installed and used. Our review moderation team reserves the right to refuse or remove any review that does not "
+"comply with these guidelines."
 msgstr ""
 
 #: src/olympia/pages/templates/pages/review_guide.html:53
@@ -13132,8 +10494,7 @@ msgid "Do:"
 msgstr "Píšte:"
 
 #: src/olympia/pages/templates/pages/review_guide.html:56
-msgid ""
-"Write like you are telling a friend about your experience with the add-on."
+msgid "Write like you are telling a friend about your experience with the add-on."
 msgstr ""
 
 #: src/olympia/pages/templates/pages/review_guide.html:61
@@ -13165,8 +10526,7 @@ msgid "Will you continue to use this add-on?"
 msgstr "Budete doplnok aj naďalej používať?"
 
 #: src/olympia/pages/templates/pages/review_guide.html:73
-msgid ""
-"Take a moment to read your review before submitting it to minimize typos."
+msgid "Take a moment to read your review before submitting it to minimize typos."
 msgstr ""
 
 #: src/olympia/pages/templates/pages/review_guide.html:79
@@ -13179,9 +10539,8 @@ msgstr ""
 
 #: src/olympia/pages/templates/pages/review_guide.html:87
 msgid ""
-"Post technical issues, support requests, or feature suggestions. Use the "
-"available support options for each add-on, if available. You can find them "
-"in the side column next to the About this Add-on section."
+"Post technical issues, support requests, or feature suggestions. Use the available support options for each add-on, if available. You can find them in the side column next to the About this Add-on "
+"section."
 msgstr ""
 
 #: src/olympia/pages/templates/pages/review_guide.html:92
@@ -13191,42 +10550,31 @@ msgstr "Psát recenze k doplňkům, které osobně nepoužíváte."
 
 #: src/olympia/pages/templates/pages/review_guide.html:97
 #, fuzzy
-msgid ""
-"Use profanity, sexual language or language that can be construed as hateful."
+msgid "Use profanity, sexual language or language that can be construed as hateful."
 msgstr "Používat hrubý, sexuálně orientovaný či jinak nevhodný jazyk."
 
 #: src/olympia/pages/templates/pages/review_guide.html:103
-msgid ""
-"Include HTML, links, source code or code snippets. Reviews are meant to be "
-"text only."
+msgid "Include HTML, links, source code or code snippets. Reviews are meant to be text only."
 msgstr ""
 
 #: src/olympia/pages/templates/pages/review_guide.html:108
 #, fuzzy
-msgid ""
-"Make false statements, disparage add-on authors or personally insult them."
-msgstr ""
-"Psát nepravdivé informace, zlehčovat autory doplňků či je osobně urážet."
+msgid "Make false statements, disparage add-on authors or personally insult them."
+msgstr "Psát nepravdivé informace, zlehčovat autory doplňků či je osobně urážet."
 
 #: src/olympia/pages/templates/pages/review_guide.html:114
-msgid ""
-"Include your own or anyone else’s email, phone number, or other personal "
-"details."
+msgid "Include your own or anyone else’s email, phone number, or other personal details."
 msgstr ""
 
 #: src/olympia/pages/templates/pages/review_guide.html:119
 #, fuzzy
-msgid ""
-"Post reviews for an add-on you or your organization wrote or represent."
-msgstr ""
-"Přidávat recenze ke svému doplňku či organizaci, kterou reprezentujete."
+msgid "Post reviews for an add-on you or your organization wrote or represent."
+msgstr "Přidávat recenze ke svému doplňku či organizaci, kterou reprezentujete."
 
 #: src/olympia/pages/templates/pages/review_guide.html:125
 msgid ""
-"Criticize an add-on for something it’s intended to do. For example, leaving "
-"a negative review of an add-on for displaying ads or requiring data "
-"gathering, when that is the intended purpose of the add-on, or the add-on "
-"requires gathering data to function."
+"Criticize an add-on for something it’s intended to do. For example, leaving a negative review of an add-on for displaying ads or requiring data gathering, when that is the intended purpose of the "
+"add-on, or the add-on requires gathering data to function."
 msgstr ""
 
 #: src/olympia/pages/templates/pages/review_guide.html:133
@@ -13236,10 +10584,8 @@ msgstr "Jak mohu nahlásit problematickou recenzi?"
 
 #: src/olympia/pages/templates/pages/review_guide.html:135
 msgid ""
-"Please report or flag any questionable reviews by clicking the \"Report this"
-" review\" and it will be submitted to the site for moderation. Our "
-"moderation team will use the Review Guidelines to evaluate whether or not to"
-" delete the review or restore it back to the site."
+"Please report or flag any questionable reviews by clicking the \"Report this review\" and it will be submitted to the site for moderation. Our moderation team will use the Review Guidelines to "
+"evaluate whether or not to delete the review or restore it back to the site."
 msgstr ""
 
 #: src/olympia/pages/templates/pages/review_guide.html:140
@@ -13249,10 +10595,7 @@ msgstr "Jsem autor doplňku, mohu odpovídat na recenze?"
 
 #: src/olympia/pages/templates/pages/review_guide.html:142
 #, python-format
-msgid ""
-"Yes, add-on authors can provide a single response to a review. You can set "
-"up a discussion topic in our <a href=\"%(forum_url)s\">forum</a> to engage "
-"in additional discussion or follow-up."
+msgid "Yes, add-on authors can provide a single response to a review. You can set up a discussion topic in our <a href=\"%(forum_url)s\">forum</a> to engage in additional discussion or follow-up."
 msgstr ""
 
 #: src/olympia/pages/templates/pages/review_guide.html:149
@@ -13262,11 +10605,8 @@ msgstr "Jsem autor doplňku, mohu smazat nepravdivé recenze či hodnocení?"
 
 #: src/olympia/pages/templates/pages/review_guide.html:151
 msgid ""
-"In general, no. But if the review did not meet the review guidelines "
-"outlined above, you can click \"Report this review\" and have it moderated. "
-"If a review included a complaint that is no longer valid due to a new "
-"release of your add-on, we may consider deleting the review. Submit your "
-"detailed request to amo-editors@mozilla.org."
+"In general, no. But if the review did not meet the review guidelines outlined above, you can click \"Report this review\" and have it moderated. If a review included a complaint that is no longer "
+"valid due to a new release of your add-on, we may consider deleting the review. Submit your detailed request to amo-editors@mozilla.org."
 msgstr ""
 
 #: src/olympia/pages/templates/pages/sunbird.html:26
@@ -13275,24 +10615,16 @@ msgstr "Vývoj Sunbirdu bol ukončený"
 
 #: src/olympia/pages/templates/pages/sunbird.html:29
 msgid ""
-"Development on the Sunbird project has halted and its final release was on "
-"March 30, 2010. We've been proud to host Sunbird add-ons on this site but as"
-" the project is no longer maintained we have disabled our support for the "
-"add-ons."
+"Development on the Sunbird project has halted and its final release was on March 30, 2010. We've been proud to host Sunbird add-ons on this site but as the project is no longer maintained we have "
+"disabled our support for the add-ons."
 msgstr ""
-"Vývoj projektu Sunbird bol ukončený a jeho finálna verzia vyšla 30. marca "
-"2010. Sme pyšní, že sme mohli hosťovať doplnky Sunbirdu na tomto webe, ale "
-"projekt už nie je dlhodobo spravovaný, takže sme podporu pre doplnky tohto "
-"projektu ukončili."
+"Vývoj projektu Sunbird bol ukončený a jeho finálna verzia vyšla 30. marca 2010. Sme pyšní, že sme mohli hosťovať doplnky Sunbirdu na tomto webe, ale projekt už nie je dlhodobo spravovaný, takže sme"
+" podporu pre doplnky tohto projektu ukončili."
 
 #: src/olympia/pages/templates/pages/sunbird.html:38
 #, python-format
-msgid ""
-"We recommend upgrading to <a href=\"%(tb_url)s\">Thunderbird</a> and <a "
-"href=\"%(lightning_url)s\">Lightning</a>."
-msgstr ""
-"Doporučujeme aktualizovať na <a href=\"%(tb_url)s\">Thunderbird</a> a <a "
-"href=\"%(lightning_url)s\">Lightning</a>."
+msgid "We recommend upgrading to <a href=\"%(tb_url)s\">Thunderbird</a> and <a href=\"%(lightning_url)s\">Lightning</a>."
+msgstr "Doporučujeme aktualizovať na <a href=\"%(tb_url)s\">Thunderbird</a> a <a href=\"%(lightning_url)s\">Lightning</a>."
 
 #: src/olympia/pages/templates/pages/sunbird.html:45
 msgid "Read more about Sunbird"
@@ -13300,8 +10632,7 @@ msgstr "Dozvedieť sa viac o Sunbirde"
 
 #: src/olympia/paypal/__init__.py:25
 msgid "There was an error communicating with PayPal. Please try again later."
-msgstr ""
-"Pri komunikácii so službou PayPal sa vyskytla chyba. Skúste to neskôr."
+msgstr "Pri komunikácii so službou PayPal sa vyskytla chyba. Skúste to neskôr."
 
 #: src/olympia/paypal/__init__.py:50
 #, fuzzy
@@ -13347,8 +10678,7 @@ msgstr "Ponechať recenziu, odstrániť označenia"
 msgid "Skip for now"
 msgstr "Teraz preskočiť"
 
-#: src/olympia/reviews/forms.py:151
-#: src/olympia/reviews/templates/reviews/review.html:107
+#: src/olympia/reviews/forms.py:151 src/olympia/reviews/templates/reviews/review.html:107
 msgid "Delete review"
 msgstr "Odstrániť recenziu"
 
@@ -13367,27 +10697,18 @@ msgstr "Pridanie recenzie doplnku {0}"
 #: src/olympia/reviews/templates/reviews/add.html:26
 #, python-format
 msgid ""
-"<h2>Keep these tips in mind:</h2> <ul> <li> Write like you're telling a "
-"friend about your experience with the add-on. Give specifics and helpful "
-"details, such as what features you liked and/or disliked, how easy to use it"
-" is, and any disadvantages it has.  Avoid generic language such as calling "
-"it \"Great\" or \"Bad\" unless you can give reasons why you believe this is "
-"so. </li> <li> Please do not post bug reports in reviews. We do not make "
-"your email address available to add-on developers and they may need to "
-"contact you to help resolve your issue. See the <a "
-"href=\"%(support)s\">support section</a> to find out where to get assistance"
-" for this add-on. </li> <li>Please keep reviews clean, avoid the use of "
-"improper language and do not post any personal information. </li> </ul> "
-"<p>Please read the <a href=\"%(guide)s\" target=\"_blank\">Review "
-"Guidelines</a> for more detail about user add-on reviews.</p>"
+"<h2>Keep these tips in mind:</h2> <ul> <li> Write like you're telling a friend about your experience with the add-on. Give specifics and helpful details, such as what features you liked and/or "
+"disliked, how easy to use it is, and any disadvantages it has. Avoid generic language such as calling it \"Great\" or \"Bad\" unless you can give reasons why you believe this is so. </li> <li> "
+"Please do not post bug reports in reviews. We do not make your email address available to add-on developers and they may need to contact you to help resolve your issue. See the <a "
+"href=\"%(support)s\">support section</a> to find out where to get assistance for this add-on. </li> <li>Please keep reviews clean, avoid the use of improper language and do not post any personal "
+"information. </li> </ul> <p>Please read the <a href=\"%(guide)s\" target=\"_blank\">Review Guidelines</a> for more detail about user add-on reviews.</p>"
 msgstr ""
 
 #: src/olympia/reviews/templates/reviews/reply.html:4
 msgid "Reply to review by {0}"
 msgstr "Odpovedať na recenziu od {0}"
 
-#: src/olympia/reviews/templates/reviews/reply.html:15
-#: src/olympia/reviews/templates/reviews/reply.html:31
+#: src/olympia/reviews/templates/reviews/reply.html:15 src/olympia/reviews/templates/reviews/reply.html:31
 msgid "Reply"
 msgstr "Odpovedať"
 
@@ -13395,8 +10716,7 @@ msgstr "Odpovedať"
 msgid "Write a Reply"
 msgstr "Napíšte odpoveď:"
 
-#: src/olympia/reviews/templates/reviews/reply.html:36
-#: src/olympia/reviews/templates/reviews/report_review.html:12
+#: src/olympia/reviews/templates/reviews/reply.html:36 src/olympia/reviews/templates/reviews/report_review.html:12
 msgid "Submit"
 msgstr "Odoslať"
 
@@ -13416,37 +10736,21 @@ msgid "by %(user)s <b>(Developer)</b> on %(date)s"
 msgstr "autor %(user)s <b>(vývojár)</b> dňa %(date)s"
 
 #. {0} is a version number (like 1.01)
-#: src/olympia/reviews/templates/reviews/review.html:50
-#: src/olympia/reviews/templates/reviews/mobile/review_list.html:41
+#: src/olympia/reviews/templates/reviews/review.html:50 src/olympia/reviews/templates/reviews/mobile/review_list.html:41
 msgid "This review is for a previous version of the add-on ({0})."
 msgstr "Táto recenzia je pre predchádzajúcu verziu doplnku ({0})."
 
 #: src/olympia/reviews/templates/reviews/review.html:56
 #, python-format
-msgid ""
-"This user has a <a href=\"%(user_review_url)s\">previous review</a> of this "
-"add-on."
-msgid_plural ""
-"This user has <a href=\"%(user_review_url)s\">%(cnt)s previous reviews</a> "
-"of this add-on."
-msgstr[0] ""
-"Tento používateľ má <a href=\"%(user_review_url)s\">predchádzajúcu "
-"kontrolu</a> tohto doplnku."
-msgstr[1] ""
-"Tento používateľ má <a href=\"%(user_review_url)s\">%(cnt)s predchádzajúce "
-"kontroly</a> tohto doplnku."
-msgstr[2] ""
-"Tento používateľ má <a href=\"%(user_review_url)s\">%(cnt)s predchádzajúcich"
-" kontrol</a> tohto doplnku."
+msgid "This user has a <a href=\"%(user_review_url)s\">previous review</a> of this add-on."
+msgid_plural "This user has <a href=\"%(user_review_url)s\">%(cnt)s previous reviews</a> of this add-on."
+msgstr[0] "Tento používateľ má <a href=\"%(user_review_url)s\">predchádzajúcu kontrolu</a> tohto doplnku."
+msgstr[1] "Tento používateľ má <a href=\"%(user_review_url)s\">%(cnt)s predchádzajúce kontroly</a> tohto doplnku."
 
 #: src/olympia/reviews/templates/reviews/review.html:62
 #, python-format
-msgid ""
-"This user has <a href=\"%(user_review_url)s\">other reviews</a> of this add-"
-"on."
-msgstr ""
-"Tento používateľ má <a href=\"%(user_review_url)s\">ďalšie recenzie</a> "
-"tohto doplnku."
+msgid "This user has <a href=\"%(user_review_url)s\">other reviews</a> of this add-on."
+msgstr "Tento používateľ má <a href=\"%(user_review_url)s\">ďalšie recenzie</a> tohto doplnku."
 
 #: src/olympia/reviews/templates/reviews/review.html:72
 msgid "Flagged for review"
@@ -13478,9 +10782,7 @@ msgid "{0} :: Reviews"
 msgstr "{0} :: Recenzie"
 
 #. {0} is an addon name.
-#: src/olympia/reviews/templates/reviews/review_list.html:24
-#: src/olympia/reviews/templates/reviews/mobile/add.html:4
-#: src/olympia/reviews/templates/reviews/mobile/review_list.html:4
+#: src/olympia/reviews/templates/reviews/review_list.html:24 src/olympia/reviews/templates/reviews/mobile/add.html:4 src/olympia/reviews/templates/reviews/mobile/review_list.html:4
 msgid "Reviews for {0}"
 msgstr "Recenzie doplnku {0}"
 
@@ -13490,7 +10792,6 @@ msgid "<b>{0}</b> review for this add-on"
 msgid_plural "<b>{0}</b> reviews for this add-on"
 msgstr[0] "<b>{0}</b> recenzia pre tento doplnok"
 msgstr[1] "<b>{0}</b> recenzie pre tento doplnok"
-msgstr[2] "<b>{0}</b> recenzí pre tento doplnok"
 
 #. {0} is a developer's name.
 #: src/olympia/reviews/templates/reviews/review_list.html:33
@@ -13503,7 +10804,6 @@ msgid "Review for %(addon)s by %(user)s"
 msgid_plural "Reviews for %(addon)s by %(user)s"
 msgstr[0] "Recenzia doplnku %(addon)s od %(user)s"
 msgstr[1] "Recenzie doplnku %(addon)s od %(user)s"
-msgstr[2] "Recenzie doplnku %(addon)s od %(user)s"
 
 #: src/olympia/reviews/templates/reviews/review_list.html:42
 msgid "No reviews found."
@@ -13518,8 +10818,7 @@ msgstr "<strong>Priemer</strong> (%(total)s)"
 msgid "Write a New Review"
 msgstr "Napísať novú recenziu"
 
-#: src/olympia/reviews/templates/reviews/review_list.html:81
-#: src/olympia/reviews/templates/reviews/mobile/reviews_link.html:15
+#: src/olympia/reviews/templates/reviews/review_list.html:81 src/olympia/reviews/templates/reviews/mobile/reviews_link.html:15
 msgid "Be the first to write a review."
 msgstr "Buďte prvý, kto napíše recenziu."
 
@@ -13528,7 +10827,6 @@ msgid "{num} review"
 msgid_plural "{num} reviews"
 msgstr[0] "{num} recenzia"
 msgstr[1] "{num} recenzie"
-msgstr[2] "{num} recenzií"
 
 # 87%
 #: src/olympia/reviews/templates/reviews/impala/reviews_rating.html:1
@@ -13541,8 +10839,7 @@ msgid "Rated %(rating)s out of 5 stars"
 msgstr "Ohodnotené %(rating)s z 5 hviezdičiek"
 
 # 75%
-#: src/olympia/reviews/templates/reviews/mobile/add_form.html:3
-#: src/olympia/reviews/templates/reviews/mobile/add_form.html:8
+#: src/olympia/reviews/templates/reviews/mobile/add_form.html:3 src/olympia/reviews/templates/reviews/mobile/add_form.html:8
 msgid "Add a Review"
 msgstr "Pridať recenziu"
 
@@ -13559,7 +10856,6 @@ msgid "Average from {0} Rating"
 msgid_plural "Average from {0} Ratings"
 msgstr[0] "Priemer z {0} hodnotenia"
 msgstr[1] "Priemer z {0} hodnotení"
-msgstr[2] "Priemer z {0} hodnotení"
 
 #: src/olympia/reviews/templates/reviews/mobile/review_list.html:34
 #, python-format
@@ -13576,7 +10872,6 @@ msgid "See All Reviews"
 msgid_plural "See All %(cnt)s Reviews"
 msgstr[0] "Zobraziť recenziu"
 msgstr[1] "Zobraziť %(cnt)s recenzie"
-msgstr[2] "Zobraziť %(cnt)s recenzií"
 
 #: src/olympia/search/forms.py:11
 msgid "Most popular this week"
@@ -13615,10 +10910,8 @@ msgid "Relevance"
 msgstr "Relevantnosť"
 
 #: src/olympia/search/helpers.py:24
-msgid ""
-"Results <strong>{0}</strong>-<strong>{1}</strong> of <strong>{2}</strong>"
-msgstr ""
-"Výsledky <strong>{0}</strong>-<strong>{1}</strong> z <strong>{2}</strong>"
+msgid "Results <strong>{0}</strong>-<strong>{1}</strong> of <strong>{2}</strong>"
+msgstr "Výsledky <strong>{0}</strong>-<strong>{1}</strong> z <strong>{2}</strong>"
 
 # {0} is a number
 # {1} is a number
@@ -13626,12 +10919,8 @@ msgstr ""
 # {3} is the word the person is searching for
 # {4} is a word (the add-on is tagged with it)
 #: src/olympia/search/helpers.py:44
-msgid ""
-"Showing {0} - {1} of {2} results for <strong>{3}</strong> tagged with "
-"<strong>{4}</strong>"
-msgstr ""
-"Zobrazuje sa {0} - {1} z {2} výsledkov hľadania výrazu <strong>{3}</strong> "
-"označených značkou <strong>{4}</strong>"
+msgid "Showing {0} - {1} of {2} results for <strong>{3}</strong> tagged with <strong>{4}</strong>"
+msgstr "Zobrazuje sa {0} - {1} z {2} výsledkov hľadania výrazu <strong>{3}</strong> označených značkou <strong>{4}</strong>"
 
 # {0} is a number
 # {1} is a number
@@ -13639,8 +10928,7 @@ msgstr ""
 # {3} is the word the person is searching for
 #: src/olympia/search/helpers.py:49
 msgid "Showing {0} - {1} of {2} results for <strong>{3}</strong>"
-msgstr ""
-"Zobrazuje sa {0} - {1} z {2} výsledkov hľadania výrazu <strong>{3}</strong>"
+msgstr "Zobrazuje sa {0} - {1} z {2} výsledkov hľadania výrazu <strong>{3}</strong>"
 
 # {0} is a number
 # {1} is a number
@@ -13648,9 +10936,7 @@ msgstr ""
 # {3} is a word (the add-on is tagged with it)
 #: src/olympia/search/helpers.py:52
 msgid "Showing {0} - {1} of {2} results tagged with <strong>{3}</strong>"
-msgstr ""
-"Zobrazuje sa {0} - {1} z {2} výsledkov označených značkou "
-"<strong>{3}</strong>"
+msgstr "Zobrazuje sa {0} - {1} z {2} výsledkov označených značkou <strong>{3}</strong>"
 
 # {0} is a number
 # {1} is a number
@@ -13660,24 +10946,22 @@ msgid "Showing {0} - {1} of {2} results"
 msgstr "Zobrazuje sa {0} - {1} z {2} výsledkov"
 
 #. {0} is an application, like Firefox.
-#: src/olympia/search/views.py:264 src/olympia/templates/base.html:17
-#: src/olympia/templates/impala/base.html:17
-#: src/olympia/templates/mobile/base_addons.html:17
+#: src/olympia/search/views.py:264 src/olympia/templates/base.html:17 src/olympia/templates/impala/base.html:17 src/olympia/templates/mobile/base_addons.html:17
 msgid "{0} Add-ons"
 msgstr "Doplnky pre {0}"
 
 #. L10n: {0} is an application, such as Firefox. This means "any version of
 #. Firefox."
-#: src/olympia/search/views.py:554
+#: src/olympia/search/views.py:547
 msgid "Any {0}"
 msgstr "Ľubovolný {0}"
 
 #. L10n: "All Systems" means show everything regardless of platform.
-#: src/olympia/search/views.py:589
+#: src/olympia/search/views.py:582
 msgid "All Systems"
 msgstr "Všetky systémy"
 
-#: src/olympia/search/views.py:600
+#: src/olympia/search/views.py:593
 msgid "All Tags"
 msgstr "Všetky značky"
 
@@ -13696,9 +10980,7 @@ msgstr "Vyhľadávanie nie je dostupné"
 
 #: src/olympia/search/templates/search/down.html:6
 msgid "Search is temporarily unavailable. Please try again in a few minutes."
-msgstr ""
-"Vyhľadávanie je dočasne nedostupné. Vyskúšajte to prosím znova o niekoľko "
-"minút."
+msgstr "Vyhľadávanie je dočasne nedostupné. Vyskúšajte to prosím znova o niekoľko minút."
 
 #. {0} is the string the user was searching for
 #: src/olympia/search/templates/search/personas.html:9
@@ -13724,7 +11006,6 @@ msgid "<b>{0}</b> matching result"
 msgid_plural "<b>{0}</b> matching results"
 msgstr[0] "<b>{0}</b> výsledok hľadania"
 msgstr[1] "<b>{0}</b> výsledky hľadania"
-msgstr[2] "<b>{0}</b> výsledkov hľadania"
 
 #: src/olympia/search/templates/search/results.html:67
 msgid "Filter Results"
@@ -13747,7 +11028,6 @@ msgid "{0} post"
 msgid_plural "{0} posts"
 msgstr[0] "{0} príspevok"
 msgstr[1] "{0} príspevky"
-msgstr[2] "{0} príspevkov"
 
 #: src/olympia/sharing/__init__.py:20
 msgid "Post to Facebook"
@@ -13758,7 +11038,6 @@ msgid "{0} Like"
 msgid_plural "{0} Likes"
 msgstr[0] "{0} like"
 msgstr[1] "{0} liky"
-msgstr[2] "{0} likov"
 
 #: src/olympia/sharing/__init__.py:30
 msgid "Tweet on Twitter"
@@ -13769,7 +11048,6 @@ msgid "{0} tweet"
 msgid_plural "{0} tweets"
 msgstr[0] "{0} príspevok"
 msgstr[1] "{0} príspevky"
-msgstr[2] "{0} príspevkov"
 
 #: src/olympia/sharing/__init__.py:40
 msgid "Share on g+"
@@ -13804,7 +11082,6 @@ msgid "{0} post on localservice1"
 msgid_plural "{0} posts on localservice1"
 msgstr[0] "{0} post on localservice1"
 msgstr[1] "{0} posts on localservice1"
-msgstr[2] "{0} posts on localservice1"
 
 #. L10n: Only change if you have reason! wiki.mozilla.org/AMO:Localizers
 #: src/olympia/sharing/__init__.py:76
@@ -13827,7 +11104,6 @@ msgid "{0} post on localservice2"
 msgid_plural "{0} posts on localservice2"
 msgstr[0] "{0} post on localservice2"
 msgstr[1] "{0} posts on localservice2"
-msgstr[2] "{0} posts on localservice2"
 
 #. L10n: Only change if you have reason! wiki.mozilla.org/AMO:Localizers
 #: src/olympia/sharing/__init__.py:91
@@ -13850,7 +11126,6 @@ msgid "{0} post on localservice3"
 msgid_plural "{0} posts on localservice3"
 msgstr[0] "{0} post on localservice3"
 msgstr[1] "{0} posts on localservice3"
-msgstr[2] "{0} posts on localservice3"
 
 #: src/olympia/sharing/templates/sharing/sharing_widget.html:2
 msgid "Share this Add-on"
@@ -13860,36 +11135,31 @@ msgstr "Zdieľať tento doplnok"
 msgid "Share this Collection"
 msgstr "Zdieľať túto kolekciu"
 
-#: src/olympia/signing/views.py:30 src/olympia/templates/base.html:75
-#: src/olympia/templates/impala/base.html:115
-msgid ""
-"Some features are temporarily disabled while we perform website maintenance."
-" We'll be back to full capacity shortly."
-msgstr ""
-"Niektoré funkcie sú dočasne vypnuté kvôli údržbe stránok. Stránka bude plne "
-"dostupná onedlho."
+#: src/olympia/signing/views.py:33 src/olympia/templates/base.html:71 src/olympia/templates/impala/base.html:112
+msgid "Some features are temporarily disabled while we perform website maintenance. We'll be back to full capacity shortly."
+msgstr "Niektoré funkcie sú dočasne vypnuté kvôli údržbe stránok. Stránka bude plne dostupná onedlho."
 
-#: src/olympia/signing/views.py:53
+#: src/olympia/signing/views.py:56
 msgid "Could not find add-on with id \"{}\"."
 msgstr "Doplnok s id \"{}\" nebol nájdený."
 
-#: src/olympia/signing/views.py:67
+#: src/olympia/signing/views.py:70
 msgid "You do not own this addon."
 msgstr "Nie ste vlastník tohto doplnku.."
 
-#: src/olympia/signing/views.py:82
+#: src/olympia/signing/views.py:87
 msgid "Missing \"upload\" key in multipart file data."
 msgstr ""
 
-#: src/olympia/signing/views.py:96
+#: src/olympia/signing/views.py:101
 msgid "Version does not match the manifest file."
 msgstr ""
 
-#: src/olympia/signing/views.py:100
+#: src/olympia/signing/views.py:105
 msgid "Version already exists."
 msgstr "Táto verzia už existuje."
 
-#: src/olympia/signing/views.py:136
+#: src/olympia/signing/views.py:141
 msgid "No uploaded file for that addon and version."
 msgstr "Pre túto verziu doplnku nebol nahraný žiadny súbor."
 
@@ -13981,8 +11251,7 @@ msgstr "Od"
 msgid "To"
 msgstr "Do"
 
-#: src/olympia/stats/templates/stats/popup.html:27
-#: src/olympia/users/templates/users/pwreset_confirm.html:38
+#: src/olympia/stats/templates/stats/popup.html:27 src/olympia/users/templates/users/pwreset_confirm.html:38
 msgid "Update"
 msgstr "Aktualizovať"
 
@@ -14003,95 +11272,89 @@ msgstr "{0} :: Štatistiky"
 msgid "Statistics Dashboard :: Add-ons for {0}"
 msgstr "Štatistiky :: Doplnky pre {0}"
 
-#: src/olympia/stats/templates/stats/stats.html:30
-msgid "Controls:"
-msgstr "Ovládače:"
-
-#: src/olympia/stats/templates/stats/stats.html:33
-msgid "reset zoom"
-msgstr "obnoviť lupu"
-
-#: src/olympia/stats/templates/stats/stats.html:40
-msgid "Group by:"
-msgstr "Zoskupiť podľa:"
-
-#: src/olympia/stats/templates/stats/stats.html:42
-msgid "day"
-msgstr "deň"
-
-#: src/olympia/stats/templates/stats/stats.html:45
-msgid "week"
-msgstr "týždeň"
-
-#: src/olympia/stats/templates/stats/stats.html:48
-msgid "month"
-msgstr "mesiac"
-
-#: src/olympia/stats/templates/stats/stats.html:54
-msgid "For last:"
-msgstr "Za posledných:"
-
-#: src/olympia/stats/templates/stats/stats.html:57
-msgid "7 days"
-msgstr "7 dní"
-
-#: src/olympia/stats/templates/stats/stats.html:60
-msgid "30 days"
-msgstr "30 dní"
-
-#: src/olympia/stats/templates/stats/stats.html:63
-msgid "90 days"
-msgstr "90 dní"
-
-#: src/olympia/stats/templates/stats/stats.html:66
-msgid "365 days"
-msgstr "365 dní"
-
-#: src/olympia/stats/templates/stats/stats.html:69
-msgid "Custom..."
-msgstr "Vlastné..."
-
 #. {0} is an add-on name
-#: src/olympia/stats/templates/stats/stats.html:88
-#: src/olympia/stats/templates/stats/stats.html:91
+#: src/olympia/stats/templates/stats/stats.html:44 src/olympia/stats/templates/stats/stats.html:47
 msgid "Statistics for {0}"
 msgstr "Štatistika pre {0}"
 
-#: src/olympia/stats/templates/stats/stats.html:94
+#: src/olympia/stats/templates/stats/stats.html:50
 msgid "Statistics Dashboard"
 msgstr "Štatistika"
 
-#: src/olympia/stats/templates/stats/stats.html:104
-msgid ""
-"Statistics processing is currently disabled, so recent data is unavailable. "
-"The statistics are still being collected and this page will be updated soon "
-"with the missing data."
+#: src/olympia/stats/templates/stats/stats.html:57
+msgid "Controls:"
+msgstr "Ovládače:"
+
+#: src/olympia/stats/templates/stats/stats.html:60
+msgid "reset zoom"
+msgstr "obnoviť lupu"
+
+#: src/olympia/stats/templates/stats/stats.html:67
+msgid "Group by:"
+msgstr "Zoskupiť podľa:"
+
+#: src/olympia/stats/templates/stats/stats.html:69
+msgid "day"
+msgstr "deň"
+
+#: src/olympia/stats/templates/stats/stats.html:72
+msgid "week"
+msgstr "týždeň"
+
+#: src/olympia/stats/templates/stats/stats.html:75
+msgid "month"
+msgstr "mesiac"
+
+#: src/olympia/stats/templates/stats/stats.html:81
+msgid "For last:"
+msgstr "Za posledných:"
+
+#: src/olympia/stats/templates/stats/stats.html:84
+msgid "7 days"
+msgstr "7 dní"
+
+#: src/olympia/stats/templates/stats/stats.html:87
+msgid "30 days"
+msgstr "30 dní"
+
+#: src/olympia/stats/templates/stats/stats.html:90
+msgid "90 days"
+msgstr "90 dní"
+
+#: src/olympia/stats/templates/stats/stats.html:93
+msgid "365 days"
+msgstr "365 dní"
+
+#: src/olympia/stats/templates/stats/stats.html:96
+msgid "Custom..."
+msgstr "Vlastné..."
+
+#: src/olympia/stats/templates/stats/stats.html:106
+msgid "Statistics processing is currently disabled, so recent data is unavailable. The statistics are still being collected and this page will be updated soon with the missing data."
 msgstr ""
 
-#: src/olympia/stats/templates/stats/stats.html:110
+#: src/olympia/stats/templates/stats/stats.html:112
 msgid "Loading the latest data&hellip;"
 msgstr "Načítavajú sa najnovšie údaje&hellip;"
 
-#: src/olympia/stats/templates/stats/stats.html:142
-#: src/olympia/stats/templates/stats/reports/overview.html:25
-#: src/olympia/stats/templates/stats/reports/overview.html:37
+#: src/olympia/stats/templates/stats/stats.html:144 src/olympia/stats/templates/stats/reports/overview.html:25 src/olympia/stats/templates/stats/reports/overview.html:37
 #: src/olympia/stats/templates/stats/reports/overview.html:49
 msgid "No data available."
 msgstr "Údaje nie sú dostupné."
 
-#: src/olympia/stats/templates/stats/stats.html:177
+#: src/olympia/stats/templates/stats/stats.html:179
 msgid "This dashboard is currently <b>public</b>."
 msgstr "Táto štatistika je momentálne <b>verejná</b>."
 
-#: src/olympia/stats/templates/stats/stats.html:179
+#: src/olympia/stats/templates/stats/stats.html:181
 msgid "Contribution stats are currently <b>private</b>."
 msgstr "Štatistiky o príspevkoch sú nastavené ako <b>súkromné</b>."
 
-#: src/olympia/stats/templates/stats/stats.html:182
+#: src/olympia/stats/templates/stats/stats.html:184
 msgid "This dashboard is currently <b>private</b>."
 msgstr "Táto štatistika je momentálne <b>súkromná</b>."
 
-#: src/olympia/stats/templates/stats/stats.html:185
+#: src/olympia/stats/templates/stats/stats.html:187
 msgid "Change settings."
 msgstr "Zmeniť nastavenie"
 
@@ -14133,14 +11396,11 @@ msgstr "Ako sa získavajú počty prevzatí?"
 
 #: src/olympia/stats/templates/stats/reports/downloads.html:10
 msgid ""
-"<h2>How are downloads counted?</h2> <p> Download counts are updated every "
-"evening and only include original add-on downloads, not updates. Downloads "
-"can be broken down by the specific source referring the download. </p>"
+"<h2>How are downloads counted?</h2> <p> Download counts are updated every evening and only include original add-on downloads, not updates. Downloads can be broken down by the specific source "
+"referring the download. </p>"
 msgstr ""
-"<h2>Ako sú počítané počty prevzatí?</h2> <p> Počty prevzatí sú aktualizované"
-" každý večer a zahŕňajú len úvodné prevzatie doplnku a nie jeho "
-"aktualizácie. Prevzatia môžu byť zdrojom, z ktorého sú preberané prerušené. "
-"</p>"
+"<h2>Ako sú počítané počty prevzatí?</h2> <p> Počty prevzatí sú aktualizované každý večer a zahŕňajú len úvodné prevzatie doplnku a nie jeho aktualizácie. Prevzatia môžu byť zdrojom, z ktorého sú "
+"preberané prerušené. </p>"
 
 #: src/olympia/stats/templates/stats/reports/locales.html:3
 msgid "User languages by Date"
@@ -14154,8 +11414,7 @@ msgstr "Používané platformy podľa dátumu"
 msgid "<b>{0}</b> Downloads"
 msgstr "<b>{0}</b> prevzatí"
 
-#: src/olympia/stats/templates/stats/reports/overview.html:9
-#: src/olympia/stats/templates/stats/reports/overview.html:13
+#: src/olympia/stats/templates/stats/reports/overview.html:9 src/olympia/stats/templates/stats/reports/overview.html:13
 msgid "Loading..."
 msgstr "Načítava sa..."
 
@@ -14206,33 +11465,17 @@ msgstr "O sledovaní externých zdrojov..."
 #: src/olympia/stats/templates/stats/reports/sources.html:10
 #, python-format
 msgid ""
-"<h2>Tracking external sources</h2> <p> If you link to your add-on's details "
-"page or directly to its file from an external site, such as your blog or "
-"website, you can append a parameter to be tracked as an additional download "
-"source on this page. For example, the following links would appear as "
-"sourced by your blog: <dl> <dt>Add-on Details Page</dt> "
-"<dd>https://addons.mozilla.org/addon/%(slug)s?src=<b>external-blog</b></dd> "
-"<dt>Direct File Link</dt> "
-"<dd>https://addons.mozilla.org/downloads/latest/%(id)s/addon-%(id)s-latest.xpi?src=<b"
-">external-blog</b></dd> </dl> <p> Only src parameters that begin with "
-"\"external-\" will be tracked, up to 61 additional characters. Any text "
-"after \"external-\" can be used to describe the source, such as \"external-"
-"blog\", \"external-sidebar\", \"external-campaign225\", etc. The following "
-"URL-safe characters are allowed: <code>a-z A-Z - . _ ~ %% +</code>"
+"<h2>Tracking external sources</h2> <p> If you link to your add-on's details page or directly to its file from an external site, such as your blog or website, you can append a parameter to be "
+"tracked as an additional download source on this page. For example, the following links would appear as sourced by your blog: <dl> <dt>Add-on Details Page</dt> "
+"<dd>https://addons.mozilla.org/addon/%(slug)s?src=<b>external-blog</b></dd> <dt>Direct File Link</dt> <dd>https://addons.mozilla.org/downloads/latest/%(id)s/addon-%(id)s-latest.xpi?src=<b>external-"
+"blog</b></dd> </dl> <p> Only src parameters that begin with \"external-\" will be tracked, up to 61 additional characters. Any text after \"external-\" can be used to describe the source, such as "
+"\"external-blog\", \"external-sidebar\", \"external-campaign225\", etc. The following URL-safe characters are allowed: <code>a-z A-Z - . _ ~ %% +</code>"
 msgstr ""
-"<h2>Sledovanie externých zdrojov</h2> <p> Ak odkazujete z externého webu na "
-"stránku s informáciami o doplnku či priamo na súbor s doplnkom, môžete "
-"pridať parameter, ktorý vám umožní sledovať zdroje, odkiaľ je doplnok "
-"preberaný. Napríklad môžete použiť nasledujúce odkazy ako zdroj pre svoj "
-"blog: <dl> <dt>Stránka s informáciami o doplnku</dt> "
-"<dd>https://addons.mozilla.org/addon/%(slug)s?src=<b>external-blog</b></dd> "
-"<dt>Priamy odkaz na súbor</dt> "
-"<dd>https://addons.mozilla.org/downloads/latest/%(id)s/addon-%(id)s-latest.xpi?src=<b"
-">external-blog</b></dd> </dl> <p>Sledované budú len zdroje, ktoré začínajú "
-"prefixom \"external-\" a nemajú viac ako 61 ďalších znakov. Akýkoľvek text "
-"za \"external-\" môže byť použitý na popis zdroja (napr. \"external-blog\", "
-"\"external-sidebar\", \"external-campaign225\" atď.). Povolené sú "
-"nasledujúce znaky: <code>a-z A-Z - . _ ~ %% +</code>"
+"<h2>Sledovanie externých zdrojov</h2> <p> Ak odkazujete z externého webu na stránku s informáciami o doplnku či priamo na súbor s doplnkom, môžete pridať parameter, ktorý vám umožní sledovať "
+"zdroje, odkiaľ je doplnok preberaný. Napríklad môžete použiť nasledujúce odkazy ako zdroj pre svoj blog: <dl> <dt>Stránka s informáciami o doplnku</dt> "
+"<dd>https://addons.mozilla.org/addon/%(slug)s?src=<b>external-blog</b></dd> <dt>Priamy odkaz na súbor</dt> <dd>https://addons.mozilla.org/downloads/latest/%(id)s/addon-%(id)s-latest.xpi?src=<b"
+">external-blog</b></dd> </dl> <p>Sledované budú len zdroje, ktoré začínajú prefixom \"external-\" a nemajú viac ako 61 ďalších znakov. Akýkoľvek text za \"external-\" môže byť použitý na popis "
+"zdroja (napr. \"external-blog\", \"external-sidebar\", \"external-campaign225\" atď.). Povolené sú nasledujúce znaky: <code>a-z A-Z - . _ ~ %% +</code>"
 
 #: src/olympia/stats/templates/stats/reports/statuses.html:3
 msgid "Add-on Status by Date"
@@ -14252,18 +11495,14 @@ msgstr "Čo sú to denný používatelia?"
 
 #: src/olympia/stats/templates/stats/reports/usage.html:11
 msgid ""
-"<h2>What are daily users?</h2> <p> Themes installed from this site check for"
-" updates once per day. The total number of these update pings is known as "
-"Active Daily Users, or the total number of people using your theme by day. "
-"</p>"
+"<h2>What are daily users?</h2> <p> Themes installed from this site check for updates once per day. The total number of these update pings is known as Active Daily Users, or the total number of "
+"people using your theme by day. </p>"
 msgstr ""
 
 #: src/olympia/stats/templates/stats/reports/usage.html:20
 msgid ""
-"<h2>What are daily users?</h2> <p> Add-ons downloaded from this site check "
-"for updates once per day. The total number of these update pings is known as"
-" Active Daily Users. Daily users can be broken down by add-on version, "
-"operating system, add-on status, application, and locale. </p>"
+"<h2>What are daily users?</h2> <p> Add-ons downloaded from this site check for updates once per day. The total number of these update pings is known as Active Daily Users. Daily users can be broken"
+" down by add-on version, operating system, add-on status, application, and locale. </p>"
 msgstr ""
 
 #: src/olympia/stats/templates/stats/reports/users_created.html:3
@@ -14274,45 +11513,27 @@ msgstr "Prihlásení používatelia podľa dátumu"
 msgid "Application versions by Date"
 msgstr "Verzie aplikácií podľa dátumu"
 
-#: src/olympia/tags/templates/tags/top_cloud.html:4
-msgid "Top {0} Tags"
-msgstr "Naj značky pre {0}"
-
-#. {0} is the current application name
-#: src/olympia/tags/templates/tags/top_cloud.html:14
-msgid "{0} Top Tags"
-msgstr "Naj značky pre {0}"
-
-#: src/olympia/templates/amo_footer.html:6
-#: src/olympia/templates/includes/lang_switcher.html:2
+#: src/olympia/templates/amo_footer.html:6 src/olympia/templates/includes/lang_switcher.html:2
 msgid "Other languages"
 msgstr "Ďalšie jazyky"
 
-#: src/olympia/templates/base.html:9 src/olympia/templates/impala/base.html:9
-#: src/olympia/templates/mobile/base_addons.html:9
+#: src/olympia/templates/base.html:9 src/olympia/templates/impala/base.html:9 src/olympia/templates/mobile/base_addons.html:9
 msgid "Mozilla Add-ons"
 msgstr "Mozilla Add-ons"
 
-#: src/olympia/templates/base.html:91
-#: src/olympia/templates/impala/base.html:81
+#: src/olympia/templates/base.html:89 src/olympia/templates/impala/base.html:78
 msgid "Find add-ons for other applications"
 msgstr "Hľadať doplnky pre iné aplikácie"
 
-#: src/olympia/templates/base.html:92
-#: src/olympia/templates/impala/base.html:81
+#: src/olympia/templates/base.html:90 src/olympia/templates/impala/base.html:78
 msgid "Other Applications"
 msgstr "Ďalšie programy"
 
-#: src/olympia/templates/base.html:141
-#: src/olympia/templates/impala/base.html:194
-msgid ""
-"To create your own collections, you must have a Mozilla Add-ons account."
-msgstr ""
-"Ak chcete vytvárať svoje vlastné kolekcie, musíte mať zriadený účet Mozilla "
-"Add-ons."
+#: src/olympia/templates/base.html:141 src/olympia/templates/impala/base.html:194
+msgid "To create your own collections, you must have a Mozilla Add-ons account."
+msgstr "Ak chcete vytvárať svoje vlastné kolekcie, musíte mať zriadený účet Mozilla Add-ons."
 
-#: src/olympia/templates/base.html:168
-#: src/olympia/templates/impala/base.html:215
+#: src/olympia/templates/base.html:168 src/olympia/templates/impala/base.html:215
 msgid "Footer logo"
 msgstr "Logo v päte"
 
@@ -14336,14 +11557,12 @@ msgstr "Stav stránky"
 msgid "get to know <b>add-ons</b>"
 msgstr "spoznajte <b>doplnky</b>"
 
-#: src/olympia/templates/footer.html:4
-#: src/olympia/templates/menu_links.html:20
+#: src/olympia/templates/footer.html:4 src/olympia/templates/menu_links.html:20
 msgid "About"
 msgstr "Čo je"
 
 # Link text to the AMO blog.
-#: src/olympia/templates/footer.html:5
-#: src/olympia/templates/menu_links.html:32
+#: src/olympia/templates/footer.html:5 src/olympia/templates/menu_links.html:32
 msgid "Blog"
 msgstr "Blog"
 
@@ -14420,9 +11639,7 @@ msgstr "Právne informácie"
 msgid "Contact Us"
 msgstr "Kontakt"
 
-#: src/olympia/templates/user_login.html:22
-#: src/olympia/users/templates/users/edit.html:31
-#: src/olympia/users/templates/users/includes/navigation.html:12
+#: src/olympia/templates/user_login.html:22 src/olympia/users/templates/users/edit.html:31 src/olympia/users/templates/users/includes/navigation.html:12
 msgid "My Account"
 msgstr "Môj účet"
 
@@ -14430,66 +11647,48 @@ msgstr "Môj účet"
 msgid "Welcome, {0}"
 msgstr "Vitajte, {0}"
 
-#: src/olympia/templates/user_login.html:41
-#: src/olympia/templates/impala/user_login.html:20
+#: src/olympia/templates/user_login.html:41 src/olympia/templates/impala/user_login.html:20
 #, python-format
 msgid "<a href=\"%(reg)s\">Register</a> or <a href=\"%(login)s\">Log in</a>"
-msgstr ""
-"<a href=\"%(reg)s\">Zaregistrujte</a> alebo <a href=\"%(login)s\">prihláste "
-"sa</a>"
+msgstr "<a href=\"%(reg)s\">Zaregistrujte</a> alebo <a href=\"%(login)s\">prihláste sa</a>"
 
-#: src/olympia/templates/impala/base.html:126
+#: src/olympia/templates/impala/base.html:123
 #, python-format
-msgid ""
-"To try the thousands of add-ons available here, download <a "
-"href=\"%(url)s\">Mozilla Firefox</a>, a fast, free way to surf the Web!"
-msgstr ""
-"Ak chcete vyskúšať tisíce doplnkov dostupných na tejto stránke, nainštalujte"
-" si <a href=\"%(url)s\">Mozilla Firefox</a>, rýchly a jednoduchý prehliadač "
-"webu."
+msgid "To try the thousands of add-ons available here, download <a href=\"%(url)s\">Mozilla Firefox</a>, a fast, free way to surf the Web!"
+msgstr "Ak chcete vyskúšať tisíce doplnkov dostupných na tejto stránke, nainštalujte si <a href=\"%(url)s\">Mozilla Firefox</a>, rýchly a jednoduchý prehliadač webu."
 
-#: src/olympia/templates/impala/base.html:138
+#: src/olympia/templates/impala/base.html:135
 #, python-format
-msgid ""
-"Add-ons is switching to Firefox Accounts for login. <a href=\"%(url)s\" "
-"class=\"fxa-login\">Sign in now to transfer your account.</a>"
+msgid "Add-ons is switching to Firefox Accounts for login. <a href=\"%(url)s\" class=\"fxa-login\">Sign in now to transfer your account.</a>"
 msgstr ""
 
 #. {0} is an application, such as Firefox.
-#: src/olympia/templates/impala/base.html:148
+#: src/olympia/templates/impala/base.html:145
 msgid "Welcome to {0} Add-ons."
 msgstr "Víta vás {0} Add-ons."
 
-#: src/olympia/templates/impala/base.html:151
-msgid ""
-"Choose from thousands of extra features and styles to make Firefox your own."
-msgstr ""
-"Vyberte si z tisícov extra funkcií a štýlov a prispôsobte si tak svoj "
-"Firefox."
+#: src/olympia/templates/impala/base.html:148
+msgid "Choose from thousands of extra features and styles to make Firefox your own."
+msgstr "Vyberte si z tisícov extra funkcií a štýlov a prispôsobte si tak svoj Firefox."
 
-#: src/olympia/templates/impala/base.html:156
+#: src/olympia/templates/impala/base.html:153
 #, python-format
 msgid "Add extra features and styles to make %(app)s your own."
-msgstr ""
-"Pridajte si vlastné funkcie a štýly, pomocou ktorých si %(app)s prispôsobíte"
-" podľa seba."
+msgstr "Pridajte si vlastné funkcie a štýly, pomocou ktorých si %(app)s prispôsobíte podľa seba."
 
-#: src/olympia/templates/impala/base.html:164
+#: src/olympia/templates/impala/base.html:161
 msgid "On the go?"
 msgstr "Čo sa deje?"
 
-#: src/olympia/templates/impala/base.html:166
+#: src/olympia/templates/impala/base.html:163
 msgid "Check out our <a class=\"mobile-link\" href=\"#\">Mobile Add-ons site</a>."
-msgstr ""
-"Pozrite si našu <a class=\"mobile-link\" href=\"#\">stránku doplnkov pre "
-"mobilný Firefox</a>."
+msgstr "Pozrite si našu <a class=\"mobile-link\" href=\"#\">stránku doplnkov pre mobilný Firefox</a>."
 
 #: src/olympia/templates/impala/header_title.html:21
 msgid "Android Add-ons"
 msgstr "Doplnky pre Android"
 
-#: src/olympia/templates/includes/forms.html:2
-#: src/olympia/templates/includes/forms.html:6
+#: src/olympia/templates/includes/forms.html:2 src/olympia/templates/includes/forms.html:6
 msgid "required"
 msgstr "vyžadované"
 
@@ -14534,15 +11733,11 @@ msgstr "Navštívte stránky Mozilla"
 msgid "menu"
 msgstr "ponuka"
 
-#: src/olympia/templates/mobile/header_auth.html:7
-#: src/olympia/users/templates/users/register.html:41
-#: src/olympia/users/templates/users/register.html:89
+#: src/olympia/templates/mobile/header_auth.html:7 src/olympia/users/templates/users/register.html:41 src/olympia/users/templates/users/register.html:89
 msgid "Register"
 msgstr "Registrovať"
 
-#: src/olympia/templates/mobile/header_auth.html:8
-#: src/olympia/users/templates/users/login_form.html:41
-#: src/olympia/users/templates/users/pwreset_complete.html:15
+#: src/olympia/templates/mobile/header_auth.html:8 src/olympia/users/templates/users/login_form.html:41 src/olympia/users/templates/users/pwreset_complete.html:15
 #: src/olympia/users/templates/users/mobile/login.html:56
 msgid "Log in"
 msgstr "Prihlásiť sa"
@@ -14553,8 +11748,7 @@ msgstr "Prihlásiť sa"
 msgid "Localize for: <a id=\"change-locale\" href=\"#\">%(dl)s</a>"
 msgstr "Lokalizovať pre: <a id=\"change-locale\" href=\"#\">%(dl)s</a>"
 
-#: src/olympia/translations/templates/translations/trans-menu.html:16
-#: src/olympia/translations/templates/translations/trans-menu.html:29
+#: src/olympia/translations/templates/translations/trans-menu.html:16 src/olympia/translations/templates/translations/trans-menu.html:29
 #, python-format
 msgid "%(title)s <em>&middot; %(lang)s</em>"
 msgstr "%(title)s <em>&middot; %(lang)s</em>"
@@ -14569,12 +11763,8 @@ msgstr "Nové jazyky"
 
 #. {0} is a language name, like 'French'
 #: src/olympia/translations/templates/translations/trans-menu.html:42
-msgid ""
-"You have unsaved changes in the <b>{0}</b> locale. Would you like to save "
-"your changes before switching locales?"
-msgstr ""
-"V lokalizácii <b>{0}</b> máte neuložené zmeny. Chcete uložiť zmeny pred "
-"prepnutím lokalizácie?"
+msgid "You have unsaved changes in the <b>{0}</b> locale. Would you like to save your changes before switching locales?"
+msgstr "V lokalizácii <b>{0}</b> máte neuložené zmeny. Chcete uložiť zmeny pred prepnutím lokalizácie?"
 
 #: src/olympia/translations/templates/translations/trans-menu.html:49
 msgid "Discard Changes"
@@ -14582,12 +11772,8 @@ msgstr "Neuložiť zmeny"
 
 #. {0} is a language name, like 'French'
 #: src/olympia/translations/templates/translations/trans-menu.html:56
-msgid ""
-"Are you sure you want to remove all <b>{0}</b> translations? This cannot be "
-"undone."
-msgstr ""
-"Chcete odstrániť všetky preklady pre jazyk <b>{0}</b? Táto operácia je "
-"nevratná."
+msgid "Are you sure you want to remove all <b>{0}</b> translations? This cannot be undone."
+msgstr "Chcete odstrániť všetky preklady pre jazyk <b>{0}</b? Táto operácia je nevratná."
 
 #: src/olympia/translations/templates/translations/trans-menu.html:61
 msgid "Delete Locale"
@@ -14608,23 +11794,14 @@ msgstr "Toto heslo nie je povolené."
 
 #: src/olympia/users/forms.py:90
 #, python-format
-msgid ""
-"As part of our new password policy, your password must be %s characters or "
-"more. Please update your password by <a href=\"%s\">issuing a password "
-"reset</a>."
-msgstr ""
-"Ako súčasť našej novej politiky hesiel požadujeme, aby vaše heslo malo %s, "
-"alebo viac znakov. Aktualizujte svoje heslo pomocou  <a href=\"%s\">jeho "
-"obnovy</a>."
+msgid "As part of our new password policy, your password must be %s characters or more. Please update your password by <a href=\"%s\">issuing a password reset</a>."
+msgstr "Ako súčasť našej novej politiky hesiel požadujeme, aby vaše heslo malo %s, alebo viac znakov. Aktualizujte svoje heslo pomocou  <a href=\"%s\">jeho obnovy</a>."
 
 #: src/olympia/users/forms.py:115
-msgid ""
-"You must recover your password through Firefox Accounts. Try logging in "
-"instead."
+msgid "You must recover your password through Firefox Accounts. Try logging in instead."
 msgstr ""
 
-#: src/olympia/users/forms.py:206
-#: src/olympia/users/templates/users/pwreset_confirm.html:24
+#: src/olympia/users/forms.py:206 src/olympia/users/templates/users/pwreset_confirm.html:24
 msgid "New password"
 msgstr "Nové heslo"
 
@@ -14637,12 +11814,8 @@ msgid "Usernames cannot contain only digits."
 msgstr "Meno používateľa nesmie obsahovať iba čísla."
 
 #: src/olympia/users/forms.py:274
-msgid ""
-"Enter a valid username consisting of letters, numbers, underscores or "
-"hyphens."
-msgstr ""
-"Zadajte platné používateľské meno, ktoré obsahuje znaky abecedy, čísla, "
-"podčiarky alebo pomlčky."
+msgid "Enter a valid username consisting of letters, numbers, underscores or hyphens."
+msgstr "Zadajte platné používateľské meno, ktoré obsahuje znaky abecedy, čísla, podčiarky alebo pomlčky."
 
 #: src/olympia/users/forms.py:277
 msgid "This username cannot be used."
@@ -14652,38 +11825,25 @@ msgstr "Toto používateľské meno nemôže byť použité."
 msgid "This username is already in use."
 msgstr "Toto používateľské meno sa už používa."
 
-#: src/olympia/users/forms.py:296
-#: src/olympia/users/templates/users/edit.html:107
+#: src/olympia/users/forms.py:296 src/olympia/users/templates/users/edit.html:107
 msgid "Display Name"
 msgstr "Zobrazované meno"
 
-#: src/olympia/users/forms.py:298
-#: src/olympia/users/templates/users/edit.html:112
-#: src/olympia/users/templates/users/vcard.html:10
+#: src/olympia/users/forms.py:298 src/olympia/users/templates/users/edit.html:112 src/olympia/users/templates/users/vcard.html:10
 msgid "Location"
 msgstr "Umiestnenie"
 
-#: src/olympia/users/forms.py:300
-#: src/olympia/users/templates/users/edit.html:117
-#: src/olympia/users/templates/users/vcard.html:16
+#: src/olympia/users/forms.py:300 src/olympia/users/templates/users/edit.html:117 src/olympia/users/templates/users/vcard.html:16
 msgid "Occupation"
 msgstr "Povolenie"
 
 #: src/olympia/users/forms.py:329
-msgid ""
-"This URL has an invalid format. Valid URLs look like "
-"http://example.com/my_page."
-msgstr ""
-"Táto adresa URL má neplatný formát. Platná adresa vyzerá takto: "
-"http://priklad.com/moja_stranka."
+msgid "This URL has an invalid format. Valid URLs look like http://example.com/my_page."
+msgstr "Táto adresa URL má neplatný formát. Platná adresa vyzerá takto: http://priklad.com/moja_stranka."
 
 #: src/olympia/users/forms.py:337
-msgid ""
-"Please use an email address from a different provider to complete your "
-"registration."
-msgstr ""
-"Použite e-mailovú adresu od iného poskytovateľa a dokončite vašu "
-"registráciu."
+msgid "Please use an email address from a different provider to complete your registration."
+msgstr "Použite e-mailovú adresu od iného poskytovateľa a dokončite vašu registráciu."
 
 #: src/olympia/users/forms.py:345
 msgid "This display name cannot be used."
@@ -14693,13 +11853,11 @@ msgstr "Toto zobrazené meno nemôže byť použité."
 msgid "The passwords did not match."
 msgstr "Heslá sa nezhodujú."
 
-#: src/olympia/users/forms.py:377
-#: src/olympia/users/templates/users/edit.html:128
+#: src/olympia/users/forms.py:377 src/olympia/users/templates/users/edit.html:128
 msgid "Profile Photo"
 msgstr "Fotografia profilu"
 
-#: src/olympia/users/forms.py:385
-#: src/olympia/users/templates/users/edit.html:142
+#: src/olympia/users/forms.py:385 src/olympia/users/templates/users/edit.html:142
 msgid "Default locale"
 msgstr "Východzí jazyk"
 
@@ -14716,9 +11874,7 @@ msgid "Email cannot be changed."
 msgstr ""
 
 #: src/olympia/users/forms.py:541
-msgid ""
-"To anonymize, enter a reason for the change but do not change any other "
-"field."
+msgid "To anonymize, enter a reason for the change but do not change any other field."
 msgstr ""
 
 #: src/olympia/users/forms.py:587
@@ -14748,19 +11904,19 @@ msgstr "Používateľ s touto e-mailovou adresou neexistuje."
 
 #. L10n: {id} will be something like "13ad6a", just a random number
 #. to differentiate this user from other anonymous users.
-#: src/olympia/users/models.py:353
+#: src/olympia/users/models.py:362
 msgid "Anonymous user {id}"
 msgstr ""
 
-#: src/olympia/users/models.py:410
+#: src/olympia/users/models.py:419
 msgid "Your account has been restricted"
 msgstr "Váš účet bol obmedzený"
 
-#: src/olympia/users/models.py:480
+#: src/olympia/users/models.py:489
 msgid "Please confirm your email address"
 msgstr "Potvrďte svoju e-mailovú adresu"
 
-#: src/olympia/users/models.py:506
+#: src/olympia/users/models.py:515
 msgid "My Mobile Add-ons"
 msgstr "Moje mobilné doplnky"
 
@@ -14829,16 +11985,12 @@ msgid "Mozilla needs to contact me about my individual app"
 msgstr "Mozilla ma potrebuje kontaktovať ohľadom mojej aplikácie"
 
 #: src/olympia/users/notifications.py:139
-msgid ""
-"Mozilla wants to contact me about relevant App Developer news and surveys"
-msgstr ""
-"Mozilla ma chce kontaktovať ohľadne relevantných noviniek a prieskumov "
-"týkajúcich sa vývoja aplikácií"
+msgid "Mozilla wants to contact me about relevant App Developer news and surveys"
+msgstr "Mozilla ma chce kontaktovať ohľadne relevantných noviniek a prieskumov týkajúcich sa vývoja aplikácií"
 
 #: src/olympia/users/notifications.py:150
 msgid "Mozilla wants to contact me about new regions added to the Marketplace"
-msgstr ""
-"Mozilla ma chce kontaktovať o pridaní nových regiónov do služby Marketplace"
+msgstr "Mozilla ma chce kontaktovať o pridaní nových regiónov do služby Marketplace"
 
 #: src/olympia/users/notifications.py:158
 msgid "User Notifications"
@@ -14861,10 +12013,7 @@ msgid "Successfully verified!"
 msgstr "Úspešne overené!"
 
 #: src/olympia/users/views.py:132
-msgid ""
-"An email has been sent to your address to confirm your account. Before you "
-"can log in, you have to activate your account by clicking on the link "
-"provided in this email."
+msgid "An email has been sent to your address to confirm your account. Before you can log in, you have to activate your account by clicking on the link provided in this email."
 msgstr ""
 
 #: src/olympia/users/views.py:136 src/olympia/users/views.py:619
@@ -14889,14 +12038,11 @@ msgstr "E-mail s potvrdením bol odoslaný"
 
 #: src/olympia/users/views.py:197
 msgid ""
-"An email has been sent to {0} to confirm your new email address. For the "
-"change to take effect, you need to click on the link provided in this email."
-" Until then, you can keep logging in with your current email address."
+"An email has been sent to {0} to confirm your new email address. For the change to take effect, you need to click on the link provided in this email. Until then, you can keep logging in with your "
+"current email address."
 msgstr ""
-"Na vašu e-mailovú adresu {0} bol zaslaný e-mail na potvrdenie vašej novej "
-"e-mailovej adresy. Pre jej nastavenie však musíte kliknúť na odkaz, ktorý je"
-" v tejto správe uvedený. Dovtedy sa stále prihlasujte pomocou vašej "
-"aktuálnej e-mailovej adresy."
+"Na vašu e-mailovú adresu {0} bol zaslaný e-mail na potvrdenie vašej novej e-mailovej adresy. Pre jej nastavenie však musíte kliknúť na odkaz, ktorý je v tejto správe uvedený. Dovtedy sa stále "
+"prihlasujte pomocou vašej aktuálnej e-mailovej adresy."
 
 #: src/olympia/users/views.py:210
 #, python-format
@@ -14908,13 +12054,11 @@ msgid "Errors Found"
 msgstr "Boli nájdené chyby"
 
 #: src/olympia/users/views.py:225
-msgid ""
-"There were errors in the changes you made. Please correct them and resubmit."
+msgid "There were errors in the changes you made. Please correct them and resubmit."
 msgstr "V zmenách, ktoré ste urobili, sú chyby. Opravte ich a odošlite znova."
 
 #: src/olympia/users/views.py:273
-msgid ""
-"We're sorry, but you are not eligible to request a t-shirt at this time."
+msgid "We're sorry, but you are not eligible to request a t-shirt at this time."
 msgstr ""
 
 #: src/olympia/users/views.py:329
@@ -14930,25 +12074,17 @@ msgid "Wrong email address or password!"
 msgstr "Nesprávna e-mailová adresa alebo heslo!"
 
 #: src/olympia/users/views.py:434
-msgid ""
-"A link to activate your user account was sent by email to your address {0}. "
-"You have to click it before you can log in."
-msgstr ""
-"Na vašu e-mailovú adresu {0} bol odoslaný odkaz na aktiváciu účtu. Na tento "
-"odkaz musíte kliknúť a až potom sa budete môcť prihlásiť."
+msgid "A link to activate your user account was sent by email to your address {0}. You have to click it before you can log in."
+msgstr "Na vašu e-mailovú adresu {0} bol odoslaný odkaz na aktiváciu účtu. Na tento odkaz musíte kliknúť a až potom sa budete môcť prihlásiť."
 
 #: src/olympia/users/views.py:439
 #, python-format
 msgid ""
-"If you did not receive the confirmation email, make sure your email service "
-"did not mark it as \"junk mail\" or \"spam\". If you need to, you can have "
-"us <a href=\"%s\">resend the confirmation message</a> to your email address "
-"mentioned above."
+"If you did not receive the confirmation email, make sure your email service did not mark it as \"junk mail\" or \"spam\". If you need to, you can have us <a href=\"%s\">resend the confirmation "
+"message</a> to your email address mentioned above."
 msgstr ""
-"Ak neobdržíte potvrdzovaciu e-mailovú správu, uistite sa, že váš "
-"poskytovateľ pošty ju neoznačil ako \"nevyžiadanú poštu\" či \"spam\". Ak to"
-" budete nutné, môžete si potvrdzovaciu správu <a href=\"%s\">nechať poslať "
-"znova</a>."
+"Ak neobdržíte potvrdzovaciu e-mailovú správu, uistite sa, že váš poskytovateľ pošty ju neoznačil ako \"nevyžiadanú poštu\" či \"spam\". Ak to budete nutné, môžete si potvrdzovaciu správu <a "
+"href=\"%s\">nechať poslať znova</a>."
 
 #: src/olympia/users/views.py:444
 msgid "Activation Email Sent"
@@ -14968,14 +12104,8 @@ msgstr "Blahoželáme! Váš účet používateľa bol úspešne vytvorený."
 
 # %1 is the user's email address
 #: src/olympia/users/views.py:615
-msgid ""
-"An email has been sent to your address {0} to confirm your account. Before "
-"you can log in, you have to activate your account by clicking on the link "
-"provided in this email."
-msgstr ""
-"Na adresu {0} bol odoslaný e-mail, ktorým potvrdíte svoj účet. Pred tým, než"
-" sa budete môcť prihlásiť, je potrebné aktivovať účet kliknutím na odkaz, "
-"ktorý sa nachádza v tejto e-mailovej správe."
+msgid "An email has been sent to your address {0} to confirm your account. Before you can log in, you have to activate your account by clicking on the link provided in this email."
+msgstr "Na adresu {0} bol odoslaný e-mail, ktorým potvrdíte svoj účet. Pred tým, než sa budete môcť prihlásiť, je potrebné aktivovať účet kliknutím na odkaz, ktorý sa nachádza v tejto e-mailovej správe."
 
 #: src/olympia/users/views.py:639
 msgid "There are errors in this form"
@@ -14993,31 +12123,22 @@ msgstr "Používateľ nahlásený."
 msgid "new"
 msgstr "nové"
 
-#: src/olympia/users/templates/users/delete.html:4
-#: src/olympia/users/templates/users/delete.html:10
+#: src/olympia/users/templates/users/delete.html:4 src/olympia/users/templates/users/delete.html:10
 msgid "Delete User Account"
 msgstr "Odstrániť používateľský účet"
 
 #: src/olympia/users/templates/users/delete.html:14
 #, python-format
 msgid ""
-"You cannot delete your account if you are listed as an <a href=\"%(link)s\">"
-" author of any add-ons</a>. To delete your account, please have another "
-"person in your development group delete you from the list of authors for "
-"your add-ons. Afterwards you will be able to delete your account here."
+"You cannot delete your account if you are listed as an <a href=\"%(link)s\"> author of any add-ons</a>. To delete your account, please have another person in your development group delete you from "
+"the list of authors for your add-ons. Afterwards you will be able to delete your account here."
 msgstr ""
-"Svoj účet nemôžete odstrániť, ak ste uvedený ako <a href=\"%(link)s\">autor "
-"nejakého doplnku</a>. Ak chcete svoj účet zrušiť, niekto zo skupiny "
-"vývojárov vašich doplnkov vás musí odstrániť zo zoznamu ich autorov. Potom "
-"si tu môžete zrušiť svoj účet."
+"Svoj účet nemôžete odstrániť, ak ste uvedený ako <a href=\"%(link)s\">autor nejakého doplnku</a>. Ak chcete svoj účet zrušiť, niekto zo skupiny vývojárov vašich doplnkov vás musí odstrániť zo "
+"zoznamu ich autorov. Potom si tu môžete zrušiť svoj účet."
 
 #: src/olympia/users/templates/users/delete.html:29
-msgid ""
-"By clicking \"delete\" your account is going to be <strong>permanently "
-"removed</strong>. That means:"
-msgstr ""
-"Po kliknutí na \"odstrániť\" bude váš účet <strong>natrvalo "
-"odstránený</strong>. To prakticky znamená:"
+msgid "By clicking \"delete\" your account is going to be <strong>permanently removed</strong>. That means:"
+msgstr "Po kliknutí na \"odstrániť\" bude váš účet <strong>natrvalo odstránený</strong>. To prakticky znamená:"
 
 #: src/olympia/users/templates/users/delete.html:35
 #, python-format
@@ -15025,11 +12146,8 @@ msgid "You will not be able to log into %(site)s anymore."
 msgstr "Už sa nebudete môcť prihlásiť k %(site)s."
 
 #: src/olympia/users/templates/users/delete.html:40
-msgid ""
-"Your reviews and ratings will not be deleted, but they will no longer be "
-"associated with you."
-msgstr ""
-"Vaše recenzie a hodnotenia nebudú odstránené, ale už s vami nebudú spájané."
+msgid "Your reviews and ratings will not be deleted, but they will no longer be associated with you."
+msgstr "Vaše recenzie a hodnotenia nebudú odstránené, ale už s vami nebudú spájané."
 
 #: src/olympia/users/templates/users/delete.html:46
 msgid "Confirm account deletion"
@@ -15043,8 +12161,7 @@ msgstr "Rozumiem, že tento krok nie je možné vrátiť späť."
 msgid "Delete my user account now"
 msgstr "Odstrániť môj účet"
 
-#: src/olympia/users/templates/users/delete_photo.html:3
-#: src/olympia/users/templates/users/delete_photo.html:9
+#: src/olympia/users/templates/users/delete_photo.html:3 src/olympia/users/templates/users/delete_photo.html:9
 msgid "Delete User Photo"
 msgstr "Odstránenie obrázku používateľa"
 
@@ -15057,25 +12174,18 @@ msgid "Please set your display name"
 msgstr ""
 
 #: src/olympia/users/templates/users/edit.html:21
-msgid ""
-"Please set your display name or username to complete the registration "
-"process."
+msgid "Please set your display name or username to complete the registration process."
 msgstr ""
 
 #: src/olympia/users/templates/users/edit.html:33
 msgid "Manage basic account information, such as username and email address."
-msgstr ""
-"Správa základných informácií o účte, ako napr. používateľské meno a "
-"e-mailová adresa."
+msgstr "Správa základných informácií o účte, ako napr. používateľské meno a e-mailová adresa."
 
-#: src/olympia/users/templates/users/edit.html:39
-#: src/olympia/users/templates/users/register.html:47
+#: src/olympia/users/templates/users/edit.html:39 src/olympia/users/templates/users/register.html:47
 msgid "Username"
 msgstr "Používateľské meno"
 
-#: src/olympia/users/templates/users/edit.html:45
-#: src/olympia/users/templates/users/pwreset_request.html:21
-#: src/olympia/users/templates/users/register.html:62
+#: src/olympia/users/templates/users/edit.html:45 src/olympia/users/templates/users/pwreset_request.html:21 src/olympia/users/templates/users/register.html:62
 msgid "Email Address"
 msgstr "E-mailová adresa"
 
@@ -15087,21 +12197,15 @@ msgstr ""
 msgid "Change Password"
 msgstr "Zmeniť heslo"
 
-#: src/olympia/users/templates/users/edit.html:68
-#: src/olympia/users/templates/users/login_form.html:22
-#: src/olympia/users/templates/users/register.html:67
+#: src/olympia/users/templates/users/edit.html:68 src/olympia/users/templates/users/login_form.html:22 src/olympia/users/templates/users/register.html:67
 #: src/olympia/users/templates/users/mobile/login.html:37
 msgid "Password"
 msgstr "Heslo"
 
 #: src/olympia/users/templates/users/edit.html:70
 #, python-format
-msgid ""
-"Change your password. If you forgot your password, you can <a "
-"href=\"%(reset_url)s\">use the reset form</a>."
-msgstr ""
-"Zmena hesla. Ak ste svoje heslo zabudli, môžete <a "
-"href=\"%(reset_url)s\">požiadať o nové</a>."
+msgid "Change your password. If you forgot your password, you can <a href=\"%(reset_url)s\">use the reset form</a>."
+msgstr "Zmena hesla. Ak ste svoje heslo zabudli, môžete <a href=\"%(reset_url)s\">požiadať o nové</a>."
 
 #: src/olympia/users/templates/users/edit.html:76
 msgid "Old Password"
@@ -15120,12 +12224,8 @@ msgid "Profile"
 msgstr "Profil"
 
 #: src/olympia/users/templates/users/edit.html:100
-msgid ""
-"Give us a bit more information about yourself. All these fields are "
-"optional, but they'll help other users get to know you better."
-msgstr ""
-"Rozšírené informácie o vás. Všetky tieto políčka sú voliteľné, ale ostatným "
-"pomôžu vás lepšie spoznať."
+msgid "Give us a bit more information about yourself. All these fields are optional, but they'll help other users get to know you better."
+msgstr "Rozšírené informácie o vás. Všetky tieto políčka sú voliteľné, ale ostatným pomôžu vás lepšie spoznať."
 
 #: src/olympia/users/templates/users/edit.html:124
 msgid "This URL will only be visible if you are a developer."
@@ -15140,18 +12240,12 @@ msgid "Delete current photo"
 msgstr "Odstrániť aktuálnu fotografiu"
 
 #: src/olympia/users/templates/users/edit.html:144
-msgid ""
-"This is the default locale used to display information about you (like your "
-"description)."
+msgid "This is the default locale used to display information about you (like your description)."
 msgstr "Východzí jazyk pre zobrazenie informácií o vás (napríklad váš popis)."
 
 #: src/olympia/users/templates/users/edit.html:152
-msgid ""
-"Introduce yourself to the community, if you like! This text will appear "
-"publicly on your user info page."
-msgstr ""
-"Predstavte sa komunite, ak chcete! Tento text bude verejne dostupný na "
-"informačnej stránke o používateľovi."
+msgid "Introduce yourself to the community, if you like! This text will appear publicly on your user info page."
+msgstr "Predstavte sa komunite, ak chcete! Tento text bude verejne dostupný na informačnej stránke o používateľovi."
 
 #: src/olympia/users/templates/users/edit.html:161
 msgid "Allowed HTML: {0}. Links are forbidden."
@@ -15178,21 +12272,12 @@ msgid "Notifications"
 msgstr "Upozornenia"
 
 #: src/olympia/users/templates/users/edit.html:195
-msgid ""
-"From time to time, Mozilla may send you email about upcoming releases and "
-"add-on events. Please select the topics you are interested in."
-msgstr ""
-"Z času na čas môže Mozilla posielať e-mailové správy o nadchádzajúcich "
-"verziách a udalostiach spojených s doplnkami. Zvoľte si témy, ktoré vás "
-"zaujímajú."
+msgid "From time to time, Mozilla may send you email about upcoming releases and add-on events. Please select the topics you are interested in."
+msgstr "Z času na čas môže Mozilla posielať e-mailové správy o nadchádzajúcich verziách a udalostiach spojených s doplnkami. Zvoľte si témy, ktoré vás zaujímajú."
 
 #: src/olympia/users/templates/users/edit.html:205
-msgid ""
-"Mozilla reserves the right to contact you individually about specific "
-"concerns with your hosted add-ons."
-msgstr ""
-"Mozilla si vyhradzuje právo individuálne Vás kontaktovať ohľadne "
-"špecifických záležitostí vašich doplnkov hostovaných Mozillou."
+msgid "Mozilla reserves the right to contact you individually about specific concerns with your hosted add-ons."
+msgstr "Mozilla si vyhradzuje právo individuálne Vás kontaktovať ohľadne špecifických záležitostí vašich doplnkov hostovaných Mozillou."
 
 #: src/olympia/users/templates/users/edit.html:215
 msgid "Admin"
@@ -15214,61 +12299,49 @@ msgstr "žiadne"
 msgid "all"
 msgstr "všetky"
 
-#: src/olympia/users/templates/users/fxa_migration.html:3
-#: src/olympia/users/templates/users/fxa_migration.html:11
-#: src/olympia/users/templates/users/mobile/fxa_migration.html:3
+#: src/olympia/users/templates/users/fxa_migration.html:3 src/olympia/users/templates/users/fxa_migration.html:11 src/olympia/users/templates/users/mobile/fxa_migration.html:3
 #: src/olympia/users/templates/users/mobile/fxa_migration.html:8
 msgid "Migrate to Firefox Accounts"
 msgstr ""
 
 #: src/olympia/users/templates/users/fxa_migration_prompt_content.html:3
-msgid ""
-"Mozilla Add-ons has transitioned to Firefox Accounts for login. Continue to "
-"complete the simple upgrade process."
+msgid "Mozilla Add-ons has transitioned to Firefox Accounts for login. Continue to complete the simple upgrade process."
 msgstr ""
 
 #: src/olympia/users/templates/users/fxa_migration_prompt_content.html:14
 msgid "Skip"
 msgstr "Preskočiť"
 
-#: src/olympia/users/templates/users/login.html:3
-#: src/olympia/users/templates/users/mobile/login.html:3
+#: src/olympia/users/templates/users/login.html:3 src/olympia/users/templates/users/mobile/login.html:3
 msgid "User Login"
 msgstr "Prihlásenie používateľa"
 
-#: src/olympia/users/templates/users/login.html:13
-#: src/olympia/users/templates/users/mobile/login.html:21
+#: src/olympia/users/templates/users/login.html:13 src/olympia/users/templates/users/mobile/login.html:21
 msgid "Enter your email"
 msgstr "Zadajte svoj e-mail"
 
-#: src/olympia/users/templates/users/login.html:15
-#: src/olympia/users/templates/users/mobile/login.html:23
+#: src/olympia/users/templates/users/login.html:15 src/olympia/users/templates/users/mobile/login.html:23
 msgid "Log In"
 msgstr "Prihlásenie"
 
-#: src/olympia/users/templates/users/login_form.html:17
-#: src/olympia/users/templates/users/mobile/login.html:32
+#: src/olympia/users/templates/users/login_form.html:17 src/olympia/users/templates/users/mobile/login.html:32
 msgid "Email address"
 msgstr "E-mailová adresa"
 
-#: src/olympia/users/templates/users/login_form.html:30
-#: src/olympia/users/templates/users/mobile/login.html:44
+#: src/olympia/users/templates/users/login_form.html:30 src/olympia/users/templates/users/mobile/login.html:44
 msgid "Remember me on this device"
 msgstr "Zapamätať si ma na tomto zariadení"
 
 # This is a header for additional help options
-#: src/olympia/users/templates/users/login_help.html:3
-#: src/olympia/users/templates/users/mobile/login.html:63
+#: src/olympia/users/templates/users/login_help.html:3 src/olympia/users/templates/users/mobile/login.html:63
 msgid "Login Problems?"
 msgstr "Problémy s prihlásením?"
 
-#: src/olympia/users/templates/users/login_help.html:5
-#: src/olympia/users/templates/users/mobile/login.html:65
+#: src/olympia/users/templates/users/login_help.html:5 src/olympia/users/templates/users/mobile/login.html:65
 msgid "I don't have an account."
 msgstr "Nemám účet."
 
-#: src/olympia/users/templates/users/login_help.html:6
-#: src/olympia/users/templates/users/mobile/login.html:66
+#: src/olympia/users/templates/users/login_help.html:6 src/olympia/users/templates/users/mobile/login.html:66
 msgid "I forgot my password."
 msgstr "Zabudol som svoje heslo."
 
@@ -15278,15 +12351,9 @@ msgstr "Zabudol som svoje heslo."
 msgid "You are now logged in as <strong>%(user_email)s</strong>!"
 msgstr "Ste prihlásený ako <strong>%(user_email)s</strong>!"
 
-#: src/olympia/users/templates/users/newpw_sent.html:3
-#: src/olympia/users/templates/users/newpw_sent.html:8
-#: src/olympia/users/templates/users/pwreset_complete.html:3
-#: src/olympia/users/templates/users/pwreset_confirm.html:4
-#: src/olympia/users/templates/users/pwreset_confirm.html:18
-#: src/olympia/users/templates/users/pwreset_request.html:4
-#: src/olympia/users/templates/users/pwreset_request.html:10
-#: src/olympia/users/templates/users/pwreset_sent.html:3
-#: src/olympia/users/templates/users/pwreset_sent.html:8
+#: src/olympia/users/templates/users/newpw_sent.html:3 src/olympia/users/templates/users/newpw_sent.html:8 src/olympia/users/templates/users/pwreset_complete.html:3
+#: src/olympia/users/templates/users/pwreset_confirm.html:4 src/olympia/users/templates/users/pwreset_confirm.html:18 src/olympia/users/templates/users/pwreset_request.html:4
+#: src/olympia/users/templates/users/pwreset_request.html:10 src/olympia/users/templates/users/pwreset_sent.html:3 src/olympia/users/templates/users/pwreset_sent.html:8
 msgid "Password Reset"
 msgstr "Vynulovanie hesla"
 
@@ -15302,8 +12369,7 @@ msgstr "Upraviť profil"
 msgid "Manage user"
 msgstr "Spravovať používateľa"
 
-#: src/olympia/users/templates/users/profile.html:18
-#: src/olympia/users/templates/users/report_abuse_full.html:9
+#: src/olympia/users/templates/users/profile.html:18 src/olympia/users/templates/users/report_abuse_full.html:9
 msgid "Report user"
 msgstr "Nahlásiť používateľa"
 
@@ -15368,51 +12434,33 @@ msgstr "Zmena úspešná!"
 msgid "Password successfully reset."
 msgstr "Heslo úspešne vynulované."
 
-#: src/olympia/users/templates/users/pwreset_confirm.html:13
-#: src/olympia/users/templates/users/pwreset_confirm.html:46
+#: src/olympia/users/templates/users/pwreset_confirm.html:13 src/olympia/users/templates/users/pwreset_confirm.html:46
 msgid "Password reset unsuccessful"
 msgstr "Vynulovanie hesla nebolo úspešné"
 
 #: src/olympia/users/templates/users/pwreset_confirm.html:14
-msgid ""
-"You have migrated to Firefox Accounts. You can no longer change your "
-"password here."
+msgid "You have migrated to Firefox Accounts. You can no longer change your password here."
 msgstr ""
 
-#: src/olympia/users/templates/users/pwreset_confirm.html:31
-#: src/olympia/users/templates/users/register.html:72
+#: src/olympia/users/templates/users/pwreset_confirm.html:31 src/olympia/users/templates/users/register.html:72
 msgid "Confirm password"
 msgstr "Potvrdiť heslo"
 
 #: src/olympia/users/templates/users/pwreset_confirm.html:47
-msgid ""
-"The password reset link was invalid, possibly because it has already been "
-"used. Please request a new password reset."
-msgstr ""
-"Odkaz na vynulovanie hesla nie je platný, pravdepodobne kvôli tomu, že v "
-"minulosti už bol použitý. Požiadajte o nové vynulovanie hesla."
+msgid "The password reset link was invalid, possibly because it has already been used. Please request a new password reset."
+msgstr "Odkaz na vynulovanie hesla nie je platný, pravdepodobne kvôli tomu, že v minulosti už bol použitý. Požiadajte o nové vynulovanie hesla."
 
 #: src/olympia/users/templates/users/pwreset_request.html:15
-msgid ""
-"Forgotten your password? Enter your e-mail address below, and we'll e-mail "
-"instructions for setting a new one."
-msgstr ""
-"Zabudli ste svoje heslo? Zadajte e-mailovú adresu, na ktorú vám zašleme "
-"inštrukcie ako získať nové."
+msgid "Forgotten your password? Enter your e-mail address below, and we'll e-mail instructions for setting a new one."
+msgstr "Zabudli ste svoje heslo? Zadajte e-mailovú adresu, na ktorú vám zašleme inštrukcie ako získať nové."
 
 #: src/olympia/users/templates/users/pwreset_request.html:25
 msgid "Send password reset link"
 msgstr "Odoslať vynulovanie hesla"
 
 #: src/olympia/users/templates/users/pwreset_sent.html:10
-msgid ""
-"An email has been sent to the requested account with further information. If"
-" you do not receive an email then please confirm you have entered the same "
-"email address used during account registration."
-msgstr ""
-"Na zadanú e-mailovú adresu bola odoslaná e-mailová správa s ďalšími "
-"informáciami. Ak správu nedostanete, uistite sa, že ste počas registrácie "
-"zadali správnu e-mailovú adresu."
+msgid "An email has been sent to the requested account with further information. If you do not receive an email then please confirm you have entered the same email address used during account registration."
+msgstr "Na zadanú e-mailovú adresu bola odoslaná e-mailová správa s ďalšími informáciami. Ak správu nedostanete, uistite sa, že ste počas registrácie zadali správnu e-mailovú adresu."
 
 #: src/olympia/users/templates/users/register.html:4
 msgid "New User Registration"
@@ -15423,12 +12471,8 @@ msgid "Why register?"
 msgstr "Prečo sa registrovať?"
 
 #: src/olympia/users/templates/users/register.html:14
-msgid ""
-"Registration on AMO is <strong>not required</strong> if you simply want to "
-"download and install public add-ons."
-msgstr ""
-"Na preberanie a inštaláciu verejných doplnkov <strong>nie je</strong> "
-"registrácia na AMO požadovaná."
+msgid "Registration on AMO is <strong>not required</strong> if you simply want to download and install public add-ons."
+msgstr "Na preberanie a inštaláciu verejných doplnkov <strong>nie je</strong> registrácia na AMO požadovaná."
 
 #: src/olympia/users/templates/users/register.html:16
 msgid "You only need to register if:"
@@ -15439,49 +12483,29 @@ msgid "You want to submit reviews for add-ons"
 msgstr "Chcete písať recenzie k doplnkom."
 
 #: src/olympia/users/templates/users/register.html:19
-msgid ""
-"You want to keep track of your favorite add-on collections or create one "
-"yourself"
+msgid "You want to keep track of your favorite add-on collections or create one yourself"
 msgstr "Chcete si evidovať svoje obľúbené doplnky do zbierok."
 
 #: src/olympia/users/templates/users/register.html:20
-msgid ""
-"You are an add-on developer and want to upload your add-on for hosting on "
-"AMO"
+msgid "You are an add-on developer and want to upload your add-on for hosting on AMO"
 msgstr "Ste vývojár doplnku a chcete ho nahrať do systému AMO."
 
 #: src/olympia/users/templates/users/register.html:23
-msgid ""
-"Upon successful registration, you will be sent a confirmation email to the "
-"address you provided. Please follow the instructions there to confirm your "
-"account."
-msgstr ""
-"Pre úspešné dokončenie registrácie vám bude odoslaný potvrdzujúci e-mail na "
-"adresu, ktorú ste zadali. Pre potvrdenie účtu postupujte podľa inštrukcií, "
-"ktoré sú v ňom uvedené."
+msgid "Upon successful registration, you will be sent a confirmation email to the address you provided. Please follow the instructions there to confirm your account."
+msgstr "Pre úspešné dokončenie registrácie vám bude odoslaný potvrdzujúci e-mail na adresu, ktorú ste zadali. Pre potvrdenie účtu postupujte podľa inštrukcií, ktoré sú v ňom uvedené."
 
 #: src/olympia/users/templates/users/register.html:30
 #, python-format
-msgid ""
-"If you like, you can read our <a href=\"%(legal)s\" title=\"Legal "
-"Notices\">Legal Notices</a> and <a href=\"%(privacy)s\" title=\"Privacy "
-"Policy\">Privacy Policy</a>."
-msgstr ""
-"Ak chcete, môžete si prečítať <a href=\"%(legal)s\" title=\"Právne "
-"informácie\">právne informácie</a> a <a href=\"%(privacy)s\" title=\"Zásady "
-"ochrany súkromia\">zásady ochrany súkromia</a>."
+msgid "If you like, you can read our <a href=\"%(legal)s\" title=\"Legal Notices\">Legal Notices</a> and <a href=\"%(privacy)s\" title=\"Privacy Policy\">Privacy Policy</a>."
+msgstr "Ak chcete, môžete si prečítať <a href=\"%(legal)s\" title=\"Právne informácie\">právne informácie</a> a <a href=\"%(privacy)s\" title=\"Zásady ochrany súkromia\">zásady ochrany súkromia</a>."
 
 #: src/olympia/users/templates/users/register.html:52
 msgid "Display name"
 msgstr "Zobrazované meno"
 
 #: src/olympia/users/templates/users/report_abuse.html:7
-msgid ""
-"Please describe why you are reporting this user, such as for spam or an "
-"inappropriate picture."
-msgstr ""
-"Popíšte, prečo nahlasujete tohto používateľa, napríklad kvôli spamu alebo "
-"nevhodnému obrázku."
+msgid "Please describe why you are reporting this user, such as for spam or an inappropriate picture."
+msgstr "Popíšte, prečo nahlasujete tohto používateľa, napríklad kvôli spamu alebo nevhodnému obrázku."
 
 #: src/olympia/users/templates/users/report_abuse_full.html:3
 msgid "Report user {0}"
@@ -15495,39 +12519,25 @@ msgstr "Objednávka trička"
 msgid "Special Edition Add-on Creator T-shirt"
 msgstr "Špeciálna edícia tričiek pre vývojárov doplnkov"
 
-#: src/olympia/users/templates/users/t-shirt.html:14
-#: src/olympia/users/templates/users/t-shirt.html:120
+#: src/olympia/users/templates/users/t-shirt.html:14 src/olympia/users/templates/users/t-shirt.html:120
 msgid "Note:"
 msgstr "Poznámka:"
 
 #: src/olympia/users/templates/users/t-shirt.html:15
-msgid ""
-"You have already submitted a request for a t-shirt. You may re-submit this "
-"form to update your information, but you will only receive one shirt."
-msgstr ""
-"Žiadosť o tričko už bola podaná. Pre upresnenie skôr zadaných informácií "
-"môžete tento formulár znovu odoslať, ale získate aj tak iba jedno tričko."
+msgid "You have already submitted a request for a t-shirt. You may re-submit this form to update your information, but you will only receive one shirt."
+msgstr "Žiadosť o tričko už bola podaná. Pre upresnenie skôr zadaných informácií môžete tento formulár znovu odoslať, ale získate aj tak iba jedno tričko."
 
 #: src/olympia/users/templates/users/t-shirt.html:26
-msgid ""
-"Thank you for helping to make Firefox the most extensible browser available!"
-msgstr ""
-"Ďakujeme, že robíte Firefox najrozšíritelnejším dostupným prehliadačom!"
+msgid "Thank you for helping to make Firefox the most extensible browser available!"
+msgstr "Ďakujeme, že robíte Firefox najrozšíritelnejším dostupným prehliadačom!"
 
 #: src/olympia/users/templates/users/t-shirt.html:33
-msgid ""
-"As a thank you gift, we'd like to send you a special-edition, community-"
-"designed t-shirt. To receive your shirt, please fill out the form below."
-msgstr ""
-"Ako poďakovanie by sme vám radi zaslali limitovanú edíciu komunitou "
-"navrhnutého trička. Aby ste ho mohli získať, vyplňte prosím formulár nižšie."
+msgid "As a thank you gift, we'd like to send you a special-edition, community-designed t-shirt. To receive your shirt, please fill out the form below."
+msgstr "Ako poďakovanie by sme vám radi zaslali limitovanú edíciu komunitou navrhnutého trička. Aby ste ho mohli získať, vyplňte prosím formulár nižšie."
 
 #: src/olympia/users/templates/users/t-shirt.html:41
-msgid ""
-"Your contact information will only be used by Mozilla to ship this special "
-"edition t-shirt."
-msgstr ""
-"Vaše kontaktné informácie budú Mozillou použité len na odoslanie trička."
+msgid "Your contact information will only be used by Mozilla to ship this special edition t-shirt."
+msgstr "Vaše kontaktné informácie budú Mozillou použité len na odoslanie trička."
 
 #: src/olympia/users/templates/users/t-shirt.html:60
 msgid "Mailing Address"
@@ -15583,18 +12593,13 @@ msgstr "Požiadať o tričko"
 
 #: src/olympia/users/templates/users/t-shirt.html:137
 msgid ""
-"We're sorry, but in order to qualify for our special edition t-shirt, you "
-"must be an add-on developer with at least one listed add-on, one unlisted "
-"but signed add-on, or any number of background themes with a combined total "
-"of 10,000 average daily users."
+"We're sorry, but in order to qualify for our special edition t-shirt, you must be an add-on developer with at least one listed add-on, one unlisted but signed add-on, or any number of background "
+"themes with a combined total of 10,000 average daily users."
 msgstr ""
 
 #: src/olympia/users/templates/users/tougher_password.html:2
-msgid ""
-"For your account a password must contain at least 8 characters including "
-"letters and numbers."
-msgstr ""
-"Heslo k účtu musí obsahovať najmenej 8 znakov vrátane písmen a čísiel."
+msgid "For your account a password must contain at least 8 characters including letters and numbers."
+msgstr "Heslo k účtu musí obsahovať najmenej 8 znakov vrátane písmen a čísiel."
 
 #: src/olympia/users/templates/users/unsubscribe.html:2
 msgid "Unsubscribe"
@@ -15606,12 +12611,8 @@ msgstr "Boli ste úspešne odhlásený."
 
 #: src/olympia/users/templates/users/unsubscribe.html:10
 #, python-format
-msgid ""
-"The email address <strong>%(email)s</strong> will no longer get messages "
-"when:"
-msgstr ""
-"Na e-mailovú adresu <strong>%(email)s</strong> už nebudú odosielané správy, "
-"ak:"
+msgid "The email address <strong>%(email)s</strong> will no longer get messages when:"
+msgstr "Na e-mailovú adresu <strong>%(email)s</strong> už nebudú odosielané správy, ak:"
 
 #: src/olympia/users/templates/users/unsubscribe.html:20
 msgid "More Actions:"
@@ -15631,14 +12632,8 @@ msgstr "Nebolo možné vás odhlásiť"
 
 #: src/olympia/users/templates/users/unsubscribe.html:30
 #, python-format
-msgid ""
-"Unfortunately, we weren't able to unsubscribe you. The link you clicked is "
-"invalid. However, you can unsubscribe still unsubscribe on your <a "
-"href=\"%(edit_url)s\">edit profile page</a>."
-msgstr ""
-"Bohužiaľ sa nepodarilo vás odhlásiť z odberu. Odkaz, na ktorý ste klikli, "
-"nie je platný. Stále sa môžete na <a href=\"%(edit_url)s\">stránke úpravy "
-"vášho profilu</a>."
+msgid "Unfortunately, we weren't able to unsubscribe you. The link you clicked is invalid. However, you can unsubscribe still unsubscribe on your <a href=\"%(edit_url)s\">edit profile page</a>."
+msgstr "Bohužiaľ sa nepodarilo vás odhlásiť z odberu. Odkaz, na ktorý ste klikli, nie je platný. Stále sa môžete na <a href=\"%(edit_url)s\">stránke úpravy vášho profilu</a>."
 
 #: src/olympia/users/templates/users/vcard.html:2
 msgid "Developer Information"
@@ -15670,7 +12665,6 @@ msgid "%(num)s theme"
 msgid_plural "%(num)s themes"
 msgstr[0] "%(num)s téma"
 msgstr[1] "%(num)s témy"
-msgstr[2] "%(num)s tém"
 
 #: src/olympia/users/templates/users/vcard.html:62
 #, python-format
@@ -15678,7 +12672,6 @@ msgid "%(num)s add-on"
 msgid_plural "%(num)s add-ons"
 msgstr[0] "%(num)s doplnok"
 msgstr[1] "%(num)s doplnky"
-msgstr[2] "%(num)s doplnkov"
 
 #: src/olympia/users/templates/users/vcard.html:75
 msgid "Average rating of developer's add-ons"
@@ -15693,15 +12686,15 @@ msgstr "História verzií %s"
 msgid "Version History with Changelogs"
 msgstr "História verzií s denníkmi zmien"
 
-#: src/olympia/versions/models.py:314
+#: src/olympia/versions/models.py:313
 msgid "Add-on uses binary components."
 msgstr "Doplnok obsahuje binárne komponenty."
 
-#: src/olympia/versions/models.py:317
+#: src/olympia/versions/models.py:316
 msgid "Add-on has opted into strict compatibility checking."
 msgstr "Doplnok má nastavenú striktnú kontrolu kompatibility."
 
-#: src/olympia/versions/models.py:715
+#: src/olympia/versions/models.py:711
 msgid "{app} {min} and later"
 msgstr "{app} {min} a vyššie"
 
@@ -15717,9 +12710,7 @@ msgstr "Sprístupnené: {0}"
 #: src/olympia/versions/templates/versions/version.html:39
 #, python-format
 msgid "Source code released under <a target=\"_blank\" href=\"%(url)s\">%(name)s</a>"
-msgstr ""
-"Zdrojový kód vydaný pod licenciou <a target=\"_blank\" "
-"href=\"%(url)s\">%(name)s</a>"
+msgstr "Zdrojový kód vydaný pod licenciou <a target=\"_blank\" href=\"%(url)s\">%(name)s</a>"
 
 #: src/olympia/versions/templates/versions/version.html:44
 #, python-format
@@ -15730,8 +12721,8 @@ msgstr "Zdrojový kód vydaný pod licenciou <a href=\"%(url)s\">%(name)s</a>"
 msgid "View the source"
 msgstr "Zobraziť zdrojový kód"
 
-#. {0} is an add-on name.
 # {0} is the add-on name
+#. {0} is an add-on name.
 #: src/olympia/versions/templates/versions/version_list.html:26
 msgid "{0} Version History"
 msgstr "História verzií {0}"
@@ -15742,22 +12733,15 @@ msgid "<b>{0}</b> version"
 msgid_plural "<b>{0}</b> versions"
 msgstr[0] "<b>{0}</b> verzia"
 msgstr[1] "<b>{0}</b> verzie"
-msgstr[2] "<b>{0}</b> verzií"
 
-#: src/olympia/versions/templates/versions/version_list.html:35
-#: src/olympia/versions/templates/versions/mobile/version_list.html:14
+#: src/olympia/versions/templates/versions/version_list.html:35 src/olympia/versions/templates/versions/mobile/version_list.html:14
 msgid "Be careful with old versions!"
 msgstr "Opatrne so starými verziami!"
 
-#: src/olympia/versions/templates/versions/version_list.html:36
-#: src/olympia/versions/templates/versions/mobile/version_list.html:15
+#: src/olympia/versions/templates/versions/version_list.html:36 src/olympia/versions/templates/versions/mobile/version_list.html:15
 #, python-format
-msgid ""
-"These versions are displayed for reference and testing purposes. You should "
-"always use the <a href=\"%(url)s\">latest version</a> of an add-on."
-msgstr ""
-"Tieto verzie sú zobrazené na ukážku a testovacie účely. Vždy by ste mali "
-"používať <a href=\"%(url)s\">najnovšiu verziu</a> tohto doplnku."
+msgid "These versions are displayed for reference and testing purposes. You should always use the <a href=\"%(url)s\">latest version</a> of an add-on."
+msgstr "Tieto verzie sú zobrazené na ukážku a testovacie účely. Vždy by ste mali používať <a href=\"%(url)s\">najnovšiu verziu</a> tohto doplnku."
 
 #: src/olympia/versions/templates/versions/mobile/version.html:4
 msgid "Beta Version {0}"
@@ -15787,3 +12771,8 @@ msgstr "Po dokončení odoslať e-mail"
 #: src/olympia/zadmin/forms.py:105
 msgid "Log emails instead of sending"
 msgstr "Logovať e-mailové správy na miesto ich odoslania"
+
+#: src/olympia/zadmin/forms.py:215
+msgid "Deleted versions can`t be changed."
+msgstr ""
+

--- a/locale/sk/LC_MESSAGES/djangojs.po
+++ b/locale/sk/LC_MESSAGES/djangojs.po
@@ -1,1287 +1,1239 @@
-# 
+#
 msgid ""
 msgstr ""
 "Project-Id-Version: AMO-JS 0.1\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2016-02-24 21:23+0000\n"
+"POT-Creation-Date: 2016-04-18 15:47+0000\n"
 "PO-Revision-Date: 2016-04-08 16:46+0000\n"
 "Last-Translator: Juraj Cigáň <kusavica@gmail.com>\n"
 "Language-Team: Mozilla.sk <l10n@mozilla.sk>\n"
-"Language: sk\n"
+"Language: \n"
 "MIME-Version: 1.0\n"
-"Content-Type: text/plain; charset=utf-8\n"
+"Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=3; plural=(n==1) ? 0 : (n>=2 && n<=4) ? 1 : 2;\n"
 "Generated-By: Babel 2.2.0\n"
-"X-Generator: Pontoon\n"
 
-#: static/js/common/ratingwidget.js:31
+#: static/js/common-all.js:1426 static/js/impala-all.js:1511 static/js/zamboni/discovery-all.js:12598 static/js/zamboni/init.js:28 static/js/zamboni/mobile-all.js:14945
+msgid "This feature is temporarily disabled while we perform website maintenance. Please check back a little later."
+msgstr "Táto funkcia je dočasne nedostupná kvôli prebiehajúcej údržbe servera. Prosím, skúste to neskôr."
+
+#. L10n: {0} is an app name like Firefox.
+#: static/js/common-all.js:1837 static/js/impala-all.js:1922 static/js/zamboni/buttons.js:73 static/js/zamboni/discovery-all.js:13108
+msgid "Accept and Install"
+msgstr "Prijať a nainštalovať"
+
+#: static/js/common-all.js:1837 static/js/impala-all.js:1922 static/js/zamboni/buttons.js:73 static/js/zamboni/discovery-all.js:13108
+msgid "Add to {0}"
+msgstr "Pridať do programu {0}"
+
+#: static/js/common-all.js:1842 static/js/impala-all.js:1927 static/js/zamboni/buttons.js:78 static/js/zamboni/discovery-all.js:13113
+msgid "Download Now"
+msgstr "Prevziať teraz"
+
+#: static/js/common-all.js:1883 static/js/impala-all.js:1968 static/js/zamboni/buttons.js:119 static/js/zamboni/discovery-all.js:13154
+msgid "Add-on has not been updated to support default-to-compatible."
+msgstr "Doplnok nebol aktualizovaný tak, aby bol v predvolenom nastavení kompatibilný."
+
+#: static/js/common-all.js:1888 static/js/impala-all.js:1973 static/js/zamboni/buttons.js:124 static/js/zamboni/discovery-all.js:13159
+msgid "You need to be using Firefox 10.0 or higher."
+msgstr "Musíte používať Firefox 10.0 alebo novší."
+
+#: static/js/common-all.js:1900 static/js/impala-all.js:1985 static/js/zamboni/buttons.js:136 static/js/zamboni/discovery-all.js:13171
+msgid "Mozilla has marked this version as incompatible with your Firefox version."
+msgstr "Mozilla označila túto verziu ako nekompatibilnú s vašou verziou Firefoxu."
+
+#. L10n: {0} is an platform like Windows or Linux.
+#: static/js/common-all.js:1981 static/js/impala-all.js:2066 static/js/zamboni/buttons.js:217 static/js/zamboni/discovery-all.js:13252
+msgid "Install for {0} anyway"
+msgstr "Napriek tomu nainštalovať pre {0}"
+
+#: static/js/common-all.js:1981 static/js/impala-all.js:2066 static/js/zamboni/buttons.js:217 static/js/zamboni/discovery-all.js:13252
+msgid "Download for {0} anyway"
+msgstr "Napriek tomu prevziať pre {0}"
+
+#: static/js/common-all.js:2038 static/js/impala-all.js:2123 static/js/zamboni/buttons.js:274 static/js/zamboni/discovery-all.js:13309
+msgid "Not available for your platform"
+msgstr "Nie je dostupné pre vašu platformu."
+
+#. L10n: {0} is an app name, {1} is the app version.
+#: static/js/common-all.js:2049 static/js/common-all.js:2086 static/js/impala-all.js:2134 static/js/impala-all.js:2171 static/js/zamboni/buttons.js:286 static/js/zamboni/buttons.js:324
+#: static/js/zamboni/discovery-all.js:13320 static/js/zamboni/discovery-all.js:13357
+msgid "Not available for {0} {1}"
+msgstr "Nie je dostupné pre {0} {1}"
+
+#: static/js/common-all.js:2112 static/js/impala-all.js:2197 static/js/zamboni/buttons.js:351 static/js/zamboni/discovery-all.js:13383
+msgid "Works with {app} {min} - {max}"
+msgstr "Funguje s {app} {min} - {max}"
+
+#: static/js/common-all.js:2114 static/js/impala-all.js:2199 static/js/zamboni/buttons.js:353 static/js/zamboni/discovery-all.js:13385
+msgid "View other versions"
+msgstr "Zobraziť ďalšie verzie"
+
+#: static/js/common-all.js:2162 static/js/impala-all.js:2247 static/js/zamboni/buttons.js:401 static/js/zamboni/discovery-all.js:13433
+msgid "Only with Firefox — Get Firefox Now!"
+msgstr "Len pre Firefox — získajte Firefox teraz!"
+
+#: static/js/common-all.js:2278 static/js/impala-all.js:2363 static/js/zamboni/buttons.js:517 static/js/zamboni/discovery-all.js:13549 static/js/zamboni/mobile-all.js:15177
+#: static/js/zamboni/mobile/buttons.js:43
+msgid "Sorry, you need a Mozilla-based browser (such as Firefox) to install a search plugin."
+msgstr "Ak chcete nainštalovať vyhľadávací modul, potrebujete prehliadač založený na kóde Mozilla (napríklad Firefox)."
+
+#: static/js/common-all.js:9088 static/js/impala-all.js:9649 static/js/zamboni/global.js:410
+msgid "Loading..."
+msgstr "Načítava sa..."
+
+#. L10n: {0} is the number of characters left.
+#: static/js/common-all.js:9152 static/js/impala-all.js:9713 static/js/zamboni/global.js:474
+msgid "<b>{0}</b> character left."
+msgid_plural "<b>{0}</b> characters left."
+msgstr[0] "Zostáva <b>{0}</b> znak."
+msgstr[1] "Zostávajú <b>{0}</b> znaky."
+
+#: static/js/common-all.js:9589 static/js/common-min.js:6 static/js/impala-all.js:10052 static/js/impala-min.js:6 static/js/common/ratingwidget.js:31 static/js/zamboni/mobile-all.js:16123
+#: static/js/zamboni/mobile-min.js:6
 msgid "{0} star"
 msgid_plural "{0} stars"
 msgstr[0] "{0} hviezdička"
 msgstr[1] "{0} hviezdičky"
-msgstr[2] "{0} hviezdičiek"
 
-#: static/js/common/upload-addon.js:41 static/js/common/upload-image.js:128
+#: static/js/common-all.js:9676 static/js/common-min.js:6 static/js/impala-all.js:10139 static/js/impala-min.js:6 static/js/zamboni/l10n.js:45
+msgid "Remove this localization"
+msgstr "Odstrániť túto lokalizáciu"
+
+#: static/js/common-all.js:10193 static/js/common-min.js:6 static/js/impala-all.js:10674 static/js/impala-min.js:6 static/js/zamboni/discovery-all.js:13678
+msgid "close"
+msgstr ""
+
+#: static/js/common-all.js:10860 static/js/common-min.js:6 static/js/impala-all.js:11481 static/js/impala-min.js:6 static/js/impala/reviews.js:23 static/js/zamboni/reviews.js:18
+msgid "Flagged for review"
+msgstr "Označené na kontrolu"
+
+#: static/js/common-all.js:10876 static/js/common-min.js:6 static/js/impala-all.js:11498 static/js/impala-min.js:6 static/js/impala/reviews.js:40 static/js/zamboni/reviews.js:34
+msgid "Your input is required"
+msgstr "Vyžaduje sa zadanie údajov"
+
+#: static/js/common-all.js:10945 static/js/common-min.js:6 static/js/impala-all.js:11610 static/js/impala-min.js:7 static/js/impala/reviews.js:152 static/js/zamboni/reviews.js:103
+msgid "Marked for deletion"
+msgstr "Označené na odstránenie"
+
+#: static/js/common-all.js:11573 static/js/common-min.js:7 static/js/impala-all.js:13809 static/js/impala-min.js:8 static/js/zamboni/collections.js:229
+msgid "Adding to Favorites&hellip;"
+msgstr "Pridať medzi obľúbené&hellip;"
+
+#: static/js/common-all.js:11576 static/js/common-min.js:7 static/js/impala-all.js:13812 static/js/impala-min.js:8 static/js/zamboni/collections.js:232
+msgid "Removing Favorite&hellip;"
+msgstr "Odstraňuje sa zo zoznamu obľúbených&hellip;"
+
+#: static/js/common-all.js:11579 static/js/common-min.js:7 static/js/impala-all.js:13815 static/js/impala-min.js:8 static/js/zamboni/collections.js:235
+msgid "Add to Favorites"
+msgstr "Pridať medzi obľúbené"
+
+#: static/js/common-all.js:11582 static/js/common-min.js:7 static/js/impala-all.js:13818 static/js/impala-min.js:8 static/js/zamboni/collections.js:238
+msgid "Remove from Favorites"
+msgstr "Odstrániť z obľúbených"
+
+#: static/js/common-all.js:11647 static/js/common-min.js:7 static/js/impala-all.js:13883 static/js/impala-min.js:8 static/js/zamboni/collections.js:303
+msgid "Pending"
+msgstr "Čakajúci"
+
+#: static/js/common-all.js:11648 static/js/common-min.js:7 static/js/impala-all.js:13884 static/js/impala-min.js:8 static/js/zamboni/collections.js:304
+msgid "Add a comment"
+msgstr "Pridať komentár"
+
+#: static/js/common-all.js:11648 static/js/common-min.js:7 static/js/impala-all.js:13884 static/js/impala-min.js:8 static/js/zamboni/collections.js:304
+msgid "Comment"
+msgstr "Komentár"
+
+#: static/js/common-all.js:11649 static/js/common-min.js:7 static/js/impala-all.js:13885 static/js/impala-min.js:8 static/js/zamboni/collections.js:305
+msgid "Remove this add-on from the collection"
+msgstr "Odstrániť tento doplnok z kolekcie"
+
+#: static/js/common-all.js:11649 static/js/common-all.js:11678 static/js/common-min.js:7 static/js/impala-all.js:13885 static/js/impala-all.js:13914 static/js/impala-min.js:8
+#: static/js/zamboni/collections.js:305 static/js/zamboni/collections.js:334
+msgid "Remove"
+msgstr "Odstrániť"
+
+#: static/js/common-all.js:11678 static/js/common-min.js:7 static/js/impala-all.js:13914 static/js/impala-min.js:8 static/js/zamboni/collections.js:334
+msgid "Remove this user as a contributor"
+msgstr "Odstrániť tohto používateľa ako prispievateľa"
+
+#: static/js/common-all.js:11690 static/js/common-min.js:7 static/js/impala-all.js:13926 static/js/impala-min.js:8 static/js/zamboni/collections.js:346
+msgid "An email address is required."
+msgstr "E-mailová adresa je požadovaná."
+
+#: static/js/common-all.js:11708 static/js/common-min.js:7 static/js/impala-all.js:13944 static/js/impala-min.js:8 static/js/zamboni/collections.js:364
+msgid "You cannot add yourself as a contributor."
+msgstr "Nemôžete ako prispievateľa pridať samých seba."
+
+#: static/js/common-all.js:11710 static/js/common-min.js:7 static/js/impala-all.js:13946 static/js/impala-min.js:8 static/js/zamboni/collections.js:366
+msgid "You have already added that user."
+msgstr "Tohto používateľa ste už pridali."
+
+#: static/js/common-all.js:11917 static/js/common-min.js:7 static/js/impala-all.js:14153 static/js/impala-min.js:8 static/js/zamboni/collections.js:573
+msgid "Add to favorites"
+msgstr "Pridať medzi obľúbené"
+
+#: static/js/common-all.js:11921 static/js/common-min.js:7 static/js/impala-all.js:14157 static/js/impala-min.js:8 static/js/zamboni/collections.js:577
+msgid "Remove from favorites"
+msgstr "Odstrániť z obľúbených"
+
+#: static/js/common-all.js:11939 static/js/common-min.js:7 static/js/impala-all.js:14175 static/js/impala-all.js:14233 static/js/impala-min.js:8 static/js/impala/collections.js:10
+#: static/js/zamboni/collections.js:595
+msgid "Follow this Collection"
+msgstr "Odoberať túto kolekciu"
+
+#: static/js/common-all.js:11948 static/js/common-min.js:7 static/js/impala-all.js:14184 static/js/impala-min.js:8 static/js/zamboni/collections.js:604
+msgid "Stop following"
+msgstr "Zastaviť odber"
+
+#: static/js/common-all.js:12096 static/js/common-min.js:7 static/js/zamboni/password-strength.js:20
+msgid "Password strength:"
+msgstr "Sila hesla:"
+
+#: static/js/common-all.js:12102 static/js/common-min.js:7 static/js/zamboni/password-strength.js:26
+msgid "At least {0} character left."
+msgid_plural "At least {0} characters left."
+msgstr[0] "Zostáva najmenej {0} znak."
+msgstr[1] "Zostávajú najmenej {0} znaky."
+
+#: static/js/common-all.js:12286 static/js/common-min.js:7 static/js/impala-all.js:14632 static/js/impala-min.js:8 static/js/impala/suggestions.js:39
+msgid "Search themes for <b>{0}</b>"
+msgstr "Vyhľadávanie tém podľa <b>{0}</b>"
+
+#: static/js/common-all.js:12288 static/js/common-min.js:7 static/js/impala-all.js:14634 static/js/impala-min.js:8 static/js/impala/suggestions.js:41
+msgid "Search apps for <b>{0}</b>"
+msgstr "Vyhľadávanie aplikácií pre <b>{0}</b>"
+
+#: static/js/common-all.js:12290 static/js/common-min.js:7 static/js/impala-all.js:14636 static/js/impala-min.js:8 static/js/impala/suggestions.js:43
+msgid "Search add-ons for <b>{0}</b>"
+msgstr "Vyhľadávanie doplnkov pre <b>{0}</b>"
+
+#: static/js/common-all.js:12521 static/js/common-min.js:7 static/js/impala-all.js:14867 static/js/impala-min.js:8 static/js/impala/site_suggestions.js:46
+msgid "Category"
+msgstr "Kategória"
+
+#. L10n: {0} is an app name.
+#: static/js/impala-all.js:11632 static/js/impala-min.js:7 static/js/impala/listing.js:11 static/js/zamboni/themes.js:13
+msgid "This theme is incompatible with your version of {0}"
+msgstr "Táto téma nie je kompatibilná s vašou verziou aplikácie {0}"
+
+#: static/js/impala-all.js:12146 static/js/impala-all.js:14331 static/js/impala-min.js:7 static/js/impala-min.js:8 static/js/common/upload-image.js:97 static/js/impala/users.js:51
+#: static/js/zamboni/devhub-all.js:894 static/js/zamboni/devhub-min.js:1
+msgid "Images must be either PNG or JPG."
+msgstr "Obrázky musia mať formát PNG alebo JPG."
+
+#: static/js/impala-all.js:12150 static/js/impala-min.js:7 static/js/common/upload-image.js:101 static/js/zamboni/devhub-all.js:898 static/js/zamboni/devhub-min.js:1
+msgid "Videos must be in WebM."
+msgstr "Videá musia byť vo formáte WebM."
+
+#: static/js/impala-all.js:12177 static/js/impala-min.js:7 static/js/common/upload-addon.js:41 static/js/common/upload-image.js:128 static/js/zamboni/devhub-all.js:272
+#: static/js/zamboni/devhub-all.js:925 static/js/zamboni/devhub-min.js:1
 msgid "There was a problem contacting the server."
 msgstr "Pri kontaktovaní servera sa vyskytla chyba."
 
-#: static/js/common/upload-addon.js:69
+#: static/js/impala-all.js:13298 static/js/impala-min.js:7 static/js/impala/persona_creation.js:60
+msgid "All Rights Reserved"
+msgstr "Všetky práva vyhradené"
+
+#: static/js/impala-all.js:13302 static/js/impala-min.js:7 static/js/impala/persona_creation.js:64
+msgid "Creative Commons Attribution 3.0"
+msgstr "Creative Commons Attribution 3.0"
+
+#: static/js/impala-all.js:13307 static/js/impala-min.js:7 static/js/impala/persona_creation.js:69
+msgid "Creative Commons Attribution-NonCommercial 3.0"
+msgstr "Creative Commons Attribution-NonCommercial 3.0"
+
+#: static/js/impala-all.js:13312 static/js/impala-min.js:7 static/js/impala/persona_creation.js:74
+msgid "Creative Commons Attribution-NonCommercial-NoDerivs 3.0"
+msgstr "Creative Commons Attribution-NonCommercial-NoDerivs 3.0"
+
+#: static/js/impala-all.js:13317 static/js/impala-min.js:7 static/js/impala/persona_creation.js:79
+msgid "Creative Commons Attribution-NonCommercial-Share Alike 3.0"
+msgstr "Creative Commons Attribution-NonCommercial-Share Alike 3.0"
+
+#: static/js/impala-all.js:13322 static/js/impala-min.js:7 static/js/impala/persona_creation.js:84
+msgid "Creative Commons Attribution-NoDerivs 3.0"
+msgstr "Creative Commons Attribution-NoDerivs 3.0"
+
+#: static/js/impala-all.js:13327 static/js/impala-min.js:7 static/js/impala/persona_creation.js:89
+msgid "Creative Commons Attribution-ShareAlike 3.0"
+msgstr "Creative Commons Attribution-ShareAlike 3.0"
+
+#: static/js/impala-all.js:13530 static/js/impala-min.js:7 static/js/impala/persona_creation.js:292
+msgid "Your Theme's Name"
+msgstr "Názov vašej témy"
+
+#: static/js/impala-all.js:14242 static/js/impala-min.js:8 static/js/impala/collections.js:19
+msgid "Stop Following"
+msgstr "Zastaviť odoberanie"
+
+#: static/js/impala-all.js:14243 static/js/impala-min.js:8 static/js/impala/collections.js:20
+msgid "Following"
+msgstr "Odoberať"
+
+#: static/js/impala-all.js:14313 static/js/impala-min.js:8 static/js/impala/users.js:33
+msgid "use original"
+msgstr "použiť originál"
+
+#: static/js/impala-all.js:14523 static/js/impala-min.js:8 static/js/impala/search.js:114
+msgid "Updating results&hellip;"
+msgstr "Prebieha aktualizácia výsledkov&hellip;"
+
+#: static/js/common/upload-addon.js:69 static/js/zamboni/devhub-all.js:300 static/js/zamboni/devhub-min.js:1
 msgid "Select a file..."
 msgstr "Zvoľte súbor..."
 
-#: static/js/common/upload-addon.js:70
+#: static/js/common/upload-addon.js:70 static/js/zamboni/devhub-all.js:301 static/js/zamboni/devhub-min.js:1
 msgid "Your add-on should end with .xpi, .jar or .xml"
 msgstr "Váš doplnok by mal mať koncovku .xpi, .jar alebo .xml"
 
 #. L10n: {0} is the percent of the file that has been uploaded.
-#: static/js/common/upload-addon.js:104
+#: static/js/common/upload-addon.js:104 static/js/zamboni/devhub-all.js:335 static/js/zamboni/devhub-min.js:1
 #, fuzzy, python-format
 msgid "{0}% complete"
 msgstr "Dokončené: {0}%"
 
 #. L10n: "{bytes uploaded} of {total filesize}".
-#: static/js/common/upload-addon.js:107
+#: static/js/common/upload-addon.js:107 static/js/zamboni/devhub-all.js:338 static/js/zamboni/devhub-min.js:1
 msgid "{0} of {1}"
 msgstr "{0} z {1}"
 
-#: static/js/common/upload-addon.js:140
+#: static/js/common/upload-addon.js:140 static/js/zamboni/devhub-all.js:371 static/js/zamboni/devhub-min.js:1
 msgid "Cancel"
 msgstr "Zrušiť"
 
-#: static/js/common/upload-addon.js:162
+#: static/js/common/upload-addon.js:162 static/js/zamboni/devhub-all.js:393 static/js/zamboni/devhub-min.js:1
 msgid "Uploading {0}"
 msgstr "Odosiela sa {0}"
 
-#: static/js/common/upload-addon.js:189
+#: static/js/common/upload-addon.js:189 static/js/zamboni/devhub-all.js:420 static/js/zamboni/devhub-min.js:1
 msgid "Error with {0}"
 msgstr "Chyba s {0}"
 
-#: static/js/common/upload-addon.js:194
+#: static/js/common/upload-addon.js:194 static/js/zamboni/devhub-all.js:425 static/js/zamboni/devhub-min.js:1
 msgid "Your add-on failed validation with {0} error."
 msgid_plural "Your add-on failed validation with {0} errors."
 msgstr[0] "Váš doplnok neprešiel overením, výsledok: {0} chyba."
 msgstr[1] "Váš doplnok neprešiel overením, výsledok: {0} chyby."
-msgstr[2] "Váš doplnok neprešiel overením, výsledok: {0} chýb."
 
-#: static/js/common/upload-addon.js:208
+#: static/js/common/upload-addon.js:208 static/js/zamboni/devhub-all.js:439 static/js/zamboni/devhub-min.js:1
 msgid "&hellip;and {0} more"
 msgid_plural "&hellip;and {0} more"
 msgstr[0] "&hellip; a jedna ďalšia"
 msgstr[1] "&hellip; a {0} ďalšie"
-msgstr[2] "&hellip; a {0} ďalších"
 
-#: static/js/common/upload-addon.js:222 static/js/common/upload-addon.js:512
+#: static/js/common/upload-addon.js:222 static/js/common/upload-addon.js:497 static/js/zamboni/devhub-all.js:453 static/js/zamboni/devhub-all.js:743 static/js/zamboni/devhub-min.js:1
 msgid "See full validation report"
 msgstr "Zobraziť celú správu o overení"
 
-#: static/js/common/upload-addon.js:234
+#: static/js/common/upload-addon.js:234 static/js/zamboni/devhub-all.js:465 static/js/zamboni/devhub-min.js:1
 msgid "Validating {0}"
 msgstr "Overuje sa {0}"
 
 #. L10n: first argument is an HTTP status code
-#: static/js/common/upload-addon.js:273
+#: static/js/common/upload-addon.js:273 static/js/zamboni/devhub-all.js:504 static/js/zamboni/devhub-min.js:1
 msgid "Received an empty response from the server; status: {0}"
 msgstr "Prijatá prázdna odpoveď zo servera. Stav: {0}"
 
-#: static/js/common/upload-addon.js:373
+#: static/js/common/upload-addon.js:370 static/js/zamboni/devhub-all.js:604 static/js/zamboni/devhub-min.js:1
 msgid "Unexpected server error while validating."
 msgstr "Počas overovania sa vyskytla neočakávaná chyba."
 
-#: static/js/common/upload-addon.js:412
+#: static/js/common/upload-addon.js:409 static/js/zamboni/devhub-all.js:643 static/js/zamboni/devhub-min.js:1
 msgid "Finished validating {0}"
 msgstr "Ukončené overovanie {0}"
 
-#: static/js/common/upload-addon.js:418
+#: static/js/common/upload-addon.js:415 static/js/zamboni/devhub-all.js:649 static/js/zamboni/devhub-min.js:1
 msgid "Your add-on validation timed out, it will be manually reviewed."
-msgstr ""
-"Overovanie vášho doplnku vypršalo, doplnok bude skontrolovaný manuálne."
+msgstr "Overovanie vášho doplnku vypršalo, doplnok bude skontrolovaný manuálne."
 
-#: static/js/common/upload-addon.js:421
+#: static/js/common/upload-addon.js:418 static/js/zamboni/devhub-all.js:652 static/js/zamboni/devhub-min.js:1
 msgid "Your add-on was validated with no errors and {0} warning."
 msgid_plural "Your add-on was validated with no errors and {0} warnings."
 msgstr[0] "Váš doplnok bol overený bez chýb a s {0} varovaním."
 msgstr[1] "Váš doplnok bol overený bez chýb a s {0} varovaniami."
-msgstr[2] "Váš doplnok bol overený bez chýb a s {0} varovaniami."
 
-#: static/js/common/upload-addon.js:426
+#: static/js/common/upload-addon.js:423 static/js/zamboni/devhub-all.js:657 static/js/zamboni/devhub-min.js:1
 msgid "Your add-on was validated with no errors and {0} message."
 msgid_plural "Your add-on was validated with no errors and {0} messages."
 msgstr[0] "Váš doplnok bol overený bez chýb a s {0} správou."
 msgstr[1] "Váš doplnok bol overený bez chýb a s {0} správami."
-msgstr[2] "Váš doplnok bol overený bez chýb a s {0} správami."
 
-#: static/js/common/upload-addon.js:431
+#: static/js/common/upload-addon.js:428 static/js/zamboni/devhub-all.js:662 static/js/zamboni/devhub-min.js:1
 msgid "Your add-on was validated with no errors or warnings."
 msgstr "Váš doplnok bol overený bez chýb alebo varovaní."
 
-#: static/js/common/upload-addon.js:446
+#: static/js/common/upload-addon.js:443 static/js/zamboni/devhub-all.js:677 static/js/zamboni/devhub-min.js:1
 msgid "Your submission will be automatically signed."
 msgstr "Vaše doplnky odoslané na kontrolu budú automaticky podpísané."
 
-#: static/js/common/upload-addon.js:465
+#: static/js/common/upload-addon.js:450 static/js/zamboni/devhub-all.js:696 static/js/zamboni/devhub-min.js:1
 msgid "Include detailed version notes (this can be done in the next step)."
 msgstr "Zahrnúť podrobné poznámky k verzii (možno nastaviť v ďalšom kroku)."
 
-#: static/js/common/upload-addon.js:466
-msgid ""
-"If your add-on requires an account to a website in order to be fully tested,"
-" include a test username and password in the Notes to Reviewer (this can be "
-"done in the next step)."
-msgstr ""
-"Ak váš doplnok vyžaduje účet na webovom serveri pre možnosť plnej kontroly, "
-"zadajte prosím používateľské meno a heslo do poznámky pre redaktora (možno "
-"vykonať v ďalšom kroku)."
+#: static/js/common/upload-addon.js:451 static/js/zamboni/devhub-all.js:697 static/js/zamboni/devhub-min.js:1
+msgid "If your add-on requires an account to a website in order to be fully tested, include a test username and password in the Notes to Reviewer (this can be done in the next step)."
+msgstr "Ak váš doplnok vyžaduje účet na webovom serveri pre možnosť plnej kontroly, zadajte prosím používateľské meno a heslo do poznámky pre redaktora (možno vykonať v ďalšom kroku)."
 
-#: static/js/common/upload-addon.js:467
-msgid ""
-"If your add-on is intended for a limited audience you should choose "
-"Preliminary Review instead of Full Review."
-msgstr ""
-"Ak je váš doplnok určený pre obmedzený počet používateľov, mali by ste "
-"vybrať predbežnú kontrolu namiesto kompletnej."
+#: static/js/common/upload-addon.js:452 static/js/zamboni/devhub-all.js:698 static/js/zamboni/devhub-min.js:1
+msgid "If your add-on is intended for a limited audience you should choose Preliminary Review instead of Full Review."
+msgstr "Ak je váš doplnok určený pre obmedzený počet používateľov, mali by ste vybrať predbežnú kontrolu namiesto kompletnej."
 
-#: static/js/common/upload-addon.js:480
+#: static/js/common/upload-addon.js:465 static/js/zamboni/devhub-all.js:711 static/js/zamboni/devhub-min.js:1
 msgid "Add-on submission checklist"
 msgstr "Zoznam doplnkov odoslaných na kontrolu"
 
-#: static/js/common/upload-addon.js:481
-msgid ""
-"Please verify the following points before finalizing your submission. This "
-"will minimize delays or misunderstanding during the review process:"
-msgstr ""
-"Skontrolujte prosím nasledujúce body pred odoslaním doplnku na kontrolu. "
-"Pomôžete tým kontrolu zrýchliť a predísť prípadnému nedorozumeniu pri "
-"procese kontroly:"
+#: static/js/common/upload-addon.js:466 static/js/zamboni/devhub-all.js:712 static/js/zamboni/devhub-min.js:1
+msgid "Please verify the following points before finalizing your submission. This will minimize delays or misunderstanding during the review process:"
+msgstr "Skontrolujte prosím nasledujúce body pred odoslaním doplnku na kontrolu. Pomôžete tým kontrolu zrýchliť a predísť prípadnému nedorozumeniu pri procese kontroly:"
 
-#: static/js/common/upload-addon.js:483
+#: static/js/common/upload-addon.js:468 static/js/zamboni/devhub-all.js:714 static/js/zamboni/devhub-min.js:1
 msgid ""
-"Compiled binaries, as well as minified or obfuscated scripts (excluding "
-"known libraries) need to have their sources submitted separately for review."
-" Make sure that you use the source code upload field to avoid having your "
-"submission rejected."
+"Compiled binaries, as well as minified or obfuscated scripts (excluding known libraries) need to have their sources submitted separately for review. Make sure that you use the source code upload "
+"field to avoid having your submission rejected."
 msgstr ""
-"Skompilované binárne súčasti rovnako ako obfuscované skripty (okrem známych "
-"knižníc) musia mať predložené zdrojové súbory na kontrolu oddelene. Uistite "
-"sa, že ste použili pole pre nahranie zdrojových kódov, aby nedošlo k "
-"zamietnutiu kontroly."
+"Skompilované binárne súčasti rovnako ako obfuscované skripty (okrem známych knižníc) musia mať predložené zdrojové súbory na kontrolu oddelene. Uistite sa, že ste použili pole pre nahranie "
+"zdrojových kódov, aby nedošlo k zamietnutiu kontroly."
 
-#: static/js/common/upload-addon.js:501
+#: static/js/common/upload-addon.js:486 static/js/zamboni/devhub-all.js:732 static/js/zamboni/devhub-min.js:1
 msgid "The validation process found these issues that can lead to rejections:"
-msgstr ""
-"Proces kontroly zistil tieto možné nedostatky, ktoré môžu viesť k "
-"zamietnutiu kontroly:"
+msgstr "Proces kontroly zistil tieto možné nedostatky, ktoré môžu viesť k zamietnutiu kontroly:"
 
-#: static/js/common/upload-addon.js:518
-msgid ""
-"If you are unfamiliar with the add-ons review process, you can read about it"
-" here."
-msgstr ""
-"Ak ešte neviete, ako prebieha proces kontroly, môžete si o ňom prečítať tu."
+#: static/js/common/upload-addon.js:503 static/js/zamboni/devhub-all.js:749 static/js/zamboni/devhub-min.js:1
+msgid "If you are unfamiliar with the add-ons review process, you can read about it here."
+msgstr "Ak ešte neviete, ako prebieha proces kontroly, môžete si o ňom prečítať tu."
 
-#: static/js/common/upload-addon.js:555
+#: static/js/common/upload-addon.js:540 static/js/zamboni/devhub-all.js:786 static/js/zamboni/devhub-min.js:1
 msgid "Sorry, no supported platform has been found."
 msgstr "Ospravedlňujeme sa, ale nebola nájdená podporovaná platforma."
 
-#: static/js/common/upload-base.js:57
+#: static/js/common/upload-base.js:57 static/js/zamboni/devhub-all.js:187 static/js/zamboni/devhub-min.js:1
 msgid "The filetype you uploaded isn't recognized."
 msgstr "Nebol rozpoznaný typ súboru, ktorý ste odoslali."
 
-#: static/js/common/upload-base.js:79
+#: static/js/common/upload-base.js:79 static/js/zamboni/devhub-all.js:209 static/js/zamboni/devhub-min.js:1
 msgid "You cancelled the upload."
 msgstr "Odosielanie ste zrušili."
 
-#: static/js/common/upload-image.js:97 static/js/impala/users.js:51
-msgid "Images must be either PNG or JPG."
-msgstr "Obrázky musia mať formát PNG alebo JPG."
-
-#: static/js/common/upload-image.js:101
-msgid "Videos must be in WebM."
-msgstr "Videá musia byť vo formáte WebM."
-
-#: static/js/impala/collections.js:10 static/js/zamboni/collections.js:595
-msgid "Follow this Collection"
-msgstr "Odoberať túto kolekciu"
-
-#: static/js/impala/collections.js:19
-msgid "Stop Following"
-msgstr "Zastaviť odoberanie"
-
-#: static/js/impala/collections.js:20
-msgid "Following"
-msgstr "Odoberať"
-
-#. L10n: {0} is an app name.
-#: static/js/impala/listing.js:11 static/js/zamboni/themes.js:13
-msgid "This theme is incompatible with your version of {0}"
-msgstr "Táto téma nie je kompatibilná s vašou verziou aplikácie {0}"
-
-#: static/js/impala/persona_creation.js:60
-msgid "All Rights Reserved"
-msgstr "Všetky práva vyhradené"
-
-#: static/js/impala/persona_creation.js:64
-msgid "Creative Commons Attribution 3.0"
-msgstr "Creative Commons Attribution 3.0"
-
-#: static/js/impala/persona_creation.js:69
-msgid "Creative Commons Attribution-NonCommercial 3.0"
-msgstr "Creative Commons Attribution-NonCommercial 3.0"
-
-#: static/js/impala/persona_creation.js:74
-msgid "Creative Commons Attribution-NonCommercial-NoDerivs 3.0"
-msgstr "Creative Commons Attribution-NonCommercial-NoDerivs 3.0"
-
-#: static/js/impala/persona_creation.js:79
-msgid "Creative Commons Attribution-NonCommercial-Share Alike 3.0"
-msgstr "Creative Commons Attribution-NonCommercial-Share Alike 3.0"
-
-#: static/js/impala/persona_creation.js:84
-msgid "Creative Commons Attribution-NoDerivs 3.0"
-msgstr "Creative Commons Attribution-NoDerivs 3.0"
-
-#: static/js/impala/persona_creation.js:89
-msgid "Creative Commons Attribution-ShareAlike 3.0"
-msgstr "Creative Commons Attribution-ShareAlike 3.0"
-
-#: static/js/impala/persona_creation.js:292
-msgid "Your Theme's Name"
-msgstr "Názov vašej témy"
-
-#: static/js/impala/reviews.js:23 static/js/zamboni/reviews.js:18
-msgid "Flagged for review"
-msgstr "Označené na kontrolu"
-
-#: static/js/impala/reviews.js:40 static/js/zamboni/reviews.js:34
-msgid "Your input is required"
-msgstr "Vyžaduje sa zadanie údajov"
-
-#: static/js/impala/reviews.js:152 static/js/zamboni/reviews.js:103
-msgid "Marked for deletion"
-msgstr "Označené na odstránenie"
-
-#: static/js/impala/search.js:114
-msgid "Updating results&hellip;"
-msgstr "Prebieha aktualizácia výsledkov&hellip;"
-
-#: static/js/impala/site_suggestions.js:46
-msgid "Category"
-msgstr "Kategória"
-
-#: static/js/impala/suggestions.js:39
-msgid "Search themes for <b>{0}</b>"
-msgstr "Vyhľadávanie tém podľa <b>{0}</b>"
-
-#: static/js/impala/suggestions.js:41
-msgid "Search apps for <b>{0}</b>"
-msgstr "Vyhľadávanie aplikácií pre <b>{0}</b>"
-
-#: static/js/impala/suggestions.js:43
-msgid "Search add-ons for <b>{0}</b>"
-msgstr "Vyhľadávanie doplnkov pre <b>{0}</b>"
-
-#: static/js/impala/users.js:33
-msgid "use original"
-msgstr "použiť originál"
-
-#: static/js/impala/stats/chart.js:267
+#: static/js/impala/stats/chart.js:267 static/js/zamboni/stats-all.js:16898 static/js/zamboni/stats-min.js:5
 msgid "Week of {0}"
 msgstr "Týždeň {0}"
 
-#: static/js/impala/stats/chart.js:269
+#: static/js/impala/stats/chart.js:269 static/js/zamboni/stats-all.js:16900 static/js/zamboni/stats-min.js:5
 msgid " downloads"
-msgstr " prevzatí"
+msgstr ""
 
-#: static/js/impala/stats/chart.js:270
+#: static/js/impala/stats/chart.js:270 static/js/zamboni/stats-all.js:16901 static/js/zamboni/stats-min.js:5
 msgid "{0} users"
 msgstr "{0} používateľov"
 
-#: static/js/impala/stats/chart.js:271
+#: static/js/impala/stats/chart.js:271 static/js/zamboni/stats-all.js:16902 static/js/zamboni/stats-min.js:5
 msgid "{0} add-ons"
 msgstr "{0} doplnkov"
 
-#: static/js/impala/stats/chart.js:272
+#: static/js/impala/stats/chart.js:272 static/js/zamboni/stats-all.js:16903 static/js/zamboni/stats-min.js:5
 msgid "{0} collections"
 msgstr "{0} kolekcií"
 
-#: static/js/impala/stats/chart.js:273
+#: static/js/impala/stats/chart.js:273 static/js/zamboni/stats-all.js:16904 static/js/zamboni/stats-min.js:5
 msgid "{0} reviews"
 msgstr "{0} recenzií"
 
-#: static/js/impala/stats/chart.js:275
+#: static/js/impala/stats/chart.js:275 static/js/zamboni/stats-all.js:16906 static/js/zamboni/stats-min.js:5
 msgid "{0} sales"
 msgstr "{0} predaných"
 
-#: static/js/impala/stats/chart.js:276
+#: static/js/impala/stats/chart.js:276 static/js/zamboni/stats-all.js:16907 static/js/zamboni/stats-min.js:5
 msgid "{0} refunds"
 msgstr "{0} vrátených platieb"
 
-#: static/js/impala/stats/chart.js:277
+#: static/js/impala/stats/chart.js:277 static/js/zamboni/stats-all.js:16908 static/js/zamboni/stats-min.js:5
 msgid "{0} installs"
 msgstr "{0} inštalácií"
 
-#: static/js/impala/stats/chart.js:369 static/js/impala/stats/csv_keys.js:3
-#: static/js/impala/stats/csv_keys.js:109
+#: static/js/impala/stats/chart.js:369 static/js/impala/stats/csv_keys.js:3 static/js/impala/stats/csv_keys.js:109 static/js/zamboni/stats-all.js:15284 static/js/zamboni/stats-all.js:15390
+#: static/js/zamboni/stats-all.js:17000 static/js/zamboni/stats-min.js:4 static/js/zamboni/stats-min.js:5
 msgid "Downloads"
 msgstr "Prevzatí"
 
-#: static/js/impala/stats/chart.js:379 static/js/impala/stats/csv_keys.js:6
-#: static/js/impala/stats/csv_keys.js:110
+#: static/js/impala/stats/chart.js:379 static/js/impala/stats/csv_keys.js:6 static/js/impala/stats/csv_keys.js:110 static/js/zamboni/stats-all.js:15287 static/js/zamboni/stats-all.js:15391
+#: static/js/zamboni/stats-all.js:17010 static/js/zamboni/stats-min.js:4 static/js/zamboni/stats-min.js:5
 msgid "Daily Users"
 msgstr "Denní používatelia"
 
-#: static/js/impala/stats/chart.js:410
+#: static/js/impala/stats/chart.js:410 static/js/zamboni/stats-all.js:17041 static/js/zamboni/stats-min.js:5
 msgid "Amount, in USD"
 msgstr "Množstvo, v USD"
 
-#: static/js/impala/stats/chart.js:421 static/js/impala/stats/csv_keys.js:104
+#: static/js/impala/stats/chart.js:421 static/js/impala/stats/csv_keys.js:104 static/js/zamboni/stats-all.js:15385 static/js/zamboni/stats-all.js:17052 static/js/zamboni/stats-min.js:5
 msgid "Number of Contributions"
 msgstr "Počet príspevkov"
 
-#: static/js/impala/stats/chart.js:447
+#: static/js/impala/stats/chart.js:447 static/js/zamboni/stats-all.js:17078 static/js/zamboni/stats-min.js:5
 msgid "More Info..."
 msgstr "Viac informácií..."
 
 #. L10n: {0} is an ISO-formatted date.
-#: static/js/impala/stats/chart.js:451
+#: static/js/impala/stats/chart.js:451 static/js/zamboni/stats-all.js:17082 static/js/zamboni/stats-min.js:5
 msgid "Details for {0}"
 msgstr "Detaily pre {0}"
 
-#: static/js/impala/stats/csv_keys.js:9
+#: static/js/impala/stats/csv_keys.js:9 static/js/zamboni/stats-all.js:15290 static/js/zamboni/stats-min.js:4
 msgid "Collections Created"
 msgstr "Vytvorené kolekcie"
 
-#: static/js/impala/stats/csv_keys.js:12
+#: static/js/impala/stats/csv_keys.js:12 static/js/zamboni/stats-all.js:15293 static/js/zamboni/stats-min.js:4
 msgid "Add-ons in Use"
 msgstr "Používané doplnky"
 
-#: static/js/impala/stats/csv_keys.js:15
+#: static/js/impala/stats/csv_keys.js:15 static/js/zamboni/stats-all.js:15296 static/js/zamboni/stats-min.js:4
 msgid "Add-ons Created"
 msgstr "Vytvorené doplnky"
 
-#: static/js/impala/stats/csv_keys.js:18
+#: static/js/impala/stats/csv_keys.js:18 static/js/zamboni/stats-all.js:15299 static/js/zamboni/stats-min.js:4
 msgid "Add-ons Downloaded"
 msgstr "Prevzaté doplnky"
 
-#: static/js/impala/stats/csv_keys.js:21
+#: static/js/impala/stats/csv_keys.js:21 static/js/zamboni/stats-all.js:15302 static/js/zamboni/stats-min.js:4
 msgid "Add-ons Updated"
 msgstr "Aktualizované doplnky"
 
-#: static/js/impala/stats/csv_keys.js:24
+#: static/js/impala/stats/csv_keys.js:24 static/js/zamboni/stats-all.js:15305 static/js/zamboni/stats-min.js:4
 msgid "Reviews Written"
 msgstr "Napísané recenzie"
 
-#: static/js/impala/stats/csv_keys.js:27
+#: static/js/impala/stats/csv_keys.js:27 static/js/zamboni/stats-all.js:15308 static/js/zamboni/stats-min.js:4
 msgid "User Signups"
 msgstr "Prihlásení používatelia"
 
-#: static/js/impala/stats/csv_keys.js:30
+#: static/js/impala/stats/csv_keys.js:30 static/js/zamboni/stats-all.js:15311 static/js/zamboni/stats-min.js:4
 msgid "Subscribers"
 msgstr "Odberatelia"
 
-#: static/js/impala/stats/csv_keys.js:33
+#: static/js/impala/stats/csv_keys.js:33 static/js/zamboni/stats-all.js:15314 static/js/zamboni/stats-min.js:4
 msgid "Ratings"
 msgstr "Hodnotenia"
 
-#: static/js/impala/stats/csv_keys.js:36
-#: static/js/impala/stats/csv_keys.js:114
+#: static/js/impala/stats/csv_keys.js:36 static/js/impala/stats/csv_keys.js:114 static/js/zamboni/stats-all.js:15317 static/js/zamboni/stats-all.js:15395 static/js/zamboni/stats-min.js:4
+#: static/js/zamboni/stats-min.js:5
 msgid "Sales"
 msgstr "Predaje"
 
-#: static/js/impala/stats/csv_keys.js:39
-#: static/js/impala/stats/csv_keys.js:113
+#: static/js/impala/stats/csv_keys.js:39 static/js/impala/stats/csv_keys.js:113 static/js/zamboni/stats-all.js:15320 static/js/zamboni/stats-all.js:15394 static/js/zamboni/stats-min.js:4
+#: static/js/zamboni/stats-min.js:5
 msgid "Installs"
 msgstr "Inštalácie"
 
-#: static/js/impala/stats/csv_keys.js:42
+#: static/js/impala/stats/csv_keys.js:42 static/js/zamboni/stats-all.js:15323 static/js/zamboni/stats-min.js:4
 msgid "Unknown"
 msgstr "Neznáme"
 
-#: static/js/impala/stats/csv_keys.js:43
+#: static/js/impala/stats/csv_keys.js:43 static/js/zamboni/stats-all.js:15324 static/js/zamboni/stats-min.js:4
 msgid "Add-ons Manager"
 msgstr "Správca doplnkov"
 
-#: static/js/impala/stats/csv_keys.js:44
+#: static/js/impala/stats/csv_keys.js:44 static/js/zamboni/stats-all.js:15325 static/js/zamboni/stats-min.js:4
 msgid "Add-ons Manager Promo"
 msgstr "Propagácia v správcovi doplnkov"
 
-#: static/js/impala/stats/csv_keys.js:45
+#: static/js/impala/stats/csv_keys.js:45 static/js/zamboni/stats-all.js:15326 static/js/zamboni/stats-min.js:4
 msgid "Add-ons Manager Featured"
 msgstr "Odporúčané v správcovi doplnkov"
 
-#: static/js/impala/stats/csv_keys.js:46
+#: static/js/impala/stats/csv_keys.js:46 static/js/zamboni/stats-all.js:15327 static/js/zamboni/stats-min.js:4
 msgid "Add-ons Manager Learn More"
 msgstr "Zistiť viac v správcovi doplnkov"
 
-#: static/js/impala/stats/csv_keys.js:47
+#: static/js/impala/stats/csv_keys.js:47 static/js/zamboni/stats-all.js:15328 static/js/zamboni/stats-min.js:4
 msgid "Search Suggestions"
 msgstr "Návrhy vyhľadávania"
 
-#: static/js/impala/stats/csv_keys.js:48
+#: static/js/impala/stats/csv_keys.js:48 static/js/zamboni/stats-all.js:15329 static/js/zamboni/stats-min.js:4
 msgid "Search Results"
 msgstr "Výsledky hľadania"
 
-#: static/js/impala/stats/csv_keys.js:49 static/js/impala/stats/csv_keys.js:50
-#: static/js/impala/stats/csv_keys.js:51
+#: static/js/impala/stats/csv_keys.js:49 static/js/impala/stats/csv_keys.js:50 static/js/impala/stats/csv_keys.js:51 static/js/zamboni/stats-all.js:15330 static/js/zamboni/stats-all.js:15331
+#: static/js/zamboni/stats-all.js:15332 static/js/zamboni/stats-min.js:4
 msgid "Homepage Promo"
 msgstr "Domovská stránka (propagácia)"
 
-#: static/js/impala/stats/csv_keys.js:52 static/js/impala/stats/csv_keys.js:53
+#: static/js/impala/stats/csv_keys.js:52 static/js/impala/stats/csv_keys.js:53 static/js/zamboni/stats-all.js:15333 static/js/zamboni/stats-all.js:15334 static/js/zamboni/stats-min.js:4
 msgid "Homepage Featured"
 msgstr "Domovská stránka (odporúčané)"
 
-#: static/js/impala/stats/csv_keys.js:54 static/js/impala/stats/csv_keys.js:55
+#: static/js/impala/stats/csv_keys.js:54 static/js/impala/stats/csv_keys.js:55 static/js/zamboni/stats-all.js:15335 static/js/zamboni/stats-all.js:15336 static/js/zamboni/stats-min.js:4
 msgid "Homepage Up and Coming"
 msgstr "Domovská stránka (zaujímavé)"
 
-#: static/js/impala/stats/csv_keys.js:56
+#: static/js/impala/stats/csv_keys.js:56 static/js/zamboni/stats-all.js:15337 static/js/zamboni/stats-min.js:4
 msgid "Homepage Most Popular"
 msgstr "Domovská stránka (populárne)"
 
-#: static/js/impala/stats/csv_keys.js:57 static/js/impala/stats/csv_keys.js:59
+#: static/js/impala/stats/csv_keys.js:57 static/js/impala/stats/csv_keys.js:59 static/js/zamboni/stats-all.js:15338 static/js/zamboni/stats-all.js:15340 static/js/zamboni/stats-min.js:4
 msgid "Detail Page"
 msgstr "Stránka s detailmi"
 
-#: static/js/impala/stats/csv_keys.js:58 static/js/impala/stats/csv_keys.js:60
+#: static/js/impala/stats/csv_keys.js:58 static/js/impala/stats/csv_keys.js:60 static/js/zamboni/stats-all.js:15339 static/js/zamboni/stats-all.js:15341 static/js/zamboni/stats-min.js:4
 msgid "Detail Page (bottom)"
 msgstr "Stránka s detailmi (dole)"
 
-#: static/js/impala/stats/csv_keys.js:61
+#: static/js/impala/stats/csv_keys.js:61 static/js/zamboni/stats-all.js:15342 static/js/zamboni/stats-min.js:4
 msgid "Detail Page (Development Channel)"
 msgstr "Stránka s detailmi (vývojársky kanál)"
 
-#: static/js/impala/stats/csv_keys.js:62 static/js/impala/stats/csv_keys.js:63
-#: static/js/impala/stats/csv_keys.js:64
+#: static/js/impala/stats/csv_keys.js:62 static/js/impala/stats/csv_keys.js:63 static/js/impala/stats/csv_keys.js:64 static/js/zamboni/stats-all.js:15343 static/js/zamboni/stats-all.js:15344
+#: static/js/zamboni/stats-all.js:15345 static/js/zamboni/stats-min.js:4
 msgid "Often Used With"
 msgstr "Často sa používa spolu s"
 
-#: static/js/impala/stats/csv_keys.js:65 static/js/impala/stats/csv_keys.js:66
+#: static/js/impala/stats/csv_keys.js:65 static/js/impala/stats/csv_keys.js:66 static/js/zamboni/stats-all.js:15346 static/js/zamboni/stats-all.js:15347 static/js/zamboni/stats-min.js:4
 msgid "Others By Author"
 msgstr "Ďalšie aplikácie tohto autora"
 
-#: static/js/impala/stats/csv_keys.js:67 static/js/impala/stats/csv_keys.js:68
+#: static/js/impala/stats/csv_keys.js:67 static/js/impala/stats/csv_keys.js:68 static/js/zamboni/stats-all.js:15348 static/js/zamboni/stats-all.js:15349 static/js/zamboni/stats-min.js:4
 msgid "Dependencies"
 msgstr "Závislosti"
 
-#: static/js/impala/stats/csv_keys.js:69 static/js/impala/stats/csv_keys.js:70
+#: static/js/impala/stats/csv_keys.js:69 static/js/impala/stats/csv_keys.js:70 static/js/zamboni/stats-all.js:15350 static/js/zamboni/stats-all.js:15351 static/js/zamboni/stats-min.js:4
 msgid "Upsell"
 msgstr "Prechod na platenú variantu"
 
-#: static/js/impala/stats/csv_keys.js:71
+#: static/js/impala/stats/csv_keys.js:71 static/js/zamboni/stats-all.js:15352 static/js/zamboni/stats-min.js:4
 msgid "Meet the Developer"
 msgstr "Spoznajte vývojára"
 
-#: static/js/impala/stats/csv_keys.js:72
+#: static/js/impala/stats/csv_keys.js:72 static/js/zamboni/stats-all.js:15353 static/js/zamboni/stats-min.js:4
 msgid "User Profile"
 msgstr "Používateľský profil"
 
-#: static/js/impala/stats/csv_keys.js:73
+#: static/js/impala/stats/csv_keys.js:73 static/js/zamboni/stats-all.js:15354 static/js/zamboni/stats-min.js:4
 msgid "Version History"
 msgstr "História verzií"
 
-#: static/js/impala/stats/csv_keys.js:75
+#: static/js/impala/stats/csv_keys.js:75 static/js/zamboni/stats-all.js:15356 static/js/zamboni/stats-min.js:4
 msgid "Sharing"
 msgstr "Zdieľanie"
 
-#: static/js/impala/stats/csv_keys.js:76
+#: static/js/impala/stats/csv_keys.js:76 static/js/zamboni/stats-all.js:15357 static/js/zamboni/stats-min.js:4
 msgid "Category Pages"
 msgstr "Stránky kategórií"
 
-#: static/js/impala/stats/csv_keys.js:77
+#: static/js/impala/stats/csv_keys.js:77 static/js/zamboni/stats-all.js:15358 static/js/zamboni/stats-min.js:4
 msgid "Collections"
 msgstr "Kolekcie"
 
-#: static/js/impala/stats/csv_keys.js:78 static/js/impala/stats/csv_keys.js:79
+#: static/js/impala/stats/csv_keys.js:78 static/js/impala/stats/csv_keys.js:79 static/js/zamboni/stats-all.js:15359 static/js/zamboni/stats-all.js:15360 static/js/zamboni/stats-min.js:4
 msgid "Category Landing Featured Carousel"
 msgstr "Kategória s odporúčanými doplnkami"
 
-#: static/js/impala/stats/csv_keys.js:80 static/js/impala/stats/csv_keys.js:81
+#: static/js/impala/stats/csv_keys.js:80 static/js/impala/stats/csv_keys.js:81 static/js/zamboni/stats-all.js:15361 static/js/zamboni/stats-all.js:15362 static/js/zamboni/stats-min.js:4
 msgid "Category Landing Top Rated"
 msgstr "Kategórie najlepšie hodnotených"
 
-#: static/js/impala/stats/csv_keys.js:82 static/js/impala/stats/csv_keys.js:83
+#: static/js/impala/stats/csv_keys.js:82 static/js/impala/stats/csv_keys.js:83 static/js/zamboni/stats-all.js:15363 static/js/zamboni/stats-all.js:15364 static/js/zamboni/stats-min.js:5
 msgid "Category Landing Most Popular"
 msgstr "Kategórie najviac populárnych"
 
-#: static/js/impala/stats/csv_keys.js:84 static/js/impala/stats/csv_keys.js:85
+#: static/js/impala/stats/csv_keys.js:84 static/js/impala/stats/csv_keys.js:85 static/js/zamboni/stats-all.js:15365 static/js/zamboni/stats-all.js:15366 static/js/zamboni/stats-min.js:5
 msgid "Category Landing Recently Added"
 msgstr "Kategórie naposledy pridaných"
 
-#: static/js/impala/stats/csv_keys.js:86 static/js/impala/stats/csv_keys.js:87
+#: static/js/impala/stats/csv_keys.js:86 static/js/impala/stats/csv_keys.js:87 static/js/zamboni/stats-all.js:15367 static/js/zamboni/stats-all.js:15368 static/js/zamboni/stats-min.js:5
 msgid "Browse Listing Featured Sort"
 msgstr "Zoznam doplnkov podľa obľúbenosti"
 
-#: static/js/impala/stats/csv_keys.js:88 static/js/impala/stats/csv_keys.js:89
+#: static/js/impala/stats/csv_keys.js:88 static/js/impala/stats/csv_keys.js:89 static/js/zamboni/stats-all.js:15369 static/js/zamboni/stats-all.js:15370 static/js/zamboni/stats-min.js:5
 msgid "Browse Listing Users Sort"
 msgstr "Zoznam doplnkov podľa počtu používateľov"
 
-#: static/js/impala/stats/csv_keys.js:90 static/js/impala/stats/csv_keys.js:91
+#: static/js/impala/stats/csv_keys.js:90 static/js/impala/stats/csv_keys.js:91 static/js/zamboni/stats-all.js:15371 static/js/zamboni/stats-all.js:15372 static/js/zamboni/stats-min.js:5
 msgid "Browse Listing Rating Sort"
 msgstr "Zoznam doplnkov podľa hodnotenia"
 
-#: static/js/impala/stats/csv_keys.js:92 static/js/impala/stats/csv_keys.js:93
+#: static/js/impala/stats/csv_keys.js:92 static/js/impala/stats/csv_keys.js:93 static/js/zamboni/stats-all.js:15373 static/js/zamboni/stats-all.js:15374 static/js/zamboni/stats-min.js:5
 msgid "Browse Listing Created Sort"
 msgstr "Zoznam doplnkov podľa dátumu vytvorenia"
 
-#: static/js/impala/stats/csv_keys.js:94 static/js/impala/stats/csv_keys.js:95
+#: static/js/impala/stats/csv_keys.js:94 static/js/impala/stats/csv_keys.js:95 static/js/zamboni/stats-all.js:15375 static/js/zamboni/stats-all.js:15376 static/js/zamboni/stats-min.js:5
 msgid "Browse Listing Name Sort"
 msgstr "Zoznam doplnkov podľa názvu"
 
-#: static/js/impala/stats/csv_keys.js:96 static/js/impala/stats/csv_keys.js:97
+#: static/js/impala/stats/csv_keys.js:96 static/js/impala/stats/csv_keys.js:97 static/js/zamboni/stats-all.js:15377 static/js/zamboni/stats-all.js:15378 static/js/zamboni/stats-min.js:5
 msgid "Browse Listing Popular Sort"
 msgstr "Zoznam doplnkov podľa popularity"
 
-#: static/js/impala/stats/csv_keys.js:98 static/js/impala/stats/csv_keys.js:99
+#: static/js/impala/stats/csv_keys.js:98 static/js/impala/stats/csv_keys.js:99 static/js/zamboni/stats-all.js:15379 static/js/zamboni/stats-all.js:15380 static/js/zamboni/stats-min.js:5
 msgid "Browse Listing Updated Sort"
 msgstr "Zoznam doplnkov podľa dátumu aktualizácie"
 
-#: static/js/impala/stats/csv_keys.js:100
-#: static/js/impala/stats/csv_keys.js:101
+#: static/js/impala/stats/csv_keys.js:100 static/js/impala/stats/csv_keys.js:101 static/js/zamboni/stats-all.js:15381 static/js/zamboni/stats-all.js:15382 static/js/zamboni/stats-min.js:5
 msgid "Browse Listing Up and Coming Sort"
 msgstr "Zoznam doplnkov podľa žiadanosti"
 
-#: static/js/impala/stats/csv_keys.js:105
+#: static/js/impala/stats/csv_keys.js:105 static/js/zamboni/stats-all.js:15386 static/js/zamboni/stats-min.js:5
 msgid "Total Amount Contributed"
 msgstr "Celkovo prispelo"
 
-#: static/js/impala/stats/csv_keys.js:106
+#: static/js/impala/stats/csv_keys.js:106 static/js/zamboni/stats-all.js:15387 static/js/zamboni/stats-min.js:5
 msgid "Average Contribution"
 msgstr "Priemerný príspevok"
 
-#: static/js/impala/stats/csv_keys.js:115
+#: static/js/impala/stats/csv_keys.js:115 static/js/zamboni/stats-all.js:15396 static/js/zamboni/stats-min.js:5
 msgid "Usage"
 msgstr "Používanie"
 
-#: static/js/impala/stats/csv_keys.js:118
+#: static/js/impala/stats/csv_keys.js:118 static/js/zamboni/stats-all.js:15399 static/js/zamboni/stats-min.js:5
 msgid "Firefox"
 msgstr "Firefox"
 
-#: static/js/impala/stats/csv_keys.js:119
+#: static/js/impala/stats/csv_keys.js:119 static/js/zamboni/stats-all.js:15400 static/js/zamboni/stats-min.js:5
 msgid "Mozilla"
 msgstr "Mozilla"
 
-#: static/js/impala/stats/csv_keys.js:120
+#: static/js/impala/stats/csv_keys.js:120 static/js/zamboni/stats-all.js:15401 static/js/zamboni/stats-min.js:5
 msgid "Thunderbird"
 msgstr "Thunderbird"
 
-#: static/js/impala/stats/csv_keys.js:121
+#: static/js/impala/stats/csv_keys.js:121 static/js/zamboni/stats-all.js:15402 static/js/zamboni/stats-min.js:5
 msgid "Sunbird"
 msgstr "Sunbird"
 
-#: static/js/impala/stats/csv_keys.js:122
+#: static/js/impala/stats/csv_keys.js:122 static/js/zamboni/stats-all.js:15403 static/js/zamboni/stats-min.js:5
 msgid "SeaMonkey"
 msgstr "SeaMonkey"
 
-#: static/js/impala/stats/csv_keys.js:123
+#: static/js/impala/stats/csv_keys.js:123 static/js/zamboni/stats-all.js:15404 static/js/zamboni/stats-min.js:5
 msgid "Fennec"
 msgstr "Fennec"
 
-#: static/js/impala/stats/csv_keys.js:124
+#: static/js/impala/stats/csv_keys.js:124 static/js/zamboni/stats-all.js:15405 static/js/zamboni/stats-min.js:5
 msgid "Android"
 msgstr "Android"
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:129
+#: static/js/impala/stats/csv_keys.js:129 static/js/zamboni/stats-all.js:15410 static/js/zamboni/stats-min.js:5
 msgid "Downloads and Daily Users, last {0} days"
 msgstr "Prevzatia a denní používatelia, posledných {0} dní"
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:131
+#: static/js/impala/stats/csv_keys.js:131 static/js/zamboni/stats-all.js:15412 static/js/zamboni/stats-min.js:5
 msgid "Downloads and Daily Users from {0} to {1}"
 msgstr "Prevzatia a denní používatelia od {0} do {1}"
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:135
+#: static/js/impala/stats/csv_keys.js:135 static/js/zamboni/stats-all.js:15416 static/js/zamboni/stats-min.js:5
 msgid "Installs and Daily Users, last {0} days"
 msgstr "Inštalácie a denní používatelia, posledných {0} dní"
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:137
+#: static/js/impala/stats/csv_keys.js:137 static/js/zamboni/stats-all.js:15418 static/js/zamboni/stats-min.js:5
 msgid "Installs and Daily Users from {0} to {1}"
 msgstr "Inštalácie a denní používatelia od {0} do {1}"
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:141
+#: static/js/impala/stats/csv_keys.js:141 static/js/zamboni/stats-all.js:15422 static/js/zamboni/stats-min.js:5
 msgid "Downloads, last {0} days"
 msgstr "Prevzatia, posledných {0} dní"
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:143
+#: static/js/impala/stats/csv_keys.js:143 static/js/zamboni/stats-all.js:15424 static/js/zamboni/stats-min.js:5
 msgid "Downloads from {0} to {1}"
 msgstr "Prevzatí od {0} do {1}"
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:147
+#: static/js/impala/stats/csv_keys.js:147 static/js/zamboni/stats-all.js:15428 static/js/zamboni/stats-min.js:5
 msgid "Daily Users, last {0} days"
 msgstr "Denní používatelia, posledných {0} dní"
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:149
+#: static/js/impala/stats/csv_keys.js:149 static/js/zamboni/stats-all.js:15430 static/js/zamboni/stats-min.js:5
 msgid "Daily Users from {0} to {1}"
 msgstr "Denní používatelia od {0} do {1}"
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:153
+#: static/js/impala/stats/csv_keys.js:153 static/js/zamboni/stats-all.js:15434 static/js/zamboni/stats-min.js:5
 msgid "Applications, last {0} days"
 msgstr "Aplikácie, posledných {0} dní"
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:155
+#: static/js/impala/stats/csv_keys.js:155 static/js/zamboni/stats-all.js:15436 static/js/zamboni/stats-min.js:5
 msgid "Applications from {0} to {1}"
 msgstr "Aplikácie od {0} do {1}"
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:159
+#: static/js/impala/stats/csv_keys.js:159 static/js/zamboni/stats-all.js:15440 static/js/zamboni/stats-min.js:5
 msgid "Platforms, last {0} days"
 msgstr "Platformy, posledných {0} dní"
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:161
+#: static/js/impala/stats/csv_keys.js:161 static/js/zamboni/stats-all.js:15442 static/js/zamboni/stats-min.js:5
 msgid "Platforms from {0} to {1}"
 msgstr "Platformy od {0} do {1}"
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:165
+#: static/js/impala/stats/csv_keys.js:165 static/js/zamboni/stats-all.js:15446 static/js/zamboni/stats-min.js:5
 msgid "Languages, last {0} days"
 msgstr "Jazyky, posledných {0} dní"
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:167
+#: static/js/impala/stats/csv_keys.js:167 static/js/zamboni/stats-all.js:15448 static/js/zamboni/stats-min.js:5
 msgid "Languages from {0} to {1}"
 msgstr "Jazyky od {0} do {1}"
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:171
+#: static/js/impala/stats/csv_keys.js:171 static/js/zamboni/stats-all.js:15452 static/js/zamboni/stats-min.js:5
 msgid "Add-on Versions, last {0} days"
 msgstr "Verzie doplnkov, posledných {0} dní"
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:173
+#: static/js/impala/stats/csv_keys.js:173 static/js/zamboni/stats-all.js:15454 static/js/zamboni/stats-min.js:5
 msgid "Add-on Versions from {0} to {1}"
 msgstr "Verzie doplnku od {0} do {1}"
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:177
+#: static/js/impala/stats/csv_keys.js:177 static/js/zamboni/stats-all.js:15458 static/js/zamboni/stats-min.js:5
 msgid "Add-on Status, last {0} days"
 msgstr "Stav doplnkov, posledných {0} dní"
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:179
+#: static/js/impala/stats/csv_keys.js:179 static/js/zamboni/stats-all.js:15460 static/js/zamboni/stats-min.js:5
 msgid "Add-on Status from {0} to {1}"
 msgstr "Stav doplnku od {0} do {1}"
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:183
+#: static/js/impala/stats/csv_keys.js:183 static/js/zamboni/stats-all.js:15464 static/js/zamboni/stats-min.js:5
 msgid "Download Sources, last {0} days"
 msgstr "Zdroje prevzatí, posledných {0} dní"
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:185
+#: static/js/impala/stats/csv_keys.js:185 static/js/zamboni/stats-all.js:15466 static/js/zamboni/stats-min.js:5
 msgid "Download Sources from {0} to {1}"
 msgstr "Zdroje preberania od {0} do {1}"
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:189
+#: static/js/impala/stats/csv_keys.js:189 static/js/zamboni/stats-all.js:15470 static/js/zamboni/stats-min.js:5
 msgid "Contributions, last {0} days"
 msgstr "Príspevky, posledných {0} dní"
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:191
+#: static/js/impala/stats/csv_keys.js:191 static/js/zamboni/stats-all.js:15472 static/js/zamboni/stats-min.js:5
 msgid "Contributions from {0} to {1}"
 msgstr "Prispievatelia od {0} do {1}"
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:195
+#: static/js/impala/stats/csv_keys.js:195 static/js/zamboni/stats-all.js:15476 static/js/zamboni/stats-min.js:5
 msgid "Site Metrics, last {0} days"
 msgstr "Štatistika webu, posledných {0} dní"
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:197
+#: static/js/impala/stats/csv_keys.js:197 static/js/zamboni/stats-all.js:15478 static/js/zamboni/stats-min.js:5
 msgid "Site Metrics from {0} to {1}"
 msgstr "Štatistika webu od {0} do {1}"
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:201
+#: static/js/impala/stats/csv_keys.js:201 static/js/zamboni/stats-all.js:15482 static/js/zamboni/stats-min.js:5
 msgid "Add-ons in Use, last {0} days"
 msgstr "Používané doplnky, posledných {0} dní"
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:203
+#: static/js/impala/stats/csv_keys.js:203 static/js/zamboni/stats-all.js:15484 static/js/zamboni/stats-min.js:5
 msgid "Add-ons in Use from {0} to {1}"
 msgstr "Používané doplnky od {0} do {1}"
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:207
+#: static/js/impala/stats/csv_keys.js:207 static/js/zamboni/stats-all.js:15488 static/js/zamboni/stats-min.js:5
 msgid "Add-ons Downloaded, last {0} days"
 msgstr "Prevzaté doplnky, posledných {0} dní"
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:209
+#: static/js/impala/stats/csv_keys.js:209 static/js/zamboni/stats-all.js:15490 static/js/zamboni/stats-min.js:5
 msgid "Add-ons Downloaded from {0} to {1}"
 msgstr "Prevzaté doplnky od {0} do {1}"
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:213
+#: static/js/impala/stats/csv_keys.js:213 static/js/zamboni/stats-all.js:15494 static/js/zamboni/stats-min.js:5
 msgid "Add-ons Created, last {0} days"
 msgstr "Vytvorené doplnky, posledných {0} dní"
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:215
+#: static/js/impala/stats/csv_keys.js:215 static/js/zamboni/stats-all.js:15496 static/js/zamboni/stats-min.js:5
 msgid "Add-ons Created from {0} to {1}"
 msgstr "Vytvorené doplnky, od {0} do {1}"
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:219
+#: static/js/impala/stats/csv_keys.js:219 static/js/zamboni/stats-all.js:15500 static/js/zamboni/stats-min.js:5
 msgid "Add-ons Updated, last {0} days"
 msgstr "Aktualizované doplnky, posledných {0} dní"
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:221
+#: static/js/impala/stats/csv_keys.js:221 static/js/zamboni/stats-all.js:15502 static/js/zamboni/stats-min.js:5
 msgid "Add-ons Updated from {0} to {1}"
 msgstr "Aktualizované doplnky, od {0} do {1}"
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:225
+#: static/js/impala/stats/csv_keys.js:225 static/js/zamboni/stats-all.js:15506 static/js/zamboni/stats-min.js:5
 msgid "Reviews Written, last {0} days"
 msgstr "Napísané recenzie, posledných {0} dní"
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:227
+#: static/js/impala/stats/csv_keys.js:227 static/js/zamboni/stats-all.js:15508 static/js/zamboni/stats-min.js:5
 msgid "Reviews Written from {0} to {1}"
 msgstr "Napísané recenzie, od {0} do {1}"
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:231
+#: static/js/impala/stats/csv_keys.js:231 static/js/zamboni/stats-all.js:15512 static/js/zamboni/stats-min.js:5
 msgid "User Signups, last {0} days"
 msgstr "Prihlásení používatelia, posledných {0} dní"
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:233
+#: static/js/impala/stats/csv_keys.js:233 static/js/zamboni/stats-all.js:15514 static/js/zamboni/stats-min.js:5
 msgid "User Signups from {0} to {1}"
 msgstr "Prihlásení používatelia, od {0} do {1}"
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:237
+#: static/js/impala/stats/csv_keys.js:237 static/js/zamboni/stats-all.js:15518 static/js/zamboni/stats-min.js:5
 msgid "Collections Created, last {0} days"
 msgstr "Vytvorené kolekcie, posledných {0} dní"
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:239
+#: static/js/impala/stats/csv_keys.js:239 static/js/zamboni/stats-all.js:15520 static/js/zamboni/stats-min.js:5
 msgid "Collections Created from {0} to {1}"
 msgstr "Vytvorené kolekcie, od {0} do {1}"
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:243
+#: static/js/impala/stats/csv_keys.js:243 static/js/zamboni/stats-all.js:15524 static/js/zamboni/stats-min.js:5
 msgid "Subscribers, last {0} days"
 msgstr "Odbery, posledných {0} dní"
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:245
+#: static/js/impala/stats/csv_keys.js:245 static/js/zamboni/stats-all.js:15526 static/js/zamboni/stats-min.js:5
 msgid "Subscribers from {0} to {1}"
 msgstr "Odbery, od {0} do {1}"
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:249
+#: static/js/impala/stats/csv_keys.js:249 static/js/zamboni/stats-all.js:15530 static/js/zamboni/stats-min.js:5
 msgid "Ratings, last {0} days"
 msgstr "Hodnotenia, posledných {0} dní"
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:251
+#: static/js/impala/stats/csv_keys.js:251 static/js/zamboni/stats-all.js:15532 static/js/zamboni/stats-min.js:5
 msgid "Ratings from {0} to {1}"
 msgstr "Hodnotenia, od {0} do {1}"
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:255
+#: static/js/impala/stats/csv_keys.js:255 static/js/zamboni/stats-all.js:15536 static/js/zamboni/stats-min.js:5
 msgid "Sales, last {0} days"
 msgstr "Predaje, posledných {0} dní"
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:257
+#: static/js/impala/stats/csv_keys.js:257 static/js/zamboni/stats-all.js:15538 static/js/zamboni/stats-min.js:5
 msgid "Sales from {0} to {1}"
 msgstr "Predaje od {0} do {1}"
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:261
+#: static/js/impala/stats/csv_keys.js:261 static/js/zamboni/stats-all.js:15542 static/js/zamboni/stats-min.js:5
 msgid "Installs, last {0} days"
 msgstr "Inštalácie, posledných {0} dní"
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:263
+#: static/js/impala/stats/csv_keys.js:263 static/js/zamboni/stats-all.js:15544 static/js/zamboni/stats-min.js:5
 msgid "Installs from {0} to {1}"
 msgstr "Inštalácie, od {0} do {1}"
 
 #. L10n: {0} and {1} are integers.
-#: static/js/impala/stats/csv_keys.js:269
+#: static/js/impala/stats/csv_keys.js:269 static/js/zamboni/stats-all.js:15550 static/js/zamboni/stats-min.js:5
 msgid "<b>{0}</b> in last {1} days"
 msgstr "<b>{0}</b> za posledných {1} dní"
 
 #. L10n: {0} is an integer and {1} and {2} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:271
-#: static/js/impala/stats/csv_keys.js:277
+#: static/js/impala/stats/csv_keys.js:271 static/js/impala/stats/csv_keys.js:277 static/js/zamboni/stats-all.js:15552 static/js/zamboni/stats-all.js:15558 static/js/zamboni/stats-min.js:5
 msgid "<b>{0}</b> from {1} to {2}"
 msgstr "<b>{0}</b> od {1} do {2}"
 
 #. L10n: {0} and {1} are integers.
-#: static/js/impala/stats/csv_keys.js:275
+#: static/js/impala/stats/csv_keys.js:275 static/js/zamboni/stats-all.js:15556 static/js/zamboni/stats-min.js:5
 msgid "<b>{0}</b> average in last {1} days"
 msgstr "<b>{0}</b> priemerne za posledných {1} dní"
 
-#: static/js/impala/stats/overview.js:19
+#: static/js/impala/stats/overview.js:19 static/js/zamboni/stats-all.js:16469 static/js/zamboni/stats-min.js:5
 msgid "No data available."
 msgstr "Údaje sú nedostupné."
 
-#: static/js/impala/stats/table.js:74
+#: static/js/impala/stats/table.js:74 static/js/zamboni/stats-all.js:17209 static/js/zamboni/stats-min.js:5
 msgid "Date"
 msgstr "Dátum"
 
-#: static/js/impala/stats/topchart.js:96
+#: static/js/impala/stats/topchart.js:96 static/js/zamboni/stats-all.js:16600 static/js/zamboni/stats-min.js:5
 msgid "Other"
 msgstr "Iný"
 
-#: static/js/zamboni/admin_validation.js:24 static/js/zamboni/devhub.js:1229
-#: static/js/zamboni/editors.js:295
+#: static/js/zamboni/admin-all.js:180 static/js/zamboni/admin-min.js:1 static/js/zamboni/admin_validation.js:24 static/js/zamboni/devhub-all.js:2408 static/js/zamboni/devhub-min.js:2
+#: static/js/zamboni/devhub.js:1229 static/js/zamboni/editors-all.js:15576 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:295
 msgid "Select an application first"
 msgstr "Najskôr zvoľte aplikáciu"
 
-#: static/js/zamboni/admin_validation.js:51
+#: static/js/zamboni/admin-all.js:207 static/js/zamboni/admin-min.js:1 static/js/zamboni/admin_validation.js:51
 msgid "Set {0} add-on to a max version of {1} and email the author."
 msgid_plural "Set {0} add-ons to a max version of {1} and email the authors."
-msgstr[0] ""
-"Nastaviť maximálnu verziu aplikácie {1} pre {0} doplnok a odoslať e-mailovú "
-"správu autorom."
-msgstr[1] ""
-"Nastaviť maximálnu verziu aplikácie {1} pre {0} doplnky a odoslať e-mailovú "
-"správu autorom."
-msgstr[2] ""
-"Nastaviť maximálnu verziu aplikácie {1} pre {0} doplnkov a odoslať e-mailovú"
-" správu autorom."
+msgstr[0] "Nastaviť maximálnu verziu aplikácie {1} pre {0} doplnok a odoslať e-mailovú správu autorom."
+msgstr[1] "Nastaviť maximálnu verziu aplikácie {1} pre {0} doplnky a odoslať e-mailovú správu autorom."
 
-#: static/js/zamboni/admin_validation.js:54
+#: static/js/zamboni/admin-all.js:210 static/js/zamboni/admin-min.js:1 static/js/zamboni/admin_validation.js:54
 msgid "Email author of {2} add-on which failed validation."
 msgid_plural "Email authors of {2} add-ons which failed validation."
 msgstr[0] "Odoslať e-mail autorovi {2} doplnku, u ktorého zlyhala kontrola."
 msgstr[1] "Odoslať e-mail autorom {2} doplnkov, u ktorých zlyhala kontrola."
-msgstr[2] "Odoslať e-mail autorom {2} doplnkov, u ktorých zlyhala kontrola."
 
-#. L10n: {0} is an app name like Firefox.
-#: static/js/zamboni/buttons.js:66
-msgid "Accept and Install"
-msgstr "Prijať a nainštalovať"
-
-#: static/js/zamboni/buttons.js:66
-msgid "Add to {0}"
-msgstr "Pridať do programu {0}"
-
-#: static/js/zamboni/buttons.js:71
-msgid "Download Now"
-msgstr "Prevziať teraz"
-
-#: static/js/zamboni/buttons.js:112
-msgid "Add-on has not been updated to support default-to-compatible."
-msgstr ""
-"Doplnok nebol aktualizovaný tak, aby bol v predvolenom nastavení "
-"kompatibilný."
-
-#: static/js/zamboni/buttons.js:117
-msgid "You need to be using Firefox 10.0 or higher."
-msgstr "Musíte používať Firefox 10.0 alebo novší."
-
-#: static/js/zamboni/buttons.js:129
-msgid ""
-"Mozilla has marked this version as incompatible with your Firefox version."
-msgstr ""
-"Mozilla označila túto verziu ako nekompatibilnú s vašou verziou Firefoxu."
-
-#. L10n: {0} is an platform like Windows or Linux.
-#: static/js/zamboni/buttons.js:210
-msgid "Install for {0} anyway"
-msgstr "Napriek tomu nainštalovať pre {0}"
-
-#: static/js/zamboni/buttons.js:210
-msgid "Download for {0} anyway"
-msgstr "Napriek tomu prevziať pre {0}"
-
-#: static/js/zamboni/buttons.js:267
-msgid "Not available for your platform"
-msgstr "Nie je dostupné pre vašu platformu."
-
-#. L10n: {0} is an app name, {1} is the app version.
-#: static/js/zamboni/buttons.js:278 static/js/zamboni/buttons.js:315
-msgid "Not available for {0} {1}"
-msgstr "Nie je dostupné pre {0} {1}"
-
-#: static/js/zamboni/buttons.js:341
-msgid "Works with {app} {min} - {max}"
-msgstr "Funguje s {app} {min} - {max}"
-
-#: static/js/zamboni/buttons.js:343
-msgid "View other versions"
-msgstr "Zobraziť ďalšie verzie"
-
-#: static/js/zamboni/buttons.js:391
-msgid "Only with Firefox — Get Firefox Now!"
-msgstr "Len pre Firefox — získajte Firefox teraz!"
-
-#: static/js/zamboni/buttons.js:507 static/js/zamboni/mobile/buttons.js:43
-msgid ""
-"Sorry, you need a Mozilla-based browser (such as Firefox) to install a "
-"search plugin."
-msgstr ""
-"Ak chcete nainštalovať vyhľadávací modul, potrebujete prehliadač založený na"
-" kóde Mozilla (napríklad Firefox)."
-
-#: static/js/zamboni/collections.js:229
-msgid "Adding to Favorites&hellip;"
-msgstr "Pridať medzi obľúbené&hellip;"
-
-#: static/js/zamboni/collections.js:232
-msgid "Removing Favorite&hellip;"
-msgstr "Odstraňuje sa zo zoznamu obľúbených&hellip;"
-
-#: static/js/zamboni/collections.js:235
-msgid "Add to Favorites"
-msgstr "Pridať medzi obľúbené"
-
-#: static/js/zamboni/collections.js:238
-msgid "Remove from Favorites"
-msgstr "Odstrániť z obľúbených"
-
-#: static/js/zamboni/collections.js:303
-msgid "Pending"
-msgstr "Čakajúci"
-
-#: static/js/zamboni/collections.js:304
-msgid "Add a comment"
-msgstr "Pridať komentár"
-
-#: static/js/zamboni/collections.js:304
-msgid "Comment"
-msgstr "Komentár"
-
-#: static/js/zamboni/collections.js:305
-msgid "Remove this add-on from the collection"
-msgstr "Odstrániť tento doplnok z kolekcie"
-
-#: static/js/zamboni/collections.js:305 static/js/zamboni/collections.js:334
-msgid "Remove"
-msgstr "Odstrániť"
-
-#: static/js/zamboni/collections.js:334
-msgid "Remove this user as a contributor"
-msgstr "Odstrániť tohto používateľa ako prispievateľa"
-
-#: static/js/zamboni/collections.js:346
-msgid "An email address is required."
-msgstr "E-mailová adresa je požadovaná."
-
-#: static/js/zamboni/collections.js:364
-msgid "You cannot add yourself as a contributor."
-msgstr "Nemôžete ako prispievateľa pridať samých seba."
-
-#: static/js/zamboni/collections.js:366
-msgid "You have already added that user."
-msgstr "Tohto používateľa ste už pridali."
-
-#: static/js/zamboni/collections.js:573
-msgid "Add to favorites"
-msgstr "Pridať medzi obľúbené"
-
-#: static/js/zamboni/collections.js:577
-msgid "Remove from favorites"
-msgstr "Odstrániť z obľúbených"
-
-#: static/js/zamboni/collections.js:604
-msgid "Stop following"
-msgstr "Zastaviť odber"
-
-#: static/js/zamboni/devhub.js:110
+#: static/js/zamboni/devhub-all.js:1289 static/js/zamboni/devhub-min.js:1 static/js/zamboni/devhub.js:110
 msgid "Your browser does not support the video tag"
 msgstr "Váš prehliadač nepodporuje HTML značku video"
 
-#: static/js/zamboni/devhub.js:371
+#: static/js/zamboni/devhub-all.js:1550 static/js/zamboni/devhub-min.js:1 static/js/zamboni/devhub.js:371
 msgid "Changes Saved"
 msgstr "Zmeny boli uložené"
 
-#: static/js/zamboni/devhub.js:387
+#: static/js/zamboni/devhub-all.js:1566 static/js/zamboni/devhub-min.js:1 static/js/zamboni/devhub.js:387
 msgid "Enter a new author's email address"
 msgstr "Zadajte e-mailovú adresu nového autora"
 
-#: static/js/zamboni/devhub.js:536
+#: static/js/zamboni/devhub-all.js:1715 static/js/zamboni/devhub-min.js:1 static/js/zamboni/devhub.js:536
 msgid "There was an error uploading your file."
 msgstr "Pri odosielaní súboru sa vyskytla chyba."
 
-#: static/js/zamboni/devhub.js:681
+#: static/js/zamboni/devhub-all.js:1860 static/js/zamboni/devhub-min.js:1 static/js/zamboni/devhub.js:681
 msgid "{files} file"
 msgid_plural "{files} files"
 msgstr[0] "{files} súbor"
 msgstr[1] "{files} súbory"
-msgstr[2] "{files} súborov"
 
-#: static/js/zamboni/devhub.js:684
+#: static/js/zamboni/devhub-all.js:1863 static/js/zamboni/devhub-min.js:1 static/js/zamboni/devhub.js:684
 msgid "{reviews} user review"
 msgid_plural "{reviews} user reviews"
 msgstr[0] "{reviews} recenzia používateľa"
 msgstr[1] "{reviews} recenzie používateľa"
-msgstr[2] "{reviews} recenzií používateľa"
 
-#: static/js/zamboni/devhub.js:796
+#: static/js/zamboni/devhub-all.js:1975 static/js/zamboni/devhub-min.js:2 static/js/zamboni/devhub.js:796
 msgid "Learn more"
 msgstr "Ďalšie informácie"
 
-#: static/js/zamboni/devhub.js:800
+#: static/js/zamboni/devhub-all.js:1979 static/js/zamboni/devhub-min.js:2 static/js/zamboni/devhub.js:800
 msgid "Example"
 msgstr "Príklad"
 
-#: static/js/zamboni/devhub.js:1130
+#: static/js/zamboni/devhub-all.js:2309 static/js/zamboni/devhub-min.js:2 static/js/zamboni/devhub.js:1130
 msgid "Image changes being processed"
 msgstr "Zmeny obrázkov sa práve spracovávajú"
 
-#: static/js/zamboni/devhub.js:1280
+#: static/js/zamboni/devhub-all.js:2459 static/js/zamboni/devhub-min.js:2 static/js/zamboni/devhub.js:1280
 msgid "Must be a valid e-mail address."
 msgstr "Musí to byť platná e-mailová adresa."
+
+#: static/js/zamboni/devhub-all.js:2613 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:80
+msgid "All tests passed successfully."
+msgstr "Všetky testy ukončené úspešne."
+
+#: static/js/zamboni/devhub-all.js:2616 static/js/zamboni/devhub-all.js:3011 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:83 static/js/zamboni/validator.js:478
+msgid "These tests were not run."
+msgstr "Tieto testy neboli spustené."
+
+#: static/js/zamboni/devhub-all.js:2664 static/js/zamboni/devhub-all.js:2677 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:131 static/js/zamboni/validator.js:144
+msgid "Tests"
+msgstr "Testy"
+
+#: static/js/zamboni/devhub-all.js:2779 static/js/zamboni/devhub-all.js:3108 static/js/zamboni/devhub-all.js:3127 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:246
+#: static/js/zamboni/validator.js:575 static/js/zamboni/validator.js:594
+msgid "Error"
+msgstr "Chyba"
+
+#: static/js/zamboni/devhub-all.js:2780 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:247
+msgid "Warning"
+msgstr "Upozornenie"
+
+#: static/js/zamboni/devhub-all.js:2794 static/js/zamboni/devhub-min.js:2 static/js/zamboni/files-all.js:5657 static/js/zamboni/files-min.js:3 static/js/zamboni/files.js:411
+#: static/js/zamboni/validator.js:261
+msgid "Ignore this message in future updates"
+msgstr "Ignorovať toto hlásenie pri ďalších aktualizáciách"
+
+#: static/js/zamboni/devhub-all.js:2817 static/js/zamboni/devhub-min.js:2 static/js/zamboni/files-all.js:5663 static/js/zamboni/files-min.js:3 static/js/zamboni/files.js:417
+#: static/js/zamboni/validator.js:284
+msgid "Severity for automated signing:"
+msgstr "Závažnosť pre automatické podpisovanie:"
+
+#: static/js/zamboni/devhub-all.js:2832 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:299
+msgid "Suggestions for passing automated signing:"
+msgstr "Odporúčania k úspešnému dokončeniu automatického podpísania:"
+
+#: static/js/zamboni/devhub-all.js:2920 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:387
+msgid "Compatibility Tests"
+msgstr "Testy kompatibility"
+
+#: static/js/zamboni/devhub-all.js:2999 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:466
+msgid "Add-on failed validation."
+msgstr "Doplnok neprešiel overením."
+
+#: static/js/zamboni/devhub-all.js:3001 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:468
+msgid "Add-on passed validation."
+msgstr "Doplnok prešiel overením."
+
+#: static/js/zamboni/devhub-all.js:3014 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:481
+msgid "{0} error"
+msgid_plural "{0} errors"
+msgstr[0] "{0} chyba"
+msgstr[1] "{0} chyby"
+
+#: static/js/zamboni/devhub-all.js:3016 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:483
+msgid "{0} warning"
+msgid_plural "{0} warnings"
+msgstr[0] "{0} upozornenie"
+msgstr[1] "{0} upozornenia"
+
+#: static/js/zamboni/devhub-all.js:3018 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:485
+msgid "{0} notice"
+msgid_plural "{0} notices"
+msgstr[0] "{0} upozornenie"
+msgstr[1] "{0} upozornenia"
+
+#: static/js/zamboni/devhub-all.js:3110 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:577
+msgid "Validation task could not complete or completed with errors"
+msgstr "Úloha overenia nemohla byť dokončená alebo bola ukončená s chybami"
+
+#: static/js/zamboni/devhub-all.js:3128 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:595
+msgid "Internal server error"
+msgstr "Vnútorná chyba servera"
 
 #: static/js/zamboni/devhub_search.js:8
 msgid "No results found."
 msgstr "Neboli nájdené žiadne výsledky."
 
-#: static/js/zamboni/editors.js:121
+#: static/js/zamboni/editors-all.js:15402 static/js/zamboni/editors-min.js:4 static/js/zamboni/editors.js:121
 msgid "{name} was viewing this page first."
 msgstr "{name} zobrazil túto stránku skôr."
 
-#: static/js/zamboni/editors.js:171
+#: static/js/zamboni/editors-all.js:15452 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:171
 msgid "Receipt checked by app."
 msgstr "Potvrdenie bolo aplikáciou skontrolované."
 
-#: static/js/zamboni/editors.js:173
+#: static/js/zamboni/editors-all.js:15454 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:173
 msgid "Receipt was not checked by app."
 msgstr "Potvrdenie nebolo aplikáciou skontrolované."
 
-#: static/js/zamboni/editors.js:244
+#: static/js/zamboni/editors-all.js:15525 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:244
 msgid "{name} was viewing this add-on first."
 msgstr "{name} skontroloval tento doplnok."
 
-#: static/js/zamboni/editors.js:255
+#: static/js/zamboni/editors-all.js:15536 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:255
 msgid "Loading&hellip;"
 msgstr "Načítava sa&hellip;"
 
-#: static/js/zamboni/editors.js:260
+#: static/js/zamboni/editors-all.js:15541 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:260
 msgid "Version Notes"
 msgstr "Poznámky k verzii"
 
-#: static/js/zamboni/editors.js:265
+#: static/js/zamboni/editors-all.js:15546 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:265
 msgid "Notes for Reviewers"
 msgstr "Poznámky ku kontrole"
 
-#: static/js/zamboni/editors.js:270
+#: static/js/zamboni/editors-all.js:15551 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:270
 msgid "No version notes found"
 msgstr "Neboli nájdené poznámky k verzii"
 
-#: static/js/zamboni/editors.js:330
+#: static/js/zamboni/editors-all.js:15611 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:330
 msgid "Average Reviews"
 msgstr ""
 
-#: static/js/zamboni/editors.js:386
+#: static/js/zamboni/editors-all.js:15667 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:386
 msgid "Number of Reviews"
 msgstr "Počet recenzií"
 
-#: static/js/zamboni/editors.js:445
+#: static/js/zamboni/editors-all.js:15726 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:445
 msgid "Error loading translation"
 msgstr "Chyba pri načítaní prekladu"
 
-#: static/js/zamboni/files.js:411 static/js/zamboni/validator.js:261
-msgid "Ignore this message in future updates"
-msgstr "Ignorovať toto hlásenie pri ďalších aktualizáciách"
-
-#: static/js/zamboni/files.js:417 static/js/zamboni/validator.js:284
-msgid "Severity for automated signing:"
-msgstr "Závažnosť pre automatické podpisovanie:"
-
-#: static/js/zamboni/global.js:410
-msgid "Loading..."
-msgstr "Načítava sa..."
-
-#. L10n: {0} is the number of characters left.
-#: static/js/zamboni/global.js:474
-msgid "<b>{0}</b> character left."
-msgid_plural "<b>{0}</b> characters left."
-msgstr[0] "Zostáva <b>{0}</b> znak."
-msgstr[1] "Zostávajú <b>{0}</b> znaky."
-msgstr[2] "Zostáva <b>{0}</b> znakov."
-
-#: static/js/zamboni/init.js:28
-msgid ""
-"This feature is temporarily disabled while we perform website maintenance. "
-"Please check back a little later."
-msgstr ""
-"Táto funkcia je dočasne nedostupná kvôli prebiehajúcej údržbe servera. "
-"Prosím, skúste to neskôr."
-
-#: static/js/zamboni/l10n.js:45
-msgid "Remove this localization"
-msgstr "Odstrániť túto lokalizáciu"
-
-#: static/js/zamboni/password-strength.js:20
-msgid "Password strength:"
-msgstr "Sila hesla:"
-
-#: static/js/zamboni/password-strength.js:26
-msgid "At least {0} character left."
-msgid_plural "At least {0} characters left."
-msgstr[0] "Zostáva najmenej {0} znak."
-msgstr[1] "Zostávajú najmenej {0} znaky."
-msgstr[2] "Zostáva najmenej {0} znakov."
-
-#: static/js/zamboni/themes_review.js:176
-msgid "Requested Info"
-msgstr "Požadované informácie"
-
-#: static/js/zamboni/themes_review.js:177
-msgid "Flagged"
-msgstr "Označené"
-
-#: static/js/zamboni/themes_review.js:178
-msgid "Duplicate"
-msgstr "Duplicitné"
-
-#: static/js/zamboni/themes_review.js:179
-msgid "Rejected"
-msgstr "Zamietnuté"
-
-#: static/js/zamboni/themes_review.js:180
-msgid "Approved"
-msgstr "Schválené"
-
-#: static/js/zamboni/themes_review.js:424
-msgid "No results found"
-msgstr "Neboli nájdené žiadne výsledky"
-
-#: static/js/zamboni/themes_review_templates.js:31
+#: static/js/zamboni/editors-all.js:15975 static/js/zamboni/editors-min.js:5 static/js/zamboni/themes_review_templates.js:31
 msgid "Theme"
 msgstr ""
 
-#: static/js/zamboni/themes_review_templates.js:33
+#: static/js/zamboni/editors-all.js:15977 static/js/zamboni/editors-min.js:5 static/js/zamboni/themes_review_templates.js:33
 msgid "Reviewer"
 msgstr "Recenzent"
 
-#: static/js/zamboni/themes_review_templates.js:35
+#: static/js/zamboni/editors-all.js:15979 static/js/zamboni/editors-min.js:5 static/js/zamboni/themes_review_templates.js:35
 msgid "Status"
 msgstr "Stav"
 
-#: static/js/zamboni/validator.js:80
-msgid "All tests passed successfully."
-msgstr "Všetky testy ukončené úspešne."
+#: static/js/zamboni/editors-all.js:16196 static/js/zamboni/editors-min.js:5 static/js/zamboni/themes_review.js:176
+msgid "Requested Info"
+msgstr "Požadované informácie"
 
-#: static/js/zamboni/validator.js:83 static/js/zamboni/validator.js:478
-msgid "These tests were not run."
-msgstr "Tieto testy neboli spustené."
+#: static/js/zamboni/editors-all.js:16197 static/js/zamboni/editors-min.js:5 static/js/zamboni/themes_review.js:177
+msgid "Flagged"
+msgstr "Označené"
 
-#: static/js/zamboni/validator.js:131 static/js/zamboni/validator.js:144
-msgid "Tests"
-msgstr "Testy"
+#: static/js/zamboni/editors-all.js:16198 static/js/zamboni/editors-min.js:5 static/js/zamboni/themes_review.js:178
+msgid "Duplicate"
+msgstr "Duplicitné"
 
-#: static/js/zamboni/validator.js:246 static/js/zamboni/validator.js:575
-#: static/js/zamboni/validator.js:594
-msgid "Error"
-msgstr "Chyba"
+#: static/js/zamboni/editors-all.js:16199 static/js/zamboni/editors-min.js:5 static/js/zamboni/themes_review.js:179
+msgid "Rejected"
+msgstr "Zamietnuté"
 
-#: static/js/zamboni/validator.js:247
-msgid "Warning"
-msgstr "Upozornenie"
+#: static/js/zamboni/editors-all.js:16200 static/js/zamboni/editors-min.js:5 static/js/zamboni/themes_review.js:180
+msgid "Approved"
+msgstr "Schválené"
 
-#: static/js/zamboni/validator.js:299
-msgid "Suggestions for passing automated signing:"
-msgstr "Odporúčania k úspešnému dokončeniu automatického podpísania:"
+#: static/js/zamboni/editors-all.js:16444 static/js/zamboni/editors-min.js:5 static/js/zamboni/themes_review.js:424
+msgid "No results found"
+msgstr "Neboli nájdené žiadne výsledky"
 
-#: static/js/zamboni/validator.js:387
-msgid "Compatibility Tests"
-msgstr "Testy kompatibility"
-
-#: static/js/zamboni/validator.js:466
-msgid "Add-on failed validation."
-msgstr "Doplnok neprešiel overením."
-
-#: static/js/zamboni/validator.js:468
-msgid "Add-on passed validation."
-msgstr "Doplnok prešiel overením."
-
-#: static/js/zamboni/validator.js:481
-msgid "{0} error"
-msgid_plural "{0} errors"
-msgstr[0] "{0} chyba"
-msgstr[1] "{0} chyby"
-msgstr[2] "{0} chýb"
-
-#: static/js/zamboni/validator.js:483
-msgid "{0} warning"
-msgid_plural "{0} warnings"
-msgstr[0] "{0} upozornenie"
-msgstr[1] "{0} upozornenia"
-msgstr[2] "{0} upozornení"
-
-#: static/js/zamboni/validator.js:485
-msgid "{0} notice"
-msgid_plural "{0} notices"
-msgstr[0] "{0} upozornenie"
-msgstr[1] "{0} upozornenia"
-msgstr[2] "{0} upozornení"
-
-#: static/js/zamboni/validator.js:577
-msgid "Validation task could not complete or completed with errors"
-msgstr "Úloha overenia nemohla byť dokončená alebo bola ukončená s chybami"
-
-#: static/js/zamboni/validator.js:595
-msgid "Internal server error"
-msgstr "Vnútorná chyba servera"
-
-#: static/js/zamboni/mobile/buttons.js:52
+#: static/js/zamboni/mobile-all.js:15186 static/js/zamboni/mobile/buttons.js:52
 msgid "Not Updated for {0} {1}"
 msgstr "Neaktualizované pre {0} {1}"
 
-#: static/js/zamboni/mobile/buttons.js:53
+#: static/js/zamboni/mobile-all.js:15187 static/js/zamboni/mobile/buttons.js:53
 msgid "Requires Newer Version of {0}"
 msgstr "Vyžaduje novšiu verziu {0}u"
 
-#: static/js/zamboni/mobile/buttons.js:54
+#: static/js/zamboni/mobile-all.js:15188 static/js/zamboni/mobile/buttons.js:54
 msgid "Unreviewed"
 msgstr "Neskontrolované"
 
-#: static/js/zamboni/mobile/buttons.js:55
+#: static/js/zamboni/mobile-all.js:15189 static/js/zamboni/mobile/buttons.js:55
 msgid "Experimental <span>(Learn More)</span>"
 msgstr "Experimentálne <span>(Ďalšie informácie)</span>"
 
-#: static/js/zamboni/mobile/buttons.js:56
-#: static/js/zamboni/mobile/buttons.js:57
+#: static/js/zamboni/mobile-all.js:15190 static/js/zamboni/mobile-all.js:15191 static/js/zamboni/mobile/buttons.js:56 static/js/zamboni/mobile/buttons.js:57
 msgid "Not Available for {0}"
 msgstr "Nie je dostupné pre {0}"
 
-#: static/js/zamboni/mobile/buttons.js:58
+#: static/js/zamboni/mobile-all.js:15192 static/js/zamboni/mobile/buttons.js:58
 msgid "Experimental"
 msgstr "Experimentálne"
 
-#: static/js/zamboni/mobile/buttons.js:59
+#: static/js/zamboni/mobile-all.js:15193 static/js/zamboni/mobile/buttons.js:59
 msgid "Themes Require Newer Version of {0}"
 msgstr "Témy požadujú novšiu verziu {0}"
 
-#: static/js/zamboni/mobile/buttons.js:60
+#: static/js/zamboni/mobile-all.js:15194 static/js/zamboni/mobile/buttons.js:60
 msgid "Themes Require {0}"
 msgstr "Témy požadujú {0}"
 
-#: static/js/zamboni/mobile/buttons.js:105
+#: static/js/zamboni/mobile-all.js:15239 static/js/zamboni/mobile/buttons.js:105
 msgid "Installing..."
 msgstr "Inštaluje sa..."
 
-#: static/js/zamboni/mobile/buttons.js:125
+#: static/js/zamboni/mobile-all.js:15259 static/js/zamboni/mobile/buttons.js:125
 msgid "This add-on has been preliminarily reviewed by Mozilla."
 msgstr "Tento doplnok bol predbežne skontrolovaný Mozillou."
 
-#: static/js/zamboni/mobile/buttons.js:250
+#: static/js/zamboni/mobile-all.js:15384 static/js/zamboni/mobile/buttons.js:250
 msgid "Keep it"
 msgstr "Ponechať"
 
-#: static/js/zamboni/mobile/general.js:344
+#: static/js/zamboni/mobile-all.js:16049 static/js/zamboni/mobile-min.js:6 static/js/zamboni/mobile/general.js:344
 msgid "You're trying it on!"
 msgstr "Skúšate ho"
 
-#: static/js/zamboni/mobile/general.js:356
+#: static/js/zamboni/mobile-all.js:16061 static/js/zamboni/mobile-min.js:6 static/js/zamboni/mobile/general.js:356
 msgid "Added to Firefox"
 msgstr "Pridané do Firefoxu"

--- a/locale/sl/LC_MESSAGES/django.po
+++ b/locale/sl/LC_MESSAGES/django.po
@@ -1,82 +1,73 @@
 # smo <smolejv@gmx.net>, 2013.
 msgid ""
 msgstr ""
-"Project-Id-Version: support.mozilla.com\n"
+"Project-Id-Version:  support.mozilla.com\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2016-02-24 21:23+0000\n"
+"POT-Creation-Date: 2016-04-18 15:47+0000\n"
 "PO-Revision-Date: 2016-04-18 10:30+0000\n"
 "Last-Translator: Miha Knavs <miha@abecednik.si>\n"
 "Language-Team: Slovenian\n"
-"Language: sl\n"
+"Language: \n"
 "MIME-Version: 1.0\n"
-"Content-Type: text/plain; charset=utf-8\n"
+"Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=4; plural=(n%100==1 ? 0 : n%100==2 ? 1 : n%100==3 || n%100==4 ? 2 : 3);\n"
 "Generated-By: Babel 2.2.0\n"
-"X-Generator: Pontoon\n"
 
-#: src/olympia/accounts/views.py:52
+#: src/olympia/accounts/views.py:54
 msgid "Your log in attempt could not be parsed. Please try again."
 msgstr "Vašega poskusa prijave ni bilo mogoče razčleniti. Poskusite znova."
 
-#: src/olympia/accounts/views.py:54
+#: src/olympia/accounts/views.py:56
 msgid "Your Firefox Account could not be found. Please try again."
 msgstr "Vašega Firefox Računa ni bilo mogoče najti. Poskusite znova."
 
-#: src/olympia/accounts/views.py:55
+#: src/olympia/accounts/views.py:57
 msgid "You could not be logged in. Please try again."
 msgstr "Ni vas bilo mogoče prijaviti. Poskusite znova."
 
-#: src/olympia/accounts/views.py:57
+#: src/olympia/accounts/views.py:59
 msgid "Your account has already been migrated to Firefox Accounts."
 msgstr "Vaš račun je že bil preseljen v Firefox Račune."
 
-#: src/olympia/accounts/views.py:59
+#: src/olympia/accounts/views.py:61
 msgid "Your Firefox Account already exists on this site."
 msgstr "Vaš Firefox Račun že obstaja na tej strani."
 
-#: src/olympia/accounts/views.py:108
+#: src/olympia/accounts/views.py:110
 msgid "Great job!"
 msgstr "Super!"
 
-#: src/olympia/accounts/views.py:109
+#: src/olympia/accounts/views.py:111
 msgid "You can now log in to Add-ons with your Firefox Account."
 msgstr "V dodatke se lahko prijavite z računom Firefox."
 
-#: src/olympia/accounts/views.py:121
+#: src/olympia/accounts/views.py:123
 msgid "Need help?"
 msgstr "Potrebujete pomoč?"
 
-#: src/olympia/addons/buttons.py:180
+#: src/olympia/addons/buttons.py:177
 msgid "Download Now"
 msgstr "Prenesi zdaj"
 
-#: src/olympia/addons/buttons.py:182
+#: src/olympia/addons/buttons.py:179
 msgid "Download"
 msgstr "Prenesi"
 
 #. L10n: please keep &nbsp; in the string so &rarr; does not wrap.
-#: src/olympia/addons/buttons.py:186
+#: src/olympia/addons/buttons.py:183
 msgid "Continue to Download&nbsp;&rarr;"
 msgstr "Nadaljuj prenos&nbsp;&rarr;"
 
-#: src/olympia/addons/buttons.py:202 src/olympia/addons/helpers.py:35
-#: src/olympia/addons/views.py:319
-#: src/olympia/addons/templates/addons/impala/details.html:114
-#: src/olympia/addons/templates/addons/impala/listing/items.html:17
-#: src/olympia/addons/templates/addons/mobile/home.html:40
-#: src/olympia/amo/templates/amo/side_nav.html:6
-#: src/olympia/amo/templates/amo/side_nav.html:10
-#: src/olympia/amo/templates/amo/site_nav.html:2
-#: src/olympia/amo/templates/amo/site_nav.html:55
-#: src/olympia/bandwagon/views.py:95 src/olympia/browse/views.py:54
-#: src/olympia/browse/views.py:68 src/olympia/browse/views.py:235
-#: src/olympia/browse/templates/browse/impala/category_landing.html:22
+#: src/olympia/addons/buttons.py:199 src/olympia/addons/helpers.py:35 src/olympia/addons/views.py:333 src/olympia/addons/templates/addons/impala/details.html:111
+#: src/olympia/addons/templates/addons/impala/listing/items.html:17 src/olympia/addons/templates/addons/mobile/home.html:40 src/olympia/amo/templates/amo/side_nav.html:6
+#: src/olympia/amo/templates/amo/side_nav.html:10 src/olympia/amo/templates/amo/site_nav.html:2 src/olympia/amo/templates/amo/site_nav.html:53 src/olympia/bandwagon/views.py:95
+#: src/olympia/browse/views.py:54 src/olympia/browse/views.py:68 src/olympia/browse/views.py:202 src/olympia/browse/templates/browse/impala/category_landing.html:22
 #: src/olympia/browse/templates/browse/personas/mobile/category_landing.html:26
 msgid "Featured"
 msgstr "Izbran"
 
-#: src/olympia/addons/buttons.py:221
+#: src/olympia/addons/buttons.py:218
 msgid "Add to {0}"
 msgstr "Dodaj v {0}"
 
@@ -99,8 +90,6 @@ msgid "Invalid tag: {0}"
 msgid_plural "Invalid tags: {0}"
 msgstr[0] "Neveljavna oznaka: {0}"
 msgstr[1] "Neveljavni oznaki: {0}"
-msgstr[2] "Neveljavne oznake: {0}"
-msgstr[3] "Neveljavne oznake: {0}"
 
 #. L10n: {0} is a single tag or a comma-separated list of tags.
 #: src/olympia/addons/forms.py:103
@@ -108,78 +97,57 @@ msgid "\"{0}\" is a reserved tag and cannot be used."
 msgid_plural "\"{0}\" are reserved tags and cannot be used."
 msgstr[0] "\"{0}\" je rezervirana oznaka in se je ne more uporabiti."
 msgstr[1] "\"{0}\" sta rezervirani oznaki in se ju ne more uporabiti."
-msgstr[2] "\"{0}\" so rezervirane oznake in se jih ne more uporabiti."
-msgstr[3] "\"{0}\" so rezervirane oznake in se jih ne more uporabiti."
 
 #: src/olympia/addons/forms.py:111
 msgid "You have {0} too many tags."
 msgid_plural "You have {0} too many tags."
 msgstr[0] "Imate {0} oznako preveč."
 msgstr[1] "Imate {0} oznaki preveč."
-msgstr[2] "Imate {0} oznake preveč."
-msgstr[3] "Imate {0} oznak preveč."
 
 #: src/olympia/addons/forms.py:117
 #, python-format
-msgid ""
-"All tags must be %s characters or less after invalid characters are removed."
-msgstr ""
-"Potem ko se je odstranilo neveljavne znake, smejo vse oznake imeti največ %s"
-" znakov,"
+msgid "All tags must be %s characters or less after invalid characters are removed."
+msgstr "Potem ko se je odstranilo neveljavne znake, smejo vse oznake imeti največ %s znakov,"
 
 #: src/olympia/addons/forms.py:121
 msgid "All tags must be at least {0} character."
 msgid_plural "All tags must be at least {0} characters."
 msgstr[0] "Vse oznake morajo biti najmanj {0} znak."
 msgstr[1] "Vse oznake morajo imeti najmanj {0} znaka."
-msgstr[2] "Vse oznake morajo imeti najmanj {0} znake."
-msgstr[3] "Vse oznake morajo imeti najmanj {0} znakov."
 
-#: src/olympia/addons/forms.py:234
-msgid ""
-"Categories cannot be changed while your add-on is featured for this "
-"application."
-msgstr ""
-"Če se vaš izdelek nahaja med izbranimi dodatki za to aplikacijo, mu "
-"kategorij ni mogoče spreminjati."
+#: src/olympia/addons/forms.py:238
+msgid "Categories cannot be changed while your add-on is featured for this application."
+msgstr "Če se vaš izdelek nahaja med izbranimi dodatki za to aplikacijo, mu kategorij ni mogoče spreminjati."
 
 #. L10n: {0} is the number of categories.
-#: src/olympia/addons/forms.py:238
+#: src/olympia/addons/forms.py:242
 msgid "You can have only {0} category."
 msgid_plural "You can have only {0} categories."
 msgstr[0] "Imate lahko samo {0} kategorijo."
 msgstr[1] "Imate lahko samo {0} kategoriji."
-msgstr[2] "Imate lahko samo {0} kategorije."
-msgstr[3] "Imate lahko samo {0} kategorij."
 
-#: src/olympia/addons/forms.py:246
-msgid ""
-"The miscellaneous category cannot be combined with additional categories."
+#: src/olympia/addons/forms.py:250
+msgid "The miscellaneous category cannot be combined with additional categories."
 msgstr "Kategorije razno ni mogoče kombinirati z dodatnimi kategorijami."
 
-#: src/olympia/addons/forms.py:369
+#: src/olympia/addons/forms.py:374
 #, python-format
-msgid ""
-"Before changing your default locale you must have a name, summary, and "
-"description in that locale. You are missing %s."
-msgstr ""
-"Preden spremenite privzeto lokalno nastavitev, morate imeti v novi "
-"nastavitvi ime, povzetek in opis. Manjka %s."
+msgid "Before changing your default locale you must have a name, summary, and description in that locale. You are missing %s."
+msgstr "Preden spremenite privzeto lokalno nastavitev, morate imeti v novi nastavitvi ime, povzetek in opis. Manjka %s."
 
-#: src/olympia/addons/forms.py:484 src/olympia/addons/forms.py:575
+#: src/olympia/addons/forms.py:455 src/olympia/addons/forms.py:546
 msgid "A license must be selected."
 msgstr "Izbrati je treba licenco."
 
-#: src/olympia/addons/forms.py:556
+#: src/olympia/addons/forms.py:527
 msgid "Give Your Theme a Name."
 msgstr "Poimenujte svojo temo."
 
-#: src/olympia/addons/forms.py:562
-#: src/olympia/devhub/templates/devhub/personas/submit.html:53
+#: src/olympia/addons/forms.py:533 src/olympia/devhub/templates/devhub/personas/submit.html:53
 msgid "Describe your Theme."
 msgstr "Opišite svojo temo."
 
-#: src/olympia/addons/forms.py:704
+#: src/olympia/addons/forms.py:675
 msgid "Enter a new author's email address"
 msgstr "Vnesite e-poštni naslov novega avtorja"
 
@@ -187,49 +155,39 @@ msgstr "Vnesite e-poštni naslov novega avtorja"
 msgid "Not Reviewed"
 msgstr "Ni pregledan"
 
-#: src/olympia/addons/models.py:301
+#: src/olympia/addons/models.py:298
 msgid "Users have the option of contributing more or less than this amount."
-msgstr ""
-"Uporabniki imajo možnost, da prispevajo več ali manj kot je ta znesek."
+msgstr "Uporabniki imajo možnost, da prispevajo več ali manj kot je ta znesek."
 
-#: src/olympia/addons/models.py:309
-msgid ""
-"Users will always be asked in the Add-ons Manager (Firefox 4 and above)"
+#: src/olympia/addons/models.py:306
+msgid "Users will always be asked in the Add-ons Manager (Firefox 4 and above). Only applies to desktop."
 msgstr ""
-"Uporabnike se bo vedno vprašalo v Upravitelju dodatkov (Firefox 4 in "
-"novejši)"
 
 # Column name in a table.
-#: src/olympia/addons/models.py:1804
-#: src/olympia/addons/templates/addons/details_box.html:55
-#: src/olympia/devhub/templates/devhub/index.html:92
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:102
+#: src/olympia/addons/models.py:1802 src/olympia/addons/templates/addons/details_box.html:55 src/olympia/devhub/templates/devhub/index.html:92
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:89
 msgid "Listed"
 msgstr "Na seznamu"
 
-#: src/olympia/addons/views.py:320
-#: src/olympia/browse/templates/browse/personas/mobile/category_landing.html:27
+#: src/olympia/addons/views.py:334 src/olympia/browse/templates/browse/personas/mobile/category_landing.html:27
 msgid "Popular"
 msgstr "Priljubljeni"
 
-#: src/olympia/addons/views.py:321 src/olympia/browse/views.py:238
-#: src/olympia/browse/views.py:280 src/olympia/browse/views.py:482
+#: src/olympia/addons/views.py:335 src/olympia/browse/views.py:205 src/olympia/browse/views.py:247 src/olympia/browse/views.py:449
 msgid "Recently Added"
 msgstr "Pred kratkim dodani"
 
-#: src/olympia/addons/views.py:322 src/olympia/bandwagon/views.py:99
-#: src/olympia/browse/views.py:60 src/olympia/browse/views.py:71
-#: src/olympia/search/forms.py:16 src/olympia/search/forms.py:91
+#: src/olympia/addons/views.py:336 src/olympia/bandwagon/views.py:99 src/olympia/browse/views.py:60 src/olympia/browse/views.py:71 src/olympia/search/forms.py:16 src/olympia/search/forms.py:91
 msgid "Recently Updated"
 msgstr "Pred kratkim posodobljeni"
 
-#. l10n: {0} is the addon name
 # %1 is an add-on name.
-#: src/olympia/addons/views.py:520
+#. l10n: {0} is the addon name
+#: src/olympia/addons/views.py:534
 msgid "Contribution for {0}"
 msgstr "Prispevek za {0}"
 
-#: src/olympia/addons/views.py:613
+#: src/olympia/addons/views.py:627
 msgid "Abuse reported."
 msgstr "Zloraba sporočena."
 
@@ -237,116 +195,70 @@ msgstr "Zloraba sporočena."
 msgid "My add-on doesn't fit into any of the categories"
 msgstr "Moj dodatek ne spada v nobeno od kategorij"
 
-#: src/olympia/addons/templates/addons/button.html:27
-#: src/olympia/addons/templates/addons/impala/button.html:11
-#: src/olympia/addons/templates/addons/mobile/button.html:11
+#: src/olympia/addons/templates/addons/button.html:27 src/olympia/addons/templates/addons/impala/button.html:11 src/olympia/addons/templates/addons/mobile/button.html:11
 msgid "No compatible versions"
 msgstr "Ni združljivih različic"
 
-#: src/olympia/addons/templates/addons/button.html:35
-#: src/olympia/addons/templates/addons/impala/button.html:19
+#: src/olympia/addons/templates/addons/button.html:35 src/olympia/addons/templates/addons/impala/button.html:19
 msgid "Added to Mobile"
 msgstr "Dodano v mobilno napravo"
 
-#: src/olympia/addons/templates/addons/button.html:37
-#: src/olympia/addons/templates/addons/impala/button.html:21
+#: src/olympia/addons/templates/addons/button.html:37 src/olympia/addons/templates/addons/impala/button.html:21
 msgid "Add to Mobile"
 msgstr "Dodaj v mobilno napravo"
 
 #. {0} is a platform name like Windows or Mac OS X.
-#: src/olympia/addons/templates/addons/button.html:66
-#: src/olympia/addons/templates/addons/includes/install_button.html:19
+#: src/olympia/addons/templates/addons/button.html:66 src/olympia/addons/templates/addons/includes/install_button.html:19
 msgid "for {0}"
 msgstr "za {0}"
 
-#: src/olympia/addons/templates/addons/button.html:82
-#: src/olympia/addons/templates/addons/mobile/button.html:23
+#: src/olympia/addons/templates/addons/button.html:82 src/olympia/addons/templates/addons/mobile/button.html:23
 msgid "View privacy policy"
 msgstr "Ogled politike zasebnosti"
 
-#: src/olympia/addons/templates/addons/button.html:87
-#: src/olympia/addons/templates/addons/details_box.html:133
-#: src/olympia/addons/templates/addons/mobile/button.html:28
+#: src/olympia/addons/templates/addons/button.html:87 src/olympia/addons/templates/addons/details_box.html:133 src/olympia/addons/templates/addons/mobile/button.html:28
 #: src/olympia/discovery/templates/discovery/addons/detail.html:28
 msgid "View End-User License Agreement"
 msgstr "Oglejte si licenčni dogovor za končnega uporabnika"
 
-#: src/olympia/addons/templates/addons/button.html:92
-#: src/olympia/addons/templates/addons/impala/button.html:54
+#: src/olympia/addons/templates/addons/button.html:92 src/olympia/addons/templates/addons/impala/button.html:54
 #, python-format
-msgid ""
-"This add-on has not been reviewed by Mozilla. <a href=\"%(url)s\">Learn "
-"more</a>"
-msgstr ""
-"Tega dodatka Mozilla predhodno ni pregledala. <a href=\"%(url)s\">Več o "
-"tem</a>"
+msgid "This add-on has not been reviewed by Mozilla. <a href=\"%(url)s\">Learn more</a>"
+msgstr "Tega dodatka Mozilla predhodno ni pregledala. <a href=\"%(url)s\">Več o tem</a>"
 
-#: src/olympia/addons/templates/addons/button.html:97
-#: src/olympia/addons/templates/addons/impala/button.html:60
+#: src/olympia/addons/templates/addons/button.html:97 src/olympia/addons/templates/addons/impala/button.html:60
 #, python-format
-msgid ""
-"This add-on has been preliminarily reviewed by Mozilla. <a "
-"href=\"%(url)s\">Learn more</a>"
-msgstr ""
-"Ta dodatek je Mozilla predhodno pregledala. <a href=\"%(url)s\">Več o "
-"tem</a>"
+msgid "This add-on has been preliminarily reviewed by Mozilla. <a href=\"%(url)s\">Learn more</a>"
+msgstr "Ta dodatek je Mozilla predhodno pregledala. <a href=\"%(url)s\">Več o tem</a>"
 
-#: src/olympia/addons/templates/addons/contribution.html:11
-#: src/olympia/addons/templates/addons/impala/developers.html:44
-msgid ""
-"The developer of this add-on asks that you help support its continued "
-"development by making a small contribution."
-msgstr ""
-"Razvijalec tega dodatka vas prosi, da mu z majhnim prispevkom pomagate pri "
-"nadaljnjem razvoju."
+#: src/olympia/addons/templates/addons/contribution.html:11 src/olympia/addons/templates/addons/impala/developers.html:44
+msgid "The developer of this add-on asks that you help support its continued development by making a small contribution."
+msgstr "Razvijalec tega dodatka vas prosi, da mu z majhnim prispevkom pomagate pri nadaljnjem razvoju."
 
 #: src/olympia/addons/templates/addons/contribution.html:14
 #, python-format
-msgid ""
-"The developer of this add-on asks that you show your support by making a "
-"donation to the <a href=\"%(charity_url)s\">%(charity_name)s</a>."
-msgstr ""
-"Razvijalec tega dodatka vas prosi, da mu z donacijo za <a "
-"href=\"%(charity_url)s\">%(charity_name)s</a> izkažete podporo."
+msgid "The developer of this add-on asks that you show your support by making a donation to the <a href=\"%(charity_url)s\">%(charity_name)s</a>."
+msgstr "Razvijalec tega dodatka vas prosi, da mu z donacijo za <a href=\"%(charity_url)s\">%(charity_name)s</a> izkažete podporo."
 
 #: src/olympia/addons/templates/addons/contribution.html:19
 #, python-format
-msgid ""
-"The developer of this add-on asks that you show your support by making a "
-"small contribution to <a href=\"%(charity_url)s\">%(charity_name)s</a>."
-msgstr ""
-"Razvijalec tega dodatka vas prosi, da mu z majhnim prispevkom za <a "
-"href=\"%(charity_url)s\">%(charity_name)s</a> izkažete podporo."
+msgid "The developer of this add-on asks that you show your support by making a small contribution to <a href=\"%(charity_url)s\">%(charity_name)s</a>."
+msgstr "Razvijalec tega dodatka vas prosi, da mu z majhnim prispevkom za <a href=\"%(charity_url)s\">%(charity_name)s</a> izkažete podporo."
 
-#: src/olympia/addons/templates/addons/contribution.html:30
-#: src/olympia/addons/templates/addons/impala/contribution.html:18
-#: src/olympia/templates/menu_links.html:25
+#: src/olympia/addons/templates/addons/contribution.html:30 src/olympia/addons/templates/addons/impala/contribution.html:18 src/olympia/templates/menu_links.html:25
 msgid "Contribute"
 msgstr "Prispevajte"
 
-#. Click Contribute button OR Install button
 # This is a separator between the graphical [contribute] button and the
 # graphical [download now] button
-#: src/olympia/addons/templates/addons/contribution.html:34
-#: src/olympia/addons/templates/addons/report_abuse.html:26
-#: src/olympia/addons/templates/addons/impala/contribution.html:32
-#: src/olympia/devhub/templates/devhub/addons/ajax_compat_update.html:36
-#: src/olympia/devhub/templates/devhub/addons/profile.html:44
-#: src/olympia/devhub/templates/devhub/addons/edit/admin.html:101
-#: src/olympia/devhub/templates/devhub/addons/edit/basic.html:152
-#: src/olympia/devhub/templates/devhub/addons/edit/details.html:85
-#: src/olympia/devhub/templates/devhub/addons/edit/support.html:67
-#: src/olympia/devhub/templates/devhub/addons/edit/technical.html:166
-#: src/olympia/devhub/templates/devhub/addons/forms_shared/media.html:149
-#: src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:44
-#: src/olympia/devhub/templates/devhub/versions/add_file_modal.html:78
-#: src/olympia/devhub/templates/devhub/versions/edit.html:139
-#: src/olympia/devhub/templates/devhub/versions/list.html:242
-#: src/olympia/devhub/templates/devhub/versions/list.html:276
-#: src/olympia/devhub/templates/devhub/versions/list.html:317
-#: src/olympia/devhub/templates/devhub/versions/list.html:351
-#: src/olympia/reviews/templates/reviews/edit_review.html:16
-#: src/olympia/translations/templates/translations/trans-menu.html:50
+#. Click Contribute button OR Install button
+#: src/olympia/addons/templates/addons/contribution.html:34 src/olympia/addons/templates/addons/report_abuse.html:26 src/olympia/addons/templates/addons/impala/contribution.html:32
+#: src/olympia/devhub/templates/devhub/addons/ajax_compat_update.html:36 src/olympia/devhub/templates/devhub/addons/profile.html:44 src/olympia/devhub/templates/devhub/addons/edit/admin.html:101
+#: src/olympia/devhub/templates/devhub/addons/edit/basic.html:152 src/olympia/devhub/templates/devhub/addons/edit/details.html:85 src/olympia/devhub/templates/devhub/addons/edit/support.html:67
+#: src/olympia/devhub/templates/devhub/addons/edit/technical.html:166 src/olympia/devhub/templates/devhub/addons/forms_shared/media.html:149
+#: src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:43 src/olympia/devhub/templates/devhub/versions/add_file_modal.html:58 src/olympia/devhub/templates/devhub/versions/edit.html:139
+#: src/olympia/devhub/templates/devhub/versions/list.html:239 src/olympia/devhub/templates/devhub/versions/list.html:281 src/olympia/devhub/templates/devhub/versions/list.html:315
+#: src/olympia/devhub/templates/devhub/versions/list.html:349 src/olympia/reviews/templates/reviews/edit_review.html:16 src/olympia/translations/templates/translations/trans-menu.html:50
 #: src/olympia/translations/templates/translations/trans-menu.html:62
 msgid "or"
 msgstr "ali"
@@ -355,41 +267,23 @@ msgstr "ali"
 msgid "Suggested Contribution: {0}"
 msgstr "Predlagani prispevek: {0}"
 
-#: src/olympia/addons/templates/addons/contribution.html:48
-#: src/olympia/amo/templates/amo/recaptcha.html:5
-#: src/olympia/versions/templates/versions/version.html:52
+#: src/olympia/addons/templates/addons/contribution.html:48 src/olympia/amo/templates/amo/recaptcha.html:5 src/olympia/versions/templates/versions/version.html:52
 msgid "What's this?"
 msgstr "Kaj je to?"
 
 #: src/olympia/addons/templates/addons/contribution.html:63
 #, python-format
-msgid ""
-"The developer of this add-on would like you to consider making a donation to"
-" the <a href=\"%(charity_url)s\">%(charity_name)s</a> if you enjoy using it."
-msgstr ""
-"Razvijalec tega dodatka bi želel, da razmislite o donaciji <a "
-"href=\"%(charity_url)s\">%(charity_name)s</a>, če vam je dodatek prišel "
-"prav."
+msgid "The developer of this add-on would like you to consider making a donation to the <a href=\"%(charity_url)s\">%(charity_name)s</a> if you enjoy using it."
+msgstr "Razvijalec tega dodatka bi želel, da razmislite o donaciji <a href=\"%(charity_url)s\">%(charity_name)s</a>, če vam je dodatek prišel prav."
 
 #: src/olympia/addons/templates/addons/contribution.html:69
 #, python-format
-msgid ""
-"The developer of this add-on would like you to consider making a small "
-"contribution to <a href=\"%(charity_url)s\">%(charity_name)s</a> if you "
-"enjoy using it."
-msgstr ""
-"Razvijalec tega dodatka bi želel, da razmislite o majhnem prispevku za <a "
-"href=\"%(charity_url)s\">%(charity_name)s</a> , če vam je dodatek prišel "
-"prav."
+msgid "The developer of this add-on would like you to consider making a small contribution to <a href=\"%(charity_url)s\">%(charity_name)s</a> if you enjoy using it."
+msgstr "Razvijalec tega dodatka bi želel, da razmislite o majhnem prispevku za <a href=\"%(charity_url)s\">%(charity_name)s</a> , če vam je dodatek prišel prav."
 
 #: src/olympia/addons/templates/addons/contribution.html:76
-msgid ""
-"Mozilla is committed to supporting a vibrant and healthy developer "
-"ecosystem. Your optional contribution helps sustain further development of "
-"this add-on."
-msgstr ""
-"Mozilla se je zavezala skrbeti za razvojni sistem, da bo vedno živ in zdrav."
-" Vaš neobvezni prispevek bo pomagal nadaljnjemu razvoju tega dodatka."
+msgid "Mozilla is committed to supporting a vibrant and healthy developer ecosystem. Your optional contribution helps sustain further development of this add-on."
+msgstr "Mozilla se je zavezala skrbeti za razvojni sistem, da bo vedno živ in zdrav. Vaš neobvezni prispevek bo pomagal nadaljnjemu razvoju tega dodatka."
 
 #: src/olympia/addons/templates/addons/contributions_lightbox.html:5
 msgid "Make a Contribution"
@@ -397,35 +291,21 @@ msgstr "Prispevajte"
 
 #: src/olympia/addons/templates/addons/contributions_lightbox.html:9
 #, python-format
-msgid ""
-"Help support the continued development of <strong>%(addon_name)s</strong> by"
-" making a small contribution through <a href=\"%(paypal_url)s\">PayPal</a>."
-msgstr ""
-"Podprite nadaljnji razvoj dodatka <strong>%(addon_name)s</strong> in darujte"
-" majhen prispevek prek <a href=\"%(paypal_url)s\">PayPal</a>."
+msgid "Help support the continued development of <strong>%(addon_name)s</strong> by making a small contribution through <a href=\"%(paypal_url)s\">PayPal</a>."
+msgstr "Podprite nadaljnji razvoj dodatka <strong>%(addon_name)s</strong> in darujte majhen prispevek prek <a href=\"%(paypal_url)s\">PayPal</a>."
 
 #: src/olympia/addons/templates/addons/contributions_lightbox.html:15
 #, python-format
 msgid ""
-"To show your support for <b>%(addon_name)s</b>, the developer asks that you "
-"make a donation to the <a href=\"%(charity_url)s\">%(charity_name)s</a> "
-"through <a href=\"%(paypal_url)s\">PayPal</a>."
-msgstr ""
-"Da pokažete pripravljenost podpreti <b>%(addon_name)s</b>, vas razvijalec "
-"prosi, da prispevate za <a href=\"%(charity_url)s\">%(charity_name)s</a> "
-"prek <a href=\"%(paypal_url)s\">PayPal</a>"
+"To show your support for <b>%(addon_name)s</b>, the developer asks that you make a donation to the <a href=\"%(charity_url)s\">%(charity_name)s</a> through <a href=\"%(paypal_url)s\">PayPal</a>."
+msgstr "Da pokažete pripravljenost podpreti <b>%(addon_name)s</b>, vas razvijalec prosi, da prispevate za <a href=\"%(charity_url)s\">%(charity_name)s</a> prek <a href=\"%(paypal_url)s\">PayPal</a>"
 
 #: src/olympia/addons/templates/addons/contributions_lightbox.html:21
 #, python-format
 msgid ""
-"To show your support for <b>%(addon_name)s</b>, the developer asks that you "
-"make a small contribution to <a "
-"href=\"%(charity_url)s\">%(charity_name)s</a> through <a "
-"href=\"%(paypal_url)s\">PayPal</a>."
-msgstr ""
-"Da pokažete pripravljenost podpreti <b>%(addon_name)s</b>, vas razvijalec "
-"prosi, da darujete <a href=\"%(charity_url)s\">%(charity_name)s</a> prek <a "
-"href=\"%(paypal_url)s\">PayPala</a>"
+"To show your support for <b>%(addon_name)s</b>, the developer asks that you make a small contribution to <a href=\"%(charity_url)s\">%(charity_name)s</a> through <a href=\"%(paypal_url)s\">PayPal</"
+"a>."
+msgstr "Da pokažete pripravljenost podpreti <b>%(addon_name)s</b>, vas razvijalec prosi, da darujete <a href=\"%(charity_url)s\">%(charity_name)s</a> prek <a href=\"%(paypal_url)s\">PayPala</a>"
 
 #: src/olympia/addons/templates/addons/contributions_lightbox.html:30
 msgid "How much would you like to contribute?"
@@ -448,8 +328,7 @@ msgstr "Znesek za prispevek mora biti številka."
 msgid "A one-time suggested contribution of {0}"
 msgstr "Predlagani enkratni prispevek {0}"
 
-#. {0} is a currency symbol (e.g., $),                    {1} is an amount
-#. input
+#. {0} is a currency symbol (e.g., $),                    {1} is an amount input
 #. field
 #: src/olympia/addons/templates/addons/contributions_lightbox.html:64
 msgid "A one-time contribution of {0} {1}"
@@ -459,11 +338,8 @@ msgstr "Enkraten prispevek {0} {1}"
 msgid "Leave a comment or request with your contribution."
 msgstr "Pustite komentar ali zahtevo s svojim prispevkom."
 
-#: src/olympia/addons/templates/addons/contributions_lightbox.html:74
-#: src/olympia/bandwagon/templates/bandwagon/ajax_new.html:20
-#: src/olympia/bandwagon/templates/bandwagon/includes/addedit.html:37
-#: src/olympia/reviews/templates/reviews/mobile/add_form.html:13
-#: src/olympia/templates/includes/forms.html:10
+#: src/olympia/addons/templates/addons/contributions_lightbox.html:74 src/olympia/bandwagon/templates/bandwagon/ajax_new.html:20 src/olympia/bandwagon/templates/bandwagon/includes/addedit.html:37
+#: src/olympia/reviews/templates/reviews/mobile/add_form.html:13 src/olympia/templates/includes/forms.html:10
 msgid "(optional)"
 msgstr "(neobvezno)"
 
@@ -483,36 +359,27 @@ msgstr "Ne, hvala"
 msgid "Contribution made, thank you."
 msgstr "Prispevek prejeli, hvala vam."
 
-#: src/olympia/addons/templates/addons/details_box.html:10
-#: src/olympia/discovery/templates/discovery/addons/detail.html:19
+#: src/olympia/addons/templates/addons/details_box.html:10 src/olympia/discovery/templates/discovery/addons/detail.html:19
 msgid "No restart required"
 msgstr "Ponoven zagon ni potreben"
 
 #. This is a caption for a table. {0} is an add-on name.
-#: src/olympia/addons/templates/addons/details_box.html:26
-#: src/olympia/addons/templates/addons/includes/persona.html:9
+#: src/olympia/addons/templates/addons/details_box.html:26 src/olympia/addons/templates/addons/includes/persona.html:9
 msgid "Add-on Information for {0}"
 msgstr "Informacije o dodatku za {0}"
 
-#: src/olympia/addons/templates/addons/details_box.html:30
-#: src/olympia/addons/templates/addons/persona_detail_table.html:3
-#: src/olympia/addons/templates/addons/mobile/details.html:63
-#: src/olympia/addons/templates/addons/mobile/persona_detail_table.html:7
-#: src/olympia/browse/views.py:459 src/olympia/devhub/views.py:75
+#: src/olympia/addons/templates/addons/details_box.html:30 src/olympia/addons/templates/addons/persona_detail_table.html:3 src/olympia/addons/templates/addons/mobile/details.html:63
+#: src/olympia/addons/templates/addons/mobile/persona_detail_table.html:7 src/olympia/browse/views.py:426 src/olympia/devhub/views.py:73
 msgid "Updated"
 msgstr "Posodobljeno"
 
-#: src/olympia/addons/templates/addons/details_box.html:38
-#: src/olympia/addons/templates/addons/mobile/details.html:71
-#: src/olympia/devhub/templates/devhub/addons/edit/support.html:43
+#: src/olympia/addons/templates/addons/details_box.html:38 src/olympia/addons/templates/addons/mobile/details.html:71 src/olympia/devhub/templates/devhub/addons/edit/support.html:43
 #: src/olympia/discovery/templates/discovery/addons/detail.html:77
 msgid "Website"
 msgstr "Spletno mesto"
 
 #. This refers to this version's compatible applications, such as Firefox 8.0
-#: src/olympia/addons/templates/addons/details_box.html:47
-#: src/olympia/addons/templates/addons/mobile/details.html:80
-#: src/olympia/search/templates/search/results.html:72
+#: src/olympia/addons/templates/addons/details_box.html:47 src/olympia/addons/templates/addons/mobile/details.html:80 src/olympia/search/templates/search/results.html:72
 #: src/olympia/versions/templates/versions/version.html:21
 msgid "Works with"
 msgstr "Deluje z"
@@ -521,45 +388,30 @@ msgstr "Deluje z"
 msgid "Visibility"
 msgstr "Vidnost"
 
-#: src/olympia/addons/templates/addons/details_box.html:57
-#: src/olympia/devhub/templates/devhub/index.html:94
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:104
+#: src/olympia/addons/templates/addons/details_box.html:57 src/olympia/devhub/templates/devhub/index.html:94 src/olympia/devhub/templates/devhub/includes/addon_details.html:91
 msgid "Hidden"
 msgstr "Skrito"
 
-#: src/olympia/addons/templates/addons/details_box.html:59
-#: src/olympia/devhub/templates/devhub/index.html:96
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:106
+#: src/olympia/addons/templates/addons/details_box.html:59 src/olympia/devhub/templates/devhub/index.html:96 src/olympia/devhub/templates/devhub/includes/addon_details.html:93
 msgid "Unlisted"
 msgstr "Nenaveden"
 
-#: src/olympia/addons/templates/addons/details_box.html:67
-#: src/olympia/devhub/templates/devhub/addons/edit/technical.html:44
+#: src/olympia/addons/templates/addons/details_box.html:67 src/olympia/devhub/templates/devhub/addons/edit/technical.html:44
 msgid "Required Add-ons"
 msgstr "Zahtevani dodatki"
 
-#: src/olympia/addons/templates/addons/details_box.html:81
-#: src/olympia/addons/templates/addons/persona_detail_table.html:15
-#: src/olympia/browse/views.py:462 src/olympia/devhub/views.py:78
-#: src/olympia/devhub/views.py:85
-#: src/olympia/discovery/templates/discovery/addons/detail.html:57
-#: src/olympia/reviews/forms.py:62
-#: src/olympia/reviews/templates/reviews/add.html:57
+#: src/olympia/addons/templates/addons/details_box.html:81 src/olympia/addons/templates/addons/persona_detail_table.html:15 src/olympia/browse/views.py:429 src/olympia/devhub/views.py:76
+#: src/olympia/devhub/views.py:83 src/olympia/discovery/templates/discovery/addons/detail.html:57 src/olympia/reviews/forms.py:62 src/olympia/reviews/templates/reviews/add.html:57
 #: src/olympia/reviews/templates/reviews/mobile/review_list.html:18
 msgid "Rating"
 msgstr "Ocena"
 
-#: src/olympia/addons/templates/addons/details_box.html:85
-#: src/olympia/browse/views.py:461 src/olympia/devhub/views.py:77
-#: src/olympia/devhub/views.py:84
-#: src/olympia/stats/templates/stats/addon_report_menu.html:8
-#: src/olympia/stats/templates/stats/collection_report_menu.html:18
+#: src/olympia/addons/templates/addons/details_box.html:85 src/olympia/browse/views.py:428 src/olympia/devhub/views.py:75 src/olympia/devhub/views.py:82
+#: src/olympia/stats/templates/stats/addon_report_menu.html:8 src/olympia/stats/templates/stats/collection_report_menu.html:18
 msgid "Downloads"
 msgstr "Prenosi"
 
-#: src/olympia/addons/templates/addons/details_box.html:91
-#: src/olympia/addons/templates/addons/details_box.html:103
-#: src/olympia/devhub/templates/devhub/addons/listing/item_actions_theme.html:17
+#: src/olympia/addons/templates/addons/details_box.html:91 src/olympia/addons/templates/addons/details_box.html:103 src/olympia/devhub/templates/devhub/addons/listing/item_actions_theme.html:17
 #: src/olympia/devhub/templates/devhub/personas/edit.html:60
 msgid "View Statistics"
 msgstr "Prikaži statistiko"
@@ -573,18 +425,13 @@ msgid "Abuse Reports"
 msgstr "Poročila o zlorabah"
 
 #. The Privacy Policy for this add-on.
-#: src/olympia/addons/templates/addons/details_box.html:121
-#: src/olympia/addons/templates/addons/privacy.html:19
-#: src/olympia/addons/templates/addons/privacy.html:23
-#: src/olympia/addons/templates/addons/impala/button.html:43
-#: src/olympia/addons/templates/addons/impala/details.html:307
-#: src/olympia/devhub/templates/devhub/includes/policy_form.html:20
+#: src/olympia/addons/templates/addons/details_box.html:121 src/olympia/addons/templates/addons/privacy.html:19 src/olympia/addons/templates/addons/privacy.html:23
+#: src/olympia/addons/templates/addons/impala/button.html:43 src/olympia/addons/templates/addons/impala/details.html:312 src/olympia/devhub/templates/devhub/includes/policy_form.html:23
 #: src/olympia/templates/mobile/base_addons.html:87
 msgid "Privacy Policy"
 msgstr "Izjava o zasebnosti"
 
-#: src/olympia/addons/templates/addons/details_box.html:124
-#: src/olympia/discovery/templates/discovery/addons/detail.html:24
+#: src/olympia/addons/templates/addons/details_box.html:124 src/olympia/discovery/templates/discovery/addons/detail.html:24
 msgid "View Privacy Policy"
 msgstr "Ogled politike zasebnosti"
 
@@ -592,8 +439,7 @@ msgstr "Ogled politike zasebnosti"
 msgid "EULA"
 msgstr "EULA"
 
-#: src/olympia/addons/templates/addons/details_box.html:171
-#: src/olympia/addons/templates/addons/details_box.html:231
+#: src/olympia/addons/templates/addons/details_box.html:171 src/olympia/addons/templates/addons/details_box.html:231
 msgid "More about this add-on"
 msgstr "Več o tem dodatku"
 
@@ -601,26 +447,21 @@ msgstr "Več o tem dodatku"
 msgid "Image Gallery"
 msgstr "Galerija slik"
 
-#: src/olympia/addons/templates/addons/details_box.html:190
-#: src/olympia/devhub/templates/devhub/addons/edit/technical.html:21
+#: src/olympia/addons/templates/addons/details_box.html:190 src/olympia/devhub/templates/devhub/addons/edit/technical.html:21
 msgid "Developer Comments"
 msgstr "Komentarji razvijalcev"
 
-#: src/olympia/addons/templates/addons/details_box.html:199
-#: src/olympia/addons/templates/addons/impala/details.html:259
+#: src/olympia/addons/templates/addons/details_box.html:199 src/olympia/addons/templates/addons/impala/details.html:264
 msgid "Development Channel"
 msgstr "Razvojni kanal"
 
-#: src/olympia/addons/templates/addons/details_box.html:202
-#: src/olympia/addons/templates/addons/mobile/details.html:124
+#: src/olympia/addons/templates/addons/details_box.html:202 src/olympia/addons/templates/addons/mobile/details.html:124
 msgid ""
-"The Development Channel lets you test an experimental new version of this "
-"add-on before it's released to the general public. Once you install the "
-"development version, you will continue to get updates from this channel."
+"The Development Channel lets you test an experimental new version of this add-on before it's released to the general public. Once you install the development version, you will continue to get "
+"updates from this channel."
 msgstr ""
-"Razvojni kanal vam omogoča preizkusiti poskusno novo različico tega dodatka,"
-" preden se jo objavi za širšo javnost. Potem ko namestite razvojno "
-"različico, boste prejemali posodobitve z razvojnega kanala."
+"Razvojni kanal vam omogoča preizkusiti poskusno novo različico tega dodatka, preden se jo objavi za širšo javnost. Potem ko namestite razvojno različico, boste prejemali posodobitve z razvojnega "
+"kanala."
 
 #: src/olympia/addons/templates/addons/details_box.html:207
 msgid "Install development version"
@@ -628,75 +469,52 @@ msgstr "Namesti razvojno različico"
 
 #: src/olympia/addons/templates/addons/details_box.html:211
 msgid ""
-"<strong>Caution:</strong> Development versions of this add-on have not been "
-"reviewed by Mozilla. Once you install a development version you will "
-"continue to receive development updates from this developer. To stop "
-"receiving development updates, reinstall the default version from the link "
-"above."
+"<strong>Caution:</strong> Development versions of this add-on have not been reviewed by Mozilla. Once you install a development version you will continue to receive development updates from this "
+"developer. To stop receiving development updates, reinstall the default version from the link above."
 msgstr ""
-"<strong>Pozor:</strong> Razvojnih različic te razširitve Mozilla ni "
-"pregledala. Potem ko namestite razvojno različico, boste prejemali razvojne "
-"posodobitve tega razvijalca. Če ne želite več prejemati razvojnih "
-"posodobitev, namestite ponovno privzeto različico v zgornji povezavi."
+"<strong>Pozor:</strong> Razvojnih različic te razširitve Mozilla ni pregledala. Potem ko namestite razvojno različico, boste prejemali razvojne posodobitve tega razvijalca. Če ne želite več "
+"prejemati razvojnih posodobitev, namestite ponovno privzeto različico v zgornji povezavi."
 
-#: src/olympia/addons/templates/addons/details_box.html:220
-#: src/olympia/addons/templates/addons/impala/details.html:278
+#: src/olympia/addons/templates/addons/details_box.html:220 src/olympia/addons/templates/addons/impala/details.html:283
 msgid "Version {0}:"
 msgstr "Različica {0}:"
 
 #: src/olympia/addons/templates/addons/details_box.html:234
 msgid "Nothing to see here!  The developer did not include any details."
-msgstr "Tu ni ničesar zanimivega!  Razvijalec ni dodal nobenih podrobnosti."
+msgstr ""
 
-#: src/olympia/addons/templates/addons/details_box.html:251
-#: src/olympia/devhub/templates/devhub/versions/edit.html:73
-#: src/olympia/editors/templates/editors/review.html:98
+#: src/olympia/addons/templates/addons/details_box.html:251 src/olympia/devhub/templates/devhub/versions/edit.html:73 src/olympia/editors/templates/editors/review.html:98
 msgid "Version Notes"
 msgstr "Opombe o različici"
 
 #. {0} is the name of the add-on.
 #. {0} is the name of the add-on
-#: src/olympia/addons/templates/addons/eula.html:6
-#: src/olympia/discovery/templates/discovery/addons/eula.html:5
+#: src/olympia/addons/templates/addons/eula.html:6 src/olympia/discovery/templates/discovery/addons/eula.html:5
 msgid "End-User License Agreement for {0}"
 msgstr "Licenčni dogovor za končnega uporabnika za {0}"
 
-#: src/olympia/addons/templates/addons/eula.html:17
-#: src/olympia/addons/templates/addons/eula.html:21
-#: src/olympia/addons/templates/addons/impala/button.html:48
-#: src/olympia/addons/templates/addons/impala/details.html:316
-#: src/olympia/devhub/templates/devhub/includes/policy_form.html:3
-#: src/olympia/discovery/templates/discovery/addons/eula.html:11
+#: src/olympia/addons/templates/addons/eula.html:17 src/olympia/addons/templates/addons/eula.html:21 src/olympia/addons/templates/addons/impala/button.html:48
+#: src/olympia/addons/templates/addons/impala/details.html:321 src/olympia/devhub/templates/devhub/includes/policy_form.html:3 src/olympia/discovery/templates/discovery/addons/eula.html:11
 msgid "End-User License Agreement"
 msgstr "Licenčni dogovor za končnega uporabnika"
 
-#: src/olympia/addons/templates/addons/eula.html:23
-#: src/olympia/discovery/templates/discovery/addons/eula.html:13
+#: src/olympia/addons/templates/addons/eula.html:23 src/olympia/discovery/templates/discovery/addons/eula.html:13
 #, python-format
-msgid ""
-"%(addon_name)s requires that you accept the following End-User License "
-"Agreement before installation can proceed:"
-msgstr ""
-"%(addon_name)s zahteva, da pred nadaljevanjem namestitve izjavite, da se "
-"strinjate z naslednjim dovoljenjem (EULA):"
+msgid "%(addon_name)s requires that you accept the following End-User License Agreement before installation can proceed:"
+msgstr "%(addon_name)s zahteva, da pred nadaljevanjem namestitve izjavite, da se strinjate z naslednjim dovoljenjem (EULA):"
 
-#: src/olympia/addons/templates/addons/eula.html:34
-#: src/olympia/addons/templates/addons/privacy.html:26
+#: src/olympia/addons/templates/addons/eula.html:34 src/olympia/addons/templates/addons/privacy.html:26
 msgid "Back to {0}…"
 msgstr "Nazaj na {0}…"
 
 # {0} is the application the user is browsing.  Examples:  Thunderbird,
 # Firefox,
 # Sunbird
-#: src/olympia/addons/templates/addons/home.html:3
-#: src/olympia/addons/templates/addons/mobile/home.html:3
-#: src/olympia/amo/helpers.py:235
+#: src/olympia/addons/templates/addons/home.html:3 src/olympia/addons/templates/addons/mobile/home.html:3 src/olympia/amo/helpers.py:235
 msgid "Add-ons for {0}"
 msgstr "Dodatki za {0}"
 
-#: src/olympia/addons/templates/addons/home.html:10
-#: src/olympia/addons/templates/addons/home.html:51
-#: src/olympia/browse/templates/browse/impala/base_listing.html:11
+#: src/olympia/addons/templates/addons/home.html:10 src/olympia/addons/templates/addons/home.html:53 src/olympia/browse/templates/browse/impala/base_listing.html:11
 msgid "Featured Extensions"
 msgstr "Izbrane razširitve"
 
@@ -704,70 +522,49 @@ msgstr "Izbrane razširitve"
 msgid "Popular Extensions"
 msgstr "Priljubljene razširitve"
 
-#: src/olympia/addons/templates/addons/home.html:42
-#: src/olympia/amo/templates/amo/side_nav.html:3
-#: src/olympia/amo/templates/amo/side_nav.html:11
-#: src/olympia/amo/templates/amo/site_nav.html:3
-#: src/olympia/amo/templates/amo/site_nav.html:25
-#: src/olympia/browse/views.py:236 src/olympia/browse/views.py:281
-#: src/olympia/browse/views.py:481
+#: src/olympia/addons/templates/addons/home.html:44 src/olympia/amo/templates/amo/side_nav.html:3 src/olympia/amo/templates/amo/side_nav.html:11 src/olympia/amo/templates/amo/site_nav.html:3
+#: src/olympia/amo/templates/amo/site_nav.html:25 src/olympia/browse/views.py:203 src/olympia/browse/views.py:248 src/olympia/browse/views.py:448
 msgid "Most Popular"
 msgstr "Najbolj priljubljeni"
 
-#: src/olympia/addons/templates/addons/home.html:43
+#: src/olympia/addons/templates/addons/home.html:45
 msgid "All »"
 msgstr "Vsi »"
 
-#: src/olympia/addons/templates/addons/home.html:52
-#: src/olympia/addons/templates/addons/home.html:61
-#: src/olympia/addons/templates/addons/home.html:70
-#: src/olympia/addons/templates/addons/home.html:78
+#: src/olympia/addons/templates/addons/home.html:54 src/olympia/addons/templates/addons/home.html:63 src/olympia/addons/templates/addons/home.html:72 src/olympia/addons/templates/addons/home.html:80
 #: src/olympia/browse/templates/browse/impala/category_landing.html:36
 msgid "See all »"
 msgstr "Glej vse »"
 
-#: src/olympia/addons/templates/addons/home.html:60
+#: src/olympia/addons/templates/addons/home.html:62
 msgid "Up &amp; Coming Extensions"
 msgstr "Razširitve na obzorju"
 
-#: src/olympia/addons/templates/addons/home.html:69
-#: src/olympia/browse/templates/browse/personas/category_landing.html:61
-#: src/olympia/discovery/templates/discovery/pane.html:74
+#: src/olympia/addons/templates/addons/home.html:71 src/olympia/browse/templates/browse/personas/category_landing.html:61 src/olympia/discovery/templates/discovery/pane.html:74
 msgid "Featured Themes"
 msgstr "Izbrane teme"
 
-#: src/olympia/addons/templates/addons/home.html:77
-#: src/olympia/bandwagon/templates/bandwagon/impala/collection_listing.html:5
+#: src/olympia/addons/templates/addons/home.html:79 src/olympia/bandwagon/templates/bandwagon/impala/collection_listing.html:5
 msgid "Featured Collections"
 msgstr "Izbrane zbirke"
 
-#: src/olympia/addons/templates/addons/listing_header.html:3
-#: src/olympia/addons/templates/addons/impala/listing/sorter.html:2
-#: src/olympia/amo/templates/amo/mobile/sort_by.html:2
+#: src/olympia/addons/templates/addons/listing_header.html:3 src/olympia/addons/templates/addons/impala/listing/sorter.html:2 src/olympia/amo/templates/amo/mobile/sort_by.html:2
 #: src/olympia/bandwagon/templates/bandwagon/collection_detail.html:118
 msgid "Sort by:"
 msgstr "Razvrsti po:"
 
 #. {0} is a date.
 #. {0} is a date
-#: src/olympia/addons/templates/addons/macros.html:7
-#: src/olympia/addons/templates/addons/macros.html:72
-#: src/olympia/addons/templates/addons/listing/items_mobile.html:48
-#: src/olympia/addons/templates/addons/listing/macros.html:42
-#: src/olympia/bandwagon/templates/bandwagon/collection_detail.html:50
-#: src/olympia/bandwagon/templates/bandwagon/collection_listing_items.html:40
-#: src/olympia/bandwagon/templates/bandwagon/impala/collection_listing_items.html:40
+#: src/olympia/addons/templates/addons/macros.html:7 src/olympia/addons/templates/addons/macros.html:72 src/olympia/addons/templates/addons/listing/items_mobile.html:48
+#: src/olympia/addons/templates/addons/listing/macros.html:42 src/olympia/bandwagon/templates/bandwagon/collection_detail.html:50
+#: src/olympia/bandwagon/templates/bandwagon/collection_listing_items.html:40 src/olympia/bandwagon/templates/bandwagon/impala/collection_listing_items.html:40
 msgid "Updated {0}"
 msgstr "Posodobljeno {0}"
 
 #. {0} is a date.
-#: src/olympia/addons/templates/addons/macros.html:10
-#: src/olympia/addons/templates/addons/macros.html:69
-#: src/olympia/addons/templates/addons/persona_preview.html:21
-#: src/olympia/addons/templates/addons/listing/items_mobile.html:44
-#: src/olympia/addons/templates/addons/listing/macros.html:39
-#: src/olympia/bandwagon/templates/bandwagon/collection_listing_items.html:37
-#: src/olympia/bandwagon/templates/bandwagon/impala/collection_listing_items.html:37
+#: src/olympia/addons/templates/addons/macros.html:10 src/olympia/addons/templates/addons/macros.html:69 src/olympia/addons/templates/addons/persona_preview.html:22
+#: src/olympia/addons/templates/addons/listing/items_mobile.html:44 src/olympia/addons/templates/addons/listing/macros.html:39
+#: src/olympia/bandwagon/templates/bandwagon/collection_listing_items.html:37 src/olympia/bandwagon/templates/bandwagon/impala/collection_listing_items.html:37
 msgid "Added {0}"
 msgstr "Dodano {0}"
 
@@ -777,8 +574,6 @@ msgid "%(num)s weekly download"
 msgid_plural "%(num)s weekly downloads"
 msgstr[0] "%(num)s prenos na teden"
 msgstr[1] "%(num)s prenosa na teden"
-msgstr[2] "%(num)s prenosi na teden"
-msgstr[3] "%(num)s prenosov na teden"
 
 #: src/olympia/addons/templates/addons/macros.html:28
 #, python-format
@@ -786,30 +581,20 @@ msgid "%(num)s user"
 msgid_plural "%(num)s users"
 msgstr[0] "%(num)s uporabnik"
 msgstr[1] "%(num)s uporabnika"
-msgstr[2] "%(num)s uporabniki"
-msgstr[3] "%(num)s uporabnikov"
 
 #. {0} is the number of downloads.
-#: src/olympia/addons/templates/addons/macros.html:53
-#: src/olympia/addons/templates/addons/impala/details.html:61
+#: src/olympia/addons/templates/addons/macros.html:53 src/olympia/addons/templates/addons/impala/details.html:59
 msgid "{0} weekly download"
 msgid_plural "{0} weekly downloads"
 msgstr[0] "{0} prenos na teden"
 msgstr[1] "{0} prenosa na teden"
-msgstr[2] "{0} prenosi na teden"
-msgstr[3] "{0} prenosov na teden"
 
 #. {0} is the number of users.
-#: src/olympia/addons/templates/addons/macros.html:61
-#: src/olympia/addons/templates/addons/impala/details.html:54
-#: src/olympia/compat/templates/compat/index.html:71
-#: src/olympia/zadmin/templates/zadmin/compat.html:67
+#: src/olympia/addons/templates/addons/macros.html:61 src/olympia/addons/templates/addons/impala/details.html:52 src/olympia/zadmin/templates/zadmin/compat.html:67
 msgid "{0} user"
 msgid_plural "{0} users"
 msgstr[0] "{0} uporabnik"
 msgstr[1] "{0} uporabnika"
-msgstr[2] "{0} uporabniki"
-msgstr[3] "{0} uporabnikov"
 
 #: src/olympia/addons/templates/addons/paypal_result.html:12
 msgid "Payment cancelled"
@@ -823,12 +608,8 @@ msgstr "Plačilo zaključeno"
 msgid "Return to the addon."
 msgstr "Nazaj na dodatek."
 
-#: src/olympia/addons/templates/addons/persona_detail.html:17
-#: src/olympia/addons/templates/addons/impala/details.html:106
-#: src/olympia/addons/templates/addons/mobile/details.html:23
-#: src/olympia/addons/templates/addons/mobile/persona_detail.html:21
-#: src/olympia/discovery/templates/discovery/addons/base.html:27
-#: src/olympia/editors/templates/editors/review.html:31
+#: src/olympia/addons/templates/addons/persona_detail.html:17 src/olympia/addons/templates/addons/impala/details.html:103 src/olympia/addons/templates/addons/mobile/details.html:23
+#: src/olympia/addons/templates/addons/mobile/persona_detail.html:21 src/olympia/discovery/templates/discovery/addons/base.html:27 src/olympia/editors/templates/editors/review.html:31
 msgid "by"
 msgstr "-"
 
@@ -838,8 +619,7 @@ msgid "More {0} Themes"
 msgstr "Več {0} tem"
 
 #. {0} is a category name, such as Nature
-#: src/olympia/addons/templates/addons/persona_detail.html:39
-#: src/olympia/addons/templates/addons/mobile/persona_detail.html:66
+#: src/olympia/addons/templates/addons/persona_detail.html:39 src/olympia/addons/templates/addons/mobile/persona_detail.html:66
 msgid "See all {0} Themes"
 msgstr "Oglejte si vse teme kategorije {0}"
 
@@ -847,186 +627,129 @@ msgstr "Oglejte si vse teme kategorije {0}"
 msgid "More by this Artist"
 msgstr "Več od tega umetnika"
 
-#: src/olympia/addons/templates/addons/persona_detail.html:52
-#: src/olympia/addons/templates/addons/mobile/persona_detail.html:49
+#: src/olympia/addons/templates/addons/persona_detail.html:52 src/olympia/addons/templates/addons/mobile/persona_detail.html:49
 msgid "See all Themes by this Artist"
 msgstr "Oglejte si vse teme tega umetnika"
 
-#: src/olympia/addons/templates/addons/persona_detail.html:71
-#: src/olympia/addons/templates/addons/mobile/home.html:42
-#: src/olympia/amo/templates/amo/side_nav.html:22
-#: src/olympia/browse/templates/browse/personas/mobile/category_landing.html:28
-#: src/olympia/devhub/templates/devhub/addons/edit/basic.html:72
-#: src/olympia/editors/templates/editors/review.html:277
-#: src/olympia/editors/templates/editors/themes/themes.html:34
-#: src/olympia/templates/categories.html:7
+#: src/olympia/addons/templates/addons/persona_detail.html:71 src/olympia/addons/templates/addons/mobile/home.html:42 src/olympia/amo/templates/amo/side_nav.html:22
+#: src/olympia/browse/templates/browse/personas/mobile/category_landing.html:28 src/olympia/devhub/templates/devhub/addons/edit/basic.html:72 src/olympia/editors/templates/editors/review.html:277
+#: src/olympia/editors/templates/editors/themes/themes.html:34 src/olympia/templates/categories.html:7
 msgid "Categories"
 msgstr "Kategorije"
 
-#: src/olympia/addons/templates/addons/persona_detail_table.html:10
-#: src/olympia/addons/templates/addons/mobile/persona_detail_table.html:3
-#: src/olympia/editors/templates/editors/themes/deleted.html:19
+#: src/olympia/addons/templates/addons/persona_detail_table.html:10 src/olympia/addons/templates/addons/mobile/persona_detail_table.html:3 src/olympia/editors/templates/editors/themes/deleted.html:19
 #: src/olympia/editors/templates/editors/themes/themes.html:25
 msgid "Artist"
 msgstr "Izvajalec"
 
-#: src/olympia/addons/templates/addons/persona_detail_table.html:19
-#: src/olympia/addons/templates/addons/mobile/persona_detail_table.html:14
-#: src/olympia/stats/templates/stats/addon_report_menu.html:17
+#: src/olympia/addons/templates/addons/persona_detail_table.html:19 src/olympia/addons/templates/addons/mobile/persona_detail_table.html:14 src/olympia/stats/templates/stats/addon_report_menu.html:17
 msgid "Daily Users"
 msgstr "Dnevnih uporabnikov"
 
 #. The License for this add-on.
-#: src/olympia/addons/templates/addons/persona_detail_table.html:26
-#: src/olympia/addons/templates/addons/impala/license.html:17
-#: src/olympia/addons/templates/addons/mobile/persona_detail_table.html:21
-#: src/olympia/devhub/templates/devhub/includes/license_form.html:5
-#: src/olympia/devhub/templates/devhub/versions/edit.html:89
-#: src/olympia/editors/templates/editors/themes/themes.html:41
+#: src/olympia/addons/templates/addons/persona_detail_table.html:26 src/olympia/addons/templates/addons/impala/license.html:17 src/olympia/addons/templates/addons/mobile/persona_detail_table.html:21
+#: src/olympia/devhub/templates/devhub/includes/license_form.html:5 src/olympia/devhub/templates/devhub/versions/edit.html:89 src/olympia/editors/templates/editors/themes/themes.html:41
 msgid "License"
 msgstr "Licenca"
 
-#: src/olympia/addons/templates/addons/persona_preview.html:12
-#: src/olympia/constants/base.py:48
+#: src/olympia/addons/templates/addons/persona_preview.html:13 src/olympia/constants/base.py:48
 msgid "Awaiting Review"
 msgstr "Čaka na pregled"
 
-#: src/olympia/addons/templates/addons/persona_preview.html:14
-#: src/olympia/amo/log.py:180 src/olympia/constants/base.py:42
-#: src/olympia/editors/helpers.py:62
+#: src/olympia/addons/templates/addons/persona_preview.html:15 src/olympia/amo/log.py:180 src/olympia/constants/base.py:42 src/olympia/editors/helpers.py:62
 msgid "Rejected"
 msgstr "Zavrnjeno"
 
-#: src/olympia/addons/templates/addons/persona_preview.html:16
-#: src/olympia/amo/log.py:159
+#: src/olympia/addons/templates/addons/persona_preview.html:17 src/olympia/amo/log.py:159
 msgid "Approved"
 msgstr "Odobreno"
 
 #. {0} is the number of users.
-#: src/olympia/addons/templates/addons/persona_preview.html:26
-#: src/olympia/addons/templates/addons/listing/items_mobile.html:36
-#: src/olympia/addons/templates/addons/listing/macros.html:31
+#: src/olympia/addons/templates/addons/persona_preview.html:27 src/olympia/addons/templates/addons/listing/items_mobile.html:36 src/olympia/addons/templates/addons/listing/macros.html:31
 msgid "<strong>{0}</strong> user"
 msgid_plural "<strong>{0}</strong> users"
 msgstr[0] "<strong>{0}</strong> uporabnik"
 msgstr[1] "<strong>{0}</strong> uporabnika"
-msgstr[2] "<strong>{0}</strong> uporabniki"
-msgstr[3] "<strong>{0}</strong> uporabnikov"
 
-#: src/olympia/addons/templates/addons/persona_preview.html:40
+#: src/olympia/addons/templates/addons/persona_preview.html:41
 msgid "Hover to Preview"
 msgstr "Tu pridržite kazalec za predogled"
 
-#: src/olympia/addons/templates/addons/persona_preview.html:46
-#: src/olympia/addons/templates/addons/persona_preview.html:48
+#: src/olympia/addons/templates/addons/persona_preview.html:47 src/olympia/addons/templates/addons/persona_preview.html:49 src/olympia/addons/templates/addons/persona_preview.html:97
 #: src/olympia/reviews/templates/reviews/add.html:15
 msgid "Add"
 msgstr "Dodaj"
 
-#: src/olympia/addons/templates/addons/persona_preview.html:57
-#: src/olympia/bandwagon/templates/bandwagon/ajax_new.html:16
-#: src/olympia/bandwagon/templates/bandwagon/edit.html:19
-#: src/olympia/bandwagon/templates/bandwagon/includes/addedit.html:19
-#: src/olympia/devhub/templates/devhub/addons/edit/admin.html:13
-#: src/olympia/devhub/templates/devhub/addons/edit/basic.html:10
-#: src/olympia/devhub/templates/devhub/addons/edit/details.html:8
-#: src/olympia/devhub/templates/devhub/addons/edit/media.html:6
-#: src/olympia/devhub/templates/devhub/addons/edit/support.html:8
-#: src/olympia/devhub/templates/devhub/addons/edit/technical.html:9
-#: src/olympia/devhub/templates/devhub/addons/submit/describe.html:29
-#: src/olympia/editors/templates/editors/review.html:257
+#: src/olympia/addons/templates/addons/persona_preview.html:58 src/olympia/bandwagon/templates/bandwagon/ajax_new.html:16 src/olympia/bandwagon/templates/bandwagon/edit.html:19
+#: src/olympia/bandwagon/templates/bandwagon/includes/addedit.html:19 src/olympia/devhub/templates/devhub/addons/edit/admin.html:13 src/olympia/devhub/templates/devhub/addons/edit/basic.html:10
+#: src/olympia/devhub/templates/devhub/addons/edit/details.html:8 src/olympia/devhub/templates/devhub/addons/edit/media.html:6 src/olympia/devhub/templates/devhub/addons/edit/support.html:8
+#: src/olympia/devhub/templates/devhub/addons/edit/technical.html:9 src/olympia/devhub/templates/devhub/addons/submit/describe.html:29 src/olympia/editors/templates/editors/review.html:257
 msgid "Edit"
 msgstr "Uredi"
 
 #. For datetime formatting, see the table on
 #. http://docs.python.org/library/datetime.html#strftime-and-strptime-behavior
-#: src/olympia/addons/templates/addons/persona_preview.html:66
+#: src/olympia/addons/templates/addons/persona_preview.html:67
 #, python-format
 msgid "%%Y-%%m-%%d"
 msgstr "%%d. %%m. %%Y"
 
-#: src/olympia/addons/templates/addons/persona_preview.html:67
+#: src/olympia/addons/templates/addons/persona_preview.html:68
 msgid "by {0} on {1}"
 msgstr "od {0} dne {1}"
 
-#: src/olympia/addons/templates/addons/persona_preview.html:75
-#: src/olympia/reviews/helpers.py:17
-#: src/olympia/reviews/templates/reviews/review_list.html:63
-#: src/olympia/reviews/templates/reviews/reviews_link.html:21
-#: src/olympia/reviews/templates/reviews/impala/reviews_link.html:16
+#: src/olympia/addons/templates/addons/persona_preview.html:76 src/olympia/reviews/helpers.py:17 src/olympia/reviews/templates/reviews/review_list.html:63
+#: src/olympia/reviews/templates/reviews/reviews_link.html:21 src/olympia/reviews/templates/reviews/impala/reviews_link.html:16
 msgid "Not yet rated"
 msgstr "Še ni ocenjeno"
 
-#: src/olympia/addons/templates/addons/persona_preview.html:78
+#: src/olympia/addons/templates/addons/persona_preview.html:79
 msgid "<b>{0}</b> users"
 msgstr "<b>{0}</b> uporabnikov"
 
 #: src/olympia/addons/templates/addons/popups.html:17
-msgid ""
-"To install this add-on and thousands more, <b>get Firefox</b>, a free and "
-"open web browser from Mozilla."
-msgstr ""
-"Če želite namestiti ta dodatek in na tisoče drugih, <b>si prenesite "
-"Firefox</b>, brezplačen in odprtokodni brskalnik Mozille."
+msgid "To install this add-on and thousands more, <b>get Firefox</b>, a free and open web browser from Mozilla."
+msgstr "Če želite namestiti ta dodatek in na tisoče drugih, <b>si prenesite Firefox</b>, brezplačen in odprtokodni brskalnik Mozille."
 
-#: src/olympia/addons/templates/addons/popups.html:21
-#: src/olympia/addons/templates/addons/popups.html:52
+#: src/olympia/addons/templates/addons/popups.html:21 src/olympia/addons/templates/addons/popups.html:52
 msgid "Learn more about Firefox"
 msgstr "Izvedite več o Firefoxu"
 
 #: src/olympia/addons/templates/addons/popups.html:22
-msgid "or <b><a class=\"installer\" href=\"{url}\">download anyway</a></b>"
-msgstr "ali <b><a class=\"installer\" href=\"{url}\">prenesite vseeno</a></b>"
+msgid "or <b><a class=\"button installer\" href=\"{url}\">download anyway</a></b>"
+msgstr ""
 
 #: src/olympia/addons/templates/addons/popups.html:26
 msgid ""
-"<strong>How to Install in Thunderbird</strong> <ol> <li>Download and save "
-"the file to your hard disk.</li> <li>In Mozilla Thunderbird, open Add-ons "
-"from the Tools menu.</li> <li>From the options button next to the add-on "
-"search field, select \"Install Add-on From File...\" and locate the "
-"downloaded add-on.</li> </ol>"
+"<strong>How to Install in Thunderbird</strong> <ol> <li>Download and save the file to your hard disk.</li> <li>In Mozilla Thunderbird, open Add-ons from the Tools menu.</li> <li>From the options "
+"button next to the add-on search field, select \"Install Add-on From File...\" and locate the downloaded add-on.</li> </ol>"
 msgstr ""
-"<strong>Kako namestiti v Thunderbirdu</strong> <ol> <li>Prenesite datoteko "
-"in jo shranite na disk.</li> <li>V Mozilla Thunderbirdu v meniju Orodja "
-"odprite Dodatke.</li> <li>Z gumbom za možnosti poleg polja za iskanje "
-"izberite \"Namesti dodatek iz datoteke...\" in nato poiščite dodatek, ki ste"
-" ga prenesli.</li> </ol>"
+"<strong>Kako namestiti v Thunderbirdu</strong> <ol> <li>Prenesite datoteko in jo shranite na disk.</li> <li>V Mozilla Thunderbirdu v meniju Orodja odprite Dodatke.</li> <li>Z gumbom za možnosti "
+"poleg polja za iskanje izberite \"Namesti dodatek iz datoteke...\" in nato poiščite dodatek, ki ste ga prenesli.</li> </ol>"
 
 #: src/olympia/addons/templates/addons/popups.html:41
-msgid ""
-"To install this Theme, <b>get Thunderbird</b>, a free and open source email "
-"client from Mozilla Messaging and install the Personas Plus add-on."
-msgstr ""
-"Če želite namestiti to temo, <b>si prenesite Thunderbird</b>, brezplačen in "
-"odprtokodni program za pošto Mozille Messaging in namestite dodatek Personas"
-" Plus."
+msgid "To install this Theme, <b>get Thunderbird</b>, a free and open source email client from Mozilla Messaging and install the Personas Plus add-on."
+msgstr "Če želite namestiti to temo, <b>si prenesite Thunderbird</b>, brezplačen in odprtokodni program za pošto Mozille Messaging in namestite dodatek Personas Plus."
 
 #: src/olympia/addons/templates/addons/popups.html:46
 msgid "Learn more about Thunderbird"
 msgstr "Več o Thunderbirdu"
 
 #: src/olympia/addons/templates/addons/popups.html:48
-msgid ""
-"To install this Theme and thousands more, <b>get Firefox</b>, a free and "
-"open web browser from Mozilla."
-msgstr ""
-"Če želite namestiti to temo in na tisoče drugih, <b>si prenesite "
-"Firefox</b>, brezplačen in odprtokodni brskalnik Mozille."
+msgid "To install this Theme and thousands more, <b>get Firefox</b>, a free and open web browser from Mozilla."
+msgstr "Če želite namestiti to temo in na tisoče drugih, <b>si prenesite Firefox</b>, brezplačen in odprtokodni brskalnik Mozille."
 
 #: src/olympia/addons/templates/addons/popups.html:60
 #, python-format
 msgid "This add-on has not been updated to work with your version of %(app)s."
 msgstr "Ta dodatek ni bil posodobljen za delo z vašo različico %(app)sa."
 
-#: src/olympia/addons/templates/addons/popups.html:63
-#: src/olympia/addons/templates/addons/popups.html:140
-#: src/olympia/addons/templates/addons/popups.html:150
+#: src/olympia/addons/templates/addons/popups.html:63 src/olympia/addons/templates/addons/popups.html:140 src/olympia/addons/templates/addons/popups.html:150
 msgid "Install Anyway"
 msgstr "Namesti vseeno"
 
 #: src/olympia/addons/templates/addons/popups.html:71
-msgid ""
-"This add-on requires a version of Firefox that has not been released yet."
+msgid "This add-on requires a version of Firefox that has not been released yet."
 msgstr "To razširitev zahteva različico Firefoxa, ki je še ni objavljena."
 
 #: src/olympia/addons/templates/addons/popups.html:74
@@ -1035,64 +758,40 @@ msgstr "Pomagajte testirati nove različice Firefoxa"
 
 #: src/olympia/addons/templates/addons/popups.html:77
 #, python-format
-msgid ""
-"This add-on requires %(app)s {new_version}. You are currently using %(app)s "
-"{old_version}."
-msgstr ""
-"Ta dodatek zahteva %(app)s {new_version}. Trenutno uporabljate %(app)s "
-"{old_version}."
+msgid "This add-on requires %(app)s {new_version}. You are currently using %(app)s {old_version}."
+msgstr "Ta dodatek zahteva %(app)s {new_version}. Trenutno uporabljate %(app)s {old_version}."
 
 #. {0} is an app name, like Firefox.
-#: src/olympia/addons/templates/addons/popups.html:82
-#: src/olympia/addons/templates/addons/popups.html:101
+#: src/olympia/addons/templates/addons/popups.html:82 src/olympia/addons/templates/addons/popups.html:101
 msgid "Upgrade {0}"
 msgstr "Nadgradite {0}"
 
 #: src/olympia/addons/templates/addons/popups.html:85
 #, python-format
 msgid "or view <a href=\"%(href)s\">older versions of this add-on</a>."
-msgstr ""
-"ali pa si oglejte <a href=\"%(href)s\">starejše različice tega dodatka</a>."
+msgstr "ali pa si oglejte <a href=\"%(href)s\">starejše različice tega dodatka</a>."
 
 #: src/olympia/addons/templates/addons/popups.html:96
 #, python-format
-msgid ""
-"This Persona requires %(app)s %(new_version)s. You are currently using "
-"%(app)s {old_version}."
-msgstr ""
-"Ta Persona zahteva %(app)s %(new_version)s. Trenutno uporabljate %(app)s "
-"{old_version}."
+msgid "This Persona requires %(app)s %(new_version)s. You are currently using %(app)s {old_version}."
+msgstr "Ta Persona zahteva %(app)s %(new_version)s. Trenutno uporabljate %(app)s {old_version}."
 
 #: src/olympia/addons/templates/addons/popups.html:108
 msgid ""
-"<strong>Caution:</strong> This add-on has not been reviewed by Mozilla and "
-"can't be installed on release versions of Firefox 43 and above.  Be careful "
-"when installing third-party software that might harm your computer."
+"<strong>Caution:</strong> This add-on has not been reviewed by Mozilla and can't be installed on release versions of Firefox 43 and above.  Be careful when installing third-party software that "
+"might harm your computer."
 msgstr ""
-"<strong>Pozor:</strong> ta dodatek Mozilla ni pregledala in ga ni mogoče "
-"namestiti na izdajni različici Firefoxa 43 in višjih.  Bodite pazljivi pri "
-"nameščanju programske opreme tretjih oseb, ki lahko poškodujejo vaš "
-"računalnik."
 
 #: src/olympia/addons/templates/addons/popups.html:120
-msgid ""
-"<strong>Please note:</strong> This add-on is not compatible with your "
-"operating system."
-msgstr ""
-"<strong>Pomnite prosim:</strong> Ta razširitev ni združljiva z vašim "
-"operacijskim sistemom."
+msgid "<strong>Please note:</strong> This add-on is not compatible with your operating system."
+msgstr "<strong>Pomnite prosim:</strong> Ta razširitev ni združljiva z vašim operacijskim sistemom."
 
-#: src/olympia/addons/templates/addons/popups.html:136
-#: src/olympia/addons/templates/addons/impala/button.html:70
+#: src/olympia/addons/templates/addons/popups.html:136 src/olympia/addons/templates/addons/impala/button.html:70
 #, python-format
-msgid ""
-"This add-on is not compatible with your version of %(app)s because of the "
-"following:"
-msgstr ""
-"Ta dodatek ni združljiv z vašo različico %(app)sa iz naslednjega razloga:"
+msgid "This add-on is not compatible with your version of %(app)s because of the following:"
+msgstr "Ta dodatek ni združljiv z vašo različico %(app)sa iz naslednjega razloga:"
 
-#: src/olympia/addons/templates/addons/popups.html:141
-#: src/olympia/addons/templates/addons/popups.html:151
+#: src/olympia/addons/templates/addons/popups.html:141 src/olympia/addons/templates/addons/popups.html:151
 msgid "View other versions"
 msgstr "Prikaži druge različice"
 
@@ -1116,144 +815,88 @@ msgid ""
 "  to your phone.  (You'll need a QR reader.  Search your phone's marketplace if\n"
 "  don't have one.)"
 msgstr ""
-"Želite {0} za svoj mobilni Firefoxu?  Preberite to kodo QR, da\n"
-"  dodatek neposredno namestite na telefon (potrebovali boste bralnik kod QR.  Če\n"
-"  ga še nimate, ga poiščite v trgovini svojega telefona.)."
 
-#: src/olympia/addons/templates/addons/report_abuse.html:6
-#: src/olympia/addons/templates/addons/report_abuse_full.html:10
-#: src/olympia/addons/templates/addons/impala/details-more.html:23
-#: src/olympia/addons/templates/addons/impala/details.html:328
+#: src/olympia/addons/templates/addons/report_abuse.html:6 src/olympia/addons/templates/addons/report_abuse_full.html:10 src/olympia/addons/templates/addons/impala/details-more.html:23
+#: src/olympia/addons/templates/addons/impala/details.html:333
 msgid "Report Abuse"
 msgstr "Prijava zlorabe"
 
 #: src/olympia/addons/templates/addons/report_abuse.html:10
 #, python-format
 msgid ""
-"If you suspect this add-on violates <a href=\"%(url)s\">our policies</a> or "
-"has security or privacy issues, please use the form below to describe your "
-"concerns. Please do not use this form for any other reason."
+"If you suspect this add-on violates <a href=\"%(url)s\">our policies</a> or has security or privacy issues, please use the form below to describe your concerns. Please do not use this form for any "
+"other reason."
 msgstr ""
-"Če sumite, da ta dodatek krši <a href=\"%(url)s\">naše pravilnike</a> , ali "
-"ima probleme v zvezi z varnostjo in zasebnostjo, vnesite prosim svoje "
-"pomisleke v obrazec spodaj. Ne uporabljajte tega obrazca za kake druge "
-"namene."
+"Če sumite, da ta dodatek krši <a href=\"%(url)s\">naše pravilnike</a> , ali ima probleme v zvezi z varnostjo in zasebnostjo, vnesite prosim svoje pomisleke v obrazec spodaj. Ne uporabljajte tega "
+"obrazca za kake druge namene."
 
-#: src/olympia/addons/templates/addons/report_abuse.html:24
-#: src/olympia/users/templates/users/report_abuse.html:19
+#: src/olympia/addons/templates/addons/report_abuse.html:24 src/olympia/users/templates/users/report_abuse.html:19
 msgid "Send Report"
 msgstr "Pošlji poročilo"
 
-#: src/olympia/addons/templates/addons/report_abuse.html:26
-#: src/olympia/addons/templates/addons/mobile/eula.html:16
-#: src/olympia/addons/templates/addons/mobile/persona_confirm.html:7
-#: src/olympia/devhub/templates/devhub/addons/ajax_compat_update.html:36
-#: src/olympia/devhub/templates/devhub/addons/profile.html:44
-#: src/olympia/devhub/templates/devhub/addons/edit/admin.html:104
-#: src/olympia/devhub/templates/devhub/addons/edit/basic.html:155
-#: src/olympia/devhub/templates/devhub/addons/edit/details.html:88
-#: src/olympia/devhub/templates/devhub/addons/edit/support.html:70
-#: src/olympia/devhub/templates/devhub/addons/edit/technical.html:169
-#: src/olympia/devhub/templates/devhub/addons/forms_shared/media.html:152
-#: src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:44
-#: src/olympia/devhub/templates/devhub/personas/edit.html:222
-#: src/olympia/devhub/templates/devhub/versions/add_file_modal.html:79
-#: src/olympia/devhub/templates/devhub/versions/edit.html:140
-#: src/olympia/devhub/templates/devhub/versions/list.html:208
-#: src/olympia/devhub/templates/devhub/versions/list.html:242
-#: src/olympia/devhub/templates/devhub/versions/list.html:276
-#: src/olympia/devhub/templates/devhub/versions/list.html:317
-#: src/olympia/reviews/templates/reviews/edit_review.html:16
-#: src/olympia/translations/templates/translations/trans-menu.html:50
-#: src/olympia/translations/templates/translations/trans-menu.html:62
-#: src/olympia/zadmin/templates/zadmin/validation.html:105
+#: src/olympia/addons/templates/addons/report_abuse.html:26 src/olympia/addons/templates/addons/mobile/eula.html:16 src/olympia/addons/templates/addons/mobile/persona_confirm.html:7
+#: src/olympia/devhub/templates/devhub/addons/ajax_compat_update.html:36 src/olympia/devhub/templates/devhub/addons/profile.html:44 src/olympia/devhub/templates/devhub/addons/edit/admin.html:104
+#: src/olympia/devhub/templates/devhub/addons/edit/basic.html:155 src/olympia/devhub/templates/devhub/addons/edit/details.html:88 src/olympia/devhub/templates/devhub/addons/edit/support.html:70
+#: src/olympia/devhub/templates/devhub/addons/edit/technical.html:169 src/olympia/devhub/templates/devhub/addons/forms_shared/media.html:152
+#: src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:43 src/olympia/devhub/templates/devhub/personas/edit.html:222 src/olympia/devhub/templates/devhub/versions/add_file_modal.html:59
+#: src/olympia/devhub/templates/devhub/versions/edit.html:140 src/olympia/devhub/templates/devhub/versions/list.html:208 src/olympia/devhub/templates/devhub/versions/list.html:239
+#: src/olympia/devhub/templates/devhub/versions/list.html:281 src/olympia/devhub/templates/devhub/versions/list.html:315 src/olympia/reviews/templates/reviews/edit_review.html:16
+#: src/olympia/translations/templates/translations/trans-menu.html:50 src/olympia/translations/templates/translations/trans-menu.html:62 src/olympia/zadmin/templates/zadmin/validation.html:105
 msgid "Cancel"
 msgstr "Prekliči"
 
-#: src/olympia/addons/templates/addons/review_add_box.html:3
-#: src/olympia/addons/templates/addons/impala/review_add_box.html:5
+#: src/olympia/addons/templates/addons/review_add_box.html:3 src/olympia/addons/templates/addons/impala/review_add_box.html:5
 msgid "What do you think?"
 msgstr "Kaj mislite?"
 
-#: src/olympia/addons/templates/addons/review_add_box.html:7
-#: src/olympia/addons/templates/addons/impala/review_add_box.html:9
+#: src/olympia/addons/templates/addons/review_add_box.html:7 src/olympia/addons/templates/addons/impala/review_add_box.html:9
 #, python-format
 msgid "Please <a href=\"%(login)s\">log in</a> to submit a review"
 msgstr "<a href=\"%(login)s\">Prijavite se</a>, da ocenite dodatek"
 
-#: src/olympia/addons/templates/addons/review_add_box.html:16
-#: src/olympia/addons/templates/addons/impala/review_add_box.html:18
-#: src/olympia/reviews/templates/reviews/mobile/add_form.html:13
+#: src/olympia/addons/templates/addons/review_add_box.html:16 src/olympia/addons/templates/addons/impala/review_add_box.html:18 src/olympia/reviews/templates/reviews/mobile/add_form.html:13
 msgid "Title:"
 msgstr "Naslov:"
 
-#: src/olympia/addons/templates/addons/review_add_box.html:17
-#: src/olympia/addons/templates/addons/impala/review_add_box.html:19
-#: src/olympia/reviews/templates/reviews/mobile/add_form.html:17
+#: src/olympia/addons/templates/addons/review_add_box.html:17 src/olympia/addons/templates/addons/impala/review_add_box.html:19 src/olympia/reviews/templates/reviews/mobile/add_form.html:17
 msgid "Review:"
 msgstr "Ocena:"
 
-#: src/olympia/addons/templates/addons/review_add_box.html:18
-#: src/olympia/addons/templates/addons/impala/review_add_box.html:20
-#: src/olympia/reviews/templates/reviews/mobile/add_form.html:16
+#: src/olympia/addons/templates/addons/review_add_box.html:18 src/olympia/addons/templates/addons/impala/review_add_box.html:20 src/olympia/reviews/templates/reviews/mobile/add_form.html:16
 msgid "Rating:"
 msgstr "Ocena:"
 
-#: src/olympia/addons/templates/addons/review_add_box.html:19
-#: src/olympia/addons/templates/addons/impala/review_add_box.html:21
-#: src/olympia/reviews/templates/reviews/add.html:63
-#: src/olympia/reviews/templates/reviews/edit_review.html:15
-#: src/olympia/reviews/templates/reviews/mobile/add_form.html:18
+#: src/olympia/addons/templates/addons/review_add_box.html:19 src/olympia/addons/templates/addons/impala/review_add_box.html:21 src/olympia/reviews/templates/reviews/add.html:63
+#: src/olympia/reviews/templates/reviews/edit_review.html:15 src/olympia/reviews/templates/reviews/mobile/add_form.html:18
 msgid "Submit review"
 msgstr "Objavi oceno"
 
-#: src/olympia/addons/templates/addons/review_add_box.html:24
-#: src/olympia/addons/templates/addons/impala/review_add_box.html:26
-msgid ""
-"Please do not post bug reports in reviews. We do not make your email address"
-" available to add-on developers and they may need to contact you to help "
-"resolve your issue."
-msgstr ""
-"V ocenah ne objavljajte poročil o težavah. Vašega e-poštnega naslova "
-"razvijalcem ne dajemo, potrebovali pa bi ga, da bi od vas zvedeli več o "
-"težavi."
+#: src/olympia/addons/templates/addons/review_add_box.html:24 src/olympia/addons/templates/addons/impala/review_add_box.html:26
+msgid "Please do not post bug reports in reviews. We do not make your email address available to add-on developers and they may need to contact you to help resolve your issue."
+msgstr "V ocenah ne objavljajte poročil o težavah. Vašega e-poštnega naslova razvijalcem ne dajemo, potrebovali pa bi ga, da bi od vas zvedeli več o težavi."
 
-#: src/olympia/addons/templates/addons/review_add_box.html:32
-#: src/olympia/addons/templates/addons/impala/review_add_box.html:35
+#: src/olympia/addons/templates/addons/review_add_box.html:32 src/olympia/addons/templates/addons/impala/review_add_box.html:35
 #, python-format
-msgid ""
-"See the <a href=\"%(support)s\">support section</a> to find out where to get"
-" assistance for this add-on."
-msgstr ""
-"Glejte <a href=\"%(support)s\">odsek za podporo</a>, da zveste, kje lahko "
-"dobite pomoč za ta dodatek."
+msgid "See the <a href=\"%(support)s\">support section</a> to find out where to get assistance for this add-on."
+msgstr "Glejte <a href=\"%(support)s\">odsek za podporo</a>, da zveste, kje lahko dobite pomoč za ta dodatek."
 
-#: src/olympia/addons/templates/addons/review_add_box.html:38
-#: src/olympia/addons/templates/addons/impala/review_add_box.html:42
-#: src/olympia/pages/templates/pages/review_guide.html:3
+#: src/olympia/addons/templates/addons/review_add_box.html:38 src/olympia/addons/templates/addons/impala/review_add_box.html:42 src/olympia/pages/templates/pages/review_guide.html:3
 #: src/olympia/pages/templates/pages/review_guide.html:44
 msgid "Review Guidelines"
 msgstr "Smernice za ocene"
 
-#: src/olympia/addons/templates/addons/review_list_box.html:5
-#: src/olympia/addons/templates/addons/impala/details-more.html:27
-#: src/olympia/editors/helpers.py:921
-#: src/olympia/reviews/templates/reviews/add.html:14
-#: src/olympia/reviews/templates/reviews/reply.html:14
-#: src/olympia/reviews/templates/reviews/review_list.html:19
+#: src/olympia/addons/templates/addons/review_list_box.html:5 src/olympia/addons/templates/addons/impala/details-more.html:27 src/olympia/editors/helpers.py:1001
+#: src/olympia/reviews/templates/reviews/add.html:14 src/olympia/reviews/templates/reviews/reply.html:14 src/olympia/reviews/templates/reviews/review_list.html:19
 #: src/olympia/reviews/templates/reviews/mobile/review_list.html:26
 msgid "Reviews"
 msgstr "Ocene"
 
-#: src/olympia/addons/templates/addons/review_list_box.html:14
-#: src/olympia/addons/templates/addons/impala/review_list_box.html:14
-#: src/olympia/reviews/templates/reviews/review.html:30
+#: src/olympia/addons/templates/addons/review_list_box.html:14 src/olympia/addons/templates/addons/impala/review_list_box.html:14 src/olympia/reviews/templates/reviews/review.html:30
 #, python-format
 msgid "by %(user)s on %(date)s"
 msgstr "od %(user)s dne %(date)s"
 
-#: src/olympia/addons/templates/addons/review_list_box.html:19
-#: src/olympia/addons/templates/addons/impala/review_list_box.html:29
+#: src/olympia/addons/templates/addons/review_list_box.html:19 src/olympia/addons/templates/addons/impala/review_list_box.html:29
 msgid "Show the developer's reply to this review"
 msgstr "Pokaži odgovor razvijalca na to oceno"
 
@@ -1263,24 +906,17 @@ msgid "See all reviews of this add-on"
 msgid_plural "See all %(cnt)s reviews of this add-on"
 msgstr[0] "Pokaži vse ocene dodatka"
 msgstr[1] "Pokaži obe oceni dodatka"
-msgstr[2] "Pokaži vse %(cnt)s ocene dodatka"
-msgstr[3] "Pokaži vseh %(cnt)s ocen dodatka"
 
-#: src/olympia/addons/templates/addons/tags_box.html:3
-#: src/olympia/devhub/templates/devhub/addons/edit/basic.html:118
+#: src/olympia/addons/templates/addons/tags_box.html:3 src/olympia/devhub/templates/devhub/addons/edit/basic.html:118
 msgid "Tags"
 msgstr "Oznake"
 
-#: src/olympia/addons/templates/addons/impala/addon_hovercard.html:7
-#: src/olympia/addons/templates/addons/impala/addon_hovercard.html:9
+#: src/olympia/addons/templates/addons/impala/addon_hovercard.html:7 src/olympia/addons/templates/addons/impala/addon_hovercard.html:9
 msgid "Icon for {0}"
 msgstr "Ikona za {0}"
 
-#: src/olympia/addons/templates/addons/impala/addon_hovercard.html:34
-#: src/olympia/addons/templates/addons/impala/featured_grid.html:26
-#: src/olympia/addons/templates/addons/impala/theme_grid.html:22
-#: src/olympia/bandwagon/templates/bandwagon/collection_detail.html:31
-#: src/olympia/users/templates/users/helpers/addon_users_list.html:7
+#: src/olympia/addons/templates/addons/impala/addon_hovercard.html:34 src/olympia/addons/templates/addons/impala/featured_grid.html:26 src/olympia/addons/templates/addons/impala/theme_grid.html:22
+#: src/olympia/bandwagon/templates/bandwagon/collection_detail.html:31 src/olympia/users/templates/users/helpers/addon_users_list.html:7
 #, python-format
 msgid "by %(users)s"
 msgstr "od %(users)s"
@@ -1300,34 +936,18 @@ msgstr "Vam je dodatek všeč?"
 
 #: src/olympia/addons/templates/addons/impala/contribution.html:43
 #, python-format
-msgid ""
-"The <a href=\"%(meet_url)s\">developer of this add-on</a> asks that you help"
-" support its continued development by making a small contribution."
-msgstr ""
-"<a href=\"%(meet_url)s\">Razvijalec tega dodatka</a> vas prosi, da mu z "
-"majhnim prispevkom pomagate pri nadaljnjem razvoju."
+msgid "The <a href=\"%(meet_url)s\">developer of this add-on</a> asks that you help support its continued development by making a small contribution."
+msgstr "<a href=\"%(meet_url)s\">Razvijalec tega dodatka</a> vas prosi, da mu z majhnim prispevkom pomagate pri nadaljnjem razvoju."
 
 #: src/olympia/addons/templates/addons/impala/contribution.html:48
 #, python-format
-msgid ""
-"The <a href=\"%(meet_url)s\">developer of this add-on</a> asks that you show"
-" your support by making a donation to the <a "
-"href=\"%(charity_url)s\">%(charity_name)s</a>."
-msgstr ""
-"<a href=\"%(meet_url)s\">Razvijalec tega dodatka</a> vas prosi, da mu z "
-"donacijo za <a href=\"%(charity_url)s\">%(charity_name)s</a> izkažete "
-"podporo."
+msgid "The <a href=\"%(meet_url)s\">developer of this add-on</a> asks that you show your support by making a donation to the <a href=\"%(charity_url)s\">%(charity_name)s</a>."
+msgstr "<a href=\"%(meet_url)s\">Razvijalec tega dodatka</a> vas prosi, da mu z donacijo za <a href=\"%(charity_url)s\">%(charity_name)s</a> izkažete podporo."
 
 #: src/olympia/addons/templates/addons/impala/contribution.html:53
 #, python-format
-msgid ""
-"The <a href=\"%(meet_url)s\">developer of this add-on</a> asks that you show"
-" your support by making a small contribution to <a "
-"href=\"%(charity_url)s\">%(charity_name)s</a>."
-msgstr ""
-"<a href=\"%(meet_url)s\">Razvijalec tega dodatka</a> vas prosi, da mu z "
-"donacijo za <a href=\"%(charity_url)s\">%(charity_name)s</a> izkažete "
-"podporo."
+msgid "The <a href=\"%(meet_url)s\">developer of this add-on</a> asks that you show your support by making a small contribution to <a href=\"%(charity_url)s\">%(charity_name)s</a>."
+msgstr "<a href=\"%(meet_url)s\">Razvijalec tega dodatka</a> vas prosi, da mu z donacijo za <a href=\"%(charity_url)s\">%(charity_name)s</a> izkažete podporo."
 
 #: src/olympia/addons/templates/addons/impala/dependencies_note.html:4
 msgid "This add-on requires the following add-ons to work properly:"
@@ -1355,155 +975,123 @@ msgid "Other add-ons by %(author)s"
 msgid_plural "Other add-ons by these authors"
 msgstr[0] "Drugi dodatki avtorja %(author)s"
 msgstr[1] "Drugi dodatki teh avtorjev"
-msgstr[2] "Drugi dodatki teh avtorjev"
-msgstr[3] "Drugi dodatki teh avtorjev"
 
-#: src/olympia/addons/templates/addons/impala/details.html:41
+#: src/olympia/addons/templates/addons/impala/details.html:39
 #, python-format
 msgid "<span itemprop=\"ratingCount\">%(num)s</span> user review"
 msgid_plural "<span itemprop=\"ratingCount\">%(num)s</span> user reviews"
 msgstr[0] "<span itemprop=\"ratingCount\">%(num)s</span> ocena uporabnika"
 msgstr[1] "<span itemprop=\"ratingCount\">%(num)s</span> oceni uporabnikov"
-msgstr[2] "<span itemprop=\"ratingCount\">%(num)s</span> ocene uporabnikov"
-msgstr[3] "<span itemprop=\"ratingCount\">%(num)s</span> ocen uporabnikov"
 
-#: src/olympia/addons/templates/addons/impala/details.html:69
+#: src/olympia/addons/templates/addons/impala/details.html:66
 msgid "View statistics"
 msgstr "Prikaži statistiko"
 
-#: src/olympia/addons/templates/addons/impala/details.html:84
+#: src/olympia/addons/templates/addons/impala/details.html:81
 msgid "Manage"
 msgstr "Upravljanje"
 
 #. {0} is an add-on name.
-#: src/olympia/addons/templates/addons/impala/details.html:96
+#: src/olympia/addons/templates/addons/impala/details.html:93
 msgid "Icon of {0}"
 msgstr "Ikona {0}"
 
-#: src/olympia/addons/templates/addons/impala/details.html:103
-#: src/olympia/addons/templates/addons/impala/listing/items.html:14
+#: src/olympia/addons/templates/addons/impala/details.html:100 src/olympia/addons/templates/addons/impala/listing/items.html:14
 msgid "No Restart"
 msgstr "Ponoven zagon ni potreben"
 
-#: src/olympia/addons/templates/addons/impala/details.html:127
+#: src/olympia/addons/templates/addons/impala/details.html:124
 #, python-format
 msgid "Meet the Developer: <a href=\"%(url)s\">%(name)s</a>"
 msgid_plural "<a href=\"%(url)s\">Meet the Developers</a>"
 msgstr[0] "Spoznajte razvijalca: <a href=\"%(url)s\">%(name)s</a>"
 msgstr[1] "<a href=\"%(url)s\">Spoznajte razvijalca</a>"
-msgstr[2] "<a href=\"%(url)s\">Spoznajte razvijalce</a>"
-msgstr[3] "<a href=\"%(url)s\">Spoznajte razvijalce</a>"
 
 # {0} is an add-on name.
-#: src/olympia/addons/templates/addons/impala/details.html:137
+#: src/olympia/addons/templates/addons/impala/details.html:134
 msgid "Learn why {0} was created and find out what's next for this add-on."
-msgstr ""
-"Več o tem, zakaj je nastal dodatek {0} in o tem, kaj je pričakovati zanj v "
-"bodoče."
+msgstr "Več o tem, zakaj je nastal dodatek {0} in o tem, kaj je pričakovati zanj v bodoče."
 
 #. {0} is an index.
-#: src/olympia/addons/templates/addons/impala/details.html:156
+#: src/olympia/addons/templates/addons/impala/details.html:161
 msgid "Add-on screenshot #{0}"
 msgstr "Slika tega dodatka #{0}"
 
-#: src/olympia/addons/templates/addons/impala/details.html:182
+#: src/olympia/addons/templates/addons/impala/details.html:187
 msgid "Add-on home page"
 msgstr "Domača stran dodatka"
 
-#: src/olympia/addons/templates/addons/impala/details.html:185
+#: src/olympia/addons/templates/addons/impala/details.html:190
 msgid "Support site"
 msgstr "Stran za podporo"
 
-#: src/olympia/addons/templates/addons/impala/details.html:189
+#: src/olympia/addons/templates/addons/impala/details.html:194
 msgid "Support E-mail"
 msgstr "E-pošta za podporo"
 
-#: src/olympia/addons/templates/addons/impala/details.html:194
-#: src/olympia/devhub/models.py:378
-#: src/olympia/devhub/templates/devhub/versions/list.html:12
-#: src/olympia/versions/templates/versions/version.html:6
-#: src/olympia/versions/templates/versions/mobile/version.html:6
+#: src/olympia/addons/templates/addons/impala/details.html:199 src/olympia/devhub/models.py:378 src/olympia/devhub/templates/devhub/versions/list.html:12
+#: src/olympia/versions/templates/versions/version.html:6 src/olympia/versions/templates/versions/mobile/version.html:6
 msgid "Version {0}"
 msgstr "Različica {0}"
 
-#: src/olympia/addons/templates/addons/impala/details.html:194
+#: src/olympia/addons/templates/addons/impala/details.html:199
 msgid "Info"
 msgstr "Informacije"
 
-#: src/olympia/addons/templates/addons/impala/details.html:195
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:129
+#: src/olympia/addons/templates/addons/impala/details.html:200 src/olympia/devhub/templates/devhub/includes/addon_details.html:116
 msgid "Last Updated:"
 msgstr "Nazadnje posodobljeno:"
 
-#: src/olympia/addons/templates/addons/impala/details.html:200
+#: src/olympia/addons/templates/addons/impala/details.html:205
 #, python-format
 msgid "Released under <a target=\"_blank\" href=\"%(url)s\">%(name)s</a>"
 msgstr "Objavljeno pod <a target=\"_blank\" href=\"%(url)s\">%(name)s</a>"
 
-#: src/olympia/addons/templates/addons/impala/details.html:201
-#: src/olympia/addons/templates/addons/impala/details.html:206
-#: src/olympia/amo/helpers.py:398 src/olympia/devhub/forms.py:142
-#: src/olympia/devhub/forms.py:173
-#: src/olympia/versions/templates/versions/version.html:40
-#: src/olympia/versions/templates/versions/version.html:45
+#: src/olympia/addons/templates/addons/impala/details.html:206 src/olympia/addons/templates/addons/impala/details.html:211 src/olympia/amo/helpers.py:398 src/olympia/devhub/forms.py:142
+#: src/olympia/devhub/forms.py:173 src/olympia/versions/templates/versions/version.html:40 src/olympia/versions/templates/versions/version.html:45
 msgid "Custom License"
 msgstr "Licenca po meri"
 
-#: src/olympia/addons/templates/addons/impala/details.html:205
+#: src/olympia/addons/templates/addons/impala/details.html:210
 #, python-format
 msgid "Released under <a href=\"%(url)s\">%(name)s</a>"
 msgstr "Objavljeno pod <a href=\"%(url)s\">%(name)s</a>"
 
-#: src/olympia/addons/templates/addons/impala/details.html:217
+#: src/olympia/addons/templates/addons/impala/details.html:222
 msgid "About this Add-on"
 msgstr "O tem dodatku"
 
-#: src/olympia/addons/templates/addons/impala/details.html:233
+#: src/olympia/addons/templates/addons/impala/details.html:238
 msgid "Developer’s Comments"
 msgstr "Komentarji razvijalca"
 
-#: src/olympia/addons/templates/addons/impala/details.html:243
+#: src/olympia/addons/templates/addons/impala/details.html:248
 msgid "Version Information"
 msgstr "Informacije o različici"
 
-#: src/olympia/addons/templates/addons/impala/details.html:250
+#: src/olympia/addons/templates/addons/impala/details.html:255
 msgid "See complete version history"
 msgstr "Glej celotno zgodovino različice"
 
-#: src/olympia/addons/templates/addons/impala/details.html:262
+#: src/olympia/addons/templates/addons/impala/details.html:267
 msgid ""
-"The Development Channel lets you test an experimental new version of this "
-"add-on before it's released to the general public. Once you install the "
-"development version, you will continue to get updates from this channel. To "
-"stop receiving development updates, reinstall the default version from the "
-"link above."
+"The Development Channel lets you test an experimental new version of this add-on before it's released to the general public. Once you install the development version, you will continue to get "
+"updates from this channel. To stop receiving development updates, reinstall the default version from the link above."
 msgstr ""
-"Razvojni kanal vam omogoča preizkusiti poizkusno novo različico tega "
-"dodatka, preden se jo objavi za širšo javnost. Potem ko namestite razvojno "
-"različico, boste prejemali posodobitve z razvojnega kanala. Če ne želite več"
-" prejemati razvojnih posodobitev, ponovno namestite privzeto različico z "
-"zgornje povezave."
+"Razvojni kanal vam omogoča preizkusiti poizkusno novo različico tega dodatka, preden se jo objavi za širšo javnost. Potem ko namestite razvojno različico, boste prejemali posodobitve z razvojnega "
+"kanala. Če ne želite več prejemati razvojnih posodobitev, ponovno namestite privzeto različico z zgornje povezave."
 
-#: src/olympia/addons/templates/addons/impala/details.html:272
-msgid ""
-"<strong>Caution:</strong> Development versions of this add-on have not been "
-"reviewed by Mozilla."
-msgstr ""
-"<strong>Pozor:</strong> Razvojnih različic tega dodatkoa Mozilla ni "
-"pregledala."
+#: src/olympia/addons/templates/addons/impala/details.html:277
+msgid "<strong>Caution:</strong> Development versions of this add-on have not been reviewed by Mozilla."
+msgstr "<strong>Pozor:</strong> Razvojnih različic tega dodatkoa Mozilla ni pregledala."
 
-#: src/olympia/addons/templates/addons/impala/details.html:287
+#: src/olympia/addons/templates/addons/impala/details.html:292
 msgid "See complete development channel history"
 msgstr "Glej celotno zgodovino razvojnega kanala"
 
-#: src/olympia/addons/templates/addons/impala/details.html:306
-#: src/olympia/addons/templates/addons/impala/details.html:315
-#: src/olympia/addons/templates/addons/impala/details.html:327
-#: src/olympia/addons/templates/addons/impala/review_add_box.html:4
-#: src/olympia/stats/templates/stats/popup.html:2
-#: src/olympia/stats/templates/stats/popup.html:8
-#: src/olympia/stats/templates/stats/stats.html:202
-#: src/olympia/users/templates/users/profile.html:119
+#: src/olympia/addons/templates/addons/impala/details.html:311 src/olympia/addons/templates/addons/impala/details.html:320 src/olympia/addons/templates/addons/impala/details.html:332
+#: src/olympia/addons/templates/addons/impala/review_add_box.html:4 src/olympia/stats/templates/stats/popup.html:2 src/olympia/stats/templates/stats/popup.html:8
+#: src/olympia/stats/templates/stats/stats.html:204 src/olympia/users/templates/users/profile.html:119
 msgid "close"
 msgstr "zapri"
 
@@ -1512,19 +1100,15 @@ msgstr "zapri"
 msgid "Thank you for installing {0}"
 msgstr "Hvala vam, da ste namestili {0}"
 
-#. {0} is an add-on name.
 # %1 is an add-on name.
+#. {0} is an add-on name.
 #: src/olympia/addons/templates/addons/impala/developers.html:12
 msgid "Meet the {0} Developer"
 msgstr "Srečajte razvijalca {0}"
 
 #: src/olympia/addons/templates/addons/impala/developers.html:41
-msgid ""
-"Before downloading this add-on, please consider supporting the development "
-"of this add-on by making a small contribution."
-msgstr ""
-"Preden prenesete ta dodatek, premislite, če ne bi njenega razvoja podprli z "
-"majhnim prispevkom."
+msgid "Before downloading this add-on, please consider supporting the development of this add-on by making a small contribution."
+msgstr "Preden prenesete ta dodatek, premislite, če ne bi njenega razvoja podprli z majhnim prispevkom."
 
 # %1 is an add-on name.
 #: src/olympia/addons/templates/addons/impala/developers.html:80
@@ -1541,12 +1125,8 @@ msgid "About the Developer"
 msgid_plural "About the Developers"
 msgstr[0] "O razvijalcu"
 msgstr[1] "O razvijalcih"
-msgstr[2] "O razvijalcih"
-msgstr[3] "O razvijalcih"
 
-#: src/olympia/addons/templates/addons/impala/developers.html:96
-#: src/olympia/users/templates/users/edit.html:130
-#: src/olympia/users/templates/users/profile.html:26
+#: src/olympia/addons/templates/addons/impala/developers.html:96 src/olympia/users/templates/users/edit.html:130 src/olympia/users/templates/users/profile.html:26
 msgid "No Photo"
 msgstr "Ni fotografije"
 
@@ -1566,24 +1146,15 @@ msgstr "Ta dodatek je administrator onemogočil."
 msgid "Source Code License for {addon}"
 msgstr "Licenca za izvorno kodo za {addon}"
 
-#: src/olympia/addons/templates/addons/impala/license.html:21
-#: src/olympia/versions/templates/versions/mobile/version.html:18
+#: src/olympia/addons/templates/addons/impala/license.html:21 src/olympia/versions/templates/versions/mobile/version.html:18
 msgid "Source Code License"
 msgstr "Licenca za izvorno kodo"
 
-#: src/olympia/addons/templates/addons/impala/persona_grid.html:16
-#: src/olympia/addons/templates/addons/impala/toplist.html:6
-msgid "{0} users"
-msgstr "{0} uporabnikov"
-
-#: src/olympia/addons/templates/addons/impala/review_list_box.html:19
-#: src/olympia/reviews/templates/reviews/review.html:40
+#: src/olympia/addons/templates/addons/impala/review_list_box.html:19 src/olympia/reviews/templates/reviews/review.html:40
 msgid "permalink"
 msgstr "povezava"
 
-#: src/olympia/addons/templates/addons/impala/review_list_box.html:23
-#: src/olympia/editors/templates/editors/queue.html:98
-#: src/olympia/reviews/templates/reviews/review.html:44
+#: src/olympia/addons/templates/addons/impala/review_list_box.html:23 src/olympia/editors/templates/editors/queue.html:104 src/olympia/reviews/templates/reviews/review.html:44
 msgid "translate"
 msgstr "prevedi"
 
@@ -1593,11 +1164,8 @@ msgid "See all user reviews"
 msgid_plural "See all %(cnt)s user reviews"
 msgstr[0] "Pokaži vse ocene uporabnikov"
 msgstr[1] "Pokaži obe oceni uporabnikov"
-msgstr[2] "Pokaži vse %(cnt)s ocene uporabnikov"
-msgstr[3] "Pokaži vseh %(cnt)s ocen uporabnikov"
 
-#: src/olympia/addons/templates/addons/impala/review_list_box.html:47
-#: src/olympia/reviews/templates/reviews/review_list.html:84
+#: src/olympia/addons/templates/addons/impala/review_list_box.html:47 src/olympia/reviews/templates/reviews/review_list.html:84
 msgid "This add-on has not yet been reviewed."
 msgstr "Tega dodatka ni ocenil še nihče."
 
@@ -1605,24 +1173,23 @@ msgstr "Tega dodatka ni ocenil še nihče."
 msgid "Be the first!"
 msgstr "Bodite prvi!"
 
-#: src/olympia/addons/templates/addons/impala/listing/sorter.html:14
-#: src/olympia/devhub/templates/devhub/addons/listing/item_actions.html:49
+#: src/olympia/addons/templates/addons/impala/toplist.html:6
+msgid "{0} users"
+msgstr "{0} uporabnikov"
+
+#: src/olympia/addons/templates/addons/impala/listing/sorter.html:14 src/olympia/devhub/templates/devhub/addons/listing/item_actions.html:49
 msgid "More"
 msgstr "Več"
 
-#: src/olympia/addons/templates/addons/includes/collection_add_widget.html:7
-#: src/olympia/addons/templates/addons/includes/collection_add_widget.html:10
+#: src/olympia/addons/templates/addons/includes/collection_add_widget.html:7 src/olympia/addons/templates/addons/includes/collection_add_widget.html:10
 msgid "Add to collection"
 msgstr "Dodaj v zbirko"
 
-#: src/olympia/addons/templates/addons/includes/dashboard_tabs.html:4
-#: src/olympia/devhub/templates/devhub/index.html:73
-#: src/olympia/devhub/templates/devhub/nav.html:14
+#: src/olympia/addons/templates/addons/includes/dashboard_tabs.html:4 src/olympia/devhub/templates/devhub/index.html:73 src/olympia/devhub/templates/devhub/nav.html:14
 msgid "My Add-ons"
 msgstr "Moji dodatki"
 
-#: src/olympia/addons/templates/addons/includes/dashboard_tabs.html:6
-#: src/olympia/amo/context_processors.py:51
+#: src/olympia/addons/templates/addons/includes/dashboard_tabs.html:6 src/olympia/amo/context_processors.py:50
 msgid "My Themes"
 msgstr "Moje teme"
 
@@ -1638,8 +1205,7 @@ msgstr "Uredi temo"
 msgid "Approve / Reject"
 msgstr "Odobri / zavrni"
 
-#: src/olympia/addons/templates/addons/includes/persona.html:25
-#: src/olympia/editors/templates/editors/themes/single.html:43
+#: src/olympia/addons/templates/addons/includes/persona.html:25 src/olympia/editors/templates/editors/themes/single.html:43
 msgid "Review History"
 msgstr "Pregled zgodovine"
 
@@ -1660,15 +1226,11 @@ msgid "Not Yet Rated"
 msgstr "Še ni ocenjeno"
 
 #. {0} is the number of downloads.
-#: src/olympia/addons/templates/addons/listing/items_mobile.html:27
-#: src/olympia/addons/templates/addons/listing/macros.html:24
-#: src/olympia/devhub/templates/devhub/addons/listing/macros.html:15
+#: src/olympia/addons/templates/addons/listing/items_mobile.html:27 src/olympia/addons/templates/addons/listing/macros.html:24 src/olympia/devhub/templates/devhub/addons/listing/macros.html:15
 msgid "<strong>{0}</strong> weekly download"
 msgid_plural "<strong>{0}</strong> weekly downloads"
 msgstr[0] "<strong>{0}</strong> prenos na teden"
 msgstr[1] "<strong>{0}</strong> prenosov na teden"
-msgstr[2] "<strong>{0}</strong> prenosov na teden"
-msgstr[3] "<strong>{0}</strong> prenosov na teden"
 
 #: src/olympia/addons/templates/addons/mobile/details.html:32
 msgid "Read More"
@@ -1678,15 +1240,11 @@ msgstr "Preberi več"
 msgid "Users"
 msgstr "Uporabniki"
 
-#: src/olympia/addons/templates/addons/mobile/details.html:92
-#: src/olympia/browse/views.py:59 src/olympia/browse/views.py:70
-#: src/olympia/search/forms.py:90
+#: src/olympia/addons/templates/addons/mobile/details.html:92 src/olympia/browse/views.py:59 src/olympia/browse/views.py:70 src/olympia/search/forms.py:90
 msgid "Weekly Downloads"
 msgstr "Prenosov na teden"
 
-#: src/olympia/addons/templates/addons/mobile/details.html:99
-#: src/olympia/compat/templates/compat/reporter_detail.html:46
-#: src/olympia/devhub/forms.py:787
+#: src/olympia/addons/templates/addons/mobile/details.html:99 src/olympia/compat/templates/compat/reporter_detail.html:46 src/olympia/devhub/forms.py:788
 #: src/olympia/devhub/templates/devhub/versions/list.html:163
 msgid "Version"
 msgstr "Različica"
@@ -1722,50 +1280,30 @@ msgstr "Licenčni sporazum"
 
 #: src/olympia/addons/templates/addons/mobile/eula.html:5
 #, python-format
-msgid ""
-"%(name)s requires that you accept the following End-User License Agreement "
-"before installation can proceed:"
-msgstr ""
-"%(name)s zahteva, da se pred nadaljnjo namestitvijo strinjate z naslednjim "
-"licenčnim sporazumom:"
+msgid "%(name)s requires that you accept the following End-User License Agreement before installation can proceed:"
+msgstr "%(name)s zahteva, da se pred nadaljnjo namestitvijo strinjate z naslednjim licenčnim sporazumom:"
 
 #: src/olympia/addons/templates/addons/mobile/eula.html:15
 msgid "Accept"
 msgstr "Sprejmi"
 
-#: src/olympia/addons/templates/addons/mobile/home.html:10
-#: src/olympia/templates/mobile/base_addons.html:53
+#: src/olympia/addons/templates/addons/mobile/home.html:10 src/olympia/templates/mobile/base_addons.html:53
 msgid "Add-ons are not currently available on Firefox for iOS."
 msgstr "V Firefoxu za iOS dodatki trenutno niso na voljo."
 
-#: src/olympia/addons/templates/addons/mobile/home.html:12
-#: src/olympia/templates/mobile/base_addons.html:55
-msgid ""
-"You need Firefox to install add-ons. <a "
-"href=\"http://mozilla.com/mobile\">Learn More&nbsp;&raquo;</a>"
-msgstr ""
-"Da namestite dodatke, potrebujete Firefox. <a "
-"href=\"http://mozilla.com/mobile\">Več o tem&nbsp;&raquo;</a>"
+#: src/olympia/addons/templates/addons/mobile/home.html:12 src/olympia/templates/mobile/base_addons.html:55
+msgid "You need Firefox to install add-ons. <a href=\"http://mozilla.com/mobile\">Learn More&nbsp;&raquo;</a>"
+msgstr "Da namestite dodatke, potrebujete Firefox. <a href=\"http://mozilla.com/mobile\">Več o tem&nbsp;&raquo;</a>"
 
 # {0} is the application name.  Example:  Firefox
-#: src/olympia/addons/templates/addons/mobile/home.html:19
-#: src/olympia/templates/header_title.html:4
-#: src/olympia/templates/impala/header_title.html:3
+#: src/olympia/addons/templates/addons/mobile/home.html:19 src/olympia/templates/header_title.html:4 src/olympia/templates/impala/header_title.html:3
 msgid "Return to the {0} Add-ons homepage"
 msgstr "Vrni se na domačo stran za {0} dodatki"
 
-#: src/olympia/addons/templates/addons/mobile/home.html:21
-#: src/olympia/amo/helpers.py:237
-#: src/olympia/bandwagon/templates/bandwagon/edit.html:34
-#: src/olympia/discovery/templates/discovery/pane.html:92
-#: src/olympia/editors/templates/editors/base.html:21
-#: src/olympia/editors/templates/editors/performance.html:72
-#: src/olympia/templates/menu_links.html:4
-#: src/olympia/templates/impala/header_title.html:13
-#: src/olympia/templates/impala/header_title.html:15
-#: src/olympia/templates/impala/header_title.html:19
-#: src/olympia/templates/impala/header_title.html:23
-#: src/olympia/templates/mobile/base_addons.html:47
+#: src/olympia/addons/templates/addons/mobile/home.html:21 src/olympia/amo/helpers.py:237 src/olympia/bandwagon/templates/bandwagon/edit.html:34 src/olympia/discovery/templates/discovery/pane.html:92
+#: src/olympia/editors/templates/editors/base.html:21 src/olympia/editors/templates/editors/performance.html:72 src/olympia/templates/menu_links.html:4
+#: src/olympia/templates/impala/header_title.html:13 src/olympia/templates/impala/header_title.html:15 src/olympia/templates/impala/header_title.html:19
+#: src/olympia/templates/impala/header_title.html:23 src/olympia/templates/mobile/base_addons.html:47
 msgid "Add-ons"
 msgstr "Dodatki"
 
@@ -1773,48 +1311,28 @@ msgstr "Dodatki"
 msgid "Easy ways to personalize."
 msgstr "Preprosti načini za prilagajanje."
 
-#: src/olympia/addons/templates/addons/mobile/home.html:24
-#: src/olympia/devhub/templates/devhub/addons/submit/done.html:47
-#: src/olympia/discovery/templates/discovery/pane.html:34
-#: src/olympia/discovery/templates/discovery/addons/detail.html:16
-#: src/olympia/discovery/templates/discovery/modules/featured.html:21
-#: src/olympia/discovery/templates/discovery/modules/monthly.html:22
+#: src/olympia/addons/templates/addons/mobile/home.html:24 src/olympia/devhub/templates/devhub/addons/submit/done.html:47 src/olympia/discovery/templates/discovery/pane.html:34
+#: src/olympia/discovery/templates/discovery/addons/detail.html:16 src/olympia/discovery/templates/discovery/modules/featured.html:21 src/olympia/discovery/templates/discovery/modules/monthly.html:22
 msgid "Learn More"
 msgstr "Več o tem"
 
 #: src/olympia/addons/templates/addons/mobile/home.html:26
 msgid ""
-"Add-ons are applications that let you personalize Firefox with extra "
-"functionality and style. Whether you mistype the name of a website or can't "
-"read a busy page, there's an add-on to improve your on-the-go browsing."
+"Add-ons are applications that let you personalize Firefox with extra functionality and style. Whether you mistype the name of a website or can't read a busy page, there's an add-on to improve your "
+"on-the-go browsing."
 msgstr ""
-"Dodatki so aplikacije, ki vam omogočajo prilagoditi Firefox z dodatno "
-"funkcionalnostjo in slogi. Če napačno vtipkate ime spletne strani ali ne "
-"morete prebrati zasedene strani, je vedno na razpolago dodatek, ki vam "
-"olajša sprotno brskanje."
+"Dodatki so aplikacije, ki vam omogočajo prilagoditi Firefox z dodatno funkcionalnostjo in slogi. Če napačno vtipkate ime spletne strani ali ne morete prebrati zasedene strani, je vedno na razpolago "
+"dodatek, ki vam olajša sprotno brskanje."
 
 #. {0} is a category name. Ex: "Sports"
 #. {0} is a category name, such as Nature.
-#: src/olympia/addons/templates/addons/mobile/home.html:43
-#: src/olympia/amo/templates/amo/site_nav.html:32
-#: src/olympia/browse/feeds.py:107
-#: src/olympia/browse/templates/browse/impala/base_listing.html:38
-#: src/olympia/browse/templates/browse/personas/base.html:6
-#: src/olympia/browse/templates/browse/personas/base.html:42
-#: src/olympia/browse/templates/browse/personas/category_landing.html:21
-#: src/olympia/browse/templates/browse/personas/category_landing.html:23
-#: src/olympia/browse/templates/browse/personas/category_landing.html:38
-#: src/olympia/browse/templates/browse/personas/grid.html:7
-#: src/olympia/browse/templates/browse/personas/grid.html:11
-#: src/olympia/browse/templates/browse/personas/mobile/base.html:7
-#: src/olympia/browse/templates/browse/personas/mobile/category_landing.html:19
-#: src/olympia/constants/base.py:180
-#: src/olympia/devhub/templates/devhub/personas/submit.html:13
-#: src/olympia/editors/helpers.py:105
-#: src/olympia/editors/templates/editors/base.html:26
-#: src/olympia/editors/templates/editors/performance.html:73
-#: src/olympia/search/templates/search/personas.html:39
-#: src/olympia/templates/menu_links.html:9
+#: src/olympia/addons/templates/addons/mobile/home.html:43 src/olympia/amo/templates/amo/site_nav.html:32 src/olympia/browse/feeds.py:107
+#: src/olympia/browse/templates/browse/impala/base_listing.html:38 src/olympia/browse/templates/browse/personas/base.html:6 src/olympia/browse/templates/browse/personas/base.html:42
+#: src/olympia/browse/templates/browse/personas/category_landing.html:21 src/olympia/browse/templates/browse/personas/category_landing.html:23
+#: src/olympia/browse/templates/browse/personas/category_landing.html:38 src/olympia/browse/templates/browse/personas/grid.html:7 src/olympia/browse/templates/browse/personas/grid.html:11
+#: src/olympia/browse/templates/browse/personas/mobile/base.html:7 src/olympia/browse/templates/browse/personas/mobile/category_landing.html:19 src/olympia/constants/base.py:180
+#: src/olympia/devhub/templates/devhub/personas/submit.html:13 src/olympia/editors/helpers.py:107 src/olympia/editors/templates/editors/base.html:26
+#: src/olympia/editors/templates/editors/performance.html:73 src/olympia/search/templates/search/personas.html:39 src/olympia/templates/menu_links.html:9
 msgid "Themes"
 msgstr "Teme"
 
@@ -1830,19 +1348,12 @@ msgstr "Ogled vseh priljubljenih dodatkov"
 msgid "More Add-ons"
 msgstr "Več dodatkov"
 
-#: src/olympia/addons/templates/addons/mobile/home.html:72
-#: src/olympia/browse/templates/browse/personas/mobile/category_landing.html:64
-#: src/olympia/search/forms.py:14
+#: src/olympia/addons/templates/addons/mobile/home.html:72 src/olympia/browse/templates/browse/personas/mobile/category_landing.html:64 src/olympia/search/forms.py:14
 msgid "Highest Rated"
 msgstr "Najbolje ocenjeni"
 
-#: src/olympia/addons/templates/addons/mobile/home.html:74
-#: src/olympia/amo/templates/amo/side_nav.html:5
-#: src/olympia/amo/templates/amo/site_nav.html:27
-#: src/olympia/amo/templates/amo/site_nav.html:57
-#: src/olympia/bandwagon/views.py:97 src/olympia/browse/views.py:57
-#: src/olympia/browse/views.py:67
-#: src/olympia/browse/templates/browse/personas/mobile/category_landing.html:65
+#: src/olympia/addons/templates/addons/mobile/home.html:74 src/olympia/amo/templates/amo/side_nav.html:5 src/olympia/amo/templates/amo/site_nav.html:27 src/olympia/amo/templates/amo/site_nav.html:55
+#: src/olympia/bandwagon/views.py:97 src/olympia/browse/views.py:57 src/olympia/browse/views.py:67 src/olympia/browse/templates/browse/personas/mobile/category_landing.html:65
 #: src/olympia/search/forms.py:15 src/olympia/search/forms.py:87
 msgid "Newest"
 msgstr "Najnovejše"
@@ -1855,122 +1366,90 @@ msgstr "Preizkusite!"
 msgid "Theme Info &raquo;"
 msgstr "Podatki o temi &raquo;"
 
-#: src/olympia/amo/context_processors.py:39
-#: src/olympia/devhub/templates/devhub/nav.html:43
+#: src/olympia/amo/context_processors.py:37 src/olympia/devhub/templates/devhub/nav.html:43
 msgid "Tools"
 msgstr "Orodja"
 
-#: src/olympia/amo/context_processors.py:48
-#: src/olympia/discovery/templates/discovery/pane_account.html:8
-#: src/olympia/users/templates/users/includes/navigation.html:2
+#: src/olympia/amo/context_processors.py:47 src/olympia/discovery/templates/discovery/pane_account.html:8 src/olympia/users/templates/users/includes/navigation.html:2
 msgid "My Profile"
 msgstr "Moj profil"
 
-#: src/olympia/amo/context_processors.py:54
-#: src/olympia/users/templates/users/edit.html:5
-#: src/olympia/users/templates/users/includes/navigation.html:3
+#: src/olympia/amo/context_processors.py:53 src/olympia/users/templates/users/edit.html:5 src/olympia/users/templates/users/includes/navigation.html:3
 msgid "Account Settings"
 msgstr "Nastavitve računa"
 
-#: src/olympia/amo/context_processors.py:57
-#: src/olympia/discovery/templates/discovery/pane_account.html:11
-#: src/olympia/users/templates/users/profile.html:83
+#: src/olympia/amo/context_processors.py:56 src/olympia/discovery/templates/discovery/pane_account.html:11 src/olympia/users/templates/users/profile.html:83
 #: src/olympia/users/templates/users/includes/navigation.html:4
 msgid "My Collections"
 msgstr "Moje zbirke"
 
-#: src/olympia/amo/context_processors.py:62
-#: src/olympia/discovery/templates/discovery/pane_account.html:10
-#: src/olympia/users/templates/users/includes/navigation.html:7
+#: src/olympia/amo/context_processors.py:61 src/olympia/discovery/templates/discovery/pane_account.html:10 src/olympia/users/templates/users/includes/navigation.html:7
 msgid "My Favorites"
 msgstr "Moje priljubljene"
 
-#: src/olympia/amo/context_processors.py:67
-#: src/olympia/discovery/templates/discovery/pane_account.html:13
-#: src/olympia/templates/impala/user_login.html:14
+#: src/olympia/amo/context_processors.py:66 src/olympia/discovery/templates/discovery/pane_account.html:13 src/olympia/templates/impala/user_login.html:14
 #: src/olympia/templates/mobile/header_auth.html:5
 msgid "Log out"
 msgstr "Odjava"
 
-#: src/olympia/amo/context_processors.py:72
-#: src/olympia/devhub/templates/devhub/addons/dashboard.html:4
+#: src/olympia/amo/context_processors.py:71 src/olympia/devhub/templates/devhub/addons/dashboard.html:4
 msgid "Manage My Submissions"
 msgstr "Urejaj moje prispevke"
 
-#: src/olympia/amo/context_processors.py:75
-#: src/olympia/devhub/templates/devhub/nav.html:27
-#: src/olympia/devhub/templates/devhub/addons/dashboard.html:25
+#: src/olympia/amo/context_processors.py:74 src/olympia/devhub/templates/devhub/nav.html:27 src/olympia/devhub/templates/devhub/addons/dashboard.html:25
 #: src/olympia/devhub/templates/devhub/addons/submit/base.html:4
 msgid "Submit a New Add-on"
 msgstr "Pošlji nov dodatek"
 
-#: src/olympia/amo/context_processors.py:77
-#: src/olympia/browse/templates/browse/personas/base.html:50
-#: src/olympia/devhub/templates/devhub/index.html:24
+#: src/olympia/amo/context_processors.py:76 src/olympia/browse/templates/browse/personas/base.html:50 src/olympia/devhub/templates/devhub/index.html:24
 #: src/olympia/devhub/templates/devhub/addons/dashboard.html:29
 msgid "Submit a New Theme"
 msgstr "Pošlji novo temo"
 
-#: src/olympia/amo/context_processors.py:79
-#: src/olympia/amo/templates/amo/site_nav.html:87
-#: src/olympia/devhub/helpers.py:36 src/olympia/devhub/helpers.py:68
-#: src/olympia/devhub/helpers.py:102 src/olympia/templates/footer.html:6
-#: src/olympia/templates/menu_links.html:14
+#: src/olympia/amo/context_processors.py:78 src/olympia/amo/templates/amo/site_nav.html:85 src/olympia/devhub/helpers.py:36 src/olympia/devhub/helpers.py:68 src/olympia/devhub/helpers.py:102
+#: src/olympia/templates/footer.html:6 src/olympia/templates/menu_links.html:14
 msgid "Developer Hub"
 msgstr "Razvojni center"
 
-#: src/olympia/amo/context_processors.py:83 src/olympia/devhub/views.py:1792
+#: src/olympia/amo/context_processors.py:81 src/olympia/devhub/views.py:1796
 msgid "Manage API Keys"
 msgstr "Upravljaj ključe API"
 
-#: src/olympia/amo/context_processors.py:88 src/olympia/editors/helpers.py:82
-#: src/olympia/editors/helpers.py:102
-#: src/olympia/editors/templates/editors/base.html:10
+#: src/olympia/amo/context_processors.py:86 src/olympia/editors/helpers.py:84 src/olympia/editors/helpers.py:104 src/olympia/editors/templates/editors/base.html:10
 msgid "Editor Tools"
 msgstr "Uredniška orodja"
 
-#: src/olympia/amo/context_processors.py:92
+#: src/olympia/amo/context_processors.py:90
 msgid "Admin Tools"
 msgstr "Skrbniška orodja"
 
-#: src/olympia/amo/fields.py:15
+#: src/olympia/amo/fields.py:20
 msgid "Incorrect, please try again."
 msgstr "Nepravilno, poskusite znova."
 
-#: src/olympia/amo/fields.py:16
+#: src/olympia/amo/fields.py:21
 msgid "Error verifying input, please try again."
 msgstr "Napaka pri preverjanju vnosa, poskusite znova."
 
-#: src/olympia/amo/fields.py:32
+#: src/olympia/amo/fields.py:37
 msgid "This must be a valid hex color code, such as #000000."
 msgstr "To mora biti veljavna šestnajstiška koda za barvo, kot je #000000."
 
-#: src/olympia/amo/fields.py:58
+#: src/olympia/amo/fields.py:63
 msgid "Enter at least one value."
 msgstr "Vnesite vsaj eno vrednost."
 
-#: src/olympia/amo/helpers.py:162
-#: src/olympia/amo/templates/amo/site_nav.html:61
-#: src/olympia/bandwagon/templates/bandwagon/add.html:9
-#: src/olympia/bandwagon/templates/bandwagon/collection_detail.html:15
-#: src/olympia/bandwagon/templates/bandwagon/delete.html:9
-#: src/olympia/bandwagon/templates/bandwagon/edit.html:15
-#: src/olympia/bandwagon/templates/bandwagon/user_listing.html:18
-#: src/olympia/bandwagon/templates/bandwagon/user_listing.html:21
-#: src/olympia/bandwagon/templates/bandwagon/impala/collection_listing.html:12
-#: src/olympia/bandwagon/templates/bandwagon/impala/collection_listing.html:20
-#: src/olympia/bandwagon/templates/bandwagon/impala/collection_listing.html:24
-#: src/olympia/bandwagon/templates/bandwagon/impala/collection_sidebar.html:3
-#: src/olympia/bandwagon/templates/bandwagon/includes/collection_sidebar.html:2
-#: src/olympia/bandwagon/templates/bandwagon/mobile/collection_listing.html:3
-#: src/olympia/stats/templates/stats/stats.html:77
-#: src/olympia/templates/menu_links.html:12
+#: src/olympia/amo/helpers.py:162 src/olympia/amo/templates/amo/site_nav.html:59 src/olympia/bandwagon/templates/bandwagon/add.html:9
+#: src/olympia/bandwagon/templates/bandwagon/collection_detail.html:15 src/olympia/bandwagon/templates/bandwagon/delete.html:9 src/olympia/bandwagon/templates/bandwagon/edit.html:15
+#: src/olympia/bandwagon/templates/bandwagon/user_listing.html:18 src/olympia/bandwagon/templates/bandwagon/user_listing.html:21
+#: src/olympia/bandwagon/templates/bandwagon/impala/collection_listing.html:12 src/olympia/bandwagon/templates/bandwagon/impala/collection_listing.html:20
+#: src/olympia/bandwagon/templates/bandwagon/impala/collection_listing.html:24 src/olympia/bandwagon/templates/bandwagon/impala/collection_sidebar.html:3
+#: src/olympia/bandwagon/templates/bandwagon/includes/collection_sidebar.html:2 src/olympia/bandwagon/templates/bandwagon/mobile/collection_listing.html:3
+#: src/olympia/stats/templates/stats/stats.html:33 src/olympia/templates/menu_links.html:12
 msgid "Collections"
 msgstr "Zbirke"
 
-#: src/olympia/amo/helpers.py:171
-#: src/olympia/amo/templates/amo/site_nav.html:85
-#: src/olympia/browse/templates/browse/language_tools.html:3
+#: src/olympia/amo/helpers.py:171 src/olympia/amo/templates/amo/site_nav.html:83 src/olympia/browse/templates/browse/language_tools.html:3
 msgid "Dictionaries & Language Packs"
 msgstr "Slovarji in jezikovni paketi"
 
@@ -2126,11 +1605,8 @@ msgstr "Zahteva se super pregled"
 msgid "Comment on {addon} {version}."
 msgstr "Komentar o {addon} {version}."
 
-#: src/olympia/amo/log.py:236
-#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:19
-#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:47
-#: src/olympia/editors/helpers.py:511
-#: src/olympia/editors/templates/editors/themes/history_table.html:11
+#: src/olympia/amo/log.py:236 src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:17 src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:45
+#: src/olympia/editors/helpers.py:584 src/olympia/editors/templates/editors/themes/history_table.html:11
 msgid "Comment"
 msgstr "Komentar"
 
@@ -2220,8 +1696,7 @@ msgstr "Avtorje se je po pošti obvestilo o skladnosti za {version}."
 
 #: src/olympia/amo/log.py:364
 msgid "Email sent to Author about add-on compatibility."
-msgstr ""
-"Avtorju je bilo poslano elektronsko sporočilo o združljivosti dodatka."
+msgstr "Avtorju je bilo poslano elektronsko sporočilo o združljivosti dodatka."
 
 #: src/olympia/amo/log.py:369
 msgid "Password changed."
@@ -2286,7 +1761,7 @@ msgstr "Označeno za dodaten pregled"
 
 #: src/olympia/amo/log.py:442
 msgid "Video removed from {addon} because of a problem with the video. "
-msgstr "Videoposnetek odstranjen iz {addon} zaradi težav z videoposnetkom. "
+msgstr ""
 
 #: src/olympia/amo/log.py:444
 msgid "Video removed"
@@ -2391,10 +1866,7 @@ msgstr "Ocena vsebine {addon} je spremenjena."
 msgid "{addon} unlisted."
 msgstr "Nenaveden {addon}."
 
-#: src/olympia/amo/log.py:592 src/olympia/amo/log.py:598
-#: src/olympia/amo/log.py:612 src/olympia/amo/log.py:618
-#: src/olympia/amo/log.py:624 src/olympia/amo/log.py:630
-#: src/olympia/amo/log.py:636
+#: src/olympia/amo/log.py:592 src/olympia/amo/log.py:598 src/olympia/amo/log.py:612 src/olympia/amo/log.py:618 src/olympia/amo/log.py:624 src/olympia/amo/log.py:630 src/olympia/amo/log.py:636
 msgid "{file} was signed."
 msgstr "{file} je bila podpisana."
 
@@ -2408,20 +1880,12 @@ msgid "Not allowed"
 msgstr "Ni dovoljeno"
 
 #: src/olympia/amo/templates/amo/403.html:7
-msgid ""
-"<h1>Oops! Not allowed.</h1> <p>You tried to do something that you weren't "
-"allowed to.</p>"
-msgstr ""
-"<h1>Opla! To ni dovoljeno.</h1> <p>Poskusili ste storiti nekaj, za kar "
-"nimate dovoljenja.</p>"
+msgid "<h1>Oops! Not allowed.</h1> <p>You tried to do something that you weren't allowed to.</p>"
+msgstr "<h1>Opla! To ni dovoljeno.</h1> <p>Poskusili ste storiti nekaj, za kar nimate dovoljenja.</p>"
 
 #: src/olympia/amo/templates/amo/403.html:12
-msgid ""
-"<p>Try going back to the previous page, refreshing and then trying "
-"again.</p>"
-msgstr ""
-"<p>Vrnite se na prejšnjo stran, ali pa obnovite stran in znova "
-"poskusite.</p>"
+msgid "<p>Try going back to the previous page, refreshing and then trying again.</p>"
+msgstr "<p>Vrnite se na prejšnjo stran, ali pa obnovite stran in znova poskusite.</p>"
 
 #: src/olympia/amo/templates/amo/404.html:3
 msgid "Not Found"
@@ -2430,35 +1894,18 @@ msgstr "Ni najti"
 #: src/olympia/amo/templates/amo/404.html:6
 #, python-format
 msgid ""
-"<h1>We're sorry, but we can't find what you're looking for.</h1> <p> The "
-"page or file you requested wasn't found on our site. It's possible that you "
-"clicked a link that's out of date, or typed in the address incorrectly. </p>"
-" <ul> <li>If you typed in the address, please double check the "
-"spelling.</li> <li> If you followed a link from somewhere, please let us "
-"know at <a href=\"mailto:webmaster@mozilla.com\">webmaster@mozilla.com</a>. "
-"Tell us where you came from and what you were looking for, and we'll do our "
-"best to fix it. </li> </ul> <p>Or you can just jump over to some of the "
-"popular pages on our website.</p> <ul> <li>Are you interested in a <a "
-"href=\"%(rec)s\">list of featured add-ons</a>?</li> <li> Do you want to <a "
-"href=\"%(search)s\">search for add-ons</a>? You may go to the <a "
-"href=\"%(search)s\">search page</a> or just use the search field above. "
-"</li> <li> If you prefer to start over, just go to the <a href=\"%(home)s"
-"\">add-ons front page</a>. </li> </ul>"
+"<h1>We're sorry, but we can't find what you're looking for.</h1> <p> The page or file you requested wasn't found on our site. It's possible that you clicked a link that's out of date, or typed in "
+"the address incorrectly. </p> <ul> <li>If you typed in the address, please double check the spelling.</li> <li> If you followed a link from somewhere, please let us know at <a href=\"mailto:"
+"webmaster@mozilla.com\">webmaster@mozilla.com</a>. Tell us where you came from and what you were looking for, and we'll do our best to fix it. </li> </ul> <p>Or you can just jump over to some of "
+"the popular pages on our website.</p> <ul> <li>Are you interested in a <a href=\"%(rec)s\">list of featured add-ons</a>?</li> <li> Do you want to <a href=\"%(search)s\">search for add-ons</a>? You "
+"may go to the <a href=\"%(search)s\">search page</a> or just use the search field above. </li> <li> If you prefer to start over, just go to the <a href=\"%(home)s\">add-ons front page</a>. </li> </"
+"ul>"
 msgstr ""
-"<h1>Žal ne najdemo tega, kar iščete.</h1><p> Strani ali datoteke, ki ste jo "
-"zahtevali, ni bilo mogoče najti na naši spletni strani. Možno je, da ste "
-"kliknili na povezavo, ki je zastarela, ali pa vnesli napačen "
-"naslov.</p><ul><li>Če ste sami vtipkali naslov, še enkrat preverite "
-"črkovanje.</li> <li> Če ste sledili povezavi od kod drugje, nam to sporočite"
-" na <a href=\"mailto:webmaster@mozilla.com\">webmaster@mozilla.com</a>. "
-"Sporočite nam, od kod ste prišli in kaj ste iskali, mi pa se bomo potrudili,"
-" da to popravimo. </li></ul><p>Lahko pa enostavno skočite na nekatere od "
-"priljubljenih strani na našem spletnem mestu. </p><ul><li>Ali vas zanima <a "
-"href=\"%(rec)s\">seznam izbranih razširitev</a>?</li><li> Želite <a "
-"href=\"%(search)s\">iskati razširitve</a>? Pojdite morda na <a "
-"href=\"%(search)s\">stran za iskanje</a> ali pa uporabite polje za iskanje "
-"zgoraj. </li><li> Če želite začeti znova, pojdite na <a "
-"href=\"%(home)s\">naslovno stran za dodatke</a>. </li> </ul>"
+"<h1>Žal ne najdemo tega, kar iščete.</h1><p> Strani ali datoteke, ki ste jo zahtevali, ni bilo mogoče najti na naši spletni strani. Možno je, da ste kliknili na povezavo, ki je zastarela, ali pa "
+"vnesli napačen naslov.</p><ul><li>Če ste sami vtipkali naslov, še enkrat preverite črkovanje.</li> <li> Če ste sledili povezavi od kod drugje, nam to sporočite na <a href=\"mailto:webmaster@mozilla."
+"com\">webmaster@mozilla.com</a>. Sporočite nam, od kod ste prišli in kaj ste iskali, mi pa se bomo potrudili, da to popravimo. </li></ul><p>Lahko pa enostavno skočite na nekatere od priljubljenih "
+"strani na našem spletnem mestu. </p><ul><li>Ali vas zanima <a href=\"%(rec)s\">seznam izbranih razširitev</a>?</li><li> Želite <a href=\"%(search)s\">iskati razširitve</a>? Pojdite morda na <a href="
+"\"%(search)s\">stran za iskanje</a> ali pa uporabite polje za iskanje zgoraj. </li><li> Če želite začeti znova, pojdite na <a href=\"%(home)s\">naslovno stran za dodatke</a>. </li> </ul>"
 
 #: src/olympia/amo/templates/amo/500.html:3
 msgid "Oops"
@@ -2466,82 +1913,49 @@ msgstr "Opla"
 
 #: src/olympia/amo/templates/amo/500.html:6
 #, python-format
-msgid ""
-"<h1>Oops!  We had an error.</h1> <p>We'll get to fixing that soon.</p> <p> "
-"You can try refreshing the page, or head back to the <a href=\"%(home)s"
-"\">Add-ons homepage</a>. </p>"
+msgid "<h1>Oops!  We had an error.</h1> <p>We'll get to fixing that soon.</p> <p> You can try refreshing the page, or head back to the <a href=\"%(home)s\">Add-ons homepage</a>. </p>"
 msgstr ""
-"<h1>Opla! Imeli smo napako.</h1> <p>Lotili se je bomo v kratkem.</p> <p> "
-"Poizkusite obnoviti stran, ali pa se vrnite na <a href=\"%(home)s\">Domačo "
-"stran za dodatke</a>. </p>"
 
 #: src/olympia/amo/templates/amo/license_link.html:10
 msgid "Some rights reserved"
 msgstr "Nekatere pravice pridržane"
 
-#: src/olympia/amo/templates/amo/no_results.html:1
-#: src/olympia/editors/templates/editors/includes/search_results_themes.html:26
+#: src/olympia/amo/templates/amo/no_results.html:1 src/olympia/editors/templates/editors/includes/search_results_themes.html:26
 msgid "No results found"
 msgstr "Ni zadetkov"
 
 #. abbreviation of 'previous'
-#: src/olympia/amo/templates/amo/paginator.html:6
-#: src/olympia/amo/templates/amo/mobile/paginator.html:4
-#: src/olympia/amo/templates/amo/mobile/paginator.html:6
-#: src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:49
-#: src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:63
-#: src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:76
-#: src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:89
+#: src/olympia/amo/templates/amo/paginator.html:6 src/olympia/amo/templates/amo/mobile/paginator.html:4 src/olympia/amo/templates/amo/mobile/paginator.html:6
+#: src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:49 src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:63
+#: src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:76 src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:89
 #: src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:102
 msgid "Prev"
 msgstr "Nazaj"
 
-#: src/olympia/amo/templates/amo/paginator.html:26
-#: src/olympia/amo/templates/amo/impala/paginator.html:26
-#: src/olympia/amo/templates/amo/mobile/impala_paginator.html:16
-#: src/olympia/amo/templates/amo/mobile/paginator.html:14
-#: src/olympia/amo/templates/amo/mobile/paginator.html:16
-#: src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:51
-#: src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:65
-#: src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:78
-#: src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:91
-#: src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:104
-#: src/olympia/discovery/templates/discovery/pane.html:45
-#: src/olympia/discovery/templates/discovery/addons/detail.html:39
-#: src/olympia/stats/templates/stats/stats.html:167
+#: src/olympia/amo/templates/amo/paginator.html:26 src/olympia/amo/templates/amo/impala/paginator.html:26 src/olympia/amo/templates/amo/mobile/impala_paginator.html:16
+#: src/olympia/amo/templates/amo/mobile/paginator.html:14 src/olympia/amo/templates/amo/mobile/paginator.html:16 src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:51
+#: src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:65 src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:78
+#: src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:91 src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:104
+#: src/olympia/discovery/templates/discovery/pane.html:45 src/olympia/discovery/templates/discovery/addons/detail.html:39 src/olympia/stats/templates/stats/stats.html:169
 msgid "Next"
 msgstr "Naprej"
 
-#: src/olympia/amo/templates/amo/paginator.html:32
-#: src/olympia/editors/templates/editors/includes/paginator_history.html:11
+#: src/olympia/amo/templates/amo/paginator.html:32 src/olympia/editors/templates/editors/includes/paginator_history.html:11
 #, python-format
-msgid ""
-"Results <strong>%(begin)s</strong>&ndash;<strong>%(end)s</strong> of "
-"<strong>%(count)s</strong>"
-msgstr ""
-"Rezultati <strong>%(begin)s</strong>&ndash;<strong>%(end)s</strong> od "
-"<strong>%(count)s</strong>"
+msgid "Results <strong>%(begin)s</strong>&ndash;<strong>%(end)s</strong> of <strong>%(count)s</strong>"
+msgstr "Rezultati <strong>%(begin)s</strong>&ndash;<strong>%(end)s</strong> od <strong>%(count)s</strong>"
 
-#: src/olympia/amo/templates/amo/read-only.html:3
-#: src/olympia/amo/templates/amo/read-only.html:7
+#: src/olympia/amo/templates/amo/read-only.html:3 src/olympia/amo/templates/amo/read-only.html:7
 msgid "Maintenance in progress"
 msgstr "Vzdrževanje je v teku"
 
 #: src/olympia/amo/templates/amo/read-only.html:9
-msgid ""
-"This feature is temporarily disabled while we perform website maintenance. "
-"Please use your browser's Back button and try again a little later."
-msgstr ""
-"Ta funkcija je trenutno onemogočena, ker teče spletno vzdrževanje. Prosimo, "
-"uporabite gumb Nazaj v brskalniku in poskusite znova nekoliko kasneje."
+msgid "This feature is temporarily disabled while we perform website maintenance. Please use your browser's Back button and try again a little later."
+msgstr "Ta funkcija je trenutno onemogočena, ker teče spletno vzdrževanje. Prosimo, uporabite gumb Nazaj v brskalniku in poskusite znova nekoliko kasneje."
 
 #: src/olympia/amo/templates/amo/read-only.html:14
-msgid ""
-"Some features on this page are temporarily disabled while we perform website"
-" maintenance. Please try again a little later."
-msgstr ""
-"Nekatere elemente na tej strani se je med postopkom spletnega vzdrževanja "
-"začasno onesposobilo. Prosimo, poskusite znova nekoliko kasneje."
+msgid "Some features on this page are temporarily disabled while we perform website maintenance. Please try again a little later."
+msgstr "Nekatere elemente na tej strani se je med postopkom spletnega vzdrževanja začasno onesposobilo. Prosimo, poskusite znova nekoliko kasneje."
 
 #: src/olympia/amo/templates/amo/recaptcha.html:4
 msgid "Are you human?"
@@ -2549,25 +1963,14 @@ msgstr "Ste človek?"
 
 #: src/olympia/amo/templates/amo/recaptcha.html:8
 msgid ""
-"<p> Please enter <strong>all the words</strong> below, <strong>separated by "
-"a space if necessary</strong>. </p> <p> If this is hard to read, you can <a "
-"href=\"#\" id=\"recaptcha_different\">try different words</a> or <a "
-"href=\"#\" id=\"recaptcha_audio\">try a different type of challenge</a> "
-"instead. </p>"
+"<p> Please enter <strong>all the words</strong> below, <strong>separated by a space if necessary</strong>. </p> <p> If this is hard to read, you can <a href=\"#\" id=\"recaptcha_different\">try "
+"different words</a> or <a href=\"#\" id=\"recaptcha_audio\">try a different type of challenge</a> instead. </p>"
 msgstr ""
-"<p> Prosimo, vnesite <strong>vse spodnje besede</strong>, <strong>ki jih po "
-"potrebi ločite s presledkom</strong>. </p> <p> Če jih težko preberete, lahko"
-" <a href=\"#\" id=\"recaptcha_different\">poskusite z drugimi besedami</a> "
-"ali namesto tega <a href=\"#\" id=\"recaptcha_audio\">poskusite drugačen "
-"izziv</a>. </p>"
+"<p> Prosimo, vnesite <strong>vse spodnje besede</strong>, <strong>ki jih po potrebi ločite s presledkom</strong>. </p> <p> Če jih težko preberete, lahko <a href=\"#\" id=\"recaptcha_different"
+"\">poskusite z drugimi besedami</a> ali namesto tega <a href=\"#\" id=\"recaptcha_audio\">poskusite drugačen izziv</a>. </p>"
 
-#: src/olympia/amo/templates/amo/side_nav.html:4
-#: src/olympia/amo/templates/amo/side_nav.html:12
-#: src/olympia/amo/templates/amo/site_nav.html:4
-#: src/olympia/amo/templates/amo/site_nav.html:26
-#: src/olympia/browse/views.py:56 src/olympia/browse/views.py:66
-#: src/olympia/browse/views.py:237 src/olympia/browse/views.py:282
-#: src/olympia/search/forms.py:86
+#: src/olympia/amo/templates/amo/side_nav.html:4 src/olympia/amo/templates/amo/side_nav.html:12 src/olympia/amo/templates/amo/site_nav.html:4 src/olympia/amo/templates/amo/site_nav.html:26
+#: src/olympia/browse/views.py:56 src/olympia/browse/views.py:66 src/olympia/browse/views.py:204 src/olympia/browse/views.py:249 src/olympia/search/forms.py:86
 msgid "Top Rated"
 msgstr "Najbolje ocenjeni"
 
@@ -2575,81 +1978,60 @@ msgstr "Najbolje ocenjeni"
 msgid "Explore"
 msgstr "Razišči"
 
-#: src/olympia/amo/templates/amo/site_nav.html:23
-#: src/olympia/browse/feeds.py:65 src/olympia/browse/feeds.py:78
-#: src/olympia/browse/feeds.py:92 src/olympia/browse/feeds.py:100
-#: src/olympia/browse/templates/browse/base_listing.html:7
-#: src/olympia/browse/templates/browse/creatured.html:10
-#: src/olympia/browse/templates/browse/impala/base_listing.html:37
+#: src/olympia/amo/templates/amo/site_nav.html:23 src/olympia/browse/feeds.py:65 src/olympia/browse/feeds.py:78 src/olympia/browse/feeds.py:92 src/olympia/browse/feeds.py:100
+#: src/olympia/browse/templates/browse/base_listing.html:7 src/olympia/browse/templates/browse/creatured.html:10 src/olympia/browse/templates/browse/impala/base_listing.html:37
 #: src/olympia/constants/base.py:173 src/olympia/templates/menu_links.html:8
 msgid "Extensions"
 msgstr "Razširitve"
 
-#: src/olympia/amo/templates/amo/site_nav.html:45
+#: src/olympia/amo/templates/amo/site_nav.html:44
 msgid "Want more customization? Try <b>Complete Themes</b>"
 msgstr "Želite urediti bolj po svoje? Poskusite <b>celotne teme</b>"
 
-#: src/olympia/amo/templates/amo/site_nav.html:56
-#: src/olympia/bandwagon/views.py:96
+#: src/olympia/amo/templates/amo/site_nav.html:54 src/olympia/bandwagon/views.py:96
 msgid "Most Followers"
 msgstr "Največ sledečih"
 
-#: src/olympia/amo/templates/amo/site_nav.html:68
-#: src/olympia/bandwagon/templates/bandwagon/impala/collection_sidebar.html:16
+#: src/olympia/amo/templates/amo/site_nav.html:66 src/olympia/bandwagon/templates/bandwagon/impala/collection_sidebar.html:16
 #: src/olympia/bandwagon/templates/bandwagon/includes/collection_sidebar.html:18
 msgid "Collections I've Made"
 msgstr "Zbirke iz moje roke"
 
-#: src/olympia/amo/templates/amo/site_nav.html:70
-#: src/olympia/bandwagon/templates/bandwagon/user_listing.html:4
-#: src/olympia/bandwagon/templates/bandwagon/impala/collection_sidebar.html:13
+#: src/olympia/amo/templates/amo/site_nav.html:68 src/olympia/bandwagon/templates/bandwagon/user_listing.html:4 src/olympia/bandwagon/templates/bandwagon/impala/collection_sidebar.html:13
 #: src/olympia/bandwagon/templates/bandwagon/includes/collection_sidebar.html:15
 msgid "Collections I'm Following"
 msgstr "Zbirke, ki jim sledim"
 
-#: src/olympia/amo/templates/amo/site_nav.html:73
-#: src/olympia/bandwagon/templates/bandwagon/impala/collection_sidebar.html:18
-#: src/olympia/bandwagon/templates/bandwagon/includes/collection_sidebar.html:20
-#: src/olympia/users/models.py:512
+#: src/olympia/amo/templates/amo/site_nav.html:71 src/olympia/bandwagon/templates/bandwagon/impala/collection_sidebar.html:18
+#: src/olympia/bandwagon/templates/bandwagon/includes/collection_sidebar.html:20 src/olympia/users/models.py:521
 msgid "My Favorite Add-ons"
 msgstr "Moji najljubši dodatki"
 
-#: src/olympia/amo/templates/amo/site_nav.html:78
+#: src/olympia/amo/templates/amo/site_nav.html:76
 msgid "More&hellip;"
 msgstr "Več &hellip;"
 
-#: src/olympia/amo/templates/amo/site_nav.html:82
+#: src/olympia/amo/templates/amo/site_nav.html:80
 msgid "Add-ons for Mobile"
 msgstr "Dodatki za mobilne naprave"
 
-#: src/olympia/amo/templates/amo/site_nav.html:86
-#: src/olympia/browse/feeds.py:207
-#: src/olympia/browse/templates/browse/search_tools.html:3
-#: src/olympia/constants/base.py:176 src/olympia/templates/menu_links.html:10
+#: src/olympia/amo/templates/amo/site_nav.html:84 src/olympia/browse/feeds.py:207 src/olympia/browse/templates/browse/search_tools.html:3 src/olympia/constants/base.py:176
+#: src/olympia/templates/menu_links.html:10
 msgid "Search Tools"
 msgstr "Orodja za iskanje"
 
 #. This is a page range (e.g., Page 1 of 50).
-#: src/olympia/amo/templates/amo/impala/paginator.html:5
-#: src/olympia/amo/templates/amo/mobile/impala_paginator.html:26
+#: src/olympia/amo/templates/amo/impala/paginator.html:5 src/olympia/amo/templates/amo/mobile/impala_paginator.html:26
 #, python-format
-msgid ""
-"Page <a href=\"%(current_pg_url)s\">%(current_pg)s</a> of <a "
-"href=\"%(last_pg_url)s\">%(last_pg)s</a>"
-msgstr ""
-"Stran <a href=\"%(current_pg_url)s\">%(current_pg)s</a> od <a "
-"href=\"%(last_pg_url)s\">%(last_pg)s</a>"
+msgid "Page <a href=\"%(current_pg_url)s\">%(current_pg)s</a> of <a href=\"%(last_pg_url)s\">%(last_pg)s</a>"
+msgstr "Stran <a href=\"%(current_pg_url)s\">%(current_pg)s</a> od <a href=\"%(last_pg_url)s\">%(last_pg)s</a>"
 
-#: src/olympia/amo/templates/amo/impala/paginator.html:16
-#: src/olympia/amo/templates/amo/mobile/impala_paginator.html:6
+#: src/olympia/amo/templates/amo/impala/paginator.html:16 src/olympia/amo/templates/amo/mobile/impala_paginator.html:6
 msgid "Jump to first page"
 msgstr "Skoči na prvo stran"
 
-#: src/olympia/amo/templates/amo/impala/paginator.html:22
-#: src/olympia/amo/templates/amo/mobile/impala_paginator.html:12
-#: src/olympia/discovery/templates/discovery/pane.html:44
-#: src/olympia/discovery/templates/discovery/addons/detail.html:38
-#: src/olympia/stats/templates/stats/stats.html:164
+#: src/olympia/amo/templates/amo/impala/paginator.html:22 src/olympia/amo/templates/amo/mobile/impala_paginator.html:12 src/olympia/discovery/templates/discovery/pane.html:44
+#: src/olympia/discovery/templates/discovery/addons/detail.html:38 src/olympia/stats/templates/stats/stats.html:166
 msgid "Previous"
 msgstr "Nazaj"
 
@@ -2659,10 +2041,9 @@ msgstr "Skoči na zadnjo stran"
 
 #. First and second arguments are the result range (e.g., 1-20);
 #. third argument is the number of total results (e.g., 1,000).
-#. third
+#. First and second arguments are the result range (e.g., 1-20);              third
 #. argument is the number of total results (e.g., 1,000).
-#: src/olympia/amo/templates/amo/impala/paginator.html:36
-#: src/olympia/amo/templates/amo/mobile/impala_paginator.html:38
+#: src/olympia/amo/templates/amo/impala/paginator.html:36 src/olympia/amo/templates/amo/mobile/impala_paginator.html:38
 #, python-format
 msgid "Showing <b>%(begin)s</b>&ndash;<b>%(end)s</b> of <b>%(count)s</b>"
 msgstr "Prikaz <b>%(begin)s</b>&ndash;<b>%(end)s</b> od <b>%(count)s</b>"
@@ -2672,45 +2053,53 @@ msgid "Page {n}"
 msgid_plural "Page {n}"
 msgstr[0] "Stran {n}"
 msgstr[1] "Stran {n}"
-msgstr[2] "Stran {n}"
-msgstr[3] "Stran {n}"
 
-#: src/olympia/amo/templates/services/install.html:38
-#, python-format
-msgid ""
-"If you are not prompted to install %(addon_name)s in a moment, please <a "
-"href=\"%(addon_xpi)s\">click here</a>."
-msgstr ""
-"Če se poziv za namestitev %(addon_name)s v kratkem ne pojavi, kliknite na <a"
-" href=\"%(addon_xpi)s\"></a> ."
-
-#: src/olympia/amo/tests/test_messages.py:57
-#: src/olympia/amo/tests/test_messages.py:58 src/olympia/reviews/forms.py:25
-#: src/olympia/reviews/forms.py:50
-#: src/olympia/reviews/templates/reviews/add.html:56
+#: src/olympia/amo/tests/test_messages.py:56 src/olympia/amo/tests/test_messages.py:57 src/olympia/reviews/forms.py:25 src/olympia/reviews/forms.py:50 src/olympia/reviews/templates/reviews/add.html:56
 #: src/olympia/reviews/templates/reviews/reply.html:30
 msgid "Title"
 msgstr "Naslov"
 
-#: src/olympia/amo/tests/test_messages.py:57
-#: src/olympia/amo/tests/test_messages.py:58
+#: src/olympia/amo/tests/test_messages.py:56 src/olympia/amo/tests/test_messages.py:57
 msgid "Body"
 msgstr "Vsebina"
 
-#: src/olympia/amo/tests/test_messages.py:59
+#: src/olympia/amo/tests/test_messages.py:58
 msgid "Another Title"
 msgstr "Drug naslov"
 
-#: src/olympia/amo/tests/test_messages.py:59
+#: src/olympia/amo/tests/test_messages.py:58
 msgid "Another Body"
 msgstr "Drugo telo"
 
-#: src/olympia/api/views.py:255
-msgid "Not implemented yet."
-msgstr "Še ni uvedeno."
+#: src/olympia/api/authentication.py:76
+msgid "Signature has expired."
+msgstr ""
 
-#: src/olympia/applications/views.py:39
-#: src/olympia/applications/templates/applications/appversions.html:3
+#: src/olympia/api/authentication.py:79
+msgid "Error decoding signature."
+msgstr ""
+
+#: src/olympia/api/authentication.py:82
+msgid "Invalid JWT Token."
+msgstr ""
+
+#: src/olympia/api/authentication.py:130
+msgid "Invalid Authorization header. No credentials provided."
+msgstr ""
+
+#: src/olympia/api/authentication.py:133
+msgid "Invalid Authorization header. Credentials string should not contain spaces."
+msgstr ""
+
+#: src/olympia/api/fields.py:29
+msgid "The field must have a length of at least {num} characters."
+msgstr ""
+
+#: src/olympia/api/fields.py:31
+msgid "The language code {lang_code} is invalid."
+msgstr ""
+
+#: src/olympia/applications/views.py:39 src/olympia/applications/templates/applications/appversions.html:3
 msgid "Application Versions"
 msgstr "Različice programa"
 
@@ -2723,22 +2112,15 @@ msgid "Valid Application Versions"
 msgstr "Veljavne različice aplikacije"
 
 #: src/olympia/applications/templates/applications/appversions.html:12
-msgid ""
-"Add-ons submitted to Mozilla Add-ons must have a manifest file with at least"
-" one of the below applications supported. Only the versions listed below are"
-" allowed for these applications."
-msgstr ""
-"Dodatki poslani v dodatke Mozilla morajo meti datoteko manifesta s podporo "
-"za vsaj eno od spodnjih aplikacij. Za te aplikacije so dovoljene damo "
-"spodnje različice."
+msgid "Add-ons submitted to Mozilla Add-ons must have a manifest file with at least one of the below applications supported. Only the versions listed below are allowed for these applications."
+msgstr "Dodatki poslani v dodatke Mozilla morajo meti datoteko manifesta s podporo za vsaj eno od spodnjih aplikacij. Za te aplikacije so dovoljene damo spodnje različice."
 
-#: src/olympia/applications/templates/applications/appversions.html:25
+#: src/olympia/applications/templates/applications/appversions.html:25 src/olympia/editors/helpers.py:361
 msgid "GUID"
 msgstr "GUID"
 
 #. {0} is an add-on name.
-#: src/olympia/applications/templates/applications/appversions.html:26
-#: src/olympia/versions/templates/versions/version_list.html:23
+#: src/olympia/applications/templates/applications/appversions.html:26 src/olympia/versions/templates/versions/version_list.html:23
 msgid "Versions"
 msgstr "Različice"
 
@@ -2748,13 +2130,8 @@ msgstr "http://developer.mozilla.org/en/docs/Install_Manifests"
 
 #: src/olympia/applications/templates/applications/appversions.html:31
 #, python-format
-msgid ""
-"If your supported application does not require a manifest file, you still "
-"must include one with the required properties as specified <a "
-"href=\"%(url)s\">here</a>."
-msgstr ""
-"Če vaša podprta aplikacija datoteke manifesta ne zahteva, jo morate vseeno "
-"vključiti z vsemi lastnostmi, ki so navedene <a href=\"%(url)s\">tukaj</a>."
+msgid "If your supported application does not require a manifest file, you still must include one with the required properties as specified <a href=\"%(url)s\">here</a>."
+msgstr "Če vaša podprta aplikacija datoteke manifesta ne zahteva, jo morate vseeno vključiti z vsemi lastnostmi, ki so navedene <a href=\"%(url)s\">tukaj</a>."
 
 #. L10n: {0} is 'Add-ons for <app>'.
 #: src/olympia/bandwagon/feeds.py:44
@@ -2762,13 +2139,9 @@ msgstr ""
 msgid "Collections :: %s"
 msgstr "Collections :: %s"
 
-#: src/olympia/bandwagon/feeds.py:50
-#: src/olympia/bandwagon/templates/bandwagon/collection_detail.html:137
-msgid ""
-"Collections are groups of related add-ons that anyone can create and share."
-msgstr ""
-"Zbirke so skupine sorodnih dodatkov, ki jih lahko vsakdo ustvari in deli z "
-"drugimi."
+#: src/olympia/bandwagon/feeds.py:50 src/olympia/bandwagon/templates/bandwagon/collection_detail.html:137
+msgid "Collections are groups of related add-ons that anyone can create and share."
+msgstr "Zbirke so skupine sorodnih dodatkov, ki jih lahko vsakdo ustvari in deli z drugimi."
 
 #. L10n: {0} is a collection name, {1} is 'Add-ons for <app>'.
 #: src/olympia/bandwagon/feeds.py:70
@@ -2823,8 +2196,7 @@ msgstr "Ta url že uporablja druga zbirka"
 msgid "Icons must be either PNG or JPG."
 msgstr "Ikone morajo biti bodisi PNG ali JPG."
 
-#: src/olympia/bandwagon/forms.py:202 src/olympia/devhub/views.py:1067
-#: src/olympia/users/forms.py:476
+#: src/olympia/bandwagon/forms.py:202 src/olympia/devhub/views.py:1067 src/olympia/users/forms.py:476
 #, python-format
 msgid "Please use images smaller than %dMB."
 msgstr "Uporabljajte slike, ki so manjše kot %dMB."
@@ -2845,8 +2217,7 @@ msgstr "Odstrani moj glas za to zbirko"
 msgid "Log in to vote for this collection"
 msgstr "Prijavite se, da glasujete za to zbirko"
 
-#: src/olympia/bandwagon/helpers.py:123
-#: src/olympia/bandwagon/templates/bandwagon/favorites_widget.html:2
+#: src/olympia/bandwagon/helpers.py:123 src/olympia/bandwagon/templates/bandwagon/favorites_widget.html:2
 msgid "Add to favorites"
 msgstr "Dodaj med priljubljene"
 
@@ -2854,20 +2225,13 @@ msgstr "Dodaj med priljubljene"
 msgid "Favorite"
 msgstr "Priljubljen"
 
-#: src/olympia/bandwagon/helpers.py:124
-#: src/olympia/bandwagon/templates/bandwagon/favorites_widget.html:2
+#: src/olympia/bandwagon/helpers.py:124 src/olympia/bandwagon/templates/bandwagon/favorites_widget.html:2
 msgid "Remove from favorites"
 msgstr "Odstrani iz priljubljenih"
 
-#: src/olympia/bandwagon/views.py:98 src/olympia/bandwagon/views.py:191
-#: src/olympia/browse/views.py:58 src/olympia/browse/views.py:69
-#: src/olympia/browse/views.py:458 src/olympia/devhub/views.py:74
-#: src/olympia/devhub/views.py:82
-#: src/olympia/devhub/templates/devhub/addons/edit/basic.html:20
-#: src/olympia/editors/templates/editors/leaderboard.html:24
-#: src/olympia/editors/templates/editors/themes/queue_list.html:48
-#: src/olympia/search/forms.py:17 src/olympia/search/forms.py:89
-#: src/olympia/users/templates/users/vcard.html:5
+#: src/olympia/bandwagon/views.py:98 src/olympia/bandwagon/views.py:191 src/olympia/browse/views.py:58 src/olympia/browse/views.py:69 src/olympia/browse/views.py:425 src/olympia/devhub/views.py:72
+#: src/olympia/devhub/views.py:80 src/olympia/devhub/templates/devhub/addons/edit/basic.html:20 src/olympia/editors/templates/editors/leaderboard.html:24
+#: src/olympia/editors/templates/editors/themes/queue_list.html:48 src/olympia/search/forms.py:17 src/olympia/search/forms.py:89 src/olympia/users/templates/users/vcard.html:5
 msgid "Name"
 msgstr "Ime"
 
@@ -2875,8 +2239,7 @@ msgstr "Ime"
 msgid "Recently Popular"
 msgstr "Pred kratkim priljubljeni"
 
-#: src/olympia/bandwagon/views.py:189
-#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:18
+#: src/olympia/bandwagon/views.py:189 src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:16
 msgid "Added"
 msgstr "Dodan"
 
@@ -2890,12 +2253,8 @@ msgstr "Zbirka ustvarjena!"
 
 #: src/olympia/bandwagon/views.py:316
 #, python-format
-msgid ""
-"Your new collection is shown below. You can <ahref=\"%(url)s\">edit "
-"additional settings</a> if you'dlike."
+msgid "Your new collection is shown below. You can <a href=\"%(url)s\">edit additional settings</a> if you'd like."
 msgstr ""
-"Vaša nova zbirka je prikazana spodaj. Lahko si, če hočete, <a "
-"href=\"%(url)s\">uredite dodatne nastavitve</a>."
 
 #: src/olympia/bandwagon/views.py:322
 msgid "Collection updated!"
@@ -2910,30 +2269,20 @@ msgstr "<a href=\"%(url)s\">Oglejte si svojo zbirko</a> za novosti."
 msgid "Icon Deleted"
 msgstr "Sličica je zbrisana"
 
-#: src/olympia/bandwagon/templates/bandwagon/add.html:3
-#: src/olympia/bandwagon/templates/bandwagon/add.html:11
-#: src/olympia/bandwagon/templates/bandwagon/includes/collection_sidebar.html:26
+#: src/olympia/bandwagon/templates/bandwagon/add.html:3 src/olympia/bandwagon/templates/bandwagon/add.html:11 src/olympia/bandwagon/templates/bandwagon/includes/collection_sidebar.html:26
 msgid "Create a New Collection"
 msgstr "Ustvari novo zbirko"
 
-#: src/olympia/bandwagon/templates/bandwagon/add.html:9
-#: src/olympia/devhub/templates/devhub/personas/submit.html:14
+#: src/olympia/bandwagon/templates/bandwagon/add.html:9 src/olympia/devhub/templates/devhub/personas/submit.html:14
 msgid "Create"
 msgstr "Ustvari"
 
-#: src/olympia/bandwagon/templates/bandwagon/add.html:24
-#: src/olympia/bandwagon/templates/bandwagon/ajax_new.html:28
+#: src/olympia/bandwagon/templates/bandwagon/add.html:24 src/olympia/bandwagon/templates/bandwagon/ajax_new.html:28
 #, python-format
-msgid ""
-"As noted in our <a href=\"%(legal)s\">Legal Notices</a>, individual "
-"collection arrangements are governed by the Creative Commons Attribution "
-"Share-Alike License"
-msgstr ""
-"Kot je zapisano v naših <a href=\"%(legal)s\">pravnih obvestilih</a> , so "
-"zasebne zbirke predmet licence Creative Commons Attribution Share-Alike"
+msgid "As noted in our <a href=\"%(legal)s\">Legal Notices</a>, individual collection arrangements are governed by the Creative Commons Attribution Share-Alike License"
+msgstr "Kot je zapisano v naših <a href=\"%(legal)s\">pravnih obvestilih</a> , so zasebne zbirke predmet licence Creative Commons Attribution Share-Alike"
 
-#: src/olympia/bandwagon/templates/bandwagon/add.html:33
-#: src/olympia/bandwagon/templates/bandwagon/ajax_new.html:38
+#: src/olympia/bandwagon/templates/bandwagon/add.html:33 src/olympia/bandwagon/templates/bandwagon/ajax_new.html:38
 msgid "Create Collection"
 msgstr "Ustvari zbirko"
 
@@ -2949,8 +2298,7 @@ msgstr "Začetek nove zbirke ..."
 msgid "Start a New Collection"
 msgstr "Začni novo zbirko"
 
-#: src/olympia/bandwagon/templates/bandwagon/ajax_new.html:6
-#: src/olympia/bandwagon/templates/bandwagon/includes/addedit.html:7
+#: src/olympia/bandwagon/templates/bandwagon/ajax_new.html:6 src/olympia/bandwagon/templates/bandwagon/includes/addedit.html:7
 msgid "Name:"
 msgstr "Ime:"
 
@@ -2963,15 +2311,11 @@ msgstr "ali <a id=\"collections-new-cancel\" href=\"#\">Prekliči</a>"
 msgid "To rate collections, you must have an add-ons account."
 msgstr "Če želite ocenjevati zbirke, morate imeti račun pri dodatkih."
 
-#: src/olympia/bandwagon/templates/bandwagon/barometer.html:18
-#: src/olympia/templates/base.html:145
-#: src/olympia/templates/impala/base.html:198
+#: src/olympia/bandwagon/templates/bandwagon/barometer.html:18 src/olympia/templates/base.html:145 src/olympia/templates/impala/base.html:198
 msgid "Create an Add-ons Account"
 msgstr "Ustvarite račun pri dodatkih"
 
-#: src/olympia/bandwagon/templates/bandwagon/barometer.html:21
-#: src/olympia/templates/base.html:148
-#: src/olympia/templates/impala/base.html:201
+#: src/olympia/bandwagon/templates/bandwagon/barometer.html:21 src/olympia/templates/base.html:148 src/olympia/templates/impala/base.html:201
 #, python-format
 msgid "or <a href=\"%(login)s\">log in to your current account</a>"
 msgstr "ali pa se <a href=\"%(login)s\">prijavite na svoj račun</a>"
@@ -2984,15 +2328,12 @@ msgstr "{0}:: Zbirke"
 msgid "private"
 msgstr "zasebne"
 
-#: src/olympia/bandwagon/templates/bandwagon/collection_detail.html:45
-#: src/olympia/bandwagon/templates/bandwagon/mobile/listing_items.html:9
+#: src/olympia/bandwagon/templates/bandwagon/collection_detail.html:45 src/olympia/bandwagon/templates/bandwagon/mobile/listing_items.html:9
 #, python-format
 msgid "<span>%(num)s</span> follower"
 msgid_plural "<span>%(num)s</span> followers"
 msgstr[0] "<span>%(num)s</span> naročnik"
 msgstr[1] "<span>%(num)s</span> naročnika"
-msgstr[2] "<span>%(num)s</span> naročniki"
-msgstr[3] "<span>%(num)s</span> naročnikov"
 
 #: src/olympia/bandwagon/templates/bandwagon/collection_detail.html:54
 msgid "About this Collection"
@@ -3022,8 +2363,7 @@ msgstr "Dodatne možnosti:"
 msgid "Edit Collection"
 msgstr "Uredi zbirko"
 
-#: src/olympia/bandwagon/templates/bandwagon/collection_detail.html:88
-#: src/olympia/bandwagon/templates/bandwagon/includes/delete.html:3
+#: src/olympia/bandwagon/templates/bandwagon/collection_detail.html:88 src/olympia/bandwagon/templates/bandwagon/includes/delete.html:3
 msgid "Delete Collection"
 msgstr "Izbriši zbirko"
 
@@ -3033,8 +2373,6 @@ msgid "%(num)s Theme in this Collection"
 msgid_plural "%(num)s Themes in this Collection"
 msgstr[0] "%(num)s tema v tej zbirki"
 msgstr[1] "%(num)s temi v tej zbirki"
-msgstr[2] "%(num)s teme v tej zbirki"
-msgstr[3] "%(num)s tem v tej zbirki"
 
 #: src/olympia/bandwagon/templates/bandwagon/collection_detail.html:111
 #, python-format
@@ -3042,15 +2380,9 @@ msgid "%(num)s Add-on in this Collection"
 msgid_plural "%(num)s Add-ons in this Collection"
 msgstr[0] "%(num)s dodatek v tej zbirki"
 msgstr[1] "%(num)s dodatka v tej zbirki"
-msgstr[2] "%(num)s dodatki v tej zbirki"
-msgstr[3] "%(num)s dodatkov v tej zbirki"
 
-#: src/olympia/bandwagon/templates/bandwagon/collection_detail.html:125
-#: src/olympia/compat/templates/compat/index.html:25
-#: src/olympia/compat/templates/compat/reporter_detail.html:29
-#: src/olympia/files/templates/files/viewer.html:29
-#: src/olympia/templates/amo_footer.html:17
-#: src/olympia/templates/includes/lang_switcher.html:10
+#: src/olympia/bandwagon/templates/bandwagon/collection_detail.html:125 src/olympia/compat/templates/compat/reporter_detail.html:29 src/olympia/files/templates/files/viewer.html:29
+#: src/olympia/templates/amo_footer.html:17 src/olympia/templates/includes/lang_switcher.html:10
 msgid "Go"
 msgstr "Pojdi"
 
@@ -3076,28 +2408,17 @@ msgstr "Oglejte si vse zbirke tega uporabnika"
 
 #: src/olympia/bandwagon/templates/bandwagon/collection_detail.html:179
 msgid ""
-"Add-ons that you mark as favorites using the <b>Add to Favorites</b> feature"
-" appear below. This collection is currently <b>public</b>, which means "
-"everyone can see it. If you would like to hide it from public view, click "
-"the button below to make it private."
+"Add-ons that you mark as favorites using the <b>Add to Favorites</b> feature appear below. This collection is currently <b>public</b>, which means everyone can see it. If you would like to hide it "
+"from public view, click the button below to make it private."
 msgstr ""
-"Dodatki, ki ste jih označili kot priljubljene s pomočjo funkcije <b>Dodaj "
-"med priljubljene</b>, so prikazani spodaj. Ta zbirka je zdaj <b>javna,</b> "
-"kar pomeni, da jo lahko vsakdo vidi. Če jo želite skriti pred javnostjo, "
-"kliknite na gumb spodaj, da jo naredite zasebno."
+"Dodatki, ki ste jih označili kot priljubljene s pomočjo funkcije <b>Dodaj med priljubljene</b>, so prikazani spodaj. Ta zbirka je zdaj <b>javna,</b> kar pomeni, da jo lahko vsakdo vidi. Če jo "
+"želite skriti pred javnostjo, kliknite na gumb spodaj, da jo naredite zasebno."
 
 #: src/olympia/bandwagon/templates/bandwagon/collection_detail.html:186
 msgid ""
-"Add-ons that you mark as favorites using the <b>Add to Favorites</b> feature"
-" appear below. This collection is currently <b>private</b>, which means only"
-" you can see it.  If you would like everyone to be able to see your "
-"favorites, click the button below to make it public."
+"Add-ons that you mark as favorites using the <b>Add to Favorites</b> feature appear below. This collection is currently <b>private</b>, which means only you can see it.  If you would like everyone "
+"to be able to see your favorites, click the button below to make it public."
 msgstr ""
-"Dodatke, ki jih označite kot priljubljene z značilnostjo <b>Dodaj k "
-"priljubljenim</b>, se bodo pojavili spodaj.  Ta zbirka je trenutno "
-"<b>zasebna</b>, kar pomeni, da jo lahko vidite samo vi.  Če bi želeli, da "
-"vsi vidijo vaše priljubljene, kliknite na spodnji gumb, da jo naredite "
-"javno."
 
 #: src/olympia/bandwagon/templates/bandwagon/collection_detail.html:196
 msgid "My favorite add-ons"
@@ -3109,8 +2430,6 @@ msgid "<span>%(addons)s</span> add-on"
 msgid_plural "<span>%(addons)s</span> add-ons"
 msgstr[0] "<span>%(addons)s</span> dodatek"
 msgstr[1] "<span>%(addons)s</span> dodatka"
-msgstr[2] "<span>%(addons)s</span> dodatki"
-msgstr[3] "<span>%(addons)s</span> dodatkov"
 
 #: src/olympia/bandwagon/templates/bandwagon/collection_grid.html:32
 #, python-format
@@ -3118,25 +2437,19 @@ msgid "<span>%(followers)s</span> follower"
 msgid_plural "<span>%(followers)s</span> followers"
 msgstr[0] "<span>%(followers)s</span> privrženec"
 msgstr[1] "<span>%(followers)s</span> privrženca"
-msgstr[2] "<span>%(followers)s</span> privrženci"
-msgstr[3] "<span>%(followers)s</span> privržencev"
 
-#. People "follow" collections to get notified of updates.
-#. Like
+#. People "follow" collections to get notified of updates.                    Like
 #. Twitter followers.
+#. People "follow" collections to get notified of updates.
 #. Like Twitter followers.
-#: src/olympia/bandwagon/templates/bandwagon/collection_listing_items.html:10
-#: src/olympia/bandwagon/templates/bandwagon/impala/collection_listing_items.html:18
+#: src/olympia/bandwagon/templates/bandwagon/collection_listing_items.html:10 src/olympia/bandwagon/templates/bandwagon/impala/collection_listing_items.html:18
 #, python-format
 msgid "%(num)s weekly follower"
 msgid_plural "%(num)s weekly followers"
 msgstr[0] "%(num)s spremljevalec na teden"
 msgstr[1] "%(num)s spremljevalca na teden"
-msgstr[2] "%(num)s spremljevalci na teden"
-msgstr[3] "%(num)s spremljevalcev na teden"
 
-#. People "follow" collections to get notified of updates.
-#. Like
+#. People "follow" collections to get notified of updates.                    Like
 #. Twitter followers.
 #: src/olympia/bandwagon/templates/bandwagon/collection_listing_items.html:18
 #, python-format
@@ -3144,37 +2457,29 @@ msgid "%(num)s monthly follower"
 msgid_plural "%(num)s monthly followers"
 msgstr[0] "%(num)s spremljevalec mesečno"
 msgstr[1] "%(num)s spremljevalca mesečno"
-msgstr[2] "%(num)s spremljevalci mesečno"
-msgstr[3] "%(num)s spremljevalcev mesečno"
 
-#. People "follow" collections to get notified of updates.
-#. Like
+#. People "follow" collections to get notified of updates.                    Like
 #. Twitter followers.
+#. People "follow" collections to get notified of updates.
 #. Like Twitter followers.
-#: src/olympia/bandwagon/templates/bandwagon/collection_listing_items.html:26
-#: src/olympia/bandwagon/templates/bandwagon/impala/collection_listing_items.html:26
+#: src/olympia/bandwagon/templates/bandwagon/collection_listing_items.html:26 src/olympia/bandwagon/templates/bandwagon/impala/collection_listing_items.html:26
 #, python-format
 msgid "%(num)s follower"
 msgid_plural "%(num)s followers"
 msgstr[0] "%(num)s spremljevalec"
 msgstr[1] "%(num)s spremljevalca"
-msgstr[2] "%(num)s spremljevalci"
-msgstr[3] "%(num)s spremljevalcev"
 
-#: src/olympia/bandwagon/templates/bandwagon/collection_listing_items.html:56
-#: src/olympia/bandwagon/templates/bandwagon/impala/collection_listing_items.html:9
+#: src/olympia/bandwagon/templates/bandwagon/collection_listing_items.html:56 src/olympia/bandwagon/templates/bandwagon/impala/collection_listing_items.html:9
 #: src/olympia/devhub/templates/devhub/personas/edit.html:27
 msgid "by {0}"
 msgstr "od {0}"
 
-#: src/olympia/bandwagon/templates/bandwagon/collection_widgets.html:5
-#: src/olympia/bandwagon/templates/bandwagon/collection_widgets.html:7
+#: src/olympia/bandwagon/templates/bandwagon/collection_widgets.html:5 src/olympia/bandwagon/templates/bandwagon/collection_widgets.html:7
 #: src/olympia/bandwagon/templates/bandwagon/impala/collection_listing_items.html:53
 msgid "Stop Following"
 msgstr "Nehaj zasledovati"
 
-#: src/olympia/bandwagon/templates/bandwagon/collection_widgets.html:6
-#: src/olympia/bandwagon/templates/bandwagon/collection_widgets.html:7
+#: src/olympia/bandwagon/templates/bandwagon/collection_widgets.html:6 src/olympia/bandwagon/templates/bandwagon/collection_widgets.html:7
 #: src/olympia/bandwagon/templates/bandwagon/impala/collection_listing_items.html:53
 msgid "Follow this Collection"
 msgstr "Zasleduj to zbirko"
@@ -3184,16 +2489,12 @@ msgid "Edit this Collection"
 msgstr "Uredi to zbirko"
 
 #. %s is the name of the collection.
-#: src/olympia/bandwagon/templates/bandwagon/delete.html:4
-#: src/olympia/bandwagon/templates/bandwagon/delete.html:15
+#: src/olympia/bandwagon/templates/bandwagon/delete.html:4 src/olympia/bandwagon/templates/bandwagon/delete.html:15
 msgid "Delete {0}"
 msgstr "Izbriši {0}"
 
-#: src/olympia/bandwagon/templates/bandwagon/delete.html:13
-#: src/olympia/devhub/templates/devhub/addons/listing/item_actions.html:14
-#: src/olympia/devhub/templates/devhub/addons/listing/item_actions_theme.html:28
-#: src/olympia/devhub/templates/devhub/versions/list.html:131
-#: src/olympia/devhub/templates/devhub/versions/list.html:149
+#: src/olympia/bandwagon/templates/bandwagon/delete.html:13 src/olympia/devhub/templates/devhub/addons/listing/item_actions.html:14
+#: src/olympia/devhub/templates/devhub/addons/listing/item_actions_theme.html:28 src/olympia/devhub/templates/devhub/versions/list.html:131 src/olympia/devhub/templates/devhub/versions/list.html:149
 #: src/olympia/devhub/templates/devhub/versions/list.html:166
 msgid "Delete"
 msgstr "Izbriši"
@@ -3202,35 +2503,24 @@ msgstr "Izbriši"
 msgid "Are you sure?"
 msgstr "Ali ste prepričani?"
 
-#: src/olympia/bandwagon/templates/bandwagon/delete.html:21
-#: src/olympia/devhub/templates/devhub/personas/edit.html:131
-#: src/olympia/devhub/templates/devhub/personas/edit.html:152
-#: src/olympia/devhub/templates/devhub/personas/edit.html:173
-#: src/olympia/devhub/templates/devhub/personas/submit.html:77
-#: src/olympia/devhub/templates/devhub/personas/submit.html:98
+#: src/olympia/bandwagon/templates/bandwagon/delete.html:21 src/olympia/devhub/templates/devhub/personas/edit.html:131 src/olympia/devhub/templates/devhub/personas/edit.html:152
+#: src/olympia/devhub/templates/devhub/personas/edit.html:173 src/olympia/devhub/templates/devhub/personas/submit.html:77 src/olympia/devhub/templates/devhub/personas/submit.html:98
 #: src/olympia/devhub/templates/devhub/personas/submit.html:119
 msgid "Yes"
 msgstr "Da"
 
-#: src/olympia/bandwagon/templates/bandwagon/delete.html:22
-#: src/olympia/devhub/templates/devhub/personas/edit.html:140
-#: src/olympia/devhub/templates/devhub/personas/edit.html:161
-#: src/olympia/devhub/templates/devhub/personas/edit.html:191
-#: src/olympia/devhub/templates/devhub/personas/submit.html:86
-#: src/olympia/devhub/templates/devhub/personas/submit.html:107
+#: src/olympia/bandwagon/templates/bandwagon/delete.html:22 src/olympia/devhub/templates/devhub/personas/edit.html:140 src/olympia/devhub/templates/devhub/personas/edit.html:161
+#: src/olympia/devhub/templates/devhub/personas/edit.html:191 src/olympia/devhub/templates/devhub/personas/submit.html:86 src/olympia/devhub/templates/devhub/personas/submit.html:107
 #: src/olympia/devhub/templates/devhub/personas/submit.html:137
 msgid "No"
 msgstr "Ne"
 
 #. {0} is the name of the collection.
-#: src/olympia/bandwagon/templates/bandwagon/edit.html:5
-#: src/olympia/bandwagon/templates/bandwagon/edit.html:21
+#: src/olympia/bandwagon/templates/bandwagon/edit.html:5 src/olympia/bandwagon/templates/bandwagon/edit.html:21
 msgid "Edit {0}"
 msgstr "Uredi {0}"
 
-#: src/olympia/bandwagon/templates/bandwagon/edit.html:29
-#: src/olympia/devhub/templates/devhub/addons/edit/details.html:20
-#: src/olympia/editors/templates/editors/themes/themes.html:62
+#: src/olympia/bandwagon/templates/bandwagon/edit.html:29 src/olympia/devhub/templates/devhub/addons/edit/details.html:20 src/olympia/editors/templates/editors/themes/themes.html:62
 msgid "Description"
 msgstr "Opis"
 
@@ -3238,32 +2528,18 @@ msgstr "Opis"
 msgid "Contributors & More"
 msgstr "Sodelavci in še kaj"
 
-#: src/olympia/bandwagon/templates/bandwagon/edit.html:54
-#: src/olympia/bandwagon/templates/bandwagon/edit.html:67
-#: src/olympia/bandwagon/templates/bandwagon/edit.html:82
-#: src/olympia/devhub/templates/devhub/addons/ajax_compat_update.html:35
-#: src/olympia/devhub/templates/devhub/addons/owner.html:59
-#: src/olympia/devhub/templates/devhub/addons/profile.html:42
-#: src/olympia/devhub/templates/devhub/addons/edit/admin.html:101
-#: src/olympia/devhub/templates/devhub/addons/edit/basic.html:152
-#: src/olympia/devhub/templates/devhub/addons/edit/details.html:85
-#: src/olympia/devhub/templates/devhub/addons/edit/support.html:67
-#: src/olympia/devhub/templates/devhub/addons/edit/technical.html:166
-#: src/olympia/devhub/templates/devhub/addons/forms_shared/media.html:149
-#: src/olympia/devhub/templates/devhub/payments/voluntary.html:64
-#: src/olympia/devhub/templates/devhub/personas/edit.html:35
-#: src/olympia/devhub/templates/devhub/personas/edit.html:304
-#: src/olympia/devhub/templates/devhub/versions/edit.html:139
-#: src/olympia/translations/templates/translations/trans-menu.html:48
+#: src/olympia/bandwagon/templates/bandwagon/edit.html:54 src/olympia/bandwagon/templates/bandwagon/edit.html:67 src/olympia/bandwagon/templates/bandwagon/edit.html:82
+#: src/olympia/devhub/templates/devhub/addons/ajax_compat_update.html:35 src/olympia/devhub/templates/devhub/addons/owner.html:59 src/olympia/devhub/templates/devhub/addons/profile.html:42
+#: src/olympia/devhub/templates/devhub/addons/edit/admin.html:101 src/olympia/devhub/templates/devhub/addons/edit/basic.html:152 src/olympia/devhub/templates/devhub/addons/edit/details.html:85
+#: src/olympia/devhub/templates/devhub/addons/edit/support.html:67 src/olympia/devhub/templates/devhub/addons/edit/technical.html:166
+#: src/olympia/devhub/templates/devhub/addons/forms_shared/media.html:149 src/olympia/devhub/templates/devhub/payments/voluntary.html:64 src/olympia/devhub/templates/devhub/personas/edit.html:35
+#: src/olympia/devhub/templates/devhub/personas/edit.html:304 src/olympia/devhub/templates/devhub/versions/edit.html:139 src/olympia/translations/templates/translations/trans-menu.html:48
 msgid "Save Changes"
 msgstr "Shrani spremembe"
 
 # <option> text in a <select> for Author role in an add-on.
-#: src/olympia/bandwagon/templates/bandwagon/edit_contributors.html:9
-#: src/olympia/bandwagon/templates/bandwagon/edit_contributors.html:12
-#: src/olympia/bandwagon/templates/bandwagon/edit_contributors.html:17
-#: src/olympia/bandwagon/templates/bandwagon/edit_contributors.html:58
-#: src/olympia/constants/base.py:134
+#: src/olympia/bandwagon/templates/bandwagon/edit_contributors.html:9 src/olympia/bandwagon/templates/bandwagon/edit_contributors.html:12
+#: src/olympia/bandwagon/templates/bandwagon/edit_contributors.html:17 src/olympia/bandwagon/templates/bandwagon/edit_contributors.html:58 src/olympia/constants/base.py:134
 msgid "Owner"
 msgstr "Lastnik"
 
@@ -3275,10 +2551,8 @@ msgstr "Spremeni v lastnika"
 msgid "Remove this user as a contributor"
 msgstr "Odstranite tega uporabnika kot sodelavca"
 
-#: src/olympia/bandwagon/templates/bandwagon/edit_contributors.html:18
-#: src/olympia/bandwagon/templates/bandwagon/edit_contributors.html:43
-#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:20
-#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:48
+#: src/olympia/bandwagon/templates/bandwagon/edit_contributors.html:18 src/olympia/bandwagon/templates/bandwagon/edit_contributors.html:43
+#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:18 src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:46
 #: src/olympia/devhub/templates/devhub/addons/ajax_compat_update.html:19
 msgid "Remove"
 msgstr "Odstrani"
@@ -3289,23 +2563,15 @@ msgstr "Sodelavci pri zbirki"
 
 #: src/olympia/bandwagon/templates/bandwagon/edit_contributors.html:26
 msgid ""
-"You can add multiple contributors to this collection.  A contributor can add"
-" and remove add-ons from this collection, but cannot change its name or "
-"description.  To add a contributor, enter their email in the box below. "
-"Contributors must have a Mozilla Add-ons account."
+"You can add multiple contributors to this collection.  A contributor can add and remove add-ons from this collection, but cannot change its name or description.  To add a contributor, enter their "
+"email in the box below. Contributors must have a Mozilla Add-ons account."
 msgstr ""
-"Tej zbirki lahko dodate več oseb, ki lahko prispevajo dodatke.  Oseba lahko "
-"dodaja ali odstranjuje dodatke iz te zbirke, vendar ne more spreminjati "
-"imena ali opisa.  Za dodajanje osebe vnesite njeno/njegovo e-pošto v spodnje"
-" polje.  Osebe morajo imeti račun Dodatkov Mozilla."
 
 #: src/olympia/bandwagon/templates/bandwagon/edit_contributors.html:40
 msgid "User"
 msgstr "Uporabnik"
 
-#: src/olympia/bandwagon/templates/bandwagon/edit_contributors.html:41
-#: src/olympia/devhub/templates/devhub/addons/edit/support.html:20
-#: src/olympia/users/templates/users/delete.html:49
+#: src/olympia/bandwagon/templates/bandwagon/edit_contributors.html:41 src/olympia/devhub/templates/devhub/addons/edit/support.html:20 src/olympia/users/templates/users/delete.html:49
 msgid "Email"
 msgstr "E-pošta"
 
@@ -3331,27 +2597,14 @@ msgid "Admin Settings"
 msgstr "Skrbnikove nastavitve"
 
 #: src/olympia/bandwagon/templates/bandwagon/edit_contributors.html:76
-msgid ""
-"<b>Warning:</b> By changing the owner of this collection, you will no longer"
-" be able to edit it. You will only be able to add and remove add-ons from "
-"it."
-msgstr ""
-"<b>Opozorilo:</b>Če spremenite lastnika te zbirke, je ne boste več mogli "
-"urejati. Lahko boste le dodajali ali odstranjevali dodatke iz nje."
+msgid "<b>Warning:</b> By changing the owner of this collection, you will no longer be able to edit it. You will only be able to add and remove add-ons from it."
+msgstr "<b>Opozorilo:</b>Če spremenite lastnika te zbirke, je ne boste več mogli urejati. Lahko boste le dodajali ali odstranjevali dodatke iz nje."
 
-#: src/olympia/bandwagon/templates/bandwagon/edit_contributors.html:83
-#: src/olympia/devhub/templates/devhub/addons/forms_shared/media.html:157
-#: src/olympia/devhub/templates/devhub/addons/submit/describe.html:69
-#: src/olympia/devhub/templates/devhub/addons/submit/license.html:60
-#: src/olympia/devhub/templates/devhub/addons/submit/upload.html:78
-#: src/olympia/devhub/templates/devhub/payments/tier.html:17
-#: src/olympia/editors/templates/editors/themes/themes.html:111
-#: src/olympia/editors/templates/editors/themes/themes.html:128
-#: src/olympia/editors/templates/editors/themes/themes.html:134
-#: src/olympia/editors/templates/editors/themes/themes.html:141
-#: src/olympia/users/templates/users/fxa_migration_prompt_content.html:10
-#: src/olympia/users/templates/users/login_form.html:42
-#: src/olympia/users/templates/users/mobile/login.html:57
+#: src/olympia/bandwagon/templates/bandwagon/edit_contributors.html:83 src/olympia/devhub/templates/devhub/addons/forms_shared/media.html:157
+#: src/olympia/devhub/templates/devhub/addons/submit/describe.html:69 src/olympia/devhub/templates/devhub/addons/submit/license.html:60 src/olympia/devhub/templates/devhub/addons/submit/upload.html:70
+#: src/olympia/devhub/templates/devhub/payments/tier.html:17 src/olympia/editors/templates/editors/themes/themes.html:111 src/olympia/editors/templates/editors/themes/themes.html:128
+#: src/olympia/editors/templates/editors/themes/themes.html:134 src/olympia/editors/templates/editors/themes/themes.html:141 src/olympia/users/templates/users/fxa_migration_prompt_content.html:10
+#: src/olympia/users/templates/users/login_form.html:42 src/olympia/users/templates/users/mobile/login.html:57
 msgid "Continue"
 msgstr "Nadaljuj"
 
@@ -3390,18 +2643,10 @@ msgstr "Zadnje čase priljubljene zbirke"
 
 #: src/olympia/bandwagon/templates/bandwagon/impala/collection_listing.html:28
 #, python-format
-msgid ""
-"Collections are groups of related add-ons that anyone can create and share. "
-"Explore collections created by other users or <a href=\"%(url)s\">create "
-"your own</a>."
-msgstr ""
-"Zbirke so skupine sorodnih dodatkov, ki jih lahko vsakdo ustvari in deli z "
-"drugimi. Raziščite zbirke, ki so jih ustvarili drugi uporabniki, ali pa <a "
-"href=\"%(url)s\">ustvarite svoje</a>."
+msgid "Collections are groups of related add-ons that anyone can create and share. Explore collections created by other users or <a href=\"%(url)s\">create your own</a>."
+msgstr "Zbirke so skupine sorodnih dodatkov, ki jih lahko vsakdo ustvari in deli z drugimi. Raziščite zbirke, ki so jih ustvarili drugi uporabniki, ali pa <a href=\"%(url)s\">ustvarite svoje</a>."
 
-#: src/olympia/bandwagon/templates/bandwagon/impala/collection_listing.html:37
-#: src/olympia/browse/templates/browse/extensions.html:13
-#: src/olympia/browse/templates/browse/themes.html:14
+#: src/olympia/bandwagon/templates/bandwagon/impala/collection_listing.html:37 src/olympia/browse/templates/browse/extensions.html:13 src/olympia/browse/templates/browse/themes.html:14
 msgid "Subscribe"
 msgstr "Naročite se"
 
@@ -3409,20 +2654,14 @@ msgstr "Naročite se"
 msgid "Following"
 msgstr "Sledi se"
 
-#: src/olympia/bandwagon/templates/bandwagon/impala/collection_sidebar.html:22
-#: src/olympia/bandwagon/templates/bandwagon/impala/collection_sidebar.html:28
+#: src/olympia/bandwagon/templates/bandwagon/impala/collection_sidebar.html:22 src/olympia/bandwagon/templates/bandwagon/impala/collection_sidebar.html:28
 #: src/olympia/bandwagon/templates/bandwagon/includes/collection_sidebar.html:32
 msgid "Create a Collection"
 msgstr "Ustvari zbirko"
 
-#: src/olympia/bandwagon/templates/bandwagon/impala/collection_sidebar.html:23
-#: src/olympia/bandwagon/templates/bandwagon/includes/collection_sidebar.html:27
-msgid ""
-"Collections make it easy to keep track of favorite add-ons and share your "
-"perfectly customized browser with others."
-msgstr ""
-"Zbirke vam omogočajo spremljati najljubše dodatke in deliti svoj do kraja "
-"prilagojen brskalnik z drugimi."
+#: src/olympia/bandwagon/templates/bandwagon/impala/collection_sidebar.html:23 src/olympia/bandwagon/templates/bandwagon/includes/collection_sidebar.html:27
+msgid "Collections make it easy to keep track of favorite add-ons and share your perfectly customized browser with others."
+msgstr "Zbirke vam omogočajo spremljati najljubše dodatke in deliti svoj do kraja prilagojen brskalnik z drugimi."
 
 #: src/olympia/bandwagon/templates/bandwagon/includes/addedit.html:42
 msgid "Collection Icon"
@@ -3434,50 +2673,42 @@ msgstr "Ponastavi"
 
 #: src/olympia/bandwagon/templates/bandwagon/includes/addedit.html:53
 msgid "PNG and JPG supported.  Image will be resized to 32x32."
-msgstr "Podprta sta PNG in JPG.  Velikost slike bo spremenjena na 32 x 32."
+msgstr ""
 
 #: src/olympia/bandwagon/templates/bandwagon/includes/addedit_errors.html:3
 msgid "There are errors in this form.  Please correct them below."
-msgstr "Ta obrazec vsebuje napake.  Popravite jih spodaj."
+msgstr ""
 
 #: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:2
 msgid "Add-ons in Your Collection"
 msgstr "Dodatki v vaši zbirki"
 
 #: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:4
-msgid ""
-"To include an add-on in this collection, enter its name in the box below and"
-" hit enter.  You can also use the <strong>Add to Collection</strong> links "
-"throughout the site to include add-ons later."
+msgid "To include an add-on in this collection, enter its name in the box below and hit enter."
 msgstr ""
-"Za vključitev dodatka v to zbirko v spodnje polje vnesite njegovo ime in "
-"pritisnite Enter.  Za kasnejše vključevanje dodatkov lahko uporabite tudi "
-"povezave <strong>Dodaj k zbirki</strong>."
 
-#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:17
-#: src/olympia/constants/base.py:400
-#: src/olympia/devhub/templates/devhub/addons/activity.html:62
+#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:15 src/olympia/constants/base.py:400 src/olympia/devhub/templates/devhub/addons/activity.html:62
+#: src/olympia/editors/helpers.py:273 src/olympia/editors/helpers.py:360
 msgid "Add-on"
 msgstr "Dodatek"
 
-#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:26
+#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:24
 msgid "Enter the name of the add-on to include"
 msgstr "Vnesite ime dodatke, ki ga hočete vključiti"
 
-#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:28
+#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:26
 msgid "Add to Collection"
 msgstr "Dodaj v zbirko"
 
-#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:45
-#: src/olympia/editors/helpers.py:936 src/olympia/editors/helpers.py:956
+#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:43 src/olympia/editors/helpers.py:1016 src/olympia/editors/helpers.py:1036
 msgid "Pending"
 msgstr "Na čakanju"
 
-#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:47
+#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:45
 msgid "Add a comment"
 msgstr "Dodaj komentar"
 
-#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:48
+#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:46
 msgid "Remove this add-on from the collection"
 msgstr "Odstrani ta dodatek iz zbirke"
 
@@ -3487,17 +2718,13 @@ msgstr "ZBIRKE"
 
 #: src/olympia/bandwagon/templates/bandwagon/mobile/collection_listing.html:8
 msgid "Groups of related add-ons that anyone can create."
-msgstr ""
-"Skupine sorodnih dodatkov, ki jih lahko vsakdo ustvari in deli z drugimi."
+msgstr "Skupine sorodnih dodatkov, ki jih lahko vsakdo ustvari in deli z drugimi."
 
-#: src/olympia/blocklist/templates/blocklist/blocked_detail.html:3
-#: src/olympia/blocklist/templates/blocklist/blocked_list.html:3
-#: src/olympia/blocklist/templates/blocklist/blocked_list.html:10
+#: src/olympia/blocklist/templates/blocklist/blocked_detail.html:3 src/olympia/blocklist/templates/blocklist/blocked_list.html:3 src/olympia/blocklist/templates/blocklist/blocked_list.html:10
 msgid "Blocked Add-ons"
 msgstr "Blokirani dodatki"
 
-#: src/olympia/blocklist/templates/blocklist/blocked_detail.html:8
-#: src/olympia/blocklist/templates/blocklist/blocked_list.html:6
+#: src/olympia/blocklist/templates/blocklist/blocked_detail.html:8 src/olympia/blocklist/templates/blocklist/blocked_list.html:6
 msgid "Blocklist"
 msgstr "Seznam blokiranih"
 
@@ -3519,41 +2746,24 @@ msgid "What does this mean?"
 msgstr "Kaj to pomeni?"
 
 #: src/olympia/blocklist/templates/blocklist/blocked_detail.html:22
-msgid ""
-"Users are strongly encouraged to disable the problematic add-on or plugin, "
-"but may choose to continue using it if they accept the risks described."
-msgstr ""
-"Uporabnikom se resno svetuje, da problematični dodatek ali vtičnik "
-"onemogočijo, vendar se lahko odločijo, da ga bodo še naprej uporabljali, če "
-"sprejmejo opisana tveganja."
+msgid "Users are strongly encouraged to disable the problematic add-on or plugin, but may choose to continue using it if they accept the risks described."
+msgstr "Uporabnikom se resno svetuje, da problematični dodatek ali vtičnik onemogočijo, vendar se lahko odločijo, da ga bodo še naprej uporabljali, če sprejmejo opisana tveganja."
 
 #: src/olympia/blocklist/templates/blocklist/blocked_detail.html:27
-msgid ""
-"The problematic add-on or plugin will be automatically disabled and no "
-"longer usable."
-msgstr ""
-"Problematičen dodatek ali vtičnik bo samodejno onemogočen in ne bo več "
-"uporaben."
+msgid "The problematic add-on or plugin will be automatically disabled and no longer usable."
+msgstr "Problematičen dodatek ali vtičnik bo samodejno onemogočen in ne bo več uporaben."
 
 #: src/olympia/blocklist/templates/blocklist/blocked_detail.html:33
 #, python-format
 msgid ""
-"When Mozilla becomes aware of add-ons, plugins, or other third-party "
-"software that seriously compromises %(app)s security, stability, or "
-"performance and meets <a href=\"%(criteria)s\">certain criteria</a>, the "
-"software may be blocked from general use.  For more information, please read"
-" <a href=\"%(support)s\">this support article</a>."
+"When Mozilla becomes aware of add-ons, plugins, or other third-party software that seriously compromises %(app)s security, stability, or performance and meets <a href=\"%(criteria)s\">certain "
+"criteria</a>, the software may be blocked from general use.  For more information, please read <a href=\"%(support)s\">this support article</a>."
 msgstr ""
-"Ko Mozilla naleti na dodatke, vtičnike ali programsko opremo tretjih oseb, "
-"ki resno ogrožajo %(app)s varnost, stabilnost ali zmogljivost in ustrezajo "
-"<a href=\"%(criteria)s\">določenim merilom</a>, jo Mozilla lahko zavrne.  Za"
-" več podatkov preberite <a href=\"%(support)s\">članek podpore</a>."
 
 #: src/olympia/blocklist/templates/blocklist/blocked_detail.html:44
 #, python-format
 msgid "Blocked on %(date)s. <a href=\"%(link)s\">View block request</a>."
-msgstr ""
-"Blokirano dne %(date)s. <a href=\"%(link)s\">Prikaz zahteve za blokado</a>."
+msgstr "Blokirano dne %(date)s. <a href=\"%(link)s\">Prikaz zahteve za blokado</a>."
 
 #: src/olympia/blocklist/templates/blocklist/blocked_detail.html:48
 #, python-format
@@ -3561,12 +2771,8 @@ msgid "Blocked on %(date)s."
 msgstr "Blokirano dne %(date)s."
 
 #: src/olympia/blocklist/templates/blocklist/blocked_list.html:11
-msgid ""
-"The following software is known to cause serious security, stability, or "
-"performance issues with {app}."
-msgstr ""
-"Za naslednjo programsko opremo je znano, da povzroča resne probleme glede "
-"varnosti, stabilnosti, ali težave pri delu s {app}."
+msgid "The following software is known to cause serious security, stability, or performance issues with {app}."
+msgstr "Za naslednjo programsko opremo je znano, da povzroča resne probleme glede varnosti, stabilnosti, ali težave pri delu s {app}."
 
 #. L10n: %s is a category name.
 #: src/olympia/browse/feeds.py:76 src/olympia/browse/feeds.py:98
@@ -3588,11 +2794,8 @@ msgstr "Izbrani dodatki :: %s"
 #. L10n: %s is an app name.
 #: src/olympia/browse/feeds.py:138
 #, python-format
-msgid ""
-"Here's a few of our favorite add-ons to help you get started customizing %s."
-msgstr ""
-"Tukaj je nekaj naših najljubših dodatkov, da boste laže začeli prilagajati "
-"%s."
+msgid "Here's a few of our favorite add-ons to help you get started customizing %s."
+msgstr "Tukaj je nekaj naših najljubših dodatkov, da boste laže začeli prilagajati %s."
 
 #. L10n: %s is a category name.
 #: src/olympia/browse/feeds.py:157
@@ -3608,43 +2811,28 @@ msgstr "Orodja za iskanje in razširitve v zvezi z iskanjem"
 msgid "Search tools"
 msgstr "Iskalniki"
 
-#: src/olympia/browse/views.py:55 src/olympia/browse/views.py:65
-#: src/olympia/search/forms.py:85
+#: src/olympia/browse/views.py:55 src/olympia/browse/views.py:65 src/olympia/search/forms.py:85
 msgid "Most Users"
 msgstr "Največ uporabnikov"
 
-#: src/olympia/browse/views.py:61 src/olympia/browse/views.py:72
-#: src/olympia/browse/views.py:279
-#: src/olympia/browse/templates/browse/personas/mobile/category_landing.html:63
-#: src/olympia/discovery/templates/discovery/pane.html:67
-#: src/olympia/search/forms.py:92
+#: src/olympia/browse/views.py:61 src/olympia/browse/views.py:72 src/olympia/browse/views.py:246 src/olympia/browse/templates/browse/personas/mobile/category_landing.html:63
+#: src/olympia/discovery/templates/discovery/pane.html:67 src/olympia/search/forms.py:92
 msgid "Up & Coming"
 msgstr "Kmalu"
 
-#: src/olympia/browse/views.py:460 src/olympia/devhub/views.py:76
-#: src/olympia/devhub/views.py:83
-#: src/olympia/discovery/templates/discovery/addons/detail.html:66
+#: src/olympia/browse/views.py:427 src/olympia/devhub/views.py:74 src/olympia/devhub/views.py:81 src/olympia/discovery/templates/discovery/addons/detail.html:66
 msgid "Created"
 msgstr "Ustvarjeno"
 
 #. {0} is the category name. Ex: Sports
-#: src/olympia/browse/templates/browse/creatured.html:5
-#: src/olympia/browse/templates/browse/creatured.html:13
+#: src/olympia/browse/templates/browse/creatured.html:5 src/olympia/browse/templates/browse/creatured.html:13
 msgid "{0}: Featured Add-ons"
 msgstr "{0}: izbrani dodatki"
 
-#: src/olympia/browse/templates/browse/creatured.html:12
-#: src/olympia/browse/templates/browse/featured.html:4
-#: src/olympia/browse/templates/browse/featured.html:12
-#: src/olympia/browse/templates/browse/featured.html:13
-#: src/olympia/devhub/templates/devhub/docs/policies-recommended.html:3
-#: src/olympia/devhub/templates/devhub/docs/policies-recommended.html:7
-#: src/olympia/devhub/templates/devhub/docs/policies-recommended.html:9
-#: src/olympia/devhub/templates/devhub/docs/policies.html:21
-#: src/olympia/devhub/templates/devhub/docs/policies.html:90
-#: src/olympia/discovery/modules.py:341
-#: src/olympia/discovery/templates/discovery/pane.html:52
-#: src/olympia/templates/menu_links.html:7
+#: src/olympia/browse/templates/browse/creatured.html:12 src/olympia/browse/templates/browse/featured.html:4 src/olympia/browse/templates/browse/featured.html:12
+#: src/olympia/browse/templates/browse/featured.html:13 src/olympia/devhub/templates/devhub/docs/policies-recommended.html:3 src/olympia/devhub/templates/devhub/docs/policies-recommended.html:7
+#: src/olympia/devhub/templates/devhub/docs/policies-recommended.html:9 src/olympia/devhub/templates/devhub/docs/policies.html:21 src/olympia/devhub/templates/devhub/docs/policies.html:90
+#: src/olympia/discovery/modules.py:341 src/olympia/discovery/templates/discovery/pane.html:52 src/olympia/templates/menu_links.html:7
 msgid "Featured Add-ons"
 msgstr "Izbrani dodatki"
 
@@ -3655,12 +2843,8 @@ msgstr "Ni izbranih dodatkov v {0}."
 
 #: src/olympia/browse/templates/browse/featured.html:15
 #, python-format
-msgid ""
-"Here's a few of our favorite add-ons to help you get started customizing "
-"%(app)s."
-msgstr ""
-"Tukaj je nekaj naših najljubših dodatkov, da boste laže začeli prilagajati "
-"%(app)s."
+msgid "Here's a few of our favorite add-ons to help you get started customizing %(app)s."
+msgstr "Tukaj je nekaj naših najljubših dodatkov, da boste laže začeli prilagajati %(app)s."
 
 #: src/olympia/browse/templates/browse/language_tools.html:9
 msgid "Install Dictionary"
@@ -3686,19 +2870,15 @@ msgstr "Na razpolago v slovenščini"
 msgid "List of language packs and dictionaries available in your locale."
 msgstr "Seznam jezikovnih paketov in slovarjev v slovenščini."
 
-#: src/olympia/browse/templates/browse/language_tools.html:41
-#: src/olympia/browse/templates/browse/language_tools.html:63
+#: src/olympia/browse/templates/browse/language_tools.html:41 src/olympia/browse/templates/browse/language_tools.html:63
 msgid "Language"
 msgstr "Jezik"
 
-#: src/olympia/browse/templates/browse/language_tools.html:42
-#: src/olympia/browse/templates/browse/language_tools.html:64
-#: src/olympia/constants/base.py:162
+#: src/olympia/browse/templates/browse/language_tools.html:42 src/olympia/browse/templates/browse/language_tools.html:64 src/olympia/constants/base.py:162
 msgid "Dictionary"
 msgstr "Slovar"
 
-#: src/olympia/browse/templates/browse/language_tools.html:43
-#: src/olympia/browse/templates/browse/language_tools.html:65
+#: src/olympia/browse/templates/browse/language_tools.html:43 src/olympia/browse/templates/browse/language_tools.html:65
 msgid "Language Pack"
 msgstr "Jezikovni paket"
 
@@ -3716,14 +2896,11 @@ msgid "{0} :: Search Tools"
 msgstr "{0} :: iskalniki"
 
 #. {0} is an integer.
-#: src/olympia/browse/templates/browse/search_tools.html:39
-#: src/olympia/devhub/templates/devhub/addons/dashboard.html:17
+#: src/olympia/browse/templates/browse/search_tools.html:39 src/olympia/devhub/templates/devhub/addons/dashboard.html:17
 msgid "<b>{0}</b> add-on"
 msgid_plural "<b>{0}</b> add-ons"
 msgstr[0] "<b>{0}</b> dodatek"
 msgstr[1] "<b>{0}</b> dodatka"
-msgstr[2] "<b>{0}</b> dodatki"
-msgstr[3] "<b>{0}</b> dodatkov"
 
 #: src/olympia/browse/templates/browse/search_tools.html:61
 msgid "Search Extensions"
@@ -3747,34 +2924,18 @@ msgstr "Dodatni viri"
 
 #. {0} is an app name, like Firefox.
 #: src/olympia/browse/templates/browse/search_tools.html:93
-msgid ""
-"Learn more about the <a "
-"href=\"http://support.mozilla.com/kb/Search+bar\">search bar</a> in {0}"
-msgstr ""
-"Preberite več o <a href=\"http://support.mozilla.com/kb/Search+bar\">iskalni"
-" vrstici</a> v {0}"
+msgid "Learn more about the <a href=\"http://support.mozilla.com/kb/Search+bar\">search bar</a> in {0}"
+msgstr "Preberite več o <a href=\"http://support.mozilla.com/kb/Search+bar\">iskalni vrstici</a> v {0}"
 
 #: src/olympia/browse/templates/browse/search_tools.html:94
-msgid ""
-"Browse through even more search providers at <a "
-"href=\"http://mycroft.mozdev.org/\">mycroft.mozdev.org</a>"
-msgstr ""
-"Brskajte po še več ponudnikih za iskanje na <a "
-"href=\"http://mycroft.mozdev.org/\">mycroft.mozdev.org</a>"
+msgid "Browse through even more search providers at <a href=\"http://mycroft.mozdev.org/\">mycroft.mozdev.org</a>"
+msgstr "Brskajte po še več ponudnikih za iskanje na <a href=\"http://mycroft.mozdev.org/\">mycroft.mozdev.org</a>"
 
 #: src/olympia/browse/templates/browse/search_tools.html:95
-msgid ""
-"<a "
-"href=\"https://developer.mozilla.org/en/Creating_OpenSearch_plugins_for_Firefox\">Make"
-" your own</a> search tool"
-msgstr ""
-"<a "
-"href=\"https://developer.mozilla.org/en/Creating_OpenSearch_plugins_for_Firefox\">Ustvarite"
-" svoj</a> iskalnik"
+msgid "<a href=\"https://developer.mozilla.org/en/Creating_OpenSearch_plugins_for_Firefox\">Make your own</a> search tool"
+msgstr "<a href=\"https://developer.mozilla.org/en/Creating_OpenSearch_plugins_for_Firefox\">Ustvarite svoj</a> iskalnik"
 
-#: src/olympia/browse/templates/browse/themes.html:6
-#: src/olympia/browse/templates/browse/themes.html:9
-#: src/olympia/constants/base.py:174
+#: src/olympia/browse/templates/browse/themes.html:6 src/olympia/browse/templates/browse/themes.html:9 src/olympia/constants/base.py:174
 msgid "Complete Themes"
 msgstr "Celotne teme"
 
@@ -3846,27 +3007,18 @@ msgid "See the %(cnt)s extension in %(name)s &raquo;"
 msgid_plural "See all %(cnt)s extensions in %(name)s &raquo;"
 msgstr[0] "Glej razširitev %(cnt)s v %(name)s &raquo;"
 msgstr[1] "Glej obe razširitvi - %(cnt)s - v %(name)s &raquo;"
-msgstr[2] "Glej vse razširitve - %(cnt)s - v %(name)s &raquo;"
-msgstr[3] "Glej vse razširitve - %(cnt)s - v %(name)s &raquo;"
 
-#: src/olympia/browse/templates/browse/mobile/extensions.html:13
-#: src/olympia/compat/templates/compat/index.html:82
-#: src/olympia/devhub/templates/devhub/devhub_search.html:24
-#: src/olympia/devhub/templates/devhub/addons/activity.html:47
-#: src/olympia/search/templates/search/no_results.html:4
-#: src/olympia/search/templates/search/mobile/results.html:36
+#: src/olympia/browse/templates/browse/mobile/extensions.html:13 src/olympia/devhub/templates/devhub/devhub_search.html:24 src/olympia/devhub/templates/devhub/addons/activity.html:47
+#: src/olympia/search/templates/search/no_results.html:4 src/olympia/search/templates/search/mobile/results.html:36
 msgid "No results found."
 msgstr "Ni najti rezultatov."
 
-#: src/olympia/browse/templates/browse/personas/base.html:6
-#: src/olympia/browse/templates/browse/personas/mobile/base.html:7
+#: src/olympia/browse/templates/browse/personas/base.html:6 src/olympia/browse/templates/browse/personas/mobile/base.html:7
 msgid "{0} Themes"
 msgstr "{0} tem"
 
 #. {0} is a user's name.
-#: src/olympia/browse/templates/browse/personas/base.html:15
-#: src/olympia/browse/templates/browse/personas/base.html:40
-#: src/olympia/browse/templates/browse/personas/grid.html:8
+#: src/olympia/browse/templates/browse/personas/base.html:15 src/olympia/browse/templates/browse/personas/base.html:40 src/olympia/browse/templates/browse/personas/grid.html:8
 msgid "{0}'s Themes"
 msgstr "Teme - {0}"
 
@@ -3886,31 +3038,23 @@ msgstr "Vaš brskalnik, vaš slog! Preoblecite ga po svojem okusu!"
 msgid "Learn more"
 msgstr "Več o tem"
 
-#: src/olympia/browse/templates/browse/personas/category_landing.html:6
-#: src/olympia/browse/templates/browse/personas/mobile/category_landing.html:5
+#: src/olympia/browse/templates/browse/personas/category_landing.html:6 src/olympia/browse/templates/browse/personas/mobile/category_landing.html:5
 msgid "View All Recently Added"
 msgstr "Ogled vseh pred kratkim dodanih"
 
-#: src/olympia/browse/templates/browse/personas/category_landing.html:7
-#: src/olympia/browse/templates/browse/personas/mobile/category_landing.html:6
+#: src/olympia/browse/templates/browse/personas/category_landing.html:7 src/olympia/browse/templates/browse/personas/mobile/category_landing.html:6
 msgid "View All Most Popular"
 msgstr "Ogled vseh najbolj priljubljenih"
 
-#: src/olympia/browse/templates/browse/personas/category_landing.html:8
-#: src/olympia/browse/templates/browse/personas/mobile/category_landing.html:7
+#: src/olympia/browse/templates/browse/personas/category_landing.html:8 src/olympia/browse/templates/browse/personas/mobile/category_landing.html:7
 msgid "View All Top Rated"
 msgstr "Ogled vseh najbolje ocenjenih"
 
 #: src/olympia/browse/templates/browse/personas/category_landing.html:40
 #, python-format
-msgid ""
-"Over 300,000 designs to personalize your browser! Move your mouse over a "
-"Background Theme to try it on. <a href=\"%(url)s\" class=\"more-info\">Start"
-" exploring</a>"
+msgid "Over 300,000 designs to personalize your browser! Move your mouse over a Background Theme to try it on. <a href=\"%(url)s\" class=\"more-info\">Start exploring</a>"
 msgstr ""
-"Več kot 300,000 dizajnov, s katerimi si lahko preoblečete svoj brskalnik! "
-"Premaknite miško prek teme za ozadje, da si jo ogledate. <a href=\"%(url)s\""
-" class=\"more-info\">Začnite raziskovati</a>"
+"Več kot 300,000 dizajnov, s katerimi si lahko preoblečete svoj brskalnik! Premaknite miško prek teme za ozadje, da si jo ogledate. <a href=\"%(url)s\" class=\"more-info\">Začnite raziskovati</a>"
 
 #: src/olympia/browse/templates/browse/personas/category_landing.html:47
 msgid "Want more personalization?"
@@ -3920,14 +3064,8 @@ msgstr "Želite večjo prilagodljivost?"
 #. theme.
 #: src/olympia/browse/templates/browse/personas/category_landing.html:50
 #, python-format
-msgid ""
-"Complete Themes transform the look of your browser with styles for the "
-"window frame, address bar, buttons, tabs, and menus. <a href=\"%(url)s\" "
-"class=\"more-info\">Start exploring</a>"
-msgstr ""
-"Celotne teme spremenijo videz brskalnika s slogi za okenski okvir, naslovno "
-"vrstico, gumbe, zavihke in menije. <a href=\"%(url)s\" class=\"more-"
-"info\">Začnite raziskovati</a>"
+msgid "Complete Themes transform the look of your browser with styles for the window frame, address bar, buttons, tabs, and menus. <a href=\"%(url)s\" class=\"more-info\">Start exploring</a>"
+msgstr "Celotne teme spremenijo videz brskalnika s slogi za okenski okvir, naslovno vrstico, gumbe, zavihke in menije. <a href=\"%(url)s\" class=\"more-info\">Začnite raziskovati</a>"
 
 #: src/olympia/browse/templates/browse/personas/category_landing.html:76
 msgid "Up & Coming Themes"
@@ -3957,7 +3095,7 @@ msgstr "&laquo; Vse teme"
 msgid "All"
 msgstr "Vsi"
 
-#: src/olympia/compat/forms.py:22 src/olympia/search/views.py:525
+#: src/olympia/compat/forms.py:22 src/olympia/editors/templates/editors/base.html:69 src/olympia/search/views.py:518
 msgid "All Add-ons"
 msgstr "Vse razširitve"
 
@@ -3969,92 +3107,32 @@ msgstr "Binarno"
 msgid "Non-binary"
 msgstr "Ne-binarno"
 
-#. Review points sources other than add-ons and themes.
-#: src/olympia/compat/views.py:87 src/olympia/constants/base.py:388
-#: src/olympia/devhub/forms.py:162
-#: src/olympia/editors/templates/editors/performance.html:75
-msgid "Other"
-msgstr "Drugo"
-
-#: src/olympia/compat/templates/compat/index.html:4
-msgid "Add-on Compatibility Report for {app} {version}"
-msgstr "Poročilo o združljivosti dodatka za {app} {version}"
-
-#: src/olympia/compat/templates/compat/index.html:11
-msgid "{app} {version} Compatibility"
-msgstr "Združljivost {app} {version}"
-
-#: src/olympia/compat/templates/compat/index.html:17
-#, python-format
-msgid "Top 95%% compatible with previous version"
-msgstr "Vrhnjih 95 %% je združljivih s prejšnjo različico"
-
-#: src/olympia/compat/templates/compat/index.html:18
-#, python-format
-msgid "Top 95%% of all add-ons"
-msgstr "Vrhnjih 95 %% vseh dodatkov"
-
-#: src/olympia/compat/templates/compat/index.html:19
-msgid "All active add-ons"
-msgstr "Vsi aktivni dodatki"
-
-#: src/olympia/compat/templates/compat/index.html:23
-#: src/olympia/constants/base.py:401
-msgid "App"
-msgstr "Aplikacija"
-
-#: src/olympia/compat/templates/compat/index.html:55
-msgid "Details for add-ons compatible with previous version:"
-msgstr "Podrobnosti za dodatke, združljive s predhodno različico:"
-
-#: src/olympia/compat/templates/compat/index.html:57
-msgid "Show all versions"
-msgstr "Pokaži vse različice"
-
-#: src/olympia/compat/templates/compat/index.html:59
-msgid "Details for add-ons compatible with all versions:"
-msgstr "Podrobnosti za dodatke, združljive z vsemi različicami:"
-
-#: src/olympia/compat/templates/compat/index.html:61
-msgid "Show previous version only"
-msgstr "Pokaži samo predhodno različico"
-
 #: src/olympia/compat/templates/compat/reporter.html:3
 msgid "Add-on Compatibility Reports"
 msgstr "Poročila o združljivosti dodatkov"
 
-#: src/olympia/compat/templates/compat/reporter.html:11
-#: src/olympia/compat/templates/compat/reporter_detail.html:35
+#: src/olympia/compat/templates/compat/reporter.html:11 src/olympia/compat/templates/compat/reporter_detail.html:35
 #, python-format
 msgid ""
-"<p> Reports submitted to us through the <a href=\"%(url_)s\">Add-on "
-"Compatibility Reporter</a> are collected here for developers to view. These "
-"reports help us determine which add-ons will need help supporting an "
-"upcoming Firefox version. </p>"
+"<p> Reports submitted to us through the <a href=\"%(url_)s\">Add-on Compatibility Reporter</a> are collected here for developers to view. These reports help us determine which add-ons will need "
+"help supporting an upcoming Firefox version. </p>"
 msgstr ""
-"<p> Poročila, ki nam jih posreduje <a href=\"%(url_)s\">Poročevalec o "
-"združljivosti dodatkov</a>, se zbira tukaj, da si jih razvijalci lahko "
-"ogledajo. Ta poročila nam pomagajo ugotoviti, kateri dodatki bodo pri "
-"naslednji različici Firefoxa potrebovali pomoč. </p>"
+"<p> Poročila, ki nam jih posreduje <a href=\"%(url_)s\">Poročevalec o združljivosti dodatkov</a>, se zbira tukaj, da si jih razvijalci lahko ogledajo. Ta poročila nam pomagajo ugotoviti, kateri "
+"dodatki bodo pri naslednji različici Firefoxa potrebovali pomoč. </p>"
 
 #: src/olympia/compat/templates/compat/reporter.html:18
 msgid "Reports for your Add-ons"
 msgstr "Poročila za vaše dodatke"
 
-#: src/olympia/compat/templates/compat/reporter.html:30
-#: src/olympia/compat/templates/compat/reporter_detail.html:9
+#: src/olympia/compat/templates/compat/reporter.html:30 src/olympia/compat/templates/compat/reporter_detail.html:9
 msgid "Add-on Compatibility Center"
 msgstr "Center za združljivost dodatkov"
 
 #: src/olympia/compat/templates/compat/reporter.html:34
 msgid "Enter the GUID of an add-on below to view any reports we've received."
-msgstr ""
-"Vnesite spodaj GUID za dodatke, da si lahko ogledate poročila, ki ste jih "
-"morda prejeli."
+msgstr "Vnesite spodaj GUID za dodatke, da si lahko ogledate poročila, ki ste jih morda prejeli."
 
-#: src/olympia/compat/templates/compat/reporter_detail.html:3
-#: src/olympia/compat/templates/compat/reporter_detail.html:10
-#: src/olympia/compat/templates/compat/reporter_detail.html:25
+#: src/olympia/compat/templates/compat/reporter_detail.html:3 src/olympia/compat/templates/compat/reporter_detail.html:10 src/olympia/compat/templates/compat/reporter_detail.html:25
 msgid "{addon} Compatibility Reports"
 msgstr "Sporočila o združljivosti {addon}"
 
@@ -4063,19 +3141,14 @@ msgid "{0} success report"
 msgid_plural "{0} success reports"
 msgstr[0] "{0} poročilo o uspehu"
 msgstr[1] "{0} poročili o uspehu"
-msgstr[2] "{0} poročila o uspehu"
-msgstr[3] "{0} poročil o uspehu"
 
 #: src/olympia/compat/templates/compat/reporter_detail.html:17
 msgid "{0} problem report"
 msgid_plural "{0} problem reports"
 msgstr[0] "{0} poročilo o težavi"
 msgstr[1] "{0} poročili o težavi"
-msgstr[2] "{0} poročila o težavi"
-msgstr[3] "{0} poročil o težavi"
 
-#: src/olympia/compat/templates/compat/reporter_detail.html:21
-#: src/olympia/users/templates/users/profile.html:70
+#: src/olympia/compat/templates/compat/reporter_detail.html:21 src/olympia/users/templates/users/profile.html:70
 msgid "View all"
 msgstr "Prikaži vse"
 
@@ -4087,10 +3160,8 @@ msgstr "Filtriraj po aplikacijah"
 msgid "Report Type"
 msgstr "Vrsta poročila"
 
-#: src/olympia/compat/templates/compat/reporter_detail.html:47
-#: src/olympia/devhub/forms.py:784
-#: src/olympia/devhub/templates/devhub/addons/ajax_compat_update.html:17
-#: src/olympia/editors/forms.py:108 src/olympia/zadmin/forms.py:45
+#: src/olympia/compat/templates/compat/reporter_detail.html:47 src/olympia/devhub/forms.py:785 src/olympia/devhub/templates/devhub/addons/ajax_compat_update.html:17 src/olympia/editors/forms.py:108
+#: src/olympia/editors/forms.py:248 src/olympia/zadmin/forms.py:45
 msgid "Application"
 msgstr "Program"
 
@@ -4102,8 +3173,7 @@ msgstr "Gradnja aplikacije"
 msgid "Platform"
 msgstr "Platforma"
 
-#: src/olympia/compat/templates/compat/reporter_detail.html:50
-#: src/olympia/editors/templates/editors/themes/themes.html:40
+#: src/olympia/compat/templates/compat/reporter_detail.html:50 src/olympia/editors/templates/editors/themes/themes.html:40
 msgid "Submitted"
 msgstr "Poslano"
 
@@ -4131,8 +3201,7 @@ msgstr "Thunderbird"
 msgid "SeaMonkey"
 msgstr "SeaMonkey"
 
-#: src/olympia/constants/applications.py:75
-#: src/olympia/pages/templates/pages/sunbird.html:4
+#: src/olympia/constants/applications.py:75 src/olympia/pages/templates/pages/sunbird.html:4
 msgid "Sunbird"
 msgstr "Sunbird"
 
@@ -4181,7 +3250,7 @@ msgid "Preliminarily Reviewed and Awaiting Full Review"
 msgstr "Predhodno pregledan, čaka na popoln pregled"
 
 # 85%
-#: src/olympia/constants/base.py:33 src/olympia/editors/helpers.py:924
+#: src/olympia/constants/base.py:33 src/olympia/editors/forms.py:258 src/olympia/editors/helpers.py:73 src/olympia/editors/helpers.py:1004
 #: src/olympia/editors/templates/editors/themes/history_table.html:34
 msgid "Deleted"
 msgstr "Izbrisano"
@@ -4215,13 +3284,11 @@ msgstr "Razvijalec"
 msgid "Viewer"
 msgstr "Prikazovalnik"
 
-#: src/olympia/constants/base.py:137
-#: src/olympia/templates/mobile/header.html:7
+#: src/olympia/constants/base.py:137 src/olympia/templates/mobile/header.html:7
 msgid "Support"
 msgstr "Podpora"
 
-#: src/olympia/constants/base.py:159 src/olympia/constants/base.py:172
-#: src/olympia/constants/platforms.py:10
+#: src/olympia/constants/base.py:159 src/olympia/constants/base.py:172 src/olympia/constants/platforms.py:10
 msgid "Any"
 msgstr "Poljuben"
 
@@ -4249,11 +3316,8 @@ msgstr "Jezikovni paket (dodatek)"
 msgid "Plugin"
 msgstr "Vtičnik"
 
-#: src/olympia/constants/base.py:167
-#: src/olympia/editors/templates/editors/includes/search_results_themes.html:5
-#: src/olympia/editors/templates/editors/themes/deleted.html:18
-#: src/olympia/editors/templates/editors/themes/history_table.html:8
-#: src/olympia/editors/templates/editors/themes/logs.html:17
+#: src/olympia/constants/base.py:167 src/olympia/editors/templates/editors/includes/search_results_themes.html:5 src/olympia/editors/templates/editors/themes/deleted.html:18
+#: src/olympia/editors/templates/editors/themes/history_table.html:8 src/olympia/editors/templates/editors/themes/logs.html:17
 msgid "Theme"
 msgstr "Tema"
 
@@ -4287,6 +3351,11 @@ msgstr "Vprašaj potem, ko so uporabniki začeli s prenosom tega dodatka"
 msgid "Ask before users can download this add-on"
 msgstr "Vprašaj, preden uporabniki začnejo s prenosom tega dodatka"
 
+#. Review points sources other than add-ons and themes.
+#: src/olympia/constants/base.py:388 src/olympia/devhub/forms.py:162 src/olympia/editors/templates/editors/performance.html:75
+msgid "Other"
+msgstr "Drugo"
+
 #: src/olympia/constants/base.py:389
 msgid "Exception"
 msgstr "Izjema"
@@ -4298,6 +3367,10 @@ msgstr "Izdaja"
 #: src/olympia/constants/base.py:391
 msgid "Change"
 msgstr "Spremeni"
+
+#: src/olympia/constants/base.py:401
+msgid "App"
+msgstr "Aplikacija"
 
 #: src/olympia/constants/base.py:402
 msgid "Persona"
@@ -4435,34 +3508,25 @@ msgstr "Podpisano za poln pregled"
 msgid "Signed of a preliminary review"
 msgstr "Predloga uvodnega pregleda"
 
-#: src/olympia/constants/editors.py:14
-#: src/olympia/editors/templates/editors/themes/queue.html:76
-#: src/olympia/editors/templates/editors/themes/themes.html:87
+#: src/olympia/constants/editors.py:14 src/olympia/editors/templates/editors/themes/queue.html:76 src/olympia/editors/templates/editors/themes/themes.html:87
 msgid "Request More Info"
 msgstr "Zahteva se dodatne informacije"
 
 # 80%
-#: src/olympia/constants/editors.py:15
-#: src/olympia/editors/templates/editors/themes/queue.html:74
-#: src/olympia/editors/templates/editors/themes/themes.html:91
+#: src/olympia/constants/editors.py:15 src/olympia/editors/templates/editors/themes/queue.html:74 src/olympia/editors/templates/editors/themes/themes.html:91
 msgid "Flag"
 msgstr "Zastava"
 
-#: src/olympia/constants/editors.py:16
-#: src/olympia/editors/templates/editors/themes/queue.html:72
-#: src/olympia/editors/templates/editors/themes/themes.html:93
+#: src/olympia/constants/editors.py:16 src/olympia/editors/templates/editors/themes/queue.html:72 src/olympia/editors/templates/editors/themes/themes.html:93
 msgid "Duplicate"
 msgstr "Podvoji"
 
-#: src/olympia/constants/editors.py:17 src/olympia/editors/helpers.py:502
-#: src/olympia/editors/templates/editors/themes/queue.html:71
-#: src/olympia/editors/templates/editors/themes/themes.html:94
+#: src/olympia/constants/editors.py:17 src/olympia/editors/helpers.py:575 src/olympia/editors/templates/editors/themes/queue.html:71 src/olympia/editors/templates/editors/themes/themes.html:94
 msgid "Reject"
 msgstr "Zavrni"
 
 # 87%
-#: src/olympia/constants/editors.py:18
-#: src/olympia/editors/templates/editors/themes/queue.html:70
+#: src/olympia/constants/editors.py:18 src/olympia/editors/templates/editors/themes/queue.html:70
 msgid "Approve"
 msgstr "Dovoli"
 
@@ -4558,7 +3622,7 @@ msgstr "Solaris"
 msgid "Android"
 msgstr "Android"
 
-#: src/olympia/core/apps.py:19
+#: src/olympia/core/apps.py:21
 msgid "Core"
 msgstr "Jedro"
 
@@ -4595,9 +3659,7 @@ msgstr "Neveljaven objekt JSON"
 msgid "Message not eligible for annotation"
 msgstr "Sporočilo ni upravičeno za opombo"
 
-#: src/olympia/devhub/forms.py:124
-#: src/olympia/devhub/templates/devhub/versions/edit.html:94
-#: src/olympia/users/templates/users/edit.html:150
+#: src/olympia/devhub/forms.py:124 src/olympia/devhub/templates/devhub/versions/edit.html:94 src/olympia/users/templates/users/edit.html:150
 msgid "Details"
 msgstr "Podrobnosti"
 
@@ -4694,38 +3756,26 @@ msgid "Submit my add-on for manual review."
 msgstr "Pošlji moj dodatek za ročni pregled."
 
 #: src/olympia/devhub/forms.py:537
-msgid "Do not list my add-on on this site (beta)"
-msgstr "Ne navedi mojih dodatkov na tej strani (beta)"
+msgid "Do not list my add-on on this site"
+msgstr ""
 
 #: src/olympia/devhub/forms.py:538
-msgid ""
-"Check this option if you intend to distribute your add-on on your own and "
-"only need it to be signed by Mozilla."
-msgstr ""
-"Označite to možnost, če nameravate razširjati svoj dodatek po svoje in "
-"potrebujete samo Mozillin podpis."
+msgid "Check this option if you intend to distribute your add-on on your own and only need it to be signed by Mozilla."
+msgstr "Označite to možnost, če nameravate razširjati svoj dodatek po svoje in potrebujete samo Mozillin podpis."
 
 #: src/olympia/devhub/forms.py:544
 msgid "This add-on will be bundled with an application installer."
 msgstr "Dodatek bo del pripomočka za nameščanje aplikacij."
 
 #: src/olympia/devhub/forms.py:546
-msgid ""
-"Add-ons that are bundled with application installers will be code reviewed "
-"by Mozilla before they are signed and are held to a higher quality standard."
-msgstr ""
-"Kodo dodatkov, ki so del pripomočka za nameščanje aplikacij, bo pred "
-"podpisom zaradi višjih standardov pregledala Mozilla."
+msgid "Add-ons that are bundled with application installers will be code reviewed by Mozilla before they are signed and are held to a higher quality standard."
+msgstr "Kodo dodatkov, ki so del pripomočka za nameščanje aplikacij, bo pred podpisom zaradi višjih standardov pregledala Mozilla."
 
-#: src/olympia/devhub/forms.py:565
-#: src/olympia/devhub/templates/devhub/addons/submit/select-review.html:24
-#: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:42
+#: src/olympia/devhub/forms.py:565 src/olympia/devhub/templates/devhub/addons/submit/select-review.html:24 src/olympia/devhub/templates/devhub/docs/policies-reviews.html:42
 msgid "Full Review"
 msgstr "Popoln pregled"
 
-#: src/olympia/devhub/forms.py:566
-#: src/olympia/devhub/templates/devhub/addons/submit/select-review.html:47
-#: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:153
+#: src/olympia/devhub/forms.py:566 src/olympia/devhub/templates/devhub/addons/submit/select-review.html:47 src/olympia/devhub/templates/devhub/docs/policies-reviews.html:153
 msgid "Preliminary Review"
 msgstr "Predhodni pregled"
 
@@ -4734,65 +3784,51 @@ msgid "Please choose a review nomination type"
 msgstr "Izberite vrsto predlaganja pregleda"
 
 #: src/olympia/devhub/forms.py:574
-msgid ""
-"A file with a version ending with a|alpha|b|beta|pre|rc and an optional "
-"number is detected as beta."
-msgstr ""
-"Datoteka z različico, ki se konča z a|alpha|b|beta|pre|rc in izbirno "
-"številko je zaznana kot beta."
+msgid "A file with a version ending with a|alpha|b|beta|pre|rc and an optional number is detected as beta."
+msgstr "Datoteka z različico, ki se konča z a|alpha|b|beta|pre|rc in izbirno številko je zaznana kot beta."
 
 #: src/olympia/devhub/forms.py:592
 #, python-format
-msgid "Version %s already exists"
-msgstr "Različica %s že obstaja"
+msgid "Version %s already exists, or was uploaded before."
+msgstr ""
 
-#: src/olympia/devhub/forms.py:604
-msgid ""
-"Select a valid choice. That choice is not one of the available choices."
+#: src/olympia/devhub/forms.py:605
+msgid "Select a valid choice. That choice is not one of the available choices."
 msgstr "Izberite veljavno izbiro. Ta izbira ni ena od tistih, ki so na voljo."
 
-#: src/olympia/devhub/forms.py:610
-msgid ""
-"A file with a version ending with a|alpha|b|beta and an optional number is "
-"detected as beta."
-msgstr ""
-"Datoteka, katere različica se končuje z a|alpha|b|beta ter neobvezno "
-"številko, je zaznana kot beta."
+#: src/olympia/devhub/forms.py:611
+msgid "A file with a version ending with a|alpha|b|beta and an optional number is detected as beta."
+msgstr "Datoteka, katere različica se končuje z a|alpha|b|beta ter neobvezno številko, je zaznana kot beta."
 
-#: src/olympia/devhub/forms.py:633
+#: src/olympia/devhub/forms.py:634
 msgid "You cannot upload any more files for this version."
 msgstr "Za to različico ne morete naložiti še več datotek."
 
-#: src/olympia/devhub/forms.py:639
+#: src/olympia/devhub/forms.py:640
 msgid "Version doesn't match"
 msgstr "Različica se ne ujema"
 
-#: src/olympia/devhub/forms.py:668
-msgid ""
-"You cannot delete a file once the review process has started.  You must "
-"delete the whole version."
+#: src/olympia/devhub/forms.py:669
+msgid "You cannot delete a file once the review process has started.  You must delete the whole version."
 msgstr ""
-"Ko se je postopek pregleda enkrat začel, datoteke ni mogoče izbrisati.  "
-"Morate izbrisati celotno različico."
 
-#: src/olympia/devhub/forms.py:688
+#: src/olympia/devhub/forms.py:689
 msgid "The platform All cannot be combined with specific platforms."
 msgstr "Platforme Vse ni mogoče kombinirati s posebnimi platformami."
 
-#: src/olympia/devhub/forms.py:693
+#: src/olympia/devhub/forms.py:694
 msgid "A platform can only be chosen once."
 msgstr "Platformo se lahko izbere samo enkrat."
 
-#: src/olympia/devhub/forms.py:706
+#: src/olympia/devhub/forms.py:707
 msgid "A review type must be selected."
 msgstr "Izbrati je treba vrsto pregleda."
 
-#: src/olympia/devhub/forms.py:788 src/olympia/editors/forms.py:114
-#: src/olympia/zadmin/forms.py:49 src/olympia/zadmin/forms.py:52
+#: src/olympia/devhub/forms.py:789 src/olympia/editors/forms.py:114 src/olympia/editors/forms.py:254 src/olympia/zadmin/forms.py:49 src/olympia/zadmin/forms.py:52
 msgid "Select an application first"
 msgstr "Izberite prosim najprej aplikacijo"
 
-#: src/olympia/devhub/forms.py:840
+#: src/olympia/devhub/forms.py:841
 msgid "There cannot be more than 3 required add-ons."
 msgstr "Več kot 3 aplikacije se ne more zahtevati."
 
@@ -4808,110 +3844,96 @@ msgstr "Moji prispevki"
 msgid "Developer Docs"
 msgstr "Dokumentacija za razvijalce"
 
-#. L10n: first parameter is the number of errors
 # {0} is a number
+#. L10n: first parameter is the number of errors
 #: src/olympia/devhub/helpers.py:200
 msgid "{0} error"
 msgid_plural "{0} errors"
 msgstr[0] "{0} napaka"
 msgstr[1] "{0} napaki"
-msgstr[2] "{0} napake"
-msgstr[3] "{0} napak"
 
-#. L10n: first parameter is the number of warnings
 # {0} is a number
+#. L10n: first parameter is the number of warnings
 #: src/olympia/devhub/helpers.py:203
 msgid "{0} warning"
 msgid_plural "{0} warnings"
 msgstr[0] "{0} opozorilo"
 msgstr[1] "{0} opozorili"
-msgstr[2] "{0} opozorila"
-msgstr[3] "{0} opozoril"
 
-#: src/olympia/devhub/models.py:375
-#: src/olympia/reviews/templates/reviews/add.html:58
+#: src/olympia/devhub/models.py:375 src/olympia/reviews/templates/reviews/add.html:58
 msgid "Review"
 msgstr "Pregled"
 
-#: src/olympia/devhub/tasks.py:551
+#: src/olympia/devhub/tasks.py:583
 #, python-format
 msgid "%s responded with %s (%s)."
 msgstr "%s odgovoril %s (%s)."
 
-#: src/olympia/devhub/tasks.py:555
+#: src/olympia/devhub/tasks.py:587
 #, python-format
 msgid "Connection to \"%s\" timed out."
 msgstr "Povezava z \"%s\" je pretekla."
 
-#: src/olympia/devhub/tasks.py:557
+#: src/olympia/devhub/tasks.py:589
 #, python-format
 msgid "Could not contact host at \"%s\"."
 msgstr "Ni prišlo do stika z gostiteljem na \"%s\"."
 
-#: src/olympia/devhub/utils.py:104
+#: src/olympia/devhub/utils.py:105
 #, python-format
-msgid ""
-"Validation generated too many errors/warnings so %s messages were truncated."
-" After addressing the visible messages, you'll be able to see the others."
-msgstr ""
-"Med preverjanjem veljavnosti je prišlo do preveč napak/opozoril, tako da je "
-"bilo %s sporočil skrajšanih. Ko enkrat spravite v red vidna sporočila, boste"
-" lahko videli tudi preostala."
+msgid "Validation generated too many errors/warnings so %s messages were truncated. After addressing the visible messages, you'll be able to see the others."
+msgstr "Med preverjanjem veljavnosti je prišlo do preveč napak/opozoril, tako da je bilo %s sporočil skrajšanih. Ko enkrat spravite v red vidna sporočila, boste lahko videli tudi preostala."
 
-#: src/olympia/devhub/views.py:183
+#: src/olympia/devhub/views.py:181
 msgid "All My Add-ons"
 msgstr "Vsi moji dodatki"
 
-#: src/olympia/devhub/views.py:210
+#: src/olympia/devhub/views.py:208
 msgid "All Activity"
 msgstr "Vsa aktivnost"
 
-#: src/olympia/devhub/views.py:211
+#: src/olympia/devhub/views.py:209
 msgid "Add-on Updates"
 msgstr "Posodobitve dodatkov"
 
-#: src/olympia/devhub/views.py:212
+#: src/olympia/devhub/views.py:210
 msgid "Add-on Status"
 msgstr "Stanje dodatka"
 
-#: src/olympia/devhub/views.py:213
+#: src/olympia/devhub/views.py:211
 msgid "User Collections"
 msgstr "Uporabniške zbirke"
 
-#: src/olympia/devhub/views.py:214
-#: src/olympia/devhub/templates/devhub/docs/policies-maintenance.html:68
-#: src/olympia/pages/templates/pages/dev_faq.html:38
+#: src/olympia/devhub/views.py:212 src/olympia/devhub/templates/devhub/docs/policies-maintenance.html:68 src/olympia/pages/templates/pages/dev_faq.html:38
 #: src/olympia/pages/templates/pages/dev_faq.html:484
 msgid "User Reviews"
 msgstr "Ocene uporabnikov"
 
-#: src/olympia/devhub/views.py:327 src/olympia/devhub/views.py:331
-#: src/olympia/devhub/views.py:484 src/olympia/devhub/views.py:513
-#: src/olympia/devhub/views.py:564 src/olympia/devhub/views.py:1150
+#: src/olympia/devhub/views.py:325 src/olympia/devhub/views.py:329 src/olympia/devhub/views.py:484 src/olympia/devhub/views.py:513 src/olympia/devhub/views.py:564 src/olympia/devhub/views.py:1156
 msgid "Changes successfully saved."
 msgstr "Spremembe uspešno shranjene."
 
-#: src/olympia/devhub/views.py:334 src/olympia/devhub/views.py:1631
+#: src/olympia/devhub/views.py:332 src/olympia/devhub/views.py:1637
 msgid "Please check the form for errors."
 msgstr "Prosimo, poiščite napake v obrazcu."
 
-#: src/olympia/devhub/views.py:346
+#: src/olympia/devhub/views.py:344
 msgid "Add-on cannot be deleted. Disable this add-on instead."
 msgstr "Dodatka ni mogoče zbrisati. Namesto tega ga onemogočite."
 
-#: src/olympia/devhub/views.py:356
+#: src/olympia/devhub/views.py:354
 msgid "Theme deleted."
 msgstr "Tema zbrisana."
 
-#: src/olympia/devhub/views.py:356
+#: src/olympia/devhub/views.py:354
 msgid "Add-on deleted."
 msgstr "Dodatek izbrisan."
 
-#: src/olympia/devhub/views.py:362
+#: src/olympia/devhub/views.py:360
 msgid "URL name was incorrect. Theme was not deleted."
 msgstr "Ime URL-ja je nepravilno. Tema ni bila izbrisana."
 
-#: src/olympia/devhub/views.py:367
+#: src/olympia/devhub/views.py:365
 msgid "URL name was incorrect. Add-on was not deleted."
 msgstr "Ime URL-ja je nepravilno. Dodatek ni bil izbrisan."
 
@@ -4939,7 +3961,7 @@ msgstr "Preveri veljavnost dodatka"
 msgid "Check Add-on Compatibility"
 msgstr "Preveri združljivost dodatka"
 
-#: src/olympia/devhub/views.py:808 src/olympia/signing/views.py:90
+#: src/olympia/devhub/views.py:808 src/olympia/signing/views.py:95
 msgid "You cannot submit this type of add-on"
 msgstr "Te vrste dodatka ne morete oddati"
 
@@ -4969,54 +3991,39 @@ msgstr "Slike morajo biti široke natanko {0} pikslov in visoke {1} pikslov."
 msgid "There was an error uploading your preview."
 msgstr "Med nalaganjem predogleda je prišlo do napake."
 
-#: src/olympia/devhub/views.py:1189
+#: src/olympia/devhub/views.py:1195
 #, python-format
 msgid "Version %s disabled."
 msgstr "Različica %s onemogočena."
 
-#: src/olympia/devhub/views.py:1193
+#: src/olympia/devhub/views.py:1199
 #, python-format
 msgid "Version %s deleted."
 msgstr "Različica %s izbrisana."
 
-#: src/olympia/devhub/views.py:1203
-msgid ""
-"This upload has failed validation, and may lack complete validation results."
-" Please take due care when reviewing it."
-msgstr ""
-"Ta prenos ni opravil preverjanja veljavnosti in morda rezultati preverjanja "
-"veljavnosti ne bodo v celoti na razpolago. Bodite pozorni, ko ga boste "
-"pregledovali."
+#: src/olympia/devhub/views.py:1209
+msgid "This upload has failed validation, and may lack complete validation results. Please take due care when reviewing it."
+msgstr "Ta prenos ni opravil preverjanja veljavnosti in morda rezultati preverjanja veljavnosti ne bodo v celoti na razpolago. Bodite pozorni, ko ga boste pregledovali."
 
-#: src/olympia/devhub/views.py:1677
+#: src/olympia/devhub/views.py:1683
 msgid "Preliminary Review Requested."
 msgstr "Zahteva se predhodni pregled."
 
-#: src/olympia/devhub/views.py:1678
+#: src/olympia/devhub/views.py:1684
 msgid "Full Review Requested."
 msgstr "Zahteva se popoln pregled."
 
-#: src/olympia/devhub/views.py:1779
-msgid ""
-"Your old credentials were revoked and are no longer valid. Be sure to update"
-" all API clients with the new credentials."
-msgstr ""
-"Vaša stara poverila so bila preklicana in niso več veljavna. Prepričajte se,"
-" da posodobite vse odjemalce API z novimi poverili."
+#: src/olympia/devhub/views.py:1783
+msgid "Your old credentials were revoked and are no longer valid. Be sure to update all API clients with the new credentials."
+msgstr "Vaša stara poverila so bila preklicana in niso več veljavna. Prepričajte se, da posodobite vse odjemalce API z novimi poverili."
 
-#: src/olympia/devhub/views.py:1797
+#: src/olympia/devhub/views.py:1801
 msgid "New API key created"
 msgstr "Nov ključ API ustvarjen"
 
 #: src/olympia/devhub/templates/devhub/agreement.html:2
-msgid ""
-"Before starting, please read and accept our Firefox Add-on Distribution "
-"Agreement. It also links to our Privacy Notice which explains how we handle "
-"your information."
-msgstr ""
-"Pred začetkom si preberite in sprejmite Sporazum o razširjanju Firefoxovih "
-"dodatkov. Povezuje se tudi na naše Obvestilo o zasebnosti, ki razlaga, kako "
-"ravnamo z vašimi podatki."
+msgid "Before starting, please read and accept our Firefox Add-on Distribution Agreement. It also links to our Privacy Notice which explains how we handle your information."
+msgstr "Pred začetkom si preberite in sprejmite Sporazum o razširjanju Firefoxovih dodatkov. Povezuje se tudi na naše Obvestilo o zasebnosti, ki razlaga, kako ravnamo z vašimi podatki."
 
 #: src/olympia/devhub/templates/devhub/agreement.html:13
 msgid "Printable Version"
@@ -5030,44 +4037,30 @@ msgstr "S tem sporazumom se strinjam"
 msgid "or <a href=\"{0}\">Cancel</a>"
 msgstr "ali <a href=\"{0}\">Prekliči</a>"
 
-#: src/olympia/devhub/templates/devhub/base.html:23
-#: src/olympia/devhub/templates/devhub/base_impala.html:20
-#: src/olympia/discovery/templates/discovery/addons/base.html:17
+#: src/olympia/devhub/templates/devhub/base.html:23 src/olympia/devhub/templates/devhub/base_impala.html:20 src/olympia/discovery/templates/discovery/addons/base.html:17
 msgid "Back to Add-ons"
 msgstr "Nazaj na dodatke"
 
 #. {0} is a search term, such as Firebug.
 #. {0} is a search query.
-#: src/olympia/devhub/templates/devhub/devhub_search.html:4
-#: src/olympia/search/templates/search/results.html:9
-#: src/olympia/search/templates/search/mobile/results.html:6
+#: src/olympia/devhub/templates/devhub/devhub_search.html:4 src/olympia/search/templates/search/results.html:9 src/olympia/search/templates/search/mobile/results.html:6
 msgid "{0} :: Search"
 msgstr "{0} :: Išči"
 
-#: src/olympia/devhub/templates/devhub/devhub_search.html:6
-#: src/olympia/devhub/templates/devhub/search.html:8
-#: src/olympia/editors/forms.py:435 src/olympia/editors/forms.py:437
-#: src/olympia/editors/templates/editors/queue.html:27
-#: src/olympia/editors/templates/editors/themes/queue_list.html:14
-#: src/olympia/search/templates/search/collections.html:17
-#: src/olympia/search/templates/search/personas.html:18
-#: src/olympia/search/templates/search/results.html:18
-#: src/olympia/search/templates/search/mobile/results.html:8
-#: src/olympia/templates/search.html:14
-#: src/olympia/templates/impala/search.html:18
+#: src/olympia/devhub/templates/devhub/devhub_search.html:6 src/olympia/devhub/templates/devhub/search.html:8 src/olympia/editors/forms.py:534 src/olympia/editors/forms.py:536
+#: src/olympia/editors/templates/editors/queue.html:27 src/olympia/editors/templates/editors/themes/queue_list.html:14 src/olympia/search/templates/search/collections.html:17
+#: src/olympia/search/templates/search/personas.html:18 src/olympia/search/templates/search/results.html:18 src/olympia/search/templates/search/mobile/results.html:8
+#: src/olympia/templates/search.html:14 src/olympia/templates/impala/search.html:18
 msgid "Search"
 msgstr "Iskanje"
 
-#: src/olympia/devhub/templates/devhub/devhub_search.html:11
-#: src/olympia/devhub/templates/devhub/devhub_search.html:15
-#: src/olympia/search/templates/search/collections.html:18
+#: src/olympia/devhub/templates/devhub/devhub_search.html:11 src/olympia/devhub/templates/devhub/devhub_search.html:15 src/olympia/search/templates/search/collections.html:18
 #: src/olympia/search/templates/search/personas.html:20
 msgid "Search Results"
 msgstr "Rezultati iskanja"
 
 #. {0} is a search term, such as Firebug.
-#: src/olympia/devhub/templates/devhub/devhub_search.html:13
-#: src/olympia/search/templates/search/results.html:11
+#: src/olympia/devhub/templates/devhub/devhub_search.html:13 src/olympia/search/templates/search/results.html:11
 msgid "Search Results for \"{0}\""
 msgstr "Rezultati iskanja za: \"{0}\""
 
@@ -5088,12 +4081,8 @@ msgid "AMO Reviewers"
 msgstr "Pregledovalci AMO"
 
 #: src/olympia/devhub/templates/devhub/index.html:29
-msgid ""
-"Get ahead! Become an AMO Reviewer today and get your add-ons reviewed "
-"faster."
-msgstr ""
-"Prehitite vrsto! Postanite pregledovalec AMO še danes in poskrbite, da bodo "
-"vaši dodatki pregledani hitreje."
+msgid "Get ahead! Become an AMO Reviewer today and get your add-ons reviewed faster."
+msgstr "Prehitite vrsto! Postanite pregledovalec AMO še danes in poskrbite, da bodo vaši dodatki pregledani hitreje."
 
 #: src/olympia/devhub/templates/devhub/index.html:32
 msgid "Become an AMO Reviewer"
@@ -5105,41 +4094,28 @@ msgstr "Naučite se vse o dodatkih"
 
 #: src/olympia/devhub/templates/devhub/index.html:41
 msgid ""
-"Add-ons let millions of Firefox users enhance and customize their browsing "
-"experience. If you're a Web developer and know <a "
-"href=\"https://developer.mozilla.org/docs/Web/HTML\">HTML</a>, <a "
-"href=\"https://developer.mozilla.org/docs/Web/JavaScript\">JavaScript</a>, "
-"and <a href=\"https://developer.mozilla.org/docs/Web/CSS\">CSS</a>, you "
-"already have all the necessary skills to make a great add-on."
+"Add-ons let millions of Firefox users enhance and customize their browsing experience. If you're a Web developer and know <a href=\"https://developer.mozilla.org/docs/Web/HTML\">HTML</a>, <a href="
+"\"https://developer.mozilla.org/docs/Web/JavaScript\">JavaScript</a>, and <a href=\"https://developer.mozilla.org/docs/Web/CSS\">CSS</a>, you already have all the necessary skills to make a great "
+"add-on."
 msgstr ""
-"Dodatki omogočajo milijonim Firefoxovih uporabnikov izboljšanje in "
-"prilagoditev njihove izkušnje brskanja. Če ste spletni razvijalec in znate "
-"<a href=\"https://developer.mozilla.org/docs/Web/HTML\">HTML</a>, <a "
-"href=\"https://developer.mozilla.org/docs/Web/JavaScript\">JavaScript</a> in"
-" <a href=\"https://developer.mozilla.org/docs/Web/CSS\">CSS</a>, že imate "
-"vse potrebne izkušnje za ustvarjanje imenitnih dodatkov."
+"Dodatki omogočajo milijonim Firefoxovih uporabnikov izboljšanje in prilagoditev njihove izkušnje brskanja. Če ste spletni razvijalec in znate <a href=\"https://developer.mozilla.org/docs/Web/HTML"
+"\">HTML</a>, <a href=\"https://developer.mozilla.org/docs/Web/JavaScript\">JavaScript</a> in <a href=\"https://developer.mozilla.org/docs/Web/CSS\">CSS</a>, že imate vse potrebne izkušnje za "
+"ustvarjanje imenitnih dodatkov."
 
 #: src/olympia/devhub/templates/devhub/index.html:51
-msgid ""
-"Head over to the <a href=\"https://developer.mozilla.org/Add-ons\">Mozilla "
-"Developer Network</a> to learn everything you need to know to get started."
-msgstr ""
-"Obiščite <a href=\"https://developer.mozilla.org/Add-ons\">Mozilla Developer"
-" Network</a>, da spoznate vse, kar je potrebno vedeti za začetek."
+msgid "Head over to the <a href=\"https://developer.mozilla.org/Add-ons\">Mozilla Developer Network</a> to learn everything you need to know to get started."
+msgstr "Obiščite <a href=\"https://developer.mozilla.org/Add-ons\">Mozilla Developer Network</a>, da spoznate vse, kar je potrebno vedeti za začetek."
 
 #: src/olympia/devhub/templates/devhub/index.html:58
 msgid "Start Making Add-ons"
 msgstr "Začni delati dodatke"
 
-#: src/olympia/devhub/templates/devhub/index.html:86
-#: src/olympia/devhub/templates/devhub/addons/listing/items.html:25
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:15
+#: src/olympia/devhub/templates/devhub/index.html:86 src/olympia/devhub/templates/devhub/addons/listing/items.html:25 src/olympia/devhub/templates/devhub/includes/addon_details.html:20
 #: src/olympia/devhub/templates/devhub/personas/edit.html:43
 msgid "Status:"
 msgstr "Stanje:"
 
-#: src/olympia/devhub/templates/devhub/index.html:90
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:100
+#: src/olympia/devhub/templates/devhub/index.html:90 src/olympia/devhub/templates/devhub/includes/addon_details.html:87
 msgid "Visibility:"
 msgstr "Vidnost:"
 
@@ -5147,22 +4123,17 @@ msgstr "Vidnost:"
 msgid "Latest Version:"
 msgstr "Najnovejša različica:"
 
-#: src/olympia/devhub/templates/devhub/index.html:109
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:145
-#: src/olympia/devhub/templates/devhub/personas/edit.html:49
+#: src/olympia/devhub/templates/devhub/index.html:109 src/olympia/devhub/templates/devhub/includes/addon_details.html:131 src/olympia/devhub/templates/devhub/personas/edit.html:49
 msgid "Queue Position:"
 msgstr "Mesto v čakalni vrsti:"
 
-#: src/olympia/devhub/templates/devhub/index.html:110
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:146
-#: src/olympia/devhub/templates/devhub/personas/edit.html:50
+#: src/olympia/devhub/templates/devhub/index.html:110 src/olympia/devhub/templates/devhub/includes/addon_details.html:132 src/olympia/devhub/templates/devhub/personas/edit.html:50
 #, python-format
 msgid "%(position)s of %(total)s"
 msgstr "%(position)s od skupaj %(total)s"
 
 # 90%
-#: src/olympia/devhub/templates/devhub/index.html:120
-#: src/olympia/devhub/templates/devhub/includes/addons_edit_nav.html:19
+#: src/olympia/devhub/templates/devhub/index.html:120 src/olympia/devhub/templates/devhub/includes/addons_edit_nav.html:19
 msgid "Upload New Version"
 msgstr "Naloži novo različico"
 
@@ -5176,12 +4147,8 @@ msgstr "Objavite svoje dodatke!"
 
 #: src/olympia/devhub/templates/devhub/index.html:136
 #, python-format
-msgid ""
-"Upload an <a href=\"%(addon_url)s\">add-on</a> or <a "
-"href=\"%(theme_url)s\">theme</a> to get started!"
-msgstr ""
-"Prenesite <a href=\"%(addon_url)s\">dodatek</a> ali <a "
-"href=\"%(theme_url)s\">temo</a>, da začnete!"
+msgid "Upload an <a href=\"%(addon_url)s\">add-on</a> or <a href=\"%(theme_url)s\">theme</a> to get started!"
+msgstr "Prenesite <a href=\"%(addon_url)s\">dodatek</a> ali <a href=\"%(theme_url)s\">temo</a>, da začnete!"
 
 #: src/olympia/devhub/templates/devhub/nav.html:2
 msgid "Return to the DevHub homepage"
@@ -5208,17 +4175,10 @@ msgstr "Razvoj dodatkov"
 msgid "Lightweight Themes"
 msgstr "Lahke teme"
 
-#: src/olympia/devhub/templates/devhub/nav.html:39
-#: src/olympia/devhub/templates/devhub/docs/policies-agreement.html:6
-#: src/olympia/devhub/templates/devhub/docs/policies-contact.html:6
-#: src/olympia/devhub/templates/devhub/docs/policies-maintenance.html:6
-#: src/olympia/devhub/templates/devhub/docs/policies-recommended.html:6
-#: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:6
-#: src/olympia/devhub/templates/devhub/docs/policies-submission.html:6
-#: src/olympia/devhub/templates/devhub/docs/policies.html:3
-#: src/olympia/devhub/templates/devhub/docs/policies.html:9
-#: src/olympia/devhub/templates/devhub/docs/policies.html:38
-#: src/olympia/devhub/templates/devhub/docs/policies.html:39
+#: src/olympia/devhub/templates/devhub/nav.html:39 src/olympia/devhub/templates/devhub/docs/policies-agreement.html:6 src/olympia/devhub/templates/devhub/docs/policies-contact.html:6
+#: src/olympia/devhub/templates/devhub/docs/policies-maintenance.html:6 src/olympia/devhub/templates/devhub/docs/policies-recommended.html:6
+#: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:6 src/olympia/devhub/templates/devhub/docs/policies-submission.html:6 src/olympia/devhub/templates/devhub/docs/policies.html:3
+#: src/olympia/devhub/templates/devhub/docs/policies.html:9 src/olympia/devhub/templates/devhub/docs/policies.html:38 src/olympia/devhub/templates/devhub/docs/policies.html:39
 msgid "Add-on Policies"
 msgstr "Politika za dodatke"
 
@@ -5259,44 +4219,16 @@ msgid "Use the field below to upload your add-on package."
 msgstr "Uporabite polje spodaj, da prenesete paket za svojo aplikacijo."
 
 #: src/olympia/devhub/templates/devhub/validate_addon.html:19
-msgid ""
-"After upload, a series of automated validation tests will run to check "
-"compatibility with the following application version:"
-msgstr ""
-"Po zaključenem prenosu se bo zagnal niz samodejnih preskusov za preverjanje "
-"veljavnosti, da se preveri združljivost z naslednjo različico programa:"
+msgid "After upload, a series of automated validation tests will run to check compatibility with the following application version:"
+msgstr "Po zaključenem prenosu se bo zagnal niz samodejnih preskusov za preverjanje veljavnosti, da se preveri združljivost z naslednjo različico programa:"
 
 #: src/olympia/devhub/templates/devhub/validate_addon.html:34
-msgid ""
-"After upload, a series of automated validation tests will be run on your "
-"file."
-msgstr ""
-"Po zaključenem prenosu se bo zagnal niz samodejnih preskusov za preverjanje "
-"veljavnosti vaše datoteke."
+msgid "After upload, a series of automated validation tests will be run on your file."
+msgstr "Po zaključenem prenosu se bo zagnal niz samodejnih preskusov za preverjanje veljavnosti vaše datoteke."
 
-#: src/olympia/devhub/templates/devhub/validate_addon.html:42
-#: src/olympia/devhub/templates/devhub/addons/submit/upload.html:23
+#: src/olympia/devhub/templates/devhub/validate_addon.html:42 src/olympia/devhub/templates/devhub/addons/submit/upload.html:23
 msgid "Do you want your add-on to be distributed on this site?"
 msgstr "Ali želite razširiti dvoj dodatek na tej strani?"
-
-#: src/olympia/devhub/templates/devhub/validate_addon.html:49
-#: src/olympia/devhub/templates/devhub/addons/submit/upload.html:30
-#: src/olympia/devhub/templates/devhub/versions/add_file_modal.html:14
-#: src/olympia/devhub/templates/devhub/versions/add_file_modal.html:53
-#: src/olympia/devhub/templates/devhub/versions/list.html:298
-msgid "Warning:"
-msgstr "Opozorilo:"
-
-#: src/olympia/devhub/templates/devhub/validate_addon.html:50
-#: src/olympia/devhub/templates/devhub/addons/submit/upload.html:31
-#, python-format
-msgid ""
-"Submission of unlisted add-ons for signing is currently in an open beta. "
-"Please <a href=\"%(url)s\" target=\"_blank\">report any bugs</a> that you "
-"encounter."
-msgstr ""
-"Predložitev navedenih dodatkov za podpisovanje je trenutno na odprti stopnji"
-" beta. <a href=\"%(url)s\" target=\"_blank\">Prijavite morebitne hrošče</a>."
 
 #. first parameter is a filename like lorem-ipsum-1.0.2.xpi
 #: src/olympia/devhub/templates/devhub/validation.html:5
@@ -5315,14 +4247,11 @@ msgstr "Veljavnost preverjena ob:"
 msgid "Tested for compatibility against:"
 msgstr "Testirano za združljivost z:"
 
-#: src/olympia/devhub/templates/devhub/addons/activity.html:4
-#: src/olympia/devhub/templates/devhub/addons/activity.html:20
+#: src/olympia/devhub/templates/devhub/addons/activity.html:4 src/olympia/devhub/templates/devhub/addons/activity.html:20
 msgid "Recent Activity for My Add-ons"
 msgstr "Nedavna aktivnost za Moji dodatki"
 
-#: src/olympia/devhub/templates/devhub/addons/activity.html:14
-#: src/olympia/devhub/templates/devhub/addons/activity.html:19
-#: src/olympia/devhub/templates/devhub/addons/dashboard.html:33
+#: src/olympia/devhub/templates/devhub/addons/activity.html:14 src/olympia/devhub/templates/devhub/addons/activity.html:19 src/olympia/devhub/templates/devhub/addons/dashboard.html:33
 msgid "Recent Activity"
 msgstr "Nedavne dejavnosti"
 
@@ -5344,44 +4273,33 @@ msgstr "Izboljšaj dejavnost"
 msgid "Activity"
 msgstr "Dejavnost"
 
-#: src/olympia/devhub/templates/devhub/addons/activity.html:83
-#: src/olympia/devhub/templates/devhub/addons/dashboard.html:34
-#: src/olympia/devhub/templates/devhub/addons/dashboard.html:35
-#: src/olympia/devhub/templates/devhub/includes/blog_posts.html:4
-#: src/olympia/devhub/templates/devhub/includes/blog_posts.html:6
+#: src/olympia/devhub/templates/devhub/addons/activity.html:83 src/olympia/devhub/templates/devhub/addons/dashboard.html:34 src/olympia/devhub/templates/devhub/addons/dashboard.html:35
+#: src/olympia/devhub/templates/devhub/includes/blog_posts.html:4 src/olympia/devhub/templates/devhub/includes/blog_posts.html:6
 msgid "Subscribe to this feed"
 msgstr "Naroči se na ta vir"
 
 #: src/olympia/devhub/templates/devhub/addons/ajax_compat_error.html:7
 #, python-format
 msgid ""
-"This add-on is incompatible with <b>%(app_name)s %(app_version)s</b>, the "
-"latest release of %(app_name)s. Please consider updating your add-on's "
-"compatibility info, or uploading a newer version of this add-on."
+"This add-on is incompatible with <b>%(app_name)s %(app_version)s</b>, the latest release of %(app_name)s. Please consider updating your add-on's compatibility info, or uploading a newer version of "
+"this add-on."
 msgstr ""
-"Ta dodatek ni združljiv s <b>%(app_name)som %(app_version)s</b>, najnovejšo "
-"različico %(app_name)sa. Razmislite o posodobitvi podatkov o združljivosti "
-"ali pa naložite novejšo različico tega dodatka."
+"Ta dodatek ni združljiv s <b>%(app_name)som %(app_version)s</b>, najnovejšo različico %(app_name)sa. Razmislite o posodobitvi podatkov o združljivosti ali pa naložite novejšo različico tega dodatka."
 
 #: src/olympia/devhub/templates/devhub/addons/ajax_compat_error.html:15
 #, python-format
 msgid ""
-"<a href=\"#\" class=\"button compat-update\" data-"
-"updateurl=\"%(update_url)s\">Update Compatibility</a> <a "
-"href=\"%(version_url)s\" class=\"button\">Upload New Version</a> or <a "
-"href=\"#\" class=\"close\">Ignore</a>"
+"<a href=\"#\" class=\"button compat-update\" data-updateurl=\"%(update_url)s\">Update Compatibility</a> <a href=\"%(version_url)s\" class=\"button\">Upload New Version</a> or <a href=\"#\" class="
+"\"close\">Ignore</a>"
 msgstr ""
-"<a href=\"#\" class=\"button compat-update\" data-"
-"updateurl=\"%(update_url)s\">Posodobi združljivost</a> <a "
-"href=\"%(version_url)s\" class=\"button\">Naloži novo različico</a>ali<a "
-"href=\"#\" class=\"close\">Prezri</a>"
+"<a href=\"#\" class=\"button compat-update\" data-updateurl=\"%(update_url)s\">Posodobi združljivost</a> <a href=\"%(version_url)s\" class=\"button\">Naloži novo različico</a>ali<a href=\"#\" class="
+"\"close\">Prezri</a>"
 
 #: src/olympia/devhub/templates/devhub/addons/ajax_compat_status.html:5
 msgid "View and update application compatibility ranges."
 msgstr "Ogled in posodabljanje razpona združljivosti za aplikacijo."
 
-#: src/olympia/devhub/templates/devhub/addons/ajax_compat_status.html:6
-#: src/olympia/devhub/templates/devhub/versions/edit.html:44
+#: src/olympia/devhub/templates/devhub/addons/ajax_compat_status.html:6 src/olympia/devhub/templates/devhub/versions/edit.html:44
 msgid "Compatibility"
 msgstr "Združljivost"
 
@@ -5389,39 +4307,25 @@ msgstr "Združljivost"
 msgid "Update Compatibility"
 msgstr "Posodobi združljivost"
 
-#: src/olympia/devhub/templates/devhub/addons/ajax_compat_update.html:4
-msgid ""
-"Adjusting application information here will allow users to install your add-"
-"on even if the install manifest in the package indicates that the add-on is "
-"incompatible."
-msgstr ""
-"Prilagojeni podatki za aplikacijo bodo omogočili uporabnikom, da namestijo "
-"vaš dodatek tudi v primeru, da po manifestu za namestitev dodatek ni "
-"združljiv."
+#: src/olympia/devhub/templates/devhub/addons/ajax_compat_update.html:4 src/olympia/devhub/templates/devhub/versions/edit.html:45
+msgid "Adjusting application information here will allow users to install your add-on even if the install manifest in the package indicates that the add-on is incompatible."
+msgstr "Prilagojeni podatki za aplikacijo bodo omogočili uporabnikom, da namestijo vaš dodatek tudi v primeru, da po manifestu za namestitev dodatek ni združljiv."
 
 #: src/olympia/devhub/templates/devhub/addons/ajax_compat_update.html:18
 msgid "Supported Versions"
 msgstr "Podprte različice"
 
-#: src/olympia/devhub/templates/devhub/addons/ajax_compat_update.html:31
-#: src/olympia/devhub/templates/devhub/versions/edit.html:63
+#: src/olympia/devhub/templates/devhub/addons/ajax_compat_update.html:31 src/olympia/devhub/templates/devhub/versions/edit.html:63
 msgid "Add Another Application&hellip;"
 msgstr "Dodaj drugo aplikacijo ..."
 
-#: src/olympia/devhub/templates/devhub/addons/ajax_compat_update.html:38
-#: src/olympia/devhub/templates/devhub/addons/owner.html:86
-#: src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:46
-#: src/olympia/devhub/templates/devhub/versions/list.html:351
-#: src/olympia/devhub/templates/devhub/versions/list.html:353
-#: src/olympia/templates/impala/base.html:132
-#: src/olympia/templates/impala/base.html:143
-#: src/olympia/templates/impala/base.html:161
-#: src/olympia/templates/impala/base.html:171
+#: src/olympia/devhub/templates/devhub/addons/ajax_compat_update.html:38 src/olympia/devhub/templates/devhub/addons/owner.html:86 src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:45
+#: src/olympia/devhub/templates/devhub/versions/list.html:349 src/olympia/devhub/templates/devhub/versions/list.html:351 src/olympia/templates/impala/base.html:129
+#: src/olympia/templates/impala/base.html:140 src/olympia/templates/impala/base.html:158 src/olympia/templates/impala/base.html:168
 msgid "Close"
 msgstr "Zapri"
 
-#: src/olympia/devhub/templates/devhub/addons/dashboard.html:43
-#: src/olympia/zadmin/templates/zadmin/index.html:22
+#: src/olympia/devhub/templates/devhub/addons/dashboard.html:43 src/olympia/zadmin/templates/zadmin/index.html:22
 #, python-format
 msgid "%(ago)s by %(user)s"
 msgstr "%(ago)s od %(user)s"
@@ -5436,32 +4340,22 @@ msgid "<b>{0}</b> theme"
 msgid_plural "<b>{0}</b> themes"
 msgstr[0] "<b>{0}</b> tema"
 msgstr[1] "<b>{0}</b> temi"
-msgstr[2] "<b>{0}</b> teme"
-msgstr[3] "<b>{0}</b> tem"
 
-#: src/olympia/devhub/templates/devhub/addons/edit.html:3
-#: src/olympia/devhub/templates/devhub/addons/listing/item_actions.html:25
-#: src/olympia/devhub/templates/devhub/addons/listing/item_actions_theme.html:7
-#: src/olympia/devhub/templates/devhub/includes/addons_edit_nav.html:2
-#: src/olympia/devhub/templates/devhub/personas/edit.html:6
-#: src/olympia/editors/templates/editors/themes/single.html:37
+#: src/olympia/devhub/templates/devhub/addons/edit.html:3 src/olympia/devhub/templates/devhub/addons/listing/item_actions.html:25
+#: src/olympia/devhub/templates/devhub/addons/listing/item_actions_theme.html:7 src/olympia/devhub/templates/devhub/includes/addons_edit_nav.html:2
+#: src/olympia/devhub/templates/devhub/personas/edit.html:6 src/olympia/editors/templates/editors/themes/single.html:37
 msgid "Edit Listing"
 msgstr "Uredi objavo"
 
-#: src/olympia/devhub/templates/devhub/addons/edit.html:13
-#: src/olympia/devhub/templates/devhub/includes/macros.html:18
-#: src/olympia/translations/templates/translations/all-locales.html:6
+#: src/olympia/devhub/templates/devhub/addons/edit.html:13 src/olympia/devhub/templates/devhub/includes/macros.html:18 src/olympia/translations/templates/translations/all-locales.html:6
 msgid "None"
 msgstr "Brez"
 
-#: src/olympia/devhub/templates/devhub/addons/owner.html:4
-#: src/olympia/devhub/templates/devhub/addons/listing/item_actions.html:52
-#: src/olympia/devhub/templates/devhub/includes/addons_edit_nav.html:3
+#: src/olympia/devhub/templates/devhub/addons/owner.html:4 src/olympia/devhub/templates/devhub/addons/listing/item_actions.html:52 src/olympia/devhub/templates/devhub/includes/addons_edit_nav.html:3
 msgid "Manage Authors & License"
 msgstr "Upravljanje z avtorji in licencami"
 
-#: src/olympia/devhub/templates/devhub/addons/owner.html:29
-#: src/olympia/editors/templates/editors/review.html:270
+#: src/olympia/devhub/templates/devhub/addons/owner.html:29 src/olympia/editors/helpers.py:362 src/olympia/editors/templates/editors/review.html:270
 msgid "Authors"
 msgstr "Avtorji"
 
@@ -5471,35 +4365,22 @@ msgstr "O vlog avtorjev"
 
 #: src/olympia/devhub/templates/devhub/addons/owner.html:78
 msgid ""
-"<p>Add-ons can have any number of authors with 3 possible roles:</p> <ul> "
-"<li><b>Owner:</b> Can manage all aspects of the add-on's listing, including "
-"adding and removing other authors</li> <li><b>Developer:</b> Can manage all "
-"aspects of the add-on's listing, except for adding and removing other "
-"authors and managing payments</li> <li><b>Viewer:</b> Can view the add-on's "
-"settings and statistics, but cannot make any changes</li> </ul>"
+"<p>Add-ons can have any number of authors with 3 possible roles:</p> <ul> <li><b>Owner:</b> Can manage all aspects of the add-on's listing, including adding and removing other authors</li> "
+"<li><b>Developer:</b> Can manage all aspects of the add-on's listing, except for adding and removing other authors and managing payments</li> <li><b>Viewer:</b> Can view the add-on's settings and "
+"statistics, but cannot make any changes</li> </ul>"
 msgstr ""
-"<p>Dodatki imajo lahko poljubno številko avtorjev z eno od naslednjih 3 "
-"možnih vlog:</p> <ul> <li><b>Lastnik:</b> Lahko skrbi za vse zadeve okoli "
-"dodatka, med drugim lahko dodaja ali odstranjuje druge avtorje</li> "
-"<li><b>Razvijalec:</b>Lahko skrbi za vse zadeve okoli dodatka, ne more pa "
-"dodajati ali odstranjevati drugih avtorjev in delati s plačili</li> "
-"<li><b>Opazovalec:</b> Ima dostop do prikazov in statistike, vendar ne more "
-"spreminjati ničesar</li> </ul>"
+"<p>Dodatki imajo lahko poljubno številko avtorjev z eno od naslednjih 3 možnih vlog:</p> <ul> <li><b>Lastnik:</b> Lahko skrbi za vse zadeve okoli dodatka, med drugim lahko dodaja ali odstranjuje "
+"druge avtorje</li> <li><b>Razvijalec:</b>Lahko skrbi za vse zadeve okoli dodatka, ne more pa dodajati ali odstranjevati drugih avtorjev in delati s plačili</li> <li><b>Opazovalec:</b> Ima dostop do "
+"prikazov in statistike, vendar ne more spreminjati ničesar</li> </ul>"
 
-#: src/olympia/devhub/templates/devhub/addons/profile.html:3
-#: src/olympia/devhub/templates/devhub/addons/listing/item_actions.html:53
-#: src/olympia/devhub/templates/devhub/includes/addons_edit_nav.html:4
+#: src/olympia/devhub/templates/devhub/addons/profile.html:3 src/olympia/devhub/templates/devhub/addons/listing/item_actions.html:53 src/olympia/devhub/templates/devhub/includes/addons_edit_nav.html:4
 msgid "Manage Developer Profile"
 msgstr "Upravljanje profila razvijalca"
 
 #: src/olympia/devhub/templates/devhub/addons/profile.html:16
 #, python-format
-msgid ""
-"Your <a href=\"%(url)s\">developer profile</a> is currently "
-"<strong>public</strong> and <strong>required</strong> for contributions."
-msgstr ""
-"Vaš <a href=\"%(url)s\">profil razvijalca</a> je trenutno "
-"<strong>javen</strong> in <strong>obvezen</strong> za plačevanje prispevkov."
+msgid "Your <a href=\"%(url)s\">developer profile</a> is currently <strong>public</strong> and <strong>required</strong> for contributions."
+msgstr "Vaš <a href=\"%(url)s\">profil razvijalca</a> je trenutno <strong>javen</strong> in <strong>obvezen</strong> za plačevanje prispevkov."
 
 #: src/olympia/devhub/templates/devhub/addons/profile.html:22
 msgid "Remove Both"
@@ -5507,12 +4388,8 @@ msgstr "Odstrani oboje"
 
 #: src/olympia/devhub/templates/devhub/addons/profile.html:27
 #, python-format
-msgid ""
-"Your <a href=\"%(url)s\">developer profile</a> is currently "
-"<strong>public</strong>."
-msgstr ""
-"Vaš <a href=\"%(url)s\">profil razvijalca</a> je trenutno "
-"<strong>javen</strong>."
+msgid "Your <a href=\"%(url)s\">developer profile</a> is currently <strong>public</strong>."
+msgstr "Vaš <a href=\"%(url)s\">profil razvijalca</a> je trenutno <strong>javen</strong>."
 
 #: src/olympia/devhub/templates/devhub/addons/profile.html:33
 msgid "Remove Profile"
@@ -5539,11 +4416,8 @@ msgstr "URL za dodatek"
 msgid "Choose a short, unique URL slug for your add-on."
 msgstr "Izberite kratko, enolično URL rekleto za vaš dodatek."
 
-#: src/olympia/devhub/templates/devhub/addons/edit/basic.html:43
-#: src/olympia/devhub/templates/devhub/includes/addons_edit_nav.html:35
-#: src/olympia/devhub/templates/devhub/personas/edit.html:56
-#: src/olympia/editors/templates/editors/review.html:255
-#: src/olympia/editors/templates/editors/themes/single.html:33
+#: src/olympia/devhub/templates/devhub/addons/edit/basic.html:43 src/olympia/devhub/templates/devhub/includes/addons_edit_nav.html:35 src/olympia/devhub/templates/devhub/personas/edit.html:56
+#: src/olympia/editors/templates/editors/review.html:255 src/olympia/editors/templates/editors/themes/single.html:33
 msgid "View Listing"
 msgstr "Prikaži objave"
 
@@ -5553,10 +4427,7 @@ msgstr "Povzetek"
 
 #: src/olympia/devhub/templates/devhub/addons/edit/basic.html:52
 msgid ""
-"A short explanation of your add-on's basic\n"
-"                          functionality that is displayed in search and browse\n"
-"                          listings, as well as at the top of your add-on's\n"
-"                          details page. It is only relevant for listed add-ons."
+"A short explanation of your add-on's basic functionality that is displayed in search and browse listings, as well as at the top of your add-on's details page. It is only relevant for listed add-ons."
 msgstr ""
 "Kratek opis osnovnega delovanja vašega\n"
 "                          dodatka, ki je prikazan na seznamu iskanja in\n"
@@ -5564,10 +4435,7 @@ msgstr ""
 "                          dodatka.  To velja samo za dodatke na seznamu."
 
 #: src/olympia/devhub/templates/devhub/addons/edit/basic.html:73
-msgid ""
-"Categories are the primary way users browse through add-ons.\n"
-"                        Choose any that fit your add-on's functionality for the most\n"
-"                        exposure. It is only relevant for listed add-ons."
+msgid "Categories are the primary way users browse through add-ons. Choose any that fit your add-on's functionality for the most exposure. It is only relevant for listed add-ons."
 msgstr ""
 "Kategorije so glavni način brskanja uporabnikov po dodatkih.\n"
 "                        Izberite vse, ki ustrezajo funkcionalnosti vašega dodatka,\n"
@@ -5577,40 +4445,26 @@ msgstr ""
 #: src/olympia/devhub/templates/devhub/addons/edit/basic.html:90
 #, python-format
 msgid ""
-"Categories cannot be changed while your add-on is featured for this "
-"application. Please email <a href=\"mailto:%(email)s\">%(email)s</a> if "
-"there is a reason you need to modify your categories."
+"Categories cannot be changed while your add-on is featured for this application. Please email <a href=\"mailto:%(email)s\">%(email)s</a> if there is a reason you need to modify your categories."
 msgstr ""
-"Če se vaš izdelek nahaja med izbranimi dodatki za to aplikacijo, mu "
-"kategorij ni mogoče spreminjati. Pišite nam na naslednji naslov<a "
-"href=\"mailto:%(email)s\">%(email)s</a>, če imate razlog za spremembe v "
-"svojih kategorijah."
+"Če se vaš izdelek nahaja med izbranimi dodatki za to aplikacijo, mu kategorij ni mogoče spreminjati. Pišite nam na naslednji naslov<a href=\"mailto:%(email)s\">%(email)s</a>, če imate razlog za "
+"spremembe v svojih kategorijah."
 
 #: src/olympia/devhub/templates/devhub/addons/edit/basic.html:119
-msgid ""
-"Tags help users find your add-on and should be short\n"
-"                        descriptors such as tabs, toolbar, or twitter.  You\n"
-"                        may have a maximum of {0} tags. It is only relevant\n"
-"                        for listed add-ons."
+msgid "Tags help users find your add-on and should be short descriptors such as tabs, toolbar, or twitter. You may have a maximum of {0} tags. It is only relevant for listed add-ons."
 msgstr ""
 "Oznake uporabnikom pomagajo najti vaš dodatek in morajo\n"
 "                        biti kratki opisi, kot so zavihki, orodna vrstica ali\n"
 "                        twitter.  Imate lahko največ {0} oznak.  To velja samo\n"
 "                        za navedene dodatke."
 
-#: src/olympia/devhub/templates/devhub/addons/edit/basic.html:129
-#: src/olympia/devhub/templates/devhub/personas/edit.html:97
-#: src/olympia/devhub/templates/devhub/personas/submit.html:46
+#: src/olympia/devhub/templates/devhub/addons/edit/basic.html:129 src/olympia/devhub/templates/devhub/personas/edit.html:97 src/olympia/devhub/templates/devhub/personas/submit.html:46
 msgid "Comma-separated, minimum of {0} character."
 msgid_plural "Comma-separated, minimum of {0} characters."
 msgstr[0] "Ločene z vejicami, najmanj {0} znak."
 msgstr[1] "Ločene z vejicami, najmanj {0} znaka."
-msgstr[2] "Ločene z vejicami, najmanj {0} znaki."
-msgstr[3] "Ločene z vejicami, najmanj {0} znakov."
 
-#: src/olympia/devhub/templates/devhub/addons/edit/basic.html:132
-#: src/olympia/devhub/templates/devhub/personas/edit.html:100
-#: src/olympia/devhub/templates/devhub/personas/submit.html:49
+#: src/olympia/devhub/templates/devhub/addons/edit/basic.html:132 src/olympia/devhub/templates/devhub/personas/edit.html:100 src/olympia/devhub/templates/devhub/personas/submit.html:49
 msgid "Example: dark, cinema, noir. Limit 20."
 msgstr "Na primer: pop, gotik, rok. Meja 20."
 
@@ -5619,8 +4473,6 @@ msgid "Reserved tag:"
 msgid_plural "Reserved tags:"
 msgstr[0] "Rezervirana oznaka:"
 msgstr[1] "Rezervirani oznaki:"
-msgstr[2] "Rezervirane oznake:"
-msgstr[3] "Rezerviranih oznak:"
 
 #: src/olympia/devhub/templates/devhub/addons/edit/details.html:5
 msgid "Add-on Details"
@@ -5631,46 +4483,33 @@ msgid "Add-on Details for {0}"
 msgstr "Podrobnosti o dodatku za {0}"
 
 #: src/olympia/devhub/templates/devhub/addons/edit/details.html:22
-msgid ""
-"A longer explanation of features,\n"
-"                          functionality, and other relevant information. This\n"
-"                          field is only displayed on the add-on's details\n"
-"                          page. It is only relevant for listed add-ons."
+msgid "A longer explanation of features, functionality, and other relevant information. This field is only displayed on the add-on's details page. It is only relevant for listed add-ons."
 msgstr ""
 "Daljši opis značilnosti, delovanja\n"
 "                          in drugi pomembni podatki.  To polje je prikazano\n"
 "                          samo na strani s podrobnostmi dodatka.  To velja\n"
 "                          samo za navedene dodatke."
 
-#: src/olympia/devhub/templates/devhub/addons/edit/details.html:44
-#: src/olympia/translations/templates/translations/trans-menu.html:13
+#: src/olympia/devhub/templates/devhub/addons/edit/details.html:44 src/olympia/translations/templates/translations/trans-menu.html:13
 msgid "Default Locale"
 msgstr "Prednastavljena območna nastavitev"
 
 #: src/olympia/devhub/templates/devhub/addons/edit/details.html:45
-msgid ""
-"Information about your add-on is displayed in this locale\n"
-"                        unless you override it with a locale-specific translation.\n"
-"                        It is only relevant for listed add-ons."
+msgid "Information about your add-on is displayed in this locale unless you override it with a locale-specific translation. It is only relevant for listed add-ons."
 msgstr ""
 "Podatki o vašem dodatku so prikazani v tem jeziku,\n"
 "                        razen če ga ne preglasite z drugim.  To velja samo za\n"
 "                        navedene dodatke."
 
-#: src/olympia/devhub/templates/devhub/addons/edit/details.html:61
-#: src/olympia/users/forms.py:311
-#: src/olympia/users/templates/users/edit.html:122
-#: src/olympia/users/templates/users/register.html:57
+#: src/olympia/devhub/templates/devhub/addons/edit/details.html:61 src/olympia/users/forms.py:311 src/olympia/users/templates/users/edit.html:122 src/olympia/users/templates/users/register.html:57
 #: src/olympia/users/templates/users/vcard.html:22
 msgid "Homepage"
 msgstr "Domača stran"
 
 #: src/olympia/devhub/templates/devhub/addons/edit/details.html:63
 msgid ""
-"If your add-on has another homepage, enter its\n"
-"                          address here. If your website is localized into other\n"
-"                          languages multiple translations of this field can be\n"
-"                          added. It is only relevant for listed add-ons."
+"If your add-on has another homepage, enter its address here. If your website is localized into other languages multiple translations of this field can be added. It is only relevant for listed add-"
+"ons."
 msgstr ""
 "Če ima vaš dodatek drugo domačo stran, tukaj\n"
 "                          vnesite njegov naslov.  Če je spletna stran prevedena\n"
@@ -5692,11 +4531,8 @@ msgstr "Informacije o podpori za {0}"
 
 #: src/olympia/devhub/templates/devhub/addons/edit/support.html:22
 msgid ""
-"If you wish to display an e-mail address for support\n"
-"                          inquiries, enter it here. If you have different\n"
-"                          addresses for each language multiple translations of\n"
-"                          this field can be added. It is only relevant for\n"
-"                          listed add-ons."
+"If you wish to display an e-mail address for support inquiries, enter it here. If you have different addresses for each language multiple translations of this field can be added. It is only "
+"relevant for listed add-ons."
 msgstr ""
 "Če želite prikazati e-poštni naslov za prošnje za\n"
 "                          podporo, jo vnesite tukaj.  Če imate za vsak jezik\n"
@@ -5705,10 +4541,8 @@ msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/support.html:45
 msgid ""
-"If your add-on has a support website or forum, enter\n"
-"                          its address here. If your website is localized into\n"
-"                          other languages, multiple translations of this field can\n"
-"                          be added. It is only relevant for listed add-ons."
+"If your add-on has a support website or forum, enter its address here. If your website is localized into other languages, multiple translations of this field can be added. It is only relevant for "
+"listed add-ons."
 msgstr ""
 "Če ima vaš dodatek spletno stran za podporo ali\n"
 "                          forum, tukaj vnesite njegov naslov.  Če je spletna stran\n"
@@ -5726,11 +4560,8 @@ msgstr "Tehnične podrobnosti za {0}"
 
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:23
 msgid ""
-"Any information end users may want to know that isn't\n"
-"                          necessarily applicable to the add-on summary or description.\n"
-"                          Common uses include listing known major bugs, information on\n"
-"                          how to report bugs, anticipated release date of a new version,\n"
-"                          etc. It is only relevant for listed add-ons."
+"Any information end users may want to know that isn't necessarily applicable to the add-on summary or description. Common uses include listing known major bugs, information on how to report bugs, "
+"anticipated release date of a new version, etc. It is only relevant for listed add-ons."
 msgstr ""
 "Vsi podatki, ki bi jih uporabniki morda želeli vedeti,\n"
 "                          ampak se ne nanašajo nujno na povzetek ali opis dodatka.\n"
@@ -5747,9 +4578,7 @@ msgid "Add-on Flags"
 msgstr "Zastavice za dodatek"
 
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:69
-msgid ""
-"These flags are used to classify add-ons. It is only\n"
-"                        relevant for listed add-ons."
+msgid "These flags are used to classify add-ons. It is only relevant for listed add-ons."
 msgstr ""
 "Te oznake se uporabljajo za razvrščanje dodatkov.\n"
 "                        To velja samo za navedene dodatke."
@@ -5767,9 +4596,7 @@ msgid "View Source?"
 msgstr "Izvor viden?"
 
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:90
-msgid ""
-"Whether the source of your add-on can be displayed in our\n"
-"                        online viewer. It is only relevant for listed add-ons."
+msgid "Whether the source of your add-on can be displayed in our online viewer. It is only relevant for listed add-ons."
 msgstr ""
 "Ali naj se izvorna koda vašega dodatka prikaže v našem spletnem\n"
 "                        pregledovalniku.  To velja samo za navedene dodatke."
@@ -5787,10 +4614,7 @@ msgid "Public Stats?"
 msgstr "Javna statistika?"
 
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:102
-msgid ""
-"Whether the download and usage stats of your add-on can\n"
-"                        be displayed in our online viewer.\n"
-"                        It is only relevant for listed add-ons."
+msgid "Whether the download and usage stats of your add-on can be displayed in our online viewer. It is only relevant for listed add-ons."
 msgstr ""
 "Ali naj bo statistika prenosov in uporabe vašega dodatka\n"
 "                        prikazana v našem spletnem pregledovalniku.\n"
@@ -5809,19 +4633,14 @@ msgid "Upgrade SDK?"
 msgstr "Posodobiti SDK?"
 
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:116
-msgid ""
-"If selected, we will try to automatically upgrade your\n"
-"                        add-on when a new version of the SDK is released.\n"
-"                        It is only relevant for listed add-ons."
+msgid "If selected, we will try to automatically upgrade your add-on when a new version of the SDK is released. It is only relevant for listed add-ons."
 msgstr ""
 "Če je izbrano, bomo samodejno poizkušali nadgraditi\n"
 "                        vaš dodatek, ko je izdana nova različica SDK-ja.\n"
 "                        To velja samo za navedene dodatke."
 
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:121
-msgid ""
-"This add-on will be automatically upgraded to new versions of the Add-on "
-"SDK."
+msgid "This add-on will be automatically upgraded to new versions of the Add-on SDK."
 msgstr "Ta dodatek se bo samodejno nadgradilo na novo SDK za dodatke."
 
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:123
@@ -5837,30 +4656,20 @@ msgid "UUID"
 msgstr "UUID"
 
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:132
-msgid ""
-"The UUID of your add-on is specified in its install manifest and uniquely "
-"identifies it. You cannot change your UUID once it has been submitted."
-msgstr ""
-"UUID vašega dodatka je naveden v njegovem manifestu za namestitev in ga "
-"enolično identificira. Ko ste dodatek enkrat poslali, UUID zanj ne morete "
-"več spremeniti."
+msgid "The UUID of your add-on is specified in its install manifest and uniquely identifies it. You cannot change your UUID once it has been submitted."
+msgstr "UUID vašega dodatka je naveden v njegovem manifestu za namestitev in ga enolično identificira. Ko ste dodatek enkrat poslali, UUID zanj ne morete več spremeniti."
 
-#: src/olympia/devhub/templates/devhub/addons/edit/technical.html:143
-#: src/olympia/devhub/templates/devhub/addons/edit/technical.html:144
+#: src/olympia/devhub/templates/devhub/addons/edit/technical.html:143 src/olympia/devhub/templates/devhub/addons/edit/technical.html:144
 msgid "Whiteboard"
 msgstr "Bela tabla"
 
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:146
 msgid ""
-"The whiteboard is the place to provide information relevant to your addon, "
-"whatever the version, to the editor. Use it to provide ways to test the "
-"addon, and any additional information that may help. This whiteboard is also"
-" editable by editors."
+"The whiteboard is the place to provide information relevant to your addon, whatever the version, to the editor. Use it to provide ways to test the addon, and any additional information that may "
+"help. This whiteboard is also editable by editors."
 msgstr ""
-"Bela oglasna deska je mesto, kjer lahko podate podatke, ki se nanašajo na "
-"vaš dodatek za posamezno različico, uredniku. Uporabite jo za določanje "
-"načinov preskušanja dodatka in vseh dodatnih pomožnih podatkov. Belo oglasno"
-" desko lahko urejajo tudi uredniki."
+"Bela oglasna deska je mesto, kjer lahko podate podatke, ki se nanašajo na vaš dodatek za posamezno različico, uredniku. Uporabite jo za določanje načinov preskušanja dodatka in vseh dodatnih "
+"pomožnih podatkov. Belo oglasno desko lahko urejajo tudi uredniki."
 
 #: src/olympia/devhub/templates/devhub/addons/edit/technical_dependencies.html:9
 msgid "Remove this dependent add-on"
@@ -5880,10 +4689,8 @@ msgstr "Sličica za dodatek"
 
 #: src/olympia/devhub/templates/devhub/addons/forms_shared/media.html:16
 msgid ""
-"Upload an icon for your add-on or choose from one of ours. The\n"
-"                      icon is displayed nearly everywhere your add-on is. Uploaded images\n"
-"                      must be one of the following image types: .png, .jpg.\n"
-"                      It is only relevant for listed add-ons."
+"Upload an icon for your add-on or choose from one of ours. The icon is displayed nearly everywhere your add-on is. Uploaded images must be one of the following image types: .png, .jpg. It is only "
+"relevant for listed add-ons."
 msgstr ""
 "Prenesite ikono za svoj dodatek ali izberite eno od naših.  Ikona\n"
 "                      je prikazana skoraj povsod, kjer je prikazan vaš dodatek.  Prenesene\n"
@@ -5900,9 +4707,7 @@ msgid "32x32px"
 msgstr "32 x 32 pik"
 
 #: src/olympia/devhub/templates/devhub/addons/forms_shared/media.html:39
-msgid ""
-"Used in listings of add-ons, like search results\n"
-"                            and featured add-ons."
+msgid "Used in listings of add-ons, like search results and featured add-ons."
 msgstr ""
 "Uporablja se na seznamih z dodatki, kot na primer\n"
 "                            v rezultatih iskanja ali pa na seznamu izbranih dodatkov."
@@ -5922,9 +4727,7 @@ msgstr "Nalaganje lastne sličice ..."
 
 #: src/olympia/devhub/templates/devhub/addons/forms_shared/media.html:65
 msgid "PNG and JPG supported. Icons resized to 64x64 pixels if larger."
-msgstr ""
-"Podprta sta PNG in JPG. Sličico se bo pomanjšalo na 64 x 64 pik, če bo "
-"prevelika."
+msgstr "Podprta sta PNG in JPG. Sličico se bo pomanjšalo na 64 x 64 pik, če bo prevelika."
 
 #: src/olympia/devhub/templates/devhub/addons/forms_shared/media.html:83
 msgid "Screenshots"
@@ -5946,94 +4749,75 @@ msgstr "Dodaj posnetek zaslona ..."
 msgid "Tests"
 msgstr "Preizkusi"
 
-#: src/olympia/devhub/templates/devhub/addons/includes/validation_compat_test_results.html:25
-#: src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:5
+#: src/olympia/devhub/templates/devhub/addons/includes/validation_compat_test_results.html:25 src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:5
 #: src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:53
 msgid "General Tests"
 msgstr "Splošni preizkusi"
 
-#: src/olympia/devhub/templates/devhub/addons/includes/validation_compat_test_results.html:32
-#: src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:9
+#: src/olympia/devhub/templates/devhub/addons/includes/validation_compat_test_results.html:32 src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:9
 #: src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:67
 msgid "Security Tests"
 msgstr "Preizkusi varnosti"
 
-#: src/olympia/devhub/templates/devhub/addons/includes/validation_compat_test_results.html:39
-#: src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:13
+#: src/olympia/devhub/templates/devhub/addons/includes/validation_compat_test_results.html:39 src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:13
 #: src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:80
 msgid "Extension Tests"
 msgstr "Preizkusi razširitve"
 
-#: src/olympia/devhub/templates/devhub/addons/includes/validation_compat_test_results.html:46
-#: src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:17
+#: src/olympia/devhub/templates/devhub/addons/includes/validation_compat_test_results.html:46 src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:17
 #: src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:93
 msgid "Localization Tests"
 msgstr "Preizkusi lokalizacije"
 
-#: src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:21
-#: src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:106
+#: src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:21 src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:106
 msgid "Compatibility Tests"
 msgstr "Preizkusi združljivosti"
 
-#: src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:29
-#: src/olympia/files/templates/files/viewer.html:142
+#: src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:29 src/olympia/files/templates/files/viewer.html:142
 msgid "Hide messages not required for automated signing"
 msgstr "Skrij sporočila, ki niso zahtevana za samodejno podpisovanje"
 
-#: src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:35
-#: src/olympia/files/templates/files/viewer.html:150
+#: src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:35 src/olympia/files/templates/files/viewer.html:150
 msgid "Hide messages present in previous version and ignored"
 msgstr "Skrij sporočila, ki so prisotna v prejšnjih različicah in prezrta"
 
-#: src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:50
-#: src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:64
-#: src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:77
-#: src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:90
+#: src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:50 src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:64
+#: src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:77 src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:90
 #: src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:103
 msgid "Top"
 msgstr "Vrh"
 
-#: src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:2
-#: src/olympia/devhub/templates/devhub/personas/edit.html:63
+#: src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:2 src/olympia/devhub/templates/devhub/personas/edit.html:63
 msgid "Delete Theme"
 msgstr "Izbriši temo"
 
-#: src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:2
-#: src/olympia/devhub/templates/devhub/versions/list.html:117
+#: src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:2 src/olympia/devhub/templates/devhub/versions/list.html:117
 msgid "Delete Add-on"
 msgstr "Izbriši dodatek"
 
 #: src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:11
 msgid "Deleting your theme will permanently remove it from the site."
-msgstr ""
-"Če svojo temo zbrišete, jo boste za vedno odstranili s spletne strani."
+msgstr "Če svojo temo zbrišete, jo boste za vedno odstranili s spletne strani."
 
 #: src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:14
-msgid ""
-"Deleting your add-on will permanently remove it from the site and prevent "
-"its GUID from being submitted again by others."
-msgstr ""
-"Če svoj dodatek izbrišete, ga boste za vedno odstranili s spletne strani in "
-"njegovega GUID-ja ne boste več mogli uporabiti."
+msgid "Deleting your add-on will permanently remove it from the site and prevent its GUID from being submitted again by others."
+msgstr "Če svoj dodatek izbrišete, ga boste za vedno odstranili s spletne strani in njegovega GUID-ja ne boste več mogli uporabiti."
 
 #: src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:24
-msgid ""
-"Enter the following text confirm your decision:\n"
-"           {slug}"
+msgid "Enter the following text confirm your decision: {slug}"
 msgstr ""
 "Vnesite naslednje besedilo, da potrdite svojo\n"
 "           odločitev: {slug}"
 
-#: src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:34
+#: src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:33
 msgid "Please tell us why you are deleting your theme:"
 msgstr "Povejte nam, zakaj brišete svojo temo:"
 
-#: src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:36
+#: src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:35
 msgid "Please tell us why you are deleting your add-on:"
 msgstr "Povejte nam, zakaj brišete svoj dodatek:"
 
-#: src/olympia/devhub/templates/devhub/addons/listing/item_actions.html:1
-#: src/olympia/devhub/templates/devhub/addons/listing/item_actions_theme.html:1
+#: src/olympia/devhub/templates/devhub/addons/listing/item_actions.html:1 src/olympia/devhub/templates/devhub/addons/listing/item_actions_theme.html:1
 #: src/olympia/editors/templates/editors/review.html:253
 msgid "Actions"
 msgstr "Ukrepi"
@@ -6066,22 +4850,17 @@ msgstr "Nova različica"
 msgid "Daily statistics on downloads and users."
 msgstr "Dnevna statistika o prenosih in uporabnikih."
 
-#: src/olympia/devhub/templates/devhub/addons/listing/item_actions.html:45
-#: src/olympia/stats/templates/stats/stats.html:75
-#: src/olympia/stats/templates/stats/stats.html:79
-#: src/olympia/stats/templates/stats/stats.html:81
+#: src/olympia/devhub/templates/devhub/addons/listing/item_actions.html:45 src/olympia/stats/templates/stats/stats.html:31 src/olympia/stats/templates/stats/stats.html:35
+#: src/olympia/stats/templates/stats/stats.html:37
 msgid "Statistics"
 msgstr "Statistika"
 
-#: src/olympia/devhub/templates/devhub/addons/listing/item_actions.html:54
-#: src/olympia/devhub/templates/devhub/includes/addons_edit_nav.html:5
-#: src/olympia/devhub/templates/devhub/payments/payments.html:3
-#: src/olympia/devhub/templates/devhub/payments/tier.html:4
+#: src/olympia/devhub/templates/devhub/addons/listing/item_actions.html:54 src/olympia/devhub/templates/devhub/includes/addons_edit_nav.html:5
+#: src/olympia/devhub/templates/devhub/payments/payments.html:3 src/olympia/devhub/templates/devhub/payments/tier.html:4
 msgid "Manage Payments"
 msgstr "Upravljanje plačil"
 
-#: src/olympia/devhub/templates/devhub/addons/listing/item_actions.html:55
-#: src/olympia/devhub/templates/devhub/includes/addons_edit_nav.html:6
+#: src/olympia/devhub/templates/devhub/addons/listing/item_actions.html:55 src/olympia/devhub/templates/devhub/includes/addons_edit_nav.html:6
 msgid "Manage Status & Versions"
 msgstr "Uredi stanje in različice"
 
@@ -6089,10 +4868,8 @@ msgstr "Uredi stanje in različice"
 msgid "View Add-on Listing"
 msgstr "Prikaži objave dodatka"
 
-#: src/olympia/devhub/templates/devhub/addons/listing/item_actions.html:64
-#: src/olympia/devhub/templates/devhub/addons/listing/item_actions_theme.html:12
-#: src/olympia/devhub/templates/devhub/includes/addons_edit_nav.html:37
-#: src/olympia/devhub/templates/devhub/personas/edit.html:58
+#: src/olympia/devhub/templates/devhub/addons/listing/item_actions.html:64 src/olympia/devhub/templates/devhub/addons/listing/item_actions_theme.html:12
+#: src/olympia/devhub/templates/devhub/includes/addons_edit_nav.html:37 src/olympia/devhub/templates/devhub/personas/edit.html:58
 msgid "View Recent Changes"
 msgstr "Prikaži zadnje spremembe"
 
@@ -6117,12 +4894,8 @@ msgid "Delete this theme."
 msgstr "Izbriši to temo."
 
 #: src/olympia/devhub/templates/devhub/addons/listing/items.html:10
-msgid ""
-"This add-on will be deleted automatically after a few days if the submission"
-" process is not completed."
-msgstr ""
-"Ta dodatek se bo samodejno izbrisalo po nekaj dneh, če se postopek "
-"predložitve ne zaključi."
+msgid "This add-on will be deleted automatically after a few days if the submission process is not completed."
+msgstr "Ta dodatek se bo samodejno izbrisalo po nekaj dneh, če se postopek predložitve ne zaključi."
 
 #: src/olympia/devhub/templates/devhub/addons/listing/items.html:27
 msgid "Disabled"
@@ -6139,8 +4912,6 @@ msgid "<strong>{0}</strong> active user"
 msgid_plural "<strong>{0}</strong> active users"
 msgstr[0] "<strong>{0}</strong> aktivni uporabnik"
 msgstr[1] "<strong>{0}</strong> aktivna uporabnika"
-msgstr[2] "<strong>{0}</strong> aktivni uporabniki"
-msgstr[3] "<strong>{0}</strong> aktivnih uporabnikov"
 
 #: src/olympia/devhub/templates/devhub/addons/submit/base.html:11
 msgid "Submit Add-on"
@@ -6162,9 +4933,7 @@ msgstr "Ime in različica:"
 msgid "The detail page will be:"
 msgstr "Stran s podrobnosti bo:"
 
-#: src/olympia/devhub/templates/devhub/addons/submit/describe.html:24
-#: src/olympia/devhub/templates/devhub/personas/edit.html:89
-#: src/olympia/devhub/templates/devhub/personas/submit.html:38
+#: src/olympia/devhub/templates/devhub/addons/submit/describe.html:24 src/olympia/devhub/templates/devhub/personas/edit.html:89 src/olympia/devhub/templates/devhub/personas/submit.html:38
 msgid "Please use only letters, numbers, underscores, and dashes in your URL."
 msgstr "V URL-ju uporabljajte prosim le črke, številke, podčrtaje in vezaje."
 
@@ -6184,14 +4953,11 @@ msgstr "Prispevajte bolj podroben opis:"
 msgid "The description will appear on the detail page."
 msgstr "Ta opis bo objavljen na strani s podrobnostmi."
 
-#: src/olympia/devhub/templates/devhub/addons/submit/done.html:4
-#: src/olympia/devhub/templates/devhub/personas/submit_done.html:4
+#: src/olympia/devhub/templates/devhub/addons/submit/done.html:4 src/olympia/devhub/templates/devhub/personas/submit_done.html:4
 msgid "Submission Complete"
 msgstr "Predložitev je končana"
 
-#: src/olympia/devhub/templates/devhub/addons/submit/done.html:8
-#: src/olympia/devhub/templates/devhub/addons/submit/sidebar.html:13
-#: src/olympia/devhub/templates/devhub/personas/submit_done.html:8
+#: src/olympia/devhub/templates/devhub/addons/submit/done.html:8 src/olympia/devhub/templates/devhub/addons/submit/sidebar.html:13 src/olympia/devhub/templates/devhub/personas/submit_done.html:8
 msgid "You're done!"
 msgstr "Končali ste!"
 
@@ -6204,51 +4970,33 @@ msgid "Your add-on has been submitted to the Full Review queue."
 msgstr "Vaš dodatek je v čakalni vrsti za polni pregled."
 
 #: src/olympia/devhub/templates/devhub/addons/submit/done.html:18
-msgid ""
-"You'll receive an email once it has been reviewed by an editor. In\n"
-"          the meantime, you and your friends can install it directly from its\n"
-"          details page:"
+msgid "You'll receive an email once it has been reviewed by an editor. In the meantime, you and your friends can install it directly from its details page:"
 msgstr ""
 "Ko bo urednik dodatek pregledal, boste prejeli obvestilo po e-pošti.\n"
 "          Do takrat si ga lahko vaši prijatelji in vi sami prenesete neposredno\n"
 "          prek strani s podrobnostmi:"
 
-#: src/olympia/devhub/templates/devhub/addons/submit/done.html:27
-#: src/olympia/devhub/templates/devhub/addons/submit/done.html:77
-#: src/olympia/devhub/templates/devhub/personas/submit_done.html:16
+#: src/olympia/devhub/templates/devhub/addons/submit/done.html:27 src/olympia/devhub/templates/devhub/addons/submit/done.html:77 src/olympia/devhub/templates/devhub/personas/submit_done.html:16
 msgid "Next steps:"
 msgstr "Naslednji koraki:"
 
-#: src/olympia/devhub/templates/devhub/addons/submit/done.html:32
-#: src/olympia/devhub/templates/devhub/addons/submit/done.html:82
+#: src/olympia/devhub/templates/devhub/addons/submit/done.html:32 src/olympia/devhub/templates/devhub/addons/submit/done.html:82
 msgid "<a href=\"{0}\">Upload</a> another platform-specific file to this version."
-msgstr ""
-"<a href=\"{0}\">Naloži</a> drugo za platformo specifično datoteko za to "
-"različico."
+msgstr "<a href=\"{0}\">Naloži</a> drugo za platformo specifično datoteko za to različico."
 
 #: src/olympia/devhub/templates/devhub/addons/submit/done.html:34
 msgid "Provide more details by <a href=\"{0}\">editing its listing</a>."
-msgstr ""
-"Dodajte še druge podrobnosti, s tem da <a href=\"{0}\">uredite objavo</a>."
+msgstr "Dodajte še druge podrobnosti, s tem da <a href=\"{0}\">uredite objavo</a>."
 
 #: src/olympia/devhub/templates/devhub/addons/submit/done.html:35
-msgid ""
-"Tell your users why you created this in your <a href=\"{0}\">Developer "
-"Profile</a>."
-msgstr ""
-"Povejte uporabnikom v svojem <a href=\"{0}\">Profilu razvijalca</a>, zakaj "
-"ste ta dodatek razvili."
+msgid "Tell your users why you created this in your <a href=\"{0}\">Developer Profile</a>."
+msgstr "Povejte uporabnikom v svojem <a href=\"{0}\">Profilu razvijalca</a>, zakaj ste ta dodatek razvili."
 
 #: src/olympia/devhub/templates/devhub/addons/submit/done.html:36
-msgid ""
-"View and subscribe to your add-on's <a href=\"{0}\">activity feed</a> to "
-"stay updated on reviews, collections, and more."
-msgstr ""
-"Oglejte si naročnino za svoj dodatek in <a href=\"{0}\"> naročite nanj</a> ,"
-" da ostanejo na tekočem, kar se ocen, zbirk in drugega tiče."
+msgid "View and subscribe to your add-on's <a href=\"{0}\">activity feed</a> to stay updated on reviews, collections, and more."
+msgstr "Oglejte si naročnino za svoj dodatek in <a href=\"{0}\"> naročite nanj</a> , da ostanejo na tekočem, kar se ocen, zbirk in drugega tiče."
 
-#: src/olympia/devhub/templates/devhub/addons/submit/done.html:37
-#: src/olympia/devhub/templates/devhub/addons/submit/done.html:86
+#: src/olympia/devhub/templates/devhub/addons/submit/done.html:37 src/olympia/devhub/templates/devhub/addons/submit/done.html:86
 msgid "View approximate review queue <a href=\"{0}\">wait times</a>."
 msgstr "Pokaži približni <a href=\"{0}\">čakalni čas</a> za pregled."
 
@@ -6258,33 +5006,22 @@ msgstr "Prehitite čakalno vrsto!"
 
 #: src/olympia/devhub/templates/devhub/addons/submit/done.html:45
 msgid "Become an AMO Reviewer today and get your add-ons reviewed faster."
-msgstr ""
-"Postanite pregledovalec AMO še danes in poskrbite, da bodo vaši dodatki "
-"pregledani prej."
+msgstr "Postanite pregledovalec AMO še danes in poskrbite, da bodo vaši dodatki pregledani prej."
 
 #: src/olympia/devhub/templates/devhub/addons/submit/done.html:54
-msgid ""
-"Your add-on has been signed and it's ready to use. You can download it here:"
-msgstr ""
-"Vaš dodatek je bil podpisan in je pripravljen za uporabo. Lahko ga prenesete"
-" od tu:"
+msgid "Your add-on has been signed and it's ready to use. You can download it here:"
+msgstr "Vaš dodatek je bil podpisan in je pripravljen za uporabo. Lahko ga prenesete od tu:"
 
 #: src/olympia/devhub/templates/devhub/addons/submit/done.html:64
-msgid ""
-"Your add-on has been submitted to the Unlisted Preliminary Review queue."
-msgstr ""
-"Vaš dodatek je bil poslan v čakalno vrsto za predhoden pregled nenavedenih "
-"dodatkov."
+msgid "Your add-on has been submitted to the Unlisted Preliminary Review queue."
+msgstr "Vaš dodatek je bil poslan v čakalno vrsto za predhoden pregled nenavedenih dodatkov."
 
 #: src/olympia/devhub/templates/devhub/addons/submit/done.html:66
 msgid "Your add-on has been submitted to the Unlisted Full Review queue."
-msgstr ""
-"Vaš dodatek je bil poslan v čakalno vrsto za poln pregled nenavedenih "
-"dodatkov."
+msgstr "Vaš dodatek je bil poslan v čakalno vrsto za poln pregled nenavedenih dodatkov."
 
 #: src/olympia/devhub/templates/devhub/addons/submit/done.html:70
-msgid ""
-"You'll receive an email once it has been reviewed by an editor and signed."
+msgid "You'll receive an email once it has been reviewed by an editor and signed."
 msgstr "Ko ga bo urednik pregledal in podpisal, boste prejeli e-pošto."
 
 #: src/olympia/devhub/templates/devhub/addons/submit/done.html:74
@@ -6292,12 +5029,8 @@ msgid "Your add-on will not be publicly available on this website."
 msgstr "Vaš dodatek ne bo javno na voljo na tej spletni strani."
 
 #: src/olympia/devhub/templates/devhub/addons/submit/done.html:84
-msgid ""
-"You can upload new versions of your add-on in the <a href=\"{0}\">add-on's "
-"developer page</a>."
-msgstr ""
-"Nove različice svojega dodatka lahko prenesete na <a href=\"{0}\">strani "
-"razvijalca dodatka</a>."
+msgid "You can upload new versions of your add-on in the <a href=\"{0}\">add-on's developer page</a>."
+msgstr "Nove različice svojega dodatka lahko prenesete na <a href=\"{0}\">strani razvijalca dodatka</a>."
 
 #: src/olympia/devhub/templates/devhub/addons/submit/license.html:4
 msgid "Step 5"
@@ -6308,14 +5041,8 @@ msgid "Step 5. Select a License"
 msgstr "Korak 5. Izberite licenco"
 
 #: src/olympia/devhub/templates/devhub/addons/submit/license.html:9
-msgid ""
-"We require all add-ons to indicate the terms under which their source code "
-"is licensed. Please select a license from the list below or enter a custom "
-"license."
-msgstr ""
-"Za vse dodatke zahtevamo, da navedejo pogoje, po katerih je licencirana "
-"njihova izvorna koda. Izberite prosim licenco v spodnjem seznamu ali vnesite"
-" svojo lastno licenco."
+msgid "We require all add-ons to indicate the terms under which their source code is licensed. Please select a license from the list below or enter a custom license."
+msgstr "Za vse dodatke zahtevamo, da navedejo pogoje, po katerih je licencirana njihova izvorna koda. Izberite prosim licenco v spodnjem seznamu ali vnesite svojo lastno licenco."
 
 #: src/olympia/devhub/templates/devhub/addons/submit/license.html:18
 msgid "Select a license for your add-on:"
@@ -6331,13 +5058,11 @@ msgstr "Korak 4. Dodaj slike"
 
 #: src/olympia/devhub/templates/devhub/addons/submit/media.html:9
 msgid ""
-"Custom icons and screenshots draw attention and help users understand what "
-"it does. We strongly recommend uploading a custom icon, as in some areas of "
-"the website, only the icon and name will appear."
+"Custom icons and screenshots draw attention and help users understand what it does. We strongly recommend uploading a custom icon, as in some areas of the website, only the icon and name will "
+"appear."
 msgstr ""
-"Ikone po meri in posnetki zaslona bodo pritegnili uporabnika in mu pomagali "
-"razumeti, kaj dodatek počne. Toplo vam priporočamo, da si prenesete ikone po"
-" meri, ker je na nekaterih področjih spletišča videti le ikono in ime."
+"Ikone po meri in posnetki zaslona bodo pritegnili uporabnika in mu pomagali razumeti, kaj dodatek počne. Toplo vam priporočamo, da si prenesete ikone po meri, ker je na nekaterih področjih "
+"spletišča videti le ikono in ime."
 
 #: src/olympia/devhub/templates/devhub/addons/submit/select-review.html:5
 msgid "Step 6"
@@ -6349,25 +5074,16 @@ msgstr "Korak 6. Izberite postopek za pregled"
 
 #: src/olympia/devhub/templates/devhub/addons/submit/select-review.html:10
 msgid ""
-"All add-ons hosted in our gallery must be reviewed by an editor before they "
-"appear in categories or search results. While waiting for review, your add-"
-"on can still be accessed through its direct URL. Please choose the review "
-"process below that best fits your add-on."
+"All add-ons hosted in our gallery must be reviewed by an editor before they appear in categories or search results. While waiting for review, your add-on can still be accessed through its direct "
+"URL. Please choose the review process below that best fits your add-on."
 msgstr ""
-"Vse dodatke, ki jih gostimo v naši galeriji, mora naprej pregledati urednik,"
-" potem šele se jih lahko objavi v kategorijah ali rezultatih iskanja. Med "
-"čakanjem na pregled lahko do svojega dodatka še vedno pridete prek "
-"neposrednega URL. Spodaj izberite postopek pregleda, ki je za vaš dodatek "
-"najbolj ustrezen."
+"Vse dodatke, ki jih gostimo v naši galeriji, mora naprej pregledati urednik, potem šele se jih lahko objavi v kategorijah ali rezultatih iskanja. Med čakanjem na pregled lahko do svojega dodatka še "
+"vedno pridete prek neposrednega URL. Spodaj izberite postopek pregleda, ki je za vaš dodatek najbolj ustrezen."
 
 #: src/olympia/devhub/templates/devhub/addons/submit/select-review.html:26
 #, python-format
-msgid ""
-"A complete review of your add-on's source and functionality. <a "
-"href=\"%(url)s\">Learn more&hellip;</a>"
-msgstr ""
-"Popoln pregled izvorne kode vašega dodatka in njegove funkcionalnosti. <a "
-"href=\"%(url)s\">Več o tem...</a>"
+msgid "A complete review of your add-on's source and functionality. <a href=\"%(url)s\">Learn more&hellip;</a>"
+msgstr "Popoln pregled izvorne kode vašega dodatka in njegove funkcionalnosti. <a href=\"%(url)s\">Več o tem...</a>"
 
 #: src/olympia/devhub/templates/devhub/addons/submit/select-review.html:32
 msgid "Appropriate for polished add-ons"
@@ -6395,12 +5111,8 @@ msgstr "Izberite popoln pregled"
 
 #: src/olympia/devhub/templates/devhub/addons/submit/select-review.html:49
 #, python-format
-msgid ""
-"A faster review of your add-on's source for any major problems. <a "
-"href=\"%(url)s\">Learn more&hellip;</a>"
-msgstr ""
-"Hitrejši pregled izvorne kode vašega dodatka, kar se nevarnosti za večje "
-"probleme tiče. <a href=\"%(url)s\">Več o tem&hellip</a>"
+msgid "A faster review of your add-on's source for any major problems. <a href=\"%(url)s\">Learn more&hellip;</a>"
+msgstr "Hitrejši pregled izvorne kode vašega dodatka, kar se nevarnosti za večje probleme tiče. <a href=\"%(url)s\">Več o tem&hellip</a>"
 
 #: src/olympia/devhub/templates/devhub/addons/submit/select-review.html:55
 msgid "Appropriate for experimental add-ons"
@@ -6446,10 +5158,8 @@ msgstr "Izberite licenco"
 msgid "Select a review process"
 msgstr "Izberite postopek pregleda"
 
-#: src/olympia/devhub/templates/devhub/addons/submit/sidebar.html:18
-#: src/olympia/devhub/templates/devhub/docs/policies-submission.html:3
-#: src/olympia/devhub/templates/devhub/docs/policies-submission.html:7
-#: src/olympia/devhub/templates/devhub/docs/policies-submission.html:9
+#: src/olympia/devhub/templates/devhub/addons/submit/sidebar.html:18 src/olympia/devhub/templates/devhub/docs/policies-submission.html:3
+#: src/olympia/devhub/templates/devhub/docs/policies-submission.html:7 src/olympia/devhub/templates/devhub/docs/policies-submission.html:9
 msgid "Submission Process"
 msgstr "Postopek predložitve"
 
@@ -6470,27 +5180,18 @@ msgid "Step 2. Upload Your Add-on"
 msgstr "Korak 2. Naložite svoj dodatek"
 
 #: src/olympia/devhub/templates/devhub/addons/submit/upload.html:11
-msgid ""
-"Use the fields below to upload your add-on package and select any platform "
-"restrictions. After upload, a series of automated validation tests will be "
-"run on your file."
-msgstr ""
-"Uporabite polja spodaj, da prenesete svoj paket za dodatek in da izberete "
-"omejitve glede okolij. Po zaključenem prenosu se bo preverilo veljavnost "
-"vaše datoteke z nizom samodejnih preskusov."
+msgid "Use the fields below to upload your add-on package and select any platform restrictions. After upload, a series of automated validation tests will be run on your file."
+msgstr "Uporabite polja spodaj, da prenesete svoj paket za dodatek in da izberete omejitve glede okolij. Po zaključenem prenosu se bo preverilo veljavnost vaše datoteke z nizom samodejnih preskusov."
 
-#: src/olympia/devhub/templates/devhub/addons/submit/upload.html:59
-#: src/olympia/devhub/templates/devhub/versions/add_file_modal.html:39
+#: src/olympia/devhub/templates/devhub/addons/submit/upload.html:51 src/olympia/devhub/templates/devhub/versions/add_file_modal.html:28
 msgid "Which platforms is this file compatible with?"
 msgstr "S katerimi okolji je združljiva ta datoteka?"
 
-#: src/olympia/devhub/templates/devhub/addons/submit/upload.html:67
-#: src/olympia/devhub/templates/devhub/versions/add_file_modal.html:65
+#: src/olympia/devhub/templates/devhub/addons/submit/upload.html:59 src/olympia/devhub/templates/devhub/versions/add_file_modal.html:45
 msgid "Administrative overrides"
 msgstr "Razveljavitve administratorja"
 
-#: src/olympia/devhub/templates/devhub/api/agreement.html:3
-#: src/olympia/devhub/templates/devhub/api/agreement.html:11
+#: src/olympia/devhub/templates/devhub/api/agreement.html:3 src/olympia/devhub/templates/devhub/api/agreement.html:11
 msgid "Firefox Add-on Distribution Agreement"
 msgstr "Sporazum o razširjanju dodatkov za Firefox"
 
@@ -6500,12 +5201,8 @@ msgstr "Poverila API"
 
 #: src/olympia/devhub/templates/devhub/api/key.html:20
 #, python-format
-msgid ""
-"For detailed instructions, consult the <a href=\"%(docs_url)s\">API "
-"documentation</a>."
-msgstr ""
-"Za podrobna navodila se posvetujte z <a href=\"%(docs_url)s\">dokumentacijo "
-"o API-jih</a>."
+msgid "For detailed instructions, consult the <a href=\"%(docs_url)s\">API documentation</a>."
+msgstr "Za podrobna navodila se posvetujte z <a href=\"%(docs_url)s\">dokumentacijo o API-jih</a>."
 
 #: src/olympia/devhub/templates/devhub/api/key.html:28
 msgid "JWT issuer"
@@ -6518,15 +5215,11 @@ msgstr "Skrivnost JWT"
 #: src/olympia/devhub/templates/devhub/api/key.html:37
 #, python-format
 msgid ""
-"To make API requests, send a <a href=\"%(jwt_url)s\">JSON Web Token "
-"(JWT)</a> as the authorization header. You'll need to generate a JWT for "
-"every request as explained in the <a href=\"%(docs_url)s\">API "
-"documentation</a>."
+"To make API requests, send a <a href=\"%(jwt_url)s\">JSON Web Token (JWT)</a> as the authorization header. You'll need to generate a JWT for every request as explained in the <a href=\"%(docs_url)s"
+"\">API documentation</a>."
 msgstr ""
-"Za opravljanje zahtev API kot glavo pooblastitve pošljite <a "
-"href=\"%(jwt_url)s\">spletni žeton JSON (JWT)</a>. JWT boste morali "
-"ustvariti za vsako zahtevo, kot je to razloženo v <a "
-"href=\"%(docs_url)s\">dokumentaciji o API-jih</a>."
+"Za opravljanje zahtev API kot glavo pooblastitve pošljite <a href=\"%(jwt_url)s\">spletni žeton JSON (JWT)</a>. JWT boste morali ustvariti za vsako zahtevo, kot je to razloženo v <a href="
+"\"%(docs_url)s\">dokumentaciji o API-jih</a>."
 
 #: src/olympia/devhub/templates/devhub/api/key.html:47
 msgid "You don't have any API credentials yet."
@@ -6534,12 +5227,8 @@ msgstr "Nimate še poverilnice API."
 
 #: src/olympia/devhub/templates/devhub/api/key.html:53
 #, python-format
-msgid ""
-"This feature is under active development. If you find a problem please <a "
-"target=\"_blank\" href=\"%(bug_link)s\">report a bug</a>."
-msgstr ""
-"Ta značilnost je v dejavnem razvoju. Če najdete težavo, <a target=\"_blank\""
-" href=\"%(bug_link)s\">prijavite hrošča</a>."
+msgid "This feature is under active development. If you find a problem please <a target=\"_blank\" href=\"%(bug_link)s\">report a bug</a>."
+msgstr "Ta značilnost je v dejavnem razvoju. Če najdete težavo, <a target=\"_blank\" href=\"%(bug_link)s\">prijavite hrošča</a>."
 
 #: src/olympia/devhub/templates/devhub/api/key.html:61
 msgid "Revoke and regenerate credentials"
@@ -6549,29 +5238,19 @@ msgstr "Prekliči in ponovno ustvari poverila"
 msgid "Generate new credentials"
 msgstr "Ustvari nova poverila"
 
-#: src/olympia/devhub/templates/devhub/docs/policies-agreement.html:3
-#: src/olympia/devhub/templates/devhub/docs/policies-agreement.html:7
-#: src/olympia/devhub/templates/devhub/docs/policies-agreement.html:9
-#: src/olympia/devhub/templates/devhub/docs/policies.html:24
-#: src/olympia/devhub/templates/devhub/docs/policies.html:103
+#: src/olympia/devhub/templates/devhub/docs/policies-agreement.html:3 src/olympia/devhub/templates/devhub/docs/policies-agreement.html:7
+#: src/olympia/devhub/templates/devhub/docs/policies-agreement.html:9 src/olympia/devhub/templates/devhub/docs/policies.html:24 src/olympia/devhub/templates/devhub/docs/policies.html:103
 msgid "Developer Agreement"
 msgstr "Sporazum za razvijalce"
 
-#: src/olympia/devhub/templates/devhub/docs/policies-contact.html:3
-#: src/olympia/devhub/templates/devhub/docs/policies-contact.html:7
-#: src/olympia/devhub/templates/devhub/docs/policies-contact.html:9
-#: src/olympia/devhub/templates/devhub/docs/policies.html:27
-#: src/olympia/devhub/templates/devhub/docs/policies.html:115
+#: src/olympia/devhub/templates/devhub/docs/policies-contact.html:3 src/olympia/devhub/templates/devhub/docs/policies-contact.html:7 src/olympia/devhub/templates/devhub/docs/policies-contact.html:9
+#: src/olympia/devhub/templates/devhub/docs/policies.html:27 src/olympia/devhub/templates/devhub/docs/policies.html:115
 msgid "Contacting Us"
 msgstr "Stik z nami"
 
 #: src/olympia/devhub/templates/devhub/docs/policies-contact.html:12
-msgid ""
-"Thanks for your interest in contacting the Mozilla Add-ons team. Please read"
-" this page carefully to ensure your request goes to the right place."
-msgstr ""
-"Hvala vam za to, da ste se obrnili na ekipo dodatkov Mozilla. Prosimo, da si"
-" pazljivo preberete to stran, da bo vaše sporočilo prišlo na pravi naslov."
+msgid "Thanks for your interest in contacting the Mozilla Add-ons team. Please read this page carefully to ensure your request goes to the right place."
+msgstr "Hvala vam za to, da ste se obrnili na ekipo dodatkov Mozilla. Prosimo, da si pazljivo preberete to stran, da bo vaše sporočilo prišlo na pravi naslov."
 
 #: src/olympia/devhub/templates/devhub/docs/policies-contact.html:17
 msgid "Add-on Support"
@@ -6579,14 +5258,11 @@ msgstr "Podpora za dodatke"
 
 #: src/olympia/devhub/templates/devhub/docs/policies-contact.html:19
 msgid ""
-"If you have a support question about a particular add-on, such as \"how do I"
-" use this add-on?\" or \"why doesn't this work properly?\", please contact "
-"that add-on's author through the support channels listed on the add-on's "
-"listing page."
+"If you have a support question about a particular add-on, such as \"how do I use this add-on?\" or \"why doesn't this work properly?\", please contact that add-on's author through the support "
+"channels listed on the add-on's listing page."
 msgstr ""
-"Če imate vprašanja o določenem dodatku, kot sta \"Kako naj uporabljam ta "
-"dodatek?\" ali \"Zakaj ne dela prav?\", se obrnite na avtorja dodatka preko "
-"kanalov za podporo, ki so navedeni na domači strani dodatka."
+"Če imate vprašanja o določenem dodatku, kot sta \"Kako naj uporabljam ta dodatek?\" ali \"Zakaj ne dela prav?\", se obrnite na avtorja dodatka preko kanalov za podporo, ki so navedeni na domači "
+"strani dodatka."
 
 #: src/olympia/devhub/templates/devhub/docs/policies-contact.html:24
 msgid "Add-on Editorial Concerns"
@@ -6599,17 +5275,11 @@ msgstr "amo-editors afna mozilla pika org"
 #: src/olympia/devhub/templates/devhub/docs/policies-contact.html:26
 #, python-format
 msgid ""
-"If you have a question about an Editor's review of an add-on or want to "
-"report a policy violation, please email %(mail_editors)s. <strong>Almost all"
-" add-on reports fall under this category.</strong> Please be sure to include"
-" a link to the add-on in question and a detailed description of your "
-"question or comment."
+"If you have a question about an Editor's review of an add-on or want to report a policy violation, please email %(mail_editors)s. <strong>Almost all add-on reports fall under this category.</"
+"strong> Please be sure to include a link to the add-on in question and a detailed description of your question or comment."
 msgstr ""
-"Če imate vprašanja glede urednikovega pregleda dodatka ali pa če bi radi "
-"prijavili kršitev pravil, pošljite e-pošto na %(mail_editors)s. "
-"<strong>Skoraj vsa sporočila o dodatkih spadajo v to kategorijo.</strong> "
-"Prosim, ne pozabite dodati povezave do dodatka, na katerega se nanaša "
-"vprašanje, in podrobne obrazložitve svojega vprašanja ali pripombe."
+"Če imate vprašanja glede urednikovega pregleda dodatka ali pa če bi radi prijavili kršitev pravil, pošljite e-pošto na %(mail_editors)s. <strong>Skoraj vsa sporočila o dodatkih spadajo v to "
+"kategorijo.</strong> Prosim, ne pozabite dodati povezave do dodatka, na katerega se nanaša vprašanje, in podrobne obrazložitve svojega vprašanja ali pripombe."
 
 #: src/olympia/devhub/templates/devhub/docs/policies-contact.html:31
 msgid "Add-on Security Vulnerabilities"
@@ -6622,21 +5292,13 @@ msgstr "amo-admins afna mozilla pika org"
 #: src/olympia/devhub/templates/devhub/docs/policies-contact.html:36
 #, python-format
 msgid ""
-"If you have discovered a security vulnerability in an add-on, even if it is "
-"not hosted here, Mozilla is very interested in your discovery and will work "
-"with the add-on developer to correct the issue as soon as possible. Add-on "
-"security issues can be reported <a "
-"href=\"http://www.mozilla.org/projects/security/security-bugs-"
-"policy.html\">confidentially</a> in <a "
-"href=\"%(link_bugzilla)s\">Bugzilla</a> or by emailing %(mail_admins)s."
+"If you have discovered a security vulnerability in an add-on, even if it is not hosted here, Mozilla is very interested in your discovery and will work with the add-on developer to correct the "
+"issue as soon as possible. Add-on security issues can be reported <a href=\"http://www.mozilla.org/projects/security/security-bugs-policy.html\">confidentially</a> in <a href=\"%(link_bugzilla)s"
+"\">Bugzilla</a> or by emailing %(mail_admins)s."
 msgstr ""
-"Če ste odkrili varnostno ranljivost v kakem dodatku, tudi če se ga ne "
-"gostuje tukaj, bo vaše odkritje Mozillo zelo zanimalo in bo razvijalcu "
-"dodatka v pomoč pri odpravljanju napake ali problema. Vprašanja glede "
-"varnosti dodatkov se lahko sporoča <a "
-"href=\"http://www.mozilla.org/projects/security/security-bugs-"
-"policy.html\">zaupno</a> na <a href=\"%(link_bugzilla)s\">Bugzilli</a> ali s"
-" pošto na naslov %(mail_admins)s."
+"Če ste odkrili varnostno ranljivost v kakem dodatku, tudi če se ga ne gostuje tukaj, bo vaše odkritje Mozillo zelo zanimalo in bo razvijalcu dodatka v pomoč pri odpravljanju napake ali problema. "
+"Vprašanja glede varnosti dodatkov se lahko sporoča <a href=\"http://www.mozilla.org/projects/security/security-bugs-policy.html\">zaupno</a> na <a href=\"%(link_bugzilla)s\">Bugzilli</a> ali s "
+"pošto na naslov %(mail_admins)s."
 
 #: src/olympia/devhub/templates/devhub/docs/policies-contact.html:42
 msgid "Website Functionality & Development"
@@ -6644,16 +5306,11 @@ msgstr "Delovanje in razvoj spletne strani"
 
 #: src/olympia/devhub/templates/devhub/docs/policies-contact.html:44
 msgid ""
-"If you've found a problem with the site, we'd love to fix it. Please <a "
-"href=\"https://github.com/mozilla/olympia/issues\">file a bug report</a> in "
-"GitHub, including the location of the problem and how you encountered it."
+"If you've found a problem with the site, we'd love to fix it. Please <a href=\"https://github.com/mozilla/addons/issues/new\">file a bug report</a> in GitHub, including the location of the problem "
+"and how you encountered it."
 msgstr ""
-"Če ste na strani našli napako, bi jo radi popravili. Na GtHubu <a "
-"href=\"https://github.com/mozilla/olympia/issues\">pošljite poročilo o "
-"hrošču</a> vključno z mestom težave in kako ste nanjo naleteli."
 
-#: src/olympia/devhub/templates/devhub/docs/policies-maintenance.html:3
-#: src/olympia/devhub/templates/devhub/docs/policies-maintenance.html:7
+#: src/olympia/devhub/templates/devhub/docs/policies-maintenance.html:3 src/olympia/devhub/templates/devhub/docs/policies-maintenance.html:7
 #: src/olympia/devhub/templates/devhub/docs/policies-maintenance.html:8
 msgid "Maintaining Your Add-ons"
 msgstr "Vzdrževanje vaših dodatkov"
@@ -6664,30 +5321,17 @@ msgstr "Kako poslati nove različice svojega dodatka"
 
 #: src/olympia/devhub/templates/devhub/docs/policies-maintenance.html:12
 msgid ""
-"Developers are encouraged to submit updates to their add-ons to fix bugs, "
-"add features, and otherwise improve their product. New versions of an add-on"
-" must have a <a "
-"href=\"https://developer.mozilla.org/en/Toolkit_version_format\">higher "
-"version number</a> and can be submitted through the Developer Tools "
-"provided. There is no limit to the number of versions that can be submitted,"
-" but please remember that versions must be reviewed by an editor."
+"Developers are encouraged to submit updates to their add-ons to fix bugs, add features, and otherwise improve their product. New versions of an add-on must have a <a href=\"https://developer."
+"mozilla.org/en/Toolkit_version_format\">higher version number</a> and can be submitted through the Developer Tools provided. There is no limit to the number of versions that can be submitted, but "
+"please remember that versions must be reviewed by an editor."
 msgstr ""
-"Razvijalce spodbujamo, da prispevajo popravke napak, nove funkcije, in na "
-"splošno izboljšave za svoje dodatke. Nove različice dodatka morajo imeti <a "
-"href=\"https://developer.mozilla.org/en/Toolkit_version_format\">zvišano "
-"številko različice</a>, pošlje pa se jih lahko preko razpoložljivih orodij "
-"za razvijalce. Za število različic, ki se jih pošlje, ni omejitev, ne "
-"pozabite pa pri tem, da mora nove različice urednik pregledati."
+"Razvijalce spodbujamo, da prispevajo popravke napak, nove funkcije, in na splošno izboljšave za svoje dodatke. Nove različice dodatka morajo imeti <a href=\"https://developer.mozilla.org/en/"
+"Toolkit_version_format\">zvišano številko različice</a>, pošlje pa se jih lahko preko razpoložljivih orodij za razvijalce. Za število različic, ki se jih pošlje, ni omejitev, ne pozabite pa pri "
+"tem, da mora nove različice urednik pregledati."
 
 #: src/olympia/devhub/templates/devhub/docs/policies-maintenance.html:18
-msgid ""
-"New versions will be added to a pending review queue, and any additional "
-"versions submitted before the review is completed will move that version to "
-"the end of the queue."
-msgstr ""
-"Nove različice se bo dodalo v vrsto čakajočih za pregled in morebitne "
-"dodatne različice, poslane pred zaključkom pregleda, bodo preselile to "
-"različico na konec čakalne vrste."
+msgid "New versions will be added to a pending review queue, and any additional versions submitted before the review is completed will move that version to the end of the queue."
+msgstr "Nove različice se bo dodalo v vrsto čakajočih za pregled in morebitne dodatne različice, poslane pred zaključkom pregleda, bodo preselile to različico na konec čakalne vrste."
 
 #: src/olympia/devhub/templates/devhub/docs/policies-maintenance.html:23
 msgid "How do I submit a Beta add-on?"
@@ -6699,51 +5343,31 @@ msgstr "Beta kanali so na voljo le v celoti pregledanim dodatkom."
 
 #: src/olympia/devhub/templates/devhub/docs/policies-maintenance.html:31
 msgid ""
-"To create a beta channel, upload a file with a unique version string that "
-"contains any of the following strings: <code>a,b,alpha,beta,pre,rc</code>, "
-"with an optional number at the end. This text must come at the end of the "
-"version string. If you understand regex format, here's what we look for in "
-"the version number: <code>\"(a|alpha|b|beta|pre|rc)\\d*$\"</code>."
+"To create a beta channel, upload a file with a unique version string that contains any of the following strings: <code>a,b,alpha,beta,pre,rc</code>, with an optional number at the end. This text "
+"must come at the end of the version string. If you understand regex format, here's what we look for in the version number: <code>\"(a|alpha|b|beta|pre|rc)\\d*$\"</code>."
 msgstr ""
-"Če želite ustvariti beta kanal, naložite datoteko z edinstvenim nizom "
-"različice, ki vsebuje katerega koli od naslednjih znakov: "
-"<code>a,b,alpha,beta,pre,rc</code> in dodatno številko na koncu. To besedilo"
-" se mora nahajati na koncu niza. Če se spoznate na regex format, tukaj je "
-"tisto, kar iščemo v številki različice: "
-"<code>\"(a|alpha|b|beta|pre|rc)\\d*$\"</code>."
+"Če želite ustvariti beta kanal, naložite datoteko z edinstvenim nizom različice, ki vsebuje katerega koli od naslednjih znakov: <code>a,b,alpha,beta,pre,rc</code> in dodatno številko na koncu. To "
+"besedilo se mora nahajati na koncu niza. Če se spoznate na regex format, tukaj je tisto, kar iščemo v številki različice: <code>\"(a|alpha|b|beta|pre|rc)\\d*$\"</code>."
 
 #: src/olympia/devhub/templates/devhub/docs/policies-maintenance.html:37
 msgid ""
-"Once a file meeting this criteria is uploaded to AMO, it will automatically "
-"be marked as a beta version. Users of add-ons with these unique version "
-"numbers will automatically be served the newest beta updates."
+"Once a file meeting this criteria is uploaded to AMO, it will automatically be marked as a beta version. Users of add-ons with these unique version numbers will automatically be served the newest "
+"beta updates."
 msgstr ""
-"Ko je datoteka. ki ustreza tem merilom, naložena na AMO, bo samodejno "
-"označena kot beta verzija. Uporabniki dodatkov s temi edinstveno različico "
-"številke bodo samodejno dobili najnovejše beta posodobitve."
+"Ko je datoteka. ki ustreza tem merilom, naložena na AMO, bo samodejno označena kot beta verzija. Uporabniki dodatkov s temi edinstveno različico številke bodo samodejno dobili najnovejše beta "
+"posodobitve."
 
 #: src/olympia/devhub/templates/devhub/docs/policies-maintenance.html:43
 msgid ""
-"While we call these \"Beta versions\", you can use this channel for "
-"nightlies, or alphas, or prerelease versions as you wish. Please note that "
-"there is only one channel for this purpose and all of your users on this "
-"channel will receive the latest add-ons submitted. For instance, if you "
-"upload <code>1.0beta1</code> to the release channel and then upload "
-"<code>1.1alpha1</code>, all users of <code>1.0beta1</code> will be offered "
-"an upgrade to <code>1.1alpha1</code>. Updates are pushed by submission date "
-"and not version number, so users will always get the most recent channel "
-"update regardless of any kind of alphabetical sorting."
+"While we call these \"Beta versions\", you can use this channel for nightlies, or alphas, or prerelease versions as you wish. Please note that there is only one channel for this purpose and all of "
+"your users on this channel will receive the latest add-ons submitted. For instance, if you upload <code>1.0beta1</code> to the release channel and then upload <code>1.1alpha1</code>, all users of "
+"<code>1.0beta1</code> will be offered an upgrade to <code>1.1alpha1</code>. Updates are pushed by submission date and not version number, so users will always get the most recent channel update "
+"regardless of any kind of alphabetical sorting."
 msgstr ""
-"Te različice imenujemo sicer \"Beta\", lahko pa uporabite ta kanal za nočne "
-"verzije, za alfa, predhodno objavo, kot vam najbolj ustreza. Upoštevajte, da"
-" je na razpolago samo en kanal za te namene in da bodo vsi vaši uporabniki "
-"na tem kanalu prejemali najnovejše poslane dodatke. Na primer, če ste "
-"prenesli <code>1.0beta1</code> na kanal za javnost in nato naložili "
-"<code>1.1alpha1</code>, bodo vsi uporabniki <code>1.0beta1</code> dobili "
-"obvestilo, da lahko nadgradijo na <code>1.1alpha1</code>. Posodobitve se "
-"potiska po datumu vložitve in ne po številkah različice, tako da bodo "
-"uporabniki po kanalu vedno dobili najnovejše posodobitve, ne glede na "
-"abecedni vrstni red."
+"Te različice imenujemo sicer \"Beta\", lahko pa uporabite ta kanal za nočne verzije, za alfa, predhodno objavo, kot vam najbolj ustreza. Upoštevajte, da je na razpolago samo en kanal za te namene "
+"in da bodo vsi vaši uporabniki na tem kanalu prejemali najnovejše poslane dodatke. Na primer, če ste prenesli <code>1.0beta1</code> na kanal za javnost in nato naložili <code>1.1alpha1</code>, bodo "
+"vsi uporabniki <code>1.0beta1</code> dobili obvestilo, da lahko nadgradijo na <code>1.1alpha1</code>. Posodobitve se potiska po datumu vložitve in ne po številkah različice, tako da bodo uporabniki "
+"po kanalu vedno dobili najnovejše posodobitve, ne glede na abecedni vrstni red."
 
 #: src/olympia/devhub/templates/devhub/docs/policies-maintenance.html:48
 msgid "Required Updates"
@@ -6751,21 +5375,13 @@ msgstr "Zahtevane posodobitve"
 
 #: src/olympia/devhub/templates/devhub/docs/policies-maintenance.html:50
 msgid ""
-"Certain situations may arise in which Mozilla requests that an add-on "
-"developer update their add-on within a given time period to address a major "
-"security issue or policy violation. We work with developers to reasonably "
-"accommodate their own schedules, but if the issue is of a serious enough "
-"nature, add-ons that cannot issue an update with the requested fix may be "
-"demoted from fully-reviewed status, disabled, or permanently removed from "
-"the site."
+"Certain situations may arise in which Mozilla requests that an add-on developer update their add-on within a given time period to address a major security issue or policy violation. We work with "
+"developers to reasonably accommodate their own schedules, but if the issue is of a serious enough nature, add-ons that cannot issue an update with the requested fix may be demoted from fully-"
+"reviewed status, disabled, or permanently removed from the site."
 msgstr ""
-"Pride lahko do določenih situacij, v katerih se zahteva od razvijalca "
-"dodatka Mozilla. da svoj dodatek zaradi pomembnih razlogov varnosti ali "
-"zaradi kršitev pravilnika v določenem roku posodobi. Sodelujemo z "
-"razvijalci, da lahko ustrezno prilagodijo svoje urnike, če pa vprašanje je "
-"dovolj resne narave, se bo dodatke, za katere ni dobiti posodobitve,  črtalo"
-" iz množice odobrenih dodatkov, onemogočilo, ali trajno odstranilo s "
-"spletišča."
+"Pride lahko do določenih situacij, v katerih se zahteva od razvijalca dodatka Mozilla. da svoj dodatek zaradi pomembnih razlogov varnosti ali zaradi kršitev pravilnika v določenem roku posodobi. "
+"Sodelujemo z razvijalci, da lahko ustrezno prilagodijo svoje urnike, če pa vprašanje je dovolj resne narave, se bo dodatke, za katere ni dobiti posodobitve,  črtalo iz množice odobrenih dodatkov, "
+"onemogočilo, ali trajno odstranilo s spletišča."
 
 #: src/olympia/devhub/templates/devhub/docs/policies-maintenance.html:55
 msgid "Transfer of Ownership"
@@ -6773,63 +5389,39 @@ msgstr "Prenos lastništva"
 
 #: src/olympia/devhub/templates/devhub/docs/policies-maintenance.html:57
 msgid ""
-"Add-ons can have multiple users with permission to update and manage the "
-"listing. Existing authors of an add-on can transfer ownership and add "
-"additional developers to an add-on's listing through the Developer Tools "
-"provided. No interaction with Mozilla representatives is necessary for a "
-"transfer of ownership."
+"Add-ons can have multiple users with permission to update and manage the listing. Existing authors of an add-on can transfer ownership and add additional developers to an add-on's listing through "
+"the Developer Tools provided. No interaction with Mozilla representatives is necessary for a transfer of ownership."
 msgstr ""
-"Dodatki imajo lahko več uporabnikov z dovoljenjem za posodabljanje in skrb "
-"za objave. Obstoječi avtorji dodatka lahko lastništvo prenesejo na druge "
-"osebe in dodajo dodatne razvijalce na seznam, in sicer s pomočjo orodja za "
-"razvijalce. ki je na razpolago. Za prenos lastništva stik s predstavniki "
-"Mozille ni potreben."
+"Dodatki imajo lahko več uporabnikov z dovoljenjem za posodabljanje in skrb za objave. Obstoječi avtorji dodatka lahko lastništvo prenesejo na druge osebe in dodajo dodatne razvijalce na seznam, in "
+"sicer s pomočjo orodja za razvijalce. ki je na razpolago. Za prenos lastništva stik s predstavniki Mozille ni potreben."
 
 #: src/olympia/devhub/templates/devhub/docs/policies-maintenance.html:63
 #, python-format
-msgid ""
-"Mozilla can assist with granting additional permissions of an add-on's "
-"listing if <a href=\"%(link_contact)s\">contacted</a> by the add-on's "
-"current owner."
-msgstr ""
-"Mozilla lahko pomaga z izdajo dodatnih dovoljenj za dodatek za kotacijo, če "
-"jo trenutni lastnik dodatka <a href=\"%(link_contact)s\">kontaktira</a>."
+msgid "Mozilla can assist with granting additional permissions of an add-on's listing if <a href=\"%(link_contact)s\">contacted</a> by the add-on's current owner."
+msgstr "Mozilla lahko pomaga z izdajo dodatnih dovoljenj za dodatek za kotacijo, če jo trenutni lastnik dodatka <a href=\"%(link_contact)s\">kontaktira</a>."
 
 #: src/olympia/devhub/templates/devhub/docs/policies-maintenance.html:70
 msgid ""
-"Mozilla encourages its users to offer feedback on their experiences when "
-"using an add-on. This allows other users to determine if the add-on is "
-"stable and useful. It also provides valuable feedback to developers, "
-"allowing them to continuously improve their add-on to meet user needs."
+"Mozilla encourages its users to offer feedback on their experiences when using an add-on. This allows other users to determine if the add-on is stable and useful. It also provides valuable feedback "
+"to developers, allowing them to continuously improve their add-on to meet user needs."
 msgstr ""
-"Mozilla spodbuja svoje uporabnike, da objavljajo povratne informacije o "
-"svojih izkušnjah pri uporabi dodatka. To omogoča drugim uporabnikom, da "
-"ugotovijo, ali je dodatek stabilen in uporaben. Prispeva tudi dragocene "
-"povratne informacije za razvijalce in jim omogoča, da stalno izboljšujejo "
-"svoje dodatke, s ciljem zadovoljiti potrebe uporabnika."
+"Mozilla spodbuja svoje uporabnike, da objavljajo povratne informacije o svojih izkušnjah pri uporabi dodatka. To omogoča drugim uporabnikom, da ugotovijo, ali je dodatek stabilen in uporaben. "
+"Prispeva tudi dragocene povratne informacije za razvijalce in jim omogoča, da stalno izboljšujejo svoje dodatke, s ciljem zadovoljiti potrebe uporabnika."
 
 #: src/olympia/devhub/templates/devhub/docs/policies-maintenance.html:76
 #, python-format
 msgid ""
-"Reviews must follow the <a href=\"%(link_guidelines)s\">review "
-"guidelines</a>. Reviews that do not meet these guidelines may be flagged for"
-" moderation, but negative reviews will not be removed unless they provide "
-"false information."
+"Reviews must follow the <a href=\"%(link_guidelines)s\">review guidelines</a>. Reviews that do not meet these guidelines may be flagged for moderation, but negative reviews will not be removed "
+"unless they provide false information."
 msgstr ""
-"Ocene morajo upoštevati <a href=\"%(link_guidelines)s\">smernice za "
-"ocene</a>. Ocene, ki se ne držijo teh smernic, se lahko označi za "
-"moderatorjev pregled, vendar se negativnih ocen ne bo odstranjevalo, razen "
-"če vsebujejo lažne informacije."
+"Ocene morajo upoštevati <a href=\"%(link_guidelines)s\">smernice za ocene</a>. Ocene, ki se ne držijo teh smernic, se lahko označi za moderatorjev pregled, vendar se negativnih ocen ne bo "
+"odstranjevalo, razen če vsebujejo lažne informacije."
 
 #: src/olympia/devhub/templates/devhub/docs/policies-maintenance.html:82
 msgid ""
-"Many developers provide a support mechanism, such as a forum, discussion "
-"group, or email address. It is recommended that support questions be posted "
-"via those mediums instead of in an add-on's review section."
-msgstr ""
-"Veliko razvijalcev ponuja mehanizem za podporo, na primer forum, skupino za "
-"razpravo ali e-poštni naslov. Priporočamo, da vprašanja za podporo zastavite"
-" tam, namesto med ocenami tega dodatka."
+"Many developers provide a support mechanism, such as a forum, discussion group, or email address. It is recommended that support questions be posted via those mediums instead of in an add-on's "
+"review section."
+msgstr "Veliko razvijalcev ponuja mehanizem za podporo, na primer forum, skupino za razpravo ali e-poštni naslov. Priporočamo, da vprašanja za podporo zastavite tam, namesto med ocenami tega dodatka."
 
 #: src/olympia/devhub/templates/devhub/docs/policies-maintenance.html:87
 msgid "Code Disputes"
@@ -6837,44 +5429,26 @@ msgstr "Spori v zvezi s kodo"
 
 #: src/olympia/devhub/templates/devhub/docs/policies-maintenance.html:90
 msgid ""
-"Many add-ons allow their source code to be openly viewed. This does not mean"
-" that the source code is open source or available for use in another add-on."
-" The original author of an add-on retains copyright of their work unless "
-"otherwise noted in the add-on's license."
+"Many add-ons allow their source code to be openly viewed. This does not mean that the source code is open source or available for use in another add-on. The original author of an add-on retains "
+"copyright of their work unless otherwise noted in the add-on's license."
 msgstr ""
-"Veliko dodatkov dovoljuje, da javnost vidi njihovo izvorno kodo. To pa ne "
-"pomeni, da gre pri izvorni kodi za odprtokodni izdelek ali da je na voljo za"
-" uporabo v kakem drugem dodatku. Izvirni avtor dodatka si pridržuje avtorske"
-" pravice, razen če ni drugače navedeno v licenci za dodatek."
+"Veliko dodatkov dovoljuje, da javnost vidi njihovo izvorno kodo. To pa ne pomeni, da gre pri izvorni kodi za odprtokodni izdelek ali da je na voljo za uporabo v kakem drugem dodatku. Izvirni avtor "
+"dodatka si pridržuje avtorske pravice, razen če ni drugače navedeno v licenci za dodatek."
 
 #: src/olympia/devhub/templates/devhub/docs/policies-maintenance.html:96
 msgid ""
-"In the event that we're notified of a copyright or license infringement, we "
-"will take steps to review the situation and determine if an actual "
-"infringement has occurred. If we determine that there is an infringement, we"
-" will remove the offending add-on and contact the author. New add-on "
-"submissions (including updates) containing infringing code will be denied "
-"approval for public status."
+"In the event that we're notified of a copyright or license infringement, we will take steps to review the situation and determine if an actual infringement has occurred. If we determine that there "
+"is an infringement, we will remove the offending add-on and contact the author. New add-on submissions (including updates) containing infringing code will be denied approval for public status."
 msgstr ""
-"V primeru, da dobimo obvestilo o kršitvi avtorskih pravic ali licence, bomo "
-"ukrepali, to je preverili stanje, da najprej ugotovimo, ali je dejansko "
-"prišlo do kršitve. Če bomo prišli do prepričanja da gre za kršitev, bomo o "
-"tem obvestili njegovega avtorja in dodatek, ki krši pravila, odstranili. "
-"Nove objave dodatka (vključno s posodobitvami), ki bodo vsebovale vprašljivo"
-" kodo, ne bodo dobile javnega statusa."
+"V primeru, da dobimo obvestilo o kršitvi avtorskih pravic ali licence, bomo ukrepali, to je preverili stanje, da najprej ugotovimo, ali je dejansko prišlo do kršitve. Če bomo prišli do prepričanja "
+"da gre za kršitev, bomo o tem obvestili njegovega avtorja in dodatek, ki krši pravila, odstranili. Nove objave dodatka (vključno s posodobitvami), ki bodo vsebovale vprašljivo kodo, ne bodo dobile "
+"javnega statusa."
 
 #: src/olympia/devhub/templates/devhub/docs/policies-maintenance.html:102
-msgid ""
-"If you are unsure of the current copyright status of an add-on's source "
-"code, you must contact the original author and receive explicit permission "
-"before using the source code."
-msgstr ""
-"Če niste prepričani o trenutnem stanju avtorskih pravic za izvorno kodo "
-"dodatka. se morate, preden kodo uporabite, obrniti na izvirnega avtorja in "
-"zaprositi za izrecno dovoljenje."
+msgid "If you are unsure of the current copyright status of an add-on's source code, you must contact the original author and receive explicit permission before using the source code."
+msgstr "Če niste prepričani o trenutnem stanju avtorskih pravic za izvorno kodo dodatka. se morate, preden kodo uporabite, obrniti na izvirnega avtorja in zaprositi za izrecno dovoljenje."
 
-#: src/olympia/devhub/templates/devhub/docs/policies-maintenance.html:107
-#: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:306
+#: src/olympia/devhub/templates/devhub/docs/policies-maintenance.html:107 src/olympia/devhub/templates/devhub/docs/policies-reviews.html:306
 #: src/olympia/devhub/templates/devhub/docs/policies-submission.html:97
 msgid "Last updated: January 13, 2011"
 msgstr "Nazadnje posodobljeno: 13. januarja 2011"
@@ -6882,55 +5456,33 @@ msgstr "Nazadnje posodobljeno: 13. januarja 2011"
 #: src/olympia/devhub/templates/devhub/docs/policies-recommended.html:13
 #, python-format
 msgid ""
-"Featured add-ons are top-quality extensions and themes highlighted on <a "
-"href=\"%(link_gallery)s\">AMO</a>, Firefox's Add-ons Manager, and across "
-"other Mozilla websites. These add-ons showcase the power of Firefox "
-"customization and are useful to a wide audience."
+"Featured add-ons are top-quality extensions and themes highlighted on <a href=\"%(link_gallery)s\">AMO</a>, Firefox's Add-ons Manager, and across other Mozilla websites. These add-ons showcase the "
+"power of Firefox customization and are useful to a wide audience."
 msgstr ""
-"Izbrani dodatki so razširitve in teme vrhunske kvalitete, ki se jih poudarja"
-" v <a href=\"%(link_gallery)s\">AMO</a>, v Upravitelju dodatkov za Firefox "
-"in na drugih spletnih mestih Mozille. Ti dodatki so lep primer za možnosti, "
-"ki jih imajo dodatki za Firefox, poleg tega so zanimivi za širok krog "
-"uporabnikov."
+"Izbrani dodatki so razširitve in teme vrhunske kvalitete, ki se jih poudarja v <a href=\"%(link_gallery)s\">AMO</a>, v Upravitelju dodatkov za Firefox in na drugih spletnih mestih Mozille. Ti "
+"dodatki so lep primer za možnosti, ki jih imajo dodatki za Firefox, poleg tega so zanimivi za širok krog uporabnikov."
 
 #: src/olympia/devhub/templates/devhub/docs/policies-recommended.html:19
 msgid ""
-"Featured add-ons are chosen by the Featured Add-ons Advisory Board, a small "
-"group of add-on developers and fans from the Mozilla community who have "
-"volunteered to review and vote on nominations."
-msgstr ""
-"Izbrane dodatke določa Odbor svetovalcev za dodatke, to je majhna skupina "
-"razvijalcev in ljubiteljev dodatkov, ki prostovoljno sodelujejo pri "
-"pregledih in izbiri kandidatov za objavo."
+"Featured add-ons are chosen by the Featured Add-ons Advisory Board, a small group of add-on developers and fans from the Mozilla community who have volunteered to review and vote on nominations."
+msgstr "Izbrane dodatke določa Odbor svetovalcev za dodatke, to je majhna skupina razvijalcev in ljubiteljev dodatkov, ki prostovoljno sodelujejo pri pregledih in izbiri kandidatov za objavo."
 
 #: src/olympia/devhub/templates/devhub/docs/policies-recommended.html:25
 #, python-format
-msgid ""
-"<a href=\"%(link_featured)s\">Featured extensions</a> are chosen every "
-"month, and <a href=\"%(link_themes)s\">featured complete themes</a> are "
-"chosen every quarter."
-msgstr ""
-"<a href=\"%(link_featured)s\">Izbrane razširitve</a> se izbira enkrat na "
-"mesec, <a href=\"%(link_themes)s\">izbrane celotne teme</a> pa enkrat na "
-"četrt leta."
+msgid "<a href=\"%(link_featured)s\">Featured extensions</a> are chosen every month, and <a href=\"%(link_themes)s\">featured complete themes</a> are chosen every quarter."
+msgstr "<a href=\"%(link_featured)s\">Izbrane razširitve</a> se izbira enkrat na mesec, <a href=\"%(link_themes)s\">izbrane celotne teme</a> pa enkrat na četrt leta."
 
 #: src/olympia/devhub/templates/devhub/docs/policies-recommended.html:30
 msgid "Criteria for Featured Add-ons"
 msgstr "Pogoji za predstavitev dodatka"
 
 #: src/olympia/devhub/templates/devhub/docs/policies-recommended.html:33
-msgid ""
-"Before nominating an add-on to be featured, please ensure it meets the "
-"following criteria:"
-msgstr ""
-"Da se vaš dodatek lahko uvrsti med kandidate, morate zagotoviti, da ustreza "
-"pogojem, ki so navedeni spodaj:"
+msgid "Before nominating an add-on to be featured, please ensure it meets the following criteria:"
+msgstr "Da se vaš dodatek lahko uvrsti med kandidate, morate zagotoviti, da ustreza pogojem, ki so navedeni spodaj:"
 
 #: src/olympia/devhub/templates/devhub/docs/policies-recommended.html:39
-msgid ""
-"The add-on must have a complete and informative listing on AMO. This means:"
-msgstr ""
-"Dodatek mora imeti popoln in informativen vnos na seznamu AMO. To pomeni:"
+msgid "The add-on must have a complete and informative listing on AMO. This means:"
+msgstr "Dodatek mora imeti popoln in informativen vnos na seznamu AMO. To pomeni:"
 
 #: src/olympia/devhub/templates/devhub/docs/policies-recommended.html:41
 msgid "a 64-pixel custom icon"
@@ -6953,44 +5505,28 @@ msgid "updated screenshots of the add-on's functionality"
 msgstr "posodobljene posnetke delovanja dodatka"
 
 #: src/olympia/devhub/templates/devhub/docs/policies-recommended.html:46
-msgid ""
-"must be fully approved by AMO editors (no preliminarily reviewed entries)"
-msgstr ""
-"dodatek morajo uredniki AMO v celoti odobriti (predhodno pregledani "
-"prispevki ne pridejo v poštev)"
+msgid "must be fully approved by AMO editors (no preliminarily reviewed entries)"
+msgstr "dodatek morajo uredniki AMO v celoti odobriti (predhodno pregledani prispevki ne pridejo v poštev)"
 
 #: src/olympia/devhub/templates/devhub/docs/policies-recommended.html:48
-msgid ""
-"The add-on must have excellent user reviews and any problems or support "
-"requests must be promptly addressed by the developer."
-msgstr ""
-"Dodatek mora imeti odlične ocene uporabnikov in na probleme ali zahteve za "
-"podporo mora razvijalec nemudoma reagirati."
+msgid "The add-on must have excellent user reviews and any problems or support requests must be promptly addressed by the developer."
+msgstr "Dodatek mora imeti odlične ocene uporabnikov in na probleme ali zahteve za podporo mora razvijalec nemudoma reagirati."
 
 #: src/olympia/devhub/templates/devhub/docs/policies-recommended.html:49
 msgid "The add-on must have a minimum of 2,000 users."
 msgstr "Dodatek mora imeti najmanj 2000 uporabnikov."
 
 #: src/olympia/devhub/templates/devhub/docs/policies-recommended.html:50
-msgid ""
-"The add-on must be compatible with the latest release of Firefox and must be"
-" compatible with beta versions 4 weeks before their final release."
-msgstr ""
-"Dodatek mora biti združljiv z najnovejšo različico Firefoxa in biti mora "
-"združljiv z beta različico 4 tedne pred končno objavo."
+msgid "The add-on must be compatible with the latest release of Firefox and must be compatible with beta versions 4 weeks before their final release."
+msgstr "Dodatek mora biti združljiv z najnovejšo različico Firefoxa in biti mora združljiv z beta različico 4 tedne pred končno objavo."
 
 #: src/olympia/devhub/templates/devhub/docs/policies-recommended.html:51
 msgid ""
-"<strong>Most importantly</strong>, the add-on must have wide consumer appeal"
-" to Firefox's users and be outstanding in nearly every way: user experience,"
-" performance, security, and usefulness or entertainment value. Featured "
-"complete themes must also be visually appealing."
+"<strong>Most importantly</strong>, the add-on must have wide consumer appeal to Firefox's users and be outstanding in nearly every way: user experience, performance, security, and usefulness or "
+"entertainment value. Featured complete themes must also be visually appealing."
 msgstr ""
-"<strong>Najbolj pomembno</strong> pa je, da mora dodatek biti privlačen za "
-"čim večji krog uporabnikov Firefoxa in da je izjemen v skoraj vseh pogledih:"
-" s stališča izkušenj uporabnikov, zmogljivosti, varnosti, koristnosti ali "
-"vrednosti kot razvedrilo. Izbrane celotne teme morajo biti tudi na videz "
-"privlačne."
+"<strong>Najbolj pomembno</strong> pa je, da mora dodatek biti privlačen za čim večji krog uporabnikov Firefoxa in da je izjemen v skoraj vseh pogledih: s stališča izkušenj uporabnikov, "
+"zmogljivosti, varnosti, koristnosti ali vrednosti kot razvedrilo. Izbrane celotne teme morajo biti tudi na videz privlačne."
 
 #: src/olympia/devhub/templates/devhub/docs/policies-recommended.html:54
 msgid "Nominating an Add-on"
@@ -7002,269 +5538,164 @@ msgstr "amo-featured afna mozilla pika org"
 
 #: src/olympia/devhub/templates/devhub/docs/policies-recommended.html:57
 #, python-format
-msgid ""
-"If you wish to nominate an add-on to be featured and it meets the criteria "
-"above, send an email to %(mail_featured)s with:"
-msgstr ""
-"Če želite imenovati dodatek kot možnega kandidata za imenovanje in če "
-"dodatek zgornja merila izpolnjuje, pošljite e-pošto na naslov "
-"%(mail_featured)s z naslednjo vsebino:"
+msgid "If you wish to nominate an add-on to be featured and it meets the criteria above, send an email to %(mail_featured)s with:"
+msgstr "Če želite imenovati dodatek kot možnega kandidata za imenovanje in če dodatek zgornja merila izpolnjuje, pošljite e-pošto na naslov %(mail_featured)s z naslednjo vsebino:"
 
 #: src/olympia/devhub/templates/devhub/docs/policies-recommended.html:62
 msgid "the add-on name, URL, and whether you are its developer"
 msgstr "ime dodatka, URL, in ali ste razvijalec tega dodatka vi"
 
 #: src/olympia/devhub/templates/devhub/docs/policies-recommended.html:63
-msgid ""
-"a short explanation of why the add-on has wide appeal and should be featured"
-msgstr ""
-"kratka obrazložitev, zakaj je dodatek privlačen za uporabnike in bi moral "
-"biti izbran"
+msgid "a short explanation of why the add-on has wide appeal and should be featured"
+msgstr "kratka obrazložitev, zakaj je dodatek privlačen za uporabnike in bi moral biti izbran"
 
 #: src/olympia/devhub/templates/devhub/docs/policies-recommended.html:64
-msgid ""
-"optionally, links to any external reviews or articles mentioning the add-on"
-msgstr ""
-"neobvezno, povezave do kakršnih koli zunanjih pregledov ali izdelkov, ki "
-"omenjajo dodatek"
+msgid "optionally, links to any external reviews or articles mentioning the add-on"
+msgstr "neobvezno, povezave do kakršnih koli zunanjih pregledov ali izdelkov, ki omenjajo dodatek"
 
 #: src/olympia/devhub/templates/devhub/docs/policies-recommended.html:68
 msgid ""
-"Add-on nominations are reviewed by the Advisory Board once a month (once "
-"every 3 months for complete theme nominations). Common reasons for rejection"
-" include lacking wide appeal to consumers, a suboptimal user experience, "
-"quality or security issues, incompatibility, and similarity to another "
-"featured add-on. Rejected add-ons cannot be re-nominated within 3 months."
+"Add-on nominations are reviewed by the Advisory Board once a month (once every 3 months for complete theme nominations). Common reasons for rejection include lacking wide appeal to consumers, a "
+"suboptimal user experience, quality or security issues, incompatibility, and similarity to another featured add-on. Rejected add-ons cannot be re-nominated within 3 months."
 msgstr ""
-"Nominacije dodatkov enkrat mesečno pregleda Odbor svetovalcev za dodatke "
-"(nominacije celotnih tem enkrat na 3 mesece). Običajni razlogi za zavrnitev "
-"vključujejo pomanjkanje privlačnosti za širok krog uporabnikov, neoptimalna "
-"uporabniška izkušnja, težave s kvaliteto ali varnostjo, nezdružljivost ali "
-"podobnost drugemu izbranemu dodatku. Zavrnjeni dodatki ne morejo biti "
-"ponovno nominirani 3 mesece po zavrnitvi."
+"Nominacije dodatkov enkrat mesečno pregleda Odbor svetovalcev za dodatke (nominacije celotnih tem enkrat na 3 mesece). Običajni razlogi za zavrnitev vključujejo pomanjkanje privlačnosti za širok "
+"krog uporabnikov, neoptimalna uporabniška izkušnja, težave s kvaliteto ali varnostjo, nezdružljivost ali podobnost drugemu izbranemu dodatku. Zavrnjeni dodatki ne morejo biti ponovno nominirani 3 "
+"mesece po zavrnitvi."
 
 #: src/olympia/devhub/templates/devhub/docs/policies-recommended.html:73
 msgid "Rotating Featured Add-ons"
 msgstr "Menjavanje izbranih dodatkov"
 
 #: src/olympia/devhub/templates/devhub/docs/policies-recommended.html:76
-msgid ""
-"Mozilla and the Featured Add-ons Advisory Board regularly evaluate and "
-"rotate out featured add-ons. Some of the most common reasons for add-ons "
-"being removed from the featured list are:"
-msgstr ""
-"Mozilla in svetovalni odbor za izbrane dodatke redno ocenjujeta in menjata "
-"dodatke na seznamu izbranih. Nekateri od najbolj pogostih razlogov, da se "
-"dodatki odstranjujejo s seznama, so:"
+msgid "Mozilla and the Featured Add-ons Advisory Board regularly evaluate and rotate out featured add-ons. Some of the most common reasons for add-ons being removed from the featured list are:"
+msgstr "Mozilla in svetovalni odbor za izbrane dodatke redno ocenjujeta in menjata dodatke na seznamu izbranih. Nekateri od najbolj pogostih razlogov, da se dodatki odstranjujejo s seznama, so:"
 
 #: src/olympia/devhub/templates/devhub/docs/policies-recommended.html:83
 msgid ""
-"Lack of growth &mdash; Add-ons that are featured typically experience a "
-"substantial gain in both downloads and active users. If an add-on is not "
-"demonstrating growth in any substantial way, that's a good indicator the "
-"add-on may not be very useful to our users."
+"Lack of growth &mdash; Add-ons that are featured typically experience a substantial gain in both downloads and active users. If an add-on is not demonstrating growth in any substantial way, that's "
+"a good indicator the add-on may not be very useful to our users."
 msgstr ""
-"Pomanjkanje rasti &mdash; dodatki, ki se jih objavlja na vidnih mestih, "
-"običajno kažejo vidno rast, tako kar se prenosov tiče kot tudi števila "
-"aktivnih uporabnikov. Če dodatek ne kaže pomembne rasti, je to zanesljiv "
-"znak za to, da za naše uporabnike ni koristen."
+"Pomanjkanje rasti &mdash; dodatki, ki se jih objavlja na vidnih mestih, običajno kažejo vidno rast, tako kar se prenosov tiče kot tudi števila aktivnih uporabnikov. Če dodatek ne kaže pomembne "
+"rasti, je to zanesljiv znak za to, da za naše uporabnike ni koristen."
 
 #: src/olympia/devhub/templates/devhub/docs/policies-recommended.html:88
-msgid ""
-"Negative reviews &mdash; Featured add-ons should have a great experience and"
-" very few bugs, so add-ons with many negative reviews may be reconsidered."
+msgid "Negative reviews &mdash; Featured add-ons should have a great experience and very few bugs, so add-ons with many negative reviews may be reconsidered."
 msgstr ""
-"Negativne ocene &mdash; izbrani dodatki bi morali delati dober vtis in imeti"
-" zelo malo napak, tako da je za dodatke s številnimi negativnimi ocenami "
-"odločitev o izboru treba ponovno premisliti."
+"Negativne ocene &mdash; izbrani dodatki bi morali delati dober vtis in imeti zelo malo napak, tako da je za dodatke s številnimi negativnimi ocenami odločitev o izboru treba ponovno premisliti."
 
 #: src/olympia/devhub/templates/devhub/docs/policies-recommended.html:93
 msgid ""
-"Incompatibility with upcoming Firefox versions &mdash; Featured add-ons are "
-"expected to be compatible with stable and beta versions of Firefox. Add-ons "
-"not yet compatible with a Beta version of Firefox four weeks before its "
-"expected release will lose their featured status."
+"Incompatibility with upcoming Firefox versions &mdash; Featured add-ons are expected to be compatible with stable and beta versions of Firefox. Add-ons not yet compatible with a Beta version of "
+"Firefox four weeks before its expected release will lose their featured status."
 msgstr ""
-"Nezdružljivost s prihodnjimi različicami Firefoxa &mdash; izbrani dodatki "
-"naj bi bili združljivi s stabilnimi in beta različicami Firefoxa. Dodatki, "
-"ki štiri tedne pred pričakovano objavo beta različice še niso združljivi z "
-"njo, izgubijo svoj status na seznamu izbranih."
+"Nezdružljivost s prihodnjimi različicami Firefoxa &mdash; izbrani dodatki naj bi bili združljivi s stabilnimi in beta različicami Firefoxa. Dodatki, ki štiri tedne pred pričakovano objavo beta "
+"različice še niso združljivi z njo, izgubijo svoj status na seznamu izbranih."
 
 #: src/olympia/devhub/templates/devhub/docs/policies-recommended.html:99
 msgid "Joining the Featured Add-ons Advisory Board"
 msgstr "Kako lahko postanete član svetovalnega odbora za izbrane dodatke"
 
 #: src/olympia/devhub/templates/devhub/docs/policies-recommended.html:102
-msgid ""
-"Every six months a new Advisory Board is chosen based on applications from "
-"the add-ons community. Members must:"
-msgstr ""
-"Vsakih šest mesecev se izbere nov svetovalni odbor na podlagi predlogov "
-"skupnosti. Člani morajo:"
+msgid "Every six months a new Advisory Board is chosen based on applications from the add-ons community. Members must:"
+msgstr "Vsakih šest mesecev se izbere nov svetovalni odbor na podlagi predlogov skupnosti. Člani morajo:"
 
 #: src/olympia/devhub/templates/devhub/docs/policies-recommended.html:108
-msgid ""
-"be active members of the add-ons community, whether as a developer, "
-"evangelist, or fan"
-msgstr ""
-"biti aktivni člani skupnosti za dodatke, bodisi kot razvijalec, evangelist, "
-"ali pa kot ljubitelj"
+msgid "be active members of the add-ons community, whether as a developer, evangelist, or fan"
+msgstr "biti aktivni člani skupnosti za dodatke, bodisi kot razvijalec, evangelist, ali pa kot ljubitelj"
 
 #: src/olympia/devhub/templates/devhub/docs/policies-recommended.html:109
-msgid ""
-"commit to trying all the nominations submitted, giving their feedback, and "
-"casting their votes every month"
-msgstr ""
-"se zavezati, da bodo preskusili vse poslane nominacije, da bodo o njih "
-"poročali in enkrat mesečno glasovali"
+msgid "commit to trying all the nominations submitted, giving their feedback, and casting their votes every month"
+msgstr "se zavezati, da bodo preskusili vse poslane nominacije, da bodo o njih poročali in enkrat mesečno glasovali"
 
 #: src/olympia/devhub/templates/devhub/docs/policies-recommended.html:110
-msgid ""
-"abstain from voting on add-ons that they have any business or personal "
-"affiliations with, as well as direct competitors of any such add-ons"
-msgstr ""
-"se bodo vzdržali glasovanja o dodatkih, s katerimi so kakorkoli poslovno ali"
-" osebno povezani, kot tudi v primeru, da gre neposredne konkurente le-teh"
+msgid "abstain from voting on add-ons that they have any business or personal affiliations with, as well as direct competitors of any such add-ons"
+msgstr "se bodo vzdržali glasovanja o dodatkih, s katerimi so kakorkoli poslovno ali osebno povezani, kot tudi v primeru, da gre neposredne konkurente le-teh"
 
 #: src/olympia/devhub/templates/devhub/docs/policies-recommended.html:114
 msgid ""
-"Members of the Mozilla Add-ons team may veto any add-on's selection because "
-"of security, privacy, compatibility, or any other reason, but in general it "
-"is up to the Board to select add-ons to feature."
+"Members of the Mozilla Add-ons team may veto any add-on's selection because of security, privacy, compatibility, or any other reason, but in general it is up to the Board to select add-ons to "
+"feature."
 msgstr ""
-"Člani ekipe za dodatke Mozille lahko vložijo veto na katerokoli izbiro "
-"dodatkov iz razlogov varnosti, zasebnosti, združljivosti ali katerega koli "
-"drugega razloga, na splošno pa je naloga Sveta, da izbira dodatke, ki se jih"
-" bo predstavilo."
+"Člani ekipe za dodatke Mozille lahko vložijo veto na katerokoli izbiro dodatkov iz razlogov varnosti, zasebnosti, združljivosti ali katerega koli drugega razloga, na splošno pa je naloga Sveta, da "
+"izbira dodatke, ki se jih bo predstavilo."
 
 #: src/olympia/devhub/templates/devhub/docs/policies-recommended.html:120
 msgid ""
-"This featured policy only applies to the addons.mozilla.org global list of "
-"featured add-ons. Add-ons featured in other locations are often pulled from "
-"this list, but Mozilla may feature any add-on in other locations without the"
-" Board's consent. Additionally, locale-specific features override the global"
-" defaults, so if a locale has opted to select its own features, some or all "
-"of the global features may not appear in that locale."
+"This featured policy only applies to the addons.mozilla.org global list of featured add-ons. Add-ons featured in other locations are often pulled from this list, but Mozilla may feature any add-on "
+"in other locations without the Board's consent. Additionally, locale-specific features override the global defaults, so if a locale has opted to select its own features, some or all of the global "
+"features may not appear in that locale."
 msgstr ""
-"Ta politika izbranih dodatkov in tem velja le za globalni seznam izbranih "
-"dodatkov na addons.mozilla.org. Dodatke na drugih lokacijah se pogosto "
-"vključuje v ta seznam, vendar Mozilla lahko predstavi dodatek z drugega "
-"naslova brez soglasja sveta. Poleg tega jezikovne posebnosti preglasujejo "
-"globalno privzete nastavitve, tako da v primeru, da se določena jezikovna "
-"skupnost odloči za funkcije, ki so za njih značilne, nekaterih ali vseh "
-"globalnih funkcij v tem jeziku lahko da ne bo na razpolago."
+"Ta politika izbranih dodatkov in tem velja le za globalni seznam izbranih dodatkov na addons.mozilla.org. Dodatke na drugih lokacijah se pogosto vključuje v ta seznam, vendar Mozilla lahko "
+"predstavi dodatek z drugega naslova brez soglasja sveta. Poleg tega jezikovne posebnosti preglasujejo globalno privzete nastavitve, tako da v primeru, da se določena jezikovna skupnost odloči za "
+"funkcije, ki so za njih značilne, nekaterih ali vseh globalnih funkcij v tem jeziku lahko da ne bo na razpolago."
 
 #: src/olympia/devhub/templates/devhub/docs/policies-recommended.html:126
 #, python-format
-msgid ""
-"Follow the <a href=\"%(link_blog)s\">Add-ons Blog</a> or <a "
-"href=\"%(link_twitter)s\">@mozamo</a> on Twitter to learn when the next "
-"application period opens."
-msgstr ""
-"Berite <a href=\"%(link_blog)s\">Blog o dodatkih</a> ali  <a "
-"href=\"%(link_twitter)s\">@mozamo</a> na Twittru, da zveste, kdaj se začne "
-"naslednji rok za prijave."
+msgid "Follow the <a href=\"%(link_blog)s\">Add-ons Blog</a> or <a href=\"%(link_twitter)s\">@mozamo</a> on Twitter to learn when the next application period opens."
+msgstr "Berite <a href=\"%(link_blog)s\">Blog o dodatkih</a> ali  <a href=\"%(link_twitter)s\">@mozamo</a> na Twittru, da zveste, kdaj se začne naslednji rok za prijave."
 
 #: src/olympia/devhub/templates/devhub/docs/policies-recommended.html:131
 msgid "Last updated: January 31, 2013"
 msgstr "Nazadnje posodobljeno: 31. januarja 2013"
 
-#: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:3
-#: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:7
-#: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:8
-#: src/olympia/devhub/templates/devhub/docs/policies.html:15
-#: src/olympia/devhub/templates/devhub/docs/policies.html:64
+#: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:3 src/olympia/devhub/templates/devhub/docs/policies-reviews.html:7 src/olympia/devhub/templates/devhub/docs/policies-reviews.html:8
+#: src/olympia/devhub/templates/devhub/docs/policies.html:15 src/olympia/devhub/templates/devhub/docs/policies.html:64
 msgid "Review Process"
 msgstr "Postopek pregleda"
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:12
 msgid ""
-"In order to ensure all add-ons hosted in our gallery are safe for users to "
-"install, Mozilla will begin requiring all hosted add-ons to undergo review. "
-"We offer two types of review and developers are free to choose the best fit "
-"for their add-on."
+"In order to ensure all add-ons hosted in our gallery are safe for users to install, Mozilla will begin requiring all hosted add-ons to undergo review. We offer two types of review and developers "
+"are free to choose the best fit for their add-on."
 msgstr ""
-"Da bi zagotovili, da so vsi dodatki, ki se jih gostuje v naši galeriji, "
-"varni za uporabnike, ki jih nameščajo, bo Mozilla od dodatkov, ki gostujejo "
-"pri njej, začela zahtevati, da opravijo pregled. Nudimo dve vrsti pregleda "
-"in razvijalci lahko prosto izbirajo, kateri od obeh njihovim dodatkom "
-"najbolj ustreza."
+"Da bi zagotovili, da so vsi dodatki, ki se jih gostuje v naši galeriji, varni za uporabnike, ki jih nameščajo, bo Mozilla od dodatkov, ki gostujejo pri njej, začela zahtevati, da opravijo pregled. "
+"Nudimo dve vrsti pregleda in razvijalci lahko prosto izbirajo, kateri od obeh njihovim dodatkom najbolj ustreza."
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:19
 msgid ""
-"<strong><a href=\"#full\">Full Review</a></strong> &mdash; a thorough "
-"functional and code review of the add-on, appropriate for add-ons ready for "
-"distribution to the masses. All site features are available to these add-"
-"ons."
+"<strong><a href=\"#full\">Full Review</a></strong> &mdash; a thorough functional and code review of the add-on, appropriate for add-ons ready for distribution to the masses. All site features are "
+"available to these add-ons."
 msgstr ""
-"<strong><a href=\"#full\">Popoln pregled</a></strong>- &mdash; temeljit "
-"pregled funkcionalnosti in kode dodatka, primeren za dodatke, ki so "
-"namenjeni masovni distribuciji. Za te dodatke so na voljo vse funkcije "
-"spletišča."
+"<strong><a href=\"#full\">Popoln pregled</a></strong>- &mdash; temeljit pregled funkcionalnosti in kode dodatka, primeren za dodatke, ki so namenjeni masovni distribuciji. Za te dodatke so na voljo "
+"vse funkcije spletišča."
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:24
 msgid ""
-"<strong><a href=\"#preliminary\">Preliminary Review</a></strong> &mdash; a "
-"faster review intended for experimental add-ons. Preliminary reviews do not "
-"check for functionality or full policy compliance, but the reviewed add-ons "
-"have install button cautions and some feature limitations."
+"<strong><a href=\"#preliminary\">Preliminary Review</a></strong> &mdash; a faster review intended for experimental add-ons. Preliminary reviews do not check for functionality or full policy "
+"compliance, but the reviewed add-ons have install button cautions and some feature limitations."
 msgstr ""
-"<strong><a href=\"#preliminary\">Predhodni pregled </a></strong>&mdash; "
-"hitrejša oblika pregleda, namenjena za eksperimentalne dodatke. Predhodni "
-"pregledi ne preverjajo delovanja ali popolne skladnosti s pravili, ampak "
-"pregledani dodatki vsebujejo opozorila glede nameščanja in imajo nekatere "
-"funkcije omejene."
+"<strong><a href=\"#preliminary\">Predhodni pregled </a></strong>&mdash; hitrejša oblika pregleda, namenjena za eksperimentalne dodatke. Predhodni pregledi ne preverjajo delovanja ali popolne "
+"skladnosti s pravili, ampak pregledani dodatki vsebujejo opozorila glede nameščanja in imajo nekatere funkcije omejene."
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:31
 msgid ""
-"Detailed descriptions of each option are below. After selecting a review "
-"process at submission, the add-on will be placed in the queue. Add-ons are "
-"reviewed by the <a href=\"https://wiki.mozilla.org/AMO:Editors\">AMO "
-"Editors</a>, a group of talented developers that volunteer to help the "
-"Mozilla project by reviewing add-ons to ensure a stable and safe experience "
-"for users. Developers will receive an email with any updates throughout the "
-"review process."
+"Detailed descriptions of each option are below. After selecting a review process at submission, the add-on will be placed in the queue. Add-ons are reviewed by the <a href=\"https://wiki.mozilla."
+"org/AMO:Editors\">AMO Editors</a>, a group of talented developers that volunteer to help the Mozilla project by reviewing add-ons to ensure a stable and safe experience for users. Developers will "
+"receive an email with any updates throughout the review process."
 msgstr ""
-"Podrobni opisi obeh možnosti so v nadaljevanju. Po izbiri postopka za "
-"pregleda se ob pošiljanju dodatek postavi v čakalno vrsto. Dodatke "
-"pregledujejo <a href=\"https://wiki.mozilla.org/AMO:Editors\">Uredniki "
-"AMO</a>, to je skupina nadarjenih razvijalcev, ki prostovoljno pomagajo "
-"Mozilla s pregledi dodatkov, da bi tako zagotovili stabilno in varno delo za"
-" uporabnike. Razvijalci bodo prejemali e-pošto z obvestili o poteku "
-"pregleda."
+"Podrobni opisi obeh možnosti so v nadaljevanju. Po izbiri postopka za pregleda se ob pošiljanju dodatek postavi v čakalno vrsto. Dodatke pregledujejo <a href=\"https://wiki.mozilla.org/AMO:Editors"
+"\">Uredniki AMO</a>, to je skupina nadarjenih razvijalcev, ki prostovoljno pomagajo Mozilla s pregledi dodatkov, da bi tako zagotovili stabilno in varno delo za uporabnike. Razvijalci bodo "
+"prejemali e-pošto z obvestili o poteku pregleda."
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:37
 msgid ""
-"While waiting for review, add-ons will not appear anywhere in the gallery "
-"publicly, but direct links to the add-on's details page will work. This "
-"allows the author to blog or share the link with friends, inviting them to "
-"try it out, even when not yet reviewed."
+"While waiting for review, add-ons will not appear anywhere in the gallery publicly, but direct links to the add-on's details page will work. This allows the author to blog or share the link with "
+"friends, inviting them to try it out, even when not yet reviewed."
 msgstr ""
-"Medtem ko čaka na pregled, se dodatka ne bodo prikazovalo nikjer v galeriji "
-"javno, vendar pa bodo neposredne povezave na stran s podrobnostmi o dodatku "
-"delovale. To omogoča, da avtor lahko objavlja svoj blog ali deli povezavo s "
-"prijatelji in jih pri tem povabi, da dodatek, tudi če še ni pregledan, "
-"preizkusijo."
+"Medtem ko čaka na pregled, se dodatka ne bodo prikazovalo nikjer v galeriji javno, vendar pa bodo neposredne povezave na stran s podrobnostmi o dodatku delovale. To omogoča, da avtor lahko objavlja "
+"svoj blog ali deli povezavo s prijatelji in jih pri tem povabi, da dodatek, tudi če še ni pregledan, preizkusijo."
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:44
 msgid ""
-"Full reviews are appropriate for add-ons that are well-tested, stable, fast,"
-" and have wide appeal to our users. If you aren't confident that your add-on"
-" meets that criteria, please consider working out the kinks while in "
-"preliminary review and accumulating user feedback first."
+"Full reviews are appropriate for add-ons that are well-tested, stable, fast, and have wide appeal to our users. If you aren't confident that your add-on meets that criteria, please consider working "
+"out the kinks while in preliminary review and accumulating user feedback first."
 msgstr ""
-"Polni pregledi so primerni za dodatke, ki so dobro preizkušeni, stabilni, "
-"hitri, in privlačni za naše uporabnike. Če niste prepričani, da vaš dodatek "
-"izpolnjuje merila, razmislite, če ga ne bi raje med predhodnim pregledom "
-"malo polikali in najprej zbrali mnenja njegovih uporabnikov."
+"Polni pregledi so primerni za dodatke, ki so dobro preizkušeni, stabilni, hitri, in privlačni za naše uporabnike. Če niste prepričani, da vaš dodatek izpolnjuje merila, razmislite, če ga ne bi raje "
+"med predhodnim pregledom malo polikali in najprej zbrali mnenja njegovih uporabnikov."
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:50
-msgid ""
-"We aim to perform full reviews in under 10 days, though most add-ons are "
-"reviewed in much less time."
-msgstr ""
-"Naš cilj je opraviti popoln pregled v roku največ 10 dni, čeprav se večino "
-"dodatkov pregleda veliko hitreje."
+msgid "We aim to perform full reviews in under 10 days, though most add-ons are reviewed in much less time."
+msgstr "Naš cilj je opraviti popoln pregled v roku največ 10 dni, čeprav se večino dodatkov pregleda veliko hitreje."
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:55
 msgid "Testing Methods &amp; Common Issues"
@@ -7275,61 +5706,36 @@ msgid "When performing a full review, editors will:"
 msgstr "Med popolnim pregledom bodo uredniki:"
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:64
-msgid ""
-"install the add-on, making sure it functions as described and is free of "
-"major defects"
-msgstr ""
-"namestili dodatek, se prepričali, da deluje, kot je opisano, in da je brez "
-"večjih napak"
+msgid "install the add-on, making sure it functions as described and is free of major defects"
+msgstr "namestili dodatek, se prepričali, da deluje, kot je opisano, in da je brez večjih napak"
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:69
-msgid ""
-"perform a source code review, looking for performance and security best "
-"practices"
-msgstr ""
-"opravili pregled izvorne kode z vidika zmogljivosti in pravil za varnostno "
-"prakso"
+msgid "perform a source code review, looking for performance and security best practices"
+msgstr "opravili pregled izvorne kode z vidika zmogljivosti in pravil za varnostno prakso"
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:74
 msgid "ensure the add-on's privacy policy is in line with its functionality"
-msgstr ""
-"se prepričali, da so pravila zasebnosti pri dodatku v skladu s "
-"funkcionalnostjo"
+msgstr "se prepričali, da so pravila zasebnosti pri dodatku v skladu s funkcionalnostjo"
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:79
-msgid ""
-"look for compliance with all of Mozilla's policies, detailed in these "
-"documents"
-msgstr ""
-"preverili, da se vsa pravila Mozille, podrobno opisana v teh dokumentih, "
-"izpolnjuje"
+msgid "look for compliance with all of Mozilla's policies, detailed in these documents"
+msgstr "preverili, da se vsa pravila Mozille, podrobno opisana v teh dokumentih, izpolnjuje"
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:86
-msgid ""
-"Some of the most common issues we see when performing these reviews are:"
-msgstr ""
-"Med najpogostejše probleme, na katere smo naleteli pri pregledih, spadajo "
-"med drugim:"
+msgid "Some of the most common issues we see when performing these reviews are:"
+msgstr "Med najpogostejše probleme, na katere smo naleteli pri pregledih, spadajo med drugim:"
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:93
 msgid ""
-"<strong>JavaScript namespace pollution</strong> &mdash; the most common "
-"violation. Be sure to <a "
-"href=\"https://developer.mozilla.org/en/XUL_School/JavaScript_Object_Management\">wrap"
-" your loose variables</a>"
+"<strong>JavaScript namespace pollution</strong> &mdash; the most common violation. Be sure to <a href=\"https://developer.mozilla.org/en/XUL_School/JavaScript_Object_Management\">wrap your loose "
+"variables</a>"
 msgstr ""
-"<strong>Onesnaženje imenskega prostora za JavaScript</strong> &mdash; "
-"najbolj pogosta kršitev. Zagotovite, da <a "
-"href=\"https://developer.mozilla.org/en/XUL_School/JavaScript_Object_Management\">bodo"
-" nepovezane spremenljivke ovite</a>"
+"<strong>Onesnaženje imenskega prostora za JavaScript</strong> &mdash; najbolj pogosta kršitev. Zagotovite, da <a href=\"https://developer.mozilla.org/en/XUL_School/JavaScript_Object_Management"
+"\">bodo nepovezane spremenljivke ovite</a>"
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:99
-msgid ""
-"proper preference naming - all preference names should begin with "
-"\"extensions.\", followed by the add-on name or some other unique identifier"
-msgstr ""
-"pravilno poimenovanje preferenc - vsa imena za preference je treba začeti z "
-"\"extensions.\", nato sledi ime dodatka ali kak drug enolični identifikator."
+msgid "proper preference naming - all preference names should begin with \"extensions.\", followed by the add-on name or some other unique identifier"
+msgstr "pravilno poimenovanje preferenc - vsa imena za preference je treba začeti z \"extensions.\", nato sledi ime dodatka ali kak drug enolični identifikator."
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:103
 msgid "remote JavaScript execution or injection"
@@ -7374,100 +5780,65 @@ msgstr "poslabšanje pri zagonu aplikacije ali pri nalaganju spletnih strani"
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:117
 #, python-format
 msgid ""
-"For information on how to avoid these problems, please see our <a "
-"href=\"%(link_howto)s\">How-to Library</a>. Some of these practices, such as"
-" binary or obfuscated code, are allowed under certain conditions outlined "
-"below."
+"For information on how to avoid these problems, please see our <a href=\"%(link_howto)s\">How-to Library</a>. Some of these practices, such as binary or obfuscated code, are allowed under certain "
+"conditions outlined below."
 msgstr ""
-"Za podatke o tem, kako se takim problemom izogniti, obiščite <a "
-"href=\"%(link_howto)s\">Kako-se? knjižnico</a>. Nekateri od teh pristopov, "
-"kot so binarna ali šifrirana koda, so dovoljeni pod določenimi pogoji, "
-"navedenimi v nadaljevanju."
+"Za podatke o tem, kako se takim problemom izogniti, obiščite <a href=\"%(link_howto)s\">Kako-se? knjižnico</a>. Nekateri od teh pristopov, kot so binarna ali šifrirana koda, so dovoljeni pod "
+"določenimi pogoji, navedenimi v nadaljevanju."
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:123
 #, python-format
 msgid ""
-"Many of the above restrictions are tested automatically by an extension "
-"scanner that will flag suspicious add-ons for editor review. You can read "
-"more about this scanner in the <a href=\"%(link_validation)s\">Validation "
-"Help</a> document."
+"Many of the above restrictions are tested automatically by an extension scanner that will flag suspicious add-ons for editor review. You can read more about this scanner in the <a href="
+"\"%(link_validation)s\">Validation Help</a> document."
 msgstr ""
-"Mnoge od zgoraj navedenih omejitev se samodejno preskusi s preiskovalnikom "
-"razširitev, ki bo sumljive dodatke označil za uredniški pregled. Več o tem "
-"si lahko preberete v dokumentu <a href=\"%(link_validation)s\">Pomoč pri "
-"preverjanju veljavnosti</a>."
+"Mnoge od zgoraj navedenih omejitev se samodejno preskusi s preiskovalnikom razširitev, ki bo sumljive dodatke označil za uredniški pregled. Več o tem si lahko preberete v dokumentu <a href="
+"\"%(link_validation)s\">Pomoč pri preverjanju veljavnosti</a>."
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:129
 msgid ""
-"If the add-on is site-specific, it is recommended that a test account is "
-"provided for use during the review process. Additionally, including detailed"
-" testing instructions will allow an editor to better understand how the add-"
-"on functions and expedite the testing process. This information can be "
-"placed in the Notes to Reviewer field when editing a version in the "
-"Developer Hub."
+"If the add-on is site-specific, it is recommended that a test account is provided for use during the review process. Additionally, including detailed testing instructions will allow an editor to "
+"better understand how the add-on functions and expedite the testing process. This information can be placed in the Notes to Reviewer field when editing a version in the Developer Hub."
 msgstr ""
-"Če je dodatek vezan na določeno spletno stran, je priporočljivo, da "
-"pregledovalcu ponudite testni račun, ki ga bo lahko uporabil med postopkom "
-"pregleda. Dobro je tudi, da mu napišete podrobna navodila za testiranje, ki "
-"bodo omogočila pregledovalcu bolje razumeti, kako dodatek deluje, in tako "
-"pospešila postopek testiranja. Te podatke lahko vnesete v polje Opombe za "
-"pregledovalca, ko v razvojnem centru urejate različico."
+"Če je dodatek vezan na določeno spletno stran, je priporočljivo, da pregledovalcu ponudite testni račun, ki ga bo lahko uporabil med postopkom pregleda. Dobro je tudi, da mu napišete podrobna "
+"navodila za testiranje, ki bodo omogočila pregledovalcu bolje razumeti, kako dodatek deluje, in tako pospešila postopek testiranja. Te podatke lahko vnesete v polje Opombe za pregledovalca, ko v "
+"razvojnem centru urejate različico."
 
-#: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:134
-#: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:168
+#: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:134 src/olympia/devhub/templates/devhub/docs/policies-reviews.html:168
 msgid "After the Review"
 msgstr "Po pregledu"
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:136
 msgid ""
-"Once an add-on is granted full review, it will immediately be available in "
-"the gallery, showing in browse and search results with a warning-free "
-"install button. All features, including voluntary contributions and beta "
-"channels will be available."
+"Once an add-on is granted full review, it will immediately be available in the gallery, showing in browse and search results with a warning-free install button. All features, including voluntary "
+"contributions and beta channels will be available."
 msgstr ""
-"Ko se za dodatek dovoli popoln pregled, bo takoj na voljo v galeriji, videti"
-" ga bo v rezultatih brskanja in iskanja z gumbom za namestitev brez "
-"opozoril. Vse funkcije, vključno s prostovoljnimi prispevki in beta kanali, "
-"bodo na voljo."
+"Ko se za dodatek dovoli popoln pregled, bo takoj na voljo v galeriji, videti ga bo v rezultatih brskanja in iskanja z gumbom za namestitev brez opozoril. Vse funkcije, vključno s prostovoljnimi "
+"prispevki in beta kanali, bodo na voljo."
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:142
 msgid ""
-"Subsequent versions of the add-on will automatically be placed in the full "
-"review queue. Until the review is completed, the new version will only be "
-"displayed on the Version History page of the add-on. Once reviewed, the "
-"version will be updated across the site and deployed through the automatic "
-"update service."
+"Subsequent versions of the add-on will automatically be placed in the full review queue. Until the review is completed, the new version will only be displayed on the Version History page of the add-"
+"on. Once reviewed, the version will be updated across the site and deployed through the automatic update service."
 msgstr ""
-"Kasnejše različice dodatka se bo samodejno postavilo v čakalno vrsto za "
-"celoten pregled. Dokler se ne konča s pregledom, bo novo različico videti le"
-" na strani Zgodovina različic za dodatek. Ko jo bodo pregledali, se bo "
-"različico posodobilo po celotnem spletišču in začelo se jo bo širiti prek "
-"samodejnega postopka za posodabljanje."
+"Kasnejše različice dodatka se bo samodejno postavilo v čakalno vrsto za celoten pregled. Dokler se ne konča s pregledom, bo novo različico videti le na strani Zgodovina različic za dodatek. Ko jo "
+"bodo pregledali, se bo različico posodobilo po celotnem spletišču in začelo se jo bo širiti prek samodejnega postopka za posodabljanje."
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:148
 msgid ""
-"If a version does not meet the criteria for full review, it can either be "
-"granted preliminary review or disabled if there is a security concern. The "
-"author will receive an email explaining the action taken and how to fix it. "
-"In most cases, the developer can simply fix the problem and re-submit for "
-"full review."
+"If a version does not meet the criteria for full review, it can either be granted preliminary review or disabled if there is a security concern. The author will receive an email explaining the "
+"action taken and how to fix it. In most cases, the developer can simply fix the problem and re-submit for full review."
 msgstr ""
-"Če različica ne izpolnjuje kriterijev za popoln pregled, se lahko bodisi "
-"odobri predhodni pregled ali pa se jo, če obstaja vprašanje varnosti, "
-"onesposobi. Avtor bo prejel e-pošto s pojasnilom ukrepov in o tem, kaj lahko"
-" stori. V večini primerov lahko razvijalec enostavno reši problem in dodatek"
-" ponovno pošlje v celoten pregled."
+"Če različica ne izpolnjuje kriterijev za popoln pregled, se lahko bodisi odobri predhodni pregled ali pa se jo, če obstaja vprašanje varnosti, onesposobi. Avtor bo prejel e-pošto s pojasnilom "
+"ukrepov in o tem, kaj lahko stori. V večini primerov lahko razvijalec enostavno reši problem in dodatek ponovno pošlje v celoten pregled."
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:155
 msgid ""
-"Preliminary reviews are appropriate for experimental add-ons and provide a "
-"way to get user testing and feedback without going through the longer, more "
-"thorough review process. We aim to complete these reviews in under 3 days."
+"Preliminary reviews are appropriate for experimental add-ons and provide a way to get user testing and feedback without going through the longer, more thorough review process. We aim to complete "
+"these reviews in under 3 days."
 msgstr ""
-"Predhodni pregledi so primerni za eksperimentalne dodatke in uporabnikom "
-"omogočajo testiranje dodatka in pošiljanje povratnih informacij, ne da bi "
-"bilo zato potrebno iti skozi daljši, temeljitejši proces pregleda. Naš cilj "
-"je te preglede opraviti v največ 3 dneh."
+"Predhodni pregledi so primerni za eksperimentalne dodatke in uporabnikom omogočajo testiranje dodatka in pošiljanje povratnih informacij, ne da bi bilo zato potrebno iti skozi daljši, temeljitejši "
+"proces pregleda. Naš cilj je te preglede opraviti v največ 3 dneh."
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:160
 msgid "Testing Methods"
@@ -7475,57 +5846,33 @@ msgstr "Testne metode"
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:162
 msgid ""
-"When performing a preliminary review, editors will review the source code "
-"for security issues and major policy violations, but will not install the "
-"add-on to test functionality in most cases. Preliminary review will be "
-"granted unless a security vulnerability or major policy violation is "
-"discovered."
+"When performing a preliminary review, editors will review the source code for security issues and major policy violations, but will not install the add-on to test functionality in most cases. "
+"Preliminary review will be granted unless a security vulnerability or major policy violation is discovered."
 msgstr ""
-"Pri izvajanju predhodnega pregleda bodo uredniki pregledali izvorno kodo s "
-"stališča varnosti in večjih kršitev pravilnika, vendar dodatka v večini "
-"primerov ne bodo nameščali, da bi preizkusili njegovo funkcionalnost. "
-"Predhodni pregled se bo odobrilo, razen če se ne odkrije varnostne "
-"ranljivosti ali večjih kršitev pravilnika."
+"Pri izvajanju predhodnega pregleda bodo uredniki pregledali izvorno kodo s stališča varnosti in večjih kršitev pravilnika, vendar dodatka v večini primerov ne bodo nameščali, da bi preizkusili "
+"njegovo funkcionalnost. Predhodni pregled se bo odobrilo, razen če se ne odkrije varnostne ranljivosti ali večjih kršitev pravilnika."
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:171
 msgid ""
-"Once preliminary review is granted, the add-on will be immediately available"
-" in the gallery, showing in browse and search results but ranked lower than "
-"fully-reviewed add-ons. Install buttons will have caution stripes and a "
-"notice that the add-on is experimental and not fully reviewed by Mozilla, "
-"though no click-through is required. Additionally, these add-ons cannot use "
-"the voluntary contributions and beta channel features."
+"Once preliminary review is granted, the add-on will be immediately available in the gallery, showing in browse and search results but ranked lower than fully-reviewed add-ons. Install buttons will "
+"have caution stripes and a notice that the add-on is experimental and not fully reviewed by Mozilla, though no click-through is required. Additionally, these add-ons cannot use the voluntary "
+"contributions and beta channel features."
 msgstr ""
-"Ko je bilo začasni pregled enkrat izdan, je dodatek takoj na voljo v "
-"galeriji, pojavi se pri brskanju in v rezultatih iskanja, vendar bo uvrščen "
-"niže kot v celoti pregledani dodatki. Namestiveni gumbi bodo šrafirani v "
-"opozorilo, poleg tega bo videti sporočilo, da je dodatek poizkusne narave in"
-" da ga Mozilla ni v celoti pregledala, četudi se kompletno klikanje ne "
-"zahteva. Poleg tega ti dodatki ne smejo predlagati prostovoljnih prispevkov "
-"in funkcije beta kanala jim niso na voljo."
+"Ko je bilo začasni pregled enkrat izdan, je dodatek takoj na voljo v galeriji, pojavi se pri brskanju in v rezultatih iskanja, vendar bo uvrščen niže kot v celoti pregledani dodatki. Namestiveni "
+"gumbi bodo šrafirani v opozorilo, poleg tega bo videti sporočilo, da je dodatek poizkusne narave in da ga Mozilla ni v celoti pregledala, četudi se kompletno klikanje ne zahteva. Poleg tega ti "
+"dodatki ne smejo predlagati prostovoljnih prispevkov in funkcije beta kanala jim niso na voljo."
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:177
-msgid ""
-"After being granted preliminary review, Mozilla may later revoke the review "
-"if other serious problems are reported to us by users."
-msgstr ""
-"Potem ko je bil odobren začasen pregled, lahko Mozilla pozneje pregled "
-"prekliče, če nam uporabniki sporočijo, da so naleteli na druge resne "
-"probleme."
+msgid "After being granted preliminary review, Mozilla may later revoke the review if other serious problems are reported to us by users."
+msgstr "Potem ko je bil odobren začasen pregled, lahko Mozilla pozneje pregled prekliče, če nam uporabniki sporočijo, da so naleteli na druge resne probleme."
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:183
 msgid ""
-"Subsequent versions of the add-on will automatically be placed in the "
-"preliminary review queue. Until the review is completed, the new version "
-"will only be displayed on the Version History page of the add-on. Once "
-"reviewed, the version will be updated across the site and deployed through "
-"the automatic update service."
+"Subsequent versions of the add-on will automatically be placed in the preliminary review queue. Until the review is completed, the new version will only be displayed on the Version History page of "
+"the add-on. Once reviewed, the version will be updated across the site and deployed through the automatic update service."
 msgstr ""
-"Kasnejše različice dodatka se bo samodejno postavilo v čakalno vrsto za "
-"predhoden pregled. Dokler se ne konča s pregledom, bo novo različico videti "
-"le na strani Zgodovina različic za dodatek. Ko jo bodo pregledali, se bo "
-"različico posodobilo po celotnem spletišču in začelo se jo bo razpošiljati s"
-" samodejnim postopkom za posodabljanje."
+"Kasnejše različice dodatka se bo samodejno postavilo v čakalno vrsto za predhoden pregled. Dokler se ne konča s pregledom, bo novo različico videti le na strani Zgodovina različic za dodatek. Ko jo "
+"bodo pregledali, se bo različico posodobilo po celotnem spletišču in začelo se jo bo razpošiljati s samodejnim postopkom za posodabljanje."
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:188
 msgid "Policies on Specific Add-on Practices"
@@ -7540,59 +5887,32 @@ msgid "The following add-ons are not permitted in any form:"
 msgstr "Naslednji dodatki v kakršni koli obliki niso dovoljeni:"
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:194
-msgid ""
-"Add-ons that embed known <a "
-"href=\"http://en.wikipedia.org/wiki/Spyware\">spyware</a> or <a "
-"href=\"http://en.wikipedia.org/wiki/Malware\">malware</a>"
-msgstr ""
-"Dodatki, ki vsebujejo poznano <a "
-"href=\"http://en.wikipedia.org/wiki/Spyware\">vohunsko </a> ali <a "
-"href=\"http://en.wikipedia.org/wiki/Malware\">zlonamerno</a> programsko "
-"opremo"
+msgid "Add-ons that embed known <a href=\"http://en.wikipedia.org/wiki/Spyware\">spyware</a> or <a href=\"http://en.wikipedia.org/wiki/Malware\">malware</a>"
+msgstr "Dodatki, ki vsebujejo poznano <a href=\"http://en.wikipedia.org/wiki/Spyware\">vohunsko </a> ali <a href=\"http://en.wikipedia.org/wiki/Malware\">zlonamerno</a> programsko opremo"
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:199
 msgid ""
-"Illegal and criminal add-ons, such as <a "
-"href=\"http://en.wikipedia.org/wiki/Click_fraud\">click fraud</a> "
-"generators, <a href=\"http://en.wikipedia.org/wiki/Warez\">warez</a> "
-"download and directory assistants, child pornography finders, etc."
+"Illegal and criminal add-ons, such as <a href=\"http://en.wikipedia.org/wiki/Click_fraud\">click fraud</a> generators, <a href=\"http://en.wikipedia.org/wiki/Warez\">warez</a> download and "
+"directory assistants, child pornography finders, etc."
 msgstr ""
-"Nezakonite in kaznive dodatke, kot so generatorji za <a "
-"href=\"http://en.wikipedia.org/wiki/Click_fraud\">prevare na klik</a>, "
-"pomočniki za prenose in mape <a "
-"href=\"http://en.wikipedia.org/wiki/Warez\">warez</a> , otroška pornografija"
-" itd."
+"Nezakonite in kaznive dodatke, kot so generatorji za <a href=\"http://en.wikipedia.org/wiki/Click_fraud\">prevare na klik</a>, pomočniki za prenose in mape <a href=\"http://en.wikipedia.org/wiki/"
+"Warez\">warez</a> , otroška pornografija itd."
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:204
-msgid ""
-"Add-ons whose main purpose is to facilitate access to pornographic material,"
-" or include references to this material in their descriptions"
-msgstr ""
-"Dodatki, ki imajo glavni namen olajšati dostop do pornografskega materiala "
-"ali ki vključujejo sklice na tak material v svojih opisih"
+msgid "Add-ons whose main purpose is to facilitate access to pornographic material, or include references to this material in their descriptions"
+msgstr "Dodatki, ki imajo glavni namen olajšati dostop do pornografskega materiala ali ki vključujejo sklice na tak material v svojih opisih"
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:210
-msgid ""
-"Add-ons that, upon installation, auto-install or launch installers of non-"
-"Firefox software"
-msgstr ""
-"Dodatki, ki se ob namestitvi začnejo sami od sebe nameščati ali ki sprožijo "
-"nameščanje programske opreme, ki ni v zvezi z Firefoxom"
+msgid "Add-ons that, upon installation, auto-install or launch installers of non-Firefox software"
+msgstr "Dodatki, ki se ob namestitvi začnejo sami od sebe nameščati ali ki sprožijo nameščanje programske opreme, ki ni v zvezi z Firefoxom"
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:215
-msgid ""
-"Add-ons that provide their own update mechanism for code or search engines"
-msgstr ""
-"Dodatki, ki vsebujejo svoj lastni posodobitveni mehanizem za kodo ali "
-"iskalnike"
+msgid "Add-ons that provide their own update mechanism for code or search engines"
+msgstr "Dodatki, ki vsebujejo svoj lastni posodobitveni mehanizem za kodo ali iskalnike"
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:220
-msgid ""
-"Add-ons that make changes to web content in ways that are non-obvious or "
-"difficult to trace by their users"
-msgstr ""
-"Dodatki, ki spreminjajo vsebino spleta na način, ki za uporabnika ni očiten "
-"ali pa je težko dokazljiv"
+msgid "Add-ons that make changes to web content in ways that are non-obvious or difficult to trace by their users"
+msgstr "Dodatki, ki spreminjajo vsebino spleta na način, ki za uporabnika ni očiten ali pa je težko dokazljiv"
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:225
 msgid "Add-ons that snoop on or intercept the network traffic of other users"
@@ -7600,8 +5920,7 @@ msgstr "Dodatki, ki vohunijo ali prestrezajo mrežni promet drugih"
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:230
 msgid "Conduit-based toolbars without explicit pre-approval"
-msgstr ""
-"Orodne vrstice na osnovi tunela (conduit) brez izrecne predhodne odobritve"
+msgstr "Orodne vrstice na osnovi tunela (conduit) brez izrecne predhodne odobritve"
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:236
 msgid "Changing of Defaults and Unexpected Features"
@@ -7609,66 +5928,34 @@ msgstr "Spreminjanje privzetih nastavitev in nepričakovane funkcije"
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:238
 msgid ""
-"Surprises can be appropriate in many situations, but they are not welcome "
-"when user security, privacy, and control are at stake. It is extremely "
-"important to be as transparent as possible when submitting an add-on for "
-"hosting on this site. A Mozilla user should be able to easily discern what "
-"the functionality of an add-on is and not be presented with unexpected "
-"experiences post-install."
+"Surprises can be appropriate in many situations, but they are not welcome when user security, privacy, and control are at stake. It is extremely important to be as transparent as possible when "
+"submitting an add-on for hosting on this site. A Mozilla user should be able to easily discern what the functionality of an add-on is and not be presented with unexpected experiences post-install."
 msgstr ""
-"Presenečenje je lahko v veliko situacijah dobrodošlo, vendar je nezaželeno, "
-"kadar so varnost, zasebnost in nadzor uporabnika ogroženi. Izjemno pomembno "
-"je, da je ob pošiljanju dodatka za gostovanje na tej spletni strani vse čim "
-"bolj pregledno. Uporabnik Mozille mora imeti možnost zlahka razumeti, kaj je"
-" funkcionalnost dodatka, ne pa da se po namestitvi mora soočati z "
-"nepričakovanim vedenjem brskalnika."
+"Presenečenje je lahko v veliko situacijah dobrodošlo, vendar je nezaželeno, kadar so varnost, zasebnost in nadzor uporabnika ogroženi. Izjemno pomembno je, da je ob pošiljanju dodatka za gostovanje "
+"na tej spletni strani vse čim bolj pregledno. Uporabnik Mozille mora imeti možnost zlahka razumeti, kaj je funkcionalnost dodatka, ne pa da se po namestitvi mora soočati z nepričakovanim vedenjem "
+"brskalnika."
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:243
 msgid ""
-"<p> Whenever an add-on includes any unexpected* feature that </p> <ul> "
-"<li>compromises user privacy or security (like sending data to third "
-"parties),</li> <li>changes default settings like the homepage or search "
-"engine, or</li> <li>changes settings or features in other add-ons or "
-"deactivates them altogether</li> </ul> <p>the features must adhere to the "
-"following requirements:</p> <ul> <li>The add-on description must clearly "
-"state what changes the add-on makes.</li> <li>All changes must be opt-in, "
-"meaning the user must take non-default action to enact the change.</li> "
-"<li>The opt-in dialog must clearly state the name of the add-on requesting "
-"the change.</li> <li>Uninstalling the add-on restores the user's original "
-"settings if they were changed.</li> </ul> <p>*Unexpected features are those "
-"that are unrelated to the add-on's primary function.</p>"
+"<p> Whenever an add-on includes any unexpected* feature that </p> <ul> <li>compromises user privacy or security (like sending data to third parties),</li> <li>changes default settings like the "
+"homepage or search engine, or</li> <li>changes settings or features in other add-ons or deactivates them altogether</li> </ul> <p>the features must adhere to the following requirements:</p> <ul> "
+"<li>The add-on description must clearly state what changes the add-on makes.</li> <li>All changes must be opt-in, meaning the user must take non-default action to enact the change.</li> <li>The opt-"
+"in dialog must clearly state the name of the add-on requesting the change.</li> <li>Uninstalling the add-on restores the user's original settings if they were changed.</li> </ul> <p>*Unexpected "
+"features are those that are unrelated to the add-on's primary function.</p>"
 msgstr ""
-"<p> Kadarkoli kak dodatek vsebuje nepričakovano* funkcijo, ki </p> <ul> "
-"<li>kompromitira zasebnost ali varnost uporabnika (npr. pošilja podatke "
-"tretjim osebam),</li> <li>spremeni privzete nastavitve, kot sta domača stran"
-" ali privzeti iskalnik, ali</li> <li>spremeni nastavitve ali funkcije v "
-"drugih dodatkih ali pa jih celo onemogoči</li> </ul> <p>mora funkcija "
-"upoštevati naslednje zahteve:</p> <ul> <li>V opisu dodatka mora biti jasno "
-"navedeno, kakšne spremembe dodatek naredi.</li> <li> Vse spremembe morajo "
-"biti opt-in, kar pomeni, da mora uporabnik izvesti možnost, ki ni privzeta, "
-"da sprejme spremembo.</li> <li>V pogovornem oknu za opt-in mora biti jasno "
-"navedeno ime dodatka, ki zahteva spremembo.</li> <li>Odstranitev dodatka "
-"mora obnoviti uporabnikove prvotne nastavitve, če so bile spremenjene.</li> "
-"</ul> <p>* Nepričakovane funkcije so funkcije, ki niso povezane z osnovno "
-"funkcijo dodatka.</p>"
+"<p> Kadarkoli kak dodatek vsebuje nepričakovano* funkcijo, ki </p> <ul> <li>kompromitira zasebnost ali varnost uporabnika (npr. pošilja podatke tretjim osebam),</li> <li>spremeni privzete "
+"nastavitve, kot sta domača stran ali privzeti iskalnik, ali</li> <li>spremeni nastavitve ali funkcije v drugih dodatkih ali pa jih celo onemogoči</li> </ul> <p>mora funkcija upoštevati naslednje "
+"zahteve:</p> <ul> <li>V opisu dodatka mora biti jasno navedeno, kakšne spremembe dodatek naredi.</li> <li> Vse spremembe morajo biti opt-in, kar pomeni, da mora uporabnik izvesti možnost, ki ni "
+"privzeta, da sprejme spremembo.</li> <li>V pogovornem oknu za opt-in mora biti jasno navedeno ime dodatka, ki zahteva spremembo.</li> <li>Odstranitev dodatka mora obnoviti uporabnikove prvotne "
+"nastavitve, če so bile spremenjene.</li> </ul> <p>* Nepričakovane funkcije so funkcije, ki niso povezane z osnovno funkcijo dodatka.</p>"
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:268
-msgid ""
-"These features cannot be introduced into an update of a fully-reviewed add-"
-"on; the opt-in change process must be part of the initial review."
-msgstr ""
-"Te funkcije se ne sme uvajati v posodobitev polno pregledanega dodatka, "
-"proces opt-in za spremembe mora biti del začetnega pregleda."
+msgid "These features cannot be introduced into an update of a fully-reviewed add-on; the opt-in change process must be part of the initial review."
+msgstr "Te funkcije se ne sme uvajati v posodobitev polno pregledanega dodatka, proces opt-in za spremembe mora biti del začetnega pregleda."
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:274
-msgid ""
-"These are minimum requirements and not a guarantee that the add-on will be "
-"approved. This section applies to all add-ons hosted on the site, including "
-"preliminarily reviewed add-ons."
-msgstr ""
-"To so minimalne zahteve, ki ne zagotavljajo, da bo dodatek odobren. Ta "
-"oddelek velja za vse dodatke, ki se jih gostuje na spletni strani, vključno "
-"s predhodno pregledanimi dodatki."
+msgid "These are minimum requirements and not a guarantee that the add-on will be approved. This section applies to all add-ons hosted on the site, including preliminarily reviewed add-ons."
+msgstr "To so minimalne zahteve, ki ne zagotavljajo, da bo dodatek odobren. Ta oddelek velja za vse dodatke, ki se jih gostuje na spletni strani, vključno s predhodno pregledanimi dodatki."
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:279
 msgid "Private Browsing Mode"
@@ -7676,18 +5963,11 @@ msgstr "Način za zasebno brskanje"
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:282
 msgid ""
-"Add-ons that store or otherwise handle browsing data must support <a "
-"href=\"https://developer.mozilla.org/En/Supporting_private_browsing_mode\">Private"
-" Browsing Mode</a>.  During a Private Browsing session, no browsing data can"
-" be written to disk, and all of this data must be cleared when Firefox quits"
-" or the Private Browsing session ends."
+"Add-ons that store or otherwise handle browsing data must support <a href=\"https://developer.mozilla.org/En/Supporting_private_browsing_mode\">Private Browsing Mode</a>. During a Private Browsing "
+"session, no browsing data can be written to disk, and all of this data must be cleared when Firefox quits or the Private Browsing session ends."
 msgstr ""
-"Dodatki, ki shranjujejo ali drugače ravnajo s podatki brskanja, morajo "
-"podpirati <a "
-"href=\"https://developer.mozilla.org/En/Supporting_private_browsing_mode\">Zasebno"
-" brskanje</a>.  Med sejo Zasebnega brskanja se na disk ne sme zapisati "
-"nobenih podatkov o brskanju in vsi ti podatki se morajo ob izhodu iz "
-"Firefoxa ali seje Zasebnega brskanja počistiti."
+"Dodatki, ki shranjujejo ali drugače ravnajo s podatki brskanja, morajo podpirati <a href=\"https://developer.mozilla.org/En/Supporting_private_browsing_mode\">Zasebno brskanje</a>.  Med sejo "
+"Zasebnega brskanja se na disk ne sme zapisati nobenih podatkov o brskanju in vsi ti podatki se morajo ob izhodu iz Firefoxa ali seje Zasebnega brskanja počistiti."
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:287
 msgid "Binary Components & Obfuscated Code"
@@ -7695,40 +5975,24 @@ msgstr "Binarne komponente in zabrisana koda"
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:289
 msgid ""
-"Add-ons may contain binary, obfuscated and minified source code, but Mozilla"
-" must be allowed to review a copy of the human-readable source code of each "
-"version of an add-on submitted for review. These add-ons are ineligible for "
-"preliminary review and must choose the full review process."
+"Add-ons may contain binary, obfuscated and minified source code, but Mozilla must be allowed to review a copy of the human-readable source code of each version of an add-on submitted for review. "
+"These add-ons are ineligible for preliminary review and must choose the full review process."
 msgstr ""
-"Dodatek lahko vsebuje binarno, zapleteno in pomanjšano izvorno kodo, vendar "
-"je treba Mozilli omogočiti, da pregleda berljivo kopijo izvorne kode za "
-"vsako različico dodatka, ki se jo pošlje v pregled. Ti dodatki za predhodni "
-"pregled niso ustrezni in zanje morate izbrati celoten proces pregleda."
+"Dodatek lahko vsebuje binarno, zapleteno in pomanjšano izvorno kodo, vendar je treba Mozilli omogočiti, da pregleda berljivo kopijo izvorne kode za vsako različico dodatka, ki se jo pošlje v "
+"pregled. Ti dodatki za predhodni pregled niso ustrezni in zanje morate izbrati celoten proces pregleda."
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:295
 msgid ""
-"If an add-on contains binary or obfuscated source code, the author will "
-"receive a message when the add-on is reviewed indicating whom to contact at "
-"Mozilla to coordinate review of the source code. This code will be reviewed "
-"by an administrator and will not be shared or redistributed in any way. The "
-"code will only be used for the purpose of reviewing the add-on."
+"If an add-on contains binary or obfuscated source code, the author will receive a message when the add-on is reviewed indicating whom to contact at Mozilla to coordinate review of the source code. "
+"This code will be reviewed by an administrator and will not be shared or redistributed in any way. The code will only be used for the purpose of reviewing the add-on."
 msgstr ""
-"Če dodatek vsebuje binarno ali zabrisano izvorno kodo, bo avtor prejel "
-"sporočilo, ko pride dodatek na vrsto za pregled, kjer bo tudi imenovana "
-"oseba pri Mozilli, ki usklajuje pregled izvorne kode. To kodo bo pregledal "
-"administrator in tretjim osebam se je ne bo v nobenem primeru dajalo v "
-"vpogled. Kodo se bo rabilo le za pregled dodatka."
+"Če dodatek vsebuje binarno ali zabrisano izvorno kodo, bo avtor prejel sporočilo, ko pride dodatek na vrsto za pregled, kjer bo tudi imenovana oseba pri Mozilli, ki usklajuje pregled izvorne kode. "
+"To kodo bo pregledal administrator in tretjim osebam se je ne bo v nobenem primeru dajalo v vpogled. Kodo se bo rabilo le za pregled dodatka."
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:301
 #, python-format
-msgid ""
-"If your add-on contains binary or obfuscated code that you don't own or "
-"can't get the source code for, you may <a href=\"%(link_contact)s\">contact "
-"us</a> for information on how to proceed."
-msgstr ""
-"Če vaš dodatek vsebuje binarno ali zabrisano kodo, vendar do izvorne kode ne"
-" morete priti, se prosim <a href=\"%(link_contact)s\"> obrnite na nas</a> "
-"glede nadaljnjega postopka."
+msgid "If your add-on contains binary or obfuscated code that you don't own or can't get the source code for, you may <a href=\"%(link_contact)s\">contact us</a> for information on how to proceed."
+msgstr "Če vaš dodatek vsebuje binarno ali zabrisano kodo, vendar do izvorne kode ne morete priti, se prosim <a href=\"%(link_contact)s\"> obrnite na nas</a> glede nadaljnjega postopka."
 
 #: src/olympia/devhub/templates/devhub/docs/policies-submission.html:11
 msgid "Criteria for Submission"
@@ -7736,227 +6000,122 @@ msgstr "Merila za pošiljanje"
 
 #: src/olympia/devhub/templates/devhub/docs/policies-submission.html:13
 msgid ""
-"Add-ons hosted on Mozilla Add-ons should be of high quality and give users "
-"an improved web experience. We look for the following things when deciding "
-"whether an add-on is appropriate to be public and unrestricted:"
+"Add-ons hosted on Mozilla Add-ons should be of high quality and give users an improved web experience. We look for the following things when deciding whether an add-on is appropriate to be public "
+"and unrestricted:"
 msgstr ""
-"Dodatki, ki se jih gostuje na Mozilli, bi morali biti visoke kakovosti in "
-"omogočati uporabnikom lažje in ugodnejše delo na spletu. Ko se odločamo o "
-"tem, ali je kak dodatek primeren za javno distribucijo brez omejitev, "
-"upoštevamo naslednje stvari:"
+"Dodatki, ki se jih gostuje na Mozilli, bi morali biti visoke kakovosti in omogočati uporabnikom lažje in ugodnejše delo na spletu. Ko se odločamo o tem, ali je kak dodatek primeren za javno "
+"distribucijo brez omejitev, upoštevamo naslednje stvari:"
 
 #: src/olympia/devhub/templates/devhub/docs/policies-submission.html:19
 msgid ""
-"<strong>Are you responsive?</strong> We expect that an author who is "
-"promoting their add-on to our applications' many users is responsive to "
-"problem reports, maintains their contact information, and updates their add-"
-"on promptly to keep current with Firefox releases and changes in our "
-"policies. This doesn't mean that you have to reply to every question that "
-"someone posts in the discussions, or that you even need to fix every bug, "
-"but we do expect that you will respond to issues in a manner that's "
-"appropriate to the severity of the issue in question."
+"<strong>Are you responsive?</strong> We expect that an author who is promoting their add-on to our applications' many users is responsive to problem reports, maintains their contact information, "
+"and updates their add-on promptly to keep current with Firefox releases and changes in our policies. This doesn't mean that you have to reply to every question that someone posts in the "
+"discussions, or that you even need to fix every bug, but we do expect that you will respond to issues in a manner that's appropriate to the severity of the issue in question."
 msgstr ""
-"<strong>Ste odzivni?</strong> Pričakujemo, da bo avtor, ki nudi svoje "
-"dodatke številnim uporabnikom naših aplikacij, imel aktiven odnos do poročil"
-" o težavah, da bo skrbel za svoje kontaktne podatke in da bo svoje izdelke "
-"dovolj hitro prilagajal na nove različice Firefoxa in na spremembe v naših "
-"smernicah. To ne pomeni, da morate odgovoriti na vsako vprašanje, ki se "
-"lahko pojavi v kaki diskusiji, tudi ni nujno, da prav vsako napako "
-"popravite, pričakujemo samo, da se boste odzivali na vprašanja na način, ki "
-"je za resnost obravnavane zadeve ustrezen."
+"<strong>Ste odzivni?</strong> Pričakujemo, da bo avtor, ki nudi svoje dodatke številnim uporabnikom naših aplikacij, imel aktiven odnos do poročil o težavah, da bo skrbel za svoje kontaktne podatke "
+"in da bo svoje izdelke dovolj hitro prilagajal na nove različice Firefoxa in na spremembe v naših smernicah. To ne pomeni, da morate odgovoriti na vsako vprašanje, ki se lahko pojavi v kaki "
+"diskusiji, tudi ni nujno, da prav vsako napako popravite, pričakujemo samo, da se boste odzivali na vprašanja na način, ki je za resnost obravnavane zadeve ustrezen."
 
 #: src/olympia/devhub/templates/devhub/docs/policies-submission.html:25
 msgid ""
-"<strong>Is the add-on clearly and accurately described?</strong> It's of the"
-" utmost importance to us that users get what they expect when they try a new"
-" add-on. Your add-on name should be clear and concise, and you should "
-"refrain from using special characters or numbers to get higher search "
-"rankings or for decorative purposes. Your description should provide details"
-" about what the add-on does, how a user should take advantage of it, and "
-"what the user should expect when they install it. Links to external "
-"documents for detailed instructions are fine, but the description itself "
-"should cover the basics and leave users confident that they know what "
-"they'll get. Also, it is important that you maintain version notes "
-"appropriately as you improve and change your add-on. Users should be able to"
-" see what's new in an add-on they may have tried previously, and should be "
-"made aware of changes that might affect their current use of the add-on when"
-" they update."
+"<strong>Is the add-on clearly and accurately described?</strong> It's of the utmost importance to us that users get what they expect when they try a new add-on. Your add-on name should be clear and "
+"concise, and you should refrain from using special characters or numbers to get higher search rankings or for decorative purposes. Your description should provide details about what the add-on "
+"does, how a user should take advantage of it, and what the user should expect when they install it. Links to external documents for detailed instructions are fine, but the description itself should "
+"cover the basics and leave users confident that they know what they'll get. Also, it is important that you maintain version notes appropriately as you improve and change your add-on. Users should "
+"be able to see what's new in an add-on they may have tried previously, and should be made aware of changes that might affect their current use of the add-on when they update."
 msgstr ""
-"<strong>Je dodatek jasno in natančno opisan?</strong> Izredno pomembno je za"
-" nas, da uporabniki dobijo, kar so pričakovali, ko novi dodatek preizkušajo."
-" Ime dodatka naj boi jasno in jedrnato, ne uporabljajte pri tem za "
-"dekorativne namene ali v upanju na višjo uvrstitev kakih posebnih znakov ali"
-" številk. Vaš opis mora vsebovati podrobnosti o tem, kaj dodatek dela. kako "
-"naj ga stranka uporabi in kaj naj pričakuje, ko bo dodatek namestila. "
-"Povezave do zunanjih dokumentov za podrobna navodila so v redu, vendar pa "
-"sam opis mora zajemati osnove, tako da bodo uporabniki prepričani, da vedo, "
-"kaj imajo v rokah. Prav tako je pomembno, da vzdržuje ustrezne opombe o "
-"različicah, o tem, kaj ste izboljšali in kaj ste v dodatku spremenili. "
-"Uporabniki bi morali dobiti možnost videti. kaj je novega v dodatku, ki so "
-"ga mogoče že nekoč preizkusili, in zvedeti, kaj bi se pri delu z dodatkom "
-"spremenilo, če ga posodobijo."
+"<strong>Je dodatek jasno in natančno opisan?</strong> Izredno pomembno je za nas, da uporabniki dobijo, kar so pričakovali, ko novi dodatek preizkušajo. Ime dodatka naj boi jasno in jedrnato, ne "
+"uporabljajte pri tem za dekorativne namene ali v upanju na višjo uvrstitev kakih posebnih znakov ali številk. Vaš opis mora vsebovati podrobnosti o tem, kaj dodatek dela. kako naj ga stranka "
+"uporabi in kaj naj pričakuje, ko bo dodatek namestila. Povezave do zunanjih dokumentov za podrobna navodila so v redu, vendar pa sam opis mora zajemati osnove, tako da bodo uporabniki prepričani, "
+"da vedo, kaj imajo v rokah. Prav tako je pomembno, da vzdržuje ustrezne opombe o različicah, o tem, kaj ste izboljšali in kaj ste v dodatku spremenili. Uporabniki bi morali dobiti možnost videti. "
+"kaj je novega v dodatku, ki so ga mogoče že nekoč preizkusili, in zvedeti, kaj bi se pri delu z dodatkom spremenilo, če ga posodobijo."
 
 #: src/olympia/devhub/templates/devhub/docs/policies-submission.html:31
 msgid ""
-"<strong>Are all privacy and security concerns clearly spelled out?</strong> "
-"This is an aspect of a clear and accurate description, but such an important"
-" one that we feel it deserves specific mention. Many very useful and well-"
-"written add-ons manipulate some form of user data, or can present security "
-"hazards if misused; they are welcome on the site, but they must make it very"
-" clear to users what risks they might encounter, and what they can do to "
-"protect themselves."
+"<strong>Are all privacy and security concerns clearly spelled out?</strong> This is an aspect of a clear and accurate description, but such an important one that we feel it deserves specific "
+"mention. Many very useful and well-written add-ons manipulate some form of user data, or can present security hazards if misused; they are welcome on the site, but they must make it very clear to "
+"users what risks they might encounter, and what they can do to protect themselves."
 msgstr ""
-"<strong>Ali so vse točke, ki se tičejo zasebnosti in varnosti,  jasno "
-"navedene?</strong> Gre za to, da mora opis biti jasen in natančen, kar bi "
-"moralo biti samo po sebi umevno, vendar se nam zdi, da je zaradi velikega "
-"pomena to točko treba izrecno poudariti. Veliko zelo koristnih in dobro "
-"napisanih dodatkov obdeluje na svojski način uporabnikove podatke, ali pa "
-"lahko predstavlja nevarnost, če se jih uporablja narobe; na spletni strani "
-"so dobrodošli, vendar pa morajo uporabniku zelo jasno opisati, na kakšne "
-"navarnosti lahko naleti in kaj lahko stori, da se pred njimi zaščiti."
+"<strong>Ali so vse točke, ki se tičejo zasebnosti in varnosti,  jasno navedene?</strong> Gre za to, da mora opis biti jasen in natančen, kar bi moralo biti samo po sebi umevno, vendar se nam zdi, "
+"da je zaradi velikega pomena to točko treba izrecno poudariti. Veliko zelo koristnih in dobro napisanih dodatkov obdeluje na svojski način uporabnikove podatke, ali pa lahko predstavlja nevarnost, "
+"če se jih uporablja narobe; na spletni strani so dobrodošli, vendar pa morajo uporabniku zelo jasno opisati, na kakšne navarnosti lahko naleti in kaj lahko stori, da se pred njimi zaščiti."
 
 #: src/olympia/devhub/templates/devhub/docs/policies-submission.html:37
 msgid ""
-"<strong>Has the add-on been well-tested, and is it free of obvious or "
-"serious defects?</strong> One important thing that we look for when "
-"considering an add-on is whether its user reviews indicate that it has "
-"received thorough testing, and that it doesn't have serious problems or "
-"negative impacts on the browser. If reviewers report problems such as major "
-"performance issues, crashes, frequent problems using the functions of the "
-"add-on, or spamming of messages to the error console, you should take those "
-"reports to heart, and re-submit your add-on after you've addressed them as "
-"best you can. We don't expect you to perfectly optimize or have zero bugs "
-"&mdash; Firefox itself undergoes constant improvement in these areas &mdash;"
-" but we do want you to take reasonable efforts to minimize downsides, and to"
-" clearly call out cases where users may be surprised by those that remain."
+"<strong>Has the add-on been well-tested, and is it free of obvious or serious defects?</strong> One important thing that we look for when considering an add-on is whether its user reviews indicate "
+"that it has received thorough testing, and that it doesn't have serious problems or negative impacts on the browser. If reviewers report problems such as major performance issues, crashes, frequent "
+"problems using the functions of the add-on, or spamming of messages to the error console, you should take those reports to heart, and re-submit your add-on after you've addressed them as best you "
+"can. We don't expect you to perfectly optimize or have zero bugs &mdash; Firefox itself undergoes constant improvement in these areas &mdash; but we do want you to take reasonable efforts to "
+"minimize downsides, and to clearly call out cases where users may be surprised by those that remain."
 msgstr ""
-"<strong>Ali ste dodatek korenito preizkusili in ali je brez očitnih ali "
-"resnih pomanjkljivosti?</strong> Pri ocenah uporabnikov smo posebno pozorni "
-"na to, ali njihovi pregledi kažejo, da je dodatek bil temeljito preverjen in"
-" da z njim ni resnih težav, ki bi lahko negativno vplivale na brskalnik. Če "
-"uredniki poročajo o problemih, kot so resne težave pri delovanju, sesutja, "
-"pogoste težave pri uporabi dodatka, ali pa da prihaja do poplave sporočil na"
-" konzolo o napakah, si boste ta poročila morali vzeti k srcu in dodatek "
-"poslati v ponoven pregled, ko ste probleme po svoji najboljši volji in "
-"zmožnostih rešili. Ne pričakujemo, da boste izdelek popolnoma optimizirali "
-"in da bo brez hroščev - Firefox sam doživlja stalne izboljšave na teh "
-"področjih - vendar pa želimo, da se kolikor je mogoče potrudite in da za "
-"preostale probleme jasno obvestite uporabnika, kako se jim izogniti."
+"<strong>Ali ste dodatek korenito preizkusili in ali je brez očitnih ali resnih pomanjkljivosti?</strong> Pri ocenah uporabnikov smo posebno pozorni na to, ali njihovi pregledi kažejo, da je dodatek "
+"bil temeljito preverjen in da z njim ni resnih težav, ki bi lahko negativno vplivale na brskalnik. Če uredniki poročajo o problemih, kot so resne težave pri delovanju, sesutja, pogoste težave pri "
+"uporabi dodatka, ali pa da prihaja do poplave sporočil na konzolo o napakah, si boste ta poročila morali vzeti k srcu in dodatek poslati v ponoven pregled, ko ste probleme po svoji najboljši volji "
+"in zmožnostih rešili. Ne pričakujemo, da boste izdelek popolnoma optimizirali in da bo brez hroščev - Firefox sam doživlja stalne izboljšave na teh področjih - vendar pa želimo, da se kolikor je "
+"mogoče potrudite in da za preostale probleme jasno obvestite uporabnika, kako se jim izogniti."
 
 #: src/olympia/devhub/templates/devhub/docs/policies-submission.html:43
 msgid ""
-"<strong>Do the add-on and add-on author both treat the user "
-"respectfully?</strong> Your software should not intrude on the user "
-"unnecessarily, try to trick the user, or conceal any of its activities from "
-"the user. Users (or even non-users) are sometimes rude in their comments, "
-"and while we will do our best to filter out inaccurate reviews as they're "
-"reported to us, we do expect that authors will avoid retaliating with "
-"rudeness of their own."
+"<strong>Do the add-on and add-on author both treat the user respectfully?</strong> Your software should not intrude on the user unnecessarily, try to trick the user, or conceal any of its "
+"activities from the user. Users (or even non-users) are sometimes rude in their comments, and while we will do our best to filter out inaccurate reviews as they're reported to us, we do expect that "
+"authors will avoid retaliating with rudeness of their own."
 msgstr ""
-"<strong>Ali se tako dodatek kot njegov avtor spoštljivo vedeta do "
-"uporabnika?</strong> Program uporabnika ne sme po nepotrebnem motiti, ne sme"
-" ga skušati varati ali skrivati pred njim, kaj se dogaja. Uporabniki (pa "
-"tudi ne-uporabniki), so s svojimi pripombami lahko precej neposredni, in "
-"čeprav skušamo po svojih najboljših močeh netočne ocene, ki se nam jih "
-"pošilja, odstraniti, vseeno pričakujemo, da se bodo avtorji sami raje "
-"vnaprej izognili maščevanju za lastno nevljudnost."
+"<strong>Ali se tako dodatek kot njegov avtor spoštljivo vedeta do uporabnika?</strong> Program uporabnika ne sme po nepotrebnem motiti, ne sme ga skušati varati ali skrivati pred njim, kaj se "
+"dogaja. Uporabniki (pa tudi ne-uporabniki), so s svojimi pripombami lahko precej neposredni, in čeprav skušamo po svojih najboljših močeh netočne ocene, ki se nam jih pošilja, odstraniti, vseeno "
+"pričakujemo, da se bodo avtorji sami raje vnaprej izognili maščevanju za lastno nevljudnost."
 
 #: src/olympia/devhub/templates/devhub/docs/policies-submission.html:49
 msgid ""
-"<strong>Is the add-on useful to an appropriately wide portion of Firefox's "
-"users?</strong> Your add-on doesn't need to be the next Greasemonkey or "
-"Firebug, but if it is only useful to people at your company or who are part "
-"of a small web community, we may feel that it's not yet appropriate to put "
-"it in front of all of our users."
+"<strong>Is the add-on useful to an appropriately wide portion of Firefox's users?</strong> Your add-on doesn't need to be the next Greasemonkey or Firebug, but if it is only useful to people at "
+"your company or who are part of a small web community, we may feel that it's not yet appropriate to put it in front of all of our users."
 msgstr ""
-"<strong>Je dodatek koristen za primerno širok delež uporabnikov "
-"Firefoxa?</strong> Za vaš dodatek ni nujno, da bo naslednji Greasemonkey ali"
-" Firebug, če pa je samo koristen za vaše kolege v podjetju ali le za majhen "
-"del uporabnikov spleta, bomo morda mnenja, da je vprašljivo nuditi ga vsem "
-"našim uporabnikom."
+"<strong>Je dodatek koristen za primerno širok delež uporabnikov Firefoxa?</strong> Za vaš dodatek ni nujno, da bo naslednji Greasemonkey ali Firebug, če pa je samo koristen za vaše kolege v "
+"podjetju ali le za majhen del uporabnikov spleta, bomo morda mnenja, da je vprašljivo nuditi ga vsem našim uporabnikom."
 
 #: src/olympia/devhub/templates/devhub/docs/policies-submission.html:55
 msgid ""
-"We are constantly looking at ways to improve the organization of the site to"
-" better accommodate add-ons that are exemplary in other ways, but are aimed "
-"at only a small community of potential users. Correctly categorizing and "
-"maintaining the metadata of your add-on will help us figure out how we can "
-"surface more of those sorts of add-ons to people who are most likely to "
-"benefit from them."
+"We are constantly looking at ways to improve the organization of the site to better accommodate add-ons that are exemplary in other ways, but are aimed at only a small community of potential users. "
+"Correctly categorizing and maintaining the metadata of your add-on will help us figure out how we can surface more of those sorts of add-ons to people who are most likely to benefit from them."
 msgstr ""
-"Nenehno iščemo možnosti za izboljšanje organizacije spleta, da bi bolje "
-"skrbeli za dodatke, ki so zgledni na druge načine, vendar pa namenjeni le "
-"majhni skupnosti potencialnih uporabnikov. Pravilno bo kategorizirani in "
-"vzdrževani metapodatki v vašem dodatku nam pomagajo ugotoviti, za katero "
-"skupino uporabnikov bodo najbolj verjetno koristni."
+"Nenehno iščemo možnosti za izboljšanje organizacije spleta, da bi bolje skrbeli za dodatke, ki so zgledni na druge načine, vendar pa namenjeni le majhni skupnosti potencialnih uporabnikov. Pravilno "
+"bo kategorizirani in vzdrževani metapodatki v vašem dodatku nam pomagajo ugotoviti, za katero skupino uporabnikov bodo najbolj verjetno koristni."
 
 #: src/olympia/devhub/templates/devhub/docs/policies-submission.html:61
 msgid ""
-"If your add-on just provides bookmarks or other simple access points to your"
-" site, it's probably not appropriate for the gallery. Like the rest of the "
-"Mozilla project, we love web applications and new web services, but Firefox "
-"add-ons should provide an improved browsing experience for the user and not "
-"just be a way to promote a new site or service through a Mozilla Add-ons "
-"listing."
+"If your add-on just provides bookmarks or other simple access points to your site, it's probably not appropriate for the gallery. Like the rest of the Mozilla project, we love web applications and "
+"new web services, but Firefox add-ons should provide an improved browsing experience for the user and not just be a way to promote a new site or service through a Mozilla Add-ons listing."
 msgstr ""
-"Če je vaš dodatek samo nudi zaznamke ali drugih enostavne dostopne točke na "
-"vašo spletno stran, za galerijo ne bo primeren. Tako kot ves projekt Mozilla"
-" , ljubimo tudi mi spletne aplikacije in nove spletne storitve, vendar pa "
-"morajo dodatki za Firefox zagotavljati uporabniku boljše, lažje, prijetnejše"
-" brskanje in ne pa biti samo način, kako se kako spletišče reklamira."
+"Če je vaš dodatek samo nudi zaznamke ali drugih enostavne dostopne točke na vašo spletno stran, za galerijo ne bo primeren. Tako kot ves projekt Mozilla , ljubimo tudi mi spletne aplikacije in nove "
+"spletne storitve, vendar pa morajo dodatki za Firefox zagotavljati uporabniku boljše, lažje, prijetnejše brskanje in ne pa biti samo način, kako se kako spletišče reklamira."
 
 #: src/olympia/devhub/templates/devhub/docs/policies-submission.html:67
 msgid ""
-"<strong>Is the add-on free of unlicensed trademarks and copyrights?</strong>"
-" Though you may mean no harm to the holder of a trademark, or the owner of a"
-" copyrighted work, we can't host add-ons that infringe on trademarks or "
-"copyrights. If you don't have permission to use a trademarked name or image,"
-" please do not submit your add-on to us. If your add-on includes code that "
-"is copyrighted by someone else, and is not licensed to you to use in your "
-"add-on, please do not submit your add-on to us."
+"<strong>Is the add-on free of unlicensed trademarks and copyrights?</strong> Though you may mean no harm to the holder of a trademark, or the owner of a copyrighted work, we can't host add-ons that "
+"infringe on trademarks or copyrights. If you don't have permission to use a trademarked name or image, please do not submit your add-on to us. If your add-on includes code that is copyrighted by "
+"someone else, and is not licensed to you to use in your add-on, please do not submit your add-on to us."
 msgstr ""
-"<strong>Je dodatek prost nelicenciranih blagovnih znamk in avtorskih "
-"pravic?</strong> Čeprav niste imeli namena oškodovati imetnika blagovne "
-"znamk ali lastnika avtorskega dela, dodatkov, ki kršijo na blagovne znamke "
-"ali avtorske pravice, ne moremo gostiti. Če nimate dovoljenja za uporabo "
-"blagovne znamke ali slike, vas prosimo, da nam svojega dodatka ne pošiljate."
-" Če vaš dodatek vsebuje kodo, ki je zaščitena z avtorskimi pravicami nekoga "
-"tretjega, pa za uporabo v vašem dodatku nimate dovoljenja, vas prosimo, da "
-"nam svojega dodatka ne pošiljate."
+"<strong>Je dodatek prost nelicenciranih blagovnih znamk in avtorskih pravic?</strong> Čeprav niste imeli namena oškodovati imetnika blagovne znamk ali lastnika avtorskega dela, dodatkov, ki kršijo "
+"na blagovne znamke ali avtorske pravice, ne moremo gostiti. Če nimate dovoljenja za uporabo blagovne znamke ali slike, vas prosimo, da nam svojega dodatka ne pošiljate. Če vaš dodatek vsebuje kodo, "
+"ki je zaščitena z avtorskimi pravicami nekoga tretjega, pa za uporabo v vašem dodatku nimate dovoljenja, vas prosimo, da nam svojega dodatka ne pošiljate."
 
 #: src/olympia/devhub/templates/devhub/docs/policies-submission.html:73
 msgid ""
-"In terms of reuse of source code from other add-ons, if the author has not "
-"clearly stated that you are permitted to use his or her code in your own "
-"work &mdash; such as by placing it under an open source license &mdash; then"
-" you should assume that you do not have the right to do so. You can contact "
-"the author to seek such permission, but we can't provide you with any "
-"special rights to it just because it's listed on the site, or because the "
-"author isn't responding to your request."
+"In terms of reuse of source code from other add-ons, if the author has not clearly stated that you are permitted to use his or her code in your own work &mdash; such as by placing it under an open "
+"source license &mdash; then you should assume that you do not have the right to do so. You can contact the author to seek such permission, but we can't provide you with any special rights to it "
+"just because it's listed on the site, or because the author isn't responding to your request."
 msgstr ""
-"V zvezi s ponovno uporabo izvorne kode iz drugih dodatkov: če avtor ni jasno"
-" navedel, da lahko uporabljate njegovo kodo v svojem delu - na primer z "
-"objavo na osnovi odprtokodne licence - potem se morate zavedati, da nimate "
-"pravice do uporabe kode. Lahko se obrnete na avtorja, da vam to dovoli, z "
-"naše strani pa v vsakem primeru ne morete pričakovati kakih posebnih pravic "
-"samo zaradi tega, ker je vaš dodatek naveden na spletni strani ali pa zato, "
-"ker se avtor na vašo prošnjo ne odziva."
+"V zvezi s ponovno uporabo izvorne kode iz drugih dodatkov: če avtor ni jasno navedel, da lahko uporabljate njegovo kodo v svojem delu - na primer z objavo na osnovi odprtokodne licence - potem se "
+"morate zavedati, da nimate pravice do uporabe kode. Lahko se obrnete na avtorja, da vam to dovoli, z naše strani pa v vsakem primeru ne morete pričakovati kakih posebnih pravic samo zaradi tega, "
+"ker je vaš dodatek naveden na spletni strani ali pa zato, ker se avtor na vašo prošnjo ne odziva."
 
 #: src/olympia/devhub/templates/devhub/docs/policies-submission.html:79
 msgid ""
-"This applies to the Mozilla Foundation's trademarks as well, including "
-"\"Mozilla\", \"Firefox\", and \"Thunderbird\". The Mozilla policy on "
-"trademark use is designed to protect against confusion, and prevent the "
-"trademarks from being overturned due to lack of protection; please respect "
-"the need for such protection, and help us preserve some of the most valuable"
-" assets of the Mozilla Foundation."
+"This applies to the Mozilla Foundation's trademarks as well, including \"Mozilla\", \"Firefox\", and \"Thunderbird\". The Mozilla policy on trademark use is designed to protect against confusion, "
+"and prevent the trademarks from being overturned due to lack of protection; please respect the need for such protection, and help us preserve some of the most valuable assets of the Mozilla "
+"Foundation."
 msgstr ""
-"To velja tudi za blagovne znamke Fundacije Mozilla, kot so \"Mozilla\", "
-"\"Firefox\" in \"Thunderbird\". Smernice Mozille o uporabi blagovne znamke "
-"imajo namen preprečiti zmedo in razvrednotenje blagovnih znamk zaradi "
-"pomanjkljive zaščite. Prosimo, da spoštujete nujnost te vrste zaščite in da "
-"nam jih pomagate varovati, saj predstavljajo najbolj dragocena sredstva "
-"fundacije Mozilla."
+"To velja tudi za blagovne znamke Fundacije Mozilla, kot so \"Mozilla\", \"Firefox\" in \"Thunderbird\". Smernice Mozille o uporabi blagovne znamke imajo namen preprečiti zmedo in razvrednotenje "
+"blagovnih znamk zaradi pomanjkljive zaščite. Prosimo, da spoštujete nujnost te vrste zaščite in da nam jih pomagate varovati, saj predstavljajo najbolj dragocena sredstva fundacije Mozilla."
 
 #: src/olympia/devhub/templates/devhub/docs/policies-submission.html:84
 msgid "Licensing"
@@ -7964,252 +6123,175 @@ msgstr "Licenciranje"
 
 #: src/olympia/devhub/templates/devhub/docs/policies-submission.html:86
 msgid ""
-"Selecting an appropriate license for your add-on is a very important step in"
-" the submission process. A license specifies the rights you grant on your "
-"source code and is important in protecting your intellectual property."
+"Selecting an appropriate license for your add-on is a very important step in the submission process. A license specifies the rights you grant on your source code and is important in protecting your "
+"intellectual property."
 msgstr ""
-"Izbira ustrezne licence za vaš dodatek je zelo pomemben korak v postopku "
-"pošiljanja. Licenca določa pravice, ki jih dodeljujete za izvorno kodo, in "
-"je pomembna pri zaščiti vaše intelektualne lastnine."
+"Izbira ustrezne licence za vaš dodatek je zelo pomemben korak v postopku pošiljanja. Licenca določa pravice, ki jih dodeljujete za izvorno kodo, in je pomembna pri zaščiti vaše intelektualne "
+"lastnine."
 
 #: src/olympia/devhub/templates/devhub/docs/policies-submission.html:92
 msgid ""
-"During the add-on submission process, you will be presented with a list of "
-"popular licenses to choose from, as well as the ability to specify your own "
-"license. It is best to consult with a legal professional about which license"
-" option is best for you. Choosing the right license for your source code "
-"will help to prevent confusion and code conflicts in the future."
+"During the add-on submission process, you will be presented with a list of popular licenses to choose from, as well as the ability to specify your own license. It is best to consult with a legal "
+"professional about which license option is best for you. Choosing the right license for your source code will help to prevent confusion and code conflicts in the future."
 msgstr ""
-"V procesu predaje dodatka boste imeli možnost ogledati si seznam "
-"priljubljenih licenc med katerimi boste lahko izbirali, prav tako boste "
-"imeli možnost, navesti svojo lastno licenco. Zato je najbolje, da se "
-"posvetujete z odvetniki o tem, katere od možnih licenc je najboljša za vas. "
-"Izbira prave licence za vaše izvorno kodo bo pomagala preprečiti zmedo in "
-"bodoče konflikte v zvezi s kodo."
+"V procesu predaje dodatka boste imeli možnost ogledati si seznam priljubljenih licenc med katerimi boste lahko izbirali, prav tako boste imeli možnost, navesti svojo lastno licenco. Zato je "
+"najbolje, da se posvetujete z odvetniki o tem, katere od možnih licenc je najboljša za vas. Izbira prave licence za vaše izvorno kodo bo pomagala preprečiti zmedo in bodoče konflikte v zvezi s kodo."
 
-#: src/olympia/devhub/templates/devhub/docs/policies.html:12
-#: src/olympia/devhub/templates/devhub/docs/policies.html:52
+#: src/olympia/devhub/templates/devhub/docs/policies.html:12 src/olympia/devhub/templates/devhub/docs/policies.html:52
 msgid "Add-on Submission"
 msgstr "Predložitev dodatka"
 
-#: src/olympia/devhub/templates/devhub/docs/policies.html:18
-#: src/olympia/devhub/templates/devhub/docs/policies.html:78
+#: src/olympia/devhub/templates/devhub/docs/policies.html:18 src/olympia/devhub/templates/devhub/docs/policies.html:78
 msgid "Maintaining Your Add-on"
 msgstr "Vzdrževanje vašega dodatka"
 
 #: src/olympia/devhub/templates/devhub/docs/policies.html:43
-msgid ""
-"Mozilla is committed to ensuring a great add-ons experience for our users "
-"and developers. Please review the policies below before submitting your add-"
-"on."
-msgstr ""
-"Mozilla se je zavezala, da bo svojim uporabnikom in razvijalcem zagotovila "
-"lepe izkušnje, kar se dodatkov tiče. Pred pošiljanjem dodatka preverite "
-"spodnja pravila."
+msgid "Mozilla is committed to ensuring a great add-ons experience for our users and developers. Please review the policies below before submitting your add-on."
+msgstr "Mozilla se je zavezala, da bo svojim uporabnikom in razvijalcem zagotovila lepe izkušnje, kar se dodatkov tiče. Pred pošiljanjem dodatka preverite spodnja pravila."
 
 #: src/olympia/devhub/templates/devhub/docs/policies.html:55
-msgid ""
-"Find out what is expected of add-ons we host and our policies on specific "
-"add-on practices."
-msgstr ""
-"Tu zveste, kaj se pričakuje od dodatkov, ki jih gostimo, in kaj je naša "
-"politika glede dodatkov."
+msgid "Find out what is expected of add-ons we host and our policies on specific add-on practices."
+msgstr "Tu zveste, kaj se pričakuje od dodatkov, ki jih gostimo, in kaj je naša politika glede dodatkov."
 
 #: src/olympia/devhub/templates/devhub/docs/policies.html:67
-msgid ""
-"What happens after your add-on is submitted? Learn about how our Editors "
-"review submissions."
-msgstr ""
-"Kaj se zgodi, ko pošljete svoj dodatek? Preberite več o tem, kakšno vlogo "
-"igrajo naši uredniki."
+msgid "What happens after your add-on is submitted? Learn about how our Editors review submissions."
+msgstr "Kaj se zgodi, ko pošljete svoj dodatek? Preberite več o tem, kakšno vlogo igrajo naši uredniki."
 
 #: src/olympia/devhub/templates/devhub/docs/policies.html:81
-msgid ""
-"Add-on updates, transferring ownership, user reviews, and what to expect "
-"once your add-on is approved."
-msgstr ""
-"Posodobitve dodatkov, prenos lastništva, pregledi uporabnikov, in kaj lahko "
-"pričakujete, ko se vaš dodatek odobri."
+msgid "Add-on updates, transferring ownership, user reviews, and what to expect once your add-on is approved."
+msgstr "Posodobitve dodatkov, prenos lastništva, pregledi uporabnikov, in kaj lahko pričakujete, ko se vaš dodatek odobri."
 
 #: src/olympia/devhub/templates/devhub/docs/policies.html:93
-msgid ""
-"How up-and-coming add-ons become featured and what&#039;s involved in the "
-"process."
-msgstr ""
-"Kako se novo nastale dodatke predstavlja in kaj je v ta postopek vključeno."
+msgid "How up-and-coming add-ons become featured and what&#039;s involved in the process."
+msgstr "Kako se novo nastale dodatke predstavlja in kaj je v ta postopek vključeno."
 
 #: src/olympia/devhub/templates/devhub/docs/policies.html:106
-msgid ""
-"Terms of Service for submitting your work to our site. Developers are "
-"required to accept this agreement before submission."
-msgstr ""
-"Pogoji za storitve ob pošiljanju vašega izdelka za našo stran. Razvijalci so"
-" pred oddajo dolžni ta dogovor sprejeti."
+msgid "Terms of Service for submitting your work to our site. Developers are required to accept this agreement before submission."
+msgstr "Pogoji za storitve ob pošiljanju vašega izdelka za našo stran. Razvijalci so pred oddajo dolžni ta dogovor sprejeti."
 
 #: src/olympia/devhub/templates/devhub/docs/policies.html:118
 msgid "How to get in touch with us regarding these policies or your add-on."
 msgstr "Kako priti v stik z nami glede teh pravil ali vašega dodatka."
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:6
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:10
 msgid "You have disabled this add-on"
 msgstr "Ta dodatek ste onemogočili"
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:20
-msgid ""
-"Your add-on's listing is disabled and is not showing\n"
-"                             anywhere in our gallery or update service."
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:24
+msgid "Your add-on's listing is disabled and is not showing anywhere in our gallery or update service."
 msgstr ""
 "Popis vašega dodatka je onemogočen in ni prikazan\n"
 "                             nikjer v naši galeriji ali storitvi za posodobitve."
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:25
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:27
 msgid "Please complete your add-on."
 msgstr "Dopoilnite prosim svoj dodatek."
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:29
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:30
 msgid "You will receive an email when the review is complete."
 msgstr "Ko bo pregled končan, boste prejeli obvestilo po e-pošti."
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:34
-msgid ""
-"You will receive an email when the review is complete. Until\n"
-"                             then, your add-on is not listed in our gallery but can be\n"
-"                             accessed directly from its details page."
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:33
+msgid "You will receive an email when the review is complete. Until then, your add-on is not listed in our gallery but can be accessed directly from its details page."
 msgstr ""
 "Ko bo pregled končan, boste prejeli e-pošto.  Do takrat vaš\n"
 "                             dodatek ne bo naveden v naši galeriji, vendar bo dostop do\n"
 "                             njega omogočen neposredno z njegove strani s podrobnostmi."
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:38
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:48
-msgid ""
-"You will receive an email when the review is\n"
-"                             complete and your add-on is signed."
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:37 src/olympia/devhub/templates/devhub/includes/addon_details.html:45
+msgid "You will receive an email when the review is complete and your add-on is signed."
 msgstr ""
 "Ko bo pregled končan in bo vaš dodatek\n"
 "                             podpisan, boste prejeli e-pošto."
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:44
-msgid ""
-"You will receive an email when the review is complete. Until\n"
-"                             then, your add-on is not listed in our gallery but can be\n"
-"                             accessed directly from its details page. "
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:41
+msgid "You will receive an email when the review is complete. Until then, your add-on is not listed in our gallery but can be accessed directly from its details page. "
 msgstr ""
-"Ko bo pregled končan, boste prejeli e-pošto.  Do takrat vaš\n"
-"                             dodatek ne bo naveden v naši galeriji, vendar bo do\n"
-"                             njega omogočen dostop neposredno s strani s\n"
-"                             podrobnostmi. "
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:54
-msgid ""
-"Your add-on is displayed in our gallery and users are\n"
-"                             receiving automatic updates."
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:49
+msgid "Your add-on is displayed in our gallery and users are receiving automatic updates."
 msgstr ""
 "Vaš dodatek je prikazan v naši galeriji in uporabniki\n"
 "                             bodo samodejno prejemali posodobitve."
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:57
-msgid ""
-"Your add-on has been signed and can be bundled with an\n"
-"                             application installer."
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:52
+msgid "Your add-on has been signed and can be bundled with an application installer."
 msgstr "Dodatek je podpisan in je lahko del namestilnika aplikacij."
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:63
-msgid ""
-"Your add-on was disabled by a site administrator and is no\n"
-"                             longer shown in our gallery. If you have any questions,\n"
-"                             please email amo-admins@mozilla.org."
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:56
+msgid "Your add-on was disabled by a site administrator and is no longer shown in our gallery. If you have any questions, please email amo-admins@mozilla.org."
 msgstr ""
 "Vaš dodatek je onemogočil skrbnik strani in ni več prikazan v\n"
 "                             naši galeriji.  Če imate kakršnokoli vprašanje, pišite na\n"
 "                             amo-admins@mozilla.org."
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:70
-msgid ""
-"Your add-on is displayed in our gallery as experimental\n"
-"                             and users are receiving automatic updates. Some features\n"
-"                             are unavailable to your add-on."
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:62
+msgid "Your add-on is displayed in our gallery as experimental and users are receiving automatic updates. Some features are unavailable to your add-on."
 msgstr ""
 "Vaš dodatek je prikazan v naši galeriji kot preskusen in\n"
 "                             uporabniki bodo samodejno prejemali posodobitve.  Nekatere\n"
 "                             značilnosti vašemu dodatku ne bodo na voljo."
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:74
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:66
 msgid "Your add-on has been signed."
 msgstr "Vaš dodatek je bil podpisan."
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:79
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:69
 msgid ""
-"You will receive an email when the full review is complete.\n"
-"                             Until then, your add-on is displayed in our gallery as\n"
-"                             experimental and users are receiving automatic updates.\n"
-"                             Some features are unavailable to your add-on."
+"You will receive an email when the full review is complete. Until then, your add-on is displayed in our gallery as experimental and users are receiving automatic updates. Some features are "
+"unavailable to your add-on."
 msgstr ""
 "Ko bo poln pregled končan, boste prejeli e-pošto.  Do takrat\n"
 "                             bo vaš dodatek prikaza v naši galeriji kot preskusen in\n"
 "                             uporabniki bodo samodejno prejemali posodobitve.\n"
 "                             Nekatere značilnosti vašemu dodatku ne bodo na voljo."
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:84
-msgid ""
-"You will receive an email when the full review is\n"
-"                             complete, making you able to bundle your add-on with an\n"
-"                             application installer."
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:74
+msgid "You will receive an email when the full review is complete, making you able to bundle your add-on with an application installer."
 msgstr ""
 "Ko bo poln pregled končan, boste prejeli e-pošto, kar\n"
 "                             vam bo omogočilo dodajanje dodatka v namestilnik aplikacij."
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:91
-msgid ""
-"All add-ons hosted in our gallery must now be reviewed by an\n"
-"                             editor. If you wish to continue hosting your add-on, please\n"
-"                             click to select a review process."
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:79
+msgid "All add-ons hosted in our gallery must now be reviewed by an editor. If you wish to continue hosting your add-on, please click to select a review process."
 msgstr ""
 "Vse dodatke, ki gostujejo v naši galeriji, mora zdaj pregledati\n"
 "                             urednik.  Če želite, da vaš dodatek še naprej gostuje\n"
 "                             v galeriji, kliknite za izbiro postopka pregleda."
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:113
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:100
 msgid "Current Version:"
 msgstr "Trenutna različica:"
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:115
-msgid ""
-"This is the version of your add-on that will\n"
-"                                           be installed if someone clicks the Install\n"
-"                                           button on addons.mozilla.org. It is only\n"
-"                                           relevant for listed add-ons."
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:102
+msgid "This is the version of your add-on that will be installed if someone clicks the Install button on addons.mozilla.org. It is only relevant for listed add-ons."
 msgstr ""
 "To je različica vašega dodatka, ki bo nameščena\n"
 "                                           ob kliku na gumb za nameščanje na\n"
 "                                           addons.mozilla.org.  To velja samo za navedene\n"
 "                                           dodatke."
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:123
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:110
 msgid "Created:"
 msgstr "Ustvarjeno:"
 
 #. {0} is a date. dennis-ignore: E201
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:125
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:131
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:112 src/olympia/devhub/templates/devhub/includes/addon_details.html:118
 #, python-format
 msgid "%%b %%e, %%Y"
 msgstr "%%b %%e, %%Y"
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:136
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:123
 msgid "Next Version:"
 msgstr "Naslednja različica:"
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:138
-msgid ""
-"This is the newest uploaded version, however\n"
-"                                           it isn’t live on the site yet."
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:125
+msgid "This is the newest uploaded version, however it isn’t live on the site yet."
 msgstr ""
 "To je najnovejša prenesena različica, vendar\n"
 "                                           še ni objavljena na strani."
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:144
-#: src/olympia/devhub/templates/devhub/versions/list.html:30
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:130 src/olympia/devhub/templates/devhub/versions/list.html:30
 msgid "Queues are not reviewed strictly in order"
 msgstr "Čakalne vrste niso pregledane natanko po vrsti"
 
@@ -8227,15 +6309,11 @@ msgstr "Ustvarite profil razvijalca"
 
 #: src/olympia/devhub/templates/devhub/includes/addons_create_profile.html:24
 msgid ""
-"Your developer profile will tell users about you, why you made this add-on, "
-"and what's next for the add-on. This profile is required for add-ons "
-"requesting contributions, but can be useful for any developer interested in "
-"connecting with users."
+"Your developer profile will tell users about you, why you made this add-on, and what's next for the add-on. This profile is required for add-ons requesting contributions, but can be useful for any "
+"developer interested in connecting with users."
 msgstr ""
-"Vaš profil razvijalca bodo uporabnikom dal vedeti kaj zanimivega o vas, o "
-"tem, zakaj ste ta dodatek razvili in kaj načrtujete v zvezi z njim. Ta "
-"profil je potreben za dodatke, ki zahtevajo prispevkov, vendar je lahko "
-"koristen za vse razvijalce, ki želijo stik s svojimi uporabniki."
+"Vaš profil razvijalca bodo uporabnikom dal vedeti kaj zanimivega o vas, o tem, zakaj ste ta dodatek razvili in kaj načrtujete v zvezi z njim. Ta profil je potreben za dodatke, ki zahtevajo "
+"prispevkov, vendar je lahko koristen za vse razvijalce, ki želijo stik s svojimi uporabniki."
 
 #: src/olympia/devhub/templates/devhub/includes/addons_create_profile.html:32
 msgid "Make sure your user profile is up to date."
@@ -8244,22 +6322,14 @@ msgstr "Poskrbite, da je vaš uporabniški profil vedno posodobljen."
 #: src/olympia/devhub/templates/devhub/includes/addons_create_profile.html:34
 #, python-format
 msgid "<a href=\"%(url)s\"><strong>Update your user profile.</strong></a>"
-msgstr ""
-"<a href=\"%(url)s\"><strong>Posodobite svoj uporabniški profil.</strong></a>"
+msgstr "<a href=\"%(url)s\"><strong>Posodobite svoj uporabniški profil.</strong></a>"
 
 #: src/olympia/devhub/templates/devhub/includes/addons_create_profile.html:45
-msgid ""
-"Whether it was an idea while in line at the grocery store or the solution to"
-" one of life's great problems, share your story."
-msgstr ""
-"Če ste na idejo prišli, ko ste stali v vrsti za blagajno v trgovini, ali pa "
-"ko vam je uspelo rešiti enega velikih problemov v vašem življenju, povejte "
-"nam svojo zgodbo."
+msgid "Whether it was an idea while in line at the grocery store or the solution to one of life's great problems, share your story."
+msgstr "Če ste na idejo prišli, ko ste stali v vrsti za blagajno v trgovini, ali pa ko vam je uspelo rešiti enega velikih problemov v vašem življenju, povejte nam svojo zgodbo."
 
 #: src/olympia/devhub/templates/devhub/includes/addons_create_profile.html:61
-msgid ""
-"Telling your users what's coming soon will give them something to look "
-"forward to."
+msgid "Telling your users what's coming soon will give them something to look forward to."
 msgstr "Uporabniku bo ugajalo, če zve, kaj vse imate v bodoče še v načrtu."
 
 #: src/olympia/devhub/templates/devhub/includes/addons_edit_nav.html:23
@@ -8293,9 +6363,7 @@ msgid "View the blog &#9658;"
 msgstr "Glejte blog &#9658;"
 
 #: src/olympia/devhub/templates/devhub/includes/license_form.html:6
-msgid ""
-"Please choose a license appropriate for the rights you grant on your source code.\n"
-"                  It is only relevant for listed add-ons."
+msgid "Please choose a license appropriate for the rights you grant on your source code. It is only relevant for listed add-ons."
 msgstr ""
 "Izberite ustrezno licenco za pravice, ki jih podeljujete za vašo izvorno kodo.  To\n"
 "                  velja samo za navedene dodatke."
@@ -8313,52 +6381,37 @@ msgstr "HTML delno podprt."
 msgid "Remove this application"
 msgstr "Odstrani to aplikacijo"
 
-#. {0} is the maximum number of add-on categories allowed.                {1}
-#. is
+#. {0} is the maximum number of add-on categories allowed.                {1} is
 #. the application name.
 #: src/olympia/devhub/templates/devhub/includes/macros.html:70
 msgid "Select <b>up to {0}</b> {1} category for this add-on:"
 msgid_plural "Select <b>up to {0}</b> {1} categories for this add-on:"
 msgstr[0] "Izberite <b>do {0}</b> {1} kategorijo za ta dodatek:"
 msgstr[1] "Izberite <b>do {0}</b> {1} kategoriji za ta dodatek:"
-msgstr[2] "Izberite <b>do {0}</b> {1} kategorije za ta dodatek:"
-msgstr[3] "Izberite <b>do {0}</b> {1} kategorij za ta dodatek:"
 
 #: src/olympia/devhub/templates/devhub/includes/policy_form.html:4
 msgid ""
-"Users will be required to accept the following End-User License Agreement (EULA) prior to installing your add-on. The presence of a EULA significantly affects the number of downloads an add-on receives. Please note that a EULA is not the same as a code license, such as the GPL or MPL.\n"
-"                It is only relevant for listed add-ons."
+"Users will be required to accept the following End-User License Agreement (EULA) prior to installing your add-on. The presence of a EULA significantly affects the number of downloads an add-on "
+"receives. Please note that a EULA is not the same as a code license, such as the GPL or MPL.It is only relevant for listed add-ons."
 msgstr ""
-"Uporabniki bodo morali pred namestitvijo vašega dodatka sprejeti naslednji Sporazum s končnim uporabnikom (EULA).  Prisotnost sporazuma znatno vpliva na število prenosov, ki jih prejme dodatek.  Upoštevajte, da EULA ni isto kot licenca za kodo, kot je GPL ali MPL.\n"
-"                To velja samo za navedene dodatke."
 
-#: src/olympia/devhub/templates/devhub/includes/policy_form.html:21
-msgid ""
-"If your add-on transmits any data from the user's computer, a privacy policy is required that explains what data is sent and how it is used.\n"
-"                It is only relevant for listed add-ons."
+#: src/olympia/devhub/templates/devhub/includes/policy_form.html:24
+msgid "If your add-on transmits any data from the user's computer, a privacy policy is required that explains what data is sent and how it is used. It is only relevant for listed add-ons."
 msgstr ""
 "Če vaš dodatek pošilja podatke iz uporabnikovega računalnika, je zahtevan pravilnik o zasebnosti, ki razlaga, kateri podatki se pošiljajo in kako se jih uporablja.\n"
 "                To velja samo za navedene dodatke."
 
 #: src/olympia/devhub/templates/devhub/includes/source_form_field.html:2
-msgid ""
-"If your add-on contains binary or obfuscated code other than known "
-"libraries, upload its sources for review."
-msgstr ""
-"Če vaš dodatek vsebuje dvojiško ali zamaskirano kodo, ki je drugačna od "
-"znanih knjižnic, naložite njegove vire za pregled."
+msgid "If your add-on contains binary or obfuscated code other than known libraries, upload its sources for review."
+msgstr "Če vaš dodatek vsebuje dvojiško ali zamaskirano kodo, ki je drugačna od znanih knjižnic, naložite njegove vire za pregled."
 
 #: src/olympia/devhub/templates/devhub/includes/source_form_field.html:3
 msgid "Read more about the source code review policy."
 msgstr "Preberite več o pravilniku pregleda izvorne kode."
 
 #: src/olympia/devhub/templates/devhub/includes/version_file.html:20
-msgid ""
-"You cannot remove an individual file after the review process has begun. You"
-" must delete the entire version."
-msgstr ""
-"Ne morete odstraniti posamezne datoteke potem, ko se je postopek pregleda "
-"enkrat začel. Morate zbrisati celotno različico."
+msgid "You cannot remove an individual file after the review process has begun. You must delete the entire version."
+msgstr "Ne morete odstraniti posamezne datoteke potem, ko se je postopek pregleda enkrat začel. Morate zbrisati celotno različico."
 
 #: src/olympia/devhub/templates/devhub/includes/version_file.html:36
 msgid "This file will be deleted on save."
@@ -8386,30 +6439,20 @@ msgid "Voluntary Contributions"
 msgstr "Prostovoljni prispevki"
 
 #: src/olympia/devhub/templates/devhub/payments/payments.html:38
-msgid ""
-"Add-ons enrolled in our contributions program can request voluntary "
-"financial support from users."
-msgstr ""
-"Dodatki, ki so vpisani v naš program prispevkov, lahko zaprosijo uporabnike "
-"za prostovoljno finančno podporo."
+msgid "Add-ons enrolled in our contributions program can request voluntary financial support from users."
+msgstr "Dodatki, ki so vpisani v naš program prispevkov, lahko zaprosijo uporabnike za prostovoljno finančno podporo."
 
 #: src/olympia/devhub/templates/devhub/payments/payments.html:40
 msgid "Encourage users to support your add-on through your Developer Profile"
-msgstr ""
-"V svojem profilu razvijalca lahko spodbudite uporabnike, da vaš dodatek "
-"podprejo."
+msgstr "V svojem profilu razvijalca lahko spodbudite uporabnike, da vaš dodatek podprejo."
 
 #: src/olympia/devhub/templates/devhub/payments/payments.html:41
 msgid "Choose when and how users are asked to contribute"
 msgstr "Navedite, kako in kdaj se uporabnika prosi za prispevek"
 
 #: src/olympia/devhub/templates/devhub/payments/payments.html:42
-msgid ""
-"Receive contributions in your PayPal account or send them to an organization"
-" of your choice"
-msgstr ""
-"Prejemajte prispevke na svoj PayPal račun ali pa jih pošiljajte "
-"organizaciji, ki ste jo izbrali"
+msgid "Receive contributions in your PayPal account or send them to an organization of your choice"
+msgstr "Prejemajte prispevke na svoj PayPal račun ali pa jih pošiljajte organizaciji, ki ste jo izbrali"
 
 #: src/olympia/devhub/templates/devhub/payments/payments.html:46
 msgid "Contributions are only available for listed add-ons."
@@ -8417,19 +6460,14 @@ msgstr "Prispevki so na voljo samo za navedene dodatke."
 
 #: src/olympia/devhub/templates/devhub/payments/payments.html:53
 #, python-format
-msgid ""
-"Contributions are only available for add-ons with a <a "
-"href=\"%(url)s\">completed developer profile</a>."
-msgstr ""
-"Prispevke se lahko predlaga samo za dodatke, ki imajo <a "
-"href=\"%(url)s\">izpolnjen profil razvijalca</a>."
+msgid "Contributions are only available for add-ons with a <a href=\"%(url)s\">completed developer profile</a>."
+msgstr "Prispevke se lahko predlaga samo za dodatke, ki imajo <a href=\"%(url)s\">izpolnjen profil razvijalca</a>."
 
 #: src/olympia/devhub/templates/devhub/payments/payments.html:59
 msgid "Contributions are only available for fully reviewed add-ons."
 msgstr "Prispevki so na voljo samo za v celoti pregledane dodatke."
 
-#: src/olympia/devhub/templates/devhub/payments/payments.html:65
-#: src/olympia/devhub/templates/devhub/payments/voluntary.html:2
+#: src/olympia/devhub/templates/devhub/payments/payments.html:65 src/olympia/devhub/templates/devhub/payments/voluntary.html:2
 msgid "Set up Contributions"
 msgstr "Uredite nastavitve za prispevke"
 
@@ -8442,18 +6480,13 @@ msgstr "Korak 2. Cenjenje in razpoložljivost"
 msgid "or <a href=\"%(cancel)s\">Cancel</a>"
 msgstr "ali <a href=\"%(cancel)s\">Prekliči</a>"
 
-#: src/olympia/devhub/templates/devhub/payments/voluntary.html:2
-#: src/olympia/stats/templates/stats/addon_report_menu.html:39
+#: src/olympia/devhub/templates/devhub/payments/voluntary.html:2 src/olympia/stats/templates/stats/addon_report_menu.html:39
 msgid "Contributions"
 msgstr "Prispevki"
 
 #: src/olympia/devhub/templates/devhub/payments/voluntary.html:3
-msgid ""
-"Fill in the fields below to begin asking for voluntary contributions from "
-"users."
-msgstr ""
-"Izpolnite spodnja polja, da lahko začnete naprošati uporabnike za "
-"prostovoljne prispevke."
+msgid "Fill in the fields below to begin asking for voluntary contributions from users."
+msgstr "Izpolnite spodnja polja, da lahko začnete naprošati uporabnike za prostovoljne prispevke."
 
 #: src/olympia/devhub/templates/devhub/payments/voluntary.html:11
 msgid "Who will receive contributions to this add-on?"
@@ -8496,23 +6529,16 @@ msgid "Send a thank-you note?"
 msgstr "Naj se pošlje zahvalno pismo?"
 
 #: src/olympia/devhub/templates/devhub/payments/voluntary.html:47
-msgid ""
-"We'll automatically email users who contribute to your add-on with this "
-"message."
-msgstr ""
-"Samodejno bomo po e-pošti uporabnikom, ki prispevajo za vaš dodatek, poslali"
-" to sporočilo."
+msgid "We'll automatically email users who contribute to your add-on with this message."
+msgstr "Samodejno bomo po e-pošti uporabnikom, ki prispevajo za vaš dodatek, poslali to sporočilo."
 
 #: src/olympia/devhub/templates/devhub/payments/voluntary.html:49
 msgid ""
-"We recommend thanking the user and telling them how much you appreciate "
-"their support. You might also want to tell them about what's next for your "
-"add-on and about any other add-ons you've made for them to try."
+"We recommend thanking the user and telling them how much you appreciate their support. You might also want to tell them about what's next for your add-on and about any other add-ons you've made for "
+"them to try."
 msgstr ""
-"Priporočamo vam, da se uporabnikom zahvalite in jim sporočite. koliko vam "
-"njihova podpora pomeni. Morda boste prav tako želeli obvestiti, kaj v "
-"bližnji bodočnosti načrtujete za svoj dodatek , in pa o tem, katere dodatke,"
-" ki ste jih razvili, bi morda uporabnik lahko tudi preizkusil."
+"Priporočamo vam, da se uporabnikom zahvalite in jim sporočite. koliko vam njihova podpora pomeni. Morda boste prav tako želeli obvestiti, kaj v bližnji bodočnosti načrtujete za svoj dodatek , in pa "
+"o tem, katere dodatke, ki ste jih razvili, bi morda uporabnik lahko tudi preizkusil."
 
 #: src/olympia/devhub/templates/devhub/payments/voluntary.html:64
 msgid "Activate Contributions"
@@ -8526,155 +6552,103 @@ msgstr "ali <a id=\"setup-cancel\" href=\"#\">Prekliči</a>"
 msgid "Transfer ownership"
 msgstr "Prenos lastništva"
 
-#: src/olympia/devhub/templates/devhub/personas/edit.html:77
-#: src/olympia/devhub/templates/devhub/personas/submit.html:31
+#: src/olympia/devhub/templates/devhub/personas/edit.html:77 src/olympia/devhub/templates/devhub/personas/submit.html:31
 msgid "Theme Details"
 msgstr "Podrobnosti o temi"
 
-#: src/olympia/devhub/templates/devhub/personas/edit.html:87
-#: src/olympia/devhub/templates/devhub/personas/submit.html:36
+#: src/olympia/devhub/templates/devhub/personas/edit.html:87 src/olympia/devhub/templates/devhub/personas/submit.html:36
 msgid "Supply a pretty URL for your detail page."
 msgstr "Poskrbite za čedno URL do strani z vašimi podrobnostmi."
 
 # 86%
-#: src/olympia/devhub/templates/devhub/personas/edit.html:92
-#: src/olympia/devhub/templates/devhub/personas/submit.html:41
+#: src/olympia/devhub/templates/devhub/personas/edit.html:92 src/olympia/devhub/templates/devhub/personas/submit.html:41
 msgid "Select the category that best describes your Theme."
 msgstr "Izberite kategorijo, ki najbolje opisuje vašo temo."
 
-#: src/olympia/devhub/templates/devhub/personas/edit.html:95
-#: src/olympia/devhub/templates/devhub/personas/submit.html:44
+#: src/olympia/devhub/templates/devhub/personas/edit.html:95 src/olympia/devhub/templates/devhub/personas/submit.html:44
 msgid "Add some tags to describe your Theme."
 msgstr "Dodajte nekaj oznak, ki opisujejo vašo temo."
 
-#: src/olympia/devhub/templates/devhub/personas/edit.html:106
-msgid ""
-"A short explanation of your theme's\n"
-"                                basic functionality that is displayed in\n"
-"                                search and browse listings, as well as at\n"
-"                                the top of your theme's details page."
+#: src/olympia/devhub/templates/devhub/personas/edit.html:106 src/olympia/devhub/templates/devhub/personas/submit.html:54
+msgid "A short explanation of your theme's basic functionality that is displayed in search and browse listings, as well as at the top of your theme's details page."
 msgstr ""
 "Kratka razlaga osnovnega delovanja\n"
 "                                vaše teme, ki je prikazana na seznamu\n"
 "                                iskanja in brskanja kot tudi na vrhu strani s\n"
 "                                podrobnostmi vaše teme."
 
-#: src/olympia/devhub/templates/devhub/personas/edit.html:122
-#: src/olympia/devhub/templates/devhub/personas/submit.html:68
+#: src/olympia/devhub/templates/devhub/personas/edit.html:122 src/olympia/devhub/templates/devhub/personas/submit.html:68
 msgid "Theme License"
 msgstr "Licenca za temo"
 
 # 88%
-#: src/olympia/devhub/templates/devhub/personas/edit.html:126
-#: src/olympia/devhub/templates/devhub/personas/submit.html:72
+#: src/olympia/devhub/templates/devhub/personas/edit.html:126 src/olympia/devhub/templates/devhub/personas/submit.html:72
 msgid "Can others share your Theme, as long as you're given credit?"
-msgstr ""
-"Lahko drugi, v kolikor ste omenjeni kot avtor, vašo temo širijo dalje?"
+msgstr "Lahko drugi, v kolikor ste omenjeni kot avtor, vašo temo širijo dalje?"
 
-#: src/olympia/devhub/templates/devhub/personas/edit.html:132
-#: src/olympia/devhub/templates/devhub/personas/edit.html:153
-#: src/olympia/devhub/templates/devhub/personas/submit.html:78
+#: src/olympia/devhub/templates/devhub/personas/edit.html:132 src/olympia/devhub/templates/devhub/personas/edit.html:153 src/olympia/devhub/templates/devhub/personas/submit.html:78
 #: src/olympia/devhub/templates/devhub/personas/submit.html:99
-msgid ""
-"The licensor permits others to copy, distribute, display, and perform the "
-"work, including for commercial purposes."
-msgstr ""
-"Dajatelj licence dovoljuje drugim kopirati, distribuirati in prikazovati "
-"izdelek ter opravljati delo, tudi v komercialne namene."
+msgid "The licensor permits others to copy, distribute, display, and perform the work, including for commercial purposes."
+msgstr "Dajatelj licence dovoljuje drugim kopirati, distribuirati in prikazovati izdelek ter opravljati delo, tudi v komercialne namene."
 
-#: src/olympia/devhub/templates/devhub/personas/edit.html:141
-#: src/olympia/devhub/templates/devhub/personas/edit.html:162
-#: src/olympia/devhub/templates/devhub/personas/submit.html:87
+#: src/olympia/devhub/templates/devhub/personas/edit.html:141 src/olympia/devhub/templates/devhub/personas/edit.html:162 src/olympia/devhub/templates/devhub/personas/submit.html:87
 #: src/olympia/devhub/templates/devhub/personas/submit.html:108
-msgid ""
-"The licensor permits others to copy, distribute, display, and perform the "
-"work for non-commercial purposes only."
-msgstr ""
-"Dajatelj licence dovoljuje drugim kopirati, distribuirati in prikazovati "
-"izdelek ter opravljati delo samo za nekomercialne namene."
+msgid "The licensor permits others to copy, distribute, display, and perform the work for non-commercial purposes only."
+msgstr "Dajatelj licence dovoljuje drugim kopirati, distribuirati in prikazovati izdelek ter opravljati delo samo za nekomercialne namene."
 
 # 85%
-#: src/olympia/devhub/templates/devhub/personas/edit.html:147
-#: src/olympia/devhub/templates/devhub/personas/submit.html:93
+#: src/olympia/devhub/templates/devhub/personas/edit.html:147 src/olympia/devhub/templates/devhub/personas/submit.html:93
 msgid "Can others make commercial use of your Theme?"
 msgstr "Lahko drugi uporabljajo vašo temo v komercialne namene?"
 
 # 86%
-#: src/olympia/devhub/templates/devhub/personas/edit.html:168
-#: src/olympia/devhub/templates/devhub/personas/submit.html:114
+#: src/olympia/devhub/templates/devhub/personas/edit.html:168 src/olympia/devhub/templates/devhub/personas/submit.html:114
 msgid "Can others create derivative works from your Theme?"
 msgstr "Lahko drugi ustvarjajo izpeljanke na osnovi vaše teme?"
 
-#: src/olympia/devhub/templates/devhub/personas/edit.html:174
-#: src/olympia/devhub/templates/devhub/personas/submit.html:120
-msgid ""
-"The licensor permits others to copy, distribute, display and perform the "
-"work, as well as make derivative works based on it."
-msgstr ""
-"Dajatelj licence dovoljuje drugim kopirati, distribuirati, prikazovati "
-"izdelek in opravljati delo, kot tudi ustvarjati izpeljanke na njeni osnovi."
+#: src/olympia/devhub/templates/devhub/personas/edit.html:174 src/olympia/devhub/templates/devhub/personas/submit.html:120
+msgid "The licensor permits others to copy, distribute, display and perform the work, as well as make derivative works based on it."
+msgstr "Dajatelj licence dovoljuje drugim kopirati, distribuirati, prikazovati izdelek in opravljati delo, kot tudi ustvarjati izpeljanke na njeni osnovi."
 
-#: src/olympia/devhub/templates/devhub/personas/edit.html:182
-#: src/olympia/devhub/templates/devhub/personas/submit.html:128
+#: src/olympia/devhub/templates/devhub/personas/edit.html:182 src/olympia/devhub/templates/devhub/personas/submit.html:128
 msgid "Yes, as long as they share alike"
 msgstr "Da, v kolikor razširjajo na en in isti način"
 
-#: src/olympia/devhub/templates/devhub/personas/edit.html:183
-#: src/olympia/devhub/templates/devhub/personas/submit.html:129
-msgid ""
-"The licensor permits others to distribute derivativeworks only under the "
-"same license or one compatible with the one that governs the licensor's "
-"work."
-msgstr ""
-"Dajatelj licence dovoljuje drugim kopirati, distribuirati izpeljanke samo "
-"pod isto licenco ali licenco, ki je skladna z licenco, s katero se njegovo "
-"delo daje na razpolago."
+#: src/olympia/devhub/templates/devhub/personas/edit.html:183 src/olympia/devhub/templates/devhub/personas/submit.html:129
+msgid "The licensor permits others to distribute derivativeworks only under the same license or one compatible with the one that governs the licensor's work."
+msgstr "Dajatelj licence dovoljuje drugim kopirati, distribuirati izpeljanke samo pod isto licenco ali licenco, ki je skladna z licenco, s katero se njegovo delo daje na razpolago."
 
-#: src/olympia/devhub/templates/devhub/personas/edit.html:192
-#: src/olympia/devhub/templates/devhub/personas/submit.html:138
-msgid ""
-"The licensor permits others to copy, distribute and transmit only unaltered "
-"copies of the work — not derivative works based on it."
-msgstr ""
-"Dajatelj licence dovoljuje drugim kopirati, distribuirati in prenašati samo "
-"nespremenjene kopije svojega dela - in ne izpeljank, ki temeljijo na njem,"
+#: src/olympia/devhub/templates/devhub/personas/edit.html:192 src/olympia/devhub/templates/devhub/personas/submit.html:138
+msgid "The licensor permits others to copy, distribute and transmit only unaltered copies of the work — not derivative works based on it."
+msgstr "Dajatelj licence dovoljuje drugim kopirati, distribuirati in prenašati samo nespremenjene kopije svojega dela - in ne izpeljank, ki temeljijo na njem,"
 
 # 87%
-#: src/olympia/devhub/templates/devhub/personas/edit.html:199
-#: src/olympia/devhub/templates/devhub/personas/submit.html:145
+#: src/olympia/devhub/templates/devhub/personas/edit.html:199 src/olympia/devhub/templates/devhub/personas/submit.html:145
 msgid "Your Theme will be released under the following license:"
 msgstr "Vašo temo se bo objavilo po naslednjo licenco:"
 
-#: src/olympia/devhub/templates/devhub/personas/edit.html:202
-#: src/olympia/devhub/templates/devhub/personas/submit.html:148
+#: src/olympia/devhub/templates/devhub/personas/edit.html:202 src/olympia/devhub/templates/devhub/personas/submit.html:148
 msgid "Select a different license."
 msgstr "Izberite drugo licenco."
 
-#: src/olympia/devhub/templates/devhub/personas/edit.html:207
-#: src/olympia/devhub/templates/devhub/personas/submit.html:153
+#: src/olympia/devhub/templates/devhub/personas/edit.html:207 src/olympia/devhub/templates/devhub/personas/submit.html:153
 msgid "Select a license for your Theme."
 msgstr "Izberite licenco za svojo temo."
 
-#: src/olympia/devhub/templates/devhub/personas/edit.html:217
-#: src/olympia/devhub/templates/devhub/personas/submit.html:163
+#: src/olympia/devhub/templates/devhub/personas/edit.html:217 src/olympia/devhub/templates/devhub/personas/submit.html:163
 msgid "Theme Design"
 msgstr "Načrt teme"
 
-#: src/olympia/devhub/templates/devhub/personas/edit.html:221
-#: src/olympia/devhub/templates/devhub/personas/edit.html:224
+#: src/olympia/devhub/templates/devhub/personas/edit.html:221 src/olympia/devhub/templates/devhub/personas/edit.html:224
 msgid "Upload New Design"
 msgstr "Naloži nov načrt"
 
 #: src/olympia/devhub/templates/devhub/personas/edit.html:226
-msgid ""
-"Upon upload and form submission, the AMO Team will review your updated "
-"design. Your current design will still be public in the meantime."
-msgstr ""
-"Potem ko naložite in sestavite prispevek, bo ekipa AMO pregledala vašo "
-"posodobljeno zasnovo. Vaša trenutna zasnova bo kljub temu javna v trenutku."
+msgid "Upon upload and form submission, the AMO Team will review your updated design. Your current design will still be public in the meantime."
+msgstr "Potem ko naložite in sestavite prispevek, bo ekipa AMO pregledala vašo posodobljeno zasnovo. Vaša trenutna zasnova bo kljub temu javna v trenutku."
 
 #: src/olympia/devhub/templates/devhub/personas/edit.html:241
-msgid "Your previously resubmitted design,  which is under pending review."
+msgid "Your previously resubmitted design, which is under pending review."
 msgstr "Vaša prej poslana zasnova, ki čaka na pregled."
 
 #: src/olympia/devhub/templates/devhub/personas/edit.html:245
@@ -8697,43 +6671,35 @@ msgstr "Glava"
 msgid "Footer"
 msgstr "Noga"
 
-#: src/olympia/devhub/templates/devhub/personas/edit.html:274
-#: src/olympia/devhub/templates/devhub/personas/submit.html:167
+#: src/olympia/devhub/templates/devhub/personas/edit.html:274 src/olympia/devhub/templates/devhub/personas/submit.html:167
 msgid "Select colors for your Theme."
 msgstr "Izberite barve za svojo temo."
 
-#: src/olympia/devhub/templates/devhub/personas/edit.html:276
-#: src/olympia/devhub/templates/devhub/personas/submit.html:169
+#: src/olympia/devhub/templates/devhub/personas/edit.html:276 src/olympia/devhub/templates/devhub/personas/submit.html:169
 msgid "Foreground Text"
 msgstr "Besedilo v ospredju"
 
-#: src/olympia/devhub/templates/devhub/personas/edit.html:277
-#: src/olympia/devhub/templates/devhub/personas/submit.html:170
+#: src/olympia/devhub/templates/devhub/personas/edit.html:277 src/olympia/devhub/templates/devhub/personas/submit.html:170
 msgid "This is the color of the tab text."
 msgstr "To je barva besedila v zavihkih."
 
-#: src/olympia/devhub/templates/devhub/personas/edit.html:279
-#: src/olympia/devhub/templates/devhub/personas/submit.html:172
+#: src/olympia/devhub/templates/devhub/personas/edit.html:279 src/olympia/devhub/templates/devhub/personas/submit.html:172
 msgid "Background"
 msgstr "Ozadje"
 
-#: src/olympia/devhub/templates/devhub/personas/edit.html:280
-#: src/olympia/devhub/templates/devhub/personas/submit.html:173
+#: src/olympia/devhub/templates/devhub/personas/edit.html:280 src/olympia/devhub/templates/devhub/personas/submit.html:173
 msgid "This is the color of the tabs."
 msgstr "To je barva zavihkov."
 
-#: src/olympia/devhub/templates/devhub/personas/edit.html:285
-#: src/olympia/devhub/templates/devhub/personas/submit.html:178
+#: src/olympia/devhub/templates/devhub/personas/edit.html:285 src/olympia/devhub/templates/devhub/personas/submit.html:178
 msgid "Preview"
 msgstr "Predogled"
 
-#: src/olympia/devhub/templates/devhub/personas/edit.html:291
-#: src/olympia/devhub/templates/devhub/personas/submit.html:183
+#: src/olympia/devhub/templates/devhub/personas/edit.html:291 src/olympia/devhub/templates/devhub/personas/submit.html:183
 msgid "Your Theme's Name"
 msgstr "Ime vaše Teme"
 
-#: src/olympia/devhub/templates/devhub/personas/edit.html:294
-#: src/olympia/devhub/templates/devhub/personas/submit.html:186
+#: src/olympia/devhub/templates/devhub/personas/edit.html:294 src/olympia/devhub/templates/devhub/personas/submit.html:186
 #, python-format
 msgid "by <a href=\"%(profile_url)s\" target=\"_blank\">%(user)s</a>"
 msgstr "avtor <a href=\"%(profile_url)s\" target=\"_blank\">%(user)s</a>"
@@ -8744,73 +6710,40 @@ msgstr "Ustvarite novo temo"
 
 #: src/olympia/devhub/templates/devhub/personas/submit.html:18
 #, python-format
-msgid ""
-"Background themes let you easily personalize the look of your Firefox. "
-"Submit your own design below, or <a href=\"%(submit_url)s\">learn how to "
-"create one</a>!"
+msgid "Background themes let you easily personalize the look of your Firefox. Submit your own design below, or <a href=\"%(submit_url)s\">learn how to create one</a>!"
 msgstr ""
-"S temami za ozadje si lahko hitro in enostavno prilagodite videz svojega "
-"Firefoxa. Spodaj pošljite svoj lastni izdelek ali pa <a "
-"href=\"%(submit_url)s\">se naučite, kako si ga lahko naredite</a>!"
+"S temami za ozadje si lahko hitro in enostavno prilagodite videz svojega Firefoxa. Spodaj pošljite svoj lastni izdelek ali pa <a href=\"%(submit_url)s\">se naučite, kako si ga lahko naredite</a>!"
 
 #: src/olympia/devhub/templates/devhub/personas/submit.html:33
 msgid "Give your Theme a name."
 msgstr "Dajte svoji Temi ime."
 
-#: src/olympia/devhub/templates/devhub/personas/submit.html:54
-msgid ""
-"A short explanation of your theme's\n"
-"                                      basic functionality that is displayed in\n"
-"                                      search and browse listings, as well as at\n"
-"                                      the top of your theme's details page."
-msgstr ""
-"Kratka razlaga osnovnega delovanja\n"
-"                                vaše teme, ki je prikazana na seznamu\n"
-"                                iskanja in brskanja kot tudi na vrhu strani s\n"
-"                                podrobnostmi."
-
 #: src/olympia/devhub/templates/devhub/personas/submit.html:198
 #, python-format
 msgid ""
-"I agree to the <a href=\"%(agreement_url)s\" target=\"_blank\">Firefox Add-"
-"on Distribution Agreement</a> and to my information being handled as "
-"described in the <a href=\"%(privacy_notice_url)s\" "
+"I agree to the <a href=\"%(agreement_url)s\" target=\"_blank\">Firefox Add-on Distribution Agreement</a> and to my information being handled as described in the <a href=\"%(privacy_notice_url)s\" "
 "target=\"_blank\">Websites, Communications and Cookies Privacy Notice</a>."
 msgstr ""
-"Strinjam se s <a href=\"%(agreement_url)s\" target=\"_blank\">Sporazumom za "
-"raširjanje Firefoxovih dodatkov</a> in z načinom ravnanja z mojimi podatki "
-"opisanem v <a href=\"%(privacy_notice_url)s\" target=\"_blank\">Obvestilu o "
-"zasebnosti za spletne strani, komunikacijo in piškotke</a>."
+"Strinjam se s <a href=\"%(agreement_url)s\" target=\"_blank\">Sporazumom za raširjanje Firefoxovih dodatkov</a> in z načinom ravnanja z mojimi podatki opisanem v <a href=\"%(privacy_notice_url)s\" "
+"target=\"_blank\">Obvestilu o zasebnosti za spletne strani, komunikacijo in piškotke</a>."
 
 #: src/olympia/devhub/templates/devhub/personas/submit.html:205
 msgid "Submit Theme"
 msgstr "Pošlji Temo"
 
 #: src/olympia/devhub/templates/devhub/personas/submit_done.html:11
-msgid ""
-"Your theme has been submitted to the Review Queue. You'll receive an email "
-"once it has been reviewed, typically within 24 hours."
-msgstr ""
-"Vaša tema je poslana in čaka v vrsti na pregled. Ko be enkrat pregledana, "
-"tipično v 24 urah, boste dobili pošto."
+msgid "Your theme has been submitted to the Review Queue. You'll receive an email once it has been reviewed, typically within 24 hours."
+msgstr "Vaša tema je poslana in čaka v vrsti na pregled. Ko be enkrat pregledana, tipično v 24 urah, boste dobili pošto."
 
 #: src/olympia/devhub/templates/devhub/personas/submit_done.html:19
 #, python-format
-msgid ""
-"Provide more details about your theme by <a href=\"%(edit_url)s\">editing "
-"its listing</a>."
-msgstr ""
-"<a href=\"%(edit_url)s\">Uredite svojo objavo </a> in ji dodajte še druge "
-"podrobnosti o svoji temi."
+msgid "Provide more details about your theme by <a href=\"%(edit_url)s\">editing its listing</a>."
+msgstr "<a href=\"%(edit_url)s\">Uredite svojo objavo </a> in ji dodajte še druge podrobnosti o svoji temi."
 
 #: src/olympia/devhub/templates/devhub/personas/submit_done.html:25
 #, python-format
-msgid ""
-"View and subscribe to your theme's <a href=\"%(feed_url)s\">activity "
-"feed</a> to stay updated on reviews, collections, and more."
-msgstr ""
-"Oglejte si in naročite se na <a href=\"%(feed_url)s\">spletna poročila</a> o"
-" svoji temi,  da ostanete na tekočem, kar se ocen, zbirk idr. tiče."
+msgid "View and subscribe to your theme's <a href=\"%(feed_url)s\">activity feed</a> to stay updated on reviews, collections, and more."
+msgstr "Oglejte si in naročite se na <a href=\"%(feed_url)s\">spletna poročila</a> o svoji temi,  da ostanete na tekočem, kar se ocen, zbirk idr. tiče."
 
 #: src/olympia/devhub/templates/devhub/personas/submit_done.html:32
 #, python-format
@@ -8826,13 +6759,11 @@ msgstr "Izberite sliko za glavo svoje Teme."
 msgid "3000 &times; 200 pixels"
 msgstr "3000 &times; 200 pik"
 
-#: src/olympia/devhub/templates/devhub/personas/includes/theme_design.html:9
-#: src/olympia/devhub/templates/devhub/personas/includes/theme_design.html:25
+#: src/olympia/devhub/templates/devhub/personas/includes/theme_design.html:9 src/olympia/devhub/templates/devhub/personas/includes/theme_design.html:25
 msgid "300 KB max"
 msgstr "300 KB maks"
 
-#: src/olympia/devhub/templates/devhub/personas/includes/theme_design.html:10
-#: src/olympia/devhub/templates/devhub/personas/includes/theme_design.html:26
+#: src/olympia/devhub/templates/devhub/personas/includes/theme_design.html:10 src/olympia/devhub/templates/devhub/personas/includes/theme_design.html:26
 msgid "PNG or JPG"
 msgstr "PNG ali JPG"
 
@@ -8862,63 +6793,31 @@ msgid "Select a different footer image"
 msgstr "Izberite drugo sliko za nogo"
 
 #: src/olympia/devhub/templates/devhub/versions/add_file_modal.html:8
-msgid ""
-"Files added to reviewed versions must be reviewed before they will be "
-"available for download."
-msgstr ""
-"Datoteke, ki jih dodate pregledanim različicam, je treba pregledati, preden "
-"bodo na voljo za prenos."
+msgid "Files added to reviewed versions must be reviewed before they will be available for download."
+msgstr "Datoteke, ki jih dodate pregledanim različicam, je treba pregledati, preden bodo na voljo za prenos."
 
-#: src/olympia/devhub/templates/devhub/versions/add_file_modal.html:15
-#, python-format
-msgid ""
-"Submission of updates to unlisted add-ons for signing is currently in an "
-"open beta. Manual review may still be required for a large number of add-"
-"ons. Please <a href=\"%(url)s\" target=\"_blank\">report any bugs</a> that "
-"you encounter."
-msgstr ""
-"Predložitev navedenih dodatkov za podpisovanje je trenutno na odprti stopnji"
-" beta. Za večje število dodatkov bo morda še vedno zahtevan ročni pregled. "
-"<a href=\"%(url)s\" target=\"_blank\">Prijavite morebitne hrošče</a>."
-
-#: src/olympia/devhub/templates/devhub/versions/add_file_modal.html:35
+#: src/olympia/devhub/templates/devhub/versions/add_file_modal.html:24
 msgid "Select the target platform for this file."
 msgstr "Izberite ciljno platformo za to datoteko."
 
-#: src/olympia/devhub/templates/devhub/versions/add_file_modal.html:46
+#: src/olympia/devhub/templates/devhub/versions/add_file_modal.html:35
 msgid "Which review type would you like to nominate for?"
 msgstr "Za katero vrsto pregleda bi se radi potegovali?"
 
-#: src/olympia/devhub/templates/devhub/versions/add_file_modal.html:51
+#: src/olympia/devhub/templates/devhub/versions/add_file_modal.html:40
 msgid "Only publish this version to my beta channel."
 msgstr "Objavi to različico le na mojem beta kanalu."
-
-#: src/olympia/devhub/templates/devhub/versions/add_file_modal.html:54
-#, python-format
-msgid ""
-"The behavior of the beta channel has changed to accommodate <a "
-"href=\"%(addon_signing_url)s\" target=\"_blank\">mandatory add-on "
-"signing</a>. The new process is currently in an open beta, and may change "
-"significantly in the near future. Please <a href=\"%(issues_url)s\" "
-"target=\"_blank\">report any bugs</a> that you encounter."
-msgstr ""
-"Vedenje kanala beta se je spremenilo za umestitev <a "
-"href=\"%(addon_signing_url)s\" target=\"_blank\">obveznega podpisovanja "
-"dodatkov</a>. Nov postopek je trenutno na stopnji beta in se lahko v bližnji"
-" prihodnosti znatno spremeni. <a href=\"%(issues_url)s\" "
-"target=\"_blank\">Prijavite morebitne hrošče</a>."
 
 #: src/olympia/devhub/templates/devhub/versions/edit.html:5
 msgid "Manage Version {0}"
 msgstr "Upravljanje različice {0}"
 
-#: src/olympia/devhub/templates/devhub/versions/edit.html:12
-#: src/olympia/devhub/templates/devhub/versions/list.html:3
+#: src/olympia/devhub/templates/devhub/versions/edit.html:12 src/olympia/devhub/templates/devhub/versions/list.html:3
 msgid "Status & Versions"
 msgstr "Stanje in različice"
 
-#. {0} is an add-on name.
 # {0} is the name of the collection
+#. {0} is an add-on name.
 #: src/olympia/devhub/templates/devhub/versions/edit.html:16
 msgid "Manage {0}"
 msgstr "Upravljanje {0}"
@@ -8931,22 +6830,10 @@ msgstr "Datoteke"
 msgid "Upload Another File"
 msgstr "Naloži še eno datoteko"
 
-#: src/olympia/devhub/templates/devhub/versions/edit.html:45
-msgid ""
-"Adjusting application information here will allow users to install your\n"
-"                          add-on even if the install manifest in the package indicates that the\n"
-"                          add-on is incompatible."
-msgstr ""
-"Prilagoditev teh podatkov bo uporabnikom omogočala namestitev\n"
-"                          dodatka, tudi če manifest namestitve v paketu nakazuje, da dodatek\n"
-"                          ni združljiv."
-
 #: src/olympia/devhub/templates/devhub/versions/edit.html:74
 msgid ""
-"Information about changes in this release, new features,\n"
-"                              known bugs, and other useful information specific to this\n"
-"                              release/version. This information is also shown in the\n"
-"                              Add-ons Manager when updating."
+"Information about changes in this release, new features, known bugs, and other useful information specific to this release/version. This information is also shown in the Add-ons Manager when "
+"updating."
 msgstr ""
 "Podatki o spremembah v tej izdaji, nove značilnosti, znani\n"
 "                              hrošči in drugi uporabni podatki, ki so značilni za to različico.\n"
@@ -8957,16 +6844,12 @@ msgstr ""
 msgid "Approval Status"
 msgstr "Stanje odobritve"
 
-#: src/olympia/devhub/templates/devhub/versions/edit.html:113
-#: src/olympia/editors/templates/editors/review.html:108
+#: src/olympia/devhub/templates/devhub/versions/edit.html:113 src/olympia/editors/templates/editors/review.html:108
 msgid "Notes for Reviewers"
 msgstr "Pojasnila za pregledovalce"
 
 #: src/olympia/devhub/templates/devhub/versions/edit.html:114
-msgid ""
-"Optionally, enter any information that may be useful\n"
-"                              to the Editor reviewing this add-on, such as test\n"
-"                              account information."
+msgid "Optionally, enter any information that may be useful to the Editor reviewing this add-on, such as test account information."
 msgstr ""
 "Izbirno vnesite podatke, ki so lahko uporabni za\n"
 "                              urednika, ki vaš dodatek pregleduje, kot so npr.\n"
@@ -8977,15 +6860,10 @@ msgid "Source code"
 msgstr "Izvorna koda"
 
 #: src/olympia/devhub/templates/devhub/versions/edit.html:128
-msgid ""
-"If your add-on contain binary or obfuscated code, make the source available "
-"here for reviewers."
-msgstr ""
-"Če vaš dodatek vsebuje dvojiško ali zamaskirano kodo, dajte njegov vir na "
-"razpolago pregledovalcem tukaj."
+msgid "If your add-on contain binary or obfuscated code, make the source available here for reviewers."
+msgstr "Če vaš dodatek vsebuje dvojiško ali zamaskirano kodo, dajte njegov vir na razpolago pregledovalcem tukaj."
 
-#: src/olympia/devhub/templates/devhub/versions/edit.html:145
-#: src/olympia/devhub/templates/devhub/versions/edit.html:149
+#: src/olympia/devhub/templates/devhub/versions/edit.html:145 src/olympia/devhub/templates/devhub/versions/edit.html:149
 msgid "Upload a new file"
 msgstr "Naloži novo datoteko"
 
@@ -9026,8 +6904,6 @@ msgid "{0} file"
 msgid_plural "{0} files"
 msgstr[0] "{0} datoteka"
 msgstr[1] "{0} datoteki"
-msgstr[2] "{0} datoteke"
-msgstr[3] "{0} datotek"
 
 #: src/olympia/devhub/templates/devhub/versions/list.html:25
 msgid "0 files"
@@ -9054,9 +6930,7 @@ msgstr "Zahtevam popoln pregled"
 msgid "Request Preliminary Review"
 msgstr "Zahtevam predhodni pregled"
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:80
-#: src/olympia/devhub/templates/devhub/versions/list.html:327
-#: src/olympia/devhub/templates/devhub/versions/list.html:350
+#: src/olympia/devhub/templates/devhub/versions/list.html:80 src/olympia/devhub/templates/devhub/versions/list.html:325 src/olympia/devhub/templates/devhub/versions/list.html:348
 msgid "Cancel Review Request"
 msgstr "Prekliči zahtevo za pregled"
 
@@ -9069,34 +6943,24 @@ msgid "Listed:"
 msgstr "Navedeni:"
 
 #: src/olympia/devhub/templates/devhub/versions/list.html:102
-msgid ""
-"Visible to everyone on {0} and included in search results and listing pages"
-msgstr ""
-"Vidno vsem na {0} in vključeno v iskalne rezultate in strani s seznamom"
+msgid "Visible to everyone on {0} and included in search results and listing pages"
+msgstr "Vidno vsem na {0} in vključeno v iskalne rezultate in strani s seznamom"
 
 #: src/olympia/devhub/templates/devhub/versions/list.html:108
 msgid "Hidden:"
 msgstr "Skrito:"
 
 #: src/olympia/devhub/templates/devhub/versions/list.html:108
-msgid ""
-"Hosted on {0}, but hidden to anyone but authors. Used to temporarily hide "
-"listings or discontinue them."
-msgstr ""
-"Gostovano na {0}, vendar skrito za vse razen avtorjev. Uporabite, če želite "
-"dodatek začasno skriti ali ga nehati razvijati."
+msgid "Hosted on {0}, but hidden to anyone but authors. Used to temporarily hide listings or discontinue them."
+msgstr "Gostovano na {0}, vendar skrito za vse razen avtorjev. Uporabite, če želite dodatek začasno skriti ali ga nehati razvijati."
 
 #: src/olympia/devhub/templates/devhub/versions/list.html:114
 msgid "Unlisted:"
 msgstr "Nenavedeni:"
 
 #: src/olympia/devhub/templates/devhub/versions/list.html:114
-msgid ""
-"Not distributed on {0}. Developers will upload new versions for signing and "
-"distribute the add-ons on their own. (beta)"
+msgid "Not distributed on {0}. Developers will upload new versions for signing and distribute the add-ons on their own."
 msgstr ""
-"Ni razširjen na {0}. Razvijalci bodo poslali nove različice za podpisovanje "
-"in dodatke razširjali po svoje. (beta)"
 
 #: src/olympia/devhub/templates/devhub/versions/list.html:122
 msgid "Current versions"
@@ -9106,18 +6970,13 @@ msgstr "Trenutne različice"
 msgid "Currently on AMO"
 msgstr "Trenutno na AMO"
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:129
-#: src/olympia/devhub/templates/devhub/versions/list.html:147
-#: src/olympia/devhub/templates/devhub/versions/list.html:164
-#: src/olympia/editors/templates/editors/includes/search_results_themes.html:7
-#: src/olympia/editors/templates/editors/themes/queue_list.html:50
+#: src/olympia/devhub/templates/devhub/versions/list.html:129 src/olympia/devhub/templates/devhub/versions/list.html:147 src/olympia/devhub/templates/devhub/versions/list.html:164
+#: src/olympia/editors/templates/editors/includes/search_results_themes.html:7 src/olympia/editors/templates/editors/themes/queue_list.html:50
 msgid "Status"
 msgstr "Stanje"
 
 # Header for a column in a table
-#: src/olympia/devhub/templates/devhub/versions/list.html:130
-#: src/olympia/devhub/templates/devhub/versions/list.html:148
-#: src/olympia/devhub/templates/devhub/versions/list.html:165
+#: src/olympia/devhub/templates/devhub/versions/list.html:130 src/olympia/devhub/templates/devhub/versions/list.html:148 src/olympia/devhub/templates/devhub/versions/list.html:165
 #: src/olympia/editors/templates/editors/includes/files_view.html:11
 msgid "Validation"
 msgstr "Preverjanje veljavnosti"
@@ -9139,14 +6998,10 @@ msgid "Full review may not be required"
 msgstr "Popoln pregled morda ne bo potreben"
 
 #: src/olympia/devhub/templates/devhub/versions/list.html:201
-msgid ""
-"Unlisted add-ons don't need Full Review unless they are distributed as part "
-"of an application installer. Read <a href=\"{link}\" target=\"_blank\">this "
-"documentation</a> for more information."
+msgid "Unlisted add-ons don't need Full Review unless they are distributed as part of an application installer. Read <a href=\"{link}\" target=\"_blank\">this documentation</a> for more information."
 msgstr ""
-"Nenavedeni dodatki ne potrebujejo popolnega pregleda, razen če so "
-"distribuirani kot del namestitvenega programa. Za več informacij si "
-"preberite <a href=\"{link}\" target=\"_blank\">dokumentacijo</a>."
+"Nenavedeni dodatki ne potrebujejo popolnega pregleda, razen če so distribuirani kot del namestitvenega programa. Za več informacij si preberite <a href=\"{link}\" target=\"_blank\">dokumentacijo</"
+"a>."
 
 #: src/olympia/devhub/templates/devhub/versions/list.html:209
 msgid "Request full review"
@@ -9158,134 +7013,87 @@ msgstr "Izbriši različico {version}"
 
 #: src/olympia/devhub/templates/devhub/versions/list.html:218
 msgid ""
-"You are about to delete the current version of your add-on. This may cause "
-"your add-on status to change, or your listing to lose public visibility, if "
-"this is the only public version of your add-on."
-msgstr ""
-"Ste pred izbrisom trenutne različice svojega dodatka. To lahko povzroči "
-"spremembo stanja dodatka, objava pa lahko postane nevidna za javnost, če je "
-"to edina javna različica vašega dodatka."
+"You are about to delete the current version of your add-on. This may cause your add-on status to change, or your listing to lose public visibility, if this is the only public version of your add-on."
+msgstr "Ste pred izbrisom trenutne različice svojega dodatka. To lahko povzroči spremembo stanja dodatka, objava pa lahko postane nevidna za javnost, če je to edina javna različica vašega dodatka."
 
 #: src/olympia/devhub/templates/devhub/versions/list.html:219
 msgid "Deleting this version will permanently delete:"
 msgstr "Brisanje te različice bo trajno izbrisalo:"
 
 #: src/olympia/devhub/templates/devhub/versions/list.html:225
-msgid ""
-"<strong>Important:</strong> Once a version has been deleted, you may not "
-"upload a new version with the same version number."
-msgstr ""
-"<strong>Pomembno:</strong> ko je različica enkrat izbrisana, morda ne boste "
-"več mogli naložiti nove različice z isto številko različice."
+msgid "<strong>Important:</strong> Once a version has been deleted, you may not upload a new version with the same version number."
+msgstr "<strong>Pomembno:</strong> ko je različica enkrat izbrisana, morda ne boste več mogli naložiti nove različice z isto številko različice."
 
 #: src/olympia/devhub/templates/devhub/versions/list.html:230
-msgid ""
-"Deleting a version which has already been reviewed\n"
-"               may also cause a significant delay in the review of\n"
-"               your next update."
-msgstr ""
-"Če izbrišete različico, ki je že bila pregledana, se\n"
-"               lahko pregled naslednje posodobitve občutno zakasni."
-
-#: src/olympia/devhub/templates/devhub/versions/list.html:233
 msgid "Are you sure you wish to delete this version?"
 msgstr "Ali ste prepričani, da želite izbrisati to različico?"
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:238
+#: src/olympia/devhub/templates/devhub/versions/list.html:235
 msgid "Delete Version"
 msgstr "Izbriši različico"
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:240
+#: src/olympia/devhub/templates/devhub/versions/list.html:237
 msgid "Disable Version"
 msgstr "Onemogoči različico"
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:247
+#: src/olympia/devhub/templates/devhub/versions/list.html:244
 msgid "Add a new Version"
 msgstr "Dodaj novo različico"
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:249
+#: src/olympia/devhub/templates/devhub/versions/list.html:246
 msgid "Add Version"
 msgstr "Dodaj različico"
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:256
-#: src/olympia/devhub/templates/devhub/versions/list.html:274
+#: src/olympia/devhub/templates/devhub/versions/list.html:253 src/olympia/devhub/templates/devhub/versions/list.html:279
 msgid "Hide Add-on"
 msgstr "Skrij dodatek"
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:259
-msgid ""
-"Hiding your add-on will prevent it from appearing anywhere in our gallery "
-"and will stop users from receiving automatic updates."
-msgstr ""
-"Skrivanje vašega dodatka bo preprečilo njegov prikaz v naši galeriji in bo "
-"ustavilo samodejne posodobitve za uporabnike."
+#: src/olympia/devhub/templates/devhub/versions/list.html:256
+msgid "Hiding your add-on will prevent it from appearing anywhere in our gallery and will stop users from receiving automatic updates."
+msgstr "Skrivanje vašega dodatka bo preprečilo njegov prikaz v naši galeriji in bo ustavilo samodejne posodobitve za uporabnike."
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:265
+#: src/olympia/devhub/templates/devhub/versions/list.html:263
+msgid "The files awaiting review will be disabled and you will need to upload new versions."
+msgstr ""
+
+#: src/olympia/devhub/templates/devhub/versions/list.html:270
 msgid "Are you sure you wish to hide your add-on?"
 msgstr "Ali res želite skriti svoj dodatek?"
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:286
-#: src/olympia/devhub/templates/devhub/versions/list.html:315
+#: src/olympia/devhub/templates/devhub/versions/list.html:291 src/olympia/devhub/templates/devhub/versions/list.html:313
 msgid "Unlist Add-on"
 msgstr "Odstrani dodatek s seznama"
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:289
+#: src/olympia/devhub/templates/devhub/versions/list.html:294
 #, python-format
 msgid ""
-"Unlisting your add-on will make it (and each of its versions/files) "
-"invisible on this website. It won't show up in searches, won't have a public"
-" facing page, and won't be updated automatically for current users.  It is "
-"recommended for unlisted add-ons to provide a custom <a "
-"href=\"%(update_url)s\" target=\"_blank\">updateURL</a> in their manifest "
-"file for automatic updates."
+"Unlisting your add-on will make it (and each of its versions/files) invisible on this website. It won't show up in searches, won't have a public facing page, and won't be updated automatically for "
+"current users. It is recommended for unlisted add-ons to provide a custom <a href=\"%(update_url)s\" target=\"_blank\">updateURL</a> in their manifest file for automatic updates."
 msgstr ""
-"Odstranitev dodatka s seznama ga bo na spletni strani naredila nevidnega, "
-"kot tudi vse njegove različice.  Ne bo se prikazal v iskanjih, ne bo imel "
-"javne strani in se ne bo samodejno posodabljal za trenutne uporabnike.  "
-"Priporočljivo je, da za nenavedene dodatke v datoteki manifesta dobavite <a "
-"href=\"%(update_url)s\" target=\"_blank\">URL posodobitev</a> za samodejne "
-"posodobitve."
+"Odstranitev dodatka s seznama ga bo na spletni strani naredila nevidnega, kot tudi vse njegove različice.  Ne bo se prikazal v iskanjih, ne bo imel javne strani in se ne bo samodejno posodabljal za "
+"trenutne uporabnike.  Priporočljivo je, da za nenavedene dodatke v datoteki manifesta dobavite <a href=\"%(update_url)s\" target=\"_blank\">URL posodobitev</a> za samodejne posodobitve."
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:299
-#, python-format
-msgid ""
-"Switching add-ons to unlisted is currently in an open beta. Please <a "
-"href=\"%(url)s\" target=\"_blank\">report any bugs</a> that you encounter."
-msgstr ""
-"Preklapljanje dodatkov na nenavedene je trenutno na odprti stopnji beta. <a "
-"href=\"%(url)s\" target=\"_blank\">Prijavite morebitne hrošče</a>."
-
-#: src/olympia/devhub/templates/devhub/versions/list.html:305
+#: src/olympia/devhub/templates/devhub/versions/list.html:303
 msgid "Unlisting an add-on is irreversible!"
 msgstr "Odstranitev dodatka s seznama ni mogoče povrniti!"
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:305
+#: src/olympia/devhub/templates/devhub/versions/list.html:303
 msgid "An unlisted add-on cannot be switched to be listed."
 msgstr "Nenavedenega dodatka ni mogoče zopet navesti."
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:307
+#: src/olympia/devhub/templates/devhub/versions/list.html:305
 msgid "Are you sure you wish to unlist your add-on?"
 msgstr "Ali res želite odstraniti svoj dodatek iz seznama?"
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:330
-msgid ""
-"Canceling your review request will leave your add-on as preliminarily "
-"reviewed."
-msgstr ""
-"Če svojo zahtevo za pregled prekličete, bo vaš dodatek ostal dalje kot "
-"predhodno pregledan."
+#: src/olympia/devhub/templates/devhub/versions/list.html:328
+msgid "Canceling your review request will leave your add-on as preliminarily reviewed."
+msgstr "Če svojo zahtevo za pregled prekličete, bo vaš dodatek ostal dalje kot predhodno pregledan."
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:335
-msgid ""
-"Canceling your review request will mark your add-on incomplete. If you do "
-"not complete your add-on after several days by re-requesting review, it will"
-" be deleted."
-msgstr ""
-"Če svojo zahtevo za pregled prekličete, se bo vaš dodatek označilo kot "
-"nepopoln. Če svojega dodatka v času nekaj dni ne dopolnite z zahtevo po "
-"pregledu, se ga zbrisalo."
+#: src/olympia/devhub/templates/devhub/versions/list.html:333
+msgid "Canceling your review request will mark your add-on incomplete. If you do not complete your add-on after several days by re-requesting review, it will be deleted."
+msgstr "Če svojo zahtevo za pregled prekličete, se bo vaš dodatek označilo kot nepopoln. Če svojega dodatka v času nekaj dni ne dopolnite z zahtevo po pregledu, se ga zbrisalo."
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:343
+#: src/olympia/devhub/templates/devhub/versions/list.html:341
 msgid "Are you sure you wish to cancel your review request?"
 msgstr "Res želite preklicati zahtevo za pregled?"
 
@@ -9295,8 +7103,7 @@ msgstr "Enostavno nakupovanje"
 
 #: src/olympia/discovery/modules.py:141
 msgid "Save on your favorite items from the comfort of your browser."
-msgstr ""
-"Privarčujte pri svojih najljubših predmetih iz udobja svojega brskalnika."
+msgstr "Privarčujte pri svojih najljubših predmetih iz udobja svojega brskalnika."
 
 #: src/olympia/discovery/modules.py:149
 msgid "Build the perfect website"
@@ -9319,18 +7126,12 @@ msgid "Translate content on the web from and into over 40 languages."
 msgstr "Prevajajte vsebino na spletu v več kot 40 jezikov."
 
 #: src/olympia/discovery/modules.py:171
-msgid ""
-"Easily connect to your social networks, and share or comment on the page "
-"you're visiting."
-msgstr ""
-"Povežite se s svojimi družabnimi omrežji in izmenjujte mnenja na straneh, ki"
-" jih obiskujete."
+msgid "Easily connect to your social networks, and share or comment on the page you're visiting."
+msgstr "Povežite se s svojimi družabnimi omrežji in izmenjujte mnenja na straneh, ki jih obiskujete."
 
 #: src/olympia/discovery/modules.py:173
-msgid ""
-"A quick view to compare prices when you shop online or search for flights."
-msgstr ""
-"Hitra primerjava cen ko nakupujete na spletu ali iščete letalske karte."
+msgid "A quick view to compare prices when you shop online or search for flights."
+msgstr "Hitra primerjava cen ko nakupujete na spletu ali iščete letalske karte."
 
 #: src/olympia/discovery/modules.py:183
 msgid "Firefox 4 Collection"
@@ -9373,23 +7174,16 @@ msgid "Add-ons that help you on your travels!"
 msgstr "Dodatki, ki vam pomagajo na potovanjih!"
 
 #: src/olympia/discovery/modules.py:226
-msgid ""
-"Displays a country flag depicting the location of the current website's "
-"server and more."
-msgstr ""
-"Prikaže zastavo države, ki ponazarja lokacijo strežnika trenutne strani, in "
-"še več."
+msgid "Displays a country flag depicting the location of the current website's server and more."
+msgstr "Prikaže zastavo države, ki ponazarja lokacijo strežnika trenutne strani, in še več."
 
 #: src/olympia/discovery/modules.py:228
 msgid "FoxClocks let you keep an eye on the time around the world."
 msgstr "FoxClocks vam omogoča ogled časa po svetu."
 
 #: src/olympia/discovery/modules.py:230
-msgid ""
-"Automatically get the lowest price when you shop online or search for "
-"flights."
-msgstr ""
-"Samodejno dobite najnižjo ceno, ko nakupujete prek spleta ali iščete polet."
+msgid "Automatically get the lowest price when you shop online or search for flights."
+msgstr "Samodejno dobite najnižjo ceno, ko nakupujete prek spleta ali iščete polet."
 
 #: src/olympia/discovery/modules.py:240
 msgid "A+ add-ons for School"
@@ -9428,12 +7222,8 @@ msgid "Put a Theme on It!"
 msgstr "Oblecite ga v temo!"
 
 #: src/olympia/discovery/modules.py:281
-msgid ""
-"Visit addons.mozilla.org from Firefox for Android and dress up your mobile "
-"browser to match your style, mood, or the season."
-msgstr ""
-"Obiščite addons.mozilla.org s Firefoxom za Android in oblecite svoj "
-"brskalnik tako, da se bo ujemal z vašim slogom, voljo ali sezono."
+msgid "Visit addons.mozilla.org from Firefox for Android and dress up your mobile browser to match your style, mood, or the season."
+msgstr "Obiščite addons.mozilla.org s Firefoxom za Android in oblecite svoj brskalnik tako, da se bo ujemal z vašim slogom, voljo ali sezono."
 
 #: src/olympia/discovery/modules.py:290
 msgid "Get up and move!"
@@ -9449,8 +7239,7 @@ msgstr "Novo &amp; zdaj"
 
 #: src/olympia/discovery/modules.py:300
 msgid "Get the latest, must-have add-ons of the moment."
-msgstr ""
-"Poiščite najnovejše dodatke tega trenutka, ki jih preprosto morate imeti."
+msgstr "Poiščite najnovejše dodatke tega trenutka, ki jih preprosto morate imeti."
 
 #: src/olympia/discovery/modules.py:332
 msgid "Worry-free browsing"
@@ -9461,12 +7250,8 @@ msgid "Protect your privacy online with the add-ons in this collection."
 msgstr "Zaščitite svojo zasebnost na spletu z dodatki iz te zbirke."
 
 #: src/olympia/discovery/modules.py:342
-msgid ""
-"Great add-ons for work, fun, privacy, productivity&hellip; just about "
-"anything!"
-msgstr ""
-"Odlični dodatki za delo, zabavo, zasebnost, storilnost &hellip; za čisto "
-"vse!"
+msgid "Great add-ons for work, fun, privacy, productivity&hellip; just about anything!"
+msgstr "Odlični dodatki za delo, zabavo, zasebnost, storilnost &hellip; za čisto vse!"
 
 #: src/olympia/discovery/modules.py:350
 msgid "Add-ons for Australis Contest Winners"
@@ -9486,22 +7271,16 @@ msgstr "Kaj so dodatki?"
 
 #: src/olympia/discovery/templates/discovery/pane.html:28
 #, python-format
-msgid ""
-"Add-ons are applications that let you personalize %(app)s with extra "
-"functionality or style. Try a time-saving sidebar, a weather notifier, or a "
-"themed look to make %(app)s your own."
+msgid "Add-ons are applications that let you personalize %(app)s with extra functionality or style. Try a time-saving sidebar, a weather notifier, or a themed look to make %(app)s your own."
 msgstr ""
-"Dodatki so aplikacije, ki vam omogočajo prilagoditi %(app)s, kar se dodatnih"
-" funkcij in sloga aplikacije tiče. Poskusite s stransko vrstico za prihranek"
-" časa, z dodatkom za vreme, s tapetami po svojem okusu, da si podomačite "
-"%(app)s."
+"Dodatki so aplikacije, ki vam omogočajo prilagoditi %(app)s, kar se dodatnih funkcij in sloga aplikacije tiče. Poskusite s stransko vrstico za prihranek časa, z dodatkom za vreme, s tapetami po "
+"svojem okusu, da si podomačite %(app)s."
 
 #: src/olympia/discovery/templates/discovery/pane.html:62
 msgid "Learn More About Add-ons"
 msgstr "Več o dodatkih"
 
-#: src/olympia/discovery/templates/discovery/pane.html:66
-#: src/olympia/discovery/templates/discovery/pane.html:73
+#: src/olympia/discovery/templates/discovery/pane.html:66 src/olympia/discovery/templates/discovery/pane.html:73
 msgid "See all"
 msgstr "Oglejte si vse"
 
@@ -9532,12 +7311,8 @@ msgstr "Živjo, {0}"
 
 #: src/olympia/discovery/templates/discovery/pane_account.html:17
 #, python-format
-msgid ""
-"Thanks for using %(app)s and supporting <a href=\"%(url)s\">Mozilla's "
-"mission</a>!"
-msgstr ""
-"Hvala, da uporabljate %(app)s in podpirate <a href=\"%(url)s\">Poslanstvo "
-"Mozille</a>!"
+msgid "Thanks for using %(app)s and supporting <a href=\"%(url)s\">Mozilla's mission</a>!"
+msgstr "Hvala, da uporabljate %(app)s in podpirate <a href=\"%(url)s\">Poslanstvo Mozille</a>!"
 
 #: src/olympia/discovery/templates/discovery/pane_account.html:23
 msgid "Add-ons downloaded:"
@@ -9561,14 +7336,8 @@ msgstr "Dodatki mimogrede"
 
 #: src/olympia/discovery/templates/discovery/modules/go-mobile.html:8
 #, python-format
-msgid ""
-"Visit <a href=\"%(url)s\">firefox.com/m</a> to get Firefox on your phone and"
-" personalize your browser anytime, anywhere. Easily discover and install "
-"add-ons from the mobile Add-ons Manager."
-msgstr ""
-"Obiščite <a href=\"%(url)s\">firefox.com/m</a> za prenos Firefoxa na telefon"
-" ter si ga prilagodite kjerkoli in kadarkoli. Dodatke lahko namreč odkrivate"
-" in nameščate tudi na mobilni napravi."
+msgid "Visit <a href=\"%(url)s\">firefox.com/m</a> to get Firefox on your phone and personalize your browser anytime, anywhere. Easily discover and install add-ons from the mobile Add-ons Manager."
+msgstr "Obiščite <a href=\"%(url)s\">firefox.com/m</a> za prenos Firefoxa na telefon ter si ga prilagodite kjerkoli in kadarkoli. Dodatke lahko namreč odkrivate in nameščate tudi na mobilni napravi."
 
 #: src/olympia/discovery/templates/discovery/modules/go-mobile.html:13
 msgid "Get Mobile Add-ons"
@@ -9580,25 +7349,15 @@ msgstr "Kupujte pametno za te praznike"
 
 #: src/olympia/discovery/templates/discovery/modules/holiday.html:5
 msgid "Find great add-ons to help you with all your holiday shopping needs."
-msgstr ""
-"Poiščite odlične dodatke, ki vam pomagajo pri vseh vaših potrebah za božično"
-" nakupovanje."
+msgstr "Poiščite odlične dodatke, ki vam pomagajo pri vseh vaših potrebah za božično nakupovanje."
 
 #: src/olympia/discovery/templates/discovery/modules/holiday.html:13
-msgid ""
-"Install the Amazon Browser Apps and receive special Amazon features right at"
-" your fingertips."
-msgstr ""
-"Namestite Amazonove aplikacije za brskalnik in prejemajte posebne Amazonove "
-"funkcije prav pod prsti."
+msgid "Install the Amazon Browser Apps and receive special Amazon features right at your fingertips."
+msgstr "Namestite Amazonove aplikacije za brskalnik in prejemajte posebne Amazonove funkcije prav pod prsti."
 
 #: src/olympia/discovery/templates/discovery/modules/holiday.html:22
-msgid ""
-"Keep an eye on your eBay activity wherever you are on the web when you "
-"install the eBay Sidebar for Firefox."
-msgstr ""
-"Ostanite pozorni na svojo aktivnost na eBayu, kadarkoli ste na spletu, ko "
-"namestite stransko vrstico eBay za Firefox."
+msgid "Keep an eye on your eBay activity wherever you are on the web when you install the eBay Sidebar for Firefox."
+msgstr "Ostanite pozorni na svojo aktivnost na eBayu, kadarkoli ste na spletu, ko namestite stransko vrstico eBay za Firefox."
 
 #: src/olympia/discovery/templates/discovery/modules/holiday.html:31
 msgid "See the entire holiday shopping add-on collection."
@@ -9675,19 +7434,19 @@ msgstr "dodatek, urednik ali komentar"
 msgid "Search by add-on name / author email"
 msgstr "Iskanje po imenu dodatka/e-pošti avtorja"
 
-#: src/olympia/editors/forms.py:103
+#: src/olympia/editors/forms.py:103 src/olympia/editors/forms.py:244 src/olympia/editors/forms.py:257
 msgid "yes"
 msgstr "da"
 
-#: src/olympia/editors/forms.py:104
+#: src/olympia/editors/forms.py:104 src/olympia/editors/forms.py:244 src/olympia/editors/forms.py:257
 msgid "no"
 msgstr "ne"
 
-#: src/olympia/editors/forms.py:105
+#: src/olympia/editors/forms.py:105 src/olympia/editors/forms.py:245
 msgid "Admin Flag"
 msgstr "Zastavica skrbnika"
 
-#: src/olympia/editors/forms.py:113
+#: src/olympia/editors/forms.py:113 src/olympia/editors/forms.py:253
 msgid "Max. Version"
 msgstr "Maks. različica"
 
@@ -9699,59 +7458,59 @@ msgstr "Dni od oddaje"
 msgid "Add-on Types"
 msgstr "Vrste dodatka"
 
-#: src/olympia/editors/forms.py:126 src/olympia/editors/helpers.py:267
+#: src/olympia/editors/forms.py:126 src/olympia/editors/helpers.py:279
 msgid "Platforms"
 msgstr "Platforme"
 
+#: src/olympia/editors/forms.py:237
+msgid "Search by add-on name / author email / guid"
+msgstr ""
+
 #. L10n: 0 = platform, 1 = filename, 2 = status message
-#: src/olympia/editors/forms.py:238
+#: src/olympia/editors/forms.py:342
 #, python-format
 msgid "<strong>%s</strong> &middot; %s &middot; %s"
 msgstr "<strong>%s</strong> &middot; %s &middot; %s"
 
-#: src/olympia/editors/forms.py:252
+#: src/olympia/editors/forms.py:356
 msgid "Comments:"
 msgstr "Komentarji:"
 
-#: src/olympia/editors/forms.py:256
+#: src/olympia/editors/forms.py:360
 msgid "Operating systems:"
 msgstr "Operacijski sistemi:"
 
-#: src/olympia/editors/forms.py:258
+#: src/olympia/editors/forms.py:362
 msgid "Applications:"
 msgstr "Programi:"
 
-#: src/olympia/editors/forms.py:260
-msgid ""
-"Notify me the next time this add-on is updated. (Subsequent updates will not"
-" generate an email)"
-msgstr ""
-"Obvesti me, ko bo ta dodatek naslednjič posodobljen. (Nadaljnje posodobitve "
-"ne bodo pošiljale e-pošte)"
+#: src/olympia/editors/forms.py:364
+msgid "Notify me the next time this add-on is updated. (Subsequent updates will not generate an email)"
+msgstr "Obvesti me, ko bo ta dodatek naslednjič posodobljen. (Nadaljnje posodobitve ne bodo pošiljale e-pošte)"
 
-#: src/olympia/editors/forms.py:265
+#: src/olympia/editors/forms.py:369
 msgid "Clear Admin Review Flag"
 msgstr "Zbriši zastavico za skrbnikov pregled"
 
-#: src/olympia/editors/forms.py:267
+#: src/olympia/editors/forms.py:371
 msgid "Clear more info requested flag"
 msgstr "Počisti zastavico zahtevanih več podatkov"
 
-#: src/olympia/editors/forms.py:281
+#: src/olympia/editors/forms.py:385
 msgid "Choose a canned response..."
 msgstr "Izberi pripravljen odgovor ..."
 
 #. L10n: Description of what can be searched for.
-#: src/olympia/editors/forms.py:324
+#: src/olympia/editors/forms.py:423
 msgid "theme name"
 msgstr "ime teme"
 
-#: src/olympia/editors/forms.py:350
+#: src/olympia/editors/forms.py:449
 msgid "Someone else is reviewing this theme."
 msgstr "To temo pregleduje nekdo drug."
 
 #. L10n: Description of what can be searched for.
-#: src/olympia/editors/forms.py:447
+#: src/olympia/editors/forms.py:546
 msgid "app, reviewer, or comment"
 msgstr "aplikacija, recenzent ali komentar"
 
@@ -9767,314 +7526,267 @@ msgstr "Čaka na predhodni pregled"
 msgid "Rejected or Unreviewed"
 msgstr "Zavrnjeno ali nepregledano"
 
-#: src/olympia/editors/helpers.py:123 src/olympia/editors/helpers.py:136
+#: src/olympia/editors/helpers.py:125 src/olympia/editors/helpers.py:138
 msgid "Queue"
 msgstr "V vrsti"
 
-#: src/olympia/editors/helpers.py:124
-#: src/olympia/editors/templates/editors/base.html:50
-#: src/olympia/editors/templates/editors/base.html:65
+#: src/olympia/editors/helpers.py:126 src/olympia/editors/templates/editors/base.html:50 src/olympia/editors/templates/editors/base.html:65
 msgid "Pending Updates"
 msgstr "Posodobitve v teku"
 
-#: src/olympia/editors/helpers.py:125
-#: src/olympia/editors/templates/editors/base.html:48
-#: src/olympia/editors/templates/editors/base.html:63
+#: src/olympia/editors/helpers.py:127 src/olympia/editors/templates/editors/base.html:48 src/olympia/editors/templates/editors/base.html:63
 msgid "Full Reviews"
 msgstr "Popolni pregledi"
 
-#: src/olympia/editors/helpers.py:126
-#: src/olympia/editors/templates/editors/base.html:52
-#: src/olympia/editors/templates/editors/base.html:67
+#: src/olympia/editors/helpers.py:128 src/olympia/editors/templates/editors/base.html:52 src/olympia/editors/templates/editors/base.html:67
 msgid "Preliminary Reviews"
 msgstr "Predhodni pregledi"
 
-#: src/olympia/editors/helpers.py:127
-#: src/olympia/editors/templates/editors/base.html:54
+#: src/olympia/editors/helpers.py:129 src/olympia/editors/templates/editors/base.html:54
 msgid "Moderated Reviews"
 msgstr "Moderirani pregledi"
 
-#: src/olympia/editors/helpers.py:128
-#: src/olympia/editors/templates/editors/base.html:46
+#: src/olympia/editors/helpers.py:130 src/olympia/editors/templates/editors/base.html:46
 msgid "Fast Track"
 msgstr "Hitra steza"
 
-#: src/olympia/editors/helpers.py:130
+#: src/olympia/editors/helpers.py:132
 msgid "Pending Themes"
 msgstr "Teme v čakanju"
 
-#: src/olympia/editors/helpers.py:131
-#: src/olympia/editors/templates/editors/themes/queue.html:4
+#: src/olympia/editors/helpers.py:133 src/olympia/editors/templates/editors/themes/queue.html:4
 msgid "Flagged Themes"
 msgstr "Označene teme"
 
-#: src/olympia/editors/helpers.py:132
+#: src/olympia/editors/helpers.py:134
 msgid "Update Themes"
 msgstr "Posodobite teme"
 
-#: src/olympia/editors/helpers.py:137
+#: src/olympia/editors/helpers.py:139
 msgid "Unlisted Pending Updates"
 msgstr "Posodobitve na čakanju za nenavedene"
 
-#: src/olympia/editors/helpers.py:138
+#: src/olympia/editors/helpers.py:140
 msgid "Unlisted Full Reviews"
 msgstr "Popolni pregledi za nenavedene"
 
-#: src/olympia/editors/helpers.py:139
+#: src/olympia/editors/helpers.py:141
 msgid "Unlisted Preliminary Reviews"
 msgstr "Predhodni pregledi za nenavedene"
 
-#: src/olympia/editors/helpers.py:170
+#: src/olympia/editors/helpers.py:142
+msgid "Unlisted All Add-ons"
+msgstr ""
+
+#: src/olympia/editors/helpers.py:173
 msgid "Fast Track ({0})"
 msgid_plural "Fast Track ({0})"
 msgstr[0] "Hitra steza ({0})"
 msgstr[1] "Hitra steza ({0})"
-msgstr[2] "Hitra steza ({0})"
-msgstr[3] "Hitra steza ({0})"
 
-#: src/olympia/editors/helpers.py:175
+#: src/olympia/editors/helpers.py:178
 msgid "Full Review ({0})"
 msgid_plural "Full Reviews ({0})"
 msgstr[0] "Popoln pregled ({0})"
 msgstr[1] "Popolna pregleda ({0})"
-msgstr[2] "Popolni pregledi ({0})"
-msgstr[3] "Popolnih pregledov ({0})"
 
-#: src/olympia/editors/helpers.py:180
+#: src/olympia/editors/helpers.py:183
 msgid "Pending Update ({0})"
 msgid_plural "Pending Updates ({0})"
 msgstr[0] "Posodobitev na čakanju ({0})"
 msgstr[1] "Posodobitvi na čakanju ({0})"
-msgstr[2] "Posodobitve na čakanju ({0})"
-msgstr[3] "Posodobitve na čakanju ({0})"
 
-#: src/olympia/editors/helpers.py:185
+#: src/olympia/editors/helpers.py:188
 msgid "Preliminary Review ({0})"
 msgid_plural "Preliminary Reviews ({0})"
 msgstr[0] "Predhoden pregled ({0})"
 msgstr[1] "Predhodna pregleda ({0})"
-msgstr[2] "Predhodni pregledi ({0})"
-msgstr[3] "Predhodni pregledi ({0})"
 
-#: src/olympia/editors/helpers.py:190
+#: src/olympia/editors/helpers.py:193
 msgid "Moderated Review ({0})"
 msgid_plural "Moderated Reviews ({0})"
 msgstr[0] "Moderiran pregled ({0})"
 msgstr[1] "Moderirana pregleda ({0})"
-msgstr[2] "Moderirani pregledi ({0})"
-msgstr[3] "Moderirani pregledi ({0})"
 
-#: src/olympia/editors/helpers.py:196
+#: src/olympia/editors/helpers.py:199
 msgid "Unlisted Full Review ({0})"
 msgid_plural "Unlisted Full Reviews ({0})"
 msgstr[0] "Poln pregled za nenavedene ({0})"
 msgstr[1] "Polna pregleda za nenavedene ({0})"
-msgstr[2] "Polni pregledi za nenavedene ({0})"
-msgstr[3] "Polni pregledi za nenavedene ({0})"
 
-#: src/olympia/editors/helpers.py:201
+#: src/olympia/editors/helpers.py:204
 msgid "Unlisted Pending Update ({0})"
 msgid_plural "Unlisted Pending Updates ({0})"
 msgstr[0] "Posodobitev na čakanju za nenavedene ({0})"
 msgstr[1] "Posodobitvi na čakanju za nenavedene ({0})"
-msgstr[2] "Posodobitve na čakanju za nenavedene ({0})"
-msgstr[3] "Posodobitve na čakanju za nenavedene ({0})"
 
-#: src/olympia/editors/helpers.py:206
+#: src/olympia/editors/helpers.py:209
 msgid "Unlisted Preliminary Review ({0})"
 msgid_plural "Unlisted Preliminary Reviews ({0})"
 msgstr[0] "Predhoden pregled za nenavedene ({0})"
 msgstr[1] "Predhodna pregleda za nenavedene ({0})"
-msgstr[2] "Predhodni pregledi za nenavedene ({0})"
-msgstr[3] "Predhodni pregledi za nenavedene ({0})"
 
-#: src/olympia/editors/helpers.py:261
-msgid "Addon"
-msgstr "Dodatek"
+#: src/olympia/editors/helpers.py:214
+msgid "Unlisted All Add-ons ({0})"
+msgid_plural "Unlisted All Add-ons ({0})"
+msgstr[0] ""
+msgstr[1] ""
 
-#: src/olympia/editors/helpers.py:262
+#: src/olympia/editors/helpers.py:274
 msgid "Type"
 msgstr "Vrsta"
 
-#: src/olympia/editors/helpers.py:263
+#: src/olympia/editors/helpers.py:275
 msgid "Waiting Time"
 msgstr "Čakalni čas"
 
-#: src/olympia/editors/helpers.py:264
-#: src/olympia/editors/templates/editors/review.html:285
+#: src/olympia/editors/helpers.py:276 src/olympia/editors/templates/editors/review.html:285
 msgid "Flags"
 msgstr "Zastave"
 
-#: src/olympia/editors/helpers.py:265
+#: src/olympia/editors/helpers.py:277
 msgid "Applications"
 msgstr "Programi"
 
-#: src/olympia/editors/helpers.py:270
+#: src/olympia/editors/helpers.py:282
 msgid "Additional"
 msgstr "Dodatno"
 
-#: src/olympia/editors/helpers.py:285
+#: src/olympia/editors/helpers.py:302
 msgid "Site Specific"
 msgstr "Tipično za stran"
 
-#: src/olympia/editors/helpers.py:287
+#: src/olympia/editors/helpers.py:304
 msgid "Requires External Software"
 msgstr "Zahteva zunanjo programsko opremo"
 
-#: src/olympia/editors/helpers.py:289
+#: src/olympia/editors/helpers.py:306
 msgid "Binary Components"
 msgstr "Binarne komponente"
 
-#: src/olympia/editors/helpers.py:313
+#: src/olympia/editors/helpers.py:339
 msgid "moments ago"
 msgstr "pred nekaj trenutki"
 
 #. L10n: first argument is number of minutes
-#: src/olympia/editors/helpers.py:316
+#: src/olympia/editors/helpers.py:342
 msgid "{0} minute"
 msgid_plural "{0} minutes"
 msgstr[0] "{0} minuta"
 msgstr[1] "{0} minuti"
-msgstr[2] "{0} minute"
-msgstr[3] "{0} minut"
 
 #. L10n: first argument is number of hours
-#: src/olympia/editors/helpers.py:320
+#: src/olympia/editors/helpers.py:346
 msgid "{0} hour"
 msgid_plural "{0} hours"
 msgstr[0] "{0} ura"
 msgstr[1] "{0} uri"
-msgstr[2] "{0} ure"
-msgstr[3] "{0} ur"
 
 #. L10n: first argument is number of days
-#: src/olympia/editors/helpers.py:324
+#: src/olympia/editors/helpers.py:350
 msgid "{0} day"
 msgid_plural "{0} days"
 msgstr[0] "{0} dan"
 msgstr[1] "{0} dneva"
-msgstr[2] "{0} dnevi"
-msgstr[3] "{0} dni"
 
-#: src/olympia/editors/helpers.py:488
+#: src/olympia/editors/helpers.py:364
+msgid "Last Review"
+msgstr ""
+
+#: src/olympia/editors/helpers.py:366
+msgid "Last Update"
+msgstr ""
+
+#: src/olympia/editors/helpers.py:387
+msgid "No Reviews"
+msgstr ""
+
+#: src/olympia/editors/helpers.py:561
 msgid "Push to public"
 msgstr "Prestavi na javno"
 
-#: src/olympia/editors/helpers.py:490
+#: src/olympia/editors/helpers.py:563
 msgid "Grant full review"
 msgstr "Dovoli poln pregled"
 
-#: src/olympia/editors/helpers.py:505
+#: src/olympia/editors/helpers.py:578
 msgid "Request more information"
 msgstr "Zahtevaj dodatne informacije"
 
-#: src/olympia/editors/helpers.py:508
+#: src/olympia/editors/helpers.py:581
 msgid "Request super-review"
 msgstr "Zahtevaj super-pregled"
 
-#: src/olympia/editors/helpers.py:519
+#: src/olympia/editors/helpers.py:592
 msgid "Grant preliminary review"
 msgstr "Dovoli predhodni pregled"
 
-#: src/olympia/editors/helpers.py:520
+#: src/olympia/editors/helpers.py:593
 msgid "This will mark the files as preliminarily reviewed."
 msgstr "To bo označilo datoteke kot predhodno pregledane."
 
-#: src/olympia/editors/helpers.py:522
-msgid ""
-"Use this form to request more information from the author. They will receive"
-" an email and be able to answer here. You will be notified by email when "
-"they reply."
-msgstr ""
-"S tem obrazcem lahko zahteva dodatne informacije od avtorja. Avtorji bodo "
-"prejeli e-pošto in lahko tukaj odgovorili. Vas bomo o odgovoru obvestili po "
-"elektronski pošti."
+#: src/olympia/editors/helpers.py:595
+msgid "Use this form to request more information from the author. They will receive an email and be able to answer here. You will be notified by email when they reply."
+msgstr "S tem obrazcem lahko zahteva dodatne informacije od avtorja. Avtorji bodo prejeli e-pošto in lahko tukaj odgovorili. Vas bomo o odgovoru obvestili po elektronski pošti."
 
-#: src/olympia/editors/helpers.py:526
+#: src/olympia/editors/helpers.py:599
 msgid ""
-"If you have concerns about this add-on's security, copyright issues, or "
-"other concerns that an administrator should look into, enter your comments "
-"in the area below. They will be sent to administrators, not the author."
+"If you have concerns about this add-on's security, copyright issues, or other concerns that an administrator should look into, enter your comments in the area below. They will be sent to "
+"administrators, not the author."
 msgstr ""
-"Če ste zaskrbljeni glede varnosti pri tem dodatku, glede avtorskih pravic "
-"ali drugih zadev, ki bi jih administrator moral preveriti, potem vnesite "
-"svoje pripombe v polje spodaj. Poslalo se jih bo administratorjem, ne "
-"avtorju."
+"Če ste zaskrbljeni glede varnosti pri tem dodatku, glede avtorskih pravic ali drugih zadev, ki bi jih administrator moral preveriti, potem vnesite svoje pripombe v polje spodaj. Poslalo se jih bo "
+"administratorjem, ne avtorju."
 
-#: src/olympia/editors/helpers.py:532
+#: src/olympia/editors/helpers.py:605
 msgid "This will reject the add-on and remove it from the review queue."
 msgstr "To bo dodatek zavrnilo in ga odstranilo iz čakalne vrste za pregled."
 
-#: src/olympia/editors/helpers.py:534
-msgid "Make a comment on this version.  The author won't be able to see this."
+#: src/olympia/editors/helpers.py:607
+msgid "Make a comment on this version. The author won't be able to see this."
 msgstr "Oddajte pripombo za to različico.  Avtor tega ne bo mogel videti."
 
-#: src/olympia/editors/helpers.py:538
+#: src/olympia/editors/helpers.py:611
 msgid "This will reject the files and remove them from the review queue."
-msgstr ""
-"To bo datoteke zavrnilo in jih odstranilo iz čakalne vrste za pregled."
+msgstr "To bo datoteke zavrnilo in jih odstranilo iz čakalne vrste za pregled."
 
-#: src/olympia/editors/helpers.py:542
-msgid ""
-"This will mark the add-on as preliminarily reviewed. Future versions will "
-"undergo preliminary review."
-msgstr ""
-"S tem se označi dodatek kot predhodno pregledan. Prihodnje različice bodo "
-"šle skozi predhodni pregled."
+#: src/olympia/editors/helpers.py:615
+msgid "This will mark the add-on as preliminarily reviewed. Future versions will undergo preliminary review."
+msgstr "S tem se označi dodatek kot predhodno pregledan. Prihodnje različice bodo šle skozi predhodni pregled."
 
-#: src/olympia/editors/helpers.py:547
-msgid ""
-"This will mark the files as preliminarily reviewed. Future versions will "
-"undergo preliminary review."
-msgstr ""
-"S tem so datoteke označene kot predhodno pregledane. Prihodnje različice "
-"bodo šle skozi predhodni pregled."
+#: src/olympia/editors/helpers.py:620
+msgid "This will mark the files as preliminarily reviewed. Future versions will undergo preliminary review."
+msgstr "S tem so datoteke označene kot predhodno pregledane. Prihodnje različice bodo šle skozi predhodni pregled."
 
-#: src/olympia/editors/helpers.py:552
+#: src/olympia/editors/helpers.py:625
 msgid "Retain preliminary review"
 msgstr "Zadrži predhodni pregled"
 
-#: src/olympia/editors/helpers.py:553
-msgid ""
-"This will retain the add-on as preliminarily reviewed. Future versions will "
-"undergo preliminary review."
-msgstr ""
-"Tako bo dodatek obdržal oznako predhodno pregledan. Prihodnje različice bodo"
-" šle skozi predhodni pregled."
+#: src/olympia/editors/helpers.py:626
+msgid "This will retain the add-on as preliminarily reviewed. Future versions will undergo preliminary review."
+msgstr "Tako bo dodatek obdržal oznako predhodno pregledan. Prihodnje različice bodo šle skozi predhodni pregled."
 
-#: src/olympia/editors/helpers.py:558
-msgid ""
-"This will approve a sandboxed version of a public add-on to appear on the "
-"public side."
-msgstr ""
-"To bo potrdilo, da se različica javnega dodatka, ki je v Peskovniku, kaže na"
-" objavljenih straneh."
+#: src/olympia/editors/helpers.py:631
+msgid "This will approve a sandboxed version of a public add-on to appear on the public side."
+msgstr "To bo potrdilo, da se različica javnega dodatka, ki je v Peskovniku, kaže na objavljenih straneh."
 
-#: src/olympia/editors/helpers.py:561
-msgid ""
-"This will reject a version of a public add-on and remove it from the queue."
+#: src/olympia/editors/helpers.py:634
+msgid "This will reject a version of a public add-on and remove it from the queue."
 msgstr "To bo zavrnilo različico javnega dodatka in ga odstranilo iz vrste."
 
-#: src/olympia/editors/helpers.py:564
-msgid ""
-"This will mark the add-on and its most recent version and files as public. "
-"Future versions will go into the sandbox until they are reviewed by an "
-"editor."
-msgstr ""
-"To bo dodatek in njegovo najnovejšo različico ter datoteke označilo kot "
-"javne. Prihodnje različice bodo šle v peskovnik, dokler jih ne pregleda "
-"urednik."
-
 #: src/olympia/editors/helpers.py:637
+msgid "This will mark the add-on and its most recent version and files as public. Future versions will go into the sandbox until they are reviewed by an editor."
+msgstr "To bo dodatek in njegovo najnovejšo različico ter datoteke označilo kot javne. Prihodnje različice bodo šle v peskovnik, dokler jih ne pregleda urednik."
+
+#: src/olympia/editors/helpers.py:714
 msgid "add-on"
 msgstr "dodatek"
 
-#: src/olympia/editors/helpers.py:940 src/olympia/editors/helpers.py:960
+#: src/olympia/editors/helpers.py:1020 src/olympia/editors/helpers.py:1040
 msgid "Flagged"
 msgstr "Označeno"
 
 # 85%
-#: src/olympia/editors/helpers.py:944 src/olympia/editors/helpers.py:963
+#: src/olympia/editors/helpers.py:1024 src/olympia/editors/helpers.py:1043
 msgid "Updates"
 msgstr "Posodobitve"
 
@@ -10126,79 +7838,70 @@ msgstr "Oddaja teme je označena za pregled"
 msgid "A question about your Theme submission"
 msgstr "Vprašanje glede oddaje vaše Teme"
 
-#: src/olympia/editors/views.py:144
+#: src/olympia/editors/views.py:146
 msgid "New Add-ons (Under 5 days)"
 msgstr "Novi dodatki (pod 5 dni)"
 
-#: src/olympia/editors/views.py:145
+#: src/olympia/editors/views.py:147
 msgid "Passable (5 to 10 days)"
 msgstr "Še gre (5 do 10 dni)"
 
-#: src/olympia/editors/views.py:146
+#: src/olympia/editors/views.py:148
 msgid "Overdue (Over 10 days)"
 msgstr "Zapadlo (Več kot 10 dni)"
 
-#: src/olympia/editors/views.py:532
+#: src/olympia/editors/views.py:539
 msgid "An unknown error occurred"
 msgstr "Prišlo je do neznane napake"
 
-#: src/olympia/editors/views.py:587
+#: src/olympia/editors/views.py:592
 msgid "Self-reviews are not allowed."
 msgstr "Samopregledi niso dovoljeni."
 
-#: src/olympia/editors/views.py:609
+#: src/olympia/editors/views.py:613
 msgid "Review successfully processed."
 msgstr "Pregled uspešno obdelan."
 
-#: src/olympia/editors/views.py:807
+#: src/olympia/editors/views.py:812
 msgid "was approved"
 msgstr "je bil odobren"
 
-#: src/olympia/editors/views.py:808
+#: src/olympia/editors/views.py:813
 msgid "given preliminary review"
 msgstr "je bil predhodno pregledan"
 
-#: src/olympia/editors/views.py:809
+#: src/olympia/editors/views.py:814
 msgid "rejected"
 msgstr "zavrnjen"
 
-#: src/olympia/editors/views.py:810
+#: src/olympia/editors/views.py:815
 msgctxt "editors_review_history_nominated_adminreview"
 msgid "escalated"
 msgstr "stopnjevan"
 
 # 79%
 # 100%
-#: src/olympia/editors/views.py:812
+#: src/olympia/editors/views.py:817
 msgid "needs more information"
 msgstr "potrebno je več podatkov"
 
-#: src/olympia/editors/views.py:813
+#: src/olympia/editors/views.py:818
 msgid "needs super review"
 msgstr "potrebuje superpregled"
 
-#: src/olympia/editors/views.py:814
+#: src/olympia/editors/views.py:819
 msgid "commented"
 msgstr "pripombe"
 
 #: src/olympia/editors/views_themes.py:326
 msgid "{0} theme review successfully processed (+{1} points, {2} total)."
-msgid_plural ""
-"{0} theme reviews successfully processed (+{1} points, {2} total)."
+msgid_plural "{0} theme reviews successfully processed (+{1} points, {2} total)."
 msgstr[0] "{0} pregled teme uspešno obdelan (+{1} točk, {2} skupno)."
 msgstr[1] "{0} pregleda teme uspešno obdelana (+{1} točk, {2} skupno)."
-msgstr[2] "{0} pregledi teme uspešno obdelani (+{1} točk, {2} skupno)."
-msgstr[3] "{0} pregledov teme uspešno obdelanih (+{1} točk, {2} skupno)."
 
 #: src/olympia/editors/views_themes.py:341
-msgid ""
-"Your theme locks have successfully been released. Other reviewers may now "
-"review those released themes. You may have to refresh the page to see the "
-"changes reflected in the table below."
-msgstr ""
-"Vaši zaklepi tem so bili uspešno sproščeni. Drugi recenzenti lahko sedaj "
-"pregledajo te sproščene teme. Morda bo potrebno osvežiti stran, da vidite "
-"spremembe, ki se odražajo v spodnji tabeli."
+msgid "Your theme locks have successfully been released. Other reviewers may now review those released themes. You may have to refresh the page to see the changes reflected in the table below."
+msgstr "Vaši zaklepi tem so bili uspešno sproščeni. Drugi recenzenti lahko sedaj pregledajo te sproščene teme. Morda bo potrebno osvežiti stran, da vidite spremembe, ki se odražajo v spodnji tabeli."
 
 #: src/olympia/editors/templates/editors/abuse_reports.html:4
 msgid "{addon} :: Abuse Reports"
@@ -10222,9 +7925,7 @@ msgstr "<i>anonimno</i> dne %(date)s [%(ip_address)s]"
 msgid "Return to the Editor Tools homepage"
 msgstr "Nazaj na domačo stran Orodja za urejanje"
 
-#: src/olympia/editors/templates/editors/base.html:43
-#: src/olympia/editors/templates/editors/themes/base.html:14
-#: src/olympia/editors/templates/editors/themes/base.html:28
+#: src/olympia/editors/templates/editors/base.html:43 src/olympia/editors/templates/editors/themes/base.html:14 src/olympia/editors/templates/editors/themes/base.html:28
 #: src/olympia/editors/templates/editors/themes/queue.html:25
 msgid "Queues"
 msgstr "Čakalne vrste"
@@ -10233,73 +7934,53 @@ msgstr "Čakalne vrste"
 msgid "Unlisted Queues"
 msgstr "Čakalne vrste za nenavedene"
 
-#: src/olympia/editors/templates/editors/base.html:72
-#: src/olympia/editors/templates/editors/performance.html:6
+#: src/olympia/editors/templates/editors/base.html:74 src/olympia/editors/templates/editors/performance.html:6
 msgid "Performance"
 msgstr "Zmogljivost"
 
-#: src/olympia/editors/templates/editors/base.html:75
-#: src/olympia/editors/templates/editors/themes/base.html:19
-#: src/olympia/editors/templates/editors/themes/base.html:38
+#: src/olympia/editors/templates/editors/base.html:77 src/olympia/editors/templates/editors/themes/base.html:19 src/olympia/editors/templates/editors/themes/base.html:38
 msgid "Logs"
 msgstr "Dnevniki"
 
-#: src/olympia/editors/templates/editors/base.html:78
-#: src/olympia/editors/templates/editors/reviewlog.html:4
-#: src/olympia/editors/templates/editors/reviewlog.html:27
+#: src/olympia/editors/templates/editors/base.html:80 src/olympia/editors/templates/editors/reviewlog.html:4 src/olympia/editors/templates/editors/reviewlog.html:27
 msgid "Add-on Review Log"
 msgstr "Dnevnik s pregledi dodatkov"
 
 # 80%
 # 100%
-#: src/olympia/editors/templates/editors/base.html:80
-#: src/olympia/editors/templates/editors/eventlog.html:4
-#: src/olympia/editors/templates/editors/eventlog.html:8
+#: src/olympia/editors/templates/editors/base.html:82 src/olympia/editors/templates/editors/eventlog.html:4 src/olympia/editors/templates/editors/eventlog.html:8
 #: src/olympia/editors/templates/editors/eventlog_detail.html:4
 msgid "Moderated Review Log"
 msgstr "Moderiran dnevnik pregledov"
 
-#: src/olympia/editors/templates/editors/base.html:82
-#: src/olympia/editors/templates/editors/beta_signed_log.html:4
-#: src/olympia/editors/templates/editors/beta_signed_log.html:8
+#: src/olympia/editors/templates/editors/base.html:84 src/olympia/editors/templates/editors/beta_signed_log.html:4 src/olympia/editors/templates/editors/beta_signed_log.html:8
 msgid "Signed Beta Files Log"
 msgstr "Dnevnik podpisanih datotek beta"
 
-#: src/olympia/editors/templates/editors/base.html:87
-#: src/olympia/editors/templates/editors/includes/daily-message.html:4
+#: src/olympia/editors/templates/editors/base.html:89 src/olympia/editors/templates/editors/includes/daily-message.html:4
 msgid "Announcement"
 msgstr "Objava"
 
 #. "Filter" is a button label (verb)
-#: src/olympia/editors/templates/editors/beta_signed_log.html:17
-#: src/olympia/editors/templates/editors/eventlog.html:24
-#: src/olympia/editors/templates/editors/reviewlog.html:21
-#: src/olympia/editors/templates/editors/themes/macros.html:45
-#: src/olympia/editors/templates/editors/themes/includes/logs_filter_deleted.html:12
+#: src/olympia/editors/templates/editors/beta_signed_log.html:17 src/olympia/editors/templates/editors/eventlog.html:24 src/olympia/editors/templates/editors/reviewlog.html:21
+#: src/olympia/editors/templates/editors/themes/macros.html:45 src/olympia/editors/templates/editors/themes/includes/logs_filter_deleted.html:12
 msgid "Filter"
 msgstr "Filtriraj"
 
-#: src/olympia/editors/templates/editors/beta_signed_log.html:23
-#: src/olympia/editors/templates/editors/eventlog.html:30
-#: src/olympia/editors/templates/editors/reviewlog.html:34
+#: src/olympia/editors/templates/editors/beta_signed_log.html:23 src/olympia/editors/templates/editors/eventlog.html:30 src/olympia/editors/templates/editors/reviewlog.html:34
 #: src/olympia/editors/templates/editors/themes/logs.html:16
 msgid "Date"
 msgstr "Datum"
 
-#: src/olympia/editors/templates/editors/beta_signed_log.html:24
-#: src/olympia/editors/templates/editors/eventlog.html:31
-#: src/olympia/editors/templates/editors/reviewlog.html:35
+#: src/olympia/editors/templates/editors/beta_signed_log.html:24 src/olympia/editors/templates/editors/eventlog.html:31 src/olympia/editors/templates/editors/reviewlog.html:35
 msgid "Event"
 msgstr "Dogodek"
 
-#: src/olympia/editors/templates/editors/beta_signed_log.html:37
-#: src/olympia/editors/templates/editors/eventlog.html:44
-#: src/olympia/editors/templates/editors/home.html:180
+#: src/olympia/editors/templates/editors/beta_signed_log.html:37 src/olympia/editors/templates/editors/eventlog.html:44 src/olympia/editors/templates/editors/home.html:180
 msgid "More details."
 msgstr "Več podrobnosti."
 
-#: src/olympia/editors/templates/editors/beta_signed_log.html:46
-#: src/olympia/editors/templates/editors/eventlog.html:53
+#: src/olympia/editors/templates/editors/beta_signed_log.html:46 src/olympia/editors/templates/editors/eventlog.html:53
 msgid "No events found for this period."
 msgstr "Za to obdobje ni najti dogodkov."
 
@@ -10338,8 +8019,6 @@ msgid "Full Review ({num})"
 msgid_plural "Full Reviews ({num})"
 msgstr[0] "Popoln pregled ({num})"
 msgstr[1] "Popolna pregleda ({num})"
-msgstr[2] "Popolni pregledi ({num})"
-msgstr[3] "Popolnih pregledov ({num})"
 
 # 86%
 # 100%
@@ -10348,8 +8027,6 @@ msgid "Pending Update ({num})"
 msgid_plural "Pending Updates ({num})"
 msgstr[0] "Posodobitev v teku ({num})"
 msgstr[1] "Posodobitvi v teku ({num})"
-msgstr[2] "Posodobitve v teku ({num})"
-msgstr[3] "Posodobitev v teku ({num})"
 
 # 88%
 # 100%
@@ -10358,27 +8035,20 @@ msgid "Preliminary Review ({num})"
 msgid_plural "Preliminary Reviews ({num})"
 msgstr[0] "Predhoden pregled ({num})"
 msgstr[1] "Predhodna pregleda ({num})"
-msgstr[2] "Predhodni pregledi ({num})"
-msgstr[3] "Predhodnih pregledov ({num})"
 
-#: src/olympia/editors/templates/editors/home.html:36
-#: src/olympia/editors/templates/editors/home.html:86
+#: src/olympia/editors/templates/editors/home.html:36 src/olympia/editors/templates/editors/home.html:86
 msgid "Current waiting times:"
 msgstr "Trenutne čakalne dobe:"
 
 # 81%
 # 100%
-#: src/olympia/editors/templates/editors/home.html:44
-#: src/olympia/editors/templates/editors/home.html:94
+#: src/olympia/editors/templates/editors/home.html:44 src/olympia/editors/templates/editors/home.html:94
 msgid "{0} add-on"
 msgid_plural "{0} add-ons"
 msgstr[0] "{0} dodatek"
 msgstr[1] "{0} dodatka"
-msgstr[2] "{0} dodatki"
-msgstr[3] "{0} dodatkov"
 
-#: src/olympia/editors/templates/editors/home.html:45
-#: src/olympia/editors/templates/editors/home.html:95
+#: src/olympia/editors/templates/editors/home.html:45 src/olympia/editors/templates/editors/home.html:95
 #, python-format
 msgid "{0}%%"
 msgstr "{0} %%"
@@ -10388,33 +8058,24 @@ msgid "Unlisted Full Review ({num})"
 msgid_plural "Unlisted Full Reviews ({num})"
 msgstr[0] "Poln pregled za nenavedene ({num})"
 msgstr[1] "Polna pregleda za nenavedene ({num})"
-msgstr[2] "Polni pregledi za nenavedene ({num})"
-msgstr[3] "Polni pregledi za nenavedene ({num})"
 
 #: src/olympia/editors/templates/editors/home.html:68
 msgid "Unlisted Pending Update ({num})"
 msgid_plural "Unlisted Pending Updates ({num})"
 msgstr[0] "Posodobitev na čakanju za nenavedene ({num})"
 msgstr[1] "Posodobitvi na čakanju za nenavedene ({num})"
-msgstr[2] "Posodobitve na čakanju za nenavedene ({num})"
-msgstr[3] "Posodobitve na čakanju za nenavedene ({num})"
 
 #: src/olympia/editors/templates/editors/home.html:75
 msgid "Unlisted Preliminary Review ({num})"
 msgid_plural "Unlisted Preliminary Reviews ({num})"
 msgstr[0] "Predhoden pregled za nenavedene ({num})"
 msgstr[1] "Predhodna pregleda za nenavedene ({num})"
-msgstr[2] "Predhodni pregledi za nenavedene ({num})"
-msgstr[3] "Predhodni pregledi za nenavedene ({num})"
 
-#: src/olympia/editors/templates/editors/home.html:109
-#: src/olympia/editors/templates/editors/performance.html:37
-#: src/olympia/editors/templates/editors/themes/home.html:54
+#: src/olympia/editors/templates/editors/home.html:109 src/olympia/editors/templates/editors/performance.html:37 src/olympia/editors/templates/editors/themes/home.html:54
 msgid "Total Reviews"
 msgstr "Skupaj pregledov"
 
-#: src/olympia/editors/templates/editors/home.html:110
-#: src/olympia/editors/templates/editors/themes/home.html:55
+#: src/olympia/editors/templates/editors/home.html:110 src/olympia/editors/templates/editors/themes/home.html:55
 msgid "Reviews This Month"
 msgstr "Pregledi ta mesec"
 
@@ -10422,29 +8083,24 @@ msgstr "Pregledi ta mesec"
 msgid "New Editors"
 msgstr "Novi uredniki"
 
-#: src/olympia/editors/templates/editors/home.html:126
-#: src/olympia/editors/templates/editors/home.html:141
+#: src/olympia/editors/templates/editors/home.html:126 src/olympia/editors/templates/editors/home.html:141
 msgid "You're #{0} with {1} reviews"
 msgstr "Vi ste {0}. z {1} pregledi"
 
-#. num = number of reviews in the queue
 # 87%
 # 100%
+#. num = number of reviews in the queue
 #: src/olympia/editors/templates/editors/home.html:171
 msgid "Moderated Review ({num})"
 msgid_plural "Moderated Reviews ({num})"
 msgstr[0] "Moderiran pregled ({num})"
 msgstr[1] "Moderirana pregleda ({num})"
-msgstr[2] "Moderirani pregledi ({num})"
-msgstr[3] "Moderiranih pregledov ({num})"
 
-#: src/olympia/editors/templates/editors/leaderboard.html:3
-#: src/olympia/editors/templates/editors/includes/reviewers_score_bar.html:56
+#: src/olympia/editors/templates/editors/leaderboard.html:3 src/olympia/editors/templates/editors/includes/reviewers_score_bar.html:56
 msgid "Reviewer Leaderboard"
 msgstr "Oglasna deska vodilnih pregledovalcev"
 
-#: src/olympia/editors/templates/editors/leaderboard.html:18
-#: src/olympia/editors/templates/editors/performance.html:65
+#: src/olympia/editors/templates/editors/leaderboard.html:18 src/olympia/editors/templates/editors/performance.html:65
 msgid "No review points awarded yet."
 msgstr "Nobenih točk pregleda še ni bilo dodeljenih."
 
@@ -10464,8 +8120,7 @@ msgstr "Sporočilo dneva"
 msgid "Update message of the day"
 msgstr "Posodobi sporočilo dneva"
 
-#: src/olympia/editors/templates/editors/motd.html:15
-#: src/olympia/editors/templates/editors/review.html:224
+#: src/olympia/editors/templates/editors/motd.html:15 src/olympia/editors/templates/editors/review.html:224
 msgid "Save"
 msgstr "Shrani"
 
@@ -10534,51 +8189,45 @@ msgstr "Napredno iskanje"
 msgid "clear search"
 msgstr "Počisti iskanje"
 
-#: src/olympia/editors/templates/editors/queue.html:72
-#: src/olympia/editors/templates/editors/queue.html:122
+#: src/olympia/editors/templates/editors/queue.html:78 src/olympia/editors/templates/editors/queue.html:128
 msgid "Process Reviews"
 msgstr "Obdelaj preglede"
 
-#: src/olympia/editors/templates/editors/queue.html:80
+#: src/olympia/editors/templates/editors/queue.html:86
 msgid "Moderation actions:"
 msgstr "Posredovalni ukrepi:"
 
-#: src/olympia/editors/templates/editors/queue.html:90
+#: src/olympia/editors/templates/editors/queue.html:96
 #, python-format
 msgid "by %(user)s on %(date)s %(stars)s (%(locale)s)"
 msgstr "s strani %(user)s dne %(date)s %(stars)s (%(locale)s)"
 
-#: src/olympia/editors/templates/editors/queue.html:106
+#: src/olympia/editors/templates/editors/queue.html:112
 #, python-format
-msgid ""
-"<strong>%(reason)s</strong> <span class=\"light\">Flagged by %(user)s on "
-"%(date)s</span>"
-msgstr ""
-"<strong>%(reason)s</strong> <span class=\"light\">Označil %(user)s dne "
-"%(date)s</span>"
+msgid "<strong>%(reason)s</strong> <span class=\"light\">Flagged by %(user)s on %(date)s</span>"
+msgstr "<strong>%(reason)s</strong> <span class=\"light\">Označil %(user)s dne %(date)s</span>"
 
-#: src/olympia/editors/templates/editors/queue.html:119
-msgid "All reviews have been moderated.  Good work!"
+#: src/olympia/editors/templates/editors/queue.html:125
+msgid "All reviews have been moderated. Good work!"
 msgstr "Vse preglede se je moderiralo.  Zelo dobro!"
 
-#: src/olympia/editors/templates/editors/queue.html:161
+#: src/olympia/editors/templates/editors/queue.html:167
 msgid "Version Notes / Notes for Reviewer"
 msgstr "Pripombe za različico/za recenzenta"
 
-#: src/olympia/editors/templates/editors/queue.html:169
+#: src/olympia/editors/templates/editors/queue.html:175
 msgid "There are currently no add-ons of this type to review."
 msgstr "Trenutno ne čaka nobena od razvrstitev te vrste za pregled."
 
-#: src/olympia/editors/templates/editors/queue.html:181
-#: src/olympia/editors/templates/editors/themes/queue_list.html:85
+#: src/olympia/editors/templates/editors/queue.html:187 src/olympia/editors/templates/editors/themes/queue_list.html:85
 msgid "Helpful Links:"
 msgstr "Koristne povezave:"
 
-#: src/olympia/editors/templates/editors/queue.html:182
+#: src/olympia/editors/templates/editors/queue.html:188
 msgid "Add-on Policy"
 msgstr "Smernice za dodatke"
 
-#: src/olympia/editors/templates/editors/queue.html:184
+#: src/olympia/editors/templates/editors/queue.html:190
 msgid "Editors' Guide"
 msgstr "Vodič za urednike"
 
@@ -10591,19 +8240,14 @@ msgstr "Preglej {0}"
 msgid "Add-on user change history"
 msgstr "Zgodovina uporabniških sprememb dodatka"
 
-#: src/olympia/editors/templates/editors/review.html:52
-#: src/olympia/editors/templates/editors/review.html:266
+#: src/olympia/editors/templates/editors/review.html:52 src/olympia/editors/templates/editors/review.html:266
 msgid "Add-on History"
 msgstr "Zgodovina dodatka"
 
 #: src/olympia/editors/templates/editors/review.html:64
 #, python-format
-msgid ""
-"Version %(version)s &middot; %(created)s <span class=\"light\">&middot; "
-"%(version_status)s</span>"
-msgstr ""
-"Različica %(version)s &middot; %(created)s <span class=\"light\">&middot; "
-"%(version_status)s</span>"
+msgid "Version %(version)s &middot; %(created)s <span class=\"light\">&middot; %(version_status)s</span>"
+msgstr "Različica %(version)s &middot; %(created)s <span class=\"light\">&middot; %(version_status)s</span>"
 
 #: src/olympia/editors/templates/editors/review.html:73
 msgid "Compatibility:"
@@ -10626,19 +8270,14 @@ msgid "This version has not been reviewed."
 msgstr "Te različice se ni pregledalo."
 
 #: src/olympia/editors/templates/editors/review.html:154
-msgid ""
-"You can still submit this form, however only do so if you know it won't "
-"conflict."
-msgstr ""
-"Ta obrazec lahko še vedno uporabite, vendar le v primeru, če veste, da ne bo"
-" sporov."
+msgid "You can still submit this form, however only do so if you know it won't conflict."
+msgstr "Ta obrazec lahko še vedno uporabite, vendar le v primeru, če veste, da ne bo sporov."
 
 #: src/olympia/editors/templates/editors/review.html:161
 msgid "Insert canned response..."
 msgstr "Vstavi pripravljen odgovor ..."
 
-#: src/olympia/editors/templates/editors/review.html:167
-#: src/olympia/files/templates/files/viewer.html:54
+#: src/olympia/editors/templates/editors/review.html:167 src/olympia/files/templates/files/viewer.html:54
 msgid "Files:"
 msgstr "Datoteke:"
 
@@ -10647,17 +8286,11 @@ msgid "Tested on:"
 msgstr "Preizkušeno na:"
 
 #: src/olympia/editors/templates/editors/review.html:220
-msgid ""
-"<strong>Warning!</strong> Another user was viewing this page before you."
-msgstr ""
-"<strong>Opozorilo!</strong> Nek drug uporabnik je ogledoval to stran pred "
-"vami."
+msgid "<strong>Warning!</strong> Another user was viewing this page before you."
+msgstr "<strong>Opozorilo!</strong> Nek drug uporabnik je ogledoval to stran pred vami."
 
 #: src/olympia/editors/templates/editors/review.html:237
-msgid ""
-"The whiteboard is the place to exchange information relevant to\n"
-"               this addon (whatever the version), between the developer and the\n"
-"               editor. This is visible and editable by both."
+msgid "The whiteboard is the place to exchange information relevant to this addon (whatever the version), between the developer and the editor. This is visible and editable by both."
 msgstr ""
 "Bela tabla je mesto za izmenjavo podatkov, ki se nanašajo na ta\n"
 "               dodatek (ne glede na različico), med razvijalcem in urednikom.\n"
@@ -10667,8 +8300,7 @@ msgstr ""
 msgid "Update the whiteboard"
 msgstr "Posodobi tablo"
 
-#: src/olympia/editors/templates/editors/review.html:257
-#: src/olympia/editors/templates/editors/review.html:258
+#: src/olympia/editors/templates/editors/review.html:257 src/olympia/editors/templates/editors/review.html:258
 msgid "(admin)"
 msgstr "(admin)"
 
@@ -10696,18 +8328,15 @@ msgstr "Urednik"
 msgid "Add-on has been deleted."
 msgstr "Dodatek je bil izbrisan."
 
-#: src/olympia/editors/templates/editors/reviewlog.html:59
-#: src/olympia/editors/templates/editors/themes/logs.html:36
+#: src/olympia/editors/templates/editors/reviewlog.html:59 src/olympia/editors/templates/editors/themes/logs.html:36
 msgid "Show Comments"
 msgstr "Pokaži komentarje"
 
-#: src/olympia/editors/templates/editors/reviewlog.html:60
-#: src/olympia/editors/templates/editors/themes/logs.html:37
+#: src/olympia/editors/templates/editors/reviewlog.html:60 src/olympia/editors/templates/editors/themes/logs.html:37
 msgid "Hide Comments"
 msgstr "Skrij komentarje"
 
-#: src/olympia/editors/templates/editors/reviewlog.html:72
-#: src/olympia/editors/templates/editors/themes/logs.html:54
+#: src/olympia/editors/templates/editors/reviewlog.html:72 src/olympia/editors/templates/editors/themes/logs.html:54
 msgid "No reviews found for this period."
 msgstr "Za to obdobje ni najti pregledov."
 
@@ -10766,11 +8395,8 @@ msgid "You have <span>{0}</span> points."
 msgstr "Imate <span>{0}</span> točk."
 
 # 88%
-#: src/olympia/editors/templates/editors/includes/search_results_themes.html:6
-#: src/olympia/editors/templates/editors/themes/history_table.html:7
-#: src/olympia/editors/templates/editors/themes/logs.html:19
-#: src/olympia/editors/templates/editors/themes/queue_list.html:49
-#: src/olympia/editors/templates/editors/themes/single.html:26
+#: src/olympia/editors/templates/editors/includes/search_results_themes.html:6 src/olympia/editors/templates/editors/themes/history_table.html:7
+#: src/olympia/editors/templates/editors/themes/logs.html:19 src/olympia/editors/templates/editors/themes/queue_list.html:49 src/olympia/editors/templates/editors/themes/single.html:26
 #: src/olympia/editors/templates/editors/themes/themes.html:45
 msgid "Reviewer"
 msgstr "Recenzent"
@@ -10795,8 +8421,7 @@ msgstr "Zgodovina pregledov za {0}"
 msgid "Review Date"
 msgstr "Datum pregleda"
 
-#: src/olympia/editors/templates/editors/themes/history_table.html:9
-#: src/olympia/editors/templates/editors/themes/logs.html:18
+#: src/olympia/editors/templates/editors/themes/history_table.html:9 src/olympia/editors/templates/editors/themes/logs.html:18
 msgid "Action"
 msgstr "Dejanje"
 
@@ -10813,24 +8438,18 @@ msgid "{num} Pending Theme Review"
 msgid_plural "{num} Pending Theme Reviews"
 msgstr[0] "{num} pregled teme v čakanju"
 msgstr[1] "{num} pregleda teme v čakanju"
-msgstr[2] "{num} pregledi teme v čakanju"
-msgstr[3] "{num} pregledov teme v čakanju"
 
 #: src/olympia/editors/templates/editors/themes/home.html:27
 msgid "{num} Flagged Review"
 msgid_plural "{num} Flagged Reviews"
 msgstr[0] "{num} označen pregled"
 msgstr[1] "{num} označena pregleda"
-msgstr[2] "{num} označeni pregledi"
-msgstr[3] "{num} označenih pregledov"
 
 #: src/olympia/editors/templates/editors/themes/home.html:34
 msgid "{num} Update"
 msgid_plural "{num} Updates"
 msgstr[0] "{num} posodobitev"
 msgstr[1] "{num} posodobitvi"
-msgstr[2] "{num} posodobitve"
-msgstr[3] "{num} posodobitev"
 
 #: src/olympia/editors/templates/editors/themes/logs.html:4
 msgid "Theme Review Log"
@@ -10949,7 +8568,7 @@ msgstr "Pošljite vprašanje umetniku"
 msgid "Describe your reason for flagging"
 msgstr "Opišite svoje razloge za označitev"
 
-#: src/olympia/files/forms.py:88
+#: src/olympia/files/forms.py:90
 msgid "Cannot diff a version against itself"
 msgstr "Ne morete razlikovati različice od same sebe"
 
@@ -10967,12 +8586,8 @@ msgid "Problems decoding {0}."
 msgstr "Težave pri dekodiranju {0}."
 
 #: src/olympia/files/helpers.py:186
-msgid ""
-"This file is not viewable online. Please download the file to view the "
-"contents."
-msgstr ""
-"Te datoteke na spletu ni mogoče prikazati. Prenesite si datoteko, če si jo "
-"hočete ogledati."
+msgid "This file is not viewable online. Please download the file to view the contents."
+msgstr "Te datoteke na spletu ni mogoče prikazati. Prenesite si datoteko, če si jo hočete ogledati."
 
 #: src/olympia/files/helpers.py:194
 msgid "This file is a directory."
@@ -10988,55 +8603,51 @@ msgstr "Pri delu z datoteko %s je prišlo do napake. %s."
 msgid "There was an error accessing file %s."
 msgstr "Pri delu z datoteko %s je prišlo do napake."
 
-#: src/olympia/files/utils.py:343
+#: src/olympia/files/utils.py:340
 msgid "Could not parse uploaded file."
 msgstr "Prenesene datoteke ni bilo mogoče razčleniti."
 
-#: src/olympia/files/utils.py:380
+#: src/olympia/files/utils.py:377
 msgid "Invalid file name in archive: {0}"
 msgstr "Neveljavno ime datoteke v arhivu: {0}"
 
-#: src/olympia/files/utils.py:388
+#: src/olympia/files/utils.py:385
 msgid "File exceeding size limit in archive: {0}"
 msgstr "Datoteka v arhivu presega omejitev velikosti: {0}"
 
-#: src/olympia/files/utils.py:439
+#: src/olympia/files/utils.py:436
 msgid "Invalid archive."
 msgstr "Neveljaven arhiv."
 
-#: src/olympia/files/utils.py:529 src/olympia/files/utils.py:532
+#: src/olympia/files/utils.py:526 src/olympia/files/utils.py:529
 msgid "Could not parse the manifest file."
 msgstr "Datoteke manifesta ni bilo mogoče razčleniti."
 
-#: src/olympia/files/utils.py:551
+#: src/olympia/files/utils.py:548
 msgid "Could not find an add-on ID."
 msgstr "ID-ja dodatka ni bilo mogoče najti."
 
-#: src/olympia/files/utils.py:554
+#: src/olympia/files/utils.py:551
 msgid "Add-on ID must be 64 characters or less."
 msgstr "ID dodatka mora vsebovati 64 znakov ali manj."
 
-#: src/olympia/files/utils.py:556
+#: src/olympia/files/utils.py:553
 msgid "Add-on ID doesn't match add-on."
 msgstr "ID dodatka se ne ujema z dodatkom."
 
-#: src/olympia/files/utils.py:564
+#: src/olympia/files/utils.py:561
 msgid "Duplicate add-on ID found."
 msgstr "Najden podvojen ID dodatka."
 
-#: src/olympia/files/utils.py:567
+#: src/olympia/files/utils.py:564
 msgid "Version numbers should have fewer than 32 characters."
 msgstr "Številke različice morajo imeti manj kot 32 znakov."
 
-#: src/olympia/files/utils.py:570
-msgid ""
-"Version numbers should only contain letters, numbers, and these punctuation "
-"characters: +*.-_."
-msgstr ""
-"Številke različice smejo vsebovati le črke, številke in naslednja ločila: "
-"+*.-_."
+#: src/olympia/files/utils.py:567
+msgid "Version numbers should only contain letters, numbers, and these punctuation characters: +*.-_."
+msgstr "Številke različice smejo vsebovati le črke, številke in naslednja ločila: +*.-_."
 
-#: src/olympia/files/utils.py:587
+#: src/olympia/files/utils.py:584
 msgid "<em:type> doesn't match add-on"
 msgstr "<em:type> se ne ujema z dodatkom"
 
@@ -11058,12 +8669,8 @@ msgstr "Prenesi {0}"
 
 #: src/olympia/files/templates/files/file.html:4
 #, python-format
-msgid ""
-"Version: %(version)s &bull; Size: %(size)s &bull; MD5 hash: %(md5)s &bull; "
-"Mimetype: %(mimetype)s"
-msgstr ""
-"Različica: %(version)s &bull; Velikost: %(size)s &bull; MD5 hash: %(md5)s "
-"&bull; Vrsta mime: %(mimetype)s"
+msgid "Version: %(version)s &bull; Size: %(size)s &bull; MD5 hash: %(md5)s &bull; Mimetype: %(mimetype)s"
+msgstr "Različica: %(version)s &bull; Velikost: %(size)s &bull; MD5 hash: %(md5)s &bull; Vrsta mime: %(mimetype)s"
 
 #: src/olympia/files/templates/files/viewer.html:4
 msgid "File Compare :: Editor tools"
@@ -11101,48 +8708,39 @@ msgstr "Različica SDK dodatka:"
 msgid "Tab stops:"
 msgstr "Tabulatorji:"
 
-#: src/olympia/files/templates/files/viewer.html:79
-#: src/olympia/files/templates/files/viewer.html:80
+#: src/olympia/files/templates/files/viewer.html:79 src/olympia/files/templates/files/viewer.html:80
 msgid "Up file"
 msgstr "Gor datoteka"
 
-#: src/olympia/files/templates/files/viewer.html:84
-#: src/olympia/files/templates/files/viewer.html:85
+#: src/olympia/files/templates/files/viewer.html:84 src/olympia/files/templates/files/viewer.html:85
 msgid "Down file"
 msgstr "Dol datoteka"
 
-#: src/olympia/files/templates/files/viewer.html:90
-#: src/olympia/files/templates/files/viewer.html:91
+#: src/olympia/files/templates/files/viewer.html:90 src/olympia/files/templates/files/viewer.html:91
 msgid "Previous diff"
 msgstr "Prejšnji diff"
 
-#: src/olympia/files/templates/files/viewer.html:93
-#: src/olympia/files/templates/files/viewer.html:94
+#: src/olympia/files/templates/files/viewer.html:93 src/olympia/files/templates/files/viewer.html:94
 msgid "Previous note"
 msgstr "Prejšnja opomba"
 
-#: src/olympia/files/templates/files/viewer.html:100
-#: src/olympia/files/templates/files/viewer.html:101
+#: src/olympia/files/templates/files/viewer.html:100 src/olympia/files/templates/files/viewer.html:101
 msgid "Next diff"
 msgstr "Naslednji diff"
 
-#: src/olympia/files/templates/files/viewer.html:103
-#: src/olympia/files/templates/files/viewer.html:104
+#: src/olympia/files/templates/files/viewer.html:103 src/olympia/files/templates/files/viewer.html:104
 msgid "Next note"
 msgstr "Naslednja opomba"
 
-#: src/olympia/files/templates/files/viewer.html:109
-#: src/olympia/files/templates/files/viewer.html:110
+#: src/olympia/files/templates/files/viewer.html:109 src/olympia/files/templates/files/viewer.html:110
 msgid "Expand all"
 msgstr "Razširi vse"
 
-#: src/olympia/files/templates/files/viewer.html:114
-#: src/olympia/files/templates/files/viewer.html:115
+#: src/olympia/files/templates/files/viewer.html:114 src/olympia/files/templates/files/viewer.html:115
 msgid "Hide or unhide tree"
 msgstr "Skrij/razkrij drevo"
 
-#: src/olympia/files/templates/files/viewer.html:119
-#: src/olympia/files/templates/files/viewer.html:120
+#: src/olympia/files/templates/files/viewer.html:119 src/olympia/files/templates/files/viewer.html:120
 msgid "Wrap or unwrap text"
 msgstr "Ovij/razvij besedilo"
 
@@ -11153,6 +8751,10 @@ msgstr "Ni datotek v naloženi datoteki."
 #: src/olympia/files/templates/files/viewer.html:134
 msgid "Fetching file."
 msgstr "Pridobivam datoteko."
+
+#: src/olympia/legacy_api/views.py:255
+msgid "Not implemented yet."
+msgstr "Še ni uvedeno."
 
 #: src/olympia/lib/constants.py:6
 msgid "United Arab Emirates Dirham"
@@ -11810,12 +9412,7 @@ msgstr "Zambijska kvača"
 msgid "Zimbabwe Dollar"
 msgstr "Zimbabvejski dolar"
 
-#: src/olympia/lib/video/ffmpeg.py:112 src/olympia/lib/video/totem.py:81
-msgid "Videos must be in WebM."
-msgstr "Videoposnetki morajo biti v obliki WebM."
-
-#: src/olympia/pages/templates/pages/about.lhtml:3
-#: src/olympia/pages/templates/pages/about.lhtml:10
+#: src/olympia/pages/templates/pages/about.lhtml:3 src/olympia/pages/templates/pages/about.lhtml:10
 msgid "About Mozilla Add-ons"
 msgstr "O Mozillinih dodatkih"
 
@@ -11825,18 +9422,11 @@ msgstr "Kaj je to spletno mesto?"
 
 #: src/olympia/pages/templates/pages/about.lhtml:13
 msgid ""
-"addons.mozilla.org, commonly known as \"AMO\", is Mozilla's official site "
-"for add-ons to Mozilla software, such as Firefox, Thunderbird, and "
-"SeaMonkey. Add-ons let you add new features and change the way your browser "
-"or application works.  Take a look around and explore the thousands of ways "
-"to customize the way you do things online."
+"addons.mozilla.org, commonly known as \"AMO\", is Mozilla's official site for add-ons to Mozilla software, such as Firefox, Thunderbird, and SeaMonkey. Add-ons let you add new features and change "
+"the way your browser or application works. Take a look around and explore the thousands of ways to customize the way you do things online."
 msgstr ""
-"addons.mozilla.org, znana tudi kot \"AMO\", je Mozillina uradna stran "
-"dodatkov za Mozillino programsko premo, kot je Firefox, Thunderbird in "
-"SeaMonkey.  Dodatki vam omogočajo dodajanje novih značilnosti in "
-"spreminjanje delovanja vašega brskalnika ali aplikacije.  Malo si poglejte "
-"naokoli in raziščite tisoče načinov za prilagoditev svojih opravil na "
-"spletu."
+"addons.mozilla.org, znana tudi kot \"AMO\", je Mozillina uradna stran dodatkov za Mozillino programsko premo, kot je Firefox, Thunderbird in SeaMonkey.  Dodatki vam omogočajo dodajanje novih "
+"značilnosti in spreminjanje delovanja vašega brskalnika ali aplikacije.  Malo si poglejte naokoli in raziščite tisoče načinov za prilagoditev svojih opravil na spletu."
 
 #: src/olympia/pages/templates/pages/about.lhtml:19
 msgid "Who creates these add-ons?"
@@ -11844,105 +9434,65 @@ msgstr "Kdo izdeluje te dodatke?"
 
 #: src/olympia/pages/templates/pages/about.lhtml:20
 msgid ""
-"The add-ons listed here have been created by thousands of developers from "
-"our community, ranging from individual hobbyists to large corporations. All "
-"publicly listed add-ons are reviewed by a team of editors before being "
-"released. Add-ons marked as Experimental have not been reviewed and should "
-"only be installed with caution."
+"The add-ons listed here have been created by thousands of developers from our community, ranging from individual hobbyists to large corporations. All publicly listed add-ons are reviewed by a team "
+"of editors before being released. Add-ons marked as Experimental have not been reviewed and should only be installed with caution."
 msgstr ""
-"Dodatke na tej strani ustvarjajo tisoči razvijalcev v naši skupnosti, od "
-"posameznih ljubiteljskih razvijalcev do velikih korporacij. Vse dodatke, ki "
-"so na voljo za javnost, pregleda ekipa urednikov, preden so izdani. Dodatki,"
-" označeni kot poskusni, niso bili pregledani, zato bodite previdni pri "
-"namestitvi."
+"Dodatke na tej strani ustvarjajo tisoči razvijalcev v naši skupnosti, od posameznih ljubiteljskih razvijalcev do velikih korporacij. Vse dodatke, ki so na voljo za javnost, pregleda ekipa "
+"urednikov, preden so izdani. Dodatki, označeni kot poskusni, niso bili pregledani, zato bodite previdni pri namestitvi."
 
 #: src/olympia/pages/templates/pages/about.lhtml:26
 msgid "How do I keep up with what's happening at AMO?"
 msgstr "Kako lahko sledim dogajanju na AMO?"
 
 #: src/olympia/pages/templates/pages/about.lhtml:27
-msgid ""
-"There are several ways to find out the latest news from the world of add-"
-"ons:"
-msgstr ""
-"Obstaja veliko načinov, da ostanete na tekočem z novicami iz sveta dodatkov:"
+msgid "There are several ways to find out the latest news from the world of add-ons:"
+msgstr "Obstaja veliko načinov, da ostanete na tekočem z novicami iz sveta dodatkov:"
 
 #: src/olympia/pages/templates/pages/about.lhtml:29
 #, python-format
-msgid ""
-"Our <a href=\"%(url)s\">Add-ons Blog</a> is regularly updated with "
-"information for both add-on enthusiasts and developers."
-msgstr ""
-"Naš <a href=\"%(url)s\">blog dodatkov</a> je redno posodobljen z "
-"informacijami za navdušence za dodatke in za razvijalce."
+msgid "Our <a href=\"%(url)s\">Add-ons Blog</a> is regularly updated with information for both add-on enthusiasts and developers."
+msgstr "Naš <a href=\"%(url)s\">blog dodatkov</a> je redno posodobljen z informacijami za navdušence za dodatke in za razvijalce."
 
 #: src/olympia/pages/templates/pages/about.lhtml:32
 #, python-format
-msgid ""
-"We often post news, tips, and tricks to our Twitter account, <a "
-"href=\"%(url)s\">mozamo</a>"
-msgstr ""
-"Novice, namige in trike pogosto objavimo na našem Twitter računu, <a "
-"href=\"%(url)s\">mozamo</a>"
+msgid "We often post news, tips, and tricks to our Twitter account, <a href=\"%(url)s\">mozamo</a>"
+msgstr "Novice, namige in trike pogosto objavimo na našem Twitter računu, <a href=\"%(url)s\">mozamo</a>"
 
 #: src/olympia/pages/templates/pages/about.lhtml:34
 #, python-format
-msgid ""
-"Our <a href=\"%(url)s\">forums</a> are a good place to interact with the "
-"add-ons community and discuss upcoming changes to AMO."
-msgstr ""
-"Naši <a href=\"%(url)s\">forumi</a> so mesto, kjer ste lahko v stiku s "
-"skupnostjo za dodatke in razpravljate o prihajajočih spremembah AMO."
+msgid "Our <a href=\"%(url)s\">forums</a> are a good place to interact with the add-ons community and discuss upcoming changes to AMO."
+msgstr "Naši <a href=\"%(url)s\">forumi</a> so mesto, kjer ste lahko v stiku s skupnostjo za dodatke in razpravljate o prihajajočih spremembah AMO."
 
 #: src/olympia/pages/templates/pages/about.lhtml:39
 msgid "This sounds great! How can I get involved?"
 msgstr "Sliši se krasno! Kako se lahko pridružim?"
 
 #: src/olympia/pages/templates/pages/about.lhtml:40
-msgid ""
-"There are plenty of ways to get involved. If you're on the technical side:"
-msgstr ""
-"Obstaja veliko načinov, da se nam pridružite. Če ste tehnični navdušenec:"
+msgid "There are plenty of ways to get involved. If you're on the technical side:"
+msgstr "Obstaja veliko načinov, da se nam pridružite. Če ste tehnični navdušenec:"
 
 #: src/olympia/pages/templates/pages/about.lhtml:42
 #, python-format
-msgid ""
-"<a href=\"%(url)s\">Make your own add-on</a>. We provide free hosting and "
-"update services and can help you reach a large audience of users."
-msgstr ""
-"<a href=\"%(url)s\">Ustvarite svoj lastni dodatek</a>. Nudimo vam brezplačno"
-" gostovanje in storitev posodabljanja ter vam pomagamo doseči veliko "
-"uporabnikov."
+msgid "<a href=\"%(url)s\">Make your own add-on</a>. We provide free hosting and update services and can help you reach a large audience of users."
+msgstr "<a href=\"%(url)s\">Ustvarite svoj lastni dodatek</a>. Nudimo vam brezplačno gostovanje in storitev posodabljanja ter vam pomagamo doseči veliko uporabnikov."
 
 #: src/olympia/pages/templates/pages/about.lhtml:45
 #, python-format
-msgid ""
-"If you have add-on development experience, <a href=\"%(url)s\"> become an "
-"editor</a>! Our editors are add-on fans with a technical background who "
-"review add-ons for code quality and stability."
+msgid "If you have add-on development experience, <a href=\"%(url)s\"> become an editor</a>! Our editors are add-on fans with a technical background who review add-ons for code quality and stability."
 msgstr ""
-"Če imate izkušnje z razvojem dodatkov, <a href=\"%(url)s\">postanite "
-"recenzent</a>! Naši recenzenti so ljubitelji dodatkov s tehničnim ozadjem, "
-"ki preverjajo kakovost in stabilnost kode dodatka."
+"Če imate izkušnje z razvojem dodatkov, <a href=\"%(url)s\">postanite recenzent</a>! Naši recenzenti so ljubitelji dodatkov s tehničnim ozadjem, ki preverjajo kakovost in stabilnost kode dodatka."
 
 #: src/olympia/pages/templates/pages/about.lhtml:49
 #, python-format
 msgid ""
-"Help improve this website. It's open source, and you can file bugs and "
-"submit patches. <a href=\"%(url)s\"> GitHub</a> contains all of our current "
-"bugs, legacy bugs can still be found in Bugzilla."
+"Help improve this website. It's open source, and you can file bugs and submit patches. <a href=\"%(url)s\"> GitHub</a> contains all of our current bugs, legacy bugs can still be found in Bugzilla."
 msgstr ""
-"Pomagajte izboljšati to spletno mesto. Je odprtokodno in vi lahko sporočate "
-"hrošče ter prispevate popravke. <a href=\"%(url)s\"> GitHub</a> vsebuje vse "
-"trenutne hrošče, stare hrošče pa je še vedno moč najti v Bugzilli."
+"Pomagajte izboljšati to spletno mesto. Je odprtokodno in vi lahko sporočate hrošče ter prispevate popravke. <a href=\"%(url)s\"> GitHub</a> vsebuje vse trenutne hrošče, stare hrošče pa je še vedno "
+"moč najti v Bugzilli."
 
 #: src/olympia/pages/templates/pages/about.lhtml:55
-msgid ""
-"If you're interested in add-ons but not quite as technical, there are still "
-"ways to help:"
-msgstr ""
-"Če vas dodatki zanimajo, vendar niste tako tehnično podprti, nam lahko "
-"pomagate tudi na druge načine:"
+msgid "If you're interested in add-ons but not quite as technical, there are still ways to help:"
+msgstr "Če vas dodatki zanimajo, vendar niste tako tehnično podprti, nam lahko pomagate tudi na druge načine:"
 
 #: src/olympia/pages/templates/pages/about.lhtml:58
 msgid "Tell your friends! Let people know which add-ons you use."
@@ -11954,13 +9504,8 @@ msgid "Participate in our <a href=\"%(url)s\">forums</a>."
 msgstr "Sodelujte v naših <a href=\"%(url)s\">forumih</a>."
 
 #: src/olympia/pages/templates/pages/about.lhtml:61
-msgid ""
-"Review add-ons on the site. Add-on authors are more likely to improve their "
-"add-ons and write new ones when they know people appreciate their work."
-msgstr ""
-"Preglejte dodatke na strani. Avtorji dodatkov bodo verjetno izboljševali "
-"svoje dodatke in dodajali nove, ko bodo videli, da uporabniki cenijo njihovo"
-" delo."
+msgid "Review add-ons on the site. Add-on authors are more likely to improve their add-ons and write new ones when they know people appreciate their work."
+msgstr "Preglejte dodatke na strani. Avtorji dodatkov bodo verjetno izboljševali svoje dodatke in dodajali nove, ko bodo videli, da uporabniki cenijo njihovo delo."
 
 #: src/olympia/pages/templates/pages/about.lhtml:66
 msgid "I have a question"
@@ -11969,23 +9514,16 @@ msgstr "Imam vprašanje"
 #: src/olympia/pages/templates/pages/about.lhtml:67
 #, python-format
 msgid ""
-"A good place to start is our <a href=\"%(faq_url)s\"><abbr "
-"title=\"Frequently Asked Questions\">FAQ</abbr></a>. If you don't find an "
-"answer there, you can <a href=\"%(forum_url)s\"> ask on our forums</a>."
+"A good place to start is our <a href=\"%(faq_url)s\"><abbr title=\"Frequently Asked Questions\">FAQ</abbr></a>. If you don't find an answer there, you can <a href=\"%(forum_url)s\"> ask on our "
+"forums</a>."
 msgstr ""
-"Mesto, kjer lahko najdete odgovor, je <a href=\"%(faq_url)s\"><abbr "
-"title=\"Pogosto zastavljena vprašanja\">FAQ</abbr></a>. Če tam ne najdete "
-"odgovora, lahko <a href=\"%(forum_url)s\">zastavite vprašanje na naših "
-"forumih</a>."
+"Mesto, kjer lahko najdete odgovor, je <a href=\"%(faq_url)s\"><abbr title=\"Pogosto zastavljena vprašanja\">FAQ</abbr></a>. Če tam ne najdete odgovora, lahko <a href=\"%(forum_url)s\">zastavite "
+"vprašanje na naših forumih</a>."
 
 #: src/olympia/pages/templates/pages/about.lhtml:72
 #, python-format
-msgid ""
-"If you really need to contact someone from the Mozilla team, please see our "
-"<a href=\"%(url)s\"> contact information</a> page."
-msgstr ""
-"Če resnično morate stopiti v stik z nekom iz Mozilline ekipe, obiščite našo "
-"stran s <a href=\"%(url)s\">podatki za kontakt</a>."
+msgid "If you really need to contact someone from the Mozilla team, please see our <a href=\"%(url)s\"> contact information</a> page."
+msgstr "Če resnično morate stopiti v stik z nekom iz Mozilline ekipe, obiščite našo stran s <a href=\"%(url)s\">podatki za kontakt</a>."
 
 #: src/olympia/pages/templates/pages/about.lhtml:76
 msgid "Who works on this website?"
@@ -11994,14 +9532,11 @@ msgstr "Kdo dela na tem spletnem mestu?"
 #: src/olympia/pages/templates/pages/about.lhtml:77
 #, python-format
 msgid ""
-"Over the years, many people have contributed to this website, including both"
-" volunteers from the community and a dedicated AMO team. A list of "
-"significant contributors can be found on our <a href=\"%(url)s\"> Site "
-"Credits</a> page."
+"Over the years, many people have contributed to this website, including both volunteers from the community and a dedicated AMO team. A list of significant contributors can be found on our <a href="
+"\"%(url)s\"> Site Credits</a> page."
 msgstr ""
-"Skozi leta je k temu spletnemu mestu prispevalo veliko ljudi, to so "
-"prostovoljci iz skupnosti kot tudi posvečena ekipa AMO. Seznam pomembnejših "
-"sodelavcev najdete na naši strani <a href=\"%(url)s\">Zasluge za stran</a>."
+"Skozi leta je k temu spletnemu mestu prispevalo veliko ljudi, to so prostovoljci iz skupnosti kot tudi posvečena ekipa AMO. Seznam pomembnejših sodelavcev najdete na naši strani <a href=\"%(url)s"
+"\">Zasluge za stran</a>."
 
 #: src/olympia/pages/templates/pages/acr_firstrun.html:4
 msgid "Add-on Compatibility Reporter"
@@ -12012,12 +9547,8 @@ msgid "Add-on Compatibility Reporter has been installed"
 msgstr "Poročevalec o združljivosti dodatkov je nameščen"
 
 #: src/olympia/pages/templates/pages/acr_firstrun.html:28
-msgid ""
-"It’s easy to help us make sure add-ons are updated in time for the release "
-"of the next version of Firefox."
-msgstr ""
-"Na enostaven način nam lahko pomagate zagotoviti, da bodo dodatki "
-"posodobljeni pravočasno za sprostitev v naslednji različici Firefox."
+msgid "It’s easy to help us make sure add-ons are updated in time for the release of the next version of Firefox."
+msgstr "Na enostaven način nam lahko pomagate zagotoviti, da bodo dodatki posodobljeni pravočasno za sprostitev v naslednji različici Firefox."
 
 #: src/olympia/pages/templates/pages/acr_firstrun.html:35
 msgid "Here’s how to get started reporting add-on compatibility:"
@@ -12025,52 +9556,36 @@ msgstr "Takole začnete s poročilom o združljivosti dodatka:"
 
 #: src/olympia/pages/templates/pages/acr_firstrun.html:40
 msgid ""
-"As you start browsing and using your add-ons, take careful note of anything "
-"that seems different from when you last used the extension. This might be a "
-"display glitch, such as a menu item missing, or something more serious, like"
-" the add-on not working at all or showing errors."
+"As you start browsing and using your add-ons, take careful note of anything that seems different from when you last used the extension. This might be a display glitch, such as a menu item missing, "
+"or something more serious, like the add-on not working at all or showing errors."
 msgstr ""
-"Kot začnete brskati in uporabljati svoje dodatke, si podrobno beležite vse, "
-"kar je pri razširitvi drugače kot prej. Lahko je majhen problem s problemom,"
-" recimo postavka v meniju manjka, ali kaj bolj resnega, recimo da dodatek "
-"sploh ne deluje ali pa napačno."
+"Kot začnete brskati in uporabljati svoje dodatke, si podrobno beležite vse, kar je pri razširitvi drugače kot prej. Lahko je majhen problem s problemom, recimo postavka v meniju manjka, ali kaj "
+"bolj resnega, recimo da dodatek sploh ne deluje ali pa napačno."
 
 #: src/olympia/pages/templates/pages/acr_firstrun.html:49
 msgid ""
-"Once you know whether a particular add-on works properly or has problems, "
-"open the Add-ons Manager and click Compatibility next to the add-on to let "
-"Mozilla know what you found in your testing. Submitting a report will help "
-"us tell the add-on developer whether their add-on is working properly in "
-"this version or might need some fixes."
+"Once you know whether a particular add-on works properly or has problems, open the Add-ons Manager and click Compatibility next to the add-on to let Mozilla know what you found in your testing. "
+"Submitting a report will help us tell the add-on developer whether their add-on is working properly in this version or might need some fixes."
 msgstr ""
-"Ko enkrat veste, da dodatek ali deluje pravilno ali ima napake, odprite "
-"Upravitelja dodatkov in kliknite na Združljivost poleg dodatka, da Mozilli "
-"sporočite, kaj ste med testiranjem odkrili. Poslano poročilo nam bo pomagalo"
-" obvestiti razvijalce, bodisi da njihovi dodatki v tej različici pravilno "
-"delujejo, bodisi da so morda potrebni popravki."
+"Ko enkrat veste, da dodatek ali deluje pravilno ali ima napake, odprite Upravitelja dodatkov in kliknite na Združljivost poleg dodatka, da Mozilli sporočite, kaj ste med testiranjem odkrili. "
+"Poslano poročilo nam bo pomagalo obvestiti razvijalce, bodisi da njihovi dodatki v tej različici pravilno delujejo, bodisi da so morda potrebni popravki."
 
 #: src/olympia/pages/templates/pages/acr_firstrun.html:61
 #, python-format
 msgid ""
-"If you upgrade to a new version of Firefox or update your add-ons, your "
-"reports for the old versions will be hidden to allow you to test the new "
-"version. If you have any questions, please ask in <a href=\"%(url)s\">our "
-"forums</a>."
+"If you upgrade to a new version of Firefox or update your add-ons, your reports for the old versions will be hidden to allow you to test the new version. If you have any questions, please ask in <a "
+"href=\"%(url)s\">our forums</a>."
 msgstr ""
-"Če nadgradite na novo različico Firefox ali posodobite svoje dodatke, se bo "
-"poročila za stare različice skrilo, da boste lahko novo  različico "
-"pretestirali. Če imate kakršnakoli vprašanja, se obrnite na <a "
-"href=\"%(url)s\"> naše forume </a>."
+"Če nadgradite na novo različico Firefox ali posodobite svoje dodatke, se bo poročila za stare različice skrilo, da boste lahko novo  različico pretestirali. Če imate kakršnakoli vprašanja, se "
+"obrnite na <a href=\"%(url)s\"> naše forume </a>."
 
 #: src/olympia/pages/templates/pages/acr_firstrun.html:69
 msgid ""
-"Thousands of add-ons are made by our community every year, and your "
-"assistance with compatibility testing helps us make sure these add-ons stay "
-"useful as we strive to provide a great user experience."
+"Thousands of add-ons are made by our community every year, and your assistance with compatibility testing helps us make sure these add-ons stay useful as we strive to provide a great user "
+"experience."
 msgstr ""
-"Naša skupnost vsako leto razvije na tisoče dodatkov in vaša pomoč pri "
-"testiranju združljivosti nam pomaga zagotavljati, da so ti dodatki ostanejo "
-"dalje  uporabni in v veselje ter korist svojim uporabnikom."
+"Naša skupnost vsako leto razvije na tisoče dodatkov in vaša pomoč pri testiranju združljivosti nam pomaga zagotavljati, da so ti dodatki ostanejo dalje  uporabni in v veselje ter korist svojim "
+"uporabnikom."
 
 #: src/olympia/pages/templates/pages/acr_firstrun.html:75
 msgid "Thank you!"
@@ -12081,12 +9596,8 @@ msgid "Site Credits"
 msgstr "Priznanja strani"
 
 #: src/olympia/pages/templates/pages/credits.html:12
-msgid ""
-"Mozilla would like to thank the following people for their contributions to "
-"the addons.mozilla.org project over the years:"
-msgstr ""
-"Za njihov prispevek k projektu addons.mozilla.org v preteklih letih bi se "
-"Mozilla rada zahvalila naslednjim ljudem:"
+msgid "Mozilla would like to thank the following people for their contributions to the addons.mozilla.org project over the years:"
+msgstr "Za njihov prispevek k projektu addons.mozilla.org v preteklih letih bi se Mozilla rada zahvalila naslednjim ljudem:"
 
 #: src/olympia/pages/templates/pages/credits.html:18
 msgid "Developers &amp; Administrators"
@@ -12119,88 +9630,63 @@ msgstr "Programska oprema in slike"
 
 #: src/olympia/pages/templates/pages/credits.html:59
 msgid ""
-"Some icons used are from the <a "
-"href=\"http://www.famfamfam.com/lab/icons/silk/\">famfamfam Silk Icon "
-"Set</a>, licensed under a <a "
-"href=\"http://creativecommons.org/licenses/by/2.5/\">Creative Commons "
-"Attribution 2.5 License</a>."
+"Some icons used are from the <a href=\"http://www.famfamfam.com/lab/icons/silk/\">famfamfam Silk Icon Set</a>, licensed under a <a href=\"http://creativecommons.org/licenses/by/2.5/\">Creative "
+"Commons Attribution 2.5 License</a>."
 msgstr ""
-"Nekatere ikone, ki jih uporabljamo, so iz <a "
-"href=\"http://www.famfamfam.com/lab/icons/silk/\">seta ikon famfamfam "
-"Silk</a>, pod licenco <a "
-"href=\"http://creativecommons.org/licenses/by/2.5/\">Creative Commons "
-"Attribution 2.5 License</a>."
+"Nekatere ikone, ki jih uporabljamo, so iz <a href=\"http://www.famfamfam.com/lab/icons/silk/\">seta ikon famfamfam Silk</a>, pod licenco <a href=\"http://creativecommons.org/licenses/by/2.5/"
+"\">Creative Commons Attribution 2.5 License</a>."
 
 #: src/olympia/pages/templates/pages/credits.html:60
 msgid ""
-"Some icons used are from the <a href=\"http://www.fatcow.com/free-"
-"icons/\">FatCow Farm-Fresh Web Icons Set</a>, licensed under a <a "
-"href=\"http://creativecommons.org/licenses/by/3.0/us/\">Creative Commons "
-"Attribution 3.0 License</a>."
+"Some icons used are from the <a href=\"http://www.fatcow.com/free-icons/\">FatCow Farm-Fresh Web Icons Set</a>, licensed under a <a href=\"http://creativecommons.org/licenses/by/3.0/us/\">Creative "
+"Commons Attribution 3.0 License</a>."
 msgstr ""
-"Nekatere ikone so iz <a href=\"http://www.fatcow.com/free-icons/\">FatCow "
-"Farm-Fresh Web Icons Set</a>, z licenco <a "
-"href=\"http://creativecommons.org/licenses/by/3.0/us/\">Creative Commons "
+"Nekatere ikone so iz <a href=\"http://www.fatcow.com/free-icons/\">FatCow Farm-Fresh Web Icons Set</a>, z licenco <a href=\"http://creativecommons.org/licenses/by/3.0/us/\">Creative Commons "
 "Attribution 3.0 License</a>."
 
 #: src/olympia/pages/templates/pages/credits.html:61
 msgid ""
-"Some pages use elements of <a "
-"href=\"http://shop.highsoft.com/highcharts.html\">Highcharts</a> (non-"
-"commercial), licensed under a <a href=\"http://creativecommons.org/licenses"
-"/by-nc/3.0/\">Creative Commons Attribution-NonCommercial 3.0 License</a>."
+"Some pages use elements of <a href=\"http://shop.highsoft.com/highcharts.html\">Highcharts</a> (non-commercial), licensed under a <a href=\"http://creativecommons.org/licenses/by-nc/3.0/\">Creative "
+"Commons Attribution-NonCommercial 3.0 License</a>."
 msgstr ""
-"Nekatere strani uporabljajo <a "
-"href=\"http://shop.highsoft.com/highcharts.html\">Highcharts</a> "
-"(nekomercialno), pod licenco <a href=\"http://creativecommons.org/licenses"
-"/by-nc/3.0/\">Creative Commons Attribution-NonCommercial 3.0 License</a>."
+"Nekatere strani uporabljajo <a href=\"http://shop.highsoft.com/highcharts.html\">Highcharts</a> (nekomercialno), pod licenco <a href=\"http://creativecommons.org/licenses/by-nc/3.0/\">Creative "
+"Commons Attribution-NonCommercial 3.0 License</a>."
 
 #: src/olympia/pages/templates/pages/credits.html:65
 #, python-format
-msgid ""
-"For information on contributing, please see our <a href=\"%(url)s\">wiki "
-"page</a>."
-msgstr ""
-"Za informacije o prispevkih si oglejte našo <a href=\"%(url)s\">wiki "
-"stran</a> ."
+msgid "For information on contributing, please see our <a href=\"%(url)s\">wiki page</a>."
+msgstr "Za informacije o prispevkih si oglejte našo <a href=\"%(url)s\">wiki stran</a> ."
 
 #: src/olympia/pages/templates/pages/dev_faq.html:4
 msgid "Developer FAQ"
 msgstr "Pogosta vprašanja razvijalcev"
 
-#: src/olympia/pages/templates/pages/dev_faq.html:31
-#: src/olympia/pages/templates/pages/review_guide.html:33
+#: src/olympia/pages/templates/pages/dev_faq.html:31 src/olympia/pages/templates/pages/review_guide.html:33
 msgid "Sections"
 msgstr "Sekcije"
 
-#: src/olympia/pages/templates/pages/dev_faq.html:33
-#: src/olympia/pages/templates/pages/dev_faq.html:45
+#: src/olympia/pages/templates/pages/dev_faq.html:33 src/olympia/pages/templates/pages/dev_faq.html:45
 msgid "Developing an Add-on"
 msgstr "Razvoj dodatkov"
 
 #. Heading for a list of resources for developers
-#: src/olympia/pages/templates/pages/dev_faq.html:34
-#: src/olympia/pages/templates/pages/dev_faq.html:208
+#: src/olympia/pages/templates/pages/dev_faq.html:34 src/olympia/pages/templates/pages/dev_faq.html:208
 msgid "Support Resources"
 msgstr "Viri za podporo"
 
-#: src/olympia/pages/templates/pages/dev_faq.html:35
-#: src/olympia/pages/templates/pages/dev_faq.html:261
+#: src/olympia/pages/templates/pages/dev_faq.html:35 src/olympia/pages/templates/pages/dev_faq.html:261
 msgid "Contributing your Add-on"
 msgstr "Kako prispevate svoj dodatek"
 
-#: src/olympia/pages/templates/pages/dev_faq.html:36
-#: src/olympia/pages/templates/pages/dev_faq.html:381
+#: src/olympia/pages/templates/pages/dev_faq.html:36 src/olympia/pages/templates/pages/dev_faq.html:381
 msgid "Add-on Review Process"
 msgstr "Postopek pregledov za dodatke"
 
-#: src/olympia/pages/templates/pages/dev_faq.html:37
-#: src/olympia/pages/templates/pages/dev_faq.html:444
+#: src/olympia/pages/templates/pages/dev_faq.html:37 src/olympia/pages/templates/pages/dev_faq.html:444
 msgid "Managing Your Add-on"
 msgstr "Upravljanje dodatkov"
 
-#: src/olympia/pages/templates/pages/dev_faq.html:39
-#: src/olympia/pages/templates/pages/dev_faq.html:528
+#: src/olympia/pages/templates/pages/dev_faq.html:39 src/olympia/pages/templates/pages/dev_faq.html:528
 msgid "References for Open Source Licenses"
 msgstr "Reference za odprto-kodne licence"
 
@@ -12210,14 +9696,8 @@ msgstr "Pogosta vprašanja za razvijalce dodatkov"
 
 #: src/olympia/pages/templates/pages/dev_faq.html:47
 #, python-format
-msgid ""
-"<h3>How do I build an Add-on?</h3> <p> Mozilla provides documentation on how"
-" to build an add-on via the <a href=\"%(url)s\">Mozilla Developer "
-"Network</a>. </p>"
-msgstr ""
-"<h3>Kako izgradim dodatek?</h3> <p> Mozilla dobavlja dokumentacijo o "
-"izgradnji dodatkov preko omrežja <a href=\"%(url)s\">Mozilla Developer "
-"Network</a>. </p>"
+msgid "<h3>How do I build an Add-on?</h3> <p> Mozilla provides documentation on how to build an add-on via the <a href=\"%(url)s\">Mozilla Developer Network</a>. </p>"
+msgstr "<h3>Kako izgradim dodatek?</h3> <p> Mozilla dobavlja dokumentacijo o izgradnji dodatkov preko omrežja <a href=\"%(url)s\">Mozilla Developer Network</a>. </p>"
 
 #: src/olympia/pages/templates/pages/dev_faq.html:55
 msgid "Other resources include:"
@@ -12237,13 +9717,11 @@ msgstr "Katera orodja potrebujem za razvoj dodatkov?"
 
 #: src/olympia/pages/templates/pages/dev_faq.html:68
 msgid ""
-"You will need to have a version of the Mozilla software that you're building"
-" the add-on for and a code editor of your choice. Add-ons can be built for "
-"almost all Mozilla software but are primarily targeted for:"
+"You will need to have a version of the Mozilla software that you're building the add-on for and a code editor of your choice. Add-ons can be built for almost all Mozilla software but are primarily "
+"targeted for:"
 msgstr ""
-"Imeti boste morali različico Mozillinega programa, za katerega izdelujete "
-"dodatek, in urejevalnik kode po vaši izbiri. Dodatke lahko ustvarite za "
-"skoraj vse Mozilline programe, vendar so v prvi vrsti namenjeni za:"
+"Imeti boste morali različico Mozillinega programa, za katerega izdelujete dodatek, in urejevalnik kode po vaši izbiri. Dodatke lahko ustvarite za skoraj vse Mozilline programe, vendar so v prvi "
+"vrsti namenjeni za:"
 
 #: src/olympia/pages/templates/pages/dev_faq.html:82
 msgid "Popular code editors include:"
@@ -12252,37 +9730,24 @@ msgstr "Priljubljeni urejevalniki kod so na primer:"
 #. This is a list of popular code editors.  Feel free to adjust as you like.
 #: src/olympia/pages/templates/pages/dev_faq.html:85
 msgid ""
-"<li><a href=\"http://komodoide.com/komodo-edit/\">Komodo Edit</a></li> "
-"<li><a href=\"http://macromates.com/\">TextMate</a></li> <li><a href=\"http"
-"://notepad-plus-plus.org/\">Notepad++</a></li> <li><a "
-"href=\"http://www.eclipse.org/\">Eclipse IDE</a></li>"
+"<li><a href=\"http://komodoide.com/komodo-edit/\">Komodo Edit</a></li> <li><a href=\"http://macromates.com/\">TextMate</a></li> <li><a href=\"http://notepad-plus-plus.org/\">Notepad++</a></li> "
+"<li><a href=\"http://www.eclipse.org/\">Eclipse IDE</a></li>"
 msgstr ""
-"<li><a href=\"http://komodoide.com/komodo-edit/\">Komodo Edit</a></li> "
-"<li><a href=\"http://macromates.com/\">TextMate</a></li> <li><a href=\"http"
-"://notepad-plus-plus.org/\">Notepad++</a></li> <li><a "
-"href=\"http://www.eclipse.org/\">Eclipse IDE</a></li>"
+"<li><a href=\"http://komodoide.com/komodo-edit/\">Komodo Edit</a></li> <li><a href=\"http://macromates.com/\">TextMate</a></li> <li><a href=\"http://notepad-plus-plus.org/\">Notepad++</a></li> "
+"<li><a href=\"http://www.eclipse.org/\">Eclipse IDE</a></li>"
 
 #: src/olympia/pages/templates/pages/dev_faq.html:94
 #, python-format
-msgid ""
-"You can also learn more about setting up your development environment via "
-"the MDN article <a href=\"%(url)s\">Setting up extension development "
-"environment</a>"
-msgstr ""
-"Več podatkov o nastavitvi razvojnega okolja lahko dobite v članku MDN <a "
-"href=\"%(url)s\">Setting up extension development environment</a>"
+msgid "You can also learn more about setting up your development environment via the MDN article <a href=\"%(url)s\">Setting up extension development environment</a>"
+msgstr "Več podatkov o nastavitvi razvojnega okolja lahko dobite v članku MDN <a href=\"%(url)s\">Setting up extension development environment</a>"
 
 #: src/olympia/pages/templates/pages/dev_faq.html:100
 msgid "What is a \".xpi\" file?"
 msgstr "Kaj je datoteka \".xpi\"?"
 
 #: src/olympia/pages/templates/pages/dev_faq.html:102
-msgid ""
-"Extensions are packaged and distributed in ZIP files or Bundles, with the "
-"XPI (pronounced \"zippy\") file extension."
-msgstr ""
-"Razširitve se spravlja in širi kot ZIP datoteke ali svežnje s pripono XPI "
-"(pogovorno \"zipi\")."
+msgid "Extensions are packaged and distributed in ZIP files or Bundles, with the XPI (pronounced \"zippy\") file extension."
+msgstr "Razširitve se spravlja in širi kot ZIP datoteke ali svežnje s pripono XPI (pogovorno \"zipi\")."
 
 #: src/olympia/pages/templates/pages/dev_faq.html:108
 msgid "What is XUL?"
@@ -12290,16 +9755,11 @@ msgstr "Kaj je XUL?"
 
 #: src/olympia/pages/templates/pages/dev_faq.html:110
 msgid ""
-"XUL (XML User Interface Language) is Mozilla's XML-based language that lets "
-"you build feature-rich cross platform applications. It provides user "
-"interface widgets like buttons, menus, toolbars, trees, etc that can be used"
-" to enhance add-ons by modifying parts of the browser UI."
+"XUL (XML User Interface Language) is Mozilla's XML-based language that lets you build feature-rich cross platform applications. It provides user interface widgets like buttons, menus, toolbars, "
+"trees, etc that can be used to enhance add-ons by modifying parts of the browser UI."
 msgstr ""
-"XUL (XML User Interface Language) je Mozillin jezik na osnovi XML, ki vam "
-"omogoča ustvariti aplikacije z bogato funkcionalnostjo in neodvisno od "
-"platforme. Ponuja komponente, kot so gumbi, meniji, orodne vrstice, drevesa "
-"itd., s katerimi lahko obogatite dodatke tako, da spremenite dele "
-"uporabniškega vmesnika brskalnika."
+"XUL (XML User Interface Language) je Mozillin jezik na osnovi XML, ki vam omogoča ustvariti aplikacije z bogato funkcionalnostjo in neodvisno od platforme. Ponuja komponente, kot so gumbi, meniji, "
+"orodne vrstice, drevesa itd., s katerimi lahko obogatite dodatke tako, da spremenite dele uporabniškega vmesnika brskalnika."
 
 #: src/olympia/pages/templates/pages/dev_faq.html:119
 msgid "What is the \"install.rdf\" file used for?"
@@ -12308,35 +9768,21 @@ msgstr "Kaj je namen datoteke \"install.rdf\"?"
 #: src/olympia/pages/templates/pages/dev_faq.html:121
 #, python-format
 msgid ""
-"This file, called an <a href=\"%(url)s\">Install Manifest</a>, is used by "
-"Add-on Manager-enabled XUL applications to determine information about an "
-"add-on as it is being installed. It contains metadata identifying the add-"
-"on, providing information about who created it, where more information can "
-"be found about it, which versions of what applications it is compatible "
-"with, how it should be updated, and so on. The format of the Install "
-"Manifest is RDF/XML."
+"This file, called an <a href=\"%(url)s\">Install Manifest</a>, is used by Add-on Manager-enabled XUL applications to determine information about an add-on as it is being installed. It contains "
+"metadata identifying the add-on, providing information about who created it, where more information can be found about it, which versions of what applications it is compatible with, how it should "
+"be updated, and so on. The format of the Install Manifest is RDF/XML."
 msgstr ""
-"To datoteko, imenovana <a href=\"%(url)s\">namestitveni manifest</a>, "
-"uporabljajo XUL aplikacije z omogočenim Upraviteljem dodatkov, da ob "
-"namestitvi dodatka dobi informacije o njem. Vsebuje metapodatke, ki "
-"identificirajo dodatek, vsebujejo informacije, kdo je avtor dodatka, kje "
-"lahko o njem najdete več informacij, s katerimi različicami katerih "
-"aplikacij je združljiv, kako naj se posodablja itd. Format namestitvenega "
-"manifesta je RDF/XML."
+"To datoteko, imenovana <a href=\"%(url)s\">namestitveni manifest</a>, uporabljajo XUL aplikacije z omogočenim Upraviteljem dodatkov, da ob namestitvi dodatka dobi informacije o njem. Vsebuje "
+"metapodatke, ki identificirajo dodatek, vsebujejo informacije, kdo je avtor dodatka, kje lahko o njem najdete več informacij, s katerimi različicami katerih aplikacij je združljiv, kako naj se "
+"posodablja itd. Format namestitvenega manifesta je RDF/XML."
 
 #: src/olympia/pages/templates/pages/dev_faq.html:132
 msgid "What does \"maxVersion\" mean?"
 msgstr "Kaj pomeni \"maxVersion\"?"
 
 #: src/olympia/pages/templates/pages/dev_faq.html:134
-msgid ""
-"This determines the maximum version of Firefox you're saying this extension "
-"will work with. Set this to be no newer than the newest currently available "
-"version!"
-msgstr ""
-"Ta številka predstavlja najnovejšo različico Firefoxa, za katero želite, da "
-"razširitev še deluje. Nastavite to številko tako, da ne bo večja od "
-"najnovejše različice, ki je trenutno na voljo!"
+msgid "This determines the maximum version of Firefox you're saying this extension will work with. Set this to be no newer than the newest currently available version!"
+msgstr "Ta številka predstavlja najnovejšo različico Firefoxa, za katero želite, da razširitev še deluje. Nastavite to številko tako, da ne bo večja od najnovejše različice, ki je trenutno na voljo!"
 
 #: src/olympia/pages/templates/pages/dev_faq.html:141
 msgid "Can my add-on contain binary components?"
@@ -12345,41 +9791,23 @@ msgstr "Ali lahko moj dodatek vsebuje binarne komponente?"
 #: src/olympia/pages/templates/pages/dev_faq.html:143
 #, python-format
 msgid ""
-"Yes. You can use Mozilla's <a href=\"%(url)s\">XPCOM component object "
-"model</a> to enhance your add-ons. XPCOM components be used and implemented "
-"in JavaScript, Java, and Python in addition to C++."
+"Yes. You can use Mozilla's <a href=\"%(url)s\">XPCOM component object model</a> to enhance your add-ons. XPCOM components be used and implemented in JavaScript, Java, and Python in addition to C++."
 msgstr ""
-"Da. Za obogatitev svojih dodatkov lahko uporabljate <a "
-"href=\"%(url)s\">objektni model za komponente XPCOM</a>. Komponente XPCOM "
-"lahko uporabite in izvedete v JavaScriptu, Javi, Pythonu poleg C++."
+"Da. Za obogatitev svojih dodatkov lahko uporabljate <a href=\"%(url)s\">objektni model za komponente XPCOM</a>. Komponente XPCOM lahko uporabite in izvedete v JavaScriptu, Javi, Pythonu poleg C++."
 
 #: src/olympia/pages/templates/pages/dev_faq.html:150
-msgid ""
-"Can I use a JavaScript library like jQuery, MooTools or Prototype to build "
-"my add-on?"
-msgstr ""
-"Ali lahko pri razvoju svojega dodatka uporabljam knjižnice v JavaScriptu, "
-"kot so jQuery, MooTools ali Prototype?"
+msgid "Can I use a JavaScript library like jQuery, MooTools or Prototype to build my add-on?"
+msgstr "Ali lahko pri razvoju svojega dodatka uporabljam knjižnice v JavaScriptu, kot so jQuery, MooTools ali Prototype?"
 
 #: src/olympia/pages/templates/pages/dev_faq.html:152
 msgid ""
-"Yes. It's possible, but some of the functionality provided by these "
-"libraries are available through XPCOM, XUL, and JavaScript. In addition, "
-"authors should take care if libraries modify primitive object prototypes "
-"(String.prototype, Date.prototype, etc.) and/or define global functions (eg."
-" the $ function). These are prone to cause conflict with other add-ons, in "
-"particular if different add-ons use different versions of libraries and so "
-"on. Developers need to be very, very careful with using them.  Mozilla does "
-"not offer documentation on using them to build add-ons."
+"Yes. It's possible, but some of the functionality provided by these libraries are available through XPCOM, XUL, and JavaScript. In addition, authors should take care if libraries modify primitive "
+"object prototypes (String.prototype, Date.prototype, etc.) and/or define global functions (eg. the $ function). These are prone to cause conflict with other add-ons, in particular if different add-"
+"ons use different versions of libraries and so on. Developers need to be very, very careful with using them. Mozilla does not offer documentation on using them to build add-ons."
 msgstr ""
-"Da, je mogoče, vendar je nekaj funkcionalnosti, ki jo nudijo te knjižnice, "
-"na voljo preko XPCOM-a, XUL-a in JavaScripta.  Poleg tega morajo biti "
-"avtorji previdni, če knjižnice spremenijo prototipe primitivnih objektov "
-"(String.prototype, Date.prototype itd.) in/ali določiti splošne funkcije "
-"(npr. funkcijo $).  Te so dovzetne za spore z drugimi dodatki, posebno, če "
-"različni dodatki uporabljajo različne različice knjižnic itd.  Razvijalci "
-"morajo biti pri njihovi uporabi zelo, zelo previdni.  Mozilla ne nudi "
-"dokumentacije o njihovi uporabi za izgradnjo dodatkov."
+"Da, je mogoče, vendar je nekaj funkcionalnosti, ki jo nudijo te knjižnice, na voljo preko XPCOM-a, XUL-a in JavaScripta.  Poleg tega morajo biti avtorji previdni, če knjižnice spremenijo prototipe "
+"primitivnih objektov (String.prototype, Date.prototype itd.) in/ali določiti splošne funkcije (npr. funkcijo $).  Te so dovzetne za spore z drugimi dodatki, posebno, če različni dodatki uporabljajo "
+"različne različice knjižnic itd.  Razvijalci morajo biti pri njihovi uporabi zelo, zelo previdni.  Mozilla ne nudi dokumentacije o njihovi uporabi za izgradnjo dodatkov."
 
 #: src/olympia/pages/templates/pages/dev_faq.html:165
 msgid "How do I debug my add-on?"
@@ -12391,31 +9819,18 @@ msgid "You can use the <a href=\"%(url)s\">Add-on Debugger</a>."
 msgstr "Lahko uporabite <a href=\"%(url)s\">Razhroščevalca dodatkov</a>."
 
 #: src/olympia/pages/templates/pages/dev_faq.html:172
-msgid ""
-"How do I test for compatibility with the latest version of Mozilla software?"
-msgstr ""
-"Kako preveriti združljivost z najnovejšo različico programske opreme "
-"Mozilla?"
+msgid "How do I test for compatibility with the latest version of Mozilla software?"
+msgstr "Kako preveriti združljivost z najnovejšo različico programske opreme Mozilla?"
 
 #: src/olympia/pages/templates/pages/dev_faq.html:174
 msgid ""
-"To ensure compatibility with the latest Mozilla software, it's important to "
-"download updates as they become available and test your add-on to ensure "
-"that it is still functioning as expected. In many cases, the latest version "
-"of Mozilla software may be a beta release. Since these releases at times "
-"introduce architectural changes that may impact the functionality of your "
-"add-on, it's important to be actively involved in the beta process to ensure"
-" that your add-on users are not negatively impacted upon final release of "
-"Mozilla software."
+"To ensure compatibility with the latest Mozilla software, it's important to download updates as they become available and test your add-on to ensure that it is still functioning as expected. In "
+"many cases, the latest version of Mozilla software may be a beta release. Since these releases at times introduce architectural changes that may impact the functionality of your add-on, it's "
+"important to be actively involved in the beta process to ensure that your add-on users are not negatively impacted upon final release of Mozilla software."
 msgstr ""
-"Da zagotovite združljivost z najnovejšo Mozillino programsko opremo, je "
-"pomembno, da prenesete posodobitve takoj, ko do na voljo in se prepričate, "
-"da vaš dodatek še vedno pravilno deluje. V veliko primerih je najnovejša "
-"različica Mozilline programske opreme beta različica. Ker te različice "
-"občasno uvedejo spremembe zgradbe, ki lahko vplivajo na delovanje vašega "
-"dodatka, je pomembno, da aktivno sodelujete v postopku beta, da uporabniki "
-"ne bodo neprijetno presenečeni ob izidu končne izdaje Mozilline programske "
-"opreme."
+"Da zagotovite združljivost z najnovejšo Mozillino programsko opremo, je pomembno, da prenesete posodobitve takoj, ko do na voljo in se prepričate, da vaš dodatek še vedno pravilno deluje. V veliko "
+"primerih je najnovejša različica Mozilline programske opreme beta različica. Ker te različice občasno uvedejo spremembe zgradbe, ki lahko vplivajo na delovanje vašega dodatka, je pomembno, da "
+"aktivno sodelujete v postopku beta, da uporabniki ne bodo neprijetno presenečeni ob izidu končne izdaje Mozilline programske opreme."
 
 #: src/olympia/pages/templates/pages/dev_faq.html:185
 msgid "How to improve the performance of my add-on?"
@@ -12424,16 +9839,11 @@ msgstr "Kako lahko izboljšam učinkovitost delovanja svojega dodatka?"
 #: src/olympia/pages/templates/pages/dev_faq.html:187
 #, python-format
 msgid ""
-"Poorly written extensions can have a severe impact on the browsing "
-"experience, including on the overall performance of Firefox itself. The "
-"following page contains many good <a href=\"%(url)s\">guides</a> that help "
-"you improve performance, whether you're developing core Mozilla code or an "
-"add-on."
+"Poorly written extensions can have a severe impact on the browsing experience, including on the overall performance of Firefox itself. The following page contains many good <a href=\"%(url)s"
+"\">guides</a> that help you improve performance, whether you're developing core Mozilla code or an add-on."
 msgstr ""
-"Slabo napisane razširitve lahko zelo vplivajo na izkušnjo brskanja, vključno"
-" z učinkovitostjo delovanja Firefoxa samega. Sledeča stran vsebuje veliko "
-"dobrih <a href=\"%(url)s\">vodnikov</a>, ki vam pomagajo izboljšati "
-"učinkovitost delovanja, ko pišete kodo sredice Mozille ali dodatka."
+"Slabo napisane razširitve lahko zelo vplivajo na izkušnjo brskanja, vključno z učinkovitostjo delovanja Firefoxa samega. Sledeča stran vsebuje veliko dobrih <a href=\"%(url)s\">vodnikov</a>, ki vam "
+"pomagajo izboljšati učinkovitost delovanja, ko pišete kodo sredice Mozille ali dodatka."
 
 #: src/olympia/pages/templates/pages/dev_faq.html:195
 msgid "Can my add-on support multiple locales?"
@@ -12443,21 +9853,15 @@ msgstr "Ali lahko moj dodatek podpira več jezikov?"
 #: src/olympia/pages/templates/pages/dev_faq.html:197
 #, python-format
 msgid ""
-"Yes. Details on localizing your add-on can be found in the the <a "
-"href=\"%(l10n_url)s\">Mozilla Developer Network Localization page</a>. <a "
-"href=\"%(bz_url)s\">The BabelZilla project</a> is also a great resource for "
-"learning about localization and volunteering to help translate add-ons."
+"Yes. Details on localizing your add-on can be found in the the <a href=\"%(l10n_url)s\">Mozilla Developer Network Localization page</a>. <a href=\"%(bz_url)s\">The BabelZilla project</a> is also a "
+"great resource for learning about localization and volunteering to help translate add-ons."
 msgstr ""
-"Da. Podrobnosti o lokaliziranju svojega dodatka lahko najdete na <a "
-"href=\"%(l10n_url)s\">strani Mozilla Developer Network Localization</a>.  <a"
-" href=\"%(bz_url)s\">Projekt BabelZilla</a> je tudi odličen vir za učenje o "
-"lokalizaciji in prostovoljni pomoči pri prevajanju dodatkov."
+"Da. Podrobnosti o lokaliziranju svojega dodatka lahko najdete na <a href=\"%(l10n_url)s\">strani Mozilla Developer Network Localization</a>.  <a href=\"%(bz_url)s\">Projekt BabelZilla</a> je tudi "
+"odličen vir za učenje o lokalizaciji in prostovoljni pomoči pri prevajanju dodatkov."
 
 #: src/olympia/pages/templates/pages/dev_faq.html:210
 msgid "I need some advice building my add-on. Where can I find help?"
-msgstr ""
-"Pri gradnji svojega dodatka potrebujem nekaj nasvetov. Kje lahko najdem "
-"pomoč?"
+msgstr "Pri gradnji svojega dodatka potrebujem nekaj nasvetov. Kje lahko najdem pomoč?"
 
 #. #extdev is the name of the IRC channel.  do not change.
 #: src/olympia/pages/templates/pages/dev_faq.html:216
@@ -12471,12 +9875,8 @@ msgstr "# Amo (za podporo v zvezi z gostovanjem vašega dodatka na AMO)"
 
 #. #jetpack is the name of the IRC channel.  do not change.
 #: src/olympia/pages/templates/pages/dev_faq.html:220
-msgid ""
-"#jetpack (for discussions about the Add-ons SDK and cfx/jpm - formerly known"
-" as Jetpack)"
-msgstr ""
-"#jetpack (za razprave o SDK-ju dodatkov in cfx/jpm - prej znanem kot "
-"Jetpack)"
+msgid "#jetpack (for discussions about the Add-ons SDK and cfx/jpm - formerly known as Jetpack)"
+msgstr "#jetpack (za razprave o SDK-ju dodatkov in cfx/jpm - prej znanem kot Jetpack)"
 
 #. Label for a link to the extension developers mailing list
 #: src/olympia/pages/templates/pages/dev_faq.html:225
@@ -12516,18 +9916,11 @@ msgstr "Ali lahko najamem tretje razvijalce za razvoj svojega dodatka?"
 #: src/olympia/pages/templates/pages/dev_faq.html:248
 #, python-format
 msgid ""
-"Yes. You may find 3rd party developers via the <a href=\"%(forum_url)s"
-"\">Add-ons forum</a>, <a href=\"%(list_url)s\">mozilla.jobs list</a>, <a "
-"href=\"%(mz_url)s\">mozillaZine forums</a> or <a href=\"%(wiki_url)s\">the "
-"Mozilla Wiki</a>. Please note that Mozilla does not offer developer "
-"recommendations."
+"Yes. You may find 3rd party developers via the <a href=\"%(forum_url)s\">Add-ons forum</a>, <a href=\"%(list_url)s\">mozilla.jobs list</a>, <a href=\"%(mz_url)s\">mozillaZine forums</a> or <a href="
+"\"%(wiki_url)s\">the Mozilla Wiki</a>. Please note that Mozilla does not offer developer recommendations."
 msgstr ""
-"Da. Razvijalce tretjih oseb lahko najdete na <a "
-"href=\"%(forum_url)s\">forumu za dodatke</a>, <a "
-"href=\"%(list_url)s\">seznamu mozilla.jobs</a>, <a "
-"href=\"%(mz_url)s\">forumih mozillaZine</a> ali strani <a "
-"href=\"%(wiki_url)s\">Mozilla Wiki</a>. Upoštevajte, da Mozilla ne ponuja "
-"priporočil za razvijalce."
+"Da. Razvijalce tretjih oseb lahko najdete na <a href=\"%(forum_url)s\">forumu za dodatke</a>, <a href=\"%(list_url)s\">seznamu mozilla.jobs</a>, <a href=\"%(mz_url)s\">forumih mozillaZine</a> ali "
+"strani <a href=\"%(wiki_url)s\">Mozilla Wiki</a>. Upoštevajte, da Mozilla ne ponuja priporočil za razvijalce."
 
 #: src/olympia/pages/templates/pages/dev_faq.html:263
 msgid "Can I host my own add-on?"
@@ -12536,21 +9929,13 @@ msgstr "Ali lahko svoj dodatek gostujem sam?"
 #: src/olympia/pages/templates/pages/dev_faq.html:265
 #, python-format
 msgid ""
-"Yes. Many developers choose to host their own add-ons. Choosing to host your"
-" add-on on <a href=\"%(amo_url)s\">Mozilla's add-on site</a>, though, allows"
-" for much greater exposure to your add-on due to the large volume of "
-"visitors to the site.  <a href=\"%(md_url)s\">mozdev.org</a> offers free "
-"project hosting for Mozilla applications and extensions providing developers"
-" with tools to help manage source code, version control, bug tracking and "
-"documentation."
+"Yes. Many developers choose to host their own add-ons. Choosing to host your add-on on <a href=\"%(amo_url)s\">Mozilla's add-on site</a>, though, allows for much greater exposure to your add-on due "
+"to the large volume of visitors to the site. <a href=\"%(md_url)s\">mozdev.org</a> offers free project hosting for Mozilla applications and extensions providing developers with tools to help manage "
+"source code, version control, bug tracking and documentation."
 msgstr ""
-"Da.  Mnogi razvijalci sami gostujejo svoje dodatke.  Po drugi strani "
-"gostovanje dodatka na <a href=\"%(amo_url)s\">Mozillini stani za dodatke</a>"
-" omogoča večjo izpostavljenost dodatka zaradi večjega obiska strani.  <a "
-"href=\"%(md_url)s\">mozdev.org</a> nudi brezplačno gostovanje projektov za "
-"Mozilline aplikacije in razširitve in razvijalcem ponuja orodja za pomoč pri"
-" upravljanju z izvorno kodo, nadzorom različic, sledenjem hroščev in "
-"dokumentacijo."
+"Da.  Mnogi razvijalci sami gostujejo svoje dodatke.  Po drugi strani gostovanje dodatka na <a href=\"%(amo_url)s\">Mozillini stani za dodatke</a> omogoča večjo izpostavljenost dodatka zaradi "
+"večjega obiska strani.  <a href=\"%(md_url)s\">mozdev.org</a> nudi brezplačno gostovanje projektov za Mozilline aplikacije in razširitve in razvijalcem ponuja orodja za pomoč pri upravljanju z "
+"izvorno kodo, nadzorom različic, sledenjem hroščev in dokumentacijo."
 
 #: src/olympia/pages/templates/pages/dev_faq.html:277
 msgid "Can Mozilla host my add-on?"
@@ -12558,12 +9943,8 @@ msgstr "Ali Mozilla lahko gosti moj dodatek?"
 
 #: src/olympia/pages/templates/pages/dev_faq.html:279
 #, python-format
-msgid ""
-"Yes. You can host your add-on on <a href=\"%(url)s\">Mozilla's add-on "
-"website</a>."
-msgstr ""
-"Da. Dodatek lahko gostite na <a href=\"%(url)s\">Mozillini strani za "
-"dodatke</a>."
+msgid "Yes. You can host your add-on on <a href=\"%(url)s\">Mozilla's add-on website</a>."
+msgstr "Da. Dodatek lahko gostite na <a href=\"%(url)s\">Mozillini strani za dodatke</a>."
 
 #: src/olympia/pages/templates/pages/dev_faq.html:284
 msgid "What is AMO?"
@@ -12571,19 +9952,11 @@ msgstr "Kaj je AMO?"
 
 #: src/olympia/pages/templates/pages/dev_faq.html:286
 msgid ""
-"Mozilla's AMO (<a "
-"href=\"https://addons.mozilla.org\">https://addons.mozilla.org</a>) is the "
-"incubator that helps developers build, distribute, and support fantastic "
-"consumer products powered by Mozilla. It provides you the tools and "
-"infrastructure necessary to manage, host and expose your add-on to a massive"
-" base of Mozilla users."
+"Mozilla's AMO (<a href=\"https://addons.mozilla.org\">https://addons.mozilla.org</a>) is the incubator that helps developers build, distribute, and support fantastic consumer products powered by "
+"Mozilla. It provides you the tools and infrastructure necessary to manage, host and expose your add-on to a massive base of Mozilla users."
 msgstr ""
-"Mozillin AMO (<a "
-"href=\"https://addons.mozilla.org\">https://addons.mozilla.org</a>) je "
-"inkubator, ki razvijalcem pomaga graditi, distribuirati in podpirati "
-"fantastične izdelke na osnovi Mozille. Ponuja vam orodja in infrastrukturo, "
-"potrebno za upravljanje, gostovanje in izpostavljanje dodatka veliki skupini"
-" Mozillinih uporabnikov."
+"Mozillin AMO (<a href=\"https://addons.mozilla.org\">https://addons.mozilla.org</a>) je inkubator, ki razvijalcem pomaga graditi, distribuirati in podpirati fantastične izdelke na osnovi Mozille. "
+"Ponuja vam orodja in infrastrukturo, potrebno za upravljanje, gostovanje in izpostavljanje dodatka veliki skupini Mozillinih uporabnikov."
 
 #: src/olympia/pages/templates/pages/dev_faq.html:295
 msgid "Does Mozilla keep my account information private?"
@@ -12591,12 +9964,8 @@ msgstr "Ali Mozilla skrbi za zasebnost podatkov mojega računa?"
 
 #: src/olympia/pages/templates/pages/dev_faq.html:297
 #, python-format
-msgid ""
-"Yes. Our <a href=\"%(url)s\">Privacy Policy</a> describes how your "
-"information is managed by Mozilla."
-msgstr ""
-"Da. Naš <a href=\"%(url)s\">pravilnik o zasebnosti</a> opisuje, kaj Mozilla "
-"naredi z vašimi podatki."
+msgid "Yes. Our <a href=\"%(url)s\">Privacy Policy</a> describes how your information is managed by Mozilla."
+msgstr "Da. Naš <a href=\"%(url)s\">pravilnik o zasebnosti</a> opisuje, kaj Mozilla naredi z vašimi podatki."
 
 #: src/olympia/pages/templates/pages/dev_faq.html:302
 msgid "What are the \"developer tools\" listed on AMO?"
@@ -12604,34 +9973,24 @@ msgstr "Kaj so \"orodja za razvijalce\", navedena na AMO?"
 
 #: src/olympia/pages/templates/pages/dev_faq.html:304
 msgid ""
-"The \"Developer Tools\" dashboard is the area that provides you the tools to"
-" successfully manage your add-ons. It provides the functionality necessary "
-"to submit your add-ons to AMO, manage add-on information, and review "
-"statistics."
+"The \"Developer Tools\" dashboard is the area that provides you the tools to successfully manage your add-ons. It provides the functionality necessary to submit your add-ons to AMO, manage add-on "
+"information, and review statistics."
 msgstr ""
-"Nadzorna plošča \"Orodja za razvijalce\" je prostor z orodji, s katerimi "
-"uspešno upravljate svoje dodatke. Ponuja funkcije, potrebne, da pošljete "
-"dodatke na AMO, upravljate informacije o dodatku in si ogledate statistiko."
+"Nadzorna plošča \"Orodja za razvijalce\" je prostor z orodji, s katerimi uspešno upravljate svoje dodatke. Ponuja funkcije, potrebne, da pošljete dodatke na AMO, upravljate informacije o dodatku in "
+"si ogledate statistiko."
 
 #: src/olympia/pages/templates/pages/dev_faq.html:312
-msgid ""
-"Does Mozilla have a policy in place as to what is an acceptable submission?"
+msgid "Does Mozilla have a policy in place as to what is an acceptable submission?"
 msgstr "Ali ima Mozilla pravila glede tega, kaj je sprejemljivo za objavo?"
 
 #: src/olympia/pages/templates/pages/dev_faq.html:314
 #, python-format
 msgid ""
-"Yes. Mozilla's <a href=\"%(p_url)s\">Add-on Policy</a> describes what is an "
-"acceptable submission. This policy is subject to change without notice.  In "
-"addition, the AMO editorial team uses the <a href=\"%(g_url)s\">Editors "
-"Reviewing Guide</a> to ensure that your add-on meets specific guidelines for"
-" functionality and security."
+"Yes. Mozilla's <a href=\"%(p_url)s\">Add-on Policy</a> describes what is an acceptable submission. This policy is subject to change without notice. In addition, the AMO editorial team uses the <a "
+"href=\"%(g_url)s\">Editors Reviewing Guide</a> to ensure that your add-on meets specific guidelines for functionality and security."
 msgstr ""
-"Da.  Mozillin <a href=\"%(p_url)s\">Pravilnik za dodatke</a> opisuje, kaj je"
-" sprejemljivo pošiljanje.  Ta pravilnik je predmet sprememb brez obvestila."
-"  Poleg tega ekipa urednikov AMO uporablja <a href=\"%(g_url)s\">Vodnik "
-"urednikov za pregledovanje</a> zaradi zagotovitve, da dodatek ustreza "
-"določenim smernicam delovanja in varnosti."
+"Da.  Mozillin <a href=\"%(p_url)s\">Pravilnik za dodatke</a> opisuje, kaj je sprejemljivo pošiljanje.  Ta pravilnik je predmet sprememb brez obvestila.  Poleg tega ekipa urednikov AMO uporablja <a "
+"href=\"%(g_url)s\">Vodnik urednikov za pregledovanje</a> zaradi zagotovitve, da dodatek ustreza določenim smernicam delovanja in varnosti."
 
 #: src/olympia/pages/templates/pages/dev_faq.html:324
 msgid "How do I submit my add-on for review?"
@@ -12640,29 +9999,19 @@ msgstr "Kako pošljem svoj dodatek v pregled?"
 #: src/olympia/pages/templates/pages/dev_faq.html:326
 #, python-format
 msgid ""
-"The Developer Tools dashboard will allow you to upload and submit add-ons to"
-" AMO. You must be a registered AMO users before you can submit an add-on. "
-"Before submitting your add-on be sure to you have read the AMO <a "
-"href=\"%(url)s\">Editors Reviewing Guide</a> to ensure that your add-on has "
-"met the guidelines used by editors to review add-ons."
+"The Developer Tools dashboard will allow you to upload and submit add-ons to AMO. You must be a registered AMO users before you can submit an add-on. Before submitting your add-on be sure to you "
+"have read the AMO <a href=\"%(url)s\">Editors Reviewing Guide</a> to ensure that your add-on has met the guidelines used by editors to review add-ons."
 msgstr ""
-"Nadzorna plošča orodij za razvijalce vam bo omogočala naložiti in poslatii "
-"dodatke na AMO. Na AMO morate biti registriran uporabnik, preden lahko "
-"pošljete svoj dodatek. Preden pošljete dodatek, preberite <a "
-"href=\"%(url)s\">Vodnik za preglede za urednike</a>, da se prepričate, da "
-"vaš dodatek upošteva smernice, po katerih recenzenti pregledujejo dodatke."
+"Nadzorna plošča orodij za razvijalce vam bo omogočala naložiti in poslatii dodatke na AMO. Na AMO morate biti registriran uporabnik, preden lahko pošljete svoj dodatek. Preden pošljete dodatek, "
+"preberite <a href=\"%(url)s\">Vodnik za preglede za urednike</a>, da se prepričate, da vaš dodatek upošteva smernice, po katerih recenzenti pregledujejo dodatke."
 
 #: src/olympia/pages/templates/pages/dev_faq.html:336
 msgid "What operating system do I choose for my add-on?"
 msgstr "Kateri operacijski sistem naj izberem za svoj dodatek?"
 
 #: src/olympia/pages/templates/pages/dev_faq.html:338
-msgid ""
-"You must choose the operating systems on which your add-on will successfully"
-" function."
-msgstr ""
-"Izbrati morate tudi operacijske sisteme, na katerih bo vaš dodatek uspešno "
-"deloval."
+msgid "You must choose the operating systems on which your add-on will successfully function."
+msgstr "Izbrati morate tudi operacijske sisteme, na katerih bo vaš dodatek uspešno deloval."
 
 #: src/olympia/pages/templates/pages/dev_faq.html:344
 msgid "What category do I choose for my add-on?"
@@ -12670,57 +10019,35 @@ msgstr "Za katero kategorijo naj se odločim pri svojem dodatku?"
 
 #: src/olympia/pages/templates/pages/dev_faq.html:346
 msgid ""
-"The choice of category is dependent on what type of audience you are "
-"targeting and the functionality of your add-on. If you're unsure of which "
-"category your add-on falls into, please choose \"Other\". The AMO team may "
-"re-categorize your add-on if it's determined that it's better suited in a "
-"different category."
+"The choice of category is dependent on what type of audience you are targeting and the functionality of your add-on. If you're unsure of which category your add-on falls into, please choose \"Other"
+"\". The AMO team may re-categorize your add-on if it's determined that it's better suited in a different category."
 msgstr ""
-"Izbira kategorije je odvisna od tega, na katero skupino uporabnikov ciljate "
-"in od funkcionalnosti vašega dodatka. Če niste prepričani, v katero "
-"kategorijo spada vaš dodatek, izberite \"Drugo\". Ekipa AMO bo morda "
-"spremenila kategorijo vašega dodatka, če se ji bo zdelo, da bolje spada v "
-"kako drugo kategorijo."
+"Izbira kategorije je odvisna od tega, na katero skupino uporabnikov ciljate in od funkcionalnosti vašega dodatka. Če niste prepričani, v katero kategorijo spada vaš dodatek, izberite \"Drugo\". "
+"Ekipa AMO bo morda spremenila kategorijo vašega dodatka, če se ji bo zdelo, da bolje spada v kako drugo kategorijo."
 
 #: src/olympia/pages/templates/pages/dev_faq.html:355
 msgid "What does \"nominating\" my add-on mean?"
 msgstr "Kaj pomeni, da je moj dodatek \"nominiran\"?"
 
 #: src/olympia/pages/templates/pages/dev_faq.html:357
-msgid ""
-"Nominated add-ons are new add-ons that the author has nominated to become "
-"public via the Developer Tools."
-msgstr ""
-"Nominirani dodatki so novi dodatki, ki jih je njih avtor nominiral za "
-"javnost v okviru Orodij za razvijalce."
+msgid "Nominated add-ons are new add-ons that the author has nominated to become public via the Developer Tools."
+msgstr "Nominirani dodatki so novi dodatki, ki jih je njih avtor nominiral za javnost v okviru Orodij za razvijalce."
 
 #: src/olympia/pages/templates/pages/dev_faq.html:363
 msgid "Can I specify a license agreement for using my add-on?"
 msgstr "Ali za uporabo svojega dodatka navedem licenčno pogodbo?"
 
 #: src/olympia/pages/templates/pages/dev_faq.html:365
-msgid ""
-"Yes. You can specify a license agreement when submitting your add-on. You "
-"can also add or update a license agreement via the Developer Tools dashboard"
-" after your add-on has been submitted."
-msgstr ""
-"Da. Ob pošiljanju dodatka lahko določite licenčno pogodbo. Licenčno pogodbo "
-"lahko tudi dodate ali posodobite z nadzorno ploščo orodij za razvijalce "
-"potem, ko je vaš dodatek že poslan."
+msgid "Yes. You can specify a license agreement when submitting your add-on. You can also add or update a license agreement via the Developer Tools dashboard after your add-on has been submitted."
+msgstr "Da. Ob pošiljanju dodatka lahko določite licenčno pogodbo. Licenčno pogodbo lahko tudi dodate ali posodobite z nadzorno ploščo orodij za razvijalce potem, ko je vaš dodatek že poslan."
 
 #: src/olympia/pages/templates/pages/dev_faq.html:372
 msgid "Can I include a privacy policy for my add-on?"
 msgstr "Ali za uporabo svojega dodatka navedem politiko zasebnosti?"
 
 #: src/olympia/pages/templates/pages/dev_faq.html:374
-msgid ""
-"Yes. You can specify a privacy policy when submitting your add-on. You can "
-"also add or update a privacy policy via the Developer Tools dashboard after "
-"your add-on has been submitted."
-msgstr ""
-"Da. Ob pošiljanju dodatka lahko določite politiko zasebnosti. Politiko "
-"zasebnosti lahko tudi dodate ali posodobite s nadzorno ploščo orodij za "
-"razvijalce potem, ko je vaš dodatek že poslan."
+msgid "Yes. You can specify a privacy policy when submitting your add-on. You can also add or update a privacy policy via the Developer Tools dashboard after your add-on has been submitted."
+msgstr "Da. Ob pošiljanju dodatka lahko določite politiko zasebnosti. Politiko zasebnosti lahko tudi dodate ali posodobite s nadzorno ploščo orodij za razvijalce potem, ko je vaš dodatek že poslan."
 
 #: src/olympia/pages/templates/pages/dev_faq.html:383
 msgid "Why must my add-on be reviewed?"
@@ -12729,15 +10056,11 @@ msgstr "Zakaj je treba moj dodatek pregledati?"
 #: src/olympia/pages/templates/pages/dev_faq.html:385
 #, python-format
 msgid ""
-"All add-ons submitted, whether new or updated, are reviewed to ensure that "
-"Mozilla users have a stable and safe experience. All add-ons submissions are"
-" reviewed using the guidelines outlined in the <a href=\"%(url)s\">Editors "
-"Reviewing Guide</a>."
+"All add-ons submitted, whether new or updated, are reviewed to ensure that Mozilla users have a stable and safe experience. All add-ons submissions are reviewed using the guidelines outlined in the "
+"<a href=\"%(url)s\">Editors Reviewing Guide</a>."
 msgstr ""
-"Vsi poslani dodatki, novi in posodobljeni, so pregledani, da Mozillinim "
-"uporabnikom zagotovimo stabilno in varno uporabo. Vsa pošiljanja dodatkov so"
-" pregledana s smernicami, opisanimi v <a href=\"%(url)s\">Vodniku za "
-"preglede za urednike</a>."
+"Vsi poslani dodatki, novi in posodobljeni, so pregledani, da Mozillinim uporabnikom zagotovimo stabilno in varno uporabo. Vsa pošiljanja dodatkov so pregledana s smernicami, opisanimi v <a href="
+"\"%(url)s\">Vodniku za preglede za urednike</a>."
 
 #: src/olympia/pages/templates/pages/dev_faq.html:393
 msgid "Who reviews my add-on?"
@@ -12746,19 +10069,13 @@ msgstr "Kdo bo pregledal moj dodatek?"
 #: src/olympia/pages/templates/pages/dev_faq.html:395
 #, python-format
 msgid ""
-"Add-ons are reviewed by the AMO Editors, a group of talented developers that"
-" volunteer to help the Mozilla project by reviewing add-ons to ensure a "
-"stable and safe experience for Mozilla users. When communicating with "
-"editors, please be courteous, patient and respectful as they are working "
-"hard to ensure that your add-on is set up correctly and follows the "
-"guidelines outlined in the <a href=\"%(url)s\">Editors Reviewing Guide</a>."
+"Add-ons are reviewed by the AMO Editors, a group of talented developers that volunteer to help the Mozilla project by reviewing add-ons to ensure a stable and safe experience for Mozilla users. "
+"When communicating with editors, please be courteous, patient and respectful as they are working hard to ensure that your add-on is set up correctly and follows the guidelines outlined in the <a "
+"href=\"%(url)s\">Editors Reviewing Guide</a>."
 msgstr ""
-"Dodatke pregledajo uredniki AMO, skupina talentiranih razvijalcev, ki "
-"prostovoljno pomagajo v projektu Mozilla s pregledovanjem dodatkov, da "
-"uporabnikom zagotovijo stabilno in varno izkušnjo. Ko komunicirate z "
-"uredniki, bodite vljudni, strpni in spoštljivi, saj trdo delajo, da "
-"zagotovijo, da je vaš dodatek pravilno narejen in spoštuje smernice, opisane"
-" v <a href=\"%(url)s\">Vodniku za preglede za urednike</a>."
+"Dodatke pregledajo uredniki AMO, skupina talentiranih razvijalcev, ki prostovoljno pomagajo v projektu Mozilla s pregledovanjem dodatkov, da uporabnikom zagotovijo stabilno in varno izkušnjo. Ko "
+"komunicirate z uredniki, bodite vljudni, strpni in spoštljivi, saj trdo delajo, da zagotovijo, da je vaš dodatek pravilno narejen in spoštuje smernice, opisane v <a href=\"%(url)s\">Vodniku za "
+"preglede za urednike</a>."
 
 #: src/olympia/pages/templates/pages/dev_faq.html:406
 msgid "What are the guidelines used to review my add-on?"
@@ -12767,29 +10084,19 @@ msgstr "Kakšne smernice se uporablja pri pregledu mojega dodatka?"
 #: src/olympia/pages/templates/pages/dev_faq.html:408
 #, python-format
 msgid ""
-"The Mozilla editorial team follows the <a href=\"%(url)s\">Editors Reviewing"
-" Guide</a> when testing an add-on for acceptance onto AMO. It is important "
-"that add-on developers review this guide to ensure that common problem areas"
-" are addressed prior to submitting their add-on for review. This will "
-"greatly assist in expediting the review process."
+"The Mozilla editorial team follows the <a href=\"%(url)s\">Editors Reviewing Guide</a> when testing an add-on for acceptance onto AMO. It is important that add-on developers review this guide to "
+"ensure that common problem areas are addressed prior to submitting their add-on for review. This will greatly assist in expediting the review process."
 msgstr ""
-"Kadar preskuša dodatke za sprejem na AMO, ekipa pregledovalcev Mozilla sledi"
-" smernicam vodnika <a href=\"%(url)s\">Editors Reviewing Guide</a>. Pomembno"
-" je, da razvijalci dodatkov pred pošiljanjem svojih dodatkov za pregled "
-"pregledajo ta vodnik, da zagotovijo obravnavo področja splošnih težav. To bo"
-" zelo pomagalo pri pospeševanju procesa pregleda."
+"Kadar preskuša dodatke za sprejem na AMO, ekipa pregledovalcev Mozilla sledi smernicam vodnika <a href=\"%(url)s\">Editors Reviewing Guide</a>. Pomembno je, da razvijalci dodatkov pred pošiljanjem "
+"svojih dodatkov za pregled pregledajo ta vodnik, da zagotovijo obravnavo področja splošnih težav. To bo zelo pomagalo pri pospeševanju procesa pregleda."
 
 #: src/olympia/pages/templates/pages/dev_faq.html:418
 msgid "How long will it take for my add-on to be reviewed?"
 msgstr "Kako dolgo bo trajalo, preden bo moj dodatek pregledan?"
 
 #: src/olympia/pages/templates/pages/dev_faq.html:420
-msgid ""
-"We cannot give a time estimate as to how long it will take before an add-on "
-"is reviewed. Many factors affect the time including the:"
-msgstr ""
-"Ne moremo reči, koliko časa bo trajal pregled dodatka. Na ta čas vpliva "
-"veliko dejavnikov, na primer:"
+msgid "We cannot give a time estimate as to how long it will take before an add-on is reviewed. Many factors affect the time including the:"
+msgstr "Ne moremo reči, koliko časa bo trajal pregled dodatka. Na ta čas vpliva veliko dejavnikov, na primer:"
 
 #. part of a list (<li>)
 #: src/olympia/pages/templates/pages/dev_faq.html:427
@@ -12809,30 +10116,19 @@ msgstr "število odkritih problematičnih območij"
 #: src/olympia/pages/templates/pages/dev_faq.html:434
 #, python-format
 msgid ""
-"This is why it's very important to read the <a href=\"%(g_url)s\">Editors "
-"Reviewing Guide</a> to ensure that your add-on is setup as expected.  It's "
-"also a good idea to read the blog post, <a "
-"href=\"%(blog_url)s\">Successfully Getting your Add-on Reviewed</a> which "
-"provides excellent insight into ensuring a smooth review of your add-on."
+"This is why it's very important to read the <a href=\"%(g_url)s\">Editors Reviewing Guide</a> to ensure that your add-on is setup as expected. It's also a good idea to read the blog post, <a href="
+"\"%(blog_url)s\">Successfully Getting your Add-on Reviewed</a> which provides excellent insight into ensuring a smooth review of your add-on."
 msgstr ""
-"Zaradi tega je zelo pomembno, da preberete <a href=\"%(g_url)s\">Vodnik "
-"urednikov za pregledovanje</a> zaradi zagotovitve, da je vaš dodatek "
-"ustrezno nastavljen.  Pametno je tudi prebrati objavo bloga <a "
-"href=\"%(blog_url)s\">Successfully Getting your Add-on Reviewed</a>, ki nudi"
-" izvrsten vpogled v zagotovitev tekočega pregleda vašega dodatka."
+"Zaradi tega je zelo pomembno, da preberete <a href=\"%(g_url)s\">Vodnik urednikov za pregledovanje</a> zaradi zagotovitve, da je vaš dodatek ustrezno nastavljen.  Pametno je tudi prebrati objavo "
+"bloga <a href=\"%(blog_url)s\">Successfully Getting your Add-on Reviewed</a>, ki nudi izvrsten vpogled v zagotovitev tekočega pregleda vašega dodatka."
 
 #: src/olympia/pages/templates/pages/dev_faq.html:446
 msgid "How can I see how many times my add-on has been downloaded?"
 msgstr "Kako lahko vidim. kolikokrat se je preneslo moj dodatek?"
 
 #: src/olympia/pages/templates/pages/dev_faq.html:448
-msgid ""
-"The Statistics Dashboard found in the Developer Tools dashboard provides "
-"information that can help you determine your add-on downloads since you've "
-"submitted it to AMO."
-msgstr ""
-"Nadzorna plošča za statistiko v okviru Orodij za razvijalce vsebuje podatke "
-"o številu prenosov od trenutka, ko ste dodatek poslali na AMO."
+msgid "The Statistics Dashboard found in the Developer Tools dashboard provides information that can help you determine your add-on downloads since you've submitted it to AMO."
+msgstr "Nadzorna plošča za statistiko v okviru Orodij za razvijalce vsebuje podatke o številu prenosov od trenutka, ko ste dodatek poslali na AMO."
 
 #: src/olympia/pages/templates/pages/dev_faq.html:455
 msgid "How can I see how many active users are using my add-on?"
@@ -12840,27 +10136,17 @@ msgstr "Kako lahko vidim, koliko aktivnih uporabnikov uporablja moj dodatek?"
 
 #: src/olympia/pages/templates/pages/dev_faq.html:457
 msgid ""
-"The Statistics Dashboard found in the Developer Tools dashboard provides "
-"information that can help you determine how many users have been actively "
-"using your add-on since you've submitted it to AMO."
-msgstr ""
-"Nadzorna plošča za statistiko v okviru nadzorne plošče orodij za razvijalce "
-"vsebuje podatke o številu dejavnih uporabnikov vašega dodatka od trenutka, "
-"ko ste ga poslali na AMO."
+"The Statistics Dashboard found in the Developer Tools dashboard provides information that can help you determine how many users have been actively using your add-on since you've submitted it to AMO."
+msgstr "Nadzorna plošča za statistiko v okviru nadzorne plošče orodij za razvijalce vsebuje podatke o številu dejavnih uporabnikov vašega dodatka od trenutka, ko ste ga poslali na AMO."
 
 #: src/olympia/pages/templates/pages/dev_faq.html:464
 msgid "How do I submit an update for my add-on?"
 msgstr "Kako naj pošljem posodobitev za svoj dodatek?"
 
 #: src/olympia/pages/templates/pages/dev_faq.html:466
-msgid ""
-"You can submit an update for your add-on via the Developer Tools dashboard "
-"by choosing the option \"Upload a new version\" and uploading a new .xpi "
-"file for your add-on."
+msgid "You can submit an update for your add-on via the Developer Tools dashboard by choosing the option \"Upload a new version\" and uploading a new .xpi file for your add-on."
 msgstr ""
-"Posodobitev za svoj dodatek lahko pošljete preko nadzorne plošče orodij za "
-"razvijalce, izberite na njej možnost \"Prenos nove različice\" in prenesite "
-"potem novo datoteko .xpi za svoj dodatek."
+"Posodobitev za svoj dodatek lahko pošljete preko nadzorne plošče orodij za razvijalce, izberite na njej možnost \"Prenos nove različice\" in prenesite potem novo datoteko .xpi za svoj dodatek."
 
 #: src/olympia/pages/templates/pages/dev_faq.html:473
 msgid "Does my update need to be reviewed by editors?"
@@ -12868,46 +10154,32 @@ msgstr "Ali morajo mojo posodobitev uredniki pregledati?"
 
 #: src/olympia/pages/templates/pages/dev_faq.html:475
 msgid ""
-"That depends. If you are simply changing a description of your add-on or "
-"updating a \"maxVersion\" to ensure compatibility with a new Mozilla "
-"software update, then your add-on does not need to be reviewed again. If, "
-"however, you submit a new updated file, then your add-on update will need to"
-" be reviewed by an editor."
+"That depends. If you are simply changing a description of your add-on or updating a \"maxVersion\" to ensure compatibility with a new Mozilla software update, then your add-on does not need to be "
+"reviewed again. If, however, you submit a new updated file, then your add-on update will need to be reviewed by an editor."
 msgstr ""
-"To je odvisno. Če ste samo spremenili opis dodatka ali posodobili "
-"\"maxVersion\" za združljivost z novo različico programa, dodatka ni "
-"potrebno ponovno pregledati. Če pa ste naložili novo posodobljeno datoteko, "
-"bo posodobitev vašega dodatka pregledal urednik."
+"To je odvisno. Če ste samo spremenili opis dodatka ali posodobili \"maxVersion\" za združljivost z novo različico programa, dodatka ni potrebno ponovno pregledati. Če pa ste naložili novo "
+"posodobljeno datoteko, bo posodobitev vašega dodatka pregledal urednik."
 
 #: src/olympia/pages/templates/pages/dev_faq.html:486
-msgid ""
-"How do I reply to a user who has posted a negative review of my add-on?"
-msgstr ""
-"Kako odgovoriti uporabniku, ki je objavil negativno mnenje o mojem dodatku?"
+msgid "How do I reply to a user who has posted a negative review of my add-on?"
+msgstr "Kako odgovoriti uporabniku, ki je objavil negativno mnenje o mojem dodatku?"
 
 #: src/olympia/pages/templates/pages/dev_faq.html:488
-msgid ""
-"A developer may reply to any review posted to their add-on as long as they "
-"are logged into AMO. In addition, any user can flag a review as:"
-msgstr ""
-"Razvijalec lahko odgovori na katerokoli oceno njegovega dodatka, dokler so "
-"prijavljeni v AMO. Katerikoli uporabnik lahko tudi označi oceno kot:"
+msgid "A developer may reply to any review posted to their add-on as long as they are logged into AMO. In addition, any user can flag a review as:"
+msgstr "Razvijalec lahko odgovori na katerokoli oceno njegovega dodatka, dokler so prijavljeni v AMO. Katerikoli uporabnik lahko tudi označi oceno kot:"
 
 #. part of a list (<li>)
-#: src/olympia/pages/templates/pages/dev_faq.html:495
-#: src/olympia/reviews/models.py:159
+#: src/olympia/pages/templates/pages/dev_faq.html:495 src/olympia/reviews/models.py:159
 msgid "Spam or otherwise non-review content"
 msgstr "Oglasi ali druga vsebina, ki ni ocena"
 
 #. part of a list (<li>)
-#: src/olympia/pages/templates/pages/dev_faq.html:497
-#: src/olympia/reviews/models.py:160
+#: src/olympia/pages/templates/pages/dev_faq.html:497 src/olympia/reviews/models.py:160
 msgid "Inappropriate language/dialog"
 msgstr "Neprimeren jezik/dialog"
 
 #. part of a list (<li>)
-#: src/olympia/pages/templates/pages/dev_faq.html:499
-#: src/olympia/reviews/models.py:161
+#: src/olympia/pages/templates/pages/dev_faq.html:499 src/olympia/reviews/models.py:161
 msgid "Misplaced bug report or support request"
 msgstr "Založeno poročilo o napaki ali zahteva za podporo"
 
@@ -12917,124 +10189,72 @@ msgid "Other (provides a pop-up prompt for information)"
 msgstr "Drugo (nudi spustno okno za informacije)"
 
 #: src/olympia/pages/templates/pages/dev_faq.html:504
-msgid ""
-"Currently, AMO does not provide a mechanism to directly communicate with a "
-"reviewer but this feature is being investigated and considered for a future "
-"update."
-msgstr ""
-"Trenutno AMO ne nudi mehanizma za neposredno komunikacijo z recenzentom, "
-"vendar se o tej temi razmišlja kot o možnosti za eno od bodočih različic."
+msgid "Currently, AMO does not provide a mechanism to directly communicate with a reviewer but this feature is being investigated and considered for a future update."
+msgstr "Trenutno AMO ne nudi mehanizma za neposredno komunikacijo z recenzentom, vendar se o tej temi razmišlja kot o možnosti za eno od bodočih različic."
 
 #: src/olympia/pages/templates/pages/dev_faq.html:511
 msgid "Can I request that a review be removed if the review is negative?"
 msgstr "Ali lahko zahtevam, da se oceno odstrani, če je negativna?"
 
 #: src/olympia/pages/templates/pages/dev_faq.html:513
-msgid ""
-"No. We do not remove negative reviews from add-ons unless they are found to "
-"be false."
-msgstr ""
-"Ne. Negativnih ocen iz dodatkov ne odstranjujemo, razen če se ugotovi, da so"
-" napačne."
+msgid "No. We do not remove negative reviews from add-ons unless they are found to be false."
+msgstr "Ne. Negativnih ocen iz dodatkov ne odstranjujemo, razen če se ugotovi, da so napačne."
 
 #: src/olympia/pages/templates/pages/dev_faq.html:519
 msgid "Can I request that a review be removed if the review is inaccurate?"
 msgstr "Ali lahko zahtevam, da se oceno odstrani, če je netočna?"
 
 #: src/olympia/pages/templates/pages/dev_faq.html:521
-msgid ""
-"If an author contacts us and asks for a review containing false or "
-"inaccurate information to be removed, we will review the post and consider "
-"removing it."
-msgstr ""
-"Če se avtor obrne na nas in prosi, da se oceno, ki vsebuje lažne ali netočne"
-" podatke, odstrani, si bomo objavo ogledali, da vidimo, ali jo je treba "
-"odstraniti."
+msgid "If an author contacts us and asks for a review containing false or inaccurate information to be removed, we will review the post and consider removing it."
+msgstr "Če se avtor obrne na nas in prosi, da se oceno, ki vsebuje lažne ali netočne podatke, odstrani, si bomo objavo ogledali, da vidimo, ali jo je treba odstraniti."
 
 #: src/olympia/pages/templates/pages/dev_faq.html:530
 msgid ""
-"Do you need more information about the various open source licenses? Are you"
-" confused as to which license you should select? What rights does a specific"
-" license grant? While nothing replaces reading the full terms of a license, "
-"below are some sites that contain information about some of the key open "
-"source licenses that may help you sort out the differences between them. "
-"These sites are being provided solely for your convenience and as a "
-"reference for your personal use. These resources do not constitute legal "
-"advice nor should they be used in lieu of such advice. Mozilla neither "
-"guarantees nor is responsible for the content of these sites or your "
-"reliance on such content."
+"Do you need more information about the various open source licenses? Are you confused as to which license you should select? What rights does a specific license grant? While nothing replaces "
+"reading the full terms of a license, below are some sites that contain information about some of the key open source licenses that may help you sort out the differences between them. These sites "
+"are being provided solely for your convenience and as a reference for your personal use. These resources do not constitute legal advice nor should they be used in lieu of such advice. Mozilla "
+"neither guarantees nor is responsible for the content of these sites or your reliance on such content."
 msgstr ""
-"Potrebujete več informacij o različnih odprtokodnih licencah? Se ne morete "
-"odločiti, katero licenco bi izbrali? Katere pravice dopušča določena "
-"licenca? Čeprav nič ne more nadomestiti branja popolnih pogojev licence, je "
-"spodaj nekaj strani, ki vsebujejo informacije o nekaterih ključnih "
-"odprtokodnih licencah, ki vam lahko pomagajo razumeti razlike med njimi. Te "
-"strani vam nudimo izključno za vašo informacijo in kot napotke za vašo "
-"osebno uporabo. Ti viri ne predstavljajo pravnih določil, niti ne smejo biti"
-" uporabljeni namesto takšnih določil. Mozilla ne garantira niti ni odgovorna"
-" za vsebino teh strani ali vaše zanašanje na to vsebino."
+"Potrebujete več informacij o različnih odprtokodnih licencah? Se ne morete odločiti, katero licenco bi izbrali? Katere pravice dopušča določena licenca? Čeprav nič ne more nadomestiti branja "
+"popolnih pogojev licence, je spodaj nekaj strani, ki vsebujejo informacije o nekaterih ključnih odprtokodnih licencah, ki vam lahko pomagajo razumeti razlike med njimi. Te strani vam nudimo "
+"izključno za vašo informacijo in kot napotke za vašo osebno uporabo. Ti viri ne predstavljajo pravnih določil, niti ne smejo biti uporabljeni namesto takšnih določil. Mozilla ne garantira niti ni "
+"odgovorna za vsebino teh strani ali vaše zanašanje na to vsebino."
 
 #: src/olympia/pages/templates/pages/dev_faq.html:545
 msgid ""
-"In addition to the full text of the Mozilla Public License(\"MPL\"), this "
-"also provides an annotated version of the MPL and an <abbr "
-"title=\"Frequently Asked Questions\">FAQ</abbr> to help you if you want to "
-"use or distribute code licensed under it."
+"In addition to the full text of the Mozilla Public License(\"MPL\"), this also provides an annotated version of the MPL and an <abbr title=\"Frequently Asked Questions\">FAQ</abbr> to help you if "
+"you want to use or distribute code licensed under it."
 msgstr ""
-"Poleg celotnega besedila Mozilla Public License (\"MPL\") nudi tudi  "
-"komentirano različico MPL in <abbr title=\"Frequently Asked "
-"Questions\">FAQ</abbr> ki vam bodo v pomoč, če želite uporabljati ali širiti"
-" kodo, ki je pod to licenco."
+"Poleg celotnega besedila Mozilla Public License (\"MPL\") nudi tudi  komentirano različico MPL in <abbr title=\"Frequently Asked Questions\">FAQ</abbr> ki vam bodo v pomoč, če želite uporabljati "
+"ali širiti kodo, ki je pod to licenco."
 
 #: src/olympia/pages/templates/pages/dev_faq.html:559
-msgid ""
-"A table summarizing and comparing how some of the key open source licenses "
-"treat distributions, proprietary software linking, and redistribution of "
-"code with changes."
-msgstr ""
-"Tabela, ki povzema in primerja nekaj ključnih odprtokodnih licenc med seboj "
-"s stališča   distribucije, povezanosti z lastniško programsko opremo in "
-"nadaljnjega širjenja kode s spremembami."
+msgid "A table summarizing and comparing how some of the key open source licenses treat distributions, proprietary software linking, and redistribution of code with changes."
+msgstr "Tabela, ki povzema in primerja nekaj ključnih odprtokodnih licenc med seboj s stališča   distribucije, povezanosti z lastniško programsko opremo in nadaljnjega širjenja kode s spremembami."
 
 #: src/olympia/pages/templates/pages/dev_faq.html:572
 msgid ""
-"Free Software Foundation provides short summaries of the key open source "
-"licenses, including whether the license qualifies as a free software license"
-" or a copyleft license.  Also includes a discussion of what constitutes a "
-"free software license or a copyleft license (e.g., a Copyleft license is a "
-"general method for making a program or other work free, and requiring all "
-"modified and extended versions of the program to be free as well.)"
+"Free Software Foundation provides short summaries of the key open source licenses, including whether the license qualifies as a free software license or a copyleft license. Also includes a "
+"discussion of what constitutes a free software license or a copyleft license (e.g., a Copyleft license is a general method for making a program or other work free, and requiring all modified and "
+"extended versions of the program to be free as well.)"
 msgstr ""
-"Free Software Foundation nudi kratke povzetke ključnih odprtokodnih licenc "
-"vključno s prepoznavanjem licence kot licence brezplačne programske opreme "
-"ali licence Svobodnih avtorskih pravic (angl. copyleft).  Vključuje tudi "
-"razpravo o tem, kaj tvori licenco brezplačne programske opreme ali licenco "
-"Svobodnih avtorskih pravic (npr. licenca Svobodnih avtorskih pravic je "
-"splošen način za zahtevanje brezplačnosti programske opreme ali drugega dela"
-" kot tudi njenih spremenjenih in razširjenih različic)."
+"Free Software Foundation nudi kratke povzetke ključnih odprtokodnih licenc vključno s prepoznavanjem licence kot licence brezplačne programske opreme ali licence Svobodnih avtorskih pravic (angl. "
+"copyleft).  Vključuje tudi razpravo o tem, kaj tvori licenco brezplačne programske opreme ali licenco Svobodnih avtorskih pravic (npr. licenca Svobodnih avtorskih pravic je splošen način za "
+"zahtevanje brezplačnosti programske opreme ali drugega dela kot tudi njenih spremenjenih in razširjenih različic)."
 
 #: src/olympia/pages/templates/pages/dev_faq.html:589
-msgid ""
-"Open Source Initiative provides the terms of some of the key open source "
-"licenses."
-msgstr ""
-"Open Source Initiative nudi pogoje nekaterih ključnih odprtokodnih licenc."
+msgid "Open Source Initiative provides the terms of some of the key open source licenses."
+msgstr "Open Source Initiative nudi pogoje nekaterih ključnih odprtokodnih licenc."
 
 #: src/olympia/pages/templates/pages/dev_faq.html:599
 msgid "A comparison of known open source licenses on Wikipedia."
 msgstr "Primerjava znanih odprtokodnih licenc na Wikipediji."
 
 #: src/olympia/pages/templates/pages/dev_faq.html:605
-msgid ""
-"A site to provide non-judgmental guidance on choosing a license for your "
-"open source project."
-msgstr ""
-"Stran, ki dobavlja nepristranske smernice za izbiro licence za vaš "
-"odprtokodni projekt."
+msgid "A site to provide non-judgmental guidance on choosing a license for your open source project."
+msgstr "Stran, ki dobavlja nepristranske smernice za izbiro licence za vaš odprtokodni projekt."
 
-#: src/olympia/pages/templates/pages/faq.html:3
-#: src/olympia/pages/templates/pages/faq.html:9
-#: src/olympia/pages/templates/pages/faq.html:10
+#: src/olympia/pages/templates/pages/faq.html:3 src/olympia/pages/templates/pages/faq.html:9 src/olympia/pages/templates/pages/faq.html:10
 msgid "Frequently Asked Questions"
 msgstr "Pogosta vprašanja"
 
@@ -13049,18 +10269,11 @@ msgstr "Kaj je dodatek?"
 #: src/olympia/pages/templates/pages/faq.html:16
 #, python-format
 msgid ""
-"Add-ons are small pieces of software that add new features or functionality "
-"to your installation of %(app_name)s. Add-ons can augment %(app_name)s with "
-"new features, foreign language dictionaries, or change its visual "
-"appearance. Through add-ons, you can customize %(app_name)s to meet your "
-"needs and tastes. <a href=\"%(learnmore_url)s\">Learn more about "
-"customization</a>"
+"Add-ons are small pieces of software that add new features or functionality to your installation of %(app_name)s. Add-ons can augment %(app_name)s with new features, foreign language dictionaries, "
+"or change its visual appearance. Through add-ons, you can customize %(app_name)s to meet your needs and tastes. <a href=\"%(learnmore_url)s\">Learn more about customization</a>"
 msgstr ""
-"Dodatki so majhni koščki programske opreme, ki vaši namestitvi %(app_name)sa"
-" dodajo nove poteze in funkcionalnost. Dodatki lahko %(app_name)s razširijo "
-"z novimi funkcijami, s slovarji tujih jezikov, ali pa spremenijo njegov "
-"videz. S pomočjo dodatkov lahko prilagodite %(app_name)s svojim potrebam in "
-"okusu. <a href=\"%(learnmore_url)s\">Preberite več o prilagoditvah</a>"
+"Dodatki so majhni koščki programske opreme, ki vaši namestitvi %(app_name)sa dodajo nove poteze in funkcionalnost. Dodatki lahko %(app_name)s razširijo z novimi funkcijami, s slovarji tujih "
+"jezikov, ali pa spremenijo njegov videz. S pomočjo dodatkov lahko prilagodite %(app_name)s svojim potrebam in okusu. <a href=\"%(learnmore_url)s\">Preberite več o prilagoditvah</a>"
 
 #: src/olympia/pages/templates/pages/faq.html:26
 msgid "Will add-ons work with my web browser or application?"
@@ -13069,25 +10282,13 @@ msgstr "Bodo dodatki delali z mojim spletnim brskalnikom ali aplikacijo?"
 #: src/olympia/pages/templates/pages/faq.html:27
 #, python-format
 msgid ""
-"Add-ons listed in this gallery only work with Mozilla-based applications, "
-"such as <a href=\"%(getfirefox_url)s\">Firefox</a>, <a "
-"href=\"%(getmobile_url)s\">Firefox Mobile</a>, <a "
-"href=\"%(getseamonkey_url)s\">SeaMonkey</a>, and <a "
-"href=\"%(getthunderbird_url)s\">Thunderbird</a>. However, not all add-ons "
-"work with each of those applications or every version of those applications."
-" Each add-on specifies which applications and versions it works with, such "
-"as Firefox 2.0 - 3.6.*. For Firefox add-ons, the install buttons will "
-"indicate whether the add-on is compatible or not."
+"Add-ons listed in this gallery only work with Mozilla-based applications, such as <a href=\"%(getfirefox_url)s\">Firefox</a>, <a href=\"%(getmobile_url)s\">Firefox Mobile</a>, <a href="
+"\"%(getseamonkey_url)s\">SeaMonkey</a>, and <a href=\"%(getthunderbird_url)s\">Thunderbird</a>. However, not all add-ons work with each of those applications or every version of those applications. "
+"Each add-on specifies which applications and versions it works with, such as Firefox 2.0 - 3.6.*. For Firefox add-ons, the install buttons will indicate whether the add-on is compatible or not."
 msgstr ""
-"Dodatki, navedeni v tej galeriji, delajo samo s programi Mozille, kot so <a "
-"href=\"%(getfirefox_url)s\">Firefox</a>, <a "
-"href=\"%(getmobile_url)s\">mobilni Firefox</a>, <a "
-"href=\"%(getseamonkey_url)s\">SeaMonkey</a> in <a "
-"href=\"%(getthunderbird_url)s\">Thunderbird</a>. Vendar pa ne delajo vsi "
-"dodatki z vsakemu od programov oziroma z vsako različico. Vsak dodatek "
-"predpisuje, za katere programe in različice deluje, na primer za Firefox "
-"2.0-3.6.*. Za dodatke za Firefox bo gumb za namestitev navedel, ali je "
-"dodatek združljiv ali ne."
+"Dodatki, navedeni v tej galeriji, delajo samo s programi Mozille, kot so <a href=\"%(getfirefox_url)s\">Firefox</a>, <a href=\"%(getmobile_url)s\">mobilni Firefox</a>, <a href=\"%(getseamonkey_url)s"
+"\">SeaMonkey</a> in <a href=\"%(getthunderbird_url)s\">Thunderbird</a>. Vendar pa ne delajo vsi dodatki z vsakemu od programov oziroma z vsako različico. Vsak dodatek predpisuje, za katere programe "
+"in različice deluje, na primer za Firefox 2.0-3.6.*. Za dodatke za Firefox bo gumb za namestitev navedel, ali je dodatek združljiv ali ne."
 
 #: src/olympia/pages/templates/pages/faq.html:42
 msgid "What are the different types of add-ons?"
@@ -13095,77 +10296,42 @@ msgstr "Katere različne vrste dodatkov obstajajo?"
 
 #: src/olympia/pages/templates/pages/faq.html:43
 #, python-format
-msgid ""
-"There are several kinds of add-ons that customize %(app_name)s in different "
-"ways:"
-msgstr ""
-"Obstaja več vrst dodatkov, ki na različne načine prilagajajo %(app_name)s:"
+msgid "There are several kinds of add-ons that customize %(app_name)s in different ways:"
+msgstr "Obstaja več vrst dodatkov, ki na različne načine prilagajajo %(app_name)s:"
 
 #: src/olympia/pages/templates/pages/faq.html:47
 #, python-format
 msgid ""
-"<strong><a href=\"%(browse_url)s\">Extensions</a></strong> add new features "
-"to %(app_name)s or modify existing functionality. There are extensions that "
-"allow you to block advertisements, download videos from websites, integrate "
-"more closely with social websites, and add features you see in other "
-"applications."
+"<strong><a href=\"%(browse_url)s\">Extensions</a></strong> add new features to %(app_name)s or modify existing functionality. There are extensions that allow you to block advertisements, download "
+"videos from websites, integrate more closely with social websites, and add features you see in other applications."
 msgstr ""
-"<strong><a href=\"%(browse_url)s\">Razširitve</a></strong> dodajajo "
-"%(app_name)su nove funkcije ali obstoječo funkcionalnost prilagajajo. "
-"Obstajajo razširitve, ki vam omogočajo, da blokirate oglase, prenašate "
-"videoposnetke s spletnih strani, se tesneje povežete z družabnimi spletnimi "
-"stranmi, ter dodate funkcije, ki jih vidite v drugih aplikacijah."
+"<strong><a href=\"%(browse_url)s\">Razširitve</a></strong> dodajajo %(app_name)su nove funkcije ali obstoječo funkcionalnost prilagajajo. Obstajajo razširitve, ki vam omogočajo, da blokirate "
+"oglase, prenašate videoposnetke s spletnih strani, se tesneje povežete z družabnimi spletnimi stranmi, ter dodate funkcije, ki jih vidite v drugih aplikacijah."
 
 #: src/olympia/pages/templates/pages/faq.html:55
 #, python-format
-msgid ""
-"<strong><a href=\"%(browse_url)s\">Complete Themes</a></strong> change the "
-"entire appearance of %(app_name)s, usually including icons, colors, dialogs,"
-" and other visual styles."
-msgstr ""
-"<strong><a href=\"%(browse_url)s\">Celotne teme</a></strong> spremenijo "
-"celoten videz %(app_name)sa, kar običajno vključuje ikone, barve, pogovorna "
-"okna in ostale vizualne sloge."
+msgid "<strong><a href=\"%(browse_url)s\">Complete Themes</a></strong> change the entire appearance of %(app_name)s, usually including icons, colors, dialogs, and other visual styles."
+msgstr "<strong><a href=\"%(browse_url)s\">Celotne teme</a></strong> spremenijo celoten videz %(app_name)sa, kar običajno vključuje ikone, barve, pogovorna okna in ostale vizualne sloge."
 
 #: src/olympia/pages/templates/pages/faq.html:61
 #, python-format
-msgid ""
-"<strong><a href=\"%(browse_url)s\">Themes</a></strong> are lightweight "
-"themes that use background images to customize your %(app_name)s toolbars."
-msgstr ""
-"<strong><a href=\"%(browse_url)s\">Teme</a></strong> so lahke teme, ki "
-"prilagodijo orodne vrstice %(app_name)sa s slikami za ozadje."
+msgid "<strong><a href=\"%(browse_url)s\">Themes</a></strong> are lightweight themes that use background images to customize your %(app_name)s toolbars."
+msgstr "<strong><a href=\"%(browse_url)s\">Teme</a></strong> so lahke teme, ki prilagodijo orodne vrstice %(app_name)sa s slikami za ozadje."
 
 #: src/olympia/pages/templates/pages/faq.html:66
 #, python-format
-msgid ""
-"<strong><a href=\"%(browse_url)s\">Search Providers</a> </strong> add "
-"additional choices to the search box dropdown. These providers allow you to "
-"quickly search any website."
-msgstr ""
-"<strong><a href=\"%(browse_url)s\">Iskalniki</a></strong> predstavljajo "
-"dodatne možnosti za spustno polje za iskanje. Ti ponudniki vam omogočajo "
-"hitro iskanje po spletnih straneh."
+msgid "<strong><a href=\"%(browse_url)s\">Search Providers</a> </strong> add additional choices to the search box dropdown. These providers allow you to quickly search any website."
+msgstr "<strong><a href=\"%(browse_url)s\">Iskalniki</a></strong> predstavljajo dodatne možnosti za spustno polje za iskanje. Ti ponudniki vam omogočajo hitro iskanje po spletnih straneh."
 
 #: src/olympia/pages/templates/pages/faq.html:72
 #, python-format
-msgid ""
-"<strong><a href=\"%(browse_url)s\">Dictionaries & Language "
-"Packs</a></strong> add support for additional languages to %(app_name)s."
-msgstr ""
-"<strong><a href=\"%(browse_url)s\">Slovarji in jezikovni paketi</a></strong>"
-" omogočajo podporo za dodatne jezike za %(app_name)s."
+msgid "<strong><a href=\"%(browse_url)s\">Dictionaries & Language Packs</a></strong> add support for additional languages to %(app_name)s."
+msgstr "<strong><a href=\"%(browse_url)s\">Slovarji in jezikovni paketi</a></strong> omogočajo podporo za dodatne jezike za %(app_name)s."
 
 #: src/olympia/pages/templates/pages/faq.html:77
 #, python-format
-msgid ""
-"<strong><a href=\"%(browse_url)s\">Plugins</a></strong> help %(app_name)s "
-"display or understand different types of media, such as Adobe Flash or Apple"
-" Quicktime."
-msgstr ""
-"<strong><a href=\"%(browse_url)s\">Vtičniki</a></strong> pomagajo, da "
-"%(app_name)s lahko prikaže ali razume različne vrste medijev, kot sta na "
-"primer Adobe Flash ali Apple Quicktime."
+msgid "<strong><a href=\"%(browse_url)s\">Plugins</a></strong> help %(app_name)s display or understand different types of media, such as Adobe Flash or Apple Quicktime."
+msgstr "<strong><a href=\"%(browse_url)s\">Vtičniki</a></strong> pomagajo, da %(app_name)s lahko prikaže ali razume različne vrste medijev, kot sta na primer Adobe Flash ali Apple Quicktime."
 
 #: src/olympia/pages/templates/pages/faq.html:85
 msgid "How do I install, manage, or remove an add-on?"
@@ -13174,22 +10340,13 @@ msgstr "Kako se namešča, upravlja ali odstranjuje dodatke?"
 #: src/olympia/pages/templates/pages/faq.html:86
 #, python-format
 msgid ""
-"In most cases, add-ons can be installed by simply clicking the install "
-"button provided. Add-ons can be managed, disabled, or uninstalled from the "
-"Add-ons Manager in %(app_name)s. For more detailed instructions, read <a "
-"href=\"%(extension_url)s\">this article on extensions</a> or <a "
-"href=\"%(theme_url)s\">this one for Themes and Complete Themes</a>. If you "
-"have difficulty installing add-ons, see <a "
-"href=\"%(troubleshooting_url)s\">Troubleshooting Extensions and Themes</a>."
+"In most cases, add-ons can be installed by simply clicking the install button provided. Add-ons can be managed, disabled, or uninstalled from the Add-ons Manager in %(app_name)s. For more detailed "
+"instructions, read <a href=\"%(extension_url)s\">this article on extensions</a> or <a href=\"%(theme_url)s\">this one for Themes and Complete Themes</a>. If you have difficulty installing add-ons, "
+"see <a href=\"%(troubleshooting_url)s\">Troubleshooting Extensions and Themes</a>."
 msgstr ""
-"V večini primerov lahko dodatek namestite tako, da preprosto kliknete na "
-"gumb, ki je na razpolago za nameščanje. Dodatke se urejuje, onemogoča ali "
-"odstranjuje v %(app_name)sovem Upravitelju dodatkov. Za podrobnejša navodila"
-" preberite <a href=\"%(extension_url)s\">ta članek za razširitve</a> ali pa "
-"<a href=\"%(theme_url)s\">tegale o temah in celotnih temah</a>. Če imate "
-"težave pri nameščanju dodatkov, glejte <a "
-"href=\"%(troubleshooting_url)s\">Odpravljanje težav pri razširitvah in "
-"temah</a>."
+"V večini primerov lahko dodatek namestite tako, da preprosto kliknete na gumb, ki je na razpolago za nameščanje. Dodatke se urejuje, onemogoča ali odstranjuje v %(app_name)sovem Upravitelju "
+"dodatkov. Za podrobnejša navodila preberite <a href=\"%(extension_url)s\">ta članek za razširitve</a> ali pa <a href=\"%(theme_url)s\">tegale o temah in celotnih temah</a>. Če imate težave pri "
+"nameščanju dodatkov, glejte <a href=\"%(troubleshooting_url)s\">Odpravljanje težav pri razširitvah in temah</a>."
 
 #: src/olympia/pages/templates/pages/faq.html:100
 msgid "How do I install add-ons without restarting Firefox?"
@@ -13198,17 +10355,11 @@ msgstr "Kako namestiti dodatke brez vnovičnega zagona Firefoxa?"
 #: src/olympia/pages/templates/pages/faq.html:101
 #, python-format
 msgid ""
-"In Firefox, add-ons marked with \"No restart required\" can be installed "
-"without restarting. These add-ons have been created using the <a "
-"href=\"%(sdk_url)s\">Add-on SDK</a> or <a "
-"href=\"%(bootstrap_url)s\">bootstrapping</a>. Other add-ons will still "
-"require a restart before you can use them."
+"In Firefox, add-ons marked with \"No restart required\" can be installed without restarting. These add-ons have been created using the <a href=\"%(sdk_url)s\">Add-on SDK</a> or <a href="
+"\"%(bootstrap_url)s\">bootstrapping</a>. Other add-ons will still require a restart before you can use them."
 msgstr ""
-"V Firefoxu je mogoče dodatke z oznako \"ponoven zagon ni potreben\" "
-"namestiti brez ponovnega zagona. Ti dodatki so bili razviti s pomočjo <a "
-"href=\"%(sdk_url)s\">SDK-ja  za dodatke</a> ali <a "
-"href=\"%(bootstrap_url)s\">začetnega nalaganja</a>. Drugi dodatki bodo še "
-"vedno zahtevali ponoven zagon, preden jih lahko uporabljate."
+"V Firefoxu je mogoče dodatke z oznako \"ponoven zagon ni potreben\" namestiti brez ponovnega zagona. Ti dodatki so bili razviti s pomočjo <a href=\"%(sdk_url)s\">SDK-ja  za dodatke</a> ali <a href="
+"\"%(bootstrap_url)s\">začetnega nalaganja</a>. Drugi dodatki bodo še vedno zahtevali ponoven zagon, preden jih lahko uporabljate."
 
 #: src/olympia/pages/templates/pages/faq.html:110
 msgid "How do I keep add-ons up-to-date?"
@@ -13217,22 +10368,13 @@ msgstr "Kako lahko poskrbim, da so dodatki na tekočem?"
 #: src/olympia/pages/templates/pages/faq.html:111
 #, python-format
 msgid ""
-"Add-ons, unlike plugins, are automatically checked for updates once every "
-"day. In Firefox, updates are automatically installed by default. Versions of"
-" Firefox prior to 4 (and other applications) will alert you that updates to "
-"your add-ons are available. <a href=\"%(plugin_url)s\">Plugins</a> are not "
-"currently automatically checked for updates, so be sure to regularly visit "
-"the <a href=\"%(plugincheck_url)s\">Plugin Check</a> page to stay up-to-"
-"date."
+"Add-ons, unlike plugins, are automatically checked for updates once every day. In Firefox, updates are automatically installed by default. Versions of Firefox prior to 4 (and other applications) "
+"will alert you that updates to your add-ons are available. <a href=\"%(plugin_url)s\">Plugins</a> are not currently automatically checked for updates, so be sure to regularly visit the <a href="
+"\"%(plugincheck_url)s\">Plugin Check</a> page to stay up-to-date."
 msgstr ""
-"Posodobitve za dodatke se za razliko od vtičnikov samodejno preverja enkrat "
-"na dan. Firefox ima privzeto nastavitev, da se posodobitve samodejno "
-"namešča. Različice Firefoxa pred 4 (in drugih aplikacij) vas bodo opozorile,"
-" da so za vaše dodatke na voljo posodobitve. Posodobitev <a "
-"href=\"%(plugin_url)s\">vtičnikov</a> se zaenkrat ne preverja samodejno, "
-"zato priporočamo, da redno obiskujete stran <a "
-"href=\"%(plugincheck_url)s\">Preverjanje vtičnikov</a> in tako ostanete na "
-"tekočem."
+"Posodobitve za dodatke se za razliko od vtičnikov samodejno preverja enkrat na dan. Firefox ima privzeto nastavitev, da se posodobitve samodejno namešča. Različice Firefoxa pred 4 (in drugih "
+"aplikacij) vas bodo opozorile, da so za vaše dodatke na voljo posodobitve. Posodobitev <a href=\"%(plugin_url)s\">vtičnikov</a> se zaenkrat ne preverja samodejno, zato priporočamo, da redno "
+"obiskujete stran <a href=\"%(plugincheck_url)s\">Preverjanje vtičnikov</a> in tako ostanete na tekočem."
 
 #: src/olympia/pages/templates/pages/faq.html:122
 msgid "Are add-ons safe to install?"
@@ -13241,20 +10383,13 @@ msgstr "Ali je dodatke varno namestiti?"
 #: src/olympia/pages/templates/pages/faq.html:123
 #, python-format
 msgid ""
-"Unless clearly marked otherwise, add-ons available from this gallery have "
-"been checked and approved by Mozilla's team of editors and are safe to "
-"install. We recommend that you only install approved add-ons. If you wish to"
-" install unapproved add-ons or add-ons from third-party websites, use "
-"caution as these add-ons may harm your computer or violate your privacy. <a "
-"href=\"%(learnmore_url)s\">Learn more about our approval process</a>"
+"Unless clearly marked otherwise, add-ons available from this gallery have been checked and approved by Mozilla's team of editors and are safe to install. We recommend that you only install approved "
+"add-ons. If you wish to install unapproved add-ons or add-ons from third-party websites, use caution as these add-ons may harm your computer or violate your privacy. <a href=\"%(learnmore_url)s"
+"\">Learn more about our approval process</a>"
 msgstr ""
-"Razen če ni jasno označeno drugače, je dodatke, ki so na voljo v tej "
-"galeriji, pregledala in odobrila skupina urednikov Mozille, tako da so "
-"dodatki varni za namestitev. Priporočamo vam, da nameščate samo odobrene "
-"dodatke. Če želite namestiti neodobrene dodatke ali dodatke s spletnih "
-"strani tretjih oseb, bodite previdni, saj ti dodatki lahko škodijo vašemu "
-"računalniku ali zlorabijo vašo zasebnost. <a href=\"%(learnmore_url)s\">Več "
-"o našem postopku odobritve</a>"
+"Razen če ni jasno označeno drugače, je dodatke, ki so na voljo v tej galeriji, pregledala in odobrila skupina urednikov Mozille, tako da so dodatki varni za namestitev. Priporočamo vam, da "
+"nameščate samo odobrene dodatke. Če želite namestiti neodobrene dodatke ali dodatke s spletnih strani tretjih oseb, bodite previdni, saj ti dodatki lahko škodijo vašemu računalniku ali zlorabijo "
+"vašo zasebnost. <a href=\"%(learnmore_url)s\">Več o našem postopku odobritve</a>"
 
 #: src/olympia/pages/templates/pages/faq.html:133
 #, python-format
@@ -13264,45 +10399,27 @@ msgstr "Ali lahko dodatki %(app_name)s upočasnijo?"
 #: src/olympia/pages/templates/pages/faq.html:135
 #, python-format
 msgid ""
-"Most add-ons do not cause a perceivable performance decrease in "
-"%(app_name)s, though installing an excessive number may have adverse "
-"effects. If you suspect an add-on is causing %(app_name)s to be slow, try "
-"disabling it."
+"Most add-ons do not cause a perceivable performance decrease in %(app_name)s, though installing an excessive number may have adverse effects. If you suspect an add-on is causing %(app_name)s to be "
+"slow, try disabling it."
 msgstr ""
-"Večina dodatkov ne povzroči zaznavnega zmanjšanja zmogljivosti v "
-"%(app_name)s, lahko pa ga povzroči namestitev prekomernega števila dodatkov."
-" Če sumite, da dodatek povzroča upočasnitev %(app_name)s, ga poskusite "
-"onemogočiti."
+"Večina dodatkov ne povzroči zaznavnega zmanjšanja zmogljivosti v %(app_name)s, lahko pa ga povzroči namestitev prekomernega števila dodatkov. Če sumite, da dodatek povzroča upočasnitev "
+"%(app_name)s, ga poskusite onemogočiti."
 
 #: src/olympia/pages/templates/pages/faq.html:141
 #, python-format
-msgid ""
-"%(app_name)s told me an add-on isn't compatible. Is there a way I can still "
-"use it?"
-msgstr ""
-"%(app_name)s mi je sporočil, da dodatek ni združljiv. Ali obstaja kak način,"
-" da ga vseeno uporabljam?"
+msgid "%(app_name)s told me an add-on isn't compatible. Is there a way I can still use it?"
+msgstr "%(app_name)s mi je sporočil, da dodatek ni združljiv. Ali obstaja kak način, da ga vseeno uporabljam?"
 
 #: src/olympia/pages/templates/pages/faq.html:144
 #, python-format
 msgid ""
-"If an add-on isn't compatible with your version of %(app_name)s, it is "
-"usually either because your version of %(app_name)s is outdated or the add-"
-"on author has not yet updated the add-on to be compatible with a newer "
-"version you are using. Mozilla does not recommend trying to circumvent these"
-" compatibility checks, as they can lead to browser instability or in some "
-"cases loss of data. For users who are testing out alpha or beta versions of "
-"Firefox, we offer the <a href=\"%(acr_url)s\">Add-on Compatibility "
-"Reporter</a> to help add-on developers update their compatibility."
+"If an add-on isn't compatible with your version of %(app_name)s, it is usually either because your version of %(app_name)s is outdated or the add-on author has not yet updated the add-on to be "
+"compatible with a newer version you are using. Mozilla does not recommend trying to circumvent these compatibility checks, as they can lead to browser instability or in some cases loss of data. For "
+"users who are testing out alpha or beta versions of Firefox, we offer the <a href=\"%(acr_url)s\">Add-on Compatibility Reporter</a> to help add-on developers update their compatibility."
 msgstr ""
-"Če dodatek ni združljiv z vašo različico %(app_name)s, je navadno vzrok "
-"bodisi, da je vaša različica %(app_name)sa zastarela, bodisi da avtor "
-"dodatka še ni posodobil do take mere, da bi bil združljiv z novejšo "
-"različico, ki jo uporabljate. Mozilla ne priporoča, da bi se preglede "
-"združljivosti skušalo obiti; posledica so lahko nestabilnost brskalnika ali "
-"v nekaterih primerih izguba podatkov. Za uporabnike, ki testirajo alfa ali "
-"beta različice Firefoxa, nudimo <a href=\"%(acr_url)s\">Poročevalca o "
-"združljivosti dodatkov</a>, ki razvijalcem dodatkov pomaga poskrbeti za "
+"Če dodatek ni združljiv z vašo različico %(app_name)s, je navadno vzrok bodisi, da je vaša različica %(app_name)sa zastarela, bodisi da avtor dodatka še ni posodobil do take mere, da bi bil "
+"združljiv z novejšo različico, ki jo uporabljate. Mozilla ne priporoča, da bi se preglede združljivosti skušalo obiti; posledica so lahko nestabilnost brskalnika ali v nekaterih primerih izguba "
+"podatkov. Za uporabnike, ki testirajo alfa ali beta različice Firefoxa, nudimo <a href=\"%(acr_url)s\">Poročevalca o združljivosti dodatkov</a>, ki razvijalcem dodatkov pomaga poskrbeti za "
 "združljivost njihovih izdelkov."
 
 #: src/olympia/pages/templates/pages/faq.html:156
@@ -13312,38 +10429,26 @@ msgstr "Kaj, če imam težave z dodatkom?"
 #: src/olympia/pages/templates/pages/faq.html:157
 #, python-format
 msgid ""
-"Add-ons are usually created by third-party developers from around the world,"
-" so the best way to get help with an add-on is to look for support links on "
-"the add-on's homepage or contact the developer. If you are having issues "
-"with %(app_name)s that you suspect are related to add-ons you have "
-"installed, <a href=\"%(troubleshooting_url)s\">visit this support "
-"article</a> for troubleshooting tips."
+"Add-ons are usually created by third-party developers from around the world, so the best way to get help with an add-on is to look for support links on the add-on's homepage or contact the "
+"developer. If you are having issues with %(app_name)s that you suspect are related to add-ons you have installed, <a href=\"%(troubleshooting_url)s\">visit this support article</a> for "
+"troubleshooting tips."
 msgstr ""
-"Dodatki običajno ustvarjajo neodvisni razvijalci z vsega sveta, tako da je "
-"pri problemih z dodatkom najbolje, če na domači strani dodatka poiščete "
-"povezavo za podporo ali pa se obrnete na razvijalca. Če ima %(app_name)s "
-"težave, za katere sumite, da so zvezane z dodatki, ki ste jih namestili, <a "
-"href=\"%(troubleshooting_url)s\">obiščite ta članek za podporo</a> z nasveti"
-" za odpravljanje težav."
+"Dodatki običajno ustvarjajo neodvisni razvijalci z vsega sveta, tako da je pri problemih z dodatkom najbolje, če na domači strani dodatka poiščete povezavo za podporo ali pa se obrnete na "
+"razvijalca. Če ima %(app_name)s težave, za katere sumite, da so zvezane z dodatki, ki ste jih namestili, <a href=\"%(troubleshooting_url)s\">obiščite ta članek za podporo</a> z nasveti za "
+"odpravljanje težav."
 
 #: src/olympia/pages/templates/pages/faq.html:169
 msgid "Add-on Gallery"
 msgstr "Galerija dodatkov"
 
 #: src/olympia/pages/templates/pages/faq.html:171
-msgid ""
-"How do I choose between add-ons that seem to do the same\n"
-"    thing?"
+msgid "How do I choose between add-ons that seem to do the same thing?"
 msgstr "Kako naj izbiram med dodatki, ki očitno delajo eno in isto?"
 
-#: src/olympia/pages/templates/pages/faq.html:173
+#: src/olympia/pages/templates/pages/faq.html:172
 msgid ""
-"There are often several add-ons that have similar features. To\n"
-"    figure out which is right for you, read the entire description of the\n"
-"    add-on and view its screenshots. If there are still several in the running,\n"
-"    read through the add-on's ratings, user reviews, and statistics to see\n"
-"    which is most liked by other users. Remember that you can also just try\n"
-"    out both and see which you like better."
+"There are often several add-ons that have similar features. To figure out which is right for you, read the entire description of the add-on and view its screenshots. If there are still several in "
+"the running, read through the add-on's ratings, user reviews, and statistics to see which is most liked by other users. Remember that you can also just try out both and see which you like better."
 msgstr ""
 "Pogosto obstaja več dodatkov, ki imajo podobne značilnosti.\n"
 "    Da ugotovite, kateri je pravi za vas, preberite celoten opis dodatka\n"
@@ -13359,37 +10464,24 @@ msgstr "Kaj, če ne najdem tega, kar iščem?"
 #: src/olympia/pages/templates/pages/faq.html:181
 #, python-format
 msgid ""
-"With thousands of add-ons available, there's something for everyone. But if "
-"you're looking for a particular add-on and can't find it, you might try "
-"searching on other sites or posting about it in our <a href=\"%(forum_url)s"
-"\">Add-ons </a>forum."
+"With thousands of add-ons available, there's something for everyone. But if you're looking for a particular add-on and can't find it, you might try searching on other sites or posting about it in "
+"our <a href=\"%(forum_url)s\">Add-ons </a>forum."
 msgstr ""
-"S tisoči objavljenih dodatkov je tu na voljo nekaj za vsakogar. Vendar če "
-"iščete določen dodatek in ga ne morete najti, ga lahko poiščete na drugih "
-"straneh ali o njem pišete v našem <a href=\"%(forum_url)s\">Forumu za "
-"dodatke</a>."
+"S tisoči objavljenih dodatkov je tu na voljo nekaj za vsakogar. Vendar če iščete določen dodatek in ga ne morete najti, ga lahko poiščete na drugih straneh ali o njem pišete v našem <a href="
+"\"%(forum_url)s\">Forumu za dodatke</a>."
 
 #: src/olympia/pages/templates/pages/faq.html:187
-msgid ""
-"What does it mean if an add-on is \"experimental\" or \"preliminarily "
-"reviewed\"?"
+msgid "What does it mean if an add-on is \"experimental\" or \"preliminarily reviewed\"?"
 msgstr "Kaj pomeni, če je dodatek \"eksperimentalen\" ali \"predhodno pregledan\"?"
 
 #: src/olympia/pages/templates/pages/faq.html:188
 #, python-format
 msgid ""
-"Experimental add-ons have been checked by our editors to make sure they "
-"don't have security problems, but they may still have bugs or not work "
-"properly. Use caution when installing experimental add-ons and uninstall the"
-" add-on immediately if you notice problems. <a href=\"%(url)s\">Learn more "
-"about our review process</a></dd>"
+"Experimental add-ons have been checked by our editors to make sure they don't have security problems, but they may still have bugs or not work properly. Use caution when installing experimental add-"
+"ons and uninstall the add-on immediately if you notice problems. <a href=\"%(url)s\">Learn more about our review process</a></dd>"
 msgstr ""
-"Eksperimentalne dodatke so naši uredniki preverili in se prepričali, da "
-"dodatki ne predstavljajo problemov, kar se varnosti tiče, vendar pa ti "
-"dodatki lahko še vedno imajo napake ali ne delujejo pravilno. Bodite "
-"previdni pri nameščanju eksperimentalnih dodatkov in jih tako odstranite, če"
-" naletite na težave. <a href=\"%(url)s\">Več o našem postopku "
-"pregledov</a></dd>"
+"Eksperimentalne dodatke so naši uredniki preverili in se prepričali, da dodatki ne predstavljajo problemov, kar se varnosti tiče, vendar pa ti dodatki lahko še vedno imajo napake ali ne delujejo "
+"pravilno. Bodite previdni pri nameščanju eksperimentalnih dodatkov in jih tako odstranite, če naletite na težave. <a href=\"%(url)s\">Več o našem postopku pregledov</a></dd>"
 
 #: src/olympia/pages/templates/pages/faq.html:196
 msgid "What does it mean if an add-on is \"not reviewed\"?"
@@ -13398,262 +10490,194 @@ msgstr "Kaj pomeni, če dodatek \"ni pregledan\"?"
 #: src/olympia/pages/templates/pages/faq.html:197
 #, python-format
 msgid ""
-"While all add-ons publicly available in our gallery are reviewed by an "
-"editor, you may receive a direct link to an add-on that hasn't yet been "
-"reviewed. Use caution when installing these add-ons, as they could harm your"
-" computer or violate your privacy. We recommend that you only install "
-"reviewed add-ons. <a href=\"%(url)s\">Learn more about our review "
-"process</a></dd>"
+"While all add-ons publicly available in our gallery are reviewed by an editor, you may receive a direct link to an add-on that hasn't yet been reviewed. Use caution when installing these add-ons, "
+"as they could harm your computer or violate your privacy. We recommend that you only install reviewed add-ons. <a href=\"%(url)s\">Learn more about our review process</a></dd>"
 msgstr ""
-"Vse dodatke, ki so na voljo javnosti v naši galeriji, je pregledal urednik, "
-"lahko pa da ste prejeli neposredno povezavo na dodatek, ki še ni pregledan. "
-"Bodite previdni pri namestitvi teh dodatkov, saj lahko škodujejo vašemu "
-"računalniku ali zlorabijo vašo zasebnost. Priporočamo vam, da nameščate samo"
-" dodatke, ki so pregledani. <a href=\"%(url)s\">Več o našem postopku "
-"pregledov</a></dd>"
+"Vse dodatke, ki so na voljo javnosti v naši galeriji, je pregledal urednik, lahko pa da ste prejeli neposredno povezavo na dodatek, ki še ni pregledan. Bodite previdni pri namestitvi teh dodatkov, "
+"saj lahko škodujejo vašemu računalniku ali zlorabijo vašo zasebnost. Priporočamo vam, da nameščate samo dodatke, ki so pregledani. <a href=\"%(url)s\">Več o našem postopku pregledov</a></dd>"
 
 #: src/olympia/pages/templates/pages/faq.html:206
 msgid "How much do add-ons cost to purchase?"
 msgstr "Koliko stanejo dodatki, če jih hočem kupiti?"
 
 #: src/olympia/pages/templates/pages/faq.html:207
-msgid ""
-"Add-ons hosted in our gallery are free unless clearly marked\n"
-"    otherwise."
+msgid "Add-ons hosted in our gallery are free unless clearly marked otherwise."
 msgstr ""
 "Dodatki, ki gostujejo v naši galeriji, so brezplačni, razen če ni\n"
 "    jasno označeno drugače."
 
-#: src/olympia/pages/templates/pages/faq.html:210
+#: src/olympia/pages/templates/pages/faq.html:209
 msgid "What does it mean when an add-on asks for contributions?"
 msgstr "Kaj pomeni, če dodatek prosi za prispevke?"
 
-#: src/olympia/pages/templates/pages/faq.html:211
+#: src/olympia/pages/templates/pages/faq.html:210
 msgid ""
-"Some add-on authors request users who enjoy an add-on to\n"
-"        contribute to its development by making a monetary contribution. These\n"
-"        contributions go directly to the developer unless a third party is\n"
-"        indicated, such as the non-profit Mozilla Foundation."
+"Some add-on authors request users who enjoy an add-on to contribute to its development by making a monetary contribution. These contributions go directly to the developer unless a third party is "
+"indicated, such as the non-profit Mozilla Foundation."
 msgstr ""
 "Nekateri avtorji dodatkov naprošajo uporabnike, katerim je\n"
 "        dodatek všeč, da prispevajo k razvoju z darovanjem denarja.  Ti\n"
 "        prispevki gredo neposredno k razvijalcu, razen če ni navedena tretja\n"
 "        oseba, kot je npr. neprofitna Mozilla Foundation."
 
-#: src/olympia/pages/templates/pages/faq.html:216
+#: src/olympia/pages/templates/pages/faq.html:215
 msgid "What are beta add-ons?"
 msgstr "Kaj so beta dodatki?"
 
-#: src/olympia/pages/templates/pages/faq.html:218
+#: src/olympia/pages/templates/pages/faq.html:217
 msgid ""
-"Beta add-ons are unreviewed versions which represent the\n"
-"        latest work of an add-on author. While different authors have different\n"
-"        standards for beta code quality, you should assume that these add-ons\n"
-"        are less stable than the general add-on releases."
+"Beta add-ons are unreviewed versions which represent the latest work of an add-on author. While different authors have different standards for beta code quality, you should assume that these add-"
+"ons are less stable than the general add-on releases."
 msgstr ""
 "Dodatki Beta so nepregledane različice, ki predstavljajo\n"
 "        najnovejše delo avtorja dodatkov.  Medtem, ko imajo različni avtorji\n"
 "        različne standarde kakovosti kode Beta, domnevajte, da so ti dodatki\n"
 "        manj stabilni od splošnih izdaj."
 
-#: src/olympia/pages/templates/pages/faq.html:222
+#: src/olympia/pages/templates/pages/faq.html:221
 msgid ""
-"Please note that when you install an add-on from the \"Beta Version\" "
-"section of an add-on's listing, you will continue to receive updates for "
-"that add-on as they become available. Like the initial version you "
-"installed, all beta releases are unreviewed by Mozilla and may harm your "
-"computer."
+"Please note that when you install an add-on from the \"Beta Version\" section of an add-on's listing, you will continue to receive updates for that add-on as they become available. Like the initial "
+"version you installed, all beta releases are unreviewed by Mozilla and may harm your computer."
 msgstr ""
-"Vedite prosim, da boste v primeru, da dodatek nameščate iz oddelka \"Beta "
-"Različica\" v objavah, še dalje dobivali posodobitve za ta dodatek, ko bodo "
-"na voljo. Niti prvotne različice, ki ste jo namestili, in tudi ne beta "
-"različic Mozilla ni pregledala, tako da lahko škodijo vašemu računalniku."
+"Vedite prosim, da boste v primeru, da dodatek nameščate iz oddelka \"Beta Različica\" v objavah, še dalje dobivali posodobitve za ta dodatek, ko bodo na voljo. Niti prvotne različice, ki ste jo "
+"namestili, in tudi ne beta različic Mozilla ni pregledala, tako da lahko škodijo vašemu računalniku."
 
-#: src/olympia/pages/templates/pages/faq.html:229
-msgid ""
-"What does it mean when an add-on is flagged as\n"
-"    slow?"
+#: src/olympia/pages/templates/pages/faq.html:228
+msgid "What does it mean when an add-on is flagged as slow?"
 msgstr "Kaj pomeni, če je dodatek označen kot počasen?"
 
-#: src/olympia/pages/templates/pages/faq.html:231
-msgid ""
-"Most add-ons load code and resources at the same time Firefox\n"
-"        is starting up. In most cases the impact in start-up time is minimal,\n"
-"        but some add-ons can cause a noticeable slowdown."
+#: src/olympia/pages/templates/pages/faq.html:229
+msgid "Most add-ons load code and resources at the same time Firefox is starting up. In most cases the impact in start-up time is minimal, but some add-ons can cause a noticeable slowdown."
 msgstr ""
 "Večina dodatkov naloži kodo in vire istočasno s Firefoxom.  V\n"
 "        večini primerov je učinek na zagonski čas majhen, vendar lahko\n"
 "        nekateri dodatki povzročijo opazno upočasnitev."
 
-#: src/olympia/pages/templates/pages/faq.html:236
+#: src/olympia/pages/templates/pages/faq.html:234
 msgid "How do I report an inappropriate or spam user review?"
 msgstr "Kako lahko prijavim neprimeren ali zasmeten uporabniški pregled?"
 
-#: src/olympia/pages/templates/pages/faq.html:237
+#: src/olympia/pages/templates/pages/faq.html:235
 msgid ""
-"To report a user review of an add-on, log in with your account\n"
-"    and visit the add-on's reviews page. Find the review you wish to report,\n"
-"    click \"Report this review\" and select a reason. Our editorial team will\n"
-"    investigate the review and take appropriate action."
+"To report a user review of an add-on, log in with your account and visit the add-on's reviews page. Find the review you wish to report, click \"Report this review\" and select a reason. Our "
+"editorial team will investigate the review and take appropriate action."
 msgstr ""
 "Za prijavo ocene uporabnika se prijavite v svoj račun in obiščite\n"
 "    stran z ocenami dodatka.  Poiščite oceno, ki jo želite prijaviti, kliknite\n"
 "    \"Prijavi to oceno\" in izberite razlog.  Naša ekipa urednikov bo preučila\n"
 "    oceno in ustrezno ukrepala."
 
-#: src/olympia/pages/templates/pages/faq.html:242
+#: src/olympia/pages/templates/pages/faq.html:240
 msgid "How do I report a bug or contact the Mozilla Add-ons team?"
 msgstr "Kako lahko prijavim napako ali se obrnem na ekipo za Dodatke Mozilla"
 
-#: src/olympia/pages/templates/pages/faq.html:243
+#: src/olympia/pages/templates/pages/faq.html:241
 #, python-format
 msgid "Please visit our <a href=\"%(contact_url)s\">Contact page</a>."
 msgstr "Obiščite prosim našo <a href=\"%(contact_url)s\">Stran za stike</a> ."
 
-#: src/olympia/pages/templates/pages/faq.html:246
+#: src/olympia/pages/templates/pages/faq.html:244
 msgid "What is a Source Code License?"
 msgstr "Kaj je licenca za izvorno kodo?"
 
-#: src/olympia/pages/templates/pages/faq.html:247
+#: src/olympia/pages/templates/pages/faq.html:245
 #, python-format
 msgid ""
-"The source code used to create an add-on is an exclusive copyright of the "
-"add-on author, unless otherwise declared in a source code license. Many add-"
-"ons on this site have <a href=\"%(url)s\" lang=\"en\">open source "
-"licenses</a> that make the source code publicly available for copy and reuse"
-" under conditions determined by the author. Most authors choose widely known"
-" open source licenses like the GPL or BSD licenses instead of making up "
-"their own."
+"The source code used to create an add-on is an exclusive copyright of the add-on author, unless otherwise declared in a source code license. Many add-ons on this site have <a href=\"%(url)s\" lang="
+"\"en\">open source licenses</a> that make the source code publicly available for copy and reuse under conditions determined by the author. Most authors choose widely known open source licenses like "
+"the GPL or BSD licenses instead of making up their own."
 msgstr ""
-"Za izvorno kodo, s katero se je ustvarilo dodatek, ima izključne avtorske "
-"pravice avtor dodatke, razen v licenci za izvorno kodo ni drugače rečeno. "
-"Veliko dodatkov na tej spletni strani ima <a href=\"%(url)s\" "
-"lang=\"en\">odprtokodno licenco</a> , na osnovi katere je izvorna koda javno"
-" na voljo za kopiranje in uporabo pod pogoji, ki jih je določil avtor. "
-"Večina avtorjev izbere kako splošno znano odprtokodno licenco, kot so "
-"licence GPL in BSD, namesto da si sestavlja svojo lastno."
+"Za izvorno kodo, s katero se je ustvarilo dodatek, ima izključne avtorske pravice avtor dodatke, razen v licenci za izvorno kodo ni drugače rečeno. Veliko dodatkov na tej spletni strani ima <a href="
+"\"%(url)s\" lang=\"en\">odprtokodno licenco</a> , na osnovi katere je izvorna koda javno na voljo za kopiranje in uporabo pod pogoji, ki jih je določil avtor. Večina avtorjev izbere kako splošno "
+"znano odprtokodno licenco, kot so licence GPL in BSD, namesto da si sestavlja svojo lastno."
 
-#: src/olympia/pages/templates/pages/faq.html:256
+#: src/olympia/pages/templates/pages/faq.html:254
 #, python-format
-msgid ""
-"Firefox and other Mozilla software are <a href=\"%(url)s\">open source</a>."
-msgstr ""
-"Firefox in druga programska oprema Mozille je <a "
-"href=\"%(url)s\">odprtokodna</a> ."
+msgid "Firefox and other Mozilla software are <a href=\"%(url)s\">open source</a>."
+msgstr "Firefox in druga programska oprema Mozille je <a href=\"%(url)s\">odprtokodna</a> ."
 
-#: src/olympia/pages/templates/pages/faq.html:264
+#: src/olympia/pages/templates/pages/faq.html:262
 msgid "Collections and Favorites"
 msgstr "Zbirke in Priljubljene"
 
-#: src/olympia/pages/templates/pages/faq.html:267
+#: src/olympia/pages/templates/pages/faq.html:265
 msgid "What is a collection?"
 msgstr "Kaj je zbirka?"
 
-#: src/olympia/pages/templates/pages/faq.html:268
+#: src/olympia/pages/templates/pages/faq.html:266
 msgid "Collections are groups of related add-ons created by users to share."
-msgstr ""
-"Zbirke so skupine sorodnih dodatkov, ki jih lahko vsakdo ustvari in deli z "
-"drugimi."
+msgstr "Zbirke so skupine sorodnih dodatkov, ki jih lahko vsakdo ustvari in deli z drugimi."
 
-#: src/olympia/pages/templates/pages/faq.html:270
+#: src/olympia/pages/templates/pages/faq.html:268
 msgid "What is the My Favorites collection?"
 msgstr "Kaj je zbirka Moje priljubljene?"
 
-#: src/olympia/pages/templates/pages/faq.html:271
-msgid ""
-"Favorite add-ons are add-ons that you have bookmarked to easily get back to "
-"later. You can add an add-on to your favorites collection by clicking \"Add "
-"to favorites\" on its details page."
+#: src/olympia/pages/templates/pages/faq.html:269
+msgid "Favorite add-ons are add-ons that you have bookmarked to easily get back to later. You can add an add-on to your favorites collection by clicking \"Add to favorites\" on its details page."
 msgstr ""
-"Priljubljeni dodatki so dodatki, ki ste jih zaznamovali, tako da je kasneje "
-"enostavno vrniti se nazaj nanje. Dodatek lahko dodate v svojo zbirko "
-"priljubljenih s klikom na \"Dodaj med priljubljene\" na svoji strani s "
-"podrobnostmi."
+"Priljubljeni dodatki so dodatki, ki ste jih zaznamovali, tako da je kasneje enostavno vrniti se nazaj nanje. Dodatek lahko dodate v svojo zbirko priljubljenih s klikom na \"Dodaj med priljubljene\" "
+"na svoji strani s podrobnostmi."
 
-#: src/olympia/pages/templates/pages/faq.html:275
-#: src/olympia/templates/menu_links.html:13
-#: src/olympia/templates/impala/header_title.html:17
+#: src/olympia/pages/templates/pages/faq.html:273 src/olympia/templates/menu_links.html:13 src/olympia/templates/impala/header_title.html:17
 msgid "Mobile Add-ons"
 msgstr "Mobilni dodatki"
 
-#: src/olympia/pages/templates/pages/faq.html:278
+#: src/olympia/pages/templates/pages/faq.html:276
 msgid "What are mobile add-ons?"
 msgstr "Kaj so dodatki za mobilne naprave?"
 
-#: src/olympia/pages/templates/pages/faq.html:279
+#: src/olympia/pages/templates/pages/faq.html:277
 #, python-format
 msgid ""
-"Mobile add-ons work with <a href=\"%(mobile_url)s\">Firefox for Mobile</a> "
-"and add or modify functionality just like desktop add-ons. You can find add-"
-"ons that work with Firefox for Mobile in our <a "
-"href=\"%(gallery_url)s\">gallery</a>."
+"Mobile add-ons work with <a href=\"%(mobile_url)s\">Firefox for Mobile</a> and add or modify functionality just like desktop add-ons. You can find add-ons that work with Firefox for Mobile in our "
+"<a href=\"%(gallery_url)s\">gallery</a>."
 msgstr ""
-"Mobilni dodatki so namenjeni <a href=\"%(mobile_url)s\">mobilnemu "
-"Firefoxu</a> in, tako kot namizni dodatki, dodajajo ali spreminjajo "
-"funkcionalnost. Dodatke, ki delujejo z mobilnim Firefoxom, najdete v naši <a"
-" href=\"%(gallery_url)s\">galeriji</a>."
+"Mobilni dodatki so namenjeni <a href=\"%(mobile_url)s\">mobilnemu Firefoxu</a> in, tako kot namizni dodatki, dodajajo ali spreminjajo funkcionalnost. Dodatke, ki delujejo z mobilnim Firefoxom, "
+"najdete v naši <a href=\"%(gallery_url)s\">galeriji</a>."
 
-#: src/olympia/pages/templates/pages/faq.html:288
+#: src/olympia/pages/templates/pages/faq.html:286
 msgid "Developer Topics"
 msgstr "Teme za razvijalce"
 
-#: src/olympia/pages/templates/pages/faq.html:289
+#: src/olympia/pages/templates/pages/faq.html:287
 #, python-format
-msgid ""
-"Please see our <a href=\"%(faq_url)s\">Developer FAQ</a> and <a "
-"href=\"%(hub_url)s\">Developer Hub</a> for answers to add-on developer-"
-"related questions."
-msgstr ""
-"Oglejte si naša <a href=\"%(faq_url)s\">Pogosta vprašanja za razvijalce</a> "
-"in <a href=\"%(hub_url)s\">Razvojni center</a> za odgovore na vprašanja, ki "
-"so povezana z razvojem."
+msgid "Please see our <a href=\"%(faq_url)s\">Developer FAQ</a> and <a href=\"%(hub_url)s\">Developer Hub</a> for answers to add-on developer-related questions."
+msgstr "Oglejte si naša <a href=\"%(faq_url)s\">Pogosta vprašanja za razvijalce</a> in <a href=\"%(hub_url)s\">Razvojni center</a> za odgovore na vprašanja, ki so povezana z razvojem."
 
-#: src/olympia/pages/templates/pages/faq.html:294
+#: src/olympia/pages/templates/pages/faq.html:292
 msgid "Still have questions?"
 msgstr "Še kakšno vprašanje?"
 
-#: src/olympia/pages/templates/pages/faq.html:295
+#: src/olympia/pages/templates/pages/faq.html:293
 #, python-format
-msgid ""
-"For general Firefox support, visit our <a href=\"%(sumo_url)s\">support "
-"website</a>. For general add-on and website questions, visit our <a "
-"href=\"%(forum_url)s\">forum</a>."
+msgid "For general Firefox support, visit our <a href=\"%(sumo_url)s\">support website</a>. For general add-on and website questions, visit our <a href=\"%(forum_url)s\">forum</a>."
 msgstr ""
-"Za splošno podporo za Firefox, obiščite naše <a "
-"href=\"%(sumo_url)s\">spletne strani za podporo</a>. Za splošna vprašanja "
-"glede dodatkov in spletišča obiščite naš <a "
-"href=\"%(forum_url)s\">forum</a>."
+"Za splošno podporo za Firefox, obiščite naše <a href=\"%(sumo_url)s\">spletne strani za podporo</a>. Za splošna vprašanja glede dodatkov in spletišča obiščite naš <a href=\"%(forum_url)s\">forum</"
+"a>."
 
-#: src/olympia/pages/templates/pages/review_guide.html:36
-#: src/olympia/pages/templates/pages/review_guide.html:51
+#: src/olympia/pages/templates/pages/review_guide.html:36 src/olympia/pages/templates/pages/review_guide.html:51
 msgid "Some tips for writing a great review"
 msgstr "Nekaj ​​nasvetov, kako napisati dobro oceno"
 
-#: src/olympia/pages/templates/pages/review_guide.html:39
-#: src/olympia/pages/templates/pages/review_guide.html:131
+#: src/olympia/pages/templates/pages/review_guide.html:39 src/olympia/pages/templates/pages/review_guide.html:131
 msgid "Frequently Asked Questions about Reviews"
 msgstr "Pogosta vprašanja o ocenah"
 
 #: src/olympia/pages/templates/pages/review_guide.html:46
 msgid ""
-"Add-on reviews are a way for you to share your opinions about the add-ons "
-"you’ve installed and used. Our review moderation team reserves the right to "
-"refuse or remove any review that does not comply with these guidelines."
+"Add-on reviews are a way for you to share your opinions about the add-ons you’ve installed and used. Our review moderation team reserves the right to refuse or remove any review that does not "
+"comply with these guidelines."
 msgstr ""
-"V ocenah dodatkov lahko delite svoja mnenja o dodatkih, ki ste jih namestili"
-" in uporabljali. Naša ekipa za moderacijo ocen si pridržuje pravice za "
-"zavrnitev in odstranitev ocen, ki niso v skladu s temi smernicami."
+"V ocenah dodatkov lahko delite svoja mnenja o dodatkih, ki ste jih namestili in uporabljali. Naša ekipa za moderacijo ocen si pridržuje pravice za zavrnitev in odstranitev ocen, ki niso v skladu s "
+"temi smernicami."
 
 #: src/olympia/pages/templates/pages/review_guide.html:53
 msgid "Do:"
 msgstr "Kako je prav:"
 
 #: src/olympia/pages/templates/pages/review_guide.html:56
-msgid ""
-"Write like you are telling a friend about your experience with the add-on."
-msgstr ""
-"Pišite, kot da pripovedujete kakemu prijatelju o svojih izkušnjah z "
-"dodatkom."
+msgid "Write like you are telling a friend about your experience with the add-on."
+msgstr "Pišite, kot da pripovedujete kakemu prijatelju o svojih izkušnjah z dodatkom."
 
 #: src/olympia/pages/templates/pages/review_guide.html:61
 msgid "Keep reviews concise and easy to understand."
@@ -13684,11 +10708,8 @@ msgid "Will you continue to use this add-on?"
 msgstr "Ali boste ta dodatek še naprej uporabljali?"
 
 #: src/olympia/pages/templates/pages/review_guide.html:73
-msgid ""
-"Take a moment to read your review before submitting it to minimize typos."
-msgstr ""
-"Vzemite si trenutek, da preberete svojo oceno, preden jo pošljete, da "
-"zmanjšate število tipkarskih napak."
+msgid "Take a moment to read your review before submitting it to minimize typos."
+msgstr "Vzemite si trenutek, da preberete svojo oceno, preden jo pošljete, da zmanjšate število tipkarskih napak."
 
 #: src/olympia/pages/templates/pages/review_guide.html:79
 msgid "Don’t:"
@@ -13700,65 +10721,43 @@ msgstr "Ne pišite ocen z eno besedo, kot so \"Super!\", \"Izvrstno\" ali \"Zani
 
 #: src/olympia/pages/templates/pages/review_guide.html:87
 msgid ""
-"Post technical issues, support requests, or feature suggestions. Use the "
-"available support options for each add-on, if available. You can find them "
-"in the side column next to the About this Add-on section."
+"Post technical issues, support requests, or feature suggestions. Use the available support options for each add-on, if available. You can find them in the side column next to the About this Add-on "
+"section."
 msgstr ""
-"Ne objavljajte tehničnih težav, zahtev za podporo ali predlogov za nove "
-"funkcije. Uporabite razpoložljive možnosti podpore za vsak dodatek, če so na"
-" voljo. Najdete jih v stranskem stolpcu poleg odseka \"O tem dodatku\"."
+"Ne objavljajte tehničnih težav, zahtev za podporo ali predlogov za nove funkcije. Uporabite razpoložljive možnosti podpore za vsak dodatek, če so na voljo. Najdete jih v stranskem stolpcu poleg "
+"odseka \"O tem dodatku\"."
 
 #: src/olympia/pages/templates/pages/review_guide.html:92
 msgid "Write reviews for add-ons which you have not personally used."
 msgstr "Ne pišite ocen za dodatke, ki jih sami niste uporabljali."
 
 #: src/olympia/pages/templates/pages/review_guide.html:97
-msgid ""
-"Use profanity, sexual language or language that can be construed as hateful."
-msgstr ""
-"Ne uporabljajte prostaških izrazov ali jezika, ki ga je lahko razumeti kot "
-"sovražnega."
+msgid "Use profanity, sexual language or language that can be construed as hateful."
+msgstr "Ne uporabljajte prostaških izrazov ali jezika, ki ga je lahko razumeti kot sovražnega."
 
 #: src/olympia/pages/templates/pages/review_guide.html:103
-msgid ""
-"Include HTML, links, source code or code snippets. Reviews are meant to be "
-"text only."
-msgstr ""
-"Ne vključujte HTML, povezav, izvorne kode ali izrezkov kode. V ocenah "
-"uporabite samo besedilo."
+msgid "Include HTML, links, source code or code snippets. Reviews are meant to be text only."
+msgstr "Ne vključujte HTML, povezav, izvorne kode ali izrezkov kode. V ocenah uporabite samo besedilo."
 
 #: src/olympia/pages/templates/pages/review_guide.html:108
-msgid ""
-"Make false statements, disparage add-on authors or personally insult them."
-msgstr ""
-"Ne dajajte neresničnih izjav, ne omalovažujte avtorjev dodatka in ne žalite "
-"jih osebno."
+msgid "Make false statements, disparage add-on authors or personally insult them."
+msgstr "Ne dajajte neresničnih izjav, ne omalovažujte avtorjev dodatka in ne žalite jih osebno."
 
 #: src/olympia/pages/templates/pages/review_guide.html:114
-msgid ""
-"Include your own or anyone else’s email, phone number, or other personal "
-"details."
-msgstr ""
-"Ne vključujte svoje e-pošte, telefonske številke in drugih osebnih podatkov "
-"ali podatkov drugih oseb."
+msgid "Include your own or anyone else’s email, phone number, or other personal details."
+msgstr "Ne vključujte svoje e-pošte, telefonske številke in drugih osebnih podatkov ali podatkov drugih oseb."
 
 #: src/olympia/pages/templates/pages/review_guide.html:119
-msgid ""
-"Post reviews for an add-on you or your organization wrote or represent."
-msgstr ""
-"Ne objavljajte ocen za dodatek, ki ste ga razvili vi sami ali vaša "
-"organizacija ali ki ga zastopate."
+msgid "Post reviews for an add-on you or your organization wrote or represent."
+msgstr "Ne objavljajte ocen za dodatek, ki ste ga razvili vi sami ali vaša organizacija ali ki ga zastopate."
 
 #: src/olympia/pages/templates/pages/review_guide.html:125
 msgid ""
-"Criticize an add-on for something it’s intended to do. For example, leaving "
-"a negative review of an add-on for displaying ads or requiring data "
-"gathering, when that is the intended purpose of the add-on, or the add-on "
-"requires gathering data to function."
+"Criticize an add-on for something it’s intended to do. For example, leaving a negative review of an add-on for displaying ads or requiring data gathering, when that is the intended purpose of the "
+"add-on, or the add-on requires gathering data to function."
 msgstr ""
-"Ne kritizirajte dodatka zaradi tega, za kar je narejen. Na primer, ne "
-"napišite negativne ocene za dodatek, če prikazuje oglase ali zahteva osebne "
-"podatke, kadar je to njegov namen ali pogoj za njegovo delovanje."
+"Ne kritizirajte dodatka zaradi tega, za kar je narejen. Na primer, ne napišite negativne ocene za dodatek, če prikazuje oglase ali zahteva osebne podatke, kadar je to njegov namen ali pogoj za "
+"njegovo delovanje."
 
 #: src/olympia/pages/templates/pages/review_guide.html:133
 msgid "How can I report a problematic review?"
@@ -13766,15 +10765,11 @@ msgstr "Kako lahko prijavim vprašljivo oceno?"
 
 #: src/olympia/pages/templates/pages/review_guide.html:135
 msgid ""
-"Please report or flag any questionable reviews by clicking the \"Report this"
-" review\" and it will be submitted to the site for moderation. Our "
-"moderation team will use the Review Guidelines to evaluate whether or not to"
-" delete the review or restore it back to the site."
+"Please report or flag any questionable reviews by clicking the \"Report this review\" and it will be submitted to the site for moderation. Our moderation team will use the Review Guidelines to "
+"evaluate whether or not to delete the review or restore it back to the site."
 msgstr ""
-"Prijavite ali označite vse vprašljive ocene s klikom na \"Prijavi to "
-"oceno\", s čimer jo boste poslali na stran za moderacijo. Naša ekipa za "
-"moderacijo bo glede na smernice za ocene presodila, ali to oceno izbrisati "
-"ali ne, ali jo obnoviti nazaj na stran."
+"Prijavite ali označite vse vprašljive ocene s klikom na \"Prijavi to oceno\", s čimer jo boste poslali na stran za moderacijo. Naša ekipa za moderacijo bo glede na smernice za ocene presodila, ali "
+"to oceno izbrisati ali ne, ali jo obnoviti nazaj na stran."
 
 #: src/olympia/pages/templates/pages/review_guide.html:140
 msgid "I’m an add-on author, can I respond to reviews?"
@@ -13782,14 +10777,8 @@ msgstr "Sem avtor dodatka, ali lahko odgovorim na oceno?"
 
 #: src/olympia/pages/templates/pages/review_guide.html:142
 #, python-format
-msgid ""
-"Yes, add-on authors can provide a single response to a review. You can set "
-"up a discussion topic in our <a href=\"%(forum_url)s\">forum</a> to engage "
-"in additional discussion or follow-up."
-msgstr ""
-"Da, avtorji dodatkov lahko na oceno objavijo en odgovor. Temo za razpravo "
-"lahko objavite na našem <a href=\"%(forum_url)s\">forumu</a>, da se "
-"poglobite v dodatno ali nadaljnjo razpravo."
+msgid "Yes, add-on authors can provide a single response to a review. You can set up a discussion topic in our <a href=\"%(forum_url)s\">forum</a> to engage in additional discussion or follow-up."
+msgstr "Da, avtorji dodatkov lahko na oceno objavijo en odgovor. Temo za razpravo lahko objavite na našem <a href=\"%(forum_url)s\">forumu</a>, da se poglobite v dodatno ali nadaljnjo razpravo."
 
 #: src/olympia/pages/templates/pages/review_guide.html:149
 msgid "I’m an add-on author, can I delete unfavorable reviews or ratings?"
@@ -13797,17 +10786,11 @@ msgstr "Sem avtor dodatka, ali lahko izbrišem neugodne ocene?"
 
 #: src/olympia/pages/templates/pages/review_guide.html:151
 msgid ""
-"In general, no. But if the review did not meet the review guidelines "
-"outlined above, you can click \"Report this review\" and have it moderated. "
-"If a review included a complaint that is no longer valid due to a new "
-"release of your add-on, we may consider deleting the review. Submit your "
-"detailed request to amo-editors@mozilla.org."
+"In general, no. But if the review did not meet the review guidelines outlined above, you can click \"Report this review\" and have it moderated. If a review included a complaint that is no longer "
+"valid due to a new release of your add-on, we may consider deleting the review. Submit your detailed request to amo-editors@mozilla.org."
 msgstr ""
-"V splošnem ne. Toda če ocena ne ustreza zgornjim smernicam, lahko kliknete "
-"\"Prijavi to oceno\" in jo predložite za moderacijo. Če ocena vključuje "
-"pritožbo, ki ni več veljavna zaradi nove izdaje vašega dodatka, bomo "
-"premislili o njenem izbrisu. Svojo podrobno zahtevo pošljite na amo-"
-"editors@mozilla.org."
+"V splošnem ne. Toda če ocena ne ustreza zgornjim smernicam, lahko kliknete \"Prijavi to oceno\" in jo predložite za moderacijo. Če ocena vključuje pritožbo, ki ni več veljavna zaradi nove izdaje "
+"vašega dodatka, bomo premislili o njenem izbrisu. Svojo podrobno zahtevo pošljite na amo-editors@mozilla.org."
 
 #: src/olympia/pages/templates/pages/sunbird.html:26
 msgid "Sunbird has retired"
@@ -13815,23 +10798,16 @@ msgstr "Sunbird je umaknjen"
 
 #: src/olympia/pages/templates/pages/sunbird.html:29
 msgid ""
-"Development on the Sunbird project has halted and its final release was on "
-"March 30, 2010.  We've been proud to host Sunbird add-ons on this site but "
-"as the project is no longer maintained we have disabled our support for the "
-"add-ons."
+"Development on the Sunbird project has halted and its final release was on March 30, 2010. We've been proud to host Sunbird add-ons on this site but as the project is no longer maintained we have "
+"disabled our support for the add-ons."
 msgstr ""
-"Razvoj projekta Sunbird je zastal z njegovo zadnjo izdajo 30. marca, 2010.  "
-"Ponosni smo, da lahko gostimo dodatke za Sunbird na tej strani, vendar ker "
-"se projekt ne vzdržuje več, smo ukinili podporo za njegove dodatke."
+"Razvoj projekta Sunbird je zastal z njegovo zadnjo izdajo 30. marca, 2010.  Ponosni smo, da lahko gostimo dodatke za Sunbird na tej strani, vendar ker se projekt ne vzdržuje več, smo ukinili "
+"podporo za njegove dodatke."
 
 #: src/olympia/pages/templates/pages/sunbird.html:38
 #, python-format
-msgid ""
-"We recommend upgrading to <a href=\"%(tb_url)s\">Thunderbird</a> and <a "
-"href=\"%(lightning_url)s\">Lightning</a>."
-msgstr ""
-"Priporočamo vam, da nadgradite na <a href=\"%(tb_url)s\">Thunderbird</a> in "
-"<a href=\"%(lightning_url)s\">Lightning</a>."
+msgid "We recommend upgrading to <a href=\"%(tb_url)s\">Thunderbird</a> and <a href=\"%(lightning_url)s\">Lightning</a>."
+msgstr "Priporočamo vam, da nadgradite na <a href=\"%(tb_url)s\">Thunderbird</a> in <a href=\"%(lightning_url)s\">Lightning</a>."
 
 #: src/olympia/pages/templates/pages/sunbird.html:45
 msgid "Read more about Sunbird"
@@ -13839,9 +10815,7 @@ msgstr "Preberite več o Sunbirdu"
 
 #: src/olympia/paypal/__init__.py:25
 msgid "There was an error communicating with PayPal. Please try again later."
-msgstr ""
-"Prišlo je do težave pri komunikaciji s Paypalom. Poskusite prosim znova "
-"kasneje."
+msgstr "Prišlo je do težave pri komunikaciji s Paypalom. Poskusite prosim znova kasneje."
 
 #: src/olympia/paypal/__init__.py:50
 msgid "There was an error with this currency."
@@ -13884,8 +10858,7 @@ msgstr "Zadrži komentar; odstrani zastavice"
 msgid "Skip for now"
 msgstr "Preskoči za zdaj"
 
-#: src/olympia/reviews/forms.py:151
-#: src/olympia/reviews/templates/reviews/review.html:107
+#: src/olympia/reviews/forms.py:151 src/olympia/reviews/templates/reviews/review.html:107
 msgid "Delete review"
 msgstr "Izbriši pregled"
 
@@ -13904,39 +10877,23 @@ msgstr "Dodaj pregled za {0}"
 #: src/olympia/reviews/templates/reviews/add.html:26
 #, python-format
 msgid ""
-"<h2>Keep these tips in mind:</h2> <ul> <li> Write like you're telling a "
-"friend about your experience with the add-on. Give specifics and helpful "
-"details, such as what features you liked and/or disliked, how easy to use it"
-" is, and any disadvantages it has.  Avoid generic language such as calling "
-"it \"Great\" or \"Bad\" unless you can give reasons why you believe this is "
-"so. </li> <li> Please do not post bug reports in reviews. We do not make "
-"your email address available to add-on developers and they may need to "
-"contact you to help resolve your issue. See the <a "
-"href=\"%(support)s\">support section</a> to find out where to get assistance"
-" for this add-on. </li> <li>Please keep reviews clean, avoid the use of "
-"improper language and do not post any personal information. </li> </ul> "
-"<p>Please read the <a href=\"%(guide)s\" target=\"_blank\">Review "
-"Guidelines</a> for more detail about user add-on reviews.</p>"
+"<h2>Keep these tips in mind:</h2> <ul> <li> Write like you're telling a friend about your experience with the add-on. Give specifics and helpful details, such as what features you liked and/or "
+"disliked, how easy to use it is, and any disadvantages it has. Avoid generic language such as calling it \"Great\" or \"Bad\" unless you can give reasons why you believe this is so. </li> <li> "
+"Please do not post bug reports in reviews. We do not make your email address available to add-on developers and they may need to contact you to help resolve your issue. See the <a href=\"%(support)s"
+"\">support section</a> to find out where to get assistance for this add-on. </li> <li>Please keep reviews clean, avoid the use of improper language and do not post any personal information. </li> </"
+"ul> <p>Please read the <a href=\"%(guide)s\" target=\"_blank\">Review Guidelines</a> for more detail about user add-on reviews.</p>"
 msgstr ""
-"<h2>V mislih imejte te namige:</h2><ul><li>Pišite, kot da pišete prijatelju "
-"o svoji izkušnji z dodatkom.  Podajte podrobnosti, kot so značilnosti, ki "
-"vam so/niso bile všeč, kako lahko ga je uporabljati in vse njegove slabosti."
-"  Izogibajte se splošnemu pisanju, kot je \"dober je\" ali \"slab je\", "
-"razen če ne navedete razlogov za to.</li><li>Ne objavljate poročil o hroščih"
-" in ocen.  Vašega e-poštnega naslova ne dajemo na razpolago razvijalcem in "
-"morda bodo z vami morali navezati stik, da vam pomagajo pri reševanju "
-"težave.  Da izveste, kje dobiti pomoč za ta dodatek, glejte <a "
-"href=\"%(support)s\">odsek za podporo</a>.</li><li>Ocene naj bodo jasne; "
-"izogibajte se neustreznemu jeziku in ne objavljajte osebnih "
-"podatkov.</li></ul><p>Za več podrobnosti o ocenah uporabnikov preberite <a "
-"href=\"%(guide)s\" target=\"_blank\">Vodnik za ocenjevanje</a>.</p>"
+"<h2>V mislih imejte te namige:</h2><ul><li>Pišite, kot da pišete prijatelju o svoji izkušnji z dodatkom.  Podajte podrobnosti, kot so značilnosti, ki vam so/niso bile všeč, kako lahko ga je "
+"uporabljati in vse njegove slabosti.  Izogibajte se splošnemu pisanju, kot je \"dober je\" ali \"slab je\", razen če ne navedete razlogov za to.</li><li>Ne objavljate poročil o hroščih in ocen.  "
+"Vašega e-poštnega naslova ne dajemo na razpolago razvijalcem in morda bodo z vami morali navezati stik, da vam pomagajo pri reševanju težave.  Da izveste, kje dobiti pomoč za ta dodatek, glejte <a "
+"href=\"%(support)s\">odsek za podporo</a>.</li><li>Ocene naj bodo jasne; izogibajte se neustreznemu jeziku in ne objavljajte osebnih podatkov.</li></ul><p>Za več podrobnosti o ocenah uporabnikov "
+"preberite <a href=\"%(guide)s\" target=\"_blank\">Vodnik za ocenjevanje</a>.</p>"
 
 #: src/olympia/reviews/templates/reviews/reply.html:4
 msgid "Reply to review by {0}"
 msgstr "Odgovor na pregled za {0}"
 
-#: src/olympia/reviews/templates/reviews/reply.html:15
-#: src/olympia/reviews/templates/reviews/reply.html:31
+#: src/olympia/reviews/templates/reviews/reply.html:15 src/olympia/reviews/templates/reviews/reply.html:31
 msgid "Reply"
 msgstr "Odgovor"
 
@@ -13944,8 +10901,7 @@ msgstr "Odgovor"
 msgid "Write a Reply"
 msgstr "Napišite odgovor"
 
-#: src/olympia/reviews/templates/reviews/reply.html:36
-#: src/olympia/reviews/templates/reviews/report_review.html:12
+#: src/olympia/reviews/templates/reviews/reply.html:36 src/olympia/reviews/templates/reviews/report_review.html:12
 msgid "Submit"
 msgstr "Pošlji"
 
@@ -13965,40 +10921,21 @@ msgid "by %(user)s <b>(Developer)</b> on %(date)s"
 msgstr "%(user)s <b>(Razvijalec)</b> dne %(date)s"
 
 #. {0} is a version number (like 1.01)
-#: src/olympia/reviews/templates/reviews/review.html:50
-#: src/olympia/reviews/templates/reviews/mobile/review_list.html:41
+#: src/olympia/reviews/templates/reviews/review.html:50 src/olympia/reviews/templates/reviews/mobile/review_list.html:41
 msgid "This review is for a previous version of the add-on ({0})."
 msgstr "Ta ocena je za prejšnjo različico dodatka ({0})."
 
 #: src/olympia/reviews/templates/reviews/review.html:56
 #, python-format
-msgid ""
-"This user has a <a href=\"%(user_review_url)s\">previous review</a> of this "
-"add-on."
-msgid_plural ""
-"This user has <a href=\"%(user_review_url)s\">%(cnt)s previous reviews</a> "
-"of this add-on."
-msgstr[0] ""
-"Ta uporabnik ima <a href=\"%(user_review_url)s\">prejšnjo oceno</a> za ta "
-"dodatek."
-msgstr[1] ""
-"Ta uporabnik ima <a href=\"%(user_review_url)s\">%(cnt)s prejšnji oceni</a> "
-"za ta dodatek."
-msgstr[2] ""
-"Ta uporabnik ima <a href=\"%(user_review_url)s\">%(cnt)s prejšnje ocene</a> "
-"za ta dodatek."
-msgstr[3] ""
-"Ta uporabnik ima <a href=\"%(user_review_url)s\">%(cnt)s prejšnjih ocen</a> "
-"za ta dodatek."
+msgid "This user has a <a href=\"%(user_review_url)s\">previous review</a> of this add-on."
+msgid_plural "This user has <a href=\"%(user_review_url)s\">%(cnt)s previous reviews</a> of this add-on."
+msgstr[0] "Ta uporabnik ima <a href=\"%(user_review_url)s\">prejšnjo oceno</a> za ta dodatek."
+msgstr[1] "Ta uporabnik ima <a href=\"%(user_review_url)s\">%(cnt)s prejšnji oceni</a> za ta dodatek."
 
 #: src/olympia/reviews/templates/reviews/review.html:62
 #, python-format
-msgid ""
-"This user has <a href=\"%(user_review_url)s\">other reviews</a> of this add-"
-"on."
-msgstr ""
-"Ta uporabnik ima <a href=\"%(user_review_url)s\">druge ocene</a> za ta "
-"dodatek."
+msgid "This user has <a href=\"%(user_review_url)s\">other reviews</a> of this add-on."
+msgstr "Ta uporabnik ima <a href=\"%(user_review_url)s\">druge ocene</a> za ta dodatek."
 
 #: src/olympia/reviews/templates/reviews/review.html:72
 msgid "Flagged for review"
@@ -14030,9 +10967,7 @@ msgid "{0} :: Reviews"
 msgstr "{0} :: pregledi"
 
 #. {0} is an addon name.
-#: src/olympia/reviews/templates/reviews/review_list.html:24
-#: src/olympia/reviews/templates/reviews/mobile/add.html:4
-#: src/olympia/reviews/templates/reviews/mobile/review_list.html:4
+#: src/olympia/reviews/templates/reviews/review_list.html:24 src/olympia/reviews/templates/reviews/mobile/add.html:4 src/olympia/reviews/templates/reviews/mobile/review_list.html:4
 msgid "Reviews for {0}"
 msgstr "Ocene za {0}"
 
@@ -14042,8 +10977,6 @@ msgid "<b>{0}</b> review for this add-on"
 msgid_plural "<b>{0}</b> reviews for this add-on"
 msgstr[0] "<b>{0}</b> ocena za ta dodatek"
 msgstr[1] "<b>{0}</b> oceni za ta dodatek"
-msgstr[2] "<b>{0}</b> ocene za ta dodatek"
-msgstr[3] "<b>{0}</b> ocen za ta dodatek"
 
 #. {0} is a developer's name.
 #: src/olympia/reviews/templates/reviews/review_list.html:33
@@ -14056,8 +10989,6 @@ msgid "Review for %(addon)s by %(user)s"
 msgid_plural "Reviews for %(addon)s by %(user)s"
 msgstr[0] "Pregled za %(addon)s uporabnika %(user)s"
 msgstr[1] "Pregleda za %(addon)s uporabnika %(user)s"
-msgstr[2] "Pregledi za %(addon)s uporabnika %(user)s"
-msgstr[3] "Pregledi za %(addon)s uporabnika %(user)s"
 
 #: src/olympia/reviews/templates/reviews/review_list.html:42
 msgid "No reviews found."
@@ -14072,8 +11003,7 @@ msgstr "<strong>Povprečje</strong> (%(total)s)"
 msgid "Write a New Review"
 msgstr "Napišite novo oceno"
 
-#: src/olympia/reviews/templates/reviews/review_list.html:81
-#: src/olympia/reviews/templates/reviews/mobile/reviews_link.html:15
+#: src/olympia/reviews/templates/reviews/review_list.html:81 src/olympia/reviews/templates/reviews/mobile/reviews_link.html:15
 msgid "Be the first to write a review."
 msgstr "Bodite prvi, ki bo napisal oceno."
 
@@ -14082,8 +11012,6 @@ msgid "{num} review"
 msgid_plural "{num} reviews"
 msgstr[0] "{num} ocena"
 msgstr[1] "{num} oceni"
-msgstr[2] "{num} ocene"
-msgstr[3] "{num} ocen"
 
 #: src/olympia/reviews/templates/reviews/impala/reviews_rating.html:1
 msgid "Rated {0} out of 5 stars"
@@ -14094,8 +11022,7 @@ msgstr "Ocena {0} od 5 zvezdic"
 msgid "Rated %(rating)s out of 5 stars"
 msgstr "Ocenjeno z %(rating)s od 5 zvezdic"
 
-#: src/olympia/reviews/templates/reviews/mobile/add_form.html:3
-#: src/olympia/reviews/templates/reviews/mobile/add_form.html:8
+#: src/olympia/reviews/templates/reviews/mobile/add_form.html:3 src/olympia/reviews/templates/reviews/mobile/add_form.html:8
 msgid "Add a Review"
 msgstr "Dodaj pregled"
 
@@ -14112,8 +11039,6 @@ msgid "Average from {0} Rating"
 msgid_plural "Average from {0} Ratings"
 msgstr[0] "Povprečje iz {0} ocene"
 msgstr[1] "Povprečje iz {0} ocen"
-msgstr[2] "Povprečje iz {0} ocen"
-msgstr[3] "Povprečje iz {0} ocen"
 
 #: src/olympia/reviews/templates/reviews/mobile/review_list.html:34
 #, python-format
@@ -14130,8 +11055,6 @@ msgid "See All Reviews"
 msgid_plural "See All %(cnt)s Reviews"
 msgstr[0] "Pokaži vse ocene"
 msgstr[1] "Pokaži obe oceni"
-msgstr[2] "Pokaži vse %(cnt)s ocene"
-msgstr[3] "Pokaži vseh %(cnt)s ocen"
 
 #: src/olympia/search/forms.py:11
 msgid "Most popular this week"
@@ -14170,10 +11093,8 @@ msgid "Relevance"
 msgstr "Pomembnost"
 
 #: src/olympia/search/helpers.py:24
-msgid ""
-"Results <strong>{0}</strong>-<strong>{1}</strong> of <strong>{2}</strong>"
-msgstr ""
-"Rezultati <strong>{0}</strong>-<strong>{1}</strong> od <strong>{2}</strong>"
+msgid "Results <strong>{0}</strong>-<strong>{1}</strong> of <strong>{2}</strong>"
+msgstr "Rezultati <strong>{0}</strong>-<strong>{1}</strong> od <strong>{2}</strong>"
 
 # {0} is a number
 # {1} is a number
@@ -14181,12 +11102,8 @@ msgstr ""
 # {3} is the word the person is searching for
 # {4} is a word (the add-on is tagged with it)
 #: src/olympia/search/helpers.py:44
-msgid ""
-"Showing {0} - {1} of {2} results for <strong>{3}</strong> tagged with "
-"<strong>{4}</strong>"
-msgstr ""
-"Prikaz {0} - {1} od {2} rezultatov za <strong>{3}</strong> z oznako "
-"<strong>{4}</strong>"
+msgid "Showing {0} - {1} of {2} results for <strong>{3}</strong> tagged with <strong>{4}</strong>"
+msgstr "Prikaz {0} - {1} od {2} rezultatov za <strong>{3}</strong> z oznako <strong>{4}</strong>"
 
 # {0} is a number
 # {1} is a number
@@ -14212,24 +11129,22 @@ msgid "Showing {0} - {1} of {2} results"
 msgstr "Prikaz {0} - {1} od {2} rezultatov"
 
 #. {0} is an application, like Firefox.
-#: src/olympia/search/views.py:264 src/olympia/templates/base.html:17
-#: src/olympia/templates/impala/base.html:17
-#: src/olympia/templates/mobile/base_addons.html:17
+#: src/olympia/search/views.py:264 src/olympia/templates/base.html:17 src/olympia/templates/impala/base.html:17 src/olympia/templates/mobile/base_addons.html:17
 msgid "{0} Add-ons"
 msgstr "Dodatki za {0}"
 
 #. L10n: {0} is an application, such as Firefox. This means "any version of
 #. Firefox."
-#: src/olympia/search/views.py:554
+#: src/olympia/search/views.py:547
 msgid "Any {0}"
 msgstr "Katerikoli {0}"
 
 #. L10n: "All Systems" means show everything regardless of platform.
-#: src/olympia/search/views.py:589
+#: src/olympia/search/views.py:582
 msgid "All Systems"
 msgstr "Vsi sistemi"
 
-#: src/olympia/search/views.py:600
+#: src/olympia/search/views.py:593
 msgid "All Tags"
 msgstr "Vse oznake"
 
@@ -14274,8 +11189,6 @@ msgid "<b>{0}</b> matching result"
 msgid_plural "<b>{0}</b> matching results"
 msgstr[0] "<b>{0}</b> zadetek"
 msgstr[1] "<b>{0}</b> zadetka"
-msgstr[2] "<b>{0}</b> zadetki"
-msgstr[3] "<b>{0}</b> zadetkov"
 
 #: src/olympia/search/templates/search/results.html:67
 msgid "Filter Results"
@@ -14298,8 +11211,6 @@ msgid "{0} post"
 msgid_plural "{0} posts"
 msgstr[0] "{0} prispevek"
 msgstr[1] "{0} prispevka"
-msgstr[2] "{0} prispevki"
-msgstr[3] "{0} prispevkov"
 
 #: src/olympia/sharing/__init__.py:20
 msgid "Post to Facebook"
@@ -14310,8 +11221,6 @@ msgid "{0} Like"
 msgid_plural "{0} Likes"
 msgstr[0] "{0} všeček"
 msgstr[1] "{0} všečka"
-msgstr[2] "{0} všečki"
-msgstr[3] "{0} všečkov"
 
 #: src/olympia/sharing/__init__.py:30
 msgid "Tweet on Twitter"
@@ -14322,8 +11231,6 @@ msgid "{0} tweet"
 msgid_plural "{0} tweets"
 msgstr[0] "{0} tvit"
 msgstr[1] "{0} tvita"
-msgstr[2] "{0} tviti"
-msgstr[3] "{0} tvitov"
 
 #: src/olympia/sharing/__init__.py:40
 msgid "Share on g+"
@@ -14358,8 +11265,6 @@ msgid "{0} post on localservice1"
 msgid_plural "{0} posts on localservice1"
 msgstr[0] "{0} objava na localservice1"
 msgstr[1] "{0} objavi na localservice1"
-msgstr[2] "{0} objave na localservice1"
-msgstr[3] "{0} objav na localservice1"
 
 #. L10n: Only change if you have reason! wiki.mozilla.org/AMO:Localizers
 #: src/olympia/sharing/__init__.py:76
@@ -14382,8 +11287,6 @@ msgid "{0} post on localservice2"
 msgid_plural "{0} posts on localservice2"
 msgstr[0] "{0} pošta na localservice2"
 msgstr[1] "{0} pošt on localservice2"
-msgstr[2] "{0} pošt on localservice2"
-msgstr[3] "{0} pošt on localservice2"
 
 #. L10n: Only change if you have reason! wiki.mozilla.org/AMO:Localizers
 #: src/olympia/sharing/__init__.py:91
@@ -14406,8 +11309,6 @@ msgid "{0} post on localservice3"
 msgid_plural "{0} posts on localservice3"
 msgstr[0] "{0} pošta na localservice3"
 msgstr[1] "{0} pošt on localservice3"
-msgstr[2] "{0} pošt on localservice3"
-msgstr[3] "{0} pošt on localservice3"
 
 #: src/olympia/sharing/templates/sharing/sharing_widget.html:2
 msgid "Share this Add-on"
@@ -14417,36 +11318,31 @@ msgstr "Deli ta dodatek z drugimi"
 msgid "Share this Collection"
 msgstr "Deli to zbirko z drugimi"
 
-#: src/olympia/signing/views.py:30 src/olympia/templates/base.html:75
-#: src/olympia/templates/impala/base.html:115
-msgid ""
-"Some features are temporarily disabled while we perform website maintenance."
-" We'll be back to full capacity shortly."
-msgstr ""
-"Nekatere značilnosti so zaradi vzdrževanja spletišča začasno izklopljene. Še"
-" malo, pa bomo spet nazaj s polno zmogljivostjo."
+#: src/olympia/signing/views.py:33 src/olympia/templates/base.html:71 src/olympia/templates/impala/base.html:112
+msgid "Some features are temporarily disabled while we perform website maintenance. We'll be back to full capacity shortly."
+msgstr "Nekatere značilnosti so zaradi vzdrževanja spletišča začasno izklopljene. Še malo, pa bomo spet nazaj s polno zmogljivostjo."
 
-#: src/olympia/signing/views.py:53
+#: src/olympia/signing/views.py:56
 msgid "Could not find add-on with id \"{}\"."
 msgstr "Dodatka z ID-jem \"{}\" ni bilo mogoče najti."
 
-#: src/olympia/signing/views.py:67
+#: src/olympia/signing/views.py:70
 msgid "You do not own this addon."
 msgstr "Niste lastnik tega dodatka."
 
-#: src/olympia/signing/views.py:82
+#: src/olympia/signing/views.py:87
 msgid "Missing \"upload\" key in multipart file data."
 msgstr "Manjkajoč ključ \"pošlji\" v večdelnih podatkih datoteke."
 
-#: src/olympia/signing/views.py:96
+#: src/olympia/signing/views.py:101
 msgid "Version does not match the manifest file."
 msgstr "Različica se ne ujema z datoteko manifesta."
 
-#: src/olympia/signing/views.py:100
+#: src/olympia/signing/views.py:105
 msgid "Version already exists."
 msgstr "Različica že obstaja."
 
-#: src/olympia/signing/views.py:136
+#: src/olympia/signing/views.py:141
 msgid "No uploaded file for that addon and version."
 msgstr "Ni poslane datoteke za ta dodatek in različico."
 
@@ -14538,8 +11434,7 @@ msgstr "od"
 msgid "To"
 msgstr "do"
 
-#: src/olympia/stats/templates/stats/popup.html:27
-#: src/olympia/users/templates/users/pwreset_confirm.html:38
+#: src/olympia/stats/templates/stats/popup.html:27 src/olympia/users/templates/users/pwreset_confirm.html:38
 msgid "Update"
 msgstr "Obnovi"
 
@@ -14560,110 +11455,101 @@ msgstr "{0} :: Kontrolna tabla za statistiko"
 msgid "Statistics Dashboard :: Add-ons for {0}"
 msgstr "Kontrolna tabla za statistiko :: Dodatki za {0}"
 
-#: src/olympia/stats/templates/stats/stats.html:30
+# %1 is the name of a collection
+#. {0} is an add-on name
+#: src/olympia/stats/templates/stats/stats.html:44 src/olympia/stats/templates/stats/stats.html:47
+msgid "Statistics for {0}"
+msgstr "Statistika za {0}"
+
+#: src/olympia/stats/templates/stats/stats.html:50
+msgid "Statistics Dashboard"
+msgstr "Kontrolna tabla za statistiko"
+
+#: src/olympia/stats/templates/stats/stats.html:57
 msgid "Controls:"
 msgstr "Kontrole:"
 
-#: src/olympia/stats/templates/stats/stats.html:33
+#: src/olympia/stats/templates/stats/stats.html:60
 msgid "reset zoom"
 msgstr "ponastavi povečavo"
 
-#: src/olympia/stats/templates/stats/stats.html:40
+#: src/olympia/stats/templates/stats/stats.html:67
 msgid "Group by:"
 msgstr "Združi po:"
 
-#: src/olympia/stats/templates/stats/stats.html:42
+#: src/olympia/stats/templates/stats/stats.html:69
 msgid "day"
 msgstr "dan"
 
-#: src/olympia/stats/templates/stats/stats.html:45
+#: src/olympia/stats/templates/stats/stats.html:72
 msgid "week"
 msgstr "teden"
 
-#: src/olympia/stats/templates/stats/stats.html:48
+#: src/olympia/stats/templates/stats/stats.html:75
 msgid "month"
 msgstr "mesec"
 
 # 88%
 # 100%
-#: src/olympia/stats/templates/stats/stats.html:54
+#: src/olympia/stats/templates/stats/stats.html:81
 msgid "For last:"
 msgstr "Za zadnjih:"
 
 # 83%
 # 100%
-#: src/olympia/stats/templates/stats/stats.html:57
+#: src/olympia/stats/templates/stats/stats.html:84
 msgid "7 days"
 msgstr "7 dni"
 
 # 85%
 # 100%
-#: src/olympia/stats/templates/stats/stats.html:60
+#: src/olympia/stats/templates/stats/stats.html:87
 msgid "30 days"
 msgstr "30 dni"
 
 # 85%
 # 100%
-#: src/olympia/stats/templates/stats/stats.html:63
+#: src/olympia/stats/templates/stats/stats.html:90
 msgid "90 days"
 msgstr "90 dni"
 
 # 85%
 # 75%
 # 100%
-#: src/olympia/stats/templates/stats/stats.html:66
+#: src/olympia/stats/templates/stats/stats.html:93
 msgid "365 days"
 msgstr "365 dni"
 
-#: src/olympia/stats/templates/stats/stats.html:69
+#: src/olympia/stats/templates/stats/stats.html:96
 msgid "Custom..."
 msgstr "Po meri ..."
 
-#. {0} is an add-on name
-# %1 is the name of a collection
-#: src/olympia/stats/templates/stats/stats.html:88
-#: src/olympia/stats/templates/stats/stats.html:91
-msgid "Statistics for {0}"
-msgstr "Statistika za {0}"
+#: src/olympia/stats/templates/stats/stats.html:106
+msgid "Statistics processing is currently disabled, so recent data is unavailable. The statistics are still being collected and this page will be updated soon with the missing data."
+msgstr "Obdelava statističnih podatkov je trenutno onemogočena, zato nedavni podatki niso na voljo. Statistika se še vedno zbira, ta stran pa bo kmalu posodobljena z manjkajočimi podatki."
 
-#: src/olympia/stats/templates/stats/stats.html:94
-msgid "Statistics Dashboard"
-msgstr "Kontrolna tabla za statistiko"
-
-#: src/olympia/stats/templates/stats/stats.html:104
-msgid ""
-"Statistics processing is currently disabled, so recent data is unavailable. "
-"The statistics are still being collected and this page will be updated soon "
-"with the missing data."
-msgstr ""
-"Obdelava statističnih podatkov je trenutno onemogočena, zato nedavni podatki"
-" niso na voljo. Statistika se še vedno zbira, ta stran pa bo kmalu "
-"posodobljena z manjkajočimi podatki."
-
-#: src/olympia/stats/templates/stats/stats.html:110
+#: src/olympia/stats/templates/stats/stats.html:112
 msgid "Loading the latest data&hellip;"
 msgstr "Nalaganje najnovejših podatkov&hellip;"
 
-#: src/olympia/stats/templates/stats/stats.html:142
-#: src/olympia/stats/templates/stats/reports/overview.html:25
-#: src/olympia/stats/templates/stats/reports/overview.html:37
+#: src/olympia/stats/templates/stats/stats.html:144 src/olympia/stats/templates/stats/reports/overview.html:25 src/olympia/stats/templates/stats/reports/overview.html:37
 #: src/olympia/stats/templates/stats/reports/overview.html:49
 msgid "No data available."
 msgstr "Podatkov ni na voljo."
 
-#: src/olympia/stats/templates/stats/stats.html:177
+#: src/olympia/stats/templates/stats/stats.html:179
 msgid "This dashboard is currently <b>public</b>."
 msgstr "Kontrolna tabla je trenutno <b>javna</b>."
 
-#: src/olympia/stats/templates/stats/stats.html:179
+#: src/olympia/stats/templates/stats/stats.html:181
 msgid "Contribution stats are currently <b>private</b>."
 msgstr "Statistike o prispevkih so trenutno <b>zasebne</b>."
 
-#: src/olympia/stats/templates/stats/stats.html:182
+#: src/olympia/stats/templates/stats/stats.html:184
 msgid "This dashboard is currently <b>private</b>."
 msgstr "Nadzorna plošča je trenutno <b>zasebna</b>."
 
-#: src/olympia/stats/templates/stats/stats.html:185
+#: src/olympia/stats/templates/stats/stats.html:187
 msgid "Change settings."
 msgstr "Spremeni nastavitve"
 
@@ -14705,13 +11591,11 @@ msgstr "Kako se šteje prenose?"
 
 #: src/olympia/stats/templates/stats/reports/downloads.html:10
 msgid ""
-"<h2>How are downloads counted?</h2> <p> Download counts are updated every "
-"evening and only include original add-on downloads, not updates. Downloads "
-"can be broken down by the specific source referring the download. </p>"
+"<h2>How are downloads counted?</h2> <p> Download counts are updated every evening and only include original add-on downloads, not updates. Downloads can be broken down by the specific source "
+"referring the download. </p>"
 msgstr ""
-"<h2>Kako se šteje prenose? </h2><p> Statistiko prenosov se posodablja vsak "
-"večer, vsebuje pa samo originalne prenose dodatkov, posodobitve pa ne. "
-"Prenose  se lahko loči po konkretnem viru za sklic na prenos.</p>"
+"<h2>Kako se šteje prenose? </h2><p> Statistiko prenosov se posodablja vsak večer, vsebuje pa samo originalne prenose dodatkov, posodobitve pa ne. Prenose  se lahko loči po konkretnem viru za sklic "
+"na prenos.</p>"
 
 #: src/olympia/stats/templates/stats/reports/locales.html:3
 msgid "User languages by Date"
@@ -14725,8 +11609,7 @@ msgstr "Uporaba platforme po datumu"
 msgid "<b>{0}</b> Downloads"
 msgstr "<b>{0}</b> prenosov"
 
-#: src/olympia/stats/templates/stats/reports/overview.html:9
-#: src/olympia/stats/templates/stats/reports/overview.html:13
+#: src/olympia/stats/templates/stats/reports/overview.html:9 src/olympia/stats/templates/stats/reports/overview.html:13
 msgid "Loading..."
 msgstr "Nalaganje..."
 
@@ -14777,34 +11660,17 @@ msgstr "O zasledovanju zunanjih virov ..."
 #: src/olympia/stats/templates/stats/reports/sources.html:10
 #, python-format
 msgid ""
-"<h2>Tracking external sources</h2> <p> If you link to your add-on's details "
-"page or directly to its file from an external site, such as your blog or "
-"website, you can append a parameter to be tracked as an additional download "
-"source on this page. For example, the following links would appear as "
-"sourced by your blog: <dl> <dt>Add-on Details Page</dt> "
-"<dd>https://addons.mozilla.org/addon/%(slug)s?src=<b>external-blog</b></dd> "
-"<dt>Direct File Link</dt> "
-"<dd>https://addons.mozilla.org/downloads/latest/%(id)s/addon-%(id)s-latest.xpi?src=<b"
-">external-blog</b></dd> </dl> <p> Only src parameters that begin with "
-"\"external-\" will be tracked, up to 61 additional characters. Any text "
-"after \"external-\" can be used to describe the source, such as \"external-"
-"blog\", \"external-sidebar\", \"external-campaign225\", etc. The following "
-"URL-safe characters are allowed: <code>a-z A-Z - . _ ~ %% +</code>"
+"<h2>Tracking external sources</h2> <p> If you link to your add-on's details page or directly to its file from an external site, such as your blog or website, you can append a parameter to be "
+"tracked as an additional download source on this page. For example, the following links would appear as sourced by your blog: <dl> <dt>Add-on Details Page</dt> <dd>https://addons.mozilla.org/addon/"
+"%(slug)s?src=<b>external-blog</b></dd> <dt>Direct File Link</dt> <dd>https://addons.mozilla.org/downloads/latest/%(id)s/addon-%(id)s-latest.xpi?src=<b>external-blog</b></dd> </dl> <p> Only src "
+"parameters that begin with \"external-\" will be tracked, up to 61 additional characters. Any text after \"external-\" can be used to describe the source, such as \"external-blog\", \"external-"
+"sidebar\", \"external-campaign225\", etc. The following URL-safe characters are allowed: <code>a-z A-Z - . _ ~ %% +</code>"
 msgstr ""
-"<h2>Sledenje zunanjim virom</h2> <p>Če ste od zunaj, recimo s svoje spletne "
-"strani ali z bloga, naredili povezavo na stran s podrobnostmi svojega "
-"dodatka ali neposredno na datoteko dodatka, lahko dodate parameter, tako da "
-"se povezavi sledi kot dodatnemu, neodvisnemu viru za prenose. Naslednje "
-"povezave bi na primer bile videti, kot da se njihov vir nahaja v vašem "
-"blogu: <dl> <dt>Stran za podrobnosti o dodatku</dt> "
-"<dd>https://addons.mozilla.org/addon/%(slug)s?src=<b>external-blog</b></dd> "
-"<dt>Direktna povezava do datoteke</dt> "
-"<dd>https://addons.mozilla.org/downloads/latest/%(id)s/addon-%(id)s-latest.xpi?src=<b"
-">external-blog</b></dd> </dl> <p> Sledilo se bo samo src parametrom, ki se "
-"začnejo z \"external-\", v dolžini do 61 dodatnih znakov. Poljubno besedilo "
-"po \"external-\" se lahko uporablja za opis vira, kot so \"external-blog\", "
-"\"external-sidebar\", \"external-campaign225\", itd. Za URL so dovoljeni "
-"naslednji znaki: <code>a-z A-Z - . _ ~ %% +</code>"
+"<h2>Sledenje zunanjim virom</h2> <p>Če ste od zunaj, recimo s svoje spletne strani ali z bloga, naredili povezavo na stran s podrobnostmi svojega dodatka ali neposredno na datoteko dodatka, lahko "
+"dodate parameter, tako da se povezavi sledi kot dodatnemu, neodvisnemu viru za prenose. Naslednje povezave bi na primer bile videti, kot da se njihov vir nahaja v vašem blogu: <dl> <dt>Stran za "
+"podrobnosti o dodatku</dt> <dd>https://addons.mozilla.org/addon/%(slug)s?src=<b>external-blog</b></dd> <dt>Direktna povezava do datoteke</dt> <dd>https://addons.mozilla.org/downloads/latest/%(id)s/"
+"addon-%(id)s-latest.xpi?src=<b>external-blog</b></dd> </dl> <p> Sledilo se bo samo src parametrom, ki se začnejo z \"external-\", v dolžini do 61 dodatnih znakov. Poljubno besedilo po \"external-\" "
+"se lahko uporablja za opis vira, kot so \"external-blog\", \"external-sidebar\", \"external-campaign225\", itd. Za URL so dovoljeni naslednji znaki: <code>a-z A-Z - . _ ~ %% +</code>"
 
 #: src/olympia/stats/templates/stats/reports/statuses.html:3
 msgid "Add-on Status by Date"
@@ -14824,28 +11690,19 @@ msgstr "Kdo so dnevni uporabniki?"
 
 #: src/olympia/stats/templates/stats/reports/usage.html:11
 msgid ""
-"<h2>What are daily users?</h2> <p> Themes installed from this site check for"
-" updates once per day. The total number of these update pings is known as "
-"Active Daily Users, or the total number of people using your theme by day. "
-"</p>"
+"<h2>What are daily users?</h2> <p> Themes installed from this site check for updates once per day. The total number of these update pings is known as Active Daily Users, or the total number of "
+"people using your theme by day. </p>"
 msgstr ""
-"<h2>Kdo so dnevni uporabniki?</h2> <p> Teme, nameščene s te strani, enkrat "
-"dnevno preverjajo posodobitve. Skupno število teh posodobitvenih pingov je "
-"znano kot Aktivni dnevni uporabniki, oziroma število uporabnikov, ki dnevno "
-"uporabljajo vašo temo. </p>"
+"<h2>Kdo so dnevni uporabniki?</h2> <p> Teme, nameščene s te strani, enkrat dnevno preverjajo posodobitve. Skupno število teh posodobitvenih pingov je znano kot Aktivni dnevni uporabniki, oziroma "
+"število uporabnikov, ki dnevno uporabljajo vašo temo. </p>"
 
 #: src/olympia/stats/templates/stats/reports/usage.html:20
 msgid ""
-"<h2>What are daily users?</h2> <p> Add-ons downloaded from this site check "
-"for updates once per day. The total number of these update pings is known as"
-" Active Daily Users. Daily users can be broken down by add-on version, "
-"operating system, add-on status, application, and locale. </p>"
+"<h2>What are daily users?</h2> <p> Add-ons downloaded from this site check for updates once per day. The total number of these update pings is known as Active Daily Users. Daily users can be broken "
+"down by add-on version, operating system, add-on status, application, and locale. </p>"
 msgstr ""
-"<h2>Kdo so dnevni uporabniki?</h2> <p> Dodatki, nameščeni s te strani, "
-"enkrat dnevno preverjajo posodobitve. Skupno število teh preverjanj je znano"
-" kot Aktivni dnevni uporabniki. Dnevne uporabnike se lahko razčleni po "
-"različici dodatka, operacijskem sistemu, stanju dodatka, aplikaciji in "
-"jeziku. </p>"
+"<h2>Kdo so dnevni uporabniki?</h2> <p> Dodatki, nameščeni s te strani, enkrat dnevno preverjajo posodobitve. Skupno število teh preverjanj je znano kot Aktivni dnevni uporabniki. Dnevne uporabnike "
+"se lahko razčleni po različici dodatka, operacijskem sistemu, stanju dodatka, aplikaciji in jeziku. </p>"
 
 #: src/olympia/stats/templates/stats/reports/users_created.html:3
 msgid "User Signups by Date"
@@ -14855,45 +11712,27 @@ msgstr "Prijave uporabnikov po datumu"
 msgid "Application versions by Date"
 msgstr "Različice aplikacije po datumu"
 
-# {0} is a number
-#: src/olympia/tags/templates/tags/top_cloud.html:4
-msgid "Top {0} Tags"
-msgstr "{0} top oznaka"
-
-#. {0} is the current application name
-#: src/olympia/tags/templates/tags/top_cloud.html:14
-msgid "{0} Top Tags"
-msgstr "{0} top oznak"
-
-#: src/olympia/templates/amo_footer.html:6
-#: src/olympia/templates/includes/lang_switcher.html:2
+#: src/olympia/templates/amo_footer.html:6 src/olympia/templates/includes/lang_switcher.html:2
 msgid "Other languages"
 msgstr "Drugi jeziki"
 
-#: src/olympia/templates/base.html:9 src/olympia/templates/impala/base.html:9
-#: src/olympia/templates/mobile/base_addons.html:9
+#: src/olympia/templates/base.html:9 src/olympia/templates/impala/base.html:9 src/olympia/templates/mobile/base_addons.html:9
 msgid "Mozilla Add-ons"
 msgstr "Dodatki Mozilla"
 
-#: src/olympia/templates/base.html:91
-#: src/olympia/templates/impala/base.html:81
+#: src/olympia/templates/base.html:89 src/olympia/templates/impala/base.html:78
 msgid "Find add-ons for other applications"
 msgstr "Poišči dodatke za druge aplikacije"
 
-#: src/olympia/templates/base.html:92
-#: src/olympia/templates/impala/base.html:81
+#: src/olympia/templates/base.html:90 src/olympia/templates/impala/base.html:78
 msgid "Other Applications"
 msgstr "Ostale aplikacije"
 
-#: src/olympia/templates/base.html:141
-#: src/olympia/templates/impala/base.html:194
-msgid ""
-"To create your own collections, you must have a Mozilla Add-ons account."
-msgstr ""
-"Če želite ustvarjate lastne zbirke, morate imeti račun pri Dodatki Mozille."
+#: src/olympia/templates/base.html:141 src/olympia/templates/impala/base.html:194
+msgid "To create your own collections, you must have a Mozilla Add-ons account."
+msgstr "Če želite ustvarjate lastne zbirke, morate imeti račun pri Dodatki Mozille."
 
-#: src/olympia/templates/base.html:168
-#: src/olympia/templates/impala/base.html:215
+#: src/olympia/templates/base.html:168 src/olympia/templates/impala/base.html:215
 msgid "Footer logo"
 msgstr "Logotip noge"
 
@@ -14910,20 +11749,18 @@ msgid "View Mobile Site"
 msgstr "Prikaži mobilno stran"
 
 #: src/olympia/templates/copyright.html:7
-msgid "Site Status "
+msgid "Site Status"
 msgstr "Stanje strani "
 
 #: src/olympia/templates/footer.html:3
 msgid "get to know <b>add-ons</b>"
 msgstr "seznanite se z <b>dodatki</b>"
 
-#: src/olympia/templates/footer.html:4
-#: src/olympia/templates/menu_links.html:20
+#: src/olympia/templates/footer.html:4 src/olympia/templates/menu_links.html:20
 msgid "About"
 msgstr "Vizitka"
 
-#: src/olympia/templates/footer.html:5
-#: src/olympia/templates/menu_links.html:32
+#: src/olympia/templates/footer.html:5 src/olympia/templates/menu_links.html:32
 msgid "Blog"
 msgstr "Blog"
 
@@ -14999,9 +11836,7 @@ msgstr "Pravno"
 msgid "Contact Us"
 msgstr "Stopite v stik z nami"
 
-#: src/olympia/templates/user_login.html:22
-#: src/olympia/users/templates/users/edit.html:31
-#: src/olympia/users/templates/users/includes/navigation.html:12
+#: src/olympia/templates/user_login.html:22 src/olympia/users/templates/users/edit.html:31 src/olympia/users/templates/users/includes/navigation.html:12
 msgid "My Account"
 msgstr "Moj račun"
 
@@ -15009,65 +11844,48 @@ msgstr "Moj račun"
 msgid "Welcome, {0}"
 msgstr "Dobrodošli, {0}"
 
-#: src/olympia/templates/user_login.html:41
-#: src/olympia/templates/impala/user_login.html:20
+#: src/olympia/templates/user_login.html:41 src/olympia/templates/impala/user_login.html:20
 #, python-format
 msgid "<a href=\"%(reg)s\">Register</a> or <a href=\"%(login)s\">Log in</a>"
-msgstr ""
-"<a href=\"%(reg)s\">Registrirajte se</a> ali <a "
-"href=\"%(login)s\">Prijavite</a>"
+msgstr "<a href=\"%(reg)s\">Registrirajte se</a> ali <a href=\"%(login)s\">Prijavite</a>"
 
-#: src/olympia/templates/impala/base.html:126
+#: src/olympia/templates/impala/base.html:123
 #, python-format
-msgid ""
-"To try the thousands of add-ons available here, download <a "
-"href=\"%(url)s\">Mozilla Firefox</a>, a fast, free way to surf the Web!"
-msgstr ""
-"Za uporabo na tisoče dodatkov na voljo tukaj, prenesite <a "
-"href=\"%(url)s\">Mozilla Firefox</a> - hiter, prost spletni brskalnik."
+msgid "To try the thousands of add-ons available here, download <a href=\"%(url)s\">Mozilla Firefox</a>, a fast, free way to surf the Web!"
+msgstr "Za uporabo na tisoče dodatkov na voljo tukaj, prenesite <a href=\"%(url)s\">Mozilla Firefox</a> - hiter, prost spletni brskalnik."
 
-#: src/olympia/templates/impala/base.html:138
+#: src/olympia/templates/impala/base.html:135
 #, python-format
-msgid ""
-"Add-ons is switching to Firefox Accounts for login. <a href=\"%(url)s\" "
-"class=\"fxa-login\">Sign in now to transfer your account.</a>"
-msgstr ""
-"Dodatki bodo za prijavo preklopili na Firefox Račune. <a href=\"%(url)s\" "
-"class=\"fxa-login\">Prijavite se, da prenesete svoj račun</a>."
+msgid "Add-ons is switching to Firefox Accounts for login. <a href=\"%(url)s\" class=\"fxa-login\">Sign in now to transfer your account.</a>"
+msgstr "Dodatki bodo za prijavo preklopili na Firefox Račune. <a href=\"%(url)s\" class=\"fxa-login\">Prijavite se, da prenesete svoj račun</a>."
 
 #. {0} is an application, such as Firefox.
-#: src/olympia/templates/impala/base.html:148
+#: src/olympia/templates/impala/base.html:145
 msgid "Welcome to {0} Add-ons."
 msgstr "Dobrodošli pri dodatkih za {0}."
 
-#: src/olympia/templates/impala/base.html:151
-msgid ""
-"Choose from thousands of extra features and styles to make Firefox your own."
-msgstr ""
-"Izberite med več tisoč dodatnih funkcij in slogov za Firefox, kar vam "
-"najbolj odgovarja."
+#: src/olympia/templates/impala/base.html:148
+msgid "Choose from thousands of extra features and styles to make Firefox your own."
+msgstr "Izberite med več tisoč dodatnih funkcij in slogov za Firefox, kar vam najbolj odgovarja."
 
-#: src/olympia/templates/impala/base.html:156
+#: src/olympia/templates/impala/base.html:153
 #, python-format
 msgid "Add extra features and styles to make %(app)s your own."
 msgstr "Dodajte funkcije in sloge, kot vam za %(app)s najbolj odgovarja."
 
-#: src/olympia/templates/impala/base.html:164
+#: src/olympia/templates/impala/base.html:161
 msgid "On the go?"
 msgstr "Na poti?"
 
-#: src/olympia/templates/impala/base.html:166
+#: src/olympia/templates/impala/base.html:163
 msgid "Check out our <a class=\"mobile-link\" href=\"#\">Mobile Add-ons site</a>."
-msgstr ""
-"Oglejte si našo<a class=\"mobile-link\" href=\"#\">spletno stran za dodatke "
-"za mobilne naprave</a>."
+msgstr "Oglejte si našo<a class=\"mobile-link\" href=\"#\">spletno stran za dodatke za mobilne naprave</a>."
 
 #: src/olympia/templates/impala/header_title.html:21
 msgid "Android Add-ons"
 msgstr "Dodatki za Android"
 
-#: src/olympia/templates/includes/forms.html:2
-#: src/olympia/templates/includes/forms.html:6
+#: src/olympia/templates/includes/forms.html:2 src/olympia/templates/includes/forms.html:6
 msgid "required"
 msgstr "potrebno"
 
@@ -15112,15 +11930,11 @@ msgstr "Obiščite Mozillo"
 msgid "menu"
 msgstr "meni"
 
-#: src/olympia/templates/mobile/header_auth.html:7
-#: src/olympia/users/templates/users/register.html:41
-#: src/olympia/users/templates/users/register.html:89
+#: src/olympia/templates/mobile/header_auth.html:7 src/olympia/users/templates/users/register.html:41 src/olympia/users/templates/users/register.html:89
 msgid "Register"
 msgstr "Registrirajte se"
 
-#: src/olympia/templates/mobile/header_auth.html:8
-#: src/olympia/users/templates/users/login_form.html:41
-#: src/olympia/users/templates/users/pwreset_complete.html:15
+#: src/olympia/templates/mobile/header_auth.html:8 src/olympia/users/templates/users/login_form.html:41 src/olympia/users/templates/users/pwreset_complete.html:15
 #: src/olympia/users/templates/users/mobile/login.html:56
 msgid "Log in"
 msgstr "Prijava"
@@ -15131,8 +11945,7 @@ msgstr "Prijava"
 msgid "Localize for: <a id=\"change-locale\" href=\"#\">%(dl)s</a>"
 msgstr "Prevedite v drug jezik: <a id=\"change-locale\" href=\"#\">%(dl)s</a>"
 
-#: src/olympia/translations/templates/translations/trans-menu.html:16
-#: src/olympia/translations/templates/translations/trans-menu.html:29
+#: src/olympia/translations/templates/translations/trans-menu.html:16 src/olympia/translations/templates/translations/trans-menu.html:29
 #, python-format
 msgid "%(title)s <em>&middot; %(lang)s</em>"
 msgstr "%(title)s <em>&middot; %(lang)s</em>"
@@ -15147,12 +11960,8 @@ msgstr "Nove lokalizacije"
 
 #. {0} is a language name, like 'French'
 #: src/olympia/translations/templates/translations/trans-menu.html:42
-msgid ""
-"You have unsaved changes in the <b>{0}</b> locale. Would you like to save "
-"your changes before switching locales?"
-msgstr ""
-"Nekatere spremembe za lokalno nastavitev <b>{0}</b> niso shranjene. Želite "
-"spremembe shraniti, preden zamenjate lokalno nastavitev?"
+msgid "You have unsaved changes in the <b>{0}</b> locale. Would you like to save your changes before switching locales?"
+msgstr "Nekatere spremembe za lokalno nastavitev <b>{0}</b> niso shranjene. Želite spremembe shraniti, preden zamenjate lokalno nastavitev?"
 
 #: src/olympia/translations/templates/translations/trans-menu.html:49
 msgid "Discard Changes"
@@ -15160,11 +11969,8 @@ msgstr "Zavrzi spremembe"
 
 #. {0} is a language name, like 'French'
 #: src/olympia/translations/templates/translations/trans-menu.html:56
-msgid ""
-"Are you sure you want to remove all <b>{0}</b> translations? This cannot be "
-"undone."
-msgstr ""
-"Res želite odstraniti vse prevode <b>{0}</b>? Za ta korak ni povratka."
+msgid "Are you sure you want to remove all <b>{0}</b> translations? This cannot be undone."
+msgstr "Res želite odstraniti vse prevode <b>{0}</b>? Za ta korak ni povratka."
 
 #: src/olympia/translations/templates/translations/trans-menu.html:61
 msgid "Delete Locale"
@@ -15185,23 +11991,14 @@ msgstr "To geslo ni dovoljeno."
 
 #: src/olympia/users/forms.py:90
 #, python-format
-msgid ""
-"As part of our new password policy, your password must be %s characters or "
-"more. Please update your password by <a href=\"%s\">issuing a password "
-"reset</a>."
-msgstr ""
-"Kot del naše nove politike gesel mora vaše geslo vsebovati %s znakov ali "
-"več. Prosimo, posodobite svoje geslo z <a href=\"%s\">izdajo ponastavitve "
-"gesla</a>."
+msgid "As part of our new password policy, your password must be %s characters or more. Please update your password by <a href=\"%s\">issuing a password reset</a>."
+msgstr "Kot del naše nove politike gesel mora vaše geslo vsebovati %s znakov ali več. Prosimo, posodobite svoje geslo z <a href=\"%s\">izdajo ponastavitve gesla</a>."
 
 #: src/olympia/users/forms.py:115
-msgid ""
-"You must recover your password through Firefox Accounts. Try logging in "
-"instead."
+msgid "You must recover your password through Firefox Accounts. Try logging in instead."
 msgstr "Geslo morate obnoviti preko Firefox Računov. Poskusite s prijavo."
 
-#: src/olympia/users/forms.py:206
-#: src/olympia/users/templates/users/pwreset_confirm.html:24
+#: src/olympia/users/forms.py:206 src/olympia/users/templates/users/pwreset_confirm.html:24
 msgid "New password"
 msgstr "Novo geslo"
 
@@ -15214,12 +12011,8 @@ msgid "Usernames cannot contain only digits."
 msgstr "Uporabniška imena ne morejo vsebovati samo številk."
 
 #: src/olympia/users/forms.py:274
-msgid ""
-"Enter a valid username consisting of letters, numbers, underscores or "
-"hyphens."
-msgstr ""
-"Vnesite veljavno uporabniško ime sestavljeno iz črk, števk, podčrtajev in "
-"vezajev."
+msgid "Enter a valid username consisting of letters, numbers, underscores or hyphens."
+msgstr "Vnesite veljavno uporabniško ime sestavljeno iz črk, števk, podčrtajev in vezajev."
 
 #: src/olympia/users/forms.py:277
 msgid "This username cannot be used."
@@ -15229,38 +12022,25 @@ msgstr "Tega uporabniškega imena ni mogoče uporabiti."
 msgid "This username is already in use."
 msgstr "To uporabniško ime je že v uporabi."
 
-#: src/olympia/users/forms.py:296
-#: src/olympia/users/templates/users/edit.html:107
+#: src/olympia/users/forms.py:296 src/olympia/users/templates/users/edit.html:107
 msgid "Display Name"
 msgstr "Prikazno ime"
 
-#: src/olympia/users/forms.py:298
-#: src/olympia/users/templates/users/edit.html:112
-#: src/olympia/users/templates/users/vcard.html:10
+#: src/olympia/users/forms.py:298 src/olympia/users/templates/users/edit.html:112 src/olympia/users/templates/users/vcard.html:10
 msgid "Location"
 msgstr "Lokacija"
 
-#: src/olympia/users/forms.py:300
-#: src/olympia/users/templates/users/edit.html:117
-#: src/olympia/users/templates/users/vcard.html:16
+#: src/olympia/users/forms.py:300 src/olympia/users/templates/users/edit.html:117 src/olympia/users/templates/users/vcard.html:16
 msgid "Occupation"
 msgstr "Poklic"
 
 #: src/olympia/users/forms.py:329
-msgid ""
-"This URL has an invalid format. Valid URLs look like "
-"http://example.com/my_page."
-msgstr ""
-"Oblika tega spletnega naslova je neveljavna. Veljaven URL je videti takole: "
-"http://primer.com/moja_stran."
+msgid "This URL has an invalid format. Valid URLs look like http://example.com/my_page."
+msgstr "Oblika tega spletnega naslova je neveljavna. Veljaven URL je videti takole: http://primer.com/moja_stran."
 
 #: src/olympia/users/forms.py:337
-msgid ""
-"Please use an email address from a different provider to complete your "
-"registration."
-msgstr ""
-"Uporabite prosim e-poštni naslov kakega drugega ponudnika, da dokončate "
-"svojo registracijo."
+msgid "Please use an email address from a different provider to complete your registration."
+msgstr "Uporabite prosim e-poštni naslov kakega drugega ponudnika, da dokončate svojo registracijo."
 
 #: src/olympia/users/forms.py:345
 msgid "This display name cannot be used."
@@ -15270,21 +12050,17 @@ msgstr "Tega prikaznega imena ni mogoče uporabljati."
 msgid "The passwords did not match."
 msgstr "Gesli se nista ujemali."
 
-#: src/olympia/users/forms.py:377
-#: src/olympia/users/templates/users/edit.html:128
+#: src/olympia/users/forms.py:377 src/olympia/users/templates/users/edit.html:128
 msgid "Profile Photo"
 msgstr "Slika za profil"
 
-#: src/olympia/users/forms.py:385
-#: src/olympia/users/templates/users/edit.html:142
+#: src/olympia/users/forms.py:385 src/olympia/users/templates/users/edit.html:142
 msgid "Default locale"
 msgstr "Privzeta območna nastavitev"
 
 #: src/olympia/users/forms.py:412
 msgid "Firefox Accounts users cannot currently change their email address."
-msgstr ""
-"Uporabniki Firefox Računov trenutno ne morejo spremeniti svojega e-poštnega "
-"naslova."
+msgstr "Uporabniki Firefox Računov trenutno ne morejo spremeniti svojega e-poštnega naslova."
 
 #: src/olympia/users/forms.py:446
 msgid "Wrong password entered!"
@@ -15295,12 +12071,8 @@ msgid "Email cannot be changed."
 msgstr "E-poštnega naslova ni mogoče spremeniti."
 
 #: src/olympia/users/forms.py:541
-msgid ""
-"To anonymize, enter a reason for the change but do not change any other "
-"field."
-msgstr ""
-"Za anonimizacijo vnesite razlog za spremembo, vendar ne spreminjajte ostalih"
-" polj."
+msgid "To anonymize, enter a reason for the change but do not change any other field."
+msgstr "Za anonimizacijo vnesite razlog za spremembo, vendar ne spreminjajte ostalih polj."
 
 #: src/olympia/users/forms.py:587
 msgid "Please enter at least one name to blacklist."
@@ -15329,19 +12101,19 @@ msgstr "Ni uporabnika s tem e-naslovom."
 
 #. L10n: {id} will be something like "13ad6a", just a random number
 #. to differentiate this user from other anonymous users.
-#: src/olympia/users/models.py:353
+#: src/olympia/users/models.py:362
 msgid "Anonymous user {id}"
 msgstr "Anonimni uporabnik {id}"
 
-#: src/olympia/users/models.py:410
+#: src/olympia/users/models.py:419
 msgid "Your account has been restricted"
 msgstr "Vaš račun se je omejilo"
 
-#: src/olympia/users/models.py:480
+#: src/olympia/users/models.py:489
 msgid "Please confirm your email address"
 msgstr "Potrdite prosim svoj e-naslov"
 
-#: src/olympia/users/models.py:506
+#: src/olympia/users/models.py:515
 msgid "My Mobile Add-ons"
 msgstr "Moji mobilni dodatki"
 
@@ -15408,17 +12180,12 @@ msgid "Mozilla needs to contact me about my individual app"
 msgstr "Mozilla mora stopiti v stik z mano zaradi določene aplikacije"
 
 #: src/olympia/users/notifications.py:139
-msgid ""
-"Mozilla wants to contact me about relevant App Developer news and surveys"
-msgstr ""
-"Mozilla želi priti v stik z mano zaradi pomembnih novic in anket za "
-"razvijalce aplikacij"
+msgid "Mozilla wants to contact me about relevant App Developer news and surveys"
+msgstr "Mozilla želi priti v stik z mano zaradi pomembnih novic in anket za razvijalce aplikacij"
 
 #: src/olympia/users/notifications.py:150
 msgid "Mozilla wants to contact me about new regions added to the Marketplace"
-msgstr ""
-"Mozilla želi priti v stik z mano glede novih območij, ki jih je dodala v "
-"Marketplace"
+msgstr "Mozilla želi priti v stik z mano glede novih območij, ki jih je dodala v Marketplace"
 
 #: src/olympia/users/notifications.py:158
 msgid "User Notifications"
@@ -15441,14 +12208,8 @@ msgid "Successfully verified!"
 msgstr "Uspešno preverjeno!"
 
 #: src/olympia/users/views.py:132
-msgid ""
-"An email has been sent to your address to confirm your account. Before you "
-"can log in, you have to activate your account by clicking on the link "
-"provided in this email."
-msgstr ""
-"Poslali smo vam e-pošto na vaš naslov, da potrdite svoj novi račun. Preden "
-"se lahko prijavite, morate aktivirati svoj račun s klikom na povezavo v tej "
-"e-pošti."
+msgid "An email has been sent to your address to confirm your account. Before you can log in, you have to activate your account by clicking on the link provided in this email."
+msgstr "Poslali smo vam e-pošto na vaš naslov, da potrdite svoj novi račun. Preden se lahko prijavite, morate aktivirati svoj račun s klikom na povezavo v tej e-pošti."
 
 #: src/olympia/users/views.py:136 src/olympia/users/views.py:619
 msgid "Confirmation Email Sent"
@@ -15472,13 +12233,11 @@ msgstr "Poštno potrdilo poslano po E-pošti"
 
 #: src/olympia/users/views.py:197
 msgid ""
-"An email has been sent to {0} to confirm your new email address. For the "
-"change to take effect, you need to click on the link provided in this email."
-" Until then, you can keep logging in with your current email address."
+"An email has been sent to {0} to confirm your new email address. For the change to take effect, you need to click on the link provided in this email. Until then, you can keep logging in with your "
+"current email address."
 msgstr ""
-"Poslali smo vam e-pošto na {0}, da potrdite svoj novi račun. Preden se lahko"
-" prijavite, morate aktivirati svoj račun s klikom na povezavo v tej e-pošti."
-"  Do nadaljnjega se lahko prijavljate s svojim sedanjim e-poštnim naslovom."
+"Poslali smo vam e-pošto na {0}, da potrdite svoj novi račun. Preden se lahko prijavite, morate aktivirati svoj račun s klikom na povezavo v tej e-pošti.  Do nadaljnjega se lahko prijavljate s "
+"svojim sedanjim e-poštnim naslovom."
 
 #: src/olympia/users/views.py:210
 #, python-format
@@ -15490,15 +12249,11 @@ msgid "Errors Found"
 msgstr "Najdene napake"
 
 #: src/olympia/users/views.py:225
-msgid ""
-"There were errors in the changes you made. Please correct them and resubmit."
-msgstr ""
-"V spremembah, ki ste jih naredili, so bile napake. Prosimo, da jih popravite"
-" in ponovno pošljete."
+msgid "There were errors in the changes you made. Please correct them and resubmit."
+msgstr "V spremembah, ki ste jih naredili, so bile napake. Prosimo, da jih popravite in ponovno pošljete."
 
 #: src/olympia/users/views.py:273
-msgid ""
-"We're sorry, but you are not eligible to request a t-shirt at this time."
+msgid "We're sorry, but you are not eligible to request a t-shirt at this time."
 msgstr "Trenutni niste upravičeni za zahtevo po majici."
 
 #: src/olympia/users/views.py:329
@@ -15514,25 +12269,17 @@ msgid "Wrong email address or password!"
 msgstr "Napačen e-poštni naslov ali geslo!"
 
 #: src/olympia/users/views.py:434
-msgid ""
-"A link to activate your user account was sent by email to your address {0}. "
-"You have to click it before you can log in."
-msgstr ""
-"Povezavo za aktiviranje vašega uporabniškega računa se je po elektronski "
-"pošti poslalo na vaš naslov {0}. Preden se prijavite, morate klikniti nanjo."
+msgid "A link to activate your user account was sent by email to your address {0}. You have to click it before you can log in."
+msgstr "Povezavo za aktiviranje vašega uporabniškega računa se je po elektronski pošti poslalo na vaš naslov {0}. Preden se prijavite, morate klikniti nanjo."
 
 #: src/olympia/users/views.py:439
 #, python-format
 msgid ""
-"If you did not receive the confirmation email, make sure your email service "
-"did not mark it as \"junk mail\" or \"spam\". If you need to, you can have "
-"us <a href=\"%s\">resend the confirmation message</a> to your email address "
-"mentioned above."
+"If you did not receive the confirmation email, make sure your email service did not mark it as \"junk mail\" or \"spam\". If you need to, you can have us <a href=\"%s\">resend the confirmation "
+"message</a> to your email address mentioned above."
 msgstr ""
-"Če niste prejeli potrditvene e-pošte, preverite, da ni bila označena za "
-"\"neželeno\" ali \"vsiljeno pošto\". Če je treba, vam lahko <a "
-"href=\"%s\">sporočilo za potrditev ponovno pošljemo</a> na vaš zgoraj "
-"omenjeni e-poštni naslov."
+"Če niste prejeli potrditvene e-pošte, preverite, da ni bila označena za \"neželeno\" ali \"vsiljeno pošto\". Če je treba, vam lahko <a href=\"%s\">sporočilo za potrditev ponovno pošljemo</a> na vaš "
+"zgoraj omenjeni e-poštni naslov."
 
 #: src/olympia/users/views.py:444
 msgid "Activation Email Sent"
@@ -15552,13 +12299,8 @@ msgstr "Čestitamo! Vaš uporabniški račun je bil uspešno ustvarjen."
 
 # %1 is the user's email address
 #: src/olympia/users/views.py:615
-msgid ""
-"An email has been sent to your address {0} to confirm your account. Before "
-"you can log in, you have to activate your account by clicking on the link "
-"provided in this email."
-msgstr ""
-"Poslali smo vam e-pošto na {0}, da potrdite svoj novi račun. Preden se lahko"
-" prijavite, morate aktivirati svoj račun s klikom na povezavo v tej e-pošti."
+msgid "An email has been sent to your address {0} to confirm your account. Before you can log in, you have to activate your account by clicking on the link provided in this email."
+msgstr "Poslali smo vam e-pošto na {0}, da potrdite svoj novi račun. Preden se lahko prijavite, morate aktivirati svoj račun s klikom na povezavo v tej e-pošti."
 
 #: src/olympia/users/views.py:639
 msgid "There are errors in this form"
@@ -15576,32 +12318,22 @@ msgstr "Uporabnik sporočen."
 msgid "new"
 msgstr "novo"
 
-#: src/olympia/users/templates/users/delete.html:4
-#: src/olympia/users/templates/users/delete.html:10
+#: src/olympia/users/templates/users/delete.html:4 src/olympia/users/templates/users/delete.html:10
 msgid "Delete User Account"
 msgstr "Izbriši uporabniški račun"
 
 #: src/olympia/users/templates/users/delete.html:14
 #, python-format
 msgid ""
-"You cannot delete your account if you are listed as an <a href=\"%(link)s\">"
-" author of any add-ons</a>. To delete your account, please have another "
-"person in your development group delete you from the list of authors for "
-"your add-ons. Afterwards you will be able to delete your account here."
+"You cannot delete your account if you are listed as an <a href=\"%(link)s\"> author of any add-ons</a>. To delete your account, please have another person in your development group delete you from "
+"the list of authors for your add-ons. Afterwards you will be able to delete your account here."
 msgstr ""
-"Ne morete izbrisati svojega računa, če ste navedeni kot <a "
-"href=\"%(link)s\">avtor kateregakoli dodatka</a>. Če želite zbrisati svoj "
-"račun, prosite enega od kolegov v vaši skupini za razvoj, da vas izbriše s "
-"seznama avtorjev za vaše dodatke. Potem lahko svoj račun na tem mestu "
-"izbrišete."
+"Ne morete izbrisati svojega računa, če ste navedeni kot <a href=\"%(link)s\">avtor kateregakoli dodatka</a>. Če želite zbrisati svoj račun, prosite enega od kolegov v vaši skupini za razvoj, da vas "
+"izbriše s seznama avtorjev za vaše dodatke. Potem lahko svoj račun na tem mestu izbrišete."
 
 #: src/olympia/users/templates/users/delete.html:29
-msgid ""
-"By clicking \"delete\" your account is going to be <strong>permanently "
-"removed</strong>. That means:"
-msgstr ""
-"Ko kliknete \"izbriši\", bo vaš račun <strong>trajno odstranjen</strong>. To"
-" pomeni:"
+msgid "By clicking \"delete\" your account is going to be <strong>permanently removed</strong>. That means:"
+msgstr "Ko kliknete \"izbriši\", bo vaš račun <strong>trajno odstranjen</strong>. To pomeni:"
 
 #: src/olympia/users/templates/users/delete.html:35
 #, python-format
@@ -15609,9 +12341,7 @@ msgid "You will not be able to log into %(site)s anymore."
 msgstr "Ne boste se več mogli prijaviti na %(site)s."
 
 #: src/olympia/users/templates/users/delete.html:40
-msgid ""
-"Your reviews and ratings will not be deleted, but they will no longer be "
-"associated with you."
+msgid "Your reviews and ratings will not be deleted, but they will no longer be associated with you."
 msgstr "Vaše ocene ne bodo izbrisane, vendar ne bodo več povezane z vami."
 
 #: src/olympia/users/templates/users/delete.html:46
@@ -15626,8 +12356,7 @@ msgstr "Razumem, da ta korak ni mogoče razveljaviti."
 msgid "Delete my user account now"
 msgstr "Izbriši moj uporabniški račun zdaj"
 
-#: src/olympia/users/templates/users/delete_photo.html:3
-#: src/olympia/users/templates/users/delete_photo.html:9
+#: src/olympia/users/templates/users/delete_photo.html:3 src/olympia/users/templates/users/delete_photo.html:9
 msgid "Delete User Photo"
 msgstr "Izbriši sliko uporabnika"
 
@@ -15640,27 +12369,18 @@ msgid "Please set your display name"
 msgstr "Nastavite svoje prikazno ime"
 
 #: src/olympia/users/templates/users/edit.html:21
-msgid ""
-"Please set your display name or username to complete the registration "
-"process."
-msgstr ""
-"Za dokončanje postopka registracije nastavite svoje prikazno ime ali "
-"uporabniško ime."
+msgid "Please set your display name or username to complete the registration process."
+msgstr "Za dokončanje postopka registracije nastavite svoje prikazno ime ali uporabniško ime."
 
 #: src/olympia/users/templates/users/edit.html:33
 msgid "Manage basic account information, such as username and email address."
-msgstr ""
-"Urejanje osnovnih podatkov o računu, kot sta recimo uporabniško ime in "
-"poštni naslov. "
+msgstr "Urejanje osnovnih podatkov o računu, kot sta recimo uporabniško ime in poštni naslov. "
 
-#: src/olympia/users/templates/users/edit.html:39
-#: src/olympia/users/templates/users/register.html:47
+#: src/olympia/users/templates/users/edit.html:39 src/olympia/users/templates/users/register.html:47
 msgid "Username"
 msgstr "Uporabniško ime"
 
-#: src/olympia/users/templates/users/edit.html:45
-#: src/olympia/users/templates/users/pwreset_request.html:21
-#: src/olympia/users/templates/users/register.html:62
+#: src/olympia/users/templates/users/edit.html:45 src/olympia/users/templates/users/pwreset_request.html:21 src/olympia/users/templates/users/register.html:62
 msgid "Email Address"
 msgstr "E-poštni naslov"
 
@@ -15672,21 +12392,15 @@ msgstr "Urejanje Firefox Računa ..."
 msgid "Change Password"
 msgstr "Spremeni geslo"
 
-#: src/olympia/users/templates/users/edit.html:68
-#: src/olympia/users/templates/users/login_form.html:22
-#: src/olympia/users/templates/users/register.html:67
+#: src/olympia/users/templates/users/edit.html:68 src/olympia/users/templates/users/login_form.html:22 src/olympia/users/templates/users/register.html:67
 #: src/olympia/users/templates/users/mobile/login.html:37
 msgid "Password"
 msgstr "Geslo"
 
 #: src/olympia/users/templates/users/edit.html:70
 #, python-format
-msgid ""
-"Change your password.  If you forgot your password, you can <a "
-"href=\"%(reset_url)s\">use the reset form</a>."
-msgstr ""
-"Spremenite svoje geslo.  Če ste pozabili geslo, lahko <a "
-"href=\"%(reset_url)s\">uporabite obrazec za ponastavitev</a>."
+msgid "Change your password. If you forgot your password, you can <a href=\"%(reset_url)s\">use the reset form</a>."
+msgstr "Spremenite svoje geslo.  Če ste pozabili geslo, lahko <a href=\"%(reset_url)s\">uporabite obrazec za ponastavitev</a>."
 
 #: src/olympia/users/templates/users/edit.html:76
 msgid "Old Password"
@@ -15705,12 +12419,8 @@ msgid "Profile"
 msgstr "Profil"
 
 #: src/olympia/users/templates/users/edit.html:100
-msgid ""
-"Give us a bit more information about yourself.  All these fields are "
-"optional, but they'll help other users get to know you better."
-msgstr ""
-"Povejte nam kaj več o sebi.  Vsa ta polja sicer niso obvezna, vendar pa bodo"
-" pomagala drugim uporabnikom, da vas bolje spoznajo."
+msgid "Give us a bit more information about yourself. All these fields are optional, but they'll help other users get to know you better."
+msgstr "Povejte nam kaj več o sebi.  Vsa ta polja sicer niso obvezna, vendar pa bodo pomagala drugim uporabnikom, da vas bolje spoznajo."
 
 #: src/olympia/users/templates/users/edit.html:124
 msgid "This URL will only be visible if you are a developer."
@@ -15725,20 +12435,12 @@ msgid "Delete current photo"
 msgstr "Izbriši trenutno sliko"
 
 #: src/olympia/users/templates/users/edit.html:144
-msgid ""
-"This is the default locale used to display information about you (like your "
-"description)."
-msgstr ""
-"To je privzeta območna nastavitev, uporabljena za prikaz informacij o vas "
-"(npr. vaš opis)."
+msgid "This is the default locale used to display information about you (like your description)."
+msgstr "To je privzeta območna nastavitev, uporabljena za prikaz informacij o vas (npr. vaš opis)."
 
 #: src/olympia/users/templates/users/edit.html:152
-msgid ""
-"Introduce yourself to the community, if you like! This text will appear "
-"publicly on your user info page."
-msgstr ""
-"Če želite, se lahko predstavite skupnosti! To besedilo bo javno prikazano na"
-" strani z informacijami o uporabniku."
+msgid "Introduce yourself to the community, if you like! This text will appear publicly on your user info page."
+msgstr "Če želite, se lahko predstavite skupnosti! To besedilo bo javno prikazano na strani z informacijami o uporabniku."
 
 #: src/olympia/users/templates/users/edit.html:161
 msgid "Allowed HTML: {0}. Links are forbidden."
@@ -15765,21 +12467,12 @@ msgid "Notifications"
 msgstr "Uradna obvestila"
 
 #: src/olympia/users/templates/users/edit.html:195
-msgid ""
-"From time to time, Mozilla may send you email about upcoming releases and "
-"add-on events. Please select the topics you are interested in."
-msgstr ""
-"Od časa do časa vam bo Mozilla lahko da poslala e-pošto o prihajajočih "
-"objavah in dogodkih okoli dodatkov. Izberite prosim spodaj teme, ki bi vas "
-"zanimale:"
+msgid "From time to time, Mozilla may send you email about upcoming releases and add-on events. Please select the topics you are interested in."
+msgstr "Od časa do časa vam bo Mozilla lahko da poslala e-pošto o prihajajočih objavah in dogodkih okoli dodatkov. Izberite prosim spodaj teme, ki bi vas zanimale:"
 
 #: src/olympia/users/templates/users/edit.html:205
-msgid ""
-"Mozilla reserves the right to contact you individually about specific "
-"concerns with your hosted add-ons."
-msgstr ""
-"Mozilla si pridržuje pravico, da se obrne na vas osebno v zvezi z vprašanji,"
-" ki se tičejo vaših gostujočih dodatkov."
+msgid "Mozilla reserves the right to contact you individually about specific concerns with your hosted add-ons."
+msgstr "Mozilla si pridržuje pravico, da se obrne na vas osebno v zvezi z vprašanji, ki se tičejo vaših gostujočih dodatkov."
 
 #: src/olympia/users/templates/users/edit.html:215
 msgid "Admin"
@@ -15801,62 +12494,48 @@ msgstr "nič"
 msgid "all"
 msgstr "vse"
 
-#: src/olympia/users/templates/users/fxa_migration.html:3
-#: src/olympia/users/templates/users/fxa_migration.html:11
-#: src/olympia/users/templates/users/mobile/fxa_migration.html:3
+#: src/olympia/users/templates/users/fxa_migration.html:3 src/olympia/users/templates/users/fxa_migration.html:11 src/olympia/users/templates/users/mobile/fxa_migration.html:3
 #: src/olympia/users/templates/users/mobile/fxa_migration.html:8
 msgid "Migrate to Firefox Accounts"
 msgstr "Preklopi na Firefox Račune"
 
 #: src/olympia/users/templates/users/fxa_migration_prompt_content.html:3
-msgid ""
-"Mozilla Add-ons has transitioned to Firefox Accounts for login. Continue to "
-"complete the simple upgrade process."
-msgstr ""
-"Dodatki Mozilla so se za prijavljanje preselili na Firefox Račune. "
-"Nadaljujte za dokončanje preprostega postopa nadgradnje."
+msgid "Mozilla Add-ons has transitioned to Firefox Accounts for login. Continue to complete the simple upgrade process."
+msgstr "Dodatki Mozilla so se za prijavljanje preselili na Firefox Račune. Nadaljujte za dokončanje preprostega postopa nadgradnje."
 
 #: src/olympia/users/templates/users/fxa_migration_prompt_content.html:14
 msgid "Skip"
 msgstr "Preskoči"
 
-#: src/olympia/users/templates/users/login.html:3
-#: src/olympia/users/templates/users/mobile/login.html:3
+#: src/olympia/users/templates/users/login.html:3 src/olympia/users/templates/users/mobile/login.html:3
 msgid "User Login"
 msgstr "Prijava uporabnika"
 
-#: src/olympia/users/templates/users/login.html:13
-#: src/olympia/users/templates/users/mobile/login.html:21
+#: src/olympia/users/templates/users/login.html:13 src/olympia/users/templates/users/mobile/login.html:21
 msgid "Enter your email"
 msgstr "Vnesite e-poštni naslov"
 
-#: src/olympia/users/templates/users/login.html:15
-#: src/olympia/users/templates/users/mobile/login.html:23
+#: src/olympia/users/templates/users/login.html:15 src/olympia/users/templates/users/mobile/login.html:23
 msgid "Log In"
 msgstr "Prijava"
 
-#: src/olympia/users/templates/users/login_form.html:17
-#: src/olympia/users/templates/users/mobile/login.html:32
+#: src/olympia/users/templates/users/login_form.html:17 src/olympia/users/templates/users/mobile/login.html:32
 msgid "Email address"
 msgstr "E-poštni naslov"
 
-#: src/olympia/users/templates/users/login_form.html:30
-#: src/olympia/users/templates/users/mobile/login.html:44
+#: src/olympia/users/templates/users/login_form.html:30 src/olympia/users/templates/users/mobile/login.html:44
 msgid "Remember me on this device"
 msgstr "Zapomni si me na tej napravi"
 
-#: src/olympia/users/templates/users/login_help.html:3
-#: src/olympia/users/templates/users/mobile/login.html:63
+#: src/olympia/users/templates/users/login_help.html:3 src/olympia/users/templates/users/mobile/login.html:63
 msgid "Login Problems?"
 msgstr "Problemi ob prijavi?"
 
-#: src/olympia/users/templates/users/login_help.html:5
-#: src/olympia/users/templates/users/mobile/login.html:65
+#: src/olympia/users/templates/users/login_help.html:5 src/olympia/users/templates/users/mobile/login.html:65
 msgid "I don't have an account."
 msgstr "Nimam računa."
 
-#: src/olympia/users/templates/users/login_help.html:6
-#: src/olympia/users/templates/users/mobile/login.html:66
+#: src/olympia/users/templates/users/login_help.html:6 src/olympia/users/templates/users/mobile/login.html:66
 msgid "I forgot my password."
 msgstr "Ne vem več svojega gesla."
 
@@ -15865,15 +12544,9 @@ msgstr "Ne vem več svojega gesla."
 msgid "You are now logged in as <strong>%(user_email)s</strong>!"
 msgstr "Prijavljeni ste zdaj kot <strong>%(user_email)s</strong>!"
 
-#: src/olympia/users/templates/users/newpw_sent.html:3
-#: src/olympia/users/templates/users/newpw_sent.html:8
-#: src/olympia/users/templates/users/pwreset_complete.html:3
-#: src/olympia/users/templates/users/pwreset_confirm.html:4
-#: src/olympia/users/templates/users/pwreset_confirm.html:18
-#: src/olympia/users/templates/users/pwreset_request.html:4
-#: src/olympia/users/templates/users/pwreset_request.html:10
-#: src/olympia/users/templates/users/pwreset_sent.html:3
-#: src/olympia/users/templates/users/pwreset_sent.html:8
+#: src/olympia/users/templates/users/newpw_sent.html:3 src/olympia/users/templates/users/newpw_sent.html:8 src/olympia/users/templates/users/pwreset_complete.html:3
+#: src/olympia/users/templates/users/pwreset_confirm.html:4 src/olympia/users/templates/users/pwreset_confirm.html:18 src/olympia/users/templates/users/pwreset_request.html:4
+#: src/olympia/users/templates/users/pwreset_request.html:10 src/olympia/users/templates/users/pwreset_sent.html:3 src/olympia/users/templates/users/pwreset_sent.html:8
 msgid "Password Reset"
 msgstr "Ponastavitev gesla"
 
@@ -15889,8 +12562,7 @@ msgstr "Uredi profil"
 msgid "Manage user"
 msgstr "Uredi uporabnika"
 
-#: src/olympia/users/templates/users/profile.html:18
-#: src/olympia/users/templates/users/report_abuse_full.html:9
+#: src/olympia/users/templates/users/profile.html:18 src/olympia/users/templates/users/report_abuse_full.html:9
 msgid "Report user"
 msgstr "Prijavi uporabnika"
 
@@ -15953,38 +12625,25 @@ msgstr "Uspeh!"
 msgid "Password successfully reset."
 msgstr "Geslo je uspešno ponastavljeno."
 
-#: src/olympia/users/templates/users/pwreset_confirm.html:13
-#: src/olympia/users/templates/users/pwreset_confirm.html:46
+#: src/olympia/users/templates/users/pwreset_confirm.html:13 src/olympia/users/templates/users/pwreset_confirm.html:46
 msgid "Password reset unsuccessful"
 msgstr "Ponastavitev gesla neuspešna"
 
 #: src/olympia/users/templates/users/pwreset_confirm.html:14
-msgid ""
-"You have migrated to Firefox Accounts. You can no longer change your "
-"password here."
-msgstr ""
-"Preklopili ste na Firefox Račune. Tukaj ne morete več spreminjati gesla."
+msgid "You have migrated to Firefox Accounts. You can no longer change your password here."
+msgstr "Preklopili ste na Firefox Račune. Tukaj ne morete več spreminjati gesla."
 
-#: src/olympia/users/templates/users/pwreset_confirm.html:31
-#: src/olympia/users/templates/users/register.html:72
+#: src/olympia/users/templates/users/pwreset_confirm.html:31 src/olympia/users/templates/users/register.html:72
 msgid "Confirm password"
 msgstr "Potrdite geslo"
 
 #: src/olympia/users/templates/users/pwreset_confirm.html:47
-msgid ""
-"The password reset link was invalid, possibly because it has already been "
-"used.  Please request a new password reset."
-msgstr ""
-"Povezava za ponastavitev gesla je bila neveljavna, morda zato, ker je že "
-"bila uporabljena.  Ponovno zahtevajte ponastavitev gesla."
+msgid "The password reset link was invalid, possibly because it has already been used. Please request a new password reset."
+msgstr "Povezava za ponastavitev gesla je bila neveljavna, morda zato, ker je že bila uporabljena.  Ponovno zahtevajte ponastavitev gesla."
 
 #: src/olympia/users/templates/users/pwreset_request.html:15
-msgid ""
-"Forgotten your password? Enter your e-mail address below, and we'll e-mail "
-"instructions for setting a new one."
-msgstr ""
-"Ste pozabili svoje geslo? Vnesite svoj e-mail naslov, mi pa vam bomo na vaš "
-"naslov poslali navodila, kako si uredite novo geslo."
+msgid "Forgotten your password? Enter your e-mail address below, and we'll e-mail instructions for setting a new one."
+msgstr "Ste pozabili svoje geslo? Vnesite svoj e-mail naslov, mi pa vam bomo na vaš naslov poslali navodila, kako si uredite novo geslo."
 
 #: src/olympia/users/templates/users/pwreset_request.html:25
 msgid "Send password reset link"
@@ -15992,13 +12651,9 @@ msgstr "Pošlji povezavo za ponastavitev gesla"
 
 #: src/olympia/users/templates/users/pwreset_sent.html:10
 msgid ""
-"An email has been sent to the requested account with further information. If"
-" you do not receive an email then please confirm you have entered the same "
-"email address used during account registration."
+"An email has been sent to the requested account with further information. If you do not receive an email then please confirm you have entered the same email address used during account registration."
 msgstr ""
-"E-pošta je bila poslana na zahtevani račun z dodatnimi informacijami. Če ne "
-"prejmete e-pošte, potem prosim potrdite, da ste vpisali isti e-poštni "
-"naslov, kot je bil vnesen pri registraciji računa."
+"E-pošta je bila poslana na zahtevani račun z dodatnimi informacijami. Če ne prejmete e-pošte, potem prosim potrdite, da ste vpisali isti e-poštni naslov, kot je bil vnesen pri registraciji računa."
 
 #: src/olympia/users/templates/users/register.html:4
 msgid "New User Registration"
@@ -16009,12 +12664,8 @@ msgid "Why register?"
 msgstr "Čemu se prijaviti?"
 
 #: src/olympia/users/templates/users/register.html:14
-msgid ""
-"Registration on AMO is <strong>not required</strong> if you simply want to "
-"download and install public add-ons."
-msgstr ""
-"Registracija na AMO <strong>ni potrebna</strong>, če želite samo prenašati "
-"in nameščati javne dodatke."
+msgid "Registration on AMO is <strong>not required</strong> if you simply want to download and install public add-ons."
+msgstr "Registracija na AMO <strong>ni potrebna</strong>, če želite samo prenašati in nameščati javne dodatke."
 
 #: src/olympia/users/templates/users/register.html:16
 msgid "You only need to register if:"
@@ -16025,52 +12676,29 @@ msgid "You want to submit reviews for add-ons"
 msgstr "Želite ocenjevati dodatke"
 
 #: src/olympia/users/templates/users/register.html:19
-msgid ""
-"You want to keep track of your favorite add-on collections or create one "
-"yourself"
-msgstr ""
-"Želite slediti svojim najljubšim zbirkam dodatkov in sami ustvariti eno"
+msgid "You want to keep track of your favorite add-on collections or create one yourself"
+msgstr "Želite slediti svojim najljubšim zbirkam dodatkov in sami ustvariti eno"
 
 #: src/olympia/users/templates/users/register.html:20
-msgid ""
-"You are an add-on developer and want to upload your add-on for hosting on "
-"AMO"
-msgstr ""
-"Ste razvijalec dodatkov in želite naložiti svoje dodatke za gostovanje na "
-"AMO"
+msgid "You are an add-on developer and want to upload your add-on for hosting on AMO"
+msgstr "Ste razvijalec dodatkov in želite naložiti svoje dodatke za gostovanje na AMO"
 
 #: src/olympia/users/templates/users/register.html:23
-msgid ""
-"Upon successful registration, you will be sent a confirmation email to the "
-"address you provided. Please follow the instructions there to confirm your "
-"account."
-msgstr ""
-"Po uspešni registraciji boste na naslov, ki ste ga navedli, prejeli "
-"potrditveno elektronsko sporočilo. Prosimo, sledite tem navodilom za "
-"potrditev svojega računa."
+msgid "Upon successful registration, you will be sent a confirmation email to the address you provided. Please follow the instructions there to confirm your account."
+msgstr "Po uspešni registraciji boste na naslov, ki ste ga navedli, prejeli potrditveno elektronsko sporočilo. Prosimo, sledite tem navodilom za potrditev svojega računa."
 
 #: src/olympia/users/templates/users/register.html:30
 #, python-format
-msgid ""
-"If you like, you can read our <a href=\"%(legal)s\" title=\"Legal "
-"Notices\">Legal Notices</a> and <a href=\"%(privacy)s\" title=\"Privacy "
-"Policy\">Privacy Policy</a>."
-msgstr ""
-"Če želite, lahko preberete naša <a href=\"%(legal)s\" title=\"Pravna "
-"obvestila\">pravna obvestila</a> in <a href=\"%(privacy)s\" title=\"Politika"
-" zasebnosti\">politiko zasebnosti</a>."
+msgid "If you like, you can read our <a href=\"%(legal)s\" title=\"Legal Notices\">Legal Notices</a> and <a href=\"%(privacy)s\" title=\"Privacy Policy\">Privacy Policy</a>."
+msgstr "Če želite, lahko preberete naša <a href=\"%(legal)s\" title=\"Pravna obvestila\">pravna obvestila</a> in <a href=\"%(privacy)s\" title=\"Politika zasebnosti\">politiko zasebnosti</a>."
 
 #: src/olympia/users/templates/users/register.html:52
 msgid "Display name"
 msgstr "Prikazno ime"
 
 #: src/olympia/users/templates/users/report_abuse.html:7
-msgid ""
-"Please describe why you are reporting this user, such as for spam or an "
-"inappropriate picture."
-msgstr ""
-"Opišite vzrok, zakaj želite prijaviti tega uporabnika, recimo zaradi smeti "
-"ali neprimerne slike."
+msgid "Please describe why you are reporting this user, such as for spam or an inappropriate picture."
+msgstr "Opišite vzrok, zakaj želite prijaviti tega uporabnika, recimo zaradi smeti ali neprimerne slike."
 
 #: src/olympia/users/templates/users/report_abuse_full.html:3
 msgid "Report user {0}"
@@ -16084,40 +12712,25 @@ msgstr "Naročilo majice"
 msgid "Special Edition Add-on Creator T-shirt"
 msgstr "Posebna izdaja majice Ustvarjalec dodatka"
 
-#: src/olympia/users/templates/users/t-shirt.html:14
-#: src/olympia/users/templates/users/t-shirt.html:120
+#: src/olympia/users/templates/users/t-shirt.html:14 src/olympia/users/templates/users/t-shirt.html:120
 msgid "Note:"
 msgstr "Opomba:"
 
 #: src/olympia/users/templates/users/t-shirt.html:15
-msgid ""
-"You have already submitted a request for a t-shirt. You may re-submit this "
-"form to update your information, but you will only receive one shirt."
-msgstr ""
-"Zahtevo za majico ste že poslali. Ta obrazec lahko ponovno pošljete, da "
-"posodobite svoje podatke, vendar boste prejeli samo eno majico."
+msgid "You have already submitted a request for a t-shirt. You may re-submit this form to update your information, but you will only receive one shirt."
+msgstr "Zahtevo za majico ste že poslali. Ta obrazec lahko ponovno pošljete, da posodobite svoje podatke, vendar boste prejeli samo eno majico."
 
 #: src/olympia/users/templates/users/t-shirt.html:26
-msgid ""
-"Thank you for helping to make Firefox the most extensible browser available!"
-msgstr ""
-"Hvala, da pomagate Firefox narediti najbolj razširljiv brskalnik na trgu!"
+msgid "Thank you for helping to make Firefox the most extensible browser available!"
+msgstr "Hvala, da pomagate Firefox narediti najbolj razširljiv brskalnik na trgu!"
 
 #: src/olympia/users/templates/users/t-shirt.html:33
-msgid ""
-"As a thank you gift, we'd like to send you a special-edition, community-"
-"designed t-shirt. To receive your shirt, please fill out the form below."
-msgstr ""
-"Kot zahvalno darilo bi vam radi poslali posebno izdajo majice, ki jo je "
-"oblikovala skupnost. Da jo prejmete, izpolnite spodnji obrazec."
+msgid "As a thank you gift, we'd like to send you a special-edition, community-designed t-shirt. To receive your shirt, please fill out the form below."
+msgstr "Kot zahvalno darilo bi vam radi poslali posebno izdajo majice, ki jo je oblikovala skupnost. Da jo prejmete, izpolnite spodnji obrazec."
 
 #: src/olympia/users/templates/users/t-shirt.html:41
-msgid ""
-"Your contact information will only be used by Mozilla to ship this special "
-"edition t-shirt."
-msgstr ""
-"Vaše podatke bo Mozilla uporabila samo za pošiljanje posebne izdaje te "
-"majice."
+msgid "Your contact information will only be used by Mozilla to ship this special edition t-shirt."
+msgstr "Vaše podatke bo Mozilla uporabila samo za pošiljanje posebne izdaje te majice."
 
 #: src/olympia/users/templates/users/t-shirt.html:60
 msgid "Mailing Address"
@@ -16173,20 +12786,14 @@ msgstr "Zahtevaj majico"
 
 #: src/olympia/users/templates/users/t-shirt.html:137
 msgid ""
-"We're sorry, but in order to qualify for our special edition t-shirt, you "
-"must be an add-on developer with at least one listed add-on, one unlisted "
-"but signed add-on, or any number of background themes with a combined total "
-"of 10,000 average daily users."
+"We're sorry, but in order to qualify for our special edition t-shirt, you must be an add-on developer with at least one listed add-on, one unlisted but signed add-on, or any number of background "
+"themes with a combined total of 10,000 average daily users."
 msgstr ""
-"Da ste upravičeni do posebne izdaje naše majice, morate biti razvijalec "
-"dodatkov z vsaj enim navedenim dodatkom, enim nenavedenim, vendar podpisanim"
-" ali katerimkoli številom tem za ozadje s skupnim številom 10.000-ih "
-"povprečnih dnevnih uporabnikov."
+"Da ste upravičeni do posebne izdaje naše majice, morate biti razvijalec dodatkov z vsaj enim navedenim dodatkom, enim nenavedenim, vendar podpisanim ali katerimkoli številom tem za ozadje s skupnim "
+"številom 10.000-ih povprečnih dnevnih uporabnikov."
 
 #: src/olympia/users/templates/users/tougher_password.html:2
-msgid ""
-"For your account a password must contain at least 8 characters including "
-"letters and numbers."
+msgid "For your account a password must contain at least 8 characters including letters and numbers."
 msgstr "Za svoj račun mora geslo vsebovati vsaj 8 znakov, to je črk in števk."
 
 #: src/olympia/users/templates/users/unsubscribe.html:2
@@ -16199,11 +12806,8 @@ msgstr "Uspešno ste se odjavili!"
 
 #: src/olympia/users/templates/users/unsubscribe.html:10
 #, python-format
-msgid ""
-"The email address <strong>%(email)s</strong> will no longer get messages "
-"when:"
-msgstr ""
-"E-poštni naslov <strong>%(email)s</strong> ne bo več dobival pošte, ko:"
+msgid "The email address <strong>%(email)s</strong> will no longer get messages when:"
+msgstr "E-poštni naslov <strong>%(email)s</strong> ne bo več dobival pošte, ko:"
 
 #: src/olympia/users/templates/users/unsubscribe.html:20
 msgid "More Actions:"
@@ -16223,14 +12827,8 @@ msgstr "Ni vas bilo mogoče odjaviti"
 
 #: src/olympia/users/templates/users/unsubscribe.html:30
 #, python-format
-msgid ""
-"Unfortunately, we weren't able to unsubscribe you.  The link you clicked is "
-"invalid. However, you can unsubscribe still unsubscribe on your <a "
-"href=\"%(edit_url)s\">edit profile page</a>."
-msgstr ""
-"Na žalost vas ne moremo odjaviti.  Povezava, na katero ste kliknili, je "
-"neveljavna.  Vendar se še vedno lahko odjavite na svoji <a "
-"href=\"%(edit_url)s\">strani za urejanje profila</a>."
+msgid "Unfortunately, we weren't able to unsubscribe you. The link you clicked is invalid. However, you can unsubscribe still unsubscribe on your <a href=\"%(edit_url)s\">edit profile page</a>."
+msgstr "Na žalost vas ne moremo odjaviti.  Povezava, na katero ste kliknili, je neveljavna.  Vendar se še vedno lahko odjavite na svoji <a href=\"%(edit_url)s\">strani za urejanje profila</a>."
 
 #: src/olympia/users/templates/users/vcard.html:2
 msgid "Developer Information"
@@ -16262,8 +12860,6 @@ msgid "%(num)s theme"
 msgid_plural "%(num)s themes"
 msgstr[0] "%(num)s tema"
 msgstr[1] "%(num)s temi"
-msgstr[2] "%(num)s teme"
-msgstr[3] "%(num)s tem"
 
 #: src/olympia/users/templates/users/vcard.html:62
 #, python-format
@@ -16271,8 +12867,6 @@ msgid "%(num)s add-on"
 msgid_plural "%(num)s add-ons"
 msgstr[0] "%(num)s dodatek"
 msgstr[1] "%(num)s dodatka"
-msgstr[2] "%(num)s dodatki"
-msgstr[3] "%(num)s dodatkov"
 
 #: src/olympia/users/templates/users/vcard.html:75
 msgid "Average rating of developer's add-ons"
@@ -16287,15 +12881,15 @@ msgstr "Zgodovina različice %s"
 msgid "Version History with Changelogs"
 msgstr "Zgodovina različic z dnevniki sprememb"
 
-#: src/olympia/versions/models.py:314
+#: src/olympia/versions/models.py:313
 msgid "Add-on uses binary components."
 msgstr "Dodarek vsebuje binarne komponente."
 
-#: src/olympia/versions/models.py:317
+#: src/olympia/versions/models.py:316
 msgid "Add-on has opted into strict compatibility checking."
 msgstr "Dodatek je vključen v strogo preverjanje združljivosti."
 
-#: src/olympia/versions/models.py:715
+#: src/olympia/versions/models.py:711
 msgid "{app} {min} and later"
 msgstr "{app} {min} in kasneje"
 
@@ -16311,9 +12905,7 @@ msgstr "Objavljeno {0}"
 #: src/olympia/versions/templates/versions/version.html:39
 #, python-format
 msgid "Source code released under <a target=\"_blank\" href=\"%(url)s\">%(name)s</a>"
-msgstr ""
-"Izvorna koda je objavljena pod <a target=\"_blank\" "
-"href=\"%(url)s\">%(name)s</a>"
+msgstr "Izvorna koda je objavljena pod <a target=\"_blank\" href=\"%(url)s\">%(name)s</a>"
 
 #: src/olympia/versions/templates/versions/version.html:44
 #, python-format
@@ -16324,8 +12916,8 @@ msgstr "Izvorna koda je objavljena pod <a href=\"%(url)s\">%(name)s</a>"
 msgid "View the source"
 msgstr "Ogled vira"
 
-#. {0} is an add-on name.
 # {0} is the add-on name
+#. {0} is an add-on name.
 #: src/olympia/versions/templates/versions/version_list.html:26
 msgid "{0} Version History"
 msgstr "Zgodovina različic {0}"
@@ -16336,23 +12928,15 @@ msgid "<b>{0}</b> version"
 msgid_plural "<b>{0}</b> versions"
 msgstr[0] "<b>{0}</b> različica"
 msgstr[1] "<b>{0}</b> različici"
-msgstr[2] "<b>{0}</b> različice"
-msgstr[3] "<b>{0}</b> različic"
 
-#: src/olympia/versions/templates/versions/version_list.html:35
-#: src/olympia/versions/templates/versions/mobile/version_list.html:14
+#: src/olympia/versions/templates/versions/version_list.html:35 src/olympia/versions/templates/versions/mobile/version_list.html:14
 msgid "Be careful with old versions!"
 msgstr "Bodite previdni pri starih različicah!"
 
-#: src/olympia/versions/templates/versions/version_list.html:36
-#: src/olympia/versions/templates/versions/mobile/version_list.html:15
+#: src/olympia/versions/templates/versions/version_list.html:36 src/olympia/versions/templates/versions/mobile/version_list.html:15
 #, python-format
-msgid ""
-"These versions are displayed for reference and testing purposes. You should "
-"always use the <a href=\"%(url)s\">latest version</a> of an add-on."
-msgstr ""
-"Te različice se prikazuje za namene sklicevanja in testiranja. Uporabljajte "
-"vedno samo <a href=\"%(url)s\">najnovejše različice</a> dodatkov."
+msgid "These versions are displayed for reference and testing purposes. You should always use the <a href=\"%(url)s\">latest version</a> of an add-on."
+msgstr "Te različice se prikazuje za namene sklicevanja in testiranja. Uporabljajte vedno samo <a href=\"%(url)s\">najnovejše različice</a> dodatkov."
 
 #: src/olympia/versions/templates/versions/mobile/version.html:4
 msgid "Beta Version {0}"
@@ -16382,3 +12966,7 @@ msgstr "E-pošta, ko končano"
 #: src/olympia/zadmin/forms.py:105
 msgid "Log emails instead of sending"
 msgstr "Zavedi e-pošto, namesto da se jo pošlje"
+
+#: src/olympia/zadmin/forms.py:215
+msgid "Deleted versions can`t be changed."
+msgstr ""

--- a/locale/sl/LC_MESSAGES/djangojs.po
+++ b/locale/sl/LC_MESSAGES/djangojs.po
@@ -1,1310 +1,1266 @@
 # smo <smolejv@gmx.net>, 2013.
 msgid ""
 msgstr ""
-"Project-Id-Version: support.mozilla.com\n"
+"Project-Id-Version:  support.mozilla.com\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2016-02-24 21:23+0000\n"
+"POT-Creation-Date: 2016-04-18 15:47+0000\n"
 "PO-Revision-Date: 2016-02-26 11:02+0000\n"
 "Last-Translator: Peter Klofutar <peter_klofutar@telemach.net>\n"
 "Language-Team: Slovenian\n"
-"Language: sl\n"
+"Language: \n"
 "MIME-Version: 1.0\n"
-"Content-Type: text/plain; charset=utf-8\n"
+"Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Plural-Forms: nplurals=4; plural=(n%100==1 ? 0 : n%100==2 ? 1 : n%100==3 || n%100==4 ? 2 : 3);\n"
 "Generated-By: Babel 2.2.0\n"
-"X-Generator: Pontoon\n"
 
-#: static/js/common/ratingwidget.js:31
+#: static/js/common-all.js:1426 static/js/impala-all.js:1511 static/js/zamboni/discovery-all.js:12598 static/js/zamboni/init.js:28 static/js/zamboni/mobile-all.js:14945
+msgid "This feature is temporarily disabled while we perform website maintenance. Please check back a little later."
+msgstr "Ta funkcija je začasno onemogočena, medtem ko na strani izvajamo vzdrževalna dela. Prosimo, poskusite znova malo kasneje."
+
+#. L10n: {0} is an app name like Firefox.
+#: static/js/common-all.js:1837 static/js/impala-all.js:1922 static/js/zamboni/buttons.js:73 static/js/zamboni/discovery-all.js:13108
+msgid "Accept and Install"
+msgstr "Sprejmi in namesti"
+
+#: static/js/common-all.js:1837 static/js/impala-all.js:1922 static/js/zamboni/buttons.js:73 static/js/zamboni/discovery-all.js:13108
+msgid "Add to {0}"
+msgstr "Dodaj v {0}"
+
+#: static/js/common-all.js:1842 static/js/impala-all.js:1927 static/js/zamboni/buttons.js:78 static/js/zamboni/discovery-all.js:13113
+msgid "Download Now"
+msgstr "Prenesi zdaj"
+
+#: static/js/common-all.js:1883 static/js/impala-all.js:1968 static/js/zamboni/buttons.js:119 static/js/zamboni/discovery-all.js:13154
+msgid "Add-on has not been updated to support default-to-compatible."
+msgstr "Dodatek ni bil posodobljen, da bi podpiral privzeto-na-združljivo."
+
+#: static/js/common-all.js:1888 static/js/impala-all.js:1973 static/js/zamboni/buttons.js:124 static/js/zamboni/discovery-all.js:13159
+msgid "You need to be using Firefox 10.0 or higher."
+msgstr "Uporabljati morate Firefox 10.0 ali novejšega."
+
+#: static/js/common-all.js:1900 static/js/impala-all.js:1985 static/js/zamboni/buttons.js:136 static/js/zamboni/discovery-all.js:13171
+msgid "Mozilla has marked this version as incompatible with your Firefox version."
+msgstr "Mozilla je označila to različico kot nezdružljivo z vašo različico Firefoxa."
+
+#. L10n: {0} is an platform like Windows or Linux.
+#: static/js/common-all.js:1981 static/js/impala-all.js:2066 static/js/zamboni/buttons.js:217 static/js/zamboni/discovery-all.js:13252
+msgid "Install for {0} anyway"
+msgstr "Vseeno namesti za {0}"
+
+#: static/js/common-all.js:1981 static/js/impala-all.js:2066 static/js/zamboni/buttons.js:217 static/js/zamboni/discovery-all.js:13252
+msgid "Download for {0} anyway"
+msgstr "Vseeno prenesi za {0}"
+
+#: static/js/common-all.js:2038 static/js/impala-all.js:2123 static/js/zamboni/buttons.js:274 static/js/zamboni/discovery-all.js:13309
+msgid "Not available for your platform"
+msgstr "Ni na voljo za vašo podlago"
+
+#. L10n: {0} is an app name, {1} is the app version.
+#: static/js/common-all.js:2049 static/js/common-all.js:2086 static/js/impala-all.js:2134 static/js/impala-all.js:2171 static/js/zamboni/buttons.js:286 static/js/zamboni/buttons.js:324
+#: static/js/zamboni/discovery-all.js:13320 static/js/zamboni/discovery-all.js:13357
+msgid "Not available for {0} {1}"
+msgstr "Ni na voljo za {0} {1}"
+
+#: static/js/common-all.js:2112 static/js/impala-all.js:2197 static/js/zamboni/buttons.js:351 static/js/zamboni/discovery-all.js:13383
+msgid "Works with {app} {min} - {max}"
+msgstr "Deluje s {app} {min} - {max}"
+
+#: static/js/common-all.js:2114 static/js/impala-all.js:2199 static/js/zamboni/buttons.js:353 static/js/zamboni/discovery-all.js:13385
+msgid "View other versions"
+msgstr "Ogled drugih različic"
+
+#: static/js/common-all.js:2162 static/js/impala-all.js:2247 static/js/zamboni/buttons.js:401 static/js/zamboni/discovery-all.js:13433
+msgid "Only with Firefox — Get Firefox Now!"
+msgstr "Samo pri Firefoxu – namestite ga!"
+
+#: static/js/common-all.js:2278 static/js/impala-all.js:2363 static/js/zamboni/buttons.js:517 static/js/zamboni/discovery-all.js:13549 static/js/zamboni/mobile-all.js:15177
+#: static/js/zamboni/mobile/buttons.js:43
+msgid "Sorry, you need a Mozilla-based browser (such as Firefox) to install a search plugin."
+msgstr "Oprostite, za namestitev vtičnika za iskanje potrebujete brskalnik na osnovi Mozille (kot je Firefox)."
+
+#: static/js/common-all.js:9088 static/js/impala-all.js:9649 static/js/zamboni/global.js:410
+msgid "Loading..."
+msgstr "Nalaganje..."
+
+#. L10n: {0} is the number of characters left.
+#: static/js/common-all.js:9152 static/js/impala-all.js:9713 static/js/zamboni/global.js:474
+msgid "<b>{0}</b> character left."
+msgid_plural "<b>{0}</b> characters left."
+msgstr[0] "<b>{0}</b> znak preostane."
+msgstr[1] "<b>{0}</b> znaka preostaneta."
+msgstr[2] ""
+msgstr[3] ""
+
+#: static/js/common-all.js:9589 static/js/common-min.js:6 static/js/impala-all.js:10052 static/js/impala-min.js:6 static/js/common/ratingwidget.js:31 static/js/zamboni/mobile-all.js:16123
+#: static/js/zamboni/mobile-min.js:6
 msgid "{0} star"
 msgid_plural "{0} stars"
 msgstr[0] "{0} zvezdica"
 msgstr[1] "{0} zvezdici"
-msgstr[2] "{0} zvezdice"
-msgstr[3] "{0} zvezdic"
+msgstr[2] ""
+msgstr[3] ""
 
-#: static/js/common/upload-addon.js:41 static/js/common/upload-image.js:128
+#: static/js/common-all.js:9676 static/js/common-min.js:6 static/js/impala-all.js:10139 static/js/impala-min.js:6 static/js/zamboni/l10n.js:45
+msgid "Remove this localization"
+msgstr "Odstrani to lokalizacijo"
+
+#: static/js/common-all.js:10193 static/js/common-min.js:6 static/js/impala-all.js:10674 static/js/impala-min.js:6 static/js/zamboni/discovery-all.js:13678
+msgid "close"
+msgstr ""
+
+#: static/js/common-all.js:10860 static/js/common-min.js:6 static/js/impala-all.js:11481 static/js/impala-min.js:6 static/js/impala/reviews.js:23 static/js/zamboni/reviews.js:18
+msgid "Flagged for review"
+msgstr "Označeno za pregled"
+
+#: static/js/common-all.js:10876 static/js/common-min.js:6 static/js/impala-all.js:11498 static/js/impala-min.js:6 static/js/impala/reviews.js:40 static/js/zamboni/reviews.js:34
+msgid "Your input is required"
+msgstr "Zahtevan je vaš vnos"
+
+#: static/js/common-all.js:10945 static/js/common-min.js:6 static/js/impala-all.js:11610 static/js/impala-min.js:7 static/js/impala/reviews.js:152 static/js/zamboni/reviews.js:103
+msgid "Marked for deletion"
+msgstr "Označeno za izbris"
+
+#: static/js/common-all.js:11573 static/js/common-min.js:7 static/js/impala-all.js:13809 static/js/impala-min.js:8 static/js/zamboni/collections.js:229
+msgid "Adding to Favorites&hellip;"
+msgstr "Dodajanje med priljubljene &hellip;"
+
+#: static/js/common-all.js:11576 static/js/common-min.js:7 static/js/impala-all.js:13812 static/js/impala-min.js:8 static/js/zamboni/collections.js:232
+msgid "Removing Favorite&hellip;"
+msgstr "Odstranjevanje priljubljene &hellip;"
+
+#: static/js/common-all.js:11579 static/js/common-min.js:7 static/js/impala-all.js:13815 static/js/impala-min.js:8 static/js/zamboni/collections.js:235
+msgid "Add to Favorites"
+msgstr "Dodaj med priljubljene"
+
+#: static/js/common-all.js:11582 static/js/common-min.js:7 static/js/impala-all.js:13818 static/js/impala-min.js:8 static/js/zamboni/collections.js:238
+msgid "Remove from Favorites"
+msgstr "Odstrani iz priljubljenih"
+
+#: static/js/common-all.js:11647 static/js/common-min.js:7 static/js/impala-all.js:13883 static/js/impala-min.js:8 static/js/zamboni/collections.js:303
+msgid "Pending"
+msgstr "V čakanju"
+
+#: static/js/common-all.js:11648 static/js/common-min.js:7 static/js/impala-all.js:13884 static/js/impala-min.js:8 static/js/zamboni/collections.js:304
+msgid "Add a comment"
+msgstr "Dodaj komentar"
+
+#: static/js/common-all.js:11648 static/js/common-min.js:7 static/js/impala-all.js:13884 static/js/impala-min.js:8 static/js/zamboni/collections.js:304
+msgid "Comment"
+msgstr "Komentar"
+
+#: static/js/common-all.js:11649 static/js/common-min.js:7 static/js/impala-all.js:13885 static/js/impala-min.js:8 static/js/zamboni/collections.js:305
+msgid "Remove this add-on from the collection"
+msgstr "Odstrani ta dodatek iz zbirke"
+
+#: static/js/common-all.js:11649 static/js/common-all.js:11678 static/js/common-min.js:7 static/js/impala-all.js:13885 static/js/impala-all.js:13914 static/js/impala-min.js:8
+#: static/js/zamboni/collections.js:305 static/js/zamboni/collections.js:334
+msgid "Remove"
+msgstr "Odstrani"
+
+#: static/js/common-all.js:11678 static/js/common-min.js:7 static/js/impala-all.js:13914 static/js/impala-min.js:8 static/js/zamboni/collections.js:334
+msgid "Remove this user as a contributor"
+msgstr "Odstrani tega uporabnika kot sodelavca"
+
+#: static/js/common-all.js:11690 static/js/common-min.js:7 static/js/impala-all.js:13926 static/js/impala-min.js:8 static/js/zamboni/collections.js:346
+msgid "An email address is required."
+msgstr "Potreben je elektronski naslov."
+
+#: static/js/common-all.js:11708 static/js/common-min.js:7 static/js/impala-all.js:13944 static/js/impala-min.js:8 static/js/zamboni/collections.js:364
+msgid "You cannot add yourself as a contributor."
+msgstr "Samega sebe ne morete dodati kot sodelavca."
+
+#: static/js/common-all.js:11710 static/js/common-min.js:7 static/js/impala-all.js:13946 static/js/impala-min.js:8 static/js/zamboni/collections.js:366
+msgid "You have already added that user."
+msgstr "Tega uporabnika ste že dodali."
+
+#: static/js/common-all.js:11917 static/js/common-min.js:7 static/js/impala-all.js:14153 static/js/impala-min.js:8 static/js/zamboni/collections.js:573
+msgid "Add to favorites"
+msgstr "Dodaj med priljubljene"
+
+#: static/js/common-all.js:11921 static/js/common-min.js:7 static/js/impala-all.js:14157 static/js/impala-min.js:8 static/js/zamboni/collections.js:577
+msgid "Remove from favorites"
+msgstr "Odstrani iz priljubljenih"
+
+#: static/js/common-all.js:11939 static/js/common-min.js:7 static/js/impala-all.js:14175 static/js/impala-all.js:14233 static/js/impala-min.js:8 static/js/impala/collections.js:10
+#: static/js/zamboni/collections.js:595
+msgid "Follow this Collection"
+msgstr "Sledi tej zbirki"
+
+#: static/js/common-all.js:11948 static/js/common-min.js:7 static/js/impala-all.js:14184 static/js/impala-min.js:8 static/js/zamboni/collections.js:604
+msgid "Stop following"
+msgstr "Nehaj slediti"
+
+#: static/js/common-all.js:12096 static/js/common-min.js:7 static/js/zamboni/password-strength.js:20
+msgid "Password strength:"
+msgstr "Moč gesla:"
+
+#: static/js/common-all.js:12102 static/js/common-min.js:7 static/js/zamboni/password-strength.js:26
+msgid "At least {0} character left."
+msgid_plural "At least {0} characters left."
+msgstr[0] "Najmanj {0} znak še preostane."
+msgstr[1] "Najmanj {0} znaka še preostaneta."
+msgstr[2] ""
+msgstr[3] ""
+
+#: static/js/common-all.js:12286 static/js/common-min.js:7 static/js/impala-all.js:14632 static/js/impala-min.js:8 static/js/impala/suggestions.js:39
+msgid "Search themes for <b>{0}</b>"
+msgstr "Iščite med temami za <b>{0}</b>"
+
+#: static/js/common-all.js:12288 static/js/common-min.js:7 static/js/impala-all.js:14634 static/js/impala-min.js:8 static/js/impala/suggestions.js:41
+msgid "Search apps for <b>{0}</b>"
+msgstr "Iščite med aplikacijami za <b>{0}</b>"
+
+#: static/js/common-all.js:12290 static/js/common-min.js:7 static/js/impala-all.js:14636 static/js/impala-min.js:8 static/js/impala/suggestions.js:43
+msgid "Search add-ons for <b>{0}</b>"
+msgstr "Iskanje po dodatkih za <b>{0}</b>"
+
+#: static/js/common-all.js:12521 static/js/common-min.js:7 static/js/impala-all.js:14867 static/js/impala-min.js:8 static/js/impala/site_suggestions.js:46
+msgid "Category"
+msgstr "Kategorija"
+
+#. L10n: {0} is an app name.
+#: static/js/impala-all.js:11632 static/js/impala-min.js:7 static/js/impala/listing.js:11 static/js/zamboni/themes.js:13
+msgid "This theme is incompatible with your version of {0}"
+msgstr "Ta tema ni združljiva z vašo različico {0}a"
+
+#: static/js/impala-all.js:12146 static/js/impala-all.js:14331 static/js/impala-min.js:7 static/js/impala-min.js:8 static/js/common/upload-image.js:97 static/js/impala/users.js:51
+#: static/js/zamboni/devhub-all.js:894 static/js/zamboni/devhub-min.js:1
+msgid "Images must be either PNG or JPG."
+msgstr "Slike morajo biti PNG ali JPG."
+
+#: static/js/impala-all.js:12150 static/js/impala-min.js:7 static/js/common/upload-image.js:101 static/js/zamboni/devhub-all.js:898 static/js/zamboni/devhub-min.js:1
+msgid "Videos must be in WebM."
+msgstr "Videoposnetki morajo biti WebM."
+
+#: static/js/impala-all.js:12177 static/js/impala-min.js:7 static/js/common/upload-addon.js:41 static/js/common/upload-image.js:128 static/js/zamboni/devhub-all.js:272
+#: static/js/zamboni/devhub-all.js:925 static/js/zamboni/devhub-min.js:1
 msgid "There was a problem contacting the server."
 msgstr "Pri vzpostavljanju stika s strežnikom je prišlo do napake."
 
-#: static/js/common/upload-addon.js:69
+#: static/js/impala-all.js:13298 static/js/impala-min.js:7 static/js/impala/persona_creation.js:60
+msgid "All Rights Reserved"
+msgstr "Vse pravice pridržane"
+
+#: static/js/impala-all.js:13302 static/js/impala-min.js:7 static/js/impala/persona_creation.js:64
+msgid "Creative Commons Attribution 3.0"
+msgstr "Creative Commons Attribution 3.0"
+
+#: static/js/impala-all.js:13307 static/js/impala-min.js:7 static/js/impala/persona_creation.js:69
+msgid "Creative Commons Attribution-NonCommercial 3.0"
+msgstr "Creative Commons Attribution-NonCommercial 3.0"
+
+#: static/js/impala-all.js:13312 static/js/impala-min.js:7 static/js/impala/persona_creation.js:74
+msgid "Creative Commons Attribution-NonCommercial-NoDerivs 3.0"
+msgstr "Creative Commons Attribution-NonCommercial-NoDerivs 3.0"
+
+#: static/js/impala-all.js:13317 static/js/impala-min.js:7 static/js/impala/persona_creation.js:79
+msgid "Creative Commons Attribution-NonCommercial-Share Alike 3.0"
+msgstr "Creative Commons Attribution-NonCommercial-Share Alike 3.0"
+
+#: static/js/impala-all.js:13322 static/js/impala-min.js:7 static/js/impala/persona_creation.js:84
+msgid "Creative Commons Attribution-NoDerivs 3.0"
+msgstr "Creative Commons Attribution-NoDerivs 3.0"
+
+#: static/js/impala-all.js:13327 static/js/impala-min.js:7 static/js/impala/persona_creation.js:89
+msgid "Creative Commons Attribution-ShareAlike 3.0"
+msgstr "Creative Commons Attribution-ShareAlike 3.0"
+
+#: static/js/impala-all.js:13530 static/js/impala-min.js:7 static/js/impala/persona_creation.js:292
+msgid "Your Theme's Name"
+msgstr "Ime vaše teme"
+
+#: static/js/impala-all.js:14242 static/js/impala-min.js:8 static/js/impala/collections.js:19
+msgid "Stop Following"
+msgstr "Nehaj slediti"
+
+#: static/js/impala-all.js:14243 static/js/impala-min.js:8 static/js/impala/collections.js:20
+msgid "Following"
+msgstr "Sledeno"
+
+#: static/js/impala-all.js:14313 static/js/impala-min.js:8 static/js/impala/users.js:33
+msgid "use original"
+msgstr "uporabi izvirno"
+
+#: static/js/impala-all.js:14523 static/js/impala-min.js:8 static/js/impala/search.js:114
+msgid "Updating results&hellip;"
+msgstr "Posodabljanje rezultatov&hellip;"
+
+#: static/js/common/upload-addon.js:69 static/js/zamboni/devhub-all.js:300 static/js/zamboni/devhub-min.js:1
 msgid "Select a file..."
 msgstr "Izberite datoteko ..."
 
-#: static/js/common/upload-addon.js:70
+#: static/js/common/upload-addon.js:70 static/js/zamboni/devhub-all.js:301 static/js/zamboni/devhub-min.js:1
 msgid "Your add-on should end with .xpi, .jar or .xml"
 msgstr "Vaš dodatek se mora končati z .xpi, .jar ali .xml"
 
 #. L10n: {0} is the percent of the file that has been uploaded.
-#: static/js/common/upload-addon.js:104
+#: static/js/common/upload-addon.js:104 static/js/zamboni/devhub-all.js:335 static/js/zamboni/devhub-min.js:1
 #, python-format
 msgid "{0}% complete"
 msgstr "{0} % dokončano"
 
 #. L10n: "{bytes uploaded} of {total filesize}".
-#: static/js/common/upload-addon.js:107
+#: static/js/common/upload-addon.js:107 static/js/zamboni/devhub-all.js:338 static/js/zamboni/devhub-min.js:1
 msgid "{0} of {1}"
 msgstr "{0} od {1}"
 
-#: static/js/common/upload-addon.js:140
+#: static/js/common/upload-addon.js:140 static/js/zamboni/devhub-all.js:371 static/js/zamboni/devhub-min.js:1
 msgid "Cancel"
 msgstr "Prekliči"
 
-#: static/js/common/upload-addon.js:162
+#: static/js/common/upload-addon.js:162 static/js/zamboni/devhub-all.js:393 static/js/zamboni/devhub-min.js:1
 msgid "Uploading {0}"
 msgstr "Nalaganje {0}"
 
-#: static/js/common/upload-addon.js:189
+#: static/js/common/upload-addon.js:189 static/js/zamboni/devhub-all.js:420 static/js/zamboni/devhub-min.js:1
 msgid "Error with {0}"
 msgstr "Napaka z {0}"
 
-#: static/js/common/upload-addon.js:194
+#: static/js/common/upload-addon.js:194 static/js/zamboni/devhub-all.js:425 static/js/zamboni/devhub-min.js:1
 msgid "Your add-on failed validation with {0} error."
 msgid_plural "Your add-on failed validation with {0} errors."
 msgstr[0] "Vaš dodatek ni prestal preverjanja veljavnosti z {0} napako."
 msgstr[1] "Vaš dodatek ni prestal preverjanja veljavnosti z {0} napakama."
-msgstr[2] "Vaš dodatek ni prestal preverjanja veljavnosti s {0} napakami."
-msgstr[3] "Vaš dodatek ni prestal preverjanja veljavnosti z {0} napakami."
+msgstr[2] ""
+msgstr[3] ""
 
-#: static/js/common/upload-addon.js:208
+#: static/js/common/upload-addon.js:208 static/js/zamboni/devhub-all.js:439 static/js/zamboni/devhub-min.js:1
 msgid "&hellip;and {0} more"
 msgid_plural "&hellip;and {0} more"
 msgstr[0] "&hellip; in še {0}"
 msgstr[1] "&hellip; in še {0}"
-msgstr[2] "&hellip; in še {0}"
-msgstr[3] "&hellip; in še {0}"
+msgstr[2] ""
+msgstr[3] ""
 
-#: static/js/common/upload-addon.js:222 static/js/common/upload-addon.js:512
+#: static/js/common/upload-addon.js:222 static/js/common/upload-addon.js:497 static/js/zamboni/devhub-all.js:453 static/js/zamboni/devhub-all.js:743 static/js/zamboni/devhub-min.js:1
 msgid "See full validation report"
 msgstr "Oglejte si popolno poročilo o preverjanju veljavnosti"
 
-#: static/js/common/upload-addon.js:234
+#: static/js/common/upload-addon.js:234 static/js/zamboni/devhub-all.js:465 static/js/zamboni/devhub-min.js:1
 msgid "Validating {0}"
 msgstr "Preverjanje veljavnosti {0}"
 
 #. L10n: first argument is an HTTP status code
-#: static/js/common/upload-addon.js:273
+#: static/js/common/upload-addon.js:273 static/js/zamboni/devhub-all.js:504 static/js/zamboni/devhub-min.js:1
 msgid "Received an empty response from the server; status: {0}"
 msgstr "Prejet prazen odziv s strežnika; stanje: {0}"
 
-#: static/js/common/upload-addon.js:373
+#: static/js/common/upload-addon.js:370 static/js/zamboni/devhub-all.js:604 static/js/zamboni/devhub-min.js:1
 msgid "Unexpected server error while validating."
 msgstr "Nepričakovana napaka strežnika med preverjanjem veljavnosti."
 
-#: static/js/common/upload-addon.js:412
+#: static/js/common/upload-addon.js:409 static/js/zamboni/devhub-all.js:643 static/js/zamboni/devhub-min.js:1
 msgid "Finished validating {0}"
 msgstr "Preverjanje veljavnosti {0} končano"
 
-#: static/js/common/upload-addon.js:418
+#: static/js/common/upload-addon.js:415 static/js/zamboni/devhub-all.js:649 static/js/zamboni/devhub-min.js:1
 msgid "Your add-on validation timed out, it will be manually reviewed."
-msgstr ""
-"Preverjanje veljavnosti vašega dodatka je poteklo, pregledan bo ročno."
+msgstr "Preverjanje veljavnosti vašega dodatka je poteklo, pregledan bo ročno."
 
-#: static/js/common/upload-addon.js:421
+#: static/js/common/upload-addon.js:418 static/js/zamboni/devhub-all.js:652 static/js/zamboni/devhub-min.js:1
 msgid "Your add-on was validated with no errors and {0} warning."
 msgid_plural "Your add-on was validated with no errors and {0} warnings."
 msgstr[0] "Vaš dodatek je bil preverjen: je brez napak in z {0} opozorilom."
 msgstr[1] "Vaš dodatek je bil preverjen: je brez napak in z {0} opozoriloma."
-msgstr[2] "Vaš dodatek je bil preverjen: je brez napak in z {0} opozorili."
-msgstr[3] "Vaš dodatek je bil preverjen: je brez napak in z {0} opozorili."
+msgstr[2] ""
+msgstr[3] ""
 
-#: static/js/common/upload-addon.js:426
+#: static/js/common/upload-addon.js:423 static/js/zamboni/devhub-all.js:657 static/js/zamboni/devhub-min.js:1
 msgid "Your add-on was validated with no errors and {0} message."
 msgid_plural "Your add-on was validated with no errors and {0} messages."
-msgstr[0] ""
-"Veljavnost vašega dodatka je bila preverjena brez napak in z {0} sporočilom."
-msgstr[1] ""
-"Veljavnost vašega dodatka je bila preverjena brez napak in z {0} "
-"sporočiloma."
-msgstr[2] ""
-"Veljavnost vašega dodatka je bila preverjena brez napak in z {0} sporočili."
-msgstr[3] ""
-"Veljavnost vašega dodatka je bila preverjena brez napak in z {0} sporočili."
+msgstr[0] "Veljavnost vašega dodatka je bila preverjena brez napak in z {0} sporočilom."
+msgstr[1] "Veljavnost vašega dodatka je bila preverjena brez napak in z {0} sporočiloma."
+msgstr[2] "Veljavnost vašega dodatka je bila preverjena brez napak in z {0} sporočili."
+msgstr[3] "Veljavnost vašega dodatka je bila preverjena brez napak in z {0} sporočili."
 
-#: static/js/common/upload-addon.js:431
+#: static/js/common/upload-addon.js:428 static/js/zamboni/devhub-all.js:662 static/js/zamboni/devhub-min.js:1
 msgid "Your add-on was validated with no errors or warnings."
 msgstr "Veljavnost vašega dodatka je bila preverjena brez napak ali opozoril."
 
-#: static/js/common/upload-addon.js:446
+#: static/js/common/upload-addon.js:443 static/js/zamboni/devhub-all.js:677 static/js/zamboni/devhub-min.js:1
 msgid "Your submission will be automatically signed."
 msgstr "Vaša oddaja bo samodejno podpisana."
 
-#: static/js/common/upload-addon.js:465
+#: static/js/common/upload-addon.js:450 static/js/zamboni/devhub-all.js:696 static/js/zamboni/devhub-min.js:1
 msgid "Include detailed version notes (this can be done in the next step)."
-msgstr ""
-"Vključite podrobne opombe o različici (to lahko storite v naslednjem "
-"koraku)."
+msgstr "Vključite podrobne opombe o različici (to lahko storite v naslednjem koraku)."
 
-#: static/js/common/upload-addon.js:466
-msgid ""
-"If your add-on requires an account to a website in order to be fully tested,"
-" include a test username and password in the Notes to Reviewer (this can be "
-"done in the next step)."
-msgstr ""
-"Če je za popoln pregled dodatka potreben račun na spletnem mestu, v opombe "
-"za recenzenta vključite uporabniško ime in geslo testnega računa (to lahko "
-"storite v naslednjem koraku)."
+#: static/js/common/upload-addon.js:451 static/js/zamboni/devhub-all.js:697 static/js/zamboni/devhub-min.js:1
+msgid "If your add-on requires an account to a website in order to be fully tested, include a test username and password in the Notes to Reviewer (this can be done in the next step)."
+msgstr "Če je za popoln pregled dodatka potreben račun na spletnem mestu, v opombe za recenzenta vključite uporabniško ime in geslo testnega računa (to lahko storite v naslednjem koraku)."
 
-#: static/js/common/upload-addon.js:467
-msgid ""
-"If your add-on is intended for a limited audience you should choose "
-"Preliminary Review instead of Full Review."
-msgstr ""
-"V primeru, da je vaš dodatek mišljen za omejeno število uporabnikov, namesto"
-" polnega pregleda izberite predhodni pregled."
+#: static/js/common/upload-addon.js:452 static/js/zamboni/devhub-all.js:698 static/js/zamboni/devhub-min.js:1
+msgid "If your add-on is intended for a limited audience you should choose Preliminary Review instead of Full Review."
+msgstr "V primeru, da je vaš dodatek mišljen za omejeno število uporabnikov, namesto polnega pregleda izberite predhodni pregled."
 
-#: static/js/common/upload-addon.js:480
+#: static/js/common/upload-addon.js:465 static/js/zamboni/devhub-all.js:711 static/js/zamboni/devhub-min.js:1
 msgid "Add-on submission checklist"
 msgstr "Nadzorni seznam oddaje dodatka"
 
-#: static/js/common/upload-addon.js:481
-msgid ""
-"Please verify the following points before finalizing your submission. This "
-"will minimize delays or misunderstanding during the review process:"
-msgstr ""
-"Pred dokončanjem svoje oddaje preverite naslednje točke. To bo zmanjšalo "
-"zakasnitve ali napačne razlage med postopkom pregleda:"
+#: static/js/common/upload-addon.js:466 static/js/zamboni/devhub-all.js:712 static/js/zamboni/devhub-min.js:1
+msgid "Please verify the following points before finalizing your submission. This will minimize delays or misunderstanding during the review process:"
+msgstr "Pred dokončanjem svoje oddaje preverite naslednje točke. To bo zmanjšalo zakasnitve ali napačne razlage med postopkom pregleda:"
 
-#: static/js/common/upload-addon.js:483
+#: static/js/common/upload-addon.js:468 static/js/zamboni/devhub-all.js:714 static/js/zamboni/devhub-min.js:1
 msgid ""
-"Compiled binaries, as well as minified or obfuscated scripts (excluding "
-"known libraries) need to have their sources submitted separately for review."
-" Make sure that you use the source code upload field to avoid having your "
-"submission rejected."
+"Compiled binaries, as well as minified or obfuscated scripts (excluding known libraries) need to have their sources submitted separately for review. Make sure that you use the source code upload "
+"field to avoid having your submission rejected."
 msgstr ""
-"Izvorna koda kodno prevedenih dvojiških datotek, kot tudi pomanjšanih ali "
-"zamaskiranih skriptov (razen znanih dvojiških datotek), mora biti za pregled"
-" poslana ločeno. Prepričajte se, da uporabite polje za prenos izvorne kode, "
-"da se izognete zavrnitvi svoje oddaje."
+"Izvorna koda kodno prevedenih dvojiških datotek, kot tudi pomanjšanih ali zamaskiranih skriptov (razen znanih dvojiških datotek), mora biti za pregled poslana ločeno. Prepričajte se, da uporabite "
+"polje za prenos izvorne kode, da se izognete zavrnitvi svoje oddaje."
 
-#: static/js/common/upload-addon.js:501
+#: static/js/common/upload-addon.js:486 static/js/zamboni/devhub-all.js:732 static/js/zamboni/devhub-min.js:1
 msgid "The validation process found these issues that can lead to rejections:"
-msgstr ""
-"Postopek preverjanja veljavnosti je odkril te težave, ki lahko vodi do "
-"zavrnitev:"
+msgstr "Postopek preverjanja veljavnosti je odkril te težave, ki lahko vodi do zavrnitev:"
 
-#: static/js/common/upload-addon.js:518
-msgid ""
-"If you are unfamiliar with the add-ons review process, you can read about it"
-" here."
-msgstr ""
-"Če se ne spoznate na postopek pregleda dodatkov, si lahko o njem preberete "
-"tukaj."
+#: static/js/common/upload-addon.js:503 static/js/zamboni/devhub-all.js:749 static/js/zamboni/devhub-min.js:1
+msgid "If you are unfamiliar with the add-ons review process, you can read about it here."
+msgstr "Če se ne spoznate na postopek pregleda dodatkov, si lahko o njem preberete tukaj."
 
-#: static/js/common/upload-addon.js:555
+#: static/js/common/upload-addon.js:540 static/js/zamboni/devhub-all.js:786 static/js/zamboni/devhub-min.js:1
 msgid "Sorry, no supported platform has been found."
 msgstr "Podprtega okolja ni bilo mogoče najti."
 
-#: static/js/common/upload-base.js:57
+#: static/js/common/upload-base.js:57 static/js/zamboni/devhub-all.js:187 static/js/zamboni/devhub-min.js:1
 msgid "The filetype you uploaded isn't recognized."
 msgstr "Vrsta datoteke, ki ste jo naložili, ni prepoznana."
 
-#: static/js/common/upload-base.js:79
+#: static/js/common/upload-base.js:79 static/js/zamboni/devhub-all.js:209 static/js/zamboni/devhub-min.js:1
 msgid "You cancelled the upload."
 msgstr "Preklicali ste nalaganje."
 
-#: static/js/common/upload-image.js:97 static/js/impala/users.js:51
-msgid "Images must be either PNG or JPG."
-msgstr "Slike morajo biti PNG ali JPG."
-
-#: static/js/common/upload-image.js:101
-msgid "Videos must be in WebM."
-msgstr "Videoposnetki morajo biti WebM."
-
-#: static/js/impala/collections.js:10 static/js/zamboni/collections.js:595
-msgid "Follow this Collection"
-msgstr "Sledi tej zbirki"
-
-#: static/js/impala/collections.js:19
-msgid "Stop Following"
-msgstr "Nehaj slediti"
-
-#: static/js/impala/collections.js:20
-msgid "Following"
-msgstr "Sledeno"
-
-#. L10n: {0} is an app name.
-#: static/js/impala/listing.js:11 static/js/zamboni/themes.js:13
-msgid "This theme is incompatible with your version of {0}"
-msgstr "Ta tema ni združljiva z vašo različico {0}a"
-
-#: static/js/impala/persona_creation.js:60
-msgid "All Rights Reserved"
-msgstr "Vse pravice pridržane"
-
-#: static/js/impala/persona_creation.js:64
-msgid "Creative Commons Attribution 3.0"
-msgstr "Creative Commons Attribution 3.0"
-
-#: static/js/impala/persona_creation.js:69
-msgid "Creative Commons Attribution-NonCommercial 3.0"
-msgstr "Creative Commons Attribution-NonCommercial 3.0"
-
-#: static/js/impala/persona_creation.js:74
-msgid "Creative Commons Attribution-NonCommercial-NoDerivs 3.0"
-msgstr "Creative Commons Attribution-NonCommercial-NoDerivs 3.0"
-
-#: static/js/impala/persona_creation.js:79
-msgid "Creative Commons Attribution-NonCommercial-Share Alike 3.0"
-msgstr "Creative Commons Attribution-NonCommercial-Share Alike 3.0"
-
-#: static/js/impala/persona_creation.js:84
-msgid "Creative Commons Attribution-NoDerivs 3.0"
-msgstr "Creative Commons Attribution-NoDerivs 3.0"
-
-#: static/js/impala/persona_creation.js:89
-msgid "Creative Commons Attribution-ShareAlike 3.0"
-msgstr "Creative Commons Attribution-ShareAlike 3.0"
-
-#: static/js/impala/persona_creation.js:292
-msgid "Your Theme's Name"
-msgstr "Ime vaše teme"
-
-#: static/js/impala/reviews.js:23 static/js/zamboni/reviews.js:18
-msgid "Flagged for review"
-msgstr "Označeno za pregled"
-
-#: static/js/impala/reviews.js:40 static/js/zamboni/reviews.js:34
-msgid "Your input is required"
-msgstr "Zahtevan je vaš vnos"
-
-#: static/js/impala/reviews.js:152 static/js/zamboni/reviews.js:103
-msgid "Marked for deletion"
-msgstr "Označeno za izbris"
-
-#: static/js/impala/search.js:114
-msgid "Updating results&hellip;"
-msgstr "Posodabljanje rezultatov&hellip;"
-
-#: static/js/impala/site_suggestions.js:46
-msgid "Category"
-msgstr "Kategorija"
-
-#: static/js/impala/suggestions.js:39
-msgid "Search themes for <b>{0}</b>"
-msgstr "Iščite med temami za <b>{0}</b>"
-
-#: static/js/impala/suggestions.js:41
-msgid "Search apps for <b>{0}</b>"
-msgstr "Iščite med aplikacijami za <b>{0}</b>"
-
-#: static/js/impala/suggestions.js:43
-msgid "Search add-ons for <b>{0}</b>"
-msgstr "Iskanje po dodatkih za <b>{0}</b>"
-
-#: static/js/impala/users.js:33
-msgid "use original"
-msgstr "uporabi izvirno"
-
-#: static/js/impala/stats/chart.js:267
+#: static/js/impala/stats/chart.js:267 static/js/zamboni/stats-all.js:16898 static/js/zamboni/stats-min.js:5
 msgid "Week of {0}"
 msgstr "Teden {0}"
 
-#: static/js/impala/stats/chart.js:269
+#: static/js/impala/stats/chart.js:269 static/js/zamboni/stats-all.js:16900 static/js/zamboni/stats-min.js:5
 msgid " downloads"
-msgstr " prenosov"
+msgstr ""
 
-#: static/js/impala/stats/chart.js:270
+#: static/js/impala/stats/chart.js:270 static/js/zamboni/stats-all.js:16901 static/js/zamboni/stats-min.js:5
 msgid "{0} users"
 msgstr "{0} uporabnikov"
 
-#: static/js/impala/stats/chart.js:271
+#: static/js/impala/stats/chart.js:271 static/js/zamboni/stats-all.js:16902 static/js/zamboni/stats-min.js:5
 msgid "{0} add-ons"
 msgstr "{0} dodatkov"
 
-#: static/js/impala/stats/chart.js:272
+#: static/js/impala/stats/chart.js:272 static/js/zamboni/stats-all.js:16903 static/js/zamboni/stats-min.js:5
 msgid "{0} collections"
 msgstr "{0} zbirk"
 
-#: static/js/impala/stats/chart.js:273
+#: static/js/impala/stats/chart.js:273 static/js/zamboni/stats-all.js:16904 static/js/zamboni/stats-min.js:5
 msgid "{0} reviews"
 msgstr "{0} pregledov"
 
-#: static/js/impala/stats/chart.js:275
+#: static/js/impala/stats/chart.js:275 static/js/zamboni/stats-all.js:16906 static/js/zamboni/stats-min.js:5
 msgid "{0} sales"
 msgstr "{0} prodaj"
 
-#: static/js/impala/stats/chart.js:276
+#: static/js/impala/stats/chart.js:276 static/js/zamboni/stats-all.js:16907 static/js/zamboni/stats-min.js:5
 msgid "{0} refunds"
 msgstr "{0} vračil denarja"
 
-#: static/js/impala/stats/chart.js:277
+#: static/js/impala/stats/chart.js:277 static/js/zamboni/stats-all.js:16908 static/js/zamboni/stats-min.js:5
 msgid "{0} installs"
 msgstr "{0} namestitev"
 
-#: static/js/impala/stats/chart.js:369 static/js/impala/stats/csv_keys.js:3
-#: static/js/impala/stats/csv_keys.js:109
+#: static/js/impala/stats/chart.js:369 static/js/impala/stats/csv_keys.js:3 static/js/impala/stats/csv_keys.js:109 static/js/zamboni/stats-all.js:15284 static/js/zamboni/stats-all.js:15390
+#: static/js/zamboni/stats-all.js:17000 static/js/zamboni/stats-min.js:4 static/js/zamboni/stats-min.js:5
 msgid "Downloads"
 msgstr "Prenosi"
 
-#: static/js/impala/stats/chart.js:379 static/js/impala/stats/csv_keys.js:6
-#: static/js/impala/stats/csv_keys.js:110
+#: static/js/impala/stats/chart.js:379 static/js/impala/stats/csv_keys.js:6 static/js/impala/stats/csv_keys.js:110 static/js/zamboni/stats-all.js:15287 static/js/zamboni/stats-all.js:15391
+#: static/js/zamboni/stats-all.js:17010 static/js/zamboni/stats-min.js:4 static/js/zamboni/stats-min.js:5
 msgid "Daily Users"
 msgstr "Dnevni uporabniki"
 
-#: static/js/impala/stats/chart.js:410
+#: static/js/impala/stats/chart.js:410 static/js/zamboni/stats-all.js:17041 static/js/zamboni/stats-min.js:5
 msgid "Amount, in USD"
 msgstr "Znesek v ameriških dolarjih"
 
-#: static/js/impala/stats/chart.js:421 static/js/impala/stats/csv_keys.js:104
+#: static/js/impala/stats/chart.js:421 static/js/impala/stats/csv_keys.js:104 static/js/zamboni/stats-all.js:15385 static/js/zamboni/stats-all.js:17052 static/js/zamboni/stats-min.js:5
 msgid "Number of Contributions"
 msgstr "Število prispevkov"
 
-#: static/js/impala/stats/chart.js:447
+#: static/js/impala/stats/chart.js:447 static/js/zamboni/stats-all.js:17078 static/js/zamboni/stats-min.js:5
 msgid "More Info..."
 msgstr "Več informacij ..."
 
 #. L10n: {0} is an ISO-formatted date.
-#: static/js/impala/stats/chart.js:451
+#: static/js/impala/stats/chart.js:451 static/js/zamboni/stats-all.js:17082 static/js/zamboni/stats-min.js:5
 msgid "Details for {0}"
 msgstr "Podrobnosti za {0}"
 
-#: static/js/impala/stats/csv_keys.js:9
+#: static/js/impala/stats/csv_keys.js:9 static/js/zamboni/stats-all.js:15290 static/js/zamboni/stats-min.js:4
 msgid "Collections Created"
 msgstr "Ustvarjene zbirke"
 
-#: static/js/impala/stats/csv_keys.js:12
+#: static/js/impala/stats/csv_keys.js:12 static/js/zamboni/stats-all.js:15293 static/js/zamboni/stats-min.js:4
 msgid "Add-ons in Use"
 msgstr "Dodatki v uporabi"
 
-#: static/js/impala/stats/csv_keys.js:15
+#: static/js/impala/stats/csv_keys.js:15 static/js/zamboni/stats-all.js:15296 static/js/zamboni/stats-min.js:4
 msgid "Add-ons Created"
 msgstr "Ustvarjeni dodatki"
 
-#: static/js/impala/stats/csv_keys.js:18
+#: static/js/impala/stats/csv_keys.js:18 static/js/zamboni/stats-all.js:15299 static/js/zamboni/stats-min.js:4
 msgid "Add-ons Downloaded"
 msgstr "Preneseni dodatki"
 
-#: static/js/impala/stats/csv_keys.js:21
+#: static/js/impala/stats/csv_keys.js:21 static/js/zamboni/stats-all.js:15302 static/js/zamboni/stats-min.js:4
 msgid "Add-ons Updated"
 msgstr "Posodobljeni dodatki"
 
-#: static/js/impala/stats/csv_keys.js:24
+#: static/js/impala/stats/csv_keys.js:24 static/js/zamboni/stats-all.js:15305 static/js/zamboni/stats-min.js:4
 msgid "Reviews Written"
 msgstr "Napisane ocene"
 
-#: static/js/impala/stats/csv_keys.js:27
+#: static/js/impala/stats/csv_keys.js:27 static/js/zamboni/stats-all.js:15308 static/js/zamboni/stats-min.js:4
 msgid "User Signups"
 msgstr "Uporabniške registracije"
 
-#: static/js/impala/stats/csv_keys.js:30
+#: static/js/impala/stats/csv_keys.js:30 static/js/zamboni/stats-all.js:15311 static/js/zamboni/stats-min.js:4
 msgid "Subscribers"
 msgstr "Naročniki"
 
-#: static/js/impala/stats/csv_keys.js:33
+#: static/js/impala/stats/csv_keys.js:33 static/js/zamboni/stats-all.js:15314 static/js/zamboni/stats-min.js:4
 msgid "Ratings"
 msgstr "Ocene"
 
-#: static/js/impala/stats/csv_keys.js:36
-#: static/js/impala/stats/csv_keys.js:114
+#: static/js/impala/stats/csv_keys.js:36 static/js/impala/stats/csv_keys.js:114 static/js/zamboni/stats-all.js:15317 static/js/zamboni/stats-all.js:15395 static/js/zamboni/stats-min.js:4
+#: static/js/zamboni/stats-min.js:5
 msgid "Sales"
 msgstr "Prodaje"
 
-#: static/js/impala/stats/csv_keys.js:39
-#: static/js/impala/stats/csv_keys.js:113
+#: static/js/impala/stats/csv_keys.js:39 static/js/impala/stats/csv_keys.js:113 static/js/zamboni/stats-all.js:15320 static/js/zamboni/stats-all.js:15394 static/js/zamboni/stats-min.js:4
+#: static/js/zamboni/stats-min.js:5
 msgid "Installs"
 msgstr "Namestitve"
 
-#: static/js/impala/stats/csv_keys.js:42
+#: static/js/impala/stats/csv_keys.js:42 static/js/zamboni/stats-all.js:15323 static/js/zamboni/stats-min.js:4
 msgid "Unknown"
 msgstr "Neznano"
 
-#: static/js/impala/stats/csv_keys.js:43
+#: static/js/impala/stats/csv_keys.js:43 static/js/zamboni/stats-all.js:15324 static/js/zamboni/stats-min.js:4
 msgid "Add-ons Manager"
 msgstr "Upravitelj dodatkov"
 
-#: static/js/impala/stats/csv_keys.js:44
+#: static/js/impala/stats/csv_keys.js:44 static/js/zamboni/stats-all.js:15325 static/js/zamboni/stats-min.js:4
 msgid "Add-ons Manager Promo"
 msgstr "Oglas Upravitelja dodatkov"
 
-#: static/js/impala/stats/csv_keys.js:45
+#: static/js/impala/stats/csv_keys.js:45 static/js/zamboni/stats-all.js:15326 static/js/zamboni/stats-min.js:4
 msgid "Add-ons Manager Featured"
 msgstr "Predstavljeni Upravitelja dodatkov"
 
-#: static/js/impala/stats/csv_keys.js:46
+#: static/js/impala/stats/csv_keys.js:46 static/js/zamboni/stats-all.js:15327 static/js/zamboni/stats-min.js:4
 msgid "Add-ons Manager Learn More"
 msgstr "Več o Upravitelju dodatkov"
 
-#: static/js/impala/stats/csv_keys.js:47
+#: static/js/impala/stats/csv_keys.js:47 static/js/zamboni/stats-all.js:15328 static/js/zamboni/stats-min.js:4
 msgid "Search Suggestions"
 msgstr "Predlogi iskanja"
 
-#: static/js/impala/stats/csv_keys.js:48
+#: static/js/impala/stats/csv_keys.js:48 static/js/zamboni/stats-all.js:15329 static/js/zamboni/stats-min.js:4
 msgid "Search Results"
 msgstr "Rezultati iskanja"
 
-#: static/js/impala/stats/csv_keys.js:49 static/js/impala/stats/csv_keys.js:50
-#: static/js/impala/stats/csv_keys.js:51
+#: static/js/impala/stats/csv_keys.js:49 static/js/impala/stats/csv_keys.js:50 static/js/impala/stats/csv_keys.js:51 static/js/zamboni/stats-all.js:15330 static/js/zamboni/stats-all.js:15331
+#: static/js/zamboni/stats-all.js:15332 static/js/zamboni/stats-min.js:4
 msgid "Homepage Promo"
 msgstr "Oglas domače strani"
 
-#: static/js/impala/stats/csv_keys.js:52 static/js/impala/stats/csv_keys.js:53
+#: static/js/impala/stats/csv_keys.js:52 static/js/impala/stats/csv_keys.js:53 static/js/zamboni/stats-all.js:15333 static/js/zamboni/stats-all.js:15334 static/js/zamboni/stats-min.js:4
 msgid "Homepage Featured"
 msgstr "Predstavljena domača stran"
 
-#: static/js/impala/stats/csv_keys.js:54 static/js/impala/stats/csv_keys.js:55
+#: static/js/impala/stats/csv_keys.js:54 static/js/impala/stats/csv_keys.js:55 static/js/zamboni/stats-all.js:15335 static/js/zamboni/stats-all.js:15336 static/js/zamboni/stats-min.js:4
 msgid "Homepage Up and Coming"
 msgstr "Prihajajoča domača stran"
 
-#: static/js/impala/stats/csv_keys.js:56
+#: static/js/impala/stats/csv_keys.js:56 static/js/zamboni/stats-all.js:15337 static/js/zamboni/stats-min.js:4
 msgid "Homepage Most Popular"
 msgstr "Najbolj priljubljena domača stran"
 
-#: static/js/impala/stats/csv_keys.js:57 static/js/impala/stats/csv_keys.js:59
+#: static/js/impala/stats/csv_keys.js:57 static/js/impala/stats/csv_keys.js:59 static/js/zamboni/stats-all.js:15338 static/js/zamboni/stats-all.js:15340 static/js/zamboni/stats-min.js:4
 msgid "Detail Page"
 msgstr "Stran s podrobnostmi"
 
-#: static/js/impala/stats/csv_keys.js:58 static/js/impala/stats/csv_keys.js:60
+#: static/js/impala/stats/csv_keys.js:58 static/js/impala/stats/csv_keys.js:60 static/js/zamboni/stats-all.js:15339 static/js/zamboni/stats-all.js:15341 static/js/zamboni/stats-min.js:4
 msgid "Detail Page (bottom)"
 msgstr "Stran s podrobnostmi (spodaj)"
 
-#: static/js/impala/stats/csv_keys.js:61
+#: static/js/impala/stats/csv_keys.js:61 static/js/zamboni/stats-all.js:15342 static/js/zamboni/stats-min.js:4
 msgid "Detail Page (Development Channel)"
 msgstr "Stran s podrobnostmi (Razvojni kanal)"
 
-#: static/js/impala/stats/csv_keys.js:62 static/js/impala/stats/csv_keys.js:63
-#: static/js/impala/stats/csv_keys.js:64
+#: static/js/impala/stats/csv_keys.js:62 static/js/impala/stats/csv_keys.js:63 static/js/impala/stats/csv_keys.js:64 static/js/zamboni/stats-all.js:15343 static/js/zamboni/stats-all.js:15344
+#: static/js/zamboni/stats-all.js:15345 static/js/zamboni/stats-min.js:4
 msgid "Often Used With"
 msgstr "Se pogosto uporablja z"
 
-#: static/js/impala/stats/csv_keys.js:65 static/js/impala/stats/csv_keys.js:66
+#: static/js/impala/stats/csv_keys.js:65 static/js/impala/stats/csv_keys.js:66 static/js/zamboni/stats-all.js:15346 static/js/zamboni/stats-all.js:15347 static/js/zamboni/stats-min.js:4
 msgid "Others By Author"
 msgstr "Ostali dodatki tega avtorja"
 
-#: static/js/impala/stats/csv_keys.js:67 static/js/impala/stats/csv_keys.js:68
+#: static/js/impala/stats/csv_keys.js:67 static/js/impala/stats/csv_keys.js:68 static/js/zamboni/stats-all.js:15348 static/js/zamboni/stats-all.js:15349 static/js/zamboni/stats-min.js:4
 msgid "Dependencies"
 msgstr "Odvisnosti"
 
-#: static/js/impala/stats/csv_keys.js:69 static/js/impala/stats/csv_keys.js:70
+#: static/js/impala/stats/csv_keys.js:69 static/js/impala/stats/csv_keys.js:70 static/js/zamboni/stats-all.js:15350 static/js/zamboni/stats-all.js:15351 static/js/zamboni/stats-min.js:4
 msgid "Upsell"
 msgstr "Dodatna ponudba"
 
-#: static/js/impala/stats/csv_keys.js:71
+#: static/js/impala/stats/csv_keys.js:71 static/js/zamboni/stats-all.js:15352 static/js/zamboni/stats-min.js:4
 msgid "Meet the Developer"
 msgstr "Spoznajte razvijalca"
 
-#: static/js/impala/stats/csv_keys.js:72
+#: static/js/impala/stats/csv_keys.js:72 static/js/zamboni/stats-all.js:15353 static/js/zamboni/stats-min.js:4
 msgid "User Profile"
 msgstr "Uporabniški profil"
 
-#: static/js/impala/stats/csv_keys.js:73
+#: static/js/impala/stats/csv_keys.js:73 static/js/zamboni/stats-all.js:15354 static/js/zamboni/stats-min.js:4
 msgid "Version History"
 msgstr "Zgodovina različice"
 
-#: static/js/impala/stats/csv_keys.js:75
+#: static/js/impala/stats/csv_keys.js:75 static/js/zamboni/stats-all.js:15356 static/js/zamboni/stats-min.js:4
 msgid "Sharing"
 msgstr "Deljenje"
 
-#: static/js/impala/stats/csv_keys.js:76
+#: static/js/impala/stats/csv_keys.js:76 static/js/zamboni/stats-all.js:15357 static/js/zamboni/stats-min.js:4
 msgid "Category Pages"
 msgstr "Strani s kategorijami"
 
-#: static/js/impala/stats/csv_keys.js:77
+#: static/js/impala/stats/csv_keys.js:77 static/js/zamboni/stats-all.js:15358 static/js/zamboni/stats-min.js:4
 msgid "Collections"
 msgstr "Zbirke"
 
-#: static/js/impala/stats/csv_keys.js:78 static/js/impala/stats/csv_keys.js:79
+#: static/js/impala/stats/csv_keys.js:78 static/js/impala/stats/csv_keys.js:79 static/js/zamboni/stats-all.js:15359 static/js/zamboni/stats-all.js:15360 static/js/zamboni/stats-min.js:4
 msgid "Category Landing Featured Carousel"
 msgstr "Ciljna kat. Vrtiljak Izbrane"
 
-#: static/js/impala/stats/csv_keys.js:80 static/js/impala/stats/csv_keys.js:81
+#: static/js/impala/stats/csv_keys.js:80 static/js/impala/stats/csv_keys.js:81 static/js/zamboni/stats-all.js:15361 static/js/zamboni/stats-all.js:15362 static/js/zamboni/stats-min.js:4
 msgid "Category Landing Top Rated"
 msgstr "Ciljna kat. Najbolje ocenjeni"
 
-#: static/js/impala/stats/csv_keys.js:82 static/js/impala/stats/csv_keys.js:83
+#: static/js/impala/stats/csv_keys.js:82 static/js/impala/stats/csv_keys.js:83 static/js/zamboni/stats-all.js:15363 static/js/zamboni/stats-all.js:15364 static/js/zamboni/stats-min.js:5
 msgid "Category Landing Most Popular"
 msgstr "Ciljna kat. Najbolj priljubljeni"
 
-#: static/js/impala/stats/csv_keys.js:84 static/js/impala/stats/csv_keys.js:85
+#: static/js/impala/stats/csv_keys.js:84 static/js/impala/stats/csv_keys.js:85 static/js/zamboni/stats-all.js:15365 static/js/zamboni/stats-all.js:15366 static/js/zamboni/stats-min.js:5
 msgid "Category Landing Recently Added"
 msgstr "Ciljna kat. Najnovejše"
 
-#: static/js/impala/stats/csv_keys.js:86 static/js/impala/stats/csv_keys.js:87
+#: static/js/impala/stats/csv_keys.js:86 static/js/impala/stats/csv_keys.js:87 static/js/zamboni/stats-all.js:15367 static/js/zamboni/stats-all.js:15368 static/js/zamboni/stats-min.js:5
 msgid "Browse Listing Featured Sort"
 msgstr "Brsk. sez. - razv. po Izbrani"
 
-#: static/js/impala/stats/csv_keys.js:88 static/js/impala/stats/csv_keys.js:89
+#: static/js/impala/stats/csv_keys.js:88 static/js/impala/stats/csv_keys.js:89 static/js/zamboni/stats-all.js:15369 static/js/zamboni/stats-all.js:15370 static/js/zamboni/stats-min.js:5
 msgid "Browse Listing Users Sort"
 msgstr "Brsk. sez. - razv. po Največ uporabnikov"
 
-#: static/js/impala/stats/csv_keys.js:90 static/js/impala/stats/csv_keys.js:91
+#: static/js/impala/stats/csv_keys.js:90 static/js/impala/stats/csv_keys.js:91 static/js/zamboni/stats-all.js:15371 static/js/zamboni/stats-all.js:15372 static/js/zamboni/stats-min.js:5
 msgid "Browse Listing Rating Sort"
 msgstr "Brsk. sez. - razv. po Najbolje ocenjeni"
 
-#: static/js/impala/stats/csv_keys.js:92 static/js/impala/stats/csv_keys.js:93
+#: static/js/impala/stats/csv_keys.js:92 static/js/impala/stats/csv_keys.js:93 static/js/zamboni/stats-all.js:15373 static/js/zamboni/stats-all.js:15374 static/js/zamboni/stats-min.js:5
 msgid "Browse Listing Created Sort"
 msgstr "Brsk. sez. - razv. po Ustvarjeno"
 
-#: static/js/impala/stats/csv_keys.js:94 static/js/impala/stats/csv_keys.js:95
+#: static/js/impala/stats/csv_keys.js:94 static/js/impala/stats/csv_keys.js:95 static/js/zamboni/stats-all.js:15375 static/js/zamboni/stats-all.js:15376 static/js/zamboni/stats-min.js:5
 msgid "Browse Listing Name Sort"
 msgstr "Brsk. sez. - razv. po Ime"
 
-#: static/js/impala/stats/csv_keys.js:96 static/js/impala/stats/csv_keys.js:97
+#: static/js/impala/stats/csv_keys.js:96 static/js/impala/stats/csv_keys.js:97 static/js/zamboni/stats-all.js:15377 static/js/zamboni/stats-all.js:15378 static/js/zamboni/stats-min.js:5
 msgid "Browse Listing Popular Sort"
 msgstr "Brsk. sez. - razv. po Najbolj priljubljeni"
 
-#: static/js/impala/stats/csv_keys.js:98 static/js/impala/stats/csv_keys.js:99
+#: static/js/impala/stats/csv_keys.js:98 static/js/impala/stats/csv_keys.js:99 static/js/zamboni/stats-all.js:15379 static/js/zamboni/stats-all.js:15380 static/js/zamboni/stats-min.js:5
 msgid "Browse Listing Updated Sort"
 msgstr "Brsk. sez. - razv. po Pred kratkim posod."
 
-#: static/js/impala/stats/csv_keys.js:100
-#: static/js/impala/stats/csv_keys.js:101
+#: static/js/impala/stats/csv_keys.js:100 static/js/impala/stats/csv_keys.js:101 static/js/zamboni/stats-all.js:15381 static/js/zamboni/stats-all.js:15382 static/js/zamboni/stats-min.js:5
 msgid "Browse Listing Up and Coming Sort"
 msgstr "Brsk. sez. - razv. po Kmalu"
 
-#: static/js/impala/stats/csv_keys.js:105
+#: static/js/impala/stats/csv_keys.js:105 static/js/zamboni/stats-all.js:15386 static/js/zamboni/stats-min.js:5
 msgid "Total Amount Contributed"
 msgstr "Skupaj prispevano"
 
-#: static/js/impala/stats/csv_keys.js:106
+#: static/js/impala/stats/csv_keys.js:106 static/js/zamboni/stats-all.js:15387 static/js/zamboni/stats-min.js:5
 msgid "Average Contribution"
 msgstr "Povprečni prispevek"
 
-#: static/js/impala/stats/csv_keys.js:115
+#: static/js/impala/stats/csv_keys.js:115 static/js/zamboni/stats-all.js:15396 static/js/zamboni/stats-min.js:5
 msgid "Usage"
 msgstr "Uporaba"
 
-#: static/js/impala/stats/csv_keys.js:118
+#: static/js/impala/stats/csv_keys.js:118 static/js/zamboni/stats-all.js:15399 static/js/zamboni/stats-min.js:5
 msgid "Firefox"
 msgstr "Firefox"
 
-#: static/js/impala/stats/csv_keys.js:119
+#: static/js/impala/stats/csv_keys.js:119 static/js/zamboni/stats-all.js:15400 static/js/zamboni/stats-min.js:5
 msgid "Mozilla"
 msgstr "Mozilla"
 
-#: static/js/impala/stats/csv_keys.js:120
+#: static/js/impala/stats/csv_keys.js:120 static/js/zamboni/stats-all.js:15401 static/js/zamboni/stats-min.js:5
 msgid "Thunderbird"
 msgstr "Thunderbird"
 
-#: static/js/impala/stats/csv_keys.js:121
+#: static/js/impala/stats/csv_keys.js:121 static/js/zamboni/stats-all.js:15402 static/js/zamboni/stats-min.js:5
 msgid "Sunbird"
 msgstr "Sunbird"
 
-#: static/js/impala/stats/csv_keys.js:122
+#: static/js/impala/stats/csv_keys.js:122 static/js/zamboni/stats-all.js:15403 static/js/zamboni/stats-min.js:5
 msgid "SeaMonkey"
 msgstr "SeaMonkey"
 
-#: static/js/impala/stats/csv_keys.js:123
+#: static/js/impala/stats/csv_keys.js:123 static/js/zamboni/stats-all.js:15404 static/js/zamboni/stats-min.js:5
 msgid "Fennec"
 msgstr "Fennec"
 
-#: static/js/impala/stats/csv_keys.js:124
+#: static/js/impala/stats/csv_keys.js:124 static/js/zamboni/stats-all.js:15405 static/js/zamboni/stats-min.js:5
 msgid "Android"
 msgstr "Android"
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:129
+#: static/js/impala/stats/csv_keys.js:129 static/js/zamboni/stats-all.js:15410 static/js/zamboni/stats-min.js:5
 msgid "Downloads and Daily Users, last {0} days"
 msgstr "Prenosi in dnevni uporabniki zadnjih {0} dni"
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:131
+#: static/js/impala/stats/csv_keys.js:131 static/js/zamboni/stats-all.js:15412 static/js/zamboni/stats-min.js:5
 msgid "Downloads and Daily Users from {0} to {1}"
 msgstr "Prenosi in dnevni uporabniki od {0} do {1}"
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:135
+#: static/js/impala/stats/csv_keys.js:135 static/js/zamboni/stats-all.js:15416 static/js/zamboni/stats-min.js:5
 msgid "Installs and Daily Users, last {0} days"
 msgstr "Namestitve in dnevni uporabniki zadnjih {0} dni"
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:137
+#: static/js/impala/stats/csv_keys.js:137 static/js/zamboni/stats-all.js:15418 static/js/zamboni/stats-min.js:5
 msgid "Installs and Daily Users from {0} to {1}"
 msgstr "Prenosi in dnevni uporabniki od {0} do {1}"
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:141
+#: static/js/impala/stats/csv_keys.js:141 static/js/zamboni/stats-all.js:15422 static/js/zamboni/stats-min.js:5
 msgid "Downloads, last {0} days"
 msgstr "Prenosi zadnjih {0} dni"
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:143
+#: static/js/impala/stats/csv_keys.js:143 static/js/zamboni/stats-all.js:15424 static/js/zamboni/stats-min.js:5
 msgid "Downloads from {0} to {1}"
 msgstr "Prenosi od {0} do {1}"
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:147
+#: static/js/impala/stats/csv_keys.js:147 static/js/zamboni/stats-all.js:15428 static/js/zamboni/stats-min.js:5
 msgid "Daily Users, last {0} days"
 msgstr "Dnevni uporabniki zadnjih {0} dni"
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:149
+#: static/js/impala/stats/csv_keys.js:149 static/js/zamboni/stats-all.js:15430 static/js/zamboni/stats-min.js:5
 msgid "Daily Users from {0} to {1}"
 msgstr "Dnevni uporabniki od {0} do {1}"
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:153
+#: static/js/impala/stats/csv_keys.js:153 static/js/zamboni/stats-all.js:15434 static/js/zamboni/stats-min.js:5
 msgid "Applications, last {0} days"
 msgstr "Programi zadnjih {0} dni"
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:155
+#: static/js/impala/stats/csv_keys.js:155 static/js/zamboni/stats-all.js:15436 static/js/zamboni/stats-min.js:5
 msgid "Applications from {0} to {1}"
 msgstr "Programi od {0} do {1}"
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:159
+#: static/js/impala/stats/csv_keys.js:159 static/js/zamboni/stats-all.js:15440 static/js/zamboni/stats-min.js:5
 msgid "Platforms, last {0} days"
 msgstr "Podlage zadnjih {0} dni"
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:161
+#: static/js/impala/stats/csv_keys.js:161 static/js/zamboni/stats-all.js:15442 static/js/zamboni/stats-min.js:5
 msgid "Platforms from {0} to {1}"
 msgstr "Podlage od {0} do {1}"
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:165
+#: static/js/impala/stats/csv_keys.js:165 static/js/zamboni/stats-all.js:15446 static/js/zamboni/stats-min.js:5
 msgid "Languages, last {0} days"
 msgstr "Jeziki zadnjih {0} dni"
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:167
+#: static/js/impala/stats/csv_keys.js:167 static/js/zamboni/stats-all.js:15448 static/js/zamboni/stats-min.js:5
 msgid "Languages from {0} to {1}"
 msgstr "Jeziki od {0} do {1}"
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:171
+#: static/js/impala/stats/csv_keys.js:171 static/js/zamboni/stats-all.js:15452 static/js/zamboni/stats-min.js:5
 msgid "Add-on Versions, last {0} days"
 msgstr "Različice dodatka zadnjih {0} dni"
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:173
+#: static/js/impala/stats/csv_keys.js:173 static/js/zamboni/stats-all.js:15454 static/js/zamboni/stats-min.js:5
 msgid "Add-on Versions from {0} to {1}"
 msgstr "Različice dodatka od {0} do {1}"
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:177
+#: static/js/impala/stats/csv_keys.js:177 static/js/zamboni/stats-all.js:15458 static/js/zamboni/stats-min.js:5
 msgid "Add-on Status, last {0} days"
 msgstr "Stanje dodatka zadnjih {0} dni"
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:179
+#: static/js/impala/stats/csv_keys.js:179 static/js/zamboni/stats-all.js:15460 static/js/zamboni/stats-min.js:5
 msgid "Add-on Status from {0} to {1}"
 msgstr "Stanje dodatka od {0} do {1}"
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:183
+#: static/js/impala/stats/csv_keys.js:183 static/js/zamboni/stats-all.js:15464 static/js/zamboni/stats-min.js:5
 msgid "Download Sources, last {0} days"
 msgstr "Viri prenosa zadnjih {0} dni"
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:185
+#: static/js/impala/stats/csv_keys.js:185 static/js/zamboni/stats-all.js:15466 static/js/zamboni/stats-min.js:5
 msgid "Download Sources from {0} to {1}"
 msgstr "Viri prenosa od {0} do {1}"
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:189
+#: static/js/impala/stats/csv_keys.js:189 static/js/zamboni/stats-all.js:15470 static/js/zamboni/stats-min.js:5
 msgid "Contributions, last {0} days"
 msgstr "Prispevki zadnjih {0} dni"
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:191
+#: static/js/impala/stats/csv_keys.js:191 static/js/zamboni/stats-all.js:15472 static/js/zamboni/stats-min.js:5
 msgid "Contributions from {0} to {1}"
 msgstr "Prispevki od {0} do {1}"
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:195
+#: static/js/impala/stats/csv_keys.js:195 static/js/zamboni/stats-all.js:15476 static/js/zamboni/stats-min.js:5
 msgid "Site Metrics, last {0} days"
 msgstr "Metrika strani, zadnjih {0} strani"
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:197
+#: static/js/impala/stats/csv_keys.js:197 static/js/zamboni/stats-all.js:15478 static/js/zamboni/stats-min.js:5
 msgid "Site Metrics from {0} to {1}"
 msgstr "Metrika strani od {0} do {1}"
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:201
+#: static/js/impala/stats/csv_keys.js:201 static/js/zamboni/stats-all.js:15482 static/js/zamboni/stats-min.js:5
 msgid "Add-ons in Use, last {0} days"
 msgstr "Dodatki v uporabi zadnjih {0} dni"
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:203
+#: static/js/impala/stats/csv_keys.js:203 static/js/zamboni/stats-all.js:15484 static/js/zamboni/stats-min.js:5
 msgid "Add-ons in Use from {0} to {1}"
 msgstr "Dodatki v uporabi od {0} do {1}"
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:207
+#: static/js/impala/stats/csv_keys.js:207 static/js/zamboni/stats-all.js:15488 static/js/zamboni/stats-min.js:5
 msgid "Add-ons Downloaded, last {0} days"
 msgstr "Preneseni dodatki zadnjih {0} dni"
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:209
+#: static/js/impala/stats/csv_keys.js:209 static/js/zamboni/stats-all.js:15490 static/js/zamboni/stats-min.js:5
 msgid "Add-ons Downloaded from {0} to {1}"
 msgstr "Preneseni dodatki od {0} do {1}"
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:213
+#: static/js/impala/stats/csv_keys.js:213 static/js/zamboni/stats-all.js:15494 static/js/zamboni/stats-min.js:5
 msgid "Add-ons Created, last {0} days"
 msgstr "Ustvarjeni dodatki zadnjih {0} dni"
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:215
+#: static/js/impala/stats/csv_keys.js:215 static/js/zamboni/stats-all.js:15496 static/js/zamboni/stats-min.js:5
 msgid "Add-ons Created from {0} to {1}"
 msgstr "Ustvarjeni dodatki od {0} do {1}"
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:219
+#: static/js/impala/stats/csv_keys.js:219 static/js/zamboni/stats-all.js:15500 static/js/zamboni/stats-min.js:5
 msgid "Add-ons Updated, last {0} days"
 msgstr "Posodobljeni dodatki zadnjih {0} dni"
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:221
+#: static/js/impala/stats/csv_keys.js:221 static/js/zamboni/stats-all.js:15502 static/js/zamboni/stats-min.js:5
 msgid "Add-ons Updated from {0} to {1}"
 msgstr "Posodobljeni dodatki od {0} do {1}"
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:225
+#: static/js/impala/stats/csv_keys.js:225 static/js/zamboni/stats-all.js:15506 static/js/zamboni/stats-min.js:5
 msgid "Reviews Written, last {0} days"
 msgstr "Napisane ocene zadnjih {0} dni"
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:227
+#: static/js/impala/stats/csv_keys.js:227 static/js/zamboni/stats-all.js:15508 static/js/zamboni/stats-min.js:5
 msgid "Reviews Written from {0} to {1}"
 msgstr "Napisane ocene od {0} do {1}"
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:231
+#: static/js/impala/stats/csv_keys.js:231 static/js/zamboni/stats-all.js:15512 static/js/zamboni/stats-min.js:5
 msgid "User Signups, last {0} days"
 msgstr "Uporabniške registracije zadnjih {0} dni"
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:233
+#: static/js/impala/stats/csv_keys.js:233 static/js/zamboni/stats-all.js:15514 static/js/zamboni/stats-min.js:5
 msgid "User Signups from {0} to {1}"
 msgstr "Uporabniške registracije od {0} do {1}"
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:237
+#: static/js/impala/stats/csv_keys.js:237 static/js/zamboni/stats-all.js:15518 static/js/zamboni/stats-min.js:5
 msgid "Collections Created, last {0} days"
 msgstr "Ustvarjene zbirke zadnjih {0} dni"
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:239
+#: static/js/impala/stats/csv_keys.js:239 static/js/zamboni/stats-all.js:15520 static/js/zamboni/stats-min.js:5
 msgid "Collections Created from {0} to {1}"
 msgstr "Ustvarjene zbirke od {0} do {1}"
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:243
+#: static/js/impala/stats/csv_keys.js:243 static/js/zamboni/stats-all.js:15524 static/js/zamboni/stats-min.js:5
 msgid "Subscribers, last {0} days"
 msgstr "Naročniki zadnjih {0} dni"
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:245
+#: static/js/impala/stats/csv_keys.js:245 static/js/zamboni/stats-all.js:15526 static/js/zamboni/stats-min.js:5
 msgid "Subscribers from {0} to {1}"
 msgstr "Naročniki od {0} do {1}"
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:249
+#: static/js/impala/stats/csv_keys.js:249 static/js/zamboni/stats-all.js:15530 static/js/zamboni/stats-min.js:5
 msgid "Ratings, last {0} days"
 msgstr "Ocene zadnjih {0} dni"
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:251
+#: static/js/impala/stats/csv_keys.js:251 static/js/zamboni/stats-all.js:15532 static/js/zamboni/stats-min.js:5
 msgid "Ratings from {0} to {1}"
 msgstr "Ocene od {0} do {1}"
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:255
+#: static/js/impala/stats/csv_keys.js:255 static/js/zamboni/stats-all.js:15536 static/js/zamboni/stats-min.js:5
 msgid "Sales, last {0} days"
 msgstr "Prodaje zadnjih {0} dni"
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:257
+#: static/js/impala/stats/csv_keys.js:257 static/js/zamboni/stats-all.js:15538 static/js/zamboni/stats-min.js:5
 msgid "Sales from {0} to {1}"
 msgstr "Prodaje od {0} do {1}"
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:261
+#: static/js/impala/stats/csv_keys.js:261 static/js/zamboni/stats-all.js:15542 static/js/zamboni/stats-min.js:5
 msgid "Installs, last {0} days"
 msgstr "Namestitve zadnjih {0} dni"
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:263
+#: static/js/impala/stats/csv_keys.js:263 static/js/zamboni/stats-all.js:15544 static/js/zamboni/stats-min.js:5
 msgid "Installs from {0} to {1}"
 msgstr "Namestitve od {0} do {1}"
 
 #. L10n: {0} and {1} are integers.
-#: static/js/impala/stats/csv_keys.js:269
+#: static/js/impala/stats/csv_keys.js:269 static/js/zamboni/stats-all.js:15550 static/js/zamboni/stats-min.js:5
 msgid "<b>{0}</b> in last {1} days"
 msgstr "<b>{0}</b> v zadnjih {1} dneh"
 
 #. L10n: {0} is an integer and {1} and {2} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:271
-#: static/js/impala/stats/csv_keys.js:277
+#: static/js/impala/stats/csv_keys.js:271 static/js/impala/stats/csv_keys.js:277 static/js/zamboni/stats-all.js:15552 static/js/zamboni/stats-all.js:15558 static/js/zamboni/stats-min.js:5
 msgid "<b>{0}</b> from {1} to {2}"
 msgstr "<b>{0}</b> od {1} do {2}"
 
 #. L10n: {0} and {1} are integers.
-#: static/js/impala/stats/csv_keys.js:275
+#: static/js/impala/stats/csv_keys.js:275 static/js/zamboni/stats-all.js:15556 static/js/zamboni/stats-min.js:5
 msgid "<b>{0}</b> average in last {1} days"
 msgstr "<b>{0}</b> povprečno zadnjih {1} dni"
 
-#: static/js/impala/stats/overview.js:19
+#: static/js/impala/stats/overview.js:19 static/js/zamboni/stats-all.js:16469 static/js/zamboni/stats-min.js:5
 msgid "No data available."
 msgstr "Ni podatkov na voljo."
 
-#: static/js/impala/stats/table.js:74
+#: static/js/impala/stats/table.js:74 static/js/zamboni/stats-all.js:17209 static/js/zamboni/stats-min.js:5
 msgid "Date"
 msgstr "Datum"
 
-#: static/js/impala/stats/topchart.js:96
+#: static/js/impala/stats/topchart.js:96 static/js/zamboni/stats-all.js:16600 static/js/zamboni/stats-min.js:5
 msgid "Other"
 msgstr "Ostalo"
 
-#: static/js/zamboni/admin_validation.js:24 static/js/zamboni/devhub.js:1229
-#: static/js/zamboni/editors.js:295
+#: static/js/zamboni/admin-all.js:180 static/js/zamboni/admin-min.js:1 static/js/zamboni/admin_validation.js:24 static/js/zamboni/devhub-all.js:2408 static/js/zamboni/devhub-min.js:2
+#: static/js/zamboni/devhub.js:1229 static/js/zamboni/editors-all.js:15576 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:295
 msgid "Select an application first"
 msgstr "Najprej izberite program"
 
-#: static/js/zamboni/admin_validation.js:51
+#: static/js/zamboni/admin-all.js:207 static/js/zamboni/admin-min.js:1 static/js/zamboni/admin_validation.js:51
 msgid "Set {0} add-on to a max version of {1} and email the author."
 msgid_plural "Set {0} add-ons to a max version of {1} and email the authors."
 msgstr[0] "Nastavi dodatek na največjo različico {1} in obvesti avtorja."
 msgstr[1] "Nastavi {0} dodatka na največjo različico {1} in obvesti avtorja."
-msgstr[2] "Nastavi {0} dodatke na največjo različico {1} in obvesti avtorja."
-msgstr[3] "Nastavi {0} dodatkov na največjo različico {1} in obvesti avtorja."
+msgstr[2] ""
+msgstr[3] ""
 
-#: static/js/zamboni/admin_validation.js:54
+#: static/js/zamboni/admin-all.js:210 static/js/zamboni/admin-min.js:1 static/js/zamboni/admin_validation.js:54
 msgid "Email author of {2} add-on which failed validation."
 msgid_plural "Email authors of {2} add-ons which failed validation."
-msgstr[0] ""
-"Obvesti avtorja o {2} dodatku, katerega preverjanje veljavnosti je "
-"spodletelo."
-msgstr[1] ""
-"Obvesti avtorje o {2} dodatkih, katerih preverjanje veljavnosti je "
-"spodletelo."
-msgstr[2] ""
-"Obvesti avtorje o {2} dodatkih, katerih preverjanje veljavnosti je "
-"spodletelo."
-msgstr[3] ""
-"Obvesti avtorje o {2} dodatkih, katerih preverjanje veljavnosti je "
-"spodletelo."
+msgstr[0] "Obvesti avtorja o {2} dodatku, katerega preverjanje veljavnosti je spodletelo."
+msgstr[1] "Obvesti avtorje o {2} dodatkih, katerih preverjanje veljavnosti je spodletelo."
+msgstr[2] "Obvesti avtorje o {2} dodatkih, katerih preverjanje veljavnosti je spodletelo."
+msgstr[3] "Obvesti avtorje o {2} dodatkih, katerih preverjanje veljavnosti je spodletelo."
 
-#. L10n: {0} is an app name like Firefox.
-#: static/js/zamboni/buttons.js:66
-msgid "Accept and Install"
-msgstr "Sprejmi in namesti"
-
-#: static/js/zamboni/buttons.js:66
-msgid "Add to {0}"
-msgstr "Dodaj v {0}"
-
-#: static/js/zamboni/buttons.js:71
-msgid "Download Now"
-msgstr "Prenesi zdaj"
-
-#: static/js/zamboni/buttons.js:112
-msgid "Add-on has not been updated to support default-to-compatible."
-msgstr "Dodatek ni bil posodobljen, da bi podpiral privzeto-na-združljivo."
-
-#: static/js/zamboni/buttons.js:117
-msgid "You need to be using Firefox 10.0 or higher."
-msgstr "Uporabljati morate Firefox 10.0 ali novejšega."
-
-#: static/js/zamboni/buttons.js:129
-msgid ""
-"Mozilla has marked this version as incompatible with your Firefox version."
-msgstr ""
-"Mozilla je označila to različico kot nezdružljivo z vašo različico Firefoxa."
-
-#. L10n: {0} is an platform like Windows or Linux.
-#: static/js/zamboni/buttons.js:210
-msgid "Install for {0} anyway"
-msgstr "Vseeno namesti za {0}"
-
-#: static/js/zamboni/buttons.js:210
-msgid "Download for {0} anyway"
-msgstr "Vseeno prenesi za {0}"
-
-#: static/js/zamboni/buttons.js:267
-msgid "Not available for your platform"
-msgstr "Ni na voljo za vašo podlago"
-
-#. L10n: {0} is an app name, {1} is the app version.
-#: static/js/zamboni/buttons.js:278 static/js/zamboni/buttons.js:315
-msgid "Not available for {0} {1}"
-msgstr "Ni na voljo za {0} {1}"
-
-#: static/js/zamboni/buttons.js:341
-msgid "Works with {app} {min} - {max}"
-msgstr "Deluje s {app} {min} - {max}"
-
-#: static/js/zamboni/buttons.js:343
-msgid "View other versions"
-msgstr "Ogled drugih različic"
-
-#: static/js/zamboni/buttons.js:391
-msgid "Only with Firefox — Get Firefox Now!"
-msgstr "Samo pri Firefoxu – namestite ga!"
-
-#: static/js/zamboni/buttons.js:507 static/js/zamboni/mobile/buttons.js:43
-msgid ""
-"Sorry, you need a Mozilla-based browser (such as Firefox) to install a "
-"search plugin."
-msgstr ""
-"Oprostite, za namestitev vtičnika za iskanje potrebujete brskalnik na osnovi"
-" Mozille (kot je Firefox)."
-
-#: static/js/zamboni/collections.js:229
-msgid "Adding to Favorites&hellip;"
-msgstr "Dodajanje med priljubljene &hellip;"
-
-#: static/js/zamboni/collections.js:232
-msgid "Removing Favorite&hellip;"
-msgstr "Odstranjevanje priljubljene &hellip;"
-
-#: static/js/zamboni/collections.js:235
-msgid "Add to Favorites"
-msgstr "Dodaj med priljubljene"
-
-#: static/js/zamboni/collections.js:238
-msgid "Remove from Favorites"
-msgstr "Odstrani iz priljubljenih"
-
-#: static/js/zamboni/collections.js:303
-msgid "Pending"
-msgstr "V čakanju"
-
-#: static/js/zamboni/collections.js:304
-msgid "Add a comment"
-msgstr "Dodaj komentar"
-
-#: static/js/zamboni/collections.js:304
-msgid "Comment"
-msgstr "Komentar"
-
-#: static/js/zamboni/collections.js:305
-msgid "Remove this add-on from the collection"
-msgstr "Odstrani ta dodatek iz zbirke"
-
-#: static/js/zamboni/collections.js:305 static/js/zamboni/collections.js:334
-msgid "Remove"
-msgstr "Odstrani"
-
-#: static/js/zamboni/collections.js:334
-msgid "Remove this user as a contributor"
-msgstr "Odstrani tega uporabnika kot sodelavca"
-
-#: static/js/zamboni/collections.js:346
-msgid "An email address is required."
-msgstr "Potreben je elektronski naslov."
-
-#: static/js/zamboni/collections.js:364
-msgid "You cannot add yourself as a contributor."
-msgstr "Samega sebe ne morete dodati kot sodelavca."
-
-#: static/js/zamboni/collections.js:366
-msgid "You have already added that user."
-msgstr "Tega uporabnika ste že dodali."
-
-#: static/js/zamboni/collections.js:573
-msgid "Add to favorites"
-msgstr "Dodaj med priljubljene"
-
-#: static/js/zamboni/collections.js:577
-msgid "Remove from favorites"
-msgstr "Odstrani iz priljubljenih"
-
-#: static/js/zamboni/collections.js:604
-msgid "Stop following"
-msgstr "Nehaj slediti"
-
-#: static/js/zamboni/devhub.js:110
+#: static/js/zamboni/devhub-all.js:1289 static/js/zamboni/devhub-min.js:1 static/js/zamboni/devhub.js:110
 msgid "Your browser does not support the video tag"
 msgstr "Vaš brskalnik ne podpira oznake video"
 
-#: static/js/zamboni/devhub.js:371
+#: static/js/zamboni/devhub-all.js:1550 static/js/zamboni/devhub-min.js:1 static/js/zamboni/devhub.js:371
 msgid "Changes Saved"
 msgstr "Spremembe shranjene"
 
-#: static/js/zamboni/devhub.js:387
+#: static/js/zamboni/devhub-all.js:1566 static/js/zamboni/devhub-min.js:1 static/js/zamboni/devhub.js:387
 msgid "Enter a new author's email address"
 msgstr "Vnesite elektronski naslov novega avtorja"
 
-#: static/js/zamboni/devhub.js:536
+#: static/js/zamboni/devhub-all.js:1715 static/js/zamboni/devhub-min.js:1 static/js/zamboni/devhub.js:536
 msgid "There was an error uploading your file."
 msgstr "Pri nalaganju vaše datoteke je prišlo do napake."
 
-#: static/js/zamboni/devhub.js:681
+#: static/js/zamboni/devhub-all.js:1860 static/js/zamboni/devhub-min.js:1 static/js/zamboni/devhub.js:681
 msgid "{files} file"
 msgid_plural "{files} files"
 msgstr[0] "{files} datoteka"
 msgstr[1] "{files} datoteki"
-msgstr[2] "{files} datoteke"
-msgstr[3] "{files} datotek"
+msgstr[2] ""
+msgstr[3] ""
 
-#: static/js/zamboni/devhub.js:684
+#: static/js/zamboni/devhub-all.js:1863 static/js/zamboni/devhub-min.js:1 static/js/zamboni/devhub.js:684
 msgid "{reviews} user review"
 msgid_plural "{reviews} user reviews"
 msgstr[0] "{reviews} uporabniška ocena"
 msgstr[1] "{reviews} uporabniški oceni"
-msgstr[2] "{reviews} uporabniške ocene"
-msgstr[3] "{reviews} uporabniških ocen"
+msgstr[2] ""
+msgstr[3] ""
 
-#: static/js/zamboni/devhub.js:796
+#: static/js/zamboni/devhub-all.js:1975 static/js/zamboni/devhub-min.js:2 static/js/zamboni/devhub.js:796
 msgid "Learn more"
 msgstr "Več o tem"
 
-#: static/js/zamboni/devhub.js:800
+#: static/js/zamboni/devhub-all.js:1979 static/js/zamboni/devhub-min.js:2 static/js/zamboni/devhub.js:800
 msgid "Example"
 msgstr "Primer"
 
-#: static/js/zamboni/devhub.js:1130
+#: static/js/zamboni/devhub-all.js:2309 static/js/zamboni/devhub-min.js:2 static/js/zamboni/devhub.js:1130
 msgid "Image changes being processed"
 msgstr "Obdelovanje sprememb slike"
 
-#: static/js/zamboni/devhub.js:1280
+#: static/js/zamboni/devhub-all.js:2459 static/js/zamboni/devhub-min.js:2 static/js/zamboni/devhub.js:1280
 msgid "Must be a valid e-mail address."
 msgstr "Mora biti veljaven elektronski naslov."
+
+#: static/js/zamboni/devhub-all.js:2613 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:80
+msgid "All tests passed successfully."
+msgstr "Vsi preskusi so bili uspešno opravljeni."
+
+#: static/js/zamboni/devhub-all.js:2616 static/js/zamboni/devhub-all.js:3011 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:83 static/js/zamboni/validator.js:478
+msgid "These tests were not run."
+msgstr "Ti preskusi niso bili zagnani."
+
+#: static/js/zamboni/devhub-all.js:2664 static/js/zamboni/devhub-all.js:2677 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:131 static/js/zamboni/validator.js:144
+msgid "Tests"
+msgstr "Preskusi"
+
+#: static/js/zamboni/devhub-all.js:2779 static/js/zamboni/devhub-all.js:3108 static/js/zamboni/devhub-all.js:3127 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:246
+#: static/js/zamboni/validator.js:575 static/js/zamboni/validator.js:594
+msgid "Error"
+msgstr "Napaka"
+
+#: static/js/zamboni/devhub-all.js:2780 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:247
+msgid "Warning"
+msgstr "Opozorilo"
+
+#: static/js/zamboni/devhub-all.js:2794 static/js/zamboni/devhub-min.js:2 static/js/zamboni/files-all.js:5657 static/js/zamboni/files-min.js:3 static/js/zamboni/files.js:411
+#: static/js/zamboni/validator.js:261
+msgid "Ignore this message in future updates"
+msgstr "Prezri to sporočilo v prihodnjih posodobitvah"
+
+#: static/js/zamboni/devhub-all.js:2817 static/js/zamboni/devhub-min.js:2 static/js/zamboni/files-all.js:5663 static/js/zamboni/files-min.js:3 static/js/zamboni/files.js:417
+#: static/js/zamboni/validator.js:284
+msgid "Severity for automated signing:"
+msgstr "Stopnja samodejnega podpisovanja:"
+
+#: static/js/zamboni/devhub-all.js:2832 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:299
+msgid "Suggestions for passing automated signing:"
+msgstr "Predlogi za opravljanje samodejnega podpisovanja:"
+
+#: static/js/zamboni/devhub-all.js:2920 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:387
+msgid "Compatibility Tests"
+msgstr "Preskusi združljivosti"
+
+#: static/js/zamboni/devhub-all.js:2999 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:466
+msgid "Add-on failed validation."
+msgstr "Preverjanje veljavnosti dodatka je spodletelo."
+
+#: static/js/zamboni/devhub-all.js:3001 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:468
+msgid "Add-on passed validation."
+msgstr "Preverjanje veljavnosti dodatka je bilo uspešno."
+
+#: static/js/zamboni/devhub-all.js:3014 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:481
+msgid "{0} error"
+msgid_plural "{0} errors"
+msgstr[0] "{0} napaka"
+msgstr[1] "{0} napaki"
+msgstr[2] ""
+msgstr[3] ""
+
+#: static/js/zamboni/devhub-all.js:3016 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:483
+msgid "{0} warning"
+msgid_plural "{0} warnings"
+msgstr[0] "{0} opozorilo"
+msgstr[1] "{0} opozorili"
+msgstr[2] ""
+msgstr[3] ""
+
+#: static/js/zamboni/devhub-all.js:3018 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:485
+msgid "{0} notice"
+msgid_plural "{0} notices"
+msgstr[0] "{0} obvestilo"
+msgstr[1] "{0} obvestili"
+msgstr[2] ""
+msgstr[3] ""
+
+#: static/js/zamboni/devhub-all.js:3110 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:577
+msgid "Validation task could not complete or completed with errors"
+msgstr "Opravilo preverjanja veljavnosti se ni moglo dokončati ali se je končalo z napakami"
+
+#: static/js/zamboni/devhub-all.js:3128 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:595
+msgid "Internal server error"
+msgstr "Notranja napaka strežnika"
 
 #: static/js/zamboni/devhub_search.js:8
 msgid "No results found."
 msgstr "Ni najdenih rezultatov."
 
-#: static/js/zamboni/editors.js:121
+#: static/js/zamboni/editors-all.js:15402 static/js/zamboni/editors-min.js:4 static/js/zamboni/editors.js:121
 msgid "{name} was viewing this page first."
 msgstr "{name} si je prvi ogledoval to stran."
 
-#: static/js/zamboni/editors.js:171
+#: static/js/zamboni/editors-all.js:15452 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:171
 msgid "Receipt checked by app."
 msgstr "Program je preveril prejem."
 
-#: static/js/zamboni/editors.js:173
+#: static/js/zamboni/editors-all.js:15454 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:173
 msgid "Receipt was not checked by app."
 msgstr "Program ni preveril prejema."
 
-#: static/js/zamboni/editors.js:244
+#: static/js/zamboni/editors-all.js:15525 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:244
 msgid "{name} was viewing this add-on first."
 msgstr "Prvi si je ogledal ta dodatek {name}."
 
-#: static/js/zamboni/editors.js:255
+#: static/js/zamboni/editors-all.js:15536 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:255
 msgid "Loading&hellip;"
 msgstr "Nalaganje &hellip;"
 
-#: static/js/zamboni/editors.js:260
+#: static/js/zamboni/editors-all.js:15541 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:260
 msgid "Version Notes"
 msgstr "Opombe ob različici"
 
-#: static/js/zamboni/editors.js:265
+#: static/js/zamboni/editors-all.js:15546 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:265
 msgid "Notes for Reviewers"
 msgstr "Opombe za pregledovalce"
 
-#: static/js/zamboni/editors.js:270
+#: static/js/zamboni/editors-all.js:15551 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:270
 msgid "No version notes found"
 msgstr "Opomb ob različici ni bilo mogoče najti"
 
-#: static/js/zamboni/editors.js:330
+#: static/js/zamboni/editors-all.js:15611 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:330
 msgid "Average Reviews"
 msgstr "Povprečno število ocen"
 
-#: static/js/zamboni/editors.js:386
+#: static/js/zamboni/editors-all.js:15667 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:386
 msgid "Number of Reviews"
 msgstr "Število ocen"
 
-#: static/js/zamboni/editors.js:445
+#: static/js/zamboni/editors-all.js:15726 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:445
 msgid "Error loading translation"
 msgstr "Napaka pri nalaganju prevoda"
 
-#: static/js/zamboni/files.js:411 static/js/zamboni/validator.js:261
-msgid "Ignore this message in future updates"
-msgstr "Prezri to sporočilo v prihodnjih posodobitvah"
-
-#: static/js/zamboni/files.js:417 static/js/zamboni/validator.js:284
-msgid "Severity for automated signing:"
-msgstr "Stopnja samodejnega podpisovanja:"
-
-#: static/js/zamboni/global.js:410
-msgid "Loading..."
-msgstr "Nalaganje..."
-
-#. L10n: {0} is the number of characters left.
-#: static/js/zamboni/global.js:474
-msgid "<b>{0}</b> character left."
-msgid_plural "<b>{0}</b> characters left."
-msgstr[0] "<b>{0}</b> znak preostane."
-msgstr[1] "<b>{0}</b> znaka preostaneta."
-msgstr[2] "<b>{0}</b> znaki preostanejo."
-msgstr[3] "<b>{0}</b> znakov preostane."
-
-#: static/js/zamboni/init.js:28
-msgid ""
-"This feature is temporarily disabled while we perform website maintenance. "
-"Please check back a little later."
-msgstr ""
-"Ta funkcija je začasno onemogočena, medtem ko na strani izvajamo vzdrževalna"
-" dela. Prosimo, poskusite znova malo kasneje."
-
-#: static/js/zamboni/l10n.js:45
-msgid "Remove this localization"
-msgstr "Odstrani to lokalizacijo"
-
-#: static/js/zamboni/password-strength.js:20
-msgid "Password strength:"
-msgstr "Moč gesla:"
-
-#: static/js/zamboni/password-strength.js:26
-msgid "At least {0} character left."
-msgid_plural "At least {0} characters left."
-msgstr[0] "Najmanj {0} znak še preostane."
-msgstr[1] "Najmanj {0} znaka še preostaneta."
-msgstr[2] "Najmanj {0} znaki še preostanejo."
-msgstr[3] "Najmanj {0} znakov še preostane."
-
-#: static/js/zamboni/themes_review.js:176
-msgid "Requested Info"
-msgstr "Zahtevani podatki"
-
-#: static/js/zamboni/themes_review.js:177
-msgid "Flagged"
-msgstr "Označeno"
-
-#: static/js/zamboni/themes_review.js:178
-msgid "Duplicate"
-msgstr "Dvojnik"
-
-#: static/js/zamboni/themes_review.js:179
-msgid "Rejected"
-msgstr "Zavrnjeno"
-
-#: static/js/zamboni/themes_review.js:180
-msgid "Approved"
-msgstr "Odobreno"
-
-#: static/js/zamboni/themes_review.js:424
-msgid "No results found"
-msgstr "Ni zadetkov"
-
-#: static/js/zamboni/themes_review_templates.js:31
+#: static/js/zamboni/editors-all.js:15975 static/js/zamboni/editors-min.js:5 static/js/zamboni/themes_review_templates.js:31
 msgid "Theme"
 msgstr "Tema"
 
-#: static/js/zamboni/themes_review_templates.js:33
+#: static/js/zamboni/editors-all.js:15977 static/js/zamboni/editors-min.js:5 static/js/zamboni/themes_review_templates.js:33
 msgid "Reviewer"
 msgstr "Pregledovalec"
 
-#: static/js/zamboni/themes_review_templates.js:35
+#: static/js/zamboni/editors-all.js:15979 static/js/zamboni/editors-min.js:5 static/js/zamboni/themes_review_templates.js:35
 msgid "Status"
 msgstr "Stanje"
 
-#: static/js/zamboni/validator.js:80
-msgid "All tests passed successfully."
-msgstr "Vsi preskusi so bili uspešno opravljeni."
+#: static/js/zamboni/editors-all.js:16196 static/js/zamboni/editors-min.js:5 static/js/zamboni/themes_review.js:176
+msgid "Requested Info"
+msgstr "Zahtevani podatki"
 
-#: static/js/zamboni/validator.js:83 static/js/zamboni/validator.js:478
-msgid "These tests were not run."
-msgstr "Ti preskusi niso bili zagnani."
+#: static/js/zamboni/editors-all.js:16197 static/js/zamboni/editors-min.js:5 static/js/zamboni/themes_review.js:177
+msgid "Flagged"
+msgstr "Označeno"
 
-#: static/js/zamboni/validator.js:131 static/js/zamboni/validator.js:144
-msgid "Tests"
-msgstr "Preskusi"
+#: static/js/zamboni/editors-all.js:16198 static/js/zamboni/editors-min.js:5 static/js/zamboni/themes_review.js:178
+msgid "Duplicate"
+msgstr "Dvojnik"
 
-#: static/js/zamboni/validator.js:246 static/js/zamboni/validator.js:575
-#: static/js/zamboni/validator.js:594
-msgid "Error"
-msgstr "Napaka"
+#: static/js/zamboni/editors-all.js:16199 static/js/zamboni/editors-min.js:5 static/js/zamboni/themes_review.js:179
+msgid "Rejected"
+msgstr "Zavrnjeno"
 
-#: static/js/zamboni/validator.js:247
-msgid "Warning"
-msgstr "Opozorilo"
+#: static/js/zamboni/editors-all.js:16200 static/js/zamboni/editors-min.js:5 static/js/zamboni/themes_review.js:180
+msgid "Approved"
+msgstr "Odobreno"
 
-#: static/js/zamboni/validator.js:299
-msgid "Suggestions for passing automated signing:"
-msgstr "Predlogi za opravljanje samodejnega podpisovanja:"
+#: static/js/zamboni/editors-all.js:16444 static/js/zamboni/editors-min.js:5 static/js/zamboni/themes_review.js:424
+msgid "No results found"
+msgstr "Ni zadetkov"
 
-#: static/js/zamboni/validator.js:387
-msgid "Compatibility Tests"
-msgstr "Preskusi združljivosti"
-
-#: static/js/zamboni/validator.js:466
-msgid "Add-on failed validation."
-msgstr "Preverjanje veljavnosti dodatka je spodletelo."
-
-#: static/js/zamboni/validator.js:468
-msgid "Add-on passed validation."
-msgstr "Preverjanje veljavnosti dodatka je bilo uspešno."
-
-#: static/js/zamboni/validator.js:481
-msgid "{0} error"
-msgid_plural "{0} errors"
-msgstr[0] "{0} napaka"
-msgstr[1] "{0} napaki"
-msgstr[2] "{0} napake"
-msgstr[3] "{0} napak"
-
-#: static/js/zamboni/validator.js:483
-msgid "{0} warning"
-msgid_plural "{0} warnings"
-msgstr[0] "{0} opozorilo"
-msgstr[1] "{0} opozorili"
-msgstr[2] "{0} opozorila"
-msgstr[3] "{0} opozoril"
-
-#: static/js/zamboni/validator.js:485
-msgid "{0} notice"
-msgid_plural "{0} notices"
-msgstr[0] "{0} obvestilo"
-msgstr[1] "{0} obvestili"
-msgstr[2] "{0} obvestila"
-msgstr[3] "{0} obvestil"
-
-#: static/js/zamboni/validator.js:577
-msgid "Validation task could not complete or completed with errors"
-msgstr ""
-"Opravilo preverjanja veljavnosti se ni moglo dokončati ali se je končalo z "
-"napakami"
-
-#: static/js/zamboni/validator.js:595
-msgid "Internal server error"
-msgstr "Notranja napaka strežnika"
-
-#: static/js/zamboni/mobile/buttons.js:52
+#: static/js/zamboni/mobile-all.js:15186 static/js/zamboni/mobile/buttons.js:52
 msgid "Not Updated for {0} {1}"
 msgstr "Ni posodobljeno za {0} {1}"
 
-#: static/js/zamboni/mobile/buttons.js:53
+#: static/js/zamboni/mobile-all.js:15187 static/js/zamboni/mobile/buttons.js:53
 msgid "Requires Newer Version of {0}"
 msgstr "Zahteva novejšo različico {0}a"
 
-#: static/js/zamboni/mobile/buttons.js:54
+#: static/js/zamboni/mobile-all.js:15188 static/js/zamboni/mobile/buttons.js:54
 msgid "Unreviewed"
 msgstr "Nepregledano"
 
-#: static/js/zamboni/mobile/buttons.js:55
+#: static/js/zamboni/mobile-all.js:15189 static/js/zamboni/mobile/buttons.js:55
 msgid "Experimental <span>(Learn More)</span>"
 msgstr "Eksperimentalno <span>(Več o tem)</span>"
 
-#: static/js/zamboni/mobile/buttons.js:56
-#: static/js/zamboni/mobile/buttons.js:57
+#: static/js/zamboni/mobile-all.js:15190 static/js/zamboni/mobile-all.js:15191 static/js/zamboni/mobile/buttons.js:56 static/js/zamboni/mobile/buttons.js:57
 msgid "Not Available for {0}"
 msgstr "Ni na voljo za {0}"
 
-#: static/js/zamboni/mobile/buttons.js:58
+#: static/js/zamboni/mobile-all.js:15192 static/js/zamboni/mobile/buttons.js:58
 msgid "Experimental"
 msgstr "Eksperimentalno"
 
-#: static/js/zamboni/mobile/buttons.js:59
+#: static/js/zamboni/mobile-all.js:15193 static/js/zamboni/mobile/buttons.js:59
 msgid "Themes Require Newer Version of {0}"
 msgstr "Teme zahtevajo novejšo različico {0}a"
 
-#: static/js/zamboni/mobile/buttons.js:60
+#: static/js/zamboni/mobile-all.js:15194 static/js/zamboni/mobile/buttons.js:60
 msgid "Themes Require {0}"
 msgstr "Teme zahtevajo {0}"
 
-#: static/js/zamboni/mobile/buttons.js:105
+#: static/js/zamboni/mobile-all.js:15239 static/js/zamboni/mobile/buttons.js:105
 msgid "Installing..."
 msgstr "Ta dodatek je Mozilla predhodno pregledala."
 
-#: static/js/zamboni/mobile/buttons.js:125
+#: static/js/zamboni/mobile-all.js:15259 static/js/zamboni/mobile/buttons.js:125
 msgid "This add-on has been preliminarily reviewed by Mozilla."
 msgstr "Ta dodatek je Mozilla predhodno pregledala."
 
-#: static/js/zamboni/mobile/buttons.js:250
+#: static/js/zamboni/mobile-all.js:15384 static/js/zamboni/mobile/buttons.js:250
 msgid "Keep it"
 msgstr "Obdrži"
 
-#: static/js/zamboni/mobile/general.js:344
+#: static/js/zamboni/mobile-all.js:16049 static/js/zamboni/mobile-min.js:6 static/js/zamboni/mobile/general.js:344
 msgid "You're trying it on!"
 msgstr "Preizkušate jo!"
 
-#: static/js/zamboni/mobile/general.js:356
+#: static/js/zamboni/mobile-all.js:16061 static/js/zamboni/mobile-min.js:6 static/js/zamboni/mobile/general.js:356
 msgid "Added to Firefox"
 msgstr "Dodano v Firefox"

--- a/locale/sq/LC_MESSAGES/django.po
+++ b/locale/sq/LC_MESSAGES/django.po
@@ -4,82 +4,73 @@
 # Besnik Bleta <besnik@programeshqip.org>, 2006-2014.
 msgid ""
 msgstr ""
-"Project-Id-Version: \n"
+"Project-Id-Version:  \n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2016-02-24 21:23+0000\n"
+"POT-Creation-Date: 2016-04-18 15:47+0000\n"
 "PO-Revision-Date: 2016-04-06 18:35+0000\n"
 "Last-Translator: Besnik Bleta <besnik@programeshqip.org>\n"
 "Language-Team: sq\n"
-"Language: sq\n"
+"Language: \n"
 "MIME-Version: 1.0\n"
-"Content-Type: text/plain; charset=utf-8\n"
+"Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 "Generated-By: Babel 2.2.0\n"
-"X-Generator: Pontoon\n"
 
-#: src/olympia/accounts/views.py:52
+#: src/olympia/accounts/views.py:54
 msgid "Your log in attempt could not be parsed. Please try again."
 msgstr "Përpjekja juaj për hyrje s’u përmbush dot. Ju lutemi, riprovoni."
 
-#: src/olympia/accounts/views.py:54
+#: src/olympia/accounts/views.py:56
 msgid "Your Firefox Account could not be found. Please try again."
 msgstr "S’u gjet dot Llogaria juaj Firefox. Ju lutemi, riprovoni."
 
-#: src/olympia/accounts/views.py:55
+#: src/olympia/accounts/views.py:57
 msgid "You could not be logged in. Please try again."
 msgstr "S’u futët dot. Ju lutemi, riprovoni."
 
-#: src/olympia/accounts/views.py:57
+#: src/olympia/accounts/views.py:59
 msgid "Your account has already been migrated to Firefox Accounts."
 msgstr "Llogaria juaj është migruar tashmë te Llogaritë Firefox."
 
-#: src/olympia/accounts/views.py:59
+#: src/olympia/accounts/views.py:61
 msgid "Your Firefox Account already exists on this site."
 msgstr "Llogaria juaj Firefox gjendet tashmë në këtë sajt."
 
-#: src/olympia/accounts/views.py:108
+#: src/olympia/accounts/views.py:110
 msgid "Great job!"
 msgstr "Punë e paqme!"
 
-#: src/olympia/accounts/views.py:109
+#: src/olympia/accounts/views.py:111
 msgid "You can now log in to Add-ons with your Firefox Account."
 msgstr "Tani te Shtesat mund të bëni hyrjen me Llogarinë tuaj Firefox."
 
-#: src/olympia/accounts/views.py:121
+#: src/olympia/accounts/views.py:123
 msgid "Need help?"
 msgstr "Ju duhet ndihmë?"
 
-#: src/olympia/addons/buttons.py:180
+#: src/olympia/addons/buttons.py:177
 msgid "Download Now"
 msgstr "Shkarkojeni Tani"
 
-#: src/olympia/addons/buttons.py:182
+#: src/olympia/addons/buttons.py:179
 msgid "Download"
 msgstr "Shkarkim"
 
 #. L10n: please keep &nbsp; in the string so &rarr; does not wrap.
-#: src/olympia/addons/buttons.py:186
+#: src/olympia/addons/buttons.py:183
 msgid "Continue to Download&nbsp;&rarr;"
 msgstr "Vazhdoni te Shkarkimet&nbsp;&rarr;"
 
-#: src/olympia/addons/buttons.py:202 src/olympia/addons/helpers.py:35
-#: src/olympia/addons/views.py:319
-#: src/olympia/addons/templates/addons/impala/details.html:114
-#: src/olympia/addons/templates/addons/impala/listing/items.html:17
-#: src/olympia/addons/templates/addons/mobile/home.html:40
-#: src/olympia/amo/templates/amo/side_nav.html:6
-#: src/olympia/amo/templates/amo/side_nav.html:10
-#: src/olympia/amo/templates/amo/site_nav.html:2
-#: src/olympia/amo/templates/amo/site_nav.html:55
-#: src/olympia/bandwagon/views.py:95 src/olympia/browse/views.py:54
-#: src/olympia/browse/views.py:68 src/olympia/browse/views.py:235
-#: src/olympia/browse/templates/browse/impala/category_landing.html:22
+#: src/olympia/addons/buttons.py:199 src/olympia/addons/helpers.py:35 src/olympia/addons/views.py:333 src/olympia/addons/templates/addons/impala/details.html:111
+#: src/olympia/addons/templates/addons/impala/listing/items.html:17 src/olympia/addons/templates/addons/mobile/home.html:40 src/olympia/amo/templates/amo/side_nav.html:6
+#: src/olympia/amo/templates/amo/side_nav.html:10 src/olympia/amo/templates/amo/site_nav.html:2 src/olympia/amo/templates/amo/site_nav.html:53 src/olympia/bandwagon/views.py:95
+#: src/olympia/browse/views.py:54 src/olympia/browse/views.py:68 src/olympia/browse/views.py:202 src/olympia/browse/templates/browse/impala/category_landing.html:22
 #: src/olympia/browse/templates/browse/personas/mobile/category_landing.html:26
 msgid "Featured"
 msgstr "Të zgjedhura"
 
-#: src/olympia/addons/buttons.py:221
+#: src/olympia/addons/buttons.py:218
 msgid "Add to {0}"
 msgstr "Shtoje te {0}"
 
@@ -89,8 +80,7 @@ msgstr "Ky emër është i përdorur tashmë. Ju lutemi, zgjidhni një tjetër."
 
 #: src/olympia/addons/forms.py:71
 msgid "This slug is already in use. Please choose another."
-msgstr ""
-"Ky identifikues është i përdorur tashmë. Ju lutemi, zgjidhni një tjetër."
+msgstr "Ky identifikues është i përdorur tashmë. Ju lutemi, zgjidhni një tjetër."
 
 #: src/olympia/addons/forms.py:74
 #, python-format
@@ -119,11 +109,8 @@ msgstr[1] "Keni {0} etiketa të tepërta."
 
 #: src/olympia/addons/forms.py:117
 #, python-format
-msgid ""
-"All tags must be %s characters or less after invalid characters are removed."
-msgstr ""
-"Krejt etiketat duhet të jenë %s ose më pak shenja të gjata, pas heqjes së "
-"shenjave të pavlefshme."
+msgid "All tags must be %s characters or less after invalid characters are removed."
+msgstr "Krejt etiketat duhet të jenë %s ose më pak shenja të gjata, pas heqjes së shenjave të pavlefshme."
 
 #: src/olympia/addons/forms.py:121
 msgid "All tags must be at least {0} character."
@@ -131,49 +118,39 @@ msgid_plural "All tags must be at least {0} characters."
 msgstr[0] "Krejt etiketat duhet të jenë të paktën {0} shenjë."
 msgstr[1] "Krejt etiketat duhet të jenë të paktën {0} shenja."
 
-#: src/olympia/addons/forms.py:234
-msgid ""
-"Categories cannot be changed while your add-on is featured for this "
-"application."
-msgstr ""
-"Kategoritë s’mund të ndryshohen, sa kohë që shtesa juaj është zgjedhur për "
-"këtë kategori."
+#: src/olympia/addons/forms.py:238
+msgid "Categories cannot be changed while your add-on is featured for this application."
+msgstr "Kategoritë s’mund të ndryshohen, sa kohë që shtesa juaj është zgjedhur për këtë kategori."
 
 #. L10n: {0} is the number of categories.
-#: src/olympia/addons/forms.py:238
+#: src/olympia/addons/forms.py:242
 msgid "You can have only {0} category."
 msgid_plural "You can have only {0} categories."
 msgstr[0] "Mund të keni vetëm {0} kategori."
 msgstr[1] "Mund të keni vetëm {0} kategori."
 
-#: src/olympia/addons/forms.py:246
-msgid ""
-"The miscellaneous category cannot be combined with additional categories."
+#: src/olympia/addons/forms.py:250
+msgid "The miscellaneous category cannot be combined with additional categories."
 msgstr "Kategoria Të ndryshme s’mund të ndërthuret me të tjera kategori."
 
-#: src/olympia/addons/forms.py:369
+#: src/olympia/addons/forms.py:374
 #, python-format
-msgid ""
-"Before changing your default locale you must have a name, summary, and "
-"description in that locale. You are missing %s."
-msgstr ""
-"Para se të ndryshoni vendoren parazgjedhje duhet të keni një emër, një "
-"përmbledhje dhe një përshkrim në gjuhën e vendores. Ju mungon %s."
+msgid "Before changing your default locale you must have a name, summary, and description in that locale. You are missing %s."
+msgstr "Para se të ndryshoni vendoren parazgjedhje duhet të keni një emër, një përmbledhje dhe një përshkrim në gjuhën e vendores. Ju mungon %s."
 
-#: src/olympia/addons/forms.py:484 src/olympia/addons/forms.py:575
+#: src/olympia/addons/forms.py:455 src/olympia/addons/forms.py:546
 msgid "A license must be selected."
 msgstr "Duhet përzgjedhur një licencë."
 
-#: src/olympia/addons/forms.py:556
+#: src/olympia/addons/forms.py:527
 msgid "Give Your Theme a Name."
 msgstr "Vërini një Emër Temës Suaj."
 
-#: src/olympia/addons/forms.py:562
-#: src/olympia/devhub/templates/devhub/personas/submit.html:53
+#: src/olympia/addons/forms.py:533 src/olympia/devhub/templates/devhub/personas/submit.html:53
 msgid "Describe your Theme."
 msgstr "Përshkruani Temën tuaj."
 
-#: src/olympia/addons/forms.py:704
+#: src/olympia/addons/forms.py:675
 msgid "Enter a new author's email address"
 msgstr "Jepni një adresë të re email të autorit"
 
@@ -181,49 +158,39 @@ msgstr "Jepni një adresë të re email të autorit"
 msgid "Not Reviewed"
 msgstr "E pashqyrtuar"
 
-#: src/olympia/addons/models.py:301
+#: src/olympia/addons/models.py:298
 msgid "Users have the option of contributing more or less than this amount."
-msgstr ""
-"Përdoruesit kanë mundësi të caktojnë kontribut më shumë ose më pak se sa kjo"
-" sasi."
+msgstr "Përdoruesit kanë mundësi të caktojnë kontribut më shumë ose më pak se sa kjo sasi."
 
-#: src/olympia/addons/models.py:309
-msgid ""
-"Users will always be asked in the Add-ons Manager (Firefox 4 and above)"
+#: src/olympia/addons/models.py:306
+msgid "Users will always be asked in the Add-ons Manager (Firefox 4 and above). Only applies to desktop."
 msgstr ""
-"Përdoruesit do të pyeten nga Përgjegjësi i Shtesave (Firefox 4 e më tej)"
 
 # Column name in a table.
-#: src/olympia/addons/models.py:1804
-#: src/olympia/addons/templates/addons/details_box.html:55
-#: src/olympia/devhub/templates/devhub/index.html:92
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:102
+#: src/olympia/addons/models.py:1802 src/olympia/addons/templates/addons/details_box.html:55 src/olympia/devhub/templates/devhub/index.html:92
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:89
 msgid "Listed"
 msgstr "E pranishme"
 
-#: src/olympia/addons/views.py:320
-#: src/olympia/browse/templates/browse/personas/mobile/category_landing.html:27
+#: src/olympia/addons/views.py:334 src/olympia/browse/templates/browse/personas/mobile/category_landing.html:27
 msgid "Popular"
 msgstr "Popullore"
 
-#: src/olympia/addons/views.py:321 src/olympia/browse/views.py:238
-#: src/olympia/browse/views.py:280 src/olympia/browse/views.py:482
+#: src/olympia/addons/views.py:335 src/olympia/browse/views.py:205 src/olympia/browse/views.py:247 src/olympia/browse/views.py:449
 msgid "Recently Added"
 msgstr "Shtuar Së Fundmi"
 
-#: src/olympia/addons/views.py:322 src/olympia/bandwagon/views.py:99
-#: src/olympia/browse/views.py:60 src/olympia/browse/views.py:71
-#: src/olympia/search/forms.py:16 src/olympia/search/forms.py:91
+#: src/olympia/addons/views.py:336 src/olympia/bandwagon/views.py:99 src/olympia/browse/views.py:60 src/olympia/browse/views.py:71 src/olympia/search/forms.py:16 src/olympia/search/forms.py:91
 msgid "Recently Updated"
 msgstr "Përditësuar së Fundmi"
 
-#. l10n: {0} is the addon name
 # %1 is an add-on name.
-#: src/olympia/addons/views.py:520
+#. l10n: {0} is the addon name
+#: src/olympia/addons/views.py:534
 msgid "Contribution for {0}"
 msgstr "Kontribut për {0}"
 
-#: src/olympia/addons/views.py:613
+#: src/olympia/addons/views.py:627
 msgid "Abuse reported."
 msgstr "Shpërdorimi u njoftua."
 
@@ -231,116 +198,70 @@ msgstr "Shpërdorimi u njoftua."
 msgid "My add-on doesn't fit into any of the categories"
 msgstr "Shtesa ime s’hyn në ndonjë nga kategoritë e mundshme"
 
-#: src/olympia/addons/templates/addons/button.html:27
-#: src/olympia/addons/templates/addons/impala/button.html:11
-#: src/olympia/addons/templates/addons/mobile/button.html:11
+#: src/olympia/addons/templates/addons/button.html:27 src/olympia/addons/templates/addons/impala/button.html:11 src/olympia/addons/templates/addons/mobile/button.html:11
 msgid "No compatible versions"
 msgstr "S’ka versione të përputhshëm"
 
-#: src/olympia/addons/templates/addons/button.html:35
-#: src/olympia/addons/templates/addons/impala/button.html:19
+#: src/olympia/addons/templates/addons/button.html:35 src/olympia/addons/templates/addons/impala/button.html:19
 msgid "Added to Mobile"
 msgstr "U shtua te Celulari"
 
-#: src/olympia/addons/templates/addons/button.html:37
-#: src/olympia/addons/templates/addons/impala/button.html:21
+#: src/olympia/addons/templates/addons/button.html:37 src/olympia/addons/templates/addons/impala/button.html:21
 msgid "Add to Mobile"
 msgstr "Shtoje te Celulari"
 
 #. {0} is a platform name like Windows or Mac OS X.
-#: src/olympia/addons/templates/addons/button.html:66
-#: src/olympia/addons/templates/addons/includes/install_button.html:19
+#: src/olympia/addons/templates/addons/button.html:66 src/olympia/addons/templates/addons/includes/install_button.html:19
 msgid "for {0}"
 msgstr "për {0}"
 
-#: src/olympia/addons/templates/addons/button.html:82
-#: src/olympia/addons/templates/addons/mobile/button.html:23
+#: src/olympia/addons/templates/addons/button.html:82 src/olympia/addons/templates/addons/mobile/button.html:23
 msgid "View privacy policy"
 msgstr "Shihni rregullat e privatësisë"
 
-#: src/olympia/addons/templates/addons/button.html:87
-#: src/olympia/addons/templates/addons/details_box.html:133
-#: src/olympia/addons/templates/addons/mobile/button.html:28
+#: src/olympia/addons/templates/addons/button.html:87 src/olympia/addons/templates/addons/details_box.html:133 src/olympia/addons/templates/addons/mobile/button.html:28
 #: src/olympia/discovery/templates/discovery/addons/detail.html:28
 msgid "View End-User License Agreement"
 msgstr "Shihni Marrëveshje Licence Përdoruesi të Thjeshtë"
 
-#: src/olympia/addons/templates/addons/button.html:92
-#: src/olympia/addons/templates/addons/impala/button.html:54
+#: src/olympia/addons/templates/addons/button.html:92 src/olympia/addons/templates/addons/impala/button.html:54
 #, python-format
-msgid ""
-"This add-on has not been reviewed by Mozilla. <a href=\"%(url)s\">Learn "
-"more</a>"
-msgstr ""
-"Kjo shtesë s’është shqyrtuar prej Mozilla-s. <a href=\"%(url)s\">Mësoni më "
-"tepër</a>"
+msgid "This add-on has not been reviewed by Mozilla. <a href=\"%(url)s\">Learn more</a>"
+msgstr "Kjo shtesë s’është shqyrtuar prej Mozilla-s. <a href=\"%(url)s\">Mësoni më tepër</a>"
 
-#: src/olympia/addons/templates/addons/button.html:97
-#: src/olympia/addons/templates/addons/impala/button.html:60
+#: src/olympia/addons/templates/addons/button.html:97 src/olympia/addons/templates/addons/impala/button.html:60
 #, python-format
-msgid ""
-"This add-on has been preliminarily reviewed by Mozilla. <a "
-"href=\"%(url)s\">Learn more</a>"
-msgstr ""
-"Kjo shtesë është shqyrtuar paraprakisht nga Mozilla. <a "
-"href=\"%(url)s\">Mësoni më tepër</a>"
+msgid "This add-on has been preliminarily reviewed by Mozilla. <a href=\"%(url)s\">Learn more</a>"
+msgstr "Kjo shtesë është shqyrtuar paraprakisht nga Mozilla. <a href=\"%(url)s\">Mësoni më tepër</a>"
 
-#: src/olympia/addons/templates/addons/contribution.html:11
-#: src/olympia/addons/templates/addons/impala/developers.html:44
-msgid ""
-"The developer of this add-on asks that you help support its continued "
-"development by making a small contribution."
-msgstr ""
-"Zhvilluesi i kësaj shtese dëshiron që të ndihmoni duke mbështetur zhvillimin"
-" e mëtejshëm të saj përmes një kontributi të vogël."
+#: src/olympia/addons/templates/addons/contribution.html:11 src/olympia/addons/templates/addons/impala/developers.html:44
+msgid "The developer of this add-on asks that you help support its continued development by making a small contribution."
+msgstr "Zhvilluesi i kësaj shtese dëshiron që të ndihmoni duke mbështetur zhvillimin e mëtejshëm të saj përmes një kontributi të vogël."
 
 #: src/olympia/addons/templates/addons/contribution.html:14
 #, python-format
-msgid ""
-"The developer of this add-on asks that you show your support by making a "
-"donation to the <a href=\"%(charity_url)s\">%(charity_name)s</a>."
-msgstr ""
-"Zhvilluesi i kësaj shtese dëshiron që përkrahjen tuaj ta tregoni duke dhënë "
-"një kontribut te <a href=\"%(charity_url)s\">%(charity_name)s</a>."
+msgid "The developer of this add-on asks that you show your support by making a donation to the <a href=\"%(charity_url)s\">%(charity_name)s</a>."
+msgstr "Zhvilluesi i kësaj shtese dëshiron që përkrahjen tuaj ta tregoni duke dhënë një kontribut te <a href=\"%(charity_url)s\">%(charity_name)s</a>."
 
 #: src/olympia/addons/templates/addons/contribution.html:19
 #, python-format
-msgid ""
-"The developer of this add-on asks that you show your support by making a "
-"small contribution to <a href=\"%(charity_url)s\">%(charity_name)s</a>."
-msgstr ""
-"Zhvilluesi i kësaj shtese dëshiron që përkrahjen tuaj ta tregoni duke dhënë "
-"një kontribut të vogël te <a href=\"%(charity_url)s\">%(charity_name)s</a>."
+msgid "The developer of this add-on asks that you show your support by making a small contribution to <a href=\"%(charity_url)s\">%(charity_name)s</a>."
+msgstr "Zhvilluesi i kësaj shtese dëshiron që përkrahjen tuaj ta tregoni duke dhënë një kontribut të vogël te <a href=\"%(charity_url)s\">%(charity_name)s</a>."
 
-#: src/olympia/addons/templates/addons/contribution.html:30
-#: src/olympia/addons/templates/addons/impala/contribution.html:18
-#: src/olympia/templates/menu_links.html:25
+#: src/olympia/addons/templates/addons/contribution.html:30 src/olympia/addons/templates/addons/impala/contribution.html:18 src/olympia/templates/menu_links.html:25
 msgid "Contribute"
 msgstr "Kontribuoni"
 
-#. Click Contribute button OR Install button
 # This is a separator between the graphical [contribute] button and the
 # graphical [download now] button
-#: src/olympia/addons/templates/addons/contribution.html:34
-#: src/olympia/addons/templates/addons/report_abuse.html:26
-#: src/olympia/addons/templates/addons/impala/contribution.html:32
-#: src/olympia/devhub/templates/devhub/addons/ajax_compat_update.html:36
-#: src/olympia/devhub/templates/devhub/addons/profile.html:44
-#: src/olympia/devhub/templates/devhub/addons/edit/admin.html:101
-#: src/olympia/devhub/templates/devhub/addons/edit/basic.html:152
-#: src/olympia/devhub/templates/devhub/addons/edit/details.html:85
-#: src/olympia/devhub/templates/devhub/addons/edit/support.html:67
-#: src/olympia/devhub/templates/devhub/addons/edit/technical.html:166
-#: src/olympia/devhub/templates/devhub/addons/forms_shared/media.html:149
-#: src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:44
-#: src/olympia/devhub/templates/devhub/versions/add_file_modal.html:78
-#: src/olympia/devhub/templates/devhub/versions/edit.html:139
-#: src/olympia/devhub/templates/devhub/versions/list.html:242
-#: src/olympia/devhub/templates/devhub/versions/list.html:276
-#: src/olympia/devhub/templates/devhub/versions/list.html:317
-#: src/olympia/devhub/templates/devhub/versions/list.html:351
-#: src/olympia/reviews/templates/reviews/edit_review.html:16
-#: src/olympia/translations/templates/translations/trans-menu.html:50
+#. Click Contribute button OR Install button
+#: src/olympia/addons/templates/addons/contribution.html:34 src/olympia/addons/templates/addons/report_abuse.html:26 src/olympia/addons/templates/addons/impala/contribution.html:32
+#: src/olympia/devhub/templates/devhub/addons/ajax_compat_update.html:36 src/olympia/devhub/templates/devhub/addons/profile.html:44 src/olympia/devhub/templates/devhub/addons/edit/admin.html:101
+#: src/olympia/devhub/templates/devhub/addons/edit/basic.html:152 src/olympia/devhub/templates/devhub/addons/edit/details.html:85 src/olympia/devhub/templates/devhub/addons/edit/support.html:67
+#: src/olympia/devhub/templates/devhub/addons/edit/technical.html:166 src/olympia/devhub/templates/devhub/addons/forms_shared/media.html:149
+#: src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:43 src/olympia/devhub/templates/devhub/versions/add_file_modal.html:58 src/olympia/devhub/templates/devhub/versions/edit.html:139
+#: src/olympia/devhub/templates/devhub/versions/list.html:239 src/olympia/devhub/templates/devhub/versions/list.html:281 src/olympia/devhub/templates/devhub/versions/list.html:315
+#: src/olympia/devhub/templates/devhub/versions/list.html:349 src/olympia/reviews/templates/reviews/edit_review.html:16 src/olympia/translations/templates/translations/trans-menu.html:50
 #: src/olympia/translations/templates/translations/trans-menu.html:62
 msgid "or"
 msgstr "ose"
@@ -349,42 +270,24 @@ msgstr "ose"
 msgid "Suggested Contribution: {0}"
 msgstr "Kontribut i Këshilluar: {0}"
 
-#: src/olympia/addons/templates/addons/contribution.html:48
-#: src/olympia/amo/templates/amo/recaptcha.html:5
-#: src/olympia/versions/templates/versions/version.html:52
+#: src/olympia/addons/templates/addons/contribution.html:48 src/olympia/amo/templates/amo/recaptcha.html:5 src/olympia/versions/templates/versions/version.html:52
 msgid "What's this?"
 msgstr "Ç’është kjo?"
 
 #: src/olympia/addons/templates/addons/contribution.html:63
 #, python-format
-msgid ""
-"The developer of this add-on would like you to consider making a donation to"
-" the <a href=\"%(charity_url)s\">%(charity_name)s</a> if you enjoy using it."
-msgstr ""
-"Zhvilluesi i kësaj shtese do të donte të shihnit mundësinë të bënit një "
-"dhurim te <a href=\"%(charity_url)s\">%(charity_name)s</a>, nëse kënaqeni "
-"nga përdorimi i saj."
+msgid "The developer of this add-on would like you to consider making a donation to the <a href=\"%(charity_url)s\">%(charity_name)s</a> if you enjoy using it."
+msgstr "Zhvilluesi i kësaj shtese do të donte të shihnit mundësinë të bënit një dhurim te <a href=\"%(charity_url)s\">%(charity_name)s</a>, nëse kënaqeni nga përdorimi i saj."
 
 #: src/olympia/addons/templates/addons/contribution.html:69
 #, python-format
-msgid ""
-"The developer of this add-on would like you to consider making a small "
-"contribution to <a href=\"%(charity_url)s\">%(charity_name)s</a> if you "
-"enjoy using it."
-msgstr ""
-"Zhvilluesi i kësaj shtese do të donte të shihnit mundësinë të bënit një "
-"dhurim të vogël te <a href=\"%(charity_url)s\">%(charity_name)s</a>, nëse "
-"kënaqeni nga përdorimi i saj."
+msgid "The developer of this add-on would like you to consider making a small contribution to <a href=\"%(charity_url)s\">%(charity_name)s</a> if you enjoy using it."
+msgstr "Zhvilluesi i kësaj shtese do të donte të shihnit mundësinë të bënit një dhurim të vogël te <a href=\"%(charity_url)s\">%(charity_name)s</a>, nëse kënaqeni nga përdorimi i saj."
 
 #: src/olympia/addons/templates/addons/contribution.html:76
-msgid ""
-"Mozilla is committed to supporting a vibrant and healthy developer "
-"ecosystem. Your optional contribution helps sustain further development of "
-"this add-on."
+msgid "Mozilla is committed to supporting a vibrant and healthy developer ecosystem. Your optional contribution helps sustain further development of this add-on."
 msgstr ""
-"Mozilla i është përkushtuar përkrahjes së një ekosistemi të gjallë dhe të "
-"shëndetshëm zhvilluesish. Kontributi juaj i mundshëm ndihmon në mbajtjen "
-"gjallë të zhvillimit të mëtejshëm të kësaj shtese."
+"Mozilla i është përkushtuar përkrahjes së një ekosistemi të gjallë dhe të shëndetshëm zhvilluesish. Kontributi juaj i mundshëm ndihmon në mbajtjen gjallë të zhvillimit të mëtejshëm të kësaj shtese."
 
 #: src/olympia/addons/templates/addons/contributions_lightbox.html:5
 msgid "Make a Contribution"
@@ -392,37 +295,24 @@ msgstr "Jepni një Kontribut"
 
 #: src/olympia/addons/templates/addons/contributions_lightbox.html:9
 #, python-format
-msgid ""
-"Help support the continued development of <strong>%(addon_name)s</strong> by"
-" making a small contribution through <a href=\"%(paypal_url)s\">PayPal</a>."
-msgstr ""
-"Ndihmoni me përkrahjen e zhvillimit pa ndërprerje të "
-"<strong>%(addon_name)s</strong>, duke dhuruar një kontribut të vogël përmes "
-"<a href=\"%(paypal_url)s\">PayPal-it</a>."
+msgid "Help support the continued development of <strong>%(addon_name)s</strong> by making a small contribution through <a href=\"%(paypal_url)s\">PayPal</a>."
+msgstr "Ndihmoni me përkrahjen e zhvillimit pa ndërprerje të <strong>%(addon_name)s</strong>, duke dhuruar një kontribut të vogël përmes <a href=\"%(paypal_url)s\">PayPal-it</a>."
 
 #: src/olympia/addons/templates/addons/contributions_lightbox.html:15
 #, python-format
 msgid ""
-"To show your support for <b>%(addon_name)s</b>, the developer asks that you "
-"make a donation to the <a href=\"%(charity_url)s\">%(charity_name)s</a> "
-"through <a href=\"%(paypal_url)s\">PayPal</a>."
+"To show your support for <b>%(addon_name)s</b>, the developer asks that you make a donation to the <a href=\"%(charity_url)s\">%(charity_name)s</a> through <a href=\"%(paypal_url)s\">PayPal</a>."
 msgstr ""
-"Si shenjë të përkrahjes suaj për <b>%(addon_name)s</b>, zhvilluesi ju fton "
-"të bëni një dhurim te <a href=\"%(charity_url)s\">%(charity_name)s</a> "
-"përmes <a href=\"%(paypal_url)s\">PayPal</a>-it."
+"Si shenjë të përkrahjes suaj për <b>%(addon_name)s</b>, zhvilluesi ju fton të bëni një dhurim te <a href=\"%(charity_url)s\">%(charity_name)s</a> përmes <a href=\"%(paypal_url)s\">PayPal</a>-it."
 
 #: src/olympia/addons/templates/addons/contributions_lightbox.html:21
 #, python-format
 msgid ""
-"To show your support for <b>%(addon_name)s</b>, the developer asks that you "
-"make a small contribution to <a "
-"href=\"%(charity_url)s\">%(charity_name)s</a> through <a "
-"href=\"%(paypal_url)s\">PayPal</a>."
+"To show your support for <b>%(addon_name)s</b>, the developer asks that you make a small contribution to <a href=\"%(charity_url)s\">%(charity_name)s</a> through <a href=\"%(paypal_url)s\">PayPal</"
+"a>."
 msgstr ""
-"Si shenjë të përkrahjes suaj për <b>%(addon_name)s</b>, zhvilluesi ju fton "
-"të bëni një kontribut të vogël te <a "
-"href=\"%(charity_url)s\">%(charity_name)s</a> përmes <a "
-"href=\"%(paypal_url)s\">PayPal</a>-it."
+"Si shenjë të përkrahjes suaj për <b>%(addon_name)s</b>, zhvilluesi ju fton të bëni një kontribut të vogël te <a href=\"%(charity_url)s\">%(charity_name)s</a> përmes <a href=\"%(paypal_url)s"
+"\">PayPal</a>-it."
 
 #: src/olympia/addons/templates/addons/contributions_lightbox.html:30
 msgid "How much would you like to contribute?"
@@ -445,8 +335,7 @@ msgstr "Sasia e kontributit duhet të jetë një numër."
 msgid "A one-time suggested contribution of {0}"
 msgstr "Kontribut i këshilluar, një herë vetëm, prej {0}"
 
-#. {0} is a currency symbol (e.g., $),                    {1} is an amount
-#. input
+#. {0} is a currency symbol (e.g., $),                    {1} is an amount input
 #. field
 #: src/olympia/addons/templates/addons/contributions_lightbox.html:64
 msgid "A one-time contribution of {0} {1}"
@@ -456,11 +345,8 @@ msgstr "Kontribut vetëm një herë, prej {1}{0}"
 msgid "Leave a comment or request with your contribution."
 msgstr "Lini një koment ose kërkesë me kontributin tuaj."
 
-#: src/olympia/addons/templates/addons/contributions_lightbox.html:74
-#: src/olympia/bandwagon/templates/bandwagon/ajax_new.html:20
-#: src/olympia/bandwagon/templates/bandwagon/includes/addedit.html:37
-#: src/olympia/reviews/templates/reviews/mobile/add_form.html:13
-#: src/olympia/templates/includes/forms.html:10
+#: src/olympia/addons/templates/addons/contributions_lightbox.html:74 src/olympia/bandwagon/templates/bandwagon/ajax_new.html:20 src/olympia/bandwagon/templates/bandwagon/includes/addedit.html:37
+#: src/olympia/reviews/templates/reviews/mobile/add_form.html:13 src/olympia/templates/includes/forms.html:10
 msgid "(optional)"
 msgstr "(opsional)"
 
@@ -480,36 +366,27 @@ msgstr "Jo, Faleminderit"
 msgid "Contribution made, thank you."
 msgstr "Kontributi u krye, ju falemi nderit."
 
-#: src/olympia/addons/templates/addons/details_box.html:10
-#: src/olympia/discovery/templates/discovery/addons/detail.html:19
+#: src/olympia/addons/templates/addons/details_box.html:10 src/olympia/discovery/templates/discovery/addons/detail.html:19
 msgid "No restart required"
 msgstr "S’lyp rinisje"
 
 #. This is a caption for a table. {0} is an add-on name.
-#: src/olympia/addons/templates/addons/details_box.html:26
-#: src/olympia/addons/templates/addons/includes/persona.html:9
+#: src/olympia/addons/templates/addons/details_box.html:26 src/olympia/addons/templates/addons/includes/persona.html:9
 msgid "Add-on Information for {0}"
 msgstr "Të dhëna Shtese për {0}"
 
-#: src/olympia/addons/templates/addons/details_box.html:30
-#: src/olympia/addons/templates/addons/persona_detail_table.html:3
-#: src/olympia/addons/templates/addons/mobile/details.html:63
-#: src/olympia/addons/templates/addons/mobile/persona_detail_table.html:7
-#: src/olympia/browse/views.py:459 src/olympia/devhub/views.py:75
+#: src/olympia/addons/templates/addons/details_box.html:30 src/olympia/addons/templates/addons/persona_detail_table.html:3 src/olympia/addons/templates/addons/mobile/details.html:63
+#: src/olympia/addons/templates/addons/mobile/persona_detail_table.html:7 src/olympia/browse/views.py:426 src/olympia/devhub/views.py:73
 msgid "Updated"
 msgstr "Përditësuar më"
 
-#: src/olympia/addons/templates/addons/details_box.html:38
-#: src/olympia/addons/templates/addons/mobile/details.html:71
-#: src/olympia/devhub/templates/devhub/addons/edit/support.html:43
+#: src/olympia/addons/templates/addons/details_box.html:38 src/olympia/addons/templates/addons/mobile/details.html:71 src/olympia/devhub/templates/devhub/addons/edit/support.html:43
 #: src/olympia/discovery/templates/discovery/addons/detail.html:77
 msgid "Website"
 msgstr "Sajt"
 
 #. This refers to this version's compatible applications, such as Firefox 8.0
-#: src/olympia/addons/templates/addons/details_box.html:47
-#: src/olympia/addons/templates/addons/mobile/details.html:80
-#: src/olympia/search/templates/search/results.html:72
+#: src/olympia/addons/templates/addons/details_box.html:47 src/olympia/addons/templates/addons/mobile/details.html:80 src/olympia/search/templates/search/results.html:72
 #: src/olympia/versions/templates/versions/version.html:21
 msgid "Works with"
 msgstr "Funksionon me"
@@ -518,45 +395,30 @@ msgstr "Funksionon me"
 msgid "Visibility"
 msgstr "Dukshmëri"
 
-#: src/olympia/addons/templates/addons/details_box.html:57
-#: src/olympia/devhub/templates/devhub/index.html:94
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:104
+#: src/olympia/addons/templates/addons/details_box.html:57 src/olympia/devhub/templates/devhub/index.html:94 src/olympia/devhub/templates/devhub/includes/addon_details.html:91
 msgid "Hidden"
 msgstr "E fshehur"
 
-#: src/olympia/addons/templates/addons/details_box.html:59
-#: src/olympia/devhub/templates/devhub/index.html:96
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:106
+#: src/olympia/addons/templates/addons/details_box.html:59 src/olympia/devhub/templates/devhub/index.html:96 src/olympia/devhub/templates/devhub/includes/addon_details.html:93
 msgid "Unlisted"
 msgstr "E palistuar"
 
-#: src/olympia/addons/templates/addons/details_box.html:67
-#: src/olympia/devhub/templates/devhub/addons/edit/technical.html:44
+#: src/olympia/addons/templates/addons/details_box.html:67 src/olympia/devhub/templates/devhub/addons/edit/technical.html:44
 msgid "Required Add-ons"
 msgstr "Shtesa të Domosdoshme"
 
-#: src/olympia/addons/templates/addons/details_box.html:81
-#: src/olympia/addons/templates/addons/persona_detail_table.html:15
-#: src/olympia/browse/views.py:462 src/olympia/devhub/views.py:78
-#: src/olympia/devhub/views.py:85
-#: src/olympia/discovery/templates/discovery/addons/detail.html:57
-#: src/olympia/reviews/forms.py:62
-#: src/olympia/reviews/templates/reviews/add.html:57
+#: src/olympia/addons/templates/addons/details_box.html:81 src/olympia/addons/templates/addons/persona_detail_table.html:15 src/olympia/browse/views.py:429 src/olympia/devhub/views.py:76
+#: src/olympia/devhub/views.py:83 src/olympia/discovery/templates/discovery/addons/detail.html:57 src/olympia/reviews/forms.py:62 src/olympia/reviews/templates/reviews/add.html:57
 #: src/olympia/reviews/templates/reviews/mobile/review_list.html:18
 msgid "Rating"
 msgstr "Vlerësim"
 
-#: src/olympia/addons/templates/addons/details_box.html:85
-#: src/olympia/browse/views.py:461 src/olympia/devhub/views.py:77
-#: src/olympia/devhub/views.py:84
-#: src/olympia/stats/templates/stats/addon_report_menu.html:8
-#: src/olympia/stats/templates/stats/collection_report_menu.html:18
+#: src/olympia/addons/templates/addons/details_box.html:85 src/olympia/browse/views.py:428 src/olympia/devhub/views.py:75 src/olympia/devhub/views.py:82
+#: src/olympia/stats/templates/stats/addon_report_menu.html:8 src/olympia/stats/templates/stats/collection_report_menu.html:18
 msgid "Downloads"
 msgstr "Shkarkime"
 
-#: src/olympia/addons/templates/addons/details_box.html:91
-#: src/olympia/addons/templates/addons/details_box.html:103
-#: src/olympia/devhub/templates/devhub/addons/listing/item_actions_theme.html:17
+#: src/olympia/addons/templates/addons/details_box.html:91 src/olympia/addons/templates/addons/details_box.html:103 src/olympia/devhub/templates/devhub/addons/listing/item_actions_theme.html:17
 #: src/olympia/devhub/templates/devhub/personas/edit.html:60
 msgid "View Statistics"
 msgstr "Shihni Statistika"
@@ -570,18 +432,13 @@ msgid "Abuse Reports"
 msgstr "Raportime Abuzimesh"
 
 #. The Privacy Policy for this add-on.
-#: src/olympia/addons/templates/addons/details_box.html:121
-#: src/olympia/addons/templates/addons/privacy.html:19
-#: src/olympia/addons/templates/addons/privacy.html:23
-#: src/olympia/addons/templates/addons/impala/button.html:43
-#: src/olympia/addons/templates/addons/impala/details.html:307
-#: src/olympia/devhub/templates/devhub/includes/policy_form.html:20
+#: src/olympia/addons/templates/addons/details_box.html:121 src/olympia/addons/templates/addons/privacy.html:19 src/olympia/addons/templates/addons/privacy.html:23
+#: src/olympia/addons/templates/addons/impala/button.html:43 src/olympia/addons/templates/addons/impala/details.html:312 src/olympia/devhub/templates/devhub/includes/policy_form.html:23
 #: src/olympia/templates/mobile/base_addons.html:87
 msgid "Privacy Policy"
 msgstr "Rregulla Privatësie"
 
-#: src/olympia/addons/templates/addons/details_box.html:124
-#: src/olympia/discovery/templates/discovery/addons/detail.html:24
+#: src/olympia/addons/templates/addons/details_box.html:124 src/olympia/discovery/templates/discovery/addons/detail.html:24
 msgid "View Privacy Policy"
 msgstr "Shihni Rregullat e Privatësisë"
 
@@ -589,8 +446,7 @@ msgstr "Shihni Rregullat e Privatësisë"
 msgid "EULA"
 msgstr "EULA"
 
-#: src/olympia/addons/templates/addons/details_box.html:171
-#: src/olympia/addons/templates/addons/details_box.html:231
+#: src/olympia/addons/templates/addons/details_box.html:171 src/olympia/addons/templates/addons/details_box.html:231
 msgid "More about this add-on"
 msgstr "Më tepër rreth kësaj shtese"
 
@@ -598,27 +454,21 @@ msgstr "Më tepër rreth kësaj shtese"
 msgid "Image Gallery"
 msgstr "Galeri Figurash"
 
-#: src/olympia/addons/templates/addons/details_box.html:190
-#: src/olympia/devhub/templates/devhub/addons/edit/technical.html:21
+#: src/olympia/addons/templates/addons/details_box.html:190 src/olympia/devhub/templates/devhub/addons/edit/technical.html:21
 msgid "Developer Comments"
 msgstr "Komente nga Zhvilluesi"
 
-#: src/olympia/addons/templates/addons/details_box.html:199
-#: src/olympia/addons/templates/addons/impala/details.html:259
+#: src/olympia/addons/templates/addons/details_box.html:199 src/olympia/addons/templates/addons/impala/details.html:264
 msgid "Development Channel"
 msgstr "Kanal Zhvillimesh"
 
-#: src/olympia/addons/templates/addons/details_box.html:202
-#: src/olympia/addons/templates/addons/mobile/details.html:124
+#: src/olympia/addons/templates/addons/details_box.html:202 src/olympia/addons/templates/addons/mobile/details.html:124
 msgid ""
-"The Development Channel lets you test an experimental new version of this "
-"add-on before it's released to the general public. Once you install the "
-"development version, you will continue to get updates from this channel."
+"The Development Channel lets you test an experimental new version of this add-on before it's released to the general public. Once you install the development version, you will continue to get "
+"updates from this channel."
 msgstr ""
-"Kanali i Zhvillimit ju lë të provoni një version të ri eksperimental të "
-"kësaj shtese, përpara se të hidhet në qarkullim për publikun e përgjithshëm."
-" Pasi instaloni versionin zhvillim, do të vazhdoni të merrni njoftime "
-"përditësimesh prej këtij kanali."
+"Kanali i Zhvillimit ju lë të provoni një version të ri eksperimental të kësaj shtese, përpara se të hidhet në qarkullim për publikun e përgjithshëm. Pasi instaloni versionin zhvillim, do të "
+"vazhdoni të merrni njoftime përditësimesh prej këtij kanali."
 
 #: src/olympia/addons/templates/addons/details_box.html:207
 msgid "Install development version"
@@ -626,75 +476,52 @@ msgstr "Instalo versionin zhvillim"
 
 #: src/olympia/addons/templates/addons/details_box.html:211
 msgid ""
-"<strong>Caution:</strong> Development versions of this add-on have not been "
-"reviewed by Mozilla. Once you install a development version you will "
-"continue to receive development updates from this developer. To stop "
-"receiving development updates, reinstall the default version from the link "
-"above."
+"<strong>Caution:</strong> Development versions of this add-on have not been reviewed by Mozilla. Once you install a development version you will continue to receive development updates from this "
+"developer. To stop receiving development updates, reinstall the default version from the link above."
 msgstr ""
-"<strong>Kujdes:</strong> Versionet beta të kësaj shtese s’janë shqyrtuar nga"
-" Mozilla. Pasi të instaloni një version beta, do të vazhdojnë t’ju vijnë "
-"përditësime prej këtij zhvilluesi. Që të mos ju vijnë përditësime lidhur me "
-"zhvillimin, riinstaloni versionin parazgjedhje prej lidhjes së më sipërme."
+"<strong>Kujdes:</strong> Versionet beta të kësaj shtese s’janë shqyrtuar nga Mozilla. Pasi të instaloni një version beta, do të vazhdojnë t’ju vijnë përditësime prej këtij zhvilluesi. Që të mos ju "
+"vijnë përditësime lidhur me zhvillimin, riinstaloni versionin parazgjedhje prej lidhjes së më sipërme."
 
-#: src/olympia/addons/templates/addons/details_box.html:220
-#: src/olympia/addons/templates/addons/impala/details.html:278
+#: src/olympia/addons/templates/addons/details_box.html:220 src/olympia/addons/templates/addons/impala/details.html:283
 msgid "Version {0}:"
 msgstr "Version {0}:"
 
 #: src/olympia/addons/templates/addons/details_box.html:234
 msgid "Nothing to see here!  The developer did not include any details."
-msgstr "Këtu nuk ka gjë për t’u parë. Programuesi s’përfshiu ndonjë hollësi."
+msgstr ""
 
-#: src/olympia/addons/templates/addons/details_box.html:251
-#: src/olympia/devhub/templates/devhub/versions/edit.html:73
-#: src/olympia/editors/templates/editors/review.html:98
+#: src/olympia/addons/templates/addons/details_box.html:251 src/olympia/devhub/templates/devhub/versions/edit.html:73 src/olympia/editors/templates/editors/review.html:98
 msgid "Version Notes"
 msgstr "Shënime Versioni"
 
 #. {0} is the name of the add-on.
 #. {0} is the name of the add-on
-#: src/olympia/addons/templates/addons/eula.html:6
-#: src/olympia/discovery/templates/discovery/addons/eula.html:5
+#: src/olympia/addons/templates/addons/eula.html:6 src/olympia/discovery/templates/discovery/addons/eula.html:5
 msgid "End-User License Agreement for {0}"
 msgstr "Licencë Përdoruesi të Thjeshtë (EULA) për {0}"
 
-#: src/olympia/addons/templates/addons/eula.html:17
-#: src/olympia/addons/templates/addons/eula.html:21
-#: src/olympia/addons/templates/addons/impala/button.html:48
-#: src/olympia/addons/templates/addons/impala/details.html:316
-#: src/olympia/devhub/templates/devhub/includes/policy_form.html:3
-#: src/olympia/discovery/templates/discovery/addons/eula.html:11
+#: src/olympia/addons/templates/addons/eula.html:17 src/olympia/addons/templates/addons/eula.html:21 src/olympia/addons/templates/addons/impala/button.html:48
+#: src/olympia/addons/templates/addons/impala/details.html:321 src/olympia/devhub/templates/devhub/includes/policy_form.html:3 src/olympia/discovery/templates/discovery/addons/eula.html:11
 msgid "End-User License Agreement"
 msgstr "Marrëveshje Licence Përdoruesi (EULA)"
 
-#: src/olympia/addons/templates/addons/eula.html:23
-#: src/olympia/discovery/templates/discovery/addons/eula.html:13
+#: src/olympia/addons/templates/addons/eula.html:23 src/olympia/discovery/templates/discovery/addons/eula.html:13
 #, python-format
-msgid ""
-"%(addon_name)s requires that you accept the following End-User License "
-"Agreement before installation can proceed:"
-msgstr ""
-"%(addon_name)s kërkon që të pranoni Marrëveshjen vijuese të Licencëns për "
-"Përdorues të Thjeshtë, përpara se të ecet më tej me instalimin:"
+msgid "%(addon_name)s requires that you accept the following End-User License Agreement before installation can proceed:"
+msgstr "%(addon_name)s kërkon që të pranoni Marrëveshjen vijuese të Licencëns për Përdorues të Thjeshtë, përpara se të ecet më tej me instalimin:"
 
-#: src/olympia/addons/templates/addons/eula.html:34
-#: src/olympia/addons/templates/addons/privacy.html:26
+#: src/olympia/addons/templates/addons/eula.html:34 src/olympia/addons/templates/addons/privacy.html:26
 msgid "Back to {0}…"
 msgstr "Mbrapsht te {0}…"
 
 # %1$s is the application the user is browsing.  Examples:  Thunderbird,
 # Firefox,
 # Sunbird
-#: src/olympia/addons/templates/addons/home.html:3
-#: src/olympia/addons/templates/addons/mobile/home.html:3
-#: src/olympia/amo/helpers.py:235
+#: src/olympia/addons/templates/addons/home.html:3 src/olympia/addons/templates/addons/mobile/home.html:3 src/olympia/amo/helpers.py:235
 msgid "Add-ons for {0}"
 msgstr "Shtesa për {0}"
 
-#: src/olympia/addons/templates/addons/home.html:10
-#: src/olympia/addons/templates/addons/home.html:51
-#: src/olympia/browse/templates/browse/impala/base_listing.html:11
+#: src/olympia/addons/templates/addons/home.html:10 src/olympia/addons/templates/addons/home.html:53 src/olympia/browse/templates/browse/impala/base_listing.html:11
 msgid "Featured Extensions"
 msgstr "Zgjerime të Zgjedhura"
 
@@ -702,70 +529,49 @@ msgstr "Zgjerime të Zgjedhura"
 msgid "Popular Extensions"
 msgstr "Zgjerime Popullore"
 
-#: src/olympia/addons/templates/addons/home.html:42
-#: src/olympia/amo/templates/amo/side_nav.html:3
-#: src/olympia/amo/templates/amo/side_nav.html:11
-#: src/olympia/amo/templates/amo/site_nav.html:3
-#: src/olympia/amo/templates/amo/site_nav.html:25
-#: src/olympia/browse/views.py:236 src/olympia/browse/views.py:281
-#: src/olympia/browse/views.py:481
+#: src/olympia/addons/templates/addons/home.html:44 src/olympia/amo/templates/amo/side_nav.html:3 src/olympia/amo/templates/amo/side_nav.html:11 src/olympia/amo/templates/amo/site_nav.html:3
+#: src/olympia/amo/templates/amo/site_nav.html:25 src/olympia/browse/views.py:203 src/olympia/browse/views.py:248 src/olympia/browse/views.py:448
 msgid "Most Popular"
 msgstr "Më Populloret"
 
-#: src/olympia/addons/templates/addons/home.html:43
+#: src/olympia/addons/templates/addons/home.html:45
 msgid "All »"
 msgstr "Krejt »"
 
-#: src/olympia/addons/templates/addons/home.html:52
-#: src/olympia/addons/templates/addons/home.html:61
-#: src/olympia/addons/templates/addons/home.html:70
-#: src/olympia/addons/templates/addons/home.html:78
+#: src/olympia/addons/templates/addons/home.html:54 src/olympia/addons/templates/addons/home.html:63 src/olympia/addons/templates/addons/home.html:72 src/olympia/addons/templates/addons/home.html:80
 #: src/olympia/browse/templates/browse/impala/category_landing.html:36
 msgid "See all »"
 msgstr "Shihini krejt »"
 
-#: src/olympia/addons/templates/addons/home.html:60
+#: src/olympia/addons/templates/addons/home.html:62
 msgid "Up &amp; Coming Extensions"
 msgstr "Zgjerime Premtuese"
 
-#: src/olympia/addons/templates/addons/home.html:69
-#: src/olympia/browse/templates/browse/personas/category_landing.html:61
-#: src/olympia/discovery/templates/discovery/pane.html:74
+#: src/olympia/addons/templates/addons/home.html:71 src/olympia/browse/templates/browse/personas/category_landing.html:61 src/olympia/discovery/templates/discovery/pane.html:74
 msgid "Featured Themes"
 msgstr "Tema të Zgjedhura"
 
-#: src/olympia/addons/templates/addons/home.html:77
-#: src/olympia/bandwagon/templates/bandwagon/impala/collection_listing.html:5
+#: src/olympia/addons/templates/addons/home.html:79 src/olympia/bandwagon/templates/bandwagon/impala/collection_listing.html:5
 msgid "Featured Collections"
 msgstr "Koleksione të Zgjedhura"
 
-#: src/olympia/addons/templates/addons/listing_header.html:3
-#: src/olympia/addons/templates/addons/impala/listing/sorter.html:2
-#: src/olympia/amo/templates/amo/mobile/sort_by.html:2
+#: src/olympia/addons/templates/addons/listing_header.html:3 src/olympia/addons/templates/addons/impala/listing/sorter.html:2 src/olympia/amo/templates/amo/mobile/sort_by.html:2
 #: src/olympia/bandwagon/templates/bandwagon/collection_detail.html:118
 msgid "Sort by:"
 msgstr "Renditur sipas:"
 
 #. {0} is a date.
 #. {0} is a date
-#: src/olympia/addons/templates/addons/macros.html:7
-#: src/olympia/addons/templates/addons/macros.html:72
-#: src/olympia/addons/templates/addons/listing/items_mobile.html:48
-#: src/olympia/addons/templates/addons/listing/macros.html:42
-#: src/olympia/bandwagon/templates/bandwagon/collection_detail.html:50
-#: src/olympia/bandwagon/templates/bandwagon/collection_listing_items.html:40
-#: src/olympia/bandwagon/templates/bandwagon/impala/collection_listing_items.html:40
+#: src/olympia/addons/templates/addons/macros.html:7 src/olympia/addons/templates/addons/macros.html:72 src/olympia/addons/templates/addons/listing/items_mobile.html:48
+#: src/olympia/addons/templates/addons/listing/macros.html:42 src/olympia/bandwagon/templates/bandwagon/collection_detail.html:50
+#: src/olympia/bandwagon/templates/bandwagon/collection_listing_items.html:40 src/olympia/bandwagon/templates/bandwagon/impala/collection_listing_items.html:40
 msgid "Updated {0}"
 msgstr "{0} u përditësua"
 
 #. {0} is a date.
-#: src/olympia/addons/templates/addons/macros.html:10
-#: src/olympia/addons/templates/addons/macros.html:69
-#: src/olympia/addons/templates/addons/persona_preview.html:21
-#: src/olympia/addons/templates/addons/listing/items_mobile.html:44
-#: src/olympia/addons/templates/addons/listing/macros.html:39
-#: src/olympia/bandwagon/templates/bandwagon/collection_listing_items.html:37
-#: src/olympia/bandwagon/templates/bandwagon/impala/collection_listing_items.html:37
+#: src/olympia/addons/templates/addons/macros.html:10 src/olympia/addons/templates/addons/macros.html:69 src/olympia/addons/templates/addons/persona_preview.html:22
+#: src/olympia/addons/templates/addons/listing/items_mobile.html:44 src/olympia/addons/templates/addons/listing/macros.html:39
+#: src/olympia/bandwagon/templates/bandwagon/collection_listing_items.html:37 src/olympia/bandwagon/templates/bandwagon/impala/collection_listing_items.html:37
 msgid "Added {0}"
 msgstr "Shtuar më {0}"
 
@@ -784,18 +590,14 @@ msgstr[0] "%(num)s përdorues"
 msgstr[1] "%(num)s përdorues"
 
 #. {0} is the number of downloads.
-#: src/olympia/addons/templates/addons/macros.html:53
-#: src/olympia/addons/templates/addons/impala/details.html:61
+#: src/olympia/addons/templates/addons/macros.html:53 src/olympia/addons/templates/addons/impala/details.html:59
 msgid "{0} weekly download"
 msgid_plural "{0} weekly downloads"
 msgstr[0] "{0} shkarkim javor"
 msgstr[1] "{0} shkarkime javore"
 
 #. {0} is the number of users.
-#: src/olympia/addons/templates/addons/macros.html:61
-#: src/olympia/addons/templates/addons/impala/details.html:54
-#: src/olympia/compat/templates/compat/index.html:71
-#: src/olympia/zadmin/templates/zadmin/compat.html:67
+#: src/olympia/addons/templates/addons/macros.html:61 src/olympia/addons/templates/addons/impala/details.html:52 src/olympia/zadmin/templates/zadmin/compat.html:67
 msgid "{0} user"
 msgid_plural "{0} users"
 msgstr[0] "{0} përdorues"
@@ -813,12 +615,8 @@ msgstr "Pagesa u plotësua"
 msgid "Return to the addon."
 msgstr "Kthehu te shtesa."
 
-#: src/olympia/addons/templates/addons/persona_detail.html:17
-#: src/olympia/addons/templates/addons/impala/details.html:106
-#: src/olympia/addons/templates/addons/mobile/details.html:23
-#: src/olympia/addons/templates/addons/mobile/persona_detail.html:21
-#: src/olympia/discovery/templates/discovery/addons/base.html:27
-#: src/olympia/editors/templates/editors/review.html:31
+#: src/olympia/addons/templates/addons/persona_detail.html:17 src/olympia/addons/templates/addons/impala/details.html:103 src/olympia/addons/templates/addons/mobile/details.html:23
+#: src/olympia/addons/templates/addons/mobile/persona_detail.html:21 src/olympia/discovery/templates/discovery/addons/base.html:27 src/olympia/editors/templates/editors/review.html:31
 msgid "by"
 msgstr "nga"
 
@@ -828,8 +626,7 @@ msgid "More {0} Themes"
 msgstr "Më Tepër Tema {0}"
 
 #. {0} is a category name, such as Nature
-#: src/olympia/addons/templates/addons/persona_detail.html:39
-#: src/olympia/addons/templates/addons/mobile/persona_detail.html:66
+#: src/olympia/addons/templates/addons/persona_detail.html:39 src/olympia/addons/templates/addons/mobile/persona_detail.html:66
 msgid "See all {0} Themes"
 msgstr "Shihini krejt Temat {0}"
 
@@ -837,187 +634,130 @@ msgstr "Shihini krejt Temat {0}"
 msgid "More by this Artist"
 msgstr "Më tepër nga ky Artist"
 
-#: src/olympia/addons/templates/addons/persona_detail.html:52
-#: src/olympia/addons/templates/addons/mobile/persona_detail.html:49
+#: src/olympia/addons/templates/addons/persona_detail.html:52 src/olympia/addons/templates/addons/mobile/persona_detail.html:49
 msgid "See all Themes by this Artist"
 msgstr "Shihni krejt Temat nga ky Artist"
 
-#: src/olympia/addons/templates/addons/persona_detail.html:71
-#: src/olympia/addons/templates/addons/mobile/home.html:42
-#: src/olympia/amo/templates/amo/side_nav.html:22
-#: src/olympia/browse/templates/browse/personas/mobile/category_landing.html:28
-#: src/olympia/devhub/templates/devhub/addons/edit/basic.html:72
-#: src/olympia/editors/templates/editors/review.html:277
-#: src/olympia/editors/templates/editors/themes/themes.html:34
-#: src/olympia/templates/categories.html:7
+#: src/olympia/addons/templates/addons/persona_detail.html:71 src/olympia/addons/templates/addons/mobile/home.html:42 src/olympia/amo/templates/amo/side_nav.html:22
+#: src/olympia/browse/templates/browse/personas/mobile/category_landing.html:28 src/olympia/devhub/templates/devhub/addons/edit/basic.html:72 src/olympia/editors/templates/editors/review.html:277
+#: src/olympia/editors/templates/editors/themes/themes.html:34 src/olympia/templates/categories.html:7
 msgid "Categories"
 msgstr "Kategori"
 
-#: src/olympia/addons/templates/addons/persona_detail_table.html:10
-#: src/olympia/addons/templates/addons/mobile/persona_detail_table.html:3
-#: src/olympia/editors/templates/editors/themes/deleted.html:19
+#: src/olympia/addons/templates/addons/persona_detail_table.html:10 src/olympia/addons/templates/addons/mobile/persona_detail_table.html:3 src/olympia/editors/templates/editors/themes/deleted.html:19
 #: src/olympia/editors/templates/editors/themes/themes.html:25
 msgid "Artist"
 msgstr "Artist"
 
-#: src/olympia/addons/templates/addons/persona_detail_table.html:19
-#: src/olympia/addons/templates/addons/mobile/persona_detail_table.html:14
-#: src/olympia/stats/templates/stats/addon_report_menu.html:17
+#: src/olympia/addons/templates/addons/persona_detail_table.html:19 src/olympia/addons/templates/addons/mobile/persona_detail_table.html:14 src/olympia/stats/templates/stats/addon_report_menu.html:17
 msgid "Daily Users"
 msgstr "Përdorues të Përditshëm"
 
 #. The License for this add-on.
-#: src/olympia/addons/templates/addons/persona_detail_table.html:26
-#: src/olympia/addons/templates/addons/impala/license.html:17
-#: src/olympia/addons/templates/addons/mobile/persona_detail_table.html:21
-#: src/olympia/devhub/templates/devhub/includes/license_form.html:5
-#: src/olympia/devhub/templates/devhub/versions/edit.html:89
-#: src/olympia/editors/templates/editors/themes/themes.html:41
+#: src/olympia/addons/templates/addons/persona_detail_table.html:26 src/olympia/addons/templates/addons/impala/license.html:17 src/olympia/addons/templates/addons/mobile/persona_detail_table.html:21
+#: src/olympia/devhub/templates/devhub/includes/license_form.html:5 src/olympia/devhub/templates/devhub/versions/edit.html:89 src/olympia/editors/templates/editors/themes/themes.html:41
 msgid "License"
 msgstr "Licencë"
 
-#: src/olympia/addons/templates/addons/persona_preview.html:12
-#: src/olympia/constants/base.py:48
+#: src/olympia/addons/templates/addons/persona_preview.html:13 src/olympia/constants/base.py:48
 msgid "Awaiting Review"
 msgstr "Në Pritje të Shqyrtimit"
 
-#: src/olympia/addons/templates/addons/persona_preview.html:14
-#: src/olympia/amo/log.py:180 src/olympia/constants/base.py:42
-#: src/olympia/editors/helpers.py:62
+#: src/olympia/addons/templates/addons/persona_preview.html:15 src/olympia/amo/log.py:180 src/olympia/constants/base.py:42 src/olympia/editors/helpers.py:62
 msgid "Rejected"
 msgstr "E hedhur poshtë"
 
-#: src/olympia/addons/templates/addons/persona_preview.html:16
-#: src/olympia/amo/log.py:159
+#: src/olympia/addons/templates/addons/persona_preview.html:17 src/olympia/amo/log.py:159
 msgid "Approved"
 msgstr "E miratuar"
 
 #. {0} is the number of users.
-#: src/olympia/addons/templates/addons/persona_preview.html:26
-#: src/olympia/addons/templates/addons/listing/items_mobile.html:36
-#: src/olympia/addons/templates/addons/listing/macros.html:31
+#: src/olympia/addons/templates/addons/persona_preview.html:27 src/olympia/addons/templates/addons/listing/items_mobile.html:36 src/olympia/addons/templates/addons/listing/macros.html:31
 msgid "<strong>{0}</strong> user"
 msgid_plural "<strong>{0}</strong> users"
 msgstr[0] "<strong>{0}</strong> përdorues"
 msgstr[1] "<strong>{0}</strong> përdorues"
 
-#: src/olympia/addons/templates/addons/persona_preview.html:40
+#: src/olympia/addons/templates/addons/persona_preview.html:41
 msgid "Hover to Preview"
 msgstr "Kaloji Kursorin Përsipër Për Paraparje"
 
-#: src/olympia/addons/templates/addons/persona_preview.html:46
-#: src/olympia/addons/templates/addons/persona_preview.html:48
+#: src/olympia/addons/templates/addons/persona_preview.html:47 src/olympia/addons/templates/addons/persona_preview.html:49 src/olympia/addons/templates/addons/persona_preview.html:97
 #: src/olympia/reviews/templates/reviews/add.html:15
 msgid "Add"
 msgstr "Shto"
 
-#: src/olympia/addons/templates/addons/persona_preview.html:57
-#: src/olympia/bandwagon/templates/bandwagon/ajax_new.html:16
-#: src/olympia/bandwagon/templates/bandwagon/edit.html:19
-#: src/olympia/bandwagon/templates/bandwagon/includes/addedit.html:19
-#: src/olympia/devhub/templates/devhub/addons/edit/admin.html:13
-#: src/olympia/devhub/templates/devhub/addons/edit/basic.html:10
-#: src/olympia/devhub/templates/devhub/addons/edit/details.html:8
-#: src/olympia/devhub/templates/devhub/addons/edit/media.html:6
-#: src/olympia/devhub/templates/devhub/addons/edit/support.html:8
-#: src/olympia/devhub/templates/devhub/addons/edit/technical.html:9
-#: src/olympia/devhub/templates/devhub/addons/submit/describe.html:29
-#: src/olympia/editors/templates/editors/review.html:257
+#: src/olympia/addons/templates/addons/persona_preview.html:58 src/olympia/bandwagon/templates/bandwagon/ajax_new.html:16 src/olympia/bandwagon/templates/bandwagon/edit.html:19
+#: src/olympia/bandwagon/templates/bandwagon/includes/addedit.html:19 src/olympia/devhub/templates/devhub/addons/edit/admin.html:13 src/olympia/devhub/templates/devhub/addons/edit/basic.html:10
+#: src/olympia/devhub/templates/devhub/addons/edit/details.html:8 src/olympia/devhub/templates/devhub/addons/edit/media.html:6 src/olympia/devhub/templates/devhub/addons/edit/support.html:8
+#: src/olympia/devhub/templates/devhub/addons/edit/technical.html:9 src/olympia/devhub/templates/devhub/addons/submit/describe.html:29 src/olympia/editors/templates/editors/review.html:257
 msgid "Edit"
 msgstr "Përpunoni"
 
 #. For datetime formatting, see the table on
 #. http://docs.python.org/library/datetime.html#strftime-and-strptime-behavior
-#: src/olympia/addons/templates/addons/persona_preview.html:66
+#: src/olympia/addons/templates/addons/persona_preview.html:67
 #, python-format
 msgid "%%Y-%%m-%%d"
 msgstr "%%d-%%m-%%Y"
 
-#: src/olympia/addons/templates/addons/persona_preview.html:67
+#: src/olympia/addons/templates/addons/persona_preview.html:68
 msgid "by {0} on {1}"
 msgstr "nga {0} më {1}"
 
-#: src/olympia/addons/templates/addons/persona_preview.html:75
-#: src/olympia/reviews/helpers.py:17
-#: src/olympia/reviews/templates/reviews/review_list.html:63
-#: src/olympia/reviews/templates/reviews/reviews_link.html:21
-#: src/olympia/reviews/templates/reviews/impala/reviews_link.html:16
+#: src/olympia/addons/templates/addons/persona_preview.html:76 src/olympia/reviews/helpers.py:17 src/olympia/reviews/templates/reviews/review_list.html:63
+#: src/olympia/reviews/templates/reviews/reviews_link.html:21 src/olympia/reviews/templates/reviews/impala/reviews_link.html:16
 msgid "Not yet rated"
 msgstr "Ende e pavlerësuar"
 
-#: src/olympia/addons/templates/addons/persona_preview.html:78
+#: src/olympia/addons/templates/addons/persona_preview.html:79
 msgid "<b>{0}</b> users"
 msgstr "<b>{0}</b> përdorues"
 
 #: src/olympia/addons/templates/addons/popups.html:17
-msgid ""
-"To install this add-on and thousands more, <b>get Firefox</b>, a free and "
-"open web browser from Mozilla."
-msgstr ""
-"Për instalimin e kësaj shtese dhe mijëra të tjerave, <b>merrni Firefox-"
-"in</b>, një shfletues web i lirë dhe i hapur, krijuar nga Mozilla."
+msgid "To install this add-on and thousands more, <b>get Firefox</b>, a free and open web browser from Mozilla."
+msgstr "Për instalimin e kësaj shtese dhe mijëra të tjerave, <b>merrni Firefox-in</b>, një shfletues web i lirë dhe i hapur, krijuar nga Mozilla."
 
-#: src/olympia/addons/templates/addons/popups.html:21
-#: src/olympia/addons/templates/addons/popups.html:52
+#: src/olympia/addons/templates/addons/popups.html:21 src/olympia/addons/templates/addons/popups.html:52
 msgid "Learn more about Firefox"
 msgstr "Mësoni më tepër rreth Firefox-it"
 
 #: src/olympia/addons/templates/addons/popups.html:22
-msgid "or <b><a class=\"installer\" href=\"{url}\">download anyway</a></b>"
-msgstr "ose <b><a class=\"installer\" href=\"{url}\">shkarkojeni sido qoftë</a></b>"
+msgid "or <b><a class=\"button installer\" href=\"{url}\">download anyway</a></b>"
+msgstr ""
 
 #: src/olympia/addons/templates/addons/popups.html:26
 msgid ""
-"<strong>How to Install in Thunderbird</strong> <ol> <li>Download and save "
-"the file to your hard disk.</li> <li>In Mozilla Thunderbird, open Add-ons "
-"from the Tools menu.</li> <li>From the options button next to the add-on "
-"search field, select \"Install Add-on From File...\" and locate the "
-"downloaded add-on.</li> </ol>"
+"<strong>How to Install in Thunderbird</strong> <ol> <li>Download and save the file to your hard disk.</li> <li>In Mozilla Thunderbird, open Add-ons from the Tools menu.</li> <li>From the options "
+"button next to the add-on search field, select \"Install Add-on From File...\" and locate the downloaded add-on.</li> </ol>"
 msgstr ""
-"<strong>Si të Instalohet në Thunderbird</strong> <ol> <li>Shkarkojeni dhe "
-"ruajeni kartelën te hard disku juaj.</li> <li>Që nga Mozilla Thunderbird, "
-"hapni Shtesat, prej menusë Mjete.</li> <li>Nga butoni i mundësive, ngjitur "
-"me fushën e kërkimit të shtesave, përzgjidhni \"Instaloni Shtesë prej "
-"Kartele...\" dhe shihni për shtesën e shkarkuar.</li> </ol>"
+"<strong>Si të Instalohet në Thunderbird</strong> <ol> <li>Shkarkojeni dhe ruajeni kartelën te hard disku juaj.</li> <li>Që nga Mozilla Thunderbird, hapni Shtesat, prej menusë Mjete.</li> <li>Nga "
+"butoni i mundësive, ngjitur me fushën e kërkimit të shtesave, përzgjidhni \"Instaloni Shtesë prej Kartele...\" dhe shihni për shtesën e shkarkuar.</li> </ol>"
 
 #: src/olympia/addons/templates/addons/popups.html:41
-msgid ""
-"To install this Theme, <b>get Thunderbird</b>, a free and open source email "
-"client from Mozilla Messaging and install the Personas Plus add-on."
-msgstr ""
-"Për ta instaluar këtë Temë, <b>merrni Thunderbird-in</b>, një klient email-"
-"esh i lirë dhe me burim të hapur, i krijuar nga Mozilla Messaging dhe "
-"instaloni shtesën Personas Plus."
+msgid "To install this Theme, <b>get Thunderbird</b>, a free and open source email client from Mozilla Messaging and install the Personas Plus add-on."
+msgstr "Për ta instaluar këtë Temë, <b>merrni Thunderbird-in</b>, një klient email-esh i lirë dhe me burim të hapur, i krijuar nga Mozilla Messaging dhe instaloni shtesën Personas Plus."
 
 #: src/olympia/addons/templates/addons/popups.html:46
 msgid "Learn more about Thunderbird"
 msgstr "Mësoni më tepër rreth Thunderbird-it"
 
 #: src/olympia/addons/templates/addons/popups.html:48
-msgid ""
-"To install this Theme and thousands more, <b>get Firefox</b>, a free and "
-"open web browser from Mozilla."
-msgstr ""
-"Që të instaloni këtë Temë dhe mijëra të tjera, <b>merrni Firefox-in</b>, një"
-" shfletues web i lirë dhe i hapur, krijuar nga Mozilla."
+msgid "To install this Theme and thousands more, <b>get Firefox</b>, a free and open web browser from Mozilla."
+msgstr "Që të instaloni këtë Temë dhe mijëra të tjera, <b>merrni Firefox-in</b>, një shfletues web i lirë dhe i hapur, krijuar nga Mozilla."
 
 #: src/olympia/addons/templates/addons/popups.html:60
 #, python-format
 msgid "This add-on has not been updated to work with your version of %(app)s."
-msgstr ""
-"Kjo shtesë s’është përditësuar të punojë me versionin tuaj të %(app)s."
+msgstr "Kjo shtesë s’është përditësuar të punojë me versionin tuaj të %(app)s."
 
-#: src/olympia/addons/templates/addons/popups.html:63
-#: src/olympia/addons/templates/addons/popups.html:140
-#: src/olympia/addons/templates/addons/popups.html:150
+#: src/olympia/addons/templates/addons/popups.html:63 src/olympia/addons/templates/addons/popups.html:140 src/olympia/addons/templates/addons/popups.html:150
 msgid "Install Anyway"
 msgstr "Instaloje Sidoqoftë"
 
 #: src/olympia/addons/templates/addons/popups.html:71
-msgid ""
-"This add-on requires a version of Firefox that has not been released yet."
-msgstr ""
-"Kjo shtesë lyp një version Firefox-i që s’është hedhur ende në qarkullim."
+msgid "This add-on requires a version of Firefox that has not been released yet."
+msgstr "Kjo shtesë lyp një version Firefox-i që s’është hedhur ende në qarkullim."
 
 #: src/olympia/addons/templates/addons/popups.html:74
 msgid "Help test new Firefox Versions"
@@ -1025,64 +765,40 @@ msgstr "Ndihmoni testimin e Versioneve të reja të Firefox-it"
 
 #: src/olympia/addons/templates/addons/popups.html:77
 #, python-format
-msgid ""
-"This add-on requires %(app)s {new_version}. You are currently using %(app)s "
-"{old_version}."
-msgstr ""
-"Kjo shtesë lyp %(app)s {new_version}. Jeni duke përdorur %(app)s "
-"{old_version}."
+msgid "This add-on requires %(app)s {new_version}. You are currently using %(app)s {old_version}."
+msgstr "Kjo shtesë lyp %(app)s {new_version}. Jeni duke përdorur %(app)s {old_version}."
 
 #. {0} is an app name, like Firefox.
-#: src/olympia/addons/templates/addons/popups.html:82
-#: src/olympia/addons/templates/addons/popups.html:101
+#: src/olympia/addons/templates/addons/popups.html:82 src/olympia/addons/templates/addons/popups.html:101
 msgid "Upgrade {0}"
 msgstr "Përmirësoni {0}"
 
 #: src/olympia/addons/templates/addons/popups.html:85
 #, python-format
 msgid "or view <a href=\"%(href)s\">older versions of this add-on</a>."
-msgstr ""
-"ose shihni <a href=\"%(href)s\">versione më të vjetër të kësaj shtese</a>."
+msgstr "ose shihni <a href=\"%(href)s\">versione më të vjetër të kësaj shtese</a>."
 
 #: src/olympia/addons/templates/addons/popups.html:96
 #, python-format
-msgid ""
-"This Persona requires %(app)s %(new_version)s. You are currently using "
-"%(app)s {old_version}."
-msgstr ""
-"Kjo Persona lyp %(app)s %(new_version)s. Jeni duke përdorur %(app)s "
-"{old_version}."
+msgid "This Persona requires %(app)s %(new_version)s. You are currently using %(app)s {old_version}."
+msgstr "Kjo Persona lyp %(app)s %(new_version)s. Jeni duke përdorur %(app)s {old_version}."
 
 #: src/olympia/addons/templates/addons/popups.html:108
 msgid ""
-"<strong>Caution:</strong> This add-on has not been reviewed by Mozilla and "
-"can't be installed on release versions of Firefox 43 and above.  Be careful "
-"when installing third-party software that might harm your computer."
+"<strong>Caution:</strong> This add-on has not been reviewed by Mozilla and can't be installed on release versions of Firefox 43 and above.  Be careful when installing third-party software that "
+"might harm your computer."
 msgstr ""
-"<strong>Kujdes:</strong> Kjo shtesë nuk është shqyrtuar nga Mozilla-s dhe "
-"s’mund të instalohet në versione të Firefox-it nga 43 e sipër. Bëni kujdes "
-"kur instaloni software palësh të treta që mund të dëmtojnë kompjuterin tuaj."
 
 #: src/olympia/addons/templates/addons/popups.html:120
-msgid ""
-"<strong>Please note:</strong> This add-on is not compatible with your "
-"operating system."
-msgstr ""
-"<strong>Ju lutemi, kini parasysh që:</strong> Kjo shtesë s’është e "
-"përputhshme me sistemin tuaj operativ."
+msgid "<strong>Please note:</strong> This add-on is not compatible with your operating system."
+msgstr "<strong>Ju lutemi, kini parasysh që:</strong> Kjo shtesë s’është e përputhshme me sistemin tuaj operativ."
 
-#: src/olympia/addons/templates/addons/popups.html:136
-#: src/olympia/addons/templates/addons/impala/button.html:70
+#: src/olympia/addons/templates/addons/popups.html:136 src/olympia/addons/templates/addons/impala/button.html:70
 #, python-format
-msgid ""
-"This add-on is not compatible with your version of %(app)s because of the "
-"following:"
-msgstr ""
-"Kjo shtesë s’është e përputhshme me versionin tuaj të %(app)s, për shkak të "
-"sa vijon:"
+msgid "This add-on is not compatible with your version of %(app)s because of the following:"
+msgstr "Kjo shtesë s’është e përputhshme me versionin tuaj të %(app)s, për shkak të sa vijon:"
 
-#: src/olympia/addons/templates/addons/popups.html:141
-#: src/olympia/addons/templates/addons/popups.html:151
+#: src/olympia/addons/templates/addons/popups.html:141 src/olympia/addons/templates/addons/popups.html:151
 msgid "View other versions"
 msgstr "Shihni versione të tjerë"
 
@@ -1106,144 +822,89 @@ msgid ""
 "  to your phone.  (You'll need a QR reader.  Search your phone's marketplace if\n"
 "  don't have one.)"
 msgstr ""
-"E doni {0} te Firefox-i në celularin tuaj? Skanoni këtë kod QR që të "
-"instalohet drejt e te telefoni juaj. (Do t’ju duhet një lexues QR-sh. Nëse "
-"nuk keni një të tillë, kërkoni në tregun e telefonit tuaj.)"
 
-#: src/olympia/addons/templates/addons/report_abuse.html:6
-#: src/olympia/addons/templates/addons/report_abuse_full.html:10
-#: src/olympia/addons/templates/addons/impala/details-more.html:23
-#: src/olympia/addons/templates/addons/impala/details.html:328
+#: src/olympia/addons/templates/addons/report_abuse.html:6 src/olympia/addons/templates/addons/report_abuse_full.html:10 src/olympia/addons/templates/addons/impala/details-more.html:23
+#: src/olympia/addons/templates/addons/impala/details.html:333
 msgid "Report Abuse"
 msgstr "Njoftoni Shpërdorim"
 
 #: src/olympia/addons/templates/addons/report_abuse.html:10
 #, python-format
 msgid ""
-"If you suspect this add-on violates <a href=\"%(url)s\">our policies</a> or "
-"has security or privacy issues, please use the form below to describe your "
-"concerns. Please do not use this form for any other reason."
+"If you suspect this add-on violates <a href=\"%(url)s\">our policies</a> or has security or privacy issues, please use the form below to describe your concerns. Please do not use this form for any "
+"other reason."
 msgstr ""
-"Nëse dyshoni se kjo shtesë cenon <a href=\"%(url)s\">rregullat tona</a> ose "
-"nëse ka probleme sigurie apo privatësie, ju lutemi, përdorni formularin më "
-"poshtë që të përshkruani shqetësimin tuaj. Ju lutemi, mos e përdorni këtë "
-"formular për arsye të tjera."
+"Nëse dyshoni se kjo shtesë cenon <a href=\"%(url)s\">rregullat tona</a> ose nëse ka probleme sigurie apo privatësie, ju lutemi, përdorni formularin më poshtë që të përshkruani shqetësimin tuaj. Ju "
+"lutemi, mos e përdorni këtë formular për arsye të tjera."
 
-#: src/olympia/addons/templates/addons/report_abuse.html:24
-#: src/olympia/users/templates/users/report_abuse.html:19
+#: src/olympia/addons/templates/addons/report_abuse.html:24 src/olympia/users/templates/users/report_abuse.html:19
 msgid "Send Report"
 msgstr "Dërgoje Njoftimin"
 
-#: src/olympia/addons/templates/addons/report_abuse.html:26
-#: src/olympia/addons/templates/addons/mobile/eula.html:16
-#: src/olympia/addons/templates/addons/mobile/persona_confirm.html:7
-#: src/olympia/devhub/templates/devhub/addons/ajax_compat_update.html:36
-#: src/olympia/devhub/templates/devhub/addons/profile.html:44
-#: src/olympia/devhub/templates/devhub/addons/edit/admin.html:104
-#: src/olympia/devhub/templates/devhub/addons/edit/basic.html:155
-#: src/olympia/devhub/templates/devhub/addons/edit/details.html:88
-#: src/olympia/devhub/templates/devhub/addons/edit/support.html:70
-#: src/olympia/devhub/templates/devhub/addons/edit/technical.html:169
-#: src/olympia/devhub/templates/devhub/addons/forms_shared/media.html:152
-#: src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:44
-#: src/olympia/devhub/templates/devhub/personas/edit.html:222
-#: src/olympia/devhub/templates/devhub/versions/add_file_modal.html:79
-#: src/olympia/devhub/templates/devhub/versions/edit.html:140
-#: src/olympia/devhub/templates/devhub/versions/list.html:208
-#: src/olympia/devhub/templates/devhub/versions/list.html:242
-#: src/olympia/devhub/templates/devhub/versions/list.html:276
-#: src/olympia/devhub/templates/devhub/versions/list.html:317
-#: src/olympia/reviews/templates/reviews/edit_review.html:16
-#: src/olympia/translations/templates/translations/trans-menu.html:50
-#: src/olympia/translations/templates/translations/trans-menu.html:62
-#: src/olympia/zadmin/templates/zadmin/validation.html:105
+#: src/olympia/addons/templates/addons/report_abuse.html:26 src/olympia/addons/templates/addons/mobile/eula.html:16 src/olympia/addons/templates/addons/mobile/persona_confirm.html:7
+#: src/olympia/devhub/templates/devhub/addons/ajax_compat_update.html:36 src/olympia/devhub/templates/devhub/addons/profile.html:44 src/olympia/devhub/templates/devhub/addons/edit/admin.html:104
+#: src/olympia/devhub/templates/devhub/addons/edit/basic.html:155 src/olympia/devhub/templates/devhub/addons/edit/details.html:88 src/olympia/devhub/templates/devhub/addons/edit/support.html:70
+#: src/olympia/devhub/templates/devhub/addons/edit/technical.html:169 src/olympia/devhub/templates/devhub/addons/forms_shared/media.html:152
+#: src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:43 src/olympia/devhub/templates/devhub/personas/edit.html:222 src/olympia/devhub/templates/devhub/versions/add_file_modal.html:59
+#: src/olympia/devhub/templates/devhub/versions/edit.html:140 src/olympia/devhub/templates/devhub/versions/list.html:208 src/olympia/devhub/templates/devhub/versions/list.html:239
+#: src/olympia/devhub/templates/devhub/versions/list.html:281 src/olympia/devhub/templates/devhub/versions/list.html:315 src/olympia/reviews/templates/reviews/edit_review.html:16
+#: src/olympia/translations/templates/translations/trans-menu.html:50 src/olympia/translations/templates/translations/trans-menu.html:62 src/olympia/zadmin/templates/zadmin/validation.html:105
 msgid "Cancel"
 msgstr "Anuloje"
 
-#: src/olympia/addons/templates/addons/review_add_box.html:3
-#: src/olympia/addons/templates/addons/impala/review_add_box.html:5
+#: src/olympia/addons/templates/addons/review_add_box.html:3 src/olympia/addons/templates/addons/impala/review_add_box.html:5
 msgid "What do you think?"
 msgstr "Si ju duket?"
 
-#: src/olympia/addons/templates/addons/review_add_box.html:7
-#: src/olympia/addons/templates/addons/impala/review_add_box.html:9
+#: src/olympia/addons/templates/addons/review_add_box.html:7 src/olympia/addons/templates/addons/impala/review_add_box.html:9
 #, python-format
 msgid "Please <a href=\"%(login)s\">log in</a> to submit a review"
 msgstr "Ju lutemi, <a href=\"%(login)s\">hyni</a> që të parashtroni një shqyrtim"
 
-#: src/olympia/addons/templates/addons/review_add_box.html:16
-#: src/olympia/addons/templates/addons/impala/review_add_box.html:18
-#: src/olympia/reviews/templates/reviews/mobile/add_form.html:13
+#: src/olympia/addons/templates/addons/review_add_box.html:16 src/olympia/addons/templates/addons/impala/review_add_box.html:18 src/olympia/reviews/templates/reviews/mobile/add_form.html:13
 msgid "Title:"
 msgstr "Titull:"
 
-#: src/olympia/addons/templates/addons/review_add_box.html:17
-#: src/olympia/addons/templates/addons/impala/review_add_box.html:19
-#: src/olympia/reviews/templates/reviews/mobile/add_form.html:17
+#: src/olympia/addons/templates/addons/review_add_box.html:17 src/olympia/addons/templates/addons/impala/review_add_box.html:19 src/olympia/reviews/templates/reviews/mobile/add_form.html:17
 msgid "Review:"
 msgstr "Shqyrtim:"
 
-#: src/olympia/addons/templates/addons/review_add_box.html:18
-#: src/olympia/addons/templates/addons/impala/review_add_box.html:20
-#: src/olympia/reviews/templates/reviews/mobile/add_form.html:16
+#: src/olympia/addons/templates/addons/review_add_box.html:18 src/olympia/addons/templates/addons/impala/review_add_box.html:20 src/olympia/reviews/templates/reviews/mobile/add_form.html:16
 msgid "Rating:"
 msgstr "Vlerësim:"
 
-#: src/olympia/addons/templates/addons/review_add_box.html:19
-#: src/olympia/addons/templates/addons/impala/review_add_box.html:21
-#: src/olympia/reviews/templates/reviews/add.html:63
-#: src/olympia/reviews/templates/reviews/edit_review.html:15
-#: src/olympia/reviews/templates/reviews/mobile/add_form.html:18
+#: src/olympia/addons/templates/addons/review_add_box.html:19 src/olympia/addons/templates/addons/impala/review_add_box.html:21 src/olympia/reviews/templates/reviews/add.html:63
+#: src/olympia/reviews/templates/reviews/edit_review.html:15 src/olympia/reviews/templates/reviews/mobile/add_form.html:18
 msgid "Submit review"
 msgstr "Parashtroni shqyrtim"
 
-#: src/olympia/addons/templates/addons/review_add_box.html:24
-#: src/olympia/addons/templates/addons/impala/review_add_box.html:26
-msgid ""
-"Please do not post bug reports in reviews. We do not make your email address"
-" available to add-on developers and they may need to contact you to help "
-"resolve your issue."
+#: src/olympia/addons/templates/addons/review_add_box.html:24 src/olympia/addons/templates/addons/impala/review_add_box.html:26
+msgid "Please do not post bug reports in reviews. We do not make your email address available to add-on developers and they may need to contact you to help resolve your issue."
 msgstr ""
-"Ju lutemi, mos postoni raportime të metash në shqyrtime. S’ua japim adresat "
-"tuaja email zhvilluesve të shtesave, e ata mund të kenë nevojë të lidhen me "
-"ju për t’ju ndihmuar në zgjidhjen e problemit."
+"Ju lutemi, mos postoni raportime të metash në shqyrtime. S’ua japim adresat tuaja email zhvilluesve të shtesave, e ata mund të kenë nevojë të lidhen me ju për t’ju ndihmuar në zgjidhjen e problemit."
 
-#: src/olympia/addons/templates/addons/review_add_box.html:32
-#: src/olympia/addons/templates/addons/impala/review_add_box.html:35
+#: src/olympia/addons/templates/addons/review_add_box.html:32 src/olympia/addons/templates/addons/impala/review_add_box.html:35
 #, python-format
-msgid ""
-"See the <a href=\"%(support)s\">support section</a> to find out where to get"
-" assistance for this add-on."
-msgstr ""
-"Shihni <a href=\"%(support)s\">ndarjen për asistencë</a> që të gjeni se nga "
-"ku mund të merret asistencë për këtë shtesë."
+msgid "See the <a href=\"%(support)s\">support section</a> to find out where to get assistance for this add-on."
+msgstr "Shihni <a href=\"%(support)s\">ndarjen për asistencë</a> që të gjeni se nga ku mund të merret asistencë për këtë shtesë."
 
-#: src/olympia/addons/templates/addons/review_add_box.html:38
-#: src/olympia/addons/templates/addons/impala/review_add_box.html:42
-#: src/olympia/pages/templates/pages/review_guide.html:3
+#: src/olympia/addons/templates/addons/review_add_box.html:38 src/olympia/addons/templates/addons/impala/review_add_box.html:42 src/olympia/pages/templates/pages/review_guide.html:3
 #: src/olympia/pages/templates/pages/review_guide.html:44
 msgid "Review Guidelines"
 msgstr "Udhëzues Shqyrtimesh"
 
-#: src/olympia/addons/templates/addons/review_list_box.html:5
-#: src/olympia/addons/templates/addons/impala/details-more.html:27
-#: src/olympia/editors/helpers.py:921
-#: src/olympia/reviews/templates/reviews/add.html:14
-#: src/olympia/reviews/templates/reviews/reply.html:14
-#: src/olympia/reviews/templates/reviews/review_list.html:19
+#: src/olympia/addons/templates/addons/review_list_box.html:5 src/olympia/addons/templates/addons/impala/details-more.html:27 src/olympia/editors/helpers.py:1001
+#: src/olympia/reviews/templates/reviews/add.html:14 src/olympia/reviews/templates/reviews/reply.html:14 src/olympia/reviews/templates/reviews/review_list.html:19
 #: src/olympia/reviews/templates/reviews/mobile/review_list.html:26
 msgid "Reviews"
 msgstr "Shqyrtime"
 
-#: src/olympia/addons/templates/addons/review_list_box.html:14
-#: src/olympia/addons/templates/addons/impala/review_list_box.html:14
-#: src/olympia/reviews/templates/reviews/review.html:30
+#: src/olympia/addons/templates/addons/review_list_box.html:14 src/olympia/addons/templates/addons/impala/review_list_box.html:14 src/olympia/reviews/templates/reviews/review.html:30
 #, python-format
 msgid "by %(user)s on %(date)s"
 msgstr "nga %(user)s më %(date)s"
 
-#: src/olympia/addons/templates/addons/review_list_box.html:19
-#: src/olympia/addons/templates/addons/impala/review_list_box.html:29
+#: src/olympia/addons/templates/addons/review_list_box.html:19 src/olympia/addons/templates/addons/impala/review_list_box.html:29
 msgid "Show the developer's reply to this review"
 msgstr "Shfaqe përgjigjen e zhvilluesit për këtë shqyrtim"
 
@@ -1254,21 +915,16 @@ msgid_plural "See all %(cnt)s reviews of this add-on"
 msgstr[0] "Shihni krejt shqyrtimet e kësaj shtese"
 msgstr[1] "Shihni krejt %(cnt)s shqyrtimet e kësaj shtese"
 
-#: src/olympia/addons/templates/addons/tags_box.html:3
-#: src/olympia/devhub/templates/devhub/addons/edit/basic.html:118
+#: src/olympia/addons/templates/addons/tags_box.html:3 src/olympia/devhub/templates/devhub/addons/edit/basic.html:118
 msgid "Tags"
 msgstr "Etiketa"
 
-#: src/olympia/addons/templates/addons/impala/addon_hovercard.html:7
-#: src/olympia/addons/templates/addons/impala/addon_hovercard.html:9
+#: src/olympia/addons/templates/addons/impala/addon_hovercard.html:7 src/olympia/addons/templates/addons/impala/addon_hovercard.html:9
 msgid "Icon for {0}"
 msgstr "Ikonë për {0}"
 
-#: src/olympia/addons/templates/addons/impala/addon_hovercard.html:34
-#: src/olympia/addons/templates/addons/impala/featured_grid.html:26
-#: src/olympia/addons/templates/addons/impala/theme_grid.html:22
-#: src/olympia/bandwagon/templates/bandwagon/collection_detail.html:31
-#: src/olympia/users/templates/users/helpers/addon_users_list.html:7
+#: src/olympia/addons/templates/addons/impala/addon_hovercard.html:34 src/olympia/addons/templates/addons/impala/featured_grid.html:26 src/olympia/addons/templates/addons/impala/theme_grid.html:22
+#: src/olympia/bandwagon/templates/bandwagon/collection_detail.html:31 src/olympia/users/templates/users/helpers/addon_users_list.html:7
 #, python-format
 msgid "by %(users)s"
 msgstr "nga %(users)s"
@@ -1288,34 +944,18 @@ msgstr "Ju pëlqeu kjo shtesë?"
 
 #: src/olympia/addons/templates/addons/impala/contribution.html:43
 #, python-format
-msgid ""
-"The <a href=\"%(meet_url)s\">developer of this add-on</a> asks that you help"
-" support its continued development by making a small contribution."
-msgstr ""
-"<a href=\"%(meet_url)s\">Zhvilluesi i kësaj shtese</a> ju kërkon të ndihmoni"
-" duke përkrahur zhvillimin e saj në vazhdimësi përmes një dhurimi të vogël."
+msgid "The <a href=\"%(meet_url)s\">developer of this add-on</a> asks that you help support its continued development by making a small contribution."
+msgstr "<a href=\"%(meet_url)s\">Zhvilluesi i kësaj shtese</a> ju kërkon të ndihmoni duke përkrahur zhvillimin e saj në vazhdimësi përmes një dhurimi të vogël."
 
 #: src/olympia/addons/templates/addons/impala/contribution.html:48
 #, python-format
-msgid ""
-"The <a href=\"%(meet_url)s\">developer of this add-on</a> asks that you show"
-" your support by making a donation to the <a "
-"href=\"%(charity_url)s\">%(charity_name)s</a>."
-msgstr ""
-"<a href=\"%(meet_url)s\">Zhvilluesi i kësaj shtese</a> ju fton që përkrahjen"
-" tuaj ta tregoni duke bërë një dhurim te <a "
-"href=\"%(charity_url)s\">%(charity_name)s</a>."
+msgid "The <a href=\"%(meet_url)s\">developer of this add-on</a> asks that you show your support by making a donation to the <a href=\"%(charity_url)s\">%(charity_name)s</a>."
+msgstr "<a href=\"%(meet_url)s\">Zhvilluesi i kësaj shtese</a> ju fton që përkrahjen tuaj ta tregoni duke bërë një dhurim te <a href=\"%(charity_url)s\">%(charity_name)s</a>."
 
 #: src/olympia/addons/templates/addons/impala/contribution.html:53
 #, python-format
-msgid ""
-"The <a href=\"%(meet_url)s\">developer of this add-on</a> asks that you show"
-" your support by making a small contribution to <a "
-"href=\"%(charity_url)s\">%(charity_name)s</a>."
-msgstr ""
-"<a href=\"%(meet_url)s\">Zhvilluesi i kësaj shtese</a> ju kërkon ta "
-"shpalosni përkrahjen tuaj përmes një dhurimi të vogël për <a "
-"href=\"%(charity_url)s\">%(charity_name)s</a>."
+msgid "The <a href=\"%(meet_url)s\">developer of this add-on</a> asks that you show your support by making a small contribution to <a href=\"%(charity_url)s\">%(charity_name)s</a>."
+msgstr "<a href=\"%(meet_url)s\">Zhvilluesi i kësaj shtese</a> ju kërkon ta shpalosni përkrahjen tuaj përmes një dhurimi të vogël për <a href=\"%(charity_url)s\">%(charity_name)s</a>."
 
 #: src/olympia/addons/templates/addons/impala/dependencies_note.html:4
 msgid "This add-on requires the following add-ons to work properly:"
@@ -1344,32 +984,31 @@ msgid_plural "Other add-ons by these authors"
 msgstr[0] "Shtesa të tjera nga %(author)s"
 msgstr[1] "Shtesa të tjera nga këta autorë"
 
-#: src/olympia/addons/templates/addons/impala/details.html:41
+#: src/olympia/addons/templates/addons/impala/details.html:39
 #, python-format
 msgid "<span itemprop=\"ratingCount\">%(num)s</span> user review"
 msgid_plural "<span itemprop=\"ratingCount\">%(num)s</span> user reviews"
 msgstr[0] "<span itemprop=\"ratingCount\">%(num)s</span> shqyrtim përdoruesi"
 msgstr[1] "<span itemprop=\"ratingCount\">%(num)s</span> shqyrtime përdoruesi"
 
-#: src/olympia/addons/templates/addons/impala/details.html:69
+#: src/olympia/addons/templates/addons/impala/details.html:66
 msgid "View statistics"
 msgstr "Shihni statistika"
 
-#: src/olympia/addons/templates/addons/impala/details.html:84
+#: src/olympia/addons/templates/addons/impala/details.html:81
 msgid "Manage"
 msgstr "Administro"
 
 #. {0} is an add-on name.
-#: src/olympia/addons/templates/addons/impala/details.html:96
+#: src/olympia/addons/templates/addons/impala/details.html:93
 msgid "Icon of {0}"
 msgstr "Ikonë e {0}"
 
-#: src/olympia/addons/templates/addons/impala/details.html:103
-#: src/olympia/addons/templates/addons/impala/listing/items.html:14
+#: src/olympia/addons/templates/addons/impala/details.html:100 src/olympia/addons/templates/addons/impala/listing/items.html:14
 msgid "No Restart"
 msgstr "Pa Rinisje"
 
-#: src/olympia/addons/templates/addons/impala/details.html:127
+#: src/olympia/addons/templates/addons/impala/details.html:124
 #, python-format
 msgid "Meet the Developer: <a href=\"%(url)s\">%(name)s</a>"
 msgid_plural "<a href=\"%(url)s\">Meet the Developers</a>"
@@ -1377,117 +1016,90 @@ msgstr[0] "Njihuni me Zhvilluesin: <a href=\"%(url)s\">%(name)s</a>"
 msgstr[1] "<a href=\"%(url)s\">Njihuni me Zhvilluesit</a>"
 
 # %1$s is an add-on name.
-#: src/olympia/addons/templates/addons/impala/details.html:137
+#: src/olympia/addons/templates/addons/impala/details.html:134
 msgid "Learn why {0} was created and find out what's next for this add-on."
-msgstr ""
-"Mësoni pse u krijua {0} dhe shihni se ç’pritet më tej prej kësaj shtese."
+msgstr "Mësoni pse u krijua {0} dhe shihni se ç’pritet më tej prej kësaj shtese."
 
 #. {0} is an index.
-#: src/olympia/addons/templates/addons/impala/details.html:156
+#: src/olympia/addons/templates/addons/impala/details.html:161
 msgid "Add-on screenshot #{0}"
 msgstr "Foto ekrani e shtesës #{0}"
 
-#: src/olympia/addons/templates/addons/impala/details.html:182
+#: src/olympia/addons/templates/addons/impala/details.html:187
 msgid "Add-on home page"
 msgstr "Faqe hyrëse e shtesës"
 
-#: src/olympia/addons/templates/addons/impala/details.html:185
+#: src/olympia/addons/templates/addons/impala/details.html:190
 msgid "Support site"
 msgstr "Sajt asistence"
 
-#: src/olympia/addons/templates/addons/impala/details.html:189
+#: src/olympia/addons/templates/addons/impala/details.html:194
 msgid "Support E-mail"
 msgstr "E-mail Asistence"
 
-#: src/olympia/addons/templates/addons/impala/details.html:194
-#: src/olympia/devhub/models.py:378
-#: src/olympia/devhub/templates/devhub/versions/list.html:12
-#: src/olympia/versions/templates/versions/version.html:6
-#: src/olympia/versions/templates/versions/mobile/version.html:6
+#: src/olympia/addons/templates/addons/impala/details.html:199 src/olympia/devhub/models.py:378 src/olympia/devhub/templates/devhub/versions/list.html:12
+#: src/olympia/versions/templates/versions/version.html:6 src/olympia/versions/templates/versions/mobile/version.html:6
 msgid "Version {0}"
 msgstr "Version {0}"
 
-#: src/olympia/addons/templates/addons/impala/details.html:194
+#: src/olympia/addons/templates/addons/impala/details.html:199
 msgid "Info"
 msgstr "Të dhëna"
 
-#: src/olympia/addons/templates/addons/impala/details.html:195
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:129
+#: src/olympia/addons/templates/addons/impala/details.html:200 src/olympia/devhub/templates/devhub/includes/addon_details.html:116
 msgid "Last Updated:"
 msgstr "Përditësuar Së Fundi:"
 
-#: src/olympia/addons/templates/addons/impala/details.html:200
+#: src/olympia/addons/templates/addons/impala/details.html:205
 #, python-format
 msgid "Released under <a target=\"_blank\" href=\"%(url)s\">%(name)s</a>"
-msgstr ""
-"Hedhur në qarkullim sipas një lejeje <a target=\"_blank\" "
-"href=\"%(url)s\">%(name)s</a>"
+msgstr "Hedhur në qarkullim sipas një lejeje <a target=\"_blank\" href=\"%(url)s\">%(name)s</a>"
 
-#: src/olympia/addons/templates/addons/impala/details.html:201
-#: src/olympia/addons/templates/addons/impala/details.html:206
-#: src/olympia/amo/helpers.py:398 src/olympia/devhub/forms.py:142
-#: src/olympia/devhub/forms.py:173
-#: src/olympia/versions/templates/versions/version.html:40
-#: src/olympia/versions/templates/versions/version.html:45
+#: src/olympia/addons/templates/addons/impala/details.html:206 src/olympia/addons/templates/addons/impala/details.html:211 src/olympia/amo/helpers.py:398 src/olympia/devhub/forms.py:142
+#: src/olympia/devhub/forms.py:173 src/olympia/versions/templates/versions/version.html:40 src/olympia/versions/templates/versions/version.html:45
 msgid "Custom License"
 msgstr "Licencë e Përshtatur"
 
-#: src/olympia/addons/templates/addons/impala/details.html:205
+#: src/olympia/addons/templates/addons/impala/details.html:210
 #, python-format
 msgid "Released under <a href=\"%(url)s\">%(name)s</a>"
 msgstr "Hedhur në qarkullim sipas <a href=\"%(url)s\">%(name)s</a>"
 
-#: src/olympia/addons/templates/addons/impala/details.html:217
+#: src/olympia/addons/templates/addons/impala/details.html:222
 msgid "About this Add-on"
 msgstr "Rreth kësaj Shtese"
 
-#: src/olympia/addons/templates/addons/impala/details.html:233
+#: src/olympia/addons/templates/addons/impala/details.html:238
 msgid "Developer’s Comments"
 msgstr "Komentet e Zhvilluesit"
 
-#: src/olympia/addons/templates/addons/impala/details.html:243
+#: src/olympia/addons/templates/addons/impala/details.html:248
 msgid "Version Information"
 msgstr "Të dhëna Versioni"
 
-#: src/olympia/addons/templates/addons/impala/details.html:250
+#: src/olympia/addons/templates/addons/impala/details.html:255
 msgid "See complete version history"
 msgstr "Shihni historikun e plotë të versioneve"
 
-#: src/olympia/addons/templates/addons/impala/details.html:262
+#: src/olympia/addons/templates/addons/impala/details.html:267
 msgid ""
-"The Development Channel lets you test an experimental new version of this "
-"add-on before it's released to the general public. Once you install the "
-"development version, you will continue to get updates from this channel. To "
-"stop receiving development updates, reinstall the default version from the "
-"link above."
+"The Development Channel lets you test an experimental new version of this add-on before it's released to the general public. Once you install the development version, you will continue to get "
+"updates from this channel. To stop receiving development updates, reinstall the default version from the link above."
 msgstr ""
-"Kanali i Zhvillimeve ju lejon të merrni në provë një version të ri "
-"eksperimental të kësaj shtese, përpara se ajo të hidhet në qarkullim për "
-"publikun e përgjithshëm. Pasi të instaloni versionin e zhvillimit, do të "
-"vazhdoni të merrni përditësime prej këtij kanali. Që të ndalni marrjen e "
-"përditësimeve nga zhvillimi, ri-instaloni versionin parazgjedhje prej "
-"lidhjes më sipër."
+"Kanali i Zhvillimeve ju lejon të merrni në provë një version të ri eksperimental të kësaj shtese, përpara se ajo të hidhet në qarkullim për publikun e përgjithshëm. Pasi të instaloni versionin e "
+"zhvillimit, do të vazhdoni të merrni përditësime prej këtij kanali. Që të ndalni marrjen e përditësimeve nga zhvillimi, ri-instaloni versionin parazgjedhje prej lidhjes më sipër."
 
-#: src/olympia/addons/templates/addons/impala/details.html:272
-msgid ""
-"<strong>Caution:</strong> Development versions of this add-on have not been "
-"reviewed by Mozilla."
-msgstr ""
-"<strong>Kujdes:</strong> Versionet zhvillim të kësaj shtese s’janë të "
-"shqyrtuara prej Mozilla-s."
+#: src/olympia/addons/templates/addons/impala/details.html:277
+msgid "<strong>Caution:</strong> Development versions of this add-on have not been reviewed by Mozilla."
+msgstr "<strong>Kujdes:</strong> Versionet zhvillim të kësaj shtese s’janë të shqyrtuara prej Mozilla-s."
 
-#: src/olympia/addons/templates/addons/impala/details.html:287
+#: src/olympia/addons/templates/addons/impala/details.html:292
 msgid "See complete development channel history"
 msgstr "Shihni historikun e plotë të kanalit të zhvillimit"
 
-#: src/olympia/addons/templates/addons/impala/details.html:306
-#: src/olympia/addons/templates/addons/impala/details.html:315
-#: src/olympia/addons/templates/addons/impala/details.html:327
-#: src/olympia/addons/templates/addons/impala/review_add_box.html:4
-#: src/olympia/stats/templates/stats/popup.html:2
-#: src/olympia/stats/templates/stats/popup.html:8
-#: src/olympia/stats/templates/stats/stats.html:202
-#: src/olympia/users/templates/users/profile.html:119
+#: src/olympia/addons/templates/addons/impala/details.html:311 src/olympia/addons/templates/addons/impala/details.html:320 src/olympia/addons/templates/addons/impala/details.html:332
+#: src/olympia/addons/templates/addons/impala/review_add_box.html:4 src/olympia/stats/templates/stats/popup.html:2 src/olympia/stats/templates/stats/popup.html:8
+#: src/olympia/stats/templates/stats/stats.html:204 src/olympia/users/templates/users/profile.html:119
 msgid "close"
 msgstr "mbylle"
 
@@ -1502,12 +1114,8 @@ msgid "Meet the {0} Developer"
 msgstr "Njihuni me Zhvilluesin e {0}"
 
 #: src/olympia/addons/templates/addons/impala/developers.html:41
-msgid ""
-"Before downloading this add-on, please consider supporting the development "
-"of this add-on by making a small contribution."
-msgstr ""
-"Përpara se të shkarkoni këtë shtesë, ju lutemi, shihni mundësinë e "
-"mbështetjes së zhvillimit të saj përmes dhënies së një kontributi të vogël."
+msgid "Before downloading this add-on, please consider supporting the development of this add-on by making a small contribution."
+msgstr "Përpara se të shkarkoni këtë shtesë, ju lutemi, shihni mundësinë e mbështetjes së zhvillimit të saj përmes dhënies së një kontributi të vogël."
 
 # %1 is an add-on name.
 #: src/olympia/addons/templates/addons/impala/developers.html:80
@@ -1525,9 +1133,7 @@ msgid_plural "About the Developers"
 msgstr[0] "Rreth Zhvilluesit"
 msgstr[1] "Rreth Zhvilluesve"
 
-#: src/olympia/addons/templates/addons/impala/developers.html:96
-#: src/olympia/users/templates/users/edit.html:130
-#: src/olympia/users/templates/users/profile.html:26
+#: src/olympia/addons/templates/addons/impala/developers.html:96 src/olympia/users/templates/users/edit.html:130 src/olympia/users/templates/users/profile.html:26
 msgid "No Photo"
 msgstr "Pa Foto"
 
@@ -1547,24 +1153,15 @@ msgstr "Kjo shtesë është çaktivizuar prej një përgjegjësi."
 msgid "Source Code License for {addon}"
 msgstr "Licencë Kodi Burim për {addon}"
 
-#: src/olympia/addons/templates/addons/impala/license.html:21
-#: src/olympia/versions/templates/versions/mobile/version.html:18
+#: src/olympia/addons/templates/addons/impala/license.html:21 src/olympia/versions/templates/versions/mobile/version.html:18
 msgid "Source Code License"
 msgstr "Licencë Kodi Burim"
 
-#: src/olympia/addons/templates/addons/impala/persona_grid.html:16
-#: src/olympia/addons/templates/addons/impala/toplist.html:6
-msgid "{0} users"
-msgstr "{0} përdorues"
-
-#: src/olympia/addons/templates/addons/impala/review_list_box.html:19
-#: src/olympia/reviews/templates/reviews/review.html:40
+#: src/olympia/addons/templates/addons/impala/review_list_box.html:19 src/olympia/reviews/templates/reviews/review.html:40
 msgid "permalink"
 msgstr "permalidhje"
 
-#: src/olympia/addons/templates/addons/impala/review_list_box.html:23
-#: src/olympia/editors/templates/editors/queue.html:98
-#: src/olympia/reviews/templates/reviews/review.html:44
+#: src/olympia/addons/templates/addons/impala/review_list_box.html:23 src/olympia/editors/templates/editors/queue.html:104 src/olympia/reviews/templates/reviews/review.html:44
 msgid "translate"
 msgstr "përktheni"
 
@@ -1575,8 +1172,7 @@ msgid_plural "See all %(cnt)s user reviews"
 msgstr[0] "Shihni krejt shqyrtimet e përdoruesit"
 msgstr[1] "Shihni krejt %(cnt)s shqyrtimet e përdoruesve"
 
-#: src/olympia/addons/templates/addons/impala/review_list_box.html:47
-#: src/olympia/reviews/templates/reviews/review_list.html:84
+#: src/olympia/addons/templates/addons/impala/review_list_box.html:47 src/olympia/reviews/templates/reviews/review_list.html:84
 msgid "This add-on has not yet been reviewed."
 msgstr "Kjo shtesë s’është shqyrtuar ende."
 
@@ -1584,24 +1180,23 @@ msgstr "Kjo shtesë s’është shqyrtuar ende."
 msgid "Be the first!"
 msgstr "Jini i pari!"
 
-#: src/olympia/addons/templates/addons/impala/listing/sorter.html:14
-#: src/olympia/devhub/templates/devhub/addons/listing/item_actions.html:49
+#: src/olympia/addons/templates/addons/impala/toplist.html:6
+msgid "{0} users"
+msgstr "{0} përdorues"
+
+#: src/olympia/addons/templates/addons/impala/listing/sorter.html:14 src/olympia/devhub/templates/devhub/addons/listing/item_actions.html:49
 msgid "More"
 msgstr "Më"
 
-#: src/olympia/addons/templates/addons/includes/collection_add_widget.html:7
-#: src/olympia/addons/templates/addons/includes/collection_add_widget.html:10
+#: src/olympia/addons/templates/addons/includes/collection_add_widget.html:7 src/olympia/addons/templates/addons/includes/collection_add_widget.html:10
 msgid "Add to collection"
 msgstr "Shtojeni në koleksion"
 
-#: src/olympia/addons/templates/addons/includes/dashboard_tabs.html:4
-#: src/olympia/devhub/templates/devhub/index.html:73
-#: src/olympia/devhub/templates/devhub/nav.html:14
+#: src/olympia/addons/templates/addons/includes/dashboard_tabs.html:4 src/olympia/devhub/templates/devhub/index.html:73 src/olympia/devhub/templates/devhub/nav.html:14
 msgid "My Add-ons"
 msgstr "Shtesat e Mia"
 
-#: src/olympia/addons/templates/addons/includes/dashboard_tabs.html:6
-#: src/olympia/amo/context_processors.py:51
+#: src/olympia/addons/templates/addons/includes/dashboard_tabs.html:6 src/olympia/amo/context_processors.py:50
 msgid "My Themes"
 msgstr "Temat e Mia"
 
@@ -1617,20 +1212,17 @@ msgstr "Përpunoni Temën"
 msgid "Approve / Reject"
 msgstr "Miratojeni / Hidheni Poshtë"
 
-#: src/olympia/addons/templates/addons/includes/persona.html:25
-#: src/olympia/editors/templates/editors/themes/single.html:43
+#: src/olympia/addons/templates/addons/includes/persona.html:25 src/olympia/editors/templates/editors/themes/single.html:43
 msgid "Review History"
 msgstr "Historik Shqyrtimesh"
 
 #: src/olympia/addons/templates/addons/includes/persona_pending_notice.html:3
 msgid "Sorry, this theme is pending. Please come back later."
-msgstr ""
-"Na ndjeni, kjo temë është vënë në radhë. Ju lutemi, rikthehuni më vonë."
+msgstr "Na ndjeni, kjo temë është vënë në radhë. Ju lutemi, rikthehuni më vonë."
 
 #: src/olympia/addons/templates/addons/includes/persona_pending_notice.html:8
 msgid "This theme is pending. It is invisible to everyone but you."
-msgstr ""
-"Kjo temë është vënë në radhë. Është e padukshme për këdo tjetër veç jush."
+msgstr "Kjo temë është vënë në radhë. Është e padukshme për këdo tjetër veç jush."
 
 #: src/olympia/addons/templates/addons/listing/items.html:29
 msgid "Collector's Note"
@@ -1641,9 +1233,7 @@ msgid "Not Yet Rated"
 msgstr "Ende e Pavlerësuar"
 
 #. {0} is the number of downloads.
-#: src/olympia/addons/templates/addons/listing/items_mobile.html:27
-#: src/olympia/addons/templates/addons/listing/macros.html:24
-#: src/olympia/devhub/templates/devhub/addons/listing/macros.html:15
+#: src/olympia/addons/templates/addons/listing/items_mobile.html:27 src/olympia/addons/templates/addons/listing/macros.html:24 src/olympia/devhub/templates/devhub/addons/listing/macros.html:15
 msgid "<strong>{0}</strong> weekly download"
 msgid_plural "<strong>{0}</strong> weekly downloads"
 msgstr[0] "<strong>{0}</strong> shkarkim javor"
@@ -1657,15 +1247,11 @@ msgstr "Lexoni Më Tepër"
 msgid "Users"
 msgstr "Përdorues"
 
-#: src/olympia/addons/templates/addons/mobile/details.html:92
-#: src/olympia/browse/views.py:59 src/olympia/browse/views.py:70
-#: src/olympia/search/forms.py:90
+#: src/olympia/addons/templates/addons/mobile/details.html:92 src/olympia/browse/views.py:59 src/olympia/browse/views.py:70 src/olympia/search/forms.py:90
 msgid "Weekly Downloads"
 msgstr "Shkarkime Javore"
 
-#: src/olympia/addons/templates/addons/mobile/details.html:99
-#: src/olympia/compat/templates/compat/reporter_detail.html:46
-#: src/olympia/devhub/forms.py:787
+#: src/olympia/addons/templates/addons/mobile/details.html:99 src/olympia/compat/templates/compat/reporter_detail.html:46 src/olympia/devhub/forms.py:788
 #: src/olympia/devhub/templates/devhub/versions/list.html:163
 msgid "Version"
 msgstr "Version"
@@ -1701,50 +1287,30 @@ msgstr "Pranim Licence"
 
 #: src/olympia/addons/templates/addons/mobile/eula.html:5
 #, python-format
-msgid ""
-"%(name)s requires that you accept the following End-User License Agreement "
-"before installation can proceed:"
-msgstr ""
-"%(name)s kërkon që të pranoni Marrëveshjen vijuese të Licencës për Përdorues"
-" të Thjeshtë, përpara se të ecet më tej me instalimin:"
+msgid "%(name)s requires that you accept the following End-User License Agreement before installation can proceed:"
+msgstr "%(name)s kërkon që të pranoni Marrëveshjen vijuese të Licencës për Përdorues të Thjeshtë, përpara se të ecet më tej me instalimin:"
 
 #: src/olympia/addons/templates/addons/mobile/eula.html:15
 msgid "Accept"
 msgstr "Pranoje"
 
-#: src/olympia/addons/templates/addons/mobile/home.html:10
-#: src/olympia/templates/mobile/base_addons.html:53
+#: src/olympia/addons/templates/addons/mobile/home.html:10 src/olympia/templates/mobile/base_addons.html:53
 msgid "Add-ons are not currently available on Firefox for iOS."
 msgstr "Hëpërhë shtesat s’janë të gatshme për Firefox-in për iOS."
 
-#: src/olympia/addons/templates/addons/mobile/home.html:12
-#: src/olympia/templates/mobile/base_addons.html:55
-msgid ""
-"You need Firefox to install add-ons. <a "
-"href=\"http://mozilla.com/mobile\">Learn More&nbsp;&raquo;</a>"
-msgstr ""
-"Që të instaloni shtesa, ju duhet Firefox-i. <a "
-"href=\"http://mozilla.com/mobile\">Mësoni Më Tepër&nbsp;&raquo;</a>"
+#: src/olympia/addons/templates/addons/mobile/home.html:12 src/olympia/templates/mobile/base_addons.html:55
+msgid "You need Firefox to install add-ons. <a href=\"http://mozilla.com/mobile\">Learn More&nbsp;&raquo;</a>"
+msgstr "Që të instaloni shtesa, ju duhet Firefox-i. <a href=\"http://mozilla.com/mobile\">Mësoni Më Tepër&nbsp;&raquo;</a>"
 
 # %1$s is the application name.  Example:  Firefox
-#: src/olympia/addons/templates/addons/mobile/home.html:19
-#: src/olympia/templates/header_title.html:4
-#: src/olympia/templates/impala/header_title.html:3
+#: src/olympia/addons/templates/addons/mobile/home.html:19 src/olympia/templates/header_title.html:4 src/olympia/templates/impala/header_title.html:3
 msgid "Return to the {0} Add-ons homepage"
 msgstr "Kthehuni te faqja hyrëse e Shtesave {0}"
 
-#: src/olympia/addons/templates/addons/mobile/home.html:21
-#: src/olympia/amo/helpers.py:237
-#: src/olympia/bandwagon/templates/bandwagon/edit.html:34
-#: src/olympia/discovery/templates/discovery/pane.html:92
-#: src/olympia/editors/templates/editors/base.html:21
-#: src/olympia/editors/templates/editors/performance.html:72
-#: src/olympia/templates/menu_links.html:4
-#: src/olympia/templates/impala/header_title.html:13
-#: src/olympia/templates/impala/header_title.html:15
-#: src/olympia/templates/impala/header_title.html:19
-#: src/olympia/templates/impala/header_title.html:23
-#: src/olympia/templates/mobile/base_addons.html:47
+#: src/olympia/addons/templates/addons/mobile/home.html:21 src/olympia/amo/helpers.py:237 src/olympia/bandwagon/templates/bandwagon/edit.html:34 src/olympia/discovery/templates/discovery/pane.html:92
+#: src/olympia/editors/templates/editors/base.html:21 src/olympia/editors/templates/editors/performance.html:72 src/olympia/templates/menu_links.html:4
+#: src/olympia/templates/impala/header_title.html:13 src/olympia/templates/impala/header_title.html:15 src/olympia/templates/impala/header_title.html:19
+#: src/olympia/templates/impala/header_title.html:23 src/olympia/templates/mobile/base_addons.html:47
 msgid "Add-ons"
 msgstr "Shtesa"
 
@@ -1752,48 +1318,28 @@ msgstr "Shtesa"
 msgid "Easy ways to personalize."
 msgstr "Mënyra të lehta për ta personalizuar."
 
-#: src/olympia/addons/templates/addons/mobile/home.html:24
-#: src/olympia/devhub/templates/devhub/addons/submit/done.html:47
-#: src/olympia/discovery/templates/discovery/pane.html:34
-#: src/olympia/discovery/templates/discovery/addons/detail.html:16
-#: src/olympia/discovery/templates/discovery/modules/featured.html:21
-#: src/olympia/discovery/templates/discovery/modules/monthly.html:22
+#: src/olympia/addons/templates/addons/mobile/home.html:24 src/olympia/devhub/templates/devhub/addons/submit/done.html:47 src/olympia/discovery/templates/discovery/pane.html:34
+#: src/olympia/discovery/templates/discovery/addons/detail.html:16 src/olympia/discovery/templates/discovery/modules/featured.html:21 src/olympia/discovery/templates/discovery/modules/monthly.html:22
 msgid "Learn More"
 msgstr "Mësoni Më Tepër"
 
 #: src/olympia/addons/templates/addons/mobile/home.html:26
 msgid ""
-"Add-ons are applications that let you personalize Firefox with extra "
-"functionality and style. Whether you mistype the name of a website or can't "
-"read a busy page, there's an add-on to improve your on-the-go browsing."
+"Add-ons are applications that let you personalize Firefox with extra functionality and style. Whether you mistype the name of a website or can't read a busy page, there's an add-on to improve your "
+"on-the-go browsing."
 msgstr ""
-"Shtesat janë aplikacione që ju lejojnë ta personalizoni Firefox-in me "
-"funksione dhe stil ekstra. Si për rastin kur shkruani gabim emrin e një "
-"sajti, ose kur s’lexoni dot në një faqe me shumë trafik, ka një shtesë që të"
-" përmirësojë shfletimin tuaj."
+"Shtesat janë aplikacione që ju lejojnë ta personalizoni Firefox-in me funksione dhe stil ekstra. Si për rastin kur shkruani gabim emrin e një sajti, ose kur s’lexoni dot në një faqe me shumë "
+"trafik, ka një shtesë që të përmirësojë shfletimin tuaj."
 
 #. {0} is a category name. Ex: "Sports"
 #. {0} is a category name, such as Nature.
-#: src/olympia/addons/templates/addons/mobile/home.html:43
-#: src/olympia/amo/templates/amo/site_nav.html:32
-#: src/olympia/browse/feeds.py:107
-#: src/olympia/browse/templates/browse/impala/base_listing.html:38
-#: src/olympia/browse/templates/browse/personas/base.html:6
-#: src/olympia/browse/templates/browse/personas/base.html:42
-#: src/olympia/browse/templates/browse/personas/category_landing.html:21
-#: src/olympia/browse/templates/browse/personas/category_landing.html:23
-#: src/olympia/browse/templates/browse/personas/category_landing.html:38
-#: src/olympia/browse/templates/browse/personas/grid.html:7
-#: src/olympia/browse/templates/browse/personas/grid.html:11
-#: src/olympia/browse/templates/browse/personas/mobile/base.html:7
-#: src/olympia/browse/templates/browse/personas/mobile/category_landing.html:19
-#: src/olympia/constants/base.py:180
-#: src/olympia/devhub/templates/devhub/personas/submit.html:13
-#: src/olympia/editors/helpers.py:105
-#: src/olympia/editors/templates/editors/base.html:26
-#: src/olympia/editors/templates/editors/performance.html:73
-#: src/olympia/search/templates/search/personas.html:39
-#: src/olympia/templates/menu_links.html:9
+#: src/olympia/addons/templates/addons/mobile/home.html:43 src/olympia/amo/templates/amo/site_nav.html:32 src/olympia/browse/feeds.py:107
+#: src/olympia/browse/templates/browse/impala/base_listing.html:38 src/olympia/browse/templates/browse/personas/base.html:6 src/olympia/browse/templates/browse/personas/base.html:42
+#: src/olympia/browse/templates/browse/personas/category_landing.html:21 src/olympia/browse/templates/browse/personas/category_landing.html:23
+#: src/olympia/browse/templates/browse/personas/category_landing.html:38 src/olympia/browse/templates/browse/personas/grid.html:7 src/olympia/browse/templates/browse/personas/grid.html:11
+#: src/olympia/browse/templates/browse/personas/mobile/base.html:7 src/olympia/browse/templates/browse/personas/mobile/category_landing.html:19 src/olympia/constants/base.py:180
+#: src/olympia/devhub/templates/devhub/personas/submit.html:13 src/olympia/editors/helpers.py:107 src/olympia/editors/templates/editors/base.html:26
+#: src/olympia/editors/templates/editors/performance.html:73 src/olympia/search/templates/search/personas.html:39 src/olympia/templates/menu_links.html:9
 msgid "Themes"
 msgstr "Tema"
 
@@ -1809,19 +1355,12 @@ msgstr "Shihni tërë shtesat Popullore"
 msgid "More Add-ons"
 msgstr "Më tepër Shtesa"
 
-#: src/olympia/addons/templates/addons/mobile/home.html:72
-#: src/olympia/browse/templates/browse/personas/mobile/category_landing.html:64
-#: src/olympia/search/forms.py:14
+#: src/olympia/addons/templates/addons/mobile/home.html:72 src/olympia/browse/templates/browse/personas/mobile/category_landing.html:64 src/olympia/search/forms.py:14
 msgid "Highest Rated"
 msgstr "Më të Vlerësuarat"
 
-#: src/olympia/addons/templates/addons/mobile/home.html:74
-#: src/olympia/amo/templates/amo/side_nav.html:5
-#: src/olympia/amo/templates/amo/site_nav.html:27
-#: src/olympia/amo/templates/amo/site_nav.html:57
-#: src/olympia/bandwagon/views.py:97 src/olympia/browse/views.py:57
-#: src/olympia/browse/views.py:67
-#: src/olympia/browse/templates/browse/personas/mobile/category_landing.html:65
+#: src/olympia/addons/templates/addons/mobile/home.html:74 src/olympia/amo/templates/amo/side_nav.html:5 src/olympia/amo/templates/amo/site_nav.html:27 src/olympia/amo/templates/amo/site_nav.html:55
+#: src/olympia/bandwagon/views.py:97 src/olympia/browse/views.py:57 src/olympia/browse/views.py:67 src/olympia/browse/templates/browse/personas/mobile/category_landing.html:65
 #: src/olympia/search/forms.py:15 src/olympia/search/forms.py:87
 msgid "Newest"
 msgstr "Më të Rejat"
@@ -1834,123 +1373,90 @@ msgstr "Provojeni!"
 msgid "Theme Info &raquo;"
 msgstr "Të dhëna Teme &raquo;"
 
-#: src/olympia/amo/context_processors.py:39
-#: src/olympia/devhub/templates/devhub/nav.html:43
+#: src/olympia/amo/context_processors.py:37 src/olympia/devhub/templates/devhub/nav.html:43
 msgid "Tools"
 msgstr "Mjete"
 
-#: src/olympia/amo/context_processors.py:48
-#: src/olympia/discovery/templates/discovery/pane_account.html:8
-#: src/olympia/users/templates/users/includes/navigation.html:2
+#: src/olympia/amo/context_processors.py:47 src/olympia/discovery/templates/discovery/pane_account.html:8 src/olympia/users/templates/users/includes/navigation.html:2
 msgid "My Profile"
 msgstr "Profili Im"
 
-#: src/olympia/amo/context_processors.py:54
-#: src/olympia/users/templates/users/edit.html:5
-#: src/olympia/users/templates/users/includes/navigation.html:3
+#: src/olympia/amo/context_processors.py:53 src/olympia/users/templates/users/edit.html:5 src/olympia/users/templates/users/includes/navigation.html:3
 msgid "Account Settings"
 msgstr "Rregullime Llogarie"
 
-#: src/olympia/amo/context_processors.py:57
-#: src/olympia/discovery/templates/discovery/pane_account.html:11
-#: src/olympia/users/templates/users/profile.html:83
+#: src/olympia/amo/context_processors.py:56 src/olympia/discovery/templates/discovery/pane_account.html:11 src/olympia/users/templates/users/profile.html:83
 #: src/olympia/users/templates/users/includes/navigation.html:4
 msgid "My Collections"
 msgstr "Koleksionet e Mia"
 
-#: src/olympia/amo/context_processors.py:62
-#: src/olympia/discovery/templates/discovery/pane_account.html:10
-#: src/olympia/users/templates/users/includes/navigation.html:7
+#: src/olympia/amo/context_processors.py:61 src/olympia/discovery/templates/discovery/pane_account.html:10 src/olympia/users/templates/users/includes/navigation.html:7
 msgid "My Favorites"
 msgstr "Të parapëlqyerit e Mi"
 
-#: src/olympia/amo/context_processors.py:67
-#: src/olympia/discovery/templates/discovery/pane_account.html:13
-#: src/olympia/templates/impala/user_login.html:14
+#: src/olympia/amo/context_processors.py:66 src/olympia/discovery/templates/discovery/pane_account.html:13 src/olympia/templates/impala/user_login.html:14
 #: src/olympia/templates/mobile/header_auth.html:5
 msgid "Log out"
 msgstr "Dilni"
 
-#: src/olympia/amo/context_processors.py:72
-#: src/olympia/devhub/templates/devhub/addons/dashboard.html:4
+#: src/olympia/amo/context_processors.py:71 src/olympia/devhub/templates/devhub/addons/dashboard.html:4
 msgid "Manage My Submissions"
 msgstr "Administro Parashtrimet e Mia"
 
-#: src/olympia/amo/context_processors.py:75
-#: src/olympia/devhub/templates/devhub/nav.html:27
-#: src/olympia/devhub/templates/devhub/addons/dashboard.html:25
+#: src/olympia/amo/context_processors.py:74 src/olympia/devhub/templates/devhub/nav.html:27 src/olympia/devhub/templates/devhub/addons/dashboard.html:25
 #: src/olympia/devhub/templates/devhub/addons/submit/base.html:4
 msgid "Submit a New Add-on"
 msgstr "Parashtroni një Shtesë të Re"
 
-#: src/olympia/amo/context_processors.py:77
-#: src/olympia/browse/templates/browse/personas/base.html:50
-#: src/olympia/devhub/templates/devhub/index.html:24
+#: src/olympia/amo/context_processors.py:76 src/olympia/browse/templates/browse/personas/base.html:50 src/olympia/devhub/templates/devhub/index.html:24
 #: src/olympia/devhub/templates/devhub/addons/dashboard.html:29
 msgid "Submit a New Theme"
 msgstr "Parashtroni Temë të Re"
 
-#: src/olympia/amo/context_processors.py:79
-#: src/olympia/amo/templates/amo/site_nav.html:87
-#: src/olympia/devhub/helpers.py:36 src/olympia/devhub/helpers.py:68
-#: src/olympia/devhub/helpers.py:102 src/olympia/templates/footer.html:6
-#: src/olympia/templates/menu_links.html:14
+#: src/olympia/amo/context_processors.py:78 src/olympia/amo/templates/amo/site_nav.html:85 src/olympia/devhub/helpers.py:36 src/olympia/devhub/helpers.py:68 src/olympia/devhub/helpers.py:102
+#: src/olympia/templates/footer.html:6 src/olympia/templates/menu_links.html:14
 msgid "Developer Hub"
 msgstr "Qendër Zhvilluesish"
 
-#: src/olympia/amo/context_processors.py:83 src/olympia/devhub/views.py:1792
+#: src/olympia/amo/context_processors.py:81 src/olympia/devhub/views.py:1796
 msgid "Manage API Keys"
 msgstr "Administroni Kyçe API"
 
-#: src/olympia/amo/context_processors.py:88 src/olympia/editors/helpers.py:82
-#: src/olympia/editors/helpers.py:102
-#: src/olympia/editors/templates/editors/base.html:10
+#: src/olympia/amo/context_processors.py:86 src/olympia/editors/helpers.py:84 src/olympia/editors/helpers.py:104 src/olympia/editors/templates/editors/base.html:10
 msgid "Editor Tools"
 msgstr "Mjete Redaktori"
 
-#: src/olympia/amo/context_processors.py:92
+#: src/olympia/amo/context_processors.py:90
 msgid "Admin Tools"
 msgstr "Mjete Përgjegjësi"
 
-#: src/olympia/amo/fields.py:15
+#: src/olympia/amo/fields.py:20
 msgid "Incorrect, please try again."
 msgstr "E pasaktë, ju lutemi, riprovoni."
 
-#: src/olympia/amo/fields.py:16
+#: src/olympia/amo/fields.py:21
 msgid "Error verifying input, please try again."
 msgstr "Gabim gjatë verifikimit të asaj që u dha, ju lutemi, riprovoni."
 
-#: src/olympia/amo/fields.py:32
+#: src/olympia/amo/fields.py:37
 msgid "This must be a valid hex color code, such as #000000."
-msgstr ""
-"Ky duhet të jetë kod u vlefshëm gjashtëmbëdhjetësh, fjala vjen #000000."
+msgstr "Ky duhet të jetë kod u vlefshëm gjashtëmbëdhjetësh, fjala vjen #000000."
 
-#: src/olympia/amo/fields.py:58
+#: src/olympia/amo/fields.py:63
 msgid "Enter at least one value."
 msgstr "Jepni të paktën një vlerë."
 
-#: src/olympia/amo/helpers.py:162
-#: src/olympia/amo/templates/amo/site_nav.html:61
-#: src/olympia/bandwagon/templates/bandwagon/add.html:9
-#: src/olympia/bandwagon/templates/bandwagon/collection_detail.html:15
-#: src/olympia/bandwagon/templates/bandwagon/delete.html:9
-#: src/olympia/bandwagon/templates/bandwagon/edit.html:15
-#: src/olympia/bandwagon/templates/bandwagon/user_listing.html:18
-#: src/olympia/bandwagon/templates/bandwagon/user_listing.html:21
-#: src/olympia/bandwagon/templates/bandwagon/impala/collection_listing.html:12
-#: src/olympia/bandwagon/templates/bandwagon/impala/collection_listing.html:20
-#: src/olympia/bandwagon/templates/bandwagon/impala/collection_listing.html:24
-#: src/olympia/bandwagon/templates/bandwagon/impala/collection_sidebar.html:3
-#: src/olympia/bandwagon/templates/bandwagon/includes/collection_sidebar.html:2
-#: src/olympia/bandwagon/templates/bandwagon/mobile/collection_listing.html:3
-#: src/olympia/stats/templates/stats/stats.html:77
-#: src/olympia/templates/menu_links.html:12
+#: src/olympia/amo/helpers.py:162 src/olympia/amo/templates/amo/site_nav.html:59 src/olympia/bandwagon/templates/bandwagon/add.html:9
+#: src/olympia/bandwagon/templates/bandwagon/collection_detail.html:15 src/olympia/bandwagon/templates/bandwagon/delete.html:9 src/olympia/bandwagon/templates/bandwagon/edit.html:15
+#: src/olympia/bandwagon/templates/bandwagon/user_listing.html:18 src/olympia/bandwagon/templates/bandwagon/user_listing.html:21
+#: src/olympia/bandwagon/templates/bandwagon/impala/collection_listing.html:12 src/olympia/bandwagon/templates/bandwagon/impala/collection_listing.html:20
+#: src/olympia/bandwagon/templates/bandwagon/impala/collection_listing.html:24 src/olympia/bandwagon/templates/bandwagon/impala/collection_sidebar.html:3
+#: src/olympia/bandwagon/templates/bandwagon/includes/collection_sidebar.html:2 src/olympia/bandwagon/templates/bandwagon/mobile/collection_listing.html:3
+#: src/olympia/stats/templates/stats/stats.html:33 src/olympia/templates/menu_links.html:12
 msgid "Collections"
 msgstr "Koleksione"
 
-#: src/olympia/amo/helpers.py:171
-#: src/olympia/amo/templates/amo/site_nav.html:85
-#: src/olympia/browse/templates/browse/language_tools.html:3
+#: src/olympia/amo/helpers.py:171 src/olympia/amo/templates/amo/site_nav.html:83 src/olympia/browse/templates/browse/language_tools.html:3
 msgid "Dictionaries & Language Packs"
 msgstr "Fjalorë & Paketa Gjuhësore"
 
@@ -2103,11 +1609,8 @@ msgstr "Është kërkuar supershqyrtim"
 msgid "Comment on {addon} {version}."
 msgstr "Koment për {addon} {version}."
 
-#: src/olympia/amo/log.py:236
-#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:19
-#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:47
-#: src/olympia/editors/helpers.py:511
-#: src/olympia/editors/templates/editors/themes/history_table.html:11
+#: src/olympia/amo/log.py:236 src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:17 src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:45
+#: src/olympia/editors/helpers.py:584 src/olympia/editors/templates/editors/themes/history_table.html:11
 msgid "Comment"
 msgstr "Koment"
 
@@ -2245,9 +1748,7 @@ msgstr "Aplikacioni u çaktivizua"
 
 #: src/olympia/amo/log.py:425
 msgid "{addon} escalated because of high number of abuse reports."
-msgstr ""
-"{addon} e kaluar për shqyrtim të mëtejshëm, për shkak të numrit të madh të "
-"njoftimeve për abuzim."
+msgstr "{addon} e kaluar për shqyrtim të mëtejshëm, për shkak të numrit të madh të njoftimeve për abuzim."
 
 #: src/olympia/amo/log.py:426
 msgid "High Abuse Reports"
@@ -2263,7 +1764,7 @@ msgstr "Kërkesë nga shqyrtuesi për shqyrtim të mëtejshëm"
 
 #: src/olympia/amo/log.py:442
 msgid "Video removed from {addon} because of a problem with the video. "
-msgstr "Videoja u hoq nga {addon} për shkak të një problemi me videon."
+msgstr ""
 
 #: src/olympia/amo/log.py:444
 msgid "Video removed"
@@ -2331,8 +1832,7 @@ msgstr "Përdoruesi {0.name} u hoq prej {group}."
 
 #: src/olympia/amo/log.py:545
 msgid "{addon} minimum requirements manually changed by reviewer."
-msgstr ""
-"Domosdoshmëritë minimum për {addon} u ndryshuan dorazi nga shqyrtuesi."
+msgstr "Domosdoshmëritë minimum për {addon} u ndryshuan dorazi nga shqyrtuesi."
 
 #: src/olympia/amo/log.py:546
 msgid "Requirements Changed by Reviewer"
@@ -2368,10 +1868,7 @@ msgstr "Klasifikimi i lëndës për {addon} u ndryshua."
 msgid "{addon} unlisted."
 msgstr "{addon} u hoq nga lista."
 
-#: src/olympia/amo/log.py:592 src/olympia/amo/log.py:598
-#: src/olympia/amo/log.py:612 src/olympia/amo/log.py:618
-#: src/olympia/amo/log.py:624 src/olympia/amo/log.py:630
-#: src/olympia/amo/log.py:636
+#: src/olympia/amo/log.py:592 src/olympia/amo/log.py:598 src/olympia/amo/log.py:612 src/olympia/amo/log.py:618 src/olympia/amo/log.py:624 src/olympia/amo/log.py:630 src/olympia/amo/log.py:636
 msgid "{file} was signed."
 msgstr "{file} qe nënshkruar."
 
@@ -2385,20 +1882,12 @@ msgid "Not allowed"
 msgstr "E palejuar"
 
 #: src/olympia/amo/templates/amo/403.html:7
-msgid ""
-"<h1>Oops! Not allowed.</h1> <p>You tried to do something that you weren't "
-"allowed to.</p>"
-msgstr ""
-"<h1>Oh! S’lejohet.</h1> <p>Provuat të bëni diçka që s’ju është lejuar ta "
-"bëni.</p>"
+msgid "<h1>Oops! Not allowed.</h1> <p>You tried to do something that you weren't allowed to.</p>"
+msgstr "<h1>Oh! S’lejohet.</h1> <p>Provuat të bëni diçka që s’ju është lejuar ta bëni.</p>"
 
 #: src/olympia/amo/templates/amo/403.html:12
-msgid ""
-"<p>Try going back to the previous page, refreshing and then trying "
-"again.</p>"
-msgstr ""
-"<p>Provoni të ktheheni mbrapsht te faqja e mëparshme, ta rifreskoni dhe "
-"mandej të riprovoni.</p>"
+msgid "<p>Try going back to the previous page, refreshing and then trying again.</p>"
+msgstr "<p>Provoni të ktheheni mbrapsht te faqja e mëparshme, ta rifreskoni dhe mandej të riprovoni.</p>"
 
 #: src/olympia/amo/templates/amo/404.html:3
 msgid "Not Found"
@@ -2407,36 +1896,19 @@ msgstr "S’u Gjet"
 #: src/olympia/amo/templates/amo/404.html:6
 #, python-format
 msgid ""
-"<h1>We're sorry, but we can't find what you're looking for.</h1> <p> The "
-"page or file you requested wasn't found on our site. It's possible that you "
-"clicked a link that's out of date, or typed in the address incorrectly. </p>"
-" <ul> <li>If you typed in the address, please double check the "
-"spelling.</li> <li> If you followed a link from somewhere, please let us "
-"know at <a href=\"mailto:webmaster@mozilla.com\">webmaster@mozilla.com</a>. "
-"Tell us where you came from and what you were looking for, and we'll do our "
-"best to fix it. </li> </ul> <p>Or you can just jump over to some of the "
-"popular pages on our website.</p> <ul> <li>Are you interested in a <a "
-"href=\"%(rec)s\">list of featured add-ons</a>?</li> <li> Do you want to <a "
-"href=\"%(search)s\">search for add-ons</a>? You may go to the <a "
-"href=\"%(search)s\">search page</a> or just use the search field above. "
-"</li> <li> If you prefer to start over, just go to the <a href=\"%(home)s"
-"\">add-ons front page</a>. </li> </ul>"
+"<h1>We're sorry, but we can't find what you're looking for.</h1> <p> The page or file you requested wasn't found on our site. It's possible that you clicked a link that's out of date, or typed in "
+"the address incorrectly. </p> <ul> <li>If you typed in the address, please double check the spelling.</li> <li> If you followed a link from somewhere, please let us know at <a href=\"mailto:"
+"webmaster@mozilla.com\">webmaster@mozilla.com</a>. Tell us where you came from and what you were looking for, and we'll do our best to fix it. </li> </ul> <p>Or you can just jump over to some of "
+"the popular pages on our website.</p> <ul> <li>Are you interested in a <a href=\"%(rec)s\">list of featured add-ons</a>?</li> <li> Do you want to <a href=\"%(search)s\">search for add-ons</a>? You "
+"may go to the <a href=\"%(search)s\">search page</a> or just use the search field above. </li> <li> If you prefer to start over, just go to the <a href=\"%(home)s\">add-ons front page</a>. </li> </"
+"ul>"
 msgstr ""
-"<h1>Na ndjeni, por s’e gjejmë dot çfarë po kërkonit.</h1> <p> Faqja ose "
-"kartela që kërkuat s’u gjet te sajti ynë. Mundet që klikuat në një lidhje të"
-" vjetruar, ose e shkruat pasaktësisht. </p> <ul> <li>Nëse e shkruat ju, ju "
-"lutemi, kontrolloni sërish drejtshkrimin.</li> <li> Nëse ndoqët një lidhje "
-"nga diku gjetkë, ju lutemi, na e bëni të ditur te <a "
-"href=\"mailto:webmaster@mozilla.com\">webmaster@mozilla.com</a>. Na tregoni "
-"aty se prej nga mbërritët dhe se për çfarë po kërkonit, dhe do të bëjmë "
-"ç’është e mundur ta ndreqim. </li> </ul> <p>Ose mundeni të hidheni te disa "
-"faqe popullore te sajti ynë.</p> <ul> <li>Ju intereson një <a "
-"href=\"%(rec)s\">listë shtesash të zgjedhura</a>?</li> <li> Doni të <a "
-"href=\"%(search)s\">kërkoni për shtesa</a>? Mund të hidheni te <a "
-"href=\"%(search)s\">faqja e kërkimeve</a> ose thjesht përdorni kutinë e "
-"kërkimeve më sipër. </li> <li> Nëse parapëlqeni t’ia nisni nga e para, "
-"thjesht shkoni te <a href=\"%(home)s\">faqja hyrëse e shtesave</a>. </li> "
-"</ul>"
+"<h1>Na ndjeni, por s’e gjejmë dot çfarë po kërkonit.</h1> <p> Faqja ose kartela që kërkuat s’u gjet te sajti ynë. Mundet që klikuat në një lidhje të vjetruar, ose e shkruat pasaktësisht. </p> <ul> "
+"<li>Nëse e shkruat ju, ju lutemi, kontrolloni sërish drejtshkrimin.</li> <li> Nëse ndoqët një lidhje nga diku gjetkë, ju lutemi, na e bëni të ditur te <a href=\"mailto:webmaster@mozilla.com"
+"\">webmaster@mozilla.com</a>. Na tregoni aty se prej nga mbërritët dhe se për çfarë po kërkonit, dhe do të bëjmë ç’është e mundur ta ndreqim. </li> </ul> <p>Ose mundeni të hidheni te disa faqe "
+"popullore te sajti ynë.</p> <ul> <li>Ju intereson një <a href=\"%(rec)s\">listë shtesash të zgjedhura</a>?</li> <li> Doni të <a href=\"%(search)s\">kërkoni për shtesa</a>? Mund të hidheni te <a "
+"href=\"%(search)s\">faqja e kërkimeve</a> ose thjesht përdorni kutinë e kërkimeve më sipër. </li> <li> Nëse parapëlqeni t’ia nisni nga e para, thjesht shkoni te <a href=\"%(home)s\">faqja hyrëse e "
+"shtesave</a>. </li> </ul>"
 
 #: src/olympia/amo/templates/amo/500.html:3
 msgid "Oops"
@@ -2444,83 +1916,49 @@ msgstr "Oh"
 
 #: src/olympia/amo/templates/amo/500.html:6
 #, python-format
-msgid ""
-"<h1>Oops!  We had an error.</h1> <p>We'll get to fixing that soon.</p> <p> "
-"You can try refreshing the page, or head back to the <a href=\"%(home)s"
-"\">Add-ons homepage</a>. </p>"
+msgid "<h1>Oops!  We had an error.</h1> <p>We'll get to fixing that soon.</p> <p> You can try refreshing the page, or head back to the <a href=\"%(home)s\">Add-ons homepage</a>. </p>"
 msgstr ""
-"<h1>Hmm... na ndodhi një gabim.</h1> <p>Do ta ndreqim së shpejti.</p> <p> "
-"Mund të provoni rifreskimin e faqes, ose kthehuni mbrapsht te <a "
-"href=\"%(home)s\">faqja hyrëse e Shtesave</a>. </p>"
 
 #: src/olympia/amo/templates/amo/license_link.html:10
 msgid "Some rights reserved"
 msgstr "Disa të drejta të ruajtura"
 
-#: src/olympia/amo/templates/amo/no_results.html:1
-#: src/olympia/editors/templates/editors/includes/search_results_themes.html:26
+#: src/olympia/amo/templates/amo/no_results.html:1 src/olympia/editors/templates/editors/includes/search_results_themes.html:26
 msgid "No results found"
 msgstr "S’u gjetën përfundime"
 
 #. abbreviation of 'previous'
-#: src/olympia/amo/templates/amo/paginator.html:6
-#: src/olympia/amo/templates/amo/mobile/paginator.html:4
-#: src/olympia/amo/templates/amo/mobile/paginator.html:6
-#: src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:49
-#: src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:63
-#: src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:76
-#: src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:89
+#: src/olympia/amo/templates/amo/paginator.html:6 src/olympia/amo/templates/amo/mobile/paginator.html:4 src/olympia/amo/templates/amo/mobile/paginator.html:6
+#: src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:49 src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:63
+#: src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:76 src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:89
 #: src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:102
 msgid "Prev"
 msgstr "E mëparshmja"
 
-#: src/olympia/amo/templates/amo/paginator.html:26
-#: src/olympia/amo/templates/amo/impala/paginator.html:26
-#: src/olympia/amo/templates/amo/mobile/impala_paginator.html:16
-#: src/olympia/amo/templates/amo/mobile/paginator.html:14
-#: src/olympia/amo/templates/amo/mobile/paginator.html:16
-#: src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:51
-#: src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:65
-#: src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:78
-#: src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:91
-#: src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:104
-#: src/olympia/discovery/templates/discovery/pane.html:45
-#: src/olympia/discovery/templates/discovery/addons/detail.html:39
-#: src/olympia/stats/templates/stats/stats.html:167
+#: src/olympia/amo/templates/amo/paginator.html:26 src/olympia/amo/templates/amo/impala/paginator.html:26 src/olympia/amo/templates/amo/mobile/impala_paginator.html:16
+#: src/olympia/amo/templates/amo/mobile/paginator.html:14 src/olympia/amo/templates/amo/mobile/paginator.html:16 src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:51
+#: src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:65 src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:78
+#: src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:91 src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:104
+#: src/olympia/discovery/templates/discovery/pane.html:45 src/olympia/discovery/templates/discovery/addons/detail.html:39 src/olympia/stats/templates/stats/stats.html:169
 msgid "Next"
 msgstr "Pasuesja"
 
-#: src/olympia/amo/templates/amo/paginator.html:32
-#: src/olympia/editors/templates/editors/includes/paginator_history.html:11
+#: src/olympia/amo/templates/amo/paginator.html:32 src/olympia/editors/templates/editors/includes/paginator_history.html:11
 #, python-format
-msgid ""
-"Results <strong>%(begin)s</strong>&ndash;<strong>%(end)s</strong> of "
-"<strong>%(count)s</strong>"
-msgstr ""
-"Përfundimet <strong>%(begin)s</strong>&ndash;<strong>%(end)s</strong> nga "
-"<strong>%(count)s</strong> gjithsej"
+msgid "Results <strong>%(begin)s</strong>&ndash;<strong>%(end)s</strong> of <strong>%(count)s</strong>"
+msgstr "Përfundimet <strong>%(begin)s</strong>&ndash;<strong>%(end)s</strong> nga <strong>%(count)s</strong> gjithsej"
 
-#: src/olympia/amo/templates/amo/read-only.html:3
-#: src/olympia/amo/templates/amo/read-only.html:7
+#: src/olympia/amo/templates/amo/read-only.html:3 src/olympia/amo/templates/amo/read-only.html:7
 msgid "Maintenance in progress"
 msgstr "Mirëmbajtje në kryerje e sipër"
 
 #: src/olympia/amo/templates/amo/read-only.html:9
-msgid ""
-"This feature is temporarily disabled while we perform website maintenance. "
-"Please use your browser's Back button and try again a little later."
-msgstr ""
-"Kjo veçori është përkohësisht e çaktivizuar, teksa kryejmë mirëmbajtjen e "
-"sajtit. Ju lutemi, përdorni butonin Mbrapsht të shfletuesi dhe riprovoni pak"
-" më vonë."
+msgid "This feature is temporarily disabled while we perform website maintenance. Please use your browser's Back button and try again a little later."
+msgstr "Kjo veçori është përkohësisht e çaktivizuar, teksa kryejmë mirëmbajtjen e sajtit. Ju lutemi, përdorni butonin Mbrapsht të shfletuesi dhe riprovoni pak më vonë."
 
 #: src/olympia/amo/templates/amo/read-only.html:14
-msgid ""
-"Some features on this page are temporarily disabled while we perform website"
-" maintenance. Please try again a little later."
-msgstr ""
-"Disa veçori në këtë faqe janë çaktivizuar përkohësisht, teksa bëjmë "
-"mirëmbajtjen e sajtit. Ju lutemi, riprovoni pas pak."
+msgid "Some features on this page are temporarily disabled while we perform website maintenance. Please try again a little later."
+msgstr "Disa veçori në këtë faqe janë çaktivizuar përkohësisht, teksa bëjmë mirëmbajtjen e sajtit. Ju lutemi, riprovoni pas pak."
 
 #: src/olympia/amo/templates/amo/recaptcha.html:4
 msgid "Are you human?"
@@ -2528,25 +1966,14 @@ msgstr "Jeni qenie njerëzore?"
 
 #: src/olympia/amo/templates/amo/recaptcha.html:8
 msgid ""
-"<p> Please enter <strong>all the words</strong> below, <strong>separated by "
-"a space if necessary</strong>. </p> <p> If this is hard to read, you can <a "
-"href=\"#\" id=\"recaptcha_different\">try different words</a> or <a "
-"href=\"#\" id=\"recaptcha_audio\">try a different type of challenge</a> "
-"instead. </p>"
+"<p> Please enter <strong>all the words</strong> below, <strong>separated by a space if necessary</strong>. </p> <p> If this is hard to read, you can <a href=\"#\" id=\"recaptcha_different\">try "
+"different words</a> or <a href=\"#\" id=\"recaptcha_audio\">try a different type of challenge</a> instead. </p>"
 msgstr ""
-"<p> Ju lutemi, jepni më poshtë <strong>krejt fjalët</strong>, <strong>të "
-"ndara nga një hapësirë, në qoftë e nevojshme</strong>. </p> <p> Nëse kjo "
-"është e zorshme të lexohet, mund të <a href=\"#\" "
-"id=\"recaptcha_different\">provoni fjalë të tjera</a> ose <a href=\"#\" "
-"id=\"recaptcha_audio\">të provoni një tjetër lloj prove</a> më mirë. </p>"
+"<p> Ju lutemi, jepni më poshtë <strong>krejt fjalët</strong>, <strong>të ndara nga një hapësirë, në qoftë e nevojshme</strong>. </p> <p> Nëse kjo është e zorshme të lexohet, mund të <a href=\"#\" "
+"id=\"recaptcha_different\">provoni fjalë të tjera</a> ose <a href=\"#\" id=\"recaptcha_audio\">të provoni një tjetër lloj prove</a> më mirë. </p>"
 
-#: src/olympia/amo/templates/amo/side_nav.html:4
-#: src/olympia/amo/templates/amo/side_nav.html:12
-#: src/olympia/amo/templates/amo/site_nav.html:4
-#: src/olympia/amo/templates/amo/site_nav.html:26
-#: src/olympia/browse/views.py:56 src/olympia/browse/views.py:66
-#: src/olympia/browse/views.py:237 src/olympia/browse/views.py:282
-#: src/olympia/search/forms.py:86
+#: src/olympia/amo/templates/amo/side_nav.html:4 src/olympia/amo/templates/amo/side_nav.html:12 src/olympia/amo/templates/amo/site_nav.html:4 src/olympia/amo/templates/amo/site_nav.html:26
+#: src/olympia/browse/views.py:56 src/olympia/browse/views.py:66 src/olympia/browse/views.py:204 src/olympia/browse/views.py:249 src/olympia/search/forms.py:86
 msgid "Top Rated"
 msgstr "Më të Vlerësuarat"
 
@@ -2555,81 +1982,60 @@ msgid "Explore"
 msgstr "Eksploroni"
 
 # Plural in this context means many of the add-on type
-#: src/olympia/amo/templates/amo/site_nav.html:23
-#: src/olympia/browse/feeds.py:65 src/olympia/browse/feeds.py:78
-#: src/olympia/browse/feeds.py:92 src/olympia/browse/feeds.py:100
-#: src/olympia/browse/templates/browse/base_listing.html:7
-#: src/olympia/browse/templates/browse/creatured.html:10
-#: src/olympia/browse/templates/browse/impala/base_listing.html:37
+#: src/olympia/amo/templates/amo/site_nav.html:23 src/olympia/browse/feeds.py:65 src/olympia/browse/feeds.py:78 src/olympia/browse/feeds.py:92 src/olympia/browse/feeds.py:100
+#: src/olympia/browse/templates/browse/base_listing.html:7 src/olympia/browse/templates/browse/creatured.html:10 src/olympia/browse/templates/browse/impala/base_listing.html:37
 #: src/olympia/constants/base.py:173 src/olympia/templates/menu_links.html:8
 msgid "Extensions"
 msgstr "Zgjerime"
 
-#: src/olympia/amo/templates/amo/site_nav.html:45
+#: src/olympia/amo/templates/amo/site_nav.html:44
 msgid "Want more customization? Try <b>Complete Themes</b>"
 msgstr "Doni më tepër përshtatje? Provoni <b>Tema të Plota</b>"
 
-#: src/olympia/amo/templates/amo/site_nav.html:56
-#: src/olympia/bandwagon/views.py:96
+#: src/olympia/amo/templates/amo/site_nav.html:54 src/olympia/bandwagon/views.py:96
 msgid "Most Followers"
 msgstr "Shumica e Pasuesve"
 
-#: src/olympia/amo/templates/amo/site_nav.html:68
-#: src/olympia/bandwagon/templates/bandwagon/impala/collection_sidebar.html:16
+#: src/olympia/amo/templates/amo/site_nav.html:66 src/olympia/bandwagon/templates/bandwagon/impala/collection_sidebar.html:16
 #: src/olympia/bandwagon/templates/bandwagon/includes/collection_sidebar.html:18
 msgid "Collections I've Made"
 msgstr "Koleksionet që Kam Krijuar"
 
-#: src/olympia/amo/templates/amo/site_nav.html:70
-#: src/olympia/bandwagon/templates/bandwagon/user_listing.html:4
-#: src/olympia/bandwagon/templates/bandwagon/impala/collection_sidebar.html:13
+#: src/olympia/amo/templates/amo/site_nav.html:68 src/olympia/bandwagon/templates/bandwagon/user_listing.html:4 src/olympia/bandwagon/templates/bandwagon/impala/collection_sidebar.html:13
 #: src/olympia/bandwagon/templates/bandwagon/includes/collection_sidebar.html:15
 msgid "Collections I'm Following"
 msgstr "Koleksionet që Ndjek"
 
-#: src/olympia/amo/templates/amo/site_nav.html:73
-#: src/olympia/bandwagon/templates/bandwagon/impala/collection_sidebar.html:18
-#: src/olympia/bandwagon/templates/bandwagon/includes/collection_sidebar.html:20
-#: src/olympia/users/models.py:512
+#: src/olympia/amo/templates/amo/site_nav.html:71 src/olympia/bandwagon/templates/bandwagon/impala/collection_sidebar.html:18
+#: src/olympia/bandwagon/templates/bandwagon/includes/collection_sidebar.html:20 src/olympia/users/models.py:521
 msgid "My Favorite Add-ons"
 msgstr "Shtesat e Mia të Parapëlqyera"
 
-#: src/olympia/amo/templates/amo/site_nav.html:78
+#: src/olympia/amo/templates/amo/site_nav.html:76
 msgid "More&hellip;"
 msgstr "Më tepër&hellip;"
 
-#: src/olympia/amo/templates/amo/site_nav.html:82
+#: src/olympia/amo/templates/amo/site_nav.html:80
 msgid "Add-ons for Mobile"
 msgstr "Shtesa për Celular"
 
-#: src/olympia/amo/templates/amo/site_nav.html:86
-#: src/olympia/browse/feeds.py:207
-#: src/olympia/browse/templates/browse/search_tools.html:3
-#: src/olympia/constants/base.py:176 src/olympia/templates/menu_links.html:10
+#: src/olympia/amo/templates/amo/site_nav.html:84 src/olympia/browse/feeds.py:207 src/olympia/browse/templates/browse/search_tools.html:3 src/olympia/constants/base.py:176
+#: src/olympia/templates/menu_links.html:10
 msgid "Search Tools"
 msgstr "Mjete Kërkimi"
 
 #. This is a page range (e.g., Page 1 of 50).
-#: src/olympia/amo/templates/amo/impala/paginator.html:5
-#: src/olympia/amo/templates/amo/mobile/impala_paginator.html:26
+#: src/olympia/amo/templates/amo/impala/paginator.html:5 src/olympia/amo/templates/amo/mobile/impala_paginator.html:26
 #, python-format
-msgid ""
-"Page <a href=\"%(current_pg_url)s\">%(current_pg)s</a> of <a "
-"href=\"%(last_pg_url)s\">%(last_pg)s</a>"
-msgstr ""
-"Faqja <a href=\"%(current_pg_url)s\">%(current_pg)s</a> nga <a "
-"href=\"%(last_pg_url)s\">%(last_pg)s</a> gjithsej"
+msgid "Page <a href=\"%(current_pg_url)s\">%(current_pg)s</a> of <a href=\"%(last_pg_url)s\">%(last_pg)s</a>"
+msgstr "Faqja <a href=\"%(current_pg_url)s\">%(current_pg)s</a> nga <a href=\"%(last_pg_url)s\">%(last_pg)s</a> gjithsej"
 
-#: src/olympia/amo/templates/amo/impala/paginator.html:16
-#: src/olympia/amo/templates/amo/mobile/impala_paginator.html:6
+#: src/olympia/amo/templates/amo/impala/paginator.html:16 src/olympia/amo/templates/amo/mobile/impala_paginator.html:6
 msgid "Jump to first page"
 msgstr "Shko te faqja e parë"
 
-#: src/olympia/amo/templates/amo/impala/paginator.html:22
-#: src/olympia/amo/templates/amo/mobile/impala_paginator.html:12
-#: src/olympia/discovery/templates/discovery/pane.html:44
-#: src/olympia/discovery/templates/discovery/addons/detail.html:38
-#: src/olympia/stats/templates/stats/stats.html:164
+#: src/olympia/amo/templates/amo/impala/paginator.html:22 src/olympia/amo/templates/amo/mobile/impala_paginator.html:12 src/olympia/discovery/templates/discovery/pane.html:44
+#: src/olympia/discovery/templates/discovery/addons/detail.html:38 src/olympia/stats/templates/stats/stats.html:166
 msgid "Previous"
 msgstr "I mëparshmi"
 
@@ -2639,15 +2045,12 @@ msgstr "Shko te faqja e fundit"
 
 #. First and second arguments are the result range (e.g., 1-20);
 #. third argument is the number of total results (e.g., 1,000).
-#. third
+#. First and second arguments are the result range (e.g., 1-20);              third
 #. argument is the number of total results (e.g., 1,000).
-#: src/olympia/amo/templates/amo/impala/paginator.html:36
-#: src/olympia/amo/templates/amo/mobile/impala_paginator.html:38
+#: src/olympia/amo/templates/amo/impala/paginator.html:36 src/olympia/amo/templates/amo/mobile/impala_paginator.html:38
 #, python-format
 msgid "Showing <b>%(begin)s</b>&ndash;<b>%(end)s</b> of <b>%(count)s</b>"
-msgstr ""
-"Po shfaqen <b>%(begin)s</b>&ndash;<b>%(end)s</b> nga <b>%(count)s</b> "
-"gjithsej"
+msgstr "Po shfaqen <b>%(begin)s</b>&ndash;<b>%(end)s</b> nga <b>%(count)s</b> gjithsej"
 
 #: src/olympia/amo/templates/amo/mobile/paginator.html:10
 msgid "Page {n}"
@@ -2655,42 +2058,52 @@ msgid_plural "Page {n}"
 msgstr[0] "Faqe {n}"
 msgstr[1] "Faqe {n}"
 
-#: src/olympia/amo/templates/services/install.html:38
-#, python-format
-msgid ""
-"If you are not prompted to install %(addon_name)s in a moment, please <a "
-"href=\"%(addon_xpi)s\">click here</a>."
-msgstr ""
-"Nëse brenda një çasti s’ju kërkohet të instaloni %(addon_name)s, ju lutemi, "
-"<a href=\"%(addon_xpi)s\">klikoni këtu</a>."
-
-#: src/olympia/amo/tests/test_messages.py:57
-#: src/olympia/amo/tests/test_messages.py:58 src/olympia/reviews/forms.py:25
-#: src/olympia/reviews/forms.py:50
-#: src/olympia/reviews/templates/reviews/add.html:56
+#: src/olympia/amo/tests/test_messages.py:56 src/olympia/amo/tests/test_messages.py:57 src/olympia/reviews/forms.py:25 src/olympia/reviews/forms.py:50 src/olympia/reviews/templates/reviews/add.html:56
 #: src/olympia/reviews/templates/reviews/reply.html:30
 msgid "Title"
 msgstr "Titull"
 
-#: src/olympia/amo/tests/test_messages.py:57
-#: src/olympia/amo/tests/test_messages.py:58
+#: src/olympia/amo/tests/test_messages.py:56 src/olympia/amo/tests/test_messages.py:57
 msgid "Body"
 msgstr "Përmbajtje"
 
-#: src/olympia/amo/tests/test_messages.py:59
+#: src/olympia/amo/tests/test_messages.py:58
 msgid "Another Title"
 msgstr "Tjetër Titull"
 
-#: src/olympia/amo/tests/test_messages.py:59
+#: src/olympia/amo/tests/test_messages.py:58
 msgid "Another Body"
 msgstr "Tjetër Përmbajtje"
 
-#: src/olympia/api/views.py:255
-msgid "Not implemented yet."
-msgstr "Ende i pasendërtuar."
+#: src/olympia/api/authentication.py:76
+msgid "Signature has expired."
+msgstr ""
 
-#: src/olympia/applications/views.py:39
-#: src/olympia/applications/templates/applications/appversions.html:3
+#: src/olympia/api/authentication.py:79
+msgid "Error decoding signature."
+msgstr ""
+
+#: src/olympia/api/authentication.py:82
+msgid "Invalid JWT Token."
+msgstr ""
+
+#: src/olympia/api/authentication.py:130
+msgid "Invalid Authorization header. No credentials provided."
+msgstr ""
+
+#: src/olympia/api/authentication.py:133
+msgid "Invalid Authorization header. Credentials string should not contain spaces."
+msgstr ""
+
+#: src/olympia/api/fields.py:29
+msgid "The field must have a length of at least {num} characters."
+msgstr ""
+
+#: src/olympia/api/fields.py:31
+msgid "The language code {lang_code} is invalid."
+msgstr ""
+
+#: src/olympia/applications/views.py:39 src/olympia/applications/templates/applications/appversions.html:3
 msgid "Application Versions"
 msgstr "Versione Aplikacionesh"
 
@@ -2703,22 +2116,17 @@ msgid "Valid Application Versions"
 msgstr "Versione të Vlefshëm Aplikacioni"
 
 #: src/olympia/applications/templates/applications/appversions.html:12
-msgid ""
-"Add-ons submitted to Mozilla Add-ons must have a manifest file with at least"
-" one of the below applications supported. Only the versions listed below are"
-" allowed for these applications."
+msgid "Add-ons submitted to Mozilla Add-ons must have a manifest file with at least one of the below applications supported. Only the versions listed below are allowed for these applications."
 msgstr ""
-"Shtesat e parashtruara te Shtesat Mozilla duhet të kenë një kartelë manifest"
-" me mbulim për të paktën një nga aplikacionet më poshtë. Lejohen vetëm "
-"versionet e radhitur më poshtë për këta aplikacione."
+"Shtesat e parashtruara te Shtesat Mozilla duhet të kenë një kartelë manifest me mbulim për të paktën një nga aplikacionet më poshtë. Lejohen vetëm versionet e radhitur më poshtë për këta "
+"aplikacione."
 
-#: src/olympia/applications/templates/applications/appversions.html:25
+#: src/olympia/applications/templates/applications/appversions.html:25 src/olympia/editors/helpers.py:361
 msgid "GUID"
 msgstr "GUID"
 
 #. {0} is an add-on name.
-#: src/olympia/applications/templates/applications/appversions.html:26
-#: src/olympia/versions/templates/versions/version_list.html:23
+#: src/olympia/applications/templates/applications/appversions.html:26 src/olympia/versions/templates/versions/version_list.html:23
 msgid "Versions"
 msgstr "Versione"
 
@@ -2728,14 +2136,8 @@ msgstr "http://developer.mozilla.org/en/docs/Install_Manifests"
 
 #: src/olympia/applications/templates/applications/appversions.html:31
 #, python-format
-msgid ""
-"If your supported application does not require a manifest file, you still "
-"must include one with the required properties as specified <a "
-"href=\"%(url)s\">here</a>."
-msgstr ""
-"Edhe po qe se aplikacioni juaj nuk kërkon domosdo një kartelë manifest, "
-"prapë duhet ta përfshini një të tillë me vetitë e domosdoshme, siç tregohet "
-"<a href=\"%(url)s\">këtu</a>."
+msgid "If your supported application does not require a manifest file, you still must include one with the required properties as specified <a href=\"%(url)s\">here</a>."
+msgstr "Edhe po qe se aplikacioni juaj nuk kërkon domosdo një kartelë manifest, prapë duhet ta përfshini një të tillë me vetitë e domosdoshme, siç tregohet <a href=\"%(url)s\">këtu</a>."
 
 #. L10n: {0} is 'Add-ons for <app>'.
 #: src/olympia/bandwagon/feeds.py:44
@@ -2743,13 +2145,9 @@ msgstr ""
 msgid "Collections :: %s"
 msgstr "Koleksione :: %s"
 
-#: src/olympia/bandwagon/feeds.py:50
-#: src/olympia/bandwagon/templates/bandwagon/collection_detail.html:137
-msgid ""
-"Collections are groups of related add-ons that anyone can create and share."
-msgstr ""
-"Koleksionet janë grupe shtesash të ngjashme, të cilët mund t’i krijojë dhe "
-"shkëmbejë cilido."
+#: src/olympia/bandwagon/feeds.py:50 src/olympia/bandwagon/templates/bandwagon/collection_detail.html:137
+msgid "Collections are groups of related add-ons that anyone can create and share."
+msgstr "Koleksionet janë grupe shtesash të ngjashme, të cilët mund t’i krijojë dhe shkëmbejë cilido."
 
 #. L10n: {0} is a collection name, {1} is 'Add-ons for <app>'.
 #: src/olympia/bandwagon/feeds.py:70
@@ -2804,8 +2202,7 @@ msgstr "Kjo url përdoret tashmë nga një tjetër koleksion"
 msgid "Icons must be either PNG or JPG."
 msgstr "Ikonat duhet të jenë ose PNG. ose JPG."
 
-#: src/olympia/bandwagon/forms.py:202 src/olympia/devhub/views.py:1067
-#: src/olympia/users/forms.py:476
+#: src/olympia/bandwagon/forms.py:202 src/olympia/devhub/views.py:1067 src/olympia/users/forms.py:476
 #, python-format
 msgid "Please use images smaller than %dMB."
 msgstr "Ju lutemi, përdorni figura më të vogla se %dMB."
@@ -2826,8 +2223,7 @@ msgstr "Hiqe votën time nga kjo përmbledhje"
 msgid "Log in to vote for this collection"
 msgstr "Hyni, që të votoni për këtë koleksion"
 
-#: src/olympia/bandwagon/helpers.py:123
-#: src/olympia/bandwagon/templates/bandwagon/favorites_widget.html:2
+#: src/olympia/bandwagon/helpers.py:123 src/olympia/bandwagon/templates/bandwagon/favorites_widget.html:2
 msgid "Add to favorites"
 msgstr "Shtojeni te të parapëlqyerat"
 
@@ -2836,20 +2232,13 @@ msgstr "Shtojeni te të parapëlqyerat"
 msgid "Favorite"
 msgstr "E parapëlqyer"
 
-#: src/olympia/bandwagon/helpers.py:124
-#: src/olympia/bandwagon/templates/bandwagon/favorites_widget.html:2
+#: src/olympia/bandwagon/helpers.py:124 src/olympia/bandwagon/templates/bandwagon/favorites_widget.html:2
 msgid "Remove from favorites"
 msgstr "Hiqe prej të parapëlqyerave"
 
-#: src/olympia/bandwagon/views.py:98 src/olympia/bandwagon/views.py:191
-#: src/olympia/browse/views.py:58 src/olympia/browse/views.py:69
-#: src/olympia/browse/views.py:458 src/olympia/devhub/views.py:74
-#: src/olympia/devhub/views.py:82
-#: src/olympia/devhub/templates/devhub/addons/edit/basic.html:20
-#: src/olympia/editors/templates/editors/leaderboard.html:24
-#: src/olympia/editors/templates/editors/themes/queue_list.html:48
-#: src/olympia/search/forms.py:17 src/olympia/search/forms.py:89
-#: src/olympia/users/templates/users/vcard.html:5
+#: src/olympia/bandwagon/views.py:98 src/olympia/bandwagon/views.py:191 src/olympia/browse/views.py:58 src/olympia/browse/views.py:69 src/olympia/browse/views.py:425 src/olympia/devhub/views.py:72
+#: src/olympia/devhub/views.py:80 src/olympia/devhub/templates/devhub/addons/edit/basic.html:20 src/olympia/editors/templates/editors/leaderboard.html:24
+#: src/olympia/editors/templates/editors/themes/queue_list.html:48 src/olympia/search/forms.py:17 src/olympia/search/forms.py:89 src/olympia/users/templates/users/vcard.html:5
 msgid "Name"
 msgstr "Emër"
 
@@ -2857,8 +2246,7 @@ msgstr "Emër"
 msgid "Recently Popular"
 msgstr "Popullore Së Fundmi"
 
-#: src/olympia/bandwagon/views.py:189
-#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:18
+#: src/olympia/bandwagon/views.py:189 src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:16
 msgid "Added"
 msgstr "U shtua"
 
@@ -2872,12 +2260,8 @@ msgstr "Koleksioni u krijua!"
 
 #: src/olympia/bandwagon/views.py:316
 #, python-format
-msgid ""
-"Your new collection is shown below. You can <ahref=\"%(url)s\">edit "
-"additional settings</a> if you'dlike."
+msgid "Your new collection is shown below. You can <a href=\"%(url)s\">edit additional settings</a> if you'd like."
 msgstr ""
-"Koleksioni juaj i ri tregohet më poshtë. Nëse doni, mund të <a "
-"href=\"%(url)s\">përpunoni rregullimet e tjera</a>."
 
 #: src/olympia/bandwagon/views.py:322
 msgid "Collection updated!"
@@ -2892,31 +2276,20 @@ msgstr "<a href=\"%(url)s\">Shihni koleksionin tuaj</a> që të shihni ndryshime
 msgid "Icon Deleted"
 msgstr "Ikona u Fshi"
 
-#: src/olympia/bandwagon/templates/bandwagon/add.html:3
-#: src/olympia/bandwagon/templates/bandwagon/add.html:11
-#: src/olympia/bandwagon/templates/bandwagon/includes/collection_sidebar.html:26
+#: src/olympia/bandwagon/templates/bandwagon/add.html:3 src/olympia/bandwagon/templates/bandwagon/add.html:11 src/olympia/bandwagon/templates/bandwagon/includes/collection_sidebar.html:26
 msgid "Create a New Collection"
 msgstr "Krijoni një Koleksion të Ri"
 
-#: src/olympia/bandwagon/templates/bandwagon/add.html:9
-#: src/olympia/devhub/templates/devhub/personas/submit.html:14
+#: src/olympia/bandwagon/templates/bandwagon/add.html:9 src/olympia/devhub/templates/devhub/personas/submit.html:14
 msgid "Create"
 msgstr "Krijoje"
 
-#: src/olympia/bandwagon/templates/bandwagon/add.html:24
-#: src/olympia/bandwagon/templates/bandwagon/ajax_new.html:28
+#: src/olympia/bandwagon/templates/bandwagon/add.html:24 src/olympia/bandwagon/templates/bandwagon/ajax_new.html:28
 #, python-format
-msgid ""
-"As noted in our <a href=\"%(legal)s\">Legal Notices</a>, individual "
-"collection arrangements are governed by the Creative Commons Attribution "
-"Share-Alike License"
-msgstr ""
-"Siç edhe shënohet te <a href=\"%(legal)s\">Shënimet tona Ligjore</a>, "
-"marrëveshjet për koleksione individuale u binden një licence Creative "
-"Commons Attribution Share-Alike License"
+msgid "As noted in our <a href=\"%(legal)s\">Legal Notices</a>, individual collection arrangements are governed by the Creative Commons Attribution Share-Alike License"
+msgstr "Siç edhe shënohet te <a href=\"%(legal)s\">Shënimet tona Ligjore</a>, marrëveshjet për koleksione individuale u binden një licence Creative Commons Attribution Share-Alike License"
 
-#: src/olympia/bandwagon/templates/bandwagon/add.html:33
-#: src/olympia/bandwagon/templates/bandwagon/ajax_new.html:38
+#: src/olympia/bandwagon/templates/bandwagon/add.html:33 src/olympia/bandwagon/templates/bandwagon/ajax_new.html:38
 msgid "Create Collection"
 msgstr "Krijoni një Koleksion"
 
@@ -2932,8 +2305,7 @@ msgstr "Filloni një koleksion të ri..."
 msgid "Start a New Collection"
 msgstr "Filloni një Koleksion të Ri"
 
-#: src/olympia/bandwagon/templates/bandwagon/ajax_new.html:6
-#: src/olympia/bandwagon/templates/bandwagon/includes/addedit.html:7
+#: src/olympia/bandwagon/templates/bandwagon/ajax_new.html:6 src/olympia/bandwagon/templates/bandwagon/includes/addedit.html:7
 msgid "Name:"
 msgstr "Emër:"
 
@@ -2944,18 +2316,13 @@ msgstr "ose <a id=\"collections-new-cancel\" href=\"#\">Anulojeni</a>"
 #. Link to remove a collection vote
 #: src/olympia/bandwagon/templates/bandwagon/barometer.html:15
 msgid "To rate collections, you must have an add-ons account."
-msgstr ""
-"Që të jepni vlerësim për këtë shtesë, duhet të keni një llogari shtesash."
+msgstr "Që të jepni vlerësim për këtë shtesë, duhet të keni një llogari shtesash."
 
-#: src/olympia/bandwagon/templates/bandwagon/barometer.html:18
-#: src/olympia/templates/base.html:145
-#: src/olympia/templates/impala/base.html:198
+#: src/olympia/bandwagon/templates/bandwagon/barometer.html:18 src/olympia/templates/base.html:145 src/olympia/templates/impala/base.html:198
 msgid "Create an Add-ons Account"
 msgstr "Krijoni një Llogari Shtesash"
 
-#: src/olympia/bandwagon/templates/bandwagon/barometer.html:21
-#: src/olympia/templates/base.html:148
-#: src/olympia/templates/impala/base.html:201
+#: src/olympia/bandwagon/templates/bandwagon/barometer.html:21 src/olympia/templates/base.html:148 src/olympia/templates/impala/base.html:201
 #, python-format
 msgid "or <a href=\"%(login)s\">log in to your current account</a>"
 msgstr "ose <a href=\"%(login)s\">hyni te llogaria juaj e tanishme</a>"
@@ -2968,8 +2335,7 @@ msgstr "{0} :: Koleksione"
 msgid "private"
 msgstr "vetjake"
 
-#: src/olympia/bandwagon/templates/bandwagon/collection_detail.html:45
-#: src/olympia/bandwagon/templates/bandwagon/mobile/listing_items.html:9
+#: src/olympia/bandwagon/templates/bandwagon/collection_detail.html:45 src/olympia/bandwagon/templates/bandwagon/mobile/listing_items.html:9
 #, python-format
 msgid "<span>%(num)s</span> follower"
 msgid_plural "<span>%(num)s</span> followers"
@@ -3004,8 +2370,7 @@ msgstr "Më tepër Mundësi:"
 msgid "Edit Collection"
 msgstr "Përpunoni Koleksionin"
 
-#: src/olympia/bandwagon/templates/bandwagon/collection_detail.html:88
-#: src/olympia/bandwagon/templates/bandwagon/includes/delete.html:3
+#: src/olympia/bandwagon/templates/bandwagon/collection_detail.html:88 src/olympia/bandwagon/templates/bandwagon/includes/delete.html:3
 msgid "Delete Collection"
 msgstr "Fshije Koleksionin"
 
@@ -3023,12 +2388,8 @@ msgid_plural "%(num)s Add-ons in this Collection"
 msgstr[0] "%(num)s Shtesë në këtë Koleksion"
 msgstr[1] "%(num)s Shtesa në këtë Koleksion"
 
-#: src/olympia/bandwagon/templates/bandwagon/collection_detail.html:125
-#: src/olympia/compat/templates/compat/index.html:25
-#: src/olympia/compat/templates/compat/reporter_detail.html:29
-#: src/olympia/files/templates/files/viewer.html:29
-#: src/olympia/templates/amo_footer.html:17
-#: src/olympia/templates/includes/lang_switcher.html:10
+#: src/olympia/bandwagon/templates/bandwagon/collection_detail.html:125 src/olympia/compat/templates/compat/reporter_detail.html:29 src/olympia/files/templates/files/viewer.html:29
+#: src/olympia/templates/amo_footer.html:17 src/olympia/templates/includes/lang_switcher.html:10
 msgid "Go"
 msgstr "Shko"
 
@@ -3054,29 +2415,17 @@ msgstr "Shihni krejt koleksionet nga ky përdorues"
 
 #: src/olympia/bandwagon/templates/bandwagon/collection_detail.html:179
 msgid ""
-"Add-ons that you mark as favorites using the <b>Add to Favorites</b> feature"
-" appear below. This collection is currently <b>public</b>, which means "
-"everyone can see it. If you would like to hide it from public view, click "
-"the button below to make it private."
+"Add-ons that you mark as favorites using the <b>Add to Favorites</b> feature appear below. This collection is currently <b>public</b>, which means everyone can see it. If you would like to hide it "
+"from public view, click the button below to make it private."
 msgstr ""
-"Shtesat që i shënoni si të parapëlqyera duke përdorur funksionin <b>Shtoje "
-"te Të parapëlqyerat</b> shfaqen më poshtë. Ky koleksion tani është "
-"<b>publik</b>, që do të thotë se mund ta shohë kushdo. Nëse do të donit ta "
-"fshihni nga sytë e publikut, klikoni mbi butonin më poshtë, që ta bëni "
-"privat."
+"Shtesat që i shënoni si të parapëlqyera duke përdorur funksionin <b>Shtoje te Të parapëlqyerat</b> shfaqen më poshtë. Ky koleksion tani është <b>publik</b>, që do të thotë se mund ta shohë kushdo. "
+"Nëse do të donit ta fshihni nga sytë e publikut, klikoni mbi butonin më poshtë, që ta bëni privat."
 
 #: src/olympia/bandwagon/templates/bandwagon/collection_detail.html:186
 msgid ""
-"Add-ons that you mark as favorites using the <b>Add to Favorites</b> feature"
-" appear below. This collection is currently <b>private</b>, which means only"
-" you can see it.  If you would like everyone to be able to see your "
-"favorites, click the button below to make it public."
+"Add-ons that you mark as favorites using the <b>Add to Favorites</b> feature appear below. This collection is currently <b>private</b>, which means only you can see it.  If you would like everyone "
+"to be able to see your favorites, click the button below to make it public."
 msgstr ""
-"Shtesat që i shënoni si të parapëlqyera duke përdorur funksionin <b>Shtoje "
-"te Të parapëlqyerat</b> shfaqen më poshtë. Ky koleksion tani është "
-"<b>privat</b>, që do të thotë se mund ta shihni vetëm ju. Nëse do të donit "
-"që gjithkush të ishte në gjendje të shihte të parapëlqyerat tuaja, klikoni "
-"mbi butonin më poshtë, që ta bëni publik."
 
 #: src/olympia/bandwagon/templates/bandwagon/collection_detail.html:196
 msgid "My favorite add-ons"
@@ -3096,20 +2445,18 @@ msgid_plural "<span>%(followers)s</span> followers"
 msgstr[0] "<span>%(followers)s</span> ndjekës"
 msgstr[1] "<span>%(followers)s</span> ndjekës"
 
-#. People "follow" collections to get notified of updates.
-#. Like
+#. People "follow" collections to get notified of updates.                    Like
 #. Twitter followers.
+#. People "follow" collections to get notified of updates.
 #. Like Twitter followers.
-#: src/olympia/bandwagon/templates/bandwagon/collection_listing_items.html:10
-#: src/olympia/bandwagon/templates/bandwagon/impala/collection_listing_items.html:18
+#: src/olympia/bandwagon/templates/bandwagon/collection_listing_items.html:10 src/olympia/bandwagon/templates/bandwagon/impala/collection_listing_items.html:18
 #, python-format
 msgid "%(num)s weekly follower"
 msgid_plural "%(num)s weekly followers"
 msgstr[0] "%(num)s ndjekës javor"
 msgstr[1] "%(num)s ndjekës javorë"
 
-#. People "follow" collections to get notified of updates.
-#. Like
+#. People "follow" collections to get notified of updates.                    Like
 #. Twitter followers.
 #: src/olympia/bandwagon/templates/bandwagon/collection_listing_items.html:18
 #, python-format
@@ -3118,32 +2465,28 @@ msgid_plural "%(num)s monthly followers"
 msgstr[0] "%(num)s ndjekës mujor"
 msgstr[1] "%(num)s ndjekës mujorë"
 
-#. People "follow" collections to get notified of updates.
-#. Like
+#. People "follow" collections to get notified of updates.                    Like
 #. Twitter followers.
+#. People "follow" collections to get notified of updates.
 #. Like Twitter followers.
-#: src/olympia/bandwagon/templates/bandwagon/collection_listing_items.html:26
-#: src/olympia/bandwagon/templates/bandwagon/impala/collection_listing_items.html:26
+#: src/olympia/bandwagon/templates/bandwagon/collection_listing_items.html:26 src/olympia/bandwagon/templates/bandwagon/impala/collection_listing_items.html:26
 #, python-format
 msgid "%(num)s follower"
 msgid_plural "%(num)s followers"
 msgstr[0] "%(num)s ndjekës"
 msgstr[1] "%(num)s ndjekës"
 
-#: src/olympia/bandwagon/templates/bandwagon/collection_listing_items.html:56
-#: src/olympia/bandwagon/templates/bandwagon/impala/collection_listing_items.html:9
+#: src/olympia/bandwagon/templates/bandwagon/collection_listing_items.html:56 src/olympia/bandwagon/templates/bandwagon/impala/collection_listing_items.html:9
 #: src/olympia/devhub/templates/devhub/personas/edit.html:27
 msgid "by {0}"
 msgstr "nga {0}"
 
-#: src/olympia/bandwagon/templates/bandwagon/collection_widgets.html:5
-#: src/olympia/bandwagon/templates/bandwagon/collection_widgets.html:7
+#: src/olympia/bandwagon/templates/bandwagon/collection_widgets.html:5 src/olympia/bandwagon/templates/bandwagon/collection_widgets.html:7
 #: src/olympia/bandwagon/templates/bandwagon/impala/collection_listing_items.html:53
 msgid "Stop Following"
 msgstr "Ndale Ndjekjen"
 
-#: src/olympia/bandwagon/templates/bandwagon/collection_widgets.html:6
-#: src/olympia/bandwagon/templates/bandwagon/collection_widgets.html:7
+#: src/olympia/bandwagon/templates/bandwagon/collection_widgets.html:6 src/olympia/bandwagon/templates/bandwagon/collection_widgets.html:7
 #: src/olympia/bandwagon/templates/bandwagon/impala/collection_listing_items.html:53
 msgid "Follow this Collection"
 msgstr "Ndiqe këtë Koleksion"
@@ -3153,16 +2496,12 @@ msgid "Edit this Collection"
 msgstr "Përpunojeni këtë Koleksion"
 
 #. %s is the name of the collection.
-#: src/olympia/bandwagon/templates/bandwagon/delete.html:4
-#: src/olympia/bandwagon/templates/bandwagon/delete.html:15
+#: src/olympia/bandwagon/templates/bandwagon/delete.html:4 src/olympia/bandwagon/templates/bandwagon/delete.html:15
 msgid "Delete {0}"
 msgstr "Fshije {0}"
 
-#: src/olympia/bandwagon/templates/bandwagon/delete.html:13
-#: src/olympia/devhub/templates/devhub/addons/listing/item_actions.html:14
-#: src/olympia/devhub/templates/devhub/addons/listing/item_actions_theme.html:28
-#: src/olympia/devhub/templates/devhub/versions/list.html:131
-#: src/olympia/devhub/templates/devhub/versions/list.html:149
+#: src/olympia/bandwagon/templates/bandwagon/delete.html:13 src/olympia/devhub/templates/devhub/addons/listing/item_actions.html:14
+#: src/olympia/devhub/templates/devhub/addons/listing/item_actions_theme.html:28 src/olympia/devhub/templates/devhub/versions/list.html:131 src/olympia/devhub/templates/devhub/versions/list.html:149
 #: src/olympia/devhub/templates/devhub/versions/list.html:166
 msgid "Delete"
 msgstr "Fshije"
@@ -3171,35 +2510,24 @@ msgstr "Fshije"
 msgid "Are you sure?"
 msgstr "Jeni i sigurt?"
 
-#: src/olympia/bandwagon/templates/bandwagon/delete.html:21
-#: src/olympia/devhub/templates/devhub/personas/edit.html:131
-#: src/olympia/devhub/templates/devhub/personas/edit.html:152
-#: src/olympia/devhub/templates/devhub/personas/edit.html:173
-#: src/olympia/devhub/templates/devhub/personas/submit.html:77
-#: src/olympia/devhub/templates/devhub/personas/submit.html:98
+#: src/olympia/bandwagon/templates/bandwagon/delete.html:21 src/olympia/devhub/templates/devhub/personas/edit.html:131 src/olympia/devhub/templates/devhub/personas/edit.html:152
+#: src/olympia/devhub/templates/devhub/personas/edit.html:173 src/olympia/devhub/templates/devhub/personas/submit.html:77 src/olympia/devhub/templates/devhub/personas/submit.html:98
 #: src/olympia/devhub/templates/devhub/personas/submit.html:119
 msgid "Yes"
 msgstr "Po"
 
-#: src/olympia/bandwagon/templates/bandwagon/delete.html:22
-#: src/olympia/devhub/templates/devhub/personas/edit.html:140
-#: src/olympia/devhub/templates/devhub/personas/edit.html:161
-#: src/olympia/devhub/templates/devhub/personas/edit.html:191
-#: src/olympia/devhub/templates/devhub/personas/submit.html:86
-#: src/olympia/devhub/templates/devhub/personas/submit.html:107
+#: src/olympia/bandwagon/templates/bandwagon/delete.html:22 src/olympia/devhub/templates/devhub/personas/edit.html:140 src/olympia/devhub/templates/devhub/personas/edit.html:161
+#: src/olympia/devhub/templates/devhub/personas/edit.html:191 src/olympia/devhub/templates/devhub/personas/submit.html:86 src/olympia/devhub/templates/devhub/personas/submit.html:107
 #: src/olympia/devhub/templates/devhub/personas/submit.html:137
 msgid "No"
 msgstr "Jo"
 
 #. {0} is the name of the collection.
-#: src/olympia/bandwagon/templates/bandwagon/edit.html:5
-#: src/olympia/bandwagon/templates/bandwagon/edit.html:21
+#: src/olympia/bandwagon/templates/bandwagon/edit.html:5 src/olympia/bandwagon/templates/bandwagon/edit.html:21
 msgid "Edit {0}"
 msgstr "Përpunoni {0}"
 
-#: src/olympia/bandwagon/templates/bandwagon/edit.html:29
-#: src/olympia/devhub/templates/devhub/addons/edit/details.html:20
-#: src/olympia/editors/templates/editors/themes/themes.html:62
+#: src/olympia/bandwagon/templates/bandwagon/edit.html:29 src/olympia/devhub/templates/devhub/addons/edit/details.html:20 src/olympia/editors/templates/editors/themes/themes.html:62
 msgid "Description"
 msgstr "Përshkrim"
 
@@ -3207,32 +2535,18 @@ msgstr "Përshkrim"
 msgid "Contributors & More"
 msgstr "Pjesëmarrës & Më tepër"
 
-#: src/olympia/bandwagon/templates/bandwagon/edit.html:54
-#: src/olympia/bandwagon/templates/bandwagon/edit.html:67
-#: src/olympia/bandwagon/templates/bandwagon/edit.html:82
-#: src/olympia/devhub/templates/devhub/addons/ajax_compat_update.html:35
-#: src/olympia/devhub/templates/devhub/addons/owner.html:59
-#: src/olympia/devhub/templates/devhub/addons/profile.html:42
-#: src/olympia/devhub/templates/devhub/addons/edit/admin.html:101
-#: src/olympia/devhub/templates/devhub/addons/edit/basic.html:152
-#: src/olympia/devhub/templates/devhub/addons/edit/details.html:85
-#: src/olympia/devhub/templates/devhub/addons/edit/support.html:67
-#: src/olympia/devhub/templates/devhub/addons/edit/technical.html:166
-#: src/olympia/devhub/templates/devhub/addons/forms_shared/media.html:149
-#: src/olympia/devhub/templates/devhub/payments/voluntary.html:64
-#: src/olympia/devhub/templates/devhub/personas/edit.html:35
-#: src/olympia/devhub/templates/devhub/personas/edit.html:304
-#: src/olympia/devhub/templates/devhub/versions/edit.html:139
-#: src/olympia/translations/templates/translations/trans-menu.html:48
+#: src/olympia/bandwagon/templates/bandwagon/edit.html:54 src/olympia/bandwagon/templates/bandwagon/edit.html:67 src/olympia/bandwagon/templates/bandwagon/edit.html:82
+#: src/olympia/devhub/templates/devhub/addons/ajax_compat_update.html:35 src/olympia/devhub/templates/devhub/addons/owner.html:59 src/olympia/devhub/templates/devhub/addons/profile.html:42
+#: src/olympia/devhub/templates/devhub/addons/edit/admin.html:101 src/olympia/devhub/templates/devhub/addons/edit/basic.html:152 src/olympia/devhub/templates/devhub/addons/edit/details.html:85
+#: src/olympia/devhub/templates/devhub/addons/edit/support.html:67 src/olympia/devhub/templates/devhub/addons/edit/technical.html:166
+#: src/olympia/devhub/templates/devhub/addons/forms_shared/media.html:149 src/olympia/devhub/templates/devhub/payments/voluntary.html:64 src/olympia/devhub/templates/devhub/personas/edit.html:35
+#: src/olympia/devhub/templates/devhub/personas/edit.html:304 src/olympia/devhub/templates/devhub/versions/edit.html:139 src/olympia/translations/templates/translations/trans-menu.html:48
 msgid "Save Changes"
 msgstr "Ruaji Ndryshimet"
 
 # <option> text in a <select> for Author role in an add-on.
-#: src/olympia/bandwagon/templates/bandwagon/edit_contributors.html:9
-#: src/olympia/bandwagon/templates/bandwagon/edit_contributors.html:12
-#: src/olympia/bandwagon/templates/bandwagon/edit_contributors.html:17
-#: src/olympia/bandwagon/templates/bandwagon/edit_contributors.html:58
-#: src/olympia/constants/base.py:134
+#: src/olympia/bandwagon/templates/bandwagon/edit_contributors.html:9 src/olympia/bandwagon/templates/bandwagon/edit_contributors.html:12
+#: src/olympia/bandwagon/templates/bandwagon/edit_contributors.html:17 src/olympia/bandwagon/templates/bandwagon/edit_contributors.html:58 src/olympia/constants/base.py:134
 msgid "Owner"
 msgstr "Pronar"
 
@@ -3244,10 +2558,8 @@ msgstr "Bëjeni Pronar"
 msgid "Remove this user as a contributor"
 msgstr "Hiqe këtë përdorues si pjesëmarrës"
 
-#: src/olympia/bandwagon/templates/bandwagon/edit_contributors.html:18
-#: src/olympia/bandwagon/templates/bandwagon/edit_contributors.html:43
-#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:20
-#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:48
+#: src/olympia/bandwagon/templates/bandwagon/edit_contributors.html:18 src/olympia/bandwagon/templates/bandwagon/edit_contributors.html:43
+#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:18 src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:46
 #: src/olympia/devhub/templates/devhub/addons/ajax_compat_update.html:19
 msgid "Remove"
 msgstr "Hiqe"
@@ -3258,24 +2570,15 @@ msgstr "Pjesëmarrës në Koleksion"
 
 #: src/olympia/bandwagon/templates/bandwagon/edit_contributors.html:26
 msgid ""
-"You can add multiple contributors to this collection.  A contributor can add"
-" and remove add-ons from this collection, but cannot change its name or "
-"description.  To add a contributor, enter their email in the box below. "
-"Contributors must have a Mozilla Add-ons account."
+"You can add multiple contributors to this collection.  A contributor can add and remove add-ons from this collection, but cannot change its name or description.  To add a contributor, enter their "
+"email in the box below. Contributors must have a Mozilla Add-ons account."
 msgstr ""
-"Mund të shtoni pjesëmarrës të shumtë te ky koleksion. Një pjesëmarrës mund "
-"të shtojë dhe të heqë shtesa prej këtij koleksioni, por nuk mund të "
-"ndryshojë emrin e tij apo përshkrimin për të. Që të shtoni një pjesëmarrës, "
-"jepni email-in e tij te kutia më poshtë. Pjesëmarrësit duhet të kenë një "
-"llogari te Shtesat e Mozilla-s."
 
 #: src/olympia/bandwagon/templates/bandwagon/edit_contributors.html:40
 msgid "User"
 msgstr "Përdorues"
 
-#: src/olympia/bandwagon/templates/bandwagon/edit_contributors.html:41
-#: src/olympia/devhub/templates/devhub/addons/edit/support.html:20
-#: src/olympia/users/templates/users/delete.html:49
+#: src/olympia/bandwagon/templates/bandwagon/edit_contributors.html:41 src/olympia/devhub/templates/devhub/addons/edit/support.html:20 src/olympia/users/templates/users/delete.html:49
 msgid "Email"
 msgstr "Email"
 
@@ -3301,28 +2604,14 @@ msgid "Admin Settings"
 msgstr "Rregullime Përgjegjësi"
 
 #: src/olympia/bandwagon/templates/bandwagon/edit_contributors.html:76
-msgid ""
-"<b>Warning:</b> By changing the owner of this collection, you will no longer"
-" be able to edit it. You will only be able to add and remove add-ons from "
-"it."
-msgstr ""
-"<b>Kujdes:</b> Duke ndryshuar të zotin e këtij koleksioni, s’do të jeni më "
-"në gjendje ta përpunoni. Do të jeni në gjendje vetëm të shtoni ose të hiqni "
-"prej tij shtesa."
+msgid "<b>Warning:</b> By changing the owner of this collection, you will no longer be able to edit it. You will only be able to add and remove add-ons from it."
+msgstr "<b>Kujdes:</b> Duke ndryshuar të zotin e këtij koleksioni, s’do të jeni më në gjendje ta përpunoni. Do të jeni në gjendje vetëm të shtoni ose të hiqni prej tij shtesa."
 
-#: src/olympia/bandwagon/templates/bandwagon/edit_contributors.html:83
-#: src/olympia/devhub/templates/devhub/addons/forms_shared/media.html:157
-#: src/olympia/devhub/templates/devhub/addons/submit/describe.html:69
-#: src/olympia/devhub/templates/devhub/addons/submit/license.html:60
-#: src/olympia/devhub/templates/devhub/addons/submit/upload.html:78
-#: src/olympia/devhub/templates/devhub/payments/tier.html:17
-#: src/olympia/editors/templates/editors/themes/themes.html:111
-#: src/olympia/editors/templates/editors/themes/themes.html:128
-#: src/olympia/editors/templates/editors/themes/themes.html:134
-#: src/olympia/editors/templates/editors/themes/themes.html:141
-#: src/olympia/users/templates/users/fxa_migration_prompt_content.html:10
-#: src/olympia/users/templates/users/login_form.html:42
-#: src/olympia/users/templates/users/mobile/login.html:57
+#: src/olympia/bandwagon/templates/bandwagon/edit_contributors.html:83 src/olympia/devhub/templates/devhub/addons/forms_shared/media.html:157
+#: src/olympia/devhub/templates/devhub/addons/submit/describe.html:69 src/olympia/devhub/templates/devhub/addons/submit/license.html:60 src/olympia/devhub/templates/devhub/addons/submit/upload.html:70
+#: src/olympia/devhub/templates/devhub/payments/tier.html:17 src/olympia/editors/templates/editors/themes/themes.html:111 src/olympia/editors/templates/editors/themes/themes.html:128
+#: src/olympia/editors/templates/editors/themes/themes.html:134 src/olympia/editors/templates/editors/themes/themes.html:141 src/olympia/users/templates/users/fxa_migration_prompt_content.html:10
+#: src/olympia/users/templates/users/login_form.html:42 src/olympia/users/templates/users/mobile/login.html:57
 msgid "Continue"
 msgstr "Vazhdo"
 
@@ -3361,18 +2650,12 @@ msgstr "Koleksione Popullore Së Fundmi"
 
 #: src/olympia/bandwagon/templates/bandwagon/impala/collection_listing.html:28
 #, python-format
-msgid ""
-"Collections are groups of related add-ons that anyone can create and share. "
-"Explore collections created by other users or <a href=\"%(url)s\">create "
-"your own</a>."
+msgid "Collections are groups of related add-ons that anyone can create and share. Explore collections created by other users or <a href=\"%(url)s\">create your own</a>."
 msgstr ""
-"Koleksionet janë grupe shtesash të ngjashme, të cilët mund t’i krijojë dhe "
-"shkëmbejë cilido. Eksploroni koleksione të krijuar nga përdorues të tjerë "
-"ose <a href=\"%(url)s\">krijoni një të tuajin</a>."
+"Koleksionet janë grupe shtesash të ngjashme, të cilët mund t’i krijojë dhe shkëmbejë cilido. Eksploroni koleksione të krijuar nga përdorues të tjerë ose <a href=\"%(url)s\">krijoni një të tuajin</"
+"a>."
 
-#: src/olympia/bandwagon/templates/bandwagon/impala/collection_listing.html:37
-#: src/olympia/browse/templates/browse/extensions.html:13
-#: src/olympia/browse/templates/browse/themes.html:14
+#: src/olympia/bandwagon/templates/bandwagon/impala/collection_listing.html:37 src/olympia/browse/templates/browse/extensions.html:13 src/olympia/browse/templates/browse/themes.html:14
 msgid "Subscribe"
 msgstr "Regjistrohuni"
 
@@ -3380,20 +2663,14 @@ msgstr "Regjistrohuni"
 msgid "Following"
 msgstr "Ndjekur Prej Jush"
 
-#: src/olympia/bandwagon/templates/bandwagon/impala/collection_sidebar.html:22
-#: src/olympia/bandwagon/templates/bandwagon/impala/collection_sidebar.html:28
+#: src/olympia/bandwagon/templates/bandwagon/impala/collection_sidebar.html:22 src/olympia/bandwagon/templates/bandwagon/impala/collection_sidebar.html:28
 #: src/olympia/bandwagon/templates/bandwagon/includes/collection_sidebar.html:32
 msgid "Create a Collection"
 msgstr "Krijoni një Koleksion"
 
-#: src/olympia/bandwagon/templates/bandwagon/impala/collection_sidebar.html:23
-#: src/olympia/bandwagon/templates/bandwagon/includes/collection_sidebar.html:27
-msgid ""
-"Collections make it easy to keep track of favorite add-ons and share your "
-"perfectly customized browser with others."
-msgstr ""
-"Koleksionet e bëjnë të lehtë ndjekjen e shtesave të pëlqyera dhe shkëmbimin "
-"me të tjerët të mundësive për përshtatje të përsosur të shfletuesit tuaj."
+#: src/olympia/bandwagon/templates/bandwagon/impala/collection_sidebar.html:23 src/olympia/bandwagon/templates/bandwagon/includes/collection_sidebar.html:27
+msgid "Collections make it easy to keep track of favorite add-ons and share your perfectly customized browser with others."
+msgstr "Koleksionet e bëjnë të lehtë ndjekjen e shtesave të pëlqyera dhe shkëmbimin me të tjerët të mundësive për përshtatje të përsosur të shfletuesit tuaj."
 
 #: src/olympia/bandwagon/templates/bandwagon/includes/addedit.html:42
 msgid "Collection Icon"
@@ -3406,51 +2683,41 @@ msgstr "Rimerre"
 #: src/olympia/bandwagon/templates/bandwagon/includes/addedit.html:53
 msgid "PNG and JPG supported.  Image will be resized to 32x32."
 msgstr ""
-"Mbulohen PNG-të dhe JPG-të. Figura do të ripërmasohet në 32x32 piksela."
 
 #: src/olympia/bandwagon/templates/bandwagon/includes/addedit_errors.html:3
 msgid "There are errors in this form.  Please correct them below."
-msgstr "Në këtë formular ka gabime. Ju lutemi, ndreqini më poshtë."
+msgstr ""
 
 #: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:2
 msgid "Add-ons in Your Collection"
 msgstr "Shtesa në Koleksionin Tuaj"
 
 #: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:4
-msgid ""
-"To include an add-on in this collection, enter its name in the box below and"
-" hit enter.  You can also use the <strong>Add to Collection</strong> links "
-"throughout the site to include add-ons later."
+msgid "To include an add-on in this collection, enter its name in the box below and hit enter."
 msgstr ""
-"Për përfshirjen e një shtese në këtë koleksion, jepni emrin e saj te kutiza "
-"më poshtë dhe shtypni Enter. Mundeni gjithashtu të përdorni lidhjet "
-"<strong>Shtojeni në Koleksion</strong>, nëpër sajt, për ta përfshirë shtesën"
-" më vonë."
 
-#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:17
-#: src/olympia/constants/base.py:400
-#: src/olympia/devhub/templates/devhub/addons/activity.html:62
+#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:15 src/olympia/constants/base.py:400 src/olympia/devhub/templates/devhub/addons/activity.html:62
+#: src/olympia/editors/helpers.py:273 src/olympia/editors/helpers.py:360
 msgid "Add-on"
 msgstr "Shtesë"
 
-#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:26
+#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:24
 msgid "Enter the name of the add-on to include"
 msgstr "Jepni emrin e shtesës që duhet përfshirë"
 
-#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:28
+#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:26
 msgid "Add to Collection"
 msgstr "Shtojeni në Koleksion"
 
-#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:45
-#: src/olympia/editors/helpers.py:936 src/olympia/editors/helpers.py:956
+#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:43 src/olympia/editors/helpers.py:1016 src/olympia/editors/helpers.py:1036
 msgid "Pending"
 msgstr "Në pritje"
 
-#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:47
+#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:45
 msgid "Add a comment"
 msgstr "Shtoni një koment"
 
-#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:48
+#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:46
 msgid "Remove this add-on from the collection"
 msgstr "Hiqe këtë shtesë prej koleksionit"
 
@@ -3462,14 +2729,11 @@ msgstr "KOLEKSIONE"
 msgid "Groups of related add-ons that anyone can create."
 msgstr "Grupe shtesash të ngjashme, të cilët mund t’i krijojë cilido."
 
-#: src/olympia/blocklist/templates/blocklist/blocked_detail.html:3
-#: src/olympia/blocklist/templates/blocklist/blocked_list.html:3
-#: src/olympia/blocklist/templates/blocklist/blocked_list.html:10
+#: src/olympia/blocklist/templates/blocklist/blocked_detail.html:3 src/olympia/blocklist/templates/blocklist/blocked_list.html:3 src/olympia/blocklist/templates/blocklist/blocked_list.html:10
 msgid "Blocked Add-ons"
 msgstr "Shtesa të Bllokuara"
 
-#: src/olympia/blocklist/templates/blocklist/blocked_detail.html:8
-#: src/olympia/blocklist/templates/blocklist/blocked_list.html:6
+#: src/olympia/blocklist/templates/blocklist/blocked_detail.html:8 src/olympia/blocklist/templates/blocklist/blocked_list.html:6
 msgid "Blocklist"
 msgstr "Listë bllokimesh"
 
@@ -3491,42 +2755,24 @@ msgid "What does this mean?"
 msgstr "Ç’do të thotë kjo?"
 
 #: src/olympia/blocklist/templates/blocklist/blocked_detail.html:22
-msgid ""
-"Users are strongly encouraged to disable the problematic add-on or plugin, "
-"but may choose to continue using it if they accept the risks described."
-msgstr ""
-"I nxisim me forcë përdoruesit të çaktivizojnë shtesa ose shtojca "
-"problematike, por mund të zgjedhin vazhdimin e përdorimit të tyre, nëse "
-"pranojnë rreziqet e përshkruara."
+msgid "Users are strongly encouraged to disable the problematic add-on or plugin, but may choose to continue using it if they accept the risks described."
+msgstr "I nxisim me forcë përdoruesit të çaktivizojnë shtesa ose shtojca problematike, por mund të zgjedhin vazhdimin e përdorimit të tyre, nëse pranojnë rreziqet e përshkruara."
 
 #: src/olympia/blocklist/templates/blocklist/blocked_detail.html:27
-msgid ""
-"The problematic add-on or plugin will be automatically disabled and no "
-"longer usable."
-msgstr ""
-"Shtesat ose shtojcat problematike do të çaktivizohen vetvetiu dhe s’do të "
-"jenë më të përdorshme."
+msgid "The problematic add-on or plugin will be automatically disabled and no longer usable."
+msgstr "Shtesat ose shtojcat problematike do të çaktivizohen vetvetiu dhe s’do të jenë më të përdorshme."
 
 #: src/olympia/blocklist/templates/blocklist/blocked_detail.html:33
 #, python-format
 msgid ""
-"When Mozilla becomes aware of add-ons, plugins, or other third-party "
-"software that seriously compromises %(app)s security, stability, or "
-"performance and meets <a href=\"%(criteria)s\">certain criteria</a>, the "
-"software may be blocked from general use.  For more information, please read"
-" <a href=\"%(support)s\">this support article</a>."
+"When Mozilla becomes aware of add-ons, plugins, or other third-party software that seriously compromises %(app)s security, stability, or performance and meets <a href=\"%(criteria)s\">certain "
+"criteria</a>, the software may be blocked from general use.  For more information, please read <a href=\"%(support)s\">this support article</a>."
 msgstr ""
-"Kur Mozilla vihet në dijeni rreth një shtese, shtojce, ose software-i nga "
-"palë të treta që prek seriozisht sigurinë, qëndrueshmërinë, ose punimin e "
-"%(app)s, dhe që plotëson <a href=\"%(criteria)s\">disa kushte</a>, software-"
-"it mund t’i bllokohet përdorimi në masë. Për më tepër të dhëna, ju lutemi, "
-"lexoni <a href=\"%(support)s\">këtë artikull asistence</a>."
 
 #: src/olympia/blocklist/templates/blocklist/blocked_detail.html:44
 #, python-format
 msgid "Blocked on %(date)s. <a href=\"%(link)s\">View block request</a>."
-msgstr ""
-"Bllokuar më %(date)s. <a href=\"%(link)s\">Shihni kërkesën për bllokim</a>."
+msgstr "Bllokuar më %(date)s. <a href=\"%(link)s\">Shihni kërkesën për bllokim</a>."
 
 #: src/olympia/blocklist/templates/blocklist/blocked_detail.html:48
 #, python-format
@@ -3534,12 +2780,8 @@ msgid "Blocked on %(date)s."
 msgstr "Bllokuar më %(date)s."
 
 #: src/olympia/blocklist/templates/blocklist/blocked_list.html:11
-msgid ""
-"The following software is known to cause serious security, stability, or "
-"performance issues with {app}."
-msgstr ""
-"Software-i vijues dihet se shkakton probleme serioze sigurie, qëndrueshmërie"
-" ose funksionimi me {app}."
+msgid "The following software is known to cause serious security, stability, or performance issues with {app}."
+msgstr "Software-i vijues dihet se shkakton probleme serioze sigurie, qëndrueshmërie ose funksionimi me {app}."
 
 #. L10n: %s is a category name.
 #: src/olympia/browse/feeds.py:76 src/olympia/browse/feeds.py:98
@@ -3561,11 +2803,8 @@ msgstr "Shtesa të Zgjedhura :: %s"
 #. L10n: %s is an app name.
 #: src/olympia/browse/feeds.py:138
 #, python-format
-msgid ""
-"Here's a few of our favorite add-ons to help you get started customizing %s."
-msgstr ""
-"Ja pak nga shtesat tona të parapëlqyera, për t’ju ndihur t’ia filloni "
-"përshtatjes së %s-it."
+msgid "Here's a few of our favorite add-ons to help you get started customizing %s."
+msgstr "Ja pak nga shtesat tona të parapëlqyera, për t’ju ndihur t’ia filloni përshtatjes së %s-it."
 
 #. L10n: %s is a category name.
 #: src/olympia/browse/feeds.py:157
@@ -3581,43 +2820,28 @@ msgstr "Mjete kërkimi dhe zgjerime të lidhura me kërkimin"
 msgid "Search tools"
 msgstr "Mjete kërkimi"
 
-#: src/olympia/browse/views.py:55 src/olympia/browse/views.py:65
-#: src/olympia/search/forms.py:85
+#: src/olympia/browse/views.py:55 src/olympia/browse/views.py:65 src/olympia/search/forms.py:85
 msgid "Most Users"
 msgstr "Shumica e Përdoruesve"
 
-#: src/olympia/browse/views.py:61 src/olympia/browse/views.py:72
-#: src/olympia/browse/views.py:279
-#: src/olympia/browse/templates/browse/personas/mobile/category_landing.html:63
-#: src/olympia/discovery/templates/discovery/pane.html:67
-#: src/olympia/search/forms.py:92
+#: src/olympia/browse/views.py:61 src/olympia/browse/views.py:72 src/olympia/browse/views.py:246 src/olympia/browse/templates/browse/personas/mobile/category_landing.html:63
+#: src/olympia/discovery/templates/discovery/pane.html:67 src/olympia/search/forms.py:92
 msgid "Up & Coming"
 msgstr "Premtuese"
 
-#: src/olympia/browse/views.py:460 src/olympia/devhub/views.py:76
-#: src/olympia/devhub/views.py:83
-#: src/olympia/discovery/templates/discovery/addons/detail.html:66
+#: src/olympia/browse/views.py:427 src/olympia/devhub/views.py:74 src/olympia/devhub/views.py:81 src/olympia/discovery/templates/discovery/addons/detail.html:66
 msgid "Created"
 msgstr "U krijua"
 
 #. {0} is the category name. Ex: Sports
-#: src/olympia/browse/templates/browse/creatured.html:5
-#: src/olympia/browse/templates/browse/creatured.html:13
+#: src/olympia/browse/templates/browse/creatured.html:5 src/olympia/browse/templates/browse/creatured.html:13
 msgid "{0}: Featured Add-ons"
 msgstr "{0}: Shtesa të Zgjedhura"
 
-#: src/olympia/browse/templates/browse/creatured.html:12
-#: src/olympia/browse/templates/browse/featured.html:4
-#: src/olympia/browse/templates/browse/featured.html:12
-#: src/olympia/browse/templates/browse/featured.html:13
-#: src/olympia/devhub/templates/devhub/docs/policies-recommended.html:3
-#: src/olympia/devhub/templates/devhub/docs/policies-recommended.html:7
-#: src/olympia/devhub/templates/devhub/docs/policies-recommended.html:9
-#: src/olympia/devhub/templates/devhub/docs/policies.html:21
-#: src/olympia/devhub/templates/devhub/docs/policies.html:90
-#: src/olympia/discovery/modules.py:341
-#: src/olympia/discovery/templates/discovery/pane.html:52
-#: src/olympia/templates/menu_links.html:7
+#: src/olympia/browse/templates/browse/creatured.html:12 src/olympia/browse/templates/browse/featured.html:4 src/olympia/browse/templates/browse/featured.html:12
+#: src/olympia/browse/templates/browse/featured.html:13 src/olympia/devhub/templates/devhub/docs/policies-recommended.html:3 src/olympia/devhub/templates/devhub/docs/policies-recommended.html:7
+#: src/olympia/devhub/templates/devhub/docs/policies-recommended.html:9 src/olympia/devhub/templates/devhub/docs/policies.html:21 src/olympia/devhub/templates/devhub/docs/policies.html:90
+#: src/olympia/discovery/modules.py:341 src/olympia/discovery/templates/discovery/pane.html:52 src/olympia/templates/menu_links.html:7
 msgid "Featured Add-ons"
 msgstr "Shtesa të Zgjedhura"
 
@@ -3628,12 +2852,8 @@ msgstr "Pa shtesa të përzgjedhura në {0}."
 
 #: src/olympia/browse/templates/browse/featured.html:15
 #, python-format
-msgid ""
-"Here's a few of our favorite add-ons to help you get started customizing "
-"%(app)s."
-msgstr ""
-"Ja disa nga shtesat tona të parapëlqyera për t’ju ndihmuar t’ia filloni me "
-"personalizimin e %(app)s-it."
+msgid "Here's a few of our favorite add-ons to help you get started customizing %(app)s."
+msgstr "Ja disa nga shtesat tona të parapëlqyera për t’ju ndihmuar t’ia filloni me personalizimin e %(app)s-it."
 
 #: src/olympia/browse/templates/browse/language_tools.html:9
 msgid "Install Dictionary"
@@ -3657,22 +2877,17 @@ msgstr "E passhme në gjuhën tuaj"
 
 #: src/olympia/browse/templates/browse/language_tools.html:38
 msgid "List of language packs and dictionaries available in your locale."
-msgstr ""
-"Listë paketash gjuhësore dhe fjalorësh që mund të kihen për vendoren tuaj."
+msgstr "Listë paketash gjuhësore dhe fjalorësh që mund të kihen për vendoren tuaj."
 
-#: src/olympia/browse/templates/browse/language_tools.html:41
-#: src/olympia/browse/templates/browse/language_tools.html:63
+#: src/olympia/browse/templates/browse/language_tools.html:41 src/olympia/browse/templates/browse/language_tools.html:63
 msgid "Language"
 msgstr "Gjuhë"
 
-#: src/olympia/browse/templates/browse/language_tools.html:42
-#: src/olympia/browse/templates/browse/language_tools.html:64
-#: src/olympia/constants/base.py:162
+#: src/olympia/browse/templates/browse/language_tools.html:42 src/olympia/browse/templates/browse/language_tools.html:64 src/olympia/constants/base.py:162
 msgid "Dictionary"
 msgstr "Fjalor"
 
-#: src/olympia/browse/templates/browse/language_tools.html:43
-#: src/olympia/browse/templates/browse/language_tools.html:65
+#: src/olympia/browse/templates/browse/language_tools.html:43 src/olympia/browse/templates/browse/language_tools.html:65
 msgid "Language Pack"
 msgstr "Paketë Gjuhësore"
 
@@ -3690,8 +2905,7 @@ msgid "{0} :: Search Tools"
 msgstr "{0} :: Mjete Kërkimi"
 
 #. {0} is an integer.
-#: src/olympia/browse/templates/browse/search_tools.html:39
-#: src/olympia/devhub/templates/devhub/addons/dashboard.html:17
+#: src/olympia/browse/templates/browse/search_tools.html:39 src/olympia/devhub/templates/devhub/addons/dashboard.html:17
 msgid "<b>{0}</b> add-on"
 msgid_plural "<b>{0}</b> add-ons"
 msgstr[0] "<b>{0}</b> shtesë"
@@ -3719,35 +2933,18 @@ msgstr "Burime Shtesë"
 
 #. {0} is an app name, like Firefox.
 #: src/olympia/browse/templates/browse/search_tools.html:93
-msgid ""
-"Learn more about the <a "
-"href=\"http://support.mozilla.com/kb/Search+bar\">search bar</a> in {0}"
-msgstr ""
-"Mësoni më tepër rreth <a "
-"href=\"http://support.mozilla.com/kb/Search+bar\">shtyllës së kërkimeve</a> "
-"te {0}"
+msgid "Learn more about the <a href=\"http://support.mozilla.com/kb/Search+bar\">search bar</a> in {0}"
+msgstr "Mësoni më tepër rreth <a href=\"http://support.mozilla.com/kb/Search+bar\">shtyllës së kërkimeve</a> te {0}"
 
 #: src/olympia/browse/templates/browse/search_tools.html:94
-msgid ""
-"Browse through even more search providers at <a "
-"href=\"http://mycroft.mozdev.org/\">mycroft.mozdev.org</a>"
-msgstr ""
-"Shfletoni nëpër më tepër mundësues kërkimesh te <a "
-"href=\"http://mycroft.mozdev.org/\">mycroft.mozdev.org</a>"
+msgid "Browse through even more search providers at <a href=\"http://mycroft.mozdev.org/\">mycroft.mozdev.org</a>"
+msgstr "Shfletoni nëpër më tepër mundësues kërkimesh te <a href=\"http://mycroft.mozdev.org/\">mycroft.mozdev.org</a>"
 
 #: src/olympia/browse/templates/browse/search_tools.html:95
-msgid ""
-"<a "
-"href=\"https://developer.mozilla.org/en/Creating_OpenSearch_plugins_for_Firefox\">Make"
-" your own</a> search tool"
-msgstr ""
-"<a "
-"href=\"https://developer.mozilla.org/en/Creating_OpenSearch_plugins_for_Firefox\">Krijoni"
-" mjetin tuaj të kërkimeve</a>"
+msgid "<a href=\"https://developer.mozilla.org/en/Creating_OpenSearch_plugins_for_Firefox\">Make your own</a> search tool"
+msgstr "<a href=\"https://developer.mozilla.org/en/Creating_OpenSearch_plugins_for_Firefox\">Krijoni mjetin tuaj të kërkimeve</a>"
 
-#: src/olympia/browse/templates/browse/themes.html:6
-#: src/olympia/browse/templates/browse/themes.html:9
-#: src/olympia/constants/base.py:174
+#: src/olympia/browse/templates/browse/themes.html:6 src/olympia/browse/templates/browse/themes.html:9 src/olympia/constants/base.py:174
 msgid "Complete Themes"
 msgstr "Tema të Plota"
 
@@ -3820,24 +3017,17 @@ msgid_plural "See all %(cnt)s extensions in %(name)s &raquo;"
 msgstr[0] "Shihni zgjatimin %(cnt)s te %(name)s &raquo;"
 msgstr[1] "Shihni krejt zgjatimet %(cnt)s te %(name)s &raquo;"
 
-#: src/olympia/browse/templates/browse/mobile/extensions.html:13
-#: src/olympia/compat/templates/compat/index.html:82
-#: src/olympia/devhub/templates/devhub/devhub_search.html:24
-#: src/olympia/devhub/templates/devhub/addons/activity.html:47
-#: src/olympia/search/templates/search/no_results.html:4
-#: src/olympia/search/templates/search/mobile/results.html:36
+#: src/olympia/browse/templates/browse/mobile/extensions.html:13 src/olympia/devhub/templates/devhub/devhub_search.html:24 src/olympia/devhub/templates/devhub/addons/activity.html:47
+#: src/olympia/search/templates/search/no_results.html:4 src/olympia/search/templates/search/mobile/results.html:36
 msgid "No results found."
 msgstr "S’u gjetën përfundime."
 
-#: src/olympia/browse/templates/browse/personas/base.html:6
-#: src/olympia/browse/templates/browse/personas/mobile/base.html:7
+#: src/olympia/browse/templates/browse/personas/base.html:6 src/olympia/browse/templates/browse/personas/mobile/base.html:7
 msgid "{0} Themes"
 msgstr "{0} Tema"
 
 #. {0} is a user's name.
-#: src/olympia/browse/templates/browse/personas/base.html:15
-#: src/olympia/browse/templates/browse/personas/base.html:40
-#: src/olympia/browse/templates/browse/personas/grid.html:8
+#: src/olympia/browse/templates/browse/personas/base.html:15 src/olympia/browse/templates/browse/personas/base.html:40 src/olympia/browse/templates/browse/personas/grid.html:8
 msgid "{0}'s Themes"
 msgstr "Tema nga {0}"
 
@@ -3857,31 +3047,22 @@ msgstr "Shfletuesi juaj, në stilin tuaj! Stoliseni me një dizajn tuajin!"
 msgid "Learn more"
 msgstr "Mësoni më tepër"
 
-#: src/olympia/browse/templates/browse/personas/category_landing.html:6
-#: src/olympia/browse/templates/browse/personas/mobile/category_landing.html:5
+#: src/olympia/browse/templates/browse/personas/category_landing.html:6 src/olympia/browse/templates/browse/personas/mobile/category_landing.html:5
 msgid "View All Recently Added"
 msgstr "Shihni Krejt të Shtuarat së Fundmi"
 
-#: src/olympia/browse/templates/browse/personas/category_landing.html:7
-#: src/olympia/browse/templates/browse/personas/mobile/category_landing.html:6
+#: src/olympia/browse/templates/browse/personas/category_landing.html:7 src/olympia/browse/templates/browse/personas/mobile/category_landing.html:6
 msgid "View All Most Popular"
 msgstr "Shihni Krejt Më Populloret"
 
-#: src/olympia/browse/templates/browse/personas/category_landing.html:8
-#: src/olympia/browse/templates/browse/personas/mobile/category_landing.html:7
+#: src/olympia/browse/templates/browse/personas/category_landing.html:8 src/olympia/browse/templates/browse/personas/mobile/category_landing.html:7
 msgid "View All Top Rated"
 msgstr "Shihni Krejt Më të Vlerësuarat"
 
 #: src/olympia/browse/templates/browse/personas/category_landing.html:40
 #, python-format
-msgid ""
-"Over 300,000 designs to personalize your browser! Move your mouse over a "
-"Background Theme to try it on. <a href=\"%(url)s\" class=\"more-info\">Start"
-" exploring</a>"
-msgstr ""
-"Mbi 30000 skema të ndryshme që të personalizoni shfletuesin tuaj! Thjesht "
-"kalojini njërës kursorin përsipër që ta provoni. <a href=\"%(url)s\" class"
-"=\"more-info\">Filloni eksplorimin</a>"
+msgid "Over 300,000 designs to personalize your browser! Move your mouse over a Background Theme to try it on. <a href=\"%(url)s\" class=\"more-info\">Start exploring</a>"
+msgstr "Mbi 30000 skema të ndryshme që të personalizoni shfletuesin tuaj! Thjesht kalojini njërës kursorin përsipër që ta provoni. <a href=\"%(url)s\" class=\"more-info\">Filloni eksplorimin</a>"
 
 #: src/olympia/browse/templates/browse/personas/category_landing.html:47
 msgid "Want more personalization?"
@@ -3891,14 +3072,9 @@ msgstr "Doni më tepër personalizim?"
 #. theme.
 #: src/olympia/browse/templates/browse/personas/category_landing.html:50
 #, python-format
-msgid ""
-"Complete Themes transform the look of your browser with styles for the "
-"window frame, address bar, buttons, tabs, and menus. <a href=\"%(url)s\" "
-"class=\"more-info\">Start exploring</a>"
+msgid "Complete Themes transform the look of your browser with styles for the window frame, address bar, buttons, tabs, and menus. <a href=\"%(url)s\" class=\"more-info\">Start exploring</a>"
 msgstr ""
-"Tema e Plotë e shndërron pamjen e shfletuesit tuaj përmes stilesh për "
-"korniza dritaresh, shtyllë adresash, butona, skeda, dhe menu. <a "
-"href=\"%(url)s\" class=\"more-info\">Filloni t’i eksploroni</a>"
+"Tema e Plotë e shndërron pamjen e shfletuesit tuaj përmes stilesh për korniza dritaresh, shtyllë adresash, butona, skeda, dhe menu. <a href=\"%(url)s\" class=\"more-info\">Filloni t’i eksploroni</a>"
 
 #: src/olympia/browse/templates/browse/personas/category_landing.html:76
 msgid "Up & Coming Themes"
@@ -3928,7 +3104,7 @@ msgstr "&laquo; Krejt Temat"
 msgid "All"
 msgstr "Krejt"
 
-#: src/olympia/compat/forms.py:22 src/olympia/search/views.py:525
+#: src/olympia/compat/forms.py:22 src/olympia/editors/templates/editors/base.html:69 src/olympia/search/views.py:518
 msgid "All Add-ons"
 msgstr "Krejt Shtesat"
 
@@ -3940,93 +3116,32 @@ msgstr "Dyore"
 msgid "Non-binary"
 msgstr "Jo-dyore"
 
-#. Review points sources other than add-ons and themes.
-#: src/olympia/compat/views.py:87 src/olympia/constants/base.py:388
-#: src/olympia/devhub/forms.py:162
-#: src/olympia/editors/templates/editors/performance.html:75
-msgid "Other"
-msgstr "Tjetër"
-
-#: src/olympia/compat/templates/compat/index.html:4
-msgid "Add-on Compatibility Report for {app} {version}"
-msgstr "Raport Përputhshmërie Shtese për {app} {version}"
-
-#: src/olympia/compat/templates/compat/index.html:11
-msgid "{app} {version} Compatibility"
-msgstr "Përputhshmëri e {app} {version}"
-
-#: src/olympia/compat/templates/compat/index.html:17
-#, python-format
-msgid "Top 95%% compatible with previous version"
-msgstr "95%% kryesueset të përputhshme me versionin e mëparshëm"
-
-#: src/olympia/compat/templates/compat/index.html:18
-#, python-format
-msgid "Top 95%% of all add-ons"
-msgstr "95%% e krejt shtesave"
-
-#: src/olympia/compat/templates/compat/index.html:19
-msgid "All active add-ons"
-msgstr "Krejt shtesat aktive"
-
-#: src/olympia/compat/templates/compat/index.html:23
-#: src/olympia/constants/base.py:401
-msgid "App"
-msgstr "Zbt"
-
-#: src/olympia/compat/templates/compat/index.html:55
-msgid "Details for add-ons compatible with previous version:"
-msgstr "Hollësi mbi shtesa të përputhshme me versionin e mëparshëm:"
-
-#: src/olympia/compat/templates/compat/index.html:57
-msgid "Show all versions"
-msgstr "Shfaqi krejt versionet"
-
-#: src/olympia/compat/templates/compat/index.html:59
-msgid "Details for add-ons compatible with all versions:"
-msgstr "Hollësi mbi shtesa të përputhshme me krejt versionet:"
-
-#: src/olympia/compat/templates/compat/index.html:61
-msgid "Show previous version only"
-msgstr "Shfaq vetëm versionin e mëparshëm"
-
 #: src/olympia/compat/templates/compat/reporter.html:3
 msgid "Add-on Compatibility Reports"
 msgstr "Raporte Përputhshmërie Shtesash"
 
-#: src/olympia/compat/templates/compat/reporter.html:11
-#: src/olympia/compat/templates/compat/reporter_detail.html:35
+#: src/olympia/compat/templates/compat/reporter.html:11 src/olympia/compat/templates/compat/reporter_detail.html:35
 #, python-format
 msgid ""
-"<p> Reports submitted to us through the <a href=\"%(url_)s\">Add-on "
-"Compatibility Reporter</a> are collected here for developers to view. These "
-"reports help us determine which add-ons will need help supporting an "
-"upcoming Firefox version. </p>"
+"<p> Reports submitted to us through the <a href=\"%(url_)s\">Add-on Compatibility Reporter</a> are collected here for developers to view. These reports help us determine which add-ons will need "
+"help supporting an upcoming Firefox version. </p>"
 msgstr ""
-"<p> Njoftimet e parashtruara për ne përmes <a href=\"%(url_)s\">Njoftuesit "
-"të Përputhshmërisë së Shtesave</a> grumbullohen këtu që t’i shohin "
-"programuesit. Këto njoftime na ndihmojnë të përcaktojmë cilat shtesa kanë "
-"nevojë për ndihmë që të punojnë me një version të ardhshëm të Firefox-it. "
-"</p>"
+"<p> Njoftimet e parashtruara për ne përmes <a href=\"%(url_)s\">Njoftuesit të Përputhshmërisë së Shtesave</a> grumbullohen këtu që t’i shohin programuesit. Këto njoftime na ndihmojnë të përcaktojmë "
+"cilat shtesa kanë nevojë për ndihmë që të punojnë me një version të ardhshëm të Firefox-it. </p>"
 
 #: src/olympia/compat/templates/compat/reporter.html:18
 msgid "Reports for your Add-ons"
 msgstr "Raporte për Shtesën tuaj"
 
-#: src/olympia/compat/templates/compat/reporter.html:30
-#: src/olympia/compat/templates/compat/reporter_detail.html:9
+#: src/olympia/compat/templates/compat/reporter.html:30 src/olympia/compat/templates/compat/reporter_detail.html:9
 msgid "Add-on Compatibility Center"
 msgstr "Qendra e Përputhshmërisë së Shtesave"
 
 #: src/olympia/compat/templates/compat/reporter.html:34
 msgid "Enter the GUID of an add-on below to view any reports we've received."
-msgstr ""
-"Jepni më poshtë GUID-në e një shtese që të shihni çfarëdo raporti që kemi "
-"marrë."
+msgstr "Jepni më poshtë GUID-në e një shtese që të shihni çfarëdo raporti që kemi marrë."
 
-#: src/olympia/compat/templates/compat/reporter_detail.html:3
-#: src/olympia/compat/templates/compat/reporter_detail.html:10
-#: src/olympia/compat/templates/compat/reporter_detail.html:25
+#: src/olympia/compat/templates/compat/reporter_detail.html:3 src/olympia/compat/templates/compat/reporter_detail.html:10 src/olympia/compat/templates/compat/reporter_detail.html:25
 msgid "{addon} Compatibility Reports"
 msgstr "Njoftime Përputhshmërie për {addon}"
 
@@ -4042,8 +3157,7 @@ msgid_plural "{0} problem reports"
 msgstr[0] "{0} njoftim problemesh"
 msgstr[1] "{0} njoftime problemesh"
 
-#: src/olympia/compat/templates/compat/reporter_detail.html:21
-#: src/olympia/users/templates/users/profile.html:70
+#: src/olympia/compat/templates/compat/reporter_detail.html:21 src/olympia/users/templates/users/profile.html:70
 msgid "View all"
 msgstr "Shihini krejt"
 
@@ -4055,10 +3169,8 @@ msgstr "Filtroji sipas Aplikacionesh"
 msgid "Report Type"
 msgstr "Lloj Raporti"
 
-#: src/olympia/compat/templates/compat/reporter_detail.html:47
-#: src/olympia/devhub/forms.py:784
-#: src/olympia/devhub/templates/devhub/addons/ajax_compat_update.html:17
-#: src/olympia/editors/forms.py:108 src/olympia/zadmin/forms.py:45
+#: src/olympia/compat/templates/compat/reporter_detail.html:47 src/olympia/devhub/forms.py:785 src/olympia/devhub/templates/devhub/addons/ajax_compat_update.html:17 src/olympia/editors/forms.py:108
+#: src/olympia/editors/forms.py:248 src/olympia/zadmin/forms.py:45
 msgid "Application"
 msgstr "Aplikacion"
 
@@ -4070,8 +3182,7 @@ msgstr "Montim Aplikacioni"
 msgid "Platform"
 msgstr "Platformë"
 
-#: src/olympia/compat/templates/compat/reporter_detail.html:50
-#: src/olympia/editors/templates/editors/themes/themes.html:40
+#: src/olympia/compat/templates/compat/reporter_detail.html:50 src/olympia/editors/templates/editors/themes/themes.html:40
 msgid "Submitted"
 msgstr "U parashtrua"
 
@@ -4099,8 +3210,7 @@ msgstr "Thunderbird"
 msgid "SeaMonkey"
 msgstr "SeaMonkey"
 
-#: src/olympia/constants/applications.py:75
-#: src/olympia/pages/templates/pages/sunbird.html:4
+#: src/olympia/constants/applications.py:75 src/olympia/pages/templates/pages/sunbird.html:4
 msgid "Sunbird"
 msgstr "Sunbird"
 
@@ -4148,7 +3258,7 @@ msgstr "E shqyrtuar Paraprakisht"
 msgid "Preliminarily Reviewed and Awaiting Full Review"
 msgstr "Shqyrtuar Paraprakisht dhe Në Pritje të Shqyrtimit të Plotë"
 
-#: src/olympia/constants/base.py:33 src/olympia/editors/helpers.py:924
+#: src/olympia/constants/base.py:33 src/olympia/editors/forms.py:258 src/olympia/editors/helpers.py:73 src/olympia/editors/helpers.py:1004
 #: src/olympia/editors/templates/editors/themes/history_table.html:34
 msgid "Deleted"
 msgstr "Fshirë"
@@ -4182,13 +3292,11 @@ msgstr "Zhvillues"
 msgid "Viewer"
 msgstr "Parës"
 
-#: src/olympia/constants/base.py:137
-#: src/olympia/templates/mobile/header.html:7
+#: src/olympia/constants/base.py:137 src/olympia/templates/mobile/header.html:7
 msgid "Support"
 msgstr "Asistencë"
 
-#: src/olympia/constants/base.py:159 src/olympia/constants/base.py:172
-#: src/olympia/constants/platforms.py:10
+#: src/olympia/constants/base.py:159 src/olympia/constants/base.py:172 src/olympia/constants/platforms.py:10
 msgid "Any"
 msgstr "Çfarëdo"
 
@@ -4216,11 +3324,8 @@ msgstr "Paketë Gjuhësore (Shtesë)"
 msgid "Plugin"
 msgstr "Shtojcë"
 
-#: src/olympia/constants/base.py:167
-#: src/olympia/editors/templates/editors/includes/search_results_themes.html:5
-#: src/olympia/editors/templates/editors/themes/deleted.html:18
-#: src/olympia/editors/templates/editors/themes/history_table.html:8
-#: src/olympia/editors/templates/editors/themes/logs.html:17
+#: src/olympia/constants/base.py:167 src/olympia/editors/templates/editors/includes/search_results_themes.html:5 src/olympia/editors/templates/editors/themes/deleted.html:18
+#: src/olympia/editors/templates/editors/themes/history_table.html:8 src/olympia/editors/templates/editors/themes/logs.html:17
 msgid "Theme"
 msgstr "Temë"
 
@@ -4254,6 +3359,11 @@ msgstr "Pyet pasi përdoruesit të fillojnë ta shkarkojnë këtë shtesë"
 msgid "Ask before users can download this add-on"
 msgstr "Pyet përpara se përdoruesit të mund ta shkarkojnë këtë shtesë"
 
+#. Review points sources other than add-ons and themes.
+#: src/olympia/constants/base.py:388 src/olympia/devhub/forms.py:162 src/olympia/editors/templates/editors/performance.html:75
+msgid "Other"
+msgstr "Tjetër"
+
 #: src/olympia/constants/base.py:389
 msgid "Exception"
 msgstr "Përjashtim"
@@ -4265,6 +3375,10 @@ msgstr "Version"
 #: src/olympia/constants/base.py:391
 msgid "Change"
 msgstr "Ndryshoje"
+
+#: src/olympia/constants/base.py:401
+msgid "App"
+msgstr "Zbt"
 
 #: src/olympia/constants/base.py:402
 msgid "Persona"
@@ -4402,32 +3516,23 @@ msgstr "Nënshkruar për shqyrtim të plotë"
 msgid "Signed of a preliminary review"
 msgstr "Nënshkruar për shqyrtim paraprak"
 
-#: src/olympia/constants/editors.py:14
-#: src/olympia/editors/templates/editors/themes/queue.html:76
-#: src/olympia/editors/templates/editors/themes/themes.html:87
+#: src/olympia/constants/editors.py:14 src/olympia/editors/templates/editors/themes/queue.html:76 src/olympia/editors/templates/editors/themes/themes.html:87
 msgid "Request More Info"
 msgstr "Kërkoni Më Tepër të Dhëna"
 
-#: src/olympia/constants/editors.py:15
-#: src/olympia/editors/templates/editors/themes/queue.html:74
-#: src/olympia/editors/templates/editors/themes/themes.html:91
+#: src/olympia/constants/editors.py:15 src/olympia/editors/templates/editors/themes/queue.html:74 src/olympia/editors/templates/editors/themes/themes.html:91
 msgid "Flag"
 msgstr "Flamur"
 
-#: src/olympia/constants/editors.py:16
-#: src/olympia/editors/templates/editors/themes/queue.html:72
-#: src/olympia/editors/templates/editors/themes/themes.html:93
+#: src/olympia/constants/editors.py:16 src/olympia/editors/templates/editors/themes/queue.html:72 src/olympia/editors/templates/editors/themes/themes.html:93
 msgid "Duplicate"
 msgstr "Dyfishoje"
 
-#: src/olympia/constants/editors.py:17 src/olympia/editors/helpers.py:502
-#: src/olympia/editors/templates/editors/themes/queue.html:71
-#: src/olympia/editors/templates/editors/themes/themes.html:94
+#: src/olympia/constants/editors.py:17 src/olympia/editors/helpers.py:575 src/olympia/editors/templates/editors/themes/queue.html:71 src/olympia/editors/templates/editors/themes/themes.html:94
 msgid "Reject"
 msgstr "Hidhe tej"
 
-#: src/olympia/constants/editors.py:18
-#: src/olympia/editors/templates/editors/themes/queue.html:70
+#: src/olympia/constants/editors.py:18 src/olympia/editors/templates/editors/themes/queue.html:70
 msgid "Approve"
 msgstr "Miratoje"
 
@@ -4523,7 +3628,7 @@ msgstr "Solaris"
 msgid "Android"
 msgstr "Android"
 
-#: src/olympia/core/apps.py:19
+#: src/olympia/core/apps.py:21
 msgid "Core"
 msgstr "Baza"
 
@@ -4560,9 +3665,7 @@ msgstr "Objekt JSON i pavlefshëm"
 msgid "Message not eligible for annotation"
 msgstr "Mesazh jo i përshtatshëm për shënim"
 
-#: src/olympia/devhub/forms.py:124
-#: src/olympia/devhub/templates/devhub/versions/edit.html:94
-#: src/olympia/users/templates/users/edit.html:150
+#: src/olympia/devhub/forms.py:124 src/olympia/devhub/templates/devhub/versions/edit.html:94 src/olympia/users/templates/users/edit.html:150
 msgid "Details"
 msgstr "Hollësi"
 
@@ -4584,9 +3687,7 @@ msgstr "Kjo shtesë ka një Marrëveshje Licence Përdoruesi të Thjeshtë"
 
 #: src/olympia/devhub/forms.py:234
 msgid "Please specify your add-on's End-User License Agreement:"
-msgstr ""
-"Ju lutemi, përcaktoni Marrëveshje Licence Përdoruesi të Thjeshtë të shtesës "
-"suaj:"
+msgstr "Ju lutemi, përcaktoni Marrëveshje Licence Përdoruesi të Thjeshtë të shtesës suaj:"
 
 #: src/olympia/devhub/forms.py:237
 msgid "This add-on has a Privacy Policy"
@@ -4634,9 +3735,7 @@ msgstr "S’vleftësoi dot id PayPal-i."
 
 #: src/olympia/devhub/forms.py:388
 msgid "Unsupported file type, please upload an archive file {extensions}."
-msgstr ""
-"Lloj i pambuluar kartele, ju lutemi, ngarkoni një kartelë arkivi "
-"{extensions}."
+msgstr "Lloj i pambuluar kartele, ju lutemi, ngarkoni një kartelë arkivi {extensions}."
 
 #: src/olympia/devhub/forms.py:407
 msgid "View current"
@@ -4663,39 +3762,26 @@ msgid "Submit my add-on for manual review."
 msgstr "Parashtoje shtesën time për shqyrtim dorazi."
 
 #: src/olympia/devhub/forms.py:537
-msgid "Do not list my add-on on this site (beta)"
-msgstr "Mos e shfaqni shtesën time në këtë sajt (beta)"
+msgid "Do not list my add-on on this site"
+msgstr ""
 
 #: src/olympia/devhub/forms.py:538
-msgid ""
-"Check this option if you intend to distribute your add-on on your own and "
-"only need it to be signed by Mozilla."
-msgstr ""
-"I vini shenjë kësaj mundësie nëse keni ndër mend ta shpërndani ju vetë "
-"shtesën tuaj dhe ju duhet vetëm që Mozilla ta nënshkruajë."
+msgid "Check this option if you intend to distribute your add-on on your own and only need it to be signed by Mozilla."
+msgstr "I vini shenjë kësaj mundësie nëse keni ndër mend ta shpërndani ju vetë shtesën tuaj dhe ju duhet vetëm që Mozilla ta nënshkruajë."
 
 #: src/olympia/devhub/forms.py:544
 msgid "This add-on will be bundled with an application installer."
 msgstr "Kjo shtesë do të paketohet tok me një instalues aplikacioni."
 
 #: src/olympia/devhub/forms.py:546
-msgid ""
-"Add-ons that are bundled with application installers will be code reviewed "
-"by Mozilla before they are signed and are held to a higher quality standard."
-msgstr ""
-"Shtesave që paketohen tok me instalues aplikacionesh do t’u shqyrtohet kodi "
-"nga Mozilla, përpara se të nënshkruhen dhe pritet të jenë të një cilësie më "
-"të lartë."
+msgid "Add-ons that are bundled with application installers will be code reviewed by Mozilla before they are signed and are held to a higher quality standard."
+msgstr "Shtesave që paketohen tok me instalues aplikacionesh do t’u shqyrtohet kodi nga Mozilla, përpara se të nënshkruhen dhe pritet të jenë të një cilësie më të lartë."
 
-#: src/olympia/devhub/forms.py:565
-#: src/olympia/devhub/templates/devhub/addons/submit/select-review.html:24
-#: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:42
+#: src/olympia/devhub/forms.py:565 src/olympia/devhub/templates/devhub/addons/submit/select-review.html:24 src/olympia/devhub/templates/devhub/docs/policies-reviews.html:42
 msgid "Full Review"
 msgstr "Shqyrtim i Plotë"
 
-#: src/olympia/devhub/forms.py:566
-#: src/olympia/devhub/templates/devhub/addons/submit/select-review.html:47
-#: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:153
+#: src/olympia/devhub/forms.py:566 src/olympia/devhub/templates/devhub/addons/submit/select-review.html:47 src/olympia/devhub/templates/devhub/docs/policies-reviews.html:153
 msgid "Preliminary Review"
 msgstr "Shqyrtim Paraprak"
 
@@ -4704,67 +3790,51 @@ msgid "Please choose a review nomination type"
 msgstr "Ju lutemi, zgjidhni lloj kandidimi shqyrtimi"
 
 #: src/olympia/devhub/forms.py:574
-msgid ""
-"A file with a version ending with a|alpha|b|beta|pre|rc and an optional "
-"number is detected as beta."
-msgstr ""
-"Një kartelë me version që përfundon si a|alpha|b|beta|pre|rc dhe një numër "
-"opsional merret si beta."
+msgid "A file with a version ending with a|alpha|b|beta|pre|rc and an optional number is detected as beta."
+msgstr "Një kartelë me version që përfundon si a|alpha|b|beta|pre|rc dhe një numër opsional merret si beta."
 
 #: src/olympia/devhub/forms.py:592
 #, python-format
-msgid "Version %s already exists"
-msgstr "Ka tashmë një version %s"
-
-#: src/olympia/devhub/forms.py:604
-msgid ""
-"Select a valid choice. That choice is not one of the available choices."
+msgid "Version %s already exists, or was uploaded before."
 msgstr ""
-"Përzgjidhni një zgjedhje të vlefshme. Ajo zgjedhje s’është një nga zgjedhjet"
-" e mundshme."
 
-#: src/olympia/devhub/forms.py:610
-msgid ""
-"A file with a version ending with a|alpha|b|beta and an optional number is "
-"detected as beta."
-msgstr ""
-"Te beta u kap një kartelë me një version që mbaron me a|alpha|b|beta dhe një"
-" numër opsional."
+#: src/olympia/devhub/forms.py:605
+msgid "Select a valid choice. That choice is not one of the available choices."
+msgstr "Përzgjidhni një zgjedhje të vlefshme. Ajo zgjedhje s’është një nga zgjedhjet e mundshme."
 
-#: src/olympia/devhub/forms.py:633
+#: src/olympia/devhub/forms.py:611
+msgid "A file with a version ending with a|alpha|b|beta and an optional number is detected as beta."
+msgstr "Te beta u kap një kartelë me një version që mbaron me a|alpha|b|beta dhe një numër opsional."
+
+#: src/olympia/devhub/forms.py:634
 msgid "You cannot upload any more files for this version."
 msgstr "S’mund të ngarkoni më kartela për këtë version."
 
-#: src/olympia/devhub/forms.py:639
+#: src/olympia/devhub/forms.py:640
 msgid "Version doesn't match"
 msgstr "Versioni s’përputhet"
 
-#: src/olympia/devhub/forms.py:668
-msgid ""
-"You cannot delete a file once the review process has started.  You must "
-"delete the whole version."
+#: src/olympia/devhub/forms.py:669
+msgid "You cannot delete a file once the review process has started.  You must delete the whole version."
 msgstr ""
-"Nuk mund ta fshini një kartelë pasi të ketë nisur procesi i shqyrtimit. "
-"Duhet të fshini krejt versionin."
 
-#: src/olympia/devhub/forms.py:688
+#: src/olympia/devhub/forms.py:689
 msgid "The platform All cannot be combined with specific platforms."
 msgstr "Platforma Krejt s’mund të ndërthuret me platforma të caktuara."
 
-#: src/olympia/devhub/forms.py:693
+#: src/olympia/devhub/forms.py:694
 msgid "A platform can only be chosen once."
 msgstr "Platforma mund të zgjidhet vetëm një herë."
 
-#: src/olympia/devhub/forms.py:706
+#: src/olympia/devhub/forms.py:707
 msgid "A review type must be selected."
 msgstr "Duhet përzgjedhur lloj rishikimi."
 
-#: src/olympia/devhub/forms.py:788 src/olympia/editors/forms.py:114
-#: src/olympia/zadmin/forms.py:49 src/olympia/zadmin/forms.py:52
+#: src/olympia/devhub/forms.py:789 src/olympia/editors/forms.py:114 src/olympia/editors/forms.py:254 src/olympia/zadmin/forms.py:49 src/olympia/zadmin/forms.py:52
 msgid "Select an application first"
 msgstr "Përzgjidhni së pari një aplikacion"
 
-#: src/olympia/devhub/forms.py:840
+#: src/olympia/devhub/forms.py:841
 msgid "There cannot be more than 3 required add-ons."
 msgstr "S’lejohen më tepër se 3 shtesa të domosdoshme."
 
@@ -4780,106 +3850,96 @@ msgstr "Parashtrimet e Mia"
 msgid "Developer Docs"
 msgstr "Dokumentim Zhvilluesish"
 
-#. L10n: first parameter is the number of errors
 # %1$s is a number
+#. L10n: first parameter is the number of errors
 #: src/olympia/devhub/helpers.py:200
 msgid "{0} error"
 msgid_plural "{0} errors"
 msgstr[0] "{0} gabim"
 msgstr[1] "{0} gabime"
 
-#. L10n: first parameter is the number of warnings
 # %1$s is a number
+#. L10n: first parameter is the number of warnings
 #: src/olympia/devhub/helpers.py:203
 msgid "{0} warning"
 msgid_plural "{0} warnings"
 msgstr[0] "{0} sinjalizim"
 msgstr[1] "{0} sinjalizime"
 
-#: src/olympia/devhub/models.py:375
-#: src/olympia/reviews/templates/reviews/add.html:58
+#: src/olympia/devhub/models.py:375 src/olympia/reviews/templates/reviews/add.html:58
 msgid "Review"
 msgstr "Shqyrtim"
 
-#: src/olympia/devhub/tasks.py:551
+#: src/olympia/devhub/tasks.py:583
 #, python-format
 msgid "%s responded with %s (%s)."
 msgstr "%s u përgjigj me %s (%s)."
 
-#: src/olympia/devhub/tasks.py:555
+#: src/olympia/devhub/tasks.py:587
 #, python-format
 msgid "Connection to \"%s\" timed out."
 msgstr "Lidhjes me \"%s\" i mbaroi koha."
 
-#: src/olympia/devhub/tasks.py:557
+#: src/olympia/devhub/tasks.py:589
 #, python-format
 msgid "Could not contact host at \"%s\"."
 msgstr "S’u lidh dot me strehën te \"%s\"."
 
-#: src/olympia/devhub/utils.py:104
+#: src/olympia/devhub/utils.py:105
 #, python-format
-msgid ""
-"Validation generated too many errors/warnings so %s messages were truncated."
-" After addressing the visible messages, you'll be able to see the others."
-msgstr ""
-"Vleftësimi prodhoi shumë gabime/sinjalizime, ndaj %s e mesazheve u prenë. "
-"Pasi të trajtoni mesazhet që duken, do të jeni në gjendje të shihni të "
-"tjerët."
+msgid "Validation generated too many errors/warnings so %s messages were truncated. After addressing the visible messages, you'll be able to see the others."
+msgstr "Vleftësimi prodhoi shumë gabime/sinjalizime, ndaj %s e mesazheve u prenë. Pasi të trajtoni mesazhet që duken, do të jeni në gjendje të shihni të tjerët."
 
-#: src/olympia/devhub/views.py:183
+#: src/olympia/devhub/views.py:181
 msgid "All My Add-ons"
 msgstr "Krejt Shtesat e Mia"
 
-#: src/olympia/devhub/views.py:210
+#: src/olympia/devhub/views.py:208
 msgid "All Activity"
 msgstr "Krejt Veprimtaria"
 
-#: src/olympia/devhub/views.py:211
+#: src/olympia/devhub/views.py:209
 msgid "Add-on Updates"
 msgstr "Përditësime Shtese"
 
-#: src/olympia/devhub/views.py:212
+#: src/olympia/devhub/views.py:210
 msgid "Add-on Status"
 msgstr "Gjendje Shtese"
 
-#: src/olympia/devhub/views.py:213
+#: src/olympia/devhub/views.py:211
 msgid "User Collections"
 msgstr "Koleksione Përdoruesi"
 
-#: src/olympia/devhub/views.py:214
-#: src/olympia/devhub/templates/devhub/docs/policies-maintenance.html:68
-#: src/olympia/pages/templates/pages/dev_faq.html:38
+#: src/olympia/devhub/views.py:212 src/olympia/devhub/templates/devhub/docs/policies-maintenance.html:68 src/olympia/pages/templates/pages/dev_faq.html:38
 #: src/olympia/pages/templates/pages/dev_faq.html:484
 msgid "User Reviews"
 msgstr "Shqyrtime Përdoruesi"
 
-#: src/olympia/devhub/views.py:327 src/olympia/devhub/views.py:331
-#: src/olympia/devhub/views.py:484 src/olympia/devhub/views.py:513
-#: src/olympia/devhub/views.py:564 src/olympia/devhub/views.py:1150
+#: src/olympia/devhub/views.py:325 src/olympia/devhub/views.py:329 src/olympia/devhub/views.py:484 src/olympia/devhub/views.py:513 src/olympia/devhub/views.py:564 src/olympia/devhub/views.py:1156
 msgid "Changes successfully saved."
 msgstr "Ndryshimet u ruajtën me sukses."
 
-#: src/olympia/devhub/views.py:334 src/olympia/devhub/views.py:1631
+#: src/olympia/devhub/views.py:332 src/olympia/devhub/views.py:1637
 msgid "Please check the form for errors."
 msgstr "Ju lutemi, kontrolloni formularin për gabime."
 
-#: src/olympia/devhub/views.py:346
+#: src/olympia/devhub/views.py:344
 msgid "Add-on cannot be deleted. Disable this add-on instead."
 msgstr "Shtesa s’mund të fshihet. Në vend të kësaj, çaktivizojeni."
 
-#: src/olympia/devhub/views.py:356
+#: src/olympia/devhub/views.py:354
 msgid "Theme deleted."
 msgstr "Tema u fshi."
 
-#: src/olympia/devhub/views.py:356
+#: src/olympia/devhub/views.py:354
 msgid "Add-on deleted."
 msgstr "Shtesa u fshi."
 
-#: src/olympia/devhub/views.py:362
+#: src/olympia/devhub/views.py:360
 msgid "URL name was incorrect. Theme was not deleted."
 msgstr "Fjalëkalimi qe i pasaktë. Tema s’u fshi."
 
-#: src/olympia/devhub/views.py:367
+#: src/olympia/devhub/views.py:365
 msgid "URL name was incorrect. Add-on was not deleted."
 msgstr "Fjalëkalimi qe i pasaktë. Shtesa s’u fshi."
 
@@ -4907,7 +3967,7 @@ msgstr "Vleftëso Shtesën"
 msgid "Check Add-on Compatibility"
 msgstr "Kontrolloni Përputhshmëri Shtese"
 
-#: src/olympia/devhub/views.py:808 src/olympia/signing/views.py:90
+#: src/olympia/devhub/views.py:808 src/olympia/signing/views.py:95
 msgid "You cannot submit this type of add-on"
 msgstr "S’mund të parashtroni këtë lloj shtojce"
 
@@ -4931,64 +3991,48 @@ msgstr "Figurat s’ mund të jenë më të mëdha se %dKB."
 #. L10n: {0} is an image width (in pixels), {1} is a height.
 #: src/olympia/devhub/views.py:1080
 msgid "Image must be exactly {0} pixels wide and {1} pixels tall."
-msgstr ""
-"Figura duhet të jetë saktësisht {0} piksela e gjerë dhe {1} piksela e lartë."
+msgstr "Figura duhet të jetë saktësisht {0} piksela e gjerë dhe {1} piksela e lartë."
 
 #: src/olympia/devhub/views.py:1087
 msgid "There was an error uploading your preview."
 msgstr "Pati një gabim gjatë ngarkimit të paraparjes suaj."
 
-#: src/olympia/devhub/views.py:1189
+#: src/olympia/devhub/views.py:1195
 #, python-format
 msgid "Version %s disabled."
 msgstr "Versioni %s u çaktivizua."
 
 # %s is the version number, e.g. 3.2.
-#: src/olympia/devhub/views.py:1193
+#: src/olympia/devhub/views.py:1199
 #, python-format
 msgid "Version %s deleted."
 msgstr "Versioni %s u fshi."
 
-#: src/olympia/devhub/views.py:1203
-msgid ""
-"This upload has failed validation, and may lack complete validation results."
-" Please take due care when reviewing it."
-msgstr ""
-"Ky ngarkim s’arriti të vleftësohej, dhe mund t’i mungojnë përfundimet e "
-"plota të vleftësimit. Ju lutemi, tregoni kujdesin e duhur, teksa e "
-"shqyrtoni."
+#: src/olympia/devhub/views.py:1209
+msgid "This upload has failed validation, and may lack complete validation results. Please take due care when reviewing it."
+msgstr "Ky ngarkim s’arriti të vleftësohej, dhe mund t’i mungojnë përfundimet e plota të vleftësimit. Ju lutemi, tregoni kujdesin e duhur, teksa e shqyrtoni."
 
-#: src/olympia/devhub/views.py:1677
+#: src/olympia/devhub/views.py:1683
 msgid "Preliminary Review Requested."
 msgstr "U kërkua Shqyrtim Paraprak."
 
-#: src/olympia/devhub/views.py:1678
+#: src/olympia/devhub/views.py:1684
 msgid "Full Review Requested."
 msgstr "U kërkua Shqyrtim i Plotë."
 
-#: src/olympia/devhub/views.py:1779
-msgid ""
-"Your old credentials were revoked and are no longer valid. Be sure to update"
-" all API clients with the new credentials."
-msgstr ""
-"Kredencialet tuaja të vjetra janë shfuqizuar dhe s’janë më të vlefshme. "
-"Sigurohumi të përditësoni me kredencialet e reja krejt klientët tuaj për "
-"API."
+#: src/olympia/devhub/views.py:1783
+msgid "Your old credentials were revoked and are no longer valid. Be sure to update all API clients with the new credentials."
+msgstr "Kredencialet tuaja të vjetra janë shfuqizuar dhe s’janë më të vlefshme. Sigurohumi të përditësoni me kredencialet e reja krejt klientët tuaj për API."
 
-#: src/olympia/devhub/views.py:1797
+#: src/olympia/devhub/views.py:1801
 msgid "New API key created"
 msgstr "U prodhua kyç i ri API"
 
 #: src/olympia/devhub/templates/devhub/agreement.html:2
-msgid ""
-"Before starting, please read and accept our Firefox Add-on Distribution "
-"Agreement. It also links to our Privacy Notice which explains how we handle "
-"your information."
+msgid "Before starting, please read and accept our Firefox Add-on Distribution Agreement. It also links to our Privacy Notice which explains how we handle your information."
 msgstr ""
-"Para se t’ia filloni, ju lutemi lexoni dhe pranoni Marrëveshjen mbi "
-"Shpërndarjen e Shtesave të Firefox-it. E cila përmban gjithashtu edhe lidhje"
-" për te Shënimet tona mbi Privatësinë, ku shpjegohet se si i trajtojmë ne të"
-" dhënat tuaja."
+"Para se t’ia filloni, ju lutemi lexoni dhe pranoni Marrëveshjen mbi Shpërndarjen e Shtesave të Firefox-it. E cila përmban gjithashtu edhe lidhje për te Shënimet tona mbi Privatësinë, ku shpjegohet "
+"se si i trajtojmë ne të dhënat tuaja."
 
 #: src/olympia/devhub/templates/devhub/agreement.html:13
 msgid "Printable Version"
@@ -5002,44 +4046,30 @@ msgstr "E pranoj këtë Marrëveshje"
 msgid "or <a href=\"{0}\">Cancel</a>"
 msgstr "ose <a href=\"{0}\">Anulojeni</a>"
 
-#: src/olympia/devhub/templates/devhub/base.html:23
-#: src/olympia/devhub/templates/devhub/base_impala.html:20
-#: src/olympia/discovery/templates/discovery/addons/base.html:17
+#: src/olympia/devhub/templates/devhub/base.html:23 src/olympia/devhub/templates/devhub/base_impala.html:20 src/olympia/discovery/templates/discovery/addons/base.html:17
 msgid "Back to Add-ons"
 msgstr "Mbrapsht te Shtesat"
 
 #. {0} is a search term, such as Firebug.
 #. {0} is a search query.
-#: src/olympia/devhub/templates/devhub/devhub_search.html:4
-#: src/olympia/search/templates/search/results.html:9
-#: src/olympia/search/templates/search/mobile/results.html:6
+#: src/olympia/devhub/templates/devhub/devhub_search.html:4 src/olympia/search/templates/search/results.html:9 src/olympia/search/templates/search/mobile/results.html:6
 msgid "{0} :: Search"
 msgstr "{0} :: Kërkim"
 
-#: src/olympia/devhub/templates/devhub/devhub_search.html:6
-#: src/olympia/devhub/templates/devhub/search.html:8
-#: src/olympia/editors/forms.py:435 src/olympia/editors/forms.py:437
-#: src/olympia/editors/templates/editors/queue.html:27
-#: src/olympia/editors/templates/editors/themes/queue_list.html:14
-#: src/olympia/search/templates/search/collections.html:17
-#: src/olympia/search/templates/search/personas.html:18
-#: src/olympia/search/templates/search/results.html:18
-#: src/olympia/search/templates/search/mobile/results.html:8
-#: src/olympia/templates/search.html:14
-#: src/olympia/templates/impala/search.html:18
+#: src/olympia/devhub/templates/devhub/devhub_search.html:6 src/olympia/devhub/templates/devhub/search.html:8 src/olympia/editors/forms.py:534 src/olympia/editors/forms.py:536
+#: src/olympia/editors/templates/editors/queue.html:27 src/olympia/editors/templates/editors/themes/queue_list.html:14 src/olympia/search/templates/search/collections.html:17
+#: src/olympia/search/templates/search/personas.html:18 src/olympia/search/templates/search/results.html:18 src/olympia/search/templates/search/mobile/results.html:8
+#: src/olympia/templates/search.html:14 src/olympia/templates/impala/search.html:18
 msgid "Search"
 msgstr "Kërkoni"
 
-#: src/olympia/devhub/templates/devhub/devhub_search.html:11
-#: src/olympia/devhub/templates/devhub/devhub_search.html:15
-#: src/olympia/search/templates/search/collections.html:18
+#: src/olympia/devhub/templates/devhub/devhub_search.html:11 src/olympia/devhub/templates/devhub/devhub_search.html:15 src/olympia/search/templates/search/collections.html:18
 #: src/olympia/search/templates/search/personas.html:20
 msgid "Search Results"
 msgstr "Përfundime Kërkimi"
 
 #. {0} is a search term, such as Firebug.
-#: src/olympia/devhub/templates/devhub/devhub_search.html:13
-#: src/olympia/search/templates/search/results.html:11
+#: src/olympia/devhub/templates/devhub/devhub_search.html:13 src/olympia/search/templates/search/results.html:11
 msgid "Search Results for \"{0}\""
 msgstr "Përfundime Kërkimi për \"{0}\""
 
@@ -5060,12 +4090,8 @@ msgid "AMO Reviewers"
 msgstr "Shqyrtues AMO"
 
 #: src/olympia/devhub/templates/devhub/index.html:29
-msgid ""
-"Get ahead! Become an AMO Reviewer today and get your add-ons reviewed "
-"faster."
-msgstr ""
-"Ecni përpara! Bëhuni që sot një Shqyrtues AMO dhe bëni që shtesat tuaja të "
-"shqyrtohen më shpejt."
+msgid "Get ahead! Become an AMO Reviewer today and get your add-ons reviewed faster."
+msgstr "Ecni përpara! Bëhuni që sot një Shqyrtues AMO dhe bëni që shtesat tuaja të shqyrtohen më shpejt."
 
 #: src/olympia/devhub/templates/devhub/index.html:32
 msgid "Become an AMO Reviewer"
@@ -5077,42 +4103,28 @@ msgstr "Mësoni Gjithçka Mbi Shtesat"
 
 #: src/olympia/devhub/templates/devhub/index.html:41
 msgid ""
-"Add-ons let millions of Firefox users enhance and customize their browsing "
-"experience. If you're a Web developer and know <a "
-"href=\"https://developer.mozilla.org/docs/Web/HTML\">HTML</a>, <a "
-"href=\"https://developer.mozilla.org/docs/Web/JavaScript\">JavaScript</a>, "
-"and <a href=\"https://developer.mozilla.org/docs/Web/CSS\">CSS</a>, you "
-"already have all the necessary skills to make a great add-on."
+"Add-ons let millions of Firefox users enhance and customize their browsing experience. If you're a Web developer and know <a href=\"https://developer.mozilla.org/docs/Web/HTML\">HTML</a>, <a href="
+"\"https://developer.mozilla.org/docs/Web/JavaScript\">JavaScript</a>, and <a href=\"https://developer.mozilla.org/docs/Web/CSS\">CSS</a>, you already have all the necessary skills to make a great "
+"add-on."
 msgstr ""
-"Shtesa u lejojnë miliona përdoruesve Firefox të zgjerojnë dhe personalizojnë"
-" punën e shfletuesit të tyre. Nëse jeni një zhvillues Web dhe keni dije për "
-"<a href=\"https://developer.mozilla.org/docs/Web/HTML\">HTML</a>, <a "
-"href=\"https://developer.mozilla.org/docs/Web/JavaScript\">JavaScript</a>, "
-"dhe <a href=\"https://developer.mozilla.org/docs/Web/CSS\">CSS</a>, keni "
-"kështu krejt aftësitë e nevojshme për të krijuar një shtesë të fuqishme."
+"Shtesa u lejojnë miliona përdoruesve Firefox të zgjerojnë dhe personalizojnë punën e shfletuesit të tyre. Nëse jeni një zhvillues Web dhe keni dije për <a href=\"https://developer.mozilla.org/docs/"
+"Web/HTML\">HTML</a>, <a href=\"https://developer.mozilla.org/docs/Web/JavaScript\">JavaScript</a>, dhe <a href=\"https://developer.mozilla.org/docs/Web/CSS\">CSS</a>, keni kështu krejt aftësitë e "
+"nevojshme për të krijuar një shtesë të fuqishme."
 
 #: src/olympia/devhub/templates/devhub/index.html:51
-msgid ""
-"Head over to the <a href=\"https://developer.mozilla.org/Add-ons\">Mozilla "
-"Developer Network</a> to learn everything you need to know to get started."
-msgstr ""
-"Shkoni te <a href=\"https://developer.mozilla.org/Add-ons\">Rrjeti i "
-"Zhvilluesve Mozilla</a> që të mësoni gjithçka ju duhet të njihni për t’ia "
-"filluar."
+msgid "Head over to the <a href=\"https://developer.mozilla.org/Add-ons\">Mozilla Developer Network</a> to learn everything you need to know to get started."
+msgstr "Shkoni te <a href=\"https://developer.mozilla.org/Add-ons\">Rrjeti i Zhvilluesve Mozilla</a> që të mësoni gjithçka ju duhet të njihni për t’ia filluar."
 
 #: src/olympia/devhub/templates/devhub/index.html:58
 msgid "Start Making Add-ons"
 msgstr "Filloni të Krijoni Shtesa"
 
-#: src/olympia/devhub/templates/devhub/index.html:86
-#: src/olympia/devhub/templates/devhub/addons/listing/items.html:25
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:15
+#: src/olympia/devhub/templates/devhub/index.html:86 src/olympia/devhub/templates/devhub/addons/listing/items.html:25 src/olympia/devhub/templates/devhub/includes/addon_details.html:20
 #: src/olympia/devhub/templates/devhub/personas/edit.html:43
 msgid "Status:"
 msgstr "Gjendje:"
 
-#: src/olympia/devhub/templates/devhub/index.html:90
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:100
+#: src/olympia/devhub/templates/devhub/index.html:90 src/olympia/devhub/templates/devhub/includes/addon_details.html:87
 msgid "Visibility:"
 msgstr "Dukshmëri:"
 
@@ -5120,21 +4132,16 @@ msgstr "Dukshmëri:"
 msgid "Latest Version:"
 msgstr "Version Më i Ri:"
 
-#: src/olympia/devhub/templates/devhub/index.html:109
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:145
-#: src/olympia/devhub/templates/devhub/personas/edit.html:49
+#: src/olympia/devhub/templates/devhub/index.html:109 src/olympia/devhub/templates/devhub/includes/addon_details.html:131 src/olympia/devhub/templates/devhub/personas/edit.html:49
 msgid "Queue Position:"
 msgstr "Vend në Radhë:"
 
-#: src/olympia/devhub/templates/devhub/index.html:110
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:146
-#: src/olympia/devhub/templates/devhub/personas/edit.html:50
+#: src/olympia/devhub/templates/devhub/index.html:110 src/olympia/devhub/templates/devhub/includes/addon_details.html:132 src/olympia/devhub/templates/devhub/personas/edit.html:50
 #, python-format
 msgid "%(position)s of %(total)s"
 msgstr "%(position)s nga %(total)s"
 
-#: src/olympia/devhub/templates/devhub/index.html:120
-#: src/olympia/devhub/templates/devhub/includes/addons_edit_nav.html:19
+#: src/olympia/devhub/templates/devhub/index.html:120 src/olympia/devhub/templates/devhub/includes/addons_edit_nav.html:19
 msgid "Upload New Version"
 msgstr "Ngarkoni Version të Ri"
 
@@ -5148,12 +4155,8 @@ msgstr "Botoni shtesat tuaja!"
 
 #: src/olympia/devhub/templates/devhub/index.html:136
 #, python-format
-msgid ""
-"Upload an <a href=\"%(addon_url)s\">add-on</a> or <a "
-"href=\"%(theme_url)s\">theme</a> to get started!"
-msgstr ""
-"Që t’ia filloni, ngarkoni një <a href=\"%(addon_url)s\">shtesë</a> ose <a "
-"href=\"%(theme_url)s\">temë</a>!"
+msgid "Upload an <a href=\"%(addon_url)s\">add-on</a> or <a href=\"%(theme_url)s\">theme</a> to get started!"
+msgstr "Që t’ia filloni, ngarkoni një <a href=\"%(addon_url)s\">shtesë</a> ose <a href=\"%(theme_url)s\">temë</a>!"
 
 #: src/olympia/devhub/templates/devhub/nav.html:2
 msgid "Return to the DevHub homepage"
@@ -5180,17 +4183,10 @@ msgstr "Zhvillim Zgjerimesh"
 msgid "Lightweight Themes"
 msgstr "Tema të Peshës së Lehtë"
 
-#: src/olympia/devhub/templates/devhub/nav.html:39
-#: src/olympia/devhub/templates/devhub/docs/policies-agreement.html:6
-#: src/olympia/devhub/templates/devhub/docs/policies-contact.html:6
-#: src/olympia/devhub/templates/devhub/docs/policies-maintenance.html:6
-#: src/olympia/devhub/templates/devhub/docs/policies-recommended.html:6
-#: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:6
-#: src/olympia/devhub/templates/devhub/docs/policies-submission.html:6
-#: src/olympia/devhub/templates/devhub/docs/policies.html:3
-#: src/olympia/devhub/templates/devhub/docs/policies.html:9
-#: src/olympia/devhub/templates/devhub/docs/policies.html:38
-#: src/olympia/devhub/templates/devhub/docs/policies.html:39
+#: src/olympia/devhub/templates/devhub/nav.html:39 src/olympia/devhub/templates/devhub/docs/policies-agreement.html:6 src/olympia/devhub/templates/devhub/docs/policies-contact.html:6
+#: src/olympia/devhub/templates/devhub/docs/policies-maintenance.html:6 src/olympia/devhub/templates/devhub/docs/policies-recommended.html:6
+#: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:6 src/olympia/devhub/templates/devhub/docs/policies-submission.html:6 src/olympia/devhub/templates/devhub/docs/policies.html:3
+#: src/olympia/devhub/templates/devhub/docs/policies.html:9 src/olympia/devhub/templates/devhub/docs/policies.html:38 src/olympia/devhub/templates/devhub/docs/policies.html:39
 msgid "Add-on Policies"
 msgstr "Rregulla Shtese"
 
@@ -5231,42 +4227,16 @@ msgid "Use the field below to upload your add-on package."
 msgstr "Përdorni fushën më poshtë për të ngarkuar paketën e shtesës suaj."
 
 #: src/olympia/devhub/templates/devhub/validate_addon.html:19
-msgid ""
-"After upload, a series of automated validation tests will run to check "
-"compatibility with the following application version:"
-msgstr ""
-"Pas ngarkimit, do të kryhen një varg provash të automatizuara vleftësimi, "
-"për t’i kontrolluar përputhshmërinë me versionin vijues të aplikacionit:"
+msgid "After upload, a series of automated validation tests will run to check compatibility with the following application version:"
+msgstr "Pas ngarkimit, do të kryhen një varg provash të automatizuara vleftësimi, për t’i kontrolluar përputhshmërinë me versionin vijues të aplikacionit:"
 
 #: src/olympia/devhub/templates/devhub/validate_addon.html:34
-msgid ""
-"After upload, a series of automated validation tests will be run on your "
-"file."
-msgstr ""
-"Pas ngarkimit, mbi kartelën tuaj do të kryhen një varg provash të "
-"automatizuara vleftësimi."
+msgid "After upload, a series of automated validation tests will be run on your file."
+msgstr "Pas ngarkimit, mbi kartelën tuaj do të kryhen një varg provash të automatizuara vleftësimi."
 
-#: src/olympia/devhub/templates/devhub/validate_addon.html:42
-#: src/olympia/devhub/templates/devhub/addons/submit/upload.html:23
+#: src/olympia/devhub/templates/devhub/validate_addon.html:42 src/olympia/devhub/templates/devhub/addons/submit/upload.html:23
 msgid "Do you want your add-on to be distributed on this site?"
 msgstr "Doni që shtesa juaj të shpërndahet përmes këtij sajti?"
-
-#: src/olympia/devhub/templates/devhub/validate_addon.html:49
-#: src/olympia/devhub/templates/devhub/addons/submit/upload.html:30
-#: src/olympia/devhub/templates/devhub/versions/add_file_modal.html:14
-#: src/olympia/devhub/templates/devhub/versions/add_file_modal.html:53
-#: src/olympia/devhub/templates/devhub/versions/list.html:298
-msgid "Warning:"
-msgstr "Kujdes:"
-
-#: src/olympia/devhub/templates/devhub/validate_addon.html:50
-#: src/olympia/devhub/templates/devhub/addons/submit/upload.html:31
-#, python-format
-msgid ""
-"Submission of unlisted add-ons for signing is currently in an open beta. "
-"Please <a href=\"%(url)s\" target=\"_blank\">report any bugs</a> that you "
-"encounter."
-msgstr ""
 
 #. first parameter is a filename like lorem-ipsum-1.0.2.xpi
 #: src/olympia/devhub/templates/devhub/validation.html:5
@@ -5285,14 +4255,11 @@ msgstr "Vleftësuar më:"
 msgid "Tested for compatibility against:"
 msgstr "Provuar për përputhshmëri kundrejt:"
 
-#: src/olympia/devhub/templates/devhub/addons/activity.html:4
-#: src/olympia/devhub/templates/devhub/addons/activity.html:20
+#: src/olympia/devhub/templates/devhub/addons/activity.html:4 src/olympia/devhub/templates/devhub/addons/activity.html:20
 msgid "Recent Activity for My Add-ons"
 msgstr "Veprimtari Së fundmi për Shtesën Time"
 
-#: src/olympia/devhub/templates/devhub/addons/activity.html:14
-#: src/olympia/devhub/templates/devhub/addons/activity.html:19
-#: src/olympia/devhub/templates/devhub/addons/dashboard.html:33
+#: src/olympia/devhub/templates/devhub/addons/activity.html:14 src/olympia/devhub/templates/devhub/addons/activity.html:19 src/olympia/devhub/templates/devhub/addons/dashboard.html:33
 msgid "Recent Activity"
 msgstr "Veprimtari Së fundi"
 
@@ -5314,45 +4281,34 @@ msgstr "Përimtësoni Veprimtarinë"
 msgid "Activity"
 msgstr "Veprimtari"
 
-#: src/olympia/devhub/templates/devhub/addons/activity.html:83
-#: src/olympia/devhub/templates/devhub/addons/dashboard.html:34
-#: src/olympia/devhub/templates/devhub/addons/dashboard.html:35
-#: src/olympia/devhub/templates/devhub/includes/blog_posts.html:4
-#: src/olympia/devhub/templates/devhub/includes/blog_posts.html:6
+#: src/olympia/devhub/templates/devhub/addons/activity.html:83 src/olympia/devhub/templates/devhub/addons/dashboard.html:34 src/olympia/devhub/templates/devhub/addons/dashboard.html:35
+#: src/olympia/devhub/templates/devhub/includes/blog_posts.html:4 src/olympia/devhub/templates/devhub/includes/blog_posts.html:6
 msgid "Subscribe to this feed"
 msgstr "Pajtohuni te kjo prurje"
 
 #: src/olympia/devhub/templates/devhub/addons/ajax_compat_error.html:7
 #, python-format
 msgid ""
-"This add-on is incompatible with <b>%(app_name)s %(app_version)s</b>, the "
-"latest release of %(app_name)s. Please consider updating your add-on's "
-"compatibility info, or uploading a newer version of this add-on."
+"This add-on is incompatible with <b>%(app_name)s %(app_version)s</b>, the latest release of %(app_name)s. Please consider updating your add-on's compatibility info, or uploading a newer version of "
+"this add-on."
 msgstr ""
-"Kjo shtesë është e papërputhshme me <b>%(app_name)s %(app_version)s</b>, "
-"hedhja më e re në qarkullim e %(app_name)s-it. Ju lutemi, shihni mundësinë e"
-" përditësimit të të dhënave të përputhshmërisë së shtesës suaj, ose të "
-"ngarkimit të një versioni më të ri të kësaj shtese."
+"Kjo shtesë është e papërputhshme me <b>%(app_name)s %(app_version)s</b>, hedhja më e re në qarkullim e %(app_name)s-it. Ju lutemi, shihni mundësinë e përditësimit të të dhënave të përputhshmërisë "
+"së shtesës suaj, ose të ngarkimit të një versioni më të ri të kësaj shtese."
 
 #: src/olympia/devhub/templates/devhub/addons/ajax_compat_error.html:15
 #, python-format
 msgid ""
-"<a href=\"#\" class=\"button compat-update\" data-"
-"updateurl=\"%(update_url)s\">Update Compatibility</a> <a "
-"href=\"%(version_url)s\" class=\"button\">Upload New Version</a> or <a "
-"href=\"#\" class=\"close\">Ignore</a>"
+"<a href=\"#\" class=\"button compat-update\" data-updateurl=\"%(update_url)s\">Update Compatibility</a> <a href=\"%(version_url)s\" class=\"button\">Upload New Version</a> or <a href=\"#\" class="
+"\"close\">Ignore</a>"
 msgstr ""
-"<a href=\"#\" class=\"button compat-update\" data-"
-"updateurl=\"%(update_url)s\">Përputhshmëri Përditësimi</a> <a "
-"href=\"%(version_url)s\" class=\"button\">Ngarkoni Version të Ri</a> ose <a "
-"href=\"#\" class=\"close\">Shpërfilleni</a>"
+"<a href=\"#\" class=\"button compat-update\" data-updateurl=\"%(update_url)s\">Përputhshmëri Përditësimi</a> <a href=\"%(version_url)s\" class=\"button\">Ngarkoni Version të Ri</a> ose <a href=\"#"
+"\" class=\"close\">Shpërfilleni</a>"
 
 #: src/olympia/devhub/templates/devhub/addons/ajax_compat_status.html:5
 msgid "View and update application compatibility ranges."
 msgstr "Shihni dhe përditësoni intervalet e përputhshmërisë së aplikacionit."
 
-#: src/olympia/devhub/templates/devhub/addons/ajax_compat_status.html:6
-#: src/olympia/devhub/templates/devhub/versions/edit.html:44
+#: src/olympia/devhub/templates/devhub/addons/ajax_compat_status.html:6 src/olympia/devhub/templates/devhub/versions/edit.html:44
 msgid "Compatibility"
 msgstr "Përputhshmëri"
 
@@ -5360,39 +4316,25 @@ msgstr "Përputhshmëri"
 msgid "Update Compatibility"
 msgstr "Përditësoni Përputhshmërinë"
 
-#: src/olympia/devhub/templates/devhub/addons/ajax_compat_update.html:4
-msgid ""
-"Adjusting application information here will allow users to install your add-"
-"on even if the install manifest in the package indicates that the add-on is "
-"incompatible."
-msgstr ""
-"Rregullimi i të dhënave të aplikacionit këtu do t’u lejojë përdoruesve të "
-"instalojnë shtesën tuaj edhe manifesti i instalimit te paketa tregon që ajo "
-"shtesë është e papërputhshme."
+#: src/olympia/devhub/templates/devhub/addons/ajax_compat_update.html:4 src/olympia/devhub/templates/devhub/versions/edit.html:45
+msgid "Adjusting application information here will allow users to install your add-on even if the install manifest in the package indicates that the add-on is incompatible."
+msgstr "Rregullimi i të dhënave të aplikacionit këtu do t’u lejojë përdoruesve të instalojnë shtesën tuaj edhe manifesti i instalimit te paketa tregon që ajo shtesë është e papërputhshme."
 
 #: src/olympia/devhub/templates/devhub/addons/ajax_compat_update.html:18
 msgid "Supported Versions"
 msgstr "Versione Që Mbulohen"
 
-#: src/olympia/devhub/templates/devhub/addons/ajax_compat_update.html:31
-#: src/olympia/devhub/templates/devhub/versions/edit.html:63
+#: src/olympia/devhub/templates/devhub/addons/ajax_compat_update.html:31 src/olympia/devhub/templates/devhub/versions/edit.html:63
 msgid "Add Another Application&hellip;"
 msgstr "Shtoni Një Tjetër Aplikacion&hellip;"
 
-#: src/olympia/devhub/templates/devhub/addons/ajax_compat_update.html:38
-#: src/olympia/devhub/templates/devhub/addons/owner.html:86
-#: src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:46
-#: src/olympia/devhub/templates/devhub/versions/list.html:351
-#: src/olympia/devhub/templates/devhub/versions/list.html:353
-#: src/olympia/templates/impala/base.html:132
-#: src/olympia/templates/impala/base.html:143
-#: src/olympia/templates/impala/base.html:161
-#: src/olympia/templates/impala/base.html:171
+#: src/olympia/devhub/templates/devhub/addons/ajax_compat_update.html:38 src/olympia/devhub/templates/devhub/addons/owner.html:86 src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:45
+#: src/olympia/devhub/templates/devhub/versions/list.html:349 src/olympia/devhub/templates/devhub/versions/list.html:351 src/olympia/templates/impala/base.html:129
+#: src/olympia/templates/impala/base.html:140 src/olympia/templates/impala/base.html:158 src/olympia/templates/impala/base.html:168
 msgid "Close"
 msgstr "Mbylle"
 
-#: src/olympia/devhub/templates/devhub/addons/dashboard.html:43
-#: src/olympia/zadmin/templates/zadmin/index.html:22
+#: src/olympia/devhub/templates/devhub/addons/dashboard.html:43 src/olympia/zadmin/templates/zadmin/index.html:22
 #, python-format
 msgid "%(ago)s by %(user)s"
 msgstr "%(ago)s nga %(user)s"
@@ -5408,29 +4350,21 @@ msgid_plural "<b>{0}</b> themes"
 msgstr[0] "<b>{0}</b> temë"
 msgstr[1] "<b>{0}</b> temë"
 
-#: src/olympia/devhub/templates/devhub/addons/edit.html:3
-#: src/olympia/devhub/templates/devhub/addons/listing/item_actions.html:25
-#: src/olympia/devhub/templates/devhub/addons/listing/item_actions_theme.html:7
-#: src/olympia/devhub/templates/devhub/includes/addons_edit_nav.html:2
-#: src/olympia/devhub/templates/devhub/personas/edit.html:6
-#: src/olympia/editors/templates/editors/themes/single.html:37
+#: src/olympia/devhub/templates/devhub/addons/edit.html:3 src/olympia/devhub/templates/devhub/addons/listing/item_actions.html:25
+#: src/olympia/devhub/templates/devhub/addons/listing/item_actions_theme.html:7 src/olympia/devhub/templates/devhub/includes/addons_edit_nav.html:2
+#: src/olympia/devhub/templates/devhub/personas/edit.html:6 src/olympia/editors/templates/editors/themes/single.html:37
 msgid "Edit Listing"
 msgstr "Përpunoni Listën"
 
-#: src/olympia/devhub/templates/devhub/addons/edit.html:13
-#: src/olympia/devhub/templates/devhub/includes/macros.html:18
-#: src/olympia/translations/templates/translations/all-locales.html:6
+#: src/olympia/devhub/templates/devhub/addons/edit.html:13 src/olympia/devhub/templates/devhub/includes/macros.html:18 src/olympia/translations/templates/translations/all-locales.html:6
 msgid "None"
 msgstr "Asnjë"
 
-#: src/olympia/devhub/templates/devhub/addons/owner.html:4
-#: src/olympia/devhub/templates/devhub/addons/listing/item_actions.html:52
-#: src/olympia/devhub/templates/devhub/includes/addons_edit_nav.html:3
+#: src/olympia/devhub/templates/devhub/addons/owner.html:4 src/olympia/devhub/templates/devhub/addons/listing/item_actions.html:52 src/olympia/devhub/templates/devhub/includes/addons_edit_nav.html:3
 msgid "Manage Authors & License"
 msgstr "Administroni Autorë & Licenca"
 
-#: src/olympia/devhub/templates/devhub/addons/owner.html:29
-#: src/olympia/editors/templates/editors/review.html:270
+#: src/olympia/devhub/templates/devhub/addons/owner.html:29 src/olympia/editors/helpers.py:362 src/olympia/editors/templates/editors/review.html:270
 msgid "Authors"
 msgstr "Autorë"
 
@@ -5440,36 +4374,22 @@ msgstr "Rreth rolit autor"
 
 #: src/olympia/devhub/templates/devhub/addons/owner.html:78
 msgid ""
-"<p>Add-ons can have any number of authors with 3 possible roles:</p> <ul> "
-"<li><b>Owner:</b> Can manage all aspects of the add-on's listing, including "
-"adding and removing other authors</li> <li><b>Developer:</b> Can manage all "
-"aspects of the add-on's listing, except for adding and removing other "
-"authors and managing payments</li> <li><b>Viewer:</b> Can view the add-on's "
-"settings and statistics, but cannot make any changes</li> </ul>"
+"<p>Add-ons can have any number of authors with 3 possible roles:</p> <ul> <li><b>Owner:</b> Can manage all aspects of the add-on's listing, including adding and removing other authors</li> "
+"<li><b>Developer:</b> Can manage all aspects of the add-on's listing, except for adding and removing other authors and managing payments</li> <li><b>Viewer:</b> Can view the add-on's settings and "
+"statistics, but cannot make any changes</li> </ul>"
 msgstr ""
-"<p>Shtesat mund të kenë çfarëdo numri autorësh me një nga 3 rolet e "
-"mundshme:</p> <ul> <li><b>Pronar:</b> Mund të administrojë krejt anët e "
-"paraqitjes së shtesës te galeria, përfshi shtimin dhe heqjen e autorëve të "
-"tjerë</li> <li><b>Zhvillues:</b> Mund të administrojë krejt anët e "
-"paraqitjes së shtesës te galeria, hiq shtimin dhe heqjen e autorëve të tjerë"
-" dhe administrimin e pagesave</li> <li><b>Parës:</b> Mund të shohë "
-"rregullimet dhe statistikat e shtesës, por s’mund të bëjë ndryshime</li> "
-"</ul>"
+"<p>Shtesat mund të kenë çfarëdo numri autorësh me një nga 3 rolet e mundshme:</p> <ul> <li><b>Pronar:</b> Mund të administrojë krejt anët e paraqitjes së shtesës te galeria, përfshi shtimin dhe "
+"heqjen e autorëve të tjerë</li> <li><b>Zhvillues:</b> Mund të administrojë krejt anët e paraqitjes së shtesës te galeria, hiq shtimin dhe heqjen e autorëve të tjerë dhe administrimin e pagesave</"
+"li> <li><b>Parës:</b> Mund të shohë rregullimet dhe statistikat e shtesës, por s’mund të bëjë ndryshime</li> </ul>"
 
-#: src/olympia/devhub/templates/devhub/addons/profile.html:3
-#: src/olympia/devhub/templates/devhub/addons/listing/item_actions.html:53
-#: src/olympia/devhub/templates/devhub/includes/addons_edit_nav.html:4
+#: src/olympia/devhub/templates/devhub/addons/profile.html:3 src/olympia/devhub/templates/devhub/addons/listing/item_actions.html:53 src/olympia/devhub/templates/devhub/includes/addons_edit_nav.html:4
 msgid "Manage Developer Profile"
 msgstr "Administroni Profil Zhvilluesi"
 
 #: src/olympia/devhub/templates/devhub/addons/profile.html:16
 #, python-format
-msgid ""
-"Your <a href=\"%(url)s\">developer profile</a> is currently "
-"<strong>public</strong> and <strong>required</strong> for contributions."
-msgstr ""
-"<a href=\"%(url)s\">Profili juaj si zhvillues</a> në këtë çast është "
-"<strong>publik</strong> dhe <strong>i domosdoshëm</strong> për kontribute."
+msgid "Your <a href=\"%(url)s\">developer profile</a> is currently <strong>public</strong> and <strong>required</strong> for contributions."
+msgstr "<a href=\"%(url)s\">Profili juaj si zhvillues</a> në këtë çast është <strong>publik</strong> dhe <strong>i domosdoshëm</strong> për kontribute."
 
 #: src/olympia/devhub/templates/devhub/addons/profile.html:22
 msgid "Remove Both"
@@ -5477,12 +4397,8 @@ msgstr "Hiqi të Dy"
 
 #: src/olympia/devhub/templates/devhub/addons/profile.html:27
 #, python-format
-msgid ""
-"Your <a href=\"%(url)s\">developer profile</a> is currently "
-"<strong>public</strong>."
-msgstr ""
-"<a href=\"%(url)s\">Profili juaj si zhvillues</a> në këtë çast është "
-"<strong>publik</strong>."
+msgid "Your <a href=\"%(url)s\">developer profile</a> is currently <strong>public</strong>."
+msgstr "<a href=\"%(url)s\">Profili juaj si zhvillues</a> në këtë çast është <strong>publik</strong>."
 
 #: src/olympia/devhub/templates/devhub/addons/profile.html:33
 msgid "Remove Profile"
@@ -5509,11 +4425,8 @@ msgstr "URL Shtese"
 msgid "Choose a short, unique URL slug for your add-on."
 msgstr "Zgjidhni një përshkrim të shkurtër, unik, për URL-në e shtesës suaj."
 
-#: src/olympia/devhub/templates/devhub/addons/edit/basic.html:43
-#: src/olympia/devhub/templates/devhub/includes/addons_edit_nav.html:35
-#: src/olympia/devhub/templates/devhub/personas/edit.html:56
-#: src/olympia/editors/templates/editors/review.html:255
-#: src/olympia/editors/templates/editors/themes/single.html:33
+#: src/olympia/devhub/templates/devhub/addons/edit/basic.html:43 src/olympia/devhub/templates/devhub/includes/addons_edit_nav.html:35 src/olympia/devhub/templates/devhub/personas/edit.html:56
+#: src/olympia/editors/templates/editors/review.html:255 src/olympia/editors/templates/editors/themes/single.html:33
 msgid "View Listing"
 msgstr "Shihni Listën"
 
@@ -5523,57 +4436,36 @@ msgstr "Përmbledhje"
 
 #: src/olympia/devhub/templates/devhub/addons/edit/basic.html:52
 msgid ""
-"A short explanation of your add-on's basic functionality that is displayed "
-"in search and browse listings, as well as at the top of your add-on's "
-"details page. It is only relevant for listed add-ons."
-msgstr ""
-"Një shpjegim i shkurtër i funksioneve bazë të shtesës suaj, që shfaqet në "
-"kërkime dhe lista, si dhe në krye të faqes së hollësive mbi shtesën tuaj. "
-"Kjo vlen vetëm për shtesa të paraqitura."
+"A short explanation of your add-on's basic functionality that is displayed in search and browse listings, as well as at the top of your add-on's details page. It is only relevant for listed add-ons."
+msgstr "Një shpjegim i shkurtër i funksioneve bazë të shtesës suaj, që shfaqet në kërkime dhe lista, si dhe në krye të faqes së hollësive mbi shtesën tuaj. Kjo vlen vetëm për shtesa të paraqitura."
 
 #: src/olympia/devhub/templates/devhub/addons/edit/basic.html:73
-msgid ""
-"Categories are the primary way users browse through add-ons.\n"
-"                        Choose any that fit your add-on's functionality for the most\n"
-"                        exposure. It is only relevant for listed add-ons."
+msgid "Categories are the primary way users browse through add-ons. Choose any that fit your add-on's functionality for the most exposure. It is only relevant for listed add-ons."
 msgstr ""
-"Kategoritë janë rruga parësore përmes të cilës përdoruesit shfletojnë për "
-"shtesa. Zgjidhni cilëndo që i përshtatet funksioneve të shtesës suaj për "
-"ekspozim sa më të madh. Kjo vlen vetëm për shtesat e paraqitura."
+"Kategoritë janë rruga parësore përmes të cilës përdoruesit shfletojnë për shtesa. Zgjidhni cilëndo që i përshtatet funksioneve të shtesës suaj për ekspozim sa më të madh. Kjo vlen vetëm për shtesat "
+"e paraqitura."
 
 #: src/olympia/devhub/templates/devhub/addons/edit/basic.html:90
 #, python-format
 msgid ""
-"Categories cannot be changed while your add-on is featured for this "
-"application. Please email <a href=\"mailto:%(email)s\">%(email)s</a> if "
-"there is a reason you need to modify your categories."
+"Categories cannot be changed while your add-on is featured for this application. Please email <a href=\"mailto:%(email)s\">%(email)s</a> if there is a reason you need to modify your categories."
 msgstr ""
-"Kategoritë s’mund të ndryshohen, ndërkohë që shtesa juaj është e zgjedhur "
-"për këtë aplikacion. Ju lutemi, dërgoni email te <a "
-"href=\"mailto:%(email)s\">%(email)s</a>, nëse ka ndonjë arsye që ju bën të "
-"modifikoni kategoritë tuaja."
+"Kategoritë s’mund të ndryshohen, ndërkohë që shtesa juaj është e zgjedhur për këtë aplikacion. Ju lutemi, dërgoni email te <a href=\"mailto:%(email)s\">%(email)s</a>, nëse ka ndonjë arsye që ju bën "
+"të modifikoni kategoritë tuaja."
 
 #: src/olympia/devhub/templates/devhub/addons/edit/basic.html:119
-msgid ""
-"Tags help users find your add-on and should be short descriptors such as "
-"tabs, toolbar, or twitter. You may have a maximum of {0} tags. It is only "
-"relevant for listed add-ons."
+msgid "Tags help users find your add-on and should be short descriptors such as tabs, toolbar, or twitter. You may have a maximum of {0} tags. It is only relevant for listed add-ons."
 msgstr ""
-"Etiketat i ndihmojnë përdoruesit të gjejnë shtesën tuaj dhe do të duhej të "
-"ishin përshkrues të shkurtër, fjala vjen, skeda, panel, ose Twitter. Mund të"
-" përdorni e shumta {0} etiketa. Kjo vlen vetëm për shtesa të paraqitura."
+"Etiketat i ndihmojnë përdoruesit të gjejnë shtesën tuaj dhe do të duhej të ishin përshkrues të shkurtër, fjala vjen, skeda, panel, ose Twitter. Mund të përdorni e shumta {0} etiketa. Kjo vlen vetëm "
+"për shtesa të paraqitura."
 
-#: src/olympia/devhub/templates/devhub/addons/edit/basic.html:129
-#: src/olympia/devhub/templates/devhub/personas/edit.html:97
-#: src/olympia/devhub/templates/devhub/personas/submit.html:46
+#: src/olympia/devhub/templates/devhub/addons/edit/basic.html:129 src/olympia/devhub/templates/devhub/personas/edit.html:97 src/olympia/devhub/templates/devhub/personas/submit.html:46
 msgid "Comma-separated, minimum of {0} character."
 msgid_plural "Comma-separated, minimum of {0} characters."
 msgstr[0] "Ndarë me presje, e pakta {0} shenjë."
 msgstr[1] "Ndarë me presje, e pakta {0} shenja."
 
-#: src/olympia/devhub/templates/devhub/addons/edit/basic.html:132
-#: src/olympia/devhub/templates/devhub/personas/edit.html:100
-#: src/olympia/devhub/templates/devhub/personas/submit.html:49
+#: src/olympia/devhub/templates/devhub/addons/edit/basic.html:132 src/olympia/devhub/templates/devhub/personas/edit.html:100 src/olympia/devhub/templates/devhub/personas/submit.html:49
 msgid "Example: dark, cinema, noir. Limit 20."
 msgstr "Shembull: errësirë, kinema, e zezë. Limit 20."
 
@@ -5592,47 +4484,29 @@ msgid "Add-on Details for {0}"
 msgstr "Hollësi Shtese për {0}"
 
 #: src/olympia/devhub/templates/devhub/addons/edit/details.html:22
-msgid ""
-"A longer explanation of features, functionality, and other relevant "
-"information. This field is only displayed on the add-on's details page. It "
-"is only relevant for listed add-ons."
-msgstr ""
-"Një shpejgim më i gjatë i veçorive, funksioneve, dhe të tjera të dhëna me "
-"rëndësi. Kjo fushë shfaqet vetëm te faqja e hollësive të shtesës. Vlen vetëm"
-" për shtesa të paraqitura."
+msgid "A longer explanation of features, functionality, and other relevant information. This field is only displayed on the add-on's details page. It is only relevant for listed add-ons."
+msgstr "Një shpejgim më i gjatë i veçorive, funksioneve, dhe të tjera të dhëna me rëndësi. Kjo fushë shfaqet vetëm te faqja e hollësive të shtesës. Vlen vetëm për shtesa të paraqitura."
 
-#: src/olympia/devhub/templates/devhub/addons/edit/details.html:44
-#: src/olympia/translations/templates/translations/trans-menu.html:13
+#: src/olympia/devhub/templates/devhub/addons/edit/details.html:44 src/olympia/translations/templates/translations/trans-menu.html:13
 msgid "Default Locale"
 msgstr "Gjuhë Parazgjedhje"
 
 #: src/olympia/devhub/templates/devhub/addons/edit/details.html:45
-msgid ""
-"Information about your add-on is displayed in this locale\n"
-"                        unless you override it with a locale-specific translation.\n"
-"                        It is only relevant for listed add-ons."
-msgstr ""
-"Të dhënat rreth shtesës suaj shfaqen në këtë gjuhë, veç në e anashkalofshi "
-"këtë gjë me një përkthim në një gjuhë të caktuar. Kjo vlen vetëm për shtesat"
-" e paraqitura."
+msgid "Information about your add-on is displayed in this locale unless you override it with a locale-specific translation. It is only relevant for listed add-ons."
+msgstr "Të dhënat rreth shtesës suaj shfaqen në këtë gjuhë, veç në e anashkalofshi këtë gjë me një përkthim në një gjuhë të caktuar. Kjo vlen vetëm për shtesat e paraqitura."
 
-#: src/olympia/devhub/templates/devhub/addons/edit/details.html:61
-#: src/olympia/users/forms.py:311
-#: src/olympia/users/templates/users/edit.html:122
-#: src/olympia/users/templates/users/register.html:57
+#: src/olympia/devhub/templates/devhub/addons/edit/details.html:61 src/olympia/users/forms.py:311 src/olympia/users/templates/users/edit.html:122 src/olympia/users/templates/users/register.html:57
 #: src/olympia/users/templates/users/vcard.html:22
 msgid "Homepage"
 msgstr "Faqe Hyrëse"
 
 #: src/olympia/devhub/templates/devhub/addons/edit/details.html:63
 msgid ""
-"If your add-on has another homepage, enter its address here. If your website"
-" is localized into other languages multiple translations of this field can "
-"be added. It is only relevant for listed add-ons."
+"If your add-on has another homepage, enter its address here. If your website is localized into other languages multiple translations of this field can be added. It is only relevant for listed add-"
+"ons."
 msgstr ""
-"Nëse shtesa juaj ka një tjetër faqe të vetën, jepeni këtu adresën e saj. "
-"Nëse sajti juaj është i përkthyer në gjuhë të tjera, mund të shtohen "
-"përkthime të kësaj fushe. Kjo vlen vetëm për shtesa të paraqitura."
+"Nëse shtesa juaj ka një tjetër faqe të vetën, jepeni këtu adresën e saj. Nëse sajti juaj është i përkthyer në gjuhë të tjera, mund të shtohen përkthime të kësaj fushe. Kjo vlen vetëm për shtesa të "
+"paraqitura."
 
 #: src/olympia/devhub/templates/devhub/addons/edit/media.html:3
 msgid "Images"
@@ -5649,24 +4523,19 @@ msgstr "Të dhëna Asistence për {0}"
 
 #: src/olympia/devhub/templates/devhub/addons/edit/support.html:22
 msgid ""
-"If you wish to display an e-mail address for support inquiries, enter it "
-"here. If you have different addresses for each language multiple "
-"translations of this field can be added. It is only relevant for listed add-"
-"ons."
+"If you wish to display an e-mail address for support inquiries, enter it here. If you have different addresses for each language multiple translations of this field can be added. It is only "
+"relevant for listed add-ons."
 msgstr ""
-"Nëse dëshironi të shfaqni një adresë email për çështje asistence, jepeni "
-"këtu. Nëse keni adresa të ndryshme për çdo gjuhë, mund të shtohen përkthime "
-"të kësaj fushe. Kjo vlen vetëm për shtesa të paraqitura."
+"Nëse dëshironi të shfaqni një adresë email për çështje asistence, jepeni këtu. Nëse keni adresa të ndryshme për çdo gjuhë, mund të shtohen përkthime të kësaj fushe. Kjo vlen vetëm për shtesa të "
+"paraqitura."
 
 #: src/olympia/devhub/templates/devhub/addons/edit/support.html:45
 msgid ""
-"If your add-on has a support website or forum, enter its address here. If "
-"your website is localized into other languages, multiple translations of "
-"this field can be added. It is only relevant for listed add-ons."
+"If your add-on has a support website or forum, enter its address here. If your website is localized into other languages, multiple translations of this field can be added. It is only relevant for "
+"listed add-ons."
 msgstr ""
-"Nëse për shtesën tuaj keni një sajt apo forum asistence, jepeni këtu adresën"
-" e tij. Nëse sajti juaj është i përkthyer në gjuhë të tjera, mund të shtohen"
-" përkthime të kësaj fushe. Kjo vlen vetëm për shtesa të paraqitura."
+"Nëse për shtesën tuaj keni një sajt apo forum asistence, jepeni këtu adresën e tij. Nëse sajti juaj është i përkthyer në gjuhë të tjera, mund të shtohen përkthime të kësaj fushe. Kjo vlen vetëm për "
+"shtesa të paraqitura."
 
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:6
 msgid "Technical Details"
@@ -5679,16 +4548,11 @@ msgstr "Hollësi Teknike për {0}"
 
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:23
 msgid ""
-"Any information end users may want to know that isn't necessarily applicable"
-" to the add-on summary or description. Common uses include listing known "
-"major bugs, information on how to report bugs, anticipated release date of a"
-" new version, etc. It is only relevant for listed add-ons."
+"Any information end users may want to know that isn't necessarily applicable to the add-on summary or description. Common uses include listing known major bugs, information on how to report bugs, "
+"anticipated release date of a new version, etc. It is only relevant for listed add-ons."
 msgstr ""
-"Çfarëdo të dhënash që përdoruesit e zakonshëm do të donin të dinin, që jo "
-"domosdoshmërisht hyn te përmbledhja ose përshkrimi i shtesës. Si të tilla "
-"gjenden rëndom paraqitje të metash të rëndësishme të njohura, të dhëna se si"
-" të raportohen të meta, datë e përafërt e hedhjes në qarkullim e një "
-"versioni të ri, etj. Kjo vlen vetëm për shtesa të paraqitura."
+"Çfarëdo të dhënash që përdoruesit e zakonshëm do të donin të dinin, që jo domosdoshmërisht hyn te përmbledhja ose përshkrimi i shtesës. Si të tilla gjenden rëndom paraqitje të metash të rëndësishme "
+"të njohura, të dhëna se si të raportohen të meta, datë e përafërt e hedhjes në qarkullim e një versioni të ri, etj. Kjo vlen vetëm për shtesa të paraqitura."
 
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:46
 msgid "Limit 3"
@@ -5699,12 +4563,8 @@ msgid "Add-on Flags"
 msgstr "Flamurka Shtese"
 
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:69
-msgid ""
-"These flags are used to classify add-ons. It is only\n"
-"                        relevant for listed add-ons."
-msgstr ""
-"Këto shenja përdoren për të klasifikuar shtesat. Kjo vlen vetëm për shtesa "
-"të pranishme në lista."
+msgid "These flags are used to classify add-ons. It is only relevant for listed add-ons."
+msgstr "Këto shenja përdoren për të klasifikuar shtesat. Kjo vlen vetëm për shtesa të pranishme në lista."
 
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:74
 msgid "This is a site-specific add-on."
@@ -5719,12 +4579,8 @@ msgid "View Source?"
 msgstr "Të shihet Burimi?"
 
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:90
-msgid ""
-"Whether the source of your add-on can be displayed in our\n"
-"                        online viewer. It is only relevant for listed add-ons."
-msgstr ""
-"Nëse mund të shfaqet apo jo burimi i shtesës suaj te vendi ynë përkatës në "
-"internet. Kjo vlen vetëm për shtesa të pranishme në lista."
+msgid "Whether the source of your add-on can be displayed in our online viewer. It is only relevant for listed add-ons."
+msgstr "Nëse mund të shfaqet apo jo burimi i shtesës suaj te vendi ynë përkatës në internet. Kjo vlen vetëm për shtesa të pranishme në lista."
 
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:94
 msgid "This add-on's source code is publicly viewable."
@@ -5739,14 +4595,8 @@ msgid "Public Stats?"
 msgstr "Statistika Publike?"
 
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:102
-msgid ""
-"Whether the download and usage stats of your add-on can\n"
-"                        be displayed in our online viewer.\n"
-"                        It is only relevant for listed add-ons."
-msgstr ""
-"Nëse mund të shfaqen apo jo statistika shkarkimesh dhe përdorimi të shtesës "
-"suaj te vendi ynë përkatës në internet. Kjo vlen vetëm për shtesa të "
-"pranishme në lista."
+msgid "Whether the download and usage stats of your add-on can be displayed in our online viewer. It is only relevant for listed add-ons."
+msgstr "Nëse mund të shfaqen apo jo statistika shkarkimesh dhe përdorimi të shtesës suaj te vendi ynë përkatës në internet. Kjo vlen vetëm për shtesa të pranishme në lista."
 
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:107
 msgid "This add-on's stats are publicly viewable."
@@ -5761,22 +4611,12 @@ msgid "Upgrade SDK?"
 msgstr "Të përmirësohet SDK-ja?"
 
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:116
-msgid ""
-"If selected, we will try to automatically upgrade your\n"
-"                        add-on when a new version of the SDK is released.\n"
-"                        It is only relevant for listed add-ons."
-msgstr ""
-"Në u përzgjedhtë, do të përpiqemi ta përmirësojmë vetvetiu shtesën tuaj, kur"
-" të ketë një version të ri të SDK-së. Kjo vlen vetëm për shtesa të "
-"paraqitura."
+msgid "If selected, we will try to automatically upgrade your add-on when a new version of the SDK is released. It is only relevant for listed add-ons."
+msgstr "Në u përzgjedhtë, do të përpiqemi ta përmirësojmë vetvetiu shtesën tuaj, kur të ketë një version të ri të SDK-së. Kjo vlen vetëm për shtesa të paraqitura."
 
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:121
-msgid ""
-"This add-on will be automatically upgraded to new versions of the Add-on "
-"SDK."
-msgstr ""
-"Kjo shtesë do të përmirësohet vetvetiu sipas versionesh të rinj SDK-je "
-"Shtesash."
+msgid "This add-on will be automatically upgraded to new versions of the Add-on SDK."
+msgstr "Kjo shtesë do të përmirësohet vetvetiu sipas versionesh të rinj SDK-je Shtesash."
 
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:123
 msgid "No, this add-on will be upgraded manually."
@@ -5791,30 +4631,20 @@ msgid "UUID"
 msgstr "UUID"
 
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:132
-msgid ""
-"The UUID of your add-on is specified in its install manifest and uniquely "
-"identifies it. You cannot change your UUID once it has been submitted."
-msgstr ""
-"UUID-ja e shtesës suaj caktohet te <em>install manifest</em>-i përkatës dhe "
-"e identifikon atë në mënyrë unike. UUID-në s’mund ta ndryshoni më dot pasi "
-"shtesa të jetë parashtruar."
+msgid "The UUID of your add-on is specified in its install manifest and uniquely identifies it. You cannot change your UUID once it has been submitted."
+msgstr "UUID-ja e shtesës suaj caktohet te <em>install manifest</em>-i përkatës dhe e identifikon atë në mënyrë unike. UUID-në s’mund ta ndryshoni më dot pasi shtesa të jetë parashtruar."
 
-#: src/olympia/devhub/templates/devhub/addons/edit/technical.html:143
-#: src/olympia/devhub/templates/devhub/addons/edit/technical.html:144
+#: src/olympia/devhub/templates/devhub/addons/edit/technical.html:143 src/olympia/devhub/templates/devhub/addons/edit/technical.html:144
 msgid "Whiteboard"
 msgstr "Tabela"
 
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:146
 msgid ""
-"The whiteboard is the place to provide information relevant to your addon, "
-"whatever the version, to the editor. Use it to provide ways to test the "
-"addon, and any additional information that may help. This whiteboard is also"
-" editable by editors."
+"The whiteboard is the place to provide information relevant to your addon, whatever the version, to the editor. Use it to provide ways to test the addon, and any additional information that may "
+"help. This whiteboard is also editable by editors."
 msgstr ""
-"Tabela është vendi për t’i dhënë redaktorit të dhëna që lidhen me shtesën "
-"tuaj, cilido qoftë versioni. Përdoreni për të ofruar rrugë për testimin e "
-"shtesës, dhe çfarëdo të dhënash shtesë që mund të hyjnë në punë. Tabelën "
-"mund ta përpunojnë gjithashtu edhe redaktorët."
+"Tabela është vendi për t’i dhënë redaktorit të dhëna që lidhen me shtesën tuaj, cilido qoftë versioni. Përdoreni për të ofruar rrugë për testimin e shtesës, dhe çfarëdo të dhënash shtesë që mund të "
+"hyjnë në punë. Tabelën mund ta përpunojnë gjithashtu edhe redaktorët."
 
 #: src/olympia/devhub/templates/devhub/addons/edit/technical_dependencies.html:9
 msgid "Remove this dependent add-on"
@@ -5834,15 +4664,11 @@ msgstr "Ikonë shtese"
 
 #: src/olympia/devhub/templates/devhub/addons/forms_shared/media.html:16
 msgid ""
-"Upload an icon for your add-on or choose from one of ours. The icon is "
-"displayed nearly everywhere your add-on is. Uploaded images must be one of "
-"the following image types: .png, .jpg. It is only relevant for listed add-"
-"ons."
+"Upload an icon for your add-on or choose from one of ours. The icon is displayed nearly everywhere your add-on is. Uploaded images must be one of the following image types: .png, .jpg. It is only "
+"relevant for listed add-ons."
 msgstr ""
-"ngarkoni një ikonë për shtesën tuaj ose zgjidhni një nga tonat. Ikona "
-"shfaqet thuajse kudo ku shfaqet shtesa juaj. Figurat e ngarkuara duhet të "
-"jenë në një nga llojet vijuese për figura: .png, .jpg. Kjo vlen vetëm për "
-"shtesa të shfaqura."
+"ngarkoni një ikonë për shtesën tuaj ose zgjidhni një nga tonat. Ikona shfaqet thuajse kudo ku shfaqet shtesa juaj. Figurat e ngarkuara duhet të jenë në një nga llojet vijuese për figura: .png, ."
+"jpg. Kjo vlen vetëm për shtesa të shfaqura."
 
 #: src/olympia/devhub/templates/devhub/addons/forms_shared/media.html:25
 msgid "Select an icon for your add-on:"
@@ -5854,12 +4680,8 @@ msgid "32x32px"
 msgstr "32x32px"
 
 #: src/olympia/devhub/templates/devhub/addons/forms_shared/media.html:39
-msgid ""
-"Used in listings of add-ons, like search results\n"
-"                            and featured add-ons."
-msgstr ""
-"E përdorur në lista shtesash, të tilla si përfundime kërkimi dhe shtesa të "
-"zgjedhura."
+msgid "Used in listings of add-ons, like search results and featured add-ons."
+msgstr "E përdorur në lista shtesash, të tilla si përfundime kërkimi dhe shtesa të zgjedhura."
 
 #. The size of the icon
 #: src/olympia/devhub/templates/devhub/addons/forms_shared/media.html:48
@@ -5876,9 +4698,7 @@ msgstr "Ngarkoni një Ikonë të Personalizuar..."
 
 #: src/olympia/devhub/templates/devhub/addons/forms_shared/media.html:65
 msgid "PNG and JPG supported. Icons resized to 64x64 pixels if larger."
-msgstr ""
-"Mbulohen PNG-të dhe JPG-të. Ikonat ripërmasohen në 64x64 piksel, po qenë më "
-"të mëdha."
+msgstr "Mbulohen PNG-të dhe JPG-të. Ikonat ripërmasohen në 64x64 piksel, po qenë më të mëdha."
 
 #: src/olympia/devhub/templates/devhub/addons/forms_shared/media.html:83
 msgid "Screenshots"
@@ -5900,61 +4720,49 @@ msgstr "Shtoni një Foto Ekrani..."
 msgid "Tests"
 msgstr "Prova"
 
-#: src/olympia/devhub/templates/devhub/addons/includes/validation_compat_test_results.html:25
-#: src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:5
+#: src/olympia/devhub/templates/devhub/addons/includes/validation_compat_test_results.html:25 src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:5
 #: src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:53
 msgid "General Tests"
 msgstr "Prova të Përgjithshme"
 
-#: src/olympia/devhub/templates/devhub/addons/includes/validation_compat_test_results.html:32
-#: src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:9
+#: src/olympia/devhub/templates/devhub/addons/includes/validation_compat_test_results.html:32 src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:9
 #: src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:67
 msgid "Security Tests"
 msgstr "Prova Sigurie"
 
-#: src/olympia/devhub/templates/devhub/addons/includes/validation_compat_test_results.html:39
-#: src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:13
+#: src/olympia/devhub/templates/devhub/addons/includes/validation_compat_test_results.html:39 src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:13
 #: src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:80
 msgid "Extension Tests"
 msgstr "Prova Zgjerimi"
 
-#: src/olympia/devhub/templates/devhub/addons/includes/validation_compat_test_results.html:46
-#: src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:17
+#: src/olympia/devhub/templates/devhub/addons/includes/validation_compat_test_results.html:46 src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:17
 #: src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:93
 msgid "Localization Tests"
 msgstr "Prova Lokalizimi"
 
-#: src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:21
-#: src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:106
+#: src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:21 src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:106
 msgid "Compatibility Tests"
 msgstr "Prova Përputhshmërie"
 
-#: src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:29
-#: src/olympia/files/templates/files/viewer.html:142
+#: src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:29 src/olympia/files/templates/files/viewer.html:142
 msgid "Hide messages not required for automated signing"
 msgstr "Fshihi mesazhet që s’janë të domosdoshëm për nënshkrim automatik"
 
-#: src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:35
-#: src/olympia/files/templates/files/viewer.html:150
+#: src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:35 src/olympia/files/templates/files/viewer.html:150
 msgid "Hide messages present in previous version and ignored"
-msgstr ""
-"Fshihi mesazhet e pranishëm në versione të mëparshëm dhe të shpërfillur"
+msgstr "Fshihi mesazhet e pranishëm në versione të mëparshëm dhe të shpërfillur"
 
-#: src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:50
-#: src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:64
-#: src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:77
-#: src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:90
+#: src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:50 src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:64
+#: src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:77 src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:90
 #: src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:103
 msgid "Top"
 msgstr "Krye"
 
-#: src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:2
-#: src/olympia/devhub/templates/devhub/personas/edit.html:63
+#: src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:2 src/olympia/devhub/templates/devhub/personas/edit.html:63
 msgid "Delete Theme"
 msgstr "Fshije Temën"
 
-#: src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:2
-#: src/olympia/devhub/templates/devhub/versions/list.html:117
+#: src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:2 src/olympia/devhub/templates/devhub/versions/list.html:117
 msgid "Delete Add-on"
 msgstr "Fshije Shtesë"
 
@@ -5963,29 +4771,22 @@ msgid "Deleting your theme will permanently remove it from the site."
 msgstr "Fshirja e temës suaj do ta heqë përgjithmonë nga sajti."
 
 #: src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:14
-msgid ""
-"Deleting your add-on will permanently remove it from the site and prevent "
-"its GUID from being submitted again by others."
-msgstr ""
-"Fshirja e shtesë suaj do ta heqë përgjithmonë prej sajtit dhe do të "
-"parandalojë parashtrimin sërish nga të tjerë të GUID-it të saj."
+msgid "Deleting your add-on will permanently remove it from the site and prevent its GUID from being submitted again by others."
+msgstr "Fshirja e shtesë suaj do ta heqë përgjithmonë prej sajtit dhe do të parandalojë parashtrimin sërish nga të tjerë të GUID-it të saj."
 
 #: src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:24
-msgid ""
-"Enter the following text confirm your decision:\n"
-"           {slug}"
+msgid "Enter the following text confirm your decision: {slug}"
 msgstr "Jepni tekstin vijues që të ripohoni vendimin tuaj: {slug}"
 
-#: src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:34
+#: src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:33
 msgid "Please tell us why you are deleting your theme:"
 msgstr "Ju lutemi, na tregoni përse po e fshini temën tuaj:"
 
-#: src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:36
+#: src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:35
 msgid "Please tell us why you are deleting your add-on:"
 msgstr "Ju lutemi, na tregoni përse po e fshini shtesën tuaj:"
 
-#: src/olympia/devhub/templates/devhub/addons/listing/item_actions.html:1
-#: src/olympia/devhub/templates/devhub/addons/listing/item_actions_theme.html:1
+#: src/olympia/devhub/templates/devhub/addons/listing/item_actions.html:1 src/olympia/devhub/templates/devhub/addons/listing/item_actions_theme.html:1
 #: src/olympia/editors/templates/editors/review.html:253
 msgid "Actions"
 msgstr "Veprime"
@@ -6018,22 +4819,17 @@ msgstr "Version i Ri"
 msgid "Daily statistics on downloads and users."
 msgstr "Statistika të përditshme mbi shkarkimet dhe përdoruesit."
 
-#: src/olympia/devhub/templates/devhub/addons/listing/item_actions.html:45
-#: src/olympia/stats/templates/stats/stats.html:75
-#: src/olympia/stats/templates/stats/stats.html:79
-#: src/olympia/stats/templates/stats/stats.html:81
+#: src/olympia/devhub/templates/devhub/addons/listing/item_actions.html:45 src/olympia/stats/templates/stats/stats.html:31 src/olympia/stats/templates/stats/stats.html:35
+#: src/olympia/stats/templates/stats/stats.html:37
 msgid "Statistics"
 msgstr "Statistika"
 
-#: src/olympia/devhub/templates/devhub/addons/listing/item_actions.html:54
-#: src/olympia/devhub/templates/devhub/includes/addons_edit_nav.html:5
-#: src/olympia/devhub/templates/devhub/payments/payments.html:3
-#: src/olympia/devhub/templates/devhub/payments/tier.html:4
+#: src/olympia/devhub/templates/devhub/addons/listing/item_actions.html:54 src/olympia/devhub/templates/devhub/includes/addons_edit_nav.html:5
+#: src/olympia/devhub/templates/devhub/payments/payments.html:3 src/olympia/devhub/templates/devhub/payments/tier.html:4
 msgid "Manage Payments"
 msgstr "Administroni Pagesat"
 
-#: src/olympia/devhub/templates/devhub/addons/listing/item_actions.html:55
-#: src/olympia/devhub/templates/devhub/includes/addons_edit_nav.html:6
+#: src/olympia/devhub/templates/devhub/addons/listing/item_actions.html:55 src/olympia/devhub/templates/devhub/includes/addons_edit_nav.html:6
 msgid "Manage Status & Versions"
 msgstr "Administroni Gjendje & Versione"
 
@@ -6041,10 +4837,8 @@ msgstr "Administroni Gjendje & Versione"
 msgid "View Add-on Listing"
 msgstr "Shihni Listën e Shtesave"
 
-#: src/olympia/devhub/templates/devhub/addons/listing/item_actions.html:64
-#: src/olympia/devhub/templates/devhub/addons/listing/item_actions_theme.html:12
-#: src/olympia/devhub/templates/devhub/includes/addons_edit_nav.html:37
-#: src/olympia/devhub/templates/devhub/personas/edit.html:58
+#: src/olympia/devhub/templates/devhub/addons/listing/item_actions.html:64 src/olympia/devhub/templates/devhub/addons/listing/item_actions_theme.html:12
+#: src/olympia/devhub/templates/devhub/includes/addons_edit_nav.html:37 src/olympia/devhub/templates/devhub/personas/edit.html:58
 msgid "View Recent Changes"
 msgstr "Shihni Ndryshimet Së Fundi"
 
@@ -6069,12 +4863,8 @@ msgid "Delete this theme."
 msgstr "Fshije këtë temë."
 
 #: src/olympia/devhub/templates/devhub/addons/listing/items.html:10
-msgid ""
-"This add-on will be deleted automatically after a few days if the submission"
-" process is not completed."
-msgstr ""
-"Kjo shtesë do të fshihet vetvetiu pas pak ditësh, nëse procesi i "
-"parashtrimit lihet i paplotësuar."
+msgid "This add-on will be deleted automatically after a few days if the submission process is not completed."
+msgstr "Kjo shtesë do të fshihet vetvetiu pas pak ditësh, nëse procesi i parashtrimit lihet i paplotësuar."
 
 #: src/olympia/devhub/templates/devhub/addons/listing/items.html:27
 msgid "Disabled"
@@ -6112,13 +4902,9 @@ msgstr "Emër dhe version:"
 msgid "The detail page will be:"
 msgstr "Faqja e hollësive do të jetë:"
 
-#: src/olympia/devhub/templates/devhub/addons/submit/describe.html:24
-#: src/olympia/devhub/templates/devhub/personas/edit.html:89
-#: src/olympia/devhub/templates/devhub/personas/submit.html:38
+#: src/olympia/devhub/templates/devhub/addons/submit/describe.html:24 src/olympia/devhub/templates/devhub/personas/edit.html:89 src/olympia/devhub/templates/devhub/personas/submit.html:38
 msgid "Please use only letters, numbers, underscores, and dashes in your URL."
-msgstr ""
-"Ju lutemi, përdorni te URL-ja juaj shkronja, numra, nënvija dhe vija "
-"ndarëse."
+msgstr "Ju lutemi, përdorni te URL-ja juaj shkronja, numra, nënvija dhe vija ndarëse."
 
 #: src/olympia/devhub/templates/devhub/addons/submit/describe.html:34
 msgid "Provide a brief summary:"
@@ -6126,8 +4912,7 @@ msgstr "Jepni një përmbledhje të shkurtër:"
 
 #: src/olympia/devhub/templates/devhub/addons/submit/describe.html:39
 msgid "This summary will be shown in listings and searches."
-msgstr ""
-"Kjo përmbledhje do të shfaqet tok me shtesën tuaj në kërkime dhe lista."
+msgstr "Kjo përmbledhje do të shfaqet tok me shtesën tuaj në kërkime dhe lista."
 
 #: src/olympia/devhub/templates/devhub/addons/submit/describe.html:58
 msgid "Provide a more detailed description:"
@@ -6137,14 +4922,11 @@ msgstr "Jepni një përshkrim më të hollësishëm:"
 msgid "The description will appear on the detail page."
 msgstr "Përshkrimi do të shfaqet te faqja e hollësive."
 
-#: src/olympia/devhub/templates/devhub/addons/submit/done.html:4
-#: src/olympia/devhub/templates/devhub/personas/submit_done.html:4
+#: src/olympia/devhub/templates/devhub/addons/submit/done.html:4 src/olympia/devhub/templates/devhub/personas/submit_done.html:4
 msgid "Submission Complete"
 msgstr "Parashtrim i Plotësuar"
 
-#: src/olympia/devhub/templates/devhub/addons/submit/done.html:8
-#: src/olympia/devhub/templates/devhub/addons/submit/sidebar.html:13
-#: src/olympia/devhub/templates/devhub/personas/submit_done.html:8
+#: src/olympia/devhub/templates/devhub/addons/submit/done.html:8 src/olympia/devhub/templates/devhub/addons/submit/sidebar.html:13 src/olympia/devhub/templates/devhub/personas/submit_done.html:8
 msgid "You're done!"
 msgstr "Kaq qe!"
 
@@ -6157,54 +4939,32 @@ msgid "Your add-on has been submitted to the Full Review queue."
 msgstr "Shtesa juaj është parashtruar te radha për Shqyrtim të Plotë."
 
 #: src/olympia/devhub/templates/devhub/addons/submit/done.html:18
-msgid ""
-"You'll receive an email once it has been reviewed by an editor. In\n"
-"          the meantime, you and your friends can install it directly from its\n"
-"          details page:"
-msgstr ""
-"Sapo shtesa juaj të jetë shqyrtuar nga një redaktor, do të merrni një email."
-" Ndërkohë, ju dhe miqtë tuaj mund ta instaloni shtesën drejt e nga faqja "
-"përkatëse:"
+msgid "You'll receive an email once it has been reviewed by an editor. In the meantime, you and your friends can install it directly from its details page:"
+msgstr "Sapo shtesa juaj të jetë shqyrtuar nga një redaktor, do të merrni një email. Ndërkohë, ju dhe miqtë tuaj mund ta instaloni shtesën drejt e nga faqja përkatëse:"
 
-#: src/olympia/devhub/templates/devhub/addons/submit/done.html:27
-#: src/olympia/devhub/templates/devhub/addons/submit/done.html:77
-#: src/olympia/devhub/templates/devhub/personas/submit_done.html:16
+#: src/olympia/devhub/templates/devhub/addons/submit/done.html:27 src/olympia/devhub/templates/devhub/addons/submit/done.html:77 src/olympia/devhub/templates/devhub/personas/submit_done.html:16
 msgid "Next steps:"
 msgstr "Hapat pasues:"
 
-#: src/olympia/devhub/templates/devhub/addons/submit/done.html:32
-#: src/olympia/devhub/templates/devhub/addons/submit/done.html:82
+#: src/olympia/devhub/templates/devhub/addons/submit/done.html:32 src/olympia/devhub/templates/devhub/addons/submit/done.html:82
 msgid "<a href=\"{0}\">Upload</a> another platform-specific file to this version."
-msgstr ""
-"<a href=\"{0}\">Ngarkoni</a> te ky version një kartelë për një platformë "
-"tjetër."
+msgstr "<a href=\"{0}\">Ngarkoni</a> te ky version një kartelë për një platformë tjetër."
 
 #: src/olympia/devhub/templates/devhub/addons/submit/done.html:34
 msgid "Provide more details by <a href=\"{0}\">editing its listing</a>."
 msgstr "Jepni më tepër hollësi duke <a href=\"{0}\">përpunuar pjesën për të</a>."
 
 #: src/olympia/devhub/templates/devhub/addons/submit/done.html:35
-msgid ""
-"Tell your users why you created this in your <a href=\"{0}\">Developer "
-"Profile</a>."
-msgstr ""
-"Tregojuni përdoruesve tuaj, te faqja juaj <a href=\"{0}\">Profil "
-"Zhvilluesi</a>, pse e krijuat këtë."
+msgid "Tell your users why you created this in your <a href=\"{0}\">Developer Profile</a>."
+msgstr "Tregojuni përdoruesve tuaj, te faqja juaj <a href=\"{0}\">Profil Zhvilluesi</a>, pse e krijuat këtë."
 
 #: src/olympia/devhub/templates/devhub/addons/submit/done.html:36
-msgid ""
-"View and subscribe to your add-on's <a href=\"{0}\">activity feed</a> to "
-"stay updated on reviews, collections, and more."
-msgstr ""
-"Shihni dhe pajtohuni te <a href=\"{0}\">prurja mbi veprimtarinë</a> te "
-"shtesa juaj, që të ndiqni shqyrtimet, koleksionet dhe të tjera gjëra."
+msgid "View and subscribe to your add-on's <a href=\"{0}\">activity feed</a> to stay updated on reviews, collections, and more."
+msgstr "Shihni dhe pajtohuni te <a href=\"{0}\">prurja mbi veprimtarinë</a> te shtesa juaj, që të ndiqni shqyrtimet, koleksionet dhe të tjera gjëra."
 
-#: src/olympia/devhub/templates/devhub/addons/submit/done.html:37
-#: src/olympia/devhub/templates/devhub/addons/submit/done.html:86
+#: src/olympia/devhub/templates/devhub/addons/submit/done.html:37 src/olympia/devhub/templates/devhub/addons/submit/done.html:86
 msgid "View approximate review queue <a href=\"{0}\">wait times</a>."
-msgstr ""
-"Shihni <a href=\"{0}\">kohë pritjeje</a> përafërsisht në radhën e "
-"shqyrtimeve."
+msgstr "Shihni <a href=\"{0}\">kohë pritjeje</a> përafërsisht në radhën e shqyrtimeve."
 
 #: src/olympia/devhub/templates/devhub/addons/submit/done.html:42
 msgid "Get Ahead in the Review Queue!"
@@ -6212,48 +4972,31 @@ msgstr "Bëni Përpara te Radha e Shqyrtimeve!"
 
 #: src/olympia/devhub/templates/devhub/addons/submit/done.html:45
 msgid "Become an AMO Reviewer today and get your add-ons reviewed faster."
-msgstr ""
-"Bëhuni që sot një Shqyrtues AMO dhe bëni që shtesat tuaja të shqyrtohen më "
-"shpejt."
+msgstr "Bëhuni që sot një Shqyrtues AMO dhe bëni që shtesat tuaja të shqyrtohen më shpejt."
 
 #: src/olympia/devhub/templates/devhub/addons/submit/done.html:54
-msgid ""
-"Your add-on has been signed and it's ready to use. You can download it here:"
-msgstr ""
-"Shtesa juaj është nënshkruar dhe është gati për përdorim. Mund ta shkarkoni "
-"që këtu:"
+msgid "Your add-on has been signed and it's ready to use. You can download it here:"
+msgstr "Shtesa juaj është nënshkruar dhe është gati për përdorim. Mund ta shkarkoni që këtu:"
 
 #: src/olympia/devhub/templates/devhub/addons/submit/done.html:64
-msgid ""
-"Your add-on has been submitted to the Unlisted Preliminary Review queue."
-msgstr ""
-"Shtesa juaj është parashtruar te radha e Shqyrtimit Paraprak të të "
-"Paklasifikuarave."
+msgid "Your add-on has been submitted to the Unlisted Preliminary Review queue."
+msgstr "Shtesa juaj është parashtruar te radha e Shqyrtimit Paraprak të të Paklasifikuarave."
 
 #: src/olympia/devhub/templates/devhub/addons/submit/done.html:66
 msgid "Your add-on has been submitted to the Unlisted Full Review queue."
-msgstr ""
-"Shtesa juaj është parashtruar te radha e Shqyrtimit të Plotë të të "
-"Paklasifikuarave."
+msgstr "Shtesa juaj është parashtruar te radha e Shqyrtimit të Plotë të të Paklasifikuarave."
 
 #: src/olympia/devhub/templates/devhub/addons/submit/done.html:70
-msgid ""
-"You'll receive an email once it has been reviewed by an editor and signed."
-msgstr ""
-"Do të merrni një email, sapo të jetë shqyrtuar nga një redaktor dhe "
-"nënshkruar."
+msgid "You'll receive an email once it has been reviewed by an editor and signed."
+msgstr "Do të merrni një email, sapo të jetë shqyrtuar nga një redaktor dhe nënshkruar."
 
 #: src/olympia/devhub/templates/devhub/addons/submit/done.html:74
 msgid "Your add-on will not be publicly available on this website."
 msgstr "Shtesa juaj s’do jetë e passhme që nga ky sajt."
 
 #: src/olympia/devhub/templates/devhub/addons/submit/done.html:84
-msgid ""
-"You can upload new versions of your add-on in the <a href=\"{0}\">add-on's "
-"developer page</a>."
-msgstr ""
-"Mund të ngarkoni versione të rinj të shtesës suaj te <a href=\"{0}\">faqja e"
-" zhvilluesve të shtesave</a>."
+msgid "You can upload new versions of your add-on in the <a href=\"{0}\">add-on's developer page</a>."
+msgstr "Mund të ngarkoni versione të rinj të shtesës suaj te <a href=\"{0}\">faqja e zhvilluesve të shtesave</a>."
 
 #: src/olympia/devhub/templates/devhub/addons/submit/license.html:4
 msgid "Step 5"
@@ -6264,14 +5007,9 @@ msgid "Step 5. Select a License"
 msgstr "Hapi 5. Përzgjidhni një Licencë"
 
 #: src/olympia/devhub/templates/devhub/addons/submit/license.html:9
-msgid ""
-"We require all add-ons to indicate the terms under which their source code "
-"is licensed. Please select a license from the list below or enter a custom "
-"license."
+msgid "We require all add-ons to indicate the terms under which their source code is licensed. Please select a license from the list below or enter a custom license."
 msgstr ""
-"Kërkojmë medoemos që krejt shtesat të tregojnë kushtet sipas të cilave "
-"licencohet kodi i tyre burim. Ju lutemi, përzgjidhni një licencë nga lista "
-"më poshtë ose jepni një leje të personalizuar."
+"Kërkojmë medoemos që krejt shtesat të tregojnë kushtet sipas të cilave licencohet kodi i tyre burim. Ju lutemi, përzgjidhni një licencë nga lista më poshtë ose jepni një leje të personalizuar."
 
 #: src/olympia/devhub/templates/devhub/addons/submit/license.html:18
 msgid "Select a license for your add-on:"
@@ -6287,14 +5025,11 @@ msgstr "Hapi 4. Shtoni Figura"
 
 #: src/olympia/devhub/templates/devhub/addons/submit/media.html:9
 msgid ""
-"Custom icons and screenshots draw attention and help users understand what "
-"it does. We strongly recommend uploading a custom icon, as in some areas of "
-"the website, only the icon and name will appear."
+"Custom icons and screenshots draw attention and help users understand what it does. We strongly recommend uploading a custom icon, as in some areas of the website, only the icon and name will "
+"appear."
 msgstr ""
-"Ikonat dhe fotot e personalizuara të ekranit tërheqin vëmendjen te shtesa "
-"juaj dhe i ndihmojnë përdoruesit të kuptojnë se çfarë kryen ajo. Këshillojmë"
-" me forcë ngarkimin e një ikone të personalizuar, ngaqë në disa zona të "
-"sajtit do të shfaqet vetëm ikona dhe emri i shtesës suaj."
+"Ikonat dhe fotot e personalizuara të ekranit tërheqin vëmendjen te shtesa juaj dhe i ndihmojnë përdoruesit të kuptojnë se çfarë kryen ajo. Këshillojmë me forcë ngarkimin e një ikone të "
+"personalizuar, ngaqë në disa zona të sajtit do të shfaqet vetëm ikona dhe emri i shtesës suaj."
 
 #: src/olympia/devhub/templates/devhub/addons/submit/select-review.html:5
 msgid "Step 6"
@@ -6306,25 +5041,16 @@ msgstr "Hapi 6. Përzgjidhni një Proces Shqyrtimi"
 
 #: src/olympia/devhub/templates/devhub/addons/submit/select-review.html:10
 msgid ""
-"All add-ons hosted in our gallery must be reviewed by an editor before they "
-"appear in categories or search results. While waiting for review, your add-"
-"on can still be accessed through its direct URL. Please choose the review "
-"process below that best fits your add-on."
+"All add-ons hosted in our gallery must be reviewed by an editor before they appear in categories or search results. While waiting for review, your add-on can still be accessed through its direct "
+"URL. Please choose the review process below that best fits your add-on."
 msgstr ""
-"Krejt shtesat e strehuara në galerinë tonë duhet të shqyrtohen nga një "
-"redaktor përpara se të shfaqen te kategoritë apo përfundimet e kërkimit. "
-"Teksa pritet ta shqyrtojnë, shtesa juaj mund të merret përmes URL-së së "
-"drejtpërdrejtë. Ju lutemi, zgjidhni më poshtë procesin e shqyrtimit që i "
-"shkon më për shtat shtesës suaj."
+"Krejt shtesat e strehuara në galerinë tonë duhet të shqyrtohen nga një redaktor përpara se të shfaqen te kategoritë apo përfundimet e kërkimit. Teksa pritet ta shqyrtojnë, shtesa juaj mund të "
+"merret përmes URL-së së drejtpërdrejtë. Ju lutemi, zgjidhni më poshtë procesin e shqyrtimit që i shkon më për shtat shtesës suaj."
 
 #: src/olympia/devhub/templates/devhub/addons/submit/select-review.html:26
 #, python-format
-msgid ""
-"A complete review of your add-on's source and functionality. <a "
-"href=\"%(url)s\">Learn more&hellip;</a>"
-msgstr ""
-"Shqyrtim i plotë i burimit të shtesës suaj dhe funksionimit të saj. <a "
-"href=\"%(url)s\">Mësoni më tepër&hellip;</a>"
+msgid "A complete review of your add-on's source and functionality. <a href=\"%(url)s\">Learn more&hellip;</a>"
+msgstr "Shqyrtim i plotë i burimit të shtesës suaj dhe funksionimit të saj. <a href=\"%(url)s\">Mësoni më tepër&hellip;</a>"
 
 #: src/olympia/devhub/templates/devhub/addons/submit/select-review.html:32
 msgid "Appropriate for polished add-ons"
@@ -6332,8 +5058,7 @@ msgstr "E përshtatshme për shtesa të lëmuara"
 
 #: src/olympia/devhub/templates/devhub/addons/submit/select-review.html:33
 msgid "Required if add-on is bundled in an installer"
-msgstr ""
-"E domosdoshme, nëse shtesa paketohet tok me një instalues aplikacioni."
+msgstr "E domosdoshme, nëse shtesa paketohet tok me një instalues aplikacioni."
 
 #: src/olympia/devhub/templates/devhub/addons/submit/select-review.html:34
 msgid "Review should take place within 10 days"
@@ -6353,12 +5078,8 @@ msgstr "Zgjidhni Shqyrtim të Plotë"
 
 #: src/olympia/devhub/templates/devhub/addons/submit/select-review.html:49
 #, python-format
-msgid ""
-"A faster review of your add-on's source for any major problems. <a "
-"href=\"%(url)s\">Learn more&hellip;</a>"
-msgstr ""
-"Shqyrtim më i shpejtë i burimit të shtesës suaj për çfarëdo problemi madhor."
-" <a href=\"%(url)s\">Mësoni më tepër&hellip;</a>"
+msgid "A faster review of your add-on's source for any major problems. <a href=\"%(url)s\">Learn more&hellip;</a>"
+msgstr "Shqyrtim më i shpejtë i burimit të shtesës suaj për çfarëdo problemi madhor. <a href=\"%(url)s\">Mësoni më tepër&hellip;</a>"
 
 #: src/olympia/devhub/templates/devhub/addons/submit/select-review.html:55
 msgid "Appropriate for experimental add-ons"
@@ -6404,10 +5125,8 @@ msgstr "Përzgjidhni një licencë"
 msgid "Select a review process"
 msgstr "Përzgjidhni një proces shqyrtimi"
 
-#: src/olympia/devhub/templates/devhub/addons/submit/sidebar.html:18
-#: src/olympia/devhub/templates/devhub/docs/policies-submission.html:3
-#: src/olympia/devhub/templates/devhub/docs/policies-submission.html:7
-#: src/olympia/devhub/templates/devhub/docs/policies-submission.html:9
+#: src/olympia/devhub/templates/devhub/addons/submit/sidebar.html:18 src/olympia/devhub/templates/devhub/docs/policies-submission.html:3
+#: src/olympia/devhub/templates/devhub/docs/policies-submission.html:7 src/olympia/devhub/templates/devhub/docs/policies-submission.html:9
 msgid "Submission Process"
 msgstr "Proces Parashtrimi"
 
@@ -6428,27 +5147,20 @@ msgid "Step 2. Upload Your Add-on"
 msgstr "Hapi 2. Ngarkojeni Shtesën Tuaj"
 
 #: src/olympia/devhub/templates/devhub/addons/submit/upload.html:11
-msgid ""
-"Use the fields below to upload your add-on package and select any platform "
-"restrictions. After upload, a series of automated validation tests will be "
-"run on your file."
+msgid "Use the fields below to upload your add-on package and select any platform restrictions. After upload, a series of automated validation tests will be run on your file."
 msgstr ""
-"Për ngarkimin e paketës së shtesës suaj dhe përzgjedhjen e çfarëdo kufizimi "
-"platforme, përdorni fushat më poshtë. Pas ngarkimit, mbi kartelën tuaj do të"
-" xhirohen një varg provash të automatizuara vleftësimi."
+"Për ngarkimin e paketës së shtesës suaj dhe përzgjedhjen e çfarëdo kufizimi platforme, përdorni fushat më poshtë. Pas ngarkimit, mbi kartelën tuaj do të xhirohen një varg provash të automatizuara "
+"vleftësimi."
 
-#: src/olympia/devhub/templates/devhub/addons/submit/upload.html:59
-#: src/olympia/devhub/templates/devhub/versions/add_file_modal.html:39
+#: src/olympia/devhub/templates/devhub/addons/submit/upload.html:51 src/olympia/devhub/templates/devhub/versions/add_file_modal.html:28
 msgid "Which platforms is this file compatible with?"
 msgstr "Me cilat platforma është e përputhshme kjo kartelë?"
 
-#: src/olympia/devhub/templates/devhub/addons/submit/upload.html:67
-#: src/olympia/devhub/templates/devhub/versions/add_file_modal.html:65
+#: src/olympia/devhub/templates/devhub/addons/submit/upload.html:59 src/olympia/devhub/templates/devhub/versions/add_file_modal.html:45
 msgid "Administrative overrides"
 msgstr "Anashkalime administrative"
 
-#: src/olympia/devhub/templates/devhub/api/agreement.html:3
-#: src/olympia/devhub/templates/devhub/api/agreement.html:11
+#: src/olympia/devhub/templates/devhub/api/agreement.html:3 src/olympia/devhub/templates/devhub/api/agreement.html:11
 msgid "Firefox Add-on Distribution Agreement"
 msgstr "Marrëveshje Shpërndarjesh Shtesash Firefox-i"
 
@@ -6458,12 +5170,8 @@ msgstr "Kredenciale API"
 
 #: src/olympia/devhub/templates/devhub/api/key.html:20
 #, python-format
-msgid ""
-"For detailed instructions, consult the <a href=\"%(docs_url)s\">API "
-"documentation</a>."
-msgstr ""
-"Për udhëzime të hollësishme, shihni <a href=\"%(docs_url)s\">dokumentimin e "
-"API-t</a>."
+msgid "For detailed instructions, consult the <a href=\"%(docs_url)s\">API documentation</a>."
+msgstr "Për udhëzime të hollësishme, shihni <a href=\"%(docs_url)s\">dokumentimin e API-t</a>."
 
 #: src/olympia/devhub/templates/devhub/api/key.html:28
 msgid "JWT issuer"
@@ -6476,15 +5184,11 @@ msgstr "E fshehtë JWT"
 #: src/olympia/devhub/templates/devhub/api/key.html:37
 #, python-format
 msgid ""
-"To make API requests, send a <a href=\"%(jwt_url)s\">JSON Web Token "
-"(JWT)</a> as the authorization header. You'll need to generate a JWT for "
-"every request as explained in the <a href=\"%(docs_url)s\">API "
-"documentation</a>."
+"To make API requests, send a <a href=\"%(jwt_url)s\">JSON Web Token (JWT)</a> as the authorization header. You'll need to generate a JWT for every request as explained in the <a href=\"%(docs_url)s"
+"\">API documentation</a>."
 msgstr ""
-"Për të bërë kërkesa API, dërgoni një <a href=\"%(jwt_url)s\">JSON Web Token "
-"(JWT)</a> si krye autorizimi. Do t’ju duhet të prodhoni një JWT për çdo "
-"kërkesë, siç shpjegohet te <a href=\"%(docs_url)s\">dokumentimi i API-"
-"it</a>."
+"Për të bërë kërkesa API, dërgoni një <a href=\"%(jwt_url)s\">JSON Web Token (JWT)</a> si krye autorizimi. Do t’ju duhet të prodhoni një JWT për çdo kërkesë, siç shpjegohet te <a href=\"%(docs_url)s"
+"\">dokumentimi i API-it</a>."
 
 #: src/olympia/devhub/templates/devhub/api/key.html:47
 msgid "You don't have any API credentials yet."
@@ -6492,12 +5196,8 @@ msgstr "S’keni ende kredenciale API."
 
 #: src/olympia/devhub/templates/devhub/api/key.html:53
 #, python-format
-msgid ""
-"This feature is under active development. If you find a problem please <a "
-"target=\"_blank\" href=\"%(bug_link)s\">report a bug</a>."
-msgstr ""
-"Kjo veçori gjendet nën zhvillim aktiv. Nëse gjeni ndonjë problem, ju lutemi,"
-" <a target=\"_blank\" href=\"%(bug_link)s\">njoftoni një të metë</a>."
+msgid "This feature is under active development. If you find a problem please <a target=\"_blank\" href=\"%(bug_link)s\">report a bug</a>."
+msgstr "Kjo veçori gjendet nën zhvillim aktiv. Nëse gjeni ndonjë problem, ju lutemi, <a target=\"_blank\" href=\"%(bug_link)s\">njoftoni një të metë</a>."
 
 #: src/olympia/devhub/templates/devhub/api/key.html:61
 msgid "Revoke and regenerate credentials"
@@ -6507,30 +5207,19 @@ msgstr "Shfuqizoji dhe riprodhoji kredencialet"
 msgid "Generate new credentials"
 msgstr "Prodho kredenciale të reja"
 
-#: src/olympia/devhub/templates/devhub/docs/policies-agreement.html:3
-#: src/olympia/devhub/templates/devhub/docs/policies-agreement.html:7
-#: src/olympia/devhub/templates/devhub/docs/policies-agreement.html:9
-#: src/olympia/devhub/templates/devhub/docs/policies.html:24
-#: src/olympia/devhub/templates/devhub/docs/policies.html:103
+#: src/olympia/devhub/templates/devhub/docs/policies-agreement.html:3 src/olympia/devhub/templates/devhub/docs/policies-agreement.html:7
+#: src/olympia/devhub/templates/devhub/docs/policies-agreement.html:9 src/olympia/devhub/templates/devhub/docs/policies.html:24 src/olympia/devhub/templates/devhub/docs/policies.html:103
 msgid "Developer Agreement"
 msgstr "Marrëveshje Zhvilluesi"
 
-#: src/olympia/devhub/templates/devhub/docs/policies-contact.html:3
-#: src/olympia/devhub/templates/devhub/docs/policies-contact.html:7
-#: src/olympia/devhub/templates/devhub/docs/policies-contact.html:9
-#: src/olympia/devhub/templates/devhub/docs/policies.html:27
-#: src/olympia/devhub/templates/devhub/docs/policies.html:115
+#: src/olympia/devhub/templates/devhub/docs/policies-contact.html:3 src/olympia/devhub/templates/devhub/docs/policies-contact.html:7 src/olympia/devhub/templates/devhub/docs/policies-contact.html:9
+#: src/olympia/devhub/templates/devhub/docs/policies.html:27 src/olympia/devhub/templates/devhub/docs/policies.html:115
 msgid "Contacting Us"
 msgstr "Si të Lidheni Me Ne"
 
 #: src/olympia/devhub/templates/devhub/docs/policies-contact.html:12
-msgid ""
-"Thanks for your interest in contacting the Mozilla Add-ons team. Please read"
-" this page carefully to ensure your request goes to the right place."
-msgstr ""
-"Faleminderit për interesin për t’u lidhur me ekipin e Shtesave Mozilla. Ju "
-"lutemi, lexojeni me kujdes këtë faqe, që të siguroheni se kërkesa juaj "
-"mbërrin në vendin e duhur."
+msgid "Thanks for your interest in contacting the Mozilla Add-ons team. Please read this page carefully to ensure your request goes to the right place."
+msgstr "Faleminderit për interesin për t’u lidhur me ekipin e Shtesave Mozilla. Ju lutemi, lexojeni me kujdes këtë faqe, që të siguroheni se kërkesa juaj mbërrin në vendin e duhur."
 
 #: src/olympia/devhub/templates/devhub/docs/policies-contact.html:17
 msgid "Add-on Support"
@@ -6538,15 +5227,11 @@ msgstr "Asistencë Shtese"
 
 #: src/olympia/devhub/templates/devhub/docs/policies-contact.html:19
 msgid ""
-"If you have a support question about a particular add-on, such as \"how do I"
-" use this add-on?\" or \"why doesn't this work properly?\", please contact "
-"that add-on's author through the support channels listed on the add-on's "
-"listing page."
+"If you have a support question about a particular add-on, such as \"how do I use this add-on?\" or \"why doesn't this work properly?\", please contact that add-on's author through the support "
+"channels listed on the add-on's listing page."
 msgstr ""
-"Nëse keni ndonjë pyetje asistence lidhur me një shtesë të veçantë, fjala "
-"vjen, \"si ta përdor këtë shtesë?\" ose \"pse s’punon si duhet kjo?\", ju "
-"lutemi, lidhuni me autorin e shtesës, përmes kanaleve për asistencë të "
-"radhitur te faqja e shtesës."
+"Nëse keni ndonjë pyetje asistence lidhur me një shtesë të veçantë, fjala vjen, \"si ta përdor këtë shtesë?\" ose \"pse s’punon si duhet kjo?\", ju lutemi, lidhuni me autorin e shtesës, përmes "
+"kanaleve për asistencë të radhitur te faqja e shtesës."
 
 #: src/olympia/devhub/templates/devhub/docs/policies-contact.html:24
 msgid "Add-on Editorial Concerns"
@@ -6559,18 +5244,11 @@ msgstr "amo-editors at mozilla dot org"
 #: src/olympia/devhub/templates/devhub/docs/policies-contact.html:26
 #, python-format
 msgid ""
-"If you have a question about an Editor's review of an add-on or want to "
-"report a policy violation, please email %(mail_editors)s. <strong>Almost all"
-" add-on reports fall under this category.</strong> Please be sure to include"
-" a link to the add-on in question and a detailed description of your "
-"question or comment."
+"If you have a question about an Editor's review of an add-on or want to report a policy violation, please email %(mail_editors)s. <strong>Almost all add-on reports fall under this category.</"
+"strong> Please be sure to include a link to the add-on in question and a detailed description of your question or comment."
 msgstr ""
-"Nëse keni ndonjë pyetje lidhur me shqyrtim Redaktori të një shtese, ose "
-"dëshironi të njoftoni cenim rregullash, ju lutemi, dërgoni email te "
-"%(mail_editors)s. <strong>Thuajse të gjitha njoftimet mbi shtesa hyjnë në "
-"këtë kategori.</strong> Ju lutemi, mos harroni të përfshini një lidhje për "
-"te shtesa në fjalë dhe një përshkrim të hollësishëm të pyetjes ose komentit "
-"tuaj."
+"Nëse keni ndonjë pyetje lidhur me shqyrtim Redaktori të një shtese, ose dëshironi të njoftoni cenim rregullash, ju lutemi, dërgoni email te %(mail_editors)s. <strong>Thuajse të gjitha njoftimet mbi "
+"shtesa hyjnë në këtë kategori.</strong> Ju lutemi, mos harroni të përfshini një lidhje për te shtesa në fjalë dhe një përshkrim të hollësishëm të pyetjes ose komentit tuaj."
 
 #: src/olympia/devhub/templates/devhub/docs/policies-contact.html:31
 msgid "Add-on Security Vulnerabilities"
@@ -6583,22 +5261,13 @@ msgstr "amo-admins at mozilla dot org"
 #: src/olympia/devhub/templates/devhub/docs/policies-contact.html:36
 #, python-format
 msgid ""
-"If you have discovered a security vulnerability in an add-on, even if it is "
-"not hosted here, Mozilla is very interested in your discovery and will work "
-"with the add-on developer to correct the issue as soon as possible. Add-on "
-"security issues can be reported <a "
-"href=\"http://www.mozilla.org/projects/security/security-bugs-"
-"policy.html\">confidentially</a> in <a "
-"href=\"%(link_bugzilla)s\">Bugzilla</a> or by emailing %(mail_admins)s."
+"If you have discovered a security vulnerability in an add-on, even if it is not hosted here, Mozilla is very interested in your discovery and will work with the add-on developer to correct the "
+"issue as soon as possible. Add-on security issues can be reported <a href=\"http://www.mozilla.org/projects/security/security-bugs-policy.html\">confidentially</a> in <a href=\"%(link_bugzilla)s"
+"\">Bugzilla</a> or by emailing %(mail_admins)s."
 msgstr ""
-"Nëse keni zbuluar një cenim sigurie te një shtesë, edhe pse s’është e "
-"strehuar këtu, Mozilla është shumë e intresuar për zbulimin tuaj dhe do të "
-"punojë me zhvilluesin e shtesës për ndreqjen e problemit sa më shpjet të "
-"jetë e mundur. Probleme sigurie shtesash mund të njoftohen <a "
-"href=\"http://www.mozilla.org/projects/security/security-bugs-"
-"policy.html\">në mënyrë konfidenciale</a> te <a "
-"href=\"%(link_bugzilla)s\">Bugzilla</a> ose duke dërguar email te "
-"%(mail_admins)s."
+"Nëse keni zbuluar një cenim sigurie te një shtesë, edhe pse s’është e strehuar këtu, Mozilla është shumë e intresuar për zbulimin tuaj dhe do të punojë me zhvilluesin e shtesës për ndreqjen e "
+"problemit sa më shpjet të jetë e mundur. Probleme sigurie shtesash mund të njoftohen <a href=\"http://www.mozilla.org/projects/security/security-bugs-policy.html\">në mënyrë konfidenciale</a> te <a "
+"href=\"%(link_bugzilla)s\">Bugzilla</a> ose duke dërguar email te %(mail_admins)s."
 
 #: src/olympia/devhub/templates/devhub/docs/policies-contact.html:42
 msgid "Website Functionality & Development"
@@ -6606,16 +5275,11 @@ msgstr "Funksionim & Zhvillim Sajti"
 
 #: src/olympia/devhub/templates/devhub/docs/policies-contact.html:44
 msgid ""
-"If you've found a problem with the site, we'd love to fix it. Please <a "
-"href=\"https://github.com/mozilla/olympia/issues\">file a bug report</a> in "
-"GitHub, including the location of the problem and how you encountered it."
+"If you've found a problem with the site, we'd love to fix it. Please <a href=\"https://github.com/mozilla/addons/issues/new\">file a bug report</a> in GitHub, including the location of the problem "
+"and how you encountered it."
 msgstr ""
-"Nëse gjetët një problem me sajtin, do të donin ta ndreqnim. Ju lutemi, <a "
-"href=\"https://github.com/mozilla/olympia/issues\">depozitoni një njoftim të"
-" mete</a> në GitHub, duke përfshirë vendin e problemi dhe se si e hasët."
 
-#: src/olympia/devhub/templates/devhub/docs/policies-maintenance.html:3
-#: src/olympia/devhub/templates/devhub/docs/policies-maintenance.html:7
+#: src/olympia/devhub/templates/devhub/docs/policies-maintenance.html:3 src/olympia/devhub/templates/devhub/docs/policies-maintenance.html:7
 #: src/olympia/devhub/templates/devhub/docs/policies-maintenance.html:8
 msgid "Maintaining Your Add-ons"
 msgstr "Mirëmbajtja e Shtesës Suaj"
@@ -6626,32 +5290,19 @@ msgstr "Parashtrimi i Versioneve të Reja të Shtesës Suaj"
 
 #: src/olympia/devhub/templates/devhub/docs/policies-maintenance.html:12
 msgid ""
-"Developers are encouraged to submit updates to their add-ons to fix bugs, "
-"add features, and otherwise improve their product. New versions of an add-on"
-" must have a <a "
-"href=\"https://developer.mozilla.org/en/Toolkit_version_format\">higher "
-"version number</a> and can be submitted through the Developer Tools "
-"provided. There is no limit to the number of versions that can be submitted,"
-" but please remember that versions must be reviewed by an editor."
+"Developers are encouraged to submit updates to their add-ons to fix bugs, add features, and otherwise improve their product. New versions of an add-on must have a <a href=\"https://developer."
+"mozilla.org/en/Toolkit_version_format\">higher version number</a> and can be submitted through the Developer Tools provided. There is no limit to the number of versions that can be submitted, but "
+"please remember that versions must be reviewed by an editor."
 msgstr ""
-"Zhvilluesit i nxisim të parashtrojnë për shtesat e tyre përditësime për "
-"ndreqje të metash, shtim veçorish, dhe çfarëdo tjetër që përmirëson "
-"produktin e tyre. Versionet e reja të një shtese duhet të kenë <a "
-"href=\"https://developer.mozilla.org/en/Toolkit_version_format\">numër më të"
-" madh versioni</a> dhe mund të parashtrohen përmes Mjeteve të Zhvilluesve që"
-" ofrojmë. Për numrin e versionit që mund të parashtrohet s’ka kufi, por, ju "
-"lutemi, mbani mend që versionet duhet të merren në shqyrtim nga një "
-"redaktor."
+"Zhvilluesit i nxisim të parashtrojnë për shtesat e tyre përditësime për ndreqje të metash, shtim veçorish, dhe çfarëdo tjetër që përmirëson produktin e tyre. Versionet e reja të një shtese duhet të "
+"kenë <a href=\"https://developer.mozilla.org/en/Toolkit_version_format\">numër më të madh versioni</a> dhe mund të parashtrohen përmes Mjeteve të Zhvilluesve që ofrojmë. Për numrin e versionit që "
+"mund të parashtrohet s’ka kufi, por, ju lutemi, mbani mend që versionet duhet të merren në shqyrtim nga një redaktor."
 
 #: src/olympia/devhub/templates/devhub/docs/policies-maintenance.html:18
-msgid ""
-"New versions will be added to a pending review queue, and any additional "
-"versions submitted before the review is completed will move that version to "
-"the end of the queue."
+msgid "New versions will be added to a pending review queue, and any additional versions submitted before the review is completed will move that version to the end of the queue."
 msgstr ""
-"Versionet e rinj do të shtohen te një radhë në pritje shqyrtimi, dhe çfarëdo"
-" versioni shtesë i parashtruar përpara se shqyrtimi të jetë plotësuar, do ta"
-" kalojë versionin paraardhës në fund të radhës."
+"Versionet e rinj do të shtohen te një radhë në pritje shqyrtimi, dhe çfarëdo versioni shtesë i parashtruar përpara se shqyrtimi të jetë plotësuar, do ta kalojë versionin paraardhës në fund të "
+"radhës."
 
 #: src/olympia/devhub/templates/devhub/docs/policies-maintenance.html:23
 msgid "How do I submit a Beta add-on?"
@@ -6663,51 +5314,31 @@ msgstr "Kanalet beta janë vetëm për shtesa të shqyrtuara plotësisht."
 
 #: src/olympia/devhub/templates/devhub/docs/policies-maintenance.html:31
 msgid ""
-"To create a beta channel, upload a file with a unique version string that "
-"contains any of the following strings: <code>a,b,alpha,beta,pre,rc</code>, "
-"with an optional number at the end. This text must come at the end of the "
-"version string. If you understand regex format, here's what we look for in "
-"the version number: <code>\"(a|alpha|b|beta|pre|rc)\\d*$\"</code>."
+"To create a beta channel, upload a file with a unique version string that contains any of the following strings: <code>a,b,alpha,beta,pre,rc</code>, with an optional number at the end. This text "
+"must come at the end of the version string. If you understand regex format, here's what we look for in the version number: <code>\"(a|alpha|b|beta|pre|rc)\\d*$\"</code>."
 msgstr ""
-"Për krijimin e një kanali beta, ngarkoni një kartelë me një varg unik "
-"versioni që përmban cilindo nga vargjet vijues: "
-"<code>a,b,alpha,beta,pre,rc</code>, me një numër, në daçi, në fund. Ky tekst"
-" duhet të gjendet në fund të vargut të versionit. Nëse merrni vesh nga "
-"formatet regex, ja se ç’presim nga një numër versioni: "
-"<code>\"(a|alpha|b|beta|pre|rc)\\d*$\"</code>."
+"Për krijimin e një kanali beta, ngarkoni një kartelë me një varg unik versioni që përmban cilindo nga vargjet vijues: <code>a,b,alpha,beta,pre,rc</code>, me një numër, në daçi, në fund. Ky tekst "
+"duhet të gjendet në fund të vargut të versionit. Nëse merrni vesh nga formatet regex, ja se ç’presim nga një numër versioni: <code>\"(a|alpha|b|beta|pre|rc)\\d*$\"</code>."
 
 #: src/olympia/devhub/templates/devhub/docs/policies-maintenance.html:37
 msgid ""
-"Once a file meeting this criteria is uploaded to AMO, it will automatically "
-"be marked as a beta version. Users of add-ons with these unique version "
-"numbers will automatically be served the newest beta updates."
+"Once a file meeting this criteria is uploaded to AMO, it will automatically be marked as a beta version. Users of add-ons with these unique version numbers will automatically be served the newest "
+"beta updates."
 msgstr ""
-"Pasi një kartelë që përputhet me këtë kriter, ngarkohet te AMO, do t’i vihet"
-" vetvetiu shenjë si një version beta. Përdoruesve të shtesave me këto numra "
-"unikë versionesh do t’u shërbehen përditësimet më të reja beta."
+"Pasi një kartelë që përputhet me këtë kriter, ngarkohet te AMO, do t’i vihet vetvetiu shenjë si një version beta. Përdoruesve të shtesave me këto numra unikë versionesh do t’u shërbehen "
+"përditësimet më të reja beta."
 
 #: src/olympia/devhub/templates/devhub/docs/policies-maintenance.html:43
 msgid ""
-"While we call these \"Beta versions\", you can use this channel for "
-"nightlies, or alphas, or prerelease versions as you wish. Please note that "
-"there is only one channel for this purpose and all of your users on this "
-"channel will receive the latest add-ons submitted. For instance, if you "
-"upload <code>1.0beta1</code> to the release channel and then upload "
-"<code>1.1alpha1</code>, all users of <code>1.0beta1</code> will be offered "
-"an upgrade to <code>1.1alpha1</code>. Updates are pushed by submission date "
-"and not version number, so users will always get the most recent channel "
-"update regardless of any kind of alphabetical sorting."
+"While we call these \"Beta versions\", you can use this channel for nightlies, or alphas, or prerelease versions as you wish. Please note that there is only one channel for this purpose and all of "
+"your users on this channel will receive the latest add-ons submitted. For instance, if you upload <code>1.0beta1</code> to the release channel and then upload <code>1.1alpha1</code>, all users of "
+"<code>1.0beta1</code> will be offered an upgrade to <code>1.1alpha1</code>. Updates are pushed by submission date and not version number, so users will always get the most recent channel update "
+"regardless of any kind of alphabetical sorting."
 msgstr ""
-"Pavarësisht se i quajmë \"Versione beta\", mund ta përdorni këtë kanal për "
-"montime të përnatshme, ose alfa, ose versione paraqarkullim, për kë të doni."
-" Ju lutemi, mbani parasysh që ka vetëm një kanal për këtë qëllim dhe krejt "
-"përdoruesit tuaj në këtë kanal do të marrin shtesat e parashtruara së fundi."
-" Për shembull, nëse ngarkoni <code>1.0beta1</code> te kanali i hedhjeve në "
-"qarkullim dhe mandej ngarkoni <code>1.1alpha1</code>, krejt përdoruesve të "
-"<code>1.0beta1</code> do t’u ofrohet një përmirësim te "
-"<code>1.1alpha1</code>. Si bazë për përditësimet merren data parashtrimesh "
-"dhe jo numra versionesh, ndaj përdoruesit do të marrin gjithmonë përditësime"
-" më të reja nga kanali, pavarësisht nga çfarëdo lloj renditjeje alfabetike."
+"Pavarësisht se i quajmë \"Versione beta\", mund ta përdorni këtë kanal për montime të përnatshme, ose alfa, ose versione paraqarkullim, për kë të doni. Ju lutemi, mbani parasysh që ka vetëm një "
+"kanal për këtë qëllim dhe krejt përdoruesit tuaj në këtë kanal do të marrin shtesat e parashtruara së fundi. Për shembull, nëse ngarkoni <code>1.0beta1</code> te kanali i hedhjeve në qarkullim dhe "
+"mandej ngarkoni <code>1.1alpha1</code>, krejt përdoruesve të <code>1.0beta1</code> do t’u ofrohet një përmirësim te <code>1.1alpha1</code>. Si bazë për përditësimet merren data parashtrimesh dhe jo "
+"numra versionesh, ndaj përdoruesit do të marrin gjithmonë përditësime më të reja nga kanali, pavarësisht nga çfarëdo lloj renditjeje alfabetike."
 
 #: src/olympia/devhub/templates/devhub/docs/policies-maintenance.html:48
 msgid "Required Updates"
@@ -6715,21 +5346,13 @@ msgstr "Përditësime të Domosdoshme"
 
 #: src/olympia/devhub/templates/devhub/docs/policies-maintenance.html:50
 msgid ""
-"Certain situations may arise in which Mozilla requests that an add-on "
-"developer update their add-on within a given time period to address a major "
-"security issue or policy violation. We work with developers to reasonably "
-"accommodate their own schedules, but if the issue is of a serious enough "
-"nature, add-ons that cannot issue an update with the requested fix may be "
-"demoted from fully-reviewed status, disabled, or permanently removed from "
-"the site."
+"Certain situations may arise in which Mozilla requests that an add-on developer update their add-on within a given time period to address a major security issue or policy violation. We work with "
+"developers to reasonably accommodate their own schedules, but if the issue is of a serious enough nature, add-ons that cannot issue an update with the requested fix may be demoted from fully-"
+"reviewed status, disabled, or permanently removed from the site."
 msgstr ""
-"Mund të ketë raste kur Mozilla i kërkon një zhvilluesi shtesash të "
-"përditësojë shtesën e tij brenda një periudhe të dhënë kohore, për të "
-"trajtuar një problem të rëndë sigurie apo cenimi rregullash. Përpiqemi të "
-"bashkërendohemi sa mundet me zhvilluesit, por nëse problemi është i një "
-"natyre goxha serioze, shtesat që s’hedhin dot në qarkullim një përditësim me"
-" ndreqjen e dhënë, mund të ulen në gradë, nga gjendja “plotësisht e "
-"shqyrtuar” në e “çaktivizuar” ose dhe të hiqen përgjithmonë prej sajtit."
+"Mund të ketë raste kur Mozilla i kërkon një zhvilluesi shtesash të përditësojë shtesën e tij brenda një periudhe të dhënë kohore, për të trajtuar një problem të rëndë sigurie apo cenimi rregullash. "
+"Përpiqemi të bashkërendohemi sa mundet me zhvilluesit, por nëse problemi është i një natyre goxha serioze, shtesat që s’hedhin dot në qarkullim një përditësim me ndreqjen e dhënë, mund të ulen në "
+"gradë, nga gjendja “plotësisht e shqyrtuar” në e “çaktivizuar” ose dhe të hiqen përgjithmonë prej sajtit."
 
 #: src/olympia/devhub/templates/devhub/docs/policies-maintenance.html:55
 msgid "Transfer of Ownership"
@@ -6737,65 +5360,41 @@ msgstr "Shpërngulje e Pronësisë"
 
 #: src/olympia/devhub/templates/devhub/docs/policies-maintenance.html:57
 msgid ""
-"Add-ons can have multiple users with permission to update and manage the "
-"listing. Existing authors of an add-on can transfer ownership and add "
-"additional developers to an add-on's listing through the Developer Tools "
-"provided. No interaction with Mozilla representatives is necessary for a "
-"transfer of ownership."
+"Add-ons can have multiple users with permission to update and manage the listing. Existing authors of an add-on can transfer ownership and add additional developers to an add-on's listing through "
+"the Developer Tools provided. No interaction with Mozilla representatives is necessary for a transfer of ownership."
 msgstr ""
-"Për shtesat mund të ketë disa përdorues me leje për përditësim dhe "
-"administrim të paraqitjes së tyre. Përmes Mjetesh Zhvilluesish autorët "
-"ekzistues të një shtese mund ta transferojnë pronësinë dhe të shtojnë të "
-"tjerë zhvillues te paraqitja e një shtese. Për transferimin e pronësisë "
-"s’lypset ndonjë ndërveprim me përfaqësues të Mozilla-s."
+"Për shtesat mund të ketë disa përdorues me leje për përditësim dhe administrim të paraqitjes së tyre. Përmes Mjetesh Zhvilluesish autorët ekzistues të një shtese mund ta transferojnë pronësinë dhe "
+"të shtojnë të tjerë zhvillues te paraqitja e një shtese. Për transferimin e pronësisë s’lypset ndonjë ndërveprim me përfaqësues të Mozilla-s."
 
 #: src/olympia/devhub/templates/devhub/docs/policies-maintenance.html:63
 #, python-format
-msgid ""
-"Mozilla can assist with granting additional permissions of an add-on's "
-"listing if <a href=\"%(link_contact)s\">contacted</a> by the add-on's "
-"current owner."
-msgstr ""
-"Mozilla mund të ndihmojë me akordim lejesh shtesë mbi paraqitjen e një "
-"shtese, nëse <a href=\"%(link_contact)s\">kontaktohet</a> nga pronari i "
-"atëkohshëm i shtesës."
+msgid "Mozilla can assist with granting additional permissions of an add-on's listing if <a href=\"%(link_contact)s\">contacted</a> by the add-on's current owner."
+msgstr "Mozilla mund të ndihmojë me akordim lejesh shtesë mbi paraqitjen e një shtese, nëse <a href=\"%(link_contact)s\">kontaktohet</a> nga pronari i atëkohshëm i shtesës."
 
 #: src/olympia/devhub/templates/devhub/docs/policies-maintenance.html:70
 msgid ""
-"Mozilla encourages its users to offer feedback on their experiences when "
-"using an add-on. This allows other users to determine if the add-on is "
-"stable and useful. It also provides valuable feedback to developers, "
-"allowing them to continuously improve their add-on to meet user needs."
+"Mozilla encourages its users to offer feedback on their experiences when using an add-on. This allows other users to determine if the add-on is stable and useful. It also provides valuable feedback "
+"to developers, allowing them to continuously improve their add-on to meet user needs."
 msgstr ""
-"Mozilla i nxit përdoruesit e vet të japin përshtypjet lidhur me punimin e "
-"shtesave. Kjo u lejon përdoruesve të tjerë të përcaktojnë nëse një shtesë "
-"është e qëndrueshme dhe e dobishme. Gjithashtu kjo u jep zhvilluesve të "
-"dhëna të dobishme, që u lejojnë atyre të përmirësojnë vazhdimisht shtesat e "
-"tyre në përputhje me nevojat e përdoruesve."
+"Mozilla i nxit përdoruesit e vet të japin përshtypjet lidhur me punimin e shtesave. Kjo u lejon përdoruesve të tjerë të përcaktojnë nëse një shtesë është e qëndrueshme dhe e dobishme. Gjithashtu "
+"kjo u jep zhvilluesve të dhëna të dobishme, që u lejojnë atyre të përmirësojnë vazhdimisht shtesat e tyre në përputhje me nevojat e përdoruesve."
 
 #: src/olympia/devhub/templates/devhub/docs/policies-maintenance.html:76
 #, python-format
 msgid ""
-"Reviews must follow the <a href=\"%(link_guidelines)s\">review "
-"guidelines</a>. Reviews that do not meet these guidelines may be flagged for"
-" moderation, but negative reviews will not be removed unless they provide "
-"false information."
+"Reviews must follow the <a href=\"%(link_guidelines)s\">review guidelines</a>. Reviews that do not meet these guidelines may be flagged for moderation, but negative reviews will not be removed "
+"unless they provide false information."
 msgstr ""
-"Shqyrtimet duhet të ndjekin <a href=\"%(link_guidelines)s\">udhëzimet mbi "
-"shqyrtime</a>. Shqyrtimet që s’pajtohen me këto udhëzime mund të kalohen për"
-" moderim, por shqyrtimet negative s’do të hiqen, veç në dhënshin informacion"
-" të rremë."
+"Shqyrtimet duhet të ndjekin <a href=\"%(link_guidelines)s\">udhëzimet mbi shqyrtime</a>. Shqyrtimet që s’pajtohen me këto udhëzime mund të kalohen për moderim, por shqyrtimet negative s’do të "
+"hiqen, veç në dhënshin informacion të rremë."
 
 #: src/olympia/devhub/templates/devhub/docs/policies-maintenance.html:82
 msgid ""
-"Many developers provide a support mechanism, such as a forum, discussion "
-"group, or email address. It is recommended that support questions be posted "
-"via those mediums instead of in an add-on's review section."
+"Many developers provide a support mechanism, such as a forum, discussion group, or email address. It is recommended that support questions be posted via those mediums instead of in an add-on's "
+"review section."
 msgstr ""
-"Mjaft zhvillues ofrojnë një mekanizëm asistence, fjala vjen një forum, një "
-"grup diskutimesh, ose një adresë email. Këshillohet që pyetjet për asistencë"
-" të postohen përmes këtyre kanaleve, në vend se te ndarja për shqyrtime të "
-"shtesës."
+"Mjaft zhvillues ofrojnë një mekanizëm asistence, fjala vjen një forum, një grup diskutimesh, ose një adresë email. Këshillohet që pyetjet për asistencë të postohen përmes këtyre kanaleve, në vend "
+"se te ndarja për shqyrtime të shtesës."
 
 #: src/olympia/devhub/templates/devhub/docs/policies-maintenance.html:87
 msgid "Code Disputes"
@@ -6803,44 +5402,26 @@ msgstr "Grindje rreth Kodit"
 
 #: src/olympia/devhub/templates/devhub/docs/policies-maintenance.html:90
 msgid ""
-"Many add-ons allow their source code to be openly viewed. This does not mean"
-" that the source code is open source or available for use in another add-on."
-" The original author of an add-on retains copyright of their work unless "
-"otherwise noted in the add-on's license."
+"Many add-ons allow their source code to be openly viewed. This does not mean that the source code is open source or available for use in another add-on. The original author of an add-on retains "
+"copyright of their work unless otherwise noted in the add-on's license."
 msgstr ""
-"Mjaft shtesa lejojnë që kodi i tyre burim të shihet haptazi. Kjo s’nënkupton"
-" që kodi burim është me burim të hapët ose se jepet për përdorim në një "
-"shtesë tjetër. Të drejtat e kopjimit mbi veprën e vet i zotëron autori "
-"origjinal i një shtese, veç në u shënoftë ndryshe te licenca e shtesës."
+"Mjaft shtesa lejojnë që kodi i tyre burim të shihet haptazi. Kjo s’nënkupton që kodi burim është me burim të hapët ose se jepet për përdorim në një shtesë tjetër. Të drejtat e kopjimit mbi veprën e "
+"vet i zotëron autori origjinal i një shtese, veç në u shënoftë ndryshe te licenca e shtesës."
 
 #: src/olympia/devhub/templates/devhub/docs/policies-maintenance.html:96
 msgid ""
-"In the event that we're notified of a copyright or license infringement, we "
-"will take steps to review the situation and determine if an actual "
-"infringement has occurred. If we determine that there is an infringement, we"
-" will remove the offending add-on and contact the author. New add-on "
-"submissions (including updates) containing infringing code will be denied "
-"approval for public status."
+"In the event that we're notified of a copyright or license infringement, we will take steps to review the situation and determine if an actual infringement has occurred. If we determine that there "
+"is an infringement, we will remove the offending add-on and contact the author. New add-on submissions (including updates) containing infringing code will be denied approval for public status."
 msgstr ""
-"Në rast se njoftohemi për një shkelje të drejtash kopjimi ose licence, do të"
-" ndërmarrim hapa për të shqyrtuar gjendjen dhe përcaktuar nëse ka ndodhur "
-"cenim faktik. Nëse përcaktojmë se ka patur cenim, do ta heqim shtesën "
-"fajtore dhe do të lidhemi me autorin. Parashtrimeve të reja shtesash "
-"(përfshi përditësime) që përmbajnë kod me shkelje do t’u mohohet miratimi "
-"për t’i kaluar publike."
+"Në rast se njoftohemi për një shkelje të drejtash kopjimi ose licence, do të ndërmarrim hapa për të shqyrtuar gjendjen dhe përcaktuar nëse ka ndodhur cenim faktik. Nëse përcaktojmë se ka patur "
+"cenim, do ta heqim shtesën fajtore dhe do të lidhemi me autorin. Parashtrimeve të reja shtesash (përfshi përditësime) që përmbajnë kod me shkelje do t’u mohohet miratimi për t’i kaluar publike."
 
 #: src/olympia/devhub/templates/devhub/docs/policies-maintenance.html:102
-msgid ""
-"If you are unsure of the current copyright status of an add-on's source "
-"code, you must contact the original author and receive explicit permission "
-"before using the source code."
+msgid "If you are unsure of the current copyright status of an add-on's source code, you must contact the original author and receive explicit permission before using the source code."
 msgstr ""
-"Nëse s’jeni i sigurt mbi gjendjen e të drejtave të kopjimit të kodit burim "
-"të një shtese, duhet të lidheni me autorin origjinal dhe të merrni leje "
-"shprehimisht, përpara se të përdorni kodin burim."
+"Nëse s’jeni i sigurt mbi gjendjen e të drejtave të kopjimit të kodit burim të një shtese, duhet të lidheni me autorin origjinal dhe të merrni leje shprehimisht, përpara se të përdorni kodin burim."
 
-#: src/olympia/devhub/templates/devhub/docs/policies-maintenance.html:107
-#: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:306
+#: src/olympia/devhub/templates/devhub/docs/policies-maintenance.html:107 src/olympia/devhub/templates/devhub/docs/policies-reviews.html:306
 #: src/olympia/devhub/templates/devhub/docs/policies-submission.html:97
 msgid "Last updated: January 13, 2011"
 msgstr "Përditësuar së fundmi: 13 Janar, 2011"
@@ -6848,57 +5429,35 @@ msgstr "Përditësuar së fundmi: 13 Janar, 2011"
 #: src/olympia/devhub/templates/devhub/docs/policies-recommended.html:13
 #, python-format
 msgid ""
-"Featured add-ons are top-quality extensions and themes highlighted on <a "
-"href=\"%(link_gallery)s\">AMO</a>, Firefox's Add-ons Manager, and across "
-"other Mozilla websites. These add-ons showcase the power of Firefox "
-"customization and are useful to a wide audience."
+"Featured add-ons are top-quality extensions and themes highlighted on <a href=\"%(link_gallery)s\">AMO</a>, Firefox's Add-ons Manager, and across other Mozilla websites. These add-ons showcase the "
+"power of Firefox customization and are useful to a wide audience."
 msgstr ""
-"Shtesat e zgjedhura janë zgjerime dhe tema të cilësisë së lartë, të nxjerra "
-"në pah te <a href=\"%(link_gallery)s\">AMO</a>, te Përgjegjësi i Shtesave te"
-" Firefox-i, dhe në të tjerë sajte të Mozilla-s. Këto shtesa shpalosin forcën"
-" e personalizimeve të Firefox-it dhe janë të dobishme për një numër të madh "
-"përdoruesish."
+"Shtesat e zgjedhura janë zgjerime dhe tema të cilësisë së lartë, të nxjerra në pah te <a href=\"%(link_gallery)s\">AMO</a>, te Përgjegjësi i Shtesave te Firefox-i, dhe në të tjerë sajte të Mozilla-"
+"s. Këto shtesa shpalosin forcën e personalizimeve të Firefox-it dhe janë të dobishme për një numër të madh përdoruesish."
 
 #: src/olympia/devhub/templates/devhub/docs/policies-recommended.html:19
 msgid ""
-"Featured add-ons are chosen by the Featured Add-ons Advisory Board, a small "
-"group of add-on developers and fans from the Mozilla community who have "
-"volunteered to review and vote on nominations."
+"Featured add-ons are chosen by the Featured Add-ons Advisory Board, a small group of add-on developers and fans from the Mozilla community who have volunteered to review and vote on nominations."
 msgstr ""
-"Shtesat e zgjedhura përcaktohen nga Trupa Këshillimore e Shtesave të "
-"Zgjedhura, një grup i vogël zhvilluesish shtesash dhe dashamirësh nga "
-"bashkësia Mozilla. vullnetarë në shqyrtimin dhe votimin e shtesave "
-"kanditate."
+"Shtesat e zgjedhura përcaktohen nga Trupa Këshillimore e Shtesave të Zgjedhura, një grup i vogël zhvilluesish shtesash dhe dashamirësh nga bashkësia Mozilla. vullnetarë në shqyrtimin dhe votimin e "
+"shtesave kanditate."
 
 #: src/olympia/devhub/templates/devhub/docs/policies-recommended.html:25
 #, python-format
-msgid ""
-"<a href=\"%(link_featured)s\">Featured extensions</a> are chosen every "
-"month, and <a href=\"%(link_themes)s\">featured complete themes</a> are "
-"chosen every quarter."
-msgstr ""
-"<a href=\"%(link_featured)s\">Zgjerimet e zgjedhura</a> përzgjidhen çdo "
-"muaj, dhe <a href=\"%(link_themes)s\">temat e plota të zgjedhura</a> çdo "
-"katërmujor."
+msgid "<a href=\"%(link_featured)s\">Featured extensions</a> are chosen every month, and <a href=\"%(link_themes)s\">featured complete themes</a> are chosen every quarter."
+msgstr "<a href=\"%(link_featured)s\">Zgjerimet e zgjedhura</a> përzgjidhen çdo muaj, dhe <a href=\"%(link_themes)s\">temat e plota të zgjedhura</a> çdo katërmujor."
 
 #: src/olympia/devhub/templates/devhub/docs/policies-recommended.html:30
 msgid "Criteria for Featured Add-ons"
 msgstr "Kritere për Shtesa të Zgjedhura"
 
 #: src/olympia/devhub/templates/devhub/docs/policies-recommended.html:33
-msgid ""
-"Before nominating an add-on to be featured, please ensure it meets the "
-"following criteria:"
-msgstr ""
-"Përpara se të kandidoni një shtesë për zgjedhje, ju lutemi, sigurohuni që "
-"pajtohet me kriteret vijuese:"
+msgid "Before nominating an add-on to be featured, please ensure it meets the following criteria:"
+msgstr "Përpara se të kandidoni një shtesë për zgjedhje, ju lutemi, sigurohuni që pajtohet me kriteret vijuese:"
 
 #: src/olympia/devhub/templates/devhub/docs/policies-recommended.html:39
-msgid ""
-"The add-on must have a complete and informative listing on AMO. This means:"
-msgstr ""
-"Shtesa duhet të ketë te AMO një paraqitje të plotë dhe informuese. Kjo do të"
-" thotë:"
+msgid "The add-on must have a complete and informative listing on AMO. This means:"
+msgstr "Shtesa duhet të ketë te AMO një paraqitje të plotë dhe informuese. Kjo do të thotë:"
 
 #: src/olympia/devhub/templates/devhub/docs/policies-recommended.html:41
 msgid "a 64-pixel custom icon"
@@ -6921,44 +5480,28 @@ msgid "updated screenshots of the add-on's functionality"
 msgstr "foto të përditësuara nga shtesa në punë e sipër"
 
 #: src/olympia/devhub/templates/devhub/docs/policies-recommended.html:46
-msgid ""
-"must be fully approved by AMO editors (no preliminarily reviewed entries)"
-msgstr ""
-"duhet të jetë plotësisht e miratuar nga redaktorët e AMO-s (jo paraprakisht)"
+msgid "must be fully approved by AMO editors (no preliminarily reviewed entries)"
+msgstr "duhet të jetë plotësisht e miratuar nga redaktorët e AMO-s (jo paraprakisht)"
 
 #: src/olympia/devhub/templates/devhub/docs/policies-recommended.html:48
-msgid ""
-"The add-on must have excellent user reviews and any problems or support "
-"requests must be promptly addressed by the developer."
-msgstr ""
-"Shtesa duhet të ketë përshtypje të shkëlqyera përdoruesish dhe çfarëdo "
-"problemi apo kërkese për asistencë të trajtohet menjëherë nga zhvilluesi."
+msgid "The add-on must have excellent user reviews and any problems or support requests must be promptly addressed by the developer."
+msgstr "Shtesa duhet të ketë përshtypje të shkëlqyera përdoruesish dhe çfarëdo problemi apo kërkese për asistencë të trajtohet menjëherë nga zhvilluesi."
 
 #: src/olympia/devhub/templates/devhub/docs/policies-recommended.html:49
 msgid "The add-on must have a minimum of 2,000 users."
 msgstr "Shtesa duhet të ketë një minimum prej 2000 përdoruesish."
 
 #: src/olympia/devhub/templates/devhub/docs/policies-recommended.html:50
-msgid ""
-"The add-on must be compatible with the latest release of Firefox and must be"
-" compatible with beta versions 4 weeks before their final release."
-msgstr ""
-"Shtesa duhet të jetë e përputhshme me versionin më të ri të Firefox-it dhe "
-"duhet të jetë e përputhshme me versione beta 4 javë përpara hedhjes së tyre "
-"përfundimtare në qarkullim."
+msgid "The add-on must be compatible with the latest release of Firefox and must be compatible with beta versions 4 weeks before their final release."
+msgstr "Shtesa duhet të jetë e përputhshme me versionin më të ri të Firefox-it dhe duhet të jetë e përputhshme me versione beta 4 javë përpara hedhjes së tyre përfundimtare në qarkullim."
 
 #: src/olympia/devhub/templates/devhub/docs/policies-recommended.html:51
 msgid ""
-"<strong>Most importantly</strong>, the add-on must have wide consumer appeal"
-" to Firefox's users and be outstanding in nearly every way: user experience,"
-" performance, security, and usefulness or entertainment value. Featured "
-"complete themes must also be visually appealing."
+"<strong>Most importantly</strong>, the add-on must have wide consumer appeal to Firefox's users and be outstanding in nearly every way: user experience, performance, security, and usefulness or "
+"entertainment value. Featured complete themes must also be visually appealing."
 msgstr ""
-"<strong>Më e rëndësishmja</strong>, shtesa duhet të ketë një tërheqje të "
-"gjerë të përdoruesve të Firefox-it dhe të jetë e pashoqe në thuajse të "
-"gjitha këndvështrimet: punimi, performanca, siguria, dhe vlerat dobiprurëse "
-"ose zbavitëse. Temat e plota të zgjedhura duhet të jenë tërheqëse edhe nga "
-"ana pamore."
+"<strong>Më e rëndësishmja</strong>, shtesa duhet të ketë një tërheqje të gjerë të përdoruesve të Firefox-it dhe të jetë e pashoqe në thuajse të gjitha këndvështrimet: punimi, performanca, siguria, "
+"dhe vlerat dobiprurëse ose zbavitëse. Temat e plota të zgjedhura duhet të jenë tërheqëse edhe nga ana pamore."
 
 #: src/olympia/devhub/templates/devhub/docs/policies-recommended.html:54
 msgid "Nominating an Add-on"
@@ -6970,275 +5513,164 @@ msgstr "amo-featured at mozilla dot org"
 
 #: src/olympia/devhub/templates/devhub/docs/policies-recommended.html:57
 #, python-format
-msgid ""
-"If you wish to nominate an add-on to be featured and it meets the criteria "
-"above, send an email to %(mail_featured)s with:"
-msgstr ""
-"Nëse dëshironi të kandidoni një shtesë për të qenë mes të zgjedhurave, dhe "
-"nëse ajo i plotëson kriteret më sipër, na dërgoni një email te "
-"%(mail_featured)s with:"
+msgid "If you wish to nominate an add-on to be featured and it meets the criteria above, send an email to %(mail_featured)s with:"
+msgstr "Nëse dëshironi të kandidoni një shtesë për të qenë mes të zgjedhurave, dhe nëse ajo i plotëson kriteret më sipër, na dërgoni një email te %(mail_featured)s with:"
 
 #: src/olympia/devhub/templates/devhub/docs/policies-recommended.html:62
 msgid "the add-on name, URL, and whether you are its developer"
 msgstr "emri i shtesës, URL-ja, dhe nëse jeni ju zhvilluesi i saj"
 
 #: src/olympia/devhub/templates/devhub/docs/policies-recommended.html:63
-msgid ""
-"a short explanation of why the add-on has wide appeal and should be featured"
-msgstr ""
-"një shpjegim i shkurtër pse shtesa mund të joshë shumë vetë dhe do të duhej "
-"zgjedhur"
+msgid "a short explanation of why the add-on has wide appeal and should be featured"
+msgstr "një shpjegim i shkurtër pse shtesa mund të joshë shumë vetë dhe do të duhej zgjedhur"
 
 #: src/olympia/devhub/templates/devhub/docs/policies-recommended.html:64
-msgid ""
-"optionally, links to any external reviews or articles mentioning the add-on"
-msgstr ""
-"në pastë, të ofrohen lidhje për te shqyrtime ose artikuj të jashtëm që e "
-"përmendin shtesën"
+msgid "optionally, links to any external reviews or articles mentioning the add-on"
+msgstr "në pastë, të ofrohen lidhje për te shqyrtime ose artikuj të jashtëm që e përmendin shtesën"
 
 #: src/olympia/devhub/templates/devhub/docs/policies-recommended.html:68
 msgid ""
-"Add-on nominations are reviewed by the Advisory Board once a month (once "
-"every 3 months for complete theme nominations). Common reasons for rejection"
-" include lacking wide appeal to consumers, a suboptimal user experience, "
-"quality or security issues, incompatibility, and similarity to another "
-"featured add-on. Rejected add-ons cannot be re-nominated within 3 months."
+"Add-on nominations are reviewed by the Advisory Board once a month (once every 3 months for complete theme nominations). Common reasons for rejection include lacking wide appeal to consumers, a "
+"suboptimal user experience, quality or security issues, incompatibility, and similarity to another featured add-on. Rejected add-ons cannot be re-nominated within 3 months."
 msgstr ""
-"Kandidimet e shtesave shqyrtohen nga Trupi Këshillimor një herë në muaj (një"
-" herë në 3 muaj për kandidime temash të plota). Te arsyet e rëndomta për "
-"mospranim përfshihen mungesa e të qenit shumë joshës për konsumatorët, "
-"funksionim nën optimalen, probleme cilësie ose sigurie, papërputhshëmri, dhe"
-" ngjashmëria me shtesa të tjera të zgjedhura tashmë. Shtesat e hedhura tej "
-"s’mund të rikandidohen brenda tre muajsh."
+"Kandidimet e shtesave shqyrtohen nga Trupi Këshillimor një herë në muaj (një herë në 3 muaj për kandidime temash të plota). Te arsyet e rëndomta për mospranim përfshihen mungesa e të qenit shumë "
+"joshës për konsumatorët, funksionim nën optimalen, probleme cilësie ose sigurie, papërputhshëmri, dhe ngjashmëria me shtesa të tjera të zgjedhura tashmë. Shtesat e hedhura tej s’mund të "
+"rikandidohen brenda tre muajsh."
 
 #: src/olympia/devhub/templates/devhub/docs/policies-recommended.html:73
 msgid "Rotating Featured Add-ons"
 msgstr "Shtesa të Zgjedhura"
 
 #: src/olympia/devhub/templates/devhub/docs/policies-recommended.html:76
-msgid ""
-"Mozilla and the Featured Add-ons Advisory Board regularly evaluate and "
-"rotate out featured add-ons. Some of the most common reasons for add-ons "
-"being removed from the featured list are:"
+msgid "Mozilla and the Featured Add-ons Advisory Board regularly evaluate and rotate out featured add-ons. Some of the most common reasons for add-ons being removed from the featured list are:"
 msgstr ""
-"Mozilla dhe Trupa Këshillimore e Shtesave të Zgjedhura peshon dhe qarkullon "
-"rregullisht shtesat e zgjedhura. Disa nga arsyet më të rëndomta që një "
-"shtesë të hiqet nga lista e të zgjedhurave janë:"
+"Mozilla dhe Trupa Këshillimore e Shtesave të Zgjedhura peshon dhe qarkullon rregullisht shtesat e zgjedhura. Disa nga arsyet më të rëndomta që një shtesë të hiqet nga lista e të zgjedhurave janë:"
 
 #: src/olympia/devhub/templates/devhub/docs/policies-recommended.html:83
 msgid ""
-"Lack of growth &mdash; Add-ons that are featured typically experience a "
-"substantial gain in both downloads and active users. If an add-on is not "
-"demonstrating growth in any substantial way, that's a good indicator the "
-"add-on may not be very useful to our users."
+"Lack of growth &mdash; Add-ons that are featured typically experience a substantial gain in both downloads and active users. If an add-on is not demonstrating growth in any substantial way, that's "
+"a good indicator the add-on may not be very useful to our users."
 msgstr ""
-"Mungesë rritjeje &mdash; Shtesat që paraqiten si të zgjedhura, zakonisht "
-"njohin një shtim thelbësor si të shkarkimeve, ashtu edhe të përdoruesve "
-"aktivë. Nëse një shtesë nuk shfaq rritje thelbësore në çfarëdo drejtimi, ky "
-"është tregues i mirë që shtesa mund të mos jetë dhe aq e dobishme për "
-"përdoruesit tanë."
+"Mungesë rritjeje &mdash; Shtesat që paraqiten si të zgjedhura, zakonisht njohin një shtim thelbësor si të shkarkimeve, ashtu edhe të përdoruesve aktivë. Nëse një shtesë nuk shfaq rritje thelbësore "
+"në çfarëdo drejtimi, ky është tregues i mirë që shtesa mund të mos jetë dhe aq e dobishme për përdoruesit tanë."
 
 #: src/olympia/devhub/templates/devhub/docs/policies-recommended.html:88
-msgid ""
-"Negative reviews &mdash; Featured add-ons should have a great experience and"
-" very few bugs, so add-ons with many negative reviews may be reconsidered."
-msgstr ""
-"Shqyrtime negative &mdash; Shtesat e zgjedhura do të duhej të kishin "
-"funksionin të shkëlqyer dhe shumë pak të meta, ndaj shtesat me shumë "
-"shqyrtime negative do të duheshin rishqyrtuar."
+msgid "Negative reviews &mdash; Featured add-ons should have a great experience and very few bugs, so add-ons with many negative reviews may be reconsidered."
+msgstr "Shqyrtime negative &mdash; Shtesat e zgjedhura do të duhej të kishin funksionin të shkëlqyer dhe shumë pak të meta, ndaj shtesat me shumë shqyrtime negative do të duheshin rishqyrtuar."
 
 #: src/olympia/devhub/templates/devhub/docs/policies-recommended.html:93
 msgid ""
-"Incompatibility with upcoming Firefox versions &mdash; Featured add-ons are "
-"expected to be compatible with stable and beta versions of Firefox. Add-ons "
-"not yet compatible with a Beta version of Firefox four weeks before its "
-"expected release will lose their featured status."
+"Incompatibility with upcoming Firefox versions &mdash; Featured add-ons are expected to be compatible with stable and beta versions of Firefox. Add-ons not yet compatible with a Beta version of "
+"Firefox four weeks before its expected release will lose their featured status."
 msgstr ""
-"Papërputhshëmria me versione të ardhshme të Firefox-it &mdash; Shtesat e "
-"zgjedhura pritet të jenë të përputhshme me versionet beta dhe ato të "
-"qëndrueshme të Firefox-it. Shtesat ende të papërputhshme me një version Beta"
-" të Firefox-it katër javë përpara hedhjes së pritshme në qarkullim do ta "
-"humbin gjendjen si të zgjedhura."
+"Papërputhshëmria me versione të ardhshme të Firefox-it &mdash; Shtesat e zgjedhura pritet të jenë të përputhshme me versionet beta dhe ato të qëndrueshme të Firefox-it. Shtesat ende të "
+"papërputhshme me një version Beta të Firefox-it katër javë përpara hedhjes së pritshme në qarkullim do ta humbin gjendjen si të zgjedhura."
 
 #: src/olympia/devhub/templates/devhub/docs/policies-recommended.html:99
 msgid "Joining the Featured Add-ons Advisory Board"
 msgstr "Bëhuni pjesë e Bordit Këshillimor për Shtesat e Zgjedhura"
 
 #: src/olympia/devhub/templates/devhub/docs/policies-recommended.html:102
-msgid ""
-"Every six months a new Advisory Board is chosen based on applications from "
-"the add-ons community. Members must:"
-msgstr ""
-"Çdo gjashtë muaj zgjidhet një Trupë e re Këshillimore, bazuar mbi "
-"kandidatura prej bashkësisë së shtesa. Anëtarët duhet:"
+msgid "Every six months a new Advisory Board is chosen based on applications from the add-ons community. Members must:"
+msgstr "Çdo gjashtë muaj zgjidhet një Trupë e re Këshillimore, bazuar mbi kandidatura prej bashkësisë së shtesa. Anëtarët duhet:"
 
 #: src/olympia/devhub/templates/devhub/docs/policies-recommended.html:108
-msgid ""
-"be active members of the add-ons community, whether as a developer, "
-"evangelist, or fan"
-msgstr ""
-"të jenë anëtarë aktivë të bashkësisë së shtesave, qofshin zhvillues, "
-"predikues apo dashamirës"
+msgid "be active members of the add-ons community, whether as a developer, evangelist, or fan"
+msgstr "të jenë anëtarë aktivë të bashkësisë së shtesave, qofshin zhvillues, predikues apo dashamirës"
 
 #: src/olympia/devhub/templates/devhub/docs/policies-recommended.html:109
-msgid ""
-"commit to trying all the nominations submitted, giving their feedback, and "
-"casting their votes every month"
-msgstr ""
-"t’i përkushtohen provës së krejt kandidaturave të parashtruara, duke dhënë "
-"përshtypjet e tyre, dhe të japin votën e tyre çdo muaj"
+msgid "commit to trying all the nominations submitted, giving their feedback, and casting their votes every month"
+msgstr "t’i përkushtohen provës së krejt kandidaturave të parashtruara, duke dhënë përshtypjet e tyre, dhe të japin votën e tyre çdo muaj"
 
 #: src/olympia/devhub/templates/devhub/docs/policies-recommended.html:110
-msgid ""
-"abstain from voting on add-ons that they have any business or personal "
-"affiliations with, as well as direct competitors of any such add-ons"
-msgstr ""
-"të mos marrin pjesë në votimin e një shtese me të cilën i lidh biznesi apo "
-"vetja, si dhe në votim për konkurrentë të drejtpërdrejt të çfarëdo shtese të"
-" tillë"
+msgid "abstain from voting on add-ons that they have any business or personal affiliations with, as well as direct competitors of any such add-ons"
+msgstr "të mos marrin pjesë në votimin e një shtese me të cilën i lidh biznesi apo vetja, si dhe në votim për konkurrentë të drejtpërdrejt të çfarëdo shtese të tillë"
 
 #: src/olympia/devhub/templates/devhub/docs/policies-recommended.html:114
 msgid ""
-"Members of the Mozilla Add-ons team may veto any add-on's selection because "
-"of security, privacy, compatibility, or any other reason, but in general it "
-"is up to the Board to select add-ons to feature."
+"Members of the Mozilla Add-ons team may veto any add-on's selection because of security, privacy, compatibility, or any other reason, but in general it is up to the Board to select add-ons to "
+"feature."
 msgstr ""
-"Anëtarët e ekipit të Shtesave Mozilla mund të vendosin veto mbi çfarëdo "
-"përzgjedhje shtese, kur vjen puna për sigurinë, privatësinë, "
-"përputhshmërinë, ose për çfarëdo arsye tjetër, por në përgjithësi i takon "
-"Trupës të përzgjedhë shtesa për te të zgjedhurat."
+"Anëtarët e ekipit të Shtesave Mozilla mund të vendosin veto mbi çfarëdo përzgjedhje shtese, kur vjen puna për sigurinë, privatësinë, përputhshmërinë, ose për çfarëdo arsye tjetër, por në "
+"përgjithësi i takon Trupës të përzgjedhë shtesa për te të zgjedhurat."
 
 #: src/olympia/devhub/templates/devhub/docs/policies-recommended.html:120
 msgid ""
-"This featured policy only applies to the addons.mozilla.org global list of "
-"featured add-ons. Add-ons featured in other locations are often pulled from "
-"this list, but Mozilla may feature any add-on in other locations without the"
-" Board's consent. Additionally, locale-specific features override the global"
-" defaults, so if a locale has opted to select its own features, some or all "
-"of the global features may not appear in that locale."
+"This featured policy only applies to the addons.mozilla.org global list of featured add-ons. Add-ons featured in other locations are often pulled from this list, but Mozilla may feature any add-on "
+"in other locations without the Board's consent. Additionally, locale-specific features override the global defaults, so if a locale has opted to select its own features, some or all of the global "
+"features may not appear in that locale."
 msgstr ""
-"Ky rregull vlen vetëm për listën e shtesave të zgjedhura te "
-"addons.mozilla.org. Shtesat e zgjedhura në vende të tjera shpesh hiqen prej "
-"kësaj liste, por Mozilla mund të kalojë te të zgjedhurat çfarëdo shtese prej"
-" vendi tjetër, pa pëlqimin e Trupës. Për më tepër, të zgjedhurat e një "
-"vendoreje anashkalojnë parazgjedhjet globale, pra nëse një vendore ka "
-"vendosur të përzgjedhë të vetat, disa ose krejt të zgjedhurat globale mund "
-"të mos shfaqen te ajo vendore."
+"Ky rregull vlen vetëm për listën e shtesave të zgjedhura te addons.mozilla.org. Shtesat e zgjedhura në vende të tjera shpesh hiqen prej kësaj liste, por Mozilla mund të kalojë te të zgjedhurat "
+"çfarëdo shtese prej vendi tjetër, pa pëlqimin e Trupës. Për më tepër, të zgjedhurat e një vendoreje anashkalojnë parazgjedhjet globale, pra nëse një vendore ka vendosur të përzgjedhë të vetat, disa "
+"ose krejt të zgjedhurat globale mund të mos shfaqen te ajo vendore."
 
 #: src/olympia/devhub/templates/devhub/docs/policies-recommended.html:126
 #, python-format
-msgid ""
-"Follow the <a href=\"%(link_blog)s\">Add-ons Blog</a> or <a "
-"href=\"%(link_twitter)s\">@mozamo</a> on Twitter to learn when the next "
-"application period opens."
-msgstr ""
-"Ndiqni <a href=\"%(link_blog)s\">Blogun e Shtesave</a> ose <a "
-"href=\"%(link_twitter)s\">@mozamo</a> në Twitter që të dini se kur hapet "
-"periudha pasuese për aplikime."
+msgid "Follow the <a href=\"%(link_blog)s\">Add-ons Blog</a> or <a href=\"%(link_twitter)s\">@mozamo</a> on Twitter to learn when the next application period opens."
+msgstr "Ndiqni <a href=\"%(link_blog)s\">Blogun e Shtesave</a> ose <a href=\"%(link_twitter)s\">@mozamo</a> në Twitter që të dini se kur hapet periudha pasuese për aplikime."
 
 #: src/olympia/devhub/templates/devhub/docs/policies-recommended.html:131
 msgid "Last updated: January 31, 2013"
 msgstr "Përditësuar së fundmi: 31 Janar, 2013"
 
-#: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:3
-#: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:7
-#: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:8
-#: src/olympia/devhub/templates/devhub/docs/policies.html:15
-#: src/olympia/devhub/templates/devhub/docs/policies.html:64
+#: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:3 src/olympia/devhub/templates/devhub/docs/policies-reviews.html:7 src/olympia/devhub/templates/devhub/docs/policies-reviews.html:8
+#: src/olympia/devhub/templates/devhub/docs/policies.html:15 src/olympia/devhub/templates/devhub/docs/policies.html:64
 msgid "Review Process"
 msgstr "Procesi i Shqyrtimit"
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:12
 msgid ""
-"In order to ensure all add-ons hosted in our gallery are safe for users to "
-"install, Mozilla will begin requiring all hosted add-ons to undergo review. "
-"We offer two types of review and developers are free to choose the best fit "
-"for their add-on."
+"In order to ensure all add-ons hosted in our gallery are safe for users to install, Mozilla will begin requiring all hosted add-ons to undergo review. We offer two types of review and developers "
+"are free to choose the best fit for their add-on."
 msgstr ""
-"Që të sigurohet se krejt shtesat e strehuara në galerinë tonë janë të "
-"parrezikshme kur instalohen nga përdoruesit, Mozilla do të fillojë të "
-"kërkojë që krejt shtesat e strehuara t’i nënshtrohen shqyrtimit. ofrojmë dy "
-"lloje shqyrtimesh dhe zhvilluesit janë të lirë të zgjedhin atë më të "
-"përshtatshmen për shtesën e tyre."
+"Që të sigurohet se krejt shtesat e strehuara në galerinë tonë janë të parrezikshme kur instalohen nga përdoruesit, Mozilla do të fillojë të kërkojë që krejt shtesat e strehuara t’i nënshtrohen "
+"shqyrtimit. ofrojmë dy lloje shqyrtimesh dhe zhvilluesit janë të lirë të zgjedhin atë më të përshtatshmen për shtesën e tyre."
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:19
 msgid ""
-"<strong><a href=\"#full\">Full Review</a></strong> &mdash; a thorough "
-"functional and code review of the add-on, appropriate for add-ons ready for "
-"distribution to the masses. All site features are available to these add-"
-"ons."
+"<strong><a href=\"#full\">Full Review</a></strong> &mdash; a thorough functional and code review of the add-on, appropriate for add-ons ready for distribution to the masses. All site features are "
+"available to these add-ons."
 msgstr ""
-"<strong><a href=\"#full\">Shqyrtim i Plotë</a></strong> &mdash; shqyrtim "
-"shterues i kodit dhe i funksionimit të shtesës, i nevojshëm për shtesa që "
-"pretendojnë të jenë të gatshme për shpërndarje te përdoruesit. Për këto "
-"shtesa janë të përdorshme krejt veçoritë e sajtit."
+"<strong><a href=\"#full\">Shqyrtim i Plotë</a></strong> &mdash; shqyrtim shterues i kodit dhe i funksionimit të shtesës, i nevojshëm për shtesa që pretendojnë të jenë të gatshme për shpërndarje te "
+"përdoruesit. Për këto shtesa janë të përdorshme krejt veçoritë e sajtit."
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:24
 msgid ""
-"<strong><a href=\"#preliminary\">Preliminary Review</a></strong> &mdash; a "
-"faster review intended for experimental add-ons. Preliminary reviews do not "
-"check for functionality or full policy compliance, but the reviewed add-ons "
-"have install button cautions and some feature limitations."
+"<strong><a href=\"#preliminary\">Preliminary Review</a></strong> &mdash; a faster review intended for experimental add-ons. Preliminary reviews do not check for functionality or full policy "
+"compliance, but the reviewed add-ons have install button cautions and some feature limitations."
 msgstr ""
-"<strong><a href=\"#preliminary\">Shqyrtim Paraprak</a></strong> &mdash; një "
-"shqyrtim më i shpejtë, i menduar për shtesa eksperimentale. Shqyrtimet "
-"paraprake s’kontrollojnë funksionimin apo përputhjen e plotë me rregullat, "
-"por për shtesat e shqyrtuara ka kufizime lidhur me butonin e instalimit dhe "
-"ca veçori."
+"<strong><a href=\"#preliminary\">Shqyrtim Paraprak</a></strong> &mdash; një shqyrtim më i shpejtë, i menduar për shtesa eksperimentale. Shqyrtimet paraprake s’kontrollojnë funksionimin apo "
+"përputhjen e plotë me rregullat, por për shtesat e shqyrtuara ka kufizime lidhur me butonin e instalimit dhe ca veçori."
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:31
 msgid ""
-"Detailed descriptions of each option are below. After selecting a review "
-"process at submission, the add-on will be placed in the queue. Add-ons are "
-"reviewed by the <a href=\"https://wiki.mozilla.org/AMO:Editors\">AMO "
-"Editors</a>, a group of talented developers that volunteer to help the "
-"Mozilla project by reviewing add-ons to ensure a stable and safe experience "
-"for users. Developers will receive an email with any updates throughout the "
-"review process."
+"Detailed descriptions of each option are below. After selecting a review process at submission, the add-on will be placed in the queue. Add-ons are reviewed by the <a href=\"https://wiki.mozilla."
+"org/AMO:Editors\">AMO Editors</a>, a group of talented developers that volunteer to help the Mozilla project by reviewing add-ons to ensure a stable and safe experience for users. Developers will "
+"receive an email with any updates throughout the review process."
 msgstr ""
-"Më poshtë ka përshkrime të hollësishme për secilën mundësi. Pasi të "
-"përzgjidhet një proces shqyrtimi gjatë parashtrimit, shtesa do të vendoset "
-"në radhë. Shtesat shqyrtohen nga <a "
-"href=\"https://wiki.mozilla.org/AMO:Editors\">Redaktorët e AMO-s</a>, një "
-"grup zhvilluesish të talentuar vullnetarë në ndihmë të projektit Mozilla "
-"përmes shqyrtimit të shtesave, për t’u siguruar përdoruesve punim të "
-"qëndrueshëm dhe të parrezikshëm. Gjatë procesit të shqyrtimit zhvilluesit do"
-" të marrin email me çfarëdo përditësimi gjatë procesit."
+"Më poshtë ka përshkrime të hollësishme për secilën mundësi. Pasi të përzgjidhet një proces shqyrtimi gjatë parashtrimit, shtesa do të vendoset në radhë. Shtesat shqyrtohen nga <a href=\"https://"
+"wiki.mozilla.org/AMO:Editors\">Redaktorët e AMO-s</a>, një grup zhvilluesish të talentuar vullnetarë në ndihmë të projektit Mozilla përmes shqyrtimit të shtesave, për t’u siguruar përdoruesve punim "
+"të qëndrueshëm dhe të parrezikshëm. Gjatë procesit të shqyrtimit zhvilluesit do të marrin email me çfarëdo përditësimi gjatë procesit."
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:37
 msgid ""
-"While waiting for review, add-ons will not appear anywhere in the gallery "
-"publicly, but direct links to the add-on's details page will work. This "
-"allows the author to blog or share the link with friends, inviting them to "
-"try it out, even when not yet reviewed."
+"While waiting for review, add-ons will not appear anywhere in the gallery publicly, but direct links to the add-on's details page will work. This allows the author to blog or share the link with "
+"friends, inviting them to try it out, even when not yet reviewed."
 msgstr ""
-"Ndërkohë që pritet për një shqyrtim, shtesa s’do të shfaqet gjëkundi "
-"publikisht në galeri, por lidhjet e drejtpërdrejta për te faqja me hollësitë"
-" e shtesës do të funksionojnë. Kjo i lejon autorit ta përdotë lidhjen në "
-"blogje ose ta ndajë atë me miqtë, për t’i ftuar ta provojnë, edhe pse "
-"s’është shqyrtuar ende."
+"Ndërkohë që pritet për një shqyrtim, shtesa s’do të shfaqet gjëkundi publikisht në galeri, por lidhjet e drejtpërdrejta për te faqja me hollësitë e shtesës do të funksionojnë. Kjo i lejon autorit "
+"ta përdotë lidhjen në blogje ose ta ndajë atë me miqtë, për t’i ftuar ta provojnë, edhe pse s’është shqyrtuar ende."
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:44
 msgid ""
-"Full reviews are appropriate for add-ons that are well-tested, stable, fast,"
-" and have wide appeal to our users. If you aren't confident that your add-on"
-" meets that criteria, please consider working out the kinks while in "
-"preliminary review and accumulating user feedback first."
+"Full reviews are appropriate for add-ons that are well-tested, stable, fast, and have wide appeal to our users. If you aren't confident that your add-on meets that criteria, please consider working "
+"out the kinks while in preliminary review and accumulating user feedback first."
 msgstr ""
-"Shqyrtimet e plota janë të përshtatshme për shtesa që janë vënë mirë në "
-"provë, janë të qëndrueshme dhe të shpejta, janë tërheqëse për një masë të "
-"madhe të përdoruesve tanë. Nëse s’jeni i bindur se shtesa juaj i plotëson "
-"këto kushte, ju lutemi, shihni së pari të merreni me gjërat e nevojshme, "
-"ndërkohë që shtesa është nën shqyrtim paraprak, dhe të grumbullimit të "
-"përshtypjeve nga përdoruesit."
+"Shqyrtimet e plota janë të përshtatshme për shtesa që janë vënë mirë në provë, janë të qëndrueshme dhe të shpejta, janë tërheqëse për një masë të madhe të përdoruesve tanë. Nëse s’jeni i bindur se "
+"shtesa juaj i plotëson këto kushte, ju lutemi, shihni së pari të merreni me gjërat e nevojshme, ndërkohë që shtesa është nën shqyrtim paraprak, dhe të grumbullimit të përshtypjeve nga përdoruesit."
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:50
-msgid ""
-"We aim to perform full reviews in under 10 days, though most add-ons are "
-"reviewed in much less time."
-msgstr ""
-"Synimi ynë është kryerja e shqyrtimeve të plota brenda 10 ditësh, por "
-"shumica e shtesave shqyrtohen në shumë më pak kohë se aq."
+msgid "We aim to perform full reviews in under 10 days, though most add-ons are reviewed in much less time."
+msgstr "Synimi ynë është kryerja e shqyrtimeve të plota brenda 10 ditësh, por shumica e shtesave shqyrtohen në shumë më pak kohë se aq."
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:55
 msgid "Testing Methods &amp; Common Issues"
@@ -7249,61 +5681,36 @@ msgid "When performing a full review, editors will:"
 msgstr "Kur të kryejnë një shqyrtim të plotë, redaktorët do të:"
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:64
-msgid ""
-"install the add-on, making sure it functions as described and is free of "
-"major defects"
-msgstr ""
-"instalojeni shtesën, duke u siguruar se funksionon siç përshkruhet dhe se "
-"s’ka defekte të rënda"
+msgid "install the add-on, making sure it functions as described and is free of major defects"
+msgstr "instalojeni shtesën, duke u siguruar se funksionon siç përshkruhet dhe se s’ka defekte të rënda"
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:69
-msgid ""
-"perform a source code review, looking for performance and security best "
-"practices"
-msgstr ""
-"kryeni një shqyrtim të kodit burim, duke nuhatur praktikat më të mira për "
-"performancën dhe sigurinë"
+msgid "perform a source code review, looking for performance and security best practices"
+msgstr "kryeni një shqyrtim të kodit burim, duke nuhatur praktikat më të mira për performancën dhe sigurinë"
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:74
 msgid "ensure the add-on's privacy policy is in line with its functionality"
-msgstr ""
-"sigurohuni që rregullat e privatësisë së shtesës janë në një vijë me "
-"funksionet e saj"
+msgstr "sigurohuni që rregullat e privatësisë së shtesës janë në një vijë me funksionet e saj"
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:79
-msgid ""
-"look for compliance with all of Mozilla's policies, detailed in these "
-"documents"
-msgstr ""
-"shihni për përputhshmëri me krejt rregullat e Mozilla-s, përshkruar me "
-"hollësi në këto dokumente"
+msgid "look for compliance with all of Mozilla's policies, detailed in these documents"
+msgstr "shihni për përputhshmëri me krejt rregullat e Mozilla-s, përshkruar me hollësi në këto dokumente"
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:86
-msgid ""
-"Some of the most common issues we see when performing these reviews are:"
-msgstr ""
-"Disa nga problemet më të rëndomta që shohim kur kryejmë këto shqyrtime janë:"
+msgid "Some of the most common issues we see when performing these reviews are:"
+msgstr "Disa nga problemet më të rëndomta që shohim kur kryejmë këto shqyrtime janë:"
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:93
 msgid ""
-"<strong>JavaScript namespace pollution</strong> &mdash; the most common "
-"violation. Be sure to <a "
-"href=\"https://developer.mozilla.org/en/XUL_School/JavaScript_Object_Management\">wrap"
-" your loose variables</a>"
+"<strong>JavaScript namespace pollution</strong> &mdash; the most common violation. Be sure to <a href=\"https://developer.mozilla.org/en/XUL_School/JavaScript_Object_Management\">wrap your loose "
+"variables</a>"
 msgstr ""
-"<strong>JavaScript namespace pollution</strong> &mdash; cenimi më i "
-"rëndomtë. Sigurohuni se <a "
-"href=\"https://developer.mozilla.org/en/XUL_School/JavaScript_Object_Management\">i"
-" keni mbështjellë ndryshoret tuaja të hapërdara</a>"
+"<strong>JavaScript namespace pollution</strong> &mdash; cenimi më i rëndomtë. Sigurohuni se <a href=\"https://developer.mozilla.org/en/XUL_School/JavaScript_Object_Management\">i keni mbështjellë "
+"ndryshoret tuaja të hapërdara</a>"
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:99
-msgid ""
-"proper preference naming - all preference names should begin with "
-"\"extensions.\", followed by the add-on name or some other unique identifier"
-msgstr ""
-"proper preference naming - krejt emrat e parapëlqimeve duhet të fillojnë me "
-"\"extensions.\", pasuar nga emri i shtesës ose ndonjë identifikues tjetër "
-"unik"
+msgid "proper preference naming - all preference names should begin with \"extensions.\", followed by the add-on name or some other unique identifier"
+msgstr "proper preference naming - krejt emrat e parapëlqimeve duhet të fillojnë me \"extensions.\", pasuar nga emri i shtesës ose ndonjë identifikues tjetër unik"
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:103
 msgid "remote JavaScript execution or injection"
@@ -7348,100 +5755,65 @@ msgstr "përkeqësim i nisjes së aplikacionit ose kohës së ngarkimit të faqe
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:117
 #, python-format
 msgid ""
-"For information on how to avoid these problems, please see our <a "
-"href=\"%(link_howto)s\">How-to Library</a>. Some of these practices, such as"
-" binary or obfuscated code, are allowed under certain conditions outlined "
-"below."
+"For information on how to avoid these problems, please see our <a href=\"%(link_howto)s\">How-to Library</a>. Some of these practices, such as binary or obfuscated code, are allowed under certain "
+"conditions outlined below."
 msgstr ""
-"Për të dhëna se si të shmangen këto probleme, ju lutemi, shihni te <a "
-"href=\"%(link_howto)s\">Biblioteka jonë Si-Të</a>. Disa nga këto praktika, "
-"të tilla si përdorim kodi dyor ose të errësuar, lejohen sipas disa kushteve "
-"të skicuara më poshtë."
+"Për të dhëna se si të shmangen këto probleme, ju lutemi, shihni te <a href=\"%(link_howto)s\">Biblioteka jonë Si-Të</a>. Disa nga këto praktika, të tilla si përdorim kodi dyor ose të errësuar, "
+"lejohen sipas disa kushteve të skicuara më poshtë."
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:123
 #, python-format
 msgid ""
-"Many of the above restrictions are tested automatically by an extension "
-"scanner that will flag suspicious add-ons for editor review. You can read "
-"more about this scanner in the <a href=\"%(link_validation)s\">Validation "
-"Help</a> document."
+"Many of the above restrictions are tested automatically by an extension scanner that will flag suspicious add-ons for editor review. You can read more about this scanner in the <a href="
+"\"%(link_validation)s\">Validation Help</a> document."
 msgstr ""
-"Mjaft nga kufizimet më sipër testohen vetvetiu nga një skanues zgjerimesh, i"
-" cili shtesave të dyshimta do t’u vërë shenjë për shqyrtim redaktori. Më "
-"shumë rreth këtij skaneri mund të lexoni te dokumenti <a "
-"href=\"%(link_validation)s\">Ndihmë mbi Vleftësimet</a>."
+"Mjaft nga kufizimet më sipër testohen vetvetiu nga një skanues zgjerimesh, i cili shtesave të dyshimta do t’u vërë shenjë për shqyrtim redaktori. Më shumë rreth këtij skaneri mund të lexoni te "
+"dokumenti <a href=\"%(link_validation)s\">Ndihmë mbi Vleftësimet</a>."
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:129
 msgid ""
-"If the add-on is site-specific, it is recommended that a test account is "
-"provided for use during the review process. Additionally, including detailed"
-" testing instructions will allow an editor to better understand how the add-"
-"on functions and expedite the testing process. This information can be "
-"placed in the Notes to Reviewer field when editing a version in the "
-"Developer Hub."
+"If the add-on is site-specific, it is recommended that a test account is provided for use during the review process. Additionally, including detailed testing instructions will allow an editor to "
+"better understand how the add-on functions and expedite the testing process. This information can be placed in the Notes to Reviewer field when editing a version in the Developer Hub."
 msgstr ""
-"Nëse shtesa është vetëm për një sajt, këshillohet të ofroni një llogari "
-"testimi, për përdorim gjatë procesit të shqyrtimit. Veç kësaj, përfshirja e "
-"udhëzimeve të hollësishme mbi testimin do t’i lejonte një redaktori të "
-"kuptonte se si funksionon shtesa dhe ta përshpejtonte procesin e testimit. "
-"Këto të dhëna mund të vendosen te fusha Shënime për Shqyrtuesin, kur një "
-"version përpunohet te Qendra e Zhvilluesit."
+"Nëse shtesa është vetëm për një sajt, këshillohet të ofroni një llogari testimi, për përdorim gjatë procesit të shqyrtimit. Veç kësaj, përfshirja e udhëzimeve të hollësishme mbi testimin do t’i "
+"lejonte një redaktori të kuptonte se si funksionon shtesa dhe ta përshpejtonte procesin e testimit. Këto të dhëna mund të vendosen te fusha Shënime për Shqyrtuesin, kur një version përpunohet te "
+"Qendra e Zhvilluesit."
 
-#: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:134
-#: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:168
+#: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:134 src/olympia/devhub/templates/devhub/docs/policies-reviews.html:168
 msgid "After the Review"
 msgstr "Pas Shqyrtimit"
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:136
 msgid ""
-"Once an add-on is granted full review, it will immediately be available in "
-"the gallery, showing in browse and search results with a warning-free "
-"install button. All features, including voluntary contributions and beta "
-"channels will be available."
+"Once an add-on is granted full review, it will immediately be available in the gallery, showing in browse and search results with a warning-free install button. All features, including voluntary "
+"contributions and beta channels will be available."
 msgstr ""
-"Pasi një shtese t’i jetë akorduar shqyrtim i plotë, do të jetë menjëherë e "
-"gatshme te galeria, e shfaqur te përfundime kërkimi apo shfletimi, me një "
-"buton instalimi pa probleme. Krejt anët e sajtit, përfshi kontribut "
-"vullnetar dhe kanale beta, do të jenë të përdorshme për të."
+"Pasi një shtese t’i jetë akorduar shqyrtim i plotë, do të jetë menjëherë e gatshme te galeria, e shfaqur te përfundime kërkimi apo shfletimi, me një buton instalimi pa probleme. Krejt anët e "
+"sajtit, përfshi kontribut vullnetar dhe kanale beta, do të jenë të përdorshme për të."
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:142
 msgid ""
-"Subsequent versions of the add-on will automatically be placed in the full "
-"review queue. Until the review is completed, the new version will only be "
-"displayed on the Version History page of the add-on. Once reviewed, the "
-"version will be updated across the site and deployed through the automatic "
-"update service."
+"Subsequent versions of the add-on will automatically be placed in the full review queue. Until the review is completed, the new version will only be displayed on the Version History page of the add-"
+"on. Once reviewed, the version will be updated across the site and deployed through the automatic update service."
 msgstr ""
-"Versionet pasuese të shtesës do të vendosen automatikisht në radhën e "
-"shqyrtimeve të plota. Deri sa pa u plotësuar shqyrtimi, versioni i ri do të "
-"shfaqet vetëm te faqja Historik Versionesh të shtesës. Pasi të jetë "
-"shqyrtuar, versioni do të përditësohet në krejt sajtin dhe do të jepet "
-"përmes shërbimit të përditësimeve të vetvetishme."
+"Versionet pasuese të shtesës do të vendosen automatikisht në radhën e shqyrtimeve të plota. Deri sa pa u plotësuar shqyrtimi, versioni i ri do të shfaqet vetëm te faqja Historik Versionesh të "
+"shtesës. Pasi të jetë shqyrtuar, versioni do të përditësohet në krejt sajtin dhe do të jepet përmes shërbimit të përditësimeve të vetvetishme."
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:148
 msgid ""
-"If a version does not meet the criteria for full review, it can either be "
-"granted preliminary review or disabled if there is a security concern. The "
-"author will receive an email explaining the action taken and how to fix it. "
-"In most cases, the developer can simply fix the problem and re-submit for "
-"full review."
+"If a version does not meet the criteria for full review, it can either be granted preliminary review or disabled if there is a security concern. The author will receive an email explaining the "
+"action taken and how to fix it. In most cases, the developer can simply fix the problem and re-submit for full review."
 msgstr ""
-"Nëse një version s’i plotëson kriteret për shqyrtim të plotë, mundet ose t’i"
-" akordohet shqyrtim paraprak, ose të çaktivizohet, kur ka çështje sigurie. "
-"Autori do të marrë një email që shpjegon veprimin e kryer dhe se si të "
-"ndreqet. Në shumicën e rasteve, zhvilluesi thjesht mund të ndreqë problemin "
-"dhe ta riparashtrojë për shqyrtim të plotë."
+"Nëse një version s’i plotëson kriteret për shqyrtim të plotë, mundet ose t’i akordohet shqyrtim paraprak, ose të çaktivizohet, kur ka çështje sigurie. Autori do të marrë një email që shpjegon "
+"veprimin e kryer dhe se si të ndreqet. Në shumicën e rasteve, zhvilluesi thjesht mund të ndreqë problemin dhe ta riparashtrojë për shqyrtim të plotë."
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:155
 msgid ""
-"Preliminary reviews are appropriate for experimental add-ons and provide a "
-"way to get user testing and feedback without going through the longer, more "
-"thorough review process. We aim to complete these reviews in under 3 days."
+"Preliminary reviews are appropriate for experimental add-ons and provide a way to get user testing and feedback without going through the longer, more thorough review process. We aim to complete "
+"these reviews in under 3 days."
 msgstr ""
-"Shqyrtimet paraprake janë të përshtatshme për shtesa eksperimentale dhe "
-"ofrojnë një rrugë për të pasur testim dhe përshtypje nga përdoruesit, pa "
-"kaluar procesin më të gjatë, më të plotë të shqyrtimit. Synimi ynë është "
-"plotësimi i këtyre shqyrtimeve brenda 3 ditësh."
+"Shqyrtimet paraprake janë të përshtatshme për shtesa eksperimentale dhe ofrojnë një rrugë për të pasur testim dhe përshtypje nga përdoruesit, pa kaluar procesin më të gjatë, më të plotë të "
+"shqyrtimit. Synimi ynë është plotësimi i këtyre shqyrtimeve brenda 3 ditësh."
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:160
 msgid "Testing Methods"
@@ -7449,56 +5821,33 @@ msgstr "Metoda Provash"
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:162
 msgid ""
-"When performing a preliminary review, editors will review the source code "
-"for security issues and major policy violations, but will not install the "
-"add-on to test functionality in most cases. Preliminary review will be "
-"granted unless a security vulnerability or major policy violation is "
-"discovered."
+"When performing a preliminary review, editors will review the source code for security issues and major policy violations, but will not install the add-on to test functionality in most cases. "
+"Preliminary review will be granted unless a security vulnerability or major policy violation is discovered."
 msgstr ""
-"Kur kryejnë një shqyrtim paraprak, redaktorët do të shqyrtojnë kodin burim "
-"lidhur me çështje sigurie dhe cenime të rënda të rregullave, por në shumicën"
-" e rasteve s’do ta instalojnë shtesën për të provuar funksionet e saj. "
-"Shqyrtimi paraprak do të akordohet, veç në u zbulofshin cenime sigurie ose "
-"dhunime të rënda të rregullave."
+"Kur kryejnë një shqyrtim paraprak, redaktorët do të shqyrtojnë kodin burim lidhur me çështje sigurie dhe cenime të rënda të rregullave, por në shumicën e rasteve s’do ta instalojnë shtesën për të "
+"provuar funksionet e saj. Shqyrtimi paraprak do të akordohet, veç në u zbulofshin cenime sigurie ose dhunime të rënda të rregullave."
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:171
 msgid ""
-"Once preliminary review is granted, the add-on will be immediately available"
-" in the gallery, showing in browse and search results but ranked lower than "
-"fully-reviewed add-ons. Install buttons will have caution stripes and a "
-"notice that the add-on is experimental and not fully reviewed by Mozilla, "
-"though no click-through is required. Additionally, these add-ons cannot use "
-"the voluntary contributions and beta channel features."
+"Once preliminary review is granted, the add-on will be immediately available in the gallery, showing in browse and search results but ranked lower than fully-reviewed add-ons. Install buttons will "
+"have caution stripes and a notice that the add-on is experimental and not fully reviewed by Mozilla, though no click-through is required. Additionally, these add-ons cannot use the voluntary "
+"contributions and beta channel features."
 msgstr ""
-"Pasi të akordohet shqyrtim paraprak, shtesa do të jetë menjëherë e passhme "
-"prej galerisë, do të jetë e shfaqur në përfundime kërkimesh dhe shfletimi, "
-"por me klasifikim më të ulët se sa shtesat me shqyrtim të plotë. Butonat e "
-"instalimit për të do të kenë viza sinjalizuese dhe një shënim që shtesa "
-"është eksperimentale dhe ende e pashqyrtuar plotësisht nga Mozilla, edhe pse"
-" s’lypset “click-through”. Për më tepër, këto shtesa s’mund të përdorin "
-"kontribute vullnetare dhe funksione kanali betash."
+"Pasi të akordohet shqyrtim paraprak, shtesa do të jetë menjëherë e passhme prej galerisë, do të jetë e shfaqur në përfundime kërkimesh dhe shfletimi, por me klasifikim më të ulët se sa shtesat me "
+"shqyrtim të plotë. Butonat e instalimit për të do të kenë viza sinjalizuese dhe një shënim që shtesa është eksperimentale dhe ende e pashqyrtuar plotësisht nga Mozilla, edhe pse s’lypset “click-"
+"through”. Për më tepër, këto shtesa s’mund të përdorin kontribute vullnetare dhe funksione kanali betash."
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:177
-msgid ""
-"After being granted preliminary review, Mozilla may later revoke the review "
-"if other serious problems are reported to us by users."
-msgstr ""
-"Pasi shqyrtimi paraprak të jetë akorduar, Mozilla mund ta shfuqizojë "
-"shqyrtimin, nëse njoftohet nga përdoruesit për probleme të tjera serioze."
+msgid "After being granted preliminary review, Mozilla may later revoke the review if other serious problems are reported to us by users."
+msgstr "Pasi shqyrtimi paraprak të jetë akorduar, Mozilla mund ta shfuqizojë shqyrtimin, nëse njoftohet nga përdoruesit për probleme të tjera serioze."
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:183
 msgid ""
-"Subsequent versions of the add-on will automatically be placed in the "
-"preliminary review queue. Until the review is completed, the new version "
-"will only be displayed on the Version History page of the add-on. Once "
-"reviewed, the version will be updated across the site and deployed through "
-"the automatic update service."
+"Subsequent versions of the add-on will automatically be placed in the preliminary review queue. Until the review is completed, the new version will only be displayed on the Version History page of "
+"the add-on. Once reviewed, the version will be updated across the site and deployed through the automatic update service."
 msgstr ""
-"Versionet pasuese të shtesës do të vendosen automatikish në radhën e "
-"shqyrtimeve paraprake. Deri sa pa u plotësuar shqyrtimi, versioni i ri do të"
-" shfaqet vetëm te faqja Historik Versionesh të shtesës. Pasi të jetë "
-"shqyrtuar, versioni do të përditësohet në krejt sajtin dhe do të jepet "
-"përmes shërbimit të përditësimeve të vetvetishme."
+"Versionet pasuese të shtesës do të vendosen automatikish në radhën e shqyrtimeve paraprake. Deri sa pa u plotësuar shqyrtimi, versioni i ri do të shfaqet vetëm te faqja Historik Versionesh të "
+"shtesës. Pasi të jetë shqyrtuar, versioni do të përditësohet në krejt sajtin dhe do të jepet përmes shërbimit të përditësimeve të vetvetishme."
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:188
 msgid "Policies on Specific Add-on Practices"
@@ -7513,63 +5862,36 @@ msgid "The following add-ons are not permitted in any form:"
 msgstr "Shtesat vijuese nuk lejohen, në çfarëdo forme qofshin:"
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:194
-msgid ""
-"Add-ons that embed known <a "
-"href=\"http://en.wikipedia.org/wiki/Spyware\">spyware</a> or <a "
-"href=\"http://en.wikipedia.org/wiki/Malware\">malware</a>"
-msgstr ""
-"Shtesa që trupëzojnë <a "
-"href=\"http://en.wikipedia.org/wiki/Spyware\">spyware</a> ose <a "
-"href=\"http://en.wikipedia.org/wiki/Malware\">malware</a> të njohur"
+msgid "Add-ons that embed known <a href=\"http://en.wikipedia.org/wiki/Spyware\">spyware</a> or <a href=\"http://en.wikipedia.org/wiki/Malware\">malware</a>"
+msgstr "Shtesa që trupëzojnë <a href=\"http://en.wikipedia.org/wiki/Spyware\">spyware</a> ose <a href=\"http://en.wikipedia.org/wiki/Malware\">malware</a> të njohur"
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:199
 msgid ""
-"Illegal and criminal add-ons, such as <a "
-"href=\"http://en.wikipedia.org/wiki/Click_fraud\">click fraud</a> "
-"generators, <a href=\"http://en.wikipedia.org/wiki/Warez\">warez</a> "
-"download and directory assistants, child pornography finders, etc."
+"Illegal and criminal add-ons, such as <a href=\"http://en.wikipedia.org/wiki/Click_fraud\">click fraud</a> generators, <a href=\"http://en.wikipedia.org/wiki/Warez\">warez</a> download and "
+"directory assistants, child pornography finders, etc."
 msgstr ""
-"Shtesa të paligjshme dhe kriminale, të tilla si prodhues <a "
-"href=\"http://en.wikipedia.org/wiki/Click_fraud\">mashtrimesh me klikim</a>,"
-" shkarkime <a href=\"http://en.wikipedia.org/wiki/Warez\">warez</a> dhe "
-"asistentë drejtorish, zbulues pornografie të miturish, etj."
+"Shtesa të paligjshme dhe kriminale, të tilla si prodhues <a href=\"http://en.wikipedia.org/wiki/Click_fraud\">mashtrimesh me klikim</a>, shkarkime <a href=\"http://en.wikipedia.org/wiki/Warez"
+"\">warez</a> dhe asistentë drejtorish, zbulues pornografie të miturish, etj."
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:204
-msgid ""
-"Add-ons whose main purpose is to facilitate access to pornographic material,"
-" or include references to this material in their descriptions"
-msgstr ""
-"Shtesa qëllimi kryesor i të cilave është lehtësimi i hyrjes në material "
-"pornografik, ose që në përshkrimin e tyre përfshijnë referenca materiali të "
-"tillë"
+msgid "Add-ons whose main purpose is to facilitate access to pornographic material, or include references to this material in their descriptions"
+msgstr "Shtesa qëllimi kryesor i të cilave është lehtësimi i hyrjes në material pornografik, ose që në përshkrimin e tyre përfshijnë referenca materiali të tillë"
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:210
-msgid ""
-"Add-ons that, upon installation, auto-install or launch installers of non-"
-"Firefox software"
-msgstr ""
-"Shtesa të cilat gjatë instalimit, vetëinstalojnë ose vënë në punë instalues "
-"software-i jo Firefox"
+msgid "Add-ons that, upon installation, auto-install or launch installers of non-Firefox software"
+msgstr "Shtesa të cilat gjatë instalimit, vetëinstalojnë ose vënë në punë instalues software-i jo Firefox"
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:215
-msgid ""
-"Add-ons that provide their own update mechanism for code or search engines"
-msgstr ""
-"Shtesa që ofrojnë mekanizëm të tyren përditësimi për kodin apo motorët e "
-"kërkimit"
+msgid "Add-ons that provide their own update mechanism for code or search engines"
+msgstr "Shtesa që ofrojnë mekanizëm të tyren përditësimi për kodin apo motorët e kërkimit"
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:220
-msgid ""
-"Add-ons that make changes to web content in ways that are non-obvious or "
-"difficult to trace by their users"
-msgstr ""
-"Shtesa që bëjnë ndryshime te lëndë web sipas rrugësh që s’janë të kuptueshme"
-" ose të vështira për t’u gjurmuar nga përdoruesit e tyre"
+msgid "Add-ons that make changes to web content in ways that are non-obvious or difficult to trace by their users"
+msgstr "Shtesa që bëjnë ndryshime te lëndë web sipas rrugësh që s’janë të kuptueshme ose të vështira për t’u gjurmuar nga përdoruesit e tyre"
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:225
 msgid "Add-ons that snoop on or intercept the network traffic of other users"
-msgstr ""
-"Shtesa që fusin hundët ose spiunojnë trafik rrjeti të përdoruesve të tjerë"
+msgstr "Shtesa që fusin hundët ose spiunojnë trafik rrjeti të përdoruesve të tjerë"
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:230
 msgid "Conduit-based toolbars without explicit pre-approval"
@@ -7581,68 +5903,35 @@ msgstr "Ndryshim Parazgjedhjesh dhe Veçori të Papritura"
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:238
 msgid ""
-"Surprises can be appropriate in many situations, but they are not welcome "
-"when user security, privacy, and control are at stake. It is extremely "
-"important to be as transparent as possible when submitting an add-on for "
-"hosting on this site. A Mozilla user should be able to easily discern what "
-"the functionality of an add-on is and not be presented with unexpected "
-"experiences post-install."
+"Surprises can be appropriate in many situations, but they are not welcome when user security, privacy, and control are at stake. It is extremely important to be as transparent as possible when "
+"submitting an add-on for hosting on this site. A Mozilla user should be able to easily discern what the functionality of an add-on is and not be presented with unexpected experiences post-install."
 msgstr ""
-"Çuditë mund të jenë të përshtatshme në shumë raste, por s’janë të "
-"mirëpritura kur bëhet fjalë për sigurinë, privatësinë dhe kontrollin e "
-"përdoruesit. Është tejet e rëndësishme të jemi sa më transparentë që mundet,"
-" parashtrohet një shtesë për shtrehim në këtë sajt. Një përdorues i "
-"Mozilla-s do të duhej të dallonte me lehtësi se cili është funksioni i një "
-"shtese dhe jo t’i vihen përpara gjëra të papritura pas instalimit."
+"Çuditë mund të jenë të përshtatshme në shumë raste, por s’janë të mirëpritura kur bëhet fjalë për sigurinë, privatësinë dhe kontrollin e përdoruesit. Është tejet e rëndësishme të jemi sa më "
+"transparentë që mundet, parashtrohet një shtesë për shtrehim në këtë sajt. Një përdorues i Mozilla-s do të duhej të dallonte me lehtësi se cili është funksioni i një shtese dhe jo t’i vihen përpara "
+"gjëra të papritura pas instalimit."
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:243
 msgid ""
-"<p> Whenever an add-on includes any unexpected* feature that </p> <ul> "
-"<li>compromises user privacy or security (like sending data to third "
-"parties),</li> <li>changes default settings like the homepage or search "
-"engine, or</li> <li>changes settings or features in other add-ons or "
-"deactivates them altogether</li> </ul> <p>the features must adhere to the "
-"following requirements:</p> <ul> <li>The add-on description must clearly "
-"state what changes the add-on makes.</li> <li>All changes must be opt-in, "
-"meaning the user must take non-default action to enact the change.</li> "
-"<li>The opt-in dialog must clearly state the name of the add-on requesting "
-"the change.</li> <li>Uninstalling the add-on restores the user's original "
-"settings if they were changed.</li> </ul> <p>*Unexpected features are those "
-"that are unrelated to the add-on's primary function.</p>"
+"<p> Whenever an add-on includes any unexpected* feature that </p> <ul> <li>compromises user privacy or security (like sending data to third parties),</li> <li>changes default settings like the "
+"homepage or search engine, or</li> <li>changes settings or features in other add-ons or deactivates them altogether</li> </ul> <p>the features must adhere to the following requirements:</p> <ul> "
+"<li>The add-on description must clearly state what changes the add-on makes.</li> <li>All changes must be opt-in, meaning the user must take non-default action to enact the change.</li> <li>The opt-"
+"in dialog must clearly state the name of the add-on requesting the change.</li> <li>Uninstalling the add-on restores the user's original settings if they were changed.</li> </ul> <p>*Unexpected "
+"features are those that are unrelated to the add-on's primary function.</p>"
 msgstr ""
-"<p> Kurdo që një shtesë fut në lojë çfarëdo veçorie të papritur* që </p> "
-"<ul> <li>komprometon privatësinë ose sigurinë e përdoruesit (fjala vjen, u "
-"dërgon të dhëna palëve të treta),</li> <li>ndryshon rregullimet "
-"parazgjedhje, të tilla si faqja hyrëse ose motorët e kërkimeve, ose</li> "
-"<li>ndryshon rregullime ose veçori te shtesa të tjera ose i çaktivizon ato "
-"krejtësisht</li> </ul> <p>veçoritë duhet të plotësojnë domosdoshmëritë "
-"vijuese:</p> <ul> <li>Përshkrimi i shtesës duhet të pohojë sheshit çfarë "
-"ndryshimesh bën shtesa.</li> <li>Krejt ndryshimet duhet të jenë nën "
-"zgjedhjen e përdoruesit, që do të thotë se përdoruesi duhet të kryejë një "
-"veprim jo parazgjedhje për aktivizimin e ndryshimit.</li> <li>Dialogu i "
-"zgjedhjes duhet të deklarojë haptazi emrin e shtesës që po kërkon "
-"ndryshimin.</li> <li>Çinstalimi i shtesës duhet të rikthejë rregullimet e "
-"mëparshme të përdoruesit, nëse qenë ndryshuar.</li> </ul> <p>*Veçori të "
-"papritura janë ato që s’lidhen me funksionin parësor të shtesës.</p>"
+"<p> Kurdo që një shtesë fut në lojë çfarëdo veçorie të papritur* që </p> <ul> <li>komprometon privatësinë ose sigurinë e përdoruesit (fjala vjen, u dërgon të dhëna palëve të treta),</li> "
+"<li>ndryshon rregullimet parazgjedhje, të tilla si faqja hyrëse ose motorët e kërkimeve, ose</li> <li>ndryshon rregullime ose veçori te shtesa të tjera ose i çaktivizon ato krejtësisht</li> </ul> "
+"<p>veçoritë duhet të plotësojnë domosdoshmëritë vijuese:</p> <ul> <li>Përshkrimi i shtesës duhet të pohojë sheshit çfarë ndryshimesh bën shtesa.</li> <li>Krejt ndryshimet duhet të jenë nën "
+"zgjedhjen e përdoruesit, që do të thotë se përdoruesi duhet të kryejë një veprim jo parazgjedhje për aktivizimin e ndryshimit.</li> <li>Dialogu i zgjedhjes duhet të deklarojë haptazi emrin e "
+"shtesës që po kërkon ndryshimin.</li> <li>Çinstalimi i shtesës duhet të rikthejë rregullimet e mëparshme të përdoruesit, nëse qenë ndryshuar.</li> </ul> <p>*Veçori të papritura janë ato që s’lidhen "
+"me funksionin parësor të shtesës.</p>"
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:268
-msgid ""
-"These features cannot be introduced into an update of a fully-reviewed add-"
-"on; the opt-in change process must be part of the initial review."
-msgstr ""
-"Këto veçori s’mund të futen për herë të parë në një përditësim shtese të "
-"shqyrtuar plotësisht; procesi i ndryshimeve me zgjedhje duhet të jetë pjesë "
-"e shqyrtimit fillestar."
+msgid "These features cannot be introduced into an update of a fully-reviewed add-on; the opt-in change process must be part of the initial review."
+msgstr "Këto veçori s’mund të futen për herë të parë në një përditësim shtese të shqyrtuar plotësisht; procesi i ndryshimeve me zgjedhje duhet të jetë pjesë e shqyrtimit fillestar."
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:274
-msgid ""
-"These are minimum requirements and not a guarantee that the add-on will be "
-"approved. This section applies to all add-ons hosted on the site, including "
-"preliminarily reviewed add-ons."
-msgstr ""
-"Këto janë domosdoshmëritë minimum dhe jo ndonjë garanci që shtesa do të "
-"miratohet. Kjo ndarje ka vlerë për krejt shtesat e strehuara në këtë sajt, "
-"përfshi shtesa të shqyrtara paraprakisht."
+msgid "These are minimum requirements and not a guarantee that the add-on will be approved. This section applies to all add-ons hosted on the site, including preliminarily reviewed add-ons."
+msgstr "Këto janë domosdoshmëritë minimum dhe jo ndonjë garanci që shtesa do të miratohet. Kjo ndarje ka vlerë për krejt shtesat e strehuara në këtë sajt, përfshi shtesa të shqyrtara paraprakisht."
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:279
 msgid "Private Browsing Mode"
@@ -7650,19 +5939,11 @@ msgstr "Mënyra Shfletim Privat"
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:282
 msgid ""
-"Add-ons that store or otherwise handle browsing data must support <a "
-"href=\"https://developer.mozilla.org/En/Supporting_private_browsing_mode\">Private"
-" Browsing Mode</a>.  During a Private Browsing session, no browsing data can"
-" be written to disk, and all of this data must be cleared when Firefox quits"
-" or the Private Browsing session ends."
+"Add-ons that store or otherwise handle browsing data must support <a href=\"https://developer.mozilla.org/En/Supporting_private_browsing_mode\">Private Browsing Mode</a>. During a Private Browsing "
+"session, no browsing data can be written to disk, and all of this data must be cleared when Firefox quits or the Private Browsing session ends."
 msgstr ""
-"Shtesat që depozitojnë, ose trajtojnë të dhëna shfletimi, duhet të mbulojnë "
-"<a "
-"href=\"https://developer.mozilla.org/En/Supporting_private_browsing_mode\">Mënyrën"
-" e Shfletimit Privat</a>. Gjatë një sesioni Shfletimi Privat, nuk mund të "
-"shkruhen në disk të dhëna shfletimi, dhe krej këto të dhëna duhet të "
-"pastrohen pasi dilet nga Firefox-i ose pasi përfundon sesioni i Shfletimit "
-"Privat."
+"Shtesat që depozitojnë, ose trajtojnë të dhëna shfletimi, duhet të mbulojnë <a href=\"https://developer.mozilla.org/En/Supporting_private_browsing_mode\">Mënyrën e Shfletimit Privat</a>. Gjatë një "
+"sesioni Shfletimi Privat, nuk mund të shkruhen në disk të dhëna shfletimi, dhe krej këto të dhëna duhet të pastrohen pasi dilet nga Firefox-i ose pasi përfundon sesioni i Shfletimit Privat."
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:287
 msgid "Binary Components & Obfuscated Code"
@@ -7670,43 +5951,26 @@ msgstr "Përbërës Dyorë & Kod i Errët"
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:289
 msgid ""
-"Add-ons may contain binary, obfuscated and minified source code, but Mozilla"
-" must be allowed to review a copy of the human-readable source code of each "
-"version of an add-on submitted for review. These add-ons are ineligible for "
-"preliminary review and must choose the full review process."
+"Add-ons may contain binary, obfuscated and minified source code, but Mozilla must be allowed to review a copy of the human-readable source code of each version of an add-on submitted for review. "
+"These add-ons are ineligible for preliminary review and must choose the full review process."
 msgstr ""
-"Shtesat mund të përmbajnë kod dyor, të errësuar, ose kod me burim të "
-"minimizuar, por Mozilla duhet të lejohet të shqyrtojë një kopje të kodit "
-"burim nën formë të lexueshme nga syri njerëzor, për çdo version shtese "
-"parashtruar për shqyrtim. Këto shtesa janë të përjashtuara nga shqyrtimi "
-"paraprak dhe duhet të zgjedhin procesin e shqyrtimit të plotë."
+"Shtesat mund të përmbajnë kod dyor, të errësuar, ose kod me burim të minimizuar, por Mozilla duhet të lejohet të shqyrtojë një kopje të kodit burim nën formë të lexueshme nga syri njerëzor, për çdo "
+"version shtese parashtruar për shqyrtim. Këto shtesa janë të përjashtuara nga shqyrtimi paraprak dhe duhet të zgjedhin procesin e shqyrtimit të plotë."
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:295
 msgid ""
-"If an add-on contains binary or obfuscated source code, the author will "
-"receive a message when the add-on is reviewed indicating whom to contact at "
-"Mozilla to coordinate review of the source code. This code will be reviewed "
-"by an administrator and will not be shared or redistributed in any way. The "
-"code will only be used for the purpose of reviewing the add-on."
+"If an add-on contains binary or obfuscated source code, the author will receive a message when the add-on is reviewed indicating whom to contact at Mozilla to coordinate review of the source code. "
+"This code will be reviewed by an administrator and will not be shared or redistributed in any way. The code will only be used for the purpose of reviewing the add-on."
 msgstr ""
-"Nëse një shtesë përmban kod burim dyor ose të errësuar, autori do të marrë "
-"një mesazh kur të jetë shqyrtuar shtesa, që tregon se cili duhet kontaktuar "
-"te Mozilla për të bashkërenduar shqyrtimin e kodit burim. Ky kod duhet të "
-"shqyrtohet nga një përgjegjës dhe s’do të ndahet në asnjë mënyrë me të tjerë"
-" apo rishpërndahet. kodi do të përdoret vetëm për qëllimin e shqyrtimit të "
-"shtesës."
+"Nëse një shtesë përmban kod burim dyor ose të errësuar, autori do të marrë një mesazh kur të jetë shqyrtuar shtesa, që tregon se cili duhet kontaktuar te Mozilla për të bashkërenduar shqyrtimin e "
+"kodit burim. Ky kod duhet të shqyrtohet nga një përgjegjës dhe s’do të ndahet në asnjë mënyrë me të tjerë apo rishpërndahet. kodi do të përdoret vetëm për qëllimin e shqyrtimit të shtesës."
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:301
 #, python-format
-msgid ""
-"If your add-on contains binary or obfuscated code that you don't own or "
-"can't get the source code for, you may <a href=\"%(link_contact)s\">contact "
-"us</a> for information on how to proceed."
+msgid "If your add-on contains binary or obfuscated code that you don't own or can't get the source code for, you may <a href=\"%(link_contact)s\">contact us</a> for information on how to proceed."
 msgstr ""
-"Nëse shtesa juaj përmban kod burim dyor ose të errësuar, që s’është pronë e "
-"juaja ose për të cilin s’gjendet dot kodi burim, mund të <a "
-"href=\"%(link_contact)s\">lidheni me ne</a> për të dhëna se si të ecet më "
-"tej."
+"Nëse shtesa juaj përmban kod burim dyor ose të errësuar, që s’është pronë e juaja ose për të cilin s’gjendet dot kodi burim, mund të <a href=\"%(link_contact)s\">lidheni me ne</a> për të dhëna se "
+"si të ecet më tej."
 
 #: src/olympia/devhub/templates/devhub/docs/policies-submission.html:11
 msgid "Criteria for Submission"
@@ -7714,235 +5978,129 @@ msgstr "Kritere për Parashtrim"
 
 #: src/olympia/devhub/templates/devhub/docs/policies-submission.html:13
 msgid ""
-"Add-ons hosted on Mozilla Add-ons should be of high quality and give users "
-"an improved web experience. We look for the following things when deciding "
-"whether an add-on is appropriate to be public and unrestricted:"
+"Add-ons hosted on Mozilla Add-ons should be of high quality and give users an improved web experience. We look for the following things when deciding whether an add-on is appropriate to be public "
+"and unrestricted:"
 msgstr ""
-"Shtesat e strehuara te Shtesat Mozilla duhet të jenë të një cilësie të lartë"
-" dhe t’u japin përdoruesve punim në web të përmirësuar. Kur vendosim nëse "
-"një shtesë është e përshtatshme për të qenë publike dhe pa kufizime, shohim "
-"për sa vijon:"
+"Shtesat e strehuara te Shtesat Mozilla duhet të jenë të një cilësie të lartë dhe t’u japin përdoruesve punim në web të përmirësuar. Kur vendosim nëse një shtesë është e përshtatshme për të qenë "
+"publike dhe pa kufizime, shohim për sa vijon:"
 
 #: src/olympia/devhub/templates/devhub/docs/policies-submission.html:19
 msgid ""
-"<strong>Are you responsive?</strong> We expect that an author who is "
-"promoting their add-on to our applications' many users is responsive to "
-"problem reports, maintains their contact information, and updates their add-"
-"on promptly to keep current with Firefox releases and changes in our "
-"policies. This doesn't mean that you have to reply to every question that "
-"someone posts in the discussions, or that you even need to fix every bug, "
-"but we do expect that you will respond to issues in a manner that's "
-"appropriate to the severity of the issue in question."
+"<strong>Are you responsive?</strong> We expect that an author who is promoting their add-on to our applications' many users is responsive to problem reports, maintains their contact information, "
+"and updates their add-on promptly to keep current with Firefox releases and changes in our policies. This doesn't mean that you have to reply to every question that someone posts in the "
+"discussions, or that you even need to fix every bug, but we do expect that you will respond to issues in a manner that's appropriate to the severity of the issue in question."
 msgstr ""
-"<strong>A jeni reagues?</strong> Ne presim që një autor i cili po promovon "
-"shtesën e tij te përdoruesit e shumtë të aplikacionit tonë të jetë reagues "
-"ndaj njoftimeve për probleme, të mirëmbajë të dhënat e tyre për kontakte, "
-"dhe të përditësojë shtesën e tij pa vonesa, për ta mbajtur në një vijë me "
-"hedhjet në qarkullim të Firefox-it dhe me ndryshimet në rregullat tona. Kjo "
-"s’do të thotë që duhet t’i përgjigjeni çdo pyetje që dikush boton në "
-"diskutime, ose se lypset të ndreqni çdo të metë, ama presim që t’u "
-"përgjigjeni problemeve në një mënyrë që përshtatet me rëndësinë e çështjes "
-"në fjalë."
+"<strong>A jeni reagues?</strong> Ne presim që një autor i cili po promovon shtesën e tij te përdoruesit e shumtë të aplikacionit tonë të jetë reagues ndaj njoftimeve për probleme, të mirëmbajë të "
+"dhënat e tyre për kontakte, dhe të përditësojë shtesën e tij pa vonesa, për ta mbajtur në një vijë me hedhjet në qarkullim të Firefox-it dhe me ndryshimet në rregullat tona. Kjo s’do të thotë që "
+"duhet t’i përgjigjeni çdo pyetje që dikush boton në diskutime, ose se lypset të ndreqni çdo të metë, ama presim që t’u përgjigjeni problemeve në një mënyrë që përshtatet me rëndësinë e çështjes në "
+"fjalë."
 
 #: src/olympia/devhub/templates/devhub/docs/policies-submission.html:25
 msgid ""
-"<strong>Is the add-on clearly and accurately described?</strong> It's of the"
-" utmost importance to us that users get what they expect when they try a new"
-" add-on. Your add-on name should be clear and concise, and you should "
-"refrain from using special characters or numbers to get higher search "
-"rankings or for decorative purposes. Your description should provide details"
-" about what the add-on does, how a user should take advantage of it, and "
-"what the user should expect when they install it. Links to external "
-"documents for detailed instructions are fine, but the description itself "
-"should cover the basics and leave users confident that they know what "
-"they'll get. Also, it is important that you maintain version notes "
-"appropriately as you improve and change your add-on. Users should be able to"
-" see what's new in an add-on they may have tried previously, and should be "
-"made aware of changes that might affect their current use of the add-on when"
-" they update."
+"<strong>Is the add-on clearly and accurately described?</strong> It's of the utmost importance to us that users get what they expect when they try a new add-on. Your add-on name should be clear and "
+"concise, and you should refrain from using special characters or numbers to get higher search rankings or for decorative purposes. Your description should provide details about what the add-on "
+"does, how a user should take advantage of it, and what the user should expect when they install it. Links to external documents for detailed instructions are fine, but the description itself should "
+"cover the basics and leave users confident that they know what they'll get. Also, it is important that you maintain version notes appropriately as you improve and change your add-on. Users should "
+"be able to see what's new in an add-on they may have tried previously, and should be made aware of changes that might affect their current use of the add-on when they update."
 msgstr ""
-"<strong>A përshkruhet qartë dhe saktë shtesa?</strong> Për ne ka rëndësi të "
-"dorës së parë që përdoruesit të marrin atë çka presin, kur provojnë një "
-"shtesë të re. Emri i shtesës suaj duhet të jetë i qartë dhe i përpiktë, dhe "
-"duhet t’i rrini larg përdorimit të shenjave speciale apo numrave me qëllim "
-"që të përfitoni vende më sipër në klasifikim apo për qëllime zbukuruese. "
-"Përshkrimi juaj duhet të japë hollësitë rreth çka kryen shtesa, si do të "
-"duhej të përfitonte prej saj përdoruesi, dhe çka do të duhej të priste prej "
-"saj kur përdoruesi e instalon. Lidhjet për te dokumentim i jashtëm lidhur me"
-" udhëzime të hollësishme s’janë problem, por vetë përshkrimi duhet të "
-"mbulonte bazat dhe ta lërë përdoruesin të bindur se e kupton se ç’do të "
-"marrë. Gjithashtu, është e rëndësishme që t’i mirëmbani si duhet shënimet e "
-"versioneve, teksa përmirësoni dhe ndryshoni shtesën tuaj. Përdoruesit do të "
-"duhej të jenë në gjendje të shohin çka të re në një shtesë që mund ta kenë "
-"provuar më parë, dhe duhet t’u lihet të jenë të ndërgjegjshëm mbi ndryshimet"
-" që mund të prekin përdorimin e tanishëm të saj, kur ta përditësojnë."
+"<strong>A përshkruhet qartë dhe saktë shtesa?</strong> Për ne ka rëndësi të dorës së parë që përdoruesit të marrin atë çka presin, kur provojnë një shtesë të re. Emri i shtesës suaj duhet të jetë i "
+"qartë dhe i përpiktë, dhe duhet t’i rrini larg përdorimit të shenjave speciale apo numrave me qëllim që të përfitoni vende më sipër në klasifikim apo për qëllime zbukuruese. Përshkrimi juaj duhet "
+"të japë hollësitë rreth çka kryen shtesa, si do të duhej të përfitonte prej saj përdoruesi, dhe çka do të duhej të priste prej saj kur përdoruesi e instalon. Lidhjet për te dokumentim i jashtëm "
+"lidhur me udhëzime të hollësishme s’janë problem, por vetë përshkrimi duhet të mbulonte bazat dhe ta lërë përdoruesin të bindur se e kupton se ç’do të marrë. Gjithashtu, është e rëndësishme që t’i "
+"mirëmbani si duhet shënimet e versioneve, teksa përmirësoni dhe ndryshoni shtesën tuaj. Përdoruesit do të duhej të jenë në gjendje të shohin çka të re në një shtesë që mund ta kenë provuar më parë, "
+"dhe duhet t’u lihet të jenë të ndërgjegjshëm mbi ndryshimet që mund të prekin përdorimin e tanishëm të saj, kur ta përditësojnë."
 
 #: src/olympia/devhub/templates/devhub/docs/policies-submission.html:31
 msgid ""
-"<strong>Are all privacy and security concerns clearly spelled out?</strong> "
-"This is an aspect of a clear and accurate description, but such an important"
-" one that we feel it deserves specific mention. Many very useful and well-"
-"written add-ons manipulate some form of user data, or can present security "
-"hazards if misused; they are welcome on the site, but they must make it very"
-" clear to users what risks they might encounter, and what they can do to "
-"protect themselves."
+"<strong>Are all privacy and security concerns clearly spelled out?</strong> This is an aspect of a clear and accurate description, but such an important one that we feel it deserves specific "
+"mention. Many very useful and well-written add-ons manipulate some form of user data, or can present security hazards if misused; they are welcome on the site, but they must make it very clear to "
+"users what risks they might encounter, and what they can do to protect themselves."
 msgstr ""
-"<strong>A janë të zbuluara qartë krejt çështjet e privatësisë dhe "
-"sigurisë?</strong> Kjo lidhet me përshkrimin e saktë dhe të përpiktë, por ka"
-" kaq rëndësi sa na duket se duhet përmendur posaçërisht. Mjaft shtesa të "
-"dobishme dhe të mirëhartuara manipulojnë ndonjë të dhënë të përodoruesit, "
-"ose mund të përbëjnë rreziqe sigurie, po u keqpërdorën; ato i mirëpresim në "
-"sajt, por duhet t’ua bëjnë shumë të qartë përdoruesve se ç’rreziqe mund të "
-"hasin, dhe se çfarë mund të bëjnë për të mbrojtur veten."
+"<strong>A janë të zbuluara qartë krejt çështjet e privatësisë dhe sigurisë?</strong> Kjo lidhet me përshkrimin e saktë dhe të përpiktë, por ka kaq rëndësi sa na duket se duhet përmendur "
+"posaçërisht. Mjaft shtesa të dobishme dhe të mirëhartuara manipulojnë ndonjë të dhënë të përodoruesit, ose mund të përbëjnë rreziqe sigurie, po u keqpërdorën; ato i mirëpresim në sajt, por duhet "
+"t’ua bëjnë shumë të qartë përdoruesve se ç’rreziqe mund të hasin, dhe se çfarë mund të bëjnë për të mbrojtur veten."
 
 #: src/olympia/devhub/templates/devhub/docs/policies-submission.html:37
 msgid ""
-"<strong>Has the add-on been well-tested, and is it free of obvious or "
-"serious defects?</strong> One important thing that we look for when "
-"considering an add-on is whether its user reviews indicate that it has "
-"received thorough testing, and that it doesn't have serious problems or "
-"negative impacts on the browser. If reviewers report problems such as major "
-"performance issues, crashes, frequent problems using the functions of the "
-"add-on, or spamming of messages to the error console, you should take those "
-"reports to heart, and re-submit your add-on after you've addressed them as "
-"best you can. We don't expect you to perfectly optimize or have zero bugs "
-"&mdash; Firefox itself undergoes constant improvement in these areas &mdash;"
-" but we do want you to take reasonable efforts to minimize downsides, and to"
-" clearly call out cases where users may be surprised by those that remain."
+"<strong>Has the add-on been well-tested, and is it free of obvious or serious defects?</strong> One important thing that we look for when considering an add-on is whether its user reviews indicate "
+"that it has received thorough testing, and that it doesn't have serious problems or negative impacts on the browser. If reviewers report problems such as major performance issues, crashes, frequent "
+"problems using the functions of the add-on, or spamming of messages to the error console, you should take those reports to heart, and re-submit your add-on after you've addressed them as best you "
+"can. We don't expect you to perfectly optimize or have zero bugs &mdash; Firefox itself undergoes constant improvement in these areas &mdash; but we do want you to take reasonable efforts to "
+"minimize downsides, and to clearly call out cases where users may be surprised by those that remain."
 msgstr ""
-"<strong>A është vënë mirë në provë shtesa, dhe a është e pastër nga defekte "
-"të dukshme sheshit apo serioze?</strong> Një gjë e rëndësishme për të cilën "
-"shohim, kur marrim në shqyrtim një shtesë, është nëse shqyrtimet e saj nga "
-"përdoruesit tregojnë se ka patur testim shterues, dhe se s’ka probleme "
-"serioze ose ndikim negativ te shfletuesi. Nëse shqyrtuesit njoftojnë "
-"probleme të tilla si çështje të rënda me performancën, vithisje, probleme të"
-" shpeshta gjatë përdorimit të funksioneve të shtesës, ose mesazhe te konsola"
-" e gabimeve, do të duhej t’i merrnit parasysh këto njoftime, dhe ta "
-"riparashtronit shtesën pasi t’i keni trajtuar ato sa më thellë që mundeni. "
-"Nuk presim prej jush ta optimizoni në përsosmëri, apo ta bëni të ketë zero "
-"të meta &mdash; vetë Firefox-i kalon nëpër përmirësime konstante në këtë "
-"fusha &mdash; por duam që ju të bëni përpjekje të arsyeshme për t’i "
-"minimizuar anët negative, dhe të thuhen qartë rastet kur përdoruesit mund të"
-" befasoheshin nga ato që mbeten."
+"<strong>A është vënë mirë në provë shtesa, dhe a është e pastër nga defekte të dukshme sheshit apo serioze?</strong> Një gjë e rëndësishme për të cilën shohim, kur marrim në shqyrtim një shtesë, "
+"është nëse shqyrtimet e saj nga përdoruesit tregojnë se ka patur testim shterues, dhe se s’ka probleme serioze ose ndikim negativ te shfletuesi. Nëse shqyrtuesit njoftojnë probleme të tilla si "
+"çështje të rënda me performancën, vithisje, probleme të shpeshta gjatë përdorimit të funksioneve të shtesës, ose mesazhe te konsola e gabimeve, do të duhej t’i merrnit parasysh këto njoftime, dhe "
+"ta riparashtronit shtesën pasi t’i keni trajtuar ato sa më thellë që mundeni. Nuk presim prej jush ta optimizoni në përsosmëri, apo ta bëni të ketë zero të meta &mdash; vetë Firefox-i kalon nëpër "
+"përmirësime konstante në këtë fusha &mdash; por duam që ju të bëni përpjekje të arsyeshme për t’i minimizuar anët negative, dhe të thuhen qartë rastet kur përdoruesit mund të befasoheshin nga ato "
+"që mbeten."
 
 #: src/olympia/devhub/templates/devhub/docs/policies-submission.html:43
 msgid ""
-"<strong>Do the add-on and add-on author both treat the user "
-"respectfully?</strong> Your software should not intrude on the user "
-"unnecessarily, try to trick the user, or conceal any of its activities from "
-"the user. Users (or even non-users) are sometimes rude in their comments, "
-"and while we will do our best to filter out inaccurate reviews as they're "
-"reported to us, we do expect that authors will avoid retaliating with "
-"rudeness of their own."
+"<strong>Do the add-on and add-on author both treat the user respectfully?</strong> Your software should not intrude on the user unnecessarily, try to trick the user, or conceal any of its "
+"activities from the user. Users (or even non-users) are sometimes rude in their comments, and while we will do our best to filter out inaccurate reviews as they're reported to us, we do expect that "
+"authors will avoid retaliating with rudeness of their own."
 msgstr ""
-"<strong>A e trajtojnë me respekt përdoruesin shtesa dhe autori i "
-"shtesës?</strong> Software-i juaj s’duhet të fusë hundët në mënyrë të "
-"panevojshme te përdoruesi, ta vërë përdoruesin përpara rrengjesh, apo t’i "
-"fshehë përdoruesit cilindo nga veprimet e saj. Përdoruesit (ose qoftë edhe "
-"jo-përdoruesit) ndonjëherë janë të sertë në komentet e tyre, dhe edhe pse "
-"bëjmë sa mundemi për të filtruar shqyrtime të pasakta që na njoftohen, "
-"presim që autorët do të shmangin kundërpëgjigje të serta nga ana e tyre."
+"<strong>A e trajtojnë me respekt përdoruesin shtesa dhe autori i shtesës?</strong> Software-i juaj s’duhet të fusë hundët në mënyrë të panevojshme te përdoruesi, ta vërë përdoruesin përpara "
+"rrengjesh, apo t’i fshehë përdoruesit cilindo nga veprimet e saj. Përdoruesit (ose qoftë edhe jo-përdoruesit) ndonjëherë janë të sertë në komentet e tyre, dhe edhe pse bëjmë sa mundemi për të "
+"filtruar shqyrtime të pasakta që na njoftohen, presim që autorët do të shmangin kundërpëgjigje të serta nga ana e tyre."
 
 #: src/olympia/devhub/templates/devhub/docs/policies-submission.html:49
 msgid ""
-"<strong>Is the add-on useful to an appropriately wide portion of Firefox's "
-"users?</strong> Your add-on doesn't need to be the next Greasemonkey or "
-"Firebug, but if it is only useful to people at your company or who are part "
-"of a small web community, we may feel that it's not yet appropriate to put "
-"it in front of all of our users."
+"<strong>Is the add-on useful to an appropriately wide portion of Firefox's users?</strong> Your add-on doesn't need to be the next Greasemonkey or Firebug, but if it is only useful to people at "
+"your company or who are part of a small web community, we may feel that it's not yet appropriate to put it in front of all of our users."
 msgstr ""
-"<strong>A është shtesa e dobishme për një pjesë të gjerë (të arsyeshme) të "
-"përdoruesve të Firefox-it?</strong> S’ka pse shtesa juaj të jetë "
-"Greasemonkey apo Firebug i ri, por nëse është e dobishme vetëm për personat "
-"e kompanisë suaj apo të një bashkësie të vogël web, na duket se s’është ende"
-" e përshtatshme të nxirret përpara gjithë përdoruesve tanë."
+"<strong>A është shtesa e dobishme për një pjesë të gjerë (të arsyeshme) të përdoruesve të Firefox-it?</strong> S’ka pse shtesa juaj të jetë Greasemonkey apo Firebug i ri, por nëse është e dobishme "
+"vetëm për personat e kompanisë suaj apo të një bashkësie të vogël web, na duket se s’është ende e përshtatshme të nxirret përpara gjithë përdoruesve tanë."
 
 #: src/olympia/devhub/templates/devhub/docs/policies-submission.html:55
 msgid ""
-"We are constantly looking at ways to improve the organization of the site to"
-" better accommodate add-ons that are exemplary in other ways, but are aimed "
-"at only a small community of potential users. Correctly categorizing and "
-"maintaining the metadata of your add-on will help us figure out how we can "
-"surface more of those sorts of add-ons to people who are most likely to "
-"benefit from them."
+"We are constantly looking at ways to improve the organization of the site to better accommodate add-ons that are exemplary in other ways, but are aimed at only a small community of potential users. "
+"Correctly categorizing and maintaining the metadata of your add-on will help us figure out how we can surface more of those sorts of add-ons to people who are most likely to benefit from them."
 msgstr ""
-"Përpiqemi në mënyrë konstante të përmirësojmë organizimin e sajtit, për t’u "
-"dhënë vend shtesave që janë shembullore në anë të tjera, por që janë menduar"
-" për vetëm një bashkësi të vogël përdoruesish potencialë. Mirëmbajtja dhe "
-"kategorizimi i saktë i tejtëdhënave të shtesës suaj do të na ndihmojë të "
-"gjejmë se si mund t’u shfaqim më tepër shtesa të këtij lloji njerëzve që, "
-"sipas gjasash, mund të përfitonin më shumë prej tyre."
+"Përpiqemi në mënyrë konstante të përmirësojmë organizimin e sajtit, për t’u dhënë vend shtesave që janë shembullore në anë të tjera, por që janë menduar për vetëm një bashkësi të vogël përdoruesish "
+"potencialë. Mirëmbajtja dhe kategorizimi i saktë i tejtëdhënave të shtesës suaj do të na ndihmojë të gjejmë se si mund t’u shfaqim më tepër shtesa të këtij lloji njerëzve që, sipas gjasash, mund të "
+"përfitonin më shumë prej tyre."
 
 #: src/olympia/devhub/templates/devhub/docs/policies-submission.html:61
 msgid ""
-"If your add-on just provides bookmarks or other simple access points to your"
-" site, it's probably not appropriate for the gallery. Like the rest of the "
-"Mozilla project, we love web applications and new web services, but Firefox "
-"add-ons should provide an improved browsing experience for the user and not "
-"just be a way to promote a new site or service through a Mozilla Add-ons "
-"listing."
+"If your add-on just provides bookmarks or other simple access points to your site, it's probably not appropriate for the gallery. Like the rest of the Mozilla project, we love web applications and "
+"new web services, but Firefox add-ons should provide an improved browsing experience for the user and not just be a way to promote a new site or service through a Mozilla Add-ons listing."
 msgstr ""
-"Nëse shtesa juaj ofron faqerojtës ose tjetër hyrje të thjeshtë te sajti "
-"juaj, s’duket se është e përshtatshme për në galerinë. Si edhe për pjesën "
-"tjetër të projekteve Mozilla, i duam aplikacionet web dhe shërbimet e reja "
-"web, por shtesat e Firefox-it do të duhej të sillnin punim të përmirësuar të"
-" shfletuesit dhe jo thjesht të jenë një rrugë për të promovuar një sajt apo "
-"shërbim të ri përmes listave të Shtesave Mozilla."
+"Nëse shtesa juaj ofron faqerojtës ose tjetër hyrje të thjeshtë te sajti juaj, s’duket se është e përshtatshme për në galerinë. Si edhe për pjesën tjetër të projekteve Mozilla, i duam aplikacionet "
+"web dhe shërbimet e reja web, por shtesat e Firefox-it do të duhej të sillnin punim të përmirësuar të shfletuesit dhe jo thjesht të jenë një rrugë për të promovuar një sajt apo shërbim të ri përmes "
+"listave të Shtesave Mozilla."
 
 #: src/olympia/devhub/templates/devhub/docs/policies-submission.html:67
 msgid ""
-"<strong>Is the add-on free of unlicensed trademarks and copyrights?</strong>"
-" Though you may mean no harm to the holder of a trademark, or the owner of a"
-" copyrighted work, we can't host add-ons that infringe on trademarks or "
-"copyrights. If you don't have permission to use a trademarked name or image,"
-" please do not submit your add-on to us. If your add-on includes code that "
-"is copyrighted by someone else, and is not licensed to you to use in your "
-"add-on, please do not submit your add-on to us."
+"<strong>Is the add-on free of unlicensed trademarks and copyrights?</strong> Though you may mean no harm to the holder of a trademark, or the owner of a copyrighted work, we can't host add-ons that "
+"infringe on trademarks or copyrights. If you don't have permission to use a trademarked name or image, please do not submit your add-on to us. If your add-on includes code that is copyrighted by "
+"someone else, and is not licensed to you to use in your add-on, please do not submit your add-on to us."
 msgstr ""
-"<strong>A është shtesa e lirë nga shenja tregtare dhe të drejta kopjimi të "
-"palicencuara?</strong> Edhe pse mund të mos keni patur në mendje t’i bëni "
-"keq të zotit të shenjës tregtare, apo të zotit të një vepre nën të drejta "
-"kopjimi, s’mund të strehojmë shtesa që cenojnë shenja tregtare apo të drejta"
-" kopjimi. Nëse s’keni leje përdorimi mbi një emër apo figurë shenjeje "
-"tregtare, ju lutemi, mos e parashtroni shtesën te ne. Nëse shtesa juaj "
-"përfshin kod i cili gjendet nën të drejta kopjimi të dikujt tjetër, dhe s’ju"
-" është licencuar për ta përdorur te shtesa juaj, ju lutemi, mos e "
+"<strong>A është shtesa e lirë nga shenja tregtare dhe të drejta kopjimi të palicencuara?</strong> Edhe pse mund të mos keni patur në mendje t’i bëni keq të zotit të shenjës tregtare, apo të zotit "
+"të një vepre nën të drejta kopjimi, s’mund të strehojmë shtesa që cenojnë shenja tregtare apo të drejta kopjimi. Nëse s’keni leje përdorimi mbi një emër apo figurë shenjeje tregtare, ju lutemi, mos "
+"e parashtroni shtesën te ne. Nëse shtesa juaj përfshin kod i cili gjendet nën të drejta kopjimi të dikujt tjetër, dhe s’ju është licencuar për ta përdorur te shtesa juaj, ju lutemi, mos e "
 "parashtroni shtesën tuaj te ne."
 
 #: src/olympia/devhub/templates/devhub/docs/policies-submission.html:73
 msgid ""
-"In terms of reuse of source code from other add-ons, if the author has not "
-"clearly stated that you are permitted to use his or her code in your own "
-"work &mdash; such as by placing it under an open source license &mdash; then"
-" you should assume that you do not have the right to do so. You can contact "
-"the author to seek such permission, but we can't provide you with any "
-"special rights to it just because it's listed on the site, or because the "
-"author isn't responding to your request."
+"In terms of reuse of source code from other add-ons, if the author has not clearly stated that you are permitted to use his or her code in your own work &mdash; such as by placing it under an open "
+"source license &mdash; then you should assume that you do not have the right to do so. You can contact the author to seek such permission, but we can't provide you with any special rights to it "
+"just because it's listed on the site, or because the author isn't responding to your request."
 msgstr ""
-"Për sa i takon ripërdorimit të kodit burim prej shtesash të tjera, nëse "
-"autori s’e deklaruar qartë që jeni lejuar të përdorni kod nga ai apo ajo në "
-"punën tuaj &mdash; përmes vendosjes së tij nën një licencë burimi të hapët "
-"&mdash; atëherë do të duhej të merrnit të mirëqenë se s’keni të drejtë ta "
-"bëni atë. Mund të lidheni me autorin për të kërkuar leje të tilla, por s’ju "
-"pajisim dot me ndonjë lloj të drejtash speciale mbi të thjesht pse gjendet "
-"në listë, ose ngaqë autori s’po i përgjigjet kërkesës suaj."
+"Për sa i takon ripërdorimit të kodit burim prej shtesash të tjera, nëse autori s’e deklaruar qartë që jeni lejuar të përdorni kod nga ai apo ajo në punën tuaj &mdash; përmes vendosjes së tij nën "
+"një licencë burimi të hapët &mdash; atëherë do të duhej të merrnit të mirëqenë se s’keni të drejtë ta bëni atë. Mund të lidheni me autorin për të kërkuar leje të tilla, por s’ju pajisim dot me "
+"ndonjë lloj të drejtash speciale mbi të thjesht pse gjendet në listë, ose ngaqë autori s’po i përgjigjet kërkesës suaj."
 
 #: src/olympia/devhub/templates/devhub/docs/policies-submission.html:79
 msgid ""
-"This applies to the Mozilla Foundation's trademarks as well, including "
-"\"Mozilla\", \"Firefox\", and \"Thunderbird\". The Mozilla policy on "
-"trademark use is designed to protect against confusion, and prevent the "
-"trademarks from being overturned due to lack of protection; please respect "
-"the need for such protection, and help us preserve some of the most valuable"
-" assets of the Mozilla Foundation."
+"This applies to the Mozilla Foundation's trademarks as well, including \"Mozilla\", \"Firefox\", and \"Thunderbird\". The Mozilla policy on trademark use is designed to protect against confusion, "
+"and prevent the trademarks from being overturned due to lack of protection; please respect the need for such protection, and help us preserve some of the most valuable assets of the Mozilla "
+"Foundation."
 msgstr ""
-"Kjo vlen edhe për shenjat tregtare të Mozilla Foundation-it, përfshi "
-"\"Mozilla\", \"Firefox\", dhe \"Thunderbird\". Rregullat e Mozilla-s mbi "
-"përdorimin e shenjave tregtare janë hartuar për mbrojtje kundër "
-"ngatërresave, dhe për të parandaluar kundëpërdorimin e shenjave tregtare nga"
-" mungesa e mbrojtjes; ju lutemi, respektojeni nevojën për një mbrojtje të "
-"tillë, dhe na ndihmoni të ruajmë disa nga vlerat më të çmuara të Mozilla "
-"Foundation-it."
+"Kjo vlen edhe për shenjat tregtare të Mozilla Foundation-it, përfshi \"Mozilla\", \"Firefox\", dhe \"Thunderbird\". Rregullat e Mozilla-s mbi përdorimin e shenjave tregtare janë hartuar për "
+"mbrojtje kundër ngatërresave, dhe për të parandaluar kundëpërdorimin e shenjave tregtare nga mungesa e mbrojtjes; ju lutemi, respektojeni nevojën për një mbrojtje të tillë, dhe na ndihmoni të "
+"ruajmë disa nga vlerat më të çmuara të Mozilla Foundation-it."
 
 #: src/olympia/devhub/templates/devhub/docs/policies-submission.html:84
 msgid "Licensing"
@@ -7950,250 +6108,152 @@ msgstr "Licencim"
 
 #: src/olympia/devhub/templates/devhub/docs/policies-submission.html:86
 msgid ""
-"Selecting an appropriate license for your add-on is a very important step in"
-" the submission process. A license specifies the rights you grant on your "
-"source code and is important in protecting your intellectual property."
+"Selecting an appropriate license for your add-on is a very important step in the submission process. A license specifies the rights you grant on your source code and is important in protecting your "
+"intellectual property."
 msgstr ""
-"Përzgjedhja e një licence të përshtatshme për shtesën tuaj është hap shumë i"
-" rëndësishëm në procesin e parashtrimit. Licenca përcakton të drejtat që "
-"akordoni mbi kodin burim të shtesës suaj dhe është e rëndësishme në "
-"mbrojtjen e të drejtave tuaja të kopjimit."
+"Përzgjedhja e një licence të përshtatshme për shtesën tuaj është hap shumë i rëndësishëm në procesin e parashtrimit. Licenca përcakton të drejtat që akordoni mbi kodin burim të shtesës suaj dhe "
+"është e rëndësishme në mbrojtjen e të drejtave tuaja të kopjimit."
 
 #: src/olympia/devhub/templates/devhub/docs/policies-submission.html:92
 msgid ""
-"During the add-on submission process, you will be presented with a list of "
-"popular licenses to choose from, as well as the ability to specify your own "
-"license. It is best to consult with a legal professional about which license"
-" option is best for you. Choosing the right license for your source code "
-"will help to prevent confusion and code conflicts in the future."
+"During the add-on submission process, you will be presented with a list of popular licenses to choose from, as well as the ability to specify your own license. It is best to consult with a legal "
+"professional about which license option is best for you. Choosing the right license for your source code will help to prevent confusion and code conflicts in the future."
 msgstr ""
-"Gjatë procesit të parashtrimit të shtesës, do t’ju shfaqet një listë "
-"licencash të njohura, prej nga mund të zgjidhni, si dhe do të keni mundësi "
-"të përcaktoni një licencë krejt tuajën. Më e mira është të këshilloheni me "
-"një njeri të ligjeve rreth se cila licencë është më e mira për ju. Zgjedhja "
-"e licencës së duhur për kodin tuaj burim do të parandalojë ngatërresa dhe "
-"përplasje rreth kodit në të ardhmen."
+"Gjatë procesit të parashtrimit të shtesës, do t’ju shfaqet një listë licencash të njohura, prej nga mund të zgjidhni, si dhe do të keni mundësi të përcaktoni një licencë krejt tuajën. Më e mira "
+"është të këshilloheni me një njeri të ligjeve rreth se cila licencë është më e mira për ju. Zgjedhja e licencës së duhur për kodin tuaj burim do të parandalojë ngatërresa dhe përplasje rreth kodit "
+"në të ardhmen."
 
-#: src/olympia/devhub/templates/devhub/docs/policies.html:12
-#: src/olympia/devhub/templates/devhub/docs/policies.html:52
+#: src/olympia/devhub/templates/devhub/docs/policies.html:12 src/olympia/devhub/templates/devhub/docs/policies.html:52
 msgid "Add-on Submission"
 msgstr "Parashtrim Shtese"
 
-#: src/olympia/devhub/templates/devhub/docs/policies.html:18
-#: src/olympia/devhub/templates/devhub/docs/policies.html:78
+#: src/olympia/devhub/templates/devhub/docs/policies.html:18 src/olympia/devhub/templates/devhub/docs/policies.html:78
 msgid "Maintaining Your Add-on"
 msgstr "Mirëmbajtja e Shtesës Suaj"
 
 #: src/olympia/devhub/templates/devhub/docs/policies.html:43
-msgid ""
-"Mozilla is committed to ensuring a great add-ons experience for our users "
-"and developers. Please review the policies below before submitting your add-"
-"on."
+msgid "Mozilla is committed to ensuring a great add-ons experience for our users and developers. Please review the policies below before submitting your add-on."
 msgstr ""
-"Mozilla i është përkushtuar bërjes së mundur sigurimit të një përvoje të "
-"shkëlqyer në punimin me shtesa për përdoruesit dhe zhvilluesit tanë. Ju "
-"lutemi, shqyrtoni rregullat më poshtë, përpara se të parashtroni shtesën "
-"tuaj."
+"Mozilla i është përkushtuar bërjes së mundur sigurimit të një përvoje të shkëlqyer në punimin me shtesa për përdoruesit dhe zhvilluesit tanë. Ju lutemi, shqyrtoni rregullat më poshtë, përpara se të "
+"parashtroni shtesën tuaj."
 
 #: src/olympia/devhub/templates/devhub/docs/policies.html:55
-msgid ""
-"Find out what is expected of add-ons we host and our policies on specific "
-"add-on practices."
-msgstr ""
-"Shihni se çfarë pritet prej shtesave që strehojmë ne dhe rregullat tona mbi "
-"disa praktika të caktuara për shtesat."
+msgid "Find out what is expected of add-ons we host and our policies on specific add-on practices."
+msgstr "Shihni se çfarë pritet prej shtesave që strehojmë ne dhe rregullat tona mbi disa praktika të caktuara për shtesat."
 
 #: src/olympia/devhub/templates/devhub/docs/policies.html:67
-msgid ""
-"What happens after your add-on is submitted? Learn about how our Editors "
-"review submissions."
-msgstr ""
-"Ç’ndodh pasi e parashtroni shtesën tuaj? Lexoni se si i shqyrtojnë "
-"Redaktorët tanë parashtrimet."
+msgid "What happens after your add-on is submitted? Learn about how our Editors review submissions."
+msgstr "Ç’ndodh pasi e parashtroni shtesën tuaj? Lexoni se si i shqyrtojnë Redaktorët tanë parashtrimet."
 
 #: src/olympia/devhub/templates/devhub/docs/policies.html:81
-msgid ""
-"Add-on updates, transferring ownership, user reviews, and what to expect "
-"once your add-on is approved."
-msgstr ""
-"Përditësime shtesash, transferim pronësie, shqyrtime përdoruesish, dhe "
-"ç’duhet të prisni pasi të jetë miratuar shtesa juaj."
+msgid "Add-on updates, transferring ownership, user reviews, and what to expect once your add-on is approved."
+msgstr "Përditësime shtesash, transferim pronësie, shqyrtime përdoruesish, dhe ç’duhet të prisni pasi të jetë miratuar shtesa juaj."
 
 #: src/olympia/devhub/templates/devhub/docs/policies.html:93
-msgid ""
-"How up-and-coming add-ons become featured and what&#039;s involved in the "
-"process."
+msgid "How up-and-coming add-ons become featured and what&#039;s involved in the process."
 msgstr "Si bëhen të zgjedhura shtesat premtuese dhe ç’përfshihet në proces."
 
 #: src/olympia/devhub/templates/devhub/docs/policies.html:106
-msgid ""
-"Terms of Service for submitting your work to our site. Developers are "
-"required to accept this agreement before submission."
-msgstr ""
-"Kushte Shërbimi për parashtrimin e punës suaj në sajtin tonë. Lypset që "
-"zhvilluesit ta pranojnë këtë marrëveshje përpara parashtrimeve."
+msgid "Terms of Service for submitting your work to our site. Developers are required to accept this agreement before submission."
+msgstr "Kushte Shërbimi për parashtrimin e punës suaj në sajtin tonë. Lypset që zhvilluesit ta pranojnë këtë marrëveshje përpara parashtrimeve."
 
 #: src/olympia/devhub/templates/devhub/docs/policies.html:118
 msgid "How to get in touch with us regarding these policies or your add-on."
 msgstr "Si të lidheni me ne për këto rregulla ose për shtesën tuaj."
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:6
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:10
 msgid "You have disabled this add-on"
 msgstr "E keni çaktivizuar këtë shtesë"
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:20
-msgid ""
-"Your add-on's listing is disabled and is not showing\n"
-"                             anywhere in our gallery or update service."
-msgstr ""
-"Paraqitja e shtesës suaj është çaktivizuar dhe ajo nuk shfaqet ndokund te "
-"galeria jonë ose te shërbimi ynë i përditësimeve."
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:24
+msgid "Your add-on's listing is disabled and is not showing anywhere in our gallery or update service."
+msgstr "Paraqitja e shtesës suaj është çaktivizuar dhe ajo nuk shfaqet ndokund te galeria jonë ose te shërbimi ynë i përditësimeve."
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:25
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:27
 msgid "Please complete your add-on."
 msgstr "Ju lutemi, plotësoni shtesën suaj."
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:29
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:30
 msgid "You will receive an email when the review is complete."
 msgstr "Kur shqyrtimi të jetë i plotë, do të merrni një email."
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:34
-msgid ""
-"You will receive an email when the review is complete. Until\n"
-"                             then, your add-on is not listed in our gallery but can be\n"
-"                             accessed directly from its details page."
-msgstr ""
-"Sapo shqyrtimi i shtesës suaj të jetë plotësuar, do të merrni një email. "
-"Deri atëherë, shtesa juaj nuk tregohet te galeria jonë, por mund të merret "
-"drejt e nga faqja e saj e hollësive."
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:33
+msgid "You will receive an email when the review is complete. Until then, your add-on is not listed in our gallery but can be accessed directly from its details page."
+msgstr "Sapo shqyrtimi i shtesës suaj të jetë plotësuar, do të merrni një email. Deri atëherë, shtesa juaj nuk tregohet te galeria jonë, por mund të merret drejt e nga faqja e saj e hollësive."
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:38
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:48
-msgid ""
-"You will receive an email when the review is\n"
-"                             complete and your add-on is signed."
-msgstr ""
-"Do të merrni një email, sapo shqyrtimi të jetë plotësuar dhe shtesa juaj të "
-"jetë nënshkruar."
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:37 src/olympia/devhub/templates/devhub/includes/addon_details.html:45
+msgid "You will receive an email when the review is complete and your add-on is signed."
+msgstr "Do të merrni një email, sapo shqyrtimi të jetë plotësuar dhe shtesa juaj të jetë nënshkruar."
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:44
-msgid ""
-"You will receive an email when the review is complete. Until\n"
-"                             then, your add-on is not listed in our gallery but can be\n"
-"                             accessed directly from its details page. "
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:41
+msgid "You will receive an email when the review is complete. Until then, your add-on is not listed in our gallery but can be accessed directly from its details page. "
 msgstr ""
-"Sapo shqyrtimi i shtesës suaj të jetë plotësuar, do të merrni një email. "
-"Deri atëherë, shtesa juaj nuk tregohet te galeria jonë, por mund të merret "
-"drejt e nga faqja e saj e hollësive."
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:54
-msgid ""
-"Your add-on is displayed in our gallery and users are\n"
-"                             receiving automatic updates."
-msgstr ""
-"Shtesa juaj tregohet te galeria jonë dhe përdoruesit po marrin përditësime "
-"të vetvetishme për të."
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:49
+msgid "Your add-on is displayed in our gallery and users are receiving automatic updates."
+msgstr "Shtesa juaj tregohet te galeria jonë dhe përdoruesit po marrin përditësime të vetvetishme për të."
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:57
-msgid ""
-"Your add-on has been signed and can be bundled with an\n"
-"                             application installer."
-msgstr ""
-"Shtesa juaj u nënshkrua dhe mund të paketohet tok me një instalues "
-"aplikacioni."
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:52
+msgid "Your add-on has been signed and can be bundled with an application installer."
+msgstr "Shtesa juaj u nënshkrua dhe mund të paketohet tok me një instalues aplikacioni."
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:63
-msgid ""
-"Your add-on was disabled by a site administrator and is no\n"
-"                             longer shown in our gallery. If you have any questions,\n"
-"                             please email amo-admins@mozilla.org."
-msgstr ""
-"Shtesa juaj është çaktivizuar nga një administrator dhe nuk shfaqet më te "
-"galeria jonë. Nëse keni ndonjë pyetje, dërgoni një email te amo-"
-"admins@mozilla.org."
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:56
+msgid "Your add-on was disabled by a site administrator and is no longer shown in our gallery. If you have any questions, please email amo-admins@mozilla.org."
+msgstr "Shtesa juaj është çaktivizuar nga një administrator dhe nuk shfaqet më te galeria jonë. Nëse keni ndonjë pyetje, dërgoni një email te amo-admins@mozilla.org."
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:70
-msgid ""
-"Your add-on is displayed in our gallery as experimental\n"
-"                             and users are receiving automatic updates. Some features\n"
-"                             are unavailable to your add-on."
-msgstr ""
-"Shtesa juaj shfaqet te galeria jonë si eksperimentale dhe përdoruesit marrin"
-" përditësime të vetvetishme për të. Disa veçori janë të papërdorshme për "
-"shtesën tuaj."
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:62
+msgid "Your add-on is displayed in our gallery as experimental and users are receiving automatic updates. Some features are unavailable to your add-on."
+msgstr "Shtesa juaj shfaqet te galeria jonë si eksperimentale dhe përdoruesit marrin përditësime të vetvetishme për të. Disa veçori janë të papërdorshme për shtesën tuaj."
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:74
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:66
 msgid "Your add-on has been signed."
 msgstr "Shtesa juaj është nënshkruar."
 
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:69
+msgid ""
+"You will receive an email when the full review is complete. Until then, your add-on is displayed in our gallery as experimental and users are receiving automatic updates. Some features are "
+"unavailable to your add-on."
+msgstr ""
+"Do të merrni një email kur të plotësohet shqyrtimi i plotë. Deri atëherë, shtesa juaj shfaqet te galeria jonë si eksperimentale dhe përdoruesit marrin përditësime të vetvetishme. Disa veçori janë "
+"të papërdorura për shtesën tuaj."
+
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:74
+msgid "You will receive an email when the full review is complete, making you able to bundle your add-on with an application installer."
+msgstr "Do të merrni një email, kur të jetë plotësuar shqyrtimi i plotë, çka ju krijon mundësinë të paketoni shtesën tuaj me një instalues aplikacioni."
+
 #: src/olympia/devhub/templates/devhub/includes/addon_details.html:79
-msgid ""
-"You will receive an email when the full review is complete. Until then, your"
-" add-on is displayed in our gallery as experimental and users are receiving "
-"automatic updates. Some features are unavailable to your add-on."
+msgid "All add-ons hosted in our gallery must now be reviewed by an editor. If you wish to continue hosting your add-on, please click to select a review process."
 msgstr ""
-"Do të merrni një email kur të plotësohet shqyrtimi i plotë. Deri atëherë, "
-"shtesa juaj shfaqet te galeria jonë si eksperimentale dhe përdoruesit marrin"
-" përditësime të vetvetishme. Disa veçori janë të papërdorura për shtesën "
-"tuaj."
+"Krejt shtesat e strehuara te galeria jonë tani e tutje duhet të jenë shqyrtuar nga një redaktor. Nëse dëshironi ta vazhdoni strehimin e shtesës suaj, ju lutemi, klikoni që të përzgjidhni një proces "
+"shqyrtimi."
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:84
-msgid ""
-"You will receive an email when the full review is\n"
-"                             complete, making you able to bundle your add-on with an\n"
-"                             application installer."
-msgstr ""
-"Do të merrni një email, kur të jetë plotësuar shqyrtimi i plotë, çka ju "
-"krijon mundësinë të paketoni shtesën tuaj me një instalues aplikacioni."
-
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:91
-msgid ""
-"All add-ons hosted in our gallery must now be reviewed by an\n"
-"                             editor. If you wish to continue hosting your add-on, please\n"
-"                             click to select a review process."
-msgstr ""
-"Krejt shtesat e strehuara te galeria jonë tani e tutje duhet të jenë "
-"shqyrtuar nga një redaktor. Nëse dëshironi ta vazhdoni strehimin e shtesës "
-"suaj, ju lutemi, klikoni që të përzgjidhni një proces shqyrtimi."
-
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:113
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:100
 msgid "Current Version:"
 msgstr "Versioni i Tanishëm:"
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:115
-msgid ""
-"This is the version of your add-on that will be installed if someone clicks "
-"the Install button on addons.mozilla.org. It is only relevant for listed "
-"add-ons."
-msgstr ""
-"Ky është një version i shtesës suaj që do të jetë e instalueshme nëse dikush"
-" klikon butonin e instalimit te addons.mozilla.org. Kjo vlen vetëm për "
-"shtesat e paraqitura."
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:102
+msgid "This is the version of your add-on that will be installed if someone clicks the Install button on addons.mozilla.org. It is only relevant for listed add-ons."
+msgstr "Ky është një version i shtesës suaj që do të jetë e instalueshme nëse dikush klikon butonin e instalimit te addons.mozilla.org. Kjo vlen vetëm për shtesat e paraqitura."
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:123
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:110
 msgid "Created:"
 msgstr "Krijuar:"
 
 #. {0} is a date. dennis-ignore: E201
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:125
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:131
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:112 src/olympia/devhub/templates/devhub/includes/addon_details.html:118
 #, python-format
 msgid "%%b %%e, %%Y"
 msgstr "%%e %%b, %%Y"
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:136
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:123
 msgid "Next Version:"
 msgstr "Versioni Pasues:"
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:138
-msgid ""
-"This is the newest uploaded version, however\n"
-"                                           it isn’t live on the site yet."
-msgstr ""
-"Ky është versioni më i ri i ngarkuar, por ende nuk është efektiv te sajti."
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:125
+msgid "This is the newest uploaded version, however it isn’t live on the site yet."
+msgstr "Ky është versioni më i ri i ngarkuar, por ende nuk është efektiv te sajti."
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:144
-#: src/olympia/devhub/templates/devhub/versions/list.html:30
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:130 src/olympia/devhub/templates/devhub/versions/list.html:30
 msgid "Queues are not reviewed strictly in order"
 msgstr "Në shqyrtime radha s’ruhet në mënyrë strikte"
 
@@ -8211,15 +6271,11 @@ msgstr "Krijoni një Profil Zhvilluesi"
 
 #: src/olympia/devhub/templates/devhub/includes/addons_create_profile.html:24
 msgid ""
-"Your developer profile will tell users about you, why you made this add-on, "
-"and what's next for the add-on. This profile is required for add-ons "
-"requesting contributions, but can be useful for any developer interested in "
-"connecting with users."
+"Your developer profile will tell users about you, why you made this add-on, and what's next for the add-on. This profile is required for add-ons requesting contributions, but can be useful for any "
+"developer interested in connecting with users."
 msgstr ""
-"Profili juaj si zhvillues u tregon përdoruesve rreth jush, pse e krijuat "
-"këtë shtesë, dhe çfarë të presin më tej për këtë shtesë. Ky profil është i "
-"domosdoshëm te shtesat që kërkojnë për kontribute, por mund të jetë i "
-"dobishëm për cilindo zhvillues të interesuar për t’u lidhur me përdoruesit."
+"Profili juaj si zhvillues u tregon përdoruesve rreth jush, pse e krijuat këtë shtesë, dhe çfarë të presin më tej për këtë shtesë. Ky profil është i domosdoshëm te shtesat që kërkojnë për "
+"kontribute, por mund të jetë i dobishëm për cilindo zhvillues të interesuar për t’u lidhur me përdoruesit."
 
 #: src/olympia/devhub/templates/devhub/includes/addons_create_profile.html:32
 msgid "Make sure your user profile is up to date."
@@ -8228,26 +6284,15 @@ msgstr "Sigurohuni që profili juaj i përdoruesit është i përditësuar."
 #: src/olympia/devhub/templates/devhub/includes/addons_create_profile.html:34
 #, python-format
 msgid "<a href=\"%(url)s\"><strong>Update your user profile.</strong></a>"
-msgstr ""
-"<a href=\"%(url)s\"><strong>Përditësoni profilin tuaj si "
-"përdorues.</strong></a>"
+msgstr "<a href=\"%(url)s\"><strong>Përditësoni profilin tuaj si përdorues.</strong></a>"
 
 #: src/olympia/devhub/templates/devhub/includes/addons_create_profile.html:45
-msgid ""
-"Whether it was an idea while in line at the grocery store or the solution to"
-" one of life's great problems, share your story."
-msgstr ""
-"Qoftë kur qe një ide që ju erdhi kur qetë në radhë për akullore, qoftë kur "
-"bëhet fjalë për zgjidhjen e një prej problemeve madhore të jetës, na tregoni"
-" rastin tuaj."
+msgid "Whether it was an idea while in line at the grocery store or the solution to one of life's great problems, share your story."
+msgstr "Qoftë kur qe një ide që ju erdhi kur qetë në radhë për akullore, qoftë kur bëhet fjalë për zgjidhjen e një prej problemeve madhore të jetës, na tregoni rastin tuaj."
 
 #: src/olympia/devhub/templates/devhub/includes/addons_create_profile.html:61
-msgid ""
-"Telling your users what's coming soon will give them something to look "
-"forward to."
-msgstr ""
-"Duke u treguar përdoruesve se ç’vjen së afërmi, u jepet diçka që të jenë në "
-"pritje."
+msgid "Telling your users what's coming soon will give them something to look forward to."
+msgstr "Duke u treguar përdoruesve se ç’vjen së afërmi, u jepet diçka që të jenë në pritje."
 
 #: src/olympia/devhub/templates/devhub/includes/addons_edit_nav.html:23
 msgid "View All"
@@ -8278,12 +6323,8 @@ msgid "View the blog &#9658;"
 msgstr "Shihni blogun &#9658;"
 
 #: src/olympia/devhub/templates/devhub/includes/license_form.html:6
-msgid ""
-"Please choose a license appropriate for the rights you grant on your source code.\n"
-"                  It is only relevant for listed add-ons."
-msgstr ""
-"Ju lutemi, zgjidhni një licencë të përshtatshme me të drejtat që akordoni "
-"mbi kodin burim të shtesës suaj. Kjo vlen vetëm për shtesat e paraqitura."
+msgid "Please choose a license appropriate for the rights you grant on your source code. It is only relevant for listed add-ons."
+msgstr "Ju lutemi, zgjidhni një licencë të përshtatshme me të drejtat që akordoni mbi kodin burim të shtesës suaj. Kjo vlen vetëm për shtesat e paraqitura."
 
 #. {0} is a list of HTML tags.
 #: src/olympia/devhub/templates/devhub/includes/macros.html:7
@@ -8298,8 +6339,7 @@ msgstr "Lejohet ca HTML."
 msgid "Remove this application"
 msgstr "Hiqe këtë aplikacion"
 
-#. {0} is the maximum number of add-on categories allowed.                {1}
-#. is
+#. {0} is the maximum number of add-on categories allowed.                {1} is
 #. the application name.
 #: src/olympia/devhub/templates/devhub/includes/macros.html:70
 msgid "Select <b>up to {0}</b> {1} category for this add-on:"
@@ -8309,45 +6349,27 @@ msgstr[1] "Përzgjidhni për këtë shtesë <b>deri në {0}</b> {1} kategori:"
 
 #: src/olympia/devhub/templates/devhub/includes/policy_form.html:4
 msgid ""
-"Users will be required to accept the following End-User License Agreement (EULA) prior to installing your add-on. The presence of a EULA significantly affects the number of downloads an add-on receives. Please note that a EULA is not the same as a code license, such as the GPL or MPL.\n"
-"                It is only relevant for listed add-ons."
+"Users will be required to accept the following End-User License Agreement (EULA) prior to installing your add-on. The presence of a EULA significantly affects the number of downloads an add-on "
+"receives. Please note that a EULA is not the same as a code license, such as the GPL or MPL.It is only relevant for listed add-ons."
 msgstr ""
-"Për përdoruesit do të jetë e domosdoshme të pranojnë Marrëveshjen e Licencës"
-" së Përdoruesit të Zakonshëm (EULA) vijuese përpara se të instalojnë shtesën"
-" tuaj. Prania e një EULA-je prek në mënyrë domethënëse numrin e shkarkimeve "
-"që i bëhen një shtese. Ju lutemi, vini re që një EULA s’është e njëjta gjë "
-"me një licencë kodi, fjala vjen GPL apo MPL. Kjo vlen vetëm për shtesa të "
-"pranishme në lista."
 
-#: src/olympia/devhub/templates/devhub/includes/policy_form.html:21
-msgid ""
-"If your add-on transmits any data from the user's computer, a privacy policy is required that explains what data is sent and how it is used.\n"
-"                It is only relevant for listed add-ons."
+#: src/olympia/devhub/templates/devhub/includes/policy_form.html:24
+msgid "If your add-on transmits any data from the user's computer, a privacy policy is required that explains what data is sent and how it is used. It is only relevant for listed add-ons."
 msgstr ""
-"Nëse shtesa juaj transmeton çfarëdo të dhënash që nga kompjuteri i "
-"përdoruesit, lypsen rregulla privatësie për të, që shpjegojnë se çfarë të "
-"dhënash dërgohen dhe se si përdoren. Kjo vlen vetëm për shtesa të pranishme "
-"në lista."
+"Nëse shtesa juaj transmeton çfarëdo të dhënash që nga kompjuteri i përdoruesit, lypsen rregulla privatësie për të, që shpjegojnë se çfarë të dhënash dërgohen dhe se si përdoren. Kjo vlen vetëm për "
+"shtesa të pranishme në lista."
 
 #: src/olympia/devhub/templates/devhub/includes/source_form_field.html:2
-msgid ""
-"If your add-on contains binary or obfuscated code other than known "
-"libraries, upload its sources for review."
-msgstr ""
-"Nëse shtesa juaj përmban kod dyor ose të turbullt, hiq librari të njohura, "
-"ngarkojini burimet e tyre për shqyrtim."
+msgid "If your add-on contains binary or obfuscated code other than known libraries, upload its sources for review."
+msgstr "Nëse shtesa juaj përmban kod dyor ose të turbullt, hiq librari të njohura, ngarkojini burimet e tyre për shqyrtim."
 
 #: src/olympia/devhub/templates/devhub/includes/source_form_field.html:3
 msgid "Read more about the source code review policy."
 msgstr "Lexoni më tepër rreth rregullave të shqyrtimit të kodit burim."
 
 #: src/olympia/devhub/templates/devhub/includes/version_file.html:20
-msgid ""
-"You cannot remove an individual file after the review process has begun. You"
-" must delete the entire version."
-msgstr ""
-"S’mund të hiqni një kartelë të vetme pas fillimit të procesit të shqyrtimit."
-" Duhet të fshini krejt versionin."
+msgid "You cannot remove an individual file after the review process has begun. You must delete the entire version."
+msgstr "S’mund të hiqni një kartelë të vetme pas fillimit të procesit të shqyrtimit. Duhet të fshini krejt versionin."
 
 #: src/olympia/devhub/templates/devhub/includes/version_file.html:36
 msgid "This file will be deleted on save."
@@ -8375,30 +6397,20 @@ msgid "Voluntary Contributions"
 msgstr "Kontribute Vullnetare"
 
 #: src/olympia/devhub/templates/devhub/payments/payments.html:38
-msgid ""
-"Add-ons enrolled in our contributions program can request voluntary "
-"financial support from users."
-msgstr ""
-"Shtesat e regjistruara te programi ynë i kontributeve mund të kërkojnë nga "
-"përdoruesit përkrahje financiare vullnetare."
+msgid "Add-ons enrolled in our contributions program can request voluntary financial support from users."
+msgstr "Shtesat e regjistruara te programi ynë i kontributeve mund të kërkojnë nga përdoruesit përkrahje financiare vullnetare."
 
 #: src/olympia/devhub/templates/devhub/payments/payments.html:40
 msgid "Encourage users to support your add-on through your Developer Profile"
-msgstr ""
-"Nxitini përdoruesit të përkrahin shtesën tuaj përmes Profilit tuaj të "
-"Zhvilluesit"
+msgstr "Nxitini përdoruesit të përkrahin shtesën tuaj përmes Profilit tuaj të Zhvilluesit"
 
 #: src/olympia/devhub/templates/devhub/payments/payments.html:41
 msgid "Choose when and how users are asked to contribute"
 msgstr "Përcaktoni kur dhe si u kërkohet përdoruesve të kontribuojnë"
 
 #: src/olympia/devhub/templates/devhub/payments/payments.html:42
-msgid ""
-"Receive contributions in your PayPal account or send them to an organization"
-" of your choice"
-msgstr ""
-"Merrni kontribute te llogaria juaj PayPal ose dërgojini te një organizëm "
-"zgjedhur prej jush"
+msgid "Receive contributions in your PayPal account or send them to an organization of your choice"
+msgstr "Merrni kontribute te llogaria juaj PayPal ose dërgojini te një organizëm zgjedhur prej jush"
 
 #: src/olympia/devhub/templates/devhub/payments/payments.html:46
 msgid "Contributions are only available for listed add-ons."
@@ -8406,20 +6418,14 @@ msgstr "Kontributet vlejnë vetëm për shtesa të paraqitura"
 
 #: src/olympia/devhub/templates/devhub/payments/payments.html:53
 #, python-format
-msgid ""
-"Contributions are only available for add-ons with a <a "
-"href=\"%(url)s\">completed developer profile</a>."
-msgstr ""
-"Kontributet mund të kihen vetëm për shtesa me <a href=\"%(url)s\">profil të "
-"plotë zhvilluesi</a>."
+msgid "Contributions are only available for add-ons with a <a href=\"%(url)s\">completed developer profile</a>."
+msgstr "Kontributet mund të kihen vetëm për shtesa me <a href=\"%(url)s\">profil të plotë zhvilluesi</a>."
 
 #: src/olympia/devhub/templates/devhub/payments/payments.html:59
 msgid "Contributions are only available for fully reviewed add-ons."
-msgstr ""
-"Kontributet janë të mundshme vetëm për shtesa të shqyrtuara plotësisht."
+msgstr "Kontributet janë të mundshme vetëm për shtesa të shqyrtuara plotësisht."
 
-#: src/olympia/devhub/templates/devhub/payments/payments.html:65
-#: src/olympia/devhub/templates/devhub/payments/voluntary.html:2
+#: src/olympia/devhub/templates/devhub/payments/payments.html:65 src/olympia/devhub/templates/devhub/payments/voluntary.html:2
 msgid "Set up Contributions"
 msgstr "Rregulloni Kontributet"
 
@@ -8432,18 +6438,13 @@ msgstr "Hapi 2. Çmime dhe Pasje"
 msgid "or <a href=\"%(cancel)s\">Cancel</a>"
 msgstr "ose <a href=\"%(cancel)s\">Anulojeni</a>"
 
-#: src/olympia/devhub/templates/devhub/payments/voluntary.html:2
-#: src/olympia/stats/templates/stats/addon_report_menu.html:39
+#: src/olympia/devhub/templates/devhub/payments/voluntary.html:2 src/olympia/stats/templates/stats/addon_report_menu.html:39
 msgid "Contributions"
 msgstr "Kontribute"
 
 #: src/olympia/devhub/templates/devhub/payments/voluntary.html:3
-msgid ""
-"Fill in the fields below to begin asking for voluntary contributions from "
-"users."
-msgstr ""
-"Plotësoni fushat vijuese që të fillohet kërkimi i kontributeve vullnetare "
-"prej përdoruesve."
+msgid "Fill in the fields below to begin asking for voluntary contributions from users."
+msgstr "Plotësoni fushat vijuese që të fillohet kërkimi i kontributeve vullnetare prej përdoruesve."
 
 #: src/olympia/devhub/templates/devhub/payments/voluntary.html:11
 msgid "Who will receive contributions to this add-on?"
@@ -8486,23 +6487,16 @@ msgid "Send a thank-you note?"
 msgstr "Të dërgohet pusullë falënderimi?"
 
 #: src/olympia/devhub/templates/devhub/payments/voluntary.html:47
-msgid ""
-"We'll automatically email users who contribute to your add-on with this "
-"message."
-msgstr ""
-"Do t’ua dërgojmë vetvetiu me email këtë mesazh përdoruesve që kontribuojnë "
-"te shtesa juaj."
+msgid "We'll automatically email users who contribute to your add-on with this message."
+msgstr "Do t’ua dërgojmë vetvetiu me email këtë mesazh përdoruesve që kontribuojnë te shtesa juaj."
 
 #: src/olympia/devhub/templates/devhub/payments/voluntary.html:49
 msgid ""
-"We recommend thanking the user and telling them how much you appreciate "
-"their support. You might also want to tell them about what's next for your "
-"add-on and about any other add-ons you've made for them to try."
+"We recommend thanking the user and telling them how much you appreciate their support. You might also want to tell them about what's next for your add-on and about any other add-ons you've made for "
+"them to try."
 msgstr ""
-"Këshillojmë që t’i falënderoni përdoruesit dhe t’u tregoni atyre se sa shumë"
-" e vlerësoni përkrahjen e tyre. Mund të doni edhe t’u tregoni se ç’vjen më "
-"tej për shtesën tuaj dhe rreth çfarëdo shtese tjetër që keni krijuar e ta "
-"provojnë."
+"Këshillojmë që t’i falënderoni përdoruesit dhe t’u tregoni atyre se sa shumë e vlerësoni përkrahjen e tyre. Mund të doni edhe t’u tregoni se ç’vjen më tej për shtesën tuaj dhe rreth çfarëdo shtese "
+"tjetër që keni krijuar e ta provojnë."
 
 #: src/olympia/devhub/templates/devhub/payments/voluntary.html:64
 msgid "Activate Contributions"
@@ -8516,153 +6510,95 @@ msgstr "ose <a id=\"setup-cancel\" href=\"#\">Anulojeni</a>"
 msgid "Transfer ownership"
 msgstr "Transferojini pronësinë"
 
-#: src/olympia/devhub/templates/devhub/personas/edit.html:77
-#: src/olympia/devhub/templates/devhub/personas/submit.html:31
+#: src/olympia/devhub/templates/devhub/personas/edit.html:77 src/olympia/devhub/templates/devhub/personas/submit.html:31
 msgid "Theme Details"
 msgstr "Hollësi Teme"
 
-#: src/olympia/devhub/templates/devhub/personas/edit.html:87
-#: src/olympia/devhub/templates/devhub/personas/submit.html:36
+#: src/olympia/devhub/templates/devhub/personas/edit.html:87 src/olympia/devhub/templates/devhub/personas/submit.html:36
 msgid "Supply a pretty URL for your detail page."
 msgstr "Jepni një URL të hijshme për te faqja e hollësive."
 
-#: src/olympia/devhub/templates/devhub/personas/edit.html:92
-#: src/olympia/devhub/templates/devhub/personas/submit.html:41
+#: src/olympia/devhub/templates/devhub/personas/edit.html:92 src/olympia/devhub/templates/devhub/personas/submit.html:41
 msgid "Select the category that best describes your Theme."
 msgstr "Përzgjidhni kategorinë që përshkruan më mirë Temën tuaj."
 
-#: src/olympia/devhub/templates/devhub/personas/edit.html:95
-#: src/olympia/devhub/templates/devhub/personas/submit.html:44
+#: src/olympia/devhub/templates/devhub/personas/edit.html:95 src/olympia/devhub/templates/devhub/personas/submit.html:44
 msgid "Add some tags to describe your Theme."
 msgstr "Shtoni ca etiketa që të përshkruajnë Temën tuaj."
 
-#: src/olympia/devhub/templates/devhub/personas/edit.html:106
-msgid ""
-"A short explanation of your theme's basic functionality that is displayed in"
-" search and browse listings, as well as at the top of your theme's details "
-"page."
-msgstr ""
-"Një shpjegim i shkurtër i funksioneve bazë të temës suaj e që shfaqet në "
-"lista kërkimi dhe shfletimi, si edhe në krye të faqes së hollësive mbi temën"
-" suaj."
+#: src/olympia/devhub/templates/devhub/personas/edit.html:106 src/olympia/devhub/templates/devhub/personas/submit.html:54
+msgid "A short explanation of your theme's basic functionality that is displayed in search and browse listings, as well as at the top of your theme's details page."
+msgstr "Një shpjegim i shkurtër i funksioneve bazë të temës suaj e që shfaqet në lista kërkimi dhe shfletimi, si edhe në krye të faqes së hollësive mbi temën suaj."
 
-#: src/olympia/devhub/templates/devhub/personas/edit.html:122
-#: src/olympia/devhub/templates/devhub/personas/submit.html:68
+#: src/olympia/devhub/templates/devhub/personas/edit.html:122 src/olympia/devhub/templates/devhub/personas/submit.html:68
 msgid "Theme License"
 msgstr "Licencë Teme"
 
-#: src/olympia/devhub/templates/devhub/personas/edit.html:126
-#: src/olympia/devhub/templates/devhub/personas/submit.html:72
+#: src/olympia/devhub/templates/devhub/personas/edit.html:126 src/olympia/devhub/templates/devhub/personas/submit.html:72
 msgid "Can others share your Theme, as long as you're given credit?"
-msgstr ""
-"A mundet të tjerët të ndajnë me dikë Temën tuaj, për sa kohë që përmendeni "
-"si autori?"
+msgstr "A mundet të tjerët të ndajnë me dikë Temën tuaj, për sa kohë që përmendeni si autori?"
 
-#: src/olympia/devhub/templates/devhub/personas/edit.html:132
-#: src/olympia/devhub/templates/devhub/personas/edit.html:153
-#: src/olympia/devhub/templates/devhub/personas/submit.html:78
+#: src/olympia/devhub/templates/devhub/personas/edit.html:132 src/olympia/devhub/templates/devhub/personas/edit.html:153 src/olympia/devhub/templates/devhub/personas/submit.html:78
 #: src/olympia/devhub/templates/devhub/personas/submit.html:99
-msgid ""
-"The licensor permits others to copy, distribute, display, and perform the "
-"work, including for commercial purposes."
-msgstr ""
-"Licencuesi u lejon të tjerëve të kopjojnë, shpërndajnë, shfaqin dhe "
-"ekzekutojnë veprën, përfshi rastet për qëllime komerciale."
+msgid "The licensor permits others to copy, distribute, display, and perform the work, including for commercial purposes."
+msgstr "Licencuesi u lejon të tjerëve të kopjojnë, shpërndajnë, shfaqin dhe ekzekutojnë veprën, përfshi rastet për qëllime komerciale."
 
-#: src/olympia/devhub/templates/devhub/personas/edit.html:141
-#: src/olympia/devhub/templates/devhub/personas/edit.html:162
-#: src/olympia/devhub/templates/devhub/personas/submit.html:87
+#: src/olympia/devhub/templates/devhub/personas/edit.html:141 src/olympia/devhub/templates/devhub/personas/edit.html:162 src/olympia/devhub/templates/devhub/personas/submit.html:87
 #: src/olympia/devhub/templates/devhub/personas/submit.html:108
-msgid ""
-"The licensor permits others to copy, distribute, display, and perform the "
-"work for non-commercial purposes only."
-msgstr ""
-"Licencuesi u lejon të tjerëve të kopjojnë, shpërndajnë, shfaqin, dhe "
-"ekzekutojnë veprën vetëm për qëllime jokomerciale."
+msgid "The licensor permits others to copy, distribute, display, and perform the work for non-commercial purposes only."
+msgstr "Licencuesi u lejon të tjerëve të kopjojnë, shpërndajnë, shfaqin, dhe ekzekutojnë veprën vetëm për qëllime jokomerciale."
 
-#: src/olympia/devhub/templates/devhub/personas/edit.html:147
-#: src/olympia/devhub/templates/devhub/personas/submit.html:93
+#: src/olympia/devhub/templates/devhub/personas/edit.html:147 src/olympia/devhub/templates/devhub/personas/submit.html:93
 msgid "Can others make commercial use of your Theme?"
 msgstr "A mund të përdoret Tema juaj në rrugë komerciale?"
 
-#: src/olympia/devhub/templates/devhub/personas/edit.html:168
-#: src/olympia/devhub/templates/devhub/personas/submit.html:114
+#: src/olympia/devhub/templates/devhub/personas/edit.html:168 src/olympia/devhub/templates/devhub/personas/submit.html:114
 msgid "Can others create derivative works from your Theme?"
 msgstr "A munden të tjerët të krijojnë vepra të rrjedhura nga Tema juaj?"
 
-#: src/olympia/devhub/templates/devhub/personas/edit.html:174
-#: src/olympia/devhub/templates/devhub/personas/submit.html:120
-msgid ""
-"The licensor permits others to copy, distribute, display and perform the "
-"work, as well as make derivative works based on it."
-msgstr ""
-"Licencuesi u lejon të tjerëve të kopjojnë, shpërndajnë, shfaqin dhe "
-"ekzekutojnë veprën, si edhe të krijojnë vepra të rrjedhura bazuar në të."
+#: src/olympia/devhub/templates/devhub/personas/edit.html:174 src/olympia/devhub/templates/devhub/personas/submit.html:120
+msgid "The licensor permits others to copy, distribute, display and perform the work, as well as make derivative works based on it."
+msgstr "Licencuesi u lejon të tjerëve të kopjojnë, shpërndajnë, shfaqin dhe ekzekutojnë veprën, si edhe të krijojnë vepra të rrjedhura bazuar në të."
 
-#: src/olympia/devhub/templates/devhub/personas/edit.html:182
-#: src/olympia/devhub/templates/devhub/personas/submit.html:128
+#: src/olympia/devhub/templates/devhub/personas/edit.html:182 src/olympia/devhub/templates/devhub/personas/submit.html:128
 msgid "Yes, as long as they share alike"
 msgstr "Po, për sa kohë që e ndajnë me të tjerët po njësoj"
 
-#: src/olympia/devhub/templates/devhub/personas/edit.html:183
-#: src/olympia/devhub/templates/devhub/personas/submit.html:129
-msgid ""
-"The licensor permits others to distribute derivativeworks only under the "
-"same license or one compatible with the one that governs the licensor's "
-"work."
-msgstr ""
-"Licensuesi u lejon të tjerëve të shpërndajnë vepra të rrjedhura vetëm sipas "
-"të njëjtës licencë ose një të përputhshmeje me atë që qeveris veprën e "
-"licensuesit."
+#: src/olympia/devhub/templates/devhub/personas/edit.html:183 src/olympia/devhub/templates/devhub/personas/submit.html:129
+msgid "The licensor permits others to distribute derivativeworks only under the same license or one compatible with the one that governs the licensor's work."
+msgstr "Licensuesi u lejon të tjerëve të shpërndajnë vepra të rrjedhura vetëm sipas të njëjtës licencë ose një të përputhshmeje me atë që qeveris veprën e licensuesit."
 
-#: src/olympia/devhub/templates/devhub/personas/edit.html:192
-#: src/olympia/devhub/templates/devhub/personas/submit.html:138
-msgid ""
-"The licensor permits others to copy, distribute and transmit only unaltered "
-"copies of the work — not derivative works based on it."
-msgstr ""
-"Licencuesi u lejon të tjerëve të kopjojnë, shpërndajnë dhe transmetojnë "
-"vetëm kopje të pandryshuara të veprës - jo vepra të rrjedhura bazuar në të."
+#: src/olympia/devhub/templates/devhub/personas/edit.html:192 src/olympia/devhub/templates/devhub/personas/submit.html:138
+msgid "The licensor permits others to copy, distribute and transmit only unaltered copies of the work — not derivative works based on it."
+msgstr "Licencuesi u lejon të tjerëve të kopjojnë, shpërndajnë dhe transmetojnë vetëm kopje të pandryshuara të veprës - jo vepra të rrjedhura bazuar në të."
 
-#: src/olympia/devhub/templates/devhub/personas/edit.html:199
-#: src/olympia/devhub/templates/devhub/personas/submit.html:145
+#: src/olympia/devhub/templates/devhub/personas/edit.html:199 src/olympia/devhub/templates/devhub/personas/submit.html:145
 msgid "Your Theme will be released under the following license:"
 msgstr "Tema juaj do të hidhet në qarkullim sipas licencës vijuese:"
 
-#: src/olympia/devhub/templates/devhub/personas/edit.html:202
-#: src/olympia/devhub/templates/devhub/personas/submit.html:148
+#: src/olympia/devhub/templates/devhub/personas/edit.html:202 src/olympia/devhub/templates/devhub/personas/submit.html:148
 msgid "Select a different license."
 msgstr "Përzgjidhni një licencë tjetër."
 
-#: src/olympia/devhub/templates/devhub/personas/edit.html:207
-#: src/olympia/devhub/templates/devhub/personas/submit.html:153
+#: src/olympia/devhub/templates/devhub/personas/edit.html:207 src/olympia/devhub/templates/devhub/personas/submit.html:153
 msgid "Select a license for your Theme."
 msgstr "Përzgjidhni një licencë për Temën tuaj."
 
-#: src/olympia/devhub/templates/devhub/personas/edit.html:217
-#: src/olympia/devhub/templates/devhub/personas/submit.html:163
+#: src/olympia/devhub/templates/devhub/personas/edit.html:217 src/olympia/devhub/templates/devhub/personas/submit.html:163
 msgid "Theme Design"
 msgstr "Hartim Teme"
 
-#: src/olympia/devhub/templates/devhub/personas/edit.html:221
-#: src/olympia/devhub/templates/devhub/personas/edit.html:224
+#: src/olympia/devhub/templates/devhub/personas/edit.html:221 src/olympia/devhub/templates/devhub/personas/edit.html:224
 msgid "Upload New Design"
 msgstr "Ngarkoni Dizajn të Ri"
 
 #: src/olympia/devhub/templates/devhub/personas/edit.html:226
-msgid ""
-"Upon upload and form submission, the AMO Team will review your updated "
-"design. Your current design will still be public in the meantime."
-msgstr ""
-"Me parashtrimin e ngarkimit dhe të formularit, Ekipi i AMO-s do të marrë në "
-"shqyrtim modelin tuaj të përditësuar. Modeli juaj i deriatëhershëm do të "
-"jetë ende publik ndërkohë."
+msgid "Upon upload and form submission, the AMO Team will review your updated design. Your current design will still be public in the meantime."
+msgstr "Me parashtrimin e ngarkimit dhe të formularit, Ekipi i AMO-s do të marrë në shqyrtim modelin tuaj të përditësuar. Modeli juaj i deriatëhershëm do të jetë ende publik ndërkohë."
 
 #: src/olympia/devhub/templates/devhub/personas/edit.html:241
-msgid "Your previously resubmitted design,  which is under pending review."
-msgstr ""
-"Skema juaj grafike, e riparashtruar më parë, që është në pritje të "
-"shqyrtimit."
+msgid "Your previously resubmitted design, which is under pending review."
+msgstr "Skema juaj grafike, e riparashtruar më parë, që është në pritje të shqyrtimit."
 
 #: src/olympia/devhub/templates/devhub/personas/edit.html:245
 msgid "Pending Header"
@@ -8684,43 +6620,35 @@ msgstr "Krye"
 msgid "Footer"
 msgstr "Fundfaqe"
 
-#: src/olympia/devhub/templates/devhub/personas/edit.html:274
-#: src/olympia/devhub/templates/devhub/personas/submit.html:167
+#: src/olympia/devhub/templates/devhub/personas/edit.html:274 src/olympia/devhub/templates/devhub/personas/submit.html:167
 msgid "Select colors for your Theme."
 msgstr "Përzgjidhni ngjyra për Temën tuaj."
 
-#: src/olympia/devhub/templates/devhub/personas/edit.html:276
-#: src/olympia/devhub/templates/devhub/personas/submit.html:169
+#: src/olympia/devhub/templates/devhub/personas/edit.html:276 src/olympia/devhub/templates/devhub/personas/submit.html:169
 msgid "Foreground Text"
 msgstr "Tekst i Përparmë"
 
-#: src/olympia/devhub/templates/devhub/personas/edit.html:277
-#: src/olympia/devhub/templates/devhub/personas/submit.html:170
+#: src/olympia/devhub/templates/devhub/personas/edit.html:277 src/olympia/devhub/templates/devhub/personas/submit.html:170
 msgid "This is the color of the tab text."
 msgstr "Kjo është ngjyra e tekstit të skedave."
 
-#: src/olympia/devhub/templates/devhub/personas/edit.html:279
-#: src/olympia/devhub/templates/devhub/personas/submit.html:172
+#: src/olympia/devhub/templates/devhub/personas/edit.html:279 src/olympia/devhub/templates/devhub/personas/submit.html:172
 msgid "Background"
 msgstr "Sfond"
 
-#: src/olympia/devhub/templates/devhub/personas/edit.html:280
-#: src/olympia/devhub/templates/devhub/personas/submit.html:173
+#: src/olympia/devhub/templates/devhub/personas/edit.html:280 src/olympia/devhub/templates/devhub/personas/submit.html:173
 msgid "This is the color of the tabs."
 msgstr "Kjo është ngjyra e skedave."
 
-#: src/olympia/devhub/templates/devhub/personas/edit.html:285
-#: src/olympia/devhub/templates/devhub/personas/submit.html:178
+#: src/olympia/devhub/templates/devhub/personas/edit.html:285 src/olympia/devhub/templates/devhub/personas/submit.html:178
 msgid "Preview"
 msgstr "Paraparje"
 
-#: src/olympia/devhub/templates/devhub/personas/edit.html:291
-#: src/olympia/devhub/templates/devhub/personas/submit.html:183
+#: src/olympia/devhub/templates/devhub/personas/edit.html:291 src/olympia/devhub/templates/devhub/personas/submit.html:183
 msgid "Your Theme's Name"
 msgstr "Emri i Temës Suaj"
 
-#: src/olympia/devhub/templates/devhub/personas/edit.html:294
-#: src/olympia/devhub/templates/devhub/personas/submit.html:186
+#: src/olympia/devhub/templates/devhub/personas/edit.html:294 src/olympia/devhub/templates/devhub/personas/submit.html:186
 #, python-format
 msgid "by <a href=\"%(profile_url)s\" target=\"_blank\">%(user)s</a>"
 msgstr "nga <a href=\"%(profile_url)s\" target=\"_blank\">%(user)s</a>"
@@ -8731,79 +6659,44 @@ msgstr "Krijoni një Temë të Re"
 
 #: src/olympia/devhub/templates/devhub/personas/submit.html:18
 #, python-format
-msgid ""
-"Background themes let you easily personalize the look of your Firefox. "
-"Submit your own design below, or <a href=\"%(submit_url)s\">learn how to "
-"create one</a>!"
-msgstr ""
-"Temat e sfondit ju lejojnë të personalizoni lehtësisht pamjen e Firefox-it "
-"tuaj. Prashtroni më poshtë modelin tuaj, ose <a "
-"href=\"%(submit_url)s\">mësoni se si të krijoni një të tillë</a>!"
+msgid "Background themes let you easily personalize the look of your Firefox. Submit your own design below, or <a href=\"%(submit_url)s\">learn how to create one</a>!"
+msgstr "Temat e sfondit ju lejojnë të personalizoni lehtësisht pamjen e Firefox-it tuaj. Prashtroni më poshtë modelin tuaj, ose <a href=\"%(submit_url)s\">mësoni se si të krijoni një të tillë</a>!"
 
 #: src/olympia/devhub/templates/devhub/personas/submit.html:33
 msgid "Give your Theme a name."
 msgstr "Vërini Temës suaj një emër."
 
-#: src/olympia/devhub/templates/devhub/personas/submit.html:54
-msgid ""
-"A short explanation of your theme's basic functionality that is displayed in"
-" search and browse listings, as well as at the top of your theme's details "
-"page."
-msgstr ""
-"Një shpjegim i shkurtër i funksioneve bazë të temës suaj e që shfaqet në "
-"lista kërkimi dhe shfletimi, si edhe në krye të faqes së hollësive mbi temën"
-" suaj."
-
 #: src/olympia/devhub/templates/devhub/personas/submit.html:198
 #, python-format
 msgid ""
-"I agree to the <a href=\"%(agreement_url)s\" target=\"_blank\">Firefox Add-"
-"on Distribution Agreement</a> and to my information being handled as "
-"described in the <a href=\"%(privacy_notice_url)s\" "
+"I agree to the <a href=\"%(agreement_url)s\" target=\"_blank\">Firefox Add-on Distribution Agreement</a> and to my information being handled as described in the <a href=\"%(privacy_notice_url)s\" "
 "target=\"_blank\">Websites, Communications and Cookies Privacy Notice</a>."
 msgstr ""
-"Pajtohem me <a href=\"%(agreement_url)s\" target=\"_blank\">Marrëveshjen e "
-"Shpërndarjes së Shtesave të Firefox-it</a> dhe me ruajtjen dhe trajtimin e "
-"të dhënave të mia ashtu siç përshkruhet te <a "
-"href=\"%(privacy_notice_url)s\" target=\"_blank\">Shënimet mbi Privatësinë "
-"në Sajte, Komunikime dhe Cookies</a>."
+"Pajtohem me <a href=\"%(agreement_url)s\" target=\"_blank\">Marrëveshjen e Shpërndarjes së Shtesave të Firefox-it</a> dhe me ruajtjen dhe trajtimin e të dhënave të mia ashtu siç përshkruhet te <a "
+"href=\"%(privacy_notice_url)s\" target=\"_blank\">Shënimet mbi Privatësinë në Sajte, Komunikime dhe Cookies</a>."
 
 #: src/olympia/devhub/templates/devhub/personas/submit.html:205
 msgid "Submit Theme"
 msgstr "Parashtrojeni Temën"
 
 #: src/olympia/devhub/templates/devhub/personas/submit_done.html:11
-msgid ""
-"Your theme has been submitted to the Review Queue. You'll receive an email "
-"once it has been reviewed, typically within 24 hours."
-msgstr ""
-"Tema juaj është parashtruat te Radha e Shqyrtimeve. Do të merrni një email, "
-"sapo të jetë shqyrtuar, zakonisht brenda 24 orësh."
+msgid "Your theme has been submitted to the Review Queue. You'll receive an email once it has been reviewed, typically within 24 hours."
+msgstr "Tema juaj është parashtruat te Radha e Shqyrtimeve. Do të merrni një email, sapo të jetë shqyrtuar, zakonisht brenda 24 orësh."
 
 #: src/olympia/devhub/templates/devhub/personas/submit_done.html:19
 #, python-format
-msgid ""
-"Provide more details about your theme by <a href=\"%(edit_url)s\">editing "
-"its listing</a>."
-msgstr ""
-"Jepni më tepër hollësi rreth temës suaj, përmes <a "
-"href=\"%(edit_url)s\">përpunimit të paraqitjes</a> së saj."
+msgid "Provide more details about your theme by <a href=\"%(edit_url)s\">editing its listing</a>."
+msgstr "Jepni më tepër hollësi rreth temës suaj, përmes <a href=\"%(edit_url)s\">përpunimit të paraqitjes</a> së saj."
 
 #: src/olympia/devhub/templates/devhub/personas/submit_done.html:25
 #, python-format
-msgid ""
-"View and subscribe to your theme's <a href=\"%(feed_url)s\">activity "
-"feed</a> to stay updated on reviews, collections, and more."
-msgstr ""
-"Shihni dhe pajtohuni te <a href=\"%(feed_url)s\">prurja mbi veprimtarinë</a>"
-" te shtesa juaj, që të merrni përditësime mbi shqyrtime të saj, koleksione "
-"ku përfshihet, dhe të tjera."
+msgid "View and subscribe to your theme's <a href=\"%(feed_url)s\">activity feed</a> to stay updated on reviews, collections, and more."
+msgstr "Shihni dhe pajtohuni te <a href=\"%(feed_url)s\">prurja mbi veprimtarinë</a> te shtesa juaj, që të merrni përditësime mbi shqyrtime të saj, koleksione ku përfshihet, dhe të tjera."
 
 #: src/olympia/devhub/templates/devhub/personas/submit_done.html:32
 #, python-format
 msgid "Join the conversation in our <a href=\"%(forum_url)s\">forums</a>."
-msgstr ""
-"Merrni pjesë në bashkëbisedim te <a href=\"%(forum_url)s\">forumet</a> tanë."
+msgstr "Merrni pjesë në bashkëbisedim te <a href=\"%(forum_url)s\">forumet</a> tanë."
 
 #: src/olympia/devhub/templates/devhub/personas/includes/theme_design.html:3
 msgid "Select a header image for your Theme."
@@ -8813,13 +6706,11 @@ msgstr "Përzgjidhni një figurë kryeje për Temën tuaj."
 msgid "3000 &times; 200 pixels"
 msgstr "3000 &times; 200 piksel"
 
-#: src/olympia/devhub/templates/devhub/personas/includes/theme_design.html:9
-#: src/olympia/devhub/templates/devhub/personas/includes/theme_design.html:25
+#: src/olympia/devhub/templates/devhub/personas/includes/theme_design.html:9 src/olympia/devhub/templates/devhub/personas/includes/theme_design.html:25
 msgid "300 KB max"
 msgstr "Maksimumi 300 KB"
 
-#: src/olympia/devhub/templates/devhub/personas/includes/theme_design.html:10
-#: src/olympia/devhub/templates/devhub/personas/includes/theme_design.html:26
+#: src/olympia/devhub/templates/devhub/personas/includes/theme_design.html:10 src/olympia/devhub/templates/devhub/personas/includes/theme_design.html:26
 msgid "PNG or JPG"
 msgstr "PNG ose JPG"
 
@@ -8848,56 +6739,32 @@ msgid "Select a different footer image"
 msgstr "Përzgjidhni një tjetër figurë fundfaqeje"
 
 #: src/olympia/devhub/templates/devhub/versions/add_file_modal.html:8
-msgid ""
-"Files added to reviewed versions must be reviewed before they will be "
-"available for download."
-msgstr ""
-"Kartelat e shtuara te versionet e shqyrtuara duhet të merren në shqyrtim, "
-"përpara se të shfaqen publikisht për shkarkim."
+msgid "Files added to reviewed versions must be reviewed before they will be available for download."
+msgstr "Kartelat e shtuara te versionet e shqyrtuara duhet të merren në shqyrtim, përpara se të shfaqen publikisht për shkarkim."
 
-#: src/olympia/devhub/templates/devhub/versions/add_file_modal.html:15
-#, python-format
-msgid ""
-"Submission of updates to unlisted add-ons for signing is currently in an "
-"open beta. Manual review may still be required for a large number of add-"
-"ons. Please <a href=\"%(url)s\" target=\"_blank\">report any bugs</a> that "
-"you encounter."
-msgstr ""
-
-#: src/olympia/devhub/templates/devhub/versions/add_file_modal.html:35
+#: src/olympia/devhub/templates/devhub/versions/add_file_modal.html:24
 msgid "Select the target platform for this file."
 msgstr "Përzgjidhni platformën objektiv për këtë kartelë."
 
-#: src/olympia/devhub/templates/devhub/versions/add_file_modal.html:46
+#: src/olympia/devhub/templates/devhub/versions/add_file_modal.html:35
 msgid "Which review type would you like to nominate for?"
 msgstr "Për çfarë lloji shqyrtimi doni të kandidohet?"
 
-#: src/olympia/devhub/templates/devhub/versions/add_file_modal.html:51
+#: src/olympia/devhub/templates/devhub/versions/add_file_modal.html:40
 msgid "Only publish this version to my beta channel."
 msgstr "Botoje këtë version vetëm te kanali im beta."
-
-#: src/olympia/devhub/templates/devhub/versions/add_file_modal.html:54
-#, python-format
-msgid ""
-"The behavior of the beta channel has changed to accommodate <a "
-"href=\"%(addon_signing_url)s\" target=\"_blank\">mandatory add-on "
-"signing</a>. The new process is currently in an open beta, and may change "
-"significantly in the near future. Please <a href=\"%(issues_url)s\" "
-"target=\"_blank\">report any bugs</a> that you encounter."
-msgstr ""
 
 # %s is the version number.
 #: src/olympia/devhub/templates/devhub/versions/edit.html:5
 msgid "Manage Version {0}"
 msgstr "Administroni Versionin {0}"
 
-#: src/olympia/devhub/templates/devhub/versions/edit.html:12
-#: src/olympia/devhub/templates/devhub/versions/list.html:3
+#: src/olympia/devhub/templates/devhub/versions/edit.html:12 src/olympia/devhub/templates/devhub/versions/list.html:3
 msgid "Status & Versions"
 msgstr "Gjendje & Versione"
 
-#. {0} is an add-on name.
 # %1$s is the name of the collection
+#. {0} is an add-on name.
 #: src/olympia/devhub/templates/devhub/versions/edit.html:16
 msgid "Manage {0}"
 msgstr "Administroni {0}"
@@ -8910,60 +6777,35 @@ msgstr "Kartela"
 msgid "Upload Another File"
 msgstr "Ngarkoni Kartelë Tjetër"
 
-#: src/olympia/devhub/templates/devhub/versions/edit.html:45
-msgid ""
-"Adjusting application information here will allow users to install your\n"
-"                          add-on even if the install manifest in the package indicates that the\n"
-"                          add-on is incompatible."
-msgstr ""
-"Rregullimi i të dhënave të aplikacionit këtu do t’u lejojë përdoruesve të "
-"instalojnë shtesën tuaj edhe manifesti i instalimit te paketa tregon që ajo "
-"shtesë është e papërputhshme."
-
 #: src/olympia/devhub/templates/devhub/versions/edit.html:74
 msgid ""
-"Information about changes in this release, new features,\n"
-"                              known bugs, and other useful information specific to this\n"
-"                              release/version. This information is also shown in the\n"
-"                              Add-ons Manager when updating."
+"Information about changes in this release, new features, known bugs, and other useful information specific to this release/version. This information is also shown in the Add-ons Manager when "
+"updating."
 msgstr ""
-"Të dhëna rreth ndryshime në këtë version, veçori të reja, të meta të "
-"njohura, dhe të tjera të dhëna të dobishme që lidhen me këtë hedhje në "
-"qarkullim/version. Këto të dhëna shfaqen edhe te Përgjegjësi i "
-"Aplikacioneve, gjatë përditësimesh."
+"Të dhëna rreth ndryshime në këtë version, veçori të reja, të meta të njohura, dhe të tjera të dhëna të dobishme që lidhen me këtë hedhje në qarkullim/version. Këto të dhëna shfaqen edhe te "
+"Përgjegjësi i Aplikacioneve, gjatë përditësimesh."
 
 #: src/olympia/devhub/templates/devhub/versions/edit.html:99
 msgid "Approval Status"
 msgstr "Gjendje Miratimi"
 
-#: src/olympia/devhub/templates/devhub/versions/edit.html:113
-#: src/olympia/editors/templates/editors/review.html:108
+#: src/olympia/devhub/templates/devhub/versions/edit.html:113 src/olympia/editors/templates/editors/review.html:108
 msgid "Notes for Reviewers"
 msgstr "Shënime për Shqyrtuesit"
 
 #: src/olympia/devhub/templates/devhub/versions/edit.html:114
-msgid ""
-"Optionally, enter any information that may be useful\n"
-"                              to the Editor reviewing this add-on, such as test\n"
-"                              account information."
-msgstr ""
-"Në daçi, jepni çfarëdo të dhëne që mund të jetë e dobishme për Shqyrtuesin "
-"që merr në shqyrtim këtë aplikacion,të tilla si të dhëna llogarie prove."
+msgid "Optionally, enter any information that may be useful to the Editor reviewing this add-on, such as test account information."
+msgstr "Në daçi, jepni çfarëdo të dhëne që mund të jetë e dobishme për Shqyrtuesin që merr në shqyrtim këtë aplikacion,të tilla si të dhëna llogarie prove."
 
 #: src/olympia/devhub/templates/devhub/versions/edit.html:127
 msgid "Source code"
 msgstr "Kodi burim"
 
 #: src/olympia/devhub/templates/devhub/versions/edit.html:128
-msgid ""
-"If your add-on contain binary or obfuscated code, make the source available "
-"here for reviewers."
-msgstr ""
-"Nëse shtesa juaj përmban kod dyor ose të turbullt, jepeni burimin këtu për "
-"shqyrtuesit."
+msgid "If your add-on contain binary or obfuscated code, make the source available here for reviewers."
+msgstr "Nëse shtesa juaj përmban kod dyor ose të turbullt, jepeni burimin këtu për shqyrtuesit."
 
-#: src/olympia/devhub/templates/devhub/versions/edit.html:145
-#: src/olympia/devhub/templates/devhub/versions/edit.html:149
+#: src/olympia/devhub/templates/devhub/versions/edit.html:145 src/olympia/devhub/templates/devhub/versions/edit.html:149
 msgid "Upload a new file"
 msgstr "Ngarkoni kartelë të re"
 
@@ -8978,8 +6820,7 @@ msgstr "Kartelë {file_id} ({platform})"
 #: src/olympia/devhub/templates/devhub/versions/file_status_message.html:5
 #, python-format
 msgid "Created on %(created)s and changed to %(status)s on %(status_date)s"
-msgstr ""
-"E krijuar më %(created)s dhe ndryshuar si %(status)s më %(status_date)s"
+msgstr "E krijuar më %(created)s dhe ndryshuar si %(status)s më %(status_date)s"
 
 #: src/olympia/devhub/templates/devhub/versions/file_status_message.html:9
 #, python-format
@@ -9032,9 +6873,7 @@ msgstr "Kërkoni Shqyrtim të Plotë"
 msgid "Request Preliminary Review"
 msgstr "Kërkoni Shqyrtim Paraprak"
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:80
-#: src/olympia/devhub/templates/devhub/versions/list.html:327
-#: src/olympia/devhub/templates/devhub/versions/list.html:350
+#: src/olympia/devhub/templates/devhub/versions/list.html:80 src/olympia/devhub/templates/devhub/versions/list.html:325 src/olympia/devhub/templates/devhub/versions/list.html:348
 msgid "Cancel Review Request"
 msgstr "Anulo Kërkesën për Shqyrtim"
 
@@ -9047,35 +6886,24 @@ msgid "Listed:"
 msgstr "E paraqitur:"
 
 #: src/olympia/devhub/templates/devhub/versions/list.html:102
-msgid ""
-"Visible to everyone on {0} and included in search results and listing pages"
-msgstr ""
-"E dukshme për këdo te {0} dhe e përfshirë në përfundime kërkimesh dhe faqe "
-"listë"
+msgid "Visible to everyone on {0} and included in search results and listing pages"
+msgstr "E dukshme për këdo te {0} dhe e përfshirë në përfundime kërkimesh dhe faqe listë"
 
 #: src/olympia/devhub/templates/devhub/versions/list.html:108
 msgid "Hidden:"
 msgstr "E fshehur:"
 
 #: src/olympia/devhub/templates/devhub/versions/list.html:108
-msgid ""
-"Hosted on {0}, but hidden to anyone but authors. Used to temporarily hide "
-"listings or discontinue them."
-msgstr ""
-"E strehuar te {0}, por e padukshme për këdo tjetër veç autorëve. E përdorur "
-"për fshehje të përkohshme në lista ose për heqje prej tyre."
+msgid "Hosted on {0}, but hidden to anyone but authors. Used to temporarily hide listings or discontinue them."
+msgstr "E strehuar te {0}, por e padukshme për këdo tjetër veç autorëve. E përdorur për fshehje të përkohshme në lista ose për heqje prej tyre."
 
 #: src/olympia/devhub/templates/devhub/versions/list.html:114
 msgid "Unlisted:"
 msgstr "E paparaqitur:"
 
 #: src/olympia/devhub/templates/devhub/versions/list.html:114
-msgid ""
-"Not distributed on {0}. Developers will upload new versions for signing and "
-"distribute the add-ons on their own. (beta)"
+msgid "Not distributed on {0}. Developers will upload new versions for signing and distribute the add-ons on their own."
 msgstr ""
-"Nuk shpërndahet në {0}. Versionet e reja të shtesave zhvilluesit do t’i "
-"ngarkojnë për nënshkrim dhe do t’i shpërndajnë vetë. (beta)"
 
 #: src/olympia/devhub/templates/devhub/versions/list.html:122
 msgid "Current versions"
@@ -9085,18 +6913,13 @@ msgstr "Versione të tanishëm"
 msgid "Currently on AMO"
 msgstr "Në AMO"
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:129
-#: src/olympia/devhub/templates/devhub/versions/list.html:147
-#: src/olympia/devhub/templates/devhub/versions/list.html:164
-#: src/olympia/editors/templates/editors/includes/search_results_themes.html:7
-#: src/olympia/editors/templates/editors/themes/queue_list.html:50
+#: src/olympia/devhub/templates/devhub/versions/list.html:129 src/olympia/devhub/templates/devhub/versions/list.html:147 src/olympia/devhub/templates/devhub/versions/list.html:164
+#: src/olympia/editors/templates/editors/includes/search_results_themes.html:7 src/olympia/editors/templates/editors/themes/queue_list.html:50
 msgid "Status"
 msgstr "Gjendje"
 
 # Header for a column in a table
-#: src/olympia/devhub/templates/devhub/versions/list.html:130
-#: src/olympia/devhub/templates/devhub/versions/list.html:148
-#: src/olympia/devhub/templates/devhub/versions/list.html:165
+#: src/olympia/devhub/templates/devhub/versions/list.html:130 src/olympia/devhub/templates/devhub/versions/list.html:148 src/olympia/devhub/templates/devhub/versions/list.html:165
 #: src/olympia/editors/templates/editors/includes/files_view.html:11
 msgid "Validation"
 msgstr "Vleftësim"
@@ -9118,14 +6941,10 @@ msgid "Full review may not be required"
 msgstr "Mund të mos jetë i domosdoshëm shqyrtimi i plotë"
 
 #: src/olympia/devhub/templates/devhub/versions/list.html:201
-msgid ""
-"Unlisted add-ons don't need Full Review unless they are distributed as part "
-"of an application installer. Read <a href=\"{link}\" target=\"_blank\">this "
-"documentation</a> for more information."
+msgid "Unlisted add-ons don't need Full Review unless they are distributed as part of an application installer. Read <a href=\"{link}\" target=\"_blank\">this documentation</a> for more information."
 msgstr ""
-"Shtesat e paklasifikuara s’kanë nevojë për Shqyrtim të Plotë, hiq rastin kur"
-" shpërndahen si pjesë e një instaluesi aplikacionesh. Për më tepër të dhëna,"
-" lexoni <a href=\"{link}\" target=\"_blank\">këtë dokumentim</a>."
+"Shtesat e paklasifikuara s’kanë nevojë për Shqyrtim të Plotë, hiq rastin kur shpërndahen si pjesë e një instaluesi aplikacionesh. Për më tepër të dhëna, lexoni <a href=\"{link}\" target=\"_blank"
+"\">këtë dokumentim</a>."
 
 #: src/olympia/devhub/templates/devhub/versions/list.html:209
 msgid "Request full review"
@@ -9138,133 +6957,90 @@ msgstr "Fshijeni Versionin {version}"
 
 #: src/olympia/devhub/templates/devhub/versions/list.html:218
 msgid ""
-"You are about to delete the current version of your add-on. This may cause "
-"your add-on status to change, or your listing to lose public visibility, if "
-"this is the only public version of your add-on."
+"You are about to delete the current version of your add-on. This may cause your add-on status to change, or your listing to lose public visibility, if this is the only public version of your add-on."
 msgstr ""
-"Ju ndan një hap nga fshirja e versionit të tanishëm të shtesës suaj. Kjo "
-"mund sjellë ndryshimin e gjendjes së shtesës suaj, ose të shkaktojë "
-"mosshfaqjen e saj publikisht, nëse ky është i vetmi version publik i shtesës"
-" suaj."
+"Ju ndan një hap nga fshirja e versionit të tanishëm të shtesës suaj. Kjo mund sjellë ndryshimin e gjendjes së shtesës suaj, ose të shkaktojë mosshfaqjen e saj publikisht, nëse ky është i vetmi "
+"version publik i shtesës suaj."
 
 #: src/olympia/devhub/templates/devhub/versions/list.html:219
 msgid "Deleting this version will permanently delete:"
 msgstr "Fshirja e këtij versioni do të fshijë përgjithmonë:"
 
 #: src/olympia/devhub/templates/devhub/versions/list.html:225
-msgid ""
-"<strong>Important:</strong> Once a version has been deleted, you may not "
-"upload a new version with the same version number."
-msgstr ""
-"<strong>E rëndësishme:</strong> Pasi një version të jetë fshirë, s’mund të "
-"ngarkoni një version të ri me të atë numër versioni."
+msgid "<strong>Important:</strong> Once a version has been deleted, you may not upload a new version with the same version number."
+msgstr "<strong>E rëndësishme:</strong> Pasi një version të jetë fshirë, s’mund të ngarkoni një version të ri me të atë numër versioni."
 
 #: src/olympia/devhub/templates/devhub/versions/list.html:230
-msgid ""
-"Deleting a version which has already been reviewed\n"
-"               may also cause a significant delay in the review of\n"
-"               your next update."
-msgstr ""
-"Fshirja e një versioni, i cili është shqyrtuar tashmë, mund të shkaktojë një"
-" vonesë domethënëse në shqyrtimin e përditësimit tuaj pasues."
-
-#: src/olympia/devhub/templates/devhub/versions/list.html:233
 msgid "Are you sure you wish to delete this version?"
 msgstr "Jeni i sigurt se doni të fshihet ky version?"
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:238
+#: src/olympia/devhub/templates/devhub/versions/list.html:235
 msgid "Delete Version"
 msgstr "Fshije Versionin"
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:240
+#: src/olympia/devhub/templates/devhub/versions/list.html:237
 msgid "Disable Version"
 msgstr "Çaktivizoje Versionin"
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:247
+#: src/olympia/devhub/templates/devhub/versions/list.html:244
 msgid "Add a new Version"
 msgstr "Shtoni Version të ri"
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:249
+#: src/olympia/devhub/templates/devhub/versions/list.html:246
 msgid "Add Version"
 msgstr "Shtoni Version"
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:256
-#: src/olympia/devhub/templates/devhub/versions/list.html:274
+#: src/olympia/devhub/templates/devhub/versions/list.html:253 src/olympia/devhub/templates/devhub/versions/list.html:279
 msgid "Hide Add-on"
 msgstr "Fshiheni Shtesën"
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:259
-msgid ""
-"Hiding your add-on will prevent it from appearing anywhere in our gallery "
-"and will stop users from receiving automatic updates."
-msgstr ""
-"Fshehja e shtesës suaj do t’i pengojë asaj shfaqjen në galerinë tonë dhe "
-"përdoruesve marrjen e përditësimeve të vetvetishme."
+#: src/olympia/devhub/templates/devhub/versions/list.html:256
+msgid "Hiding your add-on will prevent it from appearing anywhere in our gallery and will stop users from receiving automatic updates."
+msgstr "Fshehja e shtesës suaj do t’i pengojë asaj shfaqjen në galerinë tonë dhe përdoruesve marrjen e përditësimeve të vetvetishme."
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:265
+#: src/olympia/devhub/templates/devhub/versions/list.html:263
+msgid "The files awaiting review will be disabled and you will need to upload new versions."
+msgstr ""
+
+#: src/olympia/devhub/templates/devhub/versions/list.html:270
 msgid "Are you sure you wish to hide your add-on?"
 msgstr "Jeni i sigurt se doni të fshihet shtesa juaj?"
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:286
-#: src/olympia/devhub/templates/devhub/versions/list.html:315
+#: src/olympia/devhub/templates/devhub/versions/list.html:291 src/olympia/devhub/templates/devhub/versions/list.html:313
 msgid "Unlist Add-on"
 msgstr "Hiqeni Shtesën Nga Listat"
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:289
+#: src/olympia/devhub/templates/devhub/versions/list.html:294
 #, python-format
 msgid ""
-"Unlisting your add-on will make it (and each of its versions/files) "
-"invisible on this website. It won't show up in searches, won't have a public"
-" facing page, and won't be updated automatically for current users.  It is "
-"recommended for unlisted add-ons to provide a custom <a "
-"href=\"%(update_url)s\" target=\"_blank\">updateURL</a> in their manifest "
-"file for automatic updates."
+"Unlisting your add-on will make it (and each of its versions/files) invisible on this website. It won't show up in searches, won't have a public facing page, and won't be updated automatically for "
+"current users. It is recommended for unlisted add-ons to provide a custom <a href=\"%(update_url)s\" target=\"_blank\">updateURL</a> in their manifest file for automatic updates."
 msgstr ""
-"Heqja e shtesës suaj nga listat do ta bëjë atë (dhe çdo version/kartelë të "
-"saj) të padukshme në këtë sajt. S’do të duket në kërkime, s’do të ketë një "
-"faqe publike, dhe s’do të përditësohet vetvetiu për përdoruesit e "
-"deritanishëm. Për shtesa të hequra prej liste këshillohet dhënia e një <a "
-"href=\"%(update_url)s\" target=\"_blank\">updateURL</a> të përshtatur, te "
-"kartela e saj manifest, për përditësime të vetvetishme."
+"Heqja e shtesës suaj nga listat do ta bëjë atë (dhe çdo version/kartelë të saj) të padukshme në këtë sajt. S’do të duket në kërkime, s’do të ketë një faqe publike, dhe s’do të përditësohet vetvetiu "
+"për përdoruesit e deritanishëm. Për shtesa të hequra prej liste këshillohet dhënia e një <a href=\"%(update_url)s\" target=\"_blank\">updateURL</a> të përshtatur, te kartela e saj manifest, për "
+"përditësime të vetvetishme."
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:299
-#, python-format
-msgid ""
-"Switching add-ons to unlisted is currently in an open beta. Please <a "
-"href=\"%(url)s\" target=\"_blank\">report any bugs</a> that you encounter."
-msgstr ""
-
-#: src/olympia/devhub/templates/devhub/versions/list.html:305
+#: src/olympia/devhub/templates/devhub/versions/list.html:303
 msgid "Unlisting an add-on is irreversible!"
 msgstr "Heqja e një shtese nga listat është e pakthyeshme!"
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:305
+#: src/olympia/devhub/templates/devhub/versions/list.html:303
 msgid "An unlisted add-on cannot be switched to be listed."
 msgstr "Një temë e hequr nga listat s’mund të rikalohet në lista."
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:307
+#: src/olympia/devhub/templates/devhub/versions/list.html:305
 msgid "Are you sure you wish to unlist your add-on?"
 msgstr "Jeni i sigurt se doni të hiqet shtesa juaj nga lista?"
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:330
-msgid ""
-"Canceling your review request will leave your add-on as preliminarily "
-"reviewed."
-msgstr ""
-"Anulimi i kërkesës suaj për shqyrtim do ta lërë shtesën tuaj si të shqyrtuar"
-" paraprakisht."
+#: src/olympia/devhub/templates/devhub/versions/list.html:328
+msgid "Canceling your review request will leave your add-on as preliminarily reviewed."
+msgstr "Anulimi i kërkesës suaj për shqyrtim do ta lërë shtesën tuaj si të shqyrtuar paraprakisht."
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:335
-msgid ""
-"Canceling your review request will mark your add-on incomplete. If you do "
-"not complete your add-on after several days by re-requesting review, it will"
-" be deleted."
-msgstr ""
-"Anulimi i kërkesës suaj për shqyrtim do ta ricaktojë gjendjen e shtesës suaj"
-" si jo e plotë. Nëse s’e plotësoni shtesën tuaj pas disa ditësh, duke "
-"rikërkuar shqyrtim të saj, ajo do të fshihet."
+#: src/olympia/devhub/templates/devhub/versions/list.html:333
+msgid "Canceling your review request will mark your add-on incomplete. If you do not complete your add-on after several days by re-requesting review, it will be deleted."
+msgstr "Anulimi i kërkesës suaj për shqyrtim do ta ricaktojë gjendjen e shtesës suaj si jo e plotë. Nëse s’e plotësoni shtesën tuaj pas disa ditësh, duke rikërkuar shqyrtim të saj, ajo do të fshihet."
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:343
+#: src/olympia/devhub/templates/devhub/versions/list.html:341
 msgid "Are you sure you wish to cancel your review request?"
 msgstr "Jeni i sigurt se dëshironi të anulohet kërkesa juaj për shqyrtim?"
 
@@ -9297,19 +7073,12 @@ msgid "Translate content on the web from and into over 40 languages."
 msgstr "Përktheni lëndë web-i në mbi 40 gjuhë."
 
 #: src/olympia/discovery/modules.py:171
-msgid ""
-"Easily connect to your social networks, and share or comment on the page "
-"you're visiting."
-msgstr ""
-"Lidhuni kollaj me rrjetet tuaja shoqërore, dhe komentoni, ose ndajeni me të "
-"tjerët, faqen që po vizitoni."
+msgid "Easily connect to your social networks, and share or comment on the page you're visiting."
+msgstr "Lidhuni kollaj me rrjetet tuaja shoqërore, dhe komentoni, ose ndajeni me të tjerët, faqen që po vizitoni."
 
 #: src/olympia/discovery/modules.py:173
-msgid ""
-"A quick view to compare prices when you shop online or search for flights."
-msgstr ""
-"Vështrim i shpejtë për të krahasuar çmimet kur blini në linjë ose kur "
-"kërkoni për fluturime."
+msgid "A quick view to compare prices when you shop online or search for flights."
+msgstr "Vështrim i shpejtë për të krahasuar çmimet kur blini në linjë ose kur kërkoni për fluturime."
 
 #: src/olympia/discovery/modules.py:183
 msgid "Firefox 4 Collection"
@@ -9352,24 +7121,16 @@ msgid "Add-ons that help you on your travels!"
 msgstr "Shtesa që ju ndihmojnë gjatë udhëtimeve tuaja!"
 
 #: src/olympia/discovery/modules.py:226
-msgid ""
-"Displays a country flag depicting the location of the current website's "
-"server and more."
-msgstr ""
-"Shfaq një flamur shteti që simbolizon vendoren e shërbyesit të tanishëm të "
-"sajtit dhe të tjera."
+msgid "Displays a country flag depicting the location of the current website's server and more."
+msgstr "Shfaq një flamur shteti që simbolizon vendoren e shërbyesit të tanishëm të sajtit dhe të tjera."
 
 #: src/olympia/discovery/modules.py:228
 msgid "FoxClocks let you keep an eye on the time around the world."
 msgstr "FoxClocks ju lejon t’i hidhni një sy orës anembanë botës."
 
 #: src/olympia/discovery/modules.py:230
-msgid ""
-"Automatically get the lowest price when you shop online or search for "
-"flights."
-msgstr ""
-"Njihuni automatikisht me çmimet më të ulëta kur blini në linjë ose kur "
-"kërkoni për fluturime."
+msgid "Automatically get the lowest price when you shop online or search for flights."
+msgstr "Njihuni automatikisht me çmimet më të ulëta kur blini në linjë ose kur kërkoni për fluturime."
 
 #: src/olympia/discovery/modules.py:240
 msgid "A+ add-ons for School"
@@ -9408,12 +7169,8 @@ msgid "Put a Theme on It!"
 msgstr ""
 
 #: src/olympia/discovery/modules.py:281
-msgid ""
-"Visit addons.mozilla.org from Firefox for Android and dress up your mobile "
-"browser to match your style, mood, or the season."
-msgstr ""
-"Vizitoni addons.mozilla.org prej Firefox-it për Android dhe zbukurojeni "
-"shfletuesin e celularit tuaj që të përputhet me humorin tuaj, ose me stinën."
+msgid "Visit addons.mozilla.org from Firefox for Android and dress up your mobile browser to match your style, mood, or the season."
+msgstr "Vizitoni addons.mozilla.org prej Firefox-it për Android dhe zbukurojeni shfletuesin e celularit tuaj që të përputhet me humorin tuaj, ose me stinën."
 
 #: src/olympia/discovery/modules.py:290
 msgid "Get up and move!"
@@ -9421,9 +7178,7 @@ msgstr "Ngrihu dhe lëviz!"
 
 #: src/olympia/discovery/modules.py:291
 msgid "Install these fitness add-ons to keep you active and healthy."
-msgstr ""
-"Instaloni këto shtesa që lidhen me mbajtjen e trupit në formë, që të jeni "
-"aktivë dhe të shëndetshëm."
+msgstr "Instaloni këto shtesa që lidhen me mbajtjen e trupit në formë, që të jeni aktivë dhe të shëndetshëm."
 
 #: src/olympia/discovery/modules.py:299
 msgid "New &amp; Now"
@@ -9442,12 +7197,8 @@ msgid "Protect your privacy online with the add-ons in this collection."
 msgstr "Mbroni, me shtesat e këtij koleksioni, privatësinë tuaj në linjë."
 
 #: src/olympia/discovery/modules.py:342
-msgid ""
-"Great add-ons for work, fun, privacy, productivity&hellip; just about "
-"anything!"
-msgstr ""
-"Shtesa të fuqishme për punë, dëfrim, privatësi, prodhueshmëri&hellip; për "
-"gjithçhka!"
+msgid "Great add-ons for work, fun, privacy, productivity&hellip; just about anything!"
+msgstr "Shtesa të fuqishme për punë, dëfrim, privatësi, prodhueshmëri&hellip; për gjithçhka!"
 
 #: src/olympia/discovery/modules.py:350
 msgid "Add-ons for Australis Contest Winners"
@@ -9467,22 +7218,16 @@ msgstr "Ç’janë Shtesat?"
 
 #: src/olympia/discovery/templates/discovery/pane.html:28
 #, python-format
-msgid ""
-"Add-ons are applications that let you personalize %(app)s with extra "
-"functionality or style. Try a time-saving sidebar, a weather notifier, or a "
-"themed look to make %(app)s your own."
+msgid "Add-ons are applications that let you personalize %(app)s with extra functionality or style. Try a time-saving sidebar, a weather notifier, or a themed look to make %(app)s your own."
 msgstr ""
-"Shtesat janë aplikacione që ju lejojnë të personalizoni %(app)s me funksione"
-" ose stil ekstra. Provoni një anështyllë që bën diçka e ju kursen kohë, një "
-"njoftues moti, ose një pamje sipas një tematike të caktuar, që ta bëni "
-"%(app)s si e doni."
+"Shtesat janë aplikacione që ju lejojnë të personalizoni %(app)s me funksione ose stil ekstra. Provoni një anështyllë që bën diçka e ju kursen kohë, një njoftues moti, ose një pamje sipas një "
+"tematike të caktuar, që ta bëni %(app)s si e doni."
 
 #: src/olympia/discovery/templates/discovery/pane.html:62
 msgid "Learn More About Add-ons"
 msgstr "Mësoni Më Tepër Rreth Shtesave"
 
-#: src/olympia/discovery/templates/discovery/pane.html:66
-#: src/olympia/discovery/templates/discovery/pane.html:73
+#: src/olympia/discovery/templates/discovery/pane.html:66 src/olympia/discovery/templates/discovery/pane.html:73
 msgid "See all"
 msgstr "Shihini krejt"
 
@@ -9513,12 +7258,8 @@ msgstr "Tungjatjeta, {0}"
 
 #: src/olympia/discovery/templates/discovery/pane_account.html:17
 #, python-format
-msgid ""
-"Thanks for using %(app)s and supporting <a href=\"%(url)s\">Mozilla's "
-"mission</a>!"
-msgstr ""
-"Faleminderit që përdorni %(app)s dhe që përkrahni <a "
-"href=\"%(url)s\">misionin e Mozilla-s</a>!"
+msgid "Thanks for using %(app)s and supporting <a href=\"%(url)s\">Mozilla's mission</a>!"
+msgstr "Faleminderit që përdorni %(app)s dhe që përkrahni <a href=\"%(url)s\">misionin e Mozilla-s</a>!"
 
 #: src/olympia/discovery/templates/discovery/pane_account.html:23
 msgid "Add-ons downloaded:"
@@ -9542,14 +7283,10 @@ msgstr "Merrni Shtesat Me Vete"
 
 #: src/olympia/discovery/templates/discovery/modules/go-mobile.html:8
 #, python-format
-msgid ""
-"Visit <a href=\"%(url)s\">firefox.com/m</a> to get Firefox on your phone and"
-" personalize your browser anytime, anywhere. Easily discover and install "
-"add-ons from the mobile Add-ons Manager."
+msgid "Visit <a href=\"%(url)s\">firefox.com/m</a> to get Firefox on your phone and personalize your browser anytime, anywhere. Easily discover and install add-ons from the mobile Add-ons Manager."
 msgstr ""
-"Vizitoni <a href=\"%(url)s\">firefox.com/m</a> që ta merrni Firefox-in te "
-"telefoni juaj dhe që të personalizoni shfletuesin tuaj kurdi, kudo. Zbuloni "
-"dhe instaloni me lehtësi shtesa për celular prej Përgjegjësit të Shtesave."
+"Vizitoni <a href=\"%(url)s\">firefox.com/m</a> që ta merrni Firefox-in te telefoni juaj dhe që të personalizoni shfletuesin tuaj kurdi, kudo. Zbuloni dhe instaloni me lehtësi shtesa për celular "
+"prej Përgjegjësit të Shtesave."
 
 #: src/olympia/discovery/templates/discovery/modules/go-mobile.html:13
 msgid "Get Mobile Add-ons"
@@ -9561,25 +7298,15 @@ msgstr "Këtë sezon festash bëni shpenzime të mençura"
 
 #: src/olympia/discovery/templates/discovery/modules/holiday.html:5
 msgid "Find great add-ons to help you with all your holiday shopping needs."
-msgstr ""
-"Gjeni shtesa të shkëlqyera që t’ju ndihmojnë me krejt nevojat e shpenzimeve "
-"për festat."
+msgstr "Gjeni shtesa të shkëlqyera që t’ju ndihmojnë me krejt nevojat e shpenzimeve për festat."
 
 #: src/olympia/discovery/templates/discovery/modules/holiday.html:13
-msgid ""
-"Install the Amazon Browser Apps and receive special Amazon features right at"
-" your fingertips."
-msgstr ""
-"Instaloni Amazon Browser Apps dhe përfitoni duke pasur në majë të gishtave "
-"veçori speciale Amazon."
+msgid "Install the Amazon Browser Apps and receive special Amazon features right at your fingertips."
+msgstr "Instaloni Amazon Browser Apps dhe përfitoni duke pasur në majë të gishtave veçori speciale Amazon."
 
 #: src/olympia/discovery/templates/discovery/modules/holiday.html:22
-msgid ""
-"Keep an eye on your eBay activity wherever you are on the web when you "
-"install the eBay Sidebar for Firefox."
-msgstr ""
-"Mbani nën vëzhgim veprimtarinë tuaj te eBay, kurdoherë që jeni në web, pasi "
-"të instaloni eBay Sidebar për Firefox."
+msgid "Keep an eye on your eBay activity wherever you are on the web when you install the eBay Sidebar for Firefox."
+msgstr "Mbani nën vëzhgim veprimtarinë tuaj te eBay, kurdoherë që jeni në web, pasi të instaloni eBay Sidebar për Firefox."
 
 #: src/olympia/discovery/templates/discovery/modules/holiday.html:31
 msgid "See the entire holiday shopping add-on collection."
@@ -9656,19 +7383,19 @@ msgstr "shtesë, redaktor ose koment"
 msgid "Search by add-on name / author email"
 msgstr "Kërkoni sipas emrash / email-esh autorësh të shtesës"
 
-#: src/olympia/editors/forms.py:103
+#: src/olympia/editors/forms.py:103 src/olympia/editors/forms.py:244 src/olympia/editors/forms.py:257
 msgid "yes"
 msgstr "po"
 
-#: src/olympia/editors/forms.py:104
+#: src/olympia/editors/forms.py:104 src/olympia/editors/forms.py:244 src/olympia/editors/forms.py:257
 msgid "no"
 msgstr "jo"
 
-#: src/olympia/editors/forms.py:105
+#: src/olympia/editors/forms.py:105 src/olympia/editors/forms.py:245
 msgid "Admin Flag"
 msgstr "Shenjë nga Përgjegjësi"
 
-#: src/olympia/editors/forms.py:113
+#: src/olympia/editors/forms.py:113 src/olympia/editors/forms.py:253
 msgid "Max. Version"
 msgstr "Version Maksimum"
 
@@ -9680,59 +7407,59 @@ msgstr "Ditë Që Prej Parashtrimit"
 msgid "Add-on Types"
 msgstr "Lloje Shtesash"
 
-#: src/olympia/editors/forms.py:126 src/olympia/editors/helpers.py:267
+#: src/olympia/editors/forms.py:126 src/olympia/editors/helpers.py:279
 msgid "Platforms"
 msgstr "Platforma"
 
+#: src/olympia/editors/forms.py:237
+msgid "Search by add-on name / author email / guid"
+msgstr ""
+
 #. L10n: 0 = platform, 1 = filename, 2 = status message
-#: src/olympia/editors/forms.py:238
+#: src/olympia/editors/forms.py:342
 #, python-format
 msgid "<strong>%s</strong> &middot; %s &middot; %s"
 msgstr "<strong>%s</strong> &middot; %s &middot; %s"
 
-#: src/olympia/editors/forms.py:252
+#: src/olympia/editors/forms.py:356
 msgid "Comments:"
 msgstr "Komente:"
 
-#: src/olympia/editors/forms.py:256
+#: src/olympia/editors/forms.py:360
 msgid "Operating systems:"
 msgstr "Sisteme operativë:"
 
-#: src/olympia/editors/forms.py:258
+#: src/olympia/editors/forms.py:362
 msgid "Applications:"
 msgstr "Aplikacione:"
 
-#: src/olympia/editors/forms.py:260
-msgid ""
-"Notify me the next time this add-on is updated. (Subsequent updates will not"
-" generate an email)"
-msgstr ""
-"Njoftomë herës tjetër që përditësohet kjo shtesë. (Përditësimet e "
-"njëpasnjëshme s’do të shoqërohen me email.)"
+#: src/olympia/editors/forms.py:364
+msgid "Notify me the next time this add-on is updated. (Subsequent updates will not generate an email)"
+msgstr "Njoftomë herës tjetër që përditësohet kjo shtesë. (Përditësimet e njëpasnjëshme s’do të shoqërohen me email.)"
 
-#: src/olympia/editors/forms.py:265
+#: src/olympia/editors/forms.py:369
 msgid "Clear Admin Review Flag"
 msgstr "Hiqi Shenjën Për Shqyrtim Redaktori"
 
-#: src/olympia/editors/forms.py:267
+#: src/olympia/editors/forms.py:371
 msgid "Clear more info requested flag"
 msgstr "Hiqjani shenjën e kërkesës për më tepër të dhëna"
 
-#: src/olympia/editors/forms.py:281
+#: src/olympia/editors/forms.py:385
 msgid "Choose a canned response..."
 msgstr "Zgjidhni një përgjigje të gatshme..."
 
 #. L10n: Description of what can be searched for.
-#: src/olympia/editors/forms.py:324
+#: src/olympia/editors/forms.py:423
 msgid "theme name"
 msgstr "emër teme"
 
-#: src/olympia/editors/forms.py:350
+#: src/olympia/editors/forms.py:449
 msgid "Someone else is reviewing this theme."
 msgstr "Dikush tjetër po e shqyrton këtë temë."
 
 #. L10n: Description of what can be searched for.
-#: src/olympia/editors/forms.py:447
+#: src/olympia/editors/forms.py:546
 msgid "app, reviewer, or comment"
 msgstr "aplikacion, shqyrtues, ose koment"
 
@@ -9748,297 +7475,268 @@ msgstr "Në Pritje të Shqyrtimit Paraprak"
 msgid "Rejected or Unreviewed"
 msgstr "Hedhur Tej ose e Pashqyrtuar"
 
-#: src/olympia/editors/helpers.py:123 src/olympia/editors/helpers.py:136
+#: src/olympia/editors/helpers.py:125 src/olympia/editors/helpers.py:138
 msgid "Queue"
 msgstr "Radhë"
 
-#: src/olympia/editors/helpers.py:124
-#: src/olympia/editors/templates/editors/base.html:50
-#: src/olympia/editors/templates/editors/base.html:65
+#: src/olympia/editors/helpers.py:126 src/olympia/editors/templates/editors/base.html:50 src/olympia/editors/templates/editors/base.html:65
 msgid "Pending Updates"
 msgstr "Përditësim Në Radhë"
 
-#: src/olympia/editors/helpers.py:125
-#: src/olympia/editors/templates/editors/base.html:48
-#: src/olympia/editors/templates/editors/base.html:63
+#: src/olympia/editors/helpers.py:127 src/olympia/editors/templates/editors/base.html:48 src/olympia/editors/templates/editors/base.html:63
 msgid "Full Reviews"
 msgstr "Shqyrtime të Plota"
 
-#: src/olympia/editors/helpers.py:126
-#: src/olympia/editors/templates/editors/base.html:52
-#: src/olympia/editors/templates/editors/base.html:67
+#: src/olympia/editors/helpers.py:128 src/olympia/editors/templates/editors/base.html:52 src/olympia/editors/templates/editors/base.html:67
 msgid "Preliminary Reviews"
 msgstr "Shqyrtime Paraprake"
 
 # %1 is the review count
-#: src/olympia/editors/helpers.py:127
-#: src/olympia/editors/templates/editors/base.html:54
+#: src/olympia/editors/helpers.py:129 src/olympia/editors/templates/editors/base.html:54
 msgid "Moderated Reviews"
 msgstr "Shqyrtime të Moderuara"
 
-#: src/olympia/editors/helpers.py:128
-#: src/olympia/editors/templates/editors/base.html:46
+#: src/olympia/editors/helpers.py:130 src/olympia/editors/templates/editors/base.html:46
 msgid "Fast Track"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:130
+#: src/olympia/editors/helpers.py:132
 msgid "Pending Themes"
 msgstr "Tema Në Pritje"
 
-#: src/olympia/editors/helpers.py:131
-#: src/olympia/editors/templates/editors/themes/queue.html:4
+#: src/olympia/editors/helpers.py:133 src/olympia/editors/templates/editors/themes/queue.html:4
 msgid "Flagged Themes"
 msgstr "Tema Me Shenjë"
 
-#: src/olympia/editors/helpers.py:132
+#: src/olympia/editors/helpers.py:134
 msgid "Update Themes"
 msgstr "Përditësoni Tema"
 
-#: src/olympia/editors/helpers.py:137
+#: src/olympia/editors/helpers.py:139
 msgid "Unlisted Pending Updates"
 msgstr "Përditësime të Paklasifikuarash Në Pritje"
 
-#: src/olympia/editors/helpers.py:138
+#: src/olympia/editors/helpers.py:140
 msgid "Unlisted Full Reviews"
 msgstr "Shqyrtime të Plota të Paklasifikuarash"
 
-#: src/olympia/editors/helpers.py:139
+#: src/olympia/editors/helpers.py:141
 msgid "Unlisted Preliminary Reviews"
 msgstr "Shqyrtime Paraprake të Paklasifikuarash"
 
-#: src/olympia/editors/helpers.py:170
+#: src/olympia/editors/helpers.py:142
+msgid "Unlisted All Add-ons"
+msgstr ""
+
+#: src/olympia/editors/helpers.py:173
 msgid "Fast Track ({0})"
 msgid_plural "Fast Track ({0})"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/olympia/editors/helpers.py:175
+#: src/olympia/editors/helpers.py:178
 msgid "Full Review ({0})"
 msgid_plural "Full Reviews ({0})"
 msgstr[0] "Shqyrtim i Plotë ({0})"
 msgstr[1] "Shqyrtime të Plota ({0})"
 
-#: src/olympia/editors/helpers.py:180
+#: src/olympia/editors/helpers.py:183
 msgid "Pending Update ({0})"
 msgid_plural "Pending Updates ({0})"
 msgstr[0] "Përditësim Në Pritje ({0})"
 msgstr[1] "Përditësime Në Pritje ({0})"
 
-#: src/olympia/editors/helpers.py:185
+#: src/olympia/editors/helpers.py:188
 msgid "Preliminary Review ({0})"
 msgid_plural "Preliminary Reviews ({0})"
 msgstr[0] "Shqyrtim Paraprak ({0})"
 msgstr[1] "Shqyrtime Paraprake ({0})"
 
-#: src/olympia/editors/helpers.py:190
+#: src/olympia/editors/helpers.py:193
 msgid "Moderated Review ({0})"
 msgid_plural "Moderated Reviews ({0})"
 msgstr[0] "Shqyrtim i Moderuar ({0})"
 msgstr[1] "Shqyrtime të Moderuara ({0})"
 
-#: src/olympia/editors/helpers.py:196
+#: src/olympia/editors/helpers.py:199
 msgid "Unlisted Full Review ({0})"
 msgid_plural "Unlisted Full Reviews ({0})"
 msgstr[0] "Shqyrtim i Plotë të Paklasifikuare ({0})"
 msgstr[1] "Shqyrtime të Plota të Paklasifikuarash ({0})"
 
-#: src/olympia/editors/helpers.py:201
+#: src/olympia/editors/helpers.py:204
 msgid "Unlisted Pending Update ({0})"
 msgid_plural "Unlisted Pending Updates ({0})"
 msgstr[0] "Përditësim Në Pritje për të Paklasifikuar ({0})"
 msgstr[1] "Përditësime Në Pritje për të Paklasifikuara ({0})"
 
-#: src/olympia/editors/helpers.py:206
+#: src/olympia/editors/helpers.py:209
 msgid "Unlisted Preliminary Review ({0})"
 msgid_plural "Unlisted Preliminary Reviews ({0})"
 msgstr[0] "Shqyrtim Paraprak për të Paklasifikuar ({0})"
 msgstr[1] "Shqyrtime Paraprake për të Paklasifikuara ({0})"
 
-#: src/olympia/editors/helpers.py:261
-msgid "Addon"
-msgstr "Shtesë"
+#: src/olympia/editors/helpers.py:214
+msgid "Unlisted All Add-ons ({0})"
+msgid_plural "Unlisted All Add-ons ({0})"
+msgstr[0] ""
+msgstr[1] ""
 
-#: src/olympia/editors/helpers.py:262
+#: src/olympia/editors/helpers.py:274
 msgid "Type"
 msgstr "Lloj"
 
-#: src/olympia/editors/helpers.py:263
+#: src/olympia/editors/helpers.py:275
 msgid "Waiting Time"
 msgstr "Kohë Pritjeje"
 
-#: src/olympia/editors/helpers.py:264
-#: src/olympia/editors/templates/editors/review.html:285
+#: src/olympia/editors/helpers.py:276 src/olympia/editors/templates/editors/review.html:285
 msgid "Flags"
 msgstr "Flamurka"
 
-#: src/olympia/editors/helpers.py:265
+#: src/olympia/editors/helpers.py:277
 msgid "Applications"
 msgstr "Aplikacione"
 
-#: src/olympia/editors/helpers.py:270
+#: src/olympia/editors/helpers.py:282
 msgid "Additional"
 msgstr "Shtesë"
 
-#: src/olympia/editors/helpers.py:285
+#: src/olympia/editors/helpers.py:302
 msgid "Site Specific"
 msgstr "Për një Sajt të Dhënë"
 
-#: src/olympia/editors/helpers.py:287
+#: src/olympia/editors/helpers.py:304
 msgid "Requires External Software"
 msgstr "Lyp Software të Jashtëm"
 
-#: src/olympia/editors/helpers.py:289
+#: src/olympia/editors/helpers.py:306
 msgid "Binary Components"
 msgstr "Përbërës Dyorë"
 
-#: src/olympia/editors/helpers.py:313
+#: src/olympia/editors/helpers.py:339
 msgid "moments ago"
 msgstr "çaste më parë"
 
 #. L10n: first argument is number of minutes
-#: src/olympia/editors/helpers.py:316
+#: src/olympia/editors/helpers.py:342
 msgid "{0} minute"
 msgid_plural "{0} minutes"
 msgstr[0] "{0} minutë"
 msgstr[1] "{0} minuta"
 
 #. L10n: first argument is number of hours
-#: src/olympia/editors/helpers.py:320
+#: src/olympia/editors/helpers.py:346
 msgid "{0} hour"
 msgid_plural "{0} hours"
 msgstr[0] "{0} orë"
 msgstr[1] "{0} orë"
 
 #. L10n: first argument is number of days
-#: src/olympia/editors/helpers.py:324
+#: src/olympia/editors/helpers.py:350
 msgid "{0} day"
 msgid_plural "{0} days"
 msgstr[0] "{0} ditë"
 msgstr[1] "{0} ditë"
 
-#: src/olympia/editors/helpers.py:488
+#: src/olympia/editors/helpers.py:364
+msgid "Last Review"
+msgstr ""
+
+#: src/olympia/editors/helpers.py:366
+msgid "Last Update"
+msgstr ""
+
+#: src/olympia/editors/helpers.py:387
+msgid "No Reviews"
+msgstr ""
+
+#: src/olympia/editors/helpers.py:561
 msgid "Push to public"
 msgstr "Kaloje publike"
 
-#: src/olympia/editors/helpers.py:490
+#: src/olympia/editors/helpers.py:563
 msgid "Grant full review"
 msgstr "Akordojini shqyrtimit të plotë"
 
-#: src/olympia/editors/helpers.py:505
+#: src/olympia/editors/helpers.py:578
 msgid "Request more information"
 msgstr "Kërko më tepër të dhëna"
 
-#: src/olympia/editors/helpers.py:508
+#: src/olympia/editors/helpers.py:581
 msgid "Request super-review"
 msgstr "Kërkoni super-shqyrtim"
 
-#: src/olympia/editors/helpers.py:519
+#: src/olympia/editors/helpers.py:592
 msgid "Grant preliminary review"
 msgstr "Jepi shqyrtim paraprak"
 
-#: src/olympia/editors/helpers.py:520
+#: src/olympia/editors/helpers.py:593
 msgid "This will mark the files as preliminarily reviewed."
 msgstr "Kjo do t’i shënonte kartelat si të shqyrtuara paraprakisht."
 
-#: src/olympia/editors/helpers.py:522
-msgid ""
-"Use this form to request more information from the author. They will receive"
-" an email and be able to answer here. You will be notified by email when "
-"they reply."
-msgstr ""
-"Përdorni këtë formular për të kërkuar më tepër të dhëna prej autorit. Ai do "
-"të marrë një email dhe do të mundë t’ju përgjigjet këtu. Kur të përgjigjet, "
-"do të njoftoheni me email."
+#: src/olympia/editors/helpers.py:595
+msgid "Use this form to request more information from the author. They will receive an email and be able to answer here. You will be notified by email when they reply."
+msgstr "Përdorni këtë formular për të kërkuar më tepër të dhëna prej autorit. Ai do të marrë një email dhe do të mundë t’ju përgjigjet këtu. Kur të përgjigjet, do të njoftoheni me email."
 
-#: src/olympia/editors/helpers.py:526
+#: src/olympia/editors/helpers.py:599
 msgid ""
-"If you have concerns about this add-on's security, copyright issues, or "
-"other concerns that an administrator should look into, enter your comments "
-"in the area below. They will be sent to administrators, not the author."
+"If you have concerns about this add-on's security, copyright issues, or other concerns that an administrator should look into, enter your comments in the area below. They will be sent to "
+"administrators, not the author."
 msgstr ""
-"Nëse keni shqetësime rreth sigurisë së kësaj shtese, problemesh me të "
-"drejtat e kopjimit, ose shqetësime të tjera të cilat duhet t’i shohë një "
-"administrator, jepini komentet tuaja në zonën më poshtë. Ato do t’u dërgohen"
-" administratorëve, jo autorit."
+"Nëse keni shqetësime rreth sigurisë së kësaj shtese, problemesh me të drejtat e kopjimit, ose shqetësime të tjera të cilat duhet t’i shohë një administrator, jepini komentet tuaja në zonën më "
+"poshtë. Ato do t’u dërgohen administratorëve, jo autorit."
 
-#: src/olympia/editors/helpers.py:532
+#: src/olympia/editors/helpers.py:605
 msgid "This will reject the add-on and remove it from the review queue."
-msgstr ""
-"Kështu do të hidhet tej shtesa dhe do të hiqet prej radhës së shqyrtimeve."
+msgstr "Kështu do të hidhet tej shtesa dhe do të hiqet prej radhës së shqyrtimeve."
 
-#: src/olympia/editors/helpers.py:534
-msgid "Make a comment on this version.  The author won't be able to see this."
-msgstr ""
-"Bëni një koment mbi këtë version. Autori nuk do të jetë në gjendje ta shohë "
-"këtë."
+#: src/olympia/editors/helpers.py:607
+msgid "Make a comment on this version. The author won't be able to see this."
+msgstr "Bëni një koment mbi këtë version. Autori nuk do të jetë në gjendje ta shohë këtë."
 
-#: src/olympia/editors/helpers.py:538
+#: src/olympia/editors/helpers.py:611
 msgid "This will reject the files and remove them from the review queue."
-msgstr ""
-"Kështu do të hidhen tej kartelat dhe do të hiqen prej radhës së shqyrtimeve."
+msgstr "Kështu do të hidhen tej kartelat dhe do të hiqen prej radhës së shqyrtimeve."
 
-#: src/olympia/editors/helpers.py:542
-msgid ""
-"This will mark the add-on as preliminarily reviewed. Future versions will "
-"undergo preliminary review."
-msgstr ""
-"Kështu shtesa do të shënohet si e shqyrtuar paraprakisht. Versionet e "
-"ardhshme do të kalojnë nën shqyrtim paraprak."
+#: src/olympia/editors/helpers.py:615
+msgid "This will mark the add-on as preliminarily reviewed. Future versions will undergo preliminary review."
+msgstr "Kështu shtesa do të shënohet si e shqyrtuar paraprakisht. Versionet e ardhshme do të kalojnë nën shqyrtim paraprak."
 
-#: src/olympia/editors/helpers.py:547
-msgid ""
-"This will mark the files as preliminarily reviewed. Future versions will "
-"undergo preliminary review."
-msgstr ""
-"Kështu kartelat do të shënohen si të shqyrtuara paraprakisht. Versionet e "
-"ardhshme do të kalojnë nën shqyrtim paraprak."
+#: src/olympia/editors/helpers.py:620
+msgid "This will mark the files as preliminarily reviewed. Future versions will undergo preliminary review."
+msgstr "Kështu kartelat do të shënohen si të shqyrtuara paraprakisht. Versionet e ardhshme do të kalojnë nën shqyrtim paraprak."
 
-#: src/olympia/editors/helpers.py:552
+#: src/olympia/editors/helpers.py:625
 msgid "Retain preliminary review"
 msgstr "Mbaja shqyrtimin paraprak"
 
-#: src/olympia/editors/helpers.py:553
-msgid ""
-"This will retain the add-on as preliminarily reviewed. Future versions will "
-"undergo preliminary review."
-msgstr ""
-"Kjo do ta mbajë shtesën si të shqyrtuar paraprakisht. Versionet e ardhshme "
-"do të kalojnë nën shqyrtim paraprak."
+#: src/olympia/editors/helpers.py:626
+msgid "This will retain the add-on as preliminarily reviewed. Future versions will undergo preliminary review."
+msgstr "Kjo do ta mbajë shtesën si të shqyrtuar paraprakisht. Versionet e ardhshme do të kalojnë nën shqyrtim paraprak."
 
-#: src/olympia/editors/helpers.py:558
-msgid ""
-"This will approve a sandboxed version of a public add-on to appear on the "
-"public side."
-msgstr ""
-"Kjo do të miratojë shfaqjen në pjesën publike të një versioni bankëprovë të "
-"një shtese publike."
+#: src/olympia/editors/helpers.py:631
+msgid "This will approve a sandboxed version of a public add-on to appear on the public side."
+msgstr "Kjo do të miratojë shfaqjen në pjesën publike të një versioni bankëprovë të një shtese publike."
 
-#: src/olympia/editors/helpers.py:561
-msgid ""
-"This will reject a version of a public add-on and remove it from the queue."
-msgstr ""
-"Kështu do të hidhet tej një version i një shtese publike dhe do të hiqet ajo"
-" prej radhës."
-
-#: src/olympia/editors/helpers.py:564
-msgid ""
-"This will mark the add-on and its most recent version and files as public. "
-"Future versions will go into the sandbox until they are reviewed by an "
-"editor."
-msgstr ""
-"Me këtë, shtesa dhe versioni më i fundit, së bashku me kartelat përkatëse, "
-"do të shfaqen si publike. Versione të ardhshme do të kalohen në bankëprovë, "
-"deri sa të jenë shqyrtuar nga një redaktor."
+#: src/olympia/editors/helpers.py:634
+msgid "This will reject a version of a public add-on and remove it from the queue."
+msgstr "Kështu do të hidhet tej një version i një shtese publike dhe do të hiqet ajo prej radhës."
 
 #: src/olympia/editors/helpers.py:637
+msgid "This will mark the add-on and its most recent version and files as public. Future versions will go into the sandbox until they are reviewed by an editor."
+msgstr ""
+"Me këtë, shtesa dhe versioni më i fundit, së bashku me kartelat përkatëse, do të shfaqen si publike. Versione të ardhshme do të kalohen në bankëprovë, deri sa të jenë shqyrtuar nga një redaktor."
+
+#: src/olympia/editors/helpers.py:714
 msgid "add-on"
 msgstr "shtesë"
 
-#: src/olympia/editors/helpers.py:940 src/olympia/editors/helpers.py:960
+#: src/olympia/editors/helpers.py:1020 src/olympia/editors/helpers.py:1040
 msgid "Flagged"
 msgstr "Me Shenjë"
 
-#: src/olympia/editors/helpers.py:944 src/olympia/editors/helpers.py:963
+#: src/olympia/editors/helpers.py:1024 src/olympia/editors/helpers.py:1043
 msgid "Updates"
 msgstr "Përditësime"
 
@@ -10090,76 +7788,70 @@ msgstr "Parashtrim teme me shenjë të vënë për shqyrtim"
 msgid "A question about your Theme submission"
 msgstr "Një pyetje rreth parashtrimit të Temës suaj"
 
-#: src/olympia/editors/views.py:144
+#: src/olympia/editors/views.py:146
 msgid "New Add-ons (Under 5 days)"
 msgstr "Shtesa të Reja (Nën 5 ditë)"
 
-#: src/olympia/editors/views.py:145
+#: src/olympia/editors/views.py:147
 msgid "Passable (5 to 10 days)"
 msgstr "Ende në lojë (5 deri në 10 ditë)"
 
-#: src/olympia/editors/views.py:146
+#: src/olympia/editors/views.py:148
 msgid "Overdue (Over 10 days)"
 msgstr "Të kaluara (10 ditë e më tepër)"
 
-#: src/olympia/editors/views.py:532
+#: src/olympia/editors/views.py:539
 msgid "An unknown error occurred"
 msgstr "Ndodhi një gabim i panjohur"
 
-#: src/olympia/editors/views.py:587
+#: src/olympia/editors/views.py:592
 msgid "Self-reviews are not allowed."
 msgstr "Nuk lejohen shqyrtime nga vetja."
 
-#: src/olympia/editors/views.py:609
+#: src/olympia/editors/views.py:613
 msgid "Review successfully processed."
 msgstr "Shqyrtimi u krye me sukses."
 
-#: src/olympia/editors/views.py:807
+#: src/olympia/editors/views.py:812
 msgid "was approved"
 msgstr "qe miratuar"
 
-#: src/olympia/editors/views.py:808
+#: src/olympia/editors/views.py:813
 msgid "given preliminary review"
 msgstr "pati shqyrtim paraprak"
 
-#: src/olympia/editors/views.py:809
+#: src/olympia/editors/views.py:814
 msgid "rejected"
 msgstr "hedhur poshtë"
 
-#: src/olympia/editors/views.py:810
+#: src/olympia/editors/views.py:815
 msgctxt "editors_review_history_nominated_adminreview"
 msgid "escalated"
 msgstr "shtyrë përpara"
 
-#: src/olympia/editors/views.py:812
+#: src/olympia/editors/views.py:817
 msgid "needs more information"
 msgstr "lyp më tepër të dhëna"
 
-#: src/olympia/editors/views.py:813
+#: src/olympia/editors/views.py:818
 msgid "needs super review"
 msgstr "lyp super-shqyrtim"
 
-#: src/olympia/editors/views.py:814
+#: src/olympia/editors/views.py:819
 msgid "commented"
 msgstr ""
 
 #: src/olympia/editors/views_themes.py:326
 msgid "{0} theme review successfully processed (+{1} points, {2} total)."
-msgid_plural ""
-"{0} theme reviews successfully processed (+{1} points, {2} total)."
+msgid_plural "{0} theme reviews successfully processed (+{1} points, {2} total)."
 msgstr[0] "U përpunua me sukses {0} shqyrtim teme (+{1} pikë, {2} gjithsej)."
-msgstr[1] ""
-"U përpunuan me sukses {0} shqyrtime temash (+{1} pikë, {2} gjithsej)."
+msgstr[1] "U përpunuan me sukses {0} shqyrtime temash (+{1} pikë, {2} gjithsej)."
 
 #: src/olympia/editors/views_themes.py:341
-msgid ""
-"Your theme locks have successfully been released. Other reviewers may now "
-"review those released themes. You may have to refresh the page to see the "
-"changes reflected in the table below."
+msgid "Your theme locks have successfully been released. Other reviewers may now review those released themes. You may have to refresh the page to see the changes reflected in the table below."
 msgstr ""
-"Bllokimet mbi temën tuaj u hoqën me sukses. Tani shqyrtues të tjerë mund të "
-"shqyrtojnë këto tema të zhbllokuara. Mund t’ju duhet të rifreskoni faqen që "
-"ndryshimet t’i shihni të pasqyruara te tabela më poshtë."
+"Bllokimet mbi temën tuaj u hoqën me sukses. Tani shqyrtues të tjerë mund të shqyrtojnë këto tema të zhbllokuara. Mund t’ju duhet të rifreskoni faqen që ndryshimet t’i shihni të pasqyruara te tabela "
+"më poshtë."
 
 #: src/olympia/editors/templates/editors/abuse_reports.html:4
 msgid "{addon} :: Abuse Reports"
@@ -10183,9 +7875,7 @@ msgstr "<i>anonim</i> më %(date)s [%(ip_address)s]"
 msgid "Return to the Editor Tools homepage"
 msgstr "Kthehuni te faqja hyrëse e Mjeteve të Redaktorit"
 
-#: src/olympia/editors/templates/editors/base.html:43
-#: src/olympia/editors/templates/editors/themes/base.html:14
-#: src/olympia/editors/templates/editors/themes/base.html:28
+#: src/olympia/editors/templates/editors/base.html:43 src/olympia/editors/templates/editors/themes/base.html:14 src/olympia/editors/templates/editors/themes/base.html:28
 #: src/olympia/editors/templates/editors/themes/queue.html:25
 msgid "Queues"
 msgstr "Radhët"
@@ -10194,71 +7884,51 @@ msgstr "Radhët"
 msgid "Unlisted Queues"
 msgstr "Radhë të Paklasifikuarash"
 
-#: src/olympia/editors/templates/editors/base.html:72
-#: src/olympia/editors/templates/editors/performance.html:6
+#: src/olympia/editors/templates/editors/base.html:74 src/olympia/editors/templates/editors/performance.html:6
 msgid "Performance"
 msgstr "Suksesshmëri"
 
-#: src/olympia/editors/templates/editors/base.html:75
-#: src/olympia/editors/templates/editors/themes/base.html:19
-#: src/olympia/editors/templates/editors/themes/base.html:38
+#: src/olympia/editors/templates/editors/base.html:77 src/olympia/editors/templates/editors/themes/base.html:19 src/olympia/editors/templates/editors/themes/base.html:38
 msgid "Logs"
 msgstr "Regjistrime"
 
-#: src/olympia/editors/templates/editors/base.html:78
-#: src/olympia/editors/templates/editors/reviewlog.html:4
-#: src/olympia/editors/templates/editors/reviewlog.html:27
+#: src/olympia/editors/templates/editors/base.html:80 src/olympia/editors/templates/editors/reviewlog.html:4 src/olympia/editors/templates/editors/reviewlog.html:27
 msgid "Add-on Review Log"
 msgstr "Regjistër Shqyrtimesh Shtese"
 
-#: src/olympia/editors/templates/editors/base.html:80
-#: src/olympia/editors/templates/editors/eventlog.html:4
-#: src/olympia/editors/templates/editors/eventlog.html:8
+#: src/olympia/editors/templates/editors/base.html:82 src/olympia/editors/templates/editors/eventlog.html:4 src/olympia/editors/templates/editors/eventlog.html:8
 #: src/olympia/editors/templates/editors/eventlog_detail.html:4
 msgid "Moderated Review Log"
 msgstr "U moderua Regjistri i Shqyrtimeve"
 
-#: src/olympia/editors/templates/editors/base.html:82
-#: src/olympia/editors/templates/editors/beta_signed_log.html:4
-#: src/olympia/editors/templates/editors/beta_signed_log.html:8
+#: src/olympia/editors/templates/editors/base.html:84 src/olympia/editors/templates/editors/beta_signed_log.html:4 src/olympia/editors/templates/editors/beta_signed_log.html:8
 msgid "Signed Beta Files Log"
 msgstr "Regjistër Nënshkrimesh Kartelash Beta"
 
-#: src/olympia/editors/templates/editors/base.html:87
-#: src/olympia/editors/templates/editors/includes/daily-message.html:4
+#: src/olympia/editors/templates/editors/base.html:89 src/olympia/editors/templates/editors/includes/daily-message.html:4
 msgid "Announcement"
 msgstr "Njoftim"
 
 #. "Filter" is a button label (verb)
-#: src/olympia/editors/templates/editors/beta_signed_log.html:17
-#: src/olympia/editors/templates/editors/eventlog.html:24
-#: src/olympia/editors/templates/editors/reviewlog.html:21
-#: src/olympia/editors/templates/editors/themes/macros.html:45
-#: src/olympia/editors/templates/editors/themes/includes/logs_filter_deleted.html:12
+#: src/olympia/editors/templates/editors/beta_signed_log.html:17 src/olympia/editors/templates/editors/eventlog.html:24 src/olympia/editors/templates/editors/reviewlog.html:21
+#: src/olympia/editors/templates/editors/themes/macros.html:45 src/olympia/editors/templates/editors/themes/includes/logs_filter_deleted.html:12
 msgid "Filter"
 msgstr "Filtër"
 
-#: src/olympia/editors/templates/editors/beta_signed_log.html:23
-#: src/olympia/editors/templates/editors/eventlog.html:30
-#: src/olympia/editors/templates/editors/reviewlog.html:34
+#: src/olympia/editors/templates/editors/beta_signed_log.html:23 src/olympia/editors/templates/editors/eventlog.html:30 src/olympia/editors/templates/editors/reviewlog.html:34
 #: src/olympia/editors/templates/editors/themes/logs.html:16
 msgid "Date"
 msgstr "Datë"
 
-#: src/olympia/editors/templates/editors/beta_signed_log.html:24
-#: src/olympia/editors/templates/editors/eventlog.html:31
-#: src/olympia/editors/templates/editors/reviewlog.html:35
+#: src/olympia/editors/templates/editors/beta_signed_log.html:24 src/olympia/editors/templates/editors/eventlog.html:31 src/olympia/editors/templates/editors/reviewlog.html:35
 msgid "Event"
 msgstr "Ngjarje"
 
-#: src/olympia/editors/templates/editors/beta_signed_log.html:37
-#: src/olympia/editors/templates/editors/eventlog.html:44
-#: src/olympia/editors/templates/editors/home.html:180
+#: src/olympia/editors/templates/editors/beta_signed_log.html:37 src/olympia/editors/templates/editors/eventlog.html:44 src/olympia/editors/templates/editors/home.html:180
 msgid "More details."
 msgstr "Më tepër hollësi."
 
-#: src/olympia/editors/templates/editors/beta_signed_log.html:46
-#: src/olympia/editors/templates/editors/eventlog.html:53
+#: src/olympia/editors/templates/editors/beta_signed_log.html:46 src/olympia/editors/templates/editors/eventlog.html:53
 msgid "No events found for this period."
 msgstr "S’u gjetën ngjarje për këtë periudhë."
 
@@ -10308,20 +7978,17 @@ msgid_plural "Preliminary Reviews ({num})"
 msgstr[0] "Shqyrtim Paraprak ({num})"
 msgstr[1] "Shqyrtime Paraprake ({num})"
 
-#: src/olympia/editors/templates/editors/home.html:36
-#: src/olympia/editors/templates/editors/home.html:86
+#: src/olympia/editors/templates/editors/home.html:36 src/olympia/editors/templates/editors/home.html:86
 msgid "Current waiting times:"
 msgstr "Kohë pritjeje hëpërhë:"
 
-#: src/olympia/editors/templates/editors/home.html:44
-#: src/olympia/editors/templates/editors/home.html:94
+#: src/olympia/editors/templates/editors/home.html:44 src/olympia/editors/templates/editors/home.html:94
 msgid "{0} add-on"
 msgid_plural "{0} add-ons"
 msgstr[0] "{0} shtesë"
 msgstr[1] "{0} shtesa"
 
-#: src/olympia/editors/templates/editors/home.html:45
-#: src/olympia/editors/templates/editors/home.html:95
+#: src/olympia/editors/templates/editors/home.html:45 src/olympia/editors/templates/editors/home.html:95
 #, python-format
 msgid "{0}%%"
 msgstr "{0}%%"
@@ -10344,14 +8011,11 @@ msgid_plural "Unlisted Preliminary Reviews ({num})"
 msgstr[0] "Shqyrtim Paraprak për të Paklasifikuar ({num})"
 msgstr[1] "Shqyrtime Paraprake për të Paklasifikuara ({num})"
 
-#: src/olympia/editors/templates/editors/home.html:109
-#: src/olympia/editors/templates/editors/performance.html:37
-#: src/olympia/editors/templates/editors/themes/home.html:54
+#: src/olympia/editors/templates/editors/home.html:109 src/olympia/editors/templates/editors/performance.html:37 src/olympia/editors/templates/editors/themes/home.html:54
 msgid "Total Reviews"
 msgstr "Shqyrtime Gjithsej"
 
-#: src/olympia/editors/templates/editors/home.html:110
-#: src/olympia/editors/templates/editors/themes/home.html:55
+#: src/olympia/editors/templates/editors/home.html:110 src/olympia/editors/templates/editors/themes/home.html:55
 msgid "Reviews This Month"
 msgstr "Shqyrtime Këtë Muaj"
 
@@ -10359,8 +8023,7 @@ msgstr "Shqyrtime Këtë Muaj"
 msgid "New Editors"
 msgstr "Redaktorë të Rinj"
 
-#: src/olympia/editors/templates/editors/home.html:126
-#: src/olympia/editors/templates/editors/home.html:141
+#: src/olympia/editors/templates/editors/home.html:126 src/olympia/editors/templates/editors/home.html:141
 msgid "You're #{0} with {1} reviews"
 msgstr "Jeni #{0} me {1} shqyrtues"
 
@@ -10371,13 +8034,11 @@ msgid_plural "Moderated Reviews ({num})"
 msgstr[0] "Shqyrtim i Moderuar ({num})"
 msgstr[1] "Shqyrtime të Moderuara ({num})"
 
-#: src/olympia/editors/templates/editors/leaderboard.html:3
-#: src/olympia/editors/templates/editors/includes/reviewers_score_bar.html:56
+#: src/olympia/editors/templates/editors/leaderboard.html:3 src/olympia/editors/templates/editors/includes/reviewers_score_bar.html:56
 msgid "Reviewer Leaderboard"
 msgstr "Klasifikim Shqyrtuesish"
 
-#: src/olympia/editors/templates/editors/leaderboard.html:18
-#: src/olympia/editors/templates/editors/performance.html:65
+#: src/olympia/editors/templates/editors/leaderboard.html:18 src/olympia/editors/templates/editors/performance.html:65
 msgid "No review points awarded yet."
 msgstr "Ende pa pikë shqyrtuesi të akorduara."
 
@@ -10397,8 +8058,7 @@ msgstr "Mesazhi i Ditës"
 msgid "Update message of the day"
 msgstr "Mesazhi i sotëm i përditësimit"
 
-#: src/olympia/editors/templates/editors/motd.html:15
-#: src/olympia/editors/templates/editors/review.html:224
+#: src/olympia/editors/templates/editors/motd.html:15 src/olympia/editors/templates/editors/review.html:224
 msgid "Save"
 msgstr "Ruaje"
 
@@ -10466,51 +8126,45 @@ msgstr "Kërkim i Mëtejshëm"
 msgid "clear search"
 msgstr "pastro kërkimin"
 
-#: src/olympia/editors/templates/editors/queue.html:72
-#: src/olympia/editors/templates/editors/queue.html:122
+#: src/olympia/editors/templates/editors/queue.html:78 src/olympia/editors/templates/editors/queue.html:128
 msgid "Process Reviews"
 msgstr "Përpunoni Shqyrtime"
 
-#: src/olympia/editors/templates/editors/queue.html:80
+#: src/olympia/editors/templates/editors/queue.html:86
 msgid "Moderation actions:"
 msgstr "Veprime moderimi:"
 
-#: src/olympia/editors/templates/editors/queue.html:90
+#: src/olympia/editors/templates/editors/queue.html:96
 #, python-format
 msgid "by %(user)s on %(date)s %(stars)s (%(locale)s)"
 msgstr "nga %(user)s më %(date)s %(stars)s (%(locale)s)"
 
-#: src/olympia/editors/templates/editors/queue.html:106
+#: src/olympia/editors/templates/editors/queue.html:112
 #, python-format
-msgid ""
-"<strong>%(reason)s</strong> <span class=\"light\">Flagged by %(user)s on "
-"%(date)s</span>"
-msgstr ""
-"<strong>%(reason)s</strong> <span class=\"light\">I është vënë shenjë nga "
-"%(user)s më %(date)s</span>"
+msgid "<strong>%(reason)s</strong> <span class=\"light\">Flagged by %(user)s on %(date)s</span>"
+msgstr "<strong>%(reason)s</strong> <span class=\"light\">I është vënë shenjë nga %(user)s më %(date)s</span>"
 
-#: src/olympia/editors/templates/editors/queue.html:119
-msgid "All reviews have been moderated.  Good work!"
+#: src/olympia/editors/templates/editors/queue.html:125
+msgid "All reviews have been moderated. Good work!"
 msgstr "U moderuan krejt shqyrtimet. Punë e paqme!"
 
-#: src/olympia/editors/templates/editors/queue.html:161
+#: src/olympia/editors/templates/editors/queue.html:167
 msgid "Version Notes / Notes for Reviewer"
 msgstr "Shënime Versioni / Shënime për Shqyrtuesin"
 
-#: src/olympia/editors/templates/editors/queue.html:169
+#: src/olympia/editors/templates/editors/queue.html:175
 msgid "There are currently no add-ons of this type to review."
 msgstr "Hëpërhë s’ka shtesa të këtij lloji për shqyrtim."
 
-#: src/olympia/editors/templates/editors/queue.html:181
-#: src/olympia/editors/templates/editors/themes/queue_list.html:85
+#: src/olympia/editors/templates/editors/queue.html:187 src/olympia/editors/templates/editors/themes/queue_list.html:85
 msgid "Helpful Links:"
 msgstr "Lidhje të Dobishme:"
 
-#: src/olympia/editors/templates/editors/queue.html:182
+#: src/olympia/editors/templates/editors/queue.html:188
 msgid "Add-on Policy"
 msgstr "Rregulla Shtese"
 
-#: src/olympia/editors/templates/editors/queue.html:184
+#: src/olympia/editors/templates/editors/queue.html:190
 msgid "Editors' Guide"
 msgstr "Udhërrëfyes Redaktorësh"
 
@@ -10523,19 +8177,14 @@ msgstr "Shqyrtoni {0}"
 msgid "Add-on user change history"
 msgstr "Historik ndryshimes përdoruesi shtese"
 
-#: src/olympia/editors/templates/editors/review.html:52
-#: src/olympia/editors/templates/editors/review.html:266
+#: src/olympia/editors/templates/editors/review.html:52 src/olympia/editors/templates/editors/review.html:266
 msgid "Add-on History"
 msgstr "Historik Shtese"
 
 #: src/olympia/editors/templates/editors/review.html:64
 #, python-format
-msgid ""
-"Version %(version)s &middot; %(created)s <span class=\"light\">&middot; "
-"%(version_status)s</span>"
-msgstr ""
-"Version %(version)s &middot; %(created)s <span class=\"light\">&middot; "
-"%(version_status)s</span>"
+msgid "Version %(version)s &middot; %(created)s <span class=\"light\">&middot; %(version_status)s</span>"
+msgstr "Version %(version)s &middot; %(created)s <span class=\"light\">&middot; %(version_status)s</span>"
 
 #: src/olympia/editors/templates/editors/review.html:73
 msgid "Compatibility:"
@@ -10558,19 +8207,14 @@ msgid "This version has not been reviewed."
 msgstr "Ky version s’është shqyrtuar."
 
 #: src/olympia/editors/templates/editors/review.html:154
-msgid ""
-"You can still submit this form, however only do so if you know it won't "
-"conflict."
-msgstr ""
-"Mundeni prapë ta parashtroni këtë formular, megjithatë, këtë bëjeni, nëse e "
-"dini që s’do të ketë përplasje."
+msgid "You can still submit this form, however only do so if you know it won't conflict."
+msgstr "Mundeni prapë ta parashtroni këtë formular, megjithatë, këtë bëjeni, nëse e dini që s’do të ketë përplasje."
 
 #: src/olympia/editors/templates/editors/review.html:161
 msgid "Insert canned response..."
 msgstr "Fusni përgjigje të gatshme..."
 
-#: src/olympia/editors/templates/editors/review.html:167
-#: src/olympia/files/templates/files/viewer.html:54
+#: src/olympia/editors/templates/editors/review.html:167 src/olympia/files/templates/files/viewer.html:54
 msgid "Files:"
 msgstr "Kartela:"
 
@@ -10579,28 +8223,18 @@ msgid "Tested on:"
 msgstr "Provuar me:"
 
 #: src/olympia/editors/templates/editors/review.html:220
-msgid ""
-"<strong>Warning!</strong> Another user was viewing this page before you."
-msgstr ""
-"<strong>Kujdes!</strong> Para jush, këtë faqe po e shihte një tjetër "
-"përdorues."
+msgid "<strong>Warning!</strong> Another user was viewing this page before you."
+msgstr "<strong>Kujdes!</strong> Para jush, këtë faqe po e shihte një tjetër përdorues."
 
 #: src/olympia/editors/templates/editors/review.html:237
-msgid ""
-"The whiteboard is the place to exchange information relevant to\n"
-"               this addon (whatever the version), between the developer and the\n"
-"               editor. This is visible and editable by both."
-msgstr ""
-"Tabela është vendi i duhur për shkëmbim të dhënash me rëndësi për këtë "
-"shtesë (cilido qoftë versioni), mes zhvilluesit dhe redaktorit. Atë e shohin"
-" dhe mund ta përpunojnë që të dy."
+msgid "The whiteboard is the place to exchange information relevant to this addon (whatever the version), between the developer and the editor. This is visible and editable by both."
+msgstr "Tabela është vendi i duhur për shkëmbim të dhënash me rëndësi për këtë shtesë (cilido qoftë versioni), mes zhvilluesit dhe redaktorit. Atë e shohin dhe mund ta përpunojnë që të dy."
 
 #: src/olympia/editors/templates/editors/review.html:241
 msgid "Update the whiteboard"
 msgstr "Përditësoni tabelën"
 
-#: src/olympia/editors/templates/editors/review.html:257
-#: src/olympia/editors/templates/editors/review.html:258
+#: src/olympia/editors/templates/editors/review.html:257 src/olympia/editors/templates/editors/review.html:258
 msgid "(admin)"
 msgstr "(admin)"
 
@@ -10628,18 +8262,15 @@ msgstr "Redaktor"
 msgid "Add-on has been deleted."
 msgstr "Shtesa është fshirë."
 
-#: src/olympia/editors/templates/editors/reviewlog.html:59
-#: src/olympia/editors/templates/editors/themes/logs.html:36
+#: src/olympia/editors/templates/editors/reviewlog.html:59 src/olympia/editors/templates/editors/themes/logs.html:36
 msgid "Show Comments"
 msgstr "Shfaqi Komentet"
 
-#: src/olympia/editors/templates/editors/reviewlog.html:60
-#: src/olympia/editors/templates/editors/themes/logs.html:37
+#: src/olympia/editors/templates/editors/reviewlog.html:60 src/olympia/editors/templates/editors/themes/logs.html:37
 msgid "Hide Comments"
 msgstr "Fshihi Komentet"
 
-#: src/olympia/editors/templates/editors/reviewlog.html:72
-#: src/olympia/editors/templates/editors/themes/logs.html:54
+#: src/olympia/editors/templates/editors/reviewlog.html:72 src/olympia/editors/templates/editors/themes/logs.html:54
 msgid "No reviews found for this period."
 msgstr "S’u gjetën shqyrtime për këtë periudhë."
 
@@ -10697,11 +8328,8 @@ msgstr "Krejt Kohën"
 msgid "You have <span>{0}</span> points."
 msgstr "Keni <span>{0}</span> pikë."
 
-#: src/olympia/editors/templates/editors/includes/search_results_themes.html:6
-#: src/olympia/editors/templates/editors/themes/history_table.html:7
-#: src/olympia/editors/templates/editors/themes/logs.html:19
-#: src/olympia/editors/templates/editors/themes/queue_list.html:49
-#: src/olympia/editors/templates/editors/themes/single.html:26
+#: src/olympia/editors/templates/editors/includes/search_results_themes.html:6 src/olympia/editors/templates/editors/themes/history_table.html:7
+#: src/olympia/editors/templates/editors/themes/logs.html:19 src/olympia/editors/templates/editors/themes/queue_list.html:49 src/olympia/editors/templates/editors/themes/single.html:26
 #: src/olympia/editors/templates/editors/themes/themes.html:45
 msgid "Reviewer"
 msgstr "Shqyrtues"
@@ -10726,8 +8354,7 @@ msgstr "Historik Shqyrtimesh Teme për {0}"
 msgid "Review Date"
 msgstr "Datë Shqyrtimi"
 
-#: src/olympia/editors/templates/editors/themes/history_table.html:9
-#: src/olympia/editors/templates/editors/themes/logs.html:18
+#: src/olympia/editors/templates/editors/themes/history_table.html:9 src/olympia/editors/templates/editors/themes/logs.html:18
 msgid "Action"
 msgstr "Veprim"
 
@@ -10874,7 +8501,7 @@ msgstr "Bëjini artistit një pyete"
 msgid "Describe your reason for flagging"
 msgstr "Përshkruani arsyen tuaj për vënien shenjë"
 
-#: src/olympia/files/forms.py:88
+#: src/olympia/files/forms.py:90
 msgid "Cannot diff a version against itself"
 msgstr "Nuk mund të kryhet diff kundrejt vetvetes"
 
@@ -10892,12 +8519,8 @@ msgid "Problems decoding {0}."
 msgstr "Probleme me shkodimin e {0}."
 
 #: src/olympia/files/helpers.py:186
-msgid ""
-"This file is not viewable online. Please download the file to view the "
-"contents."
-msgstr ""
-"Kjo kartelë s’mund të shihet në linjë. Ju lutemi,shkarkojeni kartelën që t’i"
-" shihni lëndën."
+msgid "This file is not viewable online. Please download the file to view the contents."
+msgstr "Kjo kartelë s’mund të shihet në linjë. Ju lutemi,shkarkojeni kartelën që t’i shihni lëndën."
 
 #: src/olympia/files/helpers.py:194
 msgid "This file is a directory."
@@ -10913,55 +8536,51 @@ msgstr "Pati një gabim në përdorimin e kartelës %s. %s."
 msgid "There was an error accessing file %s."
 msgstr "Pati një gabim në përdorimin e kartelës %s."
 
-#: src/olympia/files/utils.py:343
+#: src/olympia/files/utils.py:340
 msgid "Could not parse uploaded file."
 msgstr "S’u përtyp dot kartela e ngarkuar."
 
-#: src/olympia/files/utils.py:380
+#: src/olympia/files/utils.py:377
 msgid "Invalid file name in archive: {0}"
 msgstr "Emër i pavlefshëm kartele te arkivi: {0}"
 
-#: src/olympia/files/utils.py:388
+#: src/olympia/files/utils.py:385
 msgid "File exceeding size limit in archive: {0}"
 msgstr "Kartelë që tejkalon kufirin e madhësisë te arkivi: {0}"
 
-#: src/olympia/files/utils.py:439
+#: src/olympia/files/utils.py:436
 msgid "Invalid archive."
 msgstr "Arkiv i pavlefshëm."
 
-#: src/olympia/files/utils.py:529 src/olympia/files/utils.py:532
+#: src/olympia/files/utils.py:526 src/olympia/files/utils.py:529
 msgid "Could not parse the manifest file."
 msgstr "S’përtypi dot kartelën manifest."
 
-#: src/olympia/files/utils.py:551
+#: src/olympia/files/utils.py:548
 msgid "Could not find an add-on ID."
 msgstr "S’u gjet dot një ID Shtese."
 
-#: src/olympia/files/utils.py:554
+#: src/olympia/files/utils.py:551
 msgid "Add-on ID must be 64 characters or less."
 msgstr "ID-ja e shtesës duhet të jetë nga 64 shenja e poshtë."
 
-#: src/olympia/files/utils.py:556
+#: src/olympia/files/utils.py:553
 msgid "Add-on ID doesn't match add-on."
 msgstr "ID-ja e shtesës s’përputhet me shtesën."
 
-#: src/olympia/files/utils.py:564
+#: src/olympia/files/utils.py:561
 msgid "Duplicate add-on ID found."
 msgstr "U gjet ID e përsëdytur shtese."
 
-#: src/olympia/files/utils.py:567
+#: src/olympia/files/utils.py:564
 msgid "Version numbers should have fewer than 32 characters."
 msgstr "Numrat e versioneve duhet të jenë më pak se 32 shenja të gjatë."
 
-#: src/olympia/files/utils.py:570
-msgid ""
-"Version numbers should only contain letters, numbers, and these punctuation "
-"characters: +*.-_."
-msgstr ""
-"Numrat e versioneve do të duhej të përmbanin vetëm shkronja, numra, dhe nga "
-"këto shenja pikësimi: +*.-_."
+#: src/olympia/files/utils.py:567
+msgid "Version numbers should only contain letters, numbers, and these punctuation characters: +*.-_."
+msgstr "Numrat e versioneve do të duhej të përmbanin vetëm shkronja, numra, dhe nga këto shenja pikësimi: +*.-_."
 
-#: src/olympia/files/utils.py:587
+#: src/olympia/files/utils.py:584
 msgid "<em:type> doesn't match add-on"
 msgstr "<em:type> s’përputhet me shtesën"
 
@@ -10979,12 +8598,8 @@ msgstr "Shkarko {0}"
 
 #: src/olympia/files/templates/files/file.html:4
 #, python-format
-msgid ""
-"Version: %(version)s &bull; Size: %(size)s &bull; MD5 hash: %(md5)s &bull; "
-"Mimetype: %(mimetype)s"
-msgstr ""
-"Version: %(version)s &bull; Madhësi: %(size)s &bull; Hash MD5: %(md5)s "
-"&bull; Lloj MiME: %(mimetype)s"
+msgid "Version: %(version)s &bull; Size: %(size)s &bull; MD5 hash: %(md5)s &bull; Mimetype: %(mimetype)s"
+msgstr "Version: %(version)s &bull; Madhësi: %(size)s &bull; Hash MD5: %(md5)s &bull; Lloj MiME: %(mimetype)s"
 
 #: src/olympia/files/templates/files/viewer.html:4
 msgid "File Compare :: Editor tools"
@@ -11022,48 +8637,39 @@ msgstr "Version SDK-je Shtesash:"
 msgid "Tab stops:"
 msgstr "Ndalesa tab:"
 
-#: src/olympia/files/templates/files/viewer.html:79
-#: src/olympia/files/templates/files/viewer.html:80
+#: src/olympia/files/templates/files/viewer.html:79 src/olympia/files/templates/files/viewer.html:80
 msgid "Up file"
 msgstr "Ngri kartelë"
 
-#: src/olympia/files/templates/files/viewer.html:84
-#: src/olympia/files/templates/files/viewer.html:85
+#: src/olympia/files/templates/files/viewer.html:84 src/olympia/files/templates/files/viewer.html:85
 msgid "Down file"
 msgstr "Ul kartelë"
 
-#: src/olympia/files/templates/files/viewer.html:90
-#: src/olympia/files/templates/files/viewer.html:91
+#: src/olympia/files/templates/files/viewer.html:90 src/olympia/files/templates/files/viewer.html:91
 msgid "Previous diff"
 msgstr "Diff-i i mëparshëm"
 
-#: src/olympia/files/templates/files/viewer.html:93
-#: src/olympia/files/templates/files/viewer.html:94
+#: src/olympia/files/templates/files/viewer.html:93 src/olympia/files/templates/files/viewer.html:94
 msgid "Previous note"
 msgstr "Shënimi i mëparshëm"
 
-#: src/olympia/files/templates/files/viewer.html:100
-#: src/olympia/files/templates/files/viewer.html:101
+#: src/olympia/files/templates/files/viewer.html:100 src/olympia/files/templates/files/viewer.html:101
 msgid "Next diff"
 msgstr "Diff-i pasues"
 
-#: src/olympia/files/templates/files/viewer.html:103
-#: src/olympia/files/templates/files/viewer.html:104
+#: src/olympia/files/templates/files/viewer.html:103 src/olympia/files/templates/files/viewer.html:104
 msgid "Next note"
 msgstr "Shënimi pasues"
 
-#: src/olympia/files/templates/files/viewer.html:109
-#: src/olympia/files/templates/files/viewer.html:110
+#: src/olympia/files/templates/files/viewer.html:109 src/olympia/files/templates/files/viewer.html:110
 msgid "Expand all"
 msgstr "Zgjeroji të tëra"
 
-#: src/olympia/files/templates/files/viewer.html:114
-#: src/olympia/files/templates/files/viewer.html:115
+#: src/olympia/files/templates/files/viewer.html:114 src/olympia/files/templates/files/viewer.html:115
 msgid "Hide or unhide tree"
 msgstr "Shfaq ose fshih pemën"
 
-#: src/olympia/files/templates/files/viewer.html:119
-#: src/olympia/files/templates/files/viewer.html:120
+#: src/olympia/files/templates/files/viewer.html:119 src/olympia/files/templates/files/viewer.html:120
 msgid "Wrap or unwrap text"
 msgstr "Mbështill ose shmbështill tekstet"
 
@@ -11074,6 +8680,10 @@ msgstr "Pa kartela te kartela e ngarkuar."
 #: src/olympia/files/templates/files/viewer.html:134
 msgid "Fetching file."
 msgstr "Po sillet kartelë."
+
+#: src/olympia/legacy_api/views.py:255
+msgid "Not implemented yet."
+msgstr "Ende i pasendërtuar."
 
 #: src/olympia/lib/constants.py:6
 msgid "United Arab Emirates Dirham"
@@ -11731,12 +9341,7 @@ msgstr "Kuasha e Zambias"
 msgid "Zimbabwe Dollar"
 msgstr "Dollar i Zimbabves"
 
-#: src/olympia/lib/video/ffmpeg.py:112 src/olympia/lib/video/totem.py:81
-msgid "Videos must be in WebM."
-msgstr "Videot duhet të jenë në formatin WebM."
-
-#: src/olympia/pages/templates/pages/about.lhtml:3
-#: src/olympia/pages/templates/pages/about.lhtml:10
+#: src/olympia/pages/templates/pages/about.lhtml:3 src/olympia/pages/templates/pages/about.lhtml:10
 msgid "About Mozilla Add-ons"
 msgstr "Rreth Shtesave Mozilla"
 
@@ -11746,18 +9351,12 @@ msgstr "Për çfarë është ky sajt?"
 
 #: src/olympia/pages/templates/pages/about.lhtml:13
 msgid ""
-"addons.mozilla.org, commonly known as \"AMO\", is Mozilla's official site "
-"for add-ons to Mozilla software, such as Firefox, Thunderbird, and "
-"SeaMonkey. Add-ons let you add new features and change the way your browser "
-"or application works.  Take a look around and explore the thousands of ways "
-"to customize the way you do things online."
+"addons.mozilla.org, commonly known as \"AMO\", is Mozilla's official site for add-ons to Mozilla software, such as Firefox, Thunderbird, and SeaMonkey. Add-ons let you add new features and change "
+"the way your browser or application works. Take a look around and explore the thousands of ways to customize the way you do things online."
 msgstr ""
-"addons.mozilla.org, e njohur rëndom si \"AMO\", është sajti zyrtar i "
-"Mozilla-s për shtesa ndaj software-it Mozilla, të tillë si Firefox-i, "
-"Thunderbird-i, dhe SeaMonkey. Shtesat ju lejojnë të shtoni veçori të reja "
-"dhe të ndryshoni mënyrën me të cilën funksionon shfletuesi ose aplikacioni "
-"juaj. Hidhni një sy përreth dhe eksploroni mijëra mënyra për të "
-"personalizuar rrugën sipas të cilës bëni gjëra në linjë."
+"addons.mozilla.org, e njohur rëndom si \"AMO\", është sajti zyrtar i Mozilla-s për shtesa ndaj software-it Mozilla, të tillë si Firefox-i, Thunderbird-i, dhe SeaMonkey. Shtesat ju lejojnë të shtoni "
+"veçori të reja dhe të ndryshoni mënyrën me të cilën funksionon shfletuesi ose aplikacioni juaj. Hidhni një sy përreth dhe eksploroni mijëra mënyra për të personalizuar rrugën sipas të cilës bëni "
+"gjëra në linjë."
 
 #: src/olympia/pages/templates/pages/about.lhtml:19
 msgid "Who creates these add-ons?"
@@ -11765,104 +9364,66 @@ msgstr "Kush i krijon këto shtesa?"
 
 #: src/olympia/pages/templates/pages/about.lhtml:20
 msgid ""
-"The add-ons listed here have been created by thousands of developers from "
-"our community, ranging from individual hobbyists to large corporations. All "
-"publicly listed add-ons are reviewed by a team of editors before being "
-"released. Add-ons marked as Experimental have not been reviewed and should "
-"only be installed with caution."
+"The add-ons listed here have been created by thousands of developers from our community, ranging from individual hobbyists to large corporations. All publicly listed add-ons are reviewed by a team "
+"of editors before being released. Add-ons marked as Experimental have not been reviewed and should only be installed with caution."
 msgstr ""
-"Shtesat e radhitura këtu janë krijuar nga mijëra zhvillues prej bashkësisë "
-"sonë, që shtrihet nga hobistë individualë deri te korporata të mëdha. Krejt "
-"shtesat e paraqitura publikisht shqyrtohen nga një ekip redaktorësh, përpara"
-" se të hidhen në qarkullim. Shtesat e shënuara si Eksperimentale s’janë "
-"shqyrtuar dhe do të duhej t’i instalonit duke bërë kujdes."
+"Shtesat e radhitura këtu janë krijuar nga mijëra zhvillues prej bashkësisë sonë, që shtrihet nga hobistë individualë deri te korporata të mëdha. Krejt shtesat e paraqitura publikisht shqyrtohen nga "
+"një ekip redaktorësh, përpara se të hidhen në qarkullim. Shtesat e shënuara si Eksperimentale s’janë shqyrtuar dhe do të duhej t’i instalonit duke bërë kujdes."
 
 #: src/olympia/pages/templates/pages/about.lhtml:26
 msgid "How do I keep up with what's happening at AMO?"
 msgstr "Si të mbeten në dijeni se ç’ndodh te AMO?"
 
 #: src/olympia/pages/templates/pages/about.lhtml:27
-msgid ""
-"There are several ways to find out the latest news from the world of add-"
-"ons:"
+msgid "There are several ways to find out the latest news from the world of add-ons:"
 msgstr "Ka disa rrugë për të mësuar lajmet e fundit nga bota e shtesave:"
 
 #: src/olympia/pages/templates/pages/about.lhtml:29
 #, python-format
-msgid ""
-"Our <a href=\"%(url)s\">Add-ons Blog</a> is regularly updated with "
-"information for both add-on enthusiasts and developers."
-msgstr ""
-"<a href=\"%(url)s\">Blogu ynë i Shtesave</a> përditësohet rregullisht me të "
-"dhëna si për simpatizantët e shtesave, ashtu edhe për zhvilluesit e tyre."
+msgid "Our <a href=\"%(url)s\">Add-ons Blog</a> is regularly updated with information for both add-on enthusiasts and developers."
+msgstr "<a href=\"%(url)s\">Blogu ynë i Shtesave</a> përditësohet rregullisht me të dhëna si për simpatizantët e shtesave, ashtu edhe për zhvilluesit e tyre."
 
 #: src/olympia/pages/templates/pages/about.lhtml:32
 #, python-format
-msgid ""
-"We often post news, tips, and tricks to our Twitter account, <a "
-"href=\"%(url)s\">mozamo</a>"
-msgstr ""
-"Shpesh postojnë, lajme, ndihmëza, dhe trike te llogaria jonë Twitter, <a "
-"href=\"%(url)s\">mozamo</a>"
+msgid "We often post news, tips, and tricks to our Twitter account, <a href=\"%(url)s\">mozamo</a>"
+msgstr "Shpesh postojnë, lajme, ndihmëza, dhe trike te llogaria jonë Twitter, <a href=\"%(url)s\">mozamo</a>"
 
 #: src/olympia/pages/templates/pages/about.lhtml:34
 #, python-format
-msgid ""
-"Our <a href=\"%(url)s\">forums</a> are a good place to interact with the "
-"add-ons community and discuss upcoming changes to AMO."
-msgstr ""
-"<a href=\"%(url)s\">Forumet</a> janë vend i mirë për të ndërvepruar me "
-"bashkësinë e shtesave dhe për të diskutuar ndryshimet e ardhshme te AMO."
+msgid "Our <a href=\"%(url)s\">forums</a> are a good place to interact with the add-ons community and discuss upcoming changes to AMO."
+msgstr "<a href=\"%(url)s\">Forumet</a> janë vend i mirë për të ndërvepruar me bashkësinë e shtesave dhe për të diskutuar ndryshimet e ardhshme te AMO."
 
 #: src/olympia/pages/templates/pages/about.lhtml:39
 msgid "This sounds great! How can I get involved?"
 msgstr "Duket shumë e fortë! Si mund të marr pjesë?"
 
 #: src/olympia/pages/templates/pages/about.lhtml:40
-msgid ""
-"There are plenty of ways to get involved. If you're on the technical side:"
+msgid "There are plenty of ways to get involved. If you're on the technical side:"
 msgstr "Ka plot rrugë për t’u përfshirë. Në qoftë se jeni i anës teknike:"
 
 #: src/olympia/pages/templates/pages/about.lhtml:42
 #, python-format
-msgid ""
-"<a href=\"%(url)s\">Make your own add-on</a>. We provide free hosting and "
-"update services and can help you reach a large audience of users."
-msgstr ""
-"<a href=\"%(url)s\">Krijoni shtesën tuaj</a>. Ofrojmë strehim të saj falas "
-"dhe shërbim përditësimesh dhe mund t’ju ndihmojmë të mbërrini te një publik "
-"sa më i madh përdoruesish."
+msgid "<a href=\"%(url)s\">Make your own add-on</a>. We provide free hosting and update services and can help you reach a large audience of users."
+msgstr "<a href=\"%(url)s\">Krijoni shtesën tuaj</a>. Ofrojmë strehim të saj falas dhe shërbim përditësimesh dhe mund t’ju ndihmojmë të mbërrini te një publik sa më i madh përdoruesish."
 
 #: src/olympia/pages/templates/pages/about.lhtml:45
 #, python-format
-msgid ""
-"If you have add-on development experience, <a href=\"%(url)s\"> become an "
-"editor</a>! Our editors are add-on fans with a technical background who "
-"review add-ons for code quality and stability."
+msgid "If you have add-on development experience, <a href=\"%(url)s\"> become an editor</a>! Our editors are add-on fans with a technical background who review add-ons for code quality and stability."
 msgstr ""
-"Nëse keni përvojë me zhvillimin e shtesave, <a href=\"%(url)s\"> bëhuni një "
-"redaktor</a>! Redaktorët tanë janë tifozë të shtesave, me përvojë teknike, "
-"që shqyrtojnë shtesat lidhur me cilësinë dhe qëndrueshmërinë e kodit."
+"Nëse keni përvojë me zhvillimin e shtesave, <a href=\"%(url)s\"> bëhuni një redaktor</a>! Redaktorët tanë janë tifozë të shtesave, me përvojë teknike, që shqyrtojnë shtesat lidhur me cilësinë dhe "
+"qëndrueshmërinë e kodit."
 
 #: src/olympia/pages/templates/pages/about.lhtml:49
 #, python-format
 msgid ""
-"Help improve this website. It's open source, and you can file bugs and "
-"submit patches. <a href=\"%(url)s\"> GitHub</a> contains all of our current "
-"bugs, legacy bugs can still be found in Bugzilla."
+"Help improve this website. It's open source, and you can file bugs and submit patches. <a href=\"%(url)s\"> GitHub</a> contains all of our current bugs, legacy bugs can still be found in Bugzilla."
 msgstr ""
-"Ndihmoni në përmirësimin e këtij sajti. Është me burim të hapët, dhe mund të"
-" depozitoni të meta dhe të parashtroni arnime për të. <a href=\"%(url)s\"> "
-"GitHub</a> përmban krejt të metat e tanishme, të meta të dikurshme mund të "
-"gjenden në Bugzilla."
+"Ndihmoni në përmirësimin e këtij sajti. Është me burim të hapët, dhe mund të depozitoni të meta dhe të parashtroni arnime për të. <a href=\"%(url)s\"> GitHub</a> përmban krejt të metat e tanishme, "
+"të meta të dikurshme mund të gjenden në Bugzilla."
 
 #: src/olympia/pages/templates/pages/about.lhtml:55
-msgid ""
-"If you're interested in add-ons but not quite as technical, there are still "
-"ways to help:"
-msgstr ""
-"Nëse ju interesojnë shtesat, por s’jeni edhe aq i anës teknike, ka ende "
-"rrugë për të ndihmuar:"
+msgid "If you're interested in add-ons but not quite as technical, there are still ways to help:"
+msgstr "Nëse ju interesojnë shtesat, por s’jeni edhe aq i anës teknike, ka ende rrugë për të ndihmuar:"
 
 #: src/olympia/pages/templates/pages/about.lhtml:58
 msgid "Tell your friends! Let people know which add-ons you use."
@@ -11874,13 +9435,8 @@ msgid "Participate in our <a href=\"%(url)s\">forums</a>."
 msgstr "Merrni pjesë në <a href=\"%(url)s\">forumet</a> tona."
 
 #: src/olympia/pages/templates/pages/about.lhtml:61
-msgid ""
-"Review add-ons on the site. Add-on authors are more likely to improve their "
-"add-ons and write new ones when they know people appreciate their work."
-msgstr ""
-"Shkruani te sajti recensione për shtesat. Ka më tepër gjasa që autorët e "
-"shtesave t’i përmirësojnë shtesat e tyre dhe të shkruajnë të reja, kur "
-"shohin se njerëzot e vlerësojnë punën e tyre."
+msgid "Review add-ons on the site. Add-on authors are more likely to improve their add-ons and write new ones when they know people appreciate their work."
+msgstr "Shkruani te sajti recensione për shtesat. Ka më tepër gjasa që autorët e shtesave t’i përmirësojnë shtesat e tyre dhe të shkruajnë të reja, kur shohin se njerëzot e vlerësojnë punën e tyre."
 
 #: src/olympia/pages/templates/pages/about.lhtml:66
 msgid "I have a question"
@@ -11889,23 +9445,16 @@ msgstr "Kam një pyetje"
 #: src/olympia/pages/templates/pages/about.lhtml:67
 #, python-format
 msgid ""
-"A good place to start is our <a href=\"%(faq_url)s\"><abbr "
-"title=\"Frequently Asked Questions\">FAQ</abbr></a>. If you don't find an "
-"answer there, you can <a href=\"%(forum_url)s\"> ask on our forums</a>."
+"A good place to start is our <a href=\"%(faq_url)s\"><abbr title=\"Frequently Asked Questions\">FAQ</abbr></a>. If you don't find an answer there, you can <a href=\"%(forum_url)s\"> ask on our "
+"forums</a>."
 msgstr ""
-"Një vend i mirë për t’ia filluar është faqja jonë <a "
-"href=\"%(faq_url)s\"><abbr title=\"Frequently Asked "
-"Questions\">FAQ</abbr></a>. Nëse s’gjeni përgjigje aty, mund të <a "
-"href=\"%(forum_url)s\"> pyesni në forumet tona</a>."
+"Një vend i mirë për t’ia filluar është faqja jonë <a href=\"%(faq_url)s\"><abbr title=\"Frequently Asked Questions\">FAQ</abbr></a>. Nëse s’gjeni përgjigje aty, mund të <a href=\"%(forum_url)s\"> "
+"pyesni në forumet tona</a>."
 
 #: src/olympia/pages/templates/pages/about.lhtml:72
 #, python-format
-msgid ""
-"If you really need to contact someone from the Mozilla team, please see our "
-"<a href=\"%(url)s\"> contact information</a> page."
-msgstr ""
-"Nëse dëshironi të lidheni me dikë nga ekipi Mozilla, ju lutemi, shihni faqen"
-" tonë me <a href=\"%(url)s\">të dhëna kontaktesh<a>."
+msgid "If you really need to contact someone from the Mozilla team, please see our <a href=\"%(url)s\"> contact information</a> page."
+msgstr "Nëse dëshironi të lidheni me dikë nga ekipi Mozilla, ju lutemi, shihni faqen tonë me <a href=\"%(url)s\">të dhëna kontaktesh<a>."
 
 #: src/olympia/pages/templates/pages/about.lhtml:76
 msgid "Who works on this website?"
@@ -11914,15 +9463,11 @@ msgstr "Kush merret me këtë sajt?"
 #: src/olympia/pages/templates/pages/about.lhtml:77
 #, python-format
 msgid ""
-"Over the years, many people have contributed to this website, including both"
-" volunteers from the community and a dedicated AMO team. A list of "
-"significant contributors can be found on our <a href=\"%(url)s\"> Site "
-"Credits</a> page."
+"Over the years, many people have contributed to this website, including both volunteers from the community and a dedicated AMO team. A list of significant contributors can be found on our <a href="
+"\"%(url)s\"> Site Credits</a> page."
 msgstr ""
-"Përgjatë vitesh, shumë vetë kanë dhënë ndihmesë për këtë sajt, përfshi si "
-"vullnetarë nga bashkësia, ashtu edhe një ekip posaçrisht për AMO-n. Te faqja"
-" jonë <a href=\"%(url)s\"> Kredite Sajti</a> mund të gjeni një listë të "
-"kontribuesve më me peshë."
+"Përgjatë vitesh, shumë vetë kanë dhënë ndihmesë për këtë sajt, përfshi si vullnetarë nga bashkësia, ashtu edhe një ekip posaçrisht për AMO-n. Te faqja jonë <a href=\"%(url)s\"> Kredite Sajti</a> "
+"mund të gjeni një listë të kontribuesve më me peshë."
 
 #: src/olympia/pages/templates/pages/acr_firstrun.html:4
 msgid "Add-on Compatibility Reporter"
@@ -11933,12 +9478,8 @@ msgid "Add-on Compatibility Reporter has been installed"
 msgstr "Raportuesi i Përputhshmërisë së Shtesa është instaluar"
 
 #: src/olympia/pages/templates/pages/acr_firstrun.html:28
-msgid ""
-"It’s easy to help us make sure add-ons are updated in time for the release "
-"of the next version of Firefox."
-msgstr ""
-"Është e lehtë të na ndihmoni të sigurohemi që shtesat janë të përditësuara "
-"në kohë për hedhjen në qarkullim të versionit pasues të Firefox-it."
+msgid "It’s easy to help us make sure add-ons are updated in time for the release of the next version of Firefox."
+msgstr "Është e lehtë të na ndihmoni të sigurohemi që shtesat janë të përditësuara në kohë për hedhjen në qarkullim të versionit pasues të Firefox-it."
 
 #: src/olympia/pages/templates/pages/acr_firstrun.html:35
 msgid "Here’s how to get started reporting add-on compatibility:"
@@ -11946,54 +9487,36 @@ msgstr "Ja se si t’ia filloni me njoftimet për përputhshmëri shtesash:"
 
 #: src/olympia/pages/templates/pages/acr_firstrun.html:40
 msgid ""
-"As you start browsing and using your add-ons, take careful note of anything "
-"that seems different from when you last used the extension. This might be a "
-"display glitch, such as a menu item missing, or something more serious, like"
-" the add-on not working at all or showing errors."
+"As you start browsing and using your add-ons, take careful note of anything that seems different from when you last used the extension. This might be a display glitch, such as a menu item missing, "
+"or something more serious, like the add-on not working at all or showing errors."
 msgstr ""
-"Teksa filloni të shfletoni dhe përdorni shtesat tuaja, mbani me kujdes "
-"shënim gjithçka që duket ndryshe nga hera e fundit kur patët përdorur "
-"zgjerimin. Kjo mund të jetë diçka e dukshme në ekran, fjala vjen, mungon një"
-" element menuje, ose diçka më serioze, për shembull, shtesa s’funksionon "
-"fare ose shfaq gabime."
+"Teksa filloni të shfletoni dhe përdorni shtesat tuaja, mbani me kujdes shënim gjithçka që duket ndryshe nga hera e fundit kur patët përdorur zgjerimin. Kjo mund të jetë diçka e dukshme në ekran, "
+"fjala vjen, mungon një element menuje, ose diçka më serioze, për shembull, shtesa s’funksionon fare ose shfaq gabime."
 
 #: src/olympia/pages/templates/pages/acr_firstrun.html:49
 msgid ""
-"Once you know whether a particular add-on works properly or has problems, "
-"open the Add-ons Manager and click Compatibility next to the add-on to let "
-"Mozilla know what you found in your testing. Submitting a report will help "
-"us tell the add-on developer whether their add-on is working properly in "
-"this version or might need some fixes."
+"Once you know whether a particular add-on works properly or has problems, open the Add-ons Manager and click Compatibility next to the add-on to let Mozilla know what you found in your testing. "
+"Submitting a report will help us tell the add-on developer whether their add-on is working properly in this version or might need some fixes."
 msgstr ""
-"Pasi ta dini se një shtesë e caktuar punon si duhet ose se ka probleme, "
-"hapni Përgjegjësin e Shtesave dhe klikoni mbi Përputhshmëri, ngjitur me "
-"shtesën që ta njoftoni Mozilla-n se çfarë ju doli prej provës suaj. "
-"Parashtrimi i një njoftimi do të na ndihmojë t’i tregojmë zhvilluesit të "
-"shtesës se shtesa e tij funksionon si duhet ose se mund të ketë nevojë për "
-"disa ndreqje."
+"Pasi ta dini se një shtesë e caktuar punon si duhet ose se ka probleme, hapni Përgjegjësin e Shtesave dhe klikoni mbi Përputhshmëri, ngjitur me shtesën që ta njoftoni Mozilla-n se çfarë ju doli "
+"prej provës suaj. Parashtrimi i një njoftimi do të na ndihmojë t’i tregojmë zhvilluesit të shtesës se shtesa e tij funksionon si duhet ose se mund të ketë nevojë për disa ndreqje."
 
 #: src/olympia/pages/templates/pages/acr_firstrun.html:61
 #, python-format
 msgid ""
-"If you upgrade to a new version of Firefox or update your add-ons, your "
-"reports for the old versions will be hidden to allow you to test the new "
-"version. If you have any questions, please ask in <a href=\"%(url)s\">our "
-"forums</a>."
+"If you upgrade to a new version of Firefox or update your add-ons, your reports for the old versions will be hidden to allow you to test the new version. If you have any questions, please ask in <a "
+"href=\"%(url)s\">our forums</a>."
 msgstr ""
-"Nëse e përmirësoni Firefox-in ose shtesën me një version të ri, njoftimet "
-"tuaja mbi versionet e vjetra s’do të jenë të dukshme, për t’ju lejuar të "
-"testoni versionin e ri. Nëse keni ndonjë pyetje, ju lutemi, bëjeni te <a "
-"href=\"%(url)s\">forumet tanë</a>."
+"Nëse e përmirësoni Firefox-in ose shtesën me një version të ri, njoftimet tuaja mbi versionet e vjetra s’do të jenë të dukshme, për t’ju lejuar të testoni versionin e ri. Nëse keni ndonjë pyetje, "
+"ju lutemi, bëjeni te <a href=\"%(url)s\">forumet tanë</a>."
 
 #: src/olympia/pages/templates/pages/acr_firstrun.html:69
 msgid ""
-"Thousands of add-ons are made by our community every year, and your "
-"assistance with compatibility testing helps us make sure these add-ons stay "
-"useful as we strive to provide a great user experience."
+"Thousands of add-ons are made by our community every year, and your assistance with compatibility testing helps us make sure these add-ons stay useful as we strive to provide a great user "
+"experience."
 msgstr ""
-"Çdo vit krijohen mijëra shtesa, dhe ndihma juaj me provat e përputhshmërisë "
-"na ndihmon që të sigurohemi se këto shtesa mbeten të dobishme, teksa "
-"përpiqemi t’u ofrojmë përdoruesve një punim sa më të mirë."
+"Çdo vit krijohen mijëra shtesa, dhe ndihma juaj me provat e përputhshmërisë na ndihmon që të sigurohemi se këto shtesa mbeten të dobishme, teksa përpiqemi t’u ofrojmë përdoruesve një punim sa më të "
+"mirë."
 
 #: src/olympia/pages/templates/pages/acr_firstrun.html:75
 msgid "Thank you!"
@@ -12004,12 +9527,8 @@ msgid "Site Credits"
 msgstr "Kredite Sajti"
 
 #: src/olympia/pages/templates/pages/credits.html:12
-msgid ""
-"Mozilla would like to thank the following people for their contributions to "
-"the addons.mozilla.org project over the years:"
-msgstr ""
-"Mozilla dëshiron të falënderojë personat vijues për ndihmën e tyre te "
-"projekti addons.mozilla.org përgjatë vitesh:"
+msgid "Mozilla would like to thank the following people for their contributions to the addons.mozilla.org project over the years:"
+msgstr "Mozilla dëshiron të falënderojë personat vijues për ndihmën e tyre te projekti addons.mozilla.org përgjatë vitesh:"
 
 #: src/olympia/pages/templates/pages/credits.html:18
 msgid "Developers &amp; Administrators"
@@ -12042,88 +9561,63 @@ msgstr "Software dhe Figura"
 
 #: src/olympia/pages/templates/pages/credits.html:59
 msgid ""
-"Some icons used are from the <a "
-"href=\"http://www.famfamfam.com/lab/icons/silk/\">famfamfam Silk Icon "
-"Set</a>, licensed under a <a "
-"href=\"http://creativecommons.org/licenses/by/2.5/\">Creative Commons "
-"Attribution 2.5 License</a>."
+"Some icons used are from the <a href=\"http://www.famfamfam.com/lab/icons/silk/\">famfamfam Silk Icon Set</a>, licensed under a <a href=\"http://creativecommons.org/licenses/by/2.5/\">Creative "
+"Commons Attribution 2.5 License</a>."
 msgstr ""
-"Disa nga ikonat e përdorura janë prej <a "
-"href=\"http://www.famfamfam.com/lab/icons/silk/\">famfamfam Silk Icon "
-"Set</a>, licencuar sipas <a "
-"href=\"http://creativecommons.org/licenses/by/2.5/\">Lejes Creative Commons "
-"Attribution 2.5</a>."
+"Disa nga ikonat e përdorura janë prej <a href=\"http://www.famfamfam.com/lab/icons/silk/\">famfamfam Silk Icon Set</a>, licencuar sipas <a href=\"http://creativecommons.org/licenses/by/2.5/\">Lejes "
+"Creative Commons Attribution 2.5</a>."
 
 #: src/olympia/pages/templates/pages/credits.html:60
 msgid ""
-"Some icons used are from the <a href=\"http://www.fatcow.com/free-"
-"icons/\">FatCow Farm-Fresh Web Icons Set</a>, licensed under a <a "
-"href=\"http://creativecommons.org/licenses/by/3.0/us/\">Creative Commons "
-"Attribution 3.0 License</a>."
+"Some icons used are from the <a href=\"http://www.fatcow.com/free-icons/\">FatCow Farm-Fresh Web Icons Set</a>, licensed under a <a href=\"http://creativecommons.org/licenses/by/3.0/us/\">Creative "
+"Commons Attribution 3.0 License</a>."
 msgstr ""
-"Disa nga ikonat e përdorura janë marrë prej <a href=\"http://www.fatcow.com"
-"/free-icons/\">FatCow Farm-Fresh Web Icons Set</a>, licencuar sipas <a "
-"href=\"http://creativecommons.org/licenses/by/3.0/us/\">Creative Commons "
-"Attribution 3.0 License</a>."
+"Disa nga ikonat e përdorura janë marrë prej <a href=\"http://www.fatcow.com/free-icons/\">FatCow Farm-Fresh Web Icons Set</a>, licencuar sipas <a href=\"http://creativecommons.org/licenses/by/3.0/"
+"us/\">Creative Commons Attribution 3.0 License</a>."
 
 #: src/olympia/pages/templates/pages/credits.html:61
 msgid ""
-"Some pages use elements of <a "
-"href=\"http://shop.highsoft.com/highcharts.html\">Highcharts</a> (non-"
-"commercial), licensed under a <a href=\"http://creativecommons.org/licenses"
-"/by-nc/3.0/\">Creative Commons Attribution-NonCommercial 3.0 License</a>."
+"Some pages use elements of <a href=\"http://shop.highsoft.com/highcharts.html\">Highcharts</a> (non-commercial), licensed under a <a href=\"http://creativecommons.org/licenses/by-nc/3.0/\">Creative "
+"Commons Attribution-NonCommercial 3.0 License</a>."
 msgstr ""
-"Disa nga faqet përdorin elemente nga <a "
-"href=\"http://shop.highsoft.com/highcharts.html\">Highcharts</a> "
-"(jokomerciali), licecuar sipas <a href=\"http://creativecommons.org/licenses"
-"/by-nc/3.0/\">Creative Commons Attribution-NonCommercial 3.0 License</a>."
+"Disa nga faqet përdorin elemente nga <a href=\"http://shop.highsoft.com/highcharts.html\">Highcharts</a> (jokomerciali), licecuar sipas <a href=\"http://creativecommons.org/licenses/by-nc/3.0/"
+"\">Creative Commons Attribution-NonCommercial 3.0 License</a>."
 
 #: src/olympia/pages/templates/pages/credits.html:65
 #, python-format
-msgid ""
-"For information on contributing, please see our <a href=\"%(url)s\">wiki "
-"page</a>."
-msgstr ""
-"Për informacion rreth dhënies së kontributeve, ju lutemi, shihni <a "
-"href=\"%(url)s\">faqen tonë wiki</a>."
+msgid "For information on contributing, please see our <a href=\"%(url)s\">wiki page</a>."
+msgstr "Për informacion rreth dhënies së kontributeve, ju lutemi, shihni <a href=\"%(url)s\">faqen tonë wiki</a>."
 
 #: src/olympia/pages/templates/pages/dev_faq.html:4
 msgid "Developer FAQ"
 msgstr "FAQ për Zhvilluesit"
 
-#: src/olympia/pages/templates/pages/dev_faq.html:31
-#: src/olympia/pages/templates/pages/review_guide.html:33
+#: src/olympia/pages/templates/pages/dev_faq.html:31 src/olympia/pages/templates/pages/review_guide.html:33
 msgid "Sections"
 msgstr "Ndarje"
 
-#: src/olympia/pages/templates/pages/dev_faq.html:33
-#: src/olympia/pages/templates/pages/dev_faq.html:45
+#: src/olympia/pages/templates/pages/dev_faq.html:33 src/olympia/pages/templates/pages/dev_faq.html:45
 msgid "Developing an Add-on"
 msgstr "Zhvillimi i një Shtese"
 
 #. Heading for a list of resources for developers
-#: src/olympia/pages/templates/pages/dev_faq.html:34
-#: src/olympia/pages/templates/pages/dev_faq.html:208
+#: src/olympia/pages/templates/pages/dev_faq.html:34 src/olympia/pages/templates/pages/dev_faq.html:208
 msgid "Support Resources"
 msgstr "Burime Asistence"
 
-#: src/olympia/pages/templates/pages/dev_faq.html:35
-#: src/olympia/pages/templates/pages/dev_faq.html:261
+#: src/olympia/pages/templates/pages/dev_faq.html:35 src/olympia/pages/templates/pages/dev_faq.html:261
 msgid "Contributing your Add-on"
 msgstr "Si të Kontribuoni me Shtesën tuaj"
 
-#: src/olympia/pages/templates/pages/dev_faq.html:36
-#: src/olympia/pages/templates/pages/dev_faq.html:381
+#: src/olympia/pages/templates/pages/dev_faq.html:36 src/olympia/pages/templates/pages/dev_faq.html:381
 msgid "Add-on Review Process"
 msgstr "Procesi i Shqyrtimi të Shtesës"
 
-#: src/olympia/pages/templates/pages/dev_faq.html:37
-#: src/olympia/pages/templates/pages/dev_faq.html:444
+#: src/olympia/pages/templates/pages/dev_faq.html:37 src/olympia/pages/templates/pages/dev_faq.html:444
 msgid "Managing Your Add-on"
 msgstr "Administrimi i Shtesës Suaj"
 
-#: src/olympia/pages/templates/pages/dev_faq.html:39
-#: src/olympia/pages/templates/pages/dev_faq.html:528
+#: src/olympia/pages/templates/pages/dev_faq.html:39 src/olympia/pages/templates/pages/dev_faq.html:528
 msgid "References for Open Source Licenses"
 msgstr "Referenca për Licencë Burimi të Hapur"
 
@@ -12133,14 +9627,8 @@ msgstr "FAQ për Zhvillues Shtesash"
 
 #: src/olympia/pages/templates/pages/dev_faq.html:47
 #, python-format
-msgid ""
-"<h3>How do I build an Add-on?</h3> <p> Mozilla provides documentation on how"
-" to build an add-on via the <a href=\"%(url)s\">Mozilla Developer "
-"Network</a>. </p>"
-msgstr ""
-"<h3>Si ta krijoj një Shtesë?</h3> <p> Te <a href=\"%(url)s\">Rrjeti i "
-"Zhvilluesve Mozilla</a>, Mozilla ofron dokumentim se si të krijohet një "
-"shtesë. </p>"
+msgid "<h3>How do I build an Add-on?</h3> <p> Mozilla provides documentation on how to build an add-on via the <a href=\"%(url)s\">Mozilla Developer Network</a>. </p>"
+msgstr "<h3>Si ta krijoj një Shtesë?</h3> <p> Te <a href=\"%(url)s\">Rrjeti i Zhvilluesve Mozilla</a>, Mozilla ofron dokumentim se si të krijohet një shtesë. </p>"
 
 #: src/olympia/pages/templates/pages/dev_faq.html:55
 msgid "Other resources include:"
@@ -12160,13 +9648,11 @@ msgstr "Ç’mjete më duhen që të jem në gjendje të ndërtoj një Shtesë?"
 
 #: src/olympia/pages/templates/pages/dev_faq.html:68
 msgid ""
-"You will need to have a version of the Mozilla software that you're building"
-" the add-on for and a code editor of your choice. Add-ons can be built for "
-"almost all Mozilla software but are primarily targeted for:"
+"You will need to have a version of the Mozilla software that you're building the add-on for and a code editor of your choice. Add-ons can be built for almost all Mozilla software but are primarily "
+"targeted for:"
 msgstr ""
-"Do t’ju duhet të keni një version të software-it Mozilla për të cilin po "
-"ndërtoni shtesën dhe një përpunues kodi që e zgjidhni vetë. Shtesa mund të "
-"ndërtoni për thuajse krejt software-in Mozilla, por më së pari synohen:"
+"Do t’ju duhet të keni një version të software-it Mozilla për të cilin po ndërtoni shtesën dhe një përpunues kodi që e zgjidhni vetë. Shtesa mund të ndërtoni për thuajse krejt software-in Mozilla, "
+"por më së pari synohen:"
 
 #: src/olympia/pages/templates/pages/dev_faq.html:82
 msgid "Popular code editors include:"
@@ -12175,38 +9661,24 @@ msgstr "Te përpunuesit popullorë të kodit përfshihen:"
 #. This is a list of popular code editors.  Feel free to adjust as you like.
 #: src/olympia/pages/templates/pages/dev_faq.html:85
 msgid ""
-"<li><a href=\"http://komodoide.com/komodo-edit/\">Komodo Edit</a></li> "
-"<li><a href=\"http://macromates.com/\">TextMate</a></li> <li><a href=\"http"
-"://notepad-plus-plus.org/\">Notepad++</a></li> <li><a "
-"href=\"http://www.eclipse.org/\">Eclipse IDE</a></li>"
+"<li><a href=\"http://komodoide.com/komodo-edit/\">Komodo Edit</a></li> <li><a href=\"http://macromates.com/\">TextMate</a></li> <li><a href=\"http://notepad-plus-plus.org/\">Notepad++</a></li> "
+"<li><a href=\"http://www.eclipse.org/\">Eclipse IDE</a></li>"
 msgstr ""
-"<li><a href=\"http://komodoide.com/komodo-edit/\">Komodo Edit</a></li> "
-"<li><a href=\"http://macromates.com/\">TextMate</a></li> <li><a href=\"http"
-"://notepad-plus-plus.org/\">Notepad++</a></li> <li><a "
-"href=\"http://www.eclipse.org/\">Eclipse IDE</a></li>"
+"<li><a href=\"http://komodoide.com/komodo-edit/\">Komodo Edit</a></li> <li><a href=\"http://macromates.com/\">TextMate</a></li> <li><a href=\"http://notepad-plus-plus.org/\">Notepad++</a></li> "
+"<li><a href=\"http://www.eclipse.org/\">Eclipse IDE</a></li>"
 
 #: src/olympia/pages/templates/pages/dev_faq.html:94
 #, python-format
-msgid ""
-"You can also learn more about setting up your development environment via "
-"the MDN article <a href=\"%(url)s\">Setting up extension development "
-"environment</a>"
-msgstr ""
-"Rreth rregullimit të mjedisit tuaj të zhvillimit mund të mësoni më tepër "
-"përmes artikullit të MDN-së <a href=\"%(url)s\">Rregullim mjedisi zhvillimi "
-"zgjerimesh</a>"
+msgid "You can also learn more about setting up your development environment via the MDN article <a href=\"%(url)s\">Setting up extension development environment</a>"
+msgstr "Rreth rregullimit të mjedisit tuaj të zhvillimit mund të mësoni më tepër përmes artikullit të MDN-së <a href=\"%(url)s\">Rregullim mjedisi zhvillimi zgjerimesh</a>"
 
 #: src/olympia/pages/templates/pages/dev_faq.html:100
 msgid "What is a \".xpi\" file?"
 msgstr "Ç’janë kartelat \".xpi\"?"
 
 #: src/olympia/pages/templates/pages/dev_faq.html:102
-msgid ""
-"Extensions are packaged and distributed in ZIP files or Bundles, with the "
-"XPI (pronounced \"zippy\") file extension."
-msgstr ""
-"Zgjerimet paketohen dhe shpërndahen si kartela ZIP ose Paketa, me zgjatim "
-"kartele XPI (të shqiptuar \"zipi\")."
+msgid "Extensions are packaged and distributed in ZIP files or Bundles, with the XPI (pronounced \"zippy\") file extension."
+msgstr "Zgjerimet paketohen dhe shpërndahen si kartela ZIP ose Paketa, me zgjatim kartele XPI (të shqiptuar \"zipi\")."
 
 #: src/olympia/pages/templates/pages/dev_faq.html:108
 msgid "What is XUL?"
@@ -12214,17 +9686,11 @@ msgstr "Ç’është XUL-i?"
 
 #: src/olympia/pages/templates/pages/dev_faq.html:110
 msgid ""
-"XUL (XML User Interface Language) is Mozilla's XML-based language that lets "
-"you build feature-rich cross platform applications. It provides user "
-"interface widgets like buttons, menus, toolbars, trees, etc that can be used"
-" to enhance add-ons by modifying parts of the browser UI."
+"XUL (XML User Interface Language) is Mozilla's XML-based language that lets you build feature-rich cross platform applications. It provides user interface widgets like buttons, menus, toolbars, "
+"trees, etc that can be used to enhance add-ons by modifying parts of the browser UI."
 msgstr ""
-"XUL (XML User Interface Language - Gjuhë XML Ndërfaqesh Përdoruesi) është "
-"gjuha me bazë XML e Mozilla-s, e cila ju lejon të ndërtoni aplikacione plot "
-"funksione dhe ndërplatformësh. Ajo ju furnizon elemente ndërfaqeje "
-"përdoruesi, të tillë si butona, menu, panele, struktura pemë, etj, që mund "
-"të përdoren për të zgjeruar shtesat, duke ndryshuar pjesë të Ndërfaqes së "
-"Përdoruesit të shfletuesit."
+"XUL (XML User Interface Language - Gjuhë XML Ndërfaqesh Përdoruesi) është gjuha me bazë XML e Mozilla-s, e cila ju lejon të ndërtoni aplikacione plot funksione dhe ndërplatformësh. Ajo ju furnizon "
+"elemente ndërfaqeje përdoruesi, të tillë si butona, menu, panele, struktura pemë, etj, që mund të përdoren për të zgjeruar shtesat, duke ndryshuar pjesë të Ndërfaqes së Përdoruesit të shfletuesit."
 
 #: src/olympia/pages/templates/pages/dev_faq.html:119
 msgid "What is the \"install.rdf\" file used for?"
@@ -12233,34 +9699,21 @@ msgstr "Përse përdoret kartela \"install.rdf\"?"
 #: src/olympia/pages/templates/pages/dev_faq.html:121
 #, python-format
 msgid ""
-"This file, called an <a href=\"%(url)s\">Install Manifest</a>, is used by "
-"Add-on Manager-enabled XUL applications to determine information about an "
-"add-on as it is being installed. It contains metadata identifying the add-"
-"on, providing information about who created it, where more information can "
-"be found about it, which versions of what applications it is compatible "
-"with, how it should be updated, and so on. The format of the Install "
-"Manifest is RDF/XML."
+"This file, called an <a href=\"%(url)s\">Install Manifest</a>, is used by Add-on Manager-enabled XUL applications to determine information about an add-on as it is being installed. It contains "
+"metadata identifying the add-on, providing information about who created it, where more information can be found about it, which versions of what applications it is compatible with, how it should "
+"be updated, and so on. The format of the Install Manifest is RDF/XML."
 msgstr ""
-"Kjo kartelë, e quajtur një <a href=\"%(url)s\">Manifest Instalimi</a>, "
-"përdoret nga aplikacione XUL, të përdorshme nga Përgjegjësi i Shtesave, për "
-"të përcaktuar të dhëna rreth një shtese, teksa fillon instalimi i saj. Në të"
-" përmbahen tejtëdhëna që identifikojnë shtesën, duke furnizuar informacion "
-"se kush e krijoi, ku mund të gjenden më tepër të dhëna rreth saj, cili "
-"version i cilit aplikacion është i përputhshëm me të, si do të duhej "
-"përmirësuar ajo, e me radhë. Formati për Manifeste Instalimi është RDF/XML."
+"Kjo kartelë, e quajtur një <a href=\"%(url)s\">Manifest Instalimi</a>, përdoret nga aplikacione XUL, të përdorshme nga Përgjegjësi i Shtesave, për të përcaktuar të dhëna rreth një shtese, teksa "
+"fillon instalimi i saj. Në të përmbahen tejtëdhëna që identifikojnë shtesën, duke furnizuar informacion se kush e krijoi, ku mund të gjenden më tepër të dhëna rreth saj, cili version i cilit "
+"aplikacion është i përputhshëm me të, si do të duhej përmirësuar ajo, e me radhë. Formati për Manifeste Instalimi është RDF/XML."
 
 #: src/olympia/pages/templates/pages/dev_faq.html:132
 msgid "What does \"maxVersion\" mean?"
 msgstr "Ç’do të thotë \"maxVersion\"?"
 
 #: src/olympia/pages/templates/pages/dev_faq.html:134
-msgid ""
-"This determines the maximum version of Firefox you're saying this extension "
-"will work with. Set this to be no newer than the newest currently available "
-"version!"
-msgstr ""
-"Kjo përcakton versionin maksimum të Firefox-it me të cilin thoni se do të "
-"punojë zgjerimi. Caktojeni jo më të ri se versioni më i ri i tanishëm!"
+msgid "This determines the maximum version of Firefox you're saying this extension will work with. Set this to be no newer than the newest currently available version!"
+msgstr "Kjo përcakton versionin maksimum të Firefox-it me të cilin thoni se do të punojë zgjerimi. Caktojeni jo më të ri se versioni më i ri i tanishëm!"
 
 #: src/olympia/pages/templates/pages/dev_faq.html:141
 msgid "Can my add-on contain binary components?"
@@ -12269,42 +9722,25 @@ msgstr "A mund të përmbajë shtesa ime përbërës dyorë?"
 #: src/olympia/pages/templates/pages/dev_faq.html:143
 #, python-format
 msgid ""
-"Yes. You can use Mozilla's <a href=\"%(url)s\">XPCOM component object "
-"model</a> to enhance your add-ons. XPCOM components be used and implemented "
-"in JavaScript, Java, and Python in addition to C++."
+"Yes. You can use Mozilla's <a href=\"%(url)s\">XPCOM component object model</a> to enhance your add-ons. XPCOM components be used and implemented in JavaScript, Java, and Python in addition to C++."
 msgstr ""
-"Po. Mund të përdorni <a href=\"%(url)s\">XPCOM component object model</a> të"
-" Mozilla-s për të zgjeruar shtesat tuaja. Përbërësit XPCOM të jenë përdorur "
-"dhe sendërtuar në JavaScript, Java, dhe Python, përveç se C++."
+"Po. Mund të përdorni <a href=\"%(url)s\">XPCOM component object model</a> të Mozilla-s për të zgjeruar shtesat tuaja. Përbërësit XPCOM të jenë përdorur dhe sendërtuar në JavaScript, Java, dhe "
+"Python, përveç se C++."
 
 #: src/olympia/pages/templates/pages/dev_faq.html:150
-msgid ""
-"Can I use a JavaScript library like jQuery, MooTools or Prototype to build "
-"my add-on?"
-msgstr ""
-"A mund të përdor në ndërtimin e shtesë sime librari JavaScript, të tilla si "
-"jQuery, MooTools ose Prototype?"
+msgid "Can I use a JavaScript library like jQuery, MooTools or Prototype to build my add-on?"
+msgstr "A mund të përdor në ndërtimin e shtesë sime librari JavaScript, të tilla si jQuery, MooTools ose Prototype?"
 
 #: src/olympia/pages/templates/pages/dev_faq.html:152
 msgid ""
-"Yes. It's possible, but some of the functionality provided by these "
-"libraries are available through XPCOM, XUL, and JavaScript. In addition, "
-"authors should take care if libraries modify primitive object prototypes "
-"(String.prototype, Date.prototype, etc.) and/or define global functions (eg."
-" the $ function). These are prone to cause conflict with other add-ons, in "
-"particular if different add-ons use different versions of libraries and so "
-"on. Developers need to be very, very careful with using them.  Mozilla does "
-"not offer documentation on using them to build add-ons."
+"Yes. It's possible, but some of the functionality provided by these libraries are available through XPCOM, XUL, and JavaScript. In addition, authors should take care if libraries modify primitive "
+"object prototypes (String.prototype, Date.prototype, etc.) and/or define global functions (eg. the $ function). These are prone to cause conflict with other add-ons, in particular if different add-"
+"ons use different versions of libraries and so on. Developers need to be very, very careful with using them. Mozilla does not offer documentation on using them to build add-ons."
 msgstr ""
-"Po. Është e mundur, por disa nga funksionet e furnizuara nga këto librari "
-"janë të mundshme përmes XPCOM-it, XUL-it, dhe JavaScript-it. Për më tepër, "
-"autorët duhet të kujdesen se mos libraritë modifikojnë prototipe objektesh "
-"primitive (String.prototype, Date.prototype, etj.) dhe/ose përkufizojnë "
-"funksione globalë (p.sh. funksionin $). Njihen si shkaktarë përplasjesh me "
-"shtesa të tjera, veçanërisht nëse shtesa të tjera përdorin versione të tjerë"
-" të librarive, e me radhë. Zhvilluesit duhet të jenë shumë, shumë të "
-"kujdesshëm në përdorimin e tyre. Mozilla nuk ofron dokumentim mbi përdorimin"
-" e tyre për të krijuar shtesa."
+"Po. Është e mundur, por disa nga funksionet e furnizuara nga këto librari janë të mundshme përmes XPCOM-it, XUL-it, dhe JavaScript-it. Për më tepër, autorët duhet të kujdesen se mos libraritë "
+"modifikojnë prototipe objektesh primitive (String.prototype, Date.prototype, etj.) dhe/ose përkufizojnë funksione globalë (p.sh. funksionin $). Njihen si shkaktarë përplasjesh me shtesa të tjera, "
+"veçanërisht nëse shtesa të tjera përdorin versione të tjerë të librarive, e me radhë. Zhvilluesit duhet të jenë shumë, shumë të kujdesshëm në përdorimin e tyre. Mozilla nuk ofron dokumentim mbi "
+"përdorimin e tyre për të krijuar shtesa."
 
 #: src/olympia/pages/templates/pages/dev_faq.html:165
 msgid "How do I debug my add-on?"
@@ -12316,32 +9752,19 @@ msgid "You can use the <a href=\"%(url)s\">Add-on Debugger</a>."
 msgstr "Mund të përdorni <a href=\"%(url)s\">Diagnostikues Shtesash</a>."
 
 #: src/olympia/pages/templates/pages/dev_faq.html:172
-msgid ""
-"How do I test for compatibility with the latest version of Mozilla software?"
-msgstr ""
-"Si ta provoj për përputhshmëri me versionin më të ri të software-it "
-"Mozilla-s?"
+msgid "How do I test for compatibility with the latest version of Mozilla software?"
+msgstr "Si ta provoj për përputhshmëri me versionin më të ri të software-it Mozilla-s?"
 
 #: src/olympia/pages/templates/pages/dev_faq.html:174
 msgid ""
-"To ensure compatibility with the latest Mozilla software, it's important to "
-"download updates as they become available and test your add-on to ensure "
-"that it is still functioning as expected. In many cases, the latest version "
-"of Mozilla software may be a beta release. Since these releases at times "
-"introduce architectural changes that may impact the functionality of your "
-"add-on, it's important to be actively involved in the beta process to ensure"
-" that your add-on users are not negatively impacted upon final release of "
-"Mozilla software."
+"To ensure compatibility with the latest Mozilla software, it's important to download updates as they become available and test your add-on to ensure that it is still functioning as expected. In "
+"many cases, the latest version of Mozilla software may be a beta release. Since these releases at times introduce architectural changes that may impact the functionality of your add-on, it's "
+"important to be actively involved in the beta process to ensure that your add-on users are not negatively impacted upon final release of Mozilla software."
 msgstr ""
-"Për të siguruar përputhshmëri me software-in më të ri Mozilla, është e "
-"rëndësishme të shkarkohen përditësimet dora-dorës që vijnë, dhe të testohet "
-"shtesa juaj për t’u siguruar që funksionon përsëri ashtu siç pritet. Në "
-"mjaft raste, versioni më i ri i një software-i Mozilla mund të jetë beta. "
-"Këto versione ka raste që sjellin ndryshime arkitekturore që mund të "
-"ndikojnë në funksionimin e shtesës suaj, ndaj është e rëndësishme të "
-"përfshiheni aktivisht në proceset beta, për të siguruar që përdoruesit e "
-"shtesës suaj nuk do të preken negativisht nga hedhja përfundimtare në "
-"qarkullim e software-it Mozilla."
+"Për të siguruar përputhshmëri me software-in më të ri Mozilla, është e rëndësishme të shkarkohen përditësimet dora-dorës që vijnë, dhe të testohet shtesa juaj për t’u siguruar që funksionon përsëri "
+"ashtu siç pritet. Në mjaft raste, versioni më i ri i një software-i Mozilla mund të jetë beta. Këto versione ka raste që sjellin ndryshime arkitekturore që mund të ndikojnë në funksionimin e "
+"shtesës suaj, ndaj është e rëndësishme të përfshiheni aktivisht në proceset beta, për të siguruar që përdoruesit e shtesës suaj nuk do të preken negativisht nga hedhja përfundimtare në qarkullim e "
+"software-it Mozilla."
 
 #: src/olympia/pages/templates/pages/dev_faq.html:185
 msgid "How to improve the performance of my add-on?"
@@ -12350,17 +9773,11 @@ msgstr "Si ta përmirësoj funksionimin e shtesës sime?"
 #: src/olympia/pages/templates/pages/dev_faq.html:187
 #, python-format
 msgid ""
-"Poorly written extensions can have a severe impact on the browsing "
-"experience, including on the overall performance of Firefox itself. The "
-"following page contains many good <a href=\"%(url)s\">guides</a> that help "
-"you improve performance, whether you're developing core Mozilla code or an "
-"add-on."
+"Poorly written extensions can have a severe impact on the browsing experience, including on the overall performance of Firefox itself. The following page contains many good <a href=\"%(url)s"
+"\">guides</a> that help you improve performance, whether you're developing core Mozilla code or an add-on."
 msgstr ""
-"Zgjerimet e shkruara dobët mund të kenë ndikim të rëndë në shijen që lë "
-"shfletimi, përfshi vetë funksionimin e Firefox-it. Faqja vijuese përmban "
-"mjaft <a href=\"%(url)s\">udhërrëfyes</a> të goditur që ju ndihmojnë për "
-"përmirësimin e funksionimit, qoftë kur shkruani kod për gjërat bazë Mozilla,"
-" qoftë për një shtesë."
+"Zgjerimet e shkruara dobët mund të kenë ndikim të rëndë në shijen që lë shfletimi, përfshi vetë funksionimin e Firefox-it. Faqja vijuese përmban mjaft <a href=\"%(url)s\">udhërrëfyes</a> të goditur "
+"që ju ndihmojnë për përmirësimin e funksionimit, qoftë kur shkruani kod për gjërat bazë Mozilla, qoftë për një shtesë."
 
 #: src/olympia/pages/templates/pages/dev_faq.html:195
 msgid "Can my add-on support multiple locales?"
@@ -12369,21 +9786,15 @@ msgstr "A mund të mbulojë shtesa ime shumë gjuhë?"
 #: src/olympia/pages/templates/pages/dev_faq.html:197
 #, python-format
 msgid ""
-"Yes. Details on localizing your add-on can be found in the the <a "
-"href=\"%(l10n_url)s\">Mozilla Developer Network Localization page</a>. <a "
-"href=\"%(bz_url)s\">The BabelZilla project</a> is also a great resource for "
-"learning about localization and volunteering to help translate add-ons."
+"Yes. Details on localizing your add-on can be found in the the <a href=\"%(l10n_url)s\">Mozilla Developer Network Localization page</a>. <a href=\"%(bz_url)s\">The BabelZilla project</a> is also a "
+"great resource for learning about localization and volunteering to help translate add-ons."
 msgstr ""
-"Po. Hollësië mbi përkthimin e shtesës suaj mund të gjeni te <a "
-"href=\"%(l10n_url)s\">faqja MDN mbi Përkthimet</a>. <a "
-"href=\"%(bz_url)s\">Projekti BabelZilla</a> gjithashtu është një burim i "
-"pasur për të mësuar rreth përkthimit dhe vullnetarizmit për përkthim "
-"shtesash."
+"Po. Hollësië mbi përkthimin e shtesës suaj mund të gjeni te <a href=\"%(l10n_url)s\">faqja MDN mbi Përkthimet</a>. <a href=\"%(bz_url)s\">Projekti BabelZilla</a> gjithashtu është një burim i pasur "
+"për të mësuar rreth përkthimit dhe vullnetarizmit për përkthim shtesash."
 
 #: src/olympia/pages/templates/pages/dev_faq.html:210
 msgid "I need some advice building my add-on. Where can I find help?"
-msgstr ""
-"Më duhen ca këshilla për ndërtimin e shtesës sime. Ku mund të gjej ndihmë?"
+msgstr "Më duhen ca këshilla për ndërtimin e shtesës sime. Ku mund të gjej ndihmë?"
 
 #. #extdev is the name of the IRC channel.  do not change.
 #: src/olympia/pages/templates/pages/dev_faq.html:216
@@ -12397,12 +9808,8 @@ msgstr "#amo (për asistencë lidhur me strehimin e shtesës suaj te AMO)"
 
 #. #jetpack is the name of the IRC channel.  do not change.
 #: src/olympia/pages/templates/pages/dev_faq.html:220
-msgid ""
-"#jetpack (for discussions about the Add-ons SDK and cfx/jpm - formerly known"
-" as Jetpack)"
-msgstr ""
-"#jetpack (për diskutime rreth SDK-së së Shtesave dhe cfx/jpm - të njohura "
-"dikur si Jetpack)"
+msgid "#jetpack (for discussions about the Add-ons SDK and cfx/jpm - formerly known as Jetpack)"
+msgstr "#jetpack (për diskutime rreth SDK-së së Shtesave dhe cfx/jpm - të njohura dikur si Jetpack)"
 
 #. Label for a link to the extension developers mailing list
 #: src/olympia/pages/templates/pages/dev_faq.html:225
@@ -12438,25 +9845,16 @@ msgstr "Jo."
 
 #: src/olympia/pages/templates/pages/dev_faq.html:246
 msgid "Are there 3rd party developers that I can hire to build my add-on?"
-msgstr ""
-"A ka zhvillues nga palë të treta, të cilët mund t’i punësoj për të ndërtuar "
-"shtesën time?"
+msgstr "A ka zhvillues nga palë të treta, të cilët mund t’i punësoj për të ndërtuar shtesën time?"
 
 #: src/olympia/pages/templates/pages/dev_faq.html:248
 #, python-format
 msgid ""
-"Yes. You may find 3rd party developers via the <a href=\"%(forum_url)s"
-"\">Add-ons forum</a>, <a href=\"%(list_url)s\">mozilla.jobs list</a>, <a "
-"href=\"%(mz_url)s\">mozillaZine forums</a> or <a href=\"%(wiki_url)s\">the "
-"Mozilla Wiki</a>. Please note that Mozilla does not offer developer "
-"recommendations."
+"Yes. You may find 3rd party developers via the <a href=\"%(forum_url)s\">Add-ons forum</a>, <a href=\"%(list_url)s\">mozilla.jobs list</a>, <a href=\"%(mz_url)s\">mozillaZine forums</a> or <a href="
+"\"%(wiki_url)s\">the Mozilla Wiki</a>. Please note that Mozilla does not offer developer recommendations."
 msgstr ""
-"Po. Mund të gjeni zhvillues palësh të treta përmes <a "
-"href=\"%(forum_url)s\">forumit të shtesave</a>, <a "
-"href=\"%(list_url)s\">listës mozilla.jobs</a>, <a "
-"href=\"%(mz_url)s\">forumeve te mozillaZine</a> ose te <a "
-"href=\"%(wiki_url)s\">Wiki e Mozilla-s</a>. Ju lutemi, kini parasysh që "
-"Mozilla nuk ofron rekomandime zhvilluesish."
+"Po. Mund të gjeni zhvillues palësh të treta përmes <a href=\"%(forum_url)s\">forumit të shtesave</a>, <a href=\"%(list_url)s\">listës mozilla.jobs</a>, <a href=\"%(mz_url)s\">forumeve te "
+"mozillaZine</a> ose te <a href=\"%(wiki_url)s\">Wiki e Mozilla-s</a>. Ju lutemi, kini parasysh që Mozilla nuk ofron rekomandime zhvilluesish."
 
 #: src/olympia/pages/templates/pages/dev_faq.html:263
 msgid "Can I host my own add-on?"
@@ -12465,22 +9863,13 @@ msgstr "A mund ta strehoj shtesën time?"
 #: src/olympia/pages/templates/pages/dev_faq.html:265
 #, python-format
 msgid ""
-"Yes. Many developers choose to host their own add-ons. Choosing to host your"
-" add-on on <a href=\"%(amo_url)s\">Mozilla's add-on site</a>, though, allows"
-" for much greater exposure to your add-on due to the large volume of "
-"visitors to the site.  <a href=\"%(md_url)s\">mozdev.org</a> offers free "
-"project hosting for Mozilla applications and extensions providing developers"
-" with tools to help manage source code, version control, bug tracking and "
-"documentation."
+"Yes. Many developers choose to host their own add-ons. Choosing to host your add-on on <a href=\"%(amo_url)s\">Mozilla's add-on site</a>, though, allows for much greater exposure to your add-on due "
+"to the large volume of visitors to the site. <a href=\"%(md_url)s\">mozdev.org</a> offers free project hosting for Mozilla applications and extensions providing developers with tools to help manage "
+"source code, version control, bug tracking and documentation."
 msgstr ""
-"Po. Mjaft zhvillues i strehojnë vetë shtesat e tyre. Por, po të zgjidhni të "
-"strehoni shtesën tuaj te <a href=\"%(amo_url)s\">sajti i shtesave "
-"Mozilla</a>, ju krijohet mundësia për ekspozim më të madh të shtesës suaj "
-"para një vëllimi të madh vizitorësh të sajtit. <a "
-"href=\"%(md_url)s\">mozdev.org</a> ofron strehim falas për projekte "
-"aplikacionesh dhe zgjerimesh Mozilla, duke u furnizuar zhvilluesve mjete në "
-"ndihmë të administrimit të kodit burim, për kontroll versionesh, ndjekje të "
-"metash dhe dokumentim."
+"Po. Mjaft zhvillues i strehojnë vetë shtesat e tyre. Por, po të zgjidhni të strehoni shtesën tuaj te <a href=\"%(amo_url)s\">sajti i shtesave Mozilla</a>, ju krijohet mundësia për ekspozim më të "
+"madh të shtesës suaj para një vëllimi të madh vizitorësh të sajtit. <a href=\"%(md_url)s\">mozdev.org</a> ofron strehim falas për projekte aplikacionesh dhe zgjerimesh Mozilla, duke u furnizuar "
+"zhvilluesve mjete në ndihmë të administrimit të kodit burim, për kontroll versionesh, ndjekje të metash dhe dokumentim."
 
 #: src/olympia/pages/templates/pages/dev_faq.html:277
 msgid "Can Mozilla host my add-on?"
@@ -12488,12 +9877,8 @@ msgstr "A mund ta strehojë Mozilla shtesën time?"
 
 #: src/olympia/pages/templates/pages/dev_faq.html:279
 #, python-format
-msgid ""
-"Yes. You can host your add-on on <a href=\"%(url)s\">Mozilla's add-on "
-"website</a>."
-msgstr ""
-"Po. Shtesën tuaj mund ta strehoni te <a href=\"%(url)s\">sajti i shtesave "
-"Mozilla</a>."
+msgid "Yes. You can host your add-on on <a href=\"%(url)s\">Mozilla's add-on website</a>."
+msgstr "Po. Shtesën tuaj mund ta strehoni te <a href=\"%(url)s\">sajti i shtesave Mozilla</a>."
 
 #: src/olympia/pages/templates/pages/dev_faq.html:284
 msgid "What is AMO?"
@@ -12501,19 +9886,11 @@ msgstr "Ç’është AMO-ja?"
 
 #: src/olympia/pages/templates/pages/dev_faq.html:286
 msgid ""
-"Mozilla's AMO (<a "
-"href=\"https://addons.mozilla.org\">https://addons.mozilla.org</a>) is the "
-"incubator that helps developers build, distribute, and support fantastic "
-"consumer products powered by Mozilla. It provides you the tools and "
-"infrastructure necessary to manage, host and expose your add-on to a massive"
-" base of Mozilla users."
+"Mozilla's AMO (<a href=\"https://addons.mozilla.org\">https://addons.mozilla.org</a>) is the incubator that helps developers build, distribute, and support fantastic consumer products powered by "
+"Mozilla. It provides you the tools and infrastructure necessary to manage, host and expose your add-on to a massive base of Mozilla users."
 msgstr ""
-"AMO i Mozilla-s (<a "
-"href=\"https://addons.mozilla.org\">https://addons.mozilla.org</a>) është "
-"inkubatori që ndihmon zhvilluesit të ndërtojnë, shpërndajnë, dhe ofrojnë "
-"asistencë për produkte fantastike me bazë Mozilla. Ju furnizon mjetet dhe "
-"infrastrukturën e nevojshme për të administruar, strehuar dhe ekspozuar "
-"shtesat tuaja para një baze masive përdoruesish të Mozilla-s."
+"AMO i Mozilla-s (<a href=\"https://addons.mozilla.org\">https://addons.mozilla.org</a>) është inkubatori që ndihmon zhvilluesit të ndërtojnë, shpërndajnë, dhe ofrojnë asistencë për produkte "
+"fantastike me bazë Mozilla. Ju furnizon mjetet dhe infrastrukturën e nevojshme për të administruar, strehuar dhe ekspozuar shtesat tuaja para një baze masive përdoruesish të Mozilla-s."
 
 #: src/olympia/pages/templates/pages/dev_faq.html:295
 msgid "Does Mozilla keep my account information private?"
@@ -12521,12 +9898,8 @@ msgstr "A i mban Mozilla private të dhënat e llogarisë sime?"
 
 #: src/olympia/pages/templates/pages/dev_faq.html:297
 #, python-format
-msgid ""
-"Yes. Our <a href=\"%(url)s\">Privacy Policy</a> describes how your "
-"information is managed by Mozilla."
-msgstr ""
-"Po. <a href=\"%(url)s\">Rregullat tona të Privatësisë</a> përshkruajnë se si"
-" administrohen të dhënat tuaja nga Mozilla."
+msgid "Yes. Our <a href=\"%(url)s\">Privacy Policy</a> describes how your information is managed by Mozilla."
+msgstr "Po. <a href=\"%(url)s\">Rregullat tona të Privatësisë</a> përshkruajnë se si administrohen të dhënat tuaja nga Mozilla."
 
 #: src/olympia/pages/templates/pages/dev_faq.html:302
 msgid "What are the \"developer tools\" listed on AMO?"
@@ -12534,38 +9907,24 @@ msgstr "Cilat janë \"mjetet e zhvilluesit\" të radhitura te AMO?"
 
 #: src/olympia/pages/templates/pages/dev_faq.html:304
 msgid ""
-"The \"Developer Tools\" dashboard is the area that provides you the tools to"
-" successfully manage your add-ons. It provides the functionality necessary "
-"to submit your add-ons to AMO, manage add-on information, and review "
-"statistics."
+"The \"Developer Tools\" dashboard is the area that provides you the tools to successfully manage your add-ons. It provides the functionality necessary to submit your add-ons to AMO, manage add-on "
+"information, and review statistics."
 msgstr ""
-"Pulti \"Mjete Zhvilluesi\" është zona që ju ofron mjetet për të administruar"
-" me sukses shtesat tuaja. Aty keni funksionet e nevojshme për parashtrimin e"
-" shtesave tuaja te AMO, për administrim informacioni mbi shtesën, dhe për "
-"shqyrtim statistikash."
+"Pulti \"Mjete Zhvilluesi\" është zona që ju ofron mjetet për të administruar me sukses shtesat tuaja. Aty keni funksionet e nevojshme për parashtrimin e shtesave tuaja te AMO, për administrim "
+"informacioni mbi shtesën, dhe për shqyrtim statistikash."
 
 #: src/olympia/pages/templates/pages/dev_faq.html:312
-msgid ""
-"Does Mozilla have a policy in place as to what is an acceptable submission?"
-msgstr ""
-"A ka Mozilla në fuqi ndonjë rregull se çfarë është një parashtrim i "
-"pranueshëm?"
+msgid "Does Mozilla have a policy in place as to what is an acceptable submission?"
+msgstr "A ka Mozilla në fuqi ndonjë rregull se çfarë është një parashtrim i pranueshëm?"
 
 #: src/olympia/pages/templates/pages/dev_faq.html:314
 #, python-format
 msgid ""
-"Yes. Mozilla's <a href=\"%(p_url)s\">Add-on Policy</a> describes what is an "
-"acceptable submission. This policy is subject to change without notice.  In "
-"addition, the AMO editorial team uses the <a href=\"%(g_url)s\">Editors "
-"Reviewing Guide</a> to ensure that your add-on meets specific guidelines for"
-" functionality and security."
+"Yes. Mozilla's <a href=\"%(p_url)s\">Add-on Policy</a> describes what is an acceptable submission. This policy is subject to change without notice. In addition, the AMO editorial team uses the <a "
+"href=\"%(g_url)s\">Editors Reviewing Guide</a> to ensure that your add-on meets specific guidelines for functionality and security."
 msgstr ""
-"Po. <a href=\"%(p_url)s\">Rregullat e Mozilla-s mbi Shtesat</a> përshkruajnë"
-" se cili do të ishte një parashtrim i pranueshëm. Këto rregulla janë subjekt"
-" ndryshimesh pa paralajmërim. Përveç kësaj, ekipi i redaktorëve të AMO-s "
-"përdor <a href=\"%(g_url)s\">Udhërrëfyesin për Redaktorë Shqyrtimesh</a> për"
-" të kontrolluar që shtesa juaj pajtohet me udhëzimet specifike për "
-"funksionimin dhe sigurinë."
+"Po. <a href=\"%(p_url)s\">Rregullat e Mozilla-s mbi Shtesat</a> përshkruajnë se cili do të ishte një parashtrim i pranueshëm. Këto rregulla janë subjekt ndryshimesh pa paralajmërim. Përveç kësaj, "
+"ekipi i redaktorëve të AMO-s përdor <a href=\"%(g_url)s\">Udhërrëfyesin për Redaktorë Shqyrtimesh</a> për të kontrolluar që shtesa juaj pajtohet me udhëzimet specifike për funksionimin dhe sigurinë."
 
 #: src/olympia/pages/templates/pages/dev_faq.html:324
 msgid "How do I submit my add-on for review?"
@@ -12574,30 +9933,20 @@ msgstr "Si ta parashtroj shtesën time për shqyrtim?"
 #: src/olympia/pages/templates/pages/dev_faq.html:326
 #, python-format
 msgid ""
-"The Developer Tools dashboard will allow you to upload and submit add-ons to"
-" AMO. You must be a registered AMO users before you can submit an add-on. "
-"Before submitting your add-on be sure to you have read the AMO <a "
-"href=\"%(url)s\">Editors Reviewing Guide</a> to ensure that your add-on has "
-"met the guidelines used by editors to review add-ons."
+"The Developer Tools dashboard will allow you to upload and submit add-ons to AMO. You must be a registered AMO users before you can submit an add-on. Before submitting your add-on be sure to you "
+"have read the AMO <a href=\"%(url)s\">Editors Reviewing Guide</a> to ensure that your add-on has met the guidelines used by editors to review add-ons."
 msgstr ""
-"Paneli i Mjeteve të Zhvilluesit do t’ju lejojë të ngarkoni dhe parashtroni "
-"shtesa te AMO. Lypset të jeni përdorues i regjistruar te AMO, përpara se të "
-"mundni të parashtroni një shtesë. Përpara parashtrimit të shtesës suaj "
-"sigurohuni se e keni lexuar <a href=\"%(url)s\">Udhërrëfyesin e Redaktorëve "
-"të Shtesave</a> të AMO-s, për t’u siguruar që shtesa juaj është në pajtim me"
-" udhëzimet e përdorura nga redaktorët gjatë shqyrtimit të shtesave."
+"Paneli i Mjeteve të Zhvilluesit do t’ju lejojë të ngarkoni dhe parashtroni shtesa te AMO. Lypset të jeni përdorues i regjistruar te AMO, përpara se të mundni të parashtroni një shtesë. Përpara "
+"parashtrimit të shtesës suaj sigurohuni se e keni lexuar <a href=\"%(url)s\">Udhërrëfyesin e Redaktorëve të Shtesave</a> të AMO-s, për t’u siguruar që shtesa juaj është në pajtim me udhëzimet e "
+"përdorura nga redaktorët gjatë shqyrtimit të shtesave."
 
 #: src/olympia/pages/templates/pages/dev_faq.html:336
 msgid "What operating system do I choose for my add-on?"
 msgstr "Cilin sistem operativ të zgjedh për shtesës time?"
 
 #: src/olympia/pages/templates/pages/dev_faq.html:338
-msgid ""
-"You must choose the operating systems on which your add-on will successfully"
-" function."
-msgstr ""
-"Duhet të zgjidhni sistemet operative në të cilët shtesa juaj do të "
-"funksionojë me sukses."
+msgid "You must choose the operating systems on which your add-on will successfully function."
+msgstr "Duhet të zgjidhni sistemet operative në të cilët shtesa juaj do të funksionojë me sukses."
 
 #: src/olympia/pages/templates/pages/dev_faq.html:344
 msgid "What category do I choose for my add-on?"
@@ -12605,58 +9954,39 @@ msgstr "Cilën kategori të zgjedh për shtesën time?"
 
 #: src/olympia/pages/templates/pages/dev_faq.html:346
 msgid ""
-"The choice of category is dependent on what type of audience you are "
-"targeting and the functionality of your add-on. If you're unsure of which "
-"category your add-on falls into, please choose \"Other\". The AMO team may "
-"re-categorize your add-on if it's determined that it's better suited in a "
-"different category."
+"The choice of category is dependent on what type of audience you are targeting and the functionality of your add-on. If you're unsure of which category your add-on falls into, please choose \"Other"
+"\". The AMO team may re-categorize your add-on if it's determined that it's better suited in a different category."
 msgstr ""
-"Zgjedhja e kategorisë varet nga lloji i publikut që keni në mendje dhe nga "
-"funksionet e shtesës suaj. Nëse jeni i pasigurt se në cilën kategori bie "
-"shtesa juaj, ju lutemi, zgjidhni \"Tjetër\". Ekipi i AMO-s mund ta "
-"rikategorizojë shtesën tuaj, nëse vendoset se i shkon më tepër një kategorie"
-" tjetër."
+"Zgjedhja e kategorisë varet nga lloji i publikut që keni në mendje dhe nga funksionet e shtesës suaj. Nëse jeni i pasigurt se në cilën kategori bie shtesa juaj, ju lutemi, zgjidhni \"Tjetër\". "
+"Ekipi i AMO-s mund ta rikategorizojë shtesën tuaj, nëse vendoset se i shkon më tepër një kategorie tjetër."
 
 #: src/olympia/pages/templates/pages/dev_faq.html:355
 msgid "What does \"nominating\" my add-on mean?"
 msgstr "Çfarë do të thotë \"kandidim\" i shtesës sime?"
 
 #: src/olympia/pages/templates/pages/dev_faq.html:357
-msgid ""
-"Nominated add-ons are new add-ons that the author has nominated to become "
-"public via the Developer Tools."
-msgstr ""
-"Shtesat e kandiduara janë shtesa të reja, të cilat autori i ka propozuar për"
-" t’u bërë publike përmes Mjeteve të Zhvilluesit."
+msgid "Nominated add-ons are new add-ons that the author has nominated to become public via the Developer Tools."
+msgstr "Shtesat e kandiduara janë shtesa të reja, të cilat autori i ka propozuar për t’u bërë publike përmes Mjeteve të Zhvilluesit."
 
 #: src/olympia/pages/templates/pages/dev_faq.html:363
 msgid "Can I specify a license agreement for using my add-on?"
-msgstr ""
-"A mund të përcaktoj një marrëveshje licence për përdorimin e shtesës sime?"
+msgstr "A mund të përcaktoj një marrëveshje licence për përdorimin e shtesës sime?"
 
 #: src/olympia/pages/templates/pages/dev_faq.html:365
-msgid ""
-"Yes. You can specify a license agreement when submitting your add-on. You "
-"can also add or update a license agreement via the Developer Tools dashboard"
-" after your add-on has been submitted."
+msgid "Yes. You can specify a license agreement when submitting your add-on. You can also add or update a license agreement via the Developer Tools dashboard after your add-on has been submitted."
 msgstr ""
-"Po. Mund të caktoni një marrëveshje licence, gjatë parashtrimit të shtesës "
-"suaj. Përmes pultit të Mjeteve të Zhvilluesit mund të shtoni ose përditësoni"
-" një marrëveshje licence edhe pasi shtesa juaj të jetë parashtruar."
+"Po. Mund të caktoni një marrëveshje licence, gjatë parashtrimit të shtesës suaj. Përmes pultit të Mjeteve të Zhvilluesit mund të shtoni ose përditësoni një marrëveshje licence edhe pasi shtesa juaj "
+"të jetë parashtruar."
 
 #: src/olympia/pages/templates/pages/dev_faq.html:372
 msgid "Can I include a privacy policy for my add-on?"
 msgstr "A mund të përfshij rregulla privatësie për shtesën time?"
 
 #: src/olympia/pages/templates/pages/dev_faq.html:374
-msgid ""
-"Yes. You can specify a privacy policy when submitting your add-on. You can "
-"also add or update a privacy policy via the Developer Tools dashboard after "
-"your add-on has been submitted."
+msgid "Yes. You can specify a privacy policy when submitting your add-on. You can also add or update a privacy policy via the Developer Tools dashboard after your add-on has been submitted."
 msgstr ""
-"Po. Mund të caktoni rregulla privatësie, gjatë parashtrimit të shtesës suaj."
-" Përmes pultit të Mjeteve të Zhvilluesit mund të shtoni ose përditësoni "
-"rregulla privatësie edhe pasi shtesa juaj të jetë parashtruar."
+"Po. Mund të caktoni rregulla privatësie, gjatë parashtrimit të shtesës suaj. Përmes pultit të Mjeteve të Zhvilluesit mund të shtoni ose përditësoni rregulla privatësie edhe pasi shtesa juaj të jetë "
+"parashtruar."
 
 #: src/olympia/pages/templates/pages/dev_faq.html:383
 msgid "Why must my add-on be reviewed?"
@@ -12665,15 +9995,11 @@ msgstr "Pse duhet shqyrtuar shtesa ime?"
 #: src/olympia/pages/templates/pages/dev_faq.html:385
 #, python-format
 msgid ""
-"All add-ons submitted, whether new or updated, are reviewed to ensure that "
-"Mozilla users have a stable and safe experience. All add-ons submissions are"
-" reviewed using the guidelines outlined in the <a href=\"%(url)s\">Editors "
-"Reviewing Guide</a>."
+"All add-ons submitted, whether new or updated, are reviewed to ensure that Mozilla users have a stable and safe experience. All add-ons submissions are reviewed using the guidelines outlined in the "
+"<a href=\"%(url)s\">Editors Reviewing Guide</a>."
 msgstr ""
-"Krejt shtesat e parashtruara, të reja apo të përditësuara, shqyrtohen, që "
-"përdoruesve t’u bëhet e mundur një punim i qëndrueshëm dhe i parrezik. Krejt"
-" parashtrimet e shtesave shqyrtohen duke përdorur udhëzimet e përcaktuara te"
-" <a href=\"%(url)s\">Udhërrëfyesi i Redaktorëve të Shqyrtimeve</a>."
+"Krejt shtesat e parashtruara, të reja apo të përditësuara, shqyrtohen, që përdoruesve t’u bëhet e mundur një punim i qëndrueshëm dhe i parrezik. Krejt parashtrimet e shtesave shqyrtohen duke "
+"përdorur udhëzimet e përcaktuara te <a href=\"%(url)s\">Udhërrëfyesi i Redaktorëve të Shqyrtimeve</a>."
 
 #: src/olympia/pages/templates/pages/dev_faq.html:393
 msgid "Who reviews my add-on?"
@@ -12682,21 +10008,13 @@ msgstr "Kush e shqyrton shtesën time?"
 #: src/olympia/pages/templates/pages/dev_faq.html:395
 #, python-format
 msgid ""
-"Add-ons are reviewed by the AMO Editors, a group of talented developers that"
-" volunteer to help the Mozilla project by reviewing add-ons to ensure a "
-"stable and safe experience for Mozilla users. When communicating with "
-"editors, please be courteous, patient and respectful as they are working "
-"hard to ensure that your add-on is set up correctly and follows the "
-"guidelines outlined in the <a href=\"%(url)s\">Editors Reviewing Guide</a>."
+"Add-ons are reviewed by the AMO Editors, a group of talented developers that volunteer to help the Mozilla project by reviewing add-ons to ensure a stable and safe experience for Mozilla users. "
+"When communicating with editors, please be courteous, patient and respectful as they are working hard to ensure that your add-on is set up correctly and follows the guidelines outlined in the <a "
+"href=\"%(url)s\">Editors Reviewing Guide</a>."
 msgstr ""
-"Shtesat shqyrtohen nga Redaktorët e AMO-s, një grup programuesish të "
-"talentuar, vullnetarë në ndihmë të projektit Mozilla që shqyrtojnë shtesat "
-"për t’u siguruar përdoruesve Mozilla një punim të qëndrueshëm dhe të "
-"parrezik. Kur komunikoni me redaktorët, ju lutemi, jini të sjellshëm, të "
-"duruar dhe me respekt, pasi ata punojnë fort për të siguruar që shtesa juaj "
-"të jetë rregulluar si duhet dhe se është në pajtim me udhëzimet e "
-"përcaktuara në <a href=\"%(url)s\">Udhërrëfyesin e Redaktorëve të "
-"Shtesave</a>."
+"Shtesat shqyrtohen nga Redaktorët e AMO-s, një grup programuesish të talentuar, vullnetarë në ndihmë të projektit Mozilla që shqyrtojnë shtesat për t’u siguruar përdoruesve Mozilla një punim të "
+"qëndrueshëm dhe të parrezik. Kur komunikoni me redaktorët, ju lutemi, jini të sjellshëm, të duruar dhe me respekt, pasi ata punojnë fort për të siguruar që shtesa juaj të jetë rregulluar si duhet "
+"dhe se është në pajtim me udhëzimet e përcaktuara në <a href=\"%(url)s\">Udhërrëfyesin e Redaktorëve të Shtesave</a>."
 
 #: src/olympia/pages/templates/pages/dev_faq.html:406
 msgid "What are the guidelines used to review my add-on?"
@@ -12705,30 +10023,20 @@ msgstr "Cilat janë udhëzimet e përdorura për të shqyrtuar shtesën time?"
 #: src/olympia/pages/templates/pages/dev_faq.html:408
 #, python-format
 msgid ""
-"The Mozilla editorial team follows the <a href=\"%(url)s\">Editors Reviewing"
-" Guide</a> when testing an add-on for acceptance onto AMO. It is important "
-"that add-on developers review this guide to ensure that common problem areas"
-" are addressed prior to submitting their add-on for review. This will "
-"greatly assist in expediting the review process."
+"The Mozilla editorial team follows the <a href=\"%(url)s\">Editors Reviewing Guide</a> when testing an add-on for acceptance onto AMO. It is important that add-on developers review this guide to "
+"ensure that common problem areas are addressed prior to submitting their add-on for review. This will greatly assist in expediting the review process."
 msgstr ""
-"Kur vë në provë një shtesë, për pranim te AMO, ekipi i shqyrtuesve të "
-"shtesave Mozilla ndjek <a href=\"%(url)s\">Udhërrëfyesin për Shqyrtimet</a>."
-" Është e rëndësishme që zhvilluesit e shtesave ta studiojnë këtë "
-"udhërrëfyes, për të bërë të mundur që problemet e rëndomta të jenë trajtuar "
-"përpara parashtrimit të shtesës për shqyrtim. Kjo do të ndihmojë fort në "
-"përshpejtimin e procesit të shqyrtimit."
+"Kur vë në provë një shtesë, për pranim te AMO, ekipi i shqyrtuesve të shtesave Mozilla ndjek <a href=\"%(url)s\">Udhërrëfyesin për Shqyrtimet</a>. Është e rëndësishme që zhvilluesit e shtesave ta "
+"studiojnë këtë udhërrëfyes, për të bërë të mundur që problemet e rëndomta të jenë trajtuar përpara parashtrimit të shtesës për shqyrtim. Kjo do të ndihmojë fort në përshpejtimin e procesit të "
+"shqyrtimit."
 
 #: src/olympia/pages/templates/pages/dev_faq.html:418
 msgid "How long will it take for my add-on to be reviewed?"
 msgstr "Sa kohë do të duhet për shqyrtimin e shtesës sime?"
 
 #: src/olympia/pages/templates/pages/dev_faq.html:420
-msgid ""
-"We cannot give a time estimate as to how long it will take before an add-on "
-"is reviewed. Many factors affect the time including the:"
-msgstr ""
-"Nuk japim dot përafërsisht një kohë se sa do të duhet përpara se një shtesë "
-"të jetë shqyrtuar. Ka shumë faktorë që ndikojnë, përfshi:"
+msgid "We cannot give a time estimate as to how long it will take before an add-on is reviewed. Many factors affect the time including the:"
+msgstr "Nuk japim dot përafërsisht një kohë se sa do të duhet përpara se një shtesë të jetë shqyrtuar. Ka shumë faktorë që ndikojnë, përfshi:"
 
 #. part of a list (<li>)
 #: src/olympia/pages/templates/pages/dev_faq.html:427
@@ -12748,32 +10056,20 @@ msgstr "numër zonash problematike të zbuluara"
 #: src/olympia/pages/templates/pages/dev_faq.html:434
 #, python-format
 msgid ""
-"This is why it's very important to read the <a href=\"%(g_url)s\">Editors "
-"Reviewing Guide</a> to ensure that your add-on is setup as expected.  It's "
-"also a good idea to read the blog post, <a "
-"href=\"%(blog_url)s\">Successfully Getting your Add-on Reviewed</a> which "
-"provides excellent insight into ensuring a smooth review of your add-on."
+"This is why it's very important to read the <a href=\"%(g_url)s\">Editors Reviewing Guide</a> to ensure that your add-on is setup as expected. It's also a good idea to read the blog post, <a href="
+"\"%(blog_url)s\">Successfully Getting your Add-on Reviewed</a> which provides excellent insight into ensuring a smooth review of your add-on."
 msgstr ""
-"Kjo është arsyeja pse është me shumë rëndësi të lexohet <a "
-"href=\"%(g_url)s\">Udhërrëfyesi për Redaktorë Shqyrtimesh</a> për të "
-"siguruar që shtesa juaj është rregulluar ashtu siç pritet. Po ashtu, është "
-"ide e mirë të lexohet postimi në blog, <a href=\"%(blog_url)s\">Successfully"
-" Getting your Add-on Reviewed</a> që ofron këndvështrim të shkëlqyer lidhur "
-"me bërjen të mundur të një shqyrtimi të rrjedhshëm të shtesës suaj."
+"Kjo është arsyeja pse është me shumë rëndësi të lexohet <a href=\"%(g_url)s\">Udhërrëfyesi për Redaktorë Shqyrtimesh</a> për të siguruar që shtesa juaj është rregulluar ashtu siç pritet. Po ashtu, "
+"është ide e mirë të lexohet postimi në blog, <a href=\"%(blog_url)s\">Successfully Getting your Add-on Reviewed</a> që ofron këndvështrim të shkëlqyer lidhur me bërjen të mundur të një shqyrtimi të "
+"rrjedhshëm të shtesës suaj."
 
 #: src/olympia/pages/templates/pages/dev_faq.html:446
 msgid "How can I see how many times my add-on has been downloaded?"
 msgstr "Si mund ta shoh se sa herë është shkarkuar shtesa ime?"
 
 #: src/olympia/pages/templates/pages/dev_faq.html:448
-msgid ""
-"The Statistics Dashboard found in the Developer Tools dashboard provides "
-"information that can help you determine your add-on downloads since you've "
-"submitted it to AMO."
-msgstr ""
-"Pulti i Statistikave te pulti Mjete Zhvilluesi ju ofron të dhëna që mund "
-"t’ju ndihmojnë të përcaktoni shkarkimet e shtesës suaj që nga parashtrimi i "
-"saj te AMO."
+msgid "The Statistics Dashboard found in the Developer Tools dashboard provides information that can help you determine your add-on downloads since you've submitted it to AMO."
+msgstr "Pulti i Statistikave te pulti Mjete Zhvilluesi ju ofron të dhëna që mund t’ju ndihmojnë të përcaktoni shkarkimet e shtesës suaj që nga parashtrimi i saj te AMO."
 
 #: src/olympia/pages/templates/pages/dev_faq.html:455
 msgid "How can I see how many active users are using my add-on?"
@@ -12781,27 +10077,20 @@ msgstr "Si mund të shoh se sa përdorues aktivë po e përdorin shtesën time?"
 
 #: src/olympia/pages/templates/pages/dev_faq.html:457
 msgid ""
-"The Statistics Dashboard found in the Developer Tools dashboard provides "
-"information that can help you determine how many users have been actively "
-"using your add-on since you've submitted it to AMO."
+"The Statistics Dashboard found in the Developer Tools dashboard provides information that can help you determine how many users have been actively using your add-on since you've submitted it to AMO."
 msgstr ""
-"Pulti i Statistikave që gjeni te pulti i Mjeteve të Zhvilluesit ofron "
-"informacion që mund t’ju ndihmojë të përcaktoni sa përdorues e kanë përdorur"
-" aktivisht shtesën tuaj që nga parashtrimi i saj te AMO."
+"Pulti i Statistikave që gjeni te pulti i Mjeteve të Zhvilluesit ofron informacion që mund t’ju ndihmojë të përcaktoni sa përdorues e kanë përdorur aktivisht shtesën tuaj që nga parashtrimi i saj te "
+"AMO."
 
 #: src/olympia/pages/templates/pages/dev_faq.html:464
 msgid "How do I submit an update for my add-on?"
 msgstr "Si të parashtroj një përditësim për shtesën time?"
 
 #: src/olympia/pages/templates/pages/dev_faq.html:466
-msgid ""
-"You can submit an update for your add-on via the Developer Tools dashboard "
-"by choosing the option \"Upload a new version\" and uploading a new .xpi "
-"file for your add-on."
+msgid "You can submit an update for your add-on via the Developer Tools dashboard by choosing the option \"Upload a new version\" and uploading a new .xpi file for your add-on."
 msgstr ""
-"Për shtesën tuaj mund të parashtroni një përditësim përmes pultit të Mjeteve"
-" të Zhvilluesve, duke përzgjedhur mundësinë \"Ngarkoni një version të ri\" "
-"dhe duke ngarkuar një kartelë të re .xpi për shtesën tuaj."
+"Për shtesën tuaj mund të parashtroni një përditësim përmes pultit të Mjeteve të Zhvilluesve, duke përzgjedhur mundësinë \"Ngarkoni një version të ri\" dhe duke ngarkuar një kartelë të re .xpi për "
+"shtesën tuaj."
 
 #: src/olympia/pages/templates/pages/dev_faq.html:473
 msgid "Does my update need to be reviewed by editors?"
@@ -12809,49 +10098,32 @@ msgstr "A lypset që përditësimi im të shqyrtohet nga redaktorët?"
 
 #: src/olympia/pages/templates/pages/dev_faq.html:475
 msgid ""
-"That depends. If you are simply changing a description of your add-on or "
-"updating a \"maxVersion\" to ensure compatibility with a new Mozilla "
-"software update, then your add-on does not need to be reviewed again. If, "
-"however, you submit a new updated file, then your add-on update will need to"
-" be reviewed by an editor."
+"That depends. If you are simply changing a description of your add-on or updating a \"maxVersion\" to ensure compatibility with a new Mozilla software update, then your add-on does not need to be "
+"reviewed again. If, however, you submit a new updated file, then your add-on update will need to be reviewed by an editor."
 msgstr ""
-"Varet. Nëse thjesht po ndryshoni një përshkrim të shtesës suaj, ose po "
-"përditësoni \"maxVersion\" që të siguroni përputhshmërinë me një përditësim "
-"të ri të software-it Mozilla, shtesa juaj s’ka nevojë të merret në shqyrtim "
-"sërish. Por, nëse parashtroni një kartelë të re të përditësuar, atëherë sh "
-"përditësimi i shtesës suaj do të lypë shqyrtim nga një redaktor."
+"Varet. Nëse thjesht po ndryshoni një përshkrim të shtesës suaj, ose po përditësoni \"maxVersion\" që të siguroni përputhshmërinë me një përditësim të ri të software-it Mozilla, shtesa juaj s’ka "
+"nevojë të merret në shqyrtim sërish. Por, nëse parashtroni një kartelë të re të përditësuar, atëherë sh përditësimi i shtesës suaj do të lypë shqyrtim nga një redaktor."
 
 #: src/olympia/pages/templates/pages/dev_faq.html:486
-msgid ""
-"How do I reply to a user who has posted a negative review of my add-on?"
-msgstr ""
-"Si t’i përgjigjem një përdoruesi që ka postuar një shqyrtim negativ të "
-"shtesës sime?"
+msgid "How do I reply to a user who has posted a negative review of my add-on?"
+msgstr "Si t’i përgjigjem një përdoruesi që ka postuar një shqyrtim negativ të shtesës sime?"
 
 #: src/olympia/pages/templates/pages/dev_faq.html:488
-msgid ""
-"A developer may reply to any review posted to their add-on as long as they "
-"are logged into AMO. In addition, any user can flag a review as:"
-msgstr ""
-"Një zhvillues mund t’i përgjigjet cilitdo shqyrtim të postuar mbi shtesën e "
-"tyre, mjaft të kenë bërë hyrjen në AMO. Për më tepër, çdo shqyrtues mund t’i"
-" vërë shenjë një shqyrtimi si:"
+msgid "A developer may reply to any review posted to their add-on as long as they are logged into AMO. In addition, any user can flag a review as:"
+msgstr "Një zhvillues mund t’i përgjigjet cilitdo shqyrtim të postuar mbi shtesën e tyre, mjaft të kenë bërë hyrjen në AMO. Për më tepër, çdo shqyrtues mund t’i vërë shenjë një shqyrtimi si:"
 
 #. part of a list (<li>)
-#: src/olympia/pages/templates/pages/dev_faq.html:495
-#: src/olympia/reviews/models.py:159
+#: src/olympia/pages/templates/pages/dev_faq.html:495 src/olympia/reviews/models.py:159
 msgid "Spam or otherwise non-review content"
 msgstr "E pavlerë ose përndryshe lëndë jo nga shqyrtime"
 
 #. part of a list (<li>)
-#: src/olympia/pages/templates/pages/dev_faq.html:497
-#: src/olympia/reviews/models.py:160
+#: src/olympia/pages/templates/pages/dev_faq.html:497 src/olympia/reviews/models.py:160
 msgid "Inappropriate language/dialog"
 msgstr "Gjuhë/dialog i papërshtatshëm"
 
 #. part of a list (<li>)
-#: src/olympia/pages/templates/pages/dev_faq.html:499
-#: src/olympia/reviews/models.py:161
+#: src/olympia/pages/templates/pages/dev_faq.html:499 src/olympia/reviews/models.py:161
 msgid "Misplaced bug report or support request"
 msgstr "Njoftim të metash apo kërkesë për asistencë jo në vendin e duhur"
 
@@ -12861,129 +10133,72 @@ msgid "Other (provides a pop-up prompt for information)"
 msgstr "Tjetër (ofron një fushë hapmbyll për informacion)"
 
 #: src/olympia/pages/templates/pages/dev_faq.html:504
-msgid ""
-"Currently, AMO does not provide a mechanism to directly communicate with a "
-"reviewer but this feature is being investigated and considered for a future "
-"update."
-msgstr ""
-"Hëpërhë, AMO s’ofron ndonjë mekanizëm për komunikim të drejtpërdrejtë me një"
-" shqyrtues, por kjo veçori po merret në shqyrtim për një version të së "
-"ardhmes."
+msgid "Currently, AMO does not provide a mechanism to directly communicate with a reviewer but this feature is being investigated and considered for a future update."
+msgstr "Hëpërhë, AMO s’ofron ndonjë mekanizëm për komunikim të drejtpërdrejtë me një shqyrtues, por kjo veçori po merret në shqyrtim për një version të së ardhmes."
 
 #: src/olympia/pages/templates/pages/dev_faq.html:511
 msgid "Can I request that a review be removed if the review is negative?"
-msgstr ""
-"A mund të kërkoj heqjen e një shqyrtuesi, nëse shqyrtimi është negativ?"
+msgstr "A mund të kërkoj heqjen e një shqyrtuesi, nëse shqyrtimi është negativ?"
 
 #: src/olympia/pages/templates/pages/dev_faq.html:513
-msgid ""
-"No. We do not remove negative reviews from add-ons unless they are found to "
-"be false."
-msgstr ""
-"Jo. Nuk i heqim shqyrtimet negative mbi një shtesë, veç në u gjetshin të "
-"rreme."
+msgid "No. We do not remove negative reviews from add-ons unless they are found to be false."
+msgstr "Jo. Nuk i heqim shqyrtimet negative mbi një shtesë, veç në u gjetshin të rreme."
 
 #: src/olympia/pages/templates/pages/dev_faq.html:519
 msgid "Can I request that a review be removed if the review is inaccurate?"
-msgstr ""
-"A mund të kërkoj heqjen e një shqyrtuesi, nëse shqyrtimi është i pasaktë?"
+msgstr "A mund të kërkoj heqjen e një shqyrtuesi, nëse shqyrtimi është i pasaktë?"
 
 #: src/olympia/pages/templates/pages/dev_faq.html:521
-msgid ""
-"If an author contacts us and asks for a review containing false or "
-"inaccurate information to be removed, we will review the post and consider "
-"removing it."
-msgstr ""
-"Nëse një autor na kontakton dhe na kërkon që një shqyrtim të hiqet, sepse "
-"përmban informacion të rremë ose të pasaktë, do ta marrim në shqyrtim "
-"postimin dhe do të shohim edhe heqjen e tij."
+msgid "If an author contacts us and asks for a review containing false or inaccurate information to be removed, we will review the post and consider removing it."
+msgstr "Nëse një autor na kontakton dhe na kërkon që një shqyrtim të hiqet, sepse përmban informacion të rremë ose të pasaktë, do ta marrim në shqyrtim postimin dhe do të shohim edhe heqjen e tij."
 
 #: src/olympia/pages/templates/pages/dev_faq.html:530
 msgid ""
-"Do you need more information about the various open source licenses? Are you"
-" confused as to which license you should select? What rights does a specific"
-" license grant? While nothing replaces reading the full terms of a license, "
-"below are some sites that contain information about some of the key open "
-"source licenses that may help you sort out the differences between them. "
-"These sites are being provided solely for your convenience and as a "
-"reference for your personal use. These resources do not constitute legal "
-"advice nor should they be used in lieu of such advice. Mozilla neither "
-"guarantees nor is responsible for the content of these sites or your "
-"reliance on such content."
+"Do you need more information about the various open source licenses? Are you confused as to which license you should select? What rights does a specific license grant? While nothing replaces "
+"reading the full terms of a license, below are some sites that contain information about some of the key open source licenses that may help you sort out the differences between them. These sites "
+"are being provided solely for your convenience and as a reference for your personal use. These resources do not constitute legal advice nor should they be used in lieu of such advice. Mozilla "
+"neither guarantees nor is responsible for the content of these sites or your reliance on such content."
 msgstr ""
-"Ju duhet më tepër informacion rreth licencash të ndryshme burimi të hapur? "
-"Jeni në mëdyshje se cilën licencë do të duhej të përzgjidhnit? Ç’të drejta "
-"akordon një licencë e caktuar? Ndërkohë që asgjë s’mund të zëvendësojë "
-"leximin e kushteve të plota të një licence, më poshtë keni disa sajte që "
-"përmbajnë të dhëna mbi disa nga licencat e njohura të burimit të hapur, që "
-"mund t’ju ndihmojnë të kuptoni dallimet mes tyre. Këto sajte jepen këtu "
-"vetëm për t’ju lehtësuar punën dhe si referencë për përdorim personal. Këto "
-"burime s’përbëjnë ndihmë ligjore, dhe as duhen përdorur në vend të një "
-"ndihme të tillë. Mozilla as garanton, dhe as mban përgjegjësi për lëndën e "
-"këtyre sajteve, dhe as për mbështetjen tuaj në lëndë të tillë."
+"Ju duhet më tepër informacion rreth licencash të ndryshme burimi të hapur? Jeni në mëdyshje se cilën licencë do të duhej të përzgjidhnit? Ç’të drejta akordon një licencë e caktuar? Ndërkohë që "
+"asgjë s’mund të zëvendësojë leximin e kushteve të plota të një licence, më poshtë keni disa sajte që përmbajnë të dhëna mbi disa nga licencat e njohura të burimit të hapur, që mund t’ju ndihmojnë "
+"të kuptoni dallimet mes tyre. Këto sajte jepen këtu vetëm për t’ju lehtësuar punën dhe si referencë për përdorim personal. Këto burime s’përbëjnë ndihmë ligjore, dhe as duhen përdorur në vend të "
+"një ndihme të tillë. Mozilla as garanton, dhe as mban përgjegjësi për lëndën e këtyre sajteve, dhe as për mbështetjen tuaj në lëndë të tillë."
 
 #: src/olympia/pages/templates/pages/dev_faq.html:545
 msgid ""
-"In addition to the full text of the Mozilla Public License(\"MPL\"), this "
-"also provides an annotated version of the MPL and an <abbr "
-"title=\"Frequently Asked Questions\">FAQ</abbr> to help you if you want to "
-"use or distribute code licensed under it."
+"In addition to the full text of the Mozilla Public License(\"MPL\"), this also provides an annotated version of the MPL and an <abbr title=\"Frequently Asked Questions\">FAQ</abbr> to help you if "
+"you want to use or distribute code licensed under it."
 msgstr ""
-"Përtej tekstit të plotë të licencës Mozilla Public License(\"MPL\"), këtu "
-"jepet një version i komentuar i MPL-së dhe një ndarje <abbr "
-"title=\"Frequently Asked Questions\">FAQ</abbr>, për t’ju ndihmuar të "
-"përdorni ose shpërndani kod të licencuar sipas saj."
+"Përtej tekstit të plotë të licencës Mozilla Public License(\"MPL\"), këtu jepet një version i komentuar i MPL-së dhe një ndarje <abbr title=\"Frequently Asked Questions\">FAQ</abbr>, për t’ju "
+"ndihmuar të përdorni ose shpërndani kod të licencuar sipas saj."
 
 #: src/olympia/pages/templates/pages/dev_faq.html:559
-msgid ""
-"A table summarizing and comparing how some of the key open source licenses "
-"treat distributions, proprietary software linking, and redistribution of "
-"code with changes."
-msgstr ""
-"Një tabelë që përmbledh dhe krahason se si disa prej licencave të njohura të"
-" burimit të hapur trajtojnë shpërndarjen, lidhjen te software pronësor, dhe "
-"rishpërndarjen e kodit me ndryshim."
+msgid "A table summarizing and comparing how some of the key open source licenses treat distributions, proprietary software linking, and redistribution of code with changes."
+msgstr "Një tabelë që përmbledh dhe krahason se si disa prej licencave të njohura të burimit të hapur trajtojnë shpërndarjen, lidhjen te software pronësor, dhe rishpërndarjen e kodit me ndryshim."
 
 #: src/olympia/pages/templates/pages/dev_faq.html:572
 msgid ""
-"Free Software Foundation provides short summaries of the key open source "
-"licenses, including whether the license qualifies as a free software license"
-" or a copyleft license.  Also includes a discussion of what constitutes a "
-"free software license or a copyleft license (e.g., a Copyleft license is a "
-"general method for making a program or other work free, and requiring all "
-"modified and extended versions of the program to be free as well.)"
+"Free Software Foundation provides short summaries of the key open source licenses, including whether the license qualifies as a free software license or a copyleft license. Also includes a "
+"discussion of what constitutes a free software license or a copyleft license (e.g., a Copyleft license is a general method for making a program or other work free, and requiring all modified and "
+"extended versions of the program to be free as well.)"
 msgstr ""
-"Free Software Foundation ofron përmbledhje të shkurtra të licencave kryesore"
-" të burimit të hapur, përfshi gjykimin nëse licenca kualifikohet si licencë "
-"software-i të lirë ose licencë copyleft. Po aty përfshihet një diskutim se "
-"çfarë e bën një licencë, licencë software-i të lirë apo licencë copyleft "
-"(p.sh., një licencë copyleft është një metodë e përgjithshme për ta bërë të "
-"lirë një program ose një vepër, dhe që kërkon domosdoshmërisht që krejt "
-"versionet e ndryshuara dhe zgjeruara të programit të jenë edhe ato të lira.)"
+"Free Software Foundation ofron përmbledhje të shkurtra të licencave kryesore të burimit të hapur, përfshi gjykimin nëse licenca kualifikohet si licencë software-i të lirë ose licencë copyleft. Po "
+"aty përfshihet një diskutim se çfarë e bën një licencë, licencë software-i të lirë apo licencë copyleft (p.sh., një licencë copyleft është një metodë e përgjithshme për ta bërë të lirë një program "
+"ose një vepër, dhe që kërkon domosdoshmërisht që krejt versionet e ndryshuara dhe zgjeruara të programit të jenë edhe ato të lira.)"
 
 #: src/olympia/pages/templates/pages/dev_faq.html:589
-msgid ""
-"Open Source Initiative provides the terms of some of the key open source "
-"licenses."
-msgstr ""
-"Open Source Initiative ejp kushtet e disa prej licencave kryesore të burimit"
-" të hapur."
+msgid "Open Source Initiative provides the terms of some of the key open source licenses."
+msgstr "Open Source Initiative ejp kushtet e disa prej licencave kryesore të burimit të hapur."
 
 #: src/olympia/pages/templates/pages/dev_faq.html:599
 msgid "A comparison of known open source licenses on Wikipedia."
 msgstr "Krahasim licencash të njohura burimi të hapur, te Wikipedia."
 
 #: src/olympia/pages/templates/pages/dev_faq.html:605
-msgid ""
-"A site to provide non-judgmental guidance on choosing a license for your "
-"open source project."
-msgstr ""
-"Sajt për të dhënë udhëzime, jo verdikte, mbi zgjedhjen e një licence për "
-"projektin tuaj me burim të hapur."
+msgid "A site to provide non-judgmental guidance on choosing a license for your open source project."
+msgstr "Sajt për të dhënë udhëzime, jo verdikte, mbi zgjedhjen e një licence për projektin tuaj me burim të hapur."
 
-#: src/olympia/pages/templates/pages/faq.html:3
-#: src/olympia/pages/templates/pages/faq.html:9
-#: src/olympia/pages/templates/pages/faq.html:10
+#: src/olympia/pages/templates/pages/faq.html:3 src/olympia/pages/templates/pages/faq.html:9 src/olympia/pages/templates/pages/faq.html:10
 msgid "Frequently Asked Questions"
 msgstr "Pyetje të Bëra Shpesh"
 
@@ -12998,19 +10213,12 @@ msgstr "Ç’është një shtesë?"
 #: src/olympia/pages/templates/pages/faq.html:16
 #, python-format
 msgid ""
-"Add-ons are small pieces of software that add new features or functionality "
-"to your installation of %(app_name)s. Add-ons can augment %(app_name)s with "
-"new features, foreign language dictionaries, or change its visual "
-"appearance. Through add-ons, you can customize %(app_name)s to meet your "
-"needs and tastes. <a href=\"%(learnmore_url)s\">Learn more about "
-"customization</a>"
+"Add-ons are small pieces of software that add new features or functionality to your installation of %(app_name)s. Add-ons can augment %(app_name)s with new features, foreign language dictionaries, "
+"or change its visual appearance. Through add-ons, you can customize %(app_name)s to meet your needs and tastes. <a href=\"%(learnmore_url)s\">Learn more about customization</a>"
 msgstr ""
-"Shtesat janë programe të vegjël që shtojnë te instalimi juaj i "
-"%(app_name)s-it veçori ose funksione të reja shtese. Shtesat mund ta rrisin "
-"%(app_name)s-in me veçori të reja, fjalorë gjuhësh të huaja, ose të "
-"ndryshojnë anën pamore të tij. Përmes shtesave, %(app_name)s-in mund të "
-"personalizoni që të puqet me shijet dhe nevojat tuaja. <a "
-"href=\"%(learnmore_url)s\">Mësoni më tepër rreth personalizimit</a>"
+"Shtesat janë programe të vegjël që shtojnë te instalimi juaj i %(app_name)s-it veçori ose funksione të reja shtese. Shtesat mund ta rrisin %(app_name)s-in me veçori të reja, fjalorë gjuhësh të "
+"huaja, ose të ndryshojnë anën pamore të tij. Përmes shtesave, %(app_name)s-in mund të personalizoni që të puqet me shijet dhe nevojat tuaja. <a href=\"%(learnmore_url)s\">Mësoni më tepër rreth "
+"personalizimit</a>"
 
 #: src/olympia/pages/templates/pages/faq.html:26
 msgid "Will add-ons work with my web browser or application?"
@@ -13019,25 +10227,14 @@ msgstr "A do të punojnë shtesat me shfletuesin ose aplikacionin tim web?"
 #: src/olympia/pages/templates/pages/faq.html:27
 #, python-format
 msgid ""
-"Add-ons listed in this gallery only work with Mozilla-based applications, "
-"such as <a href=\"%(getfirefox_url)s\">Firefox</a>, <a "
-"href=\"%(getmobile_url)s\">Firefox Mobile</a>, <a "
-"href=\"%(getseamonkey_url)s\">SeaMonkey</a>, and <a "
-"href=\"%(getthunderbird_url)s\">Thunderbird</a>. However, not all add-ons "
-"work with each of those applications or every version of those applications."
-" Each add-on specifies which applications and versions it works with, such "
-"as Firefox 2.0 - 3.6.*. For Firefox add-ons, the install buttons will "
-"indicate whether the add-on is compatible or not."
+"Add-ons listed in this gallery only work with Mozilla-based applications, such as <a href=\"%(getfirefox_url)s\">Firefox</a>, <a href=\"%(getmobile_url)s\">Firefox Mobile</a>, <a href="
+"\"%(getseamonkey_url)s\">SeaMonkey</a>, and <a href=\"%(getthunderbird_url)s\">Thunderbird</a>. However, not all add-ons work with each of those applications or every version of those applications. "
+"Each add-on specifies which applications and versions it works with, such as Firefox 2.0 - 3.6.*. For Firefox add-ons, the install buttons will indicate whether the add-on is compatible or not."
 msgstr ""
-"Shtesat e treguara në këtë galeri punojnë vetëm për aplikacione me bazë "
-"Mozilla, të tilla si <a href=\"%(getfirefox_url)s\">Firefox</a>, <a "
-"href=\"%(getmobile_url)s\">Firefox Mobile</a>, <a "
-"href=\"%(getseamonkey_url)s\">SeaMonkey</a>, dhe <a "
-"href=\"%(getthunderbird_url)s\">Thunderbird</a>. Megjithatë, jo të tëra "
-"shtesat punojnë me krejt këto aplikacione, ose me çdo version të këtyre "
-"aplikacioneve. Çdo shtesë e tregon se me cilat aplikacione dhe versione "
-"punon, fjala vjen Firefox 2.0 - 3.6.*. Për shtesat për Firefox, pjesa e "
-"instalimit do të tregojë nëse shtesa është e përputhshme ose jo."
+"Shtesat e treguara në këtë galeri punojnë vetëm për aplikacione me bazë Mozilla, të tilla si <a href=\"%(getfirefox_url)s\">Firefox</a>, <a href=\"%(getmobile_url)s\">Firefox Mobile</a>, <a href="
+"\"%(getseamonkey_url)s\">SeaMonkey</a>, dhe <a href=\"%(getthunderbird_url)s\">Thunderbird</a>. Megjithatë, jo të tëra shtesat punojnë me krejt këto aplikacione, ose me çdo version të këtyre "
+"aplikacioneve. Çdo shtesë e tregon se me cilat aplikacione dhe versione punon, fjala vjen Firefox 2.0 - 3.6.*. Për shtesat për Firefox, pjesa e instalimit do të tregojë nëse shtesa është e "
+"përputhshme ose jo."
 
 #: src/olympia/pages/templates/pages/faq.html:42
 msgid "What are the different types of add-ons?"
@@ -13045,78 +10242,43 @@ msgstr "Ç’janë llojet e ndryshme të shtesave?"
 
 #: src/olympia/pages/templates/pages/faq.html:43
 #, python-format
-msgid ""
-"There are several kinds of add-ons that customize %(app_name)s in different "
-"ways:"
-msgstr ""
-"Ka një numër shtesash për personalizimin e %(app_name)s-it në rrugë të "
-"ndryshme:"
+msgid "There are several kinds of add-ons that customize %(app_name)s in different ways:"
+msgstr "Ka një numër shtesash për personalizimin e %(app_name)s-it në rrugë të ndryshme:"
 
 #: src/olympia/pages/templates/pages/faq.html:47
 #, python-format
 msgid ""
-"<strong><a href=\"%(browse_url)s\">Extensions</a></strong> add new features "
-"to %(app_name)s or modify existing functionality. There are extensions that "
-"allow you to block advertisements, download videos from websites, integrate "
-"more closely with social websites, and add features you see in other "
-"applications."
+"<strong><a href=\"%(browse_url)s\">Extensions</a></strong> add new features to %(app_name)s or modify existing functionality. There are extensions that allow you to block advertisements, download "
+"videos from websites, integrate more closely with social websites, and add features you see in other applications."
 msgstr ""
-"<strong><a href=\"%(browse_url)s\">Zgjerime</a></strong> shtoni te "
-"%(app_name)s veçori të reja ose ndryshoni funksione ekzistuese. Ka zgjerime "
-"që ju lejojnë të bllokoni reklamat, të shkarkoni video prej sajtesh, të "
-"integroheni më tepër me sajte shoqërorë, dhe të shtoni veçori që shihni në "
-"aplikacione të tjera."
+"<strong><a href=\"%(browse_url)s\">Zgjerime</a></strong> shtoni te %(app_name)s veçori të reja ose ndryshoni funksione ekzistuese. Ka zgjerime që ju lejojnë të bllokoni reklamat, të shkarkoni video "
+"prej sajtesh, të integroheni më tepër me sajte shoqërorë, dhe të shtoni veçori që shihni në aplikacione të tjera."
 
 #: src/olympia/pages/templates/pages/faq.html:55
 #, python-format
-msgid ""
-"<strong><a href=\"%(browse_url)s\">Complete Themes</a></strong> change the "
-"entire appearance of %(app_name)s, usually including icons, colors, dialogs,"
-" and other visual styles."
-msgstr ""
-"<strong><a href=\"%(browse_url)s\">Temat e Plota</a></strong> ndryshojnë "
-"krejt pamjen në %(app_name)s, duke përfshirë zakonisht ikonat, ngjyrat, "
-"dialogët, dhe të tjerë elemente pamorë."
+msgid "<strong><a href=\"%(browse_url)s\">Complete Themes</a></strong> change the entire appearance of %(app_name)s, usually including icons, colors, dialogs, and other visual styles."
+msgstr "<strong><a href=\"%(browse_url)s\">Temat e Plota</a></strong> ndryshojnë krejt pamjen në %(app_name)s, duke përfshirë zakonisht ikonat, ngjyrat, dialogët, dhe të tjerë elemente pamorë."
 
 #: src/olympia/pages/templates/pages/faq.html:61
 #, python-format
-msgid ""
-"<strong><a href=\"%(browse_url)s\">Themes</a></strong> are lightweight "
-"themes that use background images to customize your %(app_name)s toolbars."
-msgstr ""
-"<strong><a href=\"%(browse_url)s\">Temat</a></strong> janë tema të lehta që "
-"përdorin figura sfondi për të personalizuar panelet tuaja te %(app_name)s."
+msgid "<strong><a href=\"%(browse_url)s\">Themes</a></strong> are lightweight themes that use background images to customize your %(app_name)s toolbars."
+msgstr "<strong><a href=\"%(browse_url)s\">Temat</a></strong> janë tema të lehta që përdorin figura sfondi për të personalizuar panelet tuaja te %(app_name)s."
 
 #: src/olympia/pages/templates/pages/faq.html:66
 #, python-format
-msgid ""
-"<strong><a href=\"%(browse_url)s\">Search Providers</a> </strong> add "
-"additional choices to the search box dropdown. These providers allow you to "
-"quickly search any website."
+msgid "<strong><a href=\"%(browse_url)s\">Search Providers</a> </strong> add additional choices to the search box dropdown. These providers allow you to quickly search any website."
 msgstr ""
-"<strong><a href=\"%(browse_url)s\">Mundësues Kërkimesh</a> </strong> shtoni "
-"te kutia hapmbyll e kërkimeve më tepër mundësit. Këta mundësues ju lejojnë "
-"të kërkoni shpejt e shpejt në çfarëdo sajti."
+"<strong><a href=\"%(browse_url)s\">Mundësues Kërkimesh</a> </strong> shtoni te kutia hapmbyll e kërkimeve më tepër mundësit. Këta mundësues ju lejojnë të kërkoni shpejt e shpejt në çfarëdo sajti."
 
 #: src/olympia/pages/templates/pages/faq.html:72
 #, python-format
-msgid ""
-"<strong><a href=\"%(browse_url)s\">Dictionaries & Language "
-"Packs</a></strong> add support for additional languages to %(app_name)s."
-msgstr ""
-"<strong><a href=\"%(browse_url)s\">Fjalorë & Paketa Gjuhësore</a></strong> "
-"shtoni mbulim për gjuhë të tjera te %(app_name)s."
+msgid "<strong><a href=\"%(browse_url)s\">Dictionaries & Language Packs</a></strong> add support for additional languages to %(app_name)s."
+msgstr "<strong><a href=\"%(browse_url)s\">Fjalorë & Paketa Gjuhësore</a></strong> shtoni mbulim për gjuhë të tjera te %(app_name)s."
 
 #: src/olympia/pages/templates/pages/faq.html:77
 #, python-format
-msgid ""
-"<strong><a href=\"%(browse_url)s\">Plugins</a></strong> help %(app_name)s "
-"display or understand different types of media, such as Adobe Flash or Apple"
-" Quicktime."
-msgstr ""
-"<strong><a href=\"%(browse_url)s\">Shtojcat</a></strong> e ndihmojnë "
-"%(app_name)s të shfaqë ose përpunojë lloje të ndryshme mediash, të tilla si "
-"Adobe Flash ose Apple Quicktime."
+msgid "<strong><a href=\"%(browse_url)s\">Plugins</a></strong> help %(app_name)s display or understand different types of media, such as Adobe Flash or Apple Quicktime."
+msgstr "<strong><a href=\"%(browse_url)s\">Shtojcat</a></strong> e ndihmojnë %(app_name)s të shfaqë ose përpunojë lloje të ndryshme mediash, të tilla si Adobe Flash ose Apple Quicktime."
 
 #: src/olympia/pages/templates/pages/faq.html:85
 msgid "How do I install, manage, or remove an add-on?"
@@ -13125,22 +10287,13 @@ msgstr "Si ta instaloj, administroj, ose heq një shtesë?"
 #: src/olympia/pages/templates/pages/faq.html:86
 #, python-format
 msgid ""
-"In most cases, add-ons can be installed by simply clicking the install "
-"button provided. Add-ons can be managed, disabled, or uninstalled from the "
-"Add-ons Manager in %(app_name)s. For more detailed instructions, read <a "
-"href=\"%(extension_url)s\">this article on extensions</a> or <a "
-"href=\"%(theme_url)s\">this one for Themes and Complete Themes</a>. If you "
-"have difficulty installing add-ons, see <a "
-"href=\"%(troubleshooting_url)s\">Troubleshooting Extensions and Themes</a>."
+"In most cases, add-ons can be installed by simply clicking the install button provided. Add-ons can be managed, disabled, or uninstalled from the Add-ons Manager in %(app_name)s. For more detailed "
+"instructions, read <a href=\"%(extension_url)s\">this article on extensions</a> or <a href=\"%(theme_url)s\">this one for Themes and Complete Themes</a>. If you have difficulty installing add-ons, "
+"see <a href=\"%(troubleshooting_url)s\">Troubleshooting Extensions and Themes</a>."
 msgstr ""
-"Në shumicën e rasteve shtesat mund të instalohen thjesht duke klikuar mbi "
-"butonin e instalimit për to. Shtesat mund të administrohen, çaktivizohen, "
-"ose çinstalohen, që nga Përgjegjësi i Shtesave te %(app_name)s-i. Për më "
-"tepër udhëzime të hollësishme, lexoni <a href=\"%(extension_url)s\">këtë "
-"artikull mbi zgjerimet</a> ose <a href=\"%(theme_url)s\">këtë lidhur me "
-"Temat dhe Temat e Plota</a>. Nëse keni vështirësi në instalimin e shtesave, "
-"shihni <a href=\"%(troubleshooting_url)s\">Diagnostikim Zgjerimesh dhe "
-"Temash</a>."
+"Në shumicën e rasteve shtesat mund të instalohen thjesht duke klikuar mbi butonin e instalimit për to. Shtesat mund të administrohen, çaktivizohen, ose çinstalohen, që nga Përgjegjësi i Shtesave te "
+"%(app_name)s-i. Për më tepër udhëzime të hollësishme, lexoni <a href=\"%(extension_url)s\">këtë artikull mbi zgjerimet</a> ose <a href=\"%(theme_url)s\">këtë lidhur me Temat dhe Temat e Plota</a>. "
+"Nëse keni vështirësi në instalimin e shtesave, shihni <a href=\"%(troubleshooting_url)s\">Diagnostikim Zgjerimesh dhe Temash</a>."
 
 #: src/olympia/pages/templates/pages/faq.html:100
 msgid "How do I install add-ons without restarting Firefox?"
@@ -13149,17 +10302,11 @@ msgstr "Si të instaloj shtesa pa rinisur Firefox-in?"
 #: src/olympia/pages/templates/pages/faq.html:101
 #, python-format
 msgid ""
-"In Firefox, add-ons marked with \"No restart required\" can be installed "
-"without restarting. These add-ons have been created using the <a "
-"href=\"%(sdk_url)s\">Add-on SDK</a> or <a "
-"href=\"%(bootstrap_url)s\">bootstrapping</a>. Other add-ons will still "
-"require a restart before you can use them."
+"In Firefox, add-ons marked with \"No restart required\" can be installed without restarting. These add-ons have been created using the <a href=\"%(sdk_url)s\">Add-on SDK</a> or <a href="
+"\"%(bootstrap_url)s\">bootstrapping</a>. Other add-ons will still require a restart before you can use them."
 msgstr ""
-"Te Firefox4, shtesat e shënuara me \"S’lyp rinisje\" mund të instalohen pa "
-"rinisje. Këto shtesa janë krijuar duke përdorur <a href=\"%(sdk_url)s\">SDK "
-"Shtesash</a> ose <a href=\"%(bootstrap_url)s\">bootstrapping</a>. Shtesat e "
-"tjera do ta kenë ende të nevojshme rinisjen, përpara se të mund t’i "
-"përdorni."
+"Te Firefox4, shtesat e shënuara me \"S’lyp rinisje\" mund të instalohen pa rinisje. Këto shtesa janë krijuar duke përdorur <a href=\"%(sdk_url)s\">SDK Shtesash</a> ose <a href=\"%(bootstrap_url)s"
+"\">bootstrapping</a>. Shtesat e tjera do ta kenë ende të nevojshme rinisjen, përpara se të mund t’i përdorni."
 
 #: src/olympia/pages/templates/pages/faq.html:110
 msgid "How do I keep add-ons up-to-date?"
@@ -13168,22 +10315,13 @@ msgstr "Si t’i mbaj të përditësuara shtesat?"
 #: src/olympia/pages/templates/pages/faq.html:111
 #, python-format
 msgid ""
-"Add-ons, unlike plugins, are automatically checked for updates once every "
-"day. In Firefox, updates are automatically installed by default. Versions of"
-" Firefox prior to 4 (and other applications) will alert you that updates to "
-"your add-ons are available. <a href=\"%(plugin_url)s\">Plugins</a> are not "
-"currently automatically checked for updates, so be sure to regularly visit "
-"the <a href=\"%(plugincheck_url)s\">Plugin Check</a> page to stay up-to-"
-"date."
+"Add-ons, unlike plugins, are automatically checked for updates once every day. In Firefox, updates are automatically installed by default. Versions of Firefox prior to 4 (and other applications) "
+"will alert you that updates to your add-ons are available. <a href=\"%(plugin_url)s\">Plugins</a> are not currently automatically checked for updates, so be sure to regularly visit the <a href="
+"\"%(plugincheck_url)s\">Plugin Check</a> page to stay up-to-date."
 msgstr ""
-"Për shtesat, ndryshe nga shtojcat, kontrollohet vetvetiu për përditësime një"
-" herë në ditë. Në Firefox, përditësimet, si parazgjedhje, do të instalohen "
-"vetvetiu. Versionet e Firefox-it para 4-s (dhe aplikacionet e tjera) do t’ju"
-" njoftojnë kur të ketë përditësime për shtesat tuaja. <a "
-"href=\"%(plugin_url)s\">Shtojcat</a> tani s’kontrollohen vetvetiu për "
-"përditësime, ndaj mos harroni të vizitoni rregullisht faqen <a "
-"href=\"%(plugincheck_url)s\">Kontroll Shtojcash</a> që t’i mbani të "
-"përditësuara."
+"Për shtesat, ndryshe nga shtojcat, kontrollohet vetvetiu për përditësime një herë në ditë. Në Firefox, përditësimet, si parazgjedhje, do të instalohen vetvetiu. Versionet e Firefox-it para 4-s (dhe "
+"aplikacionet e tjera) do t’ju njoftojnë kur të ketë përditësime për shtesat tuaja. <a href=\"%(plugin_url)s\">Shtojcat</a> tani s’kontrollohen vetvetiu për përditësime, ndaj mos harroni të vizitoni "
+"rregullisht faqen <a href=\"%(plugincheck_url)s\">Kontroll Shtojcash</a> që t’i mbani të përditësuara."
 
 #: src/olympia/pages/templates/pages/faq.html:122
 msgid "Are add-ons safe to install?"
@@ -13192,21 +10330,13 @@ msgstr "A janë të sigurta shtesat për t’i instaluar?"
 #: src/olympia/pages/templates/pages/faq.html:123
 #, python-format
 msgid ""
-"Unless clearly marked otherwise, add-ons available from this gallery have "
-"been checked and approved by Mozilla's team of editors and are safe to "
-"install. We recommend that you only install approved add-ons. If you wish to"
-" install unapproved add-ons or add-ons from third-party websites, use "
-"caution as these add-ons may harm your computer or violate your privacy. <a "
-"href=\"%(learnmore_url)s\">Learn more about our approval process</a>"
+"Unless clearly marked otherwise, add-ons available from this gallery have been checked and approved by Mozilla's team of editors and are safe to install. We recommend that you only install approved "
+"add-ons. If you wish to install unapproved add-ons or add-ons from third-party websites, use caution as these add-ons may harm your computer or violate your privacy. <a href=\"%(learnmore_url)s"
+"\">Learn more about our approval process</a>"
 msgstr ""
-"Hiq rastet kur tregohet qartë ndryshe, shtesat që mund të kihen prej kësaj "
-"galerie janë kontrolluar dhe miratuar nga ekipi Mozilla i redaktorëve dhe "
-"janë pa rrezik për instalim. Këshillojmë të instaloni vetëm shtesa të "
-"miratuara. Nëse dëshironi të instaloni shtesa të pamiratuara ose shtesa prej"
-" palësh të treta, bëni kujdes, ngaqë këto shtesa mund të dëmtojnë "
-"kompjuterin tuaj ose të cenojnë privatësinë tuaj. <a "
-"href=\"%(learnmore_url)s\">Mësoni më tepër rreth procesit tonë të "
-"miratimit</a>"
+"Hiq rastet kur tregohet qartë ndryshe, shtesat që mund të kihen prej kësaj galerie janë kontrolluar dhe miratuar nga ekipi Mozilla i redaktorëve dhe janë pa rrezik për instalim. Këshillojmë të "
+"instaloni vetëm shtesa të miratuara. Nëse dëshironi të instaloni shtesa të pamiratuara ose shtesa prej palësh të treta, bëni kujdes, ngaqë këto shtesa mund të dëmtojnë kompjuterin tuaj ose të "
+"cenojnë privatësinë tuaj. <a href=\"%(learnmore_url)s\">Mësoni më tepër rreth procesit tonë të miratimit</a>"
 
 #: src/olympia/pages/templates/pages/faq.html:133
 #, python-format
@@ -13216,46 +10346,28 @@ msgstr "A mund ta ngadalësojnë %(app_name)s-in shtesat?"
 #: src/olympia/pages/templates/pages/faq.html:135
 #, python-format
 msgid ""
-"Most add-ons do not cause a perceivable performance decrease in "
-"%(app_name)s, though installing an excessive number may have adverse "
-"effects. If you suspect an add-on is causing %(app_name)s to be slow, try "
-"disabling it."
+"Most add-ons do not cause a perceivable performance decrease in %(app_name)s, though installing an excessive number may have adverse effects. If you suspect an add-on is causing %(app_name)s to be "
+"slow, try disabling it."
 msgstr ""
-"Shumica e shtesa nuk shkaktojnë rënie të dallueshme të funksionimit në "
-"%(app_name)s, edhe pse instalimi i një numri të tepruar mund të ketë efekte "
-"negative. Nëse dyshoni se një shtesë po shkakton ngadalësimin e "
-"%(app_name)s, provoni ta çaktivizoni."
+"Shumica e shtesa nuk shkaktojnë rënie të dallueshme të funksionimit në %(app_name)s, edhe pse instalimi i një numri të tepruar mund të ketë efekte negative. Nëse dyshoni se një shtesë po shkakton "
+"ngadalësimin e %(app_name)s, provoni ta çaktivizoni."
 
 #: src/olympia/pages/templates/pages/faq.html:141
 #, python-format
-msgid ""
-"%(app_name)s told me an add-on isn't compatible. Is there a way I can still "
-"use it?"
-msgstr ""
-"%(app_name)s thotë se një shtesë s’është e përputhshme. A ka mundësi që ta "
-"përdor prapëseprapë?"
+msgid "%(app_name)s told me an add-on isn't compatible. Is there a way I can still use it?"
+msgstr "%(app_name)s thotë se një shtesë s’është e përputhshme. A ka mundësi që ta përdor prapëseprapë?"
 
 #: src/olympia/pages/templates/pages/faq.html:144
 #, python-format
 msgid ""
-"If an add-on isn't compatible with your version of %(app_name)s, it is "
-"usually either because your version of %(app_name)s is outdated or the add-"
-"on author has not yet updated the add-on to be compatible with a newer "
-"version you are using. Mozilla does not recommend trying to circumvent these"
-" compatibility checks, as they can lead to browser instability or in some "
-"cases loss of data. For users who are testing out alpha or beta versions of "
-"Firefox, we offer the <a href=\"%(acr_url)s\">Add-on Compatibility "
-"Reporter</a> to help add-on developers update their compatibility."
+"If an add-on isn't compatible with your version of %(app_name)s, it is usually either because your version of %(app_name)s is outdated or the add-on author has not yet updated the add-on to be "
+"compatible with a newer version you are using. Mozilla does not recommend trying to circumvent these compatibility checks, as they can lead to browser instability or in some cases loss of data. For "
+"users who are testing out alpha or beta versions of Firefox, we offer the <a href=\"%(acr_url)s\">Add-on Compatibility Reporter</a> to help add-on developers update their compatibility."
 msgstr ""
-"Nëse një shtesë s’është e përputhshme me versionin tuaj të %(app_name)s-it, "
-"zakonisht ndodh ose sepse versioni juaj i %(app_name)s-it është vjetruar, "
-"ose autori i shtesës s’e ka përditësuar ende shtesën, që kjo të jetë e "
-"përputhshme me versionin e ri që po përdorni. Mozilla nuk këshillon të "
-"provoni të anashkaloni këto kontrolle përputhshmërie, ngaqë kjo mund ta "
-"shpjerë shfletuesin në paqëndrueshmëri, ose në disa raste edhe në humbje të "
-"dhënash. Për përdoruesit që po provojnë versione alfa ose beta të Firefox-"
-"it, ofrojmë <a href=\"%(acr_url)s\">Raportues Përputhshmërie Shtesash</a>, "
-"për t’i ndihmuar zhvilluesit e shtesave në përditësimin e përputhshmërisë."
+"Nëse një shtesë s’është e përputhshme me versionin tuaj të %(app_name)s-it, zakonisht ndodh ose sepse versioni juaj i %(app_name)s-it është vjetruar, ose autori i shtesës s’e ka përditësuar ende "
+"shtesën, që kjo të jetë e përputhshme me versionin e ri që po përdorni. Mozilla nuk këshillon të provoni të anashkaloni këto kontrolle përputhshmërie, ngaqë kjo mund ta shpjerë shfletuesin në "
+"paqëndrueshmëri, ose në disa raste edhe në humbje të dhënash. Për përdoruesit që po provojnë versione alfa ose beta të Firefox-it, ofrojmë <a href=\"%(acr_url)s\">Raportues Përputhshmërie Shtesash</"
+"a>, për t’i ndihmuar zhvilluesit e shtesave në përditësimin e përputhshmërisë."
 
 #: src/olympia/pages/templates/pages/faq.html:156
 msgid "What if I have problems with an add-on?"
@@ -13264,46 +10376,30 @@ msgstr "Po nëse kam probleme me një shtesë?"
 #: src/olympia/pages/templates/pages/faq.html:157
 #, python-format
 msgid ""
-"Add-ons are usually created by third-party developers from around the world,"
-" so the best way to get help with an add-on is to look for support links on "
-"the add-on's homepage or contact the developer. If you are having issues "
-"with %(app_name)s that you suspect are related to add-ons you have "
-"installed, <a href=\"%(troubleshooting_url)s\">visit this support "
-"article</a> for troubleshooting tips."
+"Add-ons are usually created by third-party developers from around the world, so the best way to get help with an add-on is to look for support links on the add-on's homepage or contact the "
+"developer. If you are having issues with %(app_name)s that you suspect are related to add-ons you have installed, <a href=\"%(troubleshooting_url)s\">visit this support article</a> for "
+"troubleshooting tips."
 msgstr ""
-"Zakonisht shtesat krijohen nga zhvillues palë të treta, nga anembanë botës, "
-"ndaj rruga më e mirë për të marrë ndihmë rreth një shtese është të shihet "
-"për lidhje asistence te faqja hyrëse e shtesës ose të lidheni me "
-"zhvilluesin. Nëse keni probleme me %(app_name)s-in, për të cilat dyshoni se "
-"vijnë prej shtesave që keni instaluar, <a "
-"href=\"%(troubleshooting_url)s\">vizitoni këtë artikull rreth asistencës</a>"
-" për këshilla diagnostikimi."
+"Zakonisht shtesat krijohen nga zhvillues palë të treta, nga anembanë botës, ndaj rruga më e mirë për të marrë ndihmë rreth një shtese është të shihet për lidhje asistence te faqja hyrëse e shtesës "
+"ose të lidheni me zhvilluesin. Nëse keni probleme me %(app_name)s-in, për të cilat dyshoni se vijnë prej shtesave që keni instaluar, <a href=\"%(troubleshooting_url)s\">vizitoni këtë artikull rreth "
+"asistencës</a> për këshilla diagnostikimi."
 
 #: src/olympia/pages/templates/pages/faq.html:169
 msgid "Add-on Gallery"
 msgstr "Galeri Shtese"
 
 #: src/olympia/pages/templates/pages/faq.html:171
-msgid ""
-"How do I choose between add-ons that seem to do the same\n"
-"    thing?"
+msgid "How do I choose between add-ons that seem to do the same thing?"
 msgstr "Si të zgjedh mes shtesash që duket se bëjnë të njëjtën gjë?"
 
-#: src/olympia/pages/templates/pages/faq.html:173
+#: src/olympia/pages/templates/pages/faq.html:172
 msgid ""
-"There are often several add-ons that have similar features. To figure out "
-"which is right for you, read the entire description of the add-on and view "
-"its screenshots. If there are still several in the running, read through the"
-" add-on's ratings, user reviews, and statistics to see which is most liked "
-"by other users. Remember that you can also just try out both and see which "
-"you like better."
+"There are often several add-ons that have similar features. To figure out which is right for you, read the entire description of the add-on and view its screenshots. If there are still several in "
+"the running, read through the add-on's ratings, user reviews, and statistics to see which is most liked by other users. Remember that you can also just try out both and see which you like better."
 msgstr ""
-"Shpesh ka disa shtesa që kanë veçori të ngjashme. Për të kuptuar se cila "
-"është ajo e duhura për ju, lexoni tërë përshkrimin e shtesës dhe shihni "
-"pamjet për të. Nëse prapë s’vendosni dot, lexoni vlerësimet për shtesën, "
-"shqyrtimet nga përdorues dhe statistikat, për të parë se cila është më e "
-"pëlqyera nga përdoruesit e tjerë. Mbani mend që mund t’i provoni të gjitha "
-"dhe të shihni se cila ju pëlqen më shumë."
+"Shpesh ka disa shtesa që kanë veçori të ngjashme. Për të kuptuar se cila është ajo e duhura për ju, lexoni tërë përshkrimin e shtesës dhe shihni pamjet për të. Nëse prapë s’vendosni dot, lexoni "
+"vlerësimet për shtesën, shqyrtimet nga përdorues dhe statistikat, për të parë se cila është më e pëlqyera nga përdoruesit e tjerë. Mbani mend që mund t’i provoni të gjitha dhe të shihni se cila ju "
+"pëlqen më shumë."
 
 #: src/olympia/pages/templates/pages/faq.html:180
 msgid "What if I can't find an add-on I'm looking for?"
@@ -13312,38 +10408,24 @@ msgstr "Po nëse s’e gjej dot shtesën që po kërkoj?"
 #: src/olympia/pages/templates/pages/faq.html:181
 #, python-format
 msgid ""
-"With thousands of add-ons available, there's something for everyone. But if "
-"you're looking for a particular add-on and can't find it, you might try "
-"searching on other sites or posting about it in our <a href=\"%(forum_url)s"
-"\">Add-ons </a>forum."
+"With thousands of add-ons available, there's something for everyone. But if you're looking for a particular add-on and can't find it, you might try searching on other sites or posting about it in "
+"our <a href=\"%(forum_url)s\">Add-ons </a>forum."
 msgstr ""
-"Me mijëra shtesa të passhme, për gjithkënd ka diçka. Por nëse po kërkoni për"
-" një shtesë të veçantë dhe s’e gjeni, mund të provoni ta kërkoni te sajte të"
-" tjerë ose të postoni një kërkesë te forumi ynë <a "
-"href=\"%(forum_url)s\">Shtesa</a>."
+"Me mijëra shtesa të passhme, për gjithkënd ka diçka. Por nëse po kërkoni për një shtesë të veçantë dhe s’e gjeni, mund të provoni ta kërkoni te sajte të tjerë ose të postoni një kërkesë te forumi "
+"ynë <a href=\"%(forum_url)s\">Shtesa</a>."
 
 #: src/olympia/pages/templates/pages/faq.html:187
-msgid ""
-"What does it mean if an add-on is \"experimental\" or \"preliminarily "
-"reviewed\"?"
-msgstr ""
-"Çfarë do të thotë që një shtesë është \"eksperimentale\" ose \"e shqyrtuar "
-"paraprakisht\"?"
+msgid "What does it mean if an add-on is \"experimental\" or \"preliminarily reviewed\"?"
+msgstr "Çfarë do të thotë që një shtesë është \"eksperimentale\" ose \"e shqyrtuar paraprakisht\"?"
 
 #: src/olympia/pages/templates/pages/faq.html:188
 #, python-format
 msgid ""
-"Experimental add-ons have been checked by our editors to make sure they "
-"don't have security problems, but they may still have bugs or not work "
-"properly. Use caution when installing experimental add-ons and uninstall the"
-" add-on immediately if you notice problems. <a href=\"%(url)s\">Learn more "
-"about our review process</a></dd>"
+"Experimental add-ons have been checked by our editors to make sure they don't have security problems, but they may still have bugs or not work properly. Use caution when installing experimental add-"
+"ons and uninstall the add-on immediately if you notice problems. <a href=\"%(url)s\">Learn more about our review process</a></dd>"
 msgstr ""
-"Shtesat eksperimentale janë kontrolluar nga redaktorët tanë për t’u siguruar"
-" që s’kanë probleme sigurie, por prapë mund të kenë të meta, ose të mos "
-"punojnë si duhet. Bëni kujdes kur instaloni shtesa eksperimentale dhe "
-"çinstalojeni menjëherë shtesën nëse vini re probleme. <a "
-"href=\"%(url)s\">Mësoni më tepër rreth procesit tonë të shqyrtimit</a></dd>"
+"Shtesat eksperimentale janë kontrolluar nga redaktorët tanë për t’u siguruar që s’kanë probleme sigurie, por prapë mund të kenë të meta, ose të mos punojnë si duhet. Bëni kujdes kur instaloni "
+"shtesa eksperimentale dhe çinstalojeni menjëherë shtesën nëse vini re probleme. <a href=\"%(url)s\">Mësoni më tepër rreth procesit tonë të shqyrtimit</a></dd>"
 
 #: src/olympia/pages/templates/pages/faq.html:196
 msgid "What does it mean if an add-on is \"not reviewed\"?"
@@ -13352,273 +10434,190 @@ msgstr "Çfarë do të thotë që një shtesë \"s’është shqyrtuar\"?"
 #: src/olympia/pages/templates/pages/faq.html:197
 #, python-format
 msgid ""
-"While all add-ons publicly available in our gallery are reviewed by an "
-"editor, you may receive a direct link to an add-on that hasn't yet been "
-"reviewed. Use caution when installing these add-ons, as they could harm your"
-" computer or violate your privacy. We recommend that you only install "
-"reviewed add-ons. <a href=\"%(url)s\">Learn more about our review "
-"process</a></dd>"
+"While all add-ons publicly available in our gallery are reviewed by an editor, you may receive a direct link to an add-on that hasn't yet been reviewed. Use caution when installing these add-ons, "
+"as they could harm your computer or violate your privacy. We recommend that you only install reviewed add-ons. <a href=\"%(url)s\">Learn more about our review process</a></dd>"
 msgstr ""
-"Edhe pse krejt shtesat që mund të kihen publikisht nga galeria jonë, janë "
-"shqyrtuar nga një redaktor, mund të merrni një lidhje të drejtpërdrejtë te "
-"një shtesë që s’është shqyrtuar ende. Bëni kujdes kur instaloni shtesa të "
-"tilla, sepse mund t’ju dëmtojnë kompjuterin ose t’ju cenojnë privatësinë. "
-"Këshillojmë të instaloni vetëm shtesa të shqyrtuara. <a "
-"href=\"%(url)s\">Mësoni më tepër rreth procesit tonë të shqyrtimit</a></dd>"
+"Edhe pse krejt shtesat që mund të kihen publikisht nga galeria jonë, janë shqyrtuar nga një redaktor, mund të merrni një lidhje të drejtpërdrejtë te një shtesë që s’është shqyrtuar ende. Bëni "
+"kujdes kur instaloni shtesa të tilla, sepse mund t’ju dëmtojnë kompjuterin ose t’ju cenojnë privatësinë. Këshillojmë të instaloni vetëm shtesa të shqyrtuara. <a href=\"%(url)s\">Mësoni më tepër "
+"rreth procesit tonë të shqyrtimit</a></dd>"
 
 #: src/olympia/pages/templates/pages/faq.html:206
 msgid "How much do add-ons cost to purchase?"
 msgstr "Sa kushton blerja e shtesave?"
 
 #: src/olympia/pages/templates/pages/faq.html:207
-msgid ""
-"Add-ons hosted in our gallery are free unless clearly marked\n"
-"    otherwise."
-msgstr ""
-"Shtesat e strehuara te galeria jonë janë të lira, veç në u tregoftë qartas "
-"ndryshe."
+msgid "Add-ons hosted in our gallery are free unless clearly marked otherwise."
+msgstr "Shtesat e strehuara te galeria jonë janë të lira, veç në u tregoftë qartas ndryshe."
 
-#: src/olympia/pages/templates/pages/faq.html:210
+#: src/olympia/pages/templates/pages/faq.html:209
 msgid "What does it mean when an add-on asks for contributions?"
 msgstr "Ç’do të thotë që një shtesë të kërkojë kontribute?"
 
-#: src/olympia/pages/templates/pages/faq.html:211
+#: src/olympia/pages/templates/pages/faq.html:210
 msgid ""
-"Some add-on authors request users who enjoy an add-on to contribute to its "
-"development by making a monetary contribution. These contributions go "
-"directly to the developer unless a third party is indicated, such as the "
-"non-profit Mozilla Foundation."
+"Some add-on authors request users who enjoy an add-on to contribute to its development by making a monetary contribution. These contributions go directly to the developer unless a third party is "
+"indicated, such as the non-profit Mozilla Foundation."
 msgstr ""
-"Disa autorë shtesash u kërkojnë përdoruesve që e pëlqejnë shtesën të "
-"kontribuojnë te zhvillimi i saj përmes dhurimit të një shume parash. Këto "
-"kontribute shkojnë drejt e te zhvilluesi, veç në pastë treguar një palë të "
-"tretë, fjala vjen, fondacionin jofitimprurës Mozilla Foundation."
+"Disa autorë shtesash u kërkojnë përdoruesve që e pëlqejnë shtesën të kontribuojnë te zhvillimi i saj përmes dhurimit të një shume parash. Këto kontribute shkojnë drejt e te zhvilluesi, veç në pastë "
+"treguar një palë të tretë, fjala vjen, fondacionin jofitimprurës Mozilla Foundation."
 
-#: src/olympia/pages/templates/pages/faq.html:216
+#: src/olympia/pages/templates/pages/faq.html:215
 msgid "What are beta add-ons?"
 msgstr "Ç’janë shtesat beta?"
 
-#: src/olympia/pages/templates/pages/faq.html:218
+#: src/olympia/pages/templates/pages/faq.html:217
 msgid ""
-"Beta add-ons are unreviewed versions which represent the latest work of an "
-"add-on author. While different authors have different standards for beta "
-"code quality, you should assume that these add-ons are less stable than the "
-"general add-on releases."
+"Beta add-ons are unreviewed versions which represent the latest work of an add-on author. While different authors have different standards for beta code quality, you should assume that these add-"
+"ons are less stable than the general add-on releases."
 msgstr ""
-"Shtesat Beta janë versione të pashqyrtuara ende, të cilat përfaqësojnë punën"
-" së fundmi të autorit të shtesës. Ndërkohë që autorë të ndryshëm kanë "
-"standarde të ndryshme për cilësinë e kodit beta, do të duhej ta merrnit të "
-"mirëqenë që këto shtesa janë më pak të qëndrueshme se sa qarkullimet e "
-"përgjithshme të shtesave."
+"Shtesat Beta janë versione të pashqyrtuara ende, të cilat përfaqësojnë punën së fundmi të autorit të shtesës. Ndërkohë që autorë të ndryshëm kanë standarde të ndryshme për cilësinë e kodit beta, do "
+"të duhej ta merrnit të mirëqenë që këto shtesa janë më pak të qëndrueshme se sa qarkullimet e përgjithshme të shtesave."
 
-#: src/olympia/pages/templates/pages/faq.html:222
+#: src/olympia/pages/templates/pages/faq.html:221
 msgid ""
-"Please note that when you install an add-on from the \"Beta Version\" "
-"section of an add-on's listing, you will continue to receive updates for "
-"that add-on as they become available. Like the initial version you "
-"installed, all beta releases are unreviewed by Mozilla and may harm your "
-"computer."
+"Please note that when you install an add-on from the \"Beta Version\" section of an add-on's listing, you will continue to receive updates for that add-on as they become available. Like the initial "
+"version you installed, all beta releases are unreviewed by Mozilla and may harm your computer."
 msgstr ""
-"Ju lutemi, mbani parasysh që kur instaloni një shtesë prej ndarjes "
-"\"Versione Beta\" te faqja e shtesës, do të vazhdoni të merrni përditësime "
-"rreth asaj shtese, sa herë që të ketë të tillë. Ashtu si versioni fillestar "
-"që instaluat, krejt hedhjet në qarkullim beta janë të pashqyrtuara nga "
-"Mozilla dhe mund të dëmtojnë kompjuterin tuaj."
+"Ju lutemi, mbani parasysh që kur instaloni një shtesë prej ndarjes \"Versione Beta\" te faqja e shtesës, do të vazhdoni të merrni përditësime rreth asaj shtese, sa herë që të ketë të tillë. Ashtu "
+"si versioni fillestar që instaluat, krejt hedhjet në qarkullim beta janë të pashqyrtuara nga Mozilla dhe mund të dëmtojnë kompjuterin tuaj."
 
-#: src/olympia/pages/templates/pages/faq.html:229
-msgid ""
-"What does it mean when an add-on is flagged as\n"
-"    slow?"
+#: src/olympia/pages/templates/pages/faq.html:228
+msgid "What does it mean when an add-on is flagged as slow?"
 msgstr "Ç’nënkupton shënimi që shtesës i është vënë shenjë si e ngadaltë?"
 
-#: src/olympia/pages/templates/pages/faq.html:231
-msgid ""
-"Most add-ons load code and resources at the same time Firefox is starting "
-"up. In most cases the impact in start-up time is minimal, but some add-ons "
-"can cause a noticeable slowdown."
+#: src/olympia/pages/templates/pages/faq.html:229
+msgid "Most add-ons load code and resources at the same time Firefox is starting up. In most cases the impact in start-up time is minimal, but some add-ons can cause a noticeable slowdown."
 msgstr ""
-"Shumica e shtesave kodin dhe burimet i ngarkojnë në të njëjtën kohë që niset"
-" Firefox-i. Në shumicën e rasteve ndikimi në kohën e nisjes është minimal, "
-"por disa nga shtesat mund të shkaktojnë ngadalësim të dukshëm."
+"Shumica e shtesave kodin dhe burimet i ngarkojnë në të njëjtën kohë që niset Firefox-i. Në shumicën e rasteve ndikimi në kohën e nisjes është minimal, por disa nga shtesat mund të shkaktojnë "
+"ngadalësim të dukshëm."
 
-#: src/olympia/pages/templates/pages/faq.html:236
+#: src/olympia/pages/templates/pages/faq.html:234
 msgid "How do I report an inappropriate or spam user review?"
-msgstr ""
-"Si të njoftoj për një shqyrtim përdoruesi të papërshtatshëm ose të pavlerë?"
+msgstr "Si të njoftoj për një shqyrtim përdoruesi të papërshtatshëm ose të pavlerë?"
 
-#: src/olympia/pages/templates/pages/faq.html:237
+#: src/olympia/pages/templates/pages/faq.html:235
 msgid ""
-"To report a user review of an add-on, log in with your account and visit the"
-" add-on's reviews page. Find the review you wish to report, click \"Report "
-"this review\" and select a reason. Our editorial team will investigate the "
-"review and take appropriate action."
+"To report a user review of an add-on, log in with your account and visit the add-on's reviews page. Find the review you wish to report, click \"Report this review\" and select a reason. Our "
+"editorial team will investigate the review and take appropriate action."
 msgstr ""
-"Për raportimin e shqyrtimit të një shtese nga ana e një përdoruesi, hyni në "
-"llogarinë tuaj dhe vizitoni faqen e shqyrtimeve të shtesës. Gjeni shqyrtimin"
-" që doni të raportoni, klikoni mbi \"Raportoje këtë shqyrtim\" dhe "
-"përzgjidhni një arsye. Ekipi ynë i redaktorëve do të hetojë dhe do të "
-"ndërmarrë veprimin e duhur."
+"Për raportimin e shqyrtimit të një shtese nga ana e një përdoruesi, hyni në llogarinë tuaj dhe vizitoni faqen e shqyrtimeve të shtesës. Gjeni shqyrtimin që doni të raportoni, klikoni mbi "
+"\"Raportoje këtë shqyrtim\" dhe përzgjidhni një arsye. Ekipi ynë i redaktorëve do të hetojë dhe do të ndërmarrë veprimin e duhur."
 
-#: src/olympia/pages/templates/pages/faq.html:242
+#: src/olympia/pages/templates/pages/faq.html:240
 msgid "How do I report a bug or contact the Mozilla Add-ons team?"
 msgstr "Si ta njoftoj një të metë ose të lidhem me ekipin e Shtesave Mozilla?"
 
-#: src/olympia/pages/templates/pages/faq.html:243
+#: src/olympia/pages/templates/pages/faq.html:241
 #, python-format
 msgid "Please visit our <a href=\"%(contact_url)s\">Contact page</a>."
-msgstr ""
-"Ju lutemi, vizitoni <a href=\"%(contact_url)s\">faqen tonë të "
-"Kontakteve</a>."
+msgstr "Ju lutemi, vizitoni <a href=\"%(contact_url)s\">faqen tonë të Kontakteve</a>."
 
-#: src/olympia/pages/templates/pages/faq.html:246
+#: src/olympia/pages/templates/pages/faq.html:244
 msgid "What is a Source Code License?"
 msgstr "Cila është Licenca për Kodin Burim?"
 
-#: src/olympia/pages/templates/pages/faq.html:247
+#: src/olympia/pages/templates/pages/faq.html:245
 #, python-format
 msgid ""
-"The source code used to create an add-on is an exclusive copyright of the "
-"add-on author, unless otherwise declared in a source code license. Many add-"
-"ons on this site have <a href=\"%(url)s\" lang=\"en\">open source "
-"licenses</a> that make the source code publicly available for copy and reuse"
-" under conditions determined by the author. Most authors choose widely known"
-" open source licenses like the GPL or BSD licenses instead of making up "
-"their own."
+"The source code used to create an add-on is an exclusive copyright of the add-on author, unless otherwise declared in a source code license. Many add-ons on this site have <a href=\"%(url)s\" lang="
+"\"en\">open source licenses</a> that make the source code publicly available for copy and reuse under conditions determined by the author. Most authors choose widely known open source licenses like "
+"the GPL or BSD licenses instead of making up their own."
 msgstr ""
-"Kodi burim i përdorur për të krijuar një shtesë është e drejtë kopjimi "
-"përjashtimore e autorit të shtesës, hiq rastet kur deklarohet ndryshe në "
-"licencën e zgjedhur për kodin burim. Mjaft shtesa në këtë sajt kanë <a "
-"href=\"%(url)s\" lang=\"en\">licenca burimi të hapët</a> që ua bën kodin "
-"burim publikisht të passhëm për kopjim dhe ripërdorim sipas kushteve të "
-"përcaktuara nga autori. Shumica e autorëve zgjedhin licenca burimi të hapët "
-"të njohura gjerësisht, të tilla si licenca GPL ose BSD, në vend se të "
-"krijojnë vetë të tilla."
+"Kodi burim i përdorur për të krijuar një shtesë është e drejtë kopjimi përjashtimore e autorit të shtesës, hiq rastet kur deklarohet ndryshe në licencën e zgjedhur për kodin burim. Mjaft shtesa në "
+"këtë sajt kanë <a href=\"%(url)s\" lang=\"en\">licenca burimi të hapët</a> që ua bën kodin burim publikisht të passhëm për kopjim dhe ripërdorim sipas kushteve të përcaktuara nga autori. Shumica e "
+"autorëve zgjedhin licenca burimi të hapët të njohura gjerësisht, të tilla si licenca GPL ose BSD, në vend se të krijojnë vetë të tilla."
 
-#: src/olympia/pages/templates/pages/faq.html:256
+#: src/olympia/pages/templates/pages/faq.html:254
 #, python-format
-msgid ""
-"Firefox and other Mozilla software are <a href=\"%(url)s\">open source</a>."
-msgstr ""
-"Firefox-i dhe software-et Mozilla janë me <a href=\"%(url)s\">burim të "
-"hapët</a>."
+msgid "Firefox and other Mozilla software are <a href=\"%(url)s\">open source</a>."
+msgstr "Firefox-i dhe software-et Mozilla janë me <a href=\"%(url)s\">burim të hapët</a>."
 
-#: src/olympia/pages/templates/pages/faq.html:264
+#: src/olympia/pages/templates/pages/faq.html:262
 msgid "Collections and Favorites"
 msgstr "Koleksione dhe Të parapëlqyera"
 
-#: src/olympia/pages/templates/pages/faq.html:267
+#: src/olympia/pages/templates/pages/faq.html:265
 msgid "What is a collection?"
 msgstr "Ç’është një koleksion?"
 
-#: src/olympia/pages/templates/pages/faq.html:268
+#: src/olympia/pages/templates/pages/faq.html:266
 msgid "Collections are groups of related add-ons created by users to share."
-msgstr ""
-"Koleksionet janë grupe shtesash të ngjashme, krijuar nga përdoruesit për t’i"
-" shkëmbyer."
+msgstr "Koleksionet janë grupe shtesash të ngjashme, krijuar nga përdoruesit për t’i shkëmbyer."
 
-#: src/olympia/pages/templates/pages/faq.html:270
+#: src/olympia/pages/templates/pages/faq.html:268
 msgid "What is the My Favorites collection?"
 msgstr "Ç’është koleksioni Të Parapëlqyerat e Mia?"
 
-#: src/olympia/pages/templates/pages/faq.html:271
-msgid ""
-"Favorite add-ons are add-ons that you have bookmarked to easily get back to "
-"later. You can add an add-on to your favorites collection by clicking \"Add "
-"to favorites\" on its details page."
+#: src/olympia/pages/templates/pages/faq.html:269
+msgid "Favorite add-ons are add-ons that you have bookmarked to easily get back to later. You can add an add-on to your favorites collection by clicking \"Add to favorites\" on its details page."
 msgstr ""
-"Shtesat e parapëlqyera janë shtesa që i keni faqeruajtur për t’u kthyer "
-"kollaj në to më vonë. Një shtesë mund ta shtoni te koleksioni i të "
-"parapëlqyerave tuaja duke klikuar mbi \"Shtoje te të parapëlqyerat\", te "
-"faqja e hollësive të saj."
+"Shtesat e parapëlqyera janë shtesa që i keni faqeruajtur për t’u kthyer kollaj në to më vonë. Një shtesë mund ta shtoni te koleksioni i të parapëlqyerave tuaja duke klikuar mbi \"Shtoje te të "
+"parapëlqyerat\", te faqja e hollësive të saj."
 
-#: src/olympia/pages/templates/pages/faq.html:275
-#: src/olympia/templates/menu_links.html:13
-#: src/olympia/templates/impala/header_title.html:17
+#: src/olympia/pages/templates/pages/faq.html:273 src/olympia/templates/menu_links.html:13 src/olympia/templates/impala/header_title.html:17
 msgid "Mobile Add-ons"
 msgstr "Shtesa për Celular"
 
-#: src/olympia/pages/templates/pages/faq.html:278
+#: src/olympia/pages/templates/pages/faq.html:276
 msgid "What are mobile add-ons?"
 msgstr "Ç’janë shtesat për celular?"
 
-#: src/olympia/pages/templates/pages/faq.html:279
+#: src/olympia/pages/templates/pages/faq.html:277
 #, python-format
 msgid ""
-"Mobile add-ons work with <a href=\"%(mobile_url)s\">Firefox for Mobile</a> "
-"and add or modify functionality just like desktop add-ons. You can find add-"
-"ons that work with Firefox for Mobile in our <a "
-"href=\"%(gallery_url)s\">gallery</a>."
+"Mobile add-ons work with <a href=\"%(mobile_url)s\">Firefox for Mobile</a> and add or modify functionality just like desktop add-ons. You can find add-ons that work with Firefox for Mobile in our "
+"<a href=\"%(gallery_url)s\">gallery</a>."
 msgstr ""
-"Shtesat për celular funksionojnë me <a href=\"%(mobile_url)s\">Firefox-in "
-"për Celular</a> dhe shtojnë ose ndryshojnë punimin, ashtu si edhe shtesat "
-"për versionin desktop. Shtesa që punojnë me Firefox-in për Celular mund të "
-"gjeni te <a href=\"%(gallery_url)s\">galeria</a> jonë."
+"Shtesat për celular funksionojnë me <a href=\"%(mobile_url)s\">Firefox-in për Celular</a> dhe shtojnë ose ndryshojnë punimin, ashtu si edhe shtesat për versionin desktop. Shtesa që punojnë me "
+"Firefox-in për Celular mund të gjeni te <a href=\"%(gallery_url)s\">galeria</a> jonë."
 
-#: src/olympia/pages/templates/pages/faq.html:288
+#: src/olympia/pages/templates/pages/faq.html:286
 msgid "Developer Topics"
 msgstr "Tema Zhvilluesish"
 
-#: src/olympia/pages/templates/pages/faq.html:289
+#: src/olympia/pages/templates/pages/faq.html:287
 #, python-format
-msgid ""
-"Please see our <a href=\"%(faq_url)s\">Developer FAQ</a> and <a "
-"href=\"%(hub_url)s\">Developer Hub</a> for answers to add-on developer-"
-"related questions."
-msgstr ""
-"Ju lutemi, shihni <a href=\"%(faq_url)s\">FAQ për Zhvillues</a> dhe <a "
-"href=\"%(hub_url)s\">Developer Hub</a> për përgjigje ndaj pyetjesh që lidhen"
-" me zhvilluesit e shtesave."
+msgid "Please see our <a href=\"%(faq_url)s\">Developer FAQ</a> and <a href=\"%(hub_url)s\">Developer Hub</a> for answers to add-on developer-related questions."
+msgstr "Ju lutemi, shihni <a href=\"%(faq_url)s\">FAQ për Zhvillues</a> dhe <a href=\"%(hub_url)s\">Developer Hub</a> për përgjigje ndaj pyetjesh që lidhen me zhvilluesit e shtesave."
 
-#: src/olympia/pages/templates/pages/faq.html:294
+#: src/olympia/pages/templates/pages/faq.html:292
 msgid "Still have questions?"
 msgstr "Keni ende pyetje?"
 
-#: src/olympia/pages/templates/pages/faq.html:295
+#: src/olympia/pages/templates/pages/faq.html:293
 #, python-format
-msgid ""
-"For general Firefox support, visit our <a href=\"%(sumo_url)s\">support "
-"website</a>. For general add-on and website questions, visit our <a "
-"href=\"%(forum_url)s\">forum</a>."
+msgid "For general Firefox support, visit our <a href=\"%(sumo_url)s\">support website</a>. For general add-on and website questions, visit our <a href=\"%(forum_url)s\">forum</a>."
 msgstr ""
-"Për asistencë të përgjithshme për Firefox-in, vizitoni <a "
-"href=\"%(sumo_url)s\">sajtin tonë të asistencës</a>. Për pyetje të "
-"përgjithshme mbi shtesat dhe sajtin, vizitoni <a "
-"href=\"%(forum_url)s\">forumin</a> tonë."
+"Për asistencë të përgjithshme për Firefox-in, vizitoni <a href=\"%(sumo_url)s\">sajtin tonë të asistencës</a>. Për pyetje të përgjithshme mbi shtesat dhe sajtin, vizitoni <a href=\"%(forum_url)s"
+"\">forumin</a> tonë."
 
-#: src/olympia/pages/templates/pages/review_guide.html:36
-#: src/olympia/pages/templates/pages/review_guide.html:51
+#: src/olympia/pages/templates/pages/review_guide.html:36 src/olympia/pages/templates/pages/review_guide.html:51
 msgid "Some tips for writing a great review"
 msgstr "Pak ndihmëza për të shkruar një shqyrtim të goditur"
 
-#: src/olympia/pages/templates/pages/review_guide.html:39
-#: src/olympia/pages/templates/pages/review_guide.html:131
+#: src/olympia/pages/templates/pages/review_guide.html:39 src/olympia/pages/templates/pages/review_guide.html:131
 msgid "Frequently Asked Questions about Reviews"
 msgstr "Pyetje të Bëra Shpesh rreth Shqyrtimeve"
 
 #: src/olympia/pages/templates/pages/review_guide.html:46
 msgid ""
-"Add-on reviews are a way for you to share your opinions about the add-ons "
-"you’ve installed and used. Our review moderation team reserves the right to "
-"refuse or remove any review that does not comply with these guidelines."
+"Add-on reviews are a way for you to share your opinions about the add-ons you’ve installed and used. Our review moderation team reserves the right to refuse or remove any review that does not "
+"comply with these guidelines."
 msgstr ""
-"Shqyrtimet e shtesave janë një rrugë që t’u bëni të ditur të tjerëve "
-"mendimin tuaj mbi shtesat që instaloni dhe përdorni. Ekipi ynë i moderimit "
-"të shqyrtimeve të shtesave ruan të drejtën të hedhë poshtë ose heqë çfarëdo "
-"shqyrtimi që s’përputhet me këto udhëzime."
+"Shqyrtimet e shtesave janë një rrugë që t’u bëni të ditur të tjerëve mendimin tuaj mbi shtesat që instaloni dhe përdorni. Ekipi ynë i moderimit të shqyrtimeve të shtesave ruan të drejtën të hedhë "
+"poshtë ose heqë çfarëdo shqyrtimi që s’përputhet me këto udhëzime."
 
 #: src/olympia/pages/templates/pages/review_guide.html:53
 msgid "Do:"
 msgstr "Po:"
 
 #: src/olympia/pages/templates/pages/review_guide.html:56
-msgid ""
-"Write like you are telling a friend about your experience with the add-on."
+msgid "Write like you are telling a friend about your experience with the add-on."
 msgstr "Shkruani sikur t’i tegonit një miku rreth përvojës tuaj me shtesën."
 
 #: src/olympia/pages/templates/pages/review_guide.html:61
 msgid "Keep reviews concise and easy to understand."
-msgstr ""
-"Kujdesuni që shqyrtimet të jenë të përpikta dhe të lehta për t’u kuptuar."
+msgstr "Kujdesuni që shqyrtimet të jenë të përpikta dhe të lehta për t’u kuptuar."
 
 #: src/olympia/pages/templates/pages/review_guide.html:62
 msgid "Give specific and helpful details. For example:"
@@ -13645,11 +10644,8 @@ msgid "Will you continue to use this add-on?"
 msgstr "Do të vazhdoni ta përdorni këtë shtesë?"
 
 #: src/olympia/pages/templates/pages/review_guide.html:73
-msgid ""
-"Take a moment to read your review before submitting it to minimize typos."
-msgstr ""
-"Ndaluni një çast dhe lexojeni shqyrtimin tuaj, përpara se ta parashtroni, "
-"për ndreqje gabimesh shkrimi."
+msgid "Take a moment to read your review before submitting it to minimize typos."
+msgstr "Ndaluni një çast dhe lexojeni shqyrtimin tuaj, përpara se ta parashtroni, për ndreqje gabimesh shkrimi."
 
 #: src/olympia/pages/templates/pages/review_guide.html:79
 msgid "Don’t:"
@@ -13657,72 +10653,47 @@ msgstr "Jo:"
 
 #: src/olympia/pages/templates/pages/review_guide.html:82
 msgid "Submit one-word reviews such as \"Great!\", \"wonderful,\" or \"bad.\""
-msgstr ""
-"Parashtroni shqyrtime njëfjalëshe, të tilla si \"E fuqishme!\", \"e "
-"mrekullueshme,\" ose \"e keqe.\""
+msgstr "Parashtroni shqyrtime njëfjalëshe, të tilla si \"E fuqishme!\", \"e mrekullueshme,\" ose \"e keqe.\""
 
 #: src/olympia/pages/templates/pages/review_guide.html:87
 msgid ""
-"Post technical issues, support requests, or feature suggestions. Use the "
-"available support options for each add-on, if available. You can find them "
-"in the side column next to the About this Add-on section."
+"Post technical issues, support requests, or feature suggestions. Use the available support options for each add-on, if available. You can find them in the side column next to the About this Add-on "
+"section."
 msgstr ""
-"Postoni probleme teknike, kërkesa për asistencë, ose sugjerime për veçori të"
-" reja. Përdorni mundësitë e gatshme për asistencë për çdo shtesë, në pastë. "
-"Mund t’i gjeni në anë të shtyllës në krah të ndarjes Mbi këtë Shtesë."
+"Postoni probleme teknike, kërkesa për asistencë, ose sugjerime për veçori të reja. Përdorni mundësitë e gatshme për asistencë për çdo shtesë, në pastë. Mund t’i gjeni në anë të shtyllës në krah të "
+"ndarjes Mbi këtë Shtesë."
 
 #: src/olympia/pages/templates/pages/review_guide.html:92
 msgid "Write reviews for add-ons which you have not personally used."
 msgstr "Shkruani shqyrtime për shtesa të cilat s’i keni përdorur ju vetë."
 
 #: src/olympia/pages/templates/pages/review_guide.html:97
-msgid ""
-"Use profanity, sexual language or language that can be construed as hateful."
-msgstr ""
-"Mos përdorni fjalë të ndyra, gjuhë seksuale apo gjuhë që mund të merret si "
-"bartëse urrejtjeje."
+msgid "Use profanity, sexual language or language that can be construed as hateful."
+msgstr "Mos përdorni fjalë të ndyra, gjuhë seksuale apo gjuhë që mund të merret si bartëse urrejtjeje."
 
 #: src/olympia/pages/templates/pages/review_guide.html:103
-msgid ""
-"Include HTML, links, source code or code snippets. Reviews are meant to be "
-"text only."
-msgstr ""
-"Përfshini HTML, lidhje, kod burim ose copëza kodi. Shqyrtimet pritet të jenë"
-" vetëm tekst."
+msgid "Include HTML, links, source code or code snippets. Reviews are meant to be text only."
+msgstr "Përfshini HTML, lidhje, kod burim ose copëza kodi. Shqyrtimet pritet të jenë vetëm tekst."
 
 #: src/olympia/pages/templates/pages/review_guide.html:108
-msgid ""
-"Make false statements, disparage add-on authors or personally insult them."
-msgstr ""
-"Mos bëni pohime të rreme, mos përçmoni autorë shtesash ose mos i fyeni ata "
-"personalisht."
+msgid "Make false statements, disparage add-on authors or personally insult them."
+msgstr "Mos bëni pohime të rreme, mos përçmoni autorë shtesash ose mos i fyeni ata personalisht."
 
 #: src/olympia/pages/templates/pages/review_guide.html:114
-msgid ""
-"Include your own or anyone else’s email, phone number, or other personal "
-"details."
-msgstr ""
-"Përfshini email-in, numër telefoni apo të dhëna të tjera personale, tuajat "
-"apo të kujtdo tjetër."
+msgid "Include your own or anyone else’s email, phone number, or other personal details."
+msgstr "Përfshini email-in, numër telefoni apo të dhëna të tjera personale, tuajat apo të kujtdo tjetër."
 
 #: src/olympia/pages/templates/pages/review_guide.html:119
-msgid ""
-"Post reviews for an add-on you or your organization wrote or represent."
-msgstr ""
-"Mos postoni shqyrtime për një shtesë që e shkruat apo e përfaqësoni ju apo "
-"enti juaj."
+msgid "Post reviews for an add-on you or your organization wrote or represent."
+msgstr "Mos postoni shqyrtime për një shtesë që e shkruat apo e përfaqësoni ju apo enti juaj."
 
 #: src/olympia/pages/templates/pages/review_guide.html:125
 msgid ""
-"Criticize an add-on for something it’s intended to do. For example, leaving "
-"a negative review of an add-on for displaying ads or requiring data "
-"gathering, when that is the intended purpose of the add-on, or the add-on "
-"requires gathering data to function."
+"Criticize an add-on for something it’s intended to do. For example, leaving a negative review of an add-on for displaying ads or requiring data gathering, when that is the intended purpose of the "
+"add-on, or the add-on requires gathering data to function."
 msgstr ""
-"Të kritikojë një shtesë mbi diçka për të cilën shtesa është krijuar të bëjë."
-" Për shembull, lënia e një shqyrtimi negativ për një shtesë që shfaq reklama"
-" ose që lyp grumbullim të dhënash, në një kohë që shtesa për këtë është "
-"hartuar. ose shtesa lyp grumbullim të dhënash që të funksionojë."
+"Të kritikojë një shtesë mbi diçka për të cilën shtesa është krijuar të bëjë. Për shembull, lënia e një shqyrtimi negativ për një shtesë që shfaq reklama ose që lyp grumbullim të dhënash, në një "
+"kohë që shtesa për këtë është hartuar. ose shtesa lyp grumbullim të dhënash që të funksionojë."
 
 #: src/olympia/pages/templates/pages/review_guide.html:133
 msgid "How can I report a problematic review?"
@@ -13730,16 +10701,11 @@ msgstr "Si të njoftoj për një shqyrtim problematik?"
 
 #: src/olympia/pages/templates/pages/review_guide.html:135
 msgid ""
-"Please report or flag any questionable reviews by clicking the \"Report this"
-" review\" and it will be submitted to the site for moderation. Our "
-"moderation team will use the Review Guidelines to evaluate whether or not to"
-" delete the review or restore it back to the site."
+"Please report or flag any questionable reviews by clicking the \"Report this review\" and it will be submitted to the site for moderation. Our moderation team will use the Review Guidelines to "
+"evaluate whether or not to delete the review or restore it back to the site."
 msgstr ""
-"Ju lutemi, raportoni ose i vini shenjë cilitdo shqyrtim problematik, duke "
-"klikuar mbi \"Raportojeni këtë shqyrtim\" dhe ai do të parashtrohet te "
-"sajti, për moderim. Ekipi ynë i moderimeve do të përdorë Udhëzime Mbi "
-"Shqyrtimet për të peshuar nëse duhet fshirë apo jo shqyrtimi, ose për "
-"kthimin e tij te sajti."
+"Ju lutemi, raportoni ose i vini shenjë cilitdo shqyrtim problematik, duke klikuar mbi \"Raportojeni këtë shqyrtim\" dhe ai do të parashtrohet te sajti, për moderim. Ekipi ynë i moderimeve do të "
+"përdorë Udhëzime Mbi Shqyrtimet për të peshuar nëse duhet fshirë apo jo shqyrtimi, ose për kthimin e tij te sajti."
 
 #: src/olympia/pages/templates/pages/review_guide.html:140
 msgid "I’m an add-on author, can I respond to reviews?"
@@ -13747,34 +10713,21 @@ msgstr "Jam autor shtese, a mundem t’u përgjigjem shqyrtimeve?"
 
 #: src/olympia/pages/templates/pages/review_guide.html:142
 #, python-format
-msgid ""
-"Yes, add-on authors can provide a single response to a review. You can set "
-"up a discussion topic in our <a href=\"%(forum_url)s\">forum</a> to engage "
-"in additional discussion or follow-up."
-msgstr ""
-"Po, autorët e shtesave mund të t’i japin vetëm një përgjigje një shqyrtimi. "
-"Për diskutime shtesë apo vazhdim, mund të hapni një temë diskutimesh te <a "
-"href=\"%(forum_url)s\">forumi ynë</a>."
+msgid "Yes, add-on authors can provide a single response to a review. You can set up a discussion topic in our <a href=\"%(forum_url)s\">forum</a> to engage in additional discussion or follow-up."
+msgstr "Po, autorët e shtesave mund të t’i japin vetëm një përgjigje një shqyrtimi. Për diskutime shtesë apo vazhdim, mund të hapni një temë diskutimesh te <a href=\"%(forum_url)s\">forumi ynë</a>."
 
 #: src/olympia/pages/templates/pages/review_guide.html:149
 msgid "I’m an add-on author, can I delete unfavorable reviews or ratings?"
-msgstr ""
-"Jam autor shtese, a mund të fshij shqyrtime apo vlerësime të pafavorshme?"
+msgstr "Jam autor shtese, a mund të fshij shqyrtime apo vlerësime të pafavorshme?"
 
 #: src/olympia/pages/templates/pages/review_guide.html:151
 msgid ""
-"In general, no. But if the review did not meet the review guidelines "
-"outlined above, you can click \"Report this review\" and have it moderated. "
-"If a review included a complaint that is no longer valid due to a new "
-"release of your add-on, we may consider deleting the review. Submit your "
-"detailed request to amo-editors@mozilla.org."
+"In general, no. But if the review did not meet the review guidelines outlined above, you can click \"Report this review\" and have it moderated. If a review included a complaint that is no longer "
+"valid due to a new release of your add-on, we may consider deleting the review. Submit your detailed request to amo-editors@mozilla.org."
 msgstr ""
-"Në përgjithësi jo. Por nëse shqyrtimi s’pajtohet me udhëzimet mbi "
-"shqyrtimet, të përvijuara më sipër, mund të klikoni mbi \"Raportojeni këtë "
-"shqyrtim\" që ai të moderohet. Nëse një shqyrtim përfshinte një ankesë e "
-"cila s’ka më vend, për shkak të një versioni të ri të shtesës, mund të "
-"shohim mundësinë e fshirjes së shqyrtimit. Kërkesën e hollësishme "
-"parashtrojani amo-editors@mozilla.org."
+"Në përgjithësi jo. Por nëse shqyrtimi s’pajtohet me udhëzimet mbi shqyrtimet, të përvijuara më sipër, mund të klikoni mbi \"Raportojeni këtë shqyrtim\" që ai të moderohet. Nëse një shqyrtim "
+"përfshinte një ankesë e cila s’ka më vend, për shkak të një versioni të ri të shtesës, mund të shohim mundësinë e fshirjes së shqyrtimit. Kërkesën e hollësishme parashtrojani amo-editors@mozilla."
+"org."
 
 #: src/olympia/pages/templates/pages/sunbird.html:26
 msgid "Sunbird has retired"
@@ -13782,24 +10735,16 @@ msgstr "Sunbird-i doli në pension"
 
 #: src/olympia/pages/templates/pages/sunbird.html:29
 msgid ""
-"Development on the Sunbird project has halted and its final release was on "
-"March 30, 2010.  We've been proud to host Sunbird add-ons on this site but "
-"as the project is no longer maintained we have disabled our support for the "
-"add-ons."
+"Development on the Sunbird project has halted and its final release was on March 30, 2010. We've been proud to host Sunbird add-ons on this site but as the project is no longer maintained we have "
+"disabled our support for the add-ons."
 msgstr ""
-"Zhvillimi i projektit Sunbird është ndalur dhe hedhja përfundimtare në "
-"qarkullim qe më 30 Mars, 2010. Në këtë sajt i kemi strehuar me kënaqësi "
-"shtesat për Sunbird-in, por, meqë projekti nuk mirëmbahet më, e kemi "
-"çaktivizuar asistencën tonë për këto shtesa."
+"Zhvillimi i projektit Sunbird është ndalur dhe hedhja përfundimtare në qarkullim qe më 30 Mars, 2010. Në këtë sajt i kemi strehuar me kënaqësi shtesat për Sunbird-in, por, meqë projekti nuk "
+"mirëmbahet më, e kemi çaktivizuar asistencën tonë për këto shtesa."
 
 #: src/olympia/pages/templates/pages/sunbird.html:38
 #, python-format
-msgid ""
-"We recommend upgrading to <a href=\"%(tb_url)s\">Thunderbird</a> and <a "
-"href=\"%(lightning_url)s\">Lightning</a>."
-msgstr ""
-"Këshillojmë të kaloni te <a href=\"%(tb_url)s\">Thunderbird</a>-i dhe <a "
-"href=\"%(lightning_url)s\">Lightning</a>."
+msgid "We recommend upgrading to <a href=\"%(tb_url)s\">Thunderbird</a> and <a href=\"%(lightning_url)s\">Lightning</a>."
+msgstr "Këshillojmë të kaloni te <a href=\"%(tb_url)s\">Thunderbird</a>-i dhe <a href=\"%(lightning_url)s\">Lightning</a>."
 
 #: src/olympia/pages/templates/pages/sunbird.html:45
 msgid "Read more about Sunbird"
@@ -13807,8 +10752,7 @@ msgstr "Lexoni më tepër rreth Sunbird-it"
 
 #: src/olympia/paypal/__init__.py:25
 msgid "There was an error communicating with PayPal. Please try again later."
-msgstr ""
-"Pati një gabim gjatë lidhjes me Paypal-in. Ju lutemi, riprovoni më vonë."
+msgstr "Pati një gabim gjatë lidhjes me Paypal-in. Ju lutemi, riprovoni më vonë."
 
 #: src/olympia/paypal/__init__.py:50
 msgid "There was an error with this currency."
@@ -13851,8 +10795,7 @@ msgstr "Mbaje shqyrtimin; hiq flamurkat"
 msgid "Skip for now"
 msgstr "Hëpërhë anashkaloje"
 
-#: src/olympia/reviews/forms.py:151
-#: src/olympia/reviews/templates/reviews/review.html:107
+#: src/olympia/reviews/forms.py:151 src/olympia/reviews/templates/reviews/review.html:107
 msgid "Delete review"
 msgstr "Fshije shqyrtimin"
 
@@ -13872,42 +10815,24 @@ msgstr "Shtoni një shqyrtim për {0}"
 #: src/olympia/reviews/templates/reviews/add.html:26
 #, python-format
 msgid ""
-"<h2>Keep these tips in mind:</h2> <ul> <li> Write like you're telling a "
-"friend about your experience with the add-on. Give specifics and helpful "
-"details, such as what features you liked and/or disliked, how easy to use it"
-" is, and any disadvantages it has.  Avoid generic language such as calling "
-"it \"Great\" or \"Bad\" unless you can give reasons why you believe this is "
-"so. </li> <li> Please do not post bug reports in reviews. We do not make "
-"your email address available to add-on developers and they may need to "
-"contact you to help resolve your issue. See the <a "
-"href=\"%(support)s\">support section</a> to find out where to get assistance"
-" for this add-on. </li> <li>Please keep reviews clean, avoid the use of "
-"improper language and do not post any personal information. </li> </ul> "
-"<p>Please read the <a href=\"%(guide)s\" target=\"_blank\">Review "
-"Guidelines</a> for more detail about user add-on reviews.</p>"
+"<h2>Keep these tips in mind:</h2> <ul> <li> Write like you're telling a friend about your experience with the add-on. Give specifics and helpful details, such as what features you liked and/or "
+"disliked, how easy to use it is, and any disadvantages it has. Avoid generic language such as calling it \"Great\" or \"Bad\" unless you can give reasons why you believe this is so. </li> <li> "
+"Please do not post bug reports in reviews. We do not make your email address available to add-on developers and they may need to contact you to help resolve your issue. See the <a href=\"%(support)s"
+"\">support section</a> to find out where to get assistance for this add-on. </li> <li>Please keep reviews clean, avoid the use of improper language and do not post any personal information. </li> </"
+"ul> <p>Please read the <a href=\"%(guide)s\" target=\"_blank\">Review Guidelines</a> for more detail about user add-on reviews.</p>"
 msgstr ""
-"<h2>Mbani në mendje këto këshilla:</h2> <ul> <li> Shkruani sikur t’i "
-"tregonit një miku mbi përvojën tuaj me shtesën. Jepni hollësi specifike dhe "
-"të hollësishme, të tilla si, ç’veçori ju pëlqyen dhe/ose nuk ju pëlqyen, sa "
-"e lehtë është ta përdorësh, dhe çfarëdo mangësish që ka. Shmangni gjuhën e "
-"përgjithshme, si, për shembull, quajtjen e saj \"Madhështore\" ose \"E "
-"dobët\", po qe se nuk jepni dot arsye se përse besoni se është kështu. </li>"
-" <li> Ju lutemi, mos postoni njoftime të metash te shqyrtimet. Ne nuk u "
-"japim zhvilluesve të shtesave adresat tuaja email, dhe atyre mund t’ju duhet"
-" të lidhen me ju për t’ju ndihur në zgjidhjen e problemit tuaj. Shihni <a "
-"href=\"%(support)s\">ndarjen e asistencës</a> që të mësoni se ku të merrni "
-"asistencë për një shtesë të dhënë. </li> <li>Ju lutemi, mbajini shqyrtimet "
-"të qarta, shmangni gjuhën e papërshtatshme dhe mos postoni të dhëna "
-"personale. </li> </ul> <p>Ju lutemi, lexoni <a href=\"%(guide)s\" "
-"target=\"_blank\">Udhëzimet mbi Shqyrtimet</a>, për më tepër hollësi lidhur "
-"me shqyrtime shtesash nga përdoruesit.</p>"
+"<h2>Mbani në mendje këto këshilla:</h2> <ul> <li> Shkruani sikur t’i tregonit një miku mbi përvojën tuaj me shtesën. Jepni hollësi specifike dhe të hollësishme, të tilla si, ç’veçori ju pëlqyen dhe/"
+"ose nuk ju pëlqyen, sa e lehtë është ta përdorësh, dhe çfarëdo mangësish që ka. Shmangni gjuhën e përgjithshme, si, për shembull, quajtjen e saj \"Madhështore\" ose \"E dobët\", po qe se nuk jepni "
+"dot arsye se përse besoni se është kështu. </li> <li> Ju lutemi, mos postoni njoftime të metash te shqyrtimet. Ne nuk u japim zhvilluesve të shtesave adresat tuaja email, dhe atyre mund t’ju duhet "
+"të lidhen me ju për t’ju ndihur në zgjidhjen e problemit tuaj. Shihni <a href=\"%(support)s\">ndarjen e asistencës</a> që të mësoni se ku të merrni asistencë për një shtesë të dhënë. </li> <li>Ju "
+"lutemi, mbajini shqyrtimet të qarta, shmangni gjuhën e papërshtatshme dhe mos postoni të dhëna personale. </li> </ul> <p>Ju lutemi, lexoni <a href=\"%(guide)s\" target=\"_blank\">Udhëzimet mbi "
+"Shqyrtimet</a>, për më tepër hollësi lidhur me shqyrtime shtesash nga përdoruesit.</p>"
 
 #: src/olympia/reviews/templates/reviews/reply.html:4
 msgid "Reply to review by {0}"
 msgstr "Përgjigje shqyrtimit nga {0}"
 
-#: src/olympia/reviews/templates/reviews/reply.html:15
-#: src/olympia/reviews/templates/reviews/reply.html:31
+#: src/olympia/reviews/templates/reviews/reply.html:15 src/olympia/reviews/templates/reviews/reply.html:31
 msgid "Reply"
 msgstr "Përgjigjjuni"
 
@@ -13915,8 +10840,7 @@ msgstr "Përgjigjjuni"
 msgid "Write a Reply"
 msgstr "Shkruani një Përgjigje"
 
-#: src/olympia/reviews/templates/reviews/reply.html:36
-#: src/olympia/reviews/templates/reviews/report_review.html:12
+#: src/olympia/reviews/templates/reviews/reply.html:36 src/olympia/reviews/templates/reviews/report_review.html:12
 msgid "Submit"
 msgstr "Parashtroje"
 
@@ -13936,34 +10860,21 @@ msgid "by %(user)s <b>(Developer)</b> on %(date)s"
 msgstr "nga %(user)s <b>(Zhvillues)</b> më %(date)s"
 
 #. {0} is a version number (like 1.01)
-#: src/olympia/reviews/templates/reviews/review.html:50
-#: src/olympia/reviews/templates/reviews/mobile/review_list.html:41
+#: src/olympia/reviews/templates/reviews/review.html:50 src/olympia/reviews/templates/reviews/mobile/review_list.html:41
 msgid "This review is for a previous version of the add-on ({0})."
 msgstr "Ky shqyrtim është për një version të mëparshëm të shtesës ({0})."
 
 #: src/olympia/reviews/templates/reviews/review.html:56
 #, python-format
-msgid ""
-"This user has a <a href=\"%(user_review_url)s\">previous review</a> of this "
-"add-on."
-msgid_plural ""
-"This user has <a href=\"%(user_review_url)s\">%(cnt)s previous reviews</a> "
-"of this add-on."
-msgstr[0] ""
-"Ky përdorues ka <a href=\"%(user_review_url)s\">shqyrtim të mëparshëm</a> të"
-" kësaj shtese."
-msgstr[1] ""
-"Ky përdorues ka <a href=\"%(user_review_url)s\">%(cnt)s shqyrtime të "
-"mëparshme</a> të kësaj shtesë."
+msgid "This user has a <a href=\"%(user_review_url)s\">previous review</a> of this add-on."
+msgid_plural "This user has <a href=\"%(user_review_url)s\">%(cnt)s previous reviews</a> of this add-on."
+msgstr[0] "Ky përdorues ka <a href=\"%(user_review_url)s\">shqyrtim të mëparshëm</a> të kësaj shtese."
+msgstr[1] "Ky përdorues ka <a href=\"%(user_review_url)s\">%(cnt)s shqyrtime të mëparshme</a> të kësaj shtesë."
 
 #: src/olympia/reviews/templates/reviews/review.html:62
 #, python-format
-msgid ""
-"This user has <a href=\"%(user_review_url)s\">other reviews</a> of this add-"
-"on."
-msgstr ""
-"Ky përdorues ka edhe <a href=\"%(user_review_url)s\">shqyrtime të tjera</a> "
-"të kësaj shtese."
+msgid "This user has <a href=\"%(user_review_url)s\">other reviews</a> of this add-on."
+msgstr "Ky përdorues ka edhe <a href=\"%(user_review_url)s\">shqyrtime të tjera</a> të kësaj shtese."
 
 #: src/olympia/reviews/templates/reviews/review.html:72
 msgid "Flagged for review"
@@ -13995,9 +10906,7 @@ msgid "{0} :: Reviews"
 msgstr "{0} :: Shqyrtime"
 
 #. {0} is an addon name.
-#: src/olympia/reviews/templates/reviews/review_list.html:24
-#: src/olympia/reviews/templates/reviews/mobile/add.html:4
-#: src/olympia/reviews/templates/reviews/mobile/review_list.html:4
+#: src/olympia/reviews/templates/reviews/review_list.html:24 src/olympia/reviews/templates/reviews/mobile/add.html:4 src/olympia/reviews/templates/reviews/mobile/review_list.html:4
 msgid "Reviews for {0}"
 msgstr "Shqyrtime për {0}"
 
@@ -14033,8 +10942,7 @@ msgstr "<strong>Mesatare</strong> (%(total)s)"
 msgid "Write a New Review"
 msgstr "Shkruani një Shqyrtim të Ri"
 
-#: src/olympia/reviews/templates/reviews/review_list.html:81
-#: src/olympia/reviews/templates/reviews/mobile/reviews_link.html:15
+#: src/olympia/reviews/templates/reviews/review_list.html:81 src/olympia/reviews/templates/reviews/mobile/reviews_link.html:15
 msgid "Be the first to write a review."
 msgstr "Bëhuni i pari që shkruan një shqyrtim."
 
@@ -14053,8 +10961,7 @@ msgstr "Vlerësuar me {0} nga 5 yje të mundshëm"
 msgid "Rated %(rating)s out of 5 stars"
 msgstr "Vlerësuar me %(rating)s yje nga 5 të mundshëm"
 
-#: src/olympia/reviews/templates/reviews/mobile/add_form.html:3
-#: src/olympia/reviews/templates/reviews/mobile/add_form.html:8
+#: src/olympia/reviews/templates/reviews/mobile/add_form.html:3 src/olympia/reviews/templates/reviews/mobile/add_form.html:8
 msgid "Add a Review"
 msgstr "Shtoni Shqyrtim"
 
@@ -14125,11 +11032,8 @@ msgid "Relevance"
 msgstr "Rëndësi"
 
 #: src/olympia/search/helpers.py:24
-msgid ""
-"Results <strong>{0}</strong>-<strong>{1}</strong> of <strong>{2}</strong>"
-msgstr ""
-"Përfundimet <strong>{0}</strong>-<strong>{1}</strong> nga "
-"<strong>{2}</strong> gjithsej"
+msgid "Results <strong>{0}</strong>-<strong>{1}</strong> of <strong>{2}</strong>"
+msgstr "Përfundimet <strong>{0}</strong>-<strong>{1}</strong> nga <strong>{2}</strong> gjithsej"
 
 # %1$s is a number
 # %2$s is a number
@@ -14137,12 +11041,8 @@ msgstr ""
 # %4$s is the word the person is searching for
 # %5$s is a word (the add-on is tagged with it)
 #: src/olympia/search/helpers.py:44
-msgid ""
-"Showing {0} - {1} of {2} results for <strong>{3}</strong> tagged with "
-"<strong>{4}</strong>"
-msgstr ""
-"Po shfaqen përfundimet {0} - {1} nga {2} gjithsej të etiketuar me "
-"<strong>{4}</strong> për <strong>{3}</strong>"
+msgid "Showing {0} - {1} of {2} results for <strong>{3}</strong> tagged with <strong>{4}</strong>"
+msgstr "Po shfaqen përfundimet {0} - {1} nga {2} gjithsej të etiketuar me <strong>{4}</strong> për <strong>{3}</strong>"
 
 # %1$s is a number
 # %2$s is a number
@@ -14150,8 +11050,7 @@ msgstr ""
 # %4$s is the word the person is searching for
 #: src/olympia/search/helpers.py:49
 msgid "Showing {0} - {1} of {2} results for <strong>{3}</strong>"
-msgstr ""
-"Po shfaqen përfundimet {0} - {1} nga {2} gjithsej për <strong>{3}</strong>"
+msgstr "Po shfaqen përfundimet {0} - {1} nga {2} gjithsej për <strong>{3}</strong>"
 
 # %1$s is a number
 # %2$s is a number
@@ -14159,9 +11058,7 @@ msgstr ""
 # %4$s is a word (the add-on is tagged with it)
 #: src/olympia/search/helpers.py:52
 msgid "Showing {0} - {1} of {2} results tagged with <strong>{3}</strong>"
-msgstr ""
-"Po shfaqen përfundimet {0} - {1} nga {2} gjithsej të etiketuar me "
-"<strong>{3}</strong>"
+msgstr "Po shfaqen përfundimet {0} - {1} nga {2} gjithsej të etiketuar me <strong>{3}</strong>"
 
 # %1$s is a number
 # %2$s is a number
@@ -14171,24 +11068,22 @@ msgid "Showing {0} - {1} of {2} results"
 msgstr "Po shfaqen përfundimet {0} - {1} nga {2} gjithsej"
 
 #. {0} is an application, like Firefox.
-#: src/olympia/search/views.py:264 src/olympia/templates/base.html:17
-#: src/olympia/templates/impala/base.html:17
-#: src/olympia/templates/mobile/base_addons.html:17
+#: src/olympia/search/views.py:264 src/olympia/templates/base.html:17 src/olympia/templates/impala/base.html:17 src/olympia/templates/mobile/base_addons.html:17
 msgid "{0} Add-ons"
 msgstr "Shtesa për {0}"
 
 #. L10n: {0} is an application, such as Firefox. This means "any version of
 #. Firefox."
-#: src/olympia/search/views.py:554
+#: src/olympia/search/views.py:547
 msgid "Any {0}"
 msgstr "Çfarëdo {0}"
 
 #. L10n: "All Systems" means show everything regardless of platform.
-#: src/olympia/search/views.py:589
+#: src/olympia/search/views.py:582
 msgid "All Systems"
 msgstr "Krejt Sistemet"
 
-#: src/olympia/search/views.py:600
+#: src/olympia/search/views.py:593
 msgid "All Tags"
 msgstr "Krejt Etiketat"
 
@@ -14207,9 +11102,7 @@ msgstr "Kërkim Jo i Mundshëm"
 
 #: src/olympia/search/templates/search/down.html:6
 msgid "Search is temporarily unavailable. Please try again in a few minutes."
-msgstr ""
-"Kërkimi është përkohësisht i pamundur. Ju lutemi, riprovoni pas pak "
-"minutash."
+msgstr "Kërkimi është përkohësisht i pamundur. Ju lutemi, riprovoni pas pak minutash."
 
 #. {0} is the string the user was searching for
 #: src/olympia/search/templates/search/personas.html:9
@@ -14364,36 +11257,31 @@ msgstr "Ndajeni këtë Shtesë me të tjerët"
 msgid "Share this Collection"
 msgstr "Ndajeni këtë Koleksion me të tjerët"
 
-#: src/olympia/signing/views.py:30 src/olympia/templates/base.html:75
-#: src/olympia/templates/impala/base.html:115
-msgid ""
-"Some features are temporarily disabled while we perform website maintenance."
-" We'll be back to full capacity shortly."
-msgstr ""
-"Disa veçori janë çaktivizuar përkohësisht, teksa bëjmë mirëmbajtjen e "
-"sajtit. Së shpejti do t’i kthehemi kapacitetit të plotë."
+#: src/olympia/signing/views.py:33 src/olympia/templates/base.html:71 src/olympia/templates/impala/base.html:112
+msgid "Some features are temporarily disabled while we perform website maintenance. We'll be back to full capacity shortly."
+msgstr "Disa veçori janë çaktivizuar përkohësisht, teksa bëjmë mirëmbajtjen e sajtit. Së shpejti do t’i kthehemi kapacitetit të plotë."
 
-#: src/olympia/signing/views.py:53
+#: src/olympia/signing/views.py:56
 msgid "Could not find add-on with id \"{}\"."
 msgstr "S’u gjet dot shtesë me id-në \"{}\"."
 
-#: src/olympia/signing/views.py:67
+#: src/olympia/signing/views.py:70
 msgid "You do not own this addon."
 msgstr "Nuk jeni pronar i kësaj shtese."
 
-#: src/olympia/signing/views.py:82
+#: src/olympia/signing/views.py:87
 msgid "Missing \"upload\" key in multipart file data."
 msgstr ""
 
-#: src/olympia/signing/views.py:96
+#: src/olympia/signing/views.py:101
 msgid "Version does not match the manifest file."
 msgstr "Versioni nuk përputhet me kartelën manifest."
 
-#: src/olympia/signing/views.py:100
+#: src/olympia/signing/views.py:105
 msgid "Version already exists."
 msgstr "Versioni ekziston."
 
-#: src/olympia/signing/views.py:136
+#: src/olympia/signing/views.py:141
 msgid "No uploaded file for that addon and version."
 msgstr "S’ka kartelë të ngarkuar për atë shtesë dhe version."
 
@@ -14485,8 +11373,7 @@ msgstr "Prej"
 msgid "To"
 msgstr "Për"
 
-#: src/olympia/stats/templates/stats/popup.html:27
-#: src/olympia/users/templates/users/pwreset_confirm.html:38
+#: src/olympia/stats/templates/stats/popup.html:27 src/olympia/users/templates/users/pwreset_confirm.html:38
 msgid "Update"
 msgstr "Përditësoje"
 
@@ -14507,98 +11394,89 @@ msgstr "{0} :: Pult Statistikash"
 msgid "Statistics Dashboard :: Add-ons for {0}"
 msgstr "Pult Statistikash :: Shtesa për {0}"
 
-#: src/olympia/stats/templates/stats/stats.html:30
-msgid "Controls:"
-msgstr "Kontrolle:"
-
-#: src/olympia/stats/templates/stats/stats.html:33
-msgid "reset zoom"
-msgstr "zeroje zoom-in"
-
-#: src/olympia/stats/templates/stats/stats.html:40
-msgid "Group by:"
-msgstr "Grupoji sipas:"
-
-#: src/olympia/stats/templates/stats/stats.html:42
-msgid "day"
-msgstr "ditë"
-
-#: src/olympia/stats/templates/stats/stats.html:45
-msgid "week"
-msgstr "javë"
-
-#: src/olympia/stats/templates/stats/stats.html:48
-msgid "month"
-msgstr "muaj"
-
-#: src/olympia/stats/templates/stats/stats.html:54
-msgid "For last:"
-msgstr "Së fundi:"
-
-#: src/olympia/stats/templates/stats/stats.html:57
-msgid "7 days"
-msgstr "7 ditë"
-
-#: src/olympia/stats/templates/stats/stats.html:60
-msgid "30 days"
-msgstr "30 ditë"
-
-#: src/olympia/stats/templates/stats/stats.html:63
-msgid "90 days"
-msgstr "90 Ditë"
-
-#: src/olympia/stats/templates/stats/stats.html:66
-msgid "365 days"
-msgstr "365 ditë"
-
-#: src/olympia/stats/templates/stats/stats.html:69
-msgid "Custom..."
-msgstr "Vetjake..."
-
 #. {0} is an add-on name
-#: src/olympia/stats/templates/stats/stats.html:88
-#: src/olympia/stats/templates/stats/stats.html:91
+#: src/olympia/stats/templates/stats/stats.html:44 src/olympia/stats/templates/stats/stats.html:47
 msgid "Statistics for {0}"
 msgstr "Statistika për {0}"
 
-#: src/olympia/stats/templates/stats/stats.html:94
+#: src/olympia/stats/templates/stats/stats.html:50
 msgid "Statistics Dashboard"
 msgstr "Pult Statistikash"
 
-#: src/olympia/stats/templates/stats/stats.html:104
-msgid ""
-"Statistics processing is currently disabled, so recent data is unavailable. "
-"The statistics are still being collected and this page will be updated soon "
-"with the missing data."
-msgstr ""
-"Përpunimi i statistikave është hëpërhë i çaktivizuar, kështu që s’ka të "
-"dhëna të reja. Statistikat ende po grumbullohen dhe kjo faqe do të "
-"përditësohet së shpejti me të dhënat që mungojnë."
+#: src/olympia/stats/templates/stats/stats.html:57
+msgid "Controls:"
+msgstr "Kontrolle:"
 
-#: src/olympia/stats/templates/stats/stats.html:110
+#: src/olympia/stats/templates/stats/stats.html:60
+msgid "reset zoom"
+msgstr "zeroje zoom-in"
+
+#: src/olympia/stats/templates/stats/stats.html:67
+msgid "Group by:"
+msgstr "Grupoji sipas:"
+
+#: src/olympia/stats/templates/stats/stats.html:69
+msgid "day"
+msgstr "ditë"
+
+#: src/olympia/stats/templates/stats/stats.html:72
+msgid "week"
+msgstr "javë"
+
+#: src/olympia/stats/templates/stats/stats.html:75
+msgid "month"
+msgstr "muaj"
+
+#: src/olympia/stats/templates/stats/stats.html:81
+msgid "For last:"
+msgstr "Së fundi:"
+
+#: src/olympia/stats/templates/stats/stats.html:84
+msgid "7 days"
+msgstr "7 ditë"
+
+#: src/olympia/stats/templates/stats/stats.html:87
+msgid "30 days"
+msgstr "30 ditë"
+
+#: src/olympia/stats/templates/stats/stats.html:90
+msgid "90 days"
+msgstr "90 Ditë"
+
+#: src/olympia/stats/templates/stats/stats.html:93
+msgid "365 days"
+msgstr "365 ditë"
+
+#: src/olympia/stats/templates/stats/stats.html:96
+msgid "Custom..."
+msgstr "Vetjake..."
+
+#: src/olympia/stats/templates/stats/stats.html:106
+msgid "Statistics processing is currently disabled, so recent data is unavailable. The statistics are still being collected and this page will be updated soon with the missing data."
+msgstr "Përpunimi i statistikave është hëpërhë i çaktivizuar, kështu që s’ka të dhëna të reja. Statistikat ende po grumbullohen dhe kjo faqe do të përditësohet së shpejti me të dhënat që mungojnë."
+
+#: src/olympia/stats/templates/stats/stats.html:112
 msgid "Loading the latest data&hellip;"
 msgstr "Po ngarkohen të dhënat më të reja&hellip;"
 
-#: src/olympia/stats/templates/stats/stats.html:142
-#: src/olympia/stats/templates/stats/reports/overview.html:25
-#: src/olympia/stats/templates/stats/reports/overview.html:37
+#: src/olympia/stats/templates/stats/stats.html:144 src/olympia/stats/templates/stats/reports/overview.html:25 src/olympia/stats/templates/stats/reports/overview.html:37
 #: src/olympia/stats/templates/stats/reports/overview.html:49
 msgid "No data available."
 msgstr "Pa të dhëna të passhme."
 
-#: src/olympia/stats/templates/stats/stats.html:177
+#: src/olympia/stats/templates/stats/stats.html:179
 msgid "This dashboard is currently <b>public</b>."
 msgstr "Ky pult, për çastin, është <b>publik</b>."
 
-#: src/olympia/stats/templates/stats/stats.html:179
+#: src/olympia/stats/templates/stats/stats.html:181
 msgid "Contribution stats are currently <b>private</b>."
 msgstr "Hëpërhë, statistikat për kontribute janë <b>private</b>."
 
-#: src/olympia/stats/templates/stats/stats.html:182
+#: src/olympia/stats/templates/stats/stats.html:184
 msgid "This dashboard is currently <b>private</b>."
 msgstr "Ky pult, hëpërhë, është <b>privat</b>."
 
-#: src/olympia/stats/templates/stats/stats.html:185
+#: src/olympia/stats/templates/stats/stats.html:187
 msgid "Change settings."
 msgstr "Ndryshoni rregullimet."
 
@@ -14640,14 +11518,11 @@ msgstr "Si numërohen shkarkimet?"
 
 #: src/olympia/stats/templates/stats/reports/downloads.html:10
 msgid ""
-"<h2>How are downloads counted?</h2> <p> Download counts are updated every "
-"evening and only include original add-on downloads, not updates. Downloads "
-"can be broken down by the specific source referring the download. </p>"
+"<h2>How are downloads counted?</h2> <p> Download counts are updated every evening and only include original add-on downloads, not updates. Downloads can be broken down by the specific source "
+"referring the download. </p>"
 msgstr ""
-"<h2>Si numërohen shkarkimet?</h2> <p> Numërimi i shkarkimeve përditësohen "
-"çdo mbrëmje dhe përfshijnë vetëm shkarkimet origjinale shtesash, jo "
-"përditësimet. Shkarkimet mund të grupohen sipas burimit të caktuar që "
-"referoi shkarkimin. </p>"
+"<h2>Si numërohen shkarkimet?</h2> <p> Numërimi i shkarkimeve përditësohen çdo mbrëmje dhe përfshijnë vetëm shkarkimet origjinale shtesash, jo përditësimet. Shkarkimet mund të grupohen sipas burimit "
+"të caktuar që referoi shkarkimin. </p>"
 
 #: src/olympia/stats/templates/stats/reports/locales.html:3
 msgid "User languages by Date"
@@ -14661,8 +11536,7 @@ msgstr "Përdorime platformash sipas Datash"
 msgid "<b>{0}</b> Downloads"
 msgstr "<b>{0}</b> Shkarkime"
 
-#: src/olympia/stats/templates/stats/reports/overview.html:9
-#: src/olympia/stats/templates/stats/reports/overview.html:13
+#: src/olympia/stats/templates/stats/reports/overview.html:9 src/olympia/stats/templates/stats/reports/overview.html:13
 msgid "Loading..."
 msgstr "Po ngarkohet..."
 
@@ -14713,34 +11587,17 @@ msgstr "Si të ndiqni burime të jashtme..."
 #: src/olympia/stats/templates/stats/reports/sources.html:10
 #, python-format
 msgid ""
-"<h2>Tracking external sources</h2> <p> If you link to your add-on's details "
-"page or directly to its file from an external site, such as your blog or "
-"website, you can append a parameter to be tracked as an additional download "
-"source on this page. For example, the following links would appear as "
-"sourced by your blog: <dl> <dt>Add-on Details Page</dt> "
-"<dd>https://addons.mozilla.org/addon/%(slug)s?src=<b>external-blog</b></dd> "
-"<dt>Direct File Link</dt> "
-"<dd>https://addons.mozilla.org/downloads/latest/%(id)s/addon-%(id)s-latest.xpi?src=<b"
-">external-blog</b></dd> </dl> <p> Only src parameters that begin with "
-"\"external-\" will be tracked, up to 61 additional characters. Any text "
-"after \"external-\" can be used to describe the source, such as \"external-"
-"blog\", \"external-sidebar\", \"external-campaign225\", etc. The following "
-"URL-safe characters are allowed: <code>a-z A-Z - . _ ~ %% +</code>"
+"<h2>Tracking external sources</h2> <p> If you link to your add-on's details page or directly to its file from an external site, such as your blog or website, you can append a parameter to be "
+"tracked as an additional download source on this page. For example, the following links would appear as sourced by your blog: <dl> <dt>Add-on Details Page</dt> <dd>https://addons.mozilla.org/addon/"
+"%(slug)s?src=<b>external-blog</b></dd> <dt>Direct File Link</dt> <dd>https://addons.mozilla.org/downloads/latest/%(id)s/addon-%(id)s-latest.xpi?src=<b>external-blog</b></dd> </dl> <p> Only src "
+"parameters that begin with \"external-\" will be tracked, up to 61 additional characters. Any text after \"external-\" can be used to describe the source, such as \"external-blog\", \"external-"
+"sidebar\", \"external-campaign225\", etc. The following URL-safe characters are allowed: <code>a-z A-Z - . _ ~ %% +</code>"
 msgstr ""
-"<h2>Lidhja e burimeve të jashtme</h2> <p> Nëse keni krijuar lidhje për te "
-"faqja e hollësive të shtesës suaj, ose drejt e te kartela e saj, prej një "
-"sajti të jashtëm, të tillë si blogu ose sajti juaj, mund të shtoni te kjo "
-"faqe një parametër që të ndiqet si burim shtesë shkarkimesh. Për shembull, "
-"lidhjet vijuese do të shfaqeshin si burime nga blogu juaj: <dl> <dt>Faqe e "
-"Hollësive të Shtesës</dt> "
-"<dd>https://addons.mozilla.org/addon/%(slug)s?src=<b>external-blog</b></dd> "
-"<dt>Lidhje e Drejtpërdrejtë Kartele</dt> "
-"<dd>https://addons.mozilla.org/downloads/latest/%(id)s/addon-%(id)s-latest.xpi?src=<b"
-">external-blog</b></dd> </dl> <p> Do të ndiqen vetëm parametrat që fillojnë "
-"me \"external-\", deri në 61 shenja shtesë. Për të përshkruar burimin, mund "
-"të përdoret çfarëdo teksti pas \"external-\", të tillë si \"external-blog\","
-" \"external-anështyllë\", \"external-fushata225\", etj. Lejohen shenjat "
-"vijuese që s’janë problem për URL-të: <code>a-z A-Z - . _ ~ %% +</code>"
+"<h2>Lidhja e burimeve të jashtme</h2> <p> Nëse keni krijuar lidhje për te faqja e hollësive të shtesës suaj, ose drejt e te kartela e saj, prej një sajti të jashtëm, të tillë si blogu ose sajti "
+"juaj, mund të shtoni te kjo faqe një parametër që të ndiqet si burim shtesë shkarkimesh. Për shembull, lidhjet vijuese do të shfaqeshin si burime nga blogu juaj: <dl> <dt>Faqe e Hollësive të "
+"Shtesës</dt> <dd>https://addons.mozilla.org/addon/%(slug)s?src=<b>external-blog</b></dd> <dt>Lidhje e Drejtpërdrejtë Kartele</dt> <dd>https://addons.mozilla.org/downloads/latest/%(id)s/addon-%(id)s-"
+"latest.xpi?src=<b>external-blog</b></dd> </dl> <p> Do të ndiqen vetëm parametrat që fillojnë me \"external-\", deri në 61 shenja shtesë. Për të përshkruar burimin, mund të përdoret çfarëdo teksti "
+"pas \"external-\", të tillë si \"external-blog\", \"external-anështyllë\", \"external-fushata225\", etj. Lejohen shenjat vijuese që s’janë problem për URL-të: <code>a-z A-Z - . _ ~ %% +</code>"
 
 #: src/olympia/stats/templates/stats/reports/statuses.html:3
 msgid "Add-on Status by Date"
@@ -14760,28 +11617,19 @@ msgstr "Çfarë janë përdoruesit e përditshëm?"
 
 #: src/olympia/stats/templates/stats/reports/usage.html:11
 msgid ""
-"<h2>What are daily users?</h2> <p> Themes installed from this site check for"
-" updates once per day. The total number of these update pings is known as "
-"Active Daily Users, or the total number of people using your theme by day. "
-"</p>"
+"<h2>What are daily users?</h2> <p> Themes installed from this site check for updates once per day. The total number of these update pings is known as Active Daily Users, or the total number of "
+"people using your theme by day. </p>"
 msgstr ""
-"<h2>Ç’janë përdoruesit ditorë?</h2> <p> Temat e instaluara nga ky sajt "
-"kontrollojnë për përditësim një herë në ditë. Numri gjithseji këtyre "
-"sinjaleve ardhëse për përditësim njihet si Përdorues të Përditshëm Aktivë, "
-"ose numri gjithsej i njerëzve që përdorin temën tuaj në ditë. </p>"
+"<h2>Ç’janë përdoruesit ditorë?</h2> <p> Temat e instaluara nga ky sajt kontrollojnë për përditësim një herë në ditë. Numri gjithseji këtyre sinjaleve ardhëse për përditësim njihet si Përdorues të "
+"Përditshëm Aktivë, ose numri gjithsej i njerëzve që përdorin temën tuaj në ditë. </p>"
 
 #: src/olympia/stats/templates/stats/reports/usage.html:20
 msgid ""
-"<h2>What are daily users?</h2> <p> Add-ons downloaded from this site check "
-"for updates once per day. The total number of these update pings is known as"
-" Active Daily Users. Daily users can be broken down by add-on version, "
-"operating system, add-on status, application, and locale. </p>"
+"<h2>What are daily users?</h2> <p> Add-ons downloaded from this site check for updates once per day. The total number of these update pings is known as Active Daily Users. Daily users can be broken "
+"down by add-on version, operating system, add-on status, application, and locale. </p>"
 msgstr ""
-"<h2>Çfarë janë përdoruesit e ditës?</h2> <p> Shtesat e shkarkuara prej këtij"
-" sajti kontrollojnë për përditësime një herë në ditë. Numri gjithsej i "
-"sinjaleve prej këtyre përditësimeve njihet si Përdorues Ditorë Aktivë. "
-"Përdoruesit e ditës mund të ndahen sipas versionit të shtesës, sistemit "
-"operativ, gjendjes së shtesës, aplikacioneve, dhe vendores. </p>"
+"<h2>Çfarë janë përdoruesit e ditës?</h2> <p> Shtesat e shkarkuara prej këtij sajti kontrollojnë për përditësime një herë në ditë. Numri gjithsej i sinjaleve prej këtyre përditësimeve njihet si "
+"Përdorues Ditorë Aktivë. Përdoruesit e ditës mund të ndahen sipas versionit të shtesës, sistemit operativ, gjendjes së shtesës, aplikacioneve, dhe vendores. </p>"
 
 #: src/olympia/stats/templates/stats/reports/users_created.html:3
 msgid "User Signups by Date"
@@ -14791,45 +11639,27 @@ msgstr "Regjistrime Përdoruesish sipas Datash"
 msgid "Application versions by Date"
 msgstr "Versione aplikacioni sipas Datash"
 
-#: src/olympia/tags/templates/tags/top_cloud.html:4
-msgid "Top {0} Tags"
-msgstr "Etiketa Kryesuese për {0}"
-
-#. {0} is the current application name
-#: src/olympia/tags/templates/tags/top_cloud.html:14
-msgid "{0} Top Tags"
-msgstr "{0} Etiketat Kryesuese"
-
-#: src/olympia/templates/amo_footer.html:6
-#: src/olympia/templates/includes/lang_switcher.html:2
+#: src/olympia/templates/amo_footer.html:6 src/olympia/templates/includes/lang_switcher.html:2
 msgid "Other languages"
 msgstr "Gjuhë të tjera"
 
-#: src/olympia/templates/base.html:9 src/olympia/templates/impala/base.html:9
-#: src/olympia/templates/mobile/base_addons.html:9
+#: src/olympia/templates/base.html:9 src/olympia/templates/impala/base.html:9 src/olympia/templates/mobile/base_addons.html:9
 msgid "Mozilla Add-ons"
 msgstr "Shtesa Mozilla"
 
-#: src/olympia/templates/base.html:91
-#: src/olympia/templates/impala/base.html:81
+#: src/olympia/templates/base.html:89 src/olympia/templates/impala/base.html:78
 msgid "Find add-ons for other applications"
 msgstr "Gjeni shtesa për aplikacione të tjera"
 
-#: src/olympia/templates/base.html:92
-#: src/olympia/templates/impala/base.html:81
+#: src/olympia/templates/base.html:90 src/olympia/templates/impala/base.html:78
 msgid "Other Applications"
 msgstr "Aplikacione të Tjera"
 
-#: src/olympia/templates/base.html:141
-#: src/olympia/templates/impala/base.html:194
-msgid ""
-"To create your own collections, you must have a Mozilla Add-ons account."
-msgstr ""
-"Që të krijoni koleksionet tuaja, duhet të keni një llogari te Shtesat "
-"Mozilla."
+#: src/olympia/templates/base.html:141 src/olympia/templates/impala/base.html:194
+msgid "To create your own collections, you must have a Mozilla Add-ons account."
+msgstr "Që të krijoni koleksionet tuaja, duhet të keni një llogari te Shtesat Mozilla."
 
-#: src/olympia/templates/base.html:168
-#: src/olympia/templates/impala/base.html:215
+#: src/olympia/templates/base.html:168 src/olympia/templates/impala/base.html:215
 msgid "Footer logo"
 msgstr "Logo Fundfaqeje"
 
@@ -14846,21 +11676,19 @@ msgid "View Mobile Site"
 msgstr "Shihni Sajtin për Celular"
 
 #: src/olympia/templates/copyright.html:7
-msgid "Site Status "
+msgid "Site Status"
 msgstr "Gjendje Sajti"
 
 #: src/olympia/templates/footer.html:3
 msgid "get to know <b>add-ons</b>"
 msgstr "njihuni me <b>shtesat</b>"
 
-#: src/olympia/templates/footer.html:4
-#: src/olympia/templates/menu_links.html:20
+#: src/olympia/templates/footer.html:4 src/olympia/templates/menu_links.html:20
 msgid "About"
 msgstr "Rreth"
 
 # Link text to the AMO blog.
-#: src/olympia/templates/footer.html:5
-#: src/olympia/templates/menu_links.html:32
+#: src/olympia/templates/footer.html:5 src/olympia/templates/menu_links.html:32
 msgid "Blog"
 msgstr "Blog"
 
@@ -14937,9 +11765,7 @@ msgstr "Ligjore"
 msgid "Contact Us"
 msgstr "Lidhuni me Ne"
 
-#: src/olympia/templates/user_login.html:22
-#: src/olympia/users/templates/users/edit.html:31
-#: src/olympia/users/templates/users/includes/navigation.html:12
+#: src/olympia/templates/user_login.html:22 src/olympia/users/templates/users/edit.html:31 src/olympia/users/templates/users/includes/navigation.html:12
 msgid "My Account"
 msgstr "Llogaria Ime"
 
@@ -14948,65 +11774,48 @@ msgstr "Llogaria Ime"
 msgid "Welcome, {0}"
 msgstr "Mirë se vini, {0}"
 
-#: src/olympia/templates/user_login.html:41
-#: src/olympia/templates/impala/user_login.html:20
+#: src/olympia/templates/user_login.html:41 src/olympia/templates/impala/user_login.html:20
 #, python-format
 msgid "<a href=\"%(reg)s\">Register</a> or <a href=\"%(login)s\">Log in</a>"
 msgstr "<a href=\"%(reg)s\">Regjistrohuni</a> ose <a href=\"%(login)s\">Hyni</a>"
 
-#: src/olympia/templates/impala/base.html:126
+#: src/olympia/templates/impala/base.html:123
 #, python-format
-msgid ""
-"To try the thousands of add-ons available here, download <a "
-"href=\"%(url)s\">Mozilla Firefox</a>, a fast, free way to surf the Web!"
-msgstr ""
-"Që të provoni mijërat e shtesave që mund të kihen prej këtu, shkarkoni <a "
-"href=\"%(url)s\">Mozilla Firefox</a>, një mënyrë e shpejtë dhe e lirë për të"
-" lundruar në Web!"
+msgid "To try the thousands of add-ons available here, download <a href=\"%(url)s\">Mozilla Firefox</a>, a fast, free way to surf the Web!"
+msgstr "Që të provoni mijërat e shtesave që mund të kihen prej këtu, shkarkoni <a href=\"%(url)s\">Mozilla Firefox</a>, një mënyrë e shpejtë dhe e lirë për të lundruar në Web!"
 
-#: src/olympia/templates/impala/base.html:138
+#: src/olympia/templates/impala/base.html:135
 #, python-format
-msgid ""
-"Add-ons is switching to Firefox Accounts for login. <a href=\"%(url)s\" "
-"class=\"fxa-login\">Sign in now to transfer your account.</a>"
-msgstr ""
-"Shtesat po kalojnë te përdorimi i Llogarive Firefox për hyrjet. <a "
-"href=\"%(url)s\" class=\"fxa-login\">Bëni hyrjen tani që të shpërngulet "
-"llogaria juaj.</a>"
+msgid "Add-ons is switching to Firefox Accounts for login. <a href=\"%(url)s\" class=\"fxa-login\">Sign in now to transfer your account.</a>"
+msgstr "Shtesat po kalojnë te përdorimi i Llogarive Firefox për hyrjet. <a href=\"%(url)s\" class=\"fxa-login\">Bëni hyrjen tani që të shpërngulet llogaria juaj.</a>"
 
 #. {0} is an application, such as Firefox.
-#: src/olympia/templates/impala/base.html:148
+#: src/olympia/templates/impala/base.html:145
 msgid "Welcome to {0} Add-ons."
 msgstr "Mirë se vini te Shtesat për {0}."
 
-#: src/olympia/templates/impala/base.html:151
-msgid ""
-"Choose from thousands of extra features and styles to make Firefox your own."
-msgstr ""
-"Zgjidhni prej mijëra veçorive dhe stileve ekstra për ta bërë Firefox-in "
-"tuajin."
+#: src/olympia/templates/impala/base.html:148
+msgid "Choose from thousands of extra features and styles to make Firefox your own."
+msgstr "Zgjidhni prej mijëra veçorive dhe stileve ekstra për ta bërë Firefox-in tuajin."
 
-#: src/olympia/templates/impala/base.html:156
+#: src/olympia/templates/impala/base.html:153
 #, python-format
 msgid "Add extra features and styles to make %(app)s your own."
 msgstr "Shtoni veçori dhe stile ekstra për ta bërë këtë %(app)s tuajin."
 
-#: src/olympia/templates/impala/base.html:164
+#: src/olympia/templates/impala/base.html:161
 msgid "On the go?"
 msgstr "Në lëvizje?"
 
-#: src/olympia/templates/impala/base.html:166
+#: src/olympia/templates/impala/base.html:163
 msgid "Check out our <a class=\"mobile-link\" href=\"#\">Mobile Add-ons site</a>."
-msgstr ""
-"Hidhini një sy <a class=\"mobile-link\" href=\"#\">sajtit tonë për Shtesa "
-"Celularësh</a>."
+msgstr "Hidhini një sy <a class=\"mobile-link\" href=\"#\">sajtit tonë për Shtesa Celularësh</a>."
 
 #: src/olympia/templates/impala/header_title.html:21
 msgid "Android Add-ons"
 msgstr "Shtesa Android"
 
-#: src/olympia/templates/includes/forms.html:2
-#: src/olympia/templates/includes/forms.html:6
+#: src/olympia/templates/includes/forms.html:2 src/olympia/templates/includes/forms.html:6
 msgid "required"
 msgstr "e domosdoshme"
 
@@ -15051,15 +11860,11 @@ msgstr "Vizitoni Mozilla-n"
 msgid "menu"
 msgstr "menu"
 
-#: src/olympia/templates/mobile/header_auth.html:7
-#: src/olympia/users/templates/users/register.html:41
-#: src/olympia/users/templates/users/register.html:89
+#: src/olympia/templates/mobile/header_auth.html:7 src/olympia/users/templates/users/register.html:41 src/olympia/users/templates/users/register.html:89
 msgid "Register"
 msgstr "Regjistrohuni"
 
-#: src/olympia/templates/mobile/header_auth.html:8
-#: src/olympia/users/templates/users/login_form.html:41
-#: src/olympia/users/templates/users/pwreset_complete.html:15
+#: src/olympia/templates/mobile/header_auth.html:8 src/olympia/users/templates/users/login_form.html:41 src/olympia/users/templates/users/pwreset_complete.html:15
 #: src/olympia/users/templates/users/mobile/login.html:56
 msgid "Log in"
 msgstr "Hyni"
@@ -15070,8 +11875,7 @@ msgstr "Hyni"
 msgid "Localize for: <a id=\"change-locale\" href=\"#\">%(dl)s</a>"
 msgstr "Përkthejeni në: <a id=\"change-locale\" href=\"#\">%(dl)s</a>"
 
-#: src/olympia/translations/templates/translations/trans-menu.html:16
-#: src/olympia/translations/templates/translations/trans-menu.html:29
+#: src/olympia/translations/templates/translations/trans-menu.html:16 src/olympia/translations/templates/translations/trans-menu.html:29
 #, python-format
 msgid "%(title)s <em>&middot; %(lang)s</em>"
 msgstr "%(title)s <em>&middot; %(lang)s</em>"
@@ -15086,12 +11890,8 @@ msgstr "Vendoret e Reja"
 
 #. {0} is a language name, like 'French'
 #: src/olympia/translations/templates/translations/trans-menu.html:42
-msgid ""
-"You have unsaved changes in the <b>{0}</b> locale. Would you like to save "
-"your changes before switching locales?"
-msgstr ""
-"Keni ndryshime të paruajtura te vendorja <b>{0}</b>. Do të donit të ruanit "
-"ndryshimet tuaja përpara ndërrimit të vendores?"
+msgid "You have unsaved changes in the <b>{0}</b> locale. Would you like to save your changes before switching locales?"
+msgstr "Keni ndryshime të paruajtura te vendorja <b>{0}</b>. Do të donit të ruanit ndryshimet tuaja përpara ndërrimit të vendores?"
 
 #: src/olympia/translations/templates/translations/trans-menu.html:49
 msgid "Discard Changes"
@@ -15099,12 +11899,8 @@ msgstr "Hidhi Tej Ndryshimet"
 
 #. {0} is a language name, like 'French'
 #: src/olympia/translations/templates/translations/trans-menu.html:56
-msgid ""
-"Are you sure you want to remove all <b>{0}</b> translations? This cannot be "
-"undone."
-msgstr ""
-"Jeni i sigurt se doni të hiqen krejt përkthimet për <b>{0}</b>? Kjo s’mund "
-"të zhbëhet."
+msgid "Are you sure you want to remove all <b>{0}</b> translations? This cannot be undone."
+msgstr "Jeni i sigurt se doni të hiqen krejt përkthimet për <b>{0}</b>? Kjo s’mund të zhbëhet."
 
 #: src/olympia/translations/templates/translations/trans-menu.html:61
 msgid "Delete Locale"
@@ -15125,25 +11921,16 @@ msgstr "Ky fjalëkalim nuk lejohet."
 
 #: src/olympia/users/forms.py:90
 #, python-format
-msgid ""
-"As part of our new password policy, your password must be %s characters or "
-"more. Please update your password by <a href=\"%s\">issuing a password "
-"reset</a>."
+msgid "As part of our new password policy, your password must be %s characters or more. Please update your password by <a href=\"%s\">issuing a password reset</a>."
 msgstr ""
-"Si pjesë e rregullave tona të reja për fjalëkalimet, fjalëkalimi juaj duhet "
-"të jetë %s ose më tepër shenja. Ju lutemi, përditësoni fjalëkalimin tuaj "
-"përmes <a href=\"%s\">kërkesës për ricaktim fjalëkalimi</a>."
+"Si pjesë e rregullave tona të reja për fjalëkalimet, fjalëkalimi juaj duhet të jetë %s ose më tepër shenja. Ju lutemi, përditësoni fjalëkalimin tuaj përmes <a href=\"%s\">kërkesës për ricaktim "
+"fjalëkalimi</a>."
 
 #: src/olympia/users/forms.py:115
-msgid ""
-"You must recover your password through Firefox Accounts. Try logging in "
-"instead."
-msgstr ""
-"Fjalëkalimin tuaj mund ta rimerrni që nga Llogaritë Firefox. Provoni të bëni"
-" hyrjen."
+msgid "You must recover your password through Firefox Accounts. Try logging in instead."
+msgstr "Fjalëkalimin tuaj mund ta rimerrni që nga Llogaritë Firefox. Provoni të bëni hyrjen."
 
-#: src/olympia/users/forms.py:206
-#: src/olympia/users/templates/users/pwreset_confirm.html:24
+#: src/olympia/users/forms.py:206 src/olympia/users/templates/users/pwreset_confirm.html:24
 msgid "New password"
 msgstr "Fjalëkalim i ri"
 
@@ -15156,12 +11943,8 @@ msgid "Usernames cannot contain only digits."
 msgstr "Emri i përdoruesit s’mundet të përmbajë vetëm shifra."
 
 #: src/olympia/users/forms.py:274
-msgid ""
-"Enter a valid username consisting of letters, numbers, underscores or "
-"hyphens."
-msgstr ""
-"Jepni një emër të vlefshëm përdoruesi, të përbërë nga shkronja, numra, "
-"nënvija ose vija ndarëse."
+msgid "Enter a valid username consisting of letters, numbers, underscores or hyphens."
+msgstr "Jepni një emër të vlefshëm përdoruesi, të përbërë nga shkronja, numra, nënvija ose vija ndarëse."
 
 #: src/olympia/users/forms.py:277
 msgid "This username cannot be used."
@@ -15171,38 +11954,25 @@ msgstr "Ky emër përdoruesi s’përdoret dot."
 msgid "This username is already in use."
 msgstr "Ky emër përdoruesi është tashmë në përdorim."
 
-#: src/olympia/users/forms.py:296
-#: src/olympia/users/templates/users/edit.html:107
+#: src/olympia/users/forms.py:296 src/olympia/users/templates/users/edit.html:107
 msgid "Display Name"
 msgstr "Emër në Ekran"
 
-#: src/olympia/users/forms.py:298
-#: src/olympia/users/templates/users/edit.html:112
-#: src/olympia/users/templates/users/vcard.html:10
+#: src/olympia/users/forms.py:298 src/olympia/users/templates/users/edit.html:112 src/olympia/users/templates/users/vcard.html:10
 msgid "Location"
 msgstr "Vend"
 
-#: src/olympia/users/forms.py:300
-#: src/olympia/users/templates/users/edit.html:117
-#: src/olympia/users/templates/users/vcard.html:16
+#: src/olympia/users/forms.py:300 src/olympia/users/templates/users/edit.html:117 src/olympia/users/templates/users/vcard.html:16
 msgid "Occupation"
 msgstr "Punësim"
 
 #: src/olympia/users/forms.py:329
-msgid ""
-"This URL has an invalid format. Valid URLs look like "
-"http://example.com/my_page."
-msgstr ""
-"Kjo URL ka format të pavlefshëm. URL-të e vlefshme kanë pamje si kjo "
-"http://shembull.com/faqja_ime."
+msgid "This URL has an invalid format. Valid URLs look like http://example.com/my_page."
+msgstr "Kjo URL ka format të pavlefshëm. URL-të e vlefshme kanë pamje si kjo http://shembull.com/faqja_ime."
 
 #: src/olympia/users/forms.py:337
-msgid ""
-"Please use an email address from a different provider to complete your "
-"registration."
-msgstr ""
-"Ju lutemi, që të plotësohet regjistrimi juaj, përdorni një adresë email nga "
-"një tjetër mundësues."
+msgid "Please use an email address from a different provider to complete your registration."
+msgstr "Ju lutemi, që të plotësohet regjistrimi juaj, përdorni një adresë email nga një tjetër mundësues."
 
 #: src/olympia/users/forms.py:345
 msgid "This display name cannot be used."
@@ -15212,21 +11982,17 @@ msgstr "S’mund të përdoren ky emër ekrani."
 msgid "The passwords did not match."
 msgstr "Fjalëkalimet s’u përputhën."
 
-#: src/olympia/users/forms.py:377
-#: src/olympia/users/templates/users/edit.html:128
+#: src/olympia/users/forms.py:377 src/olympia/users/templates/users/edit.html:128
 msgid "Profile Photo"
 msgstr "Foto Profili"
 
-#: src/olympia/users/forms.py:385
-#: src/olympia/users/templates/users/edit.html:142
+#: src/olympia/users/forms.py:385 src/olympia/users/templates/users/edit.html:142
 msgid "Default locale"
 msgstr "Vendore parazgjedhje"
 
 #: src/olympia/users/forms.py:412
 msgid "Firefox Accounts users cannot currently change their email address."
-msgstr ""
-"Përdoruesit e Llogarive Firefox, hëpërhë, s’mund të ndryshojnë adresën e "
-"tyre email."
+msgstr "Përdoruesit e Llogarive Firefox, hëpërhë, s’mund të ndryshojnë adresën e tyre email."
 
 #: src/olympia/users/forms.py:446
 msgid "Wrong password entered!"
@@ -15237,12 +12003,8 @@ msgid "Email cannot be changed."
 msgstr "Email-i s’mund të ndryshohet.n"
 
 #: src/olympia/users/forms.py:541
-msgid ""
-"To anonymize, enter a reason for the change but do not change any other "
-"field."
-msgstr ""
-"Për anonimizim, jepni një arsye për ndryshimin, por mos ndryshoni ndonjë "
-"fushë tjetër."
+msgid "To anonymize, enter a reason for the change but do not change any other field."
+msgstr "Për anonimizim, jepni një arsye për ndryshimin, por mos ndryshoni ndonjë fushë tjetër."
 
 #: src/olympia/users/forms.py:587
 msgid "Please enter at least one name to blacklist."
@@ -15271,19 +12033,19 @@ msgstr "S’ka përdorues me këtë email."
 
 #. L10n: {id} will be something like "13ad6a", just a random number
 #. to differentiate this user from other anonymous users.
-#: src/olympia/users/models.py:353
+#: src/olympia/users/models.py:362
 msgid "Anonymous user {id}"
 msgstr "Përdorues i paemër {id}"
 
-#: src/olympia/users/models.py:410
+#: src/olympia/users/models.py:419
 msgid "Your account has been restricted"
 msgstr "Llogaria juaj u kufizua"
 
-#: src/olympia/users/models.py:480
+#: src/olympia/users/models.py:489
 msgid "Please confirm your email address"
 msgstr "Ju lutemi, ripohoni adresën tuaj email"
 
-#: src/olympia/users/models.py:506
+#: src/olympia/users/models.py:515
 msgid "My Mobile Add-ons"
 msgstr "Shtesat e Mia për Celular"
 
@@ -15348,16 +12110,12 @@ msgid "Mozilla needs to contact me about my individual app"
 msgstr "Mozilla ka nevojë të më kontaktojë rreth aplikacionit tim individual"
 
 #: src/olympia/users/notifications.py:139
-msgid ""
-"Mozilla wants to contact me about relevant App Developer news and surveys"
-msgstr ""
-"Mozilla ka nevojë të më kontaktojë lidhur me lajme dhe pyetësorë të "
-"rëndësishëm Zhvilluesi Shtesash"
+msgid "Mozilla wants to contact me about relevant App Developer news and surveys"
+msgstr "Mozilla ka nevojë të më kontaktojë lidhur me lajme dhe pyetësorë të rëndësishëm Zhvilluesi Shtesash"
 
 #: src/olympia/users/notifications.py:150
 msgid "Mozilla wants to contact me about new regions added to the Marketplace"
-msgstr ""
-"Mozilla dëshiron të më kontaktojë lidhur me rajone të reja të shtuara te"
+msgstr "Mozilla dëshiron të më kontaktojë lidhur me rajone të reja të shtuara te"
 
 #: src/olympia/users/notifications.py:158
 msgid "User Notifications"
@@ -15380,14 +12138,8 @@ msgid "Successfully verified!"
 msgstr "Verifikuar me sukses!"
 
 #: src/olympia/users/views.py:132
-msgid ""
-"An email has been sent to your address to confirm your account. Before you "
-"can log in, you have to activate your account by clicking on the link "
-"provided in this email."
-msgstr ""
-"Ju është dërguar email te adresa juaj që të ripohoni llogarinë tuaj. Përpara"
-" se të hyni, duhet ta aktivizoni llogarinë tuaj, duke klikuar mbi lidhjen e "
-"dhënë në këtë email."
+msgid "An email has been sent to your address to confirm your account. Before you can log in, you have to activate your account by clicking on the link provided in this email."
+msgstr "Ju është dërguar email te adresa juaj që të ripohoni llogarinë tuaj. Përpara se të hyni, duhet ta aktivizoni llogarinë tuaj, duke klikuar mbi lidhjen e dhënë në këtë email."
 
 #: src/olympia/users/views.py:136 src/olympia/users/views.py:619
 msgid "Confirmation Email Sent"
@@ -15411,14 +12163,11 @@ msgstr "Ripohimi Me Email u Dërgua"
 
 #: src/olympia/users/views.py:197
 msgid ""
-"An email has been sent to {0} to confirm your new email address. For the "
-"change to take effect, you need to click on the link provided in this email."
-" Until then, you can keep logging in with your current email address."
+"An email has been sent to {0} to confirm your new email address. For the change to take effect, you need to click on the link provided in this email. Until then, you can keep logging in with your "
+"current email address."
 msgstr ""
-"Është dërguar një email te {0} që të ripohoni adresën tuaj të re email. Që "
-"ndryshimi të hyjë në fuqi, lypset të klikoni mbi lidhjen e dhënë te ky "
-"email. Sa pa bërë këtë, mund të vazhdoni të hyni me adresën tuaj të tanishme"
-" email."
+"Është dërguar një email te {0} që të ripohoni adresën tuaj të re email. Që ndryshimi të hyjë në fuqi, lypset të klikoni mbi lidhjen e dhënë te ky email. Sa pa bërë këtë, mund të vazhdoni të hyni me "
+"adresën tuaj të tanishme email."
 
 #: src/olympia/users/views.py:210
 #, python-format
@@ -15430,16 +12179,12 @@ msgid "Errors Found"
 msgstr "U gjetën Gabime"
 
 #: src/olympia/users/views.py:225
-msgid ""
-"There were errors in the changes you made. Please correct them and resubmit."
-msgstr ""
-"Pati gabime në ndryshimet që bëtë. Ndreqini, ju lutemi, dhe riparashtrojini."
+msgid "There were errors in the changes you made. Please correct them and resubmit."
+msgstr "Pati gabime në ndryshimet që bëtë. Ndreqini, ju lutemi, dhe riparashtrojini."
 
 #: src/olympia/users/views.py:273
-msgid ""
-"We're sorry, but you are not eligible to request a t-shirt at this time."
-msgstr ""
-"Na ndjeni, por këtë radhë s’i plotësoni kushtet për të kërkuar një bluzë."
+msgid "We're sorry, but you are not eligible to request a t-shirt at this time."
+msgstr "Na ndjeni, por këtë radhë s’i plotësoni kushtet për të kërkuar një bluzë."
 
 #: src/olympia/users/views.py:329
 msgid "Your email address was changed successfully"
@@ -15454,25 +12199,17 @@ msgid "Wrong email address or password!"
 msgstr "Adresë email ose fjalëkalim i gabuar!"
 
 #: src/olympia/users/views.py:434
-msgid ""
-"A link to activate your user account was sent by email to your address {0}. "
-"You have to click it before you can log in."
-msgstr ""
-"Te adresa juaj {0} është dërguar me email një lidhje për aktivizimin e "
-"llogarisë suaj të përdoruesit. Duhet ta klikoni, përpara se të mund të hyni."
+msgid "A link to activate your user account was sent by email to your address {0}. You have to click it before you can log in."
+msgstr "Te adresa juaj {0} është dërguar me email një lidhje për aktivizimin e llogarisë suaj të përdoruesit. Duhet ta klikoni, përpara se të mund të hyni."
 
 #: src/olympia/users/views.py:439
 #, python-format
 msgid ""
-"If you did not receive the confirmation email, make sure your email service "
-"did not mark it as \"junk mail\" or \"spam\". If you need to, you can have "
-"us <a href=\"%s\">resend the confirmation message</a> to your email address "
-"mentioned above."
+"If you did not receive the confirmation email, make sure your email service did not mark it as \"junk mail\" or \"spam\". If you need to, you can have us <a href=\"%s\">resend the confirmation "
+"message</a> to your email address mentioned above."
 msgstr ""
-"Nëse s’e morët email-in e ripohimit, kontrolloni se mos shërbimi juaj email "
-"service e ka shënur si \"postë e pavlerë\" ose \"hedhurinë\". Nëse ju duhet,"
-" mund të na kërkoni <a href=\"%s\">të ridërgojmë mesazhin e ripohimit</a> te"
-" adresa juaj email e përmendur më sipër."
+"Nëse s’e morët email-in e ripohimit, kontrolloni se mos shërbimi juaj email service e ka shënur si \"postë e pavlerë\" ose \"hedhurinë\". Nëse ju duhet, mund të na kërkoni <a href=\"%s\">të "
+"ridërgojmë mesazhin e ripohimit</a> te adresa juaj email e përmendur më sipër."
 
 #: src/olympia/users/views.py:444
 msgid "Activation Email Sent"
@@ -15493,14 +12230,8 @@ msgstr "Përgëzime! Llogaria juaj e përdoruesit u krijua me sukses."
 
 # %1 is the user's email address
 #: src/olympia/users/views.py:615
-msgid ""
-"An email has been sent to your address {0} to confirm your account. Before "
-"you can log in, you have to activate your account by clicking on the link "
-"provided in this email."
-msgstr ""
-"Ju është dërguar email te adresa juaj {0} që të ripohoni llogarinë tuaj. "
-"Përpara se të hyni, duhet ta aktivizoni llogarinë tuaj, duke klikuar mbi "
-"lidhjen e dhënë në këtë email."
+msgid "An email has been sent to your address {0} to confirm your account. Before you can log in, you have to activate your account by clicking on the link provided in this email."
+msgstr "Ju është dërguar email te adresa juaj {0} që të ripohoni llogarinë tuaj. Përpara se të hyni, duhet ta aktivizoni llogarinë tuaj, duke klikuar mbi lidhjen e dhënë në këtë email."
 
 #: src/olympia/users/views.py:639
 msgid "There are errors in this form"
@@ -15518,32 +12249,22 @@ msgstr "Përdoruesi u raportua."
 msgid "new"
 msgstr "e re"
 
-#: src/olympia/users/templates/users/delete.html:4
-#: src/olympia/users/templates/users/delete.html:10
+#: src/olympia/users/templates/users/delete.html:4 src/olympia/users/templates/users/delete.html:10
 msgid "Delete User Account"
 msgstr "Fshi Llogari Përdoruesi"
 
 #: src/olympia/users/templates/users/delete.html:14
 #, python-format
 msgid ""
-"You cannot delete your account if you are listed as an <a href=\"%(link)s\">"
-" author of any add-ons</a>. To delete your account, please have another "
-"person in your development group delete you from the list of authors for "
-"your add-ons. Afterwards you will be able to delete your account here."
+"You cannot delete your account if you are listed as an <a href=\"%(link)s\"> author of any add-ons</a>. To delete your account, please have another person in your development group delete you from "
+"the list of authors for your add-ons. Afterwards you will be able to delete your account here."
 msgstr ""
-"S’mund ta fshini llogarinë tuaj nëse jeni radhitur si <a href=\"%(link)s\"> "
-"autor i ndonjë shtese</a>. Për fshirjen e llogarisë suaj, kërkojini një "
-"personi tjetër nga grupi juaj i zhvillimit t’ju fshijë nga lista e autorëve "
-"për shtesat tuaja. Pas kësaj, do të jeni në gjendje të fshini llogarinë tuaj"
-" këtu."
+"S’mund ta fshini llogarinë tuaj nëse jeni radhitur si <a href=\"%(link)s\"> autor i ndonjë shtese</a>. Për fshirjen e llogarisë suaj, kërkojini një personi tjetër nga grupi juaj i zhvillimit t’ju "
+"fshijë nga lista e autorëve për shtesat tuaja. Pas kësaj, do të jeni në gjendje të fshini llogarinë tuaj këtu."
 
 #: src/olympia/users/templates/users/delete.html:29
-msgid ""
-"By clicking \"delete\" your account is going to be <strong>permanently "
-"removed</strong>. That means:"
-msgstr ""
-"Duke klikuar mbi \"fshije\" llogaria juaj <strong>do të fshihet "
-"përgjithmonë</strong>. Kjo do të thotë:"
+msgid "By clicking \"delete\" your account is going to be <strong>permanently removed</strong>. That means:"
+msgstr "Duke klikuar mbi \"fshije\" llogaria juaj <strong>do të fshihet përgjithmonë</strong>. Kjo do të thotë:"
 
 #: src/olympia/users/templates/users/delete.html:35
 #, python-format
@@ -15551,12 +12272,8 @@ msgid "You will not be able to log into %(site)s anymore."
 msgstr "S’do të jeni më në gjendje të hyni te %(site)s."
 
 #: src/olympia/users/templates/users/delete.html:40
-msgid ""
-"Your reviews and ratings will not be deleted, but they will no longer be "
-"associated with you."
-msgstr ""
-"Shqyrtimet dhe vlerësimet tuaja s’do të fshihen, por s’do t’i përshoqërohen "
-"më llogarisë suaj."
+msgid "Your reviews and ratings will not be deleted, but they will no longer be associated with you."
+msgstr "Shqyrtimet dhe vlerësimet tuaja s’do të fshihen, por s’do t’i përshoqërohen më llogarisë suaj."
 
 #: src/olympia/users/templates/users/delete.html:46
 msgid "Confirm account deletion"
@@ -15570,8 +12287,7 @@ msgstr "E kam të qartë që ky hap s’mund të zhbëhet."
 msgid "Delete my user account now"
 msgstr "Fshije tani llogarinë time si përdorues"
 
-#: src/olympia/users/templates/users/delete_photo.html:3
-#: src/olympia/users/templates/users/delete_photo.html:9
+#: src/olympia/users/templates/users/delete_photo.html:3 src/olympia/users/templates/users/delete_photo.html:9
 msgid "Delete User Photo"
 msgstr "Fshi Foto Përdoruesi"
 
@@ -15584,27 +12300,18 @@ msgid "Please set your display name"
 msgstr "Ju lutemi, caktoni emrin tuaj të ekranit"
 
 #: src/olympia/users/templates/users/edit.html:21
-msgid ""
-"Please set your display name or username to complete the registration "
-"process."
-msgstr ""
-"Ju lutemi, caktoni emrin tuaj në ekran ose atë të përdoruesit që të "
-"plotësohet procesi i regjistrimit."
+msgid "Please set your display name or username to complete the registration process."
+msgstr "Ju lutemi, caktoni emrin tuaj në ekran ose atë të përdoruesit që të plotësohet procesi i regjistrimit."
 
 #: src/olympia/users/templates/users/edit.html:33
 msgid "Manage basic account information, such as username and email address."
-msgstr ""
-"Administroni të dhëna bazë llogarie, të tilla si emër përdoruesi dhe adresë "
-"email."
+msgstr "Administroni të dhëna bazë llogarie, të tilla si emër përdoruesi dhe adresë email."
 
-#: src/olympia/users/templates/users/edit.html:39
-#: src/olympia/users/templates/users/register.html:47
+#: src/olympia/users/templates/users/edit.html:39 src/olympia/users/templates/users/register.html:47
 msgid "Username"
 msgstr "Emër përdoruesi"
 
-#: src/olympia/users/templates/users/edit.html:45
-#: src/olympia/users/templates/users/pwreset_request.html:21
-#: src/olympia/users/templates/users/register.html:62
+#: src/olympia/users/templates/users/edit.html:45 src/olympia/users/templates/users/pwreset_request.html:21 src/olympia/users/templates/users/register.html:62
 msgid "Email Address"
 msgstr "Adresë Email"
 
@@ -15616,21 +12323,15 @@ msgstr "Administroni Llogari Firefox-i..."
 msgid "Change Password"
 msgstr "Ndryshoni Fjalëkalimin"
 
-#: src/olympia/users/templates/users/edit.html:68
-#: src/olympia/users/templates/users/login_form.html:22
-#: src/olympia/users/templates/users/register.html:67
+#: src/olympia/users/templates/users/edit.html:68 src/olympia/users/templates/users/login_form.html:22 src/olympia/users/templates/users/register.html:67
 #: src/olympia/users/templates/users/mobile/login.html:37
 msgid "Password"
 msgstr "Fjalëkalim"
 
 #: src/olympia/users/templates/users/edit.html:70
 #, python-format
-msgid ""
-"Change your password.  If you forgot your password, you can <a "
-"href=\"%(reset_url)s\">use the reset form</a>."
-msgstr ""
-"Ndryshoni fjalëkalimin tuaj. Nëse e harruat fjalëkalimin tuaj, mund të <a "
-"href=\"%(reset_url)s\">përdorni formularin e ricaktimit</a>."
+msgid "Change your password. If you forgot your password, you can <a href=\"%(reset_url)s\">use the reset form</a>."
+msgstr "Ndryshoni fjalëkalimin tuaj. Nëse e harruat fjalëkalimin tuaj, mund të <a href=\"%(reset_url)s\">përdorni formularin e ricaktimit</a>."
 
 #: src/olympia/users/templates/users/edit.html:76
 msgid "Old Password"
@@ -15649,12 +12350,8 @@ msgid "Profile"
 msgstr "Profil"
 
 #: src/olympia/users/templates/users/edit.html:100
-msgid ""
-"Give us a bit more information about yourself.  All these fields are "
-"optional, but they'll help other users get to know you better."
-msgstr ""
-"Na jepni pakëz më tepër informacion rreth vetes. Krejt këto fusha janë "
-"opsionale, por ato i ndihmojnë përdoruesit e tjerë t’ju njohin më mirë."
+msgid "Give us a bit more information about yourself. All these fields are optional, but they'll help other users get to know you better."
+msgstr "Na jepni pakëz më tepër informacion rreth vetes. Krejt këto fusha janë opsionale, por ato i ndihmojnë përdoruesit e tjerë t’ju njohin më mirë."
 
 #: src/olympia/users/templates/users/edit.html:124
 msgid "This URL will only be visible if you are a developer."
@@ -15669,20 +12366,12 @@ msgid "Delete current photo"
 msgstr "Fshije foton e tanishme"
 
 #: src/olympia/users/templates/users/edit.html:144
-msgid ""
-"This is the default locale used to display information about you (like your "
-"description)."
-msgstr ""
-"Kjo është vendorja parazgjedhje e përdorur për të shfaqur të dhëna rreth "
-"jush (fjala vjen, përshkrimin tuaj)."
+msgid "This is the default locale used to display information about you (like your description)."
+msgstr "Kjo është vendorja parazgjedhje e përdorur për të shfaqur të dhëna rreth jush (fjala vjen, përshkrimin tuaj)."
 
 #: src/olympia/users/templates/users/edit.html:152
-msgid ""
-"Introduce yourself to the community, if you like! This text will appear "
-"publicly on your user info page."
-msgstr ""
-"Paraqiteni veten te bashkësia, po deshët! Ky tekst do të duket publikisht te"
-" faqja juaj e të dhënave të përdoruesit."
+msgid "Introduce yourself to the community, if you like! This text will appear publicly on your user info page."
+msgstr "Paraqiteni veten te bashkësia, po deshët! Ky tekst do të duket publikisht te faqja juaj e të dhënave të përdoruesit."
 
 #: src/olympia/users/templates/users/edit.html:161
 msgid "Allowed HTML: {0}. Links are forbidden."
@@ -15709,21 +12398,12 @@ msgid "Notifications"
 msgstr "Njoftime"
 
 #: src/olympia/users/templates/users/edit.html:195
-msgid ""
-"From time to time, Mozilla may send you email about upcoming releases and "
-"add-on events. Please select the topics you are interested in."
-msgstr ""
-"Mozilla mund t’ju dërgojë, herë pas here, email rreth versionesh të ardhshëm"
-" dhe veprimtari që lidhen me shtesat. Ju lutemi, përzgjidhni më poshtë temat"
-" që ju interesojnë."
+msgid "From time to time, Mozilla may send you email about upcoming releases and add-on events. Please select the topics you are interested in."
+msgstr "Mozilla mund t’ju dërgojë, herë pas here, email rreth versionesh të ardhshëm dhe veprimtari që lidhen me shtesat. Ju lutemi, përzgjidhni më poshtë temat që ju interesojnë."
 
 #: src/olympia/users/templates/users/edit.html:205
-msgid ""
-"Mozilla reserves the right to contact you individually about specific "
-"concerns with your hosted add-ons."
-msgstr ""
-"Mozilla ruan të drejtën të lidhet me ju veçmas, lidhur me çështje të "
-"caktuara te shtesat që keni strehuar këtu."
+msgid "Mozilla reserves the right to contact you individually about specific concerns with your hosted add-ons."
+msgstr "Mozilla ruan të drejtën të lidhet me ju veçmas, lidhur me çështje të caktuara te shtesat që keni strehuar këtu."
 
 #: src/olympia/users/templates/users/edit.html:215
 msgid "Admin"
@@ -15745,63 +12425,49 @@ msgstr "asnjë"
 msgid "all"
 msgstr "krejt"
 
-#: src/olympia/users/templates/users/fxa_migration.html:3
-#: src/olympia/users/templates/users/fxa_migration.html:11
-#: src/olympia/users/templates/users/mobile/fxa_migration.html:3
+#: src/olympia/users/templates/users/fxa_migration.html:3 src/olympia/users/templates/users/fxa_migration.html:11 src/olympia/users/templates/users/mobile/fxa_migration.html:3
 #: src/olympia/users/templates/users/mobile/fxa_migration.html:8
 msgid "Migrate to Firefox Accounts"
 msgstr "Migroni te Llogari Firefox-i"
 
 #: src/olympia/users/templates/users/fxa_migration_prompt_content.html:3
-msgid ""
-"Mozilla Add-ons has transitioned to Firefox Accounts for login. Continue to "
-"complete the simple upgrade process."
-msgstr ""
-"Shtesat Mozilla kanë adoptuar Llogaritë Firefox për hyrjet. Vazhdoni që të "
-"plotësohet procesi i thjeshtë i përmirësimit."
+msgid "Mozilla Add-ons has transitioned to Firefox Accounts for login. Continue to complete the simple upgrade process."
+msgstr "Shtesat Mozilla kanë adoptuar Llogaritë Firefox për hyrjet. Vazhdoni që të plotësohet procesi i thjeshtë i përmirësimit."
 
 #: src/olympia/users/templates/users/fxa_migration_prompt_content.html:14
 msgid "Skip"
 msgstr "Anashkaloje"
 
-#: src/olympia/users/templates/users/login.html:3
-#: src/olympia/users/templates/users/mobile/login.html:3
+#: src/olympia/users/templates/users/login.html:3 src/olympia/users/templates/users/mobile/login.html:3
 msgid "User Login"
 msgstr "Hyrje Përdoruesi"
 
-#: src/olympia/users/templates/users/login.html:13
-#: src/olympia/users/templates/users/mobile/login.html:21
+#: src/olympia/users/templates/users/login.html:13 src/olympia/users/templates/users/mobile/login.html:21
 msgid "Enter your email"
 msgstr "Jepni email-in tuaj"
 
-#: src/olympia/users/templates/users/login.html:15
-#: src/olympia/users/templates/users/mobile/login.html:23
+#: src/olympia/users/templates/users/login.html:15 src/olympia/users/templates/users/mobile/login.html:23
 msgid "Log In"
 msgstr "Hyni"
 
-#: src/olympia/users/templates/users/login_form.html:17
-#: src/olympia/users/templates/users/mobile/login.html:32
+#: src/olympia/users/templates/users/login_form.html:17 src/olympia/users/templates/users/mobile/login.html:32
 msgid "Email address"
 msgstr "Email"
 
-#: src/olympia/users/templates/users/login_form.html:30
-#: src/olympia/users/templates/users/mobile/login.html:44
+#: src/olympia/users/templates/users/login_form.html:30 src/olympia/users/templates/users/mobile/login.html:44
 msgid "Remember me on this device"
 msgstr "Mbamë mend në këtë pajisje"
 
 # This is a header for additional help options
-#: src/olympia/users/templates/users/login_help.html:3
-#: src/olympia/users/templates/users/mobile/login.html:63
+#: src/olympia/users/templates/users/login_help.html:3 src/olympia/users/templates/users/mobile/login.html:63
 msgid "Login Problems?"
 msgstr "Probleme Hyrjeje?"
 
-#: src/olympia/users/templates/users/login_help.html:5
-#: src/olympia/users/templates/users/mobile/login.html:65
+#: src/olympia/users/templates/users/login_help.html:5 src/olympia/users/templates/users/mobile/login.html:65
 msgid "I don't have an account."
 msgstr "S’kam llogari."
 
-#: src/olympia/users/templates/users/login_help.html:6
-#: src/olympia/users/templates/users/mobile/login.html:66
+#: src/olympia/users/templates/users/login_help.html:6 src/olympia/users/templates/users/mobile/login.html:66
 msgid "I forgot my password."
 msgstr "Harrova fjalëkalimin tim."
 
@@ -15810,15 +12476,9 @@ msgstr "Harrova fjalëkalimin tim."
 msgid "You are now logged in as <strong>%(user_email)s</strong>!"
 msgstr "Tani jeni i futur si <strong>%(user_email)s</strong>!"
 
-#: src/olympia/users/templates/users/newpw_sent.html:3
-#: src/olympia/users/templates/users/newpw_sent.html:8
-#: src/olympia/users/templates/users/pwreset_complete.html:3
-#: src/olympia/users/templates/users/pwreset_confirm.html:4
-#: src/olympia/users/templates/users/pwreset_confirm.html:18
-#: src/olympia/users/templates/users/pwreset_request.html:4
-#: src/olympia/users/templates/users/pwreset_request.html:10
-#: src/olympia/users/templates/users/pwreset_sent.html:3
-#: src/olympia/users/templates/users/pwreset_sent.html:8
+#: src/olympia/users/templates/users/newpw_sent.html:3 src/olympia/users/templates/users/newpw_sent.html:8 src/olympia/users/templates/users/pwreset_complete.html:3
+#: src/olympia/users/templates/users/pwreset_confirm.html:4 src/olympia/users/templates/users/pwreset_confirm.html:18 src/olympia/users/templates/users/pwreset_request.html:4
+#: src/olympia/users/templates/users/pwreset_request.html:10 src/olympia/users/templates/users/pwreset_sent.html:3 src/olympia/users/templates/users/pwreset_sent.html:8
 msgid "Password Reset"
 msgstr "Ricaktim Fjalëkalimi"
 
@@ -15834,8 +12494,7 @@ msgstr "Përpunoni profil"
 msgid "Manage user"
 msgstr "Administroni përdoruesin"
 
-#: src/olympia/users/templates/users/profile.html:18
-#: src/olympia/users/templates/users/report_abuse_full.html:9
+#: src/olympia/users/templates/users/profile.html:18 src/olympia/users/templates/users/report_abuse_full.html:9
 msgid "Report user"
 msgstr "Raporto përdorues"
 
@@ -15898,39 +12557,25 @@ msgstr "Sukses!"
 msgid "Password successfully reset."
 msgstr "Fjalëkalim i ricaktuar me sukses."
 
-#: src/olympia/users/templates/users/pwreset_confirm.html:13
-#: src/olympia/users/templates/users/pwreset_confirm.html:46
+#: src/olympia/users/templates/users/pwreset_confirm.html:13 src/olympia/users/templates/users/pwreset_confirm.html:46
 msgid "Password reset unsuccessful"
 msgstr "Fjalëkalimi s’u ricaktua me sukses"
 
 #: src/olympia/users/templates/users/pwreset_confirm.html:14
-msgid ""
-"You have migrated to Firefox Accounts. You can no longer change your "
-"password here."
-msgstr ""
-"Keni migruar te Llogaritë Firefox. S’mund ta ndryshoni më fjalëkalimin që "
-"këtu."
+msgid "You have migrated to Firefox Accounts. You can no longer change your password here."
+msgstr "Keni migruar te Llogaritë Firefox. S’mund ta ndryshoni më fjalëkalimin që këtu."
 
-#: src/olympia/users/templates/users/pwreset_confirm.html:31
-#: src/olympia/users/templates/users/register.html:72
+#: src/olympia/users/templates/users/pwreset_confirm.html:31 src/olympia/users/templates/users/register.html:72
 msgid "Confirm password"
 msgstr "Ripohoni fjalëkalimin"
 
 #: src/olympia/users/templates/users/pwreset_confirm.html:47
-msgid ""
-"The password reset link was invalid, possibly because it has already been "
-"used.  Please request a new password reset."
-msgstr ""
-"Lidhja për ricaktimin e fjalëkalimit qe e pavlefshme, ndoshta ngaqë është "
-"përdorur tashmë një herë. Ju lutemi, kërkoni një ricaktim të ri fjalëkalimi."
+msgid "The password reset link was invalid, possibly because it has already been used. Please request a new password reset."
+msgstr "Lidhja për ricaktimin e fjalëkalimit qe e pavlefshme, ndoshta ngaqë është përdorur tashmë një herë. Ju lutemi, kërkoni një ricaktim të ri fjalëkalimi."
 
 #: src/olympia/users/templates/users/pwreset_request.html:15
-msgid ""
-"Forgotten your password? Enter your e-mail address below, and we'll e-mail "
-"instructions for setting a new one."
-msgstr ""
-"Harruat fjalëkalimin tuaj? Jepni më poshtë adresën tuaj e-mail, dhe do t’ju "
-"dërgojmë në të udhëzimet për të caktuar një të ri."
+msgid "Forgotten your password? Enter your e-mail address below, and we'll e-mail instructions for setting a new one."
+msgstr "Harruat fjalëkalimin tuaj? Jepni më poshtë adresën tuaj e-mail, dhe do t’ju dërgojmë në të udhëzimet për të caktuar një të ri."
 
 #: src/olympia/users/templates/users/pwreset_request.html:25
 msgid "Send password reset link"
@@ -15938,13 +12583,10 @@ msgstr "Dërgo lidhje ricaktimi fjalëkalimi"
 
 #: src/olympia/users/templates/users/pwreset_sent.html:10
 msgid ""
-"An email has been sent to the requested account with further information. If"
-" you do not receive an email then please confirm you have entered the same "
-"email address used during account registration."
+"An email has been sent to the requested account with further information. If you do not receive an email then please confirm you have entered the same email address used during account registration."
 msgstr ""
-"Te llogaria e kërkuar është dërguar një email me të dhëna të mëtejshme. Nëse"
-" s’ju vjen një email, ju lutemi, ripohoni që keni dhënë të njëjtën adresë "
-"email me atë të përdorur gjatë regjistrimit të llogarisë."
+"Te llogaria e kërkuar është dërguar një email me të dhëna të mëtejshme. Nëse s’ju vjen një email, ju lutemi, ripohoni që keni dhënë të njëjtën adresë email me atë të përdorur gjatë regjistrimit të "
+"llogarisë."
 
 #: src/olympia/users/templates/users/register.html:4
 msgid "New User Registration"
@@ -15955,12 +12597,8 @@ msgid "Why register?"
 msgstr "Pse të regjistrohem?"
 
 #: src/olympia/users/templates/users/register.html:14
-msgid ""
-"Registration on AMO is <strong>not required</strong> if you simply want to "
-"download and install public add-ons."
-msgstr ""
-"Rgjistrimi në AMO <strong>s’është i domosdoshëm</strong>, nëse thjesht doni "
-"të shkarkoni dhe instaloni shtesa publike."
+msgid "Registration on AMO is <strong>not required</strong> if you simply want to download and install public add-ons."
+msgstr "Rgjistrimi në AMO <strong>s’është i domosdoshëm</strong>, nëse thjesht doni të shkarkoni dhe instaloni shtesa publike."
 
 #: src/olympia/users/templates/users/register.html:16
 msgid "You only need to register if:"
@@ -15971,53 +12609,29 @@ msgid "You want to submit reviews for add-ons"
 msgstr "Dëshironi të parashtroni shqyrtime për shtesa"
 
 #: src/olympia/users/templates/users/register.html:19
-msgid ""
-"You want to keep track of your favorite add-on collections or create one "
-"yourself"
-msgstr ""
-"Doni të ndiqni koleksionet tuaj të parapëlqyer të shtesave ose të krijoni "
-"vetë një të tillë"
+msgid "You want to keep track of your favorite add-on collections or create one yourself"
+msgstr "Doni të ndiqni koleksionet tuaj të parapëlqyer të shtesave ose të krijoni vetë një të tillë"
 
 #: src/olympia/users/templates/users/register.html:20
-msgid ""
-"You are an add-on developer and want to upload your add-on for hosting on "
-"AMO"
-msgstr ""
-"Jeni zhvillues shtesash dhe dëshironi të ngarkoni shtesën tuaj për strehim "
-"te AMO"
+msgid "You are an add-on developer and want to upload your add-on for hosting on AMO"
+msgstr "Jeni zhvillues shtesash dhe dëshironi të ngarkoni shtesën tuaj për strehim te AMO"
 
 #: src/olympia/users/templates/users/register.html:23
-msgid ""
-"Upon successful registration, you will be sent a confirmation email to the "
-"address you provided. Please follow the instructions there to confirm your "
-"account."
-msgstr ""
-"Pas regjistrimit me sukses, te adresa që dhatë do t’ju dërgohet një email "
-"ripohimi. Ju lutemi, ndiqni udhëzimet e atjeshme që të ripohoni krijimin e "
-"llogarisë suaj."
+msgid "Upon successful registration, you will be sent a confirmation email to the address you provided. Please follow the instructions there to confirm your account."
+msgstr "Pas regjistrimit me sukses, te adresa që dhatë do t’ju dërgohet një email ripohimi. Ju lutemi, ndiqni udhëzimet e atjeshme që të ripohoni krijimin e llogarisë suaj."
 
 #: src/olympia/users/templates/users/register.html:30
 #, python-format
-msgid ""
-"If you like, you can read our <a href=\"%(legal)s\" title=\"Legal "
-"Notices\">Legal Notices</a> and <a href=\"%(privacy)s\" title=\"Privacy "
-"Policy\">Privacy Policy</a>."
-msgstr ""
-"Nëse doni, mund të lexoni <a href=\"%(legal)s\" title=\"Legal "
-"Notices\">Shënime Ligjore</a> dhe <a href=\"%(privacy)s\" title=\"Privacy "
-"Policy\">Rregulla Privatësie</a> tona."
+msgid "If you like, you can read our <a href=\"%(legal)s\" title=\"Legal Notices\">Legal Notices</a> and <a href=\"%(privacy)s\" title=\"Privacy Policy\">Privacy Policy</a>."
+msgstr "Nëse doni, mund të lexoni <a href=\"%(legal)s\" title=\"Legal Notices\">Shënime Ligjore</a> dhe <a href=\"%(privacy)s\" title=\"Privacy Policy\">Rregulla Privatësie</a> tona."
 
 #: src/olympia/users/templates/users/register.html:52
 msgid "Display name"
 msgstr "Emër në ekran"
 
 #: src/olympia/users/templates/users/report_abuse.html:7
-msgid ""
-"Please describe why you are reporting this user, such as for spam or an "
-"inappropriate picture."
-msgstr ""
-"Ju lutemi, përshkruani pse po e raportoni këtë përdorues, fjala vjen për "
-"postë të pavlerë ose figura të papërshtatshme."
+msgid "Please describe why you are reporting this user, such as for spam or an inappropriate picture."
+msgstr "Ju lutemi, përshkruani pse po e raportoni këtë përdorues, fjala vjen për postë të pavlerë ose figura të papërshtatshme."
 
 #: src/olympia/users/templates/users/report_abuse_full.html:3
 msgid "Report user {0}"
@@ -16031,43 +12645,25 @@ msgstr "Numër Bluze"
 msgid "Special Edition Add-on Creator T-shirt"
 msgstr "Edicion Special Bluze Krijuesi Shtesash"
 
-#: src/olympia/users/templates/users/t-shirt.html:14
-#: src/olympia/users/templates/users/t-shirt.html:120
+#: src/olympia/users/templates/users/t-shirt.html:14 src/olympia/users/templates/users/t-shirt.html:120
 msgid "Note:"
 msgstr "Shënim:"
 
 #: src/olympia/users/templates/users/t-shirt.html:15
-msgid ""
-"You have already submitted a request for a t-shirt. You may re-submit this "
-"form to update your information, but you will only receive one shirt."
-msgstr ""
-"Keni parashtruar tashmë një kërkesë për një bluzë. Mund ta riparashtroni "
-"këtë formular për të përditësuar të dhënat mbi ju, por për të marrë do të "
-"merrni vetëm një bluzë."
+msgid "You have already submitted a request for a t-shirt. You may re-submit this form to update your information, but you will only receive one shirt."
+msgstr "Keni parashtruar tashmë një kërkesë për një bluzë. Mund ta riparashtroni këtë formular për të përditësuar të dhënat mbi ju, por për të marrë do të merrni vetëm një bluzë."
 
 #: src/olympia/users/templates/users/t-shirt.html:26
-msgid ""
-"Thank you for helping to make Firefox the most extensible browser available!"
-msgstr ""
-"Ju faleminderit për ndihmën për ta bërë Firefox-in shfletuesin më të "
-"zgjerueshëm se cilido tjetër!"
+msgid "Thank you for helping to make Firefox the most extensible browser available!"
+msgstr "Ju faleminderit për ndihmën për ta bërë Firefox-in shfletuesin më të zgjerueshëm se cilido tjetër!"
 
 #: src/olympia/users/templates/users/t-shirt.html:33
-msgid ""
-"As a thank you gift, we'd like to send you a special-edition, community-"
-"designed t-shirt. To receive your shirt, please fill out the form below."
-msgstr ""
-"Si një dhuratë falënderimi, do të donim t’ju dërgonin një bluzë, edicion "
-"special, të modeluar nga bashkësia. Që të merrni bluzën tuaj, ju lutemi, "
-"plotësoni formularin e mëposhtëm."
+msgid "As a thank you gift, we'd like to send you a special-edition, community-designed t-shirt. To receive your shirt, please fill out the form below."
+msgstr "Si një dhuratë falënderimi, do të donim t’ju dërgonin një bluzë, edicion special, të modeluar nga bashkësia. Që të merrni bluzën tuaj, ju lutemi, plotësoni formularin e mëposhtëm."
 
 #: src/olympia/users/templates/users/t-shirt.html:41
-msgid ""
-"Your contact information will only be used by Mozilla to ship this special "
-"edition t-shirt."
-msgstr ""
-"Të dhënat tuaja të kontaktit do të përdoren nga Mozilla vetëm për t’ju "
-"dërguar këtë bluzë edicioni special."
+msgid "Your contact information will only be used by Mozilla to ship this special edition t-shirt."
+msgstr "Të dhënat tuaja të kontaktit do të përdoren nga Mozilla vetëm për t’ju dërguar këtë bluzë edicioni special."
 
 #: src/olympia/users/templates/users/t-shirt.html:60
 msgid "Mailing Address"
@@ -16123,23 +12719,15 @@ msgstr "Kërkoni Bluzë"
 
 #: src/olympia/users/templates/users/t-shirt.html:137
 msgid ""
-"We're sorry, but in order to qualify for our special edition t-shirt, you "
-"must be an add-on developer with at least one listed add-on, one unlisted "
-"but signed add-on, or any number of background themes with a combined total "
-"of 10,000 average daily users."
+"We're sorry, but in order to qualify for our special edition t-shirt, you must be an add-on developer with at least one listed add-on, one unlisted but signed add-on, or any number of background "
+"themes with a combined total of 10,000 average daily users."
 msgstr ""
-"Na ndjeni, por që të mund të kërkoni bluzën tonë të edicionit special, duhet"
-" të jeni një zhvillues shtesash me të paktën një shtesë në një nga listat, "
-"një tjetër jo në lista, por të nënshkruar, ose çfarëdo numri temash sfond me"
-" një numër mesatar përdoruesish të përditshëm gjithsej 10 000."
+"Na ndjeni, por që të mund të kërkoni bluzën tonë të edicionit special, duhet të jeni një zhvillues shtesash me të paktën një shtesë në një nga listat, një tjetër jo në lista, por të nënshkruar, ose "
+"çfarëdo numri temash sfond me një numër mesatar përdoruesish të përditshëm gjithsej 10 000."
 
 #: src/olympia/users/templates/users/tougher_password.html:2
-msgid ""
-"For your account a password must contain at least 8 characters including "
-"letters and numbers."
-msgstr ""
-"Fjalëkalimi për llogarinë tuaj duhet të përmbajë të paktën 8 shenja, përfshi"
-" shkronja dhe numra."
+msgid "For your account a password must contain at least 8 characters including letters and numbers."
+msgstr "Fjalëkalimi për llogarinë tuaj duhet të përmbajë të paktën 8 shenja, përfshi shkronja dhe numra."
 
 #: src/olympia/users/templates/users/unsubscribe.html:2
 msgid "Unsubscribe"
@@ -16151,11 +12739,8 @@ msgstr "U shpajtuat me sukses!"
 
 #: src/olympia/users/templates/users/unsubscribe.html:10
 #, python-format
-msgid ""
-"The email address <strong>%(email)s</strong> will no longer get messages "
-"when:"
-msgstr ""
-"Te adresa email <strong>%(email)s</strong> s’do të merren më mesazhe kur:"
+msgid "The email address <strong>%(email)s</strong> will no longer get messages when:"
+msgstr "Te adresa email <strong>%(email)s</strong> s’do të merren më mesazhe kur:"
 
 #: src/olympia/users/templates/users/unsubscribe.html:20
 msgid "More Actions:"
@@ -16175,14 +12760,8 @@ msgstr "S’ju shpajtuam dot"
 
 #: src/olympia/users/templates/users/unsubscribe.html:30
 #, python-format
-msgid ""
-"Unfortunately, we weren't able to unsubscribe you.  The link you clicked is "
-"invalid. However, you can unsubscribe still unsubscribe on your <a "
-"href=\"%(edit_url)s\">edit profile page</a>."
-msgstr ""
-"Mjerisht, nuk qemë në gjendje t’ju shpajtonim. Lidhja që klikuat është e "
-"pavlefshme. Sido qoftë, mund të shpajtoheni që nga pjesa <a "
-"href=\"%(edit_url)s\">përpunoni profilin tuaj</a>."
+msgid "Unfortunately, we weren't able to unsubscribe you. The link you clicked is invalid. However, you can unsubscribe still unsubscribe on your <a href=\"%(edit_url)s\">edit profile page</a>."
+msgstr "Mjerisht, nuk qemë në gjendje t’ju shpajtonim. Lidhja që klikuat është e pavlefshme. Sido qoftë, mund të shpajtoheni që nga pjesa <a href=\"%(edit_url)s\">përpunoni profilin tuaj</a>."
 
 #: src/olympia/users/templates/users/vcard.html:2
 msgid "Developer Information"
@@ -16235,15 +12814,15 @@ msgstr "Historik Versionesh për %s"
 msgid "Version History with Changelogs"
 msgstr "Historik Versionesh me Regjistrime Ndryshimesh"
 
-#: src/olympia/versions/models.py:314
+#: src/olympia/versions/models.py:313
 msgid "Add-on uses binary components."
 msgstr "Shtesa përdor përbërës dyorë."
 
-#: src/olympia/versions/models.py:317
+#: src/olympia/versions/models.py:316
 msgid "Add-on has opted into strict compatibility checking."
 msgstr "Shtesa ka zgjedhur të bëjë kontroll strikt të përputhshmërisë."
 
-#: src/olympia/versions/models.py:715
+#: src/olympia/versions/models.py:711
 msgid "{app} {min} and later"
 msgstr "{app} {min} dhe më të vonshëm"
 
@@ -16259,9 +12838,7 @@ msgstr "Hedhur në qarkullim më {0}"
 #: src/olympia/versions/templates/versions/version.html:39
 #, python-format
 msgid "Source code released under <a target=\"_blank\" href=\"%(url)s\">%(name)s</a>"
-msgstr ""
-"Kodi burim qarkullon sipas një lejeje <a target=\"_blank\" "
-"href=\"%(url)s\">%(name)s</a>"
+msgstr "Kodi burim qarkullon sipas një lejeje <a target=\"_blank\" href=\"%(url)s\">%(name)s</a>"
 
 #: src/olympia/versions/templates/versions/version.html:44
 #, python-format
@@ -16284,21 +12861,14 @@ msgid_plural "<b>{0}</b> versions"
 msgstr[0] "<b>{0}</b> version"
 msgstr[1] "<b>{0}</b> versione"
 
-#: src/olympia/versions/templates/versions/version_list.html:35
-#: src/olympia/versions/templates/versions/mobile/version_list.html:14
+#: src/olympia/versions/templates/versions/version_list.html:35 src/olympia/versions/templates/versions/mobile/version_list.html:14
 msgid "Be careful with old versions!"
 msgstr "Bëni kujdes me versione të vjetër!"
 
-#: src/olympia/versions/templates/versions/version_list.html:36
-#: src/olympia/versions/templates/versions/mobile/version_list.html:15
+#: src/olympia/versions/templates/versions/version_list.html:36 src/olympia/versions/templates/versions/mobile/version_list.html:15
 #, python-format
-msgid ""
-"These versions are displayed for reference and testing purposes. You should "
-"always use the <a href=\"%(url)s\">latest version</a> of an add-on."
-msgstr ""
-"Këto versione paraqiten këtu për qëllime reference dhe testimi. Do të duhej "
-"gjithnjë të përdornit <a href=\"%(url)s\">versionin e fundit</a> të një "
-"shtese."
+msgid "These versions are displayed for reference and testing purposes. You should always use the <a href=\"%(url)s\">latest version</a> of an add-on."
+msgstr "Këto versione paraqiten këtu për qëllime reference dhe testimi. Do të duhej gjithnjë të përdornit <a href=\"%(url)s\">versionin e fundit</a> të një shtese."
 
 #: src/olympia/versions/templates/versions/mobile/version.html:4
 msgid "Beta Version {0}"
@@ -16328,3 +12898,7 @@ msgstr "Dërgo email kur të mbarohet"
 #: src/olympia/zadmin/forms.py:105
 msgid "Log emails instead of sending"
 msgstr "Regjistroji email-et, në vend se t’i dërgosh"
+
+#: src/olympia/zadmin/forms.py:215
+msgid "Deleted versions can`t be changed."
+msgstr ""

--- a/locale/sq/LC_MESSAGES/djangojs.po
+++ b/locale/sq/LC_MESSAGES/djangojs.po
@@ -6,134 +6,392 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2016-02-24 21:23+0000\n"
+"POT-Creation-Date: 2016-04-18 15:47+0000\n"
 "PO-Revision-Date: 2016-03-09 21:15+0000\n"
 "Last-Translator: Besnik Bleta <besnik@programeshqip.org>\n"
 "Language-Team: Albanian <besnik@programeshqip.org>\n"
+"Language: sq\n"
 "MIME-Version: 1.0\n"
-"Content-Type: text/plain; charset=utf-8\n"
+"Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Generated-By: Babel 2.2.0\n"
 
-#: static/js/common/ratingwidget.js:31
+#: static/js/common-all.js:1426 static/js/impala-all.js:1511 static/js/zamboni/discovery-all.js:12598 static/js/zamboni/init.js:28 static/js/zamboni/mobile-all.js:14945
+msgid "This feature is temporarily disabled while we perform website maintenance. Please check back a little later."
+msgstr "Kjo veçori është çaktivizuar përkohësisht, teksa bëjmë mirëmbajtjen e \"site\"-it web. Ju lutemi, riprovoni pas pak."
+
+#. L10n: {0} is an app name like Firefox.
+#: static/js/common-all.js:1837 static/js/impala-all.js:1922 static/js/zamboni/buttons.js:73 static/js/zamboni/discovery-all.js:13108
+msgid "Accept and Install"
+msgstr "Pranoje dhe Instaloje"
+
+#: static/js/common-all.js:1837 static/js/impala-all.js:1922 static/js/zamboni/buttons.js:73 static/js/zamboni/discovery-all.js:13108
+msgid "Add to {0}"
+msgstr "Shtoje te {0}"
+
+#: static/js/common-all.js:1842 static/js/impala-all.js:1927 static/js/zamboni/buttons.js:78 static/js/zamboni/discovery-all.js:13113
+msgid "Download Now"
+msgstr "Shkarkojeni Tani"
+
+#: static/js/common-all.js:1883 static/js/impala-all.js:1968 static/js/zamboni/buttons.js:119 static/js/zamboni/discovery-all.js:13154
+msgid "Add-on has not been updated to support default-to-compatible."
+msgstr "Shtesa nuk është përditësuar për të mbuluar parazgjedhje-në-e-përputhshme."
+
+#: static/js/common-all.js:1888 static/js/impala-all.js:1973 static/js/zamboni/buttons.js:124 static/js/zamboni/discovery-all.js:13159
+msgid "You need to be using Firefox 10.0 or higher."
+msgstr "Lypset të përdorni Firefox 10.0 ose më të ri."
+
+#: static/js/common-all.js:1900 static/js/impala-all.js:1985 static/js/zamboni/buttons.js:136 static/js/zamboni/discovery-all.js:13171
+msgid "Mozilla has marked this version as incompatible with your Firefox version."
+msgstr "Mozilla i ka vënë shenjë këtij versioni si i papërputhshëm me versionin tuaj të Firefox-it."
+
+#. L10n: {0} is an platform like Windows or Linux.
+#: static/js/common-all.js:1981 static/js/impala-all.js:2066 static/js/zamboni/buttons.js:217 static/js/zamboni/discovery-all.js:13252
+msgid "Install for {0} anyway"
+msgstr "Instaloje për {0} sido qoftë"
+
+#: static/js/common-all.js:1981 static/js/impala-all.js:2066 static/js/zamboni/buttons.js:217 static/js/zamboni/discovery-all.js:13252
+msgid "Download for {0} anyway"
+msgstr "Shkarkoje për {0} sido qoftë"
+
+#: static/js/common-all.js:2038 static/js/impala-all.js:2123 static/js/zamboni/buttons.js:274 static/js/zamboni/discovery-all.js:13309
+msgid "Not available for your platform"
+msgstr "Jo i passhëm për platformën tuaj"
+
+#. L10n: {0} is an app name, {1} is the app version.
+#: static/js/common-all.js:2049 static/js/common-all.js:2086 static/js/impala-all.js:2134 static/js/impala-all.js:2171 static/js/zamboni/buttons.js:286 static/js/zamboni/buttons.js:324
+#: static/js/zamboni/discovery-all.js:13320 static/js/zamboni/discovery-all.js:13357
+msgid "Not available for {0} {1}"
+msgstr "Jo i passhëm për {0} {1}"
+
+#: static/js/common-all.js:2112 static/js/impala-all.js:2197 static/js/zamboni/buttons.js:351 static/js/zamboni/discovery-all.js:13383
+msgid "Works with {app} {min} - {max}"
+msgstr "Funksionon me {app} {min} - {max}"
+
+#: static/js/common-all.js:2114 static/js/impala-all.js:2199 static/js/zamboni/buttons.js:353 static/js/zamboni/discovery-all.js:13385
+msgid "View other versions"
+msgstr "Shihni versione të tjera"
+
+#: static/js/common-all.js:2162 static/js/impala-all.js:2247 static/js/zamboni/buttons.js:401 static/js/zamboni/discovery-all.js:13433
+msgid "Only with Firefox — Get Firefox Now!"
+msgstr "Vetëm me Firefox  — Merreni Firefox-in Tani!"
+
+#: static/js/common-all.js:2278 static/js/impala-all.js:2363 static/js/zamboni/buttons.js:517 static/js/zamboni/discovery-all.js:13549 static/js/zamboni/mobile-all.js:15177
+#: static/js/zamboni/mobile/buttons.js:43
+msgid "Sorry, you need a Mozilla-based browser (such as Firefox) to install a search plugin."
+msgstr "Na ndjeni, për të instaluar një shtojcë kërkimi lypset të kini një shfletues me bazë Mozilla (si Firefox-i)."
+
+#: static/js/common-all.js:9088 static/js/impala-all.js:9649 static/js/zamboni/global.js:410
+msgid "Loading..."
+msgstr "Po ngarkohet..."
+
+#. L10n: {0} is the number of characters left.
+#: static/js/common-all.js:9152 static/js/impala-all.js:9713 static/js/zamboni/global.js:474
+msgid "<b>{0}</b> character left."
+msgid_plural "<b>{0}</b> characters left."
+msgstr[0] "Edhe <b>{0}</b> shenjë."
+msgstr[1] "Edhe <b>{0}</b> shenja."
+
+#: static/js/common-all.js:9589 static/js/common-min.js:6 static/js/impala-all.js:10052 static/js/impala-min.js:6 static/js/common/ratingwidget.js:31 static/js/zamboni/mobile-all.js:16123
+#: static/js/zamboni/mobile-min.js:6
 msgid "{0} star"
 msgid_plural "{0} stars"
 msgstr[0] "{0} yll"
 msgstr[1] "{0} yje"
 
-#: static/js/common/upload-addon.js:41 static/js/common/upload-image.js:128
+#: static/js/common-all.js:9676 static/js/common-min.js:6 static/js/impala-all.js:10139 static/js/impala-min.js:6 static/js/zamboni/l10n.js:45
+msgid "Remove this localization"
+msgstr "Hiqe këtë përkthim"
+
+#: static/js/common-all.js:10193 static/js/common-min.js:6 static/js/impala-all.js:10674 static/js/impala-min.js:6 static/js/zamboni/discovery-all.js:13678
+msgid "close"
+msgstr ""
+
+#: static/js/common-all.js:10860 static/js/common-min.js:6 static/js/impala-all.js:11481 static/js/impala-min.js:6 static/js/impala/reviews.js:23 static/js/zamboni/reviews.js:18
+msgid "Flagged for review"
+msgstr "Me shenjë për shqyrtim"
+
+#: static/js/common-all.js:10876 static/js/common-min.js:6 static/js/impala-all.js:11498 static/js/impala-min.js:6 static/js/impala/reviews.js:40 static/js/zamboni/reviews.js:34
+msgid "Your input is required"
+msgstr "Lypset dora juaj"
+
+#: static/js/common-all.js:10945 static/js/common-min.js:6 static/js/impala-all.js:11610 static/js/impala-min.js:7 static/js/impala/reviews.js:152 static/js/zamboni/reviews.js:103
+msgid "Marked for deletion"
+msgstr "Shënuar për fshirje"
+
+#: static/js/common-all.js:11573 static/js/common-min.js:7 static/js/impala-all.js:13809 static/js/impala-min.js:8 static/js/zamboni/collections.js:229
+msgid "Adding to Favorites&hellip;"
+msgstr "Po shtohet te Të parapëlqyerit&hellip;"
+
+#: static/js/common-all.js:11576 static/js/common-min.js:7 static/js/impala-all.js:13812 static/js/impala-min.js:8 static/js/zamboni/collections.js:232
+msgid "Removing Favorite&hellip;"
+msgstr "Po hiqet prej Të parapëlqyerve&hellip;"
+
+#: static/js/common-all.js:11579 static/js/common-min.js:7 static/js/impala-all.js:13815 static/js/impala-min.js:8 static/js/zamboni/collections.js:235
+msgid "Add to Favorites"
+msgstr "Shtoje te Të parapëlqyerit"
+
+#: static/js/common-all.js:11582 static/js/common-min.js:7 static/js/impala-all.js:13818 static/js/impala-min.js:8 static/js/zamboni/collections.js:238
+msgid "Remove from Favorites"
+msgstr "Hiqe prej Të parapëlqyerve"
+
+#: static/js/common-all.js:11647 static/js/common-min.js:7 static/js/impala-all.js:13883 static/js/impala-min.js:8 static/js/zamboni/collections.js:303
+msgid "Pending"
+msgstr "Në pritje"
+
+#: static/js/common-all.js:11648 static/js/common-min.js:7 static/js/impala-all.js:13884 static/js/impala-min.js:8 static/js/zamboni/collections.js:304
+msgid "Add a comment"
+msgstr "Shtoni një koment"
+
+#: static/js/common-all.js:11648 static/js/common-min.js:7 static/js/impala-all.js:13884 static/js/impala-min.js:8 static/js/zamboni/collections.js:304
+msgid "Comment"
+msgstr "Koment"
+
+#: static/js/common-all.js:11649 static/js/common-min.js:7 static/js/impala-all.js:13885 static/js/impala-min.js:8 static/js/zamboni/collections.js:305
+msgid "Remove this add-on from the collection"
+msgstr "Hiqe këtë shtesë prej koleksionit"
+
+#: static/js/common-all.js:11649 static/js/common-all.js:11678 static/js/common-min.js:7 static/js/impala-all.js:13885 static/js/impala-all.js:13914 static/js/impala-min.js:8
+#: static/js/zamboni/collections.js:305 static/js/zamboni/collections.js:334
+msgid "Remove"
+msgstr "Hiqe"
+
+#: static/js/common-all.js:11678 static/js/common-min.js:7 static/js/impala-all.js:13914 static/js/impala-min.js:8 static/js/zamboni/collections.js:334
+msgid "Remove this user as a contributor"
+msgstr "Hiqe këtë përdorues si kontribues"
+
+#: static/js/common-all.js:11690 static/js/common-min.js:7 static/js/impala-all.js:13926 static/js/impala-min.js:8 static/js/zamboni/collections.js:346
+msgid "An email address is required."
+msgstr "Lypset një adresë email."
+
+#: static/js/common-all.js:11708 static/js/common-min.js:7 static/js/impala-all.js:13944 static/js/impala-min.js:8 static/js/zamboni/collections.js:364
+msgid "You cannot add yourself as a contributor."
+msgstr "Nuk mund të shtoni vetveten si kontribues."
+
+#: static/js/common-all.js:11710 static/js/common-min.js:7 static/js/impala-all.js:13946 static/js/impala-min.js:8 static/js/zamboni/collections.js:366
+msgid "You have already added that user."
+msgstr "E keni shtuar një herë atë përdorues."
+
+#: static/js/common-all.js:11917 static/js/common-min.js:7 static/js/impala-all.js:14153 static/js/impala-min.js:8 static/js/zamboni/collections.js:573
+msgid "Add to favorites"
+msgstr "Shtojeni te të parapëlqyerit"
+
+#: static/js/common-all.js:11921 static/js/common-min.js:7 static/js/impala-all.js:14157 static/js/impala-min.js:8 static/js/zamboni/collections.js:577
+msgid "Remove from favorites"
+msgstr "Hiqe prej të parapëlqyerve"
+
+#: static/js/common-all.js:11939 static/js/common-min.js:7 static/js/impala-all.js:14175 static/js/impala-all.js:14233 static/js/impala-min.js:8 static/js/impala/collections.js:10
+#: static/js/zamboni/collections.js:595
+msgid "Follow this Collection"
+msgstr "Ndiqe këtë Koleksion"
+
+#: static/js/common-all.js:11948 static/js/common-min.js:7 static/js/impala-all.js:14184 static/js/impala-min.js:8 static/js/zamboni/collections.js:604
+msgid "Stop following"
+msgstr "Resht së ndjekuri"
+
+#: static/js/common-all.js:12096 static/js/common-min.js:7 static/js/zamboni/password-strength.js:20
+msgid "Password strength:"
+msgstr "Fortësi fjalëkalimi:"
+
+#: static/js/common-all.js:12102 static/js/common-min.js:7 static/js/zamboni/password-strength.js:26
+msgid "At least {0} character left."
+msgid_plural "At least {0} characters left."
+msgstr[0] "Të paktën edhe <b>{0}</b> shenjë."
+msgstr[1] "Të paktën edhe <b>{0}</b> shenja."
+
+#: static/js/common-all.js:12286 static/js/common-min.js:7 static/js/impala-all.js:14632 static/js/impala-min.js:8 static/js/impala/suggestions.js:39
+msgid "Search themes for <b>{0}</b>"
+msgstr "Kërkoni tema për <b>{0}</b>"
+
+#: static/js/common-all.js:12288 static/js/common-min.js:7 static/js/impala-all.js:14634 static/js/impala-min.js:8 static/js/impala/suggestions.js:41
+msgid "Search apps for <b>{0}</b>"
+msgstr "Kërkoni aplikacione për <b>{0}</b>"
+
+#: static/js/common-all.js:12290 static/js/common-min.js:7 static/js/impala-all.js:14636 static/js/impala-min.js:8 static/js/impala/suggestions.js:43
+msgid "Search add-ons for <b>{0}</b>"
+msgstr "Kërkoni shtesa për <b>{0}</b>"
+
+#: static/js/common-all.js:12521 static/js/common-min.js:7 static/js/impala-all.js:14867 static/js/impala-min.js:8 static/js/impala/site_suggestions.js:46
+msgid "Category"
+msgstr "Kategori"
+
+#. L10n: {0} is an app name.
+#: static/js/impala-all.js:11632 static/js/impala-min.js:7 static/js/impala/listing.js:11 static/js/zamboni/themes.js:13
+msgid "This theme is incompatible with your version of {0}"
+msgstr "Kjo temë është e papërputhshme me versionin tuaj të {0}"
+
+#: static/js/impala-all.js:12146 static/js/impala-all.js:14331 static/js/impala-min.js:7 static/js/impala-min.js:8 static/js/common/upload-image.js:97 static/js/impala/users.js:51
+#: static/js/zamboni/devhub-all.js:894 static/js/zamboni/devhub-min.js:1
+msgid "Images must be either PNG or JPG."
+msgstr "Pamjet duhet të jenë ose PNG, ose JPG."
+
+#: static/js/impala-all.js:12150 static/js/impala-min.js:7 static/js/common/upload-image.js:101 static/js/zamboni/devhub-all.js:898 static/js/zamboni/devhub-min.js:1
+msgid "Videos must be in WebM."
+msgstr "Videot duhet të jenë në formatin WebM."
+
+#: static/js/impala-all.js:12177 static/js/impala-min.js:7 static/js/common/upload-addon.js:41 static/js/common/upload-image.js:128 static/js/zamboni/devhub-all.js:272
+#: static/js/zamboni/devhub-all.js:925 static/js/zamboni/devhub-min.js:1
 msgid "There was a problem contacting the server."
 msgstr "Pati një problem gjatë kontaktimit me shërbyesin."
 
-#: static/js/common/upload-addon.js:69
+#: static/js/impala-all.js:13298 static/js/impala-min.js:7 static/js/impala/persona_creation.js:60
+msgid "All Rights Reserved"
+msgstr "Tërë të Drejtat të Rezervuara"
+
+#: static/js/impala-all.js:13302 static/js/impala-min.js:7 static/js/impala/persona_creation.js:64
+msgid "Creative Commons Attribution 3.0"
+msgstr "Creative Commons Attribution 3.0"
+
+#: static/js/impala-all.js:13307 static/js/impala-min.js:7 static/js/impala/persona_creation.js:69
+msgid "Creative Commons Attribution-NonCommercial 3.0"
+msgstr "Creative Commons Attribution-NonCommercial 3.0"
+
+#: static/js/impala-all.js:13312 static/js/impala-min.js:7 static/js/impala/persona_creation.js:74
+msgid "Creative Commons Attribution-NonCommercial-NoDerivs 3.0"
+msgstr "Creative Commons Attribution-NonCommercial-NoDerivs 3.0"
+
+#: static/js/impala-all.js:13317 static/js/impala-min.js:7 static/js/impala/persona_creation.js:79
+msgid "Creative Commons Attribution-NonCommercial-Share Alike 3.0"
+msgstr "Creative Commons Attribution-NonCommercial-Share Alike 3.0"
+
+#: static/js/impala-all.js:13322 static/js/impala-min.js:7 static/js/impala/persona_creation.js:84
+msgid "Creative Commons Attribution-NoDerivs 3.0"
+msgstr "Creative Commons Attribution-NoDerivs 3.0"
+
+#: static/js/impala-all.js:13327 static/js/impala-min.js:7 static/js/impala/persona_creation.js:89
+msgid "Creative Commons Attribution-ShareAlike 3.0"
+msgstr "Creative Commons Attribution-ShareAlike 3.0"
+
+#: static/js/impala-all.js:13530 static/js/impala-min.js:7 static/js/impala/persona_creation.js:292
+msgid "Your Theme's Name"
+msgstr "Emri i Temës Suaj"
+
+#: static/js/impala-all.js:14242 static/js/impala-min.js:8 static/js/impala/collections.js:19
+msgid "Stop Following"
+msgstr "Resht Së Ndjekuri"
+
+#: static/js/impala-all.js:14243 static/js/impala-min.js:8 static/js/impala/collections.js:20
+msgid "Following"
+msgstr "Po e Ndiqni"
+
+#: static/js/impala-all.js:14313 static/js/impala-min.js:8 static/js/impala/users.js:33
+msgid "use original"
+msgstr "përdor origjinalen"
+
+#: static/js/impala-all.js:14523 static/js/impala-min.js:8 static/js/impala/search.js:114
+msgid "Updating results&hellip;"
+msgstr "Po përditësohen përfundimet&hellip;"
+
+#: static/js/common/upload-addon.js:69 static/js/zamboni/devhub-all.js:300 static/js/zamboni/devhub-min.js:1
 msgid "Select a file..."
 msgstr "Përzgjidhni një kartelë..."
 
-#: static/js/common/upload-addon.js:70
+#: static/js/common/upload-addon.js:70 static/js/zamboni/devhub-all.js:301 static/js/zamboni/devhub-min.js:1
 msgid "Your add-on should end with .xpi, .jar or .xml"
 msgstr "Shtesa juaj do të duhej të përfundonte me .xpi, .jar ose .xml"
 
 #. L10n: {0} is the percent of the file that has been uploaded.
-#: static/js/common/upload-addon.js:104
+#: static/js/common/upload-addon.js:104 static/js/zamboni/devhub-all.js:335 static/js/zamboni/devhub-min.js:1
 #, python-format
 msgid "{0}% complete"
 msgstr "{0}% e plotësuar"
 
 #. L10n: "{bytes uploaded} of {total filesize}".
-#: static/js/common/upload-addon.js:107
+#: static/js/common/upload-addon.js:107 static/js/zamboni/devhub-all.js:338 static/js/zamboni/devhub-min.js:1
 msgid "{0} of {1}"
 msgstr "{0} nga {1}"
 
-#: static/js/common/upload-addon.js:140
+#: static/js/common/upload-addon.js:140 static/js/zamboni/devhub-all.js:371 static/js/zamboni/devhub-min.js:1
 msgid "Cancel"
 msgstr "Anuloje"
 
-#: static/js/common/upload-addon.js:162
+#: static/js/common/upload-addon.js:162 static/js/zamboni/devhub-all.js:393 static/js/zamboni/devhub-min.js:1
 msgid "Uploading {0}"
 msgstr "Po ngarkohet {0}"
 
-#: static/js/common/upload-addon.js:189
+#: static/js/common/upload-addon.js:189 static/js/zamboni/devhub-all.js:420 static/js/zamboni/devhub-min.js:1
 msgid "Error with {0}"
 msgstr "Gabim me {0}"
 
-#: static/js/common/upload-addon.js:194
+#: static/js/common/upload-addon.js:194 static/js/zamboni/devhub-all.js:425 static/js/zamboni/devhub-min.js:1
 msgid "Your add-on failed validation with {0} error."
 msgid_plural "Your add-on failed validation with {0} errors."
 msgstr[0] "Vleftësimi i shtesës suaj dështoi për shkak të {0} gabimi."
 msgstr[1] "Vleftësimi i shtesës suaj dështoi për shkak të {0} gabimeve."
 
-#: static/js/common/upload-addon.js:208
+#: static/js/common/upload-addon.js:208 static/js/zamboni/devhub-all.js:439 static/js/zamboni/devhub-min.js:1
 msgid "&hellip;and {0} more"
 msgid_plural "&hellip;and {0} more"
 msgstr[0] "&hellip;dhe {0} tjetër"
 msgstr[1] "&hellip;dhe {0} të tjerë"
 
-#: static/js/common/upload-addon.js:222 static/js/common/upload-addon.js:512
+#: static/js/common/upload-addon.js:222 static/js/common/upload-addon.js:497 static/js/zamboni/devhub-all.js:453 static/js/zamboni/devhub-all.js:743 static/js/zamboni/devhub-min.js:1
 msgid "See full validation report"
 msgstr "Shihni raportin e plotë të vleftësimit"
 
-#: static/js/common/upload-addon.js:234
+#: static/js/common/upload-addon.js:234 static/js/zamboni/devhub-all.js:465 static/js/zamboni/devhub-min.js:1
 msgid "Validating {0}"
 msgstr "Po vleftësohet {0}"
 
 #. L10n: first argument is an HTTP status code
-#: static/js/common/upload-addon.js:273
+#: static/js/common/upload-addon.js:273 static/js/zamboni/devhub-all.js:504 static/js/zamboni/devhub-min.js:1
 msgid "Received an empty response from the server; status: {0}"
 msgstr "Prej shërbyesit u mor një përgjigje e zbrazët, me gjendjen: {0}"
 
-#: static/js/common/upload-addon.js:373
+#: static/js/common/upload-addon.js:370 static/js/zamboni/devhub-all.js:604 static/js/zamboni/devhub-min.js:1
 msgid "Unexpected server error while validating."
 msgstr "Gabim i papritur shërbyesi gjatë vleftësimit."
 
-#: static/js/common/upload-addon.js:412
+#: static/js/common/upload-addon.js:409 static/js/zamboni/devhub-all.js:643 static/js/zamboni/devhub-min.js:1
 msgid "Finished validating {0}"
 msgstr "Po përfundohet vleftësimi i {0}"
 
-#: static/js/common/upload-addon.js:418
+#: static/js/common/upload-addon.js:415 static/js/zamboni/devhub-all.js:649 static/js/zamboni/devhub-min.js:1
 msgid "Your add-on validation timed out, it will be manually reviewed."
 msgstr "Vleftësimit të shtesës suaj i mbaroi koha, do të shqyrtohet dorazi."
 
-#: static/js/common/upload-addon.js:421
+#: static/js/common/upload-addon.js:418 static/js/zamboni/devhub-all.js:652 static/js/zamboni/devhub-min.js:1
 msgid "Your add-on was validated with no errors and {0} warning."
 msgid_plural "Your add-on was validated with no errors and {0} warnings."
 msgstr[0] "Shtesa juaj e kaloi vleftësimin pa gabime dhe me {0} sinjalizim."
 msgstr[1] "Shtesa juaj e kaloi vleftësimin pa gabime dhe me {0} sinjalizime."
 
-#: static/js/common/upload-addon.js:426
+#: static/js/common/upload-addon.js:423 static/js/zamboni/devhub-all.js:657 static/js/zamboni/devhub-min.js:1
 msgid "Your add-on was validated with no errors and {0} message."
 msgid_plural "Your add-on was validated with no errors and {0} messages."
 msgstr[0] "Shtesa juaj u vleftësua pa gabime dhe {0} mesazh."
 msgstr[1] "Shtesa juaj u vleftësua pa gabime dhe {0} mesazhe."
 
-#: static/js/common/upload-addon.js:431
+#: static/js/common/upload-addon.js:428 static/js/zamboni/devhub-all.js:662 static/js/zamboni/devhub-min.js:1
 msgid "Your add-on was validated with no errors or warnings."
 msgstr "Shtesa juaj u vleftësua pa gabime apo sinjalizime."
 
-#: static/js/common/upload-addon.js:446
+#: static/js/common/upload-addon.js:443 static/js/zamboni/devhub-all.js:677 static/js/zamboni/devhub-min.js:1
 msgid "Your submission will be automatically signed."
 msgstr "Parashtrimi juaj do të nënshkruhet vetvetiu."
 
-#: static/js/common/upload-addon.js:465
+#: static/js/common/upload-addon.js:450 static/js/zamboni/devhub-all.js:696 static/js/zamboni/devhub-min.js:1
 msgid "Include detailed version notes (this can be done in the next step)."
 msgstr "Përfshini shënime të hollësishme versioni (kjo mund të kryhet në hapin pasues)."
 
-#: static/js/common/upload-addon.js:466
+#: static/js/common/upload-addon.js:451 static/js/zamboni/devhub-all.js:697 static/js/zamboni/devhub-min.js:1
 msgid "If your add-on requires an account to a website in order to be fully tested, include a test username and password in the Notes to Reviewer (this can be done in the next step)."
-msgstr "Nëse shtesa juaj lyp një llogari në një sajt, që të mund të testohet plotësisht, përfshini një emër përdoruesi dhe fjalëkalim testi te Shënimet për Shqyrtuesin (kjo mund të bëhet te hapi pasues)."
+msgstr ""
+"Nëse shtesa juaj lyp një llogari në një sajt, që të mund të testohet plotësisht, përfshini një emër përdoruesi dhe fjalëkalim testi te Shënimet për Shqyrtuesin (kjo mund të bëhet te hapi pasues)."
 
-#: static/js/common/upload-addon.js:467
+#: static/js/common/upload-addon.js:452 static/js/zamboni/devhub-all.js:698 static/js/zamboni/devhub-min.js:1
 msgid "If your add-on is intended for a limited audience you should choose Preliminary Review instead of Full Review."
 msgstr "Nëse shtesa juaj është menduar për një publik të kufizuar, në vend të Shqyrtimit të Plotë do të duhej të zgjidhnit Shqyrtim Paraprak."
 
-#: static/js/common/upload-addon.js:480
+#: static/js/common/upload-addon.js:465 static/js/zamboni/devhub-all.js:711 static/js/zamboni/devhub-min.js:1
 msgid "Add-on submission checklist"
 msgstr "Listë kontrolli parashtrimi shtese"
 
-#: static/js/common/upload-addon.js:481
+#: static/js/common/upload-addon.js:466 static/js/zamboni/devhub-all.js:712 static/js/zamboni/devhub-min.js:1
 msgid "Please verify the following points before finalizing your submission. This will minimize delays or misunderstanding during the review process:"
 msgstr "Ju lutemi verifikoni plotësimin e pikave vijuese, përpara se të përfundoni parashtrimin tuaj. Kjo do të minimizojë vonesat ose keqkuptimet gjatë procesit të shqyrtimit:"
 
-#: static/js/common/upload-addon.js:483
+#: static/js/common/upload-addon.js:468 static/js/zamboni/devhub-all.js:714 static/js/zamboni/devhub-min.js:1
 msgid ""
 "Compiled binaries, as well as minified or obfuscated scripts (excluding known libraries) need to have their sources submitted separately for review. Make sure that you use the source code upload "
 "field to avoid having your submission rejected."
@@ -141,1080 +399,844 @@ msgstr ""
 "Për dyorë të përpiluar, si dhe programthe të minimizuar, apo të fshehur njëfarësoj, (hiq librari të njohura) lypset të parashtrohen veçmas burimet e tyre, për shqyrtim. Mos harroni të përdorni "
 "fushën e ngarkimit të kodit burim, që të shmangni hedhjen pohstë të parashtrimit tuaj."
 
-#: static/js/common/upload-addon.js:501
+#: static/js/common/upload-addon.js:486 static/js/zamboni/devhub-all.js:732 static/js/zamboni/devhub-min.js:1
 msgid "The validation process found these issues that can lead to rejections:"
 msgstr "Procesi i vleftësimit gjeti këto probleme që mund të sjellin hedhje poshtë të parashtrimit:"
 
-#: static/js/common/upload-addon.js:518
+#: static/js/common/upload-addon.js:503 static/js/zamboni/devhub-all.js:749 static/js/zamboni/devhub-min.js:1
 msgid "If you are unfamiliar with the add-ons review process, you can read about it here."
 msgstr "Nëse procesi i shqyrtimit është i panjohur për ju, rreth tij mund të lexoni këtu."
 
-#: static/js/common/upload-addon.js:555
+#: static/js/common/upload-addon.js:540 static/js/zamboni/devhub-all.js:786 static/js/zamboni/devhub-min.js:1
 msgid "Sorry, no supported platform has been found."
 msgstr "Na ndjeni, nuk u gjet platformë e mbuluar."
 
-#: static/js/common/upload-base.js:57
+#: static/js/common/upload-base.js:57 static/js/zamboni/devhub-all.js:187 static/js/zamboni/devhub-min.js:1
 msgid "The filetype you uploaded isn't recognized."
 msgstr "Lloji i kartelës që ngarkuat nuk është i pranueshëm."
 
-#: static/js/common/upload-base.js:79
+#: static/js/common/upload-base.js:79 static/js/zamboni/devhub-all.js:209 static/js/zamboni/devhub-min.js:1
 msgid "You cancelled the upload."
 msgstr "E anuluat ngarkimin."
 
-#: static/js/common/upload-image.js:97 static/js/impala/users.js:51
-msgid "Images must be either PNG or JPG."
-msgstr "Pamjet duhet të jenë ose PNG, ose JPG."
-
-#: static/js/common/upload-image.js:101
-msgid "Videos must be in WebM."
-msgstr "Videot duhet të jenë në formatin WebM."
-
-#: static/js/impala/collections.js:10 static/js/zamboni/collections.js:595
-msgid "Follow this Collection"
-msgstr "Ndiqe këtë Koleksion"
-
-#: static/js/impala/collections.js:19
-msgid "Stop Following"
-msgstr "Resht Së Ndjekuri"
-
-#: static/js/impala/collections.js:20
-msgid "Following"
-msgstr "Po e Ndiqni"
-
-#. L10n: {0} is an app name.
-#: static/js/impala/listing.js:11 static/js/zamboni/themes.js:13
-msgid "This theme is incompatible with your version of {0}"
-msgstr "Kjo temë është e papërputhshme me versionin tuaj të {0}"
-
-#: static/js/impala/persona_creation.js:60
-msgid "All Rights Reserved"
-msgstr "Tërë të Drejtat të Rezervuara"
-
-#: static/js/impala/persona_creation.js:64
-msgid "Creative Commons Attribution 3.0"
-msgstr "Creative Commons Attribution 3.0"
-
-#: static/js/impala/persona_creation.js:69
-msgid "Creative Commons Attribution-NonCommercial 3.0"
-msgstr "Creative Commons Attribution-NonCommercial 3.0"
-
-#: static/js/impala/persona_creation.js:74
-msgid "Creative Commons Attribution-NonCommercial-NoDerivs 3.0"
-msgstr "Creative Commons Attribution-NonCommercial-NoDerivs 3.0"
-
-#: static/js/impala/persona_creation.js:79
-msgid "Creative Commons Attribution-NonCommercial-Share Alike 3.0"
-msgstr "Creative Commons Attribution-NonCommercial-Share Alike 3.0"
-
-#: static/js/impala/persona_creation.js:84
-msgid "Creative Commons Attribution-NoDerivs 3.0"
-msgstr "Creative Commons Attribution-NoDerivs 3.0"
-
-#: static/js/impala/persona_creation.js:89
-msgid "Creative Commons Attribution-ShareAlike 3.0"
-msgstr "Creative Commons Attribution-ShareAlike 3.0"
-
-#: static/js/impala/persona_creation.js:292
-msgid "Your Theme's Name"
-msgstr "Emri i Temës Suaj"
-
-#: static/js/impala/reviews.js:23 static/js/zamboni/reviews.js:18
-msgid "Flagged for review"
-msgstr "Me shenjë për shqyrtim"
-
-#: static/js/impala/reviews.js:40 static/js/zamboni/reviews.js:34
-msgid "Your input is required"
-msgstr "Lypset dora juaj"
-
-#: static/js/impala/reviews.js:152 static/js/zamboni/reviews.js:103
-msgid "Marked for deletion"
-msgstr "Shënuar për fshirje"
-
-#: static/js/impala/search.js:114
-msgid "Updating results&hellip;"
-msgstr "Po përditësohen përfundimet&hellip;"
-
-#: static/js/impala/site_suggestions.js:46
-msgid "Category"
-msgstr "Kategori"
-
-#: static/js/impala/suggestions.js:39
-msgid "Search themes for <b>{0}</b>"
-msgstr "Kërkoni tema për <b>{0}</b>"
-
-#: static/js/impala/suggestions.js:41
-msgid "Search apps for <b>{0}</b>"
-msgstr "Kërkoni aplikacione për <b>{0}</b>"
-
-#: static/js/impala/suggestions.js:43
-msgid "Search add-ons for <b>{0}</b>"
-msgstr "Kërkoni shtesa për <b>{0}</b>"
-
-#: static/js/impala/users.js:33
-msgid "use original"
-msgstr "përdor origjinalen"
-
-#: static/js/impala/stats/chart.js:267
+#: static/js/impala/stats/chart.js:267 static/js/zamboni/stats-all.js:16898 static/js/zamboni/stats-min.js:5
 msgid "Week of {0}"
 msgstr "Java e {0}"
 
-#: static/js/impala/stats/chart.js:269
+#: static/js/impala/stats/chart.js:269 static/js/zamboni/stats-all.js:16900 static/js/zamboni/stats-min.js:5
 msgid " downloads"
-msgstr "shkarkime"
+msgstr ""
 
-#: static/js/impala/stats/chart.js:270
+#: static/js/impala/stats/chart.js:270 static/js/zamboni/stats-all.js:16901 static/js/zamboni/stats-min.js:5
 msgid "{0} users"
 msgstr "{0} përdorues"
 
-#: static/js/impala/stats/chart.js:271
+#: static/js/impala/stats/chart.js:271 static/js/zamboni/stats-all.js:16902 static/js/zamboni/stats-min.js:5
 msgid "{0} add-ons"
 msgstr "{0} shtesa"
 
-#: static/js/impala/stats/chart.js:272
+#: static/js/impala/stats/chart.js:272 static/js/zamboni/stats-all.js:16903 static/js/zamboni/stats-min.js:5
 msgid "{0} collections"
 msgstr "{0} koleksione"
 
-#: static/js/impala/stats/chart.js:273
+#: static/js/impala/stats/chart.js:273 static/js/zamboni/stats-all.js:16904 static/js/zamboni/stats-min.js:5
 msgid "{0} reviews"
 msgstr "{0} shqyrtime"
 
-#: static/js/impala/stats/chart.js:275
+#: static/js/impala/stats/chart.js:275 static/js/zamboni/stats-all.js:16906 static/js/zamboni/stats-min.js:5
 msgid "{0} sales"
 msgstr "{0} shitje"
 
-#: static/js/impala/stats/chart.js:276
+#: static/js/impala/stats/chart.js:276 static/js/zamboni/stats-all.js:16907 static/js/zamboni/stats-min.js:5
 msgid "{0} refunds"
 msgstr "{0} rimbursime"
 
-#: static/js/impala/stats/chart.js:277
+#: static/js/impala/stats/chart.js:277 static/js/zamboni/stats-all.js:16908 static/js/zamboni/stats-min.js:5
 msgid "{0} installs"
 msgstr "{0} instalime"
 
-#: static/js/impala/stats/chart.js:369 static/js/impala/stats/csv_keys.js:3 static/js/impala/stats/csv_keys.js:109
+#: static/js/impala/stats/chart.js:369 static/js/impala/stats/csv_keys.js:3 static/js/impala/stats/csv_keys.js:109 static/js/zamboni/stats-all.js:15284 static/js/zamboni/stats-all.js:15390
+#: static/js/zamboni/stats-all.js:17000 static/js/zamboni/stats-min.js:4 static/js/zamboni/stats-min.js:5
 msgid "Downloads"
 msgstr "Shkarkime"
 
-#: static/js/impala/stats/chart.js:379 static/js/impala/stats/csv_keys.js:6 static/js/impala/stats/csv_keys.js:110
+#: static/js/impala/stats/chart.js:379 static/js/impala/stats/csv_keys.js:6 static/js/impala/stats/csv_keys.js:110 static/js/zamboni/stats-all.js:15287 static/js/zamboni/stats-all.js:15391
+#: static/js/zamboni/stats-all.js:17010 static/js/zamboni/stats-min.js:4 static/js/zamboni/stats-min.js:5
 msgid "Daily Users"
 msgstr "Përdorues të Përditshëm"
 
-#: static/js/impala/stats/chart.js:410
+#: static/js/impala/stats/chart.js:410 static/js/zamboni/stats-all.js:17041 static/js/zamboni/stats-min.js:5
 msgid "Amount, in USD"
 msgstr "Vleftë, në USD"
 
-#: static/js/impala/stats/chart.js:421 static/js/impala/stats/csv_keys.js:104
+#: static/js/impala/stats/chart.js:421 static/js/impala/stats/csv_keys.js:104 static/js/zamboni/stats-all.js:15385 static/js/zamboni/stats-all.js:17052 static/js/zamboni/stats-min.js:5
 msgid "Number of Contributions"
 msgstr "Numër Kontributesh"
 
-#: static/js/impala/stats/chart.js:447
+#: static/js/impala/stats/chart.js:447 static/js/zamboni/stats-all.js:17078 static/js/zamboni/stats-min.js:5
 msgid "More Info..."
 msgstr "Më tepër të Dhëna..."
 
 #. L10n: {0} is an ISO-formatted date.
-#: static/js/impala/stats/chart.js:451
+#: static/js/impala/stats/chart.js:451 static/js/zamboni/stats-all.js:17082 static/js/zamboni/stats-min.js:5
 msgid "Details for {0}"
 msgstr "Hollësi për {0}"
 
-#: static/js/impala/stats/csv_keys.js:9
+#: static/js/impala/stats/csv_keys.js:9 static/js/zamboni/stats-all.js:15290 static/js/zamboni/stats-min.js:4
 msgid "Collections Created"
 msgstr "Koleksione të Krijuar"
 
-#: static/js/impala/stats/csv_keys.js:12
+#: static/js/impala/stats/csv_keys.js:12 static/js/zamboni/stats-all.js:15293 static/js/zamboni/stats-min.js:4
 msgid "Add-ons in Use"
 msgstr "Shtesa Në Përdorim"
 
-#: static/js/impala/stats/csv_keys.js:15
+#: static/js/impala/stats/csv_keys.js:15 static/js/zamboni/stats-all.js:15296 static/js/zamboni/stats-min.js:4
 msgid "Add-ons Created"
 msgstr "Shtesa të Krijuara"
 
-#: static/js/impala/stats/csv_keys.js:18
+#: static/js/impala/stats/csv_keys.js:18 static/js/zamboni/stats-all.js:15299 static/js/zamboni/stats-min.js:4
 msgid "Add-ons Downloaded"
 msgstr "Shtesa të Shkarkuara"
 
-#: static/js/impala/stats/csv_keys.js:21
+#: static/js/impala/stats/csv_keys.js:21 static/js/zamboni/stats-all.js:15302 static/js/zamboni/stats-min.js:4
 msgid "Add-ons Updated"
 msgstr "Shtesa të Përditësuara"
 
-#: static/js/impala/stats/csv_keys.js:24
+#: static/js/impala/stats/csv_keys.js:24 static/js/zamboni/stats-all.js:15305 static/js/zamboni/stats-min.js:4
 msgid "Reviews Written"
 msgstr "Shqyrtime të Shkruara"
 
-#: static/js/impala/stats/csv_keys.js:27
+#: static/js/impala/stats/csv_keys.js:27 static/js/zamboni/stats-all.js:15308 static/js/zamboni/stats-min.js:4
 msgid "User Signups"
 msgstr "Regjistrime Përdoruesish"
 
-#: static/js/impala/stats/csv_keys.js:30
+#: static/js/impala/stats/csv_keys.js:30 static/js/zamboni/stats-all.js:15311 static/js/zamboni/stats-min.js:4
 msgid "Subscribers"
 msgstr "Pajtimtarë"
 
-#: static/js/impala/stats/csv_keys.js:33
+#: static/js/impala/stats/csv_keys.js:33 static/js/zamboni/stats-all.js:15314 static/js/zamboni/stats-min.js:4
 msgid "Ratings"
 msgstr "Vlerësime"
 
-#: static/js/impala/stats/csv_keys.js:36 static/js/impala/stats/csv_keys.js:114
+#: static/js/impala/stats/csv_keys.js:36 static/js/impala/stats/csv_keys.js:114 static/js/zamboni/stats-all.js:15317 static/js/zamboni/stats-all.js:15395 static/js/zamboni/stats-min.js:4
+#: static/js/zamboni/stats-min.js:5
 msgid "Sales"
 msgstr "Shitje"
 
-#: static/js/impala/stats/csv_keys.js:39 static/js/impala/stats/csv_keys.js:113
+#: static/js/impala/stats/csv_keys.js:39 static/js/impala/stats/csv_keys.js:113 static/js/zamboni/stats-all.js:15320 static/js/zamboni/stats-all.js:15394 static/js/zamboni/stats-min.js:4
+#: static/js/zamboni/stats-min.js:5
 msgid "Installs"
 msgstr "Instalime"
 
-#: static/js/impala/stats/csv_keys.js:42
+#: static/js/impala/stats/csv_keys.js:42 static/js/zamboni/stats-all.js:15323 static/js/zamboni/stats-min.js:4
 msgid "Unknown"
 msgstr "E panjohur"
 
-#: static/js/impala/stats/csv_keys.js:43
+#: static/js/impala/stats/csv_keys.js:43 static/js/zamboni/stats-all.js:15324 static/js/zamboni/stats-min.js:4
 msgid "Add-ons Manager"
 msgstr "Përgjegjës  Shtesash"
 
-#: static/js/impala/stats/csv_keys.js:44
+#: static/js/impala/stats/csv_keys.js:44 static/js/zamboni/stats-all.js:15325 static/js/zamboni/stats-min.js:4
 msgid "Add-ons Manager Promo"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:45
+#: static/js/impala/stats/csv_keys.js:45 static/js/zamboni/stats-all.js:15326 static/js/zamboni/stats-min.js:4
 msgid "Add-ons Manager Featured"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:46
+#: static/js/impala/stats/csv_keys.js:46 static/js/zamboni/stats-all.js:15327 static/js/zamboni/stats-min.js:4
 msgid "Add-ons Manager Learn More"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:47
+#: static/js/impala/stats/csv_keys.js:47 static/js/zamboni/stats-all.js:15328 static/js/zamboni/stats-min.js:4
 msgid "Search Suggestions"
 msgstr "Këshillime Kërkimi"
 
-#: static/js/impala/stats/csv_keys.js:48
+#: static/js/impala/stats/csv_keys.js:48 static/js/zamboni/stats-all.js:15329 static/js/zamboni/stats-min.js:4
 msgid "Search Results"
 msgstr "Përfundime Kërkimi"
 
-#: static/js/impala/stats/csv_keys.js:49 static/js/impala/stats/csv_keys.js:50 static/js/impala/stats/csv_keys.js:51
+#: static/js/impala/stats/csv_keys.js:49 static/js/impala/stats/csv_keys.js:50 static/js/impala/stats/csv_keys.js:51 static/js/zamboni/stats-all.js:15330 static/js/zamboni/stats-all.js:15331
+#: static/js/zamboni/stats-all.js:15332 static/js/zamboni/stats-min.js:4
 msgid "Homepage Promo"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:52 static/js/impala/stats/csv_keys.js:53
+#: static/js/impala/stats/csv_keys.js:52 static/js/impala/stats/csv_keys.js:53 static/js/zamboni/stats-all.js:15333 static/js/zamboni/stats-all.js:15334 static/js/zamboni/stats-min.js:4
 msgid "Homepage Featured"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:54 static/js/impala/stats/csv_keys.js:55
+#: static/js/impala/stats/csv_keys.js:54 static/js/impala/stats/csv_keys.js:55 static/js/zamboni/stats-all.js:15335 static/js/zamboni/stats-all.js:15336 static/js/zamboni/stats-min.js:4
 msgid "Homepage Up and Coming"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:56
+#: static/js/impala/stats/csv_keys.js:56 static/js/zamboni/stats-all.js:15337 static/js/zamboni/stats-min.js:4
 msgid "Homepage Most Popular"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:57 static/js/impala/stats/csv_keys.js:59
+#: static/js/impala/stats/csv_keys.js:57 static/js/impala/stats/csv_keys.js:59 static/js/zamboni/stats-all.js:15338 static/js/zamboni/stats-all.js:15340 static/js/zamboni/stats-min.js:4
 msgid "Detail Page"
 msgstr "Faqe Hollësish"
 
-#: static/js/impala/stats/csv_keys.js:58 static/js/impala/stats/csv_keys.js:60
+#: static/js/impala/stats/csv_keys.js:58 static/js/impala/stats/csv_keys.js:60 static/js/zamboni/stats-all.js:15339 static/js/zamboni/stats-all.js:15341 static/js/zamboni/stats-min.js:4
 msgid "Detail Page (bottom)"
 msgstr "Faqe Hollësish (fundi)"
 
-#: static/js/impala/stats/csv_keys.js:61
+#: static/js/impala/stats/csv_keys.js:61 static/js/zamboni/stats-all.js:15342 static/js/zamboni/stats-min.js:4
 msgid "Detail Page (Development Channel)"
 msgstr "Faqe Hollësish (Kanali i Zhvillimeve)"
 
-#: static/js/impala/stats/csv_keys.js:62 static/js/impala/stats/csv_keys.js:63 static/js/impala/stats/csv_keys.js:64
+#: static/js/impala/stats/csv_keys.js:62 static/js/impala/stats/csv_keys.js:63 static/js/impala/stats/csv_keys.js:64 static/js/zamboni/stats-all.js:15343 static/js/zamboni/stats-all.js:15344
+#: static/js/zamboni/stats-all.js:15345 static/js/zamboni/stats-min.js:4
 msgid "Often Used With"
 msgstr "Përdorur Shpesh Me"
 
-#: static/js/impala/stats/csv_keys.js:65 static/js/impala/stats/csv_keys.js:66
+#: static/js/impala/stats/csv_keys.js:65 static/js/impala/stats/csv_keys.js:66 static/js/zamboni/stats-all.js:15346 static/js/zamboni/stats-all.js:15347 static/js/zamboni/stats-min.js:4
 msgid "Others By Author"
 msgstr "Të tjera Nga Autori"
 
-#: static/js/impala/stats/csv_keys.js:67 static/js/impala/stats/csv_keys.js:68
+#: static/js/impala/stats/csv_keys.js:67 static/js/impala/stats/csv_keys.js:68 static/js/zamboni/stats-all.js:15348 static/js/zamboni/stats-all.js:15349 static/js/zamboni/stats-min.js:4
 msgid "Dependencies"
 msgstr "Varësi"
 
-#: static/js/impala/stats/csv_keys.js:69 static/js/impala/stats/csv_keys.js:70
+#: static/js/impala/stats/csv_keys.js:69 static/js/impala/stats/csv_keys.js:70 static/js/zamboni/stats-all.js:15350 static/js/zamboni/stats-all.js:15351 static/js/zamboni/stats-min.js:4
 msgid "Upsell"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:71
+#: static/js/impala/stats/csv_keys.js:71 static/js/zamboni/stats-all.js:15352 static/js/zamboni/stats-min.js:4
 msgid "Meet the Developer"
 msgstr "Njihuni me Zhvilluesin"
 
-#: static/js/impala/stats/csv_keys.js:72
+#: static/js/impala/stats/csv_keys.js:72 static/js/zamboni/stats-all.js:15353 static/js/zamboni/stats-min.js:4
 msgid "User Profile"
 msgstr "Profil Përdoruesi"
 
-#: static/js/impala/stats/csv_keys.js:73
+#: static/js/impala/stats/csv_keys.js:73 static/js/zamboni/stats-all.js:15354 static/js/zamboni/stats-min.js:4
 msgid "Version History"
 msgstr "Historik Versionesh"
 
-#: static/js/impala/stats/csv_keys.js:75
+#: static/js/impala/stats/csv_keys.js:75 static/js/zamboni/stats-all.js:15356 static/js/zamboni/stats-min.js:4
 msgid "Sharing"
 msgstr "Ndarje me të tjerët"
 
-#: static/js/impala/stats/csv_keys.js:76
+#: static/js/impala/stats/csv_keys.js:76 static/js/zamboni/stats-all.js:15357 static/js/zamboni/stats-min.js:4
 msgid "Category Pages"
 msgstr "Faqe Kategorish"
 
-#: static/js/impala/stats/csv_keys.js:77
+#: static/js/impala/stats/csv_keys.js:77 static/js/zamboni/stats-all.js:15358 static/js/zamboni/stats-min.js:4
 msgid "Collections"
 msgstr "Koleksione"
 
-#: static/js/impala/stats/csv_keys.js:78 static/js/impala/stats/csv_keys.js:79
+#: static/js/impala/stats/csv_keys.js:78 static/js/impala/stats/csv_keys.js:79 static/js/zamboni/stats-all.js:15359 static/js/zamboni/stats-all.js:15360 static/js/zamboni/stats-min.js:4
 msgid "Category Landing Featured Carousel"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:80 static/js/impala/stats/csv_keys.js:81
+#: static/js/impala/stats/csv_keys.js:80 static/js/impala/stats/csv_keys.js:81 static/js/zamboni/stats-all.js:15361 static/js/zamboni/stats-all.js:15362 static/js/zamboni/stats-min.js:4
 msgid "Category Landing Top Rated"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:82 static/js/impala/stats/csv_keys.js:83
+#: static/js/impala/stats/csv_keys.js:82 static/js/impala/stats/csv_keys.js:83 static/js/zamboni/stats-all.js:15363 static/js/zamboni/stats-all.js:15364 static/js/zamboni/stats-min.js:5
 msgid "Category Landing Most Popular"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:84 static/js/impala/stats/csv_keys.js:85
+#: static/js/impala/stats/csv_keys.js:84 static/js/impala/stats/csv_keys.js:85 static/js/zamboni/stats-all.js:15365 static/js/zamboni/stats-all.js:15366 static/js/zamboni/stats-min.js:5
 msgid "Category Landing Recently Added"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:86 static/js/impala/stats/csv_keys.js:87
+#: static/js/impala/stats/csv_keys.js:86 static/js/impala/stats/csv_keys.js:87 static/js/zamboni/stats-all.js:15367 static/js/zamboni/stats-all.js:15368 static/js/zamboni/stats-min.js:5
 msgid "Browse Listing Featured Sort"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:88 static/js/impala/stats/csv_keys.js:89
+#: static/js/impala/stats/csv_keys.js:88 static/js/impala/stats/csv_keys.js:89 static/js/zamboni/stats-all.js:15369 static/js/zamboni/stats-all.js:15370 static/js/zamboni/stats-min.js:5
 msgid "Browse Listing Users Sort"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:90 static/js/impala/stats/csv_keys.js:91
+#: static/js/impala/stats/csv_keys.js:90 static/js/impala/stats/csv_keys.js:91 static/js/zamboni/stats-all.js:15371 static/js/zamboni/stats-all.js:15372 static/js/zamboni/stats-min.js:5
 msgid "Browse Listing Rating Sort"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:92 static/js/impala/stats/csv_keys.js:93
+#: static/js/impala/stats/csv_keys.js:92 static/js/impala/stats/csv_keys.js:93 static/js/zamboni/stats-all.js:15373 static/js/zamboni/stats-all.js:15374 static/js/zamboni/stats-min.js:5
 msgid "Browse Listing Created Sort"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:94 static/js/impala/stats/csv_keys.js:95
+#: static/js/impala/stats/csv_keys.js:94 static/js/impala/stats/csv_keys.js:95 static/js/zamboni/stats-all.js:15375 static/js/zamboni/stats-all.js:15376 static/js/zamboni/stats-min.js:5
 msgid "Browse Listing Name Sort"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:96 static/js/impala/stats/csv_keys.js:97
+#: static/js/impala/stats/csv_keys.js:96 static/js/impala/stats/csv_keys.js:97 static/js/zamboni/stats-all.js:15377 static/js/zamboni/stats-all.js:15378 static/js/zamboni/stats-min.js:5
 msgid "Browse Listing Popular Sort"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:98 static/js/impala/stats/csv_keys.js:99
+#: static/js/impala/stats/csv_keys.js:98 static/js/impala/stats/csv_keys.js:99 static/js/zamboni/stats-all.js:15379 static/js/zamboni/stats-all.js:15380 static/js/zamboni/stats-min.js:5
 msgid "Browse Listing Updated Sort"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:100 static/js/impala/stats/csv_keys.js:101
+#: static/js/impala/stats/csv_keys.js:100 static/js/impala/stats/csv_keys.js:101 static/js/zamboni/stats-all.js:15381 static/js/zamboni/stats-all.js:15382 static/js/zamboni/stats-min.js:5
 msgid "Browse Listing Up and Coming Sort"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:105
+#: static/js/impala/stats/csv_keys.js:105 static/js/zamboni/stats-all.js:15386 static/js/zamboni/stats-min.js:5
 msgid "Total Amount Contributed"
 msgstr "Sasi e Kontribuar Gjithsej"
 
-#: static/js/impala/stats/csv_keys.js:106
+#: static/js/impala/stats/csv_keys.js:106 static/js/zamboni/stats-all.js:15387 static/js/zamboni/stats-min.js:5
 msgid "Average Contribution"
 msgstr "Kontribut Mesatarisht"
 
-#: static/js/impala/stats/csv_keys.js:115
+#: static/js/impala/stats/csv_keys.js:115 static/js/zamboni/stats-all.js:15396 static/js/zamboni/stats-min.js:5
 msgid "Usage"
 msgstr "Përdorim"
 
-#: static/js/impala/stats/csv_keys.js:118
+#: static/js/impala/stats/csv_keys.js:118 static/js/zamboni/stats-all.js:15399 static/js/zamboni/stats-min.js:5
 msgid "Firefox"
 msgstr "Firefox"
 
-#: static/js/impala/stats/csv_keys.js:119
+#: static/js/impala/stats/csv_keys.js:119 static/js/zamboni/stats-all.js:15400 static/js/zamboni/stats-min.js:5
 msgid "Mozilla"
 msgstr "Mozilla"
 
-#: static/js/impala/stats/csv_keys.js:120
+#: static/js/impala/stats/csv_keys.js:120 static/js/zamboni/stats-all.js:15401 static/js/zamboni/stats-min.js:5
 msgid "Thunderbird"
 msgstr "Thunderbird"
 
-#: static/js/impala/stats/csv_keys.js:121
+#: static/js/impala/stats/csv_keys.js:121 static/js/zamboni/stats-all.js:15402 static/js/zamboni/stats-min.js:5
 msgid "Sunbird"
 msgstr "Sunbird"
 
-#: static/js/impala/stats/csv_keys.js:122
+#: static/js/impala/stats/csv_keys.js:122 static/js/zamboni/stats-all.js:15403 static/js/zamboni/stats-min.js:5
 msgid "SeaMonkey"
 msgstr "SeaMonkey"
 
-#: static/js/impala/stats/csv_keys.js:123
+#: static/js/impala/stats/csv_keys.js:123 static/js/zamboni/stats-all.js:15404 static/js/zamboni/stats-min.js:5
 msgid "Fennec"
 msgstr "Fennec"
 
-#: static/js/impala/stats/csv_keys.js:124
+#: static/js/impala/stats/csv_keys.js:124 static/js/zamboni/stats-all.js:15405 static/js/zamboni/stats-min.js:5
 msgid "Android"
 msgstr "Android"
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:129
+#: static/js/impala/stats/csv_keys.js:129 static/js/zamboni/stats-all.js:15410 static/js/zamboni/stats-min.js:5
 msgid "Downloads and Daily Users, last {0} days"
 msgstr "Shkarkime dhe Përdorues të përditshëm, {0} ditët e fundit"
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:131
+#: static/js/impala/stats/csv_keys.js:131 static/js/zamboni/stats-all.js:15412 static/js/zamboni/stats-min.js:5
 msgid "Downloads and Daily Users from {0} to {1}"
 msgstr "Shkarkime dhe Përdorues të Përditshëm nga {0} te {1}"
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:135
+#: static/js/impala/stats/csv_keys.js:135 static/js/zamboni/stats-all.js:15416 static/js/zamboni/stats-min.js:5
 msgid "Installs and Daily Users, last {0} days"
 msgstr "Instalime dhe Përdorues të Përditshëm, {0} ditët e fundit"
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:137
+#: static/js/impala/stats/csv_keys.js:137 static/js/zamboni/stats-all.js:15418 static/js/zamboni/stats-min.js:5
 msgid "Installs and Daily Users from {0} to {1}"
 msgstr "Instalime dhe Përdorues të Përditshëm nga {0} te {1}"
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:141
+#: static/js/impala/stats/csv_keys.js:141 static/js/zamboni/stats-all.js:15422 static/js/zamboni/stats-min.js:5
 msgid "Downloads, last {0} days"
 msgstr "Shkarkime, {0} ditët e fundit"
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:143
+#: static/js/impala/stats/csv_keys.js:143 static/js/zamboni/stats-all.js:15424 static/js/zamboni/stats-min.js:5
 msgid "Downloads from {0} to {1}"
 msgstr "Shkarkime nga {0} te {1}"
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:147
+#: static/js/impala/stats/csv_keys.js:147 static/js/zamboni/stats-all.js:15428 static/js/zamboni/stats-min.js:5
 msgid "Daily Users, last {0} days"
 msgstr "Përdorues të Përditshëm, {0} ditët e fundit"
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:149
+#: static/js/impala/stats/csv_keys.js:149 static/js/zamboni/stats-all.js:15430 static/js/zamboni/stats-min.js:5
 msgid "Daily Users from {0} to {1}"
 msgstr "Përdorues të Përditshëm nga {0} te {1}"
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:153
+#: static/js/impala/stats/csv_keys.js:153 static/js/zamboni/stats-all.js:15434 static/js/zamboni/stats-min.js:5
 msgid "Applications, last {0} days"
 msgstr "Aplikacione, {0} ditët e fundit"
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:155
+#: static/js/impala/stats/csv_keys.js:155 static/js/zamboni/stats-all.js:15436 static/js/zamboni/stats-min.js:5
 msgid "Applications from {0} to {1}"
 msgstr "Aplikacione nga {0} te {1}"
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:159
+#: static/js/impala/stats/csv_keys.js:159 static/js/zamboni/stats-all.js:15440 static/js/zamboni/stats-min.js:5
 msgid "Platforms, last {0} days"
 msgstr "Platforma, {0} ditët e fundit"
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:161
+#: static/js/impala/stats/csv_keys.js:161 static/js/zamboni/stats-all.js:15442 static/js/zamboni/stats-min.js:5
 msgid "Platforms from {0} to {1}"
 msgstr "Platforma nga {0} te {1}"
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:165
+#: static/js/impala/stats/csv_keys.js:165 static/js/zamboni/stats-all.js:15446 static/js/zamboni/stats-min.js:5
 msgid "Languages, last {0} days"
 msgstr "Gjuhë, {0} ditët e fundit"
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:167
+#: static/js/impala/stats/csv_keys.js:167 static/js/zamboni/stats-all.js:15448 static/js/zamboni/stats-min.js:5
 msgid "Languages from {0} to {1}"
 msgstr "Gjuhë nga {0} te {1}"
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:171
+#: static/js/impala/stats/csv_keys.js:171 static/js/zamboni/stats-all.js:15452 static/js/zamboni/stats-min.js:5
 msgid "Add-on Versions, last {0} days"
 msgstr "Versione Shtesash, {0} ditët e fundit"
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:173
+#: static/js/impala/stats/csv_keys.js:173 static/js/zamboni/stats-all.js:15454 static/js/zamboni/stats-min.js:5
 msgid "Add-on Versions from {0} to {1}"
 msgstr "Versione shtesash nga {0} te {1}"
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:177
+#: static/js/impala/stats/csv_keys.js:177 static/js/zamboni/stats-all.js:15458 static/js/zamboni/stats-min.js:5
 msgid "Add-on Status, last {0} days"
 msgstr "Gjendje Shtesash, {0} ditët e fundit"
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:179
+#: static/js/impala/stats/csv_keys.js:179 static/js/zamboni/stats-all.js:15460 static/js/zamboni/stats-min.js:5
 msgid "Add-on Status from {0} to {1}"
 msgstr "Gjendje Shtesash nga {0} te {1}"
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:183
+#: static/js/impala/stats/csv_keys.js:183 static/js/zamboni/stats-all.js:15464 static/js/zamboni/stats-min.js:5
 msgid "Download Sources, last {0} days"
 msgstr "Burime Shkarkimesh, {0} ditët e fundit"
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:185
+#: static/js/impala/stats/csv_keys.js:185 static/js/zamboni/stats-all.js:15466 static/js/zamboni/stats-min.js:5
 msgid "Download Sources from {0} to {1}"
 msgstr "Burime Shkarkimi nga {0} te {1}"
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:189
+#: static/js/impala/stats/csv_keys.js:189 static/js/zamboni/stats-all.js:15470 static/js/zamboni/stats-min.js:5
 msgid "Contributions, last {0} days"
 msgstr "Kontribute, {0} ditët e fundit"
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:191
+#: static/js/impala/stats/csv_keys.js:191 static/js/zamboni/stats-all.js:15472 static/js/zamboni/stats-min.js:5
 msgid "Contributions from {0} to {1}"
 msgstr "Kontribute nga {0} te {1}"
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:195
+#: static/js/impala/stats/csv_keys.js:195 static/js/zamboni/stats-all.js:15476 static/js/zamboni/stats-min.js:5
 msgid "Site Metrics, last {0} days"
 msgstr "Matje Për Site-in, {0} ditët e fundit"
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:197
+#: static/js/impala/stats/csv_keys.js:197 static/js/zamboni/stats-all.js:15478 static/js/zamboni/stats-min.js:5
 msgid "Site Metrics from {0} to {1}"
 msgstr "Matje Për Site-in nga {0} te {1}"
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:201
+#: static/js/impala/stats/csv_keys.js:201 static/js/zamboni/stats-all.js:15482 static/js/zamboni/stats-min.js:5
 msgid "Add-ons in Use, last {0} days"
 msgstr "Shtesa në Përdorim, {0} ditët e fundit"
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:203
+#: static/js/impala/stats/csv_keys.js:203 static/js/zamboni/stats-all.js:15484 static/js/zamboni/stats-min.js:5
 msgid "Add-ons in Use from {0} to {1}"
 msgstr "Shtesa në Përdorim nga {0} te {1}"
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:207
+#: static/js/impala/stats/csv_keys.js:207 static/js/zamboni/stats-all.js:15488 static/js/zamboni/stats-min.js:5
 msgid "Add-ons Downloaded, last {0} days"
 msgstr "Shtesa të Shkarkuara, {0} ditët e fundit"
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:209
+#: static/js/impala/stats/csv_keys.js:209 static/js/zamboni/stats-all.js:15490 static/js/zamboni/stats-min.js:5
 msgid "Add-ons Downloaded from {0} to {1}"
 msgstr "Shtesa të Shkarkuara nga {0} te {1}"
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:213
+#: static/js/impala/stats/csv_keys.js:213 static/js/zamboni/stats-all.js:15494 static/js/zamboni/stats-min.js:5
 msgid "Add-ons Created, last {0} days"
 msgstr "Shtesa të Krijuara, {0} ditët e fundit"
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:215
+#: static/js/impala/stats/csv_keys.js:215 static/js/zamboni/stats-all.js:15496 static/js/zamboni/stats-min.js:5
 msgid "Add-ons Created from {0} to {1}"
 msgstr "Shtesa të Krijuara nga {0} te {1}"
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:219
+#: static/js/impala/stats/csv_keys.js:219 static/js/zamboni/stats-all.js:15500 static/js/zamboni/stats-min.js:5
 msgid "Add-ons Updated, last {0} days"
 msgstr "Shtesa të Përditësuara, {0} ditët e fundit"
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:221
+#: static/js/impala/stats/csv_keys.js:221 static/js/zamboni/stats-all.js:15502 static/js/zamboni/stats-min.js:5
 msgid "Add-ons Updated from {0} to {1}"
 msgstr "Shtesa të Përditësuara nga {0} te {1}"
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:225
+#: static/js/impala/stats/csv_keys.js:225 static/js/zamboni/stats-all.js:15506 static/js/zamboni/stats-min.js:5
 msgid "Reviews Written, last {0} days"
 msgstr "Shqyrtime të Shkruara, {0} ditët e fundit"
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:227
+#: static/js/impala/stats/csv_keys.js:227 static/js/zamboni/stats-all.js:15508 static/js/zamboni/stats-min.js:5
 msgid "Reviews Written from {0} to {1}"
 msgstr "Shqyrtime të Shkruara nga {0} te {1}"
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:231
+#: static/js/impala/stats/csv_keys.js:231 static/js/zamboni/stats-all.js:15512 static/js/zamboni/stats-min.js:5
 msgid "User Signups, last {0} days"
 msgstr "Regjistrime Përdoruesish, {0} ditët e fundit"
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:233
+#: static/js/impala/stats/csv_keys.js:233 static/js/zamboni/stats-all.js:15514 static/js/zamboni/stats-min.js:5
 msgid "User Signups from {0} to {1}"
 msgstr "Regjistrime Përdoruesish nga {0} te {1}"
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:237
+#: static/js/impala/stats/csv_keys.js:237 static/js/zamboni/stats-all.js:15518 static/js/zamboni/stats-min.js:5
 msgid "Collections Created, last {0} days"
 msgstr "Koleksione të Krijuar, {0} ditët e fundit"
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:239
+#: static/js/impala/stats/csv_keys.js:239 static/js/zamboni/stats-all.js:15520 static/js/zamboni/stats-min.js:5
 msgid "Collections Created from {0} to {1}"
 msgstr "Koleksione të Krijuar nga {0} te {1}"
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:243
+#: static/js/impala/stats/csv_keys.js:243 static/js/zamboni/stats-all.js:15524 static/js/zamboni/stats-min.js:5
 msgid "Subscribers, last {0} days"
 msgstr "Pajtimtarë, {0} ditët e fundit"
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:245
+#: static/js/impala/stats/csv_keys.js:245 static/js/zamboni/stats-all.js:15526 static/js/zamboni/stats-min.js:5
 msgid "Subscribers from {0} to {1}"
 msgstr "Pajtimtarë nga {0} te {1}"
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:249
+#: static/js/impala/stats/csv_keys.js:249 static/js/zamboni/stats-all.js:15530 static/js/zamboni/stats-min.js:5
 msgid "Ratings, last {0} days"
 msgstr "Vlerësime, {0} ditët e fundit"
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:251
+#: static/js/impala/stats/csv_keys.js:251 static/js/zamboni/stats-all.js:15532 static/js/zamboni/stats-min.js:5
 msgid "Ratings from {0} to {1}"
 msgstr "Vlerësime nga {0} te {1}"
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:255
+#: static/js/impala/stats/csv_keys.js:255 static/js/zamboni/stats-all.js:15536 static/js/zamboni/stats-min.js:5
 msgid "Sales, last {0} days"
 msgstr "Shitje, {0} ditët e fundit"
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:257
+#: static/js/impala/stats/csv_keys.js:257 static/js/zamboni/stats-all.js:15538 static/js/zamboni/stats-min.js:5
 msgid "Sales from {0} to {1}"
 msgstr "Shitje nga {0} te {1}"
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:261
+#: static/js/impala/stats/csv_keys.js:261 static/js/zamboni/stats-all.js:15542 static/js/zamboni/stats-min.js:5
 msgid "Installs, last {0} days"
 msgstr "Instalime, {0} ditët e fundit"
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:263
+#: static/js/impala/stats/csv_keys.js:263 static/js/zamboni/stats-all.js:15544 static/js/zamboni/stats-min.js:5
 msgid "Installs from {0} to {1}"
 msgstr "Instalime nga {0} te {1}"
 
 #. L10n: {0} and {1} are integers.
-#: static/js/impala/stats/csv_keys.js:269
+#: static/js/impala/stats/csv_keys.js:269 static/js/zamboni/stats-all.js:15550 static/js/zamboni/stats-min.js:5
 msgid "<b>{0}</b> in last {1} days"
 msgstr "<b>{0}</b> në {1} ditët e fundit"
 
 #. L10n: {0} is an integer and {1} and {2} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:271 static/js/impala/stats/csv_keys.js:277
+#: static/js/impala/stats/csv_keys.js:271 static/js/impala/stats/csv_keys.js:277 static/js/zamboni/stats-all.js:15552 static/js/zamboni/stats-all.js:15558 static/js/zamboni/stats-min.js:5
 msgid "<b>{0}</b> from {1} to {2}"
 msgstr "<b>{0}</b> nga {1} te {2}"
 
 #. L10n: {0} and {1} are integers.
-#: static/js/impala/stats/csv_keys.js:275
+#: static/js/impala/stats/csv_keys.js:275 static/js/zamboni/stats-all.js:15556 static/js/zamboni/stats-min.js:5
 msgid "<b>{0}</b> average in last {1} days"
 msgstr "<b>{0}</b> mesatarisht në {1} ditët e fundit"
 
-#: static/js/impala/stats/overview.js:19
+#: static/js/impala/stats/overview.js:19 static/js/zamboni/stats-all.js:16469 static/js/zamboni/stats-min.js:5
 msgid "No data available."
 msgstr "Pa të dhëna të passhme."
 
-#: static/js/impala/stats/table.js:74
+#: static/js/impala/stats/table.js:74 static/js/zamboni/stats-all.js:17209 static/js/zamboni/stats-min.js:5
 msgid "Date"
 msgstr "Datë"
 
-#: static/js/impala/stats/topchart.js:96
+#: static/js/impala/stats/topchart.js:96 static/js/zamboni/stats-all.js:16600 static/js/zamboni/stats-min.js:5
 msgid "Other"
 msgstr "Tjetër"
 
-#: static/js/zamboni/admin_validation.js:24 static/js/zamboni/devhub.js:1229 static/js/zamboni/editors.js:295
+#: static/js/zamboni/admin-all.js:180 static/js/zamboni/admin-min.js:1 static/js/zamboni/admin_validation.js:24 static/js/zamboni/devhub-all.js:2408 static/js/zamboni/devhub-min.js:2
+#: static/js/zamboni/devhub.js:1229 static/js/zamboni/editors-all.js:15576 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:295
 msgid "Select an application first"
 msgstr "Përzgjidhni së pari një aplikacion"
 
-#: static/js/zamboni/admin_validation.js:51
+#: static/js/zamboni/admin-all.js:207 static/js/zamboni/admin-min.js:1 static/js/zamboni/admin_validation.js:51
 msgid "Set {0} add-on to a max version of {1} and email the author."
 msgid_plural "Set {0} add-ons to a max version of {1} and email the authors."
 msgstr[0] "Caktoji {0} shtese versionin maksimal {1} dhe dërgoji email autorit."
 msgstr[1] "Caktoji {0} shtesave versionin maksimal {1} dhe dërgoji email autorëve."
 
-#: static/js/zamboni/admin_validation.js:54
+#: static/js/zamboni/admin-all.js:210 static/js/zamboni/admin-min.js:1 static/js/zamboni/admin_validation.js:54
 msgid "Email author of {2} add-on which failed validation."
 msgid_plural "Email authors of {2} add-ons which failed validation."
 msgstr[0] "Dërgojini email autorit të {2} shtese që nuk e kaloi vleftësimin."
 msgstr[1] "Dërgojini email autorit të {2} shtesave që nuk e kaluan vleftësimin."
 
-#. L10n: {0} is an app name like Firefox.
-#: static/js/zamboni/buttons.js:66
-msgid "Accept and Install"
-msgstr "Pranoje dhe Instaloje"
-
-#: static/js/zamboni/buttons.js:66
-msgid "Add to {0}"
-msgstr "Shtoje te {0}"
-
-#: static/js/zamboni/buttons.js:71
-msgid "Download Now"
-msgstr "Shkarkojeni Tani"
-
-#: static/js/zamboni/buttons.js:112
-msgid "Add-on has not been updated to support default-to-compatible."
-msgstr "Shtesa nuk është përditësuar për të mbuluar parazgjedhje-në-e-përputhshme."
-
-#: static/js/zamboni/buttons.js:117
-msgid "You need to be using Firefox 10.0 or higher."
-msgstr "Lypset të përdorni Firefox 10.0 ose më të ri."
-
-#: static/js/zamboni/buttons.js:129
-msgid "Mozilla has marked this version as incompatible with your Firefox version."
-msgstr "Mozilla i ka vënë shenjë këtij versioni si i papërputhshëm me versionin tuaj të Firefox-it."
-
-#. L10n: {0} is an platform like Windows or Linux.
-#: static/js/zamboni/buttons.js:210
-msgid "Install for {0} anyway"
-msgstr "Instaloje për {0} sido qoftë"
-
-#: static/js/zamboni/buttons.js:210
-msgid "Download for {0} anyway"
-msgstr "Shkarkoje për {0} sido qoftë"
-
-#: static/js/zamboni/buttons.js:267
-msgid "Not available for your platform"
-msgstr "Jo i passhëm për platformën tuaj"
-
-#. L10n: {0} is an app name, {1} is the app version.
-#: static/js/zamboni/buttons.js:278 static/js/zamboni/buttons.js:315
-msgid "Not available for {0} {1}"
-msgstr "Jo i passhëm për {0} {1}"
-
-#: static/js/zamboni/buttons.js:341
-msgid "Works with {app} {min} - {max}"
-msgstr "Funksionon me {app} {min} - {max}"
-
-#: static/js/zamboni/buttons.js:343
-msgid "View other versions"
-msgstr "Shihni versione të tjera"
-
-#: static/js/zamboni/buttons.js:391
-msgid "Only with Firefox — Get Firefox Now!"
-msgstr "Vetëm me Firefox  — Merreni Firefox-in Tani!"
-
-#: static/js/zamboni/buttons.js:507 static/js/zamboni/mobile/buttons.js:43
-msgid "Sorry, you need a Mozilla-based browser (such as Firefox) to install a search plugin."
-msgstr "Na ndjeni, për të instaluar një shtojcë kërkimi lypset të kini një shfletues me bazë Mozilla (si Firefox-i)."
-
-#: static/js/zamboni/collections.js:229
-msgid "Adding to Favorites&hellip;"
-msgstr "Po shtohet te Të parapëlqyerit&hellip;"
-
-#: static/js/zamboni/collections.js:232
-msgid "Removing Favorite&hellip;"
-msgstr "Po hiqet prej Të parapëlqyerve&hellip;"
-
-#: static/js/zamboni/collections.js:235
-msgid "Add to Favorites"
-msgstr "Shtoje te Të parapëlqyerit"
-
-#: static/js/zamboni/collections.js:238
-msgid "Remove from Favorites"
-msgstr "Hiqe prej Të parapëlqyerve"
-
-#: static/js/zamboni/collections.js:303
-msgid "Pending"
-msgstr "Në pritje"
-
-#: static/js/zamboni/collections.js:304
-msgid "Add a comment"
-msgstr "Shtoni një koment"
-
-#: static/js/zamboni/collections.js:304
-msgid "Comment"
-msgstr "Koment"
-
-#: static/js/zamboni/collections.js:305
-msgid "Remove this add-on from the collection"
-msgstr "Hiqe këtë shtesë prej koleksionit"
-
-#: static/js/zamboni/collections.js:305 static/js/zamboni/collections.js:334
-msgid "Remove"
-msgstr "Hiqe"
-
-#: static/js/zamboni/collections.js:334
-msgid "Remove this user as a contributor"
-msgstr "Hiqe këtë përdorues si kontribues"
-
-#: static/js/zamboni/collections.js:346
-msgid "An email address is required."
-msgstr "Lypset një adresë email."
-
-#: static/js/zamboni/collections.js:364
-msgid "You cannot add yourself as a contributor."
-msgstr "Nuk mund të shtoni vetveten si kontribues."
-
-#: static/js/zamboni/collections.js:366
-msgid "You have already added that user."
-msgstr "E keni shtuar një herë atë përdorues."
-
-#: static/js/zamboni/collections.js:573
-msgid "Add to favorites"
-msgstr "Shtojeni te të parapëlqyerit"
-
-#: static/js/zamboni/collections.js:577
-msgid "Remove from favorites"
-msgstr "Hiqe prej të parapëlqyerve"
-
-#: static/js/zamboni/collections.js:604
-msgid "Stop following"
-msgstr "Resht së ndjekuri"
-
-#: static/js/zamboni/devhub.js:110
+#: static/js/zamboni/devhub-all.js:1289 static/js/zamboni/devhub-min.js:1 static/js/zamboni/devhub.js:110
 msgid "Your browser does not support the video tag"
 msgstr "Shfletuesi juaj nuk e mbulon etiketën video"
 
-#: static/js/zamboni/devhub.js:371
+#: static/js/zamboni/devhub-all.js:1550 static/js/zamboni/devhub-min.js:1 static/js/zamboni/devhub.js:371
 msgid "Changes Saved"
 msgstr "Ndryshimet u Ruajtën"
 
-#: static/js/zamboni/devhub.js:387
+#: static/js/zamboni/devhub-all.js:1566 static/js/zamboni/devhub-min.js:1 static/js/zamboni/devhub.js:387
 msgid "Enter a new author's email address"
 msgstr "Jepni adresën email të autorit të ri"
 
-#: static/js/zamboni/devhub.js:536
+#: static/js/zamboni/devhub-all.js:1715 static/js/zamboni/devhub-min.js:1 static/js/zamboni/devhub.js:536
 msgid "There was an error uploading your file."
 msgstr "Pati një gabim gjatë ngarkimit të kartelës suaj."
 
-#: static/js/zamboni/devhub.js:681
+#: static/js/zamboni/devhub-all.js:1860 static/js/zamboni/devhub-min.js:1 static/js/zamboni/devhub.js:681
 msgid "{files} file"
 msgid_plural "{files} files"
 msgstr[0] "{files} kartelë"
 msgstr[1] "{files} kartela"
 
-#: static/js/zamboni/devhub.js:684
+#: static/js/zamboni/devhub-all.js:1863 static/js/zamboni/devhub-min.js:1 static/js/zamboni/devhub.js:684
 msgid "{reviews} user review"
 msgid_plural "{reviews} user reviews"
 msgstr[0] "{reviews} shqyrtim përdoruesi"
 msgstr[1] "{reviews} shqyrtime përdoruesi"
 
-#: static/js/zamboni/devhub.js:796
+#: static/js/zamboni/devhub-all.js:1975 static/js/zamboni/devhub-min.js:2 static/js/zamboni/devhub.js:796
 msgid "Learn more"
 msgstr "Mësoni më tepër"
 
-#: static/js/zamboni/devhub.js:800
+#: static/js/zamboni/devhub-all.js:1979 static/js/zamboni/devhub-min.js:2 static/js/zamboni/devhub.js:800
 msgid "Example"
 msgstr "Shembull"
 
-#: static/js/zamboni/devhub.js:1130
+#: static/js/zamboni/devhub-all.js:2309 static/js/zamboni/devhub-min.js:2 static/js/zamboni/devhub.js:1130
 msgid "Image changes being processed"
 msgstr "Po përpunohen ndryshimet e figurës"
 
-#: static/js/zamboni/devhub.js:1280
+#: static/js/zamboni/devhub-all.js:2459 static/js/zamboni/devhub-min.js:2 static/js/zamboni/devhub.js:1280
 msgid "Must be a valid e-mail address."
 msgstr "Duhet të jetë një adresë e-mail e vlefshme."
 
-#: static/js/zamboni/devhub_search.js:8
-msgid "No results found."
-msgstr "Nuk u gjetën përfundime."
-
-#: static/js/zamboni/editors.js:121
-msgid "{name} was viewing this page first."
-msgstr "{name} po e shihte së pari këtë faqe."
-
-#: static/js/zamboni/editors.js:171
-msgid "Receipt checked by app."
-msgstr "Dëftesa u kontrollua nga aplikacioni."
-
-#: static/js/zamboni/editors.js:173
-msgid "Receipt was not checked by app."
-msgstr "Dëftesa nuk qe kontrolluar nga aplikacioni."
-
-#: static/js/zamboni/editors.js:244
-msgid "{name} was viewing this add-on first."
-msgstr "{name} po e shihte i pari këtë shtesë."
-
-#: static/js/zamboni/editors.js:255
-msgid "Loading&hellip;"
-msgstr "Po ngarkohet&hellip;"
-
-#: static/js/zamboni/editors.js:260
-msgid "Version Notes"
-msgstr "Shënime Versioni"
-
-#: static/js/zamboni/editors.js:265
-msgid "Notes for Reviewers"
-msgstr "Shënime për Shqyrtuesit"
-
-#: static/js/zamboni/editors.js:270
-msgid "No version notes found"
-msgstr "S'u gjetën shënime versioni"
-
-#: static/js/zamboni/editors.js:330
-msgid "Average Reviews"
-msgstr "Shqyrtime Mesatarisht"
-
-#: static/js/zamboni/editors.js:386
-msgid "Number of Reviews"
-msgstr "Numër Shqyrtimesh"
-
-#: static/js/zamboni/editors.js:445
-msgid "Error loading translation"
-msgstr "Gabim gjatë ngarkimit të përkthimit"
-
-#: static/js/zamboni/files.js:411 static/js/zamboni/validator.js:261
-msgid "Ignore this message in future updates"
-msgstr "Shpërfille këtë mesazh gjatë përditësimesh të ardhshme"
-
-#: static/js/zamboni/files.js:417 static/js/zamboni/validator.js:284
-msgid "Severity for automated signing:"
-msgstr ""
-
-#: static/js/zamboni/global.js:410
-msgid "Loading..."
-msgstr "Po ngarkohet..."
-
-#. L10n: {0} is the number of characters left.
-#: static/js/zamboni/global.js:474
-msgid "<b>{0}</b> character left."
-msgid_plural "<b>{0}</b> characters left."
-msgstr[0] "Edhe <b>{0}</b> shenjë."
-msgstr[1] "Edhe <b>{0}</b> shenja."
-
-#: static/js/zamboni/init.js:28
-msgid "This feature is temporarily disabled while we perform website maintenance. Please check back a little later."
-msgstr "Kjo veçori është çaktivizuar përkohësisht, teksa bëjmë mirëmbajtjen e \"site\"-it web. Ju lutemi, riprovoni pas pak."
-
-#: static/js/zamboni/l10n.js:45
-msgid "Remove this localization"
-msgstr "Hiqe këtë përkthim"
-
-#: static/js/zamboni/password-strength.js:20
-msgid "Password strength:"
-msgstr "Fortësi fjalëkalimi:"
-
-#: static/js/zamboni/password-strength.js:26
-msgid "At least {0} character left."
-msgid_plural "At least {0} characters left."
-msgstr[0] "Të paktën edhe <b>{0}</b> shenjë."
-msgstr[1] "Të paktën edhe <b>{0}</b> shenja."
-
-#: static/js/zamboni/themes_review.js:176
-msgid "Requested Info"
-msgstr "Të dhëna të Domosdoshme"
-
-#: static/js/zamboni/themes_review.js:177
-msgid "Flagged"
-msgstr "Me shenjë"
-
-#: static/js/zamboni/themes_review.js:178
-msgid "Duplicate"
-msgstr "Përsëdytje"
-
-#: static/js/zamboni/themes_review.js:179
-msgid "Rejected"
-msgstr "Hedhur tej"
-
-#: static/js/zamboni/themes_review.js:180
-msgid "Approved"
-msgstr "Miratuar"
-
-#: static/js/zamboni/themes_review.js:424
-msgid "No results found"
-msgstr "S’u gjetën përfundime"
-
-#: static/js/zamboni/themes_review_templates.js:31
-msgid "Theme"
-msgstr "Temë"
-
-#: static/js/zamboni/themes_review_templates.js:33
-msgid "Reviewer"
-msgstr "Shqyrtues"
-
-#: static/js/zamboni/themes_review_templates.js:35
-msgid "Status"
-msgstr "Gjendje"
-
-#: static/js/zamboni/validator.js:80
+#: static/js/zamboni/devhub-all.js:2613 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:80
 msgid "All tests passed successfully."
 msgstr "Krejt provat u kaluan me sukses."
 
-#: static/js/zamboni/validator.js:83 static/js/zamboni/validator.js:478
+#: static/js/zamboni/devhub-all.js:2616 static/js/zamboni/devhub-all.js:3011 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:83 static/js/zamboni/validator.js:478
 msgid "These tests were not run."
 msgstr "Këto prova nuk u xhiruan."
 
-#: static/js/zamboni/validator.js:131 static/js/zamboni/validator.js:144
+#: static/js/zamboni/devhub-all.js:2664 static/js/zamboni/devhub-all.js:2677 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:131 static/js/zamboni/validator.js:144
 msgid "Tests"
 msgstr "Prova"
 
-#: static/js/zamboni/validator.js:246 static/js/zamboni/validator.js:575 static/js/zamboni/validator.js:594
+#: static/js/zamboni/devhub-all.js:2779 static/js/zamboni/devhub-all.js:3108 static/js/zamboni/devhub-all.js:3127 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:246
+#: static/js/zamboni/validator.js:575 static/js/zamboni/validator.js:594
 msgid "Error"
 msgstr "Gabim"
 
-#: static/js/zamboni/validator.js:247
+#: static/js/zamboni/devhub-all.js:2780 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:247
 msgid "Warning"
 msgstr "Sinjalizim"
 
-#: static/js/zamboni/validator.js:299
+#: static/js/zamboni/devhub-all.js:2794 static/js/zamboni/devhub-min.js:2 static/js/zamboni/files-all.js:5657 static/js/zamboni/files-min.js:3 static/js/zamboni/files.js:411
+#: static/js/zamboni/validator.js:261
+msgid "Ignore this message in future updates"
+msgstr "Shpërfille këtë mesazh gjatë përditësimesh të ardhshme"
+
+#: static/js/zamboni/devhub-all.js:2817 static/js/zamboni/devhub-min.js:2 static/js/zamboni/files-all.js:5663 static/js/zamboni/files-min.js:3 static/js/zamboni/files.js:417
+#: static/js/zamboni/validator.js:284
+msgid "Severity for automated signing:"
+msgstr ""
+
+#: static/js/zamboni/devhub-all.js:2832 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:299
 msgid "Suggestions for passing automated signing:"
 msgstr "Këshillime për të kaluar me sukses nënshkrimin e automatizuar:"
 
-#: static/js/zamboni/validator.js:387
+#: static/js/zamboni/devhub-all.js:2920 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:387
 msgid "Compatibility Tests"
 msgstr "Prova Përputhshmërie"
 
-#: static/js/zamboni/validator.js:466
+#: static/js/zamboni/devhub-all.js:2999 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:466
 msgid "Add-on failed validation."
 msgstr "Shtesa nuk e kaloi provën e vleftësimit."
 
-#: static/js/zamboni/validator.js:468
+#: static/js/zamboni/devhub-all.js:3001 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:468
 msgid "Add-on passed validation."
 msgstr "Shtesa e kaloi provën e vleftësimit."
 
-#: static/js/zamboni/validator.js:481
+#: static/js/zamboni/devhub-all.js:3014 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:481
 msgid "{0} error"
 msgid_plural "{0} errors"
 msgstr[0] "{0} gabim"
 msgstr[1] "{0} gabime"
 
-#: static/js/zamboni/validator.js:483
+#: static/js/zamboni/devhub-all.js:3016 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:483
 msgid "{0} warning"
 msgid_plural "{0} warnings"
 msgstr[0] "{0} sinjalizim"
 msgstr[1] "{0} sinjalizime"
 
-#: static/js/zamboni/validator.js:485
+#: static/js/zamboni/devhub-all.js:3018 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:485
 msgid "{0} notice"
 msgid_plural "{0} notices"
 msgstr[0] "{0} njoftim"
 msgstr[1] "{0} njoftime"
 
-#: static/js/zamboni/validator.js:577
+#: static/js/zamboni/devhub-all.js:3110 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:577
 msgid "Validation task could not complete or completed with errors"
 msgstr "Akti i vleftësimit nuk u plotësua dot ose u plotësua me gabime"
 
-#: static/js/zamboni/validator.js:595
+#: static/js/zamboni/devhub-all.js:3128 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:595
 msgid "Internal server error"
 msgstr "Gabim i brendshëm shërbyesi"
 
-#: static/js/zamboni/mobile/buttons.js:52
+#: static/js/zamboni/devhub_search.js:8
+msgid "No results found."
+msgstr "Nuk u gjetën përfundime."
+
+#: static/js/zamboni/editors-all.js:15402 static/js/zamboni/editors-min.js:4 static/js/zamboni/editors.js:121
+msgid "{name} was viewing this page first."
+msgstr "{name} po e shihte së pari këtë faqe."
+
+#: static/js/zamboni/editors-all.js:15452 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:171
+msgid "Receipt checked by app."
+msgstr "Dëftesa u kontrollua nga aplikacioni."
+
+#: static/js/zamboni/editors-all.js:15454 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:173
+msgid "Receipt was not checked by app."
+msgstr "Dëftesa nuk qe kontrolluar nga aplikacioni."
+
+#: static/js/zamboni/editors-all.js:15525 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:244
+msgid "{name} was viewing this add-on first."
+msgstr "{name} po e shihte i pari këtë shtesë."
+
+#: static/js/zamboni/editors-all.js:15536 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:255
+msgid "Loading&hellip;"
+msgstr "Po ngarkohet&hellip;"
+
+#: static/js/zamboni/editors-all.js:15541 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:260
+msgid "Version Notes"
+msgstr "Shënime Versioni"
+
+#: static/js/zamboni/editors-all.js:15546 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:265
+msgid "Notes for Reviewers"
+msgstr "Shënime për Shqyrtuesit"
+
+#: static/js/zamboni/editors-all.js:15551 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:270
+msgid "No version notes found"
+msgstr "S'u gjetën shënime versioni"
+
+#: static/js/zamboni/editors-all.js:15611 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:330
+msgid "Average Reviews"
+msgstr "Shqyrtime Mesatarisht"
+
+#: static/js/zamboni/editors-all.js:15667 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:386
+msgid "Number of Reviews"
+msgstr "Numër Shqyrtimesh"
+
+#: static/js/zamboni/editors-all.js:15726 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:445
+msgid "Error loading translation"
+msgstr "Gabim gjatë ngarkimit të përkthimit"
+
+#: static/js/zamboni/editors-all.js:15975 static/js/zamboni/editors-min.js:5 static/js/zamboni/themes_review_templates.js:31
+msgid "Theme"
+msgstr "Temë"
+
+#: static/js/zamboni/editors-all.js:15977 static/js/zamboni/editors-min.js:5 static/js/zamboni/themes_review_templates.js:33
+msgid "Reviewer"
+msgstr "Shqyrtues"
+
+#: static/js/zamboni/editors-all.js:15979 static/js/zamboni/editors-min.js:5 static/js/zamboni/themes_review_templates.js:35
+msgid "Status"
+msgstr "Gjendje"
+
+#: static/js/zamboni/editors-all.js:16196 static/js/zamboni/editors-min.js:5 static/js/zamboni/themes_review.js:176
+msgid "Requested Info"
+msgstr "Të dhëna të Domosdoshme"
+
+#: static/js/zamboni/editors-all.js:16197 static/js/zamboni/editors-min.js:5 static/js/zamboni/themes_review.js:177
+msgid "Flagged"
+msgstr "Me shenjë"
+
+#: static/js/zamboni/editors-all.js:16198 static/js/zamboni/editors-min.js:5 static/js/zamboni/themes_review.js:178
+msgid "Duplicate"
+msgstr "Përsëdytje"
+
+#: static/js/zamboni/editors-all.js:16199 static/js/zamboni/editors-min.js:5 static/js/zamboni/themes_review.js:179
+msgid "Rejected"
+msgstr "Hedhur tej"
+
+#: static/js/zamboni/editors-all.js:16200 static/js/zamboni/editors-min.js:5 static/js/zamboni/themes_review.js:180
+msgid "Approved"
+msgstr "Miratuar"
+
+#: static/js/zamboni/editors-all.js:16444 static/js/zamboni/editors-min.js:5 static/js/zamboni/themes_review.js:424
+msgid "No results found"
+msgstr "S’u gjetën përfundime"
+
+#: static/js/zamboni/mobile-all.js:15186 static/js/zamboni/mobile/buttons.js:52
 msgid "Not Updated for {0} {1}"
 msgstr "Nuk Është Përditësuar për {0} {1}"
 
-#: static/js/zamboni/mobile/buttons.js:53
+#: static/js/zamboni/mobile-all.js:15187 static/js/zamboni/mobile/buttons.js:53
 msgid "Requires Newer Version of {0}"
 msgstr "Lyp Version Më të Ri të {0}"
 
-#: static/js/zamboni/mobile/buttons.js:54
+#: static/js/zamboni/mobile-all.js:15188 static/js/zamboni/mobile/buttons.js:54
 msgid "Unreviewed"
 msgstr "Të pashqyrtuara"
 
-#: static/js/zamboni/mobile/buttons.js:55
+#: static/js/zamboni/mobile-all.js:15189 static/js/zamboni/mobile/buttons.js:55
 msgid "Experimental <span>(Learn More)</span>"
 msgstr "Eksperimentale <span>(Mësoni Më Tepër)</span>"
 
-#: static/js/zamboni/mobile/buttons.js:56 static/js/zamboni/mobile/buttons.js:57
+#: static/js/zamboni/mobile-all.js:15190 static/js/zamboni/mobile-all.js:15191 static/js/zamboni/mobile/buttons.js:56 static/js/zamboni/mobile/buttons.js:57
 msgid "Not Available for {0}"
 msgstr "Jo i Passhëm për {0}"
 
-#: static/js/zamboni/mobile/buttons.js:58
+#: static/js/zamboni/mobile-all.js:15192 static/js/zamboni/mobile/buttons.js:58
 msgid "Experimental"
 msgstr "Eksperimentale"
 
-#: static/js/zamboni/mobile/buttons.js:59
+#: static/js/zamboni/mobile-all.js:15193 static/js/zamboni/mobile/buttons.js:59
 msgid "Themes Require Newer Version of {0}"
 msgstr "Temat Lypin Version Më të Ri të {0}"
 
-#: static/js/zamboni/mobile/buttons.js:60
+#: static/js/zamboni/mobile-all.js:15194 static/js/zamboni/mobile/buttons.js:60
 msgid "Themes Require {0}"
 msgstr "Temat Lypin {0}"
 
-#: static/js/zamboni/mobile/buttons.js:105
+#: static/js/zamboni/mobile-all.js:15239 static/js/zamboni/mobile/buttons.js:105
 msgid "Installing..."
 msgstr "Po instalohet..."
 
-#: static/js/zamboni/mobile/buttons.js:125
+#: static/js/zamboni/mobile-all.js:15259 static/js/zamboni/mobile/buttons.js:125
 msgid "This add-on has been preliminarily reviewed by Mozilla."
 msgstr "Kjo shtesë është shqyrtuar paraprakisht nga Mozilla."
 
-#: static/js/zamboni/mobile/buttons.js:250
+#: static/js/zamboni/mobile-all.js:15384 static/js/zamboni/mobile/buttons.js:250
 msgid "Keep it"
 msgstr "Mbaje"
 
-#: static/js/zamboni/mobile/general.js:344
+#: static/js/zamboni/mobile-all.js:16049 static/js/zamboni/mobile-min.js:6 static/js/zamboni/mobile/general.js:344
 msgid "You're trying it on!"
 msgstr "Po e provoni!"
 
-#: static/js/zamboni/mobile/general.js:356
+#: static/js/zamboni/mobile-all.js:16061 static/js/zamboni/mobile-min.js:6 static/js/zamboni/mobile/general.js:356
 msgid "Added to Firefox"
 msgstr "U shtua te Firefox-i"
-

--- a/locale/sr/LC_MESSAGES/django.po
+++ b/locale/sr/LC_MESSAGES/django.po
@@ -5,7 +5,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version:  addons\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2016-02-24 21:23+0000\n"
+"POT-Creation-Date: 2016-04-18 15:40+0000\n"
 "PO-Revision-Date: 2015-02-07 12:40+0000\n"
 "Last-Translator: Vanja <tumbas93@gmail.com>\n"
 "Language-Team: sr\n"
@@ -14,60 +14,60 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Generated-By: Babel 2.2.0\n"
 
-#: src/olympia/accounts/views.py:52
+#: src/olympia/accounts/views.py:54
 msgid "Your log in attempt could not be parsed. Please try again."
 msgstr ""
 
-#: src/olympia/accounts/views.py:54
+#: src/olympia/accounts/views.py:56
 msgid "Your Firefox Account could not be found. Please try again."
 msgstr ""
 
-#: src/olympia/accounts/views.py:55
+#: src/olympia/accounts/views.py:57
 msgid "You could not be logged in. Please try again."
 msgstr ""
 
-#: src/olympia/accounts/views.py:57
+#: src/olympia/accounts/views.py:59
 msgid "Your account has already been migrated to Firefox Accounts."
 msgstr ""
 
-#: src/olympia/accounts/views.py:59
+#: src/olympia/accounts/views.py:61
 msgid "Your Firefox Account already exists on this site."
 msgstr ""
 
-#: src/olympia/accounts/views.py:108
+#: src/olympia/accounts/views.py:110
 msgid "Great job!"
 msgstr ""
 
-#: src/olympia/accounts/views.py:109
+#: src/olympia/accounts/views.py:111
 msgid "You can now log in to Add-ons with your Firefox Account."
 msgstr ""
 
-#: src/olympia/accounts/views.py:121
+#: src/olympia/accounts/views.py:123
 msgid "Need help?"
 msgstr ""
 
-#: src/olympia/addons/buttons.py:180
+#: src/olympia/addons/buttons.py:177
 msgid "Download Now"
 msgstr "Преузми одмах"
 
-#: src/olympia/addons/buttons.py:182
+#: src/olympia/addons/buttons.py:179
 msgid "Download"
 msgstr "Преузми"
 
 #. L10n: please keep &nbsp; in the string so &rarr; does not wrap.
-#: src/olympia/addons/buttons.py:186
+#: src/olympia/addons/buttons.py:183
 msgid "Continue to Download&nbsp;&rarr;"
 msgstr "Наставите до преузимања&nbsp;&rarr;"
 
-#: src/olympia/addons/buttons.py:202 src/olympia/addons/helpers.py:35 src/olympia/addons/views.py:319 src/olympia/addons/templates/addons/impala/details.html:114
+#: src/olympia/addons/buttons.py:199 src/olympia/addons/helpers.py:35 src/olympia/addons/views.py:333 src/olympia/addons/templates/addons/impala/details.html:111
 #: src/olympia/addons/templates/addons/impala/listing/items.html:17 src/olympia/addons/templates/addons/mobile/home.html:40 src/olympia/amo/templates/amo/side_nav.html:6
-#: src/olympia/amo/templates/amo/side_nav.html:10 src/olympia/amo/templates/amo/site_nav.html:2 src/olympia/amo/templates/amo/site_nav.html:55 src/olympia/bandwagon/views.py:95
-#: src/olympia/browse/views.py:54 src/olympia/browse/views.py:68 src/olympia/browse/views.py:235 src/olympia/browse/templates/browse/impala/category_landing.html:22
+#: src/olympia/amo/templates/amo/side_nav.html:10 src/olympia/amo/templates/amo/site_nav.html:2 src/olympia/amo/templates/amo/site_nav.html:53 src/olympia/bandwagon/views.py:95
+#: src/olympia/browse/views.py:54 src/olympia/browse/views.py:68 src/olympia/browse/views.py:202 src/olympia/browse/templates/browse/impala/category_landing.html:22
 #: src/olympia/browse/templates/browse/personas/mobile/category_landing.html:26
 msgid "Featured"
 msgstr "Издвојено"
 
-#: src/olympia/addons/buttons.py:221
+#: src/olympia/addons/buttons.py:218
 msgid "Add to {0}"
 msgstr "Додај у {0}"
 
@@ -90,7 +90,6 @@ msgid "Invalid tag: {0}"
 msgid_plural "Invalid tags: {0}"
 msgstr[0] "Неисправна ознака: {0}"
 msgstr[1] "Неисправне ознаке: {0}"
-msgstr[2] "Неисправне ознаке: {0}"
 
 #. L10n: {0} is a single tag or a comma-separated list of tags.
 #: src/olympia/addons/forms.py:103
@@ -98,14 +97,12 @@ msgid "\"{0}\" is a reserved tag and cannot be used."
 msgid_plural "\"{0}\" are reserved tags and cannot be used."
 msgstr[0] "\"{0}\" је резервисана ознака која се не може користити."
 msgstr[1] "\"{0}\" су резервисане ознаке које се не могу користити."
-msgstr[2] "\"{0}\" су резервисане ознаке које се не могу користити."
 
 #: src/olympia/addons/forms.py:111
 msgid "You have {0} too many tags."
 msgid_plural "You have {0} too many tags."
 msgstr[0] "Имате {0} превише ознака."
 msgstr[1] "Имате {0} превише ознака."
-msgstr[2] "Имате {0} превише ознака."
 
 #: src/olympia/addons/forms.py:117
 #, python-format
@@ -117,42 +114,40 @@ msgid "All tags must be at least {0} character."
 msgid_plural "All tags must be at least {0} characters."
 msgstr[0] "Све ознаке морају садржати најмање {0} карактер."
 msgstr[1] "Све ознаке морају садржати најмање {0} карактера."
-msgstr[2] "Све ознаке морају садржати најмање {0} карактера."
 
-#: src/olympia/addons/forms.py:234
+#: src/olympia/addons/forms.py:238
 msgid "Categories cannot be changed while your add-on is featured for this application."
 msgstr "Категорије се не могу изменити док је Ваш додатак издвојен за ову апликацију."
 
 #. L10n: {0} is the number of categories.
-#: src/olympia/addons/forms.py:238
+#: src/olympia/addons/forms.py:242
 msgid "You can have only {0} category."
 msgid_plural "You can have only {0} categories."
 msgstr[0] "Можете имати само {0} категорију."
 msgstr[1] "Можете имати само {0} категорије."
-msgstr[2] "Можете имати само {0} категорија."
 
-#: src/olympia/addons/forms.py:246
+#: src/olympia/addons/forms.py:250
 msgid "The miscellaneous category cannot be combined with additional categories."
 msgstr "Категорија Остало се не може спојити са додатним категоријама."
 
-#: src/olympia/addons/forms.py:369
+#: src/olympia/addons/forms.py:374
 #, python-format
 msgid "Before changing your default locale you must have a name, summary, and description in that locale. You are missing %s."
 msgstr "Пре него што измените подразумевани простор, морате имати име, кратак преглед и опис у том простору. Недостаје Вам %s."
 
-#: src/olympia/addons/forms.py:484 src/olympia/addons/forms.py:575
+#: src/olympia/addons/forms.py:455 src/olympia/addons/forms.py:546
 msgid "A license must be selected."
 msgstr "Лиценца мора бити изабрана."
 
-#: src/olympia/addons/forms.py:556
+#: src/olympia/addons/forms.py:527
 msgid "Give Your Theme a Name."
 msgstr "Дајте име Вашој теми."
 
-#: src/olympia/addons/forms.py:562 src/olympia/devhub/templates/devhub/personas/submit.html:53
+#: src/olympia/addons/forms.py:533 src/olympia/devhub/templates/devhub/personas/submit.html:53
 msgid "Describe your Theme."
 msgstr "Опишите Вашу тему."
 
-#: src/olympia/addons/forms.py:704
+#: src/olympia/addons/forms.py:675
 msgid "Enter a new author's email address"
 msgstr "Додајте адресу е-поште новог аутора"
 
@@ -160,39 +155,39 @@ msgstr "Додајте адресу е-поште новог аутора"
 msgid "Not Reviewed"
 msgstr "Није оцењено"
 
-#: src/olympia/addons/models.py:301
+#: src/olympia/addons/models.py:298
 msgid "Users have the option of contributing more or less than this amount."
 msgstr "Корисници имају опцију да доприносе више или мање од ове количине."
 
-#: src/olympia/addons/models.py:309
-msgid "Users will always be asked in the Add-ons Manager (Firefox 4 and above)"
-msgstr "Корисници ће увек бити питани у меџеру за додатке (Firefox 4 и новије)"
+#: src/olympia/addons/models.py:306
+msgid "Users will always be asked in the Add-ons Manager (Firefox 4 and above). Only applies to desktop."
+msgstr ""
 
 # Column name in a table.
-#: src/olympia/addons/models.py:1804 src/olympia/addons/templates/addons/details_box.html:55 src/olympia/devhub/templates/devhub/index.html:92
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:102
+#: src/olympia/addons/models.py:1802 src/olympia/addons/templates/addons/details_box.html:55 src/olympia/devhub/templates/devhub/index.html:92
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:89
 msgid "Listed"
 msgstr "Наведене"
 
-#: src/olympia/addons/views.py:320 src/olympia/browse/templates/browse/personas/mobile/category_landing.html:27
+#: src/olympia/addons/views.py:334 src/olympia/browse/templates/browse/personas/mobile/category_landing.html:27
 msgid "Popular"
 msgstr "Популарно"
 
-#: src/olympia/addons/views.py:321 src/olympia/browse/views.py:238 src/olympia/browse/views.py:280 src/olympia/browse/views.py:482
+#: src/olympia/addons/views.py:335 src/olympia/browse/views.py:205 src/olympia/browse/views.py:247 src/olympia/browse/views.py:449
 msgid "Recently Added"
 msgstr "Недавно додато"
 
-#: src/olympia/addons/views.py:322 src/olympia/bandwagon/views.py:99 src/olympia/browse/views.py:60 src/olympia/browse/views.py:71 src/olympia/search/forms.py:16 src/olympia/search/forms.py:91
+#: src/olympia/addons/views.py:336 src/olympia/bandwagon/views.py:99 src/olympia/browse/views.py:60 src/olympia/browse/views.py:71 src/olympia/search/forms.py:16 src/olympia/search/forms.py:91
 msgid "Recently Updated"
 msgstr "Недавно ажурирано"
 
 # %1 is an add-on name.
 #. l10n: {0} is the addon name
-#: src/olympia/addons/views.py:520
+#: src/olympia/addons/views.py:534
 msgid "Contribution for {0}"
 msgstr "Доприноси за {0}"
 
-#: src/olympia/addons/views.py:613
+#: src/olympia/addons/views.py:627
 msgid "Abuse reported."
 msgstr "Злостављање је пријављено."
 
@@ -261,9 +256,9 @@ msgstr "Приложи"
 #: src/olympia/devhub/templates/devhub/addons/ajax_compat_update.html:36 src/olympia/devhub/templates/devhub/addons/profile.html:44 src/olympia/devhub/templates/devhub/addons/edit/admin.html:101
 #: src/olympia/devhub/templates/devhub/addons/edit/basic.html:152 src/olympia/devhub/templates/devhub/addons/edit/details.html:85 src/olympia/devhub/templates/devhub/addons/edit/support.html:67
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:166 src/olympia/devhub/templates/devhub/addons/forms_shared/media.html:149
-#: src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:44 src/olympia/devhub/templates/devhub/versions/add_file_modal.html:78 src/olympia/devhub/templates/devhub/versions/edit.html:139
-#: src/olympia/devhub/templates/devhub/versions/list.html:242 src/olympia/devhub/templates/devhub/versions/list.html:276 src/olympia/devhub/templates/devhub/versions/list.html:317
-#: src/olympia/devhub/templates/devhub/versions/list.html:351 src/olympia/reviews/templates/reviews/edit_review.html:16 src/olympia/translations/templates/translations/trans-menu.html:50
+#: src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:43 src/olympia/devhub/templates/devhub/versions/add_file_modal.html:58 src/olympia/devhub/templates/devhub/versions/edit.html:139
+#: src/olympia/devhub/templates/devhub/versions/list.html:239 src/olympia/devhub/templates/devhub/versions/list.html:281 src/olympia/devhub/templates/devhub/versions/list.html:315
+#: src/olympia/devhub/templates/devhub/versions/list.html:349 src/olympia/reviews/templates/reviews/edit_review.html:16 src/olympia/translations/templates/translations/trans-menu.html:50
 #: src/olympia/translations/templates/translations/trans-menu.html:62
 msgid "or"
 msgstr "или"
@@ -375,7 +370,7 @@ msgid "Add-on Information for {0}"
 msgstr "Информације о {0} додатку"
 
 #: src/olympia/addons/templates/addons/details_box.html:30 src/olympia/addons/templates/addons/persona_detail_table.html:3 src/olympia/addons/templates/addons/mobile/details.html:63
-#: src/olympia/addons/templates/addons/mobile/persona_detail_table.html:7 src/olympia/browse/views.py:459 src/olympia/devhub/views.py:75
+#: src/olympia/addons/templates/addons/mobile/persona_detail_table.html:7 src/olympia/browse/views.py:426 src/olympia/devhub/views.py:74
 msgid "Updated"
 msgstr "Ажурирано"
 
@@ -394,11 +389,11 @@ msgstr "Ради са"
 msgid "Visibility"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/details_box.html:57 src/olympia/devhub/templates/devhub/index.html:94 src/olympia/devhub/templates/devhub/includes/addon_details.html:104
+#: src/olympia/addons/templates/addons/details_box.html:57 src/olympia/devhub/templates/devhub/index.html:94 src/olympia/devhub/templates/devhub/includes/addon_details.html:91
 msgid "Hidden"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/details_box.html:59 src/olympia/devhub/templates/devhub/index.html:96 src/olympia/devhub/templates/devhub/includes/addon_details.html:106
+#: src/olympia/addons/templates/addons/details_box.html:59 src/olympia/devhub/templates/devhub/index.html:96 src/olympia/devhub/templates/devhub/includes/addon_details.html:93
 msgid "Unlisted"
 msgstr ""
 
@@ -406,13 +401,13 @@ msgstr ""
 msgid "Required Add-ons"
 msgstr "Неопходни додаци"
 
-#: src/olympia/addons/templates/addons/details_box.html:81 src/olympia/addons/templates/addons/persona_detail_table.html:15 src/olympia/browse/views.py:462 src/olympia/devhub/views.py:78
-#: src/olympia/devhub/views.py:85 src/olympia/discovery/templates/discovery/addons/detail.html:57 src/olympia/reviews/forms.py:62 src/olympia/reviews/templates/reviews/add.html:57
+#: src/olympia/addons/templates/addons/details_box.html:81 src/olympia/addons/templates/addons/persona_detail_table.html:15 src/olympia/browse/views.py:429 src/olympia/devhub/views.py:77
+#: src/olympia/devhub/views.py:84 src/olympia/discovery/templates/discovery/addons/detail.html:57 src/olympia/reviews/forms.py:62 src/olympia/reviews/templates/reviews/add.html:57
 #: src/olympia/reviews/templates/reviews/mobile/review_list.html:18
 msgid "Rating"
 msgstr "Оцене"
 
-#: src/olympia/addons/templates/addons/details_box.html:85 src/olympia/browse/views.py:461 src/olympia/devhub/views.py:77 src/olympia/devhub/views.py:84
+#: src/olympia/addons/templates/addons/details_box.html:85 src/olympia/browse/views.py:428 src/olympia/devhub/views.py:76 src/olympia/devhub/views.py:83
 #: src/olympia/stats/templates/stats/addon_report_menu.html:8 src/olympia/stats/templates/stats/collection_report_menu.html:18
 msgid "Downloads"
 msgstr "Преузимања"
@@ -432,7 +427,7 @@ msgstr "Извештаји о злоупотреби"
 
 #. The Privacy Policy for this add-on.
 #: src/olympia/addons/templates/addons/details_box.html:121 src/olympia/addons/templates/addons/privacy.html:19 src/olympia/addons/templates/addons/privacy.html:23
-#: src/olympia/addons/templates/addons/impala/button.html:43 src/olympia/addons/templates/addons/impala/details.html:307 src/olympia/devhub/templates/devhub/includes/policy_form.html:20
+#: src/olympia/addons/templates/addons/impala/button.html:43 src/olympia/addons/templates/addons/impala/details.html:312 src/olympia/devhub/templates/devhub/includes/policy_form.html:23
 #: src/olympia/templates/mobile/base_addons.html:87
 msgid "Privacy Policy"
 msgstr "Полиса приватности"
@@ -457,7 +452,7 @@ msgstr "Галерија слика"
 msgid "Developer Comments"
 msgstr "Коментари аутора"
 
-#: src/olympia/addons/templates/addons/details_box.html:199 src/olympia/addons/templates/addons/impala/details.html:259
+#: src/olympia/addons/templates/addons/details_box.html:199 src/olympia/addons/templates/addons/impala/details.html:264
 msgid "Development Channel"
 msgstr "Канал за програмере"
 
@@ -481,7 +476,7 @@ msgstr ""
 "<strong>Опрез:</strong> Развојна верзија овог додатка није прегледана од стране Mozilla фондације. Када иснталирате развојну верзију, наставићете да добијате развојне надоградње од овог програмера."
 " Да бисте зауставили примање развојних надоградњи, поново инсталирајте развојну верзију са горе наведене везе."
 
-#: src/olympia/addons/templates/addons/details_box.html:220 src/olympia/addons/templates/addons/impala/details.html:278
+#: src/olympia/addons/templates/addons/details_box.html:220 src/olympia/addons/templates/addons/impala/details.html:283
 msgid "Version {0}:"
 msgstr "Верзија {0}:"
 
@@ -500,7 +495,7 @@ msgid "End-User License Agreement for {0}"
 msgstr "Уговор о лиценци софтвера за крајњег корисника (EULA) за {0}"
 
 #: src/olympia/addons/templates/addons/eula.html:17 src/olympia/addons/templates/addons/eula.html:21 src/olympia/addons/templates/addons/impala/button.html:48
-#: src/olympia/addons/templates/addons/impala/details.html:316 src/olympia/devhub/templates/devhub/includes/policy_form.html:3 src/olympia/discovery/templates/discovery/addons/eula.html:11
+#: src/olympia/addons/templates/addons/impala/details.html:321 src/olympia/devhub/templates/devhub/includes/policy_form.html:3 src/olympia/discovery/templates/discovery/addons/eula.html:11
 msgid "End-User License Agreement"
 msgstr "Уговор о лиценци софтвера за крајњег корисника (EULA)"
 
@@ -519,7 +514,7 @@ msgstr "Назад на {0}…"
 msgid "Add-ons for {0}"
 msgstr "Додаци за {0}"
 
-#: src/olympia/addons/templates/addons/home.html:10 src/olympia/addons/templates/addons/home.html:51 src/olympia/browse/templates/browse/impala/base_listing.html:11
+#: src/olympia/addons/templates/addons/home.html:10 src/olympia/addons/templates/addons/home.html:53 src/olympia/browse/templates/browse/impala/base_listing.html:11
 msgid "Featured Extensions"
 msgstr "Истакнуте екстензије"
 
@@ -527,29 +522,29 @@ msgstr "Истакнуте екстензије"
 msgid "Popular Extensions"
 msgstr "Популарне екстензије"
 
-#: src/olympia/addons/templates/addons/home.html:42 src/olympia/amo/templates/amo/side_nav.html:3 src/olympia/amo/templates/amo/side_nav.html:11 src/olympia/amo/templates/amo/site_nav.html:3
-#: src/olympia/amo/templates/amo/site_nav.html:25 src/olympia/browse/views.py:236 src/olympia/browse/views.py:281 src/olympia/browse/views.py:481
+#: src/olympia/addons/templates/addons/home.html:44 src/olympia/amo/templates/amo/side_nav.html:3 src/olympia/amo/templates/amo/side_nav.html:11 src/olympia/amo/templates/amo/site_nav.html:3
+#: src/olympia/amo/templates/amo/site_nav.html:25 src/olympia/browse/views.py:203 src/olympia/browse/views.py:248 src/olympia/browse/views.py:448
 msgid "Most Popular"
 msgstr "Најпопуларније"
 
-#: src/olympia/addons/templates/addons/home.html:43
+#: src/olympia/addons/templates/addons/home.html:45
 msgid "All »"
 msgstr "Све »"
 
-#: src/olympia/addons/templates/addons/home.html:52 src/olympia/addons/templates/addons/home.html:61 src/olympia/addons/templates/addons/home.html:70 src/olympia/addons/templates/addons/home.html:78
+#: src/olympia/addons/templates/addons/home.html:54 src/olympia/addons/templates/addons/home.html:63 src/olympia/addons/templates/addons/home.html:72 src/olympia/addons/templates/addons/home.html:80
 #: src/olympia/browse/templates/browse/impala/category_landing.html:36
 msgid "See all »"
 msgstr "Види све »"
 
-#: src/olympia/addons/templates/addons/home.html:60
+#: src/olympia/addons/templates/addons/home.html:62
 msgid "Up &amp; Coming Extensions"
 msgstr "Надолазеће екстензије"
 
-#: src/olympia/addons/templates/addons/home.html:69 src/olympia/browse/templates/browse/personas/category_landing.html:61 src/olympia/discovery/templates/discovery/pane.html:74
+#: src/olympia/addons/templates/addons/home.html:71 src/olympia/browse/templates/browse/personas/category_landing.html:61 src/olympia/discovery/templates/discovery/pane.html:74
 msgid "Featured Themes"
 msgstr "Истакнуте теме"
 
-#: src/olympia/addons/templates/addons/home.html:77 src/olympia/bandwagon/templates/bandwagon/impala/collection_listing.html:5
+#: src/olympia/addons/templates/addons/home.html:79 src/olympia/bandwagon/templates/bandwagon/impala/collection_listing.html:5
 msgid "Featured Collections"
 msgstr "Истакнуте колекције"
 
@@ -567,7 +562,7 @@ msgid "Updated {0}"
 msgstr "Ажурирано {0}"
 
 #. {0} is a date.
-#: src/olympia/addons/templates/addons/macros.html:10 src/olympia/addons/templates/addons/macros.html:69 src/olympia/addons/templates/addons/persona_preview.html:21
+#: src/olympia/addons/templates/addons/macros.html:10 src/olympia/addons/templates/addons/macros.html:69 src/olympia/addons/templates/addons/persona_preview.html:22
 #: src/olympia/addons/templates/addons/listing/items_mobile.html:44 src/olympia/addons/templates/addons/listing/macros.html:39 src/olympia/bandwagon/templates/bandwagon/collection_listing_items.html:37
 #: src/olympia/bandwagon/templates/bandwagon/impala/collection_listing_items.html:37
 msgid "Added {0}"
@@ -579,7 +574,6 @@ msgid "%(num)s weekly download"
 msgid_plural "%(num)s weekly downloads"
 msgstr[0] "%(num)s седмично преузимање"
 msgstr[1] "%(num)s седмична преузимања"
-msgstr[2] "%(num)s седмичних преузимања"
 
 #: src/olympia/addons/templates/addons/macros.html:28
 #, python-format
@@ -587,24 +581,20 @@ msgid "%(num)s user"
 msgid_plural "%(num)s users"
 msgstr[0] "%(num)s корисник"
 msgstr[1] "%(num)s корисника"
-msgstr[2] "%(num)s корисника"
 
 #. {0} is the number of downloads.
-#: src/olympia/addons/templates/addons/macros.html:53 src/olympia/addons/templates/addons/impala/details.html:61
+#: src/olympia/addons/templates/addons/macros.html:53 src/olympia/addons/templates/addons/impala/details.html:59
 msgid "{0} weekly download"
 msgid_plural "{0} weekly downloads"
 msgstr[0] "{0} преузимање недељно"
 msgstr[1] "{0} преузимања недељно"
-msgstr[2] "{0} преузимања недељно"
 
 #. {0} is the number of users.
-#: src/olympia/addons/templates/addons/macros.html:61 src/olympia/addons/templates/addons/impala/details.html:54 src/olympia/compat/templates/compat/index.html:71
-#: src/olympia/zadmin/templates/zadmin/compat.html:67
+#: src/olympia/addons/templates/addons/macros.html:61 src/olympia/addons/templates/addons/impala/details.html:52 src/olympia/zadmin/templates/zadmin/compat.html:67
 msgid "{0} user"
 msgid_plural "{0} users"
 msgstr[0] "{0} корисник"
 msgstr[1] "{0} корисника"
-msgstr[2] "{0} корисника"
 
 #: src/olympia/addons/templates/addons/paypal_result.html:12
 msgid "Payment cancelled"
@@ -618,7 +608,7 @@ msgstr "Плаћање завршено"
 msgid "Return to the addon."
 msgstr "Врати се на додатак."
 
-#: src/olympia/addons/templates/addons/persona_detail.html:17 src/olympia/addons/templates/addons/impala/details.html:106 src/olympia/addons/templates/addons/mobile/details.html:23
+#: src/olympia/addons/templates/addons/persona_detail.html:17 src/olympia/addons/templates/addons/impala/details.html:103 src/olympia/addons/templates/addons/mobile/details.html:23
 #: src/olympia/addons/templates/addons/mobile/persona_detail.html:21 src/olympia/discovery/templates/discovery/addons/base.html:27 src/olympia/editors/templates/editors/review.html:31
 msgid "by"
 msgstr "од"
@@ -662,35 +652,35 @@ msgstr "Дневни корисници"
 msgid "License"
 msgstr "Лиценца"
 
-#: src/olympia/addons/templates/addons/persona_preview.html:12 src/olympia/constants/base.py:48
+#: src/olympia/addons/templates/addons/persona_preview.html:13 src/olympia/constants/base.py:48
 msgid "Awaiting Review"
 msgstr "Чекам оцену"
 
-#: src/olympia/addons/templates/addons/persona_preview.html:14 src/olympia/amo/log.py:180 src/olympia/constants/base.py:42 src/olympia/editors/helpers.py:62
+#: src/olympia/addons/templates/addons/persona_preview.html:15 src/olympia/amo/log.py:180 src/olympia/constants/base.py:42 src/olympia/editors/helpers.py:62
 msgid "Rejected"
 msgstr "Одбијено"
 
-#: src/olympia/addons/templates/addons/persona_preview.html:16 src/olympia/amo/log.py:159
+#: src/olympia/addons/templates/addons/persona_preview.html:17 src/olympia/amo/log.py:159
 msgid "Approved"
 msgstr "Одобрено"
 
 #. {0} is the number of users.
-#: src/olympia/addons/templates/addons/persona_preview.html:26 src/olympia/addons/templates/addons/listing/items_mobile.html:36 src/olympia/addons/templates/addons/listing/macros.html:31
+#: src/olympia/addons/templates/addons/persona_preview.html:27 src/olympia/addons/templates/addons/listing/items_mobile.html:36 src/olympia/addons/templates/addons/listing/macros.html:31
 msgid "<strong>{0}</strong> user"
 msgid_plural "<strong>{0}</strong> users"
 msgstr[0] "<strong>{0}</strong> корисник"
 msgstr[1] "<strong>{0}</strong> корисника"
-msgstr[2] "<strong>{0}</strong> корисника"
 
-#: src/olympia/addons/templates/addons/persona_preview.html:40
+#: src/olympia/addons/templates/addons/persona_preview.html:41
 msgid "Hover to Preview"
 msgstr "Превуци за преглед"
 
-#: src/olympia/addons/templates/addons/persona_preview.html:46 src/olympia/addons/templates/addons/persona_preview.html:48 src/olympia/reviews/templates/reviews/add.html:15
+#: src/olympia/addons/templates/addons/persona_preview.html:47 src/olympia/addons/templates/addons/persona_preview.html:49 src/olympia/addons/templates/addons/persona_preview.html:97
+#: src/olympia/reviews/templates/reviews/add.html:15
 msgid "Add"
 msgstr "Додај"
 
-#: src/olympia/addons/templates/addons/persona_preview.html:57 src/olympia/bandwagon/templates/bandwagon/ajax_new.html:16 src/olympia/bandwagon/templates/bandwagon/edit.html:19
+#: src/olympia/addons/templates/addons/persona_preview.html:58 src/olympia/bandwagon/templates/bandwagon/ajax_new.html:16 src/olympia/bandwagon/templates/bandwagon/edit.html:19
 #: src/olympia/bandwagon/templates/bandwagon/includes/addedit.html:19 src/olympia/devhub/templates/devhub/addons/edit/admin.html:13 src/olympia/devhub/templates/devhub/addons/edit/basic.html:10
 #: src/olympia/devhub/templates/devhub/addons/edit/details.html:8 src/olympia/devhub/templates/devhub/addons/edit/media.html:6 src/olympia/devhub/templates/devhub/addons/edit/support.html:8
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:9 src/olympia/devhub/templates/devhub/addons/submit/describe.html:29 src/olympia/editors/templates/editors/review.html:257
@@ -699,21 +689,21 @@ msgstr "Уреди"
 
 #. For datetime formatting, see the table on
 #. http://docs.python.org/library/datetime.html#strftime-and-strptime-behavior
-#: src/olympia/addons/templates/addons/persona_preview.html:66
+#: src/olympia/addons/templates/addons/persona_preview.html:67
 #, python-format
 msgid "%%Y-%%m-%%d"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/persona_preview.html:67
+#: src/olympia/addons/templates/addons/persona_preview.html:68
 msgid "by {0} on {1}"
 msgstr "од {0} дана {1}"
 
-#: src/olympia/addons/templates/addons/persona_preview.html:75 src/olympia/reviews/helpers.py:17 src/olympia/reviews/templates/reviews/review_list.html:63
+#: src/olympia/addons/templates/addons/persona_preview.html:76 src/olympia/reviews/helpers.py:17 src/olympia/reviews/templates/reviews/review_list.html:63
 #: src/olympia/reviews/templates/reviews/reviews_link.html:21 src/olympia/reviews/templates/reviews/impala/reviews_link.html:16
 msgid "Not yet rated"
 msgstr "Није још оцењено"
 
-#: src/olympia/addons/templates/addons/persona_preview.html:78
+#: src/olympia/addons/templates/addons/persona_preview.html:79
 msgid "<b>{0}</b> users"
 msgstr "<b>{0}</b> корисници"
 
@@ -726,8 +716,8 @@ msgid "Learn more about Firefox"
 msgstr "Сазнај више о Firefox-у"
 
 #: src/olympia/addons/templates/addons/popups.html:22
-msgid "or <b><a class=\"installer\" href=\"{url}\">download anyway</a></b>"
-msgstr "или <b><a class=\"installer\" href=\"{url}\">преузмите у сваком случају</a></b>"
+msgid "or <b><a class=\"button installer\" href=\"{url}\">download anyway</a></b>"
+msgstr ""
 
 #: src/olympia/addons/templates/addons/popups.html:26
 msgid ""
@@ -788,8 +778,8 @@ msgstr "Ова Persona захтева %(app)s %(new_version)s. Тренутно 
 
 #: src/olympia/addons/templates/addons/popups.html:108
 msgid ""
-"<strong>Caution:</strong> This add-on has not been reviewed by Mozilla and can't be installed on release versions of Firefox 43 and above.  Be careful when installing third-party software that "
-"might harm your computer."
+"<strong>Caution:</strong> This add-on has not been reviewed by Mozilla and can't be installed on release versions of Firefox 43 and above. Be careful when installing third-party software that might"
+" harm your computer."
 msgstr ""
 
 #: src/olympia/addons/templates/addons/popups.html:120
@@ -826,7 +816,7 @@ msgstr ""
 "телефону ако га немате.)"
 
 #: src/olympia/addons/templates/addons/report_abuse.html:6 src/olympia/addons/templates/addons/report_abuse_full.html:10 src/olympia/addons/templates/addons/impala/details-more.html:23
-#: src/olympia/addons/templates/addons/impala/details.html:328
+#: src/olympia/addons/templates/addons/impala/details.html:333
 msgid "Report Abuse"
 msgstr "Пријави злоупотребу"
 
@@ -847,9 +837,9 @@ msgstr "Пошаљи пријаву"
 #: src/olympia/devhub/templates/devhub/addons/ajax_compat_update.html:36 src/olympia/devhub/templates/devhub/addons/profile.html:44 src/olympia/devhub/templates/devhub/addons/edit/admin.html:104
 #: src/olympia/devhub/templates/devhub/addons/edit/basic.html:155 src/olympia/devhub/templates/devhub/addons/edit/details.html:88 src/olympia/devhub/templates/devhub/addons/edit/support.html:70
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:169 src/olympia/devhub/templates/devhub/addons/forms_shared/media.html:152
-#: src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:44 src/olympia/devhub/templates/devhub/personas/edit.html:222 src/olympia/devhub/templates/devhub/versions/add_file_modal.html:79
-#: src/olympia/devhub/templates/devhub/versions/edit.html:140 src/olympia/devhub/templates/devhub/versions/list.html:208 src/olympia/devhub/templates/devhub/versions/list.html:242
-#: src/olympia/devhub/templates/devhub/versions/list.html:276 src/olympia/devhub/templates/devhub/versions/list.html:317 src/olympia/reviews/templates/reviews/edit_review.html:16
+#: src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:43 src/olympia/devhub/templates/devhub/personas/edit.html:222 src/olympia/devhub/templates/devhub/versions/add_file_modal.html:59
+#: src/olympia/devhub/templates/devhub/versions/edit.html:140 src/olympia/devhub/templates/devhub/versions/list.html:208 src/olympia/devhub/templates/devhub/versions/list.html:239
+#: src/olympia/devhub/templates/devhub/versions/list.html:281 src/olympia/devhub/templates/devhub/versions/list.html:315 src/olympia/reviews/templates/reviews/edit_review.html:16
 #: src/olympia/translations/templates/translations/trans-menu.html:50 src/olympia/translations/templates/translations/trans-menu.html:62 src/olympia/zadmin/templates/zadmin/validation.html:105
 msgid "Cancel"
 msgstr "Откажи"
@@ -894,7 +884,7 @@ msgstr "Погледајте <a href=\"%(support)s\">одељак подршке
 msgid "Review Guidelines"
 msgstr "Смернице за рецензирање"
 
-#: src/olympia/addons/templates/addons/review_list_box.html:5 src/olympia/addons/templates/addons/impala/details-more.html:27 src/olympia/editors/helpers.py:921
+#: src/olympia/addons/templates/addons/review_list_box.html:5 src/olympia/addons/templates/addons/impala/details-more.html:27 src/olympia/editors/helpers.py:1001
 #: src/olympia/reviews/templates/reviews/add.html:14 src/olympia/reviews/templates/reviews/reply.html:14 src/olympia/reviews/templates/reviews/review_list.html:19
 #: src/olympia/reviews/templates/reviews/mobile/review_list.html:26
 msgid "Reviews"
@@ -915,7 +905,6 @@ msgid "See all reviews of this add-on"
 msgid_plural "See all %(cnt)s reviews of this add-on"
 msgstr[0] "Погледајте све рецензије овог додатка"
 msgstr[1] "Погледајте све %(cnt)s рецензије овог додатка"
-msgstr[2] "Погледајте свих %(cnt)s рецензија овог додатка"
 
 #: src/olympia/addons/templates/addons/tags_box.html:3 src/olympia/devhub/templates/devhub/addons/edit/basic.html:118
 msgid "Tags"
@@ -985,108 +974,105 @@ msgid "Other add-ons by %(author)s"
 msgid_plural "Other add-ons by these authors"
 msgstr[0] "Други додаци од %(author)s"
 msgstr[1] "Други додаци од ових аутора"
-msgstr[2] "Други додаци од ових аутора"
 
-#: src/olympia/addons/templates/addons/impala/details.html:41
+#: src/olympia/addons/templates/addons/impala/details.html:39
 #, python-format
 msgid "<span itemprop=\"ratingCount\">%(num)s</span> user review"
 msgid_plural "<span itemprop=\"ratingCount\">%(num)s</span> user reviews"
 msgstr[0] "<span itemprop=\"ratingCount\">%(num)s</span> рецензија корисника"
 msgstr[1] "<span itemprop=\"ratingCount\">%(num)s</span> рецензије корисника"
-msgstr[2] "<span itemprop=\"ratingCount\">%(num)s</span> рецензија корисника"
 
-#: src/olympia/addons/templates/addons/impala/details.html:69
+#: src/olympia/addons/templates/addons/impala/details.html:66
 msgid "View statistics"
 msgstr "Преглед статистике"
 
-#: src/olympia/addons/templates/addons/impala/details.html:84
+#: src/olympia/addons/templates/addons/impala/details.html:81
 msgid "Manage"
 msgstr "Управљај"
 
 #. {0} is an add-on name.
-#: src/olympia/addons/templates/addons/impala/details.html:96
+#: src/olympia/addons/templates/addons/impala/details.html:93
 msgid "Icon of {0}"
 msgstr "Иконица од {0}"
 
-#: src/olympia/addons/templates/addons/impala/details.html:103 src/olympia/addons/templates/addons/impala/listing/items.html:14
+#: src/olympia/addons/templates/addons/impala/details.html:100 src/olympia/addons/templates/addons/impala/listing/items.html:14
 msgid "No Restart"
 msgstr "Без поновног покретања"
 
-#: src/olympia/addons/templates/addons/impala/details.html:127
+#: src/olympia/addons/templates/addons/impala/details.html:124
 #, fuzzy, python-format
 msgid "Meet the Developer: <a href=\"%(url)s\">%(name)s</a>"
 msgid_plural "<a href=\"%(url)s\">Meet the Developers</a>"
 msgstr[0] "Упознајте програмера: <a href=\"%(url)s\">%(name)s</a>"
 msgstr[1] "<a href=\"%(url)s\">Упознајте програмере</a>"
-msgstr[2] "<a href=\"%(url)s\">Упознајте програмере</a>"
 
 # {0} is an add-on name.
-#: src/olympia/addons/templates/addons/impala/details.html:137
+#: src/olympia/addons/templates/addons/impala/details.html:134
 msgid "Learn why {0} was created and find out what's next for this add-on."
 msgstr "Прочитајте зашто је {0} направљен и сазнајте шта следи у вези са овим додатком."
 
 #. {0} is an index.
-#: src/olympia/addons/templates/addons/impala/details.html:156
+#: src/olympia/addons/templates/addons/impala/details.html:161
 msgid "Add-on screenshot #{0}"
 msgstr "Слика екрана додатка #{0}"
 
-#: src/olympia/addons/templates/addons/impala/details.html:182
+#: src/olympia/addons/templates/addons/impala/details.html:187
 msgid "Add-on home page"
 msgstr "Почетна страница додатка"
 
-#: src/olympia/addons/templates/addons/impala/details.html:185
+#: src/olympia/addons/templates/addons/impala/details.html:190
 msgid "Support site"
 msgstr "Сајт подршке"
 
-#: src/olympia/addons/templates/addons/impala/details.html:189
+#: src/olympia/addons/templates/addons/impala/details.html:194
 msgid "Support E-mail"
 msgstr "Е-пошта подршке"
 
-#: src/olympia/addons/templates/addons/impala/details.html:194 src/olympia/devhub/models.py:378 src/olympia/devhub/templates/devhub/versions/list.html:12
+#: src/olympia/addons/templates/addons/impala/details.html:199 src/olympia/devhub/models.py:378 src/olympia/devhub/templates/devhub/versions/list.html:12
 #: src/olympia/versions/templates/versions/version.html:6 src/olympia/versions/templates/versions/mobile/version.html:6
 msgid "Version {0}"
 msgstr "Верзија {0}"
 
-#: src/olympia/addons/templates/addons/impala/details.html:194
+#: src/olympia/addons/templates/addons/impala/details.html:199
 msgid "Info"
 msgstr "Информације"
 
-#: src/olympia/addons/templates/addons/impala/details.html:195 src/olympia/devhub/templates/devhub/includes/addon_details.html:129
+#: src/olympia/addons/templates/addons/impala/details.html:200 src/olympia/devhub/templates/devhub/includes/addon_details.html:116
 msgid "Last Updated:"
 msgstr "Последње ажурирање:"
 
-#: src/olympia/addons/templates/addons/impala/details.html:200
+#: src/olympia/addons/templates/addons/impala/details.html:205
 #, python-format
 msgid "Released under <a target=\"_blank\" href=\"%(url)s\">%(name)s</a>"
 msgstr "Објављен под <a target=\"_blank\" href=\"%(url)s\">%(name)s</a>"
 
-#: src/olympia/addons/templates/addons/impala/details.html:201 src/olympia/addons/templates/addons/impala/details.html:206 src/olympia/amo/helpers.py:398 src/olympia/devhub/forms.py:142
+#: src/olympia/addons/templates/addons/impala/details.html:206 src/olympia/addons/templates/addons/impala/details.html:211 src/olympia/amo/helpers.py:398 src/olympia/devhub/forms.py:142
 #: src/olympia/devhub/forms.py:173 src/olympia/versions/templates/versions/version.html:40 src/olympia/versions/templates/versions/version.html:45
 msgid "Custom License"
 msgstr "Прилагођена лиценца"
 
-#: src/olympia/addons/templates/addons/impala/details.html:205
+#: src/olympia/addons/templates/addons/impala/details.html:210
 #, python-format
 msgid "Released under <a href=\"%(url)s\">%(name)s</a>"
 msgstr "Објављен под <a href=\"%(url)s\">%(name)s</a>"
 
-#: src/olympia/addons/templates/addons/impala/details.html:217
+#: src/olympia/addons/templates/addons/impala/details.html:222
 msgid "About this Add-on"
 msgstr "О додатку"
 
-#: src/olympia/addons/templates/addons/impala/details.html:233
+#: src/olympia/addons/templates/addons/impala/details.html:238
 msgid "Developer’s Comments"
 msgstr "Коментари програмера"
 
-#: src/olympia/addons/templates/addons/impala/details.html:243
+#: src/olympia/addons/templates/addons/impala/details.html:248
 msgid "Version Information"
 msgstr "Информације о верзији"
 
-#: src/olympia/addons/templates/addons/impala/details.html:250
+#: src/olympia/addons/templates/addons/impala/details.html:255
 msgid "See complete version history"
 msgstr "Погледај пуну историју верзија"
 
-#: src/olympia/addons/templates/addons/impala/details.html:262
+#: src/olympia/addons/templates/addons/impala/details.html:267
 msgid ""
 "The Development Channel lets you test an experimental new version of this add-on before it's released to the general public. Once you install the development version, you will continue to get "
 "updates from this channel. To stop receiving development updates, reinstall the default version from the link above."
@@ -1094,17 +1080,17 @@ msgstr ""
 "Канал за програмере Вам допушта да тестирате нову пробну верзију овог додатка пре него што постане доступан широј јавности. Чим инсталирате развојну верзију, наставићете да добијате надоградње са "
 "овог канала. Да бисте прекинули примање новости, поново инсталирајте подразумевану верзију са горње везе."
 
-#: src/olympia/addons/templates/addons/impala/details.html:272
+#: src/olympia/addons/templates/addons/impala/details.html:277
 msgid "<strong>Caution:</strong> Development versions of this add-on have not been reviewed by Mozilla."
 msgstr ""
 
-#: src/olympia/addons/templates/addons/impala/details.html:287
+#: src/olympia/addons/templates/addons/impala/details.html:292
 msgid "See complete development channel history"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/impala/details.html:306 src/olympia/addons/templates/addons/impala/details.html:315 src/olympia/addons/templates/addons/impala/details.html:327
+#: src/olympia/addons/templates/addons/impala/details.html:311 src/olympia/addons/templates/addons/impala/details.html:320 src/olympia/addons/templates/addons/impala/details.html:332
 #: src/olympia/addons/templates/addons/impala/review_add_box.html:4 src/olympia/stats/templates/stats/popup.html:2 src/olympia/stats/templates/stats/popup.html:8
-#: src/olympia/stats/templates/stats/stats.html:202 src/olympia/users/templates/users/profile.html:119
+#: src/olympia/stats/templates/stats/stats.html:204 src/olympia/users/templates/users/profile.html:119
 msgid "close"
 msgstr "затвори"
 
@@ -1138,7 +1124,6 @@ msgid "About the Developer"
 msgid_plural "About the Developers"
 msgstr[0] "О програмеру"
 msgstr[1] "О програмерима"
-msgstr[2] "О програмерима"
 
 #: src/olympia/addons/templates/addons/impala/developers.html:96 src/olympia/users/templates/users/edit.html:130 src/olympia/users/templates/users/profile.html:26
 msgid "No Photo"
@@ -1164,15 +1149,11 @@ msgstr "Лиценца изворног кода за {addon}"
 msgid "Source Code License"
 msgstr "Лиценца изворног кода"
 
-#: src/olympia/addons/templates/addons/impala/persona_grid.html:16 src/olympia/addons/templates/addons/impala/toplist.html:6
-msgid "{0} users"
-msgstr "{0} корисника"
-
 #: src/olympia/addons/templates/addons/impala/review_list_box.html:19 src/olympia/reviews/templates/reviews/review.html:40
 msgid "permalink"
 msgstr "трајна веза"
 
-#: src/olympia/addons/templates/addons/impala/review_list_box.html:23 src/olympia/editors/templates/editors/queue.html:98 src/olympia/reviews/templates/reviews/review.html:44
+#: src/olympia/addons/templates/addons/impala/review_list_box.html:23 src/olympia/editors/templates/editors/queue.html:104 src/olympia/reviews/templates/reviews/review.html:44
 msgid "translate"
 msgstr "преведи"
 
@@ -1182,7 +1163,6 @@ msgid "See all user reviews"
 msgid_plural "See all %(cnt)s user reviews"
 msgstr[0] "Погледајте све рецензије корисника"
 msgstr[1] "Погледајте све рецензије корисника"
-msgstr[2] "Погледајте све рецензије корисника"
 
 #: src/olympia/addons/templates/addons/impala/review_list_box.html:47 src/olympia/reviews/templates/reviews/review_list.html:84
 msgid "This add-on has not yet been reviewed."
@@ -1191,6 +1171,10 @@ msgstr "Овај додатак још нема рецензију."
 #: src/olympia/addons/templates/addons/impala/review_list_box.html:50
 msgid "Be the first!"
 msgstr "Будите први!"
+
+#: src/olympia/addons/templates/addons/impala/toplist.html:6
+msgid "{0} users"
+msgstr "{0} корисника"
 
 #: src/olympia/addons/templates/addons/impala/listing/sorter.html:14 src/olympia/devhub/templates/devhub/addons/listing/item_actions.html:49
 msgid "More"
@@ -1204,7 +1188,7 @@ msgstr "Додај у колекцију"
 msgid "My Add-ons"
 msgstr "Моји додаци"
 
-#: src/olympia/addons/templates/addons/includes/dashboard_tabs.html:6 src/olympia/amo/context_processors.py:51
+#: src/olympia/addons/templates/addons/includes/dashboard_tabs.html:6 src/olympia/amo/context_processors.py:52
 msgid "My Themes"
 msgstr "Моје теме"
 
@@ -1246,7 +1230,6 @@ msgid "<strong>{0}</strong> weekly download"
 msgid_plural "<strong>{0}</strong> weekly downloads"
 msgstr[0] "<strong>{0}</strong> преузимање недељно"
 msgstr[1] "<strong>{0}</strong> преузимања недељно"
-msgstr[2] "<strong>{0}</strong> преузимања недељно"
 
 #: src/olympia/addons/templates/addons/mobile/details.html:32
 msgid "Read More"
@@ -1260,7 +1243,7 @@ msgstr "Корисници"
 msgid "Weekly Downloads"
 msgstr "Седмична преузимања"
 
-#: src/olympia/addons/templates/addons/mobile/details.html:99 src/olympia/compat/templates/compat/reporter_detail.html:46 src/olympia/devhub/forms.py:787
+#: src/olympia/addons/templates/addons/mobile/details.html:99 src/olympia/compat/templates/compat/reporter_detail.html:46 src/olympia/devhub/forms.py:788
 #: src/olympia/devhub/templates/devhub/versions/list.html:163
 msgid "Version"
 msgstr "Верзија"
@@ -1345,7 +1328,7 @@ msgstr ""
 #: src/olympia/browse/templates/browse/personas/base.html:6 src/olympia/browse/templates/browse/personas/base.html:42 src/olympia/browse/templates/browse/personas/category_landing.html:21
 #: src/olympia/browse/templates/browse/personas/category_landing.html:23 src/olympia/browse/templates/browse/personas/category_landing.html:38 src/olympia/browse/templates/browse/personas/grid.html:7
 #: src/olympia/browse/templates/browse/personas/grid.html:11 src/olympia/browse/templates/browse/personas/mobile/base.html:7 src/olympia/browse/templates/browse/personas/mobile/category_landing.html:19
-#: src/olympia/constants/base.py:180 src/olympia/devhub/templates/devhub/personas/submit.html:13 src/olympia/editors/helpers.py:105 src/olympia/editors/templates/editors/base.html:26
+#: src/olympia/constants/base.py:180 src/olympia/devhub/templates/devhub/personas/submit.html:13 src/olympia/editors/helpers.py:107 src/olympia/editors/templates/editors/base.html:26
 #: src/olympia/editors/templates/editors/performance.html:73 src/olympia/search/templates/search/personas.html:39 src/olympia/templates/menu_links.html:9
 msgid "Themes"
 msgstr "Теме"
@@ -1366,7 +1349,7 @@ msgstr "Још додатака"
 msgid "Highest Rated"
 msgstr "Најбоље оцењене"
 
-#: src/olympia/addons/templates/addons/mobile/home.html:74 src/olympia/amo/templates/amo/side_nav.html:5 src/olympia/amo/templates/amo/site_nav.html:27 src/olympia/amo/templates/amo/site_nav.html:57
+#: src/olympia/addons/templates/addons/mobile/home.html:74 src/olympia/amo/templates/amo/side_nav.html:5 src/olympia/amo/templates/amo/site_nav.html:27 src/olympia/amo/templates/amo/site_nav.html:55
 #: src/olympia/bandwagon/views.py:97 src/olympia/browse/views.py:57 src/olympia/browse/views.py:67 src/olympia/browse/templates/browse/personas/mobile/category_landing.html:65
 #: src/olympia/search/forms.py:15 src/olympia/search/forms.py:87
 msgid "Newest"
@@ -1384,84 +1367,84 @@ msgstr "Информације о теми &raquo;"
 msgid "Tools"
 msgstr "Алати"
 
-#: src/olympia/amo/context_processors.py:48 src/olympia/discovery/templates/discovery/pane_account.html:8 src/olympia/users/templates/users/includes/navigation.html:2
+#: src/olympia/amo/context_processors.py:49 src/olympia/discovery/templates/discovery/pane_account.html:8 src/olympia/users/templates/users/includes/navigation.html:2
 msgid "My Profile"
 msgstr "Мој профил"
 
-#: src/olympia/amo/context_processors.py:54 src/olympia/users/templates/users/edit.html:5 src/olympia/users/templates/users/includes/navigation.html:3
+#: src/olympia/amo/context_processors.py:55 src/olympia/users/templates/users/edit.html:5 src/olympia/users/templates/users/includes/navigation.html:3
 msgid "Account Settings"
 msgstr "Подешавања налога"
 
-#: src/olympia/amo/context_processors.py:57 src/olympia/discovery/templates/discovery/pane_account.html:11 src/olympia/users/templates/users/profile.html:83
+#: src/olympia/amo/context_processors.py:58 src/olympia/discovery/templates/discovery/pane_account.html:11 src/olympia/users/templates/users/profile.html:83
 #: src/olympia/users/templates/users/includes/navigation.html:4
 msgid "My Collections"
 msgstr "Моје колекције"
 
-#: src/olympia/amo/context_processors.py:62 src/olympia/discovery/templates/discovery/pane_account.html:10 src/olympia/users/templates/users/includes/navigation.html:7
+#: src/olympia/amo/context_processors.py:63 src/olympia/discovery/templates/discovery/pane_account.html:10 src/olympia/users/templates/users/includes/navigation.html:7
 msgid "My Favorites"
 msgstr "Mоји омиљени"
 
-#: src/olympia/amo/context_processors.py:67 src/olympia/discovery/templates/discovery/pane_account.html:13 src/olympia/templates/impala/user_login.html:14 src/olympia/templates/mobile/header_auth.html:5
+#: src/olympia/amo/context_processors.py:68 src/olympia/discovery/templates/discovery/pane_account.html:13 src/olympia/templates/impala/user_login.html:14 src/olympia/templates/mobile/header_auth.html:5
 msgid "Log out"
 msgstr "Одјави се"
 
-#: src/olympia/amo/context_processors.py:72 src/olympia/devhub/templates/devhub/addons/dashboard.html:4
+#: src/olympia/amo/context_processors.py:73 src/olympia/devhub/templates/devhub/addons/dashboard.html:4
 msgid "Manage My Submissions"
 msgstr "Управљај мојим доставама"
 
-#: src/olympia/amo/context_processors.py:75 src/olympia/devhub/templates/devhub/nav.html:27 src/olympia/devhub/templates/devhub/addons/dashboard.html:25
+#: src/olympia/amo/context_processors.py:76 src/olympia/devhub/templates/devhub/nav.html:27 src/olympia/devhub/templates/devhub/addons/dashboard.html:25
 #: src/olympia/devhub/templates/devhub/addons/submit/base.html:4
 msgid "Submit a New Add-on"
 msgstr "Поднеси нови додатак"
 
-#: src/olympia/amo/context_processors.py:77 src/olympia/browse/templates/browse/personas/base.html:50 src/olympia/devhub/templates/devhub/index.html:24
+#: src/olympia/amo/context_processors.py:78 src/olympia/browse/templates/browse/personas/base.html:50 src/olympia/devhub/templates/devhub/index.html:24
 #: src/olympia/devhub/templates/devhub/addons/dashboard.html:29
 msgid "Submit a New Theme"
 msgstr "Поднеси нову тему"
 
-#: src/olympia/amo/context_processors.py:79 src/olympia/amo/templates/amo/site_nav.html:87 src/olympia/devhub/helpers.py:36 src/olympia/devhub/helpers.py:68 src/olympia/devhub/helpers.py:102
+#: src/olympia/amo/context_processors.py:80 src/olympia/amo/templates/amo/site_nav.html:85 src/olympia/devhub/helpers.py:36 src/olympia/devhub/helpers.py:68 src/olympia/devhub/helpers.py:102
 #: src/olympia/templates/footer.html:6 src/olympia/templates/menu_links.html:14
 msgid "Developer Hub"
 msgstr "Центар за програмера"
 
-#: src/olympia/amo/context_processors.py:83 src/olympia/devhub/views.py:1792
+#: src/olympia/amo/context_processors.py:84 src/olympia/devhub/views.py:1799
 msgid "Manage API Keys"
 msgstr ""
 
-#: src/olympia/amo/context_processors.py:88 src/olympia/editors/helpers.py:82 src/olympia/editors/helpers.py:102 src/olympia/editors/templates/editors/base.html:10
+#: src/olympia/amo/context_processors.py:89 src/olympia/editors/helpers.py:84 src/olympia/editors/helpers.py:104 src/olympia/editors/templates/editors/base.html:10
 msgid "Editor Tools"
 msgstr "Алати уредника"
 
-#: src/olympia/amo/context_processors.py:92
+#: src/olympia/amo/context_processors.py:93
 msgid "Admin Tools"
 msgstr "Алати администратора"
 
-#: src/olympia/amo/fields.py:15
+#: src/olympia/amo/fields.py:20
 msgid "Incorrect, please try again."
 msgstr ""
 
-#: src/olympia/amo/fields.py:16
+#: src/olympia/amo/fields.py:21
 msgid "Error verifying input, please try again."
 msgstr ""
 
-#: src/olympia/amo/fields.py:32
+#: src/olympia/amo/fields.py:37
 msgid "This must be a valid hex color code, such as #000000."
 msgstr "Морате унети исправну хексадецималну шифру боје, као што је #000000."
 
-#: src/olympia/amo/fields.py:58
+#: src/olympia/amo/fields.py:63
 msgid "Enter at least one value."
 msgstr "Унесите бар једну вредност."
 
-#: src/olympia/amo/helpers.py:162 src/olympia/amo/templates/amo/site_nav.html:61 src/olympia/bandwagon/templates/bandwagon/add.html:9 src/olympia/bandwagon/templates/bandwagon/collection_detail.html:15
+#: src/olympia/amo/helpers.py:162 src/olympia/amo/templates/amo/site_nav.html:59 src/olympia/bandwagon/templates/bandwagon/add.html:9 src/olympia/bandwagon/templates/bandwagon/collection_detail.html:15
 #: src/olympia/bandwagon/templates/bandwagon/delete.html:9 src/olympia/bandwagon/templates/bandwagon/edit.html:15 src/olympia/bandwagon/templates/bandwagon/user_listing.html:18
 #: src/olympia/bandwagon/templates/bandwagon/user_listing.html:21 src/olympia/bandwagon/templates/bandwagon/impala/collection_listing.html:12
 #: src/olympia/bandwagon/templates/bandwagon/impala/collection_listing.html:20 src/olympia/bandwagon/templates/bandwagon/impala/collection_listing.html:24
 #: src/olympia/bandwagon/templates/bandwagon/impala/collection_sidebar.html:3 src/olympia/bandwagon/templates/bandwagon/includes/collection_sidebar.html:2
-#: src/olympia/bandwagon/templates/bandwagon/mobile/collection_listing.html:3 src/olympia/stats/templates/stats/stats.html:77 src/olympia/templates/menu_links.html:12
+#: src/olympia/bandwagon/templates/bandwagon/mobile/collection_listing.html:3 src/olympia/stats/templates/stats/stats.html:33 src/olympia/templates/menu_links.html:12
 msgid "Collections"
 msgstr "Колекције"
 
-#: src/olympia/amo/helpers.py:171 src/olympia/amo/templates/amo/site_nav.html:85 src/olympia/browse/templates/browse/language_tools.html:3
+#: src/olympia/amo/helpers.py:171 src/olympia/amo/templates/amo/site_nav.html:83 src/olympia/browse/templates/browse/language_tools.html:3
 msgid "Dictionaries & Language Packs"
 msgstr "Речници и језички пакети"
 
@@ -1613,8 +1596,8 @@ msgstr "Захтевана супер рецензија"
 msgid "Comment on {addon} {version}."
 msgstr "Коментар на {addon} {version}."
 
-#: src/olympia/amo/log.py:236 src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:19 src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:47
-#: src/olympia/editors/helpers.py:511 src/olympia/editors/templates/editors/themes/history_table.html:11
+#: src/olympia/amo/log.py:236 src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:17 src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:45
+#: src/olympia/editors/helpers.py:584 src/olympia/editors/templates/editors/themes/history_table.html:11
 msgid "Comment"
 msgstr "Коментариши"
 
@@ -1943,7 +1926,7 @@ msgstr "Претходно"
 #: src/olympia/amo/templates/amo/mobile/paginator.html:14 src/olympia/amo/templates/amo/mobile/paginator.html:16 src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:51
 #: src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:65 src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:78
 #: src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:91 src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:104
-#: src/olympia/discovery/templates/discovery/pane.html:45 src/olympia/discovery/templates/discovery/addons/detail.html:39 src/olympia/stats/templates/stats/stats.html:167
+#: src/olympia/discovery/templates/discovery/pane.html:45 src/olympia/discovery/templates/discovery/addons/detail.html:39 src/olympia/stats/templates/stats/stats.html:169
 msgid "Next"
 msgstr "Следеће"
 
@@ -1977,7 +1960,7 @@ msgstr ""
 "id=\"recaptcha_different\">испробати различите речи</a> или <a href=\"#\" id=\"recaptcha_audio\">покушајте различите врсте изазова</a> уместо. </p>"
 
 #: src/olympia/amo/templates/amo/side_nav.html:4 src/olympia/amo/templates/amo/side_nav.html:12 src/olympia/amo/templates/amo/site_nav.html:4 src/olympia/amo/templates/amo/site_nav.html:26
-#: src/olympia/browse/views.py:56 src/olympia/browse/views.py:66 src/olympia/browse/views.py:237 src/olympia/browse/views.py:282 src/olympia/search/forms.py:86
+#: src/olympia/browse/views.py:56 src/olympia/browse/views.py:66 src/olympia/browse/views.py:204 src/olympia/browse/views.py:249 src/olympia/search/forms.py:86
 msgid "Top Rated"
 msgstr "Најбоље оцењено"
 
@@ -1992,37 +1975,37 @@ msgstr "Истражи"
 msgid "Extensions"
 msgstr "Екстензије"
 
-#: src/olympia/amo/templates/amo/site_nav.html:45
+#: src/olympia/amo/templates/amo/site_nav.html:44
 msgid "Want more customization? Try <b>Complete Themes</b>"
 msgstr ""
 
-#: src/olympia/amo/templates/amo/site_nav.html:56 src/olympia/bandwagon/views.py:96
+#: src/olympia/amo/templates/amo/site_nav.html:54 src/olympia/bandwagon/views.py:96
 msgid "Most Followers"
 msgstr "Највише пратиоца"
 
-#: src/olympia/amo/templates/amo/site_nav.html:68 src/olympia/bandwagon/templates/bandwagon/impala/collection_sidebar.html:16 src/olympia/bandwagon/templates/bandwagon/includes/collection_sidebar.html:18
+#: src/olympia/amo/templates/amo/site_nav.html:66 src/olympia/bandwagon/templates/bandwagon/impala/collection_sidebar.html:16 src/olympia/bandwagon/templates/bandwagon/includes/collection_sidebar.html:18
 msgid "Collections I've Made"
 msgstr "Моје колекције"
 
-#: src/olympia/amo/templates/amo/site_nav.html:70 src/olympia/bandwagon/templates/bandwagon/user_listing.html:4 src/olympia/bandwagon/templates/bandwagon/impala/collection_sidebar.html:13
+#: src/olympia/amo/templates/amo/site_nav.html:68 src/olympia/bandwagon/templates/bandwagon/user_listing.html:4 src/olympia/bandwagon/templates/bandwagon/impala/collection_sidebar.html:13
 #: src/olympia/bandwagon/templates/bandwagon/includes/collection_sidebar.html:15
 msgid "Collections I'm Following"
 msgstr "Колекције које пратим"
 
-#: src/olympia/amo/templates/amo/site_nav.html:73 src/olympia/bandwagon/templates/bandwagon/impala/collection_sidebar.html:18 src/olympia/bandwagon/templates/bandwagon/includes/collection_sidebar.html:20
-#: src/olympia/users/models.py:512
+#: src/olympia/amo/templates/amo/site_nav.html:71 src/olympia/bandwagon/templates/bandwagon/impala/collection_sidebar.html:18 src/olympia/bandwagon/templates/bandwagon/includes/collection_sidebar.html:20
+#: src/olympia/users/models.py:521
 msgid "My Favorite Add-ons"
 msgstr "Моји омиљени додаци"
 
-#: src/olympia/amo/templates/amo/site_nav.html:78
+#: src/olympia/amo/templates/amo/site_nav.html:76
 msgid "More&hellip;"
 msgstr "Још&hellip;"
 
-#: src/olympia/amo/templates/amo/site_nav.html:82
+#: src/olympia/amo/templates/amo/site_nav.html:80
 msgid "Add-ons for Mobile"
 msgstr "Додаци за мобилни"
 
-#: src/olympia/amo/templates/amo/site_nav.html:86 src/olympia/browse/feeds.py:207 src/olympia/browse/templates/browse/search_tools.html:3 src/olympia/constants/base.py:176
+#: src/olympia/amo/templates/amo/site_nav.html:84 src/olympia/browse/feeds.py:207 src/olympia/browse/templates/browse/search_tools.html:3 src/olympia/constants/base.py:176
 #: src/olympia/templates/menu_links.html:10
 msgid "Search Tools"
 msgstr "Алати за претрагу"
@@ -2038,7 +2021,7 @@ msgid "Jump to first page"
 msgstr "Пребаците се на прву страницу"
 
 #: src/olympia/amo/templates/amo/impala/paginator.html:22 src/olympia/amo/templates/amo/mobile/impala_paginator.html:12 src/olympia/discovery/templates/discovery/pane.html:44
-#: src/olympia/discovery/templates/discovery/addons/detail.html:38 src/olympia/stats/templates/stats/stats.html:164
+#: src/olympia/discovery/templates/discovery/addons/detail.html:38 src/olympia/stats/templates/stats/stats.html:166
 msgid "Previous"
 msgstr "Претходно"
 
@@ -2060,33 +2043,51 @@ msgid "Page {n}"
 msgid_plural "Page {n}"
 msgstr[0] "Страница {n}"
 msgstr[1] "Страница {n}"
-msgstr[2] "Страница {n}"
 
-#: src/olympia/amo/templates/services/install.html:38
-#, python-format
-msgid "If you are not prompted to install %(addon_name)s in a moment, please <a href=\"%(addon_xpi)s\">click here</a>."
-msgstr "Ако за пар момената не будете тражени да инсталирате %(addon_name)s, молимо Вас <a href=\"%(addon_xpi)s\">кликните овде</a>."
-
-#: src/olympia/amo/tests/test_messages.py:57 src/olympia/amo/tests/test_messages.py:58 src/olympia/reviews/forms.py:25 src/olympia/reviews/forms.py:50 src/olympia/reviews/templates/reviews/add.html:56
+#: src/olympia/amo/tests/test_messages.py:56 src/olympia/amo/tests/test_messages.py:57 src/olympia/reviews/forms.py:25 src/olympia/reviews/forms.py:50 src/olympia/reviews/templates/reviews/add.html:56
 #: src/olympia/reviews/templates/reviews/reply.html:30
 msgid "Title"
 msgstr "Наслов"
 
-#: src/olympia/amo/tests/test_messages.py:57 src/olympia/amo/tests/test_messages.py:58
+#: src/olympia/amo/tests/test_messages.py:56 src/olympia/amo/tests/test_messages.py:57
 msgid "Body"
 msgstr "Садржај"
 
-#: src/olympia/amo/tests/test_messages.py:59
+#: src/olympia/amo/tests/test_messages.py:58
 msgid "Another Title"
 msgstr "Други наслов"
 
-#: src/olympia/amo/tests/test_messages.py:59
+#: src/olympia/amo/tests/test_messages.py:58
 msgid "Another Body"
 msgstr "Други садржај"
 
-#: src/olympia/api/views.py:255
-msgid "Not implemented yet."
-msgstr "Није још имплементиран."
+#: src/olympia/api/authentication.py:76
+msgid "Signature has expired."
+msgstr ""
+
+#: src/olympia/api/authentication.py:79
+msgid "Error decoding signature."
+msgstr ""
+
+#: src/olympia/api/authentication.py:82
+msgid "Invalid JWT Token."
+msgstr ""
+
+#: src/olympia/api/authentication.py:130
+msgid "Invalid Authorization header. No credentials provided."
+msgstr ""
+
+#: src/olympia/api/authentication.py:133
+msgid "Invalid Authorization header. Credentials string should not contain spaces."
+msgstr ""
+
+#: src/olympia/api/fields.py:29
+msgid "The field must have a length of at least {num} characters."
+msgstr ""
+
+#: src/olympia/api/fields.py:31
+msgid "The language code {lang_code} is invalid."
+msgstr ""
 
 #: src/olympia/applications/views.py:39 src/olympia/applications/templates/applications/appversions.html:3
 msgid "Application Versions"
@@ -2104,7 +2105,7 @@ msgstr "Исправне верзије апликације"
 msgid "Add-ons submitted to Mozilla Add-ons must have a manifest file with at least one of the below applications supported. Only the versions listed below are allowed for these applications."
 msgstr ""
 
-#: src/olympia/applications/templates/applications/appversions.html:25
+#: src/olympia/applications/templates/applications/appversions.html:25 src/olympia/editors/helpers.py:361
 msgid "GUID"
 msgstr "GUID"
 
@@ -2181,11 +2182,11 @@ msgstr "Везе нису дозвољене."
 msgid "This url is already in use by another collection"
 msgstr "Овај url је у употреби од стране друге колекције"
 
-#: src/olympia/bandwagon/forms.py:197 src/olympia/devhub/views.py:1049
+#: src/olympia/bandwagon/forms.py:197 src/olympia/devhub/views.py:1050
 msgid "Icons must be either PNG or JPG."
 msgstr "Иконице морају бити или PNG или JPG формата."
 
-#: src/olympia/bandwagon/forms.py:202 src/olympia/devhub/views.py:1067 src/olympia/users/forms.py:476
+#: src/olympia/bandwagon/forms.py:202 src/olympia/devhub/views.py:1068 src/olympia/users/forms.py:476
 #, python-format
 msgid "Please use images smaller than %dMB."
 msgstr "Молимо Вас користите слике мање од %dMB."
@@ -2218,8 +2219,8 @@ msgstr "Омиљено"
 msgid "Remove from favorites"
 msgstr "Уклони из омиљених"
 
-#: src/olympia/bandwagon/views.py:98 src/olympia/bandwagon/views.py:191 src/olympia/browse/views.py:58 src/olympia/browse/views.py:69 src/olympia/browse/views.py:458 src/olympia/devhub/views.py:74
-#: src/olympia/devhub/views.py:82 src/olympia/devhub/templates/devhub/addons/edit/basic.html:20 src/olympia/editors/templates/editors/leaderboard.html:24
+#: src/olympia/bandwagon/views.py:98 src/olympia/bandwagon/views.py:191 src/olympia/browse/views.py:58 src/olympia/browse/views.py:69 src/olympia/browse/views.py:425 src/olympia/devhub/views.py:73
+#: src/olympia/devhub/views.py:81 src/olympia/devhub/templates/devhub/addons/edit/basic.html:20 src/olympia/editors/templates/editors/leaderboard.html:24
 #: src/olympia/editors/templates/editors/themes/queue_list.html:48 src/olympia/search/forms.py:17 src/olympia/search/forms.py:89 src/olympia/users/templates/users/vcard.html:5
 msgid "Name"
 msgstr "Име"
@@ -2228,7 +2229,7 @@ msgstr "Име"
 msgid "Recently Popular"
 msgstr "Скорије популарно"
 
-#: src/olympia/bandwagon/views.py:189 src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:18
+#: src/olympia/bandwagon/views.py:189 src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:16
 msgid "Added"
 msgstr "Додато"
 
@@ -2242,8 +2243,8 @@ msgstr "Колекција је креирана!"
 
 #: src/olympia/bandwagon/views.py:316
 #, python-format
-msgid "Your new collection is shown below. You can <ahref=\"%(url)s\">edit additional settings</a> if you'dlike."
-msgstr ""
+msgid "Your new collection is shown below. You can <a href=\"%(url)s\">edit additional settings</a> if you'd like."
+msgstr "Ваша нова колекција је приказана испод. Можете да <a href=\"%(url)s\">измените додатне поставке</a> ако желите."
 
 #: src/olympia/bandwagon/views.py:322
 msgid "Collection updated!"
@@ -2323,7 +2324,6 @@ msgid "<span>%(num)s</span> follower"
 msgid_plural "<span>%(num)s</span> followers"
 msgstr[0] "Број пратиоца: <span>%(num)s</span>"
 msgstr[1] "Број пратиоца: <span>%(num)s</span>"
-msgstr[2] "Број пратиоца: <span>%(num)s</span>"
 
 #: src/olympia/bandwagon/templates/bandwagon/collection_detail.html:54
 msgid "About this Collection"
@@ -2363,7 +2363,6 @@ msgid "%(num)s Theme in this Collection"
 msgid_plural "%(num)s Themes in this Collection"
 msgstr[0] "Тема у овој колекцији: %(num)s"
 msgstr[1] "Тема у овој колекцији: %(num)s"
-msgstr[2] "Тема у овој колекцији: %(num)s"
 
 #: src/olympia/bandwagon/templates/bandwagon/collection_detail.html:111
 #, python-format
@@ -2371,10 +2370,9 @@ msgid "%(num)s Add-on in this Collection"
 msgid_plural "%(num)s Add-ons in this Collection"
 msgstr[0] "Додатака у овој колекцији: %(num)s"
 msgstr[1] "Додатака у овој колекцији: %(num)s"
-msgstr[2] "Додатака у овој колекцији: %(num)s"
 
-#: src/olympia/bandwagon/templates/bandwagon/collection_detail.html:125 src/olympia/compat/templates/compat/index.html:25 src/olympia/compat/templates/compat/reporter_detail.html:29
-#: src/olympia/files/templates/files/viewer.html:29 src/olympia/templates/amo_footer.html:17 src/olympia/templates/includes/lang_switcher.html:10
+#: src/olympia/bandwagon/templates/bandwagon/collection_detail.html:125 src/olympia/compat/templates/compat/reporter_detail.html:29 src/olympia/files/templates/files/viewer.html:29
+#: src/olympia/templates/amo_footer.html:17 src/olympia/templates/includes/lang_switcher.html:10
 msgid "Go"
 msgstr "Крени"
 
@@ -2424,7 +2422,6 @@ msgid "<span>%(addons)s</span> add-on"
 msgid_plural "<span>%(addons)s</span> add-ons"
 msgstr[0] "<span>%(addons)s</span> додатак"
 msgstr[1] "<span>%(addons)s</span> додатака"
-msgstr[2] "<span>%(addons)s</span> додатака"
 
 #: src/olympia/bandwagon/templates/bandwagon/collection_grid.html:32
 #, python-format
@@ -2432,7 +2429,6 @@ msgid "<span>%(followers)s</span> follower"
 msgid_plural "<span>%(followers)s</span> followers"
 msgstr[0] "<span>%(followers)s</span> пратиоц"
 msgstr[1] "<span>%(followers)s</span> пратиоца"
-msgstr[2] "<span>%(followers)s</span> пратиоца"
 
 #. People "follow" collections to get notified of updates.                    Like
 #. Twitter followers.
@@ -2444,7 +2440,6 @@ msgid "%(num)s weekly follower"
 msgid_plural "%(num)s weekly followers"
 msgstr[0] "Број седмичних пратиоца: %(num)s"
 msgstr[1] "Број седмичних пратиоца: %(num)s"
-msgstr[2] "Број седмичних пратиоца: %(num)s"
 
 #. People "follow" collections to get notified of updates.                    Like
 #. Twitter followers.
@@ -2454,7 +2449,6 @@ msgid "%(num)s monthly follower"
 msgid_plural "%(num)s monthly followers"
 msgstr[0] "Број месечних пратиоца: %(num)s"
 msgstr[1] "Број месечних пратиоца: %(num)s"
-msgstr[2] "Број месечних пратиоца: %(num)s"
 
 #. People "follow" collections to get notified of updates.                    Like
 #. Twitter followers.
@@ -2466,7 +2460,6 @@ msgid "%(num)s follower"
 msgid_plural "%(num)s followers"
 msgstr[0] "Број пратиоца: %(num)s"
 msgstr[1] "Број пратиоца: %(num)s"
-msgstr[2] "Број пратиоца: %(num)s"
 
 #: src/olympia/bandwagon/templates/bandwagon/collection_listing_items.html:56 src/olympia/bandwagon/templates/bandwagon/impala/collection_listing_items.html:9
 #: src/olympia/devhub/templates/devhub/personas/edit.html:27
@@ -2551,7 +2544,7 @@ msgid "Remove this user as a contributor"
 msgstr "Уклони овог корисника као сарадника"
 
 #: src/olympia/bandwagon/templates/bandwagon/edit_contributors.html:18 src/olympia/bandwagon/templates/bandwagon/edit_contributors.html:43
-#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:20 src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:48
+#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:18 src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:46
 #: src/olympia/devhub/templates/devhub/addons/ajax_compat_update.html:19
 msgid "Remove"
 msgstr "Уклони"
@@ -2602,7 +2595,7 @@ msgid "<b>Warning:</b> By changing the owner of this collection, you will no lon
 msgstr "<b>Упозорење:</b> Променом власника ове колекције, више нећете имати могућност њене измене. Моћи ћете само да јој додајете или уклањате додатке."
 
 #: src/olympia/bandwagon/templates/bandwagon/edit_contributors.html:83 src/olympia/devhub/templates/devhub/addons/forms_shared/media.html:157
-#: src/olympia/devhub/templates/devhub/addons/submit/describe.html:69 src/olympia/devhub/templates/devhub/addons/submit/license.html:60 src/olympia/devhub/templates/devhub/addons/submit/upload.html:78
+#: src/olympia/devhub/templates/devhub/addons/submit/describe.html:69 src/olympia/devhub/templates/devhub/addons/submit/license.html:60 src/olympia/devhub/templates/devhub/addons/submit/upload.html:70
 #: src/olympia/devhub/templates/devhub/payments/tier.html:17 src/olympia/editors/templates/editors/themes/themes.html:111 src/olympia/editors/templates/editors/themes/themes.html:128
 #: src/olympia/editors/templates/editors/themes/themes.html:134 src/olympia/editors/templates/editors/themes/themes.html:141 src/olympia/users/templates/users/fxa_migration_prompt_content.html:10
 #: src/olympia/users/templates/users/login_form.html:42 src/olympia/users/templates/users/mobile/login.html:57
@@ -2685,32 +2678,31 @@ msgid "Add-ons in Your Collection"
 msgstr "Додаци у Вашој колекцији"
 
 #: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:4
-msgid "To include an add-on in this collection, enter its name in the box below and hit enter. You can also use the <strong>Add to Collection</strong> links throughout the site to include add-ons later."
+msgid "To include an add-on in this collection, enter its name in the box below and hit enter."
 msgstr ""
-"Да бисте ставили додатак у ову колекцију, унесите његов назив у пољу испод и притисните Еnter. Можете користити и везе <strong>Додај у колекцију</strong> на читавом сајту како бисте додали додатке "
-"касније."
 
-#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:17 src/olympia/constants/base.py:400 src/olympia/devhub/templates/devhub/addons/activity.html:62
+#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:15 src/olympia/constants/base.py:400 src/olympia/devhub/templates/devhub/addons/activity.html:62
+#: src/olympia/editors/helpers.py:273 src/olympia/editors/helpers.py:360
 msgid "Add-on"
 msgstr "Додатак"
 
-#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:26
+#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:24
 msgid "Enter the name of the add-on to include"
 msgstr "Унесите назив додатка да бисте да додали"
 
-#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:28
+#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:26
 msgid "Add to Collection"
 msgstr "Додај у колекцију"
 
-#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:45 src/olympia/editors/helpers.py:936 src/olympia/editors/helpers.py:956
+#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:43 src/olympia/editors/helpers.py:1016 src/olympia/editors/helpers.py:1036
 msgid "Pending"
 msgstr "У току"
 
-#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:47
+#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:45
 msgid "Add a comment"
 msgstr "Додај коментар"
 
-#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:48
+#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:46
 msgid "Remove this add-on from the collection"
 msgstr "Уклони овај додатак из колекције"
 
@@ -2819,12 +2811,12 @@ msgstr "Алати за претрагу"
 msgid "Most Users"
 msgstr "Већина корисника"
 
-#: src/olympia/browse/views.py:61 src/olympia/browse/views.py:72 src/olympia/browse/views.py:279 src/olympia/browse/templates/browse/personas/mobile/category_landing.html:63
+#: src/olympia/browse/views.py:61 src/olympia/browse/views.py:72 src/olympia/browse/views.py:246 src/olympia/browse/templates/browse/personas/mobile/category_landing.html:63
 #: src/olympia/discovery/templates/discovery/pane.html:67 src/olympia/search/forms.py:92
 msgid "Up & Coming"
 msgstr "Надолазеће"
 
-#: src/olympia/browse/views.py:460 src/olympia/devhub/views.py:76 src/olympia/devhub/views.py:83 src/olympia/discovery/templates/discovery/addons/detail.html:66
+#: src/olympia/browse/views.py:427 src/olympia/devhub/views.py:75 src/olympia/devhub/views.py:82 src/olympia/discovery/templates/discovery/addons/detail.html:66
 msgid "Created"
 msgstr "Креирано"
 
@@ -2905,7 +2897,6 @@ msgid "<b>{0}</b> add-on"
 msgid_plural "<b>{0}</b> add-ons"
 msgstr[0] "<b>{0}</b> додатак"
 msgstr[1] "<b>{0}</b> додатака"
-msgstr[2] "<b>{0}</b> додатака"
 
 #: src/olympia/browse/templates/browse/search_tools.html:61
 msgid "Search Extensions"
@@ -3012,10 +3003,9 @@ msgid "See the %(cnt)s extension in %(name)s &raquo;"
 msgid_plural "See all %(cnt)s extensions in %(name)s &raquo;"
 msgstr[0] "Погледајте свакo %(cnt)s проширење у %(name)s &raquo;"
 msgstr[1] "Погледајте свака %(cnt)s проширења у %(name)s &raquo;"
-msgstr[2] "Погледајте свих %(cnt)s проширења у %(name)s &raquo;"
 
-#: src/olympia/browse/templates/browse/mobile/extensions.html:13 src/olympia/compat/templates/compat/index.html:82 src/olympia/devhub/templates/devhub/devhub_search.html:24
-#: src/olympia/devhub/templates/devhub/addons/activity.html:47 src/olympia/search/templates/search/no_results.html:4 src/olympia/search/templates/search/mobile/results.html:36
+#: src/olympia/browse/templates/browse/mobile/extensions.html:13 src/olympia/devhub/templates/devhub/devhub_search.html:24 src/olympia/devhub/templates/devhub/addons/activity.html:47
+#: src/olympia/search/templates/search/no_results.html:4 src/olympia/search/templates/search/mobile/results.html:36
 msgid "No results found."
 msgstr "Нема пронађених резултата."
 
@@ -3100,7 +3090,7 @@ msgstr "&laquo; Све теме"
 msgid "All"
 msgstr "Све"
 
-#: src/olympia/compat/forms.py:22 src/olympia/search/views.py:525
+#: src/olympia/compat/forms.py:22 src/olympia/editors/templates/editors/base.html:69 src/olympia/search/views.py:518
 msgid "All Add-ons"
 msgstr "Сви додаци"
 
@@ -3111,53 +3101,6 @@ msgstr "Бинарно"
 #: src/olympia/compat/forms.py:24
 msgid "Non-binary"
 msgstr "Не-бинарно"
-
-#. Review points sources other than add-ons and themes.
-#: src/olympia/compat/views.py:87 src/olympia/constants/base.py:388 src/olympia/devhub/forms.py:162 src/olympia/editors/templates/editors/performance.html:75
-msgid "Other"
-msgstr "Друго"
-
-#: src/olympia/compat/templates/compat/index.html:4
-msgid "Add-on Compatibility Report for {app} {version}"
-msgstr "Извештај о компатибилности додатка за {app} {version}"
-
-#: src/olympia/compat/templates/compat/index.html:11
-msgid "{app} {version} Compatibility"
-msgstr "{app} {version} компатибилност"
-
-#: src/olympia/compat/templates/compat/index.html:17
-#, python-format
-msgid "Top 95%% compatible with previous version"
-msgstr ""
-
-#: src/olympia/compat/templates/compat/index.html:18
-#, python-format
-msgid "Top 95%% of all add-ons"
-msgstr ""
-
-#: src/olympia/compat/templates/compat/index.html:19
-msgid "All active add-ons"
-msgstr "Сви активни додаци"
-
-#: src/olympia/compat/templates/compat/index.html:23 src/olympia/constants/base.py:401
-msgid "App"
-msgstr "Апликација"
-
-#: src/olympia/compat/templates/compat/index.html:55
-msgid "Details for add-ons compatible with previous version:"
-msgstr "Детаљи за додатке компатибилне са претходном верзијом:"
-
-#: src/olympia/compat/templates/compat/index.html:57
-msgid "Show all versions"
-msgstr "Прикажи све верзије"
-
-#: src/olympia/compat/templates/compat/index.html:59
-msgid "Details for add-ons compatible with all versions:"
-msgstr "Детаљи за додатке компатибилне са свим верзијама:"
-
-#: src/olympia/compat/templates/compat/index.html:61
-msgid "Show previous version only"
-msgstr "Прикажи само претходну верзију"
 
 #: src/olympia/compat/templates/compat/reporter.html:3
 msgid "Add-on Compatibility Reports"
@@ -3193,14 +3136,12 @@ msgid "{0} success report"
 msgid_plural "{0} success reports"
 msgstr[0] "{0} извештај о успеху"
 msgstr[1] "{0} извештаја о успеху"
-msgstr[2] "{0} извештаја о успеху"
 
 #: src/olympia/compat/templates/compat/reporter_detail.html:17
 msgid "{0} problem report"
 msgid_plural "{0} problem reports"
 msgstr[0] "{0} извештај о проблему"
 msgstr[1] "{0} извештаја о проблему"
-msgstr[2] "{0} извештаја о проблему"
 
 #: src/olympia/compat/templates/compat/reporter_detail.html:21 src/olympia/users/templates/users/profile.html:70
 msgid "View all"
@@ -3214,8 +3155,8 @@ msgstr "Филтрирај по апликацији"
 msgid "Report Type"
 msgstr "Тип извештаја"
 
-#: src/olympia/compat/templates/compat/reporter_detail.html:47 src/olympia/devhub/forms.py:784 src/olympia/devhub/templates/devhub/addons/ajax_compat_update.html:17 src/olympia/editors/forms.py:108
-#: src/olympia/zadmin/forms.py:45
+#: src/olympia/compat/templates/compat/reporter_detail.html:47 src/olympia/devhub/forms.py:785 src/olympia/devhub/templates/devhub/addons/ajax_compat_update.html:17 src/olympia/editors/forms.py:108
+#: src/olympia/editors/forms.py:248 src/olympia/zadmin/forms.py:45
 msgid "Application"
 msgstr "Апликација"
 
@@ -3303,7 +3244,8 @@ msgstr "Прелиминарно рецензирано"
 msgid "Preliminarily Reviewed and Awaiting Full Review"
 msgstr "Прелиминарно прегледано и чека потпуну рецензију"
 
-#: src/olympia/constants/base.py:33 src/olympia/editors/helpers.py:924 src/olympia/editors/templates/editors/themes/history_table.html:34
+#: src/olympia/constants/base.py:33 src/olympia/editors/forms.py:258 src/olympia/editors/helpers.py:73 src/olympia/editors/helpers.py:1004
+#: src/olympia/editors/templates/editors/themes/history_table.html:34
 msgid "Deleted"
 msgstr "Обрисано"
 
@@ -3403,6 +3345,11 @@ msgstr "Питајте након што корисници преузму ов�
 msgid "Ask before users can download this add-on"
 msgstr "Питајте пре него што корисници преузму овај додатак"
 
+#. Review points sources other than add-ons and themes.
+#: src/olympia/constants/base.py:388 src/olympia/devhub/forms.py:162 src/olympia/editors/templates/editors/performance.html:75
+msgid "Other"
+msgstr "Друго"
+
 #: src/olympia/constants/base.py:389
 msgid "Exception"
 msgstr "Изузетак"
@@ -3414,6 +3361,10 @@ msgstr "Издање"
 #: src/olympia/constants/base.py:391
 msgid "Change"
 msgstr "Измена"
+
+#: src/olympia/constants/base.py:401
+msgid "App"
+msgstr "Апликација"
 
 #: src/olympia/constants/base.py:402
 msgid "Persona"
@@ -3563,7 +3514,7 @@ msgstr "Означи"
 msgid "Duplicate"
 msgstr "Дупликат"
 
-#: src/olympia/constants/editors.py:17 src/olympia/editors/helpers.py:502 src/olympia/editors/templates/editors/themes/queue.html:71 src/olympia/editors/templates/editors/themes/themes.html:94
+#: src/olympia/constants/editors.py:17 src/olympia/editors/helpers.py:575 src/olympia/editors/templates/editors/themes/queue.html:71 src/olympia/editors/templates/editors/themes/themes.html:94
 msgid "Reject"
 msgstr "Одбиј"
 
@@ -3663,7 +3614,7 @@ msgstr "Solaris"
 msgid "Android"
 msgstr "Android"
 
-#: src/olympia/core/apps.py:19
+#: src/olympia/core/apps.py:21
 msgid "Core"
 msgstr ""
 
@@ -3797,7 +3748,7 @@ msgid "Submit my add-on for manual review."
 msgstr ""
 
 #: src/olympia/devhub/forms.py:537
-msgid "Do not list my add-on on this site (beta)"
+msgid "Do not list my add-on on this site"
 msgstr ""
 
 #: src/olympia/devhub/forms.py:538
@@ -3830,46 +3781,46 @@ msgstr ""
 
 #: src/olympia/devhub/forms.py:592
 #, python-format
-msgid "Version %s already exists"
-msgstr "Верзија %s већ постоји"
+msgid "Version %s already exists, or was uploaded before."
+msgstr ""
 
-#: src/olympia/devhub/forms.py:604
+#: src/olympia/devhub/forms.py:605
 msgid "Select a valid choice. That choice is not one of the available choices."
 msgstr "Одаберите исправан избор. Тај избор није један од доступних избора."
 
-#: src/olympia/devhub/forms.py:610
+#: src/olympia/devhub/forms.py:611
 msgid "A file with a version ending with a|alpha|b|beta and an optional number is detected as beta."
 msgstr "Датотека са верзијом која се завршава са а|алфа|б|бета и опционим бројем је детектована као бета."
 
-#: src/olympia/devhub/forms.py:633
+#: src/olympia/devhub/forms.py:634
 msgid "You cannot upload any more files for this version."
 msgstr "Не можете више датотека отпремити за ову верзију."
 
-#: src/olympia/devhub/forms.py:639
+#: src/olympia/devhub/forms.py:640
 msgid "Version doesn't match"
 msgstr "Верзије се не поклапају"
 
-#: src/olympia/devhub/forms.py:668
+#: src/olympia/devhub/forms.py:669
 msgid "You cannot delete a file once the review process has started. You must delete the whole version."
 msgstr "Не можете обрисати датотеку чим процес рецензије започне. Морате обрисати целу верзију."
 
-#: src/olympia/devhub/forms.py:688
+#: src/olympia/devhub/forms.py:689
 msgid "The platform All cannot be combined with specific platforms."
 msgstr "Платформа Све не може се укомбиновати са одређеним платформама."
 
-#: src/olympia/devhub/forms.py:693
+#: src/olympia/devhub/forms.py:694
 msgid "A platform can only be chosen once."
 msgstr "Платформа се може само једном изабрати."
 
-#: src/olympia/devhub/forms.py:706
+#: src/olympia/devhub/forms.py:707
 msgid "A review type must be selected."
 msgstr "Морате изабрати тип рецензије."
 
-#: src/olympia/devhub/forms.py:788 src/olympia/editors/forms.py:114 src/olympia/zadmin/forms.py:49 src/olympia/zadmin/forms.py:52
+#: src/olympia/devhub/forms.py:789 src/olympia/editors/forms.py:114 src/olympia/editors/forms.py:254 src/olympia/zadmin/forms.py:49 src/olympia/zadmin/forms.py:52
 msgid "Select an application first"
 msgstr "Прво изаберите апликацију"
 
-#: src/olympia/devhub/forms.py:840
+#: src/olympia/devhub/forms.py:841
 msgid "There cannot be more than 3 required add-ons."
 msgstr "Не може бити више од 3 захтевана додатка."
 
@@ -3892,7 +3843,6 @@ msgid "{0} error"
 msgid_plural "{0} errors"
 msgstr[0] "{0} грешка"
 msgstr[1] "{0} грешке"
-msgstr[2] "{0} грешака"
 
 # {0} is a number
 #. L10n: first parameter is the number of warnings
@@ -3901,166 +3851,165 @@ msgid "{0} warning"
 msgid_plural "{0} warnings"
 msgstr[0] "{0} упозорење"
 msgstr[1] "{0} упозорења"
-msgstr[2] "{0} упозорења"
 
 #: src/olympia/devhub/models.py:375 src/olympia/reviews/templates/reviews/add.html:58
 msgid "Review"
 msgstr "Преглед"
 
-#: src/olympia/devhub/tasks.py:551
+#: src/olympia/devhub/tasks.py:583
 #, python-format
 msgid "%s responded with %s (%s)."
 msgstr "%s је одговорио са %s (%s)."
 
-#: src/olympia/devhub/tasks.py:555
+#: src/olympia/devhub/tasks.py:587
 #, python-format
 msgid "Connection to \"%s\" timed out."
 msgstr "Конекција на \"%s\" је истекла."
 
-#: src/olympia/devhub/tasks.py:557
+#: src/olympia/devhub/tasks.py:589
 #, python-format
 msgid "Could not contact host at \"%s\"."
 msgstr "Нисмо могли контактирати хост на \"%s\"."
 
-#: src/olympia/devhub/utils.py:104
+#: src/olympia/devhub/utils.py:105
 #, python-format
 msgid "Validation generated too many errors/warnings so %s messages were truncated. After addressing the visible messages, you'll be able to see the others."
 msgstr "Овера је створила превише грешака/упозорења па је %s порука скраћено. Након обраћања видљивим порукама, бићете у могућности да погледате остале."
 
-#: src/olympia/devhub/views.py:183
+#: src/olympia/devhub/views.py:182
 msgid "All My Add-ons"
 msgstr "Сви моји додаци"
 
-#: src/olympia/devhub/views.py:210
+#: src/olympia/devhub/views.py:209
 msgid "All Activity"
 msgstr "Сва активност"
 
-#: src/olympia/devhub/views.py:211
+#: src/olympia/devhub/views.py:210
 msgid "Add-on Updates"
 msgstr "Ажурирања додатка"
 
-#: src/olympia/devhub/views.py:212
+#: src/olympia/devhub/views.py:211
 msgid "Add-on Status"
 msgstr "Статус додатка"
 
-#: src/olympia/devhub/views.py:213
+#: src/olympia/devhub/views.py:212
 msgid "User Collections"
 msgstr "Корисничке збирке"
 
-#: src/olympia/devhub/views.py:214 src/olympia/devhub/templates/devhub/docs/policies-maintenance.html:68 src/olympia/pages/templates/pages/dev_faq.html:38
+#: src/olympia/devhub/views.py:213 src/olympia/devhub/templates/devhub/docs/policies-maintenance.html:68 src/olympia/pages/templates/pages/dev_faq.html:38
 #: src/olympia/pages/templates/pages/dev_faq.html:484
 msgid "User Reviews"
 msgstr "Рецензије корисника"
 
-#: src/olympia/devhub/views.py:327 src/olympia/devhub/views.py:331 src/olympia/devhub/views.py:484 src/olympia/devhub/views.py:513 src/olympia/devhub/views.py:564 src/olympia/devhub/views.py:1150
+#: src/olympia/devhub/views.py:326 src/olympia/devhub/views.py:330 src/olympia/devhub/views.py:485 src/olympia/devhub/views.py:514 src/olympia/devhub/views.py:565 src/olympia/devhub/views.py:1157
 msgid "Changes successfully saved."
 msgstr "Измене су успешно сачуване."
 
-#: src/olympia/devhub/views.py:334 src/olympia/devhub/views.py:1631
+#: src/olympia/devhub/views.py:333 src/olympia/devhub/views.py:1638
 msgid "Please check the form for errors."
 msgstr "Молимо Вас проверите да ли има грешака у форми."
 
-#: src/olympia/devhub/views.py:346
+#: src/olympia/devhub/views.py:345
 msgid "Add-on cannot be deleted. Disable this add-on instead."
 msgstr "Додатак се не може избрисати. Уместо тога га онемогућите."
 
-#: src/olympia/devhub/views.py:356
+#: src/olympia/devhub/views.py:355
 msgid "Theme deleted."
 msgstr "Тема обрисана."
 
-#: src/olympia/devhub/views.py:356
+#: src/olympia/devhub/views.py:355
 msgid "Add-on deleted."
 msgstr "Додатак обрисан."
 
-#: src/olympia/devhub/views.py:362
+#: src/olympia/devhub/views.py:361
 msgid "URL name was incorrect. Theme was not deleted."
 msgstr ""
 
-#: src/olympia/devhub/views.py:367
+#: src/olympia/devhub/views.py:366
 msgid "URL name was incorrect. Add-on was not deleted."
 msgstr ""
 
-#: src/olympia/devhub/views.py:449
+#: src/olympia/devhub/views.py:450
 msgid "An author has been added to your add-on"
 msgstr "Аутор је додат Вашем додатку"
 
-#: src/olympia/devhub/views.py:456
+#: src/olympia/devhub/views.py:457
 msgid "An author has a role changed on your add-on"
 msgstr "Аутор је променио улогу Вашег додатка"
 
-#: src/olympia/devhub/views.py:476
+#: src/olympia/devhub/views.py:477
 msgid "An author has been removed from your add-on"
 msgstr "Аутор је уклоњен са Вашег додатка"
 
-#: src/olympia/devhub/views.py:519
+#: src/olympia/devhub/views.py:520
 msgid "There were errors in your submission."
 msgstr "Постоје грешке у Вашој достави."
 
-#: src/olympia/devhub/views.py:583
+#: src/olympia/devhub/views.py:584
 msgid "Validate Add-on"
 msgstr "Оверите додатак"
 
-#: src/olympia/devhub/views.py:594
+#: src/olympia/devhub/views.py:595
 msgid "Check Add-on Compatibility"
 msgstr "Проверите компатибилност додатка"
 
-#: src/olympia/devhub/views.py:808 src/olympia/signing/views.py:90
+#: src/olympia/devhub/views.py:809 src/olympia/signing/views.py:95
 msgid "You cannot submit this type of add-on"
 msgstr ""
 
-#: src/olympia/devhub/views.py:1051 src/olympia/users/forms.py:471
+#: src/olympia/devhub/views.py:1052 src/olympia/users/forms.py:471
 msgid "Images must be either PNG or JPG."
 msgstr "Слике морају бити или PNG или JPG формата."
 
-#: src/olympia/devhub/views.py:1055
+#: src/olympia/devhub/views.py:1056
 msgid "Icons cannot be animated."
 msgstr "Иконице не могу бити покретне."
 
-#: src/olympia/devhub/views.py:1057
+#: src/olympia/devhub/views.py:1058
 msgid "Images cannot be animated."
 msgstr "Слике не могу бити покретне."
 
-#: src/olympia/devhub/views.py:1070
+#: src/olympia/devhub/views.py:1071
 #, python-format
 msgid "Images cannot be larger than %dKB."
 msgstr "Слике не могу бити веће од %dKB."
 
 #. L10n: {0} is an image width (in pixels), {1} is a height.
-#: src/olympia/devhub/views.py:1080
+#: src/olympia/devhub/views.py:1081
 msgid "Image must be exactly {0} pixels wide and {1} pixels tall."
 msgstr "Слика мора бити широка тачно {0} пиксела и висока {1} пиксела."
 
-#: src/olympia/devhub/views.py:1087
+#: src/olympia/devhub/views.py:1088
 msgid "There was an error uploading your preview."
 msgstr "Дошло је до грешке приликом отпремања Вашег прегледа."
 
-#: src/olympia/devhub/views.py:1189
+#: src/olympia/devhub/views.py:1196
 #, python-format
 msgid "Version %s disabled."
 msgstr "Верзија %s онемогућена."
 
-#: src/olympia/devhub/views.py:1193
+#: src/olympia/devhub/views.py:1200
 #, python-format
 msgid "Version %s deleted."
 msgstr "Верзија %s избрисана."
 
-#: src/olympia/devhub/views.py:1203
+#: src/olympia/devhub/views.py:1210
 msgid "This upload has failed validation, and may lack complete validation results. Please take due care when reviewing it."
 msgstr "Отпремање није прошло валидацију, и можда не садржи потпуне резултате валидације. Молимо Вас, добро проверите приликом прегледавања."
 
-#: src/olympia/devhub/views.py:1677
+#: src/olympia/devhub/views.py:1684
 msgid "Preliminary Review Requested."
 msgstr "Захтевана прелиминарна рецензија."
 
-#: src/olympia/devhub/views.py:1678
+#: src/olympia/devhub/views.py:1685
 msgid "Full Review Requested."
 msgstr "Захтевана потпуна рецензија."
 
-#: src/olympia/devhub/views.py:1779
+#: src/olympia/devhub/views.py:1786
 msgid "Your old credentials were revoked and are no longer valid. Be sure to update all API clients with the new credentials."
 msgstr ""
 
-#: src/olympia/devhub/views.py:1797
+#: src/olympia/devhub/views.py:1804
 msgid "New API key created"
 msgstr ""
 
@@ -4090,7 +4039,7 @@ msgstr "Назад на додатке"
 msgid "{0} :: Search"
 msgstr "{0} :: Претражи"
 
-#: src/olympia/devhub/templates/devhub/devhub_search.html:6 src/olympia/devhub/templates/devhub/search.html:8 src/olympia/editors/forms.py:435 src/olympia/editors/forms.py:437
+#: src/olympia/devhub/templates/devhub/devhub_search.html:6 src/olympia/devhub/templates/devhub/search.html:8 src/olympia/editors/forms.py:534 src/olympia/editors/forms.py:536
 #: src/olympia/editors/templates/editors/queue.html:27 src/olympia/editors/templates/editors/themes/queue_list.html:14 src/olympia/search/templates/search/collections.html:17
 #: src/olympia/search/templates/search/personas.html:18 src/olympia/search/templates/search/results.html:18 src/olympia/search/templates/search/mobile/results.html:8 src/olympia/templates/search.html:14
 #: src/olympia/templates/impala/search.html:18
@@ -4150,12 +4099,12 @@ msgstr ""
 msgid "Start Making Add-ons"
 msgstr "Крените правити додатке"
 
-#: src/olympia/devhub/templates/devhub/index.html:86 src/olympia/devhub/templates/devhub/addons/listing/items.html:25 src/olympia/devhub/templates/devhub/includes/addon_details.html:15
+#: src/olympia/devhub/templates/devhub/index.html:86 src/olympia/devhub/templates/devhub/addons/listing/items.html:25 src/olympia/devhub/templates/devhub/includes/addon_details.html:20
 #: src/olympia/devhub/templates/devhub/personas/edit.html:43
 msgid "Status:"
 msgstr "Статус:"
 
-#: src/olympia/devhub/templates/devhub/index.html:90 src/olympia/devhub/templates/devhub/includes/addon_details.html:100
+#: src/olympia/devhub/templates/devhub/index.html:90 src/olympia/devhub/templates/devhub/includes/addon_details.html:87
 msgid "Visibility:"
 msgstr ""
 
@@ -4163,11 +4112,11 @@ msgstr ""
 msgid "Latest Version:"
 msgstr "Последња верзија:"
 
-#: src/olympia/devhub/templates/devhub/index.html:109 src/olympia/devhub/templates/devhub/includes/addon_details.html:145 src/olympia/devhub/templates/devhub/personas/edit.html:49
+#: src/olympia/devhub/templates/devhub/index.html:109 src/olympia/devhub/templates/devhub/includes/addon_details.html:131 src/olympia/devhub/templates/devhub/personas/edit.html:49
 msgid "Queue Position:"
 msgstr "Ред позиције:"
 
-#: src/olympia/devhub/templates/devhub/index.html:110 src/olympia/devhub/templates/devhub/includes/addon_details.html:146 src/olympia/devhub/templates/devhub/personas/edit.html:50
+#: src/olympia/devhub/templates/devhub/index.html:110 src/olympia/devhub/templates/devhub/includes/addon_details.html:132 src/olympia/devhub/templates/devhub/personas/edit.html:50
 #, python-format
 msgid "%(position)s of %(total)s"
 msgstr "%(position)s од %(total)s"
@@ -4269,16 +4218,6 @@ msgstr "Након отпремања, низ аутоматизованих т�
 msgid "Do you want your add-on to be distributed on this site?"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/validate_addon.html:49 src/olympia/devhub/templates/devhub/addons/submit/upload.html:30 src/olympia/devhub/templates/devhub/versions/add_file_modal.html:14
-#: src/olympia/devhub/templates/devhub/versions/add_file_modal.html:53 src/olympia/devhub/templates/devhub/versions/list.html:298
-msgid "Warning:"
-msgstr ""
-
-#: src/olympia/devhub/templates/devhub/validate_addon.html:50 src/olympia/devhub/templates/devhub/addons/submit/upload.html:31
-#, python-format
-msgid "Submission of unlisted add-ons for signing is currently in an open beta. Please <a href=\"%(url)s\" target=\"_blank\">report any bugs</a> that you encounter."
-msgstr ""
-
 #. first parameter is a filename like lorem-ipsum-1.0.2.xpi
 #: src/olympia/devhub/templates/devhub/validation.html:5
 msgid "Validation Results for {0}"
@@ -4357,7 +4296,7 @@ msgstr "Компатибилност"
 msgid "Update Compatibility"
 msgstr "Ажурирање компатибилности"
 
-#: src/olympia/devhub/templates/devhub/addons/ajax_compat_update.html:4
+#: src/olympia/devhub/templates/devhub/addons/ajax_compat_update.html:4 src/olympia/devhub/templates/devhub/versions/edit.html:45
 msgid "Adjusting application information here will allow users to install your add-on even if the install manifest in the package indicates that the add-on is incompatible."
 msgstr "Подешавање информације о апликацији овде ће дозволити корисницима да инсталирају Ваш додатак чак иако манифест инсталације у пакету указује да је додатак некомпатибилан."
 
@@ -4369,9 +4308,9 @@ msgstr "Подржане верзије"
 msgid "Add Another Application&hellip;"
 msgstr "Додај другу апликацију&hellip;"
 
-#: src/olympia/devhub/templates/devhub/addons/ajax_compat_update.html:38 src/olympia/devhub/templates/devhub/addons/owner.html:86 src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:46
-#: src/olympia/devhub/templates/devhub/versions/list.html:351 src/olympia/devhub/templates/devhub/versions/list.html:353 src/olympia/templates/impala/base.html:132
-#: src/olympia/templates/impala/base.html:143 src/olympia/templates/impala/base.html:161 src/olympia/templates/impala/base.html:171
+#: src/olympia/devhub/templates/devhub/addons/ajax_compat_update.html:38 src/olympia/devhub/templates/devhub/addons/owner.html:86 src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:45
+#: src/olympia/devhub/templates/devhub/versions/list.html:349 src/olympia/devhub/templates/devhub/versions/list.html:351 src/olympia/templates/impala/base.html:129
+#: src/olympia/templates/impala/base.html:140 src/olympia/templates/impala/base.html:158 src/olympia/templates/impala/base.html:168
 msgid "Close"
 msgstr "Затвори"
 
@@ -4390,7 +4329,6 @@ msgid "<b>{0}</b> theme"
 msgid_plural "<b>{0}</b> themes"
 msgstr[0] "<b>{0}</b> тема"
 msgstr[1] "<b>{0}</b> теме"
-msgstr[2] "<b>{0}</b> тема"
 
 #: src/olympia/devhub/templates/devhub/addons/edit.html:3 src/olympia/devhub/templates/devhub/addons/listing/item_actions.html:25
 #: src/olympia/devhub/templates/devhub/addons/listing/item_actions_theme.html:7 src/olympia/devhub/templates/devhub/includes/addons_edit_nav.html:2
@@ -4406,7 +4344,7 @@ msgstr "Нема"
 msgid "Manage Authors & License"
 msgstr "Управљајте Ауторима и лиценцама"
 
-#: src/olympia/devhub/templates/devhub/addons/owner.html:29 src/olympia/editors/templates/editors/review.html:270
+#: src/olympia/devhub/templates/devhub/addons/owner.html:29 src/olympia/editors/helpers.py:362 src/olympia/editors/templates/editors/review.html:270
 msgid "Authors"
 msgstr "Аутори"
 
@@ -4477,18 +4415,11 @@ msgid "Summary"
 msgstr "Резиме"
 
 #: src/olympia/devhub/templates/devhub/addons/edit/basic.html:52
-msgid ""
-"A short explanation of your add-on's basic\n"
-"                          functionality that is displayed in search and browse\n"
-"                          listings, as well as at the top of your add-on's\n"
-"                          details page. It is only relevant for listed add-ons."
+msgid "A short explanation of your add-on's basic functionality that is displayed in search and browse listings, as well as at the top of your add-on's details page. It is only relevant for listed add-ons."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/basic.html:73
-msgid ""
-"Categories are the primary way users browse through add-ons.\n"
-"                        Choose any that fit your add-on's functionality for the most\n"
-"                        exposure. It is only relevant for listed add-ons."
+msgid "Categories are the primary way users browse through add-ons. Choose any that fit your add-on's functionality for the most exposure. It is only relevant for listed add-ons."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/basic.html:90
@@ -4497,11 +4428,7 @@ msgid "Categories cannot be changed while your add-on is featured for this appli
 msgstr "Категорије се не могу променити док је Ваш додатак истакнут за ову апликацију. Молимо пошаљите е-пошту <a href=\"mailto:%(email)s\">%(email)s</a> ако постоји разлог за измењивање Ваших категорија."
 
 #: src/olympia/devhub/templates/devhub/addons/edit/basic.html:119
-msgid ""
-"Tags help users find your add-on and should be short\n"
-"                        descriptors such as tabs, toolbar, or twitter.  You\n"
-"                        may have a maximum of {0} tags. It is only relevant\n"
-"                        for listed add-ons."
+msgid "Tags help users find your add-on and should be short descriptors such as tabs, toolbar, or twitter. You may have a maximum of {0} tags. It is only relevant for listed add-ons."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/basic.html:129 src/olympia/devhub/templates/devhub/personas/edit.html:97 src/olympia/devhub/templates/devhub/personas/submit.html:46
@@ -4509,7 +4436,6 @@ msgid "Comma-separated, minimum of {0} character."
 msgid_plural "Comma-separated, minimum of {0} characters."
 msgstr[0] "Раздвојено зарезима, најмање {0} карактер."
 msgstr[1] "Раздвојено зарезима, најмање {0} карактера."
-msgstr[2] "Раздвојено зарезима, најмање {0} карактера."
 
 #: src/olympia/devhub/templates/devhub/addons/edit/basic.html:132 src/olympia/devhub/templates/devhub/personas/edit.html:100 src/olympia/devhub/templates/devhub/personas/submit.html:49
 msgid "Example: dark, cinema, noir. Limit 20."
@@ -4520,7 +4446,6 @@ msgid "Reserved tag:"
 msgid_plural "Reserved tags:"
 msgstr[0] "Резервисана ознака:"
 msgstr[1] "Резервисане ознаке:"
-msgstr[2] "Резервисане ознаке:"
 
 #: src/olympia/devhub/templates/devhub/addons/edit/details.html:5
 msgid "Add-on Details"
@@ -4531,11 +4456,7 @@ msgid "Add-on Details for {0}"
 msgstr "Детаљи додатка за {0}"
 
 #: src/olympia/devhub/templates/devhub/addons/edit/details.html:22
-msgid ""
-"A longer explanation of features,\n"
-"                          functionality, and other relevant information. This\n"
-"                          field is only displayed on the add-on's details\n"
-"                          page. It is only relevant for listed add-ons."
+msgid "A longer explanation of features, functionality, and other relevant information. This field is only displayed on the add-on's details page. It is only relevant for listed add-ons."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/details.html:44 src/olympia/translations/templates/translations/trans-menu.html:13
@@ -4543,10 +4464,7 @@ msgid "Default Locale"
 msgstr "Подразумевани локал"
 
 #: src/olympia/devhub/templates/devhub/addons/edit/details.html:45
-msgid ""
-"Information about your add-on is displayed in this locale\n"
-"                        unless you override it with a locale-specific translation.\n"
-"                        It is only relevant for listed add-ons."
+msgid "Information about your add-on is displayed in this locale unless you override it with a locale-specific translation. It is only relevant for listed add-ons."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/details.html:61 src/olympia/users/forms.py:311 src/olympia/users/templates/users/edit.html:122 src/olympia/users/templates/users/register.html:57
@@ -4556,10 +4474,8 @@ msgstr "Почетна"
 
 #: src/olympia/devhub/templates/devhub/addons/edit/details.html:63
 msgid ""
-"If your add-on has another homepage, enter its\n"
-"                          address here. If your website is localized into other\n"
-"                          languages multiple translations of this field can be\n"
-"                          added. It is only relevant for listed add-ons."
+"If your add-on has another homepage, enter its address here. If your website is localized into other languages multiple translations of this field can be added. It is only relevant for listed add-"
+"ons."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/media.html:3
@@ -4577,19 +4493,14 @@ msgstr "Информације о подршци за {0}"
 
 #: src/olympia/devhub/templates/devhub/addons/edit/support.html:22
 msgid ""
-"If you wish to display an e-mail address for support\n"
-"                          inquiries, enter it here. If you have different\n"
-"                          addresses for each language multiple translations of\n"
-"                          this field can be added. It is only relevant for\n"
-"                          listed add-ons."
+"If you wish to display an e-mail address for support inquiries, enter it here. If you have different addresses for each language multiple translations of this field can be added. It is only "
+"relevant for listed add-ons."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/support.html:45
 msgid ""
-"If your add-on has a support website or forum, enter\n"
-"                          its address here. If your website is localized into\n"
-"                          other languages, multiple translations of this field can\n"
-"                          be added. It is only relevant for listed add-ons."
+"If your add-on has a support website or forum, enter its address here. If your website is localized into other languages, multiple translations of this field can be added. It is only relevant for "
+"listed add-ons."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:6
@@ -4603,11 +4514,8 @@ msgstr "Технички детаљи за {0}"
 
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:23
 msgid ""
-"Any information end users may want to know that isn't\n"
-"                          necessarily applicable to the add-on summary or description.\n"
-"                          Common uses include listing known major bugs, information on\n"
-"                          how to report bugs, anticipated release date of a new version,\n"
-"                          etc. It is only relevant for listed add-ons."
+"Any information end users may want to know that isn't necessarily applicable to the add-on summary or description. Common uses include listing known major bugs, information on how to report bugs, "
+"anticipated release date of a new version, etc. It is only relevant for listed add-ons."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:46
@@ -4619,9 +4527,7 @@ msgid "Add-on Flags"
 msgstr "Ознаке додатка"
 
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:69
-msgid ""
-"These flags are used to classify add-ons. It is only\n"
-"                        relevant for listed add-ons."
+msgid "These flags are used to classify add-ons. It is only relevant for listed add-ons."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:74
@@ -4637,9 +4543,7 @@ msgid "View Source?"
 msgstr "Погледати извор?"
 
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:90
-msgid ""
-"Whether the source of your add-on can be displayed in our\n"
-"                        online viewer. It is only relevant for listed add-ons."
+msgid "Whether the source of your add-on can be displayed in our online viewer. It is only relevant for listed add-ons."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:94
@@ -4655,10 +4559,7 @@ msgid "Public Stats?"
 msgstr "Јавна статистика?"
 
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:102
-msgid ""
-"Whether the download and usage stats of your add-on can\n"
-"                        be displayed in our online viewer.\n"
-"                        It is only relevant for listed add-ons."
+msgid "Whether the download and usage stats of your add-on can be displayed in our online viewer. It is only relevant for listed add-ons."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:107
@@ -4674,10 +4575,7 @@ msgid "Upgrade SDK?"
 msgstr "Надоградити SDK?"
 
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:116
-msgid ""
-"If selected, we will try to automatically upgrade your\n"
-"                        add-on when a new version of the SDK is released.\n"
-"                        It is only relevant for listed add-ons."
+msgid "If selected, we will try to automatically upgrade your add-on when a new version of the SDK is released. It is only relevant for listed add-ons."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:121
@@ -4728,10 +4626,8 @@ msgstr "Иконица додатка"
 
 #: src/olympia/devhub/templates/devhub/addons/forms_shared/media.html:16
 msgid ""
-"Upload an icon for your add-on or choose from one of ours. The\n"
-"                      icon is displayed nearly everywhere your add-on is. Uploaded images\n"
-"                      must be one of the following image types: .png, .jpg.\n"
-"                      It is only relevant for listed add-ons."
+"Upload an icon for your add-on or choose from one of ours. The icon is displayed nearly everywhere your add-on is. Uploaded images must be one of the following image types: .png, .jpg. It is only "
+"relevant for listed add-ons."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/forms_shared/media.html:25
@@ -4839,16 +4735,14 @@ msgid "Deleting your add-on will permanently remove it from the site and prevent
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:24
-msgid ""
-"Enter the following text confirm your decision:\n"
-"           {slug}"
+msgid "Enter the following text confirm your decision: {slug}"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:34
+#: src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:33
 msgid "Please tell us why you are deleting your theme:"
 msgstr "Реците нам зашто бришете своју тему:"
 
-#: src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:36
+#: src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:35
 msgid "Please tell us why you are deleting your add-on:"
 msgstr "Реците нам зашто бришете свој додатак:"
 
@@ -4885,8 +4779,8 @@ msgstr "Нова верзија"
 msgid "Daily statistics on downloads and users."
 msgstr "Дневне статистике о преузимању и корисницима."
 
-#: src/olympia/devhub/templates/devhub/addons/listing/item_actions.html:45 src/olympia/stats/templates/stats/stats.html:75 src/olympia/stats/templates/stats/stats.html:79
-#: src/olympia/stats/templates/stats/stats.html:81
+#: src/olympia/devhub/templates/devhub/addons/listing/item_actions.html:45 src/olympia/stats/templates/stats/stats.html:31 src/olympia/stats/templates/stats/stats.html:35
+#: src/olympia/stats/templates/stats/stats.html:37
 msgid "Statistics"
 msgstr "Статистика"
 
@@ -4947,7 +4841,6 @@ msgid "<strong>{0}</strong> active user"
 msgid_plural "<strong>{0}</strong> active users"
 msgstr[0] "<strong>{0}</strong> корисник"
 msgstr[1] "<strong>{0}</strong> корисника"
-msgstr[2] "<strong>{0}</strong> корисника"
 
 #: src/olympia/devhub/templates/devhub/addons/submit/base.html:11
 msgid "Submit Add-on"
@@ -5218,11 +5111,11 @@ msgstr ""
 "Искористите поља испод да бисте отпремили Ваш пакет са додатком и одаберите било која ограничења платформе. Након постављања, низ аутоматизованих тестова за проверу ваљаности ће бити покренути на "
 "Вашој датотеци."
 
-#: src/olympia/devhub/templates/devhub/addons/submit/upload.html:59 src/olympia/devhub/templates/devhub/versions/add_file_modal.html:39
+#: src/olympia/devhub/templates/devhub/addons/submit/upload.html:51 src/olympia/devhub/templates/devhub/versions/add_file_modal.html:28
 msgid "Which platforms is this file compatible with?"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/addons/submit/upload.html:67 src/olympia/devhub/templates/devhub/versions/add_file_modal.html:65
+#: src/olympia/devhub/templates/devhub/addons/submit/upload.html:59 src/olympia/devhub/templates/devhub/versions/add_file_modal.html:45
 msgid "Administrative overrides"
 msgstr "Административна поништавања"
 
@@ -5339,8 +5232,8 @@ msgstr "Функционалност и развој веб сајта"
 
 #: src/olympia/devhub/templates/devhub/docs/policies-contact.html:44
 msgid ""
-"If you've found a problem with the site, we'd love to fix it. Please <a href=\"https://github.com/mozilla/olympia/issues\">file a bug report</a> in GitHub, including the location of the problem and"
-" how you encountered it."
+"If you've found a problem with the site, we'd love to fix it. Please <a href=\"https://github.com/mozilla/addons/issues/new\">file a bug report</a> in GitHub, including the location of the problem "
+"and how you encountered it."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/docs/policies-maintenance.html:3 src/olympia/devhub/templates/devhub/docs/policies-maintenance.html:7
@@ -6185,62 +6078,55 @@ msgstr "Услови услуге за пријаву Вашег рада на �
 msgid "How to get in touch with us regarding these policies or your add-on."
 msgstr "Како да ступите у контакт са нама у вези ове полисе или Вашег додатка."
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:6
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:10
 msgid "You have disabled this add-on"
 msgstr "Онемогућили сте овај додатак"
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:20
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:24
 msgid "Your add-on's listing is disabled and is not showing anywhere in our gallery or update service."
 msgstr "Навођење додатка је онемогућено и не приказује се било где у нашој галерији или у услугама ажурирања."
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:25
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:27
 msgid "Please complete your add-on."
 msgstr "Молим Вас завршите Ваш додатак."
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:29
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:30
 msgid "You will receive an email when the review is complete."
 msgstr "Примићете е-пошту када је преглед завршен."
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:34
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:33
 msgid "You will receive an email when the review is complete. Until then, your add-on is not listed in our gallery but can be accessed directly from its details page."
 msgstr "Добићете е-пошту кад преглед буде завршен. До тада, Ваш додатак није на листи у нашој галерији али му се може приступити директно са његове странице са детаљима."
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:38 src/olympia/devhub/templates/devhub/includes/addon_details.html:48
-msgid ""
-"You will receive an email when the review is\n"
-"                             complete and your add-on is signed."
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:37 src/olympia/devhub/templates/devhub/includes/addon_details.html:45
+msgid "You will receive an email when the review is complete and your add-on is signed."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:44
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:41
 msgid "You will receive an email when the review is complete. Until then, your add-on is not listed in our gallery but can be accessed directly from its details page."
 msgstr "Добићете е-пошту кад преглед буде завршен. До тада, Ваш додатак није на листи у нашој галерији али му се може приступити директно са његове странице са детаљима."
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:54
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:49
 msgid "Your add-on is displayed in our gallery and users are receiving automatic updates."
 msgstr "Ваш додатак је приказан у нашој галерији и корисници примају аутоматске надоградње."
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:57
-msgid ""
-"Your add-on has been signed and can be bundled with an\n"
-"                             application installer."
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:52
+msgid "Your add-on has been signed and can be bundled with an application installer."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:63
-msgid ""
-"Your add-on was disabled by a site administrator and is no\n"
-"                             longer shown in our gallery. If you have any questions,\n"
-"                             please email amo-admins@mozilla.org."
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:56
+msgid "Your add-on was disabled by a site administrator and is no longer shown in our gallery. If you have any questions, please email amo-admins@mozilla.org."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:70
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:62
 msgid "Your add-on is displayed in our gallery as experimental and users are receiving automatic updates. Some features are unavailable to your add-on."
 msgstr "Ваш додатак је приказан у нашој галерији као експериментални и корисници примају аутоматске надоградње. Неке могућности су недоступне за Ваш додатак."
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:74
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:66
 msgid "Your add-on has been signed."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:79
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:69
 msgid ""
 "You will receive an email when the full review is complete. Until then, your add-on is displayed in our gallery as experimental and users are receiving automatic updates. Some features are "
 "unavailable to your add-on."
@@ -6248,48 +6134,41 @@ msgstr ""
 "Добићете е-пошту када пун преглед буде готов. До тада, Ваш додатак је приказан у нашој галерији као експериментални и корисници добијају аутоматске надоградње. Неке могућности нису доступне Вашем "
 "додатку."
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:84
-msgid ""
-"You will receive an email when the full review is\n"
-"                             complete, making you able to bundle your add-on with an\n"
-"                             application installer."
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:74
+msgid "You will receive an email when the full review is complete, making you able to bundle your add-on with an application installer."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:91
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:79
 msgid "All add-ons hosted in our gallery must now be reviewed by an editor. If you wish to continue hosting your add-on, please click to select a review process."
 msgstr "Сви додаци који су хостовани у нашој галерији морају бити прегледани од стране уредника. Ако желите да наставите да хостујете Ваш додатак молимо да кликнете да бисте одабрали процес рецензије."
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:113
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:100
 msgid "Current Version:"
 msgstr "Тренутна верзија:"
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:115
-msgid ""
-"This is the version of your add-on that will\n"
-"                                           be installed if someone clicks the Install\n"
-"                                           button on addons.mozilla.org. It is only\n"
-"                                           relevant for listed add-ons."
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:102
+msgid "This is the version of your add-on that will be installed if someone clicks the Install button on addons.mozilla.org. It is only relevant for listed add-ons."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:123
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:110
 msgid "Created:"
 msgstr "Направљено:"
 
 #. {0} is a date. dennis-ignore: E201
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:125 src/olympia/devhub/templates/devhub/includes/addon_details.html:131
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:112 src/olympia/devhub/templates/devhub/includes/addon_details.html:118
 #, python-format
 msgid "%%b %%e, %%Y"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:136
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:123
 msgid "Next Version:"
 msgstr "Следећа верзија:"
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:138
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:125
 msgid "This is the newest uploaded version, however it isn’t live on the site yet."
 msgstr "Ово је најновија верзија, али још увек није јавна на сајту."
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:144 src/olympia/devhub/templates/devhub/versions/list.html:30
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:130 src/olympia/devhub/templates/devhub/versions/list.html:30
 msgid "Queues are not reviewed strictly in order"
 msgstr "Редови нису строго прегледани у реду"
 
@@ -6359,9 +6238,7 @@ msgid "View the blog &#9658;"
 msgstr "Прикажи блог &#9658;"
 
 #: src/olympia/devhub/templates/devhub/includes/license_form.html:6
-msgid ""
-"Please choose a license appropriate for the rights you grant on your source code.\n"
-"                  It is only relevant for listed add-ons."
+msgid "Please choose a license appropriate for the rights you grant on your source code. It is only relevant for listed add-ons."
 msgstr ""
 
 #. {0} is a list of HTML tags.
@@ -6384,19 +6261,15 @@ msgid "Select <b>up to {0}</b> {1} category for this add-on:"
 msgid_plural "Select <b>up to {0}</b> {1} categories for this add-on:"
 msgstr[0] "Изаберите <b>до {0}</b> {1} категорију за овај додатак:"
 msgstr[1] "Изаберите <b>до {0}</b> {1} категорије за овај додатак:"
-msgstr[2] "Изаберите <b>до {0}</b> {1} категорија за овај додатак:"
 
 #: src/olympia/devhub/templates/devhub/includes/policy_form.html:4
 msgid ""
 "Users will be required to accept the following End-User License Agreement (EULA) prior to installing your add-on. The presence of a EULA significantly affects the number of downloads an add-on "
-"receives. Please note that a EULA is not the same as a code license, such as the GPL or MPL.\n"
-"                It is only relevant for listed add-ons."
+"receives. Please note that a EULA is not the same as a code license, such as the GPL or MPL.It is only relevant for listed add-ons."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/policy_form.html:21
-msgid ""
-"If your add-on transmits any data from the user's computer, a privacy policy is required that explains what data is sent and how it is used.\n"
-"                It is only relevant for listed add-ons."
+#: src/olympia/devhub/templates/devhub/includes/policy_form.html:24
+msgid "If your add-on transmits any data from the user's computer, a privacy policy is required that explains what data is sent and how it is used. It is only relevant for listed add-ons."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/includes/source_form_field.html:2
@@ -6564,7 +6437,7 @@ msgstr "Изаберите категорију која најбоље опис
 msgid "Add some tags to describe your Theme."
 msgstr "Додајте неке ознаке да опишете Вашу тему."
 
-#: src/olympia/devhub/templates/devhub/personas/edit.html:106
+#: src/olympia/devhub/templates/devhub/personas/edit.html:106 src/olympia/devhub/templates/devhub/personas/submit.html:54
 msgid "A short explanation of your theme's basic functionality that is displayed in search and browse listings, as well as at the top of your theme's details page."
 msgstr "Кратко објашњење основних фукционалности Ваше теме које је приказано у листама претраге и прегледавања, као и на врху странице са детаљима Ваше теме."
 
@@ -6704,10 +6577,6 @@ msgstr "Теме позадине су лак начин да персонали
 msgid "Give your Theme a name."
 msgstr "Дајте назив Вашој теми."
 
-#: src/olympia/devhub/templates/devhub/personas/submit.html:54
-msgid "A short explanation of your theme's basic functionality that is displayed in search and browse listings, as well as at the top of your theme's details page."
-msgstr "Кратко објашњење основних фукционалности Ваше теме које је приказано у листама претраге и прегледавања, као и на врху странице са детаљима Ваше теме."
-
 #: src/olympia/devhub/templates/devhub/personas/submit.html:198
 #, python-format
 msgid ""
@@ -6782,31 +6651,17 @@ msgstr "Изаберите другу слику за подножје"
 msgid "Files added to reviewed versions must be reviewed before they will be available for download."
 msgstr "Датотеке додате на прегледане верзије морају бити прегледане пре него буду доступне за преузимање."
 
-#: src/olympia/devhub/templates/devhub/versions/add_file_modal.html:15
-#, python-format
-msgid ""
-"Submission of updates to unlisted add-ons for signing is currently in an open beta. Manual review may still be required for a large number of add-ons. Please <a href=\"%(url)s\" "
-"target=\"_blank\">report any bugs</a> that you encounter."
-msgstr ""
-
-#: src/olympia/devhub/templates/devhub/versions/add_file_modal.html:35
+#: src/olympia/devhub/templates/devhub/versions/add_file_modal.html:24
 msgid "Select the target platform for this file."
 msgstr "Изаберите циљану платформу за ову датотеку."
 
-#: src/olympia/devhub/templates/devhub/versions/add_file_modal.html:46
+#: src/olympia/devhub/templates/devhub/versions/add_file_modal.html:35
 msgid "Which review type would you like to nominate for?"
 msgstr "За који тип преглед желите да је номинујете?"
 
-#: src/olympia/devhub/templates/devhub/versions/add_file_modal.html:51
+#: src/olympia/devhub/templates/devhub/versions/add_file_modal.html:40
 msgid "Only publish this version to my beta channel."
 msgstr "Објави ову верзију само на мој бета канал."
-
-#: src/olympia/devhub/templates/devhub/versions/add_file_modal.html:54
-#, python-format
-msgid ""
-"The behavior of the beta channel has changed to accommodate <a href=\"%(addon_signing_url)s\" target=\"_blank\">mandatory add-on signing</a>. The new process is currently in an open beta, and may "
-"change significantly in the near future. Please <a href=\"%(issues_url)s\" target=\"_blank\">report any bugs</a> that you encounter."
-msgstr ""
 
 #: src/olympia/devhub/templates/devhub/versions/edit.html:5
 msgid "Manage Version {0}"
@@ -6829,10 +6684,6 @@ msgstr "Датотеке"
 #: src/olympia/devhub/templates/devhub/versions/edit.html:38
 msgid "Upload Another File"
 msgstr "Постави још једну датотеку"
-
-#: src/olympia/devhub/templates/devhub/versions/edit.html:45
-msgid "Adjusting application information here will allow users to install your add-on even if the install manifest in the package indicates that the add-on is incompatible."
-msgstr "Подешавање информације о апликацији овде ће дозволити корисницима да инсталирају Ваш додатак чак иако манифест инсталације у пакету указује да је додатак некомпатибилан."
 
 #: src/olympia/devhub/templates/devhub/versions/edit.html:74
 msgid ""
@@ -6903,7 +6754,6 @@ msgid "{0} file"
 msgid_plural "{0} files"
 msgstr[0] "{0} датотека"
 msgstr[1] "{0} датотеке"
-msgstr[2] "{0} датотека"
 
 #: src/olympia/devhub/templates/devhub/versions/list.html:25
 msgid "0 files"
@@ -6930,7 +6780,7 @@ msgstr "Захтевај пуну преглед"
 msgid "Request Preliminary Review"
 msgstr "Захтева прелиминаран преглед"
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:80 src/olympia/devhub/templates/devhub/versions/list.html:327 src/olympia/devhub/templates/devhub/versions/list.html:350
+#: src/olympia/devhub/templates/devhub/versions/list.html:80 src/olympia/devhub/templates/devhub/versions/list.html:325 src/olympia/devhub/templates/devhub/versions/list.html:348
 msgid "Cancel Review Request"
 msgstr "Откажи захтев за преглед"
 
@@ -6959,7 +6809,7 @@ msgid "Unlisted:"
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/versions/list.html:114
-msgid "Not distributed on {0}. Developers will upload new versions for signing and distribute the add-ons on their own. (beta)"
+msgid "Not distributed on {0}. Developers will upload new versions for signing and distribute the add-ons on their own."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/versions/list.html:122
@@ -7021,78 +6871,73 @@ msgid "<strong>Important:</strong> Once a version has been deleted, you may not 
 msgstr "<strong>Важно:</strong> Када је једном верзија избрисана, не бисте требали поставити нову верзију са истим бројем."
 
 #: src/olympia/devhub/templates/devhub/versions/list.html:230
-msgid "Deleting a version which has already been reviewed may also cause a significant delay in the review of your next update."
-msgstr "Брисање верзије која је већ била прегледана може да проузрокује значајна кашњења код прегледавања Ваше следеће надоградње."
-
-#: src/olympia/devhub/templates/devhub/versions/list.html:233
 msgid "Are you sure you wish to delete this version?"
 msgstr "Да ли сте сигурни да желите обрисати ову верзију?"
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:238
+#: src/olympia/devhub/templates/devhub/versions/list.html:235
 msgid "Delete Version"
 msgstr "Обриши верзију"
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:240
+#: src/olympia/devhub/templates/devhub/versions/list.html:237
 msgid "Disable Version"
 msgstr "Онемогући верзију"
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:247
+#: src/olympia/devhub/templates/devhub/versions/list.html:244
 msgid "Add a new Version"
 msgstr "Додај нову верзију"
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:249
+#: src/olympia/devhub/templates/devhub/versions/list.html:246
 msgid "Add Version"
 msgstr "Додајте верзију"
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:256 src/olympia/devhub/templates/devhub/versions/list.html:274
+#: src/olympia/devhub/templates/devhub/versions/list.html:253 src/olympia/devhub/templates/devhub/versions/list.html:279
 msgid "Hide Add-on"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:259
+#: src/olympia/devhub/templates/devhub/versions/list.html:256
 msgid "Hiding your add-on will prevent it from appearing anywhere in our gallery and will stop users from receiving automatic updates."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:265
+#: src/olympia/devhub/templates/devhub/versions/list.html:263
+msgid "The files awaiting review will be disabled and you will need to upload new versions."
+msgstr ""
+
+#: src/olympia/devhub/templates/devhub/versions/list.html:270
 msgid "Are you sure you wish to hide your add-on?"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:286 src/olympia/devhub/templates/devhub/versions/list.html:315
+#: src/olympia/devhub/templates/devhub/versions/list.html:291 src/olympia/devhub/templates/devhub/versions/list.html:313
 msgid "Unlist Add-on"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:289
+#: src/olympia/devhub/templates/devhub/versions/list.html:294
 #, python-format
 msgid ""
 "Unlisting your add-on will make it (and each of its versions/files) invisible on this website. It won't show up in searches, won't have a public facing page, and won't be updated automatically for "
-"current users.  It is recommended for unlisted add-ons to provide a custom <a href=\"%(update_url)s\" target=\"_blank\">updateURL</a> in their manifest file for automatic updates."
+"current users. It is recommended for unlisted add-ons to provide a custom <a href=\"%(update_url)s\" target=\"_blank\">updateURL</a> in their manifest file for automatic updates."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:299
-#, python-format
-msgid "Switching add-ons to unlisted is currently in an open beta. Please <a href=\"%(url)s\" target=\"_blank\">report any bugs</a> that you encounter."
-msgstr ""
-
-#: src/olympia/devhub/templates/devhub/versions/list.html:305
+#: src/olympia/devhub/templates/devhub/versions/list.html:303
 msgid "Unlisting an add-on is irreversible!"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:305
+#: src/olympia/devhub/templates/devhub/versions/list.html:303
 msgid "An unlisted add-on cannot be switched to be listed."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:307
+#: src/olympia/devhub/templates/devhub/versions/list.html:305
 msgid "Are you sure you wish to unlist your add-on?"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:330
+#: src/olympia/devhub/templates/devhub/versions/list.html:328
 msgid "Canceling your review request will leave your add-on as preliminarily reviewed."
 msgstr "Прекидање Вашег захтева за преглед ће учинити додатак прелиминарно прегледаним."
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:335
+#: src/olympia/devhub/templates/devhub/versions/list.html:333
 msgid "Canceling your review request will mark your add-on incomplete. If you do not complete your add-on after several days by re-requesting review, it will be deleted."
 msgstr "Прекидање Вашег захтева за преглед ће означити додатак као незавршен. Уколико не завршите Ваш додатак за неколико дана поново тражећи преглед додатак ће бити избрисан."
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:343
+#: src/olympia/devhub/templates/devhub/versions/list.html:341
 msgid "Are you sure you wish to cancel your review request?"
 msgstr "Да ли сте сигурни да желите да прекинете Ваш захтев за преглед?"
 
@@ -7435,19 +7280,19 @@ msgstr "додатак, уредник или коментар"
 msgid "Search by add-on name / author email"
 msgstr "Претражи по називу додатка / е-пошти аутора"
 
-#: src/olympia/editors/forms.py:103
+#: src/olympia/editors/forms.py:103 src/olympia/editors/forms.py:244 src/olympia/editors/forms.py:257
 msgid "yes"
 msgstr "да"
 
-#: src/olympia/editors/forms.py:104
+#: src/olympia/editors/forms.py:104 src/olympia/editors/forms.py:244 src/olympia/editors/forms.py:257
 msgid "no"
 msgstr "не"
 
-#: src/olympia/editors/forms.py:105
+#: src/olympia/editors/forms.py:105 src/olympia/editors/forms.py:245
 msgid "Admin Flag"
 msgstr "Админ застава"
 
-#: src/olympia/editors/forms.py:113
+#: src/olympia/editors/forms.py:113 src/olympia/editors/forms.py:253
 msgid "Max. Version"
 msgstr "Последња верзија"
 
@@ -7459,55 +7304,59 @@ msgstr "Дана од подношења"
 msgid "Add-on Types"
 msgstr "Врсте додатка"
 
-#: src/olympia/editors/forms.py:126 src/olympia/editors/helpers.py:267
+#: src/olympia/editors/forms.py:126 src/olympia/editors/helpers.py:279
 msgid "Platforms"
 msgstr "Платформе"
 
+#: src/olympia/editors/forms.py:237
+msgid "Search by add-on name / author email / guid"
+msgstr ""
+
 #. L10n: 0 = platform, 1 = filename, 2 = status message
-#: src/olympia/editors/forms.py:238
+#: src/olympia/editors/forms.py:342
 #, python-format
 msgid "<strong>%s</strong> &middot; %s &middot; %s"
 msgstr "<strong>%s</strong> &middot; %s &middot; %s"
 
-#: src/olympia/editors/forms.py:252
+#: src/olympia/editors/forms.py:356
 msgid "Comments:"
 msgstr "Коментари:"
 
-#: src/olympia/editors/forms.py:256
+#: src/olympia/editors/forms.py:360
 msgid "Operating systems:"
 msgstr "Оперативни системи:"
 
-#: src/olympia/editors/forms.py:258
+#: src/olympia/editors/forms.py:362
 msgid "Applications:"
 msgstr "Апликације:"
 
-#: src/olympia/editors/forms.py:260
+#: src/olympia/editors/forms.py:364
 msgid "Notify me the next time this add-on is updated. (Subsequent updates will not generate an email)"
 msgstr "Обавести ме следећи пут када се овај додатак ажурира. (Накнадна ажурирања неће генерисати е-пошту)"
 
-#: src/olympia/editors/forms.py:265
+#: src/olympia/editors/forms.py:369
 msgid "Clear Admin Review Flag"
 msgstr "Уклони ознаку за рецензију администратора"
 
-#: src/olympia/editors/forms.py:267
+#: src/olympia/editors/forms.py:371
 msgid "Clear more info requested flag"
 msgstr ""
 
-#: src/olympia/editors/forms.py:281
+#: src/olympia/editors/forms.py:385
 msgid "Choose a canned response..."
 msgstr "Изабери готов одговор..."
 
 #. L10n: Description of what can be searched for.
-#: src/olympia/editors/forms.py:324
+#: src/olympia/editors/forms.py:423
 msgid "theme name"
 msgstr "назив теме"
 
-#: src/olympia/editors/forms.py:350
+#: src/olympia/editors/forms.py:449
 msgid "Someone else is reviewing this theme."
 msgstr "Неко други прегледава ову тему."
 
 #. L10n: Description of what can be searched for.
-#: src/olympia/editors/forms.py:447
+#: src/olympia/editors/forms.py:546
 msgid "app, reviewer, or comment"
 msgstr "апликација, рецензент, или коментар"
 
@@ -7523,203 +7372,210 @@ msgstr "Чекање прелиминарне рецензије"
 msgid "Rejected or Unreviewed"
 msgstr "Одбијено или непрегледано"
 
-#: src/olympia/editors/helpers.py:123 src/olympia/editors/helpers.py:136
+#: src/olympia/editors/helpers.py:125 src/olympia/editors/helpers.py:138
 msgid "Queue"
 msgstr "На чекању"
 
-#: src/olympia/editors/helpers.py:124 src/olympia/editors/templates/editors/base.html:50 src/olympia/editors/templates/editors/base.html:65
+#: src/olympia/editors/helpers.py:126 src/olympia/editors/templates/editors/base.html:50 src/olympia/editors/templates/editors/base.html:65
 msgid "Pending Updates"
 msgstr "Ажурирања на чекању"
 
-#: src/olympia/editors/helpers.py:125 src/olympia/editors/templates/editors/base.html:48 src/olympia/editors/templates/editors/base.html:63
+#: src/olympia/editors/helpers.py:127 src/olympia/editors/templates/editors/base.html:48 src/olympia/editors/templates/editors/base.html:63
 msgid "Full Reviews"
 msgstr "Потпуне рецензије"
 
-#: src/olympia/editors/helpers.py:126 src/olympia/editors/templates/editors/base.html:52 src/olympia/editors/templates/editors/base.html:67
+#: src/olympia/editors/helpers.py:128 src/olympia/editors/templates/editors/base.html:52 src/olympia/editors/templates/editors/base.html:67
 msgid "Preliminary Reviews"
 msgstr "Прелиминарне рецензије"
 
-#: src/olympia/editors/helpers.py:127 src/olympia/editors/templates/editors/base.html:54
+#: src/olympia/editors/helpers.py:129 src/olympia/editors/templates/editors/base.html:54
 msgid "Moderated Reviews"
 msgstr "Уређене рецензије"
 
-#: src/olympia/editors/helpers.py:128 src/olympia/editors/templates/editors/base.html:46
+#: src/olympia/editors/helpers.py:130 src/olympia/editors/templates/editors/base.html:46
 msgid "Fast Track"
 msgstr "Брза трака"
 
-#: src/olympia/editors/helpers.py:130
+#: src/olympia/editors/helpers.py:132
 msgid "Pending Themes"
 msgstr "Теме на чекању"
 
-#: src/olympia/editors/helpers.py:131 src/olympia/editors/templates/editors/themes/queue.html:4
+#: src/olympia/editors/helpers.py:133 src/olympia/editors/templates/editors/themes/queue.html:4
 msgid "Flagged Themes"
 msgstr "Означене теме"
 
-#: src/olympia/editors/helpers.py:132
+#: src/olympia/editors/helpers.py:134
 msgid "Update Themes"
 msgstr "Ажурирај теме"
 
-#: src/olympia/editors/helpers.py:137
+#: src/olympia/editors/helpers.py:139
 msgid "Unlisted Pending Updates"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:138
+#: src/olympia/editors/helpers.py:140
 msgid "Unlisted Full Reviews"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:139
+#: src/olympia/editors/helpers.py:141
 msgid "Unlisted Preliminary Reviews"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:170
+#: src/olympia/editors/helpers.py:142
+msgid "Unlisted All Add-ons"
+msgstr ""
+
+#: src/olympia/editors/helpers.py:173
 msgid "Fast Track ({0})"
 msgid_plural "Fast Track ({0})"
 msgstr[0] "Брза трака ({0})"
 msgstr[1] "Брза трака ({0})"
-msgstr[2] "Брза трака ({0})"
 
-#: src/olympia/editors/helpers.py:175
+#: src/olympia/editors/helpers.py:178
 msgid "Full Review ({0})"
 msgid_plural "Full Reviews ({0})"
 msgstr[0] "({0}) пуна рецензија"
 msgstr[1] "({0}) пуне рецензије"
-msgstr[2] "({0}) пуних рецензија"
 
-#: src/olympia/editors/helpers.py:180
+#: src/olympia/editors/helpers.py:183
 msgid "Pending Update ({0})"
 msgid_plural "Pending Updates ({0})"
 msgstr[0] "({0}) ажурирање на чекању"
 msgstr[1] "({0}) ажурирања на чекању"
-msgstr[2] "({0}) ажурирања на чекању"
 
-#: src/olympia/editors/helpers.py:185
+#: src/olympia/editors/helpers.py:188
 msgid "Preliminary Review ({0})"
 msgid_plural "Preliminary Reviews ({0})"
 msgstr[0] "Прелиминарни преглед ({0})"
 msgstr[1] "Прелиминарна прегледа ({0})"
-msgstr[2] "Прелиминарних прегледа ({0})"
 
-#: src/olympia/editors/helpers.py:190
+#: src/olympia/editors/helpers.py:193
 msgid "Moderated Review ({0})"
 msgid_plural "Moderated Reviews ({0})"
 msgstr[0] "Конторлисан преглед ({0})"
 msgstr[1] "Конторлисана прегледа ({0})"
-msgstr[2] "Конторлисаних прегледа ({0})"
 
-#: src/olympia/editors/helpers.py:196
+#: src/olympia/editors/helpers.py:199
 msgid "Unlisted Full Review ({0})"
 msgid_plural "Unlisted Full Reviews ({0})"
 msgstr[0] ""
 msgstr[1] ""
-msgstr[2] ""
 
-#: src/olympia/editors/helpers.py:201
+#: src/olympia/editors/helpers.py:204
 msgid "Unlisted Pending Update ({0})"
 msgid_plural "Unlisted Pending Updates ({0})"
 msgstr[0] ""
 msgstr[1] ""
-msgstr[2] ""
 
-#: src/olympia/editors/helpers.py:206
+#: src/olympia/editors/helpers.py:209
 msgid "Unlisted Preliminary Review ({0})"
 msgid_plural "Unlisted Preliminary Reviews ({0})"
 msgstr[0] ""
 msgstr[1] ""
-msgstr[2] ""
 
-#: src/olympia/editors/helpers.py:261
-msgid "Addon"
-msgstr "Додатак"
+#: src/olympia/editors/helpers.py:214
+msgid "Unlisted All Add-ons ({0})"
+msgid_plural "Unlisted All Add-ons ({0})"
+msgstr[0] ""
+msgstr[1] ""
 
-#: src/olympia/editors/helpers.py:262
+#: src/olympia/editors/helpers.py:274
 msgid "Type"
 msgstr "Тип"
 
-#: src/olympia/editors/helpers.py:263
+#: src/olympia/editors/helpers.py:275
 msgid "Waiting Time"
 msgstr "Време чекања"
 
-#: src/olympia/editors/helpers.py:264 src/olympia/editors/templates/editors/review.html:285
+#: src/olympia/editors/helpers.py:276 src/olympia/editors/templates/editors/review.html:285
 msgid "Flags"
 msgstr "Ознаке"
 
-#: src/olympia/editors/helpers.py:265
+#: src/olympia/editors/helpers.py:277
 msgid "Applications"
 msgstr "Апликације"
 
-#: src/olympia/editors/helpers.py:270
+#: src/olympia/editors/helpers.py:282
 msgid "Additional"
 msgstr "Додатно"
 
-#: src/olympia/editors/helpers.py:285
+#: src/olympia/editors/helpers.py:302
 msgid "Site Specific"
 msgstr "Посебно за сајт"
 
-#: src/olympia/editors/helpers.py:287
+#: src/olympia/editors/helpers.py:304
 msgid "Requires External Software"
 msgstr "Захтева спољни софтвер"
 
-#: src/olympia/editors/helpers.py:289
+#: src/olympia/editors/helpers.py:306
 msgid "Binary Components"
 msgstr "Бинарне компоненте"
 
-#: src/olympia/editors/helpers.py:313
+#: src/olympia/editors/helpers.py:339
 msgid "moments ago"
 msgstr "пре неколико момената"
 
 #. L10n: first argument is number of minutes
-#: src/olympia/editors/helpers.py:316
+#: src/olympia/editors/helpers.py:342
 msgid "{0} minute"
 msgid_plural "{0} minutes"
 msgstr[0] "{0} минут"
 msgstr[1] "{0} минута"
-msgstr[2] "{0} минута"
 
 #. L10n: first argument is number of hours
-#: src/olympia/editors/helpers.py:320
+#: src/olympia/editors/helpers.py:346
 msgid "{0} hour"
 msgid_plural "{0} hours"
 msgstr[0] "{0} сат"
 msgstr[1] "{0} сата"
-msgstr[2] "{0} сати"
 
 #. L10n: first argument is number of days
-#: src/olympia/editors/helpers.py:324
+#: src/olympia/editors/helpers.py:350
 msgid "{0} day"
 msgid_plural "{0} days"
 msgstr[0] "{0} дан"
 msgstr[1] "{0} дана"
-msgstr[2] "{0} дана"
 
-#: src/olympia/editors/helpers.py:488
+#: src/olympia/editors/helpers.py:364
+msgid "Last Review"
+msgstr ""
+
+#: src/olympia/editors/helpers.py:366
+msgid "Last Update"
+msgstr ""
+
+#: src/olympia/editors/helpers.py:387
+msgid "No Reviews"
+msgstr ""
+
+#: src/olympia/editors/helpers.py:561
 msgid "Push to public"
 msgstr "Направи јавним"
 
-#: src/olympia/editors/helpers.py:490
+#: src/olympia/editors/helpers.py:563
 msgid "Grant full review"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:505
+#: src/olympia/editors/helpers.py:578
 msgid "Request more information"
 msgstr "Затражи више информација"
 
-#: src/olympia/editors/helpers.py:508
+#: src/olympia/editors/helpers.py:581
 msgid "Request super-review"
 msgstr "Захтевај супер-рецензију"
 
-#: src/olympia/editors/helpers.py:519
+#: src/olympia/editors/helpers.py:592
 msgid "Grant preliminary review"
 msgstr "Одобри прелиминарни преглед"
 
-#: src/olympia/editors/helpers.py:520
+#: src/olympia/editors/helpers.py:593
 msgid "This will mark the files as preliminarily reviewed."
 msgstr "Ово ће означити датотеке као прелиминарно прегледане."
 
-#: src/olympia/editors/helpers.py:522
+#: src/olympia/editors/helpers.py:595
 msgid "Use this form to request more information from the author. They will receive an email and be able to answer here. You will be notified by email when they reply."
 msgstr "Користите ову форму да бисте захтевали више информација од аутора. Примиће е-пошту и биће у могућности овде да одговори. Бићете обавештени путем е-поште када одговори."
 
-#: src/olympia/editors/helpers.py:526
+#: src/olympia/editors/helpers.py:599
 msgid ""
 "If you have concerns about this add-on's security, copyright issues, or other concerns that an administrator should look into, enter your comments in the area below. They will be sent to "
 "administrators, not the author."
@@ -7727,55 +7583,55 @@ msgstr ""
 "Ако бринете о безбедности овог додатка, о његовим ауторским правима, или неким другим стварима које би администратор требао да погледа, унесите Ваш коментар у поље испод. Биће послат "
 "администраторима, не аутору."
 
-#: src/olympia/editors/helpers.py:532
+#: src/olympia/editors/helpers.py:605
 msgid "This will reject the add-on and remove it from the review queue."
 msgstr "Ово ће одбити додатак и уклонити га са листе чекања."
 
-#: src/olympia/editors/helpers.py:534
+#: src/olympia/editors/helpers.py:607
 msgid "Make a comment on this version. The author won't be able to see this."
 msgstr "Коментаришите ову верзију. Аутор неће бити у могућности да га види."
 
-#: src/olympia/editors/helpers.py:538
+#: src/olympia/editors/helpers.py:611
 msgid "This will reject the files and remove them from the review queue."
 msgstr "Ово ће одбити датотеке и уклонити их са чекања рецензије."
 
-#: src/olympia/editors/helpers.py:542
+#: src/olympia/editors/helpers.py:615
 msgid "This will mark the add-on as preliminarily reviewed. Future versions will undergo preliminary review."
 msgstr "Ово ће означити додатак као прелиминарно прегледан. Будуће верзије ће проћи кроз прелиминарни преглед."
 
-#: src/olympia/editors/helpers.py:547
+#: src/olympia/editors/helpers.py:620
 msgid "This will mark the files as preliminarily reviewed. Future versions will undergo preliminary review."
 msgstr "Ово ће означити датотеке као прелиминарно прегледане. Будуће верзије ће проћи кроз прелиминарни преглед."
 
-#: src/olympia/editors/helpers.py:552
+#: src/olympia/editors/helpers.py:625
 msgid "Retain preliminary review"
 msgstr "Задржи прелиминарну рецензију"
 
-#: src/olympia/editors/helpers.py:553
+#: src/olympia/editors/helpers.py:626
 msgid "This will retain the add-on as preliminarily reviewed. Future versions will undergo preliminary review."
 msgstr "Ово ће задржати додатке као прелиминарно прегледане. Будуће верзије ће проћи кроз прелиминарни преглед."
 
-#: src/olympia/editors/helpers.py:558
+#: src/olympia/editors/helpers.py:631
 msgid "This will approve a sandboxed version of a public add-on to appear on the public side."
 msgstr "Ово ће одобрити верзију у заштићеном окружењу јавног додатка да се појави на јавној страни."
 
-#: src/olympia/editors/helpers.py:561
+#: src/olympia/editors/helpers.py:634
 msgid "This will reject a version of a public add-on and remove it from the queue."
 msgstr "Ово ће одбити верзију јавног додатка и уклониће га са листе чекања."
 
-#: src/olympia/editors/helpers.py:564
+#: src/olympia/editors/helpers.py:637
 msgid "This will mark the add-on and its most recent version and files as public. Future versions will go into the sandbox until they are reviewed by an editor."
 msgstr "Ово ће означити додатак и његове скорашње верзије и датотеке као јавне. Будуће верзије ће отићи у заштићено окружење док не буду прегледане од стране уредника."
 
-#: src/olympia/editors/helpers.py:637
+#: src/olympia/editors/helpers.py:714
 msgid "add-on"
 msgstr "додатак"
 
-#: src/olympia/editors/helpers.py:940 src/olympia/editors/helpers.py:960
+#: src/olympia/editors/helpers.py:1020 src/olympia/editors/helpers.py:1040
 msgid "Flagged"
 msgstr "Означено"
 
-#: src/olympia/editors/helpers.py:944 src/olympia/editors/helpers.py:963
+#: src/olympia/editors/helpers.py:1024 src/olympia/editors/helpers.py:1043
 msgid "Updates"
 msgstr "Ажурирања"
 
@@ -7827,56 +7683,56 @@ msgstr "Поднешење теме је означено за преглед"
 msgid "A question about your Theme submission"
 msgstr "Питање о Вашем подношењу теме"
 
-#: src/olympia/editors/views.py:144
+#: src/olympia/editors/views.py:146
 msgid "New Add-ons (Under 5 days)"
 msgstr "Нови додатак (испод 5 дана)"
 
-#: src/olympia/editors/views.py:145
+#: src/olympia/editors/views.py:147
 msgid "Passable (5 to 10 days)"
 msgstr "Пролазно (5 до 10 дана)"
 
-#: src/olympia/editors/views.py:146
+#: src/olympia/editors/views.py:148
 msgid "Overdue (Over 10 days)"
 msgstr "Истекао рок (више од 10 дана)"
 
-#: src/olympia/editors/views.py:532
+#: src/olympia/editors/views.py:539
 msgid "An unknown error occurred"
 msgstr "Појавила се непозната грешка"
 
-#: src/olympia/editors/views.py:587
+#: src/olympia/editors/views.py:592
 msgid "Self-reviews are not allowed."
 msgstr "Сопствене рецензије нису дозвољене."
 
-#: src/olympia/editors/views.py:609
+#: src/olympia/editors/views.py:613
 msgid "Review successfully processed."
 msgstr "Рецензија успешно процесирана."
 
-#: src/olympia/editors/views.py:807
+#: src/olympia/editors/views.py:812
 msgid "was approved"
 msgstr "је одобрено"
 
-#: src/olympia/editors/views.py:808
+#: src/olympia/editors/views.py:813
 msgid "given preliminary review"
 msgstr "је дата прелиминарна рецензија"
 
-#: src/olympia/editors/views.py:809
+#: src/olympia/editors/views.py:814
 msgid "rejected"
 msgstr "одбијено"
 
-#: src/olympia/editors/views.py:810
+#: src/olympia/editors/views.py:815
 msgctxt "editors_review_history_nominated_adminreview"
 msgid "escalated"
 msgstr "ескалирано"
 
-#: src/olympia/editors/views.py:812
+#: src/olympia/editors/views.py:817
 msgid "needs more information"
 msgstr "треба више информација"
 
-#: src/olympia/editors/views.py:813
+#: src/olympia/editors/views.py:818
 msgid "needs super review"
 msgstr "захтева супер рецензију"
 
-#: src/olympia/editors/views.py:814
+#: src/olympia/editors/views.py:819
 msgid "commented"
 msgstr ""
 
@@ -7885,7 +7741,6 @@ msgid "{0} theme review successfully processed (+{1} points, {2} total)."
 msgid_plural "{0} theme reviews successfully processed (+{1} points, {2} total)."
 msgstr[0] "{0} рецензија теме је успешно обрађена (+{1} поена, {2} укупно)."
 msgstr[1] "{0} рецензије теме су успешно обрађене (+{1} поена, {2} укупно)."
-msgstr[2] "{0} рецензија теме су успешно обрађене (+{1} поена, {2} укупно)."
 
 #: src/olympia/editors/views_themes.py:341
 msgid "Your theme locks have successfully been released. Other reviewers may now review those released themes. You may have to refresh the page to see the changes reflected in the table below."
@@ -7922,28 +7777,28 @@ msgstr "Редови за чекање"
 msgid "Unlisted Queues"
 msgstr ""
 
-#: src/olympia/editors/templates/editors/base.html:72 src/olympia/editors/templates/editors/performance.html:6
+#: src/olympia/editors/templates/editors/base.html:74 src/olympia/editors/templates/editors/performance.html:6
 msgid "Performance"
 msgstr "Перформансе"
 
-#: src/olympia/editors/templates/editors/base.html:75 src/olympia/editors/templates/editors/themes/base.html:19 src/olympia/editors/templates/editors/themes/base.html:38
+#: src/olympia/editors/templates/editors/base.html:77 src/olympia/editors/templates/editors/themes/base.html:19 src/olympia/editors/templates/editors/themes/base.html:38
 msgid "Logs"
 msgstr "Дневници"
 
-#: src/olympia/editors/templates/editors/base.html:78 src/olympia/editors/templates/editors/reviewlog.html:4 src/olympia/editors/templates/editors/reviewlog.html:27
+#: src/olympia/editors/templates/editors/base.html:80 src/olympia/editors/templates/editors/reviewlog.html:4 src/olympia/editors/templates/editors/reviewlog.html:27
 msgid "Add-on Review Log"
 msgstr "Дневник рецензија додатка"
 
-#: src/olympia/editors/templates/editors/base.html:80 src/olympia/editors/templates/editors/eventlog.html:4 src/olympia/editors/templates/editors/eventlog.html:8
+#: src/olympia/editors/templates/editors/base.html:82 src/olympia/editors/templates/editors/eventlog.html:4 src/olympia/editors/templates/editors/eventlog.html:8
 #: src/olympia/editors/templates/editors/eventlog_detail.html:4
 msgid "Moderated Review Log"
 msgstr "Контролисан дневник прегледа"
 
-#: src/olympia/editors/templates/editors/base.html:82 src/olympia/editors/templates/editors/beta_signed_log.html:4 src/olympia/editors/templates/editors/beta_signed_log.html:8
+#: src/olympia/editors/templates/editors/base.html:84 src/olympia/editors/templates/editors/beta_signed_log.html:4 src/olympia/editors/templates/editors/beta_signed_log.html:8
 msgid "Signed Beta Files Log"
 msgstr ""
 
-#: src/olympia/editors/templates/editors/base.html:87 src/olympia/editors/templates/editors/includes/daily-message.html:4
+#: src/olympia/editors/templates/editors/base.html:89 src/olympia/editors/templates/editors/includes/daily-message.html:4
 msgid "Announcement"
 msgstr "Саопштење"
 
@@ -8003,21 +7858,18 @@ msgid "Full Review ({num})"
 msgid_plural "Full Reviews ({num})"
 msgstr[0] "({num}) пуна рецензија"
 msgstr[1] "({num}) пуне рецензије"
-msgstr[2] "({num}) пуних рецензија"
 
 #: src/olympia/editors/templates/editors/home.html:18
 msgid "Pending Update ({num})"
 msgid_plural "Pending Updates ({num})"
 msgstr[0] "({num}) надоградња на чекању"
 msgstr[1] "({num}) надоградње на чекању"
-msgstr[2] "({num}) надоградњи на чекању"
 
 #: src/olympia/editors/templates/editors/home.html:25
 msgid "Preliminary Review ({num})"
 msgid_plural "Preliminary Reviews ({num})"
 msgstr[0] "({num}) прелиминарна рецензија"
 msgstr[1] "({num}) прелиминарне рецензије"
-msgstr[2] "({num}) прелиминарних рецензија"
 
 #: src/olympia/editors/templates/editors/home.html:36 src/olympia/editors/templates/editors/home.html:86
 msgid "Current waiting times:"
@@ -8028,7 +7880,6 @@ msgid "{0} add-on"
 msgid_plural "{0} add-ons"
 msgstr[0] "{0} додатак"
 msgstr[1] "{0} додатка"
-msgstr[2] "{0} додатака"
 
 #: src/olympia/editors/templates/editors/home.html:45 src/olympia/editors/templates/editors/home.html:95
 #, python-format
@@ -8040,21 +7891,18 @@ msgid "Unlisted Full Review ({num})"
 msgid_plural "Unlisted Full Reviews ({num})"
 msgstr[0] ""
 msgstr[1] ""
-msgstr[2] ""
 
 #: src/olympia/editors/templates/editors/home.html:68
 msgid "Unlisted Pending Update ({num})"
 msgid_plural "Unlisted Pending Updates ({num})"
 msgstr[0] ""
 msgstr[1] ""
-msgstr[2] ""
 
 #: src/olympia/editors/templates/editors/home.html:75
 msgid "Unlisted Preliminary Review ({num})"
 msgid_plural "Unlisted Preliminary Reviews ({num})"
 msgstr[0] ""
 msgstr[1] ""
-msgstr[2] ""
 
 #: src/olympia/editors/templates/editors/home.html:109 src/olympia/editors/templates/editors/performance.html:37 src/olympia/editors/templates/editors/themes/home.html:54
 msgid "Total Reviews"
@@ -8078,7 +7926,6 @@ msgid "Moderated Review ({num})"
 msgid_plural "Moderated Reviews ({num})"
 msgstr[0] "({num}) уређена рецензија"
 msgstr[1] "({num}) уређене рецензије"
-msgstr[2] "({num}) уређених рецензија"
 
 #: src/olympia/editors/templates/editors/leaderboard.html:3 src/olympia/editors/templates/editors/includes/reviewers_score_bar.html:56
 msgid "Reviewer Leaderboard"
@@ -8172,46 +8019,46 @@ msgstr "Напредна претрага"
 msgid "clear search"
 msgstr "очисти претрагу"
 
-#: src/olympia/editors/templates/editors/queue.html:72 src/olympia/editors/templates/editors/queue.html:122
+#: src/olympia/editors/templates/editors/queue.html:78 src/olympia/editors/templates/editors/queue.html:128
 msgid "Process Reviews"
 msgstr "Процесирај рецензије"
 
-#: src/olympia/editors/templates/editors/queue.html:80
+#: src/olympia/editors/templates/editors/queue.html:86
 msgid "Moderation actions:"
 msgstr "Акције модерације:"
 
-#: src/olympia/editors/templates/editors/queue.html:90
+#: src/olympia/editors/templates/editors/queue.html:96
 #, python-format
 msgid "by %(user)s on %(date)s %(stars)s (%(locale)s)"
 msgstr "од %(user)s дана %(date)s %(stars)s (%(locale)s)"
 
-#: src/olympia/editors/templates/editors/queue.html:106
+#: src/olympia/editors/templates/editors/queue.html:112
 #, python-format
 msgid "<strong>%(reason)s</strong> <span class=\"light\">Flagged by %(user)s on %(date)s</span>"
 msgstr "<strong>%(reason)s</strong> <span class=\"light\">Означио %(user)s дана %(date)s</span>"
 
-#: src/olympia/editors/templates/editors/queue.html:119
+#: src/olympia/editors/templates/editors/queue.html:125
 msgid "All reviews have been moderated. Good work!"
 msgstr "Све рецензије су уређене. Свака част!"
 
-#: src/olympia/editors/templates/editors/queue.html:161
+#: src/olympia/editors/templates/editors/queue.html:167
 msgid "Version Notes / Notes for Reviewer"
 msgstr "Белешке о верзији / Белешке за рецензента"
 
 # %1 is the queue mode
-#: src/olympia/editors/templates/editors/queue.html:169
+#: src/olympia/editors/templates/editors/queue.html:175
 msgid "There are currently no add-ons of this type to review."
 msgstr "Тренутно нема додатака овог типа за преглед."
 
-#: src/olympia/editors/templates/editors/queue.html:181 src/olympia/editors/templates/editors/themes/queue_list.html:85
+#: src/olympia/editors/templates/editors/queue.html:187 src/olympia/editors/templates/editors/themes/queue_list.html:85
 msgid "Helpful Links:"
 msgstr "Корисне везе:"
 
-#: src/olympia/editors/templates/editors/queue.html:182
+#: src/olympia/editors/templates/editors/queue.html:188
 msgid "Add-on Policy"
 msgstr "Политика додатка"
 
-#: src/olympia/editors/templates/editors/queue.html:184
+#: src/olympia/editors/templates/editors/queue.html:190
 msgid "Editors' Guide"
 msgstr "Савети уредника"
 
@@ -8417,21 +8264,18 @@ msgid "{num} Pending Theme Review"
 msgid_plural "{num} Pending Theme Reviews"
 msgstr[0] "{num} Тема чека на преглед"
 msgstr[1] "{num} Теме чекају на преглед"
-msgstr[2] "{num} Тема чека на преглед"
 
 #: src/olympia/editors/templates/editors/themes/home.html:27
 msgid "{num} Flagged Review"
 msgid_plural "{num} Flagged Reviews"
 msgstr[0] "{num} Означена рецензија"
 msgstr[1] "{num} Означене рецензије"
-msgstr[2] "{num} Означених рецензија"
 
 #: src/olympia/editors/templates/editors/themes/home.html:34
 msgid "{num} Update"
 msgid_plural "{num} Updates"
 msgstr[0] "{num} Ажурирање"
 msgstr[1] "{num} Ажурирања"
-msgstr[2] "{num} Ажурирања"
 
 #: src/olympia/editors/templates/editors/themes/logs.html:4
 msgid "Theme Review Log"
@@ -8550,7 +8394,7 @@ msgstr "Поставите питање аутору"
 msgid "Describe your reason for flagging"
 msgstr "Наведите Ваше разлоге за означавање"
 
-#: src/olympia/files/forms.py:88
+#: src/olympia/files/forms.py:90
 msgid "Cannot diff a version against itself"
 msgstr ""
 
@@ -8585,51 +8429,51 @@ msgstr "Дошло је до грешке приликом приступања 
 msgid "There was an error accessing file %s."
 msgstr "Дошло је до грешке приликом приступања датотеци %s."
 
-#: src/olympia/files/utils.py:343
+#: src/olympia/files/utils.py:340
 msgid "Could not parse uploaded file."
 msgstr "Није могуће рашчланити отпремљену датотеку."
 
-#: src/olympia/files/utils.py:380
+#: src/olympia/files/utils.py:377
 msgid "Invalid file name in archive: {0}"
 msgstr "Неважећи назив датотеке у архиви: {0}"
 
-#: src/olympia/files/utils.py:388
+#: src/olympia/files/utils.py:385
 msgid "File exceeding size limit in archive: {0}"
 msgstr "Величина прелази ограничење величине у архиви: {0}"
 
-#: src/olympia/files/utils.py:439
+#: src/olympia/files/utils.py:436
 msgid "Invalid archive."
 msgstr "Неважећа архива."
 
-#: src/olympia/files/utils.py:529 src/olympia/files/utils.py:532
+#: src/olympia/files/utils.py:526 src/olympia/files/utils.py:529
 msgid "Could not parse the manifest file."
 msgstr ""
 
-#: src/olympia/files/utils.py:551
+#: src/olympia/files/utils.py:548
 msgid "Could not find an add-on ID."
 msgstr ""
 
-#: src/olympia/files/utils.py:554
+#: src/olympia/files/utils.py:551
 msgid "Add-on ID must be 64 characters or less."
 msgstr ""
 
-#: src/olympia/files/utils.py:556
+#: src/olympia/files/utils.py:553
 msgid "Add-on ID doesn't match add-on."
 msgstr ""
 
-#: src/olympia/files/utils.py:564
+#: src/olympia/files/utils.py:561
 msgid "Duplicate add-on ID found."
 msgstr ""
 
-#: src/olympia/files/utils.py:567
+#: src/olympia/files/utils.py:564
 msgid "Version numbers should have fewer than 32 characters."
 msgstr "Број верзије би требало да буде мањи од 32 карактера."
 
-#: src/olympia/files/utils.py:570
+#: src/olympia/files/utils.py:567
 msgid "Version numbers should only contain letters, numbers, and these punctuation characters: +*.-_."
 msgstr "Број верзије ви требало да садржи само слова, бројеве, и ове карактере: +*.-_."
 
-#: src/olympia/files/utils.py:587
+#: src/olympia/files/utils.py:584
 msgid "<em:type> doesn't match add-on"
 msgstr "<em:type> се не поклапа са додатком"
 
@@ -8729,6 +8573,10 @@ msgstr "Нема датотека из отпремљене датотеке."
 #: src/olympia/files/templates/files/viewer.html:134
 msgid "Fetching file."
 msgstr "Преузимање датотеке."
+
+#: src/olympia/legacy_api/views.py:255
+msgid "Not implemented yet."
+msgstr "Није још имплементиран."
 
 #: src/olympia/lib/constants.py:6
 msgid "United Arab Emirates Dirham"
@@ -9386,10 +9234,6 @@ msgstr ""
 msgid "Zimbabwe Dollar"
 msgstr ""
 
-#: src/olympia/lib/video/ffmpeg.py:112 src/olympia/lib/video/totem.py:81
-msgid "Videos must be in WebM."
-msgstr ""
-
 #: src/olympia/pages/templates/pages/about.lhtml:3 src/olympia/pages/templates/pages/about.lhtml:10
 msgid "About Mozilla Add-ons"
 msgstr "О Mozilla додацима"
@@ -9767,7 +9611,7 @@ msgstr "Да и могу да користим JavaScript библиотеку �
 msgid ""
 "Yes. It's possible, but some of the functionality provided by these libraries are available through XPCOM, XUL, and JavaScript. In addition, authors should take care if libraries modify primitive "
 "object prototypes (String.prototype, Date.prototype, etc.) and/or define global functions (eg. the $ function). These are prone to cause conflict with other add-ons, in particular if different add-"
-"ons use different versions of libraries and so on. Developers need to be very, very careful with using them.  Mozilla does not offer documentation on using them to build add-ons."
+"ons use different versions of libraries and so on. Developers need to be very, very careful with using them. Mozilla does not offer documentation on using them to build add-ons."
 msgstr ""
 
 #: src/olympia/pages/templates/pages/dev_faq.html:165
@@ -9887,7 +9731,7 @@ msgstr "Да ли могу да хостујем мој додатак?"
 #, python-format
 msgid ""
 "Yes. Many developers choose to host their own add-ons. Choosing to host your add-on on <a href=\"%(amo_url)s\">Mozilla's add-on site</a>, though, allows for much greater exposure to your add-on due"
-" to the large volume of visitors to the site.  <a href=\"%(md_url)s\">mozdev.org</a> offers free project hosting for Mozilla applications and extensions providing developers with tools to help "
+" to the large volume of visitors to the site. <a href=\"%(md_url)s\">mozdev.org</a> offers free project hosting for Mozilla applications and extensions providing developers with tools to help "
 "manage source code, version control, bug tracking and documentation."
 msgstr ""
 
@@ -9936,7 +9780,7 @@ msgstr "Да ли Mozilla има полису о томе каква подно�
 #: src/olympia/pages/templates/pages/dev_faq.html:314
 #, python-format
 msgid ""
-"Yes. Mozilla's <a href=\"%(p_url)s\">Add-on Policy</a> describes what is an acceptable submission. This policy is subject to change without notice.  In addition, the AMO editorial team uses the <a "
+"Yes. Mozilla's <a href=\"%(p_url)s\">Add-on Policy</a> describes what is an acceptable submission. This policy is subject to change without notice. In addition, the AMO editorial team uses the <a "
 "href=\"%(g_url)s\">Editors Reviewing Guide</a> to ensure that your add-on meets specific guidelines for functionality and security."
 msgstr ""
 
@@ -10053,7 +9897,7 @@ msgstr "број проблематичних области које су от�
 #: src/olympia/pages/templates/pages/dev_faq.html:434
 #, python-format
 msgid ""
-"This is why it's very important to read the <a href=\"%(g_url)s\">Editors Reviewing Guide</a> to ensure that your add-on is setup as expected.  It's also a good idea to read the blog post, <a "
+"This is why it's very important to read the <a href=\"%(g_url)s\">Editors Reviewing Guide</a> to ensure that your add-on is setup as expected. It's also a good idea to read the blog post, <a "
 "href=\"%(blog_url)s\">Successfully Getting your Add-on Reviewed</a> which provides excellent insight into ensuring a smooth review of your add-on."
 msgstr ""
 
@@ -10159,7 +10003,7 @@ msgstr ""
 
 #: src/olympia/pages/templates/pages/dev_faq.html:572
 msgid ""
-"Free Software Foundation provides short summaries of the key open source licenses, including whether the license qualifies as a free software license or a copyleft license.  Also includes a "
+"Free Software Foundation provides short summaries of the key open source licenses, including whether the license qualifies as a free software license or a copyleft license. Also includes a "
 "discussion of what constitutes a free software license or a copyleft license (e.g., a Copyleft license is a general method for making a program or other work free, and requiring all modified and "
 "extended versions of the program to be free as well.)"
 msgstr ""
@@ -10341,14 +10185,10 @@ msgstr "Галерија додатака"
 msgid "How do I choose between add-ons that seem to do the same thing?"
 msgstr "Како да се одлучим између додатака који раде исту ствар?"
 
-#: src/olympia/pages/templates/pages/faq.html:173
+#: src/olympia/pages/templates/pages/faq.html:172
 msgid ""
-"There are often several add-ons that have similar features. To\n"
-"    figure out which is right for you, read the entire description of the\n"
-"    add-on and view its screenshots. If there are still several in the running,\n"
-"    read through the add-on's ratings, user reviews, and statistics to see\n"
-"    which is most liked by other users. Remember that you can also just try\n"
-"    out both and see which you like better."
+"There are often several add-ons that have similar features. To figure out which is right for you, read the entire description of the add-on and view its screenshots. If there are still several in "
+"the running, read through the add-on's ratings, user reviews, and statistics to see which is most liked by other users. Remember that you can also just try out both and see which you like better."
 msgstr ""
 
 #: src/olympia/pages/templates/pages/faq.html:180
@@ -10392,11 +10232,11 @@ msgstr "Која је цена додатака?"
 msgid "Add-ons hosted in our gallery are free unless clearly marked otherwise."
 msgstr "Додаци који су хостовани у нашој галерији су бесплатни осим ако није назначено другачије."
 
-#: src/olympia/pages/templates/pages/faq.html:210
+#: src/olympia/pages/templates/pages/faq.html:209
 msgid "What does it mean when an add-on asks for contributions?"
 msgstr "Шта значи када додатак тражи доприносе?"
 
-#: src/olympia/pages/templates/pages/faq.html:211
+#: src/olympia/pages/templates/pages/faq.html:210
 msgid ""
 "Some add-on authors request users who enjoy an add-on to contribute to its development by making a monetary contribution. These contributions go directly to the developer unless a third party is "
 "indicated, such as the non-profit Mozilla Foundation."
@@ -10404,11 +10244,11 @@ msgstr ""
 "Неки аутори додатка очекују од корисника који уживају у додатку да допринесу његовом развоју тако што ће направити мали новчани допринос. Ови доприноси иду директно програмеру, осим ако је треће "
 "лице назначено, као што је непрофитна Mozilla фондација."
 
-#: src/olympia/pages/templates/pages/faq.html:216
+#: src/olympia/pages/templates/pages/faq.html:215
 msgid "What are beta add-ons?"
 msgstr "Шта су бета додаци?"
 
-#: src/olympia/pages/templates/pages/faq.html:218
+#: src/olympia/pages/templates/pages/faq.html:217
 msgid ""
 "Beta add-ons are unreviewed versions which represent the latest work of an add-on author. While different authors have different standards for beta code quality, you should assume that these add-"
 "ons are less stable than the general add-on releases."
@@ -10416,7 +10256,7 @@ msgstr ""
 "Бета додаци су верзије које нису прегледане и представљају најновије дело аутора додатака. Док различити аутори имају различите стандарде квалитета бета кода, треба претпоставити да су ови додаци "
 "мање стабилни од општег издања додатка."
 
-#: src/olympia/pages/templates/pages/faq.html:222
+#: src/olympia/pages/templates/pages/faq.html:221
 msgid ""
 "Please note that when you install an add-on from the \"Beta Version\" section of an add-on's listing, you will continue to receive updates for that add-on as they become available. Like the initial"
 " version you installed, all beta releases are unreviewed by Mozilla and may harm your computer."
@@ -10424,22 +10264,19 @@ msgstr ""
 "Имајте на уму да када инсталирате додатак из \"бета верзије\" секције листинга додатка, Ви ће наставити да примате исправке за тај додатак, чим оне постану доступне. Као и почетна верзија коју сте "
 "инсталирали, сва бета издања су непрегледана и могу да нашкоде Вашем рачунару."
 
-#: src/olympia/pages/templates/pages/faq.html:229
+#: src/olympia/pages/templates/pages/faq.html:228
 msgid "What does it mean when an add-on is flagged as slow?"
 msgstr "Шта значи ако је додатак означен као спор?"
 
-#: src/olympia/pages/templates/pages/faq.html:231
-msgid ""
-"Most add-ons load code and resources at the same time Firefox\n"
-"        is starting up. In most cases the impact in start-up time is minimal,\n"
-"        but some add-ons can cause a noticeable slowdown."
+#: src/olympia/pages/templates/pages/faq.html:229
+msgid "Most add-ons load code and resources at the same time Firefox is starting up. In most cases the impact in start-up time is minimal, but some add-ons can cause a noticeable slowdown."
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:236
+#: src/olympia/pages/templates/pages/faq.html:234
 msgid "How do I report an inappropriate or spam user review?"
 msgstr "Како могу да пријавим неприкладан или спам коментар?"
 
-#: src/olympia/pages/templates/pages/faq.html:237
+#: src/olympia/pages/templates/pages/faq.html:235
 msgid ""
 "To report a user review of an add-on, log in with your account and visit the add-on's reviews page. Find the review you wish to report, click \"Report this review\" and select a reason. Our "
 "editorial team will investigate the review and take appropriate action."
@@ -10447,20 +10284,20 @@ msgstr ""
 "Да бисте пријавили коментар додатка, улогујте се на Ваш налог и посетите страницу за рецензију додатка. Нађите рецензију коју желите да пријавите, кликните на \"Пријави ову рецензију\" и изаберите "
 "разлог. Тим уредника ће испитати рецензију и предузети одговарајуће мере."
 
-#: src/olympia/pages/templates/pages/faq.html:242
+#: src/olympia/pages/templates/pages/faq.html:240
 msgid "How do I report a bug or contact the Mozilla Add-ons team?"
 msgstr "Како да пријавим грешку или контактирам Mozilla тим за додатке?"
 
-#: src/olympia/pages/templates/pages/faq.html:243
+#: src/olympia/pages/templates/pages/faq.html:241
 #, python-format
 msgid "Please visit our <a href=\"%(contact_url)s\">Contact page</a>."
 msgstr "Молимо Вас да посетите нашу <a href=\"%(contact_url)s\">контакт страницу</a>."
 
-#: src/olympia/pages/templates/pages/faq.html:246
+#: src/olympia/pages/templates/pages/faq.html:244
 msgid "What is a Source Code License?"
 msgstr "Шта је лиценца изворног кода?"
 
-#: src/olympia/pages/templates/pages/faq.html:247
+#: src/olympia/pages/templates/pages/faq.html:245
 #, python-format
 msgid ""
 "The source code used to create an add-on is an exclusive copyright of the add-on author, unless otherwise declared in a source code license. Many add-ons on this site have <a href=\"%(url)s\" "
@@ -10468,42 +10305,42 @@ msgid ""
 " like the GPL or BSD licenses instead of making up their own."
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:256
+#: src/olympia/pages/templates/pages/faq.html:254
 #, python-format
 msgid "Firefox and other Mozilla software are <a href=\"%(url)s\">open source</a>."
 msgstr "Firefox и други Mozilla софтвер су <a href=\"%(url)s\">отвореног кода</a>."
 
-#: src/olympia/pages/templates/pages/faq.html:264
+#: src/olympia/pages/templates/pages/faq.html:262
 msgid "Collections and Favorites"
 msgstr "Колекције и Омиљени"
 
-#: src/olympia/pages/templates/pages/faq.html:267
+#: src/olympia/pages/templates/pages/faq.html:265
 msgid "What is a collection?"
 msgstr "Шта је колекција?"
 
-#: src/olympia/pages/templates/pages/faq.html:268
+#: src/olympia/pages/templates/pages/faq.html:266
 msgid "Collections are groups of related add-ons created by users to share."
 msgstr "Колекције су групе сродних додатака креираних од стране корисника да би се делили."
 
-#: src/olympia/pages/templates/pages/faq.html:270
+#: src/olympia/pages/templates/pages/faq.html:268
 msgid "What is the My Favorites collection?"
 msgstr "Шта је Моја омиљена колекција?"
 
-#: src/olympia/pages/templates/pages/faq.html:271
+#: src/olympia/pages/templates/pages/faq.html:269
 msgid "Favorite add-ons are add-ons that you have bookmarked to easily get back to later. You can add an add-on to your favorites collection by clicking \"Add to favorites\" on its details page."
 msgstr ""
 "Омиљени додаци су додаци које сте забележили да би сте их лако нашли касније. Можете да додате додатак у омиљене колекцију тако што ћете кликнути на \"Додај у омиљене\" на својој страници са "
 "детаљима."
 
-#: src/olympia/pages/templates/pages/faq.html:275 src/olympia/templates/menu_links.html:13 src/olympia/templates/impala/header_title.html:17
+#: src/olympia/pages/templates/pages/faq.html:273 src/olympia/templates/menu_links.html:13 src/olympia/templates/impala/header_title.html:17
 msgid "Mobile Add-ons"
 msgstr "Додаци за мобилни"
 
-#: src/olympia/pages/templates/pages/faq.html:278
+#: src/olympia/pages/templates/pages/faq.html:276
 msgid "What are mobile add-ons?"
 msgstr "Шта је мобилни додатак?"
 
-#: src/olympia/pages/templates/pages/faq.html:279
+#: src/olympia/pages/templates/pages/faq.html:277
 #, python-format
 msgid ""
 "Mobile add-ons work with <a href=\"%(mobile_url)s\">Firefox for Mobile</a> and add or modify functionality just like desktop add-ons. You can find add-ons that work with Firefox for Mobile in our "
@@ -10512,20 +10349,20 @@ msgstr ""
 "Мобилни додаци раде на <a href=\"%(mobile_url)s\">Firefox-у за мобилни </a> и они додају или мењају функционалност као додаци за десктоп. Можете наћи додатке који ради на Firefox-у за мобилни у "
 "нашој <a href=\"%(gallery_url)s\">галерији</a>."
 
-#: src/olympia/pages/templates/pages/faq.html:288
+#: src/olympia/pages/templates/pages/faq.html:286
 msgid "Developer Topics"
 msgstr "Програмерске теме"
 
-#: src/olympia/pages/templates/pages/faq.html:289
+#: src/olympia/pages/templates/pages/faq.html:287
 #, python-format
 msgid "Please see our <a href=\"%(faq_url)s\">Developer FAQ</a> and <a href=\"%(hub_url)s\">Developer Hub</a> for answers to add-on developer-related questions."
 msgstr "Погледајте наша <a href=\"%(faq_url)s\">ЧПП за програмере </a> и <a href=\"%(hub_url)s\">Developer Hub</a> за одговоре на питања које се односе на развој додатака."
 
-#: src/olympia/pages/templates/pages/faq.html:294
+#: src/olympia/pages/templates/pages/faq.html:292
 msgid "Still have questions?"
 msgstr "Још увек имате питања?"
 
-#: src/olympia/pages/templates/pages/faq.html:295
+#: src/olympia/pages/templates/pages/faq.html:293
 #, python-format
 msgid "For general Firefox support, visit our <a href=\"%(sumo_url)s\">support website</a>. For general add-on and website questions, visit our <a href=\"%(forum_url)s\">forum</a>."
 msgstr "За општу Firefox подршку, посетите наш <a href=\"%(sumo_url)s\">сајт за подршку</a>. За општа питања о додацима или опцијама веб сајта, посетите наш <a href=\"%(forum_url)s\">форум</a>."
@@ -10743,7 +10580,7 @@ msgstr "Додај рецензију за {0}"
 #, python-format
 msgid ""
 "<h2>Keep these tips in mind:</h2> <ul> <li> Write like you're telling a friend about your experience with the add-on. Give specifics and helpful details, such as what features you liked and/or "
-"disliked, how easy to use it is, and any disadvantages it has.  Avoid generic language such as calling it \"Great\" or \"Bad\" unless you can give reasons why you believe this is so. </li> <li> "
+"disliked, how easy to use it is, and any disadvantages it has. Avoid generic language such as calling it \"Great\" or \"Bad\" unless you can give reasons why you believe this is so. </li> <li> "
 "Please do not post bug reports in reviews. We do not make your email address available to add-on developers and they may need to contact you to help resolve your issue. See the <a "
 "href=\"%(support)s\">support section</a> to find out where to get assistance for this add-on. </li> <li>Please keep reviews clean, avoid the use of improper language and do not post any personal "
 "information. </li> </ul> <p>Please read the <a href=\"%(guide)s\" target=\"_blank\">Review Guidelines</a> for more detail about user add-on reviews.</p>"
@@ -10791,7 +10628,6 @@ msgid "This user has a <a href=\"%(user_review_url)s\">previous review</a> of th
 msgid_plural "This user has <a href=\"%(user_review_url)s\">%(cnt)s previous reviews</a> of this add-on."
 msgstr[0] "Овај корисник има <a href=\"%(user_review_url)s\">претходни преглед</a> овог додатка."
 msgstr[1] "Овај корисник има <a href=\"%(user_review_url)s\">%(cnt)s претходна прегледа</a> овог додатка."
-msgstr[2] "Овај корисник има <a href=\"%(user_review_url)s\">%(cnt)s претходних прегледа</a> овог додатка."
 
 #: src/olympia/reviews/templates/reviews/review.html:62
 #, python-format
@@ -10838,7 +10674,6 @@ msgid "<b>{0}</b> review for this add-on"
 msgid_plural "<b>{0}</b> reviews for this add-on"
 msgstr[0] "<b>{0}</b> преглед за овај додатак"
 msgstr[1] "<b>{0}</b> прегледа за овај додатак"
-msgstr[2] "<b>{0}</b> прегледа за овај додатак"
 
 #. {0} is a developer's name.
 #: src/olympia/reviews/templates/reviews/review_list.html:33
@@ -10851,7 +10686,6 @@ msgid "Review for %(addon)s by %(user)s"
 msgid_plural "Reviews for %(addon)s by %(user)s"
 msgstr[0] "Рецензија за %(addon)s од %(user)s"
 msgstr[1] "Рецензије за %(addon)s од %(user)s"
-msgstr[2] "Рецензије за %(addon)s од %(user)s"
 
 #: src/olympia/reviews/templates/reviews/review_list.html:42
 msgid "No reviews found."
@@ -10875,7 +10709,6 @@ msgid "{num} review"
 msgid_plural "{num} reviews"
 msgstr[0] "{num} критика"
 msgstr[1] "{num} критике"
-msgstr[2] "{num} критика"
 
 #: src/olympia/reviews/templates/reviews/impala/reviews_rating.html:1
 msgid "Rated {0} out of 5 stars"
@@ -10903,7 +10736,6 @@ msgid "Average from {0} Rating"
 msgid_plural "Average from {0} Ratings"
 msgstr[0] "Просек од {0} оцене"
 msgstr[1] "Просек од {0} оцене"
-msgstr[2] "Просек од {0} оцена"
 
 #: src/olympia/reviews/templates/reviews/mobile/review_list.html:34
 #, python-format
@@ -10920,7 +10752,6 @@ msgid "See All Reviews"
 msgid_plural "See All %(cnt)s Reviews"
 msgstr[0] "Погледај све рецензије"
 msgstr[1] "Погледај свих %(cnt)s рецензија"
-msgstr[2] "Погледај свих %(cnt)s рецензија"
 
 #: src/olympia/search/forms.py:11
 msgid "Most popular this week"
@@ -11001,16 +10832,16 @@ msgstr "{0} додатака"
 
 #. L10n: {0} is an application, such as Firefox. This means "any version of
 #. Firefox."
-#: src/olympia/search/views.py:554
+#: src/olympia/search/views.py:547
 msgid "Any {0}"
 msgstr "Било који {0}"
 
 #. L10n: "All Systems" means show everything regardless of platform.
-#: src/olympia/search/views.py:589
+#: src/olympia/search/views.py:582
 msgid "All Systems"
 msgstr "Сви системи"
 
-#: src/olympia/search/views.py:600
+#: src/olympia/search/views.py:593
 msgid "All Tags"
 msgstr "Све ознаке"
 
@@ -11055,7 +10886,6 @@ msgid "<b>{0}</b> matching result"
 msgid_plural "<b>{0}</b> matching results"
 msgstr[0] "<b>{0}</b> одговарајући резултат"
 msgstr[1] "<b>{0}</b> одговарајућа резултата"
-msgstr[2] "<b>{0}</b> одговарајућих резултата"
 
 #: src/olympia/search/templates/search/results.html:67
 msgid "Filter Results"
@@ -11078,7 +10908,6 @@ msgid "{0} post"
 msgid_plural "{0} posts"
 msgstr[0] "{0} порука"
 msgstr[1] "{0} поруке"
-msgstr[2] "{0} порука"
 
 #: src/olympia/sharing/__init__.py:20
 msgid "Post to Facebook"
@@ -11089,7 +10918,6 @@ msgid "{0} Like"
 msgid_plural "{0} Likes"
 msgstr[0] ""
 msgstr[1] ""
-msgstr[2] ""
 
 #: src/olympia/sharing/__init__.py:30
 msgid "Tweet on Twitter"
@@ -11100,7 +10928,6 @@ msgid "{0} tweet"
 msgid_plural "{0} tweets"
 msgstr[0] "{0} твит"
 msgstr[1] "{0} твита"
-msgstr[2] "{0} твитова"
 
 #: src/olympia/sharing/__init__.py:40
 msgid "Share on g+"
@@ -11135,7 +10962,6 @@ msgid "{0} post on localservice1"
 msgid_plural "{0} posts on localservice1"
 msgstr[0] "{0} објавa на localservice1"
 msgstr[1] "{0} објавe на localservice1"
-msgstr[2] "{0} објавa на localservice1"
 
 #. L10n: Only change if you have reason! wiki.mozilla.org/AMO:Localizers
 #: src/olympia/sharing/__init__.py:76
@@ -11158,7 +10984,6 @@ msgid "{0} post on localservice2"
 msgid_plural "{0} posts on localservice2"
 msgstr[0] "{0} објава на localservice2"
 msgstr[1] "{0} објаве на localservice2"
-msgstr[2] "{0} објава на localservice2"
 
 #. L10n: Only change if you have reason! wiki.mozilla.org/AMO:Localizers
 #: src/olympia/sharing/__init__.py:91
@@ -11181,7 +11006,6 @@ msgid "{0} post on localservice3"
 msgid_plural "{0} posts on localservice3"
 msgstr[0] "{0} објава на localservice3"
 msgstr[1] "{0} објаве на localservice3"
-msgstr[2] "{0} објава на localservice3"
 
 #: src/olympia/sharing/templates/sharing/sharing_widget.html:2
 msgid "Share this Add-on"
@@ -11191,31 +11015,31 @@ msgstr "Дели овај додатак са осталима"
 msgid "Share this Collection"
 msgstr "Подели ову колекцију"
 
-#: src/olympia/signing/views.py:30 src/olympia/templates/base.html:75 src/olympia/templates/impala/base.html:115
+#: src/olympia/signing/views.py:33 src/olympia/templates/base.html:71 src/olympia/templates/impala/base.html:112
 msgid "Some features are temporarily disabled while we perform website maintenance. We'll be back to full capacity shortly."
 msgstr "Неке функције су привремено онемогућене док вршимо одржавање веб сајта. Ми ћемо се вратити у пуном капацитету ускоро."
 
-#: src/olympia/signing/views.py:53
+#: src/olympia/signing/views.py:56
 msgid "Could not find add-on with id \"{}\"."
 msgstr ""
 
-#: src/olympia/signing/views.py:67
+#: src/olympia/signing/views.py:70
 msgid "You do not own this addon."
 msgstr ""
 
-#: src/olympia/signing/views.py:82
+#: src/olympia/signing/views.py:87
 msgid "Missing \"upload\" key in multipart file data."
 msgstr ""
 
-#: src/olympia/signing/views.py:96
+#: src/olympia/signing/views.py:101
 msgid "Version does not match the manifest file."
 msgstr ""
 
-#: src/olympia/signing/views.py:100
+#: src/olympia/signing/views.py:105
 msgid "Version already exists."
 msgstr ""
 
-#: src/olympia/signing/views.py:136
+#: src/olympia/signing/views.py:141
 msgid "No uploaded file for that addon and version."
 msgstr ""
 
@@ -11328,89 +11152,89 @@ msgstr "{0} :: Контролна табла статистика"
 msgid "Statistics Dashboard :: Add-ons for {0}"
 msgstr "Контролна табла статистика :: додаци за {0}"
 
-#: src/olympia/stats/templates/stats/stats.html:30
-msgid "Controls:"
-msgstr "Контроле:"
-
-#: src/olympia/stats/templates/stats/stats.html:33
-msgid "reset zoom"
-msgstr "ресетуј увеличај"
-
-#: src/olympia/stats/templates/stats/stats.html:40
-msgid "Group by:"
-msgstr "Групиши по:"
-
-#: src/olympia/stats/templates/stats/stats.html:42
-msgid "day"
-msgstr "дану"
-
-#: src/olympia/stats/templates/stats/stats.html:45
-msgid "week"
-msgstr "седмици"
-
-#: src/olympia/stats/templates/stats/stats.html:48
-msgid "month"
-msgstr "месец дана"
-
-#: src/olympia/stats/templates/stats/stats.html:54
-msgid "For last:"
-msgstr "За последњих:"
-
-#: src/olympia/stats/templates/stats/stats.html:57
-msgid "7 days"
-msgstr "7 дана"
-
-#: src/olympia/stats/templates/stats/stats.html:60
-msgid "30 days"
-msgstr "30 дана"
-
-#: src/olympia/stats/templates/stats/stats.html:63
-msgid "90 days"
-msgstr "90 дана"
-
-#: src/olympia/stats/templates/stats/stats.html:66
-msgid "365 days"
-msgstr "365 дана"
-
-#: src/olympia/stats/templates/stats/stats.html:69
-msgid "Custom..."
-msgstr "Прилагођено..."
-
 #. {0} is an add-on name
-#: src/olympia/stats/templates/stats/stats.html:88 src/olympia/stats/templates/stats/stats.html:91
+#: src/olympia/stats/templates/stats/stats.html:44 src/olympia/stats/templates/stats/stats.html:47
 msgid "Statistics for {0}"
 msgstr "Статистика за {0}"
 
-#: src/olympia/stats/templates/stats/stats.html:94
+#: src/olympia/stats/templates/stats/stats.html:50
 msgid "Statistics Dashboard"
 msgstr "Контролна табла статистика"
 
-#: src/olympia/stats/templates/stats/stats.html:104
+#: src/olympia/stats/templates/stats/stats.html:57
+msgid "Controls:"
+msgstr "Контроле:"
+
+#: src/olympia/stats/templates/stats/stats.html:60
+msgid "reset zoom"
+msgstr "ресетуј увеличај"
+
+#: src/olympia/stats/templates/stats/stats.html:67
+msgid "Group by:"
+msgstr "Групиши по:"
+
+#: src/olympia/stats/templates/stats/stats.html:69
+msgid "day"
+msgstr "дану"
+
+#: src/olympia/stats/templates/stats/stats.html:72
+msgid "week"
+msgstr "седмици"
+
+#: src/olympia/stats/templates/stats/stats.html:75
+msgid "month"
+msgstr "месец дана"
+
+#: src/olympia/stats/templates/stats/stats.html:81
+msgid "For last:"
+msgstr "За последњих:"
+
+#: src/olympia/stats/templates/stats/stats.html:84
+msgid "7 days"
+msgstr "7 дана"
+
+#: src/olympia/stats/templates/stats/stats.html:87
+msgid "30 days"
+msgstr "30 дана"
+
+#: src/olympia/stats/templates/stats/stats.html:90
+msgid "90 days"
+msgstr "90 дана"
+
+#: src/olympia/stats/templates/stats/stats.html:93
+msgid "365 days"
+msgstr "365 дана"
+
+#: src/olympia/stats/templates/stats/stats.html:96
+msgid "Custom..."
+msgstr "Прилагођено..."
+
+#: src/olympia/stats/templates/stats/stats.html:106
 msgid "Statistics processing is currently disabled, so recent data is unavailable. The statistics are still being collected and this page will be updated soon with the missing data."
 msgstr ""
 
-#: src/olympia/stats/templates/stats/stats.html:110
+#: src/olympia/stats/templates/stats/stats.html:112
 msgid "Loading the latest data&hellip;"
 msgstr "Учитавам најновије податке&hellip;"
 
-#: src/olympia/stats/templates/stats/stats.html:142 src/olympia/stats/templates/stats/reports/overview.html:25 src/olympia/stats/templates/stats/reports/overview.html:37
+#: src/olympia/stats/templates/stats/stats.html:144 src/olympia/stats/templates/stats/reports/overview.html:25 src/olympia/stats/templates/stats/reports/overview.html:37
 #: src/olympia/stats/templates/stats/reports/overview.html:49
 msgid "No data available."
 msgstr "Нема доступних података."
 
-#: src/olympia/stats/templates/stats/stats.html:177
+#: src/olympia/stats/templates/stats/stats.html:179
 msgid "This dashboard is currently <b>public</b>."
 msgstr "Ова контролна табла је тренутно <b>јавна</b>."
 
-#: src/olympia/stats/templates/stats/stats.html:179
+#: src/olympia/stats/templates/stats/stats.html:181
 msgid "Contribution stats are currently <b>private</b>."
 msgstr "Статистике доприноса су тренутно <b>приватне </b>."
 
-#: src/olympia/stats/templates/stats/stats.html:182
+#: src/olympia/stats/templates/stats/stats.html:184
 msgid "This dashboard is currently <b>private</b>."
 msgstr "Ова контролна табла је тренутно <b>приватна</b>."
 
-#: src/olympia/stats/templates/stats/stats.html:185
+#: src/olympia/stats/templates/stats/stats.html:187
 msgid "Change settings."
 msgstr "Промени поставке."
 
@@ -11568,15 +11392,6 @@ msgstr "Број регистрованих корисника по датуму
 msgid "Application versions by Date"
 msgstr "Верзије апликација по датуму"
 
-#: src/olympia/tags/templates/tags/top_cloud.html:4
-msgid "Top {0} Tags"
-msgstr "Најпопуларнијих {0} ознака"
-
-#. {0} is the current application name
-#: src/olympia/tags/templates/tags/top_cloud.html:14
-msgid "{0} Top Tags"
-msgstr "{0} Најчешће коришћене ознаке"
-
 #: src/olympia/templates/amo_footer.html:6 src/olympia/templates/includes/lang_switcher.html:2
 msgid "Other languages"
 msgstr "Други језици"
@@ -11585,11 +11400,11 @@ msgstr "Други језици"
 msgid "Mozilla Add-ons"
 msgstr "Mozilla додаци"
 
-#: src/olympia/templates/base.html:91 src/olympia/templates/impala/base.html:81
+#: src/olympia/templates/base.html:89 src/olympia/templates/impala/base.html:78
 msgid "Find add-ons for other applications"
 msgstr "Пронађите додатке за остале апликације"
 
-#: src/olympia/templates/base.html:92 src/olympia/templates/impala/base.html:81
+#: src/olympia/templates/base.html:90 src/olympia/templates/impala/base.html:78
 msgid "Other Applications"
 msgstr "Остале апликације"
 
@@ -11614,7 +11429,7 @@ msgid "View Mobile Site"
 msgstr "Сајт за мобилне уређаје"
 
 #: src/olympia/templates/copyright.html:7
-msgid "Site Status "
+msgid "Site Status"
 msgstr ""
 
 #: src/olympia/templates/footer.html:3
@@ -11716,35 +11531,35 @@ msgstr "Добродошли, {0}"
 msgid "<a href=\"%(reg)s\">Register</a> or <a href=\"%(login)s\">Log in</a>"
 msgstr "<a href=\"%(reg)s\">Региструјте налог</a> или се <a href=\"%(login)s\">пријавите</a>"
 
-#: src/olympia/templates/impala/base.html:126
+#: src/olympia/templates/impala/base.html:123
 #, python-format
 msgid "To try the thousands of add-ons available here, download <a href=\"%(url)s\">Mozilla Firefox</a>, a fast, free way to surf the Web!"
 msgstr "Да бисте испробали хиљаде додатака доступних овде, преузмите <a href=\"%(url)s\">Mozilla Firefox</a>, брз и бесплатан начин да сурфујете вебом!"
 
-#: src/olympia/templates/impala/base.html:138
+#: src/olympia/templates/impala/base.html:135
 #, python-format
 msgid "Add-ons is switching to Firefox Accounts for login. <a href=\"%(url)s\" class=\"fxa-login\">Sign in now to transfer your account.</a>"
 msgstr ""
 
 #. {0} is an application, such as Firefox.
-#: src/olympia/templates/impala/base.html:148
+#: src/olympia/templates/impala/base.html:145
 msgid "Welcome to {0} Add-ons."
 msgstr "Добродошли на {0} додатке."
 
-#: src/olympia/templates/impala/base.html:151
+#: src/olympia/templates/impala/base.html:148
 msgid "Choose from thousands of extra features and styles to make Firefox your own."
 msgstr "Изаберите из хиљаде додатних могућности и стилова како би Firefox учинили својим."
 
-#: src/olympia/templates/impala/base.html:156
+#: src/olympia/templates/impala/base.html:153
 #, python-format
 msgid "Add extra features and styles to make %(app)s your own."
 msgstr "Додајте додатне могућности и стилове како би направили %(app)s на свој начин."
 
-#: src/olympia/templates/impala/base.html:164
+#: src/olympia/templates/impala/base.html:161
 msgid "On the go?"
 msgstr "У покрету сте?"
 
-#: src/olympia/templates/impala/base.html:166
+#: src/olympia/templates/impala/base.html:163
 msgid "Check out our <a class=\"mobile-link\" href=\"#\">Mobile Add-ons site</a>."
 msgstr "Проверите наш <a class=\"mobile-link\" href=\"#\">сајт за мобилне екстензије</a>."
 
@@ -11968,19 +11783,19 @@ msgstr "Нема корисника са том адресом е-поште."
 
 #. L10n: {id} will be something like "13ad6a", just a random number
 #. to differentiate this user from other anonymous users.
-#: src/olympia/users/models.py:353
+#: src/olympia/users/models.py:362
 msgid "Anonymous user {id}"
 msgstr ""
 
-#: src/olympia/users/models.py:410
+#: src/olympia/users/models.py:419
 msgid "Your account has been restricted"
 msgstr "Ваш налог је ограничен"
 
-#: src/olympia/users/models.py:480
+#: src/olympia/users/models.py:489
 msgid "Please confirm your email address"
 msgstr "Молимо Вас потврдите адресу е-поште"
 
-#: src/olympia/users/models.py:506
+#: src/olympia/users/models.py:515
 msgid "My Mobile Add-ons"
 msgstr "Моји додаци за мобилне"
 
@@ -12721,7 +12536,6 @@ msgid "%(num)s theme"
 msgid_plural "%(num)s themes"
 msgstr[0] "%(num)s тема"
 msgstr[1] "%(num)s теме"
-msgstr[2] "%(num)s тема"
 
 #: src/olympia/users/templates/users/vcard.html:62
 #, python-format
@@ -12729,7 +12543,6 @@ msgid "%(num)s add-on"
 msgid_plural "%(num)s add-ons"
 msgstr[0] "%(num)s додатак"
 msgstr[1] "%(num)s додатка"
-msgstr[2] "%(num)s додатака"
 
 #: src/olympia/users/templates/users/vcard.html:75
 msgid "Average rating of developer's add-ons"
@@ -12745,15 +12558,15 @@ msgstr "%s историјат верзије"
 msgid "Version History with Changelogs"
 msgstr "Историјат верзија са променама"
 
-#: src/olympia/versions/models.py:314
+#: src/olympia/versions/models.py:313
 msgid "Add-on uses binary components."
 msgstr "Додаци користе бинарне компоненте."
 
-#: src/olympia/versions/models.py:317
+#: src/olympia/versions/models.py:316
 msgid "Add-on has opted into strict compatibility checking."
 msgstr "Додатак се определио строгом провером компатибилности."
 
-#: src/olympia/versions/models.py:715
+#: src/olympia/versions/models.py:711
 msgid "{app} {min} and later"
 msgstr "{app} {min} и касније"
 
@@ -12792,7 +12605,6 @@ msgid "<b>{0}</b> version"
 msgid_plural "<b>{0}</b> versions"
 msgstr[0] "<b>{0}</b> верзија"
 msgstr[1] "<b>{0}</b> верзије"
-msgstr[2] "<b>{0}</b> верзија"
 
 #: src/olympia/versions/templates/versions/version_list.html:35 src/olympia/versions/templates/versions/mobile/version_list.html:14
 msgid "Be careful with old versions!"
@@ -12831,4 +12643,8 @@ msgstr "Пошаљи ми е-пошту када је завршено"
 #: src/olympia/zadmin/forms.py:105
 msgid "Log emails instead of sending"
 msgstr "Бележи е-поште уместо слања"
+
+#: src/olympia/zadmin/forms.py:215
+msgid "Deleted versions can`t be changed."
+msgstr ""
 

--- a/locale/sr/LC_MESSAGES/djangojs.po
+++ b/locale/sr/LC_MESSAGES/djangojs.po
@@ -1,141 +1,393 @@
-
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2016-02-24 21:23+0000\n"
+"POT-Creation-Date: 2016-04-18 15:47+0000\n"
 "PO-Revision-Date: 2015-02-01 09:53+0000\n"
 "Last-Translator: Vanja <tumbas93@gmail.com>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
+"Language: \n"
 "MIME-Version: 1.0\n"
-"Content-Type: text/plain; charset=utf-8\n"
+"Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Generated-By: Babel 2.2.0\n"
 
-#: static/js/common/ratingwidget.js:31
+#: static/js/common-all.js:1426 static/js/impala-all.js:1511 static/js/zamboni/discovery-all.js:12598 static/js/zamboni/init.js:28 static/js/zamboni/mobile-all.js:14945
+msgid "This feature is temporarily disabled while we perform website maintenance. Please check back a little later."
+msgstr "Ова могућност је привремено онемогућена док обављамо задатак одржавања сајта. Молимо пробајте мало касније."
+
+#. L10n: {0} is an app name like Firefox.
+#: static/js/common-all.js:1837 static/js/impala-all.js:1922 static/js/zamboni/buttons.js:73 static/js/zamboni/discovery-all.js:13108
+msgid "Accept and Install"
+msgstr "Прихвати и инсталирај"
+
+#: static/js/common-all.js:1837 static/js/impala-all.js:1922 static/js/zamboni/buttons.js:73 static/js/zamboni/discovery-all.js:13108
+msgid "Add to {0}"
+msgstr "Додај у {0}"
+
+#: static/js/common-all.js:1842 static/js/impala-all.js:1927 static/js/zamboni/buttons.js:78 static/js/zamboni/discovery-all.js:13113
+msgid "Download Now"
+msgstr "Преузми одмах"
+
+#: static/js/common-all.js:1883 static/js/impala-all.js:1968 static/js/zamboni/buttons.js:119 static/js/zamboni/discovery-all.js:13154
+msgid "Add-on has not been updated to support default-to-compatible."
+msgstr "Додатак није ажуриран да подржава default-to-compatible."
+
+#: static/js/common-all.js:1888 static/js/impala-all.js:1973 static/js/zamboni/buttons.js:124 static/js/zamboni/discovery-all.js:13159
+msgid "You need to be using Firefox 10.0 or higher."
+msgstr "Морате користити Firefox 10.0 или новије."
+
+#: static/js/common-all.js:1900 static/js/impala-all.js:1985 static/js/zamboni/buttons.js:136 static/js/zamboni/discovery-all.js:13171
+msgid "Mozilla has marked this version as incompatible with your Firefox version."
+msgstr "Mozilla је означила ову верзију као некомпатабилну са Вашом верзијом Firefox-а."
+
+#. L10n: {0} is an platform like Windows or Linux.
+#: static/js/common-all.js:1981 static/js/impala-all.js:2066 static/js/zamboni/buttons.js:217 static/js/zamboni/discovery-all.js:13252
+msgid "Install for {0} anyway"
+msgstr "Инсталирај за {0} у сваком случају"
+
+#: static/js/common-all.js:1981 static/js/impala-all.js:2066 static/js/zamboni/buttons.js:217 static/js/zamboni/discovery-all.js:13252
+msgid "Download for {0} anyway"
+msgstr "Преузми за {0} у сваком случају"
+
+#: static/js/common-all.js:2038 static/js/impala-all.js:2123 static/js/zamboni/buttons.js:274 static/js/zamboni/discovery-all.js:13309
+msgid "Not available for your platform"
+msgstr "Није доступно за Вашу платформу"
+
+#. L10n: {0} is an app name, {1} is the app version.
+#: static/js/common-all.js:2049 static/js/common-all.js:2086 static/js/impala-all.js:2134 static/js/impala-all.js:2171 static/js/zamboni/buttons.js:286 static/js/zamboni/buttons.js:324
+#: static/js/zamboni/discovery-all.js:13320 static/js/zamboni/discovery-all.js:13357
+msgid "Not available for {0} {1}"
+msgstr "Није доступно за {0} {1}"
+
+#: static/js/common-all.js:2112 static/js/impala-all.js:2197 static/js/zamboni/buttons.js:351 static/js/zamboni/discovery-all.js:13383
+msgid "Works with {app} {min} - {max}"
+msgstr "Ради са {app} {min} - {max}"
+
+#: static/js/common-all.js:2114 static/js/impala-all.js:2199 static/js/zamboni/buttons.js:353 static/js/zamboni/discovery-all.js:13385
+msgid "View other versions"
+msgstr "Погледај остале верзије"
+
+#: static/js/common-all.js:2162 static/js/impala-all.js:2247 static/js/zamboni/buttons.js:401 static/js/zamboni/discovery-all.js:13433
+msgid "Only with Firefox — Get Firefox Now!"
+msgstr ""
+
+#: static/js/common-all.js:2278 static/js/impala-all.js:2363 static/js/zamboni/buttons.js:517 static/js/zamboni/discovery-all.js:13549 static/js/zamboni/mobile-all.js:15177
+#: static/js/zamboni/mobile/buttons.js:43
+msgid "Sorry, you need a Mozilla-based browser (such as Firefox) to install a search plugin."
+msgstr "Жао нам је, треба Вам прегледач базиран на технологији Mozilla фондације (као што је Firefox) да бисте инсталирали прикључак за претраживање."
+
+#: static/js/common-all.js:9088 static/js/impala-all.js:9649 static/js/zamboni/global.js:410
+msgid "Loading..."
+msgstr "Учитавање..."
+
+#. L10n: {0} is the number of characters left.
+#: static/js/common-all.js:9152 static/js/impala-all.js:9713 static/js/zamboni/global.js:474
+msgid "<b>{0}</b> character left."
+msgid_plural "<b>{0}</b> characters left."
+msgstr[0] "<b>{0}</b> карактер преостао."
+msgstr[1] "<b>{0}</b> карактера преостала."
+
+#: static/js/common-all.js:9589 static/js/common-min.js:6 static/js/impala-all.js:10052 static/js/impala-min.js:6 static/js/common/ratingwidget.js:31 static/js/zamboni/mobile-all.js:16123
+#: static/js/zamboni/mobile-min.js:6
 msgid "{0} star"
 msgid_plural "{0} stars"
 msgstr[0] "{0} зведица"
 msgstr[1] "{0} зведице"
-msgstr[2] "{0} зведица"
 
-#: static/js/common/upload-addon.js:41 static/js/common/upload-image.js:128
+#: static/js/common-all.js:9676 static/js/common-min.js:6 static/js/impala-all.js:10139 static/js/impala-min.js:6 static/js/zamboni/l10n.js:45
+msgid "Remove this localization"
+msgstr "Уклони ову локализацију"
+
+#: static/js/common-all.js:10193 static/js/common-min.js:6 static/js/impala-all.js:10674 static/js/impala-min.js:6 static/js/zamboni/discovery-all.js:13678
+msgid "close"
+msgstr ""
+
+#: static/js/common-all.js:10860 static/js/common-min.js:6 static/js/impala-all.js:11481 static/js/impala-min.js:6 static/js/impala/reviews.js:23 static/js/zamboni/reviews.js:18
+msgid "Flagged for review"
+msgstr "Назначено за преглед"
+
+#: static/js/common-all.js:10876 static/js/common-min.js:6 static/js/impala-all.js:11498 static/js/impala-min.js:6 static/js/impala/reviews.js:40 static/js/zamboni/reviews.js:34
+msgid "Your input is required"
+msgstr "Ваш одзив је неопходан"
+
+#: static/js/common-all.js:10945 static/js/common-min.js:6 static/js/impala-all.js:11610 static/js/impala-min.js:7 static/js/impala/reviews.js:152 static/js/zamboni/reviews.js:103
+msgid "Marked for deletion"
+msgstr "Обележено за брисање"
+
+#: static/js/common-all.js:11573 static/js/common-min.js:7 static/js/impala-all.js:13809 static/js/impala-min.js:8 static/js/zamboni/collections.js:229
+msgid "Adding to Favorites&hellip;"
+msgstr "Додајем у Омиљено&hellip;"
+
+#: static/js/common-all.js:11576 static/js/common-min.js:7 static/js/impala-all.js:13812 static/js/impala-min.js:8 static/js/zamboni/collections.js:232
+msgid "Removing Favorite&hellip;"
+msgstr "Бришем из Омиљених&hellip;"
+
+#: static/js/common-all.js:11579 static/js/common-min.js:7 static/js/impala-all.js:13815 static/js/impala-min.js:8 static/js/zamboni/collections.js:235
+msgid "Add to Favorites"
+msgstr "Додај у Омиљене"
+
+#: static/js/common-all.js:11582 static/js/common-min.js:7 static/js/impala-all.js:13818 static/js/impala-min.js:8 static/js/zamboni/collections.js:238
+msgid "Remove from Favorites"
+msgstr "Избриши из Омиљених"
+
+#: static/js/common-all.js:11647 static/js/common-min.js:7 static/js/impala-all.js:13883 static/js/impala-min.js:8 static/js/zamboni/collections.js:303
+msgid "Pending"
+msgstr "На чекању"
+
+#: static/js/common-all.js:11648 static/js/common-min.js:7 static/js/impala-all.js:13884 static/js/impala-min.js:8 static/js/zamboni/collections.js:304
+msgid "Add a comment"
+msgstr "Додај коментар"
+
+#: static/js/common-all.js:11648 static/js/common-min.js:7 static/js/impala-all.js:13884 static/js/impala-min.js:8 static/js/zamboni/collections.js:304
+msgid "Comment"
+msgstr "Коментар"
+
+#: static/js/common-all.js:11649 static/js/common-min.js:7 static/js/impala-all.js:13885 static/js/impala-min.js:8 static/js/zamboni/collections.js:305
+msgid "Remove this add-on from the collection"
+msgstr "Избриши овај додатак из колекције"
+
+#: static/js/common-all.js:11649 static/js/common-all.js:11678 static/js/common-min.js:7 static/js/impala-all.js:13885 static/js/impala-all.js:13914 static/js/impala-min.js:8
+#: static/js/zamboni/collections.js:305 static/js/zamboni/collections.js:334
+msgid "Remove"
+msgstr "Избриши"
+
+#: static/js/common-all.js:11678 static/js/common-min.js:7 static/js/impala-all.js:13914 static/js/impala-min.js:8 static/js/zamboni/collections.js:334
+msgid "Remove this user as a contributor"
+msgstr "Уклони корисника као сарадника"
+
+#: static/js/common-all.js:11690 static/js/common-min.js:7 static/js/impala-all.js:13926 static/js/impala-min.js:8 static/js/zamboni/collections.js:346
+msgid "An email address is required."
+msgstr "Адреса е-поште је обавезна."
+
+#: static/js/common-all.js:11708 static/js/common-min.js:7 static/js/impala-all.js:13944 static/js/impala-min.js:8 static/js/zamboni/collections.js:364
+msgid "You cannot add yourself as a contributor."
+msgstr "Не можете себе додати као сарадника."
+
+#: static/js/common-all.js:11710 static/js/common-min.js:7 static/js/impala-all.js:13946 static/js/impala-min.js:8 static/js/zamboni/collections.js:366
+msgid "You have already added that user."
+msgstr "Већ сте додали тог корисника."
+
+#: static/js/common-all.js:11917 static/js/common-min.js:7 static/js/impala-all.js:14153 static/js/impala-min.js:8 static/js/zamboni/collections.js:573
+msgid "Add to favorites"
+msgstr "Додај у омиљене"
+
+#: static/js/common-all.js:11921 static/js/common-min.js:7 static/js/impala-all.js:14157 static/js/impala-min.js:8 static/js/zamboni/collections.js:577
+msgid "Remove from favorites"
+msgstr "Избриши из омиљених"
+
+#: static/js/common-all.js:11939 static/js/common-min.js:7 static/js/impala-all.js:14175 static/js/impala-all.js:14233 static/js/impala-min.js:8 static/js/impala/collections.js:10
+#: static/js/zamboni/collections.js:595
+msgid "Follow this Collection"
+msgstr "Прати ову колекцију"
+
+#: static/js/common-all.js:11948 static/js/common-min.js:7 static/js/impala-all.js:14184 static/js/impala-min.js:8 static/js/zamboni/collections.js:604
+msgid "Stop following"
+msgstr "Прекини праћење"
+
+#: static/js/common-all.js:12096 static/js/common-min.js:7 static/js/zamboni/password-strength.js:20
+msgid "Password strength:"
+msgstr "Јачина лозинке:"
+
+#: static/js/common-all.js:12102 static/js/common-min.js:7 static/js/zamboni/password-strength.js:26
+msgid "At least {0} character left."
+msgid_plural "At least {0} characters left."
+msgstr[0] "Остао је још најмање {0} каратер."
+msgstr[1] "Остало је још најмање {0} каратера."
+
+#: static/js/common-all.js:12286 static/js/common-min.js:7 static/js/impala-all.js:14632 static/js/impala-min.js:8 static/js/impala/suggestions.js:39
+msgid "Search themes for <b>{0}</b>"
+msgstr "Претражи теме за термин <b>{0}</b>"
+
+#: static/js/common-all.js:12288 static/js/common-min.js:7 static/js/impala-all.js:14634 static/js/impala-min.js:8 static/js/impala/suggestions.js:41
+msgid "Search apps for <b>{0}</b>"
+msgstr "Претражи апликације за термин <b>{0}</b>"
+
+#: static/js/common-all.js:12290 static/js/common-min.js:7 static/js/impala-all.js:14636 static/js/impala-min.js:8 static/js/impala/suggestions.js:43
+msgid "Search add-ons for <b>{0}</b>"
+msgstr "Претражи додатке за термин <b>{0}</b>"
+
+#: static/js/common-all.js:12521 static/js/common-min.js:7 static/js/impala-all.js:14867 static/js/impala-min.js:8 static/js/impala/site_suggestions.js:46
+msgid "Category"
+msgstr "Категорија"
+
+#. L10n: {0} is an app name.
+#: static/js/impala-all.js:11632 static/js/impala-min.js:7 static/js/impala/listing.js:11 static/js/zamboni/themes.js:13
+msgid "This theme is incompatible with your version of {0}"
+msgstr "Ова тема није компатибилна са Вашом верзијом {0}"
+
+#: static/js/impala-all.js:12146 static/js/impala-all.js:14331 static/js/impala-min.js:7 static/js/impala-min.js:8 static/js/common/upload-image.js:97 static/js/impala/users.js:51
+#: static/js/zamboni/devhub-all.js:894 static/js/zamboni/devhub-min.js:1
+msgid "Images must be either PNG or JPG."
+msgstr "Слике морају бити PNG или JPG."
+
+#: static/js/impala-all.js:12150 static/js/impala-min.js:7 static/js/common/upload-image.js:101 static/js/zamboni/devhub-all.js:898 static/js/zamboni/devhub-min.js:1
+msgid "Videos must be in WebM."
+msgstr "Видео снимци морају бити у WebM формату."
+
+#: static/js/impala-all.js:12177 static/js/impala-min.js:7 static/js/common/upload-addon.js:41 static/js/common/upload-image.js:128 static/js/zamboni/devhub-all.js:272
+#: static/js/zamboni/devhub-all.js:925 static/js/zamboni/devhub-min.js:1
 msgid "There was a problem contacting the server."
 msgstr "Дошло је до проблема при контактирању сервера."
 
-#: static/js/common/upload-addon.js:69
+#: static/js/impala-all.js:13298 static/js/impala-min.js:7 static/js/impala/persona_creation.js:60
+msgid "All Rights Reserved"
+msgstr "Сва права су задржана"
+
+#: static/js/impala-all.js:13302 static/js/impala-min.js:7 static/js/impala/persona_creation.js:64
+msgid "Creative Commons Attribution 3.0"
+msgstr "Creative Commons Attribution 3.0"
+
+#: static/js/impala-all.js:13307 static/js/impala-min.js:7 static/js/impala/persona_creation.js:69
+msgid "Creative Commons Attribution-NonCommercial 3.0"
+msgstr "Creative Commons Attribution-NonCommercial 3.0"
+
+#: static/js/impala-all.js:13312 static/js/impala-min.js:7 static/js/impala/persona_creation.js:74
+msgid "Creative Commons Attribution-NonCommercial-NoDerivs 3.0"
+msgstr "Creative Commons Attribution-NonCommercial-NoDerivs 3.0"
+
+#: static/js/impala-all.js:13317 static/js/impala-min.js:7 static/js/impala/persona_creation.js:79
+msgid "Creative Commons Attribution-NonCommercial-Share Alike 3.0"
+msgstr "Creative Commons Attribution-NonCommercial-Share Alike 3.0"
+
+#: static/js/impala-all.js:13322 static/js/impala-min.js:7 static/js/impala/persona_creation.js:84
+msgid "Creative Commons Attribution-NoDerivs 3.0"
+msgstr "Creative Commons Attribution-NoDerivs 3.0"
+
+#: static/js/impala-all.js:13327 static/js/impala-min.js:7 static/js/impala/persona_creation.js:89
+msgid "Creative Commons Attribution-ShareAlike 3.0"
+msgstr "Creative Commons Attribution-ShareAlike 3.0"
+
+#: static/js/impala-all.js:13530 static/js/impala-min.js:7 static/js/impala/persona_creation.js:292
+msgid "Your Theme's Name"
+msgstr "Назив Ваше теме"
+
+#: static/js/impala-all.js:14242 static/js/impala-min.js:8 static/js/impala/collections.js:19
+msgid "Stop Following"
+msgstr "Прекини праћење"
+
+#: static/js/impala-all.js:14243 static/js/impala-min.js:8 static/js/impala/collections.js:20
+msgid "Following"
+msgstr "Праћење"
+
+#: static/js/impala-all.js:14313 static/js/impala-min.js:8 static/js/impala/users.js:33
+msgid "use original"
+msgstr "користи оригинал"
+
+#: static/js/impala-all.js:14523 static/js/impala-min.js:8 static/js/impala/search.js:114
+msgid "Updating results&hellip;"
+msgstr "Ажурирам резултате&hellip;"
+
+#: static/js/common/upload-addon.js:69 static/js/zamboni/devhub-all.js:300 static/js/zamboni/devhub-min.js:1
 msgid "Select a file..."
 msgstr "Изаберите датотеку..."
 
-#: static/js/common/upload-addon.js:70
+#: static/js/common/upload-addon.js:70 static/js/zamboni/devhub-all.js:301 static/js/zamboni/devhub-min.js:1
 msgid "Your add-on should end with .xpi, .jar or .xml"
 msgstr "Ваш додатак се треба завршити са .xpi, .jar или .xml"
 
 #. L10n: {0} is the percent of the file that has been uploaded.
-#: static/js/common/upload-addon.js:104
+#: static/js/common/upload-addon.js:104 static/js/zamboni/devhub-all.js:335 static/js/zamboni/devhub-min.js:1
 #, fuzzy, python-format
 msgid "{0}% complete"
 msgstr "{0}% завршено"
 
 #. L10n: "{bytes uploaded} of {total filesize}".
-#: static/js/common/upload-addon.js:107
+#: static/js/common/upload-addon.js:107 static/js/zamboni/devhub-all.js:338 static/js/zamboni/devhub-min.js:1
 msgid "{0} of {1}"
 msgstr "{0} од {1}"
 
-#: static/js/common/upload-addon.js:140
+#: static/js/common/upload-addon.js:140 static/js/zamboni/devhub-all.js:371 static/js/zamboni/devhub-min.js:1
 msgid "Cancel"
 msgstr "Откажи"
 
-#: static/js/common/upload-addon.js:162
+#: static/js/common/upload-addon.js:162 static/js/zamboni/devhub-all.js:393 static/js/zamboni/devhub-min.js:1
 msgid "Uploading {0}"
 msgstr "Отпремам {0}"
 
-#: static/js/common/upload-addon.js:189
+#: static/js/common/upload-addon.js:189 static/js/zamboni/devhub-all.js:420 static/js/zamboni/devhub-min.js:1
 msgid "Error with {0}"
 msgstr "Грешка са {0}"
 
-#: static/js/common/upload-addon.js:194
+#: static/js/common/upload-addon.js:194 static/js/zamboni/devhub-all.js:425 static/js/zamboni/devhub-min.js:1
 msgid "Your add-on failed validation with {0} error."
 msgid_plural "Your add-on failed validation with {0} errors."
 msgstr[0] "Ваш додатак није прошао проверу - {0} грешка."
 msgstr[1] "Ваш додатак није прошао проверу - {0} грешке."
-msgstr[2] "Ваш додатак није прошао проверу - {0} грешака."
 
-#: static/js/common/upload-addon.js:208
+#: static/js/common/upload-addon.js:208 static/js/zamboni/devhub-all.js:439 static/js/zamboni/devhub-min.js:1
 msgid "&hellip;and {0} more"
 msgid_plural "&hellip;and {0} more"
 msgstr[0] "&hellip;и још {0}"
 msgstr[1] "&hellip;и још {0}"
-msgstr[2] "&hellip;и још {0}"
 
-#: static/js/common/upload-addon.js:222 static/js/common/upload-addon.js:512
+#: static/js/common/upload-addon.js:222 static/js/common/upload-addon.js:497 static/js/zamboni/devhub-all.js:453 static/js/zamboni/devhub-all.js:743 static/js/zamboni/devhub-min.js:1
 msgid "See full validation report"
 msgstr "Погледајте потпуни извештај прегледа"
 
-#: static/js/common/upload-addon.js:234
+#: static/js/common/upload-addon.js:234 static/js/zamboni/devhub-all.js:465 static/js/zamboni/devhub-min.js:1
 msgid "Validating {0}"
 msgstr "Проверавам {0}"
 
 #. L10n: first argument is an HTTP status code
-#: static/js/common/upload-addon.js:273
+#: static/js/common/upload-addon.js:273 static/js/zamboni/devhub-all.js:504 static/js/zamboni/devhub-min.js:1
 msgid "Received an empty response from the server; status: {0}"
 msgstr "Добијен је празан одговор од сервера; статус: {0}"
 
-#: static/js/common/upload-addon.js:373
+#: static/js/common/upload-addon.js:370 static/js/zamboni/devhub-all.js:604 static/js/zamboni/devhub-min.js:1
 msgid "Unexpected server error while validating."
 msgstr "Неочекивана грешка на серверу током провере."
 
-#: static/js/common/upload-addon.js:412
+#: static/js/common/upload-addon.js:409 static/js/zamboni/devhub-all.js:643 static/js/zamboni/devhub-min.js:1
 msgid "Finished validating {0}"
 msgstr "Завршена провера {0}"
 
-#: static/js/common/upload-addon.js:418
+#: static/js/common/upload-addon.js:415 static/js/zamboni/devhub-all.js:649 static/js/zamboni/devhub-min.js:1
 msgid "Your add-on validation timed out, it will be manually reviewed."
 msgstr ""
 
-#: static/js/common/upload-addon.js:421
+#: static/js/common/upload-addon.js:418 static/js/zamboni/devhub-all.js:652 static/js/zamboni/devhub-min.js:1
 msgid "Your add-on was validated with no errors and {0} warning."
 msgid_plural "Your add-on was validated with no errors and {0} warnings."
 msgstr[0] ""
 msgstr[1] ""
-msgstr[2] ""
 
-#: static/js/common/upload-addon.js:426
+#: static/js/common/upload-addon.js:423 static/js/zamboni/devhub-all.js:657 static/js/zamboni/devhub-min.js:1
 msgid "Your add-on was validated with no errors and {0} message."
 msgid_plural "Your add-on was validated with no errors and {0} messages."
 msgstr[0] ""
 msgstr[1] ""
-msgstr[2] ""
 
-#: static/js/common/upload-addon.js:431
+#: static/js/common/upload-addon.js:428 static/js/zamboni/devhub-all.js:662 static/js/zamboni/devhub-min.js:1
 msgid "Your add-on was validated with no errors or warnings."
 msgstr ""
 
-#: static/js/common/upload-addon.js:446
+#: static/js/common/upload-addon.js:443 static/js/zamboni/devhub-all.js:677 static/js/zamboni/devhub-min.js:1
 msgid "Your submission will be automatically signed."
 msgstr ""
 
-#: static/js/common/upload-addon.js:465
+#: static/js/common/upload-addon.js:450 static/js/zamboni/devhub-all.js:696 static/js/zamboni/devhub-min.js:1
 msgid "Include detailed version notes (this can be done in the next step)."
 msgstr "Укључите детаљне белешке верзије (ово може бити урађено у следећем кораку)."
 
-#: static/js/common/upload-addon.js:466
+#: static/js/common/upload-addon.js:451 static/js/zamboni/devhub-all.js:697 static/js/zamboni/devhub-min.js:1
 msgid "If your add-on requires an account to a website in order to be fully tested, include a test username and password in the Notes to Reviewer (this can be done in the next step)."
-msgstr "Ако је Вашем додатку потребна лозинка до вeb странице како би била потпуно тестирана, укључите и корисничко име и лозинку за тест у Белешке рецезента (ово може бити учињено у следећем кораку)."
+msgstr ""
+"Ако је Вашем додатку потребна лозинка до вeb странице како би била потпуно тестирана, укључите и корисничко име и лозинку за тест у Белешке рецезента (ово може бити учињено у следећем кораку)."
 
-#: static/js/common/upload-addon.js:467
+#: static/js/common/upload-addon.js:452 static/js/zamboni/devhub-all.js:698 static/js/zamboni/devhub-min.js:1
 msgid "If your add-on is intended for a limited audience you should choose Preliminary Review instead of Full Review."
 msgstr ""
 
-#: static/js/common/upload-addon.js:480
+#: static/js/common/upload-addon.js:465 static/js/zamboni/devhub-all.js:711 static/js/zamboni/devhub-min.js:1
 msgid "Add-on submission checklist"
 msgstr "Списак поднесених додатака"
 
-#: static/js/common/upload-addon.js:481
+#: static/js/common/upload-addon.js:466 static/js/zamboni/devhub-all.js:712 static/js/zamboni/devhub-min.js:1
 msgid "Please verify the following points before finalizing your submission. This will minimize delays or misunderstanding during the review process:"
 msgstr "Молимо Вас да верификујете наредне такче пре завршетка подношења. Ово ће минимизовати одлагања и неразумевања током процеса рецензије:"
 
-#: static/js/common/upload-addon.js:483
+#: static/js/common/upload-addon.js:468 static/js/zamboni/devhub-all.js:714 static/js/zamboni/devhub-min.js:1
 msgid ""
 "Compiled binaries, as well as minified or obfuscated scripts (excluding known libraries) need to have their sources submitted separately for review. Make sure that you use the source code upload "
 "field to avoid having your submission rejected."
@@ -143,1089 +395,844 @@ msgstr ""
 "Компајлиране бинарне датотеке, као и умањене скрипте (не рачунајући познате библиотеке) треба одвојено поднети на рецензију. Користите поље за отпремање изворног кода да бисте избегли одбијање "
 "отпремљеног кода."
 
-#: static/js/common/upload-addon.js:501
+#: static/js/common/upload-addon.js:486 static/js/zamboni/devhub-all.js:732 static/js/zamboni/devhub-min.js:1
 msgid "The validation process found these issues that can lead to rejections:"
 msgstr "Процес валидације је нашао проблеме које могу довести до:"
 
-#: static/js/common/upload-addon.js:518
+#: static/js/common/upload-addon.js:503 static/js/zamboni/devhub-all.js:749 static/js/zamboni/devhub-min.js:1
 msgid "If you are unfamiliar with the add-ons review process, you can read about it here."
 msgstr "Ако Вам није познат процес рецензије додатака, можете прочитати о томе овде."
 
-#: static/js/common/upload-addon.js:555
+#: static/js/common/upload-addon.js:540 static/js/zamboni/devhub-all.js:786 static/js/zamboni/devhub-min.js:1
 msgid "Sorry, no supported platform has been found."
 msgstr "Нажалост није нађена ни једна подржана платформа."
 
-#: static/js/common/upload-base.js:57
+#: static/js/common/upload-base.js:57 static/js/zamboni/devhub-all.js:187 static/js/zamboni/devhub-min.js:1
 msgid "The filetype you uploaded isn't recognized."
 msgstr "Тип датотеке коју сте послали није препознат."
 
-#: static/js/common/upload-base.js:79
+#: static/js/common/upload-base.js:79 static/js/zamboni/devhub-all.js:209 static/js/zamboni/devhub-min.js:1
 msgid "You cancelled the upload."
 msgstr "Отказали сте отпремање."
 
-#: static/js/common/upload-image.js:97 static/js/impala/users.js:51
-msgid "Images must be either PNG or JPG."
-msgstr "Слике морају бити PNG или JPG."
-
-#: static/js/common/upload-image.js:101
-msgid "Videos must be in WebM."
-msgstr "Видео снимци морају бити у WebM формату."
-
-#: static/js/impala/collections.js:10 static/js/zamboni/collections.js:595
-msgid "Follow this Collection"
-msgstr "Прати ову колекцију"
-
-#: static/js/impala/collections.js:19
-msgid "Stop Following"
-msgstr "Прекини праћење"
-
-#: static/js/impala/collections.js:20
-msgid "Following"
-msgstr "Праћење"
-
-#. L10n: {0} is an app name.
-#: static/js/impala/listing.js:11 static/js/zamboni/themes.js:13
-msgid "This theme is incompatible with your version of {0}"
-msgstr "Ова тема није компатибилна са Вашом верзијом {0}"
-
-#: static/js/impala/persona_creation.js:60
-msgid "All Rights Reserved"
-msgstr "Сва права су задржана"
-
-#: static/js/impala/persona_creation.js:64
-msgid "Creative Commons Attribution 3.0"
-msgstr "Creative Commons Attribution 3.0"
-
-#: static/js/impala/persona_creation.js:69
-msgid "Creative Commons Attribution-NonCommercial 3.0"
-msgstr "Creative Commons Attribution-NonCommercial 3.0"
-
-#: static/js/impala/persona_creation.js:74
-msgid "Creative Commons Attribution-NonCommercial-NoDerivs 3.0"
-msgstr "Creative Commons Attribution-NonCommercial-NoDerivs 3.0"
-
-#: static/js/impala/persona_creation.js:79
-msgid "Creative Commons Attribution-NonCommercial-Share Alike 3.0"
-msgstr "Creative Commons Attribution-NonCommercial-Share Alike 3.0"
-
-#: static/js/impala/persona_creation.js:84
-msgid "Creative Commons Attribution-NoDerivs 3.0"
-msgstr "Creative Commons Attribution-NoDerivs 3.0"
-
-#: static/js/impala/persona_creation.js:89
-msgid "Creative Commons Attribution-ShareAlike 3.0"
-msgstr "Creative Commons Attribution-ShareAlike 3.0"
-
-#: static/js/impala/persona_creation.js:292
-msgid "Your Theme's Name"
-msgstr "Назив Ваше теме"
-
-#: static/js/impala/reviews.js:23 static/js/zamboni/reviews.js:18
-msgid "Flagged for review"
-msgstr "Назначено за преглед"
-
-#: static/js/impala/reviews.js:40 static/js/zamboni/reviews.js:34
-msgid "Your input is required"
-msgstr "Ваш одзив је неопходан"
-
-#: static/js/impala/reviews.js:152 static/js/zamboni/reviews.js:103
-msgid "Marked for deletion"
-msgstr "Обележено за брисање"
-
-#: static/js/impala/search.js:114
-msgid "Updating results&hellip;"
-msgstr "Ажурирам резултате&hellip;"
-
-#: static/js/impala/site_suggestions.js:46
-msgid "Category"
-msgstr "Категорија"
-
-#: static/js/impala/suggestions.js:39
-msgid "Search themes for <b>{0}</b>"
-msgstr "Претражи теме за термин <b>{0}</b>"
-
-#: static/js/impala/suggestions.js:41
-msgid "Search apps for <b>{0}</b>"
-msgstr "Претражи апликације за термин <b>{0}</b>"
-
-#: static/js/impala/suggestions.js:43
-msgid "Search add-ons for <b>{0}</b>"
-msgstr "Претражи додатке за термин <b>{0}</b>"
-
-#: static/js/impala/users.js:33
-msgid "use original"
-msgstr "користи оригинал"
-
-#: static/js/impala/stats/chart.js:267
+#: static/js/impala/stats/chart.js:267 static/js/zamboni/stats-all.js:16898 static/js/zamboni/stats-min.js:5
 msgid "Week of {0}"
 msgstr "Седмица од {0}"
 
-#: static/js/impala/stats/chart.js:269
+#: static/js/impala/stats/chart.js:269 static/js/zamboni/stats-all.js:16900 static/js/zamboni/stats-min.js:5
 msgid " downloads"
 msgstr ""
 
-#: static/js/impala/stats/chart.js:270
+#: static/js/impala/stats/chart.js:270 static/js/zamboni/stats-all.js:16901 static/js/zamboni/stats-min.js:5
 msgid "{0} users"
 msgstr "{0} корисника"
 
-#: static/js/impala/stats/chart.js:271
+#: static/js/impala/stats/chart.js:271 static/js/zamboni/stats-all.js:16902 static/js/zamboni/stats-min.js:5
 msgid "{0} add-ons"
 msgstr "{0} додатака"
 
-#: static/js/impala/stats/chart.js:272
+#: static/js/impala/stats/chart.js:272 static/js/zamboni/stats-all.js:16903 static/js/zamboni/stats-min.js:5
 msgid "{0} collections"
 msgstr "{0} колекције"
 
-#: static/js/impala/stats/chart.js:273
+#: static/js/impala/stats/chart.js:273 static/js/zamboni/stats-all.js:16904 static/js/zamboni/stats-min.js:5
 msgid "{0} reviews"
 msgstr "{0} рецензија"
 
-#: static/js/impala/stats/chart.js:275
+#: static/js/impala/stats/chart.js:275 static/js/zamboni/stats-all.js:16906 static/js/zamboni/stats-min.js:5
 msgid "{0} sales"
 msgstr "{0} продаја"
 
-#: static/js/impala/stats/chart.js:276
+#: static/js/impala/stats/chart.js:276 static/js/zamboni/stats-all.js:16907 static/js/zamboni/stats-min.js:5
 msgid "{0} refunds"
 msgstr "{0} рефункдација"
 
-#: static/js/impala/stats/chart.js:277
+#: static/js/impala/stats/chart.js:277 static/js/zamboni/stats-all.js:16908 static/js/zamboni/stats-min.js:5
 msgid "{0} installs"
 msgstr "{0} инсталација"
 
-#: static/js/impala/stats/chart.js:369 static/js/impala/stats/csv_keys.js:3 static/js/impala/stats/csv_keys.js:109
+#: static/js/impala/stats/chart.js:369 static/js/impala/stats/csv_keys.js:3 static/js/impala/stats/csv_keys.js:109 static/js/zamboni/stats-all.js:15284 static/js/zamboni/stats-all.js:15390
+#: static/js/zamboni/stats-all.js:17000 static/js/zamboni/stats-min.js:4 static/js/zamboni/stats-min.js:5
 msgid "Downloads"
 msgstr "Преузимања"
 
-#: static/js/impala/stats/chart.js:379 static/js/impala/stats/csv_keys.js:6 static/js/impala/stats/csv_keys.js:110
+#: static/js/impala/stats/chart.js:379 static/js/impala/stats/csv_keys.js:6 static/js/impala/stats/csv_keys.js:110 static/js/zamboni/stats-all.js:15287 static/js/zamboni/stats-all.js:15391
+#: static/js/zamboni/stats-all.js:17010 static/js/zamboni/stats-min.js:4 static/js/zamboni/stats-min.js:5
 msgid "Daily Users"
 msgstr "Број корисника по дану"
 
-#: static/js/impala/stats/chart.js:410
+#: static/js/impala/stats/chart.js:410 static/js/zamboni/stats-all.js:17041 static/js/zamboni/stats-min.js:5
 msgid "Amount, in USD"
 msgstr "Количина, у валути USD"
 
-#: static/js/impala/stats/chart.js:421 static/js/impala/stats/csv_keys.js:104
+#: static/js/impala/stats/chart.js:421 static/js/impala/stats/csv_keys.js:104 static/js/zamboni/stats-all.js:15385 static/js/zamboni/stats-all.js:17052 static/js/zamboni/stats-min.js:5
 msgid "Number of Contributions"
 msgstr "Број доприноса"
 
-#: static/js/impala/stats/chart.js:447
+#: static/js/impala/stats/chart.js:447 static/js/zamboni/stats-all.js:17078 static/js/zamboni/stats-min.js:5
 msgid "More Info..."
 msgstr "Више информација..."
 
 #. L10n: {0} is an ISO-formatted date.
-#: static/js/impala/stats/chart.js:451
+#: static/js/impala/stats/chart.js:451 static/js/zamboni/stats-all.js:17082 static/js/zamboni/stats-min.js:5
 msgid "Details for {0}"
 msgstr "Детаљи о {0}"
 
-#: static/js/impala/stats/csv_keys.js:9
+#: static/js/impala/stats/csv_keys.js:9 static/js/zamboni/stats-all.js:15290 static/js/zamboni/stats-min.js:4
 msgid "Collections Created"
 msgstr "Направљене колекције"
 
-#: static/js/impala/stats/csv_keys.js:12
+#: static/js/impala/stats/csv_keys.js:12 static/js/zamboni/stats-all.js:15293 static/js/zamboni/stats-min.js:4
 msgid "Add-ons in Use"
 msgstr "Додаци који се користе"
 
-#: static/js/impala/stats/csv_keys.js:15
+#: static/js/impala/stats/csv_keys.js:15 static/js/zamboni/stats-all.js:15296 static/js/zamboni/stats-min.js:4
 msgid "Add-ons Created"
 msgstr "Додатака направљено"
 
-#: static/js/impala/stats/csv_keys.js:18
+#: static/js/impala/stats/csv_keys.js:18 static/js/zamboni/stats-all.js:15299 static/js/zamboni/stats-min.js:4
 msgid "Add-ons Downloaded"
 msgstr "Додатака преузето"
 
-#: static/js/impala/stats/csv_keys.js:21
+#: static/js/impala/stats/csv_keys.js:21 static/js/zamboni/stats-all.js:15302 static/js/zamboni/stats-min.js:4
 msgid "Add-ons Updated"
 msgstr "Додатака ажурирано"
 
-#: static/js/impala/stats/csv_keys.js:24
+#: static/js/impala/stats/csv_keys.js:24 static/js/zamboni/stats-all.js:15305 static/js/zamboni/stats-min.js:4
 msgid "Reviews Written"
 msgstr "Рецензија написано"
 
-#: static/js/impala/stats/csv_keys.js:27
+#: static/js/impala/stats/csv_keys.js:27 static/js/zamboni/stats-all.js:15308 static/js/zamboni/stats-min.js:4
 msgid "User Signups"
 msgstr "Пријаве корисника"
 
-#: static/js/impala/stats/csv_keys.js:30
+#: static/js/impala/stats/csv_keys.js:30 static/js/zamboni/stats-all.js:15311 static/js/zamboni/stats-min.js:4
 msgid "Subscribers"
 msgstr "Претплатници"
 
-#: static/js/impala/stats/csv_keys.js:33
+#: static/js/impala/stats/csv_keys.js:33 static/js/zamboni/stats-all.js:15314 static/js/zamboni/stats-min.js:4
 msgid "Ratings"
 msgstr "Оцене"
 
-#: static/js/impala/stats/csv_keys.js:36 static/js/impala/stats/csv_keys.js:114
+#: static/js/impala/stats/csv_keys.js:36 static/js/impala/stats/csv_keys.js:114 static/js/zamboni/stats-all.js:15317 static/js/zamboni/stats-all.js:15395 static/js/zamboni/stats-min.js:4
+#: static/js/zamboni/stats-min.js:5
 msgid "Sales"
 msgstr "Продаје"
 
-#: static/js/impala/stats/csv_keys.js:39 static/js/impala/stats/csv_keys.js:113
+#: static/js/impala/stats/csv_keys.js:39 static/js/impala/stats/csv_keys.js:113 static/js/zamboni/stats-all.js:15320 static/js/zamboni/stats-all.js:15394 static/js/zamboni/stats-min.js:4
+#: static/js/zamboni/stats-min.js:5
 msgid "Installs"
 msgstr "Инсталације"
 
-#: static/js/impala/stats/csv_keys.js:42
+#: static/js/impala/stats/csv_keys.js:42 static/js/zamboni/stats-all.js:15323 static/js/zamboni/stats-min.js:4
 msgid "Unknown"
 msgstr "Непознато"
 
-#: static/js/impala/stats/csv_keys.js:43
+#: static/js/impala/stats/csv_keys.js:43 static/js/zamboni/stats-all.js:15324 static/js/zamboni/stats-min.js:4
 msgid "Add-ons Manager"
 msgstr "Менаџер додатака"
 
-#: static/js/impala/stats/csv_keys.js:44
+#: static/js/impala/stats/csv_keys.js:44 static/js/zamboni/stats-all.js:15325 static/js/zamboni/stats-min.js:4
 msgid "Add-ons Manager Promo"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:45
+#: static/js/impala/stats/csv_keys.js:45 static/js/zamboni/stats-all.js:15326 static/js/zamboni/stats-min.js:4
 msgid "Add-ons Manager Featured"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:46
+#: static/js/impala/stats/csv_keys.js:46 static/js/zamboni/stats-all.js:15327 static/js/zamboni/stats-min.js:4
 msgid "Add-ons Manager Learn More"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:47
+#: static/js/impala/stats/csv_keys.js:47 static/js/zamboni/stats-all.js:15328 static/js/zamboni/stats-min.js:4
 msgid "Search Suggestions"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:48
+#: static/js/impala/stats/csv_keys.js:48 static/js/zamboni/stats-all.js:15329 static/js/zamboni/stats-min.js:4
 msgid "Search Results"
 msgstr "Резултати претраге"
 
-#: static/js/impala/stats/csv_keys.js:49 static/js/impala/stats/csv_keys.js:50 static/js/impala/stats/csv_keys.js:51
+#: static/js/impala/stats/csv_keys.js:49 static/js/impala/stats/csv_keys.js:50 static/js/impala/stats/csv_keys.js:51 static/js/zamboni/stats-all.js:15330 static/js/zamboni/stats-all.js:15331
+#: static/js/zamboni/stats-all.js:15332 static/js/zamboni/stats-min.js:4
 msgid "Homepage Promo"
 msgstr "Промоција на почетној страни"
 
-#: static/js/impala/stats/csv_keys.js:52 static/js/impala/stats/csv_keys.js:53
+#: static/js/impala/stats/csv_keys.js:52 static/js/impala/stats/csv_keys.js:53 static/js/zamboni/stats-all.js:15333 static/js/zamboni/stats-all.js:15334 static/js/zamboni/stats-min.js:4
 msgid "Homepage Featured"
 msgstr "Издвојено на почетној страни"
 
-#: static/js/impala/stats/csv_keys.js:54 static/js/impala/stats/csv_keys.js:55
+#: static/js/impala/stats/csv_keys.js:54 static/js/impala/stats/csv_keys.js:55 static/js/zamboni/stats-all.js:15335 static/js/zamboni/stats-all.js:15336 static/js/zamboni/stats-min.js:4
 msgid "Homepage Up and Coming"
 msgstr "Надолазеће на почетној страни"
 
-#: static/js/impala/stats/csv_keys.js:56
+#: static/js/impala/stats/csv_keys.js:56 static/js/zamboni/stats-all.js:15337 static/js/zamboni/stats-min.js:4
 msgid "Homepage Most Popular"
 msgstr "Најпопуларније на почетној страни"
 
-#: static/js/impala/stats/csv_keys.js:57 static/js/impala/stats/csv_keys.js:59
+#: static/js/impala/stats/csv_keys.js:57 static/js/impala/stats/csv_keys.js:59 static/js/zamboni/stats-all.js:15338 static/js/zamboni/stats-all.js:15340 static/js/zamboni/stats-min.js:4
 msgid "Detail Page"
 msgstr "Додатне информације"
 
-#: static/js/impala/stats/csv_keys.js:58 static/js/impala/stats/csv_keys.js:60
+#: static/js/impala/stats/csv_keys.js:58 static/js/impala/stats/csv_keys.js:60 static/js/zamboni/stats-all.js:15339 static/js/zamboni/stats-all.js:15341 static/js/zamboni/stats-min.js:4
 msgid "Detail Page (bottom)"
 msgstr "Додатне информације (доле)"
 
-#: static/js/impala/stats/csv_keys.js:61
+#: static/js/impala/stats/csv_keys.js:61 static/js/zamboni/stats-all.js:15342 static/js/zamboni/stats-min.js:4
 msgid "Detail Page (Development Channel)"
 msgstr "Додатне информације (Канал за развој)"
 
-#: static/js/impala/stats/csv_keys.js:62 static/js/impala/stats/csv_keys.js:63 static/js/impala/stats/csv_keys.js:64
+#: static/js/impala/stats/csv_keys.js:62 static/js/impala/stats/csv_keys.js:63 static/js/impala/stats/csv_keys.js:64 static/js/zamboni/stats-all.js:15343 static/js/zamboni/stats-all.js:15344
+#: static/js/zamboni/stats-all.js:15345 static/js/zamboni/stats-min.js:4
 msgid "Often Used With"
 msgstr "Често коришћено уз"
 
-#: static/js/impala/stats/csv_keys.js:65 static/js/impala/stats/csv_keys.js:66
+#: static/js/impala/stats/csv_keys.js:65 static/js/impala/stats/csv_keys.js:66 static/js/zamboni/stats-all.js:15346 static/js/zamboni/stats-all.js:15347 static/js/zamboni/stats-min.js:4
 msgid "Others By Author"
 msgstr "Остало од аутора"
 
-#: static/js/impala/stats/csv_keys.js:67 static/js/impala/stats/csv_keys.js:68
+#: static/js/impala/stats/csv_keys.js:67 static/js/impala/stats/csv_keys.js:68 static/js/zamboni/stats-all.js:15348 static/js/zamboni/stats-all.js:15349 static/js/zamboni/stats-min.js:4
 msgid "Dependencies"
 msgstr "Зависи од"
 
-#: static/js/impala/stats/csv_keys.js:69 static/js/impala/stats/csv_keys.js:70
+#: static/js/impala/stats/csv_keys.js:69 static/js/impala/stats/csv_keys.js:70 static/js/zamboni/stats-all.js:15350 static/js/zamboni/stats-all.js:15351 static/js/zamboni/stats-min.js:4
 msgid "Upsell"
 msgstr "Технике увећања продаје"
 
-#: static/js/impala/stats/csv_keys.js:71
+#: static/js/impala/stats/csv_keys.js:71 static/js/zamboni/stats-all.js:15352 static/js/zamboni/stats-min.js:4
 msgid "Meet the Developer"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:72
+#: static/js/impala/stats/csv_keys.js:72 static/js/zamboni/stats-all.js:15353 static/js/zamboni/stats-min.js:4
 msgid "User Profile"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:73
+#: static/js/impala/stats/csv_keys.js:73 static/js/zamboni/stats-all.js:15354 static/js/zamboni/stats-min.js:4
 msgid "Version History"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:75
+#: static/js/impala/stats/csv_keys.js:75 static/js/zamboni/stats-all.js:15356 static/js/zamboni/stats-min.js:4
 msgid "Sharing"
 msgstr "Дељење"
 
-#: static/js/impala/stats/csv_keys.js:76
+#: static/js/impala/stats/csv_keys.js:76 static/js/zamboni/stats-all.js:15357 static/js/zamboni/stats-min.js:4
 msgid "Category Pages"
 msgstr "Странице категорија"
 
-#: static/js/impala/stats/csv_keys.js:77
+#: static/js/impala/stats/csv_keys.js:77 static/js/zamboni/stats-all.js:15358 static/js/zamboni/stats-min.js:4
 msgid "Collections"
 msgstr "Колекције"
 
-#: static/js/impala/stats/csv_keys.js:78 static/js/impala/stats/csv_keys.js:79
+#: static/js/impala/stats/csv_keys.js:78 static/js/impala/stats/csv_keys.js:79 static/js/zamboni/stats-all.js:15359 static/js/zamboni/stats-all.js:15360 static/js/zamboni/stats-min.js:4
 msgid "Category Landing Featured Carousel"
 msgstr "Клизач издвојених апл. на почетној страни категорије"
 
-#: static/js/impala/stats/csv_keys.js:80 static/js/impala/stats/csv_keys.js:81
+#: static/js/impala/stats/csv_keys.js:80 static/js/impala/stats/csv_keys.js:81 static/js/zamboni/stats-all.js:15361 static/js/zamboni/stats-all.js:15362 static/js/zamboni/stats-min.js:4
 msgid "Category Landing Top Rated"
 msgstr "Најбоље оцењене апл. на почетној страни категорије"
 
-#: static/js/impala/stats/csv_keys.js:82 static/js/impala/stats/csv_keys.js:83
+#: static/js/impala/stats/csv_keys.js:82 static/js/impala/stats/csv_keys.js:83 static/js/zamboni/stats-all.js:15363 static/js/zamboni/stats-all.js:15364 static/js/zamboni/stats-min.js:5
 msgid "Category Landing Most Popular"
 msgstr "Најпопуларније апл. на почетној страни категорије"
 
-#: static/js/impala/stats/csv_keys.js:84 static/js/impala/stats/csv_keys.js:85
+#: static/js/impala/stats/csv_keys.js:84 static/js/impala/stats/csv_keys.js:85 static/js/zamboni/stats-all.js:15365 static/js/zamboni/stats-all.js:15366 static/js/zamboni/stats-min.js:5
 msgid "Category Landing Recently Added"
 msgstr "Скоро додате апл. на почетној страни категорије"
 
-#: static/js/impala/stats/csv_keys.js:86 static/js/impala/stats/csv_keys.js:87
+#: static/js/impala/stats/csv_keys.js:86 static/js/impala/stats/csv_keys.js:87 static/js/zamboni/stats-all.js:15367 static/js/zamboni/stats-all.js:15368 static/js/zamboni/stats-min.js:5
 msgid "Browse Listing Featured Sort"
 msgstr "Преглед сортиране листе истакнутих апликација"
 
-#: static/js/impala/stats/csv_keys.js:88 static/js/impala/stats/csv_keys.js:89
+#: static/js/impala/stats/csv_keys.js:88 static/js/impala/stats/csv_keys.js:89 static/js/zamboni/stats-all.js:15369 static/js/zamboni/stats-all.js:15370 static/js/zamboni/stats-min.js:5
 msgid "Browse Listing Users Sort"
 msgstr "Преглед сортиране листе корисника"
 
-#: static/js/impala/stats/csv_keys.js:90 static/js/impala/stats/csv_keys.js:91
+#: static/js/impala/stats/csv_keys.js:90 static/js/impala/stats/csv_keys.js:91 static/js/zamboni/stats-all.js:15371 static/js/zamboni/stats-all.js:15372 static/js/zamboni/stats-min.js:5
 msgid "Browse Listing Rating Sort"
 msgstr "Преглед сортиране листе оцена"
 
-#: static/js/impala/stats/csv_keys.js:92 static/js/impala/stats/csv_keys.js:93
+#: static/js/impala/stats/csv_keys.js:92 static/js/impala/stats/csv_keys.js:93 static/js/zamboni/stats-all.js:15373 static/js/zamboni/stats-all.js:15374 static/js/zamboni/stats-min.js:5
 msgid "Browse Listing Created Sort"
 msgstr "Преглед сортиране листе креираних апликација"
 
-#: static/js/impala/stats/csv_keys.js:94 static/js/impala/stats/csv_keys.js:95
+#: static/js/impala/stats/csv_keys.js:94 static/js/impala/stats/csv_keys.js:95 static/js/zamboni/stats-all.js:15375 static/js/zamboni/stats-all.js:15376 static/js/zamboni/stats-min.js:5
 msgid "Browse Listing Name Sort"
 msgstr "Преглед сортиране листе назива"
 
-#: static/js/impala/stats/csv_keys.js:96 static/js/impala/stats/csv_keys.js:97
+#: static/js/impala/stats/csv_keys.js:96 static/js/impala/stats/csv_keys.js:97 static/js/zamboni/stats-all.js:15377 static/js/zamboni/stats-all.js:15378 static/js/zamboni/stats-min.js:5
 msgid "Browse Listing Popular Sort"
 msgstr "Преглед сортиране листе популарних апликација"
 
-#: static/js/impala/stats/csv_keys.js:98 static/js/impala/stats/csv_keys.js:99
+#: static/js/impala/stats/csv_keys.js:98 static/js/impala/stats/csv_keys.js:99 static/js/zamboni/stats-all.js:15379 static/js/zamboni/stats-all.js:15380 static/js/zamboni/stats-min.js:5
 msgid "Browse Listing Updated Sort"
 msgstr "Преглед сортиране листе ажурираних апликација"
 
-#: static/js/impala/stats/csv_keys.js:100 static/js/impala/stats/csv_keys.js:101
+#: static/js/impala/stats/csv_keys.js:100 static/js/impala/stats/csv_keys.js:101 static/js/zamboni/stats-all.js:15381 static/js/zamboni/stats-all.js:15382 static/js/zamboni/stats-min.js:5
 msgid "Browse Listing Up and Coming Sort"
 msgstr "Преглед сортиране листе надолазећих апликација"
 
-#: static/js/impala/stats/csv_keys.js:105
+#: static/js/impala/stats/csv_keys.js:105 static/js/zamboni/stats-all.js:15386 static/js/zamboni/stats-min.js:5
 msgid "Total Amount Contributed"
 msgstr "Укупан број доприноса"
 
-#: static/js/impala/stats/csv_keys.js:106
+#: static/js/impala/stats/csv_keys.js:106 static/js/zamboni/stats-all.js:15387 static/js/zamboni/stats-min.js:5
 msgid "Average Contribution"
 msgstr "Просек доприноса"
 
-#: static/js/impala/stats/csv_keys.js:115
+#: static/js/impala/stats/csv_keys.js:115 static/js/zamboni/stats-all.js:15396 static/js/zamboni/stats-min.js:5
 msgid "Usage"
 msgstr "Употреба"
 
-#: static/js/impala/stats/csv_keys.js:118
+#: static/js/impala/stats/csv_keys.js:118 static/js/zamboni/stats-all.js:15399 static/js/zamboni/stats-min.js:5
 msgid "Firefox"
 msgstr "Firefox"
 
-#: static/js/impala/stats/csv_keys.js:119
+#: static/js/impala/stats/csv_keys.js:119 static/js/zamboni/stats-all.js:15400 static/js/zamboni/stats-min.js:5
 msgid "Mozilla"
 msgstr "Mozilla"
 
-#: static/js/impala/stats/csv_keys.js:120
+#: static/js/impala/stats/csv_keys.js:120 static/js/zamboni/stats-all.js:15401 static/js/zamboni/stats-min.js:5
 msgid "Thunderbird"
 msgstr "Thunderbird"
 
-#: static/js/impala/stats/csv_keys.js:121
+#: static/js/impala/stats/csv_keys.js:121 static/js/zamboni/stats-all.js:15402 static/js/zamboni/stats-min.js:5
 msgid "Sunbird"
 msgstr "Sunbird"
 
-#: static/js/impala/stats/csv_keys.js:122
+#: static/js/impala/stats/csv_keys.js:122 static/js/zamboni/stats-all.js:15403 static/js/zamboni/stats-min.js:5
 msgid "SeaMonkey"
 msgstr "SeaMonkey"
 
-#: static/js/impala/stats/csv_keys.js:123
+#: static/js/impala/stats/csv_keys.js:123 static/js/zamboni/stats-all.js:15404 static/js/zamboni/stats-min.js:5
 msgid "Fennec"
 msgstr "Fennec"
 
-#: static/js/impala/stats/csv_keys.js:124
+#: static/js/impala/stats/csv_keys.js:124 static/js/zamboni/stats-all.js:15405 static/js/zamboni/stats-min.js:5
 msgid "Android"
 msgstr "Android"
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:129
+#: static/js/impala/stats/csv_keys.js:129 static/js/zamboni/stats-all.js:15410 static/js/zamboni/stats-min.js:5
 msgid "Downloads and Daily Users, last {0} days"
 msgstr "Преузимања и дневни корисници, последњих {0} дана"
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:131
+#: static/js/impala/stats/csv_keys.js:131 static/js/zamboni/stats-all.js:15412 static/js/zamboni/stats-min.js:5
 msgid "Downloads and Daily Users from {0} to {1}"
 msgstr "Преузимања и дневни корисници од {0} до {1}"
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:135
+#: static/js/impala/stats/csv_keys.js:135 static/js/zamboni/stats-all.js:15416 static/js/zamboni/stats-min.js:5
 msgid "Installs and Daily Users, last {0} days"
 msgstr "Инсталације и дневни корисници, последњих {0} дана"
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:137
+#: static/js/impala/stats/csv_keys.js:137 static/js/zamboni/stats-all.js:15418 static/js/zamboni/stats-min.js:5
 msgid "Installs and Daily Users from {0} to {1}"
 msgstr "Инсталације и дневни корисници од {0} до {1}"
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:141
+#: static/js/impala/stats/csv_keys.js:141 static/js/zamboni/stats-all.js:15422 static/js/zamboni/stats-min.js:5
 msgid "Downloads, last {0} days"
 msgstr "Преузимања, последњих {0} дана"
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:143
+#: static/js/impala/stats/csv_keys.js:143 static/js/zamboni/stats-all.js:15424 static/js/zamboni/stats-min.js:5
 msgid "Downloads from {0} to {1}"
 msgstr "Преузимања од {0} до {1}"
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:147
+#: static/js/impala/stats/csv_keys.js:147 static/js/zamboni/stats-all.js:15428 static/js/zamboni/stats-min.js:5
 msgid "Daily Users, last {0} days"
 msgstr "Дневни корисници, последњих {0} дана"
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:149
+#: static/js/impala/stats/csv_keys.js:149 static/js/zamboni/stats-all.js:15430 static/js/zamboni/stats-min.js:5
 msgid "Daily Users from {0} to {1}"
 msgstr "Дневни корисници од {0} до {1}"
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:153
+#: static/js/impala/stats/csv_keys.js:153 static/js/zamboni/stats-all.js:15434 static/js/zamboni/stats-min.js:5
 msgid "Applications, last {0} days"
 msgstr "Апликације, последњих {0} дана"
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:155
+#: static/js/impala/stats/csv_keys.js:155 static/js/zamboni/stats-all.js:15436 static/js/zamboni/stats-min.js:5
 msgid "Applications from {0} to {1}"
 msgstr "Апликације од {0} до {1}"
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:159
+#: static/js/impala/stats/csv_keys.js:159 static/js/zamboni/stats-all.js:15440 static/js/zamboni/stats-min.js:5
 msgid "Platforms, last {0} days"
 msgstr "Платформе, последњих {0} дана"
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:161
+#: static/js/impala/stats/csv_keys.js:161 static/js/zamboni/stats-all.js:15442 static/js/zamboni/stats-min.js:5
 msgid "Platforms from {0} to {1}"
 msgstr "Платформе од {0} до {1}"
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:165
+#: static/js/impala/stats/csv_keys.js:165 static/js/zamboni/stats-all.js:15446 static/js/zamboni/stats-min.js:5
 msgid "Languages, last {0} days"
 msgstr "Језици, последњих {0} дана"
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:167
+#: static/js/impala/stats/csv_keys.js:167 static/js/zamboni/stats-all.js:15448 static/js/zamboni/stats-min.js:5
 msgid "Languages from {0} to {1}"
 msgstr "Језици од {0} до {1}"
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:171
+#: static/js/impala/stats/csv_keys.js:171 static/js/zamboni/stats-all.js:15452 static/js/zamboni/stats-min.js:5
 msgid "Add-on Versions, last {0} days"
 msgstr "Верзије додатака, последњих {0} дана"
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:173
+#: static/js/impala/stats/csv_keys.js:173 static/js/zamboni/stats-all.js:15454 static/js/zamboni/stats-min.js:5
 msgid "Add-on Versions from {0} to {1}"
 msgstr "Верзије додатака од {0} до {1}"
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:177
+#: static/js/impala/stats/csv_keys.js:177 static/js/zamboni/stats-all.js:15458 static/js/zamboni/stats-min.js:5
 msgid "Add-on Status, last {0} days"
 msgstr "Статус додатака, последњих {0} дана"
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:179
+#: static/js/impala/stats/csv_keys.js:179 static/js/zamboni/stats-all.js:15460 static/js/zamboni/stats-min.js:5
 msgid "Add-on Status from {0} to {1}"
 msgstr "Статус додатака, од {0} до {1}"
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:183
+#: static/js/impala/stats/csv_keys.js:183 static/js/zamboni/stats-all.js:15464 static/js/zamboni/stats-min.js:5
 msgid "Download Sources, last {0} days"
 msgstr "Извори преузимања, последњих {0} дана"
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:185
+#: static/js/impala/stats/csv_keys.js:185 static/js/zamboni/stats-all.js:15466 static/js/zamboni/stats-min.js:5
 msgid "Download Sources from {0} to {1}"
 msgstr "Извори преузимања од {0} до {1}"
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:189
+#: static/js/impala/stats/csv_keys.js:189 static/js/zamboni/stats-all.js:15470 static/js/zamboni/stats-min.js:5
 msgid "Contributions, last {0} days"
 msgstr "Доприноси, последњих {0} дана"
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:191
+#: static/js/impala/stats/csv_keys.js:191 static/js/zamboni/stats-all.js:15472 static/js/zamboni/stats-min.js:5
 msgid "Contributions from {0} to {1}"
 msgstr "Доприноси од {0} до {1}"
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:195
+#: static/js/impala/stats/csv_keys.js:195 static/js/zamboni/stats-all.js:15476 static/js/zamboni/stats-min.js:5
 msgid "Site Metrics, last {0} days"
 msgstr "Показатељи за сајт, последњих {0} дана"
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:197
+#: static/js/impala/stats/csv_keys.js:197 static/js/zamboni/stats-all.js:15478 static/js/zamboni/stats-min.js:5
 msgid "Site Metrics from {0} to {1}"
 msgstr "Показатељи за сајт од {0} до {1}"
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:201
+#: static/js/impala/stats/csv_keys.js:201 static/js/zamboni/stats-all.js:15482 static/js/zamboni/stats-min.js:5
 msgid "Add-ons in Use, last {0} days"
 msgstr "Додаци у употреби, последњих {0} дана"
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:203
+#: static/js/impala/stats/csv_keys.js:203 static/js/zamboni/stats-all.js:15484 static/js/zamboni/stats-min.js:5
 msgid "Add-ons in Use from {0} to {1}"
 msgstr "Додаци у употреби од {0} до {1}"
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:207
+#: static/js/impala/stats/csv_keys.js:207 static/js/zamboni/stats-all.js:15488 static/js/zamboni/stats-min.js:5
 msgid "Add-ons Downloaded, last {0} days"
 msgstr "Додатака преузето, последњих {0} дана"
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:209
+#: static/js/impala/stats/csv_keys.js:209 static/js/zamboni/stats-all.js:15490 static/js/zamboni/stats-min.js:5
 msgid "Add-ons Downloaded from {0} to {1}"
 msgstr "Додатака преузето од {0} до {1}"
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:213
+#: static/js/impala/stats/csv_keys.js:213 static/js/zamboni/stats-all.js:15494 static/js/zamboni/stats-min.js:5
 msgid "Add-ons Created, last {0} days"
 msgstr "Додатака направљено, последњих {0} дана"
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:215
+#: static/js/impala/stats/csv_keys.js:215 static/js/zamboni/stats-all.js:15496 static/js/zamboni/stats-min.js:5
 msgid "Add-ons Created from {0} to {1}"
 msgstr "Додатака направљено од {0} до {1}"
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:219
+#: static/js/impala/stats/csv_keys.js:219 static/js/zamboni/stats-all.js:15500 static/js/zamboni/stats-min.js:5
 msgid "Add-ons Updated, last {0} days"
 msgstr "Додатака ажурирано, последњих {0} дана"
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:221
+#: static/js/impala/stats/csv_keys.js:221 static/js/zamboni/stats-all.js:15502 static/js/zamboni/stats-min.js:5
 msgid "Add-ons Updated from {0} to {1}"
 msgstr "Додатака ажурирано од {0} до {1}"
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:225
+#: static/js/impala/stats/csv_keys.js:225 static/js/zamboni/stats-all.js:15506 static/js/zamboni/stats-min.js:5
 msgid "Reviews Written, last {0} days"
 msgstr "Рецензија написано, последњих {0} дана"
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:227
+#: static/js/impala/stats/csv_keys.js:227 static/js/zamboni/stats-all.js:15508 static/js/zamboni/stats-min.js:5
 msgid "Reviews Written from {0} to {1}"
 msgstr "Рецензија написано од {0} до {1}"
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:231
+#: static/js/impala/stats/csv_keys.js:231 static/js/zamboni/stats-all.js:15512 static/js/zamboni/stats-min.js:5
 msgid "User Signups, last {0} days"
 msgstr "Регистрације корисника, последњих {0} дана"
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:233
+#: static/js/impala/stats/csv_keys.js:233 static/js/zamboni/stats-all.js:15514 static/js/zamboni/stats-min.js:5
 msgid "User Signups from {0} to {1}"
 msgstr "Регистрације корисника од {0} до {1}"
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:237
+#: static/js/impala/stats/csv_keys.js:237 static/js/zamboni/stats-all.js:15518 static/js/zamboni/stats-min.js:5
 msgid "Collections Created, last {0} days"
 msgstr "Колекција направљено, последњих {0} дана"
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:239
+#: static/js/impala/stats/csv_keys.js:239 static/js/zamboni/stats-all.js:15520 static/js/zamboni/stats-min.js:5
 msgid "Collections Created from {0} to {1}"
 msgstr "Колекција направљено од {0} до {1}"
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:243
+#: static/js/impala/stats/csv_keys.js:243 static/js/zamboni/stats-all.js:15524 static/js/zamboni/stats-min.js:5
 msgid "Subscribers, last {0} days"
 msgstr "Претплатници, последњих {0} дана"
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:245
+#: static/js/impala/stats/csv_keys.js:245 static/js/zamboni/stats-all.js:15526 static/js/zamboni/stats-min.js:5
 msgid "Subscribers from {0} to {1}"
 msgstr "Претплатници од {0} до {1}"
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:249
+#: static/js/impala/stats/csv_keys.js:249 static/js/zamboni/stats-all.js:15530 static/js/zamboni/stats-min.js:5
 msgid "Ratings, last {0} days"
 msgstr "Оцењивања, последњих {0} дана"
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:251
+#: static/js/impala/stats/csv_keys.js:251 static/js/zamboni/stats-all.js:15532 static/js/zamboni/stats-min.js:5
 msgid "Ratings from {0} to {1}"
 msgstr "Оцењивања од {0} до {1}"
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:255
+#: static/js/impala/stats/csv_keys.js:255 static/js/zamboni/stats-all.js:15536 static/js/zamboni/stats-min.js:5
 msgid "Sales, last {0} days"
 msgstr "Продаја, последњих {0} дана"
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:257
+#: static/js/impala/stats/csv_keys.js:257 static/js/zamboni/stats-all.js:15538 static/js/zamboni/stats-min.js:5
 msgid "Sales from {0} to {1}"
 msgstr "Продаја од {0} до {1}"
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:261
+#: static/js/impala/stats/csv_keys.js:261 static/js/zamboni/stats-all.js:15542 static/js/zamboni/stats-min.js:5
 msgid "Installs, last {0} days"
 msgstr "Инсталације, последњих {0} дана"
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:263
+#: static/js/impala/stats/csv_keys.js:263 static/js/zamboni/stats-all.js:15544 static/js/zamboni/stats-min.js:5
 msgid "Installs from {0} to {1}"
 msgstr "Инсталације, од {0} до {1}"
 
 #. L10n: {0} and {1} are integers.
-#: static/js/impala/stats/csv_keys.js:269
+#: static/js/impala/stats/csv_keys.js:269 static/js/zamboni/stats-all.js:15550 static/js/zamboni/stats-min.js:5
 msgid "<b>{0}</b> in last {1} days"
 msgstr "<b>{0}</b> у последњих {1} дана"
 
 #. L10n: {0} is an integer and {1} and {2} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:271 static/js/impala/stats/csv_keys.js:277
+#: static/js/impala/stats/csv_keys.js:271 static/js/impala/stats/csv_keys.js:277 static/js/zamboni/stats-all.js:15552 static/js/zamboni/stats-all.js:15558 static/js/zamboni/stats-min.js:5
 msgid "<b>{0}</b> from {1} to {2}"
 msgstr "<b>{0}</b> од {1} до {2}"
 
 #. L10n: {0} and {1} are integers.
-#: static/js/impala/stats/csv_keys.js:275
+#: static/js/impala/stats/csv_keys.js:275 static/js/zamboni/stats-all.js:15556 static/js/zamboni/stats-min.js:5
 msgid "<b>{0}</b> average in last {1} days"
 msgstr "<b>{0}</b> просечне у последњих {1} дана"
 
-#: static/js/impala/stats/overview.js:19
+#: static/js/impala/stats/overview.js:19 static/js/zamboni/stats-all.js:16469 static/js/zamboni/stats-min.js:5
 msgid "No data available."
 msgstr "Нема доступних података."
 
-#: static/js/impala/stats/table.js:74
+#: static/js/impala/stats/table.js:74 static/js/zamboni/stats-all.js:17209 static/js/zamboni/stats-min.js:5
 msgid "Date"
 msgstr "Датум"
 
-#: static/js/impala/stats/topchart.js:96
+#: static/js/impala/stats/topchart.js:96 static/js/zamboni/stats-all.js:16600 static/js/zamboni/stats-min.js:5
 msgid "Other"
 msgstr "Остали"
 
-#: static/js/zamboni/admin_validation.js:24 static/js/zamboni/devhub.js:1229 static/js/zamboni/editors.js:295
+#: static/js/zamboni/admin-all.js:180 static/js/zamboni/admin-min.js:1 static/js/zamboni/admin_validation.js:24 static/js/zamboni/devhub-all.js:2408 static/js/zamboni/devhub-min.js:2
+#: static/js/zamboni/devhub.js:1229 static/js/zamboni/editors-all.js:15576 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:295
 msgid "Select an application first"
 msgstr "Прво изаберите апликацију"
 
-#: static/js/zamboni/admin_validation.js:51
+#: static/js/zamboni/admin-all.js:207 static/js/zamboni/admin-min.js:1 static/js/zamboni/admin_validation.js:51
 msgid "Set {0} add-on to a max version of {1} and email the author."
 msgid_plural "Set {0} add-ons to a max version of {1} and email the authors."
 msgstr[0] "Подесите {0} додатак на максималну верзију од {1} и пошаљи е-пошту аутору."
 msgstr[1] "Подесите {0} додатака на максималну верзију од {1} и пошаљи е-пошту ауторима."
-msgstr[2] "Подесите {0} додатака на максималну верзију од {1} и пошаљи е-пошту ауторима."
 
-#: static/js/zamboni/admin_validation.js:54
+#: static/js/zamboni/admin-all.js:210 static/js/zamboni/admin-min.js:1 static/js/zamboni/admin_validation.js:54
 msgid "Email author of {2} add-on which failed validation."
 msgid_plural "Email authors of {2} add-ons which failed validation."
 msgstr[0] "Аутор е-поште има {2} додатак који није прошао проверу ваљаности."
 msgstr[1] "Аутор е-поште има {2} додатка који нису прошли проверу ваљаности."
-msgstr[2] "Аутор е-поште има {2} додатка који нису прошли проверу ваљаности."
 
-#. L10n: {0} is an app name like Firefox.
-#: static/js/zamboni/buttons.js:66
-msgid "Accept and Install"
-msgstr "Прихвати и инсталирај"
-
-#: static/js/zamboni/buttons.js:66
-msgid "Add to {0}"
-msgstr "Додај у {0}"
-
-#: static/js/zamboni/buttons.js:71
-msgid "Download Now"
-msgstr "Преузми одмах"
-
-#: static/js/zamboni/buttons.js:112
-msgid "Add-on has not been updated to support default-to-compatible."
-msgstr "Додатак није ажуриран да подржава default-to-compatible."
-
-#: static/js/zamboni/buttons.js:117
-msgid "You need to be using Firefox 10.0 or higher."
-msgstr "Морате користити Firefox 10.0 или новије."
-
-#: static/js/zamboni/buttons.js:129
-msgid "Mozilla has marked this version as incompatible with your Firefox version."
-msgstr "Mozilla је означила ову верзију као некомпатабилну са Вашом верзијом Firefox-а."
-
-#. L10n: {0} is an platform like Windows or Linux.
-#: static/js/zamboni/buttons.js:210
-msgid "Install for {0} anyway"
-msgstr "Инсталирај за {0} у сваком случају"
-
-#: static/js/zamboni/buttons.js:210
-msgid "Download for {0} anyway"
-msgstr "Преузми за {0} у сваком случају"
-
-#: static/js/zamboni/buttons.js:267
-msgid "Not available for your platform"
-msgstr "Није доступно за Вашу платформу"
-
-#. L10n: {0} is an app name, {1} is the app version.
-#: static/js/zamboni/buttons.js:278 static/js/zamboni/buttons.js:315
-msgid "Not available for {0} {1}"
-msgstr "Није доступно за {0} {1}"
-
-#: static/js/zamboni/buttons.js:341
-msgid "Works with {app} {min} - {max}"
-msgstr "Ради са {app} {min} - {max}"
-
-#: static/js/zamboni/buttons.js:343
-msgid "View other versions"
-msgstr "Погледај остале верзије"
-
-#: static/js/zamboni/buttons.js:391
-msgid "Only with Firefox — Get Firefox Now!"
-msgstr ""
-
-#: static/js/zamboni/buttons.js:507 static/js/zamboni/mobile/buttons.js:43
-msgid "Sorry, you need a Mozilla-based browser (such as Firefox) to install a search plugin."
-msgstr "Жао нам је, треба Вам прегледач базиран на технологији Mozilla фондације (као што је Firefox) да бисте инсталирали прикључак за претраживање."
-
-#: static/js/zamboni/collections.js:229
-msgid "Adding to Favorites&hellip;"
-msgstr "Додајем у Омиљено&hellip;"
-
-#: static/js/zamboni/collections.js:232
-msgid "Removing Favorite&hellip;"
-msgstr "Бришем из Омиљених&hellip;"
-
-#: static/js/zamboni/collections.js:235
-msgid "Add to Favorites"
-msgstr "Додај у Омиљене"
-
-#: static/js/zamboni/collections.js:238
-msgid "Remove from Favorites"
-msgstr "Избриши из Омиљених"
-
-#: static/js/zamboni/collections.js:303
-msgid "Pending"
-msgstr "На чекању"
-
-#: static/js/zamboni/collections.js:304
-msgid "Add a comment"
-msgstr "Додај коментар"
-
-#: static/js/zamboni/collections.js:304
-msgid "Comment"
-msgstr "Коментар"
-
-#: static/js/zamboni/collections.js:305
-msgid "Remove this add-on from the collection"
-msgstr "Избриши овај додатак из колекције"
-
-#: static/js/zamboni/collections.js:305 static/js/zamboni/collections.js:334
-msgid "Remove"
-msgstr "Избриши"
-
-#: static/js/zamboni/collections.js:334
-msgid "Remove this user as a contributor"
-msgstr "Уклони корисника као сарадника"
-
-#: static/js/zamboni/collections.js:346
-msgid "An email address is required."
-msgstr "Адреса е-поште је обавезна."
-
-#: static/js/zamboni/collections.js:364
-msgid "You cannot add yourself as a contributor."
-msgstr "Не можете себе додати као сарадника."
-
-#: static/js/zamboni/collections.js:366
-msgid "You have already added that user."
-msgstr "Већ сте додали тог корисника."
-
-#: static/js/zamboni/collections.js:573
-msgid "Add to favorites"
-msgstr "Додај у омиљене"
-
-#: static/js/zamboni/collections.js:577
-msgid "Remove from favorites"
-msgstr "Избриши из омиљених"
-
-#: static/js/zamboni/collections.js:604
-msgid "Stop following"
-msgstr "Прекини праћење"
-
-#: static/js/zamboni/devhub.js:110
+#: static/js/zamboni/devhub-all.js:1289 static/js/zamboni/devhub-min.js:1 static/js/zamboni/devhub.js:110
 msgid "Your browser does not support the video tag"
 msgstr "Ваш прегледач не подржава ознаке видео снимака"
 
-#: static/js/zamboni/devhub.js:371
+#: static/js/zamboni/devhub-all.js:1550 static/js/zamboni/devhub-min.js:1 static/js/zamboni/devhub.js:371
 msgid "Changes Saved"
 msgstr "Измене сачуване"
 
-#: static/js/zamboni/devhub.js:387
+#: static/js/zamboni/devhub-all.js:1566 static/js/zamboni/devhub-min.js:1 static/js/zamboni/devhub.js:387
 msgid "Enter a new author's email address"
 msgstr "Унесите адресу е-поште новог аутора"
 
-#: static/js/zamboni/devhub.js:536
+#: static/js/zamboni/devhub-all.js:1715 static/js/zamboni/devhub-min.js:1 static/js/zamboni/devhub.js:536
 msgid "There was an error uploading your file."
 msgstr "Дошло је до грешке приликом отпремања Ваше датотеке."
 
-#: static/js/zamboni/devhub.js:681
+#: static/js/zamboni/devhub-all.js:1860 static/js/zamboni/devhub-min.js:1 static/js/zamboni/devhub.js:681
 msgid "{files} file"
 msgid_plural "{files} files"
 msgstr[0] "{files} датотека"
 msgstr[1] "{files} датотеке"
-msgstr[2] "{files} датотека"
 
-#: static/js/zamboni/devhub.js:684
+#: static/js/zamboni/devhub-all.js:1863 static/js/zamboni/devhub-min.js:1 static/js/zamboni/devhub.js:684
 msgid "{reviews} user review"
 msgid_plural "{reviews} user reviews"
 msgstr[0] "{reviews} корисничка рецензија"
 msgstr[1] "{reviews} корисничке рецензије"
-msgstr[2] "{reviews} корисничких рецензија"
 
-#: static/js/zamboni/devhub.js:796
+#: static/js/zamboni/devhub-all.js:1975 static/js/zamboni/devhub-min.js:2 static/js/zamboni/devhub.js:796
 msgid "Learn more"
 msgstr "Сазнајте више"
 
-#: static/js/zamboni/devhub.js:800
+#: static/js/zamboni/devhub-all.js:1979 static/js/zamboni/devhub-min.js:2 static/js/zamboni/devhub.js:800
 msgid "Example"
 msgstr "Пример"
 
-#: static/js/zamboni/devhub.js:1130
+#: static/js/zamboni/devhub-all.js:2309 static/js/zamboni/devhub-min.js:2 static/js/zamboni/devhub.js:1130
 msgid "Image changes being processed"
 msgstr "Измене на слици се обрађују"
 
-#: static/js/zamboni/devhub.js:1280
+#: static/js/zamboni/devhub-all.js:2459 static/js/zamboni/devhub-min.js:2 static/js/zamboni/devhub.js:1280
 msgid "Must be a valid e-mail address."
 msgstr "Адреса е-поште мора бити исправна."
+
+#: static/js/zamboni/devhub-all.js:2613 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:80
+msgid "All tests passed successfully."
+msgstr "Сви тестови су успешно завршени."
+
+#: static/js/zamboni/devhub-all.js:2616 static/js/zamboni/devhub-all.js:3011 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:83 static/js/zamboni/validator.js:478
+msgid "These tests were not run."
+msgstr "Ови тестови нису извршени."
+
+#: static/js/zamboni/devhub-all.js:2664 static/js/zamboni/devhub-all.js:2677 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:131 static/js/zamboni/validator.js:144
+msgid "Tests"
+msgstr "Тестови"
+
+#: static/js/zamboni/devhub-all.js:2779 static/js/zamboni/devhub-all.js:3108 static/js/zamboni/devhub-all.js:3127 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:246
+#: static/js/zamboni/validator.js:575 static/js/zamboni/validator.js:594
+msgid "Error"
+msgstr "Грешка"
+
+#: static/js/zamboni/devhub-all.js:2780 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:247
+msgid "Warning"
+msgstr "Упозорење"
+
+#: static/js/zamboni/devhub-all.js:2794 static/js/zamboni/devhub-min.js:2 static/js/zamboni/files-all.js:5657 static/js/zamboni/files-min.js:3 static/js/zamboni/files.js:411
+#: static/js/zamboni/validator.js:261
+msgid "Ignore this message in future updates"
+msgstr ""
+
+#: static/js/zamboni/devhub-all.js:2817 static/js/zamboni/devhub-min.js:2 static/js/zamboni/files-all.js:5663 static/js/zamboni/files-min.js:3 static/js/zamboni/files.js:417
+#: static/js/zamboni/validator.js:284
+msgid "Severity for automated signing:"
+msgstr ""
+
+#: static/js/zamboni/devhub-all.js:2832 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:299
+msgid "Suggestions for passing automated signing:"
+msgstr ""
+
+#: static/js/zamboni/devhub-all.js:2920 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:387
+msgid "Compatibility Tests"
+msgstr "Тестови компатибилности"
+
+#: static/js/zamboni/devhub-all.js:2999 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:466
+msgid "Add-on failed validation."
+msgstr "Додатак није прошао проверу."
+
+#: static/js/zamboni/devhub-all.js:3001 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:468
+msgid "Add-on passed validation."
+msgstr "Додатак је прошао проверу."
+
+#: static/js/zamboni/devhub-all.js:3014 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:481
+msgid "{0} error"
+msgid_plural "{0} errors"
+msgstr[0] "{0} грешка"
+msgstr[1] "{0} грешке"
+
+#: static/js/zamboni/devhub-all.js:3016 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:483
+msgid "{0} warning"
+msgid_plural "{0} warnings"
+msgstr[0] "{0} упозорење"
+msgstr[1] "{0} упозорења"
+
+#: static/js/zamboni/devhub-all.js:3018 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:485
+msgid "{0} notice"
+msgid_plural "{0} notices"
+msgstr[0] "{0} обавештење"
+msgstr[1] "{0} обавештења"
+
+#: static/js/zamboni/devhub-all.js:3110 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:577
+msgid "Validation task could not complete or completed with errors"
+msgstr "Задатак провере није могао бити завршен или је завршен са грешкама"
+
+#: static/js/zamboni/devhub-all.js:3128 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:595
+msgid "Internal server error"
+msgstr "Грешка на серверу"
 
 #: static/js/zamboni/devhub_search.js:8
 msgid "No results found."
 msgstr "Нема резултата."
 
-#: static/js/zamboni/editors.js:121
+#: static/js/zamboni/editors-all.js:15402 static/js/zamboni/editors-min.js:4 static/js/zamboni/editors.js:121
 msgid "{name} was viewing this page first."
 msgstr "{name} је први гледао ову страницу."
 
-#: static/js/zamboni/editors.js:171
+#: static/js/zamboni/editors-all.js:15452 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:171
 msgid "Receipt checked by app."
 msgstr "Потврда проверена од стране апликације."
 
-#: static/js/zamboni/editors.js:173
+#: static/js/zamboni/editors-all.js:15454 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:173
 msgid "Receipt was not checked by app."
 msgstr "Потврда није проверена од стране апликације."
 
-#: static/js/zamboni/editors.js:244
+#: static/js/zamboni/editors-all.js:15525 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:244
 msgid "{name} was viewing this add-on first."
 msgstr "{name} је први прегледавао овај додатак."
 
-#: static/js/zamboni/editors.js:255
+#: static/js/zamboni/editors-all.js:15536 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:255
 msgid "Loading&hellip;"
 msgstr "Учитавам&hellip;"
 
-#: static/js/zamboni/editors.js:260
+#: static/js/zamboni/editors-all.js:15541 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:260
 msgid "Version Notes"
 msgstr "Белешке о верзији"
 
-#: static/js/zamboni/editors.js:265
+#: static/js/zamboni/editors-all.js:15546 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:265
 msgid "Notes for Reviewers"
 msgstr "Белешке за рецензенте"
 
-#: static/js/zamboni/editors.js:270
+#: static/js/zamboni/editors-all.js:15551 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:270
 msgid "No version notes found"
 msgstr "Није нађена ни једна белешка о верзији"
 
-#: static/js/zamboni/editors.js:330
+#: static/js/zamboni/editors-all.js:15611 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:330
 msgid "Average Reviews"
 msgstr ""
 
-#: static/js/zamboni/editors.js:386
+#: static/js/zamboni/editors-all.js:15667 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:386
 msgid "Number of Reviews"
 msgstr ""
 
-#: static/js/zamboni/editors.js:445
+#: static/js/zamboni/editors-all.js:15726 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:445
 msgid "Error loading translation"
 msgstr "Грешка при учитавању превода"
 
-#: static/js/zamboni/files.js:411 static/js/zamboni/validator.js:261
-msgid "Ignore this message in future updates"
-msgstr ""
-
-#: static/js/zamboni/files.js:417 static/js/zamboni/validator.js:284
-msgid "Severity for automated signing:"
-msgstr ""
-
-#: static/js/zamboni/global.js:410
-msgid "Loading..."
-msgstr "Учитавање..."
-
-#. L10n: {0} is the number of characters left.
-#: static/js/zamboni/global.js:474
-msgid "<b>{0}</b> character left."
-msgid_plural "<b>{0}</b> characters left."
-msgstr[0] "<b>{0}</b> карактер преостао."
-msgstr[1] "<b>{0}</b> карактера преостала."
-msgstr[2] "<b>{0}</b> карактера преостало."
-
-#: static/js/zamboni/init.js:28
-msgid "This feature is temporarily disabled while we perform website maintenance. Please check back a little later."
-msgstr "Ова могућност је привремено онемогућена док обављамо задатак одржавања сајта. Молимо пробајте мало касније."
-
-#: static/js/zamboni/l10n.js:45
-msgid "Remove this localization"
-msgstr "Уклони ову локализацију"
-
-#: static/js/zamboni/password-strength.js:20
-msgid "Password strength:"
-msgstr "Јачина лозинке:"
-
-#: static/js/zamboni/password-strength.js:26
-msgid "At least {0} character left."
-msgid_plural "At least {0} characters left."
-msgstr[0] "Остао је још најмање {0} каратер."
-msgstr[1] "Остало је још најмање {0} каратера."
-msgstr[2] "Остало је још најмање {0} каратера."
-
-#: static/js/zamboni/themes_review.js:176
-msgid "Requested Info"
-msgstr "Захтеване информације"
-
-#: static/js/zamboni/themes_review.js:177
-msgid "Flagged"
-msgstr "Означено"
-
-#: static/js/zamboni/themes_review.js:178
-msgid "Duplicate"
-msgstr "Дупликат"
-
-#: static/js/zamboni/themes_review.js:179
-msgid "Rejected"
-msgstr "Одбијено"
-
-#: static/js/zamboni/themes_review.js:180
-msgid "Approved"
-msgstr "Одобрено"
-
-#: static/js/zamboni/themes_review.js:424
-msgid "No results found"
-msgstr ""
-
-#: static/js/zamboni/themes_review_templates.js:31
+#: static/js/zamboni/editors-all.js:15975 static/js/zamboni/editors-min.js:5 static/js/zamboni/themes_review_templates.js:31
 msgid "Theme"
 msgstr ""
 
-#: static/js/zamboni/themes_review_templates.js:33
+#: static/js/zamboni/editors-all.js:15977 static/js/zamboni/editors-min.js:5 static/js/zamboni/themes_review_templates.js:33
 msgid "Reviewer"
 msgstr ""
 
-#: static/js/zamboni/themes_review_templates.js:35
+#: static/js/zamboni/editors-all.js:15979 static/js/zamboni/editors-min.js:5 static/js/zamboni/themes_review_templates.js:35
 msgid "Status"
 msgstr ""
 
-#: static/js/zamboni/validator.js:80
-msgid "All tests passed successfully."
-msgstr "Сви тестови су успешно завршени."
+#: static/js/zamboni/editors-all.js:16196 static/js/zamboni/editors-min.js:5 static/js/zamboni/themes_review.js:176
+msgid "Requested Info"
+msgstr "Захтеване информације"
 
-#: static/js/zamboni/validator.js:83 static/js/zamboni/validator.js:478
-msgid "These tests were not run."
-msgstr "Ови тестови нису извршени."
+#: static/js/zamboni/editors-all.js:16197 static/js/zamboni/editors-min.js:5 static/js/zamboni/themes_review.js:177
+msgid "Flagged"
+msgstr "Означено"
 
-#: static/js/zamboni/validator.js:131 static/js/zamboni/validator.js:144
-msgid "Tests"
-msgstr "Тестови"
+#: static/js/zamboni/editors-all.js:16198 static/js/zamboni/editors-min.js:5 static/js/zamboni/themes_review.js:178
+msgid "Duplicate"
+msgstr "Дупликат"
 
-#: static/js/zamboni/validator.js:246 static/js/zamboni/validator.js:575 static/js/zamboni/validator.js:594
-msgid "Error"
-msgstr "Грешка"
+#: static/js/zamboni/editors-all.js:16199 static/js/zamboni/editors-min.js:5 static/js/zamboni/themes_review.js:179
+msgid "Rejected"
+msgstr "Одбијено"
 
-#: static/js/zamboni/validator.js:247
-msgid "Warning"
-msgstr "Упозорење"
+#: static/js/zamboni/editors-all.js:16200 static/js/zamboni/editors-min.js:5 static/js/zamboni/themes_review.js:180
+msgid "Approved"
+msgstr "Одобрено"
 
-#: static/js/zamboni/validator.js:299
-msgid "Suggestions for passing automated signing:"
+#: static/js/zamboni/editors-all.js:16444 static/js/zamboni/editors-min.js:5 static/js/zamboni/themes_review.js:424
+msgid "No results found"
 msgstr ""
 
-#: static/js/zamboni/validator.js:387
-msgid "Compatibility Tests"
-msgstr "Тестови компатибилности"
-
-#: static/js/zamboni/validator.js:466
-msgid "Add-on failed validation."
-msgstr "Додатак није прошао проверу."
-
-#: static/js/zamboni/validator.js:468
-msgid "Add-on passed validation."
-msgstr "Додатак је прошао проверу."
-
-#: static/js/zamboni/validator.js:481
-msgid "{0} error"
-msgid_plural "{0} errors"
-msgstr[0] "{0} грешка"
-msgstr[1] "{0} грешке"
-msgstr[2] "{0} грешака"
-
-#: static/js/zamboni/validator.js:483
-msgid "{0} warning"
-msgid_plural "{0} warnings"
-msgstr[0] "{0} упозорење"
-msgstr[1] "{0} упозорења"
-msgstr[2] "{0} упозорења"
-
-#: static/js/zamboni/validator.js:485
-msgid "{0} notice"
-msgid_plural "{0} notices"
-msgstr[0] "{0} обавештење"
-msgstr[1] "{0} обавештења"
-msgstr[2] "{0} обавештења"
-
-#: static/js/zamboni/validator.js:577
-msgid "Validation task could not complete or completed with errors"
-msgstr "Задатак провере није могао бити завршен или је завршен са грешкама"
-
-#: static/js/zamboni/validator.js:595
-msgid "Internal server error"
-msgstr "Грешка на серверу"
-
-#: static/js/zamboni/mobile/buttons.js:52
+#: static/js/zamboni/mobile-all.js:15186 static/js/zamboni/mobile/buttons.js:52
 msgid "Not Updated for {0} {1}"
 msgstr "Није ажурирано за {0} {1}"
 
-#: static/js/zamboni/mobile/buttons.js:53
+#: static/js/zamboni/mobile-all.js:15187 static/js/zamboni/mobile/buttons.js:53
 msgid "Requires Newer Version of {0}"
 msgstr "Захтева верзију новију од {0}"
 
-#: static/js/zamboni/mobile/buttons.js:54
+#: static/js/zamboni/mobile-all.js:15188 static/js/zamboni/mobile/buttons.js:54
 msgid "Unreviewed"
 msgstr "Неоцењено"
 
-#: static/js/zamboni/mobile/buttons.js:55
+#: static/js/zamboni/mobile-all.js:15189 static/js/zamboni/mobile/buttons.js:55
 msgid "Experimental <span>(Learn More)</span>"
 msgstr "Експериментално <span>(Сазнај више)</span>"
 
-#: static/js/zamboni/mobile/buttons.js:56 static/js/zamboni/mobile/buttons.js:57
+#: static/js/zamboni/mobile-all.js:15190 static/js/zamboni/mobile-all.js:15191 static/js/zamboni/mobile/buttons.js:56 static/js/zamboni/mobile/buttons.js:57
 msgid "Not Available for {0}"
 msgstr "Није доступно за {0}"
 
-#: static/js/zamboni/mobile/buttons.js:58
+#: static/js/zamboni/mobile-all.js:15192 static/js/zamboni/mobile/buttons.js:58
 msgid "Experimental"
 msgstr "Експериментално"
 
-#: static/js/zamboni/mobile/buttons.js:59
+#: static/js/zamboni/mobile-all.js:15193 static/js/zamboni/mobile/buttons.js:59
 msgid "Themes Require Newer Version of {0}"
 msgstr "Теме захтевају новију верзију од {0}"
 
-#: static/js/zamboni/mobile/buttons.js:60
+#: static/js/zamboni/mobile-all.js:15194 static/js/zamboni/mobile/buttons.js:60
 msgid "Themes Require {0}"
 msgstr "Теме захтевају {0}"
 
-#: static/js/zamboni/mobile/buttons.js:105
+#: static/js/zamboni/mobile-all.js:15239 static/js/zamboni/mobile/buttons.js:105
 msgid "Installing..."
 msgstr "Инсталирам..."
 
-#: static/js/zamboni/mobile/buttons.js:125
+#: static/js/zamboni/mobile-all.js:15259 static/js/zamboni/mobile/buttons.js:125
 msgid "This add-on has been preliminarily reviewed by Mozilla."
 msgstr "Овај додатак је прелиминарно прегледан од Mozilla-е."
 
-#: static/js/zamboni/mobile/buttons.js:250
+#: static/js/zamboni/mobile-all.js:15384 static/js/zamboni/mobile/buttons.js:250
 msgid "Keep it"
 msgstr "Задржи"
 
-#: static/js/zamboni/mobile/general.js:344
+#: static/js/zamboni/mobile-all.js:16049 static/js/zamboni/mobile-min.js:6 static/js/zamboni/mobile/general.js:344
 msgid "You're trying it on!"
 msgstr "Испробавате је!"
 
-#: static/js/zamboni/mobile/general.js:356
+#: static/js/zamboni/mobile-all.js:16061 static/js/zamboni/mobile-min.js:6 static/js/zamboni/mobile/general.js:356
 msgid "Added to Firefox"
 msgstr "Додато у Firefox"
-

--- a/locale/sr_Latn/LC_MESSAGES/django.po
+++ b/locale/sr_Latn/LC_MESSAGES/django.po
@@ -5,7 +5,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version:  addons\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2016-02-24 21:23+0000\n"
+"POT-Creation-Date: 2016-04-18 15:40+0000\n"
 "PO-Revision-Date: 2015-02-07 12:40+0000\n"
 "Last-Translator: Vanja <tumbas93@gmail.com>\n"
 "Language-Team: sr\n"
@@ -14,60 +14,60 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Generated-By: Babel 2.2.0\n"
 
-#: src/olympia/accounts/views.py:52
+#: src/olympia/accounts/views.py:54
 msgid "Your log in attempt could not be parsed. Please try again."
 msgstr ""
 
-#: src/olympia/accounts/views.py:54
+#: src/olympia/accounts/views.py:56
 msgid "Your Firefox Account could not be found. Please try again."
 msgstr ""
 
-#: src/olympia/accounts/views.py:55
+#: src/olympia/accounts/views.py:57
 msgid "You could not be logged in. Please try again."
 msgstr ""
 
-#: src/olympia/accounts/views.py:57
+#: src/olympia/accounts/views.py:59
 msgid "Your account has already been migrated to Firefox Accounts."
 msgstr ""
 
-#: src/olympia/accounts/views.py:59
+#: src/olympia/accounts/views.py:61
 msgid "Your Firefox Account already exists on this site."
 msgstr ""
 
-#: src/olympia/accounts/views.py:108
+#: src/olympia/accounts/views.py:110
 msgid "Great job!"
 msgstr ""
 
-#: src/olympia/accounts/views.py:109
+#: src/olympia/accounts/views.py:111
 msgid "You can now log in to Add-ons with your Firefox Account."
 msgstr ""
 
-#: src/olympia/accounts/views.py:121
+#: src/olympia/accounts/views.py:123
 msgid "Need help?"
 msgstr ""
 
-#: src/olympia/addons/buttons.py:180
+#: src/olympia/addons/buttons.py:177
 msgid "Download Now"
 msgstr "Preuzmi odmah"
 
-#: src/olympia/addons/buttons.py:182
+#: src/olympia/addons/buttons.py:179
 msgid "Download"
 msgstr "Preuzmi"
 
 #. L10n: please keep &nbsp; in the string so &rarr; does not wrap.
-#: src/olympia/addons/buttons.py:186
+#: src/olympia/addons/buttons.py:183
 msgid "Continue to Download&nbsp;&rarr;"
 msgstr "Nastavite do preuzimanja&nbsp;&rarr;"
 
-#: src/olympia/addons/buttons.py:202 src/olympia/addons/helpers.py:35 src/olympia/addons/views.py:319 src/olympia/addons/templates/addons/impala/details.html:114
+#: src/olympia/addons/buttons.py:199 src/olympia/addons/helpers.py:35 src/olympia/addons/views.py:333 src/olympia/addons/templates/addons/impala/details.html:111
 #: src/olympia/addons/templates/addons/impala/listing/items.html:17 src/olympia/addons/templates/addons/mobile/home.html:40 src/olympia/amo/templates/amo/side_nav.html:6
-#: src/olympia/amo/templates/amo/side_nav.html:10 src/olympia/amo/templates/amo/site_nav.html:2 src/olympia/amo/templates/amo/site_nav.html:55 src/olympia/bandwagon/views.py:95
-#: src/olympia/browse/views.py:54 src/olympia/browse/views.py:68 src/olympia/browse/views.py:235 src/olympia/browse/templates/browse/impala/category_landing.html:22
+#: src/olympia/amo/templates/amo/side_nav.html:10 src/olympia/amo/templates/amo/site_nav.html:2 src/olympia/amo/templates/amo/site_nav.html:53 src/olympia/bandwagon/views.py:95
+#: src/olympia/browse/views.py:54 src/olympia/browse/views.py:68 src/olympia/browse/views.py:202 src/olympia/browse/templates/browse/impala/category_landing.html:22
 #: src/olympia/browse/templates/browse/personas/mobile/category_landing.html:26
 msgid "Featured"
 msgstr "Izdvojeno"
 
-#: src/olympia/addons/buttons.py:221
+#: src/olympia/addons/buttons.py:218
 msgid "Add to {0}"
 msgstr "Dodaj u {0}"
 
@@ -90,7 +90,6 @@ msgid "Invalid tag: {0}"
 msgid_plural "Invalid tags: {0}"
 msgstr[0] "Neispravna oznaka: {0}"
 msgstr[1] "Neispravne oznake: {0}"
-msgstr[2] "Neispravne oznake: {0}"
 
 #. L10n: {0} is a single tag or a comma-separated list of tags.
 #: src/olympia/addons/forms.py:103
@@ -98,14 +97,12 @@ msgid "\"{0}\" is a reserved tag and cannot be used."
 msgid_plural "\"{0}\" are reserved tags and cannot be used."
 msgstr[0] "\"{0}\" je rezervisana oznaka koja se ne može koristiti."
 msgstr[1] "\"{0}\" su rezervisane oznake koje se ne mogu koristiti."
-msgstr[2] "\"{0}\" su rezervisane oznake koje se ne mogu koristiti."
 
 #: src/olympia/addons/forms.py:111
 msgid "You have {0} too many tags."
 msgid_plural "You have {0} too many tags."
 msgstr[0] "Imate {0} previše oznaka."
 msgstr[1] "Imate {0} previše oznaka."
-msgstr[2] "Imate {0} previše oznaka."
 
 #: src/olympia/addons/forms.py:117
 #, python-format
@@ -117,42 +114,40 @@ msgid "All tags must be at least {0} character."
 msgid_plural "All tags must be at least {0} characters."
 msgstr[0] "Sve oznake moraju sadržati najmanje {0} karakter."
 msgstr[1] "Sve oznake moraju sadržati najmanje {0} karaktera."
-msgstr[2] "Sve oznake moraju sadržati najmanje {0} karaktera."
 
-#: src/olympia/addons/forms.py:234
+#: src/olympia/addons/forms.py:238
 msgid "Categories cannot be changed while your add-on is featured for this application."
 msgstr "Kategorije se ne mogu izmeniti dok je Vaš dodatak izdvojen za ovu aplikaciju."
 
 #. L10n: {0} is the number of categories.
-#: src/olympia/addons/forms.py:238
+#: src/olympia/addons/forms.py:242
 msgid "You can have only {0} category."
 msgid_plural "You can have only {0} categories."
 msgstr[0] "Možete imati samo {0} kategoriju."
 msgstr[1] "Možete imati samo {0} kategorije."
-msgstr[2] "Možete imati samo {0} kategorija."
 
-#: src/olympia/addons/forms.py:246
+#: src/olympia/addons/forms.py:250
 msgid "The miscellaneous category cannot be combined with additional categories."
 msgstr "Kategorija Ostalo se ne može spojiti sa dodatnim kategorijama."
 
-#: src/olympia/addons/forms.py:369
+#: src/olympia/addons/forms.py:374
 #, python-format
 msgid "Before changing your default locale you must have a name, summary, and description in that locale. You are missing %s."
 msgstr "Pre nego što izmenite podrazumevani prostor, morate imati ime, kratak pregled i opis u tom prostoru. Nedostaje Vam %s."
 
-#: src/olympia/addons/forms.py:484 src/olympia/addons/forms.py:575
+#: src/olympia/addons/forms.py:455 src/olympia/addons/forms.py:546
 msgid "A license must be selected."
 msgstr "Licenca mora biti izabrana."
 
-#: src/olympia/addons/forms.py:556
+#: src/olympia/addons/forms.py:527
 msgid "Give Your Theme a Name."
 msgstr "Dajte ime Vašoj temi."
 
-#: src/olympia/addons/forms.py:562 src/olympia/devhub/templates/devhub/personas/submit.html:53
+#: src/olympia/addons/forms.py:533 src/olympia/devhub/templates/devhub/personas/submit.html:53
 msgid "Describe your Theme."
 msgstr "Opišite Vašu temu."
 
-#: src/olympia/addons/forms.py:704
+#: src/olympia/addons/forms.py:675
 msgid "Enter a new author's email address"
 msgstr "Dodajte adresu e-pošte novog autora"
 
@@ -160,39 +155,39 @@ msgstr "Dodajte adresu e-pošte novog autora"
 msgid "Not Reviewed"
 msgstr "Nije ocenjeno"
 
-#: src/olympia/addons/models.py:301
+#: src/olympia/addons/models.py:298
 msgid "Users have the option of contributing more or less than this amount."
 msgstr "Korisnici imaju opciju da doprinose više ili manje od ove količine."
 
-#: src/olympia/addons/models.py:309
-msgid "Users will always be asked in the Add-ons Manager (Firefox 4 and above)"
-msgstr "Korisnici će uvek biti pitani u medžeru za dodatke (Firefox 4 i novije)"
+#: src/olympia/addons/models.py:306
+msgid "Users will always be asked in the Add-ons Manager (Firefox 4 and above). Only applies to desktop."
+msgstr ""
 
 # Column name in a table.
-#: src/olympia/addons/models.py:1804 src/olympia/addons/templates/addons/details_box.html:55 src/olympia/devhub/templates/devhub/index.html:92
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:102
+#: src/olympia/addons/models.py:1802 src/olympia/addons/templates/addons/details_box.html:55 src/olympia/devhub/templates/devhub/index.html:92
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:89
 msgid "Listed"
 msgstr "Navedene"
 
-#: src/olympia/addons/views.py:320 src/olympia/browse/templates/browse/personas/mobile/category_landing.html:27
+#: src/olympia/addons/views.py:334 src/olympia/browse/templates/browse/personas/mobile/category_landing.html:27
 msgid "Popular"
 msgstr "Popularno"
 
-#: src/olympia/addons/views.py:321 src/olympia/browse/views.py:238 src/olympia/browse/views.py:280 src/olympia/browse/views.py:482
+#: src/olympia/addons/views.py:335 src/olympia/browse/views.py:205 src/olympia/browse/views.py:247 src/olympia/browse/views.py:449
 msgid "Recently Added"
 msgstr "Nedavno dodato"
 
-#: src/olympia/addons/views.py:322 src/olympia/bandwagon/views.py:99 src/olympia/browse/views.py:60 src/olympia/browse/views.py:71 src/olympia/search/forms.py:16 src/olympia/search/forms.py:91
+#: src/olympia/addons/views.py:336 src/olympia/bandwagon/views.py:99 src/olympia/browse/views.py:60 src/olympia/browse/views.py:71 src/olympia/search/forms.py:16 src/olympia/search/forms.py:91
 msgid "Recently Updated"
 msgstr "Nedavno ažurirano"
 
 # %1 is an add-on name.
 #. l10n: {0} is the addon name
-#: src/olympia/addons/views.py:520
+#: src/olympia/addons/views.py:534
 msgid "Contribution for {0}"
 msgstr "Doprinosi za {0}"
 
-#: src/olympia/addons/views.py:613
+#: src/olympia/addons/views.py:627
 msgid "Abuse reported."
 msgstr "Zlostavljanje je prijavljeno."
 
@@ -261,9 +256,9 @@ msgstr "Priloži"
 #: src/olympia/devhub/templates/devhub/addons/ajax_compat_update.html:36 src/olympia/devhub/templates/devhub/addons/profile.html:44 src/olympia/devhub/templates/devhub/addons/edit/admin.html:101
 #: src/olympia/devhub/templates/devhub/addons/edit/basic.html:152 src/olympia/devhub/templates/devhub/addons/edit/details.html:85 src/olympia/devhub/templates/devhub/addons/edit/support.html:67
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:166 src/olympia/devhub/templates/devhub/addons/forms_shared/media.html:149
-#: src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:44 src/olympia/devhub/templates/devhub/versions/add_file_modal.html:78 src/olympia/devhub/templates/devhub/versions/edit.html:139
-#: src/olympia/devhub/templates/devhub/versions/list.html:242 src/olympia/devhub/templates/devhub/versions/list.html:276 src/olympia/devhub/templates/devhub/versions/list.html:317
-#: src/olympia/devhub/templates/devhub/versions/list.html:351 src/olympia/reviews/templates/reviews/edit_review.html:16 src/olympia/translations/templates/translations/trans-menu.html:50
+#: src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:43 src/olympia/devhub/templates/devhub/versions/add_file_modal.html:58 src/olympia/devhub/templates/devhub/versions/edit.html:139
+#: src/olympia/devhub/templates/devhub/versions/list.html:239 src/olympia/devhub/templates/devhub/versions/list.html:281 src/olympia/devhub/templates/devhub/versions/list.html:315
+#: src/olympia/devhub/templates/devhub/versions/list.html:349 src/olympia/reviews/templates/reviews/edit_review.html:16 src/olympia/translations/templates/translations/trans-menu.html:50
 #: src/olympia/translations/templates/translations/trans-menu.html:62
 msgid "or"
 msgstr "ili"
@@ -375,7 +370,7 @@ msgid "Add-on Information for {0}"
 msgstr "Informacije o {0} dodatku"
 
 #: src/olympia/addons/templates/addons/details_box.html:30 src/olympia/addons/templates/addons/persona_detail_table.html:3 src/olympia/addons/templates/addons/mobile/details.html:63
-#: src/olympia/addons/templates/addons/mobile/persona_detail_table.html:7 src/olympia/browse/views.py:459 src/olympia/devhub/views.py:75
+#: src/olympia/addons/templates/addons/mobile/persona_detail_table.html:7 src/olympia/browse/views.py:426 src/olympia/devhub/views.py:74
 msgid "Updated"
 msgstr "Ažurirano"
 
@@ -394,11 +389,11 @@ msgstr "Radi sa"
 msgid "Visibility"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/details_box.html:57 src/olympia/devhub/templates/devhub/index.html:94 src/olympia/devhub/templates/devhub/includes/addon_details.html:104
+#: src/olympia/addons/templates/addons/details_box.html:57 src/olympia/devhub/templates/devhub/index.html:94 src/olympia/devhub/templates/devhub/includes/addon_details.html:91
 msgid "Hidden"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/details_box.html:59 src/olympia/devhub/templates/devhub/index.html:96 src/olympia/devhub/templates/devhub/includes/addon_details.html:106
+#: src/olympia/addons/templates/addons/details_box.html:59 src/olympia/devhub/templates/devhub/index.html:96 src/olympia/devhub/templates/devhub/includes/addon_details.html:93
 msgid "Unlisted"
 msgstr ""
 
@@ -406,13 +401,13 @@ msgstr ""
 msgid "Required Add-ons"
 msgstr "Neophodni dodaci"
 
-#: src/olympia/addons/templates/addons/details_box.html:81 src/olympia/addons/templates/addons/persona_detail_table.html:15 src/olympia/browse/views.py:462 src/olympia/devhub/views.py:78
-#: src/olympia/devhub/views.py:85 src/olympia/discovery/templates/discovery/addons/detail.html:57 src/olympia/reviews/forms.py:62 src/olympia/reviews/templates/reviews/add.html:57
+#: src/olympia/addons/templates/addons/details_box.html:81 src/olympia/addons/templates/addons/persona_detail_table.html:15 src/olympia/browse/views.py:429 src/olympia/devhub/views.py:77
+#: src/olympia/devhub/views.py:84 src/olympia/discovery/templates/discovery/addons/detail.html:57 src/olympia/reviews/forms.py:62 src/olympia/reviews/templates/reviews/add.html:57
 #: src/olympia/reviews/templates/reviews/mobile/review_list.html:18
 msgid "Rating"
 msgstr "Ocene"
 
-#: src/olympia/addons/templates/addons/details_box.html:85 src/olympia/browse/views.py:461 src/olympia/devhub/views.py:77 src/olympia/devhub/views.py:84
+#: src/olympia/addons/templates/addons/details_box.html:85 src/olympia/browse/views.py:428 src/olympia/devhub/views.py:76 src/olympia/devhub/views.py:83
 #: src/olympia/stats/templates/stats/addon_report_menu.html:8 src/olympia/stats/templates/stats/collection_report_menu.html:18
 msgid "Downloads"
 msgstr "Preuzimanja"
@@ -432,7 +427,7 @@ msgstr "Izveštaji o zloupotrebi"
 
 #. The Privacy Policy for this add-on.
 #: src/olympia/addons/templates/addons/details_box.html:121 src/olympia/addons/templates/addons/privacy.html:19 src/olympia/addons/templates/addons/privacy.html:23
-#: src/olympia/addons/templates/addons/impala/button.html:43 src/olympia/addons/templates/addons/impala/details.html:307 src/olympia/devhub/templates/devhub/includes/policy_form.html:20
+#: src/olympia/addons/templates/addons/impala/button.html:43 src/olympia/addons/templates/addons/impala/details.html:312 src/olympia/devhub/templates/devhub/includes/policy_form.html:23
 #: src/olympia/templates/mobile/base_addons.html:87
 msgid "Privacy Policy"
 msgstr "Polisa privatnosti"
@@ -457,7 +452,7 @@ msgstr "Galerija slika"
 msgid "Developer Comments"
 msgstr "Komentari autora"
 
-#: src/olympia/addons/templates/addons/details_box.html:199 src/olympia/addons/templates/addons/impala/details.html:259
+#: src/olympia/addons/templates/addons/details_box.html:199 src/olympia/addons/templates/addons/impala/details.html:264
 msgid "Development Channel"
 msgstr "Kanal za programere"
 
@@ -481,7 +476,7 @@ msgstr ""
 "<strong>Oprez:</strong> Razvojna verzija ovog dodatka nije pregledana od strane Mozilla fondacije. Kada isntalirate razvojnu verziju, nastavićete da dobijate razvojne nadogradnje od ovog "
 "programera. Da biste zaustavili primanje razvojnih nadogradnji, ponovo instalirajte razvojnu verziju sa gore navedene veze."
 
-#: src/olympia/addons/templates/addons/details_box.html:220 src/olympia/addons/templates/addons/impala/details.html:278
+#: src/olympia/addons/templates/addons/details_box.html:220 src/olympia/addons/templates/addons/impala/details.html:283
 msgid "Version {0}:"
 msgstr "Verzija {0}:"
 
@@ -500,7 +495,7 @@ msgid "End-User License Agreement for {0}"
 msgstr "Ugovor o licenci softvera za krajnjeg korisnika (EULA) za {0}"
 
 #: src/olympia/addons/templates/addons/eula.html:17 src/olympia/addons/templates/addons/eula.html:21 src/olympia/addons/templates/addons/impala/button.html:48
-#: src/olympia/addons/templates/addons/impala/details.html:316 src/olympia/devhub/templates/devhub/includes/policy_form.html:3 src/olympia/discovery/templates/discovery/addons/eula.html:11
+#: src/olympia/addons/templates/addons/impala/details.html:321 src/olympia/devhub/templates/devhub/includes/policy_form.html:3 src/olympia/discovery/templates/discovery/addons/eula.html:11
 msgid "End-User License Agreement"
 msgstr "Ugovor o licenci softvera za krajnjeg korisnika (EULA)"
 
@@ -519,7 +514,7 @@ msgstr "Nazad na {0}…"
 msgid "Add-ons for {0}"
 msgstr "Dodaci za {0}"
 
-#: src/olympia/addons/templates/addons/home.html:10 src/olympia/addons/templates/addons/home.html:51 src/olympia/browse/templates/browse/impala/base_listing.html:11
+#: src/olympia/addons/templates/addons/home.html:10 src/olympia/addons/templates/addons/home.html:53 src/olympia/browse/templates/browse/impala/base_listing.html:11
 msgid "Featured Extensions"
 msgstr "Istaknute ekstenzije"
 
@@ -527,29 +522,29 @@ msgstr "Istaknute ekstenzije"
 msgid "Popular Extensions"
 msgstr "Popularne ekstenzije"
 
-#: src/olympia/addons/templates/addons/home.html:42 src/olympia/amo/templates/amo/side_nav.html:3 src/olympia/amo/templates/amo/side_nav.html:11 src/olympia/amo/templates/amo/site_nav.html:3
-#: src/olympia/amo/templates/amo/site_nav.html:25 src/olympia/browse/views.py:236 src/olympia/browse/views.py:281 src/olympia/browse/views.py:481
+#: src/olympia/addons/templates/addons/home.html:44 src/olympia/amo/templates/amo/side_nav.html:3 src/olympia/amo/templates/amo/side_nav.html:11 src/olympia/amo/templates/amo/site_nav.html:3
+#: src/olympia/amo/templates/amo/site_nav.html:25 src/olympia/browse/views.py:203 src/olympia/browse/views.py:248 src/olympia/browse/views.py:448
 msgid "Most Popular"
 msgstr "Najpopularnije"
 
-#: src/olympia/addons/templates/addons/home.html:43
+#: src/olympia/addons/templates/addons/home.html:45
 msgid "All »"
 msgstr "Sve »"
 
-#: src/olympia/addons/templates/addons/home.html:52 src/olympia/addons/templates/addons/home.html:61 src/olympia/addons/templates/addons/home.html:70 src/olympia/addons/templates/addons/home.html:78
+#: src/olympia/addons/templates/addons/home.html:54 src/olympia/addons/templates/addons/home.html:63 src/olympia/addons/templates/addons/home.html:72 src/olympia/addons/templates/addons/home.html:80
 #: src/olympia/browse/templates/browse/impala/category_landing.html:36
 msgid "See all »"
 msgstr "Vidi sve »"
 
-#: src/olympia/addons/templates/addons/home.html:60
+#: src/olympia/addons/templates/addons/home.html:62
 msgid "Up &amp; Coming Extensions"
 msgstr "Nadolazeće ekstenzije"
 
-#: src/olympia/addons/templates/addons/home.html:69 src/olympia/browse/templates/browse/personas/category_landing.html:61 src/olympia/discovery/templates/discovery/pane.html:74
+#: src/olympia/addons/templates/addons/home.html:71 src/olympia/browse/templates/browse/personas/category_landing.html:61 src/olympia/discovery/templates/discovery/pane.html:74
 msgid "Featured Themes"
 msgstr "Istaknute teme"
 
-#: src/olympia/addons/templates/addons/home.html:77 src/olympia/bandwagon/templates/bandwagon/impala/collection_listing.html:5
+#: src/olympia/addons/templates/addons/home.html:79 src/olympia/bandwagon/templates/bandwagon/impala/collection_listing.html:5
 msgid "Featured Collections"
 msgstr "Istaknute kolekcije"
 
@@ -567,7 +562,7 @@ msgid "Updated {0}"
 msgstr "Ažurirano {0}"
 
 #. {0} is a date.
-#: src/olympia/addons/templates/addons/macros.html:10 src/olympia/addons/templates/addons/macros.html:69 src/olympia/addons/templates/addons/persona_preview.html:21
+#: src/olympia/addons/templates/addons/macros.html:10 src/olympia/addons/templates/addons/macros.html:69 src/olympia/addons/templates/addons/persona_preview.html:22
 #: src/olympia/addons/templates/addons/listing/items_mobile.html:44 src/olympia/addons/templates/addons/listing/macros.html:39 src/olympia/bandwagon/templates/bandwagon/collection_listing_items.html:37
 #: src/olympia/bandwagon/templates/bandwagon/impala/collection_listing_items.html:37
 msgid "Added {0}"
@@ -579,7 +574,6 @@ msgid "%(num)s weekly download"
 msgid_plural "%(num)s weekly downloads"
 msgstr[0] "%(num)s sedmično preuzimanje"
 msgstr[1] "%(num)s sedmična preuzimanja"
-msgstr[2] "%(num)s sedmičnih preuzimanja"
 
 #: src/olympia/addons/templates/addons/macros.html:28
 #, python-format
@@ -587,24 +581,20 @@ msgid "%(num)s user"
 msgid_plural "%(num)s users"
 msgstr[0] "%(num)s korisnik"
 msgstr[1] "%(num)s korisnika"
-msgstr[2] "%(num)s korisnika"
 
 #. {0} is the number of downloads.
-#: src/olympia/addons/templates/addons/macros.html:53 src/olympia/addons/templates/addons/impala/details.html:61
+#: src/olympia/addons/templates/addons/macros.html:53 src/olympia/addons/templates/addons/impala/details.html:59
 msgid "{0} weekly download"
 msgid_plural "{0} weekly downloads"
 msgstr[0] "{0} preuzimanje nedeljno"
 msgstr[1] "{0} preuzimanja nedeljno"
-msgstr[2] "{0} preuzimanja nedeljno"
 
 #. {0} is the number of users.
-#: src/olympia/addons/templates/addons/macros.html:61 src/olympia/addons/templates/addons/impala/details.html:54 src/olympia/compat/templates/compat/index.html:71
-#: src/olympia/zadmin/templates/zadmin/compat.html:67
+#: src/olympia/addons/templates/addons/macros.html:61 src/olympia/addons/templates/addons/impala/details.html:52 src/olympia/zadmin/templates/zadmin/compat.html:67
 msgid "{0} user"
 msgid_plural "{0} users"
 msgstr[0] "{0} korisnik"
 msgstr[1] "{0} korisnika"
-msgstr[2] "{0} korisnika"
 
 #: src/olympia/addons/templates/addons/paypal_result.html:12
 msgid "Payment cancelled"
@@ -618,7 +608,7 @@ msgstr "Plaćanje završeno"
 msgid "Return to the addon."
 msgstr "Vrati se na dodatak."
 
-#: src/olympia/addons/templates/addons/persona_detail.html:17 src/olympia/addons/templates/addons/impala/details.html:106 src/olympia/addons/templates/addons/mobile/details.html:23
+#: src/olympia/addons/templates/addons/persona_detail.html:17 src/olympia/addons/templates/addons/impala/details.html:103 src/olympia/addons/templates/addons/mobile/details.html:23
 #: src/olympia/addons/templates/addons/mobile/persona_detail.html:21 src/olympia/discovery/templates/discovery/addons/base.html:27 src/olympia/editors/templates/editors/review.html:31
 msgid "by"
 msgstr "od"
@@ -662,35 +652,35 @@ msgstr "Dnevni korisnici"
 msgid "License"
 msgstr "Licenca"
 
-#: src/olympia/addons/templates/addons/persona_preview.html:12 src/olympia/constants/base.py:48
+#: src/olympia/addons/templates/addons/persona_preview.html:13 src/olympia/constants/base.py:48
 msgid "Awaiting Review"
 msgstr "Čekam ocenu"
 
-#: src/olympia/addons/templates/addons/persona_preview.html:14 src/olympia/amo/log.py:180 src/olympia/constants/base.py:42 src/olympia/editors/helpers.py:62
+#: src/olympia/addons/templates/addons/persona_preview.html:15 src/olympia/amo/log.py:180 src/olympia/constants/base.py:42 src/olympia/editors/helpers.py:62
 msgid "Rejected"
 msgstr "Odbijeno"
 
-#: src/olympia/addons/templates/addons/persona_preview.html:16 src/olympia/amo/log.py:159
+#: src/olympia/addons/templates/addons/persona_preview.html:17 src/olympia/amo/log.py:159
 msgid "Approved"
 msgstr "Odobreno"
 
 #. {0} is the number of users.
-#: src/olympia/addons/templates/addons/persona_preview.html:26 src/olympia/addons/templates/addons/listing/items_mobile.html:36 src/olympia/addons/templates/addons/listing/macros.html:31
+#: src/olympia/addons/templates/addons/persona_preview.html:27 src/olympia/addons/templates/addons/listing/items_mobile.html:36 src/olympia/addons/templates/addons/listing/macros.html:31
 msgid "<strong>{0}</strong> user"
 msgid_plural "<strong>{0}</strong> users"
 msgstr[0] "<strong>{0}</strong> korisnik"
 msgstr[1] "<strong>{0}</strong> korisnika"
-msgstr[2] "<strong>{0}</strong> korisnika"
 
-#: src/olympia/addons/templates/addons/persona_preview.html:40
+#: src/olympia/addons/templates/addons/persona_preview.html:41
 msgid "Hover to Preview"
 msgstr "Prevuci za pregled"
 
-#: src/olympia/addons/templates/addons/persona_preview.html:46 src/olympia/addons/templates/addons/persona_preview.html:48 src/olympia/reviews/templates/reviews/add.html:15
+#: src/olympia/addons/templates/addons/persona_preview.html:47 src/olympia/addons/templates/addons/persona_preview.html:49 src/olympia/addons/templates/addons/persona_preview.html:97
+#: src/olympia/reviews/templates/reviews/add.html:15
 msgid "Add"
 msgstr "Dodaj"
 
-#: src/olympia/addons/templates/addons/persona_preview.html:57 src/olympia/bandwagon/templates/bandwagon/ajax_new.html:16 src/olympia/bandwagon/templates/bandwagon/edit.html:19
+#: src/olympia/addons/templates/addons/persona_preview.html:58 src/olympia/bandwagon/templates/bandwagon/ajax_new.html:16 src/olympia/bandwagon/templates/bandwagon/edit.html:19
 #: src/olympia/bandwagon/templates/bandwagon/includes/addedit.html:19 src/olympia/devhub/templates/devhub/addons/edit/admin.html:13 src/olympia/devhub/templates/devhub/addons/edit/basic.html:10
 #: src/olympia/devhub/templates/devhub/addons/edit/details.html:8 src/olympia/devhub/templates/devhub/addons/edit/media.html:6 src/olympia/devhub/templates/devhub/addons/edit/support.html:8
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:9 src/olympia/devhub/templates/devhub/addons/submit/describe.html:29 src/olympia/editors/templates/editors/review.html:257
@@ -699,21 +689,21 @@ msgstr "Uredi"
 
 #. For datetime formatting, see the table on
 #. http://docs.python.org/library/datetime.html#strftime-and-strptime-behavior
-#: src/olympia/addons/templates/addons/persona_preview.html:66
+#: src/olympia/addons/templates/addons/persona_preview.html:67
 #, python-format
 msgid "%%Y-%%m-%%d"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/persona_preview.html:67
+#: src/olympia/addons/templates/addons/persona_preview.html:68
 msgid "by {0} on {1}"
 msgstr "od {0} dana {1}"
 
-#: src/olympia/addons/templates/addons/persona_preview.html:75 src/olympia/reviews/helpers.py:17 src/olympia/reviews/templates/reviews/review_list.html:63
+#: src/olympia/addons/templates/addons/persona_preview.html:76 src/olympia/reviews/helpers.py:17 src/olympia/reviews/templates/reviews/review_list.html:63
 #: src/olympia/reviews/templates/reviews/reviews_link.html:21 src/olympia/reviews/templates/reviews/impala/reviews_link.html:16
 msgid "Not yet rated"
 msgstr "Nije još ocenjeno"
 
-#: src/olympia/addons/templates/addons/persona_preview.html:78
+#: src/olympia/addons/templates/addons/persona_preview.html:79
 msgid "<b>{0}</b> users"
 msgstr "<b>{0}</b> korisnici"
 
@@ -726,8 +716,8 @@ msgid "Learn more about Firefox"
 msgstr "Saznaj više o Firefox-u"
 
 #: src/olympia/addons/templates/addons/popups.html:22
-msgid "or <b><a class=\"installer\" href=\"{url}\">download anyway</a></b>"
-msgstr "ili <b><a class=\"installer\" href=\"{url}\">preuzmite u svakom slučaju</a></b>"
+msgid "or <b><a class=\"button installer\" href=\"{url}\">download anyway</a></b>"
+msgstr ""
 
 #: src/olympia/addons/templates/addons/popups.html:26
 msgid ""
@@ -788,8 +778,8 @@ msgstr "Ova Persona zahteva %(app)s %(new_version)s. Trenutno koristite %(app)s 
 
 #: src/olympia/addons/templates/addons/popups.html:108
 msgid ""
-"<strong>Caution:</strong> This add-on has not been reviewed by Mozilla and can't be installed on release versions of Firefox 43 and above.  Be careful when installing third-party software that "
-"might harm your computer."
+"<strong>Caution:</strong> This add-on has not been reviewed by Mozilla and can't be installed on release versions of Firefox 43 and above. Be careful when installing third-party software that might"
+" harm your computer."
 msgstr ""
 
 #: src/olympia/addons/templates/addons/popups.html:120
@@ -826,7 +816,7 @@ msgstr ""
 "telefonu ako ga nemate.)"
 
 #: src/olympia/addons/templates/addons/report_abuse.html:6 src/olympia/addons/templates/addons/report_abuse_full.html:10 src/olympia/addons/templates/addons/impala/details-more.html:23
-#: src/olympia/addons/templates/addons/impala/details.html:328
+#: src/olympia/addons/templates/addons/impala/details.html:333
 msgid "Report Abuse"
 msgstr "Prijavi zloupotrebu"
 
@@ -847,9 +837,9 @@ msgstr "Pošalji prijavu"
 #: src/olympia/devhub/templates/devhub/addons/ajax_compat_update.html:36 src/olympia/devhub/templates/devhub/addons/profile.html:44 src/olympia/devhub/templates/devhub/addons/edit/admin.html:104
 #: src/olympia/devhub/templates/devhub/addons/edit/basic.html:155 src/olympia/devhub/templates/devhub/addons/edit/details.html:88 src/olympia/devhub/templates/devhub/addons/edit/support.html:70
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:169 src/olympia/devhub/templates/devhub/addons/forms_shared/media.html:152
-#: src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:44 src/olympia/devhub/templates/devhub/personas/edit.html:222 src/olympia/devhub/templates/devhub/versions/add_file_modal.html:79
-#: src/olympia/devhub/templates/devhub/versions/edit.html:140 src/olympia/devhub/templates/devhub/versions/list.html:208 src/olympia/devhub/templates/devhub/versions/list.html:242
-#: src/olympia/devhub/templates/devhub/versions/list.html:276 src/olympia/devhub/templates/devhub/versions/list.html:317 src/olympia/reviews/templates/reviews/edit_review.html:16
+#: src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:43 src/olympia/devhub/templates/devhub/personas/edit.html:222 src/olympia/devhub/templates/devhub/versions/add_file_modal.html:59
+#: src/olympia/devhub/templates/devhub/versions/edit.html:140 src/olympia/devhub/templates/devhub/versions/list.html:208 src/olympia/devhub/templates/devhub/versions/list.html:239
+#: src/olympia/devhub/templates/devhub/versions/list.html:281 src/olympia/devhub/templates/devhub/versions/list.html:315 src/olympia/reviews/templates/reviews/edit_review.html:16
 #: src/olympia/translations/templates/translations/trans-menu.html:50 src/olympia/translations/templates/translations/trans-menu.html:62 src/olympia/zadmin/templates/zadmin/validation.html:105
 msgid "Cancel"
 msgstr "Otkaži"
@@ -894,7 +884,7 @@ msgstr "Pogledajte <a href=\"%(support)s\">odeljak podrške</a> kako biste sazna
 msgid "Review Guidelines"
 msgstr "Smernice za recenziranje"
 
-#: src/olympia/addons/templates/addons/review_list_box.html:5 src/olympia/addons/templates/addons/impala/details-more.html:27 src/olympia/editors/helpers.py:921
+#: src/olympia/addons/templates/addons/review_list_box.html:5 src/olympia/addons/templates/addons/impala/details-more.html:27 src/olympia/editors/helpers.py:1001
 #: src/olympia/reviews/templates/reviews/add.html:14 src/olympia/reviews/templates/reviews/reply.html:14 src/olympia/reviews/templates/reviews/review_list.html:19
 #: src/olympia/reviews/templates/reviews/mobile/review_list.html:26
 msgid "Reviews"
@@ -915,7 +905,6 @@ msgid "See all reviews of this add-on"
 msgid_plural "See all %(cnt)s reviews of this add-on"
 msgstr[0] "Pogledajte sve recenzije ovog dodatka"
 msgstr[1] "Pogledajte sve %(cnt)s recenzije ovog dodatka"
-msgstr[2] "Pogledajte svih %(cnt)s recenzija ovog dodatka"
 
 #: src/olympia/addons/templates/addons/tags_box.html:3 src/olympia/devhub/templates/devhub/addons/edit/basic.html:118
 msgid "Tags"
@@ -985,108 +974,105 @@ msgid "Other add-ons by %(author)s"
 msgid_plural "Other add-ons by these authors"
 msgstr[0] "Drugi dodaci od %(author)s"
 msgstr[1] "Drugi dodaci od ovih autora"
-msgstr[2] "Drugi dodaci od ovih autora"
 
-#: src/olympia/addons/templates/addons/impala/details.html:41
+#: src/olympia/addons/templates/addons/impala/details.html:39
 #, python-format
 msgid "<span itemprop=\"ratingCount\">%(num)s</span> user review"
 msgid_plural "<span itemprop=\"ratingCount\">%(num)s</span> user reviews"
 msgstr[0] "<span itemprop=\"ratingCount\">%(num)s</span> recenzija korisnika"
 msgstr[1] "<span itemprop=\"ratingCount\">%(num)s</span> recenzije korisnika"
-msgstr[2] "<span itemprop=\"ratingCount\">%(num)s</span> recenzija korisnika"
 
-#: src/olympia/addons/templates/addons/impala/details.html:69
+#: src/olympia/addons/templates/addons/impala/details.html:66
 msgid "View statistics"
 msgstr "Pregled statistike"
 
-#: src/olympia/addons/templates/addons/impala/details.html:84
+#: src/olympia/addons/templates/addons/impala/details.html:81
 msgid "Manage"
 msgstr "Upravljaj"
 
 #. {0} is an add-on name.
-#: src/olympia/addons/templates/addons/impala/details.html:96
+#: src/olympia/addons/templates/addons/impala/details.html:93
 msgid "Icon of {0}"
 msgstr "Ikonica od {0}"
 
-#: src/olympia/addons/templates/addons/impala/details.html:103 src/olympia/addons/templates/addons/impala/listing/items.html:14
+#: src/olympia/addons/templates/addons/impala/details.html:100 src/olympia/addons/templates/addons/impala/listing/items.html:14
 msgid "No Restart"
 msgstr "Bez ponovnog pokretanja"
 
-#: src/olympia/addons/templates/addons/impala/details.html:127
+#: src/olympia/addons/templates/addons/impala/details.html:124
 #, fuzzy, python-format
 msgid "Meet the Developer: <a href=\"%(url)s\">%(name)s</a>"
 msgid_plural "<a href=\"%(url)s\">Meet the Developers</a>"
 msgstr[0] "Upoznajte programera: <a href=\"%(url)s\">%(name)s</a>"
 msgstr[1] "<a href=\"%(url)s\">Upoznajte programere</a>"
-msgstr[2] "<a href=\"%(url)s\">Upoznajte programere</a>"
 
 # {0} is an add-on name.
-#: src/olympia/addons/templates/addons/impala/details.html:137
+#: src/olympia/addons/templates/addons/impala/details.html:134
 msgid "Learn why {0} was created and find out what's next for this add-on."
 msgstr "Pročitajte zašto je {0} napravljen i saznajte šta sledi u vezi sa ovim dodatkom."
 
 #. {0} is an index.
-#: src/olympia/addons/templates/addons/impala/details.html:156
+#: src/olympia/addons/templates/addons/impala/details.html:161
 msgid "Add-on screenshot #{0}"
 msgstr "Slika ekrana dodatka #{0}"
 
-#: src/olympia/addons/templates/addons/impala/details.html:182
+#: src/olympia/addons/templates/addons/impala/details.html:187
 msgid "Add-on home page"
 msgstr "Početna stranica dodatka"
 
-#: src/olympia/addons/templates/addons/impala/details.html:185
+#: src/olympia/addons/templates/addons/impala/details.html:190
 msgid "Support site"
 msgstr "Sajt podrške"
 
-#: src/olympia/addons/templates/addons/impala/details.html:189
+#: src/olympia/addons/templates/addons/impala/details.html:194
 msgid "Support E-mail"
 msgstr "E-pošta podrške"
 
-#: src/olympia/addons/templates/addons/impala/details.html:194 src/olympia/devhub/models.py:378 src/olympia/devhub/templates/devhub/versions/list.html:12
+#: src/olympia/addons/templates/addons/impala/details.html:199 src/olympia/devhub/models.py:378 src/olympia/devhub/templates/devhub/versions/list.html:12
 #: src/olympia/versions/templates/versions/version.html:6 src/olympia/versions/templates/versions/mobile/version.html:6
 msgid "Version {0}"
 msgstr "Verzija {0}"
 
-#: src/olympia/addons/templates/addons/impala/details.html:194
+#: src/olympia/addons/templates/addons/impala/details.html:199
 msgid "Info"
 msgstr "Informacije"
 
-#: src/olympia/addons/templates/addons/impala/details.html:195 src/olympia/devhub/templates/devhub/includes/addon_details.html:129
+#: src/olympia/addons/templates/addons/impala/details.html:200 src/olympia/devhub/templates/devhub/includes/addon_details.html:116
 msgid "Last Updated:"
 msgstr "Poslednje ažuriranje:"
 
-#: src/olympia/addons/templates/addons/impala/details.html:200
+#: src/olympia/addons/templates/addons/impala/details.html:205
 #, python-format
 msgid "Released under <a target=\"_blank\" href=\"%(url)s\">%(name)s</a>"
 msgstr "Objavljen pod <a target=\"_blank\" href=\"%(url)s\">%(name)s</a>"
 
-#: src/olympia/addons/templates/addons/impala/details.html:201 src/olympia/addons/templates/addons/impala/details.html:206 src/olympia/amo/helpers.py:398 src/olympia/devhub/forms.py:142
+#: src/olympia/addons/templates/addons/impala/details.html:206 src/olympia/addons/templates/addons/impala/details.html:211 src/olympia/amo/helpers.py:398 src/olympia/devhub/forms.py:142
 #: src/olympia/devhub/forms.py:173 src/olympia/versions/templates/versions/version.html:40 src/olympia/versions/templates/versions/version.html:45
 msgid "Custom License"
 msgstr "Prilagođena licenca"
 
-#: src/olympia/addons/templates/addons/impala/details.html:205
+#: src/olympia/addons/templates/addons/impala/details.html:210
 #, python-format
 msgid "Released under <a href=\"%(url)s\">%(name)s</a>"
 msgstr "Objavljen pod <a href=\"%(url)s\">%(name)s</a>"
 
-#: src/olympia/addons/templates/addons/impala/details.html:217
+#: src/olympia/addons/templates/addons/impala/details.html:222
 msgid "About this Add-on"
 msgstr "O dodatku"
 
-#: src/olympia/addons/templates/addons/impala/details.html:233
+#: src/olympia/addons/templates/addons/impala/details.html:238
 msgid "Developer’s Comments"
 msgstr "Komentari programera"
 
-#: src/olympia/addons/templates/addons/impala/details.html:243
+#: src/olympia/addons/templates/addons/impala/details.html:248
 msgid "Version Information"
 msgstr "Informacije o verziji"
 
-#: src/olympia/addons/templates/addons/impala/details.html:250
+#: src/olympia/addons/templates/addons/impala/details.html:255
 msgid "See complete version history"
 msgstr "Pogledaj punu istoriju verzija"
 
-#: src/olympia/addons/templates/addons/impala/details.html:262
+#: src/olympia/addons/templates/addons/impala/details.html:267
 msgid ""
 "The Development Channel lets you test an experimental new version of this add-on before it's released to the general public. Once you install the development version, you will continue to get "
 "updates from this channel. To stop receiving development updates, reinstall the default version from the link above."
@@ -1094,17 +1080,17 @@ msgstr ""
 "Kanal za programere Vam dopušta da testirate novu probnu verziju ovog dodatka pre nego što postane dostupan široj javnosti. Čim instalirate razvojnu verziju, nastavićete da dobijate nadogradnje sa "
 "ovog kanala. Da biste prekinuli primanje novosti, ponovo instalirajte podrazumevanu verziju sa gornje veze."
 
-#: src/olympia/addons/templates/addons/impala/details.html:272
+#: src/olympia/addons/templates/addons/impala/details.html:277
 msgid "<strong>Caution:</strong> Development versions of this add-on have not been reviewed by Mozilla."
 msgstr ""
 
-#: src/olympia/addons/templates/addons/impala/details.html:287
+#: src/olympia/addons/templates/addons/impala/details.html:292
 msgid "See complete development channel history"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/impala/details.html:306 src/olympia/addons/templates/addons/impala/details.html:315 src/olympia/addons/templates/addons/impala/details.html:327
+#: src/olympia/addons/templates/addons/impala/details.html:311 src/olympia/addons/templates/addons/impala/details.html:320 src/olympia/addons/templates/addons/impala/details.html:332
 #: src/olympia/addons/templates/addons/impala/review_add_box.html:4 src/olympia/stats/templates/stats/popup.html:2 src/olympia/stats/templates/stats/popup.html:8
-#: src/olympia/stats/templates/stats/stats.html:202 src/olympia/users/templates/users/profile.html:119
+#: src/olympia/stats/templates/stats/stats.html:204 src/olympia/users/templates/users/profile.html:119
 msgid "close"
 msgstr "zatvori"
 
@@ -1138,7 +1124,6 @@ msgid "About the Developer"
 msgid_plural "About the Developers"
 msgstr[0] "O programeru"
 msgstr[1] "O programerima"
-msgstr[2] "O programerima"
 
 #: src/olympia/addons/templates/addons/impala/developers.html:96 src/olympia/users/templates/users/edit.html:130 src/olympia/users/templates/users/profile.html:26
 msgid "No Photo"
@@ -1164,15 +1149,11 @@ msgstr "Licenca izvornog koda za {addon}"
 msgid "Source Code License"
 msgstr "Licenca izvornog koda"
 
-#: src/olympia/addons/templates/addons/impala/persona_grid.html:16 src/olympia/addons/templates/addons/impala/toplist.html:6
-msgid "{0} users"
-msgstr "{0} korisnika"
-
 #: src/olympia/addons/templates/addons/impala/review_list_box.html:19 src/olympia/reviews/templates/reviews/review.html:40
 msgid "permalink"
 msgstr "trajna veza"
 
-#: src/olympia/addons/templates/addons/impala/review_list_box.html:23 src/olympia/editors/templates/editors/queue.html:98 src/olympia/reviews/templates/reviews/review.html:44
+#: src/olympia/addons/templates/addons/impala/review_list_box.html:23 src/olympia/editors/templates/editors/queue.html:104 src/olympia/reviews/templates/reviews/review.html:44
 msgid "translate"
 msgstr "prevedi"
 
@@ -1182,7 +1163,6 @@ msgid "See all user reviews"
 msgid_plural "See all %(cnt)s user reviews"
 msgstr[0] "Pogledajte sve recenzije korisnika"
 msgstr[1] "Pogledajte sve recenzije korisnika"
-msgstr[2] "Pogledajte sve recenzije korisnika"
 
 #: src/olympia/addons/templates/addons/impala/review_list_box.html:47 src/olympia/reviews/templates/reviews/review_list.html:84
 msgid "This add-on has not yet been reviewed."
@@ -1191,6 +1171,10 @@ msgstr "Ovaj dodatak još nema recenziju."
 #: src/olympia/addons/templates/addons/impala/review_list_box.html:50
 msgid "Be the first!"
 msgstr "Budite prvi!"
+
+#: src/olympia/addons/templates/addons/impala/toplist.html:6
+msgid "{0} users"
+msgstr "{0} korisnika"
 
 #: src/olympia/addons/templates/addons/impala/listing/sorter.html:14 src/olympia/devhub/templates/devhub/addons/listing/item_actions.html:49
 msgid "More"
@@ -1204,7 +1188,7 @@ msgstr "Dodaj u kolekciju"
 msgid "My Add-ons"
 msgstr "Moji dodaci"
 
-#: src/olympia/addons/templates/addons/includes/dashboard_tabs.html:6 src/olympia/amo/context_processors.py:51
+#: src/olympia/addons/templates/addons/includes/dashboard_tabs.html:6 src/olympia/amo/context_processors.py:52
 msgid "My Themes"
 msgstr "Moje teme"
 
@@ -1246,7 +1230,6 @@ msgid "<strong>{0}</strong> weekly download"
 msgid_plural "<strong>{0}</strong> weekly downloads"
 msgstr[0] "<strong>{0}</strong> preuzimanje nedeljno"
 msgstr[1] "<strong>{0}</strong> preuzimanja nedeljno"
-msgstr[2] "<strong>{0}</strong> preuzimanja nedeljno"
 
 #: src/olympia/addons/templates/addons/mobile/details.html:32
 msgid "Read More"
@@ -1260,7 +1243,7 @@ msgstr "Korisnici"
 msgid "Weekly Downloads"
 msgstr "Sedmična preuzimanja"
 
-#: src/olympia/addons/templates/addons/mobile/details.html:99 src/olympia/compat/templates/compat/reporter_detail.html:46 src/olympia/devhub/forms.py:787
+#: src/olympia/addons/templates/addons/mobile/details.html:99 src/olympia/compat/templates/compat/reporter_detail.html:46 src/olympia/devhub/forms.py:788
 #: src/olympia/devhub/templates/devhub/versions/list.html:163
 msgid "Version"
 msgstr "Verzija"
@@ -1345,7 +1328,7 @@ msgstr ""
 #: src/olympia/browse/templates/browse/personas/base.html:6 src/olympia/browse/templates/browse/personas/base.html:42 src/olympia/browse/templates/browse/personas/category_landing.html:21
 #: src/olympia/browse/templates/browse/personas/category_landing.html:23 src/olympia/browse/templates/browse/personas/category_landing.html:38 src/olympia/browse/templates/browse/personas/grid.html:7
 #: src/olympia/browse/templates/browse/personas/grid.html:11 src/olympia/browse/templates/browse/personas/mobile/base.html:7 src/olympia/browse/templates/browse/personas/mobile/category_landing.html:19
-#: src/olympia/constants/base.py:180 src/olympia/devhub/templates/devhub/personas/submit.html:13 src/olympia/editors/helpers.py:105 src/olympia/editors/templates/editors/base.html:26
+#: src/olympia/constants/base.py:180 src/olympia/devhub/templates/devhub/personas/submit.html:13 src/olympia/editors/helpers.py:107 src/olympia/editors/templates/editors/base.html:26
 #: src/olympia/editors/templates/editors/performance.html:73 src/olympia/search/templates/search/personas.html:39 src/olympia/templates/menu_links.html:9
 msgid "Themes"
 msgstr "Teme"
@@ -1366,7 +1349,7 @@ msgstr "Još dodataka"
 msgid "Highest Rated"
 msgstr "Najbolje ocenjene"
 
-#: src/olympia/addons/templates/addons/mobile/home.html:74 src/olympia/amo/templates/amo/side_nav.html:5 src/olympia/amo/templates/amo/site_nav.html:27 src/olympia/amo/templates/amo/site_nav.html:57
+#: src/olympia/addons/templates/addons/mobile/home.html:74 src/olympia/amo/templates/amo/side_nav.html:5 src/olympia/amo/templates/amo/site_nav.html:27 src/olympia/amo/templates/amo/site_nav.html:55
 #: src/olympia/bandwagon/views.py:97 src/olympia/browse/views.py:57 src/olympia/browse/views.py:67 src/olympia/browse/templates/browse/personas/mobile/category_landing.html:65
 #: src/olympia/search/forms.py:15 src/olympia/search/forms.py:87
 msgid "Newest"
@@ -1384,84 +1367,84 @@ msgstr "Informacije o temi &raquo;"
 msgid "Tools"
 msgstr "Alati"
 
-#: src/olympia/amo/context_processors.py:48 src/olympia/discovery/templates/discovery/pane_account.html:8 src/olympia/users/templates/users/includes/navigation.html:2
+#: src/olympia/amo/context_processors.py:49 src/olympia/discovery/templates/discovery/pane_account.html:8 src/olympia/users/templates/users/includes/navigation.html:2
 msgid "My Profile"
 msgstr "Moj profil"
 
-#: src/olympia/amo/context_processors.py:54 src/olympia/users/templates/users/edit.html:5 src/olympia/users/templates/users/includes/navigation.html:3
+#: src/olympia/amo/context_processors.py:55 src/olympia/users/templates/users/edit.html:5 src/olympia/users/templates/users/includes/navigation.html:3
 msgid "Account Settings"
 msgstr "Podešavanja naloga"
 
-#: src/olympia/amo/context_processors.py:57 src/olympia/discovery/templates/discovery/pane_account.html:11 src/olympia/users/templates/users/profile.html:83
+#: src/olympia/amo/context_processors.py:58 src/olympia/discovery/templates/discovery/pane_account.html:11 src/olympia/users/templates/users/profile.html:83
 #: src/olympia/users/templates/users/includes/navigation.html:4
 msgid "My Collections"
 msgstr "Moje kolekcije"
 
-#: src/olympia/amo/context_processors.py:62 src/olympia/discovery/templates/discovery/pane_account.html:10 src/olympia/users/templates/users/includes/navigation.html:7
+#: src/olympia/amo/context_processors.py:63 src/olympia/discovery/templates/discovery/pane_account.html:10 src/olympia/users/templates/users/includes/navigation.html:7
 msgid "My Favorites"
 msgstr "Moji omiljeni"
 
-#: src/olympia/amo/context_processors.py:67 src/olympia/discovery/templates/discovery/pane_account.html:13 src/olympia/templates/impala/user_login.html:14 src/olympia/templates/mobile/header_auth.html:5
+#: src/olympia/amo/context_processors.py:68 src/olympia/discovery/templates/discovery/pane_account.html:13 src/olympia/templates/impala/user_login.html:14 src/olympia/templates/mobile/header_auth.html:5
 msgid "Log out"
 msgstr "Odjavi se"
 
-#: src/olympia/amo/context_processors.py:72 src/olympia/devhub/templates/devhub/addons/dashboard.html:4
+#: src/olympia/amo/context_processors.py:73 src/olympia/devhub/templates/devhub/addons/dashboard.html:4
 msgid "Manage My Submissions"
 msgstr "Upravljaj mojim dostavama"
 
-#: src/olympia/amo/context_processors.py:75 src/olympia/devhub/templates/devhub/nav.html:27 src/olympia/devhub/templates/devhub/addons/dashboard.html:25
+#: src/olympia/amo/context_processors.py:76 src/olympia/devhub/templates/devhub/nav.html:27 src/olympia/devhub/templates/devhub/addons/dashboard.html:25
 #: src/olympia/devhub/templates/devhub/addons/submit/base.html:4
 msgid "Submit a New Add-on"
 msgstr "Podnesi novi dodatak"
 
-#: src/olympia/amo/context_processors.py:77 src/olympia/browse/templates/browse/personas/base.html:50 src/olympia/devhub/templates/devhub/index.html:24
+#: src/olympia/amo/context_processors.py:78 src/olympia/browse/templates/browse/personas/base.html:50 src/olympia/devhub/templates/devhub/index.html:24
 #: src/olympia/devhub/templates/devhub/addons/dashboard.html:29
 msgid "Submit a New Theme"
 msgstr "Podnesi novu temu"
 
-#: src/olympia/amo/context_processors.py:79 src/olympia/amo/templates/amo/site_nav.html:87 src/olympia/devhub/helpers.py:36 src/olympia/devhub/helpers.py:68 src/olympia/devhub/helpers.py:102
+#: src/olympia/amo/context_processors.py:80 src/olympia/amo/templates/amo/site_nav.html:85 src/olympia/devhub/helpers.py:36 src/olympia/devhub/helpers.py:68 src/olympia/devhub/helpers.py:102
 #: src/olympia/templates/footer.html:6 src/olympia/templates/menu_links.html:14
 msgid "Developer Hub"
 msgstr "Centar za programera"
 
-#: src/olympia/amo/context_processors.py:83 src/olympia/devhub/views.py:1792
+#: src/olympia/amo/context_processors.py:84 src/olympia/devhub/views.py:1799
 msgid "Manage API Keys"
 msgstr ""
 
-#: src/olympia/amo/context_processors.py:88 src/olympia/editors/helpers.py:82 src/olympia/editors/helpers.py:102 src/olympia/editors/templates/editors/base.html:10
+#: src/olympia/amo/context_processors.py:89 src/olympia/editors/helpers.py:84 src/olympia/editors/helpers.py:104 src/olympia/editors/templates/editors/base.html:10
 msgid "Editor Tools"
 msgstr "Alati urednika"
 
-#: src/olympia/amo/context_processors.py:92
+#: src/olympia/amo/context_processors.py:93
 msgid "Admin Tools"
 msgstr "Alati administratora"
 
-#: src/olympia/amo/fields.py:15
+#: src/olympia/amo/fields.py:20
 msgid "Incorrect, please try again."
 msgstr ""
 
-#: src/olympia/amo/fields.py:16
+#: src/olympia/amo/fields.py:21
 msgid "Error verifying input, please try again."
 msgstr ""
 
-#: src/olympia/amo/fields.py:32
+#: src/olympia/amo/fields.py:37
 msgid "This must be a valid hex color code, such as #000000."
 msgstr "Morate uneti ispravnu heksadecimalnu šifru boje, kao što je #000000."
 
-#: src/olympia/amo/fields.py:58
+#: src/olympia/amo/fields.py:63
 msgid "Enter at least one value."
 msgstr "Unesite bar jednu vrednost."
 
-#: src/olympia/amo/helpers.py:162 src/olympia/amo/templates/amo/site_nav.html:61 src/olympia/bandwagon/templates/bandwagon/add.html:9 src/olympia/bandwagon/templates/bandwagon/collection_detail.html:15
+#: src/olympia/amo/helpers.py:162 src/olympia/amo/templates/amo/site_nav.html:59 src/olympia/bandwagon/templates/bandwagon/add.html:9 src/olympia/bandwagon/templates/bandwagon/collection_detail.html:15
 #: src/olympia/bandwagon/templates/bandwagon/delete.html:9 src/olympia/bandwagon/templates/bandwagon/edit.html:15 src/olympia/bandwagon/templates/bandwagon/user_listing.html:18
 #: src/olympia/bandwagon/templates/bandwagon/user_listing.html:21 src/olympia/bandwagon/templates/bandwagon/impala/collection_listing.html:12
 #: src/olympia/bandwagon/templates/bandwagon/impala/collection_listing.html:20 src/olympia/bandwagon/templates/bandwagon/impala/collection_listing.html:24
 #: src/olympia/bandwagon/templates/bandwagon/impala/collection_sidebar.html:3 src/olympia/bandwagon/templates/bandwagon/includes/collection_sidebar.html:2
-#: src/olympia/bandwagon/templates/bandwagon/mobile/collection_listing.html:3 src/olympia/stats/templates/stats/stats.html:77 src/olympia/templates/menu_links.html:12
+#: src/olympia/bandwagon/templates/bandwagon/mobile/collection_listing.html:3 src/olympia/stats/templates/stats/stats.html:33 src/olympia/templates/menu_links.html:12
 msgid "Collections"
 msgstr "Kolekcije"
 
-#: src/olympia/amo/helpers.py:171 src/olympia/amo/templates/amo/site_nav.html:85 src/olympia/browse/templates/browse/language_tools.html:3
+#: src/olympia/amo/helpers.py:171 src/olympia/amo/templates/amo/site_nav.html:83 src/olympia/browse/templates/browse/language_tools.html:3
 msgid "Dictionaries & Language Packs"
 msgstr "Rečnici i jezički paketi"
 
@@ -1613,8 +1596,8 @@ msgstr "Zahtevana super recenzija"
 msgid "Comment on {addon} {version}."
 msgstr "Komentar na {addon} {version}."
 
-#: src/olympia/amo/log.py:236 src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:19 src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:47
-#: src/olympia/editors/helpers.py:511 src/olympia/editors/templates/editors/themes/history_table.html:11
+#: src/olympia/amo/log.py:236 src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:17 src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:45
+#: src/olympia/editors/helpers.py:584 src/olympia/editors/templates/editors/themes/history_table.html:11
 msgid "Comment"
 msgstr "Komentariši"
 
@@ -1943,7 +1926,7 @@ msgstr "Prethodno"
 #: src/olympia/amo/templates/amo/mobile/paginator.html:14 src/olympia/amo/templates/amo/mobile/paginator.html:16 src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:51
 #: src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:65 src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:78
 #: src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:91 src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:104
-#: src/olympia/discovery/templates/discovery/pane.html:45 src/olympia/discovery/templates/discovery/addons/detail.html:39 src/olympia/stats/templates/stats/stats.html:167
+#: src/olympia/discovery/templates/discovery/pane.html:45 src/olympia/discovery/templates/discovery/addons/detail.html:39 src/olympia/stats/templates/stats/stats.html:169
 msgid "Next"
 msgstr "Sledeće"
 
@@ -1977,7 +1960,7 @@ msgstr ""
 "id=\"recaptcha_different\">isprobati različite reči</a> ili <a href=\"#\" id=\"recaptcha_audio\">pokušajte različite vrste izazova</a> umesto. </p>"
 
 #: src/olympia/amo/templates/amo/side_nav.html:4 src/olympia/amo/templates/amo/side_nav.html:12 src/olympia/amo/templates/amo/site_nav.html:4 src/olympia/amo/templates/amo/site_nav.html:26
-#: src/olympia/browse/views.py:56 src/olympia/browse/views.py:66 src/olympia/browse/views.py:237 src/olympia/browse/views.py:282 src/olympia/search/forms.py:86
+#: src/olympia/browse/views.py:56 src/olympia/browse/views.py:66 src/olympia/browse/views.py:204 src/olympia/browse/views.py:249 src/olympia/search/forms.py:86
 msgid "Top Rated"
 msgstr "Najbolje ocenjeno"
 
@@ -1992,37 +1975,37 @@ msgstr "Istraži"
 msgid "Extensions"
 msgstr "Ekstenzije"
 
-#: src/olympia/amo/templates/amo/site_nav.html:45
+#: src/olympia/amo/templates/amo/site_nav.html:44
 msgid "Want more customization? Try <b>Complete Themes</b>"
 msgstr ""
 
-#: src/olympia/amo/templates/amo/site_nav.html:56 src/olympia/bandwagon/views.py:96
+#: src/olympia/amo/templates/amo/site_nav.html:54 src/olympia/bandwagon/views.py:96
 msgid "Most Followers"
 msgstr "Najviše pratioca"
 
-#: src/olympia/amo/templates/amo/site_nav.html:68 src/olympia/bandwagon/templates/bandwagon/impala/collection_sidebar.html:16 src/olympia/bandwagon/templates/bandwagon/includes/collection_sidebar.html:18
+#: src/olympia/amo/templates/amo/site_nav.html:66 src/olympia/bandwagon/templates/bandwagon/impala/collection_sidebar.html:16 src/olympia/bandwagon/templates/bandwagon/includes/collection_sidebar.html:18
 msgid "Collections I've Made"
 msgstr "Moje kolekcije"
 
-#: src/olympia/amo/templates/amo/site_nav.html:70 src/olympia/bandwagon/templates/bandwagon/user_listing.html:4 src/olympia/bandwagon/templates/bandwagon/impala/collection_sidebar.html:13
+#: src/olympia/amo/templates/amo/site_nav.html:68 src/olympia/bandwagon/templates/bandwagon/user_listing.html:4 src/olympia/bandwagon/templates/bandwagon/impala/collection_sidebar.html:13
 #: src/olympia/bandwagon/templates/bandwagon/includes/collection_sidebar.html:15
 msgid "Collections I'm Following"
 msgstr "Kolekcije koje pratim"
 
-#: src/olympia/amo/templates/amo/site_nav.html:73 src/olympia/bandwagon/templates/bandwagon/impala/collection_sidebar.html:18 src/olympia/bandwagon/templates/bandwagon/includes/collection_sidebar.html:20
-#: src/olympia/users/models.py:512
+#: src/olympia/amo/templates/amo/site_nav.html:71 src/olympia/bandwagon/templates/bandwagon/impala/collection_sidebar.html:18 src/olympia/bandwagon/templates/bandwagon/includes/collection_sidebar.html:20
+#: src/olympia/users/models.py:521
 msgid "My Favorite Add-ons"
 msgstr "Moji omiljeni dodaci"
 
-#: src/olympia/amo/templates/amo/site_nav.html:78
+#: src/olympia/amo/templates/amo/site_nav.html:76
 msgid "More&hellip;"
 msgstr "Još&hellip;"
 
-#: src/olympia/amo/templates/amo/site_nav.html:82
+#: src/olympia/amo/templates/amo/site_nav.html:80
 msgid "Add-ons for Mobile"
 msgstr "Dodaci za mobilni"
 
-#: src/olympia/amo/templates/amo/site_nav.html:86 src/olympia/browse/feeds.py:207 src/olympia/browse/templates/browse/search_tools.html:3 src/olympia/constants/base.py:176
+#: src/olympia/amo/templates/amo/site_nav.html:84 src/olympia/browse/feeds.py:207 src/olympia/browse/templates/browse/search_tools.html:3 src/olympia/constants/base.py:176
 #: src/olympia/templates/menu_links.html:10
 msgid "Search Tools"
 msgstr "Alati za pretragu"
@@ -2038,7 +2021,7 @@ msgid "Jump to first page"
 msgstr "Prebacite se na prvu stranicu"
 
 #: src/olympia/amo/templates/amo/impala/paginator.html:22 src/olympia/amo/templates/amo/mobile/impala_paginator.html:12 src/olympia/discovery/templates/discovery/pane.html:44
-#: src/olympia/discovery/templates/discovery/addons/detail.html:38 src/olympia/stats/templates/stats/stats.html:164
+#: src/olympia/discovery/templates/discovery/addons/detail.html:38 src/olympia/stats/templates/stats/stats.html:166
 msgid "Previous"
 msgstr "Prethodno"
 
@@ -2060,33 +2043,51 @@ msgid "Page {n}"
 msgid_plural "Page {n}"
 msgstr[0] "Stranica {n}"
 msgstr[1] "Stranica {n}"
-msgstr[2] "Stranica {n}"
 
-#: src/olympia/amo/templates/services/install.html:38
-#, python-format
-msgid "If you are not prompted to install %(addon_name)s in a moment, please <a href=\"%(addon_xpi)s\">click here</a>."
-msgstr "Ako za par momenata ne budete traženi da instalirate %(addon_name)s, molimo Vas <a href=\"%(addon_xpi)s\">kliknite ovde</a>."
-
-#: src/olympia/amo/tests/test_messages.py:57 src/olympia/amo/tests/test_messages.py:58 src/olympia/reviews/forms.py:25 src/olympia/reviews/forms.py:50 src/olympia/reviews/templates/reviews/add.html:56
+#: src/olympia/amo/tests/test_messages.py:56 src/olympia/amo/tests/test_messages.py:57 src/olympia/reviews/forms.py:25 src/olympia/reviews/forms.py:50 src/olympia/reviews/templates/reviews/add.html:56
 #: src/olympia/reviews/templates/reviews/reply.html:30
 msgid "Title"
 msgstr "Naslov"
 
-#: src/olympia/amo/tests/test_messages.py:57 src/olympia/amo/tests/test_messages.py:58
+#: src/olympia/amo/tests/test_messages.py:56 src/olympia/amo/tests/test_messages.py:57
 msgid "Body"
 msgstr "Sadržaj"
 
-#: src/olympia/amo/tests/test_messages.py:59
+#: src/olympia/amo/tests/test_messages.py:58
 msgid "Another Title"
 msgstr "Drugi naslov"
 
-#: src/olympia/amo/tests/test_messages.py:59
+#: src/olympia/amo/tests/test_messages.py:58
 msgid "Another Body"
 msgstr "Drugi sadržaj"
 
-#: src/olympia/api/views.py:255
-msgid "Not implemented yet."
-msgstr "Nije još implementiran."
+#: src/olympia/api/authentication.py:76
+msgid "Signature has expired."
+msgstr ""
+
+#: src/olympia/api/authentication.py:79
+msgid "Error decoding signature."
+msgstr ""
+
+#: src/olympia/api/authentication.py:82
+msgid "Invalid JWT Token."
+msgstr ""
+
+#: src/olympia/api/authentication.py:130
+msgid "Invalid Authorization header. No credentials provided."
+msgstr ""
+
+#: src/olympia/api/authentication.py:133
+msgid "Invalid Authorization header. Credentials string should not contain spaces."
+msgstr ""
+
+#: src/olympia/api/fields.py:29
+msgid "The field must have a length of at least {num} characters."
+msgstr ""
+
+#: src/olympia/api/fields.py:31
+msgid "The language code {lang_code} is invalid."
+msgstr ""
 
 #: src/olympia/applications/views.py:39 src/olympia/applications/templates/applications/appversions.html:3
 msgid "Application Versions"
@@ -2104,7 +2105,7 @@ msgstr "Ispravne verzije aplikacije"
 msgid "Add-ons submitted to Mozilla Add-ons must have a manifest file with at least one of the below applications supported. Only the versions listed below are allowed for these applications."
 msgstr ""
 
-#: src/olympia/applications/templates/applications/appversions.html:25
+#: src/olympia/applications/templates/applications/appversions.html:25 src/olympia/editors/helpers.py:361
 msgid "GUID"
 msgstr "GUID"
 
@@ -2181,11 +2182,11 @@ msgstr "Veze nisu dozvoljene."
 msgid "This url is already in use by another collection"
 msgstr "Ovaj url je u upotrebi od strane druge kolekcije"
 
-#: src/olympia/bandwagon/forms.py:197 src/olympia/devhub/views.py:1049
+#: src/olympia/bandwagon/forms.py:197 src/olympia/devhub/views.py:1050
 msgid "Icons must be either PNG or JPG."
 msgstr "Ikonice moraju biti ili PNG ili JPG formata."
 
-#: src/olympia/bandwagon/forms.py:202 src/olympia/devhub/views.py:1067 src/olympia/users/forms.py:476
+#: src/olympia/bandwagon/forms.py:202 src/olympia/devhub/views.py:1068 src/olympia/users/forms.py:476
 #, python-format
 msgid "Please use images smaller than %dMB."
 msgstr "Molimo Vas koristite slike manje od %dMB."
@@ -2218,8 +2219,8 @@ msgstr "Omiljeno"
 msgid "Remove from favorites"
 msgstr "Ukloni iz omiljenih"
 
-#: src/olympia/bandwagon/views.py:98 src/olympia/bandwagon/views.py:191 src/olympia/browse/views.py:58 src/olympia/browse/views.py:69 src/olympia/browse/views.py:458 src/olympia/devhub/views.py:74
-#: src/olympia/devhub/views.py:82 src/olympia/devhub/templates/devhub/addons/edit/basic.html:20 src/olympia/editors/templates/editors/leaderboard.html:24
+#: src/olympia/bandwagon/views.py:98 src/olympia/bandwagon/views.py:191 src/olympia/browse/views.py:58 src/olympia/browse/views.py:69 src/olympia/browse/views.py:425 src/olympia/devhub/views.py:73
+#: src/olympia/devhub/views.py:81 src/olympia/devhub/templates/devhub/addons/edit/basic.html:20 src/olympia/editors/templates/editors/leaderboard.html:24
 #: src/olympia/editors/templates/editors/themes/queue_list.html:48 src/olympia/search/forms.py:17 src/olympia/search/forms.py:89 src/olympia/users/templates/users/vcard.html:5
 msgid "Name"
 msgstr "Ime"
@@ -2228,7 +2229,7 @@ msgstr "Ime"
 msgid "Recently Popular"
 msgstr "Skorije popularno"
 
-#: src/olympia/bandwagon/views.py:189 src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:18
+#: src/olympia/bandwagon/views.py:189 src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:16
 msgid "Added"
 msgstr "Dodato"
 
@@ -2242,8 +2243,8 @@ msgstr "Kolekcija je kreirana!"
 
 #: src/olympia/bandwagon/views.py:316
 #, python-format
-msgid "Your new collection is shown below. You can <ahref=\"%(url)s\">edit additional settings</a> if you'dlike."
-msgstr ""
+msgid "Your new collection is shown below. You can <a href=\"%(url)s\">edit additional settings</a> if you'd like."
+msgstr "Vaša nova kolekcija je prikazana ispod. Možete da <a href=\"%(url)s\">izmenite dodatne postavke</a> ako želite."
 
 #: src/olympia/bandwagon/views.py:322
 msgid "Collection updated!"
@@ -2323,7 +2324,6 @@ msgid "<span>%(num)s</span> follower"
 msgid_plural "<span>%(num)s</span> followers"
 msgstr[0] "Broj pratioca: <span>%(num)s</span>"
 msgstr[1] "Broj pratioca: <span>%(num)s</span>"
-msgstr[2] "Broj pratioca: <span>%(num)s</span>"
 
 #: src/olympia/bandwagon/templates/bandwagon/collection_detail.html:54
 msgid "About this Collection"
@@ -2363,7 +2363,6 @@ msgid "%(num)s Theme in this Collection"
 msgid_plural "%(num)s Themes in this Collection"
 msgstr[0] "Tema u ovoj kolekciji: %(num)s"
 msgstr[1] "Tema u ovoj kolekciji: %(num)s"
-msgstr[2] "Tema u ovoj kolekciji: %(num)s"
 
 #: src/olympia/bandwagon/templates/bandwagon/collection_detail.html:111
 #, python-format
@@ -2371,10 +2370,9 @@ msgid "%(num)s Add-on in this Collection"
 msgid_plural "%(num)s Add-ons in this Collection"
 msgstr[0] "Dodataka u ovoj kolekciji: %(num)s"
 msgstr[1] "Dodataka u ovoj kolekciji: %(num)s"
-msgstr[2] "Dodataka u ovoj kolekciji: %(num)s"
 
-#: src/olympia/bandwagon/templates/bandwagon/collection_detail.html:125 src/olympia/compat/templates/compat/index.html:25 src/olympia/compat/templates/compat/reporter_detail.html:29
-#: src/olympia/files/templates/files/viewer.html:29 src/olympia/templates/amo_footer.html:17 src/olympia/templates/includes/lang_switcher.html:10
+#: src/olympia/bandwagon/templates/bandwagon/collection_detail.html:125 src/olympia/compat/templates/compat/reporter_detail.html:29 src/olympia/files/templates/files/viewer.html:29
+#: src/olympia/templates/amo_footer.html:17 src/olympia/templates/includes/lang_switcher.html:10
 msgid "Go"
 msgstr "Kreni"
 
@@ -2424,7 +2422,6 @@ msgid "<span>%(addons)s</span> add-on"
 msgid_plural "<span>%(addons)s</span> add-ons"
 msgstr[0] "<span>%(addons)s</span> dodatak"
 msgstr[1] "<span>%(addons)s</span> dodataka"
-msgstr[2] "<span>%(addons)s</span> dodataka"
 
 #: src/olympia/bandwagon/templates/bandwagon/collection_grid.html:32
 #, python-format
@@ -2432,7 +2429,6 @@ msgid "<span>%(followers)s</span> follower"
 msgid_plural "<span>%(followers)s</span> followers"
 msgstr[0] "<span>%(followers)s</span> pratioc"
 msgstr[1] "<span>%(followers)s</span> pratioca"
-msgstr[2] "<span>%(followers)s</span> pratioca"
 
 #. People "follow" collections to get notified of updates.                    Like
 #. Twitter followers.
@@ -2444,7 +2440,6 @@ msgid "%(num)s weekly follower"
 msgid_plural "%(num)s weekly followers"
 msgstr[0] "Broj sedmičnih pratioca: %(num)s"
 msgstr[1] "Broj sedmičnih pratioca: %(num)s"
-msgstr[2] "Broj sedmičnih pratioca: %(num)s"
 
 #. People "follow" collections to get notified of updates.                    Like
 #. Twitter followers.
@@ -2454,7 +2449,6 @@ msgid "%(num)s monthly follower"
 msgid_plural "%(num)s monthly followers"
 msgstr[0] "Broj mesečnih pratioca: %(num)s"
 msgstr[1] "Broj mesečnih pratioca: %(num)s"
-msgstr[2] "Broj mesečnih pratioca: %(num)s"
 
 #. People "follow" collections to get notified of updates.                    Like
 #. Twitter followers.
@@ -2466,7 +2460,6 @@ msgid "%(num)s follower"
 msgid_plural "%(num)s followers"
 msgstr[0] "Broj pratioca: %(num)s"
 msgstr[1] "Broj pratioca: %(num)s"
-msgstr[2] "Broj pratioca: %(num)s"
 
 #: src/olympia/bandwagon/templates/bandwagon/collection_listing_items.html:56 src/olympia/bandwagon/templates/bandwagon/impala/collection_listing_items.html:9
 #: src/olympia/devhub/templates/devhub/personas/edit.html:27
@@ -2551,7 +2544,7 @@ msgid "Remove this user as a contributor"
 msgstr "Ukloni ovog korisnika kao saradnika"
 
 #: src/olympia/bandwagon/templates/bandwagon/edit_contributors.html:18 src/olympia/bandwagon/templates/bandwagon/edit_contributors.html:43
-#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:20 src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:48
+#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:18 src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:46
 #: src/olympia/devhub/templates/devhub/addons/ajax_compat_update.html:19
 msgid "Remove"
 msgstr "Ukloni"
@@ -2602,7 +2595,7 @@ msgid "<b>Warning:</b> By changing the owner of this collection, you will no lon
 msgstr "<b>Upozorenje:</b> Promenom vlasnika ove kolekcije, više nećete imati mogućnost njene izmene. Moći ćete samo da joj dodajete ili uklanjate dodatke."
 
 #: src/olympia/bandwagon/templates/bandwagon/edit_contributors.html:83 src/olympia/devhub/templates/devhub/addons/forms_shared/media.html:157
-#: src/olympia/devhub/templates/devhub/addons/submit/describe.html:69 src/olympia/devhub/templates/devhub/addons/submit/license.html:60 src/olympia/devhub/templates/devhub/addons/submit/upload.html:78
+#: src/olympia/devhub/templates/devhub/addons/submit/describe.html:69 src/olympia/devhub/templates/devhub/addons/submit/license.html:60 src/olympia/devhub/templates/devhub/addons/submit/upload.html:70
 #: src/olympia/devhub/templates/devhub/payments/tier.html:17 src/olympia/editors/templates/editors/themes/themes.html:111 src/olympia/editors/templates/editors/themes/themes.html:128
 #: src/olympia/editors/templates/editors/themes/themes.html:134 src/olympia/editors/templates/editors/themes/themes.html:141 src/olympia/users/templates/users/fxa_migration_prompt_content.html:10
 #: src/olympia/users/templates/users/login_form.html:42 src/olympia/users/templates/users/mobile/login.html:57
@@ -2685,32 +2678,31 @@ msgid "Add-ons in Your Collection"
 msgstr "Dodaci u Vašoj kolekciji"
 
 #: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:4
-msgid "To include an add-on in this collection, enter its name in the box below and hit enter. You can also use the <strong>Add to Collection</strong> links throughout the site to include add-ons later."
+msgid "To include an add-on in this collection, enter its name in the box below and hit enter."
 msgstr ""
-"Da biste stavili dodatak u ovu kolekciju, unesite njegov naziv u polju ispod i pritisnite Enter. Možete koristiti i veze <strong>Dodaj u kolekciju</strong> na čitavom sajtu kako biste dodali "
-"dodatke kasnije."
 
-#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:17 src/olympia/constants/base.py:400 src/olympia/devhub/templates/devhub/addons/activity.html:62
+#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:15 src/olympia/constants/base.py:400 src/olympia/devhub/templates/devhub/addons/activity.html:62
+#: src/olympia/editors/helpers.py:273 src/olympia/editors/helpers.py:360
 msgid "Add-on"
 msgstr "Dodatak"
 
-#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:26
+#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:24
 msgid "Enter the name of the add-on to include"
 msgstr "Unesite naziv dodatka da biste da dodali"
 
-#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:28
+#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:26
 msgid "Add to Collection"
 msgstr "Dodaj u kolekciju"
 
-#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:45 src/olympia/editors/helpers.py:936 src/olympia/editors/helpers.py:956
+#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:43 src/olympia/editors/helpers.py:1016 src/olympia/editors/helpers.py:1036
 msgid "Pending"
 msgstr "U toku"
 
-#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:47
+#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:45
 msgid "Add a comment"
 msgstr "Dodaj komentar"
 
-#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:48
+#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:46
 msgid "Remove this add-on from the collection"
 msgstr "Ukloni ovaj dodatak iz kolekcije"
 
@@ -2819,12 +2811,12 @@ msgstr "Alati za pretragu"
 msgid "Most Users"
 msgstr "Većina korisnika"
 
-#: src/olympia/browse/views.py:61 src/olympia/browse/views.py:72 src/olympia/browse/views.py:279 src/olympia/browse/templates/browse/personas/mobile/category_landing.html:63
+#: src/olympia/browse/views.py:61 src/olympia/browse/views.py:72 src/olympia/browse/views.py:246 src/olympia/browse/templates/browse/personas/mobile/category_landing.html:63
 #: src/olympia/discovery/templates/discovery/pane.html:67 src/olympia/search/forms.py:92
 msgid "Up & Coming"
 msgstr "Nadolazeće"
 
-#: src/olympia/browse/views.py:460 src/olympia/devhub/views.py:76 src/olympia/devhub/views.py:83 src/olympia/discovery/templates/discovery/addons/detail.html:66
+#: src/olympia/browse/views.py:427 src/olympia/devhub/views.py:75 src/olympia/devhub/views.py:82 src/olympia/discovery/templates/discovery/addons/detail.html:66
 msgid "Created"
 msgstr "Kreirano"
 
@@ -2905,7 +2897,6 @@ msgid "<b>{0}</b> add-on"
 msgid_plural "<b>{0}</b> add-ons"
 msgstr[0] "<b>{0}</b> dodatak"
 msgstr[1] "<b>{0}</b> dodataka"
-msgstr[2] "<b>{0}</b> dodataka"
 
 #: src/olympia/browse/templates/browse/search_tools.html:61
 msgid "Search Extensions"
@@ -3012,10 +3003,9 @@ msgid "See the %(cnt)s extension in %(name)s &raquo;"
 msgid_plural "See all %(cnt)s extensions in %(name)s &raquo;"
 msgstr[0] "Pogledajte svako %(cnt)s proširenje u %(name)s &raquo;"
 msgstr[1] "Pogledajte svaka %(cnt)s proširenja u %(name)s &raquo;"
-msgstr[2] "Pogledajte svih %(cnt)s proširenja u %(name)s &raquo;"
 
-#: src/olympia/browse/templates/browse/mobile/extensions.html:13 src/olympia/compat/templates/compat/index.html:82 src/olympia/devhub/templates/devhub/devhub_search.html:24
-#: src/olympia/devhub/templates/devhub/addons/activity.html:47 src/olympia/search/templates/search/no_results.html:4 src/olympia/search/templates/search/mobile/results.html:36
+#: src/olympia/browse/templates/browse/mobile/extensions.html:13 src/olympia/devhub/templates/devhub/devhub_search.html:24 src/olympia/devhub/templates/devhub/addons/activity.html:47
+#: src/olympia/search/templates/search/no_results.html:4 src/olympia/search/templates/search/mobile/results.html:36
 msgid "No results found."
 msgstr "Nema pronađenih rezultata."
 
@@ -3100,7 +3090,7 @@ msgstr "&laquo; Sve teme"
 msgid "All"
 msgstr "Sve"
 
-#: src/olympia/compat/forms.py:22 src/olympia/search/views.py:525
+#: src/olympia/compat/forms.py:22 src/olympia/editors/templates/editors/base.html:69 src/olympia/search/views.py:518
 msgid "All Add-ons"
 msgstr "Svi dodaci"
 
@@ -3111,53 +3101,6 @@ msgstr "Binarno"
 #: src/olympia/compat/forms.py:24
 msgid "Non-binary"
 msgstr "Ne-binarno"
-
-#. Review points sources other than add-ons and themes.
-#: src/olympia/compat/views.py:87 src/olympia/constants/base.py:388 src/olympia/devhub/forms.py:162 src/olympia/editors/templates/editors/performance.html:75
-msgid "Other"
-msgstr "Drugo"
-
-#: src/olympia/compat/templates/compat/index.html:4
-msgid "Add-on Compatibility Report for {app} {version}"
-msgstr "Izveštaj o kompatibilnosti dodatka za {app} {version}"
-
-#: src/olympia/compat/templates/compat/index.html:11
-msgid "{app} {version} Compatibility"
-msgstr "{app} {version} kompatibilnost"
-
-#: src/olympia/compat/templates/compat/index.html:17
-#, python-format
-msgid "Top 95%% compatible with previous version"
-msgstr ""
-
-#: src/olympia/compat/templates/compat/index.html:18
-#, python-format
-msgid "Top 95%% of all add-ons"
-msgstr ""
-
-#: src/olympia/compat/templates/compat/index.html:19
-msgid "All active add-ons"
-msgstr "Svi aktivni dodaci"
-
-#: src/olympia/compat/templates/compat/index.html:23 src/olympia/constants/base.py:401
-msgid "App"
-msgstr "Aplikacija"
-
-#: src/olympia/compat/templates/compat/index.html:55
-msgid "Details for add-ons compatible with previous version:"
-msgstr "Detalji za dodatke kompatibilne sa prethodnom verzijom:"
-
-#: src/olympia/compat/templates/compat/index.html:57
-msgid "Show all versions"
-msgstr "Prikaži sve verzije"
-
-#: src/olympia/compat/templates/compat/index.html:59
-msgid "Details for add-ons compatible with all versions:"
-msgstr "Detalji za dodatke kompatibilne sa svim verzijama:"
-
-#: src/olympia/compat/templates/compat/index.html:61
-msgid "Show previous version only"
-msgstr "Prikaži samo prethodnu verziju"
 
 #: src/olympia/compat/templates/compat/reporter.html:3
 msgid "Add-on Compatibility Reports"
@@ -3193,14 +3136,12 @@ msgid "{0} success report"
 msgid_plural "{0} success reports"
 msgstr[0] "{0} izveštaj o uspehu"
 msgstr[1] "{0} izveštaja o uspehu"
-msgstr[2] "{0} izveštaja o uspehu"
 
 #: src/olympia/compat/templates/compat/reporter_detail.html:17
 msgid "{0} problem report"
 msgid_plural "{0} problem reports"
 msgstr[0] "{0} izveštaj o problemu"
 msgstr[1] "{0} izveštaja o problemu"
-msgstr[2] "{0} izveštaja o problemu"
 
 #: src/olympia/compat/templates/compat/reporter_detail.html:21 src/olympia/users/templates/users/profile.html:70
 msgid "View all"
@@ -3214,8 +3155,8 @@ msgstr "Filtriraj po aplikaciji"
 msgid "Report Type"
 msgstr "Tip izveštaja"
 
-#: src/olympia/compat/templates/compat/reporter_detail.html:47 src/olympia/devhub/forms.py:784 src/olympia/devhub/templates/devhub/addons/ajax_compat_update.html:17 src/olympia/editors/forms.py:108
-#: src/olympia/zadmin/forms.py:45
+#: src/olympia/compat/templates/compat/reporter_detail.html:47 src/olympia/devhub/forms.py:785 src/olympia/devhub/templates/devhub/addons/ajax_compat_update.html:17 src/olympia/editors/forms.py:108
+#: src/olympia/editors/forms.py:248 src/olympia/zadmin/forms.py:45
 msgid "Application"
 msgstr "Aplikacija"
 
@@ -3303,7 +3244,8 @@ msgstr "Preliminarno recenzirano"
 msgid "Preliminarily Reviewed and Awaiting Full Review"
 msgstr "Preliminarno pregledano i čeka potpunu recenziju"
 
-#: src/olympia/constants/base.py:33 src/olympia/editors/helpers.py:924 src/olympia/editors/templates/editors/themes/history_table.html:34
+#: src/olympia/constants/base.py:33 src/olympia/editors/forms.py:258 src/olympia/editors/helpers.py:73 src/olympia/editors/helpers.py:1004
+#: src/olympia/editors/templates/editors/themes/history_table.html:34
 msgid "Deleted"
 msgstr "Obrisano"
 
@@ -3403,6 +3345,11 @@ msgstr "Pitajte nakon što korisnici preuzmu ovaj dodatak"
 msgid "Ask before users can download this add-on"
 msgstr "Pitajte pre nego što korisnici preuzmu ovaj dodatak"
 
+#. Review points sources other than add-ons and themes.
+#: src/olympia/constants/base.py:388 src/olympia/devhub/forms.py:162 src/olympia/editors/templates/editors/performance.html:75
+msgid "Other"
+msgstr "Drugo"
+
 #: src/olympia/constants/base.py:389
 msgid "Exception"
 msgstr "Izuzetak"
@@ -3414,6 +3361,10 @@ msgstr "Izdanje"
 #: src/olympia/constants/base.py:391
 msgid "Change"
 msgstr "Izmena"
+
+#: src/olympia/constants/base.py:401
+msgid "App"
+msgstr "Aplikacija"
 
 #: src/olympia/constants/base.py:402
 msgid "Persona"
@@ -3563,7 +3514,7 @@ msgstr "Označi"
 msgid "Duplicate"
 msgstr "Duplikat"
 
-#: src/olympia/constants/editors.py:17 src/olympia/editors/helpers.py:502 src/olympia/editors/templates/editors/themes/queue.html:71 src/olympia/editors/templates/editors/themes/themes.html:94
+#: src/olympia/constants/editors.py:17 src/olympia/editors/helpers.py:575 src/olympia/editors/templates/editors/themes/queue.html:71 src/olympia/editors/templates/editors/themes/themes.html:94
 msgid "Reject"
 msgstr "Odbij"
 
@@ -3663,7 +3614,7 @@ msgstr "Solaris"
 msgid "Android"
 msgstr "Android"
 
-#: src/olympia/core/apps.py:19
+#: src/olympia/core/apps.py:21
 msgid "Core"
 msgstr ""
 
@@ -3797,7 +3748,7 @@ msgid "Submit my add-on for manual review."
 msgstr ""
 
 #: src/olympia/devhub/forms.py:537
-msgid "Do not list my add-on on this site (beta)"
+msgid "Do not list my add-on on this site"
 msgstr ""
 
 #: src/olympia/devhub/forms.py:538
@@ -3830,46 +3781,46 @@ msgstr ""
 
 #: src/olympia/devhub/forms.py:592
 #, python-format
-msgid "Version %s already exists"
-msgstr "Verzija %s već postoji"
+msgid "Version %s already exists, or was uploaded before."
+msgstr ""
 
-#: src/olympia/devhub/forms.py:604
+#: src/olympia/devhub/forms.py:605
 msgid "Select a valid choice. That choice is not one of the available choices."
 msgstr "Odaberite ispravan izbor. Taj izbor nije jedan od dostupnih izbora."
 
-#: src/olympia/devhub/forms.py:610
+#: src/olympia/devhub/forms.py:611
 msgid "A file with a version ending with a|alpha|b|beta and an optional number is detected as beta."
 msgstr "Datoteka sa verzijom koja se završava sa a|alfa|b|beta i opcionim brojem je detektovana kao beta."
 
-#: src/olympia/devhub/forms.py:633
+#: src/olympia/devhub/forms.py:634
 msgid "You cannot upload any more files for this version."
 msgstr "Ne možete više datoteka otpremiti za ovu verziju."
 
-#: src/olympia/devhub/forms.py:639
+#: src/olympia/devhub/forms.py:640
 msgid "Version doesn't match"
 msgstr "Verzije se ne poklapaju"
 
-#: src/olympia/devhub/forms.py:668
+#: src/olympia/devhub/forms.py:669
 msgid "You cannot delete a file once the review process has started. You must delete the whole version."
 msgstr "Ne možete obrisati datoteku čim proces recenzije započne. Morate obrisati celu verziju."
 
-#: src/olympia/devhub/forms.py:688
+#: src/olympia/devhub/forms.py:689
 msgid "The platform All cannot be combined with specific platforms."
 msgstr "Platforma Sve ne može se ukombinovati sa određenim platformama."
 
-#: src/olympia/devhub/forms.py:693
+#: src/olympia/devhub/forms.py:694
 msgid "A platform can only be chosen once."
 msgstr "Platforma se može samo jednom izabrati."
 
-#: src/olympia/devhub/forms.py:706
+#: src/olympia/devhub/forms.py:707
 msgid "A review type must be selected."
 msgstr "Morate izabrati tip recenzije."
 
-#: src/olympia/devhub/forms.py:788 src/olympia/editors/forms.py:114 src/olympia/zadmin/forms.py:49 src/olympia/zadmin/forms.py:52
+#: src/olympia/devhub/forms.py:789 src/olympia/editors/forms.py:114 src/olympia/editors/forms.py:254 src/olympia/zadmin/forms.py:49 src/olympia/zadmin/forms.py:52
 msgid "Select an application first"
 msgstr "Prvo izaberite aplikaciju"
 
-#: src/olympia/devhub/forms.py:840
+#: src/olympia/devhub/forms.py:841
 msgid "There cannot be more than 3 required add-ons."
 msgstr "Ne može biti više od 3 zahtevana dodatka."
 
@@ -3892,7 +3843,6 @@ msgid "{0} error"
 msgid_plural "{0} errors"
 msgstr[0] "{0} greška"
 msgstr[1] "{0} greške"
-msgstr[2] "{0} grešaka"
 
 # {0} is a number
 #. L10n: first parameter is the number of warnings
@@ -3901,166 +3851,165 @@ msgid "{0} warning"
 msgid_plural "{0} warnings"
 msgstr[0] "{0} upozorenje"
 msgstr[1] "{0} upozorenja"
-msgstr[2] "{0} upozorenja"
 
 #: src/olympia/devhub/models.py:375 src/olympia/reviews/templates/reviews/add.html:58
 msgid "Review"
 msgstr "Pregled"
 
-#: src/olympia/devhub/tasks.py:551
+#: src/olympia/devhub/tasks.py:583
 #, python-format
 msgid "%s responded with %s (%s)."
 msgstr "%s je odgovorio sa %s (%s)."
 
-#: src/olympia/devhub/tasks.py:555
+#: src/olympia/devhub/tasks.py:587
 #, python-format
 msgid "Connection to \"%s\" timed out."
 msgstr "Konekcija na \"%s\" je istekla."
 
-#: src/olympia/devhub/tasks.py:557
+#: src/olympia/devhub/tasks.py:589
 #, python-format
 msgid "Could not contact host at \"%s\"."
 msgstr "Nismo mogli kontaktirati host na \"%s\"."
 
-#: src/olympia/devhub/utils.py:104
+#: src/olympia/devhub/utils.py:105
 #, python-format
 msgid "Validation generated too many errors/warnings so %s messages were truncated. After addressing the visible messages, you'll be able to see the others."
 msgstr "Overa je stvorila previše grešaka/upozorenja pa je %s poruka skraćeno. Nakon obraćanja vidljivim porukama, bićete u mogućnosti da pogledate ostale."
 
-#: src/olympia/devhub/views.py:183
+#: src/olympia/devhub/views.py:182
 msgid "All My Add-ons"
 msgstr "Svi moji dodaci"
 
-#: src/olympia/devhub/views.py:210
+#: src/olympia/devhub/views.py:209
 msgid "All Activity"
 msgstr "Sva aktivnost"
 
-#: src/olympia/devhub/views.py:211
+#: src/olympia/devhub/views.py:210
 msgid "Add-on Updates"
 msgstr "Ažuriranja dodatka"
 
-#: src/olympia/devhub/views.py:212
+#: src/olympia/devhub/views.py:211
 msgid "Add-on Status"
 msgstr "Status dodatka"
 
-#: src/olympia/devhub/views.py:213
+#: src/olympia/devhub/views.py:212
 msgid "User Collections"
 msgstr "Korisničke zbirke"
 
-#: src/olympia/devhub/views.py:214 src/olympia/devhub/templates/devhub/docs/policies-maintenance.html:68 src/olympia/pages/templates/pages/dev_faq.html:38
+#: src/olympia/devhub/views.py:213 src/olympia/devhub/templates/devhub/docs/policies-maintenance.html:68 src/olympia/pages/templates/pages/dev_faq.html:38
 #: src/olympia/pages/templates/pages/dev_faq.html:484
 msgid "User Reviews"
 msgstr "Recenzije korisnika"
 
-#: src/olympia/devhub/views.py:327 src/olympia/devhub/views.py:331 src/olympia/devhub/views.py:484 src/olympia/devhub/views.py:513 src/olympia/devhub/views.py:564 src/olympia/devhub/views.py:1150
+#: src/olympia/devhub/views.py:326 src/olympia/devhub/views.py:330 src/olympia/devhub/views.py:485 src/olympia/devhub/views.py:514 src/olympia/devhub/views.py:565 src/olympia/devhub/views.py:1157
 msgid "Changes successfully saved."
 msgstr "Izmene su uspešno sačuvane."
 
-#: src/olympia/devhub/views.py:334 src/olympia/devhub/views.py:1631
+#: src/olympia/devhub/views.py:333 src/olympia/devhub/views.py:1638
 msgid "Please check the form for errors."
 msgstr "Molimo Vas proverite da li ima grešaka u formi."
 
-#: src/olympia/devhub/views.py:346
+#: src/olympia/devhub/views.py:345
 msgid "Add-on cannot be deleted. Disable this add-on instead."
 msgstr "Dodatak se ne može izbrisati. Umesto toga ga onemogućite."
 
-#: src/olympia/devhub/views.py:356
+#: src/olympia/devhub/views.py:355
 msgid "Theme deleted."
 msgstr "Tema obrisana."
 
-#: src/olympia/devhub/views.py:356
+#: src/olympia/devhub/views.py:355
 msgid "Add-on deleted."
 msgstr "Dodatak obrisan."
 
-#: src/olympia/devhub/views.py:362
+#: src/olympia/devhub/views.py:361
 msgid "URL name was incorrect. Theme was not deleted."
 msgstr ""
 
-#: src/olympia/devhub/views.py:367
+#: src/olympia/devhub/views.py:366
 msgid "URL name was incorrect. Add-on was not deleted."
 msgstr ""
 
-#: src/olympia/devhub/views.py:449
+#: src/olympia/devhub/views.py:450
 msgid "An author has been added to your add-on"
 msgstr "Autor je dodat Vašem dodatku"
 
-#: src/olympia/devhub/views.py:456
+#: src/olympia/devhub/views.py:457
 msgid "An author has a role changed on your add-on"
 msgstr "Autor je promenio ulogu Vašeg dodatka"
 
-#: src/olympia/devhub/views.py:476
+#: src/olympia/devhub/views.py:477
 msgid "An author has been removed from your add-on"
 msgstr "Autor je uklonjen sa Vašeg dodatka"
 
-#: src/olympia/devhub/views.py:519
+#: src/olympia/devhub/views.py:520
 msgid "There were errors in your submission."
 msgstr "Postoje greške u Vašoj dostavi."
 
-#: src/olympia/devhub/views.py:583
+#: src/olympia/devhub/views.py:584
 msgid "Validate Add-on"
 msgstr "Overite dodatak"
 
-#: src/olympia/devhub/views.py:594
+#: src/olympia/devhub/views.py:595
 msgid "Check Add-on Compatibility"
 msgstr "Proverite kompatibilnost dodatka"
 
-#: src/olympia/devhub/views.py:808 src/olympia/signing/views.py:90
+#: src/olympia/devhub/views.py:809 src/olympia/signing/views.py:95
 msgid "You cannot submit this type of add-on"
 msgstr ""
 
-#: src/olympia/devhub/views.py:1051 src/olympia/users/forms.py:471
+#: src/olympia/devhub/views.py:1052 src/olympia/users/forms.py:471
 msgid "Images must be either PNG or JPG."
 msgstr "Slike moraju biti ili PNG ili JPG formata."
 
-#: src/olympia/devhub/views.py:1055
+#: src/olympia/devhub/views.py:1056
 msgid "Icons cannot be animated."
 msgstr "Ikonice ne mogu biti pokretne."
 
-#: src/olympia/devhub/views.py:1057
+#: src/olympia/devhub/views.py:1058
 msgid "Images cannot be animated."
 msgstr "Slike ne mogu biti pokretne."
 
-#: src/olympia/devhub/views.py:1070
+#: src/olympia/devhub/views.py:1071
 #, python-format
 msgid "Images cannot be larger than %dKB."
 msgstr "Slike ne mogu biti veće od %dKB."
 
 #. L10n: {0} is an image width (in pixels), {1} is a height.
-#: src/olympia/devhub/views.py:1080
+#: src/olympia/devhub/views.py:1081
 msgid "Image must be exactly {0} pixels wide and {1} pixels tall."
 msgstr "Slika mora biti široka tačno {0} piksela i visoka {1} piksela."
 
-#: src/olympia/devhub/views.py:1087
+#: src/olympia/devhub/views.py:1088
 msgid "There was an error uploading your preview."
 msgstr "Došlo je do greške prilikom otpremanja Vašeg pregleda."
 
-#: src/olympia/devhub/views.py:1189
+#: src/olympia/devhub/views.py:1196
 #, python-format
 msgid "Version %s disabled."
 msgstr "Verzija %s onemogućena."
 
-#: src/olympia/devhub/views.py:1193
+#: src/olympia/devhub/views.py:1200
 #, python-format
 msgid "Version %s deleted."
 msgstr "Verzija %s izbrisana."
 
-#: src/olympia/devhub/views.py:1203
+#: src/olympia/devhub/views.py:1210
 msgid "This upload has failed validation, and may lack complete validation results. Please take due care when reviewing it."
 msgstr "Otpremanje nije prošlo validaciju, i možda ne sadrži potpune rezultate validacije. Molimo Vas, dobro proverite prilikom pregledavanja."
 
-#: src/olympia/devhub/views.py:1677
+#: src/olympia/devhub/views.py:1684
 msgid "Preliminary Review Requested."
 msgstr "Zahtevana preliminarna recenzija."
 
-#: src/olympia/devhub/views.py:1678
+#: src/olympia/devhub/views.py:1685
 msgid "Full Review Requested."
 msgstr "Zahtevana potpuna recenzija."
 
-#: src/olympia/devhub/views.py:1779
+#: src/olympia/devhub/views.py:1786
 msgid "Your old credentials were revoked and are no longer valid. Be sure to update all API clients with the new credentials."
 msgstr ""
 
-#: src/olympia/devhub/views.py:1797
+#: src/olympia/devhub/views.py:1804
 msgid "New API key created"
 msgstr ""
 
@@ -4090,7 +4039,7 @@ msgstr "Nazad na dodatke"
 msgid "{0} :: Search"
 msgstr "{0} :: Pretraži"
 
-#: src/olympia/devhub/templates/devhub/devhub_search.html:6 src/olympia/devhub/templates/devhub/search.html:8 src/olympia/editors/forms.py:435 src/olympia/editors/forms.py:437
+#: src/olympia/devhub/templates/devhub/devhub_search.html:6 src/olympia/devhub/templates/devhub/search.html:8 src/olympia/editors/forms.py:534 src/olympia/editors/forms.py:536
 #: src/olympia/editors/templates/editors/queue.html:27 src/olympia/editors/templates/editors/themes/queue_list.html:14 src/olympia/search/templates/search/collections.html:17
 #: src/olympia/search/templates/search/personas.html:18 src/olympia/search/templates/search/results.html:18 src/olympia/search/templates/search/mobile/results.html:8 src/olympia/templates/search.html:14
 #: src/olympia/templates/impala/search.html:18
@@ -4150,12 +4099,12 @@ msgstr ""
 msgid "Start Making Add-ons"
 msgstr "Krenite praviti dodatke"
 
-#: src/olympia/devhub/templates/devhub/index.html:86 src/olympia/devhub/templates/devhub/addons/listing/items.html:25 src/olympia/devhub/templates/devhub/includes/addon_details.html:15
+#: src/olympia/devhub/templates/devhub/index.html:86 src/olympia/devhub/templates/devhub/addons/listing/items.html:25 src/olympia/devhub/templates/devhub/includes/addon_details.html:20
 #: src/olympia/devhub/templates/devhub/personas/edit.html:43
 msgid "Status:"
 msgstr "Status:"
 
-#: src/olympia/devhub/templates/devhub/index.html:90 src/olympia/devhub/templates/devhub/includes/addon_details.html:100
+#: src/olympia/devhub/templates/devhub/index.html:90 src/olympia/devhub/templates/devhub/includes/addon_details.html:87
 msgid "Visibility:"
 msgstr ""
 
@@ -4163,11 +4112,11 @@ msgstr ""
 msgid "Latest Version:"
 msgstr "Poslednja verzija:"
 
-#: src/olympia/devhub/templates/devhub/index.html:109 src/olympia/devhub/templates/devhub/includes/addon_details.html:145 src/olympia/devhub/templates/devhub/personas/edit.html:49
+#: src/olympia/devhub/templates/devhub/index.html:109 src/olympia/devhub/templates/devhub/includes/addon_details.html:131 src/olympia/devhub/templates/devhub/personas/edit.html:49
 msgid "Queue Position:"
 msgstr "Red pozicije:"
 
-#: src/olympia/devhub/templates/devhub/index.html:110 src/olympia/devhub/templates/devhub/includes/addon_details.html:146 src/olympia/devhub/templates/devhub/personas/edit.html:50
+#: src/olympia/devhub/templates/devhub/index.html:110 src/olympia/devhub/templates/devhub/includes/addon_details.html:132 src/olympia/devhub/templates/devhub/personas/edit.html:50
 #, python-format
 msgid "%(position)s of %(total)s"
 msgstr "%(position)s od %(total)s"
@@ -4269,16 +4218,6 @@ msgstr "Nakon otpremanja, niz automatizovanih testova validacije će biti pokren
 msgid "Do you want your add-on to be distributed on this site?"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/validate_addon.html:49 src/olympia/devhub/templates/devhub/addons/submit/upload.html:30 src/olympia/devhub/templates/devhub/versions/add_file_modal.html:14
-#: src/olympia/devhub/templates/devhub/versions/add_file_modal.html:53 src/olympia/devhub/templates/devhub/versions/list.html:298
-msgid "Warning:"
-msgstr ""
-
-#: src/olympia/devhub/templates/devhub/validate_addon.html:50 src/olympia/devhub/templates/devhub/addons/submit/upload.html:31
-#, python-format
-msgid "Submission of unlisted add-ons for signing is currently in an open beta. Please <a href=\"%(url)s\" target=\"_blank\">report any bugs</a> that you encounter."
-msgstr ""
-
 #. first parameter is a filename like lorem-ipsum-1.0.2.xpi
 #: src/olympia/devhub/templates/devhub/validation.html:5
 msgid "Validation Results for {0}"
@@ -4357,7 +4296,7 @@ msgstr "Kompatibilnost"
 msgid "Update Compatibility"
 msgstr "Ažuriranje kompatibilnosti"
 
-#: src/olympia/devhub/templates/devhub/addons/ajax_compat_update.html:4
+#: src/olympia/devhub/templates/devhub/addons/ajax_compat_update.html:4 src/olympia/devhub/templates/devhub/versions/edit.html:45
 msgid "Adjusting application information here will allow users to install your add-on even if the install manifest in the package indicates that the add-on is incompatible."
 msgstr "Podešavanje informacije o aplikaciji ovde će dozvoliti korisnicima da instaliraju Vaš dodatak čak iako manifest instalacije u paketu ukazuje da je dodatak nekompatibilan."
 
@@ -4369,9 +4308,9 @@ msgstr "Podržane verzije"
 msgid "Add Another Application&hellip;"
 msgstr "Dodaj drugu aplikaciju&hellip;"
 
-#: src/olympia/devhub/templates/devhub/addons/ajax_compat_update.html:38 src/olympia/devhub/templates/devhub/addons/owner.html:86 src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:46
-#: src/olympia/devhub/templates/devhub/versions/list.html:351 src/olympia/devhub/templates/devhub/versions/list.html:353 src/olympia/templates/impala/base.html:132
-#: src/olympia/templates/impala/base.html:143 src/olympia/templates/impala/base.html:161 src/olympia/templates/impala/base.html:171
+#: src/olympia/devhub/templates/devhub/addons/ajax_compat_update.html:38 src/olympia/devhub/templates/devhub/addons/owner.html:86 src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:45
+#: src/olympia/devhub/templates/devhub/versions/list.html:349 src/olympia/devhub/templates/devhub/versions/list.html:351 src/olympia/templates/impala/base.html:129
+#: src/olympia/templates/impala/base.html:140 src/olympia/templates/impala/base.html:158 src/olympia/templates/impala/base.html:168
 msgid "Close"
 msgstr "Zatvori"
 
@@ -4390,7 +4329,6 @@ msgid "<b>{0}</b> theme"
 msgid_plural "<b>{0}</b> themes"
 msgstr[0] "<b>{0}</b> tema"
 msgstr[1] "<b>{0}</b> teme"
-msgstr[2] "<b>{0}</b> tema"
 
 #: src/olympia/devhub/templates/devhub/addons/edit.html:3 src/olympia/devhub/templates/devhub/addons/listing/item_actions.html:25
 #: src/olympia/devhub/templates/devhub/addons/listing/item_actions_theme.html:7 src/olympia/devhub/templates/devhub/includes/addons_edit_nav.html:2
@@ -4406,7 +4344,7 @@ msgstr "Nema"
 msgid "Manage Authors & License"
 msgstr "Upravljajte Autorima i licencama"
 
-#: src/olympia/devhub/templates/devhub/addons/owner.html:29 src/olympia/editors/templates/editors/review.html:270
+#: src/olympia/devhub/templates/devhub/addons/owner.html:29 src/olympia/editors/helpers.py:362 src/olympia/editors/templates/editors/review.html:270
 msgid "Authors"
 msgstr "Autori"
 
@@ -4477,18 +4415,11 @@ msgid "Summary"
 msgstr "Rezime"
 
 #: src/olympia/devhub/templates/devhub/addons/edit/basic.html:52
-msgid ""
-"A short explanation of your add-on's basic\n"
-"                          functionality that is displayed in search and browse\n"
-"                          listings, as well as at the top of your add-on's\n"
-"                          details page. It is only relevant for listed add-ons."
+msgid "A short explanation of your add-on's basic functionality that is displayed in search and browse listings, as well as at the top of your add-on's details page. It is only relevant for listed add-ons."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/basic.html:73
-msgid ""
-"Categories are the primary way users browse through add-ons.\n"
-"                        Choose any that fit your add-on's functionality for the most\n"
-"                        exposure. It is only relevant for listed add-ons."
+msgid "Categories are the primary way users browse through add-ons. Choose any that fit your add-on's functionality for the most exposure. It is only relevant for listed add-ons."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/basic.html:90
@@ -4499,11 +4430,7 @@ msgstr ""
 "kategorija."
 
 #: src/olympia/devhub/templates/devhub/addons/edit/basic.html:119
-msgid ""
-"Tags help users find your add-on and should be short\n"
-"                        descriptors such as tabs, toolbar, or twitter.  You\n"
-"                        may have a maximum of {0} tags. It is only relevant\n"
-"                        for listed add-ons."
+msgid "Tags help users find your add-on and should be short descriptors such as tabs, toolbar, or twitter. You may have a maximum of {0} tags. It is only relevant for listed add-ons."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/basic.html:129 src/olympia/devhub/templates/devhub/personas/edit.html:97 src/olympia/devhub/templates/devhub/personas/submit.html:46
@@ -4511,7 +4438,6 @@ msgid "Comma-separated, minimum of {0} character."
 msgid_plural "Comma-separated, minimum of {0} characters."
 msgstr[0] "Razdvojeno zarezima, najmanje {0} karakter."
 msgstr[1] "Razdvojeno zarezima, najmanje {0} karaktera."
-msgstr[2] "Razdvojeno zarezima, najmanje {0} karaktera."
 
 #: src/olympia/devhub/templates/devhub/addons/edit/basic.html:132 src/olympia/devhub/templates/devhub/personas/edit.html:100 src/olympia/devhub/templates/devhub/personas/submit.html:49
 msgid "Example: dark, cinema, noir. Limit 20."
@@ -4522,7 +4448,6 @@ msgid "Reserved tag:"
 msgid_plural "Reserved tags:"
 msgstr[0] "Rezervisana oznaka:"
 msgstr[1] "Rezervisane oznake:"
-msgstr[2] "Rezervisane oznake:"
 
 #: src/olympia/devhub/templates/devhub/addons/edit/details.html:5
 msgid "Add-on Details"
@@ -4533,11 +4458,7 @@ msgid "Add-on Details for {0}"
 msgstr "Detalji dodatka za {0}"
 
 #: src/olympia/devhub/templates/devhub/addons/edit/details.html:22
-msgid ""
-"A longer explanation of features,\n"
-"                          functionality, and other relevant information. This\n"
-"                          field is only displayed on the add-on's details\n"
-"                          page. It is only relevant for listed add-ons."
+msgid "A longer explanation of features, functionality, and other relevant information. This field is only displayed on the add-on's details page. It is only relevant for listed add-ons."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/details.html:44 src/olympia/translations/templates/translations/trans-menu.html:13
@@ -4545,10 +4466,7 @@ msgid "Default Locale"
 msgstr "Podrazumevani lokal"
 
 #: src/olympia/devhub/templates/devhub/addons/edit/details.html:45
-msgid ""
-"Information about your add-on is displayed in this locale\n"
-"                        unless you override it with a locale-specific translation.\n"
-"                        It is only relevant for listed add-ons."
+msgid "Information about your add-on is displayed in this locale unless you override it with a locale-specific translation. It is only relevant for listed add-ons."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/details.html:61 src/olympia/users/forms.py:311 src/olympia/users/templates/users/edit.html:122 src/olympia/users/templates/users/register.html:57
@@ -4558,10 +4476,8 @@ msgstr "Početna"
 
 #: src/olympia/devhub/templates/devhub/addons/edit/details.html:63
 msgid ""
-"If your add-on has another homepage, enter its\n"
-"                          address here. If your website is localized into other\n"
-"                          languages multiple translations of this field can be\n"
-"                          added. It is only relevant for listed add-ons."
+"If your add-on has another homepage, enter its address here. If your website is localized into other languages multiple translations of this field can be added. It is only relevant for listed add-"
+"ons."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/media.html:3
@@ -4579,19 +4495,14 @@ msgstr "Informacije o podršci za {0}"
 
 #: src/olympia/devhub/templates/devhub/addons/edit/support.html:22
 msgid ""
-"If you wish to display an e-mail address for support\n"
-"                          inquiries, enter it here. If you have different\n"
-"                          addresses for each language multiple translations of\n"
-"                          this field can be added. It is only relevant for\n"
-"                          listed add-ons."
+"If you wish to display an e-mail address for support inquiries, enter it here. If you have different addresses for each language multiple translations of this field can be added. It is only "
+"relevant for listed add-ons."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/support.html:45
 msgid ""
-"If your add-on has a support website or forum, enter\n"
-"                          its address here. If your website is localized into\n"
-"                          other languages, multiple translations of this field can\n"
-"                          be added. It is only relevant for listed add-ons."
+"If your add-on has a support website or forum, enter its address here. If your website is localized into other languages, multiple translations of this field can be added. It is only relevant for "
+"listed add-ons."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:6
@@ -4605,11 +4516,8 @@ msgstr "Tehnički detalji za {0}"
 
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:23
 msgid ""
-"Any information end users may want to know that isn't\n"
-"                          necessarily applicable to the add-on summary or description.\n"
-"                          Common uses include listing known major bugs, information on\n"
-"                          how to report bugs, anticipated release date of a new version,\n"
-"                          etc. It is only relevant for listed add-ons."
+"Any information end users may want to know that isn't necessarily applicable to the add-on summary or description. Common uses include listing known major bugs, information on how to report bugs, "
+"anticipated release date of a new version, etc. It is only relevant for listed add-ons."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:46
@@ -4621,9 +4529,7 @@ msgid "Add-on Flags"
 msgstr "Oznake dodatka"
 
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:69
-msgid ""
-"These flags are used to classify add-ons. It is only\n"
-"                        relevant for listed add-ons."
+msgid "These flags are used to classify add-ons. It is only relevant for listed add-ons."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:74
@@ -4639,9 +4545,7 @@ msgid "View Source?"
 msgstr "Pogledati izvor?"
 
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:90
-msgid ""
-"Whether the source of your add-on can be displayed in our\n"
-"                        online viewer. It is only relevant for listed add-ons."
+msgid "Whether the source of your add-on can be displayed in our online viewer. It is only relevant for listed add-ons."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:94
@@ -4657,10 +4561,7 @@ msgid "Public Stats?"
 msgstr "Javna statistika?"
 
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:102
-msgid ""
-"Whether the download and usage stats of your add-on can\n"
-"                        be displayed in our online viewer.\n"
-"                        It is only relevant for listed add-ons."
+msgid "Whether the download and usage stats of your add-on can be displayed in our online viewer. It is only relevant for listed add-ons."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:107
@@ -4676,10 +4577,7 @@ msgid "Upgrade SDK?"
 msgstr "Nadograditi SDK?"
 
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:116
-msgid ""
-"If selected, we will try to automatically upgrade your\n"
-"                        add-on when a new version of the SDK is released.\n"
-"                        It is only relevant for listed add-ons."
+msgid "If selected, we will try to automatically upgrade your add-on when a new version of the SDK is released. It is only relevant for listed add-ons."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:121
@@ -4730,10 +4628,8 @@ msgstr "Ikonica dodatka"
 
 #: src/olympia/devhub/templates/devhub/addons/forms_shared/media.html:16
 msgid ""
-"Upload an icon for your add-on or choose from one of ours. The\n"
-"                      icon is displayed nearly everywhere your add-on is. Uploaded images\n"
-"                      must be one of the following image types: .png, .jpg.\n"
-"                      It is only relevant for listed add-ons."
+"Upload an icon for your add-on or choose from one of ours. The icon is displayed nearly everywhere your add-on is. Uploaded images must be one of the following image types: .png, .jpg. It is only "
+"relevant for listed add-ons."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/forms_shared/media.html:25
@@ -4841,16 +4737,14 @@ msgid "Deleting your add-on will permanently remove it from the site and prevent
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:24
-msgid ""
-"Enter the following text confirm your decision:\n"
-"           {slug}"
+msgid "Enter the following text confirm your decision: {slug}"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:34
+#: src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:33
 msgid "Please tell us why you are deleting your theme:"
 msgstr "Recite nam zašto brišete svoju temu:"
 
-#: src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:36
+#: src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:35
 msgid "Please tell us why you are deleting your add-on:"
 msgstr "Recite nam zašto brišete svoj dodatak:"
 
@@ -4887,8 +4781,8 @@ msgstr "Nova verzija"
 msgid "Daily statistics on downloads and users."
 msgstr "Dnevne statistike o preuzimanju i korisnicima."
 
-#: src/olympia/devhub/templates/devhub/addons/listing/item_actions.html:45 src/olympia/stats/templates/stats/stats.html:75 src/olympia/stats/templates/stats/stats.html:79
-#: src/olympia/stats/templates/stats/stats.html:81
+#: src/olympia/devhub/templates/devhub/addons/listing/item_actions.html:45 src/olympia/stats/templates/stats/stats.html:31 src/olympia/stats/templates/stats/stats.html:35
+#: src/olympia/stats/templates/stats/stats.html:37
 msgid "Statistics"
 msgstr "Statistika"
 
@@ -4949,7 +4843,6 @@ msgid "<strong>{0}</strong> active user"
 msgid_plural "<strong>{0}</strong> active users"
 msgstr[0] "<strong>{0}</strong> korisnik"
 msgstr[1] "<strong>{0}</strong> korisnika"
-msgstr[2] "<strong>{0}</strong> korisnika"
 
 #: src/olympia/devhub/templates/devhub/addons/submit/base.html:11
 msgid "Submit Add-on"
@@ -5220,11 +5113,11 @@ msgstr ""
 "Iskoristite polja ispod da biste otpremili Vaš paket sa dodatkom i odaberite bilo koja ograničenja platforme. Nakon postavljanja, niz automatizovanih testova za proveru valjanosti će biti pokrenuti"
 " na Vašoj datoteci."
 
-#: src/olympia/devhub/templates/devhub/addons/submit/upload.html:59 src/olympia/devhub/templates/devhub/versions/add_file_modal.html:39
+#: src/olympia/devhub/templates/devhub/addons/submit/upload.html:51 src/olympia/devhub/templates/devhub/versions/add_file_modal.html:28
 msgid "Which platforms is this file compatible with?"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/addons/submit/upload.html:67 src/olympia/devhub/templates/devhub/versions/add_file_modal.html:65
+#: src/olympia/devhub/templates/devhub/addons/submit/upload.html:59 src/olympia/devhub/templates/devhub/versions/add_file_modal.html:45
 msgid "Administrative overrides"
 msgstr "Administrativna poništavanja"
 
@@ -5341,8 +5234,8 @@ msgstr "Funkcionalnost i razvoj veb sajta"
 
 #: src/olympia/devhub/templates/devhub/docs/policies-contact.html:44
 msgid ""
-"If you've found a problem with the site, we'd love to fix it. Please <a href=\"https://github.com/mozilla/olympia/issues\">file a bug report</a> in GitHub, including the location of the problem and"
-" how you encountered it."
+"If you've found a problem with the site, we'd love to fix it. Please <a href=\"https://github.com/mozilla/addons/issues/new\">file a bug report</a> in GitHub, including the location of the problem "
+"and how you encountered it."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/docs/policies-maintenance.html:3 src/olympia/devhub/templates/devhub/docs/policies-maintenance.html:7
@@ -6187,62 +6080,55 @@ msgstr "Uslovi usluge za prijavu Vašeg rada na naš sajt. Programeri moraju pri
 msgid "How to get in touch with us regarding these policies or your add-on."
 msgstr "Kako da stupite u kontakt sa nama u vezi ove polise ili Vašeg dodatka."
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:6
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:10
 msgid "You have disabled this add-on"
 msgstr "Onemogućili ste ovaj dodatak"
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:20
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:24
 msgid "Your add-on's listing is disabled and is not showing anywhere in our gallery or update service."
 msgstr "Navođenje dodatka je onemogućeno i ne prikazuje se bilo gde u našoj galeriji ili u uslugama ažuriranja."
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:25
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:27
 msgid "Please complete your add-on."
 msgstr "Molim Vas završite Vaš dodatak."
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:29
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:30
 msgid "You will receive an email when the review is complete."
 msgstr "Primićete e-poštu kada je pregled završen."
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:34
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:33
 msgid "You will receive an email when the review is complete. Until then, your add-on is not listed in our gallery but can be accessed directly from its details page."
 msgstr "Dobićete e-poštu kad pregled bude završen. Do tada, Vaš dodatak nije na listi u našoj galeriji ali mu se može pristupiti direktno sa njegove stranice sa detaljima."
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:38 src/olympia/devhub/templates/devhub/includes/addon_details.html:48
-msgid ""
-"You will receive an email when the review is\n"
-"                             complete and your add-on is signed."
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:37 src/olympia/devhub/templates/devhub/includes/addon_details.html:45
+msgid "You will receive an email when the review is complete and your add-on is signed."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:44
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:41
 msgid "You will receive an email when the review is complete. Until then, your add-on is not listed in our gallery but can be accessed directly from its details page."
 msgstr "Dobićete e-poštu kad pregled bude završen. Do tada, Vaš dodatak nije na listi u našoj galeriji ali mu se može pristupiti direktno sa njegove stranice sa detaljima."
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:54
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:49
 msgid "Your add-on is displayed in our gallery and users are receiving automatic updates."
 msgstr "Vaš dodatak je prikazan u našoj galeriji i korisnici primaju automatske nadogradnje."
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:57
-msgid ""
-"Your add-on has been signed and can be bundled with an\n"
-"                             application installer."
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:52
+msgid "Your add-on has been signed and can be bundled with an application installer."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:63
-msgid ""
-"Your add-on was disabled by a site administrator and is no\n"
-"                             longer shown in our gallery. If you have any questions,\n"
-"                             please email amo-admins@mozilla.org."
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:56
+msgid "Your add-on was disabled by a site administrator and is no longer shown in our gallery. If you have any questions, please email amo-admins@mozilla.org."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:70
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:62
 msgid "Your add-on is displayed in our gallery as experimental and users are receiving automatic updates. Some features are unavailable to your add-on."
 msgstr "Vaš dodatak je prikazan u našoj galeriji kao eksperimentalni i korisnici primaju automatske nadogradnje. Neke mogućnosti su nedostupne za Vaš dodatak."
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:74
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:66
 msgid "Your add-on has been signed."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:79
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:69
 msgid ""
 "You will receive an email when the full review is complete. Until then, your add-on is displayed in our gallery as experimental and users are receiving automatic updates. Some features are "
 "unavailable to your add-on."
@@ -6250,48 +6136,41 @@ msgstr ""
 "Dobićete e-poštu kada pun pregled bude gotov. Do tada, Vaš dodatak je prikazan u našoj galeriji kao eksperimentalni i korisnici dobijaju automatske nadogradnje. Neke mogućnosti nisu dostupne Vašem "
 "dodatku."
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:84
-msgid ""
-"You will receive an email when the full review is\n"
-"                             complete, making you able to bundle your add-on with an\n"
-"                             application installer."
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:74
+msgid "You will receive an email when the full review is complete, making you able to bundle your add-on with an application installer."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:91
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:79
 msgid "All add-ons hosted in our gallery must now be reviewed by an editor. If you wish to continue hosting your add-on, please click to select a review process."
 msgstr "Svi dodaci koji su hostovani u našoj galeriji moraju biti pregledani od strane urednika. Ako želite da nastavite da hostujete Vaš dodatak molimo da kliknete da biste odabrali proces recenzije."
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:113
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:100
 msgid "Current Version:"
 msgstr "Trenutna verzija:"
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:115
-msgid ""
-"This is the version of your add-on that will\n"
-"                                           be installed if someone clicks the Install\n"
-"                                           button on addons.mozilla.org. It is only\n"
-"                                           relevant for listed add-ons."
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:102
+msgid "This is the version of your add-on that will be installed if someone clicks the Install button on addons.mozilla.org. It is only relevant for listed add-ons."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:123
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:110
 msgid "Created:"
 msgstr "Napravljeno:"
 
 #. {0} is a date. dennis-ignore: E201
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:125 src/olympia/devhub/templates/devhub/includes/addon_details.html:131
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:112 src/olympia/devhub/templates/devhub/includes/addon_details.html:118
 #, python-format
 msgid "%%b %%e, %%Y"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:136
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:123
 msgid "Next Version:"
 msgstr "Sledeća verzija:"
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:138
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:125
 msgid "This is the newest uploaded version, however it isn’t live on the site yet."
 msgstr "Ovo je najnovija verzija, ali još uvek nije javna na sajtu."
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:144 src/olympia/devhub/templates/devhub/versions/list.html:30
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:130 src/olympia/devhub/templates/devhub/versions/list.html:30
 msgid "Queues are not reviewed strictly in order"
 msgstr "Redovi nisu strogo pregledani u redu"
 
@@ -6361,9 +6240,7 @@ msgid "View the blog &#9658;"
 msgstr "Prikaži blog &#9658;"
 
 #: src/olympia/devhub/templates/devhub/includes/license_form.html:6
-msgid ""
-"Please choose a license appropriate for the rights you grant on your source code.\n"
-"                  It is only relevant for listed add-ons."
+msgid "Please choose a license appropriate for the rights you grant on your source code. It is only relevant for listed add-ons."
 msgstr ""
 
 #. {0} is a list of HTML tags.
@@ -6386,19 +6263,15 @@ msgid "Select <b>up to {0}</b> {1} category for this add-on:"
 msgid_plural "Select <b>up to {0}</b> {1} categories for this add-on:"
 msgstr[0] "Izaberite <b>do {0}</b> {1} kategoriju za ovaj dodatak:"
 msgstr[1] "Izaberite <b>do {0}</b> {1} kategorije za ovaj dodatak:"
-msgstr[2] "Izaberite <b>do {0}</b> {1} kategorija za ovaj dodatak:"
 
 #: src/olympia/devhub/templates/devhub/includes/policy_form.html:4
 msgid ""
 "Users will be required to accept the following End-User License Agreement (EULA) prior to installing your add-on. The presence of a EULA significantly affects the number of downloads an add-on "
-"receives. Please note that a EULA is not the same as a code license, such as the GPL or MPL.\n"
-"                It is only relevant for listed add-ons."
+"receives. Please note that a EULA is not the same as a code license, such as the GPL or MPL.It is only relevant for listed add-ons."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/policy_form.html:21
-msgid ""
-"If your add-on transmits any data from the user's computer, a privacy policy is required that explains what data is sent and how it is used.\n"
-"                It is only relevant for listed add-ons."
+#: src/olympia/devhub/templates/devhub/includes/policy_form.html:24
+msgid "If your add-on transmits any data from the user's computer, a privacy policy is required that explains what data is sent and how it is used. It is only relevant for listed add-ons."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/includes/source_form_field.html:2
@@ -6566,7 +6439,7 @@ msgstr "Izaberite kategoriju koja najbolje opisuje Vašu temu."
 msgid "Add some tags to describe your Theme."
 msgstr "Dodajte neke oznake da opišete Vašu temu."
 
-#: src/olympia/devhub/templates/devhub/personas/edit.html:106
+#: src/olympia/devhub/templates/devhub/personas/edit.html:106 src/olympia/devhub/templates/devhub/personas/submit.html:54
 msgid "A short explanation of your theme's basic functionality that is displayed in search and browse listings, as well as at the top of your theme's details page."
 msgstr "Kratko objašnjenje osnovnih fukcionalnosti Vaše teme koje je prikazano u listama pretrage i pregledavanja, kao i na vrhu stranice sa detaljima Vaše teme."
 
@@ -6706,10 +6579,6 @@ msgstr "Teme pozadine su lak način da personalizujete Firefox. Dostavite Vaš d
 msgid "Give your Theme a name."
 msgstr "Dajte naziv Vašoj temi."
 
-#: src/olympia/devhub/templates/devhub/personas/submit.html:54
-msgid "A short explanation of your theme's basic functionality that is displayed in search and browse listings, as well as at the top of your theme's details page."
-msgstr "Kratko objašnjenje osnovnih fukcionalnosti Vaše teme koje je prikazano u listama pretrage i pregledavanja, kao i na vrhu stranice sa detaljima Vaše teme."
-
 #: src/olympia/devhub/templates/devhub/personas/submit.html:198
 #, python-format
 msgid ""
@@ -6784,31 +6653,17 @@ msgstr "Izaberite drugu sliku za podnožje"
 msgid "Files added to reviewed versions must be reviewed before they will be available for download."
 msgstr "Datoteke dodate na pregledane verzije moraju biti pregledane pre nego budu dostupne za preuzimanje."
 
-#: src/olympia/devhub/templates/devhub/versions/add_file_modal.html:15
-#, python-format
-msgid ""
-"Submission of updates to unlisted add-ons for signing is currently in an open beta. Manual review may still be required for a large number of add-ons. Please <a href=\"%(url)s\" "
-"target=\"_blank\">report any bugs</a> that you encounter."
-msgstr ""
-
-#: src/olympia/devhub/templates/devhub/versions/add_file_modal.html:35
+#: src/olympia/devhub/templates/devhub/versions/add_file_modal.html:24
 msgid "Select the target platform for this file."
 msgstr "Izaberite ciljanu platformu za ovu datoteku."
 
-#: src/olympia/devhub/templates/devhub/versions/add_file_modal.html:46
+#: src/olympia/devhub/templates/devhub/versions/add_file_modal.html:35
 msgid "Which review type would you like to nominate for?"
 msgstr "Za koji tip pregled želite da je nominujete?"
 
-#: src/olympia/devhub/templates/devhub/versions/add_file_modal.html:51
+#: src/olympia/devhub/templates/devhub/versions/add_file_modal.html:40
 msgid "Only publish this version to my beta channel."
 msgstr "Objavi ovu verziju samo na moj beta kanal."
-
-#: src/olympia/devhub/templates/devhub/versions/add_file_modal.html:54
-#, python-format
-msgid ""
-"The behavior of the beta channel has changed to accommodate <a href=\"%(addon_signing_url)s\" target=\"_blank\">mandatory add-on signing</a>. The new process is currently in an open beta, and may "
-"change significantly in the near future. Please <a href=\"%(issues_url)s\" target=\"_blank\">report any bugs</a> that you encounter."
-msgstr ""
 
 #: src/olympia/devhub/templates/devhub/versions/edit.html:5
 msgid "Manage Version {0}"
@@ -6831,10 +6686,6 @@ msgstr "Datoteke"
 #: src/olympia/devhub/templates/devhub/versions/edit.html:38
 msgid "Upload Another File"
 msgstr "Postavi još jednu datoteku"
-
-#: src/olympia/devhub/templates/devhub/versions/edit.html:45
-msgid "Adjusting application information here will allow users to install your add-on even if the install manifest in the package indicates that the add-on is incompatible."
-msgstr "Podešavanje informacije o aplikaciji ovde će dozvoliti korisnicima da instaliraju Vaš dodatak čak iako manifest instalacije u paketu ukazuje da je dodatak nekompatibilan."
 
 #: src/olympia/devhub/templates/devhub/versions/edit.html:74
 msgid ""
@@ -6905,7 +6756,6 @@ msgid "{0} file"
 msgid_plural "{0} files"
 msgstr[0] "{0} datoteka"
 msgstr[1] "{0} datoteke"
-msgstr[2] "{0} datoteka"
 
 #: src/olympia/devhub/templates/devhub/versions/list.html:25
 msgid "0 files"
@@ -6932,7 +6782,7 @@ msgstr "Zahtevaj punu pregled"
 msgid "Request Preliminary Review"
 msgstr "Zahteva preliminaran pregled"
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:80 src/olympia/devhub/templates/devhub/versions/list.html:327 src/olympia/devhub/templates/devhub/versions/list.html:350
+#: src/olympia/devhub/templates/devhub/versions/list.html:80 src/olympia/devhub/templates/devhub/versions/list.html:325 src/olympia/devhub/templates/devhub/versions/list.html:348
 msgid "Cancel Review Request"
 msgstr "Otkaži zahtev za pregled"
 
@@ -6961,7 +6811,7 @@ msgid "Unlisted:"
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/versions/list.html:114
-msgid "Not distributed on {0}. Developers will upload new versions for signing and distribute the add-ons on their own. (beta)"
+msgid "Not distributed on {0}. Developers will upload new versions for signing and distribute the add-ons on their own."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/versions/list.html:122
@@ -7023,78 +6873,73 @@ msgid "<strong>Important:</strong> Once a version has been deleted, you may not 
 msgstr "<strong>Važno:</strong> Kada je jednom verzija izbrisana, ne biste trebali postaviti novu verziju sa istim brojem."
 
 #: src/olympia/devhub/templates/devhub/versions/list.html:230
-msgid "Deleting a version which has already been reviewed may also cause a significant delay in the review of your next update."
-msgstr "Brisanje verzije koja je već bila pregledana može da prouzrokuje značajna kašnjenja kod pregledavanja Vaše sledeće nadogradnje."
-
-#: src/olympia/devhub/templates/devhub/versions/list.html:233
 msgid "Are you sure you wish to delete this version?"
 msgstr "Da li ste sigurni da želite obrisati ovu verziju?"
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:238
+#: src/olympia/devhub/templates/devhub/versions/list.html:235
 msgid "Delete Version"
 msgstr "Obriši verziju"
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:240
+#: src/olympia/devhub/templates/devhub/versions/list.html:237
 msgid "Disable Version"
 msgstr "Onemogući verziju"
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:247
+#: src/olympia/devhub/templates/devhub/versions/list.html:244
 msgid "Add a new Version"
 msgstr "Dodaj novu verziju"
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:249
+#: src/olympia/devhub/templates/devhub/versions/list.html:246
 msgid "Add Version"
 msgstr "Dodajte verziju"
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:256 src/olympia/devhub/templates/devhub/versions/list.html:274
+#: src/olympia/devhub/templates/devhub/versions/list.html:253 src/olympia/devhub/templates/devhub/versions/list.html:279
 msgid "Hide Add-on"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:259
+#: src/olympia/devhub/templates/devhub/versions/list.html:256
 msgid "Hiding your add-on will prevent it from appearing anywhere in our gallery and will stop users from receiving automatic updates."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:265
+#: src/olympia/devhub/templates/devhub/versions/list.html:263
+msgid "The files awaiting review will be disabled and you will need to upload new versions."
+msgstr ""
+
+#: src/olympia/devhub/templates/devhub/versions/list.html:270
 msgid "Are you sure you wish to hide your add-on?"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:286 src/olympia/devhub/templates/devhub/versions/list.html:315
+#: src/olympia/devhub/templates/devhub/versions/list.html:291 src/olympia/devhub/templates/devhub/versions/list.html:313
 msgid "Unlist Add-on"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:289
+#: src/olympia/devhub/templates/devhub/versions/list.html:294
 #, python-format
 msgid ""
 "Unlisting your add-on will make it (and each of its versions/files) invisible on this website. It won't show up in searches, won't have a public facing page, and won't be updated automatically for "
-"current users.  It is recommended for unlisted add-ons to provide a custom <a href=\"%(update_url)s\" target=\"_blank\">updateURL</a> in their manifest file for automatic updates."
+"current users. It is recommended for unlisted add-ons to provide a custom <a href=\"%(update_url)s\" target=\"_blank\">updateURL</a> in their manifest file for automatic updates."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:299
-#, python-format
-msgid "Switching add-ons to unlisted is currently in an open beta. Please <a href=\"%(url)s\" target=\"_blank\">report any bugs</a> that you encounter."
-msgstr ""
-
-#: src/olympia/devhub/templates/devhub/versions/list.html:305
+#: src/olympia/devhub/templates/devhub/versions/list.html:303
 msgid "Unlisting an add-on is irreversible!"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:305
+#: src/olympia/devhub/templates/devhub/versions/list.html:303
 msgid "An unlisted add-on cannot be switched to be listed."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:307
+#: src/olympia/devhub/templates/devhub/versions/list.html:305
 msgid "Are you sure you wish to unlist your add-on?"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:330
+#: src/olympia/devhub/templates/devhub/versions/list.html:328
 msgid "Canceling your review request will leave your add-on as preliminarily reviewed."
 msgstr "Prekidanje Vašeg zahteva za pregled će učiniti dodatak preliminarno pregledanim."
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:335
+#: src/olympia/devhub/templates/devhub/versions/list.html:333
 msgid "Canceling your review request will mark your add-on incomplete. If you do not complete your add-on after several days by re-requesting review, it will be deleted."
 msgstr "Prekidanje Vašeg zahteva za pregled će označiti dodatak kao nezavršen. Ukoliko ne završite Vaš dodatak za nekoliko dana ponovo tražeći pregled dodatak će biti izbrisan."
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:343
+#: src/olympia/devhub/templates/devhub/versions/list.html:341
 msgid "Are you sure you wish to cancel your review request?"
 msgstr "Da li ste sigurni da želite da prekinete Vaš zahtev za pregled?"
 
@@ -7437,19 +7282,19 @@ msgstr "dodatak, urednik ili komentar"
 msgid "Search by add-on name / author email"
 msgstr "Pretraži po nazivu dodatka / e-pošti autora"
 
-#: src/olympia/editors/forms.py:103
+#: src/olympia/editors/forms.py:103 src/olympia/editors/forms.py:244 src/olympia/editors/forms.py:257
 msgid "yes"
 msgstr "da"
 
-#: src/olympia/editors/forms.py:104
+#: src/olympia/editors/forms.py:104 src/olympia/editors/forms.py:244 src/olympia/editors/forms.py:257
 msgid "no"
 msgstr "ne"
 
-#: src/olympia/editors/forms.py:105
+#: src/olympia/editors/forms.py:105 src/olympia/editors/forms.py:245
 msgid "Admin Flag"
 msgstr "Admin zastava"
 
-#: src/olympia/editors/forms.py:113
+#: src/olympia/editors/forms.py:113 src/olympia/editors/forms.py:253
 msgid "Max. Version"
 msgstr "Poslednja verzija"
 
@@ -7461,55 +7306,59 @@ msgstr "Dana od podnošenja"
 msgid "Add-on Types"
 msgstr "Vrste dodatka"
 
-#: src/olympia/editors/forms.py:126 src/olympia/editors/helpers.py:267
+#: src/olympia/editors/forms.py:126 src/olympia/editors/helpers.py:279
 msgid "Platforms"
 msgstr "Platforme"
 
+#: src/olympia/editors/forms.py:237
+msgid "Search by add-on name / author email / guid"
+msgstr ""
+
 #. L10n: 0 = platform, 1 = filename, 2 = status message
-#: src/olympia/editors/forms.py:238
+#: src/olympia/editors/forms.py:342
 #, python-format
 msgid "<strong>%s</strong> &middot; %s &middot; %s"
 msgstr "<strong>%s</strong> &middot; %s &middot; %s"
 
-#: src/olympia/editors/forms.py:252
+#: src/olympia/editors/forms.py:356
 msgid "Comments:"
 msgstr "Komentari:"
 
-#: src/olympia/editors/forms.py:256
+#: src/olympia/editors/forms.py:360
 msgid "Operating systems:"
 msgstr "Operativni sistemi:"
 
-#: src/olympia/editors/forms.py:258
+#: src/olympia/editors/forms.py:362
 msgid "Applications:"
 msgstr "Aplikacije:"
 
-#: src/olympia/editors/forms.py:260
+#: src/olympia/editors/forms.py:364
 msgid "Notify me the next time this add-on is updated. (Subsequent updates will not generate an email)"
 msgstr "Obavesti me sledeći put kada se ovaj dodatak ažurira. (Naknadna ažuriranja neće generisati e-poštu)"
 
-#: src/olympia/editors/forms.py:265
+#: src/olympia/editors/forms.py:369
 msgid "Clear Admin Review Flag"
 msgstr "Ukloni oznaku za recenziju administratora"
 
-#: src/olympia/editors/forms.py:267
+#: src/olympia/editors/forms.py:371
 msgid "Clear more info requested flag"
 msgstr ""
 
-#: src/olympia/editors/forms.py:281
+#: src/olympia/editors/forms.py:385
 msgid "Choose a canned response..."
 msgstr "Izaberi gotov odgovor..."
 
 #. L10n: Description of what can be searched for.
-#: src/olympia/editors/forms.py:324
+#: src/olympia/editors/forms.py:423
 msgid "theme name"
 msgstr "naziv teme"
 
-#: src/olympia/editors/forms.py:350
+#: src/olympia/editors/forms.py:449
 msgid "Someone else is reviewing this theme."
 msgstr "Neko drugi pregledava ovu temu."
 
 #. L10n: Description of what can be searched for.
-#: src/olympia/editors/forms.py:447
+#: src/olympia/editors/forms.py:546
 msgid "app, reviewer, or comment"
 msgstr "aplikacija, recenzent, ili komentar"
 
@@ -7525,203 +7374,210 @@ msgstr "Čekanje preliminarne recenzije"
 msgid "Rejected or Unreviewed"
 msgstr "Odbijeno ili nepregledano"
 
-#: src/olympia/editors/helpers.py:123 src/olympia/editors/helpers.py:136
+#: src/olympia/editors/helpers.py:125 src/olympia/editors/helpers.py:138
 msgid "Queue"
 msgstr "Na čekanju"
 
-#: src/olympia/editors/helpers.py:124 src/olympia/editors/templates/editors/base.html:50 src/olympia/editors/templates/editors/base.html:65
+#: src/olympia/editors/helpers.py:126 src/olympia/editors/templates/editors/base.html:50 src/olympia/editors/templates/editors/base.html:65
 msgid "Pending Updates"
 msgstr "Ažuriranja na čekanju"
 
-#: src/olympia/editors/helpers.py:125 src/olympia/editors/templates/editors/base.html:48 src/olympia/editors/templates/editors/base.html:63
+#: src/olympia/editors/helpers.py:127 src/olympia/editors/templates/editors/base.html:48 src/olympia/editors/templates/editors/base.html:63
 msgid "Full Reviews"
 msgstr "Potpune recenzije"
 
-#: src/olympia/editors/helpers.py:126 src/olympia/editors/templates/editors/base.html:52 src/olympia/editors/templates/editors/base.html:67
+#: src/olympia/editors/helpers.py:128 src/olympia/editors/templates/editors/base.html:52 src/olympia/editors/templates/editors/base.html:67
 msgid "Preliminary Reviews"
 msgstr "Preliminarne recenzije"
 
-#: src/olympia/editors/helpers.py:127 src/olympia/editors/templates/editors/base.html:54
+#: src/olympia/editors/helpers.py:129 src/olympia/editors/templates/editors/base.html:54
 msgid "Moderated Reviews"
 msgstr "Uređene recenzije"
 
-#: src/olympia/editors/helpers.py:128 src/olympia/editors/templates/editors/base.html:46
+#: src/olympia/editors/helpers.py:130 src/olympia/editors/templates/editors/base.html:46
 msgid "Fast Track"
 msgstr "Brza traka"
 
-#: src/olympia/editors/helpers.py:130
+#: src/olympia/editors/helpers.py:132
 msgid "Pending Themes"
 msgstr "Teme na čekanju"
 
-#: src/olympia/editors/helpers.py:131 src/olympia/editors/templates/editors/themes/queue.html:4
+#: src/olympia/editors/helpers.py:133 src/olympia/editors/templates/editors/themes/queue.html:4
 msgid "Flagged Themes"
 msgstr "Označene teme"
 
-#: src/olympia/editors/helpers.py:132
+#: src/olympia/editors/helpers.py:134
 msgid "Update Themes"
 msgstr "Ažuriraj teme"
 
-#: src/olympia/editors/helpers.py:137
+#: src/olympia/editors/helpers.py:139
 msgid "Unlisted Pending Updates"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:138
+#: src/olympia/editors/helpers.py:140
 msgid "Unlisted Full Reviews"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:139
+#: src/olympia/editors/helpers.py:141
 msgid "Unlisted Preliminary Reviews"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:170
+#: src/olympia/editors/helpers.py:142
+msgid "Unlisted All Add-ons"
+msgstr ""
+
+#: src/olympia/editors/helpers.py:173
 msgid "Fast Track ({0})"
 msgid_plural "Fast Track ({0})"
 msgstr[0] "Brza traka ({0})"
 msgstr[1] "Brza traka ({0})"
-msgstr[2] "Brza traka ({0})"
 
-#: src/olympia/editors/helpers.py:175
+#: src/olympia/editors/helpers.py:178
 msgid "Full Review ({0})"
 msgid_plural "Full Reviews ({0})"
 msgstr[0] "({0}) puna recenzija"
 msgstr[1] "({0}) pune recenzije"
-msgstr[2] "({0}) punih recenzija"
 
-#: src/olympia/editors/helpers.py:180
+#: src/olympia/editors/helpers.py:183
 msgid "Pending Update ({0})"
 msgid_plural "Pending Updates ({0})"
 msgstr[0] "({0}) ažuriranje na čekanju"
 msgstr[1] "({0}) ažuriranja na čekanju"
-msgstr[2] "({0}) ažuriranja na čekanju"
 
-#: src/olympia/editors/helpers.py:185
+#: src/olympia/editors/helpers.py:188
 msgid "Preliminary Review ({0})"
 msgid_plural "Preliminary Reviews ({0})"
 msgstr[0] "Preliminarni pregled ({0})"
 msgstr[1] "Preliminarna pregleda ({0})"
-msgstr[2] "Preliminarnih pregleda ({0})"
 
-#: src/olympia/editors/helpers.py:190
+#: src/olympia/editors/helpers.py:193
 msgid "Moderated Review ({0})"
 msgid_plural "Moderated Reviews ({0})"
 msgstr[0] "Kontorlisan pregled ({0})"
 msgstr[1] "Kontorlisana pregleda ({0})"
-msgstr[2] "Kontorlisanih pregleda ({0})"
 
-#: src/olympia/editors/helpers.py:196
+#: src/olympia/editors/helpers.py:199
 msgid "Unlisted Full Review ({0})"
 msgid_plural "Unlisted Full Reviews ({0})"
 msgstr[0] ""
 msgstr[1] ""
-msgstr[2] ""
 
-#: src/olympia/editors/helpers.py:201
+#: src/olympia/editors/helpers.py:204
 msgid "Unlisted Pending Update ({0})"
 msgid_plural "Unlisted Pending Updates ({0})"
 msgstr[0] ""
 msgstr[1] ""
-msgstr[2] ""
 
-#: src/olympia/editors/helpers.py:206
+#: src/olympia/editors/helpers.py:209
 msgid "Unlisted Preliminary Review ({0})"
 msgid_plural "Unlisted Preliminary Reviews ({0})"
 msgstr[0] ""
 msgstr[1] ""
-msgstr[2] ""
 
-#: src/olympia/editors/helpers.py:261
-msgid "Addon"
-msgstr "Dodatak"
+#: src/olympia/editors/helpers.py:214
+msgid "Unlisted All Add-ons ({0})"
+msgid_plural "Unlisted All Add-ons ({0})"
+msgstr[0] ""
+msgstr[1] ""
 
-#: src/olympia/editors/helpers.py:262
+#: src/olympia/editors/helpers.py:274
 msgid "Type"
 msgstr "Tip"
 
-#: src/olympia/editors/helpers.py:263
+#: src/olympia/editors/helpers.py:275
 msgid "Waiting Time"
 msgstr "Vreme čekanja"
 
-#: src/olympia/editors/helpers.py:264 src/olympia/editors/templates/editors/review.html:285
+#: src/olympia/editors/helpers.py:276 src/olympia/editors/templates/editors/review.html:285
 msgid "Flags"
 msgstr "Oznake"
 
-#: src/olympia/editors/helpers.py:265
+#: src/olympia/editors/helpers.py:277
 msgid "Applications"
 msgstr "Aplikacije"
 
-#: src/olympia/editors/helpers.py:270
+#: src/olympia/editors/helpers.py:282
 msgid "Additional"
 msgstr "Dodatno"
 
-#: src/olympia/editors/helpers.py:285
+#: src/olympia/editors/helpers.py:302
 msgid "Site Specific"
 msgstr "Posebno za sajt"
 
-#: src/olympia/editors/helpers.py:287
+#: src/olympia/editors/helpers.py:304
 msgid "Requires External Software"
 msgstr "Zahteva spoljni softver"
 
-#: src/olympia/editors/helpers.py:289
+#: src/olympia/editors/helpers.py:306
 msgid "Binary Components"
 msgstr "Binarne komponente"
 
-#: src/olympia/editors/helpers.py:313
+#: src/olympia/editors/helpers.py:339
 msgid "moments ago"
 msgstr "pre nekoliko momenata"
 
 #. L10n: first argument is number of minutes
-#: src/olympia/editors/helpers.py:316
+#: src/olympia/editors/helpers.py:342
 msgid "{0} minute"
 msgid_plural "{0} minutes"
 msgstr[0] "{0} minut"
 msgstr[1] "{0} minuta"
-msgstr[2] "{0} minuta"
 
 #. L10n: first argument is number of hours
-#: src/olympia/editors/helpers.py:320
+#: src/olympia/editors/helpers.py:346
 msgid "{0} hour"
 msgid_plural "{0} hours"
 msgstr[0] "{0} sat"
 msgstr[1] "{0} sata"
-msgstr[2] "{0} sati"
 
 #. L10n: first argument is number of days
-#: src/olympia/editors/helpers.py:324
+#: src/olympia/editors/helpers.py:350
 msgid "{0} day"
 msgid_plural "{0} days"
 msgstr[0] "{0} dan"
 msgstr[1] "{0} dana"
-msgstr[2] "{0} dana"
 
-#: src/olympia/editors/helpers.py:488
+#: src/olympia/editors/helpers.py:364
+msgid "Last Review"
+msgstr ""
+
+#: src/olympia/editors/helpers.py:366
+msgid "Last Update"
+msgstr ""
+
+#: src/olympia/editors/helpers.py:387
+msgid "No Reviews"
+msgstr ""
+
+#: src/olympia/editors/helpers.py:561
 msgid "Push to public"
 msgstr "Napravi javnim"
 
-#: src/olympia/editors/helpers.py:490
+#: src/olympia/editors/helpers.py:563
 msgid "Grant full review"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:505
+#: src/olympia/editors/helpers.py:578
 msgid "Request more information"
 msgstr "Zatraži više informacija"
 
-#: src/olympia/editors/helpers.py:508
+#: src/olympia/editors/helpers.py:581
 msgid "Request super-review"
 msgstr "Zahtevaj super-recenziju"
 
-#: src/olympia/editors/helpers.py:519
+#: src/olympia/editors/helpers.py:592
 msgid "Grant preliminary review"
 msgstr "Odobri preliminarni pregled"
 
-#: src/olympia/editors/helpers.py:520
+#: src/olympia/editors/helpers.py:593
 msgid "This will mark the files as preliminarily reviewed."
 msgstr "Ovo će označiti datoteke kao preliminarno pregledane."
 
-#: src/olympia/editors/helpers.py:522
+#: src/olympia/editors/helpers.py:595
 msgid "Use this form to request more information from the author. They will receive an email and be able to answer here. You will be notified by email when they reply."
 msgstr "Koristite ovu formu da biste zahtevali više informacija od autora. Primiće e-poštu i biće u mogućnosti ovde da odgovori. Bićete obavešteni putem e-pošte kada odgovori."
 
-#: src/olympia/editors/helpers.py:526
+#: src/olympia/editors/helpers.py:599
 msgid ""
 "If you have concerns about this add-on's security, copyright issues, or other concerns that an administrator should look into, enter your comments in the area below. They will be sent to "
 "administrators, not the author."
@@ -7729,55 +7585,55 @@ msgstr ""
 "Ako brinete o bezbednosti ovog dodatka, o njegovim autorskim pravima, ili nekim drugim stvarima koje bi administrator trebao da pogleda, unesite Vaš komentar u polje ispod. Biće poslat "
 "administratorima, ne autoru."
 
-#: src/olympia/editors/helpers.py:532
+#: src/olympia/editors/helpers.py:605
 msgid "This will reject the add-on and remove it from the review queue."
 msgstr "Ovo će odbiti dodatak i ukloniti ga sa liste čekanja."
 
-#: src/olympia/editors/helpers.py:534
+#: src/olympia/editors/helpers.py:607
 msgid "Make a comment on this version. The author won't be able to see this."
 msgstr "Komentarišite ovu verziju. Autor neće biti u mogućnosti da ga vidi."
 
-#: src/olympia/editors/helpers.py:538
+#: src/olympia/editors/helpers.py:611
 msgid "This will reject the files and remove them from the review queue."
 msgstr "Ovo će odbiti datoteke i ukloniti ih sa čekanja recenzije."
 
-#: src/olympia/editors/helpers.py:542
+#: src/olympia/editors/helpers.py:615
 msgid "This will mark the add-on as preliminarily reviewed. Future versions will undergo preliminary review."
 msgstr "Ovo će označiti dodatak kao preliminarno pregledan. Buduće verzije će proći kroz preliminarni pregled."
 
-#: src/olympia/editors/helpers.py:547
+#: src/olympia/editors/helpers.py:620
 msgid "This will mark the files as preliminarily reviewed. Future versions will undergo preliminary review."
 msgstr "Ovo će označiti datoteke kao preliminarno pregledane. Buduće verzije će proći kroz preliminarni pregled."
 
-#: src/olympia/editors/helpers.py:552
+#: src/olympia/editors/helpers.py:625
 msgid "Retain preliminary review"
 msgstr "Zadrži preliminarnu recenziju"
 
-#: src/olympia/editors/helpers.py:553
+#: src/olympia/editors/helpers.py:626
 msgid "This will retain the add-on as preliminarily reviewed. Future versions will undergo preliminary review."
 msgstr "Ovo će zadržati dodatke kao preliminarno pregledane. Buduće verzije će proći kroz preliminarni pregled."
 
-#: src/olympia/editors/helpers.py:558
+#: src/olympia/editors/helpers.py:631
 msgid "This will approve a sandboxed version of a public add-on to appear on the public side."
 msgstr "Ovo će odobriti verziju u zaštićenom okruženju javnog dodatka da se pojavi na javnoj strani."
 
-#: src/olympia/editors/helpers.py:561
+#: src/olympia/editors/helpers.py:634
 msgid "This will reject a version of a public add-on and remove it from the queue."
 msgstr "Ovo će odbiti verziju javnog dodatka i ukloniće ga sa liste čekanja."
 
-#: src/olympia/editors/helpers.py:564
+#: src/olympia/editors/helpers.py:637
 msgid "This will mark the add-on and its most recent version and files as public. Future versions will go into the sandbox until they are reviewed by an editor."
 msgstr "Ovo će označiti dodatak i njegove skorašnje verzije i datoteke kao javne. Buduće verzije će otići u zaštićeno okruženje dok ne budu pregledane od strane urednika."
 
-#: src/olympia/editors/helpers.py:637
+#: src/olympia/editors/helpers.py:714
 msgid "add-on"
 msgstr "dodatak"
 
-#: src/olympia/editors/helpers.py:940 src/olympia/editors/helpers.py:960
+#: src/olympia/editors/helpers.py:1020 src/olympia/editors/helpers.py:1040
 msgid "Flagged"
 msgstr "Označeno"
 
-#: src/olympia/editors/helpers.py:944 src/olympia/editors/helpers.py:963
+#: src/olympia/editors/helpers.py:1024 src/olympia/editors/helpers.py:1043
 msgid "Updates"
 msgstr "Ažuriranja"
 
@@ -7829,56 +7685,56 @@ msgstr "Podnešenje teme je označeno za pregled"
 msgid "A question about your Theme submission"
 msgstr "Pitanje o Vašem podnošenju teme"
 
-#: src/olympia/editors/views.py:144
+#: src/olympia/editors/views.py:146
 msgid "New Add-ons (Under 5 days)"
 msgstr "Novi dodatak (ispod 5 dana)"
 
-#: src/olympia/editors/views.py:145
+#: src/olympia/editors/views.py:147
 msgid "Passable (5 to 10 days)"
 msgstr "Prolazno (5 do 10 dana)"
 
-#: src/olympia/editors/views.py:146
+#: src/olympia/editors/views.py:148
 msgid "Overdue (Over 10 days)"
 msgstr "Istekao rok (više od 10 dana)"
 
-#: src/olympia/editors/views.py:532
+#: src/olympia/editors/views.py:539
 msgid "An unknown error occurred"
 msgstr "Pojavila se nepoznata greška"
 
-#: src/olympia/editors/views.py:587
+#: src/olympia/editors/views.py:592
 msgid "Self-reviews are not allowed."
 msgstr "Sopstvene recenzije nisu dozvoljene."
 
-#: src/olympia/editors/views.py:609
+#: src/olympia/editors/views.py:613
 msgid "Review successfully processed."
 msgstr "Recenzija uspešno procesirana."
 
-#: src/olympia/editors/views.py:807
+#: src/olympia/editors/views.py:812
 msgid "was approved"
 msgstr "je odobreno"
 
-#: src/olympia/editors/views.py:808
+#: src/olympia/editors/views.py:813
 msgid "given preliminary review"
 msgstr "je data preliminarna recenzija"
 
-#: src/olympia/editors/views.py:809
+#: src/olympia/editors/views.py:814
 msgid "rejected"
 msgstr "odbijeno"
 
-#: src/olympia/editors/views.py:810
+#: src/olympia/editors/views.py:815
 msgctxt "editors_review_history_nominated_adminreview"
 msgid "escalated"
 msgstr "eskalirano"
 
-#: src/olympia/editors/views.py:812
+#: src/olympia/editors/views.py:817
 msgid "needs more information"
 msgstr "treba više informacija"
 
-#: src/olympia/editors/views.py:813
+#: src/olympia/editors/views.py:818
 msgid "needs super review"
 msgstr "zahteva super recenziju"
 
-#: src/olympia/editors/views.py:814
+#: src/olympia/editors/views.py:819
 msgid "commented"
 msgstr ""
 
@@ -7887,7 +7743,6 @@ msgid "{0} theme review successfully processed (+{1} points, {2} total)."
 msgid_plural "{0} theme reviews successfully processed (+{1} points, {2} total)."
 msgstr[0] "{0} recenzija teme je uspešno obrađena (+{1} poena, {2} ukupno)."
 msgstr[1] "{0} recenzije teme su uspešno obrađene (+{1} poena, {2} ukupno)."
-msgstr[2] "{0} recenzija teme su uspešno obrađene (+{1} poena, {2} ukupno)."
 
 #: src/olympia/editors/views_themes.py:341
 msgid "Your theme locks have successfully been released. Other reviewers may now review those released themes. You may have to refresh the page to see the changes reflected in the table below."
@@ -7924,28 +7779,28 @@ msgstr "Redovi za čekanje"
 msgid "Unlisted Queues"
 msgstr ""
 
-#: src/olympia/editors/templates/editors/base.html:72 src/olympia/editors/templates/editors/performance.html:6
+#: src/olympia/editors/templates/editors/base.html:74 src/olympia/editors/templates/editors/performance.html:6
 msgid "Performance"
 msgstr "Performanse"
 
-#: src/olympia/editors/templates/editors/base.html:75 src/olympia/editors/templates/editors/themes/base.html:19 src/olympia/editors/templates/editors/themes/base.html:38
+#: src/olympia/editors/templates/editors/base.html:77 src/olympia/editors/templates/editors/themes/base.html:19 src/olympia/editors/templates/editors/themes/base.html:38
 msgid "Logs"
 msgstr "Dnevnici"
 
-#: src/olympia/editors/templates/editors/base.html:78 src/olympia/editors/templates/editors/reviewlog.html:4 src/olympia/editors/templates/editors/reviewlog.html:27
+#: src/olympia/editors/templates/editors/base.html:80 src/olympia/editors/templates/editors/reviewlog.html:4 src/olympia/editors/templates/editors/reviewlog.html:27
 msgid "Add-on Review Log"
 msgstr "Dnevnik recenzija dodatka"
 
-#: src/olympia/editors/templates/editors/base.html:80 src/olympia/editors/templates/editors/eventlog.html:4 src/olympia/editors/templates/editors/eventlog.html:8
+#: src/olympia/editors/templates/editors/base.html:82 src/olympia/editors/templates/editors/eventlog.html:4 src/olympia/editors/templates/editors/eventlog.html:8
 #: src/olympia/editors/templates/editors/eventlog_detail.html:4
 msgid "Moderated Review Log"
 msgstr "Kontrolisan dnevnik pregleda"
 
-#: src/olympia/editors/templates/editors/base.html:82 src/olympia/editors/templates/editors/beta_signed_log.html:4 src/olympia/editors/templates/editors/beta_signed_log.html:8
+#: src/olympia/editors/templates/editors/base.html:84 src/olympia/editors/templates/editors/beta_signed_log.html:4 src/olympia/editors/templates/editors/beta_signed_log.html:8
 msgid "Signed Beta Files Log"
 msgstr ""
 
-#: src/olympia/editors/templates/editors/base.html:87 src/olympia/editors/templates/editors/includes/daily-message.html:4
+#: src/olympia/editors/templates/editors/base.html:89 src/olympia/editors/templates/editors/includes/daily-message.html:4
 msgid "Announcement"
 msgstr "Saopštenje"
 
@@ -8005,21 +7860,18 @@ msgid "Full Review ({num})"
 msgid_plural "Full Reviews ({num})"
 msgstr[0] "({num}) puna recenzija"
 msgstr[1] "({num}) pune recenzije"
-msgstr[2] "({num}) punih recenzija"
 
 #: src/olympia/editors/templates/editors/home.html:18
 msgid "Pending Update ({num})"
 msgid_plural "Pending Updates ({num})"
 msgstr[0] "({num}) nadogradnja na čekanju"
 msgstr[1] "({num}) nadogradnje na čekanju"
-msgstr[2] "({num}) nadogradnji na čekanju"
 
 #: src/olympia/editors/templates/editors/home.html:25
 msgid "Preliminary Review ({num})"
 msgid_plural "Preliminary Reviews ({num})"
 msgstr[0] "({num}) preliminarna recenzija"
 msgstr[1] "({num}) preliminarne recenzije"
-msgstr[2] "({num}) preliminarnih recenzija"
 
 #: src/olympia/editors/templates/editors/home.html:36 src/olympia/editors/templates/editors/home.html:86
 msgid "Current waiting times:"
@@ -8030,7 +7882,6 @@ msgid "{0} add-on"
 msgid_plural "{0} add-ons"
 msgstr[0] "{0} dodatak"
 msgstr[1] "{0} dodatka"
-msgstr[2] "{0} dodataka"
 
 #: src/olympia/editors/templates/editors/home.html:45 src/olympia/editors/templates/editors/home.html:95
 #, python-format
@@ -8042,21 +7893,18 @@ msgid "Unlisted Full Review ({num})"
 msgid_plural "Unlisted Full Reviews ({num})"
 msgstr[0] ""
 msgstr[1] ""
-msgstr[2] ""
 
 #: src/olympia/editors/templates/editors/home.html:68
 msgid "Unlisted Pending Update ({num})"
 msgid_plural "Unlisted Pending Updates ({num})"
 msgstr[0] ""
 msgstr[1] ""
-msgstr[2] ""
 
 #: src/olympia/editors/templates/editors/home.html:75
 msgid "Unlisted Preliminary Review ({num})"
 msgid_plural "Unlisted Preliminary Reviews ({num})"
 msgstr[0] ""
 msgstr[1] ""
-msgstr[2] ""
 
 #: src/olympia/editors/templates/editors/home.html:109 src/olympia/editors/templates/editors/performance.html:37 src/olympia/editors/templates/editors/themes/home.html:54
 msgid "Total Reviews"
@@ -8080,7 +7928,6 @@ msgid "Moderated Review ({num})"
 msgid_plural "Moderated Reviews ({num})"
 msgstr[0] "({num}) uređena recenzija"
 msgstr[1] "({num}) uređene recenzije"
-msgstr[2] "({num}) uređenih recenzija"
 
 #: src/olympia/editors/templates/editors/leaderboard.html:3 src/olympia/editors/templates/editors/includes/reviewers_score_bar.html:56
 msgid "Reviewer Leaderboard"
@@ -8174,46 +8021,46 @@ msgstr "Napredna pretraga"
 msgid "clear search"
 msgstr "očisti pretragu"
 
-#: src/olympia/editors/templates/editors/queue.html:72 src/olympia/editors/templates/editors/queue.html:122
+#: src/olympia/editors/templates/editors/queue.html:78 src/olympia/editors/templates/editors/queue.html:128
 msgid "Process Reviews"
 msgstr "Procesiraj recenzije"
 
-#: src/olympia/editors/templates/editors/queue.html:80
+#: src/olympia/editors/templates/editors/queue.html:86
 msgid "Moderation actions:"
 msgstr "Akcije moderacije:"
 
-#: src/olympia/editors/templates/editors/queue.html:90
+#: src/olympia/editors/templates/editors/queue.html:96
 #, python-format
 msgid "by %(user)s on %(date)s %(stars)s (%(locale)s)"
 msgstr "od %(user)s dana %(date)s %(stars)s (%(locale)s)"
 
-#: src/olympia/editors/templates/editors/queue.html:106
+#: src/olympia/editors/templates/editors/queue.html:112
 #, python-format
 msgid "<strong>%(reason)s</strong> <span class=\"light\">Flagged by %(user)s on %(date)s</span>"
 msgstr "<strong>%(reason)s</strong> <span class=\"light\">Označio %(user)s dana %(date)s</span>"
 
-#: src/olympia/editors/templates/editors/queue.html:119
+#: src/olympia/editors/templates/editors/queue.html:125
 msgid "All reviews have been moderated. Good work!"
 msgstr "Sve recenzije su uređene. Svaka čast!"
 
-#: src/olympia/editors/templates/editors/queue.html:161
+#: src/olympia/editors/templates/editors/queue.html:167
 msgid "Version Notes / Notes for Reviewer"
 msgstr "Beleške o verziji / Beleške za recenzenta"
 
 # %1 is the queue mode
-#: src/olympia/editors/templates/editors/queue.html:169
+#: src/olympia/editors/templates/editors/queue.html:175
 msgid "There are currently no add-ons of this type to review."
 msgstr "Trenutno nema dodataka ovog tipa za pregled."
 
-#: src/olympia/editors/templates/editors/queue.html:181 src/olympia/editors/templates/editors/themes/queue_list.html:85
+#: src/olympia/editors/templates/editors/queue.html:187 src/olympia/editors/templates/editors/themes/queue_list.html:85
 msgid "Helpful Links:"
 msgstr "Korisne veze:"
 
-#: src/olympia/editors/templates/editors/queue.html:182
+#: src/olympia/editors/templates/editors/queue.html:188
 msgid "Add-on Policy"
 msgstr "Politika dodatka"
 
-#: src/olympia/editors/templates/editors/queue.html:184
+#: src/olympia/editors/templates/editors/queue.html:190
 msgid "Editors' Guide"
 msgstr "Saveti urednika"
 
@@ -8419,21 +8266,18 @@ msgid "{num} Pending Theme Review"
 msgid_plural "{num} Pending Theme Reviews"
 msgstr[0] "{num} Tema čeka na pregled"
 msgstr[1] "{num} Teme čekaju na pregled"
-msgstr[2] "{num} Tema čeka na pregled"
 
 #: src/olympia/editors/templates/editors/themes/home.html:27
 msgid "{num} Flagged Review"
 msgid_plural "{num} Flagged Reviews"
 msgstr[0] "{num} Označena recenzija"
 msgstr[1] "{num} Označene recenzije"
-msgstr[2] "{num} Označenih recenzija"
 
 #: src/olympia/editors/templates/editors/themes/home.html:34
 msgid "{num} Update"
 msgid_plural "{num} Updates"
 msgstr[0] "{num} Ažuriranje"
 msgstr[1] "{num} Ažuriranja"
-msgstr[2] "{num} Ažuriranja"
 
 #: src/olympia/editors/templates/editors/themes/logs.html:4
 msgid "Theme Review Log"
@@ -8552,7 +8396,7 @@ msgstr "Postavite pitanje autoru"
 msgid "Describe your reason for flagging"
 msgstr "Navedite Vaše razloge za označavanje"
 
-#: src/olympia/files/forms.py:88
+#: src/olympia/files/forms.py:90
 msgid "Cannot diff a version against itself"
 msgstr ""
 
@@ -8587,51 +8431,51 @@ msgstr "Došlo je do greške prilikom pristupanja datoteci %s. %s."
 msgid "There was an error accessing file %s."
 msgstr "Došlo je do greške prilikom pristupanja datoteci %s."
 
-#: src/olympia/files/utils.py:343
+#: src/olympia/files/utils.py:340
 msgid "Could not parse uploaded file."
 msgstr "Nije moguće raščlaniti otpremljenu datoteku."
 
-#: src/olympia/files/utils.py:380
+#: src/olympia/files/utils.py:377
 msgid "Invalid file name in archive: {0}"
 msgstr "Nevažeći naziv datoteke u arhivi: {0}"
 
-#: src/olympia/files/utils.py:388
+#: src/olympia/files/utils.py:385
 msgid "File exceeding size limit in archive: {0}"
 msgstr "Veličina prelazi ograničenje veličine u arhivi: {0}"
 
-#: src/olympia/files/utils.py:439
+#: src/olympia/files/utils.py:436
 msgid "Invalid archive."
 msgstr "Nevažeća arhiva."
 
-#: src/olympia/files/utils.py:529 src/olympia/files/utils.py:532
+#: src/olympia/files/utils.py:526 src/olympia/files/utils.py:529
 msgid "Could not parse the manifest file."
 msgstr ""
 
-#: src/olympia/files/utils.py:551
+#: src/olympia/files/utils.py:548
 msgid "Could not find an add-on ID."
 msgstr ""
 
-#: src/olympia/files/utils.py:554
+#: src/olympia/files/utils.py:551
 msgid "Add-on ID must be 64 characters or less."
 msgstr ""
 
-#: src/olympia/files/utils.py:556
+#: src/olympia/files/utils.py:553
 msgid "Add-on ID doesn't match add-on."
 msgstr ""
 
-#: src/olympia/files/utils.py:564
+#: src/olympia/files/utils.py:561
 msgid "Duplicate add-on ID found."
 msgstr ""
 
-#: src/olympia/files/utils.py:567
+#: src/olympia/files/utils.py:564
 msgid "Version numbers should have fewer than 32 characters."
 msgstr "Broj verzije bi trebalo da bude manji od 32 karaktera."
 
-#: src/olympia/files/utils.py:570
+#: src/olympia/files/utils.py:567
 msgid "Version numbers should only contain letters, numbers, and these punctuation characters: +*.-_."
 msgstr "Broj verzije vi trebalo da sadrži samo slova, brojeve, i ove karaktere: +*.-_."
 
-#: src/olympia/files/utils.py:587
+#: src/olympia/files/utils.py:584
 msgid "<em:type> doesn't match add-on"
 msgstr "<em:type> se ne poklapa sa dodatkom"
 
@@ -8731,6 +8575,10 @@ msgstr "Nema datoteka iz otpremljene datoteke."
 #: src/olympia/files/templates/files/viewer.html:134
 msgid "Fetching file."
 msgstr "Preuzimanje datoteke."
+
+#: src/olympia/legacy_api/views.py:255
+msgid "Not implemented yet."
+msgstr "Nije još implementiran."
 
 #: src/olympia/lib/constants.py:6
 msgid "United Arab Emirates Dirham"
@@ -9388,10 +9236,6 @@ msgstr ""
 msgid "Zimbabwe Dollar"
 msgstr ""
 
-#: src/olympia/lib/video/ffmpeg.py:112 src/olympia/lib/video/totem.py:81
-msgid "Videos must be in WebM."
-msgstr ""
-
 #: src/olympia/pages/templates/pages/about.lhtml:3 src/olympia/pages/templates/pages/about.lhtml:10
 msgid "About Mozilla Add-ons"
 msgstr "O Mozilla dodacima"
@@ -9769,7 +9613,7 @@ msgstr "Da i mogu da koristim JavaScript biblioteku kao što je jQuery, MooTools
 msgid ""
 "Yes. It's possible, but some of the functionality provided by these libraries are available through XPCOM, XUL, and JavaScript. In addition, authors should take care if libraries modify primitive "
 "object prototypes (String.prototype, Date.prototype, etc.) and/or define global functions (eg. the $ function). These are prone to cause conflict with other add-ons, in particular if different add-"
-"ons use different versions of libraries and so on. Developers need to be very, very careful with using them.  Mozilla does not offer documentation on using them to build add-ons."
+"ons use different versions of libraries and so on. Developers need to be very, very careful with using them. Mozilla does not offer documentation on using them to build add-ons."
 msgstr ""
 
 #: src/olympia/pages/templates/pages/dev_faq.html:165
@@ -9889,7 +9733,7 @@ msgstr "Da li mogu da hostujem moj dodatak?"
 #, python-format
 msgid ""
 "Yes. Many developers choose to host their own add-ons. Choosing to host your add-on on <a href=\"%(amo_url)s\">Mozilla's add-on site</a>, though, allows for much greater exposure to your add-on due"
-" to the large volume of visitors to the site.  <a href=\"%(md_url)s\">mozdev.org</a> offers free project hosting for Mozilla applications and extensions providing developers with tools to help "
+" to the large volume of visitors to the site. <a href=\"%(md_url)s\">mozdev.org</a> offers free project hosting for Mozilla applications and extensions providing developers with tools to help "
 "manage source code, version control, bug tracking and documentation."
 msgstr ""
 
@@ -9938,7 +9782,7 @@ msgstr "Da li Mozilla ima polisu o tome kakva podnošenja su prihvatljiva?"
 #: src/olympia/pages/templates/pages/dev_faq.html:314
 #, python-format
 msgid ""
-"Yes. Mozilla's <a href=\"%(p_url)s\">Add-on Policy</a> describes what is an acceptable submission. This policy is subject to change without notice.  In addition, the AMO editorial team uses the <a "
+"Yes. Mozilla's <a href=\"%(p_url)s\">Add-on Policy</a> describes what is an acceptable submission. This policy is subject to change without notice. In addition, the AMO editorial team uses the <a "
 "href=\"%(g_url)s\">Editors Reviewing Guide</a> to ensure that your add-on meets specific guidelines for functionality and security."
 msgstr ""
 
@@ -10055,7 +9899,7 @@ msgstr "broj problematičnih oblasti koje su otkrivene"
 #: src/olympia/pages/templates/pages/dev_faq.html:434
 #, python-format
 msgid ""
-"This is why it's very important to read the <a href=\"%(g_url)s\">Editors Reviewing Guide</a> to ensure that your add-on is setup as expected.  It's also a good idea to read the blog post, <a "
+"This is why it's very important to read the <a href=\"%(g_url)s\">Editors Reviewing Guide</a> to ensure that your add-on is setup as expected. It's also a good idea to read the blog post, <a "
 "href=\"%(blog_url)s\">Successfully Getting your Add-on Reviewed</a> which provides excellent insight into ensuring a smooth review of your add-on."
 msgstr ""
 
@@ -10161,7 +10005,7 @@ msgstr ""
 
 #: src/olympia/pages/templates/pages/dev_faq.html:572
 msgid ""
-"Free Software Foundation provides short summaries of the key open source licenses, including whether the license qualifies as a free software license or a copyleft license.  Also includes a "
+"Free Software Foundation provides short summaries of the key open source licenses, including whether the license qualifies as a free software license or a copyleft license. Also includes a "
 "discussion of what constitutes a free software license or a copyleft license (e.g., a Copyleft license is a general method for making a program or other work free, and requiring all modified and "
 "extended versions of the program to be free as well.)"
 msgstr ""
@@ -10343,14 +10187,10 @@ msgstr "Galerija dodataka"
 msgid "How do I choose between add-ons that seem to do the same thing?"
 msgstr "Kako da se odlučim između dodataka koji rade istu stvar?"
 
-#: src/olympia/pages/templates/pages/faq.html:173
+#: src/olympia/pages/templates/pages/faq.html:172
 msgid ""
-"There are often several add-ons that have similar features. To\n"
-"    figure out which is right for you, read the entire description of the\n"
-"    add-on and view its screenshots. If there are still several in the running,\n"
-"    read through the add-on's ratings, user reviews, and statistics to see\n"
-"    which is most liked by other users. Remember that you can also just try\n"
-"    out both and see which you like better."
+"There are often several add-ons that have similar features. To figure out which is right for you, read the entire description of the add-on and view its screenshots. If there are still several in "
+"the running, read through the add-on's ratings, user reviews, and statistics to see which is most liked by other users. Remember that you can also just try out both and see which you like better."
 msgstr ""
 
 #: src/olympia/pages/templates/pages/faq.html:180
@@ -10394,11 +10234,11 @@ msgstr "Koja je cena dodataka?"
 msgid "Add-ons hosted in our gallery are free unless clearly marked otherwise."
 msgstr "Dodaci koji su hostovani u našoj galeriji su besplatni osim ako nije naznačeno drugačije."
 
-#: src/olympia/pages/templates/pages/faq.html:210
+#: src/olympia/pages/templates/pages/faq.html:209
 msgid "What does it mean when an add-on asks for contributions?"
 msgstr "Šta znači kada dodatak traži doprinose?"
 
-#: src/olympia/pages/templates/pages/faq.html:211
+#: src/olympia/pages/templates/pages/faq.html:210
 msgid ""
 "Some add-on authors request users who enjoy an add-on to contribute to its development by making a monetary contribution. These contributions go directly to the developer unless a third party is "
 "indicated, such as the non-profit Mozilla Foundation."
@@ -10406,11 +10246,11 @@ msgstr ""
 "Neki autori dodatka očekuju od korisnika koji uživaju u dodatku da doprinesu njegovom razvoju tako što će napraviti mali novčani doprinos. Ovi doprinosi idu direktno programeru, osim ako je treće "
 "lice naznačeno, kao što je neprofitna Mozilla fondacija."
 
-#: src/olympia/pages/templates/pages/faq.html:216
+#: src/olympia/pages/templates/pages/faq.html:215
 msgid "What are beta add-ons?"
 msgstr "Šta su beta dodaci?"
 
-#: src/olympia/pages/templates/pages/faq.html:218
+#: src/olympia/pages/templates/pages/faq.html:217
 msgid ""
 "Beta add-ons are unreviewed versions which represent the latest work of an add-on author. While different authors have different standards for beta code quality, you should assume that these add-"
 "ons are less stable than the general add-on releases."
@@ -10418,7 +10258,7 @@ msgstr ""
 "Beta dodaci su verzije koje nisu pregledane i predstavljaju najnovije delo autora dodataka. Dok različiti autori imaju različite standarde kvaliteta beta koda, treba pretpostaviti da su ovi dodaci "
 "manje stabilni od opšteg izdanja dodatka."
 
-#: src/olympia/pages/templates/pages/faq.html:222
+#: src/olympia/pages/templates/pages/faq.html:221
 msgid ""
 "Please note that when you install an add-on from the \"Beta Version\" section of an add-on's listing, you will continue to receive updates for that add-on as they become available. Like the initial"
 " version you installed, all beta releases are unreviewed by Mozilla and may harm your computer."
@@ -10426,22 +10266,19 @@ msgstr ""
 "Imajte na umu da kada instalirate dodatak iz \"beta verzije\" sekcije listinga dodatka, Vi će nastaviti da primate ispravke za taj dodatak, čim one postanu dostupne. Kao i početna verzija koju ste "
 "instalirali, sva beta izdanja su nepregledana i mogu da naškode Vašem računaru."
 
-#: src/olympia/pages/templates/pages/faq.html:229
+#: src/olympia/pages/templates/pages/faq.html:228
 msgid "What does it mean when an add-on is flagged as slow?"
 msgstr "Šta znači ako je dodatak označen kao spor?"
 
-#: src/olympia/pages/templates/pages/faq.html:231
-msgid ""
-"Most add-ons load code and resources at the same time Firefox\n"
-"        is starting up. In most cases the impact in start-up time is minimal,\n"
-"        but some add-ons can cause a noticeable slowdown."
+#: src/olympia/pages/templates/pages/faq.html:229
+msgid "Most add-ons load code and resources at the same time Firefox is starting up. In most cases the impact in start-up time is minimal, but some add-ons can cause a noticeable slowdown."
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:236
+#: src/olympia/pages/templates/pages/faq.html:234
 msgid "How do I report an inappropriate or spam user review?"
 msgstr "Kako mogu da prijavim neprikladan ili spam komentar?"
 
-#: src/olympia/pages/templates/pages/faq.html:237
+#: src/olympia/pages/templates/pages/faq.html:235
 msgid ""
 "To report a user review of an add-on, log in with your account and visit the add-on's reviews page. Find the review you wish to report, click \"Report this review\" and select a reason. Our "
 "editorial team will investigate the review and take appropriate action."
@@ -10449,20 +10286,20 @@ msgstr ""
 "Da biste prijavili komentar dodatka, ulogujte se na Vaš nalog i posetite stranicu za recenziju dodatka. Nađite recenziju koju želite da prijavite, kliknite na \"Prijavi ovu recenziju\" i izaberite "
 "razlog. Tim urednika će ispitati recenziju i preduzeti odgovarajuće mere."
 
-#: src/olympia/pages/templates/pages/faq.html:242
+#: src/olympia/pages/templates/pages/faq.html:240
 msgid "How do I report a bug or contact the Mozilla Add-ons team?"
 msgstr "Kako da prijavim grešku ili kontaktiram Mozilla tim za dodatke?"
 
-#: src/olympia/pages/templates/pages/faq.html:243
+#: src/olympia/pages/templates/pages/faq.html:241
 #, python-format
 msgid "Please visit our <a href=\"%(contact_url)s\">Contact page</a>."
 msgstr "Molimo Vas da posetite našu <a href=\"%(contact_url)s\">kontakt stranicu</a>."
 
-#: src/olympia/pages/templates/pages/faq.html:246
+#: src/olympia/pages/templates/pages/faq.html:244
 msgid "What is a Source Code License?"
 msgstr "Šta je licenca izvornog koda?"
 
-#: src/olympia/pages/templates/pages/faq.html:247
+#: src/olympia/pages/templates/pages/faq.html:245
 #, python-format
 msgid ""
 "The source code used to create an add-on is an exclusive copyright of the add-on author, unless otherwise declared in a source code license. Many add-ons on this site have <a href=\"%(url)s\" "
@@ -10470,42 +10307,42 @@ msgid ""
 " like the GPL or BSD licenses instead of making up their own."
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:256
+#: src/olympia/pages/templates/pages/faq.html:254
 #, python-format
 msgid "Firefox and other Mozilla software are <a href=\"%(url)s\">open source</a>."
 msgstr "Firefox i drugi Mozilla softver su <a href=\"%(url)s\">otvorenog koda</a>."
 
-#: src/olympia/pages/templates/pages/faq.html:264
+#: src/olympia/pages/templates/pages/faq.html:262
 msgid "Collections and Favorites"
 msgstr "Kolekcije i Omiljeni"
 
-#: src/olympia/pages/templates/pages/faq.html:267
+#: src/olympia/pages/templates/pages/faq.html:265
 msgid "What is a collection?"
 msgstr "Šta je kolekcija?"
 
-#: src/olympia/pages/templates/pages/faq.html:268
+#: src/olympia/pages/templates/pages/faq.html:266
 msgid "Collections are groups of related add-ons created by users to share."
 msgstr "Kolekcije su grupe srodnih dodataka kreiranih od strane korisnika da bi se delili."
 
-#: src/olympia/pages/templates/pages/faq.html:270
+#: src/olympia/pages/templates/pages/faq.html:268
 msgid "What is the My Favorites collection?"
 msgstr "Šta je Moja omiljena kolekcija?"
 
-#: src/olympia/pages/templates/pages/faq.html:271
+#: src/olympia/pages/templates/pages/faq.html:269
 msgid "Favorite add-ons are add-ons that you have bookmarked to easily get back to later. You can add an add-on to your favorites collection by clicking \"Add to favorites\" on its details page."
 msgstr ""
 "Omiljeni dodaci su dodaci koje ste zabeležili da bi ste ih lako našli kasnije. Možete da dodate dodatak u omiljene kolekciju tako što ćete kliknuti na \"Dodaj u omiljene\" na svojoj stranici sa "
 "detaljima."
 
-#: src/olympia/pages/templates/pages/faq.html:275 src/olympia/templates/menu_links.html:13 src/olympia/templates/impala/header_title.html:17
+#: src/olympia/pages/templates/pages/faq.html:273 src/olympia/templates/menu_links.html:13 src/olympia/templates/impala/header_title.html:17
 msgid "Mobile Add-ons"
 msgstr "Dodaci za mobilni"
 
-#: src/olympia/pages/templates/pages/faq.html:278
+#: src/olympia/pages/templates/pages/faq.html:276
 msgid "What are mobile add-ons?"
 msgstr "Šta je mobilni dodatak?"
 
-#: src/olympia/pages/templates/pages/faq.html:279
+#: src/olympia/pages/templates/pages/faq.html:277
 #, python-format
 msgid ""
 "Mobile add-ons work with <a href=\"%(mobile_url)s\">Firefox for Mobile</a> and add or modify functionality just like desktop add-ons. You can find add-ons that work with Firefox for Mobile in our "
@@ -10514,20 +10351,20 @@ msgstr ""
 "Mobilni dodaci rade na <a href=\"%(mobile_url)s\">Firefox-u za mobilni </a> i oni dodaju ili menjaju funkcionalnost kao dodaci za desktop. Možete naći dodatke koji radi na Firefox-u za mobilni u "
 "našoj <a href=\"%(gallery_url)s\">galeriji</a>."
 
-#: src/olympia/pages/templates/pages/faq.html:288
+#: src/olympia/pages/templates/pages/faq.html:286
 msgid "Developer Topics"
 msgstr "Programerske teme"
 
-#: src/olympia/pages/templates/pages/faq.html:289
+#: src/olympia/pages/templates/pages/faq.html:287
 #, python-format
 msgid "Please see our <a href=\"%(faq_url)s\">Developer FAQ</a> and <a href=\"%(hub_url)s\">Developer Hub</a> for answers to add-on developer-related questions."
 msgstr "Pogledajte naša <a href=\"%(faq_url)s\">ČPP za programere </a> i <a href=\"%(hub_url)s\">Developer Hub</a> za odgovore na pitanja koje se odnose na razvoj dodataka."
 
-#: src/olympia/pages/templates/pages/faq.html:294
+#: src/olympia/pages/templates/pages/faq.html:292
 msgid "Still have questions?"
 msgstr "Još uvek imate pitanja?"
 
-#: src/olympia/pages/templates/pages/faq.html:295
+#: src/olympia/pages/templates/pages/faq.html:293
 #, python-format
 msgid "For general Firefox support, visit our <a href=\"%(sumo_url)s\">support website</a>. For general add-on and website questions, visit our <a href=\"%(forum_url)s\">forum</a>."
 msgstr "Za opštu Firefox podršku, posetite naš <a href=\"%(sumo_url)s\">sajt za podršku</a>. Za opšta pitanja o dodacima ili opcijama veb sajta, posetite naš <a href=\"%(forum_url)s\">forum</a>."
@@ -10745,7 +10582,7 @@ msgstr "Dodaj recenziju za {0}"
 #, python-format
 msgid ""
 "<h2>Keep these tips in mind:</h2> <ul> <li> Write like you're telling a friend about your experience with the add-on. Give specifics and helpful details, such as what features you liked and/or "
-"disliked, how easy to use it is, and any disadvantages it has.  Avoid generic language such as calling it \"Great\" or \"Bad\" unless you can give reasons why you believe this is so. </li> <li> "
+"disliked, how easy to use it is, and any disadvantages it has. Avoid generic language such as calling it \"Great\" or \"Bad\" unless you can give reasons why you believe this is so. </li> <li> "
 "Please do not post bug reports in reviews. We do not make your email address available to add-on developers and they may need to contact you to help resolve your issue. See the <a "
 "href=\"%(support)s\">support section</a> to find out where to get assistance for this add-on. </li> <li>Please keep reviews clean, avoid the use of improper language and do not post any personal "
 "information. </li> </ul> <p>Please read the <a href=\"%(guide)s\" target=\"_blank\">Review Guidelines</a> for more detail about user add-on reviews.</p>"
@@ -10793,7 +10630,6 @@ msgid "This user has a <a href=\"%(user_review_url)s\">previous review</a> of th
 msgid_plural "This user has <a href=\"%(user_review_url)s\">%(cnt)s previous reviews</a> of this add-on."
 msgstr[0] "Ovaj korisnik ima <a href=\"%(user_review_url)s\">prethodni pregled</a> ovog dodatka."
 msgstr[1] "Ovaj korisnik ima <a href=\"%(user_review_url)s\">%(cnt)s prethodna pregleda</a> ovog dodatka."
-msgstr[2] "Ovaj korisnik ima <a href=\"%(user_review_url)s\">%(cnt)s prethodnih pregleda</a> ovog dodatka."
 
 #: src/olympia/reviews/templates/reviews/review.html:62
 #, python-format
@@ -10840,7 +10676,6 @@ msgid "<b>{0}</b> review for this add-on"
 msgid_plural "<b>{0}</b> reviews for this add-on"
 msgstr[0] "<b>{0}</b> pregled za ovaj dodatak"
 msgstr[1] "<b>{0}</b> pregleda za ovaj dodatak"
-msgstr[2] "<b>{0}</b> pregleda za ovaj dodatak"
 
 #. {0} is a developer's name.
 #: src/olympia/reviews/templates/reviews/review_list.html:33
@@ -10853,7 +10688,6 @@ msgid "Review for %(addon)s by %(user)s"
 msgid_plural "Reviews for %(addon)s by %(user)s"
 msgstr[0] "Recenzija za %(addon)s od %(user)s"
 msgstr[1] "Recenzije za %(addon)s od %(user)s"
-msgstr[2] "Recenzije za %(addon)s od %(user)s"
 
 #: src/olympia/reviews/templates/reviews/review_list.html:42
 msgid "No reviews found."
@@ -10877,7 +10711,6 @@ msgid "{num} review"
 msgid_plural "{num} reviews"
 msgstr[0] "{num} kritika"
 msgstr[1] "{num} kritike"
-msgstr[2] "{num} kritika"
 
 #: src/olympia/reviews/templates/reviews/impala/reviews_rating.html:1
 msgid "Rated {0} out of 5 stars"
@@ -10905,7 +10738,6 @@ msgid "Average from {0} Rating"
 msgid_plural "Average from {0} Ratings"
 msgstr[0] "Prosek od {0} ocene"
 msgstr[1] "Prosek od {0} ocene"
-msgstr[2] "Prosek od {0} ocena"
 
 #: src/olympia/reviews/templates/reviews/mobile/review_list.html:34
 #, python-format
@@ -10922,7 +10754,6 @@ msgid "See All Reviews"
 msgid_plural "See All %(cnt)s Reviews"
 msgstr[0] "Pogledaj sve recenzije"
 msgstr[1] "Pogledaj svih %(cnt)s recenzija"
-msgstr[2] "Pogledaj svih %(cnt)s recenzija"
 
 #: src/olympia/search/forms.py:11
 msgid "Most popular this week"
@@ -11003,16 +10834,16 @@ msgstr "{0} dodataka"
 
 #. L10n: {0} is an application, such as Firefox. This means "any version of
 #. Firefox."
-#: src/olympia/search/views.py:554
+#: src/olympia/search/views.py:547
 msgid "Any {0}"
 msgstr "Bilo koji {0}"
 
 #. L10n: "All Systems" means show everything regardless of platform.
-#: src/olympia/search/views.py:589
+#: src/olympia/search/views.py:582
 msgid "All Systems"
 msgstr "Svi sistemi"
 
-#: src/olympia/search/views.py:600
+#: src/olympia/search/views.py:593
 msgid "All Tags"
 msgstr "Sve oznake"
 
@@ -11057,7 +10888,6 @@ msgid "<b>{0}</b> matching result"
 msgid_plural "<b>{0}</b> matching results"
 msgstr[0] "<b>{0}</b> odgovarajući rezultat"
 msgstr[1] "<b>{0}</b> odgovarajuća rezultata"
-msgstr[2] "<b>{0}</b> odgovarajućih rezultata"
 
 #: src/olympia/search/templates/search/results.html:67
 msgid "Filter Results"
@@ -11080,7 +10910,6 @@ msgid "{0} post"
 msgid_plural "{0} posts"
 msgstr[0] "{0} poruka"
 msgstr[1] "{0} poruke"
-msgstr[2] "{0} poruka"
 
 #: src/olympia/sharing/__init__.py:20
 msgid "Post to Facebook"
@@ -11091,7 +10920,6 @@ msgid "{0} Like"
 msgid_plural "{0} Likes"
 msgstr[0] ""
 msgstr[1] ""
-msgstr[2] ""
 
 #: src/olympia/sharing/__init__.py:30
 msgid "Tweet on Twitter"
@@ -11102,7 +10930,6 @@ msgid "{0} tweet"
 msgid_plural "{0} tweets"
 msgstr[0] "{0} tvit"
 msgstr[1] "{0} tvita"
-msgstr[2] "{0} tvitova"
 
 #: src/olympia/sharing/__init__.py:40
 msgid "Share on g+"
@@ -11137,7 +10964,6 @@ msgid "{0} post on localservice1"
 msgid_plural "{0} posts on localservice1"
 msgstr[0] "{0} objava na localservice1"
 msgstr[1] "{0} objave na localservice1"
-msgstr[2] "{0} objava na localservice1"
 
 #. L10n: Only change if you have reason! wiki.mozilla.org/AMO:Localizers
 #: src/olympia/sharing/__init__.py:76
@@ -11160,7 +10986,6 @@ msgid "{0} post on localservice2"
 msgid_plural "{0} posts on localservice2"
 msgstr[0] "{0} objava na localservice2"
 msgstr[1] "{0} objave na localservice2"
-msgstr[2] "{0} objava na localservice2"
 
 #. L10n: Only change if you have reason! wiki.mozilla.org/AMO:Localizers
 #: src/olympia/sharing/__init__.py:91
@@ -11183,7 +11008,6 @@ msgid "{0} post on localservice3"
 msgid_plural "{0} posts on localservice3"
 msgstr[0] "{0} objava na localservice3"
 msgstr[1] "{0} objave na localservice3"
-msgstr[2] "{0} objava na localservice3"
 
 #: src/olympia/sharing/templates/sharing/sharing_widget.html:2
 msgid "Share this Add-on"
@@ -11193,31 +11017,31 @@ msgstr "Deli ovaj dodatak sa ostalima"
 msgid "Share this Collection"
 msgstr "Podeli ovu kolekciju"
 
-#: src/olympia/signing/views.py:30 src/olympia/templates/base.html:75 src/olympia/templates/impala/base.html:115
+#: src/olympia/signing/views.py:33 src/olympia/templates/base.html:71 src/olympia/templates/impala/base.html:112
 msgid "Some features are temporarily disabled while we perform website maintenance. We'll be back to full capacity shortly."
 msgstr "Neke funkcije su privremeno onemogućene dok vršimo održavanje veb sajta. Mi ćemo se vratiti u punom kapacitetu uskoro."
 
-#: src/olympia/signing/views.py:53
+#: src/olympia/signing/views.py:56
 msgid "Could not find add-on with id \"{}\"."
 msgstr ""
 
-#: src/olympia/signing/views.py:67
+#: src/olympia/signing/views.py:70
 msgid "You do not own this addon."
 msgstr ""
 
-#: src/olympia/signing/views.py:82
+#: src/olympia/signing/views.py:87
 msgid "Missing \"upload\" key in multipart file data."
 msgstr ""
 
-#: src/olympia/signing/views.py:96
+#: src/olympia/signing/views.py:101
 msgid "Version does not match the manifest file."
 msgstr ""
 
-#: src/olympia/signing/views.py:100
+#: src/olympia/signing/views.py:105
 msgid "Version already exists."
 msgstr ""
 
-#: src/olympia/signing/views.py:136
+#: src/olympia/signing/views.py:141
 msgid "No uploaded file for that addon and version."
 msgstr ""
 
@@ -11330,89 +11154,89 @@ msgstr "{0} :: Kontrolna tabla statistika"
 msgid "Statistics Dashboard :: Add-ons for {0}"
 msgstr "Kontrolna tabla statistika :: dodaci za {0}"
 
-#: src/olympia/stats/templates/stats/stats.html:30
-msgid "Controls:"
-msgstr "Kontrole:"
-
-#: src/olympia/stats/templates/stats/stats.html:33
-msgid "reset zoom"
-msgstr "resetuj uveličaj"
-
-#: src/olympia/stats/templates/stats/stats.html:40
-msgid "Group by:"
-msgstr "Grupiši po:"
-
-#: src/olympia/stats/templates/stats/stats.html:42
-msgid "day"
-msgstr "danu"
-
-#: src/olympia/stats/templates/stats/stats.html:45
-msgid "week"
-msgstr "sedmici"
-
-#: src/olympia/stats/templates/stats/stats.html:48
-msgid "month"
-msgstr "mesec dana"
-
-#: src/olympia/stats/templates/stats/stats.html:54
-msgid "For last:"
-msgstr "Za poslednjih:"
-
-#: src/olympia/stats/templates/stats/stats.html:57
-msgid "7 days"
-msgstr "7 dana"
-
-#: src/olympia/stats/templates/stats/stats.html:60
-msgid "30 days"
-msgstr "30 dana"
-
-#: src/olympia/stats/templates/stats/stats.html:63
-msgid "90 days"
-msgstr "90 dana"
-
-#: src/olympia/stats/templates/stats/stats.html:66
-msgid "365 days"
-msgstr "365 dana"
-
-#: src/olympia/stats/templates/stats/stats.html:69
-msgid "Custom..."
-msgstr "Prilagođeno..."
-
 #. {0} is an add-on name
-#: src/olympia/stats/templates/stats/stats.html:88 src/olympia/stats/templates/stats/stats.html:91
+#: src/olympia/stats/templates/stats/stats.html:44 src/olympia/stats/templates/stats/stats.html:47
 msgid "Statistics for {0}"
 msgstr "Statistika za {0}"
 
-#: src/olympia/stats/templates/stats/stats.html:94
+#: src/olympia/stats/templates/stats/stats.html:50
 msgid "Statistics Dashboard"
 msgstr "Kontrolna tabla statistika"
 
-#: src/olympia/stats/templates/stats/stats.html:104
+#: src/olympia/stats/templates/stats/stats.html:57
+msgid "Controls:"
+msgstr "Kontrole:"
+
+#: src/olympia/stats/templates/stats/stats.html:60
+msgid "reset zoom"
+msgstr "resetuj uveličaj"
+
+#: src/olympia/stats/templates/stats/stats.html:67
+msgid "Group by:"
+msgstr "Grupiši po:"
+
+#: src/olympia/stats/templates/stats/stats.html:69
+msgid "day"
+msgstr "danu"
+
+#: src/olympia/stats/templates/stats/stats.html:72
+msgid "week"
+msgstr "sedmici"
+
+#: src/olympia/stats/templates/stats/stats.html:75
+msgid "month"
+msgstr "mesec dana"
+
+#: src/olympia/stats/templates/stats/stats.html:81
+msgid "For last:"
+msgstr "Za poslednjih:"
+
+#: src/olympia/stats/templates/stats/stats.html:84
+msgid "7 days"
+msgstr "7 dana"
+
+#: src/olympia/stats/templates/stats/stats.html:87
+msgid "30 days"
+msgstr "30 dana"
+
+#: src/olympia/stats/templates/stats/stats.html:90
+msgid "90 days"
+msgstr "90 dana"
+
+#: src/olympia/stats/templates/stats/stats.html:93
+msgid "365 days"
+msgstr "365 dana"
+
+#: src/olympia/stats/templates/stats/stats.html:96
+msgid "Custom..."
+msgstr "Prilagođeno..."
+
+#: src/olympia/stats/templates/stats/stats.html:106
 msgid "Statistics processing is currently disabled, so recent data is unavailable. The statistics are still being collected and this page will be updated soon with the missing data."
 msgstr ""
 
-#: src/olympia/stats/templates/stats/stats.html:110
+#: src/olympia/stats/templates/stats/stats.html:112
 msgid "Loading the latest data&hellip;"
 msgstr "Učitavam najnovije podatke&hellip;"
 
-#: src/olympia/stats/templates/stats/stats.html:142 src/olympia/stats/templates/stats/reports/overview.html:25 src/olympia/stats/templates/stats/reports/overview.html:37
+#: src/olympia/stats/templates/stats/stats.html:144 src/olympia/stats/templates/stats/reports/overview.html:25 src/olympia/stats/templates/stats/reports/overview.html:37
 #: src/olympia/stats/templates/stats/reports/overview.html:49
 msgid "No data available."
 msgstr "Nema dostupnih podataka."
 
-#: src/olympia/stats/templates/stats/stats.html:177
+#: src/olympia/stats/templates/stats/stats.html:179
 msgid "This dashboard is currently <b>public</b>."
 msgstr "Ova kontrolna tabla je trenutno <b>javna</b>."
 
-#: src/olympia/stats/templates/stats/stats.html:179
+#: src/olympia/stats/templates/stats/stats.html:181
 msgid "Contribution stats are currently <b>private</b>."
 msgstr "Statistike doprinosa su trenutno <b>privatne </b>."
 
-#: src/olympia/stats/templates/stats/stats.html:182
+#: src/olympia/stats/templates/stats/stats.html:184
 msgid "This dashboard is currently <b>private</b>."
 msgstr "Ova kontrolna tabla je trenutno <b>privatna</b>."
 
-#: src/olympia/stats/templates/stats/stats.html:185
+#: src/olympia/stats/templates/stats/stats.html:187
 msgid "Change settings."
 msgstr "Promeni postavke."
 
@@ -11570,15 +11394,6 @@ msgstr "Broj registrovanih korisnika po datumu"
 msgid "Application versions by Date"
 msgstr "Verzije aplikacija po datumu"
 
-#: src/olympia/tags/templates/tags/top_cloud.html:4
-msgid "Top {0} Tags"
-msgstr "Najpopularnijih {0} oznaka"
-
-#. {0} is the current application name
-#: src/olympia/tags/templates/tags/top_cloud.html:14
-msgid "{0} Top Tags"
-msgstr "{0} Najčešće korišćene oznake"
-
 #: src/olympia/templates/amo_footer.html:6 src/olympia/templates/includes/lang_switcher.html:2
 msgid "Other languages"
 msgstr "Drugi jezici"
@@ -11587,11 +11402,11 @@ msgstr "Drugi jezici"
 msgid "Mozilla Add-ons"
 msgstr "Mozilla dodaci"
 
-#: src/olympia/templates/base.html:91 src/olympia/templates/impala/base.html:81
+#: src/olympia/templates/base.html:89 src/olympia/templates/impala/base.html:78
 msgid "Find add-ons for other applications"
 msgstr "Pronađite dodatke za ostale aplikacije"
 
-#: src/olympia/templates/base.html:92 src/olympia/templates/impala/base.html:81
+#: src/olympia/templates/base.html:90 src/olympia/templates/impala/base.html:78
 msgid "Other Applications"
 msgstr "Ostale aplikacije"
 
@@ -11616,7 +11431,7 @@ msgid "View Mobile Site"
 msgstr "Sajt za mobilne uređaje"
 
 #: src/olympia/templates/copyright.html:7
-msgid "Site Status "
+msgid "Site Status"
 msgstr ""
 
 #: src/olympia/templates/footer.html:3
@@ -11718,35 +11533,35 @@ msgstr "Dobrodošli, {0}"
 msgid "<a href=\"%(reg)s\">Register</a> or <a href=\"%(login)s\">Log in</a>"
 msgstr "<a href=\"%(reg)s\">Registrujte nalog</a> ili se <a href=\"%(login)s\">prijavite</a>"
 
-#: src/olympia/templates/impala/base.html:126
+#: src/olympia/templates/impala/base.html:123
 #, python-format
 msgid "To try the thousands of add-ons available here, download <a href=\"%(url)s\">Mozilla Firefox</a>, a fast, free way to surf the Web!"
 msgstr "Da biste isprobali hiljade dodataka dostupnih ovde, preuzmite <a href=\"%(url)s\">Mozilla Firefox</a>, brz i besplatan način da surfujete vebom!"
 
-#: src/olympia/templates/impala/base.html:138
+#: src/olympia/templates/impala/base.html:135
 #, python-format
 msgid "Add-ons is switching to Firefox Accounts for login. <a href=\"%(url)s\" class=\"fxa-login\">Sign in now to transfer your account.</a>"
 msgstr ""
 
 #. {0} is an application, such as Firefox.
-#: src/olympia/templates/impala/base.html:148
+#: src/olympia/templates/impala/base.html:145
 msgid "Welcome to {0} Add-ons."
 msgstr "Dobrodošli na {0} dodatke."
 
-#: src/olympia/templates/impala/base.html:151
+#: src/olympia/templates/impala/base.html:148
 msgid "Choose from thousands of extra features and styles to make Firefox your own."
 msgstr "Izaberite iz hiljade dodatnih mogućnosti i stilova kako bi Firefox učinili svojim."
 
-#: src/olympia/templates/impala/base.html:156
+#: src/olympia/templates/impala/base.html:153
 #, python-format
 msgid "Add extra features and styles to make %(app)s your own."
 msgstr "Dodajte dodatne mogućnosti i stilove kako bi napravili %(app)s na svoj način."
 
-#: src/olympia/templates/impala/base.html:164
+#: src/olympia/templates/impala/base.html:161
 msgid "On the go?"
 msgstr "U pokretu ste?"
 
-#: src/olympia/templates/impala/base.html:166
+#: src/olympia/templates/impala/base.html:163
 msgid "Check out our <a class=\"mobile-link\" href=\"#\">Mobile Add-ons site</a>."
 msgstr "Proverite naš <a class=\"mobile-link\" href=\"#\">sajt za mobilne ekstenzije</a>."
 
@@ -11970,19 +11785,19 @@ msgstr "Nema korisnika sa tom adresom e-pošte."
 
 #. L10n: {id} will be something like "13ad6a", just a random number
 #. to differentiate this user from other anonymous users.
-#: src/olympia/users/models.py:353
+#: src/olympia/users/models.py:362
 msgid "Anonymous user {id}"
 msgstr ""
 
-#: src/olympia/users/models.py:410
+#: src/olympia/users/models.py:419
 msgid "Your account has been restricted"
 msgstr "Vaš nalog je ograničen"
 
-#: src/olympia/users/models.py:480
+#: src/olympia/users/models.py:489
 msgid "Please confirm your email address"
 msgstr "Molimo Vas potvrdite adresu e-pošte"
 
-#: src/olympia/users/models.py:506
+#: src/olympia/users/models.py:515
 msgid "My Mobile Add-ons"
 msgstr "Moji dodaci za mobilne"
 
@@ -12723,7 +12538,6 @@ msgid "%(num)s theme"
 msgid_plural "%(num)s themes"
 msgstr[0] "%(num)s tema"
 msgstr[1] "%(num)s teme"
-msgstr[2] "%(num)s tema"
 
 #: src/olympia/users/templates/users/vcard.html:62
 #, python-format
@@ -12731,7 +12545,6 @@ msgid "%(num)s add-on"
 msgid_plural "%(num)s add-ons"
 msgstr[0] "%(num)s dodatak"
 msgstr[1] "%(num)s dodatka"
-msgstr[2] "%(num)s dodataka"
 
 #: src/olympia/users/templates/users/vcard.html:75
 msgid "Average rating of developer's add-ons"
@@ -12747,15 +12560,15 @@ msgstr "%s istorijat verzije"
 msgid "Version History with Changelogs"
 msgstr "Istorijat verzija sa promenama"
 
-#: src/olympia/versions/models.py:314
+#: src/olympia/versions/models.py:313
 msgid "Add-on uses binary components."
 msgstr "Dodaci koriste binarne komponente."
 
-#: src/olympia/versions/models.py:317
+#: src/olympia/versions/models.py:316
 msgid "Add-on has opted into strict compatibility checking."
 msgstr "Dodatak se opredelio strogom proverom kompatibilnosti."
 
-#: src/olympia/versions/models.py:715
+#: src/olympia/versions/models.py:711
 msgid "{app} {min} and later"
 msgstr "{app} {min} i kasnije"
 
@@ -12794,7 +12607,6 @@ msgid "<b>{0}</b> version"
 msgid_plural "<b>{0}</b> versions"
 msgstr[0] "<b>{0}</b> verzija"
 msgstr[1] "<b>{0}</b> verzije"
-msgstr[2] "<b>{0}</b> verzija"
 
 #: src/olympia/versions/templates/versions/version_list.html:35 src/olympia/versions/templates/versions/mobile/version_list.html:14
 msgid "Be careful with old versions!"
@@ -12833,4 +12645,8 @@ msgstr "Pošalji mi e-poštu kada je završeno"
 #: src/olympia/zadmin/forms.py:105
 msgid "Log emails instead of sending"
 msgstr "Beleži e-pošte umesto slanja"
+
+#: src/olympia/zadmin/forms.py:215
+msgid "Deleted versions can`t be changed."
+msgstr ""
 

--- a/locale/sr_Latn/LC_MESSAGES/djangojs.po
+++ b/locale/sr_Latn/LC_MESSAGES/djangojs.po
@@ -1,1231 +1,1238 @@
-
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2016-02-24 21:23+0000\n"
+"POT-Creation-Date: 2016-04-18 15:47+0000\n"
 "PO-Revision-Date: 2015-02-01 09:53+0000\n"
 "Last-Translator: Vanja <tumbas93@gmail.com>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
+"Language: \n"
 "MIME-Version: 1.0\n"
-"Content-Type: text/plain; charset=utf-8\n"
+"Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Generated-By: Babel 2.2.0\n"
 
-#: static/js/common/ratingwidget.js:31
+#: static/js/common-all.js:1426 static/js/impala-all.js:1511 static/js/zamboni/discovery-all.js:12598 static/js/zamboni/init.js:28 static/js/zamboni/mobile-all.js:14945
+msgid "This feature is temporarily disabled while we perform website maintenance. Please check back a little later."
+msgstr "Ova mogućnost je privremeno onemogućena dok obavljamo zadatak održavanja sajta. Molimo probajte malo kasnije."
+
+#. L10n: {0} is an app name like Firefox.
+#: static/js/common-all.js:1837 static/js/impala-all.js:1922 static/js/zamboni/buttons.js:73 static/js/zamboni/discovery-all.js:13108
+msgid "Accept and Install"
+msgstr "Prihvati i instaliraj"
+
+#: static/js/common-all.js:1837 static/js/impala-all.js:1922 static/js/zamboni/buttons.js:73 static/js/zamboni/discovery-all.js:13108
+msgid "Add to {0}"
+msgstr "Dodaj u {0}"
+
+#: static/js/common-all.js:1842 static/js/impala-all.js:1927 static/js/zamboni/buttons.js:78 static/js/zamboni/discovery-all.js:13113
+msgid "Download Now"
+msgstr "Preuzmi odmah"
+
+#: static/js/common-all.js:1883 static/js/impala-all.js:1968 static/js/zamboni/buttons.js:119 static/js/zamboni/discovery-all.js:13154
+msgid "Add-on has not been updated to support default-to-compatible."
+msgstr "Dodatak nije ažuriran da podržava default-to-compatible."
+
+#: static/js/common-all.js:1888 static/js/impala-all.js:1973 static/js/zamboni/buttons.js:124 static/js/zamboni/discovery-all.js:13159
+msgid "You need to be using Firefox 10.0 or higher."
+msgstr "Morate koristiti Firefox 10.0 ili novije."
+
+#: static/js/common-all.js:1900 static/js/impala-all.js:1985 static/js/zamboni/buttons.js:136 static/js/zamboni/discovery-all.js:13171
+msgid "Mozilla has marked this version as incompatible with your Firefox version."
+msgstr "Mozilla je označila ovu verziju kao nekompatabilnu sa Vašom verzijom Firefox-a."
+
+#. L10n: {0} is an platform like Windows or Linux.
+#: static/js/common-all.js:1981 static/js/impala-all.js:2066 static/js/zamboni/buttons.js:217 static/js/zamboni/discovery-all.js:13252
+msgid "Install for {0} anyway"
+msgstr "Instaliraj za {0} u svakom slučaju"
+
+#: static/js/common-all.js:1981 static/js/impala-all.js:2066 static/js/zamboni/buttons.js:217 static/js/zamboni/discovery-all.js:13252
+msgid "Download for {0} anyway"
+msgstr "Preuzmi za {0} u svakom slučaju"
+
+#: static/js/common-all.js:2038 static/js/impala-all.js:2123 static/js/zamboni/buttons.js:274 static/js/zamboni/discovery-all.js:13309
+msgid "Not available for your platform"
+msgstr "Nije dostupno za Vašu platformu"
+
+#. L10n: {0} is an app name, {1} is the app version.
+#: static/js/common-all.js:2049 static/js/common-all.js:2086 static/js/impala-all.js:2134 static/js/impala-all.js:2171 static/js/zamboni/buttons.js:286 static/js/zamboni/buttons.js:324
+#: static/js/zamboni/discovery-all.js:13320 static/js/zamboni/discovery-all.js:13357
+msgid "Not available for {0} {1}"
+msgstr "Nije dostupno za {0} {1}"
+
+#: static/js/common-all.js:2112 static/js/impala-all.js:2197 static/js/zamboni/buttons.js:351 static/js/zamboni/discovery-all.js:13383
+msgid "Works with {app} {min} - {max}"
+msgstr "Radi sa {app} {min} - {max}"
+
+#: static/js/common-all.js:2114 static/js/impala-all.js:2199 static/js/zamboni/buttons.js:353 static/js/zamboni/discovery-all.js:13385
+msgid "View other versions"
+msgstr "Pogledaj ostale verzije"
+
+#: static/js/common-all.js:2162 static/js/impala-all.js:2247 static/js/zamboni/buttons.js:401 static/js/zamboni/discovery-all.js:13433
+msgid "Only with Firefox — Get Firefox Now!"
+msgstr ""
+
+#: static/js/common-all.js:2278 static/js/impala-all.js:2363 static/js/zamboni/buttons.js:517 static/js/zamboni/discovery-all.js:13549 static/js/zamboni/mobile-all.js:15177
+#: static/js/zamboni/mobile/buttons.js:43
+msgid "Sorry, you need a Mozilla-based browser (such as Firefox) to install a search plugin."
+msgstr "Žao nam je, treba Vam pregledač baziran na tehnologiji Mozilla fondacije (kao što je Firefox) da biste instalirali priključak za pretraživanje."
+
+#: static/js/common-all.js:9088 static/js/impala-all.js:9649 static/js/zamboni/global.js:410
+msgid "Loading..."
+msgstr "Učitavanje..."
+
+#. L10n: {0} is the number of characters left.
+#: static/js/common-all.js:9152 static/js/impala-all.js:9713 static/js/zamboni/global.js:474
+msgid "<b>{0}</b> character left."
+msgid_plural "<b>{0}</b> characters left."
+msgstr[0] "<b>{0}</b> karakter preostao."
+msgstr[1] "<b>{0}</b> karaktera preostala."
+
+#: static/js/common-all.js:9589 static/js/common-min.js:6 static/js/impala-all.js:10052 static/js/impala-min.js:6 static/js/common/ratingwidget.js:31 static/js/zamboni/mobile-all.js:16123
+#: static/js/zamboni/mobile-min.js:6
 msgid "{0} star"
 msgid_plural "{0} stars"
 msgstr[0] "{0} zvedica"
 msgstr[1] "{0} zvedice"
-msgstr[2] "{0} zvedica"
 
-#: static/js/common/upload-addon.js:41 static/js/common/upload-image.js:128
+#: static/js/common-all.js:9676 static/js/common-min.js:6 static/js/impala-all.js:10139 static/js/impala-min.js:6 static/js/zamboni/l10n.js:45
+msgid "Remove this localization"
+msgstr "Ukloni ovu lokalizaciju"
+
+#: static/js/common-all.js:10193 static/js/common-min.js:6 static/js/impala-all.js:10674 static/js/impala-min.js:6 static/js/zamboni/discovery-all.js:13678
+msgid "close"
+msgstr ""
+
+#: static/js/common-all.js:10860 static/js/common-min.js:6 static/js/impala-all.js:11481 static/js/impala-min.js:6 static/js/impala/reviews.js:23 static/js/zamboni/reviews.js:18
+msgid "Flagged for review"
+msgstr "Naznačeno za pregled"
+
+#: static/js/common-all.js:10876 static/js/common-min.js:6 static/js/impala-all.js:11498 static/js/impala-min.js:6 static/js/impala/reviews.js:40 static/js/zamboni/reviews.js:34
+msgid "Your input is required"
+msgstr "Vaš odziv je neophodan"
+
+#: static/js/common-all.js:10945 static/js/common-min.js:6 static/js/impala-all.js:11610 static/js/impala-min.js:7 static/js/impala/reviews.js:152 static/js/zamboni/reviews.js:103
+msgid "Marked for deletion"
+msgstr "Obeleženo za brisanje"
+
+#: static/js/common-all.js:11573 static/js/common-min.js:7 static/js/impala-all.js:13809 static/js/impala-min.js:8 static/js/zamboni/collections.js:229
+msgid "Adding to Favorites&hellip;"
+msgstr "Dodajem u Omiljeno&hellip;"
+
+#: static/js/common-all.js:11576 static/js/common-min.js:7 static/js/impala-all.js:13812 static/js/impala-min.js:8 static/js/zamboni/collections.js:232
+msgid "Removing Favorite&hellip;"
+msgstr "Brišem iz Omiljenih&hellip;"
+
+#: static/js/common-all.js:11579 static/js/common-min.js:7 static/js/impala-all.js:13815 static/js/impala-min.js:8 static/js/zamboni/collections.js:235
+msgid "Add to Favorites"
+msgstr "Dodaj u Omiljene"
+
+#: static/js/common-all.js:11582 static/js/common-min.js:7 static/js/impala-all.js:13818 static/js/impala-min.js:8 static/js/zamboni/collections.js:238
+msgid "Remove from Favorites"
+msgstr "Izbriši iz Omiljenih"
+
+#: static/js/common-all.js:11647 static/js/common-min.js:7 static/js/impala-all.js:13883 static/js/impala-min.js:8 static/js/zamboni/collections.js:303
+msgid "Pending"
+msgstr "Na čekanju"
+
+#: static/js/common-all.js:11648 static/js/common-min.js:7 static/js/impala-all.js:13884 static/js/impala-min.js:8 static/js/zamboni/collections.js:304
+msgid "Add a comment"
+msgstr "Dodaj komentar"
+
+#: static/js/common-all.js:11648 static/js/common-min.js:7 static/js/impala-all.js:13884 static/js/impala-min.js:8 static/js/zamboni/collections.js:304
+msgid "Comment"
+msgstr "Komentar"
+
+#: static/js/common-all.js:11649 static/js/common-min.js:7 static/js/impala-all.js:13885 static/js/impala-min.js:8 static/js/zamboni/collections.js:305
+msgid "Remove this add-on from the collection"
+msgstr "Izbriši ovaj dodatak iz kolekcije"
+
+#: static/js/common-all.js:11649 static/js/common-all.js:11678 static/js/common-min.js:7 static/js/impala-all.js:13885 static/js/impala-all.js:13914 static/js/impala-min.js:8
+#: static/js/zamboni/collections.js:305 static/js/zamboni/collections.js:334
+msgid "Remove"
+msgstr "Izbriši"
+
+#: static/js/common-all.js:11678 static/js/common-min.js:7 static/js/impala-all.js:13914 static/js/impala-min.js:8 static/js/zamboni/collections.js:334
+msgid "Remove this user as a contributor"
+msgstr "Ukloni korisnika kao saradnika"
+
+#: static/js/common-all.js:11690 static/js/common-min.js:7 static/js/impala-all.js:13926 static/js/impala-min.js:8 static/js/zamboni/collections.js:346
+msgid "An email address is required."
+msgstr "Adresa e-pošte je obavezna."
+
+#: static/js/common-all.js:11708 static/js/common-min.js:7 static/js/impala-all.js:13944 static/js/impala-min.js:8 static/js/zamboni/collections.js:364
+msgid "You cannot add yourself as a contributor."
+msgstr "Ne možete sebe dodati kao saradnika."
+
+#: static/js/common-all.js:11710 static/js/common-min.js:7 static/js/impala-all.js:13946 static/js/impala-min.js:8 static/js/zamboni/collections.js:366
+msgid "You have already added that user."
+msgstr "Već ste dodali tog korisnika."
+
+#: static/js/common-all.js:11917 static/js/common-min.js:7 static/js/impala-all.js:14153 static/js/impala-min.js:8 static/js/zamboni/collections.js:573
+msgid "Add to favorites"
+msgstr "Dodaj u omiljene"
+
+#: static/js/common-all.js:11921 static/js/common-min.js:7 static/js/impala-all.js:14157 static/js/impala-min.js:8 static/js/zamboni/collections.js:577
+msgid "Remove from favorites"
+msgstr "Izbriši iz omiljenih"
+
+#: static/js/common-all.js:11939 static/js/common-min.js:7 static/js/impala-all.js:14175 static/js/impala-all.js:14233 static/js/impala-min.js:8 static/js/impala/collections.js:10
+#: static/js/zamboni/collections.js:595
+msgid "Follow this Collection"
+msgstr "Prati ovu kolekciju"
+
+#: static/js/common-all.js:11948 static/js/common-min.js:7 static/js/impala-all.js:14184 static/js/impala-min.js:8 static/js/zamboni/collections.js:604
+msgid "Stop following"
+msgstr "Prekini praćenje"
+
+#: static/js/common-all.js:12096 static/js/common-min.js:7 static/js/zamboni/password-strength.js:20
+msgid "Password strength:"
+msgstr "Jačina lozinke:"
+
+#: static/js/common-all.js:12102 static/js/common-min.js:7 static/js/zamboni/password-strength.js:26
+msgid "At least {0} character left."
+msgid_plural "At least {0} characters left."
+msgstr[0] "Ostao je još najmanje {0} karater."
+msgstr[1] "Ostalo je još najmanje {0} karatera."
+
+#: static/js/common-all.js:12286 static/js/common-min.js:7 static/js/impala-all.js:14632 static/js/impala-min.js:8 static/js/impala/suggestions.js:39
+msgid "Search themes for <b>{0}</b>"
+msgstr "Pretraži teme za termin <b>{0}</b>"
+
+#: static/js/common-all.js:12288 static/js/common-min.js:7 static/js/impala-all.js:14634 static/js/impala-min.js:8 static/js/impala/suggestions.js:41
+msgid "Search apps for <b>{0}</b>"
+msgstr "Pretraži aplikacije za termin <b>{0}</b>"
+
+#: static/js/common-all.js:12290 static/js/common-min.js:7 static/js/impala-all.js:14636 static/js/impala-min.js:8 static/js/impala/suggestions.js:43
+msgid "Search add-ons for <b>{0}</b>"
+msgstr "Pretraži dodatke za termin <b>{0}</b>"
+
+#: static/js/common-all.js:12521 static/js/common-min.js:7 static/js/impala-all.js:14867 static/js/impala-min.js:8 static/js/impala/site_suggestions.js:46
+msgid "Category"
+msgstr "Kategorija"
+
+#. L10n: {0} is an app name.
+#: static/js/impala-all.js:11632 static/js/impala-min.js:7 static/js/impala/listing.js:11 static/js/zamboni/themes.js:13
+msgid "This theme is incompatible with your version of {0}"
+msgstr "Ova tema nije kompatibilna sa Vašom verzijom {0}"
+
+#: static/js/impala-all.js:12146 static/js/impala-all.js:14331 static/js/impala-min.js:7 static/js/impala-min.js:8 static/js/common/upload-image.js:97 static/js/impala/users.js:51
+#: static/js/zamboni/devhub-all.js:894 static/js/zamboni/devhub-min.js:1
+msgid "Images must be either PNG or JPG."
+msgstr "Slike moraju biti PNG ili JPG."
+
+#: static/js/impala-all.js:12150 static/js/impala-min.js:7 static/js/common/upload-image.js:101 static/js/zamboni/devhub-all.js:898 static/js/zamboni/devhub-min.js:1
+msgid "Videos must be in WebM."
+msgstr "Video snimci moraju biti u WebM formatu."
+
+#: static/js/impala-all.js:12177 static/js/impala-min.js:7 static/js/common/upload-addon.js:41 static/js/common/upload-image.js:128 static/js/zamboni/devhub-all.js:272
+#: static/js/zamboni/devhub-all.js:925 static/js/zamboni/devhub-min.js:1
 msgid "There was a problem contacting the server."
 msgstr "Došlo je do problema pri kontaktiranju servera."
 
-#: static/js/common/upload-addon.js:69
+#: static/js/impala-all.js:13298 static/js/impala-min.js:7 static/js/impala/persona_creation.js:60
+msgid "All Rights Reserved"
+msgstr "Sva prava su zadržana"
+
+#: static/js/impala-all.js:13302 static/js/impala-min.js:7 static/js/impala/persona_creation.js:64
+msgid "Creative Commons Attribution 3.0"
+msgstr "Creative Commons Attribution 3.0"
+
+#: static/js/impala-all.js:13307 static/js/impala-min.js:7 static/js/impala/persona_creation.js:69
+msgid "Creative Commons Attribution-NonCommercial 3.0"
+msgstr "Creative Commons Attribution-NonCommercial 3.0"
+
+#: static/js/impala-all.js:13312 static/js/impala-min.js:7 static/js/impala/persona_creation.js:74
+msgid "Creative Commons Attribution-NonCommercial-NoDerivs 3.0"
+msgstr "Creative Commons Attribution-NonCommercial-NoDerivs 3.0"
+
+#: static/js/impala-all.js:13317 static/js/impala-min.js:7 static/js/impala/persona_creation.js:79
+msgid "Creative Commons Attribution-NonCommercial-Share Alike 3.0"
+msgstr "Creative Commons Attribution-NonCommercial-Share Alike 3.0"
+
+#: static/js/impala-all.js:13322 static/js/impala-min.js:7 static/js/impala/persona_creation.js:84
+msgid "Creative Commons Attribution-NoDerivs 3.0"
+msgstr "Creative Commons Attribution-NoDerivs 3.0"
+
+#: static/js/impala-all.js:13327 static/js/impala-min.js:7 static/js/impala/persona_creation.js:89
+msgid "Creative Commons Attribution-ShareAlike 3.0"
+msgstr "Creative Commons Attribution-ShareAlike 3.0"
+
+#: static/js/impala-all.js:13530 static/js/impala-min.js:7 static/js/impala/persona_creation.js:292
+msgid "Your Theme's Name"
+msgstr "Naziv Vaše teme"
+
+#: static/js/impala-all.js:14242 static/js/impala-min.js:8 static/js/impala/collections.js:19
+msgid "Stop Following"
+msgstr "Prekini praćenje"
+
+#: static/js/impala-all.js:14243 static/js/impala-min.js:8 static/js/impala/collections.js:20
+msgid "Following"
+msgstr "Praćenje"
+
+#: static/js/impala-all.js:14313 static/js/impala-min.js:8 static/js/impala/users.js:33
+msgid "use original"
+msgstr "koristi original"
+
+#: static/js/impala-all.js:14523 static/js/impala-min.js:8 static/js/impala/search.js:114
+msgid "Updating results&hellip;"
+msgstr "Ažuriram rezultate&hellip;"
+
+#: static/js/common/upload-addon.js:69 static/js/zamboni/devhub-all.js:300 static/js/zamboni/devhub-min.js:1
 msgid "Select a file..."
 msgstr "Izaberite datoteku..."
 
-#: static/js/common/upload-addon.js:70
+#: static/js/common/upload-addon.js:70 static/js/zamboni/devhub-all.js:301 static/js/zamboni/devhub-min.js:1
 msgid "Your add-on should end with .xpi, .jar or .xml"
 msgstr "Vaš dodatak se treba završiti sa .xpi, .jar ili .xml"
 
 #. L10n: {0} is the percent of the file that has been uploaded.
-#: static/js/common/upload-addon.js:104
+#: static/js/common/upload-addon.js:104 static/js/zamboni/devhub-all.js:335 static/js/zamboni/devhub-min.js:1
 #, fuzzy, python-format
 msgid "{0}% complete"
 msgstr "{0}% završeno"
 
 #. L10n: "{bytes uploaded} of {total filesize}".
-#: static/js/common/upload-addon.js:107
+#: static/js/common/upload-addon.js:107 static/js/zamboni/devhub-all.js:338 static/js/zamboni/devhub-min.js:1
 msgid "{0} of {1}"
 msgstr "{0} od {1}"
 
-#: static/js/common/upload-addon.js:140
+#: static/js/common/upload-addon.js:140 static/js/zamboni/devhub-all.js:371 static/js/zamboni/devhub-min.js:1
 msgid "Cancel"
 msgstr "Otkaži"
 
-#: static/js/common/upload-addon.js:162
+#: static/js/common/upload-addon.js:162 static/js/zamboni/devhub-all.js:393 static/js/zamboni/devhub-min.js:1
 msgid "Uploading {0}"
 msgstr "Otpremam {0}"
 
-#: static/js/common/upload-addon.js:189
+#: static/js/common/upload-addon.js:189 static/js/zamboni/devhub-all.js:420 static/js/zamboni/devhub-min.js:1
 msgid "Error with {0}"
 msgstr "Greška sa {0}"
 
-#: static/js/common/upload-addon.js:194
+#: static/js/common/upload-addon.js:194 static/js/zamboni/devhub-all.js:425 static/js/zamboni/devhub-min.js:1
 msgid "Your add-on failed validation with {0} error."
 msgid_plural "Your add-on failed validation with {0} errors."
 msgstr[0] "Vaš dodatak nije prošao proveru - {0} greška."
 msgstr[1] "Vaš dodatak nije prošao proveru - {0} greške."
-msgstr[2] "Vaš dodatak nije prošao proveru - {0} grešaka."
 
-#: static/js/common/upload-addon.js:208
+#: static/js/common/upload-addon.js:208 static/js/zamboni/devhub-all.js:439 static/js/zamboni/devhub-min.js:1
 msgid "&hellip;and {0} more"
 msgid_plural "&hellip;and {0} more"
 msgstr[0] "&hellip;i još {0}"
 msgstr[1] "&hellip;i još {0}"
-msgstr[2] "&hellip;i još {0}"
 
-#: static/js/common/upload-addon.js:222 static/js/common/upload-addon.js:512
+#: static/js/common/upload-addon.js:222 static/js/common/upload-addon.js:497 static/js/zamboni/devhub-all.js:453 static/js/zamboni/devhub-all.js:743 static/js/zamboni/devhub-min.js:1
 msgid "See full validation report"
 msgstr "Pogledajte potpuni izveštaj pregleda"
 
-#: static/js/common/upload-addon.js:234
+#: static/js/common/upload-addon.js:234 static/js/zamboni/devhub-all.js:465 static/js/zamboni/devhub-min.js:1
 msgid "Validating {0}"
 msgstr "Proveravam {0}"
 
 #. L10n: first argument is an HTTP status code
-#: static/js/common/upload-addon.js:273
+#: static/js/common/upload-addon.js:273 static/js/zamboni/devhub-all.js:504 static/js/zamboni/devhub-min.js:1
 msgid "Received an empty response from the server; status: {0}"
 msgstr "Dobijen je prazan odgovor od servera; status: {0}"
 
-#: static/js/common/upload-addon.js:373
+#: static/js/common/upload-addon.js:370 static/js/zamboni/devhub-all.js:604 static/js/zamboni/devhub-min.js:1
 msgid "Unexpected server error while validating."
 msgstr "Neočekivana greška na serveru tokom provere."
 
-#: static/js/common/upload-addon.js:412
+#: static/js/common/upload-addon.js:409 static/js/zamboni/devhub-all.js:643 static/js/zamboni/devhub-min.js:1
 msgid "Finished validating {0}"
 msgstr "Završena provera {0}"
 
-#: static/js/common/upload-addon.js:418
+#: static/js/common/upload-addon.js:415 static/js/zamboni/devhub-all.js:649 static/js/zamboni/devhub-min.js:1
 msgid "Your add-on validation timed out, it will be manually reviewed."
 msgstr ""
 
-#: static/js/common/upload-addon.js:421
+#: static/js/common/upload-addon.js:418 static/js/zamboni/devhub-all.js:652 static/js/zamboni/devhub-min.js:1
 msgid "Your add-on was validated with no errors and {0} warning."
 msgid_plural "Your add-on was validated with no errors and {0} warnings."
 msgstr[0] ""
 msgstr[1] ""
-msgstr[2] ""
 
-#: static/js/common/upload-addon.js:426
+#: static/js/common/upload-addon.js:423 static/js/zamboni/devhub-all.js:657 static/js/zamboni/devhub-min.js:1
 msgid "Your add-on was validated with no errors and {0} message."
 msgid_plural "Your add-on was validated with no errors and {0} messages."
 msgstr[0] ""
 msgstr[1] ""
-msgstr[2] ""
 
-#: static/js/common/upload-addon.js:431
+#: static/js/common/upload-addon.js:428 static/js/zamboni/devhub-all.js:662 static/js/zamboni/devhub-min.js:1
 msgid "Your add-on was validated with no errors or warnings."
 msgstr ""
 
-#: static/js/common/upload-addon.js:446
+#: static/js/common/upload-addon.js:443 static/js/zamboni/devhub-all.js:677 static/js/zamboni/devhub-min.js:1
 msgid "Your submission will be automatically signed."
 msgstr ""
 
-#: static/js/common/upload-addon.js:465
+#: static/js/common/upload-addon.js:450 static/js/zamboni/devhub-all.js:696 static/js/zamboni/devhub-min.js:1
 msgid "Include detailed version notes (this can be done in the next step)."
 msgstr "Uključite detaljne beleške verzije (ovo može biti urađeno u sledećem koraku)."
 
-#: static/js/common/upload-addon.js:466
+#: static/js/common/upload-addon.js:451 static/js/zamboni/devhub-all.js:697 static/js/zamboni/devhub-min.js:1
 msgid "If your add-on requires an account to a website in order to be fully tested, include a test username and password in the Notes to Reviewer (this can be done in the next step)."
-msgstr "Ako je Vašem dodatku potrebna lozinka do veb stranice kako bi bila potpuno testirana, uključite i korisničko ime i lozinku za test u Beleške recezenta (ovo može biti učinjeno u sledećem koraku)."
+msgstr ""
+"Ako je Vašem dodatku potrebna lozinka do veb stranice kako bi bila potpuno testirana, uključite i korisničko ime i lozinku za test u Beleške recezenta (ovo može biti učinjeno u sledećem koraku)."
 
-#: static/js/common/upload-addon.js:467
+#: static/js/common/upload-addon.js:452 static/js/zamboni/devhub-all.js:698 static/js/zamboni/devhub-min.js:1
 msgid "If your add-on is intended for a limited audience you should choose Preliminary Review instead of Full Review."
 msgstr ""
 
-#: static/js/common/upload-addon.js:480
+#: static/js/common/upload-addon.js:465 static/js/zamboni/devhub-all.js:711 static/js/zamboni/devhub-min.js:1
 msgid "Add-on submission checklist"
 msgstr "Spisak podnesenih dodataka"
 
-#: static/js/common/upload-addon.js:481
+#: static/js/common/upload-addon.js:466 static/js/zamboni/devhub-all.js:712 static/js/zamboni/devhub-min.js:1
 msgid "Please verify the following points before finalizing your submission. This will minimize delays or misunderstanding during the review process:"
 msgstr "Molimo Vas da verifikujete naredne takče pre završetka podnošenja. Ovo će minimizovati odlaganja i nerazumevanja tokom procesa recenzije:"
 
-#: static/js/common/upload-addon.js:483
+#: static/js/common/upload-addon.js:468 static/js/zamboni/devhub-all.js:714 static/js/zamboni/devhub-min.js:1
 msgid ""
 "Compiled binaries, as well as minified or obfuscated scripts (excluding known libraries) need to have their sources submitted separately for review. Make sure that you use the source code upload "
 "field to avoid having your submission rejected."
 msgstr ""
-"Kompajlirane binarne datoteke, kao i umanjene skripte (ne računajući poznate biblioteke) treba odvojeno podneti na recenziju. Koristite polje za otpremanje izvornog koda da biste izbegli odbijanje"
-" otpremljenog koda."
+"Kompajlirane binarne datoteke, kao i umanjene skripte (ne računajući poznate biblioteke) treba odvojeno podneti na recenziju. Koristite polje za otpremanje izvornog koda da biste izbegli odbijanje "
+"otpremljenog koda."
 
-#: static/js/common/upload-addon.js:501
+#: static/js/common/upload-addon.js:486 static/js/zamboni/devhub-all.js:732 static/js/zamboni/devhub-min.js:1
 msgid "The validation process found these issues that can lead to rejections:"
 msgstr "Proces validacije je našao probleme koje mogu dovesti do:"
 
-#: static/js/common/upload-addon.js:518
+#: static/js/common/upload-addon.js:503 static/js/zamboni/devhub-all.js:749 static/js/zamboni/devhub-min.js:1
 msgid "If you are unfamiliar with the add-ons review process, you can read about it here."
 msgstr "Ako Vam nije poznat proces recenzije dodataka, možete pročitati o tome ovde."
 
-#: static/js/common/upload-addon.js:555
+#: static/js/common/upload-addon.js:540 static/js/zamboni/devhub-all.js:786 static/js/zamboni/devhub-min.js:1
 msgid "Sorry, no supported platform has been found."
 msgstr "Nažalost nije nađena ni jedna podržana platforma."
 
-#: static/js/common/upload-base.js:57
+#: static/js/common/upload-base.js:57 static/js/zamboni/devhub-all.js:187 static/js/zamboni/devhub-min.js:1
 msgid "The filetype you uploaded isn't recognized."
 msgstr "Tip datoteke koju ste poslali nije prepoznat."
 
-#: static/js/common/upload-base.js:79
+#: static/js/common/upload-base.js:79 static/js/zamboni/devhub-all.js:209 static/js/zamboni/devhub-min.js:1
 msgid "You cancelled the upload."
 msgstr "Otkazali ste otpremanje."
 
-#: static/js/common/upload-image.js:97 static/js/impala/users.js:51
-msgid "Images must be either PNG or JPG."
-msgstr "Slike moraju biti PNG ili JPG."
-
-#: static/js/common/upload-image.js:101
-msgid "Videos must be in WebM."
-msgstr "Video snimci moraju biti u WebM formatu."
-
-#: static/js/impala/collections.js:10 static/js/zamboni/collections.js:595
-msgid "Follow this Collection"
-msgstr "Prati ovu kolekciju"
-
-#: static/js/impala/collections.js:19
-msgid "Stop Following"
-msgstr "Prekini praćenje"
-
-#: static/js/impala/collections.js:20
-msgid "Following"
-msgstr "Praćenje"
-
-#. L10n: {0} is an app name.
-#: static/js/impala/listing.js:11 static/js/zamboni/themes.js:13
-msgid "This theme is incompatible with your version of {0}"
-msgstr "Ova tema nije kompatibilna sa Vašom verzijom {0}"
-
-#: static/js/impala/persona_creation.js:60
-msgid "All Rights Reserved"
-msgstr "Sva prava su zadržana"
-
-#: static/js/impala/persona_creation.js:64
-msgid "Creative Commons Attribution 3.0"
-msgstr "Creative Commons Attribution 3.0"
-
-#: static/js/impala/persona_creation.js:69
-msgid "Creative Commons Attribution-NonCommercial 3.0"
-msgstr "Creative Commons Attribution-NonCommercial 3.0"
-
-#: static/js/impala/persona_creation.js:74
-msgid "Creative Commons Attribution-NonCommercial-NoDerivs 3.0"
-msgstr "Creative Commons Attribution-NonCommercial-NoDerivs 3.0"
-
-#: static/js/impala/persona_creation.js:79
-msgid "Creative Commons Attribution-NonCommercial-Share Alike 3.0"
-msgstr "Creative Commons Attribution-NonCommercial-Share Alike 3.0"
-
-#: static/js/impala/persona_creation.js:84
-msgid "Creative Commons Attribution-NoDerivs 3.0"
-msgstr "Creative Commons Attribution-NoDerivs 3.0"
-
-#: static/js/impala/persona_creation.js:89
-msgid "Creative Commons Attribution-ShareAlike 3.0"
-msgstr "Creative Commons Attribution-ShareAlike 3.0"
-
-#: static/js/impala/persona_creation.js:292
-msgid "Your Theme's Name"
-msgstr "Naziv Vaše teme"
-
-#: static/js/impala/reviews.js:23 static/js/zamboni/reviews.js:18
-msgid "Flagged for review"
-msgstr "Naznačeno za pregled"
-
-#: static/js/impala/reviews.js:40 static/js/zamboni/reviews.js:34
-msgid "Your input is required"
-msgstr "Vaš odziv je neophodan"
-
-#: static/js/impala/reviews.js:152 static/js/zamboni/reviews.js:103
-msgid "Marked for deletion"
-msgstr "Obeleženo za brisanje"
-
-#: static/js/impala/search.js:114
-msgid "Updating results&hellip;"
-msgstr "Ažuriram rezultate&hellip;"
-
-#: static/js/impala/site_suggestions.js:46
-msgid "Category"
-msgstr "Kategorija"
-
-#: static/js/impala/suggestions.js:39
-msgid "Search themes for <b>{0}</b>"
-msgstr "Pretraži teme za termin <b>{0}</b>"
-
-#: static/js/impala/suggestions.js:41
-msgid "Search apps for <b>{0}</b>"
-msgstr "Pretraži aplikacije za termin <b>{0}</b>"
-
-#: static/js/impala/suggestions.js:43
-msgid "Search add-ons for <b>{0}</b>"
-msgstr "Pretraži dodatke za termin <b>{0}</b>"
-
-#: static/js/impala/users.js:33
-msgid "use original"
-msgstr "koristi original"
-
-#: static/js/impala/stats/chart.js:267
+#: static/js/impala/stats/chart.js:267 static/js/zamboni/stats-all.js:16898 static/js/zamboni/stats-min.js:5
 msgid "Week of {0}"
 msgstr "Sedmica od {0}"
 
-#: static/js/impala/stats/chart.js:269
+#: static/js/impala/stats/chart.js:269 static/js/zamboni/stats-all.js:16900 static/js/zamboni/stats-min.js:5
 msgid " downloads"
 msgstr ""
 
-#: static/js/impala/stats/chart.js:270
+#: static/js/impala/stats/chart.js:270 static/js/zamboni/stats-all.js:16901 static/js/zamboni/stats-min.js:5
 msgid "{0} users"
 msgstr "{0} korisnika"
 
-#: static/js/impala/stats/chart.js:271
+#: static/js/impala/stats/chart.js:271 static/js/zamboni/stats-all.js:16902 static/js/zamboni/stats-min.js:5
 msgid "{0} add-ons"
 msgstr "{0} dodataka"
 
-#: static/js/impala/stats/chart.js:272
+#: static/js/impala/stats/chart.js:272 static/js/zamboni/stats-all.js:16903 static/js/zamboni/stats-min.js:5
 msgid "{0} collections"
 msgstr "{0} kolekcije"
 
-#: static/js/impala/stats/chart.js:273
+#: static/js/impala/stats/chart.js:273 static/js/zamboni/stats-all.js:16904 static/js/zamboni/stats-min.js:5
 msgid "{0} reviews"
 msgstr "{0} recenzija"
 
-#: static/js/impala/stats/chart.js:275
+#: static/js/impala/stats/chart.js:275 static/js/zamboni/stats-all.js:16906 static/js/zamboni/stats-min.js:5
 msgid "{0} sales"
 msgstr "{0} prodaja"
 
-#: static/js/impala/stats/chart.js:276
+#: static/js/impala/stats/chart.js:276 static/js/zamboni/stats-all.js:16907 static/js/zamboni/stats-min.js:5
 msgid "{0} refunds"
 msgstr "{0} refunkdacija"
 
-#: static/js/impala/stats/chart.js:277
+#: static/js/impala/stats/chart.js:277 static/js/zamboni/stats-all.js:16908 static/js/zamboni/stats-min.js:5
 msgid "{0} installs"
 msgstr "{0} instalacija"
 
-#: static/js/impala/stats/chart.js:369 static/js/impala/stats/csv_keys.js:3 static/js/impala/stats/csv_keys.js:109
+#: static/js/impala/stats/chart.js:369 static/js/impala/stats/csv_keys.js:3 static/js/impala/stats/csv_keys.js:109 static/js/zamboni/stats-all.js:15284 static/js/zamboni/stats-all.js:15390
+#: static/js/zamboni/stats-all.js:17000 static/js/zamboni/stats-min.js:4 static/js/zamboni/stats-min.js:5
 msgid "Downloads"
 msgstr "Preuzimanja"
 
-#: static/js/impala/stats/chart.js:379 static/js/impala/stats/csv_keys.js:6 static/js/impala/stats/csv_keys.js:110
+#: static/js/impala/stats/chart.js:379 static/js/impala/stats/csv_keys.js:6 static/js/impala/stats/csv_keys.js:110 static/js/zamboni/stats-all.js:15287 static/js/zamboni/stats-all.js:15391
+#: static/js/zamboni/stats-all.js:17010 static/js/zamboni/stats-min.js:4 static/js/zamboni/stats-min.js:5
 msgid "Daily Users"
 msgstr "Broj korisnika po danu"
 
-#: static/js/impala/stats/chart.js:410
+#: static/js/impala/stats/chart.js:410 static/js/zamboni/stats-all.js:17041 static/js/zamboni/stats-min.js:5
 msgid "Amount, in USD"
 msgstr "Količina, u valuti USD"
 
-#: static/js/impala/stats/chart.js:421 static/js/impala/stats/csv_keys.js:104
+#: static/js/impala/stats/chart.js:421 static/js/impala/stats/csv_keys.js:104 static/js/zamboni/stats-all.js:15385 static/js/zamboni/stats-all.js:17052 static/js/zamboni/stats-min.js:5
 msgid "Number of Contributions"
 msgstr "Broj doprinosa"
 
-#: static/js/impala/stats/chart.js:447
+#: static/js/impala/stats/chart.js:447 static/js/zamboni/stats-all.js:17078 static/js/zamboni/stats-min.js:5
 msgid "More Info..."
 msgstr "Više informacija..."
 
 #. L10n: {0} is an ISO-formatted date.
-#: static/js/impala/stats/chart.js:451
+#: static/js/impala/stats/chart.js:451 static/js/zamboni/stats-all.js:17082 static/js/zamboni/stats-min.js:5
 msgid "Details for {0}"
 msgstr "Detalji o {0}"
 
-#: static/js/impala/stats/csv_keys.js:9
+#: static/js/impala/stats/csv_keys.js:9 static/js/zamboni/stats-all.js:15290 static/js/zamboni/stats-min.js:4
 msgid "Collections Created"
 msgstr "Napravljene kolekcije"
 
-#: static/js/impala/stats/csv_keys.js:12
+#: static/js/impala/stats/csv_keys.js:12 static/js/zamboni/stats-all.js:15293 static/js/zamboni/stats-min.js:4
 msgid "Add-ons in Use"
 msgstr "Dodaci koji se koriste"
 
-#: static/js/impala/stats/csv_keys.js:15
+#: static/js/impala/stats/csv_keys.js:15 static/js/zamboni/stats-all.js:15296 static/js/zamboni/stats-min.js:4
 msgid "Add-ons Created"
 msgstr "Dodataka napravljeno"
 
-#: static/js/impala/stats/csv_keys.js:18
+#: static/js/impala/stats/csv_keys.js:18 static/js/zamboni/stats-all.js:15299 static/js/zamboni/stats-min.js:4
 msgid "Add-ons Downloaded"
 msgstr "Dodataka preuzeto"
 
-#: static/js/impala/stats/csv_keys.js:21
+#: static/js/impala/stats/csv_keys.js:21 static/js/zamboni/stats-all.js:15302 static/js/zamboni/stats-min.js:4
 msgid "Add-ons Updated"
 msgstr "Dodataka ažurirano"
 
-#: static/js/impala/stats/csv_keys.js:24
+#: static/js/impala/stats/csv_keys.js:24 static/js/zamboni/stats-all.js:15305 static/js/zamboni/stats-min.js:4
 msgid "Reviews Written"
 msgstr "Recenzija napisano"
 
-#: static/js/impala/stats/csv_keys.js:27
+#: static/js/impala/stats/csv_keys.js:27 static/js/zamboni/stats-all.js:15308 static/js/zamboni/stats-min.js:4
 msgid "User Signups"
 msgstr "Prijave korisnika"
 
-#: static/js/impala/stats/csv_keys.js:30
+#: static/js/impala/stats/csv_keys.js:30 static/js/zamboni/stats-all.js:15311 static/js/zamboni/stats-min.js:4
 msgid "Subscribers"
 msgstr "Pretplatnici"
 
-#: static/js/impala/stats/csv_keys.js:33
+#: static/js/impala/stats/csv_keys.js:33 static/js/zamboni/stats-all.js:15314 static/js/zamboni/stats-min.js:4
 msgid "Ratings"
 msgstr "Ocene"
 
-#: static/js/impala/stats/csv_keys.js:36 static/js/impala/stats/csv_keys.js:114
+#: static/js/impala/stats/csv_keys.js:36 static/js/impala/stats/csv_keys.js:114 static/js/zamboni/stats-all.js:15317 static/js/zamboni/stats-all.js:15395 static/js/zamboni/stats-min.js:4
+#: static/js/zamboni/stats-min.js:5
 msgid "Sales"
 msgstr "Prodaje"
 
-#: static/js/impala/stats/csv_keys.js:39 static/js/impala/stats/csv_keys.js:113
+#: static/js/impala/stats/csv_keys.js:39 static/js/impala/stats/csv_keys.js:113 static/js/zamboni/stats-all.js:15320 static/js/zamboni/stats-all.js:15394 static/js/zamboni/stats-min.js:4
+#: static/js/zamboni/stats-min.js:5
 msgid "Installs"
 msgstr "Instalacije"
 
-#: static/js/impala/stats/csv_keys.js:42
+#: static/js/impala/stats/csv_keys.js:42 static/js/zamboni/stats-all.js:15323 static/js/zamboni/stats-min.js:4
 msgid "Unknown"
 msgstr "Nepoznato"
 
-#: static/js/impala/stats/csv_keys.js:43
+#: static/js/impala/stats/csv_keys.js:43 static/js/zamboni/stats-all.js:15324 static/js/zamboni/stats-min.js:4
 msgid "Add-ons Manager"
 msgstr "Menadžer dodataka"
 
-#: static/js/impala/stats/csv_keys.js:44
+#: static/js/impala/stats/csv_keys.js:44 static/js/zamboni/stats-all.js:15325 static/js/zamboni/stats-min.js:4
 msgid "Add-ons Manager Promo"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:45
+#: static/js/impala/stats/csv_keys.js:45 static/js/zamboni/stats-all.js:15326 static/js/zamboni/stats-min.js:4
 msgid "Add-ons Manager Featured"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:46
+#: static/js/impala/stats/csv_keys.js:46 static/js/zamboni/stats-all.js:15327 static/js/zamboni/stats-min.js:4
 msgid "Add-ons Manager Learn More"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:47
+#: static/js/impala/stats/csv_keys.js:47 static/js/zamboni/stats-all.js:15328 static/js/zamboni/stats-min.js:4
 msgid "Search Suggestions"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:48
+#: static/js/impala/stats/csv_keys.js:48 static/js/zamboni/stats-all.js:15329 static/js/zamboni/stats-min.js:4
 msgid "Search Results"
 msgstr "Rezultati pretrage"
 
-#: static/js/impala/stats/csv_keys.js:49 static/js/impala/stats/csv_keys.js:50 static/js/impala/stats/csv_keys.js:51
+#: static/js/impala/stats/csv_keys.js:49 static/js/impala/stats/csv_keys.js:50 static/js/impala/stats/csv_keys.js:51 static/js/zamboni/stats-all.js:15330 static/js/zamboni/stats-all.js:15331
+#: static/js/zamboni/stats-all.js:15332 static/js/zamboni/stats-min.js:4
 msgid "Homepage Promo"
 msgstr "Promocija na početnoj strani"
 
-#: static/js/impala/stats/csv_keys.js:52 static/js/impala/stats/csv_keys.js:53
+#: static/js/impala/stats/csv_keys.js:52 static/js/impala/stats/csv_keys.js:53 static/js/zamboni/stats-all.js:15333 static/js/zamboni/stats-all.js:15334 static/js/zamboni/stats-min.js:4
 msgid "Homepage Featured"
 msgstr "Izdvojeno na početnoj strani"
 
-#: static/js/impala/stats/csv_keys.js:54 static/js/impala/stats/csv_keys.js:55
+#: static/js/impala/stats/csv_keys.js:54 static/js/impala/stats/csv_keys.js:55 static/js/zamboni/stats-all.js:15335 static/js/zamboni/stats-all.js:15336 static/js/zamboni/stats-min.js:4
 msgid "Homepage Up and Coming"
 msgstr "Nadolazeće na početnoj strani"
 
-#: static/js/impala/stats/csv_keys.js:56
+#: static/js/impala/stats/csv_keys.js:56 static/js/zamboni/stats-all.js:15337 static/js/zamboni/stats-min.js:4
 msgid "Homepage Most Popular"
 msgstr "Najpopularnije na početnoj strani"
 
-#: static/js/impala/stats/csv_keys.js:57 static/js/impala/stats/csv_keys.js:59
+#: static/js/impala/stats/csv_keys.js:57 static/js/impala/stats/csv_keys.js:59 static/js/zamboni/stats-all.js:15338 static/js/zamboni/stats-all.js:15340 static/js/zamboni/stats-min.js:4
 msgid "Detail Page"
 msgstr "Dodatne informacije"
 
-#: static/js/impala/stats/csv_keys.js:58 static/js/impala/stats/csv_keys.js:60
+#: static/js/impala/stats/csv_keys.js:58 static/js/impala/stats/csv_keys.js:60 static/js/zamboni/stats-all.js:15339 static/js/zamboni/stats-all.js:15341 static/js/zamboni/stats-min.js:4
 msgid "Detail Page (bottom)"
 msgstr "Dodatne informacije (dole)"
 
-#: static/js/impala/stats/csv_keys.js:61
+#: static/js/impala/stats/csv_keys.js:61 static/js/zamboni/stats-all.js:15342 static/js/zamboni/stats-min.js:4
 msgid "Detail Page (Development Channel)"
 msgstr "Dodatne informacije (Kanal za razvoj)"
 
-#: static/js/impala/stats/csv_keys.js:62 static/js/impala/stats/csv_keys.js:63 static/js/impala/stats/csv_keys.js:64
+#: static/js/impala/stats/csv_keys.js:62 static/js/impala/stats/csv_keys.js:63 static/js/impala/stats/csv_keys.js:64 static/js/zamboni/stats-all.js:15343 static/js/zamboni/stats-all.js:15344
+#: static/js/zamboni/stats-all.js:15345 static/js/zamboni/stats-min.js:4
 msgid "Often Used With"
 msgstr "Često korišćeno uz"
 
-#: static/js/impala/stats/csv_keys.js:65 static/js/impala/stats/csv_keys.js:66
+#: static/js/impala/stats/csv_keys.js:65 static/js/impala/stats/csv_keys.js:66 static/js/zamboni/stats-all.js:15346 static/js/zamboni/stats-all.js:15347 static/js/zamboni/stats-min.js:4
 msgid "Others By Author"
 msgstr "Ostalo od autora"
 
-#: static/js/impala/stats/csv_keys.js:67 static/js/impala/stats/csv_keys.js:68
+#: static/js/impala/stats/csv_keys.js:67 static/js/impala/stats/csv_keys.js:68 static/js/zamboni/stats-all.js:15348 static/js/zamboni/stats-all.js:15349 static/js/zamboni/stats-min.js:4
 msgid "Dependencies"
 msgstr "Zavisi od"
 
-#: static/js/impala/stats/csv_keys.js:69 static/js/impala/stats/csv_keys.js:70
+#: static/js/impala/stats/csv_keys.js:69 static/js/impala/stats/csv_keys.js:70 static/js/zamboni/stats-all.js:15350 static/js/zamboni/stats-all.js:15351 static/js/zamboni/stats-min.js:4
 msgid "Upsell"
 msgstr "Tehnike uvećanja prodaje"
 
-#: static/js/impala/stats/csv_keys.js:71
+#: static/js/impala/stats/csv_keys.js:71 static/js/zamboni/stats-all.js:15352 static/js/zamboni/stats-min.js:4
 msgid "Meet the Developer"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:72
+#: static/js/impala/stats/csv_keys.js:72 static/js/zamboni/stats-all.js:15353 static/js/zamboni/stats-min.js:4
 msgid "User Profile"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:73
+#: static/js/impala/stats/csv_keys.js:73 static/js/zamboni/stats-all.js:15354 static/js/zamboni/stats-min.js:4
 msgid "Version History"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:75
+#: static/js/impala/stats/csv_keys.js:75 static/js/zamboni/stats-all.js:15356 static/js/zamboni/stats-min.js:4
 msgid "Sharing"
 msgstr "Deljenje"
 
-#: static/js/impala/stats/csv_keys.js:76
+#: static/js/impala/stats/csv_keys.js:76 static/js/zamboni/stats-all.js:15357 static/js/zamboni/stats-min.js:4
 msgid "Category Pages"
 msgstr "Stranice kategorija"
 
-#: static/js/impala/stats/csv_keys.js:77
+#: static/js/impala/stats/csv_keys.js:77 static/js/zamboni/stats-all.js:15358 static/js/zamboni/stats-min.js:4
 msgid "Collections"
 msgstr "Kolekcije"
 
-#: static/js/impala/stats/csv_keys.js:78 static/js/impala/stats/csv_keys.js:79
+#: static/js/impala/stats/csv_keys.js:78 static/js/impala/stats/csv_keys.js:79 static/js/zamboni/stats-all.js:15359 static/js/zamboni/stats-all.js:15360 static/js/zamboni/stats-min.js:4
 msgid "Category Landing Featured Carousel"
 msgstr "Klizač izdvojenih apl. na početnoj strani kategorije"
 
-#: static/js/impala/stats/csv_keys.js:80 static/js/impala/stats/csv_keys.js:81
+#: static/js/impala/stats/csv_keys.js:80 static/js/impala/stats/csv_keys.js:81 static/js/zamboni/stats-all.js:15361 static/js/zamboni/stats-all.js:15362 static/js/zamboni/stats-min.js:4
 msgid "Category Landing Top Rated"
 msgstr "Najbolje ocenjene apl. na početnoj strani kategorije"
 
-#: static/js/impala/stats/csv_keys.js:82 static/js/impala/stats/csv_keys.js:83
+#: static/js/impala/stats/csv_keys.js:82 static/js/impala/stats/csv_keys.js:83 static/js/zamboni/stats-all.js:15363 static/js/zamboni/stats-all.js:15364 static/js/zamboni/stats-min.js:5
 msgid "Category Landing Most Popular"
 msgstr "Najpopularnije apl. na početnoj strani kategorije"
 
-#: static/js/impala/stats/csv_keys.js:84 static/js/impala/stats/csv_keys.js:85
+#: static/js/impala/stats/csv_keys.js:84 static/js/impala/stats/csv_keys.js:85 static/js/zamboni/stats-all.js:15365 static/js/zamboni/stats-all.js:15366 static/js/zamboni/stats-min.js:5
 msgid "Category Landing Recently Added"
 msgstr "Skoro dodate apl. na početnoj strani kategorije"
 
-#: static/js/impala/stats/csv_keys.js:86 static/js/impala/stats/csv_keys.js:87
+#: static/js/impala/stats/csv_keys.js:86 static/js/impala/stats/csv_keys.js:87 static/js/zamboni/stats-all.js:15367 static/js/zamboni/stats-all.js:15368 static/js/zamboni/stats-min.js:5
 msgid "Browse Listing Featured Sort"
 msgstr "Pregled sortirane liste istaknutih aplikacija"
 
-#: static/js/impala/stats/csv_keys.js:88 static/js/impala/stats/csv_keys.js:89
+#: static/js/impala/stats/csv_keys.js:88 static/js/impala/stats/csv_keys.js:89 static/js/zamboni/stats-all.js:15369 static/js/zamboni/stats-all.js:15370 static/js/zamboni/stats-min.js:5
 msgid "Browse Listing Users Sort"
 msgstr "Pregled sortirane liste korisnika"
 
-#: static/js/impala/stats/csv_keys.js:90 static/js/impala/stats/csv_keys.js:91
+#: static/js/impala/stats/csv_keys.js:90 static/js/impala/stats/csv_keys.js:91 static/js/zamboni/stats-all.js:15371 static/js/zamboni/stats-all.js:15372 static/js/zamboni/stats-min.js:5
 msgid "Browse Listing Rating Sort"
 msgstr "Pregled sortirane liste ocena"
 
-#: static/js/impala/stats/csv_keys.js:92 static/js/impala/stats/csv_keys.js:93
+#: static/js/impala/stats/csv_keys.js:92 static/js/impala/stats/csv_keys.js:93 static/js/zamboni/stats-all.js:15373 static/js/zamboni/stats-all.js:15374 static/js/zamboni/stats-min.js:5
 msgid "Browse Listing Created Sort"
 msgstr "Pregled sortirane liste kreiranih aplikacija"
 
-#: static/js/impala/stats/csv_keys.js:94 static/js/impala/stats/csv_keys.js:95
+#: static/js/impala/stats/csv_keys.js:94 static/js/impala/stats/csv_keys.js:95 static/js/zamboni/stats-all.js:15375 static/js/zamboni/stats-all.js:15376 static/js/zamboni/stats-min.js:5
 msgid "Browse Listing Name Sort"
 msgstr "Pregled sortirane liste naziva"
 
-#: static/js/impala/stats/csv_keys.js:96 static/js/impala/stats/csv_keys.js:97
+#: static/js/impala/stats/csv_keys.js:96 static/js/impala/stats/csv_keys.js:97 static/js/zamboni/stats-all.js:15377 static/js/zamboni/stats-all.js:15378 static/js/zamboni/stats-min.js:5
 msgid "Browse Listing Popular Sort"
 msgstr "Pregled sortirane liste popularnih aplikacija"
 
-#: static/js/impala/stats/csv_keys.js:98 static/js/impala/stats/csv_keys.js:99
+#: static/js/impala/stats/csv_keys.js:98 static/js/impala/stats/csv_keys.js:99 static/js/zamboni/stats-all.js:15379 static/js/zamboni/stats-all.js:15380 static/js/zamboni/stats-min.js:5
 msgid "Browse Listing Updated Sort"
 msgstr "Pregled sortirane liste ažuriranih aplikacija"
 
-#: static/js/impala/stats/csv_keys.js:100 static/js/impala/stats/csv_keys.js:101
+#: static/js/impala/stats/csv_keys.js:100 static/js/impala/stats/csv_keys.js:101 static/js/zamboni/stats-all.js:15381 static/js/zamboni/stats-all.js:15382 static/js/zamboni/stats-min.js:5
 msgid "Browse Listing Up and Coming Sort"
 msgstr "Pregled sortirane liste nadolazećih aplikacija"
 
-#: static/js/impala/stats/csv_keys.js:105
+#: static/js/impala/stats/csv_keys.js:105 static/js/zamboni/stats-all.js:15386 static/js/zamboni/stats-min.js:5
 msgid "Total Amount Contributed"
 msgstr "Ukupan broj doprinosa"
 
-#: static/js/impala/stats/csv_keys.js:106
+#: static/js/impala/stats/csv_keys.js:106 static/js/zamboni/stats-all.js:15387 static/js/zamboni/stats-min.js:5
 msgid "Average Contribution"
 msgstr "Prosek doprinosa"
 
-#: static/js/impala/stats/csv_keys.js:115
+#: static/js/impala/stats/csv_keys.js:115 static/js/zamboni/stats-all.js:15396 static/js/zamboni/stats-min.js:5
 msgid "Usage"
 msgstr "Upotreba"
 
-#: static/js/impala/stats/csv_keys.js:118
+#: static/js/impala/stats/csv_keys.js:118 static/js/zamboni/stats-all.js:15399 static/js/zamboni/stats-min.js:5
 msgid "Firefox"
 msgstr "Firefox"
 
-#: static/js/impala/stats/csv_keys.js:119
+#: static/js/impala/stats/csv_keys.js:119 static/js/zamboni/stats-all.js:15400 static/js/zamboni/stats-min.js:5
 msgid "Mozilla"
 msgstr "Mozilla"
 
-#: static/js/impala/stats/csv_keys.js:120
+#: static/js/impala/stats/csv_keys.js:120 static/js/zamboni/stats-all.js:15401 static/js/zamboni/stats-min.js:5
 msgid "Thunderbird"
 msgstr "Thunderbird"
 
-#: static/js/impala/stats/csv_keys.js:121
+#: static/js/impala/stats/csv_keys.js:121 static/js/zamboni/stats-all.js:15402 static/js/zamboni/stats-min.js:5
 msgid "Sunbird"
 msgstr "Sunbird"
 
-#: static/js/impala/stats/csv_keys.js:122
+#: static/js/impala/stats/csv_keys.js:122 static/js/zamboni/stats-all.js:15403 static/js/zamboni/stats-min.js:5
 msgid "SeaMonkey"
 msgstr "SeaMonkey"
 
-#: static/js/impala/stats/csv_keys.js:123
+#: static/js/impala/stats/csv_keys.js:123 static/js/zamboni/stats-all.js:15404 static/js/zamboni/stats-min.js:5
 msgid "Fennec"
 msgstr "Fennec"
 
-#: static/js/impala/stats/csv_keys.js:124
+#: static/js/impala/stats/csv_keys.js:124 static/js/zamboni/stats-all.js:15405 static/js/zamboni/stats-min.js:5
 msgid "Android"
 msgstr "Android"
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:129
+#: static/js/impala/stats/csv_keys.js:129 static/js/zamboni/stats-all.js:15410 static/js/zamboni/stats-min.js:5
 msgid "Downloads and Daily Users, last {0} days"
 msgstr "Preuzimanja i dnevni korisnici, poslednjih {0} dana"
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:131
+#: static/js/impala/stats/csv_keys.js:131 static/js/zamboni/stats-all.js:15412 static/js/zamboni/stats-min.js:5
 msgid "Downloads and Daily Users from {0} to {1}"
 msgstr "Preuzimanja i dnevni korisnici od {0} do {1}"
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:135
+#: static/js/impala/stats/csv_keys.js:135 static/js/zamboni/stats-all.js:15416 static/js/zamboni/stats-min.js:5
 msgid "Installs and Daily Users, last {0} days"
 msgstr "Instalacije i dnevni korisnici, poslednjih {0} dana"
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:137
+#: static/js/impala/stats/csv_keys.js:137 static/js/zamboni/stats-all.js:15418 static/js/zamboni/stats-min.js:5
 msgid "Installs and Daily Users from {0} to {1}"
 msgstr "Instalacije i dnevni korisnici od {0} do {1}"
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:141
+#: static/js/impala/stats/csv_keys.js:141 static/js/zamboni/stats-all.js:15422 static/js/zamboni/stats-min.js:5
 msgid "Downloads, last {0} days"
 msgstr "Preuzimanja, poslednjih {0} dana"
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:143
+#: static/js/impala/stats/csv_keys.js:143 static/js/zamboni/stats-all.js:15424 static/js/zamboni/stats-min.js:5
 msgid "Downloads from {0} to {1}"
 msgstr "Preuzimanja od {0} do {1}"
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:147
+#: static/js/impala/stats/csv_keys.js:147 static/js/zamboni/stats-all.js:15428 static/js/zamboni/stats-min.js:5
 msgid "Daily Users, last {0} days"
 msgstr "Dnevni korisnici, poslednjih {0} dana"
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:149
+#: static/js/impala/stats/csv_keys.js:149 static/js/zamboni/stats-all.js:15430 static/js/zamboni/stats-min.js:5
 msgid "Daily Users from {0} to {1}"
 msgstr "Dnevni korisnici od {0} do {1}"
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:153
+#: static/js/impala/stats/csv_keys.js:153 static/js/zamboni/stats-all.js:15434 static/js/zamboni/stats-min.js:5
 msgid "Applications, last {0} days"
 msgstr "Aplikacije, poslednjih {0} dana"
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:155
+#: static/js/impala/stats/csv_keys.js:155 static/js/zamboni/stats-all.js:15436 static/js/zamboni/stats-min.js:5
 msgid "Applications from {0} to {1}"
 msgstr "Aplikacije od {0} do {1}"
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:159
+#: static/js/impala/stats/csv_keys.js:159 static/js/zamboni/stats-all.js:15440 static/js/zamboni/stats-min.js:5
 msgid "Platforms, last {0} days"
 msgstr "Platforme, poslednjih {0} dana"
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:161
+#: static/js/impala/stats/csv_keys.js:161 static/js/zamboni/stats-all.js:15442 static/js/zamboni/stats-min.js:5
 msgid "Platforms from {0} to {1}"
 msgstr "Platforme od {0} do {1}"
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:165
+#: static/js/impala/stats/csv_keys.js:165 static/js/zamboni/stats-all.js:15446 static/js/zamboni/stats-min.js:5
 msgid "Languages, last {0} days"
 msgstr "Jezici, poslednjih {0} dana"
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:167
+#: static/js/impala/stats/csv_keys.js:167 static/js/zamboni/stats-all.js:15448 static/js/zamboni/stats-min.js:5
 msgid "Languages from {0} to {1}"
 msgstr "Jezici od {0} do {1}"
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:171
+#: static/js/impala/stats/csv_keys.js:171 static/js/zamboni/stats-all.js:15452 static/js/zamboni/stats-min.js:5
 msgid "Add-on Versions, last {0} days"
 msgstr "Verzije dodataka, poslednjih {0} dana"
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:173
+#: static/js/impala/stats/csv_keys.js:173 static/js/zamboni/stats-all.js:15454 static/js/zamboni/stats-min.js:5
 msgid "Add-on Versions from {0} to {1}"
 msgstr "Verzije dodataka od {0} do {1}"
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:177
+#: static/js/impala/stats/csv_keys.js:177 static/js/zamboni/stats-all.js:15458 static/js/zamboni/stats-min.js:5
 msgid "Add-on Status, last {0} days"
 msgstr "Status dodataka, poslednjih {0} dana"
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:179
+#: static/js/impala/stats/csv_keys.js:179 static/js/zamboni/stats-all.js:15460 static/js/zamboni/stats-min.js:5
 msgid "Add-on Status from {0} to {1}"
 msgstr "Status dodataka, od {0} do {1}"
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:183
+#: static/js/impala/stats/csv_keys.js:183 static/js/zamboni/stats-all.js:15464 static/js/zamboni/stats-min.js:5
 msgid "Download Sources, last {0} days"
 msgstr "Izvori preuzimanja, poslednjih {0} dana"
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:185
+#: static/js/impala/stats/csv_keys.js:185 static/js/zamboni/stats-all.js:15466 static/js/zamboni/stats-min.js:5
 msgid "Download Sources from {0} to {1}"
 msgstr "Izvori preuzimanja od {0} do {1}"
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:189
+#: static/js/impala/stats/csv_keys.js:189 static/js/zamboni/stats-all.js:15470 static/js/zamboni/stats-min.js:5
 msgid "Contributions, last {0} days"
 msgstr "Doprinosi, poslednjih {0} dana"
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:191
+#: static/js/impala/stats/csv_keys.js:191 static/js/zamboni/stats-all.js:15472 static/js/zamboni/stats-min.js:5
 msgid "Contributions from {0} to {1}"
 msgstr "Doprinosi od {0} do {1}"
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:195
+#: static/js/impala/stats/csv_keys.js:195 static/js/zamboni/stats-all.js:15476 static/js/zamboni/stats-min.js:5
 msgid "Site Metrics, last {0} days"
 msgstr "Pokazatelji za sajt, poslednjih {0} dana"
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:197
+#: static/js/impala/stats/csv_keys.js:197 static/js/zamboni/stats-all.js:15478 static/js/zamboni/stats-min.js:5
 msgid "Site Metrics from {0} to {1}"
 msgstr "Pokazatelji za sajt od {0} do {1}"
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:201
+#: static/js/impala/stats/csv_keys.js:201 static/js/zamboni/stats-all.js:15482 static/js/zamboni/stats-min.js:5
 msgid "Add-ons in Use, last {0} days"
 msgstr "Dodaci u upotrebi, poslednjih {0} dana"
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:203
+#: static/js/impala/stats/csv_keys.js:203 static/js/zamboni/stats-all.js:15484 static/js/zamboni/stats-min.js:5
 msgid "Add-ons in Use from {0} to {1}"
 msgstr "Dodaci u upotrebi od {0} do {1}"
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:207
+#: static/js/impala/stats/csv_keys.js:207 static/js/zamboni/stats-all.js:15488 static/js/zamboni/stats-min.js:5
 msgid "Add-ons Downloaded, last {0} days"
 msgstr "Dodataka preuzeto, poslednjih {0} dana"
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:209
+#: static/js/impala/stats/csv_keys.js:209 static/js/zamboni/stats-all.js:15490 static/js/zamboni/stats-min.js:5
 msgid "Add-ons Downloaded from {0} to {1}"
 msgstr "Dodataka preuzeto od {0} do {1}"
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:213
+#: static/js/impala/stats/csv_keys.js:213 static/js/zamboni/stats-all.js:15494 static/js/zamboni/stats-min.js:5
 msgid "Add-ons Created, last {0} days"
 msgstr "Dodataka napravljeno, poslednjih {0} dana"
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:215
+#: static/js/impala/stats/csv_keys.js:215 static/js/zamboni/stats-all.js:15496 static/js/zamboni/stats-min.js:5
 msgid "Add-ons Created from {0} to {1}"
 msgstr "Dodataka napravljeno od {0} do {1}"
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:219
+#: static/js/impala/stats/csv_keys.js:219 static/js/zamboni/stats-all.js:15500 static/js/zamboni/stats-min.js:5
 msgid "Add-ons Updated, last {0} days"
 msgstr "Dodataka ažurirano, poslednjih {0} dana"
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:221
+#: static/js/impala/stats/csv_keys.js:221 static/js/zamboni/stats-all.js:15502 static/js/zamboni/stats-min.js:5
 msgid "Add-ons Updated from {0} to {1}"
 msgstr "Dodataka ažurirano od {0} do {1}"
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:225
+#: static/js/impala/stats/csv_keys.js:225 static/js/zamboni/stats-all.js:15506 static/js/zamboni/stats-min.js:5
 msgid "Reviews Written, last {0} days"
 msgstr "Recenzija napisano, poslednjih {0} dana"
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:227
+#: static/js/impala/stats/csv_keys.js:227 static/js/zamboni/stats-all.js:15508 static/js/zamboni/stats-min.js:5
 msgid "Reviews Written from {0} to {1}"
 msgstr "Recenzija napisano od {0} do {1}"
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:231
+#: static/js/impala/stats/csv_keys.js:231 static/js/zamboni/stats-all.js:15512 static/js/zamboni/stats-min.js:5
 msgid "User Signups, last {0} days"
 msgstr "Registracije korisnika, poslednjih {0} dana"
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:233
+#: static/js/impala/stats/csv_keys.js:233 static/js/zamboni/stats-all.js:15514 static/js/zamboni/stats-min.js:5
 msgid "User Signups from {0} to {1}"
 msgstr "Registracije korisnika od {0} do {1}"
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:237
+#: static/js/impala/stats/csv_keys.js:237 static/js/zamboni/stats-all.js:15518 static/js/zamboni/stats-min.js:5
 msgid "Collections Created, last {0} days"
 msgstr "Kolekcija napravljeno, poslednjih {0} dana"
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:239
+#: static/js/impala/stats/csv_keys.js:239 static/js/zamboni/stats-all.js:15520 static/js/zamboni/stats-min.js:5
 msgid "Collections Created from {0} to {1}"
 msgstr "Kolekcija napravljeno od {0} do {1}"
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:243
+#: static/js/impala/stats/csv_keys.js:243 static/js/zamboni/stats-all.js:15524 static/js/zamboni/stats-min.js:5
 msgid "Subscribers, last {0} days"
 msgstr "Pretplatnici, poslednjih {0} dana"
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:245
+#: static/js/impala/stats/csv_keys.js:245 static/js/zamboni/stats-all.js:15526 static/js/zamboni/stats-min.js:5
 msgid "Subscribers from {0} to {1}"
 msgstr "Pretplatnici od {0} do {1}"
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:249
+#: static/js/impala/stats/csv_keys.js:249 static/js/zamboni/stats-all.js:15530 static/js/zamboni/stats-min.js:5
 msgid "Ratings, last {0} days"
 msgstr "Ocenjivanja, poslednjih {0} dana"
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:251
+#: static/js/impala/stats/csv_keys.js:251 static/js/zamboni/stats-all.js:15532 static/js/zamboni/stats-min.js:5
 msgid "Ratings from {0} to {1}"
 msgstr "Ocenjivanja od {0} do {1}"
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:255
+#: static/js/impala/stats/csv_keys.js:255 static/js/zamboni/stats-all.js:15536 static/js/zamboni/stats-min.js:5
 msgid "Sales, last {0} days"
 msgstr "Prodaja, poslednjih {0} dana"
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:257
+#: static/js/impala/stats/csv_keys.js:257 static/js/zamboni/stats-all.js:15538 static/js/zamboni/stats-min.js:5
 msgid "Sales from {0} to {1}"
 msgstr "Prodaja od {0} do {1}"
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:261
+#: static/js/impala/stats/csv_keys.js:261 static/js/zamboni/stats-all.js:15542 static/js/zamboni/stats-min.js:5
 msgid "Installs, last {0} days"
 msgstr "Instalacije, poslednjih {0} dana"
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:263
+#: static/js/impala/stats/csv_keys.js:263 static/js/zamboni/stats-all.js:15544 static/js/zamboni/stats-min.js:5
 msgid "Installs from {0} to {1}"
 msgstr "Instalacije, od {0} do {1}"
 
 #. L10n: {0} and {1} are integers.
-#: static/js/impala/stats/csv_keys.js:269
+#: static/js/impala/stats/csv_keys.js:269 static/js/zamboni/stats-all.js:15550 static/js/zamboni/stats-min.js:5
 msgid "<b>{0}</b> in last {1} days"
 msgstr "<b>{0}</b> u poslednjih {1} dana"
 
 #. L10n: {0} is an integer and {1} and {2} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:271 static/js/impala/stats/csv_keys.js:277
+#: static/js/impala/stats/csv_keys.js:271 static/js/impala/stats/csv_keys.js:277 static/js/zamboni/stats-all.js:15552 static/js/zamboni/stats-all.js:15558 static/js/zamboni/stats-min.js:5
 msgid "<b>{0}</b> from {1} to {2}"
 msgstr "<b>{0}</b> od {1} do {2}"
 
 #. L10n: {0} and {1} are integers.
-#: static/js/impala/stats/csv_keys.js:275
+#: static/js/impala/stats/csv_keys.js:275 static/js/zamboni/stats-all.js:15556 static/js/zamboni/stats-min.js:5
 msgid "<b>{0}</b> average in last {1} days"
 msgstr "<b>{0}</b> prosečne u poslednjih {1} dana"
 
-#: static/js/impala/stats/overview.js:19
+#: static/js/impala/stats/overview.js:19 static/js/zamboni/stats-all.js:16469 static/js/zamboni/stats-min.js:5
 msgid "No data available."
 msgstr "Nema dostupnih podataka."
 
-#: static/js/impala/stats/table.js:74
+#: static/js/impala/stats/table.js:74 static/js/zamboni/stats-all.js:17209 static/js/zamboni/stats-min.js:5
 msgid "Date"
 msgstr "Datum"
 
-#: static/js/impala/stats/topchart.js:96
+#: static/js/impala/stats/topchart.js:96 static/js/zamboni/stats-all.js:16600 static/js/zamboni/stats-min.js:5
 msgid "Other"
 msgstr "Ostali"
 
-#: static/js/zamboni/admin_validation.js:24 static/js/zamboni/devhub.js:1229 static/js/zamboni/editors.js:295
+#: static/js/zamboni/admin-all.js:180 static/js/zamboni/admin-min.js:1 static/js/zamboni/admin_validation.js:24 static/js/zamboni/devhub-all.js:2408 static/js/zamboni/devhub-min.js:2
+#: static/js/zamboni/devhub.js:1229 static/js/zamboni/editors-all.js:15576 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:295
 msgid "Select an application first"
 msgstr "Prvo izaberite aplikaciju"
 
-#: static/js/zamboni/admin_validation.js:51
+#: static/js/zamboni/admin-all.js:207 static/js/zamboni/admin-min.js:1 static/js/zamboni/admin_validation.js:51
 msgid "Set {0} add-on to a max version of {1} and email the author."
 msgid_plural "Set {0} add-ons to a max version of {1} and email the authors."
 msgstr[0] "Podesite {0} dodatak na maksimalnu verziju od {1} i pošalji e-poštu autoru."
 msgstr[1] "Podesite {0} dodataka na maksimalnu verziju od {1} i pošalji e-poštu autorima."
-msgstr[2] "Podesite {0} dodataka na maksimalnu verziju od {1} i pošalji e-poštu autorima."
 
-#: static/js/zamboni/admin_validation.js:54
+#: static/js/zamboni/admin-all.js:210 static/js/zamboni/admin-min.js:1 static/js/zamboni/admin_validation.js:54
 msgid "Email author of {2} add-on which failed validation."
 msgid_plural "Email authors of {2} add-ons which failed validation."
 msgstr[0] "Autor e-pošte ima {2} dodatak koji nije prošao proveru valjanosti."
 msgstr[1] "Autor e-pošte ima {2} dodatka koji nisu prošli proveru valjanosti."
-msgstr[2] "Autor e-pošte ima {2} dodatka koji nisu prošli proveru valjanosti."
 
-#. L10n: {0} is an app name like Firefox.
-#: static/js/zamboni/buttons.js:66
-msgid "Accept and Install"
-msgstr "Prihvati i instaliraj"
-
-#: static/js/zamboni/buttons.js:66
-msgid "Add to {0}"
-msgstr "Dodaj u {0}"
-
-#: static/js/zamboni/buttons.js:71
-msgid "Download Now"
-msgstr "Preuzmi odmah"
-
-#: static/js/zamboni/buttons.js:112
-msgid "Add-on has not been updated to support default-to-compatible."
-msgstr "Dodatak nije ažuriran da podržava default-to-compatible."
-
-#: static/js/zamboni/buttons.js:117
-msgid "You need to be using Firefox 10.0 or higher."
-msgstr "Morate koristiti Firefox 10.0 ili novije."
-
-#: static/js/zamboni/buttons.js:129
-msgid "Mozilla has marked this version as incompatible with your Firefox version."
-msgstr "Mozilla je označila ovu verziju kao nekompatabilnu sa Vašom verzijom Firefox-a."
-
-#. L10n: {0} is an platform like Windows or Linux.
-#: static/js/zamboni/buttons.js:210
-msgid "Install for {0} anyway"
-msgstr "Instaliraj za {0} u svakom slučaju"
-
-#: static/js/zamboni/buttons.js:210
-msgid "Download for {0} anyway"
-msgstr "Preuzmi za {0} u svakom slučaju"
-
-#: static/js/zamboni/buttons.js:267
-msgid "Not available for your platform"
-msgstr "Nije dostupno za Vašu platformu"
-
-#. L10n: {0} is an app name, {1} is the app version.
-#: static/js/zamboni/buttons.js:278 static/js/zamboni/buttons.js:315
-msgid "Not available for {0} {1}"
-msgstr "Nije dostupno za {0} {1}"
-
-#: static/js/zamboni/buttons.js:341
-msgid "Works with {app} {min} - {max}"
-msgstr "Radi sa {app} {min} - {max}"
-
-#: static/js/zamboni/buttons.js:343
-msgid "View other versions"
-msgstr "Pogledaj ostale verzije"
-
-#: static/js/zamboni/buttons.js:391
-msgid "Only with Firefox — Get Firefox Now!"
-msgstr ""
-
-#: static/js/zamboni/buttons.js:507 static/js/zamboni/mobile/buttons.js:43
-msgid "Sorry, you need a Mozilla-based browser (such as Firefox) to install a search plugin."
-msgstr "Žao nam je, treba Vam pregledač baziran na tehnologiji Mozilla fondacije (kao što je Firefox) da biste instalirali priključak za pretraživanje."
-
-#: static/js/zamboni/collections.js:229
-msgid "Adding to Favorites&hellip;"
-msgstr "Dodajem u Omiljeno&hellip;"
-
-#: static/js/zamboni/collections.js:232
-msgid "Removing Favorite&hellip;"
-msgstr "Brišem iz Omiljenih&hellip;"
-
-#: static/js/zamboni/collections.js:235
-msgid "Add to Favorites"
-msgstr "Dodaj u Omiljene"
-
-#: static/js/zamboni/collections.js:238
-msgid "Remove from Favorites"
-msgstr "Izbriši iz Omiljenih"
-
-#: static/js/zamboni/collections.js:303
-msgid "Pending"
-msgstr "Na čekanju"
-
-#: static/js/zamboni/collections.js:304
-msgid "Add a comment"
-msgstr "Dodaj komentar"
-
-#: static/js/zamboni/collections.js:304
-msgid "Comment"
-msgstr "Komentar"
-
-#: static/js/zamboni/collections.js:305
-msgid "Remove this add-on from the collection"
-msgstr "Izbriši ovaj dodatak iz kolekcije"
-
-#: static/js/zamboni/collections.js:305 static/js/zamboni/collections.js:334
-msgid "Remove"
-msgstr "Izbriši"
-
-#: static/js/zamboni/collections.js:334
-msgid "Remove this user as a contributor"
-msgstr "Ukloni korisnika kao saradnika"
-
-#: static/js/zamboni/collections.js:346
-msgid "An email address is required."
-msgstr "Adresa e-pošte je obavezna."
-
-#: static/js/zamboni/collections.js:364
-msgid "You cannot add yourself as a contributor."
-msgstr "Ne možete sebe dodati kao saradnika."
-
-#: static/js/zamboni/collections.js:366
-msgid "You have already added that user."
-msgstr "Već ste dodali tog korisnika."
-
-#: static/js/zamboni/collections.js:573
-msgid "Add to favorites"
-msgstr "Dodaj u omiljene"
-
-#: static/js/zamboni/collections.js:577
-msgid "Remove from favorites"
-msgstr "Izbriši iz omiljenih"
-
-#: static/js/zamboni/collections.js:604
-msgid "Stop following"
-msgstr "Prekini praćenje"
-
-#: static/js/zamboni/devhub.js:110
+#: static/js/zamboni/devhub-all.js:1289 static/js/zamboni/devhub-min.js:1 static/js/zamboni/devhub.js:110
 msgid "Your browser does not support the video tag"
 msgstr "Vaš pregledač ne podržava oznake video snimaka"
 
-#: static/js/zamboni/devhub.js:371
+#: static/js/zamboni/devhub-all.js:1550 static/js/zamboni/devhub-min.js:1 static/js/zamboni/devhub.js:371
 msgid "Changes Saved"
 msgstr "Izmene sačuvane"
 
-#: static/js/zamboni/devhub.js:387
+#: static/js/zamboni/devhub-all.js:1566 static/js/zamboni/devhub-min.js:1 static/js/zamboni/devhub.js:387
 msgid "Enter a new author's email address"
 msgstr "Unesite adresu e-pošte novog autora"
 
-#: static/js/zamboni/devhub.js:536
+#: static/js/zamboni/devhub-all.js:1715 static/js/zamboni/devhub-min.js:1 static/js/zamboni/devhub.js:536
 msgid "There was an error uploading your file."
 msgstr "Došlo je do greške prilikom otpremanja Vaše datoteke."
 
-#: static/js/zamboni/devhub.js:681
+#: static/js/zamboni/devhub-all.js:1860 static/js/zamboni/devhub-min.js:1 static/js/zamboni/devhub.js:681
 msgid "{files} file"
 msgid_plural "{files} files"
 msgstr[0] "{files} datoteka"
 msgstr[1] "{files} datoteke"
-msgstr[2] "{files} datoteka"
 
-#: static/js/zamboni/devhub.js:684
+#: static/js/zamboni/devhub-all.js:1863 static/js/zamboni/devhub-min.js:1 static/js/zamboni/devhub.js:684
 msgid "{reviews} user review"
 msgid_plural "{reviews} user reviews"
 msgstr[0] "{reviews} korisnička recenzija"
 msgstr[1] "{reviews} korisničke recenzije"
-msgstr[2] "{reviews} korisničkih recenzija"
 
-#: static/js/zamboni/devhub.js:796
+#: static/js/zamboni/devhub-all.js:1975 static/js/zamboni/devhub-min.js:2 static/js/zamboni/devhub.js:796
 msgid "Learn more"
 msgstr "Saznajte više"
 
-#: static/js/zamboni/devhub.js:800
+#: static/js/zamboni/devhub-all.js:1979 static/js/zamboni/devhub-min.js:2 static/js/zamboni/devhub.js:800
 msgid "Example"
 msgstr "Primer"
 
-#: static/js/zamboni/devhub.js:1130
+#: static/js/zamboni/devhub-all.js:2309 static/js/zamboni/devhub-min.js:2 static/js/zamboni/devhub.js:1130
 msgid "Image changes being processed"
 msgstr "Izmene na slici se obrađuju"
 
-#: static/js/zamboni/devhub.js:1280
+#: static/js/zamboni/devhub-all.js:2459 static/js/zamboni/devhub-min.js:2 static/js/zamboni/devhub.js:1280
 msgid "Must be a valid e-mail address."
 msgstr "Adresa e-pošte mora biti ispravna."
+
+#: static/js/zamboni/devhub-all.js:2613 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:80
+msgid "All tests passed successfully."
+msgstr "Svi testovi su uspešno završeni."
+
+#: static/js/zamboni/devhub-all.js:2616 static/js/zamboni/devhub-all.js:3011 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:83 static/js/zamboni/validator.js:478
+msgid "These tests were not run."
+msgstr "Ovi testovi nisu izvršeni."
+
+#: static/js/zamboni/devhub-all.js:2664 static/js/zamboni/devhub-all.js:2677 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:131 static/js/zamboni/validator.js:144
+msgid "Tests"
+msgstr "Testovi"
+
+#: static/js/zamboni/devhub-all.js:2779 static/js/zamboni/devhub-all.js:3108 static/js/zamboni/devhub-all.js:3127 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:246
+#: static/js/zamboni/validator.js:575 static/js/zamboni/validator.js:594
+msgid "Error"
+msgstr "Greška"
+
+#: static/js/zamboni/devhub-all.js:2780 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:247
+msgid "Warning"
+msgstr "Upozorenje"
+
+#: static/js/zamboni/devhub-all.js:2794 static/js/zamboni/devhub-min.js:2 static/js/zamboni/files-all.js:5657 static/js/zamboni/files-min.js:3 static/js/zamboni/files.js:411
+#: static/js/zamboni/validator.js:261
+msgid "Ignore this message in future updates"
+msgstr ""
+
+#: static/js/zamboni/devhub-all.js:2817 static/js/zamboni/devhub-min.js:2 static/js/zamboni/files-all.js:5663 static/js/zamboni/files-min.js:3 static/js/zamboni/files.js:417
+#: static/js/zamboni/validator.js:284
+msgid "Severity for automated signing:"
+msgstr ""
+
+#: static/js/zamboni/devhub-all.js:2832 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:299
+msgid "Suggestions for passing automated signing:"
+msgstr ""
+
+#: static/js/zamboni/devhub-all.js:2920 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:387
+msgid "Compatibility Tests"
+msgstr "Testovi kompatibilnosti"
+
+#: static/js/zamboni/devhub-all.js:2999 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:466
+msgid "Add-on failed validation."
+msgstr "Dodatak nije prošao proveru."
+
+#: static/js/zamboni/devhub-all.js:3001 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:468
+msgid "Add-on passed validation."
+msgstr "Dodatak je prošao proveru."
+
+#: static/js/zamboni/devhub-all.js:3014 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:481
+msgid "{0} error"
+msgid_plural "{0} errors"
+msgstr[0] "{0} greška"
+msgstr[1] "{0} greške"
+
+#: static/js/zamboni/devhub-all.js:3016 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:483
+msgid "{0} warning"
+msgid_plural "{0} warnings"
+msgstr[0] "{0} upozorenje"
+msgstr[1] "{0} upozorenja"
+
+#: static/js/zamboni/devhub-all.js:3018 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:485
+msgid "{0} notice"
+msgid_plural "{0} notices"
+msgstr[0] "{0} obaveštenje"
+msgstr[1] "{0} obaveštenja"
+
+#: static/js/zamboni/devhub-all.js:3110 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:577
+msgid "Validation task could not complete or completed with errors"
+msgstr "Zadatak provere nije mogao biti završen ili je završen sa greškama"
+
+#: static/js/zamboni/devhub-all.js:3128 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:595
+msgid "Internal server error"
+msgstr "Greška na serveru"
 
 #: static/js/zamboni/devhub_search.js:8
 msgid "No results found."
 msgstr "Nema rezultata."
 
-#: static/js/zamboni/editors.js:121
+#: static/js/zamboni/editors-all.js:15402 static/js/zamboni/editors-min.js:4 static/js/zamboni/editors.js:121
 msgid "{name} was viewing this page first."
 msgstr "{name} je prvi gledao ovu stranicu."
 
-#: static/js/zamboni/editors.js:171
+#: static/js/zamboni/editors-all.js:15452 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:171
 msgid "Receipt checked by app."
 msgstr "Potvrda proverena od strane aplikacije."
 
-#: static/js/zamboni/editors.js:173
+#: static/js/zamboni/editors-all.js:15454 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:173
 msgid "Receipt was not checked by app."
 msgstr "Potvrda nije proverena od strane aplikacije."
 
-#: static/js/zamboni/editors.js:244
+#: static/js/zamboni/editors-all.js:15525 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:244
 msgid "{name} was viewing this add-on first."
 msgstr "{name} je prvi pregledavao ovaj dodatak."
 
-#: static/js/zamboni/editors.js:255
+#: static/js/zamboni/editors-all.js:15536 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:255
 msgid "Loading&hellip;"
 msgstr "Učitavam&hellip;"
 
-#: static/js/zamboni/editors.js:260
+#: static/js/zamboni/editors-all.js:15541 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:260
 msgid "Version Notes"
 msgstr "Beleške o verziji"
 
-#: static/js/zamboni/editors.js:265
+#: static/js/zamboni/editors-all.js:15546 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:265
 msgid "Notes for Reviewers"
 msgstr "Beleške za recenzente"
 
-#: static/js/zamboni/editors.js:270
+#: static/js/zamboni/editors-all.js:15551 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:270
 msgid "No version notes found"
 msgstr "Nije nađena ni jedna beleška o verziji"
 
-#: static/js/zamboni/editors.js:330
+#: static/js/zamboni/editors-all.js:15611 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:330
 msgid "Average Reviews"
 msgstr ""
 
-#: static/js/zamboni/editors.js:386
+#: static/js/zamboni/editors-all.js:15667 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:386
 msgid "Number of Reviews"
 msgstr ""
 
-#: static/js/zamboni/editors.js:445
+#: static/js/zamboni/editors-all.js:15726 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:445
 msgid "Error loading translation"
 msgstr "Greška pri učitavanju prevoda"
 
-#: static/js/zamboni/files.js:411 static/js/zamboni/validator.js:261
-msgid "Ignore this message in future updates"
-msgstr ""
-
-#: static/js/zamboni/files.js:417 static/js/zamboni/validator.js:284
-msgid "Severity for automated signing:"
-msgstr ""
-
-#: static/js/zamboni/global.js:410
-msgid "Loading..."
-msgstr "Učitavanje..."
-
-#. L10n: {0} is the number of characters left.
-#: static/js/zamboni/global.js:474
-msgid "<b>{0}</b> character left."
-msgid_plural "<b>{0}</b> characters left."
-msgstr[0] "<b>{0}</b> karakter preostao."
-msgstr[1] "<b>{0}</b> karaktera preostala."
-msgstr[2] "<b>{0}</b> karaktera preostalo."
-
-#: static/js/zamboni/init.js:28
-msgid "This feature is temporarily disabled while we perform website maintenance. Please check back a little later."
-msgstr "Ova mogućnost je privremeno onemogućena dok obavljamo zadatak održavanja sajta. Molimo probajte malo kasnije."
-
-#: static/js/zamboni/l10n.js:45
-msgid "Remove this localization"
-msgstr "Ukloni ovu lokalizaciju"
-
-#: static/js/zamboni/password-strength.js:20
-msgid "Password strength:"
-msgstr "Jačina lozinke:"
-
-#: static/js/zamboni/password-strength.js:26
-msgid "At least {0} character left."
-msgid_plural "At least {0} characters left."
-msgstr[0] "Ostao je još najmanje {0} karater."
-msgstr[1] "Ostalo je još najmanje {0} karatera."
-msgstr[2] "Ostalo je još najmanje {0} karatera."
-
-#: static/js/zamboni/themes_review.js:176
-msgid "Requested Info"
-msgstr "Zahtevane informacije"
-
-#: static/js/zamboni/themes_review.js:177
-msgid "Flagged"
-msgstr "Označeno"
-
-#: static/js/zamboni/themes_review.js:178
-msgid "Duplicate"
-msgstr "Duplikat"
-
-#: static/js/zamboni/themes_review.js:179
-msgid "Rejected"
-msgstr "Odbijeno"
-
-#: static/js/zamboni/themes_review.js:180
-msgid "Approved"
-msgstr "Odobreno"
-
-#: static/js/zamboni/themes_review.js:424
-msgid "No results found"
-msgstr ""
-
-#: static/js/zamboni/themes_review_templates.js:31
+#: static/js/zamboni/editors-all.js:15975 static/js/zamboni/editors-min.js:5 static/js/zamboni/themes_review_templates.js:31
 msgid "Theme"
 msgstr ""
 
-#: static/js/zamboni/themes_review_templates.js:33
+#: static/js/zamboni/editors-all.js:15977 static/js/zamboni/editors-min.js:5 static/js/zamboni/themes_review_templates.js:33
 msgid "Reviewer"
 msgstr ""
 
-#: static/js/zamboni/themes_review_templates.js:35
+#: static/js/zamboni/editors-all.js:15979 static/js/zamboni/editors-min.js:5 static/js/zamboni/themes_review_templates.js:35
 msgid "Status"
 msgstr ""
 
-#: static/js/zamboni/validator.js:80
-msgid "All tests passed successfully."
-msgstr "Svi testovi su uspešno završeni."
+#: static/js/zamboni/editors-all.js:16196 static/js/zamboni/editors-min.js:5 static/js/zamboni/themes_review.js:176
+msgid "Requested Info"
+msgstr "Zahtevane informacije"
 
-#: static/js/zamboni/validator.js:83 static/js/zamboni/validator.js:478
-msgid "These tests were not run."
-msgstr "Ovi testovi nisu izvršeni."
+#: static/js/zamboni/editors-all.js:16197 static/js/zamboni/editors-min.js:5 static/js/zamboni/themes_review.js:177
+msgid "Flagged"
+msgstr "Označeno"
 
-#: static/js/zamboni/validator.js:131 static/js/zamboni/validator.js:144
-msgid "Tests"
-msgstr "Testovi"
+#: static/js/zamboni/editors-all.js:16198 static/js/zamboni/editors-min.js:5 static/js/zamboni/themes_review.js:178
+msgid "Duplicate"
+msgstr "Duplikat"
 
-#: static/js/zamboni/validator.js:246 static/js/zamboni/validator.js:575 static/js/zamboni/validator.js:594
-msgid "Error"
-msgstr "Greška"
+#: static/js/zamboni/editors-all.js:16199 static/js/zamboni/editors-min.js:5 static/js/zamboni/themes_review.js:179
+msgid "Rejected"
+msgstr "Odbijeno"
 
-#: static/js/zamboni/validator.js:247
-msgid "Warning"
-msgstr "Upozorenje"
+#: static/js/zamboni/editors-all.js:16200 static/js/zamboni/editors-min.js:5 static/js/zamboni/themes_review.js:180
+msgid "Approved"
+msgstr "Odobreno"
 
-#: static/js/zamboni/validator.js:299
-msgid "Suggestions for passing automated signing:"
+#: static/js/zamboni/editors-all.js:16444 static/js/zamboni/editors-min.js:5 static/js/zamboni/themes_review.js:424
+msgid "No results found"
 msgstr ""
 
-#: static/js/zamboni/validator.js:387
-msgid "Compatibility Tests"
-msgstr "Testovi kompatibilnosti"
-
-#: static/js/zamboni/validator.js:466
-msgid "Add-on failed validation."
-msgstr "Dodatak nije prošao proveru."
-
-#: static/js/zamboni/validator.js:468
-msgid "Add-on passed validation."
-msgstr "Dodatak je prošao proveru."
-
-#: static/js/zamboni/validator.js:481
-msgid "{0} error"
-msgid_plural "{0} errors"
-msgstr[0] "{0} greška"
-msgstr[1] "{0} greške"
-msgstr[2] "{0} grešaka"
-
-#: static/js/zamboni/validator.js:483
-msgid "{0} warning"
-msgid_plural "{0} warnings"
-msgstr[0] "{0} upozorenje"
-msgstr[1] "{0} upozorenja"
-msgstr[2] "{0} upozorenja"
-
-#: static/js/zamboni/validator.js:485
-msgid "{0} notice"
-msgid_plural "{0} notices"
-msgstr[0] "{0} obaveštenje"
-msgstr[1] "{0} obaveštenja"
-msgstr[2] "{0} obaveštenja"
-
-#: static/js/zamboni/validator.js:577
-msgid "Validation task could not complete or completed with errors"
-msgstr "Zadatak provere nije mogao biti završen ili je završen sa greškama"
-
-#: static/js/zamboni/validator.js:595
-msgid "Internal server error"
-msgstr "Greška na serveru"
-
-#: static/js/zamboni/mobile/buttons.js:52
+#: static/js/zamboni/mobile-all.js:15186 static/js/zamboni/mobile/buttons.js:52
 msgid "Not Updated for {0} {1}"
 msgstr "Nije ažurirano za {0} {1}"
 
-#: static/js/zamboni/mobile/buttons.js:53
+#: static/js/zamboni/mobile-all.js:15187 static/js/zamboni/mobile/buttons.js:53
 msgid "Requires Newer Version of {0}"
 msgstr "Zahteva verziju noviju od {0}"
 
-#: static/js/zamboni/mobile/buttons.js:54
+#: static/js/zamboni/mobile-all.js:15188 static/js/zamboni/mobile/buttons.js:54
 msgid "Unreviewed"
 msgstr "Neocenjeno"
 
-#: static/js/zamboni/mobile/buttons.js:55
+#: static/js/zamboni/mobile-all.js:15189 static/js/zamboni/mobile/buttons.js:55
 msgid "Experimental <span>(Learn More)</span>"
 msgstr "Eksperimentalno <span>(Saznaj više)</span>"
 
-#: static/js/zamboni/mobile/buttons.js:56 static/js/zamboni/mobile/buttons.js:57
+#: static/js/zamboni/mobile-all.js:15190 static/js/zamboni/mobile-all.js:15191 static/js/zamboni/mobile/buttons.js:56 static/js/zamboni/mobile/buttons.js:57
 msgid "Not Available for {0}"
 msgstr "Nije dostupno za {0}"
 
-#: static/js/zamboni/mobile/buttons.js:58
+#: static/js/zamboni/mobile-all.js:15192 static/js/zamboni/mobile/buttons.js:58
 msgid "Experimental"
 msgstr "Eksperimentalno"
 
-#: static/js/zamboni/mobile/buttons.js:59
+#: static/js/zamboni/mobile-all.js:15193 static/js/zamboni/mobile/buttons.js:59
 msgid "Themes Require Newer Version of {0}"
 msgstr "Teme zahtevaju noviju verziju od {0}"
 
-#: static/js/zamboni/mobile/buttons.js:60
+#: static/js/zamboni/mobile-all.js:15194 static/js/zamboni/mobile/buttons.js:60
 msgid "Themes Require {0}"
 msgstr "Teme zahtevaju {0}"
 
-#: static/js/zamboni/mobile/buttons.js:105
+#: static/js/zamboni/mobile-all.js:15239 static/js/zamboni/mobile/buttons.js:105
 msgid "Installing..."
 msgstr "Instaliram..."
 
-#: static/js/zamboni/mobile/buttons.js:125
+#: static/js/zamboni/mobile-all.js:15259 static/js/zamboni/mobile/buttons.js:125
 msgid "This add-on has been preliminarily reviewed by Mozilla."
 msgstr "Ovaj dodatak je preliminarno pregledan od Mozilla-e."
 
-#: static/js/zamboni/mobile/buttons.js:250
+#: static/js/zamboni/mobile-all.js:15384 static/js/zamboni/mobile/buttons.js:250
 msgid "Keep it"
 msgstr "Zadrži"
 
-#: static/js/zamboni/mobile/general.js:344
+#: static/js/zamboni/mobile-all.js:16049 static/js/zamboni/mobile-min.js:6 static/js/zamboni/mobile/general.js:344
 msgid "You're trying it on!"
 msgstr "Isprobavate je!"
 
-#: static/js/zamboni/mobile/general.js:356
+#: static/js/zamboni/mobile-all.js:16061 static/js/zamboni/mobile-min.js:6 static/js/zamboni/mobile/general.js:356
 msgid "Added to Firefox"
 msgstr "Dodato u Firefox"
-

--- a/locale/sv_SE/LC_MESSAGES/django.po
+++ b/locale/sv_SE/LC_MESSAGES/django.po
@@ -1,82 +1,73 @@
-# 
+#
 msgid ""
 msgstr ""
 "Project-Id-Version: REMORA 0.1\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2016-02-24 21:23+0000\n"
+"POT-Creation-Date: 2016-04-18 15:47+0000\n"
 "PO-Revision-Date: 2016-04-12 17:50+0000\n"
 "Last-Translator: Andreas Pettersson <az@kth.se>\n"
 "Language-Team: The Swedish l10n-team <community-sweden@lists.mozilla.org>\n"
-"Language: sv_SE\n"
+"Language: \n"
 "MIME-Version: 1.0\n"
-"Content-Type: text/plain; charset=utf-8\n"
+"Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 "Generated-By: Babel 2.2.0\n"
-"X-Generator: Pontoon\n"
 
-#: src/olympia/accounts/views.py:52
+#: src/olympia/accounts/views.py:54
 msgid "Your log in attempt could not be parsed. Please try again."
 msgstr "Ditt inloggningsförsök kunde inte tolkas. Var god försök igen."
 
-#: src/olympia/accounts/views.py:54
+#: src/olympia/accounts/views.py:56
 msgid "Your Firefox Account could not be found. Please try again."
 msgstr "Ditt Firefox-konto kunde inte hittas. Var god försök igen."
 
-#: src/olympia/accounts/views.py:55
+#: src/olympia/accounts/views.py:57
 msgid "You could not be logged in. Please try again."
 msgstr "Du kan inte logga in. Försök igen."
 
-#: src/olympia/accounts/views.py:57
+#: src/olympia/accounts/views.py:59
 msgid "Your account has already been migrated to Firefox Accounts."
 msgstr "Ditt konto har redan blivit migrerat till ett Firefox Konto."
 
-#: src/olympia/accounts/views.py:59
+#: src/olympia/accounts/views.py:61
 msgid "Your Firefox Account already exists on this site."
 msgstr "Ditt Firefox Konto existerar redan på sidan."
 
-#: src/olympia/accounts/views.py:108
+#: src/olympia/accounts/views.py:110
 msgid "Great job!"
 msgstr "Bra jobbat!"
 
-#: src/olympia/accounts/views.py:109
+#: src/olympia/accounts/views.py:111
 msgid "You can now log in to Add-ons with your Firefox Account."
 msgstr "Du kan nu logga in på tillägg med ditt Firefox-konto."
 
-#: src/olympia/accounts/views.py:121
+#: src/olympia/accounts/views.py:123
 msgid "Need help?"
 msgstr "Behöver du hjälp?"
 
-#: src/olympia/addons/buttons.py:180
+#: src/olympia/addons/buttons.py:177
 msgid "Download Now"
 msgstr "Hämta nu"
 
-#: src/olympia/addons/buttons.py:182
+#: src/olympia/addons/buttons.py:179
 msgid "Download"
 msgstr "Hämta"
 
 #. L10n: please keep &nbsp; in the string so &rarr; does not wrap.
-#: src/olympia/addons/buttons.py:186
+#: src/olympia/addons/buttons.py:183
 msgid "Continue to Download&nbsp;&rarr;"
 msgstr "Fortsätt till nedladdning&nbsp;&rarr;"
 
-#: src/olympia/addons/buttons.py:202 src/olympia/addons/helpers.py:35
-#: src/olympia/addons/views.py:319
-#: src/olympia/addons/templates/addons/impala/details.html:114
-#: src/olympia/addons/templates/addons/impala/listing/items.html:17
-#: src/olympia/addons/templates/addons/mobile/home.html:40
-#: src/olympia/amo/templates/amo/side_nav.html:6
-#: src/olympia/amo/templates/amo/side_nav.html:10
-#: src/olympia/amo/templates/amo/site_nav.html:2
-#: src/olympia/amo/templates/amo/site_nav.html:55
-#: src/olympia/bandwagon/views.py:95 src/olympia/browse/views.py:54
-#: src/olympia/browse/views.py:68 src/olympia/browse/views.py:235
-#: src/olympia/browse/templates/browse/impala/category_landing.html:22
+#: src/olympia/addons/buttons.py:199 src/olympia/addons/helpers.py:35 src/olympia/addons/views.py:333 src/olympia/addons/templates/addons/impala/details.html:111
+#: src/olympia/addons/templates/addons/impala/listing/items.html:17 src/olympia/addons/templates/addons/mobile/home.html:40 src/olympia/amo/templates/amo/side_nav.html:6
+#: src/olympia/amo/templates/amo/side_nav.html:10 src/olympia/amo/templates/amo/site_nav.html:2 src/olympia/amo/templates/amo/site_nav.html:53 src/olympia/bandwagon/views.py:95
+#: src/olympia/browse/views.py:54 src/olympia/browse/views.py:68 src/olympia/browse/views.py:202 src/olympia/browse/templates/browse/impala/category_landing.html:22
 #: src/olympia/browse/templates/browse/personas/mobile/category_landing.html:26
 msgid "Featured"
 msgstr "Utvalda"
 
-#: src/olympia/addons/buttons.py:221
+#: src/olympia/addons/buttons.py:218
 msgid "Add to {0}"
 msgstr "Lägg till i {0}"
 
@@ -115,11 +106,8 @@ msgstr[1] "Du har {0} för många taggar."
 
 #: src/olympia/addons/forms.py:117
 #, python-format
-msgid ""
-"All tags must be %s characters or less after invalid characters are removed."
-msgstr ""
-"Alla taggar måste vara %s tecken eller mindre efter att ogiltiga tecken har "
-"tagits bort."
+msgid "All tags must be %s characters or less after invalid characters are removed."
+msgstr "Alla taggar måste vara %s tecken eller mindre efter att ogiltiga tecken har tagits bort."
 
 #: src/olympia/addons/forms.py:121
 msgid "All tags must be at least {0} character."
@@ -127,49 +115,39 @@ msgid_plural "All tags must be at least {0} characters."
 msgstr[0] "Alla taggar måste minst vara {0} tecken."
 msgstr[1] "Alla taggar måste minst vara {0} tecken."
 
-#: src/olympia/addons/forms.py:234
-msgid ""
-"Categories cannot be changed while your add-on is featured for this "
-"application."
-msgstr ""
-"Kategorier kan inte ändras medan ditt tillägg är utvald för denna "
-"applikation."
+#: src/olympia/addons/forms.py:238
+msgid "Categories cannot be changed while your add-on is featured for this application."
+msgstr "Kategorier kan inte ändras medan ditt tillägg är utvald för denna applikation."
 
 #. L10n: {0} is the number of categories.
-#: src/olympia/addons/forms.py:238
+#: src/olympia/addons/forms.py:242
 msgid "You can have only {0} category."
 msgid_plural "You can have only {0} categories."
 msgstr[0] "Du kan endast ha {0} kategori."
 msgstr[1] "Du kan endast ha {0} kategorier."
 
-#: src/olympia/addons/forms.py:246
-msgid ""
-"The miscellaneous category cannot be combined with additional categories."
+#: src/olympia/addons/forms.py:250
+msgid "The miscellaneous category cannot be combined with additional categories."
 msgstr "Den övriga kategorin kan inte kombineras med ytterligare kategorier."
 
-#: src/olympia/addons/forms.py:369
+#: src/olympia/addons/forms.py:374
 #, python-format
-msgid ""
-"Before changing your default locale you must have a name, summary, and "
-"description in that locale. You are missing %s."
-msgstr ""
-"Innan du ändrar ditt standardspråk måste du ha ett namn, sammanfattning och "
-"beskrivning på det språket. Du saknar %s."
+msgid "Before changing your default locale you must have a name, summary, and description in that locale. You are missing %s."
+msgstr "Innan du ändrar ditt standardspråk måste du ha ett namn, sammanfattning och beskrivning på det språket. Du saknar %s."
 
-#: src/olympia/addons/forms.py:484 src/olympia/addons/forms.py:575
+#: src/olympia/addons/forms.py:455 src/olympia/addons/forms.py:546
 msgid "A license must be selected."
 msgstr "En licens måste väljas."
 
-#: src/olympia/addons/forms.py:556
+#: src/olympia/addons/forms.py:527
 msgid "Give Your Theme a Name."
 msgstr "Ge ditt tema ett namn."
 
-#: src/olympia/addons/forms.py:562
-#: src/olympia/devhub/templates/devhub/personas/submit.html:53
+#: src/olympia/addons/forms.py:533 src/olympia/devhub/templates/devhub/personas/submit.html:53
 msgid "Describe your Theme."
 msgstr "Beskriv ditt tema."
 
-#: src/olympia/addons/forms.py:704
+#: src/olympia/addons/forms.py:675
 msgid "Enter a new author's email address"
 msgstr "Ange en ny e-postadress till utvecklaren"
 
@@ -177,46 +155,37 @@ msgstr "Ange en ny e-postadress till utvecklaren"
 msgid "Not Reviewed"
 msgstr "Ej granskad"
 
-#: src/olympia/addons/models.py:301
+#: src/olympia/addons/models.py:298
 msgid "Users have the option of contributing more or less than this amount."
 msgstr "Användare har möjlighet att ge mer eller mindre än detta belopp."
 
-#: src/olympia/addons/models.py:309
-msgid ""
-"Users will always be asked in the Add-ons Manager (Firefox 4 and above)"
+#: src/olympia/addons/models.py:306
+msgid "Users will always be asked in the Add-ons Manager (Firefox 4 and above). Only applies to desktop."
 msgstr ""
-"Användarna kommer alltid att bli tillfrågade i tilläggshanteraren (Firefox 4"
-" och uppåt)"
 
-#: src/olympia/addons/models.py:1804
-#: src/olympia/addons/templates/addons/details_box.html:55
-#: src/olympia/devhub/templates/devhub/index.html:92
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:102
+#: src/olympia/addons/models.py:1802 src/olympia/addons/templates/addons/details_box.html:55 src/olympia/devhub/templates/devhub/index.html:92
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:89
 msgid "Listed"
 msgstr "Listad"
 
-#: src/olympia/addons/views.py:320
-#: src/olympia/browse/templates/browse/personas/mobile/category_landing.html:27
+#: src/olympia/addons/views.py:334 src/olympia/browse/templates/browse/personas/mobile/category_landing.html:27
 msgid "Popular"
 msgstr "Populära"
 
-#: src/olympia/addons/views.py:321 src/olympia/browse/views.py:238
-#: src/olympia/browse/views.py:280 src/olympia/browse/views.py:482
+#: src/olympia/addons/views.py:335 src/olympia/browse/views.py:205 src/olympia/browse/views.py:247 src/olympia/browse/views.py:449
 msgid "Recently Added"
 msgstr "Nyligen tillagd"
 
-#: src/olympia/addons/views.py:322 src/olympia/bandwagon/views.py:99
-#: src/olympia/browse/views.py:60 src/olympia/browse/views.py:71
-#: src/olympia/search/forms.py:16 src/olympia/search/forms.py:91
+#: src/olympia/addons/views.py:336 src/olympia/bandwagon/views.py:99 src/olympia/browse/views.py:60 src/olympia/browse/views.py:71 src/olympia/search/forms.py:16 src/olympia/search/forms.py:91
 msgid "Recently Updated"
 msgstr "Nyligen uppdaterad"
 
 #. l10n: {0} is the addon name
-#: src/olympia/addons/views.py:520
+#: src/olympia/addons/views.py:534
 msgid "Contribution for {0}"
 msgstr "Bidrag för {0}"
 
-#: src/olympia/addons/views.py:613
+#: src/olympia/addons/views.py:627
 msgid "Abuse reported."
 msgstr "Missbruk rapporterad."
 
@@ -224,113 +193,68 @@ msgstr "Missbruk rapporterad."
 msgid "My add-on doesn't fit into any of the categories"
 msgstr "Mitt tillägg passar inte in i någon av kategorierna"
 
-#: src/olympia/addons/templates/addons/button.html:27
-#: src/olympia/addons/templates/addons/impala/button.html:11
-#: src/olympia/addons/templates/addons/mobile/button.html:11
+#: src/olympia/addons/templates/addons/button.html:27 src/olympia/addons/templates/addons/impala/button.html:11 src/olympia/addons/templates/addons/mobile/button.html:11
 msgid "No compatible versions"
 msgstr "Inga kompatibla versioner"
 
-#: src/olympia/addons/templates/addons/button.html:35
-#: src/olympia/addons/templates/addons/impala/button.html:19
+#: src/olympia/addons/templates/addons/button.html:35 src/olympia/addons/templates/addons/impala/button.html:19
 msgid "Added to Mobile"
 msgstr "Lade till i Mobile"
 
-#: src/olympia/addons/templates/addons/button.html:37
-#: src/olympia/addons/templates/addons/impala/button.html:21
+#: src/olympia/addons/templates/addons/button.html:37 src/olympia/addons/templates/addons/impala/button.html:21
 msgid "Add to Mobile"
 msgstr "Lägg till i Mobile"
 
 #. {0} is a platform name like Windows or Mac OS X.
-#: src/olympia/addons/templates/addons/button.html:66
-#: src/olympia/addons/templates/addons/includes/install_button.html:19
+#: src/olympia/addons/templates/addons/button.html:66 src/olympia/addons/templates/addons/includes/install_button.html:19
 msgid "for {0}"
 msgstr "för {0}"
 
-#: src/olympia/addons/templates/addons/button.html:82
-#: src/olympia/addons/templates/addons/mobile/button.html:23
+#: src/olympia/addons/templates/addons/button.html:82 src/olympia/addons/templates/addons/mobile/button.html:23
 msgid "View privacy policy"
 msgstr "Visa sekretesspolicy"
 
-#: src/olympia/addons/templates/addons/button.html:87
-#: src/olympia/addons/templates/addons/details_box.html:133
-#: src/olympia/addons/templates/addons/mobile/button.html:28
+#: src/olympia/addons/templates/addons/button.html:87 src/olympia/addons/templates/addons/details_box.html:133 src/olympia/addons/templates/addons/mobile/button.html:28
 #: src/olympia/discovery/templates/discovery/addons/detail.html:28
 msgid "View End-User License Agreement"
 msgstr "Visa slutanvändarlicensavtal"
 
-#: src/olympia/addons/templates/addons/button.html:92
-#: src/olympia/addons/templates/addons/impala/button.html:54
+#: src/olympia/addons/templates/addons/button.html:92 src/olympia/addons/templates/addons/impala/button.html:54
 #, python-format
-msgid ""
-"This add-on has not been reviewed by Mozilla. <a href=\"%(url)s\">Learn "
-"more</a>"
-msgstr ""
-"Detta tillägg har inte granskats av Mozilla. <a href=\"%(url)s\">Läs mer</a>"
+msgid "This add-on has not been reviewed by Mozilla. <a href=\"%(url)s\">Learn more</a>"
+msgstr "Detta tillägg har inte granskats av Mozilla. <a href=\"%(url)s\">Läs mer</a>"
 
-#: src/olympia/addons/templates/addons/button.html:97
-#: src/olympia/addons/templates/addons/impala/button.html:60
+#: src/olympia/addons/templates/addons/button.html:97 src/olympia/addons/templates/addons/impala/button.html:60
 #, python-format
-msgid ""
-"This add-on has been preliminarily reviewed by Mozilla. <a "
-"href=\"%(url)s\">Learn more</a>"
-msgstr ""
-"Detta tillägg har preliminärt granskats av Mozilla. <a href=\"%(url)s\">Läs "
-"mer</a>"
+msgid "This add-on has been preliminarily reviewed by Mozilla. <a href=\"%(url)s\">Learn more</a>"
+msgstr "Detta tillägg har preliminärt granskats av Mozilla. <a href=\"%(url)s\">Läs mer</a>"
 
-#: src/olympia/addons/templates/addons/contribution.html:11
-#: src/olympia/addons/templates/addons/impala/developers.html:44
-msgid ""
-"The developer of this add-on asks that you help support its continued "
-"development by making a small contribution."
-msgstr ""
-"Utvecklaren av detta tillägg vill gärna att du stöder dess framtida "
-"utveckling genom att ge ett litet bidrag."
+#: src/olympia/addons/templates/addons/contribution.html:11 src/olympia/addons/templates/addons/impala/developers.html:44
+msgid "The developer of this add-on asks that you help support its continued development by making a small contribution."
+msgstr "Utvecklaren av detta tillägg vill gärna att du stöder dess framtida utveckling genom att ge ett litet bidrag."
 
 #: src/olympia/addons/templates/addons/contribution.html:14
 #, python-format
-msgid ""
-"The developer of this add-on asks that you show your support by making a "
-"donation to the <a href=\"%(charity_url)s\">%(charity_name)s</a>."
-msgstr ""
-"Utvecklaren av detta tillägg vill gärna att du visar ditt stöd genom att "
-"göra en donation till <a href=\"%(charity_url)s\">%(charity_name)s</a>."
+msgid "The developer of this add-on asks that you show your support by making a donation to the <a href=\"%(charity_url)s\">%(charity_name)s</a>."
+msgstr "Utvecklaren av detta tillägg vill gärna att du visar ditt stöd genom att göra en donation till <a href=\"%(charity_url)s\">%(charity_name)s</a>."
 
 #: src/olympia/addons/templates/addons/contribution.html:19
 #, python-format
-msgid ""
-"The developer of this add-on asks that you show your support by making a "
-"small contribution to <a href=\"%(charity_url)s\">%(charity_name)s</a>."
-msgstr ""
-"Utvecklaren av detta tillägg vill gärna att du visar ditt stöd genom att ge "
-"ett litet bidrag till <a href=\"%(charity_url)s\">%(charity_name)s</a>."
+msgid "The developer of this add-on asks that you show your support by making a small contribution to <a href=\"%(charity_url)s\">%(charity_name)s</a>."
+msgstr "Utvecklaren av detta tillägg vill gärna att du visar ditt stöd genom att ge ett litet bidrag till <a href=\"%(charity_url)s\">%(charity_name)s</a>."
 
-#: src/olympia/addons/templates/addons/contribution.html:30
-#: src/olympia/addons/templates/addons/impala/contribution.html:18
-#: src/olympia/templates/menu_links.html:25
+#: src/olympia/addons/templates/addons/contribution.html:30 src/olympia/addons/templates/addons/impala/contribution.html:18 src/olympia/templates/menu_links.html:25
 msgid "Contribute"
 msgstr "Bidra"
 
 #. Click Contribute button OR Install button
-#: src/olympia/addons/templates/addons/contribution.html:34
-#: src/olympia/addons/templates/addons/report_abuse.html:26
-#: src/olympia/addons/templates/addons/impala/contribution.html:32
-#: src/olympia/devhub/templates/devhub/addons/ajax_compat_update.html:36
-#: src/olympia/devhub/templates/devhub/addons/profile.html:44
-#: src/olympia/devhub/templates/devhub/addons/edit/admin.html:101
-#: src/olympia/devhub/templates/devhub/addons/edit/basic.html:152
-#: src/olympia/devhub/templates/devhub/addons/edit/details.html:85
-#: src/olympia/devhub/templates/devhub/addons/edit/support.html:67
-#: src/olympia/devhub/templates/devhub/addons/edit/technical.html:166
-#: src/olympia/devhub/templates/devhub/addons/forms_shared/media.html:149
-#: src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:44
-#: src/olympia/devhub/templates/devhub/versions/add_file_modal.html:78
-#: src/olympia/devhub/templates/devhub/versions/edit.html:139
-#: src/olympia/devhub/templates/devhub/versions/list.html:242
-#: src/olympia/devhub/templates/devhub/versions/list.html:276
-#: src/olympia/devhub/templates/devhub/versions/list.html:317
-#: src/olympia/devhub/templates/devhub/versions/list.html:351
-#: src/olympia/reviews/templates/reviews/edit_review.html:16
-#: src/olympia/translations/templates/translations/trans-menu.html:50
+#: src/olympia/addons/templates/addons/contribution.html:34 src/olympia/addons/templates/addons/report_abuse.html:26 src/olympia/addons/templates/addons/impala/contribution.html:32
+#: src/olympia/devhub/templates/devhub/addons/ajax_compat_update.html:36 src/olympia/devhub/templates/devhub/addons/profile.html:44 src/olympia/devhub/templates/devhub/addons/edit/admin.html:101
+#: src/olympia/devhub/templates/devhub/addons/edit/basic.html:152 src/olympia/devhub/templates/devhub/addons/edit/details.html:85 src/olympia/devhub/templates/devhub/addons/edit/support.html:67
+#: src/olympia/devhub/templates/devhub/addons/edit/technical.html:166 src/olympia/devhub/templates/devhub/addons/forms_shared/media.html:149
+#: src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:43 src/olympia/devhub/templates/devhub/versions/add_file_modal.html:58 src/olympia/devhub/templates/devhub/versions/edit.html:139
+#: src/olympia/devhub/templates/devhub/versions/list.html:239 src/olympia/devhub/templates/devhub/versions/list.html:281 src/olympia/devhub/templates/devhub/versions/list.html:315
+#: src/olympia/devhub/templates/devhub/versions/list.html:349 src/olympia/reviews/templates/reviews/edit_review.html:16 src/olympia/translations/templates/translations/trans-menu.html:50
 #: src/olympia/translations/templates/translations/trans-menu.html:62
 msgid "or"
 msgstr "eller"
@@ -339,42 +263,23 @@ msgstr "eller"
 msgid "Suggested Contribution: {0}"
 msgstr "Föreslagna bidrag: {0}"
 
-#: src/olympia/addons/templates/addons/contribution.html:48
-#: src/olympia/amo/templates/amo/recaptcha.html:5
-#: src/olympia/versions/templates/versions/version.html:52
+#: src/olympia/addons/templates/addons/contribution.html:48 src/olympia/amo/templates/amo/recaptcha.html:5 src/olympia/versions/templates/versions/version.html:52
 msgid "What's this?"
 msgstr "Vad är detta?"
 
 #: src/olympia/addons/templates/addons/contribution.html:63
 #, python-format
-msgid ""
-"The developer of this add-on would like you to consider making a donation to"
-" the <a href=\"%(charity_url)s\">%(charity_name)s</a> if you enjoy using it."
-msgstr ""
-"Utvecklaren av detta tillägg skulle vilja att ni överväger att göra en "
-"donation till <a href=\"%(charity_url)s\">%(charity_name)s</a> om du tycker "
-"om att använda den."
+msgid "The developer of this add-on would like you to consider making a donation to the <a href=\"%(charity_url)s\">%(charity_name)s</a> if you enjoy using it."
+msgstr "Utvecklaren av detta tillägg skulle vilja att ni överväger att göra en donation till <a href=\"%(charity_url)s\">%(charity_name)s</a> om du tycker om att använda den."
 
 #: src/olympia/addons/templates/addons/contribution.html:69
 #, python-format
-msgid ""
-"The developer of this add-on would like you to consider making a small "
-"contribution to <a href=\"%(charity_url)s\">%(charity_name)s</a> if you "
-"enjoy using it."
-msgstr ""
-"Utvecklaren av detta tillägg skulle vilja att ni överväger att göra ett "
-"litet bidrag till <a href=\"%(charity_url)s\">%(charity_name)s</a> om du "
-"tycker om att använda den."
+msgid "The developer of this add-on would like you to consider making a small contribution to <a href=\"%(charity_url)s\">%(charity_name)s</a> if you enjoy using it."
+msgstr "Utvecklaren av detta tillägg skulle vilja att ni överväger att göra ett litet bidrag till <a href=\"%(charity_url)s\">%(charity_name)s</a> om du tycker om att använda den."
 
 #: src/olympia/addons/templates/addons/contribution.html:76
-msgid ""
-"Mozilla is committed to supporting a vibrant and healthy developer "
-"ecosystem. Your optional contribution helps sustain further development of "
-"this add-on."
-msgstr ""
-"Mozilla arbetar för att stöda ett levande och hälsosamt ekosystem av "
-"utvecklare. Ditt personliga bidrag hjälper till med fortsatt utveckling av "
-"detta tillägg."
+msgid "Mozilla is committed to supporting a vibrant and healthy developer ecosystem. Your optional contribution helps sustain further development of this add-on."
+msgstr "Mozilla arbetar för att stöda ett levande och hälsosamt ekosystem av utvecklare. Ditt personliga bidrag hjälper till med fortsatt utveckling av detta tillägg."
 
 #: src/olympia/addons/templates/addons/contributions_lightbox.html:5
 msgid "Make a Contribution"
@@ -382,35 +287,22 @@ msgstr "Ge ett bidrag"
 
 #: src/olympia/addons/templates/addons/contributions_lightbox.html:9
 #, python-format
-msgid ""
-"Help support the continued development of <strong>%(addon_name)s</strong> by"
-" making a small contribution through <a href=\"%(paypal_url)s\">PayPal</a>."
-msgstr ""
-"Hjälp till och stöd fortsatt utveckling av <strong>%(addon_name)s</strong> "
-"genom att göra ett litet bidrag med <a href=\"%(paypal_url)s\">PayPal</a>."
+msgid "Help support the continued development of <strong>%(addon_name)s</strong> by making a small contribution through <a href=\"%(paypal_url)s\">PayPal</a>."
+msgstr "Hjälp till och stöd fortsatt utveckling av <strong>%(addon_name)s</strong> genom att göra ett litet bidrag med <a href=\"%(paypal_url)s\">PayPal</a>."
 
 #: src/olympia/addons/templates/addons/contributions_lightbox.html:15
 #, python-format
 msgid ""
-"To show your support for <b>%(addon_name)s</b>, the developer asks that you "
-"make a donation to the <a href=\"%(charity_url)s\">%(charity_name)s</a> "
-"through <a href=\"%(paypal_url)s\">PayPal</a>."
-msgstr ""
-"För att visa ditt stöd för <b>%(addon_name)s</b>, ber utvecklaren att du gör"
-" en donation till <a href=\"%(charity_url)s\">%(charity_name)s</a > genom <a"
-" href=\"%(paypal_url)s\"> PayPal</a>."
+"To show your support for <b>%(addon_name)s</b>, the developer asks that you make a donation to the <a href=\"%(charity_url)s\">%(charity_name)s</a> through <a href=\"%(paypal_url)s\">PayPal</a>."
+msgstr "För att visa ditt stöd för <b>%(addon_name)s</b>, ber utvecklaren att du gör en donation till <a href=\"%(charity_url)s\">%(charity_name)s</a > genom <a href=\"%(paypal_url)s\"> PayPal</a>."
 
 #: src/olympia/addons/templates/addons/contributions_lightbox.html:21
 #, python-format
 msgid ""
-"To show your support for <b>%(addon_name)s</b>, the developer asks that you "
-"make a small contribution to <a "
-"href=\"%(charity_url)s\">%(charity_name)s</a> through <a "
-"href=\"%(paypal_url)s\">PayPal</a>."
+"To show your support for <b>%(addon_name)s</b>, the developer asks that you make a small contribution to <a href=\"%(charity_url)s\">%(charity_name)s</a> through <a href=\"%(paypal_url)s\">PayPal</"
+"a>."
 msgstr ""
-"För att visa ditt stöd för <b>%(addon_name)s</b>, ber utvecklaren att du gör"
-" ett litet bidrag till <a href=\"%(charity_url)s\">%(charity_name)s</a > "
-"genom <a href=\"%(paypal_url)s\"> PayPal</a>."
+"För att visa ditt stöd för <b>%(addon_name)s</b>, ber utvecklaren att du gör ett litet bidrag till <a href=\"%(charity_url)s\">%(charity_name)s</a > genom <a href=\"%(paypal_url)s\"> PayPal</a>."
 
 #: src/olympia/addons/templates/addons/contributions_lightbox.html:30
 msgid "How much would you like to contribute?"
@@ -433,8 +325,7 @@ msgstr "Bidragssumma måste vara ett belopp."
 msgid "A one-time suggested contribution of {0}"
 msgstr "Ett förslaget engångsbidrag på {0}"
 
-#. {0} is a currency symbol (e.g., $),                    {1} is an amount
-#. input
+#. {0} is a currency symbol (e.g., $),                    {1} is an amount input
 #. field
 #: src/olympia/addons/templates/addons/contributions_lightbox.html:64
 msgid "A one-time contribution of {0} {1}"
@@ -444,11 +335,8 @@ msgstr "Ett engångsbidrag på {0} {1}"
 msgid "Leave a comment or request with your contribution."
 msgstr "Lämna en kommentar eller begäran med ditt bidrag."
 
-#: src/olympia/addons/templates/addons/contributions_lightbox.html:74
-#: src/olympia/bandwagon/templates/bandwagon/ajax_new.html:20
-#: src/olympia/bandwagon/templates/bandwagon/includes/addedit.html:37
-#: src/olympia/reviews/templates/reviews/mobile/add_form.html:13
-#: src/olympia/templates/includes/forms.html:10
+#: src/olympia/addons/templates/addons/contributions_lightbox.html:74 src/olympia/bandwagon/templates/bandwagon/ajax_new.html:20 src/olympia/bandwagon/templates/bandwagon/includes/addedit.html:37
+#: src/olympia/reviews/templates/reviews/mobile/add_form.html:13 src/olympia/templates/includes/forms.html:10
 msgid "(optional)"
 msgstr "(valfritt)"
 
@@ -468,36 +356,27 @@ msgstr "Nej tack"
 msgid "Contribution made, thank you."
 msgstr "Tack för ditt bidrag."
 
-#: src/olympia/addons/templates/addons/details_box.html:10
-#: src/olympia/discovery/templates/discovery/addons/detail.html:19
+#: src/olympia/addons/templates/addons/details_box.html:10 src/olympia/discovery/templates/discovery/addons/detail.html:19
 msgid "No restart required"
 msgstr "Ingen omstart krävs"
 
 #. This is a caption for a table. {0} is an add-on name.
-#: src/olympia/addons/templates/addons/details_box.html:26
-#: src/olympia/addons/templates/addons/includes/persona.html:9
+#: src/olympia/addons/templates/addons/details_box.html:26 src/olympia/addons/templates/addons/includes/persona.html:9
 msgid "Add-on Information for {0}"
 msgstr "Tilläggsinformation för {0}"
 
-#: src/olympia/addons/templates/addons/details_box.html:30
-#: src/olympia/addons/templates/addons/persona_detail_table.html:3
-#: src/olympia/addons/templates/addons/mobile/details.html:63
-#: src/olympia/addons/templates/addons/mobile/persona_detail_table.html:7
-#: src/olympia/browse/views.py:459 src/olympia/devhub/views.py:75
+#: src/olympia/addons/templates/addons/details_box.html:30 src/olympia/addons/templates/addons/persona_detail_table.html:3 src/olympia/addons/templates/addons/mobile/details.html:63
+#: src/olympia/addons/templates/addons/mobile/persona_detail_table.html:7 src/olympia/browse/views.py:426 src/olympia/devhub/views.py:73
 msgid "Updated"
 msgstr "Uppdaterad"
 
-#: src/olympia/addons/templates/addons/details_box.html:38
-#: src/olympia/addons/templates/addons/mobile/details.html:71
-#: src/olympia/devhub/templates/devhub/addons/edit/support.html:43
+#: src/olympia/addons/templates/addons/details_box.html:38 src/olympia/addons/templates/addons/mobile/details.html:71 src/olympia/devhub/templates/devhub/addons/edit/support.html:43
 #: src/olympia/discovery/templates/discovery/addons/detail.html:77
 msgid "Website"
 msgstr "Webbplats"
 
 #. This refers to this version's compatible applications, such as Firefox 8.0
-#: src/olympia/addons/templates/addons/details_box.html:47
-#: src/olympia/addons/templates/addons/mobile/details.html:80
-#: src/olympia/search/templates/search/results.html:72
+#: src/olympia/addons/templates/addons/details_box.html:47 src/olympia/addons/templates/addons/mobile/details.html:80 src/olympia/search/templates/search/results.html:72
 #: src/olympia/versions/templates/versions/version.html:21
 msgid "Works with"
 msgstr "Fungerar med"
@@ -506,45 +385,30 @@ msgstr "Fungerar med"
 msgid "Visibility"
 msgstr "Synlighet"
 
-#: src/olympia/addons/templates/addons/details_box.html:57
-#: src/olympia/devhub/templates/devhub/index.html:94
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:104
+#: src/olympia/addons/templates/addons/details_box.html:57 src/olympia/devhub/templates/devhub/index.html:94 src/olympia/devhub/templates/devhub/includes/addon_details.html:91
 msgid "Hidden"
 msgstr "Dold"
 
-#: src/olympia/addons/templates/addons/details_box.html:59
-#: src/olympia/devhub/templates/devhub/index.html:96
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:106
+#: src/olympia/addons/templates/addons/details_box.html:59 src/olympia/devhub/templates/devhub/index.html:96 src/olympia/devhub/templates/devhub/includes/addon_details.html:93
 msgid "Unlisted"
 msgstr "Olistad"
 
-#: src/olympia/addons/templates/addons/details_box.html:67
-#: src/olympia/devhub/templates/devhub/addons/edit/technical.html:44
+#: src/olympia/addons/templates/addons/details_box.html:67 src/olympia/devhub/templates/devhub/addons/edit/technical.html:44
 msgid "Required Add-ons"
 msgstr "Obligatoriska tillägg"
 
-#: src/olympia/addons/templates/addons/details_box.html:81
-#: src/olympia/addons/templates/addons/persona_detail_table.html:15
-#: src/olympia/browse/views.py:462 src/olympia/devhub/views.py:78
-#: src/olympia/devhub/views.py:85
-#: src/olympia/discovery/templates/discovery/addons/detail.html:57
-#: src/olympia/reviews/forms.py:62
-#: src/olympia/reviews/templates/reviews/add.html:57
+#: src/olympia/addons/templates/addons/details_box.html:81 src/olympia/addons/templates/addons/persona_detail_table.html:15 src/olympia/browse/views.py:429 src/olympia/devhub/views.py:76
+#: src/olympia/devhub/views.py:83 src/olympia/discovery/templates/discovery/addons/detail.html:57 src/olympia/reviews/forms.py:62 src/olympia/reviews/templates/reviews/add.html:57
 #: src/olympia/reviews/templates/reviews/mobile/review_list.html:18
 msgid "Rating"
 msgstr "Betyg"
 
-#: src/olympia/addons/templates/addons/details_box.html:85
-#: src/olympia/browse/views.py:461 src/olympia/devhub/views.py:77
-#: src/olympia/devhub/views.py:84
-#: src/olympia/stats/templates/stats/addon_report_menu.html:8
-#: src/olympia/stats/templates/stats/collection_report_menu.html:18
+#: src/olympia/addons/templates/addons/details_box.html:85 src/olympia/browse/views.py:428 src/olympia/devhub/views.py:75 src/olympia/devhub/views.py:82
+#: src/olympia/stats/templates/stats/addon_report_menu.html:8 src/olympia/stats/templates/stats/collection_report_menu.html:18
 msgid "Downloads"
 msgstr "Nerladdningar"
 
-#: src/olympia/addons/templates/addons/details_box.html:91
-#: src/olympia/addons/templates/addons/details_box.html:103
-#: src/olympia/devhub/templates/devhub/addons/listing/item_actions_theme.html:17
+#: src/olympia/addons/templates/addons/details_box.html:91 src/olympia/addons/templates/addons/details_box.html:103 src/olympia/devhub/templates/devhub/addons/listing/item_actions_theme.html:17
 #: src/olympia/devhub/templates/devhub/personas/edit.html:60
 msgid "View Statistics"
 msgstr "Visa statistik"
@@ -558,18 +422,13 @@ msgid "Abuse Reports"
 msgstr "Missbruksrapporter"
 
 #. The Privacy Policy for this add-on.
-#: src/olympia/addons/templates/addons/details_box.html:121
-#: src/olympia/addons/templates/addons/privacy.html:19
-#: src/olympia/addons/templates/addons/privacy.html:23
-#: src/olympia/addons/templates/addons/impala/button.html:43
-#: src/olympia/addons/templates/addons/impala/details.html:307
-#: src/olympia/devhub/templates/devhub/includes/policy_form.html:20
+#: src/olympia/addons/templates/addons/details_box.html:121 src/olympia/addons/templates/addons/privacy.html:19 src/olympia/addons/templates/addons/privacy.html:23
+#: src/olympia/addons/templates/addons/impala/button.html:43 src/olympia/addons/templates/addons/impala/details.html:312 src/olympia/devhub/templates/devhub/includes/policy_form.html:23
 #: src/olympia/templates/mobile/base_addons.html:87
 msgid "Privacy Policy"
 msgstr "Sekretesspolicy"
 
-#: src/olympia/addons/templates/addons/details_box.html:124
-#: src/olympia/discovery/templates/discovery/addons/detail.html:24
+#: src/olympia/addons/templates/addons/details_box.html:124 src/olympia/discovery/templates/discovery/addons/detail.html:24
 msgid "View Privacy Policy"
 msgstr "Visa sekretesspolicy"
 
@@ -577,8 +436,7 @@ msgstr "Visa sekretesspolicy"
 msgid "EULA"
 msgstr "EULA"
 
-#: src/olympia/addons/templates/addons/details_box.html:171
-#: src/olympia/addons/templates/addons/details_box.html:231
+#: src/olympia/addons/templates/addons/details_box.html:171 src/olympia/addons/templates/addons/details_box.html:231
 msgid "More about this add-on"
 msgstr "Mer om detta tillägg"
 
@@ -586,27 +444,21 @@ msgstr "Mer om detta tillägg"
 msgid "Image Gallery"
 msgstr "Bildgalleri"
 
-#: src/olympia/addons/templates/addons/details_box.html:190
-#: src/olympia/devhub/templates/devhub/addons/edit/technical.html:21
+#: src/olympia/addons/templates/addons/details_box.html:190 src/olympia/devhub/templates/devhub/addons/edit/technical.html:21
 msgid "Developer Comments"
 msgstr "Utvecklarkommentarer"
 
-#: src/olympia/addons/templates/addons/details_box.html:199
-#: src/olympia/addons/templates/addons/impala/details.html:259
+#: src/olympia/addons/templates/addons/details_box.html:199 src/olympia/addons/templates/addons/impala/details.html:264
 msgid "Development Channel"
 msgstr "Utvecklingskanal"
 
-#: src/olympia/addons/templates/addons/details_box.html:202
-#: src/olympia/addons/templates/addons/mobile/details.html:124
+#: src/olympia/addons/templates/addons/details_box.html:202 src/olympia/addons/templates/addons/mobile/details.html:124
 msgid ""
-"The Development Channel lets you test an experimental new version of this "
-"add-on before it's released to the general public. Once you install the "
-"development version, you will continue to get updates from this channel."
+"The Development Channel lets you test an experimental new version of this add-on before it's released to the general public. Once you install the development version, you will continue to get "
+"updates from this channel."
 msgstr ""
-"Utvecklingskanalen låter dig testa en experimentell ny version av detta "
-"tillägg innan det släpps till allmänheten. När du installerar "
-"utvecklingsversionen, kommer du att fortsätta att få uppdateringar från den "
-"här kanalen."
+"Utvecklingskanalen låter dig testa en experimentell ny version av detta tillägg innan det släpps till allmänheten. När du installerar utvecklingsversionen, kommer du att fortsätta att få "
+"uppdateringar från den här kanalen."
 
 #: src/olympia/addons/templates/addons/details_box.html:207
 msgid "Install development version"
@@ -614,73 +466,49 @@ msgstr "Installera utvecklingsversion"
 
 #: src/olympia/addons/templates/addons/details_box.html:211
 msgid ""
-"<strong>Caution:</strong> Development versions of this add-on have not been "
-"reviewed by Mozilla. Once you install a development version you will "
-"continue to receive development updates from this developer. To stop "
-"receiving development updates, reinstall the default version from the link "
-"above."
+"<strong>Caution:</strong> Development versions of this add-on have not been reviewed by Mozilla. Once you install a development version you will continue to receive development updates from this "
+"developer. To stop receiving development updates, reinstall the default version from the link above."
 msgstr ""
-"<strong>Varning:</strong> Utvecklingsversioner av detta tillägg har inte "
-"granskats av Mozilla. När du installerar en utvecklingsversion kommer du att"
-" fortsätta att få utvecklingsuppdateringar från utvecklaren. Att sluta ta "
-"emot utvecklingsuppdateringar, installera om standardversionen från länken "
-"ovan."
+"<strong>Varning:</strong> Utvecklingsversioner av detta tillägg har inte granskats av Mozilla. När du installerar en utvecklingsversion kommer du att fortsätta att få utvecklingsuppdateringar från "
+"utvecklaren. Att sluta ta emot utvecklingsuppdateringar, installera om standardversionen från länken ovan."
 
-#: src/olympia/addons/templates/addons/details_box.html:220
-#: src/olympia/addons/templates/addons/impala/details.html:278
+#: src/olympia/addons/templates/addons/details_box.html:220 src/olympia/addons/templates/addons/impala/details.html:283
 msgid "Version {0}:"
 msgstr "Version {0}:"
 
 #: src/olympia/addons/templates/addons/details_box.html:234
 msgid "Nothing to see here!  The developer did not include any details."
-msgstr "Inget att se här!  Utvecklaren inkluderade inga detaljer."
+msgstr ""
 
-#: src/olympia/addons/templates/addons/details_box.html:251
-#: src/olympia/devhub/templates/devhub/versions/edit.html:73
-#: src/olympia/editors/templates/editors/review.html:98
+#: src/olympia/addons/templates/addons/details_box.html:251 src/olympia/devhub/templates/devhub/versions/edit.html:73 src/olympia/editors/templates/editors/review.html:98
 msgid "Version Notes"
 msgstr "Versionsanteckningar"
 
 #. {0} is the name of the add-on.
 #. {0} is the name of the add-on
-#: src/olympia/addons/templates/addons/eula.html:6
-#: src/olympia/discovery/templates/discovery/addons/eula.html:5
+#: src/olympia/addons/templates/addons/eula.html:6 src/olympia/discovery/templates/discovery/addons/eula.html:5
 msgid "End-User License Agreement for {0}"
 msgstr "Slutanvändarlicensavtal för {0}"
 
-#: src/olympia/addons/templates/addons/eula.html:17
-#: src/olympia/addons/templates/addons/eula.html:21
-#: src/olympia/addons/templates/addons/impala/button.html:48
-#: src/olympia/addons/templates/addons/impala/details.html:316
-#: src/olympia/devhub/templates/devhub/includes/policy_form.html:3
-#: src/olympia/discovery/templates/discovery/addons/eula.html:11
+#: src/olympia/addons/templates/addons/eula.html:17 src/olympia/addons/templates/addons/eula.html:21 src/olympia/addons/templates/addons/impala/button.html:48
+#: src/olympia/addons/templates/addons/impala/details.html:321 src/olympia/devhub/templates/devhub/includes/policy_form.html:3 src/olympia/discovery/templates/discovery/addons/eula.html:11
 msgid "End-User License Agreement"
 msgstr "Slutanvändarlicensavtal"
 
-#: src/olympia/addons/templates/addons/eula.html:23
-#: src/olympia/discovery/templates/discovery/addons/eula.html:13
+#: src/olympia/addons/templates/addons/eula.html:23 src/olympia/discovery/templates/discovery/addons/eula.html:13
 #, python-format
-msgid ""
-"%(addon_name)s requires that you accept the following End-User License "
-"Agreement before installation can proceed:"
-msgstr ""
-"%(addon_name)s kräver att du accepterar följande slutanvändaravtal innan "
-"installationen kan fortsätta:"
+msgid "%(addon_name)s requires that you accept the following End-User License Agreement before installation can proceed:"
+msgstr "%(addon_name)s kräver att du accepterar följande slutanvändaravtal innan installationen kan fortsätta:"
 
-#: src/olympia/addons/templates/addons/eula.html:34
-#: src/olympia/addons/templates/addons/privacy.html:26
+#: src/olympia/addons/templates/addons/eula.html:34 src/olympia/addons/templates/addons/privacy.html:26
 msgid "Back to {0}…"
 msgstr "Tillbaks till {0}…"
 
-#: src/olympia/addons/templates/addons/home.html:3
-#: src/olympia/addons/templates/addons/mobile/home.html:3
-#: src/olympia/amo/helpers.py:235
+#: src/olympia/addons/templates/addons/home.html:3 src/olympia/addons/templates/addons/mobile/home.html:3 src/olympia/amo/helpers.py:235
 msgid "Add-ons for {0}"
 msgstr "Tillägg för {0}"
 
-#: src/olympia/addons/templates/addons/home.html:10
-#: src/olympia/addons/templates/addons/home.html:51
-#: src/olympia/browse/templates/browse/impala/base_listing.html:11
+#: src/olympia/addons/templates/addons/home.html:10 src/olympia/addons/templates/addons/home.html:53 src/olympia/browse/templates/browse/impala/base_listing.html:11
 msgid "Featured Extensions"
 msgstr "Utvalda utökningar"
 
@@ -688,70 +516,49 @@ msgstr "Utvalda utökningar"
 msgid "Popular Extensions"
 msgstr "Populära utökningar"
 
-#: src/olympia/addons/templates/addons/home.html:42
-#: src/olympia/amo/templates/amo/side_nav.html:3
-#: src/olympia/amo/templates/amo/side_nav.html:11
-#: src/olympia/amo/templates/amo/site_nav.html:3
-#: src/olympia/amo/templates/amo/site_nav.html:25
-#: src/olympia/browse/views.py:236 src/olympia/browse/views.py:281
-#: src/olympia/browse/views.py:481
+#: src/olympia/addons/templates/addons/home.html:44 src/olympia/amo/templates/amo/side_nav.html:3 src/olympia/amo/templates/amo/side_nav.html:11 src/olympia/amo/templates/amo/site_nav.html:3
+#: src/olympia/amo/templates/amo/site_nav.html:25 src/olympia/browse/views.py:203 src/olympia/browse/views.py:248 src/olympia/browse/views.py:448
 msgid "Most Popular"
 msgstr "Mest populära"
 
-#: src/olympia/addons/templates/addons/home.html:43
+#: src/olympia/addons/templates/addons/home.html:45
 msgid "All »"
 msgstr "Alla »"
 
-#: src/olympia/addons/templates/addons/home.html:52
-#: src/olympia/addons/templates/addons/home.html:61
-#: src/olympia/addons/templates/addons/home.html:70
-#: src/olympia/addons/templates/addons/home.html:78
+#: src/olympia/addons/templates/addons/home.html:54 src/olympia/addons/templates/addons/home.html:63 src/olympia/addons/templates/addons/home.html:72 src/olympia/addons/templates/addons/home.html:80
 #: src/olympia/browse/templates/browse/impala/category_landing.html:36
 msgid "See all »"
 msgstr "Visa alla »"
 
-#: src/olympia/addons/templates/addons/home.html:60
+#: src/olympia/addons/templates/addons/home.html:62
 msgid "Up &amp; Coming Extensions"
 msgstr "Bubblare utökningar"
 
-#: src/olympia/addons/templates/addons/home.html:69
-#: src/olympia/browse/templates/browse/personas/category_landing.html:61
-#: src/olympia/discovery/templates/discovery/pane.html:74
+#: src/olympia/addons/templates/addons/home.html:71 src/olympia/browse/templates/browse/personas/category_landing.html:61 src/olympia/discovery/templates/discovery/pane.html:74
 msgid "Featured Themes"
 msgstr "Utvalda teman"
 
-#: src/olympia/addons/templates/addons/home.html:77
-#: src/olympia/bandwagon/templates/bandwagon/impala/collection_listing.html:5
+#: src/olympia/addons/templates/addons/home.html:79 src/olympia/bandwagon/templates/bandwagon/impala/collection_listing.html:5
 msgid "Featured Collections"
 msgstr "Utvalda samlingar"
 
-#: src/olympia/addons/templates/addons/listing_header.html:3
-#: src/olympia/addons/templates/addons/impala/listing/sorter.html:2
-#: src/olympia/amo/templates/amo/mobile/sort_by.html:2
+#: src/olympia/addons/templates/addons/listing_header.html:3 src/olympia/addons/templates/addons/impala/listing/sorter.html:2 src/olympia/amo/templates/amo/mobile/sort_by.html:2
 #: src/olympia/bandwagon/templates/bandwagon/collection_detail.html:118
 msgid "Sort by:"
 msgstr "Sortera efter:"
 
 #. {0} is a date.
 #. {0} is a date
-#: src/olympia/addons/templates/addons/macros.html:7
-#: src/olympia/addons/templates/addons/macros.html:72
-#: src/olympia/addons/templates/addons/listing/items_mobile.html:48
-#: src/olympia/addons/templates/addons/listing/macros.html:42
-#: src/olympia/bandwagon/templates/bandwagon/collection_detail.html:50
-#: src/olympia/bandwagon/templates/bandwagon/collection_listing_items.html:40
-#: src/olympia/bandwagon/templates/bandwagon/impala/collection_listing_items.html:40
+#: src/olympia/addons/templates/addons/macros.html:7 src/olympia/addons/templates/addons/macros.html:72 src/olympia/addons/templates/addons/listing/items_mobile.html:48
+#: src/olympia/addons/templates/addons/listing/macros.html:42 src/olympia/bandwagon/templates/bandwagon/collection_detail.html:50
+#: src/olympia/bandwagon/templates/bandwagon/collection_listing_items.html:40 src/olympia/bandwagon/templates/bandwagon/impala/collection_listing_items.html:40
 msgid "Updated {0}"
 msgstr "Uppdaterad {0}"
 
 #. {0} is a date.
-#: src/olympia/addons/templates/addons/macros.html:10
-#: src/olympia/addons/templates/addons/macros.html:69
-#: src/olympia/addons/templates/addons/persona_preview.html:21
-#: src/olympia/addons/templates/addons/listing/items_mobile.html:44
-#: src/olympia/addons/templates/addons/listing/macros.html:39
-#: src/olympia/bandwagon/templates/bandwagon/collection_listing_items.html:37
-#: src/olympia/bandwagon/templates/bandwagon/impala/collection_listing_items.html:37
+#: src/olympia/addons/templates/addons/macros.html:10 src/olympia/addons/templates/addons/macros.html:69 src/olympia/addons/templates/addons/persona_preview.html:22
+#: src/olympia/addons/templates/addons/listing/items_mobile.html:44 src/olympia/addons/templates/addons/listing/macros.html:39
+#: src/olympia/bandwagon/templates/bandwagon/collection_listing_items.html:37 src/olympia/bandwagon/templates/bandwagon/impala/collection_listing_items.html:37
 msgid "Added {0}"
 msgstr "Lades till {0}"
 
@@ -770,18 +577,14 @@ msgstr[0] "%(num)s användare"
 msgstr[1] "%(num)s användare"
 
 #. {0} is the number of downloads.
-#: src/olympia/addons/templates/addons/macros.html:53
-#: src/olympia/addons/templates/addons/impala/details.html:61
+#: src/olympia/addons/templates/addons/macros.html:53 src/olympia/addons/templates/addons/impala/details.html:59
 msgid "{0} weekly download"
 msgid_plural "{0} weekly downloads"
 msgstr[0] "{0} nedladdning per vecka"
 msgstr[1] "{0} nedladdningar per vecka"
 
 #. {0} is the number of users.
-#: src/olympia/addons/templates/addons/macros.html:61
-#: src/olympia/addons/templates/addons/impala/details.html:54
-#: src/olympia/compat/templates/compat/index.html:71
-#: src/olympia/zadmin/templates/zadmin/compat.html:67
+#: src/olympia/addons/templates/addons/macros.html:61 src/olympia/addons/templates/addons/impala/details.html:52 src/olympia/zadmin/templates/zadmin/compat.html:67
 msgid "{0} user"
 msgid_plural "{0} users"
 msgstr[0] "{0} användare"
@@ -799,12 +602,8 @@ msgstr "Betalning slutförd"
 msgid "Return to the addon."
 msgstr "Gå tillbaka till tillägget."
 
-#: src/olympia/addons/templates/addons/persona_detail.html:17
-#: src/olympia/addons/templates/addons/impala/details.html:106
-#: src/olympia/addons/templates/addons/mobile/details.html:23
-#: src/olympia/addons/templates/addons/mobile/persona_detail.html:21
-#: src/olympia/discovery/templates/discovery/addons/base.html:27
-#: src/olympia/editors/templates/editors/review.html:31
+#: src/olympia/addons/templates/addons/persona_detail.html:17 src/olympia/addons/templates/addons/impala/details.html:103 src/olympia/addons/templates/addons/mobile/details.html:23
+#: src/olympia/addons/templates/addons/mobile/persona_detail.html:21 src/olympia/discovery/templates/discovery/addons/base.html:27 src/olympia/editors/templates/editors/review.html:31
 msgid "by"
 msgstr "av"
 
@@ -814,8 +613,7 @@ msgid "More {0} Themes"
 msgstr "Fler {0} teman"
 
 #. {0} is a category name, such as Nature
-#: src/olympia/addons/templates/addons/persona_detail.html:39
-#: src/olympia/addons/templates/addons/mobile/persona_detail.html:66
+#: src/olympia/addons/templates/addons/persona_detail.html:39 src/olympia/addons/templates/addons/mobile/persona_detail.html:66
 msgid "See all {0} Themes"
 msgstr "Visa alla {0} teman"
 
@@ -823,185 +621,129 @@ msgstr "Visa alla {0} teman"
 msgid "More by this Artist"
 msgstr "Mer av denna konstnär"
 
-#: src/olympia/addons/templates/addons/persona_detail.html:52
-#: src/olympia/addons/templates/addons/mobile/persona_detail.html:49
+#: src/olympia/addons/templates/addons/persona_detail.html:52 src/olympia/addons/templates/addons/mobile/persona_detail.html:49
 msgid "See all Themes by this Artist"
 msgstr "Se alla teman av denna konstnär"
 
-#: src/olympia/addons/templates/addons/persona_detail.html:71
-#: src/olympia/addons/templates/addons/mobile/home.html:42
-#: src/olympia/amo/templates/amo/side_nav.html:22
-#: src/olympia/browse/templates/browse/personas/mobile/category_landing.html:28
-#: src/olympia/devhub/templates/devhub/addons/edit/basic.html:72
-#: src/olympia/editors/templates/editors/review.html:277
-#: src/olympia/editors/templates/editors/themes/themes.html:34
-#: src/olympia/templates/categories.html:7
+#: src/olympia/addons/templates/addons/persona_detail.html:71 src/olympia/addons/templates/addons/mobile/home.html:42 src/olympia/amo/templates/amo/side_nav.html:22
+#: src/olympia/browse/templates/browse/personas/mobile/category_landing.html:28 src/olympia/devhub/templates/devhub/addons/edit/basic.html:72 src/olympia/editors/templates/editors/review.html:277
+#: src/olympia/editors/templates/editors/themes/themes.html:34 src/olympia/templates/categories.html:7
 msgid "Categories"
 msgstr "Kategorier"
 
-#: src/olympia/addons/templates/addons/persona_detail_table.html:10
-#: src/olympia/addons/templates/addons/mobile/persona_detail_table.html:3
-#: src/olympia/editors/templates/editors/themes/deleted.html:19
+#: src/olympia/addons/templates/addons/persona_detail_table.html:10 src/olympia/addons/templates/addons/mobile/persona_detail_table.html:3 src/olympia/editors/templates/editors/themes/deleted.html:19
 #: src/olympia/editors/templates/editors/themes/themes.html:25
 msgid "Artist"
 msgstr "Konstnär"
 
-#: src/olympia/addons/templates/addons/persona_detail_table.html:19
-#: src/olympia/addons/templates/addons/mobile/persona_detail_table.html:14
-#: src/olympia/stats/templates/stats/addon_report_menu.html:17
+#: src/olympia/addons/templates/addons/persona_detail_table.html:19 src/olympia/addons/templates/addons/mobile/persona_detail_table.html:14 src/olympia/stats/templates/stats/addon_report_menu.html:17
 msgid "Daily Users"
 msgstr "Dagliga användare"
 
 #. The License for this add-on.
-#: src/olympia/addons/templates/addons/persona_detail_table.html:26
-#: src/olympia/addons/templates/addons/impala/license.html:17
-#: src/olympia/addons/templates/addons/mobile/persona_detail_table.html:21
-#: src/olympia/devhub/templates/devhub/includes/license_form.html:5
-#: src/olympia/devhub/templates/devhub/versions/edit.html:89
-#: src/olympia/editors/templates/editors/themes/themes.html:41
+#: src/olympia/addons/templates/addons/persona_detail_table.html:26 src/olympia/addons/templates/addons/impala/license.html:17 src/olympia/addons/templates/addons/mobile/persona_detail_table.html:21
+#: src/olympia/devhub/templates/devhub/includes/license_form.html:5 src/olympia/devhub/templates/devhub/versions/edit.html:89 src/olympia/editors/templates/editors/themes/themes.html:41
 msgid "License"
 msgstr "Licens"
 
-#: src/olympia/addons/templates/addons/persona_preview.html:12
-#: src/olympia/constants/base.py:48
+#: src/olympia/addons/templates/addons/persona_preview.html:13 src/olympia/constants/base.py:48
 msgid "Awaiting Review"
 msgstr "Väntar på granskning"
 
-#: src/olympia/addons/templates/addons/persona_preview.html:14
-#: src/olympia/amo/log.py:180 src/olympia/constants/base.py:42
-#: src/olympia/editors/helpers.py:62
+#: src/olympia/addons/templates/addons/persona_preview.html:15 src/olympia/amo/log.py:180 src/olympia/constants/base.py:42 src/olympia/editors/helpers.py:62
 msgid "Rejected"
 msgstr "Ej godkänd"
 
-#: src/olympia/addons/templates/addons/persona_preview.html:16
-#: src/olympia/amo/log.py:159
+#: src/olympia/addons/templates/addons/persona_preview.html:17 src/olympia/amo/log.py:159
 msgid "Approved"
 msgstr "Godkänd"
 
 #. {0} is the number of users.
-#: src/olympia/addons/templates/addons/persona_preview.html:26
-#: src/olympia/addons/templates/addons/listing/items_mobile.html:36
-#: src/olympia/addons/templates/addons/listing/macros.html:31
+#: src/olympia/addons/templates/addons/persona_preview.html:27 src/olympia/addons/templates/addons/listing/items_mobile.html:36 src/olympia/addons/templates/addons/listing/macros.html:31
 msgid "<strong>{0}</strong> user"
 msgid_plural "<strong>{0}</strong> users"
 msgstr[0] "<strong>{0}</strong> användare"
 msgstr[1] "<strong>{0}</strong> användare"
 
-#: src/olympia/addons/templates/addons/persona_preview.html:40
+#: src/olympia/addons/templates/addons/persona_preview.html:41
 msgid "Hover to Preview"
 msgstr "Håll muspekaren över för att förhandsgranska"
 
-#: src/olympia/addons/templates/addons/persona_preview.html:46
-#: src/olympia/addons/templates/addons/persona_preview.html:48
+#: src/olympia/addons/templates/addons/persona_preview.html:47 src/olympia/addons/templates/addons/persona_preview.html:49 src/olympia/addons/templates/addons/persona_preview.html:97
 #: src/olympia/reviews/templates/reviews/add.html:15
 msgid "Add"
 msgstr "Lägg till"
 
-#: src/olympia/addons/templates/addons/persona_preview.html:57
-#: src/olympia/bandwagon/templates/bandwagon/ajax_new.html:16
-#: src/olympia/bandwagon/templates/bandwagon/edit.html:19
-#: src/olympia/bandwagon/templates/bandwagon/includes/addedit.html:19
-#: src/olympia/devhub/templates/devhub/addons/edit/admin.html:13
-#: src/olympia/devhub/templates/devhub/addons/edit/basic.html:10
-#: src/olympia/devhub/templates/devhub/addons/edit/details.html:8
-#: src/olympia/devhub/templates/devhub/addons/edit/media.html:6
-#: src/olympia/devhub/templates/devhub/addons/edit/support.html:8
-#: src/olympia/devhub/templates/devhub/addons/edit/technical.html:9
-#: src/olympia/devhub/templates/devhub/addons/submit/describe.html:29
-#: src/olympia/editors/templates/editors/review.html:257
+#: src/olympia/addons/templates/addons/persona_preview.html:58 src/olympia/bandwagon/templates/bandwagon/ajax_new.html:16 src/olympia/bandwagon/templates/bandwagon/edit.html:19
+#: src/olympia/bandwagon/templates/bandwagon/includes/addedit.html:19 src/olympia/devhub/templates/devhub/addons/edit/admin.html:13 src/olympia/devhub/templates/devhub/addons/edit/basic.html:10
+#: src/olympia/devhub/templates/devhub/addons/edit/details.html:8 src/olympia/devhub/templates/devhub/addons/edit/media.html:6 src/olympia/devhub/templates/devhub/addons/edit/support.html:8
+#: src/olympia/devhub/templates/devhub/addons/edit/technical.html:9 src/olympia/devhub/templates/devhub/addons/submit/describe.html:29 src/olympia/editors/templates/editors/review.html:257
 msgid "Edit"
 msgstr "Redigera"
 
 #. For datetime formatting, see the table on
 #. http://docs.python.org/library/datetime.html#strftime-and-strptime-behavior
-#: src/olympia/addons/templates/addons/persona_preview.html:66
+#: src/olympia/addons/templates/addons/persona_preview.html:67
 #, python-format
 msgid "%%Y-%%m-%%d"
 msgstr "%%Y-%%m-%%d"
 
-#: src/olympia/addons/templates/addons/persona_preview.html:67
+#: src/olympia/addons/templates/addons/persona_preview.html:68
 msgid "by {0} on {1}"
 msgstr "av {0} den {1}"
 
-#: src/olympia/addons/templates/addons/persona_preview.html:75
-#: src/olympia/reviews/helpers.py:17
-#: src/olympia/reviews/templates/reviews/review_list.html:63
-#: src/olympia/reviews/templates/reviews/reviews_link.html:21
-#: src/olympia/reviews/templates/reviews/impala/reviews_link.html:16
+#: src/olympia/addons/templates/addons/persona_preview.html:76 src/olympia/reviews/helpers.py:17 src/olympia/reviews/templates/reviews/review_list.html:63
+#: src/olympia/reviews/templates/reviews/reviews_link.html:21 src/olympia/reviews/templates/reviews/impala/reviews_link.html:16
 msgid "Not yet rated"
 msgstr "Inte betygsatt än"
 
-#: src/olympia/addons/templates/addons/persona_preview.html:78
+#: src/olympia/addons/templates/addons/persona_preview.html:79
 msgid "<b>{0}</b> users"
 msgstr "<b>{0}</b> användare"
 
 #: src/olympia/addons/templates/addons/popups.html:17
-msgid ""
-"To install this add-on and thousands more, <b>get Firefox</b>, a free and "
-"open web browser from Mozilla."
-msgstr ""
-"För att installera tillägget och tusentals andra, <b>hämta Firefox</b>, en "
-"gratis och öppen webbläsare från Mozilla."
+msgid "To install this add-on and thousands more, <b>get Firefox</b>, a free and open web browser from Mozilla."
+msgstr "För att installera tillägget och tusentals andra, <b>hämta Firefox</b>, en gratis och öppen webbläsare från Mozilla."
 
-#: src/olympia/addons/templates/addons/popups.html:21
-#: src/olympia/addons/templates/addons/popups.html:52
+#: src/olympia/addons/templates/addons/popups.html:21 src/olympia/addons/templates/addons/popups.html:52
 msgid "Learn more about Firefox"
 msgstr "Lär dig mer om Firefox"
 
 #: src/olympia/addons/templates/addons/popups.html:22
-msgid "or <b><a class=\"installer\" href=\"{url}\">download anyway</a></b>"
-msgstr "eller <b><a class=\"installer\" href=\"{url}\">hämta ändå</a></b>"
+msgid "or <b><a class=\"button installer\" href=\"{url}\">download anyway</a></b>"
+msgstr ""
 
 #: src/olympia/addons/templates/addons/popups.html:26
 msgid ""
-"<strong>How to Install in Thunderbird</strong> <ol> <li>Download and save "
-"the file to your hard disk.</li> <li>In Mozilla Thunderbird, open Add-ons "
-"from the Tools menu.</li> <li>From the options button next to the add-on "
-"search field, select \"Install Add-on From File...\" and locate the "
-"downloaded add-on.</li> </ol>"
+"<strong>How to Install in Thunderbird</strong> <ol> <li>Download and save the file to your hard disk.</li> <li>In Mozilla Thunderbird, open Add-ons from the Tools menu.</li> <li>From the options "
+"button next to the add-on search field, select \"Install Add-on From File...\" and locate the downloaded add-on.</li> </ol>"
 msgstr ""
-"<strong>Hur man installerar i Thunderbird</strong> <ol> <li>Hämta och spara "
-"filen på din hårddisk.</li> <li>I Mozilla Thunderbird, öppna tillägg från "
-"verktygsmenyn.</li> <li>Från alternativknappen bredvid tilläggssökfältet, "
-"välj \"Installera tillägg från fil...\" och leta reda på det nedladdade "
-"tillägget.</li> </ol>"
+"<strong>Hur man installerar i Thunderbird</strong> <ol> <li>Hämta och spara filen på din hårddisk.</li> <li>I Mozilla Thunderbird, öppna tillägg från verktygsmenyn.</li> <li>Från alternativknappen "
+"bredvid tilläggssökfältet, välj \"Installera tillägg från fil...\" och leta reda på det nedladdade tillägget.</li> </ol>"
 
 #: src/olympia/addons/templates/addons/popups.html:41
-msgid ""
-"To install this Theme, <b>get Thunderbird</b>, a free and open source email "
-"client from Mozilla Messaging and install the Personas Plus add-on."
-msgstr ""
-"För att installera detta tema, <b>hämta Thunderbird</b> en gratis "
-"e-postklient med öppen källkod från Mozilla Messaging och installera "
-"tillägget Personas Plus."
+msgid "To install this Theme, <b>get Thunderbird</b>, a free and open source email client from Mozilla Messaging and install the Personas Plus add-on."
+msgstr "För att installera detta tema, <b>hämta Thunderbird</b> en gratis e-postklient med öppen källkod från Mozilla Messaging och installera tillägget Personas Plus."
 
 #: src/olympia/addons/templates/addons/popups.html:46
 msgid "Learn more about Thunderbird"
 msgstr "Lär dig mer om Thunderbird"
 
 #: src/olympia/addons/templates/addons/popups.html:48
-msgid ""
-"To install this Theme and thousands more, <b>get Firefox</b>, a free and "
-"open web browser from Mozilla."
-msgstr ""
-"För att installera tillägget och tusentals andra, <b>hämta Firefox</b>, en "
-"gratis och öppen webbläsare från Mozilla."
+msgid "To install this Theme and thousands more, <b>get Firefox</b>, a free and open web browser from Mozilla."
+msgstr "För att installera tillägget och tusentals andra, <b>hämta Firefox</b>, en gratis och öppen webbläsare från Mozilla."
 
 #: src/olympia/addons/templates/addons/popups.html:60
 #, python-format
 msgid "This add-on has not been updated to work with your version of %(app)s."
-msgstr ""
-"Detta tillägg är inte uppdaterat för att fungera med din version av %(app)s."
+msgstr "Detta tillägg är inte uppdaterat för att fungera med din version av %(app)s."
 
-#: src/olympia/addons/templates/addons/popups.html:63
-#: src/olympia/addons/templates/addons/popups.html:140
-#: src/olympia/addons/templates/addons/popups.html:150
+#: src/olympia/addons/templates/addons/popups.html:63 src/olympia/addons/templates/addons/popups.html:140 src/olympia/addons/templates/addons/popups.html:150
 msgid "Install Anyway"
 msgstr "Installera ändå"
 
 #: src/olympia/addons/templates/addons/popups.html:71
-msgid ""
-"This add-on requires a version of Firefox that has not been released yet."
+msgid "This add-on requires a version of Firefox that has not been released yet."
 msgstr "Detta tillägg kräver en version av Firefox som inte har släppts ännu."
 
 #: src/olympia/addons/templates/addons/popups.html:74
@@ -1010,16 +752,11 @@ msgstr "Hjälpa till att testa nya versioner av Firefox"
 
 #: src/olympia/addons/templates/addons/popups.html:77
 #, python-format
-msgid ""
-"This add-on requires %(app)s {new_version}. You are currently using %(app)s "
-"{old_version}."
-msgstr ""
-"Detta tillägg kräver %(app)s {new_version}. Du använder för närvarande "
-"%(app)s {old_version}."
+msgid "This add-on requires %(app)s {new_version}. You are currently using %(app)s {old_version}."
+msgstr "Detta tillägg kräver %(app)s {new_version}. Du använder för närvarande %(app)s {old_version}."
 
 #. {0} is an app name, like Firefox.
-#: src/olympia/addons/templates/addons/popups.html:82
-#: src/olympia/addons/templates/addons/popups.html:101
+#: src/olympia/addons/templates/addons/popups.html:82 src/olympia/addons/templates/addons/popups.html:101
 msgid "Upgrade {0}"
 msgstr "Uppgradera {0}"
 
@@ -1030,44 +767,25 @@ msgstr "eller visa <a href=\"%(href)s\"> äldre versioner av detta tillägg</a>.
 
 #: src/olympia/addons/templates/addons/popups.html:96
 #, python-format
-msgid ""
-"This Persona requires %(app)s %(new_version)s. You are currently using "
-"%(app)s {old_version}."
-msgstr ""
-"Denna Persona kräver %(app)s %(new_version)s. Du använder för närvarande "
-"%(app)s {old_version}."
+msgid "This Persona requires %(app)s %(new_version)s. You are currently using %(app)s {old_version}."
+msgstr "Denna Persona kräver %(app)s %(new_version)s. Du använder för närvarande %(app)s {old_version}."
 
 #: src/olympia/addons/templates/addons/popups.html:108
 msgid ""
-"<strong>Caution:</strong> This add-on has not been reviewed by Mozilla and "
-"can't be installed on release versions of Firefox 43 and above.  Be careful "
-"when installing third-party software that might harm your computer."
+"<strong>Caution:</strong> This add-on has not been reviewed by Mozilla and can't be installed on release versions of Firefox 43 and above.  Be careful when installing third-party software that "
+"might harm your computer."
 msgstr ""
-"<strong>Varning:</strong> Detta tillägg har inte granskats av Mozilla och "
-"kan inte installeras på utgivna versioner av Firefox 43 och uppåt.   Var "
-"försiktig när du installerar programvara från tredje part som kan skada din "
-"dator."
 
 #: src/olympia/addons/templates/addons/popups.html:120
-msgid ""
-"<strong>Please note:</strong> This add-on is not compatible with your "
-"operating system."
-msgstr ""
-"<strong>Observera:</strong>Detta tillägg är ej kompatibelt med ditt "
-"operativsystem"
+msgid "<strong>Please note:</strong> This add-on is not compatible with your operating system."
+msgstr "<strong>Observera:</strong>Detta tillägg är ej kompatibelt med ditt operativsystem"
 
-#: src/olympia/addons/templates/addons/popups.html:136
-#: src/olympia/addons/templates/addons/impala/button.html:70
+#: src/olympia/addons/templates/addons/popups.html:136 src/olympia/addons/templates/addons/impala/button.html:70
 #, python-format
-msgid ""
-"This add-on is not compatible with your version of %(app)s because of the "
-"following:"
-msgstr ""
-"Detta tillägg är inte kompatibel med din version av %(app)s på grund av "
-"följande:"
+msgid "This add-on is not compatible with your version of %(app)s because of the following:"
+msgstr "Detta tillägg är inte kompatibel med din version av %(app)s på grund av följande:"
 
-#: src/olympia/addons/templates/addons/popups.html:141
-#: src/olympia/addons/templates/addons/popups.html:151
+#: src/olympia/addons/templates/addons/popups.html:141 src/olympia/addons/templates/addons/popups.html:151
 msgid "View other versions"
 msgstr "Visa andra versioner"
 
@@ -1091,144 +809,88 @@ msgid ""
 "  to your phone.  (You'll need a QR reader.  Search your phone's marketplace if\n"
 "  don't have one.)"
 msgstr ""
-"Vill du ha {0} på din mobila Firefox?  Skanna den här QR-koden för att installera direkt\n"
-"  på telefonen.  (Du behöver en QR-läsare.  Sök i telefonens Marketplace,\n"
-"  om du inte redan har den.)"
 
-#: src/olympia/addons/templates/addons/report_abuse.html:6
-#: src/olympia/addons/templates/addons/report_abuse_full.html:10
-#: src/olympia/addons/templates/addons/impala/details-more.html:23
-#: src/olympia/addons/templates/addons/impala/details.html:328
+#: src/olympia/addons/templates/addons/report_abuse.html:6 src/olympia/addons/templates/addons/report_abuse_full.html:10 src/olympia/addons/templates/addons/impala/details-more.html:23
+#: src/olympia/addons/templates/addons/impala/details.html:333
 msgid "Report Abuse"
 msgstr "Rapportera missbruk"
 
 #: src/olympia/addons/templates/addons/report_abuse.html:10
 #, python-format
 msgid ""
-"If you suspect this add-on violates <a href=\"%(url)s\">our policies</a> or "
-"has security or privacy issues, please use the form below to describe your "
-"concerns. Please do not use this form for any other reason."
+"If you suspect this add-on violates <a href=\"%(url)s\">our policies</a> or has security or privacy issues, please use the form below to describe your concerns. Please do not use this form for any "
+"other reason."
 msgstr ""
-"Om du misstänker att detta tillägg bryter <a href=\"%(url)s\">vår policy</a>"
-" eller har säkerhets- eller integritetsfrågor, vänligen använd formuläret "
-"nedan för att beskriva dina frågor. Använd inte detta formulär av någon "
-"annan anledning."
+"Om du misstänker att detta tillägg bryter <a href=\"%(url)s\">vår policy</a> eller har säkerhets- eller integritetsfrågor, vänligen använd formuläret nedan för att beskriva dina frågor. Använd inte "
+"detta formulär av någon annan anledning."
 
-#: src/olympia/addons/templates/addons/report_abuse.html:24
-#: src/olympia/users/templates/users/report_abuse.html:19
+#: src/olympia/addons/templates/addons/report_abuse.html:24 src/olympia/users/templates/users/report_abuse.html:19
 msgid "Send Report"
 msgstr "Skicka rapport"
 
-#: src/olympia/addons/templates/addons/report_abuse.html:26
-#: src/olympia/addons/templates/addons/mobile/eula.html:16
-#: src/olympia/addons/templates/addons/mobile/persona_confirm.html:7
-#: src/olympia/devhub/templates/devhub/addons/ajax_compat_update.html:36
-#: src/olympia/devhub/templates/devhub/addons/profile.html:44
-#: src/olympia/devhub/templates/devhub/addons/edit/admin.html:104
-#: src/olympia/devhub/templates/devhub/addons/edit/basic.html:155
-#: src/olympia/devhub/templates/devhub/addons/edit/details.html:88
-#: src/olympia/devhub/templates/devhub/addons/edit/support.html:70
-#: src/olympia/devhub/templates/devhub/addons/edit/technical.html:169
-#: src/olympia/devhub/templates/devhub/addons/forms_shared/media.html:152
-#: src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:44
-#: src/olympia/devhub/templates/devhub/personas/edit.html:222
-#: src/olympia/devhub/templates/devhub/versions/add_file_modal.html:79
-#: src/olympia/devhub/templates/devhub/versions/edit.html:140
-#: src/olympia/devhub/templates/devhub/versions/list.html:208
-#: src/olympia/devhub/templates/devhub/versions/list.html:242
-#: src/olympia/devhub/templates/devhub/versions/list.html:276
-#: src/olympia/devhub/templates/devhub/versions/list.html:317
-#: src/olympia/reviews/templates/reviews/edit_review.html:16
-#: src/olympia/translations/templates/translations/trans-menu.html:50
-#: src/olympia/translations/templates/translations/trans-menu.html:62
-#: src/olympia/zadmin/templates/zadmin/validation.html:105
+#: src/olympia/addons/templates/addons/report_abuse.html:26 src/olympia/addons/templates/addons/mobile/eula.html:16 src/olympia/addons/templates/addons/mobile/persona_confirm.html:7
+#: src/olympia/devhub/templates/devhub/addons/ajax_compat_update.html:36 src/olympia/devhub/templates/devhub/addons/profile.html:44 src/olympia/devhub/templates/devhub/addons/edit/admin.html:104
+#: src/olympia/devhub/templates/devhub/addons/edit/basic.html:155 src/olympia/devhub/templates/devhub/addons/edit/details.html:88 src/olympia/devhub/templates/devhub/addons/edit/support.html:70
+#: src/olympia/devhub/templates/devhub/addons/edit/technical.html:169 src/olympia/devhub/templates/devhub/addons/forms_shared/media.html:152
+#: src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:43 src/olympia/devhub/templates/devhub/personas/edit.html:222 src/olympia/devhub/templates/devhub/versions/add_file_modal.html:59
+#: src/olympia/devhub/templates/devhub/versions/edit.html:140 src/olympia/devhub/templates/devhub/versions/list.html:208 src/olympia/devhub/templates/devhub/versions/list.html:239
+#: src/olympia/devhub/templates/devhub/versions/list.html:281 src/olympia/devhub/templates/devhub/versions/list.html:315 src/olympia/reviews/templates/reviews/edit_review.html:16
+#: src/olympia/translations/templates/translations/trans-menu.html:50 src/olympia/translations/templates/translations/trans-menu.html:62 src/olympia/zadmin/templates/zadmin/validation.html:105
 msgid "Cancel"
 msgstr "Avbryt"
 
-#: src/olympia/addons/templates/addons/review_add_box.html:3
-#: src/olympia/addons/templates/addons/impala/review_add_box.html:5
+#: src/olympia/addons/templates/addons/review_add_box.html:3 src/olympia/addons/templates/addons/impala/review_add_box.html:5
 msgid "What do you think?"
 msgstr "Vad tycker du?"
 
-#: src/olympia/addons/templates/addons/review_add_box.html:7
-#: src/olympia/addons/templates/addons/impala/review_add_box.html:9
+#: src/olympia/addons/templates/addons/review_add_box.html:7 src/olympia/addons/templates/addons/impala/review_add_box.html:9
 #, python-format
 msgid "Please <a href=\"%(login)s\">log in</a> to submit a review"
 msgstr "<a href=\"%(login)s\">Logga in</a> för att skicka in en recension"
 
-#: src/olympia/addons/templates/addons/review_add_box.html:16
-#: src/olympia/addons/templates/addons/impala/review_add_box.html:18
-#: src/olympia/reviews/templates/reviews/mobile/add_form.html:13
+#: src/olympia/addons/templates/addons/review_add_box.html:16 src/olympia/addons/templates/addons/impala/review_add_box.html:18 src/olympia/reviews/templates/reviews/mobile/add_form.html:13
 msgid "Title:"
 msgstr "Titel:"
 
-#: src/olympia/addons/templates/addons/review_add_box.html:17
-#: src/olympia/addons/templates/addons/impala/review_add_box.html:19
-#: src/olympia/reviews/templates/reviews/mobile/add_form.html:17
+#: src/olympia/addons/templates/addons/review_add_box.html:17 src/olympia/addons/templates/addons/impala/review_add_box.html:19 src/olympia/reviews/templates/reviews/mobile/add_form.html:17
 msgid "Review:"
 msgstr "Recension:"
 
-#: src/olympia/addons/templates/addons/review_add_box.html:18
-#: src/olympia/addons/templates/addons/impala/review_add_box.html:20
-#: src/olympia/reviews/templates/reviews/mobile/add_form.html:16
+#: src/olympia/addons/templates/addons/review_add_box.html:18 src/olympia/addons/templates/addons/impala/review_add_box.html:20 src/olympia/reviews/templates/reviews/mobile/add_form.html:16
 msgid "Rating:"
 msgstr "Betyg:"
 
-#: src/olympia/addons/templates/addons/review_add_box.html:19
-#: src/olympia/addons/templates/addons/impala/review_add_box.html:21
-#: src/olympia/reviews/templates/reviews/add.html:63
-#: src/olympia/reviews/templates/reviews/edit_review.html:15
-#: src/olympia/reviews/templates/reviews/mobile/add_form.html:18
+#: src/olympia/addons/templates/addons/review_add_box.html:19 src/olympia/addons/templates/addons/impala/review_add_box.html:21 src/olympia/reviews/templates/reviews/add.html:63
+#: src/olympia/reviews/templates/reviews/edit_review.html:15 src/olympia/reviews/templates/reviews/mobile/add_form.html:18
 msgid "Submit review"
 msgstr "Skicka in recension"
 
-#: src/olympia/addons/templates/addons/review_add_box.html:24
-#: src/olympia/addons/templates/addons/impala/review_add_box.html:26
-msgid ""
-"Please do not post bug reports in reviews. We do not make your email address"
-" available to add-on developers and they may need to contact you to help "
-"resolve your issue."
-msgstr ""
-"Skicka inte felrapporter i recensioner. Vi gör inte din e-postadress "
-"tillgänglig för tilläggsutvecklare och de kan behöva kontakta dig för att "
-"lösa ditt problem."
+#: src/olympia/addons/templates/addons/review_add_box.html:24 src/olympia/addons/templates/addons/impala/review_add_box.html:26
+msgid "Please do not post bug reports in reviews. We do not make your email address available to add-on developers and they may need to contact you to help resolve your issue."
+msgstr "Skicka inte felrapporter i recensioner. Vi gör inte din e-postadress tillgänglig för tilläggsutvecklare och de kan behöva kontakta dig för att lösa ditt problem."
 
-#: src/olympia/addons/templates/addons/review_add_box.html:32
-#: src/olympia/addons/templates/addons/impala/review_add_box.html:35
+#: src/olympia/addons/templates/addons/review_add_box.html:32 src/olympia/addons/templates/addons/impala/review_add_box.html:35
 #, python-format
-msgid ""
-"See the <a href=\"%(support)s\">support section</a> to find out where to get"
-" assistance for this add-on."
-msgstr ""
-"Se <a href=\"%(support)s\">hjälpsektionen</a> för att ta reda på var du kan "
-"få hjälp med detta tillägg."
+msgid "See the <a href=\"%(support)s\">support section</a> to find out where to get assistance for this add-on."
+msgstr "Se <a href=\"%(support)s\">hjälpsektionen</a> för att ta reda på var du kan få hjälp med detta tillägg."
 
-#: src/olympia/addons/templates/addons/review_add_box.html:38
-#: src/olympia/addons/templates/addons/impala/review_add_box.html:42
-#: src/olympia/pages/templates/pages/review_guide.html:3
+#: src/olympia/addons/templates/addons/review_add_box.html:38 src/olympia/addons/templates/addons/impala/review_add_box.html:42 src/olympia/pages/templates/pages/review_guide.html:3
 #: src/olympia/pages/templates/pages/review_guide.html:44
 msgid "Review Guidelines"
 msgstr "Recensionsriktlinjer"
 
-#: src/olympia/addons/templates/addons/review_list_box.html:5
-#: src/olympia/addons/templates/addons/impala/details-more.html:27
-#: src/olympia/editors/helpers.py:921
-#: src/olympia/reviews/templates/reviews/add.html:14
-#: src/olympia/reviews/templates/reviews/reply.html:14
-#: src/olympia/reviews/templates/reviews/review_list.html:19
+#: src/olympia/addons/templates/addons/review_list_box.html:5 src/olympia/addons/templates/addons/impala/details-more.html:27 src/olympia/editors/helpers.py:1001
+#: src/olympia/reviews/templates/reviews/add.html:14 src/olympia/reviews/templates/reviews/reply.html:14 src/olympia/reviews/templates/reviews/review_list.html:19
 #: src/olympia/reviews/templates/reviews/mobile/review_list.html:26
 msgid "Reviews"
 msgstr "Recensioner"
 
-#: src/olympia/addons/templates/addons/review_list_box.html:14
-#: src/olympia/addons/templates/addons/impala/review_list_box.html:14
-#: src/olympia/reviews/templates/reviews/review.html:30
+#: src/olympia/addons/templates/addons/review_list_box.html:14 src/olympia/addons/templates/addons/impala/review_list_box.html:14 src/olympia/reviews/templates/reviews/review.html:30
 #, python-format
 msgid "by %(user)s on %(date)s"
 msgstr "av %(user)s den %(date)s"
 
-#: src/olympia/addons/templates/addons/review_list_box.html:19
-#: src/olympia/addons/templates/addons/impala/review_list_box.html:29
+#: src/olympia/addons/templates/addons/review_list_box.html:19 src/olympia/addons/templates/addons/impala/review_list_box.html:29
 msgid "Show the developer's reply to this review"
 msgstr "Visa utvecklarens svar på denna recension"
 
@@ -1239,21 +901,16 @@ msgid_plural "See all %(cnt)s reviews of this add-on"
 msgstr[0] "Visa alla recensioner av detta tillägg"
 msgstr[1] "Visa alla %(cnt)s recensioner av detta tillägg"
 
-#: src/olympia/addons/templates/addons/tags_box.html:3
-#: src/olympia/devhub/templates/devhub/addons/edit/basic.html:118
+#: src/olympia/addons/templates/addons/tags_box.html:3 src/olympia/devhub/templates/devhub/addons/edit/basic.html:118
 msgid "Tags"
 msgstr "Taggar"
 
-#: src/olympia/addons/templates/addons/impala/addon_hovercard.html:7
-#: src/olympia/addons/templates/addons/impala/addon_hovercard.html:9
+#: src/olympia/addons/templates/addons/impala/addon_hovercard.html:7 src/olympia/addons/templates/addons/impala/addon_hovercard.html:9
 msgid "Icon for {0}"
 msgstr "Ikon för {0}"
 
-#: src/olympia/addons/templates/addons/impala/addon_hovercard.html:34
-#: src/olympia/addons/templates/addons/impala/featured_grid.html:26
-#: src/olympia/addons/templates/addons/impala/theme_grid.html:22
-#: src/olympia/bandwagon/templates/bandwagon/collection_detail.html:31
-#: src/olympia/users/templates/users/helpers/addon_users_list.html:7
+#: src/olympia/addons/templates/addons/impala/addon_hovercard.html:34 src/olympia/addons/templates/addons/impala/featured_grid.html:26 src/olympia/addons/templates/addons/impala/theme_grid.html:22
+#: src/olympia/bandwagon/templates/bandwagon/collection_detail.html:31 src/olympia/users/templates/users/helpers/addon_users_list.html:7
 #, python-format
 msgid "by %(users)s"
 msgstr "av %(users)s"
@@ -1273,34 +930,18 @@ msgstr "Tycker du om detta tillägg?"
 
 #: src/olympia/addons/templates/addons/impala/contribution.html:43
 #, python-format
-msgid ""
-"The <a href=\"%(meet_url)s\">developer of this add-on</a> asks that you help"
-" support its continued development by making a small contribution."
-msgstr ""
-"<a href=\"%(meet_url)s\">Utvecklaren av detta tillägg</a> vill gärna att du "
-"stöder dess framtida utveckling genom att ge ett litet bidrag."
+msgid "The <a href=\"%(meet_url)s\">developer of this add-on</a> asks that you help support its continued development by making a small contribution."
+msgstr "<a href=\"%(meet_url)s\">Utvecklaren av detta tillägg</a> vill gärna att du stöder dess framtida utveckling genom att ge ett litet bidrag."
 
 #: src/olympia/addons/templates/addons/impala/contribution.html:48
 #, python-format
-msgid ""
-"The <a href=\"%(meet_url)s\">developer of this add-on</a> asks that you show"
-" your support by making a donation to the <a "
-"href=\"%(charity_url)s\">%(charity_name)s</a>."
-msgstr ""
-"<a href=\"%(meet_url)s\">Utvecklaren av detta tillägg </a> ber att du visa "
-"ditt stöd genom att göra en donation till <a "
-"href=\"%(charity_url)s\">%(charity_name)s</a>."
+msgid "The <a href=\"%(meet_url)s\">developer of this add-on</a> asks that you show your support by making a donation to the <a href=\"%(charity_url)s\">%(charity_name)s</a>."
+msgstr "<a href=\"%(meet_url)s\">Utvecklaren av detta tillägg </a> ber att du visa ditt stöd genom att göra en donation till <a href=\"%(charity_url)s\">%(charity_name)s</a>."
 
 #: src/olympia/addons/templates/addons/impala/contribution.html:53
 #, python-format
-msgid ""
-"The <a href=\"%(meet_url)s\">developer of this add-on</a> asks that you show"
-" your support by making a small contribution to <a "
-"href=\"%(charity_url)s\">%(charity_name)s</a>."
-msgstr ""
-"<a href=\"%(meet_url)s\">Utvecklaren av detta tillägg </a> ber att du visar "
-"ditt stöd genom att ge ett litet bidrag till <a "
-"href=\"%(charity_url)s\">%(charity_name)s</a>."
+msgid "The <a href=\"%(meet_url)s\">developer of this add-on</a> asks that you show your support by making a small contribution to <a href=\"%(charity_url)s\">%(charity_name)s</a>."
+msgstr "<a href=\"%(meet_url)s\">Utvecklaren av detta tillägg </a> ber att du visar ditt stöd genom att ge ett litet bidrag till <a href=\"%(charity_url)s\">%(charity_name)s</a>."
 
 #: src/olympia/addons/templates/addons/impala/dependencies_note.html:4
 msgid "This add-on requires the following add-ons to work properly:"
@@ -1329,147 +970,121 @@ msgid_plural "Other add-ons by these authors"
 msgstr[0] "Andra tillägg av %(author)s"
 msgstr[1] "Andra tillägg av dessa författare"
 
-#: src/olympia/addons/templates/addons/impala/details.html:41
+#: src/olympia/addons/templates/addons/impala/details.html:39
 #, python-format
 msgid "<span itemprop=\"ratingCount\">%(num)s</span> user review"
 msgid_plural "<span itemprop=\"ratingCount\">%(num)s</span> user reviews"
 msgstr[0] "<span itemprop=\"ratingCount\">%(num)s</span> användarrecension"
 msgstr[1] "<span itemprop=\"ratingCount\">%(num)s</span> användarrecensioner"
 
-#: src/olympia/addons/templates/addons/impala/details.html:69
+#: src/olympia/addons/templates/addons/impala/details.html:66
 msgid "View statistics"
 msgstr "Visa statistik"
 
-#: src/olympia/addons/templates/addons/impala/details.html:84
+#: src/olympia/addons/templates/addons/impala/details.html:81
 msgid "Manage"
 msgstr "Hantera"
 
 #. {0} is an add-on name.
-#: src/olympia/addons/templates/addons/impala/details.html:96
+#: src/olympia/addons/templates/addons/impala/details.html:93
 msgid "Icon of {0}"
 msgstr "Ikon för {0}"
 
-#: src/olympia/addons/templates/addons/impala/details.html:103
-#: src/olympia/addons/templates/addons/impala/listing/items.html:14
+#: src/olympia/addons/templates/addons/impala/details.html:100 src/olympia/addons/templates/addons/impala/listing/items.html:14
 msgid "No Restart"
 msgstr "Ingen omstart"
 
-#: src/olympia/addons/templates/addons/impala/details.html:127
+#: src/olympia/addons/templates/addons/impala/details.html:124
 #, python-format
 msgid "Meet the Developer: <a href=\"%(url)s\">%(name)s</a>"
 msgid_plural "<a href=\"%(url)s\">Meet the Developers</a>"
 msgstr[0] "Möt utvecklaren: <a href=\"%(url)s\">%(name)s</a>"
 msgstr[1] "<a href=\"%(url)s\">Möt utvecklarna</a>"
 
-#: src/olympia/addons/templates/addons/impala/details.html:137
+#: src/olympia/addons/templates/addons/impala/details.html:134
 msgid "Learn why {0} was created and find out what's next for this add-on."
-msgstr ""
-"Läs om varför {0} skapades och få reda på vad som händer i framtiden med "
-"detta tillägg."
+msgstr "Läs om varför {0} skapades och få reda på vad som händer i framtiden med detta tillägg."
 
 #. {0} is an index.
-#: src/olympia/addons/templates/addons/impala/details.html:156
+#: src/olympia/addons/templates/addons/impala/details.html:161
 msgid "Add-on screenshot #{0}"
 msgstr "Skärmdump #{0} för tillägg"
 
-#: src/olympia/addons/templates/addons/impala/details.html:182
+#: src/olympia/addons/templates/addons/impala/details.html:187
 msgid "Add-on home page"
 msgstr "Hemsida för tillägg"
 
-#: src/olympia/addons/templates/addons/impala/details.html:185
+#: src/olympia/addons/templates/addons/impala/details.html:190
 msgid "Support site"
 msgstr "Support webbplats"
 
-#: src/olympia/addons/templates/addons/impala/details.html:189
+#: src/olympia/addons/templates/addons/impala/details.html:194
 msgid "Support E-mail"
 msgstr "Support e-post"
 
-#: src/olympia/addons/templates/addons/impala/details.html:194
-#: src/olympia/devhub/models.py:378
-#: src/olympia/devhub/templates/devhub/versions/list.html:12
-#: src/olympia/versions/templates/versions/version.html:6
-#: src/olympia/versions/templates/versions/mobile/version.html:6
+#: src/olympia/addons/templates/addons/impala/details.html:199 src/olympia/devhub/models.py:378 src/olympia/devhub/templates/devhub/versions/list.html:12
+#: src/olympia/versions/templates/versions/version.html:6 src/olympia/versions/templates/versions/mobile/version.html:6
 msgid "Version {0}"
 msgstr "Version {0}"
 
-#: src/olympia/addons/templates/addons/impala/details.html:194
+#: src/olympia/addons/templates/addons/impala/details.html:199
 msgid "Info"
 msgstr "Information"
 
-#: src/olympia/addons/templates/addons/impala/details.html:195
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:129
+#: src/olympia/addons/templates/addons/impala/details.html:200 src/olympia/devhub/templates/devhub/includes/addon_details.html:116
 msgid "Last Updated:"
 msgstr "Senast uppdaterad:"
 
-#: src/olympia/addons/templates/addons/impala/details.html:200
+#: src/olympia/addons/templates/addons/impala/details.html:205
 #, python-format
 msgid "Released under <a target=\"_blank\" href=\"%(url)s\">%(name)s</a>"
 msgstr "Släppt under <a target=\"_blank\" href=\"%(url)s\">%(name)s</a>"
 
-#: src/olympia/addons/templates/addons/impala/details.html:201
-#: src/olympia/addons/templates/addons/impala/details.html:206
-#: src/olympia/amo/helpers.py:398 src/olympia/devhub/forms.py:142
-#: src/olympia/devhub/forms.py:173
-#: src/olympia/versions/templates/versions/version.html:40
-#: src/olympia/versions/templates/versions/version.html:45
+#: src/olympia/addons/templates/addons/impala/details.html:206 src/olympia/addons/templates/addons/impala/details.html:211 src/olympia/amo/helpers.py:398 src/olympia/devhub/forms.py:142
+#: src/olympia/devhub/forms.py:173 src/olympia/versions/templates/versions/version.html:40 src/olympia/versions/templates/versions/version.html:45
 msgid "Custom License"
 msgstr "Anpassad licens"
 
-#: src/olympia/addons/templates/addons/impala/details.html:205
+#: src/olympia/addons/templates/addons/impala/details.html:210
 #, python-format
 msgid "Released under <a href=\"%(url)s\">%(name)s</a>"
 msgstr "Släppt under <a href=\"%(url)s\">%(name)s</a>"
 
-#: src/olympia/addons/templates/addons/impala/details.html:217
+#: src/olympia/addons/templates/addons/impala/details.html:222
 msgid "About this Add-on"
 msgstr "Om detta tillägg"
 
-#: src/olympia/addons/templates/addons/impala/details.html:233
+#: src/olympia/addons/templates/addons/impala/details.html:238
 msgid "Developer’s Comments"
 msgstr "Utvecklarens kommentarer"
 
-#: src/olympia/addons/templates/addons/impala/details.html:243
+#: src/olympia/addons/templates/addons/impala/details.html:248
 msgid "Version Information"
 msgstr "Versionsinformation"
 
-#: src/olympia/addons/templates/addons/impala/details.html:250
+#: src/olympia/addons/templates/addons/impala/details.html:255
 msgid "See complete version history"
 msgstr "Visa fullständig versionshistorik"
 
-#: src/olympia/addons/templates/addons/impala/details.html:262
+#: src/olympia/addons/templates/addons/impala/details.html:267
 msgid ""
-"The Development Channel lets you test an experimental new version of this "
-"add-on before it's released to the general public. Once you install the "
-"development version, you will continue to get updates from this channel. To "
-"stop receiving development updates, reinstall the default version from the "
-"link above."
+"The Development Channel lets you test an experimental new version of this add-on before it's released to the general public. Once you install the development version, you will continue to get "
+"updates from this channel. To stop receiving development updates, reinstall the default version from the link above."
 msgstr ""
-"Utvecklingskanalen låter dig testa en experimentell ny version av detta "
-"tillägg innan det släpps till allmänheten. När du installerar "
-"utvecklingsversionen, kommer du att fortsätta att få uppdateringar från den "
-"här kanalen. För att sluta ta emot utvecklingsuppdateringar, installera om "
-"standardversionen från länken ovan."
+"Utvecklingskanalen låter dig testa en experimentell ny version av detta tillägg innan det släpps till allmänheten. När du installerar utvecklingsversionen, kommer du att fortsätta att få "
+"uppdateringar från den här kanalen. För att sluta ta emot utvecklingsuppdateringar, installera om standardversionen från länken ovan."
 
-#: src/olympia/addons/templates/addons/impala/details.html:272
-msgid ""
-"<strong>Caution:</strong> Development versions of this add-on have not been "
-"reviewed by Mozilla."
-msgstr ""
-"<strong>Varning:</strong> Utvecklingsversioner av detta tillägg har inte "
-"granskats av Mozilla."
+#: src/olympia/addons/templates/addons/impala/details.html:277
+msgid "<strong>Caution:</strong> Development versions of this add-on have not been reviewed by Mozilla."
+msgstr "<strong>Varning:</strong> Utvecklingsversioner av detta tillägg har inte granskats av Mozilla."
 
-#: src/olympia/addons/templates/addons/impala/details.html:287
+#: src/olympia/addons/templates/addons/impala/details.html:292
 msgid "See complete development channel history"
 msgstr "Se komplett historik för utveklingskanal"
 
-#: src/olympia/addons/templates/addons/impala/details.html:306
-#: src/olympia/addons/templates/addons/impala/details.html:315
-#: src/olympia/addons/templates/addons/impala/details.html:327
-#: src/olympia/addons/templates/addons/impala/review_add_box.html:4
-#: src/olympia/stats/templates/stats/popup.html:2
-#: src/olympia/stats/templates/stats/popup.html:8
-#: src/olympia/stats/templates/stats/stats.html:202
-#: src/olympia/users/templates/users/profile.html:119
+#: src/olympia/addons/templates/addons/impala/details.html:311 src/olympia/addons/templates/addons/impala/details.html:320 src/olympia/addons/templates/addons/impala/details.html:332
+#: src/olympia/addons/templates/addons/impala/review_add_box.html:4 src/olympia/stats/templates/stats/popup.html:2 src/olympia/stats/templates/stats/popup.html:8
+#: src/olympia/stats/templates/stats/stats.html:204 src/olympia/users/templates/users/profile.html:119
 msgid "close"
 msgstr "stäng"
 
@@ -1484,12 +1099,8 @@ msgid "Meet the {0} Developer"
 msgstr "Möt utvecklaren bakom {0}"
 
 #: src/olympia/addons/templates/addons/impala/developers.html:41
-msgid ""
-"Before downloading this add-on, please consider supporting the development "
-"of this add-on by making a small contribution."
-msgstr ""
-"Innan du laddar ner detta tillägg, överväg att stöda utvecklingen genom att "
-"ge ett litet bidrag."
+msgid "Before downloading this add-on, please consider supporting the development of this add-on by making a small contribution."
+msgstr "Innan du laddar ner detta tillägg, överväg att stöda utvecklingen genom att ge ett litet bidrag."
 
 #: src/olympia/addons/templates/addons/impala/developers.html:80
 msgid "Why was {0} created?"
@@ -1505,9 +1116,7 @@ msgid_plural "About the Developers"
 msgstr[0] "Om utvecklaren"
 msgstr[1] "Om utvecklarna"
 
-#: src/olympia/addons/templates/addons/impala/developers.html:96
-#: src/olympia/users/templates/users/edit.html:130
-#: src/olympia/users/templates/users/profile.html:26
+#: src/olympia/addons/templates/addons/impala/developers.html:96 src/olympia/users/templates/users/edit.html:130 src/olympia/users/templates/users/profile.html:26
 msgid "No Photo"
 msgstr "Inget foto"
 
@@ -1527,24 +1136,15 @@ msgstr "Detta tillägg har inaktiverats av en administratör."
 msgid "Source Code License for {addon}"
 msgstr "Källkodslicens för {addon}"
 
-#: src/olympia/addons/templates/addons/impala/license.html:21
-#: src/olympia/versions/templates/versions/mobile/version.html:18
+#: src/olympia/addons/templates/addons/impala/license.html:21 src/olympia/versions/templates/versions/mobile/version.html:18
 msgid "Source Code License"
 msgstr "Källkodslicens"
 
-#: src/olympia/addons/templates/addons/impala/persona_grid.html:16
-#: src/olympia/addons/templates/addons/impala/toplist.html:6
-msgid "{0} users"
-msgstr "{0} användare"
-
-#: src/olympia/addons/templates/addons/impala/review_list_box.html:19
-#: src/olympia/reviews/templates/reviews/review.html:40
+#: src/olympia/addons/templates/addons/impala/review_list_box.html:19 src/olympia/reviews/templates/reviews/review.html:40
 msgid "permalink"
 msgstr "permalänk"
 
-#: src/olympia/addons/templates/addons/impala/review_list_box.html:23
-#: src/olympia/editors/templates/editors/queue.html:98
-#: src/olympia/reviews/templates/reviews/review.html:44
+#: src/olympia/addons/templates/addons/impala/review_list_box.html:23 src/olympia/editors/templates/editors/queue.html:104 src/olympia/reviews/templates/reviews/review.html:44
 msgid "translate"
 msgstr "översätt"
 
@@ -1555,8 +1155,7 @@ msgid_plural "See all %(cnt)s user reviews"
 msgstr[0] "Visa alla användarrecensioner"
 msgstr[1] "Visa alla %(cnt)s användarrecensioner"
 
-#: src/olympia/addons/templates/addons/impala/review_list_box.html:47
-#: src/olympia/reviews/templates/reviews/review_list.html:84
+#: src/olympia/addons/templates/addons/impala/review_list_box.html:47 src/olympia/reviews/templates/reviews/review_list.html:84
 msgid "This add-on has not yet been reviewed."
 msgstr "Detta tillägg har ännu inte recenserats."
 
@@ -1564,24 +1163,23 @@ msgstr "Detta tillägg har ännu inte recenserats."
 msgid "Be the first!"
 msgstr "Bli den första!"
 
-#: src/olympia/addons/templates/addons/impala/listing/sorter.html:14
-#: src/olympia/devhub/templates/devhub/addons/listing/item_actions.html:49
+#: src/olympia/addons/templates/addons/impala/toplist.html:6
+msgid "{0} users"
+msgstr "{0} användare"
+
+#: src/olympia/addons/templates/addons/impala/listing/sorter.html:14 src/olympia/devhub/templates/devhub/addons/listing/item_actions.html:49
 msgid "More"
 msgstr "Mer"
 
-#: src/olympia/addons/templates/addons/includes/collection_add_widget.html:7
-#: src/olympia/addons/templates/addons/includes/collection_add_widget.html:10
+#: src/olympia/addons/templates/addons/includes/collection_add_widget.html:7 src/olympia/addons/templates/addons/includes/collection_add_widget.html:10
 msgid "Add to collection"
 msgstr "Lägg till i samling"
 
-#: src/olympia/addons/templates/addons/includes/dashboard_tabs.html:4
-#: src/olympia/devhub/templates/devhub/index.html:73
-#: src/olympia/devhub/templates/devhub/nav.html:14
+#: src/olympia/addons/templates/addons/includes/dashboard_tabs.html:4 src/olympia/devhub/templates/devhub/index.html:73 src/olympia/devhub/templates/devhub/nav.html:14
 msgid "My Add-ons"
 msgstr "Mina tillägg"
 
-#: src/olympia/addons/templates/addons/includes/dashboard_tabs.html:6
-#: src/olympia/amo/context_processors.py:51
+#: src/olympia/addons/templates/addons/includes/dashboard_tabs.html:6 src/olympia/amo/context_processors.py:50
 msgid "My Themes"
 msgstr "Mina teman"
 
@@ -1597,8 +1195,7 @@ msgstr "Redigera tema"
 msgid "Approve / Reject"
 msgstr "Godkänn / Avvisa"
 
-#: src/olympia/addons/templates/addons/includes/persona.html:25
-#: src/olympia/editors/templates/editors/themes/single.html:43
+#: src/olympia/addons/templates/addons/includes/persona.html:25 src/olympia/editors/templates/editors/themes/single.html:43
 msgid "Review History"
 msgstr "Recensionshistorik"
 
@@ -1619,9 +1216,7 @@ msgid "Not Yet Rated"
 msgstr "Inte betygsatt än"
 
 #. {0} is the number of downloads.
-#: src/olympia/addons/templates/addons/listing/items_mobile.html:27
-#: src/olympia/addons/templates/addons/listing/macros.html:24
-#: src/olympia/devhub/templates/devhub/addons/listing/macros.html:15
+#: src/olympia/addons/templates/addons/listing/items_mobile.html:27 src/olympia/addons/templates/addons/listing/macros.html:24 src/olympia/devhub/templates/devhub/addons/listing/macros.html:15
 msgid "<strong>{0}</strong> weekly download"
 msgid_plural "<strong>{0}</strong> weekly downloads"
 msgstr[0] "<strong>{0}</strong> nedladdning per vecka"
@@ -1635,15 +1230,11 @@ msgstr "Läs mer"
 msgid "Users"
 msgstr "Användare"
 
-#: src/olympia/addons/templates/addons/mobile/details.html:92
-#: src/olympia/browse/views.py:59 src/olympia/browse/views.py:70
-#: src/olympia/search/forms.py:90
+#: src/olympia/addons/templates/addons/mobile/details.html:92 src/olympia/browse/views.py:59 src/olympia/browse/views.py:70 src/olympia/search/forms.py:90
 msgid "Weekly Downloads"
 msgstr "Nedladdningar per vecka"
 
-#: src/olympia/addons/templates/addons/mobile/details.html:99
-#: src/olympia/compat/templates/compat/reporter_detail.html:46
-#: src/olympia/devhub/forms.py:787
+#: src/olympia/addons/templates/addons/mobile/details.html:99 src/olympia/compat/templates/compat/reporter_detail.html:46 src/olympia/devhub/forms.py:788
 #: src/olympia/devhub/templates/devhub/versions/list.html:163
 msgid "Version"
 msgstr "Version"
@@ -1679,49 +1270,29 @@ msgstr "Licensavtal"
 
 #: src/olympia/addons/templates/addons/mobile/eula.html:5
 #, python-format
-msgid ""
-"%(name)s requires that you accept the following End-User License Agreement "
-"before installation can proceed:"
-msgstr ""
-"%(name)s kräver att du accepterar följande slutanvändaravtal innan "
-"installationen kan fortsätta:"
+msgid "%(name)s requires that you accept the following End-User License Agreement before installation can proceed:"
+msgstr "%(name)s kräver att du accepterar följande slutanvändaravtal innan installationen kan fortsätta:"
 
 #: src/olympia/addons/templates/addons/mobile/eula.html:15
 msgid "Accept"
 msgstr "Acceptera"
 
-#: src/olympia/addons/templates/addons/mobile/home.html:10
-#: src/olympia/templates/mobile/base_addons.html:53
+#: src/olympia/addons/templates/addons/mobile/home.html:10 src/olympia/templates/mobile/base_addons.html:53
 msgid "Add-ons are not currently available on Firefox for iOS."
 msgstr "Tillägg är inte tillgängliga på Firefox för iOS."
 
-#: src/olympia/addons/templates/addons/mobile/home.html:12
-#: src/olympia/templates/mobile/base_addons.html:55
-msgid ""
-"You need Firefox to install add-ons. <a "
-"href=\"http://mozilla.com/mobile\">Learn More&nbsp;&raquo;</a>"
-msgstr ""
-"Du behöver Firefox för att installera tillägg. <a "
-"href=\"http://mozilla.com/mobile\">Läs mer&nbsp;&raquo;</a>"
+#: src/olympia/addons/templates/addons/mobile/home.html:12 src/olympia/templates/mobile/base_addons.html:55
+msgid "You need Firefox to install add-ons. <a href=\"http://mozilla.com/mobile\">Learn More&nbsp;&raquo;</a>"
+msgstr "Du behöver Firefox för att installera tillägg. <a href=\"http://mozilla.com/mobile\">Läs mer&nbsp;&raquo;</a>"
 
-#: src/olympia/addons/templates/addons/mobile/home.html:19
-#: src/olympia/templates/header_title.html:4
-#: src/olympia/templates/impala/header_title.html:3
+#: src/olympia/addons/templates/addons/mobile/home.html:19 src/olympia/templates/header_title.html:4 src/olympia/templates/impala/header_title.html:3
 msgid "Return to the {0} Add-ons homepage"
 msgstr "Återgå till hemsidan för tillägget {0}"
 
-#: src/olympia/addons/templates/addons/mobile/home.html:21
-#: src/olympia/amo/helpers.py:237
-#: src/olympia/bandwagon/templates/bandwagon/edit.html:34
-#: src/olympia/discovery/templates/discovery/pane.html:92
-#: src/olympia/editors/templates/editors/base.html:21
-#: src/olympia/editors/templates/editors/performance.html:72
-#: src/olympia/templates/menu_links.html:4
-#: src/olympia/templates/impala/header_title.html:13
-#: src/olympia/templates/impala/header_title.html:15
-#: src/olympia/templates/impala/header_title.html:19
-#: src/olympia/templates/impala/header_title.html:23
-#: src/olympia/templates/mobile/base_addons.html:47
+#: src/olympia/addons/templates/addons/mobile/home.html:21 src/olympia/amo/helpers.py:237 src/olympia/bandwagon/templates/bandwagon/edit.html:34 src/olympia/discovery/templates/discovery/pane.html:92
+#: src/olympia/editors/templates/editors/base.html:21 src/olympia/editors/templates/editors/performance.html:72 src/olympia/templates/menu_links.html:4
+#: src/olympia/templates/impala/header_title.html:13 src/olympia/templates/impala/header_title.html:15 src/olympia/templates/impala/header_title.html:19
+#: src/olympia/templates/impala/header_title.html:23 src/olympia/templates/mobile/base_addons.html:47
 msgid "Add-ons"
 msgstr "Tillägg"
 
@@ -1729,48 +1300,28 @@ msgstr "Tillägg"
 msgid "Easy ways to personalize."
 msgstr "Enkla sätt att anpassa."
 
-#: src/olympia/addons/templates/addons/mobile/home.html:24
-#: src/olympia/devhub/templates/devhub/addons/submit/done.html:47
-#: src/olympia/discovery/templates/discovery/pane.html:34
-#: src/olympia/discovery/templates/discovery/addons/detail.html:16
-#: src/olympia/discovery/templates/discovery/modules/featured.html:21
-#: src/olympia/discovery/templates/discovery/modules/monthly.html:22
+#: src/olympia/addons/templates/addons/mobile/home.html:24 src/olympia/devhub/templates/devhub/addons/submit/done.html:47 src/olympia/discovery/templates/discovery/pane.html:34
+#: src/olympia/discovery/templates/discovery/addons/detail.html:16 src/olympia/discovery/templates/discovery/modules/featured.html:21 src/olympia/discovery/templates/discovery/modules/monthly.html:22
 msgid "Learn More"
 msgstr "Läs mer"
 
 #: src/olympia/addons/templates/addons/mobile/home.html:26
 msgid ""
-"Add-ons are applications that let you personalize Firefox with extra "
-"functionality and style. Whether you mistype the name of a website or can't "
-"read a busy page, there's an add-on to improve your on-the-go browsing."
+"Add-ons are applications that let you personalize Firefox with extra functionality and style. Whether you mistype the name of a website or can't read a busy page, there's an add-on to improve your "
+"on-the-go browsing."
 msgstr ""
-"Tillägg är applikationer som låter dig anpassa Firefox med extra "
-"funktionalitet och stil. Oavsett om du skriver fel namn på en webbplats "
-"eller inte kan läsa en upptagen sida, det finns alltid ett tillägg för att "
-"förbättra din surfning."
+"Tillägg är applikationer som låter dig anpassa Firefox med extra funktionalitet och stil. Oavsett om du skriver fel namn på en webbplats eller inte kan läsa en upptagen sida, det finns alltid ett "
+"tillägg för att förbättra din surfning."
 
 #. {0} is a category name. Ex: "Sports"
 #. {0} is a category name, such as Nature.
-#: src/olympia/addons/templates/addons/mobile/home.html:43
-#: src/olympia/amo/templates/amo/site_nav.html:32
-#: src/olympia/browse/feeds.py:107
-#: src/olympia/browse/templates/browse/impala/base_listing.html:38
-#: src/olympia/browse/templates/browse/personas/base.html:6
-#: src/olympia/browse/templates/browse/personas/base.html:42
-#: src/olympia/browse/templates/browse/personas/category_landing.html:21
-#: src/olympia/browse/templates/browse/personas/category_landing.html:23
-#: src/olympia/browse/templates/browse/personas/category_landing.html:38
-#: src/olympia/browse/templates/browse/personas/grid.html:7
-#: src/olympia/browse/templates/browse/personas/grid.html:11
-#: src/olympia/browse/templates/browse/personas/mobile/base.html:7
-#: src/olympia/browse/templates/browse/personas/mobile/category_landing.html:19
-#: src/olympia/constants/base.py:180
-#: src/olympia/devhub/templates/devhub/personas/submit.html:13
-#: src/olympia/editors/helpers.py:105
-#: src/olympia/editors/templates/editors/base.html:26
-#: src/olympia/editors/templates/editors/performance.html:73
-#: src/olympia/search/templates/search/personas.html:39
-#: src/olympia/templates/menu_links.html:9
+#: src/olympia/addons/templates/addons/mobile/home.html:43 src/olympia/amo/templates/amo/site_nav.html:32 src/olympia/browse/feeds.py:107
+#: src/olympia/browse/templates/browse/impala/base_listing.html:38 src/olympia/browse/templates/browse/personas/base.html:6 src/olympia/browse/templates/browse/personas/base.html:42
+#: src/olympia/browse/templates/browse/personas/category_landing.html:21 src/olympia/browse/templates/browse/personas/category_landing.html:23
+#: src/olympia/browse/templates/browse/personas/category_landing.html:38 src/olympia/browse/templates/browse/personas/grid.html:7 src/olympia/browse/templates/browse/personas/grid.html:11
+#: src/olympia/browse/templates/browse/personas/mobile/base.html:7 src/olympia/browse/templates/browse/personas/mobile/category_landing.html:19 src/olympia/constants/base.py:180
+#: src/olympia/devhub/templates/devhub/personas/submit.html:13 src/olympia/editors/helpers.py:107 src/olympia/editors/templates/editors/base.html:26
+#: src/olympia/editors/templates/editors/performance.html:73 src/olympia/search/templates/search/personas.html:39 src/olympia/templates/menu_links.html:9
 msgid "Themes"
 msgstr "Teman"
 
@@ -1786,19 +1337,12 @@ msgstr "Visa alla populära tillägg"
 msgid "More Add-ons"
 msgstr "Fler tillägg"
 
-#: src/olympia/addons/templates/addons/mobile/home.html:72
-#: src/olympia/browse/templates/browse/personas/mobile/category_landing.html:64
-#: src/olympia/search/forms.py:14
+#: src/olympia/addons/templates/addons/mobile/home.html:72 src/olympia/browse/templates/browse/personas/mobile/category_landing.html:64 src/olympia/search/forms.py:14
 msgid "Highest Rated"
 msgstr "Högst betyg"
 
-#: src/olympia/addons/templates/addons/mobile/home.html:74
-#: src/olympia/amo/templates/amo/side_nav.html:5
-#: src/olympia/amo/templates/amo/site_nav.html:27
-#: src/olympia/amo/templates/amo/site_nav.html:57
-#: src/olympia/bandwagon/views.py:97 src/olympia/browse/views.py:57
-#: src/olympia/browse/views.py:67
-#: src/olympia/browse/templates/browse/personas/mobile/category_landing.html:65
+#: src/olympia/addons/templates/addons/mobile/home.html:74 src/olympia/amo/templates/amo/side_nav.html:5 src/olympia/amo/templates/amo/site_nav.html:27 src/olympia/amo/templates/amo/site_nav.html:55
+#: src/olympia/bandwagon/views.py:97 src/olympia/browse/views.py:57 src/olympia/browse/views.py:67 src/olympia/browse/templates/browse/personas/mobile/category_landing.html:65
 #: src/olympia/search/forms.py:15 src/olympia/search/forms.py:87
 msgid "Newest"
 msgstr "Nyast"
@@ -1811,122 +1355,90 @@ msgstr "Prova den!"
 msgid "Theme Info &raquo;"
 msgstr "Information om tema &raquo;"
 
-#: src/olympia/amo/context_processors.py:39
-#: src/olympia/devhub/templates/devhub/nav.html:43
+#: src/olympia/amo/context_processors.py:37 src/olympia/devhub/templates/devhub/nav.html:43
 msgid "Tools"
 msgstr "Verktyg"
 
-#: src/olympia/amo/context_processors.py:48
-#: src/olympia/discovery/templates/discovery/pane_account.html:8
-#: src/olympia/users/templates/users/includes/navigation.html:2
+#: src/olympia/amo/context_processors.py:47 src/olympia/discovery/templates/discovery/pane_account.html:8 src/olympia/users/templates/users/includes/navigation.html:2
 msgid "My Profile"
 msgstr "Min profil"
 
-#: src/olympia/amo/context_processors.py:54
-#: src/olympia/users/templates/users/edit.html:5
-#: src/olympia/users/templates/users/includes/navigation.html:3
+#: src/olympia/amo/context_processors.py:53 src/olympia/users/templates/users/edit.html:5 src/olympia/users/templates/users/includes/navigation.html:3
 msgid "Account Settings"
 msgstr "Kontoinställningar"
 
-#: src/olympia/amo/context_processors.py:57
-#: src/olympia/discovery/templates/discovery/pane_account.html:11
-#: src/olympia/users/templates/users/profile.html:83
+#: src/olympia/amo/context_processors.py:56 src/olympia/discovery/templates/discovery/pane_account.html:11 src/olympia/users/templates/users/profile.html:83
 #: src/olympia/users/templates/users/includes/navigation.html:4
 msgid "My Collections"
 msgstr "Mina samlingar"
 
-#: src/olympia/amo/context_processors.py:62
-#: src/olympia/discovery/templates/discovery/pane_account.html:10
-#: src/olympia/users/templates/users/includes/navigation.html:7
+#: src/olympia/amo/context_processors.py:61 src/olympia/discovery/templates/discovery/pane_account.html:10 src/olympia/users/templates/users/includes/navigation.html:7
 msgid "My Favorites"
 msgstr "Mina favoriter"
 
-#: src/olympia/amo/context_processors.py:67
-#: src/olympia/discovery/templates/discovery/pane_account.html:13
-#: src/olympia/templates/impala/user_login.html:14
+#: src/olympia/amo/context_processors.py:66 src/olympia/discovery/templates/discovery/pane_account.html:13 src/olympia/templates/impala/user_login.html:14
 #: src/olympia/templates/mobile/header_auth.html:5
 msgid "Log out"
 msgstr "Logga ut"
 
-#: src/olympia/amo/context_processors.py:72
-#: src/olympia/devhub/templates/devhub/addons/dashboard.html:4
+#: src/olympia/amo/context_processors.py:71 src/olympia/devhub/templates/devhub/addons/dashboard.html:4
 msgid "Manage My Submissions"
 msgstr "Hantera mina bidrag"
 
-#: src/olympia/amo/context_processors.py:75
-#: src/olympia/devhub/templates/devhub/nav.html:27
-#: src/olympia/devhub/templates/devhub/addons/dashboard.html:25
+#: src/olympia/amo/context_processors.py:74 src/olympia/devhub/templates/devhub/nav.html:27 src/olympia/devhub/templates/devhub/addons/dashboard.html:25
 #: src/olympia/devhub/templates/devhub/addons/submit/base.html:4
 msgid "Submit a New Add-on"
 msgstr "Skicka in ett nytt tillägg"
 
-#: src/olympia/amo/context_processors.py:77
-#: src/olympia/browse/templates/browse/personas/base.html:50
-#: src/olympia/devhub/templates/devhub/index.html:24
+#: src/olympia/amo/context_processors.py:76 src/olympia/browse/templates/browse/personas/base.html:50 src/olympia/devhub/templates/devhub/index.html:24
 #: src/olympia/devhub/templates/devhub/addons/dashboard.html:29
 msgid "Submit a New Theme"
 msgstr "Skicka in ett nytt tema"
 
-#: src/olympia/amo/context_processors.py:79
-#: src/olympia/amo/templates/amo/site_nav.html:87
-#: src/olympia/devhub/helpers.py:36 src/olympia/devhub/helpers.py:68
-#: src/olympia/devhub/helpers.py:102 src/olympia/templates/footer.html:6
-#: src/olympia/templates/menu_links.html:14
+#: src/olympia/amo/context_processors.py:78 src/olympia/amo/templates/amo/site_nav.html:85 src/olympia/devhub/helpers.py:36 src/olympia/devhub/helpers.py:68 src/olympia/devhub/helpers.py:102
+#: src/olympia/templates/footer.html:6 src/olympia/templates/menu_links.html:14
 msgid "Developer Hub"
 msgstr "Utvecklarcenter"
 
-#: src/olympia/amo/context_processors.py:83 src/olympia/devhub/views.py:1792
+#: src/olympia/amo/context_processors.py:81 src/olympia/devhub/views.py:1796
 msgid "Manage API Keys"
 msgstr "Hantera API-nycklar"
 
-#: src/olympia/amo/context_processors.py:88 src/olympia/editors/helpers.py:82
-#: src/olympia/editors/helpers.py:102
-#: src/olympia/editors/templates/editors/base.html:10
+#: src/olympia/amo/context_processors.py:86 src/olympia/editors/helpers.py:84 src/olympia/editors/helpers.py:104 src/olympia/editors/templates/editors/base.html:10
 msgid "Editor Tools"
 msgstr "Redigeringsverktyg"
 
-#: src/olympia/amo/context_processors.py:92
+#: src/olympia/amo/context_processors.py:90
 msgid "Admin Tools"
 msgstr "Adminverktyg"
 
-#: src/olympia/amo/fields.py:15
+#: src/olympia/amo/fields.py:20
 msgid "Incorrect, please try again."
 msgstr "Felaktig, försök igen."
 
-#: src/olympia/amo/fields.py:16
+#: src/olympia/amo/fields.py:21
 msgid "Error verifying input, please try again."
 msgstr "Fel vid kontroll av input, försök igen."
 
-#: src/olympia/amo/fields.py:32
+#: src/olympia/amo/fields.py:37
 msgid "This must be a valid hex color code, such as #000000."
 msgstr "Detta måste vara en giltig hexadecimal färgkod, till exempel #000000."
 
-#: src/olympia/amo/fields.py:58
+#: src/olympia/amo/fields.py:63
 msgid "Enter at least one value."
 msgstr "Ange minst ett värde."
 
-#: src/olympia/amo/helpers.py:162
-#: src/olympia/amo/templates/amo/site_nav.html:61
-#: src/olympia/bandwagon/templates/bandwagon/add.html:9
-#: src/olympia/bandwagon/templates/bandwagon/collection_detail.html:15
-#: src/olympia/bandwagon/templates/bandwagon/delete.html:9
-#: src/olympia/bandwagon/templates/bandwagon/edit.html:15
-#: src/olympia/bandwagon/templates/bandwagon/user_listing.html:18
-#: src/olympia/bandwagon/templates/bandwagon/user_listing.html:21
-#: src/olympia/bandwagon/templates/bandwagon/impala/collection_listing.html:12
-#: src/olympia/bandwagon/templates/bandwagon/impala/collection_listing.html:20
-#: src/olympia/bandwagon/templates/bandwagon/impala/collection_listing.html:24
-#: src/olympia/bandwagon/templates/bandwagon/impala/collection_sidebar.html:3
-#: src/olympia/bandwagon/templates/bandwagon/includes/collection_sidebar.html:2
-#: src/olympia/bandwagon/templates/bandwagon/mobile/collection_listing.html:3
-#: src/olympia/stats/templates/stats/stats.html:77
-#: src/olympia/templates/menu_links.html:12
+#: src/olympia/amo/helpers.py:162 src/olympia/amo/templates/amo/site_nav.html:59 src/olympia/bandwagon/templates/bandwagon/add.html:9
+#: src/olympia/bandwagon/templates/bandwagon/collection_detail.html:15 src/olympia/bandwagon/templates/bandwagon/delete.html:9 src/olympia/bandwagon/templates/bandwagon/edit.html:15
+#: src/olympia/bandwagon/templates/bandwagon/user_listing.html:18 src/olympia/bandwagon/templates/bandwagon/user_listing.html:21
+#: src/olympia/bandwagon/templates/bandwagon/impala/collection_listing.html:12 src/olympia/bandwagon/templates/bandwagon/impala/collection_listing.html:20
+#: src/olympia/bandwagon/templates/bandwagon/impala/collection_listing.html:24 src/olympia/bandwagon/templates/bandwagon/impala/collection_sidebar.html:3
+#: src/olympia/bandwagon/templates/bandwagon/includes/collection_sidebar.html:2 src/olympia/bandwagon/templates/bandwagon/mobile/collection_listing.html:3
+#: src/olympia/stats/templates/stats/stats.html:33 src/olympia/templates/menu_links.html:12
 msgid "Collections"
 msgstr "Samlingar"
 
-#: src/olympia/amo/helpers.py:171
-#: src/olympia/amo/templates/amo/site_nav.html:85
-#: src/olympia/browse/templates/browse/language_tools.html:3
+#: src/olympia/amo/helpers.py:171 src/olympia/amo/templates/amo/site_nav.html:83 src/olympia/browse/templates/browse/language_tools.html:3
 msgid "Dictionaries & Language Packs"
 msgstr "Ordlistor & språkpaket"
 
@@ -2078,11 +1590,8 @@ msgstr "Supergranskning begärd"
 msgid "Comment on {addon} {version}."
 msgstr "Kommentar till {addon} {version}."
 
-#: src/olympia/amo/log.py:236
-#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:19
-#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:47
-#: src/olympia/editors/helpers.py:511
-#: src/olympia/editors/templates/editors/themes/history_table.html:11
+#: src/olympia/amo/log.py:236 src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:17 src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:45
+#: src/olympia/editors/helpers.py:584 src/olympia/editors/templates/editors/themes/history_table.html:11
 msgid "Comment"
 msgstr "Kommentar"
 
@@ -2237,7 +1746,6 @@ msgstr "Upptrappning granskare"
 #: src/olympia/amo/log.py:442
 msgid "Video removed from {addon} because of a problem with the video. "
 msgstr ""
-"Video borttagen från {addon} för att det var ett problem med videon.  "
 
 #: src/olympia/amo/log.py:444
 msgid "Video removed"
@@ -2341,10 +1849,7 @@ msgstr "{addon} innehållsklassificering ändrad."
 msgid "{addon} unlisted."
 msgstr "{addon} olistad."
 
-#: src/olympia/amo/log.py:592 src/olympia/amo/log.py:598
-#: src/olympia/amo/log.py:612 src/olympia/amo/log.py:618
-#: src/olympia/amo/log.py:624 src/olympia/amo/log.py:630
-#: src/olympia/amo/log.py:636
+#: src/olympia/amo/log.py:592 src/olympia/amo/log.py:598 src/olympia/amo/log.py:612 src/olympia/amo/log.py:618 src/olympia/amo/log.py:624 src/olympia/amo/log.py:630 src/olympia/amo/log.py:636
 msgid "{file} was signed."
 msgstr "{file} signerades."
 
@@ -2358,20 +1863,12 @@ msgid "Not allowed"
 msgstr "Inte tillåtet"
 
 #: src/olympia/amo/templates/amo/403.html:7
-msgid ""
-"<h1>Oops! Not allowed.</h1> <p>You tried to do something that you weren't "
-"allowed to.</p>"
-msgstr ""
-"<h1>Hoppsan! Inte tillåtet.</h1> <p>Du försökte göra något som du inte "
-"fick.</p>"
+msgid "<h1>Oops! Not allowed.</h1> <p>You tried to do something that you weren't allowed to.</p>"
+msgstr "<h1>Hoppsan! Inte tillåtet.</h1> <p>Du försökte göra något som du inte fick.</p>"
 
 #: src/olympia/amo/templates/amo/403.html:12
-msgid ""
-"<p>Try going back to the previous page, refreshing and then trying "
-"again.</p>"
-msgstr ""
-"<p>Försök att gå tillbaka till föregående sida, uppdatera och försök "
-"igen.</p> "
+msgid "<p>Try going back to the previous page, refreshing and then trying again.</p>"
+msgstr "<p>Försök att gå tillbaka till föregående sida, uppdatera och försök igen.</p> "
 
 #: src/olympia/amo/templates/amo/404.html:3
 msgid "Not Found"
@@ -2380,35 +1877,18 @@ msgstr "Hittades inte"
 #: src/olympia/amo/templates/amo/404.html:6
 #, python-format
 msgid ""
-"<h1>We're sorry, but we can't find what you're looking for.</h1> <p> The "
-"page or file you requested wasn't found on our site. It's possible that you "
-"clicked a link that's out of date, or typed in the address incorrectly. </p>"
-" <ul> <li>If you typed in the address, please double check the "
-"spelling.</li> <li> If you followed a link from somewhere, please let us "
-"know at <a href=\"mailto:webmaster@mozilla.com\">webmaster@mozilla.com</a>. "
-"Tell us where you came from and what you were looking for, and we'll do our "
-"best to fix it. </li> </ul> <p>Or you can just jump over to some of the "
-"popular pages on our website.</p> <ul> <li>Are you interested in a <a "
-"href=\"%(rec)s\">list of featured add-ons</a>?</li> <li> Do you want to <a "
-"href=\"%(search)s\">search for add-ons</a>? You may go to the <a "
-"href=\"%(search)s\">search page</a> or just use the search field above. "
-"</li> <li> If you prefer to start over, just go to the <a href=\"%(home)s"
-"\">add-ons front page</a>. </li> </ul>"
+"<h1>We're sorry, but we can't find what you're looking for.</h1> <p> The page or file you requested wasn't found on our site. It's possible that you clicked a link that's out of date, or typed in "
+"the address incorrectly. </p> <ul> <li>If you typed in the address, please double check the spelling.</li> <li> If you followed a link from somewhere, please let us know at <a href=\"mailto:"
+"webmaster@mozilla.com\">webmaster@mozilla.com</a>. Tell us where you came from and what you were looking for, and we'll do our best to fix it. </li> </ul> <p>Or you can just jump over to some of "
+"the popular pages on our website.</p> <ul> <li>Are you interested in a <a href=\"%(rec)s\">list of featured add-ons</a>?</li> <li> Do you want to <a href=\"%(search)s\">search for add-ons</a>? You "
+"may go to the <a href=\"%(search)s\">search page</a> or just use the search field above. </li> <li> If you prefer to start over, just go to the <a href=\"%(home)s\">add-ons front page</a>. </li> </"
+"ul>"
 msgstr ""
-"<h1>Tyvärr, men vi kan inte hitta det du letar efter.</h1> <p> Sidan eller "
-"filen du ville nå hittades inte på vår webbplats. Det är möjligt att du "
-"klickade på en gammal länk eller skrev in adressen fel.</p> <ul> <li>Om du "
-"skrev in adressen, dubbelkolla stavningen.</li> <li>Om du följde en länk "
-"hit, berätta för oss på <a "
-"href=\"mailto:webmaster@mozilla.com\">webmaster@mozilla.com</a>. Berätta var"
-" du kom ifrån och vad du letade efter så ska vi göra vårt bästa för att fixa"
-" det (skriv på engelska).</li> </ul> <p>Eller så kan du hoppa över till "
-"några av de mest populära sidorna på webbplats.</p>< ul> <li>Är du "
-"intresserad av <a href=\"%(rec)s\">en lista över utvalda tillägg</a>?</li> "
-"<li> Vill du <a href=\"%(search)s\">söka efter tillägg</a>? Då kan du gå "
-"till <a href=\"%(search)s\">söksidan</a> eller helt enkelt använda sökfältet"
-" ovan.</li> <li> Om du vill börja om behöver du bara gå till <a "
-"href=\"%(home)s\">startsidan för tillägg</a>. </li> </ul>"
+"<h1>Tyvärr, men vi kan inte hitta det du letar efter.</h1> <p> Sidan eller filen du ville nå hittades inte på vår webbplats. Det är möjligt att du klickade på en gammal länk eller skrev in adressen "
+"fel.</p> <ul> <li>Om du skrev in adressen, dubbelkolla stavningen.</li> <li>Om du följde en länk hit, berätta för oss på <a href=\"mailto:webmaster@mozilla.com\">webmaster@mozilla.com</a>. Berätta "
+"var du kom ifrån och vad du letade efter så ska vi göra vårt bästa för att fixa det (skriv på engelska).</li> </ul> <p>Eller så kan du hoppa över till några av de mest populära sidorna på webbplats."
+"</p>< ul> <li>Är du intresserad av <a href=\"%(rec)s\">en lista över utvalda tillägg</a>?</li> <li> Vill du <a href=\"%(search)s\">söka efter tillägg</a>? Då kan du gå till <a href=\"%(search)s"
+"\">söksidan</a> eller helt enkelt använda sökfältet ovan.</li> <li> Om du vill börja om behöver du bara gå till <a href=\"%(home)s\">startsidan för tillägg</a>. </li> </ul>"
 
 #: src/olympia/amo/templates/amo/500.html:3
 msgid "Oops"
@@ -2416,83 +1896,49 @@ msgstr "Hoppsan"
 
 #: src/olympia/amo/templates/amo/500.html:6
 #, python-format
-msgid ""
-"<h1>Oops!  We had an error.</h1> <p>We'll get to fixing that soon.</p> <p> "
-"You can try refreshing the page, or head back to the <a href=\"%(home)s"
-"\">Add-ons homepage</a>. </p>"
+msgid "<h1>Oops!  We had an error.</h1> <p>We'll get to fixing that soon.</p> <p> You can try refreshing the page, or head back to the <a href=\"%(home)s\">Add-ons homepage</a>. </p>"
 msgstr ""
-"<h1>Hoppsan!  Något gick fel.</h1> <p>Vi kommer att fixa det snart.</p> <p> "
-"Du kan försöka uppdatera sidan eller gå tillbaka till <a "
-"href=\"%(home)s\">startsidan för tillägg</a>. </p>"
 
 #: src/olympia/amo/templates/amo/license_link.html:10
 msgid "Some rights reserved"
 msgstr "Vissa rättigheter reserverade"
 
-#: src/olympia/amo/templates/amo/no_results.html:1
-#: src/olympia/editors/templates/editors/includes/search_results_themes.html:26
+#: src/olympia/amo/templates/amo/no_results.html:1 src/olympia/editors/templates/editors/includes/search_results_themes.html:26
 msgid "No results found"
 msgstr "Inga träffar hittades"
 
 #. abbreviation of 'previous'
-#: src/olympia/amo/templates/amo/paginator.html:6
-#: src/olympia/amo/templates/amo/mobile/paginator.html:4
-#: src/olympia/amo/templates/amo/mobile/paginator.html:6
-#: src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:49
-#: src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:63
-#: src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:76
-#: src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:89
+#: src/olympia/amo/templates/amo/paginator.html:6 src/olympia/amo/templates/amo/mobile/paginator.html:4 src/olympia/amo/templates/amo/mobile/paginator.html:6
+#: src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:49 src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:63
+#: src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:76 src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:89
 #: src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:102
 msgid "Prev"
 msgstr "Föreg"
 
-#: src/olympia/amo/templates/amo/paginator.html:26
-#: src/olympia/amo/templates/amo/impala/paginator.html:26
-#: src/olympia/amo/templates/amo/mobile/impala_paginator.html:16
-#: src/olympia/amo/templates/amo/mobile/paginator.html:14
-#: src/olympia/amo/templates/amo/mobile/paginator.html:16
-#: src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:51
-#: src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:65
-#: src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:78
-#: src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:91
-#: src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:104
-#: src/olympia/discovery/templates/discovery/pane.html:45
-#: src/olympia/discovery/templates/discovery/addons/detail.html:39
-#: src/olympia/stats/templates/stats/stats.html:167
+#: src/olympia/amo/templates/amo/paginator.html:26 src/olympia/amo/templates/amo/impala/paginator.html:26 src/olympia/amo/templates/amo/mobile/impala_paginator.html:16
+#: src/olympia/amo/templates/amo/mobile/paginator.html:14 src/olympia/amo/templates/amo/mobile/paginator.html:16 src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:51
+#: src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:65 src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:78
+#: src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:91 src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:104
+#: src/olympia/discovery/templates/discovery/pane.html:45 src/olympia/discovery/templates/discovery/addons/detail.html:39 src/olympia/stats/templates/stats/stats.html:169
 msgid "Next"
 msgstr "Nästa"
 
-#: src/olympia/amo/templates/amo/paginator.html:32
-#: src/olympia/editors/templates/editors/includes/paginator_history.html:11
+#: src/olympia/amo/templates/amo/paginator.html:32 src/olympia/editors/templates/editors/includes/paginator_history.html:11
 #, python-format
-msgid ""
-"Results <strong>%(begin)s</strong>&ndash;<strong>%(end)s</strong> of "
-"<strong>%(count)s</strong>"
-msgstr ""
-"Resultat <strong>%(begin)s</strong>&ndash;<strong>%(end)s</strong> av "
-"<strong>%(count)s</strong>"
+msgid "Results <strong>%(begin)s</strong>&ndash;<strong>%(end)s</strong> of <strong>%(count)s</strong>"
+msgstr "Resultat <strong>%(begin)s</strong>&ndash;<strong>%(end)s</strong> av <strong>%(count)s</strong>"
 
-#: src/olympia/amo/templates/amo/read-only.html:3
-#: src/olympia/amo/templates/amo/read-only.html:7
+#: src/olympia/amo/templates/amo/read-only.html:3 src/olympia/amo/templates/amo/read-only.html:7
 msgid "Maintenance in progress"
 msgstr "Underhåll pågår"
 
 #: src/olympia/amo/templates/amo/read-only.html:9
-msgid ""
-"This feature is temporarily disabled while we perform website maintenance. "
-"Please use your browser's Back button and try again a little later."
-msgstr ""
-"Denna funktion är tillfälligt avstängd medan vi utför underhåll på "
-"webbplatsen. Använd bakåtknappen i din webbläsare och försök igen lite "
-"senare."
+msgid "This feature is temporarily disabled while we perform website maintenance. Please use your browser's Back button and try again a little later."
+msgstr "Denna funktion är tillfälligt avstängd medan vi utför underhåll på webbplatsen. Använd bakåtknappen i din webbläsare och försök igen lite senare."
 
 #: src/olympia/amo/templates/amo/read-only.html:14
-msgid ""
-"Some features on this page are temporarily disabled while we perform website"
-" maintenance. Please try again a little later."
-msgstr ""
-"Vissa funktioner på denna sida är för tillfället inaktiva eftersom vi utför "
-"underhåll av webbplatsen. Försök igen lite senare."
+msgid "Some features on this page are temporarily disabled while we perform website maintenance. Please try again a little later."
+msgstr "Vissa funktioner på denna sida är för tillfället inaktiva eftersom vi utför underhåll av webbplatsen. Försök igen lite senare."
 
 #: src/olympia/amo/templates/amo/recaptcha.html:4
 msgid "Are you human?"
@@ -2500,24 +1946,14 @@ msgstr "Är du en människa?"
 
 #: src/olympia/amo/templates/amo/recaptcha.html:8
 msgid ""
-"<p> Please enter <strong>all the words</strong> below, <strong>separated by "
-"a space if necessary</strong>. </p> <p> If this is hard to read, you can <a "
-"href=\"#\" id=\"recaptcha_different\">try different words</a> or <a "
-"href=\"#\" id=\"recaptcha_audio\">try a different type of challenge</a> "
-"instead. </p>"
+"<p> Please enter <strong>all the words</strong> below, <strong>separated by a space if necessary</strong>. </p> <p> If this is hard to read, you can <a href=\"#\" id=\"recaptcha_different\">try "
+"different words</a> or <a href=\"#\" id=\"recaptcha_audio\">try a different type of challenge</a> instead. </p>"
 msgstr ""
-"<p> Ange <strong>alla ord</strong> nedan <strong>med ett mellanslag vid "
-"behov</strong>. </p> <p> Om det är svårt att läsa kan du <a href=\"#\" "
-"id=\"recaptcha_different\">försöka med andra ord </a> eller <a href=\"#\" "
-"id=\"recaptcha_audio\">prova en annan typ av utmaning</a> istället. </p>"
+"<p> Ange <strong>alla ord</strong> nedan <strong>med ett mellanslag vid behov</strong>. </p> <p> Om det är svårt att läsa kan du <a href=\"#\" id=\"recaptcha_different\">försöka med andra ord </a> "
+"eller <a href=\"#\" id=\"recaptcha_audio\">prova en annan typ av utmaning</a> istället. </p>"
 
-#: src/olympia/amo/templates/amo/side_nav.html:4
-#: src/olympia/amo/templates/amo/side_nav.html:12
-#: src/olympia/amo/templates/amo/site_nav.html:4
-#: src/olympia/amo/templates/amo/site_nav.html:26
-#: src/olympia/browse/views.py:56 src/olympia/browse/views.py:66
-#: src/olympia/browse/views.py:237 src/olympia/browse/views.py:282
-#: src/olympia/search/forms.py:86
+#: src/olympia/amo/templates/amo/side_nav.html:4 src/olympia/amo/templates/amo/side_nav.html:12 src/olympia/amo/templates/amo/site_nav.html:4 src/olympia/amo/templates/amo/site_nav.html:26
+#: src/olympia/browse/views.py:56 src/olympia/browse/views.py:66 src/olympia/browse/views.py:204 src/olympia/browse/views.py:249 src/olympia/search/forms.py:86
 msgid "Top Rated"
 msgstr "Högst rankade"
 
@@ -2525,81 +1961,60 @@ msgstr "Högst rankade"
 msgid "Explore"
 msgstr "Utforska"
 
-#: src/olympia/amo/templates/amo/site_nav.html:23
-#: src/olympia/browse/feeds.py:65 src/olympia/browse/feeds.py:78
-#: src/olympia/browse/feeds.py:92 src/olympia/browse/feeds.py:100
-#: src/olympia/browse/templates/browse/base_listing.html:7
-#: src/olympia/browse/templates/browse/creatured.html:10
-#: src/olympia/browse/templates/browse/impala/base_listing.html:37
+#: src/olympia/amo/templates/amo/site_nav.html:23 src/olympia/browse/feeds.py:65 src/olympia/browse/feeds.py:78 src/olympia/browse/feeds.py:92 src/olympia/browse/feeds.py:100
+#: src/olympia/browse/templates/browse/base_listing.html:7 src/olympia/browse/templates/browse/creatured.html:10 src/olympia/browse/templates/browse/impala/base_listing.html:37
 #: src/olympia/constants/base.py:173 src/olympia/templates/menu_links.html:8
 msgid "Extensions"
 msgstr "Utökningar"
 
-#: src/olympia/amo/templates/amo/site_nav.html:45
+#: src/olympia/amo/templates/amo/site_nav.html:44
 msgid "Want more customization? Try <b>Complete Themes</b>"
 msgstr "Vill du ha mer anpassning? Prova <b>kompletta teman</b>"
 
-#: src/olympia/amo/templates/amo/site_nav.html:56
-#: src/olympia/bandwagon/views.py:96
+#: src/olympia/amo/templates/amo/site_nav.html:54 src/olympia/bandwagon/views.py:96
 msgid "Most Followers"
 msgstr "Flest följare"
 
-#: src/olympia/amo/templates/amo/site_nav.html:68
-#: src/olympia/bandwagon/templates/bandwagon/impala/collection_sidebar.html:16
+#: src/olympia/amo/templates/amo/site_nav.html:66 src/olympia/bandwagon/templates/bandwagon/impala/collection_sidebar.html:16
 #: src/olympia/bandwagon/templates/bandwagon/includes/collection_sidebar.html:18
 msgid "Collections I've Made"
 msgstr "Samlingar jag skapat"
 
-#: src/olympia/amo/templates/amo/site_nav.html:70
-#: src/olympia/bandwagon/templates/bandwagon/user_listing.html:4
-#: src/olympia/bandwagon/templates/bandwagon/impala/collection_sidebar.html:13
+#: src/olympia/amo/templates/amo/site_nav.html:68 src/olympia/bandwagon/templates/bandwagon/user_listing.html:4 src/olympia/bandwagon/templates/bandwagon/impala/collection_sidebar.html:13
 #: src/olympia/bandwagon/templates/bandwagon/includes/collection_sidebar.html:15
 msgid "Collections I'm Following"
 msgstr "Samlingar jag följer"
 
-#: src/olympia/amo/templates/amo/site_nav.html:73
-#: src/olympia/bandwagon/templates/bandwagon/impala/collection_sidebar.html:18
-#: src/olympia/bandwagon/templates/bandwagon/includes/collection_sidebar.html:20
-#: src/olympia/users/models.py:512
+#: src/olympia/amo/templates/amo/site_nav.html:71 src/olympia/bandwagon/templates/bandwagon/impala/collection_sidebar.html:18
+#: src/olympia/bandwagon/templates/bandwagon/includes/collection_sidebar.html:20 src/olympia/users/models.py:521
 msgid "My Favorite Add-ons"
 msgstr "Mina favorittillägg"
 
-#: src/olympia/amo/templates/amo/site_nav.html:78
+#: src/olympia/amo/templates/amo/site_nav.html:76
 msgid "More&hellip;"
 msgstr "Mer&hellip;"
 
-#: src/olympia/amo/templates/amo/site_nav.html:82
+#: src/olympia/amo/templates/amo/site_nav.html:80
 msgid "Add-ons for Mobile"
 msgstr "Tillägg för mobil"
 
-#: src/olympia/amo/templates/amo/site_nav.html:86
-#: src/olympia/browse/feeds.py:207
-#: src/olympia/browse/templates/browse/search_tools.html:3
-#: src/olympia/constants/base.py:176 src/olympia/templates/menu_links.html:10
+#: src/olympia/amo/templates/amo/site_nav.html:84 src/olympia/browse/feeds.py:207 src/olympia/browse/templates/browse/search_tools.html:3 src/olympia/constants/base.py:176
+#: src/olympia/templates/menu_links.html:10
 msgid "Search Tools"
 msgstr "Sökverktyg"
 
 #. This is a page range (e.g., Page 1 of 50).
-#: src/olympia/amo/templates/amo/impala/paginator.html:5
-#: src/olympia/amo/templates/amo/mobile/impala_paginator.html:26
+#: src/olympia/amo/templates/amo/impala/paginator.html:5 src/olympia/amo/templates/amo/mobile/impala_paginator.html:26
 #, python-format
-msgid ""
-"Page <a href=\"%(current_pg_url)s\">%(current_pg)s</a> of <a "
-"href=\"%(last_pg_url)s\">%(last_pg)s</a>"
-msgstr ""
-"Sida <a href=\"%(current_pg_url)s\">%(current_pg)s</a> av <a "
-"href=\"%(last_pg_url)s\">%(last_pg)s</a>"
+msgid "Page <a href=\"%(current_pg_url)s\">%(current_pg)s</a> of <a href=\"%(last_pg_url)s\">%(last_pg)s</a>"
+msgstr "Sida <a href=\"%(current_pg_url)s\">%(current_pg)s</a> av <a href=\"%(last_pg_url)s\">%(last_pg)s</a>"
 
-#: src/olympia/amo/templates/amo/impala/paginator.html:16
-#: src/olympia/amo/templates/amo/mobile/impala_paginator.html:6
+#: src/olympia/amo/templates/amo/impala/paginator.html:16 src/olympia/amo/templates/amo/mobile/impala_paginator.html:6
 msgid "Jump to first page"
 msgstr "Gå till första sidan"
 
-#: src/olympia/amo/templates/amo/impala/paginator.html:22
-#: src/olympia/amo/templates/amo/mobile/impala_paginator.html:12
-#: src/olympia/discovery/templates/discovery/pane.html:44
-#: src/olympia/discovery/templates/discovery/addons/detail.html:38
-#: src/olympia/stats/templates/stats/stats.html:164
+#: src/olympia/amo/templates/amo/impala/paginator.html:22 src/olympia/amo/templates/amo/mobile/impala_paginator.html:12 src/olympia/discovery/templates/discovery/pane.html:44
+#: src/olympia/discovery/templates/discovery/addons/detail.html:38 src/olympia/stats/templates/stats/stats.html:166
 msgid "Previous"
 msgstr "Föregående"
 
@@ -2609,10 +2024,9 @@ msgstr "Hoppa till sista sidan"
 
 #. First and second arguments are the result range (e.g., 1-20);
 #. third argument is the number of total results (e.g., 1,000).
-#. third
+#. First and second arguments are the result range (e.g., 1-20);              third
 #. argument is the number of total results (e.g., 1,000).
-#: src/olympia/amo/templates/amo/impala/paginator.html:36
-#: src/olympia/amo/templates/amo/mobile/impala_paginator.html:38
+#: src/olympia/amo/templates/amo/impala/paginator.html:36 src/olympia/amo/templates/amo/mobile/impala_paginator.html:38
 #, python-format
 msgid "Showing <b>%(begin)s</b>&ndash;<b>%(end)s</b> of <b>%(count)s</b>"
 msgstr "Visar <b>%(begin)s</b>&ndash;<b>%(end)s</b> av <b>%(count)s</b>"
@@ -2623,42 +2037,52 @@ msgid_plural "Page {n}"
 msgstr[0] "Sida {n}"
 msgstr[1] "Sida {n}"
 
-#: src/olympia/amo/templates/services/install.html:38
-#, python-format
-msgid ""
-"If you are not prompted to install %(addon_name)s in a moment, please <a "
-"href=\"%(addon_xpi)s\">click here</a>."
-msgstr ""
-"Om du inte uppmanas att installera %(addon_name)s om ett ögonblick, <a "
-"href=\"%(addon_xpi)s\">klicka här</a>."
-
-#: src/olympia/amo/tests/test_messages.py:57
-#: src/olympia/amo/tests/test_messages.py:58 src/olympia/reviews/forms.py:25
-#: src/olympia/reviews/forms.py:50
-#: src/olympia/reviews/templates/reviews/add.html:56
+#: src/olympia/amo/tests/test_messages.py:56 src/olympia/amo/tests/test_messages.py:57 src/olympia/reviews/forms.py:25 src/olympia/reviews/forms.py:50 src/olympia/reviews/templates/reviews/add.html:56
 #: src/olympia/reviews/templates/reviews/reply.html:30
 msgid "Title"
 msgstr "Titel"
 
-#: src/olympia/amo/tests/test_messages.py:57
-#: src/olympia/amo/tests/test_messages.py:58
+#: src/olympia/amo/tests/test_messages.py:56 src/olympia/amo/tests/test_messages.py:57
 msgid "Body"
 msgstr "Innehåll"
 
-#: src/olympia/amo/tests/test_messages.py:59
+#: src/olympia/amo/tests/test_messages.py:58
 msgid "Another Title"
 msgstr "En annan titel"
 
-#: src/olympia/amo/tests/test_messages.py:59
+#: src/olympia/amo/tests/test_messages.py:58
 msgid "Another Body"
 msgstr "Ett annat innehåll"
 
-#: src/olympia/api/views.py:255
-msgid "Not implemented yet."
-msgstr "Inte implementerat ännu."
+#: src/olympia/api/authentication.py:76
+msgid "Signature has expired."
+msgstr ""
 
-#: src/olympia/applications/views.py:39
-#: src/olympia/applications/templates/applications/appversions.html:3
+#: src/olympia/api/authentication.py:79
+msgid "Error decoding signature."
+msgstr ""
+
+#: src/olympia/api/authentication.py:82
+msgid "Invalid JWT Token."
+msgstr ""
+
+#: src/olympia/api/authentication.py:130
+msgid "Invalid Authorization header. No credentials provided."
+msgstr ""
+
+#: src/olympia/api/authentication.py:133
+msgid "Invalid Authorization header. Credentials string should not contain spaces."
+msgstr ""
+
+#: src/olympia/api/fields.py:29
+msgid "The field must have a length of at least {num} characters."
+msgstr ""
+
+#: src/olympia/api/fields.py:31
+msgid "The language code {lang_code} is invalid."
+msgstr ""
+
+#: src/olympia/applications/views.py:39 src/olympia/applications/templates/applications/appversions.html:3
 msgid "Application Versions"
 msgstr "Applikationsversioner"
 
@@ -2671,22 +2095,15 @@ msgid "Valid Application Versions"
 msgstr "Giltiga applikationsversioner"
 
 #: src/olympia/applications/templates/applications/appversions.html:12
-msgid ""
-"Add-ons submitted to Mozilla Add-ons must have a manifest file with at least"
-" one of the below applications supported. Only the versions listed below are"
-" allowed for these applications."
-msgstr ""
-"Tillägg inlämnat till Mozilla Add-ons måste ha en manifest-fil med support "
-"för minst ett av nedanstående program. Enbart de versioner som angetts nedan"
-" är tillåtna för dessa applikationer."
+msgid "Add-ons submitted to Mozilla Add-ons must have a manifest file with at least one of the below applications supported. Only the versions listed below are allowed for these applications."
+msgstr "Tillägg inlämnat till Mozilla Add-ons måste ha en manifest-fil med support för minst ett av nedanstående program. Enbart de versioner som angetts nedan är tillåtna för dessa applikationer."
 
-#: src/olympia/applications/templates/applications/appversions.html:25
+#: src/olympia/applications/templates/applications/appversions.html:25 src/olympia/editors/helpers.py:361
 msgid "GUID"
 msgstr "GUID"
 
 #. {0} is an add-on name.
-#: src/olympia/applications/templates/applications/appversions.html:26
-#: src/olympia/versions/templates/versions/version_list.html:23
+#: src/olympia/applications/templates/applications/appversions.html:26 src/olympia/versions/templates/versions/version_list.html:23
 msgid "Versions"
 msgstr "Versioner"
 
@@ -2696,14 +2113,8 @@ msgstr "http://developer.mozilla.org/en/docs/Install_Manifests"
 
 #: src/olympia/applications/templates/applications/appversions.html:31
 #, python-format
-msgid ""
-"If your supported application does not require a manifest file, you still "
-"must include one with the required properties as specified <a "
-"href=\"%(url)s\">here</a>."
-msgstr ""
-"Om din applikation som stöds inte kräver en manifest-fil behöver du "
-"fortfarande inkludera en av följande egenskaper enligt specifikationen <a "
-"href=\"%(url)s\">här</a>."
+msgid "If your supported application does not require a manifest file, you still must include one with the required properties as specified <a href=\"%(url)s\">here</a>."
+msgstr "Om din applikation som stöds inte kräver en manifest-fil behöver du fortfarande inkludera en av följande egenskaper enligt specifikationen <a href=\"%(url)s\">här</a>."
 
 #. L10n: {0} is 'Add-ons for <app>'.
 #: src/olympia/bandwagon/feeds.py:44
@@ -2711,10 +2122,8 @@ msgstr ""
 msgid "Collections :: %s"
 msgstr "Samlingar :: %s"
 
-#: src/olympia/bandwagon/feeds.py:50
-#: src/olympia/bandwagon/templates/bandwagon/collection_detail.html:137
-msgid ""
-"Collections are groups of related add-ons that anyone can create and share."
+#: src/olympia/bandwagon/feeds.py:50 src/olympia/bandwagon/templates/bandwagon/collection_detail.html:137
+msgid "Collections are groups of related add-ons that anyone can create and share."
 msgstr "Samlingar är grupper av tillägg som vem som helst kan skapa och dela."
 
 #. L10n: {0} is a collection name, {1} is 'Add-ons for <app>'.
@@ -2770,8 +2179,7 @@ msgstr "Denna URL används redan av en annan samling"
 msgid "Icons must be either PNG or JPG."
 msgstr "Ikoner måste vara antingen PNG eller JPG."
 
-#: src/olympia/bandwagon/forms.py:202 src/olympia/devhub/views.py:1067
-#: src/olympia/users/forms.py:476
+#: src/olympia/bandwagon/forms.py:202 src/olympia/devhub/views.py:1067 src/olympia/users/forms.py:476
 #, python-format
 msgid "Please use images smaller than %dMB."
 msgstr "Använd bilder mindre än %dMB."
@@ -2792,8 +2200,7 @@ msgstr "Ta bort min röst för denna samling."
 msgid "Log in to vote for this collection"
 msgstr "Logga in för att rösta på denna samling."
 
-#: src/olympia/bandwagon/helpers.py:123
-#: src/olympia/bandwagon/templates/bandwagon/favorites_widget.html:2
+#: src/olympia/bandwagon/helpers.py:123 src/olympia/bandwagon/templates/bandwagon/favorites_widget.html:2
 msgid "Add to favorites"
 msgstr "Lägg till i favoriter"
 
@@ -2801,20 +2208,13 @@ msgstr "Lägg till i favoriter"
 msgid "Favorite"
 msgstr "Favorit"
 
-#: src/olympia/bandwagon/helpers.py:124
-#: src/olympia/bandwagon/templates/bandwagon/favorites_widget.html:2
+#: src/olympia/bandwagon/helpers.py:124 src/olympia/bandwagon/templates/bandwagon/favorites_widget.html:2
 msgid "Remove from favorites"
 msgstr "Ta bort från favoriter"
 
-#: src/olympia/bandwagon/views.py:98 src/olympia/bandwagon/views.py:191
-#: src/olympia/browse/views.py:58 src/olympia/browse/views.py:69
-#: src/olympia/browse/views.py:458 src/olympia/devhub/views.py:74
-#: src/olympia/devhub/views.py:82
-#: src/olympia/devhub/templates/devhub/addons/edit/basic.html:20
-#: src/olympia/editors/templates/editors/leaderboard.html:24
-#: src/olympia/editors/templates/editors/themes/queue_list.html:48
-#: src/olympia/search/forms.py:17 src/olympia/search/forms.py:89
-#: src/olympia/users/templates/users/vcard.html:5
+#: src/olympia/bandwagon/views.py:98 src/olympia/bandwagon/views.py:191 src/olympia/browse/views.py:58 src/olympia/browse/views.py:69 src/olympia/browse/views.py:425 src/olympia/devhub/views.py:72
+#: src/olympia/devhub/views.py:80 src/olympia/devhub/templates/devhub/addons/edit/basic.html:20 src/olympia/editors/templates/editors/leaderboard.html:24
+#: src/olympia/editors/templates/editors/themes/queue_list.html:48 src/olympia/search/forms.py:17 src/olympia/search/forms.py:89 src/olympia/users/templates/users/vcard.html:5
 msgid "Name"
 msgstr "Namn"
 
@@ -2822,8 +2222,7 @@ msgstr "Namn"
 msgid "Recently Popular"
 msgstr "Nyligen populära"
 
-#: src/olympia/bandwagon/views.py:189
-#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:18
+#: src/olympia/bandwagon/views.py:189 src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:16
 msgid "Added"
 msgstr "Tillagd"
 
@@ -2837,12 +2236,8 @@ msgstr "Samling skapad!"
 
 #: src/olympia/bandwagon/views.py:316
 #, python-format
-msgid ""
-"Your new collection is shown below. You can <ahref=\"%(url)s\">edit "
-"additional settings</a> if you'dlike."
+msgid "Your new collection is shown below. You can <a href=\"%(url)s\">edit additional settings</a> if you'd like."
 msgstr ""
-"Din nya samlingen visas nedan. Du kan <a href=\"%(url)s\">redigera "
-"ytterligare inställningar</a> om du vill."
 
 #: src/olympia/bandwagon/views.py:322
 msgid "Collection updated!"
@@ -2857,30 +2252,20 @@ msgstr "<a href=\"%(url)s\">Visa din samling</a>för att se ändringarna."
 msgid "Icon Deleted"
 msgstr "Ikon borttagen"
 
-#: src/olympia/bandwagon/templates/bandwagon/add.html:3
-#: src/olympia/bandwagon/templates/bandwagon/add.html:11
-#: src/olympia/bandwagon/templates/bandwagon/includes/collection_sidebar.html:26
+#: src/olympia/bandwagon/templates/bandwagon/add.html:3 src/olympia/bandwagon/templates/bandwagon/add.html:11 src/olympia/bandwagon/templates/bandwagon/includes/collection_sidebar.html:26
 msgid "Create a New Collection"
 msgstr "Skapa en ny samling"
 
-#: src/olympia/bandwagon/templates/bandwagon/add.html:9
-#: src/olympia/devhub/templates/devhub/personas/submit.html:14
+#: src/olympia/bandwagon/templates/bandwagon/add.html:9 src/olympia/devhub/templates/devhub/personas/submit.html:14
 msgid "Create"
 msgstr "Skapa"
 
-#: src/olympia/bandwagon/templates/bandwagon/add.html:24
-#: src/olympia/bandwagon/templates/bandwagon/ajax_new.html:28
+#: src/olympia/bandwagon/templates/bandwagon/add.html:24 src/olympia/bandwagon/templates/bandwagon/ajax_new.html:28
 #, python-format
-msgid ""
-"As noted in our <a href=\"%(legal)s\">Legal Notices</a>, individual "
-"collection arrangements are governed by the Creative Commons Attribution "
-"Share-Alike License"
-msgstr ""
-"Som påpekas i vår <a href=\"%(legal)s\">Juridisk information</a> regleras "
-"individuella samlingar av Creative Commons Attribution Share-Alike License"
+msgid "As noted in our <a href=\"%(legal)s\">Legal Notices</a>, individual collection arrangements are governed by the Creative Commons Attribution Share-Alike License"
+msgstr "Som påpekas i vår <a href=\"%(legal)s\">Juridisk information</a> regleras individuella samlingar av Creative Commons Attribution Share-Alike License"
 
-#: src/olympia/bandwagon/templates/bandwagon/add.html:33
-#: src/olympia/bandwagon/templates/bandwagon/ajax_new.html:38
+#: src/olympia/bandwagon/templates/bandwagon/add.html:33 src/olympia/bandwagon/templates/bandwagon/ajax_new.html:38
 msgid "Create Collection"
 msgstr "Skapa samling"
 
@@ -2896,8 +2281,7 @@ msgstr "Starta en ny samling..."
 msgid "Start a New Collection"
 msgstr "Starta en ny samling"
 
-#: src/olympia/bandwagon/templates/bandwagon/ajax_new.html:6
-#: src/olympia/bandwagon/templates/bandwagon/includes/addedit.html:7
+#: src/olympia/bandwagon/templates/bandwagon/ajax_new.html:6 src/olympia/bandwagon/templates/bandwagon/includes/addedit.html:7
 msgid "Name:"
 msgstr "Namn:"
 
@@ -2910,15 +2294,11 @@ msgstr "eller <a id=\"collections-new-cancel\" href=\"#\">Avbryt</a>"
 msgid "To rate collections, you must have an add-ons account."
 msgstr "För att betygsätta samlingar måste du ha ett konto."
 
-#: src/olympia/bandwagon/templates/bandwagon/barometer.html:18
-#: src/olympia/templates/base.html:145
-#: src/olympia/templates/impala/base.html:198
+#: src/olympia/bandwagon/templates/bandwagon/barometer.html:18 src/olympia/templates/base.html:145 src/olympia/templates/impala/base.html:198
 msgid "Create an Add-ons Account"
 msgstr "Skapa ett konto för tillägg"
 
-#: src/olympia/bandwagon/templates/bandwagon/barometer.html:21
-#: src/olympia/templates/base.html:148
-#: src/olympia/templates/impala/base.html:201
+#: src/olympia/bandwagon/templates/bandwagon/barometer.html:21 src/olympia/templates/base.html:148 src/olympia/templates/impala/base.html:201
 #, python-format
 msgid "or <a href=\"%(login)s\">log in to your current account</a>"
 msgstr "eller <a href=\"%(login)s\">logga in på ett befintligt konto</a>"
@@ -2931,8 +2311,7 @@ msgstr "{0} :: Samlingar"
 msgid "private"
 msgstr "privat"
 
-#: src/olympia/bandwagon/templates/bandwagon/collection_detail.html:45
-#: src/olympia/bandwagon/templates/bandwagon/mobile/listing_items.html:9
+#: src/olympia/bandwagon/templates/bandwagon/collection_detail.html:45 src/olympia/bandwagon/templates/bandwagon/mobile/listing_items.html:9
 #, python-format
 msgid "<span>%(num)s</span> follower"
 msgid_plural "<span>%(num)s</span> followers"
@@ -2967,8 +2346,7 @@ msgstr "Fler alternativ:"
 msgid "Edit Collection"
 msgstr "Redigera samling"
 
-#: src/olympia/bandwagon/templates/bandwagon/collection_detail.html:88
-#: src/olympia/bandwagon/templates/bandwagon/includes/delete.html:3
+#: src/olympia/bandwagon/templates/bandwagon/collection_detail.html:88 src/olympia/bandwagon/templates/bandwagon/includes/delete.html:3
 msgid "Delete Collection"
 msgstr "Ta bort samling"
 
@@ -2986,12 +2364,8 @@ msgid_plural "%(num)s Add-ons in this Collection"
 msgstr[0] "%(num)s tillägg i denna samling"
 msgstr[1] "%(num)s tillägg i denna samling"
 
-#: src/olympia/bandwagon/templates/bandwagon/collection_detail.html:125
-#: src/olympia/compat/templates/compat/index.html:25
-#: src/olympia/compat/templates/compat/reporter_detail.html:29
-#: src/olympia/files/templates/files/viewer.html:29
-#: src/olympia/templates/amo_footer.html:17
-#: src/olympia/templates/includes/lang_switcher.html:10
+#: src/olympia/bandwagon/templates/bandwagon/collection_detail.html:125 src/olympia/compat/templates/compat/reporter_detail.html:29 src/olympia/files/templates/files/viewer.html:29
+#: src/olympia/templates/amo_footer.html:17 src/olympia/templates/includes/lang_switcher.html:10
 msgid "Go"
 msgstr "Gå till"
 
@@ -3017,27 +2391,17 @@ msgstr "Se alla samlingar denne användare gjort"
 
 #: src/olympia/bandwagon/templates/bandwagon/collection_detail.html:179
 msgid ""
-"Add-ons that you mark as favorites using the <b>Add to Favorites</b> feature"
-" appear below. This collection is currently <b>public</b>, which means "
-"everyone can see it. If you would like to hide it from public view, click "
-"the button below to make it private."
+"Add-ons that you mark as favorites using the <b>Add to Favorites</b> feature appear below. This collection is currently <b>public</b>, which means everyone can see it. If you would like to hide it "
+"from public view, click the button below to make it private."
 msgstr ""
-"Tillägg som du markerar som favoriter med hjälp av <b>Lägg till i "
-"favoriter</b> funktionen visas nedan. Denna samling är för närvarande "
-"<b>publik</b>, vilket innebär att alla kan se den. Om du vill dölja den från"
-" offentligheten, klicka på knappen nedan för att göra den privat."
+"Tillägg som du markerar som favoriter med hjälp av <b>Lägg till i favoriter</b> funktionen visas nedan. Denna samling är för närvarande <b>publik</b>, vilket innebär att alla kan se den. Om du vill "
+"dölja den från offentligheten, klicka på knappen nedan för att göra den privat."
 
 #: src/olympia/bandwagon/templates/bandwagon/collection_detail.html:186
 msgid ""
-"Add-ons that you mark as favorites using the <b>Add to Favorites</b> feature"
-" appear below. This collection is currently <b>private</b>, which means only"
-" you can see it.  If you would like everyone to be able to see your "
-"favorites, click the button below to make it public."
+"Add-ons that you mark as favorites using the <b>Add to Favorites</b> feature appear below. This collection is currently <b>private</b>, which means only you can see it.  If you would like everyone "
+"to be able to see your favorites, click the button below to make it public."
 msgstr ""
-"Tillägg du markerar som favoriter med hjälp av funktionen <b>Lägg till i "
-"favoriter</b> syns nedan. Denna samling är för närvarande <b>privat</b>, "
-"vilket innebär att enbart du kan se den.  Om du vill visa den offentligt, "
-"klicka på knappen nedan för att göra den publik."
 
 #: src/olympia/bandwagon/templates/bandwagon/collection_detail.html:196
 msgid "My favorite add-ons"
@@ -3057,20 +2421,18 @@ msgid_plural "<span>%(followers)s</span> followers"
 msgstr[0] "<span>%(followers)s</span> följare"
 msgstr[1] "<span>%(followers)s</span> följare"
 
-#. People "follow" collections to get notified of updates.
-#. Like
+#. People "follow" collections to get notified of updates.                    Like
 #. Twitter followers.
+#. People "follow" collections to get notified of updates.
 #. Like Twitter followers.
-#: src/olympia/bandwagon/templates/bandwagon/collection_listing_items.html:10
-#: src/olympia/bandwagon/templates/bandwagon/impala/collection_listing_items.html:18
+#: src/olympia/bandwagon/templates/bandwagon/collection_listing_items.html:10 src/olympia/bandwagon/templates/bandwagon/impala/collection_listing_items.html:18
 #, python-format
 msgid "%(num)s weekly follower"
 msgid_plural "%(num)s weekly followers"
 msgstr[0] "%(num)s följare per vecka"
 msgstr[1] "%(num)s följare per vecka"
 
-#. People "follow" collections to get notified of updates.
-#. Like
+#. People "follow" collections to get notified of updates.                    Like
 #. Twitter followers.
 #: src/olympia/bandwagon/templates/bandwagon/collection_listing_items.html:18
 #, python-format
@@ -3079,32 +2441,28 @@ msgid_plural "%(num)s monthly followers"
 msgstr[0] "%(num)s följare per månad"
 msgstr[1] "%(num)s följare per månad"
 
-#. People "follow" collections to get notified of updates.
-#. Like
+#. People "follow" collections to get notified of updates.                    Like
 #. Twitter followers.
+#. People "follow" collections to get notified of updates.
 #. Like Twitter followers.
-#: src/olympia/bandwagon/templates/bandwagon/collection_listing_items.html:26
-#: src/olympia/bandwagon/templates/bandwagon/impala/collection_listing_items.html:26
+#: src/olympia/bandwagon/templates/bandwagon/collection_listing_items.html:26 src/olympia/bandwagon/templates/bandwagon/impala/collection_listing_items.html:26
 #, python-format
 msgid "%(num)s follower"
 msgid_plural "%(num)s followers"
 msgstr[0] "%(num)s följare"
 msgstr[1] "%(num)s följare"
 
-#: src/olympia/bandwagon/templates/bandwagon/collection_listing_items.html:56
-#: src/olympia/bandwagon/templates/bandwagon/impala/collection_listing_items.html:9
+#: src/olympia/bandwagon/templates/bandwagon/collection_listing_items.html:56 src/olympia/bandwagon/templates/bandwagon/impala/collection_listing_items.html:9
 #: src/olympia/devhub/templates/devhub/personas/edit.html:27
 msgid "by {0}"
 msgstr "av {0}"
 
-#: src/olympia/bandwagon/templates/bandwagon/collection_widgets.html:5
-#: src/olympia/bandwagon/templates/bandwagon/collection_widgets.html:7
+#: src/olympia/bandwagon/templates/bandwagon/collection_widgets.html:5 src/olympia/bandwagon/templates/bandwagon/collection_widgets.html:7
 #: src/olympia/bandwagon/templates/bandwagon/impala/collection_listing_items.html:53
 msgid "Stop Following"
 msgstr "Sluta följa"
 
-#: src/olympia/bandwagon/templates/bandwagon/collection_widgets.html:6
-#: src/olympia/bandwagon/templates/bandwagon/collection_widgets.html:7
+#: src/olympia/bandwagon/templates/bandwagon/collection_widgets.html:6 src/olympia/bandwagon/templates/bandwagon/collection_widgets.html:7
 #: src/olympia/bandwagon/templates/bandwagon/impala/collection_listing_items.html:53
 msgid "Follow this Collection"
 msgstr "Följ denna samling"
@@ -3114,16 +2472,12 @@ msgid "Edit this Collection"
 msgstr "Redigera denna samling"
 
 #. %s is the name of the collection.
-#: src/olympia/bandwagon/templates/bandwagon/delete.html:4
-#: src/olympia/bandwagon/templates/bandwagon/delete.html:15
+#: src/olympia/bandwagon/templates/bandwagon/delete.html:4 src/olympia/bandwagon/templates/bandwagon/delete.html:15
 msgid "Delete {0}"
 msgstr "Ta bort {0}"
 
-#: src/olympia/bandwagon/templates/bandwagon/delete.html:13
-#: src/olympia/devhub/templates/devhub/addons/listing/item_actions.html:14
-#: src/olympia/devhub/templates/devhub/addons/listing/item_actions_theme.html:28
-#: src/olympia/devhub/templates/devhub/versions/list.html:131
-#: src/olympia/devhub/templates/devhub/versions/list.html:149
+#: src/olympia/bandwagon/templates/bandwagon/delete.html:13 src/olympia/devhub/templates/devhub/addons/listing/item_actions.html:14
+#: src/olympia/devhub/templates/devhub/addons/listing/item_actions_theme.html:28 src/olympia/devhub/templates/devhub/versions/list.html:131 src/olympia/devhub/templates/devhub/versions/list.html:149
 #: src/olympia/devhub/templates/devhub/versions/list.html:166
 msgid "Delete"
 msgstr "Ta bort"
@@ -3132,35 +2486,24 @@ msgstr "Ta bort"
 msgid "Are you sure?"
 msgstr "Är du säker?"
 
-#: src/olympia/bandwagon/templates/bandwagon/delete.html:21
-#: src/olympia/devhub/templates/devhub/personas/edit.html:131
-#: src/olympia/devhub/templates/devhub/personas/edit.html:152
-#: src/olympia/devhub/templates/devhub/personas/edit.html:173
-#: src/olympia/devhub/templates/devhub/personas/submit.html:77
-#: src/olympia/devhub/templates/devhub/personas/submit.html:98
+#: src/olympia/bandwagon/templates/bandwagon/delete.html:21 src/olympia/devhub/templates/devhub/personas/edit.html:131 src/olympia/devhub/templates/devhub/personas/edit.html:152
+#: src/olympia/devhub/templates/devhub/personas/edit.html:173 src/olympia/devhub/templates/devhub/personas/submit.html:77 src/olympia/devhub/templates/devhub/personas/submit.html:98
 #: src/olympia/devhub/templates/devhub/personas/submit.html:119
 msgid "Yes"
 msgstr "Ja"
 
-#: src/olympia/bandwagon/templates/bandwagon/delete.html:22
-#: src/olympia/devhub/templates/devhub/personas/edit.html:140
-#: src/olympia/devhub/templates/devhub/personas/edit.html:161
-#: src/olympia/devhub/templates/devhub/personas/edit.html:191
-#: src/olympia/devhub/templates/devhub/personas/submit.html:86
-#: src/olympia/devhub/templates/devhub/personas/submit.html:107
+#: src/olympia/bandwagon/templates/bandwagon/delete.html:22 src/olympia/devhub/templates/devhub/personas/edit.html:140 src/olympia/devhub/templates/devhub/personas/edit.html:161
+#: src/olympia/devhub/templates/devhub/personas/edit.html:191 src/olympia/devhub/templates/devhub/personas/submit.html:86 src/olympia/devhub/templates/devhub/personas/submit.html:107
 #: src/olympia/devhub/templates/devhub/personas/submit.html:137
 msgid "No"
 msgstr "Nej"
 
 #. {0} is the name of the collection.
-#: src/olympia/bandwagon/templates/bandwagon/edit.html:5
-#: src/olympia/bandwagon/templates/bandwagon/edit.html:21
+#: src/olympia/bandwagon/templates/bandwagon/edit.html:5 src/olympia/bandwagon/templates/bandwagon/edit.html:21
 msgid "Edit {0}"
 msgstr "Redigera {0}"
 
-#: src/olympia/bandwagon/templates/bandwagon/edit.html:29
-#: src/olympia/devhub/templates/devhub/addons/edit/details.html:20
-#: src/olympia/editors/templates/editors/themes/themes.html:62
+#: src/olympia/bandwagon/templates/bandwagon/edit.html:29 src/olympia/devhub/templates/devhub/addons/edit/details.html:20 src/olympia/editors/templates/editors/themes/themes.html:62
 msgid "Description"
 msgstr "Beskrivning"
 
@@ -3168,31 +2511,17 @@ msgstr "Beskrivning"
 msgid "Contributors & More"
 msgstr "Bidragsgivare & mer"
 
-#: src/olympia/bandwagon/templates/bandwagon/edit.html:54
-#: src/olympia/bandwagon/templates/bandwagon/edit.html:67
-#: src/olympia/bandwagon/templates/bandwagon/edit.html:82
-#: src/olympia/devhub/templates/devhub/addons/ajax_compat_update.html:35
-#: src/olympia/devhub/templates/devhub/addons/owner.html:59
-#: src/olympia/devhub/templates/devhub/addons/profile.html:42
-#: src/olympia/devhub/templates/devhub/addons/edit/admin.html:101
-#: src/olympia/devhub/templates/devhub/addons/edit/basic.html:152
-#: src/olympia/devhub/templates/devhub/addons/edit/details.html:85
-#: src/olympia/devhub/templates/devhub/addons/edit/support.html:67
-#: src/olympia/devhub/templates/devhub/addons/edit/technical.html:166
-#: src/olympia/devhub/templates/devhub/addons/forms_shared/media.html:149
-#: src/olympia/devhub/templates/devhub/payments/voluntary.html:64
-#: src/olympia/devhub/templates/devhub/personas/edit.html:35
-#: src/olympia/devhub/templates/devhub/personas/edit.html:304
-#: src/olympia/devhub/templates/devhub/versions/edit.html:139
-#: src/olympia/translations/templates/translations/trans-menu.html:48
+#: src/olympia/bandwagon/templates/bandwagon/edit.html:54 src/olympia/bandwagon/templates/bandwagon/edit.html:67 src/olympia/bandwagon/templates/bandwagon/edit.html:82
+#: src/olympia/devhub/templates/devhub/addons/ajax_compat_update.html:35 src/olympia/devhub/templates/devhub/addons/owner.html:59 src/olympia/devhub/templates/devhub/addons/profile.html:42
+#: src/olympia/devhub/templates/devhub/addons/edit/admin.html:101 src/olympia/devhub/templates/devhub/addons/edit/basic.html:152 src/olympia/devhub/templates/devhub/addons/edit/details.html:85
+#: src/olympia/devhub/templates/devhub/addons/edit/support.html:67 src/olympia/devhub/templates/devhub/addons/edit/technical.html:166
+#: src/olympia/devhub/templates/devhub/addons/forms_shared/media.html:149 src/olympia/devhub/templates/devhub/payments/voluntary.html:64 src/olympia/devhub/templates/devhub/personas/edit.html:35
+#: src/olympia/devhub/templates/devhub/personas/edit.html:304 src/olympia/devhub/templates/devhub/versions/edit.html:139 src/olympia/translations/templates/translations/trans-menu.html:48
 msgid "Save Changes"
 msgstr "Spara ändringar"
 
-#: src/olympia/bandwagon/templates/bandwagon/edit_contributors.html:9
-#: src/olympia/bandwagon/templates/bandwagon/edit_contributors.html:12
-#: src/olympia/bandwagon/templates/bandwagon/edit_contributors.html:17
-#: src/olympia/bandwagon/templates/bandwagon/edit_contributors.html:58
-#: src/olympia/constants/base.py:134
+#: src/olympia/bandwagon/templates/bandwagon/edit_contributors.html:9 src/olympia/bandwagon/templates/bandwagon/edit_contributors.html:12
+#: src/olympia/bandwagon/templates/bandwagon/edit_contributors.html:17 src/olympia/bandwagon/templates/bandwagon/edit_contributors.html:58 src/olympia/constants/base.py:134
 msgid "Owner"
 msgstr "Ägare"
 
@@ -3204,10 +2533,8 @@ msgstr "Gör till ägare"
 msgid "Remove this user as a contributor"
 msgstr "Ta bort den här användaren som en bidragsgivare"
 
-#: src/olympia/bandwagon/templates/bandwagon/edit_contributors.html:18
-#: src/olympia/bandwagon/templates/bandwagon/edit_contributors.html:43
-#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:20
-#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:48
+#: src/olympia/bandwagon/templates/bandwagon/edit_contributors.html:18 src/olympia/bandwagon/templates/bandwagon/edit_contributors.html:43
+#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:18 src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:46
 #: src/olympia/devhub/templates/devhub/addons/ajax_compat_update.html:19
 msgid "Remove"
 msgstr "Ta bort"
@@ -3218,24 +2545,15 @@ msgstr "Bidragare till samling"
 
 #: src/olympia/bandwagon/templates/bandwagon/edit_contributors.html:26
 msgid ""
-"You can add multiple contributors to this collection.  A contributor can add"
-" and remove add-ons from this collection, but cannot change its name or "
-"description.  To add a contributor, enter their email in the box below. "
-"Contributors must have a Mozilla Add-ons account."
+"You can add multiple contributors to this collection.  A contributor can add and remove add-ons from this collection, but cannot change its name or description.  To add a contributor, enter their "
+"email in the box below. Contributors must have a Mozilla Add-ons account."
 msgstr ""
-"Du kan lägga till flera bidragsgivare till denna samling.  En bidragsgivare "
-"kan lägga till och ta bort tillägg från denna samling, men kan inte ändra "
-"dess namn eller beskrivning.  För att lägga till en bidragsgivare, ange dess"
-" e-postadress i rutan nedan. Bidragsgivare måste ha ett Mozilla-konto för "
-"tillägg."
 
 #: src/olympia/bandwagon/templates/bandwagon/edit_contributors.html:40
 msgid "User"
 msgstr "Användare"
 
-#: src/olympia/bandwagon/templates/bandwagon/edit_contributors.html:41
-#: src/olympia/devhub/templates/devhub/addons/edit/support.html:20
-#: src/olympia/users/templates/users/delete.html:49
+#: src/olympia/bandwagon/templates/bandwagon/edit_contributors.html:41 src/olympia/devhub/templates/devhub/addons/edit/support.html:20 src/olympia/users/templates/users/delete.html:49
 msgid "Email"
 msgstr "E-postadress"
 
@@ -3260,28 +2578,14 @@ msgid "Admin Settings"
 msgstr "Administratörsinställningar"
 
 #: src/olympia/bandwagon/templates/bandwagon/edit_contributors.html:76
-msgid ""
-"<b>Warning:</b> By changing the owner of this collection, you will no longer"
-" be able to edit it. You will only be able to add and remove add-ons from "
-"it."
-msgstr ""
-"<b>Varning:</b> Om du byter ägare på den här samlingen kommer du inte längre"
-" att kunna ändra på den. Du kommer bara kunna lägga till och ta bort tillägg"
-" från den."
+msgid "<b>Warning:</b> By changing the owner of this collection, you will no longer be able to edit it. You will only be able to add and remove add-ons from it."
+msgstr "<b>Varning:</b> Om du byter ägare på den här samlingen kommer du inte längre att kunna ändra på den. Du kommer bara kunna lägga till och ta bort tillägg från den."
 
-#: src/olympia/bandwagon/templates/bandwagon/edit_contributors.html:83
-#: src/olympia/devhub/templates/devhub/addons/forms_shared/media.html:157
-#: src/olympia/devhub/templates/devhub/addons/submit/describe.html:69
-#: src/olympia/devhub/templates/devhub/addons/submit/license.html:60
-#: src/olympia/devhub/templates/devhub/addons/submit/upload.html:78
-#: src/olympia/devhub/templates/devhub/payments/tier.html:17
-#: src/olympia/editors/templates/editors/themes/themes.html:111
-#: src/olympia/editors/templates/editors/themes/themes.html:128
-#: src/olympia/editors/templates/editors/themes/themes.html:134
-#: src/olympia/editors/templates/editors/themes/themes.html:141
-#: src/olympia/users/templates/users/fxa_migration_prompt_content.html:10
-#: src/olympia/users/templates/users/login_form.html:42
-#: src/olympia/users/templates/users/mobile/login.html:57
+#: src/olympia/bandwagon/templates/bandwagon/edit_contributors.html:83 src/olympia/devhub/templates/devhub/addons/forms_shared/media.html:157
+#: src/olympia/devhub/templates/devhub/addons/submit/describe.html:69 src/olympia/devhub/templates/devhub/addons/submit/license.html:60 src/olympia/devhub/templates/devhub/addons/submit/upload.html:70
+#: src/olympia/devhub/templates/devhub/payments/tier.html:17 src/olympia/editors/templates/editors/themes/themes.html:111 src/olympia/editors/templates/editors/themes/themes.html:128
+#: src/olympia/editors/templates/editors/themes/themes.html:134 src/olympia/editors/templates/editors/themes/themes.html:141 src/olympia/users/templates/users/fxa_migration_prompt_content.html:10
+#: src/olympia/users/templates/users/login_form.html:42 src/olympia/users/templates/users/mobile/login.html:57
 msgid "Continue"
 msgstr "Fortsätt"
 
@@ -3320,18 +2624,10 @@ msgstr "Nyligen populära samlingar"
 
 #: src/olympia/bandwagon/templates/bandwagon/impala/collection_listing.html:28
 #, python-format
-msgid ""
-"Collections are groups of related add-ons that anyone can create and share. "
-"Explore collections created by other users or <a href=\"%(url)s\">create "
-"your own</a>."
-msgstr ""
-"Samlingar är grupper av tillägg som vem som helst kan skapa och dela. "
-"Utforska samlingar skapade av andra användare eller <a "
-"href=\"%(url)s\">skapa din egen</a>."
+msgid "Collections are groups of related add-ons that anyone can create and share. Explore collections created by other users or <a href=\"%(url)s\">create your own</a>."
+msgstr "Samlingar är grupper av tillägg som vem som helst kan skapa och dela. Utforska samlingar skapade av andra användare eller <a href=\"%(url)s\">skapa din egen</a>."
 
-#: src/olympia/bandwagon/templates/bandwagon/impala/collection_listing.html:37
-#: src/olympia/browse/templates/browse/extensions.html:13
-#: src/olympia/browse/templates/browse/themes.html:14
+#: src/olympia/bandwagon/templates/bandwagon/impala/collection_listing.html:37 src/olympia/browse/templates/browse/extensions.html:13 src/olympia/browse/templates/browse/themes.html:14
 msgid "Subscribe"
 msgstr "Prenumerera"
 
@@ -3339,20 +2635,14 @@ msgstr "Prenumerera"
 msgid "Following"
 msgstr "Följer"
 
-#: src/olympia/bandwagon/templates/bandwagon/impala/collection_sidebar.html:22
-#: src/olympia/bandwagon/templates/bandwagon/impala/collection_sidebar.html:28
+#: src/olympia/bandwagon/templates/bandwagon/impala/collection_sidebar.html:22 src/olympia/bandwagon/templates/bandwagon/impala/collection_sidebar.html:28
 #: src/olympia/bandwagon/templates/bandwagon/includes/collection_sidebar.html:32
 msgid "Create a Collection"
 msgstr "Skapa en samling"
 
-#: src/olympia/bandwagon/templates/bandwagon/impala/collection_sidebar.html:23
-#: src/olympia/bandwagon/templates/bandwagon/includes/collection_sidebar.html:27
-msgid ""
-"Collections make it easy to keep track of favorite add-ons and share your "
-"perfectly customized browser with others."
-msgstr ""
-"Samlingar gör det lätt att hålla koll på dina favorittillägg och dela med "
-"dig av din perfekt anpassade webbläsare till andra."
+#: src/olympia/bandwagon/templates/bandwagon/impala/collection_sidebar.html:23 src/olympia/bandwagon/templates/bandwagon/includes/collection_sidebar.html:27
+msgid "Collections make it easy to keep track of favorite add-ons and share your perfectly customized browser with others."
+msgstr "Samlingar gör det lätt att hålla koll på dina favorittillägg och dela med dig av din perfekt anpassade webbläsare till andra."
 
 #: src/olympia/bandwagon/templates/bandwagon/includes/addedit.html:42
 msgid "Collection Icon"
@@ -3364,50 +2654,42 @@ msgstr "Återställ"
 
 #: src/olympia/bandwagon/templates/bandwagon/includes/addedit.html:53
 msgid "PNG and JPG supported.  Image will be resized to 32x32."
-msgstr "PNG och JPG stöds.  Bilder skalas om till 32x32."
+msgstr ""
 
 #: src/olympia/bandwagon/templates/bandwagon/includes/addedit_errors.html:3
 msgid "There are errors in this form.  Please correct them below."
-msgstr "Det finns fel i formuläret.  Rätta dem nedan."
+msgstr ""
 
 #: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:2
 msgid "Add-ons in Your Collection"
 msgstr "Tillägg i din samling"
 
 #: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:4
-msgid ""
-"To include an add-on in this collection, enter its name in the box below and"
-" hit enter.  You can also use the <strong>Add to Collection</strong> links "
-"throughout the site to include add-ons later."
+msgid "To include an add-on in this collection, enter its name in the box below and hit enter."
 msgstr ""
-"Om du vill inkludera ett tillägg i denna samling, anger du dess namn i rutan"
-" nedan och trycker enter.  Du kan också använda <strong>Lägg till "
-"samling</strong> länkar hela webbplatsen för att inkludera tillägg senare."
 
-#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:17
-#: src/olympia/constants/base.py:400
-#: src/olympia/devhub/templates/devhub/addons/activity.html:62
+#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:15 src/olympia/constants/base.py:400 src/olympia/devhub/templates/devhub/addons/activity.html:62
+#: src/olympia/editors/helpers.py:273 src/olympia/editors/helpers.py:360
 msgid "Add-on"
 msgstr "Tillägg"
 
-#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:26
+#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:24
 msgid "Enter the name of the add-on to include"
 msgstr "Ange namnet på ett tillägg att inkludera"
 
-#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:28
+#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:26
 msgid "Add to Collection"
 msgstr "Lägg till i samling"
 
-#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:45
-#: src/olympia/editors/helpers.py:936 src/olympia/editors/helpers.py:956
+#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:43 src/olympia/editors/helpers.py:1016 src/olympia/editors/helpers.py:1036
 msgid "Pending"
 msgstr "Väntande"
 
-#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:47
+#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:45
 msgid "Add a comment"
 msgstr "Lägg till en kommentar"
 
-#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:48
+#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:46
 msgid "Remove this add-on from the collection"
 msgstr "Ta bort detta tillägg från denna samling"
 
@@ -3419,14 +2701,11 @@ msgstr "SAMLINGAR"
 msgid "Groups of related add-ons that anyone can create."
 msgstr "Grupper av relaterade tillägg som alla kan skapa."
 
-#: src/olympia/blocklist/templates/blocklist/blocked_detail.html:3
-#: src/olympia/blocklist/templates/blocklist/blocked_list.html:3
-#: src/olympia/blocklist/templates/blocklist/blocked_list.html:10
+#: src/olympia/blocklist/templates/blocklist/blocked_detail.html:3 src/olympia/blocklist/templates/blocklist/blocked_list.html:3 src/olympia/blocklist/templates/blocklist/blocked_list.html:10
 msgid "Blocked Add-ons"
 msgstr "Blockerat tillägg"
 
-#: src/olympia/blocklist/templates/blocklist/blocked_detail.html:8
-#: src/olympia/blocklist/templates/blocklist/blocked_list.html:6
+#: src/olympia/blocklist/templates/blocklist/blocked_detail.html:8 src/olympia/blocklist/templates/blocklist/blocked_list.html:6
 msgid "Blocklist"
 msgstr "Blockeringslista"
 
@@ -3448,37 +2727,19 @@ msgid "What does this mean?"
 msgstr "Vad innebär det?"
 
 #: src/olympia/blocklist/templates/blocklist/blocked_detail.html:22
-msgid ""
-"Users are strongly encouraged to disable the problematic add-on or plugin, "
-"but may choose to continue using it if they accept the risks described."
-msgstr ""
-"Användare rekommenderas att inaktivera det tillägg eller plugin med problem,"
-" men kan välja att fortsätta använda dem om de accepterar de risker som "
-"beskrivs."
+msgid "Users are strongly encouraged to disable the problematic add-on or plugin, but may choose to continue using it if they accept the risks described."
+msgstr "Användare rekommenderas att inaktivera det tillägg eller plugin med problem, men kan välja att fortsätta använda dem om de accepterar de risker som beskrivs."
 
 #: src/olympia/blocklist/templates/blocklist/blocked_detail.html:27
-msgid ""
-"The problematic add-on or plugin will be automatically disabled and no "
-"longer usable."
-msgstr ""
-"Det tillägg eller plugin med problem kommer automatiskt inaktiveras och kan "
-"inte längre användas."
+msgid "The problematic add-on or plugin will be automatically disabled and no longer usable."
+msgstr "Det tillägg eller plugin med problem kommer automatiskt inaktiveras och kan inte längre användas."
 
 #: src/olympia/blocklist/templates/blocklist/blocked_detail.html:33
 #, python-format
 msgid ""
-"When Mozilla becomes aware of add-ons, plugins, or other third-party "
-"software that seriously compromises %(app)s security, stability, or "
-"performance and meets <a href=\"%(criteria)s\">certain criteria</a>, the "
-"software may be blocked from general use.  For more information, please read"
-" <a href=\"%(support)s\">this support article</a>."
+"When Mozilla becomes aware of add-ons, plugins, or other third-party software that seriously compromises %(app)s security, stability, or performance and meets <a href=\"%(criteria)s\">certain "
+"criteria</a>, the software may be blocked from general use.  For more information, please read <a href=\"%(support)s\">this support article</a>."
 msgstr ""
-"När Mozilla får kännedom om tillägg, insticksmoduler eller andra program "
-"från tredje part som allvarligt äventyrar %(app)s säkerhet och stabilitet, "
-"eller prestanda och som uppfyller <a href=\"%(criteria)s\">vissa "
-"kriterier</a>, kan programvaran blockeras från allmän användning.  För mer "
-"information, vänligen läs <a href=\"%(support)s\">den här "
-"supportartikeln</a>."
 
 #: src/olympia/blocklist/templates/blocklist/blocked_detail.html:44
 #, python-format
@@ -3491,12 +2752,8 @@ msgid "Blocked on %(date)s."
 msgstr "Blockerad den %(date)s."
 
 #: src/olympia/blocklist/templates/blocklist/blocked_list.html:11
-msgid ""
-"The following software is known to cause serious security, stability, or "
-"performance issues with {app}."
-msgstr ""
-"Följande programvara är känd för att orsaka allvarliga säkerhet, stabilitet "
-"eller prestandaproblem med {app}."
+msgid "The following software is known to cause serious security, stability, or performance issues with {app}."
+msgstr "Följande programvara är känd för att orsaka allvarliga säkerhet, stabilitet eller prestandaproblem med {app}."
 
 #. L10n: %s is a category name.
 #: src/olympia/browse/feeds.py:76 src/olympia/browse/feeds.py:98
@@ -3518,11 +2775,8 @@ msgstr "Utvalda tillägg :: %s"
 #. L10n: %s is an app name.
 #: src/olympia/browse/feeds.py:138
 #, python-format
-msgid ""
-"Here's a few of our favorite add-ons to help you get started customizing %s."
-msgstr ""
-"Här är några av våra favorittillägg för att hjälpa dig att komma igång med "
-"anpassning %s."
+msgid "Here's a few of our favorite add-ons to help you get started customizing %s."
+msgstr "Här är några av våra favorittillägg för att hjälpa dig att komma igång med anpassning %s."
 
 #. L10n: %s is a category name.
 #: src/olympia/browse/feeds.py:157
@@ -3538,43 +2792,28 @@ msgstr "Sökverktyg och sökrelaterade utökningar"
 msgid "Search tools"
 msgstr "Sökverktyg"
 
-#: src/olympia/browse/views.py:55 src/olympia/browse/views.py:65
-#: src/olympia/search/forms.py:85
+#: src/olympia/browse/views.py:55 src/olympia/browse/views.py:65 src/olympia/search/forms.py:85
 msgid "Most Users"
 msgstr "Flest användare"
 
-#: src/olympia/browse/views.py:61 src/olympia/browse/views.py:72
-#: src/olympia/browse/views.py:279
-#: src/olympia/browse/templates/browse/personas/mobile/category_landing.html:63
-#: src/olympia/discovery/templates/discovery/pane.html:67
-#: src/olympia/search/forms.py:92
+#: src/olympia/browse/views.py:61 src/olympia/browse/views.py:72 src/olympia/browse/views.py:246 src/olympia/browse/templates/browse/personas/mobile/category_landing.html:63
+#: src/olympia/discovery/templates/discovery/pane.html:67 src/olympia/search/forms.py:92
 msgid "Up & Coming"
 msgstr "Bubblare"
 
-#: src/olympia/browse/views.py:460 src/olympia/devhub/views.py:76
-#: src/olympia/devhub/views.py:83
-#: src/olympia/discovery/templates/discovery/addons/detail.html:66
+#: src/olympia/browse/views.py:427 src/olympia/devhub/views.py:74 src/olympia/devhub/views.py:81 src/olympia/discovery/templates/discovery/addons/detail.html:66
 msgid "Created"
 msgstr "Skapad"
 
 #. {0} is the category name. Ex: Sports
-#: src/olympia/browse/templates/browse/creatured.html:5
-#: src/olympia/browse/templates/browse/creatured.html:13
+#: src/olympia/browse/templates/browse/creatured.html:5 src/olympia/browse/templates/browse/creatured.html:13
 msgid "{0}: Featured Add-ons"
 msgstr "{0}: Utvalda tillägg"
 
-#: src/olympia/browse/templates/browse/creatured.html:12
-#: src/olympia/browse/templates/browse/featured.html:4
-#: src/olympia/browse/templates/browse/featured.html:12
-#: src/olympia/browse/templates/browse/featured.html:13
-#: src/olympia/devhub/templates/devhub/docs/policies-recommended.html:3
-#: src/olympia/devhub/templates/devhub/docs/policies-recommended.html:7
-#: src/olympia/devhub/templates/devhub/docs/policies-recommended.html:9
-#: src/olympia/devhub/templates/devhub/docs/policies.html:21
-#: src/olympia/devhub/templates/devhub/docs/policies.html:90
-#: src/olympia/discovery/modules.py:341
-#: src/olympia/discovery/templates/discovery/pane.html:52
-#: src/olympia/templates/menu_links.html:7
+#: src/olympia/browse/templates/browse/creatured.html:12 src/olympia/browse/templates/browse/featured.html:4 src/olympia/browse/templates/browse/featured.html:12
+#: src/olympia/browse/templates/browse/featured.html:13 src/olympia/devhub/templates/devhub/docs/policies-recommended.html:3 src/olympia/devhub/templates/devhub/docs/policies-recommended.html:7
+#: src/olympia/devhub/templates/devhub/docs/policies-recommended.html:9 src/olympia/devhub/templates/devhub/docs/policies.html:21 src/olympia/devhub/templates/devhub/docs/policies.html:90
+#: src/olympia/discovery/modules.py:341 src/olympia/discovery/templates/discovery/pane.html:52 src/olympia/templates/menu_links.html:7
 msgid "Featured Add-ons"
 msgstr "Utvalda tillägg"
 
@@ -3585,12 +2824,8 @@ msgstr "Inga utvalda tillägg i {0}."
 
 #: src/olympia/browse/templates/browse/featured.html:15
 #, python-format
-msgid ""
-"Here's a few of our favorite add-ons to help you get started customizing "
-"%(app)s."
-msgstr ""
-"Här är några av våra favorittillägg för att hjälpa dig att komma igång med "
-"anpassning %(app)s."
+msgid "Here's a few of our favorite add-ons to help you get started customizing %(app)s."
+msgstr "Här är några av våra favorittillägg för att hjälpa dig att komma igång med anpassning %(app)s."
 
 #: src/olympia/browse/templates/browse/language_tools.html:9
 msgid "Install Dictionary"
@@ -3616,19 +2851,15 @@ msgstr "Tillgänglig på ditt språk"
 msgid "List of language packs and dictionaries available in your locale."
 msgstr "Lista över språkpaket och ordlistor tillgängliga på ditt språk."
 
-#: src/olympia/browse/templates/browse/language_tools.html:41
-#: src/olympia/browse/templates/browse/language_tools.html:63
+#: src/olympia/browse/templates/browse/language_tools.html:41 src/olympia/browse/templates/browse/language_tools.html:63
 msgid "Language"
 msgstr "Språk"
 
-#: src/olympia/browse/templates/browse/language_tools.html:42
-#: src/olympia/browse/templates/browse/language_tools.html:64
-#: src/olympia/constants/base.py:162
+#: src/olympia/browse/templates/browse/language_tools.html:42 src/olympia/browse/templates/browse/language_tools.html:64 src/olympia/constants/base.py:162
 msgid "Dictionary"
 msgstr "Ordlista"
 
-#: src/olympia/browse/templates/browse/language_tools.html:43
-#: src/olympia/browse/templates/browse/language_tools.html:65
+#: src/olympia/browse/templates/browse/language_tools.html:43 src/olympia/browse/templates/browse/language_tools.html:65
 msgid "Language Pack"
 msgstr "Språkpaket"
 
@@ -3646,8 +2877,7 @@ msgid "{0} :: Search Tools"
 msgstr "{0} :: Sökverktyg"
 
 #. {0} is an integer.
-#: src/olympia/browse/templates/browse/search_tools.html:39
-#: src/olympia/devhub/templates/devhub/addons/dashboard.html:17
+#: src/olympia/browse/templates/browse/search_tools.html:39 src/olympia/devhub/templates/devhub/addons/dashboard.html:17
 msgid "<b>{0}</b> add-on"
 msgid_plural "<b>{0}</b> add-ons"
 msgstr[0] "<b>{0}</b> tillägg"
@@ -3675,34 +2905,18 @@ msgstr "Fler resurser"
 
 #. {0} is an app name, like Firefox.
 #: src/olympia/browse/templates/browse/search_tools.html:93
-msgid ""
-"Learn more about the <a "
-"href=\"http://support.mozilla.com/kb/Search+bar\">search bar</a> in {0}"
-msgstr ""
-"Läs mer om <a href=\"http://support.mozilla.com/kb/Search+bar\">sökfält</a> "
-"i {0}"
+msgid "Learn more about the <a href=\"http://support.mozilla.com/kb/Search+bar\">search bar</a> in {0}"
+msgstr "Läs mer om <a href=\"http://support.mozilla.com/kb/Search+bar\">sökfält</a> i {0}"
 
 #: src/olympia/browse/templates/browse/search_tools.html:94
-msgid ""
-"Browse through even more search providers at <a "
-"href=\"http://mycroft.mozdev.org/\">mycroft.mozdev.org</a>"
-msgstr ""
-"Bläddra igenom ännu fler sökleverantörer på <a "
-"href=\"http://mycroft.mozdev.org/\">mycroft.mozdev.org</a>"
+msgid "Browse through even more search providers at <a href=\"http://mycroft.mozdev.org/\">mycroft.mozdev.org</a>"
+msgstr "Bläddra igenom ännu fler sökleverantörer på <a href=\"http://mycroft.mozdev.org/\">mycroft.mozdev.org</a>"
 
 #: src/olympia/browse/templates/browse/search_tools.html:95
-msgid ""
-"<a "
-"href=\"https://developer.mozilla.org/en/Creating_OpenSearch_plugins_for_Firefox\">Make"
-" your own</a> search tool"
-msgstr ""
-"<a "
-"href=\"https://developer.mozilla.org/en/Creating_OpenSearch_plugins_for_Firefox\">Gör"
-" din eget</a> sökverktyg"
+msgid "<a href=\"https://developer.mozilla.org/en/Creating_OpenSearch_plugins_for_Firefox\">Make your own</a> search tool"
+msgstr "<a href=\"https://developer.mozilla.org/en/Creating_OpenSearch_plugins_for_Firefox\">Gör din eget</a> sökverktyg"
 
-#: src/olympia/browse/templates/browse/themes.html:6
-#: src/olympia/browse/templates/browse/themes.html:9
-#: src/olympia/constants/base.py:174
+#: src/olympia/browse/templates/browse/themes.html:6 src/olympia/browse/templates/browse/themes.html:9 src/olympia/constants/base.py:174
 msgid "Complete Themes"
 msgstr "Kompletta teman"
 
@@ -3775,24 +2989,17 @@ msgid_plural "See all %(cnt)s extensions in %(name)s &raquo;"
 msgstr[0] "Visa %(cnt)s utökning i %(name)s &raquo;"
 msgstr[1] "Visa alla %(cnt)s utökningar i %(name)s &raquo;"
 
-#: src/olympia/browse/templates/browse/mobile/extensions.html:13
-#: src/olympia/compat/templates/compat/index.html:82
-#: src/olympia/devhub/templates/devhub/devhub_search.html:24
-#: src/olympia/devhub/templates/devhub/addons/activity.html:47
-#: src/olympia/search/templates/search/no_results.html:4
-#: src/olympia/search/templates/search/mobile/results.html:36
+#: src/olympia/browse/templates/browse/mobile/extensions.html:13 src/olympia/devhub/templates/devhub/devhub_search.html:24 src/olympia/devhub/templates/devhub/addons/activity.html:47
+#: src/olympia/search/templates/search/no_results.html:4 src/olympia/search/templates/search/mobile/results.html:36
 msgid "No results found."
 msgstr "Inga resultat hittades."
 
-#: src/olympia/browse/templates/browse/personas/base.html:6
-#: src/olympia/browse/templates/browse/personas/mobile/base.html:7
+#: src/olympia/browse/templates/browse/personas/base.html:6 src/olympia/browse/templates/browse/personas/mobile/base.html:7
 msgid "{0} Themes"
 msgstr "{0} Teman"
 
 #. {0} is a user's name.
-#: src/olympia/browse/templates/browse/personas/base.html:15
-#: src/olympia/browse/templates/browse/personas/base.html:40
-#: src/olympia/browse/templates/browse/personas/grid.html:8
+#: src/olympia/browse/templates/browse/personas/base.html:15 src/olympia/browse/templates/browse/personas/base.html:40 src/olympia/browse/templates/browse/personas/grid.html:8
 msgid "{0}'s Themes"
 msgstr "{0}'s Teman"
 
@@ -3812,31 +3019,22 @@ msgstr "Din webbläsare, din stil! Styla den med en egen design!"
 msgid "Learn more"
 msgstr "Läs mer"
 
-#: src/olympia/browse/templates/browse/personas/category_landing.html:6
-#: src/olympia/browse/templates/browse/personas/mobile/category_landing.html:5
+#: src/olympia/browse/templates/browse/personas/category_landing.html:6 src/olympia/browse/templates/browse/personas/mobile/category_landing.html:5
 msgid "View All Recently Added"
 msgstr "Visa alla nyligen tillagda"
 
-#: src/olympia/browse/templates/browse/personas/category_landing.html:7
-#: src/olympia/browse/templates/browse/personas/mobile/category_landing.html:6
+#: src/olympia/browse/templates/browse/personas/category_landing.html:7 src/olympia/browse/templates/browse/personas/mobile/category_landing.html:6
 msgid "View All Most Popular"
 msgstr "Visa alla populära"
 
-#: src/olympia/browse/templates/browse/personas/category_landing.html:8
-#: src/olympia/browse/templates/browse/personas/mobile/category_landing.html:7
+#: src/olympia/browse/templates/browse/personas/category_landing.html:8 src/olympia/browse/templates/browse/personas/mobile/category_landing.html:7
 msgid "View All Top Rated"
 msgstr "Visa alla högst rankade"
 
 #: src/olympia/browse/templates/browse/personas/category_landing.html:40
 #, python-format
-msgid ""
-"Over 300,000 designs to personalize your browser! Move your mouse over a "
-"Background Theme to try it on. <a href=\"%(url)s\" class=\"more-info\">Start"
-" exploring</a>"
-msgstr ""
-"Över 300.000 designer för att anpassa din webbläsare! Flytta musen över ett "
-"bakgrundstema för att prova den. <a href=\"%(url)s\" class=\"more-"
-"info\">Börja utforska</a>"
+msgid "Over 300,000 designs to personalize your browser! Move your mouse over a Background Theme to try it on. <a href=\"%(url)s\" class=\"more-info\">Start exploring</a>"
+msgstr "Över 300.000 designer för att anpassa din webbläsare! Flytta musen över ett bakgrundstema för att prova den. <a href=\"%(url)s\" class=\"more-info\">Börja utforska</a>"
 
 #: src/olympia/browse/templates/browse/personas/category_landing.html:47
 msgid "Want more personalization?"
@@ -3846,14 +3044,8 @@ msgstr "Vill du ha fler anpassningar?"
 #. theme.
 #: src/olympia/browse/templates/browse/personas/category_landing.html:50
 #, python-format
-msgid ""
-"Complete Themes transform the look of your browser with styles for the "
-"window frame, address bar, buttons, tabs, and menus. <a href=\"%(url)s\" "
-"class=\"more-info\">Start exploring</a>"
-msgstr ""
-"Kompletta teman förändrar utseendet på din webbläsare med stilar för "
-"fönsterramen, adressfältet, knappar, flikar och menyer. <a href=\"%(url)s\" "
-"class=\"more-info\">Börja utforska</a>"
+msgid "Complete Themes transform the look of your browser with styles for the window frame, address bar, buttons, tabs, and menus. <a href=\"%(url)s\" class=\"more-info\">Start exploring</a>"
+msgstr "Kompletta teman förändrar utseendet på din webbläsare med stilar för fönsterramen, adressfältet, knappar, flikar och menyer. <a href=\"%(url)s\" class=\"more-info\">Börja utforska</a>"
 
 #: src/olympia/browse/templates/browse/personas/category_landing.html:76
 msgid "Up & Coming Themes"
@@ -3883,7 +3075,7 @@ msgstr "&laquo; Alla teman"
 msgid "All"
 msgstr "Alla"
 
-#: src/olympia/compat/forms.py:22 src/olympia/search/views.py:525
+#: src/olympia/compat/forms.py:22 src/olympia/editors/templates/editors/base.html:69 src/olympia/search/views.py:518
 msgid "All Add-ons"
 msgstr "Alla tillägg"
 
@@ -3895,91 +3087,32 @@ msgstr "Binär"
 msgid "Non-binary"
 msgstr "Icke-binär"
 
-#. Review points sources other than add-ons and themes.
-#: src/olympia/compat/views.py:87 src/olympia/constants/base.py:388
-#: src/olympia/devhub/forms.py:162
-#: src/olympia/editors/templates/editors/performance.html:75
-msgid "Other"
-msgstr "Annat"
-
-#: src/olympia/compat/templates/compat/index.html:4
-msgid "Add-on Compatibility Report for {app} {version}"
-msgstr "Tillägg kompatibilitetsrapport för {app} {version}"
-
-#: src/olympia/compat/templates/compat/index.html:11
-msgid "{app} {version} Compatibility"
-msgstr "{app} {version} Kompatibilitet"
-
-#: src/olympia/compat/templates/compat/index.html:17
-#, python-format
-msgid "Top 95%% compatible with previous version"
-msgstr "Topp 95%% kompatibla med tidigare version"
-
-#: src/olympia/compat/templates/compat/index.html:18
-#, python-format
-msgid "Top 95%% of all add-ons"
-msgstr "Topp 95%% av alla tillägg"
-
-#: src/olympia/compat/templates/compat/index.html:19
-msgid "All active add-ons"
-msgstr "Alla aktiva tillägg"
-
-#: src/olympia/compat/templates/compat/index.html:23
-#: src/olympia/constants/base.py:401
-msgid "App"
-msgstr "App"
-
-#: src/olympia/compat/templates/compat/index.html:55
-msgid "Details for add-ons compatible with previous version:"
-msgstr "Detaljer för tillägg kompatibla med tidigare versioner:"
-
-#: src/olympia/compat/templates/compat/index.html:57
-msgid "Show all versions"
-msgstr "Visa alla versioner"
-
-#: src/olympia/compat/templates/compat/index.html:59
-msgid "Details for add-ons compatible with all versions:"
-msgstr "Detaljer för tillägg kompatibla med all versioner:"
-
-#: src/olympia/compat/templates/compat/index.html:61
-msgid "Show previous version only"
-msgstr "Visa endast tidigare version"
-
 #: src/olympia/compat/templates/compat/reporter.html:3
 msgid "Add-on Compatibility Reports"
 msgstr "Tillägg kompatibilitetsrapporter"
 
-#: src/olympia/compat/templates/compat/reporter.html:11
-#: src/olympia/compat/templates/compat/reporter_detail.html:35
+#: src/olympia/compat/templates/compat/reporter.html:11 src/olympia/compat/templates/compat/reporter_detail.html:35
 #, python-format
 msgid ""
-"<p> Reports submitted to us through the <a href=\"%(url_)s\">Add-on "
-"Compatibility Reporter</a> are collected here for developers to view. These "
-"reports help us determine which add-ons will need help supporting an "
-"upcoming Firefox version. </p>"
+"<p> Reports submitted to us through the <a href=\"%(url_)s\">Add-on Compatibility Reporter</a> are collected here for developers to view. These reports help us determine which add-ons will need "
+"help supporting an upcoming Firefox version. </p>"
 msgstr ""
-"<p> Rapporter som skickas in till oss genom <a href=\"%(url_)s\">Tillägg "
-"kompatibilitetsrapporter</a> samlas här för att utvecklare ska se. Dessa "
-"rapporter hjälper oss att avgöra vilka tillägg som kommer att behöva hjälp "
-"med stöd för en kommande Firefox-version. </p>"
+"<p> Rapporter som skickas in till oss genom <a href=\"%(url_)s\">Tillägg kompatibilitetsrapporter</a> samlas här för att utvecklare ska se. Dessa rapporter hjälper oss att avgöra vilka tillägg som "
+"kommer att behöva hjälp med stöd för en kommande Firefox-version. </p>"
 
 #: src/olympia/compat/templates/compat/reporter.html:18
 msgid "Reports for your Add-ons"
 msgstr "Rapporter för dina tillägg"
 
-#: src/olympia/compat/templates/compat/reporter.html:30
-#: src/olympia/compat/templates/compat/reporter_detail.html:9
+#: src/olympia/compat/templates/compat/reporter.html:30 src/olympia/compat/templates/compat/reporter_detail.html:9
 msgid "Add-on Compatibility Center"
 msgstr "Tillägg kompatibilitetscenter"
 
 #: src/olympia/compat/templates/compat/reporter.html:34
 msgid "Enter the GUID of an add-on below to view any reports we've received."
-msgstr ""
-"Öppna GUID för ett tillägg nedan för att se alla rapporter som vi har fått."
+msgstr "Öppna GUID för ett tillägg nedan för att se alla rapporter som vi har fått."
 
-#: src/olympia/compat/templates/compat/reporter_detail.html:3
-#: src/olympia/compat/templates/compat/reporter_detail.html:10
-#: src/olympia/compat/templates/compat/reporter_detail.html:25
+#: src/olympia/compat/templates/compat/reporter_detail.html:3 src/olympia/compat/templates/compat/reporter_detail.html:10 src/olympia/compat/templates/compat/reporter_detail.html:25
 msgid "{addon} Compatibility Reports"
 msgstr "{addon} kompatibilitetsrapporter"
 
@@ -3995,8 +3128,7 @@ msgid_plural "{0} problem reports"
 msgstr[0] "{0} problemrapport"
 msgstr[1] "{0} problemrapporter"
 
-#: src/olympia/compat/templates/compat/reporter_detail.html:21
-#: src/olympia/users/templates/users/profile.html:70
+#: src/olympia/compat/templates/compat/reporter_detail.html:21 src/olympia/users/templates/users/profile.html:70
 msgid "View all"
 msgstr "Visa alla"
 
@@ -4008,10 +3140,8 @@ msgstr "Filtrera efter applikation"
 msgid "Report Type"
 msgstr "Rapporttyp"
 
-#: src/olympia/compat/templates/compat/reporter_detail.html:47
-#: src/olympia/devhub/forms.py:784
-#: src/olympia/devhub/templates/devhub/addons/ajax_compat_update.html:17
-#: src/olympia/editors/forms.py:108 src/olympia/zadmin/forms.py:45
+#: src/olympia/compat/templates/compat/reporter_detail.html:47 src/olympia/devhub/forms.py:785 src/olympia/devhub/templates/devhub/addons/ajax_compat_update.html:17 src/olympia/editors/forms.py:108
+#: src/olympia/editors/forms.py:248 src/olympia/zadmin/forms.py:45
 msgid "Application"
 msgstr "Applikation"
 
@@ -4023,8 +3153,7 @@ msgstr "Applikations byggd"
 msgid "Platform"
 msgstr "Plattform"
 
-#: src/olympia/compat/templates/compat/reporter_detail.html:50
-#: src/olympia/editors/templates/editors/themes/themes.html:40
+#: src/olympia/compat/templates/compat/reporter_detail.html:50 src/olympia/editors/templates/editors/themes/themes.html:40
 msgid "Submitted"
 msgstr "Inskickad"
 
@@ -4052,8 +3181,7 @@ msgstr "Thunderbird"
 msgid "SeaMonkey"
 msgstr "SeaMonkey"
 
-#: src/olympia/constants/applications.py:75
-#: src/olympia/pages/templates/pages/sunbird.html:4
+#: src/olympia/constants/applications.py:75 src/olympia/pages/templates/pages/sunbird.html:4
 msgid "Sunbird"
 msgstr "Sunbird"
 
@@ -4101,7 +3229,7 @@ msgstr "Preliminärt granskad"
 msgid "Preliminarily Reviewed and Awaiting Full Review"
 msgstr "Preliminärt granskad och väntar på fullständig granskning"
 
-#: src/olympia/constants/base.py:33 src/olympia/editors/helpers.py:924
+#: src/olympia/constants/base.py:33 src/olympia/editors/forms.py:258 src/olympia/editors/helpers.py:73 src/olympia/editors/helpers.py:1004
 #: src/olympia/editors/templates/editors/themes/history_table.html:34
 msgid "Deleted"
 msgstr "Borttagen"
@@ -4134,13 +3262,11 @@ msgstr "Utvecklare"
 msgid "Viewer"
 msgstr "Granskare"
 
-#: src/olympia/constants/base.py:137
-#: src/olympia/templates/mobile/header.html:7
+#: src/olympia/constants/base.py:137 src/olympia/templates/mobile/header.html:7
 msgid "Support"
 msgstr "Hjälp"
 
-#: src/olympia/constants/base.py:159 src/olympia/constants/base.py:172
-#: src/olympia/constants/platforms.py:10
+#: src/olympia/constants/base.py:159 src/olympia/constants/base.py:172 src/olympia/constants/platforms.py:10
 msgid "Any"
 msgstr "Alla"
 
@@ -4168,11 +3294,8 @@ msgstr "Språkpaket (tillägg)"
 msgid "Plugin"
 msgstr "Insticksmodul"
 
-#: src/olympia/constants/base.py:167
-#: src/olympia/editors/templates/editors/includes/search_results_themes.html:5
-#: src/olympia/editors/templates/editors/themes/deleted.html:18
-#: src/olympia/editors/templates/editors/themes/history_table.html:8
-#: src/olympia/editors/templates/editors/themes/logs.html:17
+#: src/olympia/constants/base.py:167 src/olympia/editors/templates/editors/includes/search_results_themes.html:5 src/olympia/editors/templates/editors/themes/deleted.html:18
+#: src/olympia/editors/templates/editors/themes/history_table.html:8 src/olympia/editors/templates/editors/themes/logs.html:17
 msgid "Theme"
 msgstr "Tema"
 
@@ -4204,6 +3327,11 @@ msgstr "Fråga efter användare börjat ladda ner detta tillägg"
 msgid "Ask before users can download this add-on"
 msgstr "Fråga innan användarna kan ladda ner detta tillägg"
 
+#. Review points sources other than add-ons and themes.
+#: src/olympia/constants/base.py:388 src/olympia/devhub/forms.py:162 src/olympia/editors/templates/editors/performance.html:75
+msgid "Other"
+msgstr "Annat"
+
 #: src/olympia/constants/base.py:389
 msgid "Exception"
 msgstr "Undantag"
@@ -4215,6 +3343,10 @@ msgstr "Utgåva"
 #: src/olympia/constants/base.py:391
 msgid "Change"
 msgstr "Ändra"
+
+#: src/olympia/constants/base.py:401
+msgid "App"
+msgstr "App"
 
 #: src/olympia/constants/base.py:402
 msgid "Persona"
@@ -4352,32 +3484,23 @@ msgstr "Signerad för en fullständig granskning"
 msgid "Signed of a preliminary review"
 msgstr "Signerad för en preliminär granskning"
 
-#: src/olympia/constants/editors.py:14
-#: src/olympia/editors/templates/editors/themes/queue.html:76
-#: src/olympia/editors/templates/editors/themes/themes.html:87
+#: src/olympia/constants/editors.py:14 src/olympia/editors/templates/editors/themes/queue.html:76 src/olympia/editors/templates/editors/themes/themes.html:87
 msgid "Request More Info"
 msgstr "Begär mer information"
 
-#: src/olympia/constants/editors.py:15
-#: src/olympia/editors/templates/editors/themes/queue.html:74
-#: src/olympia/editors/templates/editors/themes/themes.html:91
+#: src/olympia/constants/editors.py:15 src/olympia/editors/templates/editors/themes/queue.html:74 src/olympia/editors/templates/editors/themes/themes.html:91
 msgid "Flag"
 msgstr "Flagga"
 
-#: src/olympia/constants/editors.py:16
-#: src/olympia/editors/templates/editors/themes/queue.html:72
-#: src/olympia/editors/templates/editors/themes/themes.html:93
+#: src/olympia/constants/editors.py:16 src/olympia/editors/templates/editors/themes/queue.html:72 src/olympia/editors/templates/editors/themes/themes.html:93
 msgid "Duplicate"
 msgstr "Duplicera"
 
-#: src/olympia/constants/editors.py:17 src/olympia/editors/helpers.py:502
-#: src/olympia/editors/templates/editors/themes/queue.html:71
-#: src/olympia/editors/templates/editors/themes/themes.html:94
+#: src/olympia/constants/editors.py:17 src/olympia/editors/helpers.py:575 src/olympia/editors/templates/editors/themes/queue.html:71 src/olympia/editors/templates/editors/themes/themes.html:94
 msgid "Reject"
 msgstr "Avvisa"
 
-#: src/olympia/constants/editors.py:18
-#: src/olympia/editors/templates/editors/themes/queue.html:70
+#: src/olympia/constants/editors.py:18 src/olympia/editors/templates/editors/themes/queue.html:70
 msgid "Approve"
 msgstr "Godkänn"
 
@@ -4473,7 +3596,7 @@ msgstr "Solaris"
 msgid "Android"
 msgstr "Android"
 
-#: src/olympia/core/apps.py:19
+#: src/olympia/core/apps.py:21
 msgid "Core"
 msgstr "Kärna"
 
@@ -4510,9 +3633,7 @@ msgstr "Ogiltigt JSON-objekt"
 msgid "Message not eligible for annotation"
 msgstr "Meddelande berättigar inte till anteckning"
 
-#: src/olympia/devhub/forms.py:124
-#: src/olympia/devhub/templates/devhub/versions/edit.html:94
-#: src/olympia/users/templates/users/edit.html:150
+#: src/olympia/devhub/forms.py:124 src/olympia/devhub/templates/devhub/versions/edit.html:94 src/olympia/users/templates/users/edit.html:150
 msgid "Details"
 msgstr "Detaljer"
 
@@ -4609,38 +3730,26 @@ msgid "Submit my add-on for manual review."
 msgstr "Skicka in mitt tillägg för manuell granskning."
 
 #: src/olympia/devhub/forms.py:537
-msgid "Do not list my add-on on this site (beta)"
-msgstr "Lista inte mitt tillägg på denna webbplats (beta)"
+msgid "Do not list my add-on on this site"
+msgstr ""
 
 #: src/olympia/devhub/forms.py:538
-msgid ""
-"Check this option if you intend to distribute your add-on on your own and "
-"only need it to be signed by Mozilla."
-msgstr ""
-"Markera det här alternativet om du tänker distribuera ditt tillägg på egen "
-"hand och bara behöver det för att signeras av Mozilla."
+msgid "Check this option if you intend to distribute your add-on on your own and only need it to be signed by Mozilla."
+msgstr "Markera det här alternativet om du tänker distribuera ditt tillägg på egen hand och bara behöver det för att signeras av Mozilla."
 
 #: src/olympia/devhub/forms.py:544
 msgid "This add-on will be bundled with an application installer."
 msgstr "Detta tillägg kommer paketeras med en programinstallerare."
 
 #: src/olympia/devhub/forms.py:546
-msgid ""
-"Add-ons that are bundled with application installers will be code reviewed "
-"by Mozilla before they are signed and are held to a higher quality standard."
-msgstr ""
-"Tillägg som paketeras med programinstallerare kommer att kodgranskas av "
-"Mozilla innan de är signeras och skickas till en högre kvalitetsnivå."
+msgid "Add-ons that are bundled with application installers will be code reviewed by Mozilla before they are signed and are held to a higher quality standard."
+msgstr "Tillägg som paketeras med programinstallerare kommer att kodgranskas av Mozilla innan de är signeras och skickas till en högre kvalitetsnivå."
 
-#: src/olympia/devhub/forms.py:565
-#: src/olympia/devhub/templates/devhub/addons/submit/select-review.html:24
-#: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:42
+#: src/olympia/devhub/forms.py:565 src/olympia/devhub/templates/devhub/addons/submit/select-review.html:24 src/olympia/devhub/templates/devhub/docs/policies-reviews.html:42
 msgid "Full Review"
 msgstr "Fullständig granskning"
 
-#: src/olympia/devhub/forms.py:566
-#: src/olympia/devhub/templates/devhub/addons/submit/select-review.html:47
-#: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:153
+#: src/olympia/devhub/forms.py:566 src/olympia/devhub/templates/devhub/addons/submit/select-review.html:47 src/olympia/devhub/templates/devhub/docs/policies-reviews.html:153
 msgid "Preliminary Review"
 msgstr "Preliminär granskning"
 
@@ -4649,66 +3758,51 @@ msgid "Please choose a review nomination type"
 msgstr "Välj en nomineringstyp för granskning"
 
 #: src/olympia/devhub/forms.py:574
-msgid ""
-"A file with a version ending with a|alpha|b|beta|pre|rc and an optional "
-"number is detected as beta."
-msgstr ""
-"En fil med en version som slutar med a|alpha|b|beta|pre|rc och ett valfritt "
-"nummer detekteras som beta."
+msgid "A file with a version ending with a|alpha|b|beta|pre|rc and an optional number is detected as beta."
+msgstr "En fil med en version som slutar med a|alpha|b|beta|pre|rc och ett valfritt nummer detekteras som beta."
 
 #: src/olympia/devhub/forms.py:592
 #, python-format
-msgid "Version %s already exists"
-msgstr "Version %s finns redan"
-
-#: src/olympia/devhub/forms.py:604
-msgid ""
-"Select a valid choice. That choice is not one of the available choices."
+msgid "Version %s already exists, or was uploaded before."
 msgstr ""
-"Välj ett giltigt val. Detta val är inte en av de tillgängliga alternativen."
 
-#: src/olympia/devhub/forms.py:610
-msgid ""
-"A file with a version ending with a|alpha|b|beta and an optional number is "
-"detected as beta."
-msgstr ""
-"En fil med en version som slutar med a|alpha|b|beta och ett valfritt nummer "
-"detekteras som beta."
+#: src/olympia/devhub/forms.py:605
+msgid "Select a valid choice. That choice is not one of the available choices."
+msgstr "Välj ett giltigt val. Detta val är inte en av de tillgängliga alternativen."
 
-#: src/olympia/devhub/forms.py:633
+#: src/olympia/devhub/forms.py:611
+msgid "A file with a version ending with a|alpha|b|beta and an optional number is detected as beta."
+msgstr "En fil med en version som slutar med a|alpha|b|beta och ett valfritt nummer detekteras som beta."
+
+#: src/olympia/devhub/forms.py:634
 msgid "You cannot upload any more files for this version."
 msgstr "Du kan inte ladda upp några fler filer för denna version."
 
-#: src/olympia/devhub/forms.py:639
+#: src/olympia/devhub/forms.py:640
 msgid "Version doesn't match"
 msgstr "Version matchar inte"
 
-#: src/olympia/devhub/forms.py:668
-msgid ""
-"You cannot delete a file once the review process has started.  You must "
-"delete the whole version."
+#: src/olympia/devhub/forms.py:669
+msgid "You cannot delete a file once the review process has started.  You must delete the whole version."
 msgstr ""
-"Du kan inte ta bort en fil när granskningsprocessen har startat.  Du måste "
-"ta bort hela versionen."
 
-#: src/olympia/devhub/forms.py:688
+#: src/olympia/devhub/forms.py:689
 msgid "The platform All cannot be combined with specific platforms."
 msgstr "Plattformen Alla kan inte kombineras med specifika plattformar."
 
-#: src/olympia/devhub/forms.py:693
+#: src/olympia/devhub/forms.py:694
 msgid "A platform can only be chosen once."
 msgstr "En plattform kan endast väljas en gång."
 
-#: src/olympia/devhub/forms.py:706
+#: src/olympia/devhub/forms.py:707
 msgid "A review type must be selected."
 msgstr "En granskningstyp måste väljas."
 
-#: src/olympia/devhub/forms.py:788 src/olympia/editors/forms.py:114
-#: src/olympia/zadmin/forms.py:49 src/olympia/zadmin/forms.py:52
+#: src/olympia/devhub/forms.py:789 src/olympia/editors/forms.py:114 src/olympia/editors/forms.py:254 src/olympia/zadmin/forms.py:49 src/olympia/zadmin/forms.py:52
 msgid "Select an application first"
 msgstr "Välj en applikation först"
 
-#: src/olympia/devhub/forms.py:840
+#: src/olympia/devhub/forms.py:841
 msgid "There cannot be more than 3 required add-ons."
 msgstr "Det kan inte finnas fler än 3 tillägg som krävs."
 
@@ -4738,90 +3832,80 @@ msgid_plural "{0} warnings"
 msgstr[0] "{0} varning"
 msgstr[1] "{0} varningar"
 
-#: src/olympia/devhub/models.py:375
-#: src/olympia/reviews/templates/reviews/add.html:58
+#: src/olympia/devhub/models.py:375 src/olympia/reviews/templates/reviews/add.html:58
 msgid "Review"
 msgstr "Recensera"
 
-#: src/olympia/devhub/tasks.py:551
+#: src/olympia/devhub/tasks.py:583
 #, python-format
 msgid "%s responded with %s (%s)."
 msgstr "%s svarade med %s (%s)."
 
-#: src/olympia/devhub/tasks.py:555
+#: src/olympia/devhub/tasks.py:587
 #, python-format
 msgid "Connection to \"%s\" timed out."
 msgstr "Anslutning till \"%s\" gjorde timeout."
 
-#: src/olympia/devhub/tasks.py:557
+#: src/olympia/devhub/tasks.py:589
 #, python-format
 msgid "Could not contact host at \"%s\"."
 msgstr "Det gick inte att kontakta värd på \"%s\"."
 
-#: src/olympia/devhub/utils.py:104
+#: src/olympia/devhub/utils.py:105
 #, python-format
-msgid ""
-"Validation generated too many errors/warnings so %s messages were truncated."
-" After addressing the visible messages, you'll be able to see the others."
-msgstr ""
-"Validering genererade för många fel/varningar så %s meddelanden trunkerades."
-" Efter att ha tagit itu med de meddelande som visas, kommer du att kunna se "
-"de andra."
+msgid "Validation generated too many errors/warnings so %s messages were truncated. After addressing the visible messages, you'll be able to see the others."
+msgstr "Validering genererade för många fel/varningar så %s meddelanden trunkerades. Efter att ha tagit itu med de meddelande som visas, kommer du att kunna se de andra."
 
-#: src/olympia/devhub/views.py:183
+#: src/olympia/devhub/views.py:181
 msgid "All My Add-ons"
 msgstr "Alla mina tillägg"
 
-#: src/olympia/devhub/views.py:210
+#: src/olympia/devhub/views.py:208
 msgid "All Activity"
 msgstr "All aktivitet"
 
-#: src/olympia/devhub/views.py:211
+#: src/olympia/devhub/views.py:209
 msgid "Add-on Updates"
 msgstr "Tilläggsuppdateringar"
 
-#: src/olympia/devhub/views.py:212
+#: src/olympia/devhub/views.py:210
 msgid "Add-on Status"
 msgstr "Status för tillägg"
 
-#: src/olympia/devhub/views.py:213
+#: src/olympia/devhub/views.py:211
 msgid "User Collections"
 msgstr "Användarsamlingar"
 
-#: src/olympia/devhub/views.py:214
-#: src/olympia/devhub/templates/devhub/docs/policies-maintenance.html:68
-#: src/olympia/pages/templates/pages/dev_faq.html:38
+#: src/olympia/devhub/views.py:212 src/olympia/devhub/templates/devhub/docs/policies-maintenance.html:68 src/olympia/pages/templates/pages/dev_faq.html:38
 #: src/olympia/pages/templates/pages/dev_faq.html:484
 msgid "User Reviews"
 msgstr "Användarrecensioner"
 
-#: src/olympia/devhub/views.py:327 src/olympia/devhub/views.py:331
-#: src/olympia/devhub/views.py:484 src/olympia/devhub/views.py:513
-#: src/olympia/devhub/views.py:564 src/olympia/devhub/views.py:1150
+#: src/olympia/devhub/views.py:325 src/olympia/devhub/views.py:329 src/olympia/devhub/views.py:484 src/olympia/devhub/views.py:513 src/olympia/devhub/views.py:564 src/olympia/devhub/views.py:1156
 msgid "Changes successfully saved."
 msgstr "Ändringar sparade."
 
-#: src/olympia/devhub/views.py:334 src/olympia/devhub/views.py:1631
+#: src/olympia/devhub/views.py:332 src/olympia/devhub/views.py:1637
 msgid "Please check the form for errors."
 msgstr "Kontrollera formuläret efter fel."
 
-#: src/olympia/devhub/views.py:346
+#: src/olympia/devhub/views.py:344
 msgid "Add-on cannot be deleted. Disable this add-on instead."
 msgstr "Tillägg kan inte tas bort. Inaktivera detta tillägg istället."
 
-#: src/olympia/devhub/views.py:356
+#: src/olympia/devhub/views.py:354
 msgid "Theme deleted."
 msgstr "Tema borttaget."
 
-#: src/olympia/devhub/views.py:356
+#: src/olympia/devhub/views.py:354
 msgid "Add-on deleted."
 msgstr "Tillägg borttaget."
 
-#: src/olympia/devhub/views.py:362
+#: src/olympia/devhub/views.py:360
 msgid "URL name was incorrect. Theme was not deleted."
 msgstr "URL-namn var felaktig. Tema togs inte bort."
 
-#: src/olympia/devhub/views.py:367
+#: src/olympia/devhub/views.py:365
 msgid "URL name was incorrect. Add-on was not deleted."
 msgstr "URL-namn var felaktig. Tillägg togs inte bort."
 
@@ -4849,7 +3933,7 @@ msgstr "Validera tillägg"
 msgid "Check Add-on Compatibility"
 msgstr "Kontrollera tilläggets kompatibilitet"
 
-#: src/olympia/devhub/views.py:808 src/olympia/signing/views.py:90
+#: src/olympia/devhub/views.py:808 src/olympia/signing/views.py:95
 msgid "You cannot submit this type of add-on"
 msgstr "Du kan inte skicka in denna typ av tillägg"
 
@@ -4879,53 +3963,39 @@ msgstr "Bild måste vara exakt {0} pixlar bred och {1} pixlar hög."
 msgid "There was an error uploading your preview."
 msgstr "Ett fel uppstod med uppladdning av förhandsvisning."
 
-#: src/olympia/devhub/views.py:1189
+#: src/olympia/devhub/views.py:1195
 #, python-format
 msgid "Version %s disabled."
 msgstr "Version %s inaktiverad."
 
-#: src/olympia/devhub/views.py:1193
+#: src/olympia/devhub/views.py:1199
 #, python-format
 msgid "Version %s deleted."
 msgstr "Version %s borttagen."
 
-#: src/olympia/devhub/views.py:1203
-msgid ""
-"This upload has failed validation, and may lack complete validation results."
-" Please take due care when reviewing it."
-msgstr ""
-"Denna uppladdning har misslyckats med validering och kan sakna fullständigt "
-"valideringsresultat. Ta hänsyn till detta vid granskning."
+#: src/olympia/devhub/views.py:1209
+msgid "This upload has failed validation, and may lack complete validation results. Please take due care when reviewing it."
+msgstr "Denna uppladdning har misslyckats med validering och kan sakna fullständigt valideringsresultat. Ta hänsyn till detta vid granskning."
 
-#: src/olympia/devhub/views.py:1677
+#: src/olympia/devhub/views.py:1683
 msgid "Preliminary Review Requested."
 msgstr "Preliminär granskning begärd."
 
-#: src/olympia/devhub/views.py:1678
+#: src/olympia/devhub/views.py:1684
 msgid "Full Review Requested."
 msgstr "Fullständig granskning begärd."
 
-#: src/olympia/devhub/views.py:1779
-msgid ""
-"Your old credentials were revoked and are no longer valid. Be sure to update"
-" all API clients with the new credentials."
-msgstr ""
-"Dina gamla autentiseringsuppgifter har återkallats och är inte längre "
-"giltiga. Var noga med att uppdatera alla API-klienter med nya uppgifter."
+#: src/olympia/devhub/views.py:1783
+msgid "Your old credentials were revoked and are no longer valid. Be sure to update all API clients with the new credentials."
+msgstr "Dina gamla autentiseringsuppgifter har återkallats och är inte längre giltiga. Var noga med att uppdatera alla API-klienter med nya uppgifter."
 
-#: src/olympia/devhub/views.py:1797
+#: src/olympia/devhub/views.py:1801
 msgid "New API key created"
 msgstr "Nya API-nyckel skapad"
 
 #: src/olympia/devhub/templates/devhub/agreement.html:2
-msgid ""
-"Before starting, please read and accept our Firefox Add-on Distribution "
-"Agreement. It also links to our Privacy Notice which explains how we handle "
-"your information."
-msgstr ""
-"Innan du börjar, läs och acceptera vår distributionsavtal för Firefox-"
-"tillägg. Den länkar också till vår sekretesspolicy som förklarar hur vi "
-"hanterar dina uppgifter."
+msgid "Before starting, please read and accept our Firefox Add-on Distribution Agreement. It also links to our Privacy Notice which explains how we handle your information."
+msgstr "Innan du börjar, läs och acceptera vår distributionsavtal för Firefox-tillägg. Den länkar också till vår sekretesspolicy som förklarar hur vi hanterar dina uppgifter."
 
 #: src/olympia/devhub/templates/devhub/agreement.html:13
 msgid "Printable Version"
@@ -4939,44 +4009,30 @@ msgstr "Jag accepterar detta avtal"
 msgid "or <a href=\"{0}\">Cancel</a>"
 msgstr "eller <a href=\"{0}\">Avbryt</a>"
 
-#: src/olympia/devhub/templates/devhub/base.html:23
-#: src/olympia/devhub/templates/devhub/base_impala.html:20
-#: src/olympia/discovery/templates/discovery/addons/base.html:17
+#: src/olympia/devhub/templates/devhub/base.html:23 src/olympia/devhub/templates/devhub/base_impala.html:20 src/olympia/discovery/templates/discovery/addons/base.html:17
 msgid "Back to Add-ons"
 msgstr "Tillbaka till tillägg"
 
 #. {0} is a search term, such as Firebug.
 #. {0} is a search query.
-#: src/olympia/devhub/templates/devhub/devhub_search.html:4
-#: src/olympia/search/templates/search/results.html:9
-#: src/olympia/search/templates/search/mobile/results.html:6
+#: src/olympia/devhub/templates/devhub/devhub_search.html:4 src/olympia/search/templates/search/results.html:9 src/olympia/search/templates/search/mobile/results.html:6
 msgid "{0} :: Search"
 msgstr "{0} :: Sök"
 
-#: src/olympia/devhub/templates/devhub/devhub_search.html:6
-#: src/olympia/devhub/templates/devhub/search.html:8
-#: src/olympia/editors/forms.py:435 src/olympia/editors/forms.py:437
-#: src/olympia/editors/templates/editors/queue.html:27
-#: src/olympia/editors/templates/editors/themes/queue_list.html:14
-#: src/olympia/search/templates/search/collections.html:17
-#: src/olympia/search/templates/search/personas.html:18
-#: src/olympia/search/templates/search/results.html:18
-#: src/olympia/search/templates/search/mobile/results.html:8
-#: src/olympia/templates/search.html:14
-#: src/olympia/templates/impala/search.html:18
+#: src/olympia/devhub/templates/devhub/devhub_search.html:6 src/olympia/devhub/templates/devhub/search.html:8 src/olympia/editors/forms.py:534 src/olympia/editors/forms.py:536
+#: src/olympia/editors/templates/editors/queue.html:27 src/olympia/editors/templates/editors/themes/queue_list.html:14 src/olympia/search/templates/search/collections.html:17
+#: src/olympia/search/templates/search/personas.html:18 src/olympia/search/templates/search/results.html:18 src/olympia/search/templates/search/mobile/results.html:8
+#: src/olympia/templates/search.html:14 src/olympia/templates/impala/search.html:18
 msgid "Search"
 msgstr "Sök"
 
-#: src/olympia/devhub/templates/devhub/devhub_search.html:11
-#: src/olympia/devhub/templates/devhub/devhub_search.html:15
-#: src/olympia/search/templates/search/collections.html:18
+#: src/olympia/devhub/templates/devhub/devhub_search.html:11 src/olympia/devhub/templates/devhub/devhub_search.html:15 src/olympia/search/templates/search/collections.html:18
 #: src/olympia/search/templates/search/personas.html:20
 msgid "Search Results"
 msgstr "Sökresultat"
 
 #. {0} is a search term, such as Firebug.
-#: src/olympia/devhub/templates/devhub/devhub_search.html:13
-#: src/olympia/search/templates/search/results.html:11
+#: src/olympia/devhub/templates/devhub/devhub_search.html:13 src/olympia/search/templates/search/results.html:11
 msgid "Search Results for \"{0}\""
 msgstr "Sökresultat för \"{0}\""
 
@@ -4997,11 +4053,8 @@ msgid "AMO Reviewers"
 msgstr "AMO-granskare"
 
 #: src/olympia/devhub/templates/devhub/index.html:29
-msgid ""
-"Get ahead! Become an AMO Reviewer today and get your add-ons reviewed "
-"faster."
-msgstr ""
-"Avancera! Bli en AMO-granskare idag och få ditt tillägg granskat snabbare."
+msgid "Get ahead! Become an AMO Reviewer today and get your add-ons reviewed faster."
+msgstr "Avancera! Bli en AMO-granskare idag och få ditt tillägg granskat snabbare."
 
 #: src/olympia/devhub/templates/devhub/index.html:32
 msgid "Become an AMO Reviewer"
@@ -5013,41 +4066,28 @@ msgstr "Lär dig allt om tillägg"
 
 #: src/olympia/devhub/templates/devhub/index.html:41
 msgid ""
-"Add-ons let millions of Firefox users enhance and customize their browsing "
-"experience. If you're a Web developer and know <a "
-"href=\"https://developer.mozilla.org/docs/Web/HTML\">HTML</a>, <a "
-"href=\"https://developer.mozilla.org/docs/Web/JavaScript\">JavaScript</a>, "
-"and <a href=\"https://developer.mozilla.org/docs/Web/CSS\">CSS</a>, you "
-"already have all the necessary skills to make a great add-on."
+"Add-ons let millions of Firefox users enhance and customize their browsing experience. If you're a Web developer and know <a href=\"https://developer.mozilla.org/docs/Web/HTML\">HTML</a>, <a href="
+"\"https://developer.mozilla.org/docs/Web/JavaScript\">JavaScript</a>, and <a href=\"https://developer.mozilla.org/docs/Web/CSS\">CSS</a>, you already have all the necessary skills to make a great "
+"add-on."
 msgstr ""
-"Tillägg låter miljontals Firefox-användare förbättra och anpassa sin "
-"webbupplevelse. Om du är en webbutvecklare och har kunskap inom <a "
-"href=\"https://developer.mozilla.org/docs/Web/HTML\">HTML</a>, <a "
-"href=\"https://developer.mozilla.org/docs/Web/JavaScript\">JavaScript</a> "
-"och <a href=\"https://developer.mozilla.org/docs/Web/CSS\">CSS</a>, har du "
-"redan alla de kunskaper som behövs för att skapa ett bra tillägg."
+"Tillägg låter miljontals Firefox-användare förbättra och anpassa sin webbupplevelse. Om du är en webbutvecklare och har kunskap inom <a href=\"https://developer.mozilla.org/docs/Web/HTML\">HTML</"
+"a>, <a href=\"https://developer.mozilla.org/docs/Web/JavaScript\">JavaScript</a> och <a href=\"https://developer.mozilla.org/docs/Web/CSS\">CSS</a>, har du redan alla de kunskaper som behövs för "
+"att skapa ett bra tillägg."
 
 #: src/olympia/devhub/templates/devhub/index.html:51
-msgid ""
-"Head over to the <a href=\"https://developer.mozilla.org/Add-ons\">Mozilla "
-"Developer Network</a> to learn everything you need to know to get started."
-msgstr ""
-"Bege dig till <a href=\"https://developer.mozilla.org/Add-ons\">Mozilla "
-"utvecklarnätverk</a> för att lära dig allt du behöver för att komma igång."
+msgid "Head over to the <a href=\"https://developer.mozilla.org/Add-ons\">Mozilla Developer Network</a> to learn everything you need to know to get started."
+msgstr "Bege dig till <a href=\"https://developer.mozilla.org/Add-ons\">Mozilla utvecklarnätverk</a> för att lära dig allt du behöver för att komma igång."
 
 #: src/olympia/devhub/templates/devhub/index.html:58
 msgid "Start Making Add-ons"
 msgstr "Börja skapa tillägg"
 
-#: src/olympia/devhub/templates/devhub/index.html:86
-#: src/olympia/devhub/templates/devhub/addons/listing/items.html:25
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:15
+#: src/olympia/devhub/templates/devhub/index.html:86 src/olympia/devhub/templates/devhub/addons/listing/items.html:25 src/olympia/devhub/templates/devhub/includes/addon_details.html:20
 #: src/olympia/devhub/templates/devhub/personas/edit.html:43
 msgid "Status:"
 msgstr "Status:"
 
-#: src/olympia/devhub/templates/devhub/index.html:90
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:100
+#: src/olympia/devhub/templates/devhub/index.html:90 src/olympia/devhub/templates/devhub/includes/addon_details.html:87
 msgid "Visibility:"
 msgstr "Synlighet:"
 
@@ -5055,21 +4095,16 @@ msgstr "Synlighet:"
 msgid "Latest Version:"
 msgstr "Senaste version:"
 
-#: src/olympia/devhub/templates/devhub/index.html:109
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:145
-#: src/olympia/devhub/templates/devhub/personas/edit.html:49
+#: src/olympia/devhub/templates/devhub/index.html:109 src/olympia/devhub/templates/devhub/includes/addon_details.html:131 src/olympia/devhub/templates/devhub/personas/edit.html:49
 msgid "Queue Position:"
 msgstr "Köplats:"
 
-#: src/olympia/devhub/templates/devhub/index.html:110
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:146
-#: src/olympia/devhub/templates/devhub/personas/edit.html:50
+#: src/olympia/devhub/templates/devhub/index.html:110 src/olympia/devhub/templates/devhub/includes/addon_details.html:132 src/olympia/devhub/templates/devhub/personas/edit.html:50
 #, python-format
 msgid "%(position)s of %(total)s"
 msgstr "%(position)s av %(total)s"
 
-#: src/olympia/devhub/templates/devhub/index.html:120
-#: src/olympia/devhub/templates/devhub/includes/addons_edit_nav.html:19
+#: src/olympia/devhub/templates/devhub/index.html:120 src/olympia/devhub/templates/devhub/includes/addons_edit_nav.html:19
 msgid "Upload New Version"
 msgstr "Ladda upp ny version"
 
@@ -5083,12 +4118,8 @@ msgstr "Publicera dina tillägg!"
 
 #: src/olympia/devhub/templates/devhub/index.html:136
 #, python-format
-msgid ""
-"Upload an <a href=\"%(addon_url)s\">add-on</a> or <a "
-"href=\"%(theme_url)s\">theme</a> to get started!"
-msgstr ""
-"Ladda upp ett <a href=\"%(addon_url)s\">tillägg</a> eller <a "
-"href=\"%(theme_url)s\">tema</a> för att komma igång!"
+msgid "Upload an <a href=\"%(addon_url)s\">add-on</a> or <a href=\"%(theme_url)s\">theme</a> to get started!"
+msgstr "Ladda upp ett <a href=\"%(addon_url)s\">tillägg</a> eller <a href=\"%(theme_url)s\">tema</a> för att komma igång!"
 
 #: src/olympia/devhub/templates/devhub/nav.html:2
 msgid "Return to the DevHub homepage"
@@ -5115,17 +4146,10 @@ msgstr "Utökningsutveckling"
 msgid "Lightweight Themes"
 msgstr "Lätta teman"
 
-#: src/olympia/devhub/templates/devhub/nav.html:39
-#: src/olympia/devhub/templates/devhub/docs/policies-agreement.html:6
-#: src/olympia/devhub/templates/devhub/docs/policies-contact.html:6
-#: src/olympia/devhub/templates/devhub/docs/policies-maintenance.html:6
-#: src/olympia/devhub/templates/devhub/docs/policies-recommended.html:6
-#: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:6
-#: src/olympia/devhub/templates/devhub/docs/policies-submission.html:6
-#: src/olympia/devhub/templates/devhub/docs/policies.html:3
-#: src/olympia/devhub/templates/devhub/docs/policies.html:9
-#: src/olympia/devhub/templates/devhub/docs/policies.html:38
-#: src/olympia/devhub/templates/devhub/docs/policies.html:39
+#: src/olympia/devhub/templates/devhub/nav.html:39 src/olympia/devhub/templates/devhub/docs/policies-agreement.html:6 src/olympia/devhub/templates/devhub/docs/policies-contact.html:6
+#: src/olympia/devhub/templates/devhub/docs/policies-maintenance.html:6 src/olympia/devhub/templates/devhub/docs/policies-recommended.html:6
+#: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:6 src/olympia/devhub/templates/devhub/docs/policies-submission.html:6 src/olympia/devhub/templates/devhub/docs/policies.html:3
+#: src/olympia/devhub/templates/devhub/docs/policies.html:9 src/olympia/devhub/templates/devhub/docs/policies.html:38 src/olympia/devhub/templates/devhub/docs/policies.html:39
 msgid "Add-on Policies"
 msgstr "Riktlinjer för tillägg"
 
@@ -5166,45 +4190,16 @@ msgid "Use the field below to upload your add-on package."
 msgstr "Använd fältet nedan för att ladda upp ditt tilläggspaket."
 
 #: src/olympia/devhub/templates/devhub/validate_addon.html:19
-msgid ""
-"After upload, a series of automated validation tests will run to check "
-"compatibility with the following application version:"
-msgstr ""
-"Efter uppladdning, kommer en rad automatiserade valideringstester körs för "
-"att kontrollera kompatibilitet med följande programversionen:"
+msgid "After upload, a series of automated validation tests will run to check compatibility with the following application version:"
+msgstr "Efter uppladdning, kommer en rad automatiserade valideringstester körs för att kontrollera kompatibilitet med följande programversionen:"
 
 #: src/olympia/devhub/templates/devhub/validate_addon.html:34
-msgid ""
-"After upload, a series of automated validation tests will be run on your "
-"file."
-msgstr ""
-"Efter uppladdning, kommer en rad automatiserade valideringstester köras på "
-"din fil."
+msgid "After upload, a series of automated validation tests will be run on your file."
+msgstr "Efter uppladdning, kommer en rad automatiserade valideringstester köras på din fil."
 
-#: src/olympia/devhub/templates/devhub/validate_addon.html:42
-#: src/olympia/devhub/templates/devhub/addons/submit/upload.html:23
+#: src/olympia/devhub/templates/devhub/validate_addon.html:42 src/olympia/devhub/templates/devhub/addons/submit/upload.html:23
 msgid "Do you want your add-on to be distributed on this site?"
 msgstr "Vill du att ditt tillägg ska distribueras på denna webbplats?"
-
-#: src/olympia/devhub/templates/devhub/validate_addon.html:49
-#: src/olympia/devhub/templates/devhub/addons/submit/upload.html:30
-#: src/olympia/devhub/templates/devhub/versions/add_file_modal.html:14
-#: src/olympia/devhub/templates/devhub/versions/add_file_modal.html:53
-#: src/olympia/devhub/templates/devhub/versions/list.html:298
-msgid "Warning:"
-msgstr "Varning:"
-
-#: src/olympia/devhub/templates/devhub/validate_addon.html:50
-#: src/olympia/devhub/templates/devhub/addons/submit/upload.html:31
-#, python-format
-msgid ""
-"Submission of unlisted add-ons for signing is currently in an open beta. "
-"Please <a href=\"%(url)s\" target=\"_blank\">report any bugs</a> that you "
-"encounter."
-msgstr ""
-"Att skicka in olistade tillägg för signering befinner sig i en öppen beta. "
-"<a href=\"%(url)s\" target=\"_blank\">Rapportera eventuella buggar</a> som "
-"du stöter på."
 
 #. first parameter is a filename like lorem-ipsum-1.0.2.xpi
 #: src/olympia/devhub/templates/devhub/validation.html:5
@@ -5223,14 +4218,11 @@ msgstr "Validerad på:"
 msgid "Tested for compatibility against:"
 msgstr "Testas för kompatibilitet mot:"
 
-#: src/olympia/devhub/templates/devhub/addons/activity.html:4
-#: src/olympia/devhub/templates/devhub/addons/activity.html:20
+#: src/olympia/devhub/templates/devhub/addons/activity.html:4 src/olympia/devhub/templates/devhub/addons/activity.html:20
 msgid "Recent Activity for My Add-ons"
 msgstr "Senaste aktivitet för mina tillägg"
 
-#: src/olympia/devhub/templates/devhub/addons/activity.html:14
-#: src/olympia/devhub/templates/devhub/addons/activity.html:19
-#: src/olympia/devhub/templates/devhub/addons/dashboard.html:33
+#: src/olympia/devhub/templates/devhub/addons/activity.html:14 src/olympia/devhub/templates/devhub/addons/activity.html:19 src/olympia/devhub/templates/devhub/addons/dashboard.html:33
 msgid "Recent Activity"
 msgstr "Senaste aktivitet"
 
@@ -5252,44 +4244,34 @@ msgstr "Begränsa aktivitet"
 msgid "Activity"
 msgstr "Aktivitet"
 
-#: src/olympia/devhub/templates/devhub/addons/activity.html:83
-#: src/olympia/devhub/templates/devhub/addons/dashboard.html:34
-#: src/olympia/devhub/templates/devhub/addons/dashboard.html:35
-#: src/olympia/devhub/templates/devhub/includes/blog_posts.html:4
-#: src/olympia/devhub/templates/devhub/includes/blog_posts.html:6
+#: src/olympia/devhub/templates/devhub/addons/activity.html:83 src/olympia/devhub/templates/devhub/addons/dashboard.html:34 src/olympia/devhub/templates/devhub/addons/dashboard.html:35
+#: src/olympia/devhub/templates/devhub/includes/blog_posts.html:4 src/olympia/devhub/templates/devhub/includes/blog_posts.html:6
 msgid "Subscribe to this feed"
 msgstr "Prenumerera på denna kanal"
 
 #: src/olympia/devhub/templates/devhub/addons/ajax_compat_error.html:7
 #, python-format
 msgid ""
-"This add-on is incompatible with <b>%(app_name)s %(app_version)s</b>, the "
-"latest release of %(app_name)s. Please consider updating your add-on's "
-"compatibility info, or uploading a newer version of this add-on."
+"This add-on is incompatible with <b>%(app_name)s %(app_version)s</b>, the latest release of %(app_name)s. Please consider updating your add-on's compatibility info, or uploading a newer version of "
+"this add-on."
 msgstr ""
-"Detta tillägg är inte kompatibel med <b>%(app_name)s %(app_version)s</b>, "
-"den senaste versionen av %(app_name)s. Överväg att uppdatera ditt tilläggs "
-"kompatibilitetsinfo eller ladda upp en nyare version av detta tillägg."
+"Detta tillägg är inte kompatibel med <b>%(app_name)s %(app_version)s</b>, den senaste versionen av %(app_name)s. Överväg att uppdatera ditt tilläggs kompatibilitetsinfo eller ladda upp en nyare "
+"version av detta tillägg."
 
 #: src/olympia/devhub/templates/devhub/addons/ajax_compat_error.html:15
 #, python-format
 msgid ""
-"<a href=\"#\" class=\"button compat-update\" data-"
-"updateurl=\"%(update_url)s\">Update Compatibility</a> <a "
-"href=\"%(version_url)s\" class=\"button\">Upload New Version</a> or <a "
-"href=\"#\" class=\"close\">Ignore</a>"
+"<a href=\"#\" class=\"button compat-update\" data-updateurl=\"%(update_url)s\">Update Compatibility</a> <a href=\"%(version_url)s\" class=\"button\">Upload New Version</a> or <a href=\"#\" class="
+"\"close\">Ignore</a>"
 msgstr ""
-"<a href=\"#\" class=\"button compat-update\" data-"
-"updateurl=\"%(update_url)s\">Uppdatera kompatibilitet</a> <a "
-"href=\"%(version_url)s\" class=\"button\">Ladda upp ny version</a> or <a "
-"href=\"#\" class=\"close\">Ignorera</a>"
+"<a href=\"#\" class=\"button compat-update\" data-updateurl=\"%(update_url)s\">Uppdatera kompatibilitet</a> <a href=\"%(version_url)s\" class=\"button\">Ladda upp ny version</a> or <a href=\"#\" "
+"class=\"close\">Ignorera</a>"
 
 #: src/olympia/devhub/templates/devhub/addons/ajax_compat_status.html:5
 msgid "View and update application compatibility ranges."
 msgstr "Visa och uppdatera applikationskompatibilitetsområden"
 
-#: src/olympia/devhub/templates/devhub/addons/ajax_compat_status.html:6
-#: src/olympia/devhub/templates/devhub/versions/edit.html:44
+#: src/olympia/devhub/templates/devhub/addons/ajax_compat_status.html:6 src/olympia/devhub/templates/devhub/versions/edit.html:44
 msgid "Compatibility"
 msgstr "Kompatibilitet"
 
@@ -5297,39 +4279,25 @@ msgstr "Kompatibilitet"
 msgid "Update Compatibility"
 msgstr "Uppdatera kompatibilitet"
 
-#: src/olympia/devhub/templates/devhub/addons/ajax_compat_update.html:4
-msgid ""
-"Adjusting application information here will allow users to install your add-"
-"on even if the install manifest in the package indicates that the add-on is "
-"incompatible."
-msgstr ""
-"Att justera applikationens information här, kommer att tillåta användare att"
-" installera tillägget även om installationsmanifestet i paketet visar att "
-"tillägget inte är kompatibel."
+#: src/olympia/devhub/templates/devhub/addons/ajax_compat_update.html:4 src/olympia/devhub/templates/devhub/versions/edit.html:45
+msgid "Adjusting application information here will allow users to install your add-on even if the install manifest in the package indicates that the add-on is incompatible."
+msgstr "Att justera applikationens information här, kommer att tillåta användare att installera tillägget även om installationsmanifestet i paketet visar att tillägget inte är kompatibel."
 
 #: src/olympia/devhub/templates/devhub/addons/ajax_compat_update.html:18
 msgid "Supported Versions"
 msgstr "Versioner som stöds"
 
-#: src/olympia/devhub/templates/devhub/addons/ajax_compat_update.html:31
-#: src/olympia/devhub/templates/devhub/versions/edit.html:63
+#: src/olympia/devhub/templates/devhub/addons/ajax_compat_update.html:31 src/olympia/devhub/templates/devhub/versions/edit.html:63
 msgid "Add Another Application&hellip;"
 msgstr "Lägg till en annan applikation&hellip;"
 
-#: src/olympia/devhub/templates/devhub/addons/ajax_compat_update.html:38
-#: src/olympia/devhub/templates/devhub/addons/owner.html:86
-#: src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:46
-#: src/olympia/devhub/templates/devhub/versions/list.html:351
-#: src/olympia/devhub/templates/devhub/versions/list.html:353
-#: src/olympia/templates/impala/base.html:132
-#: src/olympia/templates/impala/base.html:143
-#: src/olympia/templates/impala/base.html:161
-#: src/olympia/templates/impala/base.html:171
+#: src/olympia/devhub/templates/devhub/addons/ajax_compat_update.html:38 src/olympia/devhub/templates/devhub/addons/owner.html:86 src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:45
+#: src/olympia/devhub/templates/devhub/versions/list.html:349 src/olympia/devhub/templates/devhub/versions/list.html:351 src/olympia/templates/impala/base.html:129
+#: src/olympia/templates/impala/base.html:140 src/olympia/templates/impala/base.html:158 src/olympia/templates/impala/base.html:168
 msgid "Close"
 msgstr "Stäng"
 
-#: src/olympia/devhub/templates/devhub/addons/dashboard.html:43
-#: src/olympia/zadmin/templates/zadmin/index.html:22
+#: src/olympia/devhub/templates/devhub/addons/dashboard.html:43 src/olympia/zadmin/templates/zadmin/index.html:22
 #, python-format
 msgid "%(ago)s by %(user)s"
 msgstr "%(ago)s av %(user)s"
@@ -5345,29 +4313,21 @@ msgid_plural "<b>{0}</b> themes"
 msgstr[0] "<b>{0}</b> tema"
 msgstr[1] "<b>{0}</b> teman"
 
-#: src/olympia/devhub/templates/devhub/addons/edit.html:3
-#: src/olympia/devhub/templates/devhub/addons/listing/item_actions.html:25
-#: src/olympia/devhub/templates/devhub/addons/listing/item_actions_theme.html:7
-#: src/olympia/devhub/templates/devhub/includes/addons_edit_nav.html:2
-#: src/olympia/devhub/templates/devhub/personas/edit.html:6
-#: src/olympia/editors/templates/editors/themes/single.html:37
+#: src/olympia/devhub/templates/devhub/addons/edit.html:3 src/olympia/devhub/templates/devhub/addons/listing/item_actions.html:25
+#: src/olympia/devhub/templates/devhub/addons/listing/item_actions_theme.html:7 src/olympia/devhub/templates/devhub/includes/addons_edit_nav.html:2
+#: src/olympia/devhub/templates/devhub/personas/edit.html:6 src/olympia/editors/templates/editors/themes/single.html:37
 msgid "Edit Listing"
 msgstr "Redigera listning"
 
-#: src/olympia/devhub/templates/devhub/addons/edit.html:13
-#: src/olympia/devhub/templates/devhub/includes/macros.html:18
-#: src/olympia/translations/templates/translations/all-locales.html:6
+#: src/olympia/devhub/templates/devhub/addons/edit.html:13 src/olympia/devhub/templates/devhub/includes/macros.html:18 src/olympia/translations/templates/translations/all-locales.html:6
 msgid "None"
 msgstr "Ingen"
 
-#: src/olympia/devhub/templates/devhub/addons/owner.html:4
-#: src/olympia/devhub/templates/devhub/addons/listing/item_actions.html:52
-#: src/olympia/devhub/templates/devhub/includes/addons_edit_nav.html:3
+#: src/olympia/devhub/templates/devhub/addons/owner.html:4 src/olympia/devhub/templates/devhub/addons/listing/item_actions.html:52 src/olympia/devhub/templates/devhub/includes/addons_edit_nav.html:3
 msgid "Manage Authors & License"
 msgstr "Hantera upphovsmän & licens"
 
-#: src/olympia/devhub/templates/devhub/addons/owner.html:29
-#: src/olympia/editors/templates/editors/review.html:270
+#: src/olympia/devhub/templates/devhub/addons/owner.html:29 src/olympia/editors/helpers.py:362 src/olympia/editors/templates/editors/review.html:270
 msgid "Authors"
 msgstr "Upphovsmän"
 
@@ -5377,35 +4337,22 @@ msgstr "Om roller för upphovsmän"
 
 #: src/olympia/devhub/templates/devhub/addons/owner.html:78
 msgid ""
-"<p>Add-ons can have any number of authors with 3 possible roles:</p> <ul> "
-"<li><b>Owner:</b> Can manage all aspects of the add-on's listing, including "
-"adding and removing other authors</li> <li><b>Developer:</b> Can manage all "
-"aspects of the add-on's listing, except for adding and removing other "
-"authors and managing payments</li> <li><b>Viewer:</b> Can view the add-on's "
-"settings and statistics, but cannot make any changes</li> </ul>"
+"<p>Add-ons can have any number of authors with 3 possible roles:</p> <ul> <li><b>Owner:</b> Can manage all aspects of the add-on's listing, including adding and removing other authors</li> "
+"<li><b>Developer:</b> Can manage all aspects of the add-on's listing, except for adding and removing other authors and managing payments</li> <li><b>Viewer:</b> Can view the add-on's settings and "
+"statistics, but cannot make any changes</li> </ul>"
 msgstr ""
-"<p>Tillägg kan ha hur många upphovsmän, med 3 möjliga roller: :</p> <ul> "
-"<li><b>Ägare:</b> Kan hantera alla aspekter av tilläggets listning, "
-"inklusive lägga till och ta bort andra upphovsmän</li> "
-"<li><b>Utvecklare:</b> Kan hantera alla aspekter av tilläggets listning, med"
-" undantag för att lägga till och ta bort andra upphovsmän och hantera "
-"betalningar </li> <li><b>Betraktare:</b> kan visa tilläggets inställningar "
-"och statistik, men kan inte göra några ändringar</li> </ul>"
+"<p>Tillägg kan ha hur många upphovsmän, med 3 möjliga roller: :</p> <ul> <li><b>Ägare:</b> Kan hantera alla aspekter av tilläggets listning, inklusive lägga till och ta bort andra upphovsmän</li> "
+"<li><b>Utvecklare:</b> Kan hantera alla aspekter av tilläggets listning, med undantag för att lägga till och ta bort andra upphovsmän och hantera betalningar </li> <li><b>Betraktare:</b> kan visa "
+"tilläggets inställningar och statistik, men kan inte göra några ändringar</li> </ul>"
 
-#: src/olympia/devhub/templates/devhub/addons/profile.html:3
-#: src/olympia/devhub/templates/devhub/addons/listing/item_actions.html:53
-#: src/olympia/devhub/templates/devhub/includes/addons_edit_nav.html:4
+#: src/olympia/devhub/templates/devhub/addons/profile.html:3 src/olympia/devhub/templates/devhub/addons/listing/item_actions.html:53 src/olympia/devhub/templates/devhub/includes/addons_edit_nav.html:4
 msgid "Manage Developer Profile"
 msgstr "Hantera utvecklarprofil"
 
 #: src/olympia/devhub/templates/devhub/addons/profile.html:16
 #, python-format
-msgid ""
-"Your <a href=\"%(url)s\">developer profile</a> is currently "
-"<strong>public</strong> and <strong>required</strong> for contributions."
-msgstr ""
-"Din <a href=\"%(url)s\">utvecklarprofil</a> är för närvarande "
-"<strong>publik</strong> och det <strong>krävs</strong> för bidrag."
+msgid "Your <a href=\"%(url)s\">developer profile</a> is currently <strong>public</strong> and <strong>required</strong> for contributions."
+msgstr "Din <a href=\"%(url)s\">utvecklarprofil</a> är för närvarande <strong>publik</strong> och det <strong>krävs</strong> för bidrag."
 
 #: src/olympia/devhub/templates/devhub/addons/profile.html:22
 msgid "Remove Both"
@@ -5413,12 +4360,8 @@ msgstr "Ta bort båda"
 
 #: src/olympia/devhub/templates/devhub/addons/profile.html:27
 #, python-format
-msgid ""
-"Your <a href=\"%(url)s\">developer profile</a> is currently "
-"<strong>public</strong>."
-msgstr ""
-"Din <a href=\"%(url)s\">utvecklarprofil</a> är för närvarande "
-"<strong>publik</strong>."
+msgid "Your <a href=\"%(url)s\">developer profile</a> is currently <strong>public</strong>."
+msgstr "Din <a href=\"%(url)s\">utvecklarprofil</a> är för närvarande <strong>publik</strong>."
 
 #: src/olympia/devhub/templates/devhub/addons/profile.html:33
 msgid "Remove Profile"
@@ -5445,11 +4388,8 @@ msgstr "URL för tillägg"
 msgid "Choose a short, unique URL slug for your add-on."
 msgstr "Välj en kort, unikt URL slugg för ditt tillägg."
 
-#: src/olympia/devhub/templates/devhub/addons/edit/basic.html:43
-#: src/olympia/devhub/templates/devhub/includes/addons_edit_nav.html:35
-#: src/olympia/devhub/templates/devhub/personas/edit.html:56
-#: src/olympia/editors/templates/editors/review.html:255
-#: src/olympia/editors/templates/editors/themes/single.html:33
+#: src/olympia/devhub/templates/devhub/addons/edit/basic.html:43 src/olympia/devhub/templates/devhub/includes/addons_edit_nav.html:35 src/olympia/devhub/templates/devhub/personas/edit.html:56
+#: src/olympia/editors/templates/editors/review.html:255 src/olympia/editors/templates/editors/themes/single.html:33
 msgid "View Listing"
 msgstr "Visa listning"
 
@@ -5459,10 +4399,7 @@ msgstr "Sammanfattning"
 
 #: src/olympia/devhub/templates/devhub/addons/edit/basic.html:52
 msgid ""
-"A short explanation of your add-on's basic\n"
-"                          functionality that is displayed in search and browse\n"
-"                          listings, as well as at the top of your add-on's\n"
-"                          details page. It is only relevant for listed add-ons."
+"A short explanation of your add-on's basic functionality that is displayed in search and browse listings, as well as at the top of your add-on's details page. It is only relevant for listed add-ons."
 msgstr ""
 "En kort förklaring av din tilläggs grundfunktionalitet\n"
 "                          som visas i sök- och bläddringslistor,\n"
@@ -5470,10 +4407,7 @@ msgstr ""
 "                          Detta är endast relevant för listade tillägg."
 
 #: src/olympia/devhub/templates/devhub/addons/edit/basic.html:73
-msgid ""
-"Categories are the primary way users browse through add-ons.\n"
-"                        Choose any that fit your add-on's functionality for the most\n"
-"                        exposure. It is only relevant for listed add-ons."
+msgid "Categories are the primary way users browse through add-ons. Choose any that fit your add-on's functionality for the most exposure. It is only relevant for listed add-ons."
 msgstr ""
 "Kategorier är det främsta sättet användare surfar bland tillägg.\n"
 "                        Välj någon som passar ditt tilläggs funktionalitet för den bästa\n"
@@ -5482,37 +4416,26 @@ msgstr ""
 #: src/olympia/devhub/templates/devhub/addons/edit/basic.html:90
 #, python-format
 msgid ""
-"Categories cannot be changed while your add-on is featured for this "
-"application. Please email <a href=\"mailto:%(email)s\">%(email)s</a> if "
-"there is a reason you need to modify your categories."
+"Categories cannot be changed while your add-on is featured for this application. Please email <a href=\"mailto:%(email)s\">%(email)s</a> if there is a reason you need to modify your categories."
 msgstr ""
-"Kategorier kan inte ändras medan ditt tillägg är utvald för denna "
-"applikation. Skicka ett mejl till <a href=\"mailto:%(email)s\">%(email)s</a>"
-" om det finns en anledning till att du behöver ändra dina kategorier."
+"Kategorier kan inte ändras medan ditt tillägg är utvald för denna applikation. Skicka ett mejl till <a href=\"mailto:%(email)s\">%(email)s</a> om det finns en anledning till att du behöver ändra "
+"dina kategorier."
 
 #: src/olympia/devhub/templates/devhub/addons/edit/basic.html:119
-msgid ""
-"Tags help users find your add-on and should be short\n"
-"                        descriptors such as tabs, toolbar, or twitter.  You\n"
-"                        may have a maximum of {0} tags. It is only relevant\n"
-"                        for listed add-ons."
+msgid "Tags help users find your add-on and should be short descriptors such as tabs, toolbar, or twitter. You may have a maximum of {0} tags. It is only relevant for listed add-ons."
 msgstr ""
 "Taggar hjälper användarna att hitta ditt tillägg och bör \n"
 "                        vara korta beskrivningar så som flikar, \n"
 "                        verktygsfält eller twitter.  Du kan ha högst {0} taggar.\n"
 "                        Det är endast relevant för listade tillägg."
 
-#: src/olympia/devhub/templates/devhub/addons/edit/basic.html:129
-#: src/olympia/devhub/templates/devhub/personas/edit.html:97
-#: src/olympia/devhub/templates/devhub/personas/submit.html:46
+#: src/olympia/devhub/templates/devhub/addons/edit/basic.html:129 src/olympia/devhub/templates/devhub/personas/edit.html:97 src/olympia/devhub/templates/devhub/personas/submit.html:46
 msgid "Comma-separated, minimum of {0} character."
 msgid_plural "Comma-separated, minimum of {0} characters."
 msgstr[0] "Kommaseparerad, minst {0} tecken."
 msgstr[1] "Kommaseparerad, minst {0} tecken."
 
-#: src/olympia/devhub/templates/devhub/addons/edit/basic.html:132
-#: src/olympia/devhub/templates/devhub/personas/edit.html:100
-#: src/olympia/devhub/templates/devhub/personas/submit.html:49
+#: src/olympia/devhub/templates/devhub/addons/edit/basic.html:132 src/olympia/devhub/templates/devhub/personas/edit.html:100 src/olympia/devhub/templates/devhub/personas/submit.html:49
 msgid "Example: dark, cinema, noir. Limit 20."
 msgstr "Exempel: mörk, bio, svart. Högst 20."
 
@@ -5531,46 +4454,33 @@ msgid "Add-on Details for {0}"
 msgstr "Tilläggsdetaljer för {0}"
 
 #: src/olympia/devhub/templates/devhub/addons/edit/details.html:22
-msgid ""
-"A longer explanation of features,\n"
-"                          functionality, and other relevant information. This\n"
-"                          field is only displayed on the add-on's details\n"
-"                          page. It is only relevant for listed add-ons."
+msgid "A longer explanation of features, functionality, and other relevant information. This field is only displayed on the add-on's details page. It is only relevant for listed add-ons."
 msgstr ""
 "En längre förklaring av funktioner,\n"
 "                          funktionalitet och annan relevant information. Detta\n"
 "                          fält visas endast på tilläggets informationssida.\n"
 "                          Detta är endast relevant för listade tillägg."
 
-#: src/olympia/devhub/templates/devhub/addons/edit/details.html:44
-#: src/olympia/translations/templates/translations/trans-menu.html:13
+#: src/olympia/devhub/templates/devhub/addons/edit/details.html:44 src/olympia/translations/templates/translations/trans-menu.html:13
 msgid "Default Locale"
 msgstr "Standardspråk"
 
 #: src/olympia/devhub/templates/devhub/addons/edit/details.html:45
-msgid ""
-"Information about your add-on is displayed in this locale\n"
-"                        unless you override it with a locale-specific translation.\n"
-"                        It is only relevant for listed add-ons."
+msgid "Information about your add-on is displayed in this locale unless you override it with a locale-specific translation. It is only relevant for listed add-ons."
 msgstr ""
 "Information om ditt tillägg visas i på den här språket\n"
 "                        om du inte åsidosätter det med en språkspecifik översättning.\n"
 "                        Detta är endast relevant för listade tillägg."
 
-#: src/olympia/devhub/templates/devhub/addons/edit/details.html:61
-#: src/olympia/users/forms.py:311
-#: src/olympia/users/templates/users/edit.html:122
-#: src/olympia/users/templates/users/register.html:57
+#: src/olympia/devhub/templates/devhub/addons/edit/details.html:61 src/olympia/users/forms.py:311 src/olympia/users/templates/users/edit.html:122 src/olympia/users/templates/users/register.html:57
 #: src/olympia/users/templates/users/vcard.html:22
 msgid "Homepage"
 msgstr "Hemsida"
 
 #: src/olympia/devhub/templates/devhub/addons/edit/details.html:63
 msgid ""
-"If your add-on has another homepage, enter its\n"
-"                          address here. If your website is localized into other\n"
-"                          languages multiple translations of this field can be\n"
-"                          added. It is only relevant for listed add-ons."
+"If your add-on has another homepage, enter its address here. If your website is localized into other languages multiple translations of this field can be added. It is only relevant for listed add-"
+"ons."
 msgstr ""
 "Om ditt tillägg har en annan hemsida, ange dess\n"
 "                          adress här. Om din webbplats är översatt till andra\n"
@@ -5592,11 +4502,8 @@ msgstr "Hjälpinformation för {0}"
 
 #: src/olympia/devhub/templates/devhub/addons/edit/support.html:22
 msgid ""
-"If you wish to display an e-mail address for support\n"
-"                          inquiries, enter it here. If you have different\n"
-"                          addresses for each language multiple translations of\n"
-"                          this field can be added. It is only relevant for\n"
-"                          listed add-ons."
+"If you wish to display an e-mail address for support inquiries, enter it here. If you have different addresses for each language multiple translations of this field can be added. It is only "
+"relevant for listed add-ons."
 msgstr ""
 "Om du vill visa en e-postadress för supportfrågor,\n"
 "                          skriv den här. Om du har olika adresser\n"
@@ -5606,10 +4513,8 @@ msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/support.html:45
 msgid ""
-"If your add-on has a support website or forum, enter\n"
-"                          its address here. If your website is localized into\n"
-"                          other languages, multiple translations of this field can\n"
-"                          be added. It is only relevant for listed add-ons."
+"If your add-on has a support website or forum, enter its address here. If your website is localized into other languages, multiple translations of this field can be added. It is only relevant for "
+"listed add-ons."
 msgstr ""
 "Om ditt tillägg har en supportwebbplats eller forum, ange\n"
 "                          adressen här. Om din webbplats är översatt till\n"
@@ -5627,11 +4532,8 @@ msgstr "Tekniska detaljer för {0}"
 
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:23
 msgid ""
-"Any information end users may want to know that isn't\n"
-"                          necessarily applicable to the add-on summary or description.\n"
-"                          Common uses include listing known major bugs, information on\n"
-"                          how to report bugs, anticipated release date of a new version,\n"
-"                          etc. It is only relevant for listed add-ons."
+"Any information end users may want to know that isn't necessarily applicable to the add-on summary or description. Common uses include listing known major bugs, information on how to report bugs, "
+"anticipated release date of a new version, etc. It is only relevant for listed add-ons."
 msgstr ""
 "All information som slutanvändaren kanske vill vet men som\n"
 "                          nödvändigtvis inte är lämplig i tilläggets sammanfattning eller beskrivning.\n"
@@ -5648,9 +4550,7 @@ msgid "Add-on Flags"
 msgstr "Flaggor för tillägg"
 
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:69
-msgid ""
-"These flags are used to classify add-ons. It is only\n"
-"                        relevant for listed add-ons."
+msgid "These flags are used to classify add-ons. It is only relevant for listed add-ons."
 msgstr ""
 "Dessa flaggor används för att klassificera tillägg. Det är endast\n"
 "                        relevant för listade tillägg."
@@ -5668,9 +4568,7 @@ msgid "View Source?"
 msgstr "Visa källkod?"
 
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:90
-msgid ""
-"Whether the source of your add-on can be displayed in our\n"
-"                        online viewer. It is only relevant for listed add-ons."
+msgid "Whether the source of your add-on can be displayed in our online viewer. It is only relevant for listed add-ons."
 msgstr ""
 "Om källan till ditt tillägg kan visas i vårt\n"
 "                        visningsprogram. Detta är endast relevant för listade tillägg."
@@ -5688,10 +4586,7 @@ msgid "Public Stats?"
 msgstr "Publik statistik?"
 
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:102
-msgid ""
-"Whether the download and usage stats of your add-on can\n"
-"                        be displayed in our online viewer.\n"
-"                        It is only relevant for listed add-ons."
+msgid "Whether the download and usage stats of your add-on can be displayed in our online viewer. It is only relevant for listed add-ons."
 msgstr ""
 "Om nedladdnings och användningsstatistik för ditt tillägg kan\n"
 "                        visas i vårt visningsprogram.\n"
@@ -5710,22 +4605,15 @@ msgid "Upgrade SDK?"
 msgstr "Uppgradera SDK?"
 
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:116
-msgid ""
-"If selected, we will try to automatically upgrade your\n"
-"                        add-on when a new version of the SDK is released.\n"
-"                        It is only relevant for listed add-ons."
+msgid "If selected, we will try to automatically upgrade your add-on when a new version of the SDK is released. It is only relevant for listed add-ons."
 msgstr ""
 "Om vald, kommer vi att försöka att automatiskt uppgradera ditt\n"
 "                        tillägg när en ny version av SDK släpps.\n"
 "                        Detta är endast relevant för listade tillägg."
 
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:121
-msgid ""
-"This add-on will be automatically upgraded to new versions of the Add-on "
-"SDK."
-msgstr ""
-"Detta tillägg kommer automatiskt uppgraderas till nya versioner av SDK för "
-"tillägg."
+msgid "This add-on will be automatically upgraded to new versions of the Add-on SDK."
+msgstr "Detta tillägg kommer automatiskt uppgraderas till nya versioner av SDK för tillägg."
 
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:123
 msgid "No, this add-on will be upgraded manually."
@@ -5740,29 +4628,20 @@ msgid "UUID"
 msgstr "UUID"
 
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:132
-msgid ""
-"The UUID of your add-on is specified in its install manifest and uniquely "
-"identifies it. You cannot change your UUID once it has been submitted."
-msgstr ""
-"Ditt tilläggs UUID specificeras i dess installationsmanifest och är en unik "
-"identifierare. Du kan inte ändra din UUID när den har skickats in."
+msgid "The UUID of your add-on is specified in its install manifest and uniquely identifies it. You cannot change your UUID once it has been submitted."
+msgstr "Ditt tilläggs UUID specificeras i dess installationsmanifest och är en unik identifierare. Du kan inte ändra din UUID när den har skickats in."
 
-#: src/olympia/devhub/templates/devhub/addons/edit/technical.html:143
-#: src/olympia/devhub/templates/devhub/addons/edit/technical.html:144
+#: src/olympia/devhub/templates/devhub/addons/edit/technical.html:143 src/olympia/devhub/templates/devhub/addons/edit/technical.html:144
 msgid "Whiteboard"
 msgstr "Anslagstavla"
 
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:146
 msgid ""
-"The whiteboard is the place to provide information relevant to your addon, "
-"whatever the version, to the editor. Use it to provide ways to test the "
-"addon, and any additional information that may help. This whiteboard is also"
-" editable by editors."
+"The whiteboard is the place to provide information relevant to your addon, whatever the version, to the editor. Use it to provide ways to test the addon, and any additional information that may "
+"help. This whiteboard is also editable by editors."
 msgstr ""
-"Anslagstavlan är en plats att tillhandahålla information som är relevant för"
-" ditt tillägg, oavsett version, till redigeraren. Använd den för att ge "
-"olika sätt att testa ditt tillägg och eventuellt ytterligare information som"
-" kan hjälpa till. Denna anslagstavla är också redigerbar av redigerarna."
+"Anslagstavlan är en plats att tillhandahålla information som är relevant för ditt tillägg, oavsett version, till redigeraren. Använd den för att ge olika sätt att testa ditt tillägg och eventuellt "
+"ytterligare information som kan hjälpa till. Denna anslagstavla är också redigerbar av redigerarna."
 
 #: src/olympia/devhub/templates/devhub/addons/edit/technical_dependencies.html:9
 msgid "Remove this dependent add-on"
@@ -5782,10 +4661,8 @@ msgstr "Ikon för tillägg"
 
 #: src/olympia/devhub/templates/devhub/addons/forms_shared/media.html:16
 msgid ""
-"Upload an icon for your add-on or choose from one of ours. The\n"
-"                      icon is displayed nearly everywhere your add-on is. Uploaded images\n"
-"                      must be one of the following image types: .png, .jpg.\n"
-"                      It is only relevant for listed add-ons."
+"Upload an icon for your add-on or choose from one of ours. The icon is displayed nearly everywhere your add-on is. Uploaded images must be one of the following image types: .png, .jpg. It is only "
+"relevant for listed add-ons."
 msgstr ""
 "Ladda upp en ikon för ditt tillägg eller välj en från våra. Ikonen\n"
 "                      visas nästan överallt där ditt tillägg finns. Uppladdade bilder\n"
@@ -5802,9 +4679,7 @@ msgid "32x32px"
 msgstr "32x32px"
 
 #: src/olympia/devhub/templates/devhub/addons/forms_shared/media.html:39
-msgid ""
-"Used in listings of add-ons, like search results\n"
-"                            and featured add-ons."
+msgid "Used in listings of add-ons, like search results and featured add-ons."
 msgstr ""
 "Används i listor över tillägg, som sökresultat\n"
 "                            och utvalda tillägg."
@@ -5824,8 +4699,7 @@ msgstr "Ladda upp en anpassad ikon..."
 
 #: src/olympia/devhub/templates/devhub/addons/forms_shared/media.html:65
 msgid "PNG and JPG supported. Icons resized to 64x64 pixels if larger."
-msgstr ""
-"PNG och JPG stöds. Ikoner ändrar storlek till 64x64 pixlar, om de är större."
+msgstr "PNG och JPG stöds. Ikoner ändrar storlek till 64x64 pixlar, om de är större."
 
 #: src/olympia/devhub/templates/devhub/addons/forms_shared/media.html:83
 msgid "Screenshots"
@@ -5847,60 +4721,49 @@ msgstr "Lägg till en skärmdump..."
 msgid "Tests"
 msgstr "Tester"
 
-#: src/olympia/devhub/templates/devhub/addons/includes/validation_compat_test_results.html:25
-#: src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:5
+#: src/olympia/devhub/templates/devhub/addons/includes/validation_compat_test_results.html:25 src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:5
 #: src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:53
 msgid "General Tests"
 msgstr "Generella tester"
 
-#: src/olympia/devhub/templates/devhub/addons/includes/validation_compat_test_results.html:32
-#: src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:9
+#: src/olympia/devhub/templates/devhub/addons/includes/validation_compat_test_results.html:32 src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:9
 #: src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:67
 msgid "Security Tests"
 msgstr "Säkerhetstester"
 
-#: src/olympia/devhub/templates/devhub/addons/includes/validation_compat_test_results.html:39
-#: src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:13
+#: src/olympia/devhub/templates/devhub/addons/includes/validation_compat_test_results.html:39 src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:13
 #: src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:80
 msgid "Extension Tests"
 msgstr "Utökningstester"
 
-#: src/olympia/devhub/templates/devhub/addons/includes/validation_compat_test_results.html:46
-#: src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:17
+#: src/olympia/devhub/templates/devhub/addons/includes/validation_compat_test_results.html:46 src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:17
 #: src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:93
 msgid "Localization Tests"
 msgstr "Översättningstester"
 
-#: src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:21
-#: src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:106
+#: src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:21 src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:106
 msgid "Compatibility Tests"
 msgstr "Kompatibilitetstester"
 
-#: src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:29
-#: src/olympia/files/templates/files/viewer.html:142
+#: src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:29 src/olympia/files/templates/files/viewer.html:142
 msgid "Hide messages not required for automated signing"
 msgstr "Dölja meddelanden som inte krävs för automatisk signering"
 
-#: src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:35
-#: src/olympia/files/templates/files/viewer.html:150
+#: src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:35 src/olympia/files/templates/files/viewer.html:150
 msgid "Hide messages present in previous version and ignored"
 msgstr "Dölj meddelanden som finns i tidigare version och ignoreras"
 
-#: src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:50
-#: src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:64
-#: src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:77
-#: src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:90
+#: src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:50 src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:64
+#: src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:77 src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:90
 #: src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:103
 msgid "Top"
 msgstr "Högst upp"
 
-#: src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:2
-#: src/olympia/devhub/templates/devhub/personas/edit.html:63
+#: src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:2 src/olympia/devhub/templates/devhub/personas/edit.html:63
 msgid "Delete Theme"
 msgstr "Ta bort tema"
 
-#: src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:2
-#: src/olympia/devhub/templates/devhub/versions/list.html:117
+#: src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:2 src/olympia/devhub/templates/devhub/versions/list.html:117
 msgid "Delete Add-on"
 msgstr "Ta bort tillägg"
 
@@ -5909,31 +4772,24 @@ msgid "Deleting your theme will permanently remove it from the site."
 msgstr "Ta bort ditt tema kommer att permanent ta bort den från webbplatsen."
 
 #: src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:14
-msgid ""
-"Deleting your add-on will permanently remove it from the site and prevent "
-"its GUID from being submitted again by others."
-msgstr ""
-"Genom att ta bort ditt tillägg kommer det att permanent tas bort från denna "
-"webbplats och hindrar att dess GUID skickas in igen av andra."
+msgid "Deleting your add-on will permanently remove it from the site and prevent its GUID from being submitted again by others."
+msgstr "Genom att ta bort ditt tillägg kommer det att permanent tas bort från denna webbplats och hindrar att dess GUID skickas in igen av andra."
 
 #: src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:24
-msgid ""
-"Enter the following text confirm your decision:\n"
-"           {slug}"
+msgid "Enter the following text confirm your decision: {slug}"
 msgstr ""
 "Ange följande text för att bekräfta ditt beslut:\n"
 "           {slug}"
 
-#: src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:34
+#: src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:33
 msgid "Please tell us why you are deleting your theme:"
 msgstr "Berätta varför du tar bort ditt tema:"
 
-#: src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:36
+#: src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:35
 msgid "Please tell us why you are deleting your add-on:"
 msgstr "Berätta varför du tar bort ditt tillägg:"
 
-#: src/olympia/devhub/templates/devhub/addons/listing/item_actions.html:1
-#: src/olympia/devhub/templates/devhub/addons/listing/item_actions_theme.html:1
+#: src/olympia/devhub/templates/devhub/addons/listing/item_actions.html:1 src/olympia/devhub/templates/devhub/addons/listing/item_actions_theme.html:1
 #: src/olympia/editors/templates/editors/review.html:253
 msgid "Actions"
 msgstr "Åtgärder"
@@ -5966,22 +4822,17 @@ msgstr "Ny version"
 msgid "Daily statistics on downloads and users."
 msgstr "Statistik per dag över hämtningar och användare."
 
-#: src/olympia/devhub/templates/devhub/addons/listing/item_actions.html:45
-#: src/olympia/stats/templates/stats/stats.html:75
-#: src/olympia/stats/templates/stats/stats.html:79
-#: src/olympia/stats/templates/stats/stats.html:81
+#: src/olympia/devhub/templates/devhub/addons/listing/item_actions.html:45 src/olympia/stats/templates/stats/stats.html:31 src/olympia/stats/templates/stats/stats.html:35
+#: src/olympia/stats/templates/stats/stats.html:37
 msgid "Statistics"
 msgstr "Statistik"
 
-#: src/olympia/devhub/templates/devhub/addons/listing/item_actions.html:54
-#: src/olympia/devhub/templates/devhub/includes/addons_edit_nav.html:5
-#: src/olympia/devhub/templates/devhub/payments/payments.html:3
-#: src/olympia/devhub/templates/devhub/payments/tier.html:4
+#: src/olympia/devhub/templates/devhub/addons/listing/item_actions.html:54 src/olympia/devhub/templates/devhub/includes/addons_edit_nav.html:5
+#: src/olympia/devhub/templates/devhub/payments/payments.html:3 src/olympia/devhub/templates/devhub/payments/tier.html:4
 msgid "Manage Payments"
 msgstr "Hantera betalningar"
 
-#: src/olympia/devhub/templates/devhub/addons/listing/item_actions.html:55
-#: src/olympia/devhub/templates/devhub/includes/addons_edit_nav.html:6
+#: src/olympia/devhub/templates/devhub/addons/listing/item_actions.html:55 src/olympia/devhub/templates/devhub/includes/addons_edit_nav.html:6
 msgid "Manage Status & Versions"
 msgstr "Hantera status & versioner"
 
@@ -5989,10 +4840,8 @@ msgstr "Hantera status & versioner"
 msgid "View Add-on Listing"
 msgstr "Visa listning för tillägg"
 
-#: src/olympia/devhub/templates/devhub/addons/listing/item_actions.html:64
-#: src/olympia/devhub/templates/devhub/addons/listing/item_actions_theme.html:12
-#: src/olympia/devhub/templates/devhub/includes/addons_edit_nav.html:37
-#: src/olympia/devhub/templates/devhub/personas/edit.html:58
+#: src/olympia/devhub/templates/devhub/addons/listing/item_actions.html:64 src/olympia/devhub/templates/devhub/addons/listing/item_actions_theme.html:12
+#: src/olympia/devhub/templates/devhub/includes/addons_edit_nav.html:37 src/olympia/devhub/templates/devhub/personas/edit.html:58
 msgid "View Recent Changes"
 msgstr "Visa senaste ändringar"
 
@@ -6017,12 +4866,8 @@ msgid "Delete this theme."
 msgstr "Ta bort detta tema."
 
 #: src/olympia/devhub/templates/devhub/addons/listing/items.html:10
-msgid ""
-"This add-on will be deleted automatically after a few days if the submission"
-" process is not completed."
-msgstr ""
-"Detta tillägg kommer att raderas automatiskt efter några dagar om "
-"inskickningsprocessen inte är avslutad."
+msgid "This add-on will be deleted automatically after a few days if the submission process is not completed."
+msgstr "Detta tillägg kommer att raderas automatiskt efter några dagar om inskickningsprocessen inte är avslutad."
 
 #: src/olympia/devhub/templates/devhub/addons/listing/items.html:27
 msgid "Disabled"
@@ -6060,13 +4905,9 @@ msgstr "Namn och version:"
 msgid "The detail page will be:"
 msgstr "Detaljsidan kommer att vara:"
 
-#: src/olympia/devhub/templates/devhub/addons/submit/describe.html:24
-#: src/olympia/devhub/templates/devhub/personas/edit.html:89
-#: src/olympia/devhub/templates/devhub/personas/submit.html:38
+#: src/olympia/devhub/templates/devhub/addons/submit/describe.html:24 src/olympia/devhub/templates/devhub/personas/edit.html:89 src/olympia/devhub/templates/devhub/personas/submit.html:38
 msgid "Please use only letters, numbers, underscores, and dashes in your URL."
-msgstr ""
-"Använd endast bokstäver, siffror, understreck och bindestreck i din "
-"webbadress."
+msgstr "Använd endast bokstäver, siffror, understreck och bindestreck i din webbadress."
 
 #: src/olympia/devhub/templates/devhub/addons/submit/describe.html:34
 msgid "Provide a brief summary:"
@@ -6084,14 +4925,11 @@ msgstr "Ge en mer detaljerad beskrivning:"
 msgid "The description will appear on the detail page."
 msgstr "Beskrivningen kommer att visas på detaljsidan."
 
-#: src/olympia/devhub/templates/devhub/addons/submit/done.html:4
-#: src/olympia/devhub/templates/devhub/personas/submit_done.html:4
+#: src/olympia/devhub/templates/devhub/addons/submit/done.html:4 src/olympia/devhub/templates/devhub/personas/submit_done.html:4
 msgid "Submission Complete"
 msgstr "Inskickning komplett"
 
-#: src/olympia/devhub/templates/devhub/addons/submit/done.html:8
-#: src/olympia/devhub/templates/devhub/addons/submit/sidebar.html:13
-#: src/olympia/devhub/templates/devhub/personas/submit_done.html:8
+#: src/olympia/devhub/templates/devhub/addons/submit/done.html:8 src/olympia/devhub/templates/devhub/addons/submit/sidebar.html:13 src/olympia/devhub/templates/devhub/personas/submit_done.html:8
 msgid "You're done!"
 msgstr "Du är klar!"
 
@@ -6104,50 +4942,33 @@ msgid "Your add-on has been submitted to the Full Review queue."
 msgstr "Ditt tillägg har skickats in till kön för fullständig granskning."
 
 #: src/olympia/devhub/templates/devhub/addons/submit/done.html:18
-msgid ""
-"You'll receive an email once it has been reviewed by an editor. In\n"
-"          the meantime, you and your friends can install it directly from its\n"
-"          details page:"
+msgid "You'll receive an email once it has been reviewed by an editor. In the meantime, you and your friends can install it directly from its details page:"
 msgstr ""
 "Du kommer att få ett mejl när tillägget har granskats av en redigerare. Under\n"
 "          tiden kan du och dina vänner installera det direkt från dess\n"
 "          detaljsida:"
 
-#: src/olympia/devhub/templates/devhub/addons/submit/done.html:27
-#: src/olympia/devhub/templates/devhub/addons/submit/done.html:77
-#: src/olympia/devhub/templates/devhub/personas/submit_done.html:16
+#: src/olympia/devhub/templates/devhub/addons/submit/done.html:27 src/olympia/devhub/templates/devhub/addons/submit/done.html:77 src/olympia/devhub/templates/devhub/personas/submit_done.html:16
 msgid "Next steps:"
 msgstr "Nästa steg:"
 
-#: src/olympia/devhub/templates/devhub/addons/submit/done.html:32
-#: src/olympia/devhub/templates/devhub/addons/submit/done.html:82
+#: src/olympia/devhub/templates/devhub/addons/submit/done.html:32 src/olympia/devhub/templates/devhub/addons/submit/done.html:82
 msgid "<a href=\"{0}\">Upload</a> another platform-specific file to this version."
-msgstr ""
-"<a href=\"{0}\">Ladda upp</a> en till plattformsspecifik fil till denna "
-"version."
+msgstr "<a href=\"{0}\">Ladda upp</a> en till plattformsspecifik fil till denna version."
 
 #: src/olympia/devhub/templates/devhub/addons/submit/done.html:34
 msgid "Provide more details by <a href=\"{0}\">editing its listing</a>."
 msgstr "Ge fler detaljer genom att <a href=\"{0}\">redigera dess listning</a>."
 
 #: src/olympia/devhub/templates/devhub/addons/submit/done.html:35
-msgid ""
-"Tell your users why you created this in your <a href=\"{0}\">Developer "
-"Profile</a>."
-msgstr ""
-"Berätta för dina användare varför du skapade detta i din <a "
-"href=\"{0}\">utvecklarprofil</a>."
+msgid "Tell your users why you created this in your <a href=\"{0}\">Developer Profile</a>."
+msgstr "Berätta för dina användare varför du skapade detta i din <a href=\"{0}\">utvecklarprofil</a>."
 
 #: src/olympia/devhub/templates/devhub/addons/submit/done.html:36
-msgid ""
-"View and subscribe to your add-on's <a href=\"{0}\">activity feed</a> to "
-"stay updated on reviews, collections, and more."
-msgstr ""
-"Visa och prenumerera på ditt tilläggs <a href=\"{0}\">aktivitetsflöde</a> "
-"för att hålla dig uppdaterad på recensioner, samlingar och mer."
+msgid "View and subscribe to your add-on's <a href=\"{0}\">activity feed</a> to stay updated on reviews, collections, and more."
+msgstr "Visa och prenumerera på ditt tilläggs <a href=\"{0}\">aktivitetsflöde</a> för att hålla dig uppdaterad på recensioner, samlingar och mer."
 
-#: src/olympia/devhub/templates/devhub/addons/submit/done.html:37
-#: src/olympia/devhub/templates/devhub/addons/submit/done.html:86
+#: src/olympia/devhub/templates/devhub/addons/submit/done.html:37 src/olympia/devhub/templates/devhub/addons/submit/done.html:86
 msgid "View approximate review queue <a href=\"{0}\">wait times</a>."
 msgstr "Visa ungefärliga <a href=\"{0}\">väntetider</a> för granskningskö."
 
@@ -6160,43 +4981,28 @@ msgid "Become an AMO Reviewer today and get your add-ons reviewed faster."
 msgstr "Bli en AMO-granskare idag och få dina tillägg granskade snabbare."
 
 #: src/olympia/devhub/templates/devhub/addons/submit/done.html:54
-msgid ""
-"Your add-on has been signed and it's ready to use. You can download it here:"
-msgstr ""
-"Ditt tillägg har signerats och det är klart att använda. Du kan ladda ner "
-"det här:"
+msgid "Your add-on has been signed and it's ready to use. You can download it here:"
+msgstr "Ditt tillägg har signerats och det är klart att använda. Du kan ladda ner det här:"
 
 #: src/olympia/devhub/templates/devhub/addons/submit/done.html:64
-msgid ""
-"Your add-on has been submitted to the Unlisted Preliminary Review queue."
-msgstr ""
-"Ditt tillägg har skickats in till den olistade preliminära granskningskön."
+msgid "Your add-on has been submitted to the Unlisted Preliminary Review queue."
+msgstr "Ditt tillägg har skickats in till den olistade preliminära granskningskön."
 
 #: src/olympia/devhub/templates/devhub/addons/submit/done.html:66
 msgid "Your add-on has been submitted to the Unlisted Full Review queue."
-msgstr ""
-"Ditt tillägg har skickats in till den olistade fullständiga granskningskön."
+msgstr "Ditt tillägg har skickats in till den olistade fullständiga granskningskön."
 
 #: src/olympia/devhub/templates/devhub/addons/submit/done.html:70
-msgid ""
-"You'll receive an email once it has been reviewed by an editor and signed."
-msgstr ""
-"Du kommer att få ett mejl när det har granskats av en redigerare och "
-"signerats."
+msgid "You'll receive an email once it has been reviewed by an editor and signed."
+msgstr "Du kommer att få ett mejl när det har granskats av en redigerare och signerats."
 
 #: src/olympia/devhub/templates/devhub/addons/submit/done.html:74
 msgid "Your add-on will not be publicly available on this website."
-msgstr ""
-"Ditt tillägg kommer inte att vara tillgängliga för allmänheten på denna "
-"webbplats."
+msgstr "Ditt tillägg kommer inte att vara tillgängliga för allmänheten på denna webbplats."
 
 #: src/olympia/devhub/templates/devhub/addons/submit/done.html:84
-msgid ""
-"You can upload new versions of your add-on in the <a href=\"{0}\">add-on's "
-"developer page</a>."
-msgstr ""
-"Du kan ladda upp nya versioner av ditt tillägg på <a href=\"{0}\">tilläggets"
-" utvecklarsida</a>."
+msgid "You can upload new versions of your add-on in the <a href=\"{0}\">add-on's developer page</a>."
+msgstr "Du kan ladda upp nya versioner av ditt tillägg på <a href=\"{0}\">tilläggets utvecklarsida</a>."
 
 #: src/olympia/devhub/templates/devhub/addons/submit/license.html:4
 msgid "Step 5"
@@ -6207,13 +5013,8 @@ msgid "Step 5. Select a License"
 msgstr "Steg 5. Välj en licens"
 
 #: src/olympia/devhub/templates/devhub/addons/submit/license.html:9
-msgid ""
-"We require all add-ons to indicate the terms under which their source code "
-"is licensed. Please select a license from the list below or enter a custom "
-"license."
-msgstr ""
-"Vi kräver att alla tillägg indikerar under vilka villkor deras källkod är "
-"licensierad. Välj en licens från listan nedan eller skriv en egen licens."
+msgid "We require all add-ons to indicate the terms under which their source code is licensed. Please select a license from the list below or enter a custom license."
+msgstr "Vi kräver att alla tillägg indikerar under vilka villkor deras källkod är licensierad. Välj en licens från listan nedan eller skriv en egen licens."
 
 #: src/olympia/devhub/templates/devhub/addons/submit/license.html:18
 msgid "Select a license for your add-on:"
@@ -6229,13 +5030,11 @@ msgstr "Steg 4. Lägg till bilder"
 
 #: src/olympia/devhub/templates/devhub/addons/submit/media.html:9
 msgid ""
-"Custom icons and screenshots draw attention and help users understand what "
-"it does. We strongly recommend uploading a custom icon, as in some areas of "
-"the website, only the icon and name will appear."
+"Custom icons and screenshots draw attention and help users understand what it does. We strongly recommend uploading a custom icon, as in some areas of the website, only the icon and name will "
+"appear."
 msgstr ""
-"Anpassade ikoner och skärmdumpar drar uppmärksamhet och hjälper användare "
-"att förstå vad tillägget gör. Vi rekommenderar starkt att ladda upp en egen "
-"ikon, eftersom endast ikonen och namnet visas på vissa delar av webbplatsen."
+"Anpassade ikoner och skärmdumpar drar uppmärksamhet och hjälper användare att förstå vad tillägget gör. Vi rekommenderar starkt att ladda upp en egen ikon, eftersom endast ikonen och namnet visas "
+"på vissa delar av webbplatsen."
 
 #: src/olympia/devhub/templates/devhub/addons/submit/select-review.html:5
 msgid "Step 6"
@@ -6247,24 +5046,16 @@ msgstr "Steg 6. Välj en granskningsprocess"
 
 #: src/olympia/devhub/templates/devhub/addons/submit/select-review.html:10
 msgid ""
-"All add-ons hosted in our gallery must be reviewed by an editor before they "
-"appear in categories or search results. While waiting for review, your add-"
-"on can still be accessed through its direct URL. Please choose the review "
-"process below that best fits your add-on."
+"All add-ons hosted in our gallery must be reviewed by an editor before they appear in categories or search results. While waiting for review, your add-on can still be accessed through its direct "
+"URL. Please choose the review process below that best fits your add-on."
 msgstr ""
-"Alla tillägg som hyses i vårt galleri måste granskas av en redigerare innan "
-"de visas i kategorier eller sökresultat. I väntan på granskning, kan ditt "
-"tillägg fortfarande nås via sin webbadress. Välj granskningsprocessen nedan "
-"som bäst passar ditt tillägg."
+"Alla tillägg som hyses i vårt galleri måste granskas av en redigerare innan de visas i kategorier eller sökresultat. I väntan på granskning, kan ditt tillägg fortfarande nås via sin webbadress. "
+"Välj granskningsprocessen nedan som bäst passar ditt tillägg."
 
 #: src/olympia/devhub/templates/devhub/addons/submit/select-review.html:26
 #, python-format
-msgid ""
-"A complete review of your add-on's source and functionality. <a "
-"href=\"%(url)s\">Learn more&hellip;</a>"
-msgstr ""
-"En komplett granskning av ditt tilläggs källkod och funktionalitet. <a "
-"href=\"%(url)s\">Läs mer&hellip;</a>"
+msgid "A complete review of your add-on's source and functionality. <a href=\"%(url)s\">Learn more&hellip;</a>"
+msgstr "En komplett granskning av ditt tilläggs källkod och funktionalitet. <a href=\"%(url)s\">Läs mer&hellip;</a>"
 
 #: src/olympia/devhub/templates/devhub/addons/submit/select-review.html:32
 msgid "Appropriate for polished add-ons"
@@ -6292,12 +5083,8 @@ msgstr "Välj fullständig granskning"
 
 #: src/olympia/devhub/templates/devhub/addons/submit/select-review.html:49
 #, python-format
-msgid ""
-"A faster review of your add-on's source for any major problems. <a "
-"href=\"%(url)s\">Learn more&hellip;</a>"
-msgstr ""
-"En snabbare granskning av ditt tilläggs källkod efter större problem. <a "
-"href=\"%(url)s\">Läs mer&hellip;</a>"
+msgid "A faster review of your add-on's source for any major problems. <a href=\"%(url)s\">Learn more&hellip;</a>"
+msgstr "En snabbare granskning av ditt tilläggs källkod efter större problem. <a href=\"%(url)s\">Läs mer&hellip;</a>"
 
 #: src/olympia/devhub/templates/devhub/addons/submit/select-review.html:55
 msgid "Appropriate for experimental add-ons"
@@ -6343,10 +5130,8 @@ msgstr "Välj en licens"
 msgid "Select a review process"
 msgstr "Välj en granskningsprocess"
 
-#: src/olympia/devhub/templates/devhub/addons/submit/sidebar.html:18
-#: src/olympia/devhub/templates/devhub/docs/policies-submission.html:3
-#: src/olympia/devhub/templates/devhub/docs/policies-submission.html:7
-#: src/olympia/devhub/templates/devhub/docs/policies-submission.html:9
+#: src/olympia/devhub/templates/devhub/addons/submit/sidebar.html:18 src/olympia/devhub/templates/devhub/docs/policies-submission.html:3
+#: src/olympia/devhub/templates/devhub/docs/policies-submission.html:7 src/olympia/devhub/templates/devhub/docs/policies-submission.html:9
 msgid "Submission Process"
 msgstr "Inskickningsprocess"
 
@@ -6367,27 +5152,18 @@ msgid "Step 2. Upload Your Add-on"
 msgstr "Steg 2. Ladda upp ditt tillägg"
 
 #: src/olympia/devhub/templates/devhub/addons/submit/upload.html:11
-msgid ""
-"Use the fields below to upload your add-on package and select any platform "
-"restrictions. After upload, a series of automated validation tests will be "
-"run on your file."
-msgstr ""
-"Använd fälten nedan för att ladda upp ditt tilläggspaket och välj eventuella"
-" plattformsbegränsningar. Efter uppladdning, kommer en rad automatiserade "
-"valideringsprov köras på din fil."
+msgid "Use the fields below to upload your add-on package and select any platform restrictions. After upload, a series of automated validation tests will be run on your file."
+msgstr "Använd fälten nedan för att ladda upp ditt tilläggspaket och välj eventuella plattformsbegränsningar. Efter uppladdning, kommer en rad automatiserade valideringsprov köras på din fil."
 
-#: src/olympia/devhub/templates/devhub/addons/submit/upload.html:59
-#: src/olympia/devhub/templates/devhub/versions/add_file_modal.html:39
+#: src/olympia/devhub/templates/devhub/addons/submit/upload.html:51 src/olympia/devhub/templates/devhub/versions/add_file_modal.html:28
 msgid "Which platforms is this file compatible with?"
 msgstr "Vilka plattformar är denna fil kompatibel med?"
 
-#: src/olympia/devhub/templates/devhub/addons/submit/upload.html:67
-#: src/olympia/devhub/templates/devhub/versions/add_file_modal.html:65
+#: src/olympia/devhub/templates/devhub/addons/submit/upload.html:59 src/olympia/devhub/templates/devhub/versions/add_file_modal.html:45
 msgid "Administrative overrides"
 msgstr "Administrativa åsidosättningar"
 
-#: src/olympia/devhub/templates/devhub/api/agreement.html:3
-#: src/olympia/devhub/templates/devhub/api/agreement.html:11
+#: src/olympia/devhub/templates/devhub/api/agreement.html:3 src/olympia/devhub/templates/devhub/api/agreement.html:11
 msgid "Firefox Add-on Distribution Agreement"
 msgstr "Firefox distributionsavtal för tillägg"
 
@@ -6397,12 +5173,8 @@ msgstr "API-inloggningsuppgifter"
 
 #: src/olympia/devhub/templates/devhub/api/key.html:20
 #, python-format
-msgid ""
-"For detailed instructions, consult the <a href=\"%(docs_url)s\">API "
-"documentation</a>."
-msgstr ""
-"Detaljerade instruktioner finns i <a href=\"%(docs_url)s\">API-"
-"dokumentationen</a>."
+msgid "For detailed instructions, consult the <a href=\"%(docs_url)s\">API documentation</a>."
+msgstr "Detaljerade instruktioner finns i <a href=\"%(docs_url)s\">API-dokumentationen</a>."
 
 #: src/olympia/devhub/templates/devhub/api/key.html:28
 msgid "JWT issuer"
@@ -6415,15 +5187,11 @@ msgstr "JWT-hemlighet"
 #: src/olympia/devhub/templates/devhub/api/key.html:37
 #, python-format
 msgid ""
-"To make API requests, send a <a href=\"%(jwt_url)s\">JSON Web Token "
-"(JWT)</a> as the authorization header. You'll need to generate a JWT for "
-"every request as explained in the <a href=\"%(docs_url)s\">API "
-"documentation</a>."
+"To make API requests, send a <a href=\"%(jwt_url)s\">JSON Web Token (JWT)</a> as the authorization header. You'll need to generate a JWT for every request as explained in the <a href=\"%(docs_url)s"
+"\">API documentation</a>."
 msgstr ""
-"För att göra API förfrågningar, skicka en <a href=\"%(jwt_url)s\">JSON Web "
-"Token (JWT)</a> som authorization header. Du måste skapa en JWT för varje "
-"begäran enligt beskrivningen i <a href=\"%(docs_url)s\">API-"
-"dokumentationen</a>."
+"För att göra API förfrågningar, skicka en <a href=\"%(jwt_url)s\">JSON Web Token (JWT)</a> som authorization header. Du måste skapa en JWT för varje begäran enligt beskrivningen i <a href="
+"\"%(docs_url)s\">API-dokumentationen</a>."
 
 #: src/olympia/devhub/templates/devhub/api/key.html:47
 msgid "You don't have any API credentials yet."
@@ -6431,12 +5199,8 @@ msgstr "Du har inte någon API-inloggningsuppgifter ännu."
 
 #: src/olympia/devhub/templates/devhub/api/key.html:53
 #, python-format
-msgid ""
-"This feature is under active development. If you find a problem please <a "
-"target=\"_blank\" href=\"%(bug_link)s\">report a bug</a>."
-msgstr ""
-"Denna funktion är under aktiv utveckling. Om du upptäcker ett problem "
-"vänligen <a target=\"_blank\" href=\"%(bug_link)s\">rapportera en bugg</a>."
+msgid "This feature is under active development. If you find a problem please <a target=\"_blank\" href=\"%(bug_link)s\">report a bug</a>."
+msgstr "Denna funktion är under aktiv utveckling. Om du upptäcker ett problem vänligen <a target=\"_blank\" href=\"%(bug_link)s\">rapportera en bugg</a>."
 
 #: src/olympia/devhub/templates/devhub/api/key.html:61
 msgid "Revoke and regenerate credentials"
@@ -6446,29 +5210,19 @@ msgstr "Återkalla och regenerera autentiseringsuppgifter"
 msgid "Generate new credentials"
 msgstr "Generera nya autentiseringsuppgifter"
 
-#: src/olympia/devhub/templates/devhub/docs/policies-agreement.html:3
-#: src/olympia/devhub/templates/devhub/docs/policies-agreement.html:7
-#: src/olympia/devhub/templates/devhub/docs/policies-agreement.html:9
-#: src/olympia/devhub/templates/devhub/docs/policies.html:24
-#: src/olympia/devhub/templates/devhub/docs/policies.html:103
+#: src/olympia/devhub/templates/devhub/docs/policies-agreement.html:3 src/olympia/devhub/templates/devhub/docs/policies-agreement.html:7
+#: src/olympia/devhub/templates/devhub/docs/policies-agreement.html:9 src/olympia/devhub/templates/devhub/docs/policies.html:24 src/olympia/devhub/templates/devhub/docs/policies.html:103
 msgid "Developer Agreement"
 msgstr "Utvecklaravtal"
 
-#: src/olympia/devhub/templates/devhub/docs/policies-contact.html:3
-#: src/olympia/devhub/templates/devhub/docs/policies-contact.html:7
-#: src/olympia/devhub/templates/devhub/docs/policies-contact.html:9
-#: src/olympia/devhub/templates/devhub/docs/policies.html:27
-#: src/olympia/devhub/templates/devhub/docs/policies.html:115
+#: src/olympia/devhub/templates/devhub/docs/policies-contact.html:3 src/olympia/devhub/templates/devhub/docs/policies-contact.html:7 src/olympia/devhub/templates/devhub/docs/policies-contact.html:9
+#: src/olympia/devhub/templates/devhub/docs/policies.html:27 src/olympia/devhub/templates/devhub/docs/policies.html:115
 msgid "Contacting Us"
 msgstr "Kontakta oss"
 
 #: src/olympia/devhub/templates/devhub/docs/policies-contact.html:12
-msgid ""
-"Thanks for your interest in contacting the Mozilla Add-ons team. Please read"
-" this page carefully to ensure your request goes to the right place."
-msgstr ""
-"Tack för ditt intresse att kontakta gruppen Mozilla tillägg. Läs denna sida "
-"noga för att din fråga går till rätt ställe."
+msgid "Thanks for your interest in contacting the Mozilla Add-ons team. Please read this page carefully to ensure your request goes to the right place."
+msgstr "Tack för ditt intresse att kontakta gruppen Mozilla tillägg. Läs denna sida noga för att din fråga går till rätt ställe."
 
 #: src/olympia/devhub/templates/devhub/docs/policies-contact.html:17
 msgid "Add-on Support"
@@ -6476,15 +5230,11 @@ msgstr "Support för tillägg"
 
 #: src/olympia/devhub/templates/devhub/docs/policies-contact.html:19
 msgid ""
-"If you have a support question about a particular add-on, such as \"how do I"
-" use this add-on?\" or \"why doesn't this work properly?\", please contact "
-"that add-on's author through the support channels listed on the add-on's "
-"listing page."
+"If you have a support question about a particular add-on, such as \"how do I use this add-on?\" or \"why doesn't this work properly?\", please contact that add-on's author through the support "
+"channels listed on the add-on's listing page."
 msgstr ""
-"Om du har en supportfråga om ett visst tillägg, såsom \"hur använder jag "
-"detta tillägg?\" eller \"varför fungerar inte detta ordentligt?\", vänligen "
-"kontakta upphovsmannen för tillägget genom supportkanaler som anges på "
-"tilläggets listningssida."
+"Om du har en supportfråga om ett visst tillägg, såsom \"hur använder jag detta tillägg?\" eller \"varför fungerar inte detta ordentligt?\", vänligen kontakta upphovsmannen för tillägget genom "
+"supportkanaler som anges på tilläggets listningssida."
 
 #: src/olympia/devhub/templates/devhub/docs/policies-contact.html:24
 msgid "Add-on Editorial Concerns"
@@ -6497,17 +5247,11 @@ msgstr "amo-editors at mozilla dot org"
 #: src/olympia/devhub/templates/devhub/docs/policies-contact.html:26
 #, python-format
 msgid ""
-"If you have a question about an Editor's review of an add-on or want to "
-"report a policy violation, please email %(mail_editors)s. <strong>Almost all"
-" add-on reports fall under this category.</strong> Please be sure to include"
-" a link to the add-on in question and a detailed description of your "
-"question or comment."
+"If you have a question about an Editor's review of an add-on or want to report a policy violation, please email %(mail_editors)s. <strong>Almost all add-on reports fall under this category.</"
+"strong> Please be sure to include a link to the add-on in question and a detailed description of your question or comment."
 msgstr ""
-"Om du har en fråga om en redigerares granskning av ett tillägg eller vill "
-"rapportera ett brott mot reglerna, vänligen e-posta %(mail_editors)s. "
-"<strong>Nästan alla tilläggsrapporter faller under denna kategori.</strong> "
-"Var noga med att inkludera en länk till tillägget i frågan samt en "
-"detaljerad beskrivning av din fråga eller kommentar."
+"Om du har en fråga om en redigerares granskning av ett tillägg eller vill rapportera ett brott mot reglerna, vänligen e-posta %(mail_editors)s. <strong>Nästan alla tilläggsrapporter faller under "
+"denna kategori.</strong> Var noga med att inkludera en länk till tillägget i frågan samt en detaljerad beskrivning av din fråga eller kommentar."
 
 #: src/olympia/devhub/templates/devhub/docs/policies-contact.html:31
 msgid "Add-on Security Vulnerabilities"
@@ -6520,21 +5264,13 @@ msgstr "amo-admins at mozilla dot org"
 #: src/olympia/devhub/templates/devhub/docs/policies-contact.html:36
 #, python-format
 msgid ""
-"If you have discovered a security vulnerability in an add-on, even if it is "
-"not hosted here, Mozilla is very interested in your discovery and will work "
-"with the add-on developer to correct the issue as soon as possible. Add-on "
-"security issues can be reported <a "
-"href=\"http://www.mozilla.org/projects/security/security-bugs-"
-"policy.html\">confidentially</a> in <a "
-"href=\"%(link_bugzilla)s\">Bugzilla</a> or by emailing %(mail_admins)s."
+"If you have discovered a security vulnerability in an add-on, even if it is not hosted here, Mozilla is very interested in your discovery and will work with the add-on developer to correct the "
+"issue as soon as possible. Add-on security issues can be reported <a href=\"http://www.mozilla.org/projects/security/security-bugs-policy.html\">confidentially</a> in <a href=\"%(link_bugzilla)s"
+"\">Bugzilla</a> or by emailing %(mail_admins)s."
 msgstr ""
-"Om du har upptäckt ett säkerhetsproblem i ett tillägg, även om det inte är "
-"hyses här, är Mozilla mycket intresserad av din upptäckt och kommer att "
-"arbeta med tilläggets utvecklare för att rätta till problemet så snart som "
-"möjligt. Säkerhetsfrågor för tillägg kan rapporteras <a "
-"href=\"http://www.mozilla.org/projects/security/security-bugs-"
-"policy.html\">konfidentiellt</a> i <a "
-"href=\"%(link_bugzilla)s\">Bugzilla</a> eller via e-post %(mail_admins)s."
+"Om du har upptäckt ett säkerhetsproblem i ett tillägg, även om det inte är hyses här, är Mozilla mycket intresserad av din upptäckt och kommer att arbeta med tilläggets utvecklare för att rätta "
+"till problemet så snart som möjligt. Säkerhetsfrågor för tillägg kan rapporteras <a href=\"http://www.mozilla.org/projects/security/security-bugs-policy.html\">konfidentiellt</a> i <a href="
+"\"%(link_bugzilla)s\">Bugzilla</a> eller via e-post %(mail_admins)s."
 
 #: src/olympia/devhub/templates/devhub/docs/policies-contact.html:42
 msgid "Website Functionality & Development"
@@ -6542,16 +5278,11 @@ msgstr "Webbplatsfunktionalitet och utveckling"
 
 #: src/olympia/devhub/templates/devhub/docs/policies-contact.html:44
 msgid ""
-"If you've found a problem with the site, we'd love to fix it. Please <a "
-"href=\"https://github.com/mozilla/olympia/issues\">file a bug report</a> in "
-"GitHub, including the location of the problem and how you encountered it."
+"If you've found a problem with the site, we'd love to fix it. Please <a href=\"https://github.com/mozilla/addons/issues/new\">file a bug report</a> in GitHub, including the location of the problem "
+"and how you encountered it."
 msgstr ""
-"Om du har hittat ett problem med webbplatsen, vill vi gärna åtgärda det. <a "
-"href=\"https://github.com/mozilla/olympia/issues\">Skriv en felrapport</a> i"
-" GitHub, inklusive platsen för problemet och hur du stött på det."
 
-#: src/olympia/devhub/templates/devhub/docs/policies-maintenance.html:3
-#: src/olympia/devhub/templates/devhub/docs/policies-maintenance.html:7
+#: src/olympia/devhub/templates/devhub/docs/policies-maintenance.html:3 src/olympia/devhub/templates/devhub/docs/policies-maintenance.html:7
 #: src/olympia/devhub/templates/devhub/docs/policies-maintenance.html:8
 msgid "Maintaining Your Add-ons"
 msgstr "Underhåll av dina tillägg"
@@ -6562,31 +5293,18 @@ msgstr "Skicka in nya versioner av ditt tillägg"
 
 #: src/olympia/devhub/templates/devhub/docs/policies-maintenance.html:12
 msgid ""
-"Developers are encouraged to submit updates to their add-ons to fix bugs, "
-"add features, and otherwise improve their product. New versions of an add-on"
-" must have a <a "
-"href=\"https://developer.mozilla.org/en/Toolkit_version_format\">higher "
-"version number</a> and can be submitted through the Developer Tools "
-"provided. There is no limit to the number of versions that can be submitted,"
-" but please remember that versions must be reviewed by an editor."
+"Developers are encouraged to submit updates to their add-ons to fix bugs, add features, and otherwise improve their product. New versions of an add-on must have a <a href=\"https://developer."
+"mozilla.org/en/Toolkit_version_format\">higher version number</a> and can be submitted through the Developer Tools provided. There is no limit to the number of versions that can be submitted, but "
+"please remember that versions must be reviewed by an editor."
 msgstr ""
-"Utvecklare uppmanas att skicka in uppdateringar till sina tillägg för att "
-"fixa buggar, lägga till funktioner och på annat sätt förbättra sin produkt. "
-"Nya versioner av ett tillägg måste ha ett <a "
-"href=\"https://developer.mozilla.org/en/Toolkit_version_format\">högre "
-"versionsnummer</a> och kan skickas in via de utvecklingsverktyg som "
-"tillhandahålls. Det finns ingen gräns för hur många versioner som kan "
-"skickas in, men kom ihåg att versionerna måste granskas av en redigerare."
+"Utvecklare uppmanas att skicka in uppdateringar till sina tillägg för att fixa buggar, lägga till funktioner och på annat sätt förbättra sin produkt. Nya versioner av ett tillägg måste ha ett <a "
+"href=\"https://developer.mozilla.org/en/Toolkit_version_format\">högre versionsnummer</a> och kan skickas in via de utvecklingsverktyg som tillhandahålls. Det finns ingen gräns för hur många "
+"versioner som kan skickas in, men kom ihåg att versionerna måste granskas av en redigerare."
 
 #: src/olympia/devhub/templates/devhub/docs/policies-maintenance.html:18
-msgid ""
-"New versions will be added to a pending review queue, and any additional "
-"versions submitted before the review is completed will move that version to "
-"the end of the queue."
+msgid "New versions will be added to a pending review queue, and any additional versions submitted before the review is completed will move that version to the end of the queue."
 msgstr ""
-"Nya versioner kommer att läggas till en väntande granskningskö och "
-"eventuella ytterligare versioner som skickats in innan granskningen är klar "
-"kommer att flytta denna version till slutet av kön."
+"Nya versioner kommer att läggas till en väntande granskningskö och eventuella ytterligare versioner som skickats in innan granskningen är klar kommer att flytta denna version till slutet av kön."
 
 #: src/olympia/devhub/templates/devhub/docs/policies-maintenance.html:23
 msgid "How do I submit a Beta add-on?"
@@ -6598,51 +5316,31 @@ msgstr "Betakanaler är endast tillgängliga för fullt granskade tillägg."
 
 #: src/olympia/devhub/templates/devhub/docs/policies-maintenance.html:31
 msgid ""
-"To create a beta channel, upload a file with a unique version string that "
-"contains any of the following strings: <code>a,b,alpha,beta,pre,rc</code>, "
-"with an optional number at the end. This text must come at the end of the "
-"version string. If you understand regex format, here's what we look for in "
-"the version number: <code>\"(a|alpha|b|beta|pre|rc)\\d*$\"</code>."
+"To create a beta channel, upload a file with a unique version string that contains any of the following strings: <code>a,b,alpha,beta,pre,rc</code>, with an optional number at the end. This text "
+"must come at the end of the version string. If you understand regex format, here's what we look for in the version number: <code>\"(a|alpha|b|beta|pre|rc)\\d*$\"</code>."
 msgstr ""
-"För att skapa en betakanal, ladda upp en fil med en unik versionssträng som "
-"innehåller någon av följande strängar: <code>a,b,alpha,beta,pre, rc</code>, "
-"med ett valfritt nummer i slutet. Denna text måste komma i slutet av "
-"versionssträngen. Om du förstår formatet regex, så är detta vad vi ser i "
-"versionsnumret: <code>\"(a|alpha|b|beta|pre|rc)\\d*$\"</code>."
+"För att skapa en betakanal, ladda upp en fil med en unik versionssträng som innehåller någon av följande strängar: <code>a,b,alpha,beta,pre, rc</code>, med ett valfritt nummer i slutet. Denna text "
+"måste komma i slutet av versionssträngen. Om du förstår formatet regex, så är detta vad vi ser i versionsnumret: <code>\"(a|alpha|b|beta|pre|rc)\\d*$\"</code>."
 
 #: src/olympia/devhub/templates/devhub/docs/policies-maintenance.html:37
 msgid ""
-"Once a file meeting this criteria is uploaded to AMO, it will automatically "
-"be marked as a beta version. Users of add-ons with these unique version "
-"numbers will automatically be served the newest beta updates."
+"Once a file meeting this criteria is uploaded to AMO, it will automatically be marked as a beta version. Users of add-ons with these unique version numbers will automatically be served the newest "
+"beta updates."
 msgstr ""
-"När en fil som uppfyller dessa kriterier är uppladdad till AMO, kommer den "
-"automatiskt att markeras som en betaversion. Användare av tillägg med dessa "
-"unika versionsnummer kommer automatiskt att få de nyaste "
-"betauppdateringarna."
+"När en fil som uppfyller dessa kriterier är uppladdad till AMO, kommer den automatiskt att markeras som en betaversion. Användare av tillägg med dessa unika versionsnummer kommer automatiskt att få "
+"de nyaste betauppdateringarna."
 
 #: src/olympia/devhub/templates/devhub/docs/policies-maintenance.html:43
 msgid ""
-"While we call these \"Beta versions\", you can use this channel for "
-"nightlies, or alphas, or prerelease versions as you wish. Please note that "
-"there is only one channel for this purpose and all of your users on this "
-"channel will receive the latest add-ons submitted. For instance, if you "
-"upload <code>1.0beta1</code> to the release channel and then upload "
-"<code>1.1alpha1</code>, all users of <code>1.0beta1</code> will be offered "
-"an upgrade to <code>1.1alpha1</code>. Updates are pushed by submission date "
-"and not version number, so users will always get the most recent channel "
-"update regardless of any kind of alphabetical sorting."
+"While we call these \"Beta versions\", you can use this channel for nightlies, or alphas, or prerelease versions as you wish. Please note that there is only one channel for this purpose and all of "
+"your users on this channel will receive the latest add-ons submitted. For instance, if you upload <code>1.0beta1</code> to the release channel and then upload <code>1.1alpha1</code>, all users of "
+"<code>1.0beta1</code> will be offered an upgrade to <code>1.1alpha1</code>. Updates are pushed by submission date and not version number, so users will always get the most recent channel update "
+"regardless of any kind of alphabetical sorting."
 msgstr ""
-"Medan vi kallar dessa \"betaversioner\", kan du använda denna kanal för "
-"nightlies eller alphas, eller förhandsversioner om du så önskar. Observera "
-"att det endast finns en kanal för detta ändamål och alla dina användare på "
-"denna kanal kommer att få de senaste tillägget som skickats in. Till "
-"exempel, om du laddar upp <code>1.0beta1</code> till releasekanalen och "
-"sedan laddar upp <code>1.1alpha1</code>, kommer alla användare av "
-"<code>1.0beta1</code> att erbjudas en uppgradering till "
-"<code>1.1alpha1</code>. Uppdateringar släpps efter inskickningsdatum och "
-"inte versionsnummer, så att användarna alltid får den senaste "
-"kanaluppdatering oavsett alfabetisk sortering."
+"Medan vi kallar dessa \"betaversioner\", kan du använda denna kanal för nightlies eller alphas, eller förhandsversioner om du så önskar. Observera att det endast finns en kanal för detta ändamål "
+"och alla dina användare på denna kanal kommer att få de senaste tillägget som skickats in. Till exempel, om du laddar upp <code>1.0beta1</code> till releasekanalen och sedan laddar upp "
+"<code>1.1alpha1</code>, kommer alla användare av <code>1.0beta1</code> att erbjudas en uppgradering till <code>1.1alpha1</code>. Uppdateringar släpps efter inskickningsdatum och inte "
+"versionsnummer, så att användarna alltid får den senaste kanaluppdatering oavsett alfabetisk sortering."
 
 #: src/olympia/devhub/templates/devhub/docs/policies-maintenance.html:48
 msgid "Required Updates"
@@ -6650,21 +5348,13 @@ msgstr "Nödvändiga uppdateringar"
 
 #: src/olympia/devhub/templates/devhub/docs/policies-maintenance.html:50
 msgid ""
-"Certain situations may arise in which Mozilla requests that an add-on "
-"developer update their add-on within a given time period to address a major "
-"security issue or policy violation. We work with developers to reasonably "
-"accommodate their own schedules, but if the issue is of a serious enough "
-"nature, add-ons that cannot issue an update with the requested fix may be "
-"demoted from fully-reviewed status, disabled, or permanently removed from "
-"the site."
+"Certain situations may arise in which Mozilla requests that an add-on developer update their add-on within a given time period to address a major security issue or policy violation. We work with "
+"developers to reasonably accommodate their own schedules, but if the issue is of a serious enough nature, add-ons that cannot issue an update with the requested fix may be demoted from fully-"
+"reviewed status, disabled, or permanently removed from the site."
 msgstr ""
-"Vissa situationer kan uppstå där Mozilla begär att ett tilläggs utvecklare "
-"uppdaterar sitt tillägg inom en viss tidsperiod för att ta itu med ett stort"
-" säkerhetsproblem eller brott mot reglerna. Vi arbetar för utvecklarna ska "
-"på ett rimligt sätt tillgodose sina egna scheman, men om frågan är av "
-"tillräckligt allvarlig art, kan tillägg som inte kan utfärda en uppdatering "
-"med den begärda korrigeringen degraderas i status från fullständigt "
-"granskade, inaktiverade eller permanent borttagna från webbplatsen."
+"Vissa situationer kan uppstå där Mozilla begär att ett tilläggs utvecklare uppdaterar sitt tillägg inom en viss tidsperiod för att ta itu med ett stort säkerhetsproblem eller brott mot reglerna. Vi "
+"arbetar för utvecklarna ska på ett rimligt sätt tillgodose sina egna scheman, men om frågan är av tillräckligt allvarlig art, kan tillägg som inte kan utfärda en uppdatering med den begärda "
+"korrigeringen degraderas i status från fullständigt granskade, inaktiverade eller permanent borttagna från webbplatsen."
 
 #: src/olympia/devhub/templates/devhub/docs/policies-maintenance.html:55
 msgid "Transfer of Ownership"
@@ -6672,64 +5362,41 @@ msgstr "Överföring av ägarskap"
 
 #: src/olympia/devhub/templates/devhub/docs/policies-maintenance.html:57
 msgid ""
-"Add-ons can have multiple users with permission to update and manage the "
-"listing. Existing authors of an add-on can transfer ownership and add "
-"additional developers to an add-on's listing through the Developer Tools "
-"provided. No interaction with Mozilla representatives is necessary for a "
-"transfer of ownership."
+"Add-ons can have multiple users with permission to update and manage the listing. Existing authors of an add-on can transfer ownership and add additional developers to an add-on's listing through "
+"the Developer Tools provided. No interaction with Mozilla representatives is necessary for a transfer of ownership."
 msgstr ""
-"Tillägg kan ha flera användare med behörighet att uppdatera och hantera "
-"listning. Befintliga upphovsmän av ett tillägg kan överföra ägarskapet och "
-"lägga till ytterligare utvecklare i ett tilläggs listning genom "
-"utvecklarverktygen. Ingen interaktion med företrädare från Mozilla är "
-"nödvändig för en överföring av ägarskap."
+"Tillägg kan ha flera användare med behörighet att uppdatera och hantera listning. Befintliga upphovsmän av ett tillägg kan överföra ägarskapet och lägga till ytterligare utvecklare i ett tilläggs "
+"listning genom utvecklarverktygen. Ingen interaktion med företrädare från Mozilla är nödvändig för en överföring av ägarskap."
 
 #: src/olympia/devhub/templates/devhub/docs/policies-maintenance.html:63
 #, python-format
-msgid ""
-"Mozilla can assist with granting additional permissions of an add-on's "
-"listing if <a href=\"%(link_contact)s\">contacted</a> by the add-on's "
-"current owner."
-msgstr ""
-"Mozilla kan hjälpa till med att bevilja ytterligare tillstånd för ett "
-"tilläggs listning om de <a href=\"%(link_contact)s\">kontaktas</a> av "
-"tilläggets nuvarande ägare."
+msgid "Mozilla can assist with granting additional permissions of an add-on's listing if <a href=\"%(link_contact)s\">contacted</a> by the add-on's current owner."
+msgstr "Mozilla kan hjälpa till med att bevilja ytterligare tillstånd för ett tilläggs listning om de <a href=\"%(link_contact)s\">kontaktas</a> av tilläggets nuvarande ägare."
 
 #: src/olympia/devhub/templates/devhub/docs/policies-maintenance.html:70
 msgid ""
-"Mozilla encourages its users to offer feedback on their experiences when "
-"using an add-on. This allows other users to determine if the add-on is "
-"stable and useful. It also provides valuable feedback to developers, "
-"allowing them to continuously improve their add-on to meet user needs."
+"Mozilla encourages its users to offer feedback on their experiences when using an add-on. This allows other users to determine if the add-on is stable and useful. It also provides valuable feedback "
+"to developers, allowing them to continuously improve their add-on to meet user needs."
 msgstr ""
-"Mozilla uppmanar sina användare att ge återkoppling om sina erfarenheter när"
-" de använder ett tillägg. Detta gör att andra användare kan avgöra om "
-"tillägg är stabila och användbara. Det ger också värdefulla synpunkter till "
-"utvecklare, vilket ger dem möjlighet att kontinuerligt förbättra sina "
-"tillägg för att möta användarnas behov."
+"Mozilla uppmanar sina användare att ge återkoppling om sina erfarenheter när de använder ett tillägg. Detta gör att andra användare kan avgöra om tillägg är stabila och användbara. Det ger också "
+"värdefulla synpunkter till utvecklare, vilket ger dem möjlighet att kontinuerligt förbättra sina tillägg för att möta användarnas behov."
 
 #: src/olympia/devhub/templates/devhub/docs/policies-maintenance.html:76
 #, python-format
 msgid ""
-"Reviews must follow the <a href=\"%(link_guidelines)s\">review "
-"guidelines</a>. Reviews that do not meet these guidelines may be flagged for"
-" moderation, but negative reviews will not be removed unless they provide "
-"false information."
+"Reviews must follow the <a href=\"%(link_guidelines)s\">review guidelines</a>. Reviews that do not meet these guidelines may be flagged for moderation, but negative reviews will not be removed "
+"unless they provide false information."
 msgstr ""
-"Recensioner måste följa <a "
-"href=\"%(link_guidelines)s\">recensionsriktlinjer</a>. Recensioner som inte "
-"uppfyller dessa riktlinjer kan flaggas för moderering, men negativa "
-"recensioner kommer inte att tas bort om de inte ger falsk information."
+"Recensioner måste följa <a href=\"%(link_guidelines)s\">recensionsriktlinjer</a>. Recensioner som inte uppfyller dessa riktlinjer kan flaggas för moderering, men negativa recensioner kommer inte "
+"att tas bort om de inte ger falsk information."
 
 #: src/olympia/devhub/templates/devhub/docs/policies-maintenance.html:82
 msgid ""
-"Many developers provide a support mechanism, such as a forum, discussion "
-"group, or email address. It is recommended that support questions be posted "
-"via those mediums instead of in an add-on's review section."
+"Many developers provide a support mechanism, such as a forum, discussion group, or email address. It is recommended that support questions be posted via those mediums instead of in an add-on's "
+"review section."
 msgstr ""
-"Många utvecklare ger ett stödsystem, såsom ett forum, diskussionsgrupp eller"
-" e-postadress. Det rekommenderas att supportfrågor publiceras via dessa "
-"medier i stället för i ett tilläggs recensionssektion."
+"Många utvecklare ger ett stödsystem, såsom ett forum, diskussionsgrupp eller e-postadress. Det rekommenderas att supportfrågor publiceras via dessa medier i stället för i ett tilläggs "
+"recensionssektion."
 
 #: src/olympia/devhub/templates/devhub/docs/policies-maintenance.html:87
 msgid "Code Disputes"
@@ -6737,44 +5404,26 @@ msgstr "Kodtvister"
 
 #: src/olympia/devhub/templates/devhub/docs/policies-maintenance.html:90
 msgid ""
-"Many add-ons allow their source code to be openly viewed. This does not mean"
-" that the source code is open source or available for use in another add-on."
-" The original author of an add-on retains copyright of their work unless "
-"otherwise noted in the add-on's license."
+"Many add-ons allow their source code to be openly viewed. This does not mean that the source code is open source or available for use in another add-on. The original author of an add-on retains "
+"copyright of their work unless otherwise noted in the add-on's license."
 msgstr ""
-"Många tillägg tillåter deras källkod att visas öppet. Detta betyder inte att"
-" källkoden är öppen källkod eller tillgänglig för användning i en annat "
-"tillägg. Den ursprungliga utvecklaren av ett tillägg behåller upphovsrätten "
-"till sitt arbete om inte annat anges i tilläggets licens."
+"Många tillägg tillåter deras källkod att visas öppet. Detta betyder inte att källkoden är öppen källkod eller tillgänglig för användning i en annat tillägg. Den ursprungliga utvecklaren av ett "
+"tillägg behåller upphovsrätten till sitt arbete om inte annat anges i tilläggets licens."
 
 #: src/olympia/devhub/templates/devhub/docs/policies-maintenance.html:96
 msgid ""
-"In the event that we're notified of a copyright or license infringement, we "
-"will take steps to review the situation and determine if an actual "
-"infringement has occurred. If we determine that there is an infringement, we"
-" will remove the offending add-on and contact the author. New add-on "
-"submissions (including updates) containing infringing code will be denied "
-"approval for public status."
+"In the event that we're notified of a copyright or license infringement, we will take steps to review the situation and determine if an actual infringement has occurred. If we determine that there "
+"is an infringement, we will remove the offending add-on and contact the author. New add-on submissions (including updates) containing infringing code will be denied approval for public status."
 msgstr ""
-"I händelse av att vi får ett meddelande om upphovsrätt eller licens intrång,"
-" kommer vi att vidta åtgärder för att se över situationen och avgöra om en "
-"verklig överträdelse har skett. Om vi bedömer att det finns en överträdelse,"
-" kommer vi att ta bort den felande tillägget och kontakta utvecklaren. Nya "
-"inskickningar av tillägg (inklusive uppdateringar) innehållande överträdande"
-" kod kommer att nekas tillstånd för publik status."
+"I händelse av att vi får ett meddelande om upphovsrätt eller licens intrång, kommer vi att vidta åtgärder för att se över situationen och avgöra om en verklig överträdelse har skett. Om vi bedömer "
+"att det finns en överträdelse, kommer vi att ta bort den felande tillägget och kontakta utvecklaren. Nya inskickningar av tillägg (inklusive uppdateringar) innehållande överträdande kod kommer att "
+"nekas tillstånd för publik status."
 
 #: src/olympia/devhub/templates/devhub/docs/policies-maintenance.html:102
-msgid ""
-"If you are unsure of the current copyright status of an add-on's source "
-"code, you must contact the original author and receive explicit permission "
-"before using the source code."
-msgstr ""
-"Om du är osäker på den aktuella status för upphovsrätt som tilläggets "
-"källkod, måste du kontakta den ursprungliga utvecklaren och få uttryckligt "
-"tillstånd innan du använder källkoden."
+msgid "If you are unsure of the current copyright status of an add-on's source code, you must contact the original author and receive explicit permission before using the source code."
+msgstr "Om du är osäker på den aktuella status för upphovsrätt som tilläggets källkod, måste du kontakta den ursprungliga utvecklaren och få uttryckligt tillstånd innan du använder källkoden."
 
-#: src/olympia/devhub/templates/devhub/docs/policies-maintenance.html:107
-#: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:306
+#: src/olympia/devhub/templates/devhub/docs/policies-maintenance.html:107 src/olympia/devhub/templates/devhub/docs/policies-reviews.html:306
 #: src/olympia/devhub/templates/devhub/docs/policies-submission.html:97
 msgid "Last updated: January 13, 2011"
 msgstr "Senast uppdaterad: 13 januari 2011"
@@ -6782,54 +5431,33 @@ msgstr "Senast uppdaterad: 13 januari 2011"
 #: src/olympia/devhub/templates/devhub/docs/policies-recommended.html:13
 #, python-format
 msgid ""
-"Featured add-ons are top-quality extensions and themes highlighted on <a "
-"href=\"%(link_gallery)s\">AMO</a>, Firefox's Add-ons Manager, and across "
-"other Mozilla websites. These add-ons showcase the power of Firefox "
-"customization and are useful to a wide audience."
+"Featured add-ons are top-quality extensions and themes highlighted on <a href=\"%(link_gallery)s\">AMO</a>, Firefox's Add-ons Manager, and across other Mozilla websites. These add-ons showcase the "
+"power of Firefox customization and are useful to a wide audience."
 msgstr ""
-"Utvalda tillägg är av högsta kvalitet utökningar och teman lyfts fram på <a "
-"href=\"%(link_gallery)s\">AMO</a>, Firefox tilläggshanterare och över andra "
-"Mozilla-webbplatser. Dessa tillägg visar kraften i Firefox anpassning och är"
-" användbara för en bred publik."
+"Utvalda tillägg är av högsta kvalitet utökningar och teman lyfts fram på <a href=\"%(link_gallery)s\">AMO</a>, Firefox tilläggshanterare och över andra Mozilla-webbplatser. Dessa tillägg visar "
+"kraften i Firefox anpassning och är användbara för en bred publik."
 
 #: src/olympia/devhub/templates/devhub/docs/policies-recommended.html:19
 msgid ""
-"Featured add-ons are chosen by the Featured Add-ons Advisory Board, a small "
-"group of add-on developers and fans from the Mozilla community who have "
-"volunteered to review and vote on nominations."
-msgstr ""
-"Utvalda tillägg väljs av tilläggsdelegation, en liten grupp av "
-"tilläggsutvecklare och fans från Mozillas gemenskap som har erbjudit sig att"
-" granska och rösta om nomineringarna."
+"Featured add-ons are chosen by the Featured Add-ons Advisory Board, a small group of add-on developers and fans from the Mozilla community who have volunteered to review and vote on nominations."
+msgstr "Utvalda tillägg väljs av tilläggsdelegation, en liten grupp av tilläggsutvecklare och fans från Mozillas gemenskap som har erbjudit sig att granska och rösta om nomineringarna."
 
 #: src/olympia/devhub/templates/devhub/docs/policies-recommended.html:25
 #, python-format
-msgid ""
-"<a href=\"%(link_featured)s\">Featured extensions</a> are chosen every "
-"month, and <a href=\"%(link_themes)s\">featured complete themes</a> are "
-"chosen every quarter."
-msgstr ""
-"<a href=\"%(link_featured)s\">Utvalda utökningar</a> väljs varje månad och "
-"<a href=\"%(link_themes)s\">utvalda kompletta teman</a> väljs varje kvartal."
+msgid "<a href=\"%(link_featured)s\">Featured extensions</a> are chosen every month, and <a href=\"%(link_themes)s\">featured complete themes</a> are chosen every quarter."
+msgstr "<a href=\"%(link_featured)s\">Utvalda utökningar</a> väljs varje månad och <a href=\"%(link_themes)s\">utvalda kompletta teman</a> väljs varje kvartal."
 
 #: src/olympia/devhub/templates/devhub/docs/policies-recommended.html:30
 msgid "Criteria for Featured Add-ons"
 msgstr "Kriterier för utvalda tillägg"
 
 #: src/olympia/devhub/templates/devhub/docs/policies-recommended.html:33
-msgid ""
-"Before nominating an add-on to be featured, please ensure it meets the "
-"following criteria:"
-msgstr ""
-"Innan nominering av ett tillägg till att bli utvald, vänligen se till att "
-"den uppfyller följande kriterier:"
+msgid "Before nominating an add-on to be featured, please ensure it meets the following criteria:"
+msgstr "Innan nominering av ett tillägg till att bli utvald, vänligen se till att den uppfyller följande kriterier:"
 
 #: src/olympia/devhub/templates/devhub/docs/policies-recommended.html:39
-msgid ""
-"The add-on must have a complete and informative listing on AMO. This means:"
-msgstr ""
-"Tillägget måste ha en fullständig och informativ listning på AMO. Det "
-"betyder:"
+msgid "The add-on must have a complete and informative listing on AMO. This means:"
+msgstr "Tillägget måste ha en fullständig och informativ listning på AMO. Det betyder:"
 
 #: src/olympia/devhub/templates/devhub/docs/policies-recommended.html:41
 msgid "a 64-pixel custom icon"
@@ -6852,45 +5480,28 @@ msgid "updated screenshots of the add-on's functionality"
 msgstr "uppdaterade skärmdumpar av tilläggets funktionalitet"
 
 #: src/olympia/devhub/templates/devhub/docs/policies-recommended.html:46
-msgid ""
-"must be fully approved by AMO editors (no preliminarily reviewed entries)"
-msgstr ""
-"måste vara fullt godkänd av AMO:s redigerare (inga preliminärt granskade "
-"poster)"
+msgid "must be fully approved by AMO editors (no preliminarily reviewed entries)"
+msgstr "måste vara fullt godkänd av AMO:s redigerare (inga preliminärt granskade poster)"
 
 #: src/olympia/devhub/templates/devhub/docs/policies-recommended.html:48
-msgid ""
-"The add-on must have excellent user reviews and any problems or support "
-"requests must be promptly addressed by the developer."
-msgstr ""
-"Tillägget måste ha utmärkta användarrecensioner och eventuella problem eller"
-" supportärenden måste omedelbart åtgärdas av utvecklare."
+msgid "The add-on must have excellent user reviews and any problems or support requests must be promptly addressed by the developer."
+msgstr "Tillägget måste ha utmärkta användarrecensioner och eventuella problem eller supportärenden måste omedelbart åtgärdas av utvecklare."
 
 #: src/olympia/devhub/templates/devhub/docs/policies-recommended.html:49
 msgid "The add-on must have a minimum of 2,000 users."
 msgstr "Tillägget måste ha minst 2.000 användare."
 
 #: src/olympia/devhub/templates/devhub/docs/policies-recommended.html:50
-msgid ""
-"The add-on must be compatible with the latest release of Firefox and must be"
-" compatible with beta versions 4 weeks before their final release."
-msgstr ""
-"Tillägget måste vara kompatibel med den senaste versionen av Firefox och "
-"måste vara kompatibel med betaversioner 4 veckor innan den slutliga "
-"versionen."
+msgid "The add-on must be compatible with the latest release of Firefox and must be compatible with beta versions 4 weeks before their final release."
+msgstr "Tillägget måste vara kompatibel med den senaste versionen av Firefox och måste vara kompatibel med betaversioner 4 veckor innan den slutliga versionen."
 
 #: src/olympia/devhub/templates/devhub/docs/policies-recommended.html:51
 msgid ""
-"<strong>Most importantly</strong>, the add-on must have wide consumer appeal"
-" to Firefox's users and be outstanding in nearly every way: user experience,"
-" performance, security, and usefulness or entertainment value. Featured "
-"complete themes must also be visually appealing."
+"<strong>Most importantly</strong>, the add-on must have wide consumer appeal to Firefox's users and be outstanding in nearly every way: user experience, performance, security, and usefulness or "
+"entertainment value. Featured complete themes must also be visually appealing."
 msgstr ""
-"<strong>Viktigast av allt</strong>, tillägget måste ha bred attraktion bland"
-" Firefoxs användare och  vara enastående på nästan alla sätt: "
-"användarupplevelse, prestanda, säkerhet och användbarhet eller "
-"underhållningsvärde. Utvalda komplett teman måste också vara visuellt "
-"tilltalande."
+"<strong>Viktigast av allt</strong>, tillägget måste ha bred attraktion bland Firefoxs användare och  vara enastående på nästan alla sätt: användarupplevelse, prestanda, säkerhet och användbarhet "
+"eller underhållningsvärde. Utvalda komplett teman måste också vara visuellt tilltalande."
 
 #: src/olympia/devhub/templates/devhub/docs/policies-recommended.html:54
 msgid "Nominating an Add-on"
@@ -6902,266 +5513,164 @@ msgstr "amo-featured at mozilla dot org"
 
 #: src/olympia/devhub/templates/devhub/docs/policies-recommended.html:57
 #, python-format
-msgid ""
-"If you wish to nominate an add-on to be featured and it meets the criteria "
-"above, send an email to %(mail_featured)s with:"
-msgstr ""
-"Om du vill nominera en tillägg till att vara utvalt och det uppfyller "
-"kriterierna ovan, skicka ett mejl till %(mail_featured)s med:"
+msgid "If you wish to nominate an add-on to be featured and it meets the criteria above, send an email to %(mail_featured)s with:"
+msgstr "Om du vill nominera en tillägg till att vara utvalt och det uppfyller kriterierna ovan, skicka ett mejl till %(mail_featured)s med:"
 
 #: src/olympia/devhub/templates/devhub/docs/policies-recommended.html:62
 msgid "the add-on name, URL, and whether you are its developer"
 msgstr "tilläggets namn, URL och om du är dess utvecklare"
 
 #: src/olympia/devhub/templates/devhub/docs/policies-recommended.html:63
-msgid ""
-"a short explanation of why the add-on has wide appeal and should be featured"
-msgstr ""
-"en kort förklaring till varför tillägget har en bred attraktion och bör bli "
-"utvalt"
+msgid "a short explanation of why the add-on has wide appeal and should be featured"
+msgstr "en kort förklaring till varför tillägget har en bred attraktion och bör bli utvalt"
 
 #: src/olympia/devhub/templates/devhub/docs/policies-recommended.html:64
-msgid ""
-"optionally, links to any external reviews or articles mentioning the add-on"
-msgstr ""
-"valfritt, länkar till alla externa granskningar eller artiklar som hänvisar "
-"till tillägget"
+msgid "optionally, links to any external reviews or articles mentioning the add-on"
+msgstr "valfritt, länkar till alla externa granskningar eller artiklar som hänvisar till tillägget"
 
 #: src/olympia/devhub/templates/devhub/docs/policies-recommended.html:68
 msgid ""
-"Add-on nominations are reviewed by the Advisory Board once a month (once "
-"every 3 months for complete theme nominations). Common reasons for rejection"
-" include lacking wide appeal to consumers, a suboptimal user experience, "
-"quality or security issues, incompatibility, and similarity to another "
-"featured add-on. Rejected add-ons cannot be re-nominated within 3 months."
+"Add-on nominations are reviewed by the Advisory Board once a month (once every 3 months for complete theme nominations). Common reasons for rejection include lacking wide appeal to consumers, a "
+"suboptimal user experience, quality or security issues, incompatibility, and similarity to another featured add-on. Rejected add-ons cannot be re-nominated within 3 months."
 msgstr ""
-"Tillläggsnomineringar granskas av den rådgivande nämnden en gång i månaden "
-"(en gång var 3 månader för nomineringar av kompletta teman). Vanliga orsaker"
-" till avslag inkluderar saknad av en bred attraktion från konsumenterna, en "
-"suboptimal användarupplevelse, kvalitet eller säkerhetsfrågor, "
-"inkompatibilitet och likheten till ett annat utvalt tillägg. Avvisade "
-"tillägg kan inte åter nomineras inom 3 månader."
+"Tillläggsnomineringar granskas av den rådgivande nämnden en gång i månaden (en gång var 3 månader för nomineringar av kompletta teman). Vanliga orsaker till avslag inkluderar saknad av en bred "
+"attraktion från konsumenterna, en suboptimal användarupplevelse, kvalitet eller säkerhetsfrågor, inkompatibilitet och likheten till ett annat utvalt tillägg. Avvisade tillägg kan inte åter "
+"nomineras inom 3 månader."
 
 #: src/olympia/devhub/templates/devhub/docs/policies-recommended.html:73
 msgid "Rotating Featured Add-ons"
 msgstr "Roterande utvalda tillägg"
 
 #: src/olympia/devhub/templates/devhub/docs/policies-recommended.html:76
-msgid ""
-"Mozilla and the Featured Add-ons Advisory Board regularly evaluate and "
-"rotate out featured add-ons. Some of the most common reasons for add-ons "
-"being removed from the featured list are:"
+msgid "Mozilla and the Featured Add-ons Advisory Board regularly evaluate and rotate out featured add-ons. Some of the most common reasons for add-ons being removed from the featured list are:"
 msgstr ""
-"Mozilla och den rådgivande nämnden för utvalda tillägg utvärderar "
-"regelbundet och rotera ut utvalda tillägg. Några av de vanligaste orsakerna "
-"till att tillägg avlägsnas från den utvalda listan är:"
+"Mozilla och den rådgivande nämnden för utvalda tillägg utvärderar regelbundet och rotera ut utvalda tillägg. Några av de vanligaste orsakerna till att tillägg avlägsnas från den utvalda listan är:"
 
 #: src/olympia/devhub/templates/devhub/docs/policies-recommended.html:83
 msgid ""
-"Lack of growth &mdash; Add-ons that are featured typically experience a "
-"substantial gain in both downloads and active users. If an add-on is not "
-"demonstrating growth in any substantial way, that's a good indicator the "
-"add-on may not be very useful to our users."
+"Lack of growth &mdash; Add-ons that are featured typically experience a substantial gain in both downloads and active users. If an add-on is not demonstrating growth in any substantial way, that's "
+"a good indicator the add-on may not be very useful to our users."
 msgstr ""
-"Brist på tillväxt &mdash; Tillägg som är utvalda upplever en betydande "
-"ökning i både nedladdningar och aktiva användare. Om ett tillägg inte visar "
-"tillväxt på något betydande sätt, det är en bra indikator som visar att "
-"tillägget inte är användbart för våra användare."
+"Brist på tillväxt &mdash; Tillägg som är utvalda upplever en betydande ökning i både nedladdningar och aktiva användare. Om ett tillägg inte visar tillväxt på något betydande sätt, det är en bra "
+"indikator som visar att tillägget inte är användbart för våra användare."
 
 #: src/olympia/devhub/templates/devhub/docs/policies-recommended.html:88
-msgid ""
-"Negative reviews &mdash; Featured add-ons should have a great experience and"
-" very few bugs, so add-ons with many negative reviews may be reconsidered."
-msgstr ""
-"Negativa recensioner &mdash; Utvalda tillägg bör ha en fantastisk upplevelse"
-" och väldigt få buggar, så tillägg med många negativa recensioner kan "
-"omprövas."
+msgid "Negative reviews &mdash; Featured add-ons should have a great experience and very few bugs, so add-ons with many negative reviews may be reconsidered."
+msgstr "Negativa recensioner &mdash; Utvalda tillägg bör ha en fantastisk upplevelse och väldigt få buggar, så tillägg med många negativa recensioner kan omprövas."
 
 #: src/olympia/devhub/templates/devhub/docs/policies-recommended.html:93
 msgid ""
-"Incompatibility with upcoming Firefox versions &mdash; Featured add-ons are "
-"expected to be compatible with stable and beta versions of Firefox. Add-ons "
-"not yet compatible with a Beta version of Firefox four weeks before its "
-"expected release will lose their featured status."
+"Incompatibility with upcoming Firefox versions &mdash; Featured add-ons are expected to be compatible with stable and beta versions of Firefox. Add-ons not yet compatible with a Beta version of "
+"Firefox four weeks before its expected release will lose their featured status."
 msgstr ""
-"Inkompabilitet med kommande Firefox-versioner &mdash; Utvalda tillägg "
-"förväntas vara kompatibla för stabila och betaversioner av Firefox. Tillägg "
-"som ännu inte är kompatibla med en betaversion av Firefox fyra veckor före "
-"den förväntade släppet kommer att förlora sin utvalda status."
+"Inkompabilitet med kommande Firefox-versioner &mdash; Utvalda tillägg förväntas vara kompatibla för stabila och betaversioner av Firefox. Tillägg som ännu inte är kompatibla med en betaversion av "
+"Firefox fyra veckor före den förväntade släppet kommer att förlora sin utvalda status."
 
 #: src/olympia/devhub/templates/devhub/docs/policies-recommended.html:99
 msgid "Joining the Featured Add-ons Advisory Board"
 msgstr "Gå med i den rådgivande nämnden för utvalda tillägg"
 
 #: src/olympia/devhub/templates/devhub/docs/policies-recommended.html:102
-msgid ""
-"Every six months a new Advisory Board is chosen based on applications from "
-"the add-ons community. Members must:"
-msgstr ""
-"Varje halvår väljs en rådgivande nämnd baserat på ansökningar från "
-"gemenskapen för tillägg. Medlemmar måste:"
+msgid "Every six months a new Advisory Board is chosen based on applications from the add-ons community. Members must:"
+msgstr "Varje halvår väljs en rådgivande nämnd baserat på ansökningar från gemenskapen för tillägg. Medlemmar måste:"
 
 #: src/olympia/devhub/templates/devhub/docs/policies-recommended.html:108
-msgid ""
-"be active members of the add-ons community, whether as a developer, "
-"evangelist, or fan"
-msgstr ""
-"vara aktiva medlemmar i gemenskapen för tillägg, oavsett om du är "
-"utvecklare, missionär eller beundrare"
+msgid "be active members of the add-ons community, whether as a developer, evangelist, or fan"
+msgstr "vara aktiva medlemmar i gemenskapen för tillägg, oavsett om du är utvecklare, missionär eller beundrare"
 
 #: src/olympia/devhub/templates/devhub/docs/policies-recommended.html:109
-msgid ""
-"commit to trying all the nominations submitted, giving their feedback, and "
-"casting their votes every month"
-msgstr ""
-"åta sig att försöka testa alla kandidater, ge dem återkoppling och ge dem "
-"röster varje månad"
+msgid "commit to trying all the nominations submitted, giving their feedback, and casting their votes every month"
+msgstr "åta sig att försöka testa alla kandidater, ge dem återkoppling och ge dem röster varje månad"
 
 #: src/olympia/devhub/templates/devhub/docs/policies-recommended.html:110
-msgid ""
-"abstain from voting on add-ons that they have any business or personal "
-"affiliations with, as well as direct competitors of any such add-ons"
-msgstr ""
-"avstå från att rösta på tillägg som de har någon affärs eller personlig "
-"koppling till, liksom direkta konkurrenter till sådana tillägg"
+msgid "abstain from voting on add-ons that they have any business or personal affiliations with, as well as direct competitors of any such add-ons"
+msgstr "avstå från att rösta på tillägg som de har någon affärs eller personlig koppling till, liksom direkta konkurrenter till sådana tillägg"
 
 #: src/olympia/devhub/templates/devhub/docs/policies-recommended.html:114
 msgid ""
-"Members of the Mozilla Add-ons team may veto any add-on's selection because "
-"of security, privacy, compatibility, or any other reason, but in general it "
-"is up to the Board to select add-ons to feature."
+"Members of the Mozilla Add-ons team may veto any add-on's selection because of security, privacy, compatibility, or any other reason, but in general it is up to the Board to select add-ons to "
+"feature."
 msgstr ""
-"Medlemmar av Mozilla gruppen för tillägg kan inlägga veto mot varje tilläggs"
-" utbud på grund av säkerhet, integritet, kompatibilitet eller någon annan "
-"orsak, men i allmänhet är det upp till nämnden att välja utvalda tillägg."
+"Medlemmar av Mozilla gruppen för tillägg kan inlägga veto mot varje tilläggs utbud på grund av säkerhet, integritet, kompatibilitet eller någon annan orsak, men i allmänhet är det upp till nämnden "
+"att välja utvalda tillägg."
 
 #: src/olympia/devhub/templates/devhub/docs/policies-recommended.html:120
 msgid ""
-"This featured policy only applies to the addons.mozilla.org global list of "
-"featured add-ons. Add-ons featured in other locations are often pulled from "
-"this list, but Mozilla may feature any add-on in other locations without the"
-" Board's consent. Additionally, locale-specific features override the global"
-" defaults, so if a locale has opted to select its own features, some or all "
-"of the global features may not appear in that locale."
+"This featured policy only applies to the addons.mozilla.org global list of featured add-ons. Add-ons featured in other locations are often pulled from this list, but Mozilla may feature any add-on "
+"in other locations without the Board's consent. Additionally, locale-specific features override the global defaults, so if a locale has opted to select its own features, some or all of the global "
+"features may not appear in that locale."
 msgstr ""
-"Denna policy för utvalda gäller endast addons.mozilla.org globala lista över"
-" utvalda tillägg. Tillägg utvalda på andra platser är dras ofta från den här"
-" listan, men Mozilla kan ha utvalda tillägg från andra platser utan nämndens"
-" godkännande. Dessutom, språkspecifika funktioner åsidosätter den globala "
-"standarden, så om ett språk har valt att välja sina egna funktioner, några "
-"eller alla av de globala funktionerna kanske inte visas i det språket."
+"Denna policy för utvalda gäller endast addons.mozilla.org globala lista över utvalda tillägg. Tillägg utvalda på andra platser är dras ofta från den här listan, men Mozilla kan ha utvalda tillägg "
+"från andra platser utan nämndens godkännande. Dessutom, språkspecifika funktioner åsidosätter den globala standarden, så om ett språk har valt att välja sina egna funktioner, några eller alla av de "
+"globala funktionerna kanske inte visas i det språket."
 
 #: src/olympia/devhub/templates/devhub/docs/policies-recommended.html:126
 #, python-format
-msgid ""
-"Follow the <a href=\"%(link_blog)s\">Add-ons Blog</a> or <a "
-"href=\"%(link_twitter)s\">@mozamo</a> on Twitter to learn when the next "
-"application period opens."
-msgstr ""
-"Följ <a href=\"%(link_blog)s\">bloggen för tillägg</a> eller <a "
-"href=\"%(link_twitter)s\">@mozamo</a> på Twitter för att veta när nästa "
-"ansökningsperiod öppnar."
+msgid "Follow the <a href=\"%(link_blog)s\">Add-ons Blog</a> or <a href=\"%(link_twitter)s\">@mozamo</a> on Twitter to learn when the next application period opens."
+msgstr "Följ <a href=\"%(link_blog)s\">bloggen för tillägg</a> eller <a href=\"%(link_twitter)s\">@mozamo</a> på Twitter för att veta när nästa ansökningsperiod öppnar."
 
 #: src/olympia/devhub/templates/devhub/docs/policies-recommended.html:131
 msgid "Last updated: January 31, 2013"
 msgstr "Senast uppdaterad: 31 januari 2013"
 
-#: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:3
-#: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:7
-#: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:8
-#: src/olympia/devhub/templates/devhub/docs/policies.html:15
-#: src/olympia/devhub/templates/devhub/docs/policies.html:64
+#: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:3 src/olympia/devhub/templates/devhub/docs/policies-reviews.html:7 src/olympia/devhub/templates/devhub/docs/policies-reviews.html:8
+#: src/olympia/devhub/templates/devhub/docs/policies.html:15 src/olympia/devhub/templates/devhub/docs/policies.html:64
 msgid "Review Process"
 msgstr "Granskningsprocess"
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:12
 msgid ""
-"In order to ensure all add-ons hosted in our gallery are safe for users to "
-"install, Mozilla will begin requiring all hosted add-ons to undergo review. "
-"We offer two types of review and developers are free to choose the best fit "
-"for their add-on."
+"In order to ensure all add-ons hosted in our gallery are safe for users to install, Mozilla will begin requiring all hosted add-ons to undergo review. We offer two types of review and developers "
+"are free to choose the best fit for their add-on."
 msgstr ""
-"För att säkerställa att alla tillägg som hyses i vårt galleri är säkra för "
-"användarna att installera, kommer Mozilla att börja kräva att alla tillägg "
-"som hyses ska genomgå granskning. Vi erbjuder två typer av granskning och "
-"utvecklare är fria att välja den som passar bäst för deras tillägg."
+"För att säkerställa att alla tillägg som hyses i vårt galleri är säkra för användarna att installera, kommer Mozilla att börja kräva att alla tillägg som hyses ska genomgå granskning. Vi erbjuder "
+"två typer av granskning och utvecklare är fria att välja den som passar bäst för deras tillägg."
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:19
 msgid ""
-"<strong><a href=\"#full\">Full Review</a></strong> &mdash; a thorough "
-"functional and code review of the add-on, appropriate for add-ons ready for "
-"distribution to the masses. All site features are available to these add-"
-"ons."
+"<strong><a href=\"#full\">Full Review</a></strong> &mdash; a thorough functional and code review of the add-on, appropriate for add-ons ready for distribution to the masses. All site features are "
+"available to these add-ons."
 msgstr ""
-"<strong><a href=\"#full\">Fullständig granskning</a></strong> &mdash; en "
-"grundlig funktionell och kodgranskning av tillägget, lämplig för tillägg som"
-" är redo för distribution. Alla webbplatsfunktioner är tillgängliga för "
-"dessa tillägg."
+"<strong><a href=\"#full\">Fullständig granskning</a></strong> &mdash; en grundlig funktionell och kodgranskning av tillägget, lämplig för tillägg som är redo för distribution. Alla "
+"webbplatsfunktioner är tillgängliga för dessa tillägg."
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:24
 msgid ""
-"<strong><a href=\"#preliminary\">Preliminary Review</a></strong> &mdash; a "
-"faster review intended for experimental add-ons. Preliminary reviews do not "
-"check for functionality or full policy compliance, but the reviewed add-ons "
-"have install button cautions and some feature limitations."
+"<strong><a href=\"#preliminary\">Preliminary Review</a></strong> &mdash; a faster review intended for experimental add-ons. Preliminary reviews do not check for functionality or full policy "
+"compliance, but the reviewed add-ons have install button cautions and some feature limitations."
 msgstr ""
-"<strong><a href=\"#preliminary\">Preliminär granskning</a></strong> &mdash; "
-"en snabbare granskning avsedda för experimentella tillägg. Preliminära "
-"granskningar kontrollerar inte funktionalitet eller full policyefterlevnad, "
-"men de granskade tillägg har varning på installationsknappen och vissa "
-"funktionsbegränsningar."
+"<strong><a href=\"#preliminary\">Preliminär granskning</a></strong> &mdash; en snabbare granskning avsedda för experimentella tillägg. Preliminära granskningar kontrollerar inte funktionalitet "
+"eller full policyefterlevnad, men de granskade tillägg har varning på installationsknappen och vissa funktionsbegränsningar."
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:31
 msgid ""
-"Detailed descriptions of each option are below. After selecting a review "
-"process at submission, the add-on will be placed in the queue. Add-ons are "
-"reviewed by the <a href=\"https://wiki.mozilla.org/AMO:Editors\">AMO "
-"Editors</a>, a group of talented developers that volunteer to help the "
-"Mozilla project by reviewing add-ons to ensure a stable and safe experience "
-"for users. Developers will receive an email with any updates throughout the "
-"review process."
+"Detailed descriptions of each option are below. After selecting a review process at submission, the add-on will be placed in the queue. Add-ons are reviewed by the <a href=\"https://wiki.mozilla."
+"org/AMO:Editors\">AMO Editors</a>, a group of talented developers that volunteer to help the Mozilla project by reviewing add-ons to ensure a stable and safe experience for users. Developers will "
+"receive an email with any updates throughout the review process."
 msgstr ""
-"Detaljerade beskrivningar av varje alternativ finns nedan. När du har valt "
-"en granskningsprocess vid inskickning, kommer tillägget placeras i kön. "
-"Tillägg granskas av <a href=\"https://wiki.mozilla.org/AMO:Editors\">AMO-"
-"redigerare</a>, en grupp begåvade utvecklare som är volontärer för att "
-"hjälpa Mozilla-projektet genom att granska tillägg för att säkerställa en "
-"stabil och säker upplevelse för användarna. Utvecklare kommer få ett mejl "
-"med eventuella uppdateringar under hela granskningsprocessen."
+"Detaljerade beskrivningar av varje alternativ finns nedan. När du har valt en granskningsprocess vid inskickning, kommer tillägget placeras i kön. Tillägg granskas av <a href=\"https://wiki.mozilla."
+"org/AMO:Editors\">AMO-redigerare</a>, en grupp begåvade utvecklare som är volontärer för att hjälpa Mozilla-projektet genom att granska tillägg för att säkerställa en stabil och säker upplevelse "
+"för användarna. Utvecklare kommer få ett mejl med eventuella uppdateringar under hela granskningsprocessen."
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:37
 msgid ""
-"While waiting for review, add-ons will not appear anywhere in the gallery "
-"publicly, but direct links to the add-on's details page will work. This "
-"allows the author to blog or share the link with friends, inviting them to "
-"try it out, even when not yet reviewed."
+"While waiting for review, add-ons will not appear anywhere in the gallery publicly, but direct links to the add-on's details page will work. This allows the author to blog or share the link with "
+"friends, inviting them to try it out, even when not yet reviewed."
 msgstr ""
-"I väntan på granskning, tillägg visas inte någonstans i galleriet "
-"offentligt, men direktlänkar till tilläggets informationssida kommer att "
-"fungera. Denna gör det möjligt för upphovsmän att blogga eller dela länken "
-"med vänner och uppmana dem att prova det, även om den ännu inte har "
-"granskats."
+"I väntan på granskning, tillägg visas inte någonstans i galleriet offentligt, men direktlänkar till tilläggets informationssida kommer att fungera. Denna gör det möjligt för upphovsmän att blogga "
+"eller dela länken med vänner och uppmana dem att prova det, även om den ännu inte har granskats."
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:44
 msgid ""
-"Full reviews are appropriate for add-ons that are well-tested, stable, fast,"
-" and have wide appeal to our users. If you aren't confident that your add-on"
-" meets that criteria, please consider working out the kinks while in "
-"preliminary review and accumulating user feedback first."
+"Full reviews are appropriate for add-ons that are well-tested, stable, fast, and have wide appeal to our users. If you aren't confident that your add-on meets that criteria, please consider working "
+"out the kinks while in preliminary review and accumulating user feedback first."
 msgstr ""
-"Fullständiga granskningar är lämpliga för tillägg som är väl testade, "
-"stabila, snabba och har bred attraktion till våra användare. Om du inte är "
-"säker på att ditt tillägg uppfyller dessa kriterier, kan du överväga att "
-"arbeta med problemen medan den är i preliminär granskning och ackumulera "
-"återkoppling från användarna först."
+"Fullständiga granskningar är lämpliga för tillägg som är väl testade, stabila, snabba och har bred attraktion till våra användare. Om du inte är säker på att ditt tillägg uppfyller dessa kriterier, "
+"kan du överväga att arbeta med problemen medan den är i preliminär granskning och ackumulera återkoppling från användarna först."
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:50
-msgid ""
-"We aim to perform full reviews in under 10 days, though most add-ons are "
-"reviewed in much less time."
-msgstr ""
-"Vi strävar efter att utföra fullständig granskning på mindre än 10 dagar, "
-"även om de flesta tillägg granskas på mycket kortare tid."
+msgid "We aim to perform full reviews in under 10 days, though most add-ons are reviewed in much less time."
+msgstr "Vi strävar efter att utföra fullständig granskning på mindre än 10 dagar, även om de flesta tillägg granskas på mycket kortare tid."
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:55
 msgid "Testing Methods &amp; Common Issues"
@@ -7172,61 +5681,36 @@ msgid "When performing a full review, editors will:"
 msgstr "När du utför en fullständig granskning, kommer redigerarna:"
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:64
-msgid ""
-"install the add-on, making sure it functions as described and is free of "
-"major defects"
-msgstr ""
-"installera tillägget, se till att det fungerar som beskrivs och är fri från "
-"större defekter"
+msgid "install the add-on, making sure it functions as described and is free of major defects"
+msgstr "installera tillägget, se till att det fungerar som beskrivs och är fri från större defekter"
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:69
-msgid ""
-"perform a source code review, looking for performance and security best "
-"practices"
-msgstr ""
-"utför en källkodsgranskning, söker efter bästa metoder för prestanda och "
-"säkerhet"
+msgid "perform a source code review, looking for performance and security best practices"
+msgstr "utför en källkodsgranskning, söker efter bästa metoder för prestanda och säkerhet"
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:74
 msgid "ensure the add-on's privacy policy is in line with its functionality"
-msgstr ""
-"säkerställer att tilläggets sekretesspolicy är i linje med dess "
-"funktionalitet"
+msgstr "säkerställer att tilläggets sekretesspolicy är i linje med dess funktionalitet"
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:79
-msgid ""
-"look for compliance with all of Mozilla's policies, detailed in these "
-"documents"
-msgstr ""
-"letar efter att alla Mozillas policyer följs, beskrivs i dessa dokument"
+msgid "look for compliance with all of Mozilla's policies, detailed in these documents"
+msgstr "letar efter att alla Mozillas policyer följs, beskrivs i dessa dokument"
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:86
-msgid ""
-"Some of the most common issues we see when performing these reviews are:"
-msgstr ""
-"Några av de vanligaste problemen som vi ser när vi utför dessa granskningar "
-"är:"
+msgid "Some of the most common issues we see when performing these reviews are:"
+msgstr "Några av de vanligaste problemen som vi ser när vi utför dessa granskningar är:"
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:93
 msgid ""
-"<strong>JavaScript namespace pollution</strong> &mdash; the most common "
-"violation. Be sure to <a "
-"href=\"https://developer.mozilla.org/en/XUL_School/JavaScript_Object_Management\">wrap"
-" your loose variables</a>"
+"<strong>JavaScript namespace pollution</strong> &mdash; the most common violation. Be sure to <a href=\"https://developer.mozilla.org/en/XUL_School/JavaScript_Object_Management\">wrap your loose "
+"variables</a>"
 msgstr ""
-"<strong>JavaScript namespace förstöring</strong> &mdash; den vanligate "
-"felet. Var noga med att <a "
-"href=\"https://developer.mozilla.org/en/XUL_School/JavaScript_Object_Management\">packa"
-" in dina lösa variabler</a>"
+"<strong>JavaScript namespace förstöring</strong> &mdash; den vanligate felet. Var noga med att <a href=\"https://developer.mozilla.org/en/XUL_School/JavaScript_Object_Management\">packa in dina "
+"lösa variabler</a>"
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:99
-msgid ""
-"proper preference naming - all preference names should begin with "
-"\"extensions.\", followed by the add-on name or some other unique identifier"
-msgstr ""
-"korrekt namngivning för inställning - samtliga inställningsnamn ska börja "
-"med \"extensions.\", följt av tilläggets namn eller någon annan unik "
-"identifierare."
+msgid "proper preference naming - all preference names should begin with \"extensions.\", followed by the add-on name or some other unique identifier"
+msgstr "korrekt namngivning för inställning - samtliga inställningsnamn ska börja med \"extensions.\", följt av tilläggets namn eller någon annan unik identifierare."
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:103
 msgid "remote JavaScript execution or injection"
@@ -7271,101 +5755,65 @@ msgstr "uppstart av program eller prestandanedbrytning vid sidladdning"
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:117
 #, python-format
 msgid ""
-"For information on how to avoid these problems, please see our <a "
-"href=\"%(link_howto)s\">How-to Library</a>. Some of these practices, such as"
-" binary or obfuscated code, are allowed under certain conditions outlined "
-"below."
+"For information on how to avoid these problems, please see our <a href=\"%(link_howto)s\">How-to Library</a>. Some of these practices, such as binary or obfuscated code, are allowed under certain "
+"conditions outlined below."
 msgstr ""
-"För information om hur man kan undvika dessa problem, se våra <a "
-"href=\"%(link_howto)s\">instruktioner för bibliotek</a>. Några av dessa "
-"metoder, såsom binär eller förvanskad kod, tillåts under vissa villkor som "
-"anges nedan."
+"För information om hur man kan undvika dessa problem, se våra <a href=\"%(link_howto)s\">instruktioner för bibliotek</a>. Några av dessa metoder, såsom binär eller förvanskad kod, tillåts under "
+"vissa villkor som anges nedan."
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:123
 #, python-format
 msgid ""
-"Many of the above restrictions are tested automatically by an extension "
-"scanner that will flag suspicious add-ons for editor review. You can read "
-"more about this scanner in the <a href=\"%(link_validation)s\">Validation "
-"Help</a> document."
+"Many of the above restrictions are tested automatically by an extension scanner that will flag suspicious add-ons for editor review. You can read more about this scanner in the <a href="
+"\"%(link_validation)s\">Validation Help</a> document."
 msgstr ""
-"Många av ovanstående begränsningar testas automatiskt av en utökningsskanner"
-" som kommer att flagga misstänkta tillägg för granskning av redigerare. Du "
-"kan läsa mer om denna skanner i dokumentet<a "
+"Många av ovanstående begränsningar testas automatiskt av en utökningsskanner som kommer att flagga misstänkta tillägg för granskning av redigerare. Du kan läsa mer om denna skanner i dokumentet<a "
 "href=\"%(link_validation)s\">valideringshjälp</a>."
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:129
 msgid ""
-"If the add-on is site-specific, it is recommended that a test account is "
-"provided for use during the review process. Additionally, including detailed"
-" testing instructions will allow an editor to better understand how the add-"
-"on functions and expedite the testing process. This information can be "
-"placed in the Notes to Reviewer field when editing a version in the "
-"Developer Hub."
+"If the add-on is site-specific, it is recommended that a test account is provided for use during the review process. Additionally, including detailed testing instructions will allow an editor to "
+"better understand how the add-on functions and expedite the testing process. This information can be placed in the Notes to Reviewer field when editing a version in the Developer Hub."
 msgstr ""
-"Om tillägget är platsspecifik, är det rekommenderat att ett testkonto "
-"tillhandahålls för användning under granskningsprocessen. Dessutom kommer "
-"bland annat detaljerade testinstruktioner tillåta en redigerare för att "
-"bättre förstå hur tillägget fungerar och påskynda testprocessen. Denna "
-"information kan placeras i fältet Meddelanden till granskare när du "
-"redigerar en version i Utvecklarcenter."
+"Om tillägget är platsspecifik, är det rekommenderat att ett testkonto tillhandahålls för användning under granskningsprocessen. Dessutom kommer bland annat detaljerade testinstruktioner tillåta en "
+"redigerare för att bättre förstå hur tillägget fungerar och påskynda testprocessen. Denna information kan placeras i fältet Meddelanden till granskare när du redigerar en version i Utvecklarcenter."
 
-#: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:134
-#: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:168
+#: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:134 src/olympia/devhub/templates/devhub/docs/policies-reviews.html:168
 msgid "After the Review"
 msgstr "Efter granskningen"
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:136
 msgid ""
-"Once an add-on is granted full review, it will immediately be available in "
-"the gallery, showing in browse and search results with a warning-free "
-"install button. All features, including voluntary contributions and beta "
-"channels will be available."
+"Once an add-on is granted full review, it will immediately be available in the gallery, showing in browse and search results with a warning-free install button. All features, including voluntary "
+"contributions and beta channels will be available."
 msgstr ""
-"När ett tillägg beviljats fullständig granskning, kommer det omedelbart att "
-"finnas tillgänglig i galleriet, visas vid bläddring och sökresultat med en "
-"varningsfri installationsknapp. Alla funktioner, inklusive frivilliga bidrag"
-" och beta-kanaler kommer att finnas tillgängliga."
+"När ett tillägg beviljats fullständig granskning, kommer det omedelbart att finnas tillgänglig i galleriet, visas vid bläddring och sökresultat med en varningsfri installationsknapp. Alla "
+"funktioner, inklusive frivilliga bidrag och beta-kanaler kommer att finnas tillgängliga."
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:142
 msgid ""
-"Subsequent versions of the add-on will automatically be placed in the full "
-"review queue. Until the review is completed, the new version will only be "
-"displayed on the Version History page of the add-on. Once reviewed, the "
-"version will be updated across the site and deployed through the automatic "
-"update service."
+"Subsequent versions of the add-on will automatically be placed in the full review queue. Until the review is completed, the new version will only be displayed on the Version History page of the add-"
+"on. Once reviewed, the version will be updated across the site and deployed through the automatic update service."
 msgstr ""
-"Senare versioner av tillägget kommer automatiskt att placeras i kön för "
-"fullständig granskning. Tills granskningen är klar, kommer den nya versionen"
-" att visas i versionshistoriken på sidan för tillägget. När granskningen är "
-"klar, kommer versionen att uppdateras på hela webbplatsen och distribueras "
-"via den automatiska uppdateringstjänsten."
+"Senare versioner av tillägget kommer automatiskt att placeras i kön för fullständig granskning. Tills granskningen är klar, kommer den nya versionen att visas i versionshistoriken på sidan för "
+"tillägget. När granskningen är klar, kommer versionen att uppdateras på hela webbplatsen och distribueras via den automatiska uppdateringstjänsten."
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:148
 msgid ""
-"If a version does not meet the criteria for full review, it can either be "
-"granted preliminary review or disabled if there is a security concern. The "
-"author will receive an email explaining the action taken and how to fix it. "
-"In most cases, the developer can simply fix the problem and re-submit for "
-"full review."
+"If a version does not meet the criteria for full review, it can either be granted preliminary review or disabled if there is a security concern. The author will receive an email explaining the "
+"action taken and how to fix it. In most cases, the developer can simply fix the problem and re-submit for full review."
 msgstr ""
-"Om en version inte uppfyller kriterierna för fullständig granskning, kan det"
-" antingen beviljas preliminär granskning eller inaktiveras om det finns ett "
-"säkerhetsproblem. Upphovsmannen kommer att få ett e-postmeddelande som "
-"förklarar de åtgärder som vidtagits och hur man rättar till det. I de flesta"
-" fall kan utvecklaren helt enkelt åtgärda problemet och åter skicka in för "
-"fullständig granskning."
+"Om en version inte uppfyller kriterierna för fullständig granskning, kan det antingen beviljas preliminär granskning eller inaktiveras om det finns ett säkerhetsproblem. Upphovsmannen kommer att få "
+"ett e-postmeddelande som förklarar de åtgärder som vidtagits och hur man rättar till det. I de flesta fall kan utvecklaren helt enkelt åtgärda problemet och åter skicka in för fullständig "
+"granskning."
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:155
 msgid ""
-"Preliminary reviews are appropriate for experimental add-ons and provide a "
-"way to get user testing and feedback without going through the longer, more "
-"thorough review process. We aim to complete these reviews in under 3 days."
+"Preliminary reviews are appropriate for experimental add-ons and provide a way to get user testing and feedback without going through the longer, more thorough review process. We aim to complete "
+"these reviews in under 3 days."
 msgstr ""
-"Preliminära granskning är lämpliga för experimentella tillägg och "
-"tillhandahåller ett sätt att få användartester och återkoppling utan att gå "
-"via längre, mer grundlig granskning. Vi strävar efter att slutföra dessa "
-"granskningar på under 3 dagar."
+"Preliminära granskning är lämpliga för experimentella tillägg och tillhandahåller ett sätt att få användartester och återkoppling utan att gå via längre, mer grundlig granskning. Vi strävar efter "
+"att slutföra dessa granskningar på under 3 dagar."
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:160
 msgid "Testing Methods"
@@ -7373,56 +5821,33 @@ msgstr "Testmetoder"
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:162
 msgid ""
-"When performing a preliminary review, editors will review the source code "
-"for security issues and major policy violations, but will not install the "
-"add-on to test functionality in most cases. Preliminary review will be "
-"granted unless a security vulnerability or major policy violation is "
-"discovered."
+"When performing a preliminary review, editors will review the source code for security issues and major policy violations, but will not install the add-on to test functionality in most cases. "
+"Preliminary review will be granted unless a security vulnerability or major policy violation is discovered."
 msgstr ""
-"När du utför en preliminär granskning, kommer redigerare granska källkoden "
-"för säkerhetsfrågor och viktiga överträdelser av policy, men kommer inte att"
-" installera tillägget att testa funktionaliteten i de flesta fall. "
-"Preliminär granskning kommer att beviljas om en säkerhetsrisk eller större "
-"överträdelse mot policyn upptäcks."
+"När du utför en preliminär granskning, kommer redigerare granska källkoden för säkerhetsfrågor och viktiga överträdelser av policy, men kommer inte att installera tillägget att testa "
+"funktionaliteten i de flesta fall. Preliminär granskning kommer att beviljas om en säkerhetsrisk eller större överträdelse mot policyn upptäcks."
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:171
 msgid ""
-"Once preliminary review is granted, the add-on will be immediately available"
-" in the gallery, showing in browse and search results but ranked lower than "
-"fully-reviewed add-ons. Install buttons will have caution stripes and a "
-"notice that the add-on is experimental and not fully reviewed by Mozilla, "
-"though no click-through is required. Additionally, these add-ons cannot use "
-"the voluntary contributions and beta channel features."
+"Once preliminary review is granted, the add-on will be immediately available in the gallery, showing in browse and search results but ranked lower than fully-reviewed add-ons. Install buttons will "
+"have caution stripes and a notice that the add-on is experimental and not fully reviewed by Mozilla, though no click-through is required. Additionally, these add-ons cannot use the voluntary "
+"contributions and beta channel features."
 msgstr ""
-"När preliminär granskning har beviljats, kommer tillägget omedelbart vara "
-"tillgängligt i galleriet, visas vid bläddring och sökresultat, men med en "
-"sämre placering än fullständigt granskade tillägg. Installationsknappar "
-"kommer att ha varningsrand och ett meddelande om att tillägget är "
-"experimentellt och inte helt granskats av Mozilla, men inga extra klick "
-"krävs. Dessutom kan dessa tillägg inte använda frivilliga bidrag och "
-"funktioner för beta-kanal."
+"När preliminär granskning har beviljats, kommer tillägget omedelbart vara tillgängligt i galleriet, visas vid bläddring och sökresultat, men med en sämre placering än fullständigt granskade "
+"tillägg. Installationsknappar kommer att ha varningsrand och ett meddelande om att tillägget är experimentellt och inte helt granskats av Mozilla, men inga extra klick krävs. Dessutom kan dessa "
+"tillägg inte använda frivilliga bidrag och funktioner för beta-kanal."
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:177
-msgid ""
-"After being granted preliminary review, Mozilla may later revoke the review "
-"if other serious problems are reported to us by users."
-msgstr ""
-"Efter att ha beviljats preliminär granskning kan Mozilla senare återkalla "
-"granskningen om andra allvarliga problem rapporteras till oss av användarna."
+msgid "After being granted preliminary review, Mozilla may later revoke the review if other serious problems are reported to us by users."
+msgstr "Efter att ha beviljats preliminär granskning kan Mozilla senare återkalla granskningen om andra allvarliga problem rapporteras till oss av användarna."
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:183
 msgid ""
-"Subsequent versions of the add-on will automatically be placed in the "
-"preliminary review queue. Until the review is completed, the new version "
-"will only be displayed on the Version History page of the add-on. Once "
-"reviewed, the version will be updated across the site and deployed through "
-"the automatic update service."
+"Subsequent versions of the add-on will automatically be placed in the preliminary review queue. Until the review is completed, the new version will only be displayed on the Version History page of "
+"the add-on. Once reviewed, the version will be updated across the site and deployed through the automatic update service."
 msgstr ""
-"Senare versioner av tillägget kommer automatiskt att placeras i kön för "
-"preliminär granskning. Tills granskningen är klar, kommer den nya versionen "
-"att visas i versionshistoriken på tillägget sida. När granskningen är klar, "
-"kommer versionen att uppdateras på hela webbplatsen och distribueras via den"
-" automatiska uppdateringstjänsten."
+"Senare versioner av tillägget kommer automatiskt att placeras i kön för preliminär granskning. Tills granskningen är klar, kommer den nya versionen att visas i versionshistoriken på tillägget sida. "
+"När granskningen är klar, kommer versionen att uppdateras på hela webbplatsen och distribueras via den automatiska uppdateringstjänsten."
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:188
 msgid "Policies on Specific Add-on Practices"
@@ -7437,62 +5862,36 @@ msgid "The following add-ons are not permitted in any form:"
 msgstr "Följande tillägg är inte tillåtna i någon form:"
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:194
-msgid ""
-"Add-ons that embed known <a "
-"href=\"http://en.wikipedia.org/wiki/Spyware\">spyware</a> or <a "
-"href=\"http://en.wikipedia.org/wiki/Malware\">malware</a>"
-msgstr ""
-"Tillägg som bäddat in kända <a "
-"href=\"http://en.wikipedia.org/wiki/Spyware\">spionprogram</a> eller <a "
-"href=\"http://en.wikipedia.org/wiki/Malware\">skadlig kod</a>"
+msgid "Add-ons that embed known <a href=\"http://en.wikipedia.org/wiki/Spyware\">spyware</a> or <a href=\"http://en.wikipedia.org/wiki/Malware\">malware</a>"
+msgstr "Tillägg som bäddat in kända <a href=\"http://en.wikipedia.org/wiki/Spyware\">spionprogram</a> eller <a href=\"http://en.wikipedia.org/wiki/Malware\">skadlig kod</a>"
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:199
 msgid ""
-"Illegal and criminal add-ons, such as <a "
-"href=\"http://en.wikipedia.org/wiki/Click_fraud\">click fraud</a> "
-"generators, <a href=\"http://en.wikipedia.org/wiki/Warez\">warez</a> "
-"download and directory assistants, child pornography finders, etc."
+"Illegal and criminal add-ons, such as <a href=\"http://en.wikipedia.org/wiki/Click_fraud\">click fraud</a> generators, <a href=\"http://en.wikipedia.org/wiki/Warez\">warez</a> download and "
+"directory assistants, child pornography finders, etc."
 msgstr ""
-"Olagliga och kriminella tillägg, såsom <a "
-"href=\"http://en.wikipedia.org/wiki/Click_fraud\">klickbedrägerier</a> "
-"generatorer, <a href=\"http://en.wikipedia.org/wiki/Warez\">fildelning</a> "
-"och nummerupplysning, barnpornografisökare, etc."
+"Olagliga och kriminella tillägg, såsom <a href=\"http://en.wikipedia.org/wiki/Click_fraud\">klickbedrägerier</a> generatorer, <a href=\"http://en.wikipedia.org/wiki/Warez\">fildelning</a> och "
+"nummerupplysning, barnpornografisökare, etc."
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:204
-msgid ""
-"Add-ons whose main purpose is to facilitate access to pornographic material,"
-" or include references to this material in their descriptions"
-msgstr ""
-"Tillägg vars huvudsakliga syfte är att underlätta tillgången till "
-"pornografiskt material eller innehålla hänvisningar till detta material i "
-"sina beskrivningar"
+msgid "Add-ons whose main purpose is to facilitate access to pornographic material, or include references to this material in their descriptions"
+msgstr "Tillägg vars huvudsakliga syfte är att underlätta tillgången till pornografiskt material eller innehålla hänvisningar till detta material i sina beskrivningar"
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:210
-msgid ""
-"Add-ons that, upon installation, auto-install or launch installers of non-"
-"Firefox software"
-msgstr ""
-"Tillägg som vid installation, automatisk installation eller "
-"startinstallatörer av icke-Firefox programvara"
+msgid "Add-ons that, upon installation, auto-install or launch installers of non-Firefox software"
+msgstr "Tillägg som vid installation, automatisk installation eller startinstallatörer av icke-Firefox programvara"
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:215
-msgid ""
-"Add-ons that provide their own update mechanism for code or search engines"
-msgstr ""
-"Tillägg som har sin egen uppdateringsmekanism för kod eller sökmotorer"
+msgid "Add-ons that provide their own update mechanism for code or search engines"
+msgstr "Tillägg som har sin egen uppdateringsmekanism för kod eller sökmotorer"
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:220
-msgid ""
-"Add-ons that make changes to web content in ways that are non-obvious or "
-"difficult to trace by their users"
-msgstr ""
-"Tillägg som gör ändringar i webbinnehåll på ett sätt som inte är uppenbara "
-"eller svåra att spåra för deras användare"
+msgid "Add-ons that make changes to web content in ways that are non-obvious or difficult to trace by their users"
+msgstr "Tillägg som gör ändringar i webbinnehåll på ett sätt som inte är uppenbara eller svåra att spåra för deras användare"
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:225
 msgid "Add-ons that snoop on or intercept the network traffic of other users"
-msgstr ""
-"Tillägg som snokar eller avlyssnar nätverkstrafik från andra användare"
+msgstr "Tillägg som snokar eller avlyssnar nätverkstrafik från andra användare"
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:230
 msgid "Conduit-based toolbars without explicit pre-approval"
@@ -7504,67 +5903,34 @@ msgstr "Ändring av standardvärden och oväntade funktioner"
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:238
 msgid ""
-"Surprises can be appropriate in many situations, but they are not welcome "
-"when user security, privacy, and control are at stake. It is extremely "
-"important to be as transparent as possible when submitting an add-on for "
-"hosting on this site. A Mozilla user should be able to easily discern what "
-"the functionality of an add-on is and not be presented with unexpected "
-"experiences post-install."
+"Surprises can be appropriate in many situations, but they are not welcome when user security, privacy, and control are at stake. It is extremely important to be as transparent as possible when "
+"submitting an add-on for hosting on this site. A Mozilla user should be able to easily discern what the functionality of an add-on is and not be presented with unexpected experiences post-install."
 msgstr ""
-"Överraskningar kan vara lämpligt i många situationer, men de är inte "
-"välkomna när användaren säkerhet, integritet och kontroll står på spel. Det "
-"är oerhört viktigt att vara så öppen som möjligt när de skickar in ett "
-"tillägg för att hysas på den här webbplatsen. En Mozilla-användaren ska lätt"
-" kunna urskilja vad funktionaliteten hos ett tillägg är och inte presenteras"
-" med oväntade upplevelser efter installationen."
+"Överraskningar kan vara lämpligt i många situationer, men de är inte välkomna när användaren säkerhet, integritet och kontroll står på spel. Det är oerhört viktigt att vara så öppen som möjligt när "
+"de skickar in ett tillägg för att hysas på den här webbplatsen. En Mozilla-användaren ska lätt kunna urskilja vad funktionaliteten hos ett tillägg är och inte presenteras med oväntade upplevelser "
+"efter installationen."
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:243
 msgid ""
-"<p> Whenever an add-on includes any unexpected* feature that </p> <ul> "
-"<li>compromises user privacy or security (like sending data to third "
-"parties),</li> <li>changes default settings like the homepage or search "
-"engine, or</li> <li>changes settings or features in other add-ons or "
-"deactivates them altogether</li> </ul> <p>the features must adhere to the "
-"following requirements:</p> <ul> <li>The add-on description must clearly "
-"state what changes the add-on makes.</li> <li>All changes must be opt-in, "
-"meaning the user must take non-default action to enact the change.</li> "
-"<li>The opt-in dialog must clearly state the name of the add-on requesting "
-"the change.</li> <li>Uninstalling the add-on restores the user's original "
-"settings if they were changed.</li> </ul> <p>*Unexpected features are those "
-"that are unrelated to the add-on's primary function.</p>"
+"<p> Whenever an add-on includes any unexpected* feature that </p> <ul> <li>compromises user privacy or security (like sending data to third parties),</li> <li>changes default settings like the "
+"homepage or search engine, or</li> <li>changes settings or features in other add-ons or deactivates them altogether</li> </ul> <p>the features must adhere to the following requirements:</p> <ul> "
+"<li>The add-on description must clearly state what changes the add-on makes.</li> <li>All changes must be opt-in, meaning the user must take non-default action to enact the change.</li> <li>The opt-"
+"in dialog must clearly state the name of the add-on requesting the change.</li> <li>Uninstalling the add-on restores the user's original settings if they were changed.</li> </ul> <p>*Unexpected "
+"features are those that are unrelated to the add-on's primary function.</p>"
 msgstr ""
-"<p> När ett tillägg inkluderar oväntade* funktioner som </p> <ul> "
-"<li>äventyrar användarnas personliga integritet eller säkerhet (som att "
-"skicka data till tredje part)</li> <li>ändrar standardinställningar som "
-"hemsida eller sökmotor</li> <li>ändrar inställningar och funktioner i andra "
-"tillägg eller inaktiverar dem helt och hållet</li> </ul> <p>funktionerna "
-"måste följa följande krav:</p> <ul> <li>Tillägget beskrivningen måste "
-"tydligt ange vilka ändringar som tillägget gör. </li> <li>All ändringar "
-"måste opt-in, vilket innebär att användaren måste vidta icke-standardåtgärd "
-"för att anta ändringen.</li> <li>Opt-in dialogrutan ska tydligt ange namnet "
-"på det tillägg som vill ändra det.</li> <li>Avinstallera tillägget "
-"återställer användarens ursprungliga inställningar om de har ändrats.</li> "
-"</ul> <p>*Oväntade funktioner är de som inte är relaterade till tilläggets "
-"primära funktion.</p>"
+"<p> När ett tillägg inkluderar oväntade* funktioner som </p> <ul> <li>äventyrar användarnas personliga integritet eller säkerhet (som att skicka data till tredje part)</li> <li>ändrar "
+"standardinställningar som hemsida eller sökmotor</li> <li>ändrar inställningar och funktioner i andra tillägg eller inaktiverar dem helt och hållet</li> </ul> <p>funktionerna måste följa följande "
+"krav:</p> <ul> <li>Tillägget beskrivningen måste tydligt ange vilka ändringar som tillägget gör. </li> <li>All ändringar måste opt-in, vilket innebär att användaren måste vidta icke-standardåtgärd "
+"för att anta ändringen.</li> <li>Opt-in dialogrutan ska tydligt ange namnet på det tillägg som vill ändra det.</li> <li>Avinstallera tillägget återställer användarens ursprungliga inställningar om "
+"de har ändrats.</li> </ul> <p>*Oväntade funktioner är de som inte är relaterade till tilläggets primära funktion.</p>"
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:268
-msgid ""
-"These features cannot be introduced into an update of a fully-reviewed add-"
-"on; the opt-in change process must be part of the initial review."
-msgstr ""
-"Dessa funktioner kan inte föras in i en uppdatering av en fullt granskad "
-"tillägg; opt-in förändringsprocessen måste vara en del av den första "
-"granskning."
+msgid "These features cannot be introduced into an update of a fully-reviewed add-on; the opt-in change process must be part of the initial review."
+msgstr "Dessa funktioner kan inte föras in i en uppdatering av en fullt granskad tillägg; opt-in förändringsprocessen måste vara en del av den första granskning."
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:274
-msgid ""
-"These are minimum requirements and not a guarantee that the add-on will be "
-"approved. This section applies to all add-ons hosted on the site, including "
-"preliminarily reviewed add-ons."
-msgstr ""
-"Dessa är minimikrav och inte en garanti för att tillägget kommer att "
-"godkännas. Detta avsnitt gäller alla tillägg som hyses på webbplatsen, "
-"inklusive preliminärt granskade tillägg."
+msgid "These are minimum requirements and not a guarantee that the add-on will be approved. This section applies to all add-ons hosted on the site, including preliminarily reviewed add-ons."
+msgstr "Dessa är minimikrav och inte en garanti för att tillägget kommer att godkännas. Detta avsnitt gäller alla tillägg som hyses på webbplatsen, inklusive preliminärt granskade tillägg."
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:279
 msgid "Private Browsing Mode"
@@ -7572,18 +5938,11 @@ msgstr "Privat surfläge"
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:282
 msgid ""
-"Add-ons that store or otherwise handle browsing data must support <a "
-"href=\"https://developer.mozilla.org/En/Supporting_private_browsing_mode\">Private"
-" Browsing Mode</a>.  During a Private Browsing session, no browsing data can"
-" be written to disk, and all of this data must be cleared when Firefox quits"
-" or the Private Browsing session ends."
+"Add-ons that store or otherwise handle browsing data must support <a href=\"https://developer.mozilla.org/En/Supporting_private_browsing_mode\">Private Browsing Mode</a>. During a Private Browsing "
+"session, no browsing data can be written to disk, and all of this data must be cleared when Firefox quits or the Private Browsing session ends."
 msgstr ""
-"Tillägg som lagrar eller på annat sätt hanterar webbinformation måste stödja"
-" <a "
-"href=\"https://developer.mozilla.org/En/Supporting_private_browsing_mode\">privat"
-" surfläge</a>.  Under en privat surfsession, kan ingen webbinformation "
-"skrivas till disk och all dess data måste raderas när Firefox avslutas eller"
-" den privata surfsessionen avslutas."
+"Tillägg som lagrar eller på annat sätt hanterar webbinformation måste stödja <a href=\"https://developer.mozilla.org/En/Supporting_private_browsing_mode\">privat surfläge</a>.  Under en privat "
+"surfsession, kan ingen webbinformation skrivas till disk och all dess data måste raderas när Firefox avslutas eller den privata surfsessionen avslutas."
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:287
 msgid "Binary Components & Obfuscated Code"
@@ -7591,41 +5950,26 @@ msgstr "Binära komponenter & förvanskad kod"
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:289
 msgid ""
-"Add-ons may contain binary, obfuscated and minified source code, but Mozilla"
-" must be allowed to review a copy of the human-readable source code of each "
-"version of an add-on submitted for review. These add-ons are ineligible for "
-"preliminary review and must choose the full review process."
+"Add-ons may contain binary, obfuscated and minified source code, but Mozilla must be allowed to review a copy of the human-readable source code of each version of an add-on submitted for review. "
+"These add-ons are ineligible for preliminary review and must choose the full review process."
 msgstr ""
-"Tillägg kan innehålla binär, förvanskad och minifirad källkod, men Mozilla "
-"måste få granska en kopia av källkoden för varje version av ett tillägg som "
-"skickas in för granskning. Dessa tillägg är inte berättigade till en "
-"preliminär granskning och måste välja en fullständig granskningsprocess."
+"Tillägg kan innehålla binär, förvanskad och minifirad källkod, men Mozilla måste få granska en kopia av källkoden för varje version av ett tillägg som skickas in för granskning. Dessa tillägg är "
+"inte berättigade till en preliminär granskning och måste välja en fullständig granskningsprocess."
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:295
 msgid ""
-"If an add-on contains binary or obfuscated source code, the author will "
-"receive a message when the add-on is reviewed indicating whom to contact at "
-"Mozilla to coordinate review of the source code. This code will be reviewed "
-"by an administrator and will not be shared or redistributed in any way. The "
-"code will only be used for the purpose of reviewing the add-on."
+"If an add-on contains binary or obfuscated source code, the author will receive a message when the add-on is reviewed indicating whom to contact at Mozilla to coordinate review of the source code. "
+"This code will be reviewed by an administrator and will not be shared or redistributed in any way. The code will only be used for the purpose of reviewing the add-on."
 msgstr ""
-"Om ett tillägg innehåller binär eller förvanskad källkod, kommer "
-"upphovsmannen att få ett meddelande när tillägget granskas vilket indikerar "
-"vem man ska kontakta på Mozilla för att samordna granskning av källkoden. "
-"Denna kod kommer att granskas av en administratör och kommer inte att delas "
-"eller omfördelas på något sätt. Koden kommer endast att användas i syfte att"
-" se granska tillägget."
+"Om ett tillägg innehåller binär eller förvanskad källkod, kommer upphovsmannen att få ett meddelande när tillägget granskas vilket indikerar vem man ska kontakta på Mozilla för att samordna "
+"granskning av källkoden. Denna kod kommer att granskas av en administratör och kommer inte att delas eller omfördelas på något sätt. Koden kommer endast att användas i syfte att se granska "
+"tillägget."
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:301
 #, python-format
-msgid ""
-"If your add-on contains binary or obfuscated code that you don't own or "
-"can't get the source code for, you may <a href=\"%(link_contact)s\">contact "
-"us</a> for information on how to proceed."
+msgid "If your add-on contains binary or obfuscated code that you don't own or can't get the source code for, you may <a href=\"%(link_contact)s\">contact us</a> for information on how to proceed."
 msgstr ""
-"Om ditt tillägg innehåller binär eller förvanskad kod som du inte äger eller"
-" inte kan få källkoden för, kan du <a href=\"%(link_contact)s\">kontakta "
-"oss</a> för information om hur du ska fortsätta."
+"Om ditt tillägg innehåller binär eller förvanskad kod som du inte äger eller inte kan få källkoden för, kan du <a href=\"%(link_contact)s\">kontakta oss</a> för information om hur du ska fortsätta."
 
 #: src/olympia/devhub/templates/devhub/docs/policies-submission.html:11
 msgid "Criteria for Submission"
@@ -7633,230 +5977,125 @@ msgstr "Kriterier för inskickning"
 
 #: src/olympia/devhub/templates/devhub/docs/policies-submission.html:13
 msgid ""
-"Add-ons hosted on Mozilla Add-ons should be of high quality and give users "
-"an improved web experience. We look for the following things when deciding "
-"whether an add-on is appropriate to be public and unrestricted:"
+"Add-ons hosted on Mozilla Add-ons should be of high quality and give users an improved web experience. We look for the following things when deciding whether an add-on is appropriate to be public "
+"and unrestricted:"
 msgstr ""
-"Tillägg som hyses på Mozilla tillägg bör vara av hög kvalitet och ge "
-"användarna en bättre webbupplevelse. Vi letar efter följande saker när man "
-"beslutar om ett tillägg är lämpligt att vara offentligt och obegränsat:"
+"Tillägg som hyses på Mozilla tillägg bör vara av hög kvalitet och ge användarna en bättre webbupplevelse. Vi letar efter följande saker när man beslutar om ett tillägg är lämpligt att vara "
+"offentligt och obegränsat:"
 
 #: src/olympia/devhub/templates/devhub/docs/policies-submission.html:19
 msgid ""
-"<strong>Are you responsive?</strong> We expect that an author who is "
-"promoting their add-on to our applications' many users is responsive to "
-"problem reports, maintains their contact information, and updates their add-"
-"on promptly to keep current with Firefox releases and changes in our "
-"policies. This doesn't mean that you have to reply to every question that "
-"someone posts in the discussions, or that you even need to fix every bug, "
-"but we do expect that you will respond to issues in a manner that's "
-"appropriate to the severity of the issue in question."
+"<strong>Are you responsive?</strong> We expect that an author who is promoting their add-on to our applications' many users is responsive to problem reports, maintains their contact information, "
+"and updates their add-on promptly to keep current with Firefox releases and changes in our policies. This doesn't mean that you have to reply to every question that someone posts in the "
+"discussions, or that you even need to fix every bug, but we do expect that you will respond to issues in a manner that's appropriate to the severity of the issue in question."
 msgstr ""
-"<strong>Är du lyhörd?</strong> Vi förväntar oss det av en upphovsman som "
-"främjar sitt tillägg till våra program. Många användare är lyhörda för "
-"problemrapporter, underhåller sina kontaktuppgifter och uppdaterar sitt "
-"tillägg snabbt för att hålla sig uppdaterad med senaste Firefox och "
-"ändringar i vår policyer. Detta betyder inte att du måste svara på alla "
-"frågor som någon postar i diskussionerna eller att du ens behöver fixa varje"
-" bugg, men vi förväntar oss att du kommer att ge svar på frågor på ett sätt "
-"som är lämpligt beroende av svårighetsgraden på den aktuella frågan."
+"<strong>Är du lyhörd?</strong> Vi förväntar oss det av en upphovsman som främjar sitt tillägg till våra program. Många användare är lyhörda för problemrapporter, underhåller sina kontaktuppgifter "
+"och uppdaterar sitt tillägg snabbt för att hålla sig uppdaterad med senaste Firefox och ändringar i vår policyer. Detta betyder inte att du måste svara på alla frågor som någon postar i "
+"diskussionerna eller att du ens behöver fixa varje bugg, men vi förväntar oss att du kommer att ge svar på frågor på ett sätt som är lämpligt beroende av svårighetsgraden på den aktuella frågan."
 
 #: src/olympia/devhub/templates/devhub/docs/policies-submission.html:25
 msgid ""
-"<strong>Is the add-on clearly and accurately described?</strong> It's of the"
-" utmost importance to us that users get what they expect when they try a new"
-" add-on. Your add-on name should be clear and concise, and you should "
-"refrain from using special characters or numbers to get higher search "
-"rankings or for decorative purposes. Your description should provide details"
-" about what the add-on does, how a user should take advantage of it, and "
-"what the user should expect when they install it. Links to external "
-"documents for detailed instructions are fine, but the description itself "
-"should cover the basics and leave users confident that they know what "
-"they'll get. Also, it is important that you maintain version notes "
-"appropriately as you improve and change your add-on. Users should be able to"
-" see what's new in an add-on they may have tried previously, and should be "
-"made aware of changes that might affect their current use of the add-on when"
-" they update."
+"<strong>Is the add-on clearly and accurately described?</strong> It's of the utmost importance to us that users get what they expect when they try a new add-on. Your add-on name should be clear and "
+"concise, and you should refrain from using special characters or numbers to get higher search rankings or for decorative purposes. Your description should provide details about what the add-on "
+"does, how a user should take advantage of it, and what the user should expect when they install it. Links to external documents for detailed instructions are fine, but the description itself should "
+"cover the basics and leave users confident that they know what they'll get. Also, it is important that you maintain version notes appropriately as you improve and change your add-on. Users should "
+"be able to see what's new in an add-on they may have tried previously, and should be made aware of changes that might affect their current use of the add-on when they update."
 msgstr ""
-"<strong>Är tillägget tydligt och korrekt beskrivna?</strong> Det är av "
-"yttersta vikt för oss att användare får vad de förväntar sig när de testar "
-"ett nytt tillägg. Tilläggets namn ska vara klart och koncist och du bör "
-"avstå från att använda specialtecken eller siffror för att få bättre "
-"sökrankning eller för dekorativa ändamål. Din beskrivning bör ge information"
-" om vad tillägget gör, hur en användare kan dra nytta av det och vad "
-"användaren bör förvänta sig när de installerar det. Länkar till externa "
-"dokument för detaljerade instruktioner är bra, men beskrivningen själv bör "
-"omfatta grunderna och lämna användare säkra på att de vet vad de får. "
-"Dessutom är det viktigt att du uppdaterar versionsanteckningar när du "
-"förbättrar och ändrar ditt tillägg. Användare ska kunna se vad som är nytt i"
-" ett tillägg som de kan ha testat tidigare och ska göras medvetna om "
-"ändringar som kan påverka deras nuvarande användning av tillägget när de har"
-" uppdaterat."
+"<strong>Är tillägget tydligt och korrekt beskrivna?</strong> Det är av yttersta vikt för oss att användare får vad de förväntar sig när de testar ett nytt tillägg. Tilläggets namn ska vara klart "
+"och koncist och du bör avstå från att använda specialtecken eller siffror för att få bättre sökrankning eller för dekorativa ändamål. Din beskrivning bör ge information om vad tillägget gör, hur en "
+"användare kan dra nytta av det och vad användaren bör förvänta sig när de installerar det. Länkar till externa dokument för detaljerade instruktioner är bra, men beskrivningen själv bör omfatta "
+"grunderna och lämna användare säkra på att de vet vad de får. Dessutom är det viktigt att du uppdaterar versionsanteckningar när du förbättrar och ändrar ditt tillägg. Användare ska kunna se vad "
+"som är nytt i ett tillägg som de kan ha testat tidigare och ska göras medvetna om ändringar som kan påverka deras nuvarande användning av tillägget när de har uppdaterat."
 
 #: src/olympia/devhub/templates/devhub/docs/policies-submission.html:31
 msgid ""
-"<strong>Are all privacy and security concerns clearly spelled out?</strong> "
-"This is an aspect of a clear and accurate description, but such an important"
-" one that we feel it deserves specific mention. Many very useful and well-"
-"written add-ons manipulate some form of user data, or can present security "
-"hazards if misused; they are welcome on the site, but they must make it very"
-" clear to users what risks they might encounter, and what they can do to "
-"protect themselves."
+"<strong>Are all privacy and security concerns clearly spelled out?</strong> This is an aspect of a clear and accurate description, but such an important one that we feel it deserves specific "
+"mention. Many very useful and well-written add-ons manipulate some form of user data, or can present security hazards if misused; they are welcome on the site, but they must make it very clear to "
+"users what risks they might encounter, and what they can do to protect themselves."
 msgstr ""
-"<strong>Är alla integritets- och säkerhetsfrågor klart och tydliga?</strong>"
-" Detta är en aspekt av en tydlig och korrekt beskrivning, men den är så "
-"viktig att vi känner den förtjänar särskilt omnämnande. Många mycket "
-"användbara och välskrivna tillägg manipulera någon form av användardata "
-"eller kan utgöra en säkerhetsrisk om de missbrukas; de är välkomna på "
-"webbplatsen, men de måste göra det mycket klart för användarna vilka risker "
-"de kan råka ut för och vad de kan göra för att skydda sig."
+"<strong>Är alla integritets- och säkerhetsfrågor klart och tydliga?</strong> Detta är en aspekt av en tydlig och korrekt beskrivning, men den är så viktig att vi känner den förtjänar särskilt "
+"omnämnande. Många mycket användbara och välskrivna tillägg manipulera någon form av användardata eller kan utgöra en säkerhetsrisk om de missbrukas; de är välkomna på webbplatsen, men de måste göra "
+"det mycket klart för användarna vilka risker de kan råka ut för och vad de kan göra för att skydda sig."
 
 #: src/olympia/devhub/templates/devhub/docs/policies-submission.html:37
 msgid ""
-"<strong>Has the add-on been well-tested, and is it free of obvious or "
-"serious defects?</strong> One important thing that we look for when "
-"considering an add-on is whether its user reviews indicate that it has "
-"received thorough testing, and that it doesn't have serious problems or "
-"negative impacts on the browser. If reviewers report problems such as major "
-"performance issues, crashes, frequent problems using the functions of the "
-"add-on, or spamming of messages to the error console, you should take those "
-"reports to heart, and re-submit your add-on after you've addressed them as "
-"best you can. We don't expect you to perfectly optimize or have zero bugs "
-"&mdash; Firefox itself undergoes constant improvement in these areas &mdash;"
-" but we do want you to take reasonable efforts to minimize downsides, and to"
-" clearly call out cases where users may be surprised by those that remain."
+"<strong>Has the add-on been well-tested, and is it free of obvious or serious defects?</strong> One important thing that we look for when considering an add-on is whether its user reviews indicate "
+"that it has received thorough testing, and that it doesn't have serious problems or negative impacts on the browser. If reviewers report problems such as major performance issues, crashes, frequent "
+"problems using the functions of the add-on, or spamming of messages to the error console, you should take those reports to heart, and re-submit your add-on after you've addressed them as best you "
+"can. We don't expect you to perfectly optimize or have zero bugs &mdash; Firefox itself undergoes constant improvement in these areas &mdash; but we do want you to take reasonable efforts to "
+"minimize downsides, and to clearly call out cases where users may be surprised by those that remain."
 msgstr ""
-"<strong>Har tillägget blivit väl testat och är det fri från uppenbara eller "
-"allvarliga brister?</strong> En viktig sak som vi letar efter när man "
-"överväger ett tillägg är om användarrecensionerna visar på att den har "
-"gjorts en grundlig testning och att det inte har allvarliga problem eller "
-"negativa effekter på webbläsaren. Om granskare rapporterar problem som stora"
-" prestandaproblem, kraschar, ofta problem med funktionerna hos tillägget "
-"eller skräppost av meddelanden till felkonsolen. Då bör du ta till dig dessa"
-" rapporter och åter skicka in ditt tillägg när du har tagit i tur med dem så"
-" gott du kan. Vi förväntar oss inte att du fullständigt optimerar eller har "
-"noll fel &mdash; Firefox själv genomgår ständiga förbättringar inom dessa "
-"områden &mdash; men vi vill att du ska vidta rimliga ansträngningar för att "
-"minimera nackdelar och att tydligt berätta om händelser där användarna kan "
-"bli överraskade av dem som finns kvar."
+"<strong>Har tillägget blivit väl testat och är det fri från uppenbara eller allvarliga brister?</strong> En viktig sak som vi letar efter när man överväger ett tillägg är om användarrecensionerna "
+"visar på att den har gjorts en grundlig testning och att det inte har allvarliga problem eller negativa effekter på webbläsaren. Om granskare rapporterar problem som stora prestandaproblem, "
+"kraschar, ofta problem med funktionerna hos tillägget eller skräppost av meddelanden till felkonsolen. Då bör du ta till dig dessa rapporter och åter skicka in ditt tillägg när du har tagit i tur "
+"med dem så gott du kan. Vi förväntar oss inte att du fullständigt optimerar eller har noll fel &mdash; Firefox själv genomgår ständiga förbättringar inom dessa områden &mdash; men vi vill att du "
+"ska vidta rimliga ansträngningar för att minimera nackdelar och att tydligt berätta om händelser där användarna kan bli överraskade av dem som finns kvar."
 
 #: src/olympia/devhub/templates/devhub/docs/policies-submission.html:43
 msgid ""
-"<strong>Do the add-on and add-on author both treat the user "
-"respectfully?</strong> Your software should not intrude on the user "
-"unnecessarily, try to trick the user, or conceal any of its activities from "
-"the user. Users (or even non-users) are sometimes rude in their comments, "
-"and while we will do our best to filter out inaccurate reviews as they're "
-"reported to us, we do expect that authors will avoid retaliating with "
-"rudeness of their own."
+"<strong>Do the add-on and add-on author both treat the user respectfully?</strong> Your software should not intrude on the user unnecessarily, try to trick the user, or conceal any of its "
+"activities from the user. Users (or even non-users) are sometimes rude in their comments, and while we will do our best to filter out inaccurate reviews as they're reported to us, we do expect that "
+"authors will avoid retaliating with rudeness of their own."
 msgstr ""
-"<strong>Behandlar både tillägget och tilläggets upphovsman användaren "
-"respektfullt?</strong> Ditt program ska inte inkräkta på användaren i "
-"onödan, försöka att lura användaren eller dölja någon av sin aktiviteter "
-"från användaren. Användarna (eller även icke-användare) är ibland oförskämda"
-" i sina synpunkter och vi kommer att göra vårt bästa för att filtrera bort "
-"felaktiga recensioner som har rapporterats in till oss. Vi förväntar oss att"
-" upphovsmännen kommer undvika att hämnas med oförskämdhet från deras sida."
+"<strong>Behandlar både tillägget och tilläggets upphovsman användaren respektfullt?</strong> Ditt program ska inte inkräkta på användaren i onödan, försöka att lura användaren eller dölja någon av "
+"sin aktiviteter från användaren. Användarna (eller även icke-användare) är ibland oförskämda i sina synpunkter och vi kommer att göra vårt bästa för att filtrera bort felaktiga recensioner som har "
+"rapporterats in till oss. Vi förväntar oss att upphovsmännen kommer undvika att hämnas med oförskämdhet från deras sida."
 
 #: src/olympia/devhub/templates/devhub/docs/policies-submission.html:49
 msgid ""
-"<strong>Is the add-on useful to an appropriately wide portion of Firefox's "
-"users?</strong> Your add-on doesn't need to be the next Greasemonkey or "
-"Firebug, but if it is only useful to people at your company or who are part "
-"of a small web community, we may feel that it's not yet appropriate to put "
-"it in front of all of our users."
+"<strong>Is the add-on useful to an appropriately wide portion of Firefox's users?</strong> Your add-on doesn't need to be the next Greasemonkey or Firebug, but if it is only useful to people at "
+"your company or who are part of a small web community, we may feel that it's not yet appropriate to put it in front of all of our users."
 msgstr ""
-"<strong>Är tillägget användbart för en större del av Firefox "
-"användare?</strong> Ditt tillägg behöver inte bli nästa Greasemonkey eller "
-"Firebug, men om det endast är användbart för personer i ditt företag eller "
-"som är en del av en liten gemenskap, kan vi känna att det ännu inte är "
-"lämpligt att lägga den framför alla våra användare."
+"<strong>Är tillägget användbart för en större del av Firefox användare?</strong> Ditt tillägg behöver inte bli nästa Greasemonkey eller Firebug, men om det endast är användbart för personer i ditt "
+"företag eller som är en del av en liten gemenskap, kan vi känna att det ännu inte är lämpligt att lägga den framför alla våra användare."
 
 #: src/olympia/devhub/templates/devhub/docs/policies-submission.html:55
 msgid ""
-"We are constantly looking at ways to improve the organization of the site to"
-" better accommodate add-ons that are exemplary in other ways, but are aimed "
-"at only a small community of potential users. Correctly categorizing and "
-"maintaining the metadata of your add-on will help us figure out how we can "
-"surface more of those sorts of add-ons to people who are most likely to "
-"benefit from them."
+"We are constantly looking at ways to improve the organization of the site to better accommodate add-ons that are exemplary in other ways, but are aimed at only a small community of potential users. "
+"Correctly categorizing and maintaining the metadata of your add-on will help us figure out how we can surface more of those sorts of add-ons to people who are most likely to benefit from them."
 msgstr ""
-"Vi söker ständigt efter nya sätt att förbättra organisationen av webbplatsen"
-" för att bättre tillgodose tillägg som är exemplariska på andra sätt, men "
-"som riktar sig endast till ett liten gemenskap av potentiella användare. "
-"Korrekt kategorisering och underhålla metadata för ditt tillägg kommer att "
-"hjälpa oss räkna ut hur vi kan få till ytan fler av dessa typer av tillägg "
-"till personer som är mest benägna att dra nytta av dem."
+"Vi söker ständigt efter nya sätt att förbättra organisationen av webbplatsen för att bättre tillgodose tillägg som är exemplariska på andra sätt, men som riktar sig endast till ett liten gemenskap "
+"av potentiella användare. Korrekt kategorisering och underhålla metadata för ditt tillägg kommer att hjälpa oss räkna ut hur vi kan få till ytan fler av dessa typer av tillägg till personer som är "
+"mest benägna att dra nytta av dem."
 
 #: src/olympia/devhub/templates/devhub/docs/policies-submission.html:61
 msgid ""
-"If your add-on just provides bookmarks or other simple access points to your"
-" site, it's probably not appropriate for the gallery. Like the rest of the "
-"Mozilla project, we love web applications and new web services, but Firefox "
-"add-ons should provide an improved browsing experience for the user and not "
-"just be a way to promote a new site or service through a Mozilla Add-ons "
-"listing."
+"If your add-on just provides bookmarks or other simple access points to your site, it's probably not appropriate for the gallery. Like the rest of the Mozilla project, we love web applications and "
+"new web services, but Firefox add-ons should provide an improved browsing experience for the user and not just be a way to promote a new site or service through a Mozilla Add-ons listing."
 msgstr ""
-"Om ditt tillägg endast innehåller bokmärken eller andra enkla accesspunkter "
-"till din webbplats, är det antagligen inte lämpligt för galleriet. Liksom "
-"resten av Mozilla-projektet, gillar vi webbapplikationer och nya "
-"webbtjänster, men Firefox tillägg bör ge en förbättrad surfupplevelse för "
-"användaren och inte bara vara ett sätt att främja en ny webbplats eller "
-"tjänst genom en Mozilla tilläggslistning."
+"Om ditt tillägg endast innehåller bokmärken eller andra enkla accesspunkter till din webbplats, är det antagligen inte lämpligt för galleriet. Liksom resten av Mozilla-projektet, gillar vi "
+"webbapplikationer och nya webbtjänster, men Firefox tillägg bör ge en förbättrad surfupplevelse för användaren och inte bara vara ett sätt att främja en ny webbplats eller tjänst genom en Mozilla "
+"tilläggslistning."
 
 #: src/olympia/devhub/templates/devhub/docs/policies-submission.html:67
 msgid ""
-"<strong>Is the add-on free of unlicensed trademarks and copyrights?</strong>"
-" Though you may mean no harm to the holder of a trademark, or the owner of a"
-" copyrighted work, we can't host add-ons that infringe on trademarks or "
-"copyrights. If you don't have permission to use a trademarked name or image,"
-" please do not submit your add-on to us. If your add-on includes code that "
-"is copyrighted by someone else, and is not licensed to you to use in your "
-"add-on, please do not submit your add-on to us."
+"<strong>Is the add-on free of unlicensed trademarks and copyrights?</strong> Though you may mean no harm to the holder of a trademark, or the owner of a copyrighted work, we can't host add-ons that "
+"infringe on trademarks or copyrights. If you don't have permission to use a trademarked name or image, please do not submit your add-on to us. If your add-on includes code that is copyrighted by "
+"someone else, and is not licensed to you to use in your add-on, please do not submit your add-on to us."
 msgstr ""
-"<strong>Är tillägget fri från olicensierade varumärken och "
-"upphovsrätt?</strong> Även om du inte vill något ont till innehavaren av ett"
-" varumärke eller ägaren av ett upphovsrättsskyddat verk, kan vi inte hysa "
-"ett tillägg som strider mot varumärken eller upphovsrätt. Om du inte har "
-"tillåtelse att använda ett varumärkes namn eller bild, ska du inte skicka in"
-" ditt tillägg till oss. Om tillägget innehåller kod som är "
-"upphovsrättsskyddat av någon annan och inte licensieras till dig för "
-"användning i ditt tillägg, ska du inte skicka in ditt tillägg till oss."
+"<strong>Är tillägget fri från olicensierade varumärken och upphovsrätt?</strong> Även om du inte vill något ont till innehavaren av ett varumärke eller ägaren av ett upphovsrättsskyddat verk, kan "
+"vi inte hysa ett tillägg som strider mot varumärken eller upphovsrätt. Om du inte har tillåtelse att använda ett varumärkes namn eller bild, ska du inte skicka in ditt tillägg till oss. Om "
+"tillägget innehåller kod som är upphovsrättsskyddat av någon annan och inte licensieras till dig för användning i ditt tillägg, ska du inte skicka in ditt tillägg till oss."
 
 #: src/olympia/devhub/templates/devhub/docs/policies-submission.html:73
 msgid ""
-"In terms of reuse of source code from other add-ons, if the author has not "
-"clearly stated that you are permitted to use his or her code in your own "
-"work &mdash; such as by placing it under an open source license &mdash; then"
-" you should assume that you do not have the right to do so. You can contact "
-"the author to seek such permission, but we can't provide you with any "
-"special rights to it just because it's listed on the site, or because the "
-"author isn't responding to your request."
+"In terms of reuse of source code from other add-ons, if the author has not clearly stated that you are permitted to use his or her code in your own work &mdash; such as by placing it under an open "
+"source license &mdash; then you should assume that you do not have the right to do so. You can contact the author to seek such permission, but we can't provide you with any special rights to it "
+"just because it's listed on the site, or because the author isn't responding to your request."
 msgstr ""
-"När det gäller återanvändning av källkoden från andra tillägg, om "
-"upphovsmannen inte tydligt har uppgett att du har rätt att använda deras kod"
-" i ditt eget arbete &mdash; såsom att placera den under en öppen "
-"källkodslicens &mdash; då ska du anta att du inte har rätt att göra det. Du "
-"kan kontakta upphovsmannen för att söka ett sådant tillstånd, men vi kan "
-"inte ge dig några speciella rättigheter till det bara för att det finns med "
-"på webbplatsen eller på grund av att upphovsmannen inte svarar på din "
-"förfrågan."
+"När det gäller återanvändning av källkoden från andra tillägg, om upphovsmannen inte tydligt har uppgett att du har rätt att använda deras kod i ditt eget arbete &mdash; såsom att placera den under "
+"en öppen källkodslicens &mdash; då ska du anta att du inte har rätt att göra det. Du kan kontakta upphovsmannen för att söka ett sådant tillstånd, men vi kan inte ge dig några speciella rättigheter "
+"till det bara för att det finns med på webbplatsen eller på grund av att upphovsmannen inte svarar på din förfrågan."
 
 #: src/olympia/devhub/templates/devhub/docs/policies-submission.html:79
 msgid ""
-"This applies to the Mozilla Foundation's trademarks as well, including "
-"\"Mozilla\", \"Firefox\", and \"Thunderbird\". The Mozilla policy on "
-"trademark use is designed to protect against confusion, and prevent the "
-"trademarks from being overturned due to lack of protection; please respect "
-"the need for such protection, and help us preserve some of the most valuable"
-" assets of the Mozilla Foundation."
+"This applies to the Mozilla Foundation's trademarks as well, including \"Mozilla\", \"Firefox\", and \"Thunderbird\". The Mozilla policy on trademark use is designed to protect against confusion, "
+"and prevent the trademarks from being overturned due to lack of protection; please respect the need for such protection, and help us preserve some of the most valuable assets of the Mozilla "
+"Foundation."
 msgstr ""
-"Detta gäller Mozilla stiftelsens varumärken också, bland annat \"Mozilla\", "
-"\"Firefox\" och \"Thunderbird\". Mozilla policy för varumärkesanvändning är "
-"avsedd att skydda mot förvirring och förhindra att varumärken från att "
-"kantra på grund av bristande skydd; vänligen respektera behovet av sådant "
-"skydd och hjälp oss att bevara några av de mest värdefulla tillgångar i "
-"stiftelsen för Mozilla."
+"Detta gäller Mozilla stiftelsens varumärken också, bland annat \"Mozilla\", \"Firefox\" och \"Thunderbird\". Mozilla policy för varumärkesanvändning är avsedd att skydda mot förvirring och "
+"förhindra att varumärken från att kantra på grund av bristande skydd; vänligen respektera behovet av sådant skydd och hjälp oss att bevara några av de mest värdefulla tillgångar i stiftelsen för "
+"Mozilla."
 
 #: src/olympia/devhub/templates/devhub/docs/policies-submission.html:84
 msgid "Licensing"
@@ -7864,253 +6103,178 @@ msgstr "Licensiering"
 
 #: src/olympia/devhub/templates/devhub/docs/policies-submission.html:86
 msgid ""
-"Selecting an appropriate license for your add-on is a very important step in"
-" the submission process. A license specifies the rights you grant on your "
-"source code and is important in protecting your intellectual property."
+"Selecting an appropriate license for your add-on is a very important step in the submission process. A license specifies the rights you grant on your source code and is important in protecting your "
+"intellectual property."
 msgstr ""
-"Att välja en lämplig licens för ditt tillägg är ett mycket viktigt steg i "
-"inskickningsprocessen. En licens anger de rättigheter du beviljar på din "
-"källkod och är viktigt för att skydda dina immateriella rättigheter."
+"Att välja en lämplig licens för ditt tillägg är ett mycket viktigt steg i inskickningsprocessen. En licens anger de rättigheter du beviljar på din källkod och är viktigt för att skydda dina "
+"immateriella rättigheter."
 
 #: src/olympia/devhub/templates/devhub/docs/policies-submission.html:92
 msgid ""
-"During the add-on submission process, you will be presented with a list of "
-"popular licenses to choose from, as well as the ability to specify your own "
-"license. It is best to consult with a legal professional about which license"
-" option is best for you. Choosing the right license for your source code "
-"will help to prevent confusion and code conflicts in the future."
+"During the add-on submission process, you will be presented with a list of popular licenses to choose from, as well as the ability to specify your own license. It is best to consult with a legal "
+"professional about which license option is best for you. Choosing the right license for your source code will help to prevent confusion and code conflicts in the future."
 msgstr ""
-"Under tilläggets inskickningsprocess, kommer du att presenteras med en lista"
-" över populära licenser att välja mellan, liksom möjligheten att specificera"
-" din egen licens. Det är bäst att rådgöra med en jurist om vilket licens-"
-"alternativ som är bäst för dig. Att välja rätt licens för källkoden kommer "
-"att bidra till att förhindra förvirring och kodkonflikter i framtiden."
+"Under tilläggets inskickningsprocess, kommer du att presenteras med en lista över populära licenser att välja mellan, liksom möjligheten att specificera din egen licens. Det är bäst att rådgöra med "
+"en jurist om vilket licens-alternativ som är bäst för dig. Att välja rätt licens för källkoden kommer att bidra till att förhindra förvirring och kodkonflikter i framtiden."
 
-#: src/olympia/devhub/templates/devhub/docs/policies.html:12
-#: src/olympia/devhub/templates/devhub/docs/policies.html:52
+#: src/olympia/devhub/templates/devhub/docs/policies.html:12 src/olympia/devhub/templates/devhub/docs/policies.html:52
 msgid "Add-on Submission"
 msgstr "Inskickning tillägg"
 
-#: src/olympia/devhub/templates/devhub/docs/policies.html:18
-#: src/olympia/devhub/templates/devhub/docs/policies.html:78
+#: src/olympia/devhub/templates/devhub/docs/policies.html:18 src/olympia/devhub/templates/devhub/docs/policies.html:78
 msgid "Maintaining Your Add-on"
 msgstr "Underhåll av ditt tillägg"
 
 #: src/olympia/devhub/templates/devhub/docs/policies.html:43
-msgid ""
-"Mozilla is committed to ensuring a great add-ons experience for our users "
-"and developers. Please review the policies below before submitting your add-"
-"on."
-msgstr ""
-"Mozilla strävar efter att garantera en bra upplevelse gällande tillägg för "
-"våra användare och utvecklare. Läs igenom policyn nedan innan du skickar in "
-"ditt tillägg."
+msgid "Mozilla is committed to ensuring a great add-ons experience for our users and developers. Please review the policies below before submitting your add-on."
+msgstr "Mozilla strävar efter att garantera en bra upplevelse gällande tillägg för våra användare och utvecklare. Läs igenom policyn nedan innan du skickar in ditt tillägg."
 
 #: src/olympia/devhub/templates/devhub/docs/policies.html:55
-msgid ""
-"Find out what is expected of add-ons we host and our policies on specific "
-"add-on practices."
-msgstr ""
-"Ta reda på vad som förväntas av tillägg som vi hyser och vår policyer för "
-"särskilda tilläggsmetoder."
+msgid "Find out what is expected of add-ons we host and our policies on specific add-on practices."
+msgstr "Ta reda på vad som förväntas av tillägg som vi hyser och vår policyer för särskilda tilläggsmetoder."
 
 #: src/olympia/devhub/templates/devhub/docs/policies.html:67
-msgid ""
-"What happens after your add-on is submitted? Learn about how our Editors "
-"review submissions."
-msgstr ""
-"Vad händer efter ditt tillägg har skickats in? Lär dig mer om hur våra "
-"redigerare granskar inskickningar."
+msgid "What happens after your add-on is submitted? Learn about how our Editors review submissions."
+msgstr "Vad händer efter ditt tillägg har skickats in? Lär dig mer om hur våra redigerare granskar inskickningar."
 
 #: src/olympia/devhub/templates/devhub/docs/policies.html:81
-msgid ""
-"Add-on updates, transferring ownership, user reviews, and what to expect "
-"once your add-on is approved."
-msgstr ""
-"Tilläggsuppdateringar, överföra äganderätten, användarrecensioner och vad "
-"som väntar när ditt tillägg är godkänt."
+msgid "Add-on updates, transferring ownership, user reviews, and what to expect once your add-on is approved."
+msgstr "Tilläggsuppdateringar, överföra äganderätten, användarrecensioner och vad som väntar när ditt tillägg är godkänt."
 
 #: src/olympia/devhub/templates/devhub/docs/policies.html:93
-msgid ""
-"How up-and-coming add-ons become featured and what&#039;s involved in the "
-"process."
+msgid "How up-and-coming add-ons become featured and what&#039;s involved in the process."
 msgstr "Hur bubblande tillägg blir utvalda och vad det innebär i processen."
 
 #: src/olympia/devhub/templates/devhub/docs/policies.html:106
-msgid ""
-"Terms of Service for submitting your work to our site. Developers are "
-"required to accept this agreement before submission."
-msgstr ""
-"Användarvillkor för att skicka in ditt arbete till vår webbplats. Utvecklare"
-" måste acceptera detta avtal innan inskickning."
+msgid "Terms of Service for submitting your work to our site. Developers are required to accept this agreement before submission."
+msgstr "Användarvillkor för att skicka in ditt arbete till vår webbplats. Utvecklare måste acceptera detta avtal innan inskickning."
 
 #: src/olympia/devhub/templates/devhub/docs/policies.html:118
 msgid "How to get in touch with us regarding these policies or your add-on."
-msgstr ""
-"Hur får man kontakt med oss angående dessa policyer eller ditt tillägg."
+msgstr "Hur får man kontakt med oss angående dessa policyer eller ditt tillägg."
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:6
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:10
 msgid "You have disabled this add-on"
 msgstr "Du har inaktiverat detta tillägg"
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:20
-msgid ""
-"Your add-on's listing is disabled and is not showing\n"
-"                             anywhere in our gallery or update service."
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:24
+msgid "Your add-on's listing is disabled and is not showing anywhere in our gallery or update service."
 msgstr ""
 "Ditt tilläggs listning är inaktiverad och visas inte\n"
 "                             någonstans i vårt galleri eller uppdateringstjänst."
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:25
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:27
 msgid "Please complete your add-on."
 msgstr "Vänligen färdigställ ditt tillägg."
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:29
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:30
 msgid "You will receive an email when the review is complete."
 msgstr "Du får ett e-postmeddelande när granskningen är klar."
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:34
-msgid ""
-"You will receive an email when the review is complete. Until\n"
-"                             then, your add-on is not listed in our gallery but can be\n"
-"                             accessed directly from its details page."
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:33
+msgid "You will receive an email when the review is complete. Until then, your add-on is not listed in our gallery but can be accessed directly from its details page."
 msgstr ""
 "Du kommer att få ett mejl när granskningen är klar. Fram tills\n"
 "                             dess, kommer ditt tillägg inte listas i vårt galleri, men kan\n"
 "                             nås direkt från detaljsidan."
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:38
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:48
-msgid ""
-"You will receive an email when the review is\n"
-"                             complete and your add-on is signed."
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:37 src/olympia/devhub/templates/devhub/includes/addon_details.html:45
+msgid "You will receive an email when the review is complete and your add-on is signed."
 msgstr ""
 "Du får ett e-postmeddelande när granskningen är\n"
 "                             klar och ditt tillägg signerat."
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:44
-msgid ""
-"You will receive an email when the review is complete. Until\n"
-"                             then, your add-on is not listed in our gallery but can be\n"
-"                             accessed directly from its details page. "
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:41
+msgid "You will receive an email when the review is complete. Until then, your add-on is not listed in our gallery but can be accessed directly from its details page. "
 msgstr ""
-"Du kommer att få ett mejl när granskningen är klar. Fram tills\n"
-"                             dess, kommer ditt tillägg inte listas i vårt galleri, men kan\n"
-"                             nås direkt från detaljsidan. "
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:54
-msgid ""
-"Your add-on is displayed in our gallery and users are\n"
-"                             receiving automatic updates."
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:49
+msgid "Your add-on is displayed in our gallery and users are receiving automatic updates."
 msgstr ""
 "Ditt tillägg visas i vårt galleri och användare\n"
 "                             får automatiska uppdateringar."
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:57
-msgid ""
-"Your add-on has been signed and can be bundled with an\n"
-"                             application installer."
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:52
+msgid "Your add-on has been signed and can be bundled with an application installer."
 msgstr ""
 "Ditt tillägg har signerats och kan paketeras med ett\n"
 "                             installationsprogram."
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:63
-msgid ""
-"Your add-on was disabled by a site administrator and is no\n"
-"                             longer shown in our gallery. If you have any questions,\n"
-"                             please email amo-admins@mozilla.org."
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:56
+msgid "Your add-on was disabled by a site administrator and is no longer shown in our gallery. If you have any questions, please email amo-admins@mozilla.org."
 msgstr ""
 "Ditt tillägg har inaktiverats av en webbplatsadministratör och visas inte\n"
 "                             längre i vårt galleri. Om du har några frågor,\n"
 "                             mejla amo-admins@mozilla.org."
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:70
-msgid ""
-"Your add-on is displayed in our gallery as experimental\n"
-"                             and users are receiving automatic updates. Some features\n"
-"                             are unavailable to your add-on."
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:62
+msgid "Your add-on is displayed in our gallery as experimental and users are receiving automatic updates. Some features are unavailable to your add-on."
 msgstr ""
 "Ditt tillägg visas i vårt galleri som experimentell\n"
 "                             och användare får automatiska uppdateringar. Vissa\n"
 "                             funktioner är inte tillgängliga för ditt tillägg."
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:74
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:66
 msgid "Your add-on has been signed."
 msgstr "Ditt tillägg har signerats."
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:79
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:69
 msgid ""
-"You will receive an email when the full review is complete.\n"
-"                             Until then, your add-on is displayed in our gallery as\n"
-"                             experimental and users are receiving automatic updates.\n"
-"                             Some features are unavailable to your add-on."
+"You will receive an email when the full review is complete. Until then, your add-on is displayed in our gallery as experimental and users are receiving automatic updates. Some features are "
+"unavailable to your add-on."
 msgstr ""
 "Du kommer att få ett mejl när hela granskningen är klar.\n"
 "                             Fram till dess, visas ditt tillägg i vårt galleri som\n"
 "                             experimentell och användare får automatiska uppdateringar.\n"
 "                             Vissa funktioner är inte tillgängliga för ditt tillägg."
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:84
-msgid ""
-"You will receive an email when the full review is\n"
-"                             complete, making you able to bundle your add-on with an\n"
-"                             application installer."
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:74
+msgid "You will receive an email when the full review is complete, making you able to bundle your add-on with an application installer."
 msgstr ""
 "Du kommer att få ett mejl när den fullständiga granskningen är\n"
 "                             klar, vilket gör att du kan paketera ditt tillägg i ett\n"
 "                             installationsprogram."
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:91
-msgid ""
-"All add-ons hosted in our gallery must now be reviewed by an\n"
-"                             editor. If you wish to continue hosting your add-on, please\n"
-"                             click to select a review process."
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:79
+msgid "All add-ons hosted in our gallery must now be reviewed by an editor. If you wish to continue hosting your add-on, please click to select a review process."
 msgstr ""
 "Alla tillägg som hyses i vårt galleri måste nu granskas av en\n"
 "                             redaktör. Om du vill fortsätta hysa ditt tillägg, vänligen\n"
 "                             välj en granskningsprocess."
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:113
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:100
 msgid "Current Version:"
 msgstr "Nuvarande version:"
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:115
-msgid ""
-"This is the version of your add-on that will\n"
-"                                           be installed if someone clicks the Install\n"
-"                                           button on addons.mozilla.org. It is only\n"
-"                                           relevant for listed add-ons."
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:102
+msgid "This is the version of your add-on that will be installed if someone clicks the Install button on addons.mozilla.org. It is only relevant for listed add-ons."
 msgstr ""
 "Detta är den version av ditt tillägg som kommer\n"
 "                                           att installeras om någon klickar på knappen Installera\n"
 "                                           på addons.mozilla.org. Detta är endast\n"
 "                                           relevant för listade tillägg."
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:123
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:110
 msgid "Created:"
 msgstr "Skapad:"
 
 #. {0} is a date. dennis-ignore: E201
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:125
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:131
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:112 src/olympia/devhub/templates/devhub/includes/addon_details.html:118
 #, python-format
 msgid "%%b %%e, %%Y"
 msgstr "%%e %%b %%Y"
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:136
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:123
 msgid "Next Version:"
 msgstr "Nästa version:"
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:138
-msgid ""
-"This is the newest uploaded version, however\n"
-"                                           it isn’t live on the site yet."
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:125
+msgid "This is the newest uploaded version, however it isn’t live on the site yet."
 msgstr ""
 "Detta är den senaste uppladdade versionen, men\n"
 "                                           den är inte uppladdad på webbplatsen ännu."
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:144
-#: src/olympia/devhub/templates/devhub/versions/list.html:30
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:130 src/olympia/devhub/templates/devhub/versions/list.html:30
 msgid "Queues are not reviewed strictly in order"
 msgstr "Köerna granskas inte i strikt ordning"
 
@@ -8128,15 +6292,11 @@ msgstr "Skapa en utvecklarprofil"
 
 #: src/olympia/devhub/templates/devhub/includes/addons_create_profile.html:24
 msgid ""
-"Your developer profile will tell users about you, why you made this add-on, "
-"and what's next for the add-on. This profile is required for add-ons "
-"requesting contributions, but can be useful for any developer interested in "
-"connecting with users."
+"Your developer profile will tell users about you, why you made this add-on, and what's next for the add-on. This profile is required for add-ons requesting contributions, but can be useful for any "
+"developer interested in connecting with users."
 msgstr ""
-"Din utvecklarprofil informerar användarna om dig, varför du gjorde detta "
-"tillägg och vad som är nästa steg för tillägget. Denna profil krävs för "
-"tillägg som begär bidrag, men kan vara användbar för alla utvecklare som är "
-"intresserade av få kontakt med användare."
+"Din utvecklarprofil informerar användarna om dig, varför du gjorde detta tillägg och vad som är nästa steg för tillägget. Denna profil krävs för tillägg som begär bidrag, men kan vara användbar för "
+"alla utvecklare som är intresserade av få kontakt med användare."
 
 #: src/olympia/devhub/templates/devhub/includes/addons_create_profile.html:32
 msgid "Make sure your user profile is up to date."
@@ -8148,20 +6308,12 @@ msgid "<a href=\"%(url)s\"><strong>Update your user profile.</strong></a>"
 msgstr "<a href=\"%(url)s\"><strong>Uppdatera din användarprofil.</strong></a>"
 
 #: src/olympia/devhub/templates/devhub/includes/addons_create_profile.html:45
-msgid ""
-"Whether it was an idea while in line at the grocery store or the solution to"
-" one of life's great problems, share your story."
-msgstr ""
-"Om det var en idé som du fick i kön i mataffären eller lösningen på ett av "
-"livets stora problem, dela din berättelse."
+msgid "Whether it was an idea while in line at the grocery store or the solution to one of life's great problems, share your story."
+msgstr "Om det var en idé som du fick i kön i mataffären eller lösningen på ett av livets stora problem, dela din berättelse."
 
 #: src/olympia/devhub/templates/devhub/includes/addons_create_profile.html:61
-msgid ""
-"Telling your users what's coming soon will give them something to look "
-"forward to."
-msgstr ""
-"Berätta för dina användare vad som snart kommer kan att ge dem något att se "
-"fram emot."
+msgid "Telling your users what's coming soon will give them something to look forward to."
+msgstr "Berätta för dina användare vad som snart kommer kan att ge dem något att se fram emot."
 
 #: src/olympia/devhub/templates/devhub/includes/addons_edit_nav.html:23
 msgid "View All"
@@ -8192,9 +6344,7 @@ msgid "View the blog &#9658;"
 msgstr "Visa bloggen &#9658;"
 
 #: src/olympia/devhub/templates/devhub/includes/license_form.html:6
-msgid ""
-"Please choose a license appropriate for the rights you grant on your source code.\n"
-"                  It is only relevant for listed add-ons."
+msgid "Please choose a license appropriate for the rights you grant on your source code. It is only relevant for listed add-ons."
 msgstr ""
 "Välj en licens som lämpar sig för de rättigheter du beviljar för din källkod.\n"
 "                  Detta är endast relevant för listade tillägg."
@@ -8212,8 +6362,7 @@ msgstr "Viss HTML-stöd."
 msgid "Remove this application"
 msgstr "Ta bort denna applikation"
 
-#. {0} is the maximum number of add-on categories allowed.                {1}
-#. is
+#. {0} is the maximum number of add-on categories allowed.                {1} is
 #. the application name.
 #: src/olympia/devhub/templates/devhub/includes/macros.html:70
 msgid "Select <b>up to {0}</b> {1} category for this add-on:"
@@ -8223,39 +6372,27 @@ msgstr[1] "Välj <b>upp till {0}</b> {1} kategorier för detta tillägg:"
 
 #: src/olympia/devhub/templates/devhub/includes/policy_form.html:4
 msgid ""
-"Users will be required to accept the following End-User License Agreement (EULA) prior to installing your add-on. The presence of a EULA significantly affects the number of downloads an add-on receives. Please note that a EULA is not the same as a code license, such as the GPL or MPL.\n"
-"                It is only relevant for listed add-ons."
+"Users will be required to accept the following End-User License Agreement (EULA) prior to installing your add-on. The presence of a EULA significantly affects the number of downloads an add-on "
+"receives. Please note that a EULA is not the same as a code license, such as the GPL or MPL.It is only relevant for listed add-ons."
 msgstr ""
-"Användarna kommer att behöva acceptera följande licensavtal för slutanvändare (EULA) innan de installerar ditt tillägg. Förekomst av en EULA påverkar avsevärt antalet nedladdningar ett tillägg får. Observera att en EULA inte är samma sak som en kodlicens, såsom GPL eller MPL.\n"
-"                Detta är endast relevant för listade tillägg."
 
-#: src/olympia/devhub/templates/devhub/includes/policy_form.html:21
-msgid ""
-"If your add-on transmits any data from the user's computer, a privacy policy is required that explains what data is sent and how it is used.\n"
-"                It is only relevant for listed add-ons."
+#: src/olympia/devhub/templates/devhub/includes/policy_form.html:24
+msgid "If your add-on transmits any data from the user's computer, a privacy policy is required that explains what data is sent and how it is used. It is only relevant for listed add-ons."
 msgstr ""
 "Om ditt tillägg överför någon data från användarens dator, krävs en sekretesspolicy som förklarar vilka data som skickas och hur de används.\n"
 "                Detta är endast relevant för listade tillägg."
 
 #: src/olympia/devhub/templates/devhub/includes/source_form_field.html:2
-msgid ""
-"If your add-on contains binary or obfuscated code other than known "
-"libraries, upload its sources for review."
-msgstr ""
-"Om ditt tillägg innehåller binär eller förvrängd kod annat än kända "
-"bibliotek, ladda upp dess källor för granskning."
+msgid "If your add-on contains binary or obfuscated code other than known libraries, upload its sources for review."
+msgstr "Om ditt tillägg innehåller binär eller förvrängd kod annat än kända bibliotek, ladda upp dess källor för granskning."
 
 #: src/olympia/devhub/templates/devhub/includes/source_form_field.html:3
 msgid "Read more about the source code review policy."
 msgstr "Läs mer om granskningspolicyn för källkod."
 
 #: src/olympia/devhub/templates/devhub/includes/version_file.html:20
-msgid ""
-"You cannot remove an individual file after the review process has begun. You"
-" must delete the entire version."
-msgstr ""
-"Du kan inte ta bort en enskild fil efter granskningsprocessen har inletts. "
-"Du måste ta bort hela versionen."
+msgid "You cannot remove an individual file after the review process has begun. You must delete the entire version."
+msgstr "Du kan inte ta bort en enskild fil efter granskningsprocessen har inletts. Du måste ta bort hela versionen."
 
 #: src/olympia/devhub/templates/devhub/includes/version_file.html:36
 msgid "This file will be deleted on save."
@@ -8283,12 +6420,8 @@ msgid "Voluntary Contributions"
 msgstr "Frivilliga bidrag"
 
 #: src/olympia/devhub/templates/devhub/payments/payments.html:38
-msgid ""
-"Add-ons enrolled in our contributions program can request voluntary "
-"financial support from users."
-msgstr ""
-"Tillägg inskrivna i vårt bidragsprogram kan begära frivillig finansiellt "
-"stöd från användarna."
+msgid "Add-ons enrolled in our contributions program can request voluntary financial support from users."
+msgstr "Tillägg inskrivna i vårt bidragsprogram kan begära frivillig finansiellt stöd från användarna."
 
 #: src/olympia/devhub/templates/devhub/payments/payments.html:40
 msgid "Encourage users to support your add-on through your Developer Profile"
@@ -8299,12 +6432,8 @@ msgid "Choose when and how users are asked to contribute"
 msgstr "Välja när och hur användarna uppmanas att bidra"
 
 #: src/olympia/devhub/templates/devhub/payments/payments.html:42
-msgid ""
-"Receive contributions in your PayPal account or send them to an organization"
-" of your choice"
-msgstr ""
-"Få bidrag till ditt PayPal-konto eller skicka dem till en organisation som "
-"du väljer"
+msgid "Receive contributions in your PayPal account or send them to an organization of your choice"
+msgstr "Få bidrag till ditt PayPal-konto eller skicka dem till en organisation som du väljer"
 
 #: src/olympia/devhub/templates/devhub/payments/payments.html:46
 msgid "Contributions are only available for listed add-ons."
@@ -8312,19 +6441,14 @@ msgstr "Bidrag är endast tillgängliga för listade tillägg."
 
 #: src/olympia/devhub/templates/devhub/payments/payments.html:53
 #, python-format
-msgid ""
-"Contributions are only available for add-ons with a <a "
-"href=\"%(url)s\">completed developer profile</a>."
-msgstr ""
-"Bidrag är endast tillgängliga för tillägg med en <a href=\"%(url)s\">färdig "
-"utvecklarprofil</a>."
+msgid "Contributions are only available for add-ons with a <a href=\"%(url)s\">completed developer profile</a>."
+msgstr "Bidrag är endast tillgängliga för tillägg med en <a href=\"%(url)s\">färdig utvecklarprofil</a>."
 
 #: src/olympia/devhub/templates/devhub/payments/payments.html:59
 msgid "Contributions are only available for fully reviewed add-ons."
 msgstr "Bidrag är endast tillgängliga för fullständigt granskade tillägg."
 
-#: src/olympia/devhub/templates/devhub/payments/payments.html:65
-#: src/olympia/devhub/templates/devhub/payments/voluntary.html:2
+#: src/olympia/devhub/templates/devhub/payments/payments.html:65 src/olympia/devhub/templates/devhub/payments/voluntary.html:2
 msgid "Set up Contributions"
 msgstr "Konfigurera bidrag"
 
@@ -8337,17 +6461,13 @@ msgstr "Steg 2. Priser och tillgänglighet"
 msgid "or <a href=\"%(cancel)s\">Cancel</a>"
 msgstr "eller <a href=\"%(cancel)s\">Avbryt</a>"
 
-#: src/olympia/devhub/templates/devhub/payments/voluntary.html:2
-#: src/olympia/stats/templates/stats/addon_report_menu.html:39
+#: src/olympia/devhub/templates/devhub/payments/voluntary.html:2 src/olympia/stats/templates/stats/addon_report_menu.html:39
 msgid "Contributions"
 msgstr "Bidrag"
 
 #: src/olympia/devhub/templates/devhub/payments/voluntary.html:3
-msgid ""
-"Fill in the fields below to begin asking for voluntary contributions from "
-"users."
-msgstr ""
-"Fyll i fälten nedan för att börja be om frivilliga bidrag från användarna."
+msgid "Fill in the fields below to begin asking for voluntary contributions from users."
+msgstr "Fyll i fälten nedan för att börja be om frivilliga bidrag från användarna."
 
 #: src/olympia/devhub/templates/devhub/payments/voluntary.html:11
 msgid "Who will receive contributions to this add-on?"
@@ -8390,23 +6510,16 @@ msgid "Send a thank-you note?"
 msgstr "Skicka ett tackkort?"
 
 #: src/olympia/devhub/templates/devhub/payments/voluntary.html:47
-msgid ""
-"We'll automatically email users who contribute to your add-on with this "
-"message."
-msgstr ""
-"Vi kommer automatiskt att skicka användare som bidrar till ditt tillägg med "
-"detta meddelande."
+msgid "We'll automatically email users who contribute to your add-on with this message."
+msgstr "Vi kommer automatiskt att skicka användare som bidrar till ditt tillägg med detta meddelande."
 
 #: src/olympia/devhub/templates/devhub/payments/voluntary.html:49
 msgid ""
-"We recommend thanking the user and telling them how much you appreciate "
-"their support. You might also want to tell them about what's next for your "
-"add-on and about any other add-ons you've made for them to try."
+"We recommend thanking the user and telling them how much you appreciate their support. You might also want to tell them about what's next for your add-on and about any other add-ons you've made for "
+"them to try."
 msgstr ""
-"Vi rekommenderar att tacka användaren och berätta för dem hur mycket du "
-"uppskattar deras stöd. Du kanske också vill berätta om vad som händer med "
-"ditt tillägg och om eventuella andra tillägg som du har gjort för dem att "
-"prova."
+"Vi rekommenderar att tacka användaren och berätta för dem hur mycket du uppskattar deras stöd. Du kanske också vill berätta om vad som händer med ditt tillägg och om eventuella andra tillägg som du "
+"har gjort för dem att prova."
 
 #: src/olympia/devhub/templates/devhub/payments/voluntary.html:64
 msgid "Activate Contributions"
@@ -8420,151 +6533,99 @@ msgstr "eller <a id=\"setup-cancel\" href=\"#\">Avbryt</a>"
 msgid "Transfer ownership"
 msgstr "Överför ägarskapet"
 
-#: src/olympia/devhub/templates/devhub/personas/edit.html:77
-#: src/olympia/devhub/templates/devhub/personas/submit.html:31
+#: src/olympia/devhub/templates/devhub/personas/edit.html:77 src/olympia/devhub/templates/devhub/personas/submit.html:31
 msgid "Theme Details"
 msgstr "Detaljer för tema"
 
-#: src/olympia/devhub/templates/devhub/personas/edit.html:87
-#: src/olympia/devhub/templates/devhub/personas/submit.html:36
+#: src/olympia/devhub/templates/devhub/personas/edit.html:87 src/olympia/devhub/templates/devhub/personas/submit.html:36
 msgid "Supply a pretty URL for your detail page."
 msgstr "Tillhandahålla en snygg URL för din detaljsida."
 
-#: src/olympia/devhub/templates/devhub/personas/edit.html:92
-#: src/olympia/devhub/templates/devhub/personas/submit.html:41
+#: src/olympia/devhub/templates/devhub/personas/edit.html:92 src/olympia/devhub/templates/devhub/personas/submit.html:41
 msgid "Select the category that best describes your Theme."
 msgstr "Välj den kategori som bäst beskriver ditt tema."
 
-#: src/olympia/devhub/templates/devhub/personas/edit.html:95
-#: src/olympia/devhub/templates/devhub/personas/submit.html:44
+#: src/olympia/devhub/templates/devhub/personas/edit.html:95 src/olympia/devhub/templates/devhub/personas/submit.html:44
 msgid "Add some tags to describe your Theme."
 msgstr "Lägg till några taggar för att beskriva ditt tema."
 
-#: src/olympia/devhub/templates/devhub/personas/edit.html:106
-msgid ""
-"A short explanation of your theme's\n"
-"                                basic functionality that is displayed in\n"
-"                                search and browse listings, as well as at\n"
-"                                the top of your theme's details page."
+#: src/olympia/devhub/templates/devhub/personas/edit.html:106 src/olympia/devhub/templates/devhub/personas/submit.html:54
+msgid "A short explanation of your theme's basic functionality that is displayed in search and browse listings, as well as at the top of your theme's details page."
 msgstr ""
 "En kort förklaring av ditt temas\n"
 "                                grundläggande funktionalitet som visas i\n"
 "                                sök- och bläddringslistor, liksom överst i\n"
 "                                ditt temas detaljsida."
 
-#: src/olympia/devhub/templates/devhub/personas/edit.html:122
-#: src/olympia/devhub/templates/devhub/personas/submit.html:68
+#: src/olympia/devhub/templates/devhub/personas/edit.html:122 src/olympia/devhub/templates/devhub/personas/submit.html:68
 msgid "Theme License"
 msgstr "Licens för tema"
 
-#: src/olympia/devhub/templates/devhub/personas/edit.html:126
-#: src/olympia/devhub/templates/devhub/personas/submit.html:72
+#: src/olympia/devhub/templates/devhub/personas/edit.html:126 src/olympia/devhub/templates/devhub/personas/submit.html:72
 msgid "Can others share your Theme, as long as you're given credit?"
 msgstr "Kan andra dela ditt tema, så länge du omnämnes?"
 
-#: src/olympia/devhub/templates/devhub/personas/edit.html:132
-#: src/olympia/devhub/templates/devhub/personas/edit.html:153
-#: src/olympia/devhub/templates/devhub/personas/submit.html:78
+#: src/olympia/devhub/templates/devhub/personas/edit.html:132 src/olympia/devhub/templates/devhub/personas/edit.html:153 src/olympia/devhub/templates/devhub/personas/submit.html:78
 #: src/olympia/devhub/templates/devhub/personas/submit.html:99
-msgid ""
-"The licensor permits others to copy, distribute, display, and perform the "
-"work, including for commercial purposes."
-msgstr ""
-"Licensgivaren tillåter andra att kopiera, distribuera, visa och utföra "
-"arbetet, även för kommersiella ändamål."
+msgid "The licensor permits others to copy, distribute, display, and perform the work, including for commercial purposes."
+msgstr "Licensgivaren tillåter andra att kopiera, distribuera, visa och utföra arbetet, även för kommersiella ändamål."
 
-#: src/olympia/devhub/templates/devhub/personas/edit.html:141
-#: src/olympia/devhub/templates/devhub/personas/edit.html:162
-#: src/olympia/devhub/templates/devhub/personas/submit.html:87
+#: src/olympia/devhub/templates/devhub/personas/edit.html:141 src/olympia/devhub/templates/devhub/personas/edit.html:162 src/olympia/devhub/templates/devhub/personas/submit.html:87
 #: src/olympia/devhub/templates/devhub/personas/submit.html:108
-msgid ""
-"The licensor permits others to copy, distribute, display, and perform the "
-"work for non-commercial purposes only."
-msgstr ""
-"Licensgivaren tillåter andra att kopiera, distribuera, visa och utföra "
-"arbetet endast för icke-kommersiella ändamål."
+msgid "The licensor permits others to copy, distribute, display, and perform the work for non-commercial purposes only."
+msgstr "Licensgivaren tillåter andra att kopiera, distribuera, visa och utföra arbetet endast för icke-kommersiella ändamål."
 
-#: src/olympia/devhub/templates/devhub/personas/edit.html:147
-#: src/olympia/devhub/templates/devhub/personas/submit.html:93
+#: src/olympia/devhub/templates/devhub/personas/edit.html:147 src/olympia/devhub/templates/devhub/personas/submit.html:93
 msgid "Can others make commercial use of your Theme?"
 msgstr "Kan andra använda ditt tema i kommersiellt syfte?"
 
-#: src/olympia/devhub/templates/devhub/personas/edit.html:168
-#: src/olympia/devhub/templates/devhub/personas/submit.html:114
+#: src/olympia/devhub/templates/devhub/personas/edit.html:168 src/olympia/devhub/templates/devhub/personas/submit.html:114
 msgid "Can others create derivative works from your Theme?"
 msgstr "Kan andra skapa utvecklingar från ditt tema?"
 
-#: src/olympia/devhub/templates/devhub/personas/edit.html:174
-#: src/olympia/devhub/templates/devhub/personas/submit.html:120
-msgid ""
-"The licensor permits others to copy, distribute, display and perform the "
-"work, as well as make derivative works based on it."
-msgstr ""
-"Licensgivaren tillåter andra att kopiera, distribuera, visa och utföra "
-"arbetet, samt göra utvecklingar av tidigare arbete."
+#: src/olympia/devhub/templates/devhub/personas/edit.html:174 src/olympia/devhub/templates/devhub/personas/submit.html:120
+msgid "The licensor permits others to copy, distribute, display and perform the work, as well as make derivative works based on it."
+msgstr "Licensgivaren tillåter andra att kopiera, distribuera, visa och utföra arbetet, samt göra utvecklingar av tidigare arbete."
 
-#: src/olympia/devhub/templates/devhub/personas/edit.html:182
-#: src/olympia/devhub/templates/devhub/personas/submit.html:128
+#: src/olympia/devhub/templates/devhub/personas/edit.html:182 src/olympia/devhub/templates/devhub/personas/submit.html:128
 msgid "Yes, as long as they share alike"
 msgstr "Ja, så länge de delar likadant"
 
-#: src/olympia/devhub/templates/devhub/personas/edit.html:183
-#: src/olympia/devhub/templates/devhub/personas/submit.html:129
-msgid ""
-"The licensor permits others to distribute derivativeworks only under the "
-"same license or one compatible with the one that governs the licensor's "
-"work."
-msgstr ""
-"Licensgivaren tillåter andra att distribuera utvecklingar endast under samma"
-" licens eller en kompatibel med den som reglerar licensgivarens arbete."
+#: src/olympia/devhub/templates/devhub/personas/edit.html:183 src/olympia/devhub/templates/devhub/personas/submit.html:129
+msgid "The licensor permits others to distribute derivativeworks only under the same license or one compatible with the one that governs the licensor's work."
+msgstr "Licensgivaren tillåter andra att distribuera utvecklingar endast under samma licens eller en kompatibel med den som reglerar licensgivarens arbete."
 
-#: src/olympia/devhub/templates/devhub/personas/edit.html:192
-#: src/olympia/devhub/templates/devhub/personas/submit.html:138
-msgid ""
-"The licensor permits others to copy, distribute and transmit only unaltered "
-"copies of the work — not derivative works based on it."
-msgstr ""
-"Licensgivaren tillåter andra att kopiera, distribuera och överföra endast "
-"oförändrade kopior av arbetet — inte arbetet som bygger på den."
+#: src/olympia/devhub/templates/devhub/personas/edit.html:192 src/olympia/devhub/templates/devhub/personas/submit.html:138
+msgid "The licensor permits others to copy, distribute and transmit only unaltered copies of the work — not derivative works based on it."
+msgstr "Licensgivaren tillåter andra att kopiera, distribuera och överföra endast oförändrade kopior av arbetet — inte arbetet som bygger på den."
 
-#: src/olympia/devhub/templates/devhub/personas/edit.html:199
-#: src/olympia/devhub/templates/devhub/personas/submit.html:145
+#: src/olympia/devhub/templates/devhub/personas/edit.html:199 src/olympia/devhub/templates/devhub/personas/submit.html:145
 msgid "Your Theme will be released under the following license:"
 msgstr "Ditt tema kommer att släppas under följande licens:"
 
-#: src/olympia/devhub/templates/devhub/personas/edit.html:202
-#: src/olympia/devhub/templates/devhub/personas/submit.html:148
+#: src/olympia/devhub/templates/devhub/personas/edit.html:202 src/olympia/devhub/templates/devhub/personas/submit.html:148
 msgid "Select a different license."
 msgstr "Välj en annan licens."
 
-#: src/olympia/devhub/templates/devhub/personas/edit.html:207
-#: src/olympia/devhub/templates/devhub/personas/submit.html:153
+#: src/olympia/devhub/templates/devhub/personas/edit.html:207 src/olympia/devhub/templates/devhub/personas/submit.html:153
 msgid "Select a license for your Theme."
 msgstr "Välj en licens för ditt tema."
 
-#: src/olympia/devhub/templates/devhub/personas/edit.html:217
-#: src/olympia/devhub/templates/devhub/personas/submit.html:163
+#: src/olympia/devhub/templates/devhub/personas/edit.html:217 src/olympia/devhub/templates/devhub/personas/submit.html:163
 msgid "Theme Design"
 msgstr "Design för tema"
 
-#: src/olympia/devhub/templates/devhub/personas/edit.html:221
-#: src/olympia/devhub/templates/devhub/personas/edit.html:224
+#: src/olympia/devhub/templates/devhub/personas/edit.html:221 src/olympia/devhub/templates/devhub/personas/edit.html:224
 msgid "Upload New Design"
 msgstr "Ladda upp en ny design"
 
 #: src/olympia/devhub/templates/devhub/personas/edit.html:226
-msgid ""
-"Upon upload and form submission, the AMO Team will review your updated "
-"design. Your current design will still be public in the meantime."
-msgstr ""
-"Vid uppladdning och inskickning av formulär kommer gruppen från AMO att "
-"granska din uppdaterade design. Din nuvarande utformning kommer fortfarande "
-"att vara offentliga under tiden."
+msgid "Upon upload and form submission, the AMO Team will review your updated design. Your current design will still be public in the meantime."
+msgstr "Vid uppladdning och inskickning av formulär kommer gruppen från AMO att granska din uppdaterade design. Din nuvarande utformning kommer fortfarande att vara offentliga under tiden."
 
 #: src/olympia/devhub/templates/devhub/personas/edit.html:241
-msgid "Your previously resubmitted design,  which is under pending review."
-msgstr ""
-"Din tidigare återinskickade design,  som är under pågående granskning."
+msgid "Your previously resubmitted design, which is under pending review."
+msgstr "Din tidigare återinskickade design,  som är under pågående granskning."
 
 #: src/olympia/devhub/templates/devhub/personas/edit.html:245
 msgid "Pending Header"
@@ -8586,43 +6647,35 @@ msgstr "Sidhuvud"
 msgid "Footer"
 msgstr "Sidfot"
 
-#: src/olympia/devhub/templates/devhub/personas/edit.html:274
-#: src/olympia/devhub/templates/devhub/personas/submit.html:167
+#: src/olympia/devhub/templates/devhub/personas/edit.html:274 src/olympia/devhub/templates/devhub/personas/submit.html:167
 msgid "Select colors for your Theme."
 msgstr "Välj färger för ditt tema."
 
-#: src/olympia/devhub/templates/devhub/personas/edit.html:276
-#: src/olympia/devhub/templates/devhub/personas/submit.html:169
+#: src/olympia/devhub/templates/devhub/personas/edit.html:276 src/olympia/devhub/templates/devhub/personas/submit.html:169
 msgid "Foreground Text"
 msgstr "Förgrundstext"
 
-#: src/olympia/devhub/templates/devhub/personas/edit.html:277
-#: src/olympia/devhub/templates/devhub/personas/submit.html:170
+#: src/olympia/devhub/templates/devhub/personas/edit.html:277 src/olympia/devhub/templates/devhub/personas/submit.html:170
 msgid "This is the color of the tab text."
 msgstr "Detta är textfärgen på fliken."
 
-#: src/olympia/devhub/templates/devhub/personas/edit.html:279
-#: src/olympia/devhub/templates/devhub/personas/submit.html:172
+#: src/olympia/devhub/templates/devhub/personas/edit.html:279 src/olympia/devhub/templates/devhub/personas/submit.html:172
 msgid "Background"
 msgstr "Bakgrund"
 
-#: src/olympia/devhub/templates/devhub/personas/edit.html:280
-#: src/olympia/devhub/templates/devhub/personas/submit.html:173
+#: src/olympia/devhub/templates/devhub/personas/edit.html:280 src/olympia/devhub/templates/devhub/personas/submit.html:173
 msgid "This is the color of the tabs."
 msgstr "Detta är färgen på flikarna."
 
-#: src/olympia/devhub/templates/devhub/personas/edit.html:285
-#: src/olympia/devhub/templates/devhub/personas/submit.html:178
+#: src/olympia/devhub/templates/devhub/personas/edit.html:285 src/olympia/devhub/templates/devhub/personas/submit.html:178
 msgid "Preview"
 msgstr "Förhandsvisa"
 
-#: src/olympia/devhub/templates/devhub/personas/edit.html:291
-#: src/olympia/devhub/templates/devhub/personas/submit.html:183
+#: src/olympia/devhub/templates/devhub/personas/edit.html:291 src/olympia/devhub/templates/devhub/personas/submit.html:183
 msgid "Your Theme's Name"
 msgstr "Ditt temas namn"
 
-#: src/olympia/devhub/templates/devhub/personas/edit.html:294
-#: src/olympia/devhub/templates/devhub/personas/submit.html:186
+#: src/olympia/devhub/templates/devhub/personas/edit.html:294 src/olympia/devhub/templates/devhub/personas/submit.html:186
 #, python-format
 msgid "by <a href=\"%(profile_url)s\" target=\"_blank\">%(user)s</a>"
 msgstr "av <a href=\"%(profile_url)s\" target=\"_blank\">%(user)s</a>"
@@ -8633,75 +6686,39 @@ msgstr "Skapa ett nytt tema"
 
 #: src/olympia/devhub/templates/devhub/personas/submit.html:18
 #, python-format
-msgid ""
-"Background themes let you easily personalize the look of your Firefox. "
-"Submit your own design below, or <a href=\"%(submit_url)s\">learn how to "
-"create one</a>!"
-msgstr ""
-"Med bakgrundsteman kan du enkelt anpassa utseendet på Firefox. Skicka in din"
-" egen design nedan eller <a href=\"%(submit_url)s\">lär dig att skapa "
-"en</a>!"
+msgid "Background themes let you easily personalize the look of your Firefox. Submit your own design below, or <a href=\"%(submit_url)s\">learn how to create one</a>!"
+msgstr "Med bakgrundsteman kan du enkelt anpassa utseendet på Firefox. Skicka in din egen design nedan eller <a href=\"%(submit_url)s\">lär dig att skapa en</a>!"
 
 #: src/olympia/devhub/templates/devhub/personas/submit.html:33
 msgid "Give your Theme a name."
 msgstr "Ge ditt tema ett namn."
 
-#: src/olympia/devhub/templates/devhub/personas/submit.html:54
-msgid ""
-"A short explanation of your theme's\n"
-"                                      basic functionality that is displayed in\n"
-"                                      search and browse listings, as well as at\n"
-"                                      the top of your theme's details page."
-msgstr ""
-"En kort förklaring av ditt temas\n"
-"                                grundläggande funktionalitet som visas i\n"
-"                                sök- och bläddringslistor, liksom överst i\n"
-"                                ditt temas detaljsida."
-
 #: src/olympia/devhub/templates/devhub/personas/submit.html:198
 #, python-format
 msgid ""
-"I agree to the <a href=\"%(agreement_url)s\" target=\"_blank\">Firefox Add-"
-"on Distribution Agreement</a> and to my information being handled as "
-"described in the <a href=\"%(privacy_notice_url)s\" "
+"I agree to the <a href=\"%(agreement_url)s\" target=\"_blank\">Firefox Add-on Distribution Agreement</a> and to my information being handled as described in the <a href=\"%(privacy_notice_url)s\" "
 "target=\"_blank\">Websites, Communications and Cookies Privacy Notice</a>."
 msgstr ""
-"Jag godkänner <a href=\"%(agreement_url)s\" target=\"_blank\">Firefox "
-"distributionsavtal för tilägg</a> och min information hanteras enligt "
-"beskrivningen i <a href=\"%(privacy_notice_url)s\" "
-"target=\"_blank\">sekretesspolicyn för webbplatser, kommunikation och "
-"kakor</a>."
+"Jag godkänner <a href=\"%(agreement_url)s\" target=\"_blank\">Firefox distributionsavtal för tilägg</a> och min information hanteras enligt beskrivningen i <a href=\"%(privacy_notice_url)s\" target="
+"\"_blank\">sekretesspolicyn för webbplatser, kommunikation och kakor</a>."
 
 #: src/olympia/devhub/templates/devhub/personas/submit.html:205
 msgid "Submit Theme"
 msgstr "Skicka in tema"
 
 #: src/olympia/devhub/templates/devhub/personas/submit_done.html:11
-msgid ""
-"Your theme has been submitted to the Review Queue. You'll receive an email "
-"once it has been reviewed, typically within 24 hours."
-msgstr ""
-"Ditt tema har skickats in till granskningskön. Du får ett mejl när den har "
-"granskats, normalt inom 24 timmar."
+msgid "Your theme has been submitted to the Review Queue. You'll receive an email once it has been reviewed, typically within 24 hours."
+msgstr "Ditt tema har skickats in till granskningskön. Du får ett mejl när den har granskats, normalt inom 24 timmar."
 
 #: src/olympia/devhub/templates/devhub/personas/submit_done.html:19
 #, python-format
-msgid ""
-"Provide more details about your theme by <a href=\"%(edit_url)s\">editing "
-"its listing</a>."
-msgstr ""
-"Ge mer information om ditt tema genom att <a href=\"%(edit_url)s\">redigera "
-"dess listning</a>."
+msgid "Provide more details about your theme by <a href=\"%(edit_url)s\">editing its listing</a>."
+msgstr "Ge mer information om ditt tema genom att <a href=\"%(edit_url)s\">redigera dess listning</a>."
 
 #: src/olympia/devhub/templates/devhub/personas/submit_done.html:25
 #, python-format
-msgid ""
-"View and subscribe to your theme's <a href=\"%(feed_url)s\">activity "
-"feed</a> to stay updated on reviews, collections, and more."
-msgstr ""
-"Visa och prenumerera på ditt temas <a "
-"href=\"%(feed_url)s\">aktivitetsflöde</a> för att hålla dig uppdaterad på "
-"recensioner, samlingar och mer."
+msgid "View and subscribe to your theme's <a href=\"%(feed_url)s\">activity feed</a> to stay updated on reviews, collections, and more."
+msgstr "Visa och prenumerera på ditt temas <a href=\"%(feed_url)s\">aktivitetsflöde</a> för att hålla dig uppdaterad på recensioner, samlingar och mer."
 
 #: src/olympia/devhub/templates/devhub/personas/submit_done.html:32
 #, python-format
@@ -8716,13 +6733,11 @@ msgstr "Välj en bild för ditt tema till sidhuvudet."
 msgid "3000 &times; 200 pixels"
 msgstr "3000 &times; 200 pixlar"
 
-#: src/olympia/devhub/templates/devhub/personas/includes/theme_design.html:9
-#: src/olympia/devhub/templates/devhub/personas/includes/theme_design.html:25
+#: src/olympia/devhub/templates/devhub/personas/includes/theme_design.html:9 src/olympia/devhub/templates/devhub/personas/includes/theme_design.html:25
 msgid "300 KB max"
 msgstr "Max 300 kB"
 
-#: src/olympia/devhub/templates/devhub/personas/includes/theme_design.html:10
-#: src/olympia/devhub/templates/devhub/personas/includes/theme_design.html:26
+#: src/olympia/devhub/templates/devhub/personas/includes/theme_design.html:10 src/olympia/devhub/templates/devhub/personas/includes/theme_design.html:26
 msgid "PNG or JPG"
 msgstr "PNG eller JPG"
 
@@ -8751,60 +6766,26 @@ msgid "Select a different footer image"
 msgstr "Välj en annan bild för sidfot"
 
 #: src/olympia/devhub/templates/devhub/versions/add_file_modal.html:8
-msgid ""
-"Files added to reviewed versions must be reviewed before they will be "
-"available for download."
-msgstr ""
-"Filer som läggs till granskade versioner måste granskas innan de kommer att "
-"finnas tillgängliga för nedladdning."
+msgid "Files added to reviewed versions must be reviewed before they will be available for download."
+msgstr "Filer som läggs till granskade versioner måste granskas innan de kommer att finnas tillgängliga för nedladdning."
 
-#: src/olympia/devhub/templates/devhub/versions/add_file_modal.html:15
-#, python-format
-msgid ""
-"Submission of updates to unlisted add-ons for signing is currently in an "
-"open beta. Manual review may still be required for a large number of add-"
-"ons. Please <a href=\"%(url)s\" target=\"_blank\">report any bugs</a> that "
-"you encounter."
-msgstr ""
-"Att skicka in uppdateringar till olistade tillägg för signering befinner sig"
-" i en öppen beta. Manuell granskning kan fortfarande krävas för ett stort "
-"antal tillägg. <a href=\"%(url)s\" target=\"_blank\">Rapportera eventuella "
-"buggar</a> som du stöter på."
-
-#: src/olympia/devhub/templates/devhub/versions/add_file_modal.html:35
+#: src/olympia/devhub/templates/devhub/versions/add_file_modal.html:24
 msgid "Select the target platform for this file."
 msgstr "Välj målplattform för den här filen."
 
-#: src/olympia/devhub/templates/devhub/versions/add_file_modal.html:46
+#: src/olympia/devhub/templates/devhub/versions/add_file_modal.html:35
 msgid "Which review type would you like to nominate for?"
 msgstr "Vilken granskningstyp vill du nominera för?"
 
-#: src/olympia/devhub/templates/devhub/versions/add_file_modal.html:51
+#: src/olympia/devhub/templates/devhub/versions/add_file_modal.html:40
 msgid "Only publish this version to my beta channel."
 msgstr "Publicera endast denna version till min beta kanal."
-
-#: src/olympia/devhub/templates/devhub/versions/add_file_modal.html:54
-#, python-format
-msgid ""
-"The behavior of the beta channel has changed to accommodate <a "
-"href=\"%(addon_signing_url)s\" target=\"_blank\">mandatory add-on "
-"signing</a>. The new process is currently in an open beta, and may change "
-"significantly in the near future. Please <a href=\"%(issues_url)s\" "
-"target=\"_blank\">report any bugs</a> that you encounter."
-msgstr ""
-"Beteendet hos betakanalen har ändrats för att passa <a "
-"href=\"%(addon_signing_url)s\" target=\"_blank\">obligatorisk "
-"tilläggssignering</a>. Den nya processen är för närvarande i en öppen beta "
-"och kan komma att ändras avsevärt inom en snar framtid. <a "
-"href=\"%(issues_url)s\" target=\"_blank\">Rapportera eventuella buggar</a> "
-"som du stöter på."
 
 #: src/olympia/devhub/templates/devhub/versions/edit.html:5
 msgid "Manage Version {0}"
 msgstr "Hantera version {0}"
 
-#: src/olympia/devhub/templates/devhub/versions/edit.html:12
-#: src/olympia/devhub/templates/devhub/versions/list.html:3
+#: src/olympia/devhub/templates/devhub/versions/edit.html:12 src/olympia/devhub/templates/devhub/versions/list.html:3
 msgid "Status & Versions"
 msgstr "Status & versioner"
 
@@ -8821,22 +6802,10 @@ msgstr "Filer"
 msgid "Upload Another File"
 msgstr "Ladda upp en annan fil"
 
-#: src/olympia/devhub/templates/devhub/versions/edit.html:45
-msgid ""
-"Adjusting application information here will allow users to install your\n"
-"                          add-on even if the install manifest in the package indicates that the\n"
-"                          add-on is incompatible."
-msgstr ""
-"Genom att justera programinformation här kommer att tillåta användaren att installera\n"
-"                          ditt tillägg, även om installationens manifest i paketet indikerar att\n"
-"                          tillägget inte är kompatibla."
-
 #: src/olympia/devhub/templates/devhub/versions/edit.html:74
 msgid ""
-"Information about changes in this release, new features,\n"
-"                              known bugs, and other useful information specific to this\n"
-"                              release/version. This information is also shown in the\n"
-"                              Add-ons Manager when updating."
+"Information about changes in this release, new features, known bugs, and other useful information specific to this release/version. This information is also shown in the Add-ons Manager when "
+"updating."
 msgstr ""
 "Information om ändringar i denna utgåva, nya funktioner,\n"
 "                              kända buggar och annan nyttig information som är specifika för denna\n"
@@ -8847,16 +6816,12 @@ msgstr ""
 msgid "Approval Status"
 msgstr "Godkännandestatus"
 
-#: src/olympia/devhub/templates/devhub/versions/edit.html:113
-#: src/olympia/editors/templates/editors/review.html:108
+#: src/olympia/devhub/templates/devhub/versions/edit.html:113 src/olympia/editors/templates/editors/review.html:108
 msgid "Notes for Reviewers"
 msgstr "Anteckning för granskare"
 
 #: src/olympia/devhub/templates/devhub/versions/edit.html:114
-msgid ""
-"Optionally, enter any information that may be useful\n"
-"                              to the Editor reviewing this add-on, such as test\n"
-"                              account information."
+msgid "Optionally, enter any information that may be useful to the Editor reviewing this add-on, such as test account information."
 msgstr ""
 "Du kan även ange all information som kan vara användbar\n"
 "                              till redaktören som ska granska detta tillägg, såsom\n"
@@ -8867,15 +6832,10 @@ msgid "Source code"
 msgstr "Källkod"
 
 #: src/olympia/devhub/templates/devhub/versions/edit.html:128
-msgid ""
-"If your add-on contain binary or obfuscated code, make the source available "
-"here for reviewers."
-msgstr ""
-"Om ditt tillägg innehåller binär eller förvrängd kod, gör källan tillgänglig"
-" här för granskarna."
+msgid "If your add-on contain binary or obfuscated code, make the source available here for reviewers."
+msgstr "Om ditt tillägg innehåller binär eller förvrängd kod, gör källan tillgänglig här för granskarna."
 
-#: src/olympia/devhub/templates/devhub/versions/edit.html:145
-#: src/olympia/devhub/templates/devhub/versions/edit.html:149
+#: src/olympia/devhub/templates/devhub/versions/edit.html:145 src/olympia/devhub/templates/devhub/versions/edit.html:149
 msgid "Upload a new file"
 msgstr "Ladda upp en ny fil"
 
@@ -8942,9 +6902,7 @@ msgstr "Begär fullständig granskning"
 msgid "Request Preliminary Review"
 msgstr "Begär preliminär granskning"
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:80
-#: src/olympia/devhub/templates/devhub/versions/list.html:327
-#: src/olympia/devhub/templates/devhub/versions/list.html:350
+#: src/olympia/devhub/templates/devhub/versions/list.html:80 src/olympia/devhub/templates/devhub/versions/list.html:325 src/olympia/devhub/templates/devhub/versions/list.html:348
 msgid "Cancel Review Request"
 msgstr "Avbryt begärd granskning"
 
@@ -8957,8 +6915,7 @@ msgid "Listed:"
 msgstr "Listad:"
 
 #: src/olympia/devhub/templates/devhub/versions/list.html:102
-msgid ""
-"Visible to everyone on {0} and included in search results and listing pages"
+msgid "Visible to everyone on {0} and included in search results and listing pages"
 msgstr "Synlig för alla på {0} och ingår i sökresultaten och listningssidor"
 
 #: src/olympia/devhub/templates/devhub/versions/list.html:108
@@ -8966,24 +6923,16 @@ msgid "Hidden:"
 msgstr "Dold:"
 
 #: src/olympia/devhub/templates/devhub/versions/list.html:108
-msgid ""
-"Hosted on {0}, but hidden to anyone but authors. Used to temporarily hide "
-"listings or discontinue them."
-msgstr ""
-"Finns på {0}, men dold för andra utom för författarna. Används för att "
-"tillfälligt dölja listning eller avbryta dem."
+msgid "Hosted on {0}, but hidden to anyone but authors. Used to temporarily hide listings or discontinue them."
+msgstr "Finns på {0}, men dold för andra utom för författarna. Används för att tillfälligt dölja listning eller avbryta dem."
 
 #: src/olympia/devhub/templates/devhub/versions/list.html:114
 msgid "Unlisted:"
 msgstr "Olistad:"
 
 #: src/olympia/devhub/templates/devhub/versions/list.html:114
-msgid ""
-"Not distributed on {0}. Developers will upload new versions for signing and "
-"distribute the add-ons on their own. (beta)"
+msgid "Not distributed on {0}. Developers will upload new versions for signing and distribute the add-ons on their own."
 msgstr ""
-"Inte distribuerad till {0}. Utvecklare kommer att ladda upp nya versioner "
-"för undertecknande och distribuera tillägg på egen hand. (beta)"
 
 #: src/olympia/devhub/templates/devhub/versions/list.html:122
 msgid "Current versions"
@@ -8993,17 +6942,12 @@ msgstr "Nuvarande versioner"
 msgid "Currently on AMO"
 msgstr "För närvarande på AMO"
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:129
-#: src/olympia/devhub/templates/devhub/versions/list.html:147
-#: src/olympia/devhub/templates/devhub/versions/list.html:164
-#: src/olympia/editors/templates/editors/includes/search_results_themes.html:7
-#: src/olympia/editors/templates/editors/themes/queue_list.html:50
+#: src/olympia/devhub/templates/devhub/versions/list.html:129 src/olympia/devhub/templates/devhub/versions/list.html:147 src/olympia/devhub/templates/devhub/versions/list.html:164
+#: src/olympia/editors/templates/editors/includes/search_results_themes.html:7 src/olympia/editors/templates/editors/themes/queue_list.html:50
 msgid "Status"
 msgstr "Status"
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:130
-#: src/olympia/devhub/templates/devhub/versions/list.html:148
-#: src/olympia/devhub/templates/devhub/versions/list.html:165
+#: src/olympia/devhub/templates/devhub/versions/list.html:130 src/olympia/devhub/templates/devhub/versions/list.html:148 src/olympia/devhub/templates/devhub/versions/list.html:165
 #: src/olympia/editors/templates/editors/includes/files_view.html:11
 msgid "Validation"
 msgstr "Validering"
@@ -9025,14 +6969,10 @@ msgid "Full review may not be required"
 msgstr "Fullständig granskning kanske inte krävs"
 
 #: src/olympia/devhub/templates/devhub/versions/list.html:201
-msgid ""
-"Unlisted add-ons don't need Full Review unless they are distributed as part "
-"of an application installer. Read <a href=\"{link}\" target=\"_blank\">this "
-"documentation</a> for more information."
+msgid "Unlisted add-ons don't need Full Review unless they are distributed as part of an application installer. Read <a href=\"{link}\" target=\"_blank\">this documentation</a> for more information."
 msgstr ""
-"Olistade tillägg behöver inte fullständig granskning såvida de distribueras "
-"som en del av ett installationsprogram. Läs <a href=\"{link}\" "
-"target=\"_blank\">denna dokumentation</a> för mer information."
+"Olistade tillägg behöver inte fullständig granskning såvida de distribueras som en del av ett installationsprogram. Läs <a href=\"{link}\" target=\"_blank\">denna dokumentation</a> för mer "
+"information."
 
 #: src/olympia/devhub/templates/devhub/versions/list.html:209
 msgid "Request full review"
@@ -9044,135 +6984,91 @@ msgstr "Ta bort version {version}"
 
 #: src/olympia/devhub/templates/devhub/versions/list.html:218
 msgid ""
-"You are about to delete the current version of your add-on. This may cause "
-"your add-on status to change, or your listing to lose public visibility, if "
-"this is the only public version of your add-on."
+"You are about to delete the current version of your add-on. This may cause your add-on status to change, or your listing to lose public visibility, if this is the only public version of your add-on."
 msgstr ""
-"Du är på väg att ta bort den nuvarande versionen av ditt tillägg. Detta kan "
-"leda till att tilläggets status ändras eller din listning förloras, om detta"
-" är den enda offentliga versionen av tillägget."
+"Du är på väg att ta bort den nuvarande versionen av ditt tillägg. Detta kan leda till att tilläggets status ändras eller din listning förloras, om detta är den enda offentliga versionen av "
+"tillägget."
 
 #: src/olympia/devhub/templates/devhub/versions/list.html:219
 msgid "Deleting this version will permanently delete:"
 msgstr "Tar bort den här versionen kommer att permanent ta bort:"
 
 #: src/olympia/devhub/templates/devhub/versions/list.html:225
-msgid ""
-"<strong>Important:</strong> Once a version has been deleted, you may not "
-"upload a new version with the same version number."
-msgstr ""
-"<strong>Viktigt:</strong> När en version har tagits bort, kan du inte ladda "
-"upp en ny version med samma versionsnummer."
+msgid "<strong>Important:</strong> Once a version has been deleted, you may not upload a new version with the same version number."
+msgstr "<strong>Viktigt:</strong> När en version har tagits bort, kan du inte ladda upp en ny version med samma versionsnummer."
 
 #: src/olympia/devhub/templates/devhub/versions/list.html:230
-msgid ""
-"Deleting a version which has already been reviewed\n"
-"               may also cause a significant delay in the review of\n"
-"               your next update."
-msgstr ""
-"Ta bort en version som redan har granskats\n"
-"               kan också orsaka en signifikant fördröjning i granskningen av\n"
-"               din nästa uppdatering."
-
-#: src/olympia/devhub/templates/devhub/versions/list.html:233
 msgid "Are you sure you wish to delete this version?"
 msgstr "Är du säker på att du vill ta bort denna version?"
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:238
+#: src/olympia/devhub/templates/devhub/versions/list.html:235
 msgid "Delete Version"
 msgstr "Ta bort version"
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:240
+#: src/olympia/devhub/templates/devhub/versions/list.html:237
 msgid "Disable Version"
 msgstr "Inaktivera version"
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:247
+#: src/olympia/devhub/templates/devhub/versions/list.html:244
 msgid "Add a new Version"
 msgstr "Lägg till en ny version"
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:249
+#: src/olympia/devhub/templates/devhub/versions/list.html:246
 msgid "Add Version"
 msgstr "Lägg till version"
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:256
-#: src/olympia/devhub/templates/devhub/versions/list.html:274
+#: src/olympia/devhub/templates/devhub/versions/list.html:253 src/olympia/devhub/templates/devhub/versions/list.html:279
 msgid "Hide Add-on"
 msgstr "Dölj tillägg"
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:259
-msgid ""
-"Hiding your add-on will prevent it from appearing anywhere in our gallery "
-"and will stop users from receiving automatic updates."
-msgstr ""
-"Dölja ditt tillägg kommer att hindra den från att visas i vårt galleri och "
-"kommer att stoppa användare från att ta emot automatiska uppdateringar."
+#: src/olympia/devhub/templates/devhub/versions/list.html:256
+msgid "Hiding your add-on will prevent it from appearing anywhere in our gallery and will stop users from receiving automatic updates."
+msgstr "Dölja ditt tillägg kommer att hindra den från att visas i vårt galleri och kommer att stoppa användare från att ta emot automatiska uppdateringar."
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:265
+#: src/olympia/devhub/templates/devhub/versions/list.html:263
+msgid "The files awaiting review will be disabled and you will need to upload new versions."
+msgstr ""
+
+#: src/olympia/devhub/templates/devhub/versions/list.html:270
 msgid "Are you sure you wish to hide your add-on?"
 msgstr "Är du säker på att du vill dölja ditt tillägg?"
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:286
-#: src/olympia/devhub/templates/devhub/versions/list.html:315
+#: src/olympia/devhub/templates/devhub/versions/list.html:291 src/olympia/devhub/templates/devhub/versions/list.html:313
 msgid "Unlist Add-on"
 msgstr "Lista ej tillägg"
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:289
+#: src/olympia/devhub/templates/devhub/versions/list.html:294
 #, python-format
 msgid ""
-"Unlisting your add-on will make it (and each of its versions/files) "
-"invisible on this website. It won't show up in searches, won't have a public"
-" facing page, and won't be updated automatically for current users.  It is "
-"recommended for unlisted add-ons to provide a custom <a "
-"href=\"%(update_url)s\" target=\"_blank\">updateURL</a> in their manifest "
-"file for automatic updates."
+"Unlisting your add-on will make it (and each of its versions/files) invisible on this website. It won't show up in searches, won't have a public facing page, and won't be updated automatically for "
+"current users. It is recommended for unlisted add-ons to provide a custom <a href=\"%(update_url)s\" target=\"_blank\">updateURL</a> in their manifest file for automatic updates."
 msgstr ""
-"Olistning av ditt tillägg kommer att göra det (och var och en av dess "
-"versioner/filer) osynliga på denna webbplats. Det kommer inte att dyka upp i"
-" sökningar, kommer inte att ha en publik sida och kommer inte att uppdateras"
-" automatiskt för befintliga användare.  Det rekommenderas för olistade "
-"tillägg att ange en anpassad <a href=\"%(update_url)s\" target=\"_blank"
-"\">uppdaterings-URL</a> i sin manifestfil för automatiska uppdateringar."
+"Olistning av ditt tillägg kommer att göra det (och var och en av dess versioner/filer) osynliga på denna webbplats. Det kommer inte att dyka upp i sökningar, kommer inte att ha en publik sida och "
+"kommer inte att uppdateras automatiskt för befintliga användare.  Det rekommenderas för olistade tillägg att ange en anpassad <a href=\"%(update_url)s\" target=\"_blank\">uppdaterings-URL</a> i sin "
+"manifestfil för automatiska uppdateringar."
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:299
-#, python-format
-msgid ""
-"Switching add-ons to unlisted is currently in an open beta. Please <a "
-"href=\"%(url)s\" target=\"_blank\">report any bugs</a> that you encounter."
-msgstr ""
-"Ändra tillägg till olistad befinner sig i en öppen beta. <a href=\"%(url)s\""
-" target=\"_blank\">Rapportera eventuella buggar</a> som du stöter på."
-
-#: src/olympia/devhub/templates/devhub/versions/list.html:305
+#: src/olympia/devhub/templates/devhub/versions/list.html:303
 msgid "Unlisting an add-on is irreversible!"
 msgstr "Olistning av ett tillägg är bestående!"
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:305
+#: src/olympia/devhub/templates/devhub/versions/list.html:303
 msgid "An unlisted add-on cannot be switched to be listed."
 msgstr "Ett olistat tillägg kan inte ändras till att bli listad."
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:307
+#: src/olympia/devhub/templates/devhub/versions/list.html:305
 msgid "Are you sure you wish to unlist your add-on?"
 msgstr "Är du säker på att du vill olista ditt tillägg?"
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:330
-msgid ""
-"Canceling your review request will leave your add-on as preliminarily "
-"reviewed."
-msgstr ""
-"Avbryta din begäran om granskning kommer att lämna ditt tillägg som "
-"preliminärt granskad."
+#: src/olympia/devhub/templates/devhub/versions/list.html:328
+msgid "Canceling your review request will leave your add-on as preliminarily reviewed."
+msgstr "Avbryta din begäran om granskning kommer att lämna ditt tillägg som preliminärt granskad."
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:335
-msgid ""
-"Canceling your review request will mark your add-on incomplete. If you do "
-"not complete your add-on after several days by re-requesting review, it will"
-" be deleted."
+#: src/olympia/devhub/templates/devhub/versions/list.html:333
+msgid "Canceling your review request will mark your add-on incomplete. If you do not complete your add-on after several days by re-requesting review, it will be deleted."
 msgstr ""
-"Avbryta din begäran om granskning kommer att markera ditt tillägg som "
-"ofullständig. Om du inte slutför ditt tillägg efter flera dagar genom att "
-"åter begära granskning, kommer det att tas bort."
+"Avbryta din begäran om granskning kommer att markera ditt tillägg som ofullständig. Om du inte slutför ditt tillägg efter flera dagar genom att åter begära granskning, kommer det att tas bort."
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:343
+#: src/olympia/devhub/templates/devhub/versions/list.html:341
 msgid "Are you sure you wish to cancel your review request?"
 msgstr "Är du säker på att du vill avbryta din begäran om granskning?"
 
@@ -9205,19 +7101,12 @@ msgid "Translate content on the web from and into over 40 languages."
 msgstr "Översätt innehåll på webben från och till över 40 språk."
 
 #: src/olympia/discovery/modules.py:171
-msgid ""
-"Easily connect to your social networks, and share or comment on the page "
-"you're visiting."
-msgstr ""
-"Anslut enkelt till dina sociala nätverk, och dela eller kommentera den sida "
-"du besöker."
+msgid "Easily connect to your social networks, and share or comment on the page you're visiting."
+msgstr "Anslut enkelt till dina sociala nätverk, och dela eller kommentera den sida du besöker."
 
 #: src/olympia/discovery/modules.py:173
-msgid ""
-"A quick view to compare prices when you shop online or search for flights."
-msgstr ""
-"En snabbtitt för att jämföra priser när du handlar på nätet eller söker "
-"efter flyg."
+msgid "A quick view to compare prices when you shop online or search for flights."
+msgstr "En snabbtitt för att jämföra priser när du handlar på nätet eller söker efter flyg."
 
 #: src/olympia/discovery/modules.py:183
 msgid "Firefox 4 Collection"
@@ -9260,24 +7149,16 @@ msgid "Add-ons that help you on your travels!"
 msgstr "Tillägg som hjälper dig på dina resor!"
 
 #: src/olympia/discovery/modules.py:226
-msgid ""
-"Displays a country flag depicting the location of the current website's "
-"server and more."
-msgstr ""
-"Visar en landsflagga som visar placeringen av den aktuella webbplatsen "
-"server och mer."
+msgid "Displays a country flag depicting the location of the current website's server and more."
+msgstr "Visar en landsflagga som visar placeringen av den aktuella webbplatsen server och mer."
 
 #: src/olympia/discovery/modules.py:228
 msgid "FoxClocks let you keep an eye on the time around the world."
 msgstr "FoxClocks låter dig hålla ett öga på tiden runt om i världen."
 
 #: src/olympia/discovery/modules.py:230
-msgid ""
-"Automatically get the lowest price when you shop online or search for "
-"flights."
-msgstr ""
-"Får automatiskt det lägsta priset när du handlar på nätet eller söker efter "
-"flyg."
+msgid "Automatically get the lowest price when you shop online or search for flights."
+msgstr "Får automatiskt det lägsta priset när du handlar på nätet eller söker efter flyg."
 
 #: src/olympia/discovery/modules.py:240
 msgid "A+ add-ons for School"
@@ -9316,12 +7197,8 @@ msgid "Put a Theme on It!"
 msgstr "Sätt ett tema på det!"
 
 #: src/olympia/discovery/modules.py:281
-msgid ""
-"Visit addons.mozilla.org from Firefox for Android and dress up your mobile "
-"browser to match your style, mood, or the season."
-msgstr ""
-"Besök addons.mozilla.org från Firefox för Android och klä upp din mobila "
-"webbläsare för att matcha din stil, humör eller säsongen."
+msgid "Visit addons.mozilla.org from Firefox for Android and dress up your mobile browser to match your style, mood, or the season."
+msgstr "Besök addons.mozilla.org från Firefox för Android och klä upp din mobila webbläsare för att matcha din stil, humör eller säsongen."
 
 #: src/olympia/discovery/modules.py:290
 msgid "Get up and move!"
@@ -9348,12 +7225,8 @@ msgid "Protect your privacy online with the add-ons in this collection."
 msgstr "Skydda din integritet på nätet med tillägg i denna samling."
 
 #: src/olympia/discovery/modules.py:342
-msgid ""
-"Great add-ons for work, fun, privacy, productivity&hellip; just about "
-"anything!"
-msgstr ""
-"Bra tillägg för arbete, nöje, integritet, produktivitet&hellip; precis vad "
-"som helst!"
+msgid "Great add-ons for work, fun, privacy, productivity&hellip; just about anything!"
+msgstr "Bra tillägg för arbete, nöje, integritet, produktivitet&hellip; precis vad som helst!"
 
 #: src/olympia/discovery/modules.py:350
 msgid "Add-ons for Australis Contest Winners"
@@ -9373,21 +7246,16 @@ msgstr "Vad är tillägg?"
 
 #: src/olympia/discovery/templates/discovery/pane.html:28
 #, python-format
-msgid ""
-"Add-ons are applications that let you personalize %(app)s with extra "
-"functionality or style. Try a time-saving sidebar, a weather notifier, or a "
-"themed look to make %(app)s your own."
+msgid "Add-ons are applications that let you personalize %(app)s with extra functionality or style. Try a time-saving sidebar, a weather notifier, or a themed look to make %(app)s your own."
 msgstr ""
-"Tillägg är applikationer som låter dig göra din %(app)s personlig med extra "
-"funktionalitet eller stil. Testa en sidopanel som sparar tid, en "
-"väderrapporterare eller ett temautseende för att ge %(app)s din egen stil."
+"Tillägg är applikationer som låter dig göra din %(app)s personlig med extra funktionalitet eller stil. Testa en sidopanel som sparar tid, en väderrapporterare eller ett temautseende för att ge "
+"%(app)s din egen stil."
 
 #: src/olympia/discovery/templates/discovery/pane.html:62
 msgid "Learn More About Add-ons"
 msgstr "Lär dig mer om tillägg"
 
-#: src/olympia/discovery/templates/discovery/pane.html:66
-#: src/olympia/discovery/templates/discovery/pane.html:73
+#: src/olympia/discovery/templates/discovery/pane.html:66 src/olympia/discovery/templates/discovery/pane.html:73
 msgid "See all"
 msgstr "Visa alla"
 
@@ -9418,12 +7286,8 @@ msgstr "Hej, {0}"
 
 #: src/olympia/discovery/templates/discovery/pane_account.html:17
 #, python-format
-msgid ""
-"Thanks for using %(app)s and supporting <a href=\"%(url)s\">Mozilla's "
-"mission</a>!"
-msgstr ""
-"Tack för att du använder %(app)s och bidrar till <a "
-"href=\"%(url)s\">Mozillas mission</a>!"
+msgid "Thanks for using %(app)s and supporting <a href=\"%(url)s\">Mozilla's mission</a>!"
+msgstr "Tack för att du använder %(app)s och bidrar till <a href=\"%(url)s\">Mozillas mission</a>!"
 
 #: src/olympia/discovery/templates/discovery/pane_account.html:23
 msgid "Add-ons downloaded:"
@@ -9447,14 +7311,10 @@ msgstr "Hämta tillägg på resande fot"
 
 #: src/olympia/discovery/templates/discovery/modules/go-mobile.html:8
 #, python-format
-msgid ""
-"Visit <a href=\"%(url)s\">firefox.com/m</a> to get Firefox on your phone and"
-" personalize your browser anytime, anywhere. Easily discover and install "
-"add-ons from the mobile Add-ons Manager."
+msgid "Visit <a href=\"%(url)s\">firefox.com/m</a> to get Firefox on your phone and personalize your browser anytime, anywhere. Easily discover and install add-ons from the mobile Add-ons Manager."
 msgstr ""
-"Besök <a href=\"%(url)s\">firefox.com/m</a> för att få Firefox till din "
-"telefon och anpassa webbläsaren när som helst, var som helst. Enkelt att "
-"upptäcka och installera tillägg från den mobila tilläggshanteraren."
+"Besök <a href=\"%(url)s\">firefox.com/m</a> för att få Firefox till din telefon och anpassa webbläsaren när som helst, var som helst. Enkelt att upptäcka och installera tillägg från den mobila "
+"tilläggshanteraren."
 
 #: src/olympia/discovery/templates/discovery/modules/go-mobile.html:13
 msgid "Get Mobile Add-ons"
@@ -9466,24 +7326,15 @@ msgstr "Handla smart den här julen"
 
 #: src/olympia/discovery/templates/discovery/modules/holiday.html:5
 msgid "Find great add-ons to help you with all your holiday shopping needs."
-msgstr ""
-"Hitta bra tillägg som hjälper dig med alla dina behov vid semestershopping."
+msgstr "Hitta bra tillägg som hjälper dig med alla dina behov vid semestershopping."
 
 #: src/olympia/discovery/templates/discovery/modules/holiday.html:13
-msgid ""
-"Install the Amazon Browser Apps and receive special Amazon features right at"
-" your fingertips."
-msgstr ""
-"Installera webbläsare appar från Amazon och få särskilda Amazon-funktioner i"
-" din hand."
+msgid "Install the Amazon Browser Apps and receive special Amazon features right at your fingertips."
+msgstr "Installera webbläsare appar från Amazon och få särskilda Amazon-funktioner i din hand."
 
 #: src/olympia/discovery/templates/discovery/modules/holiday.html:22
-msgid ""
-"Keep an eye on your eBay activity wherever you are on the web when you "
-"install the eBay Sidebar for Firefox."
-msgstr ""
-"Hålla ett öga på din eBay aktivitet var du än är på webben när du "
-"installerar eBay sidofältet för Firefox."
+msgid "Keep an eye on your eBay activity wherever you are on the web when you install the eBay Sidebar for Firefox."
+msgstr "Hålla ett öga på din eBay aktivitet var du än är på webben när du installerar eBay sidofältet för Firefox."
 
 #: src/olympia/discovery/templates/discovery/modules/holiday.html:31
 msgid "See the entire holiday shopping add-on collection."
@@ -9560,19 +7411,19 @@ msgstr "tillägg, editor eller kommentar"
 msgid "Search by add-on name / author email"
 msgstr "Sök efter tilläggsnamn / upphovsman e-post"
 
-#: src/olympia/editors/forms.py:103
+#: src/olympia/editors/forms.py:103 src/olympia/editors/forms.py:244 src/olympia/editors/forms.py:257
 msgid "yes"
 msgstr "ja"
 
-#: src/olympia/editors/forms.py:104
+#: src/olympia/editors/forms.py:104 src/olympia/editors/forms.py:244 src/olympia/editors/forms.py:257
 msgid "no"
 msgstr "nej"
 
-#: src/olympia/editors/forms.py:105
+#: src/olympia/editors/forms.py:105 src/olympia/editors/forms.py:245
 msgid "Admin Flag"
 msgstr "Administratörsflagga"
 
-#: src/olympia/editors/forms.py:113
+#: src/olympia/editors/forms.py:113 src/olympia/editors/forms.py:253
 msgid "Max. Version"
 msgstr "Max. Version"
 
@@ -9584,59 +7435,59 @@ msgstr "Dagar sedan inskickning"
 msgid "Add-on Types"
 msgstr "Tilläggstyper"
 
-#: src/olympia/editors/forms.py:126 src/olympia/editors/helpers.py:267
+#: src/olympia/editors/forms.py:126 src/olympia/editors/helpers.py:279
 msgid "Platforms"
 msgstr "Plattformar"
 
+#: src/olympia/editors/forms.py:237
+msgid "Search by add-on name / author email / guid"
+msgstr ""
+
 #. L10n: 0 = platform, 1 = filename, 2 = status message
-#: src/olympia/editors/forms.py:238
+#: src/olympia/editors/forms.py:342
 #, python-format
 msgid "<strong>%s</strong> &middot; %s &middot; %s"
 msgstr "<strong>%s</strong> &middot; %s &middot; %s"
 
-#: src/olympia/editors/forms.py:252
+#: src/olympia/editors/forms.py:356
 msgid "Comments:"
 msgstr "Kommentarer:"
 
-#: src/olympia/editors/forms.py:256
+#: src/olympia/editors/forms.py:360
 msgid "Operating systems:"
 msgstr "Operativsystem:"
 
-#: src/olympia/editors/forms.py:258
+#: src/olympia/editors/forms.py:362
 msgid "Applications:"
 msgstr "Applikationer:"
 
-#: src/olympia/editors/forms.py:260
-msgid ""
-"Notify me the next time this add-on is updated. (Subsequent updates will not"
-" generate an email)"
-msgstr ""
-"Meddela mig nästa gång detta tillägg uppdateras. (Senare uppdateringar "
-"kommer inte att generera ett e-postmeddelande)"
+#: src/olympia/editors/forms.py:364
+msgid "Notify me the next time this add-on is updated. (Subsequent updates will not generate an email)"
+msgstr "Meddela mig nästa gång detta tillägg uppdateras. (Senare uppdateringar kommer inte att generera ett e-postmeddelande)"
 
-#: src/olympia/editors/forms.py:265
+#: src/olympia/editors/forms.py:369
 msgid "Clear Admin Review Flag"
 msgstr "Rensa administratörs granskningsflagga"
 
-#: src/olympia/editors/forms.py:267
+#: src/olympia/editors/forms.py:371
 msgid "Clear more info requested flag"
 msgstr "Rensa flaggan för mer information begärd"
 
-#: src/olympia/editors/forms.py:281
+#: src/olympia/editors/forms.py:385
 msgid "Choose a canned response..."
 msgstr "Välj ett standardsvar..."
 
 #. L10n: Description of what can be searched for.
-#: src/olympia/editors/forms.py:324
+#: src/olympia/editors/forms.py:423
 msgid "theme name"
 msgstr "namn på tema"
 
-#: src/olympia/editors/forms.py:350
+#: src/olympia/editors/forms.py:449
 msgid "Someone else is reviewing this theme."
 msgstr "Någon annan granskar detta tema."
 
 #. L10n: Description of what can be searched for.
-#: src/olympia/editors/forms.py:447
+#: src/olympia/editors/forms.py:546
 msgid "app, reviewer, or comment"
 msgstr "app, granskare eller kommentar"
 
@@ -9652,294 +7503,266 @@ msgstr "Väntande preliminär granskning"
 msgid "Rejected or Unreviewed"
 msgstr "Avvisad och ogranskad"
 
-#: src/olympia/editors/helpers.py:123 src/olympia/editors/helpers.py:136
+#: src/olympia/editors/helpers.py:125 src/olympia/editors/helpers.py:138
 msgid "Queue"
 msgstr "Kö"
 
-#: src/olympia/editors/helpers.py:124
-#: src/olympia/editors/templates/editors/base.html:50
-#: src/olympia/editors/templates/editors/base.html:65
+#: src/olympia/editors/helpers.py:126 src/olympia/editors/templates/editors/base.html:50 src/olympia/editors/templates/editors/base.html:65
 msgid "Pending Updates"
 msgstr "Väntande uppdateringar"
 
-#: src/olympia/editors/helpers.py:125
-#: src/olympia/editors/templates/editors/base.html:48
-#: src/olympia/editors/templates/editors/base.html:63
+#: src/olympia/editors/helpers.py:127 src/olympia/editors/templates/editors/base.html:48 src/olympia/editors/templates/editors/base.html:63
 msgid "Full Reviews"
 msgstr "Fullständig granskning"
 
-#: src/olympia/editors/helpers.py:126
-#: src/olympia/editors/templates/editors/base.html:52
-#: src/olympia/editors/templates/editors/base.html:67
+#: src/olympia/editors/helpers.py:128 src/olympia/editors/templates/editors/base.html:52 src/olympia/editors/templates/editors/base.html:67
 msgid "Preliminary Reviews"
 msgstr "Preliminära granskningar"
 
-#: src/olympia/editors/helpers.py:127
-#: src/olympia/editors/templates/editors/base.html:54
+#: src/olympia/editors/helpers.py:129 src/olympia/editors/templates/editors/base.html:54
 msgid "Moderated Reviews"
 msgstr "Modererade granskningar"
 
-#: src/olympia/editors/helpers.py:128
-#: src/olympia/editors/templates/editors/base.html:46
+#: src/olympia/editors/helpers.py:130 src/olympia/editors/templates/editors/base.html:46
 msgid "Fast Track"
 msgstr "Snabbspår"
 
-#: src/olympia/editors/helpers.py:130
+#: src/olympia/editors/helpers.py:132
 msgid "Pending Themes"
 msgstr "Väntande teman"
 
-#: src/olympia/editors/helpers.py:131
-#: src/olympia/editors/templates/editors/themes/queue.html:4
+#: src/olympia/editors/helpers.py:133 src/olympia/editors/templates/editors/themes/queue.html:4
 msgid "Flagged Themes"
 msgstr "Flaggade teman"
 
-#: src/olympia/editors/helpers.py:132
+#: src/olympia/editors/helpers.py:134
 msgid "Update Themes"
 msgstr "Uppdatera teman"
 
-#: src/olympia/editors/helpers.py:137
+#: src/olympia/editors/helpers.py:139
 msgid "Unlisted Pending Updates"
 msgstr "Olistad vändande uppdateringar"
 
-#: src/olympia/editors/helpers.py:138
+#: src/olympia/editors/helpers.py:140
 msgid "Unlisted Full Reviews"
 msgstr "Olistad fullständig granskning"
 
-#: src/olympia/editors/helpers.py:139
+#: src/olympia/editors/helpers.py:141
 msgid "Unlisted Preliminary Reviews"
 msgstr "Olistad preliminär granskning"
 
-#: src/olympia/editors/helpers.py:170
+#: src/olympia/editors/helpers.py:142
+msgid "Unlisted All Add-ons"
+msgstr ""
+
+#: src/olympia/editors/helpers.py:173
 msgid "Fast Track ({0})"
 msgid_plural "Fast Track ({0})"
 msgstr[0] "Snabbspår ({0})"
 msgstr[1] "Snabbspår ({0})"
 
-#: src/olympia/editors/helpers.py:175
+#: src/olympia/editors/helpers.py:178
 msgid "Full Review ({0})"
 msgid_plural "Full Reviews ({0})"
 msgstr[0] "Fullständig granskning ({0})"
 msgstr[1] "Fullständiga granskningar ({0})"
 
-#: src/olympia/editors/helpers.py:180
+#: src/olympia/editors/helpers.py:183
 msgid "Pending Update ({0})"
 msgid_plural "Pending Updates ({0})"
 msgstr[0] "Väntande uppdatering({0})"
 msgstr[1] "Väntande uppdateringar({0})"
 
-#: src/olympia/editors/helpers.py:185
+#: src/olympia/editors/helpers.py:188
 msgid "Preliminary Review ({0})"
 msgid_plural "Preliminary Reviews ({0})"
 msgstr[0] "Preliminär granskning({0})"
 msgstr[1] "Preliminära granskningar({0})"
 
-#: src/olympia/editors/helpers.py:190
+#: src/olympia/editors/helpers.py:193
 msgid "Moderated Review ({0})"
 msgid_plural "Moderated Reviews ({0})"
 msgstr[0] "Modererad granskning({0})"
 msgstr[1] "Modererade granskningar({0})"
 
-#: src/olympia/editors/helpers.py:196
+#: src/olympia/editors/helpers.py:199
 msgid "Unlisted Full Review ({0})"
 msgid_plural "Unlisted Full Reviews ({0})"
 msgstr[0] "Olistad fullständig granskning ({0})"
 msgstr[1] "Olistad fullständiga granskningar ({0})"
 
-#: src/olympia/editors/helpers.py:201
+#: src/olympia/editors/helpers.py:204
 msgid "Unlisted Pending Update ({0})"
 msgid_plural "Unlisted Pending Updates ({0})"
 msgstr[0] "Olistad väntande uppdatering ({0})"
 msgstr[1] "Olistad väntande uppdateringar ({0})"
 
-#: src/olympia/editors/helpers.py:206
+#: src/olympia/editors/helpers.py:209
 msgid "Unlisted Preliminary Review ({0})"
 msgid_plural "Unlisted Preliminary Reviews ({0})"
 msgstr[0] "Olistad preliminär granskning ({0})"
 msgstr[1] "Olistad preliminära granskningar ({0})"
 
-#: src/olympia/editors/helpers.py:261
-msgid "Addon"
-msgstr "Tillägg"
+#: src/olympia/editors/helpers.py:214
+msgid "Unlisted All Add-ons ({0})"
+msgid_plural "Unlisted All Add-ons ({0})"
+msgstr[0] ""
+msgstr[1] ""
 
-#: src/olympia/editors/helpers.py:262
+#: src/olympia/editors/helpers.py:274
 msgid "Type"
 msgstr "Typ"
 
-#: src/olympia/editors/helpers.py:263
+#: src/olympia/editors/helpers.py:275
 msgid "Waiting Time"
 msgstr "Väntetid"
 
-#: src/olympia/editors/helpers.py:264
-#: src/olympia/editors/templates/editors/review.html:285
+#: src/olympia/editors/helpers.py:276 src/olympia/editors/templates/editors/review.html:285
 msgid "Flags"
 msgstr "Flaggor"
 
-#: src/olympia/editors/helpers.py:265
+#: src/olympia/editors/helpers.py:277
 msgid "Applications"
 msgstr "Applikationer"
 
-#: src/olympia/editors/helpers.py:270
+#: src/olympia/editors/helpers.py:282
 msgid "Additional"
 msgstr "Ytterligare"
 
-#: src/olympia/editors/helpers.py:285
+#: src/olympia/editors/helpers.py:302
 msgid "Site Specific"
 msgstr "Platsspecifik"
 
-#: src/olympia/editors/helpers.py:287
+#: src/olympia/editors/helpers.py:304
 msgid "Requires External Software"
 msgstr "Kräver extern programvara"
 
-#: src/olympia/editors/helpers.py:289
+#: src/olympia/editors/helpers.py:306
 msgid "Binary Components"
 msgstr "Binära komponenter"
 
-#: src/olympia/editors/helpers.py:313
+#: src/olympia/editors/helpers.py:339
 msgid "moments ago"
 msgstr "nyss"
 
 #. L10n: first argument is number of minutes
-#: src/olympia/editors/helpers.py:316
+#: src/olympia/editors/helpers.py:342
 msgid "{0} minute"
 msgid_plural "{0} minutes"
 msgstr[0] "{0} minut"
 msgstr[1] "{0} minuter"
 
 #. L10n: first argument is number of hours
-#: src/olympia/editors/helpers.py:320
+#: src/olympia/editors/helpers.py:346
 msgid "{0} hour"
 msgid_plural "{0} hours"
 msgstr[0] "{0} timme"
 msgstr[1] "{0} timmar"
 
 #. L10n: first argument is number of days
-#: src/olympia/editors/helpers.py:324
+#: src/olympia/editors/helpers.py:350
 msgid "{0} day"
 msgid_plural "{0} days"
 msgstr[0] "{0} dag"
 msgstr[1] "{0} dagar"
 
-#: src/olympia/editors/helpers.py:488
+#: src/olympia/editors/helpers.py:364
+msgid "Last Review"
+msgstr ""
+
+#: src/olympia/editors/helpers.py:366
+msgid "Last Update"
+msgstr ""
+
+#: src/olympia/editors/helpers.py:387
+msgid "No Reviews"
+msgstr ""
+
+#: src/olympia/editors/helpers.py:561
 msgid "Push to public"
 msgstr "Gör publik"
 
-#: src/olympia/editors/helpers.py:490
+#: src/olympia/editors/helpers.py:563
 msgid "Grant full review"
 msgstr "Bevilja fullständig granskning"
 
-#: src/olympia/editors/helpers.py:505
+#: src/olympia/editors/helpers.py:578
 msgid "Request more information"
 msgstr "Begär mer information"
 
-#: src/olympia/editors/helpers.py:508
+#: src/olympia/editors/helpers.py:581
 msgid "Request super-review"
 msgstr "Begär supergranskning"
 
-#: src/olympia/editors/helpers.py:519
+#: src/olympia/editors/helpers.py:592
 msgid "Grant preliminary review"
 msgstr "Bevilja preliminär granskning"
 
-#: src/olympia/editors/helpers.py:520
+#: src/olympia/editors/helpers.py:593
 msgid "This will mark the files as preliminarily reviewed."
 msgstr "Detta kommer att markera filerna som preliminärt granskad."
 
-#: src/olympia/editors/helpers.py:522
-msgid ""
-"Use this form to request more information from the author. They will receive"
-" an email and be able to answer here. You will be notified by email when "
-"they reply."
-msgstr ""
-"Använd detta formulär för att begära mer information från upphovsmannen. De "
-"kommer att få ett mail och det kan besvaras här. Du kommer att meddelas via "
-"e-post när de svarat."
+#: src/olympia/editors/helpers.py:595
+msgid "Use this form to request more information from the author. They will receive an email and be able to answer here. You will be notified by email when they reply."
+msgstr "Använd detta formulär för att begära mer information från upphovsmannen. De kommer att få ett mail och det kan besvaras här. Du kommer att meddelas via e-post när de svarat."
 
-#: src/olympia/editors/helpers.py:526
+#: src/olympia/editors/helpers.py:599
 msgid ""
-"If you have concerns about this add-on's security, copyright issues, or "
-"other concerns that an administrator should look into, enter your comments "
-"in the area below. They will be sent to administrators, not the author."
+"If you have concerns about this add-on's security, copyright issues, or other concerns that an administrator should look into, enter your comments in the area below. They will be sent to "
+"administrators, not the author."
 msgstr ""
-"Om du har frågor om den här tilläggets säkerhet, upphovsrättsliga frågor "
-"eller andra funderingar som en administratör bör titta på, ange dina "
-"kommentarer i fältet nedan. De kommer att skickas till administratörer, inte"
-" upphovsmän."
+"Om du har frågor om den här tilläggets säkerhet, upphovsrättsliga frågor eller andra funderingar som en administratör bör titta på, ange dina kommentarer i fältet nedan. De kommer att skickas till "
+"administratörer, inte upphovsmän."
 
-#: src/olympia/editors/helpers.py:532
+#: src/olympia/editors/helpers.py:605
 msgid "This will reject the add-on and remove it from the review queue."
-msgstr ""
-"Detta kommer att avvisa tillägget och ta bort den från granskningskön."
+msgstr "Detta kommer att avvisa tillägget och ta bort den från granskningskön."
 
-#: src/olympia/editors/helpers.py:534
-msgid "Make a comment on this version.  The author won't be able to see this."
-msgstr ""
-"Kommentera den här versionen.  Upphovsmannen kommer inte att kunna se detta."
+#: src/olympia/editors/helpers.py:607
+msgid "Make a comment on this version. The author won't be able to see this."
+msgstr "Kommentera den här versionen.  Upphovsmannen kommer inte att kunna se detta."
 
-#: src/olympia/editors/helpers.py:538
+#: src/olympia/editors/helpers.py:611
 msgid "This will reject the files and remove them from the review queue."
 msgstr "Detta kommer att avvisa filer och ta bort dem från granskningskön."
 
-#: src/olympia/editors/helpers.py:542
-msgid ""
-"This will mark the add-on as preliminarily reviewed. Future versions will "
-"undergo preliminary review."
-msgstr ""
-"Detta kommer att markera tillägget som preliminärt granskat. Framtida "
-"versioner kommer att genomgå preliminär granskning."
+#: src/olympia/editors/helpers.py:615
+msgid "This will mark the add-on as preliminarily reviewed. Future versions will undergo preliminary review."
+msgstr "Detta kommer att markera tillägget som preliminärt granskat. Framtida versioner kommer att genomgå preliminär granskning."
 
-#: src/olympia/editors/helpers.py:547
-msgid ""
-"This will mark the files as preliminarily reviewed. Future versions will "
-"undergo preliminary review."
-msgstr ""
-"Detta kommer att markera filerna som preliminärt granskade. Framtida "
-"versioner kommer att genomgå preliminär granskning."
+#: src/olympia/editors/helpers.py:620
+msgid "This will mark the files as preliminarily reviewed. Future versions will undergo preliminary review."
+msgstr "Detta kommer att markera filerna som preliminärt granskade. Framtida versioner kommer att genomgå preliminär granskning."
 
-#: src/olympia/editors/helpers.py:552
+#: src/olympia/editors/helpers.py:625
 msgid "Retain preliminary review"
 msgstr "Behåll preliminär granskning"
 
-#: src/olympia/editors/helpers.py:553
-msgid ""
-"This will retain the add-on as preliminarily reviewed. Future versions will "
-"undergo preliminary review."
-msgstr ""
-"Detta kommer att behålla tillägget som preliminärt granskad. Framtida "
-"versioner kommer att genomgå preliminär granskning."
+#: src/olympia/editors/helpers.py:626
+msgid "This will retain the add-on as preliminarily reviewed. Future versions will undergo preliminary review."
+msgstr "Detta kommer att behålla tillägget som preliminärt granskad. Framtida versioner kommer att genomgå preliminär granskning."
 
-#: src/olympia/editors/helpers.py:558
-msgid ""
-"This will approve a sandboxed version of a public add-on to appear on the "
-"public side."
-msgstr ""
-"Detta kommer att godkänna en sandboxad version av ett offentligt tillägg att"
-" synas på den offentliga sidan."
+#: src/olympia/editors/helpers.py:631
+msgid "This will approve a sandboxed version of a public add-on to appear on the public side."
+msgstr "Detta kommer att godkänna en sandboxad version av ett offentligt tillägg att synas på den offentliga sidan."
 
-#: src/olympia/editors/helpers.py:561
-msgid ""
-"This will reject a version of a public add-on and remove it from the queue."
-msgstr ""
-"Detta kommer att avvisa en version av ett offentligt tillägg och ta bort den"
-" från kön."
-
-#: src/olympia/editors/helpers.py:564
-msgid ""
-"This will mark the add-on and its most recent version and files as public. "
-"Future versions will go into the sandbox until they are reviewed by an "
-"editor."
-msgstr ""
-"Detta kommer att markera tillägget och dess senaste version och filer som "
-"publika. Framtida versioner kommer att gå in i sandbox tills de granskas av "
-"en redigerare."
+#: src/olympia/editors/helpers.py:634
+msgid "This will reject a version of a public add-on and remove it from the queue."
+msgstr "Detta kommer att avvisa en version av ett offentligt tillägg och ta bort den från kön."
 
 #: src/olympia/editors/helpers.py:637
+msgid "This will mark the add-on and its most recent version and files as public. Future versions will go into the sandbox until they are reviewed by an editor."
+msgstr "Detta kommer att markera tillägget och dess senaste version och filer som publika. Framtida versioner kommer att gå in i sandbox tills de granskas av en redigerare."
+
+#: src/olympia/editors/helpers.py:714
 msgid "add-on"
 msgstr "tillägg"
 
-#: src/olympia/editors/helpers.py:940 src/olympia/editors/helpers.py:960
+#: src/olympia/editors/helpers.py:1020 src/olympia/editors/helpers.py:1040
 msgid "Flagged"
 msgstr "Flaggad"
 
-#: src/olympia/editors/helpers.py:944 src/olympia/editors/helpers.py:963
+#: src/olympia/editors/helpers.py:1024 src/olympia/editors/helpers.py:1043
 msgid "Updates"
 msgstr "Uppdateringar"
 
@@ -9991,75 +7814,68 @@ msgstr "Inskickat tema flaggat för granskning"
 msgid "A question about your Theme submission"
 msgstr "En fråga om ditt inskickade tema"
 
-#: src/olympia/editors/views.py:144
+#: src/olympia/editors/views.py:146
 msgid "New Add-ons (Under 5 days)"
 msgstr "Nya tillägg (Under 5 dagar)"
 
-#: src/olympia/editors/views.py:145
+#: src/olympia/editors/views.py:147
 msgid "Passable (5 to 10 days)"
 msgstr "Väntande (5 till 10 dagar)"
 
-#: src/olympia/editors/views.py:146
+#: src/olympia/editors/views.py:148
 msgid "Overdue (Over 10 days)"
 msgstr "Försenad (Över 10 dagar)"
 
-#: src/olympia/editors/views.py:532
+#: src/olympia/editors/views.py:539
 msgid "An unknown error occurred"
 msgstr "Ett okänt fel uppstod"
 
-#: src/olympia/editors/views.py:587
+#: src/olympia/editors/views.py:592
 msgid "Self-reviews are not allowed."
 msgstr "Det är inte tillåtet att granska sig själv."
 
-#: src/olympia/editors/views.py:609
+#: src/olympia/editors/views.py:613
 msgid "Review successfully processed."
 msgstr "Granskning behandlad."
 
-#: src/olympia/editors/views.py:807
+#: src/olympia/editors/views.py:812
 msgid "was approved"
 msgstr "godkändes"
 
-#: src/olympia/editors/views.py:808
+#: src/olympia/editors/views.py:813
 msgid "given preliminary review"
 msgstr "beviljad preliminär granskning"
 
-#: src/olympia/editors/views.py:809
+#: src/olympia/editors/views.py:814
 msgid "rejected"
 msgstr "avvisad"
 
-#: src/olympia/editors/views.py:810
+#: src/olympia/editors/views.py:815
 msgctxt "editors_review_history_nominated_adminreview"
 msgid "escalated"
 msgstr "upptrappad"
 
-#: src/olympia/editors/views.py:812
+#: src/olympia/editors/views.py:817
 msgid "needs more information"
 msgstr "behöver mer information"
 
-#: src/olympia/editors/views.py:813
+#: src/olympia/editors/views.py:818
 msgid "needs super review"
 msgstr "behöver supergranskning"
 
-#: src/olympia/editors/views.py:814
+#: src/olympia/editors/views.py:819
 msgid "commented"
 msgstr "kommenterade"
 
 #: src/olympia/editors/views_themes.py:326
 msgid "{0} theme review successfully processed (+{1} points, {2} total)."
-msgid_plural ""
-"{0} theme reviews successfully processed (+{1} points, {2} total)."
+msgid_plural "{0} theme reviews successfully processed (+{1} points, {2} total)."
 msgstr[0] "{0} granskning av tema behandlad (+{1} poäng, {2} totalt)."
 msgstr[1] "{0} granskningar av teman behandlade (+{1} poäng, {2} totalt)."
 
 #: src/olympia/editors/views_themes.py:341
-msgid ""
-"Your theme locks have successfully been released. Other reviewers may now "
-"review those released themes. You may have to refresh the page to see the "
-"changes reflected in the table below."
-msgstr ""
-"Ditt låsta tema har framgångsrikt släppts. Andra granskare kan nu se över "
-"dessa släppta teman. Du kanske måste uppdatera sidan för att se ändringarna "
-"i nedanstående tabell."
+msgid "Your theme locks have successfully been released. Other reviewers may now review those released themes. You may have to refresh the page to see the changes reflected in the table below."
+msgstr "Ditt låsta tema har framgångsrikt släppts. Andra granskare kan nu se över dessa släppta teman. Du kanske måste uppdatera sidan för att se ändringarna i nedanstående tabell."
 
 #: src/olympia/editors/templates/editors/abuse_reports.html:4
 msgid "{addon} :: Abuse Reports"
@@ -10083,9 +7899,7 @@ msgstr "<i>anonym</i> den %(date)s [%(ip_address)s]"
 msgid "Return to the Editor Tools homepage"
 msgstr "Gå tillbaka till hemsidan för redigeringsverktyg"
 
-#: src/olympia/editors/templates/editors/base.html:43
-#: src/olympia/editors/templates/editors/themes/base.html:14
-#: src/olympia/editors/templates/editors/themes/base.html:28
+#: src/olympia/editors/templates/editors/base.html:43 src/olympia/editors/templates/editors/themes/base.html:14 src/olympia/editors/templates/editors/themes/base.html:28
 #: src/olympia/editors/templates/editors/themes/queue.html:25
 msgid "Queues"
 msgstr "Köer"
@@ -10094,71 +7908,51 @@ msgstr "Köer"
 msgid "Unlisted Queues"
 msgstr "Olistade köer"
 
-#: src/olympia/editors/templates/editors/base.html:72
-#: src/olympia/editors/templates/editors/performance.html:6
+#: src/olympia/editors/templates/editors/base.html:74 src/olympia/editors/templates/editors/performance.html:6
 msgid "Performance"
 msgstr "Prestanda"
 
-#: src/olympia/editors/templates/editors/base.html:75
-#: src/olympia/editors/templates/editors/themes/base.html:19
-#: src/olympia/editors/templates/editors/themes/base.html:38
+#: src/olympia/editors/templates/editors/base.html:77 src/olympia/editors/templates/editors/themes/base.html:19 src/olympia/editors/templates/editors/themes/base.html:38
 msgid "Logs"
 msgstr "Loggar"
 
-#: src/olympia/editors/templates/editors/base.html:78
-#: src/olympia/editors/templates/editors/reviewlog.html:4
-#: src/olympia/editors/templates/editors/reviewlog.html:27
+#: src/olympia/editors/templates/editors/base.html:80 src/olympia/editors/templates/editors/reviewlog.html:4 src/olympia/editors/templates/editors/reviewlog.html:27
 msgid "Add-on Review Log"
 msgstr "Granskningslogg för tillägg"
 
-#: src/olympia/editors/templates/editors/base.html:80
-#: src/olympia/editors/templates/editors/eventlog.html:4
-#: src/olympia/editors/templates/editors/eventlog.html:8
+#: src/olympia/editors/templates/editors/base.html:82 src/olympia/editors/templates/editors/eventlog.html:4 src/olympia/editors/templates/editors/eventlog.html:8
 #: src/olympia/editors/templates/editors/eventlog_detail.html:4
 msgid "Moderated Review Log"
 msgstr "Modererad granskningslogg"
 
-#: src/olympia/editors/templates/editors/base.html:82
-#: src/olympia/editors/templates/editors/beta_signed_log.html:4
-#: src/olympia/editors/templates/editors/beta_signed_log.html:8
+#: src/olympia/editors/templates/editors/base.html:84 src/olympia/editors/templates/editors/beta_signed_log.html:4 src/olympia/editors/templates/editors/beta_signed_log.html:8
 msgid "Signed Beta Files Log"
 msgstr "Signerad Beta fillogg"
 
-#: src/olympia/editors/templates/editors/base.html:87
-#: src/olympia/editors/templates/editors/includes/daily-message.html:4
+#: src/olympia/editors/templates/editors/base.html:89 src/olympia/editors/templates/editors/includes/daily-message.html:4
 msgid "Announcement"
 msgstr "Meddelande"
 
 #. "Filter" is a button label (verb)
-#: src/olympia/editors/templates/editors/beta_signed_log.html:17
-#: src/olympia/editors/templates/editors/eventlog.html:24
-#: src/olympia/editors/templates/editors/reviewlog.html:21
-#: src/olympia/editors/templates/editors/themes/macros.html:45
-#: src/olympia/editors/templates/editors/themes/includes/logs_filter_deleted.html:12
+#: src/olympia/editors/templates/editors/beta_signed_log.html:17 src/olympia/editors/templates/editors/eventlog.html:24 src/olympia/editors/templates/editors/reviewlog.html:21
+#: src/olympia/editors/templates/editors/themes/macros.html:45 src/olympia/editors/templates/editors/themes/includes/logs_filter_deleted.html:12
 msgid "Filter"
 msgstr "Filtrera"
 
-#: src/olympia/editors/templates/editors/beta_signed_log.html:23
-#: src/olympia/editors/templates/editors/eventlog.html:30
-#: src/olympia/editors/templates/editors/reviewlog.html:34
+#: src/olympia/editors/templates/editors/beta_signed_log.html:23 src/olympia/editors/templates/editors/eventlog.html:30 src/olympia/editors/templates/editors/reviewlog.html:34
 #: src/olympia/editors/templates/editors/themes/logs.html:16
 msgid "Date"
 msgstr "Datum"
 
-#: src/olympia/editors/templates/editors/beta_signed_log.html:24
-#: src/olympia/editors/templates/editors/eventlog.html:31
-#: src/olympia/editors/templates/editors/reviewlog.html:35
+#: src/olympia/editors/templates/editors/beta_signed_log.html:24 src/olympia/editors/templates/editors/eventlog.html:31 src/olympia/editors/templates/editors/reviewlog.html:35
 msgid "Event"
 msgstr "Händelse"
 
-#: src/olympia/editors/templates/editors/beta_signed_log.html:37
-#: src/olympia/editors/templates/editors/eventlog.html:44
-#: src/olympia/editors/templates/editors/home.html:180
+#: src/olympia/editors/templates/editors/beta_signed_log.html:37 src/olympia/editors/templates/editors/eventlog.html:44 src/olympia/editors/templates/editors/home.html:180
 msgid "More details."
 msgstr "Mer detaljer."
 
-#: src/olympia/editors/templates/editors/beta_signed_log.html:46
-#: src/olympia/editors/templates/editors/eventlog.html:53
+#: src/olympia/editors/templates/editors/beta_signed_log.html:46 src/olympia/editors/templates/editors/eventlog.html:53
 msgid "No events found for this period."
 msgstr "Inga händelser hittades för denna period."
 
@@ -10208,20 +8002,17 @@ msgid_plural "Preliminary Reviews ({num})"
 msgstr[0] "Preliminär granskning ({num})"
 msgstr[1] "Preliminära granskningar ({num})"
 
-#: src/olympia/editors/templates/editors/home.html:36
-#: src/olympia/editors/templates/editors/home.html:86
+#: src/olympia/editors/templates/editors/home.html:36 src/olympia/editors/templates/editors/home.html:86
 msgid "Current waiting times:"
 msgstr "Aktuella väntetider:"
 
-#: src/olympia/editors/templates/editors/home.html:44
-#: src/olympia/editors/templates/editors/home.html:94
+#: src/olympia/editors/templates/editors/home.html:44 src/olympia/editors/templates/editors/home.html:94
 msgid "{0} add-on"
 msgid_plural "{0} add-ons"
 msgstr[0] "{0} tillägg"
 msgstr[1] "{0} tillägg"
 
-#: src/olympia/editors/templates/editors/home.html:45
-#: src/olympia/editors/templates/editors/home.html:95
+#: src/olympia/editors/templates/editors/home.html:45 src/olympia/editors/templates/editors/home.html:95
 #, python-format
 msgid "{0}%%"
 msgstr "{0}%%"
@@ -10244,14 +8035,11 @@ msgid_plural "Unlisted Preliminary Reviews ({num})"
 msgstr[0] "Olistad preliminär granskning ({num})"
 msgstr[1] "Olistad preliminära granskningar ({num})"
 
-#: src/olympia/editors/templates/editors/home.html:109
-#: src/olympia/editors/templates/editors/performance.html:37
-#: src/olympia/editors/templates/editors/themes/home.html:54
+#: src/olympia/editors/templates/editors/home.html:109 src/olympia/editors/templates/editors/performance.html:37 src/olympia/editors/templates/editors/themes/home.html:54
 msgid "Total Reviews"
 msgstr "Totalt antal recensioner"
 
-#: src/olympia/editors/templates/editors/home.html:110
-#: src/olympia/editors/templates/editors/themes/home.html:55
+#: src/olympia/editors/templates/editors/home.html:110 src/olympia/editors/templates/editors/themes/home.html:55
 msgid "Reviews This Month"
 msgstr "Recensioner denna månad"
 
@@ -10259,8 +8047,7 @@ msgstr "Recensioner denna månad"
 msgid "New Editors"
 msgstr "Nya redigerare"
 
-#: src/olympia/editors/templates/editors/home.html:126
-#: src/olympia/editors/templates/editors/home.html:141
+#: src/olympia/editors/templates/editors/home.html:126 src/olympia/editors/templates/editors/home.html:141
 msgid "You're #{0} with {1} reviews"
 msgstr "Du är nummer {0} med {1} recensioner"
 
@@ -10271,13 +8058,11 @@ msgid_plural "Moderated Reviews ({num})"
 msgstr[0] "Modererad granskning({num})"
 msgstr[1] "Modererade granskningar ({num})"
 
-#: src/olympia/editors/templates/editors/leaderboard.html:3
-#: src/olympia/editors/templates/editors/includes/reviewers_score_bar.html:56
+#: src/olympia/editors/templates/editors/leaderboard.html:3 src/olympia/editors/templates/editors/includes/reviewers_score_bar.html:56
 msgid "Reviewer Leaderboard"
 msgstr "Granskarnas ledartavla"
 
-#: src/olympia/editors/templates/editors/leaderboard.html:18
-#: src/olympia/editors/templates/editors/performance.html:65
+#: src/olympia/editors/templates/editors/leaderboard.html:18 src/olympia/editors/templates/editors/performance.html:65
 msgid "No review points awarded yet."
 msgstr "Inga granskningspoäng tilldelade ännu."
 
@@ -10297,8 +8082,7 @@ msgstr "Meddelande för dagen"
 msgid "Update message of the day"
 msgstr "Uppdatera meddelande för dagen"
 
-#: src/olympia/editors/templates/editors/motd.html:15
-#: src/olympia/editors/templates/editors/review.html:224
+#: src/olympia/editors/templates/editors/motd.html:15 src/olympia/editors/templates/editors/review.html:224
 msgid "Save"
 msgstr "Spara"
 
@@ -10366,51 +8150,45 @@ msgstr "Avancerad sökning"
 msgid "clear search"
 msgstr "rensa sökning"
 
-#: src/olympia/editors/templates/editors/queue.html:72
-#: src/olympia/editors/templates/editors/queue.html:122
+#: src/olympia/editors/templates/editors/queue.html:78 src/olympia/editors/templates/editors/queue.html:128
 msgid "Process Reviews"
 msgstr "Behandla granskningar"
 
-#: src/olympia/editors/templates/editors/queue.html:80
+#: src/olympia/editors/templates/editors/queue.html:86
 msgid "Moderation actions:"
 msgstr "Modererade åtgärder:"
 
-#: src/olympia/editors/templates/editors/queue.html:90
+#: src/olympia/editors/templates/editors/queue.html:96
 #, python-format
 msgid "by %(user)s on %(date)s %(stars)s (%(locale)s)"
 msgstr "av %(user)s den %(date)s %(stars)s (%(locale)s)"
 
-#: src/olympia/editors/templates/editors/queue.html:106
+#: src/olympia/editors/templates/editors/queue.html:112
 #, python-format
-msgid ""
-"<strong>%(reason)s</strong> <span class=\"light\">Flagged by %(user)s on "
-"%(date)s</span>"
-msgstr ""
-"<strong>%(reason)s</strong> <span class=\"light\">Flaggad av %(user)s den "
-"%(date)s</span>"
+msgid "<strong>%(reason)s</strong> <span class=\"light\">Flagged by %(user)s on %(date)s</span>"
+msgstr "<strong>%(reason)s</strong> <span class=\"light\">Flaggad av %(user)s den %(date)s</span>"
 
-#: src/olympia/editors/templates/editors/queue.html:119
-msgid "All reviews have been moderated.  Good work!"
+#: src/olympia/editors/templates/editors/queue.html:125
+msgid "All reviews have been moderated. Good work!"
 msgstr "Alla granskningar är modererade.  Bra jobbat!"
 
-#: src/olympia/editors/templates/editors/queue.html:161
+#: src/olympia/editors/templates/editors/queue.html:167
 msgid "Version Notes / Notes for Reviewer"
 msgstr "Versionsanteckningar / Anteckningar för granskare"
 
-#: src/olympia/editors/templates/editors/queue.html:169
+#: src/olympia/editors/templates/editors/queue.html:175
 msgid "There are currently no add-ons of this type to review."
 msgstr "Det finns för tillfället inga tillägg av denna typ att granska."
 
-#: src/olympia/editors/templates/editors/queue.html:181
-#: src/olympia/editors/templates/editors/themes/queue_list.html:85
+#: src/olympia/editors/templates/editors/queue.html:187 src/olympia/editors/templates/editors/themes/queue_list.html:85
 msgid "Helpful Links:"
 msgstr "Nyttiga länkar:"
 
-#: src/olympia/editors/templates/editors/queue.html:182
+#: src/olympia/editors/templates/editors/queue.html:188
 msgid "Add-on Policy"
 msgstr "Policy för tillägg"
 
-#: src/olympia/editors/templates/editors/queue.html:184
+#: src/olympia/editors/templates/editors/queue.html:190
 msgid "Editors' Guide"
 msgstr "Guide för redigerare"
 
@@ -10423,19 +8201,14 @@ msgstr "Granska {0}"
 msgid "Add-on user change history"
 msgstr "Användarändringshistorik för tillägg"
 
-#: src/olympia/editors/templates/editors/review.html:52
-#: src/olympia/editors/templates/editors/review.html:266
+#: src/olympia/editors/templates/editors/review.html:52 src/olympia/editors/templates/editors/review.html:266
 msgid "Add-on History"
 msgstr "Historik för tillägg"
 
 #: src/olympia/editors/templates/editors/review.html:64
 #, python-format
-msgid ""
-"Version %(version)s &middot; %(created)s <span class=\"light\">&middot; "
-"%(version_status)s</span>"
-msgstr ""
-"Version %(version)s &middot; %(created)s <span class=\"light\">&middot; "
-"%(version_status)s</span>"
+msgid "Version %(version)s &middot; %(created)s <span class=\"light\">&middot; %(version_status)s</span>"
+msgstr "Version %(version)s &middot; %(created)s <span class=\"light\">&middot; %(version_status)s</span>"
 
 #: src/olympia/editors/templates/editors/review.html:73
 msgid "Compatibility:"
@@ -10458,19 +8231,14 @@ msgid "This version has not been reviewed."
 msgstr "Denna version har inte granskats."
 
 #: src/olympia/editors/templates/editors/review.html:154
-msgid ""
-"You can still submit this form, however only do so if you know it won't "
-"conflict."
-msgstr ""
-"Du kan fortfarande skicka in formuläret, men endast om du vet att det inte "
-"kommer skapa en konflikt."
+msgid "You can still submit this form, however only do so if you know it won't conflict."
+msgstr "Du kan fortfarande skicka in formuläret, men endast om du vet att det inte kommer skapa en konflikt."
 
 #: src/olympia/editors/templates/editors/review.html:161
 msgid "Insert canned response..."
 msgstr "Infoga standardsvar..."
 
-#: src/olympia/editors/templates/editors/review.html:167
-#: src/olympia/files/templates/files/viewer.html:54
+#: src/olympia/editors/templates/editors/review.html:167 src/olympia/files/templates/files/viewer.html:54
 msgid "Files:"
 msgstr "Filer:"
 
@@ -10479,17 +8247,11 @@ msgid "Tested on:"
 msgstr "Testad på:"
 
 #: src/olympia/editors/templates/editors/review.html:220
-msgid ""
-"<strong>Warning!</strong> Another user was viewing this page before you."
-msgstr ""
-"<strong>Varning!</strong> En annan användare tittade på denna sida innan "
-"dig."
+msgid "<strong>Warning!</strong> Another user was viewing this page before you."
+msgstr "<strong>Varning!</strong> En annan användare tittade på denna sida innan dig."
 
 #: src/olympia/editors/templates/editors/review.html:237
-msgid ""
-"The whiteboard is the place to exchange information relevant to\n"
-"               this addon (whatever the version), between the developer and the\n"
-"               editor. This is visible and editable by both."
+msgid "The whiteboard is the place to exchange information relevant to this addon (whatever the version), between the developer and the editor. This is visible and editable by both."
 msgstr ""
 "Tavlan är platsen för att utbyta information som är relevant\n"
 "               för detta tillägg (oavsett version), mellan utvecklaren och\n"
@@ -10499,8 +8261,7 @@ msgstr ""
 msgid "Update the whiteboard"
 msgstr "Uppdatera anslagstavla"
 
-#: src/olympia/editors/templates/editors/review.html:257
-#: src/olympia/editors/templates/editors/review.html:258
+#: src/olympia/editors/templates/editors/review.html:257 src/olympia/editors/templates/editors/review.html:258
 msgid "(admin)"
 msgstr "(admin)"
 
@@ -10528,18 +8289,15 @@ msgstr "Redigerare"
 msgid "Add-on has been deleted."
 msgstr "Tillägg har tagits bort."
 
-#: src/olympia/editors/templates/editors/reviewlog.html:59
-#: src/olympia/editors/templates/editors/themes/logs.html:36
+#: src/olympia/editors/templates/editors/reviewlog.html:59 src/olympia/editors/templates/editors/themes/logs.html:36
 msgid "Show Comments"
 msgstr "Visa kommentarer"
 
-#: src/olympia/editors/templates/editors/reviewlog.html:60
-#: src/olympia/editors/templates/editors/themes/logs.html:37
+#: src/olympia/editors/templates/editors/reviewlog.html:60 src/olympia/editors/templates/editors/themes/logs.html:37
 msgid "Hide Comments"
 msgstr "Dölj kommentarer"
 
-#: src/olympia/editors/templates/editors/reviewlog.html:72
-#: src/olympia/editors/templates/editors/themes/logs.html:54
+#: src/olympia/editors/templates/editors/reviewlog.html:72 src/olympia/editors/templates/editors/themes/logs.html:54
 msgid "No reviews found for this period."
 msgstr "Inga granskningar funna för denna period."
 
@@ -10597,11 +8355,8 @@ msgstr "Totalt"
 msgid "You have <span>{0}</span> points."
 msgstr "Du har <span>{0}</span> poäng."
 
-#: src/olympia/editors/templates/editors/includes/search_results_themes.html:6
-#: src/olympia/editors/templates/editors/themes/history_table.html:7
-#: src/olympia/editors/templates/editors/themes/logs.html:19
-#: src/olympia/editors/templates/editors/themes/queue_list.html:49
-#: src/olympia/editors/templates/editors/themes/single.html:26
+#: src/olympia/editors/templates/editors/includes/search_results_themes.html:6 src/olympia/editors/templates/editors/themes/history_table.html:7
+#: src/olympia/editors/templates/editors/themes/logs.html:19 src/olympia/editors/templates/editors/themes/queue_list.html:49 src/olympia/editors/templates/editors/themes/single.html:26
 #: src/olympia/editors/templates/editors/themes/themes.html:45
 msgid "Reviewer"
 msgstr "Granskare"
@@ -10626,8 +8381,7 @@ msgstr "Tema granskningshistorik för {0}"
 msgid "Review Date"
 msgstr "Granskningsdatum"
 
-#: src/olympia/editors/templates/editors/themes/history_table.html:9
-#: src/olympia/editors/templates/editors/themes/logs.html:18
+#: src/olympia/editors/templates/editors/themes/history_table.html:9 src/olympia/editors/templates/editors/themes/logs.html:18
 msgid "Action"
 msgstr "Åtgärd"
 
@@ -10774,7 +8528,7 @@ msgstr "Ställa en fråga till konstnären"
 msgid "Describe your reason for flagging"
 msgstr "Beskriv din anledning till flaggning"
 
-#: src/olympia/files/forms.py:88
+#: src/olympia/files/forms.py:90
 msgid "Cannot diff a version against itself"
 msgstr "Kan inte jämföra en version mot sig själv"
 
@@ -10792,11 +8546,8 @@ msgid "Problems decoding {0}."
 msgstr "Problem med avkodningen av {0}."
 
 #: src/olympia/files/helpers.py:186
-msgid ""
-"This file is not viewable online. Please download the file to view the "
-"contents."
-msgstr ""
-"Denna fil kan inte visas online. Ladda ner filen för att visa innehållet."
+msgid "This file is not viewable online. Please download the file to view the contents."
+msgstr "Denna fil kan inte visas online. Ladda ner filen för att visa innehållet."
 
 #: src/olympia/files/helpers.py:194
 msgid "This file is a directory."
@@ -10812,55 +8563,51 @@ msgstr "Det uppstod ett fel vid åtkomst av filen %s. %s."
 msgid "There was an error accessing file %s."
 msgstr "Det gick inte att komma åt filen %s."
 
-#: src/olympia/files/utils.py:343
+#: src/olympia/files/utils.py:340
 msgid "Could not parse uploaded file."
 msgstr "Det gick inte att tolka uppladdad fil."
 
-#: src/olympia/files/utils.py:380
+#: src/olympia/files/utils.py:377
 msgid "Invalid file name in archive: {0}"
 msgstr "Ogiltigt filnamn i arkivet: {0}"
 
-#: src/olympia/files/utils.py:388
+#: src/olympia/files/utils.py:385
 msgid "File exceeding size limit in archive: {0}"
 msgstr "Fil överskrider storleksgränsen i arkiv: {0}"
 
-#: src/olympia/files/utils.py:439
+#: src/olympia/files/utils.py:436
 msgid "Invalid archive."
 msgstr "Felaktigt arkiv."
 
-#: src/olympia/files/utils.py:529 src/olympia/files/utils.py:532
+#: src/olympia/files/utils.py:526 src/olympia/files/utils.py:529
 msgid "Could not parse the manifest file."
 msgstr "Kunde inte tolka manifest-filen."
 
-#: src/olympia/files/utils.py:551
+#: src/olympia/files/utils.py:548
 msgid "Could not find an add-on ID."
 msgstr "Kunde inte hitta ett tilläggs-ID."
 
-#: src/olympia/files/utils.py:554
+#: src/olympia/files/utils.py:551
 msgid "Add-on ID must be 64 characters or less."
 msgstr "Tilläggs-ID måste vara 64 tecken eller mindre."
 
-#: src/olympia/files/utils.py:556
+#: src/olympia/files/utils.py:553
 msgid "Add-on ID doesn't match add-on."
 msgstr "Tilläggs-ID matchar inte tillägg."
 
-#: src/olympia/files/utils.py:564
+#: src/olympia/files/utils.py:561
 msgid "Duplicate add-on ID found."
 msgstr "Dubbla tilläggs-ID hittades."
 
-#: src/olympia/files/utils.py:567
+#: src/olympia/files/utils.py:564
 msgid "Version numbers should have fewer than 32 characters."
 msgstr "Versionsnummer ska ha färre än 32 tecken."
 
-#: src/olympia/files/utils.py:570
-msgid ""
-"Version numbers should only contain letters, numbers, and these punctuation "
-"characters: +*.-_."
-msgstr ""
-"Versionsnummer bör endast innehålla bokstäver, siffror och dessa "
-"skiljetecken: +*.-_."
+#: src/olympia/files/utils.py:567
+msgid "Version numbers should only contain letters, numbers, and these punctuation characters: +*.-_."
+msgstr "Versionsnummer bör endast innehålla bokstäver, siffror och dessa skiljetecken: +*.-_."
 
-#: src/olympia/files/utils.py:587
+#: src/olympia/files/utils.py:584
 msgid "<em:type> doesn't match add-on"
 msgstr "<em:type> matchar inte tillägg"
 
@@ -10878,12 +8625,8 @@ msgstr "Hämta {0}"
 
 #: src/olympia/files/templates/files/file.html:4
 #, python-format
-msgid ""
-"Version: %(version)s &bull; Size: %(size)s &bull; MD5 hash: %(md5)s &bull; "
-"Mimetype: %(mimetype)s"
-msgstr ""
-"Version: %(version)s &bull; Storlek: %(size)s &bull; MD5 hash: %(md5)s "
-"&bull; Mimetyp: %(mimetype)s"
+msgid "Version: %(version)s &bull; Size: %(size)s &bull; MD5 hash: %(md5)s &bull; Mimetype: %(mimetype)s"
+msgstr "Version: %(version)s &bull; Storlek: %(size)s &bull; MD5 hash: %(md5)s &bull; Mimetyp: %(mimetype)s"
 
 #: src/olympia/files/templates/files/viewer.html:4
 msgid "File Compare :: Editor tools"
@@ -10921,48 +8664,39 @@ msgstr "Tilläggets SDK Version:"
 msgid "Tab stops:"
 msgstr "Tabbstopp:"
 
-#: src/olympia/files/templates/files/viewer.html:79
-#: src/olympia/files/templates/files/viewer.html:80
+#: src/olympia/files/templates/files/viewer.html:79 src/olympia/files/templates/files/viewer.html:80
 msgid "Up file"
 msgstr "Fil upp"
 
-#: src/olympia/files/templates/files/viewer.html:84
-#: src/olympia/files/templates/files/viewer.html:85
+#: src/olympia/files/templates/files/viewer.html:84 src/olympia/files/templates/files/viewer.html:85
 msgid "Down file"
 msgstr "Fil ner"
 
-#: src/olympia/files/templates/files/viewer.html:90
-#: src/olympia/files/templates/files/viewer.html:91
+#: src/olympia/files/templates/files/viewer.html:90 src/olympia/files/templates/files/viewer.html:91
 msgid "Previous diff"
 msgstr "Föregående skillnad"
 
-#: src/olympia/files/templates/files/viewer.html:93
-#: src/olympia/files/templates/files/viewer.html:94
+#: src/olympia/files/templates/files/viewer.html:93 src/olympia/files/templates/files/viewer.html:94
 msgid "Previous note"
 msgstr "Föregående anteckning"
 
-#: src/olympia/files/templates/files/viewer.html:100
-#: src/olympia/files/templates/files/viewer.html:101
+#: src/olympia/files/templates/files/viewer.html:100 src/olympia/files/templates/files/viewer.html:101
 msgid "Next diff"
 msgstr "Nästa skillnad"
 
-#: src/olympia/files/templates/files/viewer.html:103
-#: src/olympia/files/templates/files/viewer.html:104
+#: src/olympia/files/templates/files/viewer.html:103 src/olympia/files/templates/files/viewer.html:104
 msgid "Next note"
 msgstr "Nästa anteckning"
 
-#: src/olympia/files/templates/files/viewer.html:109
-#: src/olympia/files/templates/files/viewer.html:110
+#: src/olympia/files/templates/files/viewer.html:109 src/olympia/files/templates/files/viewer.html:110
 msgid "Expand all"
 msgstr "Expandera alla"
 
-#: src/olympia/files/templates/files/viewer.html:114
-#: src/olympia/files/templates/files/viewer.html:115
+#: src/olympia/files/templates/files/viewer.html:114 src/olympia/files/templates/files/viewer.html:115
 msgid "Hide or unhide tree"
 msgstr "Dölj eller visa träd"
 
-#: src/olympia/files/templates/files/viewer.html:119
-#: src/olympia/files/templates/files/viewer.html:120
+#: src/olympia/files/templates/files/viewer.html:119 src/olympia/files/templates/files/viewer.html:120
 msgid "Wrap or unwrap text"
 msgstr "Radbryt eller radbryt ej text"
 
@@ -10973,6 +8707,10 @@ msgstr "Inga filer i den uppladdade filen."
 #: src/olympia/files/templates/files/viewer.html:134
 msgid "Fetching file."
 msgstr "Hämtar fil."
+
+#: src/olympia/legacy_api/views.py:255
+msgid "Not implemented yet."
+msgstr "Inte implementerat ännu."
 
 #: src/olympia/lib/constants.py:6
 msgid "United Arab Emirates Dirham"
@@ -11630,12 +9368,7 @@ msgstr "Zambisk Kwacha"
 msgid "Zimbabwe Dollar"
 msgstr "Zimbabwiska dollar"
 
-#: src/olympia/lib/video/ffmpeg.py:112 src/olympia/lib/video/totem.py:81
-msgid "Videos must be in WebM."
-msgstr "Videor måste vara i WebM."
-
-#: src/olympia/pages/templates/pages/about.lhtml:3
-#: src/olympia/pages/templates/pages/about.lhtml:10
+#: src/olympia/pages/templates/pages/about.lhtml:3 src/olympia/pages/templates/pages/about.lhtml:10
 msgid "About Mozilla Add-ons"
 msgstr "Om Mozilla tillägg"
 
@@ -11645,17 +9378,11 @@ msgstr "Vad är denna webbplats?"
 
 #: src/olympia/pages/templates/pages/about.lhtml:13
 msgid ""
-"addons.mozilla.org, commonly known as \"AMO\", is Mozilla's official site "
-"for add-ons to Mozilla software, such as Firefox, Thunderbird, and "
-"SeaMonkey. Add-ons let you add new features and change the way your browser "
-"or application works.  Take a look around and explore the thousands of ways "
-"to customize the way you do things online."
+"addons.mozilla.org, commonly known as \"AMO\", is Mozilla's official site for add-ons to Mozilla software, such as Firefox, Thunderbird, and SeaMonkey. Add-ons let you add new features and change "
+"the way your browser or application works. Take a look around and explore the thousands of ways to customize the way you do things online."
 msgstr ""
-"addons.mozilla.org, allmänt känd som \"AMO\", är Mozillas officiella "
-"webbplats för tillägg till Mozillas programvara, såsom Firefox, Thunderbird "
-"och SeaMonkey. Tillägg låter dig lägga till nya funktioner och ändra hur din"
-" webbläsare eller program fungerar.  Ta en titt och utforska tusentals sätt "
-"att anpassa ditt sätt att göra saker på nätet."
+"addons.mozilla.org, allmänt känd som \"AMO\", är Mozillas officiella webbplats för tillägg till Mozillas programvara, såsom Firefox, Thunderbird och SeaMonkey. Tillägg låter dig lägga till nya "
+"funktioner och ändra hur din webbläsare eller program fungerar.  Ta en titt och utforska tusentals sätt att anpassa ditt sätt att göra saker på nätet."
 
 #: src/olympia/pages/templates/pages/about.lhtml:19
 msgid "Who creates these add-ons?"
@@ -11663,112 +9390,69 @@ msgstr "Vem skapar dessa tillägg?"
 
 #: src/olympia/pages/templates/pages/about.lhtml:20
 msgid ""
-"The add-ons listed here have been created by thousands of developers from "
-"our community, ranging from individual hobbyists to large corporations. All "
-"publicly listed add-ons are reviewed by a team of editors before being "
-"released. Add-ons marked as Experimental have not been reviewed and should "
-"only be installed with caution."
+"The add-ons listed here have been created by thousands of developers from our community, ranging from individual hobbyists to large corporations. All publicly listed add-ons are reviewed by a team "
+"of editors before being released. Add-ons marked as Experimental have not been reviewed and should only be installed with caution."
 msgstr ""
-"De tillägg som anges här har skapats av tusentals utvecklare från vår "
-"gemenskap, som sträcker sig från enskilda hobbyister till storföretag. Alla "
-"publkit listade tillägg granskas av ett team av redigerare innan det släpps."
-" Tillägg markerade som experimentella har inte granskats och bör endast "
-"installeras med försiktighet."
+"De tillägg som anges här har skapats av tusentals utvecklare från vår gemenskap, som sträcker sig från enskilda hobbyister till storföretag. Alla publkit listade tillägg granskas av ett team av "
+"redigerare innan det släpps. Tillägg markerade som experimentella har inte granskats och bör endast installeras med försiktighet."
 
 #: src/olympia/pages/templates/pages/about.lhtml:26
 msgid "How do I keep up with what's happening at AMO?"
 msgstr "Hur gör jag för att hänga med i vad som händer på AMO?"
 
 #: src/olympia/pages/templates/pages/about.lhtml:27
-msgid ""
-"There are several ways to find out the latest news from the world of add-"
-"ons:"
-msgstr ""
-"Det finns flera sätt att ta reda på de senaste nyheterna från världen av "
-"tillägg:"
+msgid "There are several ways to find out the latest news from the world of add-ons:"
+msgstr "Det finns flera sätt att ta reda på de senaste nyheterna från världen av tillägg:"
 
 #: src/olympia/pages/templates/pages/about.lhtml:29
 #, python-format
-msgid ""
-"Our <a href=\"%(url)s\">Add-ons Blog</a> is regularly updated with "
-"information for both add-on enthusiasts and developers."
-msgstr ""
-"Vår <a href=\"%(url)s\">blogg för tillägg</a> uppdateras regelbundet med "
-"information för tilläggsentusiaster och utvecklare."
+msgid "Our <a href=\"%(url)s\">Add-ons Blog</a> is regularly updated with information for both add-on enthusiasts and developers."
+msgstr "Vår <a href=\"%(url)s\">blogg för tillägg</a> uppdateras regelbundet med information för tilläggsentusiaster och utvecklare."
 
 #: src/olympia/pages/templates/pages/about.lhtml:32
 #, python-format
-msgid ""
-"We often post news, tips, and tricks to our Twitter account, <a "
-"href=\"%(url)s\">mozamo</a>"
-msgstr ""
-"Vi postar ofta nyheter, tips och tricks till vårt Twitter-konto, <a "
-"href=\"%(url)s\">mozamo</a>"
+msgid "We often post news, tips, and tricks to our Twitter account, <a href=\"%(url)s\">mozamo</a>"
+msgstr "Vi postar ofta nyheter, tips och tricks till vårt Twitter-konto, <a href=\"%(url)s\">mozamo</a>"
 
 #: src/olympia/pages/templates/pages/about.lhtml:34
 #, python-format
-msgid ""
-"Our <a href=\"%(url)s\">forums</a> are a good place to interact with the "
-"add-ons community and discuss upcoming changes to AMO."
-msgstr ""
-"Våra <a href=\"%(url)s\">forum</a> är ett bra ställe att interagera med "
-"gemenskapen för tillägg och diskutera kommande förändringar till AMO."
+msgid "Our <a href=\"%(url)s\">forums</a> are a good place to interact with the add-ons community and discuss upcoming changes to AMO."
+msgstr "Våra <a href=\"%(url)s\">forum</a> är ett bra ställe att interagera med gemenskapen för tillägg och diskutera kommande förändringar till AMO."
 
 #: src/olympia/pages/templates/pages/about.lhtml:39
 msgid "This sounds great! How can I get involved?"
 msgstr "Detta låter bra! Hur kan jag bli involverad?"
 
 #: src/olympia/pages/templates/pages/about.lhtml:40
-msgid ""
-"There are plenty of ways to get involved. If you're on the technical side:"
-msgstr ""
-"Det finns många sätt att engagera sig. Om du är på den tekniska sidan:"
+msgid "There are plenty of ways to get involved. If you're on the technical side:"
+msgstr "Det finns många sätt att engagera sig. Om du är på den tekniska sidan:"
 
 #: src/olympia/pages/templates/pages/about.lhtml:42
 #, python-format
-msgid ""
-"<a href=\"%(url)s\">Make your own add-on</a>. We provide free hosting and "
-"update services and can help you reach a large audience of users."
-msgstr ""
-"<a href=\"%(url)s\">Göra egna tillägg</a>. Vi tillhandahåller gratis "
-"webbhotell och uppdateringstjänster och kan hjälpa dig att nå en stor publik"
-" av användare."
+msgid "<a href=\"%(url)s\">Make your own add-on</a>. We provide free hosting and update services and can help you reach a large audience of users."
+msgstr "<a href=\"%(url)s\">Göra egna tillägg</a>. Vi tillhandahåller gratis webbhotell och uppdateringstjänster och kan hjälpa dig att nå en stor publik av användare."
 
 #: src/olympia/pages/templates/pages/about.lhtml:45
 #, python-format
-msgid ""
-"If you have add-on development experience, <a href=\"%(url)s\"> become an "
-"editor</a>! Our editors are add-on fans with a technical background who "
-"review add-ons for code quality and stability."
+msgid "If you have add-on development experience, <a href=\"%(url)s\"> become an editor</a>! Our editors are add-on fans with a technical background who review add-ons for code quality and stability."
 msgstr ""
-"Om du har erfarenhet av tilläggsutveckling, <a href=\"%(url)s\"> bli en "
-"redigerare</a>! Våra redigerare är tilläggsfans med teknisk bakgrund som "
-"granskar tillägg för kodkvalitet och stabilitet."
+"Om du har erfarenhet av tilläggsutveckling, <a href=\"%(url)s\"> bli en redigerare</a>! Våra redigerare är tilläggsfans med teknisk bakgrund som granskar tillägg för kodkvalitet och stabilitet."
 
 #: src/olympia/pages/templates/pages/about.lhtml:49
 #, python-format
 msgid ""
-"Help improve this website. It's open source, and you can file bugs and "
-"submit patches. <a href=\"%(url)s\"> GitHub</a> contains all of our current "
-"bugs, legacy bugs can still be found in Bugzilla."
+"Help improve this website. It's open source, and you can file bugs and submit patches. <a href=\"%(url)s\"> GitHub</a> contains all of our current bugs, legacy bugs can still be found in Bugzilla."
 msgstr ""
-"Hjälp till att förbättra webbplatsen. Den har öppen källkod och du kan "
-"skicka in buggar och korrigeringar. <a href=\"%(url)s\"> GitHub </a> "
-"innehåller alla våra nuvarande buggar, äldre buggar kan fortfarande hittas i"
-" Bugzilla."
+"Hjälp till att förbättra webbplatsen. Den har öppen källkod och du kan skicka in buggar och korrigeringar. <a href=\"%(url)s\"> GitHub </a> innehåller alla våra nuvarande buggar, äldre buggar kan "
+"fortfarande hittas i Bugzilla."
 
 #: src/olympia/pages/templates/pages/about.lhtml:55
-msgid ""
-"If you're interested in add-ons but not quite as technical, there are still "
-"ways to help:"
-msgstr ""
-"Om du är intresserad av tillägg men inte riktigt lika teknisk, finns det "
-"fortfarande sätt att hjälpa:"
+msgid "If you're interested in add-ons but not quite as technical, there are still ways to help:"
+msgstr "Om du är intresserad av tillägg men inte riktigt lika teknisk, finns det fortfarande sätt att hjälpa:"
 
 #: src/olympia/pages/templates/pages/about.lhtml:58
 msgid "Tell your friends! Let people know which add-ons you use."
-msgstr ""
-"Berätta för dina vänner! Låta människor veta vilka tillägg som du använder."
+msgstr "Berätta för dina vänner! Låta människor veta vilka tillägg som du använder."
 
 #: src/olympia/pages/templates/pages/about.lhtml:59
 #, python-format
@@ -11776,13 +9460,8 @@ msgid "Participate in our <a href=\"%(url)s\">forums</a>."
 msgstr "Delta i våra <a href=\"%(url)s\">forum</a>."
 
 #: src/olympia/pages/templates/pages/about.lhtml:61
-msgid ""
-"Review add-ons on the site. Add-on authors are more likely to improve their "
-"add-ons and write new ones when they know people appreciate their work."
-msgstr ""
-"Granska tillägg på webbplatsen. Det är med sannolikt att upphovsmän "
-"förbättrar deras tillägg och skriver nya när de vet att personer uppskattar "
-"deras arbete."
+msgid "Review add-ons on the site. Add-on authors are more likely to improve their add-ons and write new ones when they know people appreciate their work."
+msgstr "Granska tillägg på webbplatsen. Det är med sannolikt att upphovsmän förbättrar deras tillägg och skriver nya när de vet att personer uppskattar deras arbete."
 
 #: src/olympia/pages/templates/pages/about.lhtml:66
 msgid "I have a question"
@@ -11791,22 +9470,16 @@ msgstr "Jag har en fråga"
 #: src/olympia/pages/templates/pages/about.lhtml:67
 #, python-format
 msgid ""
-"A good place to start is our <a href=\"%(faq_url)s\"><abbr "
-"title=\"Frequently Asked Questions\">FAQ</abbr></a>. If you don't find an "
-"answer there, you can <a href=\"%(forum_url)s\"> ask on our forums</a>."
+"A good place to start is our <a href=\"%(faq_url)s\"><abbr title=\"Frequently Asked Questions\">FAQ</abbr></a>. If you don't find an answer there, you can <a href=\"%(forum_url)s\"> ask on our "
+"forums</a>."
 msgstr ""
-"Ett bra ställe att börja är vår <a href=\"%(faq_url)s\"><abbr "
-"title=\"Frequently Asked Questions\">FAQ</abbr></a>. Om du inte hittar ett "
-"svar där, kan du <a href=\"%(forum_url)s\"> fråga på vårt forum</a>."
+"Ett bra ställe att börja är vår <a href=\"%(faq_url)s\"><abbr title=\"Frequently Asked Questions\">FAQ</abbr></a>. Om du inte hittar ett svar där, kan du <a href=\"%(forum_url)s\"> fråga på vårt "
+"forum</a>."
 
 #: src/olympia/pages/templates/pages/about.lhtml:72
 #, python-format
-msgid ""
-"If you really need to contact someone from the Mozilla team, please see our "
-"<a href=\"%(url)s\"> contact information</a> page."
-msgstr ""
-"Om du verkligen behöver kontakta någon från Mozillas grupp, se vår <a "
-"href=\"%(url)s\"> kontaktinformationssida</a>."
+msgid "If you really need to contact someone from the Mozilla team, please see our <a href=\"%(url)s\"> contact information</a> page."
+msgstr "Om du verkligen behöver kontakta någon från Mozillas grupp, se vår <a href=\"%(url)s\"> kontaktinformationssida</a>."
 
 #: src/olympia/pages/templates/pages/about.lhtml:76
 msgid "Who works on this website?"
@@ -11815,15 +9488,11 @@ msgstr "Som arbetar på denna webbplats?"
 #: src/olympia/pages/templates/pages/about.lhtml:77
 #, python-format
 msgid ""
-"Over the years, many people have contributed to this website, including both"
-" volunteers from the community and a dedicated AMO team. A list of "
-"significant contributors can be found on our <a href=\"%(url)s\"> Site "
-"Credits</a> page."
+"Over the years, many people have contributed to this website, including both volunteers from the community and a dedicated AMO team. A list of significant contributors can be found on our <a href="
+"\"%(url)s\"> Site Credits</a> page."
 msgstr ""
-"Genom åren har många bidragit till denna webbplats, inklusive både "
-"volontärer från gemenskapen och särskilda AMO-medlemmar. En lista över "
-"betydande bidragsgivare kan hittas på vår <a "
-"href=\"%(url)s\">medarbetarsida</a>."
+"Genom åren har många bidragit till denna webbplats, inklusive både volontärer från gemenskapen och särskilda AMO-medlemmar. En lista över betydande bidragsgivare kan hittas på vår <a href=\"%(url)s"
+"\">medarbetarsida</a>."
 
 #: src/olympia/pages/templates/pages/acr_firstrun.html:4
 msgid "Add-on Compatibility Reporter"
@@ -11834,67 +9503,45 @@ msgid "Add-on Compatibility Reporter has been installed"
 msgstr "Add-on Compatibility Reporter har installerats"
 
 #: src/olympia/pages/templates/pages/acr_firstrun.html:28
-msgid ""
-"It’s easy to help us make sure add-ons are updated in time for the release "
-"of the next version of Firefox."
-msgstr ""
-"Det är lätt att hjälpa oss att se till att tillägg uppdateras i tid för "
-"lanseringen av nästa version av Firefox."
+msgid "It’s easy to help us make sure add-ons are updated in time for the release of the next version of Firefox."
+msgstr "Det är lätt att hjälpa oss att se till att tillägg uppdateras i tid för lanseringen av nästa version av Firefox."
 
 #: src/olympia/pages/templates/pages/acr_firstrun.html:35
 msgid "Here’s how to get started reporting add-on compatibility:"
-msgstr ""
-"Här är hur du kommer igång med rapportering av ett tilläggs kompatibilitet:"
+msgstr "Här är hur du kommer igång med rapportering av ett tilläggs kompatibilitet:"
 
 #: src/olympia/pages/templates/pages/acr_firstrun.html:40
 msgid ""
-"As you start browsing and using your add-ons, take careful note of anything "
-"that seems different from when you last used the extension. This might be a "
-"display glitch, such as a menu item missing, or something more serious, like"
-" the add-on not working at all or showing errors."
+"As you start browsing and using your add-ons, take careful note of anything that seems different from when you last used the extension. This might be a display glitch, such as a menu item missing, "
+"or something more serious, like the add-on not working at all or showing errors."
 msgstr ""
-"När du börjar surfa och använda ditt tillägg, ta del av det som verkar "
-"annorlunda från när du senast använde utökningen. Detta kan vara ett "
-"tekniskt fel, till exempel et menyobjekt saknas eller något mer allvarligt, "
-"som att tillägget inte fungerar alls eller visar fel."
+"När du börjar surfa och använda ditt tillägg, ta del av det som verkar annorlunda från när du senast använde utökningen. Detta kan vara ett tekniskt fel, till exempel et menyobjekt saknas eller "
+"något mer allvarligt, som att tillägget inte fungerar alls eller visar fel."
 
 #: src/olympia/pages/templates/pages/acr_firstrun.html:49
 msgid ""
-"Once you know whether a particular add-on works properly or has problems, "
-"open the Add-ons Manager and click Compatibility next to the add-on to let "
-"Mozilla know what you found in your testing. Submitting a report will help "
-"us tell the add-on developer whether their add-on is working properly in "
-"this version or might need some fixes."
+"Once you know whether a particular add-on works properly or has problems, open the Add-ons Manager and click Compatibility next to the add-on to let Mozilla know what you found in your testing. "
+"Submitting a report will help us tell the add-on developer whether their add-on is working properly in this version or might need some fixes."
 msgstr ""
-"När du vet om ett särskilt tillägg fungerar som den ska eller har problem, "
-"öppna tilläggshanteraren och klicka på kompatibilitet bredvid tillägget för "
-"att låta Mozilla vet vad du hittat under testen. Genom att skicka in en "
-"rapport kommer du att hjälpa oss att berätta för tilläggsutvecklaren om "
-"deras tillägg fungerar korrekt i denna version eller kanske behöver vissa "
-"korrigeringar."
+"När du vet om ett särskilt tillägg fungerar som den ska eller har problem, öppna tilläggshanteraren och klicka på kompatibilitet bredvid tillägget för att låta Mozilla vet vad du hittat under "
+"testen. Genom att skicka in en rapport kommer du att hjälpa oss att berätta för tilläggsutvecklaren om deras tillägg fungerar korrekt i denna version eller kanske behöver vissa korrigeringar."
 
 #: src/olympia/pages/templates/pages/acr_firstrun.html:61
 #, python-format
 msgid ""
-"If you upgrade to a new version of Firefox or update your add-ons, your "
-"reports for the old versions will be hidden to allow you to test the new "
-"version. If you have any questions, please ask in <a href=\"%(url)s\">our "
-"forums</a>."
+"If you upgrade to a new version of Firefox or update your add-ons, your reports for the old versions will be hidden to allow you to test the new version. If you have any questions, please ask in <a "
+"href=\"%(url)s\">our forums</a>."
 msgstr ""
-"Om du uppgraderar till en ny version av Firefox eller uppdaterar ditt "
-"tillägg, dina rapporter för de gamla versionerna döljas så att du kan testa "
-"den nya versionen. Om du har några frågor, vänligen fråga i <a "
-"href=\"%(url)s\">vårt forum</a>."
+"Om du uppgraderar till en ny version av Firefox eller uppdaterar ditt tillägg, dina rapporter för de gamla versionerna döljas så att du kan testa den nya versionen. Om du har några frågor, vänligen "
+"fråga i <a href=\"%(url)s\">vårt forum</a>."
 
 #: src/olympia/pages/templates/pages/acr_firstrun.html:69
 msgid ""
-"Thousands of add-ons are made by our community every year, and your "
-"assistance with compatibility testing helps us make sure these add-ons stay "
-"useful as we strive to provide a great user experience."
+"Thousands of add-ons are made by our community every year, and your assistance with compatibility testing helps us make sure these add-ons stay useful as we strive to provide a great user "
+"experience."
 msgstr ""
-"Tusentals tillägg görs i vår gemenskap varje år och din hjälp med "
-"kompatibilitetstester hjälper oss se till att dessa tillägg fortsätter vara "
-"användbara eftersom vi strävar efter att ge en bra användarupplevelse."
+"Tusentals tillägg görs i vår gemenskap varje år och din hjälp med kompatibilitetstester hjälper oss se till att dessa tillägg fortsätter vara användbara eftersom vi strävar efter att ge en bra "
+"användarupplevelse."
 
 #: src/olympia/pages/templates/pages/acr_firstrun.html:75
 msgid "Thank you!"
@@ -11905,12 +9552,8 @@ msgid "Site Credits"
 msgstr "Medarbetarsida"
 
 #: src/olympia/pages/templates/pages/credits.html:12
-msgid ""
-"Mozilla would like to thank the following people for their contributions to "
-"the addons.mozilla.org project over the years:"
-msgstr ""
-"Mozilla vill tacka följande personer för deras bidrag till "
-"addons.mozilla.org projektet genom åren:"
+msgid "Mozilla would like to thank the following people for their contributions to the addons.mozilla.org project over the years:"
+msgstr "Mozilla vill tacka följande personer för deras bidrag till addons.mozilla.org projektet genom åren:"
 
 #: src/olympia/pages/templates/pages/credits.html:18
 msgid "Developers &amp; Administrators"
@@ -11943,87 +9586,63 @@ msgstr "Program och bilder"
 
 #: src/olympia/pages/templates/pages/credits.html:59
 msgid ""
-"Some icons used are from the <a "
-"href=\"http://www.famfamfam.com/lab/icons/silk/\">famfamfam Silk Icon "
-"Set</a>, licensed under a <a "
-"href=\"http://creativecommons.org/licenses/by/2.5/\">Creative Commons "
-"Attribution 2.5 License</a>."
+"Some icons used are from the <a href=\"http://www.famfamfam.com/lab/icons/silk/\">famfamfam Silk Icon Set</a>, licensed under a <a href=\"http://creativecommons.org/licenses/by/2.5/\">Creative "
+"Commons Attribution 2.5 License</a>."
 msgstr ""
-"Vissa ikoner som används är från <a "
-"href=\"http://www.famfamfam.com/lab/icons/silk/\">famfamfam Silk Icon "
-"Set</a>, licensierat under en <a "
-"href=\"http://creativecommons.org/licenses/by/2.5/\">Creative Commons "
-"Attribution 2.5 License</a>."
+"Vissa ikoner som används är från <a href=\"http://www.famfamfam.com/lab/icons/silk/\">famfamfam Silk Icon Set</a>, licensierat under en <a href=\"http://creativecommons.org/licenses/by/2.5/"
+"\">Creative Commons Attribution 2.5 License</a>."
 
 #: src/olympia/pages/templates/pages/credits.html:60
 msgid ""
-"Some icons used are from the <a href=\"http://www.fatcow.com/free-"
-"icons/\">FatCow Farm-Fresh Web Icons Set</a>, licensed under a <a "
-"href=\"http://creativecommons.org/licenses/by/3.0/us/\">Creative Commons "
-"Attribution 3.0 License</a>."
+"Some icons used are from the <a href=\"http://www.fatcow.com/free-icons/\">FatCow Farm-Fresh Web Icons Set</a>, licensed under a <a href=\"http://creativecommons.org/licenses/by/3.0/us/\">Creative "
+"Commons Attribution 3.0 License</a>."
 msgstr ""
-"Vissa ikoner som används är från <a href=\"http://www.fatcow.com/free-"
-"icons/\">FatCow Farm-Fresh Web Icons Set</a>, licensierat under en <a "
-"href=\"http://creativecommons.org/licenses/by/3.0/us/\">Creative Commons "
-"Attribution 3.0 License</a>."
+"Vissa ikoner som används är från <a href=\"http://www.fatcow.com/free-icons/\">FatCow Farm-Fresh Web Icons Set</a>, licensierat under en <a href=\"http://creativecommons.org/licenses/by/3.0/us/"
+"\">Creative Commons Attribution 3.0 License</a>."
 
 #: src/olympia/pages/templates/pages/credits.html:61
 msgid ""
-"Some pages use elements of <a "
-"href=\"http://shop.highsoft.com/highcharts.html\">Highcharts</a> (non-"
-"commercial), licensed under a <a href=\"http://creativecommons.org/licenses"
-"/by-nc/3.0/\">Creative Commons Attribution-NonCommercial 3.0 License</a>."
+"Some pages use elements of <a href=\"http://shop.highsoft.com/highcharts.html\">Highcharts</a> (non-commercial), licensed under a <a href=\"http://creativecommons.org/licenses/by-nc/3.0/\">Creative "
+"Commons Attribution-NonCommercial 3.0 License</a>."
 msgstr ""
-"Vissa sidor använda element av <a "
-"href=\"http://shop.highsoft.com/highcharts.html\">Highcharts</a> (icke-"
-"kommersiell), licensierat under en <a "
-"href=\"http://creativecommons.org/licenses/by-nc/3.0/\">Creative Commons "
-"Attribution-NonCommercial 3.0 License</a>."
+"Vissa sidor använda element av <a href=\"http://shop.highsoft.com/highcharts.html\">Highcharts</a> (icke-kommersiell), licensierat under en <a href=\"http://creativecommons.org/licenses/by-nc/3.0/"
+"\">Creative Commons Attribution-NonCommercial 3.0 License</a>."
 
 #: src/olympia/pages/templates/pages/credits.html:65
 #, python-format
-msgid ""
-"For information on contributing, please see our <a href=\"%(url)s\">wiki "
-"page</a>."
+msgid "For information on contributing, please see our <a href=\"%(url)s\">wiki page</a>."
 msgstr "För information om att bidra, se vår <a href=\"%(url)s\">wiki-sida</a>."
 
 #: src/olympia/pages/templates/pages/dev_faq.html:4
 msgid "Developer FAQ"
 msgstr "FAQ utvecklare"
 
-#: src/olympia/pages/templates/pages/dev_faq.html:31
-#: src/olympia/pages/templates/pages/review_guide.html:33
+#: src/olympia/pages/templates/pages/dev_faq.html:31 src/olympia/pages/templates/pages/review_guide.html:33
 msgid "Sections"
 msgstr "Avdelningar"
 
-#: src/olympia/pages/templates/pages/dev_faq.html:33
-#: src/olympia/pages/templates/pages/dev_faq.html:45
+#: src/olympia/pages/templates/pages/dev_faq.html:33 src/olympia/pages/templates/pages/dev_faq.html:45
 msgid "Developing an Add-on"
 msgstr "Utveckla ett tillägg"
 
 #. Heading for a list of resources for developers
-#: src/olympia/pages/templates/pages/dev_faq.html:34
-#: src/olympia/pages/templates/pages/dev_faq.html:208
+#: src/olympia/pages/templates/pages/dev_faq.html:34 src/olympia/pages/templates/pages/dev_faq.html:208
 msgid "Support Resources"
 msgstr "Support Resurser"
 
-#: src/olympia/pages/templates/pages/dev_faq.html:35
-#: src/olympia/pages/templates/pages/dev_faq.html:261
+#: src/olympia/pages/templates/pages/dev_faq.html:35 src/olympia/pages/templates/pages/dev_faq.html:261
 msgid "Contributing your Add-on"
 msgstr "Bidrar ditt tillägg"
 
-#: src/olympia/pages/templates/pages/dev_faq.html:36
-#: src/olympia/pages/templates/pages/dev_faq.html:381
+#: src/olympia/pages/templates/pages/dev_faq.html:36 src/olympia/pages/templates/pages/dev_faq.html:381
 msgid "Add-on Review Process"
 msgstr "Granskningsprocess för tillägg"
 
-#: src/olympia/pages/templates/pages/dev_faq.html:37
-#: src/olympia/pages/templates/pages/dev_faq.html:444
+#: src/olympia/pages/templates/pages/dev_faq.html:37 src/olympia/pages/templates/pages/dev_faq.html:444
 msgid "Managing Your Add-on"
 msgstr "Hantera ditt tillägg"
 
-#: src/olympia/pages/templates/pages/dev_faq.html:39
-#: src/olympia/pages/templates/pages/dev_faq.html:528
+#: src/olympia/pages/templates/pages/dev_faq.html:39 src/olympia/pages/templates/pages/dev_faq.html:528
 msgid "References for Open Source Licenses"
 msgstr "Referenser för Open Source licenser"
 
@@ -12033,14 +9652,8 @@ msgstr "Tilläggs utvecklar FAQ"
 
 #: src/olympia/pages/templates/pages/dev_faq.html:47
 #, python-format
-msgid ""
-"<h3>How do I build an Add-on?</h3> <p> Mozilla provides documentation on how"
-" to build an add-on via the <a href=\"%(url)s\">Mozilla Developer "
-"Network</a>. </p>"
-msgstr ""
-"<h3>Hur skapar jag ett tillägg?</h3> <p> Mozilla tillhandahåller "
-"dokumentation om hur man bygger en tillägg via <a href=\"%(url)s\">Mozilla "
-"Developer Network</a>. </p>"
+msgid "<h3>How do I build an Add-on?</h3> <p> Mozilla provides documentation on how to build an add-on via the <a href=\"%(url)s\">Mozilla Developer Network</a>. </p>"
+msgstr "<h3>Hur skapar jag ett tillägg?</h3> <p> Mozilla tillhandahåller dokumentation om hur man bygger en tillägg via <a href=\"%(url)s\">Mozilla Developer Network</a>. </p>"
 
 #: src/olympia/pages/templates/pages/dev_faq.html:55
 msgid "Other resources include:"
@@ -12060,13 +9673,10 @@ msgstr "Vilka verktyg behöver jag för att kunna bygga ett tillägg?"
 
 #: src/olympia/pages/templates/pages/dev_faq.html:68
 msgid ""
-"You will need to have a version of the Mozilla software that you're building"
-" the add-on for and a code editor of your choice. Add-ons can be built for "
-"almost all Mozilla software but are primarily targeted for:"
+"You will need to have a version of the Mozilla software that you're building the add-on for and a code editor of your choice. Add-ons can be built for almost all Mozilla software but are primarily "
+"targeted for:"
 msgstr ""
-"Du måste ha en version av Mozillas mjukvara som du bygger tillägget för och "
-"en kodredigerare som du väljer. Tillägg kan byggas för nästan alla Mozillas "
-"mjukvara men är huvudsakligen måltavlan för:"
+"Du måste ha en version av Mozillas mjukvara som du bygger tillägget för och en kodredigerare som du väljer. Tillägg kan byggas för nästan alla Mozillas mjukvara men är huvudsakligen måltavlan för:"
 
 #: src/olympia/pages/templates/pages/dev_faq.html:82
 msgid "Popular code editors include:"
@@ -12075,38 +9685,24 @@ msgstr "Populära kodredigerare inkluderar:"
 #. This is a list of popular code editors.  Feel free to adjust as you like.
 #: src/olympia/pages/templates/pages/dev_faq.html:85
 msgid ""
-"<li><a href=\"http://komodoide.com/komodo-edit/\">Komodo Edit</a></li> "
-"<li><a href=\"http://macromates.com/\">TextMate</a></li> <li><a href=\"http"
-"://notepad-plus-plus.org/\">Notepad++</a></li> <li><a "
-"href=\"http://www.eclipse.org/\">Eclipse IDE</a></li>"
+"<li><a href=\"http://komodoide.com/komodo-edit/\">Komodo Edit</a></li> <li><a href=\"http://macromates.com/\">TextMate</a></li> <li><a href=\"http://notepad-plus-plus.org/\">Notepad++</a></li> "
+"<li><a href=\"http://www.eclipse.org/\">Eclipse IDE</a></li>"
 msgstr ""
-"<li><a href=\"http://komodoide.com/komodo-edit/\">Komodo Edit</a></li> "
-"<li><a href=\"http://macromates.com/\">TextMate</a></li> <li><a href=\"http"
-"://notepad-plus-plus.org/\">Notepad++</a></li> <li><a "
-"href=\"http://www.eclipse.org/\">Eclipse IDE</a></li>"
+"<li><a href=\"http://komodoide.com/komodo-edit/\">Komodo Edit</a></li> <li><a href=\"http://macromates.com/\">TextMate</a></li> <li><a href=\"http://notepad-plus-plus.org/\">Notepad++</a></li> "
+"<li><a href=\"http://www.eclipse.org/\">Eclipse IDE</a></li>"
 
 #: src/olympia/pages/templates/pages/dev_faq.html:94
 #, python-format
-msgid ""
-"You can also learn more about setting up your development environment via "
-"the MDN article <a href=\"%(url)s\">Setting up extension development "
-"environment</a>"
-msgstr ""
-"Du kan också lära dig mer om hur du konfigurerar din utvecklingsmiljö via "
-"MDN artikeln <a href=\"%(url)s\">Konfigurera utvecklingsmiljö för "
-"utökningar</a>"
+msgid "You can also learn more about setting up your development environment via the MDN article <a href=\"%(url)s\">Setting up extension development environment</a>"
+msgstr "Du kan också lära dig mer om hur du konfigurerar din utvecklingsmiljö via MDN artikeln <a href=\"%(url)s\">Konfigurera utvecklingsmiljö för utökningar</a>"
 
 #: src/olympia/pages/templates/pages/dev_faq.html:100
 msgid "What is a \".xpi\" file?"
 msgstr "Vad är en \".xpi\"-fil?"
 
 #: src/olympia/pages/templates/pages/dev_faq.html:102
-msgid ""
-"Extensions are packaged and distributed in ZIP files or Bundles, with the "
-"XPI (pronounced \"zippy\") file extension."
-msgstr ""
-"Utökningar är paketerade och distribueras i ZIP-filer eller Bundles, med "
-"filtillägget XPI (uttalas \"zippy\")."
+msgid "Extensions are packaged and distributed in ZIP files or Bundles, with the XPI (pronounced \"zippy\") file extension."
+msgstr "Utökningar är paketerade och distribueras i ZIP-filer eller Bundles, med filtillägget XPI (uttalas \"zippy\")."
 
 #: src/olympia/pages/templates/pages/dev_faq.html:108
 msgid "What is XUL?"
@@ -12114,16 +9710,11 @@ msgstr "Vad är XUL?"
 
 #: src/olympia/pages/templates/pages/dev_faq.html:110
 msgid ""
-"XUL (XML User Interface Language) is Mozilla's XML-based language that lets "
-"you build feature-rich cross platform applications. It provides user "
-"interface widgets like buttons, menus, toolbars, trees, etc that can be used"
-" to enhance add-ons by modifying parts of the browser UI."
+"XUL (XML User Interface Language) is Mozilla's XML-based language that lets you build feature-rich cross platform applications. It provides user interface widgets like buttons, menus, toolbars, "
+"trees, etc that can be used to enhance add-ons by modifying parts of the browser UI."
 msgstr ""
-"XUL (XML User Interface Language) är Mozillas XML-baserade språk som låter "
-"dig bygga funktionsrika plattformsoberoende program. Det ger ett "
-"användargränssnitt med widgets som knappar, menyer, verktygsfält, träd, etc "
-"som kan användas för att förbättra tillägg genom att ändra delar av "
-"webbläsarens UI."
+"XUL (XML User Interface Language) är Mozillas XML-baserade språk som låter dig bygga funktionsrika plattformsoberoende program. Det ger ett användargränssnitt med widgets som knappar, menyer, "
+"verktygsfält, träd, etc som kan användas för att förbättra tillägg genom att ändra delar av webbläsarens UI."
 
 #: src/olympia/pages/templates/pages/dev_faq.html:119
 msgid "What is the \"install.rdf\" file used for?"
@@ -12132,34 +9723,21 @@ msgstr "Vad används filen \"install.rdf\" till?"
 #: src/olympia/pages/templates/pages/dev_faq.html:121
 #, python-format
 msgid ""
-"This file, called an <a href=\"%(url)s\">Install Manifest</a>, is used by "
-"Add-on Manager-enabled XUL applications to determine information about an "
-"add-on as it is being installed. It contains metadata identifying the add-"
-"on, providing information about who created it, where more information can "
-"be found about it, which versions of what applications it is compatible "
-"with, how it should be updated, and so on. The format of the Install "
-"Manifest is RDF/XML."
+"This file, called an <a href=\"%(url)s\">Install Manifest</a>, is used by Add-on Manager-enabled XUL applications to determine information about an add-on as it is being installed. It contains "
+"metadata identifying the add-on, providing information about who created it, where more information can be found about it, which versions of what applications it is compatible with, how it should "
+"be updated, and so on. The format of the Install Manifest is RDF/XML."
 msgstr ""
-"Denna fil, som kallas en <a href=\"%(url)s\">Install Manifest</a>, används "
-"av tilläggshanterar-aktiverade XUL program för att bestämma information om "
-"ett tillägg som ska installeras. Den innehåller metadata som identifierar "
-"tillägget, som ger information om vem som skapade den, där mer information "
-"kan hittas om det, vilka versioner av program som den är kompatibel med, hur"
-" det ska uppdateras och så vidare. Formatet på Install Manifest är RDF/XML."
+"Denna fil, som kallas en <a href=\"%(url)s\">Install Manifest</a>, används av tilläggshanterar-aktiverade XUL program för att bestämma information om ett tillägg som ska installeras. Den innehåller "
+"metadata som identifierar tillägget, som ger information om vem som skapade den, där mer information kan hittas om det, vilka versioner av program som den är kompatibel med, hur det ska uppdateras "
+"och så vidare. Formatet på Install Manifest är RDF/XML."
 
 #: src/olympia/pages/templates/pages/dev_faq.html:132
 msgid "What does \"maxVersion\" mean?"
 msgstr "Vad betyder \"maxVersion\"?"
 
 #: src/olympia/pages/templates/pages/dev_faq.html:134
-msgid ""
-"This determines the maximum version of Firefox you're saying this extension "
-"will work with. Set this to be no newer than the newest currently available "
-"version!"
-msgstr ""
-"Detta bestämmer den maximala versionen av Firefox du säger denna utökning "
-"kommer att fungera med. Ange detta för att inte vara nyare än den senaste "
-"tillgängliga version!"
+msgid "This determines the maximum version of Firefox you're saying this extension will work with. Set this to be no newer than the newest currently available version!"
+msgstr "Detta bestämmer den maximala versionen av Firefox du säger denna utökning kommer att fungera med. Ange detta för att inte vara nyare än den senaste tillgängliga version!"
 
 #: src/olympia/pages/templates/pages/dev_faq.html:141
 msgid "Can my add-on contain binary components?"
@@ -12168,42 +9746,25 @@ msgstr "Kan mitt tillägg innehålla binära komponenter?"
 #: src/olympia/pages/templates/pages/dev_faq.html:143
 #, python-format
 msgid ""
-"Yes. You can use Mozilla's <a href=\"%(url)s\">XPCOM component object "
-"model</a> to enhance your add-ons. XPCOM components be used and implemented "
-"in JavaScript, Java, and Python in addition to C++."
+"Yes. You can use Mozilla's <a href=\"%(url)s\">XPCOM component object model</a> to enhance your add-ons. XPCOM components be used and implemented in JavaScript, Java, and Python in addition to C++."
 msgstr ""
-"Ja. Du kan använda Mozillas <a href=\"%(url)s\">XPCOM "
-"komponentobjektmodell</a> för att förbättra ditt tillägg. XPCOM komponenter "
-"kan användas och implementeras i JavaScript, Java och Python förutom C ++."
+"Ja. Du kan använda Mozillas <a href=\"%(url)s\">XPCOM komponentobjektmodell</a> för att förbättra ditt tillägg. XPCOM komponenter kan användas och implementeras i JavaScript, Java och Python "
+"förutom C ++."
 
 #: src/olympia/pages/templates/pages/dev_faq.html:150
-msgid ""
-"Can I use a JavaScript library like jQuery, MooTools or Prototype to build "
-"my add-on?"
-msgstr ""
-"Kan jag använda ett JavaScript-bibliotek som jQuery, MooTools eller Prototyp"
-" för att bygga mitt tillägg?"
+msgid "Can I use a JavaScript library like jQuery, MooTools or Prototype to build my add-on?"
+msgstr "Kan jag använda ett JavaScript-bibliotek som jQuery, MooTools eller Prototyp för att bygga mitt tillägg?"
 
 #: src/olympia/pages/templates/pages/dev_faq.html:152
 msgid ""
-"Yes. It's possible, but some of the functionality provided by these "
-"libraries are available through XPCOM, XUL, and JavaScript. In addition, "
-"authors should take care if libraries modify primitive object prototypes "
-"(String.prototype, Date.prototype, etc.) and/or define global functions (eg."
-" the $ function). These are prone to cause conflict with other add-ons, in "
-"particular if different add-ons use different versions of libraries and so "
-"on. Developers need to be very, very careful with using them.  Mozilla does "
-"not offer documentation on using them to build add-ons."
+"Yes. It's possible, but some of the functionality provided by these libraries are available through XPCOM, XUL, and JavaScript. In addition, authors should take care if libraries modify primitive "
+"object prototypes (String.prototype, Date.prototype, etc.) and/or define global functions (eg. the $ function). These are prone to cause conflict with other add-ons, in particular if different add-"
+"ons use different versions of libraries and so on. Developers need to be very, very careful with using them. Mozilla does not offer documentation on using them to build add-ons."
 msgstr ""
-"Ja. Det är möjligt, men en del av den funktionalitet som tillhandahålls av "
-"dessa bibliotek är tillgängliga via XPCOM, XUL och JavaScript. Dessutom bör "
-"upphovsmannen ta hand om biblioteken som ändrar primitiva objektprototyper "
-"(String.prototype, Date.prototype, etc.) och/eller definiera globala "
-"funktioner (exempel funktionen $). Dessa är benägna att orsaka konflikter "
-"med andra tillägg, särskilt om olika tillägg använder olika versioner av "
-"biblioteken och så vidare. Utvecklare måste vara mycket försiktig med att "
-"använda dessa.  Mozilla erbjuder inte dokumentation om hur du använder dessa"
-" för att bygga tillägg."
+"Ja. Det är möjligt, men en del av den funktionalitet som tillhandahålls av dessa bibliotek är tillgängliga via XPCOM, XUL och JavaScript. Dessutom bör upphovsmannen ta hand om biblioteken som "
+"ändrar primitiva objektprototyper (String.prototype, Date.prototype, etc.) och/eller definiera globala funktioner (exempel funktionen $). Dessa är benägna att orsaka konflikter med andra tillägg, "
+"särskilt om olika tillägg använder olika versioner av biblioteken och så vidare. Utvecklare måste vara mycket försiktig med att använda dessa.  Mozilla erbjuder inte dokumentation om hur du "
+"använder dessa för att bygga tillägg."
 
 #: src/olympia/pages/templates/pages/dev_faq.html:165
 msgid "How do I debug my add-on?"
@@ -12215,32 +9776,19 @@ msgid "You can use the <a href=\"%(url)s\">Add-on Debugger</a>."
 msgstr "Du kan använda <a href=\"%(url)s\">felsökaren för tillägg</a>."
 
 #: src/olympia/pages/templates/pages/dev_faq.html:172
-msgid ""
-"How do I test for compatibility with the latest version of Mozilla software?"
-msgstr ""
-"Hur testar jag kompatibilitet med den senaste versionen av programvara från "
-"Mozilla?"
+msgid "How do I test for compatibility with the latest version of Mozilla software?"
+msgstr "Hur testar jag kompatibilitet med den senaste versionen av programvara från Mozilla?"
 
 #: src/olympia/pages/templates/pages/dev_faq.html:174
 msgid ""
-"To ensure compatibility with the latest Mozilla software, it's important to "
-"download updates as they become available and test your add-on to ensure "
-"that it is still functioning as expected. In many cases, the latest version "
-"of Mozilla software may be a beta release. Since these releases at times "
-"introduce architectural changes that may impact the functionality of your "
-"add-on, it's important to be actively involved in the beta process to ensure"
-" that your add-on users are not negatively impacted upon final release of "
-"Mozilla software."
+"To ensure compatibility with the latest Mozilla software, it's important to download updates as they become available and test your add-on to ensure that it is still functioning as expected. In "
+"many cases, the latest version of Mozilla software may be a beta release. Since these releases at times introduce architectural changes that may impact the functionality of your add-on, it's "
+"important to be actively involved in the beta process to ensure that your add-on users are not negatively impacted upon final release of Mozilla software."
 msgstr ""
-"För att säkerställa kompatibilitet med den senaste programvaran av Mozilla, "
-"är det viktigt att ladda ner uppdateringar när de blir tillgängliga och "
-"testa ditt tillägg för att säkerställa att det fortfarande fungerar som "
-"förväntat. I många fall kan den senaste versionen av Mozillas programvara "
-"vara en betaversion. Eftersom dessa släpp ibland inför arkitektoniska "
-"förändringar som kan påverka funktionaliteten hos ditt tillägg, är det "
-"viktigt att aktivt delta i beta-processen för att säkerställa att ditt "
-"tilläggs användare inte negativt påverkas av den slutliga utgåvan av "
-"Mozillas programvara."
+"För att säkerställa kompatibilitet med den senaste programvaran av Mozilla, är det viktigt att ladda ner uppdateringar när de blir tillgängliga och testa ditt tillägg för att säkerställa att det "
+"fortfarande fungerar som förväntat. I många fall kan den senaste versionen av Mozillas programvara vara en betaversion. Eftersom dessa släpp ibland inför arkitektoniska förändringar som kan påverka "
+"funktionaliteten hos ditt tillägg, är det viktigt att aktivt delta i beta-processen för att säkerställa att ditt tilläggs användare inte negativt påverkas av den slutliga utgåvan av Mozillas "
+"programvara."
 
 #: src/olympia/pages/templates/pages/dev_faq.html:185
 msgid "How to improve the performance of my add-on?"
@@ -12249,17 +9797,11 @@ msgstr "Hur förbättrar jag prestanda för mitt tillägg?"
 #: src/olympia/pages/templates/pages/dev_faq.html:187
 #, python-format
 msgid ""
-"Poorly written extensions can have a severe impact on the browsing "
-"experience, including on the overall performance of Firefox itself. The "
-"following page contains many good <a href=\"%(url)s\">guides</a> that help "
-"you improve performance, whether you're developing core Mozilla code or an "
-"add-on."
+"Poorly written extensions can have a severe impact on the browsing experience, including on the overall performance of Firefox itself. The following page contains many good <a href=\"%(url)s"
+"\">guides</a> that help you improve performance, whether you're developing core Mozilla code or an add-on."
 msgstr ""
-"Dåligt skrivna tillägg kan ha en allvarlig inverkan på surfupplevelsen, "
-"bland annat om den totala prestandan för Firefox själv. Följande sida "
-"innehåller många bra <a href=\"%(url)s\">guider</a> som hjälper dig att "
-"förbättra prestanda, oavsett om du utvecklar kod för Mozilla eller ett "
-"tillägg."
+"Dåligt skrivna tillägg kan ha en allvarlig inverkan på surfupplevelsen, bland annat om den totala prestandan för Firefox själv. Följande sida innehåller många bra <a href=\"%(url)s\">guider</a> som "
+"hjälper dig att förbättra prestanda, oavsett om du utvecklar kod för Mozilla eller ett tillägg."
 
 #: src/olympia/pages/templates/pages/dev_faq.html:195
 msgid "Can my add-on support multiple locales?"
@@ -12268,21 +9810,15 @@ msgstr "Kan mitt tillägg stödja flera språk?"
 #: src/olympia/pages/templates/pages/dev_faq.html:197
 #, python-format
 msgid ""
-"Yes. Details on localizing your add-on can be found in the the <a "
-"href=\"%(l10n_url)s\">Mozilla Developer Network Localization page</a>. <a "
-"href=\"%(bz_url)s\">The BabelZilla project</a> is also a great resource for "
-"learning about localization and volunteering to help translate add-ons."
+"Yes. Details on localizing your add-on can be found in the the <a href=\"%(l10n_url)s\">Mozilla Developer Network Localization page</a>. <a href=\"%(bz_url)s\">The BabelZilla project</a> is also a "
+"great resource for learning about localization and volunteering to help translate add-ons."
 msgstr ""
-"Ja. Detaljer om att översätta dit tillägg kan hittas i <a "
-"href=\"%(l10n_url)s\">Mozilla Developer Network Lokaliseringssdia</a>. <a "
-"href=\"%(bz_url)s\">Projektet BabelZilla</a> är också en stor resurs för att"
-" lära mer om lokalisering och frivillighet för att hjälpa till att översätta"
-" tillägg."
+"Ja. Detaljer om att översätta dit tillägg kan hittas i <a href=\"%(l10n_url)s\">Mozilla Developer Network Lokaliseringssdia</a>. <a href=\"%(bz_url)s\">Projektet BabelZilla</a> är också en stor "
+"resurs för att lära mer om lokalisering och frivillighet för att hjälpa till att översätta tillägg."
 
 #: src/olympia/pages/templates/pages/dev_faq.html:210
 msgid "I need some advice building my add-on. Where can I find help?"
-msgstr ""
-"Jag behöver några råd för att bygga mitt tillägg. Var hittar jag hjälp?"
+msgstr "Jag behöver några råd för att bygga mitt tillägg. Var hittar jag hjälp?"
 
 #. #extdev is the name of the IRC channel.  do not change.
 #: src/olympia/pages/templates/pages/dev_faq.html:216
@@ -12296,12 +9832,8 @@ msgstr "#amo (för support relaterat till att hysa ditt tillägg på AMO)"
 
 #. #jetpack is the name of the IRC channel.  do not change.
 #: src/olympia/pages/templates/pages/dev_faq.html:220
-msgid ""
-"#jetpack (for discussions about the Add-ons SDK and cfx/jpm - formerly known"
-" as Jetpack)"
-msgstr ""
-"#jetpack (för diskussioner om tillägg SDK och cfx/jpm - tidigare känd som "
-"Jetpack)"
+msgid "#jetpack (for discussions about the Add-ons SDK and cfx/jpm - formerly known as Jetpack)"
+msgstr "#jetpack (för diskussioner om tillägg SDK och cfx/jpm - tidigare känd som Jetpack)"
 
 #. Label for a link to the extension developers mailing list
 #: src/olympia/pages/templates/pages/dev_faq.html:225
@@ -12336,24 +9868,16 @@ msgstr "Nej."
 
 #: src/olympia/pages/templates/pages/dev_faq.html:246
 msgid "Are there 3rd party developers that I can hire to build my add-on?"
-msgstr ""
-"Finns det tredjepartsutvecklare som jag kan hyra för att bygga mitt tillägg?"
+msgstr "Finns det tredjepartsutvecklare som jag kan hyra för att bygga mitt tillägg?"
 
 #: src/olympia/pages/templates/pages/dev_faq.html:248
 #, python-format
 msgid ""
-"Yes. You may find 3rd party developers via the <a href=\"%(forum_url)s"
-"\">Add-ons forum</a>, <a href=\"%(list_url)s\">mozilla.jobs list</a>, <a "
-"href=\"%(mz_url)s\">mozillaZine forums</a> or <a href=\"%(wiki_url)s\">the "
-"Mozilla Wiki</a>. Please note that Mozilla does not offer developer "
-"recommendations."
+"Yes. You may find 3rd party developers via the <a href=\"%(forum_url)s\">Add-ons forum</a>, <a href=\"%(list_url)s\">mozilla.jobs list</a>, <a href=\"%(mz_url)s\">mozillaZine forums</a> or <a href="
+"\"%(wiki_url)s\">the Mozilla Wiki</a>. Please note that Mozilla does not offer developer recommendations."
 msgstr ""
-"Ja. Du kan hitta tredjepartsutvecklare via <a "
-"href=\"%(forum_url)s\">tilläggsforum</a>, <a "
-"href=\"%(list_url)s\">mozilla.jobs lista</a>, <a "
-"href=\"%(mz_url)s\">mozillaZine forum</a> eller <a "
-"href=\"%(wiki_url)s\">Mozilla Wiki</a>. Observera att Mozilla inte erbjuder "
-"utvecklare rekommendationer."
+"Ja. Du kan hitta tredjepartsutvecklare via <a href=\"%(forum_url)s\">tilläggsforum</a>, <a href=\"%(list_url)s\">mozilla.jobs lista</a>, <a href=\"%(mz_url)s\">mozillaZine forum</a> eller <a href="
+"\"%(wiki_url)s\">Mozilla Wiki</a>. Observera att Mozilla inte erbjuder utvecklare rekommendationer."
 
 #: src/olympia/pages/templates/pages/dev_faq.html:263
 msgid "Can I host my own add-on?"
@@ -12362,21 +9886,13 @@ msgstr "Kan jag hysa mina egna tillägg?"
 #: src/olympia/pages/templates/pages/dev_faq.html:265
 #, python-format
 msgid ""
-"Yes. Many developers choose to host their own add-ons. Choosing to host your"
-" add-on on <a href=\"%(amo_url)s\">Mozilla's add-on site</a>, though, allows"
-" for much greater exposure to your add-on due to the large volume of "
-"visitors to the site.  <a href=\"%(md_url)s\">mozdev.org</a> offers free "
-"project hosting for Mozilla applications and extensions providing developers"
-" with tools to help manage source code, version control, bug tracking and "
-"documentation."
+"Yes. Many developers choose to host their own add-ons. Choosing to host your add-on on <a href=\"%(amo_url)s\">Mozilla's add-on site</a>, though, allows for much greater exposure to your add-on due "
+"to the large volume of visitors to the site. <a href=\"%(md_url)s\">mozdev.org</a> offers free project hosting for Mozilla applications and extensions providing developers with tools to help manage "
+"source code, version control, bug tracking and documentation."
 msgstr ""
-"Ja. Många utvecklare väljer att vara värd för sina egna tillägg. Att hysa "
-"ditt tillägg på <a href=\"%(amo_url)s\">Mozillas tilläggswebbplats</a>, "
-"möjliggör en mycket större exponering av ditt tillägg på grund av den stora "
-"mängden besökare.  <a href=\"%(md_url)s\">mozdev.org </a> erbjuder att "
-"gratis hysa projekt för Mozilla applikationer och utökningar. De förser "
-"utvecklaren med verktyg för att hantera källkod, versionskontroll , "
-"felrapporteringssystem och dokumentation."
+"Ja. Många utvecklare väljer att vara värd för sina egna tillägg. Att hysa ditt tillägg på <a href=\"%(amo_url)s\">Mozillas tilläggswebbplats</a>, möjliggör en mycket större exponering av ditt "
+"tillägg på grund av den stora mängden besökare.  <a href=\"%(md_url)s\">mozdev.org </a> erbjuder att gratis hysa projekt för Mozilla applikationer och utökningar. De förser utvecklaren med verktyg "
+"för att hantera källkod, versionskontroll , felrapporteringssystem och dokumentation."
 
 #: src/olympia/pages/templates/pages/dev_faq.html:277
 msgid "Can Mozilla host my add-on?"
@@ -12384,12 +9900,8 @@ msgstr "Kan Mozilla hysa mitt tillägg?"
 
 #: src/olympia/pages/templates/pages/dev_faq.html:279
 #, python-format
-msgid ""
-"Yes. You can host your add-on on <a href=\"%(url)s\">Mozilla's add-on "
-"website</a>."
-msgstr ""
-"Ja. Du kan hysa ditt tillägg på <a href=\"%(url)s\">Mozillas webbplats för "
-"tillägg</a>."
+msgid "Yes. You can host your add-on on <a href=\"%(url)s\">Mozilla's add-on website</a>."
+msgstr "Ja. Du kan hysa ditt tillägg på <a href=\"%(url)s\">Mozillas webbplats för tillägg</a>."
 
 #: src/olympia/pages/templates/pages/dev_faq.html:284
 msgid "What is AMO?"
@@ -12397,19 +9909,11 @@ msgstr "Vad är AMO?"
 
 #: src/olympia/pages/templates/pages/dev_faq.html:286
 msgid ""
-"Mozilla's AMO (<a "
-"href=\"https://addons.mozilla.org\">https://addons.mozilla.org</a>) is the "
-"incubator that helps developers build, distribute, and support fantastic "
-"consumer products powered by Mozilla. It provides you the tools and "
-"infrastructure necessary to manage, host and expose your add-on to a massive"
-" base of Mozilla users."
+"Mozilla's AMO (<a href=\"https://addons.mozilla.org\">https://addons.mozilla.org</a>) is the incubator that helps developers build, distribute, and support fantastic consumer products powered by "
+"Mozilla. It provides you the tools and infrastructure necessary to manage, host and expose your add-on to a massive base of Mozilla users."
 msgstr ""
-"Mozillas AMO (<a "
-"href=\"https://addons.mozilla.org\">https://addons.mozilla.org</a>) är den "
-"inkubator som hjälper utvecklare bygga, distribuera och stödja fantastiska "
-"konsumentprodukter som drivs av Mozilla. Det ger dig de verktyg och den "
-"infrastruktur som behövs för att hantera, hysa och exponera dina tillägg "
-"till en massiv bas av Mozilla-användare."
+"Mozillas AMO (<a href=\"https://addons.mozilla.org\">https://addons.mozilla.org</a>) är den inkubator som hjälper utvecklare bygga, distribuera och stödja fantastiska konsumentprodukter som drivs "
+"av Mozilla. Det ger dig de verktyg och den infrastruktur som behövs för att hantera, hysa och exponera dina tillägg till en massiv bas av Mozilla-användare."
 
 #: src/olympia/pages/templates/pages/dev_faq.html:295
 msgid "Does Mozilla keep my account information private?"
@@ -12417,12 +9921,8 @@ msgstr "Ser Mozilla till att min kontoinformation är privat?"
 
 #: src/olympia/pages/templates/pages/dev_faq.html:297
 #, python-format
-msgid ""
-"Yes. Our <a href=\"%(url)s\">Privacy Policy</a> describes how your "
-"information is managed by Mozilla."
-msgstr ""
-"Ja. Vår <a href=\"%(url)s\">Sekretesspolicy</a> beskriver hur din "
-"information hanteras av Mozilla."
+msgid "Yes. Our <a href=\"%(url)s\">Privacy Policy</a> describes how your information is managed by Mozilla."
+msgstr "Ja. Vår <a href=\"%(url)s\">Sekretesspolicy</a> beskriver hur din information hanteras av Mozilla."
 
 #: src/olympia/pages/templates/pages/dev_faq.html:302
 msgid "What are the \"developer tools\" listed on AMO?"
@@ -12430,36 +9930,24 @@ msgstr "Vad innehåller \"utvecklingsverktygen\" som är listade på AMO?"
 
 #: src/olympia/pages/templates/pages/dev_faq.html:304
 msgid ""
-"The \"Developer Tools\" dashboard is the area that provides you the tools to"
-" successfully manage your add-ons. It provides the functionality necessary "
-"to submit your add-ons to AMO, manage add-on information, and review "
-"statistics."
+"The \"Developer Tools\" dashboard is the area that provides you the tools to successfully manage your add-ons. It provides the functionality necessary to submit your add-ons to AMO, manage add-on "
+"information, and review statistics."
 msgstr ""
-"Översikten för \"Utvecklingsverktyg\" är det område som ger dig verktygen "
-"för att framgångsrikt hantera dina tillägg. Det ger funktionalitet som krävs"
-" för att skicka dina tillägg till AMO, hantera tilläggsinformation och "
-"granska statistik."
+"Översikten för \"Utvecklingsverktyg\" är det område som ger dig verktygen för att framgångsrikt hantera dina tillägg. Det ger funktionalitet som krävs för att skicka dina tillägg till AMO, hantera "
+"tilläggsinformation och granska statistik."
 
 #: src/olympia/pages/templates/pages/dev_faq.html:312
-msgid ""
-"Does Mozilla have a policy in place as to what is an acceptable submission?"
-msgstr ""
-"Har Mozilla en policy på plats om vad som är en acceptabel inskickning?"
+msgid "Does Mozilla have a policy in place as to what is an acceptable submission?"
+msgstr "Har Mozilla en policy på plats om vad som är en acceptabel inskickning?"
 
 #: src/olympia/pages/templates/pages/dev_faq.html:314
 #, python-format
 msgid ""
-"Yes. Mozilla's <a href=\"%(p_url)s\">Add-on Policy</a> describes what is an "
-"acceptable submission. This policy is subject to change without notice.  In "
-"addition, the AMO editorial team uses the <a href=\"%(g_url)s\">Editors "
-"Reviewing Guide</a> to ensure that your add-on meets specific guidelines for"
-" functionality and security."
+"Yes. Mozilla's <a href=\"%(p_url)s\">Add-on Policy</a> describes what is an acceptable submission. This policy is subject to change without notice. In addition, the AMO editorial team uses the <a "
+"href=\"%(g_url)s\">Editors Reviewing Guide</a> to ensure that your add-on meets specific guidelines for functionality and security."
 msgstr ""
-"Ja. Mozillas <a href=\"%(p_url)s\">tilläggspolicy</a> beskriver vad som är "
-"en acceptabel inskickning. Denna policy kan ändras utan förvarning.  "
-"Dessutom använder AMO redaktion <a href=\"%(g_url)s\">riktlinjer för "
-"redigerare</a> för att säkerställa att ditt tillägg uppfyller de särskilda "
-"riktlinjer för funktionalitet och säkerhet."
+"Ja. Mozillas <a href=\"%(p_url)s\">tilläggspolicy</a> beskriver vad som är en acceptabel inskickning. Denna policy kan ändras utan förvarning.  Dessutom använder AMO redaktion <a href=\"%(g_url)s"
+"\">riktlinjer för redigerare</a> för att säkerställa att ditt tillägg uppfyller de särskilda riktlinjer för funktionalitet och säkerhet."
 
 #: src/olympia/pages/templates/pages/dev_faq.html:324
 msgid "How do I submit my add-on for review?"
@@ -12468,29 +9956,19 @@ msgstr "Hur skickar jag in mitt tillägg för granskning?"
 #: src/olympia/pages/templates/pages/dev_faq.html:326
 #, python-format
 msgid ""
-"The Developer Tools dashboard will allow you to upload and submit add-ons to"
-" AMO. You must be a registered AMO users before you can submit an add-on. "
-"Before submitting your add-on be sure to you have read the AMO <a "
-"href=\"%(url)s\">Editors Reviewing Guide</a> to ensure that your add-on has "
-"met the guidelines used by editors to review add-ons."
+"The Developer Tools dashboard will allow you to upload and submit add-ons to AMO. You must be a registered AMO users before you can submit an add-on. Before submitting your add-on be sure to you "
+"have read the AMO <a href=\"%(url)s\">Editors Reviewing Guide</a> to ensure that your add-on has met the guidelines used by editors to review add-ons."
 msgstr ""
-"Översikten för utvecklingsverktyg gör att du kan ladda upp och skicka in "
-"tillägg till AMO. Du måste vara registrerad AMO-användare innan du kan "
-"skicka in ett tillägg. Innan du skickar in ditt tillägg bör du ha läst AMO:s"
-" <a href=\"%(url)s\">riktlinjer för redigerare</a> för att säkerställa att "
-"ditt tillägg uppfyller de riktlinjer som används av redigerare för att "
-"granska tillägg."
+"Översikten för utvecklingsverktyg gör att du kan ladda upp och skicka in tillägg till AMO. Du måste vara registrerad AMO-användare innan du kan skicka in ett tillägg. Innan du skickar in ditt "
+"tillägg bör du ha läst AMO:s <a href=\"%(url)s\">riktlinjer för redigerare</a> för att säkerställa att ditt tillägg uppfyller de riktlinjer som används av redigerare för att granska tillägg."
 
 #: src/olympia/pages/templates/pages/dev_faq.html:336
 msgid "What operating system do I choose for my add-on?"
 msgstr "Vilket operativsystem ska jag välja för mitt tillägg?"
 
 #: src/olympia/pages/templates/pages/dev_faq.html:338
-msgid ""
-"You must choose the operating systems on which your add-on will successfully"
-" function."
-msgstr ""
-"Du måste välja de operativsystem som ditt tillägg kommer att fungera på."
+msgid "You must choose the operating systems on which your add-on will successfully function."
+msgstr "Du måste välja de operativsystem som ditt tillägg kommer att fungera på."
 
 #: src/olympia/pages/templates/pages/dev_faq.html:344
 msgid "What category do I choose for my add-on?"
@@ -12498,56 +9976,38 @@ msgstr "Vilken kategori måste jag välja för mitt tillägg?"
 
 #: src/olympia/pages/templates/pages/dev_faq.html:346
 msgid ""
-"The choice of category is dependent on what type of audience you are "
-"targeting and the functionality of your add-on. If you're unsure of which "
-"category your add-on falls into, please choose \"Other\". The AMO team may "
-"re-categorize your add-on if it's determined that it's better suited in a "
-"different category."
+"The choice of category is dependent on what type of audience you are targeting and the functionality of your add-on. If you're unsure of which category your add-on falls into, please choose \"Other"
+"\". The AMO team may re-categorize your add-on if it's determined that it's better suited in a different category."
 msgstr ""
-"Valet av kategori beror på vilken typ av målgrupp du riktar dig till och "
-"funktionaliteten hos ditt tillägg. Om du är osäker på vilken kategori ditt "
-"tillägg faller in i, välj \"Annat\". Gruppen AMO kan återkategorisera ditt "
-"tillägg om det fastställs att det är bättre lämpat i en annan kategori."
+"Valet av kategori beror på vilken typ av målgrupp du riktar dig till och funktionaliteten hos ditt tillägg. Om du är osäker på vilken kategori ditt tillägg faller in i, välj \"Annat\". Gruppen AMO "
+"kan återkategorisera ditt tillägg om det fastställs att det är bättre lämpat i en annan kategori."
 
 #: src/olympia/pages/templates/pages/dev_faq.html:355
 msgid "What does \"nominating\" my add-on mean?"
 msgstr "Vad betyder det att \"nominera\" mitt tillägg?"
 
 #: src/olympia/pages/templates/pages/dev_faq.html:357
-msgid ""
-"Nominated add-ons are new add-ons that the author has nominated to become "
-"public via the Developer Tools."
-msgstr ""
-"Nominerat tillägg är nya tillägg som upphovsmannen har nominerat att bli "
-"publika via utvecklingsverktygen."
+msgid "Nominated add-ons are new add-ons that the author has nominated to become public via the Developer Tools."
+msgstr "Nominerat tillägg är nya tillägg som upphovsmannen har nominerat att bli publika via utvecklingsverktygen."
 
 #: src/olympia/pages/templates/pages/dev_faq.html:363
 msgid "Can I specify a license agreement for using my add-on?"
 msgstr "Kan jag ange ett licensavtal för att använda mitt tillägg?"
 
 #: src/olympia/pages/templates/pages/dev_faq.html:365
-msgid ""
-"Yes. You can specify a license agreement when submitting your add-on. You "
-"can also add or update a license agreement via the Developer Tools dashboard"
-" after your add-on has been submitted."
+msgid "Yes. You can specify a license agreement when submitting your add-on. You can also add or update a license agreement via the Developer Tools dashboard after your add-on has been submitted."
 msgstr ""
-"Ja. Du kan ange ett licensavtal när du skickar in ditt tillägg. Du kan också"
-" lägga till eller uppdatera ett licensavtal via översikten för "
-"utvecklingsverktyg efter att tillägget har skickats in."
+"Ja. Du kan ange ett licensavtal när du skickar in ditt tillägg. Du kan också lägga till eller uppdatera ett licensavtal via översikten för utvecklingsverktyg efter att tillägget har skickats in."
 
 #: src/olympia/pages/templates/pages/dev_faq.html:372
 msgid "Can I include a privacy policy for my add-on?"
 msgstr "Jag kan inkludera en sekretesspolicy för mitt tillägg?"
 
 #: src/olympia/pages/templates/pages/dev_faq.html:374
-msgid ""
-"Yes. You can specify a privacy policy when submitting your add-on. You can "
-"also add or update a privacy policy via the Developer Tools dashboard after "
-"your add-on has been submitted."
+msgid "Yes. You can specify a privacy policy when submitting your add-on. You can also add or update a privacy policy via the Developer Tools dashboard after your add-on has been submitted."
 msgstr ""
-"Ja. Du kan ange en sekretesspolicy när du skickar in ditt tillägg. Du kan "
-"också lägga till eller uppdatera en sekretesspolicy via översikten för "
-"utvecklingsverktyg efter att tillägget har skickats in."
+"Ja. Du kan ange en sekretesspolicy när du skickar in ditt tillägg. Du kan också lägga till eller uppdatera en sekretesspolicy via översikten för utvecklingsverktyg efter att tillägget har skickats "
+"in."
 
 #: src/olympia/pages/templates/pages/dev_faq.html:383
 msgid "Why must my add-on be reviewed?"
@@ -12556,15 +10016,11 @@ msgstr "Varför måste mitt tillägg bli granskat?"
 #: src/olympia/pages/templates/pages/dev_faq.html:385
 #, python-format
 msgid ""
-"All add-ons submitted, whether new or updated, are reviewed to ensure that "
-"Mozilla users have a stable and safe experience. All add-ons submissions are"
-" reviewed using the guidelines outlined in the <a href=\"%(url)s\">Editors "
-"Reviewing Guide</a>."
+"All add-ons submitted, whether new or updated, are reviewed to ensure that Mozilla users have a stable and safe experience. All add-ons submissions are reviewed using the guidelines outlined in the "
+"<a href=\"%(url)s\">Editors Reviewing Guide</a>."
 msgstr ""
-"Alla tillägg som skickas in, vare sig nya eller uppdaterade, granskas för "
-"att se till att Mozilla-användare har en stabil och säker upplevelse. Alla "
-"inskickade tillägg granskas med hjälp av riktlinjerna i <a "
-"href=\"%(url)s\">riktlinjer för redigerare</a>."
+"Alla tillägg som skickas in, vare sig nya eller uppdaterade, granskas för att se till att Mozilla-användare har en stabil och säker upplevelse. Alla inskickade tillägg granskas med hjälp av "
+"riktlinjerna i <a href=\"%(url)s\">riktlinjer för redigerare</a>."
 
 #: src/olympia/pages/templates/pages/dev_faq.html:393
 msgid "Who reviews my add-on?"
@@ -12573,19 +10029,13 @@ msgstr "Vem granskar mitt tillägg?"
 #: src/olympia/pages/templates/pages/dev_faq.html:395
 #, python-format
 msgid ""
-"Add-ons are reviewed by the AMO Editors, a group of talented developers that"
-" volunteer to help the Mozilla project by reviewing add-ons to ensure a "
-"stable and safe experience for Mozilla users. When communicating with "
-"editors, please be courteous, patient and respectful as they are working "
-"hard to ensure that your add-on is set up correctly and follows the "
-"guidelines outlined in the <a href=\"%(url)s\">Editors Reviewing Guide</a>."
+"Add-ons are reviewed by the AMO Editors, a group of talented developers that volunteer to help the Mozilla project by reviewing add-ons to ensure a stable and safe experience for Mozilla users. "
+"When communicating with editors, please be courteous, patient and respectful as they are working hard to ensure that your add-on is set up correctly and follows the guidelines outlined in the <a "
+"href=\"%(url)s\">Editors Reviewing Guide</a>."
 msgstr ""
-"Tillägg granskas av AMO:s redigerare, en grupp begåvade utvecklare som "
-"frivilligt hjälper Mozilla-projekt genom att granska tillägg för att "
-"säkerställa en stabil och säker upplevelse för Mozillas användare. Vid "
-"kommunikation med redigerare, vänligen var artig, tålmodig och respektfull, "
-"eftersom de arbetar hårt för att se till att ditt tillägg är korrekt och "
-"följer riktlinjerna i <a href=\"%(url)s\">riktlinjer för redigerare</a>."
+"Tillägg granskas av AMO:s redigerare, en grupp begåvade utvecklare som frivilligt hjälper Mozilla-projekt genom att granska tillägg för att säkerställa en stabil och säker upplevelse för Mozillas "
+"användare. Vid kommunikation med redigerare, vänligen var artig, tålmodig och respektfull, eftersom de arbetar hårt för att se till att ditt tillägg är korrekt och följer riktlinjerna i <a href="
+"\"%(url)s\">riktlinjer för redigerare</a>."
 
 #: src/olympia/pages/templates/pages/dev_faq.html:406
 msgid "What are the guidelines used to review my add-on?"
@@ -12594,29 +10044,19 @@ msgstr "Vilka riktlinjer används för att granska mitt tillägg?"
 #: src/olympia/pages/templates/pages/dev_faq.html:408
 #, python-format
 msgid ""
-"The Mozilla editorial team follows the <a href=\"%(url)s\">Editors Reviewing"
-" Guide</a> when testing an add-on for acceptance onto AMO. It is important "
-"that add-on developers review this guide to ensure that common problem areas"
-" are addressed prior to submitting their add-on for review. This will "
-"greatly assist in expediting the review process."
+"The Mozilla editorial team follows the <a href=\"%(url)s\">Editors Reviewing Guide</a> when testing an add-on for acceptance onto AMO. It is important that add-on developers review this guide to "
+"ensure that common problem areas are addressed prior to submitting their add-on for review. This will greatly assist in expediting the review process."
 msgstr ""
-"Mozilla redaktionen följer <a href=\"%(url)s\">riktlinjer för redigerare</a>"
-" när man testar ett tillägg för godkännande på AMO. Det är viktigt att "
-"tilläggsutvecklare granskar denna guide för att se till att gemensamma "
-"problemområden behandlas innan de skickar in tillägg för granskning. Detta "
-"kommer att kraftigt bidra till att påskynda granskningsprocessen."
+"Mozilla redaktionen följer <a href=\"%(url)s\">riktlinjer för redigerare</a> när man testar ett tillägg för godkännande på AMO. Det är viktigt att tilläggsutvecklare granskar denna guide för att se "
+"till att gemensamma problemområden behandlas innan de skickar in tillägg för granskning. Detta kommer att kraftigt bidra till att påskynda granskningsprocessen."
 
 #: src/olympia/pages/templates/pages/dev_faq.html:418
 msgid "How long will it take for my add-on to be reviewed?"
 msgstr "Hur lång tid tar det innan mitt tillägg granskas?"
 
 #: src/olympia/pages/templates/pages/dev_faq.html:420
-msgid ""
-"We cannot give a time estimate as to how long it will take before an add-on "
-"is reviewed. Many factors affect the time including the:"
-msgstr ""
-"Vi kan inte ge en uppskattad tid om hur lång tid det tar innan ett tillägg "
-"granskas. Många faktorer påverkar tiden, inklusive:"
+msgid "We cannot give a time estimate as to how long it will take before an add-on is reviewed. Many factors affect the time including the:"
+msgstr "Vi kan inte ge en uppskattad tid om hur lång tid det tar innan ett tillägg granskas. Många faktorer påverkar tiden, inklusive:"
 
 #. part of a list (<li>)
 #: src/olympia/pages/templates/pages/dev_faq.html:427
@@ -12636,32 +10076,19 @@ msgstr "antal upptäckta problemområden"
 #: src/olympia/pages/templates/pages/dev_faq.html:434
 #, python-format
 msgid ""
-"This is why it's very important to read the <a href=\"%(g_url)s\">Editors "
-"Reviewing Guide</a> to ensure that your add-on is setup as expected.  It's "
-"also a good idea to read the blog post, <a "
-"href=\"%(blog_url)s\">Successfully Getting your Add-on Reviewed</a> which "
-"provides excellent insight into ensuring a smooth review of your add-on."
+"This is why it's very important to read the <a href=\"%(g_url)s\">Editors Reviewing Guide</a> to ensure that your add-on is setup as expected. It's also a good idea to read the blog post, <a href="
+"\"%(blog_url)s\">Successfully Getting your Add-on Reviewed</a> which provides excellent insight into ensuring a smooth review of your add-on."
 msgstr ""
-"Det är därför det är mycket viktigt att läsa <a "
-"href=\"%(g_url)s\">riktlinjer för granskare</a> för att säkerställa att ditt"
-" tillägg installeras som förväntat.  Det är också en bra idé att läsa "
-"blogginlägg, <a href=\"%(blog_url)s\">Lyckas med granskningen av ditt "
-"tillägg</a> som ger god inblick i att säkerställa en smidig granskning av "
-"ditt tillägg."
+"Det är därför det är mycket viktigt att läsa <a href=\"%(g_url)s\">riktlinjer för granskare</a> för att säkerställa att ditt tillägg installeras som förväntat.  Det är också en bra idé att läsa "
+"blogginlägg, <a href=\"%(blog_url)s\">Lyckas med granskningen av ditt tillägg</a> som ger god inblick i att säkerställa en smidig granskning av ditt tillägg."
 
 #: src/olympia/pages/templates/pages/dev_faq.html:446
 msgid "How can I see how many times my add-on has been downloaded?"
 msgstr "Hur kan jag se hur många gånger mitt tillägg har laddats ner?"
 
 #: src/olympia/pages/templates/pages/dev_faq.html:448
-msgid ""
-"The Statistics Dashboard found in the Developer Tools dashboard provides "
-"information that can help you determine your add-on downloads since you've "
-"submitted it to AMO."
-msgstr ""
-"Statistiköversikten som hittas i översikten för utvecklingsverktyg ger "
-"information som kan hjälpa dig att avgöra ditt tilläggs nedladdningar sedan "
-"du har skickat in det till AMO."
+msgid "The Statistics Dashboard found in the Developer Tools dashboard provides information that can help you determine your add-on downloads since you've submitted it to AMO."
+msgstr "Statistiköversikten som hittas i översikten för utvecklingsverktyg ger information som kan hjälpa dig att avgöra ditt tilläggs nedladdningar sedan du har skickat in det till AMO."
 
 #: src/olympia/pages/templates/pages/dev_faq.html:455
 msgid "How can I see how many active users are using my add-on?"
@@ -12669,27 +10096,18 @@ msgstr "Hur kan jag se hur många aktiva användare som använder mitt tilllägg
 
 #: src/olympia/pages/templates/pages/dev_faq.html:457
 msgid ""
-"The Statistics Dashboard found in the Developer Tools dashboard provides "
-"information that can help you determine how many users have been actively "
-"using your add-on since you've submitted it to AMO."
+"The Statistics Dashboard found in the Developer Tools dashboard provides information that can help you determine how many users have been actively using your add-on since you've submitted it to AMO."
 msgstr ""
-"Statistiköversikten som hittas i översikten för utvecklingsverktyg ger "
-"information som kan hjälpa dig att avgöra hur många användare som aktivt har"
-" använt ditt tillägg sedan du har skickat in det till AMO."
+"Statistiköversikten som hittas i översikten för utvecklingsverktyg ger information som kan hjälpa dig att avgöra hur många användare som aktivt har använt ditt tillägg sedan du har skickat in det "
+"till AMO."
 
 #: src/olympia/pages/templates/pages/dev_faq.html:464
 msgid "How do I submit an update for my add-on?"
 msgstr "Hur skickar jag in en uppdatering för mitt tillägg?"
 
 #: src/olympia/pages/templates/pages/dev_faq.html:466
-msgid ""
-"You can submit an update for your add-on via the Developer Tools dashboard "
-"by choosing the option \"Upload a new version\" and uploading a new .xpi "
-"file for your add-on."
-msgstr ""
-"Du kan skicka in en uppdatering för ditt tillägg via översikten för "
-"utvecklingsverktyg genom att välja alternativet \"Ladda upp en ny version\" "
-"och ladda upp en ny .xpi fil för ditt tillägg."
+msgid "You can submit an update for your add-on via the Developer Tools dashboard by choosing the option \"Upload a new version\" and uploading a new .xpi file for your add-on."
+msgstr "Du kan skicka in en uppdatering för ditt tillägg via översikten för utvecklingsverktyg genom att välja alternativet \"Ladda upp en ny version\" och ladda upp en ny .xpi fil för ditt tillägg."
 
 #: src/olympia/pages/templates/pages/dev_faq.html:473
 msgid "Does my update need to be reviewed by editors?"
@@ -12697,49 +10115,32 @@ msgstr "Behöver min uppdatering granskas av redigerare?"
 
 #: src/olympia/pages/templates/pages/dev_faq.html:475
 msgid ""
-"That depends. If you are simply changing a description of your add-on or "
-"updating a \"maxVersion\" to ensure compatibility with a new Mozilla "
-"software update, then your add-on does not need to be reviewed again. If, "
-"however, you submit a new updated file, then your add-on update will need to"
-" be reviewed by an editor."
+"That depends. If you are simply changing a description of your add-on or updating a \"maxVersion\" to ensure compatibility with a new Mozilla software update, then your add-on does not need to be "
+"reviewed again. If, however, you submit a new updated file, then your add-on update will need to be reviewed by an editor."
 msgstr ""
-"Det beror på. Om du bara ändrar en beskrivning för ditt tillägg eller "
-"uppdaterar en \"maxVersion\" för att säkerställa kompatibilitet med en ny "
-"programuppdatering av Mozilla, då behöver inte ditt tillägg granskas på "
-"nytt. Men om du skickar in en ny uppdaterad fil, då behöver uppdateringen av"
-" ditt tillägg granskas av en redigerare."
+"Det beror på. Om du bara ändrar en beskrivning för ditt tillägg eller uppdaterar en \"maxVersion\" för att säkerställa kompatibilitet med en ny programuppdatering av Mozilla, då behöver inte ditt "
+"tillägg granskas på nytt. Men om du skickar in en ny uppdaterad fil, då behöver uppdateringen av ditt tillägg granskas av en redigerare."
 
 #: src/olympia/pages/templates/pages/dev_faq.html:486
-msgid ""
-"How do I reply to a user who has posted a negative review of my add-on?"
-msgstr ""
-"Hur svarar jag på en användare som har postat en negativ recension av mitt "
-"tillägg?"
+msgid "How do I reply to a user who has posted a negative review of my add-on?"
+msgstr "Hur svarar jag på en användare som har postat en negativ recension av mitt tillägg?"
 
 #: src/olympia/pages/templates/pages/dev_faq.html:488
-msgid ""
-"A developer may reply to any review posted to their add-on as long as they "
-"are logged into AMO. In addition, any user can flag a review as:"
-msgstr ""
-"En utvecklare kan besvara varje inlägg som postas till deras tillägg så "
-"länge de är inloggade på AMO. Dessutom kan alla användare flagga en "
-"granskning som:"
+msgid "A developer may reply to any review posted to their add-on as long as they are logged into AMO. In addition, any user can flag a review as:"
+msgstr "En utvecklare kan besvara varje inlägg som postas till deras tillägg så länge de är inloggade på AMO. Dessutom kan alla användare flagga en granskning som:"
 
 #. part of a list (<li>)
-#: src/olympia/pages/templates/pages/dev_faq.html:495
-#: src/olympia/reviews/models.py:159
+#: src/olympia/pages/templates/pages/dev_faq.html:495 src/olympia/reviews/models.py:159
 msgid "Spam or otherwise non-review content"
 msgstr "Skräpkommentar eller annat icke recensionsartat innehåll"
 
 #. part of a list (<li>)
-#: src/olympia/pages/templates/pages/dev_faq.html:497
-#: src/olympia/reviews/models.py:160
+#: src/olympia/pages/templates/pages/dev_faq.html:497 src/olympia/reviews/models.py:160
 msgid "Inappropriate language/dialog"
 msgstr "Opassande språk/innehåll"
 
 #. part of a list (<li>)
-#: src/olympia/pages/templates/pages/dev_faq.html:499
-#: src/olympia/reviews/models.py:161
+#: src/olympia/pages/templates/pages/dev_faq.html:499 src/olympia/reviews/models.py:161
 msgid "Misplaced bug report or support request"
 msgstr "Felrapport eller begäran om hjälp på fel ställe"
 
@@ -12749,128 +10150,73 @@ msgid "Other (provides a pop-up prompt for information)"
 msgstr "Annat (ger en pop-up prompt för information)"
 
 #: src/olympia/pages/templates/pages/dev_faq.html:504
-msgid ""
-"Currently, AMO does not provide a mechanism to directly communicate with a "
-"reviewer but this feature is being investigated and considered for a future "
-"update."
-msgstr ""
-"För närvarande tillhandahåller AMO inte en mekanism för att kommunicera "
-"direkt med en granskare men denna funktion är under utredning och beaktad "
-"för en framtida uppdatering."
+msgid "Currently, AMO does not provide a mechanism to directly communicate with a reviewer but this feature is being investigated and considered for a future update."
+msgstr "För närvarande tillhandahåller AMO inte en mekanism för att kommunicera direkt med en granskare men denna funktion är under utredning och beaktad för en framtida uppdatering."
 
 #: src/olympia/pages/templates/pages/dev_faq.html:511
 msgid "Can I request that a review be removed if the review is negative?"
 msgstr "Kan jag begära att en granskning tas bort om granskningen är negativ?"
 
 #: src/olympia/pages/templates/pages/dev_faq.html:513
-msgid ""
-"No. We do not remove negative reviews from add-ons unless they are found to "
-"be false."
-msgstr ""
-"Nej. Vi tar inte bort negativa granskningar från tillägg om de inte visar "
-"sig vara falska."
+msgid "No. We do not remove negative reviews from add-ons unless they are found to be false."
+msgstr "Nej. Vi tar inte bort negativa granskningar från tillägg om de inte visar sig vara falska."
 
 #: src/olympia/pages/templates/pages/dev_faq.html:519
 msgid "Can I request that a review be removed if the review is inaccurate?"
-msgstr ""
-"Kan jag begära att en granskning tas bort om granskningen är felaktig?"
+msgstr "Kan jag begära att en granskning tas bort om granskningen är felaktig?"
 
 #: src/olympia/pages/templates/pages/dev_faq.html:521
-msgid ""
-"If an author contacts us and asks for a review containing false or "
-"inaccurate information to be removed, we will review the post and consider "
-"removing it."
-msgstr ""
-"Om en upphovsmannen kontaktar oss och ber om att en granskning tas bort som "
-"innehåller falska eller felaktiga uppgifter, går vi igenom posten och "
-"överväger att ta bort den."
+msgid "If an author contacts us and asks for a review containing false or inaccurate information to be removed, we will review the post and consider removing it."
+msgstr "Om en upphovsmannen kontaktar oss och ber om att en granskning tas bort som innehåller falska eller felaktiga uppgifter, går vi igenom posten och överväger att ta bort den."
 
 #: src/olympia/pages/templates/pages/dev_faq.html:530
 msgid ""
-"Do you need more information about the various open source licenses? Are you"
-" confused as to which license you should select? What rights does a specific"
-" license grant? While nothing replaces reading the full terms of a license, "
-"below are some sites that contain information about some of the key open "
-"source licenses that may help you sort out the differences between them. "
-"These sites are being provided solely for your convenience and as a "
-"reference for your personal use. These resources do not constitute legal "
-"advice nor should they be used in lieu of such advice. Mozilla neither "
-"guarantees nor is responsible for the content of these sites or your "
-"reliance on such content."
+"Do you need more information about the various open source licenses? Are you confused as to which license you should select? What rights does a specific license grant? While nothing replaces "
+"reading the full terms of a license, below are some sites that contain information about some of the key open source licenses that may help you sort out the differences between them. These sites "
+"are being provided solely for your convenience and as a reference for your personal use. These resources do not constitute legal advice nor should they be used in lieu of such advice. Mozilla "
+"neither guarantees nor is responsible for the content of these sites or your reliance on such content."
 msgstr ""
-"Behöver du mer information om de olika licenserna för öppen källkod? Är du "
-"förvirrad om vilken licens du ska välja? Vilka rättigheter kan en särskild "
-"licens bevilja? Då ingenting ersätter de fullständiga villkoren för en "
-"licens, nedan är några webbplatser som innehåller information om några av de"
-" viktigaste licenserna för öppen källkod som kan hjälpa dig att reda ut "
-"skillnaderna mellan dem. Dessa platser tillhandahålls enbart för din "
-"bekvämlighet och som en referens för personligt bruk. Dessa resurser utgör "
-"inte juridisk rådgivning och inte heller bör de användas i stället för ett "
-"sådant råd. Mozilla varken garanterar eller ansvarar för innehållet på dessa"
-" webbplatser eller din tillit till sådant innehåll."
+"Behöver du mer information om de olika licenserna för öppen källkod? Är du förvirrad om vilken licens du ska välja? Vilka rättigheter kan en särskild licens bevilja? Då ingenting ersätter de "
+"fullständiga villkoren för en licens, nedan är några webbplatser som innehåller information om några av de viktigaste licenserna för öppen källkod som kan hjälpa dig att reda ut skillnaderna mellan "
+"dem. Dessa platser tillhandahålls enbart för din bekvämlighet och som en referens för personligt bruk. Dessa resurser utgör inte juridisk rådgivning och inte heller bör de användas i stället för "
+"ett sådant råd. Mozilla varken garanterar eller ansvarar för innehållet på dessa webbplatser eller din tillit till sådant innehåll."
 
 #: src/olympia/pages/templates/pages/dev_faq.html:545
 msgid ""
-"In addition to the full text of the Mozilla Public License(\"MPL\"), this "
-"also provides an annotated version of the MPL and an <abbr "
-"title=\"Frequently Asked Questions\">FAQ</abbr> to help you if you want to "
-"use or distribute code licensed under it."
+"In addition to the full text of the Mozilla Public License(\"MPL\"), this also provides an annotated version of the MPL and an <abbr title=\"Frequently Asked Questions\">FAQ</abbr> to help you if "
+"you want to use or distribute code licensed under it."
 msgstr ""
-"Förutom den fullständiga texten till Mozilla Public License (\"MPL\"), ger "
-"detta också en kommenterad version av MPL och en <abbr title=\"Frequently "
-"Asked Questions\">FAQ</abbr> för att hjälpa dig om du vill använda eller "
-"distribuera koden licensierat under det."
+"Förutom den fullständiga texten till Mozilla Public License (\"MPL\"), ger detta också en kommenterad version av MPL och en <abbr title=\"Frequently Asked Questions\">FAQ</abbr> för att hjälpa dig "
+"om du vill använda eller distribuera koden licensierat under det."
 
 #: src/olympia/pages/templates/pages/dev_faq.html:559
-msgid ""
-"A table summarizing and comparing how some of the key open source licenses "
-"treat distributions, proprietary software linking, and redistribution of "
-"code with changes."
+msgid "A table summarizing and comparing how some of the key open source licenses treat distributions, proprietary software linking, and redistribution of code with changes."
 msgstr ""
-"En tabell som sammanställer och jämför hur några av de viktigaste licenserna"
-" för öppen källkod behandlar distributioner, proprietär programvarulänkning "
-"och omfördelning av koden med ändringar."
+"En tabell som sammanställer och jämför hur några av de viktigaste licenserna för öppen källkod behandlar distributioner, proprietär programvarulänkning och omfördelning av koden med ändringar."
 
 #: src/olympia/pages/templates/pages/dev_faq.html:572
 msgid ""
-"Free Software Foundation provides short summaries of the key open source "
-"licenses, including whether the license qualifies as a free software license"
-" or a copyleft license.  Also includes a discussion of what constitutes a "
-"free software license or a copyleft license (e.g., a Copyleft license is a "
-"general method for making a program or other work free, and requiring all "
-"modified and extended versions of the program to be free as well.)"
+"Free Software Foundation provides short summaries of the key open source licenses, including whether the license qualifies as a free software license or a copyleft license. Also includes a "
+"discussion of what constitutes a free software license or a copyleft license (e.g., a Copyleft license is a general method for making a program or other work free, and requiring all modified and "
+"extended versions of the program to be free as well.)"
 msgstr ""
-"Free Software Foundation ger korta sammanfattningar av de viktigaste "
-"licenserna för öppen källkod, inklusive om licensen betraktas som en gratis "
-"programvarulicens eller en copyleft-licens.  Innehåller också en diskussion "
-"om vad som utgör en gratis programvarulicens eller en copyleft-licens (t.ex."
-" är en Copyleft-licens en generell metod för att göra ett program eller "
-"annat arbete gratis och kräver att alla modifierade och utökade versioner av"
-" programmet ska vara gratis också.)"
+"Free Software Foundation ger korta sammanfattningar av de viktigaste licenserna för öppen källkod, inklusive om licensen betraktas som en gratis programvarulicens eller en copyleft-licens.  "
+"Innehåller också en diskussion om vad som utgör en gratis programvarulicens eller en copyleft-licens (t.ex. är en Copyleft-licens en generell metod för att göra ett program eller annat arbete "
+"gratis och kräver att alla modifierade och utökade versioner av programmet ska vara gratis också.)"
 
 #: src/olympia/pages/templates/pages/dev_faq.html:589
-msgid ""
-"Open Source Initiative provides the terms of some of the key open source "
-"licenses."
-msgstr ""
-"Open Source Initiative ger villkoren för några av de viktigaste licenserna "
-"för öppen källkod."
+msgid "Open Source Initiative provides the terms of some of the key open source licenses."
+msgstr "Open Source Initiative ger villkoren för några av de viktigaste licenserna för öppen källkod."
 
 #: src/olympia/pages/templates/pages/dev_faq.html:599
 msgid "A comparison of known open source licenses on Wikipedia."
 msgstr "En jämförelse av kända licenser för öppen källkod finns på Wikipedia."
 
 #: src/olympia/pages/templates/pages/dev_faq.html:605
-msgid ""
-"A site to provide non-judgmental guidance on choosing a license for your "
-"open source project."
-msgstr ""
-"En webbplats för att ge icke-dömande vägledning om hur du väljer en licens "
-"för ditt projekt med öppen källkod."
+msgid "A site to provide non-judgmental guidance on choosing a license for your open source project."
+msgstr "En webbplats för att ge icke-dömande vägledning om hur du väljer en licens för ditt projekt med öppen källkod."
 
-#: src/olympia/pages/templates/pages/faq.html:3
-#: src/olympia/pages/templates/pages/faq.html:9
-#: src/olympia/pages/templates/pages/faq.html:10
+#: src/olympia/pages/templates/pages/faq.html:3 src/olympia/pages/templates/pages/faq.html:9 src/olympia/pages/templates/pages/faq.html:10
 msgid "Frequently Asked Questions"
 msgstr "Vanliga frågor"
 
@@ -12885,18 +10231,11 @@ msgstr "Vad är ett tillägg?"
 #: src/olympia/pages/templates/pages/faq.html:16
 #, python-format
 msgid ""
-"Add-ons are small pieces of software that add new features or functionality "
-"to your installation of %(app_name)s. Add-ons can augment %(app_name)s with "
-"new features, foreign language dictionaries, or change its visual "
-"appearance. Through add-ons, you can customize %(app_name)s to meet your "
-"needs and tastes. <a href=\"%(learnmore_url)s\">Learn more about "
-"customization</a>"
+"Add-ons are small pieces of software that add new features or functionality to your installation of %(app_name)s. Add-ons can augment %(app_name)s with new features, foreign language dictionaries, "
+"or change its visual appearance. Through add-ons, you can customize %(app_name)s to meet your needs and tastes. <a href=\"%(learnmore_url)s\">Learn more about customization</a>"
 msgstr ""
-"Tillägg är små bitar av programvara som ger nya funktioner eller "
-"funktionalitet till din installation av %(app_name)s. Tillägg kan öka "
-"%(app_name)s med nya funktioner, utländska ordböcker eller ändra dess "
-"utseende. Genom tillägg, kan du skräddarsy %(app_name)s för att möta dina "
-"behov och smak. <a href=\"%(learnmore_url)s\">Läs mer om anpassning</a>"
+"Tillägg är små bitar av programvara som ger nya funktioner eller funktionalitet till din installation av %(app_name)s. Tillägg kan öka %(app_name)s med nya funktioner, utländska ordböcker eller "
+"ändra dess utseende. Genom tillägg, kan du skräddarsy %(app_name)s för att möta dina behov och smak. <a href=\"%(learnmore_url)s\">Läs mer om anpassning</a>"
 
 #: src/olympia/pages/templates/pages/faq.html:26
 msgid "Will add-ons work with my web browser or application?"
@@ -12905,25 +10244,13 @@ msgstr "Kommer tillägg att fungera med min webbläsare eller program?"
 #: src/olympia/pages/templates/pages/faq.html:27
 #, python-format
 msgid ""
-"Add-ons listed in this gallery only work with Mozilla-based applications, "
-"such as <a href=\"%(getfirefox_url)s\">Firefox</a>, <a "
-"href=\"%(getmobile_url)s\">Firefox Mobile</a>, <a "
-"href=\"%(getseamonkey_url)s\">SeaMonkey</a>, and <a "
-"href=\"%(getthunderbird_url)s\">Thunderbird</a>. However, not all add-ons "
-"work with each of those applications or every version of those applications."
-" Each add-on specifies which applications and versions it works with, such "
-"as Firefox 2.0 - 3.6.*. For Firefox add-ons, the install buttons will "
-"indicate whether the add-on is compatible or not."
+"Add-ons listed in this gallery only work with Mozilla-based applications, such as <a href=\"%(getfirefox_url)s\">Firefox</a>, <a href=\"%(getmobile_url)s\">Firefox Mobile</a>, <a href="
+"\"%(getseamonkey_url)s\">SeaMonkey</a>, and <a href=\"%(getthunderbird_url)s\">Thunderbird</a>. However, not all add-ons work with each of those applications or every version of those applications. "
+"Each add-on specifies which applications and versions it works with, such as Firefox 2.0 - 3.6.*. For Firefox add-ons, the install buttons will indicate whether the add-on is compatible or not."
 msgstr ""
-"Tillägg som listas i detta galleri fungerar endast med Mozilla-baserade "
-"program, såsom <a href=\"%(getfirefox_url)s\">Firefox</a>, <a "
-"href=\"%(getmobile_url)s\">Firefox Mobil</a>, <a "
-"href=\"%(getseamonkey_url)s\">SeaMonkey</a> och <a "
-"href=\"%(getthunderbird_url)s\">Thunderbird</a>. Men inte alla tillägg "
-"fungerar med vart och ett av dessa program eller varje version av dessa "
-"program. Varje tillägg anger vilka program och versioner som det fungerar "
-"med, såsom Firefox 2.0 - 3.6.*. För Firefoxs tillägg, kommer "
-"installationsknappen att ange om tillägget är kompatibel eller inte."
+"Tillägg som listas i detta galleri fungerar endast med Mozilla-baserade program, såsom <a href=\"%(getfirefox_url)s\">Firefox</a>, <a href=\"%(getmobile_url)s\">Firefox Mobil</a>, <a href="
+"\"%(getseamonkey_url)s\">SeaMonkey</a> och <a href=\"%(getthunderbird_url)s\">Thunderbird</a>. Men inte alla tillägg fungerar med vart och ett av dessa program eller varje version av dessa program. "
+"Varje tillägg anger vilka program och versioner som det fungerar med, såsom Firefox 2.0 - 3.6.*. För Firefoxs tillägg, kommer installationsknappen att ange om tillägget är kompatibel eller inte."
 
 #: src/olympia/pages/templates/pages/faq.html:42
 msgid "What are the different types of add-ons?"
@@ -12931,77 +10258,42 @@ msgstr "Vad finns det för olika typer av tillägg?"
 
 #: src/olympia/pages/templates/pages/faq.html:43
 #, python-format
-msgid ""
-"There are several kinds of add-ons that customize %(app_name)s in different "
-"ways:"
-msgstr ""
-"Det finns flera slags tillägg som anpassar %(app_name)s på olika sätt:"
+msgid "There are several kinds of add-ons that customize %(app_name)s in different ways:"
+msgstr "Det finns flera slags tillägg som anpassar %(app_name)s på olika sätt:"
 
 #: src/olympia/pages/templates/pages/faq.html:47
 #, python-format
 msgid ""
-"<strong><a href=\"%(browse_url)s\">Extensions</a></strong> add new features "
-"to %(app_name)s or modify existing functionality. There are extensions that "
-"allow you to block advertisements, download videos from websites, integrate "
-"more closely with social websites, and add features you see in other "
-"applications."
+"<strong><a href=\"%(browse_url)s\">Extensions</a></strong> add new features to %(app_name)s or modify existing functionality. There are extensions that allow you to block advertisements, download "
+"videos from websites, integrate more closely with social websites, and add features you see in other applications."
 msgstr ""
-"<strong><a href=\"%(browse_url)s\">Utökningar</a></strong> lägger till nya "
-"funktioner i %(app_name)s eller ändrar befintliga funktioner. Det finns "
-"utökningar som gör att du kan blockera annonser, ladda ner video från "
-"webbplatser, integreras närmare med sociala webbplatser och lägga till "
-"funktioner som du ser i andra program."
+"<strong><a href=\"%(browse_url)s\">Utökningar</a></strong> lägger till nya funktioner i %(app_name)s eller ändrar befintliga funktioner. Det finns utökningar som gör att du kan blockera annonser, "
+"ladda ner video från webbplatser, integreras närmare med sociala webbplatser och lägga till funktioner som du ser i andra program."
 
 #: src/olympia/pages/templates/pages/faq.html:55
 #, python-format
-msgid ""
-"<strong><a href=\"%(browse_url)s\">Complete Themes</a></strong> change the "
-"entire appearance of %(app_name)s, usually including icons, colors, dialogs,"
-" and other visual styles."
-msgstr ""
-"<strong><a href=\"%(browse_url)s\">Kompletta teman</a></strong> ändrar hela "
-"utseendet på %(app_name)s, oftast inklusive ikoner, färger, dialogrutor och "
-"andra visuella stilar."
+msgid "<strong><a href=\"%(browse_url)s\">Complete Themes</a></strong> change the entire appearance of %(app_name)s, usually including icons, colors, dialogs, and other visual styles."
+msgstr "<strong><a href=\"%(browse_url)s\">Kompletta teman</a></strong> ändrar hela utseendet på %(app_name)s, oftast inklusive ikoner, färger, dialogrutor och andra visuella stilar."
 
 #: src/olympia/pages/templates/pages/faq.html:61
 #, python-format
-msgid ""
-"<strong><a href=\"%(browse_url)s\">Themes</a></strong> are lightweight "
-"themes that use background images to customize your %(app_name)s toolbars."
-msgstr ""
-"<strong><a href=\"%(browse_url)s\">Teman</a></strong> är lätta teman som "
-"använder bakgrundsbilder för att anpassa verktygsfälten för %(app_name)s."
+msgid "<strong><a href=\"%(browse_url)s\">Themes</a></strong> are lightweight themes that use background images to customize your %(app_name)s toolbars."
+msgstr "<strong><a href=\"%(browse_url)s\">Teman</a></strong> är lätta teman som använder bakgrundsbilder för att anpassa verktygsfälten för %(app_name)s."
 
 #: src/olympia/pages/templates/pages/faq.html:66
 #, python-format
-msgid ""
-"<strong><a href=\"%(browse_url)s\">Search Providers</a> </strong> add "
-"additional choices to the search box dropdown. These providers allow you to "
-"quickly search any website."
-msgstr ""
-"<strong><a href=\"%(browse_url)s\">Sökleverantörer</a> </strong> lägger till"
-" ytterligare alternativ i listrutan Sök. Dessa leverantörer gör att du "
-"snabbt kan söka på webbplatsen."
+msgid "<strong><a href=\"%(browse_url)s\">Search Providers</a> </strong> add additional choices to the search box dropdown. These providers allow you to quickly search any website."
+msgstr "<strong><a href=\"%(browse_url)s\">Sökleverantörer</a> </strong> lägger till ytterligare alternativ i listrutan Sök. Dessa leverantörer gör att du snabbt kan söka på webbplatsen."
 
 #: src/olympia/pages/templates/pages/faq.html:72
 #, python-format
-msgid ""
-"<strong><a href=\"%(browse_url)s\">Dictionaries & Language "
-"Packs</a></strong> add support for additional languages to %(app_name)s."
-msgstr ""
-"<strong><a href=\"%(browse_url)s\">Ordlistor & Språkpaket</a></strong> ger "
-"stöd för ytterligare språk i %(app_name)s."
+msgid "<strong><a href=\"%(browse_url)s\">Dictionaries & Language Packs</a></strong> add support for additional languages to %(app_name)s."
+msgstr "<strong><a href=\"%(browse_url)s\">Ordlistor & Språkpaket</a></strong> ger stöd för ytterligare språk i %(app_name)s."
 
 #: src/olympia/pages/templates/pages/faq.html:77
 #, python-format
-msgid ""
-"<strong><a href=\"%(browse_url)s\">Plugins</a></strong> help %(app_name)s "
-"display or understand different types of media, such as Adobe Flash or Apple"
-" Quicktime."
-msgstr ""
-"<strong><a href=\"%(browse_url)s\">Insticksmoduler</a></strong> hjälper "
-"%(app_name)s visa eller förstå olika typer av media, till exempel Adobe "
-"Flash eller Apple Quicktime."
+msgid "<strong><a href=\"%(browse_url)s\">Plugins</a></strong> help %(app_name)s display or understand different types of media, such as Adobe Flash or Apple Quicktime."
+msgstr "<strong><a href=\"%(browse_url)s\">Insticksmoduler</a></strong> hjälper %(app_name)s visa eller förstå olika typer av media, till exempel Adobe Flash eller Apple Quicktime."
 
 #: src/olympia/pages/templates/pages/faq.html:85
 msgid "How do I install, manage, or remove an add-on?"
@@ -13010,21 +10302,13 @@ msgstr "Hur installerar jag, hanterar eller tar bort ett tillägg?"
 #: src/olympia/pages/templates/pages/faq.html:86
 #, python-format
 msgid ""
-"In most cases, add-ons can be installed by simply clicking the install "
-"button provided. Add-ons can be managed, disabled, or uninstalled from the "
-"Add-ons Manager in %(app_name)s. For more detailed instructions, read <a "
-"href=\"%(extension_url)s\">this article on extensions</a> or <a "
-"href=\"%(theme_url)s\">this one for Themes and Complete Themes</a>. If you "
-"have difficulty installing add-ons, see <a "
-"href=\"%(troubleshooting_url)s\">Troubleshooting Extensions and Themes</a>."
+"In most cases, add-ons can be installed by simply clicking the install button provided. Add-ons can be managed, disabled, or uninstalled from the Add-ons Manager in %(app_name)s. For more detailed "
+"instructions, read <a href=\"%(extension_url)s\">this article on extensions</a> or <a href=\"%(theme_url)s\">this one for Themes and Complete Themes</a>. If you have difficulty installing add-ons, "
+"see <a href=\"%(troubleshooting_url)s\">Troubleshooting Extensions and Themes</a>."
 msgstr ""
-"I de flesta fall kan tillägg installeras genom att klicka på dess "
-"installationsknapp. Tillägg kan hanteras, inaktiveras eller avinstalleras "
-"från tilläggshanteraren i %(app_name)s. För mer detaljerade instruktioner, "
-"läs <a href=\"%(extension_url)s\">denna artikel om utökningar</a> eller <a "
-"href=\"%(theme_url)s\">den här för teman och kompletta teman</a>. Om du har "
-"problem med att installera tillägg, se <a "
-"href=\"%(troubleshooting_url)s\">Felsökning av utökningar och teman</a>."
+"I de flesta fall kan tillägg installeras genom att klicka på dess installationsknapp. Tillägg kan hanteras, inaktiveras eller avinstalleras från tilläggshanteraren i %(app_name)s. För mer "
+"detaljerade instruktioner, läs <a href=\"%(extension_url)s\">denna artikel om utökningar</a> eller <a href=\"%(theme_url)s\">den här för teman och kompletta teman</a>. Om du har problem med att "
+"installera tillägg, se <a href=\"%(troubleshooting_url)s\">Felsökning av utökningar och teman</a>."
 
 #: src/olympia/pages/templates/pages/faq.html:100
 msgid "How do I install add-ons without restarting Firefox?"
@@ -13033,17 +10317,11 @@ msgstr "Hur installerar jag tillägg utan att starta om Firefox?"
 #: src/olympia/pages/templates/pages/faq.html:101
 #, python-format
 msgid ""
-"In Firefox, add-ons marked with \"No restart required\" can be installed "
-"without restarting. These add-ons have been created using the <a "
-"href=\"%(sdk_url)s\">Add-on SDK</a> or <a "
-"href=\"%(bootstrap_url)s\">bootstrapping</a>. Other add-ons will still "
-"require a restart before you can use them."
+"In Firefox, add-ons marked with \"No restart required\" can be installed without restarting. These add-ons have been created using the <a href=\"%(sdk_url)s\">Add-on SDK</a> or <a href="
+"\"%(bootstrap_url)s\">bootstrapping</a>. Other add-ons will still require a restart before you can use them."
 msgstr ""
-"I Firefox, tillägg märkta med \"Ingen omstart krävs\" kan installeras utan "
-"att behöva starta om. Dessa tillägg har skapats med hjälp med <a "
-"href=\"%(sdk_url)s\">SDK för tillägg</a> eller <a "
-"href=\"%(bootstrap_url)s\">bootstrapping</a>. Andra tillägg kommer "
-"fortfarande att kräva en omstart innan du kan använda dem."
+"I Firefox, tillägg märkta med \"Ingen omstart krävs\" kan installeras utan att behöva starta om. Dessa tillägg har skapats med hjälp med <a href=\"%(sdk_url)s\">SDK för tillägg</a> eller <a href="
+"\"%(bootstrap_url)s\">bootstrapping</a>. Andra tillägg kommer fortfarande att kräva en omstart innan du kan använda dem."
 
 #: src/olympia/pages/templates/pages/faq.html:110
 msgid "How do I keep add-ons up-to-date?"
@@ -13052,22 +10330,13 @@ msgstr "Hur håller jag tillägg uppdaterade?"
 #: src/olympia/pages/templates/pages/faq.html:111
 #, python-format
 msgid ""
-"Add-ons, unlike plugins, are automatically checked for updates once every "
-"day. In Firefox, updates are automatically installed by default. Versions of"
-" Firefox prior to 4 (and other applications) will alert you that updates to "
-"your add-ons are available. <a href=\"%(plugin_url)s\">Plugins</a> are not "
-"currently automatically checked for updates, so be sure to regularly visit "
-"the <a href=\"%(plugincheck_url)s\">Plugin Check</a> page to stay up-to-"
-"date."
+"Add-ons, unlike plugins, are automatically checked for updates once every day. In Firefox, updates are automatically installed by default. Versions of Firefox prior to 4 (and other applications) "
+"will alert you that updates to your add-ons are available. <a href=\"%(plugin_url)s\">Plugins</a> are not currently automatically checked for updates, so be sure to regularly visit the <a href="
+"\"%(plugincheck_url)s\">Plugin Check</a> page to stay up-to-date."
 msgstr ""
-"Tillägg, till skillnad från insticksmoduler, kontrolleras automatiskt efter "
-"uppdateringar en gång varje dag. I Firefox, uppdateringar installeras "
-"automatiskt som standard. Versioner av Firefox före 4 (och andra program) "
-"kommer att varna dig att uppdateringar för dina tillägg finns. <a "
-"href=\"%(plugin_url)s\">Insticksmoduler</a> kontrolleras för närvarande inte"
-" automatiskt efter uppdateringar, så se till att regelbundet besöka <a "
-"href=\"%(plugincheck_url)s\">Kontrollera insticksmoduler</a> för att hålla "
-"dig uppdaterad."
+"Tillägg, till skillnad från insticksmoduler, kontrolleras automatiskt efter uppdateringar en gång varje dag. I Firefox, uppdateringar installeras automatiskt som standard. Versioner av Firefox före "
+"4 (och andra program) kommer att varna dig att uppdateringar för dina tillägg finns. <a href=\"%(plugin_url)s\">Insticksmoduler</a> kontrolleras för närvarande inte automatiskt efter uppdateringar, "
+"så se till att regelbundet besöka <a href=\"%(plugincheck_url)s\">Kontrollera insticksmoduler</a> för att hålla dig uppdaterad."
 
 #: src/olympia/pages/templates/pages/faq.html:122
 msgid "Are add-ons safe to install?"
@@ -13076,20 +10345,13 @@ msgstr "Är tillägg säkra att installera?"
 #: src/olympia/pages/templates/pages/faq.html:123
 #, python-format
 msgid ""
-"Unless clearly marked otherwise, add-ons available from this gallery have "
-"been checked and approved by Mozilla's team of editors and are safe to "
-"install. We recommend that you only install approved add-ons. If you wish to"
-" install unapproved add-ons or add-ons from third-party websites, use "
-"caution as these add-ons may harm your computer or violate your privacy. <a "
-"href=\"%(learnmore_url)s\">Learn more about our approval process</a>"
+"Unless clearly marked otherwise, add-ons available from this gallery have been checked and approved by Mozilla's team of editors and are safe to install. We recommend that you only install approved "
+"add-ons. If you wish to install unapproved add-ons or add-ons from third-party websites, use caution as these add-ons may harm your computer or violate your privacy. <a href=\"%(learnmore_url)s"
+"\">Learn more about our approval process</a>"
 msgstr ""
-"Om inget annat är angivet, har tillägg tillgängliga från detta galleri "
-"kontrollerats och godkänts av Mozillas grupp av redigerare och är säker att "
-"installera. Vi rekommenderar att du bara installera godkända tillägg. Om du "
-"vill installera godkända tillägg eller tillägg från tredje parts "
-"webbplatser, var försiktig eftersom dessa tillägg kan skada din dator eller "
-"kränka din integritet. <a href=\"%(learnmore_url)s\">Läs mer om vår "
-"godkännandeprocess</a>"
+"Om inget annat är angivet, har tillägg tillgängliga från detta galleri kontrollerats och godkänts av Mozillas grupp av redigerare och är säker att installera. Vi rekommenderar att du bara "
+"installera godkända tillägg. Om du vill installera godkända tillägg eller tillägg från tredje parts webbplatser, var försiktig eftersom dessa tillägg kan skada din dator eller kränka din "
+"integritet. <a href=\"%(learnmore_url)s\">Läs mer om vår godkännandeprocess</a>"
 
 #: src/olympia/pages/templates/pages/faq.html:133
 #, python-format
@@ -13099,45 +10361,27 @@ msgstr "Kan tillägg göra så %(app_name)s går långsammare?"
 #: src/olympia/pages/templates/pages/faq.html:135
 #, python-format
 msgid ""
-"Most add-ons do not cause a perceivable performance decrease in "
-"%(app_name)s, though installing an excessive number may have adverse "
-"effects. If you suspect an add-on is causing %(app_name)s to be slow, try "
-"disabling it."
+"Most add-ons do not cause a perceivable performance decrease in %(app_name)s, though installing an excessive number may have adverse effects. If you suspect an add-on is causing %(app_name)s to be "
+"slow, try disabling it."
 msgstr ""
-"De flesta tillägg orsakar inte en märkbar prestandaförsämring i "
-"%(app_name)s, dock att installera alltför många kan ha negativa effekter. Om"
-" du misstänker att en tilläggskomponent orsakar att %(app_name)s blir "
-"långsam, försök att inaktivera det."
+"De flesta tillägg orsakar inte en märkbar prestandaförsämring i %(app_name)s, dock att installera alltför många kan ha negativa effekter. Om du misstänker att en tilläggskomponent orsakar att "
+"%(app_name)s blir långsam, försök att inaktivera det."
 
 #: src/olympia/pages/templates/pages/faq.html:141
 #, python-format
-msgid ""
-"%(app_name)s told me an add-on isn't compatible. Is there a way I can still "
-"use it?"
-msgstr ""
-"%(app_name)s sa att ett tillägg inte är kompatibelt. Finns det något sätt "
-"jag kan använda det på ändå?"
+msgid "%(app_name)s told me an add-on isn't compatible. Is there a way I can still use it?"
+msgstr "%(app_name)s sa att ett tillägg inte är kompatibelt. Finns det något sätt jag kan använda det på ändå?"
 
 #: src/olympia/pages/templates/pages/faq.html:144
 #, python-format
 msgid ""
-"If an add-on isn't compatible with your version of %(app_name)s, it is "
-"usually either because your version of %(app_name)s is outdated or the add-"
-"on author has not yet updated the add-on to be compatible with a newer "
-"version you are using. Mozilla does not recommend trying to circumvent these"
-" compatibility checks, as they can lead to browser instability or in some "
-"cases loss of data. For users who are testing out alpha or beta versions of "
-"Firefox, we offer the <a href=\"%(acr_url)s\">Add-on Compatibility "
-"Reporter</a> to help add-on developers update their compatibility."
+"If an add-on isn't compatible with your version of %(app_name)s, it is usually either because your version of %(app_name)s is outdated or the add-on author has not yet updated the add-on to be "
+"compatible with a newer version you are using. Mozilla does not recommend trying to circumvent these compatibility checks, as they can lead to browser instability or in some cases loss of data. For "
+"users who are testing out alpha or beta versions of Firefox, we offer the <a href=\"%(acr_url)s\">Add-on Compatibility Reporter</a> to help add-on developers update their compatibility."
 msgstr ""
-"Om ett tillägg inte är kompatibel med din version av %(app_name)s, är det "
-"vanligtvis eftersom din version av %(app_name)s är föråldrad eller "
-"tilläggets upphovsman har ännu inte uppdaterat tillägget för att vara "
-"kompatibel med en nyare version som du använder. Mozilla rekommenderar inte "
-"att försöka kringgå dessa kontroller av kompatibilitet, eftersom de kan leda"
-" till instabilitet i webbläsaren eller i vissa fall förlust av data. För "
-"användare som testar ut alfa- eller betaversioner av Firefox, erbjuder vi <a"
-" href=\"%(acr_url)s\">Add-on Compatibility Reporter</a> för att hjälpa "
+"Om ett tillägg inte är kompatibel med din version av %(app_name)s, är det vanligtvis eftersom din version av %(app_name)s är föråldrad eller tilläggets upphovsman har ännu inte uppdaterat tillägget "
+"för att vara kompatibel med en nyare version som du använder. Mozilla rekommenderar inte att försöka kringgå dessa kontroller av kompatibilitet, eftersom de kan leda till instabilitet i webbläsaren "
+"eller i vissa fall förlust av data. För användare som testar ut alfa- eller betaversioner av Firefox, erbjuder vi <a href=\"%(acr_url)s\">Add-on Compatibility Reporter</a> för att hjälpa "
 "tilläggsutvecklare uppdatera sin kompatibilitet."
 
 #: src/olympia/pages/templates/pages/faq.html:156
@@ -13147,38 +10391,26 @@ msgstr "Vad gör jag om jag har problem med ett tillägg?"
 #: src/olympia/pages/templates/pages/faq.html:157
 #, python-format
 msgid ""
-"Add-ons are usually created by third-party developers from around the world,"
-" so the best way to get help with an add-on is to look for support links on "
-"the add-on's homepage or contact the developer. If you are having issues "
-"with %(app_name)s that you suspect are related to add-ons you have "
-"installed, <a href=\"%(troubleshooting_url)s\">visit this support "
-"article</a> for troubleshooting tips."
+"Add-ons are usually created by third-party developers from around the world, so the best way to get help with an add-on is to look for support links on the add-on's homepage or contact the "
+"developer. If you are having issues with %(app_name)s that you suspect are related to add-ons you have installed, <a href=\"%(troubleshooting_url)s\">visit this support article</a> for "
+"troubleshooting tips."
 msgstr ""
-"Tillägg skapas vanligen av tredjepartsutvecklare från hela världen, så det "
-"bästa sättet att få hjälp med ett tillägg är att leta efter supportlänkar på"
-" tilläggets hemsida eller kontakta utvecklaren. Om du har problem med "
-"%(app_name)s som du misstänker är relaterade till tillägget som du har "
-"installerat, <a href=\"%(troubleshooting_url)s\">besök denna "
-"supportartikeln</a> för felsökningstips."
+"Tillägg skapas vanligen av tredjepartsutvecklare från hela världen, så det bästa sättet att få hjälp med ett tillägg är att leta efter supportlänkar på tilläggets hemsida eller kontakta "
+"utvecklaren. Om du har problem med %(app_name)s som du misstänker är relaterade till tillägget som du har installerat, <a href=\"%(troubleshooting_url)s\">besök denna supportartikeln</a> för "
+"felsökningstips."
 
 #: src/olympia/pages/templates/pages/faq.html:169
 msgid "Add-on Gallery"
 msgstr "Galleri för tillägg"
 
 #: src/olympia/pages/templates/pages/faq.html:171
-msgid ""
-"How do I choose between add-ons that seem to do the same\n"
-"    thing?"
+msgid "How do I choose between add-ons that seem to do the same thing?"
 msgstr "Hur väljer jag mellan tillägg som verkar göra samma sak?"
 
-#: src/olympia/pages/templates/pages/faq.html:173
+#: src/olympia/pages/templates/pages/faq.html:172
 msgid ""
-"There are often several add-ons that have similar features. To\n"
-"    figure out which is right for you, read the entire description of the\n"
-"    add-on and view its screenshots. If there are still several in the running,\n"
-"    read through the add-on's ratings, user reviews, and statistics to see\n"
-"    which is most liked by other users. Remember that you can also just try\n"
-"    out both and see which you like better."
+"There are often several add-ons that have similar features. To figure out which is right for you, read the entire description of the add-on and view its screenshots. If there are still several in "
+"the running, read through the add-on's ratings, user reviews, and statistics to see which is most liked by other users. Remember that you can also just try out both and see which you like better."
 msgstr ""
 "Det finns ofta flera tillägg som har liknande funktioner. För \n"
 "    att bestämma vilken som är rätt för dig, läsa hela beskrivningen för\n"
@@ -13194,38 +10426,24 @@ msgstr "Vad händer om jag inte kan hitta ett tillägg som jag söker?"
 #: src/olympia/pages/templates/pages/faq.html:181
 #, python-format
 msgid ""
-"With thousands of add-ons available, there's something for everyone. But if "
-"you're looking for a particular add-on and can't find it, you might try "
-"searching on other sites or posting about it in our <a href=\"%(forum_url)s"
-"\">Add-ons </a>forum."
+"With thousands of add-ons available, there's something for everyone. But if you're looking for a particular add-on and can't find it, you might try searching on other sites or posting about it in "
+"our <a href=\"%(forum_url)s\">Add-ons </a>forum."
 msgstr ""
-"Med tusentals tillägg tillgängliga finns det något för alla. Men om du letar"
-" efter ett särskilt tillägg och kan inte hitta det, kan du prova söka på "
-"andra webbplatser eller trådar om det i vårt <a "
+"Med tusentals tillägg tillgängliga finns det något för alla. Men om du letar efter ett särskilt tillägg och kan inte hitta det, kan du prova söka på andra webbplatser eller trådar om det i vårt <a "
 "href=\"%(forum_url)s\">tilläggsforum</a>."
 
 #: src/olympia/pages/templates/pages/faq.html:187
-msgid ""
-"What does it mean if an add-on is \"experimental\" or \"preliminarily "
-"reviewed\"?"
-msgstr ""
-"Vad innebär det om en tillägg är \"experimentell\" eller \"preliminärt "
-"granskad\"?"
+msgid "What does it mean if an add-on is \"experimental\" or \"preliminarily reviewed\"?"
+msgstr "Vad innebär det om en tillägg är \"experimentell\" eller \"preliminärt granskad\"?"
 
 #: src/olympia/pages/templates/pages/faq.html:188
 #, python-format
 msgid ""
-"Experimental add-ons have been checked by our editors to make sure they "
-"don't have security problems, but they may still have bugs or not work "
-"properly. Use caution when installing experimental add-ons and uninstall the"
-" add-on immediately if you notice problems. <a href=\"%(url)s\">Learn more "
-"about our review process</a></dd>"
+"Experimental add-ons have been checked by our editors to make sure they don't have security problems, but they may still have bugs or not work properly. Use caution when installing experimental add-"
+"ons and uninstall the add-on immediately if you notice problems. <a href=\"%(url)s\">Learn more about our review process</a></dd>"
 msgstr ""
-"Experimentella tillägg har kontrollerats av våra redigerare för att se till "
-"att de inte har säkerhetsproblem, men de kan fortfarande har fel eller "
-"fungerar inte korrekt. Var försiktig när du installerar experimentella "
-"tillägg och avinstallera tillägget omedelbart om du upptäcker problem. <a "
-"href=\"%(url)s\">Mer information om vår granskningsprocess</a></dd>"
+"Experimentella tillägg har kontrollerats av våra redigerare för att se till att de inte har säkerhetsproblem, men de kan fortfarande har fel eller fungerar inte korrekt. Var försiktig när du "
+"installerar experimentella tillägg och avinstallera tillägget omedelbart om du upptäcker problem. <a href=\"%(url)s\">Mer information om vår granskningsprocess</a></dd>"
 
 #: src/olympia/pages/templates/pages/faq.html:196
 msgid "What does it mean if an add-on is \"not reviewed\"?"
@@ -13234,18 +10452,11 @@ msgstr "Vad innebär det om en tillägg är \"ej granskad\"?"
 #: src/olympia/pages/templates/pages/faq.html:197
 #, python-format
 msgid ""
-"While all add-ons publicly available in our gallery are reviewed by an "
-"editor, you may receive a direct link to an add-on that hasn't yet been "
-"reviewed. Use caution when installing these add-ons, as they could harm your"
-" computer or violate your privacy. We recommend that you only install "
-"reviewed add-ons. <a href=\"%(url)s\">Learn more about our review "
-"process</a></dd>"
+"While all add-ons publicly available in our gallery are reviewed by an editor, you may receive a direct link to an add-on that hasn't yet been reviewed. Use caution when installing these add-ons, "
+"as they could harm your computer or violate your privacy. We recommend that you only install reviewed add-ons. <a href=\"%(url)s\">Learn more about our review process</a></dd>"
 msgstr ""
-"Eftersom alla tillägg är publikt tillgängliga i vårt galleri granskas de av "
-"en redigerare, du kan få en direkt länk till ett tillägg som ännu inte har "
-"granskats. Var försiktig när du installerar detta tillägg, eftersom de kan "
-"skada din dator eller bryta mot sekretessen. Vi rekommenderar att du bara "
-"installerar granskade tillägg. <a href=\"%(url)s\">Mer information om vår "
+"Eftersom alla tillägg är publikt tillgängliga i vårt galleri granskas de av en redigerare, du kan få en direkt länk till ett tillägg som ännu inte har granskats. Var försiktig när du installerar "
+"detta tillägg, eftersom de kan skada din dator eller bryta mot sekretessen. Vi rekommenderar att du bara installerar granskade tillägg. <a href=\"%(url)s\">Mer information om vår "
 "granskningsprocess</a></dd>"
 
 #: src/olympia/pages/templates/pages/faq.html:206
@@ -13253,244 +10464,183 @@ msgid "How much do add-ons cost to purchase?"
 msgstr "Hur mycket kostar ett tillägg att köpa?"
 
 #: src/olympia/pages/templates/pages/faq.html:207
-msgid ""
-"Add-ons hosted in our gallery are free unless clearly marked\n"
-"    otherwise."
+msgid "Add-ons hosted in our gallery are free unless clearly marked otherwise."
 msgstr ""
 "Tillägg i vårt galleri är gratis om det inte tydligt står\n"
 "    något annat."
 
-#: src/olympia/pages/templates/pages/faq.html:210
+#: src/olympia/pages/templates/pages/faq.html:209
 msgid "What does it mean when an add-on asks for contributions?"
 msgstr "Vad betyder det när ett tillägg ber om bidrag?"
 
-#: src/olympia/pages/templates/pages/faq.html:211
+#: src/olympia/pages/templates/pages/faq.html:210
 msgid ""
-"Some add-on authors request users who enjoy an add-on to\n"
-"        contribute to its development by making a monetary contribution. These\n"
-"        contributions go directly to the developer unless a third party is\n"
-"        indicated, such as the non-profit Mozilla Foundation."
+"Some add-on authors request users who enjoy an add-on to contribute to its development by making a monetary contribution. These contributions go directly to the developer unless a third party is "
+"indicated, such as the non-profit Mozilla Foundation."
 msgstr ""
 "Vissa upphovsmän av tillägg begär att användare som tycker om ett tillägg kan\n"
 "        bidra till dess utveckling genom att göra ett monetärt bidrag. Dessa\n"
 "        bidrag går direkt till utvecklaren om inte en tredje part är\n"
 "        angiven, såsom den ideella Mozilla Foundation."
 
-#: src/olympia/pages/templates/pages/faq.html:216
+#: src/olympia/pages/templates/pages/faq.html:215
 msgid "What are beta add-ons?"
 msgstr "Vad är beta-tillägg?"
 
-#: src/olympia/pages/templates/pages/faq.html:218
+#: src/olympia/pages/templates/pages/faq.html:217
 msgid ""
-"Beta add-ons are unreviewed versions which represent the\n"
-"        latest work of an add-on author. While different authors have different\n"
-"        standards for beta code quality, you should assume that these add-ons\n"
-"        are less stable than the general add-on releases."
+"Beta add-ons are unreviewed versions which represent the latest work of an add-on author. While different authors have different standards for beta code quality, you should assume that these add-"
+"ons are less stable than the general add-on releases."
 msgstr ""
 "Beta-tillägg är ej granskade versioner som representerar\n"
 "        det senaste arbetet av en tilläggsförfattare. Medan olika författare har olika\n"
 "        standarder för beta kodkvalitet, bör du anta att dessa tillägg\n"
 "        är mindre stabila än de allmänna tillägg som ges ut."
 
-#: src/olympia/pages/templates/pages/faq.html:222
+#: src/olympia/pages/templates/pages/faq.html:221
 msgid ""
-"Please note that when you install an add-on from the \"Beta Version\" "
-"section of an add-on's listing, you will continue to receive updates for "
-"that add-on as they become available. Like the initial version you "
-"installed, all beta releases are unreviewed by Mozilla and may harm your "
-"computer."
+"Please note that when you install an add-on from the \"Beta Version\" section of an add-on's listing, you will continue to receive updates for that add-on as they become available. Like the initial "
+"version you installed, all beta releases are unreviewed by Mozilla and may harm your computer."
 msgstr ""
-"Observera att när du installerar ett tillägg från sektionen \"Betaversion\" "
-"i ett tilläggs listning, kommer du att fortsätta att ta emot uppdateringar "
-"för detta tillägg när de blir tillgängliga. Som den första versionen du "
-"installerat, alla betaversioner är inte granskade av Mozilla och kan skada "
-"din dator."
+"Observera att när du installerar ett tillägg från sektionen \"Betaversion\" i ett tilläggs listning, kommer du att fortsätta att ta emot uppdateringar för detta tillägg när de blir tillgängliga. "
+"Som den första versionen du installerat, alla betaversioner är inte granskade av Mozilla och kan skada din dator."
 
-#: src/olympia/pages/templates/pages/faq.html:229
-msgid ""
-"What does it mean when an add-on is flagged as\n"
-"    slow?"
+#: src/olympia/pages/templates/pages/faq.html:228
+msgid "What does it mean when an add-on is flagged as slow?"
 msgstr ""
 "Vad betyder det när ett tillägg är flaggad som\n"
 "    långsam?"
 
-#: src/olympia/pages/templates/pages/faq.html:231
-msgid ""
-"Most add-ons load code and resources at the same time Firefox\n"
-"        is starting up. In most cases the impact in start-up time is minimal,\n"
-"        but some add-ons can cause a noticeable slowdown."
+#: src/olympia/pages/templates/pages/faq.html:229
+msgid "Most add-ons load code and resources at the same time Firefox is starting up. In most cases the impact in start-up time is minimal, but some add-ons can cause a noticeable slowdown."
 msgstr ""
 "De flesta tillägg laddar kod och resurser samtidigt som Firefox\n"
 "        startar. I de flesta fall är påverkan av uppstartstid minimal,\n"
 "        men vissa tillägg kan orsaka en märkbar fördröjning."
 
-#: src/olympia/pages/templates/pages/faq.html:236
+#: src/olympia/pages/templates/pages/faq.html:234
 msgid "How do I report an inappropriate or spam user review?"
 msgstr "Hur gör jag rapportera en olämplig eller skräppost användarrecension?"
 
-#: src/olympia/pages/templates/pages/faq.html:237
+#: src/olympia/pages/templates/pages/faq.html:235
 msgid ""
-"To report a user review of an add-on, log in with your account\n"
-"    and visit the add-on's reviews page. Find the review you wish to report,\n"
-"    click \"Report this review\" and select a reason. Our editorial team will\n"
-"    investigate the review and take appropriate action."
+"To report a user review of an add-on, log in with your account and visit the add-on's reviews page. Find the review you wish to report, click \"Report this review\" and select a reason. Our "
+"editorial team will investigate the review and take appropriate action."
 msgstr ""
 "För att rapportera en användarrecension av ett tillägg, logga in med ditt konto\n"
 "    och besök tilläggets recensionssida. Hitta granskningen du vill rapportera,\n"
 "    klicka på \"Rapportera den här recensionen\" och välj en anledning. Vår redaktion\n"
 "    kommer att undersöka recensionen och vidta lämpliga åtgärder."
 
-#: src/olympia/pages/templates/pages/faq.html:242
+#: src/olympia/pages/templates/pages/faq.html:240
 msgid "How do I report a bug or contact the Mozilla Add-ons team?"
 msgstr "Hur rapporterar jag ett fel eller kontaktar Mozilla tilläggsgrupp?"
 
-#: src/olympia/pages/templates/pages/faq.html:243
+#: src/olympia/pages/templates/pages/faq.html:241
 #, python-format
 msgid "Please visit our <a href=\"%(contact_url)s\">Contact page</a>."
 msgstr "Vänligen besök vår <a href=\"%(contact_url)s\">kontaktsida</a>."
 
-#: src/olympia/pages/templates/pages/faq.html:246
+#: src/olympia/pages/templates/pages/faq.html:244
 msgid "What is a Source Code License?"
 msgstr "Vad är en källkodslicens?"
 
-#: src/olympia/pages/templates/pages/faq.html:247
+#: src/olympia/pages/templates/pages/faq.html:245
 #, python-format
 msgid ""
-"The source code used to create an add-on is an exclusive copyright of the "
-"add-on author, unless otherwise declared in a source code license. Many add-"
-"ons on this site have <a href=\"%(url)s\" lang=\"en\">open source "
-"licenses</a> that make the source code publicly available for copy and reuse"
-" under conditions determined by the author. Most authors choose widely known"
-" open source licenses like the GPL or BSD licenses instead of making up "
-"their own."
+"The source code used to create an add-on is an exclusive copyright of the add-on author, unless otherwise declared in a source code license. Many add-ons on this site have <a href=\"%(url)s\" lang="
+"\"en\">open source licenses</a> that make the source code publicly available for copy and reuse under conditions determined by the author. Most authors choose widely known open source licenses like "
+"the GPL or BSD licenses instead of making up their own."
 msgstr ""
-"Källkoden för att skapa ett tillägg är en exklusiv upphovsrätt för "
-"tilläggets upphovsman, om inte annat angetts i en licens för källkoden. "
-"Många tillägg på webbplatsen har <a href=\"%(url)s\" lang=\"en\">licenser "
-"för öppen källkod</a> som gör att källkoden blir tillgänglig för allmänheten"
-" att kopiera och återanvända under de villkor som fastställs av "
-"upphovsmannen. De flesta upphovsmän väljer välkända licenser för öppen "
-"källkod GPL eller BSD licenser istället för att skapa sina egna."
+"Källkoden för att skapa ett tillägg är en exklusiv upphovsrätt för tilläggets upphovsman, om inte annat angetts i en licens för källkoden. Många tillägg på webbplatsen har <a href=\"%(url)s\" lang="
+"\"en\">licenser för öppen källkod</a> som gör att källkoden blir tillgänglig för allmänheten att kopiera och återanvända under de villkor som fastställs av upphovsmannen. De flesta upphovsmän "
+"väljer välkända licenser för öppen källkod GPL eller BSD licenser istället för att skapa sina egna."
 
-#: src/olympia/pages/templates/pages/faq.html:256
+#: src/olympia/pages/templates/pages/faq.html:254
 #, python-format
-msgid ""
-"Firefox and other Mozilla software are <a href=\"%(url)s\">open source</a>."
-msgstr ""
-"Firefox och andra Mozilla programvaror är <a href=\"%(url)s\">open "
-"source</a>."
+msgid "Firefox and other Mozilla software are <a href=\"%(url)s\">open source</a>."
+msgstr "Firefox och andra Mozilla programvaror är <a href=\"%(url)s\">open source</a>."
 
-#: src/olympia/pages/templates/pages/faq.html:264
+#: src/olympia/pages/templates/pages/faq.html:262
 msgid "Collections and Favorites"
 msgstr "Samlingar och favoriter"
 
-#: src/olympia/pages/templates/pages/faq.html:267
+#: src/olympia/pages/templates/pages/faq.html:265
 msgid "What is a collection?"
 msgstr "Vad är en samling?"
 
-#: src/olympia/pages/templates/pages/faq.html:268
+#: src/olympia/pages/templates/pages/faq.html:266
 msgid "Collections are groups of related add-ons created by users to share."
-msgstr ""
-"Samlingar är grupper av tillägg som samlats ihop av användare för att dela "
-"med sig av dem."
+msgstr "Samlingar är grupper av tillägg som samlats ihop av användare för att dela med sig av dem."
 
-#: src/olympia/pages/templates/pages/faq.html:270
+#: src/olympia/pages/templates/pages/faq.html:268
 msgid "What is the My Favorites collection?"
 msgstr "Vad är samlingen Mina favoriter?"
 
-#: src/olympia/pages/templates/pages/faq.html:271
-msgid ""
-"Favorite add-ons are add-ons that you have bookmarked to easily get back to "
-"later. You can add an add-on to your favorites collection by clicking \"Add "
-"to favorites\" on its details page."
+#: src/olympia/pages/templates/pages/faq.html:269
+msgid "Favorite add-ons are add-ons that you have bookmarked to easily get back to later. You can add an add-on to your favorites collection by clicking \"Add to favorites\" on its details page."
 msgstr ""
-"Favorittillägg är tillägg som du har bokmärkt för att enkelt komma tillbaka "
-"till senare. Du kan lägga till ett tillägg till din favoritsamling genom att"
-" klicka på \"Lägg till favoriter\" på deras informationssida."
+"Favorittillägg är tillägg som du har bokmärkt för att enkelt komma tillbaka till senare. Du kan lägga till ett tillägg till din favoritsamling genom att klicka på \"Lägg till favoriter\" på deras "
+"informationssida."
 
-#: src/olympia/pages/templates/pages/faq.html:275
-#: src/olympia/templates/menu_links.html:13
-#: src/olympia/templates/impala/header_title.html:17
+#: src/olympia/pages/templates/pages/faq.html:273 src/olympia/templates/menu_links.html:13 src/olympia/templates/impala/header_title.html:17
 msgid "Mobile Add-ons"
 msgstr "Mobila tillägg"
 
-#: src/olympia/pages/templates/pages/faq.html:278
+#: src/olympia/pages/templates/pages/faq.html:276
 msgid "What are mobile add-ons?"
 msgstr "Vad är mobila tillägg?"
 
-#: src/olympia/pages/templates/pages/faq.html:279
+#: src/olympia/pages/templates/pages/faq.html:277
 #, python-format
 msgid ""
-"Mobile add-ons work with <a href=\"%(mobile_url)s\">Firefox for Mobile</a> "
-"and add or modify functionality just like desktop add-ons. You can find add-"
-"ons that work with Firefox for Mobile in our <a "
-"href=\"%(gallery_url)s\">gallery</a>."
+"Mobile add-ons work with <a href=\"%(mobile_url)s\">Firefox for Mobile</a> and add or modify functionality just like desktop add-ons. You can find add-ons that work with Firefox for Mobile in our "
+"<a href=\"%(gallery_url)s\">gallery</a>."
 msgstr ""
-"Mobila tillägg fungerar med <a href=\"%(mobile_url)s\">Firefox för mobil</a>"
-" och lägga till eller ändra funktioner precis som skrivbordstillägg. Du "
-"hittar tillägg som fungerar med Firefox för mobil i vårt <a "
-"href=\"%(gallery_url)s\">galleri</a>."
+"Mobila tillägg fungerar med <a href=\"%(mobile_url)s\">Firefox för mobil</a> och lägga till eller ändra funktioner precis som skrivbordstillägg. Du hittar tillägg som fungerar med Firefox för mobil "
+"i vårt <a href=\"%(gallery_url)s\">galleri</a>."
 
-#: src/olympia/pages/templates/pages/faq.html:288
+#: src/olympia/pages/templates/pages/faq.html:286
 msgid "Developer Topics"
 msgstr "Utvecklarämnen"
 
-#: src/olympia/pages/templates/pages/faq.html:289
+#: src/olympia/pages/templates/pages/faq.html:287
 #, python-format
-msgid ""
-"Please see our <a href=\"%(faq_url)s\">Developer FAQ</a> and <a "
-"href=\"%(hub_url)s\">Developer Hub</a> for answers to add-on developer-"
-"related questions."
-msgstr ""
-"Se vår <a href=\"%(faq_url)s\">FAQ för utvecklare</a> och <a "
-"href=\"%(hub_url)s\">utvecklarcenter</a> för svar på utvecklingsrelaterade "
-"frågor för tillägg."
+msgid "Please see our <a href=\"%(faq_url)s\">Developer FAQ</a> and <a href=\"%(hub_url)s\">Developer Hub</a> for answers to add-on developer-related questions."
+msgstr "Se vår <a href=\"%(faq_url)s\">FAQ för utvecklare</a> och <a href=\"%(hub_url)s\">utvecklarcenter</a> för svar på utvecklingsrelaterade frågor för tillägg."
 
-#: src/olympia/pages/templates/pages/faq.html:294
+#: src/olympia/pages/templates/pages/faq.html:292
 msgid "Still have questions?"
 msgstr "Har du fortfarande frågor?"
 
-#: src/olympia/pages/templates/pages/faq.html:295
+#: src/olympia/pages/templates/pages/faq.html:293
 #, python-format
-msgid ""
-"For general Firefox support, visit our <a href=\"%(sumo_url)s\">support "
-"website</a>. For general add-on and website questions, visit our <a "
-"href=\"%(forum_url)s\">forum</a>."
-msgstr ""
-"För generell Firefox Support, besök våran <a href=\"%(sumo_url)s\">support "
-"hemsida</a>. För generella tilläggs och hemside frågor, besök vårat<a "
-"href=\"%(forum_url)s\">forum</a>."
+msgid "For general Firefox support, visit our <a href=\"%(sumo_url)s\">support website</a>. For general add-on and website questions, visit our <a href=\"%(forum_url)s\">forum</a>."
+msgstr "För generell Firefox Support, besök våran <a href=\"%(sumo_url)s\">support hemsida</a>. För generella tilläggs och hemside frågor, besök vårat<a href=\"%(forum_url)s\">forum</a>."
 
-#: src/olympia/pages/templates/pages/review_guide.html:36
-#: src/olympia/pages/templates/pages/review_guide.html:51
+#: src/olympia/pages/templates/pages/review_guide.html:36 src/olympia/pages/templates/pages/review_guide.html:51
 msgid "Some tips for writing a great review"
 msgstr "Några tips för att skriva en bra recension"
 
-#: src/olympia/pages/templates/pages/review_guide.html:39
-#: src/olympia/pages/templates/pages/review_guide.html:131
+#: src/olympia/pages/templates/pages/review_guide.html:39 src/olympia/pages/templates/pages/review_guide.html:131
 msgid "Frequently Asked Questions about Reviews"
 msgstr "Vanliga frågor om granskning"
 
 #: src/olympia/pages/templates/pages/review_guide.html:46
 msgid ""
-"Add-on reviews are a way for you to share your opinions about the add-ons "
-"you’ve installed and used. Our review moderation team reserves the right to "
-"refuse or remove any review that does not comply with these guidelines."
+"Add-on reviews are a way for you to share your opinions about the add-ons you’ve installed and used. Our review moderation team reserves the right to refuse or remove any review that does not "
+"comply with these guidelines."
 msgstr ""
-"Ett tilläggs recensioner är ett sätt för dig att dela med dig av dina "
-"åsikter om tillägg som du har installerat och använt. Vår moderationsgrupp "
-"förbehåller sig rätten att vägra eller ta bort recension som inte "
-"överensstämmer med dessa riktlinjer."
+"Ett tilläggs recensioner är ett sätt för dig att dela med dig av dina åsikter om tillägg som du har installerat och använt. Vår moderationsgrupp förbehåller sig rätten att vägra eller ta bort "
+"recension som inte överensstämmer med dessa riktlinjer."
 
 #: src/olympia/pages/templates/pages/review_guide.html:53
 msgid "Do:"
 msgstr "Att göra:"
 
 #: src/olympia/pages/templates/pages/review_guide.html:56
-msgid ""
-"Write like you are telling a friend about your experience with the add-on."
-msgstr ""
-"Skriv som om du berättar för en vän om dina erfarenheter med tillägget."
+msgid "Write like you are telling a friend about your experience with the add-on."
+msgstr "Skriv som om du berättar för en vän om dina erfarenheter med tillägget."
 
 #: src/olympia/pages/templates/pages/review_guide.html:61
 msgid "Keep reviews concise and easy to understand."
@@ -13521,11 +10671,8 @@ msgid "Will you continue to use this add-on?"
 msgstr "Kommer du fortsätta att använda detta tillägg?"
 
 #: src/olympia/pages/templates/pages/review_guide.html:73
-msgid ""
-"Take a moment to read your review before submitting it to minimize typos."
-msgstr ""
-"Ta en stund och läs igenom din recension innan du skickar in den för att "
-"minimera stavfel."
+msgid "Take a moment to read your review before submitting it to minimize typos."
+msgstr "Ta en stund och läs igenom din recension innan du skickar in den för att minimera stavfel."
 
 #: src/olympia/pages/templates/pages/review_guide.html:79
 msgid "Don’t:"
@@ -13533,71 +10680,47 @@ msgstr "Att inte göra:"
 
 #: src/olympia/pages/templates/pages/review_guide.html:82
 msgid "Submit one-word reviews such as \"Great!\", \"wonderful,\" or \"bad.\""
-msgstr ""
-"Skicka inte in recensioner med ett ord, som \"Bra!\", \"underbar\" eller "
-"\"dålig\"."
+msgstr "Skicka inte in recensioner med ett ord, som \"Bra!\", \"underbar\" eller \"dålig\"."
 
 #: src/olympia/pages/templates/pages/review_guide.html:87
 msgid ""
-"Post technical issues, support requests, or feature suggestions. Use the "
-"available support options for each add-on, if available. You can find them "
-"in the side column next to the About this Add-on section."
+"Post technical issues, support requests, or feature suggestions. Use the available support options for each add-on, if available. You can find them in the side column next to the About this Add-on "
+"section."
 msgstr ""
-"Posta tekniska frågor, supportfrågor eller funktionsförslag. Använd de "
-"tillgängliga supportalternativen för varje tillägg, om sådana finns. Du "
-"hittar dem i sidokolumnen bredvid avsnittet Om detta tillägg."
+"Posta tekniska frågor, supportfrågor eller funktionsförslag. Använd de tillgängliga supportalternativen för varje tillägg, om sådana finns. Du hittar dem i sidokolumnen bredvid avsnittet Om detta "
+"tillägg."
 
 #: src/olympia/pages/templates/pages/review_guide.html:92
 msgid "Write reviews for add-ons which you have not personally used."
 msgstr "Skriv omdömen om tillägg som du inte personligen har använt."
 
 #: src/olympia/pages/templates/pages/review_guide.html:97
-msgid ""
-"Use profanity, sexual language or language that can be construed as hateful."
-msgstr ""
-"Använd svordomar, sexuellt språk eller språk som kan uppfattas som hatiskt."
+msgid "Use profanity, sexual language or language that can be construed as hateful."
+msgstr "Använd svordomar, sexuellt språk eller språk som kan uppfattas som hatiskt."
 
 #: src/olympia/pages/templates/pages/review_guide.html:103
-msgid ""
-"Include HTML, links, source code or code snippets. Reviews are meant to be "
-"text only."
-msgstr ""
-"Inkludera HTML, länkar, källkod eller kodavsnitt. Omdömen är avsedda att "
-"vara enbart text."
+msgid "Include HTML, links, source code or code snippets. Reviews are meant to be text only."
+msgstr "Inkludera HTML, länkar, källkod eller kodavsnitt. Omdömen är avsedda att vara enbart text."
 
 #: src/olympia/pages/templates/pages/review_guide.html:108
-msgid ""
-"Make false statements, disparage add-on authors or personally insult them."
-msgstr ""
-"Gör felaktiga uppgifter, nedvärdera tilläggs upphovsmän eller personligen "
-"förolämpa dem."
+msgid "Make false statements, disparage add-on authors or personally insult them."
+msgstr "Gör felaktiga uppgifter, nedvärdera tilläggs upphovsmän eller personligen förolämpa dem."
 
 #: src/olympia/pages/templates/pages/review_guide.html:114
-msgid ""
-"Include your own or anyone else’s email, phone number, or other personal "
-"details."
-msgstr ""
-"Inkludera din egen eller någon annans e-post, telefonnummer eller andra "
-"personliga detaljer."
+msgid "Include your own or anyone else’s email, phone number, or other personal details."
+msgstr "Inkludera din egen eller någon annans e-post, telefonnummer eller andra personliga detaljer."
 
 #: src/olympia/pages/templates/pages/review_guide.html:119
-msgid ""
-"Post reviews for an add-on you or your organization wrote or represent."
-msgstr ""
-"Posta recensioner för ett tillägg som du eller din organisation har skrivit "
-"eller representerar."
+msgid "Post reviews for an add-on you or your organization wrote or represent."
+msgstr "Posta recensioner för ett tillägg som du eller din organisation har skrivit eller representerar."
 
 #: src/olympia/pages/templates/pages/review_guide.html:125
 msgid ""
-"Criticize an add-on for something it’s intended to do. For example, leaving "
-"a negative review of an add-on for displaying ads or requiring data "
-"gathering, when that is the intended purpose of the add-on, or the add-on "
-"requires gathering data to function."
+"Criticize an add-on for something it’s intended to do. For example, leaving a negative review of an add-on for displaying ads or requiring data gathering, when that is the intended purpose of the "
+"add-on, or the add-on requires gathering data to function."
 msgstr ""
-"Kritisera ett tillägg för något det är avsett att göra. Till exempel, lämna "
-"en negativ recension av ett tillägg för att de visar annonser eller kräver "
-"datainsamling, när detta är det avsedda ändamålet med tillägget eller "
-"tillägget kräver att samla in data för att fungera."
+"Kritisera ett tillägg för något det är avsett att göra. Till exempel, lämna en negativ recension av ett tillägg för att de visar annonser eller kräver datainsamling, när detta är det avsedda "
+"ändamålet med tillägget eller tillägget kräver att samla in data för att fungera."
 
 #: src/olympia/pages/templates/pages/review_guide.html:133
 msgid "How can I report a problematic review?"
@@ -13605,16 +10728,11 @@ msgstr "Hur kan jag rapportera en problematisk recension?"
 
 #: src/olympia/pages/templates/pages/review_guide.html:135
 msgid ""
-"Please report or flag any questionable reviews by clicking the \"Report this"
-" review\" and it will be submitted to the site for moderation. Our "
-"moderation team will use the Review Guidelines to evaluate whether or not to"
-" delete the review or restore it back to the site."
+"Please report or flag any questionable reviews by clicking the \"Report this review\" and it will be submitted to the site for moderation. Our moderation team will use the Review Guidelines to "
+"evaluate whether or not to delete the review or restore it back to the site."
 msgstr ""
-"Vänligen rapportera eller flagga alla tvivelaktig recensioner genom att "
-"klicka på \"rapportera denna recension\" och det kommer att överlämnas till "
-"platsen för moderering. Vår modereringsgrupp använder recensionsriktlinjerna"
-" för att utvärdera om de ska ta bort recensionen eller återställa det "
-"tillbaka till webbplatsen eller inte."
+"Vänligen rapportera eller flagga alla tvivelaktig recensioner genom att klicka på \"rapportera denna recension\" och det kommer att överlämnas till platsen för moderering. Vår modereringsgrupp "
+"använder recensionsriktlinjerna för att utvärdera om de ska ta bort recensionen eller återställa det tillbaka till webbplatsen eller inte."
 
 #: src/olympia/pages/templates/pages/review_guide.html:140
 msgid "I’m an add-on author, can I respond to reviews?"
@@ -13622,34 +10740,22 @@ msgstr "Jag är upphovsman för ett tillägg, kan jag svara på recensioner?"
 
 #: src/olympia/pages/templates/pages/review_guide.html:142
 #, python-format
-msgid ""
-"Yes, add-on authors can provide a single response to a review. You can set "
-"up a discussion topic in our <a href=\"%(forum_url)s\">forum</a> to engage "
-"in additional discussion or follow-up."
+msgid "Yes, add-on authors can provide a single response to a review. You can set up a discussion topic in our <a href=\"%(forum_url)s\">forum</a> to engage in additional discussion or follow-up."
 msgstr ""
-"Ja, upphovsmän till tillägg kan ge ett enda svar på en recension. Du kan "
-"ställa in ett diskussionsämne i vårt <a href=\"%(forum_url)s\">forum</a> för"
-" att engagera dig i ytterligare diskussion eller uppföljning."
+"Ja, upphovsmän till tillägg kan ge ett enda svar på en recension. Du kan ställa in ett diskussionsämne i vårt <a href=\"%(forum_url)s\">forum</a> för att engagera dig i ytterligare diskussion eller "
+"uppföljning."
 
 #: src/olympia/pages/templates/pages/review_guide.html:149
 msgid "I’m an add-on author, can I delete unfavorable reviews or ratings?"
-msgstr ""
-"Jag är upphovsman för tillägg, kan jag ta bort negativa recensioner eller "
-"betyg?"
+msgstr "Jag är upphovsman för tillägg, kan jag ta bort negativa recensioner eller betyg?"
 
 #: src/olympia/pages/templates/pages/review_guide.html:151
 msgid ""
-"In general, no. But if the review did not meet the review guidelines "
-"outlined above, you can click \"Report this review\" and have it moderated. "
-"If a review included a complaint that is no longer valid due to a new "
-"release of your add-on, we may consider deleting the review. Submit your "
-"detailed request to amo-editors@mozilla.org."
+"In general, no. But if the review did not meet the review guidelines outlined above, you can click \"Report this review\" and have it moderated. If a review included a complaint that is no longer "
+"valid due to a new release of your add-on, we may consider deleting the review. Submit your detailed request to amo-editors@mozilla.org."
 msgstr ""
-"I allmänhet, nej. Men om recensionen inte uppfyllde riktlinjerna ovan, kan "
-"du klicka på \"Rapportera denna recension\" och få den modererad. Om ett "
-"klagomål ingår i recensionen som inte längre är giltig på grund av en ny "
-"version av ditt tillägg, kan vi överväga att ta bort recensionen. Skicka in "
-"din detaljerade begäran till amo-editors@mozilla.org."
+"I allmänhet, nej. Men om recensionen inte uppfyllde riktlinjerna ovan, kan du klicka på \"Rapportera denna recension\" och få den modererad. Om ett klagomål ingår i recensionen som inte längre är "
+"giltig på grund av en ny version av ditt tillägg, kan vi överväga att ta bort recensionen. Skicka in din detaljerade begäran till amo-editors@mozilla.org."
 
 #: src/olympia/pages/templates/pages/sunbird.html:26
 msgid "Sunbird has retired"
@@ -13657,24 +10763,16 @@ msgstr "Sunbird har upphört"
 
 #: src/olympia/pages/templates/pages/sunbird.html:29
 msgid ""
-"Development on the Sunbird project has halted and its final release was on "
-"March 30, 2010.  We've been proud to host Sunbird add-ons on this site but "
-"as the project is no longer maintained we have disabled our support for the "
-"add-ons."
+"Development on the Sunbird project has halted and its final release was on March 30, 2010. We've been proud to host Sunbird add-ons on this site but as the project is no longer maintained we have "
+"disabled our support for the add-ons."
 msgstr ""
-"Utveckling på Sunbird projektet har stoppats och dess slutliga utgåva var "
-"den 30 mars 2010.  Vi har varit stolta över att vara värd för Sunbirds "
-"tillägg på denna webbplats, men eftersom projektet inte längre upprätthålls "
-"har vi inaktiverat vårt stöd för tillägg."
+"Utveckling på Sunbird projektet har stoppats och dess slutliga utgåva var den 30 mars 2010.  Vi har varit stolta över att vara värd för Sunbirds tillägg på denna webbplats, men eftersom projektet "
+"inte längre upprätthålls har vi inaktiverat vårt stöd för tillägg."
 
 #: src/olympia/pages/templates/pages/sunbird.html:38
 #, python-format
-msgid ""
-"We recommend upgrading to <a href=\"%(tb_url)s\">Thunderbird</a> and <a "
-"href=\"%(lightning_url)s\">Lightning</a>."
-msgstr ""
-"Vi rekommenderar uppgradering till <a href=\"%(tb_url)s\">Thunderbird</a> "
-"och <a href=\"%(lightning_url)s\">Lightning</a>."
+msgid "We recommend upgrading to <a href=\"%(tb_url)s\">Thunderbird</a> and <a href=\"%(lightning_url)s\">Lightning</a>."
+msgstr "Vi rekommenderar uppgradering till <a href=\"%(tb_url)s\">Thunderbird</a> och <a href=\"%(lightning_url)s\">Lightning</a>."
 
 #: src/olympia/pages/templates/pages/sunbird.html:45
 msgid "Read more about Sunbird"
@@ -13725,8 +10823,7 @@ msgstr "Behåll recension; ta bort flaggor"
 msgid "Skip for now"
 msgstr "Hoppa över nu"
 
-#: src/olympia/reviews/forms.py:151
-#: src/olympia/reviews/templates/reviews/review.html:107
+#: src/olympia/reviews/forms.py:151 src/olympia/reviews/templates/reviews/review.html:107
 msgid "Delete review"
 msgstr "Ta bort recension"
 
@@ -13745,40 +10842,23 @@ msgstr "Lägg till en recension för {0}"
 #: src/olympia/reviews/templates/reviews/add.html:26
 #, python-format
 msgid ""
-"<h2>Keep these tips in mind:</h2> <ul> <li> Write like you're telling a "
-"friend about your experience with the add-on. Give specifics and helpful "
-"details, such as what features you liked and/or disliked, how easy to use it"
-" is, and any disadvantages it has.  Avoid generic language such as calling "
-"it \"Great\" or \"Bad\" unless you can give reasons why you believe this is "
-"so. </li> <li> Please do not post bug reports in reviews. We do not make "
-"your email address available to add-on developers and they may need to "
-"contact you to help resolve your issue. See the <a "
-"href=\"%(support)s\">support section</a> to find out where to get assistance"
-" for this add-on. </li> <li>Please keep reviews clean, avoid the use of "
-"improper language and do not post any personal information. </li> </ul> "
-"<p>Please read the <a href=\"%(guide)s\" target=\"_blank\">Review "
-"Guidelines</a> for more detail about user add-on reviews.</p>"
+"<h2>Keep these tips in mind:</h2> <ul> <li> Write like you're telling a friend about your experience with the add-on. Give specifics and helpful details, such as what features you liked and/or "
+"disliked, how easy to use it is, and any disadvantages it has. Avoid generic language such as calling it \"Great\" or \"Bad\" unless you can give reasons why you believe this is so. </li> <li> "
+"Please do not post bug reports in reviews. We do not make your email address available to add-on developers and they may need to contact you to help resolve your issue. See the <a href=\"%(support)s"
+"\">support section</a> to find out where to get assistance for this add-on. </li> <li>Please keep reviews clean, avoid the use of improper language and do not post any personal information. </li> </"
+"ul> <p>Please read the <a href=\"%(guide)s\" target=\"_blank\">Review Guidelines</a> for more detail about user add-on reviews.</p>"
 msgstr ""
-"<h2>Håll dessa tips i åtanke:</h2> <ul> <li> Skriv som du berättar för en "
-"vän om dina erfarenheter med ett tillägg. Ge specifika och hjälpsamma "
-"detaljer, såsom vilka funktioner du gillade och/eller ogillade, hur lätt den"
-" är att använda och eventuella nackdelar den har.  Undvik generisk språk som"
-" att kalla det \"Bra\" eller \"Dålig\" om du inte kan ge skäl till varför du"
-" tror att det är så. </li> <li> Skicka inte felrapporter i recensioner. Vi "
-"gör inte din e-postadress tillgänglig för tilläggsutvecklare och de kan "
-"behöva kontakta dig för att lösa problemet. Se <a "
-"href=\"%(support)s\">stödsektionen</a> för att ta reda på var du kan få "
-"hjälp med detta tillägg. </li> <li> Håll recensioner rena, undvika "
-"användning av felaktigt språk och posta inte någon personlig information. "
-"</li> </ul> <p>Läs <a href=\"%(guide)s\" target=\"_blank\">riktlinjer för "
-"granskare</a> för mer information om användarrecensioner.</p>"
+"<h2>Håll dessa tips i åtanke:</h2> <ul> <li> Skriv som du berättar för en vän om dina erfarenheter med ett tillägg. Ge specifika och hjälpsamma detaljer, såsom vilka funktioner du gillade och/eller "
+"ogillade, hur lätt den är att använda och eventuella nackdelar den har.  Undvik generisk språk som att kalla det \"Bra\" eller \"Dålig\" om du inte kan ge skäl till varför du tror att det är så. </"
+"li> <li> Skicka inte felrapporter i recensioner. Vi gör inte din e-postadress tillgänglig för tilläggsutvecklare och de kan behöva kontakta dig för att lösa problemet. Se <a href=\"%(support)s"
+"\">stödsektionen</a> för att ta reda på var du kan få hjälp med detta tillägg. </li> <li> Håll recensioner rena, undvika användning av felaktigt språk och posta inte någon personlig information. </"
+"li> </ul> <p>Läs <a href=\"%(guide)s\" target=\"_blank\">riktlinjer för granskare</a> för mer information om användarrecensioner.</p>"
 
 #: src/olympia/reviews/templates/reviews/reply.html:4
 msgid "Reply to review by {0}"
 msgstr "Besvara recension av {0}"
 
-#: src/olympia/reviews/templates/reviews/reply.html:15
-#: src/olympia/reviews/templates/reviews/reply.html:31
+#: src/olympia/reviews/templates/reviews/reply.html:15 src/olympia/reviews/templates/reviews/reply.html:31
 msgid "Reply"
 msgstr "Svara"
 
@@ -13786,8 +10866,7 @@ msgstr "Svara"
 msgid "Write a Reply"
 msgstr "Skriv ett svar"
 
-#: src/olympia/reviews/templates/reviews/reply.html:36
-#: src/olympia/reviews/templates/reviews/report_review.html:12
+#: src/olympia/reviews/templates/reviews/reply.html:36 src/olympia/reviews/templates/reviews/report_review.html:12
 msgid "Submit"
 msgstr "Skicka in"
 
@@ -13807,34 +10886,21 @@ msgid "by %(user)s <b>(Developer)</b> on %(date)s"
 msgstr "av %(user)s <b>(Utvecklare)</b> den %(date)s"
 
 #. {0} is a version number (like 1.01)
-#: src/olympia/reviews/templates/reviews/review.html:50
-#: src/olympia/reviews/templates/reviews/mobile/review_list.html:41
+#: src/olympia/reviews/templates/reviews/review.html:50 src/olympia/reviews/templates/reviews/mobile/review_list.html:41
 msgid "This review is for a previous version of the add-on ({0})."
 msgstr "Denna recension är för en tidigare version av tillägget ({0})."
 
 #: src/olympia/reviews/templates/reviews/review.html:56
 #, python-format
-msgid ""
-"This user has a <a href=\"%(user_review_url)s\">previous review</a> of this "
-"add-on."
-msgid_plural ""
-"This user has <a href=\"%(user_review_url)s\">%(cnt)s previous reviews</a> "
-"of this add-on."
-msgstr[0] ""
-"Denna användare har en <a href=\"%(user_review_url)s\">tidigare "
-"recension</a> för detta tillägg."
-msgstr[1] ""
-"Denna användare har <a href=\"%(user_review_url)s\">%(cnt)s tidigare "
-"recensioner</a> för detta tillägg."
+msgid "This user has a <a href=\"%(user_review_url)s\">previous review</a> of this add-on."
+msgid_plural "This user has <a href=\"%(user_review_url)s\">%(cnt)s previous reviews</a> of this add-on."
+msgstr[0] "Denna användare har en <a href=\"%(user_review_url)s\">tidigare recension</a> för detta tillägg."
+msgstr[1] "Denna användare har <a href=\"%(user_review_url)s\">%(cnt)s tidigare recensioner</a> för detta tillägg."
 
 #: src/olympia/reviews/templates/reviews/review.html:62
 #, python-format
-msgid ""
-"This user has <a href=\"%(user_review_url)s\">other reviews</a> of this add-"
-"on."
-msgstr ""
-"Denna användare har <a href=\"%(user_review_url)s\">andra recensioner</a> "
-"för detta tillägg."
+msgid "This user has <a href=\"%(user_review_url)s\">other reviews</a> of this add-on."
+msgstr "Denna användare har <a href=\"%(user_review_url)s\">andra recensioner</a> för detta tillägg."
 
 #: src/olympia/reviews/templates/reviews/review.html:72
 msgid "Flagged for review"
@@ -13866,9 +10932,7 @@ msgid "{0} :: Reviews"
 msgstr "{0} :: Recensioner"
 
 #. {0} is an addon name.
-#: src/olympia/reviews/templates/reviews/review_list.html:24
-#: src/olympia/reviews/templates/reviews/mobile/add.html:4
-#: src/olympia/reviews/templates/reviews/mobile/review_list.html:4
+#: src/olympia/reviews/templates/reviews/review_list.html:24 src/olympia/reviews/templates/reviews/mobile/add.html:4 src/olympia/reviews/templates/reviews/mobile/review_list.html:4
 msgid "Reviews for {0}"
 msgstr "Recensioner av {0}"
 
@@ -13904,8 +10968,7 @@ msgstr "<strong>Genomsnitt</strong> (%(total)s)"
 msgid "Write a New Review"
 msgstr "Skriv en ny recension"
 
-#: src/olympia/reviews/templates/reviews/review_list.html:81
-#: src/olympia/reviews/templates/reviews/mobile/reviews_link.html:15
+#: src/olympia/reviews/templates/reviews/review_list.html:81 src/olympia/reviews/templates/reviews/mobile/reviews_link.html:15
 msgid "Be the first to write a review."
 msgstr "Bli först med att skriva en recension."
 
@@ -13924,8 +10987,7 @@ msgstr "Betygsatt {0} utav 5 stjärnor"
 msgid "Rated %(rating)s out of 5 stars"
 msgstr "Betygsatt %(rating)s utav 5 stjärnor"
 
-#: src/olympia/reviews/templates/reviews/mobile/add_form.html:3
-#: src/olympia/reviews/templates/reviews/mobile/add_form.html:8
+#: src/olympia/reviews/templates/reviews/mobile/add_form.html:3 src/olympia/reviews/templates/reviews/mobile/add_form.html:8
 msgid "Add a Review"
 msgstr "Lägg till en recension"
 
@@ -13996,18 +11058,12 @@ msgid "Relevance"
 msgstr "Relevans"
 
 #: src/olympia/search/helpers.py:24
-msgid ""
-"Results <strong>{0}</strong>-<strong>{1}</strong> of <strong>{2}</strong>"
-msgstr ""
-"Resultat <strong>{0}</strong>-<strong>{1}</strong> av <strong>{2}</strong>"
+msgid "Results <strong>{0}</strong>-<strong>{1}</strong> of <strong>{2}</strong>"
+msgstr "Resultat <strong>{0}</strong>-<strong>{1}</strong> av <strong>{2}</strong>"
 
 #: src/olympia/search/helpers.py:44
-msgid ""
-"Showing {0} - {1} of {2} results for <strong>{3}</strong> tagged with "
-"<strong>{4}</strong>"
-msgstr ""
-"Visar {0} - {1} av {2} resultat för <strong>{3}</strong> med etiketten "
-"<strong>{4}</strong>"
+msgid "Showing {0} - {1} of {2} results for <strong>{3}</strong> tagged with <strong>{4}</strong>"
+msgstr "Visar {0} - {1} av {2} resultat för <strong>{3}</strong> med etiketten <strong>{4}</strong>"
 
 #: src/olympia/search/helpers.py:49
 msgid "Showing {0} - {1} of {2} results for <strong>{3}</strong>"
@@ -14022,24 +11078,22 @@ msgid "Showing {0} - {1} of {2} results"
 msgstr "Visar {0} - {1} av {2} resultat"
 
 #. {0} is an application, like Firefox.
-#: src/olympia/search/views.py:264 src/olympia/templates/base.html:17
-#: src/olympia/templates/impala/base.html:17
-#: src/olympia/templates/mobile/base_addons.html:17
+#: src/olympia/search/views.py:264 src/olympia/templates/base.html:17 src/olympia/templates/impala/base.html:17 src/olympia/templates/mobile/base_addons.html:17
 msgid "{0} Add-ons"
 msgstr "{0} tillägg"
 
 #. L10n: {0} is an application, such as Firefox. This means "any version of
 #. Firefox."
-#: src/olympia/search/views.py:554
+#: src/olympia/search/views.py:547
 msgid "Any {0}"
 msgstr "Någon {0}"
 
 #. L10n: "All Systems" means show everything regardless of platform.
-#: src/olympia/search/views.py:589
+#: src/olympia/search/views.py:582
 msgid "All Systems"
 msgstr "Alla system"
 
-#: src/olympia/search/views.py:600
+#: src/olympia/search/views.py:593
 msgid "All Tags"
 msgstr "Alla taggar"
 
@@ -14058,8 +11112,7 @@ msgstr "Sökning ej tillgänglig"
 
 #: src/olympia/search/templates/search/down.html:6
 msgid "Search is temporarily unavailable. Please try again in a few minutes."
-msgstr ""
-"Sökning är ej tillgänglig för tillfället. Försök igen om några minuter."
+msgstr "Sökning är ej tillgänglig för tillfället. Försök igen om några minuter."
 
 #. {0} is the string the user was searching for
 #: src/olympia/search/templates/search/personas.html:9
@@ -14214,36 +11267,31 @@ msgstr "Dela detta tillägg"
 msgid "Share this Collection"
 msgstr "Dela denna samling"
 
-#: src/olympia/signing/views.py:30 src/olympia/templates/base.html:75
-#: src/olympia/templates/impala/base.html:115
-msgid ""
-"Some features are temporarily disabled while we perform website maintenance."
-" We'll be back to full capacity shortly."
-msgstr ""
-"Vissa funktioner inaktiveras tillfälligt medan vi utför webbplatsunderhåll. "
-"Vi ska vara tillbaka till full kapacitet inom kort."
+#: src/olympia/signing/views.py:33 src/olympia/templates/base.html:71 src/olympia/templates/impala/base.html:112
+msgid "Some features are temporarily disabled while we perform website maintenance. We'll be back to full capacity shortly."
+msgstr "Vissa funktioner inaktiveras tillfälligt medan vi utför webbplatsunderhåll. Vi ska vara tillbaka till full kapacitet inom kort."
 
-#: src/olympia/signing/views.py:53
+#: src/olympia/signing/views.py:56
 msgid "Could not find add-on with id \"{}\"."
 msgstr "Kunde inte hitta tillägg med id \"{}\"."
 
-#: src/olympia/signing/views.py:67
+#: src/olympia/signing/views.py:70
 msgid "You do not own this addon."
 msgstr "Du äger inte detta tillägg."
 
-#: src/olympia/signing/views.py:82
+#: src/olympia/signing/views.py:87
 msgid "Missing \"upload\" key in multipart file data."
 msgstr "Saknade \"upload\"-nyckel i multipart fildata."
 
-#: src/olympia/signing/views.py:96
+#: src/olympia/signing/views.py:101
 msgid "Version does not match the manifest file."
 msgstr "Version matchar inte manifest-fil."
 
-#: src/olympia/signing/views.py:100
+#: src/olympia/signing/views.py:105
 msgid "Version already exists."
 msgstr "Versionen finns redan."
 
-#: src/olympia/signing/views.py:136
+#: src/olympia/signing/views.py:141
 msgid "No uploaded file for that addon and version."
 msgstr "Ingen uppladdad fil för detta tillägg och version."
 
@@ -14335,8 +11383,7 @@ msgstr "Från"
 msgid "To"
 msgstr "Till"
 
-#: src/olympia/stats/templates/stats/popup.html:27
-#: src/olympia/users/templates/users/pwreset_confirm.html:38
+#: src/olympia/stats/templates/stats/popup.html:27 src/olympia/users/templates/users/pwreset_confirm.html:38
 msgid "Update"
 msgstr "Uppdatera"
 
@@ -14357,98 +11404,89 @@ msgstr "{0} :: Översikt statistik"
 msgid "Statistics Dashboard :: Add-ons for {0}"
 msgstr "Översikt statistik :: Tillägg för {0}"
 
-#: src/olympia/stats/templates/stats/stats.html:30
-msgid "Controls:"
-msgstr "Kontroller:"
-
-#: src/olympia/stats/templates/stats/stats.html:33
-msgid "reset zoom"
-msgstr "återställ zoom"
-
-#: src/olympia/stats/templates/stats/stats.html:40
-msgid "Group by:"
-msgstr "Gruppera efter:"
-
-#: src/olympia/stats/templates/stats/stats.html:42
-msgid "day"
-msgstr "dag"
-
-#: src/olympia/stats/templates/stats/stats.html:45
-msgid "week"
-msgstr "vecka"
-
-#: src/olympia/stats/templates/stats/stats.html:48
-msgid "month"
-msgstr "månad"
-
-#: src/olympia/stats/templates/stats/stats.html:54
-msgid "For last:"
-msgstr "För senaste:"
-
-#: src/olympia/stats/templates/stats/stats.html:57
-msgid "7 days"
-msgstr "7 dagarna"
-
-#: src/olympia/stats/templates/stats/stats.html:60
-msgid "30 days"
-msgstr "30 dagarna"
-
-#: src/olympia/stats/templates/stats/stats.html:63
-msgid "90 days"
-msgstr "90 dagarna"
-
-#: src/olympia/stats/templates/stats/stats.html:66
-msgid "365 days"
-msgstr "365 dagarna"
-
-#: src/olympia/stats/templates/stats/stats.html:69
-msgid "Custom..."
-msgstr "Anpassad..."
-
 #. {0} is an add-on name
-#: src/olympia/stats/templates/stats/stats.html:88
-#: src/olympia/stats/templates/stats/stats.html:91
+#: src/olympia/stats/templates/stats/stats.html:44 src/olympia/stats/templates/stats/stats.html:47
 msgid "Statistics for {0}"
 msgstr "Statistik för {0}"
 
-#: src/olympia/stats/templates/stats/stats.html:94
+#: src/olympia/stats/templates/stats/stats.html:50
 msgid "Statistics Dashboard"
 msgstr "Översikt statistisk"
 
-#: src/olympia/stats/templates/stats/stats.html:104
-msgid ""
-"Statistics processing is currently disabled, so recent data is unavailable. "
-"The statistics are still being collected and this page will be updated soon "
-"with the missing data."
-msgstr ""
-"Statistikbearbetning är för närvarande inaktiverad, aktuell data är inte "
-"tillgänglig. Statistik samlas fortfarande in och denna sida kommer att "
-"uppdateras snart med den data som saknas."
+#: src/olympia/stats/templates/stats/stats.html:57
+msgid "Controls:"
+msgstr "Kontroller:"
 
-#: src/olympia/stats/templates/stats/stats.html:110
+#: src/olympia/stats/templates/stats/stats.html:60
+msgid "reset zoom"
+msgstr "återställ zoom"
+
+#: src/olympia/stats/templates/stats/stats.html:67
+msgid "Group by:"
+msgstr "Gruppera efter:"
+
+#: src/olympia/stats/templates/stats/stats.html:69
+msgid "day"
+msgstr "dag"
+
+#: src/olympia/stats/templates/stats/stats.html:72
+msgid "week"
+msgstr "vecka"
+
+#: src/olympia/stats/templates/stats/stats.html:75
+msgid "month"
+msgstr "månad"
+
+#: src/olympia/stats/templates/stats/stats.html:81
+msgid "For last:"
+msgstr "För senaste:"
+
+#: src/olympia/stats/templates/stats/stats.html:84
+msgid "7 days"
+msgstr "7 dagarna"
+
+#: src/olympia/stats/templates/stats/stats.html:87
+msgid "30 days"
+msgstr "30 dagarna"
+
+#: src/olympia/stats/templates/stats/stats.html:90
+msgid "90 days"
+msgstr "90 dagarna"
+
+#: src/olympia/stats/templates/stats/stats.html:93
+msgid "365 days"
+msgstr "365 dagarna"
+
+#: src/olympia/stats/templates/stats/stats.html:96
+msgid "Custom..."
+msgstr "Anpassad..."
+
+#: src/olympia/stats/templates/stats/stats.html:106
+msgid "Statistics processing is currently disabled, so recent data is unavailable. The statistics are still being collected and this page will be updated soon with the missing data."
+msgstr "Statistikbearbetning är för närvarande inaktiverad, aktuell data är inte tillgänglig. Statistik samlas fortfarande in och denna sida kommer att uppdateras snart med den data som saknas."
+
+#: src/olympia/stats/templates/stats/stats.html:112
 msgid "Loading the latest data&hellip;"
 msgstr "Laddar in det senaste datat&hellip;"
 
-#: src/olympia/stats/templates/stats/stats.html:142
-#: src/olympia/stats/templates/stats/reports/overview.html:25
-#: src/olympia/stats/templates/stats/reports/overview.html:37
+#: src/olympia/stats/templates/stats/stats.html:144 src/olympia/stats/templates/stats/reports/overview.html:25 src/olympia/stats/templates/stats/reports/overview.html:37
 #: src/olympia/stats/templates/stats/reports/overview.html:49
 msgid "No data available."
 msgstr "Ingen data tillgänglig."
 
-#: src/olympia/stats/templates/stats/stats.html:177
+#: src/olympia/stats/templates/stats/stats.html:179
 msgid "This dashboard is currently <b>public</b>."
 msgstr "Den här översikten är för tillfället <b>publik</b>."
 
-#: src/olympia/stats/templates/stats/stats.html:179
+#: src/olympia/stats/templates/stats/stats.html:181
 msgid "Contribution stats are currently <b>private</b>."
 msgstr "Bidragsstatisk är för tillfället <b>privat</b>."
 
-#: src/olympia/stats/templates/stats/stats.html:182
+#: src/olympia/stats/templates/stats/stats.html:184
 msgid "This dashboard is currently <b>private</b>."
 msgstr "Den här översikten är för tillfället <b>privat</b>."
 
-#: src/olympia/stats/templates/stats/stats.html:185
+#: src/olympia/stats/templates/stats/stats.html:187
 msgid "Change settings."
 msgstr "Ändra inställningar."
 
@@ -14490,14 +11528,11 @@ msgstr "Hur räknas nedladdningar?"
 
 #: src/olympia/stats/templates/stats/reports/downloads.html:10
 msgid ""
-"<h2>How are downloads counted?</h2> <p> Download counts are updated every "
-"evening and only include original add-on downloads, not updates. Downloads "
-"can be broken down by the specific source referring the download. </p>"
+"<h2>How are downloads counted?</h2> <p> Download counts are updated every evening and only include original add-on downloads, not updates. Downloads can be broken down by the specific source "
+"referring the download. </p>"
 msgstr ""
-"<h2>Hur räknas nedladdningar?</h2> <p> Antal nedladdningar uppdateras varje "
-"kväll och inkluderar bara ursprungliga nedladdningar av tillägg, inte "
-"uppdateringar. Nedladdningar kan brytas ner efter specifika källor gällande "
-"nedladdningen. </p>"
+"<h2>Hur räknas nedladdningar?</h2> <p> Antal nedladdningar uppdateras varje kväll och inkluderar bara ursprungliga nedladdningar av tillägg, inte uppdateringar. Nedladdningar kan brytas ner efter "
+"specifika källor gällande nedladdningen. </p>"
 
 #: src/olympia/stats/templates/stats/reports/locales.html:3
 msgid "User languages by Date"
@@ -14511,8 +11546,7 @@ msgstr "Plattformsanvändning efter datum"
 msgid "<b>{0}</b> Downloads"
 msgstr "<b>{0}</b> Nedladdningar"
 
-#: src/olympia/stats/templates/stats/reports/overview.html:9
-#: src/olympia/stats/templates/stats/reports/overview.html:13
+#: src/olympia/stats/templates/stats/reports/overview.html:9 src/olympia/stats/templates/stats/reports/overview.html:13
 msgid "Loading..."
 msgstr "Laddar..."
 
@@ -14563,33 +11597,17 @@ msgstr "Om spåra externa källor..."
 #: src/olympia/stats/templates/stats/reports/sources.html:10
 #, python-format
 msgid ""
-"<h2>Tracking external sources</h2> <p> If you link to your add-on's details "
-"page or directly to its file from an external site, such as your blog or "
-"website, you can append a parameter to be tracked as an additional download "
-"source on this page. For example, the following links would appear as "
-"sourced by your blog: <dl> <dt>Add-on Details Page</dt> "
-"<dd>https://addons.mozilla.org/addon/%(slug)s?src=<b>external-blog</b></dd> "
-"<dt>Direct File Link</dt> "
-"<dd>https://addons.mozilla.org/downloads/latest/%(id)s/addon-%(id)s-latest.xpi?src=<b"
-">external-blog</b></dd> </dl> <p> Only src parameters that begin with "
-"\"external-\" will be tracked, up to 61 additional characters. Any text "
-"after \"external-\" can be used to describe the source, such as \"external-"
-"blog\", \"external-sidebar\", \"external-campaign225\", etc. The following "
-"URL-safe characters are allowed: <code>a-z A-Z - . _ ~ %% +</code>"
+"<h2>Tracking external sources</h2> <p> If you link to your add-on's details page or directly to its file from an external site, such as your blog or website, you can append a parameter to be "
+"tracked as an additional download source on this page. For example, the following links would appear as sourced by your blog: <dl> <dt>Add-on Details Page</dt> <dd>https://addons.mozilla.org/addon/"
+"%(slug)s?src=<b>external-blog</b></dd> <dt>Direct File Link</dt> <dd>https://addons.mozilla.org/downloads/latest/%(id)s/addon-%(id)s-latest.xpi?src=<b>external-blog</b></dd> </dl> <p> Only src "
+"parameters that begin with \"external-\" will be tracked, up to 61 additional characters. Any text after \"external-\" can be used to describe the source, such as \"external-blog\", \"external-"
+"sidebar\", \"external-campaign225\", etc. The following URL-safe characters are allowed: <code>a-z A-Z - . _ ~ %% +</code>"
 msgstr ""
-"<h2>Spåra externa källor</h2> <p> Om du länkar till ditt tilläggs detaljsida"
-" eller direkt till en fil från en extern plats, till exempel din blogg eller"
-" hemsida, kan du lägga till en parameter så att du kan spåras som en "
-"ytterligare nedladdningskälla på den här sidan. Exempelvis följande länkar "
-"skulle visas som källa för din blogg: <dl> <dt>Tilläggets detaljsida</dt> "
-"<dd>https://addons.mozilla.org/addon/%(slug)s?src=<b>external-blogg</b></dd>"
-" <dt>Direkt fillänk</dt> "
-"<dd>https://addons.mozilla.org/downloads/latest/%(id)s/addon-%(id)s-latest.xpi?src=<b"
-">external-blogg</b></dd> </dl> <p> Endast src-parametrar som börjar med "
-"\"external-\" kommer att spåras, upp till 61 ytterligare tecken. All text "
-"efter \"external-\" kan användas att beskriva källan, till exempel "
-"\"external-blogg\", \"external-sidebar\", \"external-campaign225\", etc. "
-"Följande URL-säkra tecken är tillåtna: <code>a-z A-Z - . _ ~ %% +</code>"
+"<h2>Spåra externa källor</h2> <p> Om du länkar till ditt tilläggs detaljsida eller direkt till en fil från en extern plats, till exempel din blogg eller hemsida, kan du lägga till en parameter så "
+"att du kan spåras som en ytterligare nedladdningskälla på den här sidan. Exempelvis följande länkar skulle visas som källa för din blogg: <dl> <dt>Tilläggets detaljsida</dt> <dd>https://addons."
+"mozilla.org/addon/%(slug)s?src=<b>external-blogg</b></dd> <dt>Direkt fillänk</dt> <dd>https://addons.mozilla.org/downloads/latest/%(id)s/addon-%(id)s-latest.xpi?src=<b>external-blogg</b></dd> </dl> "
+"<p> Endast src-parametrar som börjar med \"external-\" kommer att spåras, upp till 61 ytterligare tecken. All text efter \"external-\" kan användas att beskriva källan, till exempel \"external-blogg"
+"\", \"external-sidebar\", \"external-campaign225\", etc. Följande URL-säkra tecken är tillåtna: <code>a-z A-Z - . _ ~ %% +</code>"
 
 #: src/olympia/stats/templates/stats/reports/statuses.html:3
 msgid "Add-on Status by Date"
@@ -14609,28 +11627,19 @@ msgstr "Vad är dagliga användare?"
 
 #: src/olympia/stats/templates/stats/reports/usage.html:11
 msgid ""
-"<h2>What are daily users?</h2> <p> Themes installed from this site check for"
-" updates once per day. The total number of these update pings is known as "
-"Active Daily Users, or the total number of people using your theme by day. "
-"</p>"
+"<h2>What are daily users?</h2> <p> Themes installed from this site check for updates once per day. The total number of these update pings is known as Active Daily Users, or the total number of "
+"people using your theme by day. </p>"
 msgstr ""
-"<h2>Vad är dagliga användare?</h2> <p> Teman installerade från denna "
-"webbplats kontrollerar efter uppdaterar en gång per dag. Det totala antalet "
-"uppdateringar kallas aktiva dagliga användare eller det totala antalet "
-"personer som använder ditt tema per dag. </p>"
+"<h2>Vad är dagliga användare?</h2> <p> Teman installerade från denna webbplats kontrollerar efter uppdaterar en gång per dag. Det totala antalet uppdateringar kallas aktiva dagliga användare eller "
+"det totala antalet personer som använder ditt tema per dag. </p>"
 
 #: src/olympia/stats/templates/stats/reports/usage.html:20
 msgid ""
-"<h2>What are daily users?</h2> <p> Add-ons downloaded from this site check "
-"for updates once per day. The total number of these update pings is known as"
-" Active Daily Users. Daily users can be broken down by add-on version, "
-"operating system, add-on status, application, and locale. </p>"
+"<h2>What are daily users?</h2> <p> Add-ons downloaded from this site check for updates once per day. The total number of these update pings is known as Active Daily Users. Daily users can be broken "
+"down by add-on version, operating system, add-on status, application, and locale. </p>"
 msgstr ""
-"<h2>Vad är dagliga användare?</h2> <p> Tillägg nedladdade från denna "
-"webbplats kontrollerar efter uppdateringar en gång per dag. Det totala "
-"antalet uppdateringar kallas aktiva dagliga användare. Dagliga användare kan"
-" brytas ner efter tilläggsversion, operativsystem, tilläggsstatus, "
-"applikation och språk. </p>"
+"<h2>Vad är dagliga användare?</h2> <p> Tillägg nedladdade från denna webbplats kontrollerar efter uppdateringar en gång per dag. Det totala antalet uppdateringar kallas aktiva dagliga användare. "
+"Dagliga användare kan brytas ner efter tilläggsversion, operativsystem, tilläggsstatus, applikation och språk. </p>"
 
 #: src/olympia/stats/templates/stats/reports/users_created.html:3
 msgid "User Signups by Date"
@@ -14640,44 +11649,27 @@ msgstr "Registrerade användare efter datum"
 msgid "Application versions by Date"
 msgstr "Applikationsversioner efter datum"
 
-#: src/olympia/tags/templates/tags/top_cloud.html:4
-msgid "Top {0} Tags"
-msgstr "Topp {0} taggar"
-
-#. {0} is the current application name
-#: src/olympia/tags/templates/tags/top_cloud.html:14
-msgid "{0} Top Tags"
-msgstr "{0} topptaggar"
-
-#: src/olympia/templates/amo_footer.html:6
-#: src/olympia/templates/includes/lang_switcher.html:2
+#: src/olympia/templates/amo_footer.html:6 src/olympia/templates/includes/lang_switcher.html:2
 msgid "Other languages"
 msgstr "Andra språk"
 
-#: src/olympia/templates/base.html:9 src/olympia/templates/impala/base.html:9
-#: src/olympia/templates/mobile/base_addons.html:9
+#: src/olympia/templates/base.html:9 src/olympia/templates/impala/base.html:9 src/olympia/templates/mobile/base_addons.html:9
 msgid "Mozilla Add-ons"
 msgstr "Mozilla tillägg"
 
-#: src/olympia/templates/base.html:91
-#: src/olympia/templates/impala/base.html:81
+#: src/olympia/templates/base.html:89 src/olympia/templates/impala/base.html:78
 msgid "Find add-ons for other applications"
 msgstr "Hitta tillägg för andra applikationer"
 
-#: src/olympia/templates/base.html:92
-#: src/olympia/templates/impala/base.html:81
+#: src/olympia/templates/base.html:90 src/olympia/templates/impala/base.html:78
 msgid "Other Applications"
 msgstr "Andra applikationer"
 
-#: src/olympia/templates/base.html:141
-#: src/olympia/templates/impala/base.html:194
-msgid ""
-"To create your own collections, you must have a Mozilla Add-ons account."
-msgstr ""
-"För att skapa egna samlingar, måste du ha ett konto för Mozilla tillägg."
+#: src/olympia/templates/base.html:141 src/olympia/templates/impala/base.html:194
+msgid "To create your own collections, you must have a Mozilla Add-ons account."
+msgstr "För att skapa egna samlingar, måste du ha ett konto för Mozilla tillägg."
 
-#: src/olympia/templates/base.html:168
-#: src/olympia/templates/impala/base.html:215
+#: src/olympia/templates/base.html:168 src/olympia/templates/impala/base.html:215
 msgid "Footer logo"
 msgstr "Logotyp sidfot"
 
@@ -14694,20 +11686,18 @@ msgid "View Mobile Site"
 msgstr "Visa mobil webbplats"
 
 #: src/olympia/templates/copyright.html:7
-msgid "Site Status "
+msgid "Site Status"
 msgstr "Webbplatsstatus "
 
 #: src/olympia/templates/footer.html:3
 msgid "get to know <b>add-ons</b>"
 msgstr "lär känna <b>tillägg</b>"
 
-#: src/olympia/templates/footer.html:4
-#: src/olympia/templates/menu_links.html:20
+#: src/olympia/templates/footer.html:4 src/olympia/templates/menu_links.html:20
 msgid "About"
 msgstr "Om"
 
-#: src/olympia/templates/footer.html:5
-#: src/olympia/templates/menu_links.html:32
+#: src/olympia/templates/footer.html:5 src/olympia/templates/menu_links.html:32
 msgid "Blog"
 msgstr "Blogg"
 
@@ -14783,9 +11773,7 @@ msgstr "Juridisk"
 msgid "Contact Us"
 msgstr "Kontakta oss"
 
-#: src/olympia/templates/user_login.html:22
-#: src/olympia/users/templates/users/edit.html:31
-#: src/olympia/users/templates/users/includes/navigation.html:12
+#: src/olympia/templates/user_login.html:22 src/olympia/users/templates/users/edit.html:31 src/olympia/users/templates/users/includes/navigation.html:12
 msgid "My Account"
 msgstr "Mitt konto"
 
@@ -14793,53 +11781,40 @@ msgstr "Mitt konto"
 msgid "Welcome, {0}"
 msgstr "Välkommen, {0}"
 
-#: src/olympia/templates/user_login.html:41
-#: src/olympia/templates/impala/user_login.html:20
+#: src/olympia/templates/user_login.html:41 src/olympia/templates/impala/user_login.html:20
 #, python-format
 msgid "<a href=\"%(reg)s\">Register</a> or <a href=\"%(login)s\">Log in</a>"
 msgstr "<a href=\"%(reg)s\">Registrera</a> eller <a href=\"%(login)s\">Logga in</a>"
 
-#: src/olympia/templates/impala/base.html:126
+#: src/olympia/templates/impala/base.html:123
 #, python-format
-msgid ""
-"To try the thousands of add-ons available here, download <a "
-"href=\"%(url)s\">Mozilla Firefox</a>, a fast, free way to surf the Web!"
-msgstr ""
-"För att prova de tusentals tillägg tillgängliga här, ladda ner <a "
-"href=\"%(url)s\">Mozilla Firefox</a>, ett snabbt och gratis sätt att surfa "
-"på webben!"
+msgid "To try the thousands of add-ons available here, download <a href=\"%(url)s\">Mozilla Firefox</a>, a fast, free way to surf the Web!"
+msgstr "För att prova de tusentals tillägg tillgängliga här, ladda ner <a href=\"%(url)s\">Mozilla Firefox</a>, ett snabbt och gratis sätt att surfa på webben!"
 
-#: src/olympia/templates/impala/base.html:138
+#: src/olympia/templates/impala/base.html:135
 #, python-format
-msgid ""
-"Add-ons is switching to Firefox Accounts for login. <a href=\"%(url)s\" "
-"class=\"fxa-login\">Sign in now to transfer your account.</a>"
-msgstr ""
-"Tillägg byter till Firefox konton för att logga in. <a href=\"%(url)s\" "
-"class=\"fxa-login\">Logga in nu för att överföra ditt konto.</a>"
+msgid "Add-ons is switching to Firefox Accounts for login. <a href=\"%(url)s\" class=\"fxa-login\">Sign in now to transfer your account.</a>"
+msgstr "Tillägg byter till Firefox konton för att logga in. <a href=\"%(url)s\" class=\"fxa-login\">Logga in nu för att överföra ditt konto.</a>"
 
 #. {0} is an application, such as Firefox.
-#: src/olympia/templates/impala/base.html:148
+#: src/olympia/templates/impala/base.html:145
 msgid "Welcome to {0} Add-ons."
 msgstr "Välkommen till {0} tillägg."
 
-#: src/olympia/templates/impala/base.html:151
-msgid ""
-"Choose from thousands of extra features and styles to make Firefox your own."
-msgstr ""
-"Välj bland tusentals extrafunktioner och stilar för att göra Firefox till "
-"ditt."
+#: src/olympia/templates/impala/base.html:148
+msgid "Choose from thousands of extra features and styles to make Firefox your own."
+msgstr "Välj bland tusentals extrafunktioner och stilar för att göra Firefox till ditt."
 
-#: src/olympia/templates/impala/base.html:156
+#: src/olympia/templates/impala/base.html:153
 #, python-format
 msgid "Add extra features and styles to make %(app)s your own."
 msgstr "Lägg till extra funktioner och stilar för att göra %(app)s till ditt."
 
-#: src/olympia/templates/impala/base.html:164
+#: src/olympia/templates/impala/base.html:161
 msgid "On the go?"
 msgstr "På språng?"
 
-#: src/olympia/templates/impala/base.html:166
+#: src/olympia/templates/impala/base.html:163
 msgid "Check out our <a class=\"mobile-link\" href=\"#\">Mobile Add-ons site</a>."
 msgstr "Kolla in vår <a class=\"mobile-link\" href=\"#\">mobila tilläggssida</a>."
 
@@ -14847,8 +11822,7 @@ msgstr "Kolla in vår <a class=\"mobile-link\" href=\"#\">mobila tilläggssida</
 msgid "Android Add-ons"
 msgstr "Android tillägg"
 
-#: src/olympia/templates/includes/forms.html:2
-#: src/olympia/templates/includes/forms.html:6
+#: src/olympia/templates/includes/forms.html:2 src/olympia/templates/includes/forms.html:6
 msgid "required"
 msgstr "obligatorisk"
 
@@ -14893,15 +11867,11 @@ msgstr "Besök Mozilla"
 msgid "menu"
 msgstr "meny"
 
-#: src/olympia/templates/mobile/header_auth.html:7
-#: src/olympia/users/templates/users/register.html:41
-#: src/olympia/users/templates/users/register.html:89
+#: src/olympia/templates/mobile/header_auth.html:7 src/olympia/users/templates/users/register.html:41 src/olympia/users/templates/users/register.html:89
 msgid "Register"
 msgstr "Registrera"
 
-#: src/olympia/templates/mobile/header_auth.html:8
-#: src/olympia/users/templates/users/login_form.html:41
-#: src/olympia/users/templates/users/pwreset_complete.html:15
+#: src/olympia/templates/mobile/header_auth.html:8 src/olympia/users/templates/users/login_form.html:41 src/olympia/users/templates/users/pwreset_complete.html:15
 #: src/olympia/users/templates/users/mobile/login.html:56
 msgid "Log in"
 msgstr "Logga in"
@@ -14912,8 +11882,7 @@ msgstr "Logga in"
 msgid "Localize for: <a id=\"change-locale\" href=\"#\">%(dl)s</a>"
 msgstr "Översätt för: <a id=\"change-locale\" href=\"#\">%(dl)s</a>"
 
-#: src/olympia/translations/templates/translations/trans-menu.html:16
-#: src/olympia/translations/templates/translations/trans-menu.html:29
+#: src/olympia/translations/templates/translations/trans-menu.html:16 src/olympia/translations/templates/translations/trans-menu.html:29
 #, python-format
 msgid "%(title)s <em>&middot; %(lang)s</em>"
 msgstr "%(title)s <em>&middot; %(lang)s</em>"
@@ -14928,12 +11897,8 @@ msgstr "Nya språk"
 
 #. {0} is a language name, like 'French'
 #: src/olympia/translations/templates/translations/trans-menu.html:42
-msgid ""
-"You have unsaved changes in the <b>{0}</b> locale. Would you like to save "
-"your changes before switching locales?"
-msgstr ""
-"Du har ändringar som inte sparats i språket <b>{0}</b>. Vill du spara "
-"ändringarna innan du byter språk?"
+msgid "You have unsaved changes in the <b>{0}</b> locale. Would you like to save your changes before switching locales?"
+msgstr "Du har ändringar som inte sparats i språket <b>{0}</b>. Vill du spara ändringarna innan du byter språk?"
 
 #: src/olympia/translations/templates/translations/trans-menu.html:49
 msgid "Discard Changes"
@@ -14941,12 +11906,8 @@ msgstr "Ignorera ändringar"
 
 #. {0} is a language name, like 'French'
 #: src/olympia/translations/templates/translations/trans-menu.html:56
-msgid ""
-"Are you sure you want to remove all <b>{0}</b> translations? This cannot be "
-"undone."
-msgstr ""
-"Är du säker på att du vill ta bort alla <b>{0}</b> översättningar? Detta kan"
-" inte ångras."
+msgid "Are you sure you want to remove all <b>{0}</b> translations? This cannot be undone."
+msgstr "Är du säker på att du vill ta bort alla <b>{0}</b> översättningar? Detta kan inte ångras."
 
 #: src/olympia/translations/templates/translations/trans-menu.html:61
 msgid "Delete Locale"
@@ -14967,25 +11928,14 @@ msgstr "Detta lösenord är inte tillåtet."
 
 #: src/olympia/users/forms.py:90
 #, python-format
-msgid ""
-"As part of our new password policy, your password must be %s characters or "
-"more. Please update your password by <a href=\"%s\">issuing a password "
-"reset</a>."
-msgstr ""
-"Som en del av vår nya lösenordspolicy, måste ditt lösenord vara %s tecken "
-"eller mer. Vänligen uppdatera ditt lösenord genom att <a href=\"%s\">utfärda"
-" en lösenordsåterställning</a>."
+msgid "As part of our new password policy, your password must be %s characters or more. Please update your password by <a href=\"%s\">issuing a password reset</a>."
+msgstr "Som en del av vår nya lösenordspolicy, måste ditt lösenord vara %s tecken eller mer. Vänligen uppdatera ditt lösenord genom att <a href=\"%s\">utfärda en lösenordsåterställning</a>."
 
 #: src/olympia/users/forms.py:115
-msgid ""
-"You must recover your password through Firefox Accounts. Try logging in "
-"instead."
-msgstr ""
-"Du måste återställa ditt lösenord via Firefox-konton. Försök logga in "
-"istället."
+msgid "You must recover your password through Firefox Accounts. Try logging in instead."
+msgstr "Du måste återställa ditt lösenord via Firefox-konton. Försök logga in istället."
 
-#: src/olympia/users/forms.py:206
-#: src/olympia/users/templates/users/pwreset_confirm.html:24
+#: src/olympia/users/forms.py:206 src/olympia/users/templates/users/pwreset_confirm.html:24
 msgid "New password"
 msgstr "Nytt lösenord"
 
@@ -14998,12 +11948,8 @@ msgid "Usernames cannot contain only digits."
 msgstr "Användarnamn kan inte endast innehålla siffror."
 
 #: src/olympia/users/forms.py:274
-msgid ""
-"Enter a valid username consisting of letters, numbers, underscores or "
-"hyphens."
-msgstr ""
-"Ange ett giltigt användarnamn som består av bokstäver, siffror, understreck "
-"eller bindestreck."
+msgid "Enter a valid username consisting of letters, numbers, underscores or hyphens."
+msgstr "Ange ett giltigt användarnamn som består av bokstäver, siffror, understreck eller bindestreck."
 
 #: src/olympia/users/forms.py:277
 msgid "This username cannot be used."
@@ -15013,38 +11959,25 @@ msgstr "Det här användarnamnet kan inte användas."
 msgid "This username is already in use."
 msgstr "Användarnamnet används redan"
 
-#: src/olympia/users/forms.py:296
-#: src/olympia/users/templates/users/edit.html:107
+#: src/olympia/users/forms.py:296 src/olympia/users/templates/users/edit.html:107
 msgid "Display Name"
 msgstr "Visningsnamn"
 
-#: src/olympia/users/forms.py:298
-#: src/olympia/users/templates/users/edit.html:112
-#: src/olympia/users/templates/users/vcard.html:10
+#: src/olympia/users/forms.py:298 src/olympia/users/templates/users/edit.html:112 src/olympia/users/templates/users/vcard.html:10
 msgid "Location"
 msgstr "Plats"
 
-#: src/olympia/users/forms.py:300
-#: src/olympia/users/templates/users/edit.html:117
-#: src/olympia/users/templates/users/vcard.html:16
+#: src/olympia/users/forms.py:300 src/olympia/users/templates/users/edit.html:117 src/olympia/users/templates/users/vcard.html:16
 msgid "Occupation"
 msgstr "Yrke"
 
 #: src/olympia/users/forms.py:329
-msgid ""
-"This URL has an invalid format. Valid URLs look like "
-"http://example.com/my_page."
-msgstr ""
-"URLen har ett ogiltigt format. Giltiga URLer ser ut som "
-"http://example.com/my_page."
+msgid "This URL has an invalid format. Valid URLs look like http://example.com/my_page."
+msgstr "URLen har ett ogiltigt format. Giltiga URLer ser ut som http://example.com/my_page."
 
 #: src/olympia/users/forms.py:337
-msgid ""
-"Please use an email address from a different provider to complete your "
-"registration."
-msgstr ""
-"Använd en e-postadress från en annan leverantör för att slutföra din "
-"registrering."
+msgid "Please use an email address from a different provider to complete your registration."
+msgstr "Använd en e-postadress från en annan leverantör för att slutföra din registrering."
 
 #: src/olympia/users/forms.py:345
 msgid "This display name cannot be used."
@@ -15054,20 +11987,17 @@ msgstr "Detta visningsnamn kan inte användas."
 msgid "The passwords did not match."
 msgstr "Lösenorden stämmer inte överens."
 
-#: src/olympia/users/forms.py:377
-#: src/olympia/users/templates/users/edit.html:128
+#: src/olympia/users/forms.py:377 src/olympia/users/templates/users/edit.html:128
 msgid "Profile Photo"
 msgstr "Profilfoto"
 
-#: src/olympia/users/forms.py:385
-#: src/olympia/users/templates/users/edit.html:142
+#: src/olympia/users/forms.py:385 src/olympia/users/templates/users/edit.html:142
 msgid "Default locale"
 msgstr "Standardspråk"
 
 #: src/olympia/users/forms.py:412
 msgid "Firefox Accounts users cannot currently change their email address."
-msgstr ""
-"Användare med Firefox-konto kan för närvarande inte ändra sin e-postadress."
+msgstr "Användare med Firefox-konto kan för närvarande inte ändra sin e-postadress."
 
 #: src/olympia/users/forms.py:446
 msgid "Wrong password entered!"
@@ -15078,12 +12008,8 @@ msgid "Email cannot be changed."
 msgstr "E-postadress kan inte ändras."
 
 #: src/olympia/users/forms.py:541
-msgid ""
-"To anonymize, enter a reason for the change but do not change any other "
-"field."
-msgstr ""
-"För att anonymisera, ange en orsak till förändringen men ändra inte något "
-"annat textfält."
+msgid "To anonymize, enter a reason for the change but do not change any other field."
+msgstr "För att anonymisera, ange en orsak till förändringen men ändra inte något annat textfält."
 
 #: src/olympia/users/forms.py:587
 msgid "Please enter at least one name to blacklist."
@@ -15112,19 +12038,19 @@ msgstr "Ingen användare med den e-postadressen."
 
 #. L10n: {id} will be something like "13ad6a", just a random number
 #. to differentiate this user from other anonymous users.
-#: src/olympia/users/models.py:353
+#: src/olympia/users/models.py:362
 msgid "Anonymous user {id}"
 msgstr "Anonym användare {id}"
 
-#: src/olympia/users/models.py:410
+#: src/olympia/users/models.py:419
 msgid "Your account has been restricted"
 msgstr "Ditt konto har begränsats"
 
-#: src/olympia/users/models.py:480
+#: src/olympia/users/models.py:489
 msgid "Please confirm your email address"
 msgstr "Bekräfta din e-postadress"
 
-#: src/olympia/users/models.py:506
+#: src/olympia/users/models.py:515
 msgid "My Mobile Add-ons"
 msgstr "Mina Mobile-tillägg"
 
@@ -15189,16 +12115,12 @@ msgid "Mozilla needs to contact me about my individual app"
 msgstr "Mozilla behöver kontakta mig om min individuella app"
 
 #: src/olympia/users/notifications.py:139
-msgid ""
-"Mozilla wants to contact me about relevant App Developer news and surveys"
-msgstr ""
-"Mozilla vill kontakta mig om relevanta utvecklarnyheter och undersökningar "
-"för app"
+msgid "Mozilla wants to contact me about relevant App Developer news and surveys"
+msgstr "Mozilla vill kontakta mig om relevanta utvecklarnyheter och undersökningar för app"
 
 #: src/olympia/users/notifications.py:150
 msgid "Mozilla wants to contact me about new regions added to the Marketplace"
-msgstr ""
-"Mozilla vill kontakta mig om nya regioner som har lagts till i Marketplace"
+msgstr "Mozilla vill kontakta mig om nya regioner som har lagts till i Marketplace"
 
 #: src/olympia/users/notifications.py:158
 msgid "User Notifications"
@@ -15221,14 +12143,8 @@ msgid "Successfully verified!"
 msgstr "Verifierad!"
 
 #: src/olympia/users/views.py:132
-msgid ""
-"An email has been sent to your address to confirm your account. Before you "
-"can log in, you have to activate your account by clicking on the link "
-"provided in this email."
-msgstr ""
-"Ett e-postmeddelande har skickats till din adress för att bekräfta ditt "
-"konto. Innan du kan logga in, måste du aktivera ditt konto genom att klicka "
-"på länken i detta mail."
+msgid "An email has been sent to your address to confirm your account. Before you can log in, you have to activate your account by clicking on the link provided in this email."
+msgstr "Ett e-postmeddelande har skickats till din adress för att bekräfta ditt konto. Innan du kan logga in, måste du aktivera ditt konto genom att klicka på länken i detta mail."
 
 #: src/olympia/users/views.py:136 src/olympia/users/views.py:619
 msgid "Confirmation Email Sent"
@@ -15252,13 +12168,11 @@ msgstr "E-postbekräftelse har skickats"
 
 #: src/olympia/users/views.py:197
 msgid ""
-"An email has been sent to {0} to confirm your new email address. For the "
-"change to take effect, you need to click on the link provided in this email."
-" Until then, you can keep logging in with your current email address."
+"An email has been sent to {0} to confirm your new email address. For the change to take effect, you need to click on the link provided in this email. Until then, you can keep logging in with your "
+"current email address."
 msgstr ""
-"Ett mejl har skickats till {0} för att bekräfta din nya e-postadress. För "
-"att ändringen ska träda i kraft, måste du klicka på länken i detta mejl. "
-"Tills dess kan du logga in med din nuvarande e-postadress."
+"Ett mejl har skickats till {0} för att bekräfta din nya e-postadress. För att ändringen ska träda i kraft, måste du klicka på länken i detta mejl. Tills dess kan du logga in med din nuvarande e-"
+"postadress."
 
 #: src/olympia/users/views.py:210
 #, python-format
@@ -15270,16 +12184,12 @@ msgid "Errors Found"
 msgstr "Fel hittades"
 
 #: src/olympia/users/views.py:225
-msgid ""
-"There were errors in the changes you made. Please correct them and resubmit."
-msgstr ""
-"Det fanns fel i dina ändringar. Vänligen korrigera och skicka in igen."
+msgid "There were errors in the changes you made. Please correct them and resubmit."
+msgstr "Det fanns fel i dina ändringar. Vänligen korrigera och skicka in igen."
 
 #: src/olympia/users/views.py:273
-msgid ""
-"We're sorry, but you are not eligible to request a t-shirt at this time."
-msgstr ""
-"Vi beklagar, men du har inte rätt att begära en t-shirt för tillfället."
+msgid "We're sorry, but you are not eligible to request a t-shirt at this time."
+msgstr "Vi beklagar, men du har inte rätt att begära en t-shirt för tillfället."
 
 #: src/olympia/users/views.py:329
 msgid "Your email address was changed successfully"
@@ -15294,25 +12204,17 @@ msgid "Wrong email address or password!"
 msgstr "Felaktig e-postadress eller lösenord!"
 
 #: src/olympia/users/views.py:434
-msgid ""
-"A link to activate your user account was sent by email to your address {0}. "
-"You have to click it before you can log in."
-msgstr ""
-"En länk för att aktivera ditt användarkonto skickades via e-post till din "
-"adress {0}. Du måste klicka på den innan du kan logga in."
+msgid "A link to activate your user account was sent by email to your address {0}. You have to click it before you can log in."
+msgstr "En länk för att aktivera ditt användarkonto skickades via e-post till din adress {0}. Du måste klicka på den innan du kan logga in."
 
 #: src/olympia/users/views.py:439
 #, python-format
 msgid ""
-"If you did not receive the confirmation email, make sure your email service "
-"did not mark it as \"junk mail\" or \"spam\". If you need to, you can have "
-"us <a href=\"%s\">resend the confirmation message</a> to your email address "
-"mentioned above."
+"If you did not receive the confirmation email, make sure your email service did not mark it as \"junk mail\" or \"spam\". If you need to, you can have us <a href=\"%s\">resend the confirmation "
+"message</a> to your email address mentioned above."
 msgstr ""
-"Om du inte har fått en e-postbekräftelse, se till att din e-posttjänst inte "
-"markerat den som \"skräppost\" eller \"spam\". Om du behöver, kan vi <a "
-"href=\"%s\">skicka bekräftelsemeddelandet igen</a> till din e-postadress som"
-" nämns ovan."
+"Om du inte har fått en e-postbekräftelse, se till att din e-posttjänst inte markerat den som \"skräppost\" eller \"spam\". Om du behöver, kan vi <a href=\"%s\">skicka bekräftelsemeddelandet igen</"
+"a> till din e-postadress som nämns ovan."
 
 #: src/olympia/users/views.py:444
 msgid "Activation Email Sent"
@@ -15331,14 +12233,8 @@ msgid "Congratulations! Your user account was successfully created."
 msgstr "Grattis! Ditt konto skapades."
 
 #: src/olympia/users/views.py:615
-msgid ""
-"An email has been sent to your address {0} to confirm your account. Before "
-"you can log in, you have to activate your account by clicking on the link "
-"provided in this email."
-msgstr ""
-"E-post har skickats till din adress {0} för att bekräfta ditt konto. Innan "
-"du kan logga in måste du aktivera ditt konto genom att klicka på länken i "
-"detta brev."
+msgid "An email has been sent to your address {0} to confirm your account. Before you can log in, you have to activate your account by clicking on the link provided in this email."
+msgstr "E-post har skickats till din adress {0} för att bekräfta ditt konto. Innan du kan logga in måste du aktivera ditt konto genom att klicka på länken i detta brev."
 
 #: src/olympia/users/views.py:639
 msgid "There are errors in this form"
@@ -15356,32 +12252,22 @@ msgstr "Användare rapporterad."
 msgid "new"
 msgstr "ny"
 
-#: src/olympia/users/templates/users/delete.html:4
-#: src/olympia/users/templates/users/delete.html:10
+#: src/olympia/users/templates/users/delete.html:4 src/olympia/users/templates/users/delete.html:10
 msgid "Delete User Account"
 msgstr "Ta bort användarkonto"
 
 #: src/olympia/users/templates/users/delete.html:14
 #, python-format
 msgid ""
-"You cannot delete your account if you are listed as an <a href=\"%(link)s\">"
-" author of any add-ons</a>. To delete your account, please have another "
-"person in your development group delete you from the list of authors for "
-"your add-ons. Afterwards you will be able to delete your account here."
+"You cannot delete your account if you are listed as an <a href=\"%(link)s\"> author of any add-ons</a>. To delete your account, please have another person in your development group delete you from "
+"the list of authors for your add-ons. Afterwards you will be able to delete your account here."
 msgstr ""
-"Du kan inte ta bort ditt konto om du är listad som <a "
-"href=\"%(link)s\">författare till något tillägg</a>. För att ta bort ditt "
-"konto, se till att någon annan i din utvecklingsgrupp tar bort dig från "
-"listan av författare till era tillägg. Efter detta kommer du att kunna ta "
-"bort ditt konto här."
+"Du kan inte ta bort ditt konto om du är listad som <a href=\"%(link)s\">författare till något tillägg</a>. För att ta bort ditt konto, se till att någon annan i din utvecklingsgrupp tar bort dig "
+"från listan av författare till era tillägg. Efter detta kommer du att kunna ta bort ditt konto här."
 
 #: src/olympia/users/templates/users/delete.html:29
-msgid ""
-"By clicking \"delete\" your account is going to be <strong>permanently "
-"removed</strong>. That means:"
-msgstr ""
-"Genom att klicka på \"ta bort\" kommer ditt konto att <strong>tas bort "
-"permanent</strong>. Det innebär:"
+msgid "By clicking \"delete\" your account is going to be <strong>permanently removed</strong>. That means:"
+msgstr "Genom att klicka på \"ta bort\" kommer ditt konto att <strong>tas bort permanent</strong>. Det innebär:"
 
 #: src/olympia/users/templates/users/delete.html:35
 #, python-format
@@ -15389,12 +12275,8 @@ msgid "You will not be able to log into %(site)s anymore."
 msgstr "Du kommer inte att kunna logga in på %(site)s längre."
 
 #: src/olympia/users/templates/users/delete.html:40
-msgid ""
-"Your reviews and ratings will not be deleted, but they will no longer be "
-"associated with you."
-msgstr ""
-"Dina recensioner och betyg tas inte bort, men de kommer inte längre att vara"
-" associerade med dig."
+msgid "Your reviews and ratings will not be deleted, but they will no longer be associated with you."
+msgstr "Dina recensioner och betyg tas inte bort, men de kommer inte längre att vara associerade med dig."
 
 #: src/olympia/users/templates/users/delete.html:46
 msgid "Confirm account deletion"
@@ -15408,8 +12290,7 @@ msgstr "Jag förstår att detta steg inte kan göras ogjort."
 msgid "Delete my user account now"
 msgstr "Ta bort mitt användarkonto nu"
 
-#: src/olympia/users/templates/users/delete_photo.html:3
-#: src/olympia/users/templates/users/delete_photo.html:9
+#: src/olympia/users/templates/users/delete_photo.html:3 src/olympia/users/templates/users/delete_photo.html:9
 msgid "Delete User Photo"
 msgstr "Ta bort användarfoto"
 
@@ -15422,26 +12303,18 @@ msgid "Please set your display name"
 msgstr "Vänligen ange ditt visningsnamn"
 
 #: src/olympia/users/templates/users/edit.html:21
-msgid ""
-"Please set your display name or username to complete the registration "
-"process."
-msgstr ""
-"Vänligen ange ditt visningsnamn eller användarnamn för att slutföra "
-"registreringen."
+msgid "Please set your display name or username to complete the registration process."
+msgstr "Vänligen ange ditt visningsnamn eller användarnamn för att slutföra registreringen."
 
 #: src/olympia/users/templates/users/edit.html:33
 msgid "Manage basic account information, such as username and email address."
-msgstr ""
-"Hantera grundläggande kontoinformation, såsom användarnamn och e-postadress."
+msgstr "Hantera grundläggande kontoinformation, såsom användarnamn och e-postadress."
 
-#: src/olympia/users/templates/users/edit.html:39
-#: src/olympia/users/templates/users/register.html:47
+#: src/olympia/users/templates/users/edit.html:39 src/olympia/users/templates/users/register.html:47
 msgid "Username"
 msgstr "Användarnamn"
 
-#: src/olympia/users/templates/users/edit.html:45
-#: src/olympia/users/templates/users/pwreset_request.html:21
-#: src/olympia/users/templates/users/register.html:62
+#: src/olympia/users/templates/users/edit.html:45 src/olympia/users/templates/users/pwreset_request.html:21 src/olympia/users/templates/users/register.html:62
 msgid "Email Address"
 msgstr "E-postadress"
 
@@ -15453,21 +12326,15 @@ msgstr "Hantera Firefox konto..."
 msgid "Change Password"
 msgstr "Ändra lösenord"
 
-#: src/olympia/users/templates/users/edit.html:68
-#: src/olympia/users/templates/users/login_form.html:22
-#: src/olympia/users/templates/users/register.html:67
+#: src/olympia/users/templates/users/edit.html:68 src/olympia/users/templates/users/login_form.html:22 src/olympia/users/templates/users/register.html:67
 #: src/olympia/users/templates/users/mobile/login.html:37
 msgid "Password"
 msgstr "Lösenord"
 
 #: src/olympia/users/templates/users/edit.html:70
 #, python-format
-msgid ""
-"Change your password.  If you forgot your password, you can <a "
-"href=\"%(reset_url)s\">use the reset form</a>."
-msgstr ""
-"Ändra ditt lösenord.  Om du har glömt ditt lösenord kan du <a "
-"href=\"%(reset_url)s\">använda återställningsformuläret</a>."
+msgid "Change your password. If you forgot your password, you can <a href=\"%(reset_url)s\">use the reset form</a>."
+msgstr "Ändra ditt lösenord.  Om du har glömt ditt lösenord kan du <a href=\"%(reset_url)s\">använda återställningsformuläret</a>."
 
 #: src/olympia/users/templates/users/edit.html:76
 msgid "Old Password"
@@ -15486,12 +12353,8 @@ msgid "Profile"
 msgstr "Profil"
 
 #: src/olympia/users/templates/users/edit.html:100
-msgid ""
-"Give us a bit more information about yourself.  All these fields are "
-"optional, but they'll help other users get to know you better."
-msgstr ""
-"Ge oss lite mer information om dig själv.  Alla dessa fält är valfria, men "
-"de hjälper andra användare att lära känna dig bättre."
+msgid "Give us a bit more information about yourself. All these fields are optional, but they'll help other users get to know you better."
+msgstr "Ge oss lite mer information om dig själv.  Alla dessa fält är valfria, men de hjälper andra användare att lära känna dig bättre."
 
 #: src/olympia/users/templates/users/edit.html:124
 msgid "This URL will only be visible if you are a developer."
@@ -15506,20 +12369,12 @@ msgid "Delete current photo"
 msgstr "Ta bort aktuell bild"
 
 #: src/olympia/users/templates/users/edit.html:144
-msgid ""
-"This is the default locale used to display information about you (like your "
-"description)."
-msgstr ""
-"Detta är standardspråket som används för att visa information om dig (som "
-"din beskrivning)."
+msgid "This is the default locale used to display information about you (like your description)."
+msgstr "Detta är standardspråket som används för att visa information om dig (som din beskrivning)."
 
 #: src/olympia/users/templates/users/edit.html:152
-msgid ""
-"Introduce yourself to the community, if you like! This text will appear "
-"publicly on your user info page."
-msgstr ""
-"Presentera dig själv för gemenskapen, om du vill! Denna text visas publikt "
-"på din användarinformationssida."
+msgid "Introduce yourself to the community, if you like! This text will appear publicly on your user info page."
+msgstr "Presentera dig själv för gemenskapen, om du vill! Denna text visas publikt på din användarinformationssida."
 
 #: src/olympia/users/templates/users/edit.html:161
 msgid "Allowed HTML: {0}. Links are forbidden."
@@ -15546,20 +12401,12 @@ msgid "Notifications"
 msgstr "Aviseringar"
 
 #: src/olympia/users/templates/users/edit.html:195
-msgid ""
-"From time to time, Mozilla may send you email about upcoming releases and "
-"add-on events. Please select the topics you are interested in."
-msgstr ""
-"Från tid till annan, skickar Mozilla dig e-post om kommande releaser och "
-"tilläggshändelser. Välj de ämnen du är intresserad."
+msgid "From time to time, Mozilla may send you email about upcoming releases and add-on events. Please select the topics you are interested in."
+msgstr "Från tid till annan, skickar Mozilla dig e-post om kommande releaser och tilläggshändelser. Välj de ämnen du är intresserad."
 
 #: src/olympia/users/templates/users/edit.html:205
-msgid ""
-"Mozilla reserves the right to contact you individually about specific "
-"concerns with your hosted add-ons."
-msgstr ""
-"Mozilla reserverar sig rätten att kontakta dig individuellt om eventuella "
-"särskilda frågeställningar kring ditt tillägg."
+msgid "Mozilla reserves the right to contact you individually about specific concerns with your hosted add-ons."
+msgstr "Mozilla reserverar sig rätten att kontakta dig individuellt om eventuella särskilda frågeställningar kring ditt tillägg."
 
 #: src/olympia/users/templates/users/edit.html:215
 msgid "Admin"
@@ -15581,62 +12428,48 @@ msgstr "Inga"
 msgid "all"
 msgstr "Alla"
 
-#: src/olympia/users/templates/users/fxa_migration.html:3
-#: src/olympia/users/templates/users/fxa_migration.html:11
-#: src/olympia/users/templates/users/mobile/fxa_migration.html:3
+#: src/olympia/users/templates/users/fxa_migration.html:3 src/olympia/users/templates/users/fxa_migration.html:11 src/olympia/users/templates/users/mobile/fxa_migration.html:3
 #: src/olympia/users/templates/users/mobile/fxa_migration.html:8
 msgid "Migrate to Firefox Accounts"
 msgstr "Migrera till Firefox-konton"
 
 #: src/olympia/users/templates/users/fxa_migration_prompt_content.html:3
-msgid ""
-"Mozilla Add-ons has transitioned to Firefox Accounts for login. Continue to "
-"complete the simple upgrade process."
-msgstr ""
-"Mozilla tillägg har övergått till Firefox-konton för att logga in. Fortsätt "
-"för att slutföra den enkla uppgraderingsprocessen."
+msgid "Mozilla Add-ons has transitioned to Firefox Accounts for login. Continue to complete the simple upgrade process."
+msgstr "Mozilla tillägg har övergått till Firefox-konton för att logga in. Fortsätt för att slutföra den enkla uppgraderingsprocessen."
 
 #: src/olympia/users/templates/users/fxa_migration_prompt_content.html:14
 msgid "Skip"
 msgstr "Hoppa över"
 
-#: src/olympia/users/templates/users/login.html:3
-#: src/olympia/users/templates/users/mobile/login.html:3
+#: src/olympia/users/templates/users/login.html:3 src/olympia/users/templates/users/mobile/login.html:3
 msgid "User Login"
 msgstr "Användarinloggning"
 
-#: src/olympia/users/templates/users/login.html:13
-#: src/olympia/users/templates/users/mobile/login.html:21
+#: src/olympia/users/templates/users/login.html:13 src/olympia/users/templates/users/mobile/login.html:21
 msgid "Enter your email"
 msgstr "Ange din e-postadress"
 
-#: src/olympia/users/templates/users/login.html:15
-#: src/olympia/users/templates/users/mobile/login.html:23
+#: src/olympia/users/templates/users/login.html:15 src/olympia/users/templates/users/mobile/login.html:23
 msgid "Log In"
 msgstr "Logga in"
 
-#: src/olympia/users/templates/users/login_form.html:17
-#: src/olympia/users/templates/users/mobile/login.html:32
+#: src/olympia/users/templates/users/login_form.html:17 src/olympia/users/templates/users/mobile/login.html:32
 msgid "Email address"
 msgstr "E-postadress"
 
-#: src/olympia/users/templates/users/login_form.html:30
-#: src/olympia/users/templates/users/mobile/login.html:44
+#: src/olympia/users/templates/users/login_form.html:30 src/olympia/users/templates/users/mobile/login.html:44
 msgid "Remember me on this device"
 msgstr "Kom ihåg mig på denna enhet"
 
-#: src/olympia/users/templates/users/login_help.html:3
-#: src/olympia/users/templates/users/mobile/login.html:63
+#: src/olympia/users/templates/users/login_help.html:3 src/olympia/users/templates/users/mobile/login.html:63
 msgid "Login Problems?"
 msgstr "Problem att logga in?"
 
-#: src/olympia/users/templates/users/login_help.html:5
-#: src/olympia/users/templates/users/mobile/login.html:65
+#: src/olympia/users/templates/users/login_help.html:5 src/olympia/users/templates/users/mobile/login.html:65
 msgid "I don't have an account."
 msgstr "Jag har inget konto."
 
-#: src/olympia/users/templates/users/login_help.html:6
-#: src/olympia/users/templates/users/mobile/login.html:66
+#: src/olympia/users/templates/users/login_help.html:6 src/olympia/users/templates/users/mobile/login.html:66
 msgid "I forgot my password."
 msgstr "Jag har glömt mitt lösenord."
 
@@ -15645,15 +12478,9 @@ msgstr "Jag har glömt mitt lösenord."
 msgid "You are now logged in as <strong>%(user_email)s</strong>!"
 msgstr "Du är inloggad som <strong>%(user_email)s</strong>!"
 
-#: src/olympia/users/templates/users/newpw_sent.html:3
-#: src/olympia/users/templates/users/newpw_sent.html:8
-#: src/olympia/users/templates/users/pwreset_complete.html:3
-#: src/olympia/users/templates/users/pwreset_confirm.html:4
-#: src/olympia/users/templates/users/pwreset_confirm.html:18
-#: src/olympia/users/templates/users/pwreset_request.html:4
-#: src/olympia/users/templates/users/pwreset_request.html:10
-#: src/olympia/users/templates/users/pwreset_sent.html:3
-#: src/olympia/users/templates/users/pwreset_sent.html:8
+#: src/olympia/users/templates/users/newpw_sent.html:3 src/olympia/users/templates/users/newpw_sent.html:8 src/olympia/users/templates/users/pwreset_complete.html:3
+#: src/olympia/users/templates/users/pwreset_confirm.html:4 src/olympia/users/templates/users/pwreset_confirm.html:18 src/olympia/users/templates/users/pwreset_request.html:4
+#: src/olympia/users/templates/users/pwreset_request.html:10 src/olympia/users/templates/users/pwreset_sent.html:3 src/olympia/users/templates/users/pwreset_sent.html:8
 msgid "Password Reset"
 msgstr "Återställ lösenord"
 
@@ -15669,8 +12496,7 @@ msgstr "Redigera profil"
 msgid "Manage user"
 msgstr "Hantera användare"
 
-#: src/olympia/users/templates/users/profile.html:18
-#: src/olympia/users/templates/users/report_abuse_full.html:9
+#: src/olympia/users/templates/users/profile.html:18 src/olympia/users/templates/users/report_abuse_full.html:9
 msgid "Report user"
 msgstr "Rapportera användare"
 
@@ -15730,39 +12556,25 @@ msgstr "Succé!"
 msgid "Password successfully reset."
 msgstr "Lösenordet återställt."
 
-#: src/olympia/users/templates/users/pwreset_confirm.html:13
-#: src/olympia/users/templates/users/pwreset_confirm.html:46
+#: src/olympia/users/templates/users/pwreset_confirm.html:13 src/olympia/users/templates/users/pwreset_confirm.html:46
 msgid "Password reset unsuccessful"
 msgstr "Lösenordsåterställning misslyckades"
 
 #: src/olympia/users/templates/users/pwreset_confirm.html:14
-msgid ""
-"You have migrated to Firefox Accounts. You can no longer change your "
-"password here."
-msgstr ""
-"Du har migrerat till Firefox-konton. Du kan inte längre ändra ditt lösenord "
-"här."
+msgid "You have migrated to Firefox Accounts. You can no longer change your password here."
+msgstr "Du har migrerat till Firefox-konton. Du kan inte längre ändra ditt lösenord här."
 
-#: src/olympia/users/templates/users/pwreset_confirm.html:31
-#: src/olympia/users/templates/users/register.html:72
+#: src/olympia/users/templates/users/pwreset_confirm.html:31 src/olympia/users/templates/users/register.html:72
 msgid "Confirm password"
 msgstr "Bekräfta lösenord"
 
 #: src/olympia/users/templates/users/pwreset_confirm.html:47
-msgid ""
-"The password reset link was invalid, possibly because it has already been "
-"used.  Please request a new password reset."
-msgstr ""
-"Länken för lösenordsåterställning var ogiltig, möjligen eftersom det redan "
-"har använts.  Begär en ny lösenordsåterställning."
+msgid "The password reset link was invalid, possibly because it has already been used. Please request a new password reset."
+msgstr "Länken för lösenordsåterställning var ogiltig, möjligen eftersom det redan har använts.  Begär en ny lösenordsåterställning."
 
 #: src/olympia/users/templates/users/pwreset_request.html:15
-msgid ""
-"Forgotten your password? Enter your e-mail address below, and we'll e-mail "
-"instructions for setting a new one."
-msgstr ""
-"Glömt ditt lösenord? Fyll i din e-postadress nedan och så kommer vi att "
-"skicka instruktioner om hur du skapar en ny."
+msgid "Forgotten your password? Enter your e-mail address below, and we'll e-mail instructions for setting a new one."
+msgstr "Glömt ditt lösenord? Fyll i din e-postadress nedan och så kommer vi att skicka instruktioner om hur du skapar en ny."
 
 #: src/olympia/users/templates/users/pwreset_request.html:25
 msgid "Send password reset link"
@@ -15770,13 +12582,8 @@ msgstr "Skicka länk för att återställa lösenord"
 
 #: src/olympia/users/templates/users/pwreset_sent.html:10
 msgid ""
-"An email has been sent to the requested account with further information. If"
-" you do not receive an email then please confirm you have entered the same "
-"email address used during account registration."
-msgstr ""
-"E-post har skickats till det begärda kontot med ytterligare information. Om "
-"du inte får någon e-post ber vi dig bekräfta att du angav samma e-postadress"
-" som när kontot registrerades."
+"An email has been sent to the requested account with further information. If you do not receive an email then please confirm you have entered the same email address used during account registration."
+msgstr "E-post har skickats till det begärda kontot med ytterligare information. Om du inte får någon e-post ber vi dig bekräfta att du angav samma e-postadress som när kontot registrerades."
 
 #: src/olympia/users/templates/users/register.html:4
 msgid "New User Registration"
@@ -15787,12 +12594,8 @@ msgid "Why register?"
 msgstr "Varför registrera sig?"
 
 #: src/olympia/users/templates/users/register.html:14
-msgid ""
-"Registration on AMO is <strong>not required</strong> if you simply want to "
-"download and install public add-ons."
-msgstr ""
-"Registrering på AMO <strong>krävs inte</strong> om du bara vill hämta och "
-"installera publika tillägg."
+msgid "Registration on AMO is <strong>not required</strong> if you simply want to download and install public add-ons."
+msgstr "Registrering på AMO <strong>krävs inte</strong> om du bara vill hämta och installera publika tillägg."
 
 #: src/olympia/users/templates/users/register.html:16
 msgid "You only need to register if:"
@@ -15803,48 +12606,29 @@ msgid "You want to submit reviews for add-ons"
 msgstr "Du vill skicka in recensioner för tillägg"
 
 #: src/olympia/users/templates/users/register.html:19
-msgid ""
-"You want to keep track of your favorite add-on collections or create one "
-"yourself"
+msgid "You want to keep track of your favorite add-on collections or create one yourself"
 msgstr "Du vill hålla koll på dina favorit-tilläggssamlingar eller skapa egna"
 
 #: src/olympia/users/templates/users/register.html:20
-msgid ""
-"You are an add-on developer and want to upload your add-on for hosting on "
-"AMO"
+msgid "You are an add-on developer and want to upload your add-on for hosting on AMO"
 msgstr "Du är en tilläggsutvecklare och publicera ditt tillägg på AMO"
 
 #: src/olympia/users/templates/users/register.html:23
-msgid ""
-"Upon successful registration, you will be sent a confirmation email to the "
-"address you provided. Please follow the instructions there to confirm your "
-"account."
-msgstr ""
-"Vid godkänd registrering, kommer det att skickas en e-postbekräftelse till "
-"den adress du angav. Följ instruktionerna där för att bekräfta ditt konto."
+msgid "Upon successful registration, you will be sent a confirmation email to the address you provided. Please follow the instructions there to confirm your account."
+msgstr "Vid godkänd registrering, kommer det att skickas en e-postbekräftelse till den adress du angav. Följ instruktionerna där för att bekräfta ditt konto."
 
 #: src/olympia/users/templates/users/register.html:30
 #, python-format
-msgid ""
-"If you like, you can read our <a href=\"%(legal)s\" title=\"Legal "
-"Notices\">Legal Notices</a> and <a href=\"%(privacy)s\" title=\"Privacy "
-"Policy\">Privacy Policy</a>."
-msgstr ""
-"Om du vill kan du läsa vår <a href=\"%(legal)s\" title=\"Legal "
-"Notices\">juridiska villkor</a> och <a href=\"%(privacy)s\" title=\"Privacy "
-"Policy\">sekretesspolicy</a>."
+msgid "If you like, you can read our <a href=\"%(legal)s\" title=\"Legal Notices\">Legal Notices</a> and <a href=\"%(privacy)s\" title=\"Privacy Policy\">Privacy Policy</a>."
+msgstr "Om du vill kan du läsa vår <a href=\"%(legal)s\" title=\"Legal Notices\">juridiska villkor</a> och <a href=\"%(privacy)s\" title=\"Privacy Policy\">sekretesspolicy</a>."
 
 #: src/olympia/users/templates/users/register.html:52
 msgid "Display name"
 msgstr "Visningsnamn"
 
 #: src/olympia/users/templates/users/report_abuse.html:7
-msgid ""
-"Please describe why you are reporting this user, such as for spam or an "
-"inappropriate picture."
-msgstr ""
-"Beskriv varför du anmäler denna användare, till exempel för skräppost eller "
-"en olämplig bild."
+msgid "Please describe why you are reporting this user, such as for spam or an inappropriate picture."
+msgstr "Beskriv varför du anmäler denna användare, till exempel för skräppost eller en olämplig bild."
 
 #: src/olympia/users/templates/users/report_abuse_full.html:3
 msgid "Report user {0}"
@@ -15858,42 +12642,25 @@ msgstr "Betälla t-tröja"
 msgid "Special Edition Add-on Creator T-shirt"
 msgstr "Specialutgåva tilläggsskapar t-tröja"
 
-#: src/olympia/users/templates/users/t-shirt.html:14
-#: src/olympia/users/templates/users/t-shirt.html:120
+#: src/olympia/users/templates/users/t-shirt.html:14 src/olympia/users/templates/users/t-shirt.html:120
 msgid "Note:"
 msgstr "Obs:"
 
 #: src/olympia/users/templates/users/t-shirt.html:15
-msgid ""
-"You have already submitted a request for a t-shirt. You may re-submit this "
-"form to update your information, but you will only receive one shirt."
-msgstr ""
-"Du har redan skickat in en begäran om en t-tröja. Du kan skicka in detta "
-"formulär på nytt för att uppdatera dina uppgifter, men du kommer bara att få"
-" en t-tröja."
+msgid "You have already submitted a request for a t-shirt. You may re-submit this form to update your information, but you will only receive one shirt."
+msgstr "Du har redan skickat in en begäran om en t-tröja. Du kan skicka in detta formulär på nytt för att uppdatera dina uppgifter, men du kommer bara att få en t-tröja."
 
 #: src/olympia/users/templates/users/t-shirt.html:26
-msgid ""
-"Thank you for helping to make Firefox the most extensible browser available!"
-msgstr ""
-"Tack för att du hjälper till att göra Firefox den mest utökningsbara "
-"webbläsaren som finns!"
+msgid "Thank you for helping to make Firefox the most extensible browser available!"
+msgstr "Tack för att du hjälper till att göra Firefox den mest utökningsbara webbläsaren som finns!"
 
 #: src/olympia/users/templates/users/t-shirt.html:33
-msgid ""
-"As a thank you gift, we'd like to send you a special-edition, community-"
-"designed t-shirt. To receive your shirt, please fill out the form below."
-msgstr ""
-"Som en tackgåva, skulle vi vilja skicka dig en speciellutgåva, en t-tröja "
-"utformad av gemenskapen. För att få din tröja, fyll i formuläret nedan."
+msgid "As a thank you gift, we'd like to send you a special-edition, community-designed t-shirt. To receive your shirt, please fill out the form below."
+msgstr "Som en tackgåva, skulle vi vilja skicka dig en speciellutgåva, en t-tröja utformad av gemenskapen. För att få din tröja, fyll i formuläret nedan."
 
 #: src/olympia/users/templates/users/t-shirt.html:41
-msgid ""
-"Your contact information will only be used by Mozilla to ship this special "
-"edition t-shirt."
-msgstr ""
-"Dina kontaktuppgifter kommer endast att användas av Mozilla för att leverera"
-" denna specialutgåva t-tröja."
+msgid "Your contact information will only be used by Mozilla to ship this special edition t-shirt."
+msgstr "Dina kontaktuppgifter kommer endast att användas av Mozilla för att leverera denna specialutgåva t-tröja."
 
 #: src/olympia/users/templates/users/t-shirt.html:60
 msgid "Mailing Address"
@@ -15949,23 +12716,15 @@ msgstr "Begär t-tröja"
 
 #: src/olympia/users/templates/users/t-shirt.html:137
 msgid ""
-"We're sorry, but in order to qualify for our special edition t-shirt, you "
-"must be an add-on developer with at least one listed add-on, one unlisted "
-"but signed add-on, or any number of background themes with a combined total "
-"of 10,000 average daily users."
+"We're sorry, but in order to qualify for our special edition t-shirt, you must be an add-on developer with at least one listed add-on, one unlisted but signed add-on, or any number of background "
+"themes with a combined total of 10,000 average daily users."
 msgstr ""
-"Vi ber om ursäkt, men för att kvalificera sig för vår specialutgåva t-tröja,"
-" måste du vara en utvecklare för tillägg med minst ett listat tillägg, en "
-"olistat men signerat tillägg eller valfritt antal bakgrundsteman med "
-"sammanlagt 10.000 genomsnittliga dagliga användare."
+"Vi ber om ursäkt, men för att kvalificera sig för vår specialutgåva t-tröja, måste du vara en utvecklare för tillägg med minst ett listat tillägg, en olistat men signerat tillägg eller valfritt "
+"antal bakgrundsteman med sammanlagt 10.000 genomsnittliga dagliga användare."
 
 #: src/olympia/users/templates/users/tougher_password.html:2
-msgid ""
-"For your account a password must contain at least 8 characters including "
-"letters and numbers."
-msgstr ""
-"För ditt lösenord för kontot måste innehålla minst 8 tecken inklusive "
-"bokstäver och siffror."
+msgid "For your account a password must contain at least 8 characters including letters and numbers."
+msgstr "För ditt lösenord för kontot måste innehålla minst 8 tecken inklusive bokstäver och siffror."
 
 #: src/olympia/users/templates/users/unsubscribe.html:2
 msgid "Unsubscribe"
@@ -15977,12 +12736,8 @@ msgstr "Du har avslutat prenumerationen!"
 
 #: src/olympia/users/templates/users/unsubscribe.html:10
 #, python-format
-msgid ""
-"The email address <strong>%(email)s</strong> will no longer get messages "
-"when:"
-msgstr ""
-"E-postadressen <strong>%(email)s</strong> kommer inte längre att få "
-"meddelanden när:"
+msgid "The email address <strong>%(email)s</strong> will no longer get messages when:"
+msgstr "E-postadressen <strong>%(email)s</strong> kommer inte längre att få meddelanden när:"
 
 #: src/olympia/users/templates/users/unsubscribe.html:20
 msgid "More Actions:"
@@ -16002,14 +12757,9 @@ msgstr "Vi kunde inte avsluta prenumerationen för dig"
 
 #: src/olympia/users/templates/users/unsubscribe.html:30
 #, python-format
-msgid ""
-"Unfortunately, we weren't able to unsubscribe you.  The link you clicked is "
-"invalid. However, you can unsubscribe still unsubscribe on your <a "
-"href=\"%(edit_url)s\">edit profile page</a>."
+msgid "Unfortunately, we weren't able to unsubscribe you. The link you clicked is invalid. However, you can unsubscribe still unsubscribe on your <a href=\"%(edit_url)s\">edit profile page</a>."
 msgstr ""
-"Tyvärr, kunde vi inte att avsluta prenumerationen för dig.  Länken du "
-"klickade på är ogiltig. Däremot kan du fortfarande avsluta prenumerationen "
-"genom din <a href=\"%(edit_url)s\">profilsida</a>."
+"Tyvärr, kunde vi inte att avsluta prenumerationen för dig.  Länken du klickade på är ogiltig. Däremot kan du fortfarande avsluta prenumerationen genom din <a href=\"%(edit_url)s\">profilsida</a>."
 
 #: src/olympia/users/templates/users/vcard.html:2
 msgid "Developer Information"
@@ -16062,15 +12812,15 @@ msgstr "%s versionshistorik"
 msgid "Version History with Changelogs"
 msgstr "Versionshistorik med ändringsloggar"
 
-#: src/olympia/versions/models.py:314
+#: src/olympia/versions/models.py:313
 msgid "Add-on uses binary components."
 msgstr "Tillägget använder binära komponenter."
 
-#: src/olympia/versions/models.py:317
+#: src/olympia/versions/models.py:316
 msgid "Add-on has opted into strict compatibility checking."
 msgstr "Tillägg har valt in i strikt kompatibilitetskontroll."
 
-#: src/olympia/versions/models.py:715
+#: src/olympia/versions/models.py:711
 msgid "{app} {min} and later"
 msgstr "{app} {min} och senare"
 
@@ -16109,20 +12859,14 @@ msgid_plural "<b>{0}</b> versions"
 msgstr[0] "<b>{0}</b> version"
 msgstr[1] "<b>{0}</b> versioner"
 
-#: src/olympia/versions/templates/versions/version_list.html:35
-#: src/olympia/versions/templates/versions/mobile/version_list.html:14
+#: src/olympia/versions/templates/versions/version_list.html:35 src/olympia/versions/templates/versions/mobile/version_list.html:14
 msgid "Be careful with old versions!"
 msgstr "Var försiktig med gamla versioner!"
 
-#: src/olympia/versions/templates/versions/version_list.html:36
-#: src/olympia/versions/templates/versions/mobile/version_list.html:15
+#: src/olympia/versions/templates/versions/version_list.html:36 src/olympia/versions/templates/versions/mobile/version_list.html:15
 #, python-format
-msgid ""
-"These versions are displayed for reference and testing purposes. You should "
-"always use the <a href=\"%(url)s\">latest version</a> of an add-on."
-msgstr ""
-"Dessa versioner visas för referens och teständamål. Du bör alltid använda <a"
-" href=\"%(url)s\">den senaste versionen</a> av ett tillägg."
+msgid "These versions are displayed for reference and testing purposes. You should always use the <a href=\"%(url)s\">latest version</a> of an add-on."
+msgstr "Dessa versioner visas för referens och teständamål. Du bör alltid använda <a href=\"%(url)s\">den senaste versionen</a> av ett tillägg."
 
 #: src/olympia/versions/templates/versions/mobile/version.html:4
 msgid "Beta Version {0}"
@@ -16152,3 +12896,7 @@ msgstr "E-post när det är klart"
 #: src/olympia/zadmin/forms.py:105
 msgid "Log emails instead of sending"
 msgstr "Logga e-post istället för att skicka"
+
+#: src/olympia/zadmin/forms.py:215
+msgid "Deleted versions can`t be changed."
+msgstr ""

--- a/locale/sv_SE/LC_MESSAGES/djangojs.po
+++ b/locale/sv_SE/LC_MESSAGES/djangojs.po
@@ -1,1267 +1,1239 @@
-# 
+#
 msgid ""
 msgstr ""
 "Project-Id-Version: AMO-JS 0.1\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2016-02-24 21:23+0000\n"
+"POT-Creation-Date: 2016-04-18 15:47+0000\n"
 "PO-Revision-Date: 2015-08-10 21:30+0000\n"
 "Last-Translator: Andreas Pettersson <az@kth.se>\n"
 "Language-Team: The Swedish l10n-team <community-sweden@lists.mozilla.org>\n"
-"Language: sv_SE\n"
+"Language: \n"
 "MIME-Version: 1.0\n"
-"Content-Type: text/plain; charset=utf-8\n"
+"Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 "Generated-By: Babel 2.2.0\n"
-"X-Generator: Pontoon\n"
 
-#: static/js/common/ratingwidget.js:31
-msgid "{0} star"
-msgid_plural "{0} stars"
-msgstr[0] "{0} stjärna"
-msgstr[1] "{0} stjärnor"
-
-#: static/js/common/upload-addon.js:41 static/js/common/upload-image.js:128
-msgid "There was a problem contacting the server."
-msgstr "Det gick inte att kontakta servern."
-
-#: static/js/common/upload-addon.js:69
-msgid "Select a file..."
-msgstr "Välj en fil..."
-
-#: static/js/common/upload-addon.js:70
-msgid "Your add-on should end with .xpi, .jar or .xml"
-msgstr "Ditt tillägg bör sluta med .xpi, .jar eller .xml"
-
-#. L10n: {0} is the percent of the file that has been uploaded.
-#: static/js/common/upload-addon.js:104
-#, python-format
-msgid "{0}% complete"
-msgstr "{0}% klart"
-
-#. L10n: "{bytes uploaded} of {total filesize}".
-#: static/js/common/upload-addon.js:107
-msgid "{0} of {1}"
-msgstr "{0} av {1}"
-
-#: static/js/common/upload-addon.js:140
-msgid "Cancel"
-msgstr "Avbryt"
-
-#: static/js/common/upload-addon.js:162
-msgid "Uploading {0}"
-msgstr "Laddar upp {0}"
-
-#: static/js/common/upload-addon.js:189
-msgid "Error with {0}"
-msgstr "Fel med {0}"
-
-#: static/js/common/upload-addon.js:194
-msgid "Your add-on failed validation with {0} error."
-msgid_plural "Your add-on failed validation with {0} errors."
-msgstr[0] "Ditt tillägg misslyckades validering med {0} fel."
-msgstr[1] "Ditt tillägg misslyckades validering med {0} fel."
-
-#: static/js/common/upload-addon.js:208
-msgid "&hellip;and {0} more"
-msgid_plural "&hellip;and {0} more"
-msgstr[0] "&hellip;och {0} mer"
-msgstr[1] "&hellip;och {0} fler"
-
-#: static/js/common/upload-addon.js:222 static/js/common/upload-addon.js:512
-msgid "See full validation report"
-msgstr "Se fullständig valideringsrapport"
-
-#: static/js/common/upload-addon.js:234
-msgid "Validating {0}"
-msgstr "Validerar {0}"
-
-#. L10n: first argument is an HTTP status code
-#: static/js/common/upload-addon.js:273
-msgid "Received an empty response from the server; status: {0}"
-msgstr "Fick ett tomt svar från servern; status: {0}"
-
-#: static/js/common/upload-addon.js:373
-msgid "Unexpected server error while validating."
-msgstr "Oväntat serverfel under validering."
-
-#: static/js/common/upload-addon.js:412
-msgid "Finished validating {0}"
-msgstr "Validering klar för {0}"
-
-#: static/js/common/upload-addon.js:418
-msgid "Your add-on validation timed out, it will be manually reviewed."
-msgstr ""
-"Ditt tilläggs validering gjorde timeout, det kommer att granskas manuellt."
-
-#: static/js/common/upload-addon.js:421
-msgid "Your add-on was validated with no errors and {0} warning."
-msgid_plural "Your add-on was validated with no errors and {0} warnings."
-msgstr[0] "Ditt tillägg validerades utan fel och {0} varning."
-msgstr[1] "Ditt tillägg validerades utan fel och {0} varningar."
-
-#: static/js/common/upload-addon.js:426
-msgid "Your add-on was validated with no errors and {0} message."
-msgid_plural "Your add-on was validated with no errors and {0} messages."
-msgstr[0] "Ditt tillägg validerades utan fel och {0} meddelande."
-msgstr[1] "Ditt tillägg validerades utan fel och {0} meddelanden."
-
-#: static/js/common/upload-addon.js:431
-msgid "Your add-on was validated with no errors or warnings."
-msgstr "Ditt tillägg validerades utan fel eller varningar."
-
-#: static/js/common/upload-addon.js:446
-msgid "Your submission will be automatically signed."
-msgstr "Ditt bidrag kommer att signeras automatiskt."
-
-#: static/js/common/upload-addon.js:465
-msgid "Include detailed version notes (this can be done in the next step)."
-msgstr ""
-"Inkludera detaljerade versionsanteckningar (detta kan göras i nästa steg)."
-
-#: static/js/common/upload-addon.js:466
-msgid ""
-"If your add-on requires an account to a website in order to be fully tested,"
-" include a test username and password in the Notes to Reviewer (this can be "
-"done in the next step)."
-msgstr ""
-"Om ditt tillägg kräver ett konto till en webbplats för att bli fullständigt "
-"testat, inkludera ett test användarnamn och lösenord i meddelande till "
-"granskaren (detta kan göras i nästa steg)."
-
-#: static/js/common/upload-addon.js:467
-msgid ""
-"If your add-on is intended for a limited audience you should choose "
-"Preliminary Review instead of Full Review."
-msgstr ""
-"Om ditt tillägg är avsedd för en begränsad publik bör du välja preliminär "
-"granskning istället för fullständig granskning."
-
-#: static/js/common/upload-addon.js:480
-msgid "Add-on submission checklist"
-msgstr "Checklista för att skicka in tillägg"
-
-#: static/js/common/upload-addon.js:481
-msgid ""
-"Please verify the following points before finalizing your submission. This "
-"will minimize delays or misunderstanding during the review process:"
-msgstr ""
-"Vänligen kontrollera följande punkter innan du slutför ditt bidrag. Detta "
-"kommer att minimera förseningar eller missförstånd under "
-"granskningsprocessen:"
-
-#: static/js/common/upload-addon.js:483
-msgid ""
-"Compiled binaries, as well as minified or obfuscated scripts (excluding "
-"known libraries) need to have their sources submitted separately for review."
-" Make sure that you use the source code upload field to avoid having your "
-"submission rejected."
-msgstr ""
-"Kompilerade binärfiler, liksom minifierad eller förvrängda skript (exklusive"
-" kända bibliotek) måste skicka in sina källor separat för granskning. Se "
-"till att du använder uppladdningsfältet för källkoden för att undvika att "
-"ditt bidrag avvisas."
-
-#: static/js/common/upload-addon.js:501
-msgid "The validation process found these issues that can lead to rejections:"
-msgstr "Valideringsprocessen hittade dessa problem som kan leda till avslag:"
-
-#: static/js/common/upload-addon.js:518
-msgid ""
-"If you are unfamiliar with the add-ons review process, you can read about it"
-" here."
-msgstr ""
-"Om du är obekant med granskningsprocessen för tillägg, kan du läsa om det "
-"här."
-
-#: static/js/common/upload-addon.js:555
-msgid "Sorry, no supported platform has been found."
-msgstr "Tyvärr har ingen plattform som stöds hittats."
-
-#: static/js/common/upload-base.js:57
-msgid "The filetype you uploaded isn't recognized."
-msgstr "Filtypen du laddade upp är okänd."
-
-#: static/js/common/upload-base.js:79
-msgid "You cancelled the upload."
-msgstr "Du avbröt uppladdningen."
-
-#: static/js/common/upload-image.js:97 static/js/impala/users.js:51
-msgid "Images must be either PNG or JPG."
-msgstr "Bilder måste vara antingen PNG eller JPG."
-
-#: static/js/common/upload-image.js:101
-msgid "Videos must be in WebM."
-msgstr "Videor måste vara i WebM."
-
-#: static/js/impala/collections.js:10 static/js/zamboni/collections.js:595
-msgid "Follow this Collection"
-msgstr "Följ denna samling"
-
-#: static/js/impala/collections.js:19
-msgid "Stop Following"
-msgstr "Sluta följa"
-
-#: static/js/impala/collections.js:20
-msgid "Following"
-msgstr "Följer"
-
-#. L10n: {0} is an app name.
-#: static/js/impala/listing.js:11 static/js/zamboni/themes.js:13
-msgid "This theme is incompatible with your version of {0}"
-msgstr "Detta tema är inte kompatibelt med din version av {0}"
-
-#: static/js/impala/persona_creation.js:60
-msgid "All Rights Reserved"
-msgstr "Med ensamrätt"
-
-#: static/js/impala/persona_creation.js:64
-msgid "Creative Commons Attribution 3.0"
-msgstr "Creative Commons Attribution 3.0"
-
-#: static/js/impala/persona_creation.js:69
-msgid "Creative Commons Attribution-NonCommercial 3.0"
-msgstr "Creative Commons Attribution-NonCommercial 3.0"
-
-#: static/js/impala/persona_creation.js:74
-msgid "Creative Commons Attribution-NonCommercial-NoDerivs 3.0"
-msgstr "Creative Commons Attribution-NonCommercial-NoDerivs 3.0"
-
-#: static/js/impala/persona_creation.js:79
-msgid "Creative Commons Attribution-NonCommercial-Share Alike 3.0"
-msgstr "Creative Commons Attribution-NonCommercial-Share Alike 3.0"
-
-#: static/js/impala/persona_creation.js:84
-msgid "Creative Commons Attribution-NoDerivs 3.0"
-msgstr "Creative Commons Attribution-NoDerivs 3.0"
-
-#: static/js/impala/persona_creation.js:89
-msgid "Creative Commons Attribution-ShareAlike 3.0"
-msgstr "Creative Commons Attribution-ShareAlike 3.0"
-
-#: static/js/impala/persona_creation.js:292
-msgid "Your Theme's Name"
-msgstr "Ditt temas namn"
-
-#: static/js/impala/reviews.js:23 static/js/zamboni/reviews.js:18
-msgid "Flagged for review"
-msgstr "Flaggad för granskning"
-
-#: static/js/impala/reviews.js:40 static/js/zamboni/reviews.js:34
-msgid "Your input is required"
-msgstr "Du måste ange något"
-
-#: static/js/impala/reviews.js:152 static/js/zamboni/reviews.js:103
-msgid "Marked for deletion"
-msgstr "Markerad för borttagning"
-
-#: static/js/impala/search.js:114
-msgid "Updating results&hellip;"
-msgstr "Uppdaterar resultat&hellip;"
-
-#: static/js/impala/site_suggestions.js:46
-msgid "Category"
-msgstr "Kategori"
-
-#: static/js/impala/suggestions.js:39
-msgid "Search themes for <b>{0}</b>"
-msgstr "Sök teman för <b>{0}</b>"
-
-#: static/js/impala/suggestions.js:41
-msgid "Search apps for <b>{0}</b>"
-msgstr "Sök appar för <b>{0}</b>"
-
-#: static/js/impala/suggestions.js:43
-msgid "Search add-ons for <b>{0}</b>"
-msgstr "Sök tillägg för <b>{0}</b>"
-
-#: static/js/impala/users.js:33
-msgid "use original"
-msgstr "använd original"
-
-#: static/js/impala/stats/chart.js:267
-msgid "Week of {0}"
-msgstr "Vecka för {0}"
-
-#: static/js/impala/stats/chart.js:269
-msgid " downloads"
-msgstr " nedladdningar"
-
-#: static/js/impala/stats/chart.js:270
-msgid "{0} users"
-msgstr "{0} användare"
-
-#: static/js/impala/stats/chart.js:271
-msgid "{0} add-ons"
-msgstr "{0} tillägg"
-
-#: static/js/impala/stats/chart.js:272
-msgid "{0} collections"
-msgstr "{0} samlingar"
-
-#: static/js/impala/stats/chart.js:273
-msgid "{0} reviews"
-msgstr "{0} recensioner"
-
-#: static/js/impala/stats/chart.js:275
-msgid "{0} sales"
-msgstr "{0} försäljningar"
-
-#: static/js/impala/stats/chart.js:276
-msgid "{0} refunds"
-msgstr "{0} återbetalningar"
-
-#: static/js/impala/stats/chart.js:277
-msgid "{0} installs"
-msgstr "{0} installationer"
-
-#: static/js/impala/stats/chart.js:369 static/js/impala/stats/csv_keys.js:3
-#: static/js/impala/stats/csv_keys.js:109
-msgid "Downloads"
-msgstr "Nedladdningar"
-
-#: static/js/impala/stats/chart.js:379 static/js/impala/stats/csv_keys.js:6
-#: static/js/impala/stats/csv_keys.js:110
-msgid "Daily Users"
-msgstr "Dagliga användare"
-
-#: static/js/impala/stats/chart.js:410
-msgid "Amount, in USD"
-msgstr "Belopp, i USD"
-
-#: static/js/impala/stats/chart.js:421 static/js/impala/stats/csv_keys.js:104
-msgid "Number of Contributions"
-msgstr "Antal bidrag"
-
-#: static/js/impala/stats/chart.js:447
-msgid "More Info..."
-msgstr "Mer info..."
-
-#. L10n: {0} is an ISO-formatted date.
-#: static/js/impala/stats/chart.js:451
-msgid "Details for {0}"
-msgstr "Detaljer för {0}"
-
-#: static/js/impala/stats/csv_keys.js:9
-msgid "Collections Created"
-msgstr "Samlingar skapade"
-
-#: static/js/impala/stats/csv_keys.js:12
-msgid "Add-ons in Use"
-msgstr "Tillägg i användning"
-
-#: static/js/impala/stats/csv_keys.js:15
-msgid "Add-ons Created"
-msgstr "Tillägg skapat"
-
-#: static/js/impala/stats/csv_keys.js:18
-msgid "Add-ons Downloaded"
-msgstr "Tillägg nedladdat"
-
-#: static/js/impala/stats/csv_keys.js:21
-msgid "Add-ons Updated"
-msgstr "Tillägg uppdaterad"
-
-#: static/js/impala/stats/csv_keys.js:24
-msgid "Reviews Written"
-msgstr "Recensioner skrivna"
-
-#: static/js/impala/stats/csv_keys.js:27
-msgid "User Signups"
-msgstr "Användarregistreringar"
-
-#: static/js/impala/stats/csv_keys.js:30
-msgid "Subscribers"
-msgstr "Prenumeranter"
-
-#: static/js/impala/stats/csv_keys.js:33
-msgid "Ratings"
-msgstr "Betyg"
-
-#: static/js/impala/stats/csv_keys.js:36
-#: static/js/impala/stats/csv_keys.js:114
-msgid "Sales"
-msgstr "Försäljning"
-
-#: static/js/impala/stats/csv_keys.js:39
-#: static/js/impala/stats/csv_keys.js:113
-msgid "Installs"
-msgstr "Installationer"
-
-#: static/js/impala/stats/csv_keys.js:42
-msgid "Unknown"
-msgstr "Okänd"
-
-#: static/js/impala/stats/csv_keys.js:43
-msgid "Add-ons Manager"
-msgstr "Tilläggshanterare"
-
-#: static/js/impala/stats/csv_keys.js:44
-msgid "Add-ons Manager Promo"
-msgstr "Tilläggshanterare promo"
-
-#: static/js/impala/stats/csv_keys.js:45
-msgid "Add-ons Manager Featured"
-msgstr "Tilläggshanterare utvalda"
-
-#: static/js/impala/stats/csv_keys.js:46
-msgid "Add-ons Manager Learn More"
-msgstr "Tilläggshanterare läs mer"
-
-#: static/js/impala/stats/csv_keys.js:47
-msgid "Search Suggestions"
-msgstr "Sökförslag"
-
-#: static/js/impala/stats/csv_keys.js:48
-msgid "Search Results"
-msgstr "Sökresultat"
-
-#: static/js/impala/stats/csv_keys.js:49 static/js/impala/stats/csv_keys.js:50
-#: static/js/impala/stats/csv_keys.js:51
-msgid "Homepage Promo"
-msgstr "Hemsida promo"
-
-#: static/js/impala/stats/csv_keys.js:52 static/js/impala/stats/csv_keys.js:53
-msgid "Homepage Featured"
-msgstr "Hemsida utvalda"
-
-#: static/js/impala/stats/csv_keys.js:54 static/js/impala/stats/csv_keys.js:55
-msgid "Homepage Up and Coming"
-msgstr "Hemsida bubblare"
-
-#: static/js/impala/stats/csv_keys.js:56
-msgid "Homepage Most Popular"
-msgstr "Hemsida mest populära"
-
-#: static/js/impala/stats/csv_keys.js:57 static/js/impala/stats/csv_keys.js:59
-msgid "Detail Page"
-msgstr "Detaljsida"
-
-#: static/js/impala/stats/csv_keys.js:58 static/js/impala/stats/csv_keys.js:60
-msgid "Detail Page (bottom)"
-msgstr "Detaljsida (nederst)"
-
-#: static/js/impala/stats/csv_keys.js:61
-msgid "Detail Page (Development Channel)"
-msgstr "Detaljsida (utvecklingskanal)"
-
-#: static/js/impala/stats/csv_keys.js:62 static/js/impala/stats/csv_keys.js:63
-#: static/js/impala/stats/csv_keys.js:64
-msgid "Often Used With"
-msgstr "Används ofta med"
-
-#: static/js/impala/stats/csv_keys.js:65 static/js/impala/stats/csv_keys.js:66
-msgid "Others By Author"
-msgstr "Andra av utvecklaren"
-
-#: static/js/impala/stats/csv_keys.js:67 static/js/impala/stats/csv_keys.js:68
-msgid "Dependencies"
-msgstr "Beroenden"
-
-#: static/js/impala/stats/csv_keys.js:69 static/js/impala/stats/csv_keys.js:70
-msgid "Upsell"
-msgstr "Uppgradering"
-
-#: static/js/impala/stats/csv_keys.js:71
-msgid "Meet the Developer"
-msgstr "Möt utvecklaren"
-
-#: static/js/impala/stats/csv_keys.js:72
-msgid "User Profile"
-msgstr "Användarprofil"
-
-#: static/js/impala/stats/csv_keys.js:73
-msgid "Version History"
-msgstr "Versionshistorik"
-
-#: static/js/impala/stats/csv_keys.js:75
-msgid "Sharing"
-msgstr "Delning"
-
-#: static/js/impala/stats/csv_keys.js:76
-msgid "Category Pages"
-msgstr "Kategorisidor"
-
-#: static/js/impala/stats/csv_keys.js:77
-msgid "Collections"
-msgstr "Samlingar"
-
-#: static/js/impala/stats/csv_keys.js:78 static/js/impala/stats/csv_keys.js:79
-msgid "Category Landing Featured Carousel"
-msgstr "Kategoriöversikt: Karusell med utvalda tillägg"
-
-#: static/js/impala/stats/csv_keys.js:80 static/js/impala/stats/csv_keys.js:81
-msgid "Category Landing Top Rated"
-msgstr "Kategoriöversikt: Högst omdöme"
-
-#: static/js/impala/stats/csv_keys.js:82 static/js/impala/stats/csv_keys.js:83
-msgid "Category Landing Most Popular"
-msgstr "Kategoriöversikt: Populäraste"
-
-#: static/js/impala/stats/csv_keys.js:84 static/js/impala/stats/csv_keys.js:85
-msgid "Category Landing Recently Added"
-msgstr "Kategoriöversikt: Nyligen tillagda"
-
-#: static/js/impala/stats/csv_keys.js:86 static/js/impala/stats/csv_keys.js:87
-msgid "Browse Listing Featured Sort"
-msgstr "Bläddringslista: Sorterad efter utvalda tillägg"
-
-#: static/js/impala/stats/csv_keys.js:88 static/js/impala/stats/csv_keys.js:89
-msgid "Browse Listing Users Sort"
-msgstr "Bläddringslista: Sorterad efter användare"
-
-#: static/js/impala/stats/csv_keys.js:90 static/js/impala/stats/csv_keys.js:91
-msgid "Browse Listing Rating Sort"
-msgstr "Bläddringslista: Sorterad efter omdöme"
-
-#: static/js/impala/stats/csv_keys.js:92 static/js/impala/stats/csv_keys.js:93
-msgid "Browse Listing Created Sort"
-msgstr "Bläddringslista: Sorterad efter skapad"
-
-#: static/js/impala/stats/csv_keys.js:94 static/js/impala/stats/csv_keys.js:95
-msgid "Browse Listing Name Sort"
-msgstr "Bläddringslista: Sorterad efter namn"
-
-#: static/js/impala/stats/csv_keys.js:96 static/js/impala/stats/csv_keys.js:97
-msgid "Browse Listing Popular Sort"
-msgstr "Bläddringslista: Sorterad efter popularitet"
-
-#: static/js/impala/stats/csv_keys.js:98 static/js/impala/stats/csv_keys.js:99
-msgid "Browse Listing Updated Sort"
-msgstr "Bläddringslista: Sorterad efter uppdaterad"
-
-#: static/js/impala/stats/csv_keys.js:100
-#: static/js/impala/stats/csv_keys.js:101
-msgid "Browse Listing Up and Coming Sort"
-msgstr "Bläddringslista: Sorterad efter bubblare"
-
-#: static/js/impala/stats/csv_keys.js:105
-msgid "Total Amount Contributed"
-msgstr "Totalt bidragsbelopp"
-
-#: static/js/impala/stats/csv_keys.js:106
-msgid "Average Contribution"
-msgstr "Genomsnittligt bidrag"
-
-#: static/js/impala/stats/csv_keys.js:115
-msgid "Usage"
-msgstr "Användning"
-
-#: static/js/impala/stats/csv_keys.js:118
-msgid "Firefox"
-msgstr "Firefox"
-
-#: static/js/impala/stats/csv_keys.js:119
-msgid "Mozilla"
-msgstr "Mozilla"
-
-#: static/js/impala/stats/csv_keys.js:120
-msgid "Thunderbird"
-msgstr "Thunderbird"
-
-#: static/js/impala/stats/csv_keys.js:121
-msgid "Sunbird"
-msgstr "Sunbird"
-
-#: static/js/impala/stats/csv_keys.js:122
-msgid "SeaMonkey"
-msgstr "SeaMonkey"
-
-#: static/js/impala/stats/csv_keys.js:123
-msgid "Fennec"
-msgstr "Fennec"
-
-#: static/js/impala/stats/csv_keys.js:124
-msgid "Android"
-msgstr "Android"
-
-#. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:129
-msgid "Downloads and Daily Users, last {0} days"
-msgstr "Nedladdningar och dagliga användare de senaste {0} dagarna"
-
-#. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:131
-msgid "Downloads and Daily Users from {0} to {1}"
-msgstr "Nedladdningar och dagliga användare mellan {0} och {1}"
-
-#. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:135
-msgid "Installs and Daily Users, last {0} days"
-msgstr "Installationer och dagliga användare de senaste {0} dagarna"
-
-#. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:137
-msgid "Installs and Daily Users from {0} to {1}"
-msgstr "Installationer och dagliga användare mellan {0} och {1}"
-
-#. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:141
-msgid "Downloads, last {0} days"
-msgstr "Nedladdningar de senaste {0} dagarna"
-
-#. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:143
-msgid "Downloads from {0} to {1}"
-msgstr "Nedladdningar mellan {0} och {1}"
-
-#. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:147
-msgid "Daily Users, last {0} days"
-msgstr "Dagliga användare de senaste {0} dagarna"
-
-#. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:149
-msgid "Daily Users from {0} to {1}"
-msgstr "Dagliga användare mellan {0} och {1}"
-
-#. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:153
-msgid "Applications, last {0} days"
-msgstr "Applikationer de senaste {0} dagarna"
-
-#. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:155
-msgid "Applications from {0} to {1}"
-msgstr "Applikationer mellan {0} och {1}"
-
-#. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:159
-msgid "Platforms, last {0} days"
-msgstr "Plattformar de senaste {0} dagarna"
-
-#. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:161
-msgid "Platforms from {0} to {1}"
-msgstr "Plattformar mellan {0} och {1}"
-
-#. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:165
-msgid "Languages, last {0} days"
-msgstr "Språk de senaste {0} dagarna"
-
-#. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:167
-msgid "Languages from {0} to {1}"
-msgstr "Språk mellan {0} och {1}"
-
-#. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:171
-msgid "Add-on Versions, last {0} days"
-msgstr "Tilläggsversioner de senaste {0} dagarna"
-
-#. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:173
-msgid "Add-on Versions from {0} to {1}"
-msgstr "Tilläggsversioner mellan {0} och {1}"
-
-#. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:177
-msgid "Add-on Status, last {0} days"
-msgstr "Tilläggsstatus de senaste {0} dagarna"
-
-#. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:179
-msgid "Add-on Status from {0} to {1}"
-msgstr "Tilläggsstatus mellan {0} och {1}"
-
-#. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:183
-msgid "Download Sources, last {0} days"
-msgstr "Ladda ner källor de senaste {0} dagarna"
-
-#. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:185
-msgid "Download Sources from {0} to {1}"
-msgstr "Ladda ner källor mellan {0} och {1}"
-
-#. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:189
-msgid "Contributions, last {0} days"
-msgstr "Bidrag de senaste {0} dagarna"
-
-#. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:191
-msgid "Contributions from {0} to {1}"
-msgstr "Bidrag mellan {0} och {1}"
-
-#. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:195
-msgid "Site Metrics, last {0} days"
-msgstr "Webbplatsstatistik de senaste {0} dagarna"
-
-#. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:197
-msgid "Site Metrics from {0} to {1}"
-msgstr "Webbplatsstatistik mellan {0} och {1}"
-
-#. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:201
-msgid "Add-ons in Use, last {0} days"
-msgstr "Tillägg i användning de senaste {0} dagarna"
-
-#. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:203
-msgid "Add-ons in Use from {0} to {1}"
-msgstr "Tillägg i användning mellan {0} och {1}"
-
-#. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:207
-msgid "Add-ons Downloaded, last {0} days"
-msgstr "Tillägg nedladdade de senaste {0} dagarna"
-
-#. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:209
-msgid "Add-ons Downloaded from {0} to {1}"
-msgstr "Tillägg nedladdade mellan {0} och {1}"
-
-#. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:213
-msgid "Add-ons Created, last {0} days"
-msgstr "Tillägg skapade de senaste {0} dagarna"
-
-#. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:215
-msgid "Add-ons Created from {0} to {1}"
-msgstr "Tillägg skapade mellan {0} och {1}"
-
-#. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:219
-msgid "Add-ons Updated, last {0} days"
-msgstr "Tillägg uppdaterade de senaste {0} dagarna"
-
-#. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:221
-msgid "Add-ons Updated from {0} to {1}"
-msgstr "Tillägg uppdaterade mellan {0} och {1}"
-
-#. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:225
-msgid "Reviews Written, last {0} days"
-msgstr "Recensioner skrivna de senaste {0} dagarna"
-
-#. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:227
-msgid "Reviews Written from {0} to {1}"
-msgstr "Recensioner skrivna mellan {0} och {1}"
-
-#. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:231
-msgid "User Signups, last {0} days"
-msgstr "Användarregistreringar de senaste {0} dagarna"
-
-#. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:233
-msgid "User Signups from {0} to {1}"
-msgstr "Användarregistreringar mellan {0} och {1}"
-
-#. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:237
-msgid "Collections Created, last {0} days"
-msgstr "Samlingar skapade de senaste {0} dagarna"
-
-#. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:239
-msgid "Collections Created from {0} to {1}"
-msgstr "Samlingar skapade mellan {0} och {1}"
-
-#. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:243
-msgid "Subscribers, last {0} days"
-msgstr "Prenumeranter de senaste {0} dagarna"
-
-#. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:245
-msgid "Subscribers from {0} to {1}"
-msgstr "Prenumeranter mellan {0} och {1}"
-
-#. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:249
-msgid "Ratings, last {0} days"
-msgstr "Betygsatt de senaste {0} dagarna"
-
-#. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:251
-msgid "Ratings from {0} to {1}"
-msgstr "Betygsatt mellan {0} och {1}"
-
-#. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:255
-msgid "Sales, last {0} days"
-msgstr "Försäljning de senaste {0} dagarna"
-
-#. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:257
-msgid "Sales from {0} to {1}"
-msgstr "Försäljning mellan {0} och {1}"
-
-#. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:261
-msgid "Installs, last {0} days"
-msgstr "Installationer de senaste {0} dagarna"
-
-#. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:263
-msgid "Installs from {0} to {1}"
-msgstr "Installationer mellan {0} och {1}"
-
-#. L10n: {0} and {1} are integers.
-#: static/js/impala/stats/csv_keys.js:269
-msgid "<b>{0}</b> in last {1} days"
-msgstr "<b>{0}</b> de senaste {1} dagarna"
-
-#. L10n: {0} is an integer and {1} and {2} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:271
-#: static/js/impala/stats/csv_keys.js:277
-msgid "<b>{0}</b> from {1} to {2}"
-msgstr "<b>{0}</b> mellan {1} och {2}"
-
-#. L10n: {0} and {1} are integers.
-#: static/js/impala/stats/csv_keys.js:275
-msgid "<b>{0}</b> average in last {1} days"
-msgstr "<b>{0}</b> genomsnitt de senaste {1} dagarna"
-
-#: static/js/impala/stats/overview.js:19
-msgid "No data available."
-msgstr "Inga data tillgängliga."
-
-#: static/js/impala/stats/table.js:74
-msgid "Date"
-msgstr "Datum"
-
-#: static/js/impala/stats/topchart.js:96
-msgid "Other"
-msgstr "Andra"
-
-#: static/js/zamboni/admin_validation.js:24 static/js/zamboni/devhub.js:1229
-#: static/js/zamboni/editors.js:295
-msgid "Select an application first"
-msgstr "Välj en applikation först"
-
-#: static/js/zamboni/admin_validation.js:51
-msgid "Set {0} add-on to a max version of {1} and email the author."
-msgid_plural "Set {0} add-ons to a max version of {1} and email the authors."
-msgstr[0] ""
-"Ställ in tillägget {0} till maxversion på {1} och mejla utvecklaren."
-msgstr[1] ""
-"Ställ in tillägget {0} till maxversion på {1} och mejla utvecklarna."
-
-#: static/js/zamboni/admin_validation.js:54
-msgid "Email author of {2} add-on which failed validation."
-msgid_plural "Email authors of {2} add-ons which failed validation."
-msgstr[0] "Mejla utvecklaren av tillägget {2} som misslyckades validering."
-msgstr[1] "Mejla utvecklarna av tillägget {2} som misslyckades validering."
+#: static/js/common-all.js:1426 static/js/impala-all.js:1511 static/js/zamboni/discovery-all.js:12598 static/js/zamboni/init.js:28 static/js/zamboni/mobile-all.js:14945
+msgid "This feature is temporarily disabled while we perform website maintenance. Please check back a little later."
+msgstr "Den här funktionen är tillfälligt inaktiverad under tiden vi utför underhåll på webbplatsen. Vänligen kom tillbaka lite senare."
 
 #. L10n: {0} is an app name like Firefox.
-#: static/js/zamboni/buttons.js:66
+#: static/js/common-all.js:1837 static/js/impala-all.js:1922 static/js/zamboni/buttons.js:73 static/js/zamboni/discovery-all.js:13108
 msgid "Accept and Install"
 msgstr "Godkänn och installera"
 
-#: static/js/zamboni/buttons.js:66
+#: static/js/common-all.js:1837 static/js/impala-all.js:1922 static/js/zamboni/buttons.js:73 static/js/zamboni/discovery-all.js:13108
 msgid "Add to {0}"
 msgstr "Lägg till i {0}"
 
-#: static/js/zamboni/buttons.js:71
+#: static/js/common-all.js:1842 static/js/impala-all.js:1927 static/js/zamboni/buttons.js:78 static/js/zamboni/discovery-all.js:13113
 msgid "Download Now"
 msgstr "Hämta nu"
 
-#: static/js/zamboni/buttons.js:112
+#: static/js/common-all.js:1883 static/js/impala-all.js:1968 static/js/zamboni/buttons.js:119 static/js/zamboni/discovery-all.js:13154
 msgid "Add-on has not been updated to support default-to-compatible."
 msgstr "Tillägg har inte uppdaterats för att stödja kompatibel-till-standard."
 
-#: static/js/zamboni/buttons.js:117
+#: static/js/common-all.js:1888 static/js/impala-all.js:1973 static/js/zamboni/buttons.js:124 static/js/zamboni/discovery-all.js:13159
 msgid "You need to be using Firefox 10.0 or higher."
 msgstr "Du måste använda Firefox 10.0 eller senare."
 
-#: static/js/zamboni/buttons.js:129
-msgid ""
-"Mozilla has marked this version as incompatible with your Firefox version."
-msgstr ""
-"Mozilla har markerat denna version som inkompatibel med din Firefox-version."
+#: static/js/common-all.js:1900 static/js/impala-all.js:1985 static/js/zamboni/buttons.js:136 static/js/zamboni/discovery-all.js:13171
+msgid "Mozilla has marked this version as incompatible with your Firefox version."
+msgstr "Mozilla har markerat denna version som inkompatibel med din Firefox-version."
 
 #. L10n: {0} is an platform like Windows or Linux.
-#: static/js/zamboni/buttons.js:210
+#: static/js/common-all.js:1981 static/js/impala-all.js:2066 static/js/zamboni/buttons.js:217 static/js/zamboni/discovery-all.js:13252
 msgid "Install for {0} anyway"
 msgstr "Installera för {0} ändå"
 
-#: static/js/zamboni/buttons.js:210
+#: static/js/common-all.js:1981 static/js/impala-all.js:2066 static/js/zamboni/buttons.js:217 static/js/zamboni/discovery-all.js:13252
 msgid "Download for {0} anyway"
 msgstr "Hämta för {0} ändå"
 
-#: static/js/zamboni/buttons.js:267
+#: static/js/common-all.js:2038 static/js/impala-all.js:2123 static/js/zamboni/buttons.js:274 static/js/zamboni/discovery-all.js:13309
 msgid "Not available for your platform"
 msgstr "Ej tillgänglig för din plattform"
 
 #. L10n: {0} is an app name, {1} is the app version.
-#: static/js/zamboni/buttons.js:278 static/js/zamboni/buttons.js:315
+#: static/js/common-all.js:2049 static/js/common-all.js:2086 static/js/impala-all.js:2134 static/js/impala-all.js:2171 static/js/zamboni/buttons.js:286 static/js/zamboni/buttons.js:324
+#: static/js/zamboni/discovery-all.js:13320 static/js/zamboni/discovery-all.js:13357
 msgid "Not available for {0} {1}"
 msgstr "Ej tillgänglig för {0} {1}"
 
-#: static/js/zamboni/buttons.js:341
+#: static/js/common-all.js:2112 static/js/impala-all.js:2197 static/js/zamboni/buttons.js:351 static/js/zamboni/discovery-all.js:13383
 msgid "Works with {app} {min} - {max}"
 msgstr "Fungerar med {app} {min} - {max}"
 
-#: static/js/zamboni/buttons.js:343
+#: static/js/common-all.js:2114 static/js/impala-all.js:2199 static/js/zamboni/buttons.js:353 static/js/zamboni/discovery-all.js:13385
 msgid "View other versions"
 msgstr "Visa andra versioner"
 
-#: static/js/zamboni/buttons.js:391
+#: static/js/common-all.js:2162 static/js/impala-all.js:2247 static/js/zamboni/buttons.js:401 static/js/zamboni/discovery-all.js:13433
 msgid "Only with Firefox — Get Firefox Now!"
 msgstr "Endast med Firefox — Hämta Firefox nu!"
 
-#: static/js/zamboni/buttons.js:507 static/js/zamboni/mobile/buttons.js:43
-msgid ""
-"Sorry, you need a Mozilla-based browser (such as Firefox) to install a "
-"search plugin."
-msgstr ""
-"Tyvärr, du behöver en Mozillabaserad webbläsare (som Firefox) för att "
-"installera ett söktillägg."
+#: static/js/common-all.js:2278 static/js/impala-all.js:2363 static/js/zamboni/buttons.js:517 static/js/zamboni/discovery-all.js:13549 static/js/zamboni/mobile-all.js:15177
+#: static/js/zamboni/mobile/buttons.js:43
+msgid "Sorry, you need a Mozilla-based browser (such as Firefox) to install a search plugin."
+msgstr "Tyvärr, du behöver en Mozillabaserad webbläsare (som Firefox) för att installera ett söktillägg."
 
-#: static/js/zamboni/collections.js:229
-msgid "Adding to Favorites&hellip;"
-msgstr "Lägger till i favoriter&hellip;"
-
-#: static/js/zamboni/collections.js:232
-msgid "Removing Favorite&hellip;"
-msgstr "Tar bort favorit&hellip;"
-
-#: static/js/zamboni/collections.js:235
-msgid "Add to Favorites"
-msgstr "Lägg till i favoriter"
-
-#: static/js/zamboni/collections.js:238
-msgid "Remove from Favorites"
-msgstr "Ta bort från favoriter"
-
-#: static/js/zamboni/collections.js:303
-msgid "Pending"
-msgstr "Väntande"
-
-#: static/js/zamboni/collections.js:304
-msgid "Add a comment"
-msgstr "Lägg till en kommentar"
-
-#: static/js/zamboni/collections.js:304
-msgid "Comment"
-msgstr "Kommentar"
-
-#: static/js/zamboni/collections.js:305
-msgid "Remove this add-on from the collection"
-msgstr "Ta bort detta tillägg från samlingen"
-
-#: static/js/zamboni/collections.js:305 static/js/zamboni/collections.js:334
-msgid "Remove"
-msgstr "Ta bort"
-
-#: static/js/zamboni/collections.js:334
-msgid "Remove this user as a contributor"
-msgstr "Ta bort denna användare som bidragare"
-
-#: static/js/zamboni/collections.js:346
-msgid "An email address is required."
-msgstr "En e-postadress krävs."
-
-#: static/js/zamboni/collections.js:364
-msgid "You cannot add yourself as a contributor."
-msgstr "Du kan inte lägga till dig själv som en bidragare."
-
-#: static/js/zamboni/collections.js:366
-msgid "You have already added that user."
-msgstr "Du har redan lagt till den användaren."
-
-#: static/js/zamboni/collections.js:573
-msgid "Add to favorites"
-msgstr "Lägg till i favoriter"
-
-#: static/js/zamboni/collections.js:577
-msgid "Remove from favorites"
-msgstr "Ta bort från favoriter"
-
-#: static/js/zamboni/collections.js:604
-msgid "Stop following"
-msgstr "Sluta följa"
-
-#: static/js/zamboni/devhub.js:110
-msgid "Your browser does not support the video tag"
-msgstr "Din webbläsare stöder inte videotaggen"
-
-#: static/js/zamboni/devhub.js:371
-msgid "Changes Saved"
-msgstr "Ändringar sparade"
-
-#: static/js/zamboni/devhub.js:387
-msgid "Enter a new author's email address"
-msgstr "Ange en ny e-postadress till utvecklaren"
-
-#: static/js/zamboni/devhub.js:536
-msgid "There was an error uploading your file."
-msgstr "Det var problem med uppladdningen av filen."
-
-#: static/js/zamboni/devhub.js:681
-msgid "{files} file"
-msgid_plural "{files} files"
-msgstr[0] "{files} fil"
-msgstr[1] "{files} filer"
-
-#: static/js/zamboni/devhub.js:684
-msgid "{reviews} user review"
-msgid_plural "{reviews} user reviews"
-msgstr[0] "{reviews} användarrecension"
-msgstr[1] "{reviews} användarrecensioner"
-
-#: static/js/zamboni/devhub.js:796
-msgid "Learn more"
-msgstr "Lär dig mer"
-
-#: static/js/zamboni/devhub.js:800
-msgid "Example"
-msgstr "Exempel"
-
-#: static/js/zamboni/devhub.js:1130
-msgid "Image changes being processed"
-msgstr "Bildändringar behandlas"
-
-#: static/js/zamboni/devhub.js:1280
-msgid "Must be a valid e-mail address."
-msgstr "Måste vara en giltig e-postadress."
-
-#: static/js/zamboni/devhub_search.js:8
-msgid "No results found."
-msgstr "Inga träffar hittades."
-
-#: static/js/zamboni/editors.js:121
-msgid "{name} was viewing this page first."
-msgstr "{name} tittade på sidan först."
-
-#: static/js/zamboni/editors.js:171
-msgid "Receipt checked by app."
-msgstr "Kvitto kontrollerad av app."
-
-#: static/js/zamboni/editors.js:173
-msgid "Receipt was not checked by app."
-msgstr "Kvitto inte kontrollerad av app."
-
-#: static/js/zamboni/editors.js:244
-msgid "{name} was viewing this add-on first."
-msgstr "{name} tittade på tillägget först."
-
-#: static/js/zamboni/editors.js:255
-msgid "Loading&hellip;"
-msgstr "Laddar&hellip;"
-
-#: static/js/zamboni/editors.js:260
-msgid "Version Notes"
-msgstr "Versionsanteckningar"
-
-#: static/js/zamboni/editors.js:265
-msgid "Notes for Reviewers"
-msgstr "Meddelande för granskare"
-
-#: static/js/zamboni/editors.js:270
-msgid "No version notes found"
-msgstr "Inga versionsanteckningar hittades"
-
-#: static/js/zamboni/editors.js:330
-msgid "Average Reviews"
-msgstr "Genomsnittliga omdömen"
-
-#: static/js/zamboni/editors.js:386
-msgid "Number of Reviews"
-msgstr "Antal recensioner"
-
-#: static/js/zamboni/editors.js:445
-msgid "Error loading translation"
-msgstr "Fel vid laddning av översättning"
-
-#: static/js/zamboni/files.js:411 static/js/zamboni/validator.js:261
-msgid "Ignore this message in future updates"
-msgstr "Ignorera det här meddelandet i framtida uppdateringar"
-
-#: static/js/zamboni/files.js:417 static/js/zamboni/validator.js:284
-msgid "Severity for automated signing:"
-msgstr "Allvarlighetsgrad för automatisk signering:"
-
-#: static/js/zamboni/global.js:410
+#: static/js/common-all.js:9088 static/js/impala-all.js:9649 static/js/zamboni/global.js:410
 msgid "Loading..."
 msgstr "Laddar..."
 
 #. L10n: {0} is the number of characters left.
-#: static/js/zamboni/global.js:474
+#: static/js/common-all.js:9152 static/js/impala-all.js:9713 static/js/zamboni/global.js:474
 msgid "<b>{0}</b> character left."
 msgid_plural "<b>{0}</b> characters left."
 msgstr[0] "<b>{0}</b> tecken kvar."
 msgstr[1] "<b>{0}</b> tecken kvar."
 
-#: static/js/zamboni/init.js:28
-msgid ""
-"This feature is temporarily disabled while we perform website maintenance. "
-"Please check back a little later."
-msgstr ""
-"Den här funktionen är tillfälligt inaktiverad under tiden vi utför underhåll"
-" på webbplatsen. Vänligen kom tillbaka lite senare."
+#: static/js/common-all.js:9589 static/js/common-min.js:6 static/js/impala-all.js:10052 static/js/impala-min.js:6 static/js/common/ratingwidget.js:31 static/js/zamboni/mobile-all.js:16123
+#: static/js/zamboni/mobile-min.js:6
+msgid "{0} star"
+msgid_plural "{0} stars"
+msgstr[0] "{0} stjärna"
+msgstr[1] "{0} stjärnor"
 
-#: static/js/zamboni/l10n.js:45
+#: static/js/common-all.js:9676 static/js/common-min.js:6 static/js/impala-all.js:10139 static/js/impala-min.js:6 static/js/zamboni/l10n.js:45
 msgid "Remove this localization"
 msgstr "Ta bort denna översättning"
 
-#: static/js/zamboni/password-strength.js:20
+#: static/js/common-all.js:10193 static/js/common-min.js:6 static/js/impala-all.js:10674 static/js/impala-min.js:6 static/js/zamboni/discovery-all.js:13678
+msgid "close"
+msgstr ""
+
+#: static/js/common-all.js:10860 static/js/common-min.js:6 static/js/impala-all.js:11481 static/js/impala-min.js:6 static/js/impala/reviews.js:23 static/js/zamboni/reviews.js:18
+msgid "Flagged for review"
+msgstr "Flaggad för granskning"
+
+#: static/js/common-all.js:10876 static/js/common-min.js:6 static/js/impala-all.js:11498 static/js/impala-min.js:6 static/js/impala/reviews.js:40 static/js/zamboni/reviews.js:34
+msgid "Your input is required"
+msgstr "Du måste ange något"
+
+#: static/js/common-all.js:10945 static/js/common-min.js:6 static/js/impala-all.js:11610 static/js/impala-min.js:7 static/js/impala/reviews.js:152 static/js/zamboni/reviews.js:103
+msgid "Marked for deletion"
+msgstr "Markerad för borttagning"
+
+#: static/js/common-all.js:11573 static/js/common-min.js:7 static/js/impala-all.js:13809 static/js/impala-min.js:8 static/js/zamboni/collections.js:229
+msgid "Adding to Favorites&hellip;"
+msgstr "Lägger till i favoriter&hellip;"
+
+#: static/js/common-all.js:11576 static/js/common-min.js:7 static/js/impala-all.js:13812 static/js/impala-min.js:8 static/js/zamboni/collections.js:232
+msgid "Removing Favorite&hellip;"
+msgstr "Tar bort favorit&hellip;"
+
+#: static/js/common-all.js:11579 static/js/common-min.js:7 static/js/impala-all.js:13815 static/js/impala-min.js:8 static/js/zamboni/collections.js:235
+msgid "Add to Favorites"
+msgstr "Lägg till i favoriter"
+
+#: static/js/common-all.js:11582 static/js/common-min.js:7 static/js/impala-all.js:13818 static/js/impala-min.js:8 static/js/zamboni/collections.js:238
+msgid "Remove from Favorites"
+msgstr "Ta bort från favoriter"
+
+#: static/js/common-all.js:11647 static/js/common-min.js:7 static/js/impala-all.js:13883 static/js/impala-min.js:8 static/js/zamboni/collections.js:303
+msgid "Pending"
+msgstr "Väntande"
+
+#: static/js/common-all.js:11648 static/js/common-min.js:7 static/js/impala-all.js:13884 static/js/impala-min.js:8 static/js/zamboni/collections.js:304
+msgid "Add a comment"
+msgstr "Lägg till en kommentar"
+
+#: static/js/common-all.js:11648 static/js/common-min.js:7 static/js/impala-all.js:13884 static/js/impala-min.js:8 static/js/zamboni/collections.js:304
+msgid "Comment"
+msgstr "Kommentar"
+
+#: static/js/common-all.js:11649 static/js/common-min.js:7 static/js/impala-all.js:13885 static/js/impala-min.js:8 static/js/zamboni/collections.js:305
+msgid "Remove this add-on from the collection"
+msgstr "Ta bort detta tillägg från samlingen"
+
+#: static/js/common-all.js:11649 static/js/common-all.js:11678 static/js/common-min.js:7 static/js/impala-all.js:13885 static/js/impala-all.js:13914 static/js/impala-min.js:8
+#: static/js/zamboni/collections.js:305 static/js/zamboni/collections.js:334
+msgid "Remove"
+msgstr "Ta bort"
+
+#: static/js/common-all.js:11678 static/js/common-min.js:7 static/js/impala-all.js:13914 static/js/impala-min.js:8 static/js/zamboni/collections.js:334
+msgid "Remove this user as a contributor"
+msgstr "Ta bort denna användare som bidragare"
+
+#: static/js/common-all.js:11690 static/js/common-min.js:7 static/js/impala-all.js:13926 static/js/impala-min.js:8 static/js/zamboni/collections.js:346
+msgid "An email address is required."
+msgstr "En e-postadress krävs."
+
+#: static/js/common-all.js:11708 static/js/common-min.js:7 static/js/impala-all.js:13944 static/js/impala-min.js:8 static/js/zamboni/collections.js:364
+msgid "You cannot add yourself as a contributor."
+msgstr "Du kan inte lägga till dig själv som en bidragare."
+
+#: static/js/common-all.js:11710 static/js/common-min.js:7 static/js/impala-all.js:13946 static/js/impala-min.js:8 static/js/zamboni/collections.js:366
+msgid "You have already added that user."
+msgstr "Du har redan lagt till den användaren."
+
+#: static/js/common-all.js:11917 static/js/common-min.js:7 static/js/impala-all.js:14153 static/js/impala-min.js:8 static/js/zamboni/collections.js:573
+msgid "Add to favorites"
+msgstr "Lägg till i favoriter"
+
+#: static/js/common-all.js:11921 static/js/common-min.js:7 static/js/impala-all.js:14157 static/js/impala-min.js:8 static/js/zamboni/collections.js:577
+msgid "Remove from favorites"
+msgstr "Ta bort från favoriter"
+
+#: static/js/common-all.js:11939 static/js/common-min.js:7 static/js/impala-all.js:14175 static/js/impala-all.js:14233 static/js/impala-min.js:8 static/js/impala/collections.js:10
+#: static/js/zamboni/collections.js:595
+msgid "Follow this Collection"
+msgstr "Följ denna samling"
+
+#: static/js/common-all.js:11948 static/js/common-min.js:7 static/js/impala-all.js:14184 static/js/impala-min.js:8 static/js/zamboni/collections.js:604
+msgid "Stop following"
+msgstr "Sluta följa"
+
+#: static/js/common-all.js:12096 static/js/common-min.js:7 static/js/zamboni/password-strength.js:20
 msgid "Password strength:"
 msgstr "Lösenordsstyrka:"
 
-#: static/js/zamboni/password-strength.js:26
+#: static/js/common-all.js:12102 static/js/common-min.js:7 static/js/zamboni/password-strength.js:26
 msgid "At least {0} character left."
 msgid_plural "At least {0} characters left."
 msgstr[0] "Minst {0} tecken kvar."
 msgstr[1] "Minst {0} tecken kvar."
 
-#: static/js/zamboni/themes_review.js:176
-msgid "Requested Info"
-msgstr "Begärd info"
+#: static/js/common-all.js:12286 static/js/common-min.js:7 static/js/impala-all.js:14632 static/js/impala-min.js:8 static/js/impala/suggestions.js:39
+msgid "Search themes for <b>{0}</b>"
+msgstr "Sök teman för <b>{0}</b>"
 
-#: static/js/zamboni/themes_review.js:177
-msgid "Flagged"
-msgstr "Flaggad"
+#: static/js/common-all.js:12288 static/js/common-min.js:7 static/js/impala-all.js:14634 static/js/impala-min.js:8 static/js/impala/suggestions.js:41
+msgid "Search apps for <b>{0}</b>"
+msgstr "Sök appar för <b>{0}</b>"
 
-#: static/js/zamboni/themes_review.js:178
-msgid "Duplicate"
-msgstr "Duplicera"
+#: static/js/common-all.js:12290 static/js/common-min.js:7 static/js/impala-all.js:14636 static/js/impala-min.js:8 static/js/impala/suggestions.js:43
+msgid "Search add-ons for <b>{0}</b>"
+msgstr "Sök tillägg för <b>{0}</b>"
 
-#: static/js/zamboni/themes_review.js:179
-msgid "Rejected"
-msgstr "Ej godkänd"
+#: static/js/common-all.js:12521 static/js/common-min.js:7 static/js/impala-all.js:14867 static/js/impala-min.js:8 static/js/impala/site_suggestions.js:46
+msgid "Category"
+msgstr "Kategori"
 
-#: static/js/zamboni/themes_review.js:180
-msgid "Approved"
-msgstr "Godkänd"
+#. L10n: {0} is an app name.
+#: static/js/impala-all.js:11632 static/js/impala-min.js:7 static/js/impala/listing.js:11 static/js/zamboni/themes.js:13
+msgid "This theme is incompatible with your version of {0}"
+msgstr "Detta tema är inte kompatibelt med din version av {0}"
 
-#: static/js/zamboni/themes_review.js:424
-msgid "No results found"
-msgstr "Inga resultat hittades"
+#: static/js/impala-all.js:12146 static/js/impala-all.js:14331 static/js/impala-min.js:7 static/js/impala-min.js:8 static/js/common/upload-image.js:97 static/js/impala/users.js:51
+#: static/js/zamboni/devhub-all.js:894 static/js/zamboni/devhub-min.js:1
+msgid "Images must be either PNG or JPG."
+msgstr "Bilder måste vara antingen PNG eller JPG."
 
-#: static/js/zamboni/themes_review_templates.js:31
-msgid "Theme"
-msgstr "Tema"
+#: static/js/impala-all.js:12150 static/js/impala-min.js:7 static/js/common/upload-image.js:101 static/js/zamboni/devhub-all.js:898 static/js/zamboni/devhub-min.js:1
+msgid "Videos must be in WebM."
+msgstr "Videor måste vara i WebM."
 
-#: static/js/zamboni/themes_review_templates.js:33
-msgid "Reviewer"
-msgstr "Granskare"
+#: static/js/impala-all.js:12177 static/js/impala-min.js:7 static/js/common/upload-addon.js:41 static/js/common/upload-image.js:128 static/js/zamboni/devhub-all.js:272
+#: static/js/zamboni/devhub-all.js:925 static/js/zamboni/devhub-min.js:1
+msgid "There was a problem contacting the server."
+msgstr "Det gick inte att kontakta servern."
 
-#: static/js/zamboni/themes_review_templates.js:35
-msgid "Status"
-msgstr "Status"
+#: static/js/impala-all.js:13298 static/js/impala-min.js:7 static/js/impala/persona_creation.js:60
+msgid "All Rights Reserved"
+msgstr "Med ensamrätt"
 
-#: static/js/zamboni/validator.js:80
+#: static/js/impala-all.js:13302 static/js/impala-min.js:7 static/js/impala/persona_creation.js:64
+msgid "Creative Commons Attribution 3.0"
+msgstr "Creative Commons Attribution 3.0"
+
+#: static/js/impala-all.js:13307 static/js/impala-min.js:7 static/js/impala/persona_creation.js:69
+msgid "Creative Commons Attribution-NonCommercial 3.0"
+msgstr "Creative Commons Attribution-NonCommercial 3.0"
+
+#: static/js/impala-all.js:13312 static/js/impala-min.js:7 static/js/impala/persona_creation.js:74
+msgid "Creative Commons Attribution-NonCommercial-NoDerivs 3.0"
+msgstr "Creative Commons Attribution-NonCommercial-NoDerivs 3.0"
+
+#: static/js/impala-all.js:13317 static/js/impala-min.js:7 static/js/impala/persona_creation.js:79
+msgid "Creative Commons Attribution-NonCommercial-Share Alike 3.0"
+msgstr "Creative Commons Attribution-NonCommercial-Share Alike 3.0"
+
+#: static/js/impala-all.js:13322 static/js/impala-min.js:7 static/js/impala/persona_creation.js:84
+msgid "Creative Commons Attribution-NoDerivs 3.0"
+msgstr "Creative Commons Attribution-NoDerivs 3.0"
+
+#: static/js/impala-all.js:13327 static/js/impala-min.js:7 static/js/impala/persona_creation.js:89
+msgid "Creative Commons Attribution-ShareAlike 3.0"
+msgstr "Creative Commons Attribution-ShareAlike 3.0"
+
+#: static/js/impala-all.js:13530 static/js/impala-min.js:7 static/js/impala/persona_creation.js:292
+msgid "Your Theme's Name"
+msgstr "Ditt temas namn"
+
+#: static/js/impala-all.js:14242 static/js/impala-min.js:8 static/js/impala/collections.js:19
+msgid "Stop Following"
+msgstr "Sluta följa"
+
+#: static/js/impala-all.js:14243 static/js/impala-min.js:8 static/js/impala/collections.js:20
+msgid "Following"
+msgstr "Följer"
+
+#: static/js/impala-all.js:14313 static/js/impala-min.js:8 static/js/impala/users.js:33
+msgid "use original"
+msgstr "använd original"
+
+#: static/js/impala-all.js:14523 static/js/impala-min.js:8 static/js/impala/search.js:114
+msgid "Updating results&hellip;"
+msgstr "Uppdaterar resultat&hellip;"
+
+#: static/js/common/upload-addon.js:69 static/js/zamboni/devhub-all.js:300 static/js/zamboni/devhub-min.js:1
+msgid "Select a file..."
+msgstr "Välj en fil..."
+
+#: static/js/common/upload-addon.js:70 static/js/zamboni/devhub-all.js:301 static/js/zamboni/devhub-min.js:1
+msgid "Your add-on should end with .xpi, .jar or .xml"
+msgstr "Ditt tillägg bör sluta med .xpi, .jar eller .xml"
+
+#. L10n: {0} is the percent of the file that has been uploaded.
+#: static/js/common/upload-addon.js:104 static/js/zamboni/devhub-all.js:335 static/js/zamboni/devhub-min.js:1
+#, python-format
+msgid "{0}% complete"
+msgstr "{0}% klart"
+
+#. L10n: "{bytes uploaded} of {total filesize}".
+#: static/js/common/upload-addon.js:107 static/js/zamboni/devhub-all.js:338 static/js/zamboni/devhub-min.js:1
+msgid "{0} of {1}"
+msgstr "{0} av {1}"
+
+#: static/js/common/upload-addon.js:140 static/js/zamboni/devhub-all.js:371 static/js/zamboni/devhub-min.js:1
+msgid "Cancel"
+msgstr "Avbryt"
+
+#: static/js/common/upload-addon.js:162 static/js/zamboni/devhub-all.js:393 static/js/zamboni/devhub-min.js:1
+msgid "Uploading {0}"
+msgstr "Laddar upp {0}"
+
+#: static/js/common/upload-addon.js:189 static/js/zamboni/devhub-all.js:420 static/js/zamboni/devhub-min.js:1
+msgid "Error with {0}"
+msgstr "Fel med {0}"
+
+#: static/js/common/upload-addon.js:194 static/js/zamboni/devhub-all.js:425 static/js/zamboni/devhub-min.js:1
+msgid "Your add-on failed validation with {0} error."
+msgid_plural "Your add-on failed validation with {0} errors."
+msgstr[0] "Ditt tillägg misslyckades validering med {0} fel."
+msgstr[1] "Ditt tillägg misslyckades validering med {0} fel."
+
+#: static/js/common/upload-addon.js:208 static/js/zamboni/devhub-all.js:439 static/js/zamboni/devhub-min.js:1
+msgid "&hellip;and {0} more"
+msgid_plural "&hellip;and {0} more"
+msgstr[0] "&hellip;och {0} mer"
+msgstr[1] "&hellip;och {0} fler"
+
+#: static/js/common/upload-addon.js:222 static/js/common/upload-addon.js:497 static/js/zamboni/devhub-all.js:453 static/js/zamboni/devhub-all.js:743 static/js/zamboni/devhub-min.js:1
+msgid "See full validation report"
+msgstr "Se fullständig valideringsrapport"
+
+#: static/js/common/upload-addon.js:234 static/js/zamboni/devhub-all.js:465 static/js/zamboni/devhub-min.js:1
+msgid "Validating {0}"
+msgstr "Validerar {0}"
+
+#. L10n: first argument is an HTTP status code
+#: static/js/common/upload-addon.js:273 static/js/zamboni/devhub-all.js:504 static/js/zamboni/devhub-min.js:1
+msgid "Received an empty response from the server; status: {0}"
+msgstr "Fick ett tomt svar från servern; status: {0}"
+
+#: static/js/common/upload-addon.js:370 static/js/zamboni/devhub-all.js:604 static/js/zamboni/devhub-min.js:1
+msgid "Unexpected server error while validating."
+msgstr "Oväntat serverfel under validering."
+
+#: static/js/common/upload-addon.js:409 static/js/zamboni/devhub-all.js:643 static/js/zamboni/devhub-min.js:1
+msgid "Finished validating {0}"
+msgstr "Validering klar för {0}"
+
+#: static/js/common/upload-addon.js:415 static/js/zamboni/devhub-all.js:649 static/js/zamboni/devhub-min.js:1
+msgid "Your add-on validation timed out, it will be manually reviewed."
+msgstr "Ditt tilläggs validering gjorde timeout, det kommer att granskas manuellt."
+
+#: static/js/common/upload-addon.js:418 static/js/zamboni/devhub-all.js:652 static/js/zamboni/devhub-min.js:1
+msgid "Your add-on was validated with no errors and {0} warning."
+msgid_plural "Your add-on was validated with no errors and {0} warnings."
+msgstr[0] "Ditt tillägg validerades utan fel och {0} varning."
+msgstr[1] "Ditt tillägg validerades utan fel och {0} varningar."
+
+#: static/js/common/upload-addon.js:423 static/js/zamboni/devhub-all.js:657 static/js/zamboni/devhub-min.js:1
+msgid "Your add-on was validated with no errors and {0} message."
+msgid_plural "Your add-on was validated with no errors and {0} messages."
+msgstr[0] "Ditt tillägg validerades utan fel och {0} meddelande."
+msgstr[1] "Ditt tillägg validerades utan fel och {0} meddelanden."
+
+#: static/js/common/upload-addon.js:428 static/js/zamboni/devhub-all.js:662 static/js/zamboni/devhub-min.js:1
+msgid "Your add-on was validated with no errors or warnings."
+msgstr "Ditt tillägg validerades utan fel eller varningar."
+
+#: static/js/common/upload-addon.js:443 static/js/zamboni/devhub-all.js:677 static/js/zamboni/devhub-min.js:1
+msgid "Your submission will be automatically signed."
+msgstr "Ditt bidrag kommer att signeras automatiskt."
+
+#: static/js/common/upload-addon.js:450 static/js/zamboni/devhub-all.js:696 static/js/zamboni/devhub-min.js:1
+msgid "Include detailed version notes (this can be done in the next step)."
+msgstr "Inkludera detaljerade versionsanteckningar (detta kan göras i nästa steg)."
+
+#: static/js/common/upload-addon.js:451 static/js/zamboni/devhub-all.js:697 static/js/zamboni/devhub-min.js:1
+msgid "If your add-on requires an account to a website in order to be fully tested, include a test username and password in the Notes to Reviewer (this can be done in the next step)."
+msgstr "Om ditt tillägg kräver ett konto till en webbplats för att bli fullständigt testat, inkludera ett test användarnamn och lösenord i meddelande till granskaren (detta kan göras i nästa steg)."
+
+#: static/js/common/upload-addon.js:452 static/js/zamboni/devhub-all.js:698 static/js/zamboni/devhub-min.js:1
+msgid "If your add-on is intended for a limited audience you should choose Preliminary Review instead of Full Review."
+msgstr "Om ditt tillägg är avsedd för en begränsad publik bör du välja preliminär granskning istället för fullständig granskning."
+
+#: static/js/common/upload-addon.js:465 static/js/zamboni/devhub-all.js:711 static/js/zamboni/devhub-min.js:1
+msgid "Add-on submission checklist"
+msgstr "Checklista för att skicka in tillägg"
+
+#: static/js/common/upload-addon.js:466 static/js/zamboni/devhub-all.js:712 static/js/zamboni/devhub-min.js:1
+msgid "Please verify the following points before finalizing your submission. This will minimize delays or misunderstanding during the review process:"
+msgstr "Vänligen kontrollera följande punkter innan du slutför ditt bidrag. Detta kommer att minimera förseningar eller missförstånd under granskningsprocessen:"
+
+#: static/js/common/upload-addon.js:468 static/js/zamboni/devhub-all.js:714 static/js/zamboni/devhub-min.js:1
+msgid ""
+"Compiled binaries, as well as minified or obfuscated scripts (excluding known libraries) need to have their sources submitted separately for review. Make sure that you use the source code upload "
+"field to avoid having your submission rejected."
+msgstr ""
+"Kompilerade binärfiler, liksom minifierad eller förvrängda skript (exklusive kända bibliotek) måste skicka in sina källor separat för granskning. Se till att du använder uppladdningsfältet för "
+"källkoden för att undvika att ditt bidrag avvisas."
+
+#: static/js/common/upload-addon.js:486 static/js/zamboni/devhub-all.js:732 static/js/zamboni/devhub-min.js:1
+msgid "The validation process found these issues that can lead to rejections:"
+msgstr "Valideringsprocessen hittade dessa problem som kan leda till avslag:"
+
+#: static/js/common/upload-addon.js:503 static/js/zamboni/devhub-all.js:749 static/js/zamboni/devhub-min.js:1
+msgid "If you are unfamiliar with the add-ons review process, you can read about it here."
+msgstr "Om du är obekant med granskningsprocessen för tillägg, kan du läsa om det här."
+
+#: static/js/common/upload-addon.js:540 static/js/zamboni/devhub-all.js:786 static/js/zamboni/devhub-min.js:1
+msgid "Sorry, no supported platform has been found."
+msgstr "Tyvärr har ingen plattform som stöds hittats."
+
+#: static/js/common/upload-base.js:57 static/js/zamboni/devhub-all.js:187 static/js/zamboni/devhub-min.js:1
+msgid "The filetype you uploaded isn't recognized."
+msgstr "Filtypen du laddade upp är okänd."
+
+#: static/js/common/upload-base.js:79 static/js/zamboni/devhub-all.js:209 static/js/zamboni/devhub-min.js:1
+msgid "You cancelled the upload."
+msgstr "Du avbröt uppladdningen."
+
+#: static/js/impala/stats/chart.js:267 static/js/zamboni/stats-all.js:16898 static/js/zamboni/stats-min.js:5
+msgid "Week of {0}"
+msgstr "Vecka för {0}"
+
+#: static/js/impala/stats/chart.js:269 static/js/zamboni/stats-all.js:16900 static/js/zamboni/stats-min.js:5
+msgid " downloads"
+msgstr ""
+
+#: static/js/impala/stats/chart.js:270 static/js/zamboni/stats-all.js:16901 static/js/zamboni/stats-min.js:5
+msgid "{0} users"
+msgstr "{0} användare"
+
+#: static/js/impala/stats/chart.js:271 static/js/zamboni/stats-all.js:16902 static/js/zamboni/stats-min.js:5
+msgid "{0} add-ons"
+msgstr "{0} tillägg"
+
+#: static/js/impala/stats/chart.js:272 static/js/zamboni/stats-all.js:16903 static/js/zamboni/stats-min.js:5
+msgid "{0} collections"
+msgstr "{0} samlingar"
+
+#: static/js/impala/stats/chart.js:273 static/js/zamboni/stats-all.js:16904 static/js/zamboni/stats-min.js:5
+msgid "{0} reviews"
+msgstr "{0} recensioner"
+
+#: static/js/impala/stats/chart.js:275 static/js/zamboni/stats-all.js:16906 static/js/zamboni/stats-min.js:5
+msgid "{0} sales"
+msgstr "{0} försäljningar"
+
+#: static/js/impala/stats/chart.js:276 static/js/zamboni/stats-all.js:16907 static/js/zamboni/stats-min.js:5
+msgid "{0} refunds"
+msgstr "{0} återbetalningar"
+
+#: static/js/impala/stats/chart.js:277 static/js/zamboni/stats-all.js:16908 static/js/zamboni/stats-min.js:5
+msgid "{0} installs"
+msgstr "{0} installationer"
+
+#: static/js/impala/stats/chart.js:369 static/js/impala/stats/csv_keys.js:3 static/js/impala/stats/csv_keys.js:109 static/js/zamboni/stats-all.js:15284 static/js/zamboni/stats-all.js:15390
+#: static/js/zamboni/stats-all.js:17000 static/js/zamboni/stats-min.js:4 static/js/zamboni/stats-min.js:5
+msgid "Downloads"
+msgstr "Nedladdningar"
+
+#: static/js/impala/stats/chart.js:379 static/js/impala/stats/csv_keys.js:6 static/js/impala/stats/csv_keys.js:110 static/js/zamboni/stats-all.js:15287 static/js/zamboni/stats-all.js:15391
+#: static/js/zamboni/stats-all.js:17010 static/js/zamboni/stats-min.js:4 static/js/zamboni/stats-min.js:5
+msgid "Daily Users"
+msgstr "Dagliga användare"
+
+#: static/js/impala/stats/chart.js:410 static/js/zamboni/stats-all.js:17041 static/js/zamboni/stats-min.js:5
+msgid "Amount, in USD"
+msgstr "Belopp, i USD"
+
+#: static/js/impala/stats/chart.js:421 static/js/impala/stats/csv_keys.js:104 static/js/zamboni/stats-all.js:15385 static/js/zamboni/stats-all.js:17052 static/js/zamboni/stats-min.js:5
+msgid "Number of Contributions"
+msgstr "Antal bidrag"
+
+#: static/js/impala/stats/chart.js:447 static/js/zamboni/stats-all.js:17078 static/js/zamboni/stats-min.js:5
+msgid "More Info..."
+msgstr "Mer info..."
+
+#. L10n: {0} is an ISO-formatted date.
+#: static/js/impala/stats/chart.js:451 static/js/zamboni/stats-all.js:17082 static/js/zamboni/stats-min.js:5
+msgid "Details for {0}"
+msgstr "Detaljer för {0}"
+
+#: static/js/impala/stats/csv_keys.js:9 static/js/zamboni/stats-all.js:15290 static/js/zamboni/stats-min.js:4
+msgid "Collections Created"
+msgstr "Samlingar skapade"
+
+#: static/js/impala/stats/csv_keys.js:12 static/js/zamboni/stats-all.js:15293 static/js/zamboni/stats-min.js:4
+msgid "Add-ons in Use"
+msgstr "Tillägg i användning"
+
+#: static/js/impala/stats/csv_keys.js:15 static/js/zamboni/stats-all.js:15296 static/js/zamboni/stats-min.js:4
+msgid "Add-ons Created"
+msgstr "Tillägg skapat"
+
+#: static/js/impala/stats/csv_keys.js:18 static/js/zamboni/stats-all.js:15299 static/js/zamboni/stats-min.js:4
+msgid "Add-ons Downloaded"
+msgstr "Tillägg nedladdat"
+
+#: static/js/impala/stats/csv_keys.js:21 static/js/zamboni/stats-all.js:15302 static/js/zamboni/stats-min.js:4
+msgid "Add-ons Updated"
+msgstr "Tillägg uppdaterad"
+
+#: static/js/impala/stats/csv_keys.js:24 static/js/zamboni/stats-all.js:15305 static/js/zamboni/stats-min.js:4
+msgid "Reviews Written"
+msgstr "Recensioner skrivna"
+
+#: static/js/impala/stats/csv_keys.js:27 static/js/zamboni/stats-all.js:15308 static/js/zamboni/stats-min.js:4
+msgid "User Signups"
+msgstr "Användarregistreringar"
+
+#: static/js/impala/stats/csv_keys.js:30 static/js/zamboni/stats-all.js:15311 static/js/zamboni/stats-min.js:4
+msgid "Subscribers"
+msgstr "Prenumeranter"
+
+#: static/js/impala/stats/csv_keys.js:33 static/js/zamboni/stats-all.js:15314 static/js/zamboni/stats-min.js:4
+msgid "Ratings"
+msgstr "Betyg"
+
+#: static/js/impala/stats/csv_keys.js:36 static/js/impala/stats/csv_keys.js:114 static/js/zamboni/stats-all.js:15317 static/js/zamboni/stats-all.js:15395 static/js/zamboni/stats-min.js:4
+#: static/js/zamboni/stats-min.js:5
+msgid "Sales"
+msgstr "Försäljning"
+
+#: static/js/impala/stats/csv_keys.js:39 static/js/impala/stats/csv_keys.js:113 static/js/zamboni/stats-all.js:15320 static/js/zamboni/stats-all.js:15394 static/js/zamboni/stats-min.js:4
+#: static/js/zamboni/stats-min.js:5
+msgid "Installs"
+msgstr "Installationer"
+
+#: static/js/impala/stats/csv_keys.js:42 static/js/zamboni/stats-all.js:15323 static/js/zamboni/stats-min.js:4
+msgid "Unknown"
+msgstr "Okänd"
+
+#: static/js/impala/stats/csv_keys.js:43 static/js/zamboni/stats-all.js:15324 static/js/zamboni/stats-min.js:4
+msgid "Add-ons Manager"
+msgstr "Tilläggshanterare"
+
+#: static/js/impala/stats/csv_keys.js:44 static/js/zamboni/stats-all.js:15325 static/js/zamboni/stats-min.js:4
+msgid "Add-ons Manager Promo"
+msgstr "Tilläggshanterare promo"
+
+#: static/js/impala/stats/csv_keys.js:45 static/js/zamboni/stats-all.js:15326 static/js/zamboni/stats-min.js:4
+msgid "Add-ons Manager Featured"
+msgstr "Tilläggshanterare utvalda"
+
+#: static/js/impala/stats/csv_keys.js:46 static/js/zamboni/stats-all.js:15327 static/js/zamboni/stats-min.js:4
+msgid "Add-ons Manager Learn More"
+msgstr "Tilläggshanterare läs mer"
+
+#: static/js/impala/stats/csv_keys.js:47 static/js/zamboni/stats-all.js:15328 static/js/zamboni/stats-min.js:4
+msgid "Search Suggestions"
+msgstr "Sökförslag"
+
+#: static/js/impala/stats/csv_keys.js:48 static/js/zamboni/stats-all.js:15329 static/js/zamboni/stats-min.js:4
+msgid "Search Results"
+msgstr "Sökresultat"
+
+#: static/js/impala/stats/csv_keys.js:49 static/js/impala/stats/csv_keys.js:50 static/js/impala/stats/csv_keys.js:51 static/js/zamboni/stats-all.js:15330 static/js/zamboni/stats-all.js:15331
+#: static/js/zamboni/stats-all.js:15332 static/js/zamboni/stats-min.js:4
+msgid "Homepage Promo"
+msgstr "Hemsida promo"
+
+#: static/js/impala/stats/csv_keys.js:52 static/js/impala/stats/csv_keys.js:53 static/js/zamboni/stats-all.js:15333 static/js/zamboni/stats-all.js:15334 static/js/zamboni/stats-min.js:4
+msgid "Homepage Featured"
+msgstr "Hemsida utvalda"
+
+#: static/js/impala/stats/csv_keys.js:54 static/js/impala/stats/csv_keys.js:55 static/js/zamboni/stats-all.js:15335 static/js/zamboni/stats-all.js:15336 static/js/zamboni/stats-min.js:4
+msgid "Homepage Up and Coming"
+msgstr "Hemsida bubblare"
+
+#: static/js/impala/stats/csv_keys.js:56 static/js/zamboni/stats-all.js:15337 static/js/zamboni/stats-min.js:4
+msgid "Homepage Most Popular"
+msgstr "Hemsida mest populära"
+
+#: static/js/impala/stats/csv_keys.js:57 static/js/impala/stats/csv_keys.js:59 static/js/zamboni/stats-all.js:15338 static/js/zamboni/stats-all.js:15340 static/js/zamboni/stats-min.js:4
+msgid "Detail Page"
+msgstr "Detaljsida"
+
+#: static/js/impala/stats/csv_keys.js:58 static/js/impala/stats/csv_keys.js:60 static/js/zamboni/stats-all.js:15339 static/js/zamboni/stats-all.js:15341 static/js/zamboni/stats-min.js:4
+msgid "Detail Page (bottom)"
+msgstr "Detaljsida (nederst)"
+
+#: static/js/impala/stats/csv_keys.js:61 static/js/zamboni/stats-all.js:15342 static/js/zamboni/stats-min.js:4
+msgid "Detail Page (Development Channel)"
+msgstr "Detaljsida (utvecklingskanal)"
+
+#: static/js/impala/stats/csv_keys.js:62 static/js/impala/stats/csv_keys.js:63 static/js/impala/stats/csv_keys.js:64 static/js/zamboni/stats-all.js:15343 static/js/zamboni/stats-all.js:15344
+#: static/js/zamboni/stats-all.js:15345 static/js/zamboni/stats-min.js:4
+msgid "Often Used With"
+msgstr "Används ofta med"
+
+#: static/js/impala/stats/csv_keys.js:65 static/js/impala/stats/csv_keys.js:66 static/js/zamboni/stats-all.js:15346 static/js/zamboni/stats-all.js:15347 static/js/zamboni/stats-min.js:4
+msgid "Others By Author"
+msgstr "Andra av utvecklaren"
+
+#: static/js/impala/stats/csv_keys.js:67 static/js/impala/stats/csv_keys.js:68 static/js/zamboni/stats-all.js:15348 static/js/zamboni/stats-all.js:15349 static/js/zamboni/stats-min.js:4
+msgid "Dependencies"
+msgstr "Beroenden"
+
+#: static/js/impala/stats/csv_keys.js:69 static/js/impala/stats/csv_keys.js:70 static/js/zamboni/stats-all.js:15350 static/js/zamboni/stats-all.js:15351 static/js/zamboni/stats-min.js:4
+msgid "Upsell"
+msgstr "Uppgradering"
+
+#: static/js/impala/stats/csv_keys.js:71 static/js/zamboni/stats-all.js:15352 static/js/zamboni/stats-min.js:4
+msgid "Meet the Developer"
+msgstr "Möt utvecklaren"
+
+#: static/js/impala/stats/csv_keys.js:72 static/js/zamboni/stats-all.js:15353 static/js/zamboni/stats-min.js:4
+msgid "User Profile"
+msgstr "Användarprofil"
+
+#: static/js/impala/stats/csv_keys.js:73 static/js/zamboni/stats-all.js:15354 static/js/zamboni/stats-min.js:4
+msgid "Version History"
+msgstr "Versionshistorik"
+
+#: static/js/impala/stats/csv_keys.js:75 static/js/zamboni/stats-all.js:15356 static/js/zamboni/stats-min.js:4
+msgid "Sharing"
+msgstr "Delning"
+
+#: static/js/impala/stats/csv_keys.js:76 static/js/zamboni/stats-all.js:15357 static/js/zamboni/stats-min.js:4
+msgid "Category Pages"
+msgstr "Kategorisidor"
+
+#: static/js/impala/stats/csv_keys.js:77 static/js/zamboni/stats-all.js:15358 static/js/zamboni/stats-min.js:4
+msgid "Collections"
+msgstr "Samlingar"
+
+#: static/js/impala/stats/csv_keys.js:78 static/js/impala/stats/csv_keys.js:79 static/js/zamboni/stats-all.js:15359 static/js/zamboni/stats-all.js:15360 static/js/zamboni/stats-min.js:4
+msgid "Category Landing Featured Carousel"
+msgstr "Kategoriöversikt: Karusell med utvalda tillägg"
+
+#: static/js/impala/stats/csv_keys.js:80 static/js/impala/stats/csv_keys.js:81 static/js/zamboni/stats-all.js:15361 static/js/zamboni/stats-all.js:15362 static/js/zamboni/stats-min.js:4
+msgid "Category Landing Top Rated"
+msgstr "Kategoriöversikt: Högst omdöme"
+
+#: static/js/impala/stats/csv_keys.js:82 static/js/impala/stats/csv_keys.js:83 static/js/zamboni/stats-all.js:15363 static/js/zamboni/stats-all.js:15364 static/js/zamboni/stats-min.js:5
+msgid "Category Landing Most Popular"
+msgstr "Kategoriöversikt: Populäraste"
+
+#: static/js/impala/stats/csv_keys.js:84 static/js/impala/stats/csv_keys.js:85 static/js/zamboni/stats-all.js:15365 static/js/zamboni/stats-all.js:15366 static/js/zamboni/stats-min.js:5
+msgid "Category Landing Recently Added"
+msgstr "Kategoriöversikt: Nyligen tillagda"
+
+#: static/js/impala/stats/csv_keys.js:86 static/js/impala/stats/csv_keys.js:87 static/js/zamboni/stats-all.js:15367 static/js/zamboni/stats-all.js:15368 static/js/zamboni/stats-min.js:5
+msgid "Browse Listing Featured Sort"
+msgstr "Bläddringslista: Sorterad efter utvalda tillägg"
+
+#: static/js/impala/stats/csv_keys.js:88 static/js/impala/stats/csv_keys.js:89 static/js/zamboni/stats-all.js:15369 static/js/zamboni/stats-all.js:15370 static/js/zamboni/stats-min.js:5
+msgid "Browse Listing Users Sort"
+msgstr "Bläddringslista: Sorterad efter användare"
+
+#: static/js/impala/stats/csv_keys.js:90 static/js/impala/stats/csv_keys.js:91 static/js/zamboni/stats-all.js:15371 static/js/zamboni/stats-all.js:15372 static/js/zamboni/stats-min.js:5
+msgid "Browse Listing Rating Sort"
+msgstr "Bläddringslista: Sorterad efter omdöme"
+
+#: static/js/impala/stats/csv_keys.js:92 static/js/impala/stats/csv_keys.js:93 static/js/zamboni/stats-all.js:15373 static/js/zamboni/stats-all.js:15374 static/js/zamboni/stats-min.js:5
+msgid "Browse Listing Created Sort"
+msgstr "Bläddringslista: Sorterad efter skapad"
+
+#: static/js/impala/stats/csv_keys.js:94 static/js/impala/stats/csv_keys.js:95 static/js/zamboni/stats-all.js:15375 static/js/zamboni/stats-all.js:15376 static/js/zamboni/stats-min.js:5
+msgid "Browse Listing Name Sort"
+msgstr "Bläddringslista: Sorterad efter namn"
+
+#: static/js/impala/stats/csv_keys.js:96 static/js/impala/stats/csv_keys.js:97 static/js/zamboni/stats-all.js:15377 static/js/zamboni/stats-all.js:15378 static/js/zamboni/stats-min.js:5
+msgid "Browse Listing Popular Sort"
+msgstr "Bläddringslista: Sorterad efter popularitet"
+
+#: static/js/impala/stats/csv_keys.js:98 static/js/impala/stats/csv_keys.js:99 static/js/zamboni/stats-all.js:15379 static/js/zamboni/stats-all.js:15380 static/js/zamboni/stats-min.js:5
+msgid "Browse Listing Updated Sort"
+msgstr "Bläddringslista: Sorterad efter uppdaterad"
+
+#: static/js/impala/stats/csv_keys.js:100 static/js/impala/stats/csv_keys.js:101 static/js/zamboni/stats-all.js:15381 static/js/zamboni/stats-all.js:15382 static/js/zamboni/stats-min.js:5
+msgid "Browse Listing Up and Coming Sort"
+msgstr "Bläddringslista: Sorterad efter bubblare"
+
+#: static/js/impala/stats/csv_keys.js:105 static/js/zamboni/stats-all.js:15386 static/js/zamboni/stats-min.js:5
+msgid "Total Amount Contributed"
+msgstr "Totalt bidragsbelopp"
+
+#: static/js/impala/stats/csv_keys.js:106 static/js/zamboni/stats-all.js:15387 static/js/zamboni/stats-min.js:5
+msgid "Average Contribution"
+msgstr "Genomsnittligt bidrag"
+
+#: static/js/impala/stats/csv_keys.js:115 static/js/zamboni/stats-all.js:15396 static/js/zamboni/stats-min.js:5
+msgid "Usage"
+msgstr "Användning"
+
+#: static/js/impala/stats/csv_keys.js:118 static/js/zamboni/stats-all.js:15399 static/js/zamboni/stats-min.js:5
+msgid "Firefox"
+msgstr "Firefox"
+
+#: static/js/impala/stats/csv_keys.js:119 static/js/zamboni/stats-all.js:15400 static/js/zamboni/stats-min.js:5
+msgid "Mozilla"
+msgstr "Mozilla"
+
+#: static/js/impala/stats/csv_keys.js:120 static/js/zamboni/stats-all.js:15401 static/js/zamboni/stats-min.js:5
+msgid "Thunderbird"
+msgstr "Thunderbird"
+
+#: static/js/impala/stats/csv_keys.js:121 static/js/zamboni/stats-all.js:15402 static/js/zamboni/stats-min.js:5
+msgid "Sunbird"
+msgstr "Sunbird"
+
+#: static/js/impala/stats/csv_keys.js:122 static/js/zamboni/stats-all.js:15403 static/js/zamboni/stats-min.js:5
+msgid "SeaMonkey"
+msgstr "SeaMonkey"
+
+#: static/js/impala/stats/csv_keys.js:123 static/js/zamboni/stats-all.js:15404 static/js/zamboni/stats-min.js:5
+msgid "Fennec"
+msgstr "Fennec"
+
+#: static/js/impala/stats/csv_keys.js:124 static/js/zamboni/stats-all.js:15405 static/js/zamboni/stats-min.js:5
+msgid "Android"
+msgstr "Android"
+
+#. L10n: {0} is an integer.
+#: static/js/impala/stats/csv_keys.js:129 static/js/zamboni/stats-all.js:15410 static/js/zamboni/stats-min.js:5
+msgid "Downloads and Daily Users, last {0} days"
+msgstr "Nedladdningar och dagliga användare de senaste {0} dagarna"
+
+#. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
+#: static/js/impala/stats/csv_keys.js:131 static/js/zamboni/stats-all.js:15412 static/js/zamboni/stats-min.js:5
+msgid "Downloads and Daily Users from {0} to {1}"
+msgstr "Nedladdningar och dagliga användare mellan {0} och {1}"
+
+#. L10n: {0} is an integer.
+#: static/js/impala/stats/csv_keys.js:135 static/js/zamboni/stats-all.js:15416 static/js/zamboni/stats-min.js:5
+msgid "Installs and Daily Users, last {0} days"
+msgstr "Installationer och dagliga användare de senaste {0} dagarna"
+
+#. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
+#: static/js/impala/stats/csv_keys.js:137 static/js/zamboni/stats-all.js:15418 static/js/zamboni/stats-min.js:5
+msgid "Installs and Daily Users from {0} to {1}"
+msgstr "Installationer och dagliga användare mellan {0} och {1}"
+
+#. L10n: {0} is an integer.
+#: static/js/impala/stats/csv_keys.js:141 static/js/zamboni/stats-all.js:15422 static/js/zamboni/stats-min.js:5
+msgid "Downloads, last {0} days"
+msgstr "Nedladdningar de senaste {0} dagarna"
+
+#. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
+#: static/js/impala/stats/csv_keys.js:143 static/js/zamboni/stats-all.js:15424 static/js/zamboni/stats-min.js:5
+msgid "Downloads from {0} to {1}"
+msgstr "Nedladdningar mellan {0} och {1}"
+
+#. L10n: {0} is an integer.
+#: static/js/impala/stats/csv_keys.js:147 static/js/zamboni/stats-all.js:15428 static/js/zamboni/stats-min.js:5
+msgid "Daily Users, last {0} days"
+msgstr "Dagliga användare de senaste {0} dagarna"
+
+#. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
+#: static/js/impala/stats/csv_keys.js:149 static/js/zamboni/stats-all.js:15430 static/js/zamboni/stats-min.js:5
+msgid "Daily Users from {0} to {1}"
+msgstr "Dagliga användare mellan {0} och {1}"
+
+#. L10n: {0} is an integer.
+#: static/js/impala/stats/csv_keys.js:153 static/js/zamboni/stats-all.js:15434 static/js/zamboni/stats-min.js:5
+msgid "Applications, last {0} days"
+msgstr "Applikationer de senaste {0} dagarna"
+
+#. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
+#: static/js/impala/stats/csv_keys.js:155 static/js/zamboni/stats-all.js:15436 static/js/zamboni/stats-min.js:5
+msgid "Applications from {0} to {1}"
+msgstr "Applikationer mellan {0} och {1}"
+
+#. L10n: {0} is an integer.
+#: static/js/impala/stats/csv_keys.js:159 static/js/zamboni/stats-all.js:15440 static/js/zamboni/stats-min.js:5
+msgid "Platforms, last {0} days"
+msgstr "Plattformar de senaste {0} dagarna"
+
+#. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
+#: static/js/impala/stats/csv_keys.js:161 static/js/zamboni/stats-all.js:15442 static/js/zamboni/stats-min.js:5
+msgid "Platforms from {0} to {1}"
+msgstr "Plattformar mellan {0} och {1}"
+
+#. L10n: {0} is an integer.
+#: static/js/impala/stats/csv_keys.js:165 static/js/zamboni/stats-all.js:15446 static/js/zamboni/stats-min.js:5
+msgid "Languages, last {0} days"
+msgstr "Språk de senaste {0} dagarna"
+
+#. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
+#: static/js/impala/stats/csv_keys.js:167 static/js/zamboni/stats-all.js:15448 static/js/zamboni/stats-min.js:5
+msgid "Languages from {0} to {1}"
+msgstr "Språk mellan {0} och {1}"
+
+#. L10n: {0} is an integer.
+#: static/js/impala/stats/csv_keys.js:171 static/js/zamboni/stats-all.js:15452 static/js/zamboni/stats-min.js:5
+msgid "Add-on Versions, last {0} days"
+msgstr "Tilläggsversioner de senaste {0} dagarna"
+
+#. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
+#: static/js/impala/stats/csv_keys.js:173 static/js/zamboni/stats-all.js:15454 static/js/zamboni/stats-min.js:5
+msgid "Add-on Versions from {0} to {1}"
+msgstr "Tilläggsversioner mellan {0} och {1}"
+
+#. L10n: {0} is an integer.
+#: static/js/impala/stats/csv_keys.js:177 static/js/zamboni/stats-all.js:15458 static/js/zamboni/stats-min.js:5
+msgid "Add-on Status, last {0} days"
+msgstr "Tilläggsstatus de senaste {0} dagarna"
+
+#. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
+#: static/js/impala/stats/csv_keys.js:179 static/js/zamboni/stats-all.js:15460 static/js/zamboni/stats-min.js:5
+msgid "Add-on Status from {0} to {1}"
+msgstr "Tilläggsstatus mellan {0} och {1}"
+
+#. L10n: {0} is an integer.
+#: static/js/impala/stats/csv_keys.js:183 static/js/zamboni/stats-all.js:15464 static/js/zamboni/stats-min.js:5
+msgid "Download Sources, last {0} days"
+msgstr "Ladda ner källor de senaste {0} dagarna"
+
+#. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
+#: static/js/impala/stats/csv_keys.js:185 static/js/zamboni/stats-all.js:15466 static/js/zamboni/stats-min.js:5
+msgid "Download Sources from {0} to {1}"
+msgstr "Ladda ner källor mellan {0} och {1}"
+
+#. L10n: {0} is an integer.
+#: static/js/impala/stats/csv_keys.js:189 static/js/zamboni/stats-all.js:15470 static/js/zamboni/stats-min.js:5
+msgid "Contributions, last {0} days"
+msgstr "Bidrag de senaste {0} dagarna"
+
+#. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
+#: static/js/impala/stats/csv_keys.js:191 static/js/zamboni/stats-all.js:15472 static/js/zamboni/stats-min.js:5
+msgid "Contributions from {0} to {1}"
+msgstr "Bidrag mellan {0} och {1}"
+
+#. L10n: {0} is an integer.
+#: static/js/impala/stats/csv_keys.js:195 static/js/zamboni/stats-all.js:15476 static/js/zamboni/stats-min.js:5
+msgid "Site Metrics, last {0} days"
+msgstr "Webbplatsstatistik de senaste {0} dagarna"
+
+#. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
+#: static/js/impala/stats/csv_keys.js:197 static/js/zamboni/stats-all.js:15478 static/js/zamboni/stats-min.js:5
+msgid "Site Metrics from {0} to {1}"
+msgstr "Webbplatsstatistik mellan {0} och {1}"
+
+#. L10n: {0} is an integer.
+#: static/js/impala/stats/csv_keys.js:201 static/js/zamboni/stats-all.js:15482 static/js/zamboni/stats-min.js:5
+msgid "Add-ons in Use, last {0} days"
+msgstr "Tillägg i användning de senaste {0} dagarna"
+
+#. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
+#: static/js/impala/stats/csv_keys.js:203 static/js/zamboni/stats-all.js:15484 static/js/zamboni/stats-min.js:5
+msgid "Add-ons in Use from {0} to {1}"
+msgstr "Tillägg i användning mellan {0} och {1}"
+
+#. L10n: {0} is an integer.
+#: static/js/impala/stats/csv_keys.js:207 static/js/zamboni/stats-all.js:15488 static/js/zamboni/stats-min.js:5
+msgid "Add-ons Downloaded, last {0} days"
+msgstr "Tillägg nedladdade de senaste {0} dagarna"
+
+#. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
+#: static/js/impala/stats/csv_keys.js:209 static/js/zamboni/stats-all.js:15490 static/js/zamboni/stats-min.js:5
+msgid "Add-ons Downloaded from {0} to {1}"
+msgstr "Tillägg nedladdade mellan {0} och {1}"
+
+#. L10n: {0} is an integer.
+#: static/js/impala/stats/csv_keys.js:213 static/js/zamboni/stats-all.js:15494 static/js/zamboni/stats-min.js:5
+msgid "Add-ons Created, last {0} days"
+msgstr "Tillägg skapade de senaste {0} dagarna"
+
+#. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
+#: static/js/impala/stats/csv_keys.js:215 static/js/zamboni/stats-all.js:15496 static/js/zamboni/stats-min.js:5
+msgid "Add-ons Created from {0} to {1}"
+msgstr "Tillägg skapade mellan {0} och {1}"
+
+#. L10n: {0} is an integer.
+#: static/js/impala/stats/csv_keys.js:219 static/js/zamboni/stats-all.js:15500 static/js/zamboni/stats-min.js:5
+msgid "Add-ons Updated, last {0} days"
+msgstr "Tillägg uppdaterade de senaste {0} dagarna"
+
+#. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
+#: static/js/impala/stats/csv_keys.js:221 static/js/zamboni/stats-all.js:15502 static/js/zamboni/stats-min.js:5
+msgid "Add-ons Updated from {0} to {1}"
+msgstr "Tillägg uppdaterade mellan {0} och {1}"
+
+#. L10n: {0} is an integer.
+#: static/js/impala/stats/csv_keys.js:225 static/js/zamboni/stats-all.js:15506 static/js/zamboni/stats-min.js:5
+msgid "Reviews Written, last {0} days"
+msgstr "Recensioner skrivna de senaste {0} dagarna"
+
+#. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
+#: static/js/impala/stats/csv_keys.js:227 static/js/zamboni/stats-all.js:15508 static/js/zamboni/stats-min.js:5
+msgid "Reviews Written from {0} to {1}"
+msgstr "Recensioner skrivna mellan {0} och {1}"
+
+#. L10n: {0} is an integer.
+#: static/js/impala/stats/csv_keys.js:231 static/js/zamboni/stats-all.js:15512 static/js/zamboni/stats-min.js:5
+msgid "User Signups, last {0} days"
+msgstr "Användarregistreringar de senaste {0} dagarna"
+
+#. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
+#: static/js/impala/stats/csv_keys.js:233 static/js/zamboni/stats-all.js:15514 static/js/zamboni/stats-min.js:5
+msgid "User Signups from {0} to {1}"
+msgstr "Användarregistreringar mellan {0} och {1}"
+
+#. L10n: {0} is an integer.
+#: static/js/impala/stats/csv_keys.js:237 static/js/zamboni/stats-all.js:15518 static/js/zamboni/stats-min.js:5
+msgid "Collections Created, last {0} days"
+msgstr "Samlingar skapade de senaste {0} dagarna"
+
+#. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
+#: static/js/impala/stats/csv_keys.js:239 static/js/zamboni/stats-all.js:15520 static/js/zamboni/stats-min.js:5
+msgid "Collections Created from {0} to {1}"
+msgstr "Samlingar skapade mellan {0} och {1}"
+
+#. L10n: {0} is an integer.
+#: static/js/impala/stats/csv_keys.js:243 static/js/zamboni/stats-all.js:15524 static/js/zamboni/stats-min.js:5
+msgid "Subscribers, last {0} days"
+msgstr "Prenumeranter de senaste {0} dagarna"
+
+#. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
+#: static/js/impala/stats/csv_keys.js:245 static/js/zamboni/stats-all.js:15526 static/js/zamboni/stats-min.js:5
+msgid "Subscribers from {0} to {1}"
+msgstr "Prenumeranter mellan {0} och {1}"
+
+#. L10n: {0} is an integer.
+#: static/js/impala/stats/csv_keys.js:249 static/js/zamboni/stats-all.js:15530 static/js/zamboni/stats-min.js:5
+msgid "Ratings, last {0} days"
+msgstr "Betygsatt de senaste {0} dagarna"
+
+#. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
+#: static/js/impala/stats/csv_keys.js:251 static/js/zamboni/stats-all.js:15532 static/js/zamboni/stats-min.js:5
+msgid "Ratings from {0} to {1}"
+msgstr "Betygsatt mellan {0} och {1}"
+
+#. L10n: {0} is an integer.
+#: static/js/impala/stats/csv_keys.js:255 static/js/zamboni/stats-all.js:15536 static/js/zamboni/stats-min.js:5
+msgid "Sales, last {0} days"
+msgstr "Försäljning de senaste {0} dagarna"
+
+#. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
+#: static/js/impala/stats/csv_keys.js:257 static/js/zamboni/stats-all.js:15538 static/js/zamboni/stats-min.js:5
+msgid "Sales from {0} to {1}"
+msgstr "Försäljning mellan {0} och {1}"
+
+#. L10n: {0} is an integer.
+#: static/js/impala/stats/csv_keys.js:261 static/js/zamboni/stats-all.js:15542 static/js/zamboni/stats-min.js:5
+msgid "Installs, last {0} days"
+msgstr "Installationer de senaste {0} dagarna"
+
+#. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
+#: static/js/impala/stats/csv_keys.js:263 static/js/zamboni/stats-all.js:15544 static/js/zamboni/stats-min.js:5
+msgid "Installs from {0} to {1}"
+msgstr "Installationer mellan {0} och {1}"
+
+#. L10n: {0} and {1} are integers.
+#: static/js/impala/stats/csv_keys.js:269 static/js/zamboni/stats-all.js:15550 static/js/zamboni/stats-min.js:5
+msgid "<b>{0}</b> in last {1} days"
+msgstr "<b>{0}</b> de senaste {1} dagarna"
+
+#. L10n: {0} is an integer and {1} and {2} are dates in YYYY-MM-DD format.
+#: static/js/impala/stats/csv_keys.js:271 static/js/impala/stats/csv_keys.js:277 static/js/zamboni/stats-all.js:15552 static/js/zamboni/stats-all.js:15558 static/js/zamboni/stats-min.js:5
+msgid "<b>{0}</b> from {1} to {2}"
+msgstr "<b>{0}</b> mellan {1} och {2}"
+
+#. L10n: {0} and {1} are integers.
+#: static/js/impala/stats/csv_keys.js:275 static/js/zamboni/stats-all.js:15556 static/js/zamboni/stats-min.js:5
+msgid "<b>{0}</b> average in last {1} days"
+msgstr "<b>{0}</b> genomsnitt de senaste {1} dagarna"
+
+#: static/js/impala/stats/overview.js:19 static/js/zamboni/stats-all.js:16469 static/js/zamboni/stats-min.js:5
+msgid "No data available."
+msgstr "Inga data tillgängliga."
+
+#: static/js/impala/stats/table.js:74 static/js/zamboni/stats-all.js:17209 static/js/zamboni/stats-min.js:5
+msgid "Date"
+msgstr "Datum"
+
+#: static/js/impala/stats/topchart.js:96 static/js/zamboni/stats-all.js:16600 static/js/zamboni/stats-min.js:5
+msgid "Other"
+msgstr "Andra"
+
+#: static/js/zamboni/admin-all.js:180 static/js/zamboni/admin-min.js:1 static/js/zamboni/admin_validation.js:24 static/js/zamboni/devhub-all.js:2408 static/js/zamboni/devhub-min.js:2
+#: static/js/zamboni/devhub.js:1229 static/js/zamboni/editors-all.js:15576 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:295
+msgid "Select an application first"
+msgstr "Välj en applikation först"
+
+#: static/js/zamboni/admin-all.js:207 static/js/zamboni/admin-min.js:1 static/js/zamboni/admin_validation.js:51
+msgid "Set {0} add-on to a max version of {1} and email the author."
+msgid_plural "Set {0} add-ons to a max version of {1} and email the authors."
+msgstr[0] "Ställ in tillägget {0} till maxversion på {1} och mejla utvecklaren."
+msgstr[1] "Ställ in tillägget {0} till maxversion på {1} och mejla utvecklarna."
+
+#: static/js/zamboni/admin-all.js:210 static/js/zamboni/admin-min.js:1 static/js/zamboni/admin_validation.js:54
+msgid "Email author of {2} add-on which failed validation."
+msgid_plural "Email authors of {2} add-ons which failed validation."
+msgstr[0] "Mejla utvecklaren av tillägget {2} som misslyckades validering."
+msgstr[1] "Mejla utvecklarna av tillägget {2} som misslyckades validering."
+
+#: static/js/zamboni/devhub-all.js:1289 static/js/zamboni/devhub-min.js:1 static/js/zamboni/devhub.js:110
+msgid "Your browser does not support the video tag"
+msgstr "Din webbläsare stöder inte videotaggen"
+
+#: static/js/zamboni/devhub-all.js:1550 static/js/zamboni/devhub-min.js:1 static/js/zamboni/devhub.js:371
+msgid "Changes Saved"
+msgstr "Ändringar sparade"
+
+#: static/js/zamboni/devhub-all.js:1566 static/js/zamboni/devhub-min.js:1 static/js/zamboni/devhub.js:387
+msgid "Enter a new author's email address"
+msgstr "Ange en ny e-postadress till utvecklaren"
+
+#: static/js/zamboni/devhub-all.js:1715 static/js/zamboni/devhub-min.js:1 static/js/zamboni/devhub.js:536
+msgid "There was an error uploading your file."
+msgstr "Det var problem med uppladdningen av filen."
+
+#: static/js/zamboni/devhub-all.js:1860 static/js/zamboni/devhub-min.js:1 static/js/zamboni/devhub.js:681
+msgid "{files} file"
+msgid_plural "{files} files"
+msgstr[0] "{files} fil"
+msgstr[1] "{files} filer"
+
+#: static/js/zamboni/devhub-all.js:1863 static/js/zamboni/devhub-min.js:1 static/js/zamboni/devhub.js:684
+msgid "{reviews} user review"
+msgid_plural "{reviews} user reviews"
+msgstr[0] "{reviews} användarrecension"
+msgstr[1] "{reviews} användarrecensioner"
+
+#: static/js/zamboni/devhub-all.js:1975 static/js/zamboni/devhub-min.js:2 static/js/zamboni/devhub.js:796
+msgid "Learn more"
+msgstr "Lär dig mer"
+
+#: static/js/zamboni/devhub-all.js:1979 static/js/zamboni/devhub-min.js:2 static/js/zamboni/devhub.js:800
+msgid "Example"
+msgstr "Exempel"
+
+#: static/js/zamboni/devhub-all.js:2309 static/js/zamboni/devhub-min.js:2 static/js/zamboni/devhub.js:1130
+msgid "Image changes being processed"
+msgstr "Bildändringar behandlas"
+
+#: static/js/zamboni/devhub-all.js:2459 static/js/zamboni/devhub-min.js:2 static/js/zamboni/devhub.js:1280
+msgid "Must be a valid e-mail address."
+msgstr "Måste vara en giltig e-postadress."
+
+#: static/js/zamboni/devhub-all.js:2613 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:80
 msgid "All tests passed successfully."
 msgstr "Alla test klarades."
 
-#: static/js/zamboni/validator.js:83 static/js/zamboni/validator.js:478
+#: static/js/zamboni/devhub-all.js:2616 static/js/zamboni/devhub-all.js:3011 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:83 static/js/zamboni/validator.js:478
 msgid "These tests were not run."
 msgstr "Dessa tester kördes inte."
 
-#: static/js/zamboni/validator.js:131 static/js/zamboni/validator.js:144
+#: static/js/zamboni/devhub-all.js:2664 static/js/zamboni/devhub-all.js:2677 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:131 static/js/zamboni/validator.js:144
 msgid "Tests"
 msgstr "Tester"
 
-#: static/js/zamboni/validator.js:246 static/js/zamboni/validator.js:575
-#: static/js/zamboni/validator.js:594
+#: static/js/zamboni/devhub-all.js:2779 static/js/zamboni/devhub-all.js:3108 static/js/zamboni/devhub-all.js:3127 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:246
+#: static/js/zamboni/validator.js:575 static/js/zamboni/validator.js:594
 msgid "Error"
 msgstr "Fel"
 
-#: static/js/zamboni/validator.js:247
+#: static/js/zamboni/devhub-all.js:2780 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:247
 msgid "Warning"
 msgstr "Varning"
 
-#: static/js/zamboni/validator.js:299
+#: static/js/zamboni/devhub-all.js:2794 static/js/zamboni/devhub-min.js:2 static/js/zamboni/files-all.js:5657 static/js/zamboni/files-min.js:3 static/js/zamboni/files.js:411
+#: static/js/zamboni/validator.js:261
+msgid "Ignore this message in future updates"
+msgstr "Ignorera det här meddelandet i framtida uppdateringar"
+
+#: static/js/zamboni/devhub-all.js:2817 static/js/zamboni/devhub-min.js:2 static/js/zamboni/files-all.js:5663 static/js/zamboni/files-min.js:3 static/js/zamboni/files.js:417
+#: static/js/zamboni/validator.js:284
+msgid "Severity for automated signing:"
+msgstr "Allvarlighetsgrad för automatisk signering:"
+
+#: static/js/zamboni/devhub-all.js:2832 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:299
 msgid "Suggestions for passing automated signing:"
 msgstr "Förslag för att klara automatisk signering:"
 
-#: static/js/zamboni/validator.js:387
+#: static/js/zamboni/devhub-all.js:2920 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:387
 msgid "Compatibility Tests"
 msgstr "Kompatibilitetstester"
 
-#: static/js/zamboni/validator.js:466
+#: static/js/zamboni/devhub-all.js:2999 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:466
 msgid "Add-on failed validation."
 msgstr "Tillägg misslyckades validering."
 
-#: static/js/zamboni/validator.js:468
+#: static/js/zamboni/devhub-all.js:3001 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:468
 msgid "Add-on passed validation."
 msgstr "Tillägg passerade validering."
 
-#: static/js/zamboni/validator.js:481
+#: static/js/zamboni/devhub-all.js:3014 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:481
 msgid "{0} error"
 msgid_plural "{0} errors"
 msgstr[0] "{0} fel"
 msgstr[1] "{0} fel"
 
-#: static/js/zamboni/validator.js:483
+#: static/js/zamboni/devhub-all.js:3016 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:483
 msgid "{0} warning"
 msgid_plural "{0} warnings"
 msgstr[0] "{0} varning"
 msgstr[1] "{0} varningar"
 
-#: static/js/zamboni/validator.js:485
+#: static/js/zamboni/devhub-all.js:3018 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:485
 msgid "{0} notice"
 msgid_plural "{0} notices"
 msgstr[0] "{0} meddelande"
 msgstr[1] "{0} meddelanden"
 
-#: static/js/zamboni/validator.js:577
+#: static/js/zamboni/devhub-all.js:3110 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:577
 msgid "Validation task could not complete or completed with errors"
 msgstr "Valideringsjobbet kunde inte slutföras eller avslutades med fel"
 
-#: static/js/zamboni/validator.js:595
+#: static/js/zamboni/devhub-all.js:3128 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:595
 msgid "Internal server error"
 msgstr "Internt serverfel"
 
-#: static/js/zamboni/mobile/buttons.js:52
+#: static/js/zamboni/devhub_search.js:8
+msgid "No results found."
+msgstr "Inga träffar hittades."
+
+#: static/js/zamboni/editors-all.js:15402 static/js/zamboni/editors-min.js:4 static/js/zamboni/editors.js:121
+msgid "{name} was viewing this page first."
+msgstr "{name} tittade på sidan först."
+
+#: static/js/zamboni/editors-all.js:15452 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:171
+msgid "Receipt checked by app."
+msgstr "Kvitto kontrollerad av app."
+
+#: static/js/zamboni/editors-all.js:15454 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:173
+msgid "Receipt was not checked by app."
+msgstr "Kvitto inte kontrollerad av app."
+
+#: static/js/zamboni/editors-all.js:15525 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:244
+msgid "{name} was viewing this add-on first."
+msgstr "{name} tittade på tillägget först."
+
+#: static/js/zamboni/editors-all.js:15536 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:255
+msgid "Loading&hellip;"
+msgstr "Laddar&hellip;"
+
+#: static/js/zamboni/editors-all.js:15541 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:260
+msgid "Version Notes"
+msgstr "Versionsanteckningar"
+
+#: static/js/zamboni/editors-all.js:15546 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:265
+msgid "Notes for Reviewers"
+msgstr "Meddelande för granskare"
+
+#: static/js/zamboni/editors-all.js:15551 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:270
+msgid "No version notes found"
+msgstr "Inga versionsanteckningar hittades"
+
+#: static/js/zamboni/editors-all.js:15611 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:330
+msgid "Average Reviews"
+msgstr "Genomsnittliga omdömen"
+
+#: static/js/zamboni/editors-all.js:15667 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:386
+msgid "Number of Reviews"
+msgstr "Antal recensioner"
+
+#: static/js/zamboni/editors-all.js:15726 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:445
+msgid "Error loading translation"
+msgstr "Fel vid laddning av översättning"
+
+#: static/js/zamboni/editors-all.js:15975 static/js/zamboni/editors-min.js:5 static/js/zamboni/themes_review_templates.js:31
+msgid "Theme"
+msgstr "Tema"
+
+#: static/js/zamboni/editors-all.js:15977 static/js/zamboni/editors-min.js:5 static/js/zamboni/themes_review_templates.js:33
+msgid "Reviewer"
+msgstr "Granskare"
+
+#: static/js/zamboni/editors-all.js:15979 static/js/zamboni/editors-min.js:5 static/js/zamboni/themes_review_templates.js:35
+msgid "Status"
+msgstr "Status"
+
+#: static/js/zamboni/editors-all.js:16196 static/js/zamboni/editors-min.js:5 static/js/zamboni/themes_review.js:176
+msgid "Requested Info"
+msgstr "Begärd info"
+
+#: static/js/zamboni/editors-all.js:16197 static/js/zamboni/editors-min.js:5 static/js/zamboni/themes_review.js:177
+msgid "Flagged"
+msgstr "Flaggad"
+
+#: static/js/zamboni/editors-all.js:16198 static/js/zamboni/editors-min.js:5 static/js/zamboni/themes_review.js:178
+msgid "Duplicate"
+msgstr "Duplicera"
+
+#: static/js/zamboni/editors-all.js:16199 static/js/zamboni/editors-min.js:5 static/js/zamboni/themes_review.js:179
+msgid "Rejected"
+msgstr "Ej godkänd"
+
+#: static/js/zamboni/editors-all.js:16200 static/js/zamboni/editors-min.js:5 static/js/zamboni/themes_review.js:180
+msgid "Approved"
+msgstr "Godkänd"
+
+#: static/js/zamboni/editors-all.js:16444 static/js/zamboni/editors-min.js:5 static/js/zamboni/themes_review.js:424
+msgid "No results found"
+msgstr "Inga resultat hittades"
+
+#: static/js/zamboni/mobile-all.js:15186 static/js/zamboni/mobile/buttons.js:52
 msgid "Not Updated for {0} {1}"
 msgstr "Inte uppdaterad för {0} {1}"
 
-#: static/js/zamboni/mobile/buttons.js:53
+#: static/js/zamboni/mobile-all.js:15187 static/js/zamboni/mobile/buttons.js:53
 msgid "Requires Newer Version of {0}"
 msgstr "Kräver en nyare version av {0}"
 
-#: static/js/zamboni/mobile/buttons.js:54
+#: static/js/zamboni/mobile-all.js:15188 static/js/zamboni/mobile/buttons.js:54
 msgid "Unreviewed"
 msgstr "Ej granskad"
 
-#: static/js/zamboni/mobile/buttons.js:55
+#: static/js/zamboni/mobile-all.js:15189 static/js/zamboni/mobile/buttons.js:55
 msgid "Experimental <span>(Learn More)</span>"
 msgstr "Experimentell <span>(Läs mer)</span>"
 
-#: static/js/zamboni/mobile/buttons.js:56
-#: static/js/zamboni/mobile/buttons.js:57
+#: static/js/zamboni/mobile-all.js:15190 static/js/zamboni/mobile-all.js:15191 static/js/zamboni/mobile/buttons.js:56 static/js/zamboni/mobile/buttons.js:57
 msgid "Not Available for {0}"
 msgstr "Inte tillgänglig för {0}"
 
-#: static/js/zamboni/mobile/buttons.js:58
+#: static/js/zamboni/mobile-all.js:15192 static/js/zamboni/mobile/buttons.js:58
 msgid "Experimental"
 msgstr "Experimentell"
 
-#: static/js/zamboni/mobile/buttons.js:59
+#: static/js/zamboni/mobile-all.js:15193 static/js/zamboni/mobile/buttons.js:59
 msgid "Themes Require Newer Version of {0}"
 msgstr "Teman kräver nyare version av {0}"
 
-#: static/js/zamboni/mobile/buttons.js:60
+#: static/js/zamboni/mobile-all.js:15194 static/js/zamboni/mobile/buttons.js:60
 msgid "Themes Require {0}"
 msgstr "Teman kräver {0}"
 
-#: static/js/zamboni/mobile/buttons.js:105
+#: static/js/zamboni/mobile-all.js:15239 static/js/zamboni/mobile/buttons.js:105
 msgid "Installing..."
 msgstr "Installerar..."
 
-#: static/js/zamboni/mobile/buttons.js:125
+#: static/js/zamboni/mobile-all.js:15259 static/js/zamboni/mobile/buttons.js:125
 msgid "This add-on has been preliminarily reviewed by Mozilla."
 msgstr "Detta tillägg har preliminärt granskats av Mozilla."
 
-#: static/js/zamboni/mobile/buttons.js:250
+#: static/js/zamboni/mobile-all.js:15384 static/js/zamboni/mobile/buttons.js:250
 msgid "Keep it"
 msgstr "Behåll den"
 
-#: static/js/zamboni/mobile/general.js:344
+#: static/js/zamboni/mobile-all.js:16049 static/js/zamboni/mobile-min.js:6 static/js/zamboni/mobile/general.js:344
 msgid "You're trying it on!"
 msgstr "Du provar den!"
 
-#: static/js/zamboni/mobile/general.js:356
+#: static/js/zamboni/mobile-all.js:16061 static/js/zamboni/mobile-min.js:6 static/js/zamboni/mobile/general.js:356
 msgid "Added to Firefox"
 msgstr "Tillagd i Firefox"

--- a/locale/te/LC_MESSAGES/django.po
+++ b/locale/te/LC_MESSAGES/django.po
@@ -2,69 +2,70 @@ msgid ""
 msgstr ""
 "Project-Id-Version:  addons\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2016-02-24 21:23+0000\n"
+"POT-Creation-Date: 2016-04-18 15:47+0000\n"
 "PO-Revision-Date: 2012-03-02 17:35-0700\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
+"Language: \n"
 "MIME-Version: 1.0\n"
-"Content-Type: text/plain; charset=utf-8\n"
+"Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Generated-By: Babel 2.2.0\n"
 
-#: src/olympia/accounts/views.py:52
+#: src/olympia/accounts/views.py:54
 msgid "Your log in attempt could not be parsed. Please try again."
 msgstr ""
 
-#: src/olympia/accounts/views.py:54
+#: src/olympia/accounts/views.py:56
 msgid "Your Firefox Account could not be found. Please try again."
 msgstr ""
 
-#: src/olympia/accounts/views.py:55
+#: src/olympia/accounts/views.py:57
 msgid "You could not be logged in. Please try again."
 msgstr ""
 
-#: src/olympia/accounts/views.py:57
+#: src/olympia/accounts/views.py:59
 msgid "Your account has already been migrated to Firefox Accounts."
 msgstr ""
 
-#: src/olympia/accounts/views.py:59
+#: src/olympia/accounts/views.py:61
 msgid "Your Firefox Account already exists on this site."
 msgstr ""
 
-#: src/olympia/accounts/views.py:108
+#: src/olympia/accounts/views.py:110
 msgid "Great job!"
 msgstr ""
 
-#: src/olympia/accounts/views.py:109
+#: src/olympia/accounts/views.py:111
 msgid "You can now log in to Add-ons with your Firefox Account."
 msgstr ""
 
-#: src/olympia/accounts/views.py:121
+#: src/olympia/accounts/views.py:123
 msgid "Need help?"
 msgstr ""
 
-#: src/olympia/addons/buttons.py:180
+#: src/olympia/addons/buttons.py:177
 msgid "Download Now"
 msgstr ""
 
-#: src/olympia/addons/buttons.py:182
+#: src/olympia/addons/buttons.py:179
 msgid "Download"
 msgstr ""
 
 #. L10n: please keep &nbsp; in the string so &rarr; does not wrap.
-#: src/olympia/addons/buttons.py:186
+#: src/olympia/addons/buttons.py:183
 msgid "Continue to Download&nbsp;&rarr;"
 msgstr ""
 
-#: src/olympia/addons/buttons.py:202 src/olympia/addons/helpers.py:35 src/olympia/addons/views.py:319 src/olympia/addons/templates/addons/impala/details.html:114
+#: src/olympia/addons/buttons.py:199 src/olympia/addons/helpers.py:35 src/olympia/addons/views.py:333 src/olympia/addons/templates/addons/impala/details.html:111
 #: src/olympia/addons/templates/addons/impala/listing/items.html:17 src/olympia/addons/templates/addons/mobile/home.html:40 src/olympia/amo/templates/amo/side_nav.html:6
-#: src/olympia/amo/templates/amo/side_nav.html:10 src/olympia/amo/templates/amo/site_nav.html:2 src/olympia/amo/templates/amo/site_nav.html:55 src/olympia/bandwagon/views.py:95
-#: src/olympia/browse/views.py:54 src/olympia/browse/views.py:68 src/olympia/browse/views.py:235 src/olympia/browse/templates/browse/impala/category_landing.html:22
+#: src/olympia/amo/templates/amo/side_nav.html:10 src/olympia/amo/templates/amo/site_nav.html:2 src/olympia/amo/templates/amo/site_nav.html:53 src/olympia/bandwagon/views.py:95
+#: src/olympia/browse/views.py:54 src/olympia/browse/views.py:68 src/olympia/browse/views.py:202 src/olympia/browse/templates/browse/impala/category_landing.html:22
 #: src/olympia/browse/templates/browse/personas/mobile/category_landing.html:26
 msgid "Featured"
 msgstr ""
 
-#: src/olympia/addons/buttons.py:221
+#: src/olympia/addons/buttons.py:218
 msgid "Add to {0}"
 msgstr ""
 
@@ -112,39 +113,39 @@ msgid_plural "All tags must be at least {0} characters."
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/olympia/addons/forms.py:234
+#: src/olympia/addons/forms.py:238
 msgid "Categories cannot be changed while your add-on is featured for this application."
 msgstr ""
 
 #. L10n: {0} is the number of categories.
-#: src/olympia/addons/forms.py:238
+#: src/olympia/addons/forms.py:242
 msgid "You can have only {0} category."
 msgid_plural "You can have only {0} categories."
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/olympia/addons/forms.py:246
+#: src/olympia/addons/forms.py:250
 msgid "The miscellaneous category cannot be combined with additional categories."
 msgstr ""
 
-#: src/olympia/addons/forms.py:369
+#: src/olympia/addons/forms.py:374
 #, python-format
 msgid "Before changing your default locale you must have a name, summary, and description in that locale. You are missing %s."
 msgstr ""
 
-#: src/olympia/addons/forms.py:484 src/olympia/addons/forms.py:575
+#: src/olympia/addons/forms.py:455 src/olympia/addons/forms.py:546
 msgid "A license must be selected."
 msgstr ""
 
-#: src/olympia/addons/forms.py:556
+#: src/olympia/addons/forms.py:527
 msgid "Give Your Theme a Name."
 msgstr ""
 
-#: src/olympia/addons/forms.py:562 src/olympia/devhub/templates/devhub/personas/submit.html:53
+#: src/olympia/addons/forms.py:533 src/olympia/devhub/templates/devhub/personas/submit.html:53
 msgid "Describe your Theme."
 msgstr ""
 
-#: src/olympia/addons/forms.py:704
+#: src/olympia/addons/forms.py:675
 msgid "Enter a new author's email address"
 msgstr ""
 
@@ -152,37 +153,37 @@ msgstr ""
 msgid "Not Reviewed"
 msgstr ""
 
-#: src/olympia/addons/models.py:301
+#: src/olympia/addons/models.py:298
 msgid "Users have the option of contributing more or less than this amount."
 msgstr ""
 
-#: src/olympia/addons/models.py:309
-msgid "Users will always be asked in the Add-ons Manager (Firefox 4 and above)"
+#: src/olympia/addons/models.py:306
+msgid "Users will always be asked in the Add-ons Manager (Firefox 4 and above). Only applies to desktop."
 msgstr ""
 
-#: src/olympia/addons/models.py:1804 src/olympia/addons/templates/addons/details_box.html:55 src/olympia/devhub/templates/devhub/index.html:92
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:102
+#: src/olympia/addons/models.py:1802 src/olympia/addons/templates/addons/details_box.html:55 src/olympia/devhub/templates/devhub/index.html:92
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:89
 msgid "Listed"
 msgstr ""
 
-#: src/olympia/addons/views.py:320 src/olympia/browse/templates/browse/personas/mobile/category_landing.html:27
+#: src/olympia/addons/views.py:334 src/olympia/browse/templates/browse/personas/mobile/category_landing.html:27
 msgid "Popular"
 msgstr ""
 
-#: src/olympia/addons/views.py:321 src/olympia/browse/views.py:238 src/olympia/browse/views.py:280 src/olympia/browse/views.py:482
+#: src/olympia/addons/views.py:335 src/olympia/browse/views.py:205 src/olympia/browse/views.py:247 src/olympia/browse/views.py:449
 msgid "Recently Added"
 msgstr ""
 
-#: src/olympia/addons/views.py:322 src/olympia/bandwagon/views.py:99 src/olympia/browse/views.py:60 src/olympia/browse/views.py:71 src/olympia/search/forms.py:16 src/olympia/search/forms.py:91
+#: src/olympia/addons/views.py:336 src/olympia/bandwagon/views.py:99 src/olympia/browse/views.py:60 src/olympia/browse/views.py:71 src/olympia/search/forms.py:16 src/olympia/search/forms.py:91
 msgid "Recently Updated"
 msgstr ""
 
 #. l10n: {0} is the addon name
-#: src/olympia/addons/views.py:520
+#: src/olympia/addons/views.py:534
 msgid "Contribution for {0}"
 msgstr ""
 
-#: src/olympia/addons/views.py:613
+#: src/olympia/addons/views.py:627
 msgid "Abuse reported."
 msgstr ""
 
@@ -249,9 +250,9 @@ msgstr ""
 #: src/olympia/devhub/templates/devhub/addons/ajax_compat_update.html:36 src/olympia/devhub/templates/devhub/addons/profile.html:44 src/olympia/devhub/templates/devhub/addons/edit/admin.html:101
 #: src/olympia/devhub/templates/devhub/addons/edit/basic.html:152 src/olympia/devhub/templates/devhub/addons/edit/details.html:85 src/olympia/devhub/templates/devhub/addons/edit/support.html:67
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:166 src/olympia/devhub/templates/devhub/addons/forms_shared/media.html:149
-#: src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:44 src/olympia/devhub/templates/devhub/versions/add_file_modal.html:78 src/olympia/devhub/templates/devhub/versions/edit.html:139
-#: src/olympia/devhub/templates/devhub/versions/list.html:242 src/olympia/devhub/templates/devhub/versions/list.html:276 src/olympia/devhub/templates/devhub/versions/list.html:317
-#: src/olympia/devhub/templates/devhub/versions/list.html:351 src/olympia/reviews/templates/reviews/edit_review.html:16 src/olympia/translations/templates/translations/trans-menu.html:50
+#: src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:43 src/olympia/devhub/templates/devhub/versions/add_file_modal.html:58 src/olympia/devhub/templates/devhub/versions/edit.html:139
+#: src/olympia/devhub/templates/devhub/versions/list.html:239 src/olympia/devhub/templates/devhub/versions/list.html:281 src/olympia/devhub/templates/devhub/versions/list.html:315
+#: src/olympia/devhub/templates/devhub/versions/list.html:349 src/olympia/reviews/templates/reviews/edit_review.html:16 src/olympia/translations/templates/translations/trans-menu.html:50
 #: src/olympia/translations/templates/translations/trans-menu.html:62
 msgid "or"
 msgstr ""
@@ -362,7 +363,7 @@ msgid "Add-on Information for {0}"
 msgstr ""
 
 #: src/olympia/addons/templates/addons/details_box.html:30 src/olympia/addons/templates/addons/persona_detail_table.html:3 src/olympia/addons/templates/addons/mobile/details.html:63
-#: src/olympia/addons/templates/addons/mobile/persona_detail_table.html:7 src/olympia/browse/views.py:459 src/olympia/devhub/views.py:75
+#: src/olympia/addons/templates/addons/mobile/persona_detail_table.html:7 src/olympia/browse/views.py:426 src/olympia/devhub/views.py:73
 msgid "Updated"
 msgstr ""
 
@@ -381,11 +382,11 @@ msgstr ""
 msgid "Visibility"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/details_box.html:57 src/olympia/devhub/templates/devhub/index.html:94 src/olympia/devhub/templates/devhub/includes/addon_details.html:104
+#: src/olympia/addons/templates/addons/details_box.html:57 src/olympia/devhub/templates/devhub/index.html:94 src/olympia/devhub/templates/devhub/includes/addon_details.html:91
 msgid "Hidden"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/details_box.html:59 src/olympia/devhub/templates/devhub/index.html:96 src/olympia/devhub/templates/devhub/includes/addon_details.html:106
+#: src/olympia/addons/templates/addons/details_box.html:59 src/olympia/devhub/templates/devhub/index.html:96 src/olympia/devhub/templates/devhub/includes/addon_details.html:93
 msgid "Unlisted"
 msgstr ""
 
@@ -393,13 +394,13 @@ msgstr ""
 msgid "Required Add-ons"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/details_box.html:81 src/olympia/addons/templates/addons/persona_detail_table.html:15 src/olympia/browse/views.py:462 src/olympia/devhub/views.py:78
-#: src/olympia/devhub/views.py:85 src/olympia/discovery/templates/discovery/addons/detail.html:57 src/olympia/reviews/forms.py:62 src/olympia/reviews/templates/reviews/add.html:57
+#: src/olympia/addons/templates/addons/details_box.html:81 src/olympia/addons/templates/addons/persona_detail_table.html:15 src/olympia/browse/views.py:429 src/olympia/devhub/views.py:76
+#: src/olympia/devhub/views.py:83 src/olympia/discovery/templates/discovery/addons/detail.html:57 src/olympia/reviews/forms.py:62 src/olympia/reviews/templates/reviews/add.html:57
 #: src/olympia/reviews/templates/reviews/mobile/review_list.html:18
 msgid "Rating"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/details_box.html:85 src/olympia/browse/views.py:461 src/olympia/devhub/views.py:77 src/olympia/devhub/views.py:84
+#: src/olympia/addons/templates/addons/details_box.html:85 src/olympia/browse/views.py:428 src/olympia/devhub/views.py:75 src/olympia/devhub/views.py:82
 #: src/olympia/stats/templates/stats/addon_report_menu.html:8 src/olympia/stats/templates/stats/collection_report_menu.html:18
 msgid "Downloads"
 msgstr ""
@@ -419,7 +420,7 @@ msgstr ""
 
 #. The Privacy Policy for this add-on.
 #: src/olympia/addons/templates/addons/details_box.html:121 src/olympia/addons/templates/addons/privacy.html:19 src/olympia/addons/templates/addons/privacy.html:23
-#: src/olympia/addons/templates/addons/impala/button.html:43 src/olympia/addons/templates/addons/impala/details.html:307 src/olympia/devhub/templates/devhub/includes/policy_form.html:20
+#: src/olympia/addons/templates/addons/impala/button.html:43 src/olympia/addons/templates/addons/impala/details.html:312 src/olympia/devhub/templates/devhub/includes/policy_form.html:23
 #: src/olympia/templates/mobile/base_addons.html:87
 msgid "Privacy Policy"
 msgstr ""
@@ -444,7 +445,7 @@ msgstr ""
 msgid "Developer Comments"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/details_box.html:199 src/olympia/addons/templates/addons/impala/details.html:259
+#: src/olympia/addons/templates/addons/details_box.html:199 src/olympia/addons/templates/addons/impala/details.html:264
 msgid "Development Channel"
 msgstr ""
 
@@ -464,7 +465,7 @@ msgid ""
 "developer. To stop receiving development updates, reinstall the default version from the link above."
 msgstr ""
 
-#: src/olympia/addons/templates/addons/details_box.html:220 src/olympia/addons/templates/addons/impala/details.html:278
+#: src/olympia/addons/templates/addons/details_box.html:220 src/olympia/addons/templates/addons/impala/details.html:283
 msgid "Version {0}:"
 msgstr ""
 
@@ -483,7 +484,7 @@ msgid "End-User License Agreement for {0}"
 msgstr ""
 
 #: src/olympia/addons/templates/addons/eula.html:17 src/olympia/addons/templates/addons/eula.html:21 src/olympia/addons/templates/addons/impala/button.html:48
-#: src/olympia/addons/templates/addons/impala/details.html:316 src/olympia/devhub/templates/devhub/includes/policy_form.html:3 src/olympia/discovery/templates/discovery/addons/eula.html:11
+#: src/olympia/addons/templates/addons/impala/details.html:321 src/olympia/devhub/templates/devhub/includes/policy_form.html:3 src/olympia/discovery/templates/discovery/addons/eula.html:11
 msgid "End-User License Agreement"
 msgstr ""
 
@@ -500,7 +501,7 @@ msgstr ""
 msgid "Add-ons for {0}"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/home.html:10 src/olympia/addons/templates/addons/home.html:51 src/olympia/browse/templates/browse/impala/base_listing.html:11
+#: src/olympia/addons/templates/addons/home.html:10 src/olympia/addons/templates/addons/home.html:53 src/olympia/browse/templates/browse/impala/base_listing.html:11
 msgid "Featured Extensions"
 msgstr ""
 
@@ -508,29 +509,29 @@ msgstr ""
 msgid "Popular Extensions"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/home.html:42 src/olympia/amo/templates/amo/side_nav.html:3 src/olympia/amo/templates/amo/side_nav.html:11 src/olympia/amo/templates/amo/site_nav.html:3
-#: src/olympia/amo/templates/amo/site_nav.html:25 src/olympia/browse/views.py:236 src/olympia/browse/views.py:281 src/olympia/browse/views.py:481
+#: src/olympia/addons/templates/addons/home.html:44 src/olympia/amo/templates/amo/side_nav.html:3 src/olympia/amo/templates/amo/side_nav.html:11 src/olympia/amo/templates/amo/site_nav.html:3
+#: src/olympia/amo/templates/amo/site_nav.html:25 src/olympia/browse/views.py:203 src/olympia/browse/views.py:248 src/olympia/browse/views.py:448
 msgid "Most Popular"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/home.html:43
+#: src/olympia/addons/templates/addons/home.html:45
 msgid "All »"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/home.html:52 src/olympia/addons/templates/addons/home.html:61 src/olympia/addons/templates/addons/home.html:70 src/olympia/addons/templates/addons/home.html:78
+#: src/olympia/addons/templates/addons/home.html:54 src/olympia/addons/templates/addons/home.html:63 src/olympia/addons/templates/addons/home.html:72 src/olympia/addons/templates/addons/home.html:80
 #: src/olympia/browse/templates/browse/impala/category_landing.html:36
 msgid "See all »"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/home.html:60
+#: src/olympia/addons/templates/addons/home.html:62
 msgid "Up &amp; Coming Extensions"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/home.html:69 src/olympia/browse/templates/browse/personas/category_landing.html:61 src/olympia/discovery/templates/discovery/pane.html:74
+#: src/olympia/addons/templates/addons/home.html:71 src/olympia/browse/templates/browse/personas/category_landing.html:61 src/olympia/discovery/templates/discovery/pane.html:74
 msgid "Featured Themes"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/home.html:77 src/olympia/bandwagon/templates/bandwagon/impala/collection_listing.html:5
+#: src/olympia/addons/templates/addons/home.html:79 src/olympia/bandwagon/templates/bandwagon/impala/collection_listing.html:5
 msgid "Featured Collections"
 msgstr ""
 
@@ -548,7 +549,7 @@ msgid "Updated {0}"
 msgstr ""
 
 #. {0} is a date.
-#: src/olympia/addons/templates/addons/macros.html:10 src/olympia/addons/templates/addons/macros.html:69 src/olympia/addons/templates/addons/persona_preview.html:21
+#: src/olympia/addons/templates/addons/macros.html:10 src/olympia/addons/templates/addons/macros.html:69 src/olympia/addons/templates/addons/persona_preview.html:22
 #: src/olympia/addons/templates/addons/listing/items_mobile.html:44 src/olympia/addons/templates/addons/listing/macros.html:39
 #: src/olympia/bandwagon/templates/bandwagon/collection_listing_items.html:37 src/olympia/bandwagon/templates/bandwagon/impala/collection_listing_items.html:37
 msgid "Added {0}"
@@ -569,15 +570,14 @@ msgstr[0] ""
 msgstr[1] ""
 
 #. {0} is the number of downloads.
-#: src/olympia/addons/templates/addons/macros.html:53 src/olympia/addons/templates/addons/impala/details.html:61
+#: src/olympia/addons/templates/addons/macros.html:53 src/olympia/addons/templates/addons/impala/details.html:59
 msgid "{0} weekly download"
 msgid_plural "{0} weekly downloads"
 msgstr[0] ""
 msgstr[1] ""
 
 #. {0} is the number of users.
-#: src/olympia/addons/templates/addons/macros.html:61 src/olympia/addons/templates/addons/impala/details.html:54 src/olympia/compat/templates/compat/index.html:71
-#: src/olympia/zadmin/templates/zadmin/compat.html:67
+#: src/olympia/addons/templates/addons/macros.html:61 src/olympia/addons/templates/addons/impala/details.html:52 src/olympia/zadmin/templates/zadmin/compat.html:67
 msgid "{0} user"
 msgid_plural "{0} users"
 msgstr[0] ""
@@ -595,7 +595,7 @@ msgstr ""
 msgid "Return to the addon."
 msgstr ""
 
-#: src/olympia/addons/templates/addons/persona_detail.html:17 src/olympia/addons/templates/addons/impala/details.html:106 src/olympia/addons/templates/addons/mobile/details.html:23
+#: src/olympia/addons/templates/addons/persona_detail.html:17 src/olympia/addons/templates/addons/impala/details.html:103 src/olympia/addons/templates/addons/mobile/details.html:23
 #: src/olympia/addons/templates/addons/mobile/persona_detail.html:21 src/olympia/discovery/templates/discovery/addons/base.html:27 src/olympia/editors/templates/editors/review.html:31
 msgid "by"
 msgstr ""
@@ -639,34 +639,35 @@ msgstr ""
 msgid "License"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/persona_preview.html:12 src/olympia/constants/base.py:48
+#: src/olympia/addons/templates/addons/persona_preview.html:13 src/olympia/constants/base.py:48
 msgid "Awaiting Review"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/persona_preview.html:14 src/olympia/amo/log.py:180 src/olympia/constants/base.py:42 src/olympia/editors/helpers.py:62
+#: src/olympia/addons/templates/addons/persona_preview.html:15 src/olympia/amo/log.py:180 src/olympia/constants/base.py:42 src/olympia/editors/helpers.py:62
 msgid "Rejected"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/persona_preview.html:16 src/olympia/amo/log.py:159
+#: src/olympia/addons/templates/addons/persona_preview.html:17 src/olympia/amo/log.py:159
 msgid "Approved"
 msgstr ""
 
 #. {0} is the number of users.
-#: src/olympia/addons/templates/addons/persona_preview.html:26 src/olympia/addons/templates/addons/listing/items_mobile.html:36 src/olympia/addons/templates/addons/listing/macros.html:31
+#: src/olympia/addons/templates/addons/persona_preview.html:27 src/olympia/addons/templates/addons/listing/items_mobile.html:36 src/olympia/addons/templates/addons/listing/macros.html:31
 msgid "<strong>{0}</strong> user"
 msgid_plural "<strong>{0}</strong> users"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/olympia/addons/templates/addons/persona_preview.html:40
+#: src/olympia/addons/templates/addons/persona_preview.html:41
 msgid "Hover to Preview"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/persona_preview.html:46 src/olympia/addons/templates/addons/persona_preview.html:48 src/olympia/reviews/templates/reviews/add.html:15
+#: src/olympia/addons/templates/addons/persona_preview.html:47 src/olympia/addons/templates/addons/persona_preview.html:49 src/olympia/addons/templates/addons/persona_preview.html:97
+#: src/olympia/reviews/templates/reviews/add.html:15
 msgid "Add"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/persona_preview.html:57 src/olympia/bandwagon/templates/bandwagon/ajax_new.html:16 src/olympia/bandwagon/templates/bandwagon/edit.html:19
+#: src/olympia/addons/templates/addons/persona_preview.html:58 src/olympia/bandwagon/templates/bandwagon/ajax_new.html:16 src/olympia/bandwagon/templates/bandwagon/edit.html:19
 #: src/olympia/bandwagon/templates/bandwagon/includes/addedit.html:19 src/olympia/devhub/templates/devhub/addons/edit/admin.html:13 src/olympia/devhub/templates/devhub/addons/edit/basic.html:10
 #: src/olympia/devhub/templates/devhub/addons/edit/details.html:8 src/olympia/devhub/templates/devhub/addons/edit/media.html:6 src/olympia/devhub/templates/devhub/addons/edit/support.html:8
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:9 src/olympia/devhub/templates/devhub/addons/submit/describe.html:29 src/olympia/editors/templates/editors/review.html:257
@@ -675,21 +676,21 @@ msgstr ""
 
 #. For datetime formatting, see the table on
 #. http://docs.python.org/library/datetime.html#strftime-and-strptime-behavior
-#: src/olympia/addons/templates/addons/persona_preview.html:66
+#: src/olympia/addons/templates/addons/persona_preview.html:67
 #, python-format
 msgid "%%Y-%%m-%%d"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/persona_preview.html:67
+#: src/olympia/addons/templates/addons/persona_preview.html:68
 msgid "by {0} on {1}"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/persona_preview.html:75 src/olympia/reviews/helpers.py:17 src/olympia/reviews/templates/reviews/review_list.html:63
+#: src/olympia/addons/templates/addons/persona_preview.html:76 src/olympia/reviews/helpers.py:17 src/olympia/reviews/templates/reviews/review_list.html:63
 #: src/olympia/reviews/templates/reviews/reviews_link.html:21 src/olympia/reviews/templates/reviews/impala/reviews_link.html:16
 msgid "Not yet rated"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/persona_preview.html:78
+#: src/olympia/addons/templates/addons/persona_preview.html:79
 msgid "<b>{0}</b> users"
 msgstr ""
 
@@ -702,7 +703,7 @@ msgid "Learn more about Firefox"
 msgstr ""
 
 #: src/olympia/addons/templates/addons/popups.html:22
-msgid "or <b><a class=\"installer\" href=\"{url}\">download anyway</a></b>"
+msgid "or <b><a class=\"button installer\" href=\"{url}\">download anyway</a></b>"
 msgstr ""
 
 #: src/olympia/addons/templates/addons/popups.html:26
@@ -801,7 +802,7 @@ msgid ""
 msgstr ""
 
 #: src/olympia/addons/templates/addons/report_abuse.html:6 src/olympia/addons/templates/addons/report_abuse_full.html:10 src/olympia/addons/templates/addons/impala/details-more.html:23
-#: src/olympia/addons/templates/addons/impala/details.html:328
+#: src/olympia/addons/templates/addons/impala/details.html:333
 msgid "Report Abuse"
 msgstr ""
 
@@ -820,9 +821,9 @@ msgstr ""
 #: src/olympia/devhub/templates/devhub/addons/ajax_compat_update.html:36 src/olympia/devhub/templates/devhub/addons/profile.html:44 src/olympia/devhub/templates/devhub/addons/edit/admin.html:104
 #: src/olympia/devhub/templates/devhub/addons/edit/basic.html:155 src/olympia/devhub/templates/devhub/addons/edit/details.html:88 src/olympia/devhub/templates/devhub/addons/edit/support.html:70
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:169 src/olympia/devhub/templates/devhub/addons/forms_shared/media.html:152
-#: src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:44 src/olympia/devhub/templates/devhub/personas/edit.html:222 src/olympia/devhub/templates/devhub/versions/add_file_modal.html:79
-#: src/olympia/devhub/templates/devhub/versions/edit.html:140 src/olympia/devhub/templates/devhub/versions/list.html:208 src/olympia/devhub/templates/devhub/versions/list.html:242
-#: src/olympia/devhub/templates/devhub/versions/list.html:276 src/olympia/devhub/templates/devhub/versions/list.html:317 src/olympia/reviews/templates/reviews/edit_review.html:16
+#: src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:43 src/olympia/devhub/templates/devhub/personas/edit.html:222 src/olympia/devhub/templates/devhub/versions/add_file_modal.html:59
+#: src/olympia/devhub/templates/devhub/versions/edit.html:140 src/olympia/devhub/templates/devhub/versions/list.html:208 src/olympia/devhub/templates/devhub/versions/list.html:239
+#: src/olympia/devhub/templates/devhub/versions/list.html:281 src/olympia/devhub/templates/devhub/versions/list.html:315 src/olympia/reviews/templates/reviews/edit_review.html:16
 #: src/olympia/translations/templates/translations/trans-menu.html:50 src/olympia/translations/templates/translations/trans-menu.html:62 src/olympia/zadmin/templates/zadmin/validation.html:105
 msgid "Cancel"
 msgstr ""
@@ -867,7 +868,7 @@ msgstr ""
 msgid "Review Guidelines"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/review_list_box.html:5 src/olympia/addons/templates/addons/impala/details-more.html:27 src/olympia/editors/helpers.py:921
+#: src/olympia/addons/templates/addons/review_list_box.html:5 src/olympia/addons/templates/addons/impala/details-more.html:27 src/olympia/editors/helpers.py:1001
 #: src/olympia/reviews/templates/reviews/add.html:14 src/olympia/reviews/templates/reviews/reply.html:14 src/olympia/reviews/templates/reviews/review_list.html:19
 #: src/olympia/reviews/templates/reviews/mobile/review_list.html:26
 msgid "Reviews"
@@ -958,119 +959,119 @@ msgid_plural "Other add-ons by these authors"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/olympia/addons/templates/addons/impala/details.html:41
+#: src/olympia/addons/templates/addons/impala/details.html:39
 #, python-format
 msgid "<span itemprop=\"ratingCount\">%(num)s</span> user review"
 msgid_plural "<span itemprop=\"ratingCount\">%(num)s</span> user reviews"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/olympia/addons/templates/addons/impala/details.html:69
+#: src/olympia/addons/templates/addons/impala/details.html:66
 msgid "View statistics"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/impala/details.html:84
+#: src/olympia/addons/templates/addons/impala/details.html:81
 msgid "Manage"
 msgstr ""
 
 #. {0} is an add-on name.
-#: src/olympia/addons/templates/addons/impala/details.html:96
+#: src/olympia/addons/templates/addons/impala/details.html:93
 msgid "Icon of {0}"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/impala/details.html:103 src/olympia/addons/templates/addons/impala/listing/items.html:14
+#: src/olympia/addons/templates/addons/impala/details.html:100 src/olympia/addons/templates/addons/impala/listing/items.html:14
 msgid "No Restart"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/impala/details.html:127
+#: src/olympia/addons/templates/addons/impala/details.html:124
 #, python-format
 msgid "Meet the Developer: <a href=\"%(url)s\">%(name)s</a>"
 msgid_plural "<a href=\"%(url)s\">Meet the Developers</a>"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/olympia/addons/templates/addons/impala/details.html:137
+#: src/olympia/addons/templates/addons/impala/details.html:134
 msgid "Learn why {0} was created and find out what's next for this add-on."
 msgstr ""
 
 #. {0} is an index.
-#: src/olympia/addons/templates/addons/impala/details.html:156
+#: src/olympia/addons/templates/addons/impala/details.html:161
 msgid "Add-on screenshot #{0}"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/impala/details.html:182
+#: src/olympia/addons/templates/addons/impala/details.html:187
 msgid "Add-on home page"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/impala/details.html:185
+#: src/olympia/addons/templates/addons/impala/details.html:190
 msgid "Support site"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/impala/details.html:189
+#: src/olympia/addons/templates/addons/impala/details.html:194
 msgid "Support E-mail"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/impala/details.html:194 src/olympia/devhub/models.py:378 src/olympia/devhub/templates/devhub/versions/list.html:12
+#: src/olympia/addons/templates/addons/impala/details.html:199 src/olympia/devhub/models.py:378 src/olympia/devhub/templates/devhub/versions/list.html:12
 #: src/olympia/versions/templates/versions/version.html:6 src/olympia/versions/templates/versions/mobile/version.html:6
 msgid "Version {0}"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/impala/details.html:194
+#: src/olympia/addons/templates/addons/impala/details.html:199
 msgid "Info"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/impala/details.html:195 src/olympia/devhub/templates/devhub/includes/addon_details.html:129
+#: src/olympia/addons/templates/addons/impala/details.html:200 src/olympia/devhub/templates/devhub/includes/addon_details.html:116
 msgid "Last Updated:"
-msgstr ""
-
-#: src/olympia/addons/templates/addons/impala/details.html:200
-#, python-format
-msgid "Released under <a target=\"_blank\" href=\"%(url)s\">%(name)s</a>"
-msgstr ""
-
-#: src/olympia/addons/templates/addons/impala/details.html:201 src/olympia/addons/templates/addons/impala/details.html:206 src/olympia/amo/helpers.py:398 src/olympia/devhub/forms.py:142
-#: src/olympia/devhub/forms.py:173 src/olympia/versions/templates/versions/version.html:40 src/olympia/versions/templates/versions/version.html:45
-msgid "Custom License"
 msgstr ""
 
 #: src/olympia/addons/templates/addons/impala/details.html:205
 #, python-format
+msgid "Released under <a target=\"_blank\" href=\"%(url)s\">%(name)s</a>"
+msgstr ""
+
+#: src/olympia/addons/templates/addons/impala/details.html:206 src/olympia/addons/templates/addons/impala/details.html:211 src/olympia/amo/helpers.py:398 src/olympia/devhub/forms.py:142
+#: src/olympia/devhub/forms.py:173 src/olympia/versions/templates/versions/version.html:40 src/olympia/versions/templates/versions/version.html:45
+msgid "Custom License"
+msgstr ""
+
+#: src/olympia/addons/templates/addons/impala/details.html:210
+#, python-format
 msgid "Released under <a href=\"%(url)s\">%(name)s</a>"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/impala/details.html:217
+#: src/olympia/addons/templates/addons/impala/details.html:222
 msgid "About this Add-on"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/impala/details.html:233
+#: src/olympia/addons/templates/addons/impala/details.html:238
 msgid "Developer’s Comments"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/impala/details.html:243
+#: src/olympia/addons/templates/addons/impala/details.html:248
 msgid "Version Information"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/impala/details.html:250
+#: src/olympia/addons/templates/addons/impala/details.html:255
 msgid "See complete version history"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/impala/details.html:262
+#: src/olympia/addons/templates/addons/impala/details.html:267
 msgid ""
 "The Development Channel lets you test an experimental new version of this add-on before it's released to the general public. Once you install the development version, you will continue to get "
 "updates from this channel. To stop receiving development updates, reinstall the default version from the link above."
 msgstr ""
 
-#: src/olympia/addons/templates/addons/impala/details.html:272
+#: src/olympia/addons/templates/addons/impala/details.html:277
 msgid "<strong>Caution:</strong> Development versions of this add-on have not been reviewed by Mozilla."
 msgstr ""
 
-#: src/olympia/addons/templates/addons/impala/details.html:287
+#: src/olympia/addons/templates/addons/impala/details.html:292
 msgid "See complete development channel history"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/impala/details.html:306 src/olympia/addons/templates/addons/impala/details.html:315 src/olympia/addons/templates/addons/impala/details.html:327
+#: src/olympia/addons/templates/addons/impala/details.html:311 src/olympia/addons/templates/addons/impala/details.html:320 src/olympia/addons/templates/addons/impala/details.html:332
 #: src/olympia/addons/templates/addons/impala/review_add_box.html:4 src/olympia/stats/templates/stats/popup.html:2 src/olympia/stats/templates/stats/popup.html:8
-#: src/olympia/stats/templates/stats/stats.html:202 src/olympia/users/templates/users/profile.html:119
+#: src/olympia/stats/templates/stats/stats.html:204 src/olympia/users/templates/users/profile.html:119
 msgid "close"
 msgstr ""
 
@@ -1126,15 +1127,11 @@ msgstr ""
 msgid "Source Code License"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/impala/persona_grid.html:16 src/olympia/addons/templates/addons/impala/toplist.html:6
-msgid "{0} users"
-msgstr ""
-
 #: src/olympia/addons/templates/addons/impala/review_list_box.html:19 src/olympia/reviews/templates/reviews/review.html:40
 msgid "permalink"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/impala/review_list_box.html:23 src/olympia/editors/templates/editors/queue.html:98 src/olympia/reviews/templates/reviews/review.html:44
+#: src/olympia/addons/templates/addons/impala/review_list_box.html:23 src/olympia/editors/templates/editors/queue.html:104 src/olympia/reviews/templates/reviews/review.html:44
 msgid "translate"
 msgstr ""
 
@@ -1153,6 +1150,10 @@ msgstr ""
 msgid "Be the first!"
 msgstr ""
 
+#: src/olympia/addons/templates/addons/impala/toplist.html:6
+msgid "{0} users"
+msgstr ""
+
 #: src/olympia/addons/templates/addons/impala/listing/sorter.html:14 src/olympia/devhub/templates/devhub/addons/listing/item_actions.html:49
 msgid "More"
 msgstr ""
@@ -1165,7 +1166,7 @@ msgstr ""
 msgid "My Add-ons"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/includes/dashboard_tabs.html:6 src/olympia/amo/context_processors.py:51
+#: src/olympia/addons/templates/addons/includes/dashboard_tabs.html:6 src/olympia/amo/context_processors.py:50
 msgid "My Themes"
 msgstr ""
 
@@ -1220,7 +1221,7 @@ msgstr ""
 msgid "Weekly Downloads"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/mobile/details.html:99 src/olympia/compat/templates/compat/reporter_detail.html:46 src/olympia/devhub/forms.py:787
+#: src/olympia/addons/templates/addons/mobile/details.html:99 src/olympia/compat/templates/compat/reporter_detail.html:46 src/olympia/devhub/forms.py:788
 #: src/olympia/devhub/templates/devhub/versions/list.html:163
 msgid "Version"
 msgstr ""
@@ -1304,7 +1305,7 @@ msgstr ""
 #: src/olympia/browse/templates/browse/personas/category_landing.html:21 src/olympia/browse/templates/browse/personas/category_landing.html:23
 #: src/olympia/browse/templates/browse/personas/category_landing.html:38 src/olympia/browse/templates/browse/personas/grid.html:7 src/olympia/browse/templates/browse/personas/grid.html:11
 #: src/olympia/browse/templates/browse/personas/mobile/base.html:7 src/olympia/browse/templates/browse/personas/mobile/category_landing.html:19 src/olympia/constants/base.py:180
-#: src/olympia/devhub/templates/devhub/personas/submit.html:13 src/olympia/editors/helpers.py:105 src/olympia/editors/templates/editors/base.html:26
+#: src/olympia/devhub/templates/devhub/personas/submit.html:13 src/olympia/editors/helpers.py:107 src/olympia/editors/templates/editors/base.html:26
 #: src/olympia/editors/templates/editors/performance.html:73 src/olympia/search/templates/search/personas.html:39 src/olympia/templates/menu_links.html:9
 msgid "Themes"
 msgstr ""
@@ -1325,7 +1326,7 @@ msgstr ""
 msgid "Highest Rated"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/mobile/home.html:74 src/olympia/amo/templates/amo/side_nav.html:5 src/olympia/amo/templates/amo/site_nav.html:27 src/olympia/amo/templates/amo/site_nav.html:57
+#: src/olympia/addons/templates/addons/mobile/home.html:74 src/olympia/amo/templates/amo/side_nav.html:5 src/olympia/amo/templates/amo/site_nav.html:27 src/olympia/amo/templates/amo/site_nav.html:55
 #: src/olympia/bandwagon/views.py:97 src/olympia/browse/views.py:57 src/olympia/browse/views.py:67 src/olympia/browse/templates/browse/personas/mobile/category_landing.html:65
 #: src/olympia/search/forms.py:15 src/olympia/search/forms.py:87
 msgid "Newest"
@@ -1339,90 +1340,90 @@ msgstr ""
 msgid "Theme Info &raquo;"
 msgstr ""
 
-#: src/olympia/amo/context_processors.py:39 src/olympia/devhub/templates/devhub/nav.html:43
+#: src/olympia/amo/context_processors.py:37 src/olympia/devhub/templates/devhub/nav.html:43
 msgid "Tools"
 msgstr ""
 
-#: src/olympia/amo/context_processors.py:48 src/olympia/discovery/templates/discovery/pane_account.html:8 src/olympia/users/templates/users/includes/navigation.html:2
+#: src/olympia/amo/context_processors.py:47 src/olympia/discovery/templates/discovery/pane_account.html:8 src/olympia/users/templates/users/includes/navigation.html:2
 msgid "My Profile"
 msgstr ""
 
-#: src/olympia/amo/context_processors.py:54 src/olympia/users/templates/users/edit.html:5 src/olympia/users/templates/users/includes/navigation.html:3
+#: src/olympia/amo/context_processors.py:53 src/olympia/users/templates/users/edit.html:5 src/olympia/users/templates/users/includes/navigation.html:3
 msgid "Account Settings"
 msgstr ""
 
-#: src/olympia/amo/context_processors.py:57 src/olympia/discovery/templates/discovery/pane_account.html:11 src/olympia/users/templates/users/profile.html:83
+#: src/olympia/amo/context_processors.py:56 src/olympia/discovery/templates/discovery/pane_account.html:11 src/olympia/users/templates/users/profile.html:83
 #: src/olympia/users/templates/users/includes/navigation.html:4
 msgid "My Collections"
 msgstr ""
 
-#: src/olympia/amo/context_processors.py:62 src/olympia/discovery/templates/discovery/pane_account.html:10 src/olympia/users/templates/users/includes/navigation.html:7
+#: src/olympia/amo/context_processors.py:61 src/olympia/discovery/templates/discovery/pane_account.html:10 src/olympia/users/templates/users/includes/navigation.html:7
 msgid "My Favorites"
 msgstr ""
 
-#: src/olympia/amo/context_processors.py:67 src/olympia/discovery/templates/discovery/pane_account.html:13 src/olympia/templates/impala/user_login.html:14
+#: src/olympia/amo/context_processors.py:66 src/olympia/discovery/templates/discovery/pane_account.html:13 src/olympia/templates/impala/user_login.html:14
 #: src/olympia/templates/mobile/header_auth.html:5
 msgid "Log out"
 msgstr ""
 
-#: src/olympia/amo/context_processors.py:72 src/olympia/devhub/templates/devhub/addons/dashboard.html:4
+#: src/olympia/amo/context_processors.py:71 src/olympia/devhub/templates/devhub/addons/dashboard.html:4
 msgid "Manage My Submissions"
 msgstr ""
 
-#: src/olympia/amo/context_processors.py:75 src/olympia/devhub/templates/devhub/nav.html:27 src/olympia/devhub/templates/devhub/addons/dashboard.html:25
+#: src/olympia/amo/context_processors.py:74 src/olympia/devhub/templates/devhub/nav.html:27 src/olympia/devhub/templates/devhub/addons/dashboard.html:25
 #: src/olympia/devhub/templates/devhub/addons/submit/base.html:4
 msgid "Submit a New Add-on"
 msgstr ""
 
-#: src/olympia/amo/context_processors.py:77 src/olympia/browse/templates/browse/personas/base.html:50 src/olympia/devhub/templates/devhub/index.html:24
+#: src/olympia/amo/context_processors.py:76 src/olympia/browse/templates/browse/personas/base.html:50 src/olympia/devhub/templates/devhub/index.html:24
 #: src/olympia/devhub/templates/devhub/addons/dashboard.html:29
 msgid "Submit a New Theme"
 msgstr ""
 
-#: src/olympia/amo/context_processors.py:79 src/olympia/amo/templates/amo/site_nav.html:87 src/olympia/devhub/helpers.py:36 src/olympia/devhub/helpers.py:68 src/olympia/devhub/helpers.py:102
+#: src/olympia/amo/context_processors.py:78 src/olympia/amo/templates/amo/site_nav.html:85 src/olympia/devhub/helpers.py:36 src/olympia/devhub/helpers.py:68 src/olympia/devhub/helpers.py:102
 #: src/olympia/templates/footer.html:6 src/olympia/templates/menu_links.html:14
 msgid "Developer Hub"
 msgstr ""
 
-#: src/olympia/amo/context_processors.py:83 src/olympia/devhub/views.py:1792
+#: src/olympia/amo/context_processors.py:81 src/olympia/devhub/views.py:1796
 msgid "Manage API Keys"
 msgstr ""
 
-#: src/olympia/amo/context_processors.py:88 src/olympia/editors/helpers.py:82 src/olympia/editors/helpers.py:102 src/olympia/editors/templates/editors/base.html:10
+#: src/olympia/amo/context_processors.py:86 src/olympia/editors/helpers.py:84 src/olympia/editors/helpers.py:104 src/olympia/editors/templates/editors/base.html:10
 msgid "Editor Tools"
 msgstr ""
 
-#: src/olympia/amo/context_processors.py:92
+#: src/olympia/amo/context_processors.py:90
 msgid "Admin Tools"
 msgstr ""
 
-#: src/olympia/amo/fields.py:15
+#: src/olympia/amo/fields.py:20
 msgid "Incorrect, please try again."
 msgstr ""
 
-#: src/olympia/amo/fields.py:16
+#: src/olympia/amo/fields.py:21
 msgid "Error verifying input, please try again."
 msgstr ""
 
-#: src/olympia/amo/fields.py:32
+#: src/olympia/amo/fields.py:37
 msgid "This must be a valid hex color code, such as #000000."
 msgstr ""
 
-#: src/olympia/amo/fields.py:58
+#: src/olympia/amo/fields.py:63
 msgid "Enter at least one value."
 msgstr ""
 
-#: src/olympia/amo/helpers.py:162 src/olympia/amo/templates/amo/site_nav.html:61 src/olympia/bandwagon/templates/bandwagon/add.html:9
+#: src/olympia/amo/helpers.py:162 src/olympia/amo/templates/amo/site_nav.html:59 src/olympia/bandwagon/templates/bandwagon/add.html:9
 #: src/olympia/bandwagon/templates/bandwagon/collection_detail.html:15 src/olympia/bandwagon/templates/bandwagon/delete.html:9 src/olympia/bandwagon/templates/bandwagon/edit.html:15
 #: src/olympia/bandwagon/templates/bandwagon/user_listing.html:18 src/olympia/bandwagon/templates/bandwagon/user_listing.html:21
 #: src/olympia/bandwagon/templates/bandwagon/impala/collection_listing.html:12 src/olympia/bandwagon/templates/bandwagon/impala/collection_listing.html:20
 #: src/olympia/bandwagon/templates/bandwagon/impala/collection_listing.html:24 src/olympia/bandwagon/templates/bandwagon/impala/collection_sidebar.html:3
 #: src/olympia/bandwagon/templates/bandwagon/includes/collection_sidebar.html:2 src/olympia/bandwagon/templates/bandwagon/mobile/collection_listing.html:3
-#: src/olympia/stats/templates/stats/stats.html:77 src/olympia/templates/menu_links.html:12
+#: src/olympia/stats/templates/stats/stats.html:33 src/olympia/templates/menu_links.html:12
 msgid "Collections"
 msgstr ""
 
-#: src/olympia/amo/helpers.py:171 src/olympia/amo/templates/amo/site_nav.html:85 src/olympia/browse/templates/browse/language_tools.html:3
+#: src/olympia/amo/helpers.py:171 src/olympia/amo/templates/amo/site_nav.html:83 src/olympia/browse/templates/browse/language_tools.html:3
 msgid "Dictionaries & Language Packs"
 msgstr ""
 
@@ -1574,8 +1575,8 @@ msgstr ""
 msgid "Comment on {addon} {version}."
 msgstr ""
 
-#: src/olympia/amo/log.py:236 src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:19 src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:47
-#: src/olympia/editors/helpers.py:511 src/olympia/editors/templates/editors/themes/history_table.html:11
+#: src/olympia/amo/log.py:236 src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:17 src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:45
+#: src/olympia/editors/helpers.py:584 src/olympia/editors/templates/editors/themes/history_table.html:11
 msgid "Comment"
 msgstr ""
 
@@ -1898,7 +1899,7 @@ msgstr ""
 #: src/olympia/amo/templates/amo/mobile/paginator.html:14 src/olympia/amo/templates/amo/mobile/paginator.html:16 src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:51
 #: src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:65 src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:78
 #: src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:91 src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:104
-#: src/olympia/discovery/templates/discovery/pane.html:45 src/olympia/discovery/templates/discovery/addons/detail.html:39 src/olympia/stats/templates/stats/stats.html:167
+#: src/olympia/discovery/templates/discovery/pane.html:45 src/olympia/discovery/templates/discovery/addons/detail.html:39 src/olympia/stats/templates/stats/stats.html:169
 msgid "Next"
 msgstr ""
 
@@ -1930,7 +1931,7 @@ msgid ""
 msgstr ""
 
 #: src/olympia/amo/templates/amo/side_nav.html:4 src/olympia/amo/templates/amo/side_nav.html:12 src/olympia/amo/templates/amo/site_nav.html:4 src/olympia/amo/templates/amo/site_nav.html:26
-#: src/olympia/browse/views.py:56 src/olympia/browse/views.py:66 src/olympia/browse/views.py:237 src/olympia/browse/views.py:282 src/olympia/search/forms.py:86
+#: src/olympia/browse/views.py:56 src/olympia/browse/views.py:66 src/olympia/browse/views.py:204 src/olympia/browse/views.py:249 src/olympia/search/forms.py:86
 msgid "Top Rated"
 msgstr ""
 
@@ -1944,38 +1945,38 @@ msgstr ""
 msgid "Extensions"
 msgstr ""
 
-#: src/olympia/amo/templates/amo/site_nav.html:45
+#: src/olympia/amo/templates/amo/site_nav.html:44
 msgid "Want more customization? Try <b>Complete Themes</b>"
 msgstr ""
 
-#: src/olympia/amo/templates/amo/site_nav.html:56 src/olympia/bandwagon/views.py:96
+#: src/olympia/amo/templates/amo/site_nav.html:54 src/olympia/bandwagon/views.py:96
 msgid "Most Followers"
 msgstr ""
 
-#: src/olympia/amo/templates/amo/site_nav.html:68 src/olympia/bandwagon/templates/bandwagon/impala/collection_sidebar.html:16
+#: src/olympia/amo/templates/amo/site_nav.html:66 src/olympia/bandwagon/templates/bandwagon/impala/collection_sidebar.html:16
 #: src/olympia/bandwagon/templates/bandwagon/includes/collection_sidebar.html:18
 msgid "Collections I've Made"
 msgstr ""
 
-#: src/olympia/amo/templates/amo/site_nav.html:70 src/olympia/bandwagon/templates/bandwagon/user_listing.html:4 src/olympia/bandwagon/templates/bandwagon/impala/collection_sidebar.html:13
+#: src/olympia/amo/templates/amo/site_nav.html:68 src/olympia/bandwagon/templates/bandwagon/user_listing.html:4 src/olympia/bandwagon/templates/bandwagon/impala/collection_sidebar.html:13
 #: src/olympia/bandwagon/templates/bandwagon/includes/collection_sidebar.html:15
 msgid "Collections I'm Following"
 msgstr ""
 
-#: src/olympia/amo/templates/amo/site_nav.html:73 src/olympia/bandwagon/templates/bandwagon/impala/collection_sidebar.html:18
-#: src/olympia/bandwagon/templates/bandwagon/includes/collection_sidebar.html:20 src/olympia/users/models.py:512
+#: src/olympia/amo/templates/amo/site_nav.html:71 src/olympia/bandwagon/templates/bandwagon/impala/collection_sidebar.html:18
+#: src/olympia/bandwagon/templates/bandwagon/includes/collection_sidebar.html:20 src/olympia/users/models.py:521
 msgid "My Favorite Add-ons"
 msgstr ""
 
-#: src/olympia/amo/templates/amo/site_nav.html:78
+#: src/olympia/amo/templates/amo/site_nav.html:76
 msgid "More&hellip;"
 msgstr ""
 
-#: src/olympia/amo/templates/amo/site_nav.html:82
+#: src/olympia/amo/templates/amo/site_nav.html:80
 msgid "Add-ons for Mobile"
 msgstr ""
 
-#: src/olympia/amo/templates/amo/site_nav.html:86 src/olympia/browse/feeds.py:207 src/olympia/browse/templates/browse/search_tools.html:3 src/olympia/constants/base.py:176
+#: src/olympia/amo/templates/amo/site_nav.html:84 src/olympia/browse/feeds.py:207 src/olympia/browse/templates/browse/search_tools.html:3 src/olympia/constants/base.py:176
 #: src/olympia/templates/menu_links.html:10
 msgid "Search Tools"
 msgstr ""
@@ -1991,7 +1992,7 @@ msgid "Jump to first page"
 msgstr ""
 
 #: src/olympia/amo/templates/amo/impala/paginator.html:22 src/olympia/amo/templates/amo/mobile/impala_paginator.html:12 src/olympia/discovery/templates/discovery/pane.html:44
-#: src/olympia/discovery/templates/discovery/addons/detail.html:38 src/olympia/stats/templates/stats/stats.html:164
+#: src/olympia/discovery/templates/discovery/addons/detail.html:38 src/olympia/stats/templates/stats/stats.html:166
 msgid "Previous"
 msgstr ""
 
@@ -2014,30 +2015,49 @@ msgid_plural "Page {n}"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/olympia/amo/templates/services/install.html:38
-#, python-format
-msgid "If you are not prompted to install %(addon_name)s in a moment, please <a href=\"%(addon_xpi)s\">click here</a>."
-msgstr ""
-
-#: src/olympia/amo/tests/test_messages.py:57 src/olympia/amo/tests/test_messages.py:58 src/olympia/reviews/forms.py:25 src/olympia/reviews/forms.py:50 src/olympia/reviews/templates/reviews/add.html:56
+#: src/olympia/amo/tests/test_messages.py:56 src/olympia/amo/tests/test_messages.py:57 src/olympia/reviews/forms.py:25 src/olympia/reviews/forms.py:50 src/olympia/reviews/templates/reviews/add.html:56
 #: src/olympia/reviews/templates/reviews/reply.html:30
 msgid "Title"
 msgstr ""
 
-#: src/olympia/amo/tests/test_messages.py:57 src/olympia/amo/tests/test_messages.py:58
+#: src/olympia/amo/tests/test_messages.py:56 src/olympia/amo/tests/test_messages.py:57
 msgid "Body"
 msgstr ""
 
-#: src/olympia/amo/tests/test_messages.py:59
+#: src/olympia/amo/tests/test_messages.py:58
 msgid "Another Title"
 msgstr ""
 
-#: src/olympia/amo/tests/test_messages.py:59
+#: src/olympia/amo/tests/test_messages.py:58
 msgid "Another Body"
 msgstr ""
 
-#: src/olympia/api/views.py:255
-msgid "Not implemented yet."
+#: src/olympia/api/authentication.py:76
+msgid "Signature has expired."
+msgstr ""
+
+#: src/olympia/api/authentication.py:79
+msgid "Error decoding signature."
+msgstr ""
+
+#: src/olympia/api/authentication.py:82
+msgid "Invalid JWT Token."
+msgstr ""
+
+#: src/olympia/api/authentication.py:130
+msgid "Invalid Authorization header. No credentials provided."
+msgstr ""
+
+#: src/olympia/api/authentication.py:133
+msgid "Invalid Authorization header. Credentials string should not contain spaces."
+msgstr ""
+
+#: src/olympia/api/fields.py:29
+msgid "The field must have a length of at least {num} characters."
+msgstr ""
+
+#: src/olympia/api/fields.py:31
+msgid "The language code {lang_code} is invalid."
 msgstr ""
 
 #: src/olympia/applications/views.py:39 src/olympia/applications/templates/applications/appversions.html:3
@@ -2056,7 +2076,7 @@ msgstr ""
 msgid "Add-ons submitted to Mozilla Add-ons must have a manifest file with at least one of the below applications supported. Only the versions listed below are allowed for these applications."
 msgstr ""
 
-#: src/olympia/applications/templates/applications/appversions.html:25
+#: src/olympia/applications/templates/applications/appversions.html:25 src/olympia/editors/helpers.py:361
 msgid "GUID"
 msgstr ""
 
@@ -2170,8 +2190,8 @@ msgstr ""
 msgid "Remove from favorites"
 msgstr ""
 
-#: src/olympia/bandwagon/views.py:98 src/olympia/bandwagon/views.py:191 src/olympia/browse/views.py:58 src/olympia/browse/views.py:69 src/olympia/browse/views.py:458 src/olympia/devhub/views.py:74
-#: src/olympia/devhub/views.py:82 src/olympia/devhub/templates/devhub/addons/edit/basic.html:20 src/olympia/editors/templates/editors/leaderboard.html:24
+#: src/olympia/bandwagon/views.py:98 src/olympia/bandwagon/views.py:191 src/olympia/browse/views.py:58 src/olympia/browse/views.py:69 src/olympia/browse/views.py:425 src/olympia/devhub/views.py:72
+#: src/olympia/devhub/views.py:80 src/olympia/devhub/templates/devhub/addons/edit/basic.html:20 src/olympia/editors/templates/editors/leaderboard.html:24
 #: src/olympia/editors/templates/editors/themes/queue_list.html:48 src/olympia/search/forms.py:17 src/olympia/search/forms.py:89 src/olympia/users/templates/users/vcard.html:5
 msgid "Name"
 msgstr ""
@@ -2180,7 +2200,7 @@ msgstr ""
 msgid "Recently Popular"
 msgstr ""
 
-#: src/olympia/bandwagon/views.py:189 src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:18
+#: src/olympia/bandwagon/views.py:189 src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:16
 msgid "Added"
 msgstr ""
 
@@ -2194,7 +2214,7 @@ msgstr ""
 
 #: src/olympia/bandwagon/views.py:316
 #, python-format
-msgid "Your new collection is shown below. You can <ahref=\"%(url)s\">edit additional settings</a> if you'dlike."
+msgid "Your new collection is shown below. You can <a href=\"%(url)s\">edit additional settings</a> if you'd like."
 msgstr ""
 
 #: src/olympia/bandwagon/views.py:322
@@ -2322,8 +2342,8 @@ msgid_plural "%(num)s Add-ons in this Collection"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/olympia/bandwagon/templates/bandwagon/collection_detail.html:125 src/olympia/compat/templates/compat/index.html:25 src/olympia/compat/templates/compat/reporter_detail.html:29
-#: src/olympia/files/templates/files/viewer.html:29 src/olympia/templates/amo_footer.html:17 src/olympia/templates/includes/lang_switcher.html:10
+#: src/olympia/bandwagon/templates/bandwagon/collection_detail.html:125 src/olympia/compat/templates/compat/reporter_detail.html:29 src/olympia/files/templates/files/viewer.html:29
+#: src/olympia/templates/amo_footer.html:17 src/olympia/templates/includes/lang_switcher.html:10
 msgid "Go"
 msgstr ""
 
@@ -2490,7 +2510,7 @@ msgid "Remove this user as a contributor"
 msgstr ""
 
 #: src/olympia/bandwagon/templates/bandwagon/edit_contributors.html:18 src/olympia/bandwagon/templates/bandwagon/edit_contributors.html:43
-#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:20 src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:48
+#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:18 src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:46
 #: src/olympia/devhub/templates/devhub/addons/ajax_compat_update.html:19
 msgid "Remove"
 msgstr ""
@@ -2538,7 +2558,7 @@ msgid "<b>Warning:</b> By changing the owner of this collection, you will no lon
 msgstr ""
 
 #: src/olympia/bandwagon/templates/bandwagon/edit_contributors.html:83 src/olympia/devhub/templates/devhub/addons/forms_shared/media.html:157
-#: src/olympia/devhub/templates/devhub/addons/submit/describe.html:69 src/olympia/devhub/templates/devhub/addons/submit/license.html:60 src/olympia/devhub/templates/devhub/addons/submit/upload.html:78
+#: src/olympia/devhub/templates/devhub/addons/submit/describe.html:69 src/olympia/devhub/templates/devhub/addons/submit/license.html:60 src/olympia/devhub/templates/devhub/addons/submit/upload.html:70
 #: src/olympia/devhub/templates/devhub/payments/tier.html:17 src/olympia/editors/templates/editors/themes/themes.html:111 src/olympia/editors/templates/editors/themes/themes.html:128
 #: src/olympia/editors/templates/editors/themes/themes.html:134 src/olympia/editors/templates/editors/themes/themes.html:141 src/olympia/users/templates/users/fxa_migration_prompt_content.html:10
 #: src/olympia/users/templates/users/login_form.html:42 src/olympia/users/templates/users/mobile/login.html:57
@@ -2621,31 +2641,31 @@ msgid "Add-ons in Your Collection"
 msgstr ""
 
 #: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:4
-msgid ""
-"To include an add-on in this collection, enter its name in the box below and hit enter.  You can also use the <strong>Add to Collection</strong> links throughout the site to include add-ons later."
+msgid "To include an add-on in this collection, enter its name in the box below and hit enter."
 msgstr ""
 
-#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:17 src/olympia/constants/base.py:400 src/olympia/devhub/templates/devhub/addons/activity.html:62
+#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:15 src/olympia/constants/base.py:400 src/olympia/devhub/templates/devhub/addons/activity.html:62
+#: src/olympia/editors/helpers.py:273 src/olympia/editors/helpers.py:360
 msgid "Add-on"
 msgstr ""
 
-#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:26
+#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:24
 msgid "Enter the name of the add-on to include"
 msgstr ""
 
-#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:28
+#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:26
 msgid "Add to Collection"
 msgstr ""
 
-#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:45 src/olympia/editors/helpers.py:936 src/olympia/editors/helpers.py:956
+#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:43 src/olympia/editors/helpers.py:1016 src/olympia/editors/helpers.py:1036
 msgid "Pending"
 msgstr ""
 
-#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:47
+#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:45
 msgid "Add a comment"
 msgstr ""
 
-#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:48
+#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:46
 msgid "Remove this add-on from the collection"
 msgstr ""
 
@@ -2752,12 +2772,12 @@ msgstr ""
 msgid "Most Users"
 msgstr ""
 
-#: src/olympia/browse/views.py:61 src/olympia/browse/views.py:72 src/olympia/browse/views.py:279 src/olympia/browse/templates/browse/personas/mobile/category_landing.html:63
+#: src/olympia/browse/views.py:61 src/olympia/browse/views.py:72 src/olympia/browse/views.py:246 src/olympia/browse/templates/browse/personas/mobile/category_landing.html:63
 #: src/olympia/discovery/templates/discovery/pane.html:67 src/olympia/search/forms.py:92
 msgid "Up & Coming"
 msgstr ""
 
-#: src/olympia/browse/views.py:460 src/olympia/devhub/views.py:76 src/olympia/devhub/views.py:83 src/olympia/discovery/templates/discovery/addons/detail.html:66
+#: src/olympia/browse/views.py:427 src/olympia/devhub/views.py:74 src/olympia/devhub/views.py:81 src/olympia/discovery/templates/discovery/addons/detail.html:66
 msgid "Created"
 msgstr ""
 
@@ -2945,8 +2965,8 @@ msgid_plural "See all %(cnt)s extensions in %(name)s &raquo;"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/olympia/browse/templates/browse/mobile/extensions.html:13 src/olympia/compat/templates/compat/index.html:82 src/olympia/devhub/templates/devhub/devhub_search.html:24
-#: src/olympia/devhub/templates/devhub/addons/activity.html:47 src/olympia/search/templates/search/no_results.html:4 src/olympia/search/templates/search/mobile/results.html:36
+#: src/olympia/browse/templates/browse/mobile/extensions.html:13 src/olympia/devhub/templates/devhub/devhub_search.html:24 src/olympia/devhub/templates/devhub/addons/activity.html:47
+#: src/olympia/search/templates/search/no_results.html:4 src/olympia/search/templates/search/mobile/results.html:36
 msgid "No results found."
 msgstr ""
 
@@ -3031,7 +3051,7 @@ msgstr ""
 msgid "All"
 msgstr ""
 
-#: src/olympia/compat/forms.py:22 src/olympia/search/views.py:525
+#: src/olympia/compat/forms.py:22 src/olympia/editors/templates/editors/base.html:69 src/olympia/search/views.py:518
 msgid "All Add-ons"
 msgstr ""
 
@@ -3041,53 +3061,6 @@ msgstr ""
 
 #: src/olympia/compat/forms.py:24
 msgid "Non-binary"
-msgstr ""
-
-#. Review points sources other than add-ons and themes.
-#: src/olympia/compat/views.py:87 src/olympia/constants/base.py:388 src/olympia/devhub/forms.py:162 src/olympia/editors/templates/editors/performance.html:75
-msgid "Other"
-msgstr ""
-
-#: src/olympia/compat/templates/compat/index.html:4
-msgid "Add-on Compatibility Report for {app} {version}"
-msgstr ""
-
-#: src/olympia/compat/templates/compat/index.html:11
-msgid "{app} {version} Compatibility"
-msgstr ""
-
-#: src/olympia/compat/templates/compat/index.html:17
-#, python-format
-msgid "Top 95%% compatible with previous version"
-msgstr ""
-
-#: src/olympia/compat/templates/compat/index.html:18
-#, python-format
-msgid "Top 95%% of all add-ons"
-msgstr ""
-
-#: src/olympia/compat/templates/compat/index.html:19
-msgid "All active add-ons"
-msgstr ""
-
-#: src/olympia/compat/templates/compat/index.html:23 src/olympia/constants/base.py:401
-msgid "App"
-msgstr ""
-
-#: src/olympia/compat/templates/compat/index.html:55
-msgid "Details for add-ons compatible with previous version:"
-msgstr ""
-
-#: src/olympia/compat/templates/compat/index.html:57
-msgid "Show all versions"
-msgstr ""
-
-#: src/olympia/compat/templates/compat/index.html:59
-msgid "Details for add-ons compatible with all versions:"
-msgstr ""
-
-#: src/olympia/compat/templates/compat/index.html:61
-msgid "Show previous version only"
 msgstr ""
 
 #: src/olympia/compat/templates/compat/reporter.html:3
@@ -3141,8 +3114,8 @@ msgstr ""
 msgid "Report Type"
 msgstr ""
 
-#: src/olympia/compat/templates/compat/reporter_detail.html:47 src/olympia/devhub/forms.py:784 src/olympia/devhub/templates/devhub/addons/ajax_compat_update.html:17 src/olympia/editors/forms.py:108
-#: src/olympia/zadmin/forms.py:45
+#: src/olympia/compat/templates/compat/reporter_detail.html:47 src/olympia/devhub/forms.py:785 src/olympia/devhub/templates/devhub/addons/ajax_compat_update.html:17 src/olympia/editors/forms.py:108
+#: src/olympia/editors/forms.py:248 src/olympia/zadmin/forms.py:45
 msgid "Application"
 msgstr ""
 
@@ -3230,7 +3203,8 @@ msgstr ""
 msgid "Preliminarily Reviewed and Awaiting Full Review"
 msgstr ""
 
-#: src/olympia/constants/base.py:33 src/olympia/editors/helpers.py:924 src/olympia/editors/templates/editors/themes/history_table.html:34
+#: src/olympia/constants/base.py:33 src/olympia/editors/forms.py:258 src/olympia/editors/helpers.py:73 src/olympia/editors/helpers.py:1004
+#: src/olympia/editors/templates/editors/themes/history_table.html:34
 msgid "Deleted"
 msgstr ""
 
@@ -3327,6 +3301,11 @@ msgstr ""
 msgid "Ask before users can download this add-on"
 msgstr ""
 
+#. Review points sources other than add-ons and themes.
+#: src/olympia/constants/base.py:388 src/olympia/devhub/forms.py:162 src/olympia/editors/templates/editors/performance.html:75
+msgid "Other"
+msgstr ""
+
 #: src/olympia/constants/base.py:389
 msgid "Exception"
 msgstr ""
@@ -3337,6 +3316,10 @@ msgstr ""
 
 #: src/olympia/constants/base.py:391
 msgid "Change"
+msgstr ""
+
+#: src/olympia/constants/base.py:401
+msgid "App"
 msgstr ""
 
 #: src/olympia/constants/base.py:402
@@ -3487,7 +3470,7 @@ msgstr ""
 msgid "Duplicate"
 msgstr ""
 
-#: src/olympia/constants/editors.py:17 src/olympia/editors/helpers.py:502 src/olympia/editors/templates/editors/themes/queue.html:71 src/olympia/editors/templates/editors/themes/themes.html:94
+#: src/olympia/constants/editors.py:17 src/olympia/editors/helpers.py:575 src/olympia/editors/templates/editors/themes/queue.html:71 src/olympia/editors/templates/editors/themes/themes.html:94
 msgid "Reject"
 msgstr ""
 
@@ -3587,7 +3570,7 @@ msgstr ""
 msgid "Android"
 msgstr ""
 
-#: src/olympia/core/apps.py:19
+#: src/olympia/core/apps.py:21
 msgid "Core"
 msgstr ""
 
@@ -3721,7 +3704,7 @@ msgid "Submit my add-on for manual review."
 msgstr ""
 
 #: src/olympia/devhub/forms.py:537
-msgid "Do not list my add-on on this site (beta)"
+msgid "Do not list my add-on on this site"
 msgstr ""
 
 #: src/olympia/devhub/forms.py:538
@@ -3754,46 +3737,46 @@ msgstr ""
 
 #: src/olympia/devhub/forms.py:592
 #, python-format
-msgid "Version %s already exists"
+msgid "Version %s already exists, or was uploaded before."
 msgstr ""
 
-#: src/olympia/devhub/forms.py:604
+#: src/olympia/devhub/forms.py:605
 msgid "Select a valid choice. That choice is not one of the available choices."
 msgstr ""
 
-#: src/olympia/devhub/forms.py:610
+#: src/olympia/devhub/forms.py:611
 msgid "A file with a version ending with a|alpha|b|beta and an optional number is detected as beta."
 msgstr ""
 
-#: src/olympia/devhub/forms.py:633
+#: src/olympia/devhub/forms.py:634
 msgid "You cannot upload any more files for this version."
 msgstr ""
 
-#: src/olympia/devhub/forms.py:639
+#: src/olympia/devhub/forms.py:640
 msgid "Version doesn't match"
 msgstr ""
 
-#: src/olympia/devhub/forms.py:668
+#: src/olympia/devhub/forms.py:669
 msgid "You cannot delete a file once the review process has started.  You must delete the whole version."
 msgstr ""
 
-#: src/olympia/devhub/forms.py:688
+#: src/olympia/devhub/forms.py:689
 msgid "The platform All cannot be combined with specific platforms."
 msgstr ""
 
-#: src/olympia/devhub/forms.py:693
+#: src/olympia/devhub/forms.py:694
 msgid "A platform can only be chosen once."
 msgstr ""
 
-#: src/olympia/devhub/forms.py:706
+#: src/olympia/devhub/forms.py:707
 msgid "A review type must be selected."
 msgstr ""
 
-#: src/olympia/devhub/forms.py:788 src/olympia/editors/forms.py:114 src/olympia/zadmin/forms.py:49 src/olympia/zadmin/forms.py:52
+#: src/olympia/devhub/forms.py:789 src/olympia/editors/forms.py:114 src/olympia/editors/forms.py:254 src/olympia/zadmin/forms.py:49 src/olympia/zadmin/forms.py:52
 msgid "Select an application first"
 msgstr ""
 
-#: src/olympia/devhub/forms.py:840
+#: src/olympia/devhub/forms.py:841
 msgid "There cannot be more than 3 required add-ons."
 msgstr ""
 
@@ -3827,76 +3810,76 @@ msgstr[1] ""
 msgid "Review"
 msgstr ""
 
-#: src/olympia/devhub/tasks.py:551
+#: src/olympia/devhub/tasks.py:583
 #, python-format
 msgid "%s responded with %s (%s)."
 msgstr ""
 
-#: src/olympia/devhub/tasks.py:555
+#: src/olympia/devhub/tasks.py:587
 #, python-format
 msgid "Connection to \"%s\" timed out."
 msgstr ""
 
-#: src/olympia/devhub/tasks.py:557
+#: src/olympia/devhub/tasks.py:589
 #, python-format
 msgid "Could not contact host at \"%s\"."
 msgstr ""
 
-#: src/olympia/devhub/utils.py:104
+#: src/olympia/devhub/utils.py:105
 #, python-format
 msgid "Validation generated too many errors/warnings so %s messages were truncated. After addressing the visible messages, you'll be able to see the others."
 msgstr ""
 
-#: src/olympia/devhub/views.py:183
+#: src/olympia/devhub/views.py:181
 msgid "All My Add-ons"
 msgstr ""
 
-#: src/olympia/devhub/views.py:210
+#: src/olympia/devhub/views.py:208
 msgid "All Activity"
 msgstr ""
 
-#: src/olympia/devhub/views.py:211
+#: src/olympia/devhub/views.py:209
 msgid "Add-on Updates"
 msgstr ""
 
-#: src/olympia/devhub/views.py:212
+#: src/olympia/devhub/views.py:210
 msgid "Add-on Status"
 msgstr ""
 
-#: src/olympia/devhub/views.py:213
+#: src/olympia/devhub/views.py:211
 msgid "User Collections"
 msgstr ""
 
-#: src/olympia/devhub/views.py:214 src/olympia/devhub/templates/devhub/docs/policies-maintenance.html:68 src/olympia/pages/templates/pages/dev_faq.html:38
+#: src/olympia/devhub/views.py:212 src/olympia/devhub/templates/devhub/docs/policies-maintenance.html:68 src/olympia/pages/templates/pages/dev_faq.html:38
 #: src/olympia/pages/templates/pages/dev_faq.html:484
 msgid "User Reviews"
 msgstr ""
 
-#: src/olympia/devhub/views.py:327 src/olympia/devhub/views.py:331 src/olympia/devhub/views.py:484 src/olympia/devhub/views.py:513 src/olympia/devhub/views.py:564 src/olympia/devhub/views.py:1150
+#: src/olympia/devhub/views.py:325 src/olympia/devhub/views.py:329 src/olympia/devhub/views.py:484 src/olympia/devhub/views.py:513 src/olympia/devhub/views.py:564 src/olympia/devhub/views.py:1156
 msgid "Changes successfully saved."
 msgstr ""
 
-#: src/olympia/devhub/views.py:334 src/olympia/devhub/views.py:1631
+#: src/olympia/devhub/views.py:332 src/olympia/devhub/views.py:1637
 msgid "Please check the form for errors."
 msgstr ""
 
-#: src/olympia/devhub/views.py:346
+#: src/olympia/devhub/views.py:344
 msgid "Add-on cannot be deleted. Disable this add-on instead."
 msgstr ""
 
-#: src/olympia/devhub/views.py:356
+#: src/olympia/devhub/views.py:354
 msgid "Theme deleted."
 msgstr ""
 
-#: src/olympia/devhub/views.py:356
+#: src/olympia/devhub/views.py:354
 msgid "Add-on deleted."
 msgstr ""
 
-#: src/olympia/devhub/views.py:362
+#: src/olympia/devhub/views.py:360
 msgid "URL name was incorrect. Theme was not deleted."
 msgstr ""
 
-#: src/olympia/devhub/views.py:367
+#: src/olympia/devhub/views.py:365
 msgid "URL name was incorrect. Add-on was not deleted."
 msgstr ""
 
@@ -3924,7 +3907,7 @@ msgstr ""
 msgid "Check Add-on Compatibility"
 msgstr ""
 
-#: src/olympia/devhub/views.py:808 src/olympia/signing/views.py:90
+#: src/olympia/devhub/views.py:808 src/olympia/signing/views.py:95
 msgid "You cannot submit this type of add-on"
 msgstr ""
 
@@ -3954,33 +3937,33 @@ msgstr ""
 msgid "There was an error uploading your preview."
 msgstr ""
 
-#: src/olympia/devhub/views.py:1189
+#: src/olympia/devhub/views.py:1195
 #, python-format
 msgid "Version %s disabled."
 msgstr ""
 
-#: src/olympia/devhub/views.py:1193
+#: src/olympia/devhub/views.py:1199
 #, python-format
 msgid "Version %s deleted."
 msgstr ""
 
-#: src/olympia/devhub/views.py:1203
+#: src/olympia/devhub/views.py:1209
 msgid "This upload has failed validation, and may lack complete validation results. Please take due care when reviewing it."
 msgstr ""
 
-#: src/olympia/devhub/views.py:1677
+#: src/olympia/devhub/views.py:1683
 msgid "Preliminary Review Requested."
 msgstr ""
 
-#: src/olympia/devhub/views.py:1678
+#: src/olympia/devhub/views.py:1684
 msgid "Full Review Requested."
 msgstr ""
 
-#: src/olympia/devhub/views.py:1779
+#: src/olympia/devhub/views.py:1783
 msgid "Your old credentials were revoked and are no longer valid. Be sure to update all API clients with the new credentials."
 msgstr ""
 
-#: src/olympia/devhub/views.py:1797
+#: src/olympia/devhub/views.py:1801
 msgid "New API key created"
 msgstr ""
 
@@ -4010,7 +3993,7 @@ msgstr ""
 msgid "{0} :: Search"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/devhub_search.html:6 src/olympia/devhub/templates/devhub/search.html:8 src/olympia/editors/forms.py:435 src/olympia/editors/forms.py:437
+#: src/olympia/devhub/templates/devhub/devhub_search.html:6 src/olympia/devhub/templates/devhub/search.html:8 src/olympia/editors/forms.py:534 src/olympia/editors/forms.py:536
 #: src/olympia/editors/templates/editors/queue.html:27 src/olympia/editors/templates/editors/themes/queue_list.html:14 src/olympia/search/templates/search/collections.html:17
 #: src/olympia/search/templates/search/personas.html:18 src/olympia/search/templates/search/results.html:18 src/olympia/search/templates/search/mobile/results.html:8
 #: src/olympia/templates/search.html:14 src/olympia/templates/impala/search.html:18
@@ -4070,12 +4053,12 @@ msgstr ""
 msgid "Start Making Add-ons"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/index.html:86 src/olympia/devhub/templates/devhub/addons/listing/items.html:25 src/olympia/devhub/templates/devhub/includes/addon_details.html:15
+#: src/olympia/devhub/templates/devhub/index.html:86 src/olympia/devhub/templates/devhub/addons/listing/items.html:25 src/olympia/devhub/templates/devhub/includes/addon_details.html:20
 #: src/olympia/devhub/templates/devhub/personas/edit.html:43
 msgid "Status:"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/index.html:90 src/olympia/devhub/templates/devhub/includes/addon_details.html:100
+#: src/olympia/devhub/templates/devhub/index.html:90 src/olympia/devhub/templates/devhub/includes/addon_details.html:87
 msgid "Visibility:"
 msgstr ""
 
@@ -4083,11 +4066,11 @@ msgstr ""
 msgid "Latest Version:"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/index.html:109 src/olympia/devhub/templates/devhub/includes/addon_details.html:145 src/olympia/devhub/templates/devhub/personas/edit.html:49
+#: src/olympia/devhub/templates/devhub/index.html:109 src/olympia/devhub/templates/devhub/includes/addon_details.html:131 src/olympia/devhub/templates/devhub/personas/edit.html:49
 msgid "Queue Position:"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/index.html:110 src/olympia/devhub/templates/devhub/includes/addon_details.html:146 src/olympia/devhub/templates/devhub/personas/edit.html:50
+#: src/olympia/devhub/templates/devhub/index.html:110 src/olympia/devhub/templates/devhub/includes/addon_details.html:132 src/olympia/devhub/templates/devhub/personas/edit.html:50
 #, python-format
 msgid "%(position)s of %(total)s"
 msgstr ""
@@ -4189,16 +4172,6 @@ msgstr ""
 msgid "Do you want your add-on to be distributed on this site?"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/validate_addon.html:49 src/olympia/devhub/templates/devhub/addons/submit/upload.html:30 src/olympia/devhub/templates/devhub/versions/add_file_modal.html:14
-#: src/olympia/devhub/templates/devhub/versions/add_file_modal.html:53 src/olympia/devhub/templates/devhub/versions/list.html:298
-msgid "Warning:"
-msgstr ""
-
-#: src/olympia/devhub/templates/devhub/validate_addon.html:50 src/olympia/devhub/templates/devhub/addons/submit/upload.html:31
-#, python-format
-msgid "Submission of unlisted add-ons for signing is currently in an open beta. Please <a href=\"%(url)s\" target=\"_blank\">report any bugs</a> that you encounter."
-msgstr ""
-
 #. first parameter is a filename like lorem-ipsum-1.0.2.xpi
 #: src/olympia/devhub/templates/devhub/validation.html:5
 msgid "Validation Results for {0}"
@@ -4273,7 +4246,7 @@ msgstr ""
 msgid "Update Compatibility"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/addons/ajax_compat_update.html:4
+#: src/olympia/devhub/templates/devhub/addons/ajax_compat_update.html:4 src/olympia/devhub/templates/devhub/versions/edit.html:45
 msgid "Adjusting application information here will allow users to install your add-on even if the install manifest in the package indicates that the add-on is incompatible."
 msgstr ""
 
@@ -4285,9 +4258,9 @@ msgstr ""
 msgid "Add Another Application&hellip;"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/addons/ajax_compat_update.html:38 src/olympia/devhub/templates/devhub/addons/owner.html:86 src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:46
-#: src/olympia/devhub/templates/devhub/versions/list.html:351 src/olympia/devhub/templates/devhub/versions/list.html:353 src/olympia/templates/impala/base.html:132
-#: src/olympia/templates/impala/base.html:143 src/olympia/templates/impala/base.html:161 src/olympia/templates/impala/base.html:171
+#: src/olympia/devhub/templates/devhub/addons/ajax_compat_update.html:38 src/olympia/devhub/templates/devhub/addons/owner.html:86 src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:45
+#: src/olympia/devhub/templates/devhub/versions/list.html:349 src/olympia/devhub/templates/devhub/versions/list.html:351 src/olympia/templates/impala/base.html:129
+#: src/olympia/templates/impala/base.html:140 src/olympia/templates/impala/base.html:158 src/olympia/templates/impala/base.html:168
 msgid "Close"
 msgstr ""
 
@@ -4321,7 +4294,7 @@ msgstr ""
 msgid "Manage Authors & License"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/addons/owner.html:29 src/olympia/editors/templates/editors/review.html:270
+#: src/olympia/devhub/templates/devhub/addons/owner.html:29 src/olympia/editors/helpers.py:362 src/olympia/editors/templates/editors/review.html:270
 msgid "Authors"
 msgstr ""
 
@@ -4390,17 +4363,11 @@ msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/basic.html:52
 msgid ""
-"A short explanation of your add-on's basic\n"
-"                          functionality that is displayed in search and browse\n"
-"                          listings, as well as at the top of your add-on's\n"
-"                          details page. It is only relevant for listed add-ons."
+"A short explanation of your add-on's basic functionality that is displayed in search and browse listings, as well as at the top of your add-on's details page. It is only relevant for listed add-ons."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/basic.html:73
-msgid ""
-"Categories are the primary way users browse through add-ons.\n"
-"                        Choose any that fit your add-on's functionality for the most\n"
-"                        exposure. It is only relevant for listed add-ons."
+msgid "Categories are the primary way users browse through add-ons. Choose any that fit your add-on's functionality for the most exposure. It is only relevant for listed add-ons."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/basic.html:90
@@ -4410,11 +4377,7 @@ msgid ""
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/basic.html:119
-msgid ""
-"Tags help users find your add-on and should be short\n"
-"                        descriptors such as tabs, toolbar, or twitter.  You\n"
-"                        may have a maximum of {0} tags. It is only relevant\n"
-"                        for listed add-ons."
+msgid "Tags help users find your add-on and should be short descriptors such as tabs, toolbar, or twitter. You may have a maximum of {0} tags. It is only relevant for listed add-ons."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/basic.html:129 src/olympia/devhub/templates/devhub/personas/edit.html:97 src/olympia/devhub/templates/devhub/personas/submit.html:46
@@ -4442,11 +4405,7 @@ msgid "Add-on Details for {0}"
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/details.html:22
-msgid ""
-"A longer explanation of features,\n"
-"                          functionality, and other relevant information. This\n"
-"                          field is only displayed on the add-on's details\n"
-"                          page. It is only relevant for listed add-ons."
+msgid "A longer explanation of features, functionality, and other relevant information. This field is only displayed on the add-on's details page. It is only relevant for listed add-ons."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/details.html:44 src/olympia/translations/templates/translations/trans-menu.html:13
@@ -4454,10 +4413,7 @@ msgid "Default Locale"
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/details.html:45
-msgid ""
-"Information about your add-on is displayed in this locale\n"
-"                        unless you override it with a locale-specific translation.\n"
-"                        It is only relevant for listed add-ons."
+msgid "Information about your add-on is displayed in this locale unless you override it with a locale-specific translation. It is only relevant for listed add-ons."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/details.html:61 src/olympia/users/forms.py:311 src/olympia/users/templates/users/edit.html:122 src/olympia/users/templates/users/register.html:57
@@ -4467,10 +4423,8 @@ msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/details.html:63
 msgid ""
-"If your add-on has another homepage, enter its\n"
-"                          address here. If your website is localized into other\n"
-"                          languages multiple translations of this field can be\n"
-"                          added. It is only relevant for listed add-ons."
+"If your add-on has another homepage, enter its address here. If your website is localized into other languages multiple translations of this field can be added. It is only relevant for listed add-"
+"ons."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/media.html:3
@@ -4488,19 +4442,14 @@ msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/support.html:22
 msgid ""
-"If you wish to display an e-mail address for support\n"
-"                          inquiries, enter it here. If you have different\n"
-"                          addresses for each language multiple translations of\n"
-"                          this field can be added. It is only relevant for\n"
-"                          listed add-ons."
+"If you wish to display an e-mail address for support inquiries, enter it here. If you have different addresses for each language multiple translations of this field can be added. It is only "
+"relevant for listed add-ons."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/support.html:45
 msgid ""
-"If your add-on has a support website or forum, enter\n"
-"                          its address here. If your website is localized into\n"
-"                          other languages, multiple translations of this field can\n"
-"                          be added. It is only relevant for listed add-ons."
+"If your add-on has a support website or forum, enter its address here. If your website is localized into other languages, multiple translations of this field can be added. It is only relevant for "
+"listed add-ons."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:6
@@ -4514,11 +4463,8 @@ msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:23
 msgid ""
-"Any information end users may want to know that isn't\n"
-"                          necessarily applicable to the add-on summary or description.\n"
-"                          Common uses include listing known major bugs, information on\n"
-"                          how to report bugs, anticipated release date of a new version,\n"
-"                          etc. It is only relevant for listed add-ons."
+"Any information end users may want to know that isn't necessarily applicable to the add-on summary or description. Common uses include listing known major bugs, information on how to report bugs, "
+"anticipated release date of a new version, etc. It is only relevant for listed add-ons."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:46
@@ -4530,9 +4476,7 @@ msgid "Add-on Flags"
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:69
-msgid ""
-"These flags are used to classify add-ons. It is only\n"
-"                        relevant for listed add-ons."
+msgid "These flags are used to classify add-ons. It is only relevant for listed add-ons."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:74
@@ -4548,9 +4492,7 @@ msgid "View Source?"
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:90
-msgid ""
-"Whether the source of your add-on can be displayed in our\n"
-"                        online viewer. It is only relevant for listed add-ons."
+msgid "Whether the source of your add-on can be displayed in our online viewer. It is only relevant for listed add-ons."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:94
@@ -4566,10 +4508,7 @@ msgid "Public Stats?"
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:102
-msgid ""
-"Whether the download and usage stats of your add-on can\n"
-"                        be displayed in our online viewer.\n"
-"                        It is only relevant for listed add-ons."
+msgid "Whether the download and usage stats of your add-on can be displayed in our online viewer. It is only relevant for listed add-ons."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:107
@@ -4585,10 +4524,7 @@ msgid "Upgrade SDK?"
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:116
-msgid ""
-"If selected, we will try to automatically upgrade your\n"
-"                        add-on when a new version of the SDK is released.\n"
-"                        It is only relevant for listed add-ons."
+msgid "If selected, we will try to automatically upgrade your add-on when a new version of the SDK is released. It is only relevant for listed add-ons."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:121
@@ -4639,10 +4575,8 @@ msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/forms_shared/media.html:16
 msgid ""
-"Upload an icon for your add-on or choose from one of ours. The\n"
-"                      icon is displayed nearly everywhere your add-on is. Uploaded images\n"
-"                      must be one of the following image types: .png, .jpg.\n"
-"                      It is only relevant for listed add-ons."
+"Upload an icon for your add-on or choose from one of ours. The icon is displayed nearly everywhere your add-on is. Uploaded images must be one of the following image types: .png, .jpg. It is only "
+"relevant for listed add-ons."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/forms_shared/media.html:25
@@ -4655,9 +4589,7 @@ msgid "32x32px"
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/forms_shared/media.html:39
-msgid ""
-"Used in listings of add-ons, like search results\n"
-"                            and featured add-ons."
+msgid "Used in listings of add-ons, like search results and featured add-ons."
 msgstr ""
 
 #. The size of the icon
@@ -4752,16 +4684,14 @@ msgid "Deleting your add-on will permanently remove it from the site and prevent
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:24
-msgid ""
-"Enter the following text confirm your decision:\n"
-"           {slug}"
+msgid "Enter the following text confirm your decision: {slug}"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:34
+#: src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:33
 msgid "Please tell us why you are deleting your theme:"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:36
+#: src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:35
 msgid "Please tell us why you are deleting your add-on:"
 msgstr ""
 
@@ -4798,8 +4728,8 @@ msgstr ""
 msgid "Daily statistics on downloads and users."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/addons/listing/item_actions.html:45 src/olympia/stats/templates/stats/stats.html:75 src/olympia/stats/templates/stats/stats.html:79
-#: src/olympia/stats/templates/stats/stats.html:81
+#: src/olympia/devhub/templates/devhub/addons/listing/item_actions.html:45 src/olympia/stats/templates/stats/stats.html:31 src/olympia/stats/templates/stats/stats.html:35
+#: src/olympia/stats/templates/stats/stats.html:37
 msgid "Statistics"
 msgstr ""
 
@@ -4918,10 +4848,7 @@ msgid "Your add-on has been submitted to the Full Review queue."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/submit/done.html:18
-msgid ""
-"You'll receive an email once it has been reviewed by an editor. In\n"
-"          the meantime, you and your friends can install it directly from its\n"
-"          details page:"
+msgid "You'll receive an email once it has been reviewed by an editor. In the meantime, you and your friends can install it directly from its details page:"
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/submit/done.html:27 src/olympia/devhub/templates/devhub/addons/submit/done.html:77 src/olympia/devhub/templates/devhub/personas/submit_done.html:16
@@ -5127,11 +5054,11 @@ msgstr ""
 msgid "Use the fields below to upload your add-on package and select any platform restrictions. After upload, a series of automated validation tests will be run on your file."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/addons/submit/upload.html:59 src/olympia/devhub/templates/devhub/versions/add_file_modal.html:39
+#: src/olympia/devhub/templates/devhub/addons/submit/upload.html:51 src/olympia/devhub/templates/devhub/versions/add_file_modal.html:28
 msgid "Which platforms is this file compatible with?"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/addons/submit/upload.html:67 src/olympia/devhub/templates/devhub/versions/add_file_modal.html:65
+#: src/olympia/devhub/templates/devhub/addons/submit/upload.html:59 src/olympia/devhub/templates/devhub/versions/add_file_modal.html:45
 msgid "Administrative overrides"
 msgstr ""
 
@@ -5241,8 +5168,8 @@ msgstr ""
 
 #: src/olympia/devhub/templates/devhub/docs/policies-contact.html:44
 msgid ""
-"If you've found a problem with the site, we'd love to fix it. Please <a href=\"https://github.com/mozilla/olympia/issues\">file a bug report</a> in GitHub, including the location of the problem and "
-"how you encountered it."
+"If you've found a problem with the site, we'd love to fix it. Please <a href=\"https://github.com/mozilla/addons/issues/new\">file a bug report</a> in GitHub, including the location of the problem "
+"and how you encountered it."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/docs/policies-maintenance.html:3 src/olympia/devhub/templates/devhub/docs/policies-maintenance.html:7
@@ -5809,7 +5736,7 @@ msgstr ""
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:282
 msgid ""
-"Add-ons that store or otherwise handle browsing data must support <a href=\"https://developer.mozilla.org/En/Supporting_private_browsing_mode\">Private Browsing Mode</a>.  During a Private Browsing "
+"Add-ons that store or otherwise handle browsing data must support <a href=\"https://developer.mozilla.org/En/Supporting_private_browsing_mode\">Private Browsing Mode</a>. During a Private Browsing "
 "session, no browsing data can be written to disk, and all of this data must be cleared when Firefox quits or the Private Browsing session ends."
 msgstr ""
 
@@ -5974,129 +5901,95 @@ msgstr ""
 msgid "How to get in touch with us regarding these policies or your add-on."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:6
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:10
 msgid "You have disabled this add-on"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:20
-msgid ""
-"Your add-on's listing is disabled and is not showing\n"
-"                             anywhere in our gallery or update service."
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:24
+msgid "Your add-on's listing is disabled and is not showing anywhere in our gallery or update service."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:25
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:27
 msgid "Please complete your add-on."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:29
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:30
 msgid "You will receive an email when the review is complete."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:34
-msgid ""
-"You will receive an email when the review is complete. Until\n"
-"                             then, your add-on is not listed in our gallery but can be\n"
-"                             accessed directly from its details page."
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:33
+msgid "You will receive an email when the review is complete. Until then, your add-on is not listed in our gallery but can be accessed directly from its details page."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:38 src/olympia/devhub/templates/devhub/includes/addon_details.html:48
-msgid ""
-"You will receive an email when the review is\n"
-"                             complete and your add-on is signed."
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:37 src/olympia/devhub/templates/devhub/includes/addon_details.html:45
+msgid "You will receive an email when the review is complete and your add-on is signed."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:44
-msgid ""
-"You will receive an email when the review is complete. Until\n"
-"                             then, your add-on is not listed in our gallery but can be\n"
-"                             accessed directly from its details page. "
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:41
+msgid "You will receive an email when the review is complete. Until then, your add-on is not listed in our gallery but can be accessed directly from its details page. "
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:54
-msgid ""
-"Your add-on is displayed in our gallery and users are\n"
-"                             receiving automatic updates."
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:49
+msgid "Your add-on is displayed in our gallery and users are receiving automatic updates."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:57
-msgid ""
-"Your add-on has been signed and can be bundled with an\n"
-"                             application installer."
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:52
+msgid "Your add-on has been signed and can be bundled with an application installer."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:63
-msgid ""
-"Your add-on was disabled by a site administrator and is no\n"
-"                             longer shown in our gallery. If you have any questions,\n"
-"                             please email amo-admins@mozilla.org."
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:56
+msgid "Your add-on was disabled by a site administrator and is no longer shown in our gallery. If you have any questions, please email amo-admins@mozilla.org."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:70
-msgid ""
-"Your add-on is displayed in our gallery as experimental\n"
-"                             and users are receiving automatic updates. Some features\n"
-"                             are unavailable to your add-on."
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:62
+msgid "Your add-on is displayed in our gallery as experimental and users are receiving automatic updates. Some features are unavailable to your add-on."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:74
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:66
 msgid "Your add-on has been signed."
 msgstr ""
 
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:69
+msgid ""
+"You will receive an email when the full review is complete. Until then, your add-on is displayed in our gallery as experimental and users are receiving automatic updates. Some features are "
+"unavailable to your add-on."
+msgstr ""
+
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:74
+msgid "You will receive an email when the full review is complete, making you able to bundle your add-on with an application installer."
+msgstr ""
+
 #: src/olympia/devhub/templates/devhub/includes/addon_details.html:79
-msgid ""
-"You will receive an email when the full review is complete.\n"
-"                             Until then, your add-on is displayed in our gallery as\n"
-"                             experimental and users are receiving automatic updates.\n"
-"                             Some features are unavailable to your add-on."
+msgid "All add-ons hosted in our gallery must now be reviewed by an editor. If you wish to continue hosting your add-on, please click to select a review process."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:84
-msgid ""
-"You will receive an email when the full review is\n"
-"                             complete, making you able to bundle your add-on with an\n"
-"                             application installer."
-msgstr ""
-
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:91
-msgid ""
-"All add-ons hosted in our gallery must now be reviewed by an\n"
-"                             editor. If you wish to continue hosting your add-on, please\n"
-"                             click to select a review process."
-msgstr ""
-
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:113
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:100
 msgid "Current Version:"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:115
-msgid ""
-"This is the version of your add-on that will\n"
-"                                           be installed if someone clicks the Install\n"
-"                                           button on addons.mozilla.org. It is only\n"
-"                                           relevant for listed add-ons."
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:102
+msgid "This is the version of your add-on that will be installed if someone clicks the Install button on addons.mozilla.org. It is only relevant for listed add-ons."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:123
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:110
 msgid "Created:"
 msgstr ""
 
 #. {0} is a date. dennis-ignore: E201
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:125 src/olympia/devhub/templates/devhub/includes/addon_details.html:131
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:112 src/olympia/devhub/templates/devhub/includes/addon_details.html:118
 #, python-format
 msgid "%%b %%e, %%Y"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:136
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:123
 msgid "Next Version:"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:138
-msgid ""
-"This is the newest uploaded version, however\n"
-"                                           it isn’t live on the site yet."
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:125
+msgid "This is the newest uploaded version, however it isn’t live on the site yet."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:144 src/olympia/devhub/templates/devhub/versions/list.html:30
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:130 src/olympia/devhub/templates/devhub/versions/list.html:30
 msgid "Queues are not reviewed strictly in order"
 msgstr ""
 
@@ -6164,9 +6057,7 @@ msgid "View the blog &#9658;"
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/includes/license_form.html:6
-msgid ""
-"Please choose a license appropriate for the rights you grant on your source code.\n"
-"                  It is only relevant for listed add-ons."
+msgid "Please choose a license appropriate for the rights you grant on your source code. It is only relevant for listed add-ons."
 msgstr ""
 
 #. {0} is a list of HTML tags.
@@ -6193,14 +6084,11 @@ msgstr[1] ""
 #: src/olympia/devhub/templates/devhub/includes/policy_form.html:4
 msgid ""
 "Users will be required to accept the following End-User License Agreement (EULA) prior to installing your add-on. The presence of a EULA significantly affects the number of downloads an add-on "
-"receives. Please note that a EULA is not the same as a code license, such as the GPL or MPL.\n"
-"                It is only relevant for listed add-ons."
+"receives. Please note that a EULA is not the same as a code license, such as the GPL or MPL.It is only relevant for listed add-ons."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/policy_form.html:21
-msgid ""
-"If your add-on transmits any data from the user's computer, a privacy policy is required that explains what data is sent and how it is used.\n"
-"                It is only relevant for listed add-ons."
+#: src/olympia/devhub/templates/devhub/includes/policy_form.html:24
+msgid "If your add-on transmits any data from the user's computer, a privacy policy is required that explains what data is sent and how it is used. It is only relevant for listed add-ons."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/includes/source_form_field.html:2
@@ -6368,12 +6256,8 @@ msgstr ""
 msgid "Add some tags to describe your Theme."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/personas/edit.html:106
-msgid ""
-"A short explanation of your theme's\n"
-"                                basic functionality that is displayed in\n"
-"                                search and browse listings, as well as at\n"
-"                                the top of your theme's details page."
+#: src/olympia/devhub/templates/devhub/personas/edit.html:106 src/olympia/devhub/templates/devhub/personas/submit.html:54
+msgid "A short explanation of your theme's basic functionality that is displayed in search and browse listings, as well as at the top of your theme's details page."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/personas/edit.html:122 src/olympia/devhub/templates/devhub/personas/submit.html:68
@@ -6443,7 +6327,7 @@ msgid "Upon upload and form submission, the AMO Team will review your updated de
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/personas/edit.html:241
-msgid "Your previously resubmitted design,  which is under pending review."
+msgid "Your previously resubmitted design, which is under pending review."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/personas/edit.html:245
@@ -6510,14 +6394,6 @@ msgstr ""
 
 #: src/olympia/devhub/templates/devhub/personas/submit.html:33
 msgid "Give your Theme a name."
-msgstr ""
-
-#: src/olympia/devhub/templates/devhub/personas/submit.html:54
-msgid ""
-"A short explanation of your theme's\n"
-"                                      basic functionality that is displayed in\n"
-"                                      search and browse listings, as well as at\n"
-"                                      the top of your theme's details page."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/personas/submit.html:198
@@ -6594,30 +6470,16 @@ msgstr ""
 msgid "Files added to reviewed versions must be reviewed before they will be available for download."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/add_file_modal.html:15
-#, python-format
-msgid ""
-"Submission of updates to unlisted add-ons for signing is currently in an open beta. Manual review may still be required for a large number of add-ons. Please <a href=\"%(url)s\" target=\"_blank"
-"\">report any bugs</a> that you encounter."
-msgstr ""
-
-#: src/olympia/devhub/templates/devhub/versions/add_file_modal.html:35
+#: src/olympia/devhub/templates/devhub/versions/add_file_modal.html:24
 msgid "Select the target platform for this file."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/add_file_modal.html:46
+#: src/olympia/devhub/templates/devhub/versions/add_file_modal.html:35
 msgid "Which review type would you like to nominate for?"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/add_file_modal.html:51
+#: src/olympia/devhub/templates/devhub/versions/add_file_modal.html:40
 msgid "Only publish this version to my beta channel."
-msgstr ""
-
-#: src/olympia/devhub/templates/devhub/versions/add_file_modal.html:54
-#, python-format
-msgid ""
-"The behavior of the beta channel has changed to accommodate <a href=\"%(addon_signing_url)s\" target=\"_blank\">mandatory add-on signing</a>. The new process is currently in an open beta, and may "
-"change significantly in the near future. Please <a href=\"%(issues_url)s\" target=\"_blank\">report any bugs</a> that you encounter."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/versions/edit.html:5
@@ -6641,19 +6503,10 @@ msgstr ""
 msgid "Upload Another File"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/edit.html:45
-msgid ""
-"Adjusting application information here will allow users to install your\n"
-"                          add-on even if the install manifest in the package indicates that the\n"
-"                          add-on is incompatible."
-msgstr ""
-
 #: src/olympia/devhub/templates/devhub/versions/edit.html:74
 msgid ""
-"Information about changes in this release, new features,\n"
-"                              known bugs, and other useful information specific to this\n"
-"                              release/version. This information is also shown in the\n"
-"                              Add-ons Manager when updating."
+"Information about changes in this release, new features, known bugs, and other useful information specific to this release/version. This information is also shown in the Add-ons Manager when "
+"updating."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/versions/edit.html:99
@@ -6665,10 +6518,7 @@ msgid "Notes for Reviewers"
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/versions/edit.html:114
-msgid ""
-"Optionally, enter any information that may be useful\n"
-"                              to the Editor reviewing this add-on, such as test\n"
-"                              account information."
+msgid "Optionally, enter any information that may be useful to the Editor reviewing this add-on, such as test account information."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/versions/edit.html:127
@@ -6746,7 +6596,7 @@ msgstr ""
 msgid "Request Preliminary Review"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:80 src/olympia/devhub/templates/devhub/versions/list.html:327 src/olympia/devhub/templates/devhub/versions/list.html:350
+#: src/olympia/devhub/templates/devhub/versions/list.html:80 src/olympia/devhub/templates/devhub/versions/list.html:325 src/olympia/devhub/templates/devhub/versions/list.html:348
 msgid "Cancel Review Request"
 msgstr ""
 
@@ -6775,7 +6625,7 @@ msgid "Unlisted:"
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/versions/list.html:114
-msgid "Not distributed on {0}. Developers will upload new versions for signing and distribute the add-ons on their own. (beta)"
+msgid "Not distributed on {0}. Developers will upload new versions for signing and distribute the add-ons on their own."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/versions/list.html:122
@@ -6838,81 +6688,73 @@ msgid "<strong>Important:</strong> Once a version has been deleted, you may not 
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/versions/list.html:230
-msgid ""
-"Deleting a version which has already been reviewed\n"
-"               may also cause a significant delay in the review of\n"
-"               your next update."
-msgstr ""
-
-#: src/olympia/devhub/templates/devhub/versions/list.html:233
 msgid "Are you sure you wish to delete this version?"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:238
+#: src/olympia/devhub/templates/devhub/versions/list.html:235
 msgid "Delete Version"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:240
+#: src/olympia/devhub/templates/devhub/versions/list.html:237
 msgid "Disable Version"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:247
+#: src/olympia/devhub/templates/devhub/versions/list.html:244
 msgid "Add a new Version"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:249
+#: src/olympia/devhub/templates/devhub/versions/list.html:246
 msgid "Add Version"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:256 src/olympia/devhub/templates/devhub/versions/list.html:274
+#: src/olympia/devhub/templates/devhub/versions/list.html:253 src/olympia/devhub/templates/devhub/versions/list.html:279
 msgid "Hide Add-on"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:259
+#: src/olympia/devhub/templates/devhub/versions/list.html:256
 msgid "Hiding your add-on will prevent it from appearing anywhere in our gallery and will stop users from receiving automatic updates."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:265
+#: src/olympia/devhub/templates/devhub/versions/list.html:263
+msgid "The files awaiting review will be disabled and you will need to upload new versions."
+msgstr ""
+
+#: src/olympia/devhub/templates/devhub/versions/list.html:270
 msgid "Are you sure you wish to hide your add-on?"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:286 src/olympia/devhub/templates/devhub/versions/list.html:315
+#: src/olympia/devhub/templates/devhub/versions/list.html:291 src/olympia/devhub/templates/devhub/versions/list.html:313
 msgid "Unlist Add-on"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:289
+#: src/olympia/devhub/templates/devhub/versions/list.html:294
 #, python-format
 msgid ""
 "Unlisting your add-on will make it (and each of its versions/files) invisible on this website. It won't show up in searches, won't have a public facing page, and won't be updated automatically for "
-"current users.  It is recommended for unlisted add-ons to provide a custom <a href=\"%(update_url)s\" target=\"_blank\">updateURL</a> in their manifest file for automatic updates."
+"current users. It is recommended for unlisted add-ons to provide a custom <a href=\"%(update_url)s\" target=\"_blank\">updateURL</a> in their manifest file for automatic updates."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:299
-#, python-format
-msgid "Switching add-ons to unlisted is currently in an open beta. Please <a href=\"%(url)s\" target=\"_blank\">report any bugs</a> that you encounter."
-msgstr ""
-
-#: src/olympia/devhub/templates/devhub/versions/list.html:305
+#: src/olympia/devhub/templates/devhub/versions/list.html:303
 msgid "Unlisting an add-on is irreversible!"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:305
+#: src/olympia/devhub/templates/devhub/versions/list.html:303
 msgid "An unlisted add-on cannot be switched to be listed."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:307
+#: src/olympia/devhub/templates/devhub/versions/list.html:305
 msgid "Are you sure you wish to unlist your add-on?"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:330
+#: src/olympia/devhub/templates/devhub/versions/list.html:328
 msgid "Canceling your review request will leave your add-on as preliminarily reviewed."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:335
+#: src/olympia/devhub/templates/devhub/versions/list.html:333
 msgid "Canceling your review request will mark your add-on incomplete. If you do not complete your add-on after several days by re-requesting review, it will be deleted."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:343
+#: src/olympia/devhub/templates/devhub/versions/list.html:341
 msgid "Are you sure you wish to cancel your review request?"
 msgstr ""
 
@@ -7251,19 +7093,19 @@ msgstr ""
 msgid "Search by add-on name / author email"
 msgstr ""
 
-#: src/olympia/editors/forms.py:103
+#: src/olympia/editors/forms.py:103 src/olympia/editors/forms.py:244 src/olympia/editors/forms.py:257
 msgid "yes"
 msgstr ""
 
-#: src/olympia/editors/forms.py:104
+#: src/olympia/editors/forms.py:104 src/olympia/editors/forms.py:244 src/olympia/editors/forms.py:257
 msgid "no"
 msgstr ""
 
-#: src/olympia/editors/forms.py:105
+#: src/olympia/editors/forms.py:105 src/olympia/editors/forms.py:245
 msgid "Admin Flag"
 msgstr ""
 
-#: src/olympia/editors/forms.py:113
+#: src/olympia/editors/forms.py:113 src/olympia/editors/forms.py:253
 msgid "Max. Version"
 msgstr ""
 
@@ -7275,55 +7117,59 @@ msgstr ""
 msgid "Add-on Types"
 msgstr ""
 
-#: src/olympia/editors/forms.py:126 src/olympia/editors/helpers.py:267
+#: src/olympia/editors/forms.py:126 src/olympia/editors/helpers.py:279
 msgid "Platforms"
 msgstr ""
 
+#: src/olympia/editors/forms.py:237
+msgid "Search by add-on name / author email / guid"
+msgstr ""
+
 #. L10n: 0 = platform, 1 = filename, 2 = status message
-#: src/olympia/editors/forms.py:238
+#: src/olympia/editors/forms.py:342
 #, python-format
 msgid "<strong>%s</strong> &middot; %s &middot; %s"
 msgstr ""
 
-#: src/olympia/editors/forms.py:252
+#: src/olympia/editors/forms.py:356
 msgid "Comments:"
 msgstr ""
 
-#: src/olympia/editors/forms.py:256
+#: src/olympia/editors/forms.py:360
 msgid "Operating systems:"
 msgstr ""
 
-#: src/olympia/editors/forms.py:258
+#: src/olympia/editors/forms.py:362
 msgid "Applications:"
 msgstr ""
 
-#: src/olympia/editors/forms.py:260
+#: src/olympia/editors/forms.py:364
 msgid "Notify me the next time this add-on is updated. (Subsequent updates will not generate an email)"
 msgstr ""
 
-#: src/olympia/editors/forms.py:265
+#: src/olympia/editors/forms.py:369
 msgid "Clear Admin Review Flag"
 msgstr ""
 
-#: src/olympia/editors/forms.py:267
+#: src/olympia/editors/forms.py:371
 msgid "Clear more info requested flag"
 msgstr ""
 
-#: src/olympia/editors/forms.py:281
+#: src/olympia/editors/forms.py:385
 msgid "Choose a canned response..."
 msgstr ""
 
 #. L10n: Description of what can be searched for.
-#: src/olympia/editors/forms.py:324
+#: src/olympia/editors/forms.py:423
 msgid "theme name"
 msgstr ""
 
-#: src/olympia/editors/forms.py:350
+#: src/olympia/editors/forms.py:449
 msgid "Someone else is reviewing this theme."
 msgstr ""
 
 #. L10n: Description of what can be searched for.
-#: src/olympia/editors/forms.py:447
+#: src/olympia/editors/forms.py:546
 msgid "app, reviewer, or comment"
 msgstr ""
 
@@ -7339,246 +7185,264 @@ msgstr ""
 msgid "Rejected or Unreviewed"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:123 src/olympia/editors/helpers.py:136
+#: src/olympia/editors/helpers.py:125 src/olympia/editors/helpers.py:138
 msgid "Queue"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:124 src/olympia/editors/templates/editors/base.html:50 src/olympia/editors/templates/editors/base.html:65
+#: src/olympia/editors/helpers.py:126 src/olympia/editors/templates/editors/base.html:50 src/olympia/editors/templates/editors/base.html:65
 msgid "Pending Updates"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:125 src/olympia/editors/templates/editors/base.html:48 src/olympia/editors/templates/editors/base.html:63
+#: src/olympia/editors/helpers.py:127 src/olympia/editors/templates/editors/base.html:48 src/olympia/editors/templates/editors/base.html:63
 msgid "Full Reviews"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:126 src/olympia/editors/templates/editors/base.html:52 src/olympia/editors/templates/editors/base.html:67
+#: src/olympia/editors/helpers.py:128 src/olympia/editors/templates/editors/base.html:52 src/olympia/editors/templates/editors/base.html:67
 msgid "Preliminary Reviews"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:127 src/olympia/editors/templates/editors/base.html:54
+#: src/olympia/editors/helpers.py:129 src/olympia/editors/templates/editors/base.html:54
 msgid "Moderated Reviews"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:128 src/olympia/editors/templates/editors/base.html:46
+#: src/olympia/editors/helpers.py:130 src/olympia/editors/templates/editors/base.html:46
 msgid "Fast Track"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:130
+#: src/olympia/editors/helpers.py:132
 msgid "Pending Themes"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:131 src/olympia/editors/templates/editors/themes/queue.html:4
+#: src/olympia/editors/helpers.py:133 src/olympia/editors/templates/editors/themes/queue.html:4
 msgid "Flagged Themes"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:132
+#: src/olympia/editors/helpers.py:134
 msgid "Update Themes"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:137
+#: src/olympia/editors/helpers.py:139
 msgid "Unlisted Pending Updates"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:138
+#: src/olympia/editors/helpers.py:140
 msgid "Unlisted Full Reviews"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:139
+#: src/olympia/editors/helpers.py:141
 msgid "Unlisted Preliminary Reviews"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:170
+#: src/olympia/editors/helpers.py:142
+msgid "Unlisted All Add-ons"
+msgstr ""
+
+#: src/olympia/editors/helpers.py:173
 msgid "Fast Track ({0})"
 msgid_plural "Fast Track ({0})"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/olympia/editors/helpers.py:175
+#: src/olympia/editors/helpers.py:178
 msgid "Full Review ({0})"
 msgid_plural "Full Reviews ({0})"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/olympia/editors/helpers.py:180
+#: src/olympia/editors/helpers.py:183
 msgid "Pending Update ({0})"
 msgid_plural "Pending Updates ({0})"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/olympia/editors/helpers.py:185
+#: src/olympia/editors/helpers.py:188
 msgid "Preliminary Review ({0})"
 msgid_plural "Preliminary Reviews ({0})"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/olympia/editors/helpers.py:190
+#: src/olympia/editors/helpers.py:193
 msgid "Moderated Review ({0})"
 msgid_plural "Moderated Reviews ({0})"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/olympia/editors/helpers.py:196
+#: src/olympia/editors/helpers.py:199
 msgid "Unlisted Full Review ({0})"
 msgid_plural "Unlisted Full Reviews ({0})"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/olympia/editors/helpers.py:201
+#: src/olympia/editors/helpers.py:204
 msgid "Unlisted Pending Update ({0})"
 msgid_plural "Unlisted Pending Updates ({0})"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/olympia/editors/helpers.py:206
+#: src/olympia/editors/helpers.py:209
 msgid "Unlisted Preliminary Review ({0})"
 msgid_plural "Unlisted Preliminary Reviews ({0})"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/olympia/editors/helpers.py:261
-msgid "Addon"
-msgstr ""
+#: src/olympia/editors/helpers.py:214
+msgid "Unlisted All Add-ons ({0})"
+msgid_plural "Unlisted All Add-ons ({0})"
+msgstr[0] ""
+msgstr[1] ""
 
-#: src/olympia/editors/helpers.py:262
+#: src/olympia/editors/helpers.py:274
 msgid "Type"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:263
+#: src/olympia/editors/helpers.py:275
 msgid "Waiting Time"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:264 src/olympia/editors/templates/editors/review.html:285
+#: src/olympia/editors/helpers.py:276 src/olympia/editors/templates/editors/review.html:285
 msgid "Flags"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:265
+#: src/olympia/editors/helpers.py:277
 msgid "Applications"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:270
+#: src/olympia/editors/helpers.py:282
 msgid "Additional"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:285
+#: src/olympia/editors/helpers.py:302
 msgid "Site Specific"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:287
+#: src/olympia/editors/helpers.py:304
 msgid "Requires External Software"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:289
+#: src/olympia/editors/helpers.py:306
 msgid "Binary Components"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:313
+#: src/olympia/editors/helpers.py:339
 msgid "moments ago"
 msgstr ""
 
 #. L10n: first argument is number of minutes
-#: src/olympia/editors/helpers.py:316
+#: src/olympia/editors/helpers.py:342
 msgid "{0} minute"
 msgid_plural "{0} minutes"
 msgstr[0] ""
 msgstr[1] ""
 
 #. L10n: first argument is number of hours
-#: src/olympia/editors/helpers.py:320
+#: src/olympia/editors/helpers.py:346
 msgid "{0} hour"
 msgid_plural "{0} hours"
 msgstr[0] ""
 msgstr[1] ""
 
 #. L10n: first argument is number of days
-#: src/olympia/editors/helpers.py:324
+#: src/olympia/editors/helpers.py:350
 msgid "{0} day"
 msgid_plural "{0} days"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/olympia/editors/helpers.py:488
+#: src/olympia/editors/helpers.py:364
+msgid "Last Review"
+msgstr ""
+
+#: src/olympia/editors/helpers.py:366
+msgid "Last Update"
+msgstr ""
+
+#: src/olympia/editors/helpers.py:387
+msgid "No Reviews"
+msgstr ""
+
+#: src/olympia/editors/helpers.py:561
 msgid "Push to public"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:490
+#: src/olympia/editors/helpers.py:563
 msgid "Grant full review"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:505
+#: src/olympia/editors/helpers.py:578
 msgid "Request more information"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:508
+#: src/olympia/editors/helpers.py:581
 msgid "Request super-review"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:519
+#: src/olympia/editors/helpers.py:592
 msgid "Grant preliminary review"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:520
+#: src/olympia/editors/helpers.py:593
 msgid "This will mark the files as preliminarily reviewed."
 msgstr ""
 
-#: src/olympia/editors/helpers.py:522
+#: src/olympia/editors/helpers.py:595
 msgid "Use this form to request more information from the author. They will receive an email and be able to answer here. You will be notified by email when they reply."
 msgstr ""
 
-#: src/olympia/editors/helpers.py:526
+#: src/olympia/editors/helpers.py:599
 msgid ""
 "If you have concerns about this add-on's security, copyright issues, or other concerns that an administrator should look into, enter your comments in the area below. They will be sent to "
 "administrators, not the author."
 msgstr ""
 
-#: src/olympia/editors/helpers.py:532
+#: src/olympia/editors/helpers.py:605
 msgid "This will reject the add-on and remove it from the review queue."
 msgstr ""
 
-#: src/olympia/editors/helpers.py:534
-msgid "Make a comment on this version.  The author won't be able to see this."
+#: src/olympia/editors/helpers.py:607
+msgid "Make a comment on this version. The author won't be able to see this."
 msgstr ""
 
-#: src/olympia/editors/helpers.py:538
+#: src/olympia/editors/helpers.py:611
 msgid "This will reject the files and remove them from the review queue."
 msgstr ""
 
-#: src/olympia/editors/helpers.py:542
+#: src/olympia/editors/helpers.py:615
 msgid "This will mark the add-on as preliminarily reviewed. Future versions will undergo preliminary review."
 msgstr ""
 
-#: src/olympia/editors/helpers.py:547
+#: src/olympia/editors/helpers.py:620
 msgid "This will mark the files as preliminarily reviewed. Future versions will undergo preliminary review."
 msgstr ""
 
-#: src/olympia/editors/helpers.py:552
+#: src/olympia/editors/helpers.py:625
 msgid "Retain preliminary review"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:553
+#: src/olympia/editors/helpers.py:626
 msgid "This will retain the add-on as preliminarily reviewed. Future versions will undergo preliminary review."
 msgstr ""
 
-#: src/olympia/editors/helpers.py:558
+#: src/olympia/editors/helpers.py:631
 msgid "This will approve a sandboxed version of a public add-on to appear on the public side."
 msgstr ""
 
-#: src/olympia/editors/helpers.py:561
+#: src/olympia/editors/helpers.py:634
 msgid "This will reject a version of a public add-on and remove it from the queue."
 msgstr ""
 
-#: src/olympia/editors/helpers.py:564
+#: src/olympia/editors/helpers.py:637
 msgid "This will mark the add-on and its most recent version and files as public. Future versions will go into the sandbox until they are reviewed by an editor."
 msgstr ""
 
-#: src/olympia/editors/helpers.py:637
+#: src/olympia/editors/helpers.py:714
 msgid "add-on"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:940 src/olympia/editors/helpers.py:960
+#: src/olympia/editors/helpers.py:1020 src/olympia/editors/helpers.py:1040
 msgid "Flagged"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:944 src/olympia/editors/helpers.py:963
+#: src/olympia/editors/helpers.py:1024 src/olympia/editors/helpers.py:1043
 msgid "Updates"
 msgstr ""
 
@@ -7630,56 +7494,56 @@ msgstr ""
 msgid "A question about your Theme submission"
 msgstr ""
 
-#: src/olympia/editors/views.py:144
+#: src/olympia/editors/views.py:146
 msgid "New Add-ons (Under 5 days)"
 msgstr ""
 
-#: src/olympia/editors/views.py:145
+#: src/olympia/editors/views.py:147
 msgid "Passable (5 to 10 days)"
 msgstr ""
 
-#: src/olympia/editors/views.py:146
+#: src/olympia/editors/views.py:148
 msgid "Overdue (Over 10 days)"
 msgstr ""
 
-#: src/olympia/editors/views.py:532
+#: src/olympia/editors/views.py:539
 msgid "An unknown error occurred"
 msgstr ""
 
-#: src/olympia/editors/views.py:587
+#: src/olympia/editors/views.py:592
 msgid "Self-reviews are not allowed."
 msgstr ""
 
-#: src/olympia/editors/views.py:609
+#: src/olympia/editors/views.py:613
 msgid "Review successfully processed."
 msgstr ""
 
-#: src/olympia/editors/views.py:807
+#: src/olympia/editors/views.py:812
 msgid "was approved"
 msgstr ""
 
-#: src/olympia/editors/views.py:808
+#: src/olympia/editors/views.py:813
 msgid "given preliminary review"
 msgstr ""
 
-#: src/olympia/editors/views.py:809
+#: src/olympia/editors/views.py:814
 msgid "rejected"
 msgstr ""
 
-#: src/olympia/editors/views.py:810
+#: src/olympia/editors/views.py:815
 msgctxt "editors_review_history_nominated_adminreview"
 msgid "escalated"
 msgstr ""
 
-#: src/olympia/editors/views.py:812
+#: src/olympia/editors/views.py:817
 msgid "needs more information"
 msgstr ""
 
-#: src/olympia/editors/views.py:813
+#: src/olympia/editors/views.py:818
 msgid "needs super review"
 msgstr ""
 
-#: src/olympia/editors/views.py:814
+#: src/olympia/editors/views.py:819
 msgid "commented"
 msgstr ""
 
@@ -7724,28 +7588,28 @@ msgstr ""
 msgid "Unlisted Queues"
 msgstr ""
 
-#: src/olympia/editors/templates/editors/base.html:72 src/olympia/editors/templates/editors/performance.html:6
+#: src/olympia/editors/templates/editors/base.html:74 src/olympia/editors/templates/editors/performance.html:6
 msgid "Performance"
 msgstr ""
 
-#: src/olympia/editors/templates/editors/base.html:75 src/olympia/editors/templates/editors/themes/base.html:19 src/olympia/editors/templates/editors/themes/base.html:38
+#: src/olympia/editors/templates/editors/base.html:77 src/olympia/editors/templates/editors/themes/base.html:19 src/olympia/editors/templates/editors/themes/base.html:38
 msgid "Logs"
 msgstr ""
 
-#: src/olympia/editors/templates/editors/base.html:78 src/olympia/editors/templates/editors/reviewlog.html:4 src/olympia/editors/templates/editors/reviewlog.html:27
+#: src/olympia/editors/templates/editors/base.html:80 src/olympia/editors/templates/editors/reviewlog.html:4 src/olympia/editors/templates/editors/reviewlog.html:27
 msgid "Add-on Review Log"
 msgstr ""
 
-#: src/olympia/editors/templates/editors/base.html:80 src/olympia/editors/templates/editors/eventlog.html:4 src/olympia/editors/templates/editors/eventlog.html:8
+#: src/olympia/editors/templates/editors/base.html:82 src/olympia/editors/templates/editors/eventlog.html:4 src/olympia/editors/templates/editors/eventlog.html:8
 #: src/olympia/editors/templates/editors/eventlog_detail.html:4
 msgid "Moderated Review Log"
 msgstr ""
 
-#: src/olympia/editors/templates/editors/base.html:82 src/olympia/editors/templates/editors/beta_signed_log.html:4 src/olympia/editors/templates/editors/beta_signed_log.html:8
+#: src/olympia/editors/templates/editors/base.html:84 src/olympia/editors/templates/editors/beta_signed_log.html:4 src/olympia/editors/templates/editors/beta_signed_log.html:8
 msgid "Signed Beta Files Log"
 msgstr ""
 
-#: src/olympia/editors/templates/editors/base.html:87 src/olympia/editors/templates/editors/includes/daily-message.html:4
+#: src/olympia/editors/templates/editors/base.html:89 src/olympia/editors/templates/editors/includes/daily-message.html:4
 msgid "Announcement"
 msgstr ""
 
@@ -7966,45 +7830,45 @@ msgstr ""
 msgid "clear search"
 msgstr ""
 
-#: src/olympia/editors/templates/editors/queue.html:72 src/olympia/editors/templates/editors/queue.html:122
+#: src/olympia/editors/templates/editors/queue.html:78 src/olympia/editors/templates/editors/queue.html:128
 msgid "Process Reviews"
 msgstr ""
 
-#: src/olympia/editors/templates/editors/queue.html:80
+#: src/olympia/editors/templates/editors/queue.html:86
 msgid "Moderation actions:"
 msgstr ""
 
-#: src/olympia/editors/templates/editors/queue.html:90
+#: src/olympia/editors/templates/editors/queue.html:96
 #, python-format
 msgid "by %(user)s on %(date)s %(stars)s (%(locale)s)"
 msgstr ""
 
-#: src/olympia/editors/templates/editors/queue.html:106
+#: src/olympia/editors/templates/editors/queue.html:112
 #, python-format
 msgid "<strong>%(reason)s</strong> <span class=\"light\">Flagged by %(user)s on %(date)s</span>"
 msgstr ""
 
-#: src/olympia/editors/templates/editors/queue.html:119
-msgid "All reviews have been moderated.  Good work!"
+#: src/olympia/editors/templates/editors/queue.html:125
+msgid "All reviews have been moderated. Good work!"
 msgstr ""
 
-#: src/olympia/editors/templates/editors/queue.html:161
+#: src/olympia/editors/templates/editors/queue.html:167
 msgid "Version Notes / Notes for Reviewer"
 msgstr ""
 
-#: src/olympia/editors/templates/editors/queue.html:169
+#: src/olympia/editors/templates/editors/queue.html:175
 msgid "There are currently no add-ons of this type to review."
 msgstr ""
 
-#: src/olympia/editors/templates/editors/queue.html:181 src/olympia/editors/templates/editors/themes/queue_list.html:85
+#: src/olympia/editors/templates/editors/queue.html:187 src/olympia/editors/templates/editors/themes/queue_list.html:85
 msgid "Helpful Links:"
 msgstr ""
 
-#: src/olympia/editors/templates/editors/queue.html:182
+#: src/olympia/editors/templates/editors/queue.html:188
 msgid "Add-on Policy"
 msgstr ""
 
-#: src/olympia/editors/templates/editors/queue.html:184
+#: src/olympia/editors/templates/editors/queue.html:190
 msgid "Editors' Guide"
 msgstr ""
 
@@ -8067,10 +7931,7 @@ msgid "<strong>Warning!</strong> Another user was viewing this page before you."
 msgstr ""
 
 #: src/olympia/editors/templates/editors/review.html:237
-msgid ""
-"The whiteboard is the place to exchange information relevant to\n"
-"               this addon (whatever the version), between the developer and the\n"
-"               editor. This is visible and editable by both."
+msgid "The whiteboard is the place to exchange information relevant to this addon (whatever the version), between the developer and the editor. This is visible and editable by both."
 msgstr ""
 
 #: src/olympia/editors/templates/editors/review.html:241
@@ -8344,7 +8205,7 @@ msgstr ""
 msgid "Describe your reason for flagging"
 msgstr ""
 
-#: src/olympia/files/forms.py:88
+#: src/olympia/files/forms.py:90
 msgid "Cannot diff a version against itself"
 msgstr ""
 
@@ -8379,51 +8240,51 @@ msgstr ""
 msgid "There was an error accessing file %s."
 msgstr ""
 
-#: src/olympia/files/utils.py:343
+#: src/olympia/files/utils.py:340
 msgid "Could not parse uploaded file."
 msgstr ""
 
-#: src/olympia/files/utils.py:380
+#: src/olympia/files/utils.py:377
 msgid "Invalid file name in archive: {0}"
 msgstr ""
 
-#: src/olympia/files/utils.py:388
+#: src/olympia/files/utils.py:385
 msgid "File exceeding size limit in archive: {0}"
 msgstr ""
 
-#: src/olympia/files/utils.py:439
+#: src/olympia/files/utils.py:436
 msgid "Invalid archive."
 msgstr ""
 
-#: src/olympia/files/utils.py:529 src/olympia/files/utils.py:532
+#: src/olympia/files/utils.py:526 src/olympia/files/utils.py:529
 msgid "Could not parse the manifest file."
 msgstr ""
 
-#: src/olympia/files/utils.py:551
+#: src/olympia/files/utils.py:548
 msgid "Could not find an add-on ID."
 msgstr ""
 
-#: src/olympia/files/utils.py:554
+#: src/olympia/files/utils.py:551
 msgid "Add-on ID must be 64 characters or less."
 msgstr ""
 
-#: src/olympia/files/utils.py:556
+#: src/olympia/files/utils.py:553
 msgid "Add-on ID doesn't match add-on."
 msgstr ""
 
-#: src/olympia/files/utils.py:564
+#: src/olympia/files/utils.py:561
 msgid "Duplicate add-on ID found."
 msgstr ""
 
-#: src/olympia/files/utils.py:567
+#: src/olympia/files/utils.py:564
 msgid "Version numbers should have fewer than 32 characters."
 msgstr ""
 
-#: src/olympia/files/utils.py:570
+#: src/olympia/files/utils.py:567
 msgid "Version numbers should only contain letters, numbers, and these punctuation characters: +*.-_."
 msgstr ""
 
-#: src/olympia/files/utils.py:587
+#: src/olympia/files/utils.py:584
 msgid "<em:type> doesn't match add-on"
 msgstr ""
 
@@ -8522,6 +8383,10 @@ msgstr ""
 
 #: src/olympia/files/templates/files/viewer.html:134
 msgid "Fetching file."
+msgstr ""
+
+#: src/olympia/legacy_api/views.py:255
+msgid "Not implemented yet."
 msgstr ""
 
 #: src/olympia/lib/constants.py:6
@@ -9180,10 +9045,6 @@ msgstr ""
 msgid "Zimbabwe Dollar"
 msgstr ""
 
-#: src/olympia/lib/video/ffmpeg.py:112 src/olympia/lib/video/totem.py:81
-msgid "Videos must be in WebM."
-msgstr ""
-
 #: src/olympia/pages/templates/pages/about.lhtml:3 src/olympia/pages/templates/pages/about.lhtml:10
 msgid "About Mozilla Add-ons"
 msgstr ""
@@ -9195,7 +9056,7 @@ msgstr ""
 #: src/olympia/pages/templates/pages/about.lhtml:13
 msgid ""
 "addons.mozilla.org, commonly known as \"AMO\", is Mozilla's official site for add-ons to Mozilla software, such as Firefox, Thunderbird, and SeaMonkey. Add-ons let you add new features and change "
-"the way your browser or application works.  Take a look around and explore the thousands of ways to customize the way you do things online."
+"the way your browser or application works. Take a look around and explore the thousands of ways to customize the way you do things online."
 msgstr ""
 
 #: src/olympia/pages/templates/pages/about.lhtml:19
@@ -9540,7 +9401,7 @@ msgstr ""
 msgid ""
 "Yes. It's possible, but some of the functionality provided by these libraries are available through XPCOM, XUL, and JavaScript. In addition, authors should take care if libraries modify primitive "
 "object prototypes (String.prototype, Date.prototype, etc.) and/or define global functions (eg. the $ function). These are prone to cause conflict with other add-ons, in particular if different add-"
-"ons use different versions of libraries and so on. Developers need to be very, very careful with using them.  Mozilla does not offer documentation on using them to build add-ons."
+"ons use different versions of libraries and so on. Developers need to be very, very careful with using them. Mozilla does not offer documentation on using them to build add-ons."
 msgstr ""
 
 #: src/olympia/pages/templates/pages/dev_faq.html:165
@@ -9654,8 +9515,8 @@ msgstr ""
 #, python-format
 msgid ""
 "Yes. Many developers choose to host their own add-ons. Choosing to host your add-on on <a href=\"%(amo_url)s\">Mozilla's add-on site</a>, though, allows for much greater exposure to your add-on due "
-"to the large volume of visitors to the site.  <a href=\"%(md_url)s\">mozdev.org</a> offers free project hosting for Mozilla applications and extensions providing developers with tools to help "
-"manage source code, version control, bug tracking and documentation."
+"to the large volume of visitors to the site. <a href=\"%(md_url)s\">mozdev.org</a> offers free project hosting for Mozilla applications and extensions providing developers with tools to help manage "
+"source code, version control, bug tracking and documentation."
 msgstr ""
 
 #: src/olympia/pages/templates/pages/dev_faq.html:277
@@ -9703,7 +9564,7 @@ msgstr ""
 #: src/olympia/pages/templates/pages/dev_faq.html:314
 #, python-format
 msgid ""
-"Yes. Mozilla's <a href=\"%(p_url)s\">Add-on Policy</a> describes what is an acceptable submission. This policy is subject to change without notice.  In addition, the AMO editorial team uses the <a "
+"Yes. Mozilla's <a href=\"%(p_url)s\">Add-on Policy</a> describes what is an acceptable submission. This policy is subject to change without notice. In addition, the AMO editorial team uses the <a "
 "href=\"%(g_url)s\">Editors Reviewing Guide</a> to ensure that your add-on meets specific guidelines for functionality and security."
 msgstr ""
 
@@ -9820,7 +9681,7 @@ msgstr ""
 #: src/olympia/pages/templates/pages/dev_faq.html:434
 #, python-format
 msgid ""
-"This is why it's very important to read the <a href=\"%(g_url)s\">Editors Reviewing Guide</a> to ensure that your add-on is setup as expected.  It's also a good idea to read the blog post, <a href="
+"This is why it's very important to read the <a href=\"%(g_url)s\">Editors Reviewing Guide</a> to ensure that your add-on is setup as expected. It's also a good idea to read the blog post, <a href="
 "\"%(blog_url)s\">Successfully Getting your Add-on Reviewed</a> which provides excellent insight into ensuring a smooth review of your add-on."
 msgstr ""
 
@@ -9927,7 +9788,7 @@ msgstr ""
 
 #: src/olympia/pages/templates/pages/dev_faq.html:572
 msgid ""
-"Free Software Foundation provides short summaries of the key open source licenses, including whether the license qualifies as a free software license or a copyleft license.  Also includes a "
+"Free Software Foundation provides short summaries of the key open source licenses, including whether the license qualifies as a free software license or a copyleft license. Also includes a "
 "discussion of what constitutes a free software license or a copyleft license (e.g., a Copyleft license is a general method for making a program or other work free, and requiring all modified and "
 "extended versions of the program to be free as well.)"
 msgstr ""
@@ -10105,19 +9966,13 @@ msgid "Add-on Gallery"
 msgstr ""
 
 #: src/olympia/pages/templates/pages/faq.html:171
-msgid ""
-"How do I choose between add-ons that seem to do the same\n"
-"    thing?"
+msgid "How do I choose between add-ons that seem to do the same thing?"
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:173
+#: src/olympia/pages/templates/pages/faq.html:172
 msgid ""
-"There are often several add-ons that have similar features. To\n"
-"    figure out which is right for you, read the entire description of the\n"
-"    add-on and view its screenshots. If there are still several in the running,\n"
-"    read through the add-on's ratings, user reviews, and statistics to see\n"
-"    which is most liked by other users. Remember that you can also just try\n"
-"    out both and see which you like better."
+"There are often several add-ons that have similar features. To figure out which is right for you, read the entire description of the add-on and view its screenshots. If there are still several in "
+"the running, read through the add-on's ratings, user reviews, and statistics to see which is most liked by other users. Remember that you can also just try out both and see which you like better."
 msgstr ""
 
 #: src/olympia/pages/templates/pages/faq.html:180
@@ -10158,80 +10013,67 @@ msgid "How much do add-ons cost to purchase?"
 msgstr ""
 
 #: src/olympia/pages/templates/pages/faq.html:207
-msgid ""
-"Add-ons hosted in our gallery are free unless clearly marked\n"
-"    otherwise."
+msgid "Add-ons hosted in our gallery are free unless clearly marked otherwise."
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:210
+#: src/olympia/pages/templates/pages/faq.html:209
 msgid "What does it mean when an add-on asks for contributions?"
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:211
+#: src/olympia/pages/templates/pages/faq.html:210
 msgid ""
-"Some add-on authors request users who enjoy an add-on to\n"
-"        contribute to its development by making a monetary contribution. These\n"
-"        contributions go directly to the developer unless a third party is\n"
-"        indicated, such as the non-profit Mozilla Foundation."
+"Some add-on authors request users who enjoy an add-on to contribute to its development by making a monetary contribution. These contributions go directly to the developer unless a third party is "
+"indicated, such as the non-profit Mozilla Foundation."
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:216
+#: src/olympia/pages/templates/pages/faq.html:215
 msgid "What are beta add-ons?"
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:218
+#: src/olympia/pages/templates/pages/faq.html:217
 msgid ""
-"Beta add-ons are unreviewed versions which represent the\n"
-"        latest work of an add-on author. While different authors have different\n"
-"        standards for beta code quality, you should assume that these add-ons\n"
-"        are less stable than the general add-on releases."
+"Beta add-ons are unreviewed versions which represent the latest work of an add-on author. While different authors have different standards for beta code quality, you should assume that these add-"
+"ons are less stable than the general add-on releases."
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:222
+#: src/olympia/pages/templates/pages/faq.html:221
 msgid ""
 "Please note that when you install an add-on from the \"Beta Version\" section of an add-on's listing, you will continue to receive updates for that add-on as they become available. Like the initial "
 "version you installed, all beta releases are unreviewed by Mozilla and may harm your computer."
 msgstr ""
 
+#: src/olympia/pages/templates/pages/faq.html:228
+msgid "What does it mean when an add-on is flagged as slow?"
+msgstr ""
+
 #: src/olympia/pages/templates/pages/faq.html:229
-msgid ""
-"What does it mean when an add-on is flagged as\n"
-"    slow?"
+msgid "Most add-ons load code and resources at the same time Firefox is starting up. In most cases the impact in start-up time is minimal, but some add-ons can cause a noticeable slowdown."
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:231
-msgid ""
-"Most add-ons load code and resources at the same time Firefox\n"
-"        is starting up. In most cases the impact in start-up time is minimal,\n"
-"        but some add-ons can cause a noticeable slowdown."
-msgstr ""
-
-#: src/olympia/pages/templates/pages/faq.html:236
+#: src/olympia/pages/templates/pages/faq.html:234
 msgid "How do I report an inappropriate or spam user review?"
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:237
+#: src/olympia/pages/templates/pages/faq.html:235
 msgid ""
-"To report a user review of an add-on, log in with your account\n"
-"    and visit the add-on's reviews page. Find the review you wish to report,\n"
-"    click \"Report this review\" and select a reason. Our editorial team will\n"
-"    investigate the review and take appropriate action."
+"To report a user review of an add-on, log in with your account and visit the add-on's reviews page. Find the review you wish to report, click \"Report this review\" and select a reason. Our "
+"editorial team will investigate the review and take appropriate action."
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:242
+#: src/olympia/pages/templates/pages/faq.html:240
 msgid "How do I report a bug or contact the Mozilla Add-ons team?"
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:243
+#: src/olympia/pages/templates/pages/faq.html:241
 #, python-format
 msgid "Please visit our <a href=\"%(contact_url)s\">Contact page</a>."
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:246
+#: src/olympia/pages/templates/pages/faq.html:244
 msgid "What is a Source Code License?"
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:247
+#: src/olympia/pages/templates/pages/faq.html:245
 #, python-format
 msgid ""
 "The source code used to create an add-on is an exclusive copyright of the add-on author, unless otherwise declared in a source code license. Many add-ons on this site have <a href=\"%(url)s\" lang="
@@ -10239,60 +10081,60 @@ msgid ""
 "the GPL or BSD licenses instead of making up their own."
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:256
+#: src/olympia/pages/templates/pages/faq.html:254
 #, python-format
 msgid "Firefox and other Mozilla software are <a href=\"%(url)s\">open source</a>."
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:264
+#: src/olympia/pages/templates/pages/faq.html:262
 msgid "Collections and Favorites"
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:267
+#: src/olympia/pages/templates/pages/faq.html:265
 msgid "What is a collection?"
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:268
+#: src/olympia/pages/templates/pages/faq.html:266
 msgid "Collections are groups of related add-ons created by users to share."
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:270
+#: src/olympia/pages/templates/pages/faq.html:268
 msgid "What is the My Favorites collection?"
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:271
+#: src/olympia/pages/templates/pages/faq.html:269
 msgid "Favorite add-ons are add-ons that you have bookmarked to easily get back to later. You can add an add-on to your favorites collection by clicking \"Add to favorites\" on its details page."
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:275 src/olympia/templates/menu_links.html:13 src/olympia/templates/impala/header_title.html:17
+#: src/olympia/pages/templates/pages/faq.html:273 src/olympia/templates/menu_links.html:13 src/olympia/templates/impala/header_title.html:17
 msgid "Mobile Add-ons"
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:278
+#: src/olympia/pages/templates/pages/faq.html:276
 msgid "What are mobile add-ons?"
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:279
+#: src/olympia/pages/templates/pages/faq.html:277
 #, python-format
 msgid ""
 "Mobile add-ons work with <a href=\"%(mobile_url)s\">Firefox for Mobile</a> and add or modify functionality just like desktop add-ons. You can find add-ons that work with Firefox for Mobile in our "
 "<a href=\"%(gallery_url)s\">gallery</a>."
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:288
+#: src/olympia/pages/templates/pages/faq.html:286
 msgid "Developer Topics"
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:289
+#: src/olympia/pages/templates/pages/faq.html:287
 #, python-format
 msgid "Please see our <a href=\"%(faq_url)s\">Developer FAQ</a> and <a href=\"%(hub_url)s\">Developer Hub</a> for answers to add-on developer-related questions."
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:294
+#: src/olympia/pages/templates/pages/faq.html:292
 msgid "Still have questions?"
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:295
+#: src/olympia/pages/templates/pages/faq.html:293
 #, python-format
 msgid "For general Firefox support, visit our <a href=\"%(sumo_url)s\">support website</a>. For general add-on and website questions, visit our <a href=\"%(forum_url)s\">forum</a>."
 msgstr ""
@@ -10430,7 +10272,7 @@ msgstr ""
 
 #: src/olympia/pages/templates/pages/sunbird.html:29
 msgid ""
-"Development on the Sunbird project has halted and its final release was on March 30, 2010.  We've been proud to host Sunbird add-ons on this site but as the project is no longer maintained we have "
+"Development on the Sunbird project has halted and its final release was on March 30, 2010. We've been proud to host Sunbird add-ons on this site but as the project is no longer maintained we have "
 "disabled our support for the add-ons."
 msgstr ""
 
@@ -10508,7 +10350,7 @@ msgstr ""
 #, python-format
 msgid ""
 "<h2>Keep these tips in mind:</h2> <ul> <li> Write like you're telling a friend about your experience with the add-on. Give specifics and helpful details, such as what features you liked and/or "
-"disliked, how easy to use it is, and any disadvantages it has.  Avoid generic language such as calling it \"Great\" or \"Bad\" unless you can give reasons why you believe this is so. </li> <li> "
+"disliked, how easy to use it is, and any disadvantages it has. Avoid generic language such as calling it \"Great\" or \"Bad\" unless you can give reasons why you believe this is so. </li> <li> "
 "Please do not post bug reports in reviews. We do not make your email address available to add-on developers and they may need to contact you to help resolve your issue. See the <a href=\"%(support)s"
 "\">support section</a> to find out where to get assistance for this add-on. </li> <li>Please keep reviews clean, avoid the use of improper language and do not post any personal information. </li> </"
 "ul> <p>Please read the <a href=\"%(guide)s\" target=\"_blank\">Review Guidelines</a> for more detail about user add-on reviews.</p>"
@@ -10744,16 +10586,16 @@ msgstr ""
 
 #. L10n: {0} is an application, such as Firefox. This means "any version of
 #. Firefox."
-#: src/olympia/search/views.py:554
+#: src/olympia/search/views.py:547
 msgid "Any {0}"
 msgstr ""
 
 #. L10n: "All Systems" means show everything regardless of platform.
-#: src/olympia/search/views.py:589
+#: src/olympia/search/views.py:582
 msgid "All Systems"
 msgstr ""
 
-#: src/olympia/search/views.py:600
+#: src/olympia/search/views.py:593
 msgid "All Tags"
 msgstr ""
 
@@ -10927,31 +10769,31 @@ msgstr ""
 msgid "Share this Collection"
 msgstr ""
 
-#: src/olympia/signing/views.py:30 src/olympia/templates/base.html:75 src/olympia/templates/impala/base.html:115
+#: src/olympia/signing/views.py:33 src/olympia/templates/base.html:71 src/olympia/templates/impala/base.html:112
 msgid "Some features are temporarily disabled while we perform website maintenance. We'll be back to full capacity shortly."
 msgstr ""
 
-#: src/olympia/signing/views.py:53
+#: src/olympia/signing/views.py:56
 msgid "Could not find add-on with id \"{}\"."
 msgstr ""
 
-#: src/olympia/signing/views.py:67
+#: src/olympia/signing/views.py:70
 msgid "You do not own this addon."
 msgstr ""
 
-#: src/olympia/signing/views.py:82
+#: src/olympia/signing/views.py:87
 msgid "Missing \"upload\" key in multipart file data."
 msgstr ""
 
-#: src/olympia/signing/views.py:96
+#: src/olympia/signing/views.py:101
 msgid "Version does not match the manifest file."
 msgstr ""
 
-#: src/olympia/signing/views.py:100
+#: src/olympia/signing/views.py:105
 msgid "Version already exists."
 msgstr ""
 
-#: src/olympia/signing/views.py:136
+#: src/olympia/signing/views.py:141
 msgid "No uploaded file for that addon and version."
 msgstr ""
 
@@ -11064,89 +10906,89 @@ msgstr ""
 msgid "Statistics Dashboard :: Add-ons for {0}"
 msgstr ""
 
-#: src/olympia/stats/templates/stats/stats.html:30
-msgid "Controls:"
-msgstr ""
-
-#: src/olympia/stats/templates/stats/stats.html:33
-msgid "reset zoom"
-msgstr ""
-
-#: src/olympia/stats/templates/stats/stats.html:40
-msgid "Group by:"
-msgstr ""
-
-#: src/olympia/stats/templates/stats/stats.html:42
-msgid "day"
-msgstr ""
-
-#: src/olympia/stats/templates/stats/stats.html:45
-msgid "week"
-msgstr ""
-
-#: src/olympia/stats/templates/stats/stats.html:48
-msgid "month"
-msgstr ""
-
-#: src/olympia/stats/templates/stats/stats.html:54
-msgid "For last:"
-msgstr ""
-
-#: src/olympia/stats/templates/stats/stats.html:57
-msgid "7 days"
-msgstr ""
-
-#: src/olympia/stats/templates/stats/stats.html:60
-msgid "30 days"
-msgstr ""
-
-#: src/olympia/stats/templates/stats/stats.html:63
-msgid "90 days"
-msgstr ""
-
-#: src/olympia/stats/templates/stats/stats.html:66
-msgid "365 days"
-msgstr ""
-
-#: src/olympia/stats/templates/stats/stats.html:69
-msgid "Custom..."
-msgstr ""
-
 #. {0} is an add-on name
-#: src/olympia/stats/templates/stats/stats.html:88 src/olympia/stats/templates/stats/stats.html:91
+#: src/olympia/stats/templates/stats/stats.html:44 src/olympia/stats/templates/stats/stats.html:47
 msgid "Statistics for {0}"
 msgstr ""
 
-#: src/olympia/stats/templates/stats/stats.html:94
+#: src/olympia/stats/templates/stats/stats.html:50
 msgid "Statistics Dashboard"
 msgstr ""
 
-#: src/olympia/stats/templates/stats/stats.html:104
+#: src/olympia/stats/templates/stats/stats.html:57
+msgid "Controls:"
+msgstr ""
+
+#: src/olympia/stats/templates/stats/stats.html:60
+msgid "reset zoom"
+msgstr ""
+
+#: src/olympia/stats/templates/stats/stats.html:67
+msgid "Group by:"
+msgstr ""
+
+#: src/olympia/stats/templates/stats/stats.html:69
+msgid "day"
+msgstr ""
+
+#: src/olympia/stats/templates/stats/stats.html:72
+msgid "week"
+msgstr ""
+
+#: src/olympia/stats/templates/stats/stats.html:75
+msgid "month"
+msgstr ""
+
+#: src/olympia/stats/templates/stats/stats.html:81
+msgid "For last:"
+msgstr ""
+
+#: src/olympia/stats/templates/stats/stats.html:84
+msgid "7 days"
+msgstr ""
+
+#: src/olympia/stats/templates/stats/stats.html:87
+msgid "30 days"
+msgstr ""
+
+#: src/olympia/stats/templates/stats/stats.html:90
+msgid "90 days"
+msgstr ""
+
+#: src/olympia/stats/templates/stats/stats.html:93
+msgid "365 days"
+msgstr ""
+
+#: src/olympia/stats/templates/stats/stats.html:96
+msgid "Custom..."
+msgstr ""
+
+#: src/olympia/stats/templates/stats/stats.html:106
 msgid "Statistics processing is currently disabled, so recent data is unavailable. The statistics are still being collected and this page will be updated soon with the missing data."
 msgstr ""
 
-#: src/olympia/stats/templates/stats/stats.html:110
+#: src/olympia/stats/templates/stats/stats.html:112
 msgid "Loading the latest data&hellip;"
 msgstr ""
 
-#: src/olympia/stats/templates/stats/stats.html:142 src/olympia/stats/templates/stats/reports/overview.html:25 src/olympia/stats/templates/stats/reports/overview.html:37
+#: src/olympia/stats/templates/stats/stats.html:144 src/olympia/stats/templates/stats/reports/overview.html:25 src/olympia/stats/templates/stats/reports/overview.html:37
 #: src/olympia/stats/templates/stats/reports/overview.html:49
 msgid "No data available."
 msgstr ""
 
-#: src/olympia/stats/templates/stats/stats.html:177
+#: src/olympia/stats/templates/stats/stats.html:179
 msgid "This dashboard is currently <b>public</b>."
 msgstr ""
 
-#: src/olympia/stats/templates/stats/stats.html:179
+#: src/olympia/stats/templates/stats/stats.html:181
 msgid "Contribution stats are currently <b>private</b>."
 msgstr ""
 
-#: src/olympia/stats/templates/stats/stats.html:182
+#: src/olympia/stats/templates/stats/stats.html:184
 msgid "This dashboard is currently <b>private</b>."
 msgstr ""
 
-#: src/olympia/stats/templates/stats/stats.html:185
+#: src/olympia/stats/templates/stats/stats.html:187
 msgid "Change settings."
 msgstr ""
 
@@ -11298,15 +11140,6 @@ msgstr ""
 msgid "Application versions by Date"
 msgstr ""
 
-#: src/olympia/tags/templates/tags/top_cloud.html:4
-msgid "Top {0} Tags"
-msgstr ""
-
-#. {0} is the current application name
-#: src/olympia/tags/templates/tags/top_cloud.html:14
-msgid "{0} Top Tags"
-msgstr ""
-
 #: src/olympia/templates/amo_footer.html:6 src/olympia/templates/includes/lang_switcher.html:2
 msgid "Other languages"
 msgstr ""
@@ -11315,11 +11148,11 @@ msgstr ""
 msgid "Mozilla Add-ons"
 msgstr ""
 
-#: src/olympia/templates/base.html:91 src/olympia/templates/impala/base.html:81
+#: src/olympia/templates/base.html:89 src/olympia/templates/impala/base.html:78
 msgid "Find add-ons for other applications"
 msgstr ""
 
-#: src/olympia/templates/base.html:92 src/olympia/templates/impala/base.html:81
+#: src/olympia/templates/base.html:90 src/olympia/templates/impala/base.html:78
 msgid "Other Applications"
 msgstr ""
 
@@ -11344,7 +11177,7 @@ msgid "View Mobile Site"
 msgstr ""
 
 #: src/olympia/templates/copyright.html:7
-msgid "Site Status "
+msgid "Site Status"
 msgstr ""
 
 #: src/olympia/templates/footer.html:3
@@ -11444,35 +11277,35 @@ msgstr ""
 msgid "<a href=\"%(reg)s\">Register</a> or <a href=\"%(login)s\">Log in</a>"
 msgstr ""
 
-#: src/olympia/templates/impala/base.html:126
+#: src/olympia/templates/impala/base.html:123
 #, python-format
 msgid "To try the thousands of add-ons available here, download <a href=\"%(url)s\">Mozilla Firefox</a>, a fast, free way to surf the Web!"
 msgstr ""
 
-#: src/olympia/templates/impala/base.html:138
+#: src/olympia/templates/impala/base.html:135
 #, python-format
 msgid "Add-ons is switching to Firefox Accounts for login. <a href=\"%(url)s\" class=\"fxa-login\">Sign in now to transfer your account.</a>"
 msgstr ""
 
 #. {0} is an application, such as Firefox.
-#: src/olympia/templates/impala/base.html:148
+#: src/olympia/templates/impala/base.html:145
 msgid "Welcome to {0} Add-ons."
 msgstr ""
 
-#: src/olympia/templates/impala/base.html:151
+#: src/olympia/templates/impala/base.html:148
 msgid "Choose from thousands of extra features and styles to make Firefox your own."
 msgstr ""
 
-#: src/olympia/templates/impala/base.html:156
+#: src/olympia/templates/impala/base.html:153
 #, python-format
 msgid "Add extra features and styles to make %(app)s your own."
 msgstr ""
 
-#: src/olympia/templates/impala/base.html:164
+#: src/olympia/templates/impala/base.html:161
 msgid "On the go?"
 msgstr ""
 
-#: src/olympia/templates/impala/base.html:166
+#: src/olympia/templates/impala/base.html:163
 msgid "Check out our <a class=\"mobile-link\" href=\"#\">Mobile Add-ons site</a>."
 msgstr ""
 
@@ -11696,19 +11529,19 @@ msgstr ""
 
 #. L10n: {id} will be something like "13ad6a", just a random number
 #. to differentiate this user from other anonymous users.
-#: src/olympia/users/models.py:353
+#: src/olympia/users/models.py:362
 msgid "Anonymous user {id}"
 msgstr ""
 
-#: src/olympia/users/models.py:410
+#: src/olympia/users/models.py:419
 msgid "Your account has been restricted"
 msgstr ""
 
-#: src/olympia/users/models.py:480
+#: src/olympia/users/models.py:489
 msgid "Please confirm your email address"
 msgstr ""
 
-#: src/olympia/users/models.py:506
+#: src/olympia/users/models.py:515
 msgid "My Mobile Add-ons"
 msgstr ""
 
@@ -11985,7 +11818,7 @@ msgstr ""
 
 #: src/olympia/users/templates/users/edit.html:70
 #, python-format
-msgid "Change your password.  If you forgot your password, you can <a href=\"%(reset_url)s\">use the reset form</a>."
+msgid "Change your password. If you forgot your password, you can <a href=\"%(reset_url)s\">use the reset form</a>."
 msgstr ""
 
 #: src/olympia/users/templates/users/edit.html:76
@@ -12005,7 +11838,7 @@ msgid "Profile"
 msgstr ""
 
 #: src/olympia/users/templates/users/edit.html:100
-msgid "Give us a bit more information about yourself.  All these fields are optional, but they'll help other users get to know you better."
+msgid "Give us a bit more information about yourself. All these fields are optional, but they'll help other users get to know you better."
 msgstr ""
 
 #: src/olympia/users/templates/users/edit.html:124
@@ -12221,7 +12054,7 @@ msgid "Confirm password"
 msgstr ""
 
 #: src/olympia/users/templates/users/pwreset_confirm.html:47
-msgid "The password reset link was invalid, possibly because it has already been used.  Please request a new password reset."
+msgid "The password reset link was invalid, possibly because it has already been used. Please request a new password reset."
 msgstr ""
 
 #: src/olympia/users/templates/users/pwreset_request.html:15
@@ -12407,7 +12240,7 @@ msgstr ""
 
 #: src/olympia/users/templates/users/unsubscribe.html:30
 #, python-format
-msgid "Unfortunately, we weren't able to unsubscribe you.  The link you clicked is invalid. However, you can unsubscribe still unsubscribe on your <a href=\"%(edit_url)s\">edit profile page</a>."
+msgid "Unfortunately, we weren't able to unsubscribe you. The link you clicked is invalid. However, you can unsubscribe still unsubscribe on your <a href=\"%(edit_url)s\">edit profile page</a>."
 msgstr ""
 
 #: src/olympia/users/templates/users/vcard.html:2
@@ -12461,15 +12294,15 @@ msgstr ""
 msgid "Version History with Changelogs"
 msgstr ""
 
-#: src/olympia/versions/models.py:314
+#: src/olympia/versions/models.py:313
 msgid "Add-on uses binary components."
 msgstr ""
 
-#: src/olympia/versions/models.py:317
+#: src/olympia/versions/models.py:316
 msgid "Add-on has opted into strict compatibility checking."
 msgstr ""
 
-#: src/olympia/versions/models.py:715
+#: src/olympia/versions/models.py:711
 msgid "{app} {min} and later"
 msgstr ""
 
@@ -12544,4 +12377,8 @@ msgstr ""
 
 #: src/olympia/zadmin/forms.py:105
 msgid "Log emails instead of sending"
+msgstr ""
+
+#: src/olympia/zadmin/forms.py:215
+msgid "Deleted versions can`t be changed."
 msgstr ""

--- a/locale/te/LC_MESSAGES/djangojs.po
+++ b/locale/te/LC_MESSAGES/djangojs.po
@@ -1,1215 +1,1235 @@
-
 msgid ""
 msgstr ""
 "Project-Id-Version:  addons\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2016-02-24 21:23+0000\n"
+"POT-Creation-Date: 2016-04-18 15:47+0000\n"
 "PO-Revision-Date: 2012-03-02 17:35-0700\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
+"Language: \n"
 "MIME-Version: 1.0\n"
-"Content-Type: text/plain; charset=utf-8\n"
+"Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Generated-By: Babel 2.2.0\n"
 
-#: static/js/common/ratingwidget.js:31
+#: static/js/common-all.js:1426 static/js/impala-all.js:1511 static/js/zamboni/discovery-all.js:12598 static/js/zamboni/init.js:28 static/js/zamboni/mobile-all.js:14945
+msgid "This feature is temporarily disabled while we perform website maintenance. Please check back a little later."
+msgstr ""
+
+#. L10n: {0} is an app name like Firefox.
+#: static/js/common-all.js:1837 static/js/impala-all.js:1922 static/js/zamboni/buttons.js:73 static/js/zamboni/discovery-all.js:13108
+msgid "Accept and Install"
+msgstr ""
+
+#: static/js/common-all.js:1837 static/js/impala-all.js:1922 static/js/zamboni/buttons.js:73 static/js/zamboni/discovery-all.js:13108
+msgid "Add to {0}"
+msgstr ""
+
+#: static/js/common-all.js:1842 static/js/impala-all.js:1927 static/js/zamboni/buttons.js:78 static/js/zamboni/discovery-all.js:13113
+msgid "Download Now"
+msgstr ""
+
+#: static/js/common-all.js:1883 static/js/impala-all.js:1968 static/js/zamboni/buttons.js:119 static/js/zamboni/discovery-all.js:13154
+msgid "Add-on has not been updated to support default-to-compatible."
+msgstr ""
+
+#: static/js/common-all.js:1888 static/js/impala-all.js:1973 static/js/zamboni/buttons.js:124 static/js/zamboni/discovery-all.js:13159
+msgid "You need to be using Firefox 10.0 or higher."
+msgstr ""
+
+#: static/js/common-all.js:1900 static/js/impala-all.js:1985 static/js/zamboni/buttons.js:136 static/js/zamboni/discovery-all.js:13171
+msgid "Mozilla has marked this version as incompatible with your Firefox version."
+msgstr ""
+
+#. L10n: {0} is an platform like Windows or Linux.
+#: static/js/common-all.js:1981 static/js/impala-all.js:2066 static/js/zamboni/buttons.js:217 static/js/zamboni/discovery-all.js:13252
+msgid "Install for {0} anyway"
+msgstr ""
+
+#: static/js/common-all.js:1981 static/js/impala-all.js:2066 static/js/zamboni/buttons.js:217 static/js/zamboni/discovery-all.js:13252
+msgid "Download for {0} anyway"
+msgstr ""
+
+#: static/js/common-all.js:2038 static/js/impala-all.js:2123 static/js/zamboni/buttons.js:274 static/js/zamboni/discovery-all.js:13309
+msgid "Not available for your platform"
+msgstr ""
+
+#. L10n: {0} is an app name, {1} is the app version.
+#: static/js/common-all.js:2049 static/js/common-all.js:2086 static/js/impala-all.js:2134 static/js/impala-all.js:2171 static/js/zamboni/buttons.js:286 static/js/zamboni/buttons.js:324
+#: static/js/zamboni/discovery-all.js:13320 static/js/zamboni/discovery-all.js:13357
+msgid "Not available for {0} {1}"
+msgstr ""
+
+#: static/js/common-all.js:2112 static/js/impala-all.js:2197 static/js/zamboni/buttons.js:351 static/js/zamboni/discovery-all.js:13383
+msgid "Works with {app} {min} - {max}"
+msgstr ""
+
+#: static/js/common-all.js:2114 static/js/impala-all.js:2199 static/js/zamboni/buttons.js:353 static/js/zamboni/discovery-all.js:13385
+msgid "View other versions"
+msgstr ""
+
+#: static/js/common-all.js:2162 static/js/impala-all.js:2247 static/js/zamboni/buttons.js:401 static/js/zamboni/discovery-all.js:13433
+msgid "Only with Firefox — Get Firefox Now!"
+msgstr ""
+
+#: static/js/common-all.js:2278 static/js/impala-all.js:2363 static/js/zamboni/buttons.js:517 static/js/zamboni/discovery-all.js:13549 static/js/zamboni/mobile-all.js:15177
+#: static/js/zamboni/mobile/buttons.js:43
+msgid "Sorry, you need a Mozilla-based browser (such as Firefox) to install a search plugin."
+msgstr ""
+
+#: static/js/common-all.js:9088 static/js/impala-all.js:9649 static/js/zamboni/global.js:410
+msgid "Loading..."
+msgstr ""
+
+#. L10n: {0} is the number of characters left.
+#: static/js/common-all.js:9152 static/js/impala-all.js:9713 static/js/zamboni/global.js:474
+msgid "<b>{0}</b> character left."
+msgid_plural "<b>{0}</b> characters left."
+msgstr[0] ""
+msgstr[1] ""
+
+#: static/js/common-all.js:9589 static/js/common-min.js:6 static/js/impala-all.js:10052 static/js/impala-min.js:6 static/js/common/ratingwidget.js:31 static/js/zamboni/mobile-all.js:16123
+#: static/js/zamboni/mobile-min.js:6
 msgid "{0} star"
 msgid_plural "{0} stars"
 msgstr[0] ""
 msgstr[1] ""
 
-#: static/js/common/upload-addon.js:41 static/js/common/upload-image.js:128
+#: static/js/common-all.js:9676 static/js/common-min.js:6 static/js/impala-all.js:10139 static/js/impala-min.js:6 static/js/zamboni/l10n.js:45
+msgid "Remove this localization"
+msgstr ""
+
+#: static/js/common-all.js:10193 static/js/common-min.js:6 static/js/impala-all.js:10674 static/js/impala-min.js:6 static/js/zamboni/discovery-all.js:13678
+msgid "close"
+msgstr ""
+
+#: static/js/common-all.js:10860 static/js/common-min.js:6 static/js/impala-all.js:11481 static/js/impala-min.js:6 static/js/impala/reviews.js:23 static/js/zamboni/reviews.js:18
+msgid "Flagged for review"
+msgstr ""
+
+#: static/js/common-all.js:10876 static/js/common-min.js:6 static/js/impala-all.js:11498 static/js/impala-min.js:6 static/js/impala/reviews.js:40 static/js/zamboni/reviews.js:34
+msgid "Your input is required"
+msgstr ""
+
+#: static/js/common-all.js:10945 static/js/common-min.js:6 static/js/impala-all.js:11610 static/js/impala-min.js:7 static/js/impala/reviews.js:152 static/js/zamboni/reviews.js:103
+msgid "Marked for deletion"
+msgstr ""
+
+#: static/js/common-all.js:11573 static/js/common-min.js:7 static/js/impala-all.js:13809 static/js/impala-min.js:8 static/js/zamboni/collections.js:229
+msgid "Adding to Favorites&hellip;"
+msgstr ""
+
+#: static/js/common-all.js:11576 static/js/common-min.js:7 static/js/impala-all.js:13812 static/js/impala-min.js:8 static/js/zamboni/collections.js:232
+msgid "Removing Favorite&hellip;"
+msgstr ""
+
+#: static/js/common-all.js:11579 static/js/common-min.js:7 static/js/impala-all.js:13815 static/js/impala-min.js:8 static/js/zamboni/collections.js:235
+msgid "Add to Favorites"
+msgstr ""
+
+#: static/js/common-all.js:11582 static/js/common-min.js:7 static/js/impala-all.js:13818 static/js/impala-min.js:8 static/js/zamboni/collections.js:238
+msgid "Remove from Favorites"
+msgstr ""
+
+#: static/js/common-all.js:11647 static/js/common-min.js:7 static/js/impala-all.js:13883 static/js/impala-min.js:8 static/js/zamboni/collections.js:303
+msgid "Pending"
+msgstr ""
+
+#: static/js/common-all.js:11648 static/js/common-min.js:7 static/js/impala-all.js:13884 static/js/impala-min.js:8 static/js/zamboni/collections.js:304
+msgid "Add a comment"
+msgstr ""
+
+#: static/js/common-all.js:11648 static/js/common-min.js:7 static/js/impala-all.js:13884 static/js/impala-min.js:8 static/js/zamboni/collections.js:304
+msgid "Comment"
+msgstr ""
+
+#: static/js/common-all.js:11649 static/js/common-min.js:7 static/js/impala-all.js:13885 static/js/impala-min.js:8 static/js/zamboni/collections.js:305
+msgid "Remove this add-on from the collection"
+msgstr ""
+
+#: static/js/common-all.js:11649 static/js/common-all.js:11678 static/js/common-min.js:7 static/js/impala-all.js:13885 static/js/impala-all.js:13914 static/js/impala-min.js:8
+#: static/js/zamboni/collections.js:305 static/js/zamboni/collections.js:334
+msgid "Remove"
+msgstr ""
+
+#: static/js/common-all.js:11678 static/js/common-min.js:7 static/js/impala-all.js:13914 static/js/impala-min.js:8 static/js/zamboni/collections.js:334
+msgid "Remove this user as a contributor"
+msgstr ""
+
+#: static/js/common-all.js:11690 static/js/common-min.js:7 static/js/impala-all.js:13926 static/js/impala-min.js:8 static/js/zamboni/collections.js:346
+msgid "An email address is required."
+msgstr ""
+
+#: static/js/common-all.js:11708 static/js/common-min.js:7 static/js/impala-all.js:13944 static/js/impala-min.js:8 static/js/zamboni/collections.js:364
+msgid "You cannot add yourself as a contributor."
+msgstr ""
+
+#: static/js/common-all.js:11710 static/js/common-min.js:7 static/js/impala-all.js:13946 static/js/impala-min.js:8 static/js/zamboni/collections.js:366
+msgid "You have already added that user."
+msgstr ""
+
+#: static/js/common-all.js:11917 static/js/common-min.js:7 static/js/impala-all.js:14153 static/js/impala-min.js:8 static/js/zamboni/collections.js:573
+msgid "Add to favorites"
+msgstr ""
+
+#: static/js/common-all.js:11921 static/js/common-min.js:7 static/js/impala-all.js:14157 static/js/impala-min.js:8 static/js/zamboni/collections.js:577
+msgid "Remove from favorites"
+msgstr ""
+
+#: static/js/common-all.js:11939 static/js/common-min.js:7 static/js/impala-all.js:14175 static/js/impala-all.js:14233 static/js/impala-min.js:8 static/js/impala/collections.js:10
+#: static/js/zamboni/collections.js:595
+msgid "Follow this Collection"
+msgstr ""
+
+#: static/js/common-all.js:11948 static/js/common-min.js:7 static/js/impala-all.js:14184 static/js/impala-min.js:8 static/js/zamboni/collections.js:604
+msgid "Stop following"
+msgstr ""
+
+#: static/js/common-all.js:12096 static/js/common-min.js:7 static/js/zamboni/password-strength.js:20
+msgid "Password strength:"
+msgstr ""
+
+#: static/js/common-all.js:12102 static/js/common-min.js:7 static/js/zamboni/password-strength.js:26
+msgid "At least {0} character left."
+msgid_plural "At least {0} characters left."
+msgstr[0] ""
+msgstr[1] ""
+
+#: static/js/common-all.js:12286 static/js/common-min.js:7 static/js/impala-all.js:14632 static/js/impala-min.js:8 static/js/impala/suggestions.js:39
+msgid "Search themes for <b>{0}</b>"
+msgstr ""
+
+#: static/js/common-all.js:12288 static/js/common-min.js:7 static/js/impala-all.js:14634 static/js/impala-min.js:8 static/js/impala/suggestions.js:41
+msgid "Search apps for <b>{0}</b>"
+msgstr ""
+
+#: static/js/common-all.js:12290 static/js/common-min.js:7 static/js/impala-all.js:14636 static/js/impala-min.js:8 static/js/impala/suggestions.js:43
+msgid "Search add-ons for <b>{0}</b>"
+msgstr ""
+
+#: static/js/common-all.js:12521 static/js/common-min.js:7 static/js/impala-all.js:14867 static/js/impala-min.js:8 static/js/impala/site_suggestions.js:46
+msgid "Category"
+msgstr ""
+
+#. L10n: {0} is an app name.
+#: static/js/impala-all.js:11632 static/js/impala-min.js:7 static/js/impala/listing.js:11 static/js/zamboni/themes.js:13
+msgid "This theme is incompatible with your version of {0}"
+msgstr ""
+
+#: static/js/impala-all.js:12146 static/js/impala-all.js:14331 static/js/impala-min.js:7 static/js/impala-min.js:8 static/js/common/upload-image.js:97 static/js/impala/users.js:51
+#: static/js/zamboni/devhub-all.js:894 static/js/zamboni/devhub-min.js:1
+msgid "Images must be either PNG or JPG."
+msgstr ""
+
+#: static/js/impala-all.js:12150 static/js/impala-min.js:7 static/js/common/upload-image.js:101 static/js/zamboni/devhub-all.js:898 static/js/zamboni/devhub-min.js:1
+msgid "Videos must be in WebM."
+msgstr ""
+
+#: static/js/impala-all.js:12177 static/js/impala-min.js:7 static/js/common/upload-addon.js:41 static/js/common/upload-image.js:128 static/js/zamboni/devhub-all.js:272
+#: static/js/zamboni/devhub-all.js:925 static/js/zamboni/devhub-min.js:1
 msgid "There was a problem contacting the server."
 msgstr ""
 
-#: static/js/common/upload-addon.js:69
+#: static/js/impala-all.js:13298 static/js/impala-min.js:7 static/js/impala/persona_creation.js:60
+msgid "All Rights Reserved"
+msgstr ""
+
+#: static/js/impala-all.js:13302 static/js/impala-min.js:7 static/js/impala/persona_creation.js:64
+msgid "Creative Commons Attribution 3.0"
+msgstr ""
+
+#: static/js/impala-all.js:13307 static/js/impala-min.js:7 static/js/impala/persona_creation.js:69
+msgid "Creative Commons Attribution-NonCommercial 3.0"
+msgstr ""
+
+#: static/js/impala-all.js:13312 static/js/impala-min.js:7 static/js/impala/persona_creation.js:74
+msgid "Creative Commons Attribution-NonCommercial-NoDerivs 3.0"
+msgstr ""
+
+#: static/js/impala-all.js:13317 static/js/impala-min.js:7 static/js/impala/persona_creation.js:79
+msgid "Creative Commons Attribution-NonCommercial-Share Alike 3.0"
+msgstr ""
+
+#: static/js/impala-all.js:13322 static/js/impala-min.js:7 static/js/impala/persona_creation.js:84
+msgid "Creative Commons Attribution-NoDerivs 3.0"
+msgstr ""
+
+#: static/js/impala-all.js:13327 static/js/impala-min.js:7 static/js/impala/persona_creation.js:89
+msgid "Creative Commons Attribution-ShareAlike 3.0"
+msgstr ""
+
+#: static/js/impala-all.js:13530 static/js/impala-min.js:7 static/js/impala/persona_creation.js:292
+msgid "Your Theme's Name"
+msgstr ""
+
+#: static/js/impala-all.js:14242 static/js/impala-min.js:8 static/js/impala/collections.js:19
+msgid "Stop Following"
+msgstr ""
+
+#: static/js/impala-all.js:14243 static/js/impala-min.js:8 static/js/impala/collections.js:20
+msgid "Following"
+msgstr ""
+
+#: static/js/impala-all.js:14313 static/js/impala-min.js:8 static/js/impala/users.js:33
+msgid "use original"
+msgstr ""
+
+#: static/js/impala-all.js:14523 static/js/impala-min.js:8 static/js/impala/search.js:114
+msgid "Updating results&hellip;"
+msgstr ""
+
+#: static/js/common/upload-addon.js:69 static/js/zamboni/devhub-all.js:300 static/js/zamboni/devhub-min.js:1
 msgid "Select a file..."
 msgstr ""
 
-#: static/js/common/upload-addon.js:70
+#: static/js/common/upload-addon.js:70 static/js/zamboni/devhub-all.js:301 static/js/zamboni/devhub-min.js:1
 msgid "Your add-on should end with .xpi, .jar or .xml"
 msgstr ""
 
 #. L10n: {0} is the percent of the file that has been uploaded.
-#: static/js/common/upload-addon.js:104
+#: static/js/common/upload-addon.js:104 static/js/zamboni/devhub-all.js:335 static/js/zamboni/devhub-min.js:1
 #, python-format
 msgid "{0}% complete"
 msgstr ""
 
 #. L10n: "{bytes uploaded} of {total filesize}".
-#: static/js/common/upload-addon.js:107
+#: static/js/common/upload-addon.js:107 static/js/zamboni/devhub-all.js:338 static/js/zamboni/devhub-min.js:1
 msgid "{0} of {1}"
 msgstr ""
 
-#: static/js/common/upload-addon.js:140
+#: static/js/common/upload-addon.js:140 static/js/zamboni/devhub-all.js:371 static/js/zamboni/devhub-min.js:1
 msgid "Cancel"
 msgstr ""
 
-#: static/js/common/upload-addon.js:162
+#: static/js/common/upload-addon.js:162 static/js/zamboni/devhub-all.js:393 static/js/zamboni/devhub-min.js:1
 msgid "Uploading {0}"
 msgstr ""
 
-#: static/js/common/upload-addon.js:189
+#: static/js/common/upload-addon.js:189 static/js/zamboni/devhub-all.js:420 static/js/zamboni/devhub-min.js:1
 msgid "Error with {0}"
 msgstr ""
 
-#: static/js/common/upload-addon.js:194
+#: static/js/common/upload-addon.js:194 static/js/zamboni/devhub-all.js:425 static/js/zamboni/devhub-min.js:1
 msgid "Your add-on failed validation with {0} error."
 msgid_plural "Your add-on failed validation with {0} errors."
 msgstr[0] ""
 msgstr[1] ""
 
-#: static/js/common/upload-addon.js:208
+#: static/js/common/upload-addon.js:208 static/js/zamboni/devhub-all.js:439 static/js/zamboni/devhub-min.js:1
 msgid "&hellip;and {0} more"
 msgid_plural "&hellip;and {0} more"
 msgstr[0] ""
 msgstr[1] ""
 
-#: static/js/common/upload-addon.js:222 static/js/common/upload-addon.js:512
+#: static/js/common/upload-addon.js:222 static/js/common/upload-addon.js:497 static/js/zamboni/devhub-all.js:453 static/js/zamboni/devhub-all.js:743 static/js/zamboni/devhub-min.js:1
 msgid "See full validation report"
 msgstr ""
 
-#: static/js/common/upload-addon.js:234
+#: static/js/common/upload-addon.js:234 static/js/zamboni/devhub-all.js:465 static/js/zamboni/devhub-min.js:1
 msgid "Validating {0}"
 msgstr ""
 
 #. L10n: first argument is an HTTP status code
-#: static/js/common/upload-addon.js:273
+#: static/js/common/upload-addon.js:273 static/js/zamboni/devhub-all.js:504 static/js/zamboni/devhub-min.js:1
 msgid "Received an empty response from the server; status: {0}"
 msgstr ""
 
-#: static/js/common/upload-addon.js:373
+#: static/js/common/upload-addon.js:370 static/js/zamboni/devhub-all.js:604 static/js/zamboni/devhub-min.js:1
 msgid "Unexpected server error while validating."
 msgstr ""
 
-#: static/js/common/upload-addon.js:412
+#: static/js/common/upload-addon.js:409 static/js/zamboni/devhub-all.js:643 static/js/zamboni/devhub-min.js:1
 msgid "Finished validating {0}"
 msgstr ""
 
-#: static/js/common/upload-addon.js:418
+#: static/js/common/upload-addon.js:415 static/js/zamboni/devhub-all.js:649 static/js/zamboni/devhub-min.js:1
 msgid "Your add-on validation timed out, it will be manually reviewed."
 msgstr ""
 
-#: static/js/common/upload-addon.js:421
+#: static/js/common/upload-addon.js:418 static/js/zamboni/devhub-all.js:652 static/js/zamboni/devhub-min.js:1
 msgid "Your add-on was validated with no errors and {0} warning."
 msgid_plural "Your add-on was validated with no errors and {0} warnings."
 msgstr[0] ""
 msgstr[1] ""
 
-#: static/js/common/upload-addon.js:426
+#: static/js/common/upload-addon.js:423 static/js/zamboni/devhub-all.js:657 static/js/zamboni/devhub-min.js:1
 msgid "Your add-on was validated with no errors and {0} message."
 msgid_plural "Your add-on was validated with no errors and {0} messages."
 msgstr[0] ""
 msgstr[1] ""
 
-#: static/js/common/upload-addon.js:431
+#: static/js/common/upload-addon.js:428 static/js/zamboni/devhub-all.js:662 static/js/zamboni/devhub-min.js:1
 msgid "Your add-on was validated with no errors or warnings."
 msgstr ""
 
-#: static/js/common/upload-addon.js:446
+#: static/js/common/upload-addon.js:443 static/js/zamboni/devhub-all.js:677 static/js/zamboni/devhub-min.js:1
 msgid "Your submission will be automatically signed."
 msgstr ""
 
-#: static/js/common/upload-addon.js:465
+#: static/js/common/upload-addon.js:450 static/js/zamboni/devhub-all.js:696 static/js/zamboni/devhub-min.js:1
 msgid "Include detailed version notes (this can be done in the next step)."
 msgstr ""
 
-#: static/js/common/upload-addon.js:466
+#: static/js/common/upload-addon.js:451 static/js/zamboni/devhub-all.js:697 static/js/zamboni/devhub-min.js:1
 msgid "If your add-on requires an account to a website in order to be fully tested, include a test username and password in the Notes to Reviewer (this can be done in the next step)."
 msgstr ""
 
-#: static/js/common/upload-addon.js:467
+#: static/js/common/upload-addon.js:452 static/js/zamboni/devhub-all.js:698 static/js/zamboni/devhub-min.js:1
 msgid "If your add-on is intended for a limited audience you should choose Preliminary Review instead of Full Review."
 msgstr ""
 
-#: static/js/common/upload-addon.js:480
+#: static/js/common/upload-addon.js:465 static/js/zamboni/devhub-all.js:711 static/js/zamboni/devhub-min.js:1
 msgid "Add-on submission checklist"
 msgstr ""
 
-#: static/js/common/upload-addon.js:481
+#: static/js/common/upload-addon.js:466 static/js/zamboni/devhub-all.js:712 static/js/zamboni/devhub-min.js:1
 msgid "Please verify the following points before finalizing your submission. This will minimize delays or misunderstanding during the review process:"
 msgstr ""
 
-#: static/js/common/upload-addon.js:483
+#: static/js/common/upload-addon.js:468 static/js/zamboni/devhub-all.js:714 static/js/zamboni/devhub-min.js:1
 msgid ""
 "Compiled binaries, as well as minified or obfuscated scripts (excluding known libraries) need to have their sources submitted separately for review. Make sure that you use the source code upload "
 "field to avoid having your submission rejected."
 msgstr ""
 
-#: static/js/common/upload-addon.js:501
+#: static/js/common/upload-addon.js:486 static/js/zamboni/devhub-all.js:732 static/js/zamboni/devhub-min.js:1
 msgid "The validation process found these issues that can lead to rejections:"
 msgstr ""
 
-#: static/js/common/upload-addon.js:518
+#: static/js/common/upload-addon.js:503 static/js/zamboni/devhub-all.js:749 static/js/zamboni/devhub-min.js:1
 msgid "If you are unfamiliar with the add-ons review process, you can read about it here."
 msgstr ""
 
-#: static/js/common/upload-addon.js:555
+#: static/js/common/upload-addon.js:540 static/js/zamboni/devhub-all.js:786 static/js/zamboni/devhub-min.js:1
 msgid "Sorry, no supported platform has been found."
 msgstr ""
 
-#: static/js/common/upload-base.js:57
+#: static/js/common/upload-base.js:57 static/js/zamboni/devhub-all.js:187 static/js/zamboni/devhub-min.js:1
 msgid "The filetype you uploaded isn't recognized."
 msgstr ""
 
-#: static/js/common/upload-base.js:79
+#: static/js/common/upload-base.js:79 static/js/zamboni/devhub-all.js:209 static/js/zamboni/devhub-min.js:1
 msgid "You cancelled the upload."
 msgstr ""
 
-#: static/js/common/upload-image.js:97 static/js/impala/users.js:51
-msgid "Images must be either PNG or JPG."
-msgstr ""
-
-#: static/js/common/upload-image.js:101
-msgid "Videos must be in WebM."
-msgstr ""
-
-#: static/js/impala/collections.js:10 static/js/zamboni/collections.js:595
-msgid "Follow this Collection"
-msgstr ""
-
-#: static/js/impala/collections.js:19
-msgid "Stop Following"
-msgstr ""
-
-#: static/js/impala/collections.js:20
-msgid "Following"
-msgstr ""
-
-#. L10n: {0} is an app name.
-#: static/js/impala/listing.js:11 static/js/zamboni/themes.js:13
-msgid "This theme is incompatible with your version of {0}"
-msgstr ""
-
-#: static/js/impala/persona_creation.js:60
-msgid "All Rights Reserved"
-msgstr ""
-
-#: static/js/impala/persona_creation.js:64
-msgid "Creative Commons Attribution 3.0"
-msgstr ""
-
-#: static/js/impala/persona_creation.js:69
-msgid "Creative Commons Attribution-NonCommercial 3.0"
-msgstr ""
-
-#: static/js/impala/persona_creation.js:74
-msgid "Creative Commons Attribution-NonCommercial-NoDerivs 3.0"
-msgstr ""
-
-#: static/js/impala/persona_creation.js:79
-msgid "Creative Commons Attribution-NonCommercial-Share Alike 3.0"
-msgstr ""
-
-#: static/js/impala/persona_creation.js:84
-msgid "Creative Commons Attribution-NoDerivs 3.0"
-msgstr ""
-
-#: static/js/impala/persona_creation.js:89
-msgid "Creative Commons Attribution-ShareAlike 3.0"
-msgstr ""
-
-#: static/js/impala/persona_creation.js:292
-msgid "Your Theme's Name"
-msgstr ""
-
-#: static/js/impala/reviews.js:23 static/js/zamboni/reviews.js:18
-msgid "Flagged for review"
-msgstr ""
-
-#: static/js/impala/reviews.js:40 static/js/zamboni/reviews.js:34
-msgid "Your input is required"
-msgstr ""
-
-#: static/js/impala/reviews.js:152 static/js/zamboni/reviews.js:103
-msgid "Marked for deletion"
-msgstr ""
-
-#: static/js/impala/search.js:114
-msgid "Updating results&hellip;"
-msgstr ""
-
-#: static/js/impala/site_suggestions.js:46
-msgid "Category"
-msgstr ""
-
-#: static/js/impala/suggestions.js:39
-msgid "Search themes for <b>{0}</b>"
-msgstr ""
-
-#: static/js/impala/suggestions.js:41
-msgid "Search apps for <b>{0}</b>"
-msgstr ""
-
-#: static/js/impala/suggestions.js:43
-msgid "Search add-ons for <b>{0}</b>"
-msgstr ""
-
-#: static/js/impala/users.js:33
-msgid "use original"
-msgstr ""
-
-#: static/js/impala/stats/chart.js:267
+#: static/js/impala/stats/chart.js:267 static/js/zamboni/stats-all.js:16898 static/js/zamboni/stats-min.js:5
 msgid "Week of {0}"
 msgstr ""
 
-#: static/js/impala/stats/chart.js:269
+#: static/js/impala/stats/chart.js:269 static/js/zamboni/stats-all.js:16900 static/js/zamboni/stats-min.js:5
 msgid " downloads"
 msgstr ""
 
-#: static/js/impala/stats/chart.js:270
+#: static/js/impala/stats/chart.js:270 static/js/zamboni/stats-all.js:16901 static/js/zamboni/stats-min.js:5
 msgid "{0} users"
 msgstr ""
 
-#: static/js/impala/stats/chart.js:271
+#: static/js/impala/stats/chart.js:271 static/js/zamboni/stats-all.js:16902 static/js/zamboni/stats-min.js:5
 msgid "{0} add-ons"
 msgstr ""
 
-#: static/js/impala/stats/chart.js:272
+#: static/js/impala/stats/chart.js:272 static/js/zamboni/stats-all.js:16903 static/js/zamboni/stats-min.js:5
 msgid "{0} collections"
 msgstr ""
 
-#: static/js/impala/stats/chart.js:273
+#: static/js/impala/stats/chart.js:273 static/js/zamboni/stats-all.js:16904 static/js/zamboni/stats-min.js:5
 msgid "{0} reviews"
 msgstr ""
 
-#: static/js/impala/stats/chart.js:275
+#: static/js/impala/stats/chart.js:275 static/js/zamboni/stats-all.js:16906 static/js/zamboni/stats-min.js:5
 msgid "{0} sales"
 msgstr ""
 
-#: static/js/impala/stats/chart.js:276
+#: static/js/impala/stats/chart.js:276 static/js/zamboni/stats-all.js:16907 static/js/zamboni/stats-min.js:5
 msgid "{0} refunds"
 msgstr ""
 
-#: static/js/impala/stats/chart.js:277
+#: static/js/impala/stats/chart.js:277 static/js/zamboni/stats-all.js:16908 static/js/zamboni/stats-min.js:5
 msgid "{0} installs"
 msgstr ""
 
-#: static/js/impala/stats/chart.js:369 static/js/impala/stats/csv_keys.js:3 static/js/impala/stats/csv_keys.js:109
+#: static/js/impala/stats/chart.js:369 static/js/impala/stats/csv_keys.js:3 static/js/impala/stats/csv_keys.js:109 static/js/zamboni/stats-all.js:15284 static/js/zamboni/stats-all.js:15390
+#: static/js/zamboni/stats-all.js:17000 static/js/zamboni/stats-min.js:4 static/js/zamboni/stats-min.js:5
 msgid "Downloads"
 msgstr ""
 
-#: static/js/impala/stats/chart.js:379 static/js/impala/stats/csv_keys.js:6 static/js/impala/stats/csv_keys.js:110
+#: static/js/impala/stats/chart.js:379 static/js/impala/stats/csv_keys.js:6 static/js/impala/stats/csv_keys.js:110 static/js/zamboni/stats-all.js:15287 static/js/zamboni/stats-all.js:15391
+#: static/js/zamboni/stats-all.js:17010 static/js/zamboni/stats-min.js:4 static/js/zamboni/stats-min.js:5
 msgid "Daily Users"
 msgstr ""
 
-#: static/js/impala/stats/chart.js:410
+#: static/js/impala/stats/chart.js:410 static/js/zamboni/stats-all.js:17041 static/js/zamboni/stats-min.js:5
 msgid "Amount, in USD"
 msgstr ""
 
-#: static/js/impala/stats/chart.js:421 static/js/impala/stats/csv_keys.js:104
+#: static/js/impala/stats/chart.js:421 static/js/impala/stats/csv_keys.js:104 static/js/zamboni/stats-all.js:15385 static/js/zamboni/stats-all.js:17052 static/js/zamboni/stats-min.js:5
 msgid "Number of Contributions"
 msgstr ""
 
-#: static/js/impala/stats/chart.js:447
+#: static/js/impala/stats/chart.js:447 static/js/zamboni/stats-all.js:17078 static/js/zamboni/stats-min.js:5
 msgid "More Info..."
 msgstr ""
 
 #. L10n: {0} is an ISO-formatted date.
-#: static/js/impala/stats/chart.js:451
+#: static/js/impala/stats/chart.js:451 static/js/zamboni/stats-all.js:17082 static/js/zamboni/stats-min.js:5
 msgid "Details for {0}"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:9
+#: static/js/impala/stats/csv_keys.js:9 static/js/zamboni/stats-all.js:15290 static/js/zamboni/stats-min.js:4
 msgid "Collections Created"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:12
+#: static/js/impala/stats/csv_keys.js:12 static/js/zamboni/stats-all.js:15293 static/js/zamboni/stats-min.js:4
 msgid "Add-ons in Use"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:15
+#: static/js/impala/stats/csv_keys.js:15 static/js/zamboni/stats-all.js:15296 static/js/zamboni/stats-min.js:4
 msgid "Add-ons Created"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:18
+#: static/js/impala/stats/csv_keys.js:18 static/js/zamboni/stats-all.js:15299 static/js/zamboni/stats-min.js:4
 msgid "Add-ons Downloaded"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:21
+#: static/js/impala/stats/csv_keys.js:21 static/js/zamboni/stats-all.js:15302 static/js/zamboni/stats-min.js:4
 msgid "Add-ons Updated"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:24
+#: static/js/impala/stats/csv_keys.js:24 static/js/zamboni/stats-all.js:15305 static/js/zamboni/stats-min.js:4
 msgid "Reviews Written"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:27
+#: static/js/impala/stats/csv_keys.js:27 static/js/zamboni/stats-all.js:15308 static/js/zamboni/stats-min.js:4
 msgid "User Signups"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:30
+#: static/js/impala/stats/csv_keys.js:30 static/js/zamboni/stats-all.js:15311 static/js/zamboni/stats-min.js:4
 msgid "Subscribers"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:33
+#: static/js/impala/stats/csv_keys.js:33 static/js/zamboni/stats-all.js:15314 static/js/zamboni/stats-min.js:4
 msgid "Ratings"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:36 static/js/impala/stats/csv_keys.js:114
+#: static/js/impala/stats/csv_keys.js:36 static/js/impala/stats/csv_keys.js:114 static/js/zamboni/stats-all.js:15317 static/js/zamboni/stats-all.js:15395 static/js/zamboni/stats-min.js:4
+#: static/js/zamboni/stats-min.js:5
 msgid "Sales"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:39 static/js/impala/stats/csv_keys.js:113
+#: static/js/impala/stats/csv_keys.js:39 static/js/impala/stats/csv_keys.js:113 static/js/zamboni/stats-all.js:15320 static/js/zamboni/stats-all.js:15394 static/js/zamboni/stats-min.js:4
+#: static/js/zamboni/stats-min.js:5
 msgid "Installs"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:42
+#: static/js/impala/stats/csv_keys.js:42 static/js/zamboni/stats-all.js:15323 static/js/zamboni/stats-min.js:4
 msgid "Unknown"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:43
+#: static/js/impala/stats/csv_keys.js:43 static/js/zamboni/stats-all.js:15324 static/js/zamboni/stats-min.js:4
 msgid "Add-ons Manager"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:44
+#: static/js/impala/stats/csv_keys.js:44 static/js/zamboni/stats-all.js:15325 static/js/zamboni/stats-min.js:4
 msgid "Add-ons Manager Promo"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:45
+#: static/js/impala/stats/csv_keys.js:45 static/js/zamboni/stats-all.js:15326 static/js/zamboni/stats-min.js:4
 msgid "Add-ons Manager Featured"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:46
+#: static/js/impala/stats/csv_keys.js:46 static/js/zamboni/stats-all.js:15327 static/js/zamboni/stats-min.js:4
 msgid "Add-ons Manager Learn More"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:47
+#: static/js/impala/stats/csv_keys.js:47 static/js/zamboni/stats-all.js:15328 static/js/zamboni/stats-min.js:4
 msgid "Search Suggestions"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:48
+#: static/js/impala/stats/csv_keys.js:48 static/js/zamboni/stats-all.js:15329 static/js/zamboni/stats-min.js:4
 msgid "Search Results"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:49 static/js/impala/stats/csv_keys.js:50 static/js/impala/stats/csv_keys.js:51
+#: static/js/impala/stats/csv_keys.js:49 static/js/impala/stats/csv_keys.js:50 static/js/impala/stats/csv_keys.js:51 static/js/zamboni/stats-all.js:15330 static/js/zamboni/stats-all.js:15331
+#: static/js/zamboni/stats-all.js:15332 static/js/zamboni/stats-min.js:4
 msgid "Homepage Promo"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:52 static/js/impala/stats/csv_keys.js:53
+#: static/js/impala/stats/csv_keys.js:52 static/js/impala/stats/csv_keys.js:53 static/js/zamboni/stats-all.js:15333 static/js/zamboni/stats-all.js:15334 static/js/zamboni/stats-min.js:4
 msgid "Homepage Featured"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:54 static/js/impala/stats/csv_keys.js:55
+#: static/js/impala/stats/csv_keys.js:54 static/js/impala/stats/csv_keys.js:55 static/js/zamboni/stats-all.js:15335 static/js/zamboni/stats-all.js:15336 static/js/zamboni/stats-min.js:4
 msgid "Homepage Up and Coming"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:56
+#: static/js/impala/stats/csv_keys.js:56 static/js/zamboni/stats-all.js:15337 static/js/zamboni/stats-min.js:4
 msgid "Homepage Most Popular"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:57 static/js/impala/stats/csv_keys.js:59
+#: static/js/impala/stats/csv_keys.js:57 static/js/impala/stats/csv_keys.js:59 static/js/zamboni/stats-all.js:15338 static/js/zamboni/stats-all.js:15340 static/js/zamboni/stats-min.js:4
 msgid "Detail Page"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:58 static/js/impala/stats/csv_keys.js:60
+#: static/js/impala/stats/csv_keys.js:58 static/js/impala/stats/csv_keys.js:60 static/js/zamboni/stats-all.js:15339 static/js/zamboni/stats-all.js:15341 static/js/zamboni/stats-min.js:4
 msgid "Detail Page (bottom)"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:61
+#: static/js/impala/stats/csv_keys.js:61 static/js/zamboni/stats-all.js:15342 static/js/zamboni/stats-min.js:4
 msgid "Detail Page (Development Channel)"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:62 static/js/impala/stats/csv_keys.js:63 static/js/impala/stats/csv_keys.js:64
+#: static/js/impala/stats/csv_keys.js:62 static/js/impala/stats/csv_keys.js:63 static/js/impala/stats/csv_keys.js:64 static/js/zamboni/stats-all.js:15343 static/js/zamboni/stats-all.js:15344
+#: static/js/zamboni/stats-all.js:15345 static/js/zamboni/stats-min.js:4
 msgid "Often Used With"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:65 static/js/impala/stats/csv_keys.js:66
+#: static/js/impala/stats/csv_keys.js:65 static/js/impala/stats/csv_keys.js:66 static/js/zamboni/stats-all.js:15346 static/js/zamboni/stats-all.js:15347 static/js/zamboni/stats-min.js:4
 msgid "Others By Author"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:67 static/js/impala/stats/csv_keys.js:68
+#: static/js/impala/stats/csv_keys.js:67 static/js/impala/stats/csv_keys.js:68 static/js/zamboni/stats-all.js:15348 static/js/zamboni/stats-all.js:15349 static/js/zamboni/stats-min.js:4
 msgid "Dependencies"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:69 static/js/impala/stats/csv_keys.js:70
+#: static/js/impala/stats/csv_keys.js:69 static/js/impala/stats/csv_keys.js:70 static/js/zamboni/stats-all.js:15350 static/js/zamboni/stats-all.js:15351 static/js/zamboni/stats-min.js:4
 msgid "Upsell"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:71
+#: static/js/impala/stats/csv_keys.js:71 static/js/zamboni/stats-all.js:15352 static/js/zamboni/stats-min.js:4
 msgid "Meet the Developer"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:72
+#: static/js/impala/stats/csv_keys.js:72 static/js/zamboni/stats-all.js:15353 static/js/zamboni/stats-min.js:4
 msgid "User Profile"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:73
+#: static/js/impala/stats/csv_keys.js:73 static/js/zamboni/stats-all.js:15354 static/js/zamboni/stats-min.js:4
 msgid "Version History"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:75
+#: static/js/impala/stats/csv_keys.js:75 static/js/zamboni/stats-all.js:15356 static/js/zamboni/stats-min.js:4
 msgid "Sharing"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:76
+#: static/js/impala/stats/csv_keys.js:76 static/js/zamboni/stats-all.js:15357 static/js/zamboni/stats-min.js:4
 msgid "Category Pages"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:77
+#: static/js/impala/stats/csv_keys.js:77 static/js/zamboni/stats-all.js:15358 static/js/zamboni/stats-min.js:4
 msgid "Collections"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:78 static/js/impala/stats/csv_keys.js:79
+#: static/js/impala/stats/csv_keys.js:78 static/js/impala/stats/csv_keys.js:79 static/js/zamboni/stats-all.js:15359 static/js/zamboni/stats-all.js:15360 static/js/zamboni/stats-min.js:4
 msgid "Category Landing Featured Carousel"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:80 static/js/impala/stats/csv_keys.js:81
+#: static/js/impala/stats/csv_keys.js:80 static/js/impala/stats/csv_keys.js:81 static/js/zamboni/stats-all.js:15361 static/js/zamboni/stats-all.js:15362 static/js/zamboni/stats-min.js:4
 msgid "Category Landing Top Rated"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:82 static/js/impala/stats/csv_keys.js:83
+#: static/js/impala/stats/csv_keys.js:82 static/js/impala/stats/csv_keys.js:83 static/js/zamboni/stats-all.js:15363 static/js/zamboni/stats-all.js:15364 static/js/zamboni/stats-min.js:5
 msgid "Category Landing Most Popular"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:84 static/js/impala/stats/csv_keys.js:85
+#: static/js/impala/stats/csv_keys.js:84 static/js/impala/stats/csv_keys.js:85 static/js/zamboni/stats-all.js:15365 static/js/zamboni/stats-all.js:15366 static/js/zamboni/stats-min.js:5
 msgid "Category Landing Recently Added"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:86 static/js/impala/stats/csv_keys.js:87
+#: static/js/impala/stats/csv_keys.js:86 static/js/impala/stats/csv_keys.js:87 static/js/zamboni/stats-all.js:15367 static/js/zamboni/stats-all.js:15368 static/js/zamboni/stats-min.js:5
 msgid "Browse Listing Featured Sort"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:88 static/js/impala/stats/csv_keys.js:89
+#: static/js/impala/stats/csv_keys.js:88 static/js/impala/stats/csv_keys.js:89 static/js/zamboni/stats-all.js:15369 static/js/zamboni/stats-all.js:15370 static/js/zamboni/stats-min.js:5
 msgid "Browse Listing Users Sort"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:90 static/js/impala/stats/csv_keys.js:91
+#: static/js/impala/stats/csv_keys.js:90 static/js/impala/stats/csv_keys.js:91 static/js/zamboni/stats-all.js:15371 static/js/zamboni/stats-all.js:15372 static/js/zamboni/stats-min.js:5
 msgid "Browse Listing Rating Sort"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:92 static/js/impala/stats/csv_keys.js:93
+#: static/js/impala/stats/csv_keys.js:92 static/js/impala/stats/csv_keys.js:93 static/js/zamboni/stats-all.js:15373 static/js/zamboni/stats-all.js:15374 static/js/zamboni/stats-min.js:5
 msgid "Browse Listing Created Sort"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:94 static/js/impala/stats/csv_keys.js:95
+#: static/js/impala/stats/csv_keys.js:94 static/js/impala/stats/csv_keys.js:95 static/js/zamboni/stats-all.js:15375 static/js/zamboni/stats-all.js:15376 static/js/zamboni/stats-min.js:5
 msgid "Browse Listing Name Sort"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:96 static/js/impala/stats/csv_keys.js:97
+#: static/js/impala/stats/csv_keys.js:96 static/js/impala/stats/csv_keys.js:97 static/js/zamboni/stats-all.js:15377 static/js/zamboni/stats-all.js:15378 static/js/zamboni/stats-min.js:5
 msgid "Browse Listing Popular Sort"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:98 static/js/impala/stats/csv_keys.js:99
+#: static/js/impala/stats/csv_keys.js:98 static/js/impala/stats/csv_keys.js:99 static/js/zamboni/stats-all.js:15379 static/js/zamboni/stats-all.js:15380 static/js/zamboni/stats-min.js:5
 msgid "Browse Listing Updated Sort"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:100 static/js/impala/stats/csv_keys.js:101
+#: static/js/impala/stats/csv_keys.js:100 static/js/impala/stats/csv_keys.js:101 static/js/zamboni/stats-all.js:15381 static/js/zamboni/stats-all.js:15382 static/js/zamboni/stats-min.js:5
 msgid "Browse Listing Up and Coming Sort"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:105
+#: static/js/impala/stats/csv_keys.js:105 static/js/zamboni/stats-all.js:15386 static/js/zamboni/stats-min.js:5
 msgid "Total Amount Contributed"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:106
+#: static/js/impala/stats/csv_keys.js:106 static/js/zamboni/stats-all.js:15387 static/js/zamboni/stats-min.js:5
 msgid "Average Contribution"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:115
+#: static/js/impala/stats/csv_keys.js:115 static/js/zamboni/stats-all.js:15396 static/js/zamboni/stats-min.js:5
 msgid "Usage"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:118
+#: static/js/impala/stats/csv_keys.js:118 static/js/zamboni/stats-all.js:15399 static/js/zamboni/stats-min.js:5
 msgid "Firefox"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:119
+#: static/js/impala/stats/csv_keys.js:119 static/js/zamboni/stats-all.js:15400 static/js/zamboni/stats-min.js:5
 msgid "Mozilla"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:120
+#: static/js/impala/stats/csv_keys.js:120 static/js/zamboni/stats-all.js:15401 static/js/zamboni/stats-min.js:5
 msgid "Thunderbird"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:121
+#: static/js/impala/stats/csv_keys.js:121 static/js/zamboni/stats-all.js:15402 static/js/zamboni/stats-min.js:5
 msgid "Sunbird"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:122
+#: static/js/impala/stats/csv_keys.js:122 static/js/zamboni/stats-all.js:15403 static/js/zamboni/stats-min.js:5
 msgid "SeaMonkey"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:123
+#: static/js/impala/stats/csv_keys.js:123 static/js/zamboni/stats-all.js:15404 static/js/zamboni/stats-min.js:5
 msgid "Fennec"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:124
+#: static/js/impala/stats/csv_keys.js:124 static/js/zamboni/stats-all.js:15405 static/js/zamboni/stats-min.js:5
 msgid "Android"
 msgstr ""
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:129
+#: static/js/impala/stats/csv_keys.js:129 static/js/zamboni/stats-all.js:15410 static/js/zamboni/stats-min.js:5
 msgid "Downloads and Daily Users, last {0} days"
 msgstr ""
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:131
+#: static/js/impala/stats/csv_keys.js:131 static/js/zamboni/stats-all.js:15412 static/js/zamboni/stats-min.js:5
 msgid "Downloads and Daily Users from {0} to {1}"
 msgstr ""
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:135
+#: static/js/impala/stats/csv_keys.js:135 static/js/zamboni/stats-all.js:15416 static/js/zamboni/stats-min.js:5
 msgid "Installs and Daily Users, last {0} days"
 msgstr ""
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:137
+#: static/js/impala/stats/csv_keys.js:137 static/js/zamboni/stats-all.js:15418 static/js/zamboni/stats-min.js:5
 msgid "Installs and Daily Users from {0} to {1}"
 msgstr ""
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:141
+#: static/js/impala/stats/csv_keys.js:141 static/js/zamboni/stats-all.js:15422 static/js/zamboni/stats-min.js:5
 msgid "Downloads, last {0} days"
 msgstr ""
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:143
+#: static/js/impala/stats/csv_keys.js:143 static/js/zamboni/stats-all.js:15424 static/js/zamboni/stats-min.js:5
 msgid "Downloads from {0} to {1}"
 msgstr ""
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:147
+#: static/js/impala/stats/csv_keys.js:147 static/js/zamboni/stats-all.js:15428 static/js/zamboni/stats-min.js:5
 msgid "Daily Users, last {0} days"
 msgstr ""
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:149
+#: static/js/impala/stats/csv_keys.js:149 static/js/zamboni/stats-all.js:15430 static/js/zamboni/stats-min.js:5
 msgid "Daily Users from {0} to {1}"
 msgstr ""
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:153
+#: static/js/impala/stats/csv_keys.js:153 static/js/zamboni/stats-all.js:15434 static/js/zamboni/stats-min.js:5
 msgid "Applications, last {0} days"
 msgstr ""
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:155
+#: static/js/impala/stats/csv_keys.js:155 static/js/zamboni/stats-all.js:15436 static/js/zamboni/stats-min.js:5
 msgid "Applications from {0} to {1}"
 msgstr ""
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:159
+#: static/js/impala/stats/csv_keys.js:159 static/js/zamboni/stats-all.js:15440 static/js/zamboni/stats-min.js:5
 msgid "Platforms, last {0} days"
 msgstr ""
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:161
+#: static/js/impala/stats/csv_keys.js:161 static/js/zamboni/stats-all.js:15442 static/js/zamboni/stats-min.js:5
 msgid "Platforms from {0} to {1}"
 msgstr ""
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:165
+#: static/js/impala/stats/csv_keys.js:165 static/js/zamboni/stats-all.js:15446 static/js/zamboni/stats-min.js:5
 msgid "Languages, last {0} days"
 msgstr ""
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:167
+#: static/js/impala/stats/csv_keys.js:167 static/js/zamboni/stats-all.js:15448 static/js/zamboni/stats-min.js:5
 msgid "Languages from {0} to {1}"
 msgstr ""
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:171
+#: static/js/impala/stats/csv_keys.js:171 static/js/zamboni/stats-all.js:15452 static/js/zamboni/stats-min.js:5
 msgid "Add-on Versions, last {0} days"
 msgstr ""
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:173
+#: static/js/impala/stats/csv_keys.js:173 static/js/zamboni/stats-all.js:15454 static/js/zamboni/stats-min.js:5
 msgid "Add-on Versions from {0} to {1}"
 msgstr ""
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:177
+#: static/js/impala/stats/csv_keys.js:177 static/js/zamboni/stats-all.js:15458 static/js/zamboni/stats-min.js:5
 msgid "Add-on Status, last {0} days"
 msgstr ""
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:179
+#: static/js/impala/stats/csv_keys.js:179 static/js/zamboni/stats-all.js:15460 static/js/zamboni/stats-min.js:5
 msgid "Add-on Status from {0} to {1}"
 msgstr ""
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:183
+#: static/js/impala/stats/csv_keys.js:183 static/js/zamboni/stats-all.js:15464 static/js/zamboni/stats-min.js:5
 msgid "Download Sources, last {0} days"
 msgstr ""
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:185
+#: static/js/impala/stats/csv_keys.js:185 static/js/zamboni/stats-all.js:15466 static/js/zamboni/stats-min.js:5
 msgid "Download Sources from {0} to {1}"
 msgstr ""
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:189
+#: static/js/impala/stats/csv_keys.js:189 static/js/zamboni/stats-all.js:15470 static/js/zamboni/stats-min.js:5
 msgid "Contributions, last {0} days"
 msgstr ""
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:191
+#: static/js/impala/stats/csv_keys.js:191 static/js/zamboni/stats-all.js:15472 static/js/zamboni/stats-min.js:5
 msgid "Contributions from {0} to {1}"
 msgstr ""
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:195
+#: static/js/impala/stats/csv_keys.js:195 static/js/zamboni/stats-all.js:15476 static/js/zamboni/stats-min.js:5
 msgid "Site Metrics, last {0} days"
 msgstr ""
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:197
+#: static/js/impala/stats/csv_keys.js:197 static/js/zamboni/stats-all.js:15478 static/js/zamboni/stats-min.js:5
 msgid "Site Metrics from {0} to {1}"
 msgstr ""
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:201
+#: static/js/impala/stats/csv_keys.js:201 static/js/zamboni/stats-all.js:15482 static/js/zamboni/stats-min.js:5
 msgid "Add-ons in Use, last {0} days"
 msgstr ""
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:203
+#: static/js/impala/stats/csv_keys.js:203 static/js/zamboni/stats-all.js:15484 static/js/zamboni/stats-min.js:5
 msgid "Add-ons in Use from {0} to {1}"
 msgstr ""
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:207
+#: static/js/impala/stats/csv_keys.js:207 static/js/zamboni/stats-all.js:15488 static/js/zamboni/stats-min.js:5
 msgid "Add-ons Downloaded, last {0} days"
 msgstr ""
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:209
+#: static/js/impala/stats/csv_keys.js:209 static/js/zamboni/stats-all.js:15490 static/js/zamboni/stats-min.js:5
 msgid "Add-ons Downloaded from {0} to {1}"
 msgstr ""
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:213
+#: static/js/impala/stats/csv_keys.js:213 static/js/zamboni/stats-all.js:15494 static/js/zamboni/stats-min.js:5
 msgid "Add-ons Created, last {0} days"
 msgstr ""
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:215
+#: static/js/impala/stats/csv_keys.js:215 static/js/zamboni/stats-all.js:15496 static/js/zamboni/stats-min.js:5
 msgid "Add-ons Created from {0} to {1}"
 msgstr ""
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:219
+#: static/js/impala/stats/csv_keys.js:219 static/js/zamboni/stats-all.js:15500 static/js/zamboni/stats-min.js:5
 msgid "Add-ons Updated, last {0} days"
 msgstr ""
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:221
+#: static/js/impala/stats/csv_keys.js:221 static/js/zamboni/stats-all.js:15502 static/js/zamboni/stats-min.js:5
 msgid "Add-ons Updated from {0} to {1}"
 msgstr ""
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:225
+#: static/js/impala/stats/csv_keys.js:225 static/js/zamboni/stats-all.js:15506 static/js/zamboni/stats-min.js:5
 msgid "Reviews Written, last {0} days"
 msgstr ""
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:227
+#: static/js/impala/stats/csv_keys.js:227 static/js/zamboni/stats-all.js:15508 static/js/zamboni/stats-min.js:5
 msgid "Reviews Written from {0} to {1}"
 msgstr ""
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:231
+#: static/js/impala/stats/csv_keys.js:231 static/js/zamboni/stats-all.js:15512 static/js/zamboni/stats-min.js:5
 msgid "User Signups, last {0} days"
 msgstr ""
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:233
+#: static/js/impala/stats/csv_keys.js:233 static/js/zamboni/stats-all.js:15514 static/js/zamboni/stats-min.js:5
 msgid "User Signups from {0} to {1}"
 msgstr ""
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:237
+#: static/js/impala/stats/csv_keys.js:237 static/js/zamboni/stats-all.js:15518 static/js/zamboni/stats-min.js:5
 msgid "Collections Created, last {0} days"
 msgstr ""
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:239
+#: static/js/impala/stats/csv_keys.js:239 static/js/zamboni/stats-all.js:15520 static/js/zamboni/stats-min.js:5
 msgid "Collections Created from {0} to {1}"
 msgstr ""
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:243
+#: static/js/impala/stats/csv_keys.js:243 static/js/zamboni/stats-all.js:15524 static/js/zamboni/stats-min.js:5
 msgid "Subscribers, last {0} days"
 msgstr ""
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:245
+#: static/js/impala/stats/csv_keys.js:245 static/js/zamboni/stats-all.js:15526 static/js/zamboni/stats-min.js:5
 msgid "Subscribers from {0} to {1}"
 msgstr ""
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:249
+#: static/js/impala/stats/csv_keys.js:249 static/js/zamboni/stats-all.js:15530 static/js/zamboni/stats-min.js:5
 msgid "Ratings, last {0} days"
 msgstr ""
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:251
+#: static/js/impala/stats/csv_keys.js:251 static/js/zamboni/stats-all.js:15532 static/js/zamboni/stats-min.js:5
 msgid "Ratings from {0} to {1}"
 msgstr ""
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:255
+#: static/js/impala/stats/csv_keys.js:255 static/js/zamboni/stats-all.js:15536 static/js/zamboni/stats-min.js:5
 msgid "Sales, last {0} days"
 msgstr ""
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:257
+#: static/js/impala/stats/csv_keys.js:257 static/js/zamboni/stats-all.js:15538 static/js/zamboni/stats-min.js:5
 msgid "Sales from {0} to {1}"
 msgstr ""
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:261
+#: static/js/impala/stats/csv_keys.js:261 static/js/zamboni/stats-all.js:15542 static/js/zamboni/stats-min.js:5
 msgid "Installs, last {0} days"
 msgstr ""
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:263
+#: static/js/impala/stats/csv_keys.js:263 static/js/zamboni/stats-all.js:15544 static/js/zamboni/stats-min.js:5
 msgid "Installs from {0} to {1}"
 msgstr ""
 
 #. L10n: {0} and {1} are integers.
-#: static/js/impala/stats/csv_keys.js:269
+#: static/js/impala/stats/csv_keys.js:269 static/js/zamboni/stats-all.js:15550 static/js/zamboni/stats-min.js:5
 msgid "<b>{0}</b> in last {1} days"
 msgstr ""
 
 #. L10n: {0} is an integer and {1} and {2} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:271 static/js/impala/stats/csv_keys.js:277
+#: static/js/impala/stats/csv_keys.js:271 static/js/impala/stats/csv_keys.js:277 static/js/zamboni/stats-all.js:15552 static/js/zamboni/stats-all.js:15558 static/js/zamboni/stats-min.js:5
 msgid "<b>{0}</b> from {1} to {2}"
 msgstr ""
 
 #. L10n: {0} and {1} are integers.
-#: static/js/impala/stats/csv_keys.js:275
+#: static/js/impala/stats/csv_keys.js:275 static/js/zamboni/stats-all.js:15556 static/js/zamboni/stats-min.js:5
 msgid "<b>{0}</b> average in last {1} days"
 msgstr ""
 
-#: static/js/impala/stats/overview.js:19
+#: static/js/impala/stats/overview.js:19 static/js/zamboni/stats-all.js:16469 static/js/zamboni/stats-min.js:5
 msgid "No data available."
 msgstr ""
 
-#: static/js/impala/stats/table.js:74
+#: static/js/impala/stats/table.js:74 static/js/zamboni/stats-all.js:17209 static/js/zamboni/stats-min.js:5
 msgid "Date"
 msgstr ""
 
-#: static/js/impala/stats/topchart.js:96
+#: static/js/impala/stats/topchart.js:96 static/js/zamboni/stats-all.js:16600 static/js/zamboni/stats-min.js:5
 msgid "Other"
 msgstr ""
 
-#: static/js/zamboni/admin_validation.js:24 static/js/zamboni/devhub.js:1229 static/js/zamboni/editors.js:295
+#: static/js/zamboni/admin-all.js:180 static/js/zamboni/admin-min.js:1 static/js/zamboni/admin_validation.js:24 static/js/zamboni/devhub-all.js:2408 static/js/zamboni/devhub-min.js:2
+#: static/js/zamboni/devhub.js:1229 static/js/zamboni/editors-all.js:15576 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:295
 msgid "Select an application first"
 msgstr ""
 
-#: static/js/zamboni/admin_validation.js:51
+#: static/js/zamboni/admin-all.js:207 static/js/zamboni/admin-min.js:1 static/js/zamboni/admin_validation.js:51
 msgid "Set {0} add-on to a max version of {1} and email the author."
 msgid_plural "Set {0} add-ons to a max version of {1} and email the authors."
 msgstr[0] ""
 msgstr[1] ""
 
-#: static/js/zamboni/admin_validation.js:54
+#: static/js/zamboni/admin-all.js:210 static/js/zamboni/admin-min.js:1 static/js/zamboni/admin_validation.js:54
 msgid "Email author of {2} add-on which failed validation."
 msgid_plural "Email authors of {2} add-ons which failed validation."
 msgstr[0] ""
 msgstr[1] ""
 
-#. L10n: {0} is an app name like Firefox.
-#: static/js/zamboni/buttons.js:66
-msgid "Accept and Install"
-msgstr ""
-
-#: static/js/zamboni/buttons.js:66
-msgid "Add to {0}"
-msgstr ""
-
-#: static/js/zamboni/buttons.js:71
-msgid "Download Now"
-msgstr ""
-
-#: static/js/zamboni/buttons.js:112
-msgid "Add-on has not been updated to support default-to-compatible."
-msgstr ""
-
-#: static/js/zamboni/buttons.js:117
-msgid "You need to be using Firefox 10.0 or higher."
-msgstr ""
-
-#: static/js/zamboni/buttons.js:129
-msgid "Mozilla has marked this version as incompatible with your Firefox version."
-msgstr ""
-
-#. L10n: {0} is an platform like Windows or Linux.
-#: static/js/zamboni/buttons.js:210
-msgid "Install for {0} anyway"
-msgstr ""
-
-#: static/js/zamboni/buttons.js:210
-msgid "Download for {0} anyway"
-msgstr ""
-
-#: static/js/zamboni/buttons.js:267
-msgid "Not available for your platform"
-msgstr ""
-
-#. L10n: {0} is an app name, {1} is the app version.
-#: static/js/zamboni/buttons.js:278 static/js/zamboni/buttons.js:315
-msgid "Not available for {0} {1}"
-msgstr ""
-
-#: static/js/zamboni/buttons.js:341
-msgid "Works with {app} {min} - {max}"
-msgstr ""
-
-#: static/js/zamboni/buttons.js:343
-msgid "View other versions"
-msgstr ""
-
-#: static/js/zamboni/buttons.js:391
-msgid "Only with Firefox — Get Firefox Now!"
-msgstr ""
-
-#: static/js/zamboni/buttons.js:507 static/js/zamboni/mobile/buttons.js:43
-msgid "Sorry, you need a Mozilla-based browser (such as Firefox) to install a search plugin."
-msgstr ""
-
-#: static/js/zamboni/collections.js:229
-msgid "Adding to Favorites&hellip;"
-msgstr ""
-
-#: static/js/zamboni/collections.js:232
-msgid "Removing Favorite&hellip;"
-msgstr ""
-
-#: static/js/zamboni/collections.js:235
-msgid "Add to Favorites"
-msgstr ""
-
-#: static/js/zamboni/collections.js:238
-msgid "Remove from Favorites"
-msgstr ""
-
-#: static/js/zamboni/collections.js:303
-msgid "Pending"
-msgstr ""
-
-#: static/js/zamboni/collections.js:304
-msgid "Add a comment"
-msgstr ""
-
-#: static/js/zamboni/collections.js:304
-msgid "Comment"
-msgstr ""
-
-#: static/js/zamboni/collections.js:305
-msgid "Remove this add-on from the collection"
-msgstr ""
-
-#: static/js/zamboni/collections.js:305 static/js/zamboni/collections.js:334
-msgid "Remove"
-msgstr ""
-
-#: static/js/zamboni/collections.js:334
-msgid "Remove this user as a contributor"
-msgstr ""
-
-#: static/js/zamboni/collections.js:346
-msgid "An email address is required."
-msgstr ""
-
-#: static/js/zamboni/collections.js:364
-msgid "You cannot add yourself as a contributor."
-msgstr ""
-
-#: static/js/zamboni/collections.js:366
-msgid "You have already added that user."
-msgstr ""
-
-#: static/js/zamboni/collections.js:573
-msgid "Add to favorites"
-msgstr ""
-
-#: static/js/zamboni/collections.js:577
-msgid "Remove from favorites"
-msgstr ""
-
-#: static/js/zamboni/collections.js:604
-msgid "Stop following"
-msgstr ""
-
-#: static/js/zamboni/devhub.js:110
+#: static/js/zamboni/devhub-all.js:1289 static/js/zamboni/devhub-min.js:1 static/js/zamboni/devhub.js:110
 msgid "Your browser does not support the video tag"
 msgstr ""
 
-#: static/js/zamboni/devhub.js:371
+#: static/js/zamboni/devhub-all.js:1550 static/js/zamboni/devhub-min.js:1 static/js/zamboni/devhub.js:371
 msgid "Changes Saved"
 msgstr ""
 
-#: static/js/zamboni/devhub.js:387
+#: static/js/zamboni/devhub-all.js:1566 static/js/zamboni/devhub-min.js:1 static/js/zamboni/devhub.js:387
 msgid "Enter a new author's email address"
 msgstr ""
 
-#: static/js/zamboni/devhub.js:536
+#: static/js/zamboni/devhub-all.js:1715 static/js/zamboni/devhub-min.js:1 static/js/zamboni/devhub.js:536
 msgid "There was an error uploading your file."
 msgstr ""
 
-#: static/js/zamboni/devhub.js:681
+#: static/js/zamboni/devhub-all.js:1860 static/js/zamboni/devhub-min.js:1 static/js/zamboni/devhub.js:681
 msgid "{files} file"
 msgid_plural "{files} files"
 msgstr[0] ""
 msgstr[1] ""
 
-#: static/js/zamboni/devhub.js:684
+#: static/js/zamboni/devhub-all.js:1863 static/js/zamboni/devhub-min.js:1 static/js/zamboni/devhub.js:684
 msgid "{reviews} user review"
 msgid_plural "{reviews} user reviews"
 msgstr[0] ""
 msgstr[1] ""
 
-#: static/js/zamboni/devhub.js:796
+#: static/js/zamboni/devhub-all.js:1975 static/js/zamboni/devhub-min.js:2 static/js/zamboni/devhub.js:796
 msgid "Learn more"
 msgstr ""
 
-#: static/js/zamboni/devhub.js:800
+#: static/js/zamboni/devhub-all.js:1979 static/js/zamboni/devhub-min.js:2 static/js/zamboni/devhub.js:800
 msgid "Example"
 msgstr ""
 
-#: static/js/zamboni/devhub.js:1130
+#: static/js/zamboni/devhub-all.js:2309 static/js/zamboni/devhub-min.js:2 static/js/zamboni/devhub.js:1130
 msgid "Image changes being processed"
 msgstr ""
 
-#: static/js/zamboni/devhub.js:1280
+#: static/js/zamboni/devhub-all.js:2459 static/js/zamboni/devhub-min.js:2 static/js/zamboni/devhub.js:1280
 msgid "Must be a valid e-mail address."
+msgstr ""
+
+#: static/js/zamboni/devhub-all.js:2613 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:80
+msgid "All tests passed successfully."
+msgstr ""
+
+#: static/js/zamboni/devhub-all.js:2616 static/js/zamboni/devhub-all.js:3011 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:83 static/js/zamboni/validator.js:478
+msgid "These tests were not run."
+msgstr ""
+
+#: static/js/zamboni/devhub-all.js:2664 static/js/zamboni/devhub-all.js:2677 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:131 static/js/zamboni/validator.js:144
+msgid "Tests"
+msgstr ""
+
+#: static/js/zamboni/devhub-all.js:2779 static/js/zamboni/devhub-all.js:3108 static/js/zamboni/devhub-all.js:3127 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:246
+#: static/js/zamboni/validator.js:575 static/js/zamboni/validator.js:594
+msgid "Error"
+msgstr ""
+
+#: static/js/zamboni/devhub-all.js:2780 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:247
+msgid "Warning"
+msgstr ""
+
+#: static/js/zamboni/devhub-all.js:2794 static/js/zamboni/devhub-min.js:2 static/js/zamboni/files-all.js:5657 static/js/zamboni/files-min.js:3 static/js/zamboni/files.js:411
+#: static/js/zamboni/validator.js:261
+msgid "Ignore this message in future updates"
+msgstr ""
+
+#: static/js/zamboni/devhub-all.js:2817 static/js/zamboni/devhub-min.js:2 static/js/zamboni/files-all.js:5663 static/js/zamboni/files-min.js:3 static/js/zamboni/files.js:417
+#: static/js/zamboni/validator.js:284
+msgid "Severity for automated signing:"
+msgstr ""
+
+#: static/js/zamboni/devhub-all.js:2832 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:299
+msgid "Suggestions for passing automated signing:"
+msgstr ""
+
+#: static/js/zamboni/devhub-all.js:2920 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:387
+msgid "Compatibility Tests"
+msgstr ""
+
+#: static/js/zamboni/devhub-all.js:2999 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:466
+msgid "Add-on failed validation."
+msgstr ""
+
+#: static/js/zamboni/devhub-all.js:3001 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:468
+msgid "Add-on passed validation."
+msgstr ""
+
+#: static/js/zamboni/devhub-all.js:3014 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:481
+msgid "{0} error"
+msgid_plural "{0} errors"
+msgstr[0] ""
+msgstr[1] ""
+
+#: static/js/zamboni/devhub-all.js:3016 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:483
+msgid "{0} warning"
+msgid_plural "{0} warnings"
+msgstr[0] ""
+msgstr[1] ""
+
+#: static/js/zamboni/devhub-all.js:3018 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:485
+msgid "{0} notice"
+msgid_plural "{0} notices"
+msgstr[0] ""
+msgstr[1] ""
+
+#: static/js/zamboni/devhub-all.js:3110 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:577
+msgid "Validation task could not complete or completed with errors"
+msgstr ""
+
+#: static/js/zamboni/devhub-all.js:3128 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:595
+msgid "Internal server error"
 msgstr ""
 
 #: static/js/zamboni/devhub_search.js:8
 msgid "No results found."
 msgstr ""
 
-#: static/js/zamboni/editors.js:121
+#: static/js/zamboni/editors-all.js:15402 static/js/zamboni/editors-min.js:4 static/js/zamboni/editors.js:121
 msgid "{name} was viewing this page first."
 msgstr ""
 
-#: static/js/zamboni/editors.js:171
+#: static/js/zamboni/editors-all.js:15452 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:171
 msgid "Receipt checked by app."
 msgstr ""
 
-#: static/js/zamboni/editors.js:173
+#: static/js/zamboni/editors-all.js:15454 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:173
 msgid "Receipt was not checked by app."
 msgstr ""
 
-#: static/js/zamboni/editors.js:244
+#: static/js/zamboni/editors-all.js:15525 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:244
 msgid "{name} was viewing this add-on first."
 msgstr ""
 
-#: static/js/zamboni/editors.js:255
+#: static/js/zamboni/editors-all.js:15536 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:255
 msgid "Loading&hellip;"
 msgstr ""
 
-#: static/js/zamboni/editors.js:260
+#: static/js/zamboni/editors-all.js:15541 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:260
 msgid "Version Notes"
 msgstr ""
 
-#: static/js/zamboni/editors.js:265
+#: static/js/zamboni/editors-all.js:15546 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:265
 msgid "Notes for Reviewers"
 msgstr ""
 
-#: static/js/zamboni/editors.js:270
+#: static/js/zamboni/editors-all.js:15551 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:270
 msgid "No version notes found"
 msgstr ""
 
-#: static/js/zamboni/editors.js:330
+#: static/js/zamboni/editors-all.js:15611 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:330
 msgid "Average Reviews"
 msgstr ""
 
-#: static/js/zamboni/editors.js:386
+#: static/js/zamboni/editors-all.js:15667 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:386
 msgid "Number of Reviews"
 msgstr ""
 
-#: static/js/zamboni/editors.js:445
+#: static/js/zamboni/editors-all.js:15726 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:445
 msgid "Error loading translation"
 msgstr ""
 
-#: static/js/zamboni/files.js:411 static/js/zamboni/validator.js:261
-msgid "Ignore this message in future updates"
-msgstr ""
-
-#: static/js/zamboni/files.js:417 static/js/zamboni/validator.js:284
-msgid "Severity for automated signing:"
-msgstr ""
-
-#: static/js/zamboni/global.js:410
-msgid "Loading..."
-msgstr ""
-
-#. L10n: {0} is the number of characters left.
-#: static/js/zamboni/global.js:474
-msgid "<b>{0}</b> character left."
-msgid_plural "<b>{0}</b> characters left."
-msgstr[0] ""
-msgstr[1] ""
-
-#: static/js/zamboni/init.js:28
-msgid "This feature is temporarily disabled while we perform website maintenance. Please check back a little later."
-msgstr ""
-
-#: static/js/zamboni/l10n.js:45
-msgid "Remove this localization"
-msgstr ""
-
-#: static/js/zamboni/password-strength.js:20
-msgid "Password strength:"
-msgstr ""
-
-#: static/js/zamboni/password-strength.js:26
-msgid "At least {0} character left."
-msgid_plural "At least {0} characters left."
-msgstr[0] ""
-msgstr[1] ""
-
-#: static/js/zamboni/themes_review.js:176
-msgid "Requested Info"
-msgstr ""
-
-#: static/js/zamboni/themes_review.js:177
-msgid "Flagged"
-msgstr ""
-
-#: static/js/zamboni/themes_review.js:178
-msgid "Duplicate"
-msgstr ""
-
-#: static/js/zamboni/themes_review.js:179
-msgid "Rejected"
-msgstr ""
-
-#: static/js/zamboni/themes_review.js:180
-msgid "Approved"
-msgstr ""
-
-#: static/js/zamboni/themes_review.js:424
-msgid "No results found"
-msgstr ""
-
-#: static/js/zamboni/themes_review_templates.js:31
+#: static/js/zamboni/editors-all.js:15975 static/js/zamboni/editors-min.js:5 static/js/zamboni/themes_review_templates.js:31
 msgid "Theme"
 msgstr ""
 
-#: static/js/zamboni/themes_review_templates.js:33
+#: static/js/zamboni/editors-all.js:15977 static/js/zamboni/editors-min.js:5 static/js/zamboni/themes_review_templates.js:33
 msgid "Reviewer"
 msgstr ""
 
-#: static/js/zamboni/themes_review_templates.js:35
+#: static/js/zamboni/editors-all.js:15979 static/js/zamboni/editors-min.js:5 static/js/zamboni/themes_review_templates.js:35
 msgid "Status"
 msgstr ""
 
-#: static/js/zamboni/validator.js:80
-msgid "All tests passed successfully."
+#: static/js/zamboni/editors-all.js:16196 static/js/zamboni/editors-min.js:5 static/js/zamboni/themes_review.js:176
+msgid "Requested Info"
 msgstr ""
 
-#: static/js/zamboni/validator.js:83 static/js/zamboni/validator.js:478
-msgid "These tests were not run."
+#: static/js/zamboni/editors-all.js:16197 static/js/zamboni/editors-min.js:5 static/js/zamboni/themes_review.js:177
+msgid "Flagged"
 msgstr ""
 
-#: static/js/zamboni/validator.js:131 static/js/zamboni/validator.js:144
-msgid "Tests"
+#: static/js/zamboni/editors-all.js:16198 static/js/zamboni/editors-min.js:5 static/js/zamboni/themes_review.js:178
+msgid "Duplicate"
 msgstr ""
 
-#: static/js/zamboni/validator.js:246 static/js/zamboni/validator.js:575 static/js/zamboni/validator.js:594
-msgid "Error"
+#: static/js/zamboni/editors-all.js:16199 static/js/zamboni/editors-min.js:5 static/js/zamboni/themes_review.js:179
+msgid "Rejected"
 msgstr ""
 
-#: static/js/zamboni/validator.js:247
-msgid "Warning"
+#: static/js/zamboni/editors-all.js:16200 static/js/zamboni/editors-min.js:5 static/js/zamboni/themes_review.js:180
+msgid "Approved"
 msgstr ""
 
-#: static/js/zamboni/validator.js:299
-msgid "Suggestions for passing automated signing:"
+#: static/js/zamboni/editors-all.js:16444 static/js/zamboni/editors-min.js:5 static/js/zamboni/themes_review.js:424
+msgid "No results found"
 msgstr ""
 
-#: static/js/zamboni/validator.js:387
-msgid "Compatibility Tests"
-msgstr ""
-
-#: static/js/zamboni/validator.js:466
-msgid "Add-on failed validation."
-msgstr ""
-
-#: static/js/zamboni/validator.js:468
-msgid "Add-on passed validation."
-msgstr ""
-
-#: static/js/zamboni/validator.js:481
-msgid "{0} error"
-msgid_plural "{0} errors"
-msgstr[0] ""
-msgstr[1] ""
-
-#: static/js/zamboni/validator.js:483
-msgid "{0} warning"
-msgid_plural "{0} warnings"
-msgstr[0] ""
-msgstr[1] ""
-
-#: static/js/zamboni/validator.js:485
-msgid "{0} notice"
-msgid_plural "{0} notices"
-msgstr[0] ""
-msgstr[1] ""
-
-#: static/js/zamboni/validator.js:577
-msgid "Validation task could not complete or completed with errors"
-msgstr ""
-
-#: static/js/zamboni/validator.js:595
-msgid "Internal server error"
-msgstr ""
-
-#: static/js/zamboni/mobile/buttons.js:52
+#: static/js/zamboni/mobile-all.js:15186 static/js/zamboni/mobile/buttons.js:52
 msgid "Not Updated for {0} {1}"
 msgstr ""
 
-#: static/js/zamboni/mobile/buttons.js:53
+#: static/js/zamboni/mobile-all.js:15187 static/js/zamboni/mobile/buttons.js:53
 msgid "Requires Newer Version of {0}"
 msgstr ""
 
-#: static/js/zamboni/mobile/buttons.js:54
+#: static/js/zamboni/mobile-all.js:15188 static/js/zamboni/mobile/buttons.js:54
 msgid "Unreviewed"
 msgstr ""
 
-#: static/js/zamboni/mobile/buttons.js:55
+#: static/js/zamboni/mobile-all.js:15189 static/js/zamboni/mobile/buttons.js:55
 msgid "Experimental <span>(Learn More)</span>"
 msgstr ""
 
-#: static/js/zamboni/mobile/buttons.js:56 static/js/zamboni/mobile/buttons.js:57
+#: static/js/zamboni/mobile-all.js:15190 static/js/zamboni/mobile-all.js:15191 static/js/zamboni/mobile/buttons.js:56 static/js/zamboni/mobile/buttons.js:57
 msgid "Not Available for {0}"
 msgstr ""
 
-#: static/js/zamboni/mobile/buttons.js:58
+#: static/js/zamboni/mobile-all.js:15192 static/js/zamboni/mobile/buttons.js:58
 msgid "Experimental"
 msgstr ""
 
-#: static/js/zamboni/mobile/buttons.js:59
+#: static/js/zamboni/mobile-all.js:15193 static/js/zamboni/mobile/buttons.js:59
 msgid "Themes Require Newer Version of {0}"
 msgstr ""
 
-#: static/js/zamboni/mobile/buttons.js:60
+#: static/js/zamboni/mobile-all.js:15194 static/js/zamboni/mobile/buttons.js:60
 msgid "Themes Require {0}"
 msgstr ""
 
-#: static/js/zamboni/mobile/buttons.js:105
+#: static/js/zamboni/mobile-all.js:15239 static/js/zamboni/mobile/buttons.js:105
 msgid "Installing..."
 msgstr ""
 
-#: static/js/zamboni/mobile/buttons.js:125
+#: static/js/zamboni/mobile-all.js:15259 static/js/zamboni/mobile/buttons.js:125
 msgid "This add-on has been preliminarily reviewed by Mozilla."
 msgstr ""
 
-#: static/js/zamboni/mobile/buttons.js:250
+#: static/js/zamboni/mobile-all.js:15384 static/js/zamboni/mobile/buttons.js:250
 msgid "Keep it"
 msgstr ""
 
-#: static/js/zamboni/mobile/general.js:344
+#: static/js/zamboni/mobile-all.js:16049 static/js/zamboni/mobile-min.js:6 static/js/zamboni/mobile/general.js:344
 msgid "You're trying it on!"
 msgstr ""
 
-#: static/js/zamboni/mobile/general.js:356
+#: static/js/zamboni/mobile-all.js:16061 static/js/zamboni/mobile-min.js:6 static/js/zamboni/mobile/general.js:356
 msgid "Added to Firefox"
 msgstr ""
-

--- a/locale/templates/LC_MESSAGES/django.pot
+++ b/locale/templates/LC_MESSAGES/django.pot
@@ -4,7 +4,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT 1.0\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2016-04-11 14:21+0000\n"
+"POT-Creation-Date: 2016-04-18 15:47+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -45,21 +45,21 @@ msgstr ""
 msgid "Need help?"
 msgstr ""
 
-#: src/olympia/addons/buttons.py:180
+#: src/olympia/addons/buttons.py:177
 msgid "Download Now"
 msgstr ""
 
-#: src/olympia/addons/buttons.py:182
+#: src/olympia/addons/buttons.py:179
 msgid "Download"
 msgstr ""
 
 #. L10n: please keep &nbsp; in the string so &rarr; does not wrap.
-#: src/olympia/addons/buttons.py:186
+#: src/olympia/addons/buttons.py:183
 msgid "Continue to Download&nbsp;&rarr;"
 msgstr ""
 
-#: src/olympia/addons/buttons.py:202 src/olympia/addons/helpers.py:35
-#: src/olympia/addons/views.py:332
+#: src/olympia/addons/buttons.py:199 src/olympia/addons/helpers.py:35
+#: src/olympia/addons/views.py:333
 #: src/olympia/addons/templates/addons/impala/details.html:111
 #: src/olympia/addons/templates/addons/impala/listing/items.html:17
 #: src/olympia/addons/templates/addons/mobile/home.html:40
@@ -68,13 +68,13 @@ msgstr ""
 #: src/olympia/amo/templates/amo/site_nav.html:2
 #: src/olympia/amo/templates/amo/site_nav.html:53 src/olympia/bandwagon/views.py:95
 #: src/olympia/browse/views.py:54 src/olympia/browse/views.py:68
-#: src/olympia/browse/views.py:235
+#: src/olympia/browse/views.py:202
 #: src/olympia/browse/templates/browse/impala/category_landing.html:22
 #: src/olympia/browse/templates/browse/personas/mobile/category_landing.html:26
 msgid "Featured"
 msgstr ""
 
-#: src/olympia/addons/buttons.py:221
+#: src/olympia/addons/buttons.py:218
 msgid "Add to {0}"
 msgstr ""
 
@@ -177,35 +177,35 @@ msgid ""
 " applies to desktop."
 msgstr ""
 
-#: src/olympia/addons/models.py:1800
+#: src/olympia/addons/models.py:1802
 #: src/olympia/addons/templates/addons/details_box.html:55
 #: src/olympia/devhub/templates/devhub/index.html:92
 #: src/olympia/devhub/templates/devhub/includes/addon_details.html:89
 msgid "Listed"
 msgstr ""
 
-#: src/olympia/addons/views.py:333
+#: src/olympia/addons/views.py:334
 #: src/olympia/browse/templates/browse/personas/mobile/category_landing.html:27
 msgid "Popular"
 msgstr ""
 
-#: src/olympia/addons/views.py:334 src/olympia/browse/views.py:238
-#: src/olympia/browse/views.py:280 src/olympia/browse/views.py:482
+#: src/olympia/addons/views.py:335 src/olympia/browse/views.py:205
+#: src/olympia/browse/views.py:247 src/olympia/browse/views.py:449
 msgid "Recently Added"
 msgstr ""
 
-#: src/olympia/addons/views.py:335 src/olympia/bandwagon/views.py:99
+#: src/olympia/addons/views.py:336 src/olympia/bandwagon/views.py:99
 #: src/olympia/browse/views.py:60 src/olympia/browse/views.py:71
 #: src/olympia/search/forms.py:16 src/olympia/search/forms.py:91
 msgid "Recently Updated"
 msgstr ""
 
 #. l10n: {0} is the addon name
-#: src/olympia/addons/views.py:533
+#: src/olympia/addons/views.py:534
 msgid "Contribution for {0}"
 msgstr ""
 
-#: src/olympia/addons/views.py:626
+#: src/olympia/addons/views.py:627
 msgid "Abuse reported."
 msgstr ""
 
@@ -303,7 +303,7 @@ msgstr ""
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:166
 #: src/olympia/devhub/templates/devhub/addons/forms_shared/media.html:149
 #: src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:43
-#: src/olympia/devhub/templates/devhub/versions/add_file_modal.html:57
+#: src/olympia/devhub/templates/devhub/versions/add_file_modal.html:58
 #: src/olympia/devhub/templates/devhub/versions/edit.html:139
 #: src/olympia/devhub/templates/devhub/versions/list.html:239
 #: src/olympia/devhub/templates/devhub/versions/list.html:281
@@ -443,7 +443,7 @@ msgstr ""
 #: src/olympia/addons/templates/addons/persona_detail_table.html:3
 #: src/olympia/addons/templates/addons/mobile/details.html:63
 #: src/olympia/addons/templates/addons/mobile/persona_detail_table.html:7
-#: src/olympia/browse/views.py:459 src/olympia/devhub/views.py:75
+#: src/olympia/browse/views.py:426 src/olympia/devhub/views.py:73
 msgid "Updated"
 msgstr ""
 
@@ -485,8 +485,8 @@ msgstr ""
 
 #: src/olympia/addons/templates/addons/details_box.html:81
 #: src/olympia/addons/templates/addons/persona_detail_table.html:15
-#: src/olympia/browse/views.py:462 src/olympia/devhub/views.py:78
-#: src/olympia/devhub/views.py:85
+#: src/olympia/browse/views.py:429 src/olympia/devhub/views.py:76
+#: src/olympia/devhub/views.py:83
 #: src/olympia/discovery/templates/discovery/addons/detail.html:57
 #: src/olympia/reviews/forms.py:62
 #: src/olympia/reviews/templates/reviews/add.html:57
@@ -495,8 +495,8 @@ msgid "Rating"
 msgstr ""
 
 #: src/olympia/addons/templates/addons/details_box.html:85
-#: src/olympia/browse/views.py:461 src/olympia/devhub/views.py:77
-#: src/olympia/devhub/views.py:84
+#: src/olympia/browse/views.py:428 src/olympia/devhub/views.py:75
+#: src/olympia/devhub/views.py:82
 #: src/olympia/stats/templates/stats/addon_report_menu.html:8
 #: src/olympia/stats/templates/stats/collection_report_menu.html:18
 msgid "Downloads"
@@ -640,8 +640,8 @@ msgstr ""
 #: src/olympia/amo/templates/amo/side_nav.html:3
 #: src/olympia/amo/templates/amo/side_nav.html:11
 #: src/olympia/amo/templates/amo/site_nav.html:3
-#: src/olympia/amo/templates/amo/site_nav.html:25 src/olympia/browse/views.py:236
-#: src/olympia/browse/views.py:281 src/olympia/browse/views.py:481
+#: src/olympia/amo/templates/amo/site_nav.html:25 src/olympia/browse/views.py:203
+#: src/olympia/browse/views.py:248 src/olympia/browse/views.py:448
 msgid "Most Popular"
 msgstr ""
 
@@ -839,6 +839,7 @@ msgstr ""
 
 #: src/olympia/addons/templates/addons/persona_preview.html:47
 #: src/olympia/addons/templates/addons/persona_preview.html:49
+#: src/olympia/addons/templates/addons/persona_preview.html:97
 #: src/olympia/reviews/templates/reviews/add.html:15
 msgid "Add"
 msgstr ""
@@ -893,7 +894,7 @@ msgid "Learn more about Firefox"
 msgstr ""
 
 #: src/olympia/addons/templates/addons/popups.html:22
-msgid "or <b><a class=\"installer\" href=\"{url}\">download anyway</a></b>"
+msgid "or <b><a class=\"button installer\" href=\"{url}\">download anyway</a></b>"
 msgstr ""
 
 #: src/olympia/addons/templates/addons/popups.html:26
@@ -1046,7 +1047,7 @@ msgstr ""
 #: src/olympia/devhub/templates/devhub/addons/forms_shared/media.html:152
 #: src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:43
 #: src/olympia/devhub/templates/devhub/personas/edit.html:222
-#: src/olympia/devhub/templates/devhub/versions/add_file_modal.html:58
+#: src/olympia/devhub/templates/devhub/versions/add_file_modal.html:59
 #: src/olympia/devhub/templates/devhub/versions/edit.html:140
 #: src/olympia/devhub/templates/devhub/versions/list.html:208
 #: src/olympia/devhub/templates/devhub/versions/list.html:239
@@ -1121,7 +1122,7 @@ msgstr ""
 
 #: src/olympia/addons/templates/addons/review_list_box.html:5
 #: src/olympia/addons/templates/addons/impala/details-more.html:27
-#: src/olympia/editors/helpers.py:997
+#: src/olympia/editors/helpers.py:1001
 #: src/olympia/reviews/templates/reviews/add.html:14
 #: src/olympia/reviews/templates/reviews/reply.html:14
 #: src/olympia/reviews/templates/reviews/review_list.html:19
@@ -1360,7 +1361,7 @@ msgstr ""
 #: src/olympia/addons/templates/addons/impala/review_add_box.html:4
 #: src/olympia/stats/templates/stats/popup.html:2
 #: src/olympia/stats/templates/stats/popup.html:8
-#: src/olympia/stats/templates/stats/stats.html:202
+#: src/olympia/stats/templates/stats/stats.html:204
 #: src/olympia/users/templates/users/profile.html:119
 msgid "close"
 msgstr ""
@@ -1428,7 +1429,7 @@ msgid "permalink"
 msgstr ""
 
 #: src/olympia/addons/templates/addons/impala/review_list_box.html:23
-#: src/olympia/editors/templates/editors/queue.html:98
+#: src/olympia/editors/templates/editors/queue.html:104
 #: src/olympia/reviews/templates/reviews/review.html:44
 msgid "translate"
 msgstr ""
@@ -1470,7 +1471,7 @@ msgid "My Add-ons"
 msgstr ""
 
 #: src/olympia/addons/templates/addons/includes/dashboard_tabs.html:6
-#: src/olympia/amo/context_processors.py:52
+#: src/olympia/amo/context_processors.py:50
 msgid "My Themes"
 msgstr ""
 
@@ -1532,7 +1533,7 @@ msgstr ""
 
 #: src/olympia/addons/templates/addons/mobile/details.html:99
 #: src/olympia/compat/templates/compat/reporter_detail.html:46
-#: src/olympia/devhub/forms.py:779
+#: src/olympia/devhub/forms.py:788
 #: src/olympia/devhub/templates/devhub/versions/list.html:163
 msgid "Version"
 msgstr ""
@@ -1690,80 +1691,80 @@ msgstr ""
 msgid "Theme Info &raquo;"
 msgstr ""
 
-#: src/olympia/amo/context_processors.py:39
+#: src/olympia/amo/context_processors.py:37
 #: src/olympia/devhub/templates/devhub/nav.html:43
 msgid "Tools"
 msgstr ""
 
-#: src/olympia/amo/context_processors.py:49
+#: src/olympia/amo/context_processors.py:47
 #: src/olympia/discovery/templates/discovery/pane_account.html:8
 #: src/olympia/users/templates/users/includes/navigation.html:2
 msgid "My Profile"
 msgstr ""
 
-#: src/olympia/amo/context_processors.py:55
+#: src/olympia/amo/context_processors.py:53
 #: src/olympia/users/templates/users/edit.html:5
 #: src/olympia/users/templates/users/includes/navigation.html:3
 msgid "Account Settings"
 msgstr ""
 
-#: src/olympia/amo/context_processors.py:58
+#: src/olympia/amo/context_processors.py:56
 #: src/olympia/discovery/templates/discovery/pane_account.html:11
 #: src/olympia/users/templates/users/profile.html:83
 #: src/olympia/users/templates/users/includes/navigation.html:4
 msgid "My Collections"
 msgstr ""
 
-#: src/olympia/amo/context_processors.py:63
+#: src/olympia/amo/context_processors.py:61
 #: src/olympia/discovery/templates/discovery/pane_account.html:10
 #: src/olympia/users/templates/users/includes/navigation.html:7
 msgid "My Favorites"
 msgstr ""
 
-#: src/olympia/amo/context_processors.py:68
+#: src/olympia/amo/context_processors.py:66
 #: src/olympia/discovery/templates/discovery/pane_account.html:13
 #: src/olympia/templates/impala/user_login.html:14
 #: src/olympia/templates/mobile/header_auth.html:5
 msgid "Log out"
 msgstr ""
 
-#: src/olympia/amo/context_processors.py:73
+#: src/olympia/amo/context_processors.py:71
 #: src/olympia/devhub/templates/devhub/addons/dashboard.html:4
 msgid "Manage My Submissions"
 msgstr ""
 
-#: src/olympia/amo/context_processors.py:76
+#: src/olympia/amo/context_processors.py:74
 #: src/olympia/devhub/templates/devhub/nav.html:27
 #: src/olympia/devhub/templates/devhub/addons/dashboard.html:25
 #: src/olympia/devhub/templates/devhub/addons/submit/base.html:4
 msgid "Submit a New Add-on"
 msgstr ""
 
-#: src/olympia/amo/context_processors.py:78
+#: src/olympia/amo/context_processors.py:76
 #: src/olympia/browse/templates/browse/personas/base.html:50
 #: src/olympia/devhub/templates/devhub/index.html:24
 #: src/olympia/devhub/templates/devhub/addons/dashboard.html:29
 msgid "Submit a New Theme"
 msgstr ""
 
-#: src/olympia/amo/context_processors.py:80
+#: src/olympia/amo/context_processors.py:78
 #: src/olympia/amo/templates/amo/site_nav.html:85 src/olympia/devhub/helpers.py:36
 #: src/olympia/devhub/helpers.py:68 src/olympia/devhub/helpers.py:102
 #: src/olympia/templates/footer.html:6 src/olympia/templates/menu_links.html:14
 msgid "Developer Hub"
 msgstr ""
 
-#: src/olympia/amo/context_processors.py:84 src/olympia/devhub/views.py:1795
+#: src/olympia/amo/context_processors.py:81 src/olympia/devhub/views.py:1796
 msgid "Manage API Keys"
 msgstr ""
 
-#: src/olympia/amo/context_processors.py:89 src/olympia/editors/helpers.py:84
+#: src/olympia/amo/context_processors.py:86 src/olympia/editors/helpers.py:84
 #: src/olympia/editors/helpers.py:104
 #: src/olympia/editors/templates/editors/base.html:10
 msgid "Editor Tools"
 msgstr ""
 
-#: src/olympia/amo/context_processors.py:93
+#: src/olympia/amo/context_processors.py:90
 msgid "Admin Tools"
 msgstr ""
 
@@ -1796,7 +1797,7 @@ msgstr ""
 #: src/olympia/bandwagon/templates/bandwagon/impala/collection_sidebar.html:3
 #: src/olympia/bandwagon/templates/bandwagon/includes/collection_sidebar.html:2
 #: src/olympia/bandwagon/templates/bandwagon/mobile/collection_listing.html:3
-#: src/olympia/stats/templates/stats/stats.html:77
+#: src/olympia/stats/templates/stats/stats.html:33
 #: src/olympia/templates/menu_links.html:12
 msgid "Collections"
 msgstr ""
@@ -1955,9 +1956,9 @@ msgid "Comment on {addon} {version}."
 msgstr ""
 
 #: src/olympia/amo/log.py:236
-#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:19
-#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:47
-#: src/olympia/editors/helpers.py:580
+#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:17
+#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:45
+#: src/olympia/editors/helpers.py:584
 #: src/olympia/editors/templates/editors/themes/history_table.html:11
 msgid "Comment"
 msgstr ""
@@ -2309,7 +2310,7 @@ msgstr ""
 #: src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:104
 #: src/olympia/discovery/templates/discovery/pane.html:45
 #: src/olympia/discovery/templates/discovery/addons/detail.html:39
-#: src/olympia/stats/templates/stats/stats.html:167
+#: src/olympia/stats/templates/stats/stats.html:169
 msgid "Next"
 msgstr ""
 
@@ -2355,8 +2356,8 @@ msgstr ""
 #: src/olympia/amo/templates/amo/side_nav.html:12
 #: src/olympia/amo/templates/amo/site_nav.html:4
 #: src/olympia/amo/templates/amo/site_nav.html:26 src/olympia/browse/views.py:56
-#: src/olympia/browse/views.py:66 src/olympia/browse/views.py:237
-#: src/olympia/browse/views.py:282 src/olympia/search/forms.py:86
+#: src/olympia/browse/views.py:66 src/olympia/browse/views.py:204
+#: src/olympia/browse/views.py:249 src/olympia/search/forms.py:86
 msgid "Top Rated"
 msgstr ""
 
@@ -2434,7 +2435,7 @@ msgstr ""
 #: src/olympia/amo/templates/amo/mobile/impala_paginator.html:12
 #: src/olympia/discovery/templates/discovery/pane.html:44
 #: src/olympia/discovery/templates/discovery/addons/detail.html:38
-#: src/olympia/stats/templates/stats/stats.html:164
+#: src/olympia/stats/templates/stats/stats.html:166
 msgid "Previous"
 msgstr ""
 
@@ -2610,11 +2611,11 @@ msgstr ""
 msgid "This url is already in use by another collection"
 msgstr ""
 
-#: src/olympia/bandwagon/forms.py:197 src/olympia/devhub/views.py:1053
+#: src/olympia/bandwagon/forms.py:197 src/olympia/devhub/views.py:1049
 msgid "Icons must be either PNG or JPG."
 msgstr ""
 
-#: src/olympia/bandwagon/forms.py:202 src/olympia/devhub/views.py:1071
+#: src/olympia/bandwagon/forms.py:202 src/olympia/devhub/views.py:1067
 #: src/olympia/users/forms.py:476
 #, python-format
 msgid "Please use images smaller than %dMB."
@@ -2652,8 +2653,8 @@ msgstr ""
 
 #: src/olympia/bandwagon/views.py:98 src/olympia/bandwagon/views.py:191
 #: src/olympia/browse/views.py:58 src/olympia/browse/views.py:69
-#: src/olympia/browse/views.py:458 src/olympia/devhub/views.py:74
-#: src/olympia/devhub/views.py:82
+#: src/olympia/browse/views.py:425 src/olympia/devhub/views.py:72
+#: src/olympia/devhub/views.py:80
 #: src/olympia/devhub/templates/devhub/addons/edit/basic.html:20
 #: src/olympia/editors/templates/editors/leaderboard.html:24
 #: src/olympia/editors/templates/editors/themes/queue_list.html:48
@@ -2667,7 +2668,7 @@ msgid "Recently Popular"
 msgstr ""
 
 #: src/olympia/bandwagon/views.py:189
-#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:18
+#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:16
 msgid "Added"
 msgstr ""
 
@@ -3034,8 +3035,8 @@ msgstr ""
 
 #: src/olympia/bandwagon/templates/bandwagon/edit_contributors.html:18
 #: src/olympia/bandwagon/templates/bandwagon/edit_contributors.html:43
-#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:20
-#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:48
+#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:18
+#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:46
 #: src/olympia/devhub/templates/devhub/addons/ajax_compat_update.html:19
 msgid "Remove"
 msgstr ""
@@ -3092,7 +3093,7 @@ msgstr ""
 #: src/olympia/devhub/templates/devhub/addons/forms_shared/media.html:157
 #: src/olympia/devhub/templates/devhub/addons/submit/describe.html:69
 #: src/olympia/devhub/templates/devhub/addons/submit/license.html:60
-#: src/olympia/devhub/templates/devhub/addons/submit/upload.html:64
+#: src/olympia/devhub/templates/devhub/addons/submit/upload.html:70
 #: src/olympia/devhub/templates/devhub/payments/tier.html:17
 #: src/olympia/editors/templates/editors/themes/themes.html:111
 #: src/olympia/editors/templates/editors/themes/themes.html:128
@@ -3191,35 +3192,34 @@ msgstr ""
 #: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:4
 msgid ""
 "To include an add-on in this collection, enter its name in the box below and "
-"hit enter.  You can also use the <strong>Add to Collection</strong> links "
-"throughout the site to include add-ons later."
+"hit enter."
 msgstr ""
 
-#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:17
+#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:15
 #: src/olympia/constants/base.py:400
 #: src/olympia/devhub/templates/devhub/addons/activity.html:62
 #: src/olympia/editors/helpers.py:273 src/olympia/editors/helpers.py:360
 msgid "Add-on"
 msgstr ""
 
-#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:26
+#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:24
 msgid "Enter the name of the add-on to include"
 msgstr ""
 
-#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:28
+#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:26
 msgid "Add to Collection"
 msgstr ""
 
-#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:45
-#: src/olympia/editors/helpers.py:1012 src/olympia/editors/helpers.py:1032
+#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:43
+#: src/olympia/editors/helpers.py:1016 src/olympia/editors/helpers.py:1036
 msgid "Pending"
 msgstr ""
 
-#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:47
+#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:45
 msgid "Add a comment"
 msgstr ""
 
-#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:48
+#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:46
 msgid "Remove this add-on from the collection"
 msgstr ""
 
@@ -3340,15 +3340,15 @@ msgid "Most Users"
 msgstr ""
 
 #: src/olympia/browse/views.py:61 src/olympia/browse/views.py:72
-#: src/olympia/browse/views.py:279
+#: src/olympia/browse/views.py:246
 #: src/olympia/browse/templates/browse/personas/mobile/category_landing.html:63
 #: src/olympia/discovery/templates/discovery/pane.html:67
 #: src/olympia/search/forms.py:92
 msgid "Up & Coming"
 msgstr ""
 
-#: src/olympia/browse/views.py:460 src/olympia/devhub/views.py:76
-#: src/olympia/devhub/views.py:83
+#: src/olympia/browse/views.py:427 src/olympia/devhub/views.py:74
+#: src/olympia/devhub/views.py:81
 #: src/olympia/discovery/templates/discovery/addons/detail.html:66
 msgid "Created"
 msgstr ""
@@ -3736,9 +3736,10 @@ msgid "Report Type"
 msgstr ""
 
 #: src/olympia/compat/templates/compat/reporter_detail.html:47
-#: src/olympia/devhub/forms.py:776
+#: src/olympia/devhub/forms.py:785
 #: src/olympia/devhub/templates/devhub/addons/ajax_compat_update.html:17
-#: src/olympia/editors/forms.py:108 src/olympia/zadmin/forms.py:45
+#: src/olympia/editors/forms.py:108 src/olympia/editors/forms.py:248
+#: src/olympia/zadmin/forms.py:45
 msgid "Application"
 msgstr ""
 
@@ -3828,8 +3829,8 @@ msgstr ""
 msgid "Preliminarily Reviewed and Awaiting Full Review"
 msgstr ""
 
-#: src/olympia/constants/base.py:33 src/olympia/editors/helpers.py:73
-#: src/olympia/editors/helpers.py:1000
+#: src/olympia/constants/base.py:33 src/olympia/editors/forms.py:258
+#: src/olympia/editors/helpers.py:73 src/olympia/editors/helpers.py:1004
 #: src/olympia/editors/templates/editors/themes/history_table.html:34
 msgid "Deleted"
 msgstr ""
@@ -4107,7 +4108,7 @@ msgstr ""
 msgid "Duplicate"
 msgstr ""
 
-#: src/olympia/constants/editors.py:17 src/olympia/editors/helpers.py:571
+#: src/olympia/constants/editors.py:17 src/olympia/editors/helpers.py:575
 #: src/olympia/editors/templates/editors/themes/queue.html:71
 #: src/olympia/editors/templates/editors/themes/themes.html:94
 msgid "Reject"
@@ -4355,75 +4356,86 @@ msgid ""
 "only need it to be signed by Mozilla."
 msgstr ""
 
-#: src/olympia/devhub/forms.py:556
+#: src/olympia/devhub/forms.py:544
+msgid "This add-on will be bundled with an application installer."
+msgstr ""
+
+#: src/olympia/devhub/forms.py:546
+msgid ""
+"Add-ons that are bundled with application installers will be code reviewed by"
+" Mozilla before they are signed and are held to a higher quality standard."
+msgstr ""
+
+#: src/olympia/devhub/forms.py:565
 #: src/olympia/devhub/templates/devhub/addons/submit/select-review.html:24
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:42
 msgid "Full Review"
 msgstr ""
 
-#: src/olympia/devhub/forms.py:557
+#: src/olympia/devhub/forms.py:566
 #: src/olympia/devhub/templates/devhub/addons/submit/select-review.html:47
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:153
 msgid "Preliminary Review"
 msgstr ""
 
-#: src/olympia/devhub/forms.py:561
+#: src/olympia/devhub/forms.py:570
 msgid "Please choose a review nomination type"
 msgstr ""
 
-#: src/olympia/devhub/forms.py:565
+#: src/olympia/devhub/forms.py:574
 msgid ""
 "A file with a version ending with a|alpha|b|beta|pre|rc and an optional "
 "number is detected as beta."
 msgstr ""
 
-#: src/olympia/devhub/forms.py:583
+#: src/olympia/devhub/forms.py:592
 #, python-format
 msgid "Version %s already exists, or was uploaded before."
 msgstr ""
 
-#: src/olympia/devhub/forms.py:596
+#: src/olympia/devhub/forms.py:605
 msgid "Select a valid choice. That choice is not one of the available choices."
 msgstr ""
 
-#: src/olympia/devhub/forms.py:602
+#: src/olympia/devhub/forms.py:611
 msgid ""
 "A file with a version ending with a|alpha|b|beta and an optional number is "
 "detected as beta."
 msgstr ""
 
-#: src/olympia/devhub/forms.py:625
+#: src/olympia/devhub/forms.py:634
 msgid "You cannot upload any more files for this version."
 msgstr ""
 
-#: src/olympia/devhub/forms.py:631
+#: src/olympia/devhub/forms.py:640
 msgid "Version doesn't match"
 msgstr ""
 
-#: src/olympia/devhub/forms.py:660
+#: src/olympia/devhub/forms.py:669
 msgid ""
 "You cannot delete a file once the review process has started.  You must "
 "delete the whole version."
 msgstr ""
 
-#: src/olympia/devhub/forms.py:680
+#: src/olympia/devhub/forms.py:689
 msgid "The platform All cannot be combined with specific platforms."
 msgstr ""
 
-#: src/olympia/devhub/forms.py:685
+#: src/olympia/devhub/forms.py:694
 msgid "A platform can only be chosen once."
 msgstr ""
 
-#: src/olympia/devhub/forms.py:698
+#: src/olympia/devhub/forms.py:707
 msgid "A review type must be selected."
 msgstr ""
 
-#: src/olympia/devhub/forms.py:780 src/olympia/editors/forms.py:114
-#: src/olympia/zadmin/forms.py:49 src/olympia/zadmin/forms.py:52
+#: src/olympia/devhub/forms.py:789 src/olympia/editors/forms.py:114
+#: src/olympia/editors/forms.py:254 src/olympia/zadmin/forms.py:49
+#: src/olympia/zadmin/forms.py:52
 msgid "Select an application first"
 msgstr ""
 
-#: src/olympia/devhub/forms.py:832
+#: src/olympia/devhub/forms.py:841
 msgid "There cannot be more than 3 required add-ons."
 msgstr ""
 
@@ -4458,17 +4470,17 @@ msgstr[1] ""
 msgid "Review"
 msgstr ""
 
-#: src/olympia/devhub/tasks.py:590
+#: src/olympia/devhub/tasks.py:583
 #, python-format
 msgid "%s responded with %s (%s)."
 msgstr ""
 
-#: src/olympia/devhub/tasks.py:594
+#: src/olympia/devhub/tasks.py:587
 #, python-format
 msgid "Connection to \"%s\" timed out."
 msgstr ""
 
-#: src/olympia/devhub/tasks.py:596
+#: src/olympia/devhub/tasks.py:589
 #, python-format
 msgid "Could not contact host at \"%s\"."
 msgstr ""
@@ -4480,148 +4492,148 @@ msgid ""
 "After addressing the visible messages, you'll be able to see the others."
 msgstr ""
 
-#: src/olympia/devhub/views.py:183
+#: src/olympia/devhub/views.py:181
 msgid "All My Add-ons"
 msgstr ""
 
-#: src/olympia/devhub/views.py:210
+#: src/olympia/devhub/views.py:208
 msgid "All Activity"
 msgstr ""
 
-#: src/olympia/devhub/views.py:211
+#: src/olympia/devhub/views.py:209
 msgid "Add-on Updates"
 msgstr ""
 
-#: src/olympia/devhub/views.py:212
+#: src/olympia/devhub/views.py:210
 msgid "Add-on Status"
 msgstr ""
 
-#: src/olympia/devhub/views.py:213
+#: src/olympia/devhub/views.py:211
 msgid "User Collections"
 msgstr ""
 
-#: src/olympia/devhub/views.py:214
+#: src/olympia/devhub/views.py:212
 #: src/olympia/devhub/templates/devhub/docs/policies-maintenance.html:68
 #: src/olympia/pages/templates/pages/dev_faq.html:38
 #: src/olympia/pages/templates/pages/dev_faq.html:484
 msgid "User Reviews"
 msgstr ""
 
-#: src/olympia/devhub/views.py:327 src/olympia/devhub/views.py:331
-#: src/olympia/devhub/views.py:487 src/olympia/devhub/views.py:516
-#: src/olympia/devhub/views.py:567 src/olympia/devhub/views.py:1160
+#: src/olympia/devhub/views.py:325 src/olympia/devhub/views.py:329
+#: src/olympia/devhub/views.py:484 src/olympia/devhub/views.py:513
+#: src/olympia/devhub/views.py:564 src/olympia/devhub/views.py:1156
 msgid "Changes successfully saved."
 msgstr ""
 
-#: src/olympia/devhub/views.py:334 src/olympia/devhub/views.py:1634
+#: src/olympia/devhub/views.py:332 src/olympia/devhub/views.py:1637
 msgid "Please check the form for errors."
 msgstr ""
 
-#: src/olympia/devhub/views.py:346
+#: src/olympia/devhub/views.py:344
 msgid "Add-on cannot be deleted. Disable this add-on instead."
 msgstr ""
 
-#: src/olympia/devhub/views.py:356
+#: src/olympia/devhub/views.py:354
 msgid "Theme deleted."
 msgstr ""
 
-#: src/olympia/devhub/views.py:356
+#: src/olympia/devhub/views.py:354
 msgid "Add-on deleted."
 msgstr ""
 
-#: src/olympia/devhub/views.py:362
+#: src/olympia/devhub/views.py:360
 msgid "URL name was incorrect. Theme was not deleted."
 msgstr ""
 
-#: src/olympia/devhub/views.py:367
+#: src/olympia/devhub/views.py:365
 msgid "URL name was incorrect. Add-on was not deleted."
 msgstr ""
 
-#: src/olympia/devhub/views.py:452
+#: src/olympia/devhub/views.py:449
 msgid "An author has been added to your add-on"
 msgstr ""
 
-#: src/olympia/devhub/views.py:459
+#: src/olympia/devhub/views.py:456
 msgid "An author has a role changed on your add-on"
 msgstr ""
 
-#: src/olympia/devhub/views.py:479
+#: src/olympia/devhub/views.py:476
 msgid "An author has been removed from your add-on"
 msgstr ""
 
-#: src/olympia/devhub/views.py:522
+#: src/olympia/devhub/views.py:519
 msgid "There were errors in your submission."
 msgstr ""
 
-#: src/olympia/devhub/views.py:586
+#: src/olympia/devhub/views.py:583
 msgid "Validate Add-on"
 msgstr ""
 
-#: src/olympia/devhub/views.py:597
+#: src/olympia/devhub/views.py:594
 msgid "Check Add-on Compatibility"
 msgstr ""
 
-#: src/olympia/devhub/views.py:812 src/olympia/signing/views.py:95
+#: src/olympia/devhub/views.py:808 src/olympia/signing/views.py:95
 msgid "You cannot submit this type of add-on"
 msgstr ""
 
-#: src/olympia/devhub/views.py:1055 src/olympia/users/forms.py:471
+#: src/olympia/devhub/views.py:1051 src/olympia/users/forms.py:471
 msgid "Images must be either PNG or JPG."
 msgstr ""
 
-#: src/olympia/devhub/views.py:1059
+#: src/olympia/devhub/views.py:1055
 msgid "Icons cannot be animated."
 msgstr ""
 
-#: src/olympia/devhub/views.py:1061
+#: src/olympia/devhub/views.py:1057
 msgid "Images cannot be animated."
 msgstr ""
 
-#: src/olympia/devhub/views.py:1074
+#: src/olympia/devhub/views.py:1070
 #, python-format
 msgid "Images cannot be larger than %dKB."
 msgstr ""
 
 #. L10n: {0} is an image width (in pixels), {1} is a height.
-#: src/olympia/devhub/views.py:1084
+#: src/olympia/devhub/views.py:1080
 msgid "Image must be exactly {0} pixels wide and {1} pixels tall."
 msgstr ""
 
-#: src/olympia/devhub/views.py:1091
+#: src/olympia/devhub/views.py:1087
 msgid "There was an error uploading your preview."
 msgstr ""
 
-#: src/olympia/devhub/views.py:1199
+#: src/olympia/devhub/views.py:1195
 #, python-format
 msgid "Version %s disabled."
 msgstr ""
 
-#: src/olympia/devhub/views.py:1203
+#: src/olympia/devhub/views.py:1199
 #, python-format
 msgid "Version %s deleted."
 msgstr ""
 
-#: src/olympia/devhub/views.py:1213
+#: src/olympia/devhub/views.py:1209
 msgid ""
 "This upload has failed validation, and may lack complete validation results. "
 "Please take due care when reviewing it."
 msgstr ""
 
-#: src/olympia/devhub/views.py:1680
+#: src/olympia/devhub/views.py:1683
 msgid "Preliminary Review Requested."
 msgstr ""
 
-#: src/olympia/devhub/views.py:1681
+#: src/olympia/devhub/views.py:1684
 msgid "Full Review Requested."
 msgstr ""
 
-#: src/olympia/devhub/views.py:1782
+#: src/olympia/devhub/views.py:1783
 msgid ""
 "Your old credentials were revoked and are no longer valid. Be sure to update "
 "all API clients with the new credentials."
 msgstr ""
 
-#: src/olympia/devhub/views.py:1800
+#: src/olympia/devhub/views.py:1801
 msgid "New API key created"
 msgstr ""
 
@@ -4660,7 +4672,7 @@ msgstr ""
 
 #: src/olympia/devhub/templates/devhub/devhub_search.html:6
 #: src/olympia/devhub/templates/devhub/search.html:8
-#: src/olympia/editors/forms.py:430 src/olympia/editors/forms.py:432
+#: src/olympia/editors/forms.py:534 src/olympia/editors/forms.py:536
 #: src/olympia/editors/templates/editors/queue.html:27
 #: src/olympia/editors/templates/editors/themes/queue_list.html:14
 #: src/olympia/search/templates/search/collections.html:17
@@ -5528,9 +5540,9 @@ msgid "Daily statistics on downloads and users."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/listing/item_actions.html:45
-#: src/olympia/stats/templates/stats/stats.html:75
-#: src/olympia/stats/templates/stats/stats.html:79
-#: src/olympia/stats/templates/stats/stats.html:81
+#: src/olympia/stats/templates/stats/stats.html:31
+#: src/olympia/stats/templates/stats/stats.html:35
+#: src/olympia/stats/templates/stats/stats.html:37
 msgid "Statistics"
 msgstr ""
 
@@ -5894,13 +5906,13 @@ msgid ""
 "run on your file."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/addons/submit/upload.html:45
-#: src/olympia/devhub/templates/devhub/versions/add_file_modal.html:27
+#: src/olympia/devhub/templates/devhub/addons/submit/upload.html:51
+#: src/olympia/devhub/templates/devhub/versions/add_file_modal.html:28
 msgid "Which platforms is this file compatible with?"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/addons/submit/upload.html:53
-#: src/olympia/devhub/templates/devhub/versions/add_file_modal.html:44
+#: src/olympia/devhub/templates/devhub/addons/submit/upload.html:59
+#: src/olympia/devhub/templates/devhub/versions/add_file_modal.html:45
 msgid "Administrative overrides"
 msgstr ""
 
@@ -7697,21 +7709,21 @@ msgstr ""
 msgid "Select a different footer image"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/add_file_modal.html:7
+#: src/olympia/devhub/templates/devhub/versions/add_file_modal.html:8
 msgid ""
 "Files added to reviewed versions must be reviewed before they will be "
 "available for download."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/add_file_modal.html:23
+#: src/olympia/devhub/templates/devhub/versions/add_file_modal.html:24
 msgid "Select the target platform for this file."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/add_file_modal.html:34
+#: src/olympia/devhub/templates/devhub/versions/add_file_modal.html:35
 msgid "Which review type would you like to nominate for?"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/add_file_modal.html:39
+#: src/olympia/devhub/templates/devhub/versions/add_file_modal.html:40
 msgid "Only publish this version to my beta channel."
 msgstr ""
 
@@ -8387,19 +8399,21 @@ msgstr ""
 msgid "Search by add-on name / author email"
 msgstr ""
 
-#: src/olympia/editors/forms.py:103
+#: src/olympia/editors/forms.py:103 src/olympia/editors/forms.py:244
+#: src/olympia/editors/forms.py:257
 msgid "yes"
 msgstr ""
 
-#: src/olympia/editors/forms.py:104
+#: src/olympia/editors/forms.py:104 src/olympia/editors/forms.py:244
+#: src/olympia/editors/forms.py:257
 msgid "no"
 msgstr ""
 
-#: src/olympia/editors/forms.py:105
+#: src/olympia/editors/forms.py:105 src/olympia/editors/forms.py:245
 msgid "Admin Flag"
 msgstr ""
 
-#: src/olympia/editors/forms.py:113
+#: src/olympia/editors/forms.py:113 src/olympia/editors/forms.py:253
 msgid "Max. Version"
 msgstr ""
 
@@ -8415,53 +8429,57 @@ msgstr ""
 msgid "Platforms"
 msgstr ""
 
+#: src/olympia/editors/forms.py:237
+msgid "Search by add-on name / author email / guid"
+msgstr ""
+
 #. L10n: 0 = platform, 1 = filename, 2 = status message
-#: src/olympia/editors/forms.py:238
+#: src/olympia/editors/forms.py:342
 #, python-format
 msgid "<strong>%s</strong> &middot; %s &middot; %s"
 msgstr ""
 
-#: src/olympia/editors/forms.py:252
+#: src/olympia/editors/forms.py:356
 msgid "Comments:"
 msgstr ""
 
-#: src/olympia/editors/forms.py:256
+#: src/olympia/editors/forms.py:360
 msgid "Operating systems:"
 msgstr ""
 
-#: src/olympia/editors/forms.py:258
+#: src/olympia/editors/forms.py:362
 msgid "Applications:"
 msgstr ""
 
-#: src/olympia/editors/forms.py:260
+#: src/olympia/editors/forms.py:364
 msgid ""
 "Notify me the next time this add-on is updated. (Subsequent updates will not "
 "generate an email)"
 msgstr ""
 
-#: src/olympia/editors/forms.py:265
+#: src/olympia/editors/forms.py:369
 msgid "Clear Admin Review Flag"
 msgstr ""
 
-#: src/olympia/editors/forms.py:267
+#: src/olympia/editors/forms.py:371
 msgid "Clear more info requested flag"
 msgstr ""
 
-#: src/olympia/editors/forms.py:281
+#: src/olympia/editors/forms.py:385
 msgid "Choose a canned response..."
 msgstr ""
 
 #. L10n: Description of what can be searched for.
-#: src/olympia/editors/forms.py:319
+#: src/olympia/editors/forms.py:423
 msgid "theme name"
 msgstr ""
 
-#: src/olympia/editors/forms.py:345
+#: src/olympia/editors/forms.py:449
 msgid "Someone else is reviewing this theme."
 msgstr ""
 
 #. L10n: Description of what can be searched for.
-#: src/olympia/editors/forms.py:442
+#: src/olympia/editors/forms.py:546
 msgid "app, reviewer, or comment"
 msgstr ""
 
@@ -8658,104 +8676,108 @@ msgstr ""
 msgid "Last Update"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:559
-msgid "Push to public"
+#: src/olympia/editors/helpers.py:387
+msgid "No Reviews"
 msgstr ""
 
 #: src/olympia/editors/helpers.py:561
+msgid "Push to public"
+msgstr ""
+
+#: src/olympia/editors/helpers.py:563
 msgid "Grant full review"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:574
+#: src/olympia/editors/helpers.py:578
 msgid "Request more information"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:577
+#: src/olympia/editors/helpers.py:581
 msgid "Request super-review"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:588
+#: src/olympia/editors/helpers.py:592
 msgid "Grant preliminary review"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:589
+#: src/olympia/editors/helpers.py:593
 msgid "This will mark the files as preliminarily reviewed."
 msgstr ""
 
-#: src/olympia/editors/helpers.py:591
+#: src/olympia/editors/helpers.py:595
 msgid ""
 "Use this form to request more information from the author. They will receive "
 "an email and be able to answer here. You will be notified by email when they "
 "reply."
 msgstr ""
 
-#: src/olympia/editors/helpers.py:595
+#: src/olympia/editors/helpers.py:599
 msgid ""
 "If you have concerns about this add-on's security, copyright issues, or other"
 " concerns that an administrator should look into, enter your comments in the "
 "area below. They will be sent to administrators, not the author."
 msgstr ""
 
-#: src/olympia/editors/helpers.py:601
+#: src/olympia/editors/helpers.py:605
 msgid "This will reject the add-on and remove it from the review queue."
 msgstr ""
 
-#: src/olympia/editors/helpers.py:603
+#: src/olympia/editors/helpers.py:607
 msgid "Make a comment on this version. The author won't be able to see this."
 msgstr ""
 
-#: src/olympia/editors/helpers.py:607
+#: src/olympia/editors/helpers.py:611
 msgid "This will reject the files and remove them from the review queue."
 msgstr ""
 
-#: src/olympia/editors/helpers.py:611
+#: src/olympia/editors/helpers.py:615
 msgid ""
 "This will mark the add-on as preliminarily reviewed. Future versions will "
 "undergo preliminary review."
 msgstr ""
 
-#: src/olympia/editors/helpers.py:616
+#: src/olympia/editors/helpers.py:620
 msgid ""
 "This will mark the files as preliminarily reviewed. Future versions will "
 "undergo preliminary review."
 msgstr ""
 
-#: src/olympia/editors/helpers.py:621
+#: src/olympia/editors/helpers.py:625
 msgid "Retain preliminary review"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:622
+#: src/olympia/editors/helpers.py:626
 msgid ""
 "This will retain the add-on as preliminarily reviewed. Future versions will "
 "undergo preliminary review."
 msgstr ""
 
-#: src/olympia/editors/helpers.py:627
+#: src/olympia/editors/helpers.py:631
 msgid ""
 "This will approve a sandboxed version of a public add-on to appear on the "
 "public side."
 msgstr ""
 
-#: src/olympia/editors/helpers.py:630
+#: src/olympia/editors/helpers.py:634
 msgid "This will reject a version of a public add-on and remove it from the queue."
 msgstr ""
 
-#: src/olympia/editors/helpers.py:633
+#: src/olympia/editors/helpers.py:637
 msgid ""
 "This will mark the add-on and its most recent version and files as public. "
 "Future versions will go into the sandbox until they are reviewed by an "
 "editor."
 msgstr ""
 
-#: src/olympia/editors/helpers.py:710
+#: src/olympia/editors/helpers.py:714
 msgid "add-on"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:1016 src/olympia/editors/helpers.py:1036
+#: src/olympia/editors/helpers.py:1020 src/olympia/editors/helpers.py:1040
 msgid "Flagged"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:1020 src/olympia/editors/helpers.py:1039
+#: src/olympia/editors/helpers.py:1024 src/olympia/editors/helpers.py:1043
 msgid "Updates"
 msgstr ""
 
@@ -8819,44 +8841,44 @@ msgstr ""
 msgid "Overdue (Over 10 days)"
 msgstr ""
 
-#: src/olympia/editors/views.py:538
+#: src/olympia/editors/views.py:539
 msgid "An unknown error occurred"
 msgstr ""
 
-#: src/olympia/editors/views.py:591
+#: src/olympia/editors/views.py:592
 msgid "Self-reviews are not allowed."
 msgstr ""
 
-#: src/olympia/editors/views.py:612
+#: src/olympia/editors/views.py:613
 msgid "Review successfully processed."
 msgstr ""
 
-#: src/olympia/editors/views.py:811
+#: src/olympia/editors/views.py:812
 msgid "was approved"
 msgstr ""
 
-#: src/olympia/editors/views.py:812
+#: src/olympia/editors/views.py:813
 msgid "given preliminary review"
 msgstr ""
 
-#: src/olympia/editors/views.py:813
+#: src/olympia/editors/views.py:814
 msgid "rejected"
 msgstr ""
 
-#: src/olympia/editors/views.py:814
+#: src/olympia/editors/views.py:815
 msgctxt "editors_review_history_nominated_adminreview"
 msgid "escalated"
 msgstr ""
 
-#: src/olympia/editors/views.py:816
+#: src/olympia/editors/views.py:817
 msgid "needs more information"
 msgstr ""
 
-#: src/olympia/editors/views.py:817
+#: src/olympia/editors/views.py:818
 msgid "needs super review"
 msgstr ""
 
-#: src/olympia/editors/views.py:818
+#: src/olympia/editors/views.py:819
 msgid "commented"
 msgstr ""
 
@@ -9178,49 +9200,49 @@ msgstr ""
 msgid "clear search"
 msgstr ""
 
-#: src/olympia/editors/templates/editors/queue.html:72
-#: src/olympia/editors/templates/editors/queue.html:122
+#: src/olympia/editors/templates/editors/queue.html:78
+#: src/olympia/editors/templates/editors/queue.html:128
 msgid "Process Reviews"
 msgstr ""
 
-#: src/olympia/editors/templates/editors/queue.html:80
+#: src/olympia/editors/templates/editors/queue.html:86
 msgid "Moderation actions:"
 msgstr ""
 
-#: src/olympia/editors/templates/editors/queue.html:90
+#: src/olympia/editors/templates/editors/queue.html:96
 #, python-format
 msgid "by %(user)s on %(date)s %(stars)s (%(locale)s)"
 msgstr ""
 
-#: src/olympia/editors/templates/editors/queue.html:106
+#: src/olympia/editors/templates/editors/queue.html:112
 #, python-format
 msgid ""
 "<strong>%(reason)s</strong> <span class=\"light\">Flagged by %(user)s on "
 "%(date)s</span>"
 msgstr ""
 
-#: src/olympia/editors/templates/editors/queue.html:119
+#: src/olympia/editors/templates/editors/queue.html:125
 msgid "All reviews have been moderated. Good work!"
 msgstr ""
 
-#: src/olympia/editors/templates/editors/queue.html:161
+#: src/olympia/editors/templates/editors/queue.html:167
 msgid "Version Notes / Notes for Reviewer"
 msgstr ""
 
-#: src/olympia/editors/templates/editors/queue.html:169
+#: src/olympia/editors/templates/editors/queue.html:175
 msgid "There are currently no add-ons of this type to review."
 msgstr ""
 
-#: src/olympia/editors/templates/editors/queue.html:181
+#: src/olympia/editors/templates/editors/queue.html:187
 #: src/olympia/editors/templates/editors/themes/queue_list.html:85
 msgid "Helpful Links:"
 msgstr ""
 
-#: src/olympia/editors/templates/editors/queue.html:182
+#: src/olympia/editors/templates/editors/queue.html:188
 msgid "Add-on Policy"
 msgstr ""
 
-#: src/olympia/editors/templates/editors/queue.html:184
+#: src/olympia/editors/templates/editors/queue.html:190
 msgid "Editors' Guide"
 msgstr ""
 
@@ -10427,10 +10449,6 @@ msgstr ""
 
 #: src/olympia/lib/constants.py:169
 msgid "Zimbabwe Dollar"
-msgstr ""
-
-#: src/olympia/lib/video/ffmpeg.py:112 src/olympia/lib/video/totem.py:81
-msgid "Videos must be in WebM."
 msgstr ""
 
 #: src/olympia/pages/templates/pages/about.lhtml:3
@@ -12626,95 +12644,95 @@ msgstr ""
 msgid "Statistics Dashboard :: Add-ons for {0}"
 msgstr ""
 
-#: src/olympia/stats/templates/stats/stats.html:30
-msgid "Controls:"
-msgstr ""
-
-#: src/olympia/stats/templates/stats/stats.html:33
-msgid "reset zoom"
-msgstr ""
-
-#: src/olympia/stats/templates/stats/stats.html:40
-msgid "Group by:"
-msgstr ""
-
-#: src/olympia/stats/templates/stats/stats.html:42
-msgid "day"
-msgstr ""
-
-#: src/olympia/stats/templates/stats/stats.html:45
-msgid "week"
-msgstr ""
-
-#: src/olympia/stats/templates/stats/stats.html:48
-msgid "month"
-msgstr ""
-
-#: src/olympia/stats/templates/stats/stats.html:54
-msgid "For last:"
-msgstr ""
-
-#: src/olympia/stats/templates/stats/stats.html:57
-msgid "7 days"
-msgstr ""
-
-#: src/olympia/stats/templates/stats/stats.html:60
-msgid "30 days"
-msgstr ""
-
-#: src/olympia/stats/templates/stats/stats.html:63
-msgid "90 days"
-msgstr ""
-
-#: src/olympia/stats/templates/stats/stats.html:66
-msgid "365 days"
-msgstr ""
-
-#: src/olympia/stats/templates/stats/stats.html:69
-msgid "Custom..."
-msgstr ""
-
 #. {0} is an add-on name
-#: src/olympia/stats/templates/stats/stats.html:88
-#: src/olympia/stats/templates/stats/stats.html:91
+#: src/olympia/stats/templates/stats/stats.html:44
+#: src/olympia/stats/templates/stats/stats.html:47
 msgid "Statistics for {0}"
 msgstr ""
 
-#: src/olympia/stats/templates/stats/stats.html:94
+#: src/olympia/stats/templates/stats/stats.html:50
 msgid "Statistics Dashboard"
 msgstr ""
 
-#: src/olympia/stats/templates/stats/stats.html:104
+#: src/olympia/stats/templates/stats/stats.html:57
+msgid "Controls:"
+msgstr ""
+
+#: src/olympia/stats/templates/stats/stats.html:60
+msgid "reset zoom"
+msgstr ""
+
+#: src/olympia/stats/templates/stats/stats.html:67
+msgid "Group by:"
+msgstr ""
+
+#: src/olympia/stats/templates/stats/stats.html:69
+msgid "day"
+msgstr ""
+
+#: src/olympia/stats/templates/stats/stats.html:72
+msgid "week"
+msgstr ""
+
+#: src/olympia/stats/templates/stats/stats.html:75
+msgid "month"
+msgstr ""
+
+#: src/olympia/stats/templates/stats/stats.html:81
+msgid "For last:"
+msgstr ""
+
+#: src/olympia/stats/templates/stats/stats.html:84
+msgid "7 days"
+msgstr ""
+
+#: src/olympia/stats/templates/stats/stats.html:87
+msgid "30 days"
+msgstr ""
+
+#: src/olympia/stats/templates/stats/stats.html:90
+msgid "90 days"
+msgstr ""
+
+#: src/olympia/stats/templates/stats/stats.html:93
+msgid "365 days"
+msgstr ""
+
+#: src/olympia/stats/templates/stats/stats.html:96
+msgid "Custom..."
+msgstr ""
+
+#: src/olympia/stats/templates/stats/stats.html:106
 msgid ""
 "Statistics processing is currently disabled, so recent data is unavailable. "
 "The statistics are still being collected and this page will be updated soon "
 "with the missing data."
 msgstr ""
 
-#: src/olympia/stats/templates/stats/stats.html:110
+#: src/olympia/stats/templates/stats/stats.html:112
 msgid "Loading the latest data&hellip;"
 msgstr ""
 
-#: src/olympia/stats/templates/stats/stats.html:142
+#: src/olympia/stats/templates/stats/stats.html:144
 #: src/olympia/stats/templates/stats/reports/overview.html:25
 #: src/olympia/stats/templates/stats/reports/overview.html:37
 #: src/olympia/stats/templates/stats/reports/overview.html:49
 msgid "No data available."
 msgstr ""
 
-#: src/olympia/stats/templates/stats/stats.html:177
+#: src/olympia/stats/templates/stats/stats.html:179
 msgid "This dashboard is currently <b>public</b>."
 msgstr ""
 
-#: src/olympia/stats/templates/stats/stats.html:179
+#: src/olympia/stats/templates/stats/stats.html:181
 msgid "Contribution stats are currently <b>private</b>."
 msgstr ""
 
-#: src/olympia/stats/templates/stats/stats.html:182
+#: src/olympia/stats/templates/stats/stats.html:184
 msgid "This dashboard is currently <b>private</b>."
 msgstr ""
 
-#: src/olympia/stats/templates/stats/stats.html:185
+#: src/olympia/stats/templates/stats/stats.html:187
 msgid "Change settings."
 msgstr ""
 
@@ -14243,5 +14261,9 @@ msgstr ""
 
 #: src/olympia/zadmin/forms.py:105
 msgid "Log emails instead of sending"
+msgstr ""
+
+#: src/olympia/zadmin/forms.py:215
+msgid "Deleted versions can`t be changed."
 msgstr ""
 

--- a/locale/templates/LC_MESSAGES/djangojs.pot
+++ b/locale/templates/LC_MESSAGES/djangojs.pot
@@ -4,7 +4,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT 1.0\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2016-04-11 14:21+0000\n"
+"POT-Creation-Date: 2016-04-18 15:47+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -71,29 +71,29 @@ msgstr ""
 #. L10n: {0} is an app name, {1} is the app version.
 #: static/js/common-all.js:2049 static/js/common-all.js:2086
 #: static/js/impala-all.js:2134 static/js/impala-all.js:2171
-#: static/js/zamboni/buttons.js:285 static/js/zamboni/buttons.js:322
+#: static/js/zamboni/buttons.js:286 static/js/zamboni/buttons.js:324
 #: static/js/zamboni/discovery-all.js:13320
 #: static/js/zamboni/discovery-all.js:13357
 msgid "Not available for {0} {1}"
 msgstr ""
 
 #: static/js/common-all.js:2112 static/js/impala-all.js:2197
-#: static/js/zamboni/buttons.js:348 static/js/zamboni/discovery-all.js:13383
+#: static/js/zamboni/buttons.js:351 static/js/zamboni/discovery-all.js:13383
 msgid "Works with {app} {min} - {max}"
 msgstr ""
 
 #: static/js/common-all.js:2114 static/js/impala-all.js:2199
-#: static/js/zamboni/buttons.js:350 static/js/zamboni/discovery-all.js:13385
+#: static/js/zamboni/buttons.js:353 static/js/zamboni/discovery-all.js:13385
 msgid "View other versions"
 msgstr ""
 
 #: static/js/common-all.js:2162 static/js/impala-all.js:2247
-#: static/js/zamboni/buttons.js:398 static/js/zamboni/discovery-all.js:13433
+#: static/js/zamboni/buttons.js:401 static/js/zamboni/discovery-all.js:13433
 msgid "Only with Firefox — Get Firefox Now!"
 msgstr ""
 
 #: static/js/common-all.js:2278 static/js/impala-all.js:2363
-#: static/js/zamboni/buttons.js:514 static/js/zamboni/discovery-all.js:13549
+#: static/js/zamboni/buttons.js:517 static/js/zamboni/discovery-all.js:13549
 #: static/js/zamboni/mobile-all.js:15177 static/js/zamboni/mobile/buttons.js:43
 msgid ""
 "Sorry, you need a Mozilla-based browser (such as Firefox) to install a search"
@@ -430,7 +430,7 @@ msgid_plural "&hellip;and {0} more"
 msgstr[0] ""
 msgstr[1] ""
 
-#: static/js/common/upload-addon.js:222 static/js/common/upload-addon.js:478
+#: static/js/common/upload-addon.js:222 static/js/common/upload-addon.js:497
 #: static/js/zamboni/devhub-all.js:453 static/js/zamboni/devhub-all.js:743
 #: static/js/zamboni/devhub-min.js:1
 msgid "See full validation report"
@@ -447,51 +447,51 @@ msgstr ""
 msgid "Received an empty response from the server; status: {0}"
 msgstr ""
 
-#: static/js/common/upload-addon.js:352 static/js/zamboni/devhub-all.js:604
+#: static/js/common/upload-addon.js:370 static/js/zamboni/devhub-all.js:604
 #: static/js/zamboni/devhub-min.js:1
 msgid "Unexpected server error while validating."
 msgstr ""
 
-#: static/js/common/upload-addon.js:391 static/js/zamboni/devhub-all.js:643
+#: static/js/common/upload-addon.js:409 static/js/zamboni/devhub-all.js:643
 #: static/js/zamboni/devhub-min.js:1
 msgid "Finished validating {0}"
 msgstr ""
 
-#: static/js/common/upload-addon.js:397 static/js/zamboni/devhub-all.js:649
+#: static/js/common/upload-addon.js:415 static/js/zamboni/devhub-all.js:649
 #: static/js/zamboni/devhub-min.js:1
 msgid "Your add-on validation timed out, it will be manually reviewed."
 msgstr ""
 
-#: static/js/common/upload-addon.js:400 static/js/zamboni/devhub-all.js:652
+#: static/js/common/upload-addon.js:418 static/js/zamboni/devhub-all.js:652
 #: static/js/zamboni/devhub-min.js:1
 msgid "Your add-on was validated with no errors and {0} warning."
 msgid_plural "Your add-on was validated with no errors and {0} warnings."
 msgstr[0] ""
 msgstr[1] ""
 
-#: static/js/common/upload-addon.js:405 static/js/zamboni/devhub-all.js:657
+#: static/js/common/upload-addon.js:423 static/js/zamboni/devhub-all.js:657
 #: static/js/zamboni/devhub-min.js:1
 msgid "Your add-on was validated with no errors and {0} message."
 msgid_plural "Your add-on was validated with no errors and {0} messages."
 msgstr[0] ""
 msgstr[1] ""
 
-#: static/js/common/upload-addon.js:410 static/js/zamboni/devhub-all.js:662
+#: static/js/common/upload-addon.js:428 static/js/zamboni/devhub-all.js:662
 #: static/js/zamboni/devhub-min.js:1
 msgid "Your add-on was validated with no errors or warnings."
 msgstr ""
 
-#: static/js/common/upload-addon.js:424 static/js/zamboni/devhub-all.js:677
+#: static/js/common/upload-addon.js:443 static/js/zamboni/devhub-all.js:677
 #: static/js/zamboni/devhub-min.js:1
 msgid "Your submission will be automatically signed."
 msgstr ""
 
-#: static/js/common/upload-addon.js:431 static/js/zamboni/devhub-all.js:696
+#: static/js/common/upload-addon.js:450 static/js/zamboni/devhub-all.js:696
 #: static/js/zamboni/devhub-min.js:1
 msgid "Include detailed version notes (this can be done in the next step)."
 msgstr ""
 
-#: static/js/common/upload-addon.js:432 static/js/zamboni/devhub-all.js:697
+#: static/js/common/upload-addon.js:451 static/js/zamboni/devhub-all.js:697
 #: static/js/zamboni/devhub-min.js:1
 msgid ""
 "If your add-on requires an account to a website in order to be fully tested, "
@@ -499,26 +499,26 @@ msgid ""
 "done in the next step)."
 msgstr ""
 
-#: static/js/common/upload-addon.js:433 static/js/zamboni/devhub-all.js:698
+#: static/js/common/upload-addon.js:452 static/js/zamboni/devhub-all.js:698
 #: static/js/zamboni/devhub-min.js:1
 msgid ""
 "If your add-on is intended for a limited audience you should choose "
 "Preliminary Review instead of Full Review."
 msgstr ""
 
-#: static/js/common/upload-addon.js:446 static/js/zamboni/devhub-all.js:711
+#: static/js/common/upload-addon.js:465 static/js/zamboni/devhub-all.js:711
 #: static/js/zamboni/devhub-min.js:1
 msgid "Add-on submission checklist"
 msgstr ""
 
-#: static/js/common/upload-addon.js:447 static/js/zamboni/devhub-all.js:712
+#: static/js/common/upload-addon.js:466 static/js/zamboni/devhub-all.js:712
 #: static/js/zamboni/devhub-min.js:1
 msgid ""
 "Please verify the following points before finalizing your submission. This "
 "will minimize delays or misunderstanding during the review process:"
 msgstr ""
 
-#: static/js/common/upload-addon.js:449 static/js/zamboni/devhub-all.js:714
+#: static/js/common/upload-addon.js:468 static/js/zamboni/devhub-all.js:714
 #: static/js/zamboni/devhub-min.js:1
 msgid ""
 "Compiled binaries, as well as minified or obfuscated scripts (excluding known"
@@ -527,19 +527,19 @@ msgid ""
 "submission rejected."
 msgstr ""
 
-#: static/js/common/upload-addon.js:467 static/js/zamboni/devhub-all.js:732
+#: static/js/common/upload-addon.js:486 static/js/zamboni/devhub-all.js:732
 #: static/js/zamboni/devhub-min.js:1
 msgid "The validation process found these issues that can lead to rejections:"
 msgstr ""
 
-#: static/js/common/upload-addon.js:484 static/js/zamboni/devhub-all.js:749
+#: static/js/common/upload-addon.js:503 static/js/zamboni/devhub-all.js:749
 #: static/js/zamboni/devhub-min.js:1
 msgid ""
 "If you are unfamiliar with the add-ons review process, you can read about it "
 "here."
 msgstr ""
 
-#: static/js/common/upload-addon.js:521 static/js/zamboni/devhub-all.js:786
+#: static/js/common/upload-addon.js:540 static/js/zamboni/devhub-all.js:786
 #: static/js/zamboni/devhub-min.js:1
 msgid "Sorry, no supported platform has been found."
 msgstr ""

--- a/locale/th/LC_MESSAGES/django.po
+++ b/locale/th/LC_MESSAGES/django.po
@@ -6,69 +6,70 @@ msgid ""
 msgstr ""
 "Project-Id-Version:  addons\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2016-02-24 21:23+0000\n"
+"POT-Creation-Date: 2016-04-18 15:47+0000\n"
 "PO-Revision-Date: 2013-11-08 06:31+0000\n"
 "Last-Translator: earthx2 <fujiko.doramon71@gmail.com>\n"
 "Language-Team: Thai\n"
+"Language: \n"
 "MIME-Version: 1.0\n"
-"Content-Type: text/plain; charset=utf-8\n"
+"Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Generated-By: Babel 2.2.0\n"
 
-#: src/olympia/accounts/views.py:52
+#: src/olympia/accounts/views.py:54
 msgid "Your log in attempt could not be parsed. Please try again."
 msgstr ""
 
-#: src/olympia/accounts/views.py:54
+#: src/olympia/accounts/views.py:56
 msgid "Your Firefox Account could not be found. Please try again."
 msgstr ""
 
-#: src/olympia/accounts/views.py:55
+#: src/olympia/accounts/views.py:57
 msgid "You could not be logged in. Please try again."
 msgstr ""
 
-#: src/olympia/accounts/views.py:57
+#: src/olympia/accounts/views.py:59
 msgid "Your account has already been migrated to Firefox Accounts."
 msgstr ""
 
-#: src/olympia/accounts/views.py:59
+#: src/olympia/accounts/views.py:61
 msgid "Your Firefox Account already exists on this site."
 msgstr ""
 
-#: src/olympia/accounts/views.py:108
+#: src/olympia/accounts/views.py:110
 msgid "Great job!"
 msgstr ""
 
-#: src/olympia/accounts/views.py:109
+#: src/olympia/accounts/views.py:111
 msgid "You can now log in to Add-ons with your Firefox Account."
 msgstr ""
 
-#: src/olympia/accounts/views.py:121
+#: src/olympia/accounts/views.py:123
 msgid "Need help?"
 msgstr ""
 
-#: src/olympia/addons/buttons.py:180
+#: src/olympia/addons/buttons.py:177
 msgid "Download Now"
 msgstr "ดาวน์โหลดเดี๋ยวนี้"
 
-#: src/olympia/addons/buttons.py:182
+#: src/olympia/addons/buttons.py:179
 msgid "Download"
 msgstr "ดาวน์โหลด"
 
 #. L10n: please keep &nbsp; in the string so &rarr; does not wrap.
-#: src/olympia/addons/buttons.py:186
+#: src/olympia/addons/buttons.py:183
 msgid "Continue to Download&nbsp;&rarr;"
 msgstr "ดำเนินการดาวน์โหลดต่อไป&nbsp;&rarr;"
 
-#: src/olympia/addons/buttons.py:202 src/olympia/addons/helpers.py:35 src/olympia/addons/views.py:319 src/olympia/addons/templates/addons/impala/details.html:114
+#: src/olympia/addons/buttons.py:199 src/olympia/addons/helpers.py:35 src/olympia/addons/views.py:333 src/olympia/addons/templates/addons/impala/details.html:111
 #: src/olympia/addons/templates/addons/impala/listing/items.html:17 src/olympia/addons/templates/addons/mobile/home.html:40 src/olympia/amo/templates/amo/side_nav.html:6
-#: src/olympia/amo/templates/amo/side_nav.html:10 src/olympia/amo/templates/amo/site_nav.html:2 src/olympia/amo/templates/amo/site_nav.html:55 src/olympia/bandwagon/views.py:95
-#: src/olympia/browse/views.py:54 src/olympia/browse/views.py:68 src/olympia/browse/views.py:235 src/olympia/browse/templates/browse/impala/category_landing.html:22
+#: src/olympia/amo/templates/amo/side_nav.html:10 src/olympia/amo/templates/amo/site_nav.html:2 src/olympia/amo/templates/amo/site_nav.html:53 src/olympia/bandwagon/views.py:95
+#: src/olympia/browse/views.py:54 src/olympia/browse/views.py:68 src/olympia/browse/views.py:202 src/olympia/browse/templates/browse/impala/category_landing.html:22
 #: src/olympia/browse/templates/browse/personas/mobile/category_landing.html:26
 msgid "Featured"
 msgstr "แนะนำ"
 
-#: src/olympia/addons/buttons.py:221
+#: src/olympia/addons/buttons.py:218
 msgid "Add to {0}"
 msgstr "เพิ่มไปที่ {0}"
 
@@ -90,17 +91,20 @@ msgstr ""
 msgid "Invalid tag: {0}"
 msgid_plural "Invalid tags: {0}"
 msgstr[0] "ป้ายชื่อที่ไม่ถูกต้อง: {0}"
+msgstr[1] ""
 
 #. L10n: {0} is a single tag or a comma-separated list of tags.
 #: src/olympia/addons/forms.py:103
 msgid "\"{0}\" is a reserved tag and cannot be used."
 msgid_plural "\"{0}\" are reserved tags and cannot be used."
 msgstr[0] "\"{0}\" เป็นป้ายชื่อที่ถูกจองไว้แล้วและไม่สามารถใช้ได้"
+msgstr[1] ""
 
 #: src/olympia/addons/forms.py:111
 msgid "You have {0} too many tags."
 msgid_plural "You have {0} too many tags."
 msgstr[0] "คุณมี {0} แท็กที่มากเกินไป"
+msgstr[1] ""
 
 #: src/olympia/addons/forms.py:117
 #, python-format
@@ -111,39 +115,41 @@ msgstr "ป้ายชื่อทั้งหมดจะต้องมี %s
 msgid "All tags must be at least {0} character."
 msgid_plural "All tags must be at least {0} characters."
 msgstr[0] "ป้ายชื่อทั้งหมดจะต้องมีอย่างน้อย {0} อักขระ"
+msgstr[1] ""
 
-#: src/olympia/addons/forms.py:234
+#: src/olympia/addons/forms.py:238
 msgid "Categories cannot be changed while your add-on is featured for this application."
 msgstr ""
 
 #. L10n: {0} is the number of categories.
-#: src/olympia/addons/forms.py:238
+#: src/olympia/addons/forms.py:242
 msgid "You can have only {0} category."
 msgid_plural "You can have only {0} categories."
 msgstr[0] "คุณสามารถมีได้แค่ {0} หมวดหมู่"
+msgstr[1] ""
 
-#: src/olympia/addons/forms.py:246
+#: src/olympia/addons/forms.py:250
 msgid "The miscellaneous category cannot be combined with additional categories."
 msgstr ""
 
-#: src/olympia/addons/forms.py:369
+#: src/olympia/addons/forms.py:374
 #, python-format
 msgid "Before changing your default locale you must have a name, summary, and description in that locale. You are missing %s."
 msgstr "ก่อนที่จะเปลี่ยนภาษาเริ่มต้นของคุณ คุณจะต้องมีชื่อ บทสรุป และคำอธิบายในภาษานั้น คุณยังขาด %s"
 
-#: src/olympia/addons/forms.py:484 src/olympia/addons/forms.py:575
+#: src/olympia/addons/forms.py:455 src/olympia/addons/forms.py:546
 msgid "A license must be selected."
 msgstr "ลิขสิทธิ์จะต้องถูกเลือก"
 
-#: src/olympia/addons/forms.py:556
+#: src/olympia/addons/forms.py:527
 msgid "Give Your Theme a Name."
 msgstr "ตั้งชื่อให้ชุดตกแต่งของคุณ"
 
-#: src/olympia/addons/forms.py:562 src/olympia/devhub/templates/devhub/personas/submit.html:53
+#: src/olympia/addons/forms.py:533 src/olympia/devhub/templates/devhub/personas/submit.html:53
 msgid "Describe your Theme."
 msgstr "อธิบายชุดตกแต่งของคุณ"
 
-#: src/olympia/addons/forms.py:704
+#: src/olympia/addons/forms.py:675
 msgid "Enter a new author's email address"
 msgstr "ใส่ที่อยู่อีเมลใหม่ของผู้สร้าง"
 
@@ -151,37 +157,37 @@ msgstr "ใส่ที่อยู่อีเมลใหม่ของผู
 msgid "Not Reviewed"
 msgstr "ยังไม่ถูกตรวจสอบ"
 
-#: src/olympia/addons/models.py:301
+#: src/olympia/addons/models.py:298
 msgid "Users have the option of contributing more or less than this amount."
 msgstr "ผู้ใช้มีตัวเลือกที่จะบริจาคมากกว่าหรือน้อยกว่าจำนวนนี้"
 
-#: src/olympia/addons/models.py:309
-msgid "Users will always be asked in the Add-ons Manager (Firefox 4 and above)"
-msgstr "ผู้ใช้จะถูกถามเสมอในตัวจัดการส่วนเสริม (Firefox 4 ขึ้นไป)"
+#: src/olympia/addons/models.py:306
+msgid "Users will always be asked in the Add-ons Manager (Firefox 4 and above). Only applies to desktop."
+msgstr ""
 
-#: src/olympia/addons/models.py:1804 src/olympia/addons/templates/addons/details_box.html:55 src/olympia/devhub/templates/devhub/index.html:92
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:102
+#: src/olympia/addons/models.py:1802 src/olympia/addons/templates/addons/details_box.html:55 src/olympia/devhub/templates/devhub/index.html:92
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:89
 msgid "Listed"
 msgstr "รายการ"
 
-#: src/olympia/addons/views.py:320 src/olympia/browse/templates/browse/personas/mobile/category_landing.html:27
+#: src/olympia/addons/views.py:334 src/olympia/browse/templates/browse/personas/mobile/category_landing.html:27
 msgid "Popular"
 msgstr "ยอดนิยม"
 
-#: src/olympia/addons/views.py:321 src/olympia/browse/views.py:238 src/olympia/browse/views.py:280 src/olympia/browse/views.py:482
+#: src/olympia/addons/views.py:335 src/olympia/browse/views.py:205 src/olympia/browse/views.py:247 src/olympia/browse/views.py:449
 msgid "Recently Added"
 msgstr "ถูกเพิ่มเมื่อเร็ว ๆ นี้"
 
-#: src/olympia/addons/views.py:322 src/olympia/bandwagon/views.py:99 src/olympia/browse/views.py:60 src/olympia/browse/views.py:71 src/olympia/search/forms.py:16 src/olympia/search/forms.py:91
+#: src/olympia/addons/views.py:336 src/olympia/bandwagon/views.py:99 src/olympia/browse/views.py:60 src/olympia/browse/views.py:71 src/olympia/search/forms.py:16 src/olympia/search/forms.py:91
 msgid "Recently Updated"
 msgstr "ถูกปรับปรุงเมื่อเร็ว ๆ นี้"
 
 #. l10n: {0} is the addon name
-#: src/olympia/addons/views.py:520
+#: src/olympia/addons/views.py:534
 msgid "Contribution for {0}"
 msgstr "การบริจาคสำหรับ {0}"
 
-#: src/olympia/addons/views.py:613
+#: src/olympia/addons/views.py:627
 msgid "Abuse reported."
 msgstr "รายงานการละเมิดแล้ว"
 
@@ -248,9 +254,9 @@ msgstr "บริจาค"
 #: src/olympia/devhub/templates/devhub/addons/ajax_compat_update.html:36 src/olympia/devhub/templates/devhub/addons/profile.html:44 src/olympia/devhub/templates/devhub/addons/edit/admin.html:101
 #: src/olympia/devhub/templates/devhub/addons/edit/basic.html:152 src/olympia/devhub/templates/devhub/addons/edit/details.html:85 src/olympia/devhub/templates/devhub/addons/edit/support.html:67
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:166 src/olympia/devhub/templates/devhub/addons/forms_shared/media.html:149
-#: src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:44 src/olympia/devhub/templates/devhub/versions/add_file_modal.html:78 src/olympia/devhub/templates/devhub/versions/edit.html:139
-#: src/olympia/devhub/templates/devhub/versions/list.html:242 src/olympia/devhub/templates/devhub/versions/list.html:276 src/olympia/devhub/templates/devhub/versions/list.html:317
-#: src/olympia/devhub/templates/devhub/versions/list.html:351 src/olympia/reviews/templates/reviews/edit_review.html:16 src/olympia/translations/templates/translations/trans-menu.html:50
+#: src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:43 src/olympia/devhub/templates/devhub/versions/add_file_modal.html:58 src/olympia/devhub/templates/devhub/versions/edit.html:139
+#: src/olympia/devhub/templates/devhub/versions/list.html:239 src/olympia/devhub/templates/devhub/versions/list.html:281 src/olympia/devhub/templates/devhub/versions/list.html:315
+#: src/olympia/devhub/templates/devhub/versions/list.html:349 src/olympia/reviews/templates/reviews/edit_review.html:16 src/olympia/translations/templates/translations/trans-menu.html:50
 #: src/olympia/translations/templates/translations/trans-menu.html:62
 msgid "or"
 msgstr "หรือ"
@@ -361,7 +367,7 @@ msgid "Add-on Information for {0}"
 msgstr "ข้อมูลส่วนเสริมสำหรับ {0}"
 
 #: src/olympia/addons/templates/addons/details_box.html:30 src/olympia/addons/templates/addons/persona_detail_table.html:3 src/olympia/addons/templates/addons/mobile/details.html:63
-#: src/olympia/addons/templates/addons/mobile/persona_detail_table.html:7 src/olympia/browse/views.py:459 src/olympia/devhub/views.py:75
+#: src/olympia/addons/templates/addons/mobile/persona_detail_table.html:7 src/olympia/browse/views.py:426 src/olympia/devhub/views.py:73
 msgid "Updated"
 msgstr "ปรับปรุง"
 
@@ -380,11 +386,11 @@ msgstr "ทำงานกับ"
 msgid "Visibility"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/details_box.html:57 src/olympia/devhub/templates/devhub/index.html:94 src/olympia/devhub/templates/devhub/includes/addon_details.html:104
+#: src/olympia/addons/templates/addons/details_box.html:57 src/olympia/devhub/templates/devhub/index.html:94 src/olympia/devhub/templates/devhub/includes/addon_details.html:91
 msgid "Hidden"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/details_box.html:59 src/olympia/devhub/templates/devhub/index.html:96 src/olympia/devhub/templates/devhub/includes/addon_details.html:106
+#: src/olympia/addons/templates/addons/details_box.html:59 src/olympia/devhub/templates/devhub/index.html:96 src/olympia/devhub/templates/devhub/includes/addon_details.html:93
 msgid "Unlisted"
 msgstr ""
 
@@ -392,14 +398,14 @@ msgstr ""
 msgid "Required Add-ons"
 msgstr "ส่วนเสริมที่ต้องการ"
 
-#: src/olympia/addons/templates/addons/details_box.html:81 src/olympia/addons/templates/addons/persona_detail_table.html:15 src/olympia/browse/views.py:462 src/olympia/devhub/views.py:78
-#: src/olympia/devhub/views.py:85 src/olympia/discovery/templates/discovery/addons/detail.html:57 src/olympia/reviews/forms.py:62 src/olympia/reviews/templates/reviews/add.html:57
+#: src/olympia/addons/templates/addons/details_box.html:81 src/olympia/addons/templates/addons/persona_detail_table.html:15 src/olympia/browse/views.py:429 src/olympia/devhub/views.py:76
+#: src/olympia/devhub/views.py:83 src/olympia/discovery/templates/discovery/addons/detail.html:57 src/olympia/reviews/forms.py:62 src/olympia/reviews/templates/reviews/add.html:57
 #: src/olympia/reviews/templates/reviews/mobile/review_list.html:18
 msgid "Rating"
 msgstr "การจัดอันดับ"
 
 # 88%
-#: src/olympia/addons/templates/addons/details_box.html:85 src/olympia/browse/views.py:461 src/olympia/devhub/views.py:77 src/olympia/devhub/views.py:84
+#: src/olympia/addons/templates/addons/details_box.html:85 src/olympia/browse/views.py:428 src/olympia/devhub/views.py:75 src/olympia/devhub/views.py:82
 #: src/olympia/stats/templates/stats/addon_report_menu.html:8 src/olympia/stats/templates/stats/collection_report_menu.html:18
 #, fuzzy
 msgid "Downloads"
@@ -420,7 +426,7 @@ msgstr "รายงานการละเมิด"
 
 #. The Privacy Policy for this add-on.
 #: src/olympia/addons/templates/addons/details_box.html:121 src/olympia/addons/templates/addons/privacy.html:19 src/olympia/addons/templates/addons/privacy.html:23
-#: src/olympia/addons/templates/addons/impala/button.html:43 src/olympia/addons/templates/addons/impala/details.html:307 src/olympia/devhub/templates/devhub/includes/policy_form.html:20
+#: src/olympia/addons/templates/addons/impala/button.html:43 src/olympia/addons/templates/addons/impala/details.html:312 src/olympia/devhub/templates/devhub/includes/policy_form.html:23
 #: src/olympia/templates/mobile/base_addons.html:87
 msgid "Privacy Policy"
 msgstr "นโยบายความเป็นส่วนตัว"
@@ -445,7 +451,7 @@ msgstr "คลังภาพ"
 msgid "Developer Comments"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/details_box.html:199 src/olympia/addons/templates/addons/impala/details.html:259
+#: src/olympia/addons/templates/addons/details_box.html:199 src/olympia/addons/templates/addons/impala/details.html:264
 msgid "Development Channel"
 msgstr "ช่องการพัฒนา"
 
@@ -465,13 +471,13 @@ msgid ""
 "developer. To stop receiving development updates, reinstall the default version from the link above."
 msgstr "<strong>คำเตือน:</strong> รุ่นพัฒนาของส่วนเสริมนี้ยังไม่ถูกตรวจสอบโดย Mozilla เมื่อคุณติดตั้งรุ่นพัฒนาคุณจะยังคงได้รับการปรับปรุงเป็นรุ่นพัฒนาจากนักพัฒนานี้ เพื่อหยุดการปรับปรุงเป็นรุ่นพัฒนา ติดตั้งรุ่นเริ่มต้นใหม่จากลิงก์ด้านบน"
 
-#: src/olympia/addons/templates/addons/details_box.html:220 src/olympia/addons/templates/addons/impala/details.html:278
+#: src/olympia/addons/templates/addons/details_box.html:220 src/olympia/addons/templates/addons/impala/details.html:283
 msgid "Version {0}:"
 msgstr "รุ่น {0}:"
 
 #: src/olympia/addons/templates/addons/details_box.html:234
-msgid "Nothing to see here! The developer did not include any details."
-msgstr "ไม่มีอะไรให้ดูที่นี่! นักพัฒนาไม่ได้ใส่รายละเอียดใด ๆ"
+msgid "Nothing to see here!  The developer did not include any details."
+msgstr ""
 
 #: src/olympia/addons/templates/addons/details_box.html:251 src/olympia/devhub/templates/devhub/versions/edit.html:73 src/olympia/editors/templates/editors/review.html:98
 msgid "Version Notes"
@@ -484,7 +490,7 @@ msgid "End-User License Agreement for {0}"
 msgstr "ข้อตกลงใบอนุญาตสำหรับผู้ใช้ทั่วไปของ {0}"
 
 #: src/olympia/addons/templates/addons/eula.html:17 src/olympia/addons/templates/addons/eula.html:21 src/olympia/addons/templates/addons/impala/button.html:48
-#: src/olympia/addons/templates/addons/impala/details.html:316 src/olympia/devhub/templates/devhub/includes/policy_form.html:3 src/olympia/discovery/templates/discovery/addons/eula.html:11
+#: src/olympia/addons/templates/addons/impala/details.html:321 src/olympia/devhub/templates/devhub/includes/policy_form.html:3 src/olympia/discovery/templates/discovery/addons/eula.html:11
 msgid "End-User License Agreement"
 msgstr "ข้อตกลงใบอนุญาตสำหรับผู้ใช้ทั่วไป"
 
@@ -501,7 +507,7 @@ msgstr "กลับไปที่ {0}…"
 msgid "Add-ons for {0}"
 msgstr "ส่วนเสริมสำหรับ {0}"
 
-#: src/olympia/addons/templates/addons/home.html:10 src/olympia/addons/templates/addons/home.html:51 src/olympia/browse/templates/browse/impala/base_listing.html:11
+#: src/olympia/addons/templates/addons/home.html:10 src/olympia/addons/templates/addons/home.html:53 src/olympia/browse/templates/browse/impala/base_listing.html:11
 msgid "Featured Extensions"
 msgstr "ส่วนขยายที่แนะนำ"
 
@@ -509,29 +515,29 @@ msgstr "ส่วนขยายที่แนะนำ"
 msgid "Popular Extensions"
 msgstr "ส่วนขยายยอดนิยม"
 
-#: src/olympia/addons/templates/addons/home.html:42 src/olympia/amo/templates/amo/side_nav.html:3 src/olympia/amo/templates/amo/side_nav.html:11 src/olympia/amo/templates/amo/site_nav.html:3
-#: src/olympia/amo/templates/amo/site_nav.html:25 src/olympia/browse/views.py:236 src/olympia/browse/views.py:281 src/olympia/browse/views.py:481
+#: src/olympia/addons/templates/addons/home.html:44 src/olympia/amo/templates/amo/side_nav.html:3 src/olympia/amo/templates/amo/side_nav.html:11 src/olympia/amo/templates/amo/site_nav.html:3
+#: src/olympia/amo/templates/amo/site_nav.html:25 src/olympia/browse/views.py:203 src/olympia/browse/views.py:248 src/olympia/browse/views.py:448
 msgid "Most Popular"
 msgstr "ได้รับความนิยมสูงสุด"
 
-#: src/olympia/addons/templates/addons/home.html:43
+#: src/olympia/addons/templates/addons/home.html:45
 msgid "All »"
 msgstr "ทั้งหมด »"
 
-#: src/olympia/addons/templates/addons/home.html:52 src/olympia/addons/templates/addons/home.html:61 src/olympia/addons/templates/addons/home.html:70 src/olympia/addons/templates/addons/home.html:78
+#: src/olympia/addons/templates/addons/home.html:54 src/olympia/addons/templates/addons/home.html:63 src/olympia/addons/templates/addons/home.html:72 src/olympia/addons/templates/addons/home.html:80
 #: src/olympia/browse/templates/browse/impala/category_landing.html:36
 msgid "See all »"
 msgstr "ดูทั้งหมด »"
 
-#: src/olympia/addons/templates/addons/home.html:60
+#: src/olympia/addons/templates/addons/home.html:62
 msgid "Up &amp; Coming Extensions"
 msgstr "ส่วนขยายที่กำลังจะมา"
 
-#: src/olympia/addons/templates/addons/home.html:69 src/olympia/browse/templates/browse/personas/category_landing.html:61 src/olympia/discovery/templates/discovery/pane.html:74
+#: src/olympia/addons/templates/addons/home.html:71 src/olympia/browse/templates/browse/personas/category_landing.html:61 src/olympia/discovery/templates/discovery/pane.html:74
 msgid "Featured Themes"
 msgstr "ชุดตกแต่งที่แนะนำ"
 
-#: src/olympia/addons/templates/addons/home.html:77 src/olympia/bandwagon/templates/bandwagon/impala/collection_listing.html:5
+#: src/olympia/addons/templates/addons/home.html:79 src/olympia/bandwagon/templates/bandwagon/impala/collection_listing.html:5
 msgid "Featured Collections"
 msgstr "ชุดสะสมที่แนะนำ"
 
@@ -549,7 +555,7 @@ msgid "Updated {0}"
 msgstr "ปรับปรุงเมื่อ {0}"
 
 #. {0} is a date.
-#: src/olympia/addons/templates/addons/macros.html:10 src/olympia/addons/templates/addons/macros.html:69 src/olympia/addons/templates/addons/persona_preview.html:21
+#: src/olympia/addons/templates/addons/macros.html:10 src/olympia/addons/templates/addons/macros.html:69 src/olympia/addons/templates/addons/persona_preview.html:22
 #: src/olympia/addons/templates/addons/listing/items_mobile.html:44 src/olympia/addons/templates/addons/listing/macros.html:39
 #: src/olympia/bandwagon/templates/bandwagon/collection_listing_items.html:37 src/olympia/bandwagon/templates/bandwagon/impala/collection_listing_items.html:37
 msgid "Added {0}"
@@ -560,25 +566,28 @@ msgstr "เพิ่มเมื่อ {0}"
 msgid "%(num)s weekly download"
 msgid_plural "%(num)s weekly downloads"
 msgstr[0] "%(num)s ดาวน์โหลดต่อสัปดาห์"
+msgstr[1] ""
 
 #: src/olympia/addons/templates/addons/macros.html:28
 #, python-format
 msgid "%(num)s user"
 msgid_plural "%(num)s users"
 msgstr[0] "%(num)s ผู้ใช้"
+msgstr[1] ""
 
 #. {0} is the number of downloads.
-#: src/olympia/addons/templates/addons/macros.html:53 src/olympia/addons/templates/addons/impala/details.html:61
+#: src/olympia/addons/templates/addons/macros.html:53 src/olympia/addons/templates/addons/impala/details.html:59
 msgid "{0} weekly download"
 msgid_plural "{0} weekly downloads"
 msgstr[0] "{0} ดาวน์โหลดต่อสัปดาห์"
+msgstr[1] ""
 
 #. {0} is the number of users.
-#: src/olympia/addons/templates/addons/macros.html:61 src/olympia/addons/templates/addons/impala/details.html:54 src/olympia/compat/templates/compat/index.html:71
-#: src/olympia/zadmin/templates/zadmin/compat.html:67
+#: src/olympia/addons/templates/addons/macros.html:61 src/olympia/addons/templates/addons/impala/details.html:52 src/olympia/zadmin/templates/zadmin/compat.html:67
 msgid "{0} user"
 msgid_plural "{0} users"
 msgstr[0] "{0} ผู้ใช้"
+msgstr[1] ""
 
 #: src/olympia/addons/templates/addons/paypal_result.html:12
 msgid "Payment cancelled"
@@ -592,7 +601,7 @@ msgstr "การจ่ายเงินเสร็จสมบูรณ์"
 msgid "Return to the addon."
 msgstr "กลับไปยังส่วนเสริม"
 
-#: src/olympia/addons/templates/addons/persona_detail.html:17 src/olympia/addons/templates/addons/impala/details.html:106 src/olympia/addons/templates/addons/mobile/details.html:23
+#: src/olympia/addons/templates/addons/persona_detail.html:17 src/olympia/addons/templates/addons/impala/details.html:103 src/olympia/addons/templates/addons/mobile/details.html:23
 #: src/olympia/addons/templates/addons/mobile/persona_detail.html:21 src/olympia/discovery/templates/discovery/addons/base.html:27 src/olympia/editors/templates/editors/review.html:31
 msgid "by"
 msgstr "โดย"
@@ -636,33 +645,35 @@ msgstr "ผู้ใช้ต่อวัน"
 msgid "License"
 msgstr "ใบอนุญาต"
 
-#: src/olympia/addons/templates/addons/persona_preview.html:12 src/olympia/constants/base.py:48
+#: src/olympia/addons/templates/addons/persona_preview.html:13 src/olympia/constants/base.py:48
 msgid "Awaiting Review"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/persona_preview.html:14 src/olympia/amo/log.py:180 src/olympia/constants/base.py:42 src/olympia/editors/helpers.py:62
+#: src/olympia/addons/templates/addons/persona_preview.html:15 src/olympia/amo/log.py:180 src/olympia/constants/base.py:42 src/olympia/editors/helpers.py:62
 msgid "Rejected"
 msgstr "ถูกปฏิเสธ"
 
-#: src/olympia/addons/templates/addons/persona_preview.html:16 src/olympia/amo/log.py:159
+#: src/olympia/addons/templates/addons/persona_preview.html:17 src/olympia/amo/log.py:159
 msgid "Approved"
 msgstr "ได้รับการอนุมัติ"
 
 #. {0} is the number of users.
-#: src/olympia/addons/templates/addons/persona_preview.html:26 src/olympia/addons/templates/addons/listing/items_mobile.html:36 src/olympia/addons/templates/addons/listing/macros.html:31
+#: src/olympia/addons/templates/addons/persona_preview.html:27 src/olympia/addons/templates/addons/listing/items_mobile.html:36 src/olympia/addons/templates/addons/listing/macros.html:31
 msgid "<strong>{0}</strong> user"
 msgid_plural "<strong>{0}</strong> users"
 msgstr[0] "<strong>{0}</strong> ผู้ใช้"
+msgstr[1] ""
 
-#: src/olympia/addons/templates/addons/persona_preview.html:40
+#: src/olympia/addons/templates/addons/persona_preview.html:41
 msgid "Hover to Preview"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/persona_preview.html:46 src/olympia/addons/templates/addons/persona_preview.html:48 src/olympia/reviews/templates/reviews/add.html:15
+#: src/olympia/addons/templates/addons/persona_preview.html:47 src/olympia/addons/templates/addons/persona_preview.html:49 src/olympia/addons/templates/addons/persona_preview.html:97
+#: src/olympia/reviews/templates/reviews/add.html:15
 msgid "Add"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/persona_preview.html:57 src/olympia/bandwagon/templates/bandwagon/ajax_new.html:16 src/olympia/bandwagon/templates/bandwagon/edit.html:19
+#: src/olympia/addons/templates/addons/persona_preview.html:58 src/olympia/bandwagon/templates/bandwagon/ajax_new.html:16 src/olympia/bandwagon/templates/bandwagon/edit.html:19
 #: src/olympia/bandwagon/templates/bandwagon/includes/addedit.html:19 src/olympia/devhub/templates/devhub/addons/edit/admin.html:13 src/olympia/devhub/templates/devhub/addons/edit/basic.html:10
 #: src/olympia/devhub/templates/devhub/addons/edit/details.html:8 src/olympia/devhub/templates/devhub/addons/edit/media.html:6 src/olympia/devhub/templates/devhub/addons/edit/support.html:8
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:9 src/olympia/devhub/templates/devhub/addons/submit/describe.html:29 src/olympia/editors/templates/editors/review.html:257
@@ -671,21 +682,21 @@ msgstr "แก้ไข"
 
 #. For datetime formatting, see the table on
 #. http://docs.python.org/library/datetime.html#strftime-and-strptime-behavior
-#: src/olympia/addons/templates/addons/persona_preview.html:66
+#: src/olympia/addons/templates/addons/persona_preview.html:67
 #, python-format
 msgid "%%Y-%%m-%%d"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/persona_preview.html:67
+#: src/olympia/addons/templates/addons/persona_preview.html:68
 msgid "by {0} on {1}"
 msgstr "โดย {0} บน {1}"
 
-#: src/olympia/addons/templates/addons/persona_preview.html:75 src/olympia/reviews/helpers.py:17 src/olympia/reviews/templates/reviews/review_list.html:63
+#: src/olympia/addons/templates/addons/persona_preview.html:76 src/olympia/reviews/helpers.py:17 src/olympia/reviews/templates/reviews/review_list.html:63
 #: src/olympia/reviews/templates/reviews/reviews_link.html:21 src/olympia/reviews/templates/reviews/impala/reviews_link.html:16
 msgid "Not yet rated"
 msgstr "ยังไม่มีการจัดอันดับ"
 
-#: src/olympia/addons/templates/addons/persona_preview.html:78
+#: src/olympia/addons/templates/addons/persona_preview.html:79
 msgid "<b>{0}</b> users"
 msgstr "<b>{0}</b> ผู้ใช้"
 
@@ -698,8 +709,8 @@ msgid "Learn more about Firefox"
 msgstr "เรียนรู้เพิ่มเติมเกี่ยวกับ Firefox"
 
 #: src/olympia/addons/templates/addons/popups.html:22
-msgid "or <b><a class=\"installer\" href=\"{url}\">download anyway</a></b>"
-msgstr "หรือ <b><a class=\"installer\" href=\"{url}\">ติดตั้งต่อไป</a></b>"
+msgid "or <b><a class=\"button installer\" href=\"{url}\">download anyway</a></b>"
+msgstr ""
 
 #: src/olympia/addons/templates/addons/popups.html:26
 msgid ""
@@ -790,11 +801,14 @@ msgid "QR code for add-on"
 msgstr "QR code ของส่วนเสริม"
 
 #: src/olympia/addons/templates/addons/qr_code.html:6
-msgid "Want {0} on your mobile Firefox? Scan this QR code to install directly to your phone. (You'll need a QR reader. Search your phone's marketplace if don't have one.)"
-msgstr "ต้องการ {0} ใน Firefox บนมือถือของคุณ? สแกน QR code นี้เพื่อติดตั้งโดยตรงบนมือถือของคุณ (คุณจำเป็นต้องมีตัวอ่าน QR ค้นหาในร้านค้าแอพบนมือถือของคุณถ้าคุณไม่มี)"
+msgid ""
+"Want {0} on your mobile Firefox?  Scan this QR code to install directly\n"
+"  to your phone.  (You'll need a QR reader.  Search your phone's marketplace if\n"
+"  don't have one.)"
+msgstr ""
 
 #: src/olympia/addons/templates/addons/report_abuse.html:6 src/olympia/addons/templates/addons/report_abuse_full.html:10 src/olympia/addons/templates/addons/impala/details-more.html:23
-#: src/olympia/addons/templates/addons/impala/details.html:328
+#: src/olympia/addons/templates/addons/impala/details.html:333
 msgid "Report Abuse"
 msgstr "รายงานการละเมิด"
 
@@ -813,9 +827,9 @@ msgstr "ส่งรายงาน"
 #: src/olympia/devhub/templates/devhub/addons/ajax_compat_update.html:36 src/olympia/devhub/templates/devhub/addons/profile.html:44 src/olympia/devhub/templates/devhub/addons/edit/admin.html:104
 #: src/olympia/devhub/templates/devhub/addons/edit/basic.html:155 src/olympia/devhub/templates/devhub/addons/edit/details.html:88 src/olympia/devhub/templates/devhub/addons/edit/support.html:70
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:169 src/olympia/devhub/templates/devhub/addons/forms_shared/media.html:152
-#: src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:44 src/olympia/devhub/templates/devhub/personas/edit.html:222 src/olympia/devhub/templates/devhub/versions/add_file_modal.html:79
-#: src/olympia/devhub/templates/devhub/versions/edit.html:140 src/olympia/devhub/templates/devhub/versions/list.html:208 src/olympia/devhub/templates/devhub/versions/list.html:242
-#: src/olympia/devhub/templates/devhub/versions/list.html:276 src/olympia/devhub/templates/devhub/versions/list.html:317 src/olympia/reviews/templates/reviews/edit_review.html:16
+#: src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:43 src/olympia/devhub/templates/devhub/personas/edit.html:222 src/olympia/devhub/templates/devhub/versions/add_file_modal.html:59
+#: src/olympia/devhub/templates/devhub/versions/edit.html:140 src/olympia/devhub/templates/devhub/versions/list.html:208 src/olympia/devhub/templates/devhub/versions/list.html:239
+#: src/olympia/devhub/templates/devhub/versions/list.html:281 src/olympia/devhub/templates/devhub/versions/list.html:315 src/olympia/reviews/templates/reviews/edit_review.html:16
 #: src/olympia/translations/templates/translations/trans-menu.html:50 src/olympia/translations/templates/translations/trans-menu.html:62 src/olympia/zadmin/templates/zadmin/validation.html:105
 msgid "Cancel"
 msgstr "ยกเลิก"
@@ -860,7 +874,7 @@ msgstr "ดู<a href=\"%(support)s\">ส่วนการสนับสนุ
 msgid "Review Guidelines"
 msgstr "แนวทางการวิจารณ์"
 
-#: src/olympia/addons/templates/addons/review_list_box.html:5 src/olympia/addons/templates/addons/impala/details-more.html:27 src/olympia/editors/helpers.py:921
+#: src/olympia/addons/templates/addons/review_list_box.html:5 src/olympia/addons/templates/addons/impala/details-more.html:27 src/olympia/editors/helpers.py:1001
 #: src/olympia/reviews/templates/reviews/add.html:14 src/olympia/reviews/templates/reviews/reply.html:14 src/olympia/reviews/templates/reviews/review_list.html:19
 #: src/olympia/reviews/templates/reviews/mobile/review_list.html:26
 msgid "Reviews"
@@ -880,6 +894,7 @@ msgstr "แสดงการตอบกลับของนักพัฒน
 msgid "See all reviews of this add-on"
 msgid_plural "See all %(cnt)s reviews of this add-on"
 msgstr[0] "ดูบทวิจารณ์ทั้งหมดของส่วนเสริมนี้"
+msgstr[1] ""
 
 #: src/olympia/addons/templates/addons/tags_box.html:3 src/olympia/devhub/templates/devhub/addons/edit/basic.html:118
 msgid "Tags"
@@ -948,118 +963,121 @@ msgstr "บางส่วนของชุดสะสมเหล่านี
 msgid "Other add-ons by %(author)s"
 msgid_plural "Other add-ons by these authors"
 msgstr[0] "ส่วนเสริมอื่นโดย %(author)s"
+msgstr[1] ""
 
-#: src/olympia/addons/templates/addons/impala/details.html:41
+#: src/olympia/addons/templates/addons/impala/details.html:39
 #, python-format
 msgid "<span itemprop=\"ratingCount\">%(num)s</span> user review"
 msgid_plural "<span itemprop=\"ratingCount\">%(num)s</span> user reviews"
 msgstr[0] "<span itemprop=\"ratingCount\">%(num)s</span> การวิจารณ์ของผู้ใช้"
+msgstr[1] ""
 
-#: src/olympia/addons/templates/addons/impala/details.html:69
+#: src/olympia/addons/templates/addons/impala/details.html:66
 msgid "View statistics"
 msgstr "ดูสถิติ"
 
-#: src/olympia/addons/templates/addons/impala/details.html:84
+#: src/olympia/addons/templates/addons/impala/details.html:81
 msgid "Manage"
 msgstr "จัดการ"
 
 #. {0} is an add-on name.
-#: src/olympia/addons/templates/addons/impala/details.html:96
+#: src/olympia/addons/templates/addons/impala/details.html:93
 msgid "Icon of {0}"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/impala/details.html:103 src/olympia/addons/templates/addons/impala/listing/items.html:14
+#: src/olympia/addons/templates/addons/impala/details.html:100 src/olympia/addons/templates/addons/impala/listing/items.html:14
 msgid "No Restart"
 msgstr "ไม่ต้องเริ่มใหม่"
 
-#: src/olympia/addons/templates/addons/impala/details.html:127
+#: src/olympia/addons/templates/addons/impala/details.html:124
 #, fuzzy, python-format
 msgid "Meet the Developer: <a href=\"%(url)s\">%(name)s</a>"
 msgid_plural "<a href=\"%(url)s\">Meet the Developers</a>"
 msgstr[0] "พบกับนักพัฒนา: <a href=\"%(url)s\">%(name)s</a>"
+msgstr[1] ""
 
-#: src/olympia/addons/templates/addons/impala/details.html:137
+#: src/olympia/addons/templates/addons/impala/details.html:134
 msgid "Learn why {0} was created and find out what's next for this add-on."
 msgstr "เรียนรู้ว่าทำไม {0} จึงถูกสร้างขึ้นและค้นหาว่ามีอะไรต่อไปสำหรับส่วนเสริมนี้"
 
 #. {0} is an index.
-#: src/olympia/addons/templates/addons/impala/details.html:156
+#: src/olympia/addons/templates/addons/impala/details.html:161
 msgid "Add-on screenshot #{0}"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/impala/details.html:182
+#: src/olympia/addons/templates/addons/impala/details.html:187
 msgid "Add-on home page"
 msgstr "หน้าแรกของส่วนเสริม"
 
-#: src/olympia/addons/templates/addons/impala/details.html:185
+#: src/olympia/addons/templates/addons/impala/details.html:190
 msgid "Support site"
 msgstr "เว็บไซต์การสนับสนุน"
 
-#: src/olympia/addons/templates/addons/impala/details.html:189
+#: src/olympia/addons/templates/addons/impala/details.html:194
 msgid "Support E-mail"
 msgstr "อีเมลการสนับสนุน"
 
-#: src/olympia/addons/templates/addons/impala/details.html:194 src/olympia/devhub/models.py:378 src/olympia/devhub/templates/devhub/versions/list.html:12
+#: src/olympia/addons/templates/addons/impala/details.html:199 src/olympia/devhub/models.py:378 src/olympia/devhub/templates/devhub/versions/list.html:12
 #: src/olympia/versions/templates/versions/version.html:6 src/olympia/versions/templates/versions/mobile/version.html:6
 msgid "Version {0}"
 msgstr "รุ่น {0}"
 
-#: src/olympia/addons/templates/addons/impala/details.html:194
+#: src/olympia/addons/templates/addons/impala/details.html:199
 msgid "Info"
 msgstr "ข้อมูล"
 
-#: src/olympia/addons/templates/addons/impala/details.html:195 src/olympia/devhub/templates/devhub/includes/addon_details.html:129
+#: src/olympia/addons/templates/addons/impala/details.html:200 src/olympia/devhub/templates/devhub/includes/addon_details.html:116
 msgid "Last Updated:"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/impala/details.html:200
+#: src/olympia/addons/templates/addons/impala/details.html:205
 #, python-format
 msgid "Released under <a target=\"_blank\" href=\"%(url)s\">%(name)s</a>"
 msgstr "ออกภายใต้ <a target=\"_blank\" href=\"%(url)s\">%(name)s</a>"
 
-#: src/olympia/addons/templates/addons/impala/details.html:201 src/olympia/addons/templates/addons/impala/details.html:206 src/olympia/amo/helpers.py:398 src/olympia/devhub/forms.py:142
+#: src/olympia/addons/templates/addons/impala/details.html:206 src/olympia/addons/templates/addons/impala/details.html:211 src/olympia/amo/helpers.py:398 src/olympia/devhub/forms.py:142
 #: src/olympia/devhub/forms.py:173 src/olympia/versions/templates/versions/version.html:40 src/olympia/versions/templates/versions/version.html:45
 msgid "Custom License"
 msgstr "ใบอนุญาตที่กำหนดเอง"
 
-#: src/olympia/addons/templates/addons/impala/details.html:205
+#: src/olympia/addons/templates/addons/impala/details.html:210
 #, python-format
 msgid "Released under <a href=\"%(url)s\">%(name)s</a>"
 msgstr "ออกภายใต้ <a href=\"%(url)s\">%(name)s</a>"
 
-#: src/olympia/addons/templates/addons/impala/details.html:217
+#: src/olympia/addons/templates/addons/impala/details.html:222
 msgid "About this Add-on"
 msgstr "เกี่ยวกับส่วนเสริมนี้"
 
-#: src/olympia/addons/templates/addons/impala/details.html:233
+#: src/olympia/addons/templates/addons/impala/details.html:238
 msgid "Developer’s Comments"
 msgstr "ความคิดเห็นของนักพัฒนา"
 
-#: src/olympia/addons/templates/addons/impala/details.html:243
+#: src/olympia/addons/templates/addons/impala/details.html:248
 msgid "Version Information"
 msgstr "ข้อมูลของรุ่น"
 
-#: src/olympia/addons/templates/addons/impala/details.html:250
+#: src/olympia/addons/templates/addons/impala/details.html:255
 msgid "See complete version history"
 msgstr "ดูประวัติของรุ่นแบบเต็ม"
 
-#: src/olympia/addons/templates/addons/impala/details.html:262
+#: src/olympia/addons/templates/addons/impala/details.html:267
 msgid ""
 "The Development Channel lets you test an experimental new version of this add-on before it's released to the general public. Once you install the development version, you will continue to get "
 "updates from this channel. To stop receiving development updates, reinstall the default version from the link above."
 msgstr "ช่องการพัฒนาเชิญชวนให้คุณทดสอบรุ่นทดลองใหม่ของส่วนเสริมนี้ก่อนจะถูกปล่อยสู่สาธารณะ เมื่อคุณติดตั้งรุ่นพัฒนา คุณจะยังคงได้รับการปรับปรุงจากช่องนี้ เพื่อหยุดการปรับปรุงเป็นรุ่นพัฒนา ให้ติดตั้งรุ่นปกติจากลิงก์ด้านบน"
 
-#: src/olympia/addons/templates/addons/impala/details.html:272
+#: src/olympia/addons/templates/addons/impala/details.html:277
 msgid "<strong>Caution:</strong> Development versions of this add-on have not been reviewed by Mozilla."
 msgstr ""
 
-#: src/olympia/addons/templates/addons/impala/details.html:287
+#: src/olympia/addons/templates/addons/impala/details.html:292
 msgid "See complete development channel history"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/impala/details.html:306 src/olympia/addons/templates/addons/impala/details.html:315 src/olympia/addons/templates/addons/impala/details.html:327
+#: src/olympia/addons/templates/addons/impala/details.html:311 src/olympia/addons/templates/addons/impala/details.html:320 src/olympia/addons/templates/addons/impala/details.html:332
 #: src/olympia/addons/templates/addons/impala/review_add_box.html:4 src/olympia/stats/templates/stats/popup.html:2 src/olympia/stats/templates/stats/popup.html:8
-#: src/olympia/stats/templates/stats/stats.html:202 src/olympia/users/templates/users/profile.html:119
+#: src/olympia/stats/templates/stats/stats.html:204 src/olympia/users/templates/users/profile.html:119
 msgid "close"
 msgstr "ปิด"
 
@@ -1089,6 +1107,7 @@ msgstr "มีอะไรต่อไปสำหรับ {0}"
 msgid "About the Developer"
 msgid_plural "About the Developers"
 msgstr[0] "เกี่ยวกับนักพัฒนา"
+msgstr[1] ""
 
 #: src/olympia/addons/templates/addons/impala/developers.html:96 src/olympia/users/templates/users/edit.html:130 src/olympia/users/templates/users/profile.html:26
 msgid "No Photo"
@@ -1114,15 +1133,11 @@ msgstr "ใบอนุญาตซอร์สโค้ดของ {addon}"
 msgid "Source Code License"
 msgstr "ใบอนุญาตซอร์สโค้ด"
 
-#: src/olympia/addons/templates/addons/impala/persona_grid.html:16 src/olympia/addons/templates/addons/impala/toplist.html:6
-msgid "{0} users"
-msgstr "{0} ผู้ใช้"
-
 #: src/olympia/addons/templates/addons/impala/review_list_box.html:19 src/olympia/reviews/templates/reviews/review.html:40
 msgid "permalink"
 msgstr "ลิงก์ถาวร"
 
-#: src/olympia/addons/templates/addons/impala/review_list_box.html:23 src/olympia/editors/templates/editors/queue.html:98 src/olympia/reviews/templates/reviews/review.html:44
+#: src/olympia/addons/templates/addons/impala/review_list_box.html:23 src/olympia/editors/templates/editors/queue.html:104 src/olympia/reviews/templates/reviews/review.html:44
 msgid "translate"
 msgstr ""
 
@@ -1131,6 +1146,7 @@ msgstr ""
 msgid "See all user reviews"
 msgid_plural "See all %(cnt)s user reviews"
 msgstr[0] "ดูบทวิจารณ์ของผู้ใช้ทั้งหมด"
+msgstr[1] ""
 
 #: src/olympia/addons/templates/addons/impala/review_list_box.html:47 src/olympia/reviews/templates/reviews/review_list.html:84
 msgid "This add-on has not yet been reviewed."
@@ -1139,6 +1155,10 @@ msgstr "ส่วนเสริมนี้ยังไม่ถูกตรว
 #: src/olympia/addons/templates/addons/impala/review_list_box.html:50
 msgid "Be the first!"
 msgstr "เป็นคนแรก!"
+
+#: src/olympia/addons/templates/addons/impala/toplist.html:6
+msgid "{0} users"
+msgstr "{0} ผู้ใช้"
 
 #: src/olympia/addons/templates/addons/impala/listing/sorter.html:14 src/olympia/devhub/templates/devhub/addons/listing/item_actions.html:49
 msgid "More"
@@ -1152,7 +1172,7 @@ msgstr "เพิ่มไปยังชุดสะสม"
 msgid "My Add-ons"
 msgstr "ส่วนเสริมของฉัน"
 
-#: src/olympia/addons/templates/addons/includes/dashboard_tabs.html:6 src/olympia/amo/context_processors.py:51
+#: src/olympia/addons/templates/addons/includes/dashboard_tabs.html:6 src/olympia/amo/context_processors.py:50
 msgid "My Themes"
 msgstr "ชุดตกแต่งของฉัน"
 
@@ -1193,6 +1213,7 @@ msgstr "ยังไม่ถูกจัดอันดับ"
 msgid "<strong>{0}</strong> weekly download"
 msgid_plural "<strong>{0}</strong> weekly downloads"
 msgstr[0] "<strong>{0}</strong> ดาวน์โหลดต่อสัปดาห์"
+msgstr[1] ""
 
 #: src/olympia/addons/templates/addons/mobile/details.html:32
 msgid "Read More"
@@ -1206,7 +1227,7 @@ msgstr "ผู้ใช้"
 msgid "Weekly Downloads"
 msgstr "การดาวน์โหลดต่อสัปดาห์"
 
-#: src/olympia/addons/templates/addons/mobile/details.html:99 src/olympia/compat/templates/compat/reporter_detail.html:46 src/olympia/devhub/forms.py:787
+#: src/olympia/addons/templates/addons/mobile/details.html:99 src/olympia/compat/templates/compat/reporter_detail.html:46 src/olympia/devhub/forms.py:788
 #: src/olympia/devhub/templates/devhub/versions/list.html:163
 msgid "Version"
 msgstr "รุ่น"
@@ -1290,7 +1311,7 @@ msgstr ""
 #: src/olympia/browse/templates/browse/personas/category_landing.html:21 src/olympia/browse/templates/browse/personas/category_landing.html:23
 #: src/olympia/browse/templates/browse/personas/category_landing.html:38 src/olympia/browse/templates/browse/personas/grid.html:7 src/olympia/browse/templates/browse/personas/grid.html:11
 #: src/olympia/browse/templates/browse/personas/mobile/base.html:7 src/olympia/browse/templates/browse/personas/mobile/category_landing.html:19 src/olympia/constants/base.py:180
-#: src/olympia/devhub/templates/devhub/personas/submit.html:13 src/olympia/editors/helpers.py:105 src/olympia/editors/templates/editors/base.html:26
+#: src/olympia/devhub/templates/devhub/personas/submit.html:13 src/olympia/editors/helpers.py:107 src/olympia/editors/templates/editors/base.html:26
 #: src/olympia/editors/templates/editors/performance.html:73 src/olympia/search/templates/search/personas.html:39 src/olympia/templates/menu_links.html:9
 msgid "Themes"
 msgstr "ชุดตกแต่ง"
@@ -1311,7 +1332,7 @@ msgstr "ส่วนเสริมเพิ่มเติม"
 msgid "Highest Rated"
 msgstr "การจัดอันดับสูงสุด"
 
-#: src/olympia/addons/templates/addons/mobile/home.html:74 src/olympia/amo/templates/amo/side_nav.html:5 src/olympia/amo/templates/amo/site_nav.html:27 src/olympia/amo/templates/amo/site_nav.html:57
+#: src/olympia/addons/templates/addons/mobile/home.html:74 src/olympia/amo/templates/amo/side_nav.html:5 src/olympia/amo/templates/amo/site_nav.html:27 src/olympia/amo/templates/amo/site_nav.html:55
 #: src/olympia/bandwagon/views.py:97 src/olympia/browse/views.py:57 src/olympia/browse/views.py:67 src/olympia/browse/templates/browse/personas/mobile/category_landing.html:65
 #: src/olympia/search/forms.py:15 src/olympia/search/forms.py:87
 msgid "Newest"
@@ -1325,90 +1346,90 @@ msgstr "ลองใช้ดู!"
 msgid "Theme Info &raquo;"
 msgstr ""
 
-#: src/olympia/amo/context_processors.py:39 src/olympia/devhub/templates/devhub/nav.html:43
+#: src/olympia/amo/context_processors.py:37 src/olympia/devhub/templates/devhub/nav.html:43
 msgid "Tools"
 msgstr "เครื่องมือ"
 
-#: src/olympia/amo/context_processors.py:48 src/olympia/discovery/templates/discovery/pane_account.html:8 src/olympia/users/templates/users/includes/navigation.html:2
+#: src/olympia/amo/context_processors.py:47 src/olympia/discovery/templates/discovery/pane_account.html:8 src/olympia/users/templates/users/includes/navigation.html:2
 msgid "My Profile"
 msgstr "ข้อมูลส่วนตัวของฉัน"
 
-#: src/olympia/amo/context_processors.py:54 src/olympia/users/templates/users/edit.html:5 src/olympia/users/templates/users/includes/navigation.html:3
+#: src/olympia/amo/context_processors.py:53 src/olympia/users/templates/users/edit.html:5 src/olympia/users/templates/users/includes/navigation.html:3
 msgid "Account Settings"
 msgstr "การตั้งค่าบัญชี"
 
-#: src/olympia/amo/context_processors.py:57 src/olympia/discovery/templates/discovery/pane_account.html:11 src/olympia/users/templates/users/profile.html:83
+#: src/olympia/amo/context_processors.py:56 src/olympia/discovery/templates/discovery/pane_account.html:11 src/olympia/users/templates/users/profile.html:83
 #: src/olympia/users/templates/users/includes/navigation.html:4
 msgid "My Collections"
 msgstr "ชุดสะสมของฉัน"
 
-#: src/olympia/amo/context_processors.py:62 src/olympia/discovery/templates/discovery/pane_account.html:10 src/olympia/users/templates/users/includes/navigation.html:7
+#: src/olympia/amo/context_processors.py:61 src/olympia/discovery/templates/discovery/pane_account.html:10 src/olympia/users/templates/users/includes/navigation.html:7
 msgid "My Favorites"
 msgstr "รายการโปรดของฉัน"
 
-#: src/olympia/amo/context_processors.py:67 src/olympia/discovery/templates/discovery/pane_account.html:13 src/olympia/templates/impala/user_login.html:14
+#: src/olympia/amo/context_processors.py:66 src/olympia/discovery/templates/discovery/pane_account.html:13 src/olympia/templates/impala/user_login.html:14
 #: src/olympia/templates/mobile/header_auth.html:5
 msgid "Log out"
 msgstr "ออกจากระบบ"
 
-#: src/olympia/amo/context_processors.py:72 src/olympia/devhub/templates/devhub/addons/dashboard.html:4
+#: src/olympia/amo/context_processors.py:71 src/olympia/devhub/templates/devhub/addons/dashboard.html:4
 msgid "Manage My Submissions"
 msgstr ""
 
-#: src/olympia/amo/context_processors.py:75 src/olympia/devhub/templates/devhub/nav.html:27 src/olympia/devhub/templates/devhub/addons/dashboard.html:25
+#: src/olympia/amo/context_processors.py:74 src/olympia/devhub/templates/devhub/nav.html:27 src/olympia/devhub/templates/devhub/addons/dashboard.html:25
 #: src/olympia/devhub/templates/devhub/addons/submit/base.html:4
 msgid "Submit a New Add-on"
 msgstr "ส่งส่วนเสริมใหม่"
 
-#: src/olympia/amo/context_processors.py:77 src/olympia/browse/templates/browse/personas/base.html:50 src/olympia/devhub/templates/devhub/index.html:24
+#: src/olympia/amo/context_processors.py:76 src/olympia/browse/templates/browse/personas/base.html:50 src/olympia/devhub/templates/devhub/index.html:24
 #: src/olympia/devhub/templates/devhub/addons/dashboard.html:29
 msgid "Submit a New Theme"
 msgstr "ส่งชุดตกแต่งใหม่"
 
-#: src/olympia/amo/context_processors.py:79 src/olympia/amo/templates/amo/site_nav.html:87 src/olympia/devhub/helpers.py:36 src/olympia/devhub/helpers.py:68 src/olympia/devhub/helpers.py:102
+#: src/olympia/amo/context_processors.py:78 src/olympia/amo/templates/amo/site_nav.html:85 src/olympia/devhub/helpers.py:36 src/olympia/devhub/helpers.py:68 src/olympia/devhub/helpers.py:102
 #: src/olympia/templates/footer.html:6 src/olympia/templates/menu_links.html:14
 msgid "Developer Hub"
 msgstr "ศูนย์กลางนักพัฒนา"
 
-#: src/olympia/amo/context_processors.py:83 src/olympia/devhub/views.py:1792
+#: src/olympia/amo/context_processors.py:81 src/olympia/devhub/views.py:1796
 msgid "Manage API Keys"
 msgstr ""
 
-#: src/olympia/amo/context_processors.py:88 src/olympia/editors/helpers.py:82 src/olympia/editors/helpers.py:102 src/olympia/editors/templates/editors/base.html:10
+#: src/olympia/amo/context_processors.py:86 src/olympia/editors/helpers.py:84 src/olympia/editors/helpers.py:104 src/olympia/editors/templates/editors/base.html:10
 msgid "Editor Tools"
 msgstr "เครื่องมือแก้ไข"
 
-#: src/olympia/amo/context_processors.py:92
+#: src/olympia/amo/context_processors.py:90
 msgid "Admin Tools"
 msgstr "เครื่องมือผู้ดูแลระบบ"
 
-#: src/olympia/amo/fields.py:15
+#: src/olympia/amo/fields.py:20
 msgid "Incorrect, please try again."
 msgstr ""
 
-#: src/olympia/amo/fields.py:16
+#: src/olympia/amo/fields.py:21
 msgid "Error verifying input, please try again."
 msgstr ""
 
-#: src/olympia/amo/fields.py:32
+#: src/olympia/amo/fields.py:37
 msgid "This must be a valid hex color code, such as #000000."
 msgstr "สิ่งนี้ต้องเป็นโค้ดสี hex ที่ถูกต้อง เช่น #000000"
 
-#: src/olympia/amo/fields.py:58
+#: src/olympia/amo/fields.py:63
 msgid "Enter at least one value."
 msgstr ""
 
-#: src/olympia/amo/helpers.py:162 src/olympia/amo/templates/amo/site_nav.html:61 src/olympia/bandwagon/templates/bandwagon/add.html:9
+#: src/olympia/amo/helpers.py:162 src/olympia/amo/templates/amo/site_nav.html:59 src/olympia/bandwagon/templates/bandwagon/add.html:9
 #: src/olympia/bandwagon/templates/bandwagon/collection_detail.html:15 src/olympia/bandwagon/templates/bandwagon/delete.html:9 src/olympia/bandwagon/templates/bandwagon/edit.html:15
 #: src/olympia/bandwagon/templates/bandwagon/user_listing.html:18 src/olympia/bandwagon/templates/bandwagon/user_listing.html:21
 #: src/olympia/bandwagon/templates/bandwagon/impala/collection_listing.html:12 src/olympia/bandwagon/templates/bandwagon/impala/collection_listing.html:20
 #: src/olympia/bandwagon/templates/bandwagon/impala/collection_listing.html:24 src/olympia/bandwagon/templates/bandwagon/impala/collection_sidebar.html:3
 #: src/olympia/bandwagon/templates/bandwagon/includes/collection_sidebar.html:2 src/olympia/bandwagon/templates/bandwagon/mobile/collection_listing.html:3
-#: src/olympia/stats/templates/stats/stats.html:77 src/olympia/templates/menu_links.html:12
+#: src/olympia/stats/templates/stats/stats.html:33 src/olympia/templates/menu_links.html:12
 msgid "Collections"
 msgstr "ชุดสะสม"
 
-#: src/olympia/amo/helpers.py:171 src/olympia/amo/templates/amo/site_nav.html:85 src/olympia/browse/templates/browse/language_tools.html:3
+#: src/olympia/amo/helpers.py:171 src/olympia/amo/templates/amo/site_nav.html:83 src/olympia/browse/templates/browse/language_tools.html:3
 msgid "Dictionaries & Language Packs"
 msgstr "พจนานุกรมและชุดภาษา"
 
@@ -1560,8 +1581,8 @@ msgstr ""
 msgid "Comment on {addon} {version}."
 msgstr "ความคิดเห็นบน {addon} {version}"
 
-#: src/olympia/amo/log.py:236 src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:19 src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:47
-#: src/olympia/editors/helpers.py:511 src/olympia/editors/templates/editors/themes/history_table.html:11
+#: src/olympia/amo/log.py:236 src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:17 src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:45
+#: src/olympia/editors/helpers.py:584 src/olympia/editors/templates/editors/themes/history_table.html:11
 msgid "Comment"
 msgstr "ความคิดเห็น"
 
@@ -1714,8 +1735,8 @@ msgid "Reviewer escalation"
 msgstr ""
 
 #: src/olympia/amo/log.py:442
-msgid "Video removed from {addon} because of a problem with the video."
-msgstr "วิดีโอถูกถอดออกจาก {addon} เนื่องจากเกิดปัญหาเกี่ยวกับวิดีโอ"
+msgid "Video removed from {addon} because of a problem with the video. "
+msgstr ""
 
 #: src/olympia/amo/log.py:444
 msgid "Video removed"
@@ -1888,7 +1909,7 @@ msgstr "ก่อนหน้า"
 #: src/olympia/amo/templates/amo/mobile/paginator.html:14 src/olympia/amo/templates/amo/mobile/paginator.html:16 src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:51
 #: src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:65 src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:78
 #: src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:91 src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:104
-#: src/olympia/discovery/templates/discovery/pane.html:45 src/olympia/discovery/templates/discovery/addons/detail.html:39 src/olympia/stats/templates/stats/stats.html:167
+#: src/olympia/discovery/templates/discovery/pane.html:45 src/olympia/discovery/templates/discovery/addons/detail.html:39 src/olympia/stats/templates/stats/stats.html:169
 msgid "Next"
 msgstr "ถัดไป"
 
@@ -1920,7 +1941,7 @@ msgid ""
 msgstr ""
 
 #: src/olympia/amo/templates/amo/side_nav.html:4 src/olympia/amo/templates/amo/side_nav.html:12 src/olympia/amo/templates/amo/site_nav.html:4 src/olympia/amo/templates/amo/site_nav.html:26
-#: src/olympia/browse/views.py:56 src/olympia/browse/views.py:66 src/olympia/browse/views.py:237 src/olympia/browse/views.py:282 src/olympia/search/forms.py:86
+#: src/olympia/browse/views.py:56 src/olympia/browse/views.py:66 src/olympia/browse/views.py:204 src/olympia/browse/views.py:249 src/olympia/search/forms.py:86
 msgid "Top Rated"
 msgstr "ถูกจัดอันดับสูงสุด"
 
@@ -1934,38 +1955,38 @@ msgstr "สำรวจ"
 msgid "Extensions"
 msgstr "ส่วนขยาย"
 
-#: src/olympia/amo/templates/amo/site_nav.html:45
+#: src/olympia/amo/templates/amo/site_nav.html:44
 msgid "Want more customization? Try <b>Complete Themes</b>"
 msgstr ""
 
-#: src/olympia/amo/templates/amo/site_nav.html:56 src/olympia/bandwagon/views.py:96
+#: src/olympia/amo/templates/amo/site_nav.html:54 src/olympia/bandwagon/views.py:96
 msgid "Most Followers"
 msgstr "ติดตามมากที่สุด"
 
-#: src/olympia/amo/templates/amo/site_nav.html:68 src/olympia/bandwagon/templates/bandwagon/impala/collection_sidebar.html:16
+#: src/olympia/amo/templates/amo/site_nav.html:66 src/olympia/bandwagon/templates/bandwagon/impala/collection_sidebar.html:16
 #: src/olympia/bandwagon/templates/bandwagon/includes/collection_sidebar.html:18
 msgid "Collections I've Made"
 msgstr "ชุดสะสมที่ฉันสร้าง"
 
-#: src/olympia/amo/templates/amo/site_nav.html:70 src/olympia/bandwagon/templates/bandwagon/user_listing.html:4 src/olympia/bandwagon/templates/bandwagon/impala/collection_sidebar.html:13
+#: src/olympia/amo/templates/amo/site_nav.html:68 src/olympia/bandwagon/templates/bandwagon/user_listing.html:4 src/olympia/bandwagon/templates/bandwagon/impala/collection_sidebar.html:13
 #: src/olympia/bandwagon/templates/bandwagon/includes/collection_sidebar.html:15
 msgid "Collections I'm Following"
 msgstr "ชุดสะสมที่ฉันติดตาม"
 
-#: src/olympia/amo/templates/amo/site_nav.html:73 src/olympia/bandwagon/templates/bandwagon/impala/collection_sidebar.html:18
-#: src/olympia/bandwagon/templates/bandwagon/includes/collection_sidebar.html:20 src/olympia/users/models.py:512
+#: src/olympia/amo/templates/amo/site_nav.html:71 src/olympia/bandwagon/templates/bandwagon/impala/collection_sidebar.html:18
+#: src/olympia/bandwagon/templates/bandwagon/includes/collection_sidebar.html:20 src/olympia/users/models.py:521
 msgid "My Favorite Add-ons"
 msgstr "ส่วนเสริมโปรดของฉัน"
 
-#: src/olympia/amo/templates/amo/site_nav.html:78
+#: src/olympia/amo/templates/amo/site_nav.html:76
 msgid "More&hellip;"
 msgstr "เพิ่มเติม&hellip;"
 
-#: src/olympia/amo/templates/amo/site_nav.html:82
+#: src/olympia/amo/templates/amo/site_nav.html:80
 msgid "Add-ons for Mobile"
 msgstr "ส่วนเสริมสำหรับมือถือ"
 
-#: src/olympia/amo/templates/amo/site_nav.html:86 src/olympia/browse/feeds.py:207 src/olympia/browse/templates/browse/search_tools.html:3 src/olympia/constants/base.py:176
+#: src/olympia/amo/templates/amo/site_nav.html:84 src/olympia/browse/feeds.py:207 src/olympia/browse/templates/browse/search_tools.html:3 src/olympia/constants/base.py:176
 #: src/olympia/templates/menu_links.html:10
 msgid "Search Tools"
 msgstr "เครื่องมือค้นหา"
@@ -1981,7 +2002,7 @@ msgid "Jump to first page"
 msgstr "กระโดดไปยังหน้าแรก"
 
 #: src/olympia/amo/templates/amo/impala/paginator.html:22 src/olympia/amo/templates/amo/mobile/impala_paginator.html:12 src/olympia/discovery/templates/discovery/pane.html:44
-#: src/olympia/discovery/templates/discovery/addons/detail.html:38 src/olympia/stats/templates/stats/stats.html:164
+#: src/olympia/discovery/templates/discovery/addons/detail.html:38 src/olympia/stats/templates/stats/stats.html:166
 msgid "Previous"
 msgstr "ก่อนหน้า"
 
@@ -2002,31 +2023,51 @@ msgstr "กำลังแสดง <b>%(begin)s</b>&ndash;<b>%(end)s</b> จา
 msgid "Page {n}"
 msgid_plural "Page {n}"
 msgstr[0] "หน้า"
+msgstr[1] ""
 
-#: src/olympia/amo/templates/services/install.html:38
-#, python-format
-msgid "If you are not prompted to install %(addon_name)s in a moment, please <a href=\"%(addon_xpi)s\">click here</a>."
-msgstr "ถ้าคุณไม่ได้รับการแจ้งให้ติดตั้ง %(addon_name)s ในชั่วขณะ โปรด<a href=\"%(addon_xpi)s\">คลิกที่นี่</a>"
-
-#: src/olympia/amo/tests/test_messages.py:57 src/olympia/amo/tests/test_messages.py:58 src/olympia/reviews/forms.py:25 src/olympia/reviews/forms.py:50 src/olympia/reviews/templates/reviews/add.html:56
+#: src/olympia/amo/tests/test_messages.py:56 src/olympia/amo/tests/test_messages.py:57 src/olympia/reviews/forms.py:25 src/olympia/reviews/forms.py:50 src/olympia/reviews/templates/reviews/add.html:56
 #: src/olympia/reviews/templates/reviews/reply.html:30
 msgid "Title"
 msgstr "หัวข้อ"
 
-#: src/olympia/amo/tests/test_messages.py:57 src/olympia/amo/tests/test_messages.py:58
+#: src/olympia/amo/tests/test_messages.py:56 src/olympia/amo/tests/test_messages.py:57
 msgid "Body"
 msgstr "เนื้อหา"
 
-#: src/olympia/amo/tests/test_messages.py:59
+#: src/olympia/amo/tests/test_messages.py:58
 msgid "Another Title"
 msgstr "หัวข้ออื่น"
 
-#: src/olympia/amo/tests/test_messages.py:59
+#: src/olympia/amo/tests/test_messages.py:58
 msgid "Another Body"
 msgstr "เนื้อหาอื่น"
 
-#: src/olympia/api/views.py:255
-msgid "Not implemented yet."
+#: src/olympia/api/authentication.py:76
+msgid "Signature has expired."
+msgstr ""
+
+#: src/olympia/api/authentication.py:79
+msgid "Error decoding signature."
+msgstr ""
+
+#: src/olympia/api/authentication.py:82
+msgid "Invalid JWT Token."
+msgstr ""
+
+#: src/olympia/api/authentication.py:130
+msgid "Invalid Authorization header. No credentials provided."
+msgstr ""
+
+#: src/olympia/api/authentication.py:133
+msgid "Invalid Authorization header. Credentials string should not contain spaces."
+msgstr ""
+
+#: src/olympia/api/fields.py:29
+msgid "The field must have a length of at least {num} characters."
+msgstr ""
+
+#: src/olympia/api/fields.py:31
+msgid "The language code {lang_code} is invalid."
 msgstr ""
 
 #: src/olympia/applications/views.py:39 src/olympia/applications/templates/applications/appversions.html:3
@@ -2045,7 +2086,7 @@ msgstr "รุ่นแอพพลิเคชันที่ถูกต้อ
 msgid "Add-ons submitted to Mozilla Add-ons must have a manifest file with at least one of the below applications supported. Only the versions listed below are allowed for these applications."
 msgstr ""
 
-#: src/olympia/applications/templates/applications/appversions.html:25
+#: src/olympia/applications/templates/applications/appversions.html:25 src/olympia/editors/helpers.py:361
 msgid "GUID"
 msgstr "GUID"
 
@@ -2159,8 +2200,8 @@ msgstr "รายการโปรด"
 msgid "Remove from favorites"
 msgstr "เอาออกจากรายการโปรด"
 
-#: src/olympia/bandwagon/views.py:98 src/olympia/bandwagon/views.py:191 src/olympia/browse/views.py:58 src/olympia/browse/views.py:69 src/olympia/browse/views.py:458 src/olympia/devhub/views.py:74
-#: src/olympia/devhub/views.py:82 src/olympia/devhub/templates/devhub/addons/edit/basic.html:20 src/olympia/editors/templates/editors/leaderboard.html:24
+#: src/olympia/bandwagon/views.py:98 src/olympia/bandwagon/views.py:191 src/olympia/browse/views.py:58 src/olympia/browse/views.py:69 src/olympia/browse/views.py:425 src/olympia/devhub/views.py:72
+#: src/olympia/devhub/views.py:80 src/olympia/devhub/templates/devhub/addons/edit/basic.html:20 src/olympia/editors/templates/editors/leaderboard.html:24
 #: src/olympia/editors/templates/editors/themes/queue_list.html:48 src/olympia/search/forms.py:17 src/olympia/search/forms.py:89 src/olympia/users/templates/users/vcard.html:5
 msgid "Name"
 msgstr "ชื่อ"
@@ -2169,7 +2210,7 @@ msgstr "ชื่อ"
 msgid "Recently Popular"
 msgstr "ที่นิยมเร็ว ๆ นี้"
 
-#: src/olympia/bandwagon/views.py:189 src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:18
+#: src/olympia/bandwagon/views.py:189 src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:16
 msgid "Added"
 msgstr "เพิ่มแล้ว"
 
@@ -2183,7 +2224,7 @@ msgstr "สร้างชุดสะสมแล้ว!"
 
 #: src/olympia/bandwagon/views.py:316
 #, python-format
-msgid "Your new collection is shown below. You can <ahref=\"%(url)s\">edit additional settings</a> if you'dlike."
+msgid "Your new collection is shown below. You can <a href=\"%(url)s\">edit additional settings</a> if you'd like."
 msgstr ""
 
 #: src/olympia/bandwagon/views.py:322
@@ -2263,6 +2304,7 @@ msgstr "ส่วนตัว"
 msgid "<span>%(num)s</span> follower"
 msgid_plural "<span>%(num)s</span> followers"
 msgstr[0] "มีผู้ติดตาม <span>%(num)s</span> คน"
+msgstr[1] ""
 
 #: src/olympia/bandwagon/templates/bandwagon/collection_detail.html:54
 msgid "About this Collection"
@@ -2301,15 +2343,17 @@ msgstr "ลบชุดสะสม"
 msgid "%(num)s Theme in this Collection"
 msgid_plural "%(num)s Themes in this Collection"
 msgstr[0] "%(num)s ชุดตกแต่งในชุดสะสมนี้"
+msgstr[1] ""
 
 #: src/olympia/bandwagon/templates/bandwagon/collection_detail.html:111
 #, python-format
 msgid "%(num)s Add-on in this Collection"
 msgid_plural "%(num)s Add-ons in this Collection"
 msgstr[0] "%(num)s ส่วนเสริมในชุดสะสมนี้"
+msgstr[1] ""
 
-#: src/olympia/bandwagon/templates/bandwagon/collection_detail.html:125 src/olympia/compat/templates/compat/index.html:25 src/olympia/compat/templates/compat/reporter_detail.html:29
-#: src/olympia/files/templates/files/viewer.html:29 src/olympia/templates/amo_footer.html:17 src/olympia/templates/includes/lang_switcher.html:10
+#: src/olympia/bandwagon/templates/bandwagon/collection_detail.html:125 src/olympia/compat/templates/compat/reporter_detail.html:29 src/olympia/files/templates/files/viewer.html:29
+#: src/olympia/templates/amo_footer.html:17 src/olympia/templates/includes/lang_switcher.html:10
 msgid "Go"
 msgstr "ไป"
 
@@ -2343,11 +2387,9 @@ msgstr ""
 
 #: src/olympia/bandwagon/templates/bandwagon/collection_detail.html:186
 msgid ""
-"Add-ons that you mark as favorites using the <b>Add to Favorites</b> feature appear below. This collection is currently <b>private</b>, which means only you can see it. If you would like everyone "
+"Add-ons that you mark as favorites using the <b>Add to Favorites</b> feature appear below. This collection is currently <b>private</b>, which means only you can see it.  If you would like everyone "
 "to be able to see your favorites, click the button below to make it public."
 msgstr ""
-"ส่วนเสริมที่คุณทำเครื่องหมายเป็นรายการโปรดโดยใช้คุณสมบัติ<b>เพิ่มไปยังรายการโปรด</b>ปรากฏอยู่ด้านล่าง ชุดสะสมนี้เป็น<b>ส่วนตัว</b>ในปัจจุบัน ซึ่งหมายความว่าเฉพาะคุณเท่านั้นที่สามารถเห็นมันได้ "
-"ถ้าคุณต้องการให้ทุกคนสามารถเห็นรายการโปรดของคุณได้ให้คลิกปุ่มที่อยู่ด้านล่างเพื่อทำให้มันเป็นสาธารณะ"
 
 #: src/olympia/bandwagon/templates/bandwagon/collection_detail.html:196
 msgid "My favorite add-ons"
@@ -2358,12 +2400,14 @@ msgstr "ส่วนเสริมโปรดของฉัน"
 msgid "<span>%(addons)s</span> add-on"
 msgid_plural "<span>%(addons)s</span> add-ons"
 msgstr[0] "<span>%(addons)s</span> ส่วนเสริม"
+msgstr[1] ""
 
 #: src/olympia/bandwagon/templates/bandwagon/collection_grid.html:32
 #, python-format
 msgid "<span>%(followers)s</span> follower"
 msgid_plural "<span>%(followers)s</span> followers"
 msgstr[0] ""
+msgstr[1] ""
 
 #. People "follow" collections to get notified of updates.                    Like
 #. Twitter followers.
@@ -2374,6 +2418,7 @@ msgstr[0] ""
 msgid "%(num)s weekly follower"
 msgid_plural "%(num)s weekly followers"
 msgstr[0] "%(num)s ผู้ติดตามรายสัปดาห์"
+msgstr[1] ""
 
 #. People "follow" collections to get notified of updates.                    Like
 #. Twitter followers.
@@ -2382,6 +2427,7 @@ msgstr[0] "%(num)s ผู้ติดตามรายสัปดาห์"
 msgid "%(num)s monthly follower"
 msgid_plural "%(num)s monthly followers"
 msgstr[0] "%(num)s ผู้ติดตามรายเดือน"
+msgstr[1] ""
 
 #. People "follow" collections to get notified of updates.                    Like
 #. Twitter followers.
@@ -2392,6 +2438,7 @@ msgstr[0] "%(num)s ผู้ติดตามรายเดือน"
 msgid "%(num)s follower"
 msgid_plural "%(num)s followers"
 msgstr[0] "%(num)s ผู้ติดตาม"
+msgstr[1] ""
 
 #: src/olympia/bandwagon/templates/bandwagon/collection_listing_items.html:56 src/olympia/bandwagon/templates/bandwagon/impala/collection_listing_items.html:9
 #: src/olympia/devhub/templates/devhub/personas/edit.html:27
@@ -2475,7 +2522,7 @@ msgid "Remove this user as a contributor"
 msgstr "เอาผู้ใช้นี้ออกจากการเป็นผู้มีส่วนร่วม"
 
 #: src/olympia/bandwagon/templates/bandwagon/edit_contributors.html:18 src/olympia/bandwagon/templates/bandwagon/edit_contributors.html:43
-#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:20 src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:48
+#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:18 src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:46
 #: src/olympia/devhub/templates/devhub/addons/ajax_compat_update.html:19
 msgid "Remove"
 msgstr "เอาออก"
@@ -2486,10 +2533,9 @@ msgstr "ผู้มีส่วนร่วมชุดสะสม"
 
 #: src/olympia/bandwagon/templates/bandwagon/edit_contributors.html:26
 msgid ""
-"You can add multiple contributors to this collection. A contributor can add and remove add-ons from this collection, but cannot change its name or description. To add a contributor, enter their "
+"You can add multiple contributors to this collection.  A contributor can add and remove add-ons from this collection, but cannot change its name or description.  To add a contributor, enter their "
 "email in the box below. Contributors must have a Mozilla Add-ons account."
 msgstr ""
-"คุณสามารถเพิ่มผู้มีส่วนร่วมหลายคนให้กับชุดสะสมนี้ ผู้มีส่วนร่วมสามารถเพิ่มและเอาส่วนเสริมออกจากชุดสะสมนี้ แต่ไม่สามารถเปลี่ยนชื่อหรือคำอธิบายของมันได้ ในการเพิ่มผู้มีส่วนร่วม ให้ใส่อีเมลของพวกเขาในกล่องด้านล่าง ผู้มีส่วนร่วมต้องมีบัญชีของ Mozilla Add-ons"
 
 #: src/olympia/bandwagon/templates/bandwagon/edit_contributors.html:40
 msgid "User"
@@ -2524,7 +2570,7 @@ msgid "<b>Warning:</b> By changing the owner of this collection, you will no lon
 msgstr "<b>คำเตือน:</b> การเปลี่ยนเจ้าของของชุดสะสมนี้ คุณจะไม่สามารถแก้ไขมันได้อีก คุณจะสามารถทำได้เพียงเพิ่มหรือลบส่วนเสริมที่อยู่ในนั้นออกเท่านั้น"
 
 #: src/olympia/bandwagon/templates/bandwagon/edit_contributors.html:83 src/olympia/devhub/templates/devhub/addons/forms_shared/media.html:157
-#: src/olympia/devhub/templates/devhub/addons/submit/describe.html:69 src/olympia/devhub/templates/devhub/addons/submit/license.html:60 src/olympia/devhub/templates/devhub/addons/submit/upload.html:78
+#: src/olympia/devhub/templates/devhub/addons/submit/describe.html:69 src/olympia/devhub/templates/devhub/addons/submit/license.html:60 src/olympia/devhub/templates/devhub/addons/submit/upload.html:70
 #: src/olympia/devhub/templates/devhub/payments/tier.html:17 src/olympia/editors/templates/editors/themes/themes.html:111 src/olympia/editors/templates/editors/themes/themes.html:128
 #: src/olympia/editors/templates/editors/themes/themes.html:134 src/olympia/editors/templates/editors/themes/themes.html:141 src/olympia/users/templates/users/fxa_migration_prompt_content.html:10
 #: src/olympia/users/templates/users/login_form.html:42 src/olympia/users/templates/users/mobile/login.html:57
@@ -2595,8 +2641,8 @@ msgid "Reset"
 msgstr "ตั้งค่าใหม่"
 
 #: src/olympia/bandwagon/templates/bandwagon/includes/addedit.html:53
-msgid "PNG and JPG supported. Image will be resized to 32x32."
-msgstr "รองรับ PNG และ JPG รูปจะถูกย่อที่ขนาด 32x32"
+msgid "PNG and JPG supported.  Image will be resized to 32x32."
+msgstr ""
 
 #: src/olympia/bandwagon/templates/bandwagon/includes/addedit_errors.html:3
 msgid "There are errors in this form.  Please correct them below."
@@ -2607,31 +2653,31 @@ msgid "Add-ons in Your Collection"
 msgstr "ส่วนเสริมในชุดสะสมของคุณ"
 
 #: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:4
-msgid ""
-"To include an add-on in this collection, enter its name in the box below and hit enter. You can also use the <strong>Add to Collection</strong> links throughout the site to include add-ons later."
-msgstr "การเพิ่มส่วนเสริมในชุดสะสมนี้ ทำได้โดยใส่ชื่อของส่วนเสริมลงในช่องข้างล่างแล้วกดปุ่ม enter และคุณยังสามารถใช้ลิงก์ <strong>เพิ่มไปยังชุดสะสม</strong> ในเว็บเพื่อที่จะเพิ่มส่วนเสริมในภายหลัง"
+msgid "To include an add-on in this collection, enter its name in the box below and hit enter."
+msgstr ""
 
-#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:17 src/olympia/constants/base.py:400 src/olympia/devhub/templates/devhub/addons/activity.html:62
+#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:15 src/olympia/constants/base.py:400 src/olympia/devhub/templates/devhub/addons/activity.html:62
+#: src/olympia/editors/helpers.py:273 src/olympia/editors/helpers.py:360
 msgid "Add-on"
 msgstr "ส่วนเสริม"
 
-#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:26
+#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:24
 msgid "Enter the name of the add-on to include"
 msgstr "ใส่ชื่อของส่วนเสริมที่จะเพิ่ม"
 
-#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:28
+#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:26
 msgid "Add to Collection"
 msgstr "เพิ่งไปยังชุดสะสม"
 
-#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:45 src/olympia/editors/helpers.py:936 src/olympia/editors/helpers.py:956
+#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:43 src/olympia/editors/helpers.py:1016 src/olympia/editors/helpers.py:1036
 msgid "Pending"
 msgstr "รอดำเนินการอยู่"
 
-#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:47
+#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:45
 msgid "Add a comment"
 msgstr "เพิ่มความเห็น"
 
-#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:48
+#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:46
 msgid "Remove this add-on from the collection"
 msgstr "เอาส่วนเสริมนี้ออกจากชุดสะสม"
 
@@ -2738,12 +2784,12 @@ msgstr "เครื่องมือค้นหา"
 msgid "Most Users"
 msgstr "ผู้ใช้ส่วนใหญ่"
 
-#: src/olympia/browse/views.py:61 src/olympia/browse/views.py:72 src/olympia/browse/views.py:279 src/olympia/browse/templates/browse/personas/mobile/category_landing.html:63
+#: src/olympia/browse/views.py:61 src/olympia/browse/views.py:72 src/olympia/browse/views.py:246 src/olympia/browse/templates/browse/personas/mobile/category_landing.html:63
 #: src/olympia/discovery/templates/discovery/pane.html:67 src/olympia/search/forms.py:92
 msgid "Up & Coming"
 msgstr "กำลังจะมา"
 
-#: src/olympia/browse/views.py:460 src/olympia/devhub/views.py:76 src/olympia/devhub/views.py:83 src/olympia/discovery/templates/discovery/addons/detail.html:66
+#: src/olympia/browse/views.py:427 src/olympia/devhub/views.py:74 src/olympia/devhub/views.py:81 src/olympia/discovery/templates/discovery/addons/detail.html:66
 msgid "Created"
 msgstr "สร้างเมื่อ"
 
@@ -2823,6 +2869,7 @@ msgstr "{0} :: เครื่องมือค้นหา"
 msgid "<b>{0}</b> add-on"
 msgid_plural "<b>{0}</b> add-ons"
 msgstr[0] "<b>{0}</b> ส่วนเสริม"
+msgstr[1] ""
 
 #: src/olympia/browse/templates/browse/search_tools.html:61
 msgid "Search Extensions"
@@ -2928,9 +2975,10 @@ msgstr "ชุดตกแต่งแบบสมบูรณ์ที่กำ
 msgid "See the %(cnt)s extension in %(name)s &raquo;"
 msgid_plural "See all %(cnt)s extensions in %(name)s &raquo;"
 msgstr[0] ""
+msgstr[1] ""
 
-#: src/olympia/browse/templates/browse/mobile/extensions.html:13 src/olympia/compat/templates/compat/index.html:82 src/olympia/devhub/templates/devhub/devhub_search.html:24
-#: src/olympia/devhub/templates/devhub/addons/activity.html:47 src/olympia/search/templates/search/no_results.html:4 src/olympia/search/templates/search/mobile/results.html:36
+#: src/olympia/browse/templates/browse/mobile/extensions.html:13 src/olympia/devhub/templates/devhub/devhub_search.html:24 src/olympia/devhub/templates/devhub/addons/activity.html:47
+#: src/olympia/search/templates/search/no_results.html:4 src/olympia/search/templates/search/mobile/results.html:36
 msgid "No results found."
 msgstr "ไม่พบผลลัพธ์"
 
@@ -3016,7 +3064,7 @@ msgid "All"
 msgstr "ทั้งหมด"
 
 # 81%
-#: src/olympia/compat/forms.py:22 src/olympia/search/views.py:525
+#: src/olympia/compat/forms.py:22 src/olympia/editors/templates/editors/base.html:69 src/olympia/search/views.py:518
 #, fuzzy
 msgid "All Add-ons"
 msgstr "ส่วนเสริมทั้งหมด"
@@ -3028,53 +3076,6 @@ msgstr ""
 #: src/olympia/compat/forms.py:24
 msgid "Non-binary"
 msgstr ""
-
-#. Review points sources other than add-ons and themes.
-#: src/olympia/compat/views.py:87 src/olympia/constants/base.py:388 src/olympia/devhub/forms.py:162 src/olympia/editors/templates/editors/performance.html:75
-msgid "Other"
-msgstr "อื่น ๆ"
-
-#: src/olympia/compat/templates/compat/index.html:4
-msgid "Add-on Compatibility Report for {app} {version}"
-msgstr "รายงานความเข้ากันได้ของส่วนเสริมสำหรับ {app} {version}"
-
-#: src/olympia/compat/templates/compat/index.html:11
-msgid "{app} {version} Compatibility"
-msgstr "ความเข้ากันได้ของ {app} {version}"
-
-#: src/olympia/compat/templates/compat/index.html:17
-#, python-format
-msgid "Top 95%% compatible with previous version"
-msgstr ""
-
-#: src/olympia/compat/templates/compat/index.html:18
-#, python-format
-msgid "Top 95%% of all add-ons"
-msgstr ""
-
-#: src/olympia/compat/templates/compat/index.html:19
-msgid "All active add-ons"
-msgstr ""
-
-#: src/olympia/compat/templates/compat/index.html:23 src/olympia/constants/base.py:401
-msgid "App"
-msgstr "แอพ"
-
-#: src/olympia/compat/templates/compat/index.html:55
-msgid "Details for add-ons compatible with previous version:"
-msgstr "รายละเอียดสำหรับความเข้ากันได้ของส่วนเสริมกับรุ่นก่อนหน้า:"
-
-#: src/olympia/compat/templates/compat/index.html:57
-msgid "Show all versions"
-msgstr "แสดงทุกรุ่น"
-
-#: src/olympia/compat/templates/compat/index.html:59
-msgid "Details for add-ons compatible with all versions:"
-msgstr "รายละเอียดสำหรับความเข้ากันได้ของส่วนเสริมกับทุกรุ่น:"
-
-#: src/olympia/compat/templates/compat/index.html:61
-msgid "Show previous version only"
-msgstr "แสดงรุ่นก่อนหน้าเท่านั้น"
 
 #: src/olympia/compat/templates/compat/reporter.html:3
 msgid "Add-on Compatibility Reports"
@@ -3107,11 +3108,13 @@ msgstr "รายงานความเข้ากันได้ของ {a
 msgid "{0} success report"
 msgid_plural "{0} success reports"
 msgstr[0] ""
+msgstr[1] ""
 
 #: src/olympia/compat/templates/compat/reporter_detail.html:17
 msgid "{0} problem report"
 msgid_plural "{0} problem reports"
 msgstr[0] ""
+msgstr[1] ""
 
 #: src/olympia/compat/templates/compat/reporter_detail.html:21 src/olympia/users/templates/users/profile.html:70
 msgid "View all"
@@ -3125,8 +3128,8 @@ msgstr "กรองโดยแอพพลิเคชัน"
 msgid "Report Type"
 msgstr "ประเภทของรายงาน"
 
-#: src/olympia/compat/templates/compat/reporter_detail.html:47 src/olympia/devhub/forms.py:784 src/olympia/devhub/templates/devhub/addons/ajax_compat_update.html:17 src/olympia/editors/forms.py:108
-#: src/olympia/zadmin/forms.py:45
+#: src/olympia/compat/templates/compat/reporter_detail.html:47 src/olympia/devhub/forms.py:785 src/olympia/devhub/templates/devhub/addons/ajax_compat_update.html:17 src/olympia/editors/forms.py:108
+#: src/olympia/editors/forms.py:248 src/olympia/zadmin/forms.py:45
 msgid "Application"
 msgstr "แอพพลิเคชัน"
 
@@ -3214,7 +3217,8 @@ msgstr ""
 msgid "Preliminarily Reviewed and Awaiting Full Review"
 msgstr ""
 
-#: src/olympia/constants/base.py:33 src/olympia/editors/helpers.py:924 src/olympia/editors/templates/editors/themes/history_table.html:34
+#: src/olympia/constants/base.py:33 src/olympia/editors/forms.py:258 src/olympia/editors/helpers.py:73 src/olympia/editors/helpers.py:1004
+#: src/olympia/editors/templates/editors/themes/history_table.html:34
 msgid "Deleted"
 msgstr ""
 
@@ -3311,6 +3315,11 @@ msgstr "ถามเมื่อผู้ใช้เริ่มดาวน์
 msgid "Ask before users can download this add-on"
 msgstr "ถามก่อนที่ผู้ใช้จะสามารถดาวน์โหลดส่วนเสริมนี้"
 
+#. Review points sources other than add-ons and themes.
+#: src/olympia/constants/base.py:388 src/olympia/devhub/forms.py:162 src/olympia/editors/templates/editors/performance.html:75
+msgid "Other"
+msgstr "อื่น ๆ"
+
 #: src/olympia/constants/base.py:389
 msgid "Exception"
 msgstr "ข้อยกเว้น"
@@ -3322,6 +3331,10 @@ msgstr ""
 #: src/olympia/constants/base.py:391
 msgid "Change"
 msgstr "เปลี่ยน"
+
+#: src/olympia/constants/base.py:401
+msgid "App"
+msgstr "แอพ"
 
 #: src/olympia/constants/base.py:402
 msgid "Persona"
@@ -3471,7 +3484,7 @@ msgstr ""
 msgid "Duplicate"
 msgstr ""
 
-#: src/olympia/constants/editors.py:17 src/olympia/editors/helpers.py:502 src/olympia/editors/templates/editors/themes/queue.html:71 src/olympia/editors/templates/editors/themes/themes.html:94
+#: src/olympia/constants/editors.py:17 src/olympia/editors/helpers.py:575 src/olympia/editors/templates/editors/themes/queue.html:71 src/olympia/editors/templates/editors/themes/themes.html:94
 msgid "Reject"
 msgstr ""
 
@@ -3571,7 +3584,7 @@ msgstr ""
 msgid "Android"
 msgstr ""
 
-#: src/olympia/core/apps.py:19
+#: src/olympia/core/apps.py:21
 msgid "Core"
 msgstr ""
 
@@ -3705,7 +3718,7 @@ msgid "Submit my add-on for manual review."
 msgstr ""
 
 #: src/olympia/devhub/forms.py:537
-msgid "Do not list my add-on on this site (beta)"
+msgid "Do not list my add-on on this site"
 msgstr ""
 
 #: src/olympia/devhub/forms.py:538
@@ -3738,46 +3751,46 @@ msgstr ""
 
 #: src/olympia/devhub/forms.py:592
 #, python-format
-msgid "Version %s already exists"
-msgstr "รุ่น %s มีอยู่แล้ว"
+msgid "Version %s already exists, or was uploaded before."
+msgstr ""
 
-#: src/olympia/devhub/forms.py:604
+#: src/olympia/devhub/forms.py:605
 msgid "Select a valid choice. That choice is not one of the available choices."
 msgstr ""
 
-#: src/olympia/devhub/forms.py:610
+#: src/olympia/devhub/forms.py:611
 msgid "A file with a version ending with a|alpha|b|beta and an optional number is detected as beta."
 msgstr ""
 
-#: src/olympia/devhub/forms.py:633
+#: src/olympia/devhub/forms.py:634
 msgid "You cannot upload any more files for this version."
 msgstr "คุณไม่สามารถอัปโหลดไฟล์สำหรับรุ่นนี้เพิ่มเติมได้อีกแล้ว"
 
-#: src/olympia/devhub/forms.py:639
+#: src/olympia/devhub/forms.py:640
 msgid "Version doesn't match"
 msgstr "รุ่นไม่ตรงกัน"
 
-#: src/olympia/devhub/forms.py:668
+#: src/olympia/devhub/forms.py:669
 msgid "You cannot delete a file once the review process has started.  You must delete the whole version."
 msgstr ""
 
-#: src/olympia/devhub/forms.py:688
+#: src/olympia/devhub/forms.py:689
 msgid "The platform All cannot be combined with specific platforms."
 msgstr ""
 
-#: src/olympia/devhub/forms.py:693
+#: src/olympia/devhub/forms.py:694
 msgid "A platform can only be chosen once."
 msgstr "แพลตฟอร์มถูกเลือกได้เพียงครั้งเดียวเท่านั้น"
 
-#: src/olympia/devhub/forms.py:706
+#: src/olympia/devhub/forms.py:707
 msgid "A review type must be selected."
 msgstr "ต้องเลือกประเภทของบทวิจารณ์"
 
-#: src/olympia/devhub/forms.py:788 src/olympia/editors/forms.py:114 src/olympia/zadmin/forms.py:49 src/olympia/zadmin/forms.py:52
+#: src/olympia/devhub/forms.py:789 src/olympia/editors/forms.py:114 src/olympia/editors/forms.py:254 src/olympia/zadmin/forms.py:49 src/olympia/zadmin/forms.py:52
 msgid "Select an application first"
 msgstr "เลือกแอพพลิเคชันก่อน"
 
-#: src/olympia/devhub/forms.py:840
+#: src/olympia/devhub/forms.py:841
 msgid "There cannot be more than 3 required add-ons."
 msgstr ""
 
@@ -3798,87 +3811,89 @@ msgstr ""
 msgid "{0} error"
 msgid_plural "{0} errors"
 msgstr[0] "{0} ข้อผิดพลาด"
+msgstr[1] ""
 
 #. L10n: first parameter is the number of warnings
 #: src/olympia/devhub/helpers.py:203
 msgid "{0} warning"
 msgid_plural "{0} warnings"
 msgstr[0] "{0} คำเตือน"
+msgstr[1] ""
 
 #: src/olympia/devhub/models.py:375 src/olympia/reviews/templates/reviews/add.html:58
 msgid "Review"
 msgstr ""
 
-#: src/olympia/devhub/tasks.py:551
+#: src/olympia/devhub/tasks.py:583
 #, python-format
 msgid "%s responded with %s (%s)."
 msgstr ""
 
-#: src/olympia/devhub/tasks.py:555
+#: src/olympia/devhub/tasks.py:587
 #, python-format
 msgid "Connection to \"%s\" timed out."
 msgstr "หมดเวลาในการเชื่อมต่อไปยัง \"%s\""
 
-#: src/olympia/devhub/tasks.py:557
+#: src/olympia/devhub/tasks.py:589
 #, python-format
 msgid "Could not contact host at \"%s\"."
 msgstr ""
 
-#: src/olympia/devhub/utils.py:104
+#: src/olympia/devhub/utils.py:105
 #, python-format
 msgid "Validation generated too many errors/warnings so %s messages were truncated. After addressing the visible messages, you'll be able to see the others."
 msgstr ""
 
-#: src/olympia/devhub/views.py:183
+#: src/olympia/devhub/views.py:181
 msgid "All My Add-ons"
 msgstr "ส่วนเสริมทั้งหมดของฉัน"
 
-#: src/olympia/devhub/views.py:210
+#: src/olympia/devhub/views.py:208
 msgid "All Activity"
 msgstr "กิจกรรมทั้งหมด"
 
-#: src/olympia/devhub/views.py:211
+#: src/olympia/devhub/views.py:209
 msgid "Add-on Updates"
 msgstr "ปรับปรุงส่วนเสริม"
 
-#: src/olympia/devhub/views.py:212
+#: src/olympia/devhub/views.py:210
 msgid "Add-on Status"
 msgstr "สถานะส่วนเสริม"
 
-#: src/olympia/devhub/views.py:213
+#: src/olympia/devhub/views.py:211
 msgid "User Collections"
 msgstr ""
 
-#: src/olympia/devhub/views.py:214 src/olympia/devhub/templates/devhub/docs/policies-maintenance.html:68 src/olympia/pages/templates/pages/dev_faq.html:38
+#: src/olympia/devhub/views.py:212 src/olympia/devhub/templates/devhub/docs/policies-maintenance.html:68 src/olympia/pages/templates/pages/dev_faq.html:38
 #: src/olympia/pages/templates/pages/dev_faq.html:484
 msgid "User Reviews"
 msgstr ""
 
-#: src/olympia/devhub/views.py:327 src/olympia/devhub/views.py:331 src/olympia/devhub/views.py:484 src/olympia/devhub/views.py:513 src/olympia/devhub/views.py:564 src/olympia/devhub/views.py:1150
+#: src/olympia/devhub/views.py:325 src/olympia/devhub/views.py:329 src/olympia/devhub/views.py:484 src/olympia/devhub/views.py:513 src/olympia/devhub/views.py:564 src/olympia/devhub/views.py:1156
 msgid "Changes successfully saved."
 msgstr "การเปลี่ยนแปลงถูกบันทึกเรียบร้อย"
 
-#: src/olympia/devhub/views.py:334 src/olympia/devhub/views.py:1631
+#: src/olympia/devhub/views.py:332 src/olympia/devhub/views.py:1637
 msgid "Please check the form for errors."
 msgstr ""
 
-#: src/olympia/devhub/views.py:346
+#: src/olympia/devhub/views.py:344
 msgid "Add-on cannot be deleted. Disable this add-on instead."
 msgstr "ส่วนเสริมนี้ไม่สามารถลบได้ ให้ปิดการทำงานของส่วนเสริมนี้แทน"
 
-#: src/olympia/devhub/views.py:356
+#: src/olympia/devhub/views.py:354
 msgid "Theme deleted."
 msgstr "ลบชุดตกแต่งแล้ว"
 
-#: src/olympia/devhub/views.py:356
+#: src/olympia/devhub/views.py:354
 msgid "Add-on deleted."
 msgstr "ลบส่วนเสริมแล้ว"
 
-#: src/olympia/devhub/views.py:362
+#: src/olympia/devhub/views.py:360
 msgid "URL name was incorrect. Theme was not deleted."
 msgstr ""
 
-#: src/olympia/devhub/views.py:367
+#: src/olympia/devhub/views.py:365
 msgid "URL name was incorrect. Add-on was not deleted."
 msgstr ""
 
@@ -3906,7 +3921,7 @@ msgstr ""
 msgid "Check Add-on Compatibility"
 msgstr "ตรวจสอบความเข้ากันได้ของส่วนเสริม"
 
-#: src/olympia/devhub/views.py:808 src/olympia/signing/views.py:90
+#: src/olympia/devhub/views.py:808 src/olympia/signing/views.py:95
 msgid "You cannot submit this type of add-on"
 msgstr ""
 
@@ -3936,33 +3951,33 @@ msgstr "รูปภาพจะต้องกว้าง {0} พิกเซ�
 msgid "There was an error uploading your preview."
 msgstr ""
 
-#: src/olympia/devhub/views.py:1189
+#: src/olympia/devhub/views.py:1195
 #, python-format
 msgid "Version %s disabled."
 msgstr ""
 
-#: src/olympia/devhub/views.py:1193
+#: src/olympia/devhub/views.py:1199
 #, python-format
 msgid "Version %s deleted."
 msgstr "ลบรุ่น %s แล้ว"
 
-#: src/olympia/devhub/views.py:1203
+#: src/olympia/devhub/views.py:1209
 msgid "This upload has failed validation, and may lack complete validation results. Please take due care when reviewing it."
 msgstr ""
 
-#: src/olympia/devhub/views.py:1677
+#: src/olympia/devhub/views.py:1683
 msgid "Preliminary Review Requested."
 msgstr ""
 
-#: src/olympia/devhub/views.py:1678
+#: src/olympia/devhub/views.py:1684
 msgid "Full Review Requested."
 msgstr ""
 
-#: src/olympia/devhub/views.py:1779
+#: src/olympia/devhub/views.py:1783
 msgid "Your old credentials were revoked and are no longer valid. Be sure to update all API clients with the new credentials."
 msgstr ""
 
-#: src/olympia/devhub/views.py:1797
+#: src/olympia/devhub/views.py:1801
 msgid "New API key created"
 msgstr ""
 
@@ -3992,7 +4007,7 @@ msgstr "กลับไปยังส่วนเสริม"
 msgid "{0} :: Search"
 msgstr "{0} :: ค้นหา"
 
-#: src/olympia/devhub/templates/devhub/devhub_search.html:6 src/olympia/devhub/templates/devhub/search.html:8 src/olympia/editors/forms.py:435 src/olympia/editors/forms.py:437
+#: src/olympia/devhub/templates/devhub/devhub_search.html:6 src/olympia/devhub/templates/devhub/search.html:8 src/olympia/editors/forms.py:534 src/olympia/editors/forms.py:536
 #: src/olympia/editors/templates/editors/queue.html:27 src/olympia/editors/templates/editors/themes/queue_list.html:14 src/olympia/search/templates/search/collections.html:17
 #: src/olympia/search/templates/search/personas.html:18 src/olympia/search/templates/search/results.html:18 src/olympia/search/templates/search/mobile/results.html:8
 #: src/olympia/templates/search.html:14 src/olympia/templates/impala/search.html:18
@@ -4052,12 +4067,12 @@ msgstr ""
 msgid "Start Making Add-ons"
 msgstr "เริ่มต้นสร้างส่วนเสริม"
 
-#: src/olympia/devhub/templates/devhub/index.html:86 src/olympia/devhub/templates/devhub/addons/listing/items.html:25 src/olympia/devhub/templates/devhub/includes/addon_details.html:15
+#: src/olympia/devhub/templates/devhub/index.html:86 src/olympia/devhub/templates/devhub/addons/listing/items.html:25 src/olympia/devhub/templates/devhub/includes/addon_details.html:20
 #: src/olympia/devhub/templates/devhub/personas/edit.html:43
 msgid "Status:"
 msgstr "สถานะ:"
 
-#: src/olympia/devhub/templates/devhub/index.html:90 src/olympia/devhub/templates/devhub/includes/addon_details.html:100
+#: src/olympia/devhub/templates/devhub/index.html:90 src/olympia/devhub/templates/devhub/includes/addon_details.html:87
 msgid "Visibility:"
 msgstr ""
 
@@ -4065,11 +4080,11 @@ msgstr ""
 msgid "Latest Version:"
 msgstr "รุ่นล่าสุด:"
 
-#: src/olympia/devhub/templates/devhub/index.html:109 src/olympia/devhub/templates/devhub/includes/addon_details.html:145 src/olympia/devhub/templates/devhub/personas/edit.html:49
+#: src/olympia/devhub/templates/devhub/index.html:109 src/olympia/devhub/templates/devhub/includes/addon_details.html:131 src/olympia/devhub/templates/devhub/personas/edit.html:49
 msgid "Queue Position:"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/index.html:110 src/olympia/devhub/templates/devhub/includes/addon_details.html:146 src/olympia/devhub/templates/devhub/personas/edit.html:50
+#: src/olympia/devhub/templates/devhub/index.html:110 src/olympia/devhub/templates/devhub/includes/addon_details.html:132 src/olympia/devhub/templates/devhub/personas/edit.html:50
 #, python-format
 msgid "%(position)s of %(total)s"
 msgstr "%(position)s จาก %(total)s"
@@ -4171,16 +4186,6 @@ msgstr ""
 msgid "Do you want your add-on to be distributed on this site?"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/validate_addon.html:49 src/olympia/devhub/templates/devhub/addons/submit/upload.html:30 src/olympia/devhub/templates/devhub/versions/add_file_modal.html:14
-#: src/olympia/devhub/templates/devhub/versions/add_file_modal.html:53 src/olympia/devhub/templates/devhub/versions/list.html:298
-msgid "Warning:"
-msgstr ""
-
-#: src/olympia/devhub/templates/devhub/validate_addon.html:50 src/olympia/devhub/templates/devhub/addons/submit/upload.html:31
-#, python-format
-msgid "Submission of unlisted add-ons for signing is currently in an open beta. Please <a href=\"%(url)s\" target=\"_blank\">report any bugs</a> that you encounter."
-msgstr ""
-
 #. first parameter is a filename like lorem-ipsum-1.0.2.xpi
 #: src/olympia/devhub/templates/devhub/validation.html:5
 msgid "Validation Results for {0}"
@@ -4257,7 +4262,7 @@ msgstr "ความเข้ากันได้"
 msgid "Update Compatibility"
 msgstr "ปรับปรุงความเข้ากันได้"
 
-#: src/olympia/devhub/templates/devhub/addons/ajax_compat_update.html:4
+#: src/olympia/devhub/templates/devhub/addons/ajax_compat_update.html:4 src/olympia/devhub/templates/devhub/versions/edit.html:45
 msgid "Adjusting application information here will allow users to install your add-on even if the install manifest in the package indicates that the add-on is incompatible."
 msgstr ""
 
@@ -4269,9 +4274,9 @@ msgstr "รุ่นที่รองรับ"
 msgid "Add Another Application&hellip;"
 msgstr "เพิ่มแอพพลิเคชันอื่น&hellip;"
 
-#: src/olympia/devhub/templates/devhub/addons/ajax_compat_update.html:38 src/olympia/devhub/templates/devhub/addons/owner.html:86 src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:46
-#: src/olympia/devhub/templates/devhub/versions/list.html:351 src/olympia/devhub/templates/devhub/versions/list.html:353 src/olympia/templates/impala/base.html:132
-#: src/olympia/templates/impala/base.html:143 src/olympia/templates/impala/base.html:161 src/olympia/templates/impala/base.html:171
+#: src/olympia/devhub/templates/devhub/addons/ajax_compat_update.html:38 src/olympia/devhub/templates/devhub/addons/owner.html:86 src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:45
+#: src/olympia/devhub/templates/devhub/versions/list.html:349 src/olympia/devhub/templates/devhub/versions/list.html:351 src/olympia/templates/impala/base.html:129
+#: src/olympia/templates/impala/base.html:140 src/olympia/templates/impala/base.html:158 src/olympia/templates/impala/base.html:168
 msgid "Close"
 msgstr "ปิด"
 
@@ -4289,6 +4294,7 @@ msgstr ""
 msgid "<b>{0}</b> theme"
 msgid_plural "<b>{0}</b> themes"
 msgstr[0] ""
+msgstr[1] ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit.html:3 src/olympia/devhub/templates/devhub/addons/listing/item_actions.html:25
 #: src/olympia/devhub/templates/devhub/addons/listing/item_actions_theme.html:7 src/olympia/devhub/templates/devhub/includes/addons_edit_nav.html:2
@@ -4304,7 +4310,7 @@ msgstr "ไม่มี"
 msgid "Manage Authors & License"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/addons/owner.html:29 src/olympia/editors/templates/editors/review.html:270
+#: src/olympia/devhub/templates/devhub/addons/owner.html:29 src/olympia/editors/helpers.py:362 src/olympia/editors/templates/editors/review.html:270
 msgid "Authors"
 msgstr ""
 
@@ -4373,17 +4379,11 @@ msgstr "สรุป"
 
 #: src/olympia/devhub/templates/devhub/addons/edit/basic.html:52
 msgid ""
-"A short explanation of your add-on's basic\n"
-"                          functionality that is displayed in search and browse\n"
-"                          listings, as well as at the top of your add-on's\n"
-"                          details page. It is only relevant for listed add-ons."
+"A short explanation of your add-on's basic functionality that is displayed in search and browse listings, as well as at the top of your add-on's details page. It is only relevant for listed add-ons."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/basic.html:73
-msgid ""
-"Categories are the primary way users browse through add-ons.\n"
-"                        Choose any that fit your add-on's functionality for the most\n"
-"                        exposure. It is only relevant for listed add-ons."
+msgid "Categories are the primary way users browse through add-ons. Choose any that fit your add-on's functionality for the most exposure. It is only relevant for listed add-ons."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/basic.html:90
@@ -4393,17 +4393,14 @@ msgid ""
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/basic.html:119
-msgid ""
-"Tags help users find your add-on and should be short\n"
-"                        descriptors such as tabs, toolbar, or twitter.  You\n"
-"                        may have a maximum of {0} tags. It is only relevant\n"
-"                        for listed add-ons."
+msgid "Tags help users find your add-on and should be short descriptors such as tabs, toolbar, or twitter. You may have a maximum of {0} tags. It is only relevant for listed add-ons."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/basic.html:129 src/olympia/devhub/templates/devhub/personas/edit.html:97 src/olympia/devhub/templates/devhub/personas/submit.html:46
 msgid "Comma-separated, minimum of {0} character."
 msgid_plural "Comma-separated, minimum of {0} characters."
 msgstr[0] ""
+msgstr[1] ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/basic.html:132 src/olympia/devhub/templates/devhub/personas/edit.html:100 src/olympia/devhub/templates/devhub/personas/submit.html:49
 msgid "Example: dark, cinema, noir. Limit 20."
@@ -4413,6 +4410,7 @@ msgstr ""
 msgid "Reserved tag:"
 msgid_plural "Reserved tags:"
 msgstr[0] ""
+msgstr[1] ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/details.html:5
 msgid "Add-on Details"
@@ -4423,11 +4421,7 @@ msgid "Add-on Details for {0}"
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/details.html:22
-msgid ""
-"A longer explanation of features,\n"
-"                          functionality, and other relevant information. This\n"
-"                          field is only displayed on the add-on's details\n"
-"                          page. It is only relevant for listed add-ons."
+msgid "A longer explanation of features, functionality, and other relevant information. This field is only displayed on the add-on's details page. It is only relevant for listed add-ons."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/details.html:44 src/olympia/translations/templates/translations/trans-menu.html:13
@@ -4435,10 +4429,7 @@ msgid "Default Locale"
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/details.html:45
-msgid ""
-"Information about your add-on is displayed in this locale\n"
-"                        unless you override it with a locale-specific translation.\n"
-"                        It is only relevant for listed add-ons."
+msgid "Information about your add-on is displayed in this locale unless you override it with a locale-specific translation. It is only relevant for listed add-ons."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/details.html:61 src/olympia/users/forms.py:311 src/olympia/users/templates/users/edit.html:122 src/olympia/users/templates/users/register.html:57
@@ -4448,10 +4439,8 @@ msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/details.html:63
 msgid ""
-"If your add-on has another homepage, enter its\n"
-"                          address here. If your website is localized into other\n"
-"                          languages multiple translations of this field can be\n"
-"                          added. It is only relevant for listed add-ons."
+"If your add-on has another homepage, enter its address here. If your website is localized into other languages multiple translations of this field can be added. It is only relevant for listed add-"
+"ons."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/media.html:3
@@ -4469,19 +4458,14 @@ msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/support.html:22
 msgid ""
-"If you wish to display an e-mail address for support\n"
-"                          inquiries, enter it here. If you have different\n"
-"                          addresses for each language multiple translations of\n"
-"                          this field can be added. It is only relevant for\n"
-"                          listed add-ons."
+"If you wish to display an e-mail address for support inquiries, enter it here. If you have different addresses for each language multiple translations of this field can be added. It is only "
+"relevant for listed add-ons."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/support.html:45
 msgid ""
-"If your add-on has a support website or forum, enter\n"
-"                          its address here. If your website is localized into\n"
-"                          other languages, multiple translations of this field can\n"
-"                          be added. It is only relevant for listed add-ons."
+"If your add-on has a support website or forum, enter its address here. If your website is localized into other languages, multiple translations of this field can be added. It is only relevant for "
+"listed add-ons."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:6
@@ -4495,11 +4479,8 @@ msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:23
 msgid ""
-"Any information end users may want to know that isn't\n"
-"                          necessarily applicable to the add-on summary or description.\n"
-"                          Common uses include listing known major bugs, information on\n"
-"                          how to report bugs, anticipated release date of a new version,\n"
-"                          etc. It is only relevant for listed add-ons."
+"Any information end users may want to know that isn't necessarily applicable to the add-on summary or description. Common uses include listing known major bugs, information on how to report bugs, "
+"anticipated release date of a new version, etc. It is only relevant for listed add-ons."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:46
@@ -4511,9 +4492,7 @@ msgid "Add-on Flags"
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:69
-msgid ""
-"These flags are used to classify add-ons. It is only\n"
-"                        relevant for listed add-ons."
+msgid "These flags are used to classify add-ons. It is only relevant for listed add-ons."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:74
@@ -4529,9 +4508,7 @@ msgid "View Source?"
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:90
-msgid ""
-"Whether the source of your add-on can be displayed in our\n"
-"                        online viewer. It is only relevant for listed add-ons."
+msgid "Whether the source of your add-on can be displayed in our online viewer. It is only relevant for listed add-ons."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:94
@@ -4547,10 +4524,7 @@ msgid "Public Stats?"
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:102
-msgid ""
-"Whether the download and usage stats of your add-on can\n"
-"                        be displayed in our online viewer.\n"
-"                        It is only relevant for listed add-ons."
+msgid "Whether the download and usage stats of your add-on can be displayed in our online viewer. It is only relevant for listed add-ons."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:107
@@ -4566,10 +4540,7 @@ msgid "Upgrade SDK?"
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:116
-msgid ""
-"If selected, we will try to automatically upgrade your\n"
-"                        add-on when a new version of the SDK is released.\n"
-"                        It is only relevant for listed add-ons."
+msgid "If selected, we will try to automatically upgrade your add-on when a new version of the SDK is released. It is only relevant for listed add-ons."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:121
@@ -4620,10 +4591,8 @@ msgstr "ไอคอนของส่วนเสริม"
 
 #: src/olympia/devhub/templates/devhub/addons/forms_shared/media.html:16
 msgid ""
-"Upload an icon for your add-on or choose from one of ours. The\n"
-"                      icon is displayed nearly everywhere your add-on is. Uploaded images\n"
-"                      must be one of the following image types: .png, .jpg.\n"
-"                      It is only relevant for listed add-ons."
+"Upload an icon for your add-on or choose from one of ours. The icon is displayed nearly everywhere your add-on is. Uploaded images must be one of the following image types: .png, .jpg. It is only "
+"relevant for listed add-ons."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/forms_shared/media.html:25
@@ -4731,16 +4700,14 @@ msgid "Deleting your add-on will permanently remove it from the site and prevent
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:24
-msgid ""
-"Enter the following text confirm your decision:\n"
-"           {slug}"
+msgid "Enter the following text confirm your decision: {slug}"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:34
+#: src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:33
 msgid "Please tell us why you are deleting your theme:"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:36
+#: src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:35
 msgid "Please tell us why you are deleting your add-on:"
 msgstr ""
 
@@ -4777,8 +4744,8 @@ msgstr ""
 msgid "Daily statistics on downloads and users."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/addons/listing/item_actions.html:45 src/olympia/stats/templates/stats/stats.html:75 src/olympia/stats/templates/stats/stats.html:79
-#: src/olympia/stats/templates/stats/stats.html:81
+#: src/olympia/devhub/templates/devhub/addons/listing/item_actions.html:45 src/olympia/stats/templates/stats/stats.html:31 src/olympia/stats/templates/stats/stats.html:35
+#: src/olympia/stats/templates/stats/stats.html:37
 msgid "Statistics"
 msgstr "สถิติ"
 
@@ -4838,6 +4805,7 @@ msgstr ""
 msgid "<strong>{0}</strong> active user"
 msgid_plural "<strong>{0}</strong> active users"
 msgstr[0] ""
+msgstr[1] ""
 
 #: src/olympia/devhub/templates/devhub/addons/submit/base.html:11
 msgid "Submit Add-on"
@@ -4896,10 +4864,7 @@ msgid "Your add-on has been submitted to the Full Review queue."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/submit/done.html:18
-msgid ""
-"You'll receive an email once it has been reviewed by an editor. In\n"
-"          the meantime, you and your friends can install it directly from its\n"
-"          details page:"
+msgid "You'll receive an email once it has been reviewed by an editor. In the meantime, you and your friends can install it directly from its details page:"
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/submit/done.html:27 src/olympia/devhub/templates/devhub/addons/submit/done.html:77 src/olympia/devhub/templates/devhub/personas/submit_done.html:16
@@ -5105,11 +5070,11 @@ msgstr ""
 msgid "Use the fields below to upload your add-on package and select any platform restrictions. After upload, a series of automated validation tests will be run on your file."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/addons/submit/upload.html:59 src/olympia/devhub/templates/devhub/versions/add_file_modal.html:39
+#: src/olympia/devhub/templates/devhub/addons/submit/upload.html:51 src/olympia/devhub/templates/devhub/versions/add_file_modal.html:28
 msgid "Which platforms is this file compatible with?"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/addons/submit/upload.html:67 src/olympia/devhub/templates/devhub/versions/add_file_modal.html:65
+#: src/olympia/devhub/templates/devhub/addons/submit/upload.html:59 src/olympia/devhub/templates/devhub/versions/add_file_modal.html:45
 msgid "Administrative overrides"
 msgstr ""
 
@@ -5219,8 +5184,8 @@ msgstr ""
 
 #: src/olympia/devhub/templates/devhub/docs/policies-contact.html:44
 msgid ""
-"If you've found a problem with the site, we'd love to fix it. Please <a href=\"https://github.com/mozilla/olympia/issues\">file a bug report</a> in GitHub, including the location of the problem and "
-"how you encountered it."
+"If you've found a problem with the site, we'd love to fix it. Please <a href=\"https://github.com/mozilla/addons/issues/new\">file a bug report</a> in GitHub, including the location of the problem "
+"and how you encountered it."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/docs/policies-maintenance.html:3 src/olympia/devhub/templates/devhub/docs/policies-maintenance.html:7
@@ -5787,7 +5752,7 @@ msgstr ""
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:282
 msgid ""
-"Add-ons that store or otherwise handle browsing data must support <a href=\"https://developer.mozilla.org/En/Supporting_private_browsing_mode\">Private Browsing Mode</a>.  During a Private Browsing "
+"Add-ons that store or otherwise handle browsing data must support <a href=\"https://developer.mozilla.org/En/Supporting_private_browsing_mode\">Private Browsing Mode</a>. During a Private Browsing "
 "session, no browsing data can be written to disk, and all of this data must be cleared when Firefox quits or the Private Browsing session ends."
 msgstr ""
 
@@ -5952,129 +5917,95 @@ msgstr ""
 msgid "How to get in touch with us regarding these policies or your add-on."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:6
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:10
 msgid "You have disabled this add-on"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:20
-msgid ""
-"Your add-on's listing is disabled and is not showing\n"
-"                             anywhere in our gallery or update service."
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:24
+msgid "Your add-on's listing is disabled and is not showing anywhere in our gallery or update service."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:25
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:27
 msgid "Please complete your add-on."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:29
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:30
 msgid "You will receive an email when the review is complete."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:34
-msgid ""
-"You will receive an email when the review is complete. Until\n"
-"                             then, your add-on is not listed in our gallery but can be\n"
-"                             accessed directly from its details page."
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:33
+msgid "You will receive an email when the review is complete. Until then, your add-on is not listed in our gallery but can be accessed directly from its details page."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:38 src/olympia/devhub/templates/devhub/includes/addon_details.html:48
-msgid ""
-"You will receive an email when the review is\n"
-"                             complete and your add-on is signed."
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:37 src/olympia/devhub/templates/devhub/includes/addon_details.html:45
+msgid "You will receive an email when the review is complete and your add-on is signed."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:44
-msgid ""
-"You will receive an email when the review is complete. Until\n"
-"                             then, your add-on is not listed in our gallery but can be\n"
-"                             accessed directly from its details page. "
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:41
+msgid "You will receive an email when the review is complete. Until then, your add-on is not listed in our gallery but can be accessed directly from its details page. "
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:54
-msgid ""
-"Your add-on is displayed in our gallery and users are\n"
-"                             receiving automatic updates."
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:49
+msgid "Your add-on is displayed in our gallery and users are receiving automatic updates."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:57
-msgid ""
-"Your add-on has been signed and can be bundled with an\n"
-"                             application installer."
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:52
+msgid "Your add-on has been signed and can be bundled with an application installer."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:63
-msgid ""
-"Your add-on was disabled by a site administrator and is no\n"
-"                             longer shown in our gallery. If you have any questions,\n"
-"                             please email amo-admins@mozilla.org."
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:56
+msgid "Your add-on was disabled by a site administrator and is no longer shown in our gallery. If you have any questions, please email amo-admins@mozilla.org."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:70
-msgid ""
-"Your add-on is displayed in our gallery as experimental\n"
-"                             and users are receiving automatic updates. Some features\n"
-"                             are unavailable to your add-on."
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:62
+msgid "Your add-on is displayed in our gallery as experimental and users are receiving automatic updates. Some features are unavailable to your add-on."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:74
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:66
 msgid "Your add-on has been signed."
 msgstr ""
 
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:69
+msgid ""
+"You will receive an email when the full review is complete. Until then, your add-on is displayed in our gallery as experimental and users are receiving automatic updates. Some features are "
+"unavailable to your add-on."
+msgstr ""
+
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:74
+msgid "You will receive an email when the full review is complete, making you able to bundle your add-on with an application installer."
+msgstr ""
+
 #: src/olympia/devhub/templates/devhub/includes/addon_details.html:79
-msgid ""
-"You will receive an email when the full review is complete.\n"
-"                             Until then, your add-on is displayed in our gallery as\n"
-"                             experimental and users are receiving automatic updates.\n"
-"                             Some features are unavailable to your add-on."
+msgid "All add-ons hosted in our gallery must now be reviewed by an editor. If you wish to continue hosting your add-on, please click to select a review process."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:84
-msgid ""
-"You will receive an email when the full review is\n"
-"                             complete, making you able to bundle your add-on with an\n"
-"                             application installer."
-msgstr ""
-
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:91
-msgid ""
-"All add-ons hosted in our gallery must now be reviewed by an\n"
-"                             editor. If you wish to continue hosting your add-on, please\n"
-"                             click to select a review process."
-msgstr ""
-
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:113
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:100
 msgid "Current Version:"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:115
-msgid ""
-"This is the version of your add-on that will\n"
-"                                           be installed if someone clicks the Install\n"
-"                                           button on addons.mozilla.org. It is only\n"
-"                                           relevant for listed add-ons."
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:102
+msgid "This is the version of your add-on that will be installed if someone clicks the Install button on addons.mozilla.org. It is only relevant for listed add-ons."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:123
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:110
 msgid "Created:"
 msgstr ""
 
 #. {0} is a date. dennis-ignore: E201
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:125 src/olympia/devhub/templates/devhub/includes/addon_details.html:131
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:112 src/olympia/devhub/templates/devhub/includes/addon_details.html:118
 #, python-format
 msgid "%%b %%e, %%Y"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:136
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:123
 msgid "Next Version:"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:138
-msgid ""
-"This is the newest uploaded version, however\n"
-"                                           it isn’t live on the site yet."
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:125
+msgid "This is the newest uploaded version, however it isn’t live on the site yet."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:144 src/olympia/devhub/templates/devhub/versions/list.html:30
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:130 src/olympia/devhub/templates/devhub/versions/list.html:30
 msgid "Queues are not reviewed strictly in order"
 msgstr ""
 
@@ -6142,9 +6073,7 @@ msgid "View the blog &#9658;"
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/includes/license_form.html:6
-msgid ""
-"Please choose a license appropriate for the rights you grant on your source code.\n"
-"                  It is only relevant for listed add-ons."
+msgid "Please choose a license appropriate for the rights you grant on your source code. It is only relevant for listed add-ons."
 msgstr ""
 
 #. {0} is a list of HTML tags.
@@ -6166,18 +6095,16 @@ msgstr ""
 msgid "Select <b>up to {0}</b> {1} category for this add-on:"
 msgid_plural "Select <b>up to {0}</b> {1} categories for this add-on:"
 msgstr[0] ""
+msgstr[1] ""
 
 #: src/olympia/devhub/templates/devhub/includes/policy_form.html:4
 msgid ""
 "Users will be required to accept the following End-User License Agreement (EULA) prior to installing your add-on. The presence of a EULA significantly affects the number of downloads an add-on "
-"receives. Please note that a EULA is not the same as a code license, such as the GPL or MPL.\n"
-"                It is only relevant for listed add-ons."
+"receives. Please note that a EULA is not the same as a code license, such as the GPL or MPL.It is only relevant for listed add-ons."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/policy_form.html:21
-msgid ""
-"If your add-on transmits any data from the user's computer, a privacy policy is required that explains what data is sent and how it is used.\n"
-"                It is only relevant for listed add-ons."
+#: src/olympia/devhub/templates/devhub/includes/policy_form.html:24
+msgid "If your add-on transmits any data from the user's computer, a privacy policy is required that explains what data is sent and how it is used. It is only relevant for listed add-ons."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/includes/source_form_field.html:2
@@ -6345,12 +6272,8 @@ msgstr ""
 msgid "Add some tags to describe your Theme."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/personas/edit.html:106
-msgid ""
-"A short explanation of your theme's\n"
-"                                basic functionality that is displayed in\n"
-"                                search and browse listings, as well as at\n"
-"                                the top of your theme's details page."
+#: src/olympia/devhub/templates/devhub/personas/edit.html:106 src/olympia/devhub/templates/devhub/personas/submit.html:54
+msgid "A short explanation of your theme's basic functionality that is displayed in search and browse listings, as well as at the top of your theme's details page."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/personas/edit.html:122 src/olympia/devhub/templates/devhub/personas/submit.html:68
@@ -6420,7 +6343,7 @@ msgid "Upon upload and form submission, the AMO Team will review your updated de
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/personas/edit.html:241
-msgid "Your previously resubmitted design,  which is under pending review."
+msgid "Your previously resubmitted design, which is under pending review."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/personas/edit.html:245
@@ -6487,14 +6410,6 @@ msgstr ""
 
 #: src/olympia/devhub/templates/devhub/personas/submit.html:33
 msgid "Give your Theme a name."
-msgstr ""
-
-#: src/olympia/devhub/templates/devhub/personas/submit.html:54
-msgid ""
-"A short explanation of your theme's\n"
-"                                      basic functionality that is displayed in\n"
-"                                      search and browse listings, as well as at\n"
-"                                      the top of your theme's details page."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/personas/submit.html:198
@@ -6571,30 +6486,16 @@ msgstr ""
 msgid "Files added to reviewed versions must be reviewed before they will be available for download."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/add_file_modal.html:15
-#, python-format
-msgid ""
-"Submission of updates to unlisted add-ons for signing is currently in an open beta. Manual review may still be required for a large number of add-ons. Please <a href=\"%(url)s\" target=\"_blank"
-"\">report any bugs</a> that you encounter."
-msgstr ""
-
-#: src/olympia/devhub/templates/devhub/versions/add_file_modal.html:35
+#: src/olympia/devhub/templates/devhub/versions/add_file_modal.html:24
 msgid "Select the target platform for this file."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/add_file_modal.html:46
+#: src/olympia/devhub/templates/devhub/versions/add_file_modal.html:35
 msgid "Which review type would you like to nominate for?"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/add_file_modal.html:51
+#: src/olympia/devhub/templates/devhub/versions/add_file_modal.html:40
 msgid "Only publish this version to my beta channel."
-msgstr ""
-
-#: src/olympia/devhub/templates/devhub/versions/add_file_modal.html:54
-#, python-format
-msgid ""
-"The behavior of the beta channel has changed to accommodate <a href=\"%(addon_signing_url)s\" target=\"_blank\">mandatory add-on signing</a>. The new process is currently in an open beta, and may "
-"change significantly in the near future. Please <a href=\"%(issues_url)s\" target=\"_blank\">report any bugs</a> that you encounter."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/versions/edit.html:5
@@ -6618,19 +6519,10 @@ msgstr ""
 msgid "Upload Another File"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/edit.html:45
-msgid ""
-"Adjusting application information here will allow users to install your\n"
-"                          add-on even if the install manifest in the package indicates that the\n"
-"                          add-on is incompatible."
-msgstr ""
-
 #: src/olympia/devhub/templates/devhub/versions/edit.html:74
 msgid ""
-"Information about changes in this release, new features,\n"
-"                              known bugs, and other useful information specific to this\n"
-"                              release/version. This information is also shown in the\n"
-"                              Add-ons Manager when updating."
+"Information about changes in this release, new features, known bugs, and other useful information specific to this release/version. This information is also shown in the Add-ons Manager when "
+"updating."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/versions/edit.html:99
@@ -6642,10 +6534,7 @@ msgid "Notes for Reviewers"
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/versions/edit.html:114
-msgid ""
-"Optionally, enter any information that may be useful\n"
-"                              to the Editor reviewing this add-on, such as test\n"
-"                              account information."
+msgid "Optionally, enter any information that may be useful to the Editor reviewing this add-on, such as test account information."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/versions/edit.html:127
@@ -6696,6 +6585,7 @@ msgstr ""
 msgid "{0} file"
 msgid_plural "{0} files"
 msgstr[0] ""
+msgstr[1] ""
 
 #: src/olympia/devhub/templates/devhub/versions/list.html:25
 msgid "0 files"
@@ -6722,7 +6612,7 @@ msgstr ""
 msgid "Request Preliminary Review"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:80 src/olympia/devhub/templates/devhub/versions/list.html:327 src/olympia/devhub/templates/devhub/versions/list.html:350
+#: src/olympia/devhub/templates/devhub/versions/list.html:80 src/olympia/devhub/templates/devhub/versions/list.html:325 src/olympia/devhub/templates/devhub/versions/list.html:348
 msgid "Cancel Review Request"
 msgstr ""
 
@@ -6751,7 +6641,7 @@ msgid "Unlisted:"
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/versions/list.html:114
-msgid "Not distributed on {0}. Developers will upload new versions for signing and distribute the add-ons on their own. (beta)"
+msgid "Not distributed on {0}. Developers will upload new versions for signing and distribute the add-ons on their own."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/versions/list.html:122
@@ -6814,81 +6704,73 @@ msgid "<strong>Important:</strong> Once a version has been deleted, you may not 
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/versions/list.html:230
-msgid ""
-"Deleting a version which has already been reviewed\n"
-"               may also cause a significant delay in the review of\n"
-"               your next update."
-msgstr ""
-
-#: src/olympia/devhub/templates/devhub/versions/list.html:233
 msgid "Are you sure you wish to delete this version?"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:238
+#: src/olympia/devhub/templates/devhub/versions/list.html:235
 msgid "Delete Version"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:240
+#: src/olympia/devhub/templates/devhub/versions/list.html:237
 msgid "Disable Version"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:247
+#: src/olympia/devhub/templates/devhub/versions/list.html:244
 msgid "Add a new Version"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:249
+#: src/olympia/devhub/templates/devhub/versions/list.html:246
 msgid "Add Version"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:256 src/olympia/devhub/templates/devhub/versions/list.html:274
+#: src/olympia/devhub/templates/devhub/versions/list.html:253 src/olympia/devhub/templates/devhub/versions/list.html:279
 msgid "Hide Add-on"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:259
+#: src/olympia/devhub/templates/devhub/versions/list.html:256
 msgid "Hiding your add-on will prevent it from appearing anywhere in our gallery and will stop users from receiving automatic updates."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:265
+#: src/olympia/devhub/templates/devhub/versions/list.html:263
+msgid "The files awaiting review will be disabled and you will need to upload new versions."
+msgstr ""
+
+#: src/olympia/devhub/templates/devhub/versions/list.html:270
 msgid "Are you sure you wish to hide your add-on?"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:286 src/olympia/devhub/templates/devhub/versions/list.html:315
+#: src/olympia/devhub/templates/devhub/versions/list.html:291 src/olympia/devhub/templates/devhub/versions/list.html:313
 msgid "Unlist Add-on"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:289
+#: src/olympia/devhub/templates/devhub/versions/list.html:294
 #, python-format
 msgid ""
 "Unlisting your add-on will make it (and each of its versions/files) invisible on this website. It won't show up in searches, won't have a public facing page, and won't be updated automatically for "
-"current users.  It is recommended for unlisted add-ons to provide a custom <a href=\"%(update_url)s\" target=\"_blank\">updateURL</a> in their manifest file for automatic updates."
+"current users. It is recommended for unlisted add-ons to provide a custom <a href=\"%(update_url)s\" target=\"_blank\">updateURL</a> in their manifest file for automatic updates."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:299
-#, python-format
-msgid "Switching add-ons to unlisted is currently in an open beta. Please <a href=\"%(url)s\" target=\"_blank\">report any bugs</a> that you encounter."
-msgstr ""
-
-#: src/olympia/devhub/templates/devhub/versions/list.html:305
+#: src/olympia/devhub/templates/devhub/versions/list.html:303
 msgid "Unlisting an add-on is irreversible!"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:305
+#: src/olympia/devhub/templates/devhub/versions/list.html:303
 msgid "An unlisted add-on cannot be switched to be listed."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:307
+#: src/olympia/devhub/templates/devhub/versions/list.html:305
 msgid "Are you sure you wish to unlist your add-on?"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:330
+#: src/olympia/devhub/templates/devhub/versions/list.html:328
 msgid "Canceling your review request will leave your add-on as preliminarily reviewed."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:335
+#: src/olympia/devhub/templates/devhub/versions/list.html:333
 msgid "Canceling your review request will mark your add-on incomplete. If you do not complete your add-on after several days by re-requesting review, it will be deleted."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:343
+#: src/olympia/devhub/templates/devhub/versions/list.html:341
 msgid "Are you sure you wish to cancel your review request?"
 msgstr ""
 
@@ -7227,19 +7109,19 @@ msgstr ""
 msgid "Search by add-on name / author email"
 msgstr ""
 
-#: src/olympia/editors/forms.py:103
+#: src/olympia/editors/forms.py:103 src/olympia/editors/forms.py:244 src/olympia/editors/forms.py:257
 msgid "yes"
 msgstr "ใช่"
 
-#: src/olympia/editors/forms.py:104
+#: src/olympia/editors/forms.py:104 src/olympia/editors/forms.py:244 src/olympia/editors/forms.py:257
 msgid "no"
 msgstr ""
 
-#: src/olympia/editors/forms.py:105
+#: src/olympia/editors/forms.py:105 src/olympia/editors/forms.py:245
 msgid "Admin Flag"
 msgstr ""
 
-#: src/olympia/editors/forms.py:113
+#: src/olympia/editors/forms.py:113 src/olympia/editors/forms.py:253
 msgid "Max. Version"
 msgstr ""
 
@@ -7251,55 +7133,59 @@ msgstr ""
 msgid "Add-on Types"
 msgstr ""
 
-#: src/olympia/editors/forms.py:126 src/olympia/editors/helpers.py:267
+#: src/olympia/editors/forms.py:126 src/olympia/editors/helpers.py:279
 msgid "Platforms"
 msgstr ""
 
+#: src/olympia/editors/forms.py:237
+msgid "Search by add-on name / author email / guid"
+msgstr ""
+
 #. L10n: 0 = platform, 1 = filename, 2 = status message
-#: src/olympia/editors/forms.py:238
+#: src/olympia/editors/forms.py:342
 #, python-format
 msgid "<strong>%s</strong> &middot; %s &middot; %s"
 msgstr ""
 
-#: src/olympia/editors/forms.py:252
+#: src/olympia/editors/forms.py:356
 msgid "Comments:"
 msgstr ""
 
-#: src/olympia/editors/forms.py:256
+#: src/olympia/editors/forms.py:360
 msgid "Operating systems:"
 msgstr ""
 
-#: src/olympia/editors/forms.py:258
+#: src/olympia/editors/forms.py:362
 msgid "Applications:"
 msgstr ""
 
-#: src/olympia/editors/forms.py:260
+#: src/olympia/editors/forms.py:364
 msgid "Notify me the next time this add-on is updated. (Subsequent updates will not generate an email)"
 msgstr ""
 
-#: src/olympia/editors/forms.py:265
+#: src/olympia/editors/forms.py:369
 msgid "Clear Admin Review Flag"
 msgstr ""
 
-#: src/olympia/editors/forms.py:267
+#: src/olympia/editors/forms.py:371
 msgid "Clear more info requested flag"
 msgstr ""
 
-#: src/olympia/editors/forms.py:281
+#: src/olympia/editors/forms.py:385
 msgid "Choose a canned response..."
 msgstr ""
 
 #. L10n: Description of what can be searched for.
-#: src/olympia/editors/forms.py:324
+#: src/olympia/editors/forms.py:423
 msgid "theme name"
 msgstr ""
 
-#: src/olympia/editors/forms.py:350
+#: src/olympia/editors/forms.py:449
 msgid "Someone else is reviewing this theme."
 msgstr ""
 
 #. L10n: Description of what can be searched for.
-#: src/olympia/editors/forms.py:447
+#: src/olympia/editors/forms.py:546
 msgid "app, reviewer, or comment"
 msgstr ""
 
@@ -7315,235 +7201,264 @@ msgstr ""
 msgid "Rejected or Unreviewed"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:123 src/olympia/editors/helpers.py:136
+#: src/olympia/editors/helpers.py:125 src/olympia/editors/helpers.py:138
 msgid "Queue"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:124 src/olympia/editors/templates/editors/base.html:50 src/olympia/editors/templates/editors/base.html:65
+#: src/olympia/editors/helpers.py:126 src/olympia/editors/templates/editors/base.html:50 src/olympia/editors/templates/editors/base.html:65
 msgid "Pending Updates"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:125 src/olympia/editors/templates/editors/base.html:48 src/olympia/editors/templates/editors/base.html:63
+#: src/olympia/editors/helpers.py:127 src/olympia/editors/templates/editors/base.html:48 src/olympia/editors/templates/editors/base.html:63
 msgid "Full Reviews"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:126 src/olympia/editors/templates/editors/base.html:52 src/olympia/editors/templates/editors/base.html:67
+#: src/olympia/editors/helpers.py:128 src/olympia/editors/templates/editors/base.html:52 src/olympia/editors/templates/editors/base.html:67
 msgid "Preliminary Reviews"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:127 src/olympia/editors/templates/editors/base.html:54
+#: src/olympia/editors/helpers.py:129 src/olympia/editors/templates/editors/base.html:54
 msgid "Moderated Reviews"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:128 src/olympia/editors/templates/editors/base.html:46
+#: src/olympia/editors/helpers.py:130 src/olympia/editors/templates/editors/base.html:46
 msgid "Fast Track"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:130
+#: src/olympia/editors/helpers.py:132
 msgid "Pending Themes"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:131 src/olympia/editors/templates/editors/themes/queue.html:4
+#: src/olympia/editors/helpers.py:133 src/olympia/editors/templates/editors/themes/queue.html:4
 msgid "Flagged Themes"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:132
+#: src/olympia/editors/helpers.py:134
 msgid "Update Themes"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:137
+#: src/olympia/editors/helpers.py:139
 msgid "Unlisted Pending Updates"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:138
+#: src/olympia/editors/helpers.py:140
 msgid "Unlisted Full Reviews"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:139
+#: src/olympia/editors/helpers.py:141
 msgid "Unlisted Preliminary Reviews"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:170
+#: src/olympia/editors/helpers.py:142
+msgid "Unlisted All Add-ons"
+msgstr ""
+
+#: src/olympia/editors/helpers.py:173
 msgid "Fast Track ({0})"
 msgid_plural "Fast Track ({0})"
 msgstr[0] ""
+msgstr[1] ""
 
-#: src/olympia/editors/helpers.py:175
+#: src/olympia/editors/helpers.py:178
 msgid "Full Review ({0})"
 msgid_plural "Full Reviews ({0})"
 msgstr[0] ""
+msgstr[1] ""
 
-#: src/olympia/editors/helpers.py:180
+#: src/olympia/editors/helpers.py:183
 msgid "Pending Update ({0})"
 msgid_plural "Pending Updates ({0})"
 msgstr[0] ""
+msgstr[1] ""
 
-#: src/olympia/editors/helpers.py:185
+#: src/olympia/editors/helpers.py:188
 msgid "Preliminary Review ({0})"
 msgid_plural "Preliminary Reviews ({0})"
 msgstr[0] ""
+msgstr[1] ""
 
-#: src/olympia/editors/helpers.py:190
+#: src/olympia/editors/helpers.py:193
 msgid "Moderated Review ({0})"
 msgid_plural "Moderated Reviews ({0})"
 msgstr[0] ""
+msgstr[1] ""
 
-#: src/olympia/editors/helpers.py:196
+#: src/olympia/editors/helpers.py:199
 msgid "Unlisted Full Review ({0})"
 msgid_plural "Unlisted Full Reviews ({0})"
 msgstr[0] ""
+msgstr[1] ""
 
-#: src/olympia/editors/helpers.py:201
+#: src/olympia/editors/helpers.py:204
 msgid "Unlisted Pending Update ({0})"
 msgid_plural "Unlisted Pending Updates ({0})"
 msgstr[0] ""
+msgstr[1] ""
 
-#: src/olympia/editors/helpers.py:206
+#: src/olympia/editors/helpers.py:209
 msgid "Unlisted Preliminary Review ({0})"
 msgid_plural "Unlisted Preliminary Reviews ({0})"
 msgstr[0] ""
+msgstr[1] ""
 
-#: src/olympia/editors/helpers.py:261
-msgid "Addon"
-msgstr ""
+#: src/olympia/editors/helpers.py:214
+msgid "Unlisted All Add-ons ({0})"
+msgid_plural "Unlisted All Add-ons ({0})"
+msgstr[0] ""
+msgstr[1] ""
 
-#: src/olympia/editors/helpers.py:262
+#: src/olympia/editors/helpers.py:274
 msgid "Type"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:263
+#: src/olympia/editors/helpers.py:275
 msgid "Waiting Time"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:264 src/olympia/editors/templates/editors/review.html:285
+#: src/olympia/editors/helpers.py:276 src/olympia/editors/templates/editors/review.html:285
 msgid "Flags"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:265
+#: src/olympia/editors/helpers.py:277
 msgid "Applications"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:270
+#: src/olympia/editors/helpers.py:282
 msgid "Additional"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:285
+#: src/olympia/editors/helpers.py:302
 msgid "Site Specific"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:287
+#: src/olympia/editors/helpers.py:304
 msgid "Requires External Software"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:289
+#: src/olympia/editors/helpers.py:306
 msgid "Binary Components"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:313
+#: src/olympia/editors/helpers.py:339
 msgid "moments ago"
 msgstr ""
 
 #. L10n: first argument is number of minutes
-#: src/olympia/editors/helpers.py:316
+#: src/olympia/editors/helpers.py:342
 msgid "{0} minute"
 msgid_plural "{0} minutes"
 msgstr[0] ""
+msgstr[1] ""
 
 #. L10n: first argument is number of hours
-#: src/olympia/editors/helpers.py:320
+#: src/olympia/editors/helpers.py:346
 msgid "{0} hour"
 msgid_plural "{0} hours"
 msgstr[0] ""
+msgstr[1] ""
 
 #. L10n: first argument is number of days
-#: src/olympia/editors/helpers.py:324
+#: src/olympia/editors/helpers.py:350
 msgid "{0} day"
 msgid_plural "{0} days"
 msgstr[0] ""
+msgstr[1] ""
 
-#: src/olympia/editors/helpers.py:488
+#: src/olympia/editors/helpers.py:364
+msgid "Last Review"
+msgstr ""
+
+#: src/olympia/editors/helpers.py:366
+msgid "Last Update"
+msgstr ""
+
+#: src/olympia/editors/helpers.py:387
+msgid "No Reviews"
+msgstr ""
+
+#: src/olympia/editors/helpers.py:561
 msgid "Push to public"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:490
+#: src/olympia/editors/helpers.py:563
 msgid "Grant full review"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:505
+#: src/olympia/editors/helpers.py:578
 msgid "Request more information"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:508
+#: src/olympia/editors/helpers.py:581
 msgid "Request super-review"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:519
+#: src/olympia/editors/helpers.py:592
 msgid "Grant preliminary review"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:520
+#: src/olympia/editors/helpers.py:593
 msgid "This will mark the files as preliminarily reviewed."
 msgstr ""
 
-#: src/olympia/editors/helpers.py:522
+#: src/olympia/editors/helpers.py:595
 msgid "Use this form to request more information from the author. They will receive an email and be able to answer here. You will be notified by email when they reply."
 msgstr ""
 
-#: src/olympia/editors/helpers.py:526
+#: src/olympia/editors/helpers.py:599
 msgid ""
 "If you have concerns about this add-on's security, copyright issues, or other concerns that an administrator should look into, enter your comments in the area below. They will be sent to "
 "administrators, not the author."
 msgstr ""
 
-#: src/olympia/editors/helpers.py:532
+#: src/olympia/editors/helpers.py:605
 msgid "This will reject the add-on and remove it from the review queue."
 msgstr ""
 
-#: src/olympia/editors/helpers.py:534
-msgid "Make a comment on this version.  The author won't be able to see this."
+#: src/olympia/editors/helpers.py:607
+msgid "Make a comment on this version. The author won't be able to see this."
 msgstr ""
 
-#: src/olympia/editors/helpers.py:538
+#: src/olympia/editors/helpers.py:611
 msgid "This will reject the files and remove them from the review queue."
 msgstr ""
 
-#: src/olympia/editors/helpers.py:542
+#: src/olympia/editors/helpers.py:615
 msgid "This will mark the add-on as preliminarily reviewed. Future versions will undergo preliminary review."
 msgstr ""
 
-#: src/olympia/editors/helpers.py:547
+#: src/olympia/editors/helpers.py:620
 msgid "This will mark the files as preliminarily reviewed. Future versions will undergo preliminary review."
 msgstr ""
 
-#: src/olympia/editors/helpers.py:552
+#: src/olympia/editors/helpers.py:625
 msgid "Retain preliminary review"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:553
+#: src/olympia/editors/helpers.py:626
 msgid "This will retain the add-on as preliminarily reviewed. Future versions will undergo preliminary review."
 msgstr ""
 
-#: src/olympia/editors/helpers.py:558
+#: src/olympia/editors/helpers.py:631
 msgid "This will approve a sandboxed version of a public add-on to appear on the public side."
 msgstr ""
 
-#: src/olympia/editors/helpers.py:561
+#: src/olympia/editors/helpers.py:634
 msgid "This will reject a version of a public add-on and remove it from the queue."
 msgstr ""
 
-#: src/olympia/editors/helpers.py:564
+#: src/olympia/editors/helpers.py:637
 msgid "This will mark the add-on and its most recent version and files as public. Future versions will go into the sandbox until they are reviewed by an editor."
 msgstr ""
 
-#: src/olympia/editors/helpers.py:637
+#: src/olympia/editors/helpers.py:714
 msgid "add-on"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:940 src/olympia/editors/helpers.py:960
+#: src/olympia/editors/helpers.py:1020 src/olympia/editors/helpers.py:1040
 msgid "Flagged"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:944 src/olympia/editors/helpers.py:963
+#: src/olympia/editors/helpers.py:1024 src/olympia/editors/helpers.py:1043
 msgid "Updates"
 msgstr ""
 
@@ -7595,56 +7510,56 @@ msgstr ""
 msgid "A question about your Theme submission"
 msgstr ""
 
-#: src/olympia/editors/views.py:144
+#: src/olympia/editors/views.py:146
 msgid "New Add-ons (Under 5 days)"
 msgstr ""
 
-#: src/olympia/editors/views.py:145
+#: src/olympia/editors/views.py:147
 msgid "Passable (5 to 10 days)"
 msgstr ""
 
-#: src/olympia/editors/views.py:146
+#: src/olympia/editors/views.py:148
 msgid "Overdue (Over 10 days)"
 msgstr ""
 
-#: src/olympia/editors/views.py:532
+#: src/olympia/editors/views.py:539
 msgid "An unknown error occurred"
 msgstr ""
 
-#: src/olympia/editors/views.py:587
+#: src/olympia/editors/views.py:592
 msgid "Self-reviews are not allowed."
 msgstr ""
 
-#: src/olympia/editors/views.py:609
+#: src/olympia/editors/views.py:613
 msgid "Review successfully processed."
 msgstr ""
 
-#: src/olympia/editors/views.py:807
+#: src/olympia/editors/views.py:812
 msgid "was approved"
 msgstr ""
 
-#: src/olympia/editors/views.py:808
+#: src/olympia/editors/views.py:813
 msgid "given preliminary review"
 msgstr ""
 
-#: src/olympia/editors/views.py:809
+#: src/olympia/editors/views.py:814
 msgid "rejected"
 msgstr ""
 
-#: src/olympia/editors/views.py:810
+#: src/olympia/editors/views.py:815
 msgctxt "editors_review_history_nominated_adminreview"
 msgid "escalated"
 msgstr ""
 
-#: src/olympia/editors/views.py:812
+#: src/olympia/editors/views.py:817
 msgid "needs more information"
 msgstr ""
 
-#: src/olympia/editors/views.py:813
+#: src/olympia/editors/views.py:818
 msgid "needs super review"
 msgstr ""
 
-#: src/olympia/editors/views.py:814
+#: src/olympia/editors/views.py:819
 msgid "commented"
 msgstr ""
 
@@ -7652,6 +7567,7 @@ msgstr ""
 msgid "{0} theme review successfully processed (+{1} points, {2} total)."
 msgid_plural "{0} theme reviews successfully processed (+{1} points, {2} total)."
 msgstr[0] ""
+msgstr[1] ""
 
 #: src/olympia/editors/views_themes.py:341
 msgid "Your theme locks have successfully been released. Other reviewers may now review those released themes. You may have to refresh the page to see the changes reflected in the table below."
@@ -7688,28 +7604,28 @@ msgstr ""
 msgid "Unlisted Queues"
 msgstr ""
 
-#: src/olympia/editors/templates/editors/base.html:72 src/olympia/editors/templates/editors/performance.html:6
+#: src/olympia/editors/templates/editors/base.html:74 src/olympia/editors/templates/editors/performance.html:6
 msgid "Performance"
 msgstr ""
 
-#: src/olympia/editors/templates/editors/base.html:75 src/olympia/editors/templates/editors/themes/base.html:19 src/olympia/editors/templates/editors/themes/base.html:38
+#: src/olympia/editors/templates/editors/base.html:77 src/olympia/editors/templates/editors/themes/base.html:19 src/olympia/editors/templates/editors/themes/base.html:38
 msgid "Logs"
 msgstr ""
 
-#: src/olympia/editors/templates/editors/base.html:78 src/olympia/editors/templates/editors/reviewlog.html:4 src/olympia/editors/templates/editors/reviewlog.html:27
+#: src/olympia/editors/templates/editors/base.html:80 src/olympia/editors/templates/editors/reviewlog.html:4 src/olympia/editors/templates/editors/reviewlog.html:27
 msgid "Add-on Review Log"
 msgstr ""
 
-#: src/olympia/editors/templates/editors/base.html:80 src/olympia/editors/templates/editors/eventlog.html:4 src/olympia/editors/templates/editors/eventlog.html:8
+#: src/olympia/editors/templates/editors/base.html:82 src/olympia/editors/templates/editors/eventlog.html:4 src/olympia/editors/templates/editors/eventlog.html:8
 #: src/olympia/editors/templates/editors/eventlog_detail.html:4
 msgid "Moderated Review Log"
 msgstr ""
 
-#: src/olympia/editors/templates/editors/base.html:82 src/olympia/editors/templates/editors/beta_signed_log.html:4 src/olympia/editors/templates/editors/beta_signed_log.html:8
+#: src/olympia/editors/templates/editors/base.html:84 src/olympia/editors/templates/editors/beta_signed_log.html:4 src/olympia/editors/templates/editors/beta_signed_log.html:8
 msgid "Signed Beta Files Log"
 msgstr ""
 
-#: src/olympia/editors/templates/editors/base.html:87 src/olympia/editors/templates/editors/includes/daily-message.html:4
+#: src/olympia/editors/templates/editors/base.html:89 src/olympia/editors/templates/editors/includes/daily-message.html:4
 msgid "Announcement"
 msgstr ""
 
@@ -7768,16 +7684,19 @@ msgstr ""
 msgid "Full Review ({num})"
 msgid_plural "Full Reviews ({num})"
 msgstr[0] ""
+msgstr[1] ""
 
 #: src/olympia/editors/templates/editors/home.html:18
 msgid "Pending Update ({num})"
 msgid_plural "Pending Updates ({num})"
 msgstr[0] ""
+msgstr[1] ""
 
 #: src/olympia/editors/templates/editors/home.html:25
 msgid "Preliminary Review ({num})"
 msgid_plural "Preliminary Reviews ({num})"
 msgstr[0] ""
+msgstr[1] ""
 
 #: src/olympia/editors/templates/editors/home.html:36 src/olympia/editors/templates/editors/home.html:86
 msgid "Current waiting times:"
@@ -7787,6 +7706,7 @@ msgstr ""
 msgid "{0} add-on"
 msgid_plural "{0} add-ons"
 msgstr[0] ""
+msgstr[1] ""
 
 #: src/olympia/editors/templates/editors/home.html:45 src/olympia/editors/templates/editors/home.html:95
 #, python-format
@@ -7797,16 +7717,19 @@ msgstr ""
 msgid "Unlisted Full Review ({num})"
 msgid_plural "Unlisted Full Reviews ({num})"
 msgstr[0] ""
+msgstr[1] ""
 
 #: src/olympia/editors/templates/editors/home.html:68
 msgid "Unlisted Pending Update ({num})"
 msgid_plural "Unlisted Pending Updates ({num})"
 msgstr[0] ""
+msgstr[1] ""
 
 #: src/olympia/editors/templates/editors/home.html:75
 msgid "Unlisted Preliminary Review ({num})"
 msgid_plural "Unlisted Preliminary Reviews ({num})"
 msgstr[0] ""
+msgstr[1] ""
 
 #: src/olympia/editors/templates/editors/home.html:109 src/olympia/editors/templates/editors/performance.html:37 src/olympia/editors/templates/editors/themes/home.html:54
 msgid "Total Reviews"
@@ -7829,6 +7752,7 @@ msgstr ""
 msgid "Moderated Review ({num})"
 msgid_plural "Moderated Reviews ({num})"
 msgstr[0] ""
+msgstr[1] ""
 
 #: src/olympia/editors/templates/editors/leaderboard.html:3 src/olympia/editors/templates/editors/includes/reviewers_score_bar.html:56
 msgid "Reviewer Leaderboard"
@@ -7922,45 +7846,45 @@ msgstr "การค้นหาขั้นสูง"
 msgid "clear search"
 msgstr "ล้างการค้นหา"
 
-#: src/olympia/editors/templates/editors/queue.html:72 src/olympia/editors/templates/editors/queue.html:122
+#: src/olympia/editors/templates/editors/queue.html:78 src/olympia/editors/templates/editors/queue.html:128
 msgid "Process Reviews"
 msgstr ""
 
-#: src/olympia/editors/templates/editors/queue.html:80
+#: src/olympia/editors/templates/editors/queue.html:86
 msgid "Moderation actions:"
 msgstr ""
 
-#: src/olympia/editors/templates/editors/queue.html:90
+#: src/olympia/editors/templates/editors/queue.html:96
 #, python-format
 msgid "by %(user)s on %(date)s %(stars)s (%(locale)s)"
 msgstr ""
 
-#: src/olympia/editors/templates/editors/queue.html:106
+#: src/olympia/editors/templates/editors/queue.html:112
 #, python-format
 msgid "<strong>%(reason)s</strong> <span class=\"light\">Flagged by %(user)s on %(date)s</span>"
 msgstr ""
 
-#: src/olympia/editors/templates/editors/queue.html:119
-msgid "All reviews have been moderated.  Good work!"
+#: src/olympia/editors/templates/editors/queue.html:125
+msgid "All reviews have been moderated. Good work!"
 msgstr ""
 
-#: src/olympia/editors/templates/editors/queue.html:161
+#: src/olympia/editors/templates/editors/queue.html:167
 msgid "Version Notes / Notes for Reviewer"
 msgstr ""
 
-#: src/olympia/editors/templates/editors/queue.html:169
+#: src/olympia/editors/templates/editors/queue.html:175
 msgid "There are currently no add-ons of this type to review."
 msgstr ""
 
-#: src/olympia/editors/templates/editors/queue.html:181 src/olympia/editors/templates/editors/themes/queue_list.html:85
+#: src/olympia/editors/templates/editors/queue.html:187 src/olympia/editors/templates/editors/themes/queue_list.html:85
 msgid "Helpful Links:"
 msgstr ""
 
-#: src/olympia/editors/templates/editors/queue.html:182
+#: src/olympia/editors/templates/editors/queue.html:188
 msgid "Add-on Policy"
 msgstr ""
 
-#: src/olympia/editors/templates/editors/queue.html:184
+#: src/olympia/editors/templates/editors/queue.html:190
 msgid "Editors' Guide"
 msgstr ""
 
@@ -8023,10 +7947,7 @@ msgid "<strong>Warning!</strong> Another user was viewing this page before you."
 msgstr ""
 
 #: src/olympia/editors/templates/editors/review.html:237
-msgid ""
-"The whiteboard is the place to exchange information relevant to\n"
-"               this addon (whatever the version), between the developer and the\n"
-"               editor. This is visible and editable by both."
+msgid "The whiteboard is the place to exchange information relevant to this addon (whatever the version), between the developer and the editor. This is visible and editable by both."
 msgstr ""
 
 #: src/olympia/editors/templates/editors/review.html:241
@@ -8169,16 +8090,19 @@ msgstr ""
 msgid "{num} Pending Theme Review"
 msgid_plural "{num} Pending Theme Reviews"
 msgstr[0] ""
+msgstr[1] ""
 
 #: src/olympia/editors/templates/editors/themes/home.html:27
 msgid "{num} Flagged Review"
 msgid_plural "{num} Flagged Reviews"
 msgstr[0] ""
+msgstr[1] ""
 
 #: src/olympia/editors/templates/editors/themes/home.html:34
 msgid "{num} Update"
 msgid_plural "{num} Updates"
 msgstr[0] ""
+msgstr[1] ""
 
 #: src/olympia/editors/templates/editors/themes/logs.html:4
 msgid "Theme Review Log"
@@ -8297,7 +8221,7 @@ msgstr ""
 msgid "Describe your reason for flagging"
 msgstr ""
 
-#: src/olympia/files/forms.py:88
+#: src/olympia/files/forms.py:90
 msgid "Cannot diff a version against itself"
 msgstr ""
 
@@ -8332,51 +8256,51 @@ msgstr ""
 msgid "There was an error accessing file %s."
 msgstr ""
 
-#: src/olympia/files/utils.py:343
+#: src/olympia/files/utils.py:340
 msgid "Could not parse uploaded file."
 msgstr ""
 
-#: src/olympia/files/utils.py:380
+#: src/olympia/files/utils.py:377
 msgid "Invalid file name in archive: {0}"
 msgstr ""
 
-#: src/olympia/files/utils.py:388
+#: src/olympia/files/utils.py:385
 msgid "File exceeding size limit in archive: {0}"
 msgstr ""
 
-#: src/olympia/files/utils.py:439
+#: src/olympia/files/utils.py:436
 msgid "Invalid archive."
 msgstr ""
 
-#: src/olympia/files/utils.py:529 src/olympia/files/utils.py:532
+#: src/olympia/files/utils.py:526 src/olympia/files/utils.py:529
 msgid "Could not parse the manifest file."
 msgstr ""
 
-#: src/olympia/files/utils.py:551
+#: src/olympia/files/utils.py:548
 msgid "Could not find an add-on ID."
 msgstr ""
 
-#: src/olympia/files/utils.py:554
+#: src/olympia/files/utils.py:551
 msgid "Add-on ID must be 64 characters or less."
 msgstr ""
 
-#: src/olympia/files/utils.py:556
+#: src/olympia/files/utils.py:553
 msgid "Add-on ID doesn't match add-on."
 msgstr ""
 
-#: src/olympia/files/utils.py:564
+#: src/olympia/files/utils.py:561
 msgid "Duplicate add-on ID found."
 msgstr ""
 
-#: src/olympia/files/utils.py:567
+#: src/olympia/files/utils.py:564
 msgid "Version numbers should have fewer than 32 characters."
 msgstr ""
 
-#: src/olympia/files/utils.py:570
+#: src/olympia/files/utils.py:567
 msgid "Version numbers should only contain letters, numbers, and these punctuation characters: +*.-_."
 msgstr ""
 
-#: src/olympia/files/utils.py:587
+#: src/olympia/files/utils.py:584
 msgid "<em:type> doesn't match add-on"
 msgstr ""
 
@@ -8477,6 +8401,10 @@ msgstr ""
 
 #: src/olympia/files/templates/files/viewer.html:134
 msgid "Fetching file."
+msgstr ""
+
+#: src/olympia/legacy_api/views.py:255
+msgid "Not implemented yet."
 msgstr ""
 
 #: src/olympia/lib/constants.py:6
@@ -9135,10 +9063,6 @@ msgstr ""
 msgid "Zimbabwe Dollar"
 msgstr ""
 
-#: src/olympia/lib/video/ffmpeg.py:112 src/olympia/lib/video/totem.py:81
-msgid "Videos must be in WebM."
-msgstr ""
-
 #: src/olympia/pages/templates/pages/about.lhtml:3 src/olympia/pages/templates/pages/about.lhtml:10
 msgid "About Mozilla Add-ons"
 msgstr ""
@@ -9150,7 +9074,7 @@ msgstr ""
 #: src/olympia/pages/templates/pages/about.lhtml:13
 msgid ""
 "addons.mozilla.org, commonly known as \"AMO\", is Mozilla's official site for add-ons to Mozilla software, such as Firefox, Thunderbird, and SeaMonkey. Add-ons let you add new features and change "
-"the way your browser or application works.  Take a look around and explore the thousands of ways to customize the way you do things online."
+"the way your browser or application works. Take a look around and explore the thousands of ways to customize the way you do things online."
 msgstr ""
 
 #: src/olympia/pages/templates/pages/about.lhtml:19
@@ -9495,7 +9419,7 @@ msgstr ""
 msgid ""
 "Yes. It's possible, but some of the functionality provided by these libraries are available through XPCOM, XUL, and JavaScript. In addition, authors should take care if libraries modify primitive "
 "object prototypes (String.prototype, Date.prototype, etc.) and/or define global functions (eg. the $ function). These are prone to cause conflict with other add-ons, in particular if different add-"
-"ons use different versions of libraries and so on. Developers need to be very, very careful with using them.  Mozilla does not offer documentation on using them to build add-ons."
+"ons use different versions of libraries and so on. Developers need to be very, very careful with using them. Mozilla does not offer documentation on using them to build add-ons."
 msgstr ""
 
 #: src/olympia/pages/templates/pages/dev_faq.html:165
@@ -9609,8 +9533,8 @@ msgstr ""
 #, python-format
 msgid ""
 "Yes. Many developers choose to host their own add-ons. Choosing to host your add-on on <a href=\"%(amo_url)s\">Mozilla's add-on site</a>, though, allows for much greater exposure to your add-on due "
-"to the large volume of visitors to the site.  <a href=\"%(md_url)s\">mozdev.org</a> offers free project hosting for Mozilla applications and extensions providing developers with tools to help "
-"manage source code, version control, bug tracking and documentation."
+"to the large volume of visitors to the site. <a href=\"%(md_url)s\">mozdev.org</a> offers free project hosting for Mozilla applications and extensions providing developers with tools to help manage "
+"source code, version control, bug tracking and documentation."
 msgstr ""
 
 #: src/olympia/pages/templates/pages/dev_faq.html:277
@@ -9658,7 +9582,7 @@ msgstr ""
 #: src/olympia/pages/templates/pages/dev_faq.html:314
 #, python-format
 msgid ""
-"Yes. Mozilla's <a href=\"%(p_url)s\">Add-on Policy</a> describes what is an acceptable submission. This policy is subject to change without notice.  In addition, the AMO editorial team uses the <a "
+"Yes. Mozilla's <a href=\"%(p_url)s\">Add-on Policy</a> describes what is an acceptable submission. This policy is subject to change without notice. In addition, the AMO editorial team uses the <a "
 "href=\"%(g_url)s\">Editors Reviewing Guide</a> to ensure that your add-on meets specific guidelines for functionality and security."
 msgstr ""
 
@@ -9775,7 +9699,7 @@ msgstr ""
 #: src/olympia/pages/templates/pages/dev_faq.html:434
 #, python-format
 msgid ""
-"This is why it's very important to read the <a href=\"%(g_url)s\">Editors Reviewing Guide</a> to ensure that your add-on is setup as expected.  It's also a good idea to read the blog post, <a href="
+"This is why it's very important to read the <a href=\"%(g_url)s\">Editors Reviewing Guide</a> to ensure that your add-on is setup as expected. It's also a good idea to read the blog post, <a href="
 "\"%(blog_url)s\">Successfully Getting your Add-on Reviewed</a> which provides excellent insight into ensuring a smooth review of your add-on."
 msgstr ""
 
@@ -9882,7 +9806,7 @@ msgstr ""
 
 #: src/olympia/pages/templates/pages/dev_faq.html:572
 msgid ""
-"Free Software Foundation provides short summaries of the key open source licenses, including whether the license qualifies as a free software license or a copyleft license.  Also includes a "
+"Free Software Foundation provides short summaries of the key open source licenses, including whether the license qualifies as a free software license or a copyleft license. Also includes a "
 "discussion of what constitutes a free software license or a copyleft license (e.g., a Copyleft license is a general method for making a program or other work free, and requiring all modified and "
 "extended versions of the program to be free as well.)"
 msgstr ""
@@ -10060,19 +9984,13 @@ msgid "Add-on Gallery"
 msgstr ""
 
 #: src/olympia/pages/templates/pages/faq.html:171
-msgid ""
-"How do I choose between add-ons that seem to do the same\n"
-"    thing?"
+msgid "How do I choose between add-ons that seem to do the same thing?"
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:173
+#: src/olympia/pages/templates/pages/faq.html:172
 msgid ""
-"There are often several add-ons that have similar features. To\n"
-"    figure out which is right for you, read the entire description of the\n"
-"    add-on and view its screenshots. If there are still several in the running,\n"
-"    read through the add-on's ratings, user reviews, and statistics to see\n"
-"    which is most liked by other users. Remember that you can also just try\n"
-"    out both and see which you like better."
+"There are often several add-ons that have similar features. To figure out which is right for you, read the entire description of the add-on and view its screenshots. If there are still several in "
+"the running, read through the add-on's ratings, user reviews, and statistics to see which is most liked by other users. Remember that you can also just try out both and see which you like better."
 msgstr ""
 
 #: src/olympia/pages/templates/pages/faq.html:180
@@ -10113,80 +10031,67 @@ msgid "How much do add-ons cost to purchase?"
 msgstr ""
 
 #: src/olympia/pages/templates/pages/faq.html:207
-msgid ""
-"Add-ons hosted in our gallery are free unless clearly marked\n"
-"    otherwise."
+msgid "Add-ons hosted in our gallery are free unless clearly marked otherwise."
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:210
+#: src/olympia/pages/templates/pages/faq.html:209
 msgid "What does it mean when an add-on asks for contributions?"
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:211
+#: src/olympia/pages/templates/pages/faq.html:210
 msgid ""
-"Some add-on authors request users who enjoy an add-on to\n"
-"        contribute to its development by making a monetary contribution. These\n"
-"        contributions go directly to the developer unless a third party is\n"
-"        indicated, such as the non-profit Mozilla Foundation."
+"Some add-on authors request users who enjoy an add-on to contribute to its development by making a monetary contribution. These contributions go directly to the developer unless a third party is "
+"indicated, such as the non-profit Mozilla Foundation."
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:216
+#: src/olympia/pages/templates/pages/faq.html:215
 msgid "What are beta add-ons?"
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:218
+#: src/olympia/pages/templates/pages/faq.html:217
 msgid ""
-"Beta add-ons are unreviewed versions which represent the\n"
-"        latest work of an add-on author. While different authors have different\n"
-"        standards for beta code quality, you should assume that these add-ons\n"
-"        are less stable than the general add-on releases."
+"Beta add-ons are unreviewed versions which represent the latest work of an add-on author. While different authors have different standards for beta code quality, you should assume that these add-"
+"ons are less stable than the general add-on releases."
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:222
+#: src/olympia/pages/templates/pages/faq.html:221
 msgid ""
 "Please note that when you install an add-on from the \"Beta Version\" section of an add-on's listing, you will continue to receive updates for that add-on as they become available. Like the initial "
 "version you installed, all beta releases are unreviewed by Mozilla and may harm your computer."
 msgstr ""
 
+#: src/olympia/pages/templates/pages/faq.html:228
+msgid "What does it mean when an add-on is flagged as slow?"
+msgstr ""
+
 #: src/olympia/pages/templates/pages/faq.html:229
-msgid ""
-"What does it mean when an add-on is flagged as\n"
-"    slow?"
+msgid "Most add-ons load code and resources at the same time Firefox is starting up. In most cases the impact in start-up time is minimal, but some add-ons can cause a noticeable slowdown."
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:231
-msgid ""
-"Most add-ons load code and resources at the same time Firefox\n"
-"        is starting up. In most cases the impact in start-up time is minimal,\n"
-"        but some add-ons can cause a noticeable slowdown."
-msgstr ""
-
-#: src/olympia/pages/templates/pages/faq.html:236
+#: src/olympia/pages/templates/pages/faq.html:234
 msgid "How do I report an inappropriate or spam user review?"
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:237
+#: src/olympia/pages/templates/pages/faq.html:235
 msgid ""
-"To report a user review of an add-on, log in with your account\n"
-"    and visit the add-on's reviews page. Find the review you wish to report,\n"
-"    click \"Report this review\" and select a reason. Our editorial team will\n"
-"    investigate the review and take appropriate action."
+"To report a user review of an add-on, log in with your account and visit the add-on's reviews page. Find the review you wish to report, click \"Report this review\" and select a reason. Our "
+"editorial team will investigate the review and take appropriate action."
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:242
+#: src/olympia/pages/templates/pages/faq.html:240
 msgid "How do I report a bug or contact the Mozilla Add-ons team?"
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:243
+#: src/olympia/pages/templates/pages/faq.html:241
 #, python-format
 msgid "Please visit our <a href=\"%(contact_url)s\">Contact page</a>."
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:246
+#: src/olympia/pages/templates/pages/faq.html:244
 msgid "What is a Source Code License?"
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:247
+#: src/olympia/pages/templates/pages/faq.html:245
 #, python-format
 msgid ""
 "The source code used to create an add-on is an exclusive copyright of the add-on author, unless otherwise declared in a source code license. Many add-ons on this site have <a href=\"%(url)s\" lang="
@@ -10194,60 +10099,60 @@ msgid ""
 "the GPL or BSD licenses instead of making up their own."
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:256
+#: src/olympia/pages/templates/pages/faq.html:254
 #, python-format
 msgid "Firefox and other Mozilla software are <a href=\"%(url)s\">open source</a>."
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:264
+#: src/olympia/pages/templates/pages/faq.html:262
 msgid "Collections and Favorites"
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:267
+#: src/olympia/pages/templates/pages/faq.html:265
 msgid "What is a collection?"
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:268
+#: src/olympia/pages/templates/pages/faq.html:266
 msgid "Collections are groups of related add-ons created by users to share."
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:270
+#: src/olympia/pages/templates/pages/faq.html:268
 msgid "What is the My Favorites collection?"
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:271
+#: src/olympia/pages/templates/pages/faq.html:269
 msgid "Favorite add-ons are add-ons that you have bookmarked to easily get back to later. You can add an add-on to your favorites collection by clicking \"Add to favorites\" on its details page."
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:275 src/olympia/templates/menu_links.html:13 src/olympia/templates/impala/header_title.html:17
+#: src/olympia/pages/templates/pages/faq.html:273 src/olympia/templates/menu_links.html:13 src/olympia/templates/impala/header_title.html:17
 msgid "Mobile Add-ons"
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:278
+#: src/olympia/pages/templates/pages/faq.html:276
 msgid "What are mobile add-ons?"
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:279
+#: src/olympia/pages/templates/pages/faq.html:277
 #, python-format
 msgid ""
 "Mobile add-ons work with <a href=\"%(mobile_url)s\">Firefox for Mobile</a> and add or modify functionality just like desktop add-ons. You can find add-ons that work with Firefox for Mobile in our "
 "<a href=\"%(gallery_url)s\">gallery</a>."
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:288
+#: src/olympia/pages/templates/pages/faq.html:286
 msgid "Developer Topics"
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:289
+#: src/olympia/pages/templates/pages/faq.html:287
 #, python-format
 msgid "Please see our <a href=\"%(faq_url)s\">Developer FAQ</a> and <a href=\"%(hub_url)s\">Developer Hub</a> for answers to add-on developer-related questions."
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:294
+#: src/olympia/pages/templates/pages/faq.html:292
 msgid "Still have questions?"
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:295
+#: src/olympia/pages/templates/pages/faq.html:293
 #, python-format
 msgid "For general Firefox support, visit our <a href=\"%(sumo_url)s\">support website</a>. For general add-on and website questions, visit our <a href=\"%(forum_url)s\">forum</a>."
 msgstr ""
@@ -10385,7 +10290,7 @@ msgstr ""
 
 #: src/olympia/pages/templates/pages/sunbird.html:29
 msgid ""
-"Development on the Sunbird project has halted and its final release was on March 30, 2010.  We've been proud to host Sunbird add-ons on this site but as the project is no longer maintained we have "
+"Development on the Sunbird project has halted and its final release was on March 30, 2010. We've been proud to host Sunbird add-ons on this site but as the project is no longer maintained we have "
 "disabled our support for the add-ons."
 msgstr ""
 
@@ -10463,7 +10368,7 @@ msgstr ""
 #, python-format
 msgid ""
 "<h2>Keep these tips in mind:</h2> <ul> <li> Write like you're telling a friend about your experience with the add-on. Give specifics and helpful details, such as what features you liked and/or "
-"disliked, how easy to use it is, and any disadvantages it has.  Avoid generic language such as calling it \"Great\" or \"Bad\" unless you can give reasons why you believe this is so. </li> <li> "
+"disliked, how easy to use it is, and any disadvantages it has. Avoid generic language such as calling it \"Great\" or \"Bad\" unless you can give reasons why you believe this is so. </li> <li> "
 "Please do not post bug reports in reviews. We do not make your email address available to add-on developers and they may need to contact you to help resolve your issue. See the <a href=\"%(support)s"
 "\">support section</a> to find out where to get assistance for this add-on. </li> <li>Please keep reviews clean, avoid the use of improper language and do not post any personal information. </li> </"
 "ul> <p>Please read the <a href=\"%(guide)s\" target=\"_blank\">Review Guidelines</a> for more detail about user add-on reviews.</p>"
@@ -10510,6 +10415,7 @@ msgstr ""
 msgid "This user has a <a href=\"%(user_review_url)s\">previous review</a> of this add-on."
 msgid_plural "This user has <a href=\"%(user_review_url)s\">%(cnt)s previous reviews</a> of this add-on."
 msgstr[0] ""
+msgstr[1] ""
 
 #: src/olympia/reviews/templates/reviews/review.html:62
 #, python-format
@@ -10555,6 +10461,7 @@ msgstr ""
 msgid "<b>{0}</b> review for this add-on"
 msgid_plural "<b>{0}</b> reviews for this add-on"
 msgstr[0] ""
+msgstr[1] ""
 
 #. {0} is a developer's name.
 #: src/olympia/reviews/templates/reviews/review_list.html:33
@@ -10566,6 +10473,7 @@ msgstr ""
 msgid "Review for %(addon)s by %(user)s"
 msgid_plural "Reviews for %(addon)s by %(user)s"
 msgstr[0] ""
+msgstr[1] ""
 
 #: src/olympia/reviews/templates/reviews/review_list.html:42
 msgid "No reviews found."
@@ -10588,6 +10496,7 @@ msgstr ""
 msgid "{num} review"
 msgid_plural "{num} reviews"
 msgstr[0] ""
+msgstr[1] ""
 
 #: src/olympia/reviews/templates/reviews/impala/reviews_rating.html:1
 msgid "Rated {0} out of 5 stars"
@@ -10614,6 +10523,7 @@ msgstr ""
 msgid "Average from {0} Rating"
 msgid_plural "Average from {0} Ratings"
 msgstr[0] ""
+msgstr[1] ""
 
 #: src/olympia/reviews/templates/reviews/mobile/review_list.html:34
 #, python-format
@@ -10629,6 +10539,7 @@ msgstr ""
 msgid "See All Reviews"
 msgid_plural "See All %(cnt)s Reviews"
 msgstr[0] ""
+msgstr[1] ""
 
 #: src/olympia/search/forms.py:11
 msgid "Most popular this week"
@@ -10693,16 +10604,16 @@ msgstr "ส่วนเสริมของ {0}"
 
 #. L10n: {0} is an application, such as Firefox. This means "any version of
 #. Firefox."
-#: src/olympia/search/views.py:554
+#: src/olympia/search/views.py:547
 msgid "Any {0}"
 msgstr ""
 
 #. L10n: "All Systems" means show everything regardless of platform.
-#: src/olympia/search/views.py:589
+#: src/olympia/search/views.py:582
 msgid "All Systems"
 msgstr ""
 
-#: src/olympia/search/views.py:600
+#: src/olympia/search/views.py:593
 msgid "All Tags"
 msgstr ""
 
@@ -10746,6 +10657,7 @@ msgstr ""
 msgid "<b>{0}</b> matching result"
 msgid_plural "<b>{0}</b> matching results"
 msgstr[0] ""
+msgstr[1] ""
 
 #: src/olympia/search/templates/search/results.html:67
 msgid "Filter Results"
@@ -10767,6 +10679,7 @@ msgstr ""
 msgid "{0} post"
 msgid_plural "{0} posts"
 msgstr[0] ""
+msgstr[1] ""
 
 #: src/olympia/sharing/__init__.py:20
 msgid "Post to Facebook"
@@ -10776,6 +10689,7 @@ msgstr ""
 msgid "{0} Like"
 msgid_plural "{0} Likes"
 msgstr[0] ""
+msgstr[1] ""
 
 #: src/olympia/sharing/__init__.py:30
 msgid "Tweet on Twitter"
@@ -10785,6 +10699,7 @@ msgstr ""
 msgid "{0} tweet"
 msgid_plural "{0} tweets"
 msgstr[0] ""
+msgstr[1] ""
 
 #: src/olympia/sharing/__init__.py:40
 msgid "Share on g+"
@@ -10818,6 +10733,7 @@ msgstr ""
 msgid "{0} post on localservice1"
 msgid_plural "{0} posts on localservice1"
 msgstr[0] ""
+msgstr[1] ""
 
 #. L10n: Only change if you have reason! wiki.mozilla.org/AMO:Localizers
 #: src/olympia/sharing/__init__.py:76
@@ -10839,6 +10755,7 @@ msgstr ""
 msgid "{0} post on localservice2"
 msgid_plural "{0} posts on localservice2"
 msgstr[0] ""
+msgstr[1] ""
 
 #. L10n: Only change if you have reason! wiki.mozilla.org/AMO:Localizers
 #: src/olympia/sharing/__init__.py:91
@@ -10860,6 +10777,7 @@ msgstr ""
 msgid "{0} post on localservice3"
 msgid_plural "{0} posts on localservice3"
 msgstr[0] ""
+msgstr[1] ""
 
 #: src/olympia/sharing/templates/sharing/sharing_widget.html:2
 msgid "Share this Add-on"
@@ -10869,31 +10787,31 @@ msgstr ""
 msgid "Share this Collection"
 msgstr ""
 
-#: src/olympia/signing/views.py:30 src/olympia/templates/base.html:75 src/olympia/templates/impala/base.html:115
+#: src/olympia/signing/views.py:33 src/olympia/templates/base.html:71 src/olympia/templates/impala/base.html:112
 msgid "Some features are temporarily disabled while we perform website maintenance. We'll be back to full capacity shortly."
 msgstr ""
 
-#: src/olympia/signing/views.py:53
+#: src/olympia/signing/views.py:56
 msgid "Could not find add-on with id \"{}\"."
 msgstr ""
 
-#: src/olympia/signing/views.py:67
+#: src/olympia/signing/views.py:70
 msgid "You do not own this addon."
 msgstr ""
 
-#: src/olympia/signing/views.py:82
+#: src/olympia/signing/views.py:87
 msgid "Missing \"upload\" key in multipart file data."
 msgstr ""
 
-#: src/olympia/signing/views.py:96
+#: src/olympia/signing/views.py:101
 msgid "Version does not match the manifest file."
 msgstr ""
 
-#: src/olympia/signing/views.py:100
+#: src/olympia/signing/views.py:105
 msgid "Version already exists."
 msgstr ""
 
-#: src/olympia/signing/views.py:136
+#: src/olympia/signing/views.py:141
 msgid "No uploaded file for that addon and version."
 msgstr ""
 
@@ -11006,89 +10924,89 @@ msgstr ""
 msgid "Statistics Dashboard :: Add-ons for {0}"
 msgstr ""
 
-#: src/olympia/stats/templates/stats/stats.html:30
-msgid "Controls:"
-msgstr ""
-
-#: src/olympia/stats/templates/stats/stats.html:33
-msgid "reset zoom"
-msgstr ""
-
-#: src/olympia/stats/templates/stats/stats.html:40
-msgid "Group by:"
-msgstr ""
-
-#: src/olympia/stats/templates/stats/stats.html:42
-msgid "day"
-msgstr ""
-
-#: src/olympia/stats/templates/stats/stats.html:45
-msgid "week"
-msgstr ""
-
-#: src/olympia/stats/templates/stats/stats.html:48
-msgid "month"
-msgstr ""
-
-#: src/olympia/stats/templates/stats/stats.html:54
-msgid "For last:"
-msgstr ""
-
-#: src/olympia/stats/templates/stats/stats.html:57
-msgid "7 days"
-msgstr ""
-
-#: src/olympia/stats/templates/stats/stats.html:60
-msgid "30 days"
-msgstr ""
-
-#: src/olympia/stats/templates/stats/stats.html:63
-msgid "90 days"
-msgstr ""
-
-#: src/olympia/stats/templates/stats/stats.html:66
-msgid "365 days"
-msgstr ""
-
-#: src/olympia/stats/templates/stats/stats.html:69
-msgid "Custom..."
-msgstr ""
-
 #. {0} is an add-on name
-#: src/olympia/stats/templates/stats/stats.html:88 src/olympia/stats/templates/stats/stats.html:91
+#: src/olympia/stats/templates/stats/stats.html:44 src/olympia/stats/templates/stats/stats.html:47
 msgid "Statistics for {0}"
 msgstr ""
 
-#: src/olympia/stats/templates/stats/stats.html:94
+#: src/olympia/stats/templates/stats/stats.html:50
 msgid "Statistics Dashboard"
 msgstr ""
 
-#: src/olympia/stats/templates/stats/stats.html:104
+#: src/olympia/stats/templates/stats/stats.html:57
+msgid "Controls:"
+msgstr ""
+
+#: src/olympia/stats/templates/stats/stats.html:60
+msgid "reset zoom"
+msgstr ""
+
+#: src/olympia/stats/templates/stats/stats.html:67
+msgid "Group by:"
+msgstr ""
+
+#: src/olympia/stats/templates/stats/stats.html:69
+msgid "day"
+msgstr ""
+
+#: src/olympia/stats/templates/stats/stats.html:72
+msgid "week"
+msgstr ""
+
+#: src/olympia/stats/templates/stats/stats.html:75
+msgid "month"
+msgstr ""
+
+#: src/olympia/stats/templates/stats/stats.html:81
+msgid "For last:"
+msgstr ""
+
+#: src/olympia/stats/templates/stats/stats.html:84
+msgid "7 days"
+msgstr ""
+
+#: src/olympia/stats/templates/stats/stats.html:87
+msgid "30 days"
+msgstr ""
+
+#: src/olympia/stats/templates/stats/stats.html:90
+msgid "90 days"
+msgstr ""
+
+#: src/olympia/stats/templates/stats/stats.html:93
+msgid "365 days"
+msgstr ""
+
+#: src/olympia/stats/templates/stats/stats.html:96
+msgid "Custom..."
+msgstr ""
+
+#: src/olympia/stats/templates/stats/stats.html:106
 msgid "Statistics processing is currently disabled, so recent data is unavailable. The statistics are still being collected and this page will be updated soon with the missing data."
 msgstr ""
 
-#: src/olympia/stats/templates/stats/stats.html:110
+#: src/olympia/stats/templates/stats/stats.html:112
 msgid "Loading the latest data&hellip;"
 msgstr ""
 
-#: src/olympia/stats/templates/stats/stats.html:142 src/olympia/stats/templates/stats/reports/overview.html:25 src/olympia/stats/templates/stats/reports/overview.html:37
+#: src/olympia/stats/templates/stats/stats.html:144 src/olympia/stats/templates/stats/reports/overview.html:25 src/olympia/stats/templates/stats/reports/overview.html:37
 #: src/olympia/stats/templates/stats/reports/overview.html:49
 msgid "No data available."
 msgstr ""
 
-#: src/olympia/stats/templates/stats/stats.html:177
+#: src/olympia/stats/templates/stats/stats.html:179
 msgid "This dashboard is currently <b>public</b>."
 msgstr ""
 
-#: src/olympia/stats/templates/stats/stats.html:179
+#: src/olympia/stats/templates/stats/stats.html:181
 msgid "Contribution stats are currently <b>private</b>."
 msgstr ""
 
-#: src/olympia/stats/templates/stats/stats.html:182
+#: src/olympia/stats/templates/stats/stats.html:184
 msgid "This dashboard is currently <b>private</b>."
 msgstr ""
 
-#: src/olympia/stats/templates/stats/stats.html:185
+#: src/olympia/stats/templates/stats/stats.html:187
 msgid "Change settings."
 msgstr ""
 
@@ -11240,15 +11158,6 @@ msgstr ""
 msgid "Application versions by Date"
 msgstr ""
 
-#: src/olympia/tags/templates/tags/top_cloud.html:4
-msgid "Top {0} Tags"
-msgstr ""
-
-#. {0} is the current application name
-#: src/olympia/tags/templates/tags/top_cloud.html:14
-msgid "{0} Top Tags"
-msgstr ""
-
 #: src/olympia/templates/amo_footer.html:6 src/olympia/templates/includes/lang_switcher.html:2
 msgid "Other languages"
 msgstr ""
@@ -11257,11 +11166,11 @@ msgstr ""
 msgid "Mozilla Add-ons"
 msgstr ""
 
-#: src/olympia/templates/base.html:91 src/olympia/templates/impala/base.html:81
+#: src/olympia/templates/base.html:89 src/olympia/templates/impala/base.html:78
 msgid "Find add-ons for other applications"
 msgstr ""
 
-#: src/olympia/templates/base.html:92 src/olympia/templates/impala/base.html:81
+#: src/olympia/templates/base.html:90 src/olympia/templates/impala/base.html:78
 msgid "Other Applications"
 msgstr ""
 
@@ -11286,7 +11195,7 @@ msgid "View Mobile Site"
 msgstr ""
 
 #: src/olympia/templates/copyright.html:7
-msgid "Site Status "
+msgid "Site Status"
 msgstr ""
 
 #: src/olympia/templates/footer.html:3
@@ -11386,35 +11295,35 @@ msgstr "ยินดีต้อนรับ {0}"
 msgid "<a href=\"%(reg)s\">Register</a> or <a href=\"%(login)s\">Log in</a>"
 msgstr ""
 
-#: src/olympia/templates/impala/base.html:126
+#: src/olympia/templates/impala/base.html:123
 #, python-format
 msgid "To try the thousands of add-ons available here, download <a href=\"%(url)s\">Mozilla Firefox</a>, a fast, free way to surf the Web!"
 msgstr ""
 
-#: src/olympia/templates/impala/base.html:138
+#: src/olympia/templates/impala/base.html:135
 #, python-format
 msgid "Add-ons is switching to Firefox Accounts for login. <a href=\"%(url)s\" class=\"fxa-login\">Sign in now to transfer your account.</a>"
 msgstr ""
 
 #. {0} is an application, such as Firefox.
-#: src/olympia/templates/impala/base.html:148
+#: src/olympia/templates/impala/base.html:145
 msgid "Welcome to {0} Add-ons."
 msgstr ""
 
-#: src/olympia/templates/impala/base.html:151
+#: src/olympia/templates/impala/base.html:148
 msgid "Choose from thousands of extra features and styles to make Firefox your own."
 msgstr ""
 
-#: src/olympia/templates/impala/base.html:156
+#: src/olympia/templates/impala/base.html:153
 #, python-format
 msgid "Add extra features and styles to make %(app)s your own."
 msgstr ""
 
-#: src/olympia/templates/impala/base.html:164
+#: src/olympia/templates/impala/base.html:161
 msgid "On the go?"
 msgstr ""
 
-#: src/olympia/templates/impala/base.html:166
+#: src/olympia/templates/impala/base.html:163
 msgid "Check out our <a class=\"mobile-link\" href=\"#\">Mobile Add-ons site</a>."
 msgstr ""
 
@@ -11638,19 +11547,19 @@ msgstr ""
 
 #. L10n: {id} will be something like "13ad6a", just a random number
 #. to differentiate this user from other anonymous users.
-#: src/olympia/users/models.py:353
+#: src/olympia/users/models.py:362
 msgid "Anonymous user {id}"
 msgstr ""
 
-#: src/olympia/users/models.py:410
+#: src/olympia/users/models.py:419
 msgid "Your account has been restricted"
 msgstr ""
 
-#: src/olympia/users/models.py:480
+#: src/olympia/users/models.py:489
 msgid "Please confirm your email address"
 msgstr ""
 
-#: src/olympia/users/models.py:506
+#: src/olympia/users/models.py:515
 msgid "My Mobile Add-ons"
 msgstr ""
 
@@ -11927,7 +11836,7 @@ msgstr ""
 
 #: src/olympia/users/templates/users/edit.html:70
 #, python-format
-msgid "Change your password.  If you forgot your password, you can <a href=\"%(reset_url)s\">use the reset form</a>."
+msgid "Change your password. If you forgot your password, you can <a href=\"%(reset_url)s\">use the reset form</a>."
 msgstr ""
 
 #: src/olympia/users/templates/users/edit.html:76
@@ -11947,7 +11856,7 @@ msgid "Profile"
 msgstr ""
 
 #: src/olympia/users/templates/users/edit.html:100
-msgid "Give us a bit more information about yourself.  All these fields are optional, but they'll help other users get to know you better."
+msgid "Give us a bit more information about yourself. All these fields are optional, but they'll help other users get to know you better."
 msgstr ""
 
 #: src/olympia/users/templates/users/edit.html:124
@@ -12163,7 +12072,7 @@ msgid "Confirm password"
 msgstr ""
 
 #: src/olympia/users/templates/users/pwreset_confirm.html:47
-msgid "The password reset link was invalid, possibly because it has already been used.  Please request a new password reset."
+msgid "The password reset link was invalid, possibly because it has already been used. Please request a new password reset."
 msgstr ""
 
 #: src/olympia/users/templates/users/pwreset_request.html:15
@@ -12349,7 +12258,7 @@ msgstr ""
 
 #: src/olympia/users/templates/users/unsubscribe.html:30
 #, python-format
-msgid "Unfortunately, we weren't able to unsubscribe you.  The link you clicked is invalid. However, you can unsubscribe still unsubscribe on your <a href=\"%(edit_url)s\">edit profile page</a>."
+msgid "Unfortunately, we weren't able to unsubscribe you. The link you clicked is invalid. However, you can unsubscribe still unsubscribe on your <a href=\"%(edit_url)s\">edit profile page</a>."
 msgstr ""
 
 #: src/olympia/users/templates/users/vcard.html:2
@@ -12381,12 +12290,14 @@ msgstr ""
 msgid "%(num)s theme"
 msgid_plural "%(num)s themes"
 msgstr[0] ""
+msgstr[1] ""
 
 #: src/olympia/users/templates/users/vcard.html:62
 #, python-format
 msgid "%(num)s add-on"
 msgid_plural "%(num)s add-ons"
 msgstr[0] ""
+msgstr[1] ""
 
 #: src/olympia/users/templates/users/vcard.html:75
 msgid "Average rating of developer's add-ons"
@@ -12401,15 +12312,15 @@ msgstr ""
 msgid "Version History with Changelogs"
 msgstr ""
 
-#: src/olympia/versions/models.py:314
+#: src/olympia/versions/models.py:313
 msgid "Add-on uses binary components."
 msgstr ""
 
-#: src/olympia/versions/models.py:317
+#: src/olympia/versions/models.py:316
 msgid "Add-on has opted into strict compatibility checking."
 msgstr ""
 
-#: src/olympia/versions/models.py:715
+#: src/olympia/versions/models.py:711
 msgid "{app} {min} and later"
 msgstr ""
 
@@ -12446,6 +12357,7 @@ msgstr ""
 msgid "<b>{0}</b> version"
 msgid_plural "<b>{0}</b> versions"
 msgstr[0] ""
+msgstr[1] ""
 
 #: src/olympia/versions/templates/versions/version_list.html:35 src/olympia/versions/templates/versions/mobile/version_list.html:14
 msgid "Be careful with old versions!"
@@ -12483,4 +12395,8 @@ msgstr ""
 
 #: src/olympia/zadmin/forms.py:105
 msgid "Log emails instead of sending"
+msgstr ""
+
+#: src/olympia/zadmin/forms.py:215
+msgid "Deleted versions can`t be changed."
 msgstr ""

--- a/locale/th/LC_MESSAGES/djangojs.po
+++ b/locale/th/LC_MESSAGES/djangojs.po
@@ -1,1201 +1,1235 @@
-
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2016-02-24 21:23+0000\n"
+"POT-Creation-Date: 2016-04-18 15:47+0000\n"
 "PO-Revision-Date: 2013-11-08 06:01+0000\n"
 "Last-Translator: earthx2 <fujiko.doramon71@gmail.com>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
+"Language: \n"
 "MIME-Version: 1.0\n"
-"Content-Type: text/plain; charset=utf-8\n"
+"Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Generated-By: Babel 2.2.0\n"
 
-#: static/js/common/ratingwidget.js:31
+#: static/js/common-all.js:1426 static/js/impala-all.js:1511 static/js/zamboni/discovery-all.js:12598 static/js/zamboni/init.js:28 static/js/zamboni/mobile-all.js:14945
+msgid "This feature is temporarily disabled while we perform website maintenance. Please check back a little later."
+msgstr "คุณสมบัตินี้ถูกปิดใช้งานชั่วคราวในขณะที่เรากำลังทำการบำรุงรักษาเว็บไซต์ โปรดกลับมาอีกครั้งในภายหลัง"
+
+#. L10n: {0} is an app name like Firefox.
+#: static/js/common-all.js:1837 static/js/impala-all.js:1922 static/js/zamboni/buttons.js:73 static/js/zamboni/discovery-all.js:13108
+msgid "Accept and Install"
+msgstr "ยอมรับและติดตั้ง"
+
+#: static/js/common-all.js:1837 static/js/impala-all.js:1922 static/js/zamboni/buttons.js:73 static/js/zamboni/discovery-all.js:13108
+msgid "Add to {0}"
+msgstr "เพิ่มไปยัง {0}"
+
+#: static/js/common-all.js:1842 static/js/impala-all.js:1927 static/js/zamboni/buttons.js:78 static/js/zamboni/discovery-all.js:13113
+msgid "Download Now"
+msgstr "ดาวน์โหลดเดี๋ยวนี้"
+
+#: static/js/common-all.js:1883 static/js/impala-all.js:1968 static/js/zamboni/buttons.js:119 static/js/zamboni/discovery-all.js:13154
+msgid "Add-on has not been updated to support default-to-compatible."
+msgstr ""
+
+#: static/js/common-all.js:1888 static/js/impala-all.js:1973 static/js/zamboni/buttons.js:124 static/js/zamboni/discovery-all.js:13159
+msgid "You need to be using Firefox 10.0 or higher."
+msgstr "คุณจำเป็นต้องใช้ Firefox 10.0 หรือสูงกว่า"
+
+#: static/js/common-all.js:1900 static/js/impala-all.js:1985 static/js/zamboni/buttons.js:136 static/js/zamboni/discovery-all.js:13171
+msgid "Mozilla has marked this version as incompatible with your Firefox version."
+msgstr "Mozilla ทำเครื่องหมายว่ารุ่นนี้ไม่เข้ากันกับรุ่น Firefox ของคุณ"
+
+#. L10n: {0} is an platform like Windows or Linux.
+#: static/js/common-all.js:1981 static/js/impala-all.js:2066 static/js/zamboni/buttons.js:217 static/js/zamboni/discovery-all.js:13252
+msgid "Install for {0} anyway"
+msgstr "ติดตั้ง {0} ต่อไป"
+
+#: static/js/common-all.js:1981 static/js/impala-all.js:2066 static/js/zamboni/buttons.js:217 static/js/zamboni/discovery-all.js:13252
+msgid "Download for {0} anyway"
+msgstr "ดาวน์โหลด {0} ต่อไป"
+
+#: static/js/common-all.js:2038 static/js/impala-all.js:2123 static/js/zamboni/buttons.js:274 static/js/zamboni/discovery-all.js:13309
+msgid "Not available for your platform"
+msgstr "ไม่พร้อมใช้งานสำหรับแพลตฟอร์มของคุณ"
+
+#. L10n: {0} is an app name, {1} is the app version.
+#: static/js/common-all.js:2049 static/js/common-all.js:2086 static/js/impala-all.js:2134 static/js/impala-all.js:2171 static/js/zamboni/buttons.js:286 static/js/zamboni/buttons.js:324
+#: static/js/zamboni/discovery-all.js:13320 static/js/zamboni/discovery-all.js:13357
+msgid "Not available for {0} {1}"
+msgstr "ไม่พร้อมใช้งานสำหรับ {0} {1}"
+
+#: static/js/common-all.js:2112 static/js/impala-all.js:2197 static/js/zamboni/buttons.js:351 static/js/zamboni/discovery-all.js:13383
+msgid "Works with {app} {min} - {max}"
+msgstr "ทำงานได้กับ {app} {min} - {max}"
+
+#: static/js/common-all.js:2114 static/js/impala-all.js:2199 static/js/zamboni/buttons.js:353 static/js/zamboni/discovery-all.js:13385
+msgid "View other versions"
+msgstr "ดูรุ่นอื่น"
+
+#: static/js/common-all.js:2162 static/js/impala-all.js:2247 static/js/zamboni/buttons.js:401 static/js/zamboni/discovery-all.js:13433
+msgid "Only with Firefox — Get Firefox Now!"
+msgstr ""
+
+#: static/js/common-all.js:2278 static/js/impala-all.js:2363 static/js/zamboni/buttons.js:517 static/js/zamboni/discovery-all.js:13549 static/js/zamboni/mobile-all.js:15177
+#: static/js/zamboni/mobile/buttons.js:43
+msgid "Sorry, you need a Mozilla-based browser (such as Firefox) to install a search plugin."
+msgstr "ขออภัย คุณจำเป็นต้องใช้เบราว์เซอร์ที่มีรากฐานมาจาก Mozilla (เช่น Firefox) เพื่อติดตั้งโปรแกรมเสริมสำหรับการค้นหา"
+
+#: static/js/common-all.js:9088 static/js/impala-all.js:9649 static/js/zamboni/global.js:410
+msgid "Loading..."
+msgstr "กำลังโหลด…"
+
+#. L10n: {0} is the number of characters left.
+#: static/js/common-all.js:9152 static/js/impala-all.js:9713 static/js/zamboni/global.js:474
+msgid "<b>{0}</b> character left."
+msgid_plural "<b>{0}</b> characters left."
+msgstr[0] "เหลือ <b>{0}</b> ตัวอักษร"
+msgstr[1] ""
+
+#: static/js/common-all.js:9589 static/js/common-min.js:6 static/js/impala-all.js:10052 static/js/impala-min.js:6 static/js/common/ratingwidget.js:31 static/js/zamboni/mobile-all.js:16123
+#: static/js/zamboni/mobile-min.js:6
 msgid "{0} star"
 msgid_plural "{0} stars"
 msgstr[0] "{0} ดาว"
+msgstr[1] ""
 
-#: static/js/common/upload-addon.js:41 static/js/common/upload-image.js:128
+#: static/js/common-all.js:9676 static/js/common-min.js:6 static/js/impala-all.js:10139 static/js/impala-min.js:6 static/js/zamboni/l10n.js:45
+msgid "Remove this localization"
+msgstr "ลบการแปลนี้"
+
+#: static/js/common-all.js:10193 static/js/common-min.js:6 static/js/impala-all.js:10674 static/js/impala-min.js:6 static/js/zamboni/discovery-all.js:13678
+msgid "close"
+msgstr ""
+
+#: static/js/common-all.js:10860 static/js/common-min.js:6 static/js/impala-all.js:11481 static/js/impala-min.js:6 static/js/impala/reviews.js:23 static/js/zamboni/reviews.js:18
+msgid "Flagged for review"
+msgstr "ปักธงสำหรับการวิจารณ์"
+
+#: static/js/common-all.js:10876 static/js/common-min.js:6 static/js/impala-all.js:11498 static/js/impala-min.js:6 static/js/impala/reviews.js:40 static/js/zamboni/reviews.js:34
+msgid "Your input is required"
+msgstr "คุณต้องป้อนข้อมูล"
+
+#: static/js/common-all.js:10945 static/js/common-min.js:6 static/js/impala-all.js:11610 static/js/impala-min.js:7 static/js/impala/reviews.js:152 static/js/zamboni/reviews.js:103
+msgid "Marked for deletion"
+msgstr "ทำเครื่องหมายสำหรับการลบ"
+
+#: static/js/common-all.js:11573 static/js/common-min.js:7 static/js/impala-all.js:13809 static/js/impala-min.js:8 static/js/zamboni/collections.js:229
+msgid "Adding to Favorites&hellip;"
+msgstr "เพิ่มเข้ารายการโปรด&hellip;"
+
+#: static/js/common-all.js:11576 static/js/common-min.js:7 static/js/impala-all.js:13812 static/js/impala-min.js:8 static/js/zamboni/collections.js:232
+msgid "Removing Favorite&hellip;"
+msgstr "เอาออกจากรายการโปรด&hellip;"
+
+#: static/js/common-all.js:11579 static/js/common-min.js:7 static/js/impala-all.js:13815 static/js/impala-min.js:8 static/js/zamboni/collections.js:235
+msgid "Add to Favorites"
+msgstr "เพิ่มเข้ารายการโปรด"
+
+#: static/js/common-all.js:11582 static/js/common-min.js:7 static/js/impala-all.js:13818 static/js/impala-min.js:8 static/js/zamboni/collections.js:238
+msgid "Remove from Favorites"
+msgstr "เอาออกจากรายการโปรด"
+
+#: static/js/common-all.js:11647 static/js/common-min.js:7 static/js/impala-all.js:13883 static/js/impala-min.js:8 static/js/zamboni/collections.js:303
+msgid "Pending"
+msgstr "กำลังรอ"
+
+#: static/js/common-all.js:11648 static/js/common-min.js:7 static/js/impala-all.js:13884 static/js/impala-min.js:8 static/js/zamboni/collections.js:304
+msgid "Add a comment"
+msgstr "แสดงความคิดเห็น"
+
+#: static/js/common-all.js:11648 static/js/common-min.js:7 static/js/impala-all.js:13884 static/js/impala-min.js:8 static/js/zamboni/collections.js:304
+msgid "Comment"
+msgstr "ความคิดเห็น"
+
+#: static/js/common-all.js:11649 static/js/common-min.js:7 static/js/impala-all.js:13885 static/js/impala-min.js:8 static/js/zamboni/collections.js:305
+msgid "Remove this add-on from the collection"
+msgstr "เอาส่วนเสริมนี้ออกจากชุด"
+
+#: static/js/common-all.js:11649 static/js/common-all.js:11678 static/js/common-min.js:7 static/js/impala-all.js:13885 static/js/impala-all.js:13914 static/js/impala-min.js:8
+#: static/js/zamboni/collections.js:305 static/js/zamboni/collections.js:334
+msgid "Remove"
+msgstr "เอาออก"
+
+#: static/js/common-all.js:11678 static/js/common-min.js:7 static/js/impala-all.js:13914 static/js/impala-min.js:8 static/js/zamboni/collections.js:334
+msgid "Remove this user as a contributor"
+msgstr ""
+
+#: static/js/common-all.js:11690 static/js/common-min.js:7 static/js/impala-all.js:13926 static/js/impala-min.js:8 static/js/zamboni/collections.js:346
+msgid "An email address is required."
+msgstr "ต้องการที่อยู่อีเมล"
+
+#: static/js/common-all.js:11708 static/js/common-min.js:7 static/js/impala-all.js:13944 static/js/impala-min.js:8 static/js/zamboni/collections.js:364
+msgid "You cannot add yourself as a contributor."
+msgstr ""
+
+#: static/js/common-all.js:11710 static/js/common-min.js:7 static/js/impala-all.js:13946 static/js/impala-min.js:8 static/js/zamboni/collections.js:366
+msgid "You have already added that user."
+msgstr "คุณได้เพิ่มผู้ใช้คนนี้แล้ว"
+
+#: static/js/common-all.js:11917 static/js/common-min.js:7 static/js/impala-all.js:14153 static/js/impala-min.js:8 static/js/zamboni/collections.js:573
+msgid "Add to favorites"
+msgstr "เพิ่มไปยังรายการโปรด"
+
+#: static/js/common-all.js:11921 static/js/common-min.js:7 static/js/impala-all.js:14157 static/js/impala-min.js:8 static/js/zamboni/collections.js:577
+msgid "Remove from favorites"
+msgstr "เอาออกจากรายการโปรด"
+
+#: static/js/common-all.js:11939 static/js/common-min.js:7 static/js/impala-all.js:14175 static/js/impala-all.js:14233 static/js/impala-min.js:8 static/js/impala/collections.js:10
+#: static/js/zamboni/collections.js:595
+msgid "Follow this Collection"
+msgstr "ติดตามชุดนี้"
+
+#: static/js/common-all.js:11948 static/js/common-min.js:7 static/js/impala-all.js:14184 static/js/impala-min.js:8 static/js/zamboni/collections.js:604
+msgid "Stop following"
+msgstr "หยุดการติดตาม"
+
+#: static/js/common-all.js:12096 static/js/common-min.js:7 static/js/zamboni/password-strength.js:20
+msgid "Password strength:"
+msgstr "ความแข็งแกร่งของรหัสผ่าน:"
+
+#: static/js/common-all.js:12102 static/js/common-min.js:7 static/js/zamboni/password-strength.js:26
+msgid "At least {0} character left."
+msgid_plural "At least {0} characters left."
+msgstr[0] "ยังเหลืออีกอย่างน้อย {0} ตัวอักษร"
+msgstr[1] ""
+
+#: static/js/common-all.js:12286 static/js/common-min.js:7 static/js/impala-all.js:14632 static/js/impala-min.js:8 static/js/impala/suggestions.js:39
+msgid "Search themes for <b>{0}</b>"
+msgstr ""
+
+#: static/js/common-all.js:12288 static/js/common-min.js:7 static/js/impala-all.js:14634 static/js/impala-min.js:8 static/js/impala/suggestions.js:41
+msgid "Search apps for <b>{0}</b>"
+msgstr "ค้นหาแอพสำหรับ <b>{0}</b>"
+
+#: static/js/common-all.js:12290 static/js/common-min.js:7 static/js/impala-all.js:14636 static/js/impala-min.js:8 static/js/impala/suggestions.js:43
+msgid "Search add-ons for <b>{0}</b>"
+msgstr "ค้นหาส่วนเสริมสำหรับ <b>{0}</b>"
+
+#: static/js/common-all.js:12521 static/js/common-min.js:7 static/js/impala-all.js:14867 static/js/impala-min.js:8 static/js/impala/site_suggestions.js:46
+msgid "Category"
+msgstr "หมวดหมู่"
+
+#. L10n: {0} is an app name.
+#: static/js/impala-all.js:11632 static/js/impala-min.js:7 static/js/impala/listing.js:11 static/js/zamboni/themes.js:13
+msgid "This theme is incompatible with your version of {0}"
+msgstr "ชุดตกแต่งนี้เข้ากันไม่ได้กับรุ่น {0} ของคุณ"
+
+#: static/js/impala-all.js:12146 static/js/impala-all.js:14331 static/js/impala-min.js:7 static/js/impala-min.js:8 static/js/common/upload-image.js:97 static/js/impala/users.js:51
+#: static/js/zamboni/devhub-all.js:894 static/js/zamboni/devhub-min.js:1
+msgid "Images must be either PNG or JPG."
+msgstr "รูปภาพต้องเป็น PNG หรือไม่ก็ JPG"
+
+#: static/js/impala-all.js:12150 static/js/impala-min.js:7 static/js/common/upload-image.js:101 static/js/zamboni/devhub-all.js:898 static/js/zamboni/devhub-min.js:1
+msgid "Videos must be in WebM."
+msgstr "วิดีโอต้องเป็นแบบ WebM"
+
+#: static/js/impala-all.js:12177 static/js/impala-min.js:7 static/js/common/upload-addon.js:41 static/js/common/upload-image.js:128 static/js/zamboni/devhub-all.js:272
+#: static/js/zamboni/devhub-all.js:925 static/js/zamboni/devhub-min.js:1
 msgid "There was a problem contacting the server."
 msgstr "มีปัญหาในการติดต่อกับเซอร์เวอร์"
 
-#: static/js/common/upload-addon.js:69
+#: static/js/impala-all.js:13298 static/js/impala-min.js:7 static/js/impala/persona_creation.js:60
+msgid "All Rights Reserved"
+msgstr "สงวนลิขสิทธิ์"
+
+#: static/js/impala-all.js:13302 static/js/impala-min.js:7 static/js/impala/persona_creation.js:64
+msgid "Creative Commons Attribution 3.0"
+msgstr "สัญญาอนุญาตครีเอทีฟคอมมอนส์ 3.0"
+
+#: static/js/impala-all.js:13307 static/js/impala-min.js:7 static/js/impala/persona_creation.js:69
+msgid "Creative Commons Attribution-NonCommercial 3.0"
+msgstr "สัญญาอนุญาตครีเอทีฟคอมมอนส์-ไม่ใช้เพื่อการค้า 3.0"
+
+#: static/js/impala-all.js:13312 static/js/impala-min.js:7 static/js/impala/persona_creation.js:74
+msgid "Creative Commons Attribution-NonCommercial-NoDerivs 3.0"
+msgstr "สัญญาอนุญาตครีเอทีฟคอมมอนส์-ไม่ใช้เพื่อการค้า-ไม่ดัดแปลง 3.0"
+
+#: static/js/impala-all.js:13317 static/js/impala-min.js:7 static/js/impala/persona_creation.js:79
+msgid "Creative Commons Attribution-NonCommercial-Share Alike 3.0"
+msgstr "สัญญาอนุญาตครีเอทีฟคอมมอนส์-ไม่ใช้เพื่อการค้า-อนุญาตแบบเดียวกัน 3.0"
+
+#: static/js/impala-all.js:13322 static/js/impala-min.js:7 static/js/impala/persona_creation.js:84
+msgid "Creative Commons Attribution-NoDerivs 3.0"
+msgstr "สัญญาอนุญาตครีเอทีฟคอมมอนส์-ไม่ดัดแปลง 3.0"
+
+#: static/js/impala-all.js:13327 static/js/impala-min.js:7 static/js/impala/persona_creation.js:89
+msgid "Creative Commons Attribution-ShareAlike 3.0"
+msgstr "สัญญาอนุญาตครีเอทีฟคอมมอนส์-อนุญาตแบบเดียวกัน 3.0"
+
+#: static/js/impala-all.js:13530 static/js/impala-min.js:7 static/js/impala/persona_creation.js:292
+msgid "Your Theme's Name"
+msgstr "ชื่อชุดตกแต่งของคุณ"
+
+#: static/js/impala-all.js:14242 static/js/impala-min.js:8 static/js/impala/collections.js:19
+msgid "Stop Following"
+msgstr "เลิกติดตาม"
+
+#: static/js/impala-all.js:14243 static/js/impala-min.js:8 static/js/impala/collections.js:20
+msgid "Following"
+msgstr "กำลังติดตาม"
+
+#: static/js/impala-all.js:14313 static/js/impala-min.js:8 static/js/impala/users.js:33
+msgid "use original"
+msgstr "ใช้ต้นฉบับ"
+
+#: static/js/impala-all.js:14523 static/js/impala-min.js:8 static/js/impala/search.js:114
+msgid "Updating results&hellip;"
+msgstr "กำลังปรับปรุงผลลัพธ์&hellip;"
+
+#: static/js/common/upload-addon.js:69 static/js/zamboni/devhub-all.js:300 static/js/zamboni/devhub-min.js:1
 msgid "Select a file..."
 msgstr "เลือกไฟล์…"
 
-#: static/js/common/upload-addon.js:70
+#: static/js/common/upload-addon.js:70 static/js/zamboni/devhub-all.js:301 static/js/zamboni/devhub-min.js:1
 msgid "Your add-on should end with .xpi, .jar or .xml"
 msgstr "ส่วนเสริมของคุณควรลงท้ายด้วย .xpi .jar หรือ .xml"
 
 #. L10n: {0} is the percent of the file that has been uploaded.
-#: static/js/common/upload-addon.js:104
+#: static/js/common/upload-addon.js:104 static/js/zamboni/devhub-all.js:335 static/js/zamboni/devhub-min.js:1
 #, fuzzy, python-format
 msgid "{0}% complete"
 msgstr "เสร็จสิ้น {0}%"
 
 #. L10n: "{bytes uploaded} of {total filesize}".
-#: static/js/common/upload-addon.js:107
+#: static/js/common/upload-addon.js:107 static/js/zamboni/devhub-all.js:338 static/js/zamboni/devhub-min.js:1
 msgid "{0} of {1}"
 msgstr "{0} จาก {1}"
 
-#: static/js/common/upload-addon.js:140
+#: static/js/common/upload-addon.js:140 static/js/zamboni/devhub-all.js:371 static/js/zamboni/devhub-min.js:1
 msgid "Cancel"
 msgstr "ยกเลิก"
 
-#: static/js/common/upload-addon.js:162
+#: static/js/common/upload-addon.js:162 static/js/zamboni/devhub-all.js:393 static/js/zamboni/devhub-min.js:1
 msgid "Uploading {0}"
 msgstr "กำลังอัปโหลด {0}"
 
-#: static/js/common/upload-addon.js:189
+#: static/js/common/upload-addon.js:189 static/js/zamboni/devhub-all.js:420 static/js/zamboni/devhub-min.js:1
 msgid "Error with {0}"
 msgstr "เกิดข้อผิดพลาดกับ {0}"
 
-#: static/js/common/upload-addon.js:194
+#: static/js/common/upload-addon.js:194 static/js/zamboni/devhub-all.js:425 static/js/zamboni/devhub-min.js:1
 msgid "Your add-on failed validation with {0} error."
 msgid_plural "Your add-on failed validation with {0} errors."
 msgstr[0] "ส่วนเสริมของคุณไม่ผ่านการตรวจสอบด้วย {0} ข้อผิดพลาด"
+msgstr[1] ""
 
-#: static/js/common/upload-addon.js:208
+#: static/js/common/upload-addon.js:208 static/js/zamboni/devhub-all.js:439 static/js/zamboni/devhub-min.js:1
 msgid "&hellip;and {0} more"
 msgid_plural "&hellip;and {0} more"
 msgstr[0] "&hellip;และอื่นๆ {0}"
+msgstr[1] ""
 
-#: static/js/common/upload-addon.js:222 static/js/common/upload-addon.js:512
+#: static/js/common/upload-addon.js:222 static/js/common/upload-addon.js:497 static/js/zamboni/devhub-all.js:453 static/js/zamboni/devhub-all.js:743 static/js/zamboni/devhub-min.js:1
 msgid "See full validation report"
 msgstr "ดูรายงานการตรวจสอบ"
 
-#: static/js/common/upload-addon.js:234
+#: static/js/common/upload-addon.js:234 static/js/zamboni/devhub-all.js:465 static/js/zamboni/devhub-min.js:1
 msgid "Validating {0}"
 msgstr "กำลังตรวจสอบ {0}"
 
 #. L10n: first argument is an HTTP status code
-#: static/js/common/upload-addon.js:273
+#: static/js/common/upload-addon.js:273 static/js/zamboni/devhub-all.js:504 static/js/zamboni/devhub-min.js:1
 msgid "Received an empty response from the server; status: {0}"
 msgstr "ได้รับการตอบสนองที่ว่างเปล่าจากแม่ข่าย; สถานะ: {0}"
 
-#: static/js/common/upload-addon.js:373
+#: static/js/common/upload-addon.js:370 static/js/zamboni/devhub-all.js:604 static/js/zamboni/devhub-min.js:1
 msgid "Unexpected server error while validating."
 msgstr "ข้อผิดพลาดของแม่ข่ายที่ไม่คาดคิดขณะกำลังทำการตรวจสอบ"
 
-#: static/js/common/upload-addon.js:412
+#: static/js/common/upload-addon.js:409 static/js/zamboni/devhub-all.js:643 static/js/zamboni/devhub-min.js:1
 msgid "Finished validating {0}"
 msgstr "เสร็จสิ้นการตรวจสอบ {0}"
 
-#: static/js/common/upload-addon.js:418
+#: static/js/common/upload-addon.js:415 static/js/zamboni/devhub-all.js:649 static/js/zamboni/devhub-min.js:1
 msgid "Your add-on validation timed out, it will be manually reviewed."
 msgstr ""
 
-#: static/js/common/upload-addon.js:421
+#: static/js/common/upload-addon.js:418 static/js/zamboni/devhub-all.js:652 static/js/zamboni/devhub-min.js:1
 msgid "Your add-on was validated with no errors and {0} warning."
 msgid_plural "Your add-on was validated with no errors and {0} warnings."
 msgstr[0] ""
+msgstr[1] ""
 
-#: static/js/common/upload-addon.js:426
+#: static/js/common/upload-addon.js:423 static/js/zamboni/devhub-all.js:657 static/js/zamboni/devhub-min.js:1
 msgid "Your add-on was validated with no errors and {0} message."
 msgid_plural "Your add-on was validated with no errors and {0} messages."
 msgstr[0] ""
+msgstr[1] ""
 
-#: static/js/common/upload-addon.js:431
+#: static/js/common/upload-addon.js:428 static/js/zamboni/devhub-all.js:662 static/js/zamboni/devhub-min.js:1
 msgid "Your add-on was validated with no errors or warnings."
 msgstr ""
 
-#: static/js/common/upload-addon.js:446
+#: static/js/common/upload-addon.js:443 static/js/zamboni/devhub-all.js:677 static/js/zamboni/devhub-min.js:1
 msgid "Your submission will be automatically signed."
 msgstr ""
 
-#: static/js/common/upload-addon.js:465
+#: static/js/common/upload-addon.js:450 static/js/zamboni/devhub-all.js:696 static/js/zamboni/devhub-min.js:1
 msgid "Include detailed version notes (this can be done in the next step)."
 msgstr ""
 
-#: static/js/common/upload-addon.js:466
+#: static/js/common/upload-addon.js:451 static/js/zamboni/devhub-all.js:697 static/js/zamboni/devhub-min.js:1
 msgid "If your add-on requires an account to a website in order to be fully tested, include a test username and password in the Notes to Reviewer (this can be done in the next step)."
 msgstr ""
 
-#: static/js/common/upload-addon.js:467
+#: static/js/common/upload-addon.js:452 static/js/zamboni/devhub-all.js:698 static/js/zamboni/devhub-min.js:1
 msgid "If your add-on is intended for a limited audience you should choose Preliminary Review instead of Full Review."
 msgstr ""
 
-#: static/js/common/upload-addon.js:480
+#: static/js/common/upload-addon.js:465 static/js/zamboni/devhub-all.js:711 static/js/zamboni/devhub-min.js:1
 msgid "Add-on submission checklist"
 msgstr ""
 
-#: static/js/common/upload-addon.js:481
+#: static/js/common/upload-addon.js:466 static/js/zamboni/devhub-all.js:712 static/js/zamboni/devhub-min.js:1
 msgid "Please verify the following points before finalizing your submission. This will minimize delays or misunderstanding during the review process:"
 msgstr ""
 
-#: static/js/common/upload-addon.js:483
+#: static/js/common/upload-addon.js:468 static/js/zamboni/devhub-all.js:714 static/js/zamboni/devhub-min.js:1
 msgid ""
 "Compiled binaries, as well as minified or obfuscated scripts (excluding known libraries) need to have their sources submitted separately for review. Make sure that you use the source code upload "
 "field to avoid having your submission rejected."
 msgstr ""
 
-#: static/js/common/upload-addon.js:501
+#: static/js/common/upload-addon.js:486 static/js/zamboni/devhub-all.js:732 static/js/zamboni/devhub-min.js:1
 msgid "The validation process found these issues that can lead to rejections:"
 msgstr ""
 
-#: static/js/common/upload-addon.js:518
+#: static/js/common/upload-addon.js:503 static/js/zamboni/devhub-all.js:749 static/js/zamboni/devhub-min.js:1
 msgid "If you are unfamiliar with the add-ons review process, you can read about it here."
 msgstr ""
 
-#: static/js/common/upload-addon.js:555
+#: static/js/common/upload-addon.js:540 static/js/zamboni/devhub-all.js:786 static/js/zamboni/devhub-min.js:1
 msgid "Sorry, no supported platform has been found."
 msgstr ""
 
-#: static/js/common/upload-base.js:57
+#: static/js/common/upload-base.js:57 static/js/zamboni/devhub-all.js:187 static/js/zamboni/devhub-min.js:1
 msgid "The filetype you uploaded isn't recognized."
 msgstr "ไม่รู้จักรูปแบบไฟล์ที่คุณอัปโหลด"
 
-#: static/js/common/upload-base.js:79
+#: static/js/common/upload-base.js:79 static/js/zamboni/devhub-all.js:209 static/js/zamboni/devhub-min.js:1
 msgid "You cancelled the upload."
 msgstr "คุณได้ยกเลิกการอัปโหลด"
 
-#: static/js/common/upload-image.js:97 static/js/impala/users.js:51
-msgid "Images must be either PNG or JPG."
-msgstr "รูปภาพต้องเป็น PNG หรือไม่ก็ JPG"
-
-#: static/js/common/upload-image.js:101
-msgid "Videos must be in WebM."
-msgstr "วิดีโอต้องเป็นแบบ WebM"
-
-#: static/js/impala/collections.js:10 static/js/zamboni/collections.js:595
-msgid "Follow this Collection"
-msgstr "ติดตามชุดนี้"
-
-#: static/js/impala/collections.js:19
-msgid "Stop Following"
-msgstr "เลิกติดตาม"
-
-#: static/js/impala/collections.js:20
-msgid "Following"
-msgstr "กำลังติดตาม"
-
-#. L10n: {0} is an app name.
-#: static/js/impala/listing.js:11 static/js/zamboni/themes.js:13
-msgid "This theme is incompatible with your version of {0}"
-msgstr "ชุดตกแต่งนี้เข้ากันไม่ได้กับรุ่น {0} ของคุณ"
-
-#: static/js/impala/persona_creation.js:60
-msgid "All Rights Reserved"
-msgstr "สงวนลิขสิทธิ์"
-
-#: static/js/impala/persona_creation.js:64
-msgid "Creative Commons Attribution 3.0"
-msgstr "สัญญาอนุญาตครีเอทีฟคอมมอนส์ 3.0"
-
-#: static/js/impala/persona_creation.js:69
-msgid "Creative Commons Attribution-NonCommercial 3.0"
-msgstr "สัญญาอนุญาตครีเอทีฟคอมมอนส์-ไม่ใช้เพื่อการค้า 3.0"
-
-#: static/js/impala/persona_creation.js:74
-msgid "Creative Commons Attribution-NonCommercial-NoDerivs 3.0"
-msgstr "สัญญาอนุญาตครีเอทีฟคอมมอนส์-ไม่ใช้เพื่อการค้า-ไม่ดัดแปลง 3.0"
-
-#: static/js/impala/persona_creation.js:79
-msgid "Creative Commons Attribution-NonCommercial-Share Alike 3.0"
-msgstr "สัญญาอนุญาตครีเอทีฟคอมมอนส์-ไม่ใช้เพื่อการค้า-อนุญาตแบบเดียวกัน 3.0"
-
-#: static/js/impala/persona_creation.js:84
-msgid "Creative Commons Attribution-NoDerivs 3.0"
-msgstr "สัญญาอนุญาตครีเอทีฟคอมมอนส์-ไม่ดัดแปลง 3.0"
-
-#: static/js/impala/persona_creation.js:89
-msgid "Creative Commons Attribution-ShareAlike 3.0"
-msgstr "สัญญาอนุญาตครีเอทีฟคอมมอนส์-อนุญาตแบบเดียวกัน 3.0"
-
-#: static/js/impala/persona_creation.js:292
-msgid "Your Theme's Name"
-msgstr "ชื่อชุดตกแต่งของคุณ"
-
-#: static/js/impala/reviews.js:23 static/js/zamboni/reviews.js:18
-msgid "Flagged for review"
-msgstr "ปักธงสำหรับการวิจารณ์"
-
-#: static/js/impala/reviews.js:40 static/js/zamboni/reviews.js:34
-msgid "Your input is required"
-msgstr "คุณต้องป้อนข้อมูล"
-
-#: static/js/impala/reviews.js:152 static/js/zamboni/reviews.js:103
-msgid "Marked for deletion"
-msgstr "ทำเครื่องหมายสำหรับการลบ"
-
-#: static/js/impala/search.js:114
-msgid "Updating results&hellip;"
-msgstr "กำลังปรับปรุงผลลัพธ์&hellip;"
-
-#: static/js/impala/site_suggestions.js:46
-msgid "Category"
-msgstr "หมวดหมู่"
-
-#: static/js/impala/suggestions.js:39
-msgid "Search themes for <b>{0}</b>"
-msgstr ""
-
-#: static/js/impala/suggestions.js:41
-msgid "Search apps for <b>{0}</b>"
-msgstr "ค้นหาแอพสำหรับ <b>{0}</b>"
-
-#: static/js/impala/suggestions.js:43
-msgid "Search add-ons for <b>{0}</b>"
-msgstr "ค้นหาส่วนเสริมสำหรับ <b>{0}</b>"
-
-#: static/js/impala/users.js:33
-msgid "use original"
-msgstr "ใช้ต้นฉบับ"
-
-#: static/js/impala/stats/chart.js:267
+#: static/js/impala/stats/chart.js:267 static/js/zamboni/stats-all.js:16898 static/js/zamboni/stats-min.js:5
 msgid "Week of {0}"
 msgstr "สัปดาห์ที่ {0}"
 
-#: static/js/impala/stats/chart.js:269
+#: static/js/impala/stats/chart.js:269 static/js/zamboni/stats-all.js:16900 static/js/zamboni/stats-min.js:5
 msgid " downloads"
 msgstr ""
 
-#: static/js/impala/stats/chart.js:270
+#: static/js/impala/stats/chart.js:270 static/js/zamboni/stats-all.js:16901 static/js/zamboni/stats-min.js:5
 msgid "{0} users"
 msgstr "{0} ผู้ใช้"
 
-#: static/js/impala/stats/chart.js:271
+#: static/js/impala/stats/chart.js:271 static/js/zamboni/stats-all.js:16902 static/js/zamboni/stats-min.js:5
 msgid "{0} add-ons"
 msgstr "{0} ส่วนเสริม"
 
-#: static/js/impala/stats/chart.js:272
+#: static/js/impala/stats/chart.js:272 static/js/zamboni/stats-all.js:16903 static/js/zamboni/stats-min.js:5
 msgid "{0} collections"
 msgstr "{0} ชุด"
 
-#: static/js/impala/stats/chart.js:273
+#: static/js/impala/stats/chart.js:273 static/js/zamboni/stats-all.js:16904 static/js/zamboni/stats-min.js:5
 msgid "{0} reviews"
 msgstr "{0} บทวิจารณ์"
 
-#: static/js/impala/stats/chart.js:275
+#: static/js/impala/stats/chart.js:275 static/js/zamboni/stats-all.js:16906 static/js/zamboni/stats-min.js:5
 msgid "{0} sales"
 msgstr "{0} การขาย"
 
-#: static/js/impala/stats/chart.js:276
+#: static/js/impala/stats/chart.js:276 static/js/zamboni/stats-all.js:16907 static/js/zamboni/stats-min.js:5
 msgid "{0} refunds"
 msgstr "{0} การคืนเงิน"
 
-#: static/js/impala/stats/chart.js:277
+#: static/js/impala/stats/chart.js:277 static/js/zamboni/stats-all.js:16908 static/js/zamboni/stats-min.js:5
 msgid "{0} installs"
 msgstr "{0} การติดตั้ง"
 
-#: static/js/impala/stats/chart.js:369 static/js/impala/stats/csv_keys.js:3 static/js/impala/stats/csv_keys.js:109
+#: static/js/impala/stats/chart.js:369 static/js/impala/stats/csv_keys.js:3 static/js/impala/stats/csv_keys.js:109 static/js/zamboni/stats-all.js:15284 static/js/zamboni/stats-all.js:15390
+#: static/js/zamboni/stats-all.js:17000 static/js/zamboni/stats-min.js:4 static/js/zamboni/stats-min.js:5
 msgid "Downloads"
 msgstr "ดาวน์โหลด"
 
-#: static/js/impala/stats/chart.js:379 static/js/impala/stats/csv_keys.js:6 static/js/impala/stats/csv_keys.js:110
+#: static/js/impala/stats/chart.js:379 static/js/impala/stats/csv_keys.js:6 static/js/impala/stats/csv_keys.js:110 static/js/zamboni/stats-all.js:15287 static/js/zamboni/stats-all.js:15391
+#: static/js/zamboni/stats-all.js:17010 static/js/zamboni/stats-min.js:4 static/js/zamboni/stats-min.js:5
 msgid "Daily Users"
 msgstr "ผู้ใช้ต่อวัน"
 
-#: static/js/impala/stats/chart.js:410
+#: static/js/impala/stats/chart.js:410 static/js/zamboni/stats-all.js:17041 static/js/zamboni/stats-min.js:5
 msgid "Amount, in USD"
 msgstr "จำนวนในดอลลาร์สหรัฐ"
 
-#: static/js/impala/stats/chart.js:421 static/js/impala/stats/csv_keys.js:104
+#: static/js/impala/stats/chart.js:421 static/js/impala/stats/csv_keys.js:104 static/js/zamboni/stats-all.js:15385 static/js/zamboni/stats-all.js:17052 static/js/zamboni/stats-min.js:5
 msgid "Number of Contributions"
 msgstr "จำนวนการบริจาค"
 
-#: static/js/impala/stats/chart.js:447
+#: static/js/impala/stats/chart.js:447 static/js/zamboni/stats-all.js:17078 static/js/zamboni/stats-min.js:5
 msgid "More Info..."
 msgstr "ข้อมูลเพิ่มเติม..."
 
 #. L10n: {0} is an ISO-formatted date.
-#: static/js/impala/stats/chart.js:451
+#: static/js/impala/stats/chart.js:451 static/js/zamboni/stats-all.js:17082 static/js/zamboni/stats-min.js:5
 msgid "Details for {0}"
 msgstr "รายละเอียดสำหรับ {0}"
 
-#: static/js/impala/stats/csv_keys.js:9
+#: static/js/impala/stats/csv_keys.js:9 static/js/zamboni/stats-all.js:15290 static/js/zamboni/stats-min.js:4
 msgid "Collections Created"
 msgstr "ชุดที่สร้างแล้ว"
 
-#: static/js/impala/stats/csv_keys.js:12
+#: static/js/impala/stats/csv_keys.js:12 static/js/zamboni/stats-all.js:15293 static/js/zamboni/stats-min.js:4
 msgid "Add-ons in Use"
 msgstr "ส่วนเสริมที่ใช้อยู่"
 
-#: static/js/impala/stats/csv_keys.js:15
+#: static/js/impala/stats/csv_keys.js:15 static/js/zamboni/stats-all.js:15296 static/js/zamboni/stats-min.js:4
 msgid "Add-ons Created"
 msgstr "ส่วนเสริมที่สร้าง"
 
-#: static/js/impala/stats/csv_keys.js:18
+#: static/js/impala/stats/csv_keys.js:18 static/js/zamboni/stats-all.js:15299 static/js/zamboni/stats-min.js:4
 msgid "Add-ons Downloaded"
 msgstr "ส่วนเสริมที่ดาวน์โหลด"
 
-#: static/js/impala/stats/csv_keys.js:21
+#: static/js/impala/stats/csv_keys.js:21 static/js/zamboni/stats-all.js:15302 static/js/zamboni/stats-min.js:4
 msgid "Add-ons Updated"
 msgstr "ส่วนเสริมที่ปรับปรุง"
 
-#: static/js/impala/stats/csv_keys.js:24
+#: static/js/impala/stats/csv_keys.js:24 static/js/zamboni/stats-all.js:15305 static/js/zamboni/stats-min.js:4
 msgid "Reviews Written"
 msgstr "เขียนบทวิจารณ์แล้ว"
 
-#: static/js/impala/stats/csv_keys.js:27
+#: static/js/impala/stats/csv_keys.js:27 static/js/zamboni/stats-all.js:15308 static/js/zamboni/stats-min.js:4
 msgid "User Signups"
 msgstr "ผู้ใช้ที่ลงทะเบียน"
 
-#: static/js/impala/stats/csv_keys.js:30
+#: static/js/impala/stats/csv_keys.js:30 static/js/zamboni/stats-all.js:15311 static/js/zamboni/stats-min.js:4
 msgid "Subscribers"
 msgstr "ผู้ติดตาม"
 
-#: static/js/impala/stats/csv_keys.js:33
+#: static/js/impala/stats/csv_keys.js:33 static/js/zamboni/stats-all.js:15314 static/js/zamboni/stats-min.js:4
 msgid "Ratings"
 msgstr "การจัดอันดับ"
 
-#: static/js/impala/stats/csv_keys.js:36 static/js/impala/stats/csv_keys.js:114
+#: static/js/impala/stats/csv_keys.js:36 static/js/impala/stats/csv_keys.js:114 static/js/zamboni/stats-all.js:15317 static/js/zamboni/stats-all.js:15395 static/js/zamboni/stats-min.js:4
+#: static/js/zamboni/stats-min.js:5
 msgid "Sales"
 msgstr "ขาย"
 
-#: static/js/impala/stats/csv_keys.js:39 static/js/impala/stats/csv_keys.js:113
+#: static/js/impala/stats/csv_keys.js:39 static/js/impala/stats/csv_keys.js:113 static/js/zamboni/stats-all.js:15320 static/js/zamboni/stats-all.js:15394 static/js/zamboni/stats-min.js:4
+#: static/js/zamboni/stats-min.js:5
 msgid "Installs"
 msgstr "ติดตั้ง"
 
-#: static/js/impala/stats/csv_keys.js:42
+#: static/js/impala/stats/csv_keys.js:42 static/js/zamboni/stats-all.js:15323 static/js/zamboni/stats-min.js:4
 msgid "Unknown"
 msgstr "ไม่ทราบ"
 
-#: static/js/impala/stats/csv_keys.js:43
+#: static/js/impala/stats/csv_keys.js:43 static/js/zamboni/stats-all.js:15324 static/js/zamboni/stats-min.js:4
 msgid "Add-ons Manager"
 msgstr "ตัวจัดการส่วนเสริม"
 
-#: static/js/impala/stats/csv_keys.js:44
+#: static/js/impala/stats/csv_keys.js:44 static/js/zamboni/stats-all.js:15325 static/js/zamboni/stats-min.js:4
 msgid "Add-ons Manager Promo"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:45
+#: static/js/impala/stats/csv_keys.js:45 static/js/zamboni/stats-all.js:15326 static/js/zamboni/stats-min.js:4
 msgid "Add-ons Manager Featured"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:46
+#: static/js/impala/stats/csv_keys.js:46 static/js/zamboni/stats-all.js:15327 static/js/zamboni/stats-min.js:4
 msgid "Add-ons Manager Learn More"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:47
+#: static/js/impala/stats/csv_keys.js:47 static/js/zamboni/stats-all.js:15328 static/js/zamboni/stats-min.js:4
 msgid "Search Suggestions"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:48
+#: static/js/impala/stats/csv_keys.js:48 static/js/zamboni/stats-all.js:15329 static/js/zamboni/stats-min.js:4
 msgid "Search Results"
 msgstr "ผลลัพธ์การค้นหา"
 
-#: static/js/impala/stats/csv_keys.js:49 static/js/impala/stats/csv_keys.js:50 static/js/impala/stats/csv_keys.js:51
+#: static/js/impala/stats/csv_keys.js:49 static/js/impala/stats/csv_keys.js:50 static/js/impala/stats/csv_keys.js:51 static/js/zamboni/stats-all.js:15330 static/js/zamboni/stats-all.js:15331
+#: static/js/zamboni/stats-all.js:15332 static/js/zamboni/stats-min.js:4
 msgid "Homepage Promo"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:52 static/js/impala/stats/csv_keys.js:53
+#: static/js/impala/stats/csv_keys.js:52 static/js/impala/stats/csv_keys.js:53 static/js/zamboni/stats-all.js:15333 static/js/zamboni/stats-all.js:15334 static/js/zamboni/stats-min.js:4
 msgid "Homepage Featured"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:54 static/js/impala/stats/csv_keys.js:55
+#: static/js/impala/stats/csv_keys.js:54 static/js/impala/stats/csv_keys.js:55 static/js/zamboni/stats-all.js:15335 static/js/zamboni/stats-all.js:15336 static/js/zamboni/stats-min.js:4
 msgid "Homepage Up and Coming"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:56
+#: static/js/impala/stats/csv_keys.js:56 static/js/zamboni/stats-all.js:15337 static/js/zamboni/stats-min.js:4
 msgid "Homepage Most Popular"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:57 static/js/impala/stats/csv_keys.js:59
+#: static/js/impala/stats/csv_keys.js:57 static/js/impala/stats/csv_keys.js:59 static/js/zamboni/stats-all.js:15338 static/js/zamboni/stats-all.js:15340 static/js/zamboni/stats-min.js:4
 msgid "Detail Page"
 msgstr "หน้ารายละเอียด"
 
-#: static/js/impala/stats/csv_keys.js:58 static/js/impala/stats/csv_keys.js:60
+#: static/js/impala/stats/csv_keys.js:58 static/js/impala/stats/csv_keys.js:60 static/js/zamboni/stats-all.js:15339 static/js/zamboni/stats-all.js:15341 static/js/zamboni/stats-min.js:4
 msgid "Detail Page (bottom)"
 msgstr "หน้ารายละเอียด (ด้านล่าง)"
 
-#: static/js/impala/stats/csv_keys.js:61
+#: static/js/impala/stats/csv_keys.js:61 static/js/zamboni/stats-all.js:15342 static/js/zamboni/stats-min.js:4
 msgid "Detail Page (Development Channel)"
 msgstr "หน้ารายละเอียด (ช่องการพัฒนา)"
 
-#: static/js/impala/stats/csv_keys.js:62 static/js/impala/stats/csv_keys.js:63 static/js/impala/stats/csv_keys.js:64
+#: static/js/impala/stats/csv_keys.js:62 static/js/impala/stats/csv_keys.js:63 static/js/impala/stats/csv_keys.js:64 static/js/zamboni/stats-all.js:15343 static/js/zamboni/stats-all.js:15344
+#: static/js/zamboni/stats-all.js:15345 static/js/zamboni/stats-min.js:4
 msgid "Often Used With"
 msgstr "ใช้บ่อยๆ โดย"
 
-#: static/js/impala/stats/csv_keys.js:65 static/js/impala/stats/csv_keys.js:66
+#: static/js/impala/stats/csv_keys.js:65 static/js/impala/stats/csv_keys.js:66 static/js/zamboni/stats-all.js:15346 static/js/zamboni/stats-all.js:15347 static/js/zamboni/stats-min.js:4
 msgid "Others By Author"
 msgstr "อื่น ๆ โดยผู้สร้าง"
 
-#: static/js/impala/stats/csv_keys.js:67 static/js/impala/stats/csv_keys.js:68
+#: static/js/impala/stats/csv_keys.js:67 static/js/impala/stats/csv_keys.js:68 static/js/zamboni/stats-all.js:15348 static/js/zamboni/stats-all.js:15349 static/js/zamboni/stats-min.js:4
 msgid "Dependencies"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:69 static/js/impala/stats/csv_keys.js:70
+#: static/js/impala/stats/csv_keys.js:69 static/js/impala/stats/csv_keys.js:70 static/js/zamboni/stats-all.js:15350 static/js/zamboni/stats-all.js:15351 static/js/zamboni/stats-min.js:4
 msgid "Upsell"
 msgstr "เพิ่มยอดขาย"
 
-#: static/js/impala/stats/csv_keys.js:71
+#: static/js/impala/stats/csv_keys.js:71 static/js/zamboni/stats-all.js:15352 static/js/zamboni/stats-min.js:4
 msgid "Meet the Developer"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:72
+#: static/js/impala/stats/csv_keys.js:72 static/js/zamboni/stats-all.js:15353 static/js/zamboni/stats-min.js:4
 msgid "User Profile"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:73
+#: static/js/impala/stats/csv_keys.js:73 static/js/zamboni/stats-all.js:15354 static/js/zamboni/stats-min.js:4
 msgid "Version History"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:75
+#: static/js/impala/stats/csv_keys.js:75 static/js/zamboni/stats-all.js:15356 static/js/zamboni/stats-min.js:4
 msgid "Sharing"
 msgstr "การแบ่งปัน"
 
-#: static/js/impala/stats/csv_keys.js:76
+#: static/js/impala/stats/csv_keys.js:76 static/js/zamboni/stats-all.js:15357 static/js/zamboni/stats-min.js:4
 msgid "Category Pages"
 msgstr "หน้าหมวดหมู่"
 
-#: static/js/impala/stats/csv_keys.js:77
+#: static/js/impala/stats/csv_keys.js:77 static/js/zamboni/stats-all.js:15358 static/js/zamboni/stats-min.js:4
 msgid "Collections"
 msgstr "ชุด"
 
-#: static/js/impala/stats/csv_keys.js:78 static/js/impala/stats/csv_keys.js:79
+#: static/js/impala/stats/csv_keys.js:78 static/js/impala/stats/csv_keys.js:79 static/js/zamboni/stats-all.js:15359 static/js/zamboni/stats-all.js:15360 static/js/zamboni/stats-min.js:4
 msgid "Category Landing Featured Carousel"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:80 static/js/impala/stats/csv_keys.js:81
+#: static/js/impala/stats/csv_keys.js:80 static/js/impala/stats/csv_keys.js:81 static/js/zamboni/stats-all.js:15361 static/js/zamboni/stats-all.js:15362 static/js/zamboni/stats-min.js:4
 msgid "Category Landing Top Rated"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:82 static/js/impala/stats/csv_keys.js:83
+#: static/js/impala/stats/csv_keys.js:82 static/js/impala/stats/csv_keys.js:83 static/js/zamboni/stats-all.js:15363 static/js/zamboni/stats-all.js:15364 static/js/zamboni/stats-min.js:5
 msgid "Category Landing Most Popular"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:84 static/js/impala/stats/csv_keys.js:85
+#: static/js/impala/stats/csv_keys.js:84 static/js/impala/stats/csv_keys.js:85 static/js/zamboni/stats-all.js:15365 static/js/zamboni/stats-all.js:15366 static/js/zamboni/stats-min.js:5
 msgid "Category Landing Recently Added"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:86 static/js/impala/stats/csv_keys.js:87
+#: static/js/impala/stats/csv_keys.js:86 static/js/impala/stats/csv_keys.js:87 static/js/zamboni/stats-all.js:15367 static/js/zamboni/stats-all.js:15368 static/js/zamboni/stats-min.js:5
 msgid "Browse Listing Featured Sort"
 msgstr "ดูรายการตามการแนะนำ"
 
-#: static/js/impala/stats/csv_keys.js:88 static/js/impala/stats/csv_keys.js:89
+#: static/js/impala/stats/csv_keys.js:88 static/js/impala/stats/csv_keys.js:89 static/js/zamboni/stats-all.js:15369 static/js/zamboni/stats-all.js:15370 static/js/zamboni/stats-min.js:5
 msgid "Browse Listing Users Sort"
 msgstr "เรียกดูรายการตามผู้ใช้"
 
-#: static/js/impala/stats/csv_keys.js:90 static/js/impala/stats/csv_keys.js:91
+#: static/js/impala/stats/csv_keys.js:90 static/js/impala/stats/csv_keys.js:91 static/js/zamboni/stats-all.js:15371 static/js/zamboni/stats-all.js:15372 static/js/zamboni/stats-min.js:5
 msgid "Browse Listing Rating Sort"
 msgstr "เรียกดูรายการตามการจัดอันดับ"
 
-#: static/js/impala/stats/csv_keys.js:92 static/js/impala/stats/csv_keys.js:93
+#: static/js/impala/stats/csv_keys.js:92 static/js/impala/stats/csv_keys.js:93 static/js/zamboni/stats-all.js:15373 static/js/zamboni/stats-all.js:15374 static/js/zamboni/stats-min.js:5
 msgid "Browse Listing Created Sort"
 msgstr "เรียกดูรายการตามการสร้าง"
 
-#: static/js/impala/stats/csv_keys.js:94 static/js/impala/stats/csv_keys.js:95
+#: static/js/impala/stats/csv_keys.js:94 static/js/impala/stats/csv_keys.js:95 static/js/zamboni/stats-all.js:15375 static/js/zamboni/stats-all.js:15376 static/js/zamboni/stats-min.js:5
 msgid "Browse Listing Name Sort"
 msgstr "เรียกดูรายการตามชื่อ"
 
-#: static/js/impala/stats/csv_keys.js:96 static/js/impala/stats/csv_keys.js:97
+#: static/js/impala/stats/csv_keys.js:96 static/js/impala/stats/csv_keys.js:97 static/js/zamboni/stats-all.js:15377 static/js/zamboni/stats-all.js:15378 static/js/zamboni/stats-min.js:5
 msgid "Browse Listing Popular Sort"
 msgstr "เรียกดูรายการตามความนิยม"
 
-#: static/js/impala/stats/csv_keys.js:98 static/js/impala/stats/csv_keys.js:99
+#: static/js/impala/stats/csv_keys.js:98 static/js/impala/stats/csv_keys.js:99 static/js/zamboni/stats-all.js:15379 static/js/zamboni/stats-all.js:15380 static/js/zamboni/stats-min.js:5
 msgid "Browse Listing Updated Sort"
 msgstr "เรียกดูรายการตามการปรับปรุง"
 
-#: static/js/impala/stats/csv_keys.js:100 static/js/impala/stats/csv_keys.js:101
+#: static/js/impala/stats/csv_keys.js:100 static/js/impala/stats/csv_keys.js:101 static/js/zamboni/stats-all.js:15381 static/js/zamboni/stats-all.js:15382 static/js/zamboni/stats-min.js:5
 msgid "Browse Listing Up and Coming Sort"
 msgstr "เรียกดูรายการตามที่กำลังจะมาถึง"
 
-#: static/js/impala/stats/csv_keys.js:105
+#: static/js/impala/stats/csv_keys.js:105 static/js/zamboni/stats-all.js:15386 static/js/zamboni/stats-min.js:5
 msgid "Total Amount Contributed"
 msgstr "จำนวนการบริจาครวม"
 
-#: static/js/impala/stats/csv_keys.js:106
+#: static/js/impala/stats/csv_keys.js:106 static/js/zamboni/stats-all.js:15387 static/js/zamboni/stats-min.js:5
 msgid "Average Contribution"
 msgstr "การบริจาคโดยเฉลี่ย"
 
-#: static/js/impala/stats/csv_keys.js:115
+#: static/js/impala/stats/csv_keys.js:115 static/js/zamboni/stats-all.js:15396 static/js/zamboni/stats-min.js:5
 msgid "Usage"
 msgstr "การใช้งาน"
 
-#: static/js/impala/stats/csv_keys.js:118
+#: static/js/impala/stats/csv_keys.js:118 static/js/zamboni/stats-all.js:15399 static/js/zamboni/stats-min.js:5
 msgid "Firefox"
 msgstr "Firefox"
 
-#: static/js/impala/stats/csv_keys.js:119
+#: static/js/impala/stats/csv_keys.js:119 static/js/zamboni/stats-all.js:15400 static/js/zamboni/stats-min.js:5
 msgid "Mozilla"
 msgstr "Mozilla"
 
-#: static/js/impala/stats/csv_keys.js:120
+#: static/js/impala/stats/csv_keys.js:120 static/js/zamboni/stats-all.js:15401 static/js/zamboni/stats-min.js:5
 msgid "Thunderbird"
 msgstr "Thunderbird"
 
-#: static/js/impala/stats/csv_keys.js:121
+#: static/js/impala/stats/csv_keys.js:121 static/js/zamboni/stats-all.js:15402 static/js/zamboni/stats-min.js:5
 msgid "Sunbird"
 msgstr "Sunbird"
 
-#: static/js/impala/stats/csv_keys.js:122
+#: static/js/impala/stats/csv_keys.js:122 static/js/zamboni/stats-all.js:15403 static/js/zamboni/stats-min.js:5
 msgid "SeaMonkey"
 msgstr "SeaMonkey"
 
-#: static/js/impala/stats/csv_keys.js:123
+#: static/js/impala/stats/csv_keys.js:123 static/js/zamboni/stats-all.js:15404 static/js/zamboni/stats-min.js:5
 msgid "Fennec"
 msgstr "Fennec"
 
-#: static/js/impala/stats/csv_keys.js:124
+#: static/js/impala/stats/csv_keys.js:124 static/js/zamboni/stats-all.js:15405 static/js/zamboni/stats-min.js:5
 msgid "Android"
 msgstr ""
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:129
+#: static/js/impala/stats/csv_keys.js:129 static/js/zamboni/stats-all.js:15410 static/js/zamboni/stats-min.js:5
 msgid "Downloads and Daily Users, last {0} days"
 msgstr "การดาวน์โหลดและผู้ใช้ต่อวันใน {0} วันล่าสุด"
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:131
+#: static/js/impala/stats/csv_keys.js:131 static/js/zamboni/stats-all.js:15412 static/js/zamboni/stats-min.js:5
 msgid "Downloads and Daily Users from {0} to {1}"
 msgstr "การดาวน์โหลดและผู้ใช้ต่อวันจาก {0} ถึง {1}"
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:135
+#: static/js/impala/stats/csv_keys.js:135 static/js/zamboni/stats-all.js:15416 static/js/zamboni/stats-min.js:5
 msgid "Installs and Daily Users, last {0} days"
 msgstr "การติดตั้งและผู้ใช้ต่อวันใน {0} วันล่าสุด"
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:137
+#: static/js/impala/stats/csv_keys.js:137 static/js/zamboni/stats-all.js:15418 static/js/zamboni/stats-min.js:5
 msgid "Installs and Daily Users from {0} to {1}"
 msgstr "การติดตั้งและผู้ใช้ต่อวันจาก {0} ถึง {1}"
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:141
+#: static/js/impala/stats/csv_keys.js:141 static/js/zamboni/stats-all.js:15422 static/js/zamboni/stats-min.js:5
 msgid "Downloads, last {0} days"
 msgstr "การดาวน์โหลดใน {0} วันล่าสุด"
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:143
+#: static/js/impala/stats/csv_keys.js:143 static/js/zamboni/stats-all.js:15424 static/js/zamboni/stats-min.js:5
 msgid "Downloads from {0} to {1}"
 msgstr "การดาวน์โหลดจาก {0} ถึง {1}"
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:147
+#: static/js/impala/stats/csv_keys.js:147 static/js/zamboni/stats-all.js:15428 static/js/zamboni/stats-min.js:5
 msgid "Daily Users, last {0} days"
 msgstr "ผู้ใช้ต่อวันใน {0} วันล่าสุด"
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:149
+#: static/js/impala/stats/csv_keys.js:149 static/js/zamboni/stats-all.js:15430 static/js/zamboni/stats-min.js:5
 msgid "Daily Users from {0} to {1}"
 msgstr "ผู้ใช้ต่อวันจาก {0} ถึง {1}"
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:153
+#: static/js/impala/stats/csv_keys.js:153 static/js/zamboni/stats-all.js:15434 static/js/zamboni/stats-min.js:5
 msgid "Applications, last {0} days"
 msgstr "แอพพลิเคชั่นใน {0} วันล่าสุด"
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:155
+#: static/js/impala/stats/csv_keys.js:155 static/js/zamboni/stats-all.js:15436 static/js/zamboni/stats-min.js:5
 msgid "Applications from {0} to {1}"
 msgstr "แอพพลิเคชั่นจาก {0} ถึง {1}"
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:159
+#: static/js/impala/stats/csv_keys.js:159 static/js/zamboni/stats-all.js:15440 static/js/zamboni/stats-min.js:5
 msgid "Platforms, last {0} days"
 msgstr "แพลตฟอร์มใน {0} วันล่าสุด"
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:161
+#: static/js/impala/stats/csv_keys.js:161 static/js/zamboni/stats-all.js:15442 static/js/zamboni/stats-min.js:5
 msgid "Platforms from {0} to {1}"
 msgstr "แพลตฟอร์มจาก {0} ถึง {1}"
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:165
+#: static/js/impala/stats/csv_keys.js:165 static/js/zamboni/stats-all.js:15446 static/js/zamboni/stats-min.js:5
 msgid "Languages, last {0} days"
 msgstr "ภาษาใน {0} วันล่าสุด"
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:167
+#: static/js/impala/stats/csv_keys.js:167 static/js/zamboni/stats-all.js:15448 static/js/zamboni/stats-min.js:5
 msgid "Languages from {0} to {1}"
 msgstr "ภาษาจาก {0} ถึง {1}"
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:171
+#: static/js/impala/stats/csv_keys.js:171 static/js/zamboni/stats-all.js:15452 static/js/zamboni/stats-min.js:5
 msgid "Add-on Versions, last {0} days"
 msgstr "รุ่นของส่วนเสริมใน {0} วันล่าสุด"
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:173
+#: static/js/impala/stats/csv_keys.js:173 static/js/zamboni/stats-all.js:15454 static/js/zamboni/stats-min.js:5
 msgid "Add-on Versions from {0} to {1}"
 msgstr "รุ่นของส่วนเสริมจาก {0} ถึง {1}"
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:177
+#: static/js/impala/stats/csv_keys.js:177 static/js/zamboni/stats-all.js:15458 static/js/zamboni/stats-min.js:5
 msgid "Add-on Status, last {0} days"
 msgstr "สถานะของส่วนเสริมใน {0} วันล่าสุด"
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:179
+#: static/js/impala/stats/csv_keys.js:179 static/js/zamboni/stats-all.js:15460 static/js/zamboni/stats-min.js:5
 msgid "Add-on Status from {0} to {1}"
 msgstr "สถานะของส่วนเสริมจาก {0} ถึง {1}"
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:183
+#: static/js/impala/stats/csv_keys.js:183 static/js/zamboni/stats-all.js:15464 static/js/zamboni/stats-min.js:5
 msgid "Download Sources, last {0} days"
 msgstr "การดาวน์โหลดซอร์สใน {0} วันล่าสุด"
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:185
+#: static/js/impala/stats/csv_keys.js:185 static/js/zamboni/stats-all.js:15466 static/js/zamboni/stats-min.js:5
 msgid "Download Sources from {0} to {1}"
 msgstr "การดาวน์โหลดซอร์สจาก {0} ถึง {1}"
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:189
+#: static/js/impala/stats/csv_keys.js:189 static/js/zamboni/stats-all.js:15470 static/js/zamboni/stats-min.js:5
 msgid "Contributions, last {0} days"
 msgstr "การบริจาคใน {0} วันล่าสุด"
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:191
+#: static/js/impala/stats/csv_keys.js:191 static/js/zamboni/stats-all.js:15472 static/js/zamboni/stats-min.js:5
 msgid "Contributions from {0} to {1}"
 msgstr "การบริจาคจาก {0} ถึง {1}"
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:195
+#: static/js/impala/stats/csv_keys.js:195 static/js/zamboni/stats-all.js:15476 static/js/zamboni/stats-min.js:5
 msgid "Site Metrics, last {0} days"
 msgstr ""
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:197
+#: static/js/impala/stats/csv_keys.js:197 static/js/zamboni/stats-all.js:15478 static/js/zamboni/stats-min.js:5
 msgid "Site Metrics from {0} to {1}"
 msgstr ""
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:201
+#: static/js/impala/stats/csv_keys.js:201 static/js/zamboni/stats-all.js:15482 static/js/zamboni/stats-min.js:5
 msgid "Add-ons in Use, last {0} days"
 msgstr "ส่วนเสริมที่ใช้งานใน {0} วันล่าสุด"
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:203
+#: static/js/impala/stats/csv_keys.js:203 static/js/zamboni/stats-all.js:15484 static/js/zamboni/stats-min.js:5
 msgid "Add-ons in Use from {0} to {1}"
 msgstr "ส่วนเสริมที่ใช้จาก {0} ถึง {1}"
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:207
+#: static/js/impala/stats/csv_keys.js:207 static/js/zamboni/stats-all.js:15488 static/js/zamboni/stats-min.js:5
 msgid "Add-ons Downloaded, last {0} days"
 msgstr "ส่วนเสริมที่ดาวน์โหลดใน {0} วันล่าสุด"
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:209
+#: static/js/impala/stats/csv_keys.js:209 static/js/zamboni/stats-all.js:15490 static/js/zamboni/stats-min.js:5
 msgid "Add-ons Downloaded from {0} to {1}"
 msgstr "ส่วนเสริมที่ดาวน์โหลดจาก {0} ถึง {1}"
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:213
+#: static/js/impala/stats/csv_keys.js:213 static/js/zamboni/stats-all.js:15494 static/js/zamboni/stats-min.js:5
 msgid "Add-ons Created, last {0} days"
 msgstr "ส่วนเสริมที่สร้างใน {0} วันล่าสุด"
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:215
+#: static/js/impala/stats/csv_keys.js:215 static/js/zamboni/stats-all.js:15496 static/js/zamboni/stats-min.js:5
 msgid "Add-ons Created from {0} to {1}"
 msgstr "ส่วนเสริมที่สร้างจาก {0} ถึง {1}"
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:219
+#: static/js/impala/stats/csv_keys.js:219 static/js/zamboni/stats-all.js:15500 static/js/zamboni/stats-min.js:5
 msgid "Add-ons Updated, last {0} days"
 msgstr "ส่วนเสริมที่ปรับปรุงใน {0} วันล่าสุด"
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:221
+#: static/js/impala/stats/csv_keys.js:221 static/js/zamboni/stats-all.js:15502 static/js/zamboni/stats-min.js:5
 msgid "Add-ons Updated from {0} to {1}"
 msgstr "ส่วนเสริมที่ปรับปรุงจาก {0} ถึง {1}"
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:225
+#: static/js/impala/stats/csv_keys.js:225 static/js/zamboni/stats-all.js:15506 static/js/zamboni/stats-min.js:5
 msgid "Reviews Written, last {0} days"
 msgstr "บทวิจารณ์ที่เขียนใน {0} วันล่าสุด"
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:227
+#: static/js/impala/stats/csv_keys.js:227 static/js/zamboni/stats-all.js:15508 static/js/zamboni/stats-min.js:5
 msgid "Reviews Written from {0} to {1}"
 msgstr "บทวิจารณ์ที่เขียนจาก {0} ถึง {1}"
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:231
+#: static/js/impala/stats/csv_keys.js:231 static/js/zamboni/stats-all.js:15512 static/js/zamboni/stats-min.js:5
 msgid "User Signups, last {0} days"
 msgstr "ผู้ใช้ที่ลงทะเบียนใน {0} วันล่าสุด"
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:233
+#: static/js/impala/stats/csv_keys.js:233 static/js/zamboni/stats-all.js:15514 static/js/zamboni/stats-min.js:5
 msgid "User Signups from {0} to {1}"
 msgstr "ผู้ใช้ที่ลงทะเบียนจาก {0} ถึง {1}"
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:237
+#: static/js/impala/stats/csv_keys.js:237 static/js/zamboni/stats-all.js:15518 static/js/zamboni/stats-min.js:5
 msgid "Collections Created, last {0} days"
 msgstr "ชุดที่สร้างใน {0} วันล่าสุด"
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:239
+#: static/js/impala/stats/csv_keys.js:239 static/js/zamboni/stats-all.js:15520 static/js/zamboni/stats-min.js:5
 msgid "Collections Created from {0} to {1}"
 msgstr "ชุดที่สร้างจาก {0} ถึง {1}"
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:243
+#: static/js/impala/stats/csv_keys.js:243 static/js/zamboni/stats-all.js:15524 static/js/zamboni/stats-min.js:5
 msgid "Subscribers, last {0} days"
 msgstr "ผู้ติดตามใน {0} วันล่าสุด"
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:245
+#: static/js/impala/stats/csv_keys.js:245 static/js/zamboni/stats-all.js:15526 static/js/zamboni/stats-min.js:5
 msgid "Subscribers from {0} to {1}"
 msgstr "ผู้ติดตามจาก {0} ถึง {1}"
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:249
+#: static/js/impala/stats/csv_keys.js:249 static/js/zamboni/stats-all.js:15530 static/js/zamboni/stats-min.js:5
 msgid "Ratings, last {0} days"
 msgstr "การจัดอันดับใน {0} วันล่าสุด"
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:251
+#: static/js/impala/stats/csv_keys.js:251 static/js/zamboni/stats-all.js:15532 static/js/zamboni/stats-min.js:5
 msgid "Ratings from {0} to {1}"
 msgstr "การจัดอันดับจาก {0} ถึง {1}"
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:255
+#: static/js/impala/stats/csv_keys.js:255 static/js/zamboni/stats-all.js:15536 static/js/zamboni/stats-min.js:5
 msgid "Sales, last {0} days"
 msgstr "การขายใน {0} วันล่าสุด"
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:257
+#: static/js/impala/stats/csv_keys.js:257 static/js/zamboni/stats-all.js:15538 static/js/zamboni/stats-min.js:5
 msgid "Sales from {0} to {1}"
 msgstr "การขายจาก {0} ถึง {1}"
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:261
+#: static/js/impala/stats/csv_keys.js:261 static/js/zamboni/stats-all.js:15542 static/js/zamboni/stats-min.js:5
 msgid "Installs, last {0} days"
 msgstr "การติดตั้งใน {0} วันล่าสุด"
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:263
+#: static/js/impala/stats/csv_keys.js:263 static/js/zamboni/stats-all.js:15544 static/js/zamboni/stats-min.js:5
 msgid "Installs from {0} to {1}"
 msgstr "การติดตั้งจาก {0} ถึง {1}"
 
 #. L10n: {0} and {1} are integers.
-#: static/js/impala/stats/csv_keys.js:269
+#: static/js/impala/stats/csv_keys.js:269 static/js/zamboni/stats-all.js:15550 static/js/zamboni/stats-min.js:5
 msgid "<b>{0}</b> in last {1} days"
 msgstr "<b>{0}</b> ใน {1} วันล่าสุด"
 
 #. L10n: {0} is an integer and {1} and {2} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:271 static/js/impala/stats/csv_keys.js:277
+#: static/js/impala/stats/csv_keys.js:271 static/js/impala/stats/csv_keys.js:277 static/js/zamboni/stats-all.js:15552 static/js/zamboni/stats-all.js:15558 static/js/zamboni/stats-min.js:5
 msgid "<b>{0}</b> from {1} to {2}"
 msgstr "<b>{0}</b> จาก {1} ถึง {2}"
 
 #. L10n: {0} and {1} are integers.
-#: static/js/impala/stats/csv_keys.js:275
+#: static/js/impala/stats/csv_keys.js:275 static/js/zamboni/stats-all.js:15556 static/js/zamboni/stats-min.js:5
 msgid "<b>{0}</b> average in last {1} days"
 msgstr "<b>{0}</b> เฉลี่ยใน {1} วันล่าสุด"
 
-#: static/js/impala/stats/overview.js:19
+#: static/js/impala/stats/overview.js:19 static/js/zamboni/stats-all.js:16469 static/js/zamboni/stats-min.js:5
 msgid "No data available."
 msgstr "ไม่มีข้อมูล"
 
-#: static/js/impala/stats/table.js:74
+#: static/js/impala/stats/table.js:74 static/js/zamboni/stats-all.js:17209 static/js/zamboni/stats-min.js:5
 msgid "Date"
 msgstr "วันที่"
 
-#: static/js/impala/stats/topchart.js:96
+#: static/js/impala/stats/topchart.js:96 static/js/zamboni/stats-all.js:16600 static/js/zamboni/stats-min.js:5
 msgid "Other"
 msgstr "อื่น ๆ"
 
-#: static/js/zamboni/admin_validation.js:24 static/js/zamboni/devhub.js:1229 static/js/zamboni/editors.js:295
+#: static/js/zamboni/admin-all.js:180 static/js/zamboni/admin-min.js:1 static/js/zamboni/admin_validation.js:24 static/js/zamboni/devhub-all.js:2408 static/js/zamboni/devhub-min.js:2
+#: static/js/zamboni/devhub.js:1229 static/js/zamboni/editors-all.js:15576 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:295
 msgid "Select an application first"
 msgstr "เลือกแอพพลิเคชั่นก่อน"
 
-#: static/js/zamboni/admin_validation.js:51
+#: static/js/zamboni/admin-all.js:207 static/js/zamboni/admin-min.js:1 static/js/zamboni/admin_validation.js:51
 msgid "Set {0} add-on to a max version of {1} and email the author."
 msgid_plural "Set {0} add-ons to a max version of {1} and email the authors."
 msgstr[0] ""
+msgstr[1] ""
 
-#: static/js/zamboni/admin_validation.js:54
+#: static/js/zamboni/admin-all.js:210 static/js/zamboni/admin-min.js:1 static/js/zamboni/admin_validation.js:54
 msgid "Email author of {2} add-on which failed validation."
 msgid_plural "Email authors of {2} add-ons which failed validation."
 msgstr[0] ""
+msgstr[1] ""
 
-#. L10n: {0} is an app name like Firefox.
-#: static/js/zamboni/buttons.js:66
-msgid "Accept and Install"
-msgstr "ยอมรับและติดตั้ง"
-
-#: static/js/zamboni/buttons.js:66
-msgid "Add to {0}"
-msgstr "เพิ่มไปยัง {0}"
-
-#: static/js/zamboni/buttons.js:71
-msgid "Download Now"
-msgstr "ดาวน์โหลดเดี๋ยวนี้"
-
-#: static/js/zamboni/buttons.js:112
-msgid "Add-on has not been updated to support default-to-compatible."
-msgstr ""
-
-#: static/js/zamboni/buttons.js:117
-msgid "You need to be using Firefox 10.0 or higher."
-msgstr "คุณจำเป็นต้องใช้ Firefox 10.0 หรือสูงกว่า"
-
-#: static/js/zamboni/buttons.js:129
-msgid "Mozilla has marked this version as incompatible with your Firefox version."
-msgstr "Mozilla ทำเครื่องหมายว่ารุ่นนี้ไม่เข้ากันกับรุ่น Firefox ของคุณ"
-
-#. L10n: {0} is an platform like Windows or Linux.
-#: static/js/zamboni/buttons.js:210
-msgid "Install for {0} anyway"
-msgstr "ติดตั้ง {0} ต่อไป"
-
-#: static/js/zamboni/buttons.js:210
-msgid "Download for {0} anyway"
-msgstr "ดาวน์โหลด {0} ต่อไป"
-
-#: static/js/zamboni/buttons.js:267
-msgid "Not available for your platform"
-msgstr "ไม่พร้อมใช้งานสำหรับแพลตฟอร์มของคุณ"
-
-#. L10n: {0} is an app name, {1} is the app version.
-#: static/js/zamboni/buttons.js:278 static/js/zamboni/buttons.js:315
-msgid "Not available for {0} {1}"
-msgstr "ไม่พร้อมใช้งานสำหรับ {0} {1}"
-
-#: static/js/zamboni/buttons.js:341
-msgid "Works with {app} {min} - {max}"
-msgstr "ทำงานได้กับ {app} {min} - {max}"
-
-#: static/js/zamboni/buttons.js:343
-msgid "View other versions"
-msgstr "ดูรุ่นอื่น"
-
-#: static/js/zamboni/buttons.js:391
-msgid "Only with Firefox — Get Firefox Now!"
-msgstr ""
-
-#: static/js/zamboni/buttons.js:507 static/js/zamboni/mobile/buttons.js:43
-msgid "Sorry, you need a Mozilla-based browser (such as Firefox) to install a search plugin."
-msgstr "ขออภัย คุณจำเป็นต้องใช้เบราว์เซอร์ที่มีรากฐานมาจาก Mozilla (เช่น Firefox) เพื่อติดตั้งโปรแกรมเสริมสำหรับการค้นหา"
-
-#: static/js/zamboni/collections.js:229
-msgid "Adding to Favorites&hellip;"
-msgstr "เพิ่มเข้ารายการโปรด&hellip;"
-
-#: static/js/zamboni/collections.js:232
-msgid "Removing Favorite&hellip;"
-msgstr "เอาออกจากรายการโปรด&hellip;"
-
-#: static/js/zamboni/collections.js:235
-msgid "Add to Favorites"
-msgstr "เพิ่มเข้ารายการโปรด"
-
-#: static/js/zamboni/collections.js:238
-msgid "Remove from Favorites"
-msgstr "เอาออกจากรายการโปรด"
-
-#: static/js/zamboni/collections.js:303
-msgid "Pending"
-msgstr "กำลังรอ"
-
-#: static/js/zamboni/collections.js:304
-msgid "Add a comment"
-msgstr "แสดงความคิดเห็น"
-
-#: static/js/zamboni/collections.js:304
-msgid "Comment"
-msgstr "ความคิดเห็น"
-
-#: static/js/zamboni/collections.js:305
-msgid "Remove this add-on from the collection"
-msgstr "เอาส่วนเสริมนี้ออกจากชุด"
-
-#: static/js/zamboni/collections.js:305 static/js/zamboni/collections.js:334
-msgid "Remove"
-msgstr "เอาออก"
-
-#: static/js/zamboni/collections.js:334
-msgid "Remove this user as a contributor"
-msgstr ""
-
-#: static/js/zamboni/collections.js:346
-msgid "An email address is required."
-msgstr "ต้องการที่อยู่อีเมล"
-
-#: static/js/zamboni/collections.js:364
-msgid "You cannot add yourself as a contributor."
-msgstr ""
-
-#: static/js/zamboni/collections.js:366
-msgid "You have already added that user."
-msgstr "คุณได้เพิ่มผู้ใช้คนนี้แล้ว"
-
-#: static/js/zamboni/collections.js:573
-msgid "Add to favorites"
-msgstr "เพิ่มไปยังรายการโปรด"
-
-#: static/js/zamboni/collections.js:577
-msgid "Remove from favorites"
-msgstr "เอาออกจากรายการโปรด"
-
-#: static/js/zamboni/collections.js:604
-msgid "Stop following"
-msgstr "หยุดการติดตาม"
-
-#: static/js/zamboni/devhub.js:110
+#: static/js/zamboni/devhub-all.js:1289 static/js/zamboni/devhub-min.js:1 static/js/zamboni/devhub.js:110
 msgid "Your browser does not support the video tag"
 msgstr "เบราว์เซอร์ของคุณไม่รองรับวิดีโอแท็ก"
 
-#: static/js/zamboni/devhub.js:371
+#: static/js/zamboni/devhub-all.js:1550 static/js/zamboni/devhub-min.js:1 static/js/zamboni/devhub.js:371
 msgid "Changes Saved"
 msgstr "การเปลี่ยนแปลงถูกบันทึกแล้ว"
 
-#: static/js/zamboni/devhub.js:387
+#: static/js/zamboni/devhub-all.js:1566 static/js/zamboni/devhub-min.js:1 static/js/zamboni/devhub.js:387
 msgid "Enter a new author's email address"
 msgstr ""
 
-#: static/js/zamboni/devhub.js:536
+#: static/js/zamboni/devhub-all.js:1715 static/js/zamboni/devhub-min.js:1 static/js/zamboni/devhub.js:536
 msgid "There was an error uploading your file."
 msgstr "เกิดข้อผิดพลาดขึ้นในระหว่างการอัปโหลดไฟล์ของคุณ"
 
-#: static/js/zamboni/devhub.js:681
+#: static/js/zamboni/devhub-all.js:1860 static/js/zamboni/devhub-min.js:1 static/js/zamboni/devhub.js:681
 msgid "{files} file"
 msgid_plural "{files} files"
 msgstr[0] "{files} ไฟล์"
+msgstr[1] ""
 
-#: static/js/zamboni/devhub.js:684
+#: static/js/zamboni/devhub-all.js:1863 static/js/zamboni/devhub-min.js:1 static/js/zamboni/devhub.js:684
 msgid "{reviews} user review"
 msgid_plural "{reviews} user reviews"
 msgstr[0] ""
+msgstr[1] ""
 
-#: static/js/zamboni/devhub.js:796
+#: static/js/zamboni/devhub-all.js:1975 static/js/zamboni/devhub-min.js:2 static/js/zamboni/devhub.js:796
 msgid "Learn more"
 msgstr "เรียนรู้เพิ่มเติม"
 
-#: static/js/zamboni/devhub.js:800
+#: static/js/zamboni/devhub-all.js:1979 static/js/zamboni/devhub-min.js:2 static/js/zamboni/devhub.js:800
 msgid "Example"
 msgstr "ตัวอย่าง"
 
-#: static/js/zamboni/devhub.js:1130
+#: static/js/zamboni/devhub-all.js:2309 static/js/zamboni/devhub-min.js:2 static/js/zamboni/devhub.js:1130
 msgid "Image changes being processed"
 msgstr "รูปภาพที่เปลี่ยนกำลังดำเนินการอยู่"
 
-#: static/js/zamboni/devhub.js:1280
+#: static/js/zamboni/devhub-all.js:2459 static/js/zamboni/devhub-min.js:2 static/js/zamboni/devhub.js:1280
 msgid "Must be a valid e-mail address."
 msgstr "ต้องเป็นที่อยู่อีเมลที่ถูกต้อง"
+
+#: static/js/zamboni/devhub-all.js:2613 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:80
+msgid "All tests passed successfully."
+msgstr "การทดสอบทั้งหมดผ่านอย่างประสบความสำเร็จ"
+
+#: static/js/zamboni/devhub-all.js:2616 static/js/zamboni/devhub-all.js:3011 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:83 static/js/zamboni/validator.js:478
+msgid "These tests were not run."
+msgstr "การทดสอบเหล่านี้ไม่ทำงาน"
+
+#: static/js/zamboni/devhub-all.js:2664 static/js/zamboni/devhub-all.js:2677 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:131 static/js/zamboni/validator.js:144
+msgid "Tests"
+msgstr "ทดสอบ"
+
+#: static/js/zamboni/devhub-all.js:2779 static/js/zamboni/devhub-all.js:3108 static/js/zamboni/devhub-all.js:3127 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:246
+#: static/js/zamboni/validator.js:575 static/js/zamboni/validator.js:594
+msgid "Error"
+msgstr "ข้อผิดพลาด"
+
+#: static/js/zamboni/devhub-all.js:2780 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:247
+msgid "Warning"
+msgstr "คำเตือน"
+
+#: static/js/zamboni/devhub-all.js:2794 static/js/zamboni/devhub-min.js:2 static/js/zamboni/files-all.js:5657 static/js/zamboni/files-min.js:3 static/js/zamboni/files.js:411
+#: static/js/zamboni/validator.js:261
+msgid "Ignore this message in future updates"
+msgstr ""
+
+#: static/js/zamboni/devhub-all.js:2817 static/js/zamboni/devhub-min.js:2 static/js/zamboni/files-all.js:5663 static/js/zamboni/files-min.js:3 static/js/zamboni/files.js:417
+#: static/js/zamboni/validator.js:284
+msgid "Severity for automated signing:"
+msgstr ""
+
+#: static/js/zamboni/devhub-all.js:2832 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:299
+msgid "Suggestions for passing automated signing:"
+msgstr ""
+
+#: static/js/zamboni/devhub-all.js:2920 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:387
+msgid "Compatibility Tests"
+msgstr "การทดสอบความเข้ากันได้"
+
+#: static/js/zamboni/devhub-all.js:2999 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:466
+msgid "Add-on failed validation."
+msgstr "ส่วนเสริมของคุณไม่ผ่านการตรวจสอบ"
+
+#: static/js/zamboni/devhub-all.js:3001 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:468
+msgid "Add-on passed validation."
+msgstr "ส่วนเสริมของคุณได้ผ่านการตรวจสอบ"
+
+#: static/js/zamboni/devhub-all.js:3014 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:481
+msgid "{0} error"
+msgid_plural "{0} errors"
+msgstr[0] "{0} ข้อผิดพลาด"
+msgstr[1] ""
+
+#: static/js/zamboni/devhub-all.js:3016 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:483
+msgid "{0} warning"
+msgid_plural "{0} warnings"
+msgstr[0] "{0} คำเตือน"
+msgstr[1] ""
+
+#: static/js/zamboni/devhub-all.js:3018 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:485
+msgid "{0} notice"
+msgid_plural "{0} notices"
+msgstr[0] ""
+msgstr[1] ""
+
+#: static/js/zamboni/devhub-all.js:3110 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:577
+msgid "Validation task could not complete or completed with errors"
+msgstr "งานการตรวจสอบไม่สามารถเสร็จสิ้นได้เพราะมีข้อผิดพลาด"
+
+#: static/js/zamboni/devhub-all.js:3128 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:595
+msgid "Internal server error"
+msgstr "ข้อผิดพลาดภายในเซอร์เวอร์"
 
 #: static/js/zamboni/devhub_search.js:8
 msgid "No results found."
 msgstr "ไม่พบผลลัพธ์"
 
-#: static/js/zamboni/editors.js:121
+#: static/js/zamboni/editors-all.js:15402 static/js/zamboni/editors-min.js:4 static/js/zamboni/editors.js:121
 msgid "{name} was viewing this page first."
 msgstr "{name} ดูหน้านี้เป็นคนแรก"
 
-#: static/js/zamboni/editors.js:171
+#: static/js/zamboni/editors-all.js:15452 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:171
 msgid "Receipt checked by app."
 msgstr "ใบเสร็จถูกตรวจสอบโดยแอพ"
 
-#: static/js/zamboni/editors.js:173
+#: static/js/zamboni/editors-all.js:15454 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:173
 msgid "Receipt was not checked by app."
 msgstr "ใบเสร็จไม่ได้ถูกตรวจสอบโดยแอพ"
 
-#: static/js/zamboni/editors.js:244
+#: static/js/zamboni/editors-all.js:15525 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:244
 msgid "{name} was viewing this add-on first."
 msgstr ""
 
-#: static/js/zamboni/editors.js:255
+#: static/js/zamboni/editors-all.js:15536 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:255
 msgid "Loading&hellip;"
 msgstr "กำลังโหลด&hellip;"
 
-#: static/js/zamboni/editors.js:260
+#: static/js/zamboni/editors-all.js:15541 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:260
 msgid "Version Notes"
 msgstr "บันทึกประจำรุ่น"
 
-#: static/js/zamboni/editors.js:265
+#: static/js/zamboni/editors-all.js:15546 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:265
 msgid "Notes for Reviewers"
 msgstr "หมายเหตุสำหรับนักวิจารณ์"
 
-#: static/js/zamboni/editors.js:270
+#: static/js/zamboni/editors-all.js:15551 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:270
 msgid "No version notes found"
 msgstr "ไม่พบบันทึกประจำรุ่น"
 
-#: static/js/zamboni/editors.js:330
+#: static/js/zamboni/editors-all.js:15611 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:330
 msgid "Average Reviews"
 msgstr ""
 
-#: static/js/zamboni/editors.js:386
+#: static/js/zamboni/editors-all.js:15667 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:386
 msgid "Number of Reviews"
 msgstr ""
 
-#: static/js/zamboni/editors.js:445
+#: static/js/zamboni/editors-all.js:15726 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:445
 msgid "Error loading translation"
 msgstr ""
 
-#: static/js/zamboni/files.js:411 static/js/zamboni/validator.js:261
-msgid "Ignore this message in future updates"
-msgstr ""
-
-#: static/js/zamboni/files.js:417 static/js/zamboni/validator.js:284
-msgid "Severity for automated signing:"
-msgstr ""
-
-#: static/js/zamboni/global.js:410
-msgid "Loading..."
-msgstr "กำลังโหลด…"
-
-#. L10n: {0} is the number of characters left.
-#: static/js/zamboni/global.js:474
-msgid "<b>{0}</b> character left."
-msgid_plural "<b>{0}</b> characters left."
-msgstr[0] "เหลือ <b>{0}</b> ตัวอักษร"
-
-#: static/js/zamboni/init.js:28
-msgid "This feature is temporarily disabled while we perform website maintenance. Please check back a little later."
-msgstr "คุณสมบัตินี้ถูกปิดใช้งานชั่วคราวในขณะที่เรากำลังทำการบำรุงรักษาเว็บไซต์ โปรดกลับมาอีกครั้งในภายหลัง"
-
-#: static/js/zamboni/l10n.js:45
-msgid "Remove this localization"
-msgstr "ลบการแปลนี้"
-
-#: static/js/zamboni/password-strength.js:20
-msgid "Password strength:"
-msgstr "ความแข็งแกร่งของรหัสผ่าน:"
-
-#: static/js/zamboni/password-strength.js:26
-msgid "At least {0} character left."
-msgid_plural "At least {0} characters left."
-msgstr[0] "ยังเหลืออีกอย่างน้อย {0} ตัวอักษร"
-
-#: static/js/zamboni/themes_review.js:176
-msgid "Requested Info"
-msgstr "ข้อมูลที่ร้องขอ"
-
-#: static/js/zamboni/themes_review.js:177
-msgid "Flagged"
-msgstr "ถูกปักธง"
-
-#: static/js/zamboni/themes_review.js:178
-msgid "Duplicate"
-msgstr "ซ้ำ"
-
-#: static/js/zamboni/themes_review.js:179
-msgid "Rejected"
-msgstr "ถูกปฏิเสธ"
-
-#: static/js/zamboni/themes_review.js:180
-msgid "Approved"
-msgstr "อนุมัติแล้ว"
-
-#: static/js/zamboni/themes_review.js:424
-msgid "No results found"
-msgstr ""
-
-#: static/js/zamboni/themes_review_templates.js:31
+#: static/js/zamboni/editors-all.js:15975 static/js/zamboni/editors-min.js:5 static/js/zamboni/themes_review_templates.js:31
 msgid "Theme"
 msgstr ""
 
-#: static/js/zamboni/themes_review_templates.js:33
+#: static/js/zamboni/editors-all.js:15977 static/js/zamboni/editors-min.js:5 static/js/zamboni/themes_review_templates.js:33
 msgid "Reviewer"
 msgstr ""
 
-#: static/js/zamboni/themes_review_templates.js:35
+#: static/js/zamboni/editors-all.js:15979 static/js/zamboni/editors-min.js:5 static/js/zamboni/themes_review_templates.js:35
 msgid "Status"
 msgstr ""
 
-#: static/js/zamboni/validator.js:80
-msgid "All tests passed successfully."
-msgstr "การทดสอบทั้งหมดผ่านอย่างประสบความสำเร็จ"
+#: static/js/zamboni/editors-all.js:16196 static/js/zamboni/editors-min.js:5 static/js/zamboni/themes_review.js:176
+msgid "Requested Info"
+msgstr "ข้อมูลที่ร้องขอ"
 
-#: static/js/zamboni/validator.js:83 static/js/zamboni/validator.js:478
-msgid "These tests were not run."
-msgstr "การทดสอบเหล่านี้ไม่ทำงาน"
+#: static/js/zamboni/editors-all.js:16197 static/js/zamboni/editors-min.js:5 static/js/zamboni/themes_review.js:177
+msgid "Flagged"
+msgstr "ถูกปักธง"
 
-#: static/js/zamboni/validator.js:131 static/js/zamboni/validator.js:144
-msgid "Tests"
-msgstr "ทดสอบ"
+#: static/js/zamboni/editors-all.js:16198 static/js/zamboni/editors-min.js:5 static/js/zamboni/themes_review.js:178
+msgid "Duplicate"
+msgstr "ซ้ำ"
 
-#: static/js/zamboni/validator.js:246 static/js/zamboni/validator.js:575 static/js/zamboni/validator.js:594
-msgid "Error"
-msgstr "ข้อผิดพลาด"
+#: static/js/zamboni/editors-all.js:16199 static/js/zamboni/editors-min.js:5 static/js/zamboni/themes_review.js:179
+msgid "Rejected"
+msgstr "ถูกปฏิเสธ"
 
-#: static/js/zamboni/validator.js:247
-msgid "Warning"
-msgstr "คำเตือน"
+#: static/js/zamboni/editors-all.js:16200 static/js/zamboni/editors-min.js:5 static/js/zamboni/themes_review.js:180
+msgid "Approved"
+msgstr "อนุมัติแล้ว"
 
-#: static/js/zamboni/validator.js:299
-msgid "Suggestions for passing automated signing:"
+#: static/js/zamboni/editors-all.js:16444 static/js/zamboni/editors-min.js:5 static/js/zamboni/themes_review.js:424
+msgid "No results found"
 msgstr ""
 
-#: static/js/zamboni/validator.js:387
-msgid "Compatibility Tests"
-msgstr "การทดสอบความเข้ากันได้"
-
-#: static/js/zamboni/validator.js:466
-msgid "Add-on failed validation."
-msgstr "ส่วนเสริมของคุณไม่ผ่านการตรวจสอบ"
-
-#: static/js/zamboni/validator.js:468
-msgid "Add-on passed validation."
-msgstr "ส่วนเสริมของคุณได้ผ่านการตรวจสอบ"
-
-#: static/js/zamboni/validator.js:481
-msgid "{0} error"
-msgid_plural "{0} errors"
-msgstr[0] "{0} ข้อผิดพลาด"
-
-#: static/js/zamboni/validator.js:483
-msgid "{0} warning"
-msgid_plural "{0} warnings"
-msgstr[0] "{0} คำเตือน"
-
-#: static/js/zamboni/validator.js:485
-msgid "{0} notice"
-msgid_plural "{0} notices"
-msgstr[0] ""
-
-#: static/js/zamboni/validator.js:577
-msgid "Validation task could not complete or completed with errors"
-msgstr "งานการตรวจสอบไม่สามารถเสร็จสิ้นได้เพราะมีข้อผิดพลาด"
-
-#: static/js/zamboni/validator.js:595
-msgid "Internal server error"
-msgstr "ข้อผิดพลาดภายในเซอร์เวอร์"
-
-#: static/js/zamboni/mobile/buttons.js:52
+#: static/js/zamboni/mobile-all.js:15186 static/js/zamboni/mobile/buttons.js:52
 msgid "Not Updated for {0} {1}"
 msgstr "ไม่ได้รับการปรับปรุงสำหรับ {0} {1}"
 
-#: static/js/zamboni/mobile/buttons.js:53
+#: static/js/zamboni/mobile-all.js:15187 static/js/zamboni/mobile/buttons.js:53
 msgid "Requires Newer Version of {0}"
 msgstr "ต้องการรุ่นใหม่กว่าของ {0}"
 
-#: static/js/zamboni/mobile/buttons.js:54
+#: static/js/zamboni/mobile-all.js:15188 static/js/zamboni/mobile/buttons.js:54
 msgid "Unreviewed"
 msgstr "ยังไม่ถูกตรวจสอบ"
 
-#: static/js/zamboni/mobile/buttons.js:55
+#: static/js/zamboni/mobile-all.js:15189 static/js/zamboni/mobile/buttons.js:55
 msgid "Experimental <span>(Learn More)</span>"
 msgstr "ทดลอง <span>(เรียนรู้เพิ่มเติม)</span>"
 
-#: static/js/zamboni/mobile/buttons.js:56 static/js/zamboni/mobile/buttons.js:57
+#: static/js/zamboni/mobile-all.js:15190 static/js/zamboni/mobile-all.js:15191 static/js/zamboni/mobile/buttons.js:56 static/js/zamboni/mobile/buttons.js:57
 msgid "Not Available for {0}"
 msgstr "ไม่พร้อมใช้งานสำหรับ {0}"
 
-#: static/js/zamboni/mobile/buttons.js:58
+#: static/js/zamboni/mobile-all.js:15192 static/js/zamboni/mobile/buttons.js:58
 msgid "Experimental"
 msgstr "ทดลอง"
 
-#: static/js/zamboni/mobile/buttons.js:59
+#: static/js/zamboni/mobile-all.js:15193 static/js/zamboni/mobile/buttons.js:59
 msgid "Themes Require Newer Version of {0}"
 msgstr "ชุดตกแต่งต้องการรุ่นที่ใหม่กว่าของ {0}"
 
-#: static/js/zamboni/mobile/buttons.js:60
+#: static/js/zamboni/mobile-all.js:15194 static/js/zamboni/mobile/buttons.js:60
 msgid "Themes Require {0}"
 msgstr "ชุดตกแต่งต้องการ {0}"
 
-#: static/js/zamboni/mobile/buttons.js:105
+#: static/js/zamboni/mobile-all.js:15239 static/js/zamboni/mobile/buttons.js:105
 msgid "Installing..."
 msgstr "กำลังติดตั้ง…"
 
-#: static/js/zamboni/mobile/buttons.js:125
+#: static/js/zamboni/mobile-all.js:15259 static/js/zamboni/mobile/buttons.js:125
 msgid "This add-on has been preliminarily reviewed by Mozilla."
 msgstr "ส่วนเสริมนี้ได้รับการตรวจสอบเบื้องต้นโดย Mozilla"
 
-#: static/js/zamboni/mobile/buttons.js:250
+#: static/js/zamboni/mobile-all.js:15384 static/js/zamboni/mobile/buttons.js:250
 msgid "Keep it"
 msgstr "เก็บไว้"
 
-#: static/js/zamboni/mobile/general.js:344
+#: static/js/zamboni/mobile-all.js:16049 static/js/zamboni/mobile-min.js:6 static/js/zamboni/mobile/general.js:344
 msgid "You're trying it on!"
 msgstr "คุณกำลังพยายามทำมันอยู่!"
 
-#: static/js/zamboni/mobile/general.js:356
+#: static/js/zamboni/mobile-all.js:16061 static/js/zamboni/mobile-min.js:6 static/js/zamboni/mobile/general.js:356
 msgid "Added to Firefox"
 msgstr "เพิ่มเข้า Firefox แล้ว"
-

--- a/locale/tr/LC_MESSAGES/django.po
+++ b/locale/tr/LC_MESSAGES/django.po
@@ -6,71 +6,72 @@ msgid ""
 msgstr ""
 "Project-Id-Version: REMORA 0.1\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2016-02-24 21:23+0000\n"
+"POT-Creation-Date: 2016-04-18 15:47+0000\n"
 "PO-Revision-Date: 2016-02-13 16:25+0000\n"
 "Last-Translator: Selim Şumlu <selim@sum.lu>\n"
 "Language-Team: Turkish (Türkçe)\n"
+"Language: \n"
 "MIME-Version: 1.0\n"
-"Content-Type: text/plain; charset=utf-8\n"
+"Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Generated-By: Babel 2.2.0\n"
 
-#: src/olympia/accounts/views.py:52
+#: src/olympia/accounts/views.py:54
 msgid "Your log in attempt could not be parsed. Please try again."
 msgstr ""
 
-#: src/olympia/accounts/views.py:54
+#: src/olympia/accounts/views.py:56
 msgid "Your Firefox Account could not be found. Please try again."
 msgstr ""
 
-#: src/olympia/accounts/views.py:55
+#: src/olympia/accounts/views.py:57
 msgid "You could not be logged in. Please try again."
 msgstr ""
 
-#: src/olympia/accounts/views.py:57
+#: src/olympia/accounts/views.py:59
 msgid "Your account has already been migrated to Firefox Accounts."
 msgstr ""
 
-#: src/olympia/accounts/views.py:59
+#: src/olympia/accounts/views.py:61
 msgid "Your Firefox Account already exists on this site."
 msgstr ""
 
-#: src/olympia/accounts/views.py:108
+#: src/olympia/accounts/views.py:110
 msgid "Great job!"
 msgstr ""
 
-#: src/olympia/accounts/views.py:109
+#: src/olympia/accounts/views.py:111
 msgid "You can now log in to Add-ons with your Firefox Account."
 msgstr ""
 
-#: src/olympia/accounts/views.py:121
+#: src/olympia/accounts/views.py:123
 msgid "Need help?"
 msgstr ""
 
-#: src/olympia/addons/buttons.py:180
+#: src/olympia/addons/buttons.py:177
 msgid "Download Now"
 msgstr "Şimdi indir"
 
 # 88%
 # 100%
-#: src/olympia/addons/buttons.py:182
+#: src/olympia/addons/buttons.py:179
 msgid "Download"
 msgstr "İndirme"
 
 #. L10n: please keep &nbsp; in the string so &rarr; does not wrap.
-#: src/olympia/addons/buttons.py:186
+#: src/olympia/addons/buttons.py:183
 msgid "Continue to Download&nbsp;&rarr;"
 msgstr "İndirmeye devam et&nbsp;&rarr;"
 
-#: src/olympia/addons/buttons.py:202 src/olympia/addons/helpers.py:35 src/olympia/addons/views.py:319 src/olympia/addons/templates/addons/impala/details.html:114
+#: src/olympia/addons/buttons.py:199 src/olympia/addons/helpers.py:35 src/olympia/addons/views.py:333 src/olympia/addons/templates/addons/impala/details.html:111
 #: src/olympia/addons/templates/addons/impala/listing/items.html:17 src/olympia/addons/templates/addons/mobile/home.html:40 src/olympia/amo/templates/amo/side_nav.html:6
-#: src/olympia/amo/templates/amo/side_nav.html:10 src/olympia/amo/templates/amo/site_nav.html:2 src/olympia/amo/templates/amo/site_nav.html:55 src/olympia/bandwagon/views.py:95
-#: src/olympia/browse/views.py:54 src/olympia/browse/views.py:68 src/olympia/browse/views.py:235 src/olympia/browse/templates/browse/impala/category_landing.html:22
+#: src/olympia/amo/templates/amo/side_nav.html:10 src/olympia/amo/templates/amo/site_nav.html:2 src/olympia/amo/templates/amo/site_nav.html:53 src/olympia/bandwagon/views.py:95
+#: src/olympia/browse/views.py:54 src/olympia/browse/views.py:68 src/olympia/browse/views.py:202 src/olympia/browse/templates/browse/impala/category_landing.html:22
 #: src/olympia/browse/templates/browse/personas/mobile/category_landing.html:26
 msgid "Featured"
 msgstr "Öne Çıkanlarda"
 
-#: src/olympia/addons/buttons.py:221
+#: src/olympia/addons/buttons.py:218
 msgid "Add to {0}"
 msgstr "{0}'a ekle"
 
@@ -92,17 +93,20 @@ msgstr "Kısa ad \"%s\" olmaz. Lütfen başka bir kısa ad seçin."
 msgid "Invalid tag: {0}"
 msgid_plural "Invalid tags: {0}"
 msgstr[0] "Geçersiz etiket: {0}"
+msgstr[1] ""
 
 #. L10n: {0} is a single tag or a comma-separated list of tags.
 #: src/olympia/addons/forms.py:103
 msgid "\"{0}\" is a reserved tag and cannot be used."
 msgid_plural "\"{0}\" are reserved tags and cannot be used."
 msgstr[0] "\"{0}\" rezerve bir etikettir ve kullanılamaz."
+msgstr[1] ""
 
 #: src/olympia/addons/forms.py:111
 msgid "You have {0} too many tags."
 msgid_plural "You have {0} too many tags."
 msgstr[0] "{0} fazla etiketiniz var."
+msgstr[1] ""
 
 #: src/olympia/addons/forms.py:117
 #, python-format
@@ -113,39 +117,41 @@ msgstr "Geçersiz karakterler çıkarıldıktan sonra tüm etiketler %s veya dah
 msgid "All tags must be at least {0} character."
 msgid_plural "All tags must be at least {0} characters."
 msgstr[0] "Tüm etiketler en az {0} karakter olmalıdır."
+msgstr[1] ""
 
-#: src/olympia/addons/forms.py:234
+#: src/olympia/addons/forms.py:238
 msgid "Categories cannot be changed while your add-on is featured for this application."
 msgstr "Eklentiniz bu uygulama için öne çıkanlardayken kategoriler değiştirilemez."
 
 #. L10n: {0} is the number of categories.
-#: src/olympia/addons/forms.py:238
+#: src/olympia/addons/forms.py:242
 msgid "You can have only {0} category."
 msgid_plural "You can have only {0} categories."
 msgstr[0] "Yalnızca {0} kategoriniz olabilir."
+msgstr[1] ""
 
-#: src/olympia/addons/forms.py:246
+#: src/olympia/addons/forms.py:250
 msgid "The miscellaneous category cannot be combined with additional categories."
 msgstr "Diğer kategorisi ekstra kategorilerle birlikte kullanılamaz."
 
-#: src/olympia/addons/forms.py:369
+#: src/olympia/addons/forms.py:374
 #, python-format
 msgid "Before changing your default locale you must have a name, summary, and description in that locale. You are missing %s."
 msgstr "Varsaılan dilinizi değiştirmek için o dilde bir adınız, özetiniz ve açıklamanız olmalıdır. %s mevcut değil."
 
-#: src/olympia/addons/forms.py:484 src/olympia/addons/forms.py:575
+#: src/olympia/addons/forms.py:455 src/olympia/addons/forms.py:546
 msgid "A license must be selected."
 msgstr "Bir lisans seçilmelidir."
 
-#: src/olympia/addons/forms.py:556
+#: src/olympia/addons/forms.py:527
 msgid "Give Your Theme a Name."
 msgstr "Temanıza Bir Adı Verin."
 
-#: src/olympia/addons/forms.py:562 src/olympia/devhub/templates/devhub/personas/submit.html:53
+#: src/olympia/addons/forms.py:533 src/olympia/devhub/templates/devhub/personas/submit.html:53
 msgid "Describe your Theme."
 msgstr "Temanızı Tanımlayın."
 
-#: src/olympia/addons/forms.py:704
+#: src/olympia/addons/forms.py:675
 msgid "Enter a new author's email address"
 msgstr "Yeni yazarın e-posta adresini girin"
 
@@ -153,41 +159,41 @@ msgstr "Yeni yazarın e-posta adresini girin"
 msgid "Not Reviewed"
 msgstr "İncelenmemiş"
 
-#: src/olympia/addons/models.py:301
+#: src/olympia/addons/models.py:298
 msgid "Users have the option of contributing more or less than this amount."
 msgstr "Kullanıcılar bu miktardan daha fazla veya daha az bağışta bulunma seçeneğine sahiptir."
 
-#: src/olympia/addons/models.py:309
-msgid "Users will always be asked in the Add-ons Manager (Firefox 4 and above)"
-msgstr "Eklenti Yöneticisi'nde her zaman sorulacaktır (Firefox 4 ve üstü)"
+#: src/olympia/addons/models.py:306
+msgid "Users will always be asked in the Add-ons Manager (Firefox 4 and above). Only applies to desktop."
+msgstr ""
 
 # Column name in a table.
-#: src/olympia/addons/models.py:1804 src/olympia/addons/templates/addons/details_box.html:55 src/olympia/devhub/templates/devhub/index.html:92
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:102
+#: src/olympia/addons/models.py:1802 src/olympia/addons/templates/addons/details_box.html:55 src/olympia/devhub/templates/devhub/index.html:92
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:89
 msgid "Listed"
 msgstr "Listelenen"
 
-#: src/olympia/addons/views.py:320 src/olympia/browse/templates/browse/personas/mobile/category_landing.html:27
+#: src/olympia/addons/views.py:334 src/olympia/browse/templates/browse/personas/mobile/category_landing.html:27
 msgid "Popular"
 msgstr "Popüler"
 
-#: src/olympia/addons/views.py:321 src/olympia/browse/views.py:238 src/olympia/browse/views.py:280 src/olympia/browse/views.py:482
+#: src/olympia/addons/views.py:335 src/olympia/browse/views.py:205 src/olympia/browse/views.py:247 src/olympia/browse/views.py:449
 msgid "Recently Added"
 msgstr "Son Eklenenler"
 
 # 75%
 # 100%
-#: src/olympia/addons/views.py:322 src/olympia/bandwagon/views.py:99 src/olympia/browse/views.py:60 src/olympia/browse/views.py:71 src/olympia/search/forms.py:16 src/olympia/search/forms.py:91
+#: src/olympia/addons/views.py:336 src/olympia/bandwagon/views.py:99 src/olympia/browse/views.py:60 src/olympia/browse/views.py:71 src/olympia/search/forms.py:16 src/olympia/search/forms.py:91
 msgid "Recently Updated"
 msgstr "Son Güncellenenler"
 
 # %1 is an add-on name.
 #. l10n: {0} is the addon name
-#: src/olympia/addons/views.py:520
+#: src/olympia/addons/views.py:534
 msgid "Contribution for {0}"
 msgstr "{0} için bağış"
 
-#: src/olympia/addons/views.py:613
+#: src/olympia/addons/views.py:627
 msgid "Abuse reported."
 msgstr "İhlal rapor edildi."
 
@@ -256,9 +262,9 @@ msgstr "Bağışta Bulun"
 #: src/olympia/devhub/templates/devhub/addons/ajax_compat_update.html:36 src/olympia/devhub/templates/devhub/addons/profile.html:44 src/olympia/devhub/templates/devhub/addons/edit/admin.html:101
 #: src/olympia/devhub/templates/devhub/addons/edit/basic.html:152 src/olympia/devhub/templates/devhub/addons/edit/details.html:85 src/olympia/devhub/templates/devhub/addons/edit/support.html:67
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:166 src/olympia/devhub/templates/devhub/addons/forms_shared/media.html:149
-#: src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:44 src/olympia/devhub/templates/devhub/versions/add_file_modal.html:78 src/olympia/devhub/templates/devhub/versions/edit.html:139
-#: src/olympia/devhub/templates/devhub/versions/list.html:242 src/olympia/devhub/templates/devhub/versions/list.html:276 src/olympia/devhub/templates/devhub/versions/list.html:317
-#: src/olympia/devhub/templates/devhub/versions/list.html:351 src/olympia/reviews/templates/reviews/edit_review.html:16 src/olympia/translations/templates/translations/trans-menu.html:50
+#: src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:43 src/olympia/devhub/templates/devhub/versions/add_file_modal.html:58 src/olympia/devhub/templates/devhub/versions/edit.html:139
+#: src/olympia/devhub/templates/devhub/versions/list.html:239 src/olympia/devhub/templates/devhub/versions/list.html:281 src/olympia/devhub/templates/devhub/versions/list.html:315
+#: src/olympia/devhub/templates/devhub/versions/list.html:349 src/olympia/reviews/templates/reviews/edit_review.html:16 src/olympia/translations/templates/translations/trans-menu.html:50
 #: src/olympia/translations/templates/translations/trans-menu.html:62
 msgid "or"
 msgstr "veya"
@@ -374,7 +380,7 @@ msgid "Add-on Information for {0}"
 msgstr "{0} Eklenti Bilgileri"
 
 #: src/olympia/addons/templates/addons/details_box.html:30 src/olympia/addons/templates/addons/persona_detail_table.html:3 src/olympia/addons/templates/addons/mobile/details.html:63
-#: src/olympia/addons/templates/addons/mobile/persona_detail_table.html:7 src/olympia/browse/views.py:459 src/olympia/devhub/views.py:75
+#: src/olympia/addons/templates/addons/mobile/persona_detail_table.html:7 src/olympia/browse/views.py:426 src/olympia/devhub/views.py:73
 msgid "Updated"
 msgstr "Güncelleme"
 
@@ -393,11 +399,11 @@ msgstr "Uyumlu sürümler"
 msgid "Visibility"
 msgstr "Görünürlük"
 
-#: src/olympia/addons/templates/addons/details_box.html:57 src/olympia/devhub/templates/devhub/index.html:94 src/olympia/devhub/templates/devhub/includes/addon_details.html:104
+#: src/olympia/addons/templates/addons/details_box.html:57 src/olympia/devhub/templates/devhub/index.html:94 src/olympia/devhub/templates/devhub/includes/addon_details.html:91
 msgid "Hidden"
 msgstr "Gizli"
 
-#: src/olympia/addons/templates/addons/details_box.html:59 src/olympia/devhub/templates/devhub/index.html:96 src/olympia/devhub/templates/devhub/includes/addon_details.html:106
+#: src/olympia/addons/templates/addons/details_box.html:59 src/olympia/devhub/templates/devhub/index.html:96 src/olympia/devhub/templates/devhub/includes/addon_details.html:93
 msgid "Unlisted"
 msgstr "Listelenmemiş"
 
@@ -406,14 +412,14 @@ msgid "Required Add-ons"
 msgstr "Gerekli eklentiler"
 
 # 100%
-#: src/olympia/addons/templates/addons/details_box.html:81 src/olympia/addons/templates/addons/persona_detail_table.html:15 src/olympia/browse/views.py:462 src/olympia/devhub/views.py:78
-#: src/olympia/devhub/views.py:85 src/olympia/discovery/templates/discovery/addons/detail.html:57 src/olympia/reviews/forms.py:62 src/olympia/reviews/templates/reviews/add.html:57
+#: src/olympia/addons/templates/addons/details_box.html:81 src/olympia/addons/templates/addons/persona_detail_table.html:15 src/olympia/browse/views.py:429 src/olympia/devhub/views.py:76
+#: src/olympia/devhub/views.py:83 src/olympia/discovery/templates/discovery/addons/detail.html:57 src/olympia/reviews/forms.py:62 src/olympia/reviews/templates/reviews/add.html:57
 #: src/olympia/reviews/templates/reviews/mobile/review_list.html:18
 msgid "Rating"
 msgstr "Puan"
 
 # 100%
-#: src/olympia/addons/templates/addons/details_box.html:85 src/olympia/browse/views.py:461 src/olympia/devhub/views.py:77 src/olympia/devhub/views.py:84
+#: src/olympia/addons/templates/addons/details_box.html:85 src/olympia/browse/views.py:428 src/olympia/devhub/views.py:75 src/olympia/devhub/views.py:82
 #: src/olympia/stats/templates/stats/addon_report_menu.html:8 src/olympia/stats/templates/stats/collection_report_menu.html:18
 msgid "Downloads"
 msgstr "İndirme"
@@ -433,7 +439,7 @@ msgstr "Suistimal Raporları"
 
 #. The Privacy Policy for this add-on.
 #: src/olympia/addons/templates/addons/details_box.html:121 src/olympia/addons/templates/addons/privacy.html:19 src/olympia/addons/templates/addons/privacy.html:23
-#: src/olympia/addons/templates/addons/impala/button.html:43 src/olympia/addons/templates/addons/impala/details.html:307 src/olympia/devhub/templates/devhub/includes/policy_form.html:20
+#: src/olympia/addons/templates/addons/impala/button.html:43 src/olympia/addons/templates/addons/impala/details.html:312 src/olympia/devhub/templates/devhub/includes/policy_form.html:23
 #: src/olympia/templates/mobile/base_addons.html:87
 msgid "Privacy Policy"
 msgstr "Gizlilik Politikası"
@@ -461,7 +467,7 @@ msgstr "Resim Galerisi"
 msgid "Developer Comments"
 msgstr "Geliştirici yorumları"
 
-#: src/olympia/addons/templates/addons/details_box.html:199 src/olympia/addons/templates/addons/impala/details.html:259
+#: src/olympia/addons/templates/addons/details_box.html:199 src/olympia/addons/templates/addons/impala/details.html:264
 msgid "Development Channel"
 msgstr "Geliştirme Kanalı"
 
@@ -485,13 +491,13 @@ msgstr ""
 "<strong>Uyarı:</strong> Bu eklentinin geliştirme sürümleri Mozilla tarafından incelenmemiştir. Geliştirme sürümünü bir kez yükledikten sonra bu geliştiricinin geliştirme güncellemelerini almaya "
 "devam edeceksiniz. Gelişme güncellemelerini durdurmak için, yukarıki linkten varsayılan sürümü tekrar yükleyin."
 
-#: src/olympia/addons/templates/addons/details_box.html:220 src/olympia/addons/templates/addons/impala/details.html:278
+#: src/olympia/addons/templates/addons/details_box.html:220 src/olympia/addons/templates/addons/impala/details.html:283
 msgid "Version {0}:"
 msgstr "Sürüm {0}:"
 
 #: src/olympia/addons/templates/addons/details_box.html:234
-msgid "Nothing to see here! The developer did not include any details."
-msgstr "Burada bir şey yok! Geliştirici herhangi bir ayrıntı eklememiş."
+msgid "Nothing to see here!  The developer did not include any details."
+msgstr ""
 
 #: src/olympia/addons/templates/addons/details_box.html:251 src/olympia/devhub/templates/devhub/versions/edit.html:73 src/olympia/editors/templates/editors/review.html:98
 msgid "Version Notes"
@@ -506,7 +512,7 @@ msgid "End-User License Agreement for {0}"
 msgstr "{0} Son Kullanıcı Lisans Anlaşması"
 
 #: src/olympia/addons/templates/addons/eula.html:17 src/olympia/addons/templates/addons/eula.html:21 src/olympia/addons/templates/addons/impala/button.html:48
-#: src/olympia/addons/templates/addons/impala/details.html:316 src/olympia/devhub/templates/devhub/includes/policy_form.html:3 src/olympia/discovery/templates/discovery/addons/eula.html:11
+#: src/olympia/addons/templates/addons/impala/details.html:321 src/olympia/devhub/templates/devhub/includes/policy_form.html:3 src/olympia/discovery/templates/discovery/addons/eula.html:11
 msgid "End-User License Agreement"
 msgstr "Son Kullanıcı Lisans Anlaşması"
 
@@ -526,7 +532,7 @@ msgstr "{0} sayfasına dön..."
 msgid "Add-ons for {0}"
 msgstr "{0} Eklentileri"
 
-#: src/olympia/addons/templates/addons/home.html:10 src/olympia/addons/templates/addons/home.html:51 src/olympia/browse/templates/browse/impala/base_listing.html:11
+#: src/olympia/addons/templates/addons/home.html:10 src/olympia/addons/templates/addons/home.html:53 src/olympia/browse/templates/browse/impala/base_listing.html:11
 msgid "Featured Extensions"
 msgstr "Öne Çıkan Uzantılar"
 
@@ -534,31 +540,31 @@ msgstr "Öne Çıkan Uzantılar"
 msgid "Popular Extensions"
 msgstr "Popüler Uzantılar"
 
-#: src/olympia/addons/templates/addons/home.html:42 src/olympia/amo/templates/amo/side_nav.html:3 src/olympia/amo/templates/amo/side_nav.html:11 src/olympia/amo/templates/amo/site_nav.html:3
-#: src/olympia/amo/templates/amo/site_nav.html:25 src/olympia/browse/views.py:236 src/olympia/browse/views.py:281 src/olympia/browse/views.py:481
+#: src/olympia/addons/templates/addons/home.html:44 src/olympia/amo/templates/amo/side_nav.html:3 src/olympia/amo/templates/amo/side_nav.html:11 src/olympia/amo/templates/amo/site_nav.html:3
+#: src/olympia/amo/templates/amo/site_nav.html:25 src/olympia/browse/views.py:203 src/olympia/browse/views.py:248 src/olympia/browse/views.py:448
 msgid "Most Popular"
 msgstr "En Popüler"
 
-#: src/olympia/addons/templates/addons/home.html:43
+#: src/olympia/addons/templates/addons/home.html:45
 msgid "All »"
 msgstr "Tümü »"
 
-#: src/olympia/addons/templates/addons/home.html:52 src/olympia/addons/templates/addons/home.html:61 src/olympia/addons/templates/addons/home.html:70 src/olympia/addons/templates/addons/home.html:78
+#: src/olympia/addons/templates/addons/home.html:54 src/olympia/addons/templates/addons/home.html:63 src/olympia/addons/templates/addons/home.html:72 src/olympia/addons/templates/addons/home.html:80
 #: src/olympia/browse/templates/browse/impala/category_landing.html:36
 msgid "See all »"
 msgstr "Tümünü gör »"
 
-#: src/olympia/addons/templates/addons/home.html:60
+#: src/olympia/addons/templates/addons/home.html:62
 msgid "Up &amp; Coming Extensions"
 msgstr "Yükselişte Olan Uzantılar"
 
-#: src/olympia/addons/templates/addons/home.html:69 src/olympia/browse/templates/browse/personas/category_landing.html:61 src/olympia/discovery/templates/discovery/pane.html:74
+#: src/olympia/addons/templates/addons/home.html:71 src/olympia/browse/templates/browse/personas/category_landing.html:61 src/olympia/discovery/templates/discovery/pane.html:74
 msgid "Featured Themes"
 msgstr "Öne Çıkan Temalar"
 
 # 80%
 # 100%
-#: src/olympia/addons/templates/addons/home.html:77 src/olympia/bandwagon/templates/bandwagon/impala/collection_listing.html:5
+#: src/olympia/addons/templates/addons/home.html:79 src/olympia/bandwagon/templates/bandwagon/impala/collection_listing.html:5
 msgid "Featured Collections"
 msgstr "Öne Çıkan Koleksiyonlar"
 
@@ -576,7 +582,7 @@ msgid "Updated {0}"
 msgstr "{0} tarihinde güncellendi"
 
 #. {0} is a date.
-#: src/olympia/addons/templates/addons/macros.html:10 src/olympia/addons/templates/addons/macros.html:69 src/olympia/addons/templates/addons/persona_preview.html:21
+#: src/olympia/addons/templates/addons/macros.html:10 src/olympia/addons/templates/addons/macros.html:69 src/olympia/addons/templates/addons/persona_preview.html:22
 #: src/olympia/addons/templates/addons/listing/items_mobile.html:44 src/olympia/addons/templates/addons/listing/macros.html:39
 #: src/olympia/bandwagon/templates/bandwagon/collection_listing_items.html:37 src/olympia/bandwagon/templates/bandwagon/impala/collection_listing_items.html:37
 msgid "Added {0}"
@@ -587,25 +593,28 @@ msgstr "{0} tarihinde eklendi"
 msgid "%(num)s weekly download"
 msgid_plural "%(num)s weekly downloads"
 msgstr[0] "%(num)s haftalık indirme"
+msgstr[1] ""
 
 #: src/olympia/addons/templates/addons/macros.html:28
 #, python-format
 msgid "%(num)s user"
 msgid_plural "%(num)s users"
 msgstr[0] "%(num)s kullanıcı"
+msgstr[1] ""
 
 #. {0} is the number of downloads.
-#: src/olympia/addons/templates/addons/macros.html:53 src/olympia/addons/templates/addons/impala/details.html:61
+#: src/olympia/addons/templates/addons/macros.html:53 src/olympia/addons/templates/addons/impala/details.html:59
 msgid "{0} weekly download"
 msgid_plural "{0} weekly downloads"
 msgstr[0] "Haftalık {0} indirme"
+msgstr[1] ""
 
 #. {0} is the number of users.
-#: src/olympia/addons/templates/addons/macros.html:61 src/olympia/addons/templates/addons/impala/details.html:54 src/olympia/compat/templates/compat/index.html:71
-#: src/olympia/zadmin/templates/zadmin/compat.html:67
+#: src/olympia/addons/templates/addons/macros.html:61 src/olympia/addons/templates/addons/impala/details.html:52 src/olympia/zadmin/templates/zadmin/compat.html:67
 msgid "{0} user"
 msgid_plural "{0} users"
 msgstr[0] "{0} kullanıcı"
+msgstr[1] ""
 
 #: src/olympia/addons/templates/addons/paypal_result.html:12
 msgid "Payment cancelled"
@@ -619,7 +628,7 @@ msgstr "Ödeme tamamlandı"
 msgid "Return to the addon."
 msgstr "Eklentiye geri dön."
 
-#: src/olympia/addons/templates/addons/persona_detail.html:17 src/olympia/addons/templates/addons/impala/details.html:106 src/olympia/addons/templates/addons/mobile/details.html:23
+#: src/olympia/addons/templates/addons/persona_detail.html:17 src/olympia/addons/templates/addons/impala/details.html:103 src/olympia/addons/templates/addons/mobile/details.html:23
 #: src/olympia/addons/templates/addons/mobile/persona_detail.html:21 src/olympia/discovery/templates/discovery/addons/base.html:27 src/olympia/editors/templates/editors/review.html:31
 msgid "by"
 msgstr "geliştiren:"
@@ -663,33 +672,35 @@ msgstr "Günlük Kullanıcı"
 msgid "License"
 msgstr "Lisans"
 
-#: src/olympia/addons/templates/addons/persona_preview.html:12 src/olympia/constants/base.py:48
+#: src/olympia/addons/templates/addons/persona_preview.html:13 src/olympia/constants/base.py:48
 msgid "Awaiting Review"
 msgstr "İnceleme Bekliyor"
 
-#: src/olympia/addons/templates/addons/persona_preview.html:14 src/olympia/amo/log.py:180 src/olympia/constants/base.py:42 src/olympia/editors/helpers.py:62
+#: src/olympia/addons/templates/addons/persona_preview.html:15 src/olympia/amo/log.py:180 src/olympia/constants/base.py:42 src/olympia/editors/helpers.py:62
 msgid "Rejected"
 msgstr "Reddedildi."
 
-#: src/olympia/addons/templates/addons/persona_preview.html:16 src/olympia/amo/log.py:159
+#: src/olympia/addons/templates/addons/persona_preview.html:17 src/olympia/amo/log.py:159
 msgid "Approved"
 msgstr "Onaylandı"
 
 #. {0} is the number of users.
-#: src/olympia/addons/templates/addons/persona_preview.html:26 src/olympia/addons/templates/addons/listing/items_mobile.html:36 src/olympia/addons/templates/addons/listing/macros.html:31
+#: src/olympia/addons/templates/addons/persona_preview.html:27 src/olympia/addons/templates/addons/listing/items_mobile.html:36 src/olympia/addons/templates/addons/listing/macros.html:31
 msgid "<strong>{0}</strong> user"
 msgid_plural "<strong>{0}</strong> users"
 msgstr[0] "<strong>{0}</strong> kullanıcı"
+msgstr[1] ""
 
-#: src/olympia/addons/templates/addons/persona_preview.html:40
+#: src/olympia/addons/templates/addons/persona_preview.html:41
 msgid "Hover to Preview"
 msgstr "Ön izleme için üstüne gelin"
 
-#: src/olympia/addons/templates/addons/persona_preview.html:46 src/olympia/addons/templates/addons/persona_preview.html:48 src/olympia/reviews/templates/reviews/add.html:15
+#: src/olympia/addons/templates/addons/persona_preview.html:47 src/olympia/addons/templates/addons/persona_preview.html:49 src/olympia/addons/templates/addons/persona_preview.html:97
+#: src/olympia/reviews/templates/reviews/add.html:15
 msgid "Add"
 msgstr "Ekle"
 
-#: src/olympia/addons/templates/addons/persona_preview.html:57 src/olympia/bandwagon/templates/bandwagon/ajax_new.html:16 src/olympia/bandwagon/templates/bandwagon/edit.html:19
+#: src/olympia/addons/templates/addons/persona_preview.html:58 src/olympia/bandwagon/templates/bandwagon/ajax_new.html:16 src/olympia/bandwagon/templates/bandwagon/edit.html:19
 #: src/olympia/bandwagon/templates/bandwagon/includes/addedit.html:19 src/olympia/devhub/templates/devhub/addons/edit/admin.html:13 src/olympia/devhub/templates/devhub/addons/edit/basic.html:10
 #: src/olympia/devhub/templates/devhub/addons/edit/details.html:8 src/olympia/devhub/templates/devhub/addons/edit/media.html:6 src/olympia/devhub/templates/devhub/addons/edit/support.html:8
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:9 src/olympia/devhub/templates/devhub/addons/submit/describe.html:29 src/olympia/editors/templates/editors/review.html:257
@@ -698,21 +709,21 @@ msgstr "Düzenle"
 
 #. For datetime formatting, see the table on
 #. http://docs.python.org/library/datetime.html#strftime-and-strptime-behavior
-#: src/olympia/addons/templates/addons/persona_preview.html:66
+#: src/olympia/addons/templates/addons/persona_preview.html:67
 #, python-format
 msgid "%%Y-%%m-%%d"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/persona_preview.html:67
+#: src/olympia/addons/templates/addons/persona_preview.html:68
 msgid "by {0} on {1}"
 msgstr "{0} tarafından {1} tarihinde"
 
-#: src/olympia/addons/templates/addons/persona_preview.html:75 src/olympia/reviews/helpers.py:17 src/olympia/reviews/templates/reviews/review_list.html:63
+#: src/olympia/addons/templates/addons/persona_preview.html:76 src/olympia/reviews/helpers.py:17 src/olympia/reviews/templates/reviews/review_list.html:63
 #: src/olympia/reviews/templates/reviews/reviews_link.html:21 src/olympia/reviews/templates/reviews/impala/reviews_link.html:16
 msgid "Not yet rated"
 msgstr "Henüz puanlanmamış"
 
-#: src/olympia/addons/templates/addons/persona_preview.html:78
+#: src/olympia/addons/templates/addons/persona_preview.html:79
 msgid "<b>{0}</b> users"
 msgstr "<b>{0}</b> kullanıcı"
 
@@ -725,8 +736,8 @@ msgid "Learn more about Firefox"
 msgstr "Firefox hakkında daha fazla bilgi alın"
 
 #: src/olympia/addons/templates/addons/popups.html:22
-msgid "or <b><a class=\"installer\" href=\"{url}\">download anyway</a></b>"
-msgstr "veya <b><a class=\"installer\" href=\"{url}\">hemen indirin</a></b>"
+msgid "or <b><a class=\"button installer\" href=\"{url}\">download anyway</a></b>"
+msgstr ""
 
 #: src/olympia/addons/templates/addons/popups.html:26
 msgid ""
@@ -787,11 +798,9 @@ msgstr "Bu Persona %(app)s %(new_version)s gerektiriyor. Siz şu anda %(app)s {o
 
 #: src/olympia/addons/templates/addons/popups.html:108
 msgid ""
-"<strong>Caution:</strong> This add-on has not been reviewed by Mozilla and can't be installed on release versions of Firefox 43 and above. Be careful when installing third-party software that might "
-"harm your computer."
+"<strong>Caution:</strong> This add-on has not been reviewed by Mozilla and can't be installed on release versions of Firefox 43 and above.  Be careful when installing third-party software that "
+"might harm your computer."
 msgstr ""
-"<strong>Dikkat:</strong> Bu eklenti Mozilla tarafından henüz incelenmedi ve Firefox 43 ve üstündeki son kullanıcı sürümlerine kurulamaz. Bilgisayarınıza zararı dokunabilecek üçüncü taraf "
-"yazılımlarını kurarken dikkatli olun."
 
 #: src/olympia/addons/templates/addons/popups.html:120
 msgid "<strong>Please note:</strong> This add-on is not compatible with your operating system."
@@ -821,12 +830,14 @@ msgid "QR code for add-on"
 msgstr "Eklentinin QR kodu"
 
 #: src/olympia/addons/templates/addons/qr_code.html:6
-msgid "Want {0} on your mobile Firefox? Scan this QR code to install directly to your phone. (You'll need a QR reader. Search your phone's marketplace if don't have one.)"
+msgid ""
+"Want {0} on your mobile Firefox?  Scan this QR code to install directly\n"
+"  to your phone.  (You'll need a QR reader.  Search your phone's marketplace if\n"
+"  don't have one.)"
 msgstr ""
-"Mobil Firefox'unuzda {0} olsun ister misiniz? Doğrudan telefonunuza yüklemek için bu QR kodunu tarayın. (Bir QR okuyucusuna ihtiyacınız olacak. Yüklü bir tane yoksa telefonunuz marketinde arayın.)"
 
 #: src/olympia/addons/templates/addons/report_abuse.html:6 src/olympia/addons/templates/addons/report_abuse_full.html:10 src/olympia/addons/templates/addons/impala/details-more.html:23
-#: src/olympia/addons/templates/addons/impala/details.html:328
+#: src/olympia/addons/templates/addons/impala/details.html:333
 msgid "Report Abuse"
 msgstr "Suistimal rapor et"
 
@@ -847,9 +858,9 @@ msgstr "Rapor Gönder"
 #: src/olympia/devhub/templates/devhub/addons/ajax_compat_update.html:36 src/olympia/devhub/templates/devhub/addons/profile.html:44 src/olympia/devhub/templates/devhub/addons/edit/admin.html:104
 #: src/olympia/devhub/templates/devhub/addons/edit/basic.html:155 src/olympia/devhub/templates/devhub/addons/edit/details.html:88 src/olympia/devhub/templates/devhub/addons/edit/support.html:70
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:169 src/olympia/devhub/templates/devhub/addons/forms_shared/media.html:152
-#: src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:44 src/olympia/devhub/templates/devhub/personas/edit.html:222 src/olympia/devhub/templates/devhub/versions/add_file_modal.html:79
-#: src/olympia/devhub/templates/devhub/versions/edit.html:140 src/olympia/devhub/templates/devhub/versions/list.html:208 src/olympia/devhub/templates/devhub/versions/list.html:242
-#: src/olympia/devhub/templates/devhub/versions/list.html:276 src/olympia/devhub/templates/devhub/versions/list.html:317 src/olympia/reviews/templates/reviews/edit_review.html:16
+#: src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:43 src/olympia/devhub/templates/devhub/personas/edit.html:222 src/olympia/devhub/templates/devhub/versions/add_file_modal.html:59
+#: src/olympia/devhub/templates/devhub/versions/edit.html:140 src/olympia/devhub/templates/devhub/versions/list.html:208 src/olympia/devhub/templates/devhub/versions/list.html:239
+#: src/olympia/devhub/templates/devhub/versions/list.html:281 src/olympia/devhub/templates/devhub/versions/list.html:315 src/olympia/reviews/templates/reviews/edit_review.html:16
 #: src/olympia/translations/templates/translations/trans-menu.html:50 src/olympia/translations/templates/translations/trans-menu.html:62 src/olympia/zadmin/templates/zadmin/validation.html:105
 msgid "Cancel"
 msgstr "Vazgeç"
@@ -894,7 +905,7 @@ msgstr "Bu eklentiyle ilgili nereden destek alabileceğinizi öğrenmek için <a
 msgid "Review Guidelines"
 msgstr "İnceleme Yönergesi"
 
-#: src/olympia/addons/templates/addons/review_list_box.html:5 src/olympia/addons/templates/addons/impala/details-more.html:27 src/olympia/editors/helpers.py:921
+#: src/olympia/addons/templates/addons/review_list_box.html:5 src/olympia/addons/templates/addons/impala/details-more.html:27 src/olympia/editors/helpers.py:1001
 #: src/olympia/reviews/templates/reviews/add.html:14 src/olympia/reviews/templates/reviews/reply.html:14 src/olympia/reviews/templates/reviews/review_list.html:19
 #: src/olympia/reviews/templates/reviews/mobile/review_list.html:26
 msgid "Reviews"
@@ -914,6 +925,7 @@ msgstr "Geliştiricinin bu incelemeye yanıtını göster"
 msgid "See all reviews of this add-on"
 msgid_plural "See all %(cnt)s reviews of this add-on"
 msgstr[0] "Bu eklentinin tüm incelemelerini göster"
+msgstr[1] ""
 
 # 100%
 #: src/olympia/addons/templates/addons/tags_box.html:3 src/olympia/devhub/templates/devhub/addons/edit/basic.html:118
@@ -983,103 +995,106 @@ msgstr "Bu koleksiyonların bir parçası"
 msgid "Other add-ons by %(author)s"
 msgid_plural "Other add-ons by these authors"
 msgstr[0] "%(author)s tarafından geliştirilen diğer eklentiler"
+msgstr[1] ""
 
-#: src/olympia/addons/templates/addons/impala/details.html:41
+#: src/olympia/addons/templates/addons/impala/details.html:39
 #, python-format
 msgid "<span itemprop=\"ratingCount\">%(num)s</span> user review"
 msgid_plural "<span itemprop=\"ratingCount\">%(num)s</span> user reviews"
 msgstr[0] "<span itemprop=\"ratingCount\">%(num)s</span> kullanıcı değerlendirmesi"
+msgstr[1] ""
 
-#: src/olympia/addons/templates/addons/impala/details.html:69
+#: src/olympia/addons/templates/addons/impala/details.html:66
 msgid "View statistics"
 msgstr "İstatistikleri göster"
 
-#: src/olympia/addons/templates/addons/impala/details.html:84
+#: src/olympia/addons/templates/addons/impala/details.html:81
 msgid "Manage"
 msgstr "Yönet"
 
 #. {0} is an add-on name.
-#: src/olympia/addons/templates/addons/impala/details.html:96
+#: src/olympia/addons/templates/addons/impala/details.html:93
 msgid "Icon of {0}"
 msgstr "{0} simgesi"
 
-#: src/olympia/addons/templates/addons/impala/details.html:103 src/olympia/addons/templates/addons/impala/listing/items.html:14
+#: src/olympia/addons/templates/addons/impala/details.html:100 src/olympia/addons/templates/addons/impala/listing/items.html:14
 msgid "No Restart"
 msgstr "Yeniden Başlatmasız"
 
-#: src/olympia/addons/templates/addons/impala/details.html:127
+#: src/olympia/addons/templates/addons/impala/details.html:124
 #, fuzzy, python-format
 msgid "Meet the Developer: <a href=\"%(url)s\">%(name)s</a>"
 msgid_plural "<a href=\"%(url)s\">Meet the Developers</a>"
 msgstr[0] "Geliştiriciyle Tanışın: <a href=\"%(url)s\">%(name)s</a>"
+msgstr[1] ""
 
 # {0} is an add-on name.
-#: src/olympia/addons/templates/addons/impala/details.html:137
+#: src/olympia/addons/templates/addons/impala/details.html:134
 msgid "Learn why {0} was created and find out what's next for this add-on."
 msgstr "{0} neden geliştirildi? Bu eklentiyi gelecekte neler bekliyor?"
 
 #. {0} is an index.
-#: src/olympia/addons/templates/addons/impala/details.html:156
+#: src/olympia/addons/templates/addons/impala/details.html:161
 msgid "Add-on screenshot #{0}"
 msgstr "Eklenti Ekran Görüntüsü #{0}"
 
-#: src/olympia/addons/templates/addons/impala/details.html:182
+#: src/olympia/addons/templates/addons/impala/details.html:187
 msgid "Add-on home page"
 msgstr "Eklentinin web sitesi"
 
-#: src/olympia/addons/templates/addons/impala/details.html:185
+#: src/olympia/addons/templates/addons/impala/details.html:190
 msgid "Support site"
 msgstr "Destek sitesi"
 
-#: src/olympia/addons/templates/addons/impala/details.html:189
+#: src/olympia/addons/templates/addons/impala/details.html:194
 msgid "Support E-mail"
 msgstr "E-posta desteği"
 
-#: src/olympia/addons/templates/addons/impala/details.html:194 src/olympia/devhub/models.py:378 src/olympia/devhub/templates/devhub/versions/list.html:12
+#: src/olympia/addons/templates/addons/impala/details.html:199 src/olympia/devhub/models.py:378 src/olympia/devhub/templates/devhub/versions/list.html:12
 #: src/olympia/versions/templates/versions/version.html:6 src/olympia/versions/templates/versions/mobile/version.html:6
 msgid "Version {0}"
 msgstr "Sürüm {0}"
 
-#: src/olympia/addons/templates/addons/impala/details.html:194
+#: src/olympia/addons/templates/addons/impala/details.html:199
 msgid "Info"
 msgstr "Bilgi"
 
-#: src/olympia/addons/templates/addons/impala/details.html:195 src/olympia/devhub/templates/devhub/includes/addon_details.html:129
+#: src/olympia/addons/templates/addons/impala/details.html:200 src/olympia/devhub/templates/devhub/includes/addon_details.html:116
 msgid "Last Updated:"
 msgstr "Son Güncellenme:"
 
-#: src/olympia/addons/templates/addons/impala/details.html:200
+#: src/olympia/addons/templates/addons/impala/details.html:205
 #, python-format
 msgid "Released under <a target=\"_blank\" href=\"%(url)s\">%(name)s</a>"
 msgstr "<a target=\"_blank\" href=\"%(url)s\">%(name)s</a> altında yayımlanmıştır"
 
-#: src/olympia/addons/templates/addons/impala/details.html:201 src/olympia/addons/templates/addons/impala/details.html:206 src/olympia/amo/helpers.py:398 src/olympia/devhub/forms.py:142
+#: src/olympia/addons/templates/addons/impala/details.html:206 src/olympia/addons/templates/addons/impala/details.html:211 src/olympia/amo/helpers.py:398 src/olympia/devhub/forms.py:142
 #: src/olympia/devhub/forms.py:173 src/olympia/versions/templates/versions/version.html:40 src/olympia/versions/templates/versions/version.html:45
 msgid "Custom License"
 msgstr "Özel Lisans"
 
-#: src/olympia/addons/templates/addons/impala/details.html:205
+#: src/olympia/addons/templates/addons/impala/details.html:210
 #, python-format
 msgid "Released under <a href=\"%(url)s\">%(name)s</a>"
 msgstr "<a href=\"%(url)s\">%(name)s</a> altında yayımlanmış"
 
-#: src/olympia/addons/templates/addons/impala/details.html:217
+#: src/olympia/addons/templates/addons/impala/details.html:222
 msgid "About this Add-on"
 msgstr "Bu eklenti hakkında"
 
-#: src/olympia/addons/templates/addons/impala/details.html:233
+#: src/olympia/addons/templates/addons/impala/details.html:238
 msgid "Developer’s Comments"
 msgstr "Geliştiricinin Yorumları"
 
-#: src/olympia/addons/templates/addons/impala/details.html:243
+#: src/olympia/addons/templates/addons/impala/details.html:248
 msgid "Version Information"
 msgstr "Sürüm Bilgisi"
 
-#: src/olympia/addons/templates/addons/impala/details.html:250
+#: src/olympia/addons/templates/addons/impala/details.html:255
 msgid "See complete version history"
 msgstr "Tüm sürüm geçmişini görüntüle"
 
-#: src/olympia/addons/templates/addons/impala/details.html:262
+#: src/olympia/addons/templates/addons/impala/details.html:267
 msgid ""
 "The Development Channel lets you test an experimental new version of this add-on before it's released to the general public. Once you install the development version, you will continue to get "
 "updates from this channel. To stop receiving development updates, reinstall the default version from the link above."
@@ -1087,17 +1102,17 @@ msgstr ""
 "Geliştirme Kanalı, bu eklentinin deneysel bir yeni sürümünü genel kullamına açılmadan önce test etmenizi sağlar. Geliştirme sürümünü bir kez kurduktan sonra bu kanaldaki güncellemeleri almaya devam "
 "edeceksiniz. Geliştirme güncellemelerini almayı durdurmak için yukarıdaki bağlantıdan varsayılan sürümü tekrar yükleyin."
 
-#: src/olympia/addons/templates/addons/impala/details.html:272
+#: src/olympia/addons/templates/addons/impala/details.html:277
 msgid "<strong>Caution:</strong> Development versions of this add-on have not been reviewed by Mozilla."
 msgstr "<strong>Dikkat:</strong> Bu eklentinin geliştirme sürümleri henüz Mozilla tarafından incelenmedi."
 
-#: src/olympia/addons/templates/addons/impala/details.html:287
+#: src/olympia/addons/templates/addons/impala/details.html:292
 msgid "See complete development channel history"
 msgstr "Bütün gelişme kanalı geçmişini gör"
 
-#: src/olympia/addons/templates/addons/impala/details.html:306 src/olympia/addons/templates/addons/impala/details.html:315 src/olympia/addons/templates/addons/impala/details.html:327
+#: src/olympia/addons/templates/addons/impala/details.html:311 src/olympia/addons/templates/addons/impala/details.html:320 src/olympia/addons/templates/addons/impala/details.html:332
 #: src/olympia/addons/templates/addons/impala/review_add_box.html:4 src/olympia/stats/templates/stats/popup.html:2 src/olympia/stats/templates/stats/popup.html:8
-#: src/olympia/stats/templates/stats/stats.html:202 src/olympia/users/templates/users/profile.html:119
+#: src/olympia/stats/templates/stats/stats.html:204 src/olympia/users/templates/users/profile.html:119
 msgid "close"
 msgstr "kapat"
 
@@ -1130,6 +1145,7 @@ msgstr "{0} eklentisini gelecekte neler bekliyor?"
 msgid "About the Developer"
 msgid_plural "About the Developers"
 msgstr[0] "Geliştirici(ler) Hakkında"
+msgstr[1] ""
 
 #: src/olympia/addons/templates/addons/impala/developers.html:96 src/olympia/users/templates/users/edit.html:130 src/olympia/users/templates/users/profile.html:26
 msgid "No Photo"
@@ -1155,15 +1171,11 @@ msgstr "{addon} kaynak kodu lisansı"
 msgid "Source Code License"
 msgstr "Kaynak Kodu Lisansı"
 
-#: src/olympia/addons/templates/addons/impala/persona_grid.html:16 src/olympia/addons/templates/addons/impala/toplist.html:6
-msgid "{0} users"
-msgstr "{0} kullanıcı"
-
 #: src/olympia/addons/templates/addons/impala/review_list_box.html:19 src/olympia/reviews/templates/reviews/review.html:40
 msgid "permalink"
 msgstr "kalıcı bağlantı"
 
-#: src/olympia/addons/templates/addons/impala/review_list_box.html:23 src/olympia/editors/templates/editors/queue.html:98 src/olympia/reviews/templates/reviews/review.html:44
+#: src/olympia/addons/templates/addons/impala/review_list_box.html:23 src/olympia/editors/templates/editors/queue.html:104 src/olympia/reviews/templates/reviews/review.html:44
 msgid "translate"
 msgstr "çevir"
 
@@ -1172,6 +1184,7 @@ msgstr "çevir"
 msgid "See all user reviews"
 msgid_plural "See all %(cnt)s user reviews"
 msgstr[0] "Tüm kullanıcı incelemelerini gör"
+msgstr[1] ""
 
 #: src/olympia/addons/templates/addons/impala/review_list_box.html:47 src/olympia/reviews/templates/reviews/review_list.html:84
 msgid "This add-on has not yet been reviewed."
@@ -1180,6 +1193,10 @@ msgstr "Bu eklenti henüz incelenmemiş."
 #: src/olympia/addons/templates/addons/impala/review_list_box.html:50
 msgid "Be the first!"
 msgstr "İlk siz inceleyin!"
+
+#: src/olympia/addons/templates/addons/impala/toplist.html:6
+msgid "{0} users"
+msgstr "{0} kullanıcı"
 
 #: src/olympia/addons/templates/addons/impala/listing/sorter.html:14 src/olympia/devhub/templates/devhub/addons/listing/item_actions.html:49
 msgid "More"
@@ -1195,7 +1212,7 @@ msgstr "Koleksiyona ekle"
 msgid "My Add-ons"
 msgstr "Eklentilerim"
 
-#: src/olympia/addons/templates/addons/includes/dashboard_tabs.html:6 src/olympia/amo/context_processors.py:51
+#: src/olympia/addons/templates/addons/includes/dashboard_tabs.html:6 src/olympia/amo/context_processors.py:50
 msgid "My Themes"
 msgstr "Temalarım"
 
@@ -1238,6 +1255,7 @@ msgstr "Henüz puanlanmamış"
 msgid "<strong>{0}</strong> weekly download"
 msgid_plural "<strong>{0}</strong> weekly downloads"
 msgstr[0] "Haftada <strong>{0}</strong> indirme"
+msgstr[1] ""
 
 #: src/olympia/addons/templates/addons/mobile/details.html:32
 msgid "Read More"
@@ -1251,7 +1269,7 @@ msgstr "Kullanıcı"
 msgid "Weekly Downloads"
 msgstr "Haftalık İndirme"
 
-#: src/olympia/addons/templates/addons/mobile/details.html:99 src/olympia/compat/templates/compat/reporter_detail.html:46 src/olympia/devhub/forms.py:787
+#: src/olympia/addons/templates/addons/mobile/details.html:99 src/olympia/compat/templates/compat/reporter_detail.html:46 src/olympia/devhub/forms.py:788
 #: src/olympia/devhub/templates/devhub/versions/list.html:163
 msgid "Version"
 msgstr "Sürüm"
@@ -1338,7 +1356,7 @@ msgstr ""
 #: src/olympia/browse/templates/browse/personas/category_landing.html:21 src/olympia/browse/templates/browse/personas/category_landing.html:23
 #: src/olympia/browse/templates/browse/personas/category_landing.html:38 src/olympia/browse/templates/browse/personas/grid.html:7 src/olympia/browse/templates/browse/personas/grid.html:11
 #: src/olympia/browse/templates/browse/personas/mobile/base.html:7 src/olympia/browse/templates/browse/personas/mobile/category_landing.html:19 src/olympia/constants/base.py:180
-#: src/olympia/devhub/templates/devhub/personas/submit.html:13 src/olympia/editors/helpers.py:105 src/olympia/editors/templates/editors/base.html:26
+#: src/olympia/devhub/templates/devhub/personas/submit.html:13 src/olympia/editors/helpers.py:107 src/olympia/editors/templates/editors/base.html:26
 #: src/olympia/editors/templates/editors/performance.html:73 src/olympia/search/templates/search/personas.html:39 src/olympia/templates/menu_links.html:9
 msgid "Themes"
 msgstr "Temalar"
@@ -1364,7 +1382,7 @@ msgid "Highest Rated"
 msgstr "En Yüksek Puanlı"
 
 # 100%
-#: src/olympia/addons/templates/addons/mobile/home.html:74 src/olympia/amo/templates/amo/side_nav.html:5 src/olympia/amo/templates/amo/site_nav.html:27 src/olympia/amo/templates/amo/site_nav.html:57
+#: src/olympia/addons/templates/addons/mobile/home.html:74 src/olympia/amo/templates/amo/side_nav.html:5 src/olympia/amo/templates/amo/site_nav.html:27 src/olympia/amo/templates/amo/site_nav.html:55
 #: src/olympia/bandwagon/views.py:97 src/olympia/browse/views.py:57 src/olympia/browse/views.py:67 src/olympia/browse/templates/browse/personas/mobile/category_landing.html:65
 #: src/olympia/search/forms.py:15 src/olympia/search/forms.py:87
 msgid "Newest"
@@ -1378,90 +1396,90 @@ msgstr "Deneyin!"
 msgid "Theme Info &raquo;"
 msgstr "Tema Bilgisi &raquo;"
 
-#: src/olympia/amo/context_processors.py:39 src/olympia/devhub/templates/devhub/nav.html:43
+#: src/olympia/amo/context_processors.py:37 src/olympia/devhub/templates/devhub/nav.html:43
 msgid "Tools"
 msgstr "Araçlar"
 
-#: src/olympia/amo/context_processors.py:48 src/olympia/discovery/templates/discovery/pane_account.html:8 src/olympia/users/templates/users/includes/navigation.html:2
+#: src/olympia/amo/context_processors.py:47 src/olympia/discovery/templates/discovery/pane_account.html:8 src/olympia/users/templates/users/includes/navigation.html:2
 msgid "My Profile"
 msgstr "Profilim"
 
-#: src/olympia/amo/context_processors.py:54 src/olympia/users/templates/users/edit.html:5 src/olympia/users/templates/users/includes/navigation.html:3
+#: src/olympia/amo/context_processors.py:53 src/olympia/users/templates/users/edit.html:5 src/olympia/users/templates/users/includes/navigation.html:3
 msgid "Account Settings"
 msgstr "Hesap Ayarları"
 
-#: src/olympia/amo/context_processors.py:57 src/olympia/discovery/templates/discovery/pane_account.html:11 src/olympia/users/templates/users/profile.html:83
+#: src/olympia/amo/context_processors.py:56 src/olympia/discovery/templates/discovery/pane_account.html:11 src/olympia/users/templates/users/profile.html:83
 #: src/olympia/users/templates/users/includes/navigation.html:4
 msgid "My Collections"
 msgstr "Koleksiyonlarım"
 
-#: src/olympia/amo/context_processors.py:62 src/olympia/discovery/templates/discovery/pane_account.html:10 src/olympia/users/templates/users/includes/navigation.html:7
+#: src/olympia/amo/context_processors.py:61 src/olympia/discovery/templates/discovery/pane_account.html:10 src/olympia/users/templates/users/includes/navigation.html:7
 msgid "My Favorites"
 msgstr "Favorilerim"
 
-#: src/olympia/amo/context_processors.py:67 src/olympia/discovery/templates/discovery/pane_account.html:13 src/olympia/templates/impala/user_login.html:14
+#: src/olympia/amo/context_processors.py:66 src/olympia/discovery/templates/discovery/pane_account.html:13 src/olympia/templates/impala/user_login.html:14
 #: src/olympia/templates/mobile/header_auth.html:5
 msgid "Log out"
 msgstr "Çıkış yap"
 
-#: src/olympia/amo/context_processors.py:72 src/olympia/devhub/templates/devhub/addons/dashboard.html:4
+#: src/olympia/amo/context_processors.py:71 src/olympia/devhub/templates/devhub/addons/dashboard.html:4
 msgid "Manage My Submissions"
 msgstr "Başvurularımı Yönet"
 
-#: src/olympia/amo/context_processors.py:75 src/olympia/devhub/templates/devhub/nav.html:27 src/olympia/devhub/templates/devhub/addons/dashboard.html:25
+#: src/olympia/amo/context_processors.py:74 src/olympia/devhub/templates/devhub/nav.html:27 src/olympia/devhub/templates/devhub/addons/dashboard.html:25
 #: src/olympia/devhub/templates/devhub/addons/submit/base.html:4
 msgid "Submit a New Add-on"
 msgstr "Yeni Eklenti Gönder"
 
-#: src/olympia/amo/context_processors.py:77 src/olympia/browse/templates/browse/personas/base.html:50 src/olympia/devhub/templates/devhub/index.html:24
+#: src/olympia/amo/context_processors.py:76 src/olympia/browse/templates/browse/personas/base.html:50 src/olympia/devhub/templates/devhub/index.html:24
 #: src/olympia/devhub/templates/devhub/addons/dashboard.html:29
 msgid "Submit a New Theme"
 msgstr "Yeni Tema Gönder"
 
-#: src/olympia/amo/context_processors.py:79 src/olympia/amo/templates/amo/site_nav.html:87 src/olympia/devhub/helpers.py:36 src/olympia/devhub/helpers.py:68 src/olympia/devhub/helpers.py:102
+#: src/olympia/amo/context_processors.py:78 src/olympia/amo/templates/amo/site_nav.html:85 src/olympia/devhub/helpers.py:36 src/olympia/devhub/helpers.py:68 src/olympia/devhub/helpers.py:102
 #: src/olympia/templates/footer.html:6 src/olympia/templates/menu_links.html:14
 msgid "Developer Hub"
 msgstr "Geliştirici Merkezi"
 
-#: src/olympia/amo/context_processors.py:83 src/olympia/devhub/views.py:1792
+#: src/olympia/amo/context_processors.py:81 src/olympia/devhub/views.py:1796
 msgid "Manage API Keys"
 msgstr "API Anahtarlarını Yönet"
 
-#: src/olympia/amo/context_processors.py:88 src/olympia/editors/helpers.py:82 src/olympia/editors/helpers.py:102 src/olympia/editors/templates/editors/base.html:10
+#: src/olympia/amo/context_processors.py:86 src/olympia/editors/helpers.py:84 src/olympia/editors/helpers.py:104 src/olympia/editors/templates/editors/base.html:10
 msgid "Editor Tools"
 msgstr "Editör Araçları"
 
-#: src/olympia/amo/context_processors.py:92
+#: src/olympia/amo/context_processors.py:90
 msgid "Admin Tools"
 msgstr "Yönetici Araçları"
 
-#: src/olympia/amo/fields.py:15
+#: src/olympia/amo/fields.py:20
 msgid "Incorrect, please try again."
 msgstr "Hatalı, lütfen tekrar deneyiniz."
 
-#: src/olympia/amo/fields.py:16
+#: src/olympia/amo/fields.py:21
 msgid "Error verifying input, please try again."
 msgstr "Girdi doğrulanmasında hata oluştu, lütfen tekrar deneyiniz."
 
-#: src/olympia/amo/fields.py:32
+#: src/olympia/amo/fields.py:37
 msgid "This must be a valid hex color code, such as #000000."
 msgstr "Geçerli bir hex renk kodu (örn. #000000) girmelisiniz."
 
-#: src/olympia/amo/fields.py:58
+#: src/olympia/amo/fields.py:63
 msgid "Enter at least one value."
 msgstr "En az bir değer girin."
 
-#: src/olympia/amo/helpers.py:162 src/olympia/amo/templates/amo/site_nav.html:61 src/olympia/bandwagon/templates/bandwagon/add.html:9
+#: src/olympia/amo/helpers.py:162 src/olympia/amo/templates/amo/site_nav.html:59 src/olympia/bandwagon/templates/bandwagon/add.html:9
 #: src/olympia/bandwagon/templates/bandwagon/collection_detail.html:15 src/olympia/bandwagon/templates/bandwagon/delete.html:9 src/olympia/bandwagon/templates/bandwagon/edit.html:15
 #: src/olympia/bandwagon/templates/bandwagon/user_listing.html:18 src/olympia/bandwagon/templates/bandwagon/user_listing.html:21
 #: src/olympia/bandwagon/templates/bandwagon/impala/collection_listing.html:12 src/olympia/bandwagon/templates/bandwagon/impala/collection_listing.html:20
 #: src/olympia/bandwagon/templates/bandwagon/impala/collection_listing.html:24 src/olympia/bandwagon/templates/bandwagon/impala/collection_sidebar.html:3
 #: src/olympia/bandwagon/templates/bandwagon/includes/collection_sidebar.html:2 src/olympia/bandwagon/templates/bandwagon/mobile/collection_listing.html:3
-#: src/olympia/stats/templates/stats/stats.html:77 src/olympia/templates/menu_links.html:12
+#: src/olympia/stats/templates/stats/stats.html:33 src/olympia/templates/menu_links.html:12
 msgid "Collections"
 msgstr "Koleksiyonlar"
 
-#: src/olympia/amo/helpers.py:171 src/olympia/amo/templates/amo/site_nav.html:85 src/olympia/browse/templates/browse/language_tools.html:3
+#: src/olympia/amo/helpers.py:171 src/olympia/amo/templates/amo/site_nav.html:83 src/olympia/browse/templates/browse/language_tools.html:3
 msgid "Dictionaries & Language Packs"
 msgstr "Sözlükler & Dil Paketleri"
 
@@ -1615,8 +1633,8 @@ msgstr "{addon} {version} için yorum yapın."
 
 # 87%
 # 100%
-#: src/olympia/amo/log.py:236 src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:19 src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:47
-#: src/olympia/editors/helpers.py:511 src/olympia/editors/templates/editors/themes/history_table.html:11
+#: src/olympia/amo/log.py:236 src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:17 src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:45
+#: src/olympia/editors/helpers.py:584 src/olympia/editors/templates/editors/themes/history_table.html:11
 msgid "Comment"
 msgstr "Yorum"
 
@@ -1921,9 +1939,8 @@ msgstr "Hata"
 
 #: src/olympia/amo/templates/amo/500.html:6
 #, python-format
-msgid "<h1>Oops! We had an error.</h1> <p>We'll get to fixing that soon.</p> <p> You can try refreshing the page, or head back to the <a href=\"%(home)s\">Add-ons homepage</a>. </p>"
+msgid "<h1>Oops!  We had an error.</h1> <p>We'll get to fixing that soon.</p> <p> You can try refreshing the page, or head back to the <a href=\"%(home)s\">Add-ons homepage</a>. </p>"
 msgstr ""
-"<h1>Tüh! Bir hata oluştu.</h1> <p>Bunu en kısa sürede gidermeye çalışacağız.</p> <p>Sayfayı tazelemeyi deneyebilir veya <a href=\"%(home)s\">Eklentiler ana sayfasına</a> geri dönebilirsiniz.</p>"
 
 #: src/olympia/amo/templates/amo/license_link.html:10
 msgid "Some rights reserved"
@@ -1945,7 +1962,7 @@ msgstr "Önceki"
 #: src/olympia/amo/templates/amo/mobile/paginator.html:14 src/olympia/amo/templates/amo/mobile/paginator.html:16 src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:51
 #: src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:65 src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:78
 #: src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:91 src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:104
-#: src/olympia/discovery/templates/discovery/pane.html:45 src/olympia/discovery/templates/discovery/addons/detail.html:39 src/olympia/stats/templates/stats/stats.html:167
+#: src/olympia/discovery/templates/discovery/pane.html:45 src/olympia/discovery/templates/discovery/addons/detail.html:39 src/olympia/stats/templates/stats/stats.html:169
 msgid "Next"
 msgstr "Sonraki"
 
@@ -1977,7 +1994,7 @@ msgid ""
 msgstr ""
 
 #: src/olympia/amo/templates/amo/side_nav.html:4 src/olympia/amo/templates/amo/side_nav.html:12 src/olympia/amo/templates/amo/site_nav.html:4 src/olympia/amo/templates/amo/site_nav.html:26
-#: src/olympia/browse/views.py:56 src/olympia/browse/views.py:66 src/olympia/browse/views.py:237 src/olympia/browse/views.py:282 src/olympia/search/forms.py:86
+#: src/olympia/browse/views.py:56 src/olympia/browse/views.py:66 src/olympia/browse/views.py:204 src/olympia/browse/views.py:249 src/olympia/search/forms.py:86
 msgid "Top Rated"
 msgstr "Yüksek Puanlılar"
 
@@ -1992,38 +2009,38 @@ msgstr "Keşfedin"
 msgid "Extensions"
 msgstr "Uzantılar"
 
-#: src/olympia/amo/templates/amo/site_nav.html:45
+#: src/olympia/amo/templates/amo/site_nav.html:44
 msgid "Want more customization? Try <b>Complete Themes</b>"
 msgstr ""
 
-#: src/olympia/amo/templates/amo/site_nav.html:56 src/olympia/bandwagon/views.py:96
+#: src/olympia/amo/templates/amo/site_nav.html:54 src/olympia/bandwagon/views.py:96
 msgid "Most Followers"
 msgstr "En çok takip edilenler"
 
-#: src/olympia/amo/templates/amo/site_nav.html:68 src/olympia/bandwagon/templates/bandwagon/impala/collection_sidebar.html:16
+#: src/olympia/amo/templates/amo/site_nav.html:66 src/olympia/bandwagon/templates/bandwagon/impala/collection_sidebar.html:16
 #: src/olympia/bandwagon/templates/bandwagon/includes/collection_sidebar.html:18
 msgid "Collections I've Made"
 msgstr "Oluşturduğum Koleksiyonlar"
 
-#: src/olympia/amo/templates/amo/site_nav.html:70 src/olympia/bandwagon/templates/bandwagon/user_listing.html:4 src/olympia/bandwagon/templates/bandwagon/impala/collection_sidebar.html:13
+#: src/olympia/amo/templates/amo/site_nav.html:68 src/olympia/bandwagon/templates/bandwagon/user_listing.html:4 src/olympia/bandwagon/templates/bandwagon/impala/collection_sidebar.html:13
 #: src/olympia/bandwagon/templates/bandwagon/includes/collection_sidebar.html:15
 msgid "Collections I'm Following"
 msgstr "İzlediğim Koleksiyonlar"
 
-#: src/olympia/amo/templates/amo/site_nav.html:73 src/olympia/bandwagon/templates/bandwagon/impala/collection_sidebar.html:18
-#: src/olympia/bandwagon/templates/bandwagon/includes/collection_sidebar.html:20 src/olympia/users/models.py:512
+#: src/olympia/amo/templates/amo/site_nav.html:71 src/olympia/bandwagon/templates/bandwagon/impala/collection_sidebar.html:18
+#: src/olympia/bandwagon/templates/bandwagon/includes/collection_sidebar.html:20 src/olympia/users/models.py:521
 msgid "My Favorite Add-ons"
 msgstr "Favori Eklentilerim"
 
-#: src/olympia/amo/templates/amo/site_nav.html:78
+#: src/olympia/amo/templates/amo/site_nav.html:76
 msgid "More&hellip;"
 msgstr "Daha fazlası&hellip;"
 
-#: src/olympia/amo/templates/amo/site_nav.html:82
+#: src/olympia/amo/templates/amo/site_nav.html:80
 msgid "Add-ons for Mobile"
 msgstr "Mobil Eklentiler"
 
-#: src/olympia/amo/templates/amo/site_nav.html:86 src/olympia/browse/feeds.py:207 src/olympia/browse/templates/browse/search_tools.html:3 src/olympia/constants/base.py:176
+#: src/olympia/amo/templates/amo/site_nav.html:84 src/olympia/browse/feeds.py:207 src/olympia/browse/templates/browse/search_tools.html:3 src/olympia/constants/base.py:176
 #: src/olympia/templates/menu_links.html:10
 msgid "Search Tools"
 msgstr "Arama Araçları"
@@ -2039,7 +2056,7 @@ msgid "Jump to first page"
 msgstr "İlk sayfaya git"
 
 #: src/olympia/amo/templates/amo/impala/paginator.html:22 src/olympia/amo/templates/amo/mobile/impala_paginator.html:12 src/olympia/discovery/templates/discovery/pane.html:44
-#: src/olympia/discovery/templates/discovery/addons/detail.html:38 src/olympia/stats/templates/stats/stats.html:164
+#: src/olympia/discovery/templates/discovery/addons/detail.html:38 src/olympia/stats/templates/stats/stats.html:166
 msgid "Previous"
 msgstr "Önceki"
 
@@ -2060,32 +2077,52 @@ msgstr "<b>%(count)s</b> sonuçtan <b>%(begin)s</b>&ndash;<b>%(end)s</b> arasın
 msgid "Page {n}"
 msgid_plural "Page {n}"
 msgstr[0] "Sayfa {n}"
+msgstr[1] ""
 
-#: src/olympia/amo/templates/services/install.html:38
-#, python-format
-msgid "If you are not prompted to install %(addon_name)s in a moment, please <a href=\"%(addon_xpi)s\">click here</a>."
-msgstr ""
-
-#: src/olympia/amo/tests/test_messages.py:57 src/olympia/amo/tests/test_messages.py:58 src/olympia/reviews/forms.py:25 src/olympia/reviews/forms.py:50 src/olympia/reviews/templates/reviews/add.html:56
+#: src/olympia/amo/tests/test_messages.py:56 src/olympia/amo/tests/test_messages.py:57 src/olympia/reviews/forms.py:25 src/olympia/reviews/forms.py:50 src/olympia/reviews/templates/reviews/add.html:56
 #: src/olympia/reviews/templates/reviews/reply.html:30
 msgid "Title"
 msgstr "Başlık"
 
-#: src/olympia/amo/tests/test_messages.py:57 src/olympia/amo/tests/test_messages.py:58
+#: src/olympia/amo/tests/test_messages.py:56 src/olympia/amo/tests/test_messages.py:57
 msgid "Body"
 msgstr "Gövde"
 
-#: src/olympia/amo/tests/test_messages.py:59
+#: src/olympia/amo/tests/test_messages.py:58
 msgid "Another Title"
 msgstr "Başka Başlık"
 
-#: src/olympia/amo/tests/test_messages.py:59
+#: src/olympia/amo/tests/test_messages.py:58
 msgid "Another Body"
 msgstr "Başka Gövde"
 
-#: src/olympia/api/views.py:255
-msgid "Not implemented yet."
-msgstr "Henüz hazır değil."
+#: src/olympia/api/authentication.py:76
+msgid "Signature has expired."
+msgstr ""
+
+#: src/olympia/api/authentication.py:79
+msgid "Error decoding signature."
+msgstr ""
+
+#: src/olympia/api/authentication.py:82
+msgid "Invalid JWT Token."
+msgstr ""
+
+#: src/olympia/api/authentication.py:130
+msgid "Invalid Authorization header. No credentials provided."
+msgstr ""
+
+#: src/olympia/api/authentication.py:133
+msgid "Invalid Authorization header. Credentials string should not contain spaces."
+msgstr ""
+
+#: src/olympia/api/fields.py:29
+msgid "The field must have a length of at least {num} characters."
+msgstr ""
+
+#: src/olympia/api/fields.py:31
+msgid "The language code {lang_code} is invalid."
+msgstr ""
 
 #: src/olympia/applications/views.py:39 src/olympia/applications/templates/applications/appversions.html:3
 msgid "Application Versions"
@@ -2103,7 +2140,7 @@ msgstr "Geçerli Uygulama Sürümleri"
 msgid "Add-ons submitted to Mozilla Add-ons must have a manifest file with at least one of the below applications supported. Only the versions listed below are allowed for these applications."
 msgstr ""
 
-#: src/olympia/applications/templates/applications/appversions.html:25
+#: src/olympia/applications/templates/applications/appversions.html:25 src/olympia/editors/helpers.py:361
 msgid "GUID"
 msgstr "GUID"
 
@@ -2221,8 +2258,8 @@ msgstr "Favori"
 msgid "Remove from favorites"
 msgstr "Favorilerden kaldır"
 
-#: src/olympia/bandwagon/views.py:98 src/olympia/bandwagon/views.py:191 src/olympia/browse/views.py:58 src/olympia/browse/views.py:69 src/olympia/browse/views.py:458 src/olympia/devhub/views.py:74
-#: src/olympia/devhub/views.py:82 src/olympia/devhub/templates/devhub/addons/edit/basic.html:20 src/olympia/editors/templates/editors/leaderboard.html:24
+#: src/olympia/bandwagon/views.py:98 src/olympia/bandwagon/views.py:191 src/olympia/browse/views.py:58 src/olympia/browse/views.py:69 src/olympia/browse/views.py:425 src/olympia/devhub/views.py:72
+#: src/olympia/devhub/views.py:80 src/olympia/devhub/templates/devhub/addons/edit/basic.html:20 src/olympia/editors/templates/editors/leaderboard.html:24
 #: src/olympia/editors/templates/editors/themes/queue_list.html:48 src/olympia/search/forms.py:17 src/olympia/search/forms.py:89 src/olympia/users/templates/users/vcard.html:5
 msgid "Name"
 msgstr "İsim"
@@ -2231,7 +2268,7 @@ msgstr "İsim"
 msgid "Recently Popular"
 msgstr "Yeni Popüler Olan"
 
-#: src/olympia/bandwagon/views.py:189 src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:18
+#: src/olympia/bandwagon/views.py:189 src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:16
 msgid "Added"
 msgstr "Eklendi"
 
@@ -2246,7 +2283,7 @@ msgstr "Koleksiyon oluşturuldu!"
 
 #: src/olympia/bandwagon/views.py:316
 #, python-format
-msgid "Your new collection is shown below. You can <ahref=\"%(url)s\">edit additional settings</a> if you'dlike."
+msgid "Your new collection is shown below. You can <a href=\"%(url)s\">edit additional settings</a> if you'd like."
 msgstr ""
 
 #: src/olympia/bandwagon/views.py:322
@@ -2335,6 +2372,7 @@ msgstr "özel"
 msgid "<span>%(num)s</span> follower"
 msgid_plural "<span>%(num)s</span> followers"
 msgstr[0] "<span>%(num)s</span> takipçi"
+msgstr[1] ""
 
 # 76%
 # 100%
@@ -2379,16 +2417,18 @@ msgstr "Koleksiyonu Sil"
 msgid "%(num)s Theme in this Collection"
 msgid_plural "%(num)s Themes in this Collection"
 msgstr[0] ""
+msgstr[1] ""
 
 #: src/olympia/bandwagon/templates/bandwagon/collection_detail.html:111
 #, python-format
 msgid "%(num)s Add-on in this Collection"
 msgid_plural "%(num)s Add-ons in this Collection"
 msgstr[0] "Bu koleksiyonda %(num)s eklenti var"
+msgstr[1] ""
 
 # 100%
-#: src/olympia/bandwagon/templates/bandwagon/collection_detail.html:125 src/olympia/compat/templates/compat/index.html:25 src/olympia/compat/templates/compat/reporter_detail.html:29
-#: src/olympia/files/templates/files/viewer.html:29 src/olympia/templates/amo_footer.html:17 src/olympia/templates/includes/lang_switcher.html:10
+#: src/olympia/bandwagon/templates/bandwagon/collection_detail.html:125 src/olympia/compat/templates/compat/reporter_detail.html:29 src/olympia/files/templates/files/viewer.html:29
+#: src/olympia/templates/amo_footer.html:17 src/olympia/templates/includes/lang_switcher.html:10
 msgid "Go"
 msgstr "Git"
 
@@ -2433,12 +2473,14 @@ msgstr "En beğendiğim eklentiler"
 msgid "<span>%(addons)s</span> add-on"
 msgid_plural "<span>%(addons)s</span> add-ons"
 msgstr[0] "<span>%(addons)s</span> eklenti"
+msgstr[1] ""
 
 #: src/olympia/bandwagon/templates/bandwagon/collection_grid.html:32
 #, python-format
 msgid "<span>%(followers)s</span> follower"
 msgid_plural "<span>%(followers)s</span> followers"
 msgstr[0] "<span>%(followers)s</span> takipçi"
+msgstr[1] ""
 
 #. People "follow" collections to get notified of updates.                    Like
 #. Twitter followers.
@@ -2449,6 +2491,7 @@ msgstr[0] "<span>%(followers)s</span> takipçi"
 msgid "%(num)s weekly follower"
 msgid_plural "%(num)s weekly followers"
 msgstr[0] "%(num)s haftalık takipçi"
+msgstr[1] ""
 
 #. People "follow" collections to get notified of updates.                    Like
 #. Twitter followers.
@@ -2457,6 +2500,7 @@ msgstr[0] "%(num)s haftalık takipçi"
 msgid "%(num)s monthly follower"
 msgid_plural "%(num)s monthly followers"
 msgstr[0] ""
+msgstr[1] ""
 
 #. People "follow" collections to get notified of updates.                    Like
 #. Twitter followers.
@@ -2467,6 +2511,7 @@ msgstr[0] ""
 msgid "%(num)s follower"
 msgid_plural "%(num)s followers"
 msgstr[0] "%(num)s takipçi"
+msgstr[1] ""
 
 #: src/olympia/bandwagon/templates/bandwagon/collection_listing_items.html:56 src/olympia/bandwagon/templates/bandwagon/impala/collection_listing_items.html:9
 #: src/olympia/devhub/templates/devhub/personas/edit.html:27
@@ -2553,7 +2598,7 @@ msgid "Remove this user as a contributor"
 msgstr "Bu kullanıcıyı katkıda bulunanlardan çıkar"
 
 #: src/olympia/bandwagon/templates/bandwagon/edit_contributors.html:18 src/olympia/bandwagon/templates/bandwagon/edit_contributors.html:43
-#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:20 src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:48
+#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:18 src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:46
 #: src/olympia/devhub/templates/devhub/addons/ajax_compat_update.html:19
 msgid "Remove"
 msgstr "Çıkar"
@@ -2564,11 +2609,9 @@ msgstr "Koleksiyona Katkıda Bulunanlar"
 
 #: src/olympia/bandwagon/templates/bandwagon/edit_contributors.html:26
 msgid ""
-"You can add multiple contributors to this collection. A contributor can add and remove add-ons from this collection, but cannot change its name or description. To add a contributor, enter their "
+"You can add multiple contributors to this collection.  A contributor can add and remove add-ons from this collection, but cannot change its name or description.  To add a contributor, enter their "
 "email in the box below. Contributors must have a Mozilla Add-ons account."
 msgstr ""
-"Bu koleksiyona birden fazla katkıcı ekleyebilirsinsiniz. Bir katkıcı bu koleksiyona eklenti ekleyebilir ve kaldırabilir, fakat koleksiyon ismini ve açıklamasını değiştiremez. Katkıcı eklemek için "
-"aşağıya e-posta adresini yazın. Katkıcılar Mozilla Eklentiler hesabına sahip olmalıdır."
 
 #: src/olympia/bandwagon/templates/bandwagon/edit_contributors.html:40
 msgid "User"
@@ -2606,7 +2649,7 @@ msgid "<b>Warning:</b> By changing the owner of this collection, you will no lon
 msgstr ""
 
 #: src/olympia/bandwagon/templates/bandwagon/edit_contributors.html:83 src/olympia/devhub/templates/devhub/addons/forms_shared/media.html:157
-#: src/olympia/devhub/templates/devhub/addons/submit/describe.html:69 src/olympia/devhub/templates/devhub/addons/submit/license.html:60 src/olympia/devhub/templates/devhub/addons/submit/upload.html:78
+#: src/olympia/devhub/templates/devhub/addons/submit/describe.html:69 src/olympia/devhub/templates/devhub/addons/submit/license.html:60 src/olympia/devhub/templates/devhub/addons/submit/upload.html:70
 #: src/olympia/devhub/templates/devhub/payments/tier.html:17 src/olympia/editors/templates/editors/themes/themes.html:111 src/olympia/editors/templates/editors/themes/themes.html:128
 #: src/olympia/editors/templates/editors/themes/themes.html:134 src/olympia/editors/templates/editors/themes/themes.html:141 src/olympia/users/templates/users/fxa_migration_prompt_content.html:10
 #: src/olympia/users/templates/users/login_form.html:42 src/olympia/users/templates/users/mobile/login.html:57
@@ -2680,43 +2723,43 @@ msgid "Reset"
 msgstr "Sıfırla"
 
 #: src/olympia/bandwagon/templates/bandwagon/includes/addedit.html:53
-msgid "PNG and JPG supported. Image will be resized to 32x32."
-msgstr "PNG ve JPG destekleniyor. Resim boyutu 32x32'ye boyutlandırılacak."
+msgid "PNG and JPG supported.  Image will be resized to 32x32."
+msgstr ""
 
 #: src/olympia/bandwagon/templates/bandwagon/includes/addedit_errors.html:3
-msgid "There are errors in this form. Please correct them below."
-msgstr "Formda bazı hatalar var. Lütfen aşağıdakileri düzeltin."
+msgid "There are errors in this form.  Please correct them below."
+msgstr ""
 
 #: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:2
 msgid "Add-ons in Your Collection"
 msgstr "Koleksiyonunuzdaki Eklentiler"
 
 #: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:4
-msgid ""
-"To include an add-on in this collection, enter its name in the box below and hit enter.  You can also use the <strong>Add to Collection</strong> links throughout the site to include add-ons later."
+msgid "To include an add-on in this collection, enter its name in the box below and hit enter."
 msgstr ""
 
-#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:17 src/olympia/constants/base.py:400 src/olympia/devhub/templates/devhub/addons/activity.html:62
+#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:15 src/olympia/constants/base.py:400 src/olympia/devhub/templates/devhub/addons/activity.html:62
+#: src/olympia/editors/helpers.py:273 src/olympia/editors/helpers.py:360
 msgid "Add-on"
 msgstr "Eklenti"
 
-#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:26
+#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:24
 msgid "Enter the name of the add-on to include"
 msgstr ""
 
-#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:28
+#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:26
 msgid "Add to Collection"
 msgstr "Koleksiyona Ekle"
 
-#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:45 src/olympia/editors/helpers.py:936 src/olympia/editors/helpers.py:956
+#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:43 src/olympia/editors/helpers.py:1016 src/olympia/editors/helpers.py:1036
 msgid "Pending"
 msgstr "Beklemede"
 
-#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:47
+#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:45
 msgid "Add a comment"
 msgstr "Yorum ekleyin"
 
-#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:48
+#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:46
 msgid "Remove this add-on from the collection"
 msgstr "Koleksiyondan eklentiyi kaldır"
 
@@ -2823,12 +2866,12 @@ msgstr "Arama araçları"
 msgid "Most Users"
 msgstr "Çoğu Kullanıcı"
 
-#: src/olympia/browse/views.py:61 src/olympia/browse/views.py:72 src/olympia/browse/views.py:279 src/olympia/browse/templates/browse/personas/mobile/category_landing.html:63
+#: src/olympia/browse/views.py:61 src/olympia/browse/views.py:72 src/olympia/browse/views.py:246 src/olympia/browse/templates/browse/personas/mobile/category_landing.html:63
 #: src/olympia/discovery/templates/discovery/pane.html:67 src/olympia/search/forms.py:92
 msgid "Up & Coming"
 msgstr "Yükselişte"
 
-#: src/olympia/browse/views.py:460 src/olympia/devhub/views.py:76 src/olympia/devhub/views.py:83 src/olympia/discovery/templates/discovery/addons/detail.html:66
+#: src/olympia/browse/views.py:427 src/olympia/devhub/views.py:74 src/olympia/devhub/views.py:81 src/olympia/discovery/templates/discovery/addons/detail.html:66
 msgid "Created"
 msgstr "Oluşturma"
 
@@ -2911,6 +2954,7 @@ msgstr "{0} :: Arama Araçları"
 msgid "<b>{0}</b> add-on"
 msgid_plural "<b>{0}</b> add-ons"
 msgstr[0] "<b>{0}</b> eklenti"
+msgstr[1] ""
 
 #: src/olympia/browse/templates/browse/search_tools.html:61
 msgid "Search Extensions"
@@ -3016,9 +3060,10 @@ msgstr ""
 msgid "See the %(cnt)s extension in %(name)s &raquo;"
 msgid_plural "See all %(cnt)s extensions in %(name)s &raquo;"
 msgstr[0] ""
+msgstr[1] ""
 
-#: src/olympia/browse/templates/browse/mobile/extensions.html:13 src/olympia/compat/templates/compat/index.html:82 src/olympia/devhub/templates/devhub/devhub_search.html:24
-#: src/olympia/devhub/templates/devhub/addons/activity.html:47 src/olympia/search/templates/search/no_results.html:4 src/olympia/search/templates/search/mobile/results.html:36
+#: src/olympia/browse/templates/browse/mobile/extensions.html:13 src/olympia/devhub/templates/devhub/devhub_search.html:24 src/olympia/devhub/templates/devhub/addons/activity.html:47
+#: src/olympia/search/templates/search/no_results.html:4 src/olympia/search/templates/search/mobile/results.html:36
 msgid "No results found."
 msgstr "Sonuç bulunamadı."
 
@@ -3103,7 +3148,7 @@ msgstr "&laquo; Tüm Temalar"
 msgid "All"
 msgstr "Tümü"
 
-#: src/olympia/compat/forms.py:22 src/olympia/search/views.py:525
+#: src/olympia/compat/forms.py:22 src/olympia/editors/templates/editors/base.html:69 src/olympia/search/views.py:518
 msgid "All Add-ons"
 msgstr "Tüm Eklentiler"
 
@@ -3114,53 +3159,6 @@ msgstr "İkili"
 #: src/olympia/compat/forms.py:24
 msgid "Non-binary"
 msgstr "İkili olmayan"
-
-#. Review points sources other than add-ons and themes.
-#: src/olympia/compat/views.py:87 src/olympia/constants/base.py:388 src/olympia/devhub/forms.py:162 src/olympia/editors/templates/editors/performance.html:75
-msgid "Other"
-msgstr "Diğer"
-
-#: src/olympia/compat/templates/compat/index.html:4
-msgid "Add-on Compatibility Report for {app} {version}"
-msgstr "{app} {version} için Eklenti Uyumluluk Raporu"
-
-#: src/olympia/compat/templates/compat/index.html:11
-msgid "{app} {version} Compatibility"
-msgstr "{app} {version} Uyumluluğu"
-
-#: src/olympia/compat/templates/compat/index.html:17
-#, python-format
-msgid "Top 95%% compatible with previous version"
-msgstr ""
-
-#: src/olympia/compat/templates/compat/index.html:18
-#, python-format
-msgid "Top 95%% of all add-ons"
-msgstr ""
-
-#: src/olympia/compat/templates/compat/index.html:19
-msgid "All active add-ons"
-msgstr "Tüm aktif eklentiler"
-
-#: src/olympia/compat/templates/compat/index.html:23 src/olympia/constants/base.py:401
-msgid "App"
-msgstr "Uygulama"
-
-#: src/olympia/compat/templates/compat/index.html:55
-msgid "Details for add-ons compatible with previous version:"
-msgstr "Önceki sürümle uyumlu eklentiler için ayrıntılar:"
-
-#: src/olympia/compat/templates/compat/index.html:57
-msgid "Show all versions"
-msgstr "Tüm sürümleri göster"
-
-#: src/olympia/compat/templates/compat/index.html:59
-msgid "Details for add-ons compatible with all versions:"
-msgstr "Tüm sürümlerle uyumlu eklenti ayrıntıları:"
-
-#: src/olympia/compat/templates/compat/index.html:61
-msgid "Show previous version only"
-msgstr "Sadece önceki sürümleri göster"
 
 #: src/olympia/compat/templates/compat/reporter.html:3
 msgid "Add-on Compatibility Reports"
@@ -3195,11 +3193,13 @@ msgstr "{addon} Uyumluluk Raporları"
 msgid "{0} success report"
 msgid_plural "{0} success reports"
 msgstr[0] "{0} başarı raporu"
+msgstr[1] ""
 
 #: src/olympia/compat/templates/compat/reporter_detail.html:17
 msgid "{0} problem report"
 msgid_plural "{0} problem reports"
 msgstr[0] "{0} sorun raporu"
+msgstr[1] ""
 
 #: src/olympia/compat/templates/compat/reporter_detail.html:21 src/olympia/users/templates/users/profile.html:70
 msgid "View all"
@@ -3215,8 +3215,8 @@ msgstr "Rapor Türü"
 
 # 84%
 # 100%
-#: src/olympia/compat/templates/compat/reporter_detail.html:47 src/olympia/devhub/forms.py:784 src/olympia/devhub/templates/devhub/addons/ajax_compat_update.html:17 src/olympia/editors/forms.py:108
-#: src/olympia/zadmin/forms.py:45
+#: src/olympia/compat/templates/compat/reporter_detail.html:47 src/olympia/devhub/forms.py:785 src/olympia/devhub/templates/devhub/addons/ajax_compat_update.html:17 src/olympia/editors/forms.py:108
+#: src/olympia/editors/forms.py:248 src/olympia/zadmin/forms.py:45
 msgid "Application"
 msgstr "Uygulama"
 
@@ -3306,7 +3306,8 @@ msgstr "Ön incelemeden geçti"
 msgid "Preliminarily Reviewed and Awaiting Full Review"
 msgstr ""
 
-#: src/olympia/constants/base.py:33 src/olympia/editors/helpers.py:924 src/olympia/editors/templates/editors/themes/history_table.html:34
+#: src/olympia/constants/base.py:33 src/olympia/editors/forms.py:258 src/olympia/editors/helpers.py:73 src/olympia/editors/helpers.py:1004
+#: src/olympia/editors/templates/editors/themes/history_table.html:34
 msgid "Deleted"
 msgstr "Silindi"
 
@@ -3408,6 +3409,11 @@ msgstr "Kullanıcılar bu eklentiyi indirmeye başladıktan sonra sor"
 msgid "Ask before users can download this add-on"
 msgstr "Kullanıcılar bu eklentiyi indirmeden önce sor"
 
+#. Review points sources other than add-ons and themes.
+#: src/olympia/constants/base.py:388 src/olympia/devhub/forms.py:162 src/olympia/editors/templates/editors/performance.html:75
+msgid "Other"
+msgstr "Diğer"
+
 #: src/olympia/constants/base.py:389
 msgid "Exception"
 msgstr "İstisna"
@@ -3419,6 +3425,10 @@ msgstr "Yayımla"
 #: src/olympia/constants/base.py:391
 msgid "Change"
 msgstr "Değiştir"
+
+#: src/olympia/constants/base.py:401
+msgid "App"
+msgstr "Uygulama"
 
 #: src/olympia/constants/base.py:402
 msgid "Persona"
@@ -3568,7 +3578,7 @@ msgstr "İşaretle"
 msgid "Duplicate"
 msgstr "Kopyala"
 
-#: src/olympia/constants/editors.py:17 src/olympia/editors/helpers.py:502 src/olympia/editors/templates/editors/themes/queue.html:71 src/olympia/editors/templates/editors/themes/themes.html:94
+#: src/olympia/constants/editors.py:17 src/olympia/editors/helpers.py:575 src/olympia/editors/templates/editors/themes/queue.html:71 src/olympia/editors/templates/editors/themes/themes.html:94
 msgid "Reject"
 msgstr "Geri Çevir"
 
@@ -3668,7 +3678,7 @@ msgstr "Solaris"
 msgid "Android"
 msgstr "Android"
 
-#: src/olympia/core/apps.py:19
+#: src/olympia/core/apps.py:21
 msgid "Core"
 msgstr ""
 
@@ -3802,7 +3812,7 @@ msgid "Submit my add-on for manual review."
 msgstr ""
 
 #: src/olympia/devhub/forms.py:537
-msgid "Do not list my add-on on this site (beta)"
+msgid "Do not list my add-on on this site"
 msgstr ""
 
 #: src/olympia/devhub/forms.py:538
@@ -3835,46 +3845,46 @@ msgstr ""
 
 #: src/olympia/devhub/forms.py:592
 #, python-format
-msgid "Version %s already exists"
-msgstr "%s sürümü zaten mevcut"
+msgid "Version %s already exists, or was uploaded before."
+msgstr ""
 
-#: src/olympia/devhub/forms.py:604
+#: src/olympia/devhub/forms.py:605
 msgid "Select a valid choice. That choice is not one of the available choices."
 msgstr ""
 
-#: src/olympia/devhub/forms.py:610
+#: src/olympia/devhub/forms.py:611
 msgid "A file with a version ending with a|alpha|b|beta and an optional number is detected as beta."
 msgstr ""
 
-#: src/olympia/devhub/forms.py:633
+#: src/olympia/devhub/forms.py:634
 msgid "You cannot upload any more files for this version."
 msgstr "Bu sürüm için daha fazla dosya yükleyemezsiniz."
 
-#: src/olympia/devhub/forms.py:639
+#: src/olympia/devhub/forms.py:640
 msgid "Version doesn't match"
 msgstr "Sürüm eşleşmiyor"
 
-#: src/olympia/devhub/forms.py:668
-msgid "You cannot delete a file once the review process has started. You must delete the whole version."
-msgstr "İnceleme süreci başladığında bir dosyayı silemezsiniz. Tüm sürümü silmelisiniz."
+#: src/olympia/devhub/forms.py:669
+msgid "You cannot delete a file once the review process has started.  You must delete the whole version."
+msgstr ""
 
-#: src/olympia/devhub/forms.py:688
+#: src/olympia/devhub/forms.py:689
 msgid "The platform All cannot be combined with specific platforms."
 msgstr ""
 
-#: src/olympia/devhub/forms.py:693
+#: src/olympia/devhub/forms.py:694
 msgid "A platform can only be chosen once."
 msgstr "Bir platform sadece bir kez seçilebilir."
 
-#: src/olympia/devhub/forms.py:706
+#: src/olympia/devhub/forms.py:707
 msgid "A review type must be selected."
 msgstr "Bir inceleme türü seçili olmalıdır."
 
-#: src/olympia/devhub/forms.py:788 src/olympia/editors/forms.py:114 src/olympia/zadmin/forms.py:49 src/olympia/zadmin/forms.py:52
+#: src/olympia/devhub/forms.py:789 src/olympia/editors/forms.py:114 src/olympia/editors/forms.py:254 src/olympia/zadmin/forms.py:49 src/olympia/zadmin/forms.py:52
 msgid "Select an application first"
 msgstr "Önce bir uygulama seçin"
 
-#: src/olympia/devhub/forms.py:840
+#: src/olympia/devhub/forms.py:841
 msgid "There cannot be more than 3 required add-ons."
 msgstr "3'ten fazla gerekli eklenti olamaz."
 
@@ -3896,6 +3906,7 @@ msgstr "Geliştirici Belgeleri"
 msgid "{0} error"
 msgid_plural "{0} errors"
 msgstr[0] "{0} hata"
+msgstr[1] ""
 
 # {0} is a number
 #. L10n: first parameter is the number of warnings
@@ -3903,84 +3914,85 @@ msgstr[0] "{0} hata"
 msgid "{0} warning"
 msgid_plural "{0} warnings"
 msgstr[0] "{0} uyarı"
+msgstr[1] ""
 
 #: src/olympia/devhub/models.py:375 src/olympia/reviews/templates/reviews/add.html:58
 #, fuzzy
 msgid "Review"
 msgstr "Review"
 
-#: src/olympia/devhub/tasks.py:551
+#: src/olympia/devhub/tasks.py:583
 #, python-format
 msgid "%s responded with %s (%s)."
 msgstr ""
 
-#: src/olympia/devhub/tasks.py:555
+#: src/olympia/devhub/tasks.py:587
 #, python-format
 msgid "Connection to \"%s\" timed out."
 msgstr ""
 
-#: src/olympia/devhub/tasks.py:557
+#: src/olympia/devhub/tasks.py:589
 #, python-format
 msgid "Could not contact host at \"%s\"."
 msgstr ""
 
-#: src/olympia/devhub/utils.py:104
+#: src/olympia/devhub/utils.py:105
 #, python-format
 msgid "Validation generated too many errors/warnings so %s messages were truncated. After addressing the visible messages, you'll be able to see the others."
 msgstr ""
 
-#: src/olympia/devhub/views.py:183
+#: src/olympia/devhub/views.py:181
 msgid "All My Add-ons"
 msgstr "Tüm Eklentilerim"
 
-#: src/olympia/devhub/views.py:210
+#: src/olympia/devhub/views.py:208
 msgid "All Activity"
 msgstr ""
 
-#: src/olympia/devhub/views.py:211
+#: src/olympia/devhub/views.py:209
 msgid "Add-on Updates"
 msgstr "Eklenti Güncellemeleri"
 
-#: src/olympia/devhub/views.py:212
+#: src/olympia/devhub/views.py:210
 msgid "Add-on Status"
 msgstr "Eklenti Durumu"
 
 # 75%
 # 100%
-#: src/olympia/devhub/views.py:213
+#: src/olympia/devhub/views.py:211
 msgid "User Collections"
 msgstr "Kullanıcı koleksiyonları"
 
-#: src/olympia/devhub/views.py:214 src/olympia/devhub/templates/devhub/docs/policies-maintenance.html:68 src/olympia/pages/templates/pages/dev_faq.html:38
+#: src/olympia/devhub/views.py:212 src/olympia/devhub/templates/devhub/docs/policies-maintenance.html:68 src/olympia/pages/templates/pages/dev_faq.html:38
 #: src/olympia/pages/templates/pages/dev_faq.html:484
 msgid "User Reviews"
 msgstr "Kullanıcı İncelemeleri"
 
-#: src/olympia/devhub/views.py:327 src/olympia/devhub/views.py:331 src/olympia/devhub/views.py:484 src/olympia/devhub/views.py:513 src/olympia/devhub/views.py:564 src/olympia/devhub/views.py:1150
+#: src/olympia/devhub/views.py:325 src/olympia/devhub/views.py:329 src/olympia/devhub/views.py:484 src/olympia/devhub/views.py:513 src/olympia/devhub/views.py:564 src/olympia/devhub/views.py:1156
 msgid "Changes successfully saved."
 msgstr "Değişiklikler başarıyla kaydedildi."
 
-#: src/olympia/devhub/views.py:334 src/olympia/devhub/views.py:1631
+#: src/olympia/devhub/views.py:332 src/olympia/devhub/views.py:1637
 msgid "Please check the form for errors."
 msgstr ""
 
-#: src/olympia/devhub/views.py:346
+#: src/olympia/devhub/views.py:344
 msgid "Add-on cannot be deleted. Disable this add-on instead."
 msgstr ""
 
-#: src/olympia/devhub/views.py:356
+#: src/olympia/devhub/views.py:354
 msgid "Theme deleted."
 msgstr ""
 
-#: src/olympia/devhub/views.py:356
+#: src/olympia/devhub/views.py:354
 msgid "Add-on deleted."
 msgstr "Eklenti silindi."
 
-#: src/olympia/devhub/views.py:362
+#: src/olympia/devhub/views.py:360
 msgid "URL name was incorrect. Theme was not deleted."
 msgstr ""
 
-#: src/olympia/devhub/views.py:367
+#: src/olympia/devhub/views.py:365
 msgid "URL name was incorrect. Add-on was not deleted."
 msgstr ""
 
@@ -4008,7 +4020,7 @@ msgstr "Eklentiyi doğrula"
 msgid "Check Add-on Compatibility"
 msgstr "Eklenti uyumluluğunu denetle"
 
-#: src/olympia/devhub/views.py:808 src/olympia/signing/views.py:90
+#: src/olympia/devhub/views.py:808 src/olympia/signing/views.py:95
 msgid "You cannot submit this type of add-on"
 msgstr ""
 
@@ -4038,33 +4050,33 @@ msgstr "Resim tam olarak {0} piksel eninde ve {1} piksel boyunda olmalıdır."
 msgid "There was an error uploading your preview."
 msgstr ""
 
-#: src/olympia/devhub/views.py:1189
+#: src/olympia/devhub/views.py:1195
 #, python-format
 msgid "Version %s disabled."
 msgstr ""
 
-#: src/olympia/devhub/views.py:1193
+#: src/olympia/devhub/views.py:1199
 #, python-format
 msgid "Version %s deleted."
 msgstr "%s sürümü silindi."
 
-#: src/olympia/devhub/views.py:1203
+#: src/olympia/devhub/views.py:1209
 msgid "This upload has failed validation, and may lack complete validation results. Please take due care when reviewing it."
 msgstr ""
 
-#: src/olympia/devhub/views.py:1677
+#: src/olympia/devhub/views.py:1683
 msgid "Preliminary Review Requested."
 msgstr ""
 
-#: src/olympia/devhub/views.py:1678
+#: src/olympia/devhub/views.py:1684
 msgid "Full Review Requested."
 msgstr ""
 
-#: src/olympia/devhub/views.py:1779
+#: src/olympia/devhub/views.py:1783
 msgid "Your old credentials were revoked and are no longer valid. Be sure to update all API clients with the new credentials."
 msgstr ""
 
-#: src/olympia/devhub/views.py:1797
+#: src/olympia/devhub/views.py:1801
 msgid "New API key created"
 msgstr ""
 
@@ -4094,7 +4106,7 @@ msgstr "Eklentilere geri dön"
 msgid "{0} :: Search"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/devhub_search.html:6 src/olympia/devhub/templates/devhub/search.html:8 src/olympia/editors/forms.py:435 src/olympia/editors/forms.py:437
+#: src/olympia/devhub/templates/devhub/devhub_search.html:6 src/olympia/devhub/templates/devhub/search.html:8 src/olympia/editors/forms.py:534 src/olympia/editors/forms.py:536
 #: src/olympia/editors/templates/editors/queue.html:27 src/olympia/editors/templates/editors/themes/queue_list.html:14 src/olympia/search/templates/search/collections.html:17
 #: src/olympia/search/templates/search/personas.html:18 src/olympia/search/templates/search/results.html:18 src/olympia/search/templates/search/mobile/results.html:8
 #: src/olympia/templates/search.html:14 src/olympia/templates/impala/search.html:18
@@ -4154,12 +4166,12 @@ msgstr ""
 msgid "Start Making Add-ons"
 msgstr "Eklenti Yapmaya Başlayın"
 
-#: src/olympia/devhub/templates/devhub/index.html:86 src/olympia/devhub/templates/devhub/addons/listing/items.html:25 src/olympia/devhub/templates/devhub/includes/addon_details.html:15
+#: src/olympia/devhub/templates/devhub/index.html:86 src/olympia/devhub/templates/devhub/addons/listing/items.html:25 src/olympia/devhub/templates/devhub/includes/addon_details.html:20
 #: src/olympia/devhub/templates/devhub/personas/edit.html:43
 msgid "Status:"
 msgstr "Durum:"
 
-#: src/olympia/devhub/templates/devhub/index.html:90 src/olympia/devhub/templates/devhub/includes/addon_details.html:100
+#: src/olympia/devhub/templates/devhub/index.html:90 src/olympia/devhub/templates/devhub/includes/addon_details.html:87
 msgid "Visibility:"
 msgstr "Görünürlük:"
 
@@ -4167,11 +4179,11 @@ msgstr "Görünürlük:"
 msgid "Latest Version:"
 msgstr "En Son Sürüm:"
 
-#: src/olympia/devhub/templates/devhub/index.html:109 src/olympia/devhub/templates/devhub/includes/addon_details.html:145 src/olympia/devhub/templates/devhub/personas/edit.html:49
+#: src/olympia/devhub/templates/devhub/index.html:109 src/olympia/devhub/templates/devhub/includes/addon_details.html:131 src/olympia/devhub/templates/devhub/personas/edit.html:49
 msgid "Queue Position:"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/index.html:110 src/olympia/devhub/templates/devhub/includes/addon_details.html:146 src/olympia/devhub/templates/devhub/personas/edit.html:50
+#: src/olympia/devhub/templates/devhub/index.html:110 src/olympia/devhub/templates/devhub/includes/addon_details.html:132 src/olympia/devhub/templates/devhub/personas/edit.html:50
 #, python-format
 msgid "%(position)s of %(total)s"
 msgstr ""
@@ -4275,16 +4287,6 @@ msgstr "Yüklemeden sonra dosyanız üzerinde bir dizi otomatik doğrulama testi
 msgid "Do you want your add-on to be distributed on this site?"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/validate_addon.html:49 src/olympia/devhub/templates/devhub/addons/submit/upload.html:30 src/olympia/devhub/templates/devhub/versions/add_file_modal.html:14
-#: src/olympia/devhub/templates/devhub/versions/add_file_modal.html:53 src/olympia/devhub/templates/devhub/versions/list.html:298
-msgid "Warning:"
-msgstr "Uyarı:"
-
-#: src/olympia/devhub/templates/devhub/validate_addon.html:50 src/olympia/devhub/templates/devhub/addons/submit/upload.html:31
-#, python-format
-msgid "Submission of unlisted add-ons for signing is currently in an open beta. Please <a href=\"%(url)s\" target=\"_blank\">report any bugs</a> that you encounter."
-msgstr ""
-
 #. first parameter is a filename like lorem-ipsum-1.0.2.xpi
 #: src/olympia/devhub/templates/devhub/validation.html:5
 msgid "Validation Results for {0}"
@@ -4359,7 +4361,7 @@ msgstr "Uyumluluk"
 msgid "Update Compatibility"
 msgstr "Uyumluluğu Güncelle"
 
-#: src/olympia/devhub/templates/devhub/addons/ajax_compat_update.html:4
+#: src/olympia/devhub/templates/devhub/addons/ajax_compat_update.html:4 src/olympia/devhub/templates/devhub/versions/edit.html:45
 msgid "Adjusting application information here will allow users to install your add-on even if the install manifest in the package indicates that the add-on is incompatible."
 msgstr ""
 
@@ -4371,9 +4373,9 @@ msgstr "Desteklenen Sürümler"
 msgid "Add Another Application&hellip;"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/addons/ajax_compat_update.html:38 src/olympia/devhub/templates/devhub/addons/owner.html:86 src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:46
-#: src/olympia/devhub/templates/devhub/versions/list.html:351 src/olympia/devhub/templates/devhub/versions/list.html:353 src/olympia/templates/impala/base.html:132
-#: src/olympia/templates/impala/base.html:143 src/olympia/templates/impala/base.html:161 src/olympia/templates/impala/base.html:171
+#: src/olympia/devhub/templates/devhub/addons/ajax_compat_update.html:38 src/olympia/devhub/templates/devhub/addons/owner.html:86 src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:45
+#: src/olympia/devhub/templates/devhub/versions/list.html:349 src/olympia/devhub/templates/devhub/versions/list.html:351 src/olympia/templates/impala/base.html:129
+#: src/olympia/templates/impala/base.html:140 src/olympia/templates/impala/base.html:158 src/olympia/templates/impala/base.html:168
 msgid "Close"
 msgstr "Kapat"
 
@@ -4391,6 +4393,7 @@ msgstr "Eklentilerimin önceki etkinlikleri"
 msgid "<b>{0}</b> theme"
 msgid_plural "<b>{0}</b> themes"
 msgstr[0] ""
+msgstr[1] ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit.html:3 src/olympia/devhub/templates/devhub/addons/listing/item_actions.html:25
 #: src/olympia/devhub/templates/devhub/addons/listing/item_actions_theme.html:7 src/olympia/devhub/templates/devhub/includes/addons_edit_nav.html:2
@@ -4406,7 +4409,7 @@ msgstr "Hiçbiri"
 msgid "Manage Authors & License"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/addons/owner.html:29 src/olympia/editors/templates/editors/review.html:270
+#: src/olympia/devhub/templates/devhub/addons/owner.html:29 src/olympia/editors/helpers.py:362 src/olympia/editors/templates/editors/review.html:270
 msgid "Authors"
 msgstr "Yazarlar"
 
@@ -4475,17 +4478,11 @@ msgstr "Özet"
 
 #: src/olympia/devhub/templates/devhub/addons/edit/basic.html:52
 msgid ""
-"A short explanation of your add-on's basic\n"
-"                          functionality that is displayed in search and browse\n"
-"                          listings, as well as at the top of your add-on's\n"
-"                          details page. It is only relevant for listed add-ons."
+"A short explanation of your add-on's basic functionality that is displayed in search and browse listings, as well as at the top of your add-on's details page. It is only relevant for listed add-ons."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/basic.html:73
-msgid ""
-"Categories are the primary way users browse through add-ons.\n"
-"                        Choose any that fit your add-on's functionality for the most\n"
-"                        exposure. It is only relevant for listed add-ons."
+msgid "Categories are the primary way users browse through add-ons. Choose any that fit your add-on's functionality for the most exposure. It is only relevant for listed add-ons."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/basic.html:90
@@ -4495,17 +4492,14 @@ msgid ""
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/basic.html:119
-msgid ""
-"Tags help users find your add-on and should be short\n"
-"                        descriptors such as tabs, toolbar, or twitter.  You\n"
-"                        may have a maximum of {0} tags. It is only relevant\n"
-"                        for listed add-ons."
+msgid "Tags help users find your add-on and should be short descriptors such as tabs, toolbar, or twitter. You may have a maximum of {0} tags. It is only relevant for listed add-ons."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/basic.html:129 src/olympia/devhub/templates/devhub/personas/edit.html:97 src/olympia/devhub/templates/devhub/personas/submit.html:46
 msgid "Comma-separated, minimum of {0} character."
 msgid_plural "Comma-separated, minimum of {0} characters."
 msgstr[0] "Virgülle ayrılmış, en az {0} karakter."
+msgstr[1] ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/basic.html:132 src/olympia/devhub/templates/devhub/personas/edit.html:100 src/olympia/devhub/templates/devhub/personas/submit.html:49
 msgid "Example: dark, cinema, noir. Limit 20."
@@ -4515,6 +4509,7 @@ msgstr ""
 msgid "Reserved tag:"
 msgid_plural "Reserved tags:"
 msgstr[0] "Ayrılmış etiketler:"
+msgstr[1] ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/details.html:5
 msgid "Add-on Details"
@@ -4525,11 +4520,7 @@ msgid "Add-on Details for {0}"
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/details.html:22
-msgid ""
-"A longer explanation of features,\n"
-"                          functionality, and other relevant information. This\n"
-"                          field is only displayed on the add-on's details\n"
-"                          page. It is only relevant for listed add-ons."
+msgid "A longer explanation of features, functionality, and other relevant information. This field is only displayed on the add-on's details page. It is only relevant for listed add-ons."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/details.html:44 src/olympia/translations/templates/translations/trans-menu.html:13
@@ -4537,10 +4528,7 @@ msgid "Default Locale"
 msgstr "Varsayılan dil"
 
 #: src/olympia/devhub/templates/devhub/addons/edit/details.html:45
-msgid ""
-"Information about your add-on is displayed in this locale\n"
-"                        unless you override it with a locale-specific translation.\n"
-"                        It is only relevant for listed add-ons."
+msgid "Information about your add-on is displayed in this locale unless you override it with a locale-specific translation. It is only relevant for listed add-ons."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/details.html:61 src/olympia/users/forms.py:311 src/olympia/users/templates/users/edit.html:122 src/olympia/users/templates/users/register.html:57
@@ -4550,10 +4538,8 @@ msgstr "Ana Sayfa"
 
 #: src/olympia/devhub/templates/devhub/addons/edit/details.html:63
 msgid ""
-"If your add-on has another homepage, enter its\n"
-"                          address here. If your website is localized into other\n"
-"                          languages multiple translations of this field can be\n"
-"                          added. It is only relevant for listed add-ons."
+"If your add-on has another homepage, enter its address here. If your website is localized into other languages multiple translations of this field can be added. It is only relevant for listed add-"
+"ons."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/media.html:3
@@ -4571,19 +4557,14 @@ msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/support.html:22
 msgid ""
-"If you wish to display an e-mail address for support\n"
-"                          inquiries, enter it here. If you have different\n"
-"                          addresses for each language multiple translations of\n"
-"                          this field can be added. It is only relevant for\n"
-"                          listed add-ons."
+"If you wish to display an e-mail address for support inquiries, enter it here. If you have different addresses for each language multiple translations of this field can be added. It is only "
+"relevant for listed add-ons."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/support.html:45
 msgid ""
-"If your add-on has a support website or forum, enter\n"
-"                          its address here. If your website is localized into\n"
-"                          other languages, multiple translations of this field can\n"
-"                          be added. It is only relevant for listed add-ons."
+"If your add-on has a support website or forum, enter its address here. If your website is localized into other languages, multiple translations of this field can be added. It is only relevant for "
+"listed add-ons."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:6
@@ -4597,11 +4578,8 @@ msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:23
 msgid ""
-"Any information end users may want to know that isn't\n"
-"                          necessarily applicable to the add-on summary or description.\n"
-"                          Common uses include listing known major bugs, information on\n"
-"                          how to report bugs, anticipated release date of a new version,\n"
-"                          etc. It is only relevant for listed add-ons."
+"Any information end users may want to know that isn't necessarily applicable to the add-on summary or description. Common uses include listing known major bugs, information on how to report bugs, "
+"anticipated release date of a new version, etc. It is only relevant for listed add-ons."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:46
@@ -4613,9 +4591,7 @@ msgid "Add-on Flags"
 msgstr "Eklenti İşaretleri"
 
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:69
-msgid ""
-"These flags are used to classify add-ons. It is only\n"
-"                        relevant for listed add-ons."
+msgid "These flags are used to classify add-ons. It is only relevant for listed add-ons."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:74
@@ -4631,9 +4607,7 @@ msgid "View Source?"
 msgstr "Kaynağa Bakılsın mı?"
 
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:90
-msgid ""
-"Whether the source of your add-on can be displayed in our\n"
-"                        online viewer. It is only relevant for listed add-ons."
+msgid "Whether the source of your add-on can be displayed in our online viewer. It is only relevant for listed add-ons."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:94
@@ -4649,10 +4623,7 @@ msgid "Public Stats?"
 msgstr "İstatistikler Herkese Açık mı?"
 
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:102
-msgid ""
-"Whether the download and usage stats of your add-on can\n"
-"                        be displayed in our online viewer.\n"
-"                        It is only relevant for listed add-ons."
+msgid "Whether the download and usage stats of your add-on can be displayed in our online viewer. It is only relevant for listed add-ons."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:107
@@ -4668,10 +4639,7 @@ msgid "Upgrade SDK?"
 msgstr "SDK yükseltilsin mi?"
 
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:116
-msgid ""
-"If selected, we will try to automatically upgrade your\n"
-"                        add-on when a new version of the SDK is released.\n"
-"                        It is only relevant for listed add-ons."
+msgid "If selected, we will try to automatically upgrade your add-on when a new version of the SDK is released. It is only relevant for listed add-ons."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:121
@@ -4724,10 +4692,8 @@ msgstr "Eklenti simgesi"
 
 #: src/olympia/devhub/templates/devhub/addons/forms_shared/media.html:16
 msgid ""
-"Upload an icon for your add-on or choose from one of ours. The\n"
-"                      icon is displayed nearly everywhere your add-on is. Uploaded images\n"
-"                      must be one of the following image types: .png, .jpg.\n"
-"                      It is only relevant for listed add-ons."
+"Upload an icon for your add-on or choose from one of ours. The icon is displayed nearly everywhere your add-on is. Uploaded images must be one of the following image types: .png, .jpg. It is only "
+"relevant for listed add-ons."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/forms_shared/media.html:25
@@ -4740,9 +4706,7 @@ msgid "32x32px"
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/forms_shared/media.html:39
-msgid ""
-"Used in listings of add-ons, like search results\n"
-"                            and featured add-ons."
+msgid "Used in listings of add-ons, like search results and featured add-ons."
 msgstr ""
 
 #. The size of the icon
@@ -4837,16 +4801,14 @@ msgid "Deleting your add-on will permanently remove it from the site and prevent
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:24
-msgid ""
-"Enter the following text confirm your decision:\n"
-"           {slug}"
+msgid "Enter the following text confirm your decision: {slug}"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:34
+#: src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:33
 msgid "Please tell us why you are deleting your theme:"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:36
+#: src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:35
 msgid "Please tell us why you are deleting your add-on:"
 msgstr ""
 
@@ -4883,8 +4845,8 @@ msgstr "Yeni Sürüm"
 msgid "Daily statistics on downloads and users."
 msgstr "İndirme ve kullanıcılarla ilgili günlük istatistikler."
 
-#: src/olympia/devhub/templates/devhub/addons/listing/item_actions.html:45 src/olympia/stats/templates/stats/stats.html:75 src/olympia/stats/templates/stats/stats.html:79
-#: src/olympia/stats/templates/stats/stats.html:81
+#: src/olympia/devhub/templates/devhub/addons/listing/item_actions.html:45 src/olympia/stats/templates/stats/stats.html:31 src/olympia/stats/templates/stats/stats.html:35
+#: src/olympia/stats/templates/stats/stats.html:37
 msgid "Statistics"
 msgstr "İstatistikler"
 
@@ -4944,6 +4906,7 @@ msgstr "<b>Sıra:</b> %(pos)s / %(total)s"
 msgid "<strong>{0}</strong> active user"
 msgid_plural "<strong>{0}</strong> active users"
 msgstr[0] "<strong>{0}</strong> etkin kullanıcı"
+msgstr[1] ""
 
 #: src/olympia/devhub/templates/devhub/addons/submit/base.html:11
 msgid "Submit Add-on"
@@ -5002,10 +4965,7 @@ msgid "Your add-on has been submitted to the Full Review queue."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/submit/done.html:18
-msgid ""
-"You'll receive an email once it has been reviewed by an editor. In\n"
-"          the meantime, you and your friends can install it directly from its\n"
-"          details page:"
+msgid "You'll receive an email once it has been reviewed by an editor. In the meantime, you and your friends can install it directly from its details page:"
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/submit/done.html:27 src/olympia/devhub/templates/devhub/addons/submit/done.html:77 src/olympia/devhub/templates/devhub/personas/submit_done.html:16
@@ -5211,11 +5171,11 @@ msgstr "2. Adım: Eklentinizi Karşıya Yükleyin"
 msgid "Use the fields below to upload your add-on package and select any platform restrictions. After upload, a series of automated validation tests will be run on your file."
 msgstr "Aşağıdaki sahaları kullanarak eklenti paketinizi karşıya yükleyin ve varsa platform kısıtlamalarını seçin. Karşıya yüklemeden sonra, dosya üzerinde bir dizi doğrulama testi uygulanacak."
 
-#: src/olympia/devhub/templates/devhub/addons/submit/upload.html:59 src/olympia/devhub/templates/devhub/versions/add_file_modal.html:39
+#: src/olympia/devhub/templates/devhub/addons/submit/upload.html:51 src/olympia/devhub/templates/devhub/versions/add_file_modal.html:28
 msgid "Which platforms is this file compatible with?"
 msgstr "Bu dosya hangi platformlarla uyumlu?"
 
-#: src/olympia/devhub/templates/devhub/addons/submit/upload.html:67 src/olympia/devhub/templates/devhub/versions/add_file_modal.html:65
+#: src/olympia/devhub/templates/devhub/addons/submit/upload.html:59 src/olympia/devhub/templates/devhub/versions/add_file_modal.html:45
 msgid "Administrative overrides"
 msgstr "Yönetsel kural istisnaları"
 
@@ -5330,8 +5290,8 @@ msgstr "Site İşlevselliği ve Geliştirme"
 
 #: src/olympia/devhub/templates/devhub/docs/policies-contact.html:44
 msgid ""
-"If you've found a problem with the site, we'd love to fix it. Please <a href=\"https://github.com/mozilla/olympia/issues\">file a bug report</a> in GitHub, including the location of the problem and "
-"how you encountered it."
+"If you've found a problem with the site, we'd love to fix it. Please <a href=\"https://github.com/mozilla/addons/issues/new\">file a bug report</a> in GitHub, including the location of the problem "
+"and how you encountered it."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/docs/policies-maintenance.html:3 src/olympia/devhub/templates/devhub/docs/policies-maintenance.html:7
@@ -5929,7 +5889,7 @@ msgstr ""
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:282
 msgid ""
-"Add-ons that store or otherwise handle browsing data must support <a href=\"https://developer.mozilla.org/En/Supporting_private_browsing_mode\">Private Browsing Mode</a>.  During a Private Browsing "
+"Add-ons that store or otherwise handle browsing data must support <a href=\"https://developer.mozilla.org/En/Supporting_private_browsing_mode\">Private Browsing Mode</a>. During a Private Browsing "
 "session, no browsing data can be written to disk, and all of this data must be cleared when Firefox quits or the Private Browsing session ends."
 msgstr ""
 
@@ -6094,129 +6054,95 @@ msgstr ""
 msgid "How to get in touch with us regarding these policies or your add-on."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:6
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:10
 msgid "You have disabled this add-on"
 msgstr "Bu eklentiyi devre dışı bıraktınız"
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:20
-msgid ""
-"Your add-on's listing is disabled and is not showing\n"
-"                             anywhere in our gallery or update service."
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:24
+msgid "Your add-on's listing is disabled and is not showing anywhere in our gallery or update service."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:25
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:27
 msgid "Please complete your add-on."
 msgstr "Lütfen eklentinizi tamamlayın."
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:29
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:30
 msgid "You will receive an email when the review is complete."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:34
-msgid ""
-"You will receive an email when the review is complete. Until\n"
-"                             then, your add-on is not listed in our gallery but can be\n"
-"                             accessed directly from its details page."
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:33
+msgid "You will receive an email when the review is complete. Until then, your add-on is not listed in our gallery but can be accessed directly from its details page."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:38 src/olympia/devhub/templates/devhub/includes/addon_details.html:48
-msgid ""
-"You will receive an email when the review is\n"
-"                             complete and your add-on is signed."
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:37 src/olympia/devhub/templates/devhub/includes/addon_details.html:45
+msgid "You will receive an email when the review is complete and your add-on is signed."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:44
-msgid ""
-"You will receive an email when the review is complete. Until\n"
-"                             then, your add-on is not listed in our gallery but can be\n"
-"                             accessed directly from its details page. "
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:41
+msgid "You will receive an email when the review is complete. Until then, your add-on is not listed in our gallery but can be accessed directly from its details page. "
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:54
-msgid ""
-"Your add-on is displayed in our gallery and users are\n"
-"                             receiving automatic updates."
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:49
+msgid "Your add-on is displayed in our gallery and users are receiving automatic updates."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:57
-msgid ""
-"Your add-on has been signed and can be bundled with an\n"
-"                             application installer."
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:52
+msgid "Your add-on has been signed and can be bundled with an application installer."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:63
-msgid ""
-"Your add-on was disabled by a site administrator and is no\n"
-"                             longer shown in our gallery. If you have any questions,\n"
-"                             please email amo-admins@mozilla.org."
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:56
+msgid "Your add-on was disabled by a site administrator and is no longer shown in our gallery. If you have any questions, please email amo-admins@mozilla.org."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:70
-msgid ""
-"Your add-on is displayed in our gallery as experimental\n"
-"                             and users are receiving automatic updates. Some features\n"
-"                             are unavailable to your add-on."
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:62
+msgid "Your add-on is displayed in our gallery as experimental and users are receiving automatic updates. Some features are unavailable to your add-on."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:74
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:66
 msgid "Your add-on has been signed."
 msgstr ""
 
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:69
+msgid ""
+"You will receive an email when the full review is complete. Until then, your add-on is displayed in our gallery as experimental and users are receiving automatic updates. Some features are "
+"unavailable to your add-on."
+msgstr ""
+
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:74
+msgid "You will receive an email when the full review is complete, making you able to bundle your add-on with an application installer."
+msgstr ""
+
 #: src/olympia/devhub/templates/devhub/includes/addon_details.html:79
-msgid ""
-"You will receive an email when the full review is complete.\n"
-"                             Until then, your add-on is displayed in our gallery as\n"
-"                             experimental and users are receiving automatic updates.\n"
-"                             Some features are unavailable to your add-on."
+msgid "All add-ons hosted in our gallery must now be reviewed by an editor. If you wish to continue hosting your add-on, please click to select a review process."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:84
-msgid ""
-"You will receive an email when the full review is\n"
-"                             complete, making you able to bundle your add-on with an\n"
-"                             application installer."
-msgstr ""
-
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:91
-msgid ""
-"All add-ons hosted in our gallery must now be reviewed by an\n"
-"                             editor. If you wish to continue hosting your add-on, please\n"
-"                             click to select a review process."
-msgstr ""
-
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:113
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:100
 msgid "Current Version:"
 msgstr "Mevcut sürüm:"
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:115
-msgid ""
-"This is the version of your add-on that will\n"
-"                                           be installed if someone clicks the Install\n"
-"                                           button on addons.mozilla.org. It is only\n"
-"                                           relevant for listed add-ons."
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:102
+msgid "This is the version of your add-on that will be installed if someone clicks the Install button on addons.mozilla.org. It is only relevant for listed add-ons."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:123
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:110
 msgid "Created:"
 msgstr "Oluşturulma:"
 
 #. {0} is a date. dennis-ignore: E201
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:125 src/olympia/devhub/templates/devhub/includes/addon_details.html:131
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:112 src/olympia/devhub/templates/devhub/includes/addon_details.html:118
 #, python-format
 msgid "%%b %%e, %%Y"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:136
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:123
 msgid "Next Version:"
 msgstr "Sonraki sürüm:"
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:138
-msgid ""
-"This is the newest uploaded version, however\n"
-"                                           it isn’t live on the site yet."
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:125
+msgid "This is the newest uploaded version, however it isn’t live on the site yet."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:144 src/olympia/devhub/templates/devhub/versions/list.html:30
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:130 src/olympia/devhub/templates/devhub/versions/list.html:30
 msgid "Queues are not reviewed strictly in order"
 msgstr ""
 
@@ -6288,9 +6214,7 @@ msgid "View the blog &#9658;"
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/includes/license_form.html:6
-msgid ""
-"Please choose a license appropriate for the rights you grant on your source code.\n"
-"                  It is only relevant for listed add-ons."
+msgid "Please choose a license appropriate for the rights you grant on your source code. It is only relevant for listed add-ons."
 msgstr ""
 
 #. {0} is a list of HTML tags.
@@ -6312,18 +6236,16 @@ msgstr "Bu uygulamayı kaldır"
 msgid "Select <b>up to {0}</b> {1} category for this add-on:"
 msgid_plural "Select <b>up to {0}</b> {1} categories for this add-on:"
 msgstr[0] ""
+msgstr[1] ""
 
 #: src/olympia/devhub/templates/devhub/includes/policy_form.html:4
 msgid ""
 "Users will be required to accept the following End-User License Agreement (EULA) prior to installing your add-on. The presence of a EULA significantly affects the number of downloads an add-on "
-"receives. Please note that a EULA is not the same as a code license, such as the GPL or MPL.\n"
-"                It is only relevant for listed add-ons."
+"receives. Please note that a EULA is not the same as a code license, such as the GPL or MPL.It is only relevant for listed add-ons."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/policy_form.html:21
-msgid ""
-"If your add-on transmits any data from the user's computer, a privacy policy is required that explains what data is sent and how it is used.\n"
-"                It is only relevant for listed add-ons."
+#: src/olympia/devhub/templates/devhub/includes/policy_form.html:24
+msgid "If your add-on transmits any data from the user's computer, a privacy policy is required that explains what data is sent and how it is used. It is only relevant for listed add-ons."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/includes/source_form_field.html:2
@@ -6491,12 +6413,8 @@ msgstr ""
 msgid "Add some tags to describe your Theme."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/personas/edit.html:106
-msgid ""
-"A short explanation of your theme's\n"
-"                                basic functionality that is displayed in\n"
-"                                search and browse listings, as well as at\n"
-"                                the top of your theme's details page."
+#: src/olympia/devhub/templates/devhub/personas/edit.html:106 src/olympia/devhub/templates/devhub/personas/submit.html:54
+msgid "A short explanation of your theme's basic functionality that is displayed in search and browse listings, as well as at the top of your theme's details page."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/personas/edit.html:122 src/olympia/devhub/templates/devhub/personas/submit.html:68
@@ -6568,7 +6486,7 @@ msgid "Upon upload and form submission, the AMO Team will review your updated de
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/personas/edit.html:241
-msgid "Your previously resubmitted design,  which is under pending review."
+msgid "Your previously resubmitted design, which is under pending review."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/personas/edit.html:245
@@ -6636,14 +6554,6 @@ msgstr ""
 #: src/olympia/devhub/templates/devhub/personas/submit.html:33
 msgid "Give your Theme a name."
 msgstr "Temanıza bir ad verin."
-
-#: src/olympia/devhub/templates/devhub/personas/submit.html:54
-msgid ""
-"A short explanation of your theme's\n"
-"                                      basic functionality that is displayed in\n"
-"                                      search and browse listings, as well as at\n"
-"                                      the top of your theme's details page."
-msgstr ""
 
 #: src/olympia/devhub/templates/devhub/personas/submit.html:198
 #, python-format
@@ -6719,30 +6629,16 @@ msgstr "Farklı bir alt kısım resmi seçin"
 msgid "Files added to reviewed versions must be reviewed before they will be available for download."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/add_file_modal.html:15
-#, python-format
-msgid ""
-"Submission of updates to unlisted add-ons for signing is currently in an open beta. Manual review may still be required for a large number of add-ons. Please <a href=\"%(url)s\" target=\"_blank"
-"\">report any bugs</a> that you encounter."
-msgstr ""
-
-#: src/olympia/devhub/templates/devhub/versions/add_file_modal.html:35
+#: src/olympia/devhub/templates/devhub/versions/add_file_modal.html:24
 msgid "Select the target platform for this file."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/add_file_modal.html:46
+#: src/olympia/devhub/templates/devhub/versions/add_file_modal.html:35
 msgid "Which review type would you like to nominate for?"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/add_file_modal.html:51
+#: src/olympia/devhub/templates/devhub/versions/add_file_modal.html:40
 msgid "Only publish this version to my beta channel."
-msgstr ""
-
-#: src/olympia/devhub/templates/devhub/versions/add_file_modal.html:54
-#, python-format
-msgid ""
-"The behavior of the beta channel has changed to accommodate <a href=\"%(addon_signing_url)s\" target=\"_blank\">mandatory add-on signing</a>. The new process is currently in an open beta, and may "
-"change significantly in the near future. Please <a href=\"%(issues_url)s\" target=\"_blank\">report any bugs</a> that you encounter."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/versions/edit.html:5
@@ -6770,19 +6666,10 @@ msgstr "Dosyalar"
 msgid "Upload Another File"
 msgstr "Başka bir dosya yükle"
 
-#: src/olympia/devhub/templates/devhub/versions/edit.html:45
-msgid ""
-"Adjusting application information here will allow users to install your\n"
-"                          add-on even if the install manifest in the package indicates that the\n"
-"                          add-on is incompatible."
-msgstr ""
-
 #: src/olympia/devhub/templates/devhub/versions/edit.html:74
 msgid ""
-"Information about changes in this release, new features,\n"
-"                              known bugs, and other useful information specific to this\n"
-"                              release/version. This information is also shown in the\n"
-"                              Add-ons Manager when updating."
+"Information about changes in this release, new features, known bugs, and other useful information specific to this release/version. This information is also shown in the Add-ons Manager when "
+"updating."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/versions/edit.html:99
@@ -6794,10 +6681,7 @@ msgid "Notes for Reviewers"
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/versions/edit.html:114
-msgid ""
-"Optionally, enter any information that may be useful\n"
-"                              to the Editor reviewing this add-on, such as test\n"
-"                              account information."
+msgid "Optionally, enter any information that may be useful to the Editor reviewing this add-on, such as test account information."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/versions/edit.html:127
@@ -6848,6 +6732,7 @@ msgstr "Bu sürümü düzenle"
 msgid "{0} file"
 msgid_plural "{0} files"
 msgstr[0] "{0} dosya"
+msgstr[1] ""
 
 #: src/olympia/devhub/templates/devhub/versions/list.html:25
 msgid "0 files"
@@ -6874,7 +6759,7 @@ msgstr ""
 msgid "Request Preliminary Review"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:80 src/olympia/devhub/templates/devhub/versions/list.html:327 src/olympia/devhub/templates/devhub/versions/list.html:350
+#: src/olympia/devhub/templates/devhub/versions/list.html:80 src/olympia/devhub/templates/devhub/versions/list.html:325 src/olympia/devhub/templates/devhub/versions/list.html:348
 msgid "Cancel Review Request"
 msgstr ""
 
@@ -6903,7 +6788,7 @@ msgid "Unlisted:"
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/versions/list.html:114
-msgid "Not distributed on {0}. Developers will upload new versions for signing and distribute the add-ons on their own. (beta)"
+msgid "Not distributed on {0}. Developers will upload new versions for signing and distribute the add-ons on their own."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/versions/list.html:122
@@ -6967,83 +6852,75 @@ msgid "<strong>Important:</strong> Once a version has been deleted, you may not 
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/versions/list.html:230
-msgid ""
-"Deleting a version which has already been reviewed\n"
-"               may also cause a significant delay in the review of\n"
-"               your next update."
-msgstr ""
-
-#: src/olympia/devhub/templates/devhub/versions/list.html:233
 msgid "Are you sure you wish to delete this version?"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:238
+#: src/olympia/devhub/templates/devhub/versions/list.html:235
 msgid "Delete Version"
 msgstr "Sürümü sil"
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:240
+#: src/olympia/devhub/templates/devhub/versions/list.html:237
 msgid "Disable Version"
 msgstr "Sürümü devre dışı bırak"
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:247
+#: src/olympia/devhub/templates/devhub/versions/list.html:244
 msgid "Add a new Version"
 msgstr "Yeni sürüm ekle"
 
 # 75%
 # 100%
-#: src/olympia/devhub/templates/devhub/versions/list.html:249
+#: src/olympia/devhub/templates/devhub/versions/list.html:246
 msgid "Add Version"
 msgstr "Sürüm ekle"
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:256 src/olympia/devhub/templates/devhub/versions/list.html:274
+#: src/olympia/devhub/templates/devhub/versions/list.html:253 src/olympia/devhub/templates/devhub/versions/list.html:279
 msgid "Hide Add-on"
 msgstr "Eklentiyi gizle"
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:259
+#: src/olympia/devhub/templates/devhub/versions/list.html:256
 msgid "Hiding your add-on will prevent it from appearing anywhere in our gallery and will stop users from receiving automatic updates."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:265
+#: src/olympia/devhub/templates/devhub/versions/list.html:263
+msgid "The files awaiting review will be disabled and you will need to upload new versions."
+msgstr ""
+
+#: src/olympia/devhub/templates/devhub/versions/list.html:270
 msgid "Are you sure you wish to hide your add-on?"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:286 src/olympia/devhub/templates/devhub/versions/list.html:315
+#: src/olympia/devhub/templates/devhub/versions/list.html:291 src/olympia/devhub/templates/devhub/versions/list.html:313
 msgid "Unlist Add-on"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:289
+#: src/olympia/devhub/templates/devhub/versions/list.html:294
 #, python-format
 msgid ""
 "Unlisting your add-on will make it (and each of its versions/files) invisible on this website. It won't show up in searches, won't have a public facing page, and won't be updated automatically for "
-"current users.  It is recommended for unlisted add-ons to provide a custom <a href=\"%(update_url)s\" target=\"_blank\">updateURL</a> in their manifest file for automatic updates."
+"current users. It is recommended for unlisted add-ons to provide a custom <a href=\"%(update_url)s\" target=\"_blank\">updateURL</a> in their manifest file for automatic updates."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:299
-#, python-format
-msgid "Switching add-ons to unlisted is currently in an open beta. Please <a href=\"%(url)s\" target=\"_blank\">report any bugs</a> that you encounter."
-msgstr ""
-
-#: src/olympia/devhub/templates/devhub/versions/list.html:305
+#: src/olympia/devhub/templates/devhub/versions/list.html:303
 msgid "Unlisting an add-on is irreversible!"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:305
+#: src/olympia/devhub/templates/devhub/versions/list.html:303
 msgid "An unlisted add-on cannot be switched to be listed."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:307
+#: src/olympia/devhub/templates/devhub/versions/list.html:305
 msgid "Are you sure you wish to unlist your add-on?"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:330
+#: src/olympia/devhub/templates/devhub/versions/list.html:328
 msgid "Canceling your review request will leave your add-on as preliminarily reviewed."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:335
+#: src/olympia/devhub/templates/devhub/versions/list.html:333
 msgid "Canceling your review request will mark your add-on incomplete. If you do not complete your add-on after several days by re-requesting review, it will be deleted."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:343
+#: src/olympia/devhub/templates/devhub/versions/list.html:341
 msgid "Are you sure you wish to cancel your review request?"
 msgstr ""
 
@@ -7385,20 +7262,20 @@ msgstr "eklenti, editör veya yorum"
 msgid "Search by add-on name / author email"
 msgstr "Eklenti adıyla veya yazar e-postasıyla ara"
 
-#: src/olympia/editors/forms.py:103
+#: src/olympia/editors/forms.py:103 src/olympia/editors/forms.py:244 src/olympia/editors/forms.py:257
 msgid "yes"
 msgstr "evet"
 
-#: src/olympia/editors/forms.py:104
+#: src/olympia/editors/forms.py:104 src/olympia/editors/forms.py:244 src/olympia/editors/forms.py:257
 msgid "no"
 msgstr "hayır"
 
-#: src/olympia/editors/forms.py:105
+#: src/olympia/editors/forms.py:105 src/olympia/editors/forms.py:245
 #, fuzzy
 msgid "Admin Flag"
 msgstr "Admin Flag"
 
-#: src/olympia/editors/forms.py:113
+#: src/olympia/editors/forms.py:113 src/olympia/editors/forms.py:253
 #, fuzzy
 msgid "Max. Version"
 msgstr "Max. Version"
@@ -7411,56 +7288,60 @@ msgstr "Gönderiden bugüne geçen gün"
 msgid "Add-on Types"
 msgstr "Eklenti türleri"
 
-#: src/olympia/editors/forms.py:126 src/olympia/editors/helpers.py:267
+#: src/olympia/editors/forms.py:126 src/olympia/editors/helpers.py:279
 msgid "Platforms"
 msgstr "Platformlar"
 
+#: src/olympia/editors/forms.py:237
+msgid "Search by add-on name / author email / guid"
+msgstr ""
+
 #. L10n: 0 = platform, 1 = filename, 2 = status message
-#: src/olympia/editors/forms.py:238
+#: src/olympia/editors/forms.py:342
 #, python-format
 msgid "<strong>%s</strong> &middot; %s &middot; %s"
 msgstr "<strong>%s</strong> &middot; %s &middot; %s"
 
-#: src/olympia/editors/forms.py:252
+#: src/olympia/editors/forms.py:356
 msgid "Comments:"
 msgstr "Yorumlar:"
 
-#: src/olympia/editors/forms.py:256
+#: src/olympia/editors/forms.py:360
 msgid "Operating systems:"
 msgstr "İşletim sistemleri:"
 
-#: src/olympia/editors/forms.py:258
+#: src/olympia/editors/forms.py:362
 msgid "Applications:"
 msgstr "Uygulamalar:"
 
-#: src/olympia/editors/forms.py:260
+#: src/olympia/editors/forms.py:364
 #, fuzzy
 msgid "Notify me the next time this add-on is updated. (Subsequent updates will not generate an email)"
 msgstr "Notify me the next time this add-on is updated. (Subsequent updates will not generate an email)"
 
-#: src/olympia/editors/forms.py:265
+#: src/olympia/editors/forms.py:369
 msgid "Clear Admin Review Flag"
 msgstr ""
 
-#: src/olympia/editors/forms.py:267
+#: src/olympia/editors/forms.py:371
 msgid "Clear more info requested flag"
 msgstr ""
 
-#: src/olympia/editors/forms.py:281
+#: src/olympia/editors/forms.py:385
 msgid "Choose a canned response..."
 msgstr ""
 
 #. L10n: Description of what can be searched for.
-#: src/olympia/editors/forms.py:324
+#: src/olympia/editors/forms.py:423
 msgid "theme name"
 msgstr "tema adı"
 
-#: src/olympia/editors/forms.py:350
+#: src/olympia/editors/forms.py:449
 msgid "Someone else is reviewing this theme."
 msgstr ""
 
 #. L10n: Description of what can be searched for.
-#: src/olympia/editors/forms.py:447
+#: src/olympia/editors/forms.py:546
 msgid "app, reviewer, or comment"
 msgstr ""
 
@@ -7476,185 +7357,214 @@ msgstr ""
 msgid "Rejected or Unreviewed"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:123 src/olympia/editors/helpers.py:136
+#: src/olympia/editors/helpers.py:125 src/olympia/editors/helpers.py:138
 msgid "Queue"
 msgstr "Kuyruk"
 
-#: src/olympia/editors/helpers.py:124 src/olympia/editors/templates/editors/base.html:50 src/olympia/editors/templates/editors/base.html:65
+#: src/olympia/editors/helpers.py:126 src/olympia/editors/templates/editors/base.html:50 src/olympia/editors/templates/editors/base.html:65
 msgid "Pending Updates"
 msgstr "Bekleyen güncelemeler"
 
-#: src/olympia/editors/helpers.py:125 src/olympia/editors/templates/editors/base.html:48 src/olympia/editors/templates/editors/base.html:63
+#: src/olympia/editors/helpers.py:127 src/olympia/editors/templates/editors/base.html:48 src/olympia/editors/templates/editors/base.html:63
 msgid "Full Reviews"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:126 src/olympia/editors/templates/editors/base.html:52 src/olympia/editors/templates/editors/base.html:67
+#: src/olympia/editors/helpers.py:128 src/olympia/editors/templates/editors/base.html:52 src/olympia/editors/templates/editors/base.html:67
 msgid "Preliminary Reviews"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:127 src/olympia/editors/templates/editors/base.html:54
+#: src/olympia/editors/helpers.py:129 src/olympia/editors/templates/editors/base.html:54
 msgid "Moderated Reviews"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:128 src/olympia/editors/templates/editors/base.html:46
+#: src/olympia/editors/helpers.py:130 src/olympia/editors/templates/editors/base.html:46
 msgid "Fast Track"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:130
+#: src/olympia/editors/helpers.py:132
 msgid "Pending Themes"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:131 src/olympia/editors/templates/editors/themes/queue.html:4
+#: src/olympia/editors/helpers.py:133 src/olympia/editors/templates/editors/themes/queue.html:4
 msgid "Flagged Themes"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:132
+#: src/olympia/editors/helpers.py:134
 msgid "Update Themes"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:137
+#: src/olympia/editors/helpers.py:139
 msgid "Unlisted Pending Updates"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:138
+#: src/olympia/editors/helpers.py:140
 msgid "Unlisted Full Reviews"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:139
+#: src/olympia/editors/helpers.py:141
 msgid "Unlisted Preliminary Reviews"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:170
+#: src/olympia/editors/helpers.py:142
+msgid "Unlisted All Add-ons"
+msgstr ""
+
+#: src/olympia/editors/helpers.py:173
 msgid "Fast Track ({0})"
 msgid_plural "Fast Track ({0})"
 msgstr[0] ""
+msgstr[1] ""
 
-#: src/olympia/editors/helpers.py:175
+#: src/olympia/editors/helpers.py:178
 msgid "Full Review ({0})"
 msgid_plural "Full Reviews ({0})"
 msgstr[0] ""
+msgstr[1] ""
 
-#: src/olympia/editors/helpers.py:180
+#: src/olympia/editors/helpers.py:183
 msgid "Pending Update ({0})"
 msgid_plural "Pending Updates ({0})"
 msgstr[0] ""
+msgstr[1] ""
 
-#: src/olympia/editors/helpers.py:185
+#: src/olympia/editors/helpers.py:188
 msgid "Preliminary Review ({0})"
 msgid_plural "Preliminary Reviews ({0})"
 msgstr[0] ""
+msgstr[1] ""
 
-#: src/olympia/editors/helpers.py:190
+#: src/olympia/editors/helpers.py:193
 msgid "Moderated Review ({0})"
 msgid_plural "Moderated Reviews ({0})"
 msgstr[0] ""
+msgstr[1] ""
 
-#: src/olympia/editors/helpers.py:196
+#: src/olympia/editors/helpers.py:199
 msgid "Unlisted Full Review ({0})"
 msgid_plural "Unlisted Full Reviews ({0})"
 msgstr[0] ""
+msgstr[1] ""
 
-#: src/olympia/editors/helpers.py:201
+#: src/olympia/editors/helpers.py:204
 msgid "Unlisted Pending Update ({0})"
 msgid_plural "Unlisted Pending Updates ({0})"
 msgstr[0] ""
+msgstr[1] ""
 
-#: src/olympia/editors/helpers.py:206
+#: src/olympia/editors/helpers.py:209
 msgid "Unlisted Preliminary Review ({0})"
 msgid_plural "Unlisted Preliminary Reviews ({0})"
 msgstr[0] ""
+msgstr[1] ""
 
-#: src/olympia/editors/helpers.py:261
-msgid "Addon"
-msgstr "Eklenti"
+#: src/olympia/editors/helpers.py:214
+msgid "Unlisted All Add-ons ({0})"
+msgid_plural "Unlisted All Add-ons ({0})"
+msgstr[0] ""
+msgstr[1] ""
 
-#: src/olympia/editors/helpers.py:262
+#: src/olympia/editors/helpers.py:274
 msgid "Type"
 msgstr "Türü"
 
-#: src/olympia/editors/helpers.py:263
+#: src/olympia/editors/helpers.py:275
 msgid "Waiting Time"
 msgstr "Bekleme süresi"
 
-#: src/olympia/editors/helpers.py:264 src/olympia/editors/templates/editors/review.html:285
+#: src/olympia/editors/helpers.py:276 src/olympia/editors/templates/editors/review.html:285
 #, fuzzy
 msgid "Flags"
 msgstr "Flags"
 
 # 92%
 # 100%
-#: src/olympia/editors/helpers.py:265
+#: src/olympia/editors/helpers.py:277
 msgid "Applications"
 msgstr "Uygulamalar"
 
-#: src/olympia/editors/helpers.py:270
+#: src/olympia/editors/helpers.py:282
 msgid "Additional"
 msgstr "Ek"
 
-#: src/olympia/editors/helpers.py:285
+#: src/olympia/editors/helpers.py:302
 msgid "Site Specific"
 msgstr "Site Specific"
 
-#: src/olympia/editors/helpers.py:287
+#: src/olympia/editors/helpers.py:304
 msgid "Requires External Software"
 msgstr "Harici yazılım gerektirir"
 
-#: src/olympia/editors/helpers.py:289
+#: src/olympia/editors/helpers.py:306
 msgid "Binary Components"
 msgstr "İkili bileşenler"
 
-#: src/olympia/editors/helpers.py:313
+#: src/olympia/editors/helpers.py:339
 msgid "moments ago"
 msgstr ""
 
 #. L10n: first argument is number of minutes
-#: src/olympia/editors/helpers.py:316
+#: src/olympia/editors/helpers.py:342
 msgid "{0} minute"
 msgid_plural "{0} minutes"
 msgstr[0] "{0} dakika"
+msgstr[1] ""
 
 #. L10n: first argument is number of hours
-#: src/olympia/editors/helpers.py:320
+#: src/olympia/editors/helpers.py:346
 msgid "{0} hour"
 msgid_plural "{0} hours"
 msgstr[0] "{0} saat"
+msgstr[1] ""
 
 #. L10n: first argument is number of days
-#: src/olympia/editors/helpers.py:324
+#: src/olympia/editors/helpers.py:350
 msgid "{0} day"
 msgid_plural "{0} days"
 msgstr[0] "{0} gün"
+msgstr[1] ""
 
-#: src/olympia/editors/helpers.py:488
+#: src/olympia/editors/helpers.py:364
+msgid "Last Review"
+msgstr ""
+
+#: src/olympia/editors/helpers.py:366
+msgid "Last Update"
+msgstr ""
+
+#: src/olympia/editors/helpers.py:387
+msgid "No Reviews"
+msgstr ""
+
+#: src/olympia/editors/helpers.py:561
 msgid "Push to public"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:490
+#: src/olympia/editors/helpers.py:563
 msgid "Grant full review"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:505
+#: src/olympia/editors/helpers.py:578
 msgid "Request more information"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:508
+#: src/olympia/editors/helpers.py:581
 msgid "Request super-review"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:519
+#: src/olympia/editors/helpers.py:592
 msgid "Grant preliminary review"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:520
+#: src/olympia/editors/helpers.py:593
 msgid "This will mark the files as preliminarily reviewed."
 msgstr ""
 
-#: src/olympia/editors/helpers.py:522
+#: src/olympia/editors/helpers.py:595
 #, fuzzy
 msgid "Use this form to request more information from the author. They will receive an email and be able to answer here. You will be notified by email when they reply."
 msgstr "Use this form to request more information from the author. They will receive an email and be able to answer here. You will be notified by email when they reply."
 
-#: src/olympia/editors/helpers.py:526
+#: src/olympia/editors/helpers.py:599
 msgid ""
 "If you have concerns about this add-on's security, copyright issues, or other concerns that an administrator should look into, enter your comments in the area below. They will be sent to "
 "administrators, not the author."
@@ -7662,55 +7572,55 @@ msgstr ""
 "If you have concerns about this add-on's security, copyright issues, or other concerns that an administrator should look into, enter your comments in the area below. They will be sent to "
 "administrators, not the author."
 
-#: src/olympia/editors/helpers.py:532
+#: src/olympia/editors/helpers.py:605
 msgid "This will reject the add-on and remove it from the review queue."
 msgstr ""
 
-#: src/olympia/editors/helpers.py:534
-msgid "Make a comment on this version.  The author won't be able to see this."
+#: src/olympia/editors/helpers.py:607
+msgid "Make a comment on this version. The author won't be able to see this."
 msgstr ""
 
-#: src/olympia/editors/helpers.py:538
+#: src/olympia/editors/helpers.py:611
 msgid "This will reject the files and remove them from the review queue."
 msgstr ""
 
-#: src/olympia/editors/helpers.py:542
+#: src/olympia/editors/helpers.py:615
 msgid "This will mark the add-on as preliminarily reviewed. Future versions will undergo preliminary review."
 msgstr ""
 
-#: src/olympia/editors/helpers.py:547
+#: src/olympia/editors/helpers.py:620
 msgid "This will mark the files as preliminarily reviewed. Future versions will undergo preliminary review."
 msgstr ""
 
-#: src/olympia/editors/helpers.py:552
+#: src/olympia/editors/helpers.py:625
 msgid "Retain preliminary review"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:553
+#: src/olympia/editors/helpers.py:626
 msgid "This will retain the add-on as preliminarily reviewed. Future versions will undergo preliminary review."
 msgstr ""
 
-#: src/olympia/editors/helpers.py:558
+#: src/olympia/editors/helpers.py:631
 msgid "This will approve a sandboxed version of a public add-on to appear on the public side."
 msgstr "This will approve a sandboxed version of a public add-on to appear on the public side."
 
-#: src/olympia/editors/helpers.py:561
+#: src/olympia/editors/helpers.py:634
 msgid "This will reject a version of a public add-on and remove it from the queue."
 msgstr ""
 
-#: src/olympia/editors/helpers.py:564
+#: src/olympia/editors/helpers.py:637
 msgid "This will mark the add-on and its most recent version and files as public. Future versions will go into the sandbox until they are reviewed by an editor."
 msgstr "This will mark the add-on and its most recent version and files as public. Future versions will go into the sandbox until they are reviewed by an editor."
 
-#: src/olympia/editors/helpers.py:637
+#: src/olympia/editors/helpers.py:714
 msgid "add-on"
 msgstr "eklenti"
 
-#: src/olympia/editors/helpers.py:940 src/olympia/editors/helpers.py:960
+#: src/olympia/editors/helpers.py:1020 src/olympia/editors/helpers.py:1040
 msgid "Flagged"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:944 src/olympia/editors/helpers.py:963
+#: src/olympia/editors/helpers.py:1024 src/olympia/editors/helpers.py:1043
 msgid "Updates"
 msgstr "Güncellemeler"
 
@@ -7762,56 +7672,56 @@ msgstr ""
 msgid "A question about your Theme submission"
 msgstr ""
 
-#: src/olympia/editors/views.py:144
+#: src/olympia/editors/views.py:146
 msgid "New Add-ons (Under 5 days)"
 msgstr ""
 
-#: src/olympia/editors/views.py:145
+#: src/olympia/editors/views.py:147
 msgid "Passable (5 to 10 days)"
 msgstr ""
 
-#: src/olympia/editors/views.py:146
+#: src/olympia/editors/views.py:148
 msgid "Overdue (Over 10 days)"
 msgstr ""
 
-#: src/olympia/editors/views.py:532
+#: src/olympia/editors/views.py:539
 msgid "An unknown error occurred"
 msgstr ""
 
-#: src/olympia/editors/views.py:587
+#: src/olympia/editors/views.py:592
 msgid "Self-reviews are not allowed."
 msgstr "Self-reviews are not allowed."
 
-#: src/olympia/editors/views.py:609
+#: src/olympia/editors/views.py:613
 msgid "Review successfully processed."
 msgstr "Review successfully processed."
 
-#: src/olympia/editors/views.py:807
+#: src/olympia/editors/views.py:812
 msgid "was approved"
 msgstr ""
 
-#: src/olympia/editors/views.py:808
+#: src/olympia/editors/views.py:813
 msgid "given preliminary review"
 msgstr ""
 
-#: src/olympia/editors/views.py:809
+#: src/olympia/editors/views.py:814
 msgid "rejected"
 msgstr "reddedildi"
 
-#: src/olympia/editors/views.py:810
+#: src/olympia/editors/views.py:815
 msgctxt "editors_review_history_nominated_adminreview"
 msgid "escalated"
 msgstr ""
 
-#: src/olympia/editors/views.py:812
+#: src/olympia/editors/views.py:817
 msgid "needs more information"
 msgstr "daha fazla bilgi gerekiyor"
 
-#: src/olympia/editors/views.py:813
+#: src/olympia/editors/views.py:818
 msgid "needs super review"
 msgstr ""
 
-#: src/olympia/editors/views.py:814
+#: src/olympia/editors/views.py:819
 msgid "commented"
 msgstr "yorumlandı"
 
@@ -7819,6 +7729,7 @@ msgstr "yorumlandı"
 msgid "{0} theme review successfully processed (+{1} points, {2} total)."
 msgid_plural "{0} theme reviews successfully processed (+{1} points, {2} total)."
 msgstr[0] ""
+msgstr[1] ""
 
 #: src/olympia/editors/views_themes.py:341
 msgid "Your theme locks have successfully been released. Other reviewers may now review those released themes. You may have to refresh the page to see the changes reflected in the table below."
@@ -7855,28 +7766,28 @@ msgstr ""
 msgid "Unlisted Queues"
 msgstr ""
 
-#: src/olympia/editors/templates/editors/base.html:72 src/olympia/editors/templates/editors/performance.html:6
+#: src/olympia/editors/templates/editors/base.html:74 src/olympia/editors/templates/editors/performance.html:6
 msgid "Performance"
 msgstr "Performans"
 
-#: src/olympia/editors/templates/editors/base.html:75 src/olympia/editors/templates/editors/themes/base.html:19 src/olympia/editors/templates/editors/themes/base.html:38
+#: src/olympia/editors/templates/editors/base.html:77 src/olympia/editors/templates/editors/themes/base.html:19 src/olympia/editors/templates/editors/themes/base.html:38
 msgid "Logs"
 msgstr ""
 
-#: src/olympia/editors/templates/editors/base.html:78 src/olympia/editors/templates/editors/reviewlog.html:4 src/olympia/editors/templates/editors/reviewlog.html:27
+#: src/olympia/editors/templates/editors/base.html:80 src/olympia/editors/templates/editors/reviewlog.html:4 src/olympia/editors/templates/editors/reviewlog.html:27
 msgid "Add-on Review Log"
 msgstr ""
 
-#: src/olympia/editors/templates/editors/base.html:80 src/olympia/editors/templates/editors/eventlog.html:4 src/olympia/editors/templates/editors/eventlog.html:8
+#: src/olympia/editors/templates/editors/base.html:82 src/olympia/editors/templates/editors/eventlog.html:4 src/olympia/editors/templates/editors/eventlog.html:8
 #: src/olympia/editors/templates/editors/eventlog_detail.html:4
 msgid "Moderated Review Log"
 msgstr ""
 
-#: src/olympia/editors/templates/editors/base.html:82 src/olympia/editors/templates/editors/beta_signed_log.html:4 src/olympia/editors/templates/editors/beta_signed_log.html:8
+#: src/olympia/editors/templates/editors/base.html:84 src/olympia/editors/templates/editors/beta_signed_log.html:4 src/olympia/editors/templates/editors/beta_signed_log.html:8
 msgid "Signed Beta Files Log"
 msgstr ""
 
-#: src/olympia/editors/templates/editors/base.html:87 src/olympia/editors/templates/editors/includes/daily-message.html:4
+#: src/olympia/editors/templates/editors/base.html:89 src/olympia/editors/templates/editors/includes/daily-message.html:4
 msgid "Announcement"
 msgstr "Duyuru"
 
@@ -7936,16 +7847,19 @@ msgstr "Silmeyi geri al"
 msgid "Full Review ({num})"
 msgid_plural "Full Reviews ({num})"
 msgstr[0] ""
+msgstr[1] ""
 
 #: src/olympia/editors/templates/editors/home.html:18
 msgid "Pending Update ({num})"
 msgid_plural "Pending Updates ({num})"
 msgstr[0] ""
+msgstr[1] ""
 
 #: src/olympia/editors/templates/editors/home.html:25
 msgid "Preliminary Review ({num})"
 msgid_plural "Preliminary Reviews ({num})"
 msgstr[0] ""
+msgstr[1] ""
 
 #: src/olympia/editors/templates/editors/home.html:36 src/olympia/editors/templates/editors/home.html:86
 msgid "Current waiting times:"
@@ -7955,6 +7869,7 @@ msgstr ""
 msgid "{0} add-on"
 msgid_plural "{0} add-ons"
 msgstr[0] ""
+msgstr[1] ""
 
 #: src/olympia/editors/templates/editors/home.html:45 src/olympia/editors/templates/editors/home.html:95
 #, python-format
@@ -7965,16 +7880,19 @@ msgstr ""
 msgid "Unlisted Full Review ({num})"
 msgid_plural "Unlisted Full Reviews ({num})"
 msgstr[0] ""
+msgstr[1] ""
 
 #: src/olympia/editors/templates/editors/home.html:68
 msgid "Unlisted Pending Update ({num})"
 msgid_plural "Unlisted Pending Updates ({num})"
 msgstr[0] ""
+msgstr[1] ""
 
 #: src/olympia/editors/templates/editors/home.html:75
 msgid "Unlisted Preliminary Review ({num})"
 msgid_plural "Unlisted Preliminary Reviews ({num})"
 msgstr[0] ""
+msgstr[1] ""
 
 #: src/olympia/editors/templates/editors/home.html:109 src/olympia/editors/templates/editors/performance.html:37 src/olympia/editors/templates/editors/themes/home.html:54
 #, fuzzy
@@ -7998,6 +7916,7 @@ msgstr ""
 msgid "Moderated Review ({num})"
 msgid_plural "Moderated Reviews ({num})"
 msgstr[0] ""
+msgstr[1] ""
 
 #: src/olympia/editors/templates/editors/leaderboard.html:3 src/olympia/editors/templates/editors/includes/reviewers_score_bar.html:56
 msgid "Reviewer Leaderboard"
@@ -8091,45 +8010,45 @@ msgstr "Gelişmiş arama"
 msgid "clear search"
 msgstr "aramayı temizle"
 
-#: src/olympia/editors/templates/editors/queue.html:72 src/olympia/editors/templates/editors/queue.html:122
+#: src/olympia/editors/templates/editors/queue.html:78 src/olympia/editors/templates/editors/queue.html:128
 msgid "Process Reviews"
 msgstr "Denetim işlemi"
 
-#: src/olympia/editors/templates/editors/queue.html:80
+#: src/olympia/editors/templates/editors/queue.html:86
 msgid "Moderation actions:"
 msgstr ""
 
-#: src/olympia/editors/templates/editors/queue.html:90
+#: src/olympia/editors/templates/editors/queue.html:96
 #, python-format
 msgid "by %(user)s on %(date)s %(stars)s (%(locale)s)"
 msgstr ""
 
-#: src/olympia/editors/templates/editors/queue.html:106
+#: src/olympia/editors/templates/editors/queue.html:112
 #, python-format
 msgid "<strong>%(reason)s</strong> <span class=\"light\">Flagged by %(user)s on %(date)s</span>"
 msgstr ""
 
-#: src/olympia/editors/templates/editors/queue.html:119
-msgid "All reviews have been moderated.  Good work!"
+#: src/olympia/editors/templates/editors/queue.html:125
+msgid "All reviews have been moderated. Good work!"
 msgstr ""
 
-#: src/olympia/editors/templates/editors/queue.html:161
+#: src/olympia/editors/templates/editors/queue.html:167
 msgid "Version Notes / Notes for Reviewer"
 msgstr ""
 
-#: src/olympia/editors/templates/editors/queue.html:169
+#: src/olympia/editors/templates/editors/queue.html:175
 msgid "There are currently no add-ons of this type to review."
 msgstr ""
 
-#: src/olympia/editors/templates/editors/queue.html:181 src/olympia/editors/templates/editors/themes/queue_list.html:85
+#: src/olympia/editors/templates/editors/queue.html:187 src/olympia/editors/templates/editors/themes/queue_list.html:85
 msgid "Helpful Links:"
 msgstr "İşe Yarar Bağlantılar:"
 
-#: src/olympia/editors/templates/editors/queue.html:182
+#: src/olympia/editors/templates/editors/queue.html:188
 msgid "Add-on Policy"
 msgstr "Eklenti Politikası"
 
-#: src/olympia/editors/templates/editors/queue.html:184
+#: src/olympia/editors/templates/editors/queue.html:190
 msgid "Editors' Guide"
 msgstr "Editör Rehberi"
 
@@ -8192,10 +8111,7 @@ msgid "<strong>Warning!</strong> Another user was viewing this page before you."
 msgstr ""
 
 #: src/olympia/editors/templates/editors/review.html:237
-msgid ""
-"The whiteboard is the place to exchange information relevant to\n"
-"               this addon (whatever the version), between the developer and the\n"
-"               editor. This is visible and editable by both."
+msgid "The whiteboard is the place to exchange information relevant to this addon (whatever the version), between the developer and the editor. This is visible and editable by both."
 msgstr ""
 
 #: src/olympia/editors/templates/editors/review.html:241
@@ -8339,16 +8255,19 @@ msgstr "Şu an için hiçbir inceleme yok."
 msgid "{num} Pending Theme Review"
 msgid_plural "{num} Pending Theme Reviews"
 msgstr[0] "Bekleyen {num} Tema İncelemesi"
+msgstr[1] ""
 
 #: src/olympia/editors/templates/editors/themes/home.html:27
 msgid "{num} Flagged Review"
 msgid_plural "{num} Flagged Reviews"
 msgstr[0] "İşaretlenmiş {num} İnceleme"
+msgstr[1] ""
 
 #: src/olympia/editors/templates/editors/themes/home.html:34
 msgid "{num} Update"
 msgid_plural "{num} Updates"
 msgstr[0] "{num} Güncelleme"
+msgstr[1] ""
 
 #: src/olympia/editors/templates/editors/themes/logs.html:4
 msgid "Theme Review Log"
@@ -8467,7 +8386,7 @@ msgstr ""
 msgid "Describe your reason for flagging"
 msgstr ""
 
-#: src/olympia/files/forms.py:88
+#: src/olympia/files/forms.py:90
 msgid "Cannot diff a version against itself"
 msgstr ""
 
@@ -8502,51 +8421,51 @@ msgstr ""
 msgid "There was an error accessing file %s."
 msgstr ""
 
-#: src/olympia/files/utils.py:343
+#: src/olympia/files/utils.py:340
 msgid "Could not parse uploaded file."
 msgstr ""
 
-#: src/olympia/files/utils.py:380
+#: src/olympia/files/utils.py:377
 msgid "Invalid file name in archive: {0}"
 msgstr ""
 
-#: src/olympia/files/utils.py:388
+#: src/olympia/files/utils.py:385
 msgid "File exceeding size limit in archive: {0}"
 msgstr ""
 
-#: src/olympia/files/utils.py:439
+#: src/olympia/files/utils.py:436
 msgid "Invalid archive."
 msgstr ""
 
-#: src/olympia/files/utils.py:529 src/olympia/files/utils.py:532
+#: src/olympia/files/utils.py:526 src/olympia/files/utils.py:529
 msgid "Could not parse the manifest file."
 msgstr ""
 
-#: src/olympia/files/utils.py:551
+#: src/olympia/files/utils.py:548
 msgid "Could not find an add-on ID."
 msgstr "Eklenti kimliği bulunamadı."
 
-#: src/olympia/files/utils.py:554
+#: src/olympia/files/utils.py:551
 msgid "Add-on ID must be 64 characters or less."
 msgstr "Eklenti kimliği 64 veya daha az karakterli olmalı."
 
-#: src/olympia/files/utils.py:556
+#: src/olympia/files/utils.py:553
 msgid "Add-on ID doesn't match add-on."
 msgstr "Eklenti kimliği eklenti ile eşleşmiyor."
 
-#: src/olympia/files/utils.py:564
+#: src/olympia/files/utils.py:561
 msgid "Duplicate add-on ID found."
 msgstr "Mükerrer eklenti kimliği tespit edildi."
 
-#: src/olympia/files/utils.py:567
+#: src/olympia/files/utils.py:564
 msgid "Version numbers should have fewer than 32 characters."
 msgstr "Sürüm numaraları 32'den az karakterli olmalı."
 
-#: src/olympia/files/utils.py:570
+#: src/olympia/files/utils.py:567
 msgid "Version numbers should only contain letters, numbers, and these punctuation characters: +*.-_."
 msgstr "Sürüm numaralarında sadece harfler, numaralar ve bu noktalama işaretleri olmalı: +*.-_."
 
-#: src/olympia/files/utils.py:587
+#: src/olympia/files/utils.py:584
 msgid "<em:type> doesn't match add-on"
 msgstr "<em:type> eklentiyle uyuşmuyor"
 
@@ -8646,6 +8565,10 @@ msgstr ""
 #: src/olympia/files/templates/files/viewer.html:134
 msgid "Fetching file."
 msgstr ""
+
+#: src/olympia/legacy_api/views.py:255
+msgid "Not implemented yet."
+msgstr "Henüz hazır değil."
 
 #: src/olympia/lib/constants.py:6
 msgid "United Arab Emirates Dirham"
@@ -9303,10 +9226,6 @@ msgstr ""
 msgid "Zimbabwe Dollar"
 msgstr ""
 
-#: src/olympia/lib/video/ffmpeg.py:112 src/olympia/lib/video/totem.py:81
-msgid "Videos must be in WebM."
-msgstr ""
-
 #: src/olympia/pages/templates/pages/about.lhtml:3 src/olympia/pages/templates/pages/about.lhtml:10
 msgid "About Mozilla Add-ons"
 msgstr "Mozilla Eklentileri Hakkında"
@@ -9318,7 +9237,7 @@ msgstr "Bu site ne için var?"
 #: src/olympia/pages/templates/pages/about.lhtml:13
 msgid ""
 "addons.mozilla.org, commonly known as \"AMO\", is Mozilla's official site for add-ons to Mozilla software, such as Firefox, Thunderbird, and SeaMonkey. Add-ons let you add new features and change "
-"the way your browser or application works.  Take a look around and explore the thousands of ways to customize the way you do things online."
+"the way your browser or application works. Take a look around and explore the thousands of ways to customize the way you do things online."
 msgstr ""
 
 #: src/olympia/pages/templates/pages/about.lhtml:19
@@ -9663,7 +9582,7 @@ msgstr ""
 msgid ""
 "Yes. It's possible, but some of the functionality provided by these libraries are available through XPCOM, XUL, and JavaScript. In addition, authors should take care if libraries modify primitive "
 "object prototypes (String.prototype, Date.prototype, etc.) and/or define global functions (eg. the $ function). These are prone to cause conflict with other add-ons, in particular if different add-"
-"ons use different versions of libraries and so on. Developers need to be very, very careful with using them.  Mozilla does not offer documentation on using them to build add-ons."
+"ons use different versions of libraries and so on. Developers need to be very, very careful with using them. Mozilla does not offer documentation on using them to build add-ons."
 msgstr ""
 
 #: src/olympia/pages/templates/pages/dev_faq.html:165
@@ -9777,8 +9696,8 @@ msgstr "Kendi eklentimi barındırabilir miyim?"
 #, python-format
 msgid ""
 "Yes. Many developers choose to host their own add-ons. Choosing to host your add-on on <a href=\"%(amo_url)s\">Mozilla's add-on site</a>, though, allows for much greater exposure to your add-on due "
-"to the large volume of visitors to the site.  <a href=\"%(md_url)s\">mozdev.org</a> offers free project hosting for Mozilla applications and extensions providing developers with tools to help "
-"manage source code, version control, bug tracking and documentation."
+"to the large volume of visitors to the site. <a href=\"%(md_url)s\">mozdev.org</a> offers free project hosting for Mozilla applications and extensions providing developers with tools to help manage "
+"source code, version control, bug tracking and documentation."
 msgstr ""
 
 #: src/olympia/pages/templates/pages/dev_faq.html:277
@@ -9826,7 +9745,7 @@ msgstr ""
 #: src/olympia/pages/templates/pages/dev_faq.html:314
 #, python-format
 msgid ""
-"Yes. Mozilla's <a href=\"%(p_url)s\">Add-on Policy</a> describes what is an acceptable submission. This policy is subject to change without notice.  In addition, the AMO editorial team uses the <a "
+"Yes. Mozilla's <a href=\"%(p_url)s\">Add-on Policy</a> describes what is an acceptable submission. This policy is subject to change without notice. In addition, the AMO editorial team uses the <a "
 "href=\"%(g_url)s\">Editors Reviewing Guide</a> to ensure that your add-on meets specific guidelines for functionality and security."
 msgstr ""
 
@@ -9943,7 +9862,7 @@ msgstr ""
 #: src/olympia/pages/templates/pages/dev_faq.html:434
 #, python-format
 msgid ""
-"This is why it's very important to read the <a href=\"%(g_url)s\">Editors Reviewing Guide</a> to ensure that your add-on is setup as expected.  It's also a good idea to read the blog post, <a href="
+"This is why it's very important to read the <a href=\"%(g_url)s\">Editors Reviewing Guide</a> to ensure that your add-on is setup as expected. It's also a good idea to read the blog post, <a href="
 "\"%(blog_url)s\">Successfully Getting your Add-on Reviewed</a> which provides excellent insight into ensuring a smooth review of your add-on."
 msgstr ""
 
@@ -10053,7 +9972,7 @@ msgstr ""
 
 #: src/olympia/pages/templates/pages/dev_faq.html:572
 msgid ""
-"Free Software Foundation provides short summaries of the key open source licenses, including whether the license qualifies as a free software license or a copyleft license.  Also includes a "
+"Free Software Foundation provides short summaries of the key open source licenses, including whether the license qualifies as a free software license or a copyleft license. Also includes a "
 "discussion of what constitutes a free software license or a copyleft license (e.g., a Copyleft license is a general method for making a program or other work free, and requiring all modified and "
 "extended versions of the program to be free as well.)"
 msgstr ""
@@ -10231,19 +10150,13 @@ msgid "Add-on Gallery"
 msgstr ""
 
 #: src/olympia/pages/templates/pages/faq.html:171
-msgid ""
-"How do I choose between add-ons that seem to do the same\n"
-"    thing?"
+msgid "How do I choose between add-ons that seem to do the same thing?"
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:173
+#: src/olympia/pages/templates/pages/faq.html:172
 msgid ""
-"There are often several add-ons that have similar features. To\n"
-"    figure out which is right for you, read the entire description of the\n"
-"    add-on and view its screenshots. If there are still several in the running,\n"
-"    read through the add-on's ratings, user reviews, and statistics to see\n"
-"    which is most liked by other users. Remember that you can also just try\n"
-"    out both and see which you like better."
+"There are often several add-ons that have similar features. To figure out which is right for you, read the entire description of the add-on and view its screenshots. If there are still several in "
+"the running, read through the add-on's ratings, user reviews, and statistics to see which is most liked by other users. Remember that you can also just try out both and see which you like better."
 msgstr ""
 
 #: src/olympia/pages/templates/pages/faq.html:180
@@ -10284,80 +10197,67 @@ msgid "How much do add-ons cost to purchase?"
 msgstr ""
 
 #: src/olympia/pages/templates/pages/faq.html:207
-msgid ""
-"Add-ons hosted in our gallery are free unless clearly marked\n"
-"    otherwise."
+msgid "Add-ons hosted in our gallery are free unless clearly marked otherwise."
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:210
+#: src/olympia/pages/templates/pages/faq.html:209
 msgid "What does it mean when an add-on asks for contributions?"
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:211
+#: src/olympia/pages/templates/pages/faq.html:210
 msgid ""
-"Some add-on authors request users who enjoy an add-on to\n"
-"        contribute to its development by making a monetary contribution. These\n"
-"        contributions go directly to the developer unless a third party is\n"
-"        indicated, such as the non-profit Mozilla Foundation."
+"Some add-on authors request users who enjoy an add-on to contribute to its development by making a monetary contribution. These contributions go directly to the developer unless a third party is "
+"indicated, such as the non-profit Mozilla Foundation."
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:216
+#: src/olympia/pages/templates/pages/faq.html:215
 msgid "What are beta add-ons?"
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:218
+#: src/olympia/pages/templates/pages/faq.html:217
 msgid ""
-"Beta add-ons are unreviewed versions which represent the\n"
-"        latest work of an add-on author. While different authors have different\n"
-"        standards for beta code quality, you should assume that these add-ons\n"
-"        are less stable than the general add-on releases."
+"Beta add-ons are unreviewed versions which represent the latest work of an add-on author. While different authors have different standards for beta code quality, you should assume that these add-"
+"ons are less stable than the general add-on releases."
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:222
+#: src/olympia/pages/templates/pages/faq.html:221
 msgid ""
 "Please note that when you install an add-on from the \"Beta Version\" section of an add-on's listing, you will continue to receive updates for that add-on as they become available. Like the initial "
 "version you installed, all beta releases are unreviewed by Mozilla and may harm your computer."
 msgstr ""
 
+#: src/olympia/pages/templates/pages/faq.html:228
+msgid "What does it mean when an add-on is flagged as slow?"
+msgstr ""
+
 #: src/olympia/pages/templates/pages/faq.html:229
-msgid ""
-"What does it mean when an add-on is flagged as\n"
-"    slow?"
+msgid "Most add-ons load code and resources at the same time Firefox is starting up. In most cases the impact in start-up time is minimal, but some add-ons can cause a noticeable slowdown."
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:231
-msgid ""
-"Most add-ons load code and resources at the same time Firefox\n"
-"        is starting up. In most cases the impact in start-up time is minimal,\n"
-"        but some add-ons can cause a noticeable slowdown."
-msgstr ""
-
-#: src/olympia/pages/templates/pages/faq.html:236
+#: src/olympia/pages/templates/pages/faq.html:234
 msgid "How do I report an inappropriate or spam user review?"
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:237
+#: src/olympia/pages/templates/pages/faq.html:235
 msgid ""
-"To report a user review of an add-on, log in with your account\n"
-"    and visit the add-on's reviews page. Find the review you wish to report,\n"
-"    click \"Report this review\" and select a reason. Our editorial team will\n"
-"    investigate the review and take appropriate action."
+"To report a user review of an add-on, log in with your account and visit the add-on's reviews page. Find the review you wish to report, click \"Report this review\" and select a reason. Our "
+"editorial team will investigate the review and take appropriate action."
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:242
+#: src/olympia/pages/templates/pages/faq.html:240
 msgid "How do I report a bug or contact the Mozilla Add-ons team?"
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:243
+#: src/olympia/pages/templates/pages/faq.html:241
 #, python-format
 msgid "Please visit our <a href=\"%(contact_url)s\">Contact page</a>."
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:246
+#: src/olympia/pages/templates/pages/faq.html:244
 msgid "What is a Source Code License?"
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:247
+#: src/olympia/pages/templates/pages/faq.html:245
 #, python-format
 msgid ""
 "The source code used to create an add-on is an exclusive copyright of the add-on author, unless otherwise declared in a source code license. Many add-ons on this site have <a href=\"%(url)s\" lang="
@@ -10365,63 +10265,63 @@ msgid ""
 "the GPL or BSD licenses instead of making up their own."
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:256
+#: src/olympia/pages/templates/pages/faq.html:254
 #, python-format
 msgid "Firefox and other Mozilla software are <a href=\"%(url)s\">open source</a>."
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:264
+#: src/olympia/pages/templates/pages/faq.html:262
 msgid "Collections and Favorites"
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:267
+#: src/olympia/pages/templates/pages/faq.html:265
 msgid "What is a collection?"
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:268
+#: src/olympia/pages/templates/pages/faq.html:266
 msgid "Collections are groups of related add-ons created by users to share."
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:270
+#: src/olympia/pages/templates/pages/faq.html:268
 msgid "What is the My Favorites collection?"
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:271
+#: src/olympia/pages/templates/pages/faq.html:269
 msgid "Favorite add-ons are add-ons that you have bookmarked to easily get back to later. You can add an add-on to your favorites collection by clicking \"Add to favorites\" on its details page."
 msgstr ""
 
 # 75%
 # 78%
 # 100%
-#: src/olympia/pages/templates/pages/faq.html:275 src/olympia/templates/menu_links.html:13 src/olympia/templates/impala/header_title.html:17
+#: src/olympia/pages/templates/pages/faq.html:273 src/olympia/templates/menu_links.html:13 src/olympia/templates/impala/header_title.html:17
 msgid "Mobile Add-ons"
 msgstr "Mobil Eklentiler"
 
-#: src/olympia/pages/templates/pages/faq.html:278
+#: src/olympia/pages/templates/pages/faq.html:276
 msgid "What are mobile add-ons?"
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:279
+#: src/olympia/pages/templates/pages/faq.html:277
 #, python-format
 msgid ""
 "Mobile add-ons work with <a href=\"%(mobile_url)s\">Firefox for Mobile</a> and add or modify functionality just like desktop add-ons. You can find add-ons that work with Firefox for Mobile in our "
 "<a href=\"%(gallery_url)s\">gallery</a>."
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:288
+#: src/olympia/pages/templates/pages/faq.html:286
 msgid "Developer Topics"
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:289
+#: src/olympia/pages/templates/pages/faq.html:287
 #, python-format
 msgid "Please see our <a href=\"%(faq_url)s\">Developer FAQ</a> and <a href=\"%(hub_url)s\">Developer Hub</a> for answers to add-on developer-related questions."
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:294
+#: src/olympia/pages/templates/pages/faq.html:292
 msgid "Still have questions?"
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:295
+#: src/olympia/pages/templates/pages/faq.html:293
 #, python-format
 msgid "For general Firefox support, visit our <a href=\"%(sumo_url)s\">support website</a>. For general add-on and website questions, visit our <a href=\"%(forum_url)s\">forum</a>."
 msgstr ""
@@ -10559,7 +10459,7 @@ msgstr ""
 
 #: src/olympia/pages/templates/pages/sunbird.html:29
 msgid ""
-"Development on the Sunbird project has halted and its final release was on March 30, 2010.  We've been proud to host Sunbird add-ons on this site but as the project is no longer maintained we have "
+"Development on the Sunbird project has halted and its final release was on March 30, 2010. We've been proud to host Sunbird add-ons on this site but as the project is no longer maintained we have "
 "disabled our support for the add-ons."
 msgstr ""
 
@@ -10642,7 +10542,7 @@ msgstr ""
 #, python-format
 msgid ""
 "<h2>Keep these tips in mind:</h2> <ul> <li> Write like you're telling a friend about your experience with the add-on. Give specifics and helpful details, such as what features you liked and/or "
-"disliked, how easy to use it is, and any disadvantages it has.  Avoid generic language such as calling it \"Great\" or \"Bad\" unless you can give reasons why you believe this is so. </li> <li> "
+"disliked, how easy to use it is, and any disadvantages it has. Avoid generic language such as calling it \"Great\" or \"Bad\" unless you can give reasons why you believe this is so. </li> <li> "
 "Please do not post bug reports in reviews. We do not make your email address available to add-on developers and they may need to contact you to help resolve your issue. See the <a href=\"%(support)s"
 "\">support section</a> to find out where to get assistance for this add-on. </li> <li>Please keep reviews clean, avoid the use of improper language and do not post any personal information. </li> </"
 "ul> <p>Please read the <a href=\"%(guide)s\" target=\"_blank\">Review Guidelines</a> for more detail about user add-on reviews.</p>"
@@ -10689,6 +10589,7 @@ msgstr ""
 msgid "This user has a <a href=\"%(user_review_url)s\">previous review</a> of this add-on."
 msgid_plural "This user has <a href=\"%(user_review_url)s\">%(cnt)s previous reviews</a> of this add-on."
 msgstr[0] ""
+msgstr[1] ""
 
 #: src/olympia/reviews/templates/reviews/review.html:62
 #, python-format
@@ -10735,6 +10636,7 @@ msgstr ""
 msgid "<b>{0}</b> review for this add-on"
 msgid_plural "<b>{0}</b> reviews for this add-on"
 msgstr[0] ""
+msgstr[1] ""
 
 #. {0} is a developer's name.
 #: src/olympia/reviews/templates/reviews/review_list.html:33
@@ -10746,6 +10648,7 @@ msgstr ""
 msgid "Review for %(addon)s by %(user)s"
 msgid_plural "Reviews for %(addon)s by %(user)s"
 msgstr[0] ""
+msgstr[1] ""
 
 # 76%
 # 100%
@@ -10774,6 +10677,7 @@ msgstr ""
 msgid "{num} review"
 msgid_plural "{num} reviews"
 msgstr[0] "{num} inceleme"
+msgstr[1] ""
 
 #: src/olympia/reviews/templates/reviews/impala/reviews_rating.html:1
 msgid "Rated {0} out of 5 stars"
@@ -10800,6 +10704,7 @@ msgstr ""
 msgid "Average from {0} Rating"
 msgid_plural "Average from {0} Ratings"
 msgstr[0] ""
+msgstr[1] ""
 
 #: src/olympia/reviews/templates/reviews/mobile/review_list.html:34
 #, python-format
@@ -10815,6 +10720,7 @@ msgstr ""
 msgid "See All Reviews"
 msgid_plural "See All %(cnt)s Reviews"
 msgstr[0] ""
+msgstr[1] ""
 
 #: src/olympia/search/forms.py:11
 #, fuzzy
@@ -10903,16 +10809,16 @@ msgstr "{0} Eklentileri"
 
 #. L10n: {0} is an application, such as Firefox. This means "any version of
 #. Firefox."
-#: src/olympia/search/views.py:554
+#: src/olympia/search/views.py:547
 msgid "Any {0}"
 msgstr ""
 
 #. L10n: "All Systems" means show everything regardless of platform.
-#: src/olympia/search/views.py:589
+#: src/olympia/search/views.py:582
 msgid "All Systems"
 msgstr ""
 
-#: src/olympia/search/views.py:600
+#: src/olympia/search/views.py:593
 msgid "All Tags"
 msgstr "Tüm Etiketler"
 
@@ -10956,6 +10862,7 @@ msgstr ""
 msgid "<b>{0}</b> matching result"
 msgid_plural "<b>{0}</b> matching results"
 msgstr[0] ""
+msgstr[1] ""
 
 #: src/olympia/search/templates/search/results.html:67
 msgid "Filter Results"
@@ -10977,6 +10884,7 @@ msgstr ""
 msgid "{0} post"
 msgid_plural "{0} posts"
 msgstr[0] ""
+msgstr[1] ""
 
 #: src/olympia/sharing/__init__.py:20
 #, fuzzy
@@ -10987,6 +10895,7 @@ msgstr "Post to Facebook"
 msgid "{0} Like"
 msgid_plural "{0} Likes"
 msgstr[0] ""
+msgstr[1] ""
 
 #: src/olympia/sharing/__init__.py:30
 msgid "Tweet on Twitter"
@@ -10996,6 +10905,7 @@ msgstr ""
 msgid "{0} tweet"
 msgid_plural "{0} tweets"
 msgstr[0] ""
+msgstr[1] ""
 
 #: src/olympia/sharing/__init__.py:40
 msgid "Share on g+"
@@ -11029,6 +10939,7 @@ msgstr ""
 msgid "{0} post on localservice1"
 msgid_plural "{0} posts on localservice1"
 msgstr[0] ""
+msgstr[1] ""
 
 #. L10n: Only change if you have reason! wiki.mozilla.org/AMO:Localizers
 #: src/olympia/sharing/__init__.py:76
@@ -11050,6 +10961,7 @@ msgstr ""
 msgid "{0} post on localservice2"
 msgid_plural "{0} posts on localservice2"
 msgstr[0] ""
+msgstr[1] ""
 
 #. L10n: Only change if you have reason! wiki.mozilla.org/AMO:Localizers
 #: src/olympia/sharing/__init__.py:91
@@ -11071,6 +10983,7 @@ msgstr ""
 msgid "{0} post on localservice3"
 msgid_plural "{0} posts on localservice3"
 msgstr[0] ""
+msgstr[1] ""
 
 #: src/olympia/sharing/templates/sharing/sharing_widget.html:2
 msgid "Share this Add-on"
@@ -11080,31 +10993,31 @@ msgstr "Bu eklentiyi paylaş"
 msgid "Share this Collection"
 msgstr "Bu koleksiyonu paylaş"
 
-#: src/olympia/signing/views.py:30 src/olympia/templates/base.html:75 src/olympia/templates/impala/base.html:115
+#: src/olympia/signing/views.py:33 src/olympia/templates/base.html:71 src/olympia/templates/impala/base.html:112
 msgid "Some features are temporarily disabled while we perform website maintenance. We'll be back to full capacity shortly."
 msgstr "Web sitemizde bakım çalışması yapıldığından bazı özellikler geçici olarak devre dışı bırakılmıştır. Kısa süre içinde normal işleyişimize döneceğiz."
 
-#: src/olympia/signing/views.py:53
+#: src/olympia/signing/views.py:56
 msgid "Could not find add-on with id \"{}\"."
 msgstr ""
 
-#: src/olympia/signing/views.py:67
+#: src/olympia/signing/views.py:70
 msgid "You do not own this addon."
 msgstr ""
 
-#: src/olympia/signing/views.py:82
+#: src/olympia/signing/views.py:87
 msgid "Missing \"upload\" key in multipart file data."
 msgstr ""
 
-#: src/olympia/signing/views.py:96
+#: src/olympia/signing/views.py:101
 msgid "Version does not match the manifest file."
 msgstr ""
 
-#: src/olympia/signing/views.py:100
+#: src/olympia/signing/views.py:105
 msgid "Version already exists."
 msgstr "Sürüm hâlihazırda mevcut."
 
-#: src/olympia/signing/views.py:136
+#: src/olympia/signing/views.py:141
 msgid "No uploaded file for that addon and version."
 msgstr ""
 
@@ -11223,89 +11136,89 @@ msgstr ""
 msgid "Statistics Dashboard :: Add-ons for {0}"
 msgstr ""
 
-#: src/olympia/stats/templates/stats/stats.html:30
-msgid "Controls:"
-msgstr ""
-
-#: src/olympia/stats/templates/stats/stats.html:33
-msgid "reset zoom"
-msgstr "yakınlaşmayı sıfırla"
-
-#: src/olympia/stats/templates/stats/stats.html:40
-msgid "Group by:"
-msgstr ""
-
-#: src/olympia/stats/templates/stats/stats.html:42
-msgid "day"
-msgstr "gün"
-
-#: src/olympia/stats/templates/stats/stats.html:45
-msgid "week"
-msgstr "hafta"
-
-#: src/olympia/stats/templates/stats/stats.html:48
-msgid "month"
-msgstr "ay"
-
-#: src/olympia/stats/templates/stats/stats.html:54
-msgid "For last:"
-msgstr ""
-
-#: src/olympia/stats/templates/stats/stats.html:57
-msgid "7 days"
-msgstr "7 gün"
-
-#: src/olympia/stats/templates/stats/stats.html:60
-msgid "30 days"
-msgstr "30 gün"
-
-#: src/olympia/stats/templates/stats/stats.html:63
-msgid "90 days"
-msgstr "90 gün"
-
-#: src/olympia/stats/templates/stats/stats.html:66
-msgid "365 days"
-msgstr "365 gün"
-
-#: src/olympia/stats/templates/stats/stats.html:69
-msgid "Custom..."
-msgstr ""
-
 #. {0} is an add-on name
-#: src/olympia/stats/templates/stats/stats.html:88 src/olympia/stats/templates/stats/stats.html:91
+#: src/olympia/stats/templates/stats/stats.html:44 src/olympia/stats/templates/stats/stats.html:47
 msgid "Statistics for {0}"
 msgstr "{0} İstatistikleri"
 
-#: src/olympia/stats/templates/stats/stats.html:94
+#: src/olympia/stats/templates/stats/stats.html:50
 msgid "Statistics Dashboard"
 msgstr ""
 
-#: src/olympia/stats/templates/stats/stats.html:104
+#: src/olympia/stats/templates/stats/stats.html:57
+msgid "Controls:"
+msgstr ""
+
+#: src/olympia/stats/templates/stats/stats.html:60
+msgid "reset zoom"
+msgstr "yakınlaşmayı sıfırla"
+
+#: src/olympia/stats/templates/stats/stats.html:67
+msgid "Group by:"
+msgstr ""
+
+#: src/olympia/stats/templates/stats/stats.html:69
+msgid "day"
+msgstr "gün"
+
+#: src/olympia/stats/templates/stats/stats.html:72
+msgid "week"
+msgstr "hafta"
+
+#: src/olympia/stats/templates/stats/stats.html:75
+msgid "month"
+msgstr "ay"
+
+#: src/olympia/stats/templates/stats/stats.html:81
+msgid "For last:"
+msgstr ""
+
+#: src/olympia/stats/templates/stats/stats.html:84
+msgid "7 days"
+msgstr "7 gün"
+
+#: src/olympia/stats/templates/stats/stats.html:87
+msgid "30 days"
+msgstr "30 gün"
+
+#: src/olympia/stats/templates/stats/stats.html:90
+msgid "90 days"
+msgstr "90 gün"
+
+#: src/olympia/stats/templates/stats/stats.html:93
+msgid "365 days"
+msgstr "365 gün"
+
+#: src/olympia/stats/templates/stats/stats.html:96
+msgid "Custom..."
+msgstr ""
+
+#: src/olympia/stats/templates/stats/stats.html:106
 msgid "Statistics processing is currently disabled, so recent data is unavailable. The statistics are still being collected and this page will be updated soon with the missing data."
 msgstr ""
 
-#: src/olympia/stats/templates/stats/stats.html:110
+#: src/olympia/stats/templates/stats/stats.html:112
 msgid "Loading the latest data&hellip;"
 msgstr ""
 
-#: src/olympia/stats/templates/stats/stats.html:142 src/olympia/stats/templates/stats/reports/overview.html:25 src/olympia/stats/templates/stats/reports/overview.html:37
+#: src/olympia/stats/templates/stats/stats.html:144 src/olympia/stats/templates/stats/reports/overview.html:25 src/olympia/stats/templates/stats/reports/overview.html:37
 #: src/olympia/stats/templates/stats/reports/overview.html:49
 msgid "No data available."
 msgstr ""
 
-#: src/olympia/stats/templates/stats/stats.html:177
+#: src/olympia/stats/templates/stats/stats.html:179
 msgid "This dashboard is currently <b>public</b>."
 msgstr ""
 
-#: src/olympia/stats/templates/stats/stats.html:179
+#: src/olympia/stats/templates/stats/stats.html:181
 msgid "Contribution stats are currently <b>private</b>."
 msgstr ""
 
-#: src/olympia/stats/templates/stats/stats.html:182
+#: src/olympia/stats/templates/stats/stats.html:184
 msgid "This dashboard is currently <b>private</b>."
 msgstr ""
 
-#: src/olympia/stats/templates/stats/stats.html:185
+#: src/olympia/stats/templates/stats/stats.html:187
 msgid "Change settings."
 msgstr "Ayarları değiştir."
 
@@ -11457,16 +11370,6 @@ msgstr ""
 msgid "Application versions by Date"
 msgstr ""
 
-# {0} is a number
-#: src/olympia/tags/templates/tags/top_cloud.html:4
-msgid "Top {0} Tags"
-msgstr "En Popüler {0} Etiket"
-
-#. {0} is the current application name
-#: src/olympia/tags/templates/tags/top_cloud.html:14
-msgid "{0} Top Tags"
-msgstr "En Popüler {0} Etiketleri"
-
 #: src/olympia/templates/amo_footer.html:6 src/olympia/templates/includes/lang_switcher.html:2
 msgid "Other languages"
 msgstr "Diğer diller"
@@ -11478,11 +11381,11 @@ msgstr "Diğer diller"
 msgid "Mozilla Add-ons"
 msgstr "Mozilla Eklentileri"
 
-#: src/olympia/templates/base.html:91 src/olympia/templates/impala/base.html:81
+#: src/olympia/templates/base.html:89 src/olympia/templates/impala/base.html:78
 msgid "Find add-ons for other applications"
 msgstr "Diğer uygulamalar için eklenti bul"
 
-#: src/olympia/templates/base.html:92 src/olympia/templates/impala/base.html:81
+#: src/olympia/templates/base.html:90 src/olympia/templates/impala/base.html:78
 msgid "Other Applications"
 msgstr "Diğer Uygulamalar"
 
@@ -11507,7 +11410,7 @@ msgid "View Mobile Site"
 msgstr "Mobil siteyi görüntüle"
 
 #: src/olympia/templates/copyright.html:7
-msgid "Site Status "
+msgid "Site Status"
 msgstr ""
 
 #: src/olympia/templates/footer.html:3
@@ -11609,35 +11512,35 @@ msgstr "Hoş geldin {0}"
 msgid "<a href=\"%(reg)s\">Register</a> or <a href=\"%(login)s\">Log in</a>"
 msgstr "<a href=\"%(reg)s\">Kaydol</a> veya <a href=\"%(login)s\">oturum aç</a>"
 
-#: src/olympia/templates/impala/base.html:126
+#: src/olympia/templates/impala/base.html:123
 #, python-format
 msgid "To try the thousands of add-ons available here, download <a href=\"%(url)s\">Mozilla Firefox</a>, a fast, free way to surf the Web!"
 msgstr "Burada gördüğünüz binlerce eklentiyi denemek için, hızlı ve ücretsiz web tarayıcısı <a href=\"%(url)s\">Mozilla Firefox</a>'u indirin."
 
-#: src/olympia/templates/impala/base.html:138
+#: src/olympia/templates/impala/base.html:135
 #, python-format
 msgid "Add-ons is switching to Firefox Accounts for login. <a href=\"%(url)s\" class=\"fxa-login\">Sign in now to transfer your account.</a>"
 msgstr ""
 
 #. {0} is an application, such as Firefox.
-#: src/olympia/templates/impala/base.html:148
+#: src/olympia/templates/impala/base.html:145
 msgid "Welcome to {0} Add-ons."
 msgstr "{0} Eklentileri'ne hoş geldiniz."
 
-#: src/olympia/templates/impala/base.html:151
+#: src/olympia/templates/impala/base.html:148
 msgid "Choose from thousands of extra features and styles to make Firefox your own."
 msgstr "Firefox'unuzu kişiselleştirmek için binlerce ekstra özellik ve stilden istediklerinizi seçin."
 
-#: src/olympia/templates/impala/base.html:156
+#: src/olympia/templates/impala/base.html:153
 #, python-format
 msgid "Add extra features and styles to make %(app)s your own."
 msgstr "%(app)s uygulamanızı kişiselleştirmek için ekstra özellikler ve stiller ekleyin."
 
-#: src/olympia/templates/impala/base.html:164
+#: src/olympia/templates/impala/base.html:161
 msgid "On the go?"
 msgstr "Yolda mısınız?"
 
-#: src/olympia/templates/impala/base.html:166
+#: src/olympia/templates/impala/base.html:163
 msgid "Check out our <a class=\"mobile-link\" href=\"#\">Mobile Add-ons site</a>."
 msgstr "<a class=\"mobile-link\" href=\"#\">Mobil Eklentiler sitemize</a> göz atın."
 
@@ -11863,22 +11766,22 @@ msgstr "Bu e-posta ile kayıtlı kullanıcı yok."
 
 #. L10n: {id} will be something like "13ad6a", just a random number
 #. to differentiate this user from other anonymous users.
-#: src/olympia/users/models.py:353
+#: src/olympia/users/models.py:362
 msgid "Anonymous user {id}"
 msgstr ""
 
-#: src/olympia/users/models.py:410
+#: src/olympia/users/models.py:419
 msgid "Your account has been restricted"
 msgstr "Hesabınız kısıtlandı."
 
-#: src/olympia/users/models.py:480
+#: src/olympia/users/models.py:489
 msgid "Please confirm your email address"
 msgstr "Lütfen e-posta adresinizi doğrulayın"
 
 # 75%
 # 78%
 # 82%
-#: src/olympia/users/models.py:506
+#: src/olympia/users/models.py:515
 msgid "My Mobile Add-ons"
 msgstr "Mobil eklentilerim"
 
@@ -12597,7 +12500,7 @@ msgstr ""
 
 #: src/olympia/users/templates/users/unsubscribe.html:30
 #, python-format
-msgid "Unfortunately, we weren't able to unsubscribe you.  The link you clicked is invalid. However, you can unsubscribe still unsubscribe on your <a href=\"%(edit_url)s\">edit profile page</a>."
+msgid "Unfortunately, we weren't able to unsubscribe you. The link you clicked is invalid. However, you can unsubscribe still unsubscribe on your <a href=\"%(edit_url)s\">edit profile page</a>."
 msgstr ""
 
 #: src/olympia/users/templates/users/vcard.html:2
@@ -12629,12 +12532,14 @@ msgstr "{0} eklenti"
 msgid "%(num)s theme"
 msgid_plural "%(num)s themes"
 msgstr[0] "%(num)s tema"
+msgstr[1] ""
 
 #: src/olympia/users/templates/users/vcard.html:62
 #, python-format
 msgid "%(num)s add-on"
 msgid_plural "%(num)s add-ons"
 msgstr[0] ""
+msgstr[1] ""
 
 #: src/olympia/users/templates/users/vcard.html:75
 msgid "Average rating of developer's add-ons"
@@ -12652,15 +12557,15 @@ msgstr "%s Sürüm Geçmişi"
 msgid "Version History with Changelogs"
 msgstr "Version History with Changelogs"
 
-#: src/olympia/versions/models.py:314
+#: src/olympia/versions/models.py:313
 msgid "Add-on uses binary components."
 msgstr ""
 
-#: src/olympia/versions/models.py:317
+#: src/olympia/versions/models.py:316
 msgid "Add-on has opted into strict compatibility checking."
 msgstr ""
 
-#: src/olympia/versions/models.py:715
+#: src/olympia/versions/models.py:711
 msgid "{app} {min} and later"
 msgstr ""
 
@@ -12698,6 +12603,7 @@ msgstr "{0} Sürüm Geçmişi"
 msgid "<b>{0}</b> version"
 msgid_plural "<b>{0}</b> versions"
 msgstr[0] ""
+msgstr[1] ""
 
 #: src/olympia/versions/templates/versions/version_list.html:35 src/olympia/versions/templates/versions/mobile/version_list.html:14
 msgid "Be careful with old versions!"
@@ -12739,3 +12645,7 @@ msgstr "Bittiğinde e-posta gönder"
 #: src/olympia/zadmin/forms.py:105
 msgid "Log emails instead of sending"
 msgstr "E-postaları göndermek yerine kaydet"
+
+#: src/olympia/zadmin/forms.py:215
+msgid "Deleted versions can`t be changed."
+msgstr ""

--- a/locale/tr/LC_MESSAGES/djangojs.po
+++ b/locale/tr/LC_MESSAGES/djangojs.po
@@ -3,129 +3,391 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2016-02-24 21:23+0000\n"
+"POT-Creation-Date: 2016-04-18 15:47+0000\n"
 "PO-Revision-Date: 2016-01-05 12:35+0000\n"
 "Last-Translator: asteko <aserkant@protonmail.ch>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
+"Language: \n"
 "MIME-Version: 1.0\n"
-"Content-Type: text/plain; charset=utf-8\n"
+"Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Generated-By: Babel 2.2.0\n"
 
-#: static/js/common/ratingwidget.js:31
+#: static/js/common-all.js:1426 static/js/impala-all.js:1511 static/js/zamboni/discovery-all.js:12598 static/js/zamboni/init.js:28 static/js/zamboni/mobile-all.js:14945
+msgid "This feature is temporarily disabled while we perform website maintenance. Please check back a little later."
+msgstr "Bakım nedeniyle bu özellik şu anda devre dışıdır. Lütfen daha sonra tekrar deneyin."
+
+#. L10n: {0} is an app name like Firefox.
+#: static/js/common-all.js:1837 static/js/impala-all.js:1922 static/js/zamboni/buttons.js:73 static/js/zamboni/discovery-all.js:13108
+msgid "Accept and Install"
+msgstr "Kabul et ve kur"
+
+#: static/js/common-all.js:1837 static/js/impala-all.js:1922 static/js/zamboni/buttons.js:73 static/js/zamboni/discovery-all.js:13108
+msgid "Add to {0}"
+msgstr "{0}'a Ekle"
+
+#: static/js/common-all.js:1842 static/js/impala-all.js:1927 static/js/zamboni/buttons.js:78 static/js/zamboni/discovery-all.js:13113
+msgid "Download Now"
+msgstr "Şimdi İndir"
+
+#: static/js/common-all.js:1883 static/js/impala-all.js:1968 static/js/zamboni/buttons.js:119 static/js/zamboni/discovery-all.js:13154
+msgid "Add-on has not been updated to support default-to-compatible."
+msgstr ""
+
+#: static/js/common-all.js:1888 static/js/impala-all.js:1973 static/js/zamboni/buttons.js:124 static/js/zamboni/discovery-all.js:13159
+msgid "You need to be using Firefox 10.0 or higher."
+msgstr "Firefox 10.0 ve üstü bir sürüm kullanmanız gerek."
+
+#: static/js/common-all.js:1900 static/js/impala-all.js:1985 static/js/zamboni/buttons.js:136 static/js/zamboni/discovery-all.js:13171
+msgid "Mozilla has marked this version as incompatible with your Firefox version."
+msgstr "Mozilla bu sürümü Firefox sürümünüz ile uyumsuz olarak işaretledi."
+
+#. L10n: {0} is an platform like Windows or Linux.
+#: static/js/common-all.js:1981 static/js/impala-all.js:2066 static/js/zamboni/buttons.js:217 static/js/zamboni/discovery-all.js:13252
+msgid "Install for {0} anyway"
+msgstr "Yine de {0} için yükle"
+
+#: static/js/common-all.js:1981 static/js/impala-all.js:2066 static/js/zamboni/buttons.js:217 static/js/zamboni/discovery-all.js:13252
+msgid "Download for {0} anyway"
+msgstr "Yine de {0} için indir"
+
+#: static/js/common-all.js:2038 static/js/impala-all.js:2123 static/js/zamboni/buttons.js:274 static/js/zamboni/discovery-all.js:13309
+msgid "Not available for your platform"
+msgstr "Sizin platformunuz için mevcut değil"
+
+#. L10n: {0} is an app name, {1} is the app version.
+#: static/js/common-all.js:2049 static/js/common-all.js:2086 static/js/impala-all.js:2134 static/js/impala-all.js:2171 static/js/zamboni/buttons.js:286 static/js/zamboni/buttons.js:324
+#: static/js/zamboni/discovery-all.js:13320 static/js/zamboni/discovery-all.js:13357
+msgid "Not available for {0} {1}"
+msgstr "{0} {1} için mevcut değil"
+
+#: static/js/common-all.js:2112 static/js/impala-all.js:2197 static/js/zamboni/buttons.js:351 static/js/zamboni/discovery-all.js:13383
+msgid "Works with {app} {min} - {max}"
+msgstr "{app} {min} - {max} ile çalışır"
+
+#: static/js/common-all.js:2114 static/js/impala-all.js:2199 static/js/zamboni/buttons.js:353 static/js/zamboni/discovery-all.js:13385
+msgid "View other versions"
+msgstr "Diğer sürümleri görüntüle"
+
+#: static/js/common-all.js:2162 static/js/impala-all.js:2247 static/js/zamboni/buttons.js:401 static/js/zamboni/discovery-all.js:13433
+msgid "Only with Firefox — Get Firefox Now!"
+msgstr "Yalnızca Firefox ile — Firefox'u hemen indirin!"
+
+#: static/js/common-all.js:2278 static/js/impala-all.js:2363 static/js/zamboni/buttons.js:517 static/js/zamboni/discovery-all.js:13549 static/js/zamboni/mobile-all.js:15177
+#: static/js/zamboni/mobile/buttons.js:43
+msgid "Sorry, you need a Mozilla-based browser (such as Firefox) to install a search plugin."
+msgstr "Üzgünüz, arama eklentisi yükleyebilmeniz için Mozilla tabanlı (örn. Firefox) bir tarayıcıya ihtiyacınız var."
+
+#: static/js/common-all.js:9088 static/js/impala-all.js:9649 static/js/zamboni/global.js:410
+msgid "Loading..."
+msgstr "Yükleniyor..."
+
+#. L10n: {0} is the number of characters left.
+#: static/js/common-all.js:9152 static/js/impala-all.js:9713 static/js/zamboni/global.js:474
+msgid "<b>{0}</b> character left."
+msgid_plural "<b>{0}</b> characters left."
+msgstr[0] "<b>{0}</b> karakter kaldı."
+msgstr[1] ""
+
+#: static/js/common-all.js:9589 static/js/common-min.js:6 static/js/impala-all.js:10052 static/js/impala-min.js:6 static/js/common/ratingwidget.js:31 static/js/zamboni/mobile-all.js:16123
+#: static/js/zamboni/mobile-min.js:6
 msgid "{0} star"
 msgid_plural "{0} stars"
 msgstr[0] "{0} yıldız"
+msgstr[1] ""
 
-#: static/js/common/upload-addon.js:41 static/js/common/upload-image.js:128
+#: static/js/common-all.js:9676 static/js/common-min.js:6 static/js/impala-all.js:10139 static/js/impala-min.js:6 static/js/zamboni/l10n.js:45
+msgid "Remove this localization"
+msgstr "Bu yerelleştirmeyi kaldır"
+
+#: static/js/common-all.js:10193 static/js/common-min.js:6 static/js/impala-all.js:10674 static/js/impala-min.js:6 static/js/zamboni/discovery-all.js:13678
+msgid "close"
+msgstr ""
+
+#: static/js/common-all.js:10860 static/js/common-min.js:6 static/js/impala-all.js:11481 static/js/impala-min.js:6 static/js/impala/reviews.js:23 static/js/zamboni/reviews.js:18
+msgid "Flagged for review"
+msgstr "İnceleme için işaretlendi"
+
+#: static/js/common-all.js:10876 static/js/common-min.js:6 static/js/impala-all.js:11498 static/js/impala-min.js:6 static/js/impala/reviews.js:40 static/js/zamboni/reviews.js:34
+msgid "Your input is required"
+msgstr "Giriş gerekli"
+
+#: static/js/common-all.js:10945 static/js/common-min.js:6 static/js/impala-all.js:11610 static/js/impala-min.js:7 static/js/impala/reviews.js:152 static/js/zamboni/reviews.js:103
+msgid "Marked for deletion"
+msgstr "Silmek için işaretlendi"
+
+#: static/js/common-all.js:11573 static/js/common-min.js:7 static/js/impala-all.js:13809 static/js/impala-min.js:8 static/js/zamboni/collections.js:229
+msgid "Adding to Favorites&hellip;"
+msgstr "Favorilere ekleniyor&hellip;"
+
+#: static/js/common-all.js:11576 static/js/common-min.js:7 static/js/impala-all.js:13812 static/js/impala-min.js:8 static/js/zamboni/collections.js:232
+msgid "Removing Favorite&hellip;"
+msgstr "Favorilerden kaldırılıyor&hellip;"
+
+#: static/js/common-all.js:11579 static/js/common-min.js:7 static/js/impala-all.js:13815 static/js/impala-min.js:8 static/js/zamboni/collections.js:235
+msgid "Add to Favorites"
+msgstr "Favorilere Ekle"
+
+#: static/js/common-all.js:11582 static/js/common-min.js:7 static/js/impala-all.js:13818 static/js/impala-min.js:8 static/js/zamboni/collections.js:238
+msgid "Remove from Favorites"
+msgstr "Favorilerden Kaldır"
+
+#: static/js/common-all.js:11647 static/js/common-min.js:7 static/js/impala-all.js:13883 static/js/impala-min.js:8 static/js/zamboni/collections.js:303
+msgid "Pending"
+msgstr "Beklemede"
+
+#: static/js/common-all.js:11648 static/js/common-min.js:7 static/js/impala-all.js:13884 static/js/impala-min.js:8 static/js/zamboni/collections.js:304
+msgid "Add a comment"
+msgstr "Yorum ekle"
+
+#: static/js/common-all.js:11648 static/js/common-min.js:7 static/js/impala-all.js:13884 static/js/impala-min.js:8 static/js/zamboni/collections.js:304
+msgid "Comment"
+msgstr "Yorum"
+
+#: static/js/common-all.js:11649 static/js/common-min.js:7 static/js/impala-all.js:13885 static/js/impala-min.js:8 static/js/zamboni/collections.js:305
+msgid "Remove this add-on from the collection"
+msgstr "Bu eklentiyi koleksiyondan kaldır"
+
+#: static/js/common-all.js:11649 static/js/common-all.js:11678 static/js/common-min.js:7 static/js/impala-all.js:13885 static/js/impala-all.js:13914 static/js/impala-min.js:8
+#: static/js/zamboni/collections.js:305 static/js/zamboni/collections.js:334
+msgid "Remove"
+msgstr "Kaldır"
+
+#: static/js/common-all.js:11678 static/js/common-min.js:7 static/js/impala-all.js:13914 static/js/impala-min.js:8 static/js/zamboni/collections.js:334
+msgid "Remove this user as a contributor"
+msgstr "Bu kullanıcıyı katkıda bulunanlardan çıkar"
+
+#: static/js/common-all.js:11690 static/js/common-min.js:7 static/js/impala-all.js:13926 static/js/impala-min.js:8 static/js/zamboni/collections.js:346
+msgid "An email address is required."
+msgstr "Bir e-posta adresi gereklidir."
+
+#: static/js/common-all.js:11708 static/js/common-min.js:7 static/js/impala-all.js:13944 static/js/impala-min.js:8 static/js/zamboni/collections.js:364
+msgid "You cannot add yourself as a contributor."
+msgstr "Kendinizi katkıda bulunan olarak ekleyemezsiniz."
+
+#: static/js/common-all.js:11710 static/js/common-min.js:7 static/js/impala-all.js:13946 static/js/impala-min.js:8 static/js/zamboni/collections.js:366
+msgid "You have already added that user."
+msgstr "Bu kullanıcıyı zaten eklediniz."
+
+#: static/js/common-all.js:11917 static/js/common-min.js:7 static/js/impala-all.js:14153 static/js/impala-min.js:8 static/js/zamboni/collections.js:573
+msgid "Add to favorites"
+msgstr "Favorilerime ekle"
+
+#: static/js/common-all.js:11921 static/js/common-min.js:7 static/js/impala-all.js:14157 static/js/impala-min.js:8 static/js/zamboni/collections.js:577
+msgid "Remove from favorites"
+msgstr "Favorilerimden kaldır"
+
+#: static/js/common-all.js:11939 static/js/common-min.js:7 static/js/impala-all.js:14175 static/js/impala-all.js:14233 static/js/impala-min.js:8 static/js/impala/collections.js:10
+#: static/js/zamboni/collections.js:595
+msgid "Follow this Collection"
+msgstr "Bu Koleksiyonu İzle"
+
+#: static/js/common-all.js:11948 static/js/common-min.js:7 static/js/impala-all.js:14184 static/js/impala-min.js:8 static/js/zamboni/collections.js:604
+msgid "Stop following"
+msgstr "İzlemeyi durdur"
+
+#: static/js/common-all.js:12096 static/js/common-min.js:7 static/js/zamboni/password-strength.js:20
+msgid "Password strength:"
+msgstr "Parola gücü:"
+
+#: static/js/common-all.js:12102 static/js/common-min.js:7 static/js/zamboni/password-strength.js:26
+msgid "At least {0} character left."
+msgid_plural "At least {0} characters left."
+msgstr[0] "En az {0} karakter kaldı."
+msgstr[1] ""
+
+#: static/js/common-all.js:12286 static/js/common-min.js:7 static/js/impala-all.js:14632 static/js/impala-min.js:8 static/js/impala/suggestions.js:39
+msgid "Search themes for <b>{0}</b>"
+msgstr "<b>{0}</b> için temaları ara"
+
+#: static/js/common-all.js:12288 static/js/common-min.js:7 static/js/impala-all.js:14634 static/js/impala-min.js:8 static/js/impala/suggestions.js:41
+msgid "Search apps for <b>{0}</b>"
+msgstr "<b>{0}</b> için uygulamaları ara"
+
+#: static/js/common-all.js:12290 static/js/common-min.js:7 static/js/impala-all.js:14636 static/js/impala-min.js:8 static/js/impala/suggestions.js:43
+msgid "Search add-ons for <b>{0}</b>"
+msgstr "<b>{0}</b> için eklentileri ara"
+
+#: static/js/common-all.js:12521 static/js/common-min.js:7 static/js/impala-all.js:14867 static/js/impala-min.js:8 static/js/impala/site_suggestions.js:46
+msgid "Category"
+msgstr "Kategori"
+
+#. L10n: {0} is an app name.
+#: static/js/impala-all.js:11632 static/js/impala-min.js:7 static/js/impala/listing.js:11 static/js/zamboni/themes.js:13
+msgid "This theme is incompatible with your version of {0}"
+msgstr "Bu tema sizin {0} sürümünüzle uyumlu değil"
+
+#: static/js/impala-all.js:12146 static/js/impala-all.js:14331 static/js/impala-min.js:7 static/js/impala-min.js:8 static/js/common/upload-image.js:97 static/js/impala/users.js:51
+#: static/js/zamboni/devhub-all.js:894 static/js/zamboni/devhub-min.js:1
+msgid "Images must be either PNG or JPG."
+msgstr "Resimler PNG veya JPG olmalıdır."
+
+#: static/js/impala-all.js:12150 static/js/impala-min.js:7 static/js/common/upload-image.js:101 static/js/zamboni/devhub-all.js:898 static/js/zamboni/devhub-min.js:1
+msgid "Videos must be in WebM."
+msgstr "Videolar WebM olmalıdır."
+
+#: static/js/impala-all.js:12177 static/js/impala-min.js:7 static/js/common/upload-addon.js:41 static/js/common/upload-image.js:128 static/js/zamboni/devhub-all.js:272
+#: static/js/zamboni/devhub-all.js:925 static/js/zamboni/devhub-min.js:1
 msgid "There was a problem contacting the server."
 msgstr "Sunucuyla bağlantı kurulurken bir hata oluştu."
 
-#: static/js/common/upload-addon.js:69
+#: static/js/impala-all.js:13298 static/js/impala-min.js:7 static/js/impala/persona_creation.js:60
+msgid "All Rights Reserved"
+msgstr "Tüm hakları saklıdır"
+
+#: static/js/impala-all.js:13302 static/js/impala-min.js:7 static/js/impala/persona_creation.js:64
+msgid "Creative Commons Attribution 3.0"
+msgstr "Creative Commons Attribution 3.0"
+
+#: static/js/impala-all.js:13307 static/js/impala-min.js:7 static/js/impala/persona_creation.js:69
+msgid "Creative Commons Attribution-NonCommercial 3.0"
+msgstr "Creative Commons Attribution-NonCommercial 3.0"
+
+#: static/js/impala-all.js:13312 static/js/impala-min.js:7 static/js/impala/persona_creation.js:74
+msgid "Creative Commons Attribution-NonCommercial-NoDerivs 3.0"
+msgstr "Creative Commons Attribution-NonCommercial-NoDerivs 3.0"
+
+#: static/js/impala-all.js:13317 static/js/impala-min.js:7 static/js/impala/persona_creation.js:79
+msgid "Creative Commons Attribution-NonCommercial-Share Alike 3.0"
+msgstr "Creative Commons Attribution-NonCommercial-Share Alike 3.0"
+
+#: static/js/impala-all.js:13322 static/js/impala-min.js:7 static/js/impala/persona_creation.js:84
+msgid "Creative Commons Attribution-NoDerivs 3.0"
+msgstr "Creative Commons Attribution-NoDerivs 3.0"
+
+#: static/js/impala-all.js:13327 static/js/impala-min.js:7 static/js/impala/persona_creation.js:89
+msgid "Creative Commons Attribution-ShareAlike 3.0"
+msgstr "Creative Commons Attribution-ShareAlike 3.0"
+
+#: static/js/impala-all.js:13530 static/js/impala-min.js:7 static/js/impala/persona_creation.js:292
+msgid "Your Theme's Name"
+msgstr "Temanızın Adı"
+
+#: static/js/impala-all.js:14242 static/js/impala-min.js:8 static/js/impala/collections.js:19
+msgid "Stop Following"
+msgstr "Takip etmeyi bırak"
+
+#: static/js/impala-all.js:14243 static/js/impala-min.js:8 static/js/impala/collections.js:20
+msgid "Following"
+msgstr "Takip ediliyor"
+
+#: static/js/impala-all.js:14313 static/js/impala-min.js:8 static/js/impala/users.js:33
+msgid "use original"
+msgstr "orijinalini kullan"
+
+#: static/js/impala-all.js:14523 static/js/impala-min.js:8 static/js/impala/search.js:114
+msgid "Updating results&hellip;"
+msgstr "Sonuçlar güncelleniyor&hellip;"
+
+#: static/js/common/upload-addon.js:69 static/js/zamboni/devhub-all.js:300 static/js/zamboni/devhub-min.js:1
 msgid "Select a file..."
 msgstr "Dosya seçin..."
 
-#: static/js/common/upload-addon.js:70
+#: static/js/common/upload-addon.js:70 static/js/zamboni/devhub-all.js:301 static/js/zamboni/devhub-min.js:1
 msgid "Your add-on should end with .xpi, .jar or .xml"
 msgstr "Eklentiniz .xpi, .jar veya .xml ile bitmelidir."
 
 #. L10n: {0} is the percent of the file that has been uploaded.
-#: static/js/common/upload-addon.js:104
+#: static/js/common/upload-addon.js:104 static/js/zamboni/devhub-all.js:335 static/js/zamboni/devhub-min.js:1
 #, fuzzy, python-format
 msgid "{0}% complete"
 msgstr "{0}% tamamlandı"
 
 #. L10n: "{bytes uploaded} of {total filesize}".
-#: static/js/common/upload-addon.js:107
+#: static/js/common/upload-addon.js:107 static/js/zamboni/devhub-all.js:338 static/js/zamboni/devhub-min.js:1
 msgid "{0} of {1}"
 msgstr "{0} / {1}"
 
-#: static/js/common/upload-addon.js:140
+#: static/js/common/upload-addon.js:140 static/js/zamboni/devhub-all.js:371 static/js/zamboni/devhub-min.js:1
 msgid "Cancel"
 msgstr "İptal"
 
-#: static/js/common/upload-addon.js:162
+#: static/js/common/upload-addon.js:162 static/js/zamboni/devhub-all.js:393 static/js/zamboni/devhub-min.js:1
 msgid "Uploading {0}"
 msgstr "{0} yükleniyor"
 
-#: static/js/common/upload-addon.js:189
+#: static/js/common/upload-addon.js:189 static/js/zamboni/devhub-all.js:420 static/js/zamboni/devhub-min.js:1
 msgid "Error with {0}"
 msgstr "{0} hatası"
 
-#: static/js/common/upload-addon.js:194
+#: static/js/common/upload-addon.js:194 static/js/zamboni/devhub-all.js:425 static/js/zamboni/devhub-min.js:1
 msgid "Your add-on failed validation with {0} error."
 msgid_plural "Your add-on failed validation with {0} errors."
 msgstr[0] "Eklentinizin doğrulanması {0} hata ile başarısız oldu."
+msgstr[1] ""
 
-#: static/js/common/upload-addon.js:208
+#: static/js/common/upload-addon.js:208 static/js/zamboni/devhub-all.js:439 static/js/zamboni/devhub-min.js:1
 msgid "&hellip;and {0} more"
 msgid_plural "&hellip;and {0} more"
 msgstr[0] "&hellip;ve{0} tane daha"
+msgstr[1] ""
 
-#: static/js/common/upload-addon.js:222 static/js/common/upload-addon.js:512
+#: static/js/common/upload-addon.js:222 static/js/common/upload-addon.js:497 static/js/zamboni/devhub-all.js:453 static/js/zamboni/devhub-all.js:743 static/js/zamboni/devhub-min.js:1
 msgid "See full validation report"
 msgstr "Tam doğrulama raporuna bak"
 
-#: static/js/common/upload-addon.js:234
+#: static/js/common/upload-addon.js:234 static/js/zamboni/devhub-all.js:465 static/js/zamboni/devhub-min.js:1
 msgid "Validating {0}"
 msgstr "{0} doğrulanıyor"
 
 #. L10n: first argument is an HTTP status code
-#: static/js/common/upload-addon.js:273
+#: static/js/common/upload-addon.js:273 static/js/zamboni/devhub-all.js:504 static/js/zamboni/devhub-min.js:1
 msgid "Received an empty response from the server; status: {0}"
 msgstr "Sunucudan boş yanıt alındı. Durum: {0}"
 
-#: static/js/common/upload-addon.js:373
+#: static/js/common/upload-addon.js:370 static/js/zamboni/devhub-all.js:604 static/js/zamboni/devhub-min.js:1
 msgid "Unexpected server error while validating."
 msgstr "Doğrulama sırasında beklenmeyen sunucu hatası."
 
-#: static/js/common/upload-addon.js:412
+#: static/js/common/upload-addon.js:409 static/js/zamboni/devhub-all.js:643 static/js/zamboni/devhub-min.js:1
 msgid "Finished validating {0}"
 msgstr "{0} doğrulaması tamamlandı"
 
-#: static/js/common/upload-addon.js:418
+#: static/js/common/upload-addon.js:415 static/js/zamboni/devhub-all.js:649 static/js/zamboni/devhub-min.js:1
 msgid "Your add-on validation timed out, it will be manually reviewed."
 msgstr "Eklenti doğrulamanız zaman aşımına uğradı; eklenti özel olarak incelenecek."
 
-#: static/js/common/upload-addon.js:421
+#: static/js/common/upload-addon.js:418 static/js/zamboni/devhub-all.js:652 static/js/zamboni/devhub-min.js:1
 msgid "Your add-on was validated with no errors and {0} warning."
 msgid_plural "Your add-on was validated with no errors and {0} warnings."
 msgstr[0] "Eklentiniz hata olmadan ve {0} uyarı ile doğrulandı."
+msgstr[1] ""
 
-#: static/js/common/upload-addon.js:426
+#: static/js/common/upload-addon.js:423 static/js/zamboni/devhub-all.js:657 static/js/zamboni/devhub-min.js:1
 msgid "Your add-on was validated with no errors and {0} message."
 msgid_plural "Your add-on was validated with no errors and {0} messages."
 msgstr[0] "Eklentiniz hatasız olarak ve {0} mesajla doğrulandı."
+msgstr[1] ""
 
-#: static/js/common/upload-addon.js:431
+#: static/js/common/upload-addon.js:428 static/js/zamboni/devhub-all.js:662 static/js/zamboni/devhub-min.js:1
 msgid "Your add-on was validated with no errors or warnings."
 msgstr "Eklentiniz hatasız ve uyarısız olarak doğrulanmıştır."
 
-#: static/js/common/upload-addon.js:446
+#: static/js/common/upload-addon.js:443 static/js/zamboni/devhub-all.js:677 static/js/zamboni/devhub-min.js:1
 msgid "Your submission will be automatically signed."
 msgstr "Gönderiminiz otomatik olarak imzalanacak."
 
-#: static/js/common/upload-addon.js:465
+#: static/js/common/upload-addon.js:450 static/js/zamboni/devhub-all.js:696 static/js/zamboni/devhub-min.js:1
 msgid "Include detailed version notes (this can be done in the next step)."
 msgstr "Ayrıntılı sürüm notlarını yazın. (Bu, sonraki adımda da yapılabilir.)"
 
-#: static/js/common/upload-addon.js:466
+#: static/js/common/upload-addon.js:451 static/js/zamboni/devhub-all.js:697 static/js/zamboni/devhub-min.js:1
 msgid "If your add-on requires an account to a website in order to be fully tested, include a test username and password in the Notes to Reviewer (this can be done in the next step)."
 msgstr "Eklentinizin tam anlamıyla denenmesi için bir sitede hesap açılması gerekiyorsa, İnceleyene Notlar kısmında deneme kullanıcı adı ve parolasını yazın. (Bu, sonraki adımda da yapılabilir.)"
 
-#: static/js/common/upload-addon.js:467
+#: static/js/common/upload-addon.js:452 static/js/zamboni/devhub-all.js:698 static/js/zamboni/devhub-min.js:1
 msgid "If your add-on is intended for a limited audience you should choose Preliminary Review instead of Full Review."
 msgstr "Eklentiniz kısıtlı bir kitleye yönelik hazırlandıysa Tam İnceleme yerine Ön İnceleme'yi seçin."
 
-#: static/js/common/upload-addon.js:480
+#: static/js/common/upload-addon.js:465 static/js/zamboni/devhub-all.js:711 static/js/zamboni/devhub-min.js:1
 msgid "Add-on submission checklist"
 msgstr "Eklenti gönderimi kontrol listesi"
 
-#: static/js/common/upload-addon.js:481
+#: static/js/common/upload-addon.js:466 static/js/zamboni/devhub-all.js:712 static/js/zamboni/devhub-min.js:1
 msgid "Please verify the following points before finalizing your submission. This will minimize delays or misunderstanding during the review process:"
 msgstr "Gönderimi tamamlamadan önce lütfen aşağıdaki noktaları doğrulayın. Böylece inceleme sürecindeki gecikmeleri ve yanlış anlamaları en aza indirmiş olursunuz:"
 
-#: static/js/common/upload-addon.js:483
+#: static/js/common/upload-addon.js:468 static/js/zamboni/devhub-all.js:714 static/js/zamboni/devhub-min.js:1
 msgid ""
 "Compiled binaries, as well as minified or obfuscated scripts (excluding known libraries) need to have their sources submitted separately for review. Make sure that you use the source code upload "
 "field to avoid having your submission rejected."
@@ -133,1071 +395,844 @@ msgstr ""
 "Derlenmiş ikililer, ayrıca küçültülmüş veya karartılmış betikler (bilinen kitaplıklar hariç) incelenecekse, bunların kendi kaynaklarının ayrı olarak bulunması gerekir. Başvurunuzun geri "
 "çevrilmesini önlemek adına, kaynak kodu gönderme sahasını kullandığınızdan emin olun."
 
-#: static/js/common/upload-addon.js:501
+#: static/js/common/upload-addon.js:486 static/js/zamboni/devhub-all.js:732 static/js/zamboni/devhub-min.js:1
 msgid "The validation process found these issues that can lead to rejections:"
 msgstr "Doğrulama işlemleri sırasında başvurunun reddine yol açabilecek sorunlar bulundu:"
 
-#: static/js/common/upload-addon.js:518
+#: static/js/common/upload-addon.js:503 static/js/zamboni/devhub-all.js:749 static/js/zamboni/devhub-min.js:1
 msgid "If you are unfamiliar with the add-ons review process, you can read about it here."
 msgstr "Eklenti inceleme sürecine aşina değilseniz, konuyla ilgili burada bilgi alabilirsiniz."
 
-#: static/js/common/upload-addon.js:555
+#: static/js/common/upload-addon.js:540 static/js/zamboni/devhub-all.js:786 static/js/zamboni/devhub-min.js:1
 msgid "Sorry, no supported platform has been found."
 msgstr "Üzgünüz, desteklenen platform bulunamadı."
 
-#: static/js/common/upload-base.js:57
+#: static/js/common/upload-base.js:57 static/js/zamboni/devhub-all.js:187 static/js/zamboni/devhub-min.js:1
 msgid "The filetype you uploaded isn't recognized."
 msgstr "Yüklediğiniz dosya türü tanınmıyor."
 
-#: static/js/common/upload-base.js:79
+#: static/js/common/upload-base.js:79 static/js/zamboni/devhub-all.js:209 static/js/zamboni/devhub-min.js:1
 msgid "You cancelled the upload."
 msgstr "Yüklemeyi iptal ettiniz."
 
-#: static/js/common/upload-image.js:97 static/js/impala/users.js:51
-msgid "Images must be either PNG or JPG."
-msgstr "Resimler PNG veya JPG olmalıdır."
-
-#: static/js/common/upload-image.js:101
-msgid "Videos must be in WebM."
-msgstr "Videolar WebM olmalıdır."
-
-#: static/js/impala/collections.js:10 static/js/zamboni/collections.js:595
-msgid "Follow this Collection"
-msgstr "Bu Koleksiyonu İzle"
-
-#: static/js/impala/collections.js:19
-msgid "Stop Following"
-msgstr "Takip etmeyi bırak"
-
-#: static/js/impala/collections.js:20
-msgid "Following"
-msgstr "Takip ediliyor"
-
-#. L10n: {0} is an app name.
-#: static/js/impala/listing.js:11 static/js/zamboni/themes.js:13
-msgid "This theme is incompatible with your version of {0}"
-msgstr "Bu tema sizin {0} sürümünüzle uyumlu değil"
-
-#: static/js/impala/persona_creation.js:60
-msgid "All Rights Reserved"
-msgstr "Tüm hakları saklıdır"
-
-#: static/js/impala/persona_creation.js:64
-msgid "Creative Commons Attribution 3.0"
-msgstr "Creative Commons Attribution 3.0"
-
-#: static/js/impala/persona_creation.js:69
-msgid "Creative Commons Attribution-NonCommercial 3.0"
-msgstr "Creative Commons Attribution-NonCommercial 3.0"
-
-#: static/js/impala/persona_creation.js:74
-msgid "Creative Commons Attribution-NonCommercial-NoDerivs 3.0"
-msgstr "Creative Commons Attribution-NonCommercial-NoDerivs 3.0"
-
-#: static/js/impala/persona_creation.js:79
-msgid "Creative Commons Attribution-NonCommercial-Share Alike 3.0"
-msgstr "Creative Commons Attribution-NonCommercial-Share Alike 3.0"
-
-#: static/js/impala/persona_creation.js:84
-msgid "Creative Commons Attribution-NoDerivs 3.0"
-msgstr "Creative Commons Attribution-NoDerivs 3.0"
-
-#: static/js/impala/persona_creation.js:89
-msgid "Creative Commons Attribution-ShareAlike 3.0"
-msgstr "Creative Commons Attribution-ShareAlike 3.0"
-
-#: static/js/impala/persona_creation.js:292
-msgid "Your Theme's Name"
-msgstr "Temanızın Adı"
-
-#: static/js/impala/reviews.js:23 static/js/zamboni/reviews.js:18
-msgid "Flagged for review"
-msgstr "İnceleme için işaretlendi"
-
-#: static/js/impala/reviews.js:40 static/js/zamboni/reviews.js:34
-msgid "Your input is required"
-msgstr "Giriş gerekli"
-
-#: static/js/impala/reviews.js:152 static/js/zamboni/reviews.js:103
-msgid "Marked for deletion"
-msgstr "Silmek için işaretlendi"
-
-#: static/js/impala/search.js:114
-msgid "Updating results&hellip;"
-msgstr "Sonuçlar güncelleniyor&hellip;"
-
-#: static/js/impala/site_suggestions.js:46
-msgid "Category"
-msgstr "Kategori"
-
-#: static/js/impala/suggestions.js:39
-msgid "Search themes for <b>{0}</b>"
-msgstr "<b>{0}</b> için temaları ara"
-
-#: static/js/impala/suggestions.js:41
-msgid "Search apps for <b>{0}</b>"
-msgstr "<b>{0}</b> için uygulamaları ara"
-
-#: static/js/impala/suggestions.js:43
-msgid "Search add-ons for <b>{0}</b>"
-msgstr "<b>{0}</b> için eklentileri ara"
-
-#: static/js/impala/users.js:33
-msgid "use original"
-msgstr "orijinalini kullan"
-
-#: static/js/impala/stats/chart.js:267
+#: static/js/impala/stats/chart.js:267 static/js/zamboni/stats-all.js:16898 static/js/zamboni/stats-min.js:5
 msgid "Week of {0}"
 msgstr "{0} haftası"
 
-#: static/js/impala/stats/chart.js:269
+#: static/js/impala/stats/chart.js:269 static/js/zamboni/stats-all.js:16900 static/js/zamboni/stats-min.js:5
 msgid " downloads"
-msgstr " indirme"
+msgstr ""
 
-#: static/js/impala/stats/chart.js:270
+#: static/js/impala/stats/chart.js:270 static/js/zamboni/stats-all.js:16901 static/js/zamboni/stats-min.js:5
 msgid "{0} users"
 msgstr "{0} kullanıcı"
 
-#: static/js/impala/stats/chart.js:271
+#: static/js/impala/stats/chart.js:271 static/js/zamboni/stats-all.js:16902 static/js/zamboni/stats-min.js:5
 msgid "{0} add-ons"
 msgstr "{0} eklenti"
 
-#: static/js/impala/stats/chart.js:272
+#: static/js/impala/stats/chart.js:272 static/js/zamboni/stats-all.js:16903 static/js/zamboni/stats-min.js:5
 msgid "{0} collections"
 msgstr "{0} koleksiyon"
 
-#: static/js/impala/stats/chart.js:273
+#: static/js/impala/stats/chart.js:273 static/js/zamboni/stats-all.js:16904 static/js/zamboni/stats-min.js:5
 msgid "{0} reviews"
 msgstr "{0} inceleme"
 
-#: static/js/impala/stats/chart.js:275
+#: static/js/impala/stats/chart.js:275 static/js/zamboni/stats-all.js:16906 static/js/zamboni/stats-min.js:5
 msgid "{0} sales"
 msgstr "{0} satış"
 
-#: static/js/impala/stats/chart.js:276
+#: static/js/impala/stats/chart.js:276 static/js/zamboni/stats-all.js:16907 static/js/zamboni/stats-min.js:5
 msgid "{0} refunds"
 msgstr "{0} iade"
 
-#: static/js/impala/stats/chart.js:277
+#: static/js/impala/stats/chart.js:277 static/js/zamboni/stats-all.js:16908 static/js/zamboni/stats-min.js:5
 msgid "{0} installs"
 msgstr "{0} kurulum"
 
-#: static/js/impala/stats/chart.js:369 static/js/impala/stats/csv_keys.js:3 static/js/impala/stats/csv_keys.js:109
+#: static/js/impala/stats/chart.js:369 static/js/impala/stats/csv_keys.js:3 static/js/impala/stats/csv_keys.js:109 static/js/zamboni/stats-all.js:15284 static/js/zamboni/stats-all.js:15390
+#: static/js/zamboni/stats-all.js:17000 static/js/zamboni/stats-min.js:4 static/js/zamboni/stats-min.js:5
 msgid "Downloads"
 msgstr "İndirme"
 
-#: static/js/impala/stats/chart.js:379 static/js/impala/stats/csv_keys.js:6 static/js/impala/stats/csv_keys.js:110
+#: static/js/impala/stats/chart.js:379 static/js/impala/stats/csv_keys.js:6 static/js/impala/stats/csv_keys.js:110 static/js/zamboni/stats-all.js:15287 static/js/zamboni/stats-all.js:15391
+#: static/js/zamboni/stats-all.js:17010 static/js/zamboni/stats-min.js:4 static/js/zamboni/stats-min.js:5
 msgid "Daily Users"
 msgstr "Günlük kullanıcı"
 
-#: static/js/impala/stats/chart.js:410
+#: static/js/impala/stats/chart.js:410 static/js/zamboni/stats-all.js:17041 static/js/zamboni/stats-min.js:5
 msgid "Amount, in USD"
 msgstr "Tutar (USD)"
 
-#: static/js/impala/stats/chart.js:421 static/js/impala/stats/csv_keys.js:104
+#: static/js/impala/stats/chart.js:421 static/js/impala/stats/csv_keys.js:104 static/js/zamboni/stats-all.js:15385 static/js/zamboni/stats-all.js:17052 static/js/zamboni/stats-min.js:5
 msgid "Number of Contributions"
 msgstr "Katkı sayısı"
 
-#: static/js/impala/stats/chart.js:447
+#: static/js/impala/stats/chart.js:447 static/js/zamboni/stats-all.js:17078 static/js/zamboni/stats-min.js:5
 msgid "More Info..."
 msgstr "Daha fazla bilgi..."
 
 #. L10n: {0} is an ISO-formatted date.
-#: static/js/impala/stats/chart.js:451
+#: static/js/impala/stats/chart.js:451 static/js/zamboni/stats-all.js:17082 static/js/zamboni/stats-min.js:5
 msgid "Details for {0}"
 msgstr "{0} ayrıntıları"
 
-#: static/js/impala/stats/csv_keys.js:9
+#: static/js/impala/stats/csv_keys.js:9 static/js/zamboni/stats-all.js:15290 static/js/zamboni/stats-min.js:4
 msgid "Collections Created"
 msgstr "Oluşturulan koleksiyon"
 
-#: static/js/impala/stats/csv_keys.js:12
+#: static/js/impala/stats/csv_keys.js:12 static/js/zamboni/stats-all.js:15293 static/js/zamboni/stats-min.js:4
 msgid "Add-ons in Use"
 msgstr "Kullanımdaki eklenti"
 
-#: static/js/impala/stats/csv_keys.js:15
+#: static/js/impala/stats/csv_keys.js:15 static/js/zamboni/stats-all.js:15296 static/js/zamboni/stats-min.js:4
 msgid "Add-ons Created"
 msgstr "Oluşturulan eklenti"
 
-#: static/js/impala/stats/csv_keys.js:18
+#: static/js/impala/stats/csv_keys.js:18 static/js/zamboni/stats-all.js:15299 static/js/zamboni/stats-min.js:4
 msgid "Add-ons Downloaded"
 msgstr "İndirilen eklenti"
 
-#: static/js/impala/stats/csv_keys.js:21
+#: static/js/impala/stats/csv_keys.js:21 static/js/zamboni/stats-all.js:15302 static/js/zamboni/stats-min.js:4
 msgid "Add-ons Updated"
 msgstr "Güncellenen eklenti"
 
-#: static/js/impala/stats/csv_keys.js:24
+#: static/js/impala/stats/csv_keys.js:24 static/js/zamboni/stats-all.js:15305 static/js/zamboni/stats-min.js:4
 msgid "Reviews Written"
 msgstr "Yazılan inceleme"
 
-#: static/js/impala/stats/csv_keys.js:27
+#: static/js/impala/stats/csv_keys.js:27 static/js/zamboni/stats-all.js:15308 static/js/zamboni/stats-min.js:4
 msgid "User Signups"
 msgstr "Kullanıcı kaydı"
 
-#: static/js/impala/stats/csv_keys.js:30
+#: static/js/impala/stats/csv_keys.js:30 static/js/zamboni/stats-all.js:15311 static/js/zamboni/stats-min.js:4
 msgid "Subscribers"
 msgstr "Abone"
 
-#: static/js/impala/stats/csv_keys.js:33
+#: static/js/impala/stats/csv_keys.js:33 static/js/zamboni/stats-all.js:15314 static/js/zamboni/stats-min.js:4
 msgid "Ratings"
 msgstr "Puanlama"
 
-#: static/js/impala/stats/csv_keys.js:36 static/js/impala/stats/csv_keys.js:114
+#: static/js/impala/stats/csv_keys.js:36 static/js/impala/stats/csv_keys.js:114 static/js/zamboni/stats-all.js:15317 static/js/zamboni/stats-all.js:15395 static/js/zamboni/stats-min.js:4
+#: static/js/zamboni/stats-min.js:5
 msgid "Sales"
 msgstr "Satış"
 
-#: static/js/impala/stats/csv_keys.js:39 static/js/impala/stats/csv_keys.js:113
+#: static/js/impala/stats/csv_keys.js:39 static/js/impala/stats/csv_keys.js:113 static/js/zamboni/stats-all.js:15320 static/js/zamboni/stats-all.js:15394 static/js/zamboni/stats-min.js:4
+#: static/js/zamboni/stats-min.js:5
 msgid "Installs"
 msgstr "Kurulum"
 
-#: static/js/impala/stats/csv_keys.js:42
+#: static/js/impala/stats/csv_keys.js:42 static/js/zamboni/stats-all.js:15323 static/js/zamboni/stats-min.js:4
 msgid "Unknown"
 msgstr "Bilinmiyor"
 
-#: static/js/impala/stats/csv_keys.js:43
+#: static/js/impala/stats/csv_keys.js:43 static/js/zamboni/stats-all.js:15324 static/js/zamboni/stats-min.js:4
 msgid "Add-ons Manager"
 msgstr "Eklenti Yöneticisi"
 
-#: static/js/impala/stats/csv_keys.js:44
+#: static/js/impala/stats/csv_keys.js:44 static/js/zamboni/stats-all.js:15325 static/js/zamboni/stats-min.js:4
 msgid "Add-ons Manager Promo"
 msgstr "Eklenti Yöneticisi Tanıtım"
 
-#: static/js/impala/stats/csv_keys.js:45
+#: static/js/impala/stats/csv_keys.js:45 static/js/zamboni/stats-all.js:15326 static/js/zamboni/stats-min.js:4
 msgid "Add-ons Manager Featured"
 msgstr "Eklenti Yöneticisi Öne Çıkarılan"
 
-#: static/js/impala/stats/csv_keys.js:46
+#: static/js/impala/stats/csv_keys.js:46 static/js/zamboni/stats-all.js:15327 static/js/zamboni/stats-min.js:4
 msgid "Add-ons Manager Learn More"
 msgstr "Eklenti Yöneticisi Daha Fazla Bilgi Al"
 
-#: static/js/impala/stats/csv_keys.js:47
+#: static/js/impala/stats/csv_keys.js:47 static/js/zamboni/stats-all.js:15328 static/js/zamboni/stats-min.js:4
 msgid "Search Suggestions"
 msgstr "Arama Önerileri"
 
-#: static/js/impala/stats/csv_keys.js:48
+#: static/js/impala/stats/csv_keys.js:48 static/js/zamboni/stats-all.js:15329 static/js/zamboni/stats-min.js:4
 msgid "Search Results"
 msgstr "Arama Sonuçları"
 
-#: static/js/impala/stats/csv_keys.js:49 static/js/impala/stats/csv_keys.js:50 static/js/impala/stats/csv_keys.js:51
+#: static/js/impala/stats/csv_keys.js:49 static/js/impala/stats/csv_keys.js:50 static/js/impala/stats/csv_keys.js:51 static/js/zamboni/stats-all.js:15330 static/js/zamboni/stats-all.js:15331
+#: static/js/zamboni/stats-all.js:15332 static/js/zamboni/stats-min.js:4
 msgid "Homepage Promo"
 msgstr "Ana sayfa tanıtımı"
 
-#: static/js/impala/stats/csv_keys.js:52 static/js/impala/stats/csv_keys.js:53
+#: static/js/impala/stats/csv_keys.js:52 static/js/impala/stats/csv_keys.js:53 static/js/zamboni/stats-all.js:15333 static/js/zamboni/stats-all.js:15334 static/js/zamboni/stats-min.js:4
 msgid "Homepage Featured"
 msgstr "Ana sayfa vitrindekiler"
 
-#: static/js/impala/stats/csv_keys.js:54 static/js/impala/stats/csv_keys.js:55
+#: static/js/impala/stats/csv_keys.js:54 static/js/impala/stats/csv_keys.js:55 static/js/zamboni/stats-all.js:15335 static/js/zamboni/stats-all.js:15336 static/js/zamboni/stats-min.js:4
 msgid "Homepage Up and Coming"
 msgstr "Ana sayfa yükselenler"
 
-#: static/js/impala/stats/csv_keys.js:56
+#: static/js/impala/stats/csv_keys.js:56 static/js/zamboni/stats-all.js:15337 static/js/zamboni/stats-min.js:4
 msgid "Homepage Most Popular"
 msgstr "Ana sayfa en popüler"
 
-#: static/js/impala/stats/csv_keys.js:57 static/js/impala/stats/csv_keys.js:59
+#: static/js/impala/stats/csv_keys.js:57 static/js/impala/stats/csv_keys.js:59 static/js/zamboni/stats-all.js:15338 static/js/zamboni/stats-all.js:15340 static/js/zamboni/stats-min.js:4
 msgid "Detail Page"
 msgstr "Ayrıntı sayfası"
 
-#: static/js/impala/stats/csv_keys.js:58 static/js/impala/stats/csv_keys.js:60
+#: static/js/impala/stats/csv_keys.js:58 static/js/impala/stats/csv_keys.js:60 static/js/zamboni/stats-all.js:15339 static/js/zamboni/stats-all.js:15341 static/js/zamboni/stats-min.js:4
 msgid "Detail Page (bottom)"
 msgstr "Ayrıntı sayfası (alt)"
 
-#: static/js/impala/stats/csv_keys.js:61
+#: static/js/impala/stats/csv_keys.js:61 static/js/zamboni/stats-all.js:15342 static/js/zamboni/stats-min.js:4
 msgid "Detail Page (Development Channel)"
 msgstr "Ayrıntı sayfası (geliştirme kanalı)"
 
-#: static/js/impala/stats/csv_keys.js:62 static/js/impala/stats/csv_keys.js:63 static/js/impala/stats/csv_keys.js:64
+#: static/js/impala/stats/csv_keys.js:62 static/js/impala/stats/csv_keys.js:63 static/js/impala/stats/csv_keys.js:64 static/js/zamboni/stats-all.js:15343 static/js/zamboni/stats-all.js:15344
+#: static/js/zamboni/stats-all.js:15345 static/js/zamboni/stats-min.js:4
 msgid "Often Used With"
 msgstr "Sıklıkla birlikte kullanılanlar"
 
-#: static/js/impala/stats/csv_keys.js:65 static/js/impala/stats/csv_keys.js:66
+#: static/js/impala/stats/csv_keys.js:65 static/js/impala/stats/csv_keys.js:66 static/js/zamboni/stats-all.js:15346 static/js/zamboni/stats-all.js:15347 static/js/zamboni/stats-min.js:4
 msgid "Others By Author"
 msgstr "Bu yazardan"
 
-#: static/js/impala/stats/csv_keys.js:67 static/js/impala/stats/csv_keys.js:68
+#: static/js/impala/stats/csv_keys.js:67 static/js/impala/stats/csv_keys.js:68 static/js/zamboni/stats-all.js:15348 static/js/zamboni/stats-all.js:15349 static/js/zamboni/stats-min.js:4
 msgid "Dependencies"
 msgstr "Bağımlılıklar"
 
-#: static/js/impala/stats/csv_keys.js:69 static/js/impala/stats/csv_keys.js:70
+#: static/js/impala/stats/csv_keys.js:69 static/js/impala/stats/csv_keys.js:70 static/js/zamboni/stats-all.js:15350 static/js/zamboni/stats-all.js:15351 static/js/zamboni/stats-min.js:4
 msgid "Upsell"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:71
+#: static/js/impala/stats/csv_keys.js:71 static/js/zamboni/stats-all.js:15352 static/js/zamboni/stats-min.js:4
 msgid "Meet the Developer"
 msgstr "Geliştiriciyle tanışın"
 
-#: static/js/impala/stats/csv_keys.js:72
+#: static/js/impala/stats/csv_keys.js:72 static/js/zamboni/stats-all.js:15353 static/js/zamboni/stats-min.js:4
 msgid "User Profile"
 msgstr "Kullanıcı Kimliği"
 
-#: static/js/impala/stats/csv_keys.js:73
+#: static/js/impala/stats/csv_keys.js:73 static/js/zamboni/stats-all.js:15354 static/js/zamboni/stats-min.js:4
 msgid "Version History"
 msgstr "Sürüm Geçmişi"
 
-#: static/js/impala/stats/csv_keys.js:75
+#: static/js/impala/stats/csv_keys.js:75 static/js/zamboni/stats-all.js:15356 static/js/zamboni/stats-min.js:4
 msgid "Sharing"
 msgstr "Paylaşım"
 
-#: static/js/impala/stats/csv_keys.js:76
+#: static/js/impala/stats/csv_keys.js:76 static/js/zamboni/stats-all.js:15357 static/js/zamboni/stats-min.js:4
 msgid "Category Pages"
 msgstr "Kategori Sayfaları"
 
-#: static/js/impala/stats/csv_keys.js:77
+#: static/js/impala/stats/csv_keys.js:77 static/js/zamboni/stats-all.js:15358 static/js/zamboni/stats-min.js:4
 msgid "Collections"
 msgstr "Koleksiyonlar"
 
-#: static/js/impala/stats/csv_keys.js:78 static/js/impala/stats/csv_keys.js:79
+#: static/js/impala/stats/csv_keys.js:78 static/js/impala/stats/csv_keys.js:79 static/js/zamboni/stats-all.js:15359 static/js/zamboni/stats-all.js:15360 static/js/zamboni/stats-min.js:4
 msgid "Category Landing Featured Carousel"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:80 static/js/impala/stats/csv_keys.js:81
+#: static/js/impala/stats/csv_keys.js:80 static/js/impala/stats/csv_keys.js:81 static/js/zamboni/stats-all.js:15361 static/js/zamboni/stats-all.js:15362 static/js/zamboni/stats-min.js:4
 msgid "Category Landing Top Rated"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:82 static/js/impala/stats/csv_keys.js:83
+#: static/js/impala/stats/csv_keys.js:82 static/js/impala/stats/csv_keys.js:83 static/js/zamboni/stats-all.js:15363 static/js/zamboni/stats-all.js:15364 static/js/zamboni/stats-min.js:5
 msgid "Category Landing Most Popular"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:84 static/js/impala/stats/csv_keys.js:85
+#: static/js/impala/stats/csv_keys.js:84 static/js/impala/stats/csv_keys.js:85 static/js/zamboni/stats-all.js:15365 static/js/zamboni/stats-all.js:15366 static/js/zamboni/stats-min.js:5
 msgid "Category Landing Recently Added"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:86 static/js/impala/stats/csv_keys.js:87
+#: static/js/impala/stats/csv_keys.js:86 static/js/impala/stats/csv_keys.js:87 static/js/zamboni/stats-all.js:15367 static/js/zamboni/stats-all.js:15368 static/js/zamboni/stats-min.js:5
 msgid "Browse Listing Featured Sort"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:88 static/js/impala/stats/csv_keys.js:89
+#: static/js/impala/stats/csv_keys.js:88 static/js/impala/stats/csv_keys.js:89 static/js/zamboni/stats-all.js:15369 static/js/zamboni/stats-all.js:15370 static/js/zamboni/stats-min.js:5
 msgid "Browse Listing Users Sort"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:90 static/js/impala/stats/csv_keys.js:91
+#: static/js/impala/stats/csv_keys.js:90 static/js/impala/stats/csv_keys.js:91 static/js/zamboni/stats-all.js:15371 static/js/zamboni/stats-all.js:15372 static/js/zamboni/stats-min.js:5
 msgid "Browse Listing Rating Sort"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:92 static/js/impala/stats/csv_keys.js:93
+#: static/js/impala/stats/csv_keys.js:92 static/js/impala/stats/csv_keys.js:93 static/js/zamboni/stats-all.js:15373 static/js/zamboni/stats-all.js:15374 static/js/zamboni/stats-min.js:5
 msgid "Browse Listing Created Sort"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:94 static/js/impala/stats/csv_keys.js:95
+#: static/js/impala/stats/csv_keys.js:94 static/js/impala/stats/csv_keys.js:95 static/js/zamboni/stats-all.js:15375 static/js/zamboni/stats-all.js:15376 static/js/zamboni/stats-min.js:5
 msgid "Browse Listing Name Sort"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:96 static/js/impala/stats/csv_keys.js:97
+#: static/js/impala/stats/csv_keys.js:96 static/js/impala/stats/csv_keys.js:97 static/js/zamboni/stats-all.js:15377 static/js/zamboni/stats-all.js:15378 static/js/zamboni/stats-min.js:5
 msgid "Browse Listing Popular Sort"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:98 static/js/impala/stats/csv_keys.js:99
+#: static/js/impala/stats/csv_keys.js:98 static/js/impala/stats/csv_keys.js:99 static/js/zamboni/stats-all.js:15379 static/js/zamboni/stats-all.js:15380 static/js/zamboni/stats-min.js:5
 msgid "Browse Listing Updated Sort"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:100 static/js/impala/stats/csv_keys.js:101
+#: static/js/impala/stats/csv_keys.js:100 static/js/impala/stats/csv_keys.js:101 static/js/zamboni/stats-all.js:15381 static/js/zamboni/stats-all.js:15382 static/js/zamboni/stats-min.js:5
 msgid "Browse Listing Up and Coming Sort"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:105
+#: static/js/impala/stats/csv_keys.js:105 static/js/zamboni/stats-all.js:15386 static/js/zamboni/stats-min.js:5
 msgid "Total Amount Contributed"
 msgstr "Toplam Katkı Miktarı"
 
-#: static/js/impala/stats/csv_keys.js:106
+#: static/js/impala/stats/csv_keys.js:106 static/js/zamboni/stats-all.js:15387 static/js/zamboni/stats-min.js:5
 msgid "Average Contribution"
 msgstr "Ortalama Katkı"
 
-#: static/js/impala/stats/csv_keys.js:115
+#: static/js/impala/stats/csv_keys.js:115 static/js/zamboni/stats-all.js:15396 static/js/zamboni/stats-min.js:5
 msgid "Usage"
 msgstr "Kullanım"
 
-#: static/js/impala/stats/csv_keys.js:118
+#: static/js/impala/stats/csv_keys.js:118 static/js/zamboni/stats-all.js:15399 static/js/zamboni/stats-min.js:5
 msgid "Firefox"
 msgstr "Firefox"
 
-#: static/js/impala/stats/csv_keys.js:119
+#: static/js/impala/stats/csv_keys.js:119 static/js/zamboni/stats-all.js:15400 static/js/zamboni/stats-min.js:5
 msgid "Mozilla"
 msgstr "Mozilla"
 
-#: static/js/impala/stats/csv_keys.js:120
+#: static/js/impala/stats/csv_keys.js:120 static/js/zamboni/stats-all.js:15401 static/js/zamboni/stats-min.js:5
 msgid "Thunderbird"
 msgstr "Thunderbird"
 
-#: static/js/impala/stats/csv_keys.js:121
+#: static/js/impala/stats/csv_keys.js:121 static/js/zamboni/stats-all.js:15402 static/js/zamboni/stats-min.js:5
 msgid "Sunbird"
 msgstr "Sunbird"
 
-#: static/js/impala/stats/csv_keys.js:122
+#: static/js/impala/stats/csv_keys.js:122 static/js/zamboni/stats-all.js:15403 static/js/zamboni/stats-min.js:5
 msgid "SeaMonkey"
 msgstr "SeaMonkey"
 
-#: static/js/impala/stats/csv_keys.js:123
+#: static/js/impala/stats/csv_keys.js:123 static/js/zamboni/stats-all.js:15404 static/js/zamboni/stats-min.js:5
 msgid "Fennec"
 msgstr "Fennec"
 
-#: static/js/impala/stats/csv_keys.js:124
+#: static/js/impala/stats/csv_keys.js:124 static/js/zamboni/stats-all.js:15405 static/js/zamboni/stats-min.js:5
 msgid "Android"
 msgstr "Android"
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:129
+#: static/js/impala/stats/csv_keys.js:129 static/js/zamboni/stats-all.js:15410 static/js/zamboni/stats-min.js:5
 msgid "Downloads and Daily Users, last {0} days"
 msgstr "İndirmeler ve Günlük Kullanıcılar, son {0} gün"
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:131
+#: static/js/impala/stats/csv_keys.js:131 static/js/zamboni/stats-all.js:15412 static/js/zamboni/stats-min.js:5
 msgid "Downloads and Daily Users from {0} to {1}"
 msgstr "{0} - {1} Arası İndirmeler ve Günlük Kullanıcılar"
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:135
+#: static/js/impala/stats/csv_keys.js:135 static/js/zamboni/stats-all.js:15416 static/js/zamboni/stats-min.js:5
 msgid "Installs and Daily Users, last {0} days"
 msgstr "Kurulum ve Günlük Kullanıcı, son {0} gün"
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:137
+#: static/js/impala/stats/csv_keys.js:137 static/js/zamboni/stats-all.js:15418 static/js/zamboni/stats-min.js:5
 msgid "Installs and Daily Users from {0} to {1}"
 msgstr "Kurulum ve Günlük Kullanıcı, {0} - {1} arasında"
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:141
+#: static/js/impala/stats/csv_keys.js:141 static/js/zamboni/stats-all.js:15422 static/js/zamboni/stats-min.js:5
 msgid "Downloads, last {0} days"
 msgstr "İndirmeler, son {0} gün"
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:143
+#: static/js/impala/stats/csv_keys.js:143 static/js/zamboni/stats-all.js:15424 static/js/zamboni/stats-min.js:5
 msgid "Downloads from {0} to {1}"
 msgstr "{0} - {1} Arası İndirmeler"
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:147
+#: static/js/impala/stats/csv_keys.js:147 static/js/zamboni/stats-all.js:15428 static/js/zamboni/stats-min.js:5
 msgid "Daily Users, last {0} days"
 msgstr "Günlük Kullanıcılar, son {0} gün"
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:149
+#: static/js/impala/stats/csv_keys.js:149 static/js/zamboni/stats-all.js:15430 static/js/zamboni/stats-min.js:5
 msgid "Daily Users from {0} to {1}"
 msgstr "{0} - {1} Arası Günlük Kullanıcılar"
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:153
+#: static/js/impala/stats/csv_keys.js:153 static/js/zamboni/stats-all.js:15434 static/js/zamboni/stats-min.js:5
 msgid "Applications, last {0} days"
 msgstr "Uygulamalar, son {0} gün"
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:155
+#: static/js/impala/stats/csv_keys.js:155 static/js/zamboni/stats-all.js:15436 static/js/zamboni/stats-min.js:5
 msgid "Applications from {0} to {1}"
 msgstr "{0} - {1} Arası Uygulamalar"
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:159
+#: static/js/impala/stats/csv_keys.js:159 static/js/zamboni/stats-all.js:15440 static/js/zamboni/stats-min.js:5
 msgid "Platforms, last {0} days"
 msgstr "Platformlar, son {0} gün"
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:161
+#: static/js/impala/stats/csv_keys.js:161 static/js/zamboni/stats-all.js:15442 static/js/zamboni/stats-min.js:5
 msgid "Platforms from {0} to {1}"
 msgstr "{0} - {1} Arası Platformlar"
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:165
+#: static/js/impala/stats/csv_keys.js:165 static/js/zamboni/stats-all.js:15446 static/js/zamboni/stats-min.js:5
 msgid "Languages, last {0} days"
 msgstr "Diller, son {0} gün"
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:167
+#: static/js/impala/stats/csv_keys.js:167 static/js/zamboni/stats-all.js:15448 static/js/zamboni/stats-min.js:5
 msgid "Languages from {0} to {1}"
 msgstr "{0} - {1} Arası Diller"
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:171
+#: static/js/impala/stats/csv_keys.js:171 static/js/zamboni/stats-all.js:15452 static/js/zamboni/stats-min.js:5
 msgid "Add-on Versions, last {0} days"
 msgstr "Eklenti Sürümleri, son {0} gün"
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:173
+#: static/js/impala/stats/csv_keys.js:173 static/js/zamboni/stats-all.js:15454 static/js/zamboni/stats-min.js:5
 msgid "Add-on Versions from {0} to {1}"
 msgstr "{0} - {1} Arası Eklenti Sürümleri"
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:177
+#: static/js/impala/stats/csv_keys.js:177 static/js/zamboni/stats-all.js:15458 static/js/zamboni/stats-min.js:5
 msgid "Add-on Status, last {0} days"
 msgstr "Eklenti Durumu, son {0} gün"
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:179
+#: static/js/impala/stats/csv_keys.js:179 static/js/zamboni/stats-all.js:15460 static/js/zamboni/stats-min.js:5
 msgid "Add-on Status from {0} to {1}"
 msgstr "{0} - {1} Arası Eklenti Durumu"
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:183
+#: static/js/impala/stats/csv_keys.js:183 static/js/zamboni/stats-all.js:15464 static/js/zamboni/stats-min.js:5
 msgid "Download Sources, last {0} days"
 msgstr "İndirme Kaynakları, son {0} gün"
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:185
+#: static/js/impala/stats/csv_keys.js:185 static/js/zamboni/stats-all.js:15466 static/js/zamboni/stats-min.js:5
 msgid "Download Sources from {0} to {1}"
 msgstr "{0} - {1} Arası İndirme Kaynakları"
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:189
+#: static/js/impala/stats/csv_keys.js:189 static/js/zamboni/stats-all.js:15470 static/js/zamboni/stats-min.js:5
 msgid "Contributions, last {0} days"
 msgstr "Katkılar, son {0} gün"
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:191
+#: static/js/impala/stats/csv_keys.js:191 static/js/zamboni/stats-all.js:15472 static/js/zamboni/stats-min.js:5
 msgid "Contributions from {0} to {1}"
 msgstr "{0} - {1} Arası Katkılar"
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:195
+#: static/js/impala/stats/csv_keys.js:195 static/js/zamboni/stats-all.js:15476 static/js/zamboni/stats-min.js:5
 msgid "Site Metrics, last {0} days"
 msgstr "Site Ölçümleri, son {0} gün"
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:197
+#: static/js/impala/stats/csv_keys.js:197 static/js/zamboni/stats-all.js:15478 static/js/zamboni/stats-min.js:5
 msgid "Site Metrics from {0} to {1}"
 msgstr "Site Ölçümleri, {0} - {1} arasında"
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:201
+#: static/js/impala/stats/csv_keys.js:201 static/js/zamboni/stats-all.js:15482 static/js/zamboni/stats-min.js:5
 msgid "Add-ons in Use, last {0} days"
 msgstr "Kullanımdaki Eklentiler, son {0} gün"
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:203
+#: static/js/impala/stats/csv_keys.js:203 static/js/zamboni/stats-all.js:15484 static/js/zamboni/stats-min.js:5
 msgid "Add-ons in Use from {0} to {1}"
 msgstr "Kullanımdaki Eklentiler, {0} - {1} arasında"
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:207
+#: static/js/impala/stats/csv_keys.js:207 static/js/zamboni/stats-all.js:15488 static/js/zamboni/stats-min.js:5
 msgid "Add-ons Downloaded, last {0} days"
 msgstr "İndirilen Eklentiler, son {0} gün"
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:209
+#: static/js/impala/stats/csv_keys.js:209 static/js/zamboni/stats-all.js:15490 static/js/zamboni/stats-min.js:5
 msgid "Add-ons Downloaded from {0} to {1}"
 msgstr "İndirilen Eklentiler, {0} - {1} arasında"
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:213
+#: static/js/impala/stats/csv_keys.js:213 static/js/zamboni/stats-all.js:15494 static/js/zamboni/stats-min.js:5
 msgid "Add-ons Created, last {0} days"
 msgstr "Oluşturulan Eklentiler, son {0} gün"
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:215
+#: static/js/impala/stats/csv_keys.js:215 static/js/zamboni/stats-all.js:15496 static/js/zamboni/stats-min.js:5
 msgid "Add-ons Created from {0} to {1}"
 msgstr "Oluşturulan Eklentiler, {0} - {1} arasında"
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:219
+#: static/js/impala/stats/csv_keys.js:219 static/js/zamboni/stats-all.js:15500 static/js/zamboni/stats-min.js:5
 msgid "Add-ons Updated, last {0} days"
 msgstr "Güncellenen Eklentiler, son {0} gün"
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:221
+#: static/js/impala/stats/csv_keys.js:221 static/js/zamboni/stats-all.js:15502 static/js/zamboni/stats-min.js:5
 msgid "Add-ons Updated from {0} to {1}"
 msgstr "Güncellenen Eklentiler, {0} - {1} arasında"
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:225
+#: static/js/impala/stats/csv_keys.js:225 static/js/zamboni/stats-all.js:15506 static/js/zamboni/stats-min.js:5
 msgid "Reviews Written, last {0} days"
 msgstr "Yazılan İncelemeler, son {0} gün"
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:227
+#: static/js/impala/stats/csv_keys.js:227 static/js/zamboni/stats-all.js:15508 static/js/zamboni/stats-min.js:5
 msgid "Reviews Written from {0} to {1}"
 msgstr "Yazılan İncelemeler, {0} - {1} arasında"
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:231
+#: static/js/impala/stats/csv_keys.js:231 static/js/zamboni/stats-all.js:15512 static/js/zamboni/stats-min.js:5
 msgid "User Signups, last {0} days"
 msgstr "Yeni Kullanıcı Kayıtları, son {0} gün"
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:233
+#: static/js/impala/stats/csv_keys.js:233 static/js/zamboni/stats-all.js:15514 static/js/zamboni/stats-min.js:5
 msgid "User Signups from {0} to {1}"
 msgstr "Yeni Kullanıcı Kayıtları, {0} - {1} arasında"
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:237
+#: static/js/impala/stats/csv_keys.js:237 static/js/zamboni/stats-all.js:15518 static/js/zamboni/stats-min.js:5
 msgid "Collections Created, last {0} days"
 msgstr "Oluşturulan Koleksiyonlar, son {0} gün"
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:239
+#: static/js/impala/stats/csv_keys.js:239 static/js/zamboni/stats-all.js:15520 static/js/zamboni/stats-min.js:5
 msgid "Collections Created from {0} to {1}"
 msgstr "Oluşturulan Koleksiyonlar, {0} - {1} arasında"
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:243
+#: static/js/impala/stats/csv_keys.js:243 static/js/zamboni/stats-all.js:15524 static/js/zamboni/stats-min.js:5
 msgid "Subscribers, last {0} days"
 msgstr "Aboneler, son {0} gün"
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:245
+#: static/js/impala/stats/csv_keys.js:245 static/js/zamboni/stats-all.js:15526 static/js/zamboni/stats-min.js:5
 msgid "Subscribers from {0} to {1}"
 msgstr "Aboneler, {0} - {1} arasında"
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:249
+#: static/js/impala/stats/csv_keys.js:249 static/js/zamboni/stats-all.js:15530 static/js/zamboni/stats-min.js:5
 msgid "Ratings, last {0} days"
 msgstr "Değerlendirmeler, son {0} gün"
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:251
+#: static/js/impala/stats/csv_keys.js:251 static/js/zamboni/stats-all.js:15532 static/js/zamboni/stats-min.js:5
 msgid "Ratings from {0} to {1}"
 msgstr "Değerlendirmeler, {0} - {1} arasında"
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:255
+#: static/js/impala/stats/csv_keys.js:255 static/js/zamboni/stats-all.js:15536 static/js/zamboni/stats-min.js:5
 msgid "Sales, last {0} days"
 msgstr "Satışlar, son {0} gün"
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:257
+#: static/js/impala/stats/csv_keys.js:257 static/js/zamboni/stats-all.js:15538 static/js/zamboni/stats-min.js:5
 msgid "Sales from {0} to {1}"
 msgstr "Satışlar, {0} - {1} arasında"
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:261
+#: static/js/impala/stats/csv_keys.js:261 static/js/zamboni/stats-all.js:15542 static/js/zamboni/stats-min.js:5
 msgid "Installs, last {0} days"
 msgstr "Kurulumlar, son {0} gün"
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:263
+#: static/js/impala/stats/csv_keys.js:263 static/js/zamboni/stats-all.js:15544 static/js/zamboni/stats-min.js:5
 msgid "Installs from {0} to {1}"
 msgstr "Kurulumlar, {0} - {1} arasında"
 
 #. L10n: {0} and {1} are integers.
-#: static/js/impala/stats/csv_keys.js:269
+#: static/js/impala/stats/csv_keys.js:269 static/js/zamboni/stats-all.js:15550 static/js/zamboni/stats-min.js:5
 msgid "<b>{0}</b> in last {1} days"
 msgstr "son {1} günde <b>{0}</b>"
 
 #. L10n: {0} is an integer and {1} and {2} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:271 static/js/impala/stats/csv_keys.js:277
+#: static/js/impala/stats/csv_keys.js:271 static/js/impala/stats/csv_keys.js:277 static/js/zamboni/stats-all.js:15552 static/js/zamboni/stats-all.js:15558 static/js/zamboni/stats-min.js:5
 msgid "<b>{0}</b> from {1} to {2}"
 msgstr "{1} - {2} arasında <b>{0}</b>"
 
 #. L10n: {0} and {1} are integers.
-#: static/js/impala/stats/csv_keys.js:275
+#: static/js/impala/stats/csv_keys.js:275 static/js/zamboni/stats-all.js:15556 static/js/zamboni/stats-min.js:5
 msgid "<b>{0}</b> average in last {1} days"
 msgstr "son {1} günde ortalama <b>{0}</b>"
 
-#: static/js/impala/stats/overview.js:19
+#: static/js/impala/stats/overview.js:19 static/js/zamboni/stats-all.js:16469 static/js/zamboni/stats-min.js:5
 msgid "No data available."
 msgstr "Veri yok."
 
-#: static/js/impala/stats/table.js:74
+#: static/js/impala/stats/table.js:74 static/js/zamboni/stats-all.js:17209 static/js/zamboni/stats-min.js:5
 msgid "Date"
 msgstr "Tarih"
 
-#: static/js/impala/stats/topchart.js:96
+#: static/js/impala/stats/topchart.js:96 static/js/zamboni/stats-all.js:16600 static/js/zamboni/stats-min.js:5
 msgid "Other"
 msgstr "Diğer"
 
-#: static/js/zamboni/admin_validation.js:24 static/js/zamboni/devhub.js:1229 static/js/zamboni/editors.js:295
+#: static/js/zamboni/admin-all.js:180 static/js/zamboni/admin-min.js:1 static/js/zamboni/admin_validation.js:24 static/js/zamboni/devhub-all.js:2408 static/js/zamboni/devhub-min.js:2
+#: static/js/zamboni/devhub.js:1229 static/js/zamboni/editors-all.js:15576 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:295
 msgid "Select an application first"
 msgstr "Önce bir uygulama seçin"
 
-#: static/js/zamboni/admin_validation.js:51
+#: static/js/zamboni/admin-all.js:207 static/js/zamboni/admin-min.js:1 static/js/zamboni/admin_validation.js:51
 msgid "Set {0} add-on to a max version of {1} and email the author."
 msgid_plural "Set {0} add-ons to a max version of {1} and email the authors."
 msgstr[0] "{0} eklentinin maksimum sürümünü {1} olarak ayarla ve geliştiricilere e-posta gönder."
+msgstr[1] ""
 
-#: static/js/zamboni/admin_validation.js:54
+#: static/js/zamboni/admin-all.js:210 static/js/zamboni/admin-min.js:1 static/js/zamboni/admin_validation.js:54
 msgid "Email author of {2} add-on which failed validation."
 msgid_plural "Email authors of {2} add-ons which failed validation."
 msgstr[0] "Doğrulamayı geçemeyen {2} eklentisinin yazarına e-posta gönder."
+msgstr[1] ""
 
-#. L10n: {0} is an app name like Firefox.
-#: static/js/zamboni/buttons.js:66
-msgid "Accept and Install"
-msgstr "Kabul et ve kur"
-
-#: static/js/zamboni/buttons.js:66
-msgid "Add to {0}"
-msgstr "{0}'a Ekle"
-
-#: static/js/zamboni/buttons.js:71
-msgid "Download Now"
-msgstr "Şimdi İndir"
-
-#: static/js/zamboni/buttons.js:112
-msgid "Add-on has not been updated to support default-to-compatible."
-msgstr ""
-
-#: static/js/zamboni/buttons.js:117
-msgid "You need to be using Firefox 10.0 or higher."
-msgstr "Firefox 10.0 ve üstü bir sürüm kullanmanız gerek."
-
-#: static/js/zamboni/buttons.js:129
-msgid "Mozilla has marked this version as incompatible with your Firefox version."
-msgstr "Mozilla bu sürümü Firefox sürümünüz ile uyumsuz olarak işaretledi."
-
-#. L10n: {0} is an platform like Windows or Linux.
-#: static/js/zamboni/buttons.js:210
-msgid "Install for {0} anyway"
-msgstr "Yine de {0} için yükle"
-
-#: static/js/zamboni/buttons.js:210
-msgid "Download for {0} anyway"
-msgstr "Yine de {0} için indir"
-
-#: static/js/zamboni/buttons.js:267
-msgid "Not available for your platform"
-msgstr "Sizin platformunuz için mevcut değil"
-
-#. L10n: {0} is an app name, {1} is the app version.
-#: static/js/zamboni/buttons.js:278 static/js/zamboni/buttons.js:315
-msgid "Not available for {0} {1}"
-msgstr "{0} {1} için mevcut değil"
-
-#: static/js/zamboni/buttons.js:341
-msgid "Works with {app} {min} - {max}"
-msgstr "{app} {min} - {max} ile çalışır"
-
-#: static/js/zamboni/buttons.js:343
-msgid "View other versions"
-msgstr "Diğer sürümleri görüntüle"
-
-#: static/js/zamboni/buttons.js:391
-msgid "Only with Firefox — Get Firefox Now!"
-msgstr "Yalnızca Firefox ile — Firefox'u hemen indirin!"
-
-#: static/js/zamboni/buttons.js:507 static/js/zamboni/mobile/buttons.js:43
-msgid "Sorry, you need a Mozilla-based browser (such as Firefox) to install a search plugin."
-msgstr "Üzgünüz, arama eklentisi yükleyebilmeniz için Mozilla tabanlı (örn. Firefox) bir tarayıcıya ihtiyacınız var."
-
-#: static/js/zamboni/collections.js:229
-msgid "Adding to Favorites&hellip;"
-msgstr "Favorilere ekleniyor&hellip;"
-
-#: static/js/zamboni/collections.js:232
-msgid "Removing Favorite&hellip;"
-msgstr "Favorilerden kaldırılıyor&hellip;"
-
-#: static/js/zamboni/collections.js:235
-msgid "Add to Favorites"
-msgstr "Favorilere Ekle"
-
-#: static/js/zamboni/collections.js:238
-msgid "Remove from Favorites"
-msgstr "Favorilerden Kaldır"
-
-#: static/js/zamboni/collections.js:303
-msgid "Pending"
-msgstr "Beklemede"
-
-#: static/js/zamboni/collections.js:304
-msgid "Add a comment"
-msgstr "Yorum ekle"
-
-#: static/js/zamboni/collections.js:304
-msgid "Comment"
-msgstr "Yorum"
-
-#: static/js/zamboni/collections.js:305
-msgid "Remove this add-on from the collection"
-msgstr "Bu eklentiyi koleksiyondan kaldır"
-
-#: static/js/zamboni/collections.js:305 static/js/zamboni/collections.js:334
-msgid "Remove"
-msgstr "Kaldır"
-
-#: static/js/zamboni/collections.js:334
-msgid "Remove this user as a contributor"
-msgstr "Bu kullanıcıyı katkıda bulunanlardan çıkar"
-
-#: static/js/zamboni/collections.js:346
-msgid "An email address is required."
-msgstr "Bir e-posta adresi gereklidir."
-
-#: static/js/zamboni/collections.js:364
-msgid "You cannot add yourself as a contributor."
-msgstr "Kendinizi katkıda bulunan olarak ekleyemezsiniz."
-
-#: static/js/zamboni/collections.js:366
-msgid "You have already added that user."
-msgstr "Bu kullanıcıyı zaten eklediniz."
-
-#: static/js/zamboni/collections.js:573
-msgid "Add to favorites"
-msgstr "Favorilerime ekle"
-
-#: static/js/zamboni/collections.js:577
-msgid "Remove from favorites"
-msgstr "Favorilerimden kaldır"
-
-#: static/js/zamboni/collections.js:604
-msgid "Stop following"
-msgstr "İzlemeyi durdur"
-
-#: static/js/zamboni/devhub.js:110
+#: static/js/zamboni/devhub-all.js:1289 static/js/zamboni/devhub-min.js:1 static/js/zamboni/devhub.js:110
 msgid "Your browser does not support the video tag"
 msgstr "Tarayıcınız video etiketini desteklemiyor"
 
-#: static/js/zamboni/devhub.js:371
+#: static/js/zamboni/devhub-all.js:1550 static/js/zamboni/devhub-min.js:1 static/js/zamboni/devhub.js:371
 msgid "Changes Saved"
 msgstr "Değişiklikler kaydedildi"
 
-#: static/js/zamboni/devhub.js:387
+#: static/js/zamboni/devhub-all.js:1566 static/js/zamboni/devhub-min.js:1 static/js/zamboni/devhub.js:387
 msgid "Enter a new author's email address"
 msgstr "Yeni geliştiricinin e-posta adresini girin"
 
-#: static/js/zamboni/devhub.js:536
+#: static/js/zamboni/devhub-all.js:1715 static/js/zamboni/devhub-min.js:1 static/js/zamboni/devhub.js:536
 msgid "There was an error uploading your file."
 msgstr "Dosyanız yüklenirken bir hata oluştu."
 
-#: static/js/zamboni/devhub.js:681
+#: static/js/zamboni/devhub-all.js:1860 static/js/zamboni/devhub-min.js:1 static/js/zamboni/devhub.js:681
 msgid "{files} file"
 msgid_plural "{files} files"
 msgstr[0] "{files} dosya"
+msgstr[1] ""
 
-#: static/js/zamboni/devhub.js:684
+#: static/js/zamboni/devhub-all.js:1863 static/js/zamboni/devhub-min.js:1 static/js/zamboni/devhub.js:684
 msgid "{reviews} user review"
 msgid_plural "{reviews} user reviews"
 msgstr[0] "{reviews} kullanıcı incelemesi"
+msgstr[1] ""
 
-#: static/js/zamboni/devhub.js:796
+#: static/js/zamboni/devhub-all.js:1975 static/js/zamboni/devhub-min.js:2 static/js/zamboni/devhub.js:796
 msgid "Learn more"
 msgstr "Daha fazla bilgi"
 
-#: static/js/zamboni/devhub.js:800
+#: static/js/zamboni/devhub-all.js:1979 static/js/zamboni/devhub-min.js:2 static/js/zamboni/devhub.js:800
 msgid "Example"
 msgstr "Örnek"
 
-#: static/js/zamboni/devhub.js:1130
+#: static/js/zamboni/devhub-all.js:2309 static/js/zamboni/devhub-min.js:2 static/js/zamboni/devhub.js:1130
 msgid "Image changes being processed"
 msgstr "Resim değişiklikleri işleniyor"
 
-#: static/js/zamboni/devhub.js:1280
+#: static/js/zamboni/devhub-all.js:2459 static/js/zamboni/devhub-min.js:2 static/js/zamboni/devhub.js:1280
 msgid "Must be a valid e-mail address."
 msgstr "Geçerli bir e-posta adresi olmalı."
+
+#: static/js/zamboni/devhub-all.js:2613 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:80
+msgid "All tests passed successfully."
+msgstr "Tüm testler başarıyla geçildi."
+
+#: static/js/zamboni/devhub-all.js:2616 static/js/zamboni/devhub-all.js:3011 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:83 static/js/zamboni/validator.js:478
+msgid "These tests were not run."
+msgstr "Bu testler çalıştırılmadı."
+
+#: static/js/zamboni/devhub-all.js:2664 static/js/zamboni/devhub-all.js:2677 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:131 static/js/zamboni/validator.js:144
+msgid "Tests"
+msgstr "Testler"
+
+#: static/js/zamboni/devhub-all.js:2779 static/js/zamboni/devhub-all.js:3108 static/js/zamboni/devhub-all.js:3127 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:246
+#: static/js/zamboni/validator.js:575 static/js/zamboni/validator.js:594
+msgid "Error"
+msgstr "Hata"
+
+#: static/js/zamboni/devhub-all.js:2780 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:247
+msgid "Warning"
+msgstr "Uyarı"
+
+#: static/js/zamboni/devhub-all.js:2794 static/js/zamboni/devhub-min.js:2 static/js/zamboni/files-all.js:5657 static/js/zamboni/files-min.js:3 static/js/zamboni/files.js:411
+#: static/js/zamboni/validator.js:261
+msgid "Ignore this message in future updates"
+msgstr "Gelecekteki güncellemelerde bu iletiyi yok say"
+
+#: static/js/zamboni/devhub-all.js:2817 static/js/zamboni/devhub-min.js:2 static/js/zamboni/files-all.js:5663 static/js/zamboni/files-min.js:3 static/js/zamboni/files.js:417
+#: static/js/zamboni/validator.js:284
+msgid "Severity for automated signing:"
+msgstr "Otomatik imzalamanın önem derecesi:"
+
+#: static/js/zamboni/devhub-all.js:2832 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:299
+msgid "Suggestions for passing automated signing:"
+msgstr "Otomatik imzalamaya geçmek için öneriler:"
+
+#: static/js/zamboni/devhub-all.js:2920 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:387
+msgid "Compatibility Tests"
+msgstr "Uyumluluk Testleri"
+
+#: static/js/zamboni/devhub-all.js:2999 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:466
+msgid "Add-on failed validation."
+msgstr "Eklenti, doğrulamadan geçemedi."
+
+#: static/js/zamboni/devhub-all.js:3001 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:468
+msgid "Add-on passed validation."
+msgstr "Eklenti, doğrulamadan geçti."
+
+#: static/js/zamboni/devhub-all.js:3014 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:481
+msgid "{0} error"
+msgid_plural "{0} errors"
+msgstr[0] "{0} hata"
+msgstr[1] ""
+
+#: static/js/zamboni/devhub-all.js:3016 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:483
+msgid "{0} warning"
+msgid_plural "{0} warnings"
+msgstr[0] "{0} uyarı"
+msgstr[1] ""
+
+#: static/js/zamboni/devhub-all.js:3018 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:485
+msgid "{0} notice"
+msgid_plural "{0} notices"
+msgstr[0] "{0} bildirim"
+msgstr[1] ""
+
+#: static/js/zamboni/devhub-all.js:3110 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:577
+msgid "Validation task could not complete or completed with errors"
+msgstr "Doğrulama görevi tamamlanmadı veya hatalı olarak tamamlandı"
+
+#: static/js/zamboni/devhub-all.js:3128 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:595
+msgid "Internal server error"
+msgstr "İç sunucu hatası"
 
 #: static/js/zamboni/devhub_search.js:8
 msgid "No results found."
 msgstr "Sonuç bulunamadı."
 
-#: static/js/zamboni/editors.js:121
+#: static/js/zamboni/editors-all.js:15402 static/js/zamboni/editors-min.js:4 static/js/zamboni/editors.js:121
 msgid "{name} was viewing this page first."
 msgstr "{name} bu sayfayı ilk olarak inceliyordu."
 
-#: static/js/zamboni/editors.js:171
+#: static/js/zamboni/editors-all.js:15452 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:171
 msgid "Receipt checked by app."
 msgstr "Alındı bilgisi uygulama tarafından denetlendi."
 
-#: static/js/zamboni/editors.js:173
+#: static/js/zamboni/editors-all.js:15454 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:173
 msgid "Receipt was not checked by app."
 msgstr "Alındı bilgisi uygulama tarafından denetlenmedi."
 
-#: static/js/zamboni/editors.js:244
+#: static/js/zamboni/editors-all.js:15525 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:244
 msgid "{name} was viewing this add-on first."
 msgstr "İlk {name} bu eklentiye bakıyordu."
 
-#: static/js/zamboni/editors.js:255
+#: static/js/zamboni/editors-all.js:15536 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:255
 msgid "Loading&hellip;"
 msgstr "Yükleniyor&hellip;"
 
-#: static/js/zamboni/editors.js:260
+#: static/js/zamboni/editors-all.js:15541 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:260
 msgid "Version Notes"
 msgstr "Sürüm Notları"
 
-#: static/js/zamboni/editors.js:265
+#: static/js/zamboni/editors-all.js:15546 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:265
 msgid "Notes for Reviewers"
 msgstr "Yorumcular İçin Notlar"
 
-#: static/js/zamboni/editors.js:270
+#: static/js/zamboni/editors-all.js:15551 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:270
 msgid "No version notes found"
 msgstr "Hiçbir sürüm notu bulunamadı"
 
-#: static/js/zamboni/editors.js:330
+#: static/js/zamboni/editors-all.js:15611 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:330
 msgid "Average Reviews"
 msgstr ""
 
-#: static/js/zamboni/editors.js:386
+#: static/js/zamboni/editors-all.js:15667 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:386
 msgid "Number of Reviews"
 msgstr ""
 
-#: static/js/zamboni/editors.js:445
+#: static/js/zamboni/editors-all.js:15726 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:445
 msgid "Error loading translation"
 msgstr "Çeviri yüklemede hata"
 
-#: static/js/zamboni/files.js:411 static/js/zamboni/validator.js:261
-msgid "Ignore this message in future updates"
-msgstr "Gelecekteki güncellemelerde bu iletiyi yok say"
-
-#: static/js/zamboni/files.js:417 static/js/zamboni/validator.js:284
-msgid "Severity for automated signing:"
-msgstr "Otomatik imzalamanın önem derecesi:"
-
-#: static/js/zamboni/global.js:410
-msgid "Loading..."
-msgstr "Yükleniyor..."
-
-#. L10n: {0} is the number of characters left.
-#: static/js/zamboni/global.js:474
-msgid "<b>{0}</b> character left."
-msgid_plural "<b>{0}</b> characters left."
-msgstr[0] "<b>{0}</b> karakter kaldı."
-
-#: static/js/zamboni/init.js:28
-msgid "This feature is temporarily disabled while we perform website maintenance. Please check back a little later."
-msgstr "Bakım nedeniyle bu özellik şu anda devre dışıdır. Lütfen daha sonra tekrar deneyin."
-
-#: static/js/zamboni/l10n.js:45
-msgid "Remove this localization"
-msgstr "Bu yerelleştirmeyi kaldır"
-
-#: static/js/zamboni/password-strength.js:20
-msgid "Password strength:"
-msgstr "Parola gücü:"
-
-#: static/js/zamboni/password-strength.js:26
-msgid "At least {0} character left."
-msgid_plural "At least {0} characters left."
-msgstr[0] "En az {0} karakter kaldı."
-
-#: static/js/zamboni/themes_review.js:176
-msgid "Requested Info"
-msgstr "İstenen Bilgi"
-
-#: static/js/zamboni/themes_review.js:177
-msgid "Flagged"
-msgstr "İşaretlendi"
-
-#: static/js/zamboni/themes_review.js:178
-msgid "Duplicate"
-msgstr "Çift kopya"
-
-#: static/js/zamboni/themes_review.js:179
-msgid "Rejected"
-msgstr "Reddedildi"
-
-#: static/js/zamboni/themes_review.js:180
-msgid "Approved"
-msgstr "Onaylandı"
-
-#: static/js/zamboni/themes_review.js:424
-msgid "No results found"
-msgstr ""
-
-#: static/js/zamboni/themes_review_templates.js:31
+#: static/js/zamboni/editors-all.js:15975 static/js/zamboni/editors-min.js:5 static/js/zamboni/themes_review_templates.js:31
 msgid "Theme"
 msgstr ""
 
-#: static/js/zamboni/themes_review_templates.js:33
+#: static/js/zamboni/editors-all.js:15977 static/js/zamboni/editors-min.js:5 static/js/zamboni/themes_review_templates.js:33
 msgid "Reviewer"
 msgstr ""
 
-#: static/js/zamboni/themes_review_templates.js:35
+#: static/js/zamboni/editors-all.js:15979 static/js/zamboni/editors-min.js:5 static/js/zamboni/themes_review_templates.js:35
 msgid "Status"
 msgstr ""
 
-#: static/js/zamboni/validator.js:80
-msgid "All tests passed successfully."
-msgstr "Tüm testler başarıyla geçildi."
+#: static/js/zamboni/editors-all.js:16196 static/js/zamboni/editors-min.js:5 static/js/zamboni/themes_review.js:176
+msgid "Requested Info"
+msgstr "İstenen Bilgi"
 
-#: static/js/zamboni/validator.js:83 static/js/zamboni/validator.js:478
-msgid "These tests were not run."
-msgstr "Bu testler çalıştırılmadı."
+#: static/js/zamboni/editors-all.js:16197 static/js/zamboni/editors-min.js:5 static/js/zamboni/themes_review.js:177
+msgid "Flagged"
+msgstr "İşaretlendi"
 
-#: static/js/zamboni/validator.js:131 static/js/zamboni/validator.js:144
-msgid "Tests"
-msgstr "Testler"
+#: static/js/zamboni/editors-all.js:16198 static/js/zamboni/editors-min.js:5 static/js/zamboni/themes_review.js:178
+msgid "Duplicate"
+msgstr "Çift kopya"
 
-#: static/js/zamboni/validator.js:246 static/js/zamboni/validator.js:575 static/js/zamboni/validator.js:594
-msgid "Error"
-msgstr "Hata"
+#: static/js/zamboni/editors-all.js:16199 static/js/zamboni/editors-min.js:5 static/js/zamboni/themes_review.js:179
+msgid "Rejected"
+msgstr "Reddedildi"
 
-#: static/js/zamboni/validator.js:247
-msgid "Warning"
-msgstr "Uyarı"
+#: static/js/zamboni/editors-all.js:16200 static/js/zamboni/editors-min.js:5 static/js/zamboni/themes_review.js:180
+msgid "Approved"
+msgstr "Onaylandı"
 
-#: static/js/zamboni/validator.js:299
-msgid "Suggestions for passing automated signing:"
-msgstr "Otomatik imzalamaya geçmek için öneriler:"
+#: static/js/zamboni/editors-all.js:16444 static/js/zamboni/editors-min.js:5 static/js/zamboni/themes_review.js:424
+msgid "No results found"
+msgstr ""
 
-#: static/js/zamboni/validator.js:387
-msgid "Compatibility Tests"
-msgstr "Uyumluluk Testleri"
-
-#: static/js/zamboni/validator.js:466
-msgid "Add-on failed validation."
-msgstr "Eklenti, doğrulamadan geçemedi."
-
-#: static/js/zamboni/validator.js:468
-msgid "Add-on passed validation."
-msgstr "Eklenti, doğrulamadan geçti."
-
-#: static/js/zamboni/validator.js:481
-msgid "{0} error"
-msgid_plural "{0} errors"
-msgstr[0] "{0} hata"
-
-#: static/js/zamboni/validator.js:483
-msgid "{0} warning"
-msgid_plural "{0} warnings"
-msgstr[0] "{0} uyarı"
-
-#: static/js/zamboni/validator.js:485
-msgid "{0} notice"
-msgid_plural "{0} notices"
-msgstr[0] "{0} bildirim"
-
-#: static/js/zamboni/validator.js:577
-msgid "Validation task could not complete or completed with errors"
-msgstr "Doğrulama görevi tamamlanmadı veya hatalı olarak tamamlandı"
-
-#: static/js/zamboni/validator.js:595
-msgid "Internal server error"
-msgstr "İç sunucu hatası"
-
-#: static/js/zamboni/mobile/buttons.js:52
+#: static/js/zamboni/mobile-all.js:15186 static/js/zamboni/mobile/buttons.js:52
 msgid "Not Updated for {0} {1}"
 msgstr "{0} {1} için güncellenmemiş"
 
-#: static/js/zamboni/mobile/buttons.js:53
+#: static/js/zamboni/mobile-all.js:15187 static/js/zamboni/mobile/buttons.js:53
 msgid "Requires Newer Version of {0}"
 msgstr "{0}'un daha yeni sürümünü gerektiriyor"
 
-#: static/js/zamboni/mobile/buttons.js:54
+#: static/js/zamboni/mobile-all.js:15188 static/js/zamboni/mobile/buttons.js:54
 msgid "Unreviewed"
 msgstr "İncelenmemiş"
 
-#: static/js/zamboni/mobile/buttons.js:55
+#: static/js/zamboni/mobile-all.js:15189 static/js/zamboni/mobile/buttons.js:55
 msgid "Experimental <span>(Learn More)</span>"
 msgstr "Deneysel <span>(Daha fazla bilgi)</ span>"
 
-#: static/js/zamboni/mobile/buttons.js:56 static/js/zamboni/mobile/buttons.js:57
+#: static/js/zamboni/mobile-all.js:15190 static/js/zamboni/mobile-all.js:15191 static/js/zamboni/mobile/buttons.js:56 static/js/zamboni/mobile/buttons.js:57
 msgid "Not Available for {0}"
 msgstr "{0} için mevcut değil"
 
-#: static/js/zamboni/mobile/buttons.js:58
+#: static/js/zamboni/mobile-all.js:15192 static/js/zamboni/mobile/buttons.js:58
 msgid "Experimental"
 msgstr "Deneysel"
 
-#: static/js/zamboni/mobile/buttons.js:59
+#: static/js/zamboni/mobile-all.js:15193 static/js/zamboni/mobile/buttons.js:59
 msgid "Themes Require Newer Version of {0}"
 msgstr "Temalar Daha Yeni {0} Sürümü Gerektiriyor"
 
-#: static/js/zamboni/mobile/buttons.js:60
+#: static/js/zamboni/mobile-all.js:15194 static/js/zamboni/mobile/buttons.js:60
 msgid "Themes Require {0}"
 msgstr "Temalar {0} Gerektiriyor"
 
-#: static/js/zamboni/mobile/buttons.js:105
+#: static/js/zamboni/mobile-all.js:15239 static/js/zamboni/mobile/buttons.js:105
 msgid "Installing..."
 msgstr "Yükleniyor..."
 
-#: static/js/zamboni/mobile/buttons.js:125
+#: static/js/zamboni/mobile-all.js:15259 static/js/zamboni/mobile/buttons.js:125
 msgid "This add-on has been preliminarily reviewed by Mozilla."
 msgstr "Bu eklenti, Mozilla tarafından ön incelemeden geçirilmiştir."
 
-#: static/js/zamboni/mobile/buttons.js:250
+#: static/js/zamboni/mobile-all.js:15384 static/js/zamboni/mobile/buttons.js:250
 msgid "Keep it"
 msgstr "Kalsın"
 
-#: static/js/zamboni/mobile/general.js:344
+#: static/js/zamboni/mobile-all.js:16049 static/js/zamboni/mobile-min.js:6 static/js/zamboni/mobile/general.js:344
 msgid "You're trying it on!"
 msgstr "Deniyorsunuz!"
 
-#: static/js/zamboni/mobile/general.js:356
+#: static/js/zamboni/mobile-all.js:16061 static/js/zamboni/mobile-min.js:6 static/js/zamboni/mobile/general.js:356
 msgid "Added to Firefox"
 msgstr "Firefox'a eklendi"
-

--- a/locale/uk/LC_MESSAGES/django.po
+++ b/locale/uk/LC_MESSAGES/django.po
@@ -8,84 +8,72 @@
 # Andriy Radyk <ander@mozilla.org.ua>, 2010.
 msgid ""
 msgstr ""
-"Project-Id-Version: \n"
+"Project-Id-Version:  \n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2016-02-24 21:23+0000\n"
+"POT-Creation-Date: 2016-04-18 15:40+0000\n"
 "PO-Revision-Date: 2016-04-10 18:04+0000\n"
 "Last-Translator: Artem Polivanchuk <a.polivanchuk@outlook.com>\n"
 "Language-Team: \n"
-"Language: uk\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=3; plural=(n%10==1 && n%100!=11 ? 0 : n%10>=2 && n%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2);\n"
 "Generated-By: Babel 2.2.0\n"
-"X-Generator: Pontoon\n"
-
-#: src/olympia/accounts/views.py:52
-msgid "Your log in attempt could not be parsed. Please try again."
-msgstr ""
-"Ваша спроба входу не може бути оброблена. Будь ласка, спробуйте знову."
 
 #: src/olympia/accounts/views.py:54
-msgid "Your Firefox Account could not be found. Please try again."
-msgstr ""
-"Не вдалося знайти Ваш обліковий запис Firefox. Будь ласка, спробуйте ще раз."
+msgid "Your log in attempt could not be parsed. Please try again."
+msgstr "Ваша спроба входу не може бути оброблена. Будь ласка, спробуйте знову."
 
-#: src/olympia/accounts/views.py:55
+#: src/olympia/accounts/views.py:56
+msgid "Your Firefox Account could not be found. Please try again."
+msgstr "Не вдалося знайти Ваш обліковий запис Firefox. Будь ласка, спробуйте ще раз."
+
+#: src/olympia/accounts/views.py:57
 msgid "You could not be logged in. Please try again."
 msgstr "Не вдається виконати вхід. Будь ласка, спробуйте знову."
 
-#: src/olympia/accounts/views.py:57
+#: src/olympia/accounts/views.py:59
 msgid "Your account has already been migrated to Firefox Accounts."
 msgstr "Ваш обліковий запис вже перенесено до облікових записів Firefox."
 
-#: src/olympia/accounts/views.py:59
+#: src/olympia/accounts/views.py:61
 msgid "Your Firefox Account already exists on this site."
 msgstr "У Вас вже є обліковий запис Firefox для цього сайту."
 
-#: src/olympia/accounts/views.py:108
+#: src/olympia/accounts/views.py:110
 msgid "Great job!"
 msgstr "Чудова робота!"
 
-#: src/olympia/accounts/views.py:109
+#: src/olympia/accounts/views.py:111
 msgid "You can now log in to Add-ons with your Firefox Account."
 msgstr "Ви можете ввійти до Додатків за допомогою облікового запису Firefox."
 
-#: src/olympia/accounts/views.py:121
+#: src/olympia/accounts/views.py:123
 msgid "Need help?"
 msgstr "Потрібна допомога?"
 
-#: src/olympia/addons/buttons.py:180
+#: src/olympia/addons/buttons.py:177
 msgid "Download Now"
 msgstr "Завантажити зараз"
 
-#: src/olympia/addons/buttons.py:182
+#: src/olympia/addons/buttons.py:179
 msgid "Download"
 msgstr "Завантажити"
 
 #. L10n: please keep &nbsp; in the string so &rarr; does not wrap.
-#: src/olympia/addons/buttons.py:186
+#: src/olympia/addons/buttons.py:183
 msgid "Continue to Download&nbsp;&rarr;"
 msgstr "Продовжити завантаження&nbsp;&rarr;"
 
-#: src/olympia/addons/buttons.py:202 src/olympia/addons/helpers.py:35
-#: src/olympia/addons/views.py:319
-#: src/olympia/addons/templates/addons/impala/details.html:114
-#: src/olympia/addons/templates/addons/impala/listing/items.html:17
-#: src/olympia/addons/templates/addons/mobile/home.html:40
-#: src/olympia/amo/templates/amo/side_nav.html:6
-#: src/olympia/amo/templates/amo/side_nav.html:10
-#: src/olympia/amo/templates/amo/site_nav.html:2
-#: src/olympia/amo/templates/amo/site_nav.html:55
-#: src/olympia/bandwagon/views.py:95 src/olympia/browse/views.py:54
-#: src/olympia/browse/views.py:68 src/olympia/browse/views.py:235
-#: src/olympia/browse/templates/browse/impala/category_landing.html:22
+#: src/olympia/addons/buttons.py:199 src/olympia/addons/helpers.py:35 src/olympia/addons/views.py:333 src/olympia/addons/templates/addons/impala/details.html:111
+#: src/olympia/addons/templates/addons/impala/listing/items.html:17 src/olympia/addons/templates/addons/mobile/home.html:40 src/olympia/amo/templates/amo/side_nav.html:6
+#: src/olympia/amo/templates/amo/side_nav.html:10 src/olympia/amo/templates/amo/site_nav.html:2 src/olympia/amo/templates/amo/site_nav.html:53 src/olympia/bandwagon/views.py:95
+#: src/olympia/browse/views.py:54 src/olympia/browse/views.py:68 src/olympia/browse/views.py:202 src/olympia/browse/templates/browse/impala/category_landing.html:22
 #: src/olympia/browse/templates/browse/personas/mobile/category_landing.html:26
 msgid "Featured"
 msgstr "Відібрані"
 
-#: src/olympia/addons/buttons.py:221
+#: src/olympia/addons/buttons.py:218
 msgid "Add to {0}"
 msgstr "Додати до {0}"
 
@@ -108,7 +96,6 @@ msgid "Invalid tag: {0}"
 msgid_plural "Invalid tags: {0}"
 msgstr[0] "Недійсна мітка: {0}"
 msgstr[1] "Недійсні мітки: {0}"
-msgstr[2] "Недійсні мітки: {0}"
 
 #. L10n: {0} is a single tag or a comma-separated list of tags.
 #: src/olympia/addons/forms.py:103
@@ -116,73 +103,57 @@ msgid "\"{0}\" is a reserved tag and cannot be used."
 msgid_plural "\"{0}\" are reserved tags and cannot be used."
 msgstr[0] "\"{0}\" є зарезервованою міткою і не може використовуватись."
 msgstr[1] "\"{0}\" є зарезервованими мітками і не можуть використовуватись."
-msgstr[2] "\"{0}\" є зарезервованими мітками і не можуть використовуватись."
 
 #: src/olympia/addons/forms.py:111
 msgid "You have {0} too many tags."
 msgid_plural "You have {0} too many tags."
 msgstr[0] "У вас на {0} мітку більше допустимого."
 msgstr[1] "У вас на {0} мітки більше допустимого."
-msgstr[2] "У вас на {0} міток більше допустимого."
 
 #: src/olympia/addons/forms.py:117
 #, python-format
-msgid ""
-"All tags must be %s characters or less after invalid characters are removed."
-msgstr ""
-"Довжина всіх міток не повинна перевищувати %s символів після того, як "
-"вилучено заборонені символи."
+msgid "All tags must be %s characters or less after invalid characters are removed."
+msgstr "Довжина всіх міток не повинна перевищувати %s символів після того, як вилучено заборонені символи."
 
 #: src/olympia/addons/forms.py:121
 msgid "All tags must be at least {0} character."
 msgid_plural "All tags must be at least {0} characters."
 msgstr[0] "Довжина всіх міток повинна бути не меншою {0} символу."
 msgstr[1] "Довжина всіх міток повинна бути не меншою {0} символи."
-msgstr[2] "Довжина всіх міток повинна бути не меншою {0} символів."
 
-#: src/olympia/addons/forms.py:234
-msgid ""
-"Categories cannot be changed while your add-on is featured for this "
-"application."
-msgstr ""
-"Категорії не можна змінити поки ваш додаток вибрано для цієї програми."
+#: src/olympia/addons/forms.py:238
+msgid "Categories cannot be changed while your add-on is featured for this application."
+msgstr "Категорії не можна змінити поки ваш додаток вибрано для цієї програми."
 
 #. L10n: {0} is the number of categories.
-#: src/olympia/addons/forms.py:238
+#: src/olympia/addons/forms.py:242
 msgid "You can have only {0} category."
 msgid_plural "You can have only {0} categories."
 msgstr[0] "У вас може бути лише {0} категорія."
 msgstr[1] "У вас може бути лише {0} категорії."
-msgstr[2] "У вас може бути лише {0} категорій."
 
-#: src/olympia/addons/forms.py:246
-msgid ""
-"The miscellaneous category cannot be combined with additional categories."
+#: src/olympia/addons/forms.py:250
+msgid "The miscellaneous category cannot be combined with additional categories."
 msgstr "Категорія Різне не може бути об'єднана з додатковими категоріями."
 
-#: src/olympia/addons/forms.py:369
+#: src/olympia/addons/forms.py:374
 #, python-format
-msgid ""
-"Before changing your default locale you must have a name, summary, and "
-"description in that locale. You are missing %s."
-msgstr ""
-"Перед зміною вашої типової локалі, ви повинні мати ім'я, коротку інформацію "
-"і опис на цій локалі. Вам не вистачає %s."
+msgid "Before changing your default locale you must have a name, summary, and description in that locale. You are missing %s."
+msgstr "Перед зміною вашої типової локалі, ви повинні мати ім'я, коротку інформацію і опис на цій локалі. Вам не вистачає %s."
 
-#: src/olympia/addons/forms.py:484 src/olympia/addons/forms.py:575
+#: src/olympia/addons/forms.py:455 src/olympia/addons/forms.py:546
 msgid "A license must be selected."
 msgstr "Повинна бути вибрана ліцензія."
 
-#: src/olympia/addons/forms.py:556
+#: src/olympia/addons/forms.py:527
 msgid "Give Your Theme a Name."
 msgstr "Дайте назву своїй темі."
 
-#: src/olympia/addons/forms.py:562
-#: src/olympia/devhub/templates/devhub/personas/submit.html:53
+#: src/olympia/addons/forms.py:533 src/olympia/devhub/templates/devhub/personas/submit.html:53
 msgid "Describe your Theme."
 msgstr "Опишіть свою тему."
 
-#: src/olympia/addons/forms.py:704
+#: src/olympia/addons/forms.py:675
 msgid "Enter a new author's email address"
 msgstr "Введіть нову адресу електронної пошти автора"
 
@@ -190,46 +161,37 @@ msgstr "Введіть нову адресу електронної пошти �
 msgid "Not Reviewed"
 msgstr "Не переглянуто"
 
-#: src/olympia/addons/models.py:301
+#: src/olympia/addons/models.py:298
 msgid "Users have the option of contributing more or less than this amount."
-msgstr ""
-"Користувачі можуть зробити внесок, більший або менший зазначеної суми."
+msgstr "Користувачі можуть зробити внесок, більший або менший зазначеної суми."
 
-#: src/olympia/addons/models.py:309
-msgid ""
-"Users will always be asked in the Add-ons Manager (Firefox 4 and above)"
+#: src/olympia/addons/models.py:306
+msgid "Users will always be asked in the Add-ons Manager (Firefox 4 and above). Only applies to desktop."
 msgstr ""
-"Користувачів завжди будуть питати у менеджері додатків (Firefox 4 та вище)"
 
-#: src/olympia/addons/models.py:1804
-#: src/olympia/addons/templates/addons/details_box.html:55
-#: src/olympia/devhub/templates/devhub/index.html:92
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:102
+#: src/olympia/addons/models.py:1802 src/olympia/addons/templates/addons/details_box.html:55 src/olympia/devhub/templates/devhub/index.html:92
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:89
 msgid "Listed"
 msgstr "У списку"
 
-#: src/olympia/addons/views.py:320
-#: src/olympia/browse/templates/browse/personas/mobile/category_landing.html:27
+#: src/olympia/addons/views.py:334 src/olympia/browse/templates/browse/personas/mobile/category_landing.html:27
 msgid "Popular"
 msgstr "Популярні"
 
-#: src/olympia/addons/views.py:321 src/olympia/browse/views.py:238
-#: src/olympia/browse/views.py:280 src/olympia/browse/views.py:482
+#: src/olympia/addons/views.py:335 src/olympia/browse/views.py:205 src/olympia/browse/views.py:247 src/olympia/browse/views.py:449
 msgid "Recently Added"
 msgstr "Додані недавно"
 
-#: src/olympia/addons/views.py:322 src/olympia/bandwagon/views.py:99
-#: src/olympia/browse/views.py:60 src/olympia/browse/views.py:71
-#: src/olympia/search/forms.py:16 src/olympia/search/forms.py:91
+#: src/olympia/addons/views.py:336 src/olympia/bandwagon/views.py:99 src/olympia/browse/views.py:60 src/olympia/browse/views.py:71 src/olympia/search/forms.py:16 src/olympia/search/forms.py:91
 msgid "Recently Updated"
 msgstr "Нещодавно оновлені"
 
 #. l10n: {0} is the addon name
-#: src/olympia/addons/views.py:520
+#: src/olympia/addons/views.py:534
 msgid "Contribution for {0}"
 msgstr "Внесок до {0}"
 
-#: src/olympia/addons/views.py:613
+#: src/olympia/addons/views.py:627
 msgid "Abuse reported."
 msgstr "Скаргу відправлено."
 
@@ -237,115 +199,68 @@ msgstr "Скаргу відправлено."
 msgid "My add-on doesn't fit into any of the categories"
 msgstr "Мій додаток не підходить жодній з категорій"
 
-#: src/olympia/addons/templates/addons/button.html:27
-#: src/olympia/addons/templates/addons/impala/button.html:11
-#: src/olympia/addons/templates/addons/mobile/button.html:11
+#: src/olympia/addons/templates/addons/button.html:27 src/olympia/addons/templates/addons/impala/button.html:11 src/olympia/addons/templates/addons/mobile/button.html:11
 msgid "No compatible versions"
 msgstr "Немає сумісних версій"
 
-#: src/olympia/addons/templates/addons/button.html:35
-#: src/olympia/addons/templates/addons/impala/button.html:19
+#: src/olympia/addons/templates/addons/button.html:35 src/olympia/addons/templates/addons/impala/button.html:19
 msgid "Added to Mobile"
 msgstr "Додано до у Мобільні"
 
-#: src/olympia/addons/templates/addons/button.html:37
-#: src/olympia/addons/templates/addons/impala/button.html:21
+#: src/olympia/addons/templates/addons/button.html:37 src/olympia/addons/templates/addons/impala/button.html:21
 msgid "Add to Mobile"
 msgstr "Додати у Мобільні"
 
 #. {0} is a platform name like Windows or Mac OS X.
-#: src/olympia/addons/templates/addons/button.html:66
-#: src/olympia/addons/templates/addons/includes/install_button.html:19
+#: src/olympia/addons/templates/addons/button.html:66 src/olympia/addons/templates/addons/includes/install_button.html:19
 msgid "for {0}"
 msgstr "для {0}"
 
-#: src/olympia/addons/templates/addons/button.html:82
-#: src/olympia/addons/templates/addons/mobile/button.html:23
+#: src/olympia/addons/templates/addons/button.html:82 src/olympia/addons/templates/addons/mobile/button.html:23
 msgid "View privacy policy"
 msgstr "Ознайомитися з політикою приватності"
 
-#: src/olympia/addons/templates/addons/button.html:87
-#: src/olympia/addons/templates/addons/details_box.html:133
-#: src/olympia/addons/templates/addons/mobile/button.html:28
+#: src/olympia/addons/templates/addons/button.html:87 src/olympia/addons/templates/addons/details_box.html:133 src/olympia/addons/templates/addons/mobile/button.html:28
 #: src/olympia/discovery/templates/discovery/addons/detail.html:28
 msgid "View End-User License Agreement"
 msgstr "Переглянути ліцензійну угоду кінцевого користувача"
 
-#: src/olympia/addons/templates/addons/button.html:92
-#: src/olympia/addons/templates/addons/impala/button.html:54
+#: src/olympia/addons/templates/addons/button.html:92 src/olympia/addons/templates/addons/impala/button.html:54
 #, python-format
-msgid ""
-"This add-on has not been reviewed by Mozilla. <a href=\"%(url)s\">Learn "
-"more</a>"
-msgstr ""
-"Цей додаток не був перевірений Mozilla. <a href=\"%(url)s\">Дізнатись "
-"більше</a>"
+msgid "This add-on has not been reviewed by Mozilla. <a href=\"%(url)s\">Learn more</a>"
+msgstr "Цей додаток не був перевірений Mozilla. <a href=\"%(url)s\">Дізнатись більше</a>"
 
-#: src/olympia/addons/templates/addons/button.html:97
-#: src/olympia/addons/templates/addons/impala/button.html:60
+#: src/olympia/addons/templates/addons/button.html:97 src/olympia/addons/templates/addons/impala/button.html:60
 #, python-format
-msgid ""
-"This add-on has been preliminarily reviewed by Mozilla. <a "
-"href=\"%(url)s\">Learn more</a>"
-msgstr ""
-"Цей додаток пройшов попередній розгляд Mozilla. <a "
-"href=\"%(url)s\">Дізнатись більше</a>"
+msgid "This add-on has been preliminarily reviewed by Mozilla. <a href=\"%(url)s\">Learn more</a>"
+msgstr "Цей додаток пройшов попередній розгляд Mozilla. <a href=\"%(url)s\">Дізнатись більше</a>"
 
-#: src/olympia/addons/templates/addons/contribution.html:11
-#: src/olympia/addons/templates/addons/impala/developers.html:44
-msgid ""
-"The developer of this add-on asks that you help support its continued "
-"development by making a small contribution."
-msgstr ""
-"Розробник цього додатку просить вас посприяти його подальшому розвитку, "
-"зробивши свій невеличкий внесок."
+#: src/olympia/addons/templates/addons/contribution.html:11 src/olympia/addons/templates/addons/impala/developers.html:44
+msgid "The developer of this add-on asks that you help support its continued development by making a small contribution."
+msgstr "Розробник цього додатку просить вас посприяти його подальшому розвитку, зробивши свій невеличкий внесок."
 
 #: src/olympia/addons/templates/addons/contribution.html:14
 #, python-format
-msgid ""
-"The developer of this add-on asks that you show your support by making a "
-"donation to the <a href=\"%(charity_url)s\">%(charity_name)s</a>."
-msgstr ""
-"Розробник цього додатку просить вас виявити свою підтримку, зробивши внесок "
-"на <a href=\"%(charity_url)s\">%(charity_name)s</a>."
+msgid "The developer of this add-on asks that you show your support by making a donation to the <a href=\"%(charity_url)s\">%(charity_name)s</a>."
+msgstr "Розробник цього додатку просить вас виявити свою підтримку, зробивши внесок на <a href=\"%(charity_url)s\">%(charity_name)s</a>."
 
 #: src/olympia/addons/templates/addons/contribution.html:19
 #, python-format
-msgid ""
-"The developer of this add-on asks that you show your support by making a "
-"small contribution to <a href=\"%(charity_url)s\">%(charity_name)s</a>."
-msgstr ""
-"Розробник цього додатку просить вас виявити свою підтримку, зробивши "
-"невеликий внесок на користь <a "
-"href=\"%(charity_url)s\">%(charity_name)s</a>."
+msgid "The developer of this add-on asks that you show your support by making a small contribution to <a href=\"%(charity_url)s\">%(charity_name)s</a>."
+msgstr "Розробник цього додатку просить вас виявити свою підтримку, зробивши невеликий внесок на користь <a href=\"%(charity_url)s\">%(charity_name)s</a>."
 
-#: src/olympia/addons/templates/addons/contribution.html:30
-#: src/olympia/addons/templates/addons/impala/contribution.html:18
-#: src/olympia/templates/menu_links.html:25
+#: src/olympia/addons/templates/addons/contribution.html:30 src/olympia/addons/templates/addons/impala/contribution.html:18 src/olympia/templates/menu_links.html:25
 msgid "Contribute"
 msgstr "Зробити внесок"
 
 #. Click Contribute button OR Install button
-#: src/olympia/addons/templates/addons/contribution.html:34
-#: src/olympia/addons/templates/addons/report_abuse.html:26
-#: src/olympia/addons/templates/addons/impala/contribution.html:32
-#: src/olympia/devhub/templates/devhub/addons/ajax_compat_update.html:36
-#: src/olympia/devhub/templates/devhub/addons/profile.html:44
-#: src/olympia/devhub/templates/devhub/addons/edit/admin.html:101
-#: src/olympia/devhub/templates/devhub/addons/edit/basic.html:152
-#: src/olympia/devhub/templates/devhub/addons/edit/details.html:85
-#: src/olympia/devhub/templates/devhub/addons/edit/support.html:67
-#: src/olympia/devhub/templates/devhub/addons/edit/technical.html:166
-#: src/olympia/devhub/templates/devhub/addons/forms_shared/media.html:149
-#: src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:44
-#: src/olympia/devhub/templates/devhub/versions/add_file_modal.html:78
-#: src/olympia/devhub/templates/devhub/versions/edit.html:139
-#: src/olympia/devhub/templates/devhub/versions/list.html:242
-#: src/olympia/devhub/templates/devhub/versions/list.html:276
-#: src/olympia/devhub/templates/devhub/versions/list.html:317
-#: src/olympia/devhub/templates/devhub/versions/list.html:351
-#: src/olympia/reviews/templates/reviews/edit_review.html:16
-#: src/olympia/translations/templates/translations/trans-menu.html:50
+#: src/olympia/addons/templates/addons/contribution.html:34 src/olympia/addons/templates/addons/report_abuse.html:26 src/olympia/addons/templates/addons/impala/contribution.html:32
+#: src/olympia/devhub/templates/devhub/addons/ajax_compat_update.html:36 src/olympia/devhub/templates/devhub/addons/profile.html:44 src/olympia/devhub/templates/devhub/addons/edit/admin.html:101
+#: src/olympia/devhub/templates/devhub/addons/edit/basic.html:152 src/olympia/devhub/templates/devhub/addons/edit/details.html:85 src/olympia/devhub/templates/devhub/addons/edit/support.html:67
+#: src/olympia/devhub/templates/devhub/addons/edit/technical.html:166 src/olympia/devhub/templates/devhub/addons/forms_shared/media.html:149
+#: src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:43 src/olympia/devhub/templates/devhub/versions/add_file_modal.html:58 src/olympia/devhub/templates/devhub/versions/edit.html:139
+#: src/olympia/devhub/templates/devhub/versions/list.html:239 src/olympia/devhub/templates/devhub/versions/list.html:281 src/olympia/devhub/templates/devhub/versions/list.html:315
+#: src/olympia/devhub/templates/devhub/versions/list.html:349 src/olympia/reviews/templates/reviews/edit_review.html:16 src/olympia/translations/templates/translations/trans-menu.html:50
 #: src/olympia/translations/templates/translations/trans-menu.html:62
 msgid "or"
 msgstr "або"
@@ -354,43 +269,23 @@ msgstr "або"
 msgid "Suggested Contribution: {0}"
 msgstr "Пропонований внесок: {0}"
 
-#: src/olympia/addons/templates/addons/contribution.html:48
-#: src/olympia/amo/templates/amo/recaptcha.html:5
-#: src/olympia/versions/templates/versions/version.html:52
+#: src/olympia/addons/templates/addons/contribution.html:48 src/olympia/amo/templates/amo/recaptcha.html:5 src/olympia/versions/templates/versions/version.html:52
 msgid "What's this?"
 msgstr "Що це?"
 
 #: src/olympia/addons/templates/addons/contribution.html:63
 #, python-format
-msgid ""
-"The developer of this add-on would like you to consider making a donation to"
-" the <a href=\"%(charity_url)s\">%(charity_name)s</a> if you enjoy using it."
-msgstr ""
-"Розробник цього додатку бажає, щоб ви розглянули можливість зробити внесок "
-"на користь <a href=\"%(charity_url)s\">%(charity_name)s</a>, якщо вам "
-"подобається його використовувати."
+msgid "The developer of this add-on would like you to consider making a donation to the <a href=\"%(charity_url)s\">%(charity_name)s</a> if you enjoy using it."
+msgstr "Розробник цього додатку бажає, щоб ви розглянули можливість зробити внесок на користь <a href=\"%(charity_url)s\">%(charity_name)s</a>, якщо вам подобається його використовувати."
 
 #: src/olympia/addons/templates/addons/contribution.html:69
 #, python-format
-msgid ""
-"The developer of this add-on would like you to consider making a small "
-"contribution to <a href=\"%(charity_url)s\">%(charity_name)s</a> if you "
-"enjoy using it."
-msgstr ""
-"Розробник цього додатку бажає, щоб ви розглянули можливість зробити "
-"невеликий внесок на користь <a "
-"href=\"%(charity_url)s\">%(charity_name)s</a>, якщо вам подобається його "
-"використовувати."
+msgid "The developer of this add-on would like you to consider making a small contribution to <a href=\"%(charity_url)s\">%(charity_name)s</a> if you enjoy using it."
+msgstr "Розробник цього додатку бажає, щоб ви розглянули можливість зробити невеликий внесок на користь <a href=\"%(charity_url)s\">%(charity_name)s</a>, якщо вам подобається його використовувати."
 
 #: src/olympia/addons/templates/addons/contribution.html:76
-msgid ""
-"Mozilla is committed to supporting a vibrant and healthy developer "
-"ecosystem. Your optional contribution helps sustain further development of "
-"this add-on."
-msgstr ""
-"Завдання Mozilla - підтримувати здорову та сприятливу робочу атмосферу для "
-"розробникiв. Ваш додатковий внесок допоможе підтримувати подальший розвиток "
-"цього додатку."
+msgid "Mozilla is committed to supporting a vibrant and healthy developer ecosystem. Your optional contribution helps sustain further development of this add-on."
+msgstr "Завдання Mozilla - підтримувати здорову та сприятливу робочу атмосферу для розробникiв. Ваш додатковий внесок допоможе підтримувати подальший розвиток цього додатку."
 
 #: src/olympia/addons/templates/addons/contributions_lightbox.html:5
 msgid "Make a Contribution"
@@ -398,35 +293,21 @@ msgstr "Зробити внесок"
 
 #: src/olympia/addons/templates/addons/contributions_lightbox.html:9
 #, python-format
-msgid ""
-"Help support the continued development of <strong>%(addon_name)s</strong> by"
-" making a small contribution through <a href=\"%(paypal_url)s\">PayPal</a>."
-msgstr ""
-"Допоможіть підтримати продовження розробки <strong>%(addon_name)s</strong>, "
-"зробивши невеликий внесок через <a href=\"%(paypal_url)s\">PayPal</a>."
+msgid "Help support the continued development of <strong>%(addon_name)s</strong> by making a small contribution through <a href=\"%(paypal_url)s\">PayPal</a>."
+msgstr "Допоможіть підтримати продовження розробки <strong>%(addon_name)s</strong>, зробивши невеликий внесок через <a href=\"%(paypal_url)s\">PayPal</a>."
 
 #: src/olympia/addons/templates/addons/contributions_lightbox.html:15
 #, python-format
-msgid ""
-"To show your support for <b>%(addon_name)s</b>, the developer asks that you "
-"make a donation to the <a href=\"%(charity_url)s\">%(charity_name)s</a> "
-"through <a href=\"%(paypal_url)s\">PayPal</a>."
-msgstr ""
-"Щоб виявити свою підтримку <b>%(addon_name)s</b>, розробник просить вас "
-"зробити внесок на користь <a href=\"%(charity_url)s\">%(charity_name)s</a> "
-"через <a href=\"%(paypal_url)s\">PayPal</a>."
+msgid "To show your support for <b>%(addon_name)s</b>, the developer asks that you make a donation to the <a href=\"%(charity_url)s\">%(charity_name)s</a> through <a href=\"%(paypal_url)s\">PayPal</a>."
+msgstr "Щоб виявити свою підтримку <b>%(addon_name)s</b>, розробник просить вас зробити внесок на користь <a href=\"%(charity_url)s\">%(charity_name)s</a> через <a href=\"%(paypal_url)s\">PayPal</a>."
 
 #: src/olympia/addons/templates/addons/contributions_lightbox.html:21
 #, python-format
 msgid ""
-"To show your support for <b>%(addon_name)s</b>, the developer asks that you "
-"make a small contribution to <a "
-"href=\"%(charity_url)s\">%(charity_name)s</a> through <a "
+"To show your support for <b>%(addon_name)s</b>, the developer asks that you make a small contribution to <a href=\"%(charity_url)s\">%(charity_name)s</a> through <a "
 "href=\"%(paypal_url)s\">PayPal</a>."
 msgstr ""
-"Щоб виявити свою підтримку <b>%(addon_name)s</b>, розробник просить вас "
-"зробити невеликий внесок на користь <a "
-"href=\"%(charity_url)s\">%(charity_name)s</a> через <a "
+"Щоб виявити свою підтримку <b>%(addon_name)s</b>, розробник просить вас зробити невеликий внесок на користь <a href=\"%(charity_url)s\">%(charity_name)s</a> через <a "
 "href=\"%(paypal_url)s\">PayPal</a>."
 
 #: src/olympia/addons/templates/addons/contributions_lightbox.html:30
@@ -450,8 +331,7 @@ msgstr "Сума внеску повинна бути числом."
 msgid "A one-time suggested contribution of {0}"
 msgstr "Пропонований одноразовий внесок {0}"
 
-#. {0} is a currency symbol (e.g., $),                    {1} is an amount
-#. input
+#. {0} is a currency symbol (e.g., $),                    {1} is an amount input
 #. field
 #: src/olympia/addons/templates/addons/contributions_lightbox.html:64
 msgid "A one-time contribution of {0} {1}"
@@ -461,11 +341,8 @@ msgstr "Одноразовий внесок {0} {1}"
 msgid "Leave a comment or request with your contribution."
 msgstr "Залиште коментар або запит разом з вашим внеском."
 
-#: src/olympia/addons/templates/addons/contributions_lightbox.html:74
-#: src/olympia/bandwagon/templates/bandwagon/ajax_new.html:20
-#: src/olympia/bandwagon/templates/bandwagon/includes/addedit.html:37
-#: src/olympia/reviews/templates/reviews/mobile/add_form.html:13
-#: src/olympia/templates/includes/forms.html:10
+#: src/olympia/addons/templates/addons/contributions_lightbox.html:74 src/olympia/bandwagon/templates/bandwagon/ajax_new.html:20 src/olympia/bandwagon/templates/bandwagon/includes/addedit.html:37
+#: src/olympia/reviews/templates/reviews/mobile/add_form.html:13 src/olympia/templates/includes/forms.html:10
 msgid "(optional)"
 msgstr "(необов’язково)"
 
@@ -485,36 +362,27 @@ msgstr "Ні, дякую"
 msgid "Contribution made, thank you."
 msgstr "Внесок зроблено, дякуємо."
 
-#: src/olympia/addons/templates/addons/details_box.html:10
-#: src/olympia/discovery/templates/discovery/addons/detail.html:19
+#: src/olympia/addons/templates/addons/details_box.html:10 src/olympia/discovery/templates/discovery/addons/detail.html:19
 msgid "No restart required"
 msgstr "Не потребує перезапуску"
 
 #. This is a caption for a table. {0} is an add-on name.
-#: src/olympia/addons/templates/addons/details_box.html:26
-#: src/olympia/addons/templates/addons/includes/persona.html:9
+#: src/olympia/addons/templates/addons/details_box.html:26 src/olympia/addons/templates/addons/includes/persona.html:9
 msgid "Add-on Information for {0}"
 msgstr "Інформація додатку для {0}"
 
-#: src/olympia/addons/templates/addons/details_box.html:30
-#: src/olympia/addons/templates/addons/persona_detail_table.html:3
-#: src/olympia/addons/templates/addons/mobile/details.html:63
-#: src/olympia/addons/templates/addons/mobile/persona_detail_table.html:7
-#: src/olympia/browse/views.py:459 src/olympia/devhub/views.py:75
+#: src/olympia/addons/templates/addons/details_box.html:30 src/olympia/addons/templates/addons/persona_detail_table.html:3 src/olympia/addons/templates/addons/mobile/details.html:63
+#: src/olympia/addons/templates/addons/mobile/persona_detail_table.html:7 src/olympia/browse/views.py:426 src/olympia/devhub/views.py:74
 msgid "Updated"
 msgstr "Оновлено"
 
-#: src/olympia/addons/templates/addons/details_box.html:38
-#: src/olympia/addons/templates/addons/mobile/details.html:71
-#: src/olympia/devhub/templates/devhub/addons/edit/support.html:43
+#: src/olympia/addons/templates/addons/details_box.html:38 src/olympia/addons/templates/addons/mobile/details.html:71 src/olympia/devhub/templates/devhub/addons/edit/support.html:43
 #: src/olympia/discovery/templates/discovery/addons/detail.html:77
 msgid "Website"
 msgstr "Сайт"
 
 #. This refers to this version's compatible applications, such as Firefox 8.0
-#: src/olympia/addons/templates/addons/details_box.html:47
-#: src/olympia/addons/templates/addons/mobile/details.html:80
-#: src/olympia/search/templates/search/results.html:72
+#: src/olympia/addons/templates/addons/details_box.html:47 src/olympia/addons/templates/addons/mobile/details.html:80 src/olympia/search/templates/search/results.html:72
 #: src/olympia/versions/templates/versions/version.html:21
 msgid "Works with"
 msgstr "Працює з"
@@ -523,45 +391,30 @@ msgstr "Працює з"
 msgid "Visibility"
 msgstr "Видимість"
 
-#: src/olympia/addons/templates/addons/details_box.html:57
-#: src/olympia/devhub/templates/devhub/index.html:94
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:104
+#: src/olympia/addons/templates/addons/details_box.html:57 src/olympia/devhub/templates/devhub/index.html:94 src/olympia/devhub/templates/devhub/includes/addon_details.html:91
 msgid "Hidden"
 msgstr "Приховано"
 
-#: src/olympia/addons/templates/addons/details_box.html:59
-#: src/olympia/devhub/templates/devhub/index.html:96
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:106
+#: src/olympia/addons/templates/addons/details_box.html:59 src/olympia/devhub/templates/devhub/index.html:96 src/olympia/devhub/templates/devhub/includes/addon_details.html:93
 msgid "Unlisted"
 msgstr "Не в списку"
 
-#: src/olympia/addons/templates/addons/details_box.html:67
-#: src/olympia/devhub/templates/devhub/addons/edit/technical.html:44
+#: src/olympia/addons/templates/addons/details_box.html:67 src/olympia/devhub/templates/devhub/addons/edit/technical.html:44
 msgid "Required Add-ons"
 msgstr "Необхідні додатки"
 
-#: src/olympia/addons/templates/addons/details_box.html:81
-#: src/olympia/addons/templates/addons/persona_detail_table.html:15
-#: src/olympia/browse/views.py:462 src/olympia/devhub/views.py:78
-#: src/olympia/devhub/views.py:85
-#: src/olympia/discovery/templates/discovery/addons/detail.html:57
-#: src/olympia/reviews/forms.py:62
-#: src/olympia/reviews/templates/reviews/add.html:57
+#: src/olympia/addons/templates/addons/details_box.html:81 src/olympia/addons/templates/addons/persona_detail_table.html:15 src/olympia/browse/views.py:429 src/olympia/devhub/views.py:77
+#: src/olympia/devhub/views.py:84 src/olympia/discovery/templates/discovery/addons/detail.html:57 src/olympia/reviews/forms.py:62 src/olympia/reviews/templates/reviews/add.html:57
 #: src/olympia/reviews/templates/reviews/mobile/review_list.html:18
 msgid "Rating"
 msgstr "Оцінка"
 
-#: src/olympia/addons/templates/addons/details_box.html:85
-#: src/olympia/browse/views.py:461 src/olympia/devhub/views.py:77
-#: src/olympia/devhub/views.py:84
-#: src/olympia/stats/templates/stats/addon_report_menu.html:8
-#: src/olympia/stats/templates/stats/collection_report_menu.html:18
+#: src/olympia/addons/templates/addons/details_box.html:85 src/olympia/browse/views.py:428 src/olympia/devhub/views.py:76 src/olympia/devhub/views.py:83
+#: src/olympia/stats/templates/stats/addon_report_menu.html:8 src/olympia/stats/templates/stats/collection_report_menu.html:18
 msgid "Downloads"
 msgstr "Завантаження"
 
-#: src/olympia/addons/templates/addons/details_box.html:91
-#: src/olympia/addons/templates/addons/details_box.html:103
-#: src/olympia/devhub/templates/devhub/addons/listing/item_actions_theme.html:17
+#: src/olympia/addons/templates/addons/details_box.html:91 src/olympia/addons/templates/addons/details_box.html:103 src/olympia/devhub/templates/devhub/addons/listing/item_actions_theme.html:17
 #: src/olympia/devhub/templates/devhub/personas/edit.html:60
 msgid "View Statistics"
 msgstr "Переглянути статистику"
@@ -575,18 +428,13 @@ msgid "Abuse Reports"
 msgstr "Скарги"
 
 #. The Privacy Policy for this add-on.
-#: src/olympia/addons/templates/addons/details_box.html:121
-#: src/olympia/addons/templates/addons/privacy.html:19
-#: src/olympia/addons/templates/addons/privacy.html:23
-#: src/olympia/addons/templates/addons/impala/button.html:43
-#: src/olympia/addons/templates/addons/impala/details.html:307
-#: src/olympia/devhub/templates/devhub/includes/policy_form.html:20
+#: src/olympia/addons/templates/addons/details_box.html:121 src/olympia/addons/templates/addons/privacy.html:19 src/olympia/addons/templates/addons/privacy.html:23
+#: src/olympia/addons/templates/addons/impala/button.html:43 src/olympia/addons/templates/addons/impala/details.html:312 src/olympia/devhub/templates/devhub/includes/policy_form.html:23
 #: src/olympia/templates/mobile/base_addons.html:87
 msgid "Privacy Policy"
 msgstr "Політика приватності"
 
-#: src/olympia/addons/templates/addons/details_box.html:124
-#: src/olympia/discovery/templates/discovery/addons/detail.html:24
+#: src/olympia/addons/templates/addons/details_box.html:124 src/olympia/discovery/templates/discovery/addons/detail.html:24
 msgid "View Privacy Policy"
 msgstr "Переглянути політику приватності"
 
@@ -594,8 +442,7 @@ msgstr "Переглянути політику приватності"
 msgid "EULA"
 msgstr "ЛУКК"
 
-#: src/olympia/addons/templates/addons/details_box.html:171
-#: src/olympia/addons/templates/addons/details_box.html:231
+#: src/olympia/addons/templates/addons/details_box.html:171 src/olympia/addons/templates/addons/details_box.html:231
 msgid "More about this add-on"
 msgstr "Докладніше про цей додаток"
 
@@ -603,26 +450,21 @@ msgstr "Докладніше про цей додаток"
 msgid "Image Gallery"
 msgstr "Галерея зображень"
 
-#: src/olympia/addons/templates/addons/details_box.html:190
-#: src/olympia/devhub/templates/devhub/addons/edit/technical.html:21
+#: src/olympia/addons/templates/addons/details_box.html:190 src/olympia/devhub/templates/devhub/addons/edit/technical.html:21
 msgid "Developer Comments"
 msgstr "Коментарі розробника"
 
-#: src/olympia/addons/templates/addons/details_box.html:199
-#: src/olympia/addons/templates/addons/impala/details.html:259
+#: src/olympia/addons/templates/addons/details_box.html:199 src/olympia/addons/templates/addons/impala/details.html:264
 msgid "Development Channel"
 msgstr "Канал розробки"
 
-#: src/olympia/addons/templates/addons/details_box.html:202
-#: src/olympia/addons/templates/addons/mobile/details.html:124
+#: src/olympia/addons/templates/addons/details_box.html:202 src/olympia/addons/templates/addons/mobile/details.html:124
 msgid ""
-"The Development Channel lets you test an experimental new version of this "
-"add-on before it's released to the general public. Once you install the "
-"development version, you will continue to get updates from this channel."
+"The Development Channel lets you test an experimental new version of this add-on before it's released to the general public. Once you install the development version, you will continue to get "
+"updates from this channel."
 msgstr ""
-"Канал розробки дає вам змогу випробувати експериментальну версію цього "
-"додатку перед його випуском для всіх. Після встановлення експериментальної "
-"версії ви будете надалі отримувати оновлення з цього каналу."
+"Канал розробки дає вам змогу випробувати експериментальну версію цього додатку перед його випуском для всіх. Після встановлення експериментальної версії ви будете надалі отримувати оновлення з "
+"цього каналу."
 
 #: src/olympia/addons/templates/addons/details_box.html:207
 msgid "Install development version"
@@ -630,73 +472,49 @@ msgstr "Встановити експериментальну версію"
 
 #: src/olympia/addons/templates/addons/details_box.html:211
 msgid ""
-"<strong>Caution:</strong> Development versions of this add-on have not been "
-"reviewed by Mozilla. Once you install a development version you will "
-"continue to receive development updates from this developer. To stop "
-"receiving development updates, reinstall the default version from the link "
-"above."
+"<strong>Caution:</strong> Development versions of this add-on have not been reviewed by Mozilla. Once you install a development version you will continue to receive development updates from this "
+"developer. To stop receiving development updates, reinstall the default version from the link above."
 msgstr ""
-"<strong>Обережно:</strong> Експериментальні версії цього додатку не були "
-"розглянути Mozilla. Після встановлення експериментальної версії ви будете "
-"надалі отримувати експериментальні оновлення від цього розробника. Щоб "
-"припинити отримання експериментальних оновлень, перевстановіть типову версію"
-" за вищевказаним посиланням."
+"<strong>Обережно:</strong> Експериментальні версії цього додатку не були розглянути Mozilla. Після встановлення експериментальної версії ви будете надалі отримувати експериментальні оновлення від "
+"цього розробника. Щоб припинити отримання експериментальних оновлень, перевстановіть типову версію за вищевказаним посиланням."
 
-#: src/olympia/addons/templates/addons/details_box.html:220
-#: src/olympia/addons/templates/addons/impala/details.html:278
+#: src/olympia/addons/templates/addons/details_box.html:220 src/olympia/addons/templates/addons/impala/details.html:283
 msgid "Version {0}:"
 msgstr "Версія {0}:"
 
 #: src/olympia/addons/templates/addons/details_box.html:234
-msgid "Nothing to see here!  The developer did not include any details."
-msgstr "Тут нічого дивитись! Розробник не додав жодних деталей."
+msgid "Nothing to see here! The developer did not include any details."
+msgstr "Тут нічого дивитись! Розробник не включив жодних деталей."
 
-#: src/olympia/addons/templates/addons/details_box.html:251
-#: src/olympia/devhub/templates/devhub/versions/edit.html:73
-#: src/olympia/editors/templates/editors/review.html:98
+#: src/olympia/addons/templates/addons/details_box.html:251 src/olympia/devhub/templates/devhub/versions/edit.html:73 src/olympia/editors/templates/editors/review.html:98
 msgid "Version Notes"
 msgstr "Примітки до версії"
 
 #. {0} is the name of the add-on.
 #. {0} is the name of the add-on
-#: src/olympia/addons/templates/addons/eula.html:6
-#: src/olympia/discovery/templates/discovery/addons/eula.html:5
+#: src/olympia/addons/templates/addons/eula.html:6 src/olympia/discovery/templates/discovery/addons/eula.html:5
 msgid "End-User License Agreement for {0}"
 msgstr "Ліцензійна угода з кінцевим користувачем для {0}"
 
-#: src/olympia/addons/templates/addons/eula.html:17
-#: src/olympia/addons/templates/addons/eula.html:21
-#: src/olympia/addons/templates/addons/impala/button.html:48
-#: src/olympia/addons/templates/addons/impala/details.html:316
-#: src/olympia/devhub/templates/devhub/includes/policy_form.html:3
-#: src/olympia/discovery/templates/discovery/addons/eula.html:11
+#: src/olympia/addons/templates/addons/eula.html:17 src/olympia/addons/templates/addons/eula.html:21 src/olympia/addons/templates/addons/impala/button.html:48
+#: src/olympia/addons/templates/addons/impala/details.html:321 src/olympia/devhub/templates/devhub/includes/policy_form.html:3 src/olympia/discovery/templates/discovery/addons/eula.html:11
 msgid "End-User License Agreement"
 msgstr "Ліцензійна угода з кінцевим користувачем"
 
-#: src/olympia/addons/templates/addons/eula.html:23
-#: src/olympia/discovery/templates/discovery/addons/eula.html:13
+#: src/olympia/addons/templates/addons/eula.html:23 src/olympia/discovery/templates/discovery/addons/eula.html:13
 #, python-format
-msgid ""
-"%(addon_name)s requires that you accept the following End-User License "
-"Agreement before installation can proceed:"
-msgstr ""
-"%(addon_name)s потребує, щоб перед встановленням ви погодились із наступними"
-" умовами ліцензійної угоди кінцевого користувача:"
+msgid "%(addon_name)s requires that you accept the following End-User License Agreement before installation can proceed:"
+msgstr "%(addon_name)s потребує, щоб перед встановленням ви погодились із наступними умовами ліцензійної угоди кінцевого користувача:"
 
-#: src/olympia/addons/templates/addons/eula.html:34
-#: src/olympia/addons/templates/addons/privacy.html:26
+#: src/olympia/addons/templates/addons/eula.html:34 src/olympia/addons/templates/addons/privacy.html:26
 msgid "Back to {0}…"
 msgstr "Повернутися до {0}…"
 
-#: src/olympia/addons/templates/addons/home.html:3
-#: src/olympia/addons/templates/addons/mobile/home.html:3
-#: src/olympia/amo/helpers.py:235
+#: src/olympia/addons/templates/addons/home.html:3 src/olympia/addons/templates/addons/mobile/home.html:3 src/olympia/amo/helpers.py:235
 msgid "Add-ons for {0}"
 msgstr "Додатки для {0}"
 
-#: src/olympia/addons/templates/addons/home.html:10
-#: src/olympia/addons/templates/addons/home.html:51
-#: src/olympia/browse/templates/browse/impala/base_listing.html:11
+#: src/olympia/addons/templates/addons/home.html:10 src/olympia/addons/templates/addons/home.html:53 src/olympia/browse/templates/browse/impala/base_listing.html:11
 msgid "Featured Extensions"
 msgstr "Відібрані розширення"
 
@@ -704,69 +522,48 @@ msgstr "Відібрані розширення"
 msgid "Popular Extensions"
 msgstr "Популярні розширення"
 
-#: src/olympia/addons/templates/addons/home.html:42
-#: src/olympia/amo/templates/amo/side_nav.html:3
-#: src/olympia/amo/templates/amo/side_nav.html:11
-#: src/olympia/amo/templates/amo/site_nav.html:3
-#: src/olympia/amo/templates/amo/site_nav.html:25
-#: src/olympia/browse/views.py:236 src/olympia/browse/views.py:281
-#: src/olympia/browse/views.py:481
+#: src/olympia/addons/templates/addons/home.html:44 src/olympia/amo/templates/amo/side_nav.html:3 src/olympia/amo/templates/amo/side_nav.html:11 src/olympia/amo/templates/amo/site_nav.html:3
+#: src/olympia/amo/templates/amo/site_nav.html:25 src/olympia/browse/views.py:203 src/olympia/browse/views.py:248 src/olympia/browse/views.py:448
 msgid "Most Popular"
 msgstr "Найпопулярніші"
 
-#: src/olympia/addons/templates/addons/home.html:43
+#: src/olympia/addons/templates/addons/home.html:45
 msgid "All »"
 msgstr "Всі »"
 
-#: src/olympia/addons/templates/addons/home.html:52
-#: src/olympia/addons/templates/addons/home.html:61
-#: src/olympia/addons/templates/addons/home.html:70
-#: src/olympia/addons/templates/addons/home.html:78
+#: src/olympia/addons/templates/addons/home.html:54 src/olympia/addons/templates/addons/home.html:63 src/olympia/addons/templates/addons/home.html:72 src/olympia/addons/templates/addons/home.html:80
 #: src/olympia/browse/templates/browse/impala/category_landing.html:36
 msgid "See all »"
 msgstr "Дивитися всі »"
 
-#: src/olympia/addons/templates/addons/home.html:60
+#: src/olympia/addons/templates/addons/home.html:62
 msgid "Up &amp; Coming Extensions"
 msgstr "Розширення, які набирають популярність"
 
-#: src/olympia/addons/templates/addons/home.html:69
-#: src/olympia/browse/templates/browse/personas/category_landing.html:61
-#: src/olympia/discovery/templates/discovery/pane.html:74
+#: src/olympia/addons/templates/addons/home.html:71 src/olympia/browse/templates/browse/personas/category_landing.html:61 src/olympia/discovery/templates/discovery/pane.html:74
 msgid "Featured Themes"
 msgstr "Відібрані теми"
 
-#: src/olympia/addons/templates/addons/home.html:77
-#: src/olympia/bandwagon/templates/bandwagon/impala/collection_listing.html:5
+#: src/olympia/addons/templates/addons/home.html:79 src/olympia/bandwagon/templates/bandwagon/impala/collection_listing.html:5
 msgid "Featured Collections"
 msgstr "Відібрані збірки"
 
-#: src/olympia/addons/templates/addons/listing_header.html:3
-#: src/olympia/addons/templates/addons/impala/listing/sorter.html:2
-#: src/olympia/amo/templates/amo/mobile/sort_by.html:2
+#: src/olympia/addons/templates/addons/listing_header.html:3 src/olympia/addons/templates/addons/impala/listing/sorter.html:2 src/olympia/amo/templates/amo/mobile/sort_by.html:2
 #: src/olympia/bandwagon/templates/bandwagon/collection_detail.html:118
 msgid "Sort by:"
 msgstr "Сортувати за:"
 
 #. {0} is a date.
 #. {0} is a date
-#: src/olympia/addons/templates/addons/macros.html:7
-#: src/olympia/addons/templates/addons/macros.html:72
-#: src/olympia/addons/templates/addons/listing/items_mobile.html:48
-#: src/olympia/addons/templates/addons/listing/macros.html:42
-#: src/olympia/bandwagon/templates/bandwagon/collection_detail.html:50
-#: src/olympia/bandwagon/templates/bandwagon/collection_listing_items.html:40
-#: src/olympia/bandwagon/templates/bandwagon/impala/collection_listing_items.html:40
+#: src/olympia/addons/templates/addons/macros.html:7 src/olympia/addons/templates/addons/macros.html:72 src/olympia/addons/templates/addons/listing/items_mobile.html:48
+#: src/olympia/addons/templates/addons/listing/macros.html:42 src/olympia/bandwagon/templates/bandwagon/collection_detail.html:50
+#: src/olympia/bandwagon/templates/bandwagon/collection_listing_items.html:40 src/olympia/bandwagon/templates/bandwagon/impala/collection_listing_items.html:40
 msgid "Updated {0}"
 msgstr "Оновлено {0}"
 
 #. {0} is a date.
-#: src/olympia/addons/templates/addons/macros.html:10
-#: src/olympia/addons/templates/addons/macros.html:69
-#: src/olympia/addons/templates/addons/persona_preview.html:21
-#: src/olympia/addons/templates/addons/listing/items_mobile.html:44
-#: src/olympia/addons/templates/addons/listing/macros.html:39
-#: src/olympia/bandwagon/templates/bandwagon/collection_listing_items.html:37
+#: src/olympia/addons/templates/addons/macros.html:10 src/olympia/addons/templates/addons/macros.html:69 src/olympia/addons/templates/addons/persona_preview.html:22
+#: src/olympia/addons/templates/addons/listing/items_mobile.html:44 src/olympia/addons/templates/addons/listing/macros.html:39 src/olympia/bandwagon/templates/bandwagon/collection_listing_items.html:37
 #: src/olympia/bandwagon/templates/bandwagon/impala/collection_listing_items.html:37
 msgid "Added {0}"
 msgstr "Додано {0}"
@@ -777,7 +574,6 @@ msgid "%(num)s weekly download"
 msgid_plural "%(num)s weekly downloads"
 msgstr[0] "%(num)s щотижневе завантаження"
 msgstr[1] "%(num)s щотижневі завантаження"
-msgstr[2] "%(num)s щотижневих завантажень"
 
 #: src/olympia/addons/templates/addons/macros.html:28
 #, python-format
@@ -785,27 +581,20 @@ msgid "%(num)s user"
 msgid_plural "%(num)s users"
 msgstr[0] "%(num)s користувач"
 msgstr[1] "%(num)s користувача"
-msgstr[2] "%(num)s користувачів"
 
 #. {0} is the number of downloads.
-#: src/olympia/addons/templates/addons/macros.html:53
-#: src/olympia/addons/templates/addons/impala/details.html:61
+#: src/olympia/addons/templates/addons/macros.html:53 src/olympia/addons/templates/addons/impala/details.html:59
 msgid "{0} weekly download"
 msgid_plural "{0} weekly downloads"
 msgstr[0] "{0} щотижневе завантаження"
 msgstr[1] "{0} щотижневі завантаження"
-msgstr[2] "{0} щотижневих завантажень"
 
 #. {0} is the number of users.
-#: src/olympia/addons/templates/addons/macros.html:61
-#: src/olympia/addons/templates/addons/impala/details.html:54
-#: src/olympia/compat/templates/compat/index.html:71
-#: src/olympia/zadmin/templates/zadmin/compat.html:67
+#: src/olympia/addons/templates/addons/macros.html:61 src/olympia/addons/templates/addons/impala/details.html:52 src/olympia/zadmin/templates/zadmin/compat.html:67
 msgid "{0} user"
 msgid_plural "{0} users"
 msgstr[0] "{0} користувач"
 msgstr[1] "{0} користувача"
-msgstr[2] "{0} користувачів"
 
 #: src/olympia/addons/templates/addons/paypal_result.html:12
 msgid "Payment cancelled"
@@ -819,12 +608,8 @@ msgstr "Платіж завершено"
 msgid "Return to the addon."
 msgstr "Повернутися до додатку."
 
-#: src/olympia/addons/templates/addons/persona_detail.html:17
-#: src/olympia/addons/templates/addons/impala/details.html:106
-#: src/olympia/addons/templates/addons/mobile/details.html:23
-#: src/olympia/addons/templates/addons/mobile/persona_detail.html:21
-#: src/olympia/discovery/templates/discovery/addons/base.html:27
-#: src/olympia/editors/templates/editors/review.html:31
+#: src/olympia/addons/templates/addons/persona_detail.html:17 src/olympia/addons/templates/addons/impala/details.html:103 src/olympia/addons/templates/addons/mobile/details.html:23
+#: src/olympia/addons/templates/addons/mobile/persona_detail.html:21 src/olympia/discovery/templates/discovery/addons/base.html:27 src/olympia/editors/templates/editors/review.html:31
 msgid "by"
 msgstr "автор"
 
@@ -834,8 +619,7 @@ msgid "More {0} Themes"
 msgstr "Більше тем {0}"
 
 #. {0} is a category name, such as Nature
-#: src/olympia/addons/templates/addons/persona_detail.html:39
-#: src/olympia/addons/templates/addons/mobile/persona_detail.html:66
+#: src/olympia/addons/templates/addons/persona_detail.html:39 src/olympia/addons/templates/addons/mobile/persona_detail.html:66
 msgid "See all {0} Themes"
 msgstr "Дивитися всі теми {0}"
 
@@ -843,185 +627,129 @@ msgstr "Дивитися всі теми {0}"
 msgid "More by this Artist"
 msgstr "Більше від цього художника"
 
-#: src/olympia/addons/templates/addons/persona_detail.html:52
-#: src/olympia/addons/templates/addons/mobile/persona_detail.html:49
+#: src/olympia/addons/templates/addons/persona_detail.html:52 src/olympia/addons/templates/addons/mobile/persona_detail.html:49
 msgid "See all Themes by this Artist"
 msgstr "Дивитись більше тем цього художника"
 
-#: src/olympia/addons/templates/addons/persona_detail.html:71
-#: src/olympia/addons/templates/addons/mobile/home.html:42
-#: src/olympia/amo/templates/amo/side_nav.html:22
-#: src/olympia/browse/templates/browse/personas/mobile/category_landing.html:28
-#: src/olympia/devhub/templates/devhub/addons/edit/basic.html:72
-#: src/olympia/editors/templates/editors/review.html:277
-#: src/olympia/editors/templates/editors/themes/themes.html:34
-#: src/olympia/templates/categories.html:7
+#: src/olympia/addons/templates/addons/persona_detail.html:71 src/olympia/addons/templates/addons/mobile/home.html:42 src/olympia/amo/templates/amo/side_nav.html:22
+#: src/olympia/browse/templates/browse/personas/mobile/category_landing.html:28 src/olympia/devhub/templates/devhub/addons/edit/basic.html:72 src/olympia/editors/templates/editors/review.html:277
+#: src/olympia/editors/templates/editors/themes/themes.html:34 src/olympia/templates/categories.html:7
 msgid "Categories"
 msgstr "Категорії"
 
-#: src/olympia/addons/templates/addons/persona_detail_table.html:10
-#: src/olympia/addons/templates/addons/mobile/persona_detail_table.html:3
-#: src/olympia/editors/templates/editors/themes/deleted.html:19
+#: src/olympia/addons/templates/addons/persona_detail_table.html:10 src/olympia/addons/templates/addons/mobile/persona_detail_table.html:3 src/olympia/editors/templates/editors/themes/deleted.html:19
 #: src/olympia/editors/templates/editors/themes/themes.html:25
 msgid "Artist"
 msgstr "Художник"
 
-#: src/olympia/addons/templates/addons/persona_detail_table.html:19
-#: src/olympia/addons/templates/addons/mobile/persona_detail_table.html:14
-#: src/olympia/stats/templates/stats/addon_report_menu.html:17
+#: src/olympia/addons/templates/addons/persona_detail_table.html:19 src/olympia/addons/templates/addons/mobile/persona_detail_table.html:14 src/olympia/stats/templates/stats/addon_report_menu.html:17
 msgid "Daily Users"
 msgstr "Щоденних користувачів"
 
 #. The License for this add-on.
-#: src/olympia/addons/templates/addons/persona_detail_table.html:26
-#: src/olympia/addons/templates/addons/impala/license.html:17
-#: src/olympia/addons/templates/addons/mobile/persona_detail_table.html:21
-#: src/olympia/devhub/templates/devhub/includes/license_form.html:5
-#: src/olympia/devhub/templates/devhub/versions/edit.html:89
-#: src/olympia/editors/templates/editors/themes/themes.html:41
+#: src/olympia/addons/templates/addons/persona_detail_table.html:26 src/olympia/addons/templates/addons/impala/license.html:17 src/olympia/addons/templates/addons/mobile/persona_detail_table.html:21
+#: src/olympia/devhub/templates/devhub/includes/license_form.html:5 src/olympia/devhub/templates/devhub/versions/edit.html:89 src/olympia/editors/templates/editors/themes/themes.html:41
 msgid "License"
 msgstr "Ліцензія"
 
-#: src/olympia/addons/templates/addons/persona_preview.html:12
-#: src/olympia/constants/base.py:48
+#: src/olympia/addons/templates/addons/persona_preview.html:13 src/olympia/constants/base.py:48
 msgid "Awaiting Review"
 msgstr "Очікує перевірки"
 
-#: src/olympia/addons/templates/addons/persona_preview.html:14
-#: src/olympia/amo/log.py:180 src/olympia/constants/base.py:42
-#: src/olympia/editors/helpers.py:62
+#: src/olympia/addons/templates/addons/persona_preview.html:15 src/olympia/amo/log.py:180 src/olympia/constants/base.py:42 src/olympia/editors/helpers.py:62
 msgid "Rejected"
 msgstr "Відхилено"
 
-#: src/olympia/addons/templates/addons/persona_preview.html:16
-#: src/olympia/amo/log.py:159
+#: src/olympia/addons/templates/addons/persona_preview.html:17 src/olympia/amo/log.py:159
 msgid "Approved"
 msgstr "Схвалено"
 
 #. {0} is the number of users.
-#: src/olympia/addons/templates/addons/persona_preview.html:26
-#: src/olympia/addons/templates/addons/listing/items_mobile.html:36
-#: src/olympia/addons/templates/addons/listing/macros.html:31
+#: src/olympia/addons/templates/addons/persona_preview.html:27 src/olympia/addons/templates/addons/listing/items_mobile.html:36 src/olympia/addons/templates/addons/listing/macros.html:31
 msgid "<strong>{0}</strong> user"
 msgid_plural "<strong>{0}</strong> users"
 msgstr[0] "<strong>{0}</strong> користувач"
 msgstr[1] "<strong>{0}</strong> користувача"
-msgstr[2] "<strong>{0}</strong> користувачів"
 
-#: src/olympia/addons/templates/addons/persona_preview.html:40
+#: src/olympia/addons/templates/addons/persona_preview.html:41
 msgid "Hover to Preview"
 msgstr "Наведіть для попереднього перегляду"
 
-#: src/olympia/addons/templates/addons/persona_preview.html:46
-#: src/olympia/addons/templates/addons/persona_preview.html:48
+#: src/olympia/addons/templates/addons/persona_preview.html:47 src/olympia/addons/templates/addons/persona_preview.html:49 src/olympia/addons/templates/addons/persona_preview.html:97
 #: src/olympia/reviews/templates/reviews/add.html:15
 msgid "Add"
 msgstr "Додати"
 
-#: src/olympia/addons/templates/addons/persona_preview.html:57
-#: src/olympia/bandwagon/templates/bandwagon/ajax_new.html:16
-#: src/olympia/bandwagon/templates/bandwagon/edit.html:19
-#: src/olympia/bandwagon/templates/bandwagon/includes/addedit.html:19
-#: src/olympia/devhub/templates/devhub/addons/edit/admin.html:13
-#: src/olympia/devhub/templates/devhub/addons/edit/basic.html:10
-#: src/olympia/devhub/templates/devhub/addons/edit/details.html:8
-#: src/olympia/devhub/templates/devhub/addons/edit/media.html:6
-#: src/olympia/devhub/templates/devhub/addons/edit/support.html:8
-#: src/olympia/devhub/templates/devhub/addons/edit/technical.html:9
-#: src/olympia/devhub/templates/devhub/addons/submit/describe.html:29
-#: src/olympia/editors/templates/editors/review.html:257
+#: src/olympia/addons/templates/addons/persona_preview.html:58 src/olympia/bandwagon/templates/bandwagon/ajax_new.html:16 src/olympia/bandwagon/templates/bandwagon/edit.html:19
+#: src/olympia/bandwagon/templates/bandwagon/includes/addedit.html:19 src/olympia/devhub/templates/devhub/addons/edit/admin.html:13 src/olympia/devhub/templates/devhub/addons/edit/basic.html:10
+#: src/olympia/devhub/templates/devhub/addons/edit/details.html:8 src/olympia/devhub/templates/devhub/addons/edit/media.html:6 src/olympia/devhub/templates/devhub/addons/edit/support.html:8
+#: src/olympia/devhub/templates/devhub/addons/edit/technical.html:9 src/olympia/devhub/templates/devhub/addons/submit/describe.html:29 src/olympia/editors/templates/editors/review.html:257
 msgid "Edit"
 msgstr "Редагувати"
 
 #. For datetime formatting, see the table on
 #. http://docs.python.org/library/datetime.html#strftime-and-strptime-behavior
-#: src/olympia/addons/templates/addons/persona_preview.html:66
+#: src/olympia/addons/templates/addons/persona_preview.html:67
 #, python-format
 msgid "%%Y-%%m-%%d"
 msgstr "%%d.%%m.%%Y"
 
-#: src/olympia/addons/templates/addons/persona_preview.html:67
+#: src/olympia/addons/templates/addons/persona_preview.html:68
 msgid "by {0} on {1}"
 msgstr "створено {0} {1}"
 
-#: src/olympia/addons/templates/addons/persona_preview.html:75
-#: src/olympia/reviews/helpers.py:17
-#: src/olympia/reviews/templates/reviews/review_list.html:63
-#: src/olympia/reviews/templates/reviews/reviews_link.html:21
-#: src/olympia/reviews/templates/reviews/impala/reviews_link.html:16
+#: src/olympia/addons/templates/addons/persona_preview.html:76 src/olympia/reviews/helpers.py:17 src/olympia/reviews/templates/reviews/review_list.html:63
+#: src/olympia/reviews/templates/reviews/reviews_link.html:21 src/olympia/reviews/templates/reviews/impala/reviews_link.html:16
 msgid "Not yet rated"
 msgstr "Ще не оцінено"
 
-#: src/olympia/addons/templates/addons/persona_preview.html:78
+#: src/olympia/addons/templates/addons/persona_preview.html:79
 msgid "<b>{0}</b> users"
 msgstr "<b>{0}</b> користувачів"
 
 #: src/olympia/addons/templates/addons/popups.html:17
-msgid ""
-"To install this add-on and thousands more, <b>get Firefox</b>, a free and "
-"open web browser from Mozilla."
-msgstr ""
-"Щоб встановити цей додаток, а також тисячі інших, <b>встановіть Firefox</b>,"
-" безплатний та відкритий веб-браузер від Mozilla."
+msgid "To install this add-on and thousands more, <b>get Firefox</b>, a free and open web browser from Mozilla."
+msgstr "Щоб встановити цей додаток, а також тисячі інших, <b>встановіть Firefox</b>, безплатний та відкритий веб-браузер від Mozilla."
 
-#: src/olympia/addons/templates/addons/popups.html:21
-#: src/olympia/addons/templates/addons/popups.html:52
+#: src/olympia/addons/templates/addons/popups.html:21 src/olympia/addons/templates/addons/popups.html:52
 msgid "Learn more about Firefox"
 msgstr "Дізнатись більше про Firefox"
 
 #: src/olympia/addons/templates/addons/popups.html:22
-msgid "or <b><a class=\"installer\" href=\"{url}\">download anyway</a></b>"
-msgstr "чи <b><a class=\"installer\" href=\"{url}\">завантажити все одно</a></b>"
+msgid "or <b><a class=\"button installer\" href=\"{url}\">download anyway</a></b>"
+msgstr ""
 
 #: src/olympia/addons/templates/addons/popups.html:26
 msgid ""
-"<strong>How to Install in Thunderbird</strong> <ol> <li>Download and save "
-"the file to your hard disk.</li> <li>In Mozilla Thunderbird, open Add-ons "
-"from the Tools menu.</li> <li>From the options button next to the add-on "
-"search field, select \"Install Add-on From File...\" and locate the "
-"downloaded add-on.</li> </ol>"
+"<strong>How to Install in Thunderbird</strong> <ol> <li>Download and save the file to your hard disk.</li> <li>In Mozilla Thunderbird, open Add-ons from the Tools menu.</li> <li>From the options "
+"button next to the add-on search field, select \"Install Add-on From File...\" and locate the downloaded add-on.</li> </ol>"
 msgstr ""
-"<strong>Як встановити в Thunderbird</strong> <ol> <li>Завантажте та "
-"встановіть файл на свій жорсткий диск.</li> <li>У Mozilla Thunderbird, "
-"відкрийте Додатки з меню Інструменти.</li> <li>За допомогою кнопки опції, "
-"біля поля пошуку додатків, виберіть \"Встановити додаток з файлу...\" та "
-"виберіть завантажений файл.</li> </ol>"
+"<strong>Як встановити в Thunderbird</strong> <ol> <li>Завантажте та встановіть файл на свій жорсткий диск.</li> <li>У Mozilla Thunderbird, відкрийте Додатки з меню Інструменти.</li> <li>За "
+"допомогою кнопки опції, біля поля пошуку додатків, виберіть \"Встановити додаток з файлу...\" та виберіть завантажений файл.</li> </ol>"
 
 #: src/olympia/addons/templates/addons/popups.html:41
-msgid ""
-"To install this Theme, <b>get Thunderbird</b>, a free and open source email "
-"client from Mozilla Messaging and install the Personas Plus add-on."
-msgstr ""
-"Щоб встановити цю тему, <b>отримайте Thunderbird</b>, безплатний клієнт "
-"електронної пошти з відкритим кодом від Mozilla та встановіть додаток "
-"Personas Plus."
+msgid "To install this Theme, <b>get Thunderbird</b>, a free and open source email client from Mozilla Messaging and install the Personas Plus add-on."
+msgstr "Щоб встановити цю тему, <b>отримайте Thunderbird</b>, безплатний клієнт електронної пошти з відкритим кодом від Mozilla та встановіть додаток Personas Plus."
 
 #: src/olympia/addons/templates/addons/popups.html:46
 msgid "Learn more about Thunderbird"
 msgstr "Дізнатись більше про Thunderbird"
 
 #: src/olympia/addons/templates/addons/popups.html:48
-msgid ""
-"To install this Theme and thousands more, <b>get Firefox</b>, a free and "
-"open web browser from Mozilla."
-msgstr ""
-"Щоб встановити цю тему, а також тисячі інших, <b>отримайте Firefox</b>, "
-"безплатний браузер з відкритим кодом від Mozilla."
+msgid "To install this Theme and thousands more, <b>get Firefox</b>, a free and open web browser from Mozilla."
+msgstr "Щоб встановити цю тему, а також тисячі інших, <b>отримайте Firefox</b>, безплатний браузер з відкритим кодом від Mozilla."
 
 #: src/olympia/addons/templates/addons/popups.html:60
 #, python-format
 msgid "This add-on has not been updated to work with your version of %(app)s."
 msgstr "Цей додаток не був оновлений для роботи з вашою версією %(app)s."
 
-#: src/olympia/addons/templates/addons/popups.html:63
-#: src/olympia/addons/templates/addons/popups.html:140
-#: src/olympia/addons/templates/addons/popups.html:150
+#: src/olympia/addons/templates/addons/popups.html:63 src/olympia/addons/templates/addons/popups.html:140 src/olympia/addons/templates/addons/popups.html:150
 msgid "Install Anyway"
 msgstr "Все одно встановити"
 
 #: src/olympia/addons/templates/addons/popups.html:71
-msgid ""
-"This add-on requires a version of Firefox that has not been released yet."
+msgid "This add-on requires a version of Firefox that has not been released yet."
 msgstr "Цей додаток потребує версію Firefox, яка ще не була випущена."
 
 #: src/olympia/addons/templates/addons/popups.html:74
@@ -1030,16 +758,11 @@ msgstr "Допоможіть випробувати нові версії Firefo
 
 #: src/olympia/addons/templates/addons/popups.html:77
 #, python-format
-msgid ""
-"This add-on requires %(app)s {new_version}. You are currently using %(app)s "
-"{old_version}."
-msgstr ""
-"Цей додаток потребує %(app)s {new_version}. Зараз ви використовуєте %(app)s "
-"{old_version}."
+msgid "This add-on requires %(app)s {new_version}. You are currently using %(app)s {old_version}."
+msgstr "Цей додаток потребує %(app)s {new_version}. Зараз ви використовуєте %(app)s {old_version}."
 
 #. {0} is an app name, like Firefox.
-#: src/olympia/addons/templates/addons/popups.html:82
-#: src/olympia/addons/templates/addons/popups.html:101
+#: src/olympia/addons/templates/addons/popups.html:82 src/olympia/addons/templates/addons/popups.html:101
 msgid "Upgrade {0}"
 msgstr "Оновити {0}"
 
@@ -1050,42 +773,27 @@ msgstr "чи преглянути <a href=\"%(href)s\">старіші версі
 
 #: src/olympia/addons/templates/addons/popups.html:96
 #, python-format
-msgid ""
-"This Persona requires %(app)s %(new_version)s. You are currently using "
-"%(app)s {old_version}."
-msgstr ""
-"Persona потребує %(app)s %(new_version)s. Зараз ви використовуєте %(app)s "
-"{old_version}."
+msgid "This Persona requires %(app)s %(new_version)s. You are currently using %(app)s {old_version}."
+msgstr "Persona потребує %(app)s %(new_version)s. Зараз ви використовуєте %(app)s {old_version}."
 
 #: src/olympia/addons/templates/addons/popups.html:108
 msgid ""
-"<strong>Caution:</strong> This add-on has not been reviewed by Mozilla and "
-"can't be installed on release versions of Firefox 43 and above.  Be careful "
-"when installing third-party software that might harm your computer."
+"<strong>Caution:</strong> This add-on has not been reviewed by Mozilla and can't be installed on release versions of Firefox 43 and above. Be careful when installing third-party software that might"
+" harm your computer."
 msgstr ""
-"<strong>Увага:</strong> Цей додаток не був перевірений Mozilla і не може "
-"бути встановлений на версію Firefox 43 та вище.  Будьте обережні при "
-"встановленні програмного забезпечення від третіх сторін, яке може пошкодити "
-"ваш комп'ютер."
+"<strong>Увага:</strong> Цей додаток не був розглянутий Mozilla і не може бути встановлений на реліз версій Firefox 43 і вище. Будьте обережні при установці стороннього програмного забезпечення, яке"
+" може пошкодити ваш комп'ютер."
 
 #: src/olympia/addons/templates/addons/popups.html:120
-msgid ""
-"<strong>Please note:</strong> This add-on is not compatible with your "
-"operating system."
-msgstr ""
-"<strong>Будь ласка, зауважте:</strong> Цей додаток несумісний з вашою "
-"операційною системою."
+msgid "<strong>Please note:</strong> This add-on is not compatible with your operating system."
+msgstr "<strong>Будь ласка, зауважте:</strong> Цей додаток несумісний з вашою операційною системою."
 
-#: src/olympia/addons/templates/addons/popups.html:136
-#: src/olympia/addons/templates/addons/impala/button.html:70
+#: src/olympia/addons/templates/addons/popups.html:136 src/olympia/addons/templates/addons/impala/button.html:70
 #, python-format
-msgid ""
-"This add-on is not compatible with your version of %(app)s because of the "
-"following:"
+msgid "This add-on is not compatible with your version of %(app)s because of the following:"
 msgstr "Цей додаток несумісний з вашою версією %(app)s у зв'язку з наступним:"
 
-#: src/olympia/addons/templates/addons/popups.html:141
-#: src/olympia/addons/templates/addons/popups.html:151
+#: src/olympia/addons/templates/addons/popups.html:141 src/olympia/addons/templates/addons/popups.html:151
 msgid "View other versions"
 msgstr "Переглянути інші версії"
 
@@ -1104,149 +812,92 @@ msgid "QR code for add-on"
 msgstr "QR-код для додатку"
 
 #: src/olympia/addons/templates/addons/qr_code.html:6
-msgid ""
-"Want {0} on your mobile Firefox?  Scan this QR code to install directly\n"
-"  to your phone.  (You'll need a QR reader.  Search your phone's marketplace if\n"
-"  don't have one.)"
+msgid "Want {0} on your mobile Firefox? Scan this QR code to install directly to your phone. (You'll need a QR reader. Search your phone's marketplace if don't have one.)"
 msgstr ""
-"Хочете встановити {0} у ваш мобільний Firefox?  Проскануйте цей QR-код для встановлення прямо\n"
-"  на ваш телефон.  (Вам знадобиться QR-читач.  Пошукайте в магазині додатків вашого телефона,\n"
-"  якщо у вас його немає.)"
+"Хочете {0} на своєму мобільному Firefox? Зіскануйте цей QR-код, щоб встановити прямо у свій телефон. (Вам потрібна програма для зчитування QR-кодів. Знайдіть її у своєму магазині програм, якщо у "
+"вас її немає.)"
 
-#: src/olympia/addons/templates/addons/report_abuse.html:6
-#: src/olympia/addons/templates/addons/report_abuse_full.html:10
-#: src/olympia/addons/templates/addons/impala/details-more.html:23
-#: src/olympia/addons/templates/addons/impala/details.html:328
+#: src/olympia/addons/templates/addons/report_abuse.html:6 src/olympia/addons/templates/addons/report_abuse_full.html:10 src/olympia/addons/templates/addons/impala/details-more.html:23
+#: src/olympia/addons/templates/addons/impala/details.html:333
 msgid "Report Abuse"
 msgstr "Надіслати скаргу"
 
 #: src/olympia/addons/templates/addons/report_abuse.html:10
 #, python-format
 msgid ""
-"If you suspect this add-on violates <a href=\"%(url)s\">our policies</a> or "
-"has security or privacy issues, please use the form below to describe your "
-"concerns. Please do not use this form for any other reason."
+"If you suspect this add-on violates <a href=\"%(url)s\">our policies</a> or has security or privacy issues, please use the form below to describe your concerns. Please do not use this form for any "
+"other reason."
 msgstr ""
-"Якщо ви підозрюєте цей додаток у порушенні <a href=\"%(url)s\">нашої "
-"політики</a> або у проблемах безпеки чи приватності, скористайтеся формою "
-"внизу для опису вашої стурбованості. Будь ласка, не використовуйте дану "
-"форму для будь-яких інших цілей."
+"Якщо ви підозрюєте цей додаток у порушенні <a href=\"%(url)s\">нашої політики</a> або у проблемах безпеки чи приватності, скористайтеся формою внизу для опису вашої стурбованості. Будь ласка, не "
+"використовуйте дану форму для будь-яких інших цілей."
 
-#: src/olympia/addons/templates/addons/report_abuse.html:24
-#: src/olympia/users/templates/users/report_abuse.html:19
+#: src/olympia/addons/templates/addons/report_abuse.html:24 src/olympia/users/templates/users/report_abuse.html:19
 msgid "Send Report"
 msgstr "Надіслати звіт"
 
-#: src/olympia/addons/templates/addons/report_abuse.html:26
-#: src/olympia/addons/templates/addons/mobile/eula.html:16
-#: src/olympia/addons/templates/addons/mobile/persona_confirm.html:7
-#: src/olympia/devhub/templates/devhub/addons/ajax_compat_update.html:36
-#: src/olympia/devhub/templates/devhub/addons/profile.html:44
-#: src/olympia/devhub/templates/devhub/addons/edit/admin.html:104
-#: src/olympia/devhub/templates/devhub/addons/edit/basic.html:155
-#: src/olympia/devhub/templates/devhub/addons/edit/details.html:88
-#: src/olympia/devhub/templates/devhub/addons/edit/support.html:70
-#: src/olympia/devhub/templates/devhub/addons/edit/technical.html:169
-#: src/olympia/devhub/templates/devhub/addons/forms_shared/media.html:152
-#: src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:44
-#: src/olympia/devhub/templates/devhub/personas/edit.html:222
-#: src/olympia/devhub/templates/devhub/versions/add_file_modal.html:79
-#: src/olympia/devhub/templates/devhub/versions/edit.html:140
-#: src/olympia/devhub/templates/devhub/versions/list.html:208
-#: src/olympia/devhub/templates/devhub/versions/list.html:242
-#: src/olympia/devhub/templates/devhub/versions/list.html:276
-#: src/olympia/devhub/templates/devhub/versions/list.html:317
-#: src/olympia/reviews/templates/reviews/edit_review.html:16
-#: src/olympia/translations/templates/translations/trans-menu.html:50
-#: src/olympia/translations/templates/translations/trans-menu.html:62
-#: src/olympia/zadmin/templates/zadmin/validation.html:105
+#: src/olympia/addons/templates/addons/report_abuse.html:26 src/olympia/addons/templates/addons/mobile/eula.html:16 src/olympia/addons/templates/addons/mobile/persona_confirm.html:7
+#: src/olympia/devhub/templates/devhub/addons/ajax_compat_update.html:36 src/olympia/devhub/templates/devhub/addons/profile.html:44 src/olympia/devhub/templates/devhub/addons/edit/admin.html:104
+#: src/olympia/devhub/templates/devhub/addons/edit/basic.html:155 src/olympia/devhub/templates/devhub/addons/edit/details.html:88 src/olympia/devhub/templates/devhub/addons/edit/support.html:70
+#: src/olympia/devhub/templates/devhub/addons/edit/technical.html:169 src/olympia/devhub/templates/devhub/addons/forms_shared/media.html:152
+#: src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:43 src/olympia/devhub/templates/devhub/personas/edit.html:222 src/olympia/devhub/templates/devhub/versions/add_file_modal.html:59
+#: src/olympia/devhub/templates/devhub/versions/edit.html:140 src/olympia/devhub/templates/devhub/versions/list.html:208 src/olympia/devhub/templates/devhub/versions/list.html:239
+#: src/olympia/devhub/templates/devhub/versions/list.html:281 src/olympia/devhub/templates/devhub/versions/list.html:315 src/olympia/reviews/templates/reviews/edit_review.html:16
+#: src/olympia/translations/templates/translations/trans-menu.html:50 src/olympia/translations/templates/translations/trans-menu.html:62 src/olympia/zadmin/templates/zadmin/validation.html:105
 msgid "Cancel"
 msgstr "Скасувати"
 
-#: src/olympia/addons/templates/addons/review_add_box.html:3
-#: src/olympia/addons/templates/addons/impala/review_add_box.html:5
+#: src/olympia/addons/templates/addons/review_add_box.html:3 src/olympia/addons/templates/addons/impala/review_add_box.html:5
 msgid "What do you think?"
 msgstr "Що скажете?"
 
-#: src/olympia/addons/templates/addons/review_add_box.html:7
-#: src/olympia/addons/templates/addons/impala/review_add_box.html:9
+#: src/olympia/addons/templates/addons/review_add_box.html:7 src/olympia/addons/templates/addons/impala/review_add_box.html:9
 #, python-format
 msgid "Please <a href=\"%(login)s\">log in</a> to submit a review"
 msgstr "Будь ласка <a href=\"%(login)s\">увійдіть</a>, щоб залишити відгук"
 
-#: src/olympia/addons/templates/addons/review_add_box.html:16
-#: src/olympia/addons/templates/addons/impala/review_add_box.html:18
-#: src/olympia/reviews/templates/reviews/mobile/add_form.html:13
+#: src/olympia/addons/templates/addons/review_add_box.html:16 src/olympia/addons/templates/addons/impala/review_add_box.html:18 src/olympia/reviews/templates/reviews/mobile/add_form.html:13
 msgid "Title:"
 msgstr "Назва:"
 
-#: src/olympia/addons/templates/addons/review_add_box.html:17
-#: src/olympia/addons/templates/addons/impala/review_add_box.html:19
-#: src/olympia/reviews/templates/reviews/mobile/add_form.html:17
+#: src/olympia/addons/templates/addons/review_add_box.html:17 src/olympia/addons/templates/addons/impala/review_add_box.html:19 src/olympia/reviews/templates/reviews/mobile/add_form.html:17
 msgid "Review:"
 msgstr "Відгук:"
 
-#: src/olympia/addons/templates/addons/review_add_box.html:18
-#: src/olympia/addons/templates/addons/impala/review_add_box.html:20
-#: src/olympia/reviews/templates/reviews/mobile/add_form.html:16
+#: src/olympia/addons/templates/addons/review_add_box.html:18 src/olympia/addons/templates/addons/impala/review_add_box.html:20 src/olympia/reviews/templates/reviews/mobile/add_form.html:16
 msgid "Rating:"
 msgstr "Рейтинг:"
 
-#: src/olympia/addons/templates/addons/review_add_box.html:19
-#: src/olympia/addons/templates/addons/impala/review_add_box.html:21
-#: src/olympia/reviews/templates/reviews/add.html:63
-#: src/olympia/reviews/templates/reviews/edit_review.html:15
-#: src/olympia/reviews/templates/reviews/mobile/add_form.html:18
+#: src/olympia/addons/templates/addons/review_add_box.html:19 src/olympia/addons/templates/addons/impala/review_add_box.html:21 src/olympia/reviews/templates/reviews/add.html:63
+#: src/olympia/reviews/templates/reviews/edit_review.html:15 src/olympia/reviews/templates/reviews/mobile/add_form.html:18
 msgid "Submit review"
 msgstr "Відправити відгук"
 
-#: src/olympia/addons/templates/addons/review_add_box.html:24
-#: src/olympia/addons/templates/addons/impala/review_add_box.html:26
-msgid ""
-"Please do not post bug reports in reviews. We do not make your email address"
-" available to add-on developers and they may need to contact you to help "
-"resolve your issue."
-msgstr ""
-"Будь ласка, не надсилайте повідомлення про помилки у відгуках. Ми не "
-"розголошуємо вашу електронну адресу, а розробникам може бути потрібно "
-"зв’язатись з вами, щоб допомогти."
+#: src/olympia/addons/templates/addons/review_add_box.html:24 src/olympia/addons/templates/addons/impala/review_add_box.html:26
+msgid "Please do not post bug reports in reviews. We do not make your email address available to add-on developers and they may need to contact you to help resolve your issue."
+msgstr "Будь ласка, не надсилайте повідомлення про помилки у відгуках. Ми не розголошуємо вашу електронну адресу, а розробникам може бути потрібно зв’язатись з вами, щоб допомогти."
 
-#: src/olympia/addons/templates/addons/review_add_box.html:32
-#: src/olympia/addons/templates/addons/impala/review_add_box.html:35
+#: src/olympia/addons/templates/addons/review_add_box.html:32 src/olympia/addons/templates/addons/impala/review_add_box.html:35
 #, python-format
-msgid ""
-"See the <a href=\"%(support)s\">support section</a> to find out where to get"
-" assistance for this add-on."
-msgstr ""
-"Для отримання інформації про те, як отримати допомогу для цього додатку, "
-"зверніться до <a href=\"%(support)s\">розділу підтримки</a>."
+msgid "See the <a href=\"%(support)s\">support section</a> to find out where to get assistance for this add-on."
+msgstr "Для отримання інформації про те, як отримати допомогу для цього додатку, зверніться до <a href=\"%(support)s\">розділу підтримки</a>."
 
-#: src/olympia/addons/templates/addons/review_add_box.html:38
-#: src/olympia/addons/templates/addons/impala/review_add_box.html:42
-#: src/olympia/pages/templates/pages/review_guide.html:3
+#: src/olympia/addons/templates/addons/review_add_box.html:38 src/olympia/addons/templates/addons/impala/review_add_box.html:42 src/olympia/pages/templates/pages/review_guide.html:3
 #: src/olympia/pages/templates/pages/review_guide.html:44
 msgid "Review Guidelines"
 msgstr "Щодо відгуків"
 
-#: src/olympia/addons/templates/addons/review_list_box.html:5
-#: src/olympia/addons/templates/addons/impala/details-more.html:27
-#: src/olympia/editors/helpers.py:921
-#: src/olympia/reviews/templates/reviews/add.html:14
-#: src/olympia/reviews/templates/reviews/reply.html:14
-#: src/olympia/reviews/templates/reviews/review_list.html:19
+#: src/olympia/addons/templates/addons/review_list_box.html:5 src/olympia/addons/templates/addons/impala/details-more.html:27 src/olympia/editors/helpers.py:1001
+#: src/olympia/reviews/templates/reviews/add.html:14 src/olympia/reviews/templates/reviews/reply.html:14 src/olympia/reviews/templates/reviews/review_list.html:19
 #: src/olympia/reviews/templates/reviews/mobile/review_list.html:26
 msgid "Reviews"
 msgstr "Відгуки"
 
-#: src/olympia/addons/templates/addons/review_list_box.html:14
-#: src/olympia/addons/templates/addons/impala/review_list_box.html:14
-#: src/olympia/reviews/templates/reviews/review.html:30
+#: src/olympia/addons/templates/addons/review_list_box.html:14 src/olympia/addons/templates/addons/impala/review_list_box.html:14 src/olympia/reviews/templates/reviews/review.html:30
 #, python-format
 msgid "by %(user)s on %(date)s"
 msgstr "від %(user)s за %(date)s"
 
-#: src/olympia/addons/templates/addons/review_list_box.html:19
-#: src/olympia/addons/templates/addons/impala/review_list_box.html:29
+#: src/olympia/addons/templates/addons/review_list_box.html:19 src/olympia/addons/templates/addons/impala/review_list_box.html:29
 msgid "Show the developer's reply to this review"
 msgstr "Показати відповідь розробника на цей відгук"
 
@@ -1256,23 +907,17 @@ msgid "See all reviews of this add-on"
 msgid_plural "See all %(cnt)s reviews of this add-on"
 msgstr[0] "Дивитися всі відгуки для цього додатку"
 msgstr[1] "Дивитися всі %(cnt)s відгуки для цього додатку"
-msgstr[2] "Дивитися всі %(cnt)s відгуків для цього додатку"
 
-#: src/olympia/addons/templates/addons/tags_box.html:3
-#: src/olympia/devhub/templates/devhub/addons/edit/basic.html:118
+#: src/olympia/addons/templates/addons/tags_box.html:3 src/olympia/devhub/templates/devhub/addons/edit/basic.html:118
 msgid "Tags"
 msgstr "Мітки"
 
-#: src/olympia/addons/templates/addons/impala/addon_hovercard.html:7
-#: src/olympia/addons/templates/addons/impala/addon_hovercard.html:9
+#: src/olympia/addons/templates/addons/impala/addon_hovercard.html:7 src/olympia/addons/templates/addons/impala/addon_hovercard.html:9
 msgid "Icon for {0}"
 msgstr "Піктограма для {0}"
 
-#: src/olympia/addons/templates/addons/impala/addon_hovercard.html:34
-#: src/olympia/addons/templates/addons/impala/featured_grid.html:26
-#: src/olympia/addons/templates/addons/impala/theme_grid.html:22
-#: src/olympia/bandwagon/templates/bandwagon/collection_detail.html:31
-#: src/olympia/users/templates/users/helpers/addon_users_list.html:7
+#: src/olympia/addons/templates/addons/impala/addon_hovercard.html:34 src/olympia/addons/templates/addons/impala/featured_grid.html:26 src/olympia/addons/templates/addons/impala/theme_grid.html:22
+#: src/olympia/bandwagon/templates/bandwagon/collection_detail.html:31 src/olympia/users/templates/users/helpers/addon_users_list.html:7
 #, python-format
 msgid "by %(users)s"
 msgstr "від %(users)s"
@@ -1292,34 +937,18 @@ msgstr "Подобається цей додаток?"
 
 #: src/olympia/addons/templates/addons/impala/contribution.html:43
 #, python-format
-msgid ""
-"The <a href=\"%(meet_url)s\">developer of this add-on</a> asks that you help"
-" support its continued development by making a small contribution."
-msgstr ""
-"<a href=\"%(meet_url)s\">Розробник цього додатку</a> просить вас підтримати "
-"його подальшу розробку, зробивши невеликий внесок."
+msgid "The <a href=\"%(meet_url)s\">developer of this add-on</a> asks that you help support its continued development by making a small contribution."
+msgstr "<a href=\"%(meet_url)s\">Розробник цього додатку</a> просить вас підтримати його подальшу розробку, зробивши невеликий внесок."
 
 #: src/olympia/addons/templates/addons/impala/contribution.html:48
 #, python-format
-msgid ""
-"The <a href=\"%(meet_url)s\">developer of this add-on</a> asks that you show"
-" your support by making a donation to the <a "
-"href=\"%(charity_url)s\">%(charity_name)s</a>."
-msgstr ""
-"<a href=\"%(meet_url)s\">Розробник цього додатку</a> просить вас виявити "
-"свою підтримку, зробивши внесок на користь <a "
-"href=\"%(charity_url)s\">%(charity_name)s</a>."
+msgid "The <a href=\"%(meet_url)s\">developer of this add-on</a> asks that you show your support by making a donation to the <a href=\"%(charity_url)s\">%(charity_name)s</a>."
+msgstr "<a href=\"%(meet_url)s\">Розробник цього додатку</a> просить вас виявити свою підтримку, зробивши внесок на користь <a href=\"%(charity_url)s\">%(charity_name)s</a>."
 
 #: src/olympia/addons/templates/addons/impala/contribution.html:53
 #, python-format
-msgid ""
-"The <a href=\"%(meet_url)s\">developer of this add-on</a> asks that you show"
-" your support by making a small contribution to <a "
-"href=\"%(charity_url)s\">%(charity_name)s</a>."
-msgstr ""
-"<a href=\"%(meet_url)s\">Розробник цього додатку</a> просить вас виявити "
-"свою підтримку, зробивши невеликий внесок на користь <a "
-"href=\"%(charity_url)s\">%(charity_name)s</a>."
+msgid "The <a href=\"%(meet_url)s\">developer of this add-on</a> asks that you show your support by making a small contribution to <a href=\"%(charity_url)s\">%(charity_name)s</a>."
+msgstr "<a href=\"%(meet_url)s\">Розробник цього додатку</a> просить вас виявити свою підтримку, зробивши невеликий внесок на користь <a href=\"%(charity_url)s\">%(charity_name)s</a>."
 
 #: src/olympia/addons/templates/addons/impala/dependencies_note.html:4
 msgid "This add-on requires the following add-ons to work properly:"
@@ -1347,148 +976,122 @@ msgid "Other add-ons by %(author)s"
 msgid_plural "Other add-ons by these authors"
 msgstr[0] "Інші додатки від %(author)s"
 msgstr[1] "Інші додатки від цих розробників"
-msgstr[2] "Інші додатки від цих розробників"
 
-#: src/olympia/addons/templates/addons/impala/details.html:41
+#: src/olympia/addons/templates/addons/impala/details.html:39
 #, python-format
 msgid "<span itemprop=\"ratingCount\">%(num)s</span> user review"
 msgid_plural "<span itemprop=\"ratingCount\">%(num)s</span> user reviews"
 msgstr[0] "<span itemprop=\"ratingCount\">%(num)s</span> відгук користувача"
 msgstr[1] "<span itemprop=\"ratingCount\">%(num)s</span> відгуки користувачів"
-msgstr[2] "<span itemprop=\"ratingCount\">%(num)s</span> відгуків користувачів"
 
-#: src/olympia/addons/templates/addons/impala/details.html:69
+#: src/olympia/addons/templates/addons/impala/details.html:66
 msgid "View statistics"
 msgstr "Переглянути статистику"
 
-#: src/olympia/addons/templates/addons/impala/details.html:84
+#: src/olympia/addons/templates/addons/impala/details.html:81
 msgid "Manage"
 msgstr "Керувати"
 
 #. {0} is an add-on name.
-#: src/olympia/addons/templates/addons/impala/details.html:96
+#: src/olympia/addons/templates/addons/impala/details.html:93
 msgid "Icon of {0}"
 msgstr "Піктограма {0}"
 
-#: src/olympia/addons/templates/addons/impala/details.html:103
-#: src/olympia/addons/templates/addons/impala/listing/items.html:14
+#: src/olympia/addons/templates/addons/impala/details.html:100 src/olympia/addons/templates/addons/impala/listing/items.html:14
 msgid "No Restart"
 msgstr "Без перезапуску"
 
-#: src/olympia/addons/templates/addons/impala/details.html:127
+#: src/olympia/addons/templates/addons/impala/details.html:124
 #, python-format
 msgid "Meet the Developer: <a href=\"%(url)s\">%(name)s</a>"
 msgid_plural "<a href=\"%(url)s\">Meet the Developers</a>"
 msgstr[0] "Познайомитися з розробником: <a href=\"%(url)s\">%(name)s</a>"
 msgstr[1] "<a href=\"%(url)s\">Познайомитися з розробниками</a>"
-msgstr[2] "<a href=\"%(url)s\">Познайомитися з розробниками</a>"
 
-#: src/olympia/addons/templates/addons/impala/details.html:137
+#: src/olympia/addons/templates/addons/impala/details.html:134
 msgid "Learn why {0} was created and find out what's next for this add-on."
 msgstr "Дізнатися, чому був створений {0} та які подальші плани щодо нього."
 
 #. {0} is an index.
-#: src/olympia/addons/templates/addons/impala/details.html:156
+#: src/olympia/addons/templates/addons/impala/details.html:161
 msgid "Add-on screenshot #{0}"
 msgstr "Знімок екрану #{0} додатку"
 
-#: src/olympia/addons/templates/addons/impala/details.html:182
+#: src/olympia/addons/templates/addons/impala/details.html:187
 msgid "Add-on home page"
 msgstr "Домашня сторінка додатку"
 
-#: src/olympia/addons/templates/addons/impala/details.html:185
+#: src/olympia/addons/templates/addons/impala/details.html:190
 msgid "Support site"
 msgstr "Сайт підтримки"
 
-#: src/olympia/addons/templates/addons/impala/details.html:189
+#: src/olympia/addons/templates/addons/impala/details.html:194
 msgid "Support E-mail"
 msgstr "Електронна пошта підтримки"
 
-#: src/olympia/addons/templates/addons/impala/details.html:194
-#: src/olympia/devhub/models.py:378
-#: src/olympia/devhub/templates/devhub/versions/list.html:12
-#: src/olympia/versions/templates/versions/version.html:6
-#: src/olympia/versions/templates/versions/mobile/version.html:6
+#: src/olympia/addons/templates/addons/impala/details.html:199 src/olympia/devhub/models.py:378 src/olympia/devhub/templates/devhub/versions/list.html:12
+#: src/olympia/versions/templates/versions/version.html:6 src/olympia/versions/templates/versions/mobile/version.html:6
 msgid "Version {0}"
 msgstr "Версія {0}"
 
-#: src/olympia/addons/templates/addons/impala/details.html:194
+#: src/olympia/addons/templates/addons/impala/details.html:199
 msgid "Info"
 msgstr "Інформація"
 
-#: src/olympia/addons/templates/addons/impala/details.html:195
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:129
+#: src/olympia/addons/templates/addons/impala/details.html:200 src/olympia/devhub/templates/devhub/includes/addon_details.html:116
 msgid "Last Updated:"
 msgstr "Останнє оновлення:"
 
-#: src/olympia/addons/templates/addons/impala/details.html:200
+#: src/olympia/addons/templates/addons/impala/details.html:205
 #, python-format
 msgid "Released under <a target=\"_blank\" href=\"%(url)s\">%(name)s</a>"
 msgstr "Випущено на умовах <a target=\"_blank\" href=\"%(url)s\">%(name)s</a>"
 
-#: src/olympia/addons/templates/addons/impala/details.html:201
-#: src/olympia/addons/templates/addons/impala/details.html:206
-#: src/olympia/amo/helpers.py:398 src/olympia/devhub/forms.py:142
-#: src/olympia/devhub/forms.py:173
-#: src/olympia/versions/templates/versions/version.html:40
-#: src/olympia/versions/templates/versions/version.html:45
+#: src/olympia/addons/templates/addons/impala/details.html:206 src/olympia/addons/templates/addons/impala/details.html:211 src/olympia/amo/helpers.py:398 src/olympia/devhub/forms.py:142
+#: src/olympia/devhub/forms.py:173 src/olympia/versions/templates/versions/version.html:40 src/olympia/versions/templates/versions/version.html:45
 msgid "Custom License"
 msgstr "Custom License"
 
-#: src/olympia/addons/templates/addons/impala/details.html:205
+#: src/olympia/addons/templates/addons/impala/details.html:210
 #, python-format
 msgid "Released under <a href=\"%(url)s\">%(name)s</a>"
 msgstr "Випущено під <a href=\"%(url)s\">%(name)s</a>"
 
-#: src/olympia/addons/templates/addons/impala/details.html:217
+#: src/olympia/addons/templates/addons/impala/details.html:222
 msgid "About this Add-on"
 msgstr "Про цей додаток"
 
-#: src/olympia/addons/templates/addons/impala/details.html:233
+#: src/olympia/addons/templates/addons/impala/details.html:238
 msgid "Developer’s Comments"
 msgstr "Коментарі розробника"
 
-#: src/olympia/addons/templates/addons/impala/details.html:243
+#: src/olympia/addons/templates/addons/impala/details.html:248
 msgid "Version Information"
 msgstr "Інформація про версію"
 
-#: src/olympia/addons/templates/addons/impala/details.html:250
+#: src/olympia/addons/templates/addons/impala/details.html:255
 msgid "See complete version history"
 msgstr "Подивитися повну історію версій"
 
-#: src/olympia/addons/templates/addons/impala/details.html:262
+#: src/olympia/addons/templates/addons/impala/details.html:267
 msgid ""
-"The Development Channel lets you test an experimental new version of this "
-"add-on before it's released to the general public. Once you install the "
-"development version, you will continue to get updates from this channel. To "
-"stop receiving development updates, reinstall the default version from the "
-"link above."
+"The Development Channel lets you test an experimental new version of this add-on before it's released to the general public. Once you install the development version, you will continue to get "
+"updates from this channel. To stop receiving development updates, reinstall the default version from the link above."
 msgstr ""
-"Канал розробника дозволяє вам випробувати експериментальну нову версію цього"
-" додатку перед його виходом у загал. Після встановлення експериментальної "
-"версії ви надалі будете отримувати оновлення з цього каналу. Щоб припинити "
-"експериментальні оновлення, перевстановіть типову версію за посиланням вище."
+"Канал розробника дозволяє вам випробувати експериментальну нову версію цього додатку перед його виходом у загал. Після встановлення експериментальної версії ви надалі будете отримувати оновлення з "
+"цього каналу. Щоб припинити експериментальні оновлення, перевстановіть типову версію за посиланням вище."
 
-#: src/olympia/addons/templates/addons/impala/details.html:272
-msgid ""
-"<strong>Caution:</strong> Development versions of this add-on have not been "
-"reviewed by Mozilla."
-msgstr ""
-"<strong>Увага:</strong> Тестові версії цього додатку не були перевірені "
-"Mozilla."
+#: src/olympia/addons/templates/addons/impala/details.html:277
+msgid "<strong>Caution:</strong> Development versions of this add-on have not been reviewed by Mozilla."
+msgstr "<strong>Увага:</strong> Тестові версії цього додатку не були перевірені Mozilla."
 
-#: src/olympia/addons/templates/addons/impala/details.html:287
+#: src/olympia/addons/templates/addons/impala/details.html:292
 msgid "See complete development channel history"
 msgstr "Дивитися повну історію каналу розробки"
 
-#: src/olympia/addons/templates/addons/impala/details.html:306
-#: src/olympia/addons/templates/addons/impala/details.html:315
-#: src/olympia/addons/templates/addons/impala/details.html:327
-#: src/olympia/addons/templates/addons/impala/review_add_box.html:4
-#: src/olympia/stats/templates/stats/popup.html:2
-#: src/olympia/stats/templates/stats/popup.html:8
-#: src/olympia/stats/templates/stats/stats.html:202
-#: src/olympia/users/templates/users/profile.html:119
+#: src/olympia/addons/templates/addons/impala/details.html:311 src/olympia/addons/templates/addons/impala/details.html:320 src/olympia/addons/templates/addons/impala/details.html:332
+#: src/olympia/addons/templates/addons/impala/review_add_box.html:4 src/olympia/stats/templates/stats/popup.html:2 src/olympia/stats/templates/stats/popup.html:8
+#: src/olympia/stats/templates/stats/stats.html:204 src/olympia/users/templates/users/profile.html:119
 msgid "close"
 msgstr "закрити"
 
@@ -1503,13 +1106,10 @@ msgid "Meet the {0} Developer"
 msgstr "Познайомитись із розробником {0}"
 
 #: src/olympia/addons/templates/addons/impala/developers.html:41
-msgid ""
-"Before downloading this add-on, please consider supporting the development "
-"of this add-on by making a small contribution."
+msgid "Before downloading this add-on, please consider supporting the development of this add-on by making a small contribution."
 msgstr ""
-"Перед тим, як завантажити цей додаток, вважайте необхідним для його "
-"підтримки зробити ваш невеличкий внесок.Перед тим, як завантажити цей "
-"додаток, вважайте необхідною його підтримкою ваш невеличкий внесок."
+"Перед тим, як завантажити цей додаток, вважайте необхідним для його підтримки зробити ваш невеличкий внесок.Перед тим, як завантажити цей додаток, вважайте необхідною його підтримкою ваш невеличкий"
+" внесок."
 
 #: src/olympia/addons/templates/addons/impala/developers.html:80
 msgid "Why was {0} created?"
@@ -1524,11 +1124,8 @@ msgid "About the Developer"
 msgid_plural "About the Developers"
 msgstr[0] "Про розробника"
 msgstr[1] "Про розробників"
-msgstr[2] "Про розробників"
 
-#: src/olympia/addons/templates/addons/impala/developers.html:96
-#: src/olympia/users/templates/users/edit.html:130
-#: src/olympia/users/templates/users/profile.html:26
+#: src/olympia/addons/templates/addons/impala/developers.html:96 src/olympia/users/templates/users/edit.html:130 src/olympia/users/templates/users/profile.html:26
 msgid "No Photo"
 msgstr "Немає фото"
 
@@ -1548,24 +1145,15 @@ msgstr "Цей додаток був відключений адміністра
 msgid "Source Code License for {addon}"
 msgstr "Ліцензія початкового коду для {addon}"
 
-#: src/olympia/addons/templates/addons/impala/license.html:21
-#: src/olympia/versions/templates/versions/mobile/version.html:18
+#: src/olympia/addons/templates/addons/impala/license.html:21 src/olympia/versions/templates/versions/mobile/version.html:18
 msgid "Source Code License"
 msgstr "Ліцензія джерельного коду"
 
-#: src/olympia/addons/templates/addons/impala/persona_grid.html:16
-#: src/olympia/addons/templates/addons/impala/toplist.html:6
-msgid "{0} users"
-msgstr "{0} користувачів"
-
-#: src/olympia/addons/templates/addons/impala/review_list_box.html:19
-#: src/olympia/reviews/templates/reviews/review.html:40
+#: src/olympia/addons/templates/addons/impala/review_list_box.html:19 src/olympia/reviews/templates/reviews/review.html:40
 msgid "permalink"
 msgstr "постійне посилання"
 
-#: src/olympia/addons/templates/addons/impala/review_list_box.html:23
-#: src/olympia/editors/templates/editors/queue.html:98
-#: src/olympia/reviews/templates/reviews/review.html:44
+#: src/olympia/addons/templates/addons/impala/review_list_box.html:23 src/olympia/editors/templates/editors/queue.html:104 src/olympia/reviews/templates/reviews/review.html:44
 msgid "translate"
 msgstr "перекласти"
 
@@ -1575,10 +1163,8 @@ msgid "See all user reviews"
 msgid_plural "See all %(cnt)s user reviews"
 msgstr[0] "Дивитися всі відгуки користувачів"
 msgstr[1] "Дивитися всі %(cnt)s відгуки користувачів"
-msgstr[2] "Дивитися всі %(cnt)s відгуків користувачів"
 
-#: src/olympia/addons/templates/addons/impala/review_list_box.html:47
-#: src/olympia/reviews/templates/reviews/review_list.html:84
+#: src/olympia/addons/templates/addons/impala/review_list_box.html:47 src/olympia/reviews/templates/reviews/review_list.html:84
 msgid "This add-on has not yet been reviewed."
 msgstr "Досі не було відгуків для цього додатку."
 
@@ -1586,24 +1172,23 @@ msgstr "Досі не було відгуків для цього додатку
 msgid "Be the first!"
 msgstr "Станьте першим!"
 
-#: src/olympia/addons/templates/addons/impala/listing/sorter.html:14
-#: src/olympia/devhub/templates/devhub/addons/listing/item_actions.html:49
+#: src/olympia/addons/templates/addons/impala/toplist.html:6
+msgid "{0} users"
+msgstr "{0} користувачів"
+
+#: src/olympia/addons/templates/addons/impala/listing/sorter.html:14 src/olympia/devhub/templates/devhub/addons/listing/item_actions.html:49
 msgid "More"
 msgstr "Більше"
 
-#: src/olympia/addons/templates/addons/includes/collection_add_widget.html:7
-#: src/olympia/addons/templates/addons/includes/collection_add_widget.html:10
+#: src/olympia/addons/templates/addons/includes/collection_add_widget.html:7 src/olympia/addons/templates/addons/includes/collection_add_widget.html:10
 msgid "Add to collection"
 msgstr "Додати в збірку"
 
-#: src/olympia/addons/templates/addons/includes/dashboard_tabs.html:4
-#: src/olympia/devhub/templates/devhub/index.html:73
-#: src/olympia/devhub/templates/devhub/nav.html:14
+#: src/olympia/addons/templates/addons/includes/dashboard_tabs.html:4 src/olympia/devhub/templates/devhub/index.html:73 src/olympia/devhub/templates/devhub/nav.html:14
 msgid "My Add-ons"
 msgstr "Мої додатки"
 
-#: src/olympia/addons/templates/addons/includes/dashboard_tabs.html:6
-#: src/olympia/amo/context_processors.py:51
+#: src/olympia/addons/templates/addons/includes/dashboard_tabs.html:6 src/olympia/amo/context_processors.py:52
 msgid "My Themes"
 msgstr "Мої теми"
 
@@ -1619,8 +1204,7 @@ msgstr "Редагувати тему"
 msgid "Approve / Reject"
 msgstr "Схвалити / Відхилити"
 
-#: src/olympia/addons/templates/addons/includes/persona.html:25
-#: src/olympia/editors/templates/editors/themes/single.html:43
+#: src/olympia/addons/templates/addons/includes/persona.html:25 src/olympia/editors/templates/editors/themes/single.html:43
 msgid "Review History"
 msgstr "Історія переглядів"
 
@@ -1641,14 +1225,11 @@ msgid "Not Yet Rated"
 msgstr "Ще не оцінено"
 
 #. {0} is the number of downloads.
-#: src/olympia/addons/templates/addons/listing/items_mobile.html:27
-#: src/olympia/addons/templates/addons/listing/macros.html:24
-#: src/olympia/devhub/templates/devhub/addons/listing/macros.html:15
+#: src/olympia/addons/templates/addons/listing/items_mobile.html:27 src/olympia/addons/templates/addons/listing/macros.html:24 src/olympia/devhub/templates/devhub/addons/listing/macros.html:15
 msgid "<strong>{0}</strong> weekly download"
 msgid_plural "<strong>{0}</strong> weekly downloads"
 msgstr[0] "<strong>{0}</strong> завантаження щотижня"
 msgstr[1] "<strong>{0}</strong> завантаження щотижня"
-msgstr[2] "<strong>{0}</strong> завантажень щотижня"
 
 #: src/olympia/addons/templates/addons/mobile/details.html:32
 msgid "Read More"
@@ -1658,15 +1239,11 @@ msgstr "Читати більше"
 msgid "Users"
 msgstr "Користувачі"
 
-#: src/olympia/addons/templates/addons/mobile/details.html:92
-#: src/olympia/browse/views.py:59 src/olympia/browse/views.py:70
-#: src/olympia/search/forms.py:90
+#: src/olympia/addons/templates/addons/mobile/details.html:92 src/olympia/browse/views.py:59 src/olympia/browse/views.py:70 src/olympia/search/forms.py:90
 msgid "Weekly Downloads"
 msgstr "Щотижневі завантаження"
 
-#: src/olympia/addons/templates/addons/mobile/details.html:99
-#: src/olympia/compat/templates/compat/reporter_detail.html:46
-#: src/olympia/devhub/forms.py:787
+#: src/olympia/addons/templates/addons/mobile/details.html:99 src/olympia/compat/templates/compat/reporter_detail.html:46 src/olympia/devhub/forms.py:788
 #: src/olympia/devhub/templates/devhub/versions/list.html:163
 msgid "Version"
 msgstr "Версія"
@@ -1702,49 +1279,28 @@ msgstr "Ліцензійна угода"
 
 #: src/olympia/addons/templates/addons/mobile/eula.html:5
 #, python-format
-msgid ""
-"%(name)s requires that you accept the following End-User License Agreement "
-"before installation can proceed:"
-msgstr ""
-"%(name)s потребує, щоб перед встановленням ви погодились із наступною "
-"ліцензійною угодою кінцевого користувача:"
+msgid "%(name)s requires that you accept the following End-User License Agreement before installation can proceed:"
+msgstr "%(name)s потребує, щоб перед встановленням ви погодились із наступною ліцензійною угодою кінцевого користувача:"
 
 #: src/olympia/addons/templates/addons/mobile/eula.html:15
 msgid "Accept"
 msgstr "Погодитись"
 
-#: src/olympia/addons/templates/addons/mobile/home.html:10
-#: src/olympia/templates/mobile/base_addons.html:53
+#: src/olympia/addons/templates/addons/mobile/home.html:10 src/olympia/templates/mobile/base_addons.html:53
 msgid "Add-ons are not currently available on Firefox for iOS."
 msgstr "В даний момент додатки недоступні на Firefox для iOS."
 
-#: src/olympia/addons/templates/addons/mobile/home.html:12
-#: src/olympia/templates/mobile/base_addons.html:55
-msgid ""
-"You need Firefox to install add-ons. <a "
-"href=\"http://mozilla.com/mobile\">Learn More&nbsp;&raquo;</a>"
-msgstr ""
-"Щоб встановлювати додатки, вам потрібен Firefox. <a "
-"href=\"http://mozilla.com/mobile\">Дізнатись більше&nbsp;&raquo;</a>"
+#: src/olympia/addons/templates/addons/mobile/home.html:12 src/olympia/templates/mobile/base_addons.html:55
+msgid "You need Firefox to install add-ons. <a href=\"http://mozilla.com/mobile\">Learn More&nbsp;&raquo;</a>"
+msgstr "Щоб встановлювати додатки, вам потрібен Firefox. <a href=\"http://mozilla.com/mobile\">Дізнатись більше&nbsp;&raquo;</a>"
 
-#: src/olympia/addons/templates/addons/mobile/home.html:19
-#: src/olympia/templates/header_title.html:4
-#: src/olympia/templates/impala/header_title.html:3
+#: src/olympia/addons/templates/addons/mobile/home.html:19 src/olympia/templates/header_title.html:4 src/olympia/templates/impala/header_title.html:3
 msgid "Return to the {0} Add-ons homepage"
 msgstr "Повернутись на домашню сторінку додатків {0}"
 
-#: src/olympia/addons/templates/addons/mobile/home.html:21
-#: src/olympia/amo/helpers.py:237
-#: src/olympia/bandwagon/templates/bandwagon/edit.html:34
-#: src/olympia/discovery/templates/discovery/pane.html:92
-#: src/olympia/editors/templates/editors/base.html:21
-#: src/olympia/editors/templates/editors/performance.html:72
-#: src/olympia/templates/menu_links.html:4
-#: src/olympia/templates/impala/header_title.html:13
-#: src/olympia/templates/impala/header_title.html:15
-#: src/olympia/templates/impala/header_title.html:19
-#: src/olympia/templates/impala/header_title.html:23
-#: src/olympia/templates/mobile/base_addons.html:47
+#: src/olympia/addons/templates/addons/mobile/home.html:21 src/olympia/amo/helpers.py:237 src/olympia/bandwagon/templates/bandwagon/edit.html:34 src/olympia/discovery/templates/discovery/pane.html:92
+#: src/olympia/editors/templates/editors/base.html:21 src/olympia/editors/templates/editors/performance.html:72 src/olympia/templates/menu_links.html:4 src/olympia/templates/impala/header_title.html:13
+#: src/olympia/templates/impala/header_title.html:15 src/olympia/templates/impala/header_title.html:19 src/olympia/templates/impala/header_title.html:23 src/olympia/templates/mobile/base_addons.html:47
 msgid "Add-ons"
 msgstr "Додатки"
 
@@ -1752,47 +1308,27 @@ msgstr "Додатки"
 msgid "Easy ways to personalize."
 msgstr "Легкі шляхи персоналізувати."
 
-#: src/olympia/addons/templates/addons/mobile/home.html:24
-#: src/olympia/devhub/templates/devhub/addons/submit/done.html:47
-#: src/olympia/discovery/templates/discovery/pane.html:34
-#: src/olympia/discovery/templates/discovery/addons/detail.html:16
-#: src/olympia/discovery/templates/discovery/modules/featured.html:21
-#: src/olympia/discovery/templates/discovery/modules/monthly.html:22
+#: src/olympia/addons/templates/addons/mobile/home.html:24 src/olympia/devhub/templates/devhub/addons/submit/done.html:47 src/olympia/discovery/templates/discovery/pane.html:34
+#: src/olympia/discovery/templates/discovery/addons/detail.html:16 src/olympia/discovery/templates/discovery/modules/featured.html:21 src/olympia/discovery/templates/discovery/modules/monthly.html:22
 msgid "Learn More"
 msgstr "Дізнатись більше"
 
 #: src/olympia/addons/templates/addons/mobile/home.html:26
 msgid ""
-"Add-ons are applications that let you personalize Firefox with extra "
-"functionality and style. Whether you mistype the name of a website or can't "
-"read a busy page, there's an add-on to improve your on-the-go browsing."
+"Add-ons are applications that let you personalize Firefox with extra functionality and style. Whether you mistype the name of a website or can't read a busy page, there's an add-on to improve your "
+"on-the-go browsing."
 msgstr ""
-"Додатки - це програми, які дозволяють розширити можливості та стиль Firefox."
-" Якщо ви помилились при введенні назви сайту, або не можете прочитати "
-"зайняту сторінку, існує додаток, який покращує ваш перегляд в дорозі."
+"Додатки - це програми, які дозволяють розширити можливості та стиль Firefox. Якщо ви помилились при введенні назви сайту, або не можете прочитати зайняту сторінку, існує додаток, який покращує ваш "
+"перегляд в дорозі."
 
 #. {0} is a category name. Ex: "Sports"
 #. {0} is a category name, such as Nature.
-#: src/olympia/addons/templates/addons/mobile/home.html:43
-#: src/olympia/amo/templates/amo/site_nav.html:32
-#: src/olympia/browse/feeds.py:107
-#: src/olympia/browse/templates/browse/impala/base_listing.html:38
-#: src/olympia/browse/templates/browse/personas/base.html:6
-#: src/olympia/browse/templates/browse/personas/base.html:42
-#: src/olympia/browse/templates/browse/personas/category_landing.html:21
-#: src/olympia/browse/templates/browse/personas/category_landing.html:23
-#: src/olympia/browse/templates/browse/personas/category_landing.html:38
-#: src/olympia/browse/templates/browse/personas/grid.html:7
-#: src/olympia/browse/templates/browse/personas/grid.html:11
-#: src/olympia/browse/templates/browse/personas/mobile/base.html:7
-#: src/olympia/browse/templates/browse/personas/mobile/category_landing.html:19
-#: src/olympia/constants/base.py:180
-#: src/olympia/devhub/templates/devhub/personas/submit.html:13
-#: src/olympia/editors/helpers.py:105
-#: src/olympia/editors/templates/editors/base.html:26
-#: src/olympia/editors/templates/editors/performance.html:73
-#: src/olympia/search/templates/search/personas.html:39
-#: src/olympia/templates/menu_links.html:9
+#: src/olympia/addons/templates/addons/mobile/home.html:43 src/olympia/amo/templates/amo/site_nav.html:32 src/olympia/browse/feeds.py:107 src/olympia/browse/templates/browse/impala/base_listing.html:38
+#: src/olympia/browse/templates/browse/personas/base.html:6 src/olympia/browse/templates/browse/personas/base.html:42 src/olympia/browse/templates/browse/personas/category_landing.html:21
+#: src/olympia/browse/templates/browse/personas/category_landing.html:23 src/olympia/browse/templates/browse/personas/category_landing.html:38 src/olympia/browse/templates/browse/personas/grid.html:7
+#: src/olympia/browse/templates/browse/personas/grid.html:11 src/olympia/browse/templates/browse/personas/mobile/base.html:7 src/olympia/browse/templates/browse/personas/mobile/category_landing.html:19
+#: src/olympia/constants/base.py:180 src/olympia/devhub/templates/devhub/personas/submit.html:13 src/olympia/editors/helpers.py:107 src/olympia/editors/templates/editors/base.html:26
+#: src/olympia/editors/templates/editors/performance.html:73 src/olympia/search/templates/search/personas.html:39 src/olympia/templates/menu_links.html:9
 msgid "Themes"
 msgstr "Теми"
 
@@ -1808,19 +1344,12 @@ msgstr "Переглянути всі популярні додатки"
 msgid "More Add-ons"
 msgstr "Більше додатків"
 
-#: src/olympia/addons/templates/addons/mobile/home.html:72
-#: src/olympia/browse/templates/browse/personas/mobile/category_landing.html:64
-#: src/olympia/search/forms.py:14
+#: src/olympia/addons/templates/addons/mobile/home.html:72 src/olympia/browse/templates/browse/personas/mobile/category_landing.html:64 src/olympia/search/forms.py:14
 msgid "Highest Rated"
 msgstr "Найвище оцінені"
 
-#: src/olympia/addons/templates/addons/mobile/home.html:74
-#: src/olympia/amo/templates/amo/side_nav.html:5
-#: src/olympia/amo/templates/amo/site_nav.html:27
-#: src/olympia/amo/templates/amo/site_nav.html:57
-#: src/olympia/bandwagon/views.py:97 src/olympia/browse/views.py:57
-#: src/olympia/browse/views.py:67
-#: src/olympia/browse/templates/browse/personas/mobile/category_landing.html:65
+#: src/olympia/addons/templates/addons/mobile/home.html:74 src/olympia/amo/templates/amo/side_nav.html:5 src/olympia/amo/templates/amo/site_nav.html:27 src/olympia/amo/templates/amo/site_nav.html:55
+#: src/olympia/bandwagon/views.py:97 src/olympia/browse/views.py:57 src/olympia/browse/views.py:67 src/olympia/browse/templates/browse/personas/mobile/category_landing.html:65
 #: src/olympia/search/forms.py:15 src/olympia/search/forms.py:87
 msgid "Newest"
 msgstr "Найновіші"
@@ -1833,122 +1362,88 @@ msgstr "Спробуйте їх!"
 msgid "Theme Info &raquo;"
 msgstr "Інформація про тему &raquo;"
 
-#: src/olympia/amo/context_processors.py:39
-#: src/olympia/devhub/templates/devhub/nav.html:43
+#: src/olympia/amo/context_processors.py:39 src/olympia/devhub/templates/devhub/nav.html:43
 msgid "Tools"
 msgstr "Інструменти"
 
-#: src/olympia/amo/context_processors.py:48
-#: src/olympia/discovery/templates/discovery/pane_account.html:8
-#: src/olympia/users/templates/users/includes/navigation.html:2
+#: src/olympia/amo/context_processors.py:49 src/olympia/discovery/templates/discovery/pane_account.html:8 src/olympia/users/templates/users/includes/navigation.html:2
 msgid "My Profile"
 msgstr "Мій профіль"
 
-#: src/olympia/amo/context_processors.py:54
-#: src/olympia/users/templates/users/edit.html:5
-#: src/olympia/users/templates/users/includes/navigation.html:3
+#: src/olympia/amo/context_processors.py:55 src/olympia/users/templates/users/edit.html:5 src/olympia/users/templates/users/includes/navigation.html:3
 msgid "Account Settings"
 msgstr "Налаштування облікового запису"
 
-#: src/olympia/amo/context_processors.py:57
-#: src/olympia/discovery/templates/discovery/pane_account.html:11
-#: src/olympia/users/templates/users/profile.html:83
+#: src/olympia/amo/context_processors.py:58 src/olympia/discovery/templates/discovery/pane_account.html:11 src/olympia/users/templates/users/profile.html:83
 #: src/olympia/users/templates/users/includes/navigation.html:4
 msgid "My Collections"
 msgstr "Мої збірки"
 
-#: src/olympia/amo/context_processors.py:62
-#: src/olympia/discovery/templates/discovery/pane_account.html:10
-#: src/olympia/users/templates/users/includes/navigation.html:7
+#: src/olympia/amo/context_processors.py:63 src/olympia/discovery/templates/discovery/pane_account.html:10 src/olympia/users/templates/users/includes/navigation.html:7
 msgid "My Favorites"
 msgstr "Мої Вподобання"
 
-#: src/olympia/amo/context_processors.py:67
-#: src/olympia/discovery/templates/discovery/pane_account.html:13
-#: src/olympia/templates/impala/user_login.html:14
-#: src/olympia/templates/mobile/header_auth.html:5
+#: src/olympia/amo/context_processors.py:68 src/olympia/discovery/templates/discovery/pane_account.html:13 src/olympia/templates/impala/user_login.html:14 src/olympia/templates/mobile/header_auth.html:5
 msgid "Log out"
 msgstr "Вийти"
 
-#: src/olympia/amo/context_processors.py:72
-#: src/olympia/devhub/templates/devhub/addons/dashboard.html:4
+#: src/olympia/amo/context_processors.py:73 src/olympia/devhub/templates/devhub/addons/dashboard.html:4
 msgid "Manage My Submissions"
 msgstr "Керувати моїми представленнями"
 
-#: src/olympia/amo/context_processors.py:75
-#: src/olympia/devhub/templates/devhub/nav.html:27
-#: src/olympia/devhub/templates/devhub/addons/dashboard.html:25
+#: src/olympia/amo/context_processors.py:76 src/olympia/devhub/templates/devhub/nav.html:27 src/olympia/devhub/templates/devhub/addons/dashboard.html:25
 #: src/olympia/devhub/templates/devhub/addons/submit/base.html:4
 msgid "Submit a New Add-on"
 msgstr "Відправити новий додаток"
 
-#: src/olympia/amo/context_processors.py:77
-#: src/olympia/browse/templates/browse/personas/base.html:50
-#: src/olympia/devhub/templates/devhub/index.html:24
+#: src/olympia/amo/context_processors.py:78 src/olympia/browse/templates/browse/personas/base.html:50 src/olympia/devhub/templates/devhub/index.html:24
 #: src/olympia/devhub/templates/devhub/addons/dashboard.html:29
 msgid "Submit a New Theme"
 msgstr "Відправити нову тему"
 
-#: src/olympia/amo/context_processors.py:79
-#: src/olympia/amo/templates/amo/site_nav.html:87
-#: src/olympia/devhub/helpers.py:36 src/olympia/devhub/helpers.py:68
-#: src/olympia/devhub/helpers.py:102 src/olympia/templates/footer.html:6
-#: src/olympia/templates/menu_links.html:14
+#: src/olympia/amo/context_processors.py:80 src/olympia/amo/templates/amo/site_nav.html:85 src/olympia/devhub/helpers.py:36 src/olympia/devhub/helpers.py:68 src/olympia/devhub/helpers.py:102
+#: src/olympia/templates/footer.html:6 src/olympia/templates/menu_links.html:14
 msgid "Developer Hub"
 msgstr "Центр розробника"
 
-#: src/olympia/amo/context_processors.py:83 src/olympia/devhub/views.py:1792
+#: src/olympia/amo/context_processors.py:84 src/olympia/devhub/views.py:1799
 msgid "Manage API Keys"
 msgstr "Керувати API Ключами"
 
-#: src/olympia/amo/context_processors.py:88 src/olympia/editors/helpers.py:82
-#: src/olympia/editors/helpers.py:102
-#: src/olympia/editors/templates/editors/base.html:10
+#: src/olympia/amo/context_processors.py:89 src/olympia/editors/helpers.py:84 src/olympia/editors/helpers.py:104 src/olympia/editors/templates/editors/base.html:10
 msgid "Editor Tools"
 msgstr "Інструменти редактора"
 
-#: src/olympia/amo/context_processors.py:92
+#: src/olympia/amo/context_processors.py:93
 msgid "Admin Tools"
 msgstr "Адміністративні інструменти"
 
-#: src/olympia/amo/fields.py:15
+#: src/olympia/amo/fields.py:20
 msgid "Incorrect, please try again."
 msgstr "Неправильно, спробуйте знову."
 
-#: src/olympia/amo/fields.py:16
+#: src/olympia/amo/fields.py:21
 msgid "Error verifying input, please try again."
 msgstr "Помилка перевірки введення, спробуйте знову."
 
-#: src/olympia/amo/fields.py:32
+#: src/olympia/amo/fields.py:37
 msgid "This must be a valid hex color code, such as #000000."
 msgstr "Це повинен бути дійсний hex-код кольору, наприклад #000000."
 
-#: src/olympia/amo/fields.py:58
+#: src/olympia/amo/fields.py:63
 msgid "Enter at least one value."
 msgstr "Введіть хоча б одне значення."
 
-#: src/olympia/amo/helpers.py:162
-#: src/olympia/amo/templates/amo/site_nav.html:61
-#: src/olympia/bandwagon/templates/bandwagon/add.html:9
-#: src/olympia/bandwagon/templates/bandwagon/collection_detail.html:15
-#: src/olympia/bandwagon/templates/bandwagon/delete.html:9
-#: src/olympia/bandwagon/templates/bandwagon/edit.html:15
-#: src/olympia/bandwagon/templates/bandwagon/user_listing.html:18
-#: src/olympia/bandwagon/templates/bandwagon/user_listing.html:21
-#: src/olympia/bandwagon/templates/bandwagon/impala/collection_listing.html:12
-#: src/olympia/bandwagon/templates/bandwagon/impala/collection_listing.html:20
-#: src/olympia/bandwagon/templates/bandwagon/impala/collection_listing.html:24
-#: src/olympia/bandwagon/templates/bandwagon/impala/collection_sidebar.html:3
-#: src/olympia/bandwagon/templates/bandwagon/includes/collection_sidebar.html:2
-#: src/olympia/bandwagon/templates/bandwagon/mobile/collection_listing.html:3
-#: src/olympia/stats/templates/stats/stats.html:77
-#: src/olympia/templates/menu_links.html:12
+#: src/olympia/amo/helpers.py:162 src/olympia/amo/templates/amo/site_nav.html:59 src/olympia/bandwagon/templates/bandwagon/add.html:9 src/olympia/bandwagon/templates/bandwagon/collection_detail.html:15
+#: src/olympia/bandwagon/templates/bandwagon/delete.html:9 src/olympia/bandwagon/templates/bandwagon/edit.html:15 src/olympia/bandwagon/templates/bandwagon/user_listing.html:18
+#: src/olympia/bandwagon/templates/bandwagon/user_listing.html:21 src/olympia/bandwagon/templates/bandwagon/impala/collection_listing.html:12
+#: src/olympia/bandwagon/templates/bandwagon/impala/collection_listing.html:20 src/olympia/bandwagon/templates/bandwagon/impala/collection_listing.html:24
+#: src/olympia/bandwagon/templates/bandwagon/impala/collection_sidebar.html:3 src/olympia/bandwagon/templates/bandwagon/includes/collection_sidebar.html:2
+#: src/olympia/bandwagon/templates/bandwagon/mobile/collection_listing.html:3 src/olympia/stats/templates/stats/stats.html:33 src/olympia/templates/menu_links.html:12
 msgid "Collections"
 msgstr "Збірки"
 
-#: src/olympia/amo/helpers.py:171
-#: src/olympia/amo/templates/amo/site_nav.html:85
-#: src/olympia/browse/templates/browse/language_tools.html:3
+#: src/olympia/amo/helpers.py:171 src/olympia/amo/templates/amo/site_nav.html:83 src/olympia/browse/templates/browse/language_tools.html:3
 msgid "Dictionaries & Language Packs"
 msgstr "Словники та мовні пакети"
 
@@ -2100,11 +1595,8 @@ msgstr "Запитано спеціальний огляд"
 msgid "Comment on {addon} {version}."
 msgstr "Коментар про {addon} {version}."
 
-#: src/olympia/amo/log.py:236
-#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:19
-#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:47
-#: src/olympia/editors/helpers.py:511
-#: src/olympia/editors/templates/editors/themes/history_table.html:11
+#: src/olympia/amo/log.py:236 src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:17 src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:45
+#: src/olympia/editors/helpers.py:584 src/olympia/editors/templates/editors/themes/history_table.html:11
 msgid "Comment"
 msgstr "Коментар"
 
@@ -2242,8 +1734,7 @@ msgstr "Застосунок вимкнено"
 
 #: src/olympia/amo/log.py:425
 msgid "{addon} escalated because of high number of abuse reports."
-msgstr ""
-"{addon} передано вище через велику кількість повідомлень про зловживання."
+msgstr "{addon} передано вище через велику кількість повідомлень про зловживання."
 
 #: src/olympia/amo/log.py:426
 msgid "High Abuse Reports"
@@ -2258,8 +1749,8 @@ msgid "Reviewer escalation"
 msgstr "Ескалація перевірки"
 
 #: src/olympia/amo/log.py:442
-msgid "Video removed from {addon} because of a problem with the video. "
-msgstr "Відео видалене з {addon} через проблеми з відео. "
+msgid "Video removed from {addon} because of a problem with the video."
+msgstr "Відео вилучено з {addon} через проблеми з відтворенням."
 
 #: src/olympia/amo/log.py:444
 msgid "Video removed"
@@ -2363,10 +1854,7 @@ msgstr "Рейтинг вмісту {addon} змінено."
 msgid "{addon} unlisted."
 msgstr "{addon} прибрано зі списку."
 
-#: src/olympia/amo/log.py:592 src/olympia/amo/log.py:598
-#: src/olympia/amo/log.py:612 src/olympia/amo/log.py:618
-#: src/olympia/amo/log.py:624 src/olympia/amo/log.py:630
-#: src/olympia/amo/log.py:636
+#: src/olympia/amo/log.py:592 src/olympia/amo/log.py:598 src/olympia/amo/log.py:612 src/olympia/amo/log.py:618 src/olympia/amo/log.py:624 src/olympia/amo/log.py:630 src/olympia/amo/log.py:636
 msgid "{file} was signed."
 msgstr "{file} був підписаний."
 
@@ -2380,20 +1868,12 @@ msgid "Not allowed"
 msgstr "Не дозволено"
 
 #: src/olympia/amo/templates/amo/403.html:7
-msgid ""
-"<h1>Oops! Not allowed.</h1> <p>You tried to do something that you weren't "
-"allowed to.</p>"
-msgstr ""
-"<h1>Ой! Не дозволено.</h1> <p>Ви намагаєтесь зробити щось, на що не маєте "
-"дозволу.</p>"
+msgid "<h1>Oops! Not allowed.</h1> <p>You tried to do something that you weren't allowed to.</p>"
+msgstr "<h1>Ой! Не дозволено.</h1> <p>Ви намагаєтесь зробити щось, на що не маєте дозволу.</p>"
 
 #: src/olympia/amo/templates/amo/403.html:12
-msgid ""
-"<p>Try going back to the previous page, refreshing and then trying "
-"again.</p>"
-msgstr ""
-"<p>Спробуйте повернутись на попередню сторінку, перезавантажити, а потім "
-"спробуйте ще раз.</p>"
+msgid "<p>Try going back to the previous page, refreshing and then trying again.</p>"
+msgstr "<p>Спробуйте повернутись на попередню сторінку, перезавантажити, а потім спробуйте ще раз.</p>"
 
 #: src/olympia/amo/templates/amo/404.html:3
 msgid "Not Found"
@@ -2402,36 +1882,19 @@ msgstr "Не знайдено"
 #: src/olympia/amo/templates/amo/404.html:6
 #, python-format
 msgid ""
-"<h1>We're sorry, but we can't find what you're looking for.</h1> <p> The "
-"page or file you requested wasn't found on our site. It's possible that you "
-"clicked a link that's out of date, or typed in the address incorrectly. </p>"
-" <ul> <li>If you typed in the address, please double check the "
-"spelling.</li> <li> If you followed a link from somewhere, please let us "
-"know at <a href=\"mailto:webmaster@mozilla.com\">webmaster@mozilla.com</a>. "
-"Tell us where you came from and what you were looking for, and we'll do our "
-"best to fix it. </li> </ul> <p>Or you can just jump over to some of the "
-"popular pages on our website.</p> <ul> <li>Are you interested in a <a "
-"href=\"%(rec)s\">list of featured add-ons</a>?</li> <li> Do you want to <a "
-"href=\"%(search)s\">search for add-ons</a>? You may go to the <a "
-"href=\"%(search)s\">search page</a> or just use the search field above. "
-"</li> <li> If you prefer to start over, just go to the <a href=\"%(home)s"
-"\">add-ons front page</a>. </li> </ul>"
+"<h1>We're sorry, but we can't find what you're looking for.</h1> <p> The page or file you requested wasn't found on our site. It's possible that you clicked a link that's out of date, or typed in "
+"the address incorrectly. </p> <ul> <li>If you typed in the address, please double check the spelling.</li> <li> If you followed a link from somewhere, please let us know at <a "
+"href=\"mailto:webmaster@mozilla.com\">webmaster@mozilla.com</a>. Tell us where you came from and what you were looking for, and we'll do our best to fix it. </li> </ul> <p>Or you can just jump over"
+" to some of the popular pages on our website.</p> <ul> <li>Are you interested in a <a href=\"%(rec)s\">list of featured add-ons</a>?</li> <li> Do you want to <a href=\"%(search)s\">search for add-"
+"ons</a>? You may go to the <a href=\"%(search)s\">search page</a> or just use the search field above. </li> <li> If you prefer to start over, just go to the <a href=\"%(home)s\">add-ons front "
+"page</a>. </li> </ul>"
 msgstr ""
-"<h1>Вибачте, проте ми не можемо знайти те, що ви шукали.</h1> <p>Запитану "
-"сторінка або файл не знайдено на нашому сайті. Можливо, ви натиснули "
-"застаріле посилання або зробили помилку в адресі.</p> <ul> <li>Якщо ви "
-"вводили адресу, будь ласка, переконайтесь у вірності її написання.</li> "
-"<li>Якщо ви звідкілясь перейшли за посиланням, будь ласка, повідомте нам про"
-" це за адресою<a "
-"href=\"mailto:webmaster@mozilla.com\">webmaster@mozilla.com</a>. Повідомте "
-"нам, звідкіля ви прийшли та що ви шукаєте, і ми зробимо все можливе, щоб "
-"виправити це.</li> </ul> <p>Або ви можете перейти до деяких популярних "
-"сторінок на нашому сайті.</p> <ul> <li>Можливо вас зацікавить <a "
-"href=\"%(rec)s\">список обраних додатків</a>?</li> <li> Чи ви хочете <a "
-"href=\"%(search)s\">знайти додаток</a>? Ви можете перейти до <a "
-"href=\"%(search)s\">сторінки пошуку</a> або просто використати поле пошуку, "
-"розташоване вище.</li> <li>Якщо ви хочете розпочати з початку, просто "
-"перейдіть до <a href=\"%(home)s\">головної сторінки додатків</a>.</li> </ul>"
+"<h1>Вибачте, проте ми не можемо знайти те, що ви шукали.</h1> <p>Запитану сторінка або файл не знайдено на нашому сайті. Можливо, ви натиснули застаріле посилання або зробили помилку в адресі.</p> "
+"<ul> <li>Якщо ви вводили адресу, будь ласка, переконайтесь у вірності її написання.</li> <li>Якщо ви звідкілясь перейшли за посиланням, будь ласка, повідомте нам про це за адресою<a "
+"href=\"mailto:webmaster@mozilla.com\">webmaster@mozilla.com</a>. Повідомте нам, звідкіля ви прийшли та що ви шукаєте, і ми зробимо все можливе, щоб виправити це.</li> </ul> <p>Або ви можете перейти"
+" до деяких популярних сторінок на нашому сайті.</p> <ul> <li>Можливо вас зацікавить <a href=\"%(rec)s\">список обраних додатків</a>?</li> <li> Чи ви хочете <a href=\"%(search)s\">знайти "
+"додаток</a>? Ви можете перейти до <a href=\"%(search)s\">сторінки пошуку</a> або просто використати поле пошуку, розташоване вище.</li> <li>Якщо ви хочете розпочати з початку, просто перейдіть до "
+"<a href=\"%(home)s\">головної сторінки додатків</a>.</li> </ul>"
 
 #: src/olympia/amo/templates/amo/500.html:3
 msgid "Oops"
@@ -2439,83 +1902,49 @@ msgstr "Ой"
 
 #: src/olympia/amo/templates/amo/500.html:6
 #, python-format
-msgid ""
-"<h1>Oops!  We had an error.</h1> <p>We'll get to fixing that soon.</p> <p> "
-"You can try refreshing the page, or head back to the <a href=\"%(home)s"
-"\">Add-ons homepage</a>. </p>"
-msgstr ""
-"<h1>Отакої!  У нас виникла помилка.</h1> <p> Ми виправимо її найближчим "
-"часом.</p> <p> Ви можете спробувати оновити сторінку або повернутись на <a "
-"href=\"%(home)s\"> домашню сторінку додатків</a>. </p>"
+msgid "<h1>Oops! We had an error.</h1> <p>We'll get to fixing that soon.</p> <p> You can try refreshing the page, or head back to the <a href=\"%(home)s\">Add-ons homepage</a>. </p>"
+msgstr "<h1>Ой! Сталася помилка.</h1> <p>Невдовзі ми її виправимо.</p> <p> Ви можете спробувати оновити сторінку, або повернутися назад на <a href=\"%(home)s\">Домашню сторінку</a>. </p>"
 
 #: src/olympia/amo/templates/amo/license_link.html:10
 msgid "Some rights reserved"
 msgstr "Деякі права захищено"
 
-#: src/olympia/amo/templates/amo/no_results.html:1
-#: src/olympia/editors/templates/editors/includes/search_results_themes.html:26
+#: src/olympia/amo/templates/amo/no_results.html:1 src/olympia/editors/templates/editors/includes/search_results_themes.html:26
 msgid "No results found"
 msgstr "Результатів не знайдено"
 
 #. abbreviation of 'previous'
-#: src/olympia/amo/templates/amo/paginator.html:6
-#: src/olympia/amo/templates/amo/mobile/paginator.html:4
-#: src/olympia/amo/templates/amo/mobile/paginator.html:6
-#: src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:49
-#: src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:63
-#: src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:76
-#: src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:89
+#: src/olympia/amo/templates/amo/paginator.html:6 src/olympia/amo/templates/amo/mobile/paginator.html:4 src/olympia/amo/templates/amo/mobile/paginator.html:6
+#: src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:49 src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:63
+#: src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:76 src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:89
 #: src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:102
 msgid "Prev"
 msgstr "Попередня"
 
-#: src/olympia/amo/templates/amo/paginator.html:26
-#: src/olympia/amo/templates/amo/impala/paginator.html:26
-#: src/olympia/amo/templates/amo/mobile/impala_paginator.html:16
-#: src/olympia/amo/templates/amo/mobile/paginator.html:14
-#: src/olympia/amo/templates/amo/mobile/paginator.html:16
-#: src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:51
-#: src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:65
-#: src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:78
-#: src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:91
-#: src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:104
-#: src/olympia/discovery/templates/discovery/pane.html:45
-#: src/olympia/discovery/templates/discovery/addons/detail.html:39
-#: src/olympia/stats/templates/stats/stats.html:167
+#: src/olympia/amo/templates/amo/paginator.html:26 src/olympia/amo/templates/amo/impala/paginator.html:26 src/olympia/amo/templates/amo/mobile/impala_paginator.html:16
+#: src/olympia/amo/templates/amo/mobile/paginator.html:14 src/olympia/amo/templates/amo/mobile/paginator.html:16 src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:51
+#: src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:65 src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:78
+#: src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:91 src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:104
+#: src/olympia/discovery/templates/discovery/pane.html:45 src/olympia/discovery/templates/discovery/addons/detail.html:39 src/olympia/stats/templates/stats/stats.html:169
 msgid "Next"
 msgstr "Наступна"
 
-#: src/olympia/amo/templates/amo/paginator.html:32
-#: src/olympia/editors/templates/editors/includes/paginator_history.html:11
+#: src/olympia/amo/templates/amo/paginator.html:32 src/olympia/editors/templates/editors/includes/paginator_history.html:11
 #, python-format
-msgid ""
-"Results <strong>%(begin)s</strong>&ndash;<strong>%(end)s</strong> of "
-"<strong>%(count)s</strong>"
-msgstr ""
-"Результати <strong>%(begin)s</strong>&ndash;<strong>%(end)s</strong> з "
-"<strong>%(count)s</strong>"
+msgid "Results <strong>%(begin)s</strong>&ndash;<strong>%(end)s</strong> of <strong>%(count)s</strong>"
+msgstr "Результати <strong>%(begin)s</strong>&ndash;<strong>%(end)s</strong> з <strong>%(count)s</strong>"
 
-#: src/olympia/amo/templates/amo/read-only.html:3
-#: src/olympia/amo/templates/amo/read-only.html:7
+#: src/olympia/amo/templates/amo/read-only.html:3 src/olympia/amo/templates/amo/read-only.html:7
 msgid "Maintenance in progress"
 msgstr "Триває технічне обслуговування"
 
 #: src/olympia/amo/templates/amo/read-only.html:9
-msgid ""
-"This feature is temporarily disabled while we perform website maintenance. "
-"Please use your browser's Back button and try again a little later."
-msgstr ""
-"Ця функція тимчасово відключена, поки ми проводимо технічне обслуговування "
-"сайту. Будь ласка, скористайтесь кнопкою \"Назад\" свого браузера і "
-"спробуйте знову трохи пізніше."
+msgid "This feature is temporarily disabled while we perform website maintenance. Please use your browser's Back button and try again a little later."
+msgstr "Ця функція тимчасово відключена, поки ми проводимо технічне обслуговування сайту. Будь ласка, скористайтесь кнопкою \"Назад\" свого браузера і спробуйте знову трохи пізніше."
 
 #: src/olympia/amo/templates/amo/read-only.html:14
-msgid ""
-"Some features on this page are temporarily disabled while we perform website"
-" maintenance. Please try again a little later."
-msgstr ""
-"Деякі функції на цій сторінці тимчасово відключені, поки ми проводимо "
-"технічне обслуговування сайту. Будь ласка спробуйте знову трохи пізніше."
+msgid "Some features on this page are temporarily disabled while we perform website maintenance. Please try again a little later."
+msgstr "Деякі функції на цій сторінці тимчасово відключені, поки ми проводимо технічне обслуговування сайту. Будь ласка спробуйте знову трохи пізніше."
 
 #: src/olympia/amo/templates/amo/recaptcha.html:4
 msgid "Are you human?"
@@ -2523,24 +1952,14 @@ msgstr "Ви людина?"
 
 #: src/olympia/amo/templates/amo/recaptcha.html:8
 msgid ""
-"<p> Please enter <strong>all the words</strong> below, <strong>separated by "
-"a space if necessary</strong>. </p> <p> If this is hard to read, you can <a "
-"href=\"#\" id=\"recaptcha_different\">try different words</a> or <a "
-"href=\"#\" id=\"recaptcha_audio\">try a different type of challenge</a> "
-"instead. </p>"
+"<p> Please enter <strong>all the words</strong> below, <strong>separated by a space if necessary</strong>. </p> <p> If this is hard to read, you can <a href=\"#\" id=\"recaptcha_different\">try "
+"different words</a> or <a href=\"#\" id=\"recaptcha_audio\">try a different type of challenge</a> instead. </p>"
 msgstr ""
-"<p> Введіть будь ласка <strong>всі слова</strong> внизу, <strong>разом з "
-"пробілами</strong>. </p> <p> Якщо важко прочитати, ви можете <a href=\"#\" "
-"id=\"recaptcha_different\">спробувати інші слова</a> або <a href=\"#\" "
-"id=\"recaptcha_audio\">спробувати інший тип відображення</a> натомість. </p>"
+"<p> Введіть будь ласка <strong>всі слова</strong> внизу, <strong>разом з пробілами</strong>. </p> <p> Якщо важко прочитати, ви можете <a href=\"#\" id=\"recaptcha_different\">спробувати інші "
+"слова</a> або <a href=\"#\" id=\"recaptcha_audio\">спробувати інший тип відображення</a> натомість. </p>"
 
-#: src/olympia/amo/templates/amo/side_nav.html:4
-#: src/olympia/amo/templates/amo/side_nav.html:12
-#: src/olympia/amo/templates/amo/site_nav.html:4
-#: src/olympia/amo/templates/amo/site_nav.html:26
-#: src/olympia/browse/views.py:56 src/olympia/browse/views.py:66
-#: src/olympia/browse/views.py:237 src/olympia/browse/views.py:282
-#: src/olympia/search/forms.py:86
+#: src/olympia/amo/templates/amo/side_nav.html:4 src/olympia/amo/templates/amo/side_nav.html:12 src/olympia/amo/templates/amo/site_nav.html:4 src/olympia/amo/templates/amo/site_nav.html:26
+#: src/olympia/browse/views.py:56 src/olympia/browse/views.py:66 src/olympia/browse/views.py:204 src/olympia/browse/views.py:249 src/olympia/search/forms.py:86
 msgid "Top Rated"
 msgstr "Найвище оцінені"
 
@@ -2548,81 +1967,59 @@ msgstr "Найвище оцінені"
 msgid "Explore"
 msgstr "Переглянути"
 
-#: src/olympia/amo/templates/amo/site_nav.html:23
-#: src/olympia/browse/feeds.py:65 src/olympia/browse/feeds.py:78
-#: src/olympia/browse/feeds.py:92 src/olympia/browse/feeds.py:100
-#: src/olympia/browse/templates/browse/base_listing.html:7
-#: src/olympia/browse/templates/browse/creatured.html:10
-#: src/olympia/browse/templates/browse/impala/base_listing.html:37
+#: src/olympia/amo/templates/amo/site_nav.html:23 src/olympia/browse/feeds.py:65 src/olympia/browse/feeds.py:78 src/olympia/browse/feeds.py:92 src/olympia/browse/feeds.py:100
+#: src/olympia/browse/templates/browse/base_listing.html:7 src/olympia/browse/templates/browse/creatured.html:10 src/olympia/browse/templates/browse/impala/base_listing.html:37
 #: src/olympia/constants/base.py:173 src/olympia/templates/menu_links.html:8
 msgid "Extensions"
 msgstr "Розширення"
 
-#: src/olympia/amo/templates/amo/site_nav.html:45
+#: src/olympia/amo/templates/amo/site_nav.html:44
 msgid "Want more customization? Try <b>Complete Themes</b>"
 msgstr "Хочете більше налаштувань? Спробуйте <b>Повні теми</b>"
 
-#: src/olympia/amo/templates/amo/site_nav.html:56
-#: src/olympia/bandwagon/views.py:96
+#: src/olympia/amo/templates/amo/site_nav.html:54 src/olympia/bandwagon/views.py:96
 msgid "Most Followers"
 msgstr "Найбільше прихильників"
 
-#: src/olympia/amo/templates/amo/site_nav.html:68
-#: src/olympia/bandwagon/templates/bandwagon/impala/collection_sidebar.html:16
-#: src/olympia/bandwagon/templates/bandwagon/includes/collection_sidebar.html:18
+#: src/olympia/amo/templates/amo/site_nav.html:66 src/olympia/bandwagon/templates/bandwagon/impala/collection_sidebar.html:16 src/olympia/bandwagon/templates/bandwagon/includes/collection_sidebar.html:18
 msgid "Collections I've Made"
 msgstr "Створені мною збірки"
 
-#: src/olympia/amo/templates/amo/site_nav.html:70
-#: src/olympia/bandwagon/templates/bandwagon/user_listing.html:4
-#: src/olympia/bandwagon/templates/bandwagon/impala/collection_sidebar.html:13
+#: src/olympia/amo/templates/amo/site_nav.html:68 src/olympia/bandwagon/templates/bandwagon/user_listing.html:4 src/olympia/bandwagon/templates/bandwagon/impala/collection_sidebar.html:13
 #: src/olympia/bandwagon/templates/bandwagon/includes/collection_sidebar.html:15
 msgid "Collections I'm Following"
 msgstr "Збірки, за якими я слідкую"
 
-#: src/olympia/amo/templates/amo/site_nav.html:73
-#: src/olympia/bandwagon/templates/bandwagon/impala/collection_sidebar.html:18
-#: src/olympia/bandwagon/templates/bandwagon/includes/collection_sidebar.html:20
-#: src/olympia/users/models.py:512
+#: src/olympia/amo/templates/amo/site_nav.html:71 src/olympia/bandwagon/templates/bandwagon/impala/collection_sidebar.html:18 src/olympia/bandwagon/templates/bandwagon/includes/collection_sidebar.html:20
+#: src/olympia/users/models.py:521
 msgid "My Favorite Add-ons"
 msgstr "Мої улюблені додатки"
 
-#: src/olympia/amo/templates/amo/site_nav.html:78
+#: src/olympia/amo/templates/amo/site_nav.html:76
 msgid "More&hellip;"
 msgstr "Більше&hellip;"
 
-#: src/olympia/amo/templates/amo/site_nav.html:82
+#: src/olympia/amo/templates/amo/site_nav.html:80
 msgid "Add-ons for Mobile"
 msgstr "Мобільні додатки"
 
-#: src/olympia/amo/templates/amo/site_nav.html:86
-#: src/olympia/browse/feeds.py:207
-#: src/olympia/browse/templates/browse/search_tools.html:3
-#: src/olympia/constants/base.py:176 src/olympia/templates/menu_links.html:10
+#: src/olympia/amo/templates/amo/site_nav.html:84 src/olympia/browse/feeds.py:207 src/olympia/browse/templates/browse/search_tools.html:3 src/olympia/constants/base.py:176
+#: src/olympia/templates/menu_links.html:10
 msgid "Search Tools"
 msgstr "Пошукові інструменти"
 
 #. This is a page range (e.g., Page 1 of 50).
-#: src/olympia/amo/templates/amo/impala/paginator.html:5
-#: src/olympia/amo/templates/amo/mobile/impala_paginator.html:26
+#: src/olympia/amo/templates/amo/impala/paginator.html:5 src/olympia/amo/templates/amo/mobile/impala_paginator.html:26
 #, python-format
-msgid ""
-"Page <a href=\"%(current_pg_url)s\">%(current_pg)s</a> of <a "
-"href=\"%(last_pg_url)s\">%(last_pg)s</a>"
-msgstr ""
-"Сторінка <a href=\"%(current_pg_url)s\">%(current_pg)s</a> із <a "
-"href=\"%(last_pg_url)s\">%(last_pg)s</a>"
+msgid "Page <a href=\"%(current_pg_url)s\">%(current_pg)s</a> of <a href=\"%(last_pg_url)s\">%(last_pg)s</a>"
+msgstr "Сторінка <a href=\"%(current_pg_url)s\">%(current_pg)s</a> із <a href=\"%(last_pg_url)s\">%(last_pg)s</a>"
 
-#: src/olympia/amo/templates/amo/impala/paginator.html:16
-#: src/olympia/amo/templates/amo/mobile/impala_paginator.html:6
+#: src/olympia/amo/templates/amo/impala/paginator.html:16 src/olympia/amo/templates/amo/mobile/impala_paginator.html:6
 msgid "Jump to first page"
 msgstr "Перейти на першу сторінку"
 
-#: src/olympia/amo/templates/amo/impala/paginator.html:22
-#: src/olympia/amo/templates/amo/mobile/impala_paginator.html:12
-#: src/olympia/discovery/templates/discovery/pane.html:44
-#: src/olympia/discovery/templates/discovery/addons/detail.html:38
-#: src/olympia/stats/templates/stats/stats.html:164
+#: src/olympia/amo/templates/amo/impala/paginator.html:22 src/olympia/amo/templates/amo/mobile/impala_paginator.html:12 src/olympia/discovery/templates/discovery/pane.html:44
+#: src/olympia/discovery/templates/discovery/addons/detail.html:38 src/olympia/stats/templates/stats/stats.html:166
 msgid "Previous"
 msgstr "Попередня"
 
@@ -2632,10 +2029,9 @@ msgstr "До останньої сторінки"
 
 #. First and second arguments are the result range (e.g., 1-20);
 #. third argument is the number of total results (e.g., 1,000).
-#. third
+#. First and second arguments are the result range (e.g., 1-20);              third
 #. argument is the number of total results (e.g., 1,000).
-#: src/olympia/amo/templates/amo/impala/paginator.html:36
-#: src/olympia/amo/templates/amo/mobile/impala_paginator.html:38
+#: src/olympia/amo/templates/amo/impala/paginator.html:36 src/olympia/amo/templates/amo/mobile/impala_paginator.html:38
 #, python-format
 msgid "Showing <b>%(begin)s</b>&ndash;<b>%(end)s</b> of <b>%(count)s</b>"
 msgstr "Показано <b>%(begin)s</b>&ndash;<b>%(end)s</b> із <b>%(count)s</b>"
@@ -2645,44 +2041,53 @@ msgid "Page {n}"
 msgid_plural "Page {n}"
 msgstr[0] "Сторінка {n}"
 msgstr[1] "Сторінка {n}"
-msgstr[2] "Сторінка {n}"
 
-#: src/olympia/amo/templates/services/install.html:38
-#, python-format
-msgid ""
-"If you are not prompted to install %(addon_name)s in a moment, please <a "
-"href=\"%(addon_xpi)s\">click here</a>."
-msgstr ""
-"Якщо ви зараз не отримаєте пропозицію встановити %(addon_name)s, будь ласка "
-"<a href=\"%(addon_xpi)s\">натисніть тут</a>."
-
-#: src/olympia/amo/tests/test_messages.py:57
-#: src/olympia/amo/tests/test_messages.py:58 src/olympia/reviews/forms.py:25
-#: src/olympia/reviews/forms.py:50
-#: src/olympia/reviews/templates/reviews/add.html:56
+#: src/olympia/amo/tests/test_messages.py:56 src/olympia/amo/tests/test_messages.py:57 src/olympia/reviews/forms.py:25 src/olympia/reviews/forms.py:50 src/olympia/reviews/templates/reviews/add.html:56
 #: src/olympia/reviews/templates/reviews/reply.html:30
 msgid "Title"
 msgstr "Заголовок"
 
-#: src/olympia/amo/tests/test_messages.py:57
-#: src/olympia/amo/tests/test_messages.py:58
+#: src/olympia/amo/tests/test_messages.py:56 src/olympia/amo/tests/test_messages.py:57
 msgid "Body"
 msgstr "Вміст"
 
-#: src/olympia/amo/tests/test_messages.py:59
+#: src/olympia/amo/tests/test_messages.py:58
 msgid "Another Title"
 msgstr "Інший заголовок"
 
-#: src/olympia/amo/tests/test_messages.py:59
+#: src/olympia/amo/tests/test_messages.py:58
 msgid "Another Body"
 msgstr "Інший вміст"
 
-#: src/olympia/api/views.py:255
-msgid "Not implemented yet."
-msgstr "Ще не впроваджено."
+#: src/olympia/api/authentication.py:76
+msgid "Signature has expired."
+msgstr ""
 
-#: src/olympia/applications/views.py:39
-#: src/olympia/applications/templates/applications/appversions.html:3
+#: src/olympia/api/authentication.py:79
+msgid "Error decoding signature."
+msgstr ""
+
+#: src/olympia/api/authentication.py:82
+msgid "Invalid JWT Token."
+msgstr ""
+
+#: src/olympia/api/authentication.py:130
+msgid "Invalid Authorization header. No credentials provided."
+msgstr ""
+
+#: src/olympia/api/authentication.py:133
+msgid "Invalid Authorization header. Credentials string should not contain spaces."
+msgstr ""
+
+#: src/olympia/api/fields.py:29
+msgid "The field must have a length of at least {num} characters."
+msgstr ""
+
+#: src/olympia/api/fields.py:31
+msgid "The language code {lang_code} is invalid."
+msgstr ""
+
+#: src/olympia/applications/views.py:39 src/olympia/applications/templates/applications/appversions.html:3
 msgid "Application Versions"
 msgstr "Версії програми"
 
@@ -2695,22 +2100,15 @@ msgid "Valid Application Versions"
 msgstr "Дійсні версії програми"
 
 #: src/olympia/applications/templates/applications/appversions.html:12
-msgid ""
-"Add-ons submitted to Mozilla Add-ons must have a manifest file with at least"
-" one of the below applications supported. Only the versions listed below are"
-" allowed for these applications."
-msgstr ""
-"Додатки відправлені до Додатків Mozilla повинні мати файл маніфест з хоча б "
-"одним із перерахованих нижче застосунків. Дозволеними для даних застосунків "
-"є версії перераховані нижче."
+msgid "Add-ons submitted to Mozilla Add-ons must have a manifest file with at least one of the below applications supported. Only the versions listed below are allowed for these applications."
+msgstr "Додатки відправлені до Додатків Mozilla повинні мати файл маніфест з хоча б одним із перерахованих нижче застосунків. Дозволеними для даних застосунків є версії перераховані нижче."
 
-#: src/olympia/applications/templates/applications/appversions.html:25
+#: src/olympia/applications/templates/applications/appversions.html:25 src/olympia/editors/helpers.py:361
 msgid "GUID"
 msgstr "GUID"
 
 #. {0} is an add-on name.
-#: src/olympia/applications/templates/applications/appversions.html:26
-#: src/olympia/versions/templates/versions/version_list.html:23
+#: src/olympia/applications/templates/applications/appversions.html:26 src/olympia/versions/templates/versions/version_list.html:23
 msgid "Versions"
 msgstr "Версії"
 
@@ -2720,14 +2118,8 @@ msgstr "http://developer.mozilla.org/en/docs/Install_Manifests"
 
 #: src/olympia/applications/templates/applications/appversions.html:31
 #, python-format
-msgid ""
-"If your supported application does not require a manifest file, you still "
-"must include one with the required properties as specified <a "
-"href=\"%(url)s\">here</a>."
-msgstr ""
-"Навіть якщо підтримуваний Вами застосунок не вимагає файлу маніфесту, Вам "
-"все одно необхідно вказати <a href=\"%(url)s\">тут</a> властивості, що "
-"вимагаються."
+msgid "If your supported application does not require a manifest file, you still must include one with the required properties as specified <a href=\"%(url)s\">here</a>."
+msgstr "Навіть якщо підтримуваний Вами застосунок не вимагає файлу маніфесту, Вам все одно необхідно вказати <a href=\"%(url)s\">тут</a> властивості, що вимагаються."
 
 #. L10n: {0} is 'Add-ons for <app>'.
 #: src/olympia/bandwagon/feeds.py:44
@@ -2735,13 +2127,9 @@ msgstr ""
 msgid "Collections :: %s"
 msgstr "Збірки :: %s"
 
-#: src/olympia/bandwagon/feeds.py:50
-#: src/olympia/bandwagon/templates/bandwagon/collection_detail.html:137
-msgid ""
-"Collections are groups of related add-ons that anyone can create and share."
-msgstr ""
-"Збірки - це групи відповідних додатків, які може створювати та поширювати "
-"будь-хто."
+#: src/olympia/bandwagon/feeds.py:50 src/olympia/bandwagon/templates/bandwagon/collection_detail.html:137
+msgid "Collections are groups of related add-ons that anyone can create and share."
+msgstr "Збірки - це групи відповідних додатків, які може створювати та поширювати будь-хто."
 
 #. L10n: {0} is a collection name, {1} is 'Add-ons for <app>'.
 #: src/olympia/bandwagon/feeds.py:70
@@ -2778,8 +2166,7 @@ msgstr "Іконка"
 
 #: src/olympia/bandwagon/forms.py:143
 msgid "Please don't fill out this field, it's used to catch bots"
-msgstr ""
-"Будь ласка, не заповнюйте це поле, воно використовується щоб зловити ботів"
+msgstr "Будь ласка, не заповнюйте це поле, воно використовується щоб зловити ботів"
 
 #: src/olympia/bandwagon/forms.py:167
 msgid "This name cannot be used."
@@ -2793,12 +2180,11 @@ msgstr "Посилання не дозволені."
 msgid "This url is already in use by another collection"
 msgstr "Ця адреса URL вже використовується в іншій збірці"
 
-#: src/olympia/bandwagon/forms.py:197 src/olympia/devhub/views.py:1049
+#: src/olympia/bandwagon/forms.py:197 src/olympia/devhub/views.py:1050
 msgid "Icons must be either PNG or JPG."
 msgstr "Іконки повинні мати формат PNG або JPG."
 
-#: src/olympia/bandwagon/forms.py:202 src/olympia/devhub/views.py:1067
-#: src/olympia/users/forms.py:476
+#: src/olympia/bandwagon/forms.py:202 src/olympia/devhub/views.py:1068 src/olympia/users/forms.py:476
 #, python-format
 msgid "Please use images smaller than %dMB."
 msgstr "Будь ласка, використовуйте зображення розміром до %dMB."
@@ -2819,8 +2205,7 @@ msgstr "Вилучити мій голос за цю збірку"
 msgid "Log in to vote for this collection"
 msgstr "Увійдіть, щоб проголосувати за цю збірку"
 
-#: src/olympia/bandwagon/helpers.py:123
-#: src/olympia/bandwagon/templates/bandwagon/favorites_widget.html:2
+#: src/olympia/bandwagon/helpers.py:123 src/olympia/bandwagon/templates/bandwagon/favorites_widget.html:2
 msgid "Add to favorites"
 msgstr "Додати до вподобань"
 
@@ -2828,20 +2213,13 @@ msgstr "Додати до вподобань"
 msgid "Favorite"
 msgstr "Вподобання"
 
-#: src/olympia/bandwagon/helpers.py:124
-#: src/olympia/bandwagon/templates/bandwagon/favorites_widget.html:2
+#: src/olympia/bandwagon/helpers.py:124 src/olympia/bandwagon/templates/bandwagon/favorites_widget.html:2
 msgid "Remove from favorites"
 msgstr "Вилучити з вподобань"
 
-#: src/olympia/bandwagon/views.py:98 src/olympia/bandwagon/views.py:191
-#: src/olympia/browse/views.py:58 src/olympia/browse/views.py:69
-#: src/olympia/browse/views.py:458 src/olympia/devhub/views.py:74
-#: src/olympia/devhub/views.py:82
-#: src/olympia/devhub/templates/devhub/addons/edit/basic.html:20
-#: src/olympia/editors/templates/editors/leaderboard.html:24
-#: src/olympia/editors/templates/editors/themes/queue_list.html:48
-#: src/olympia/search/forms.py:17 src/olympia/search/forms.py:89
-#: src/olympia/users/templates/users/vcard.html:5
+#: src/olympia/bandwagon/views.py:98 src/olympia/bandwagon/views.py:191 src/olympia/browse/views.py:58 src/olympia/browse/views.py:69 src/olympia/browse/views.py:425 src/olympia/devhub/views.py:73
+#: src/olympia/devhub/views.py:81 src/olympia/devhub/templates/devhub/addons/edit/basic.html:20 src/olympia/editors/templates/editors/leaderboard.html:24
+#: src/olympia/editors/templates/editors/themes/queue_list.html:48 src/olympia/search/forms.py:17 src/olympia/search/forms.py:89 src/olympia/users/templates/users/vcard.html:5
 msgid "Name"
 msgstr "Ім'я"
 
@@ -2849,8 +2227,7 @@ msgstr "Ім'я"
 msgid "Recently Popular"
 msgstr "Нещодавно популярні"
 
-#: src/olympia/bandwagon/views.py:189
-#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:18
+#: src/olympia/bandwagon/views.py:189 src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:16
 msgid "Added"
 msgstr "Додано"
 
@@ -2864,12 +2241,8 @@ msgstr "Збірку створено!"
 
 #: src/olympia/bandwagon/views.py:316
 #, python-format
-msgid ""
-"Your new collection is shown below. You can <ahref=\"%(url)s\">edit "
-"additional settings</a> if you'dlike."
-msgstr ""
-"Ваша нова збірка показана нижче. Якщо хочете, ви можете "
-"<ahref=\"%(url)s\">змінити додаткові налаштування</a>."
+msgid "Your new collection is shown below. You can <a href=\"%(url)s\">edit additional settings</a> if you'd like."
+msgstr "Ваша нова збірка показана внизу. Якщо бажаєте, ви можете <a href=\"%(url)s\">змінити додаткові налаштування</a>."
 
 #: src/olympia/bandwagon/views.py:322
 msgid "Collection updated!"
@@ -2884,31 +2257,20 @@ msgstr "<a href=\"%(url)s\">Переглянути свою збірку</a>, щ
 msgid "Icon Deleted"
 msgstr "Іконка видалена"
 
-#: src/olympia/bandwagon/templates/bandwagon/add.html:3
-#: src/olympia/bandwagon/templates/bandwagon/add.html:11
-#: src/olympia/bandwagon/templates/bandwagon/includes/collection_sidebar.html:26
+#: src/olympia/bandwagon/templates/bandwagon/add.html:3 src/olympia/bandwagon/templates/bandwagon/add.html:11 src/olympia/bandwagon/templates/bandwagon/includes/collection_sidebar.html:26
 msgid "Create a New Collection"
 msgstr "Створити нову збірку"
 
-#: src/olympia/bandwagon/templates/bandwagon/add.html:9
-#: src/olympia/devhub/templates/devhub/personas/submit.html:14
+#: src/olympia/bandwagon/templates/bandwagon/add.html:9 src/olympia/devhub/templates/devhub/personas/submit.html:14
 msgid "Create"
 msgstr "Створити"
 
-#: src/olympia/bandwagon/templates/bandwagon/add.html:24
-#: src/olympia/bandwagon/templates/bandwagon/ajax_new.html:28
+#: src/olympia/bandwagon/templates/bandwagon/add.html:24 src/olympia/bandwagon/templates/bandwagon/ajax_new.html:28
 #, python-format
-msgid ""
-"As noted in our <a href=\"%(legal)s\">Legal Notices</a>, individual "
-"collection arrangements are governed by the Creative Commons Attribution "
-"Share-Alike License"
-msgstr ""
-"Як зазначено у наших <a href=\"%(legal)s\">Юридичних відомостях</a>, угоди "
-"індивідуальних збірок керуються ліцензією Creative Commons Attribution "
-"Share-Alike"
+msgid "As noted in our <a href=\"%(legal)s\">Legal Notices</a>, individual collection arrangements are governed by the Creative Commons Attribution Share-Alike License"
+msgstr "Як зазначено у наших <a href=\"%(legal)s\">Юридичних відомостях</a>, угоди індивідуальних збірок керуються ліцензією Creative Commons Attribution Share-Alike"
 
-#: src/olympia/bandwagon/templates/bandwagon/add.html:33
-#: src/olympia/bandwagon/templates/bandwagon/ajax_new.html:38
+#: src/olympia/bandwagon/templates/bandwagon/add.html:33 src/olympia/bandwagon/templates/bandwagon/ajax_new.html:38
 msgid "Create Collection"
 msgstr "Створити збірку"
 
@@ -2924,8 +2286,7 @@ msgstr "Почати нову збірку..."
 msgid "Start a New Collection"
 msgstr "Почати нову збірку"
 
-#: src/olympia/bandwagon/templates/bandwagon/ajax_new.html:6
-#: src/olympia/bandwagon/templates/bandwagon/includes/addedit.html:7
+#: src/olympia/bandwagon/templates/bandwagon/ajax_new.html:6 src/olympia/bandwagon/templates/bandwagon/includes/addedit.html:7
 msgid "Name:"
 msgstr "Назва:"
 
@@ -2936,18 +2297,13 @@ msgstr "або <a id=\"collections-new-cancel\" href=\"#\">Скасувати</a
 #. Link to remove a collection vote
 #: src/olympia/bandwagon/templates/bandwagon/barometer.html:15
 msgid "To rate collections, you must have an add-ons account."
-msgstr ""
-"Щоб оцінити збірки, у вас повинен бути обліковий запис на сайті додатків."
+msgstr "Щоб оцінити збірки, у вас повинен бути обліковий запис на сайті додатків."
 
-#: src/olympia/bandwagon/templates/bandwagon/barometer.html:18
-#: src/olympia/templates/base.html:145
-#: src/olympia/templates/impala/base.html:198
+#: src/olympia/bandwagon/templates/bandwagon/barometer.html:18 src/olympia/templates/base.html:145 src/olympia/templates/impala/base.html:198
 msgid "Create an Add-ons Account"
 msgstr "Створити обліковий запис на сайті додатків"
 
-#: src/olympia/bandwagon/templates/bandwagon/barometer.html:21
-#: src/olympia/templates/base.html:148
-#: src/olympia/templates/impala/base.html:201
+#: src/olympia/bandwagon/templates/bandwagon/barometer.html:21 src/olympia/templates/base.html:148 src/olympia/templates/impala/base.html:201
 #, python-format
 msgid "or <a href=\"%(login)s\">log in to your current account</a>"
 msgstr "або <a href=\"%(login)s\">увійти в свій поточний обліковий запис</a>"
@@ -2960,14 +2316,12 @@ msgstr "{0} :: Збірки"
 msgid "private"
 msgstr "приватний"
 
-#: src/olympia/bandwagon/templates/bandwagon/collection_detail.html:45
-#: src/olympia/bandwagon/templates/bandwagon/mobile/listing_items.html:9
+#: src/olympia/bandwagon/templates/bandwagon/collection_detail.html:45 src/olympia/bandwagon/templates/bandwagon/mobile/listing_items.html:9
 #, python-format
 msgid "<span>%(num)s</span> follower"
 msgid_plural "<span>%(num)s</span> followers"
 msgstr[0] "<span>%(num)s</span> прихильник"
 msgstr[1] "<span>%(num)s</span> прихильника"
-msgstr[2] "<span>%(num)s</span> прихильників"
 
 #: src/olympia/bandwagon/templates/bandwagon/collection_detail.html:54
 msgid "About this Collection"
@@ -2997,8 +2351,7 @@ msgstr "Більше опцій:"
 msgid "Edit Collection"
 msgstr "Змінити збірку"
 
-#: src/olympia/bandwagon/templates/bandwagon/collection_detail.html:88
-#: src/olympia/bandwagon/templates/bandwagon/includes/delete.html:3
+#: src/olympia/bandwagon/templates/bandwagon/collection_detail.html:88 src/olympia/bandwagon/templates/bandwagon/includes/delete.html:3
 msgid "Delete Collection"
 msgstr "Видалити збірку"
 
@@ -3008,7 +2361,6 @@ msgid "%(num)s Theme in this Collection"
 msgid_plural "%(num)s Themes in this Collection"
 msgstr[0] "%(num)s тема в цій збірці"
 msgstr[1] "%(num)s теми в цій збірці"
-msgstr[2] "%(num)s тем у цій збірці"
 
 #: src/olympia/bandwagon/templates/bandwagon/collection_detail.html:111
 #, python-format
@@ -3016,14 +2368,9 @@ msgid "%(num)s Add-on in this Collection"
 msgid_plural "%(num)s Add-ons in this Collection"
 msgstr[0] "%(num)s додаток у цій збірці"
 msgstr[1] "%(num)s додатки в цій збірці"
-msgstr[2] "%(num)s додатків у цій збірці"
 
-#: src/olympia/bandwagon/templates/bandwagon/collection_detail.html:125
-#: src/olympia/compat/templates/compat/index.html:25
-#: src/olympia/compat/templates/compat/reporter_detail.html:29
-#: src/olympia/files/templates/files/viewer.html:29
-#: src/olympia/templates/amo_footer.html:17
-#: src/olympia/templates/includes/lang_switcher.html:10
+#: src/olympia/bandwagon/templates/bandwagon/collection_detail.html:125 src/olympia/compat/templates/compat/reporter_detail.html:29 src/olympia/files/templates/files/viewer.html:29
+#: src/olympia/templates/amo_footer.html:17 src/olympia/templates/includes/lang_switcher.html:10
 msgid "Go"
 msgstr "Перейти"
 
@@ -3049,28 +2396,19 @@ msgstr "Дивитися всі збірки цього користувача"
 
 #: src/olympia/bandwagon/templates/bandwagon/collection_detail.html:179
 msgid ""
-"Add-ons that you mark as favorites using the <b>Add to Favorites</b> feature"
-" appear below. This collection is currently <b>public</b>, which means "
-"everyone can see it. If you would like to hide it from public view, click "
-"the button below to make it private."
+"Add-ons that you mark as favorites using the <b>Add to Favorites</b> feature appear below. This collection is currently <b>public</b>, which means everyone can see it. If you would like to hide it "
+"from public view, click the button below to make it private."
 msgstr ""
-"Додатки, які Ви відзначите як обрані, використовуючи функцію <b>Додати в "
-"Обране</b>, з'являться у розташованому нижче полі. Нині ця добірка є "
-"<b>публічною</b>, що означає, що будь-хто може її побачити. Якщо Ви хочете "
-"приховати її від публічного перегляду, натисніть розташовану нижче кнопку, "
-"щоб зробити її приватною."
+"Додатки, які Ви відзначите як обрані, використовуючи функцію <b>Додати в Обране</b>, з'являться у розташованому нижче полі. Нині ця добірка є <b>публічною</b>, що означає, що будь-хто може її "
+"побачити. Якщо Ви хочете приховати її від публічного перегляду, натисніть розташовану нижче кнопку, щоб зробити її приватною."
 
 #: src/olympia/bandwagon/templates/bandwagon/collection_detail.html:186
 msgid ""
-"Add-ons that you mark as favorites using the <b>Add to Favorites</b> feature"
-" appear below. This collection is currently <b>private</b>, which means only"
-" you can see it.  If you would like everyone to be able to see your "
-"favorites, click the button below to make it public."
+"Add-ons that you mark as favorites using the <b>Add to Favorites</b> feature appear below. This collection is currently <b>private</b>, which means only you can see it. If you would like everyone "
+"to be able to see your favorites, click the button below to make it public."
 msgstr ""
-"Додатки, які ви позначите як улюблені, використовуючи <b>Додати до "
-"вподобань</b>, з'являться нижче. Ця збірка наразі є <b>приватною</b>, що "
-"означає, що лише ви можете її бачити.  Якщо ви хочете, щоб всі мали змогу "
-"бачити ваші вподобання, натисніть на кнопку нижче."
+"Додатки, які Ви позначите як обрані, використовуючи функцію <b>Додати в Обране</b>, з'являться у полі розташованому нижче. Ця добірка наразі є <b>приватною</b>, що означає, що лише Ви зможете її "
+"побачити. Якщо Ви хочете, щоб будь-хто інший міг бачити обрані Вами додатки, натисніть розташовану нижче кнопку, щоб зробити її публічною."
 
 #: src/olympia/bandwagon/templates/bandwagon/collection_detail.html:196
 msgid "My favorite add-ons"
@@ -3082,7 +2420,6 @@ msgid "<span>%(addons)s</span> add-on"
 msgid_plural "<span>%(addons)s</span> add-ons"
 msgstr[0] "<span>%(addons)s</span> додаток"
 msgstr[1] "<span>%(addons)s</span> додатки"
-msgstr[2] "<span>%(addons)s</span> додатків"
 
 #: src/olympia/bandwagon/templates/bandwagon/collection_grid.html:32
 #, python-format
@@ -3090,23 +2427,19 @@ msgid "<span>%(followers)s</span> follower"
 msgid_plural "<span>%(followers)s</span> followers"
 msgstr[0] "<span>%(followers)s</span> прихильник"
 msgstr[1] "<span>%(followers)s</span> прихильника"
-msgstr[2] "<span>%(followers)s</span> прихильників"
 
-#. People "follow" collections to get notified of updates.
-#. Like
+#. People "follow" collections to get notified of updates.                    Like
 #. Twitter followers.
+#. People "follow" collections to get notified of updates.
 #. Like Twitter followers.
-#: src/olympia/bandwagon/templates/bandwagon/collection_listing_items.html:10
-#: src/olympia/bandwagon/templates/bandwagon/impala/collection_listing_items.html:18
+#: src/olympia/bandwagon/templates/bandwagon/collection_listing_items.html:10 src/olympia/bandwagon/templates/bandwagon/impala/collection_listing_items.html:18
 #, python-format
 msgid "%(num)s weekly follower"
 msgid_plural "%(num)s weekly followers"
 msgstr[0] "%(num)s щотижневий прихильник"
 msgstr[1] "%(num)s щотижневих прихильника"
-msgstr[2] "%(num)s щотижневих прихильників"
 
-#. People "follow" collections to get notified of updates.
-#. Like
+#. People "follow" collections to get notified of updates.                    Like
 #. Twitter followers.
 #: src/olympia/bandwagon/templates/bandwagon/collection_listing_items.html:18
 #, python-format
@@ -3114,35 +2447,29 @@ msgid "%(num)s monthly follower"
 msgid_plural "%(num)s monthly followers"
 msgstr[0] "%(num)s щомісячний прихильник"
 msgstr[1] "%(num)s щомісячні прихильника"
-msgstr[2] "%(num)s щомісячних прихильників"
 
-#. People "follow" collections to get notified of updates.
-#. Like
+#. People "follow" collections to get notified of updates.                    Like
 #. Twitter followers.
+#. People "follow" collections to get notified of updates.
 #. Like Twitter followers.
-#: src/olympia/bandwagon/templates/bandwagon/collection_listing_items.html:26
-#: src/olympia/bandwagon/templates/bandwagon/impala/collection_listing_items.html:26
+#: src/olympia/bandwagon/templates/bandwagon/collection_listing_items.html:26 src/olympia/bandwagon/templates/bandwagon/impala/collection_listing_items.html:26
 #, python-format
 msgid "%(num)s follower"
 msgid_plural "%(num)s followers"
 msgstr[0] "%(num)s прихильник"
 msgstr[1] "%(num)s прихильника"
-msgstr[2] "%(num)s прихильників"
 
-#: src/olympia/bandwagon/templates/bandwagon/collection_listing_items.html:56
-#: src/olympia/bandwagon/templates/bandwagon/impala/collection_listing_items.html:9
+#: src/olympia/bandwagon/templates/bandwagon/collection_listing_items.html:56 src/olympia/bandwagon/templates/bandwagon/impala/collection_listing_items.html:9
 #: src/olympia/devhub/templates/devhub/personas/edit.html:27
 msgid "by {0}"
 msgstr "від {0}"
 
-#: src/olympia/bandwagon/templates/bandwagon/collection_widgets.html:5
-#: src/olympia/bandwagon/templates/bandwagon/collection_widgets.html:7
+#: src/olympia/bandwagon/templates/bandwagon/collection_widgets.html:5 src/olympia/bandwagon/templates/bandwagon/collection_widgets.html:7
 #: src/olympia/bandwagon/templates/bandwagon/impala/collection_listing_items.html:53
 msgid "Stop Following"
 msgstr "Не слідкувати"
 
-#: src/olympia/bandwagon/templates/bandwagon/collection_widgets.html:6
-#: src/olympia/bandwagon/templates/bandwagon/collection_widgets.html:7
+#: src/olympia/bandwagon/templates/bandwagon/collection_widgets.html:6 src/olympia/bandwagon/templates/bandwagon/collection_widgets.html:7
 #: src/olympia/bandwagon/templates/bandwagon/impala/collection_listing_items.html:53
 msgid "Follow this Collection"
 msgstr "Слідкувати за цією збіркою"
@@ -3152,16 +2479,12 @@ msgid "Edit this Collection"
 msgstr "Змінити цю збірку"
 
 #. %s is the name of the collection.
-#: src/olympia/bandwagon/templates/bandwagon/delete.html:4
-#: src/olympia/bandwagon/templates/bandwagon/delete.html:15
+#: src/olympia/bandwagon/templates/bandwagon/delete.html:4 src/olympia/bandwagon/templates/bandwagon/delete.html:15
 msgid "Delete {0}"
 msgstr "Вилучити {0}"
 
-#: src/olympia/bandwagon/templates/bandwagon/delete.html:13
-#: src/olympia/devhub/templates/devhub/addons/listing/item_actions.html:14
-#: src/olympia/devhub/templates/devhub/addons/listing/item_actions_theme.html:28
-#: src/olympia/devhub/templates/devhub/versions/list.html:131
-#: src/olympia/devhub/templates/devhub/versions/list.html:149
+#: src/olympia/bandwagon/templates/bandwagon/delete.html:13 src/olympia/devhub/templates/devhub/addons/listing/item_actions.html:14
+#: src/olympia/devhub/templates/devhub/addons/listing/item_actions_theme.html:28 src/olympia/devhub/templates/devhub/versions/list.html:131 src/olympia/devhub/templates/devhub/versions/list.html:149
 #: src/olympia/devhub/templates/devhub/versions/list.html:166
 msgid "Delete"
 msgstr "Вилучити"
@@ -3170,35 +2493,24 @@ msgstr "Вилучити"
 msgid "Are you sure?"
 msgstr "Ви впевнені?"
 
-#: src/olympia/bandwagon/templates/bandwagon/delete.html:21
-#: src/olympia/devhub/templates/devhub/personas/edit.html:131
-#: src/olympia/devhub/templates/devhub/personas/edit.html:152
-#: src/olympia/devhub/templates/devhub/personas/edit.html:173
-#: src/olympia/devhub/templates/devhub/personas/submit.html:77
-#: src/olympia/devhub/templates/devhub/personas/submit.html:98
+#: src/olympia/bandwagon/templates/bandwagon/delete.html:21 src/olympia/devhub/templates/devhub/personas/edit.html:131 src/olympia/devhub/templates/devhub/personas/edit.html:152
+#: src/olympia/devhub/templates/devhub/personas/edit.html:173 src/olympia/devhub/templates/devhub/personas/submit.html:77 src/olympia/devhub/templates/devhub/personas/submit.html:98
 #: src/olympia/devhub/templates/devhub/personas/submit.html:119
 msgid "Yes"
 msgstr "Так"
 
-#: src/olympia/bandwagon/templates/bandwagon/delete.html:22
-#: src/olympia/devhub/templates/devhub/personas/edit.html:140
-#: src/olympia/devhub/templates/devhub/personas/edit.html:161
-#: src/olympia/devhub/templates/devhub/personas/edit.html:191
-#: src/olympia/devhub/templates/devhub/personas/submit.html:86
-#: src/olympia/devhub/templates/devhub/personas/submit.html:107
+#: src/olympia/bandwagon/templates/bandwagon/delete.html:22 src/olympia/devhub/templates/devhub/personas/edit.html:140 src/olympia/devhub/templates/devhub/personas/edit.html:161
+#: src/olympia/devhub/templates/devhub/personas/edit.html:191 src/olympia/devhub/templates/devhub/personas/submit.html:86 src/olympia/devhub/templates/devhub/personas/submit.html:107
 #: src/olympia/devhub/templates/devhub/personas/submit.html:137
 msgid "No"
 msgstr "Ні"
 
 #. {0} is the name of the collection.
-#: src/olympia/bandwagon/templates/bandwagon/edit.html:5
-#: src/olympia/bandwagon/templates/bandwagon/edit.html:21
+#: src/olympia/bandwagon/templates/bandwagon/edit.html:5 src/olympia/bandwagon/templates/bandwagon/edit.html:21
 msgid "Edit {0}"
 msgstr "Змінити {0}"
 
-#: src/olympia/bandwagon/templates/bandwagon/edit.html:29
-#: src/olympia/devhub/templates/devhub/addons/edit/details.html:20
-#: src/olympia/editors/templates/editors/themes/themes.html:62
+#: src/olympia/bandwagon/templates/bandwagon/edit.html:29 src/olympia/devhub/templates/devhub/addons/edit/details.html:20 src/olympia/editors/templates/editors/themes/themes.html:62
 msgid "Description"
 msgstr "Опис"
 
@@ -3206,31 +2518,17 @@ msgstr "Опис"
 msgid "Contributors & More"
 msgstr "Помічники та інше"
 
-#: src/olympia/bandwagon/templates/bandwagon/edit.html:54
-#: src/olympia/bandwagon/templates/bandwagon/edit.html:67
-#: src/olympia/bandwagon/templates/bandwagon/edit.html:82
-#: src/olympia/devhub/templates/devhub/addons/ajax_compat_update.html:35
-#: src/olympia/devhub/templates/devhub/addons/owner.html:59
-#: src/olympia/devhub/templates/devhub/addons/profile.html:42
-#: src/olympia/devhub/templates/devhub/addons/edit/admin.html:101
-#: src/olympia/devhub/templates/devhub/addons/edit/basic.html:152
-#: src/olympia/devhub/templates/devhub/addons/edit/details.html:85
-#: src/olympia/devhub/templates/devhub/addons/edit/support.html:67
-#: src/olympia/devhub/templates/devhub/addons/edit/technical.html:166
-#: src/olympia/devhub/templates/devhub/addons/forms_shared/media.html:149
-#: src/olympia/devhub/templates/devhub/payments/voluntary.html:64
-#: src/olympia/devhub/templates/devhub/personas/edit.html:35
-#: src/olympia/devhub/templates/devhub/personas/edit.html:304
-#: src/olympia/devhub/templates/devhub/versions/edit.html:139
-#: src/olympia/translations/templates/translations/trans-menu.html:48
+#: src/olympia/bandwagon/templates/bandwagon/edit.html:54 src/olympia/bandwagon/templates/bandwagon/edit.html:67 src/olympia/bandwagon/templates/bandwagon/edit.html:82
+#: src/olympia/devhub/templates/devhub/addons/ajax_compat_update.html:35 src/olympia/devhub/templates/devhub/addons/owner.html:59 src/olympia/devhub/templates/devhub/addons/profile.html:42
+#: src/olympia/devhub/templates/devhub/addons/edit/admin.html:101 src/olympia/devhub/templates/devhub/addons/edit/basic.html:152 src/olympia/devhub/templates/devhub/addons/edit/details.html:85
+#: src/olympia/devhub/templates/devhub/addons/edit/support.html:67 src/olympia/devhub/templates/devhub/addons/edit/technical.html:166
+#: src/olympia/devhub/templates/devhub/addons/forms_shared/media.html:149 src/olympia/devhub/templates/devhub/payments/voluntary.html:64 src/olympia/devhub/templates/devhub/personas/edit.html:35
+#: src/olympia/devhub/templates/devhub/personas/edit.html:304 src/olympia/devhub/templates/devhub/versions/edit.html:139 src/olympia/translations/templates/translations/trans-menu.html:48
 msgid "Save Changes"
 msgstr "Зберегти зміни"
 
-#: src/olympia/bandwagon/templates/bandwagon/edit_contributors.html:9
-#: src/olympia/bandwagon/templates/bandwagon/edit_contributors.html:12
-#: src/olympia/bandwagon/templates/bandwagon/edit_contributors.html:17
-#: src/olympia/bandwagon/templates/bandwagon/edit_contributors.html:58
-#: src/olympia/constants/base.py:134
+#: src/olympia/bandwagon/templates/bandwagon/edit_contributors.html:9 src/olympia/bandwagon/templates/bandwagon/edit_contributors.html:12
+#: src/olympia/bandwagon/templates/bandwagon/edit_contributors.html:17 src/olympia/bandwagon/templates/bandwagon/edit_contributors.html:58 src/olympia/constants/base.py:134
 msgid "Owner"
 msgstr "Власник"
 
@@ -3242,10 +2540,8 @@ msgstr "Зробити власником"
 msgid "Remove this user as a contributor"
 msgstr "Вилучити цього користувача як помічника"
 
-#: src/olympia/bandwagon/templates/bandwagon/edit_contributors.html:18
-#: src/olympia/bandwagon/templates/bandwagon/edit_contributors.html:43
-#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:20
-#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:48
+#: src/olympia/bandwagon/templates/bandwagon/edit_contributors.html:18 src/olympia/bandwagon/templates/bandwagon/edit_contributors.html:43
+#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:18 src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:46
 #: src/olympia/devhub/templates/devhub/addons/ajax_compat_update.html:19
 msgid "Remove"
 msgstr "Вилучити"
@@ -3256,23 +2552,17 @@ msgstr "Помічники збірки"
 
 #: src/olympia/bandwagon/templates/bandwagon/edit_contributors.html:26
 msgid ""
-"You can add multiple contributors to this collection.  A contributor can add"
-" and remove add-ons from this collection, but cannot change its name or "
-"description.  To add a contributor, enter their email in the box below. "
-"Contributors must have a Mozilla Add-ons account."
+"You can add multiple contributors to this collection. A contributor can add and remove add-ons from this collection, but cannot change its name or description. To add a contributor, enter their "
+"email in the box below. Contributors must have a Mozilla Add-ons account."
 msgstr ""
-"Ви можете додати декілька помічників у цю збірку.  Помічник може додавати та"
-" видаляти додатки зі збірки, але не може змінювати їхні назви та описи.  Щоб"
-" додати помічника, введіть його адресу електронної пошти у поле нижче. "
-"Помічники повинні мати обліковий запис на сайті додатків Mozilla."
+"Ви можете додати декілька помічників до цієї збірки. Помічник може додавати і вилучати додатки з цієї збірки, але не може змінити її назву чи опис. Щоб додати помічника, введіть його адресу "
+"електронної пошти у полі внизу. Помічники повинні мати обліковий запис на сайті додатків Mozilla."
 
 #: src/olympia/bandwagon/templates/bandwagon/edit_contributors.html:40
 msgid "User"
 msgstr "Користувач"
 
-#: src/olympia/bandwagon/templates/bandwagon/edit_contributors.html:41
-#: src/olympia/devhub/templates/devhub/addons/edit/support.html:20
-#: src/olympia/users/templates/users/delete.html:49
+#: src/olympia/bandwagon/templates/bandwagon/edit_contributors.html:41 src/olympia/devhub/templates/devhub/addons/edit/support.html:20 src/olympia/users/templates/users/delete.html:49
 msgid "Email"
 msgstr "Адреса ел. пошти"
 
@@ -3297,27 +2587,14 @@ msgid "Admin Settings"
 msgstr "Налаштування адміністратора"
 
 #: src/olympia/bandwagon/templates/bandwagon/edit_contributors.html:76
-msgid ""
-"<b>Warning:</b> By changing the owner of this collection, you will no longer"
-" be able to edit it. You will only be able to add and remove add-ons from "
-"it."
-msgstr ""
-"<b>Увага:</b> Змінивши власника цієї збірки, ви більше не зможете редагувати"
-" її. Ви зможете тільки додавати або вилучати додатки з неї."
+msgid "<b>Warning:</b> By changing the owner of this collection, you will no longer be able to edit it. You will only be able to add and remove add-ons from it."
+msgstr "<b>Увага:</b> Змінивши власника цієї збірки, ви більше не зможете редагувати її. Ви зможете тільки додавати або вилучати додатки з неї."
 
-#: src/olympia/bandwagon/templates/bandwagon/edit_contributors.html:83
-#: src/olympia/devhub/templates/devhub/addons/forms_shared/media.html:157
-#: src/olympia/devhub/templates/devhub/addons/submit/describe.html:69
-#: src/olympia/devhub/templates/devhub/addons/submit/license.html:60
-#: src/olympia/devhub/templates/devhub/addons/submit/upload.html:78
-#: src/olympia/devhub/templates/devhub/payments/tier.html:17
-#: src/olympia/editors/templates/editors/themes/themes.html:111
-#: src/olympia/editors/templates/editors/themes/themes.html:128
-#: src/olympia/editors/templates/editors/themes/themes.html:134
-#: src/olympia/editors/templates/editors/themes/themes.html:141
-#: src/olympia/users/templates/users/fxa_migration_prompt_content.html:10
-#: src/olympia/users/templates/users/login_form.html:42
-#: src/olympia/users/templates/users/mobile/login.html:57
+#: src/olympia/bandwagon/templates/bandwagon/edit_contributors.html:83 src/olympia/devhub/templates/devhub/addons/forms_shared/media.html:157
+#: src/olympia/devhub/templates/devhub/addons/submit/describe.html:69 src/olympia/devhub/templates/devhub/addons/submit/license.html:60 src/olympia/devhub/templates/devhub/addons/submit/upload.html:70
+#: src/olympia/devhub/templates/devhub/payments/tier.html:17 src/olympia/editors/templates/editors/themes/themes.html:111 src/olympia/editors/templates/editors/themes/themes.html:128
+#: src/olympia/editors/templates/editors/themes/themes.html:134 src/olympia/editors/templates/editors/themes/themes.html:141 src/olympia/users/templates/users/fxa_migration_prompt_content.html:10
+#: src/olympia/users/templates/users/login_form.html:42 src/olympia/users/templates/users/mobile/login.html:57
 msgid "Continue"
 msgstr "Продовжити"
 
@@ -3356,18 +2633,10 @@ msgstr "Нещодавно популярні збірки"
 
 #: src/olympia/bandwagon/templates/bandwagon/impala/collection_listing.html:28
 #, python-format
-msgid ""
-"Collections are groups of related add-ons that anyone can create and share. "
-"Explore collections created by other users or <a href=\"%(url)s\">create "
-"your own</a>."
-msgstr ""
-"Збірки - це групи відповідних додатків, які може створити та поширювати "
-"кожен. Перегляньте збірки, створені іншими користувачами або <a "
-"href=\"%(url)s\">створіть власну</a>."
+msgid "Collections are groups of related add-ons that anyone can create and share. Explore collections created by other users or <a href=\"%(url)s\">create your own</a>."
+msgstr "Збірки - це групи відповідних додатків, які може створити та поширювати кожен. Перегляньте збірки, створені іншими користувачами або <a href=\"%(url)s\">створіть власну</a>."
 
-#: src/olympia/bandwagon/templates/bandwagon/impala/collection_listing.html:37
-#: src/olympia/browse/templates/browse/extensions.html:13
-#: src/olympia/browse/templates/browse/themes.html:14
+#: src/olympia/bandwagon/templates/bandwagon/impala/collection_listing.html:37 src/olympia/browse/templates/browse/extensions.html:13 src/olympia/browse/templates/browse/themes.html:14
 msgid "Subscribe"
 msgstr "Підписатись"
 
@@ -3375,20 +2644,14 @@ msgstr "Підписатись"
 msgid "Following"
 msgstr "Слідую"
 
-#: src/olympia/bandwagon/templates/bandwagon/impala/collection_sidebar.html:22
-#: src/olympia/bandwagon/templates/bandwagon/impala/collection_sidebar.html:28
+#: src/olympia/bandwagon/templates/bandwagon/impala/collection_sidebar.html:22 src/olympia/bandwagon/templates/bandwagon/impala/collection_sidebar.html:28
 #: src/olympia/bandwagon/templates/bandwagon/includes/collection_sidebar.html:32
 msgid "Create a Collection"
 msgstr "Створити збірку"
 
-#: src/olympia/bandwagon/templates/bandwagon/impala/collection_sidebar.html:23
-#: src/olympia/bandwagon/templates/bandwagon/includes/collection_sidebar.html:27
-msgid ""
-"Collections make it easy to keep track of favorite add-ons and share your "
-"perfectly customized browser with others."
-msgstr ""
-"Збірки дають змогу з легкістю слідкувати за улюбленими додатками та ділитись"
-" вашим ідеально пристосованим браузером з іншими."
+#: src/olympia/bandwagon/templates/bandwagon/impala/collection_sidebar.html:23 src/olympia/bandwagon/templates/bandwagon/includes/collection_sidebar.html:27
+msgid "Collections make it easy to keep track of favorite add-ons and share your perfectly customized browser with others."
+msgstr "Збірки дають змогу з легкістю слідкувати за улюбленими додатками та ділитись вашим ідеально пристосованим браузером з іншими."
 
 #: src/olympia/bandwagon/templates/bandwagon/includes/addedit.html:42
 msgid "Collection Icon"
@@ -3399,52 +2662,43 @@ msgid "Reset"
 msgstr "Скинути"
 
 #: src/olympia/bandwagon/templates/bandwagon/includes/addedit.html:53
-msgid "PNG and JPG supported.  Image will be resized to 32x32."
-msgstr ""
-"Підтримуються формати PNG та JPG.  Розмір зображення буде змінено до 32x32."
+msgid "PNG and JPG supported. Image will be resized to 32x32."
+msgstr "Підтримуються формати PNG та JPG. Розмір зображення буде змінено до 32x32."
 
 #: src/olympia/bandwagon/templates/bandwagon/includes/addedit_errors.html:3
-msgid "There are errors in this form.  Please correct them below."
-msgstr "У цій формі наявні помилки.  Виправте, будь ласка, їх нижче."
+msgid "There are errors in this form. Please correct them below."
+msgstr "У цій формі наявні помилки. Виправте будь ласка їх внизу."
 
 #: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:2
 msgid "Add-ons in Your Collection"
 msgstr "Додатки у вашій збірці"
 
 #: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:4
-msgid ""
-"To include an add-on in this collection, enter its name in the box below and"
-" hit enter.  You can also use the <strong>Add to Collection</strong> links "
-"throughout the site to include add-ons later."
+msgid "To include an add-on in this collection, enter its name in the box below and hit enter."
 msgstr ""
-"Щоб включити додаток до цієї збірки, введіть його ім'я у поле нижче та "
-"натисніть enter.  Ви також можете використовувати посилання <strong>Додати "
-"до Збірки</strong> на сайті, щоб включити додатки пізніше."
 
-#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:17
-#: src/olympia/constants/base.py:400
-#: src/olympia/devhub/templates/devhub/addons/activity.html:62
+#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:15 src/olympia/constants/base.py:400 src/olympia/devhub/templates/devhub/addons/activity.html:62
+#: src/olympia/editors/helpers.py:273 src/olympia/editors/helpers.py:360
 msgid "Add-on"
 msgstr "Додаток"
 
-#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:26
+#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:24
 msgid "Enter the name of the add-on to include"
 msgstr "Введіть назву додатку щоб включити"
 
-#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:28
+#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:26
 msgid "Add to Collection"
 msgstr "Додати до збірки"
 
-#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:45
-#: src/olympia/editors/helpers.py:936 src/olympia/editors/helpers.py:956
+#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:43 src/olympia/editors/helpers.py:1016 src/olympia/editors/helpers.py:1036
 msgid "Pending"
 msgstr "Очікує"
 
-#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:47
+#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:45
 msgid "Add a comment"
 msgstr "Додати коментар"
 
-#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:48
+#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:46
 msgid "Remove this add-on from the collection"
 msgstr "Вилучити цей додаток зі збірки"
 
@@ -3456,14 +2710,11 @@ msgstr "ЗБІРКИ"
 msgid "Groups of related add-ons that anyone can create."
 msgstr "Групи подібних додатків, які може створити кожен."
 
-#: src/olympia/blocklist/templates/blocklist/blocked_detail.html:3
-#: src/olympia/blocklist/templates/blocklist/blocked_list.html:3
-#: src/olympia/blocklist/templates/blocklist/blocked_list.html:10
+#: src/olympia/blocklist/templates/blocklist/blocked_detail.html:3 src/olympia/blocklist/templates/blocklist/blocked_list.html:3 src/olympia/blocklist/templates/blocklist/blocked_list.html:10
 msgid "Blocked Add-ons"
 msgstr "Заблоковані додатки"
 
-#: src/olympia/blocklist/templates/blocklist/blocked_detail.html:8
-#: src/olympia/blocklist/templates/blocklist/blocked_list.html:6
+#: src/olympia/blocklist/templates/blocklist/blocked_detail.html:8 src/olympia/blocklist/templates/blocklist/blocked_list.html:6
 msgid "Blocklist"
 msgstr "Чорний список"
 
@@ -3485,43 +2736,26 @@ msgid "What does this mean?"
 msgstr "Що це значить?"
 
 #: src/olympia/blocklist/templates/blocklist/blocked_detail.html:22
-msgid ""
-"Users are strongly encouraged to disable the problematic add-on or plugin, "
-"but may choose to continue using it if they accept the risks described."
-msgstr ""
-"Користувачам наполегливо рекомендується відключити проблемний додаток чи "
-"плагін, хоча вони можуть продовжувати використовувати його, якщо вони "
-"приймають на себе описаний ризик."
+msgid "Users are strongly encouraged to disable the problematic add-on or plugin, but may choose to continue using it if they accept the risks described."
+msgstr "Користувачам наполегливо рекомендується відключити проблемний додаток чи плагін, хоча вони можуть продовжувати використовувати його, якщо вони приймають на себе описаний ризик."
 
 #: src/olympia/blocklist/templates/blocklist/blocked_detail.html:27
-msgid ""
-"The problematic add-on or plugin will be automatically disabled and no "
-"longer usable."
-msgstr ""
-"Проблемний додаток чи плагін буде автоматично відключено і надалі не зможе "
-"використовуватись."
+msgid "The problematic add-on or plugin will be automatically disabled and no longer usable."
+msgstr "Проблемний додаток чи плагін буде автоматично відключено і надалі не зможе використовуватись."
 
 #: src/olympia/blocklist/templates/blocklist/blocked_detail.html:33
 #, python-format
 msgid ""
-"When Mozilla becomes aware of add-ons, plugins, or other third-party "
-"software that seriously compromises %(app)s security, stability, or "
-"performance and meets <a href=\"%(criteria)s\">certain criteria</a>, the "
-"software may be blocked from general use.  For more information, please read"
-" <a href=\"%(support)s\">this support article</a>."
+"When Mozilla becomes aware of add-ons, plugins, or other third-party software that seriously compromises %(app)s security, stability, or performance and meets <a href=\"%(criteria)s\">certain "
+"criteria</a>, the software may be blocked from general use. For more information, please read <a href=\"%(support)s\">this support article</a>."
 msgstr ""
-"Коли Mozilla стає відомо про додатки, плагіни або інше програмне "
-"забезпечення сторонніх виробників, що серйозно компрометує безпеку, "
-"стабільність або продуктивність %(app)s і відповідає <a "
-"href=\"%(criteria)s\">певним критеріям</a>, то таке програмне забезпечення "
-"може бути заблоковано для загального користування.  Прочитайте <a "
-"href=\"%(support)s\"> статтю підтримки</a>, щоб дізнатися більше."
+"Коли Mozilla стає відомо про додатки, плагіни чи інші сторонні програми, які серйозно підривають безпеку, стабільність чи продуктивність %(app)s та відповідають <a href=\"%(criteria)s\">певним "
+"критеріям</a>, використання цих програм може бути заблоковане. Для отримання додаткової інформації, будь ласка, прочитайте <a href=\"%(support)s\">цю статтю</a>."
 
 #: src/olympia/blocklist/templates/blocklist/blocked_detail.html:44
 #, python-format
 msgid "Blocked on %(date)s. <a href=\"%(link)s\">View block request</a>."
-msgstr ""
-"Заблоковано %(date)s. <a href=\"%(link)s\">Переглянути запит блокування</a>."
+msgstr "Заблоковано %(date)s. <a href=\"%(link)s\">Переглянути запит блокування</a>."
 
 #: src/olympia/blocklist/templates/blocklist/blocked_detail.html:48
 #, python-format
@@ -3529,12 +2763,8 @@ msgid "Blocked on %(date)s."
 msgstr "Заблоковано %(date)s."
 
 #: src/olympia/blocklist/templates/blocklist/blocked_list.html:11
-msgid ""
-"The following software is known to cause serious security, stability, or "
-"performance issues with {app}."
-msgstr ""
-"Відомо, що наступні програми викликають серйозні проблеми з безпекою, "
-"стабільністю чи продуктивністю {app}."
+msgid "The following software is known to cause serious security, stability, or performance issues with {app}."
+msgstr "Відомо, що наступні програми викликають серйозні проблеми з безпекою, стабільністю чи продуктивністю {app}."
 
 #. L10n: %s is a category name.
 #: src/olympia/browse/feeds.py:76 src/olympia/browse/feeds.py:98
@@ -3556,11 +2786,8 @@ msgstr "Відібрані додатки :: %s"
 #. L10n: %s is an app name.
 #: src/olympia/browse/feeds.py:138
 #, python-format
-msgid ""
-"Here's a few of our favorite add-ons to help you get started customizing %s."
-msgstr ""
-"Ось кілька наших улюблених додатків, щоб допомогти вам почати прилаштовувати"
-" %s."
+msgid "Here's a few of our favorite add-ons to help you get started customizing %s."
+msgstr "Ось кілька наших улюблених додатків, щоб допомогти вам почати прилаштовувати %s."
 
 #. L10n: %s is a category name.
 #: src/olympia/browse/feeds.py:157
@@ -3576,43 +2803,28 @@ msgstr "Засоби пошуку та пов'язані з пошуком ро�
 msgid "Search tools"
 msgstr "Засоби пошуку"
 
-#: src/olympia/browse/views.py:55 src/olympia/browse/views.py:65
-#: src/olympia/search/forms.py:85
+#: src/olympia/browse/views.py:55 src/olympia/browse/views.py:65 src/olympia/search/forms.py:85
 msgid "Most Users"
 msgstr "Найбільше користувачів"
 
-#: src/olympia/browse/views.py:61 src/olympia/browse/views.py:72
-#: src/olympia/browse/views.py:279
-#: src/olympia/browse/templates/browse/personas/mobile/category_landing.html:63
-#: src/olympia/discovery/templates/discovery/pane.html:67
-#: src/olympia/search/forms.py:92
+#: src/olympia/browse/views.py:61 src/olympia/browse/views.py:72 src/olympia/browse/views.py:246 src/olympia/browse/templates/browse/personas/mobile/category_landing.html:63
+#: src/olympia/discovery/templates/discovery/pane.html:67 src/olympia/search/forms.py:92
 msgid "Up & Coming"
 msgstr "Набирають популярність"
 
-#: src/olympia/browse/views.py:460 src/olympia/devhub/views.py:76
-#: src/olympia/devhub/views.py:83
-#: src/olympia/discovery/templates/discovery/addons/detail.html:66
+#: src/olympia/browse/views.py:427 src/olympia/devhub/views.py:75 src/olympia/devhub/views.py:82 src/olympia/discovery/templates/discovery/addons/detail.html:66
 msgid "Created"
 msgstr "Створено"
 
 #. {0} is the category name. Ex: Sports
-#: src/olympia/browse/templates/browse/creatured.html:5
-#: src/olympia/browse/templates/browse/creatured.html:13
+#: src/olympia/browse/templates/browse/creatured.html:5 src/olympia/browse/templates/browse/creatured.html:13
 msgid "{0}: Featured Add-ons"
 msgstr "{0}: Відібрані додатки"
 
-#: src/olympia/browse/templates/browse/creatured.html:12
-#: src/olympia/browse/templates/browse/featured.html:4
-#: src/olympia/browse/templates/browse/featured.html:12
-#: src/olympia/browse/templates/browse/featured.html:13
-#: src/olympia/devhub/templates/devhub/docs/policies-recommended.html:3
-#: src/olympia/devhub/templates/devhub/docs/policies-recommended.html:7
-#: src/olympia/devhub/templates/devhub/docs/policies-recommended.html:9
-#: src/olympia/devhub/templates/devhub/docs/policies.html:21
-#: src/olympia/devhub/templates/devhub/docs/policies.html:90
-#: src/olympia/discovery/modules.py:341
-#: src/olympia/discovery/templates/discovery/pane.html:52
-#: src/olympia/templates/menu_links.html:7
+#: src/olympia/browse/templates/browse/creatured.html:12 src/olympia/browse/templates/browse/featured.html:4 src/olympia/browse/templates/browse/featured.html:12
+#: src/olympia/browse/templates/browse/featured.html:13 src/olympia/devhub/templates/devhub/docs/policies-recommended.html:3 src/olympia/devhub/templates/devhub/docs/policies-recommended.html:7
+#: src/olympia/devhub/templates/devhub/docs/policies-recommended.html:9 src/olympia/devhub/templates/devhub/docs/policies.html:21 src/olympia/devhub/templates/devhub/docs/policies.html:90
+#: src/olympia/discovery/modules.py:341 src/olympia/discovery/templates/discovery/pane.html:52 src/olympia/templates/menu_links.html:7
 msgid "Featured Add-ons"
 msgstr "Відібрані додатки"
 
@@ -3623,12 +2835,8 @@ msgstr "В {0} немає відібраних додатків."
 
 #: src/olympia/browse/templates/browse/featured.html:15
 #, python-format
-msgid ""
-"Here's a few of our favorite add-ons to help you get started customizing "
-"%(app)s."
-msgstr ""
-"Ось кілька наших улюблених додатків, щоб допомогти вам почати прилаштовувати"
-" %(app)s."
+msgid "Here's a few of our favorite add-ons to help you get started customizing %(app)s."
+msgstr "Ось кілька наших улюблених додатків, щоб допомогти вам почати прилаштовувати %(app)s."
 
 #: src/olympia/browse/templates/browse/language_tools.html:9
 msgid "Install Dictionary"
@@ -3654,19 +2862,15 @@ msgstr "Доступно вашою мовою"
 msgid "List of language packs and dictionaries available in your locale."
 msgstr "Список мовних пакетів та словників, які доступні вашою мовою."
 
-#: src/olympia/browse/templates/browse/language_tools.html:41
-#: src/olympia/browse/templates/browse/language_tools.html:63
+#: src/olympia/browse/templates/browse/language_tools.html:41 src/olympia/browse/templates/browse/language_tools.html:63
 msgid "Language"
 msgstr "Мова"
 
-#: src/olympia/browse/templates/browse/language_tools.html:42
-#: src/olympia/browse/templates/browse/language_tools.html:64
-#: src/olympia/constants/base.py:162
+#: src/olympia/browse/templates/browse/language_tools.html:42 src/olympia/browse/templates/browse/language_tools.html:64 src/olympia/constants/base.py:162
 msgid "Dictionary"
 msgstr "Словник"
 
-#: src/olympia/browse/templates/browse/language_tools.html:43
-#: src/olympia/browse/templates/browse/language_tools.html:65
+#: src/olympia/browse/templates/browse/language_tools.html:43 src/olympia/browse/templates/browse/language_tools.html:65
 msgid "Language Pack"
 msgstr "Мовний пакет"
 
@@ -3684,13 +2888,11 @@ msgid "{0} :: Search Tools"
 msgstr "{0} :: Засоби пошуку"
 
 #. {0} is an integer.
-#: src/olympia/browse/templates/browse/search_tools.html:39
-#: src/olympia/devhub/templates/devhub/addons/dashboard.html:17
+#: src/olympia/browse/templates/browse/search_tools.html:39 src/olympia/devhub/templates/devhub/addons/dashboard.html:17
 msgid "<b>{0}</b> add-on"
 msgid_plural "<b>{0}</b> add-ons"
 msgstr[0] "<b>{0}</b> додаток"
 msgstr[1] "<b>{0}</b> додатка"
-msgstr[2] "<b>{0}</b> додатоки"
 
 #: src/olympia/browse/templates/browse/search_tools.html:61
 msgid "Search Extensions"
@@ -3714,34 +2916,18 @@ msgstr "Додаткові ресурси"
 
 #. {0} is an app name, like Firefox.
 #: src/olympia/browse/templates/browse/search_tools.html:93
-msgid ""
-"Learn more about the <a "
-"href=\"http://support.mozilla.com/kb/Search+bar\">search bar</a> in {0}"
-msgstr ""
-"Дізнатись більше про <a "
-"href=\"http://support.mozilla.com/kb/Search+bar\">панель пошуку</a> в {0}"
+msgid "Learn more about the <a href=\"http://support.mozilla.com/kb/Search+bar\">search bar</a> in {0}"
+msgstr "Дізнатись більше про <a href=\"http://support.mozilla.com/kb/Search+bar\">панель пошуку</a> в {0}"
 
 #: src/olympia/browse/templates/browse/search_tools.html:94
-msgid ""
-"Browse through even more search providers at <a "
-"href=\"http://mycroft.mozdev.org/\">mycroft.mozdev.org</a>"
-msgstr ""
-"Знайдіть ще більше провайдерів пошуку на сайті <a "
-"href=\"http://mycroft.mozdev.org/\">mycroft.mozdev.org</a>"
+msgid "Browse through even more search providers at <a href=\"http://mycroft.mozdev.org/\">mycroft.mozdev.org</a>"
+msgstr "Знайдіть ще більше провайдерів пошуку на сайті <a href=\"http://mycroft.mozdev.org/\">mycroft.mozdev.org</a>"
 
 #: src/olympia/browse/templates/browse/search_tools.html:95
-msgid ""
-"<a "
-"href=\"https://developer.mozilla.org/en/Creating_OpenSearch_plugins_for_Firefox\">Make"
-" your own</a> search tool"
-msgstr ""
-"<a "
-"href=\"https://developer.mozilla.org/en/Creating_OpenSearch_plugins_for_Firefox\">Створіть"
-" власний</a> засіб пошуку"
+msgid "<a href=\"https://developer.mozilla.org/en/Creating_OpenSearch_plugins_for_Firefox\">Make your own</a> search tool"
+msgstr "<a href=\"https://developer.mozilla.org/en/Creating_OpenSearch_plugins_for_Firefox\">Створіть власний</a> засіб пошуку"
 
-#: src/olympia/browse/templates/browse/themes.html:6
-#: src/olympia/browse/templates/browse/themes.html:9
-#: src/olympia/constants/base.py:174
+#: src/olympia/browse/templates/browse/themes.html:6 src/olympia/browse/templates/browse/themes.html:9 src/olympia/constants/base.py:174
 msgid "Complete Themes"
 msgstr "Повні теми"
 
@@ -3813,26 +2999,18 @@ msgid "See the %(cnt)s extension in %(name)s &raquo;"
 msgid_plural "See all %(cnt)s extensions in %(name)s &raquo;"
 msgstr[0] "Показати %(cnt)s розширення в %(name)s &raquo;"
 msgstr[1] "Показати всі %(cnt)s розширення в %(name)s &raquo;"
-msgstr[2] "Показати всі %(cnt)s розширень в %(name)s &raquo;"
 
-#: src/olympia/browse/templates/browse/mobile/extensions.html:13
-#: src/olympia/compat/templates/compat/index.html:82
-#: src/olympia/devhub/templates/devhub/devhub_search.html:24
-#: src/olympia/devhub/templates/devhub/addons/activity.html:47
-#: src/olympia/search/templates/search/no_results.html:4
-#: src/olympia/search/templates/search/mobile/results.html:36
+#: src/olympia/browse/templates/browse/mobile/extensions.html:13 src/olympia/devhub/templates/devhub/devhub_search.html:24 src/olympia/devhub/templates/devhub/addons/activity.html:47
+#: src/olympia/search/templates/search/no_results.html:4 src/olympia/search/templates/search/mobile/results.html:36
 msgid "No results found."
 msgstr "Результатів не знайдено."
 
-#: src/olympia/browse/templates/browse/personas/base.html:6
-#: src/olympia/browse/templates/browse/personas/mobile/base.html:7
+#: src/olympia/browse/templates/browse/personas/base.html:6 src/olympia/browse/templates/browse/personas/mobile/base.html:7
 msgid "{0} Themes"
 msgstr "{0} Теми"
 
 #. {0} is a user's name.
-#: src/olympia/browse/templates/browse/personas/base.html:15
-#: src/olympia/browse/templates/browse/personas/base.html:40
-#: src/olympia/browse/templates/browse/personas/grid.html:8
+#: src/olympia/browse/templates/browse/personas/base.html:15 src/olympia/browse/templates/browse/personas/base.html:40 src/olympia/browse/templates/browse/personas/grid.html:8
 msgid "{0}'s Themes"
 msgstr "Теми {0}"
 
@@ -3846,38 +3024,28 @@ msgstr "Створити свою власну тему"
 
 #: src/olympia/browse/templates/browse/personas/base.html:46
 msgid "Your browser, your style! Dress it up with a design of your own!"
-msgstr ""
-"Ваш браузер у Вашому стилі! Використовуйте для нього свій власний дизайн!"
+msgstr "Ваш браузер у Вашому стилі! Використовуйте для нього свій власний дизайн!"
 
 #: src/olympia/browse/templates/browse/personas/base.html:51
 msgid "Learn more"
 msgstr "Дізнатись більше"
 
-#: src/olympia/browse/templates/browse/personas/category_landing.html:6
-#: src/olympia/browse/templates/browse/personas/mobile/category_landing.html:5
+#: src/olympia/browse/templates/browse/personas/category_landing.html:6 src/olympia/browse/templates/browse/personas/mobile/category_landing.html:5
 msgid "View All Recently Added"
 msgstr "Переглянути всі нещодавно додані"
 
-#: src/olympia/browse/templates/browse/personas/category_landing.html:7
-#: src/olympia/browse/templates/browse/personas/mobile/category_landing.html:6
+#: src/olympia/browse/templates/browse/personas/category_landing.html:7 src/olympia/browse/templates/browse/personas/mobile/category_landing.html:6
 msgid "View All Most Popular"
 msgstr "Переглянути всі найпопулярніші"
 
-#: src/olympia/browse/templates/browse/personas/category_landing.html:8
-#: src/olympia/browse/templates/browse/personas/mobile/category_landing.html:7
+#: src/olympia/browse/templates/browse/personas/category_landing.html:8 src/olympia/browse/templates/browse/personas/mobile/category_landing.html:7
 msgid "View All Top Rated"
 msgstr "Переглянути всі найвище оцінені"
 
 #: src/olympia/browse/templates/browse/personas/category_landing.html:40
 #, python-format
-msgid ""
-"Over 300,000 designs to personalize your browser! Move your mouse over a "
-"Background Theme to try it on. <a href=\"%(url)s\" class=\"more-info\">Start"
-" exploring</a>"
-msgstr ""
-"Понад 300,000 тем для зміни вигляду вашого браузера! Наведіть вказівник миші"
-" на тему, щоб випробувати її. <a href=\"%(url)s\" class=\"more-info\">Почати"
-" огляд</a>"
+msgid "Over 300,000 designs to personalize your browser! Move your mouse over a Background Theme to try it on. <a href=\"%(url)s\" class=\"more-info\">Start exploring</a>"
+msgstr "Понад 300,000 тем для зміни вигляду вашого браузера! Наведіть вказівник миші на тему, щоб випробувати її. <a href=\"%(url)s\" class=\"more-info\">Почати огляд</a>"
 
 #: src/olympia/browse/templates/browse/personas/category_landing.html:47
 msgid "Want more personalization?"
@@ -3887,14 +3055,8 @@ msgstr "Хочете більше персоналізації?"
 #. theme.
 #: src/olympia/browse/templates/browse/personas/category_landing.html:50
 #, python-format
-msgid ""
-"Complete Themes transform the look of your browser with styles for the "
-"window frame, address bar, buttons, tabs, and menus. <a href=\"%(url)s\" "
-"class=\"more-info\">Start exploring</a>"
-msgstr ""
-"Повні теми перетворюють вигляд вікна, панелі пошуку, кнопок, вкладок та меню"
-" вашого браузера. <a href=\"%(url)s\" class=\"more-info\">Почати "
-"перегляд</a>"
+msgid "Complete Themes transform the look of your browser with styles for the window frame, address bar, buttons, tabs, and menus. <a href=\"%(url)s\" class=\"more-info\">Start exploring</a>"
+msgstr "Повні теми перетворюють вигляд вікна, панелі пошуку, кнопок, вкладок та меню вашого браузера. <a href=\"%(url)s\" class=\"more-info\">Почати перегляд</a>"
 
 #: src/olympia/browse/templates/browse/personas/category_landing.html:76
 msgid "Up & Coming Themes"
@@ -3924,7 +3086,7 @@ msgstr "&laquo; Всі теми"
 msgid "All"
 msgstr "Всі"
 
-#: src/olympia/compat/forms.py:22 src/olympia/search/views.py:525
+#: src/olympia/compat/forms.py:22 src/olympia/editors/templates/editors/base.html:69 src/olympia/search/views.py:518
 msgid "All Add-ons"
 msgstr "Всі додатки"
 
@@ -3936,80 +3098,24 @@ msgstr "Бінарні"
 msgid "Non-binary"
 msgstr "Не бінарні"
 
-#. Review points sources other than add-ons and themes.
-#: src/olympia/compat/views.py:87 src/olympia/constants/base.py:388
-#: src/olympia/devhub/forms.py:162
-#: src/olympia/editors/templates/editors/performance.html:75
-msgid "Other"
-msgstr "Інше"
-
-#: src/olympia/compat/templates/compat/index.html:4
-msgid "Add-on Compatibility Report for {app} {version}"
-msgstr "Звіт сумісності додатку для {app} {version}"
-
-#: src/olympia/compat/templates/compat/index.html:11
-msgid "{app} {version} Compatibility"
-msgstr "Сумісність {app} {version}"
-
-#: src/olympia/compat/templates/compat/index.html:17
-#, python-format
-msgid "Top 95%% compatible with previous version"
-msgstr "Найкращі 95%% сумісних з попередньою версією"
-
-#: src/olympia/compat/templates/compat/index.html:18
-#, python-format
-msgid "Top 95%% of all add-ons"
-msgstr "Найкращі 95%% з усіх додатків"
-
-#: src/olympia/compat/templates/compat/index.html:19
-msgid "All active add-ons"
-msgstr "Всі активні додатки"
-
-#: src/olympia/compat/templates/compat/index.html:23
-#: src/olympia/constants/base.py:401
-msgid "App"
-msgstr "Дод."
-
-#: src/olympia/compat/templates/compat/index.html:55
-msgid "Details for add-ons compatible with previous version:"
-msgstr "Докладна інформація для додатків, сумісних з попередньою версією:"
-
-#: src/olympia/compat/templates/compat/index.html:57
-msgid "Show all versions"
-msgstr "Показати всі версії"
-
-#: src/olympia/compat/templates/compat/index.html:59
-msgid "Details for add-ons compatible with all versions:"
-msgstr "Докладна інформація для додатків, сумісних з усіма версіями:"
-
-#: src/olympia/compat/templates/compat/index.html:61
-msgid "Show previous version only"
-msgstr "Показати тільки попередню версію"
-
 #: src/olympia/compat/templates/compat/reporter.html:3
 msgid "Add-on Compatibility Reports"
 msgstr "Звіти сумісності додатку"
 
-#: src/olympia/compat/templates/compat/reporter.html:11
-#: src/olympia/compat/templates/compat/reporter_detail.html:35
+#: src/olympia/compat/templates/compat/reporter.html:11 src/olympia/compat/templates/compat/reporter_detail.html:35
 #, python-format
 msgid ""
-"<p> Reports submitted to us through the <a href=\"%(url_)s\">Add-on "
-"Compatibility Reporter</a> are collected here for developers to view. These "
-"reports help us determine which add-ons will need help supporting an "
-"upcoming Firefox version. </p>"
+"<p> Reports submitted to us through the <a href=\"%(url_)s\">Add-on Compatibility Reporter</a> are collected here for developers to view. These reports help us determine which add-ons will need "
+"help supporting an upcoming Firefox version. </p>"
 msgstr ""
-"<p> Звіти, що відправляються нам через <a href=\"%(url_)s\">Add-on "
-"Compatibility Reporter</a>, збираються тут для огляду розробниками. Ці звіти"
-" допомагають нам визначити, яким додаткам буде потрібна допомога по "
-"підтримці в майбутній версії Firefox. </p>"
+"<p> Звіти, що відправляються нам через <a href=\"%(url_)s\">Add-on Compatibility Reporter</a>, збираються тут для огляду розробниками. Ці звіти допомагають нам визначити, яким додаткам буде "
+"потрібна допомога по підтримці в майбутній версії Firefox. </p>"
 
 #: src/olympia/compat/templates/compat/reporter.html:18
 msgid "Reports for your Add-ons"
 msgstr "Звіти для ваших додатків"
 
-#: src/olympia/compat/templates/compat/reporter.html:30
-#: src/olympia/compat/templates/compat/reporter_detail.html:9
+#: src/olympia/compat/templates/compat/reporter.html:30 src/olympia/compat/templates/compat/reporter_detail.html:9
 msgid "Add-on Compatibility Center"
 msgstr "Центр сумісності додатку"
 
@@ -4017,9 +3123,7 @@ msgstr "Центр сумісності додатку"
 msgid "Enter the GUID of an add-on below to view any reports we've received."
 msgstr "Введіть GUID додатка внизу, щоб переглянути звіти, які ми отримали."
 
-#: src/olympia/compat/templates/compat/reporter_detail.html:3
-#: src/olympia/compat/templates/compat/reporter_detail.html:10
-#: src/olympia/compat/templates/compat/reporter_detail.html:25
+#: src/olympia/compat/templates/compat/reporter_detail.html:3 src/olympia/compat/templates/compat/reporter_detail.html:10 src/olympia/compat/templates/compat/reporter_detail.html:25
 msgid "{addon} Compatibility Reports"
 msgstr "Звіти сумісності {addon}"
 
@@ -4028,17 +3132,14 @@ msgid "{0} success report"
 msgid_plural "{0} success reports"
 msgstr[0] "{0} повідомлення про успіх"
 msgstr[1] "{0} повідомлення про успіх"
-msgstr[2] "{0} повідомлень про успіх"
 
 #: src/olympia/compat/templates/compat/reporter_detail.html:17
 msgid "{0} problem report"
 msgid_plural "{0} problem reports"
 msgstr[0] "{0} повідомлення про проблему"
 msgstr[1] "{0} повідомлення про проблему"
-msgstr[2] "{0} повідомлень про проблему"
 
-#: src/olympia/compat/templates/compat/reporter_detail.html:21
-#: src/olympia/users/templates/users/profile.html:70
+#: src/olympia/compat/templates/compat/reporter_detail.html:21 src/olympia/users/templates/users/profile.html:70
 msgid "View all"
 msgstr "Переглянути всі"
 
@@ -4050,10 +3151,8 @@ msgstr "Фільтр за додатком"
 msgid "Report Type"
 msgstr "Тип звіту"
 
-#: src/olympia/compat/templates/compat/reporter_detail.html:47
-#: src/olympia/devhub/forms.py:784
-#: src/olympia/devhub/templates/devhub/addons/ajax_compat_update.html:17
-#: src/olympia/editors/forms.py:108 src/olympia/zadmin/forms.py:45
+#: src/olympia/compat/templates/compat/reporter_detail.html:47 src/olympia/devhub/forms.py:785 src/olympia/devhub/templates/devhub/addons/ajax_compat_update.html:17 src/olympia/editors/forms.py:108
+#: src/olympia/editors/forms.py:248 src/olympia/zadmin/forms.py:45
 msgid "Application"
 msgstr "Програма"
 
@@ -4065,8 +3164,7 @@ msgstr "Збирання додатку"
 msgid "Platform"
 msgstr "Платформа"
 
-#: src/olympia/compat/templates/compat/reporter_detail.html:50
-#: src/olympia/editors/templates/editors/themes/themes.html:40
+#: src/olympia/compat/templates/compat/reporter_detail.html:50 src/olympia/editors/templates/editors/themes/themes.html:40
 msgid "Submitted"
 msgstr "Відправлено"
 
@@ -4094,8 +3192,7 @@ msgstr "Thunderbird"
 msgid "SeaMonkey"
 msgstr "SeaMonkey"
 
-#: src/olympia/constants/applications.py:75
-#: src/olympia/pages/templates/pages/sunbird.html:4
+#: src/olympia/constants/applications.py:75 src/olympia/pages/templates/pages/sunbird.html:4
 msgid "Sunbird"
 msgstr "Sunbird"
 
@@ -4143,7 +3240,7 @@ msgstr "Попередньо перевірено"
 msgid "Preliminarily Reviewed and Awaiting Full Review"
 msgstr "Попередньо перевірено та очікує повної перевірки"
 
-#: src/olympia/constants/base.py:33 src/olympia/editors/helpers.py:924
+#: src/olympia/constants/base.py:33 src/olympia/editors/forms.py:258 src/olympia/editors/helpers.py:73 src/olympia/editors/helpers.py:1004
 #: src/olympia/editors/templates/editors/themes/history_table.html:34
 msgid "Deleted"
 msgstr "Видалено"
@@ -4176,13 +3273,11 @@ msgstr "Розробник"
 msgid "Viewer"
 msgstr "Оглядач"
 
-#: src/olympia/constants/base.py:137
-#: src/olympia/templates/mobile/header.html:7
+#: src/olympia/constants/base.py:137 src/olympia/templates/mobile/header.html:7
 msgid "Support"
 msgstr "Підтримка"
 
-#: src/olympia/constants/base.py:159 src/olympia/constants/base.py:172
-#: src/olympia/constants/platforms.py:10
+#: src/olympia/constants/base.py:159 src/olympia/constants/base.py:172 src/olympia/constants/platforms.py:10
 msgid "Any"
 msgstr "Будь-який"
 
@@ -4210,11 +3305,8 @@ msgstr "Мовний пакет (Додаток)"
 msgid "Plugin"
 msgstr "Плагін"
 
-#: src/olympia/constants/base.py:167
-#: src/olympia/editors/templates/editors/includes/search_results_themes.html:5
-#: src/olympia/editors/templates/editors/themes/deleted.html:18
-#: src/olympia/editors/templates/editors/themes/history_table.html:8
-#: src/olympia/editors/templates/editors/themes/logs.html:17
+#: src/olympia/constants/base.py:167 src/olympia/editors/templates/editors/includes/search_results_themes.html:5 src/olympia/editors/templates/editors/themes/deleted.html:18
+#: src/olympia/editors/templates/editors/themes/history_table.html:8 src/olympia/editors/templates/editors/themes/logs.html:17
 msgid "Theme"
 msgstr "Тему"
 
@@ -4240,12 +3332,16 @@ msgstr "Запитувати лише на сторінці цього дода�
 
 #: src/olympia/constants/base.py:272
 msgid "Ask after users start downloading this add-on"
-msgstr ""
-"Запитати після того, як користувачі почнуть завантаження цього додатку"
+msgstr "Запитати після того, як користувачі почнуть завантаження цього додатку"
 
 #: src/olympia/constants/base.py:273
 msgid "Ask before users can download this add-on"
 msgstr "Запитати перед тим, як користувачі зможуть завантажити цей додаток"
+
+#. Review points sources other than add-ons and themes.
+#: src/olympia/constants/base.py:388 src/olympia/devhub/forms.py:162 src/olympia/editors/templates/editors/performance.html:75
+msgid "Other"
+msgstr "Інше"
 
 #: src/olympia/constants/base.py:389
 msgid "Exception"
@@ -4258,6 +3354,10 @@ msgstr "Випуск"
 #: src/olympia/constants/base.py:391
 msgid "Change"
 msgstr "Змінити"
+
+#: src/olympia/constants/base.py:401
+msgid "App"
+msgstr "Дод."
 
 #: src/olympia/constants/base.py:402
 msgid "Persona"
@@ -4395,32 +3495,23 @@ msgstr "Підписаний на повну перевірку"
 msgid "Signed of a preliminary review"
 msgstr "Підписаний на попередню перевірку"
 
-#: src/olympia/constants/editors.py:14
-#: src/olympia/editors/templates/editors/themes/queue.html:76
-#: src/olympia/editors/templates/editors/themes/themes.html:87
+#: src/olympia/constants/editors.py:14 src/olympia/editors/templates/editors/themes/queue.html:76 src/olympia/editors/templates/editors/themes/themes.html:87
 msgid "Request More Info"
 msgstr "Запитати більше інформації"
 
-#: src/olympia/constants/editors.py:15
-#: src/olympia/editors/templates/editors/themes/queue.html:74
-#: src/olympia/editors/templates/editors/themes/themes.html:91
+#: src/olympia/constants/editors.py:15 src/olympia/editors/templates/editors/themes/queue.html:74 src/olympia/editors/templates/editors/themes/themes.html:91
 msgid "Flag"
 msgstr "Прапорець"
 
-#: src/olympia/constants/editors.py:16
-#: src/olympia/editors/templates/editors/themes/queue.html:72
-#: src/olympia/editors/templates/editors/themes/themes.html:93
+#: src/olympia/constants/editors.py:16 src/olympia/editors/templates/editors/themes/queue.html:72 src/olympia/editors/templates/editors/themes/themes.html:93
 msgid "Duplicate"
 msgstr "Дублікат"
 
-#: src/olympia/constants/editors.py:17 src/olympia/editors/helpers.py:502
-#: src/olympia/editors/templates/editors/themes/queue.html:71
-#: src/olympia/editors/templates/editors/themes/themes.html:94
+#: src/olympia/constants/editors.py:17 src/olympia/editors/helpers.py:575 src/olympia/editors/templates/editors/themes/queue.html:71 src/olympia/editors/templates/editors/themes/themes.html:94
 msgid "Reject"
 msgstr "Відхилити"
 
-#: src/olympia/constants/editors.py:18
-#: src/olympia/editors/templates/editors/themes/queue.html:70
+#: src/olympia/constants/editors.py:18 src/olympia/editors/templates/editors/themes/queue.html:70
 msgid "Approve"
 msgstr "Схвалити"
 
@@ -4516,7 +3607,7 @@ msgstr "Solaris"
 msgid "Android"
 msgstr "Android"
 
-#: src/olympia/core/apps.py:19
+#: src/olympia/core/apps.py:21
 msgid "Core"
 msgstr "Ядро"
 
@@ -4553,9 +3644,7 @@ msgstr "Невірний об'єкт JSON"
 msgid "Message not eligible for annotation"
 msgstr "Повідомлення немає права на анотації"
 
-#: src/olympia/devhub/forms.py:124
-#: src/olympia/devhub/templates/devhub/versions/edit.html:94
-#: src/olympia/users/templates/users/edit.html:150
+#: src/olympia/devhub/forms.py:124 src/olympia/devhub/templates/devhub/versions/edit.html:94 src/olympia/users/templates/users/edit.html:150
 msgid "Details"
 msgstr "Подробиці"
 
@@ -4625,8 +3714,7 @@ msgstr "Не вдалося затвердити ідентифікатор PayP
 
 #: src/olympia/devhub/forms.py:388
 msgid "Unsupported file type, please upload an archive file {extensions}."
-msgstr ""
-"Непідтримуваний тип файлу, вивантажте будь ласка файл архіву (розширення)."
+msgstr "Непідтримуваний тип файлу, вивантажте будь ласка файл архіву (розширення)."
 
 #: src/olympia/devhub/forms.py:407
 msgid "View current"
@@ -4642,8 +3730,7 @@ msgstr "Потрібен, принаймні, один сумісний дода
 
 #: src/olympia/devhub/forms.py:501 src/olympia/devhub/forms.py:522
 msgid "There was an error with your upload. Please try again."
-msgstr ""
-"У процесі Вашого завантаження сталася помилка. Будь ласка, спробуйте знову."
+msgstr "У процесі Вашого завантаження сталася помилка. Будь ласка, спробуйте знову."
 
 #: src/olympia/devhub/forms.py:506
 msgid "Override failed validation"
@@ -4654,38 +3741,26 @@ msgid "Submit my add-on for manual review."
 msgstr "Подати мій додаток на ручну перевірку."
 
 #: src/olympia/devhub/forms.py:537
-msgid "Do not list my add-on on this site (beta)"
-msgstr "Не показувати мій додаток на цьому сайті (бета)"
+msgid "Do not list my add-on on this site"
+msgstr ""
 
 #: src/olympia/devhub/forms.py:538
-msgid ""
-"Check this option if you intend to distribute your add-on on your own and "
-"only need it to be signed by Mozilla."
-msgstr ""
-"Відмітьте цю опцію, якщо ви збираєтесь розповсюджувати свій додаток "
-"власноруч і потребуєте лише підпис Mozilla."
+msgid "Check this option if you intend to distribute your add-on on your own and only need it to be signed by Mozilla."
+msgstr "Відмітьте цю опцію, якщо ви збираєтесь розповсюджувати свій додаток власноруч і потребуєте лише підпис Mozilla."
 
 #: src/olympia/devhub/forms.py:544
 msgid "This add-on will be bundled with an application installer."
 msgstr "Цей додаток буде встановлено разом із основною програмою."
 
 #: src/olympia/devhub/forms.py:546
-msgid ""
-"Add-ons that are bundled with application installers will be code reviewed "
-"by Mozilla before they are signed and are held to a higher quality standard."
-msgstr ""
-"Код додатків, прив'язаних до інсталлятора, буде перевірено Mozilla перед їх "
-"підписом, та відповідатиме найвищим критеріям якості."
+msgid "Add-ons that are bundled with application installers will be code reviewed by Mozilla before they are signed and are held to a higher quality standard."
+msgstr "Код додатків, прив'язаних до інсталлятора, буде перевірено Mozilla перед їх підписом, та відповідатиме найвищим критеріям якості."
 
-#: src/olympia/devhub/forms.py:565
-#: src/olympia/devhub/templates/devhub/addons/submit/select-review.html:24
-#: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:42
+#: src/olympia/devhub/forms.py:565 src/olympia/devhub/templates/devhub/addons/submit/select-review.html:24 src/olympia/devhub/templates/devhub/docs/policies-reviews.html:42
 msgid "Full Review"
 msgstr "Повна перевірка"
 
-#: src/olympia/devhub/forms.py:566
-#: src/olympia/devhub/templates/devhub/addons/submit/select-review.html:47
-#: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:153
+#: src/olympia/devhub/forms.py:566 src/olympia/devhub/templates/devhub/addons/submit/select-review.html:47 src/olympia/devhub/templates/devhub/docs/policies-reviews.html:153
 msgid "Preliminary Review"
 msgstr "Попередня перевірка"
 
@@ -4694,65 +3769,51 @@ msgid "Please choose a review nomination type"
 msgstr "Будь ласка, оберіть тип номінації на перевірку"
 
 #: src/olympia/devhub/forms.py:574
-msgid ""
-"A file with a version ending with a|alpha|b|beta|pre|rc and an optional "
-"number is detected as beta."
-msgstr ""
-"Файл з версією, що закінчується на a|alpha|b|beta|pre|rc і необов'язковим "
-"числом, визначається як бета."
+msgid "A file with a version ending with a|alpha|b|beta|pre|rc and an optional number is detected as beta."
+msgstr "Файл з версією, що закінчується на a|alpha|b|beta|pre|rc і необов'язковим числом, визначається як бета."
 
 #: src/olympia/devhub/forms.py:592
 #, python-format
-msgid "Version %s already exists"
-msgstr "Версія %s вже існує"
+msgid "Version %s already exists, or was uploaded before."
+msgstr ""
 
-#: src/olympia/devhub/forms.py:604
-msgid ""
-"Select a valid choice. That choice is not one of the available choices."
+#: src/olympia/devhub/forms.py:605
+msgid "Select a valid choice. That choice is not one of the available choices."
 msgstr "Зробіть правильний вибір. Цей вибір не є одним з доступних варіантів."
 
-#: src/olympia/devhub/forms.py:610
-msgid ""
-"A file with a version ending with a|alpha|b|beta and an optional number is "
-"detected as beta."
-msgstr ""
-"Файл з версією, що закінчується на a|alpha|b|beta і необов'язкове число, "
-"визначається як бета."
+#: src/olympia/devhub/forms.py:611
+msgid "A file with a version ending with a|alpha|b|beta and an optional number is detected as beta."
+msgstr "Файл з версією, що закінчується на a|alpha|b|beta і необов'язкове число, визначається як бета."
 
-#: src/olympia/devhub/forms.py:633
+#: src/olympia/devhub/forms.py:634
 msgid "You cannot upload any more files for this version."
 msgstr "Ви більше не можете вивантажувати файли для цієї версії."
 
-#: src/olympia/devhub/forms.py:639
+#: src/olympia/devhub/forms.py:640
 msgid "Version doesn't match"
 msgstr "Версія не підходить"
 
-#: src/olympia/devhub/forms.py:668
-msgid ""
-"You cannot delete a file once the review process has started.  You must "
-"delete the whole version."
-msgstr ""
-"Ви не можете видалити файл, якщо почався процес перевірки.  Ви повинні "
-"видалити повністю всю версію."
+#: src/olympia/devhub/forms.py:669
+msgid "You cannot delete a file once the review process has started. You must delete the whole version."
+msgstr "Ви не можете видалити файл, якщо почався процес перевірки. Ви повинні видалити повністю всю версію."
 
-#: src/olympia/devhub/forms.py:688
+#: src/olympia/devhub/forms.py:689
 msgid "The platform All cannot be combined with specific platforms."
 msgstr "Платформа Все не може бути об'єднана з конкретними платформами."
 
-#: src/olympia/devhub/forms.py:693
+#: src/olympia/devhub/forms.py:694
 msgid "A platform can only be chosen once."
 msgstr "Платформа може бути вибрана тільки один раз."
 
-#: src/olympia/devhub/forms.py:706
+#: src/olympia/devhub/forms.py:707
 msgid "A review type must be selected."
 msgstr "Повинен бути вибраний тип перевірки."
 
-#: src/olympia/devhub/forms.py:788 src/olympia/editors/forms.py:114
-#: src/olympia/zadmin/forms.py:49 src/olympia/zadmin/forms.py:52
+#: src/olympia/devhub/forms.py:789 src/olympia/editors/forms.py:114 src/olympia/editors/forms.py:254 src/olympia/zadmin/forms.py:49 src/olympia/zadmin/forms.py:52
 msgid "Select an application first"
 msgstr "Спочатку оберіть програму"
 
-#: src/olympia/devhub/forms.py:840
+#: src/olympia/devhub/forms.py:841
 msgid "There cannot be more than 3 required add-ons."
 msgstr "Кількість необхідних додатків не може перевищувати 3."
 
@@ -4774,7 +3835,6 @@ msgid "{0} error"
 msgid_plural "{0} errors"
 msgstr[0] "{0} помилка"
 msgstr[1] "{0} помилки"
-msgstr[2] "{0} помилок"
 
 #. L10n: first parameter is the number of warnings
 #: src/olympia/devhub/helpers.py:203
@@ -4782,198 +3842,173 @@ msgid "{0} warning"
 msgid_plural "{0} warnings"
 msgstr[0] "{0} попередження"
 msgstr[1] "{0} попередження"
-msgstr[2] "{0} попереджень"
 
-#: src/olympia/devhub/models.py:375
-#: src/olympia/reviews/templates/reviews/add.html:58
+#: src/olympia/devhub/models.py:375 src/olympia/reviews/templates/reviews/add.html:58
 msgid "Review"
 msgstr "Відгук"
 
-#: src/olympia/devhub/tasks.py:551
+#: src/olympia/devhub/tasks.py:583
 #, python-format
 msgid "%s responded with %s (%s)."
 msgstr "%s відповів з %s (%s)."
 
-#: src/olympia/devhub/tasks.py:555
+#: src/olympia/devhub/tasks.py:587
 #, python-format
 msgid "Connection to \"%s\" timed out."
 msgstr "Час очікування з'єднання з \"%s\" завершився."
 
-#: src/olympia/devhub/tasks.py:557
+#: src/olympia/devhub/tasks.py:589
 #, python-format
 msgid "Could not contact host at \"%s\"."
 msgstr "Не вдалося зв'язатись з хостом на \"%s\"."
 
-#: src/olympia/devhub/utils.py:104
+#: src/olympia/devhub/utils.py:105
 #, python-format
-msgid ""
-"Validation generated too many errors/warnings so %s messages were truncated."
-" After addressing the visible messages, you'll be able to see the others."
-msgstr ""
-"Валідація згенерувала занадто багато помилок та попереджень, тому %s "
-"повідомлень не було відображено. Після усунення видимих повідомлень, Ви "
-"зможете побачити інші."
+msgid "Validation generated too many errors/warnings so %s messages were truncated. After addressing the visible messages, you'll be able to see the others."
+msgstr "Валідація згенерувала занадто багато помилок та попереджень, тому %s повідомлень не було відображено. Після усунення видимих повідомлень, Ви зможете побачити інші."
 
-#: src/olympia/devhub/views.py:183
+#: src/olympia/devhub/views.py:182
 msgid "All My Add-ons"
 msgstr "Всі мої додатки"
 
-#: src/olympia/devhub/views.py:210
+#: src/olympia/devhub/views.py:209
 msgid "All Activity"
 msgstr "Вся активність"
 
-#: src/olympia/devhub/views.py:211
+#: src/olympia/devhub/views.py:210
 msgid "Add-on Updates"
 msgstr "Оновлення додатку"
 
-#: src/olympia/devhub/views.py:212
+#: src/olympia/devhub/views.py:211
 msgid "Add-on Status"
 msgstr "Статус додатку"
 
-#: src/olympia/devhub/views.py:213
+#: src/olympia/devhub/views.py:212
 msgid "User Collections"
 msgstr "Збірки користувача"
 
-#: src/olympia/devhub/views.py:214
-#: src/olympia/devhub/templates/devhub/docs/policies-maintenance.html:68
-#: src/olympia/pages/templates/pages/dev_faq.html:38
+#: src/olympia/devhub/views.py:213 src/olympia/devhub/templates/devhub/docs/policies-maintenance.html:68 src/olympia/pages/templates/pages/dev_faq.html:38
 #: src/olympia/pages/templates/pages/dev_faq.html:484
 msgid "User Reviews"
 msgstr "Відгуки користувачів"
 
-#: src/olympia/devhub/views.py:327 src/olympia/devhub/views.py:331
-#: src/olympia/devhub/views.py:484 src/olympia/devhub/views.py:513
-#: src/olympia/devhub/views.py:564 src/olympia/devhub/views.py:1150
+#: src/olympia/devhub/views.py:326 src/olympia/devhub/views.py:330 src/olympia/devhub/views.py:485 src/olympia/devhub/views.py:514 src/olympia/devhub/views.py:565 src/olympia/devhub/views.py:1157
 msgid "Changes successfully saved."
 msgstr "Зміни успішно збережені."
 
-#: src/olympia/devhub/views.py:334 src/olympia/devhub/views.py:1631
+#: src/olympia/devhub/views.py:333 src/olympia/devhub/views.py:1638
 msgid "Please check the form for errors."
 msgstr "Перевірте форму на наявність помилок."
 
-#: src/olympia/devhub/views.py:346
+#: src/olympia/devhub/views.py:345
 msgid "Add-on cannot be deleted. Disable this add-on instead."
 msgstr "Додаток неможливо видалити. Натомість відключіть його."
 
-#: src/olympia/devhub/views.py:356
+#: src/olympia/devhub/views.py:355
 msgid "Theme deleted."
 msgstr "Тема видалена."
 
-#: src/olympia/devhub/views.py:356
+#: src/olympia/devhub/views.py:355
 msgid "Add-on deleted."
 msgstr "Додаток видалений."
 
-#: src/olympia/devhub/views.py:362
+#: src/olympia/devhub/views.py:361
 msgid "URL name was incorrect. Theme was not deleted."
 msgstr "Неправильна назва URL. Тема не була видалена."
 
-#: src/olympia/devhub/views.py:367
+#: src/olympia/devhub/views.py:366
 msgid "URL name was incorrect. Add-on was not deleted."
 msgstr "Неправильна назва URL. Додаток не був видалений."
 
-#: src/olympia/devhub/views.py:449
+#: src/olympia/devhub/views.py:450
 msgid "An author has been added to your add-on"
 msgstr "До Вашого додатку був доданий автор"
 
-#: src/olympia/devhub/views.py:456
+#: src/olympia/devhub/views.py:457
 msgid "An author has a role changed on your add-on"
 msgstr "Автор змінив роль у Вашому додатку"
 
-#: src/olympia/devhub/views.py:476
+#: src/olympia/devhub/views.py:477
 msgid "An author has been removed from your add-on"
 msgstr "Із Вашого додатку був видалений автор"
 
-#: src/olympia/devhub/views.py:519
+#: src/olympia/devhub/views.py:520
 msgid "There were errors in your submission."
 msgstr "У Вашому представленні були помилки."
 
-#: src/olympia/devhub/views.py:583
+#: src/olympia/devhub/views.py:584
 msgid "Validate Add-on"
 msgstr "Валідувати додаток"
 
-#: src/olympia/devhub/views.py:594
+#: src/olympia/devhub/views.py:595
 msgid "Check Add-on Compatibility"
 msgstr "Перевірка сумісності додатку"
 
-#: src/olympia/devhub/views.py:808 src/olympia/signing/views.py:90
+#: src/olympia/devhub/views.py:809 src/olympia/signing/views.py:95
 msgid "You cannot submit this type of add-on"
 msgstr "Не можна подавати додаток такого типу"
 
-#: src/olympia/devhub/views.py:1051 src/olympia/users/forms.py:471
+#: src/olympia/devhub/views.py:1052 src/olympia/users/forms.py:471
 msgid "Images must be either PNG or JPG."
 msgstr "Зображення повинні бути у форматі PNG чи JPG."
 
-#: src/olympia/devhub/views.py:1055
+#: src/olympia/devhub/views.py:1056
 msgid "Icons cannot be animated."
 msgstr "Іконки не можуть бути з анімацією."
 
-#: src/olympia/devhub/views.py:1057
+#: src/olympia/devhub/views.py:1058
 msgid "Images cannot be animated."
 msgstr "Зображення не можуть бути з анімацією."
 
-#: src/olympia/devhub/views.py:1070
+#: src/olympia/devhub/views.py:1071
 #, python-format
 msgid "Images cannot be larger than %dKB."
 msgstr "Зображення не можуть перевищувати розмір %dKB."
 
 #. L10n: {0} is an image width (in pixels), {1} is a height.
-#: src/olympia/devhub/views.py:1080
+#: src/olympia/devhub/views.py:1081
 msgid "Image must be exactly {0} pixels wide and {1} pixels tall."
-msgstr ""
-"Зображення повинно бути точно {0} пікселів завширшки та {1} пікселів "
-"заввишки."
+msgstr "Зображення повинно бути точно {0} пікселів завширшки та {1} пікселів заввишки."
 
-#: src/olympia/devhub/views.py:1087
+#: src/olympia/devhub/views.py:1088
 msgid "There was an error uploading your preview."
 msgstr "При вивантаженні вашого попереднього перегляду сталася помилка."
 
-#: src/olympia/devhub/views.py:1189
+#: src/olympia/devhub/views.py:1196
 #, python-format
 msgid "Version %s disabled."
 msgstr "Версію %s відключено."
 
-#: src/olympia/devhub/views.py:1193
+#: src/olympia/devhub/views.py:1200
 #, python-format
 msgid "Version %s deleted."
 msgstr "Версію %s видалено."
 
-#: src/olympia/devhub/views.py:1203
-msgid ""
-"This upload has failed validation, and may lack complete validation results."
-" Please take due care when reviewing it."
-msgstr ""
-"Це завантаження не пройшло валідацію і у ньому можуть бути відсутніми деякі "
-"результати повної валідації. Будь ласка, будьте уважні при його перевірці."
+#: src/olympia/devhub/views.py:1210
+msgid "This upload has failed validation, and may lack complete validation results. Please take due care when reviewing it."
+msgstr "Це завантаження не пройшло валідацію і у ньому можуть бути відсутніми деякі результати повної валідації. Будь ласка, будьте уважні при його перевірці."
 
-#: src/olympia/devhub/views.py:1677
+#: src/olympia/devhub/views.py:1684
 msgid "Preliminary Review Requested."
 msgstr "Запитана попередня перевірка."
 
-#: src/olympia/devhub/views.py:1678
+#: src/olympia/devhub/views.py:1685
 msgid "Full Review Requested."
 msgstr "Запитана повна перевірка."
 
-#: src/olympia/devhub/views.py:1779
-msgid ""
-"Your old credentials were revoked and are no longer valid. Be sure to update"
-" all API clients with the new credentials."
-msgstr ""
-"Ваші старі облікові дані були відкликані й більше недійсні. Переконайтеся, "
-"що всі клієнти API мають нові облікові дані."
+#: src/olympia/devhub/views.py:1786
+msgid "Your old credentials were revoked and are no longer valid. Be sure to update all API clients with the new credentials."
+msgstr "Ваші старі облікові дані були відкликані й більше недійсні. Переконайтеся, що всі клієнти API мають нові облікові дані."
 
-#: src/olympia/devhub/views.py:1797
+#: src/olympia/devhub/views.py:1804
 msgid "New API key created"
 msgstr "Новий ключ API створено"
 
 #: src/olympia/devhub/templates/devhub/agreement.html:2
-msgid ""
-"Before starting, please read and accept our Firefox Add-on Distribution "
-"Agreement. It also links to our Privacy Notice which explains how we handle "
-"your information."
+msgid "Before starting, please read and accept our Firefox Add-on Distribution Agreement. It also links to our Privacy Notice which explains how we handle your information."
 msgstr ""
-"Перед початком, будь ласка, прочитайте та погодьтеся з умовами нашої угоди "
-"розповсюдження додатків Firefox. Вона також посилається на наше повідомлення"
-" про приватність, в якому пояснюється як ми обробляємо вашу інформацію."
+"Перед початком, будь ласка, прочитайте та погодьтеся з умовами нашої угоди розповсюдження додатків Firefox. Вона також посилається на наше повідомлення про приватність, в якому пояснюється як ми "
+"обробляємо вашу інформацію."
 
 #: src/olympia/devhub/templates/devhub/agreement.html:13
 msgid "Printable Version"
@@ -4987,44 +4022,30 @@ msgstr "Я приймаю цю угоду"
 msgid "or <a href=\"{0}\">Cancel</a>"
 msgstr "чи<a href=\"{0}\">Скасувати</a>"
 
-#: src/olympia/devhub/templates/devhub/base.html:23
-#: src/olympia/devhub/templates/devhub/base_impala.html:20
-#: src/olympia/discovery/templates/discovery/addons/base.html:17
+#: src/olympia/devhub/templates/devhub/base.html:23 src/olympia/devhub/templates/devhub/base_impala.html:20 src/olympia/discovery/templates/discovery/addons/base.html:17
 msgid "Back to Add-ons"
 msgstr "Назад до додатків"
 
 #. {0} is a search term, such as Firebug.
 #. {0} is a search query.
-#: src/olympia/devhub/templates/devhub/devhub_search.html:4
-#: src/olympia/search/templates/search/results.html:9
-#: src/olympia/search/templates/search/mobile/results.html:6
+#: src/olympia/devhub/templates/devhub/devhub_search.html:4 src/olympia/search/templates/search/results.html:9 src/olympia/search/templates/search/mobile/results.html:6
 msgid "{0} :: Search"
 msgstr "{0} :: Пошук"
 
-#: src/olympia/devhub/templates/devhub/devhub_search.html:6
-#: src/olympia/devhub/templates/devhub/search.html:8
-#: src/olympia/editors/forms.py:435 src/olympia/editors/forms.py:437
-#: src/olympia/editors/templates/editors/queue.html:27
-#: src/olympia/editors/templates/editors/themes/queue_list.html:14
-#: src/olympia/search/templates/search/collections.html:17
-#: src/olympia/search/templates/search/personas.html:18
-#: src/olympia/search/templates/search/results.html:18
-#: src/olympia/search/templates/search/mobile/results.html:8
-#: src/olympia/templates/search.html:14
+#: src/olympia/devhub/templates/devhub/devhub_search.html:6 src/olympia/devhub/templates/devhub/search.html:8 src/olympia/editors/forms.py:534 src/olympia/editors/forms.py:536
+#: src/olympia/editors/templates/editors/queue.html:27 src/olympia/editors/templates/editors/themes/queue_list.html:14 src/olympia/search/templates/search/collections.html:17
+#: src/olympia/search/templates/search/personas.html:18 src/olympia/search/templates/search/results.html:18 src/olympia/search/templates/search/mobile/results.html:8 src/olympia/templates/search.html:14
 #: src/olympia/templates/impala/search.html:18
 msgid "Search"
 msgstr "Пошук"
 
-#: src/olympia/devhub/templates/devhub/devhub_search.html:11
-#: src/olympia/devhub/templates/devhub/devhub_search.html:15
-#: src/olympia/search/templates/search/collections.html:18
+#: src/olympia/devhub/templates/devhub/devhub_search.html:11 src/olympia/devhub/templates/devhub/devhub_search.html:15 src/olympia/search/templates/search/collections.html:18
 #: src/olympia/search/templates/search/personas.html:20
 msgid "Search Results"
 msgstr "Результати пошуку"
 
 #. {0} is a search term, such as Firebug.
-#: src/olympia/devhub/templates/devhub/devhub_search.html:13
-#: src/olympia/search/templates/search/results.html:11
+#: src/olympia/devhub/templates/devhub/devhub_search.html:13 src/olympia/search/templates/search/results.html:11
 msgid "Search Results for \"{0}\""
 msgstr "Результати пошуку для \"{0}\""
 
@@ -5045,12 +4066,8 @@ msgid "AMO Reviewers"
 msgstr "Рецензенти AMO"
 
 #: src/olympia/devhub/templates/devhub/index.html:29
-msgid ""
-"Get ahead! Become an AMO Reviewer today and get your add-ons reviewed "
-"faster."
-msgstr ""
-"Будьте попереду! Ставайте рецензентом AMO сьогодні та прискорюйте перевірку "
-"Ваших додатків."
+msgid "Get ahead! Become an AMO Reviewer today and get your add-ons reviewed faster."
+msgstr "Будьте попереду! Ставайте рецензентом AMO сьогодні та прискорюйте перевірку Ваших додатків."
 
 #: src/olympia/devhub/templates/devhub/index.html:32
 msgid "Become an AMO Reviewer"
@@ -5062,42 +4079,28 @@ msgstr "Дізнайтесь все про додатки"
 
 #: src/olympia/devhub/templates/devhub/index.html:41
 msgid ""
-"Add-ons let millions of Firefox users enhance and customize their browsing "
-"experience. If you're a Web developer and know <a "
-"href=\"https://developer.mozilla.org/docs/Web/HTML\">HTML</a>, <a "
-"href=\"https://developer.mozilla.org/docs/Web/JavaScript\">JavaScript</a>, "
-"and <a href=\"https://developer.mozilla.org/docs/Web/CSS\">CSS</a>, you "
-"already have all the necessary skills to make a great add-on."
+"Add-ons let millions of Firefox users enhance and customize their browsing experience. If you're a Web developer and know <a href=\"https://developer.mozilla.org/docs/Web/HTML\">HTML</a>, <a "
+"href=\"https://developer.mozilla.org/docs/Web/JavaScript\">JavaScript</a>, and <a href=\"https://developer.mozilla.org/docs/Web/CSS\">CSS</a>, you already have all the necessary skills to make a "
+"great add-on."
 msgstr ""
-"Додатки дозволяють мільйонам користувачів Firefox розширювати та "
-"налаштовувати своє середовище для роботи в мережі Інтернет. Якщо Ви веб-"
-"розробник і знаєте <a "
-"href=\"https://developer.mozilla.org/docs/Web/HTML\">HTML</a>, <a "
-"href=\"https://developer.mozilla.org/docs/Web/JavaScript\">JavaScript</a> і "
-"<a href=\"https://developer.mozilla.org/docs/Web/CSS\">CSS</a>, у Вас вже є "
-"всі необхідні навички, щоб створити чудовий додаток."
+"Додатки дозволяють мільйонам користувачів Firefox розширювати та налаштовувати своє середовище для роботи в мережі Інтернет. Якщо Ви веб-розробник і знаєте <a "
+"href=\"https://developer.mozilla.org/docs/Web/HTML\">HTML</a>, <a href=\"https://developer.mozilla.org/docs/Web/JavaScript\">JavaScript</a> і <a "
+"href=\"https://developer.mozilla.org/docs/Web/CSS\">CSS</a>, у Вас вже є всі необхідні навички, щоб створити чудовий додаток."
 
 #: src/olympia/devhub/templates/devhub/index.html:51
-msgid ""
-"Head over to the <a href=\"https://developer.mozilla.org/Add-ons\">Mozilla "
-"Developer Network</a> to learn everything you need to know to get started."
-msgstr ""
-"Зайдіть в <a href=\"https://developer.mozilla.org/Add-ons\">Мережа "
-"розробників Mozilla</a>, щоб дізнатись все необхідне для початку роботи."
+msgid "Head over to the <a href=\"https://developer.mozilla.org/Add-ons\">Mozilla Developer Network</a> to learn everything you need to know to get started."
+msgstr "Зайдіть в <a href=\"https://developer.mozilla.org/Add-ons\">Мережа розробників Mozilla</a>, щоб дізнатись все необхідне для початку роботи."
 
 #: src/olympia/devhub/templates/devhub/index.html:58
 msgid "Start Making Add-ons"
 msgstr "Почати створювати додатки"
 
-#: src/olympia/devhub/templates/devhub/index.html:86
-#: src/olympia/devhub/templates/devhub/addons/listing/items.html:25
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:15
+#: src/olympia/devhub/templates/devhub/index.html:86 src/olympia/devhub/templates/devhub/addons/listing/items.html:25 src/olympia/devhub/templates/devhub/includes/addon_details.html:20
 #: src/olympia/devhub/templates/devhub/personas/edit.html:43
 msgid "Status:"
 msgstr "Статус:"
 
-#: src/olympia/devhub/templates/devhub/index.html:90
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:100
+#: src/olympia/devhub/templates/devhub/index.html:90 src/olympia/devhub/templates/devhub/includes/addon_details.html:87
 msgid "Visibility:"
 msgstr "Видимість:"
 
@@ -5105,21 +4108,16 @@ msgstr "Видимість:"
 msgid "Latest Version:"
 msgstr "Остання версія:"
 
-#: src/olympia/devhub/templates/devhub/index.html:109
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:145
-#: src/olympia/devhub/templates/devhub/personas/edit.html:49
+#: src/olympia/devhub/templates/devhub/index.html:109 src/olympia/devhub/templates/devhub/includes/addon_details.html:131 src/olympia/devhub/templates/devhub/personas/edit.html:49
 msgid "Queue Position:"
 msgstr "Позиція в черзі:"
 
-#: src/olympia/devhub/templates/devhub/index.html:110
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:146
-#: src/olympia/devhub/templates/devhub/personas/edit.html:50
+#: src/olympia/devhub/templates/devhub/index.html:110 src/olympia/devhub/templates/devhub/includes/addon_details.html:132 src/olympia/devhub/templates/devhub/personas/edit.html:50
 #, python-format
 msgid "%(position)s of %(total)s"
 msgstr "%(position)s з %(total)s"
 
-#: src/olympia/devhub/templates/devhub/index.html:120
-#: src/olympia/devhub/templates/devhub/includes/addons_edit_nav.html:19
+#: src/olympia/devhub/templates/devhub/index.html:120 src/olympia/devhub/templates/devhub/includes/addons_edit_nav.html:19
 msgid "Upload New Version"
 msgstr "Вивантажити нову версію"
 
@@ -5133,12 +4131,8 @@ msgstr "Публікуйте Ваші додатки!"
 
 #: src/olympia/devhub/templates/devhub/index.html:136
 #, python-format
-msgid ""
-"Upload an <a href=\"%(addon_url)s\">add-on</a> or <a "
-"href=\"%(theme_url)s\">theme</a> to get started!"
-msgstr ""
-"Щоб почати, завантажте <a href=\"%(addon_url)s\">додаток</a> або <a "
-"href=\"%(theme_url)s\">тему</a>!"
+msgid "Upload an <a href=\"%(addon_url)s\">add-on</a> or <a href=\"%(theme_url)s\">theme</a> to get started!"
+msgstr "Щоб почати, завантажте <a href=\"%(addon_url)s\">додаток</a> або <a href=\"%(theme_url)s\">тему</a>!"
 
 #: src/olympia/devhub/templates/devhub/nav.html:2
 msgid "Return to the DevHub homepage"
@@ -5165,17 +4159,10 @@ msgstr "Розробка розширення"
 msgid "Lightweight Themes"
 msgstr "Легкі теми"
 
-#: src/olympia/devhub/templates/devhub/nav.html:39
-#: src/olympia/devhub/templates/devhub/docs/policies-agreement.html:6
-#: src/olympia/devhub/templates/devhub/docs/policies-contact.html:6
-#: src/olympia/devhub/templates/devhub/docs/policies-maintenance.html:6
-#: src/olympia/devhub/templates/devhub/docs/policies-recommended.html:6
-#: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:6
-#: src/olympia/devhub/templates/devhub/docs/policies-submission.html:6
-#: src/olympia/devhub/templates/devhub/docs/policies.html:3
-#: src/olympia/devhub/templates/devhub/docs/policies.html:9
-#: src/olympia/devhub/templates/devhub/docs/policies.html:38
-#: src/olympia/devhub/templates/devhub/docs/policies.html:39
+#: src/olympia/devhub/templates/devhub/nav.html:39 src/olympia/devhub/templates/devhub/docs/policies-agreement.html:6 src/olympia/devhub/templates/devhub/docs/policies-contact.html:6
+#: src/olympia/devhub/templates/devhub/docs/policies-maintenance.html:6 src/olympia/devhub/templates/devhub/docs/policies-recommended.html:6
+#: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:6 src/olympia/devhub/templates/devhub/docs/policies-submission.html:6 src/olympia/devhub/templates/devhub/docs/policies.html:3
+#: src/olympia/devhub/templates/devhub/docs/policies.html:9 src/olympia/devhub/templates/devhub/docs/policies.html:38 src/olympia/devhub/templates/devhub/docs/policies.html:39
 msgid "Add-on Policies"
 msgstr "Правила додатків"
 
@@ -5213,50 +4200,19 @@ msgstr "Пошук документації для розробників"
 
 #: src/olympia/devhub/templates/devhub/validate_addon.html:13
 msgid "Use the field below to upload your add-on package."
-msgstr ""
-"Використовуйте розташоване нижче поле, щоб завантажити свій пакет додатку."
+msgstr "Використовуйте розташоване нижче поле, щоб завантажити свій пакет додатку."
 
 #: src/olympia/devhub/templates/devhub/validate_addon.html:19
-msgid ""
-"After upload, a series of automated validation tests will run to check "
-"compatibility with the following application version:"
-msgstr ""
-"Після завантаження буде запущена серія автоматичних валідуючих тестів, які "
-"перевірять сумісність із наступною версією програми:"
+msgid "After upload, a series of automated validation tests will run to check compatibility with the following application version:"
+msgstr "Після завантаження буде запущена серія автоматичних валідуючих тестів, які перевірять сумісність із наступною версією програми:"
 
 #: src/olympia/devhub/templates/devhub/validate_addon.html:34
-msgid ""
-"After upload, a series of automated validation tests will be run on your "
-"file."
-msgstr ""
-"Після завантаження, над Вашим файлом буде проведена серія автоматичних "
-"валідуючих тестів."
+msgid "After upload, a series of automated validation tests will be run on your file."
+msgstr "Після завантаження, над Вашим файлом буде проведена серія автоматичних валідуючих тестів."
 
-#: src/olympia/devhub/templates/devhub/validate_addon.html:42
-#: src/olympia/devhub/templates/devhub/addons/submit/upload.html:23
+#: src/olympia/devhub/templates/devhub/validate_addon.html:42 src/olympia/devhub/templates/devhub/addons/submit/upload.html:23
 msgid "Do you want your add-on to be distributed on this site?"
 msgstr "Ви хочете розповсюджувати свій додаток на цьому сайті?"
-
-#: src/olympia/devhub/templates/devhub/validate_addon.html:49
-#: src/olympia/devhub/templates/devhub/addons/submit/upload.html:30
-#: src/olympia/devhub/templates/devhub/versions/add_file_modal.html:14
-#: src/olympia/devhub/templates/devhub/versions/add_file_modal.html:53
-#: src/olympia/devhub/templates/devhub/versions/list.html:298
-msgid "Warning:"
-msgstr "Попередження:"
-
-#: src/olympia/devhub/templates/devhub/validate_addon.html:50
-#: src/olympia/devhub/templates/devhub/addons/submit/upload.html:31
-#, python-format
-msgid ""
-"Submission of unlisted add-ons for signing is currently in an open beta. "
-"Please <a href=\"%(url)s\" target=\"_blank\">report any bugs</a> that you "
-"encounter."
-msgstr ""
-"Функція подання неопублікованих додатків на підписання в даний момент "
-"знаходиться у відкритому бета-тестуванні. Будь ласка, <a href=\"%(url)s\" "
-"target=\"_blank\">повідомляйте про будь-які помилки</a>, з якими ви "
-"стикаєтесь."
 
 #. first parameter is a filename like lorem-ipsum-1.0.2.xpi
 #: src/olympia/devhub/templates/devhub/validation.html:5
@@ -5275,14 +4231,11 @@ msgstr "Валідовано:"
 msgid "Tested for compatibility against:"
 msgstr "Протестовано на сумісність на:"
 
-#: src/olympia/devhub/templates/devhub/addons/activity.html:4
-#: src/olympia/devhub/templates/devhub/addons/activity.html:20
+#: src/olympia/devhub/templates/devhub/addons/activity.html:4 src/olympia/devhub/templates/devhub/addons/activity.html:20
 msgid "Recent Activity for My Add-ons"
 msgstr "Нещодавня активність для моїх додатків"
 
-#: src/olympia/devhub/templates/devhub/addons/activity.html:14
-#: src/olympia/devhub/templates/devhub/addons/activity.html:19
-#: src/olympia/devhub/templates/devhub/addons/dashboard.html:33
+#: src/olympia/devhub/templates/devhub/addons/activity.html:14 src/olympia/devhub/templates/devhub/addons/activity.html:19 src/olympia/devhub/templates/devhub/addons/dashboard.html:33
 msgid "Recent Activity"
 msgstr "Нещодавня активність"
 
@@ -5304,45 +4257,34 @@ msgstr "Уточнити активність"
 msgid "Activity"
 msgstr "Активність"
 
-#: src/olympia/devhub/templates/devhub/addons/activity.html:83
-#: src/olympia/devhub/templates/devhub/addons/dashboard.html:34
-#: src/olympia/devhub/templates/devhub/addons/dashboard.html:35
-#: src/olympia/devhub/templates/devhub/includes/blog_posts.html:4
-#: src/olympia/devhub/templates/devhub/includes/blog_posts.html:6
+#: src/olympia/devhub/templates/devhub/addons/activity.html:83 src/olympia/devhub/templates/devhub/addons/dashboard.html:34 src/olympia/devhub/templates/devhub/addons/dashboard.html:35
+#: src/olympia/devhub/templates/devhub/includes/blog_posts.html:4 src/olympia/devhub/templates/devhub/includes/blog_posts.html:6
 msgid "Subscribe to this feed"
 msgstr "Підписатись на цю стрічку"
 
 #: src/olympia/devhub/templates/devhub/addons/ajax_compat_error.html:7
 #, python-format
 msgid ""
-"This add-on is incompatible with <b>%(app_name)s %(app_version)s</b>, the "
-"latest release of %(app_name)s. Please consider updating your add-on's "
-"compatibility info, or uploading a newer version of this add-on."
+"This add-on is incompatible with <b>%(app_name)s %(app_version)s</b>, the latest release of %(app_name)s. Please consider updating your add-on's compatibility info, or uploading a newer version of "
+"this add-on."
 msgstr ""
-"Цей додаток несумісний з <b>%(app_name)s %(app_version)s</b>, останньою "
-"версією %(app_name)s. Будь ласка, розгляньте питання щодо оновлення "
-"інформації про сумісність Вашого додатку чи завантаження нової версії цього "
-"додатку."
+"Цей додаток несумісний з <b>%(app_name)s %(app_version)s</b>, останньою версією %(app_name)s. Будь ласка, розгляньте питання щодо оновлення інформації про сумісність Вашого додатку чи завантаження "
+"нової версії цього додатку."
 
 #: src/olympia/devhub/templates/devhub/addons/ajax_compat_error.html:15
 #, python-format
 msgid ""
-"<a href=\"#\" class=\"button compat-update\" data-"
-"updateurl=\"%(update_url)s\">Update Compatibility</a> <a "
-"href=\"%(version_url)s\" class=\"button\">Upload New Version</a> or <a "
-"href=\"#\" class=\"close\">Ignore</a>"
+"<a href=\"#\" class=\"button compat-update\" data-updateurl=\"%(update_url)s\">Update Compatibility</a> <a href=\"%(version_url)s\" class=\"button\">Upload New Version</a> or <a href=\"#\" "
+"class=\"close\">Ignore</a>"
 msgstr ""
-"<a href=\"#\" class=\"button compat-update\" data-"
-"updateurl=\"%(update_url)s\">Оновити сумісність</a> <a "
-"href=\"%(version_url)s\" class=\"button\">Завантажити нову версію</a> або <a"
-" href=\"#\" class=\"close\">Ігнорувати</a>"
+"<a href=\"#\" class=\"button compat-update\" data-updateurl=\"%(update_url)s\">Оновити сумісність</a> <a href=\"%(version_url)s\" class=\"button\">Завантажити нову версію</a> або <a href=\"#\" "
+"class=\"close\">Ігнорувати</a>"
 
 #: src/olympia/devhub/templates/devhub/addons/ajax_compat_status.html:5
 msgid "View and update application compatibility ranges."
 msgstr "Переглянути та оновити діапазони сумісності додатків."
 
-#: src/olympia/devhub/templates/devhub/addons/ajax_compat_status.html:6
-#: src/olympia/devhub/templates/devhub/versions/edit.html:44
+#: src/olympia/devhub/templates/devhub/addons/ajax_compat_status.html:6 src/olympia/devhub/templates/devhub/versions/edit.html:44
 msgid "Compatibility"
 msgstr "Сумісність"
 
@@ -5350,39 +4292,25 @@ msgstr "Сумісність"
 msgid "Update Compatibility"
 msgstr "Оновити сумісність"
 
-#: src/olympia/devhub/templates/devhub/addons/ajax_compat_update.html:4
-msgid ""
-"Adjusting application information here will allow users to install your add-"
-"on even if the install manifest in the package indicates that the add-on is "
-"incompatible."
-msgstr ""
-"Налаштування інформації про програму тут, дозволить користувачам встановити "
-"Ваш додаток, навіть якщо маніфест встановлення в пакеті вказує, що додаток є"
-" несумісним."
+#: src/olympia/devhub/templates/devhub/addons/ajax_compat_update.html:4 src/olympia/devhub/templates/devhub/versions/edit.html:45
+msgid "Adjusting application information here will allow users to install your add-on even if the install manifest in the package indicates that the add-on is incompatible."
+msgstr "Налаштування інформації про програму тут, дозволить користувачам встановити Ваш додаток, навіть якщо маніфест встановлення в пакеті вказує, що додаток є несумісним."
 
 #: src/olympia/devhub/templates/devhub/addons/ajax_compat_update.html:18
 msgid "Supported Versions"
 msgstr "Підтримувані версії"
 
-#: src/olympia/devhub/templates/devhub/addons/ajax_compat_update.html:31
-#: src/olympia/devhub/templates/devhub/versions/edit.html:63
+#: src/olympia/devhub/templates/devhub/addons/ajax_compat_update.html:31 src/olympia/devhub/templates/devhub/versions/edit.html:63
 msgid "Add Another Application&hellip;"
 msgstr "Додати іншу програму&hellip;"
 
-#: src/olympia/devhub/templates/devhub/addons/ajax_compat_update.html:38
-#: src/olympia/devhub/templates/devhub/addons/owner.html:86
-#: src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:46
-#: src/olympia/devhub/templates/devhub/versions/list.html:351
-#: src/olympia/devhub/templates/devhub/versions/list.html:353
-#: src/olympia/templates/impala/base.html:132
-#: src/olympia/templates/impala/base.html:143
-#: src/olympia/templates/impala/base.html:161
-#: src/olympia/templates/impala/base.html:171
+#: src/olympia/devhub/templates/devhub/addons/ajax_compat_update.html:38 src/olympia/devhub/templates/devhub/addons/owner.html:86 src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:45
+#: src/olympia/devhub/templates/devhub/versions/list.html:349 src/olympia/devhub/templates/devhub/versions/list.html:351 src/olympia/templates/impala/base.html:129
+#: src/olympia/templates/impala/base.html:140 src/olympia/templates/impala/base.html:158 src/olympia/templates/impala/base.html:168
 msgid "Close"
 msgstr "Закрити"
 
-#: src/olympia/devhub/templates/devhub/addons/dashboard.html:43
-#: src/olympia/zadmin/templates/zadmin/index.html:22
+#: src/olympia/devhub/templates/devhub/addons/dashboard.html:43 src/olympia/zadmin/templates/zadmin/index.html:22
 #, python-format
 msgid "%(ago)s by %(user)s"
 msgstr "%(ago)s від %(user)s"
@@ -5397,31 +4325,22 @@ msgid "<b>{0}</b> theme"
 msgid_plural "<b>{0}</b> themes"
 msgstr[0] "<b>{0}</b> тема"
 msgstr[1] "<b>{0}</b> теми"
-msgstr[2] "<b>{0}</b> тем"
 
-#: src/olympia/devhub/templates/devhub/addons/edit.html:3
-#: src/olympia/devhub/templates/devhub/addons/listing/item_actions.html:25
-#: src/olympia/devhub/templates/devhub/addons/listing/item_actions_theme.html:7
-#: src/olympia/devhub/templates/devhub/includes/addons_edit_nav.html:2
-#: src/olympia/devhub/templates/devhub/personas/edit.html:6
-#: src/olympia/editors/templates/editors/themes/single.html:37
+#: src/olympia/devhub/templates/devhub/addons/edit.html:3 src/olympia/devhub/templates/devhub/addons/listing/item_actions.html:25
+#: src/olympia/devhub/templates/devhub/addons/listing/item_actions_theme.html:7 src/olympia/devhub/templates/devhub/includes/addons_edit_nav.html:2
+#: src/olympia/devhub/templates/devhub/personas/edit.html:6 src/olympia/editors/templates/editors/themes/single.html:37
 msgid "Edit Listing"
 msgstr "Редагувати список"
 
-#: src/olympia/devhub/templates/devhub/addons/edit.html:13
-#: src/olympia/devhub/templates/devhub/includes/macros.html:18
-#: src/olympia/translations/templates/translations/all-locales.html:6
+#: src/olympia/devhub/templates/devhub/addons/edit.html:13 src/olympia/devhub/templates/devhub/includes/macros.html:18 src/olympia/translations/templates/translations/all-locales.html:6
 msgid "None"
 msgstr "Жодного"
 
-#: src/olympia/devhub/templates/devhub/addons/owner.html:4
-#: src/olympia/devhub/templates/devhub/addons/listing/item_actions.html:52
-#: src/olympia/devhub/templates/devhub/includes/addons_edit_nav.html:3
+#: src/olympia/devhub/templates/devhub/addons/owner.html:4 src/olympia/devhub/templates/devhub/addons/listing/item_actions.html:52 src/olympia/devhub/templates/devhub/includes/addons_edit_nav.html:3
 msgid "Manage Authors & License"
 msgstr "Керування авторами і ліцензією"
 
-#: src/olympia/devhub/templates/devhub/addons/owner.html:29
-#: src/olympia/editors/templates/editors/review.html:270
+#: src/olympia/devhub/templates/devhub/addons/owner.html:29 src/olympia/editors/helpers.py:362 src/olympia/editors/templates/editors/review.html:270
 msgid "Authors"
 msgstr "Автори"
 
@@ -5431,35 +4350,22 @@ msgstr "Про ролі автора"
 
 #: src/olympia/devhub/templates/devhub/addons/owner.html:78
 msgid ""
-"<p>Add-ons can have any number of authors with 3 possible roles:</p> <ul> "
-"<li><b>Owner:</b> Can manage all aspects of the add-on's listing, including "
-"adding and removing other authors</li> <li><b>Developer:</b> Can manage all "
-"aspects of the add-on's listing, except for adding and removing other "
-"authors and managing payments</li> <li><b>Viewer:</b> Can view the add-on's "
-"settings and statistics, but cannot make any changes</li> </ul>"
+"<p>Add-ons can have any number of authors with 3 possible roles:</p> <ul> <li><b>Owner:</b> Can manage all aspects of the add-on's listing, including adding and removing other authors</li> "
+"<li><b>Developer:</b> Can manage all aspects of the add-on's listing, except for adding and removing other authors and managing payments</li> <li><b>Viewer:</b> Can view the add-on's settings and "
+"statistics, but cannot make any changes</li> </ul>"
 msgstr ""
-"<p>Додатки можуть мати будь-яку кількість авторів з трьома можливими "
-"ролями:</p> <ul> <li><b>Власник:</b> Може керувати всіма аспектами "
-"розміщення додатків, включаючи додавання і вилучення авторів</li> "
-"<li><b>Розробник:</b> Може керувати всіма аспектами розміщення додатків, за "
-"виключенням додавання і вилучення інших авторів і керування платежами</li> "
-"<li><b>Глядач:</b> Може переглядати налаштування і статистику додатків, але "
-"не може вносити будь-які зміни</li> </ul>"
+"<p>Додатки можуть мати будь-яку кількість авторів з трьома можливими ролями:</p> <ul> <li><b>Власник:</b> Може керувати всіма аспектами розміщення додатків, включаючи додавання і вилучення "
+"авторів</li> <li><b>Розробник:</b> Може керувати всіма аспектами розміщення додатків, за виключенням додавання і вилучення інших авторів і керування платежами</li> <li><b>Глядач:</b> Може "
+"переглядати налаштування і статистику додатків, але не може вносити будь-які зміни</li> </ul>"
 
-#: src/olympia/devhub/templates/devhub/addons/profile.html:3
-#: src/olympia/devhub/templates/devhub/addons/listing/item_actions.html:53
-#: src/olympia/devhub/templates/devhub/includes/addons_edit_nav.html:4
+#: src/olympia/devhub/templates/devhub/addons/profile.html:3 src/olympia/devhub/templates/devhub/addons/listing/item_actions.html:53 src/olympia/devhub/templates/devhub/includes/addons_edit_nav.html:4
 msgid "Manage Developer Profile"
 msgstr "Впорядкувати Профіль розробника"
 
 #: src/olympia/devhub/templates/devhub/addons/profile.html:16
 #, python-format
-msgid ""
-"Your <a href=\"%(url)s\">developer profile</a> is currently "
-"<strong>public</strong> and <strong>required</strong> for contributions."
-msgstr ""
-"Ваш <a href=\"%(url)s\">профіль розробника</a> наразі є "
-"<strong>публічним</strong> і <strong>потрібен</strong> для збору внесків."
+msgid "Your <a href=\"%(url)s\">developer profile</a> is currently <strong>public</strong> and <strong>required</strong> for contributions."
+msgstr "Ваш <a href=\"%(url)s\">профіль розробника</a> наразі є <strong>публічним</strong> і <strong>потрібен</strong> для збору внесків."
 
 #: src/olympia/devhub/templates/devhub/addons/profile.html:22
 msgid "Remove Both"
@@ -5467,12 +4373,8 @@ msgstr "Видалити обидва"
 
 #: src/olympia/devhub/templates/devhub/addons/profile.html:27
 #, python-format
-msgid ""
-"Your <a href=\"%(url)s\">developer profile</a> is currently "
-"<strong>public</strong>."
-msgstr ""
-"Ваш <a href=\"%(url)s\">профіль розробника</a> наразі є "
-"<strong>публічним</strong>."
+msgid "Your <a href=\"%(url)s\">developer profile</a> is currently <strong>public</strong>."
+msgstr "Ваш <a href=\"%(url)s\">профіль розробника</a> наразі є <strong>публічним</strong>."
 
 #: src/olympia/devhub/templates/devhub/addons/profile.html:33
 msgid "Remove Profile"
@@ -5499,11 +4401,8 @@ msgstr "URL додатка"
 msgid "Choose a short, unique URL slug for your add-on."
 msgstr "Оберіть короткий, унікальний URL slug для Вашого додатка."
 
-#: src/olympia/devhub/templates/devhub/addons/edit/basic.html:43
-#: src/olympia/devhub/templates/devhub/includes/addons_edit_nav.html:35
-#: src/olympia/devhub/templates/devhub/personas/edit.html:56
-#: src/olympia/editors/templates/editors/review.html:255
-#: src/olympia/editors/templates/editors/themes/single.html:33
+#: src/olympia/devhub/templates/devhub/addons/edit/basic.html:43 src/olympia/devhub/templates/devhub/includes/addons_edit_nav.html:35 src/olympia/devhub/templates/devhub/personas/edit.html:56
+#: src/olympia/editors/templates/editors/review.html:255 src/olympia/editors/templates/editors/themes/single.html:33
 msgid "View Listing"
 msgstr "Переглянути список"
 
@@ -5512,11 +4411,7 @@ msgid "Summary"
 msgstr "Звіт"
 
 #: src/olympia/devhub/templates/devhub/addons/edit/basic.html:52
-msgid ""
-"A short explanation of your add-on's basic\n"
-"                          functionality that is displayed in search and browse\n"
-"                          listings, as well as at the top of your add-on's\n"
-"                          details page. It is only relevant for listed add-ons."
+msgid "A short explanation of your add-on's basic functionality that is displayed in search and browse listings, as well as at the top of your add-on's details page. It is only relevant for listed add-ons."
 msgstr ""
 "Коротке пояснення про базову функціональність\n"
 "                          ваших додатків, що показана у списках пошуку та перегляду,\n"
@@ -5524,10 +4419,7 @@ msgstr ""
 "                          Це стосується лише опублікованих додатків."
 
 #: src/olympia/devhub/templates/devhub/addons/edit/basic.html:73
-msgid ""
-"Categories are the primary way users browse through add-ons. Choose any that"
-" fit your add-on's functionality for the most exposure. It is only relevant "
-"for listed add-ons."
+msgid "Categories are the primary way users browse through add-ons. Choose any that fit your add-on's functionality for the most exposure. It is only relevant for listed add-ons."
 msgstr ""
 "Категорії - основний критерій, за яким користувачі переглядають додатки.\n"
 "                        Виберіть будь-яку, яка найкращим чином відповідає функціональності вашого додатка.\n"
@@ -5535,38 +4427,24 @@ msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/basic.html:90
 #, python-format
-msgid ""
-"Categories cannot be changed while your add-on is featured for this "
-"application. Please email <a href=\"mailto:%(email)s\">%(email)s</a> if "
-"there is a reason you need to modify your categories."
+msgid "Categories cannot be changed while your add-on is featured for this application. Please email <a href=\"mailto:%(email)s\">%(email)s</a> if there is a reason you need to modify your categories."
 msgstr ""
-"Якщо Ваш додаток для цієї програми є Обраним, його категорії не можуть бути "
-"змінені. Якщо у Вас є причина, через яку Вам необхідно змінити Ваші "
-"категорії, будь ласка, напишіть за цією адресою <a "
+"Якщо Ваш додаток для цієї програми є Обраним, його категорії не можуть бути змінені. Якщо у Вас є причина, через яку Вам необхідно змінити Ваші категорії, будь ласка, напишіть за цією адресою <a "
 "href=\"mailto:%(email)s\">%(email)s</a>."
 
 #: src/olympia/devhub/templates/devhub/addons/edit/basic.html:119
-msgid ""
-"Tags help users find your add-on and should be short descriptors such as "
-"tabs, toolbar, or twitter. You may have a maximum of {0} tags. It is only "
-"relevant for listed add-ons."
+msgid "Tags help users find your add-on and should be short descriptors such as tabs, toolbar, or twitter. You may have a maximum of {0} tags. It is only relevant for listed add-ons."
 msgstr ""
-"Теги допомагають користувачам знайти ваш додаток і вони повинні бути "
-"коротким описом, таким як вкладки, панель чи twitter. Ви можете мати "
-"максимум {0} тегів. Це стосується лише додатків, які знаходяться в списку."
+"Теги допомагають користувачам знайти ваш додаток і вони повинні бути коротким описом, таким як вкладки, панель чи twitter. Ви можете мати максимум {0} тегів. Це стосується лише додатків, які "
+"знаходяться в списку."
 
-#: src/olympia/devhub/templates/devhub/addons/edit/basic.html:129
-#: src/olympia/devhub/templates/devhub/personas/edit.html:97
-#: src/olympia/devhub/templates/devhub/personas/submit.html:46
+#: src/olympia/devhub/templates/devhub/addons/edit/basic.html:129 src/olympia/devhub/templates/devhub/personas/edit.html:97 src/olympia/devhub/templates/devhub/personas/submit.html:46
 msgid "Comma-separated, minimum of {0} character."
 msgid_plural "Comma-separated, minimum of {0} characters."
 msgstr[0] "Розділені комами, не менше {0} символа."
 msgstr[1] "Розділені комами, не менше {0} символів."
-msgstr[2] "Розділені комами, не менше {0} символів."
 
-#: src/olympia/devhub/templates/devhub/addons/edit/basic.html:132
-#: src/olympia/devhub/templates/devhub/personas/edit.html:100
-#: src/olympia/devhub/templates/devhub/personas/submit.html:49
+#: src/olympia/devhub/templates/devhub/addons/edit/basic.html:132 src/olympia/devhub/templates/devhub/personas/edit.html:100 src/olympia/devhub/templates/devhub/personas/submit.html:49
 msgid "Example: dark, cinema, noir. Limit 20."
 msgstr "Приклад: темний, кіно, нуар. Ліміт 20."
 
@@ -5575,7 +4453,6 @@ msgid "Reserved tag:"
 msgid_plural "Reserved tags:"
 msgstr[0] "Зарезервована мітка:"
 msgstr[1] "Зарезервовані мітки:"
-msgstr[2] "Зарезервовані мітки:"
 
 #: src/olympia/devhub/templates/devhub/addons/edit/details.html:5
 msgid "Add-on Details"
@@ -5586,47 +4463,29 @@ msgid "Add-on Details for {0}"
 msgstr "Інформація про додаток для {0}"
 
 #: src/olympia/devhub/templates/devhub/addons/edit/details.html:22
-msgid ""
-"A longer explanation of features, functionality, and other relevant "
-"information. This field is only displayed on the add-on's details page. It "
-"is only relevant for listed add-ons."
-msgstr ""
-"Більший опис особливостей, функціональності та іншої відповідної інформації."
-" Це поле відображається тільки на сторінці вашого додатка. Це стосується "
-"лише додатків, які знаходяться в списку."
+msgid "A longer explanation of features, functionality, and other relevant information. This field is only displayed on the add-on's details page. It is only relevant for listed add-ons."
+msgstr "Більший опис особливостей, функціональності та іншої відповідної інформації. Це поле відображається тільки на сторінці вашого додатка. Це стосується лише додатків, які знаходяться в списку."
 
-#: src/olympia/devhub/templates/devhub/addons/edit/details.html:44
-#: src/olympia/translations/templates/translations/trans-menu.html:13
+#: src/olympia/devhub/templates/devhub/addons/edit/details.html:44 src/olympia/translations/templates/translations/trans-menu.html:13
 msgid "Default Locale"
 msgstr "Типова Локаль"
 
 #: src/olympia/devhub/templates/devhub/addons/edit/details.html:45
-msgid ""
-"Information about your add-on is displayed in this locale unless you "
-"override it with a locale-specific translation. It is only relevant for "
-"listed add-ons."
-msgstr ""
-"Інформація про ваш додаток відображається цією мовою, якщо ви не заміните її"
-" перекладом іншою мовою. Це стосується тільки додатків, що знаходяться в "
-"списку."
+msgid "Information about your add-on is displayed in this locale unless you override it with a locale-specific translation. It is only relevant for listed add-ons."
+msgstr "Інформація про ваш додаток відображається цією мовою, якщо ви не заміните її перекладом іншою мовою. Це стосується тільки додатків, що знаходяться в списку."
 
-#: src/olympia/devhub/templates/devhub/addons/edit/details.html:61
-#: src/olympia/users/forms.py:311
-#: src/olympia/users/templates/users/edit.html:122
-#: src/olympia/users/templates/users/register.html:57
+#: src/olympia/devhub/templates/devhub/addons/edit/details.html:61 src/olympia/users/forms.py:311 src/olympia/users/templates/users/edit.html:122 src/olympia/users/templates/users/register.html:57
 #: src/olympia/users/templates/users/vcard.html:22
 msgid "Homepage"
 msgstr "Домашня сторінка"
 
 #: src/olympia/devhub/templates/devhub/addons/edit/details.html:63
 msgid ""
-"If your add-on has another homepage, enter its address here. If your website"
-" is localized into other languages multiple translations of this field can "
-"be added. It is only relevant for listed add-ons."
+"If your add-on has another homepage, enter its address here. If your website is localized into other languages multiple translations of this field can be added. It is only relevant for listed add-"
+"ons."
 msgstr ""
-"Якщо у вашого додатку є інша домашня сторінка, введіть тут її адресу. Якщо "
-"ваш сайт перекладений іншими мови, для цього поля можна додати кілька "
-"перекладів. Це стосується тільки додатків, що знаходяться в списку."
+"Якщо у вашого додатку є інша домашня сторінка, введіть тут її адресу. Якщо ваш сайт перекладений іншими мови, для цього поля можна додати кілька перекладів. Це стосується тільки додатків, що "
+"знаходяться в списку."
 
 #: src/olympia/devhub/templates/devhub/addons/edit/media.html:3
 msgid "Images"
@@ -5643,25 +4502,19 @@ msgstr "Інформація про підтримку для {0}"
 
 #: src/olympia/devhub/templates/devhub/addons/edit/support.html:22
 msgid ""
-"If you wish to display an e-mail address for support inquiries, enter it "
-"here. If you have different addresses for each language multiple "
-"translations of this field can be added. It is only relevant for listed add-"
-"ons."
+"If you wish to display an e-mail address for support inquiries, enter it here. If you have different addresses for each language multiple translations of this field can be added. It is only "
+"relevant for listed add-ons."
 msgstr ""
-"Якщо ви хочете показати адресу електронної пошти для запитів підтримки, "
-"введіть її тут. Якщо у вас є різні адреси для для кожної мови, для цього "
-"поля можна додати кілька перекладів. Це стосується тільки додатків, що "
-"знаходяться в списку."
+"Якщо ви хочете показати адресу електронної пошти для запитів підтримки, введіть її тут. Якщо у вас є різні адреси для для кожної мови, для цього поля можна додати кілька перекладів. Це стосується "
+"тільки додатків, що знаходяться в списку."
 
 #: src/olympia/devhub/templates/devhub/addons/edit/support.html:45
 msgid ""
-"If your add-on has a support website or forum, enter its address here. If "
-"your website is localized into other languages, multiple translations of "
-"this field can be added. It is only relevant for listed add-ons."
+"If your add-on has a support website or forum, enter its address here. If your website is localized into other languages, multiple translations of this field can be added. It is only relevant for "
+"listed add-ons."
 msgstr ""
-"Якщо у вашого додатка є сайт або форум підтримки, введіть тут його адресу. "
-"Якщо ваш сайт перекладений іншими мовами, для цього поля можна додати кілька"
-" перекладів. Це стосується тільки додатків, що знаходяться в списку."
+"Якщо у вашого додатка є сайт або форум підтримки, введіть тут його адресу. Якщо ваш сайт перекладений іншими мовами, для цього поля можна додати кілька перекладів. Це стосується тільки додатків, що"
+" знаходяться в списку."
 
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:6
 msgid "Technical Details"
@@ -5674,16 +4527,11 @@ msgstr "Технічні деталі для {0}"
 
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:23
 msgid ""
-"Any information end users may want to know that isn't necessarily applicable"
-" to the add-on summary or description. Common uses include listing known "
-"major bugs, information on how to report bugs, anticipated release date of a"
-" new version, etc. It is only relevant for listed add-ons."
+"Any information end users may want to know that isn't necessarily applicable to the add-on summary or description. Common uses include listing known major bugs, information on how to report bugs, "
+"anticipated release date of a new version, etc. It is only relevant for listed add-ons."
 msgstr ""
-"Будь-яка інформація, яку можливо захочуть дізнатися кінцеві користувачі, але"
-" якій не місце в зведенні або описі додатка. Зазвичай використовується для "
-"відомостей про серйозні помилки, про те як повідомляти про помилки, "
-"передбачувану дату випуску нової версії і т.д. Це стосується тільки "
-"додатків, що знаходяться в списку."
+"Будь-яка інформація, яку можливо захочуть дізнатися кінцеві користувачі, але якій не місце в зведенні або описі додатка. Зазвичай використовується для відомостей про серйозні помилки, про те як "
+"повідомляти про помилки, передбачувану дату випуску нової версії і т.д. Це стосується тільки додатків, що знаходяться в списку."
 
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:46
 msgid "Limit 3"
@@ -5694,9 +4542,7 @@ msgid "Add-on Flags"
 msgstr "Прапорці додатку"
 
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:69
-msgid ""
-"These flags are used to classify add-ons. It is only\n"
-"                        relevant for listed add-ons."
+msgid "These flags are used to classify add-ons. It is only relevant for listed add-ons."
 msgstr ""
 "Ці прапорці використовуються для класифікації додатків.\n"
 "                        Це стосується лише опублікованих додатків."
@@ -5714,9 +4560,7 @@ msgid "View Source?"
 msgstr "Переглянути програмний код?"
 
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:90
-msgid ""
-"Whether the source of your add-on can be displayed in our\n"
-"                        online viewer. It is only relevant for listed add-ons."
+msgid "Whether the source of your add-on can be displayed in our online viewer. It is only relevant for listed add-ons."
 msgstr ""
 "Чи може джерело вашого додатка бути відображене у нашому\n"
 "                        засобі онлайн-перегляду. Це стосується лише опублікованих додатків."
@@ -5734,10 +4578,7 @@ msgid "Public Stats?"
 msgstr "Публічна статистика?"
 
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:102
-msgid ""
-"Whether the download and usage stats of your add-on can\n"
-"                        be displayed in our online viewer.\n"
-"                        It is only relevant for listed add-ons."
+msgid "Whether the download and usage stats of your add-on can be displayed in our online viewer. It is only relevant for listed add-ons."
 msgstr ""
 "Чи може статистика завантажень або використання вашого додатка\n"
 "                        бути показана в нашому засобі онлайн-перегляду.\n"
@@ -5756,18 +4597,11 @@ msgid "Upgrade SDK?"
 msgstr "Оновити SDK?"
 
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:116
-msgid ""
-"If selected, we will try to automatically upgrade your add-on when a new "
-"version of the SDK is released. It is only relevant for listed add-ons."
-msgstr ""
-"Якщо вибрано, ми постараємося автоматично оновити ваш додаток, коли буде "
-"випущена нова версія SDK. Це стосується тільки додатків, що знаходяться в "
-"списку."
+msgid "If selected, we will try to automatically upgrade your add-on when a new version of the SDK is released. It is only relevant for listed add-ons."
+msgstr "Якщо вибрано, ми постараємося автоматично оновити ваш додаток, коли буде випущена нова версія SDK. Це стосується тільки додатків, що знаходяться в списку."
 
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:121
-msgid ""
-"This add-on will be automatically upgraded to new versions of the Add-on "
-"SDK."
+msgid "This add-on will be automatically upgraded to new versions of the Add-on SDK."
 msgstr "Цей додаток буде автоматично оновлений до нових версій SDK додатку."
 
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:123
@@ -5783,31 +4617,20 @@ msgid "UUID"
 msgstr "UUID"
 
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:132
-msgid ""
-"The UUID of your add-on is specified in its install manifest and uniquely "
-"identifies it. You cannot change your UUID once it has been submitted."
-msgstr ""
-"UUID вашого додатку зазначений у його маніфесті установки і є його "
-"унікальним ідентифікатором. Після його відправлення ви не зможете змінити "
-"UUID."
+msgid "The UUID of your add-on is specified in its install manifest and uniquely identifies it. You cannot change your UUID once it has been submitted."
+msgstr "UUID вашого додатку зазначений у його маніфесті установки і є його унікальним ідентифікатором. Після його відправлення ви не зможете змінити UUID."
 
-#: src/olympia/devhub/templates/devhub/addons/edit/technical.html:143
-#: src/olympia/devhub/templates/devhub/addons/edit/technical.html:144
+#: src/olympia/devhub/templates/devhub/addons/edit/technical.html:143 src/olympia/devhub/templates/devhub/addons/edit/technical.html:144
 msgid "Whiteboard"
 msgstr "Біла дошка"
 
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:146
 msgid ""
-"The whiteboard is the place to provide information relevant to your addon, "
-"whatever the version, to the editor. Use it to provide ways to test the "
-"addon, and any additional information that may help. This whiteboard is also"
-" editable by editors."
+"The whiteboard is the place to provide information relevant to your addon, whatever the version, to the editor. Use it to provide ways to test the addon, and any additional information that may "
+"help. This whiteboard is also editable by editors."
 msgstr ""
-"Біла дошка є місцем для надання редактору інформації, яка має відношення до "
-"вашого додатку, незалежно від версії. Використовуйте її, щоб забезпечити "
-"способи тестування додатку, та для розміщення будь-якої додаткової "
-"інформації, яка може допомогти. Ця дошка може також редагуватися "
-"редакторами."
+"Біла дошка є місцем для надання редактору інформації, яка має відношення до вашого додатку, незалежно від версії. Використовуйте її, щоб забезпечити способи тестування додатку, та для розміщення "
+"будь-якої додаткової інформації, яка може допомогти. Ця дошка може також редагуватися редакторами."
 
 #: src/olympia/devhub/templates/devhub/addons/edit/technical_dependencies.html:9
 msgid "Remove this dependent add-on"
@@ -5827,15 +4650,11 @@ msgstr "Іконка додатку"
 
 #: src/olympia/devhub/templates/devhub/addons/forms_shared/media.html:16
 msgid ""
-"Upload an icon for your add-on or choose from one of ours. The icon is "
-"displayed nearly everywhere your add-on is. Uploaded images must be one of "
-"the following image types: .png, .jpg. It is only relevant for listed add-"
-"ons."
+"Upload an icon for your add-on or choose from one of ours. The icon is displayed nearly everywhere your add-on is. Uploaded images must be one of the following image types: .png, .jpg. It is only "
+"relevant for listed add-ons."
 msgstr ""
-"Завантажте значок для вашого додатка або виберіть один з наших. Значок "
-"відображається майже скрізь, де є ваш додаток. Завантажені зображення "
-"повинні мати один з наступних типів: .png, .jpg. Це стосується тільки "
-"додатків, що знаходяться в списку."
+"Завантажте значок для вашого додатка або виберіть один з наших. Значок відображається майже скрізь, де є ваш додаток. Завантажені зображення повинні мати один з наступних типів: .png, .jpg. Це "
+"стосується тільки додатків, що знаходяться в списку."
 
 #: src/olympia/devhub/templates/devhub/addons/forms_shared/media.html:25
 msgid "Select an icon for your add-on:"
@@ -5847,9 +4666,7 @@ msgid "32x32px"
 msgstr "32x32px"
 
 #: src/olympia/devhub/templates/devhub/addons/forms_shared/media.html:39
-msgid ""
-"Used in listings of add-ons, like search results\n"
-"                            and featured add-ons."
+msgid "Used in listings of add-ons, like search results and featured add-ons."
 msgstr ""
 "Використовується у списках додатків, таких як\n"
 "                            результати пошуку та популярні додатки."
@@ -5869,9 +4686,7 @@ msgstr "Вивантажити власну іконку..."
 
 #: src/olympia/devhub/templates/devhub/addons/forms_shared/media.html:65
 msgid "PNG and JPG supported. Icons resized to 64x64 pixels if larger."
-msgstr ""
-"Підтримуються формати PNG та JPG. Великі зображення будуть зменшені до "
-"розміру 64х64 пікселів."
+msgstr "Підтримуються формати PNG та JPG. Великі зображення будуть зменшені до розміру 64х64 пікселів."
 
 #: src/olympia/devhub/templates/devhub/addons/forms_shared/media.html:83
 msgid "Screenshots"
@@ -5893,61 +4708,49 @@ msgstr "Додати знімок екрана..."
 msgid "Tests"
 msgstr "Тести"
 
-#: src/olympia/devhub/templates/devhub/addons/includes/validation_compat_test_results.html:25
-#: src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:5
+#: src/olympia/devhub/templates/devhub/addons/includes/validation_compat_test_results.html:25 src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:5
 #: src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:53
 msgid "General Tests"
 msgstr "Загальні тести"
 
-#: src/olympia/devhub/templates/devhub/addons/includes/validation_compat_test_results.html:32
-#: src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:9
+#: src/olympia/devhub/templates/devhub/addons/includes/validation_compat_test_results.html:32 src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:9
 #: src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:67
 msgid "Security Tests"
 msgstr "Тести безпеки"
 
-#: src/olympia/devhub/templates/devhub/addons/includes/validation_compat_test_results.html:39
-#: src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:13
+#: src/olympia/devhub/templates/devhub/addons/includes/validation_compat_test_results.html:39 src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:13
 #: src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:80
 msgid "Extension Tests"
 msgstr "Тести розширення"
 
-#: src/olympia/devhub/templates/devhub/addons/includes/validation_compat_test_results.html:46
-#: src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:17
+#: src/olympia/devhub/templates/devhub/addons/includes/validation_compat_test_results.html:46 src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:17
 #: src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:93
 msgid "Localization Tests"
 msgstr "Тести локалізації"
 
-#: src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:21
-#: src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:106
+#: src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:21 src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:106
 msgid "Compatibility Tests"
 msgstr "Тести сумісності"
 
-#: src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:29
-#: src/olympia/files/templates/files/viewer.html:142
+#: src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:29 src/olympia/files/templates/files/viewer.html:142
 msgid "Hide messages not required for automated signing"
 msgstr "Приховати повідомлення, які необов'язкові для автоматичного входу"
 
-#: src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:35
-#: src/olympia/files/templates/files/viewer.html:150
+#: src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:35 src/olympia/files/templates/files/viewer.html:150
 msgid "Hide messages present in previous version and ignored"
-msgstr ""
-"Приховати повідомлення, які присутні у попередніх версіях та ігноруються"
+msgstr "Приховати повідомлення, які присутні у попередніх версіях та ігноруються"
 
-#: src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:50
-#: src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:64
-#: src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:77
-#: src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:90
+#: src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:50 src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:64
+#: src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:77 src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:90
 #: src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:103
 msgid "Top"
 msgstr "Нагору"
 
-#: src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:2
-#: src/olympia/devhub/templates/devhub/personas/edit.html:63
+#: src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:2 src/olympia/devhub/templates/devhub/personas/edit.html:63
 msgid "Delete Theme"
 msgstr "Вилучити тему"
 
-#: src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:2
-#: src/olympia/devhub/templates/devhub/versions/list.html:117
+#: src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:2 src/olympia/devhub/templates/devhub/versions/list.html:117
 msgid "Delete Add-on"
 msgstr "Вилучити додаток"
 
@@ -5956,31 +4759,24 @@ msgid "Deleting your theme will permanently remove it from the site."
 msgstr "Вилучення вашої теми повністю прибере її з сайту."
 
 #: src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:14
-msgid ""
-"Deleting your add-on will permanently remove it from the site and prevent "
-"its GUID from being submitted again by others."
-msgstr ""
-"Видалення вашого додатку повністю вилучить його з сайту і заблокує повторне "
-"подання його GUID іншими."
+msgid "Deleting your add-on will permanently remove it from the site and prevent its GUID from being submitted again by others."
+msgstr "Видалення вашого додатку повністю вилучить його з сайту і заблокує повторне подання його GUID іншими."
 
 #: src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:24
-msgid ""
-"Enter the following text confirm your decision:\n"
-"           {slug}"
+msgid "Enter the following text confirm your decision: {slug}"
 msgstr ""
 "Введіть наступний текст, щоб підтвердити Ваше рішення: \n"
 " {slug}"
 
-#: src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:34
+#: src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:33
 msgid "Please tell us why you are deleting your theme:"
 msgstr "Будь ласка, розкажіть нам, чому ви видаляєте свою тему:"
 
-#: src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:36
+#: src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:35
 msgid "Please tell us why you are deleting your add-on:"
 msgstr "Будь ласка, розкажіть нам, чому ви видаляєте свій додаток:"
 
-#: src/olympia/devhub/templates/devhub/addons/listing/item_actions.html:1
-#: src/olympia/devhub/templates/devhub/addons/listing/item_actions_theme.html:1
+#: src/olympia/devhub/templates/devhub/addons/listing/item_actions.html:1 src/olympia/devhub/templates/devhub/addons/listing/item_actions_theme.html:1
 #: src/olympia/editors/templates/editors/review.html:253
 msgid "Actions"
 msgstr "Дії"
@@ -6013,22 +4809,17 @@ msgstr "Нова версія"
 msgid "Daily statistics on downloads and users."
 msgstr "Щоденна статистика завантажень та користувачів."
 
-#: src/olympia/devhub/templates/devhub/addons/listing/item_actions.html:45
-#: src/olympia/stats/templates/stats/stats.html:75
-#: src/olympia/stats/templates/stats/stats.html:79
-#: src/olympia/stats/templates/stats/stats.html:81
+#: src/olympia/devhub/templates/devhub/addons/listing/item_actions.html:45 src/olympia/stats/templates/stats/stats.html:31 src/olympia/stats/templates/stats/stats.html:35
+#: src/olympia/stats/templates/stats/stats.html:37
 msgid "Statistics"
 msgstr "Статистика"
 
-#: src/olympia/devhub/templates/devhub/addons/listing/item_actions.html:54
-#: src/olympia/devhub/templates/devhub/includes/addons_edit_nav.html:5
-#: src/olympia/devhub/templates/devhub/payments/payments.html:3
+#: src/olympia/devhub/templates/devhub/addons/listing/item_actions.html:54 src/olympia/devhub/templates/devhub/includes/addons_edit_nav.html:5 src/olympia/devhub/templates/devhub/payments/payments.html:3
 #: src/olympia/devhub/templates/devhub/payments/tier.html:4
 msgid "Manage Payments"
 msgstr "Керувати платежами"
 
-#: src/olympia/devhub/templates/devhub/addons/listing/item_actions.html:55
-#: src/olympia/devhub/templates/devhub/includes/addons_edit_nav.html:6
+#: src/olympia/devhub/templates/devhub/addons/listing/item_actions.html:55 src/olympia/devhub/templates/devhub/includes/addons_edit_nav.html:6
 msgid "Manage Status & Versions"
 msgstr "Керування статусом і версіями"
 
@@ -6036,10 +4827,8 @@ msgstr "Керування статусом і версіями"
 msgid "View Add-on Listing"
 msgstr "Показати сторінку додатку"
 
-#: src/olympia/devhub/templates/devhub/addons/listing/item_actions.html:64
-#: src/olympia/devhub/templates/devhub/addons/listing/item_actions_theme.html:12
-#: src/olympia/devhub/templates/devhub/includes/addons_edit_nav.html:37
-#: src/olympia/devhub/templates/devhub/personas/edit.html:58
+#: src/olympia/devhub/templates/devhub/addons/listing/item_actions.html:64 src/olympia/devhub/templates/devhub/addons/listing/item_actions_theme.html:12
+#: src/olympia/devhub/templates/devhub/includes/addons_edit_nav.html:37 src/olympia/devhub/templates/devhub/personas/edit.html:58
 msgid "View Recent Changes"
 msgstr "Переглянути нещодавні зміни"
 
@@ -6064,12 +4853,8 @@ msgid "Delete this theme."
 msgstr "Видалити цю тему."
 
 #: src/olympia/devhub/templates/devhub/addons/listing/items.html:10
-msgid ""
-"This add-on will be deleted automatically after a few days if the submission"
-" process is not completed."
-msgstr ""
-"Цей додаток буде видалений автоматично через декілька днів якщо процес "
-"представлення не буде завершено."
+msgid "This add-on will be deleted automatically after a few days if the submission process is not completed."
+msgstr "Цей додаток буде видалений автоматично через декілька днів якщо процес представлення не буде завершено."
 
 #: src/olympia/devhub/templates/devhub/addons/listing/items.html:27
 msgid "Disabled"
@@ -6086,7 +4871,6 @@ msgid "<strong>{0}</strong> active user"
 msgid_plural "<strong>{0}</strong> active users"
 msgstr[0] "<strong>{0}</strong> активний користувач"
 msgstr[1] "<strong>{0}</strong> активних користувача"
-msgstr[2] "<strong>{0}</strong> активних користувачів"
 
 #: src/olympia/devhub/templates/devhub/addons/submit/base.html:11
 msgid "Submit Add-on"
@@ -6108,13 +4892,9 @@ msgstr "Назва і версія:"
 msgid "The detail page will be:"
 msgstr "Сторінкою інформації буде:"
 
-#: src/olympia/devhub/templates/devhub/addons/submit/describe.html:24
-#: src/olympia/devhub/templates/devhub/personas/edit.html:89
-#: src/olympia/devhub/templates/devhub/personas/submit.html:38
+#: src/olympia/devhub/templates/devhub/addons/submit/describe.html:24 src/olympia/devhub/templates/devhub/personas/edit.html:89 src/olympia/devhub/templates/devhub/personas/submit.html:38
 msgid "Please use only letters, numbers, underscores, and dashes in your URL."
-msgstr ""
-"Будь ласка, використовуйте в своїй URL лише літери, цифри, підкреслювання і "
-"тире."
+msgstr "Будь ласка, використовуйте в своїй URL лише літери, цифри, підкреслювання і тире."
 
 #: src/olympia/devhub/templates/devhub/addons/submit/describe.html:34
 msgid "Provide a brief summary:"
@@ -6132,14 +4912,11 @@ msgstr "Надати більше детальний опис:"
 msgid "The description will appear on the detail page."
 msgstr "Опис з'явиться на сторінці детальної інформації."
 
-#: src/olympia/devhub/templates/devhub/addons/submit/done.html:4
-#: src/olympia/devhub/templates/devhub/personas/submit_done.html:4
+#: src/olympia/devhub/templates/devhub/addons/submit/done.html:4 src/olympia/devhub/templates/devhub/personas/submit_done.html:4
 msgid "Submission Complete"
 msgstr "Відправлення завершене"
 
-#: src/olympia/devhub/templates/devhub/addons/submit/done.html:8
-#: src/olympia/devhub/templates/devhub/addons/submit/sidebar.html:13
-#: src/olympia/devhub/templates/devhub/personas/submit_done.html:8
+#: src/olympia/devhub/templates/devhub/addons/submit/done.html:8 src/olympia/devhub/templates/devhub/addons/submit/sidebar.html:13 src/olympia/devhub/templates/devhub/personas/submit_done.html:8
 msgid "You're done!"
 msgstr "Ви завершили!"
 
@@ -6152,55 +4929,35 @@ msgid "Your add-on has been submitted to the Full Review queue."
 msgstr "Ваш додаток був відправлений в чергу на повну перевірку."
 
 #: src/olympia/devhub/templates/devhub/addons/submit/done.html:18
-msgid ""
-"You'll receive an email once it has been reviewed by an editor. In\n"
-"          the meantime, you and your friends can install it directly from its\n"
-"          details page:"
+msgid "You'll receive an email once it has been reviewed by an editor. In the meantime, you and your friends can install it directly from its details page:"
 msgstr ""
 "Ви отримаєте електронний лист, як тільки додаток буде перевірено\n"
 "          редактором. Тим часом ви та ваші друзі можуть встановити його\n"
 "          зі сторінки інформації:"
 
-#: src/olympia/devhub/templates/devhub/addons/submit/done.html:27
-#: src/olympia/devhub/templates/devhub/addons/submit/done.html:77
-#: src/olympia/devhub/templates/devhub/personas/submit_done.html:16
+#: src/olympia/devhub/templates/devhub/addons/submit/done.html:27 src/olympia/devhub/templates/devhub/addons/submit/done.html:77 src/olympia/devhub/templates/devhub/personas/submit_done.html:16
 msgid "Next steps:"
 msgstr "Подальші кроки:"
 
-#: src/olympia/devhub/templates/devhub/addons/submit/done.html:32
-#: src/olympia/devhub/templates/devhub/addons/submit/done.html:82
+#: src/olympia/devhub/templates/devhub/addons/submit/done.html:32 src/olympia/devhub/templates/devhub/addons/submit/done.html:82
 msgid "<a href=\"{0}\">Upload</a> another platform-specific file to this version."
-msgstr ""
-"<a href=\"{0}\">Вивантажити</a> інший специфічний файл для платформи до цієї"
-" версії."
+msgstr "<a href=\"{0}\">Вивантажити</a> інший специфічний файл для платформи до цієї версії."
 
 #: src/olympia/devhub/templates/devhub/addons/submit/done.html:34
 msgid "Provide more details by <a href=\"{0}\">editing its listing</a>."
-msgstr ""
-"Надайте більше інформації, <a href=\"{0}\">відредагувавши його сторінку</a>."
+msgstr "Надайте більше інформації, <a href=\"{0}\">відредагувавши його сторінку</a>."
 
 #: src/olympia/devhub/templates/devhub/addons/submit/done.html:35
-msgid ""
-"Tell your users why you created this in your <a href=\"{0}\">Developer "
-"Profile</a>."
-msgstr ""
-"Розкажіть своїм користувачам, чому ви його створили, у вашому <a "
-"href=\"{0}\">профілі розробника</a>."
+msgid "Tell your users why you created this in your <a href=\"{0}\">Developer Profile</a>."
+msgstr "Розкажіть своїм користувачам, чому ви його створили, у вашому <a href=\"{0}\">профілі розробника</a>."
 
 #: src/olympia/devhub/templates/devhub/addons/submit/done.html:36
-msgid ""
-"View and subscribe to your add-on's <a href=\"{0}\">activity feed</a> to "
-"stay updated on reviews, collections, and more."
-msgstr ""
-"Перегляньте та підпишіться на <a href=\"{0}\">стрічку активності</a> вашого "
-"додатку, щоб бути в курсі відгуків, збірок та багато іншого."
+msgid "View and subscribe to your add-on's <a href=\"{0}\">activity feed</a> to stay updated on reviews, collections, and more."
+msgstr "Перегляньте та підпишіться на <a href=\"{0}\">стрічку активності</a> вашого додатку, щоб бути в курсі відгуків, збірок та багато іншого."
 
-#: src/olympia/devhub/templates/devhub/addons/submit/done.html:37
-#: src/olympia/devhub/templates/devhub/addons/submit/done.html:86
+#: src/olympia/devhub/templates/devhub/addons/submit/done.html:37 src/olympia/devhub/templates/devhub/addons/submit/done.html:86
 msgid "View approximate review queue <a href=\"{0}\">wait times</a>."
-msgstr ""
-"Показати приблизний <a href=\"{0}\">час очікування</a> у черзі на проведення"
-" перевірки."
+msgstr "Показати приблизний <a href=\"{0}\">час очікування</a> у черзі на проведення перевірки."
 
 #: src/olympia/devhub/templates/devhub/addons/submit/done.html:42
 msgid "Get Ahead in the Review Queue!"
@@ -6211,43 +4968,28 @@ msgid "Become an AMO Reviewer today and get your add-ons reviewed faster."
 msgstr "Станьте рецензентом AMO та прискорте перевірку ваших додатків."
 
 #: src/olympia/devhub/templates/devhub/addons/submit/done.html:54
-msgid ""
-"Your add-on has been signed and it's ready to use. You can download it here:"
-msgstr ""
-"Ваш додаток було підписано і він готовий до використання. Ви можете "
-"завантажити його тут:"
+msgid "Your add-on has been signed and it's ready to use. You can download it here:"
+msgstr "Ваш додаток було підписано і він готовий до використання. Ви можете завантажити його тут:"
 
 #: src/olympia/devhub/templates/devhub/addons/submit/done.html:64
-msgid ""
-"Your add-on has been submitted to the Unlisted Preliminary Review queue."
-msgstr ""
-"Ваш додаток був відправлений у чергу на проведення Попередньої Перевірки "
-"Невідображених."
+msgid "Your add-on has been submitted to the Unlisted Preliminary Review queue."
+msgstr "Ваш додаток був відправлений у чергу на проведення Попередньої Перевірки Невідображених."
 
 #: src/olympia/devhub/templates/devhub/addons/submit/done.html:66
 msgid "Your add-on has been submitted to the Unlisted Full Review queue."
-msgstr ""
-"Ваш додаток був відправлений у чергу на проведення Повної Перевірки "
-"Невідображених."
+msgstr "Ваш додаток був відправлений у чергу на проведення Повної Перевірки Невідображених."
 
 #: src/olympia/devhub/templates/devhub/addons/submit/done.html:70
-msgid ""
-"You'll receive an email once it has been reviewed by an editor and signed."
-msgstr ""
-"Ви отримаєте лист електронною поштою, як тільки він буде перевірений "
-"редактором і підписаний."
+msgid "You'll receive an email once it has been reviewed by an editor and signed."
+msgstr "Ви отримаєте лист електронною поштою, як тільки він буде перевірений редактором і підписаний."
 
 #: src/olympia/devhub/templates/devhub/addons/submit/done.html:74
 msgid "Your add-on will not be publicly available on this website."
 msgstr "Ваш додаток не буде загальнодоступним на цьому веб-сайті."
 
 #: src/olympia/devhub/templates/devhub/addons/submit/done.html:84
-msgid ""
-"You can upload new versions of your add-on in the <a href=\"{0}\">add-on's "
-"developer page</a>."
-msgstr ""
-"Ви можете вивантажувати нові версії вашого додатка на <a "
-"href=\"{0}\">сторінці розробника додатка</a>."
+msgid "You can upload new versions of your add-on in the <a href=\"{0}\">add-on's developer page</a>."
+msgstr "Ви можете вивантажувати нові версії вашого додатка на <a href=\"{0}\">сторінці розробника додатка</a>."
 
 #: src/olympia/devhub/templates/devhub/addons/submit/license.html:4
 msgid "Step 5"
@@ -6258,14 +5000,8 @@ msgid "Step 5. Select a License"
 msgstr "Крок 5. Виберіть ліцензію"
 
 #: src/olympia/devhub/templates/devhub/addons/submit/license.html:9
-msgid ""
-"We require all add-ons to indicate the terms under which their source code "
-"is licensed. Please select a license from the list below or enter a custom "
-"license."
-msgstr ""
-"Ми вимагаємо для всіх додатків зазначати умови на яких ліцензовано їх "
-"початковий код. Будь ласка, виберіть ліцензію зі списку внизу або введіть "
-"свою."
+msgid "We require all add-ons to indicate the terms under which their source code is licensed. Please select a license from the list below or enter a custom license."
+msgstr "Ми вимагаємо для всіх додатків зазначати умови на яких ліцензовано їх початковий код. Будь ласка, виберіть ліцензію зі списку внизу або введіть свою."
 
 #: src/olympia/devhub/templates/devhub/addons/submit/license.html:18
 msgid "Select a license for your add-on:"
@@ -6281,13 +5017,11 @@ msgstr "Крок 4. Додати зображення"
 
 #: src/olympia/devhub/templates/devhub/addons/submit/media.html:9
 msgid ""
-"Custom icons and screenshots draw attention and help users understand what "
-"it does. We strongly recommend uploading a custom icon, as in some areas of "
-"the website, only the icon and name will appear."
+"Custom icons and screenshots draw attention and help users understand what it does. We strongly recommend uploading a custom icon, as in some areas of the website, only the icon and name will "
+"appear."
 msgstr ""
-"Власні іконки та знімки екрану приваблюють та допомагають користувачам "
-"зрозуміти, що він робить. Ми наполегливо рекомендуємо завантажити свою "
-"іконку, адже у деяких частинах веб-сайту з'явиться тільки ім'я та іконка."
+"Власні іконки та знімки екрану приваблюють та допомагають користувачам зрозуміти, що він робить. Ми наполегливо рекомендуємо завантажити свою іконку, адже у деяких частинах веб-сайту з'явиться "
+"тільки ім'я та іконка."
 
 #: src/olympia/devhub/templates/devhub/addons/submit/select-review.html:5
 msgid "Step 6"
@@ -6299,25 +5033,16 @@ msgstr "Крок 6. Виберіть процес перевірки"
 
 #: src/olympia/devhub/templates/devhub/addons/submit/select-review.html:10
 msgid ""
-"All add-ons hosted in our gallery must be reviewed by an editor before they "
-"appear in categories or search results. While waiting for review, your add-"
-"on can still be accessed through its direct URL. Please choose the review "
-"process below that best fits your add-on."
+"All add-ons hosted in our gallery must be reviewed by an editor before they appear in categories or search results. While waiting for review, your add-on can still be accessed through its direct "
+"URL. Please choose the review process below that best fits your add-on."
 msgstr ""
-"Усі додатки, розміщені у нашій галереї, повинні бути розглянуті редактором "
-"перед тим, як вони з'являться в категоріях чи результатах пошуку. В "
-"очікуванні перевірки ваш додаток може бути доступним для встановлення за "
-"його прямим посиланням. Будь ласка, виберіть нижче процес перевірки, котрий "
-"найкраще підходить для вашого додатку."
+"Усі додатки, розміщені у нашій галереї, повинні бути розглянуті редактором перед тим, як вони з'являться в категоріях чи результатах пошуку. В очікуванні перевірки ваш додаток може бути доступним "
+"для встановлення за його прямим посиланням. Будь ласка, виберіть нижче процес перевірки, котрий найкраще підходить для вашого додатку."
 
 #: src/olympia/devhub/templates/devhub/addons/submit/select-review.html:26
 #, python-format
-msgid ""
-"A complete review of your add-on's source and functionality. <a "
-"href=\"%(url)s\">Learn more&hellip;</a>"
-msgstr ""
-"Повна перевірка програмного коду та функціональності вашого додатку. <a "
-"href=\"%(url)s\">Докладніше&hellip;</a>"
+msgid "A complete review of your add-on's source and functionality. <a href=\"%(url)s\">Learn more&hellip;</a>"
+msgstr "Повна перевірка програмного коду та функціональності вашого додатку. <a href=\"%(url)s\">Докладніше&hellip;</a>"
 
 #: src/olympia/devhub/templates/devhub/addons/submit/select-review.html:32
 msgid "Appropriate for polished add-ons"
@@ -6345,12 +5070,8 @@ msgstr "Вибрати повну перевірку"
 
 #: src/olympia/devhub/templates/devhub/addons/submit/select-review.html:49
 #, python-format
-msgid ""
-"A faster review of your add-on's source for any major problems. <a "
-"href=\"%(url)s\">Learn more&hellip;</a>"
-msgstr ""
-"Швидка перевірка програмного коду вашого додатку для виявлення будь-яких "
-"серйозних проблем. <a href=\"%(url)s\">Докладніше&hellip;</a>"
+msgid "A faster review of your add-on's source for any major problems. <a href=\"%(url)s\">Learn more&hellip;</a>"
+msgstr "Швидка перевірка програмного коду вашого додатку для виявлення будь-яких серйозних проблем. <a href=\"%(url)s\">Докладніше&hellip;</a>"
 
 #: src/olympia/devhub/templates/devhub/addons/submit/select-review.html:55
 msgid "Appropriate for experimental add-ons"
@@ -6396,10 +5117,8 @@ msgstr "Виберіть ліцензію"
 msgid "Select a review process"
 msgstr "Виберіть процес розгляду"
 
-#: src/olympia/devhub/templates/devhub/addons/submit/sidebar.html:18
-#: src/olympia/devhub/templates/devhub/docs/policies-submission.html:3
-#: src/olympia/devhub/templates/devhub/docs/policies-submission.html:7
-#: src/olympia/devhub/templates/devhub/docs/policies-submission.html:9
+#: src/olympia/devhub/templates/devhub/addons/submit/sidebar.html:18 src/olympia/devhub/templates/devhub/docs/policies-submission.html:3
+#: src/olympia/devhub/templates/devhub/docs/policies-submission.html:7 src/olympia/devhub/templates/devhub/docs/policies-submission.html:9
 msgid "Submission Process"
 msgstr "Процес відправлення"
 
@@ -6420,27 +5139,18 @@ msgid "Step 2. Upload Your Add-on"
 msgstr "Крок 2. Завантажте ваш додаток"
 
 #: src/olympia/devhub/templates/devhub/addons/submit/upload.html:11
-msgid ""
-"Use the fields below to upload your add-on package and select any platform "
-"restrictions. After upload, a series of automated validation tests will be "
-"run on your file."
-msgstr ""
-"Для завантаження пакету свого додатку і вибору обмежень щодо платформи "
-"користуйтеся полями нижче. Після завантаження ваш файл буде перевірено з "
-"використанням серії автоматичних тестів валідації."
+msgid "Use the fields below to upload your add-on package and select any platform restrictions. After upload, a series of automated validation tests will be run on your file."
+msgstr "Для завантаження пакету свого додатку і вибору обмежень щодо платформи користуйтеся полями нижче. Після завантаження ваш файл буде перевірено з використанням серії автоматичних тестів валідації."
 
-#: src/olympia/devhub/templates/devhub/addons/submit/upload.html:59
-#: src/olympia/devhub/templates/devhub/versions/add_file_modal.html:39
+#: src/olympia/devhub/templates/devhub/addons/submit/upload.html:51 src/olympia/devhub/templates/devhub/versions/add_file_modal.html:28
 msgid "Which platforms is this file compatible with?"
 msgstr "З якими платформами сумісний цей файл?"
 
-#: src/olympia/devhub/templates/devhub/addons/submit/upload.html:67
-#: src/olympia/devhub/templates/devhub/versions/add_file_modal.html:65
+#: src/olympia/devhub/templates/devhub/addons/submit/upload.html:59 src/olympia/devhub/templates/devhub/versions/add_file_modal.html:45
 msgid "Administrative overrides"
 msgstr "Адміністративні дії"
 
-#: src/olympia/devhub/templates/devhub/api/agreement.html:3
-#: src/olympia/devhub/templates/devhub/api/agreement.html:11
+#: src/olympia/devhub/templates/devhub/api/agreement.html:3 src/olympia/devhub/templates/devhub/api/agreement.html:11
 msgid "Firefox Add-on Distribution Agreement"
 msgstr "Угода Firefox про розповсюдження додатків"
 
@@ -6450,12 +5160,8 @@ msgstr "Облікові дані API"
 
 #: src/olympia/devhub/templates/devhub/api/key.html:20
 #, python-format
-msgid ""
-"For detailed instructions, consult the <a href=\"%(docs_url)s\">API "
-"documentation</a>."
-msgstr ""
-"Для докладних інструкцій, можете переглянути <a "
-"href=\"%(docs_url)s\">документацію API</a>."
+msgid "For detailed instructions, consult the <a href=\"%(docs_url)s\">API documentation</a>."
+msgstr "Для докладних інструкцій, можете переглянути <a href=\"%(docs_url)s\">документацію API</a>."
 
 #: src/olympia/devhub/templates/devhub/api/key.html:28
 msgid "JWT issuer"
@@ -6468,14 +5174,11 @@ msgstr "JWT таємниця"
 #: src/olympia/devhub/templates/devhub/api/key.html:37
 #, python-format
 msgid ""
-"To make API requests, send a <a href=\"%(jwt_url)s\">JSON Web Token "
-"(JWT)</a> as the authorization header. You'll need to generate a JWT for "
-"every request as explained in the <a href=\"%(docs_url)s\">API "
-"documentation</a>."
+"To make API requests, send a <a href=\"%(jwt_url)s\">JSON Web Token (JWT)</a> as the authorization header. You'll need to generate a JWT for every request as explained in the <a "
+"href=\"%(docs_url)s\">API documentation</a>."
 msgstr ""
-"Для здійснення запитів API, надішліть <a href=\"%(jwt_url)s\">JSON Web Token"
-" (JWT)</a> в якості заголовку авторизації. Вам потрібно згенерувати JWT для "
-"кожного запиту, як описано у <a href=\"%(docs_url)s\">API документації</a>."
+"Для здійснення запитів API, надішліть <a href=\"%(jwt_url)s\">JSON Web Token (JWT)</a> в якості заголовку авторизації. Вам потрібно згенерувати JWT для кожного запиту, як описано у <a "
+"href=\"%(docs_url)s\">API документації</a>."
 
 #: src/olympia/devhub/templates/devhub/api/key.html:47
 msgid "You don't have any API credentials yet."
@@ -6483,13 +5186,8 @@ msgstr "У вас поки що немає жодних облікових да�
 
 #: src/olympia/devhub/templates/devhub/api/key.html:53
 #, python-format
-msgid ""
-"This feature is under active development. If you find a problem please <a "
-"target=\"_blank\" href=\"%(bug_link)s\">report a bug</a>."
-msgstr ""
-"Ця функція знаходиться на стадії активної розробки. Якщо ви знайшли "
-"проблему, будь ласка <a target=\"_blank\" href=\"%(bug_link)s\">повідомте "
-"про неї</a>."
+msgid "This feature is under active development. If you find a problem please <a target=\"_blank\" href=\"%(bug_link)s\">report a bug</a>."
+msgstr "Ця функція знаходиться на стадії активної розробки. Якщо ви знайшли проблему, будь ласка <a target=\"_blank\" href=\"%(bug_link)s\">повідомте про неї</a>."
 
 #: src/olympia/devhub/templates/devhub/api/key.html:61
 msgid "Revoke and regenerate credentials"
@@ -6499,30 +5197,19 @@ msgstr "Відкликати й генерувати облікові дані"
 msgid "Generate new credentials"
 msgstr "Генерувати нові облікові дані"
 
-#: src/olympia/devhub/templates/devhub/docs/policies-agreement.html:3
-#: src/olympia/devhub/templates/devhub/docs/policies-agreement.html:7
-#: src/olympia/devhub/templates/devhub/docs/policies-agreement.html:9
-#: src/olympia/devhub/templates/devhub/docs/policies.html:24
-#: src/olympia/devhub/templates/devhub/docs/policies.html:103
+#: src/olympia/devhub/templates/devhub/docs/policies-agreement.html:3 src/olympia/devhub/templates/devhub/docs/policies-agreement.html:7 src/olympia/devhub/templates/devhub/docs/policies-agreement.html:9
+#: src/olympia/devhub/templates/devhub/docs/policies.html:24 src/olympia/devhub/templates/devhub/docs/policies.html:103
 msgid "Developer Agreement"
 msgstr "Угода розробника"
 
-#: src/olympia/devhub/templates/devhub/docs/policies-contact.html:3
-#: src/olympia/devhub/templates/devhub/docs/policies-contact.html:7
-#: src/olympia/devhub/templates/devhub/docs/policies-contact.html:9
-#: src/olympia/devhub/templates/devhub/docs/policies.html:27
-#: src/olympia/devhub/templates/devhub/docs/policies.html:115
+#: src/olympia/devhub/templates/devhub/docs/policies-contact.html:3 src/olympia/devhub/templates/devhub/docs/policies-contact.html:7 src/olympia/devhub/templates/devhub/docs/policies-contact.html:9
+#: src/olympia/devhub/templates/devhub/docs/policies.html:27 src/olympia/devhub/templates/devhub/docs/policies.html:115
 msgid "Contacting Us"
 msgstr "Зв'язок з нами"
 
 #: src/olympia/devhub/templates/devhub/docs/policies-contact.html:12
-msgid ""
-"Thanks for your interest in contacting the Mozilla Add-ons team. Please read"
-" this page carefully to ensure your request goes to the right place."
-msgstr ""
-"Дякуємо за ваш інтерес до зв'язку з командою додатків Mozilla. Будь ласка, "
-"уважно прочитайте цю сторінку, щоб переконатися, що ваш запит потрапить у "
-"потрібне місце."
+msgid "Thanks for your interest in contacting the Mozilla Add-ons team. Please read this page carefully to ensure your request goes to the right place."
+msgstr "Дякуємо за ваш інтерес до зв'язку з командою додатків Mozilla. Будь ласка, уважно прочитайте цю сторінку, щоб переконатися, що ваш запит потрапить у потрібне місце."
 
 #: src/olympia/devhub/templates/devhub/docs/policies-contact.html:17
 msgid "Add-on Support"
@@ -6530,15 +5217,11 @@ msgstr "Підтримка додатку"
 
 #: src/olympia/devhub/templates/devhub/docs/policies-contact.html:19
 msgid ""
-"If you have a support question about a particular add-on, such as \"how do I"
-" use this add-on?\" or \"why doesn't this work properly?\", please contact "
-"that add-on's author through the support channels listed on the add-on's "
-"listing page."
+"If you have a support question about a particular add-on, such as \"how do I use this add-on?\" or \"why doesn't this work properly?\", please contact that add-on's author through the support "
+"channels listed on the add-on's listing page."
 msgstr ""
-"Якщо у вас є питання, пов'язане з роботою конкретного додатку, таке як \"як "
-"мені використовувати цей додаток?\" чи \"чому він неправильно працює?\", "
-"зв'яжіться будь ласка з автором додатку через канали підтримки, зазначені на"
-" сторінці інформації додатку."
+"Якщо у вас є питання, пов'язане з роботою конкретного додатку, таке як \"як мені використовувати цей додаток?\" чи \"чому він неправильно працює?\", зв'яжіться будь ласка з автором додатку через "
+"канали підтримки, зазначені на сторінці інформації додатку."
 
 #: src/olympia/devhub/templates/devhub/docs/policies-contact.html:24
 msgid "Add-on Editorial Concerns"
@@ -6551,17 +5234,11 @@ msgstr "amo-editors на mozilla крапка org"
 #: src/olympia/devhub/templates/devhub/docs/policies-contact.html:26
 #, python-format
 msgid ""
-"If you have a question about an Editor's review of an add-on or want to "
-"report a policy violation, please email %(mail_editors)s. <strong>Almost all"
-" add-on reports fall under this category.</strong> Please be sure to include"
-" a link to the add-on in question and a detailed description of your "
-"question or comment."
+"If you have a question about an Editor's review of an add-on or want to report a policy violation, please email %(mail_editors)s. <strong>Almost all add-on reports fall under this "
+"category.</strong> Please be sure to include a link to the add-on in question and a detailed description of your question or comment."
 msgstr ""
-"Якщо у вас є питання з приводу рецензії редактора на додаток чи ви бажаєте "
-"повідомити про порушення політики, будь ласка, напишіть %(mail_editors)s. "
-"<strong>Майже усі повідомлення про додатки потрапляють у цю "
-"категорію.</strong> Будь ласка, не забудьте вказати посилання на додаток, "
-"про який йде мова, та детальний опис вашого питання чи коментар."
+"Якщо у вас є питання з приводу рецензії редактора на додаток чи ви бажаєте повідомити про порушення політики, будь ласка, напишіть %(mail_editors)s. <strong>Майже усі повідомлення про додатки "
+"потрапляють у цю категорію.</strong> Будь ласка, не забудьте вказати посилання на додаток, про який йде мова, та детальний опис вашого питання чи коментар."
 
 #: src/olympia/devhub/templates/devhub/docs/policies-contact.html:31
 msgid "Add-on Security Vulnerabilities"
@@ -6574,21 +5251,13 @@ msgstr "amo-admins at mozilla dot org"
 #: src/olympia/devhub/templates/devhub/docs/policies-contact.html:36
 #, python-format
 msgid ""
-"If you have discovered a security vulnerability in an add-on, even if it is "
-"not hosted here, Mozilla is very interested in your discovery and will work "
-"with the add-on developer to correct the issue as soon as possible. Add-on "
-"security issues can be reported <a "
-"href=\"http://www.mozilla.org/projects/security/security-bugs-"
-"policy.html\">confidentially</a> in <a "
+"If you have discovered a security vulnerability in an add-on, even if it is not hosted here, Mozilla is very interested in your discovery and will work with the add-on developer to correct the "
+"issue as soon as possible. Add-on security issues can be reported <a href=\"http://www.mozilla.org/projects/security/security-bugs-policy.html\">confidentially</a> in <a "
 "href=\"%(link_bugzilla)s\">Bugzilla</a> or by emailing %(mail_admins)s."
 msgstr ""
-"Якщо ви виявили вразливість безпеки додатку, навіть якщо його розміщено не "
-"тут, Mozilla буде дуже зацікавлена вашим відкриттям й буде працювати разом з"
-" розробником додатку щодо найшвидшого усунення проблеми. Про проблеми "
-"безпеки додатків можна <a href=\"http://www.mozilla.org/projects/security"
-"/security-bugs-policy.html\">конфіденційно</a> повідомити у <a "
-"href=\"%(link_bugzilla)s\">Bugzilla</a> чи за електронною адресою "
-"%(mail_admins)s."
+"Якщо ви виявили вразливість безпеки додатку, навіть якщо його розміщено не тут, Mozilla буде дуже зацікавлена вашим відкриттям й буде працювати разом з розробником додатку щодо найшвидшого усунення"
+" проблеми. Про проблеми безпеки додатків можна <a href=\"http://www.mozilla.org/projects/security/security-bugs-policy.html\">конфіденційно</a> повідомити у <a "
+"href=\"%(link_bugzilla)s\">Bugzilla</a> чи за електронною адресою %(mail_admins)s."
 
 #: src/olympia/devhub/templates/devhub/docs/policies-contact.html:42
 msgid "Website Functionality & Development"
@@ -6596,17 +5265,11 @@ msgstr "Функціональність та розробка веб-сайту
 
 #: src/olympia/devhub/templates/devhub/docs/policies-contact.html:44
 msgid ""
-"If you've found a problem with the site, we'd love to fix it. Please <a "
-"href=\"https://github.com/mozilla/olympia/issues\">file a bug report</a> in "
-"GitHub, including the location of the problem and how you encountered it."
+"If you've found a problem with the site, we'd love to fix it. Please <a href=\"https://github.com/mozilla/addons/issues/new\">file a bug report</a> in GitHub, including the location of the problem "
+"and how you encountered it."
 msgstr ""
-"Якщо ви виявили проблему з сайтом, ми з радістю її виправимо. Будь ласка, <a"
-" href=\"https://github.com/mozilla/olympia/issues\">відправте повідомлення "
-"про помилку</a> на GitHub, вказавши розташування проблеми і як ви з нею "
-"зіштовхнулися."
 
-#: src/olympia/devhub/templates/devhub/docs/policies-maintenance.html:3
-#: src/olympia/devhub/templates/devhub/docs/policies-maintenance.html:7
+#: src/olympia/devhub/templates/devhub/docs/policies-maintenance.html:3 src/olympia/devhub/templates/devhub/docs/policies-maintenance.html:7
 #: src/olympia/devhub/templates/devhub/docs/policies-maintenance.html:8
 msgid "Maintaining Your Add-ons"
 msgstr "Обслуговування ваших додатків"
@@ -6617,31 +5280,17 @@ msgstr "Представлення нових версій вашого дода
 
 #: src/olympia/devhub/templates/devhub/docs/policies-maintenance.html:12
 msgid ""
-"Developers are encouraged to submit updates to their add-ons to fix bugs, "
-"add features, and otherwise improve their product. New versions of an add-on"
-" must have a <a "
-"href=\"https://developer.mozilla.org/en/Toolkit_version_format\">higher "
-"version number</a> and can be submitted through the Developer Tools "
-"provided. There is no limit to the number of versions that can be submitted,"
-" but please remember that versions must be reviewed by an editor."
+"Developers are encouraged to submit updates to their add-ons to fix bugs, add features, and otherwise improve their product. New versions of an add-on must have a <a "
+"href=\"https://developer.mozilla.org/en/Toolkit_version_format\">higher version number</a> and can be submitted through the Developer Tools provided. There is no limit to the number of versions "
+"that can be submitted, but please remember that versions must be reviewed by an editor."
 msgstr ""
-"Розробникам пропонується надавати оновлення для своїх додатків, задля "
-"виправлення помилок, додавання нових функцій та внесення інших змін. Нові "
-"версії додатку повинні мати <a "
-"href=\"https://developer.mozilla.org/en/Toolkit_version_format\">вищий номер"
-" версії</a> і можуть бути представлені за допомогою наданих Інструментів "
-"Розробника. Не існує ніяких обмежень щодо числа представлених версій, але "
-"будь ласка, пам'ятайте, що версії повинні бути перевірені редактором."
+"Розробникам пропонується надавати оновлення для своїх додатків, задля виправлення помилок, додавання нових функцій та внесення інших змін. Нові версії додатку повинні мати <a "
+"href=\"https://developer.mozilla.org/en/Toolkit_version_format\">вищий номер версії</a> і можуть бути представлені за допомогою наданих Інструментів Розробника. Не існує ніяких обмежень щодо числа "
+"представлених версій, але будь ласка, пам'ятайте, що версії повинні бути перевірені редактором."
 
 #: src/olympia/devhub/templates/devhub/docs/policies-maintenance.html:18
-msgid ""
-"New versions will be added to a pending review queue, and any additional "
-"versions submitted before the review is completed will move that version to "
-"the end of the queue."
-msgstr ""
-"Нові версії стануть у чергу на очікування перевірки, і будь-які додаткові "
-"версії, відправлені перед закінченням перевірки, поставлять цю версію у "
-"кінець черги."
+msgid "New versions will be added to a pending review queue, and any additional versions submitted before the review is completed will move that version to the end of the queue."
+msgstr "Нові версії стануть у чергу на очікування перевірки, і будь-які додаткові версії, відправлені перед закінченням перевірки, поставлять цю версію у кінець черги."
 
 #: src/olympia/devhub/templates/devhub/docs/policies-maintenance.html:23
 msgid "How do I submit a Beta add-on?"
@@ -6653,51 +5302,31 @@ msgstr "Бета-канали доступні тільки для повніс�
 
 #: src/olympia/devhub/templates/devhub/docs/policies-maintenance.html:31
 msgid ""
-"To create a beta channel, upload a file with a unique version string that "
-"contains any of the following strings: <code>a,b,alpha,beta,pre,rc</code>, "
-"with an optional number at the end. This text must come at the end of the "
-"version string. If you understand regex format, here's what we look for in "
-"the version number: <code>\"(a|alpha|b|beta|pre|rc)\\d*$\"</code>."
+"To create a beta channel, upload a file with a unique version string that contains any of the following strings: <code>a,b,alpha,beta,pre,rc</code>, with an optional number at the end. This text "
+"must come at the end of the version string. If you understand regex format, here's what we look for in the version number: <code>\"(a|alpha|b|beta|pre|rc)\\d*$\"</code>."
 msgstr ""
-"Для створення бета-каналу, завантажте файл з рядком унікальної версії, що "
-"містить будь-який з наступних рядків: <code>a,b,alpha,beta,pre,rc</code>, з "
-"опціональним числом у кінці. Цей текст повинен бути у кінці рядка версії. "
-"Якщо ви розумієте формат regex, ось те, що ми шукаємо в номері версії: "
-"<code>\"(a|alpha|b|beta|pre|rc)\\d*$\"</code>."
+"Для створення бета-каналу, завантажте файл з рядком унікальної версії, що містить будь-який з наступних рядків: <code>a,b,alpha,beta,pre,rc</code>, з опціональним числом у кінці. Цей текст повинен "
+"бути у кінці рядка версії. Якщо ви розумієте формат regex, ось те, що ми шукаємо в номері версії: <code>\"(a|alpha|b|beta|pre|rc)\\d*$\"</code>."
 
 #: src/olympia/devhub/templates/devhub/docs/policies-maintenance.html:37
 msgid ""
-"Once a file meeting this criteria is uploaded to AMO, it will automatically "
-"be marked as a beta version. Users of add-ons with these unique version "
-"numbers will automatically be served the newest beta updates."
+"Once a file meeting this criteria is uploaded to AMO, it will automatically be marked as a beta version. Users of add-ons with these unique version numbers will automatically be served the newest "
+"beta updates."
 msgstr ""
-"Як тільки файл, що відповідає цим критеріям, буде завантажений на АМО, він "
-"автоматично буде позначений як бета-версія. Користувачам додатків з цими "
-"унікальними номерами версії будуть автоматично надсилатися найновіші "
-"оновлення бета-версії."
+"Як тільки файл, що відповідає цим критеріям, буде завантажений на АМО, він автоматично буде позначений як бета-версія. Користувачам додатків з цими унікальними номерами версії будуть автоматично "
+"надсилатися найновіші оновлення бета-версії."
 
 #: src/olympia/devhub/templates/devhub/docs/policies-maintenance.html:43
 msgid ""
-"While we call these \"Beta versions\", you can use this channel for "
-"nightlies, or alphas, or prerelease versions as you wish. Please note that "
-"there is only one channel for this purpose and all of your users on this "
-"channel will receive the latest add-ons submitted. For instance, if you "
-"upload <code>1.0beta1</code> to the release channel and then upload "
-"<code>1.1alpha1</code>, all users of <code>1.0beta1</code> will be offered "
-"an upgrade to <code>1.1alpha1</code>. Updates are pushed by submission date "
-"and not version number, so users will always get the most recent channel "
-"update regardless of any kind of alphabetical sorting."
+"While we call these \"Beta versions\", you can use this channel for nightlies, or alphas, or prerelease versions as you wish. Please note that there is only one channel for this purpose and all of "
+"your users on this channel will receive the latest add-ons submitted. For instance, if you upload <code>1.0beta1</code> to the release channel and then upload <code>1.1alpha1</code>, all users of "
+"<code>1.0beta1</code> will be offered an upgrade to <code>1.1alpha1</code>. Updates are pushed by submission date and not version number, so users will always get the most recent channel update "
+"regardless of any kind of alphabetical sorting."
 msgstr ""
-"Хоч ми й називаємо це \"Бета-версії\", ви можете використовувати цей канал "
-"для нічних збірок, чи альф, або попередніх версій, як ви того хочете. Будь "
-"ласка, зверніть увагу, що для цього є тільки один канал і всі ваші "
-"користувачі на цьому каналі отримуватимуть найновіші представлені додатки. "
-"Наприклад, якщо ви завантажуєте <code>1.0beta1</code> у канал релізів, а "
-"потім завантажуєте <code>1.1alpha1</code>, усім користувачам "
-"<code>1.0beta1</code> буде запропоновано оновлення до "
-"<code>1.1alpha1</code>. Оновлення поширюються за датою представлення, а не "
-"за номером версії, тому користувачі завжди будуть отримувати найновіші "
-"оновлення каналу, незалежно від будь-якого сортування за абеткою."
+"Хоч ми й називаємо це \"Бета-версії\", ви можете використовувати цей канал для нічних збірок, чи альф, або попередніх версій, як ви того хочете. Будь ласка, зверніть увагу, що для цього є тільки "
+"один канал і всі ваші користувачі на цьому каналі отримуватимуть найновіші представлені додатки. Наприклад, якщо ви завантажуєте <code>1.0beta1</code> у канал релізів, а потім завантажуєте "
+"<code>1.1alpha1</code>, усім користувачам <code>1.0beta1</code> буде запропоновано оновлення до <code>1.1alpha1</code>. Оновлення поширюються за датою представлення, а не за номером версії, тому "
+"користувачі завжди будуть отримувати найновіші оновлення каналу, незалежно від будь-якого сортування за абеткою."
 
 #: src/olympia/devhub/templates/devhub/docs/policies-maintenance.html:48
 msgid "Required Updates"
@@ -6705,21 +5334,13 @@ msgstr "Потрібні оновлення"
 
 #: src/olympia/devhub/templates/devhub/docs/policies-maintenance.html:50
 msgid ""
-"Certain situations may arise in which Mozilla requests that an add-on "
-"developer update their add-on within a given time period to address a major "
-"security issue or policy violation. We work with developers to reasonably "
-"accommodate their own schedules, but if the issue is of a serious enough "
-"nature, add-ons that cannot issue an update with the requested fix may be "
-"demoted from fully-reviewed status, disabled, or permanently removed from "
-"the site."
+"Certain situations may arise in which Mozilla requests that an add-on developer update their add-on within a given time period to address a major security issue or policy violation. We work with "
+"developers to reasonably accommodate their own schedules, but if the issue is of a serious enough nature, add-ons that cannot issue an update with the requested fix may be demoted from fully-"
+"reviewed status, disabled, or permanently removed from the site."
 msgstr ""
-"Можуть виникнути певні ситуації, за яких Mozilla просить розробника додатку "
-"оновити свій додаток протягом визначеного періоду часу, задля вирішення "
-"серйозної проблеми безпеки чи виправити порушення політики. Ми працюємо з "
-"розробниками, щоб при змозі узгодити це з їх власними графіками, але якщо це"
-" питання з досить серйозним характером, то додатки, які не можуть випустити "
-"оновлення з потрібним виправленням, можуть бути понижені в статусі з "
-"повністю перевіреного, виключені чи назавжди видалені з сайту."
+"Можуть виникнути певні ситуації, за яких Mozilla просить розробника додатку оновити свій додаток протягом визначеного періоду часу, задля вирішення серйозної проблеми безпеки чи виправити порушення"
+" політики. Ми працюємо з розробниками, щоб при змозі узгодити це з їх власними графіками, але якщо це питання з досить серйозним характером, то додатки, які не можуть випустити оновлення з "
+"потрібним виправленням, можуть бути понижені в статусі з повністю перевіреного, виключені чи назавжди видалені з сайту."
 
 #: src/olympia/devhub/templates/devhub/docs/policies-maintenance.html:55
 msgid "Transfer of Ownership"
@@ -6727,64 +5348,41 @@ msgstr "Передача власності"
 
 #: src/olympia/devhub/templates/devhub/docs/policies-maintenance.html:57
 msgid ""
-"Add-ons can have multiple users with permission to update and manage the "
-"listing. Existing authors of an add-on can transfer ownership and add "
-"additional developers to an add-on's listing through the Developer Tools "
-"provided. No interaction with Mozilla representatives is necessary for a "
-"transfer of ownership."
+"Add-ons can have multiple users with permission to update and manage the listing. Existing authors of an add-on can transfer ownership and add additional developers to an add-on's listing through "
+"the Developer Tools provided. No interaction with Mozilla representatives is necessary for a transfer of ownership."
 msgstr ""
-"Додатки можуть мати декілька користувачів, яким дозволено оновлювати і "
-"змінювати його сторінку. Існуючі автори додатку можуть передавати у "
-"власність і додавати додаткових розробників на сторінку додатку через "
-"Інструменти Розробника. Для передачі у власність взаємодія з представниками "
-"Mozilla не потрібна."
+"Додатки можуть мати декілька користувачів, яким дозволено оновлювати і змінювати його сторінку. Існуючі автори додатку можуть передавати у власність і додавати додаткових розробників на сторінку "
+"додатку через Інструменти Розробника. Для передачі у власність взаємодія з представниками Mozilla не потрібна."
 
 #: src/olympia/devhub/templates/devhub/docs/policies-maintenance.html:63
 #, python-format
-msgid ""
-"Mozilla can assist with granting additional permissions of an add-on's "
-"listing if <a href=\"%(link_contact)s\">contacted</a> by the add-on's "
-"current owner."
-msgstr ""
-"Mozilla може допомогти з наданням додаткових дозволів на сторінку додатку, "
-"якщо <a href=\"%(link_contact)s\">з нею зв'яжеться</a> поточний власник "
-"додатку."
+msgid "Mozilla can assist with granting additional permissions of an add-on's listing if <a href=\"%(link_contact)s\">contacted</a> by the add-on's current owner."
+msgstr "Mozilla може допомогти з наданням додаткових дозволів на сторінку додатку, якщо <a href=\"%(link_contact)s\">з нею зв'яжеться</a> поточний власник додатку."
 
 #: src/olympia/devhub/templates/devhub/docs/policies-maintenance.html:70
 msgid ""
-"Mozilla encourages its users to offer feedback on their experiences when "
-"using an add-on. This allows other users to determine if the add-on is "
-"stable and useful. It also provides valuable feedback to developers, "
-"allowing them to continuously improve their add-on to meet user needs."
+"Mozilla encourages its users to offer feedback on their experiences when using an add-on. This allows other users to determine if the add-on is stable and useful. It also provides valuable feedback"
+" to developers, allowing them to continuously improve their add-on to meet user needs."
 msgstr ""
-"Mozilla рекомендує своїм користувачам висловлювати думку про свій досвід "
-"використання додатку. Це дозволяє іншим користувачам визначити, чи додаток є"
-" стабільним і корисним. Це також надає цінну інформацію для розробників, "
-"дозволяючи їм постійно вдосконалювати свій додаток для задоволення потреб "
-"користувачів."
+"Mozilla рекомендує своїм користувачам висловлювати думку про свій досвід використання додатку. Це дозволяє іншим користувачам визначити, чи додаток є стабільним і корисним. Це також надає цінну "
+"інформацію для розробників, дозволяючи їм постійно вдосконалювати свій додаток для задоволення потреб користувачів."
 
 #: src/olympia/devhub/templates/devhub/docs/policies-maintenance.html:76
 #, python-format
 msgid ""
-"Reviews must follow the <a href=\"%(link_guidelines)s\">review "
-"guidelines</a>. Reviews that do not meet these guidelines may be flagged for"
-" moderation, but negative reviews will not be removed unless they provide "
-"false information."
+"Reviews must follow the <a href=\"%(link_guidelines)s\">review guidelines</a>. Reviews that do not meet these guidelines may be flagged for moderation, but negative reviews will not be removed "
+"unless they provide false information."
 msgstr ""
-"Відгуки повинні відповідати <a href=\"%(link_guidelines)s\">певним "
-"вимогам</a>. Відгуки, що не відповідають зазначеним вимогам, можуть бути "
-"позначені для модерації, але негативні відгуки не будуть видалятися, якщо "
-"тільки вони не містять неправдиву інформацію."
+"Відгуки повинні відповідати <a href=\"%(link_guidelines)s\">певним вимогам</a>. Відгуки, що не відповідають зазначеним вимогам, можуть бути позначені для модерації, але негативні відгуки не будуть "
+"видалятися, якщо тільки вони не містять неправдиву інформацію."
 
 #: src/olympia/devhub/templates/devhub/docs/policies-maintenance.html:82
 msgid ""
-"Many developers provide a support mechanism, such as a forum, discussion "
-"group, or email address. It is recommended that support questions be posted "
-"via those mediums instead of in an add-on's review section."
+"Many developers provide a support mechanism, such as a forum, discussion group, or email address. It is recommended that support questions be posted via those mediums instead of in an add-on's "
+"review section."
 msgstr ""
-"Багато розробників надають механізм підтримки, такі як форум, дискусійна "
-"група або адресу електронної пошти. Ми рекомендуємо розміщувати питання щодо"
-" підтримки в цих середовищах замість розділу відгуків на додаток."
+"Багато розробників надають механізм підтримки, такі як форум, дискусійна група або адресу електронної пошти. Ми рекомендуємо розміщувати питання щодо підтримки в цих середовищах замість розділу "
+"відгуків на додаток."
 
 #: src/olympia/devhub/templates/devhub/docs/policies-maintenance.html:87
 msgid "Code Disputes"
@@ -6792,44 +5390,26 @@ msgstr "Оскарження коду"
 
 #: src/olympia/devhub/templates/devhub/docs/policies-maintenance.html:90
 msgid ""
-"Many add-ons allow their source code to be openly viewed. This does not mean"
-" that the source code is open source or available for use in another add-on."
-" The original author of an add-on retains copyright of their work unless "
-"otherwise noted in the add-on's license."
+"Many add-ons allow their source code to be openly viewed. This does not mean that the source code is open source or available for use in another add-on. The original author of an add-on retains "
+"copyright of their work unless otherwise noted in the add-on's license."
 msgstr ""
-"Багато додатків дозволяють відкрито переглянути їх програмний код. Але це не"
-" значить, що їх програмний код є відкритим або доступний для використання в "
-"іншому додатку. Оригінальний автор додатку зберігає авторські права на свою "
-"роботу, якщо інше не зазначено в ліцензії додатку."
+"Багато додатків дозволяють відкрито переглянути їх програмний код. Але це не значить, що їх програмний код є відкритим або доступний для використання в іншому додатку. Оригінальний автор додатку "
+"зберігає авторські права на свою роботу, якщо інше не зазначено в ліцензії додатку."
 
 #: src/olympia/devhub/templates/devhub/docs/policies-maintenance.html:96
 msgid ""
-"In the event that we're notified of a copyright or license infringement, we "
-"will take steps to review the situation and determine if an actual "
-"infringement has occurred. If we determine that there is an infringement, we"
-" will remove the offending add-on and contact the author. New add-on "
-"submissions (including updates) containing infringing code will be denied "
-"approval for public status."
+"In the event that we're notified of a copyright or license infringement, we will take steps to review the situation and determine if an actual infringement has occurred. If we determine that there "
+"is an infringement, we will remove the offending add-on and contact the author. New add-on submissions (including updates) containing infringing code will be denied approval for public status."
 msgstr ""
-"У випадку, якщо ми будемо повідомлені про порушення авторських прав або "
-"ліцензії, ми зробимо кроки для аналізу ситуації і визначення того, чи "
-"відбулося фактичне порушення. Якщо ми визначимо, що відбулося порушення, ми "
-"видалимо цей додаток та зв'яжемося з автором. Новим представленням додатку "
-"(включаючи оновлення), що містять код, який містить порушення, буде "
-"відмовлено в наданні публічного статусу."
+"У випадку, якщо ми будемо повідомлені про порушення авторських прав або ліцензії, ми зробимо кроки для аналізу ситуації і визначення того, чи відбулося фактичне порушення. Якщо ми визначимо, що "
+"відбулося порушення, ми видалимо цей додаток та зв'яжемося з автором. Новим представленням додатку (включаючи оновлення), що містять код, який містить порушення, буде відмовлено в наданні "
+"публічного статусу."
 
 #: src/olympia/devhub/templates/devhub/docs/policies-maintenance.html:102
-msgid ""
-"If you are unsure of the current copyright status of an add-on's source "
-"code, you must contact the original author and receive explicit permission "
-"before using the source code."
-msgstr ""
-"Якщо ви не впевнені в поточному стані авторських прав на програмний код "
-"додатку, ви повинні зв'язатися з оригінальним автором і отримати дозвіл, "
-"перш ніж використовувати програмний код."
+msgid "If you are unsure of the current copyright status of an add-on's source code, you must contact the original author and receive explicit permission before using the source code."
+msgstr "Якщо ви не впевнені в поточному стані авторських прав на програмний код додатку, ви повинні зв'язатися з оригінальним автором і отримати дозвіл, перш ніж використовувати програмний код."
 
-#: src/olympia/devhub/templates/devhub/docs/policies-maintenance.html:107
-#: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:306
+#: src/olympia/devhub/templates/devhub/docs/policies-maintenance.html:107 src/olympia/devhub/templates/devhub/docs/policies-reviews.html:306
 #: src/olympia/devhub/templates/devhub/docs/policies-submission.html:97
 msgid "Last updated: January 13, 2011"
 msgstr "Останнє оновлення: 13 січня 2011"
@@ -6837,55 +5417,34 @@ msgstr "Останнє оновлення: 13 січня 2011"
 #: src/olympia/devhub/templates/devhub/docs/policies-recommended.html:13
 #, python-format
 msgid ""
-"Featured add-ons are top-quality extensions and themes highlighted on <a "
-"href=\"%(link_gallery)s\">AMO</a>, Firefox's Add-ons Manager, and across "
-"other Mozilla websites. These add-ons showcase the power of Firefox "
-"customization and are useful to a wide audience."
+"Featured add-ons are top-quality extensions and themes highlighted on <a href=\"%(link_gallery)s\">AMO</a>, Firefox's Add-ons Manager, and across other Mozilla websites. These add-ons showcase the "
+"power of Firefox customization and are useful to a wide audience."
 msgstr ""
-"Відібрані додатки є високоякісними розширеннями і темами, виділеними на <a "
-"href=\"%(link_gallery)s\">AMO</a>, менеджері додатків Firefox та інших веб-"
-"сайтах Mozilla. Ці додатки демонструють силу налаштовуваності Firefox і "
-"корисні для широкої аудиторії."
+"Відібрані додатки є високоякісними розширеннями і темами, виділеними на <a href=\"%(link_gallery)s\">AMO</a>, менеджері додатків Firefox та інших веб-сайтах Mozilla. Ці додатки демонструють силу "
+"налаштовуваності Firefox і корисні для широкої аудиторії."
 
 #: src/olympia/devhub/templates/devhub/docs/policies-recommended.html:19
-msgid ""
-"Featured add-ons are chosen by the Featured Add-ons Advisory Board, a small "
-"group of add-on developers and fans from the Mozilla community who have "
-"volunteered to review and vote on nominations."
+msgid "Featured add-ons are chosen by the Featured Add-ons Advisory Board, a small group of add-on developers and fans from the Mozilla community who have volunteered to review and vote on nominations."
 msgstr ""
-"Відібрані додатки вибираються кожен місяць Консультативною Радою з "
-"Відібраних додатків, невеликою групою розробників додатків і шанувальників "
-"зі спільноти Mozilla, які зголосилися розглянути кандидатів і проголосувати "
-"за номінаціями."
+"Відібрані додатки вибираються кожен місяць Консультативною Радою з Відібраних додатків, невеликою групою розробників додатків і шанувальників зі спільноти Mozilla, які зголосилися розглянути "
+"кандидатів і проголосувати за номінаціями."
 
 #: src/olympia/devhub/templates/devhub/docs/policies-recommended.html:25
 #, python-format
-msgid ""
-"<a href=\"%(link_featured)s\">Featured extensions</a> are chosen every "
-"month, and <a href=\"%(link_themes)s\">featured complete themes</a> are "
-"chosen every quarter."
-msgstr ""
-"<a href=\"%(link_featured)s\">Відібрані розширення</a> вибираються кожен "
-"місяць, а <a href=\"%(link_themes)s\"> відібрані повні теми </a> вибираються"
-" раз в квартал."
+msgid "<a href=\"%(link_featured)s\">Featured extensions</a> are chosen every month, and <a href=\"%(link_themes)s\">featured complete themes</a> are chosen every quarter."
+msgstr "<a href=\"%(link_featured)s\">Відібрані розширення</a> вибираються кожен місяць, а <a href=\"%(link_themes)s\"> відібрані повні теми </a> вибираються раз в квартал."
 
 #: src/olympia/devhub/templates/devhub/docs/policies-recommended.html:30
 msgid "Criteria for Featured Add-ons"
 msgstr "Критерії для відібраних додатків"
 
 #: src/olympia/devhub/templates/devhub/docs/policies-recommended.html:33
-msgid ""
-"Before nominating an add-on to be featured, please ensure it meets the "
-"following criteria:"
-msgstr ""
-"Перед номінацією додатку до обраних переконайтеся, що він відповідає таким "
-"критеріям:"
+msgid "Before nominating an add-on to be featured, please ensure it meets the following criteria:"
+msgstr "Перед номінацією додатку до обраних переконайтеся, що він відповідає таким критеріям:"
 
 #: src/olympia/devhub/templates/devhub/docs/policies-recommended.html:39
-msgid ""
-"The add-on must have a complete and informative listing on AMO. This means:"
-msgstr ""
-"Додаток повинен мати повну і інформативну сторінку на AMO. Це означає:"
+msgid "The add-on must have a complete and informative listing on AMO. This means:"
+msgstr "Додаток повинен мати повну і інформативну сторінку на AMO. Це означає:"
 
 #: src/olympia/devhub/templates/devhub/docs/policies-recommended.html:41
 msgid "a 64-pixel custom icon"
@@ -6908,43 +5467,28 @@ msgid "updated screenshots of the add-on's functionality"
 msgstr "оновлені знімки екрану функціональності додатку"
 
 #: src/olympia/devhub/templates/devhub/docs/policies-recommended.html:46
-msgid ""
-"must be fully approved by AMO editors (no preliminarily reviewed entries)"
-msgstr ""
-"має бути повністю схвалений редакторами АМО (немає записів попередньої "
-"перевірки)"
+msgid "must be fully approved by AMO editors (no preliminarily reviewed entries)"
+msgstr "має бути повністю схвалений редакторами АМО (немає записів попередньої перевірки)"
 
 #: src/olympia/devhub/templates/devhub/docs/policies-recommended.html:48
-msgid ""
-"The add-on must have excellent user reviews and any problems or support "
-"requests must be promptly addressed by the developer."
-msgstr ""
-"Додатки повинні мати відмінні відгуки користувачів, а будь-які проблеми або "
-"запити на підтримку повинні бути негайно розглянуті розробником."
+msgid "The add-on must have excellent user reviews and any problems or support requests must be promptly addressed by the developer."
+msgstr "Додатки повинні мати відмінні відгуки користувачів, а будь-які проблеми або запити на підтримку повинні бути негайно розглянуті розробником."
 
 #: src/olympia/devhub/templates/devhub/docs/policies-recommended.html:49
 msgid "The add-on must have a minimum of 2,000 users."
 msgstr "Додатки повинні мати не менше 2000 користувачів."
 
 #: src/olympia/devhub/templates/devhub/docs/policies-recommended.html:50
-msgid ""
-"The add-on must be compatible with the latest release of Firefox and must be"
-" compatible with beta versions 4 weeks before their final release."
-msgstr ""
-"Цей додаток повинен бути сумісним з останнім випуском Firefox, а також бета "
-"версіями за 4 тижні перед їх фінальним випуском."
+msgid "The add-on must be compatible with the latest release of Firefox and must be compatible with beta versions 4 weeks before their final release."
+msgstr "Цей додаток повинен бути сумісним з останнім випуском Firefox, а також бета версіями за 4 тижні перед їх фінальним випуском."
 
 #: src/olympia/devhub/templates/devhub/docs/policies-recommended.html:51
 msgid ""
-"<strong>Most importantly</strong>, the add-on must have wide consumer appeal"
-" to Firefox's users and be outstanding in nearly every way: user experience,"
-" performance, security, and usefulness or entertainment value. Featured "
-"complete themes must also be visually appealing."
+"<strong>Most importantly</strong>, the add-on must have wide consumer appeal to Firefox's users and be outstanding in nearly every way: user experience, performance, security, and usefulness or "
+"entertainment value. Featured complete themes must also be visually appealing."
 msgstr ""
-"<strong>Найважливіше</strong>, додаток повинен викликати широкий інтерес у "
-"користувачів Firefox та бути визначним майже в усіх відношеннях: "
-"користувацький інтерфейс, швидкодія, безпека, бути корисним чи цікавим. "
-"Відібрані повні теми також повинні бути візуально привабливими."
+"<strong>Найважливіше</strong>, додаток повинен викликати широкий інтерес у користувачів Firefox та бути визначним майже в усіх відношеннях: користувацький інтерфейс, швидкодія, безпека, бути "
+"корисним чи цікавим. Відібрані повні теми також повинні бути візуально привабливими."
 
 #: src/olympia/devhub/templates/devhub/docs/policies-recommended.html:54
 msgid "Nominating an Add-on"
@@ -6956,266 +5500,163 @@ msgstr "amo-featured at mozilla dot org"
 
 #: src/olympia/devhub/templates/devhub/docs/policies-recommended.html:57
 #, python-format
-msgid ""
-"If you wish to nominate an add-on to be featured and it meets the criteria "
-"above, send an email to %(mail_featured)s with:"
-msgstr ""
-"Якщо Ви хочете номінувати додаток до обраних і якщо він відповідає "
-"перерахованим вище критеріям, відправте лист електронною поштою за адресою "
-"%(mail_featured)s з:"
+msgid "If you wish to nominate an add-on to be featured and it meets the criteria above, send an email to %(mail_featured)s with:"
+msgstr "Якщо Ви хочете номінувати додаток до обраних і якщо він відповідає перерахованим вище критеріям, відправте лист електронною поштою за адресою %(mail_featured)s з:"
 
 #: src/olympia/devhub/templates/devhub/docs/policies-recommended.html:62
 msgid "the add-on name, URL, and whether you are its developer"
 msgstr "назвою додатку, URL, і чи є ви його розробником"
 
 #: src/olympia/devhub/templates/devhub/docs/policies-recommended.html:63
-msgid ""
-"a short explanation of why the add-on has wide appeal and should be featured"
-msgstr ""
-"коротке пояснення, чому додаток викликає великий інтерес і повинен бути "
-"обраним"
+msgid "a short explanation of why the add-on has wide appeal and should be featured"
+msgstr "коротке пояснення, чому додаток викликає великий інтерес і повинен бути обраним"
 
 #: src/olympia/devhub/templates/devhub/docs/policies-recommended.html:64
-msgid ""
-"optionally, links to any external reviews or articles mentioning the add-on"
-msgstr ""
-"необов'язково, посилання на будь-які зовнішні огляди та статті, що згадують "
-"додаток"
+msgid "optionally, links to any external reviews or articles mentioning the add-on"
+msgstr "необов'язково, посилання на будь-які зовнішні огляди та статті, що згадують додаток"
 
 #: src/olympia/devhub/templates/devhub/docs/policies-recommended.html:68
 msgid ""
-"Add-on nominations are reviewed by the Advisory Board once a month (once "
-"every 3 months for complete theme nominations). Common reasons for rejection"
-" include lacking wide appeal to consumers, a suboptimal user experience, "
-"quality or security issues, incompatibility, and similarity to another "
-"featured add-on. Rejected add-ons cannot be re-nominated within 3 months."
+"Add-on nominations are reviewed by the Advisory Board once a month (once every 3 months for complete theme nominations). Common reasons for rejection include lacking wide appeal to consumers, a "
+"suboptimal user experience, quality or security issues, incompatibility, and similarity to another featured add-on. Rejected add-ons cannot be re-nominated within 3 months."
 msgstr ""
-"Номінації додатків розглядаються нашою Консультативною радою один раз на "
-"місяць (раз на 3 місяці для номінацій повних тем). Типовими причинами "
-"відхилення є відсутність великого інтересу користувачів, неоптимальний "
-"користувацький інтерфейс, проблеми з якістю або безпекою, несумісність і "
-"схожість з іншим обраним додатком. Відхилені додатки не можуть бути повторно"
-" номіновані протягом 3 місяців."
+"Номінації додатків розглядаються нашою Консультативною радою один раз на місяць (раз на 3 місяці для номінацій повних тем). Типовими причинами відхилення є відсутність великого інтересу "
+"користувачів, неоптимальний користувацький інтерфейс, проблеми з якістю або безпекою, несумісність і схожість з іншим обраним додатком. Відхилені додатки не можуть бути повторно номіновані протягом"
+" 3 місяців."
 
 #: src/olympia/devhub/templates/devhub/docs/policies-recommended.html:73
 msgid "Rotating Featured Add-ons"
 msgstr "Ротація обраних додатків"
 
 #: src/olympia/devhub/templates/devhub/docs/policies-recommended.html:76
-msgid ""
-"Mozilla and the Featured Add-ons Advisory Board regularly evaluate and "
-"rotate out featured add-ons. Some of the most common reasons for add-ons "
-"being removed from the featured list are:"
-msgstr ""
-"Mozilla і Консультативна Рада з Обраних додатків регулярно роблять оцінку і "
-"ротацію обраних додатків. Одними з найбільш поширених причин, через які "
-"додатки видаляються зі списку обраних, є:"
+msgid "Mozilla and the Featured Add-ons Advisory Board regularly evaluate and rotate out featured add-ons. Some of the most common reasons for add-ons being removed from the featured list are:"
+msgstr "Mozilla і Консультативна Рада з Обраних додатків регулярно роблять оцінку і ротацію обраних додатків. Одними з найбільш поширених причин, через які додатки видаляються зі списку обраних, є:"
 
 #: src/olympia/devhub/templates/devhub/docs/policies-recommended.html:83
 msgid ""
-"Lack of growth &mdash; Add-ons that are featured typically experience a "
-"substantial gain in both downloads and active users. If an add-on is not "
-"demonstrating growth in any substantial way, that's a good indicator the "
-"add-on may not be very useful to our users."
+"Lack of growth &mdash; Add-ons that are featured typically experience a substantial gain in both downloads and active users. If an add-on is not demonstrating growth in any substantial way, that's "
+"a good indicator the add-on may not be very useful to our users."
 msgstr ""
-"Відсутність зростання &mdash; Додатки, що потрапили в обрані, як правило "
-"відчувають істотне зростання завантажень і активних користувачів. Якщо "
-"додаток не демонструє суттєвого зростання, це є хорошим індикатором того, що"
-" він може бути не дуже корисним для користувачів."
+"Відсутність зростання &mdash; Додатки, що потрапили в обрані, як правило відчувають істотне зростання завантажень і активних користувачів. Якщо додаток не демонструє суттєвого зростання, це є "
+"хорошим індикатором того, що він може бути не дуже корисним для користувачів."
 
 #: src/olympia/devhub/templates/devhub/docs/policies-recommended.html:88
-msgid ""
-"Negative reviews &mdash; Featured add-ons should have a great experience and"
-" very few bugs, so add-ons with many negative reviews may be reconsidered."
-msgstr ""
-"Негативні відгуки &mdash; Обрані додатки повинні відмінно працювати і мати "
-"малу кількість помилок, тому рішення щодо додатків з великою кількістю "
-"негативних відгуків може бути переглянуто."
+msgid "Negative reviews &mdash; Featured add-ons should have a great experience and very few bugs, so add-ons with many negative reviews may be reconsidered."
+msgstr "Негативні відгуки &mdash; Обрані додатки повинні відмінно працювати і мати малу кількість помилок, тому рішення щодо додатків з великою кількістю негативних відгуків може бути переглянуто."
 
 #: src/olympia/devhub/templates/devhub/docs/policies-recommended.html:93
 msgid ""
-"Incompatibility with upcoming Firefox versions &mdash; Featured add-ons are "
-"expected to be compatible with stable and beta versions of Firefox. Add-ons "
-"not yet compatible with a Beta version of Firefox four weeks before its "
-"expected release will lose their featured status."
+"Incompatibility with upcoming Firefox versions &mdash; Featured add-ons are expected to be compatible with stable and beta versions of Firefox. Add-ons not yet compatible with a Beta version of "
+"Firefox four weeks before its expected release will lose their featured status."
 msgstr ""
-"Несумісність з наступними версіями Firefox &mdash; Очікується, що обрані "
-"додатки повинні бути сумісні зі стабільними та бета-версіями Firefox. "
-"Додатки, які ще не сумісні з бета-версією Firefox за чотири тижні до його "
-"очікуваного релізу, втратять свій статус обраного."
+"Несумісність з наступними версіями Firefox &mdash; Очікується, що обрані додатки повинні бути сумісні зі стабільними та бета-версіями Firefox. Додатки, які ще не сумісні з бета-версією Firefox за "
+"чотири тижні до його очікуваного релізу, втратять свій статус обраного."
 
 #: src/olympia/devhub/templates/devhub/docs/policies-recommended.html:99
 msgid "Joining the Featured Add-ons Advisory Board"
 msgstr "Приєднання до Консультативної Ради з Обраних додатків"
 
 #: src/olympia/devhub/templates/devhub/docs/policies-recommended.html:102
-msgid ""
-"Every six months a new Advisory Board is chosen based on applications from "
-"the add-ons community. Members must:"
-msgstr ""
-"Кожні шість місяців на основі заявок від спільноти додатків вибирається нова"
-" Консультативна Рада. Учасники повинні:"
+msgid "Every six months a new Advisory Board is chosen based on applications from the add-ons community. Members must:"
+msgstr "Кожні шість місяців на основі заявок від спільноти додатків вибирається нова Консультативна Рада. Учасники повинні:"
 
 #: src/olympia/devhub/templates/devhub/docs/policies-recommended.html:108
-msgid ""
-"be active members of the add-ons community, whether as a developer, "
-"evangelist, or fan"
-msgstr ""
-"бути активними членами спільноти додатків, незалежно від того, чи є вони "
-"розробниками, євангелістами, або фанами"
+msgid "be active members of the add-ons community, whether as a developer, evangelist, or fan"
+msgstr "бути активними членами спільноти додатків, незалежно від того, чи є вони розробниками, євангелістами, або фанами"
 
 #: src/olympia/devhub/templates/devhub/docs/policies-recommended.html:109
-msgid ""
-"commit to trying all the nominations submitted, giving their feedback, and "
-"casting their votes every month"
-msgstr ""
-"зобов'язуються спробувати всі представлені номінації, відправити свої "
-"відгуки та голосувати кожного місяця"
+msgid "commit to trying all the nominations submitted, giving their feedback, and casting their votes every month"
+msgstr "зобов'язуються спробувати всі представлені номінації, відправити свої відгуки та голосувати кожного місяця"
 
 #: src/olympia/devhub/templates/devhub/docs/policies-recommended.html:110
-msgid ""
-"abstain from voting on add-ons that they have any business or personal "
-"affiliations with, as well as direct competitors of any such add-ons"
-msgstr ""
-"утриматися від голосування за додатки, з якими у них є ділові або особисті "
-"відносини, а також за прямих конкурентів будь-яких таких додатків"
+msgid "abstain from voting on add-ons that they have any business or personal affiliations with, as well as direct competitors of any such add-ons"
+msgstr "утриматися від голосування за додатки, з якими у них є ділові або особисті відносини, а також за прямих конкурентів будь-яких таких додатків"
 
 #: src/olympia/devhub/templates/devhub/docs/policies-recommended.html:114
 msgid ""
-"Members of the Mozilla Add-ons team may veto any add-on's selection because "
-"of security, privacy, compatibility, or any other reason, but in general it "
-"is up to the Board to select add-ons to feature."
+"Members of the Mozilla Add-ons team may veto any add-on's selection because of security, privacy, compatibility, or any other reason, but in general it is up to the Board to select add-ons to "
+"feature."
 msgstr ""
-"Члени команди додатків Mozilla можуть накласти вето на вибір будь-якого "
-"додатку через безпеку, приватність, сумісність або з якоїсь іншої причини, "
-"але в цілому вибір обраних додатків залежить від Ради."
+"Члени команди додатків Mozilla можуть накласти вето на вибір будь-якого додатку через безпеку, приватність, сумісність або з якоїсь іншої причини, але в цілому вибір обраних додатків залежить від "
+"Ради."
 
 #: src/olympia/devhub/templates/devhub/docs/policies-recommended.html:120
 msgid ""
-"This featured policy only applies to the addons.mozilla.org global list of "
-"featured add-ons. Add-ons featured in other locations are often pulled from "
-"this list, but Mozilla may feature any add-on in other locations without the"
-" Board's consent. Additionally, locale-specific features override the global"
-" defaults, so if a locale has opted to select its own features, some or all "
-"of the global features may not appear in that locale."
+"This featured policy only applies to the addons.mozilla.org global list of featured add-ons. Add-ons featured in other locations are often pulled from this list, but Mozilla may feature any add-on "
+"in other locations without the Board's consent. Additionally, locale-specific features override the global defaults, so if a locale has opted to select its own features, some or all of the global "
+"features may not appear in that locale."
 msgstr ""
-"Ця політика обраних додатків застосовується тільки до глобального списку "
-"обраних додатків addons.mozilla.org. Додатки, обрані в інших місцях, часто "
-"беруться з цього списку, але Mozilla можуть обирати будь-які додатки в інших"
-" місцях без згоди Ради. Крім того обрані, специфічні для локалі, мають "
-"пріоритет над глобальним списком за замовчуванням, так що якщо локаль "
-"вирішила вибрати свої обрані додатки, деякі або всі з глобального списку "
-"обраних можуть не відображатися в цій локалі."
+"Ця політика обраних додатків застосовується тільки до глобального списку обраних додатків addons.mozilla.org. Додатки, обрані в інших місцях, часто беруться з цього списку, але Mozilla можуть "
+"обирати будь-які додатки в інших місцях без згоди Ради. Крім того обрані, специфічні для локалі, мають пріоритет над глобальним списком за замовчуванням, так що якщо локаль вирішила вибрати свої "
+"обрані додатки, деякі або всі з глобального списку обраних можуть не відображатися в цій локалі."
 
 #: src/olympia/devhub/templates/devhub/docs/policies-recommended.html:126
 #, python-format
-msgid ""
-"Follow the <a href=\"%(link_blog)s\">Add-ons Blog</a> or <a "
-"href=\"%(link_twitter)s\">@mozamo</a> on Twitter to learn when the next "
-"application period opens."
-msgstr ""
-"Стежте за <a href=\"%(link_blog)s\">Блогом додатків</a> або <a "
-"href=\"%(link_twitter)s\">@mozamo</a> в Твіттері, щоб дізнатися, коли "
-"відкриється наступний період номінацій."
+msgid "Follow the <a href=\"%(link_blog)s\">Add-ons Blog</a> or <a href=\"%(link_twitter)s\">@mozamo</a> on Twitter to learn when the next application period opens."
+msgstr "Стежте за <a href=\"%(link_blog)s\">Блогом додатків</a> або <a href=\"%(link_twitter)s\">@mozamo</a> в Твіттері, щоб дізнатися, коли відкриється наступний період номінацій."
 
 #: src/olympia/devhub/templates/devhub/docs/policies-recommended.html:131
 msgid "Last updated: January 31, 2013"
 msgstr "Останнє оновлення: 31 січня 2013"
 
-#: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:3
-#: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:7
-#: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:8
-#: src/olympia/devhub/templates/devhub/docs/policies.html:15
-#: src/olympia/devhub/templates/devhub/docs/policies.html:64
+#: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:3 src/olympia/devhub/templates/devhub/docs/policies-reviews.html:7 src/olympia/devhub/templates/devhub/docs/policies-reviews.html:8
+#: src/olympia/devhub/templates/devhub/docs/policies.html:15 src/olympia/devhub/templates/devhub/docs/policies.html:64
 msgid "Review Process"
 msgstr "Процес перевірки"
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:12
 msgid ""
-"In order to ensure all add-ons hosted in our gallery are safe for users to "
-"install, Mozilla will begin requiring all hosted add-ons to undergo review. "
-"We offer two types of review and developers are free to choose the best fit "
-"for their add-on."
+"In order to ensure all add-ons hosted in our gallery are safe for users to install, Mozilla will begin requiring all hosted add-ons to undergo review. We offer two types of review and developers "
+"are free to choose the best fit for their add-on."
 msgstr ""
-"Для того, щоб переконатися, що всі додатки, розміщені в нашій галереї, "
-"безпечні для встановлення користувачами, Mozilla почне вимагати, щоб всі "
-"розміщені додатки пройшли перевірку. Ми пропонуємо два типи перевірки і "
-"розробники можуть вибирати найкращий варіант для їх додатку."
+"Для того, щоб переконатися, що всі додатки, розміщені в нашій галереї, безпечні для встановлення користувачами, Mozilla почне вимагати, щоб всі розміщені додатки пройшли перевірку. Ми пропонуємо "
+"два типи перевірки і розробники можуть вибирати найкращий варіант для їх додатку."
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:19
 msgid ""
-"<strong><a href=\"#full\">Full Review</a></strong> &mdash; a thorough "
-"functional and code review of the add-on, appropriate for add-ons ready for "
-"distribution to the masses. All site features are available to these add-"
-"ons."
+"<strong><a href=\"#full\">Full Review</a></strong> &mdash; a thorough functional and code review of the add-on, appropriate for add-ons ready for distribution to the masses. All site features are "
+"available to these add-ons."
 msgstr ""
-"<strong><a href=\"#full\">Повна перевірка</a></strong> &mdash; ретельна "
-"перевірка функцій і коду додатку, підходить для додатків, готових для "
-"масового поширення. Для цих додатків доступні всі можливості сайту."
+"<strong><a href=\"#full\">Повна перевірка</a></strong> &mdash; ретельна перевірка функцій і коду додатку, підходить для додатків, готових для масового поширення. Для цих додатків доступні всі "
+"можливості сайту."
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:24
 msgid ""
-"<strong><a href=\"#preliminary\">Preliminary Review</a></strong> &mdash; a "
-"faster review intended for experimental add-ons. Preliminary reviews do not "
-"check for functionality or full policy compliance, but the reviewed add-ons "
-"have install button cautions and some feature limitations."
+"<strong><a href=\"#preliminary\">Preliminary Review</a></strong> &mdash; a faster review intended for experimental add-ons. Preliminary reviews do not check for functionality or full policy "
+"compliance, but the reviewed add-ons have install button cautions and some feature limitations."
 msgstr ""
-"<strong><a href=\"#preliminary\">Попередня перевірка</a></strong> &mdash; "
-"більш швидка перевірка, призначена для експериментальних додатків. Попередні"
-" перевірки не перевіряють функціональність і повну відповідність політиці. "
-"Перевірені таким чином додатки видають при установці попередження і мають "
-"деякі обмеження в можливостях."
+"<strong><a href=\"#preliminary\">Попередня перевірка</a></strong> &mdash; більш швидка перевірка, призначена для експериментальних додатків. Попередні перевірки не перевіряють функціональність і "
+"повну відповідність політиці. Перевірені таким чином додатки видають при установці попередження і мають деякі обмеження в можливостях."
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:31
 msgid ""
-"Detailed descriptions of each option are below. After selecting a review "
-"process at submission, the add-on will be placed in the queue. Add-ons are "
-"reviewed by the <a href=\"https://wiki.mozilla.org/AMO:Editors\">AMO "
-"Editors</a>, a group of talented developers that volunteer to help the "
-"Mozilla project by reviewing add-ons to ensure a stable and safe experience "
-"for users. Developers will receive an email with any updates throughout the "
-"review process."
+"Detailed descriptions of each option are below. After selecting a review process at submission, the add-on will be placed in the queue. Add-ons are reviewed by the <a "
+"href=\"https://wiki.mozilla.org/AMO:Editors\">AMO Editors</a>, a group of talented developers that volunteer to help the Mozilla project by reviewing add-ons to ensure a stable and safe experience "
+"for users. Developers will receive an email with any updates throughout the review process."
 msgstr ""
-"Нижче наведені докладні описи кожного варіанту. Після вибору при поданні "
-"процесу перевірки додаток буде поміщено в чергу. Додатки розглядаються<a "
-"href=\"https://wiki.mozilla.org/AMO:Editors\">Редакторами АМО</a> - групою "
-"талановитих розробників, які добровільно допомагають проекту Mozilla, "
-"перевіряючи додатки, щоб переконатися, що вони забезпечують стабільну і "
-"безпечну роботу користувачів. Розробники будуть отримувати листи електронною"
-" поштою з інформацією про будь-які оновлення в процесі перевірки."
+"Нижче наведені докладні описи кожного варіанту. Після вибору при поданні процесу перевірки додаток буде поміщено в чергу. Додатки розглядаються<a "
+"href=\"https://wiki.mozilla.org/AMO:Editors\">Редакторами АМО</a> - групою талановитих розробників, які добровільно допомагають проекту Mozilla, перевіряючи додатки, щоб переконатися, що вони "
+"забезпечують стабільну і безпечну роботу користувачів. Розробники будуть отримувати листи електронною поштою з інформацією про будь-які оновлення в процесі перевірки."
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:37
 msgid ""
-"While waiting for review, add-ons will not appear anywhere in the gallery "
-"publicly, but direct links to the add-on's details page will work. This "
-"allows the author to blog or share the link with friends, inviting them to "
-"try it out, even when not yet reviewed."
+"While waiting for review, add-ons will not appear anywhere in the gallery publicly, but direct links to the add-on's details page will work. This allows the author to blog or share the link with "
+"friends, inviting them to try it out, even when not yet reviewed."
 msgstr ""
-"Поки триває розгляд, додаток не з'явиться ніде в загальнодоступній галереї, "
-"але пряме посилання на сторінку додатку буде діяти. Це дозволить автору "
-"ділитися посиланням з друзями, запрошуючи їх спробувати його в роботі, "
-"навіть якщо він ще не затверджений."
+"Поки триває розгляд, додаток не з'явиться ніде в загальнодоступній галереї, але пряме посилання на сторінку додатку буде діяти. Це дозволить автору ділитися посиланням з друзями, запрошуючи їх "
+"спробувати його в роботі, навіть якщо він ще не затверджений."
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:44
 msgid ""
-"Full reviews are appropriate for add-ons that are well-tested, stable, fast,"
-" and have wide appeal to our users. If you aren't confident that your add-on"
-" meets that criteria, please consider working out the kinks while in "
-"preliminary review and accumulating user feedback first."
+"Full reviews are appropriate for add-ons that are well-tested, stable, fast, and have wide appeal to our users. If you aren't confident that your add-on meets that criteria, please consider working"
+" out the kinks while in preliminary review and accumulating user feedback first."
 msgstr ""
-"Повні перевірки підходять для добре протестованих, стабільних і швидких "
-"додатків, що цікавлять широке коло користувачів. Якщо Ви не впевнені, що Ваш"
-" додаток відповідає цим критеріям, будь ласка, подумайте над усуненням "
-"проблем, поки додаток знаходиться в стадії попередньої перевірки і збирає "
-"відгуки користувачів."
+"Повні перевірки підходять для добре протестованих, стабільних і швидких додатків, що цікавлять широке коло користувачів. Якщо Ви не впевнені, що Ваш додаток відповідає цим критеріям, будь ласка, "
+"подумайте над усуненням проблем, поки додаток знаходиться в стадії попередньої перевірки і збирає відгуки користувачів."
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:50
-msgid ""
-"We aim to perform full reviews in under 10 days, though most add-ons are "
-"reviewed in much less time."
-msgstr ""
-"Ми намагаємося виконувати перевірки менше 10 днів, хоча більшість додатків "
-"перевіряється набагато швидше."
+msgid "We aim to perform full reviews in under 10 days, though most add-ons are reviewed in much less time."
+msgstr "Ми намагаємося виконувати перевірки менше 10 днів, хоча більшість додатків перевіряється набагато швидше."
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:55
 msgid "Testing Methods &amp; Common Issues"
@@ -7226,61 +5667,36 @@ msgid "When performing a full review, editors will:"
 msgstr "Під час виконання повної перевірки, редактори:"
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:64
-msgid ""
-"install the add-on, making sure it functions as described and is free of "
-"major defects"
-msgstr ""
-"встановіть додаток, переконайтеся, що він працює так, як описано, і не має "
-"значних дефектів"
+msgid "install the add-on, making sure it functions as described and is free of major defects"
+msgstr "встановіть додаток, переконайтеся, що він працює так, як описано, і не має значних дефектів"
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:69
-msgid ""
-"perform a source code review, looking for performance and security best "
-"practices"
-msgstr ""
-"перевірте програмний код, шукаючи відповідність рекомендаціям з "
-"продуктивності і безпеки"
+msgid "perform a source code review, looking for performance and security best practices"
+msgstr "перевірте програмний код, шукаючи відповідність рекомендаціям з продуктивності і безпеки"
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:74
 msgid "ensure the add-on's privacy policy is in line with its functionality"
-msgstr ""
-"переконайтеся, що політика приватності додатку відповідає його "
-"функціональності"
+msgstr "переконайтеся, що політика приватності додатку відповідає його функціональності"
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:79
-msgid ""
-"look for compliance with all of Mozilla's policies, detailed in these "
-"documents"
-msgstr ""
-"перевірте дотримання всіх політик Mozilla, викладених у цих документах"
+msgid "look for compliance with all of Mozilla's policies, detailed in these documents"
+msgstr "перевірте дотримання всіх політик Mozilla, викладених у цих документах"
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:86
-msgid ""
-"Some of the most common issues we see when performing these reviews are:"
-msgstr ""
-"Деякі з найбільш поширених проблем, які ми бачимо при виконанні цих "
-"перевірок:"
+msgid "Some of the most common issues we see when performing these reviews are:"
+msgstr "Деякі з найбільш поширених проблем, які ми бачимо при виконанні цих перевірок:"
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:93
 msgid ""
-"<strong>JavaScript namespace pollution</strong> &mdash; the most common "
-"violation. Be sure to <a "
-"href=\"https://developer.mozilla.org/en/XUL_School/JavaScript_Object_Management\">wrap"
-" your loose variables</a>"
+"<strong>JavaScript namespace pollution</strong> &mdash; the most common violation. Be sure to <a href=\"https://developer.mozilla.org/en/XUL_School/JavaScript_Object_Management\">wrap your loose "
+"variables</a>"
 msgstr ""
-"<strong>Забруднення простору імен JavaScript</strong> &mdash; найбільш "
-"поширене порушення. Не забудьте <a "
-"href=\"https://developer.mozilla.org/en/XUL_School/JavaScript_Object_Management\">обернути"
-" свої вільні змінні</a>"
+"<strong>Забруднення простору імен JavaScript</strong> &mdash; найбільш поширене порушення. Не забудьте <a href=\"https://developer.mozilla.org/en/XUL_School/JavaScript_Object_Management\">обернути "
+"свої вільні змінні</a>"
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:99
-msgid ""
-"proper preference naming - all preference names should begin with "
-"\"extensions.\", followed by the add-on name or some other unique identifier"
-msgstr ""
-"належне найменування налаштувань - всі імена налаштувань слід починати з "
-"\"extensions.\", за яким слідує ім'я додатку або інший унікальний "
-"ідентифікатор"
+msgid "proper preference naming - all preference names should begin with \"extensions.\", followed by the add-on name or some other unique identifier"
+msgstr "належне найменування налаштувань - всі імена налаштувань слід починати з \"extensions.\", за яким слідує ім'я додатку або інший унікальний ідентифікатор"
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:103
 msgid "remote JavaScript execution or injection"
@@ -7325,99 +5741,64 @@ msgstr "деградація швидкості запуску програми 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:117
 #, python-format
 msgid ""
-"For information on how to avoid these problems, please see our <a "
-"href=\"%(link_howto)s\">How-to Library</a>. Some of these practices, such as"
-" binary or obfuscated code, are allowed under certain conditions outlined "
-"below."
+"For information on how to avoid these problems, please see our <a href=\"%(link_howto)s\">How-to Library</a>. Some of these practices, such as binary or obfuscated code, are allowed under certain "
+"conditions outlined below."
 msgstr ""
-"Для отримання інформації про те, як уникнути цих проблем, ознайомтеся з <a "
-"href=\"%(link_howto)s\">Бібліотекою інструкцій</a>. Деякі з цих методів, "
-"наприклад, бінарний або заплутаний код, дозволяються з дотриманням певних "
-"умов визначених нижче."
+"Для отримання інформації про те, як уникнути цих проблем, ознайомтеся з <a href=\"%(link_howto)s\">Бібліотекою інструкцій</a>. Деякі з цих методів, наприклад, бінарний або заплутаний код, "
+"дозволяються з дотриманням певних умов визначених нижче."
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:123
 #, python-format
 msgid ""
-"Many of the above restrictions are tested automatically by an extension "
-"scanner that will flag suspicious add-ons for editor review. You can read "
-"more about this scanner in the <a href=\"%(link_validation)s\">Validation "
-"Help</a> document."
+"Many of the above restrictions are tested automatically by an extension scanner that will flag suspicious add-ons for editor review. You can read more about this scanner in the <a "
+"href=\"%(link_validation)s\">Validation Help</a> document."
 msgstr ""
-"Багато із зазначених вище обмежень перевіряються автоматично сканером "
-"розширень, який надсилатиме підозрілі додатки на перевірку редактором. Ви "
-"можете дізнатися більше про цей сканер в документі <a "
-"href=\"%(link_validation)s\">Довідка з валідації</a>."
+"Багато із зазначених вище обмежень перевіряються автоматично сканером розширень, який надсилатиме підозрілі додатки на перевірку редактором. Ви можете дізнатися більше про цей сканер в документі <a"
+" href=\"%(link_validation)s\">Довідка з валідації</a>."
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:129
 msgid ""
-"If the add-on is site-specific, it is recommended that a test account is "
-"provided for use during the review process. Additionally, including detailed"
-" testing instructions will allow an editor to better understand how the add-"
-"on functions and expedite the testing process. This information can be "
-"placed in the Notes to Reviewer field when editing a version in the "
-"Developer Hub."
+"If the add-on is site-specific, it is recommended that a test account is provided for use during the review process. Additionally, including detailed testing instructions will allow an editor to "
+"better understand how the add-on functions and expedite the testing process. This information can be placed in the Notes to Reviewer field when editing a version in the Developer Hub."
 msgstr ""
-"Якщо додаток є специфічним для сайту, ми рекомендуємо вам надати тестовий "
-"обліковий запис для використання в процесі перевірки. Крім того, включивши "
-"докладні інструкції з тестування, ви допоможете редактору краще зрозуміти, "
-"як працює додаток і прискорити процес тестування. Ця інформація може бути "
-"розміщена в поле Примітки для перевіряючих при редагуванні версії в Центрі "
-"розробки."
+"Якщо додаток є специфічним для сайту, ми рекомендуємо вам надати тестовий обліковий запис для використання в процесі перевірки. Крім того, включивши докладні інструкції з тестування, ви допоможете "
+"редактору краще зрозуміти, як працює додаток і прискорити процес тестування. Ця інформація може бути розміщена в поле Примітки для перевіряючих при редагуванні версії в Центрі розробки."
 
-#: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:134
-#: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:168
+#: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:134 src/olympia/devhub/templates/devhub/docs/policies-reviews.html:168
 msgid "After the Review"
 msgstr "Після розгляду"
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:136
 msgid ""
-"Once an add-on is granted full review, it will immediately be available in "
-"the gallery, showing in browse and search results with a warning-free "
-"install button. All features, including voluntary contributions and beta "
-"channels will be available."
+"Once an add-on is granted full review, it will immediately be available in the gallery, showing in browse and search results with a warning-free install button. All features, including voluntary "
+"contributions and beta channels will be available."
 msgstr ""
-"Як тільки додаток пройде повну перевірку, він зразу стане доступним в "
-"галереї, відображатиметься на сайті і в результатах пошуку з кнопкою "
-"установки, яка не має попередження. Всі функції, включаючи добровільні "
-"внески та бета-канали будуть доступні."
+"Як тільки додаток пройде повну перевірку, він зразу стане доступним в галереї, відображатиметься на сайті і в результатах пошуку з кнопкою установки, яка не має попередження. Всі функції, включаючи"
+" добровільні внески та бета-канали будуть доступні."
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:142
 msgid ""
-"Subsequent versions of the add-on will automatically be placed in the full "
-"review queue. Until the review is completed, the new version will only be "
-"displayed on the Version History page of the add-on. Once reviewed, the "
-"version will be updated across the site and deployed through the automatic "
-"update service."
+"Subsequent versions of the add-on will automatically be placed in the full review queue. Until the review is completed, the new version will only be displayed on the Version History page of the "
+"add-on. Once reviewed, the version will be updated across the site and deployed through the automatic update service."
 msgstr ""
-"Подальші версії додатку будуть автоматично розміщуватися в черзі на повну "
-"перевірку. До завершення перевірки, нова версія відображатиметься тільки на "
-"сторінці історії версій додатку. По завершенні перевірки, версію буде "
-"оновлено на сайті й розгорнуто через службу автоматичного оновлення."
+"Подальші версії додатку будуть автоматично розміщуватися в черзі на повну перевірку. До завершення перевірки, нова версія відображатиметься тільки на сторінці історії версій додатку. По завершенні "
+"перевірки, версію буде оновлено на сайті й розгорнуто через службу автоматичного оновлення."
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:148
 msgid ""
-"If a version does not meet the criteria for full review, it can either be "
-"granted preliminary review or disabled if there is a security concern. The "
-"author will receive an email explaining the action taken and how to fix it. "
-"In most cases, the developer can simply fix the problem and re-submit for "
-"full review."
+"If a version does not meet the criteria for full review, it can either be granted preliminary review or disabled if there is a security concern. The author will receive an email explaining the "
+"action taken and how to fix it. In most cases, the developer can simply fix the problem and re-submit for full review."
 msgstr ""
-"Якщо версія не відповідає критеріям повної перевірки, вона може або пройти "
-"попередню перевірку, або бути відключена, якщо виникла проблема з безпекою. "
-"Автор отримає електронного листа, що пояснює вжиті заходи і те, як виправити"
-" цю ситуацію. У більшості випадків розробник може просто виправити проблему "
-"і знову представити версію для повної перевірки."
+"Якщо версія не відповідає критеріям повної перевірки, вона може або пройти попередню перевірку, або бути відключена, якщо виникла проблема з безпекою. Автор отримає електронного листа, що пояснює "
+"вжиті заходи і те, як виправити цю ситуацію. У більшості випадків розробник може просто виправити проблему і знову представити версію для повної перевірки."
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:155
 msgid ""
-"Preliminary reviews are appropriate for experimental add-ons and provide a "
-"way to get user testing and feedback without going through the longer, more "
-"thorough review process. We aim to complete these reviews in under 3 days."
+"Preliminary reviews are appropriate for experimental add-ons and provide a way to get user testing and feedback without going through the longer, more thorough review process. We aim to complete "
+"these reviews in under 3 days."
 msgstr ""
-"Попередні перевірки підходять для експериментальних додатків і забезпечують "
-"тестування користувачами і зворотний зв'язок, без проходження більш довгого,"
-" більш ретельного процесу перевірки. Ми прагнемо завершувати ці перевірки "
-"протягом 3 днів."
+"Попередні перевірки підходять для експериментальних додатків і забезпечують тестування користувачами і зворотний зв'язок, без проходження більш довгого, більш ретельного процесу перевірки. Ми "
+"прагнемо завершувати ці перевірки протягом 3 днів."
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:160
 msgid "Testing Methods"
@@ -7425,55 +5806,33 @@ msgstr "Методи тестування"
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:162
 msgid ""
-"When performing a preliminary review, editors will review the source code "
-"for security issues and major policy violations, but will not install the "
-"add-on to test functionality in most cases. Preliminary review will be "
-"granted unless a security vulnerability or major policy violation is "
-"discovered."
+"When performing a preliminary review, editors will review the source code for security issues and major policy violations, but will not install the add-on to test functionality in most cases. "
+"Preliminary review will be granted unless a security vulnerability or major policy violation is discovered."
 msgstr ""
-"Під час проведення попередньої перевірки, редактори перевірять програмний "
-"код на наявність проблем безпеки і серйозних порушень політики, але в "
-"більшості випадків не встановлюватимуть додаток для перевірки його "
-"функціональності. Попередня перевірка буде пройдена, якщо не буде виявлена "
-"уразливість в системі безпеки або грубе порушення політики."
+"Під час проведення попередньої перевірки, редактори перевірять програмний код на наявність проблем безпеки і серйозних порушень політики, але в більшості випадків не встановлюватимуть додаток для "
+"перевірки його функціональності. Попередня перевірка буде пройдена, якщо не буде виявлена уразливість в системі безпеки або грубе порушення політики."
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:171
 msgid ""
-"Once preliminary review is granted, the add-on will be immediately available"
-" in the gallery, showing in browse and search results but ranked lower than "
-"fully-reviewed add-ons. Install buttons will have caution stripes and a "
-"notice that the add-on is experimental and not fully reviewed by Mozilla, "
-"though no click-through is required. Additionally, these add-ons cannot use "
-"the voluntary contributions and beta channel features."
+"Once preliminary review is granted, the add-on will be immediately available in the gallery, showing in browse and search results but ranked lower than fully-reviewed add-ons. Install buttons will "
+"have caution stripes and a notice that the add-on is experimental and not fully reviewed by Mozilla, though no click-through is required. Additionally, these add-ons cannot use the voluntary "
+"contributions and beta channel features."
 msgstr ""
-"Після успішного проходження попередньої перевірки, додаток відразу ж стане "
-"доступним в галереї, буде показаний в перегляді та результатах пошуку, але "
-"буде мати більш низький статус, ніж повністю перевірені додатки. Кнопки "
-"установки матимуть попереджувальні смуги і повідомлення, що додаток є "
-"експериментальним і не повністю перевірений Mozilla. Крім того, ці додатки "
-"не можуть використовувати добровільні внески та функції бета-каналів."
+"Після успішного проходження попередньої перевірки, додаток відразу ж стане доступним в галереї, буде показаний в перегляді та результатах пошуку, але буде мати більш низький статус, ніж повністю "
+"перевірені додатки. Кнопки установки матимуть попереджувальні смуги і повідомлення, що додаток є експериментальним і не повністю перевірений Mozilla. Крім того, ці додатки не можуть використовувати"
+" добровільні внески та функції бета-каналів."
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:177
-msgid ""
-"After being granted preliminary review, Mozilla may later revoke the review "
-"if other serious problems are reported to us by users."
-msgstr ""
-"Після успішного проходження попередньої перевірки, Mozilla згодом може "
-"відкликати своє схвалення, якщо користувачі повідомлять нам про інші "
-"серйозні проблеми."
+msgid "After being granted preliminary review, Mozilla may later revoke the review if other serious problems are reported to us by users."
+msgstr "Після успішного проходження попередньої перевірки, Mozilla згодом може відкликати своє схвалення, якщо користувачі повідомлять нам про інші серйозні проблеми."
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:183
 msgid ""
-"Subsequent versions of the add-on will automatically be placed in the "
-"preliminary review queue. Until the review is completed, the new version "
-"will only be displayed on the Version History page of the add-on. Once "
-"reviewed, the version will be updated across the site and deployed through "
-"the automatic update service."
+"Subsequent versions of the add-on will automatically be placed in the preliminary review queue. Until the review is completed, the new version will only be displayed on the Version History page of "
+"the add-on. Once reviewed, the version will be updated across the site and deployed through the automatic update service."
 msgstr ""
-"Подальші версії додатку будуть автоматично розміщуватися в черзі на "
-"попередню перевірку. До завершення перевірки, нова версія буде відображена "
-"тільки на сторінці історії версій додатку. По завершенні перевірки, версія "
-"буде оновлена на сайті й розгорнута службою автоматичного оновлення."
+"Подальші версії додатку будуть автоматично розміщуватися в черзі на попередню перевірку. До завершення перевірки, нова версія буде відображена тільки на сторінці історії версій додатку. По "
+"завершенні перевірки, версія буде оновлена на сайті й розгорнута службою автоматичного оновлення."
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:188
 msgid "Policies on Specific Add-on Practices"
@@ -7488,68 +5847,40 @@ msgid "The following add-ons are not permitted in any form:"
 msgstr "Такі додатки не дозволяються ні в якій формі:"
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:194
-msgid ""
-"Add-ons that embed known <a "
-"href=\"http://en.wikipedia.org/wiki/Spyware\">spyware</a> or <a "
-"href=\"http://en.wikipedia.org/wiki/Malware\">malware</a>"
-msgstr ""
-"Додатки, які містять відомі <a "
-"href=\"http://en.wikipedia.org/wiki/Spyware\">шпигунські</a> чи <a "
-"href=\"http://en.wikipedia.org/wiki/Malware\">шкідливі</a> програми"
+msgid "Add-ons that embed known <a href=\"http://en.wikipedia.org/wiki/Spyware\">spyware</a> or <a href=\"http://en.wikipedia.org/wiki/Malware\">malware</a>"
+msgstr "Додатки, які містять відомі <a href=\"http://en.wikipedia.org/wiki/Spyware\">шпигунські</a> чи <a href=\"http://en.wikipedia.org/wiki/Malware\">шкідливі</a> програми"
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:199
 msgid ""
-"Illegal and criminal add-ons, such as <a "
-"href=\"http://en.wikipedia.org/wiki/Click_fraud\">click fraud</a> "
-"generators, <a href=\"http://en.wikipedia.org/wiki/Warez\">warez</a> "
-"download and directory assistants, child pornography finders, etc."
+"Illegal and criminal add-ons, such as <a href=\"http://en.wikipedia.org/wiki/Click_fraud\">click fraud</a> generators, <a href=\"http://en.wikipedia.org/wiki/Warez\">warez</a> download and "
+"directory assistants, child pornography finders, etc."
 msgstr ""
-"Незаконні і злочинні додатки, такі як генератори <a "
-"href=\"http://en.wikipedia.org/wiki/Click_fraud\">клік-фроду</a>, "
-"завантаження <a href=\"http://en.wikipedia.org/wiki/Warez\">варезу</a> і "
+"Незаконні і злочинні додатки, такі як генератори <a href=\"http://en.wikipedia.org/wiki/Click_fraud\">клік-фроду</a>, завантаження <a href=\"http://en.wikipedia.org/wiki/Warez\">варезу</a> і "
 "каталоги-помічники, шукачі дитячої порнографії, і т.д."
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:204
-msgid ""
-"Add-ons whose main purpose is to facilitate access to pornographic material,"
-" or include references to this material in their descriptions"
-msgstr ""
-"Додатки, головна мета яких полягає в полегшенні доступу до порнографічних "
-"матеріалів, або містять в своїх описах посилання на ці матеріали"
+msgid "Add-ons whose main purpose is to facilitate access to pornographic material, or include references to this material in their descriptions"
+msgstr "Додатки, головна мета яких полягає в полегшенні доступу до порнографічних матеріалів, або містять в своїх описах посилання на ці матеріали"
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:210
-msgid ""
-"Add-ons that, upon installation, auto-install or launch installers of non-"
-"Firefox software"
-msgstr ""
-"Додатки, які після свого встановлення, автоматично встановлюють або "
-"запускають інсталятори програмного забезпечення, яке не стосується Firefox"
+msgid "Add-ons that, upon installation, auto-install or launch installers of non-Firefox software"
+msgstr "Додатки, які після свого встановлення, автоматично встановлюють або запускають інсталятори програмного забезпечення, яке не стосується Firefox"
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:215
-msgid ""
-"Add-ons that provide their own update mechanism for code or search engines"
-msgstr ""
-"Додатки, які містять свій власний механізм оновлення для коду або пошукових "
-"систем"
+msgid "Add-ons that provide their own update mechanism for code or search engines"
+msgstr "Додатки, які містять свій власний механізм оновлення для коду або пошукових систем"
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:220
-msgid ""
-"Add-ons that make changes to web content in ways that are non-obvious or "
-"difficult to trace by their users"
-msgstr ""
-"Додатки, які вносять зміни в веб-вміст не очевидними або важкими для "
-"відстеження користувачами способами"
+msgid "Add-ons that make changes to web content in ways that are non-obvious or difficult to trace by their users"
+msgstr "Додатки, які вносять зміни в веб-вміст не очевидними або важкими для відстеження користувачами способами"
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:225
 msgid "Add-ons that snoop on or intercept the network traffic of other users"
-msgstr ""
-"Додатки, які підглядають або перехоплюють мережевий трафік інших "
-"користувачів"
+msgstr "Додатки, які підглядають або перехоплюють мережевий трафік інших користувачів"
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:230
 msgid "Conduit-based toolbars without explicit pre-approval"
-msgstr ""
-"Засновані на Conduit панелі інструментів без явного попереднього схвалення"
+msgstr "Засновані на Conduit панелі інструментів без явного попереднього схвалення"
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:236
 msgid "Changing of Defaults and Unexpected Features"
@@ -7557,67 +5888,34 @@ msgstr "Такі, що змінюють типові значення і маю�
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:238
 msgid ""
-"Surprises can be appropriate in many situations, but they are not welcome "
-"when user security, privacy, and control are at stake. It is extremely "
-"important to be as transparent as possible when submitting an add-on for "
-"hosting on this site. A Mozilla user should be able to easily discern what "
-"the functionality of an add-on is and not be presented with unexpected "
-"experiences post-install."
+"Surprises can be appropriate in many situations, but they are not welcome when user security, privacy, and control are at stake. It is extremely important to be as transparent as possible when "
+"submitting an add-on for hosting on this site. A Mozilla user should be able to easily discern what the functionality of an add-on is and not be presented with unexpected experiences post-install."
 msgstr ""
-"Сюрпризи можуть бути доречними в різних ситуаціях, але вони не є бажаними, "
-"коли на кону стоїть безпека і приватність користувача або його контроль за "
-"ситуацією. При направленні додатку для розміщення на цьому сайті надзвичайно"
-" важливо дотримуватися максимальної прозорості. Користувач Mozilla має легко"
-" розпізнати, що є функціональністю додатку і не зустрічатися з несподіваними"
-" сюрпризами після встановлення."
+"Сюрпризи можуть бути доречними в різних ситуаціях, але вони не є бажаними, коли на кону стоїть безпека і приватність користувача або його контроль за ситуацією. При направленні додатку для "
+"розміщення на цьому сайті надзвичайно важливо дотримуватися максимальної прозорості. Користувач Mozilla має легко розпізнати, що є функціональністю додатку і не зустрічатися з несподіваними "
+"сюрпризами після встановлення."
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:243
 msgid ""
-"<p> Whenever an add-on includes any unexpected* feature that </p> <ul> "
-"<li>compromises user privacy or security (like sending data to third "
-"parties),</li> <li>changes default settings like the homepage or search "
-"engine, or</li> <li>changes settings or features in other add-ons or "
-"deactivates them altogether</li> </ul> <p>the features must adhere to the "
-"following requirements:</p> <ul> <li>The add-on description must clearly "
-"state what changes the add-on makes.</li> <li>All changes must be opt-in, "
-"meaning the user must take non-default action to enact the change.</li> "
-"<li>The opt-in dialog must clearly state the name of the add-on requesting "
-"the change.</li> <li>Uninstalling the add-on restores the user's original "
-"settings if they were changed.</li> </ul> <p>*Unexpected features are those "
-"that are unrelated to the add-on's primary function.</p>"
+"<p> Whenever an add-on includes any unexpected* feature that </p> <ul> <li>compromises user privacy or security (like sending data to third parties),</li> <li>changes default settings like the "
+"homepage or search engine, or</li> <li>changes settings or features in other add-ons or deactivates them altogether</li> </ul> <p>the features must adhere to the following requirements:</p> <ul> "
+"<li>The add-on description must clearly state what changes the add-on makes.</li> <li>All changes must be opt-in, meaning the user must take non-default action to enact the change.</li> <li>The "
+"opt-in dialog must clearly state the name of the add-on requesting the change.</li> <li>Uninstalling the add-on restores the user's original settings if they were changed.</li> </ul> <p>*Unexpected"
+" features are those that are unrelated to the add-on's primary function.</p>"
 msgstr ""
-"<p> Кожного разу, коли додаток включає в себе будь-яку несподівану* функцію,"
-" яка </p> <ul> <li>компрометує приватність або безпеку користувача "
-"(наприклад передає дані третім особам),</li> <li>змінює типові налаштування,"
-" наприклад домашню сторінку чи засіб пошуку, або</li> <li>змінює "
-"налаштування чи функції в інших додатках, або деактивує їх "
-"повністю</li></ul><p>функції повинні відповідати таким вимогам:</p> <ul> "
-"<li>Опис додатка повинен чітко вказувати які він робить зміни.</li> "
-"<li>Користувач повинен в явному вигляді погодитися прийняти всі зміни, тобто"
-" користувач повинен провести нестандартні дії по прийняттю змін.</li> <li>У "
-"діалоговому вікні, де відбуваються зміни, має бути чітко зазначено ім'я "
-"додатку, який пропонує зміни.</li> <li>Видалення додатка повинно "
-"відновлювати початкові налаштування користувача, якщо вони були "
-"змінені.</li> </ul> <p>*Несподіваними функціями є такі, що не стосуються "
-"основної функції додатка.</p>"
+"<p> Кожного разу, коли додаток включає в себе будь-яку несподівану* функцію, яка </p> <ul> <li>компрометує приватність або безпеку користувача (наприклад передає дані третім особам),</li> "
+"<li>змінює типові налаштування, наприклад домашню сторінку чи засіб пошуку, або</li> <li>змінює налаштування чи функції в інших додатках, або деактивує їх повністю</li></ul><p>функції повинні "
+"відповідати таким вимогам:</p> <ul> <li>Опис додатка повинен чітко вказувати які він робить зміни.</li> <li>Користувач повинен в явному вигляді погодитися прийняти всі зміни, тобто користувач "
+"повинен провести нестандартні дії по прийняттю змін.</li> <li>У діалоговому вікні, де відбуваються зміни, має бути чітко зазначено ім'я додатку, який пропонує зміни.</li> <li>Видалення додатка "
+"повинно відновлювати початкові налаштування користувача, якщо вони були змінені.</li> </ul> <p>*Несподіваними функціями є такі, що не стосуються основної функції додатка.</p>"
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:268
-msgid ""
-"These features cannot be introduced into an update of a fully-reviewed add-"
-"on; the opt-in change process must be part of the initial review."
-msgstr ""
-"Ці функції не можуть бути в оновленні повністю перевіреного додатка; зміна "
-"процесу отримання згоди має бути частиною первинної перевірки."
+msgid "These features cannot be introduced into an update of a fully-reviewed add-on; the opt-in change process must be part of the initial review."
+msgstr "Ці функції не можуть бути в оновленні повністю перевіреного додатка; зміна процесу отримання згоди має бути частиною первинної перевірки."
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:274
-msgid ""
-"These are minimum requirements and not a guarantee that the add-on will be "
-"approved. This section applies to all add-ons hosted on the site, including "
-"preliminarily reviewed add-ons."
-msgstr ""
-"Це мінімальні вимоги і вони не гарантують того, що додаток буде схвалено. "
-"Цей розділ стосується всіх додатків, розміщених на сайті, у тому числі "
-"попередньо схвалених."
+msgid "These are minimum requirements and not a guarantee that the add-on will be approved. This section applies to all add-ons hosted on the site, including preliminarily reviewed add-ons."
+msgstr "Це мінімальні вимоги і вони не гарантують того, що додаток буде схвалено. Цей розділ стосується всіх додатків, розміщених на сайті, у тому числі попередньо схвалених."
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:279
 msgid "Private Browsing Mode"
@@ -7625,18 +5923,12 @@ msgstr "Режим приватного перегляду"
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:282
 msgid ""
-"Add-ons that store or otherwise handle browsing data must support <a "
-"href=\"https://developer.mozilla.org/En/Supporting_private_browsing_mode\">Private"
-" Browsing Mode</a>. During a Private Browsing session, no browsing data can "
-"be written to disk, and all of this data must be cleared when Firefox quits "
-"or the Private Browsing session ends."
+"Add-ons that store or otherwise handle browsing data must support <a href=\"https://developer.mozilla.org/En/Supporting_private_browsing_mode\">Private Browsing Mode</a>. During a Private Browsing "
+"session, no browsing data can be written to disk, and all of this data must be cleared when Firefox quits or the Private Browsing session ends."
 msgstr ""
-"Додатки, які зберігають чи іншим чином обробляють дані веб-перегляду повинні"
-" підтримувати <a "
-"href=\"https://developer.mozilla.org/En/Supporting_private_browsing_mode\">режим"
-" приватного перегляду</a>. Під час сеансу приватного перегляду ніякі дані "
-"веб-перегляду не повинні записуватися на диск, і всі ці дані повинні бути "
-"очищені при виході з Firefox або при завершенні сеансу приватного перегляду."
+"Додатки, які зберігають чи іншим чином обробляють дані веб-перегляду повинні підтримувати <a href=\"https://developer.mozilla.org/En/Supporting_private_browsing_mode\">режим приватного "
+"перегляду</a>. Під час сеансу приватного перегляду ніякі дані веб-перегляду не повинні записуватися на диск, і всі ці дані повинні бути очищені при виході з Firefox або при завершенні сеансу "
+"приватного перегляду."
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:287
 msgid "Binary Components & Obfuscated Code"
@@ -7644,42 +5936,26 @@ msgstr "Бінарні компоненти і заплутаний код"
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:289
 msgid ""
-"Add-ons may contain binary, obfuscated and minified source code, but Mozilla"
-" must be allowed to review a copy of the human-readable source code of each "
-"version of an add-on submitted for review. These add-ons are ineligible for "
-"preliminary review and must choose the full review process."
+"Add-ons may contain binary, obfuscated and minified source code, but Mozilla must be allowed to review a copy of the human-readable source code of each version of an add-on submitted for review. "
+"These add-ons are ineligible for preliminary review and must choose the full review process."
 msgstr ""
-"Додатки можуть містити бінарний, заплутаний та мінімізований програмний код,"
-" але для Mozilla повинна бути надана можливість перевірки доступною для "
-"людського розуміння копії програмного коду для кожної версії додатку, "
-"представленого для перевірки. Ці додатки не мають права на процес "
-"попередньої перевірки й повинні вибрати процес повної перевірки."
+"Додатки можуть містити бінарний, заплутаний та мінімізований програмний код, але для Mozilla повинна бути надана можливість перевірки доступною для людського розуміння копії програмного коду для "
+"кожної версії додатку, представленого для перевірки. Ці додатки не мають права на процес попередньої перевірки й повинні вибрати процес повної перевірки."
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:295
 msgid ""
-"If an add-on contains binary or obfuscated source code, the author will "
-"receive a message when the add-on is reviewed indicating whom to contact at "
-"Mozilla to coordinate review of the source code. This code will be reviewed "
-"by an administrator and will not be shared or redistributed in any way. The "
-"code will only be used for the purpose of reviewing the add-on."
+"If an add-on contains binary or obfuscated source code, the author will receive a message when the add-on is reviewed indicating whom to contact at Mozilla to coordinate review of the source code. "
+"This code will be reviewed by an administrator and will not be shared or redistributed in any way. The code will only be used for the purpose of reviewing the add-on."
 msgstr ""
-"Якщо додаток містить бінарний або заплутаний програмний код, при перевірці "
-"додатка автор отримає повідомлення, що вказує, з ким із Mozilla йому треба "
-"зв'язатися для координації перевірки цього коду. Код буде перевірений "
-"адміністратором і не передаватиметься або розповсюджуватиметься будь-яким "
-"чином. Код буде використаний тільки з метою перевірки додатку."
+"Якщо додаток містить бінарний або заплутаний програмний код, при перевірці додатка автор отримає повідомлення, що вказує, з ким із Mozilla йому треба зв'язатися для координації перевірки цього "
+"коду. Код буде перевірений адміністратором і не передаватиметься або розповсюджуватиметься будь-яким чином. Код буде використаний тільки з метою перевірки додатку."
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:301
 #, python-format
-msgid ""
-"If your add-on contains binary or obfuscated code that you don't own or "
-"can't get the source code for, you may <a href=\"%(link_contact)s\">contact "
-"us</a> for information on how to proceed."
+msgid "If your add-on contains binary or obfuscated code that you don't own or can't get the source code for, you may <a href=\"%(link_contact)s\">contact us</a> for information on how to proceed."
 msgstr ""
-"Якщо ваш додаток містить бінарний або заплутаний код, який вам не належить "
-"або для якого ви не можете отримати програмний код, ви можете <a "
-"href=\"%(link_contact)s\">зв'язатися з нами</a> для отримання інформації про"
-" подальші дії."
+"Якщо ваш додаток містить бінарний або заплутаний код, який вам не належить або для якого ви не можете отримати програмний код, ви можете <a href=\"%(link_contact)s\">зв'язатися з нами</a> для "
+"отримання інформації про подальші дії."
 
 #: src/olympia/devhub/templates/devhub/docs/policies-submission.html:11
 msgid "Criteria for Submission"
@@ -7687,229 +5963,125 @@ msgstr "Критерій представлення"
 
 #: src/olympia/devhub/templates/devhub/docs/policies-submission.html:13
 msgid ""
-"Add-ons hosted on Mozilla Add-ons should be of high quality and give users "
-"an improved web experience. We look for the following things when deciding "
-"whether an add-on is appropriate to be public and unrestricted:"
+"Add-ons hosted on Mozilla Add-ons should be of high quality and give users an improved web experience. We look for the following things when deciding whether an add-on is appropriate to be public "
+"and unrestricted:"
 msgstr ""
-"Додатки, розміщені на сайті дододатків Mozilla повинні мати високу якість і "
-"покращувати користувачам роботу в Інтернеті. При прийнятті рішення, чи може "
-"додаток бути публічним і необмеженим у поширенні ми дивимося на наступне:"
+"Додатки, розміщені на сайті дододатків Mozilla повинні мати високу якість і покращувати користувачам роботу в Інтернеті. При прийнятті рішення, чи може додаток бути публічним і необмеженим у "
+"поширенні ми дивимося на наступне:"
 
 #: src/olympia/devhub/templates/devhub/docs/policies-submission.html:19
 msgid ""
-"<strong>Are you responsive?</strong> We expect that an author who is "
-"promoting their add-on to our applications' many users is responsive to "
-"problem reports, maintains their contact information, and updates their add-"
-"on promptly to keep current with Firefox releases and changes in our "
-"policies. This doesn't mean that you have to reply to every question that "
-"someone posts in the discussions, or that you even need to fix every bug, "
-"but we do expect that you will respond to issues in a manner that's "
-"appropriate to the severity of the issue in question."
+"<strong>Are you responsive?</strong> We expect that an author who is promoting their add-on to our applications' many users is responsive to problem reports, maintains their contact information, "
+"and updates their add-on promptly to keep current with Firefox releases and changes in our policies. This doesn't mean that you have to reply to every question that someone posts in the "
+"discussions, or that you even need to fix every bug, but we do expect that you will respond to issues in a manner that's appropriate to the severity of the issue in question."
 msgstr ""
-"<strong>Ви чуйні?</strong> Ми очікуємо, що автор, який поширює свій додаток "
-"для наших численних користувачів, буде реагувати на повідомлення про "
-"проблеми, мати актуальні контактні дані та оперативно оновлювати свій "
-"додаток, не відстаючи від випусків Firefox і змін в наших політиках. Це не "
-"означає, що ви повинні відповідати на кожне питання, яке задається ким-"
-"небудь в ході обговорення, або навіть що вам потрібно виправляти кожну "
-"помилку, але ми очікуємо, що ви будете реагувати на проблеми відповідно до "
-"їх важливості."
+"<strong>Ви чуйні?</strong> Ми очікуємо, що автор, який поширює свій додаток для наших численних користувачів, буде реагувати на повідомлення про проблеми, мати актуальні контактні дані та "
+"оперативно оновлювати свій додаток, не відстаючи від випусків Firefox і змін в наших політиках. Це не означає, що ви повинні відповідати на кожне питання, яке задається ким-небудь в ході "
+"обговорення, або навіть що вам потрібно виправляти кожну помилку, але ми очікуємо, що ви будете реагувати на проблеми відповідно до їх важливості."
 
 #: src/olympia/devhub/templates/devhub/docs/policies-submission.html:25
 msgid ""
-"<strong>Is the add-on clearly and accurately described?</strong> It's of the"
-" utmost importance to us that users get what they expect when they try a new"
-" add-on. Your add-on name should be clear and concise, and you should "
-"refrain from using special characters or numbers to get higher search "
-"rankings or for decorative purposes. Your description should provide details"
-" about what the add-on does, how a user should take advantage of it, and "
-"what the user should expect when they install it. Links to external "
-"documents for detailed instructions are fine, but the description itself "
-"should cover the basics and leave users confident that they know what "
-"they'll get. Also, it is important that you maintain version notes "
-"appropriately as you improve and change your add-on. Users should be able to"
-" see what's new in an add-on they may have tried previously, and should be "
-"made aware of changes that might affect their current use of the add-on when"
-" they update."
+"<strong>Is the add-on clearly and accurately described?</strong> It's of the utmost importance to us that users get what they expect when they try a new add-on. Your add-on name should be clear and"
+" concise, and you should refrain from using special characters or numbers to get higher search rankings or for decorative purposes. Your description should provide details about what the add-on "
+"does, how a user should take advantage of it, and what the user should expect when they install it. Links to external documents for detailed instructions are fine, but the description itself should"
+" cover the basics and leave users confident that they know what they'll get. Also, it is important that you maintain version notes appropriately as you improve and change your add-on. Users should "
+"be able to see what's new in an add-on they may have tried previously, and should be made aware of changes that might affect their current use of the add-on when they update."
 msgstr ""
-"<strong>Додаток описано чітко й акуратно?</strong> Для нас вкрай важливо, "
-"щоб користувачі отримували те, чого вони очікують від роботи нового додатку."
-" Ім'я вашого додатку повинно бути чітким і зрозумілим, і вам слід "
-"утримуватися від використання спеціальних символів або цифр для отримання "
-"більш високого пошукового рейтингу або в декоративних цілях. Ваш опис має "
-"надавати інформацію про те, що робить додаток, як його можна використовувати"
-" і що повинен очікувати користувач після встановлення додатку. Ви можете "
-"вказати посилання на зовнішні документи з детальними інструкціями, але сам "
-"опис повинен містити основи, щоб дати користувачам впевненість, що вони "
-"знають, що отримають. Крім того, важливо, щоб ви додавали примітки до нових "
-"версій про те, як ви покращуєте і змінюєте ваш додаток. Користувачі повинні "
-"бачити, що нового з'явилося в раніше використовуваному ними додатку, і бути "
-"в курсі змін, які можуть вплинути на їх поточну роботу з додатком після "
-"оновлення."
+"<strong>Додаток описано чітко й акуратно?</strong> Для нас вкрай важливо, щоб користувачі отримували те, чого вони очікують від роботи нового додатку. Ім'я вашого додатку повинно бути чітким і "
+"зрозумілим, і вам слід утримуватися від використання спеціальних символів або цифр для отримання більш високого пошукового рейтингу або в декоративних цілях. Ваш опис має надавати інформацію про "
+"те, що робить додаток, як його можна використовувати і що повинен очікувати користувач після встановлення додатку. Ви можете вказати посилання на зовнішні документи з детальними інструкціями, але "
+"сам опис повинен містити основи, щоб дати користувачам впевненість, що вони знають, що отримають. Крім того, важливо, щоб ви додавали примітки до нових версій про те, як ви покращуєте і змінюєте "
+"ваш додаток. Користувачі повинні бачити, що нового з'явилося в раніше використовуваному ними додатку, і бути в курсі змін, які можуть вплинути на їх поточну роботу з додатком після оновлення."
 
 #: src/olympia/devhub/templates/devhub/docs/policies-submission.html:31
 msgid ""
-"<strong>Are all privacy and security concerns clearly spelled out?</strong> "
-"This is an aspect of a clear and accurate description, but such an important"
-" one that we feel it deserves specific mention. Many very useful and well-"
-"written add-ons manipulate some form of user data, or can present security "
-"hazards if misused; they are welcome on the site, but they must make it very"
-" clear to users what risks they might encounter, and what they can do to "
-"protect themselves."
+"<strong>Are all privacy and security concerns clearly spelled out?</strong> This is an aspect of a clear and accurate description, but such an important one that we feel it deserves specific "
+"mention. Many very useful and well-written add-ons manipulate some form of user data, or can present security hazards if misused; they are welcome on the site, but they must make it very clear to "
+"users what risks they might encounter, and what they can do to protect themselves."
 msgstr ""
-"<strong>Чи всі питання приватності і безпеки прописані чітко?</strong> Це є "
-"аспектом чіткого і точного опису, та є настільки важливим, що потребує "
-"особливої уваги. Багато дуже корисних і добре описаних додатків маніпулюють "
-"тією або іншою формою даних користувача або можуть становити загрозу безпеці"
-" при їх неправильному використанні; ми вітаємо їх на нашому сайті, але вони "
-"повинні дуже чітко проінформувати користувачів, з якими ризиками вони можуть"
-" зіткнутися, і що вони можуть зробити для свого захисту."
+"<strong>Чи всі питання приватності і безпеки прописані чітко?</strong> Це є аспектом чіткого і точного опису, та є настільки важливим, що потребує особливої уваги. Багато дуже корисних і добре "
+"описаних додатків маніпулюють тією або іншою формою даних користувача або можуть становити загрозу безпеці при їх неправильному використанні; ми вітаємо їх на нашому сайті, але вони повинні дуже "
+"чітко проінформувати користувачів, з якими ризиками вони можуть зіткнутися, і що вони можуть зробити для свого захисту."
 
 #: src/olympia/devhub/templates/devhub/docs/policies-submission.html:37
 msgid ""
-"<strong>Has the add-on been well-tested, and is it free of obvious or "
-"serious defects?</strong> One important thing that we look for when "
-"considering an add-on is whether its user reviews indicate that it has "
-"received thorough testing, and that it doesn't have serious problems or "
-"negative impacts on the browser. If reviewers report problems such as major "
-"performance issues, crashes, frequent problems using the functions of the "
-"add-on, or spamming of messages to the error console, you should take those "
-"reports to heart, and re-submit your add-on after you've addressed them as "
-"best you can. We don't expect you to perfectly optimize or have zero bugs "
-"&mdash; Firefox itself undergoes constant improvement in these areas &mdash;"
-" but we do want you to take reasonable efforts to minimize downsides, and to"
-" clearly call out cases where users may be surprised by those that remain."
+"<strong>Has the add-on been well-tested, and is it free of obvious or serious defects?</strong> One important thing that we look for when considering an add-on is whether its user reviews indicate "
+"that it has received thorough testing, and that it doesn't have serious problems or negative impacts on the browser. If reviewers report problems such as major performance issues, crashes, frequent"
+" problems using the functions of the add-on, or spamming of messages to the error console, you should take those reports to heart, and re-submit your add-on after you've addressed them as best you "
+"can. We don't expect you to perfectly optimize or have zero bugs &mdash; Firefox itself undergoes constant improvement in these areas &mdash; but we do want you to take reasonable efforts to "
+"minimize downsides, and to clearly call out cases where users may be surprised by those that remain."
 msgstr ""
-"<strong>Чи додаток було добре протестовано і в нього немає очевидних або "
-"серйозних дефектів?</strong> Одним дуже важливим моментом, на який ми "
-"звертаємо увагу під час розгляду додатку є відгуки користувачів, які "
-"показують, що додаток пройшов ретельне тестування, і не має серйозних "
-"проблем або негативного впливу на браузер. Якщо у відгуках повідомляється "
-"про серйозні проблеми з продуктивністю, падіння, постійні проблеми при "
-"використанні функцій додатку або безлічі повідомлень на консолі помилок, ви "
-"повинні ретельно розглянути ці повідомлення, і знову представити ваш додаток"
-" після максимального усунення цих проблем. Ми не очікуємо, що ви досягнете "
-"максимальної оптимізації або повного усунення помилок &mdash; в цих областях"
-" Firefox сам піддається постійним удосконаленням &mdash; але ми хочемо, щоб "
-"ви доклали зусиль для зменшення недоліків і чітко позначили ті випадки, в "
-"яких користувачі можуть зустріти неочікувані ними проблеми, що залишилися."
+"<strong>Чи додаток було добре протестовано і в нього немає очевидних або серйозних дефектів?</strong> Одним дуже важливим моментом, на який ми звертаємо увагу під час розгляду додатку є відгуки "
+"користувачів, які показують, що додаток пройшов ретельне тестування, і не має серйозних проблем або негативного впливу на браузер. Якщо у відгуках повідомляється про серйозні проблеми з "
+"продуктивністю, падіння, постійні проблеми при використанні функцій додатку або безлічі повідомлень на консолі помилок, ви повинні ретельно розглянути ці повідомлення, і знову представити ваш "
+"додаток після максимального усунення цих проблем. Ми не очікуємо, що ви досягнете максимальної оптимізації або повного усунення помилок &mdash; в цих областях Firefox сам піддається постійним "
+"удосконаленням &mdash; але ми хочемо, щоб ви доклали зусиль для зменшення недоліків і чітко позначили ті випадки, в яких користувачі можуть зустріти неочікувані ними проблеми, що залишилися."
 
 #: src/olympia/devhub/templates/devhub/docs/policies-submission.html:43
 msgid ""
-"<strong>Do the add-on and add-on author both treat the user "
-"respectfully?</strong> Your software should not intrude on the user "
-"unnecessarily, try to trick the user, or conceal any of its activities from "
-"the user. Users (or even non-users) are sometimes rude in their comments, "
-"and while we will do our best to filter out inaccurate reviews as they're "
-"reported to us, we do expect that authors will avoid retaliating with "
-"rudeness of their own."
+"<strong>Do the add-on and add-on author both treat the user respectfully?</strong> Your software should not intrude on the user unnecessarily, try to trick the user, or conceal any of its "
+"activities from the user. Users (or even non-users) are sometimes rude in their comments, and while we will do our best to filter out inaccurate reviews as they're reported to us, we do expect that"
+" authors will avoid retaliating with rudeness of their own."
 msgstr ""
-"<strong>Чи відноситься додаток або автор додатка з повагою до "
-"користувача?</strong> Ваша програма не повинна без необхідності втручатися в"
-" роботу користувача, намагатися обдурити або приховувати будь-які свої дії. "
-"Користувачі (або навіть не користувачі) іноді грублять у своїх коментарях, і"
-" поки ми зробимо все можливе, щоб відфільтрувати некоректні відгуки, ми "
-"очікуємо від авторів, що вони не будуть відповідати грубістю на грубість."
+"<strong>Чи відноситься додаток або автор додатка з повагою до користувача?</strong> Ваша програма не повинна без необхідності втручатися в роботу користувача, намагатися обдурити або приховувати "
+"будь-які свої дії. Користувачі (або навіть не користувачі) іноді грублять у своїх коментарях, і поки ми зробимо все можливе, щоб відфільтрувати некоректні відгуки, ми очікуємо від авторів, що вони "
+"не будуть відповідати грубістю на грубість."
 
 #: src/olympia/devhub/templates/devhub/docs/policies-submission.html:49
 msgid ""
-"<strong>Is the add-on useful to an appropriately wide portion of Firefox's "
-"users?</strong> Your add-on doesn't need to be the next Greasemonkey or "
-"Firebug, but if it is only useful to people at your company or who are part "
-"of a small web community, we may feel that it's not yet appropriate to put "
-"it in front of all of our users."
+"<strong>Is the add-on useful to an appropriately wide portion of Firefox's users?</strong> Your add-on doesn't need to be the next Greasemonkey or Firebug, but if it is only useful to people at "
+"your company or who are part of a small web community, we may feel that it's not yet appropriate to put it in front of all of our users."
 msgstr ""
-"<strong>Чи є додаток корисним для більш-менш широкої частини користувачів "
-"Firefox?</strong> Вашому додатку не обов'язково бути наступним Greasemonkey "
-"або Firebug, але якщо він корисний тільки людям у вашій компанії або тим, "
-"хто є частиною невеликої веб-спільноти, ми можемо вирішити, що він не "
-"підходить для розміщення перед усіма нашими користувачами."
+"<strong>Чи є додаток корисним для більш-менш широкої частини користувачів Firefox?</strong> Вашому додатку не обов'язково бути наступним Greasemonkey або Firebug, але якщо він корисний тільки людям"
+" у вашій компанії або тим, хто є частиною невеликої веб-спільноти, ми можемо вирішити, що він не підходить для розміщення перед усіма нашими користувачами."
 
 #: src/olympia/devhub/templates/devhub/docs/policies-submission.html:55
 msgid ""
-"We are constantly looking at ways to improve the organization of the site to"
-" better accommodate add-ons that are exemplary in other ways, but are aimed "
-"at only a small community of potential users. Correctly categorizing and "
-"maintaining the metadata of your add-on will help us figure out how we can "
-"surface more of those sorts of add-ons to people who are most likely to "
-"benefit from them."
+"We are constantly looking at ways to improve the organization of the site to better accommodate add-ons that are exemplary in other ways, but are aimed at only a small community of potential users."
+" Correctly categorizing and maintaining the metadata of your add-on will help us figure out how we can surface more of those sorts of add-ons to people who are most likely to benefit from them."
 msgstr ""
-"Ми постійно шукаємо шляхи поліпшення організації сайту для кращого "
-"розміщення додатків, які хоч і мають зразкове виконання, але націлені лише "
-"на невелике співтовариство потенційних користувачів. Правильна категоризація"
-" та управління метаданими вашого додатка допоможуть нам зрозуміти, яким "
-"чином ми можемо надати більше додатків подібного типу людям, яким вони "
-"можуть принести найбільшу користь."
+"Ми постійно шукаємо шляхи поліпшення організації сайту для кращого розміщення додатків, які хоч і мають зразкове виконання, але націлені лише на невелике співтовариство потенційних користувачів. "
+"Правильна категоризація та управління метаданими вашого додатка допоможуть нам зрозуміти, яким чином ми можемо надати більше додатків подібного типу людям, яким вони можуть принести найбільшу "
+"користь."
 
 #: src/olympia/devhub/templates/devhub/docs/policies-submission.html:61
 msgid ""
-"If your add-on just provides bookmarks or other simple access points to your"
-" site, it's probably not appropriate for the gallery. Like the rest of the "
-"Mozilla project, we love web applications and new web services, but Firefox "
-"add-ons should provide an improved browsing experience for the user and not "
-"just be a way to promote a new site or service through a Mozilla Add-ons "
-"listing."
+"If your add-on just provides bookmarks or other simple access points to your site, it's probably not appropriate for the gallery. Like the rest of the Mozilla project, we love web applications and "
+"new web services, but Firefox add-ons should provide an improved browsing experience for the user and not just be a way to promote a new site or service through a Mozilla Add-ons listing."
 msgstr ""
-"Якщо ваш додаток просто надає закладки та інші прості точки доступу на ваш "
-"сайт, то, ймовірно, він не підходить для галереї. Як усьому проекту Mozilla,"
-" так і нам, подобаються веб-додатки та нові веб-сервіси, але додатки Firefox"
-" повинні забезпечувати поліпшення веб-перегляду для користувача, а не бути "
-"просто способом просування нового сайту чи послуги через сторінки додатків "
-"Mozilla."
+"Якщо ваш додаток просто надає закладки та інші прості точки доступу на ваш сайт, то, ймовірно, він не підходить для галереї. Як усьому проекту Mozilla, так і нам, подобаються веб-додатки та нові "
+"веб-сервіси, але додатки Firefox повинні забезпечувати поліпшення веб-перегляду для користувача, а не бути просто способом просування нового сайту чи послуги через сторінки додатків Mozilla."
 
 #: src/olympia/devhub/templates/devhub/docs/policies-submission.html:67
 msgid ""
-"<strong>Is the add-on free of unlicensed trademarks and copyrights?</strong>"
-" Though you may mean no harm to the holder of a trademark, or the owner of a"
-" copyrighted work, we can't host add-ons that infringe on trademarks or "
-"copyrights. If you don't have permission to use a trademarked name or image,"
-" please do not submit your add-on to us. If your add-on includes code that "
-"is copyrighted by someone else, and is not licensed to you to use in your "
-"add-on, please do not submit your add-on to us."
+"<strong>Is the add-on free of unlicensed trademarks and copyrights?</strong> Though you may mean no harm to the holder of a trademark, or the owner of a copyrighted work, we can't host add-ons that"
+" infringe on trademarks or copyrights. If you don't have permission to use a trademarked name or image, please do not submit your add-on to us. If your add-on includes code that is copyrighted by "
+"someone else, and is not licensed to you to use in your add-on, please do not submit your add-on to us."
 msgstr ""
-"<strong>Чи відсутні в додатку неліцензовані торгові марки та авторські "
-"права?</strong> Хоча можливо ви не хочете заподіяти будь-якої шкоди власнику"
-" товарного знака або власнику захищеної авторським правом роботи, ми не "
-"можемо розміщувати додатки, які зазіхають на товарні знаки або авторські "
-"права. Якщо у вас немає дозволу на використання назви чи зображення торгової"
-" марки, будь ласка, не надсилайте нам ваші додатки. Якщо ваш додаток включає"
-" в себе код, на який поширюється чуже авторське право, і ви не маєте "
-"ліцензії на використання його у вашому додатку, будь ласка, не надсилайте "
+"<strong>Чи відсутні в додатку неліцензовані торгові марки та авторські права?</strong> Хоча можливо ви не хочете заподіяти будь-якої шкоди власнику товарного знака або власнику захищеної авторським"
+" правом роботи, ми не можемо розміщувати додатки, які зазіхають на товарні знаки або авторські права. Якщо у вас немає дозволу на використання назви чи зображення торгової марки, будь ласка, не "
+"надсилайте нам ваші додатки. Якщо ваш додаток включає в себе код, на який поширюється чуже авторське право, і ви не маєте ліцензії на використання його у вашому додатку, будь ласка, не надсилайте "
 "нам ваші додатки."
 
 #: src/olympia/devhub/templates/devhub/docs/policies-submission.html:73
 msgid ""
-"In terms of reuse of source code from other add-ons, if the author has not "
-"clearly stated that you are permitted to use his or her code in your own "
-"work &mdash; such as by placing it under an open source license &mdash; then"
-" you should assume that you do not have the right to do so. You can contact "
-"the author to seek such permission, but we can't provide you with any "
-"special rights to it just because it's listed on the site, or because the "
-"author isn't responding to your request."
+"In terms of reuse of source code from other add-ons, if the author has not clearly stated that you are permitted to use his or her code in your own work &mdash; such as by placing it under an open "
+"source license &mdash; then you should assume that you do not have the right to do so. You can contact the author to seek such permission, but we can't provide you with any special rights to it "
+"just because it's listed on the site, or because the author isn't responding to your request."
 msgstr ""
-"З точки зору повторного використання початкового коду з інших додатків, якщо"
-" автор не вказав у явному вигляді, що ви маєте право використовувати його "
-"код у вашій роботі &mdash; наприклад, розмістивши його під відкритою "
-"ліцензією &mdash; то ви повинні припустити, що ви не маєте право це робити. "
-"Ви можете зв'язатися з автором, щоб запросити такий дозвіл, але ми не можемо"
-" надати вам на нього які-небудь спеціальні права лише тому, що це розміщено "
-"на сайті, або тому, що автор не відповідає на ваш запит."
+"З точки зору повторного використання початкового коду з інших додатків, якщо автор не вказав у явному вигляді, що ви маєте право використовувати його код у вашій роботі &mdash; наприклад, "
+"розмістивши його під відкритою ліцензією &mdash; то ви повинні припустити, що ви не маєте право це робити. Ви можете зв'язатися з автором, щоб запросити такий дозвіл, але ми не можемо надати вам на"
+" нього які-небудь спеціальні права лише тому, що це розміщено на сайті, або тому, що автор не відповідає на ваш запит."
 
 #: src/olympia/devhub/templates/devhub/docs/policies-submission.html:79
 msgid ""
-"This applies to the Mozilla Foundation's trademarks as well, including "
-"\"Mozilla\", \"Firefox\", and \"Thunderbird\". The Mozilla policy on "
-"trademark use is designed to protect against confusion, and prevent the "
-"trademarks from being overturned due to lack of protection; please respect "
-"the need for such protection, and help us preserve some of the most valuable"
-" assets of the Mozilla Foundation."
+"This applies to the Mozilla Foundation's trademarks as well, including \"Mozilla\", \"Firefox\", and \"Thunderbird\". The Mozilla policy on trademark use is designed to protect against confusion, "
+"and prevent the trademarks from being overturned due to lack of protection; please respect the need for such protection, and help us preserve some of the most valuable assets of the Mozilla "
+"Foundation."
 msgstr ""
-"Це застосовується також до товарних знаків Mozilla Foundation, включаючи "
-"\"Mozilla\", \"Firefox\", і \"Thunderbird\". Політика використання товарних "
-"знаків Mozilla розроблена для захисту від плутанини і для запобігання "
-"відкликання прав на товарні знаки внаслідок відсутності їх захисту; будь "
-"ласка, поважайте необхідність такого захисту, і допоможіть нам зберегти "
-"деякі з найбільш цінних активів Mozilla Foundation."
+"Це застосовується також до товарних знаків Mozilla Foundation, включаючи \"Mozilla\", \"Firefox\", і \"Thunderbird\". Політика використання товарних знаків Mozilla розроблена для захисту від "
+"плутанини і для запобігання відкликання прав на товарні знаки внаслідок відсутності їх захисту; будь ласка, поважайте необхідність такого захисту, і допоможіть нам зберегти деякі з найбільш цінних "
+"активів Mozilla Foundation."
 
 #: src/olympia/devhub/templates/devhub/docs/policies-submission.html:84
 msgid "Licensing"
@@ -7917,243 +6089,155 @@ msgstr "Ліцензування"
 
 #: src/olympia/devhub/templates/devhub/docs/policies-submission.html:86
 msgid ""
-"Selecting an appropriate license for your add-on is a very important step in"
-" the submission process. A license specifies the rights you grant on your "
-"source code and is important in protecting your intellectual property."
+"Selecting an appropriate license for your add-on is a very important step in the submission process. A license specifies the rights you grant on your source code and is important in protecting your"
+" intellectual property."
 msgstr ""
-"Вибір ліцензії, яка підходить до вашого додатка є дуже важливим кроком у "
-"процесі подання. Ліцензія визначає права, які ви надаєте на ваш початковий "
-"код, і відіграє важливу роль в захисті вашої інтелектуальної власності."
+"Вибір ліцензії, яка підходить до вашого додатка є дуже важливим кроком у процесі подання. Ліцензія визначає права, які ви надаєте на ваш початковий код, і відіграє важливу роль в захисті вашої "
+"інтелектуальної власності."
 
 #: src/olympia/devhub/templates/devhub/docs/policies-submission.html:92
 msgid ""
-"During the add-on submission process, you will be presented with a list of "
-"popular licenses to choose from, as well as the ability to specify your own "
-"license. It is best to consult with a legal professional about which license"
-" option is best for you. Choosing the right license for your source code "
-"will help to prevent confusion and code conflicts in the future."
+"During the add-on submission process, you will be presented with a list of popular licenses to choose from, as well as the ability to specify your own license. It is best to consult with a legal "
+"professional about which license option is best for you. Choosing the right license for your source code will help to prevent confusion and code conflicts in the future."
 msgstr ""
-"В процесі подання додатку, вам буде представлено на вибір список популярних "
-"ліцензій, а також дана можливість вказати свою власну ліцензію. Щоб "
-"дізнатися, який варіант ліцензії вам найкраще підходить, проконсультуйтеся з"
-" юристом. Вибір правильної ліцензії для вашого початкового коду допоможе "
-"уникнути плутанини і конфліктів коду в майбутньому."
+"В процесі подання додатку, вам буде представлено на вибір список популярних ліцензій, а також дана можливість вказати свою власну ліцензію. Щоб дізнатися, який варіант ліцензії вам найкраще "
+"підходить, проконсультуйтеся з юристом. Вибір правильної ліцензії для вашого початкового коду допоможе уникнути плутанини і конфліктів коду в майбутньому."
 
-#: src/olympia/devhub/templates/devhub/docs/policies.html:12
-#: src/olympia/devhub/templates/devhub/docs/policies.html:52
+#: src/olympia/devhub/templates/devhub/docs/policies.html:12 src/olympia/devhub/templates/devhub/docs/policies.html:52
 msgid "Add-on Submission"
 msgstr "Представлення додатка"
 
-#: src/olympia/devhub/templates/devhub/docs/policies.html:18
-#: src/olympia/devhub/templates/devhub/docs/policies.html:78
+#: src/olympia/devhub/templates/devhub/docs/policies.html:18 src/olympia/devhub/templates/devhub/docs/policies.html:78
 msgid "Maintaining Your Add-on"
 msgstr "Обслуговування вашого додатка"
 
 #: src/olympia/devhub/templates/devhub/docs/policies.html:43
-msgid ""
-"Mozilla is committed to ensuring a great add-ons experience for our users "
-"and developers. Please review the policies below before submitting your add-"
-"on."
-msgstr ""
-"Mozilla прагне забезпечити відмінну роботу додатків нашим користувачам і "
-"розробникам. Будь ласка, ознайомтеся з наведеним нижче правилами, перед "
-"надсиланням додатка."
+msgid "Mozilla is committed to ensuring a great add-ons experience for our users and developers. Please review the policies below before submitting your add-on."
+msgstr "Mozilla прагне забезпечити відмінну роботу додатків нашим користувачам і розробникам. Будь ласка, ознайомтеся з наведеним нижче правилами, перед надсиланням додатка."
 
 #: src/olympia/devhub/templates/devhub/docs/policies.html:55
-msgid ""
-"Find out what is expected of add-ons we host and our policies on specific "
-"add-on practices."
-msgstr ""
-"Дізнайтеся, що очікується від додатків, які ми розміщуємо та які наші "
-"політики зі специфічних практик використання додатків."
+msgid "Find out what is expected of add-ons we host and our policies on specific add-on practices."
+msgstr "Дізнайтеся, що очікується від додатків, які ми розміщуємо та які наші політики зі специфічних практик використання додатків."
 
 #: src/olympia/devhub/templates/devhub/docs/policies.html:67
-msgid ""
-"What happens after your add-on is submitted? Learn about how our Editors "
-"review submissions."
-msgstr ""
-"Що відбувається після подання вашого додатка? Дізнайтеся про те, як наші "
-"редактори перевіряють представлення."
+msgid "What happens after your add-on is submitted? Learn about how our Editors review submissions."
+msgstr "Що відбувається після подання вашого додатка? Дізнайтеся про те, як наші редактори перевіряють представлення."
 
 #: src/olympia/devhub/templates/devhub/docs/policies.html:81
-msgid ""
-"Add-on updates, transferring ownership, user reviews, and what to expect "
-"once your add-on is approved."
-msgstr ""
-"Оновлення додатків, передача володіння, відгуки користувачів, і чого "
-"очікувати після схвалення вашого додатка."
+msgid "Add-on updates, transferring ownership, user reviews, and what to expect once your add-on is approved."
+msgstr "Оновлення додатків, передача володіння, відгуки користувачів, і чого очікувати після схвалення вашого додатка."
 
 #: src/olympia/devhub/templates/devhub/docs/policies.html:93
-msgid ""
-"How up-and-coming add-ons become featured and what&#039;s involved in the "
-"process."
-msgstr ""
-"Як перспективні додатки стають обраними і що залучено до цього процесу."
+msgid "How up-and-coming add-ons become featured and what&#039;s involved in the process."
+msgstr "Як перспективні додатки стають обраними і що залучено до цього процесу."
 
 #: src/olympia/devhub/templates/devhub/docs/policies.html:106
-msgid ""
-"Terms of Service for submitting your work to our site. Developers are "
-"required to accept this agreement before submission."
-msgstr ""
-"Умови надання послуг для представлення ваших робіт на нашому сайті. "
-"Розробники повинні прийняти цю угоду перед представленням."
+msgid "Terms of Service for submitting your work to our site. Developers are required to accept this agreement before submission."
+msgstr "Умови надання послуг для представлення ваших робіт на нашому сайті. Розробники повинні прийняти цю угоду перед представленням."
 
 #: src/olympia/devhub/templates/devhub/docs/policies.html:118
 msgid "How to get in touch with us regarding these policies or your add-on."
 msgstr "Як зв'язатися з нами з приводу цих політик або вашого додатка."
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:6
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:10
 msgid "You have disabled this add-on"
 msgstr "Ви вимкнули цей додаток"
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:20
-msgid ""
-"Your add-on's listing is disabled and is not showing\n"
-"                             anywhere in our gallery or update service."
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:24
+msgid "Your add-on's listing is disabled and is not showing anywhere in our gallery or update service."
 msgstr ""
 "Сторінка вашого додатку відключена і не відображається\n"
 "                             ні в нашій галереї, ні в службі оновлення."
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:25
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:27
 msgid "Please complete your add-on."
 msgstr "Будь ласка, доробіть ваш додаток."
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:29
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:30
 msgid "You will receive an email when the review is complete."
 msgstr "Ви отримаєте лист, коли перевірка буде закінчена."
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:34
-msgid ""
-"You will receive an email when the review is complete. Until then, your add-"
-"on is not listed in our gallery but can be accessed directly from its "
-"details page."
-msgstr ""
-"По завершенні процесу перевірки ви отримаєте лист. До цього моменту ваш "
-"додаток не буде відображатися в галереї, але буде доступним зі своєї "
-"сторінки."
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:33
+msgid "You will receive an email when the review is complete. Until then, your add-on is not listed in our gallery but can be accessed directly from its details page."
+msgstr "По завершенні процесу перевірки ви отримаєте лист. До цього моменту ваш додаток не буде відображатися в галереї, але буде доступним зі своєї сторінки."
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:38
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:48
-msgid ""
-"You will receive an email when the review is\n"
-"                             complete and your add-on is signed."
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:37 src/olympia/devhub/templates/devhub/includes/addon_details.html:45
+msgid "You will receive an email when the review is complete and your add-on is signed."
 msgstr ""
 "По завершенні процесу перевірки та після\n"
 "                             підпису додатку ви отримаєте лист."
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:44
-msgid ""
-"You will receive an email when the review is complete. Until then, your add-"
-"on is not listed in our gallery but can be accessed directly from its "
-"details page."
-msgstr ""
-"По завершенні процесу перевірки ви отримаєте лист. До цього моменту ваш "
-"додаток не буде відображатися в галереї, але буде доступним зі своєї "
-"сторінки."
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:41
+msgid "You will receive an email when the review is complete. Until then, your add-on is not listed in our gallery but can be accessed directly from its details page."
+msgstr "По завершенні процесу перевірки ви отримаєте лист. До цього моменту ваш додаток не буде відображатися в галереї, але буде доступним зі своєї сторінки."
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:54
-msgid ""
-"Your add-on is displayed in our gallery and users are\n"
-"                             receiving automatic updates."
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:49
+msgid "Your add-on is displayed in our gallery and users are receiving automatic updates."
 msgstr ""
 "Ваш додаток відображається в нашій галереї та користувачі\n"
 "                             отримують автоматичні оновлення."
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:57
-msgid ""
-"Your add-on has been signed and can be bundled with an\n"
-"                             application installer."
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:52
+msgid "Your add-on has been signed and can be bundled with an application installer."
 msgstr ""
 "Ваш додаток був підписаний і може бути об'єднаний з\n"
 "                             інсталятором програми."
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:63
-msgid ""
-"Your add-on was disabled by a site administrator and is no longer shown in "
-"our gallery. If you have any questions, please email amo-admins@mozilla.org."
-msgstr ""
-"Ваш додаток був виключений адміністратором сайту і більше не показується в "
-"нашій галереї. Якщо у вас є запитання, будь ласка, напишіть на amo-"
-"admins@mozilla.org."
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:56
+msgid "Your add-on was disabled by a site administrator and is no longer shown in our gallery. If you have any questions, please email amo-admins@mozilla.org."
+msgstr "Ваш додаток був виключений адміністратором сайту і більше не показується в нашій галереї. Якщо у вас є запитання, будь ласка, напишіть на amo-admins@mozilla.org."
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:70
-msgid ""
-"Your add-on is displayed in our gallery as experimental and users are "
-"receiving automatic updates. Some features are unavailable to your add-on."
-msgstr ""
-"Ваш додаток відображається в нашій галереї як експериментальний та "
-"користувачі отримують автоматичні оновлення. Деякі функції для вашого "
-"додатку недоступні."
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:62
+msgid "Your add-on is displayed in our gallery as experimental and users are receiving automatic updates. Some features are unavailable to your add-on."
+msgstr "Ваш додаток відображається в нашій галереї як експериментальний та користувачі отримують автоматичні оновлення. Деякі функції для вашого додатку недоступні."
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:74
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:66
 msgid "Your add-on has been signed."
 msgstr "Ваш додаток був підписаний."
 
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:69
+msgid ""
+"You will receive an email when the full review is complete. Until then, your add-on is displayed in our gallery as experimental and users are receiving automatic updates. Some features are "
+"unavailable to your add-on."
+msgstr ""
+"Після закінчення процесу повної перевірки ви отримаєте лист. До цього ваш додаток знаходитиметься в нашій галереї як експериментальний і користувачі будуть отримувати автоматичні оновлення. Деякі "
+"функції для вашого додатка будуть недоступні."
+
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:74
+msgid "You will receive an email when the full review is complete, making you able to bundle your add-on with an application installer."
+msgstr "Ви отримаєте електронний лист після завершення повного розгляду, даючи вам можливість об'єднати свій додаток з інсталятором програми."
+
 #: src/olympia/devhub/templates/devhub/includes/addon_details.html:79
-msgid ""
-"You will receive an email when the full review is complete. Until then, your"
-" add-on is displayed in our gallery as experimental and users are receiving "
-"automatic updates. Some features are unavailable to your add-on."
-msgstr ""
-"Після закінчення процесу повної перевірки ви отримаєте лист. До цього ваш "
-"додаток знаходитиметься в нашій галереї як експериментальний і користувачі "
-"будуть отримувати автоматичні оновлення. Деякі функції для вашого додатка "
-"будуть недоступні."
+msgid "All add-ons hosted in our gallery must now be reviewed by an editor. If you wish to continue hosting your add-on, please click to select a review process."
+msgstr "Всі додатки, розміщені в нашій галереї, тепер повинні бути перевірені редактором. Якщо ви хочете продовжити самі розміщувати свій додаток, клацніть, щоб вибрати варіант перевірки."
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:84
-msgid ""
-"You will receive an email when the full review is complete, making you able "
-"to bundle your add-on with an application installer."
-msgstr ""
-"Ви отримаєте електронний лист після завершення повного розгляду, даючи вам "
-"можливість об'єднати свій додаток з інсталятором програми."
-
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:91
-msgid ""
-"All add-ons hosted in our gallery must now be reviewed by an editor. If you "
-"wish to continue hosting your add-on, please click to select a review "
-"process."
-msgstr ""
-"Всі додатки, розміщені в нашій галереї, тепер повинні бути перевірені "
-"редактором. Якщо ви хочете продовжити самі розміщувати свій додаток, "
-"клацніть, щоб вибрати варіант перевірки."
-
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:113
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:100
 msgid "Current Version:"
 msgstr "Поточна версія:"
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:115
-msgid ""
-"This is the version of your add-on that will be installed if someone clicks "
-"the Install button on addons.mozilla.org. It is only relevant for listed "
-"add-ons."
-msgstr ""
-"Це версія вашого додатку, яка буде встановлена, якщо хтось натисне на кнопку"
-" Встановити на addons.mozilla.org. Це відноситься тільки до наведених "
-"додатків."
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:102
+msgid "This is the version of your add-on that will be installed if someone clicks the Install button on addons.mozilla.org. It is only relevant for listed add-ons."
+msgstr "Це версія вашого додатку, яка буде встановлена, якщо хтось натисне на кнопку Встановити на addons.mozilla.org. Це відноситься тільки до наведених додатків."
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:123
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:110
 msgid "Created:"
 msgstr "Створено:"
 
 #. {0} is a date. dennis-ignore: E201
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:125
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:131
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:112 src/olympia/devhub/templates/devhub/includes/addon_details.html:118
 #, python-format
 msgid "%%b %%e, %%Y"
 msgstr "%%e %%b %%Y"
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:136
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:123
 msgid "Next Version:"
 msgstr "Наступна версія:"
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:138
-msgid ""
-"This is the newest uploaded version, however it isn’t live on the site yet."
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:125
+msgid "This is the newest uploaded version, however it isn’t live on the site yet."
 msgstr "Це найновіша завантажена версія, проте її ще немає на сайті."
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:144
-#: src/olympia/devhub/templates/devhub/versions/list.html:30
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:130 src/olympia/devhub/templates/devhub/versions/list.html:30
 msgid "Queues are not reviewed strictly in order"
 msgstr "Черги не перевіряються чітко за порядком"
 
@@ -8171,15 +6255,11 @@ msgstr "Створити профіль розробника"
 
 #: src/olympia/devhub/templates/devhub/includes/addons_create_profile.html:24
 msgid ""
-"Your developer profile will tell users about you, why you made this add-on, "
-"and what's next for the add-on. This profile is required for add-ons "
-"requesting contributions, but can be useful for any developer interested in "
-"connecting with users."
+"Your developer profile will tell users about you, why you made this add-on, and what's next for the add-on. This profile is required for add-ons requesting contributions, but can be useful for any "
+"developer interested in connecting with users."
 msgstr ""
-"Ваш профіль розробника розповість користувачам про вас, про те чому ви "
-"зробили цей додаток та подальші його плани. Цей профіль обов'язковий для "
-"додатків, які містять пропозицію зробити внесок, але може бути корисним для "
-"будь-якого розробника, зацікавленого у встановленні взаємин з користувачами."
+"Ваш профіль розробника розповість користувачам про вас, про те чому ви зробили цей додаток та подальші його плани. Цей профіль обов'язковий для додатків, які містять пропозицію зробити внесок, але "
+"може бути корисним для будь-якого розробника, зацікавленого у встановленні взаємин з користувачами."
 
 #: src/olympia/devhub/templates/devhub/includes/addons_create_profile.html:32
 msgid "Make sure your user profile is up to date."
@@ -8191,20 +6271,12 @@ msgid "<a href=\"%(url)s\"><strong>Update your user profile.</strong></a>"
 msgstr "<a href=\"%(url)s\"><strong>Оновіть ваш профіль користувача.</strong></a>"
 
 #: src/olympia/devhub/templates/devhub/includes/addons_create_profile.html:45
-msgid ""
-"Whether it was an idea while in line at the grocery store or the solution to"
-" one of life's great problems, share your story."
-msgstr ""
-"Чи було це спонтанним приходом ідеї в черзі в магазині або вирішенням однієї"
-" з великих життєвих проблем, поділіться своєю історією."
+msgid "Whether it was an idea while in line at the grocery store or the solution to one of life's great problems, share your story."
+msgstr "Чи було це спонтанним приходом ідеї в черзі в магазині або вирішенням однієї з великих життєвих проблем, поділіться своєю історією."
 
 #: src/olympia/devhub/templates/devhub/includes/addons_create_profile.html:61
-msgid ""
-"Telling your users what's coming soon will give them something to look "
-"forward to."
-msgstr ""
-"Розповівши своїм користувачам, що станеться найближчим часом, ви дасте їм "
-"уявлення, на що можна очікувати."
+msgid "Telling your users what's coming soon will give them something to look forward to."
+msgstr "Розповівши своїм користувачам, що станеться найближчим часом, ви дасте їм уявлення, на що можна очікувати."
 
 #: src/olympia/devhub/templates/devhub/includes/addons_edit_nav.html:23
 msgid "View All"
@@ -8235,9 +6307,7 @@ msgid "View the blog &#9658;"
 msgstr "Прочитати блог &#9658;"
 
 #: src/olympia/devhub/templates/devhub/includes/license_form.html:6
-msgid ""
-"Please choose a license appropriate for the rights you grant on your source code.\n"
-"                  It is only relevant for listed add-ons."
+msgid "Please choose a license appropriate for the rights you grant on your source code. It is only relevant for listed add-ons."
 msgstr ""
 "Будь ласка, оберіть ліцензію у відповідності до прав, які ви обрали для свого\n"
 "                  програмного коду. Це стосується лише опублікованих додатків."
@@ -8255,60 +6325,37 @@ msgstr "Дещо з HTML підтримується."
 msgid "Remove this application"
 msgstr "Видалити цю програму"
 
-#. {0} is the maximum number of add-on categories allowed.                {1}
-#. is
+#. {0} is the maximum number of add-on categories allowed.                {1} is
 #. the application name.
 #: src/olympia/devhub/templates/devhub/includes/macros.html:70
 msgid "Select <b>up to {0}</b> {1} category for this add-on:"
 msgid_plural "Select <b>up to {0}</b> {1} categories for this add-on:"
 msgstr[0] "Виберіть <b>не більше {0}</b> {1} категорії для цього додатку:"
 msgstr[1] "Виберіть <b>не більше {0}</b> {1} категорій для цього додатку:"
-msgstr[2] "Виберіть <b>не більше {0}</b> {1} категорій для цього додатку:"
 
 #: src/olympia/devhub/templates/devhub/includes/policy_form.html:4
 msgid ""
-"Users will be required to accept the following End-User License Agreement "
-"(EULA) prior to installing your add-on. The presence of a EULA significantly"
-" affects the number of downloads an add-on receives. Please note that a EULA"
-" is not the same as a code license, such as the GPL or MPL. It is only "
-"relevant for listed add-ons."
+"Users will be required to accept the following End-User License Agreement (EULA) prior to installing your add-on. The presence of a EULA significantly affects the number of downloads an add-on "
+"receives. Please note that a EULA is not the same as a code license, such as the GPL or MPL.It is only relevant for listed add-ons."
 msgstr ""
-"Перед встановленням вашого додатку користувачі повинні будуть погодитися з "
-"Ліцензійною Угодою Кінцевого Користувача (EULA). Ця наявність EULA значною "
-"мірою впливає на кількість завантажень додатку. Будь ласка, зверніть увагу, "
-"що EULA не має відношення до ліцензії коду, такої як GPL чи MPL. Це "
-"стосується лише додатків, які знаходяться в списку."
 
-#: src/olympia/devhub/templates/devhub/includes/policy_form.html:21
-msgid ""
-"If your add-on transmits any data from the user's computer, a privacy policy"
-" is required that explains what data is sent and how it is used. It is only "
-"relevant for listed add-ons."
+#: src/olympia/devhub/templates/devhub/includes/policy_form.html:24
+msgid "If your add-on transmits any data from the user's computer, a privacy policy is required that explains what data is sent and how it is used. It is only relevant for listed add-ons."
 msgstr ""
-"Якщо ваш додаток передає будь-які дані з комп'ютера користувача, то "
-"необхідно мати політику приватності з поясненням, які дані передаються та "
-"яким чином вони використовуються. Це стосується лише додатків, які "
-"знаходяться в списку."
+"Якщо ваш додаток передає будь-які дані з комп'ютера користувача, то необхідно мати політику приватності з поясненням, які дані передаються та яким чином вони використовуються. Це стосується лише "
+"додатків, які знаходяться в списку."
 
 #: src/olympia/devhub/templates/devhub/includes/source_form_field.html:2
-msgid ""
-"If your add-on contains binary or obfuscated code other than known "
-"libraries, upload its sources for review."
-msgstr ""
-"Якщо ваш додаток містить бінарний або заплутаний код, не враховуючи відомих "
-"бібліотек, завантажте його програмний код для перевірки."
+msgid "If your add-on contains binary or obfuscated code other than known libraries, upload its sources for review."
+msgstr "Якщо ваш додаток містить бінарний або заплутаний код, не враховуючи відомих бібліотек, завантажте його програмний код для перевірки."
 
 #: src/olympia/devhub/templates/devhub/includes/source_form_field.html:3
 msgid "Read more about the source code review policy."
 msgstr "Дізнайтеся більше про політику перевірки програмного коду."
 
 #: src/olympia/devhub/templates/devhub/includes/version_file.html:20
-msgid ""
-"You cannot remove an individual file after the review process has begun. You"
-" must delete the entire version."
-msgstr ""
-"Ви не можете видалити окремий файл після початку процесу перевірки. Ви "
-"повинні видалити версію цілком."
+msgid "You cannot remove an individual file after the review process has begun. You must delete the entire version."
+msgstr "Ви не можете видалити окремий файл після початку процесу перевірки. Ви повинні видалити версію цілком."
 
 #: src/olympia/devhub/templates/devhub/includes/version_file.html:36
 msgid "This file will be deleted on save."
@@ -8336,29 +6383,20 @@ msgid "Voluntary Contributions"
 msgstr "Добровільні внески"
 
 #: src/olympia/devhub/templates/devhub/payments/payments.html:38
-msgid ""
-"Add-ons enrolled in our contributions program can request voluntary "
-"financial support from users."
-msgstr ""
-"Додатки, які беруть участь у нашій програмі внесків, можуть просити "
-"користувачів надавати добровільну фінансову підтримку."
+msgid "Add-ons enrolled in our contributions program can request voluntary financial support from users."
+msgstr "Додатки, які беруть участь у нашій програмі внесків, можуть просити користувачів надавати добровільну фінансову підтримку."
 
 #: src/olympia/devhub/templates/devhub/payments/payments.html:40
 msgid "Encourage users to support your add-on through your Developer Profile"
-msgstr ""
-"Попросіть користувачів підтримати ваш додаток через ваш Профіль розробника"
+msgstr "Попросіть користувачів підтримати ваш додаток через ваш Профіль розробника"
 
 #: src/olympia/devhub/templates/devhub/payments/payments.html:41
 msgid "Choose when and how users are asked to contribute"
 msgstr "Виберіть, коли і як просити користувачів зробити внесок"
 
 #: src/olympia/devhub/templates/devhub/payments/payments.html:42
-msgid ""
-"Receive contributions in your PayPal account or send them to an organization"
-" of your choice"
-msgstr ""
-"Отримувати внески на ваш рахунок в PayPal або відправляти їх в організацію "
-"на свій вибір"
+msgid "Receive contributions in your PayPal account or send them to an organization of your choice"
+msgstr "Отримувати внески на ваш рахунок в PayPal або відправляти їх в організацію на свій вибір"
 
 #: src/olympia/devhub/templates/devhub/payments/payments.html:46
 msgid "Contributions are only available for listed add-ons."
@@ -8366,19 +6404,14 @@ msgstr "Внески доступні лише для опублікованих
 
 #: src/olympia/devhub/templates/devhub/payments/payments.html:53
 #, python-format
-msgid ""
-"Contributions are only available for add-ons with a <a "
-"href=\"%(url)s\">completed developer profile</a>."
-msgstr ""
-"Внески доступні тільки для додатків з <a href=\"%(url)s\">заповненим "
-"профілем розробника</a>."
+msgid "Contributions are only available for add-ons with a <a href=\"%(url)s\">completed developer profile</a>."
+msgstr "Внески доступні тільки для додатків з <a href=\"%(url)s\">заповненим профілем розробника</a>."
 
 #: src/olympia/devhub/templates/devhub/payments/payments.html:59
 msgid "Contributions are only available for fully reviewed add-ons."
 msgstr "Внески доступні тільки для повністю перевірених додатків."
 
-#: src/olympia/devhub/templates/devhub/payments/payments.html:65
-#: src/olympia/devhub/templates/devhub/payments/voluntary.html:2
+#: src/olympia/devhub/templates/devhub/payments/payments.html:65 src/olympia/devhub/templates/devhub/payments/voluntary.html:2
 msgid "Set up Contributions"
 msgstr "Налаштування внесків"
 
@@ -8391,18 +6424,13 @@ msgstr "Крок 2. Ціна і доступність"
 msgid "or <a href=\"%(cancel)s\">Cancel</a>"
 msgstr "чи <a href=\"%(cancel)s\">Скасувати</a>"
 
-#: src/olympia/devhub/templates/devhub/payments/voluntary.html:2
-#: src/olympia/stats/templates/stats/addon_report_menu.html:39
+#: src/olympia/devhub/templates/devhub/payments/voluntary.html:2 src/olympia/stats/templates/stats/addon_report_menu.html:39
 msgid "Contributions"
 msgstr "Внески"
 
 #: src/olympia/devhub/templates/devhub/payments/voluntary.html:3
-msgid ""
-"Fill in the fields below to begin asking for voluntary contributions from "
-"users."
-msgstr ""
-"Заповніть розташовані нижче поля, щоб почати просити користувачів зробити "
-"добровільні внески."
+msgid "Fill in the fields below to begin asking for voluntary contributions from users."
+msgstr "Заповніть розташовані нижче поля, щоб почати просити користувачів зробити добровільні внески."
 
 #: src/olympia/devhub/templates/devhub/payments/voluntary.html:11
 msgid "Who will receive contributions to this add-on?"
@@ -8445,23 +6473,16 @@ msgid "Send a thank-you note?"
 msgstr "Відправити лист подяки?"
 
 #: src/olympia/devhub/templates/devhub/payments/voluntary.html:47
-msgid ""
-"We'll automatically email users who contribute to your add-on with this "
-"message."
-msgstr ""
-"Ми автоматично відправимо користувачам, які зробили внесок, електронний лист"
-" з цим повідомленням."
+msgid "We'll automatically email users who contribute to your add-on with this message."
+msgstr "Ми автоматично відправимо користувачам, які зробили внесок, електронний лист з цим повідомленням."
 
 #: src/olympia/devhub/templates/devhub/payments/voluntary.html:49
 msgid ""
-"We recommend thanking the user and telling them how much you appreciate "
-"their support. You might also want to tell them about what's next for your "
-"add-on and about any other add-ons you've made for them to try."
+"We recommend thanking the user and telling them how much you appreciate their support. You might also want to tell them about what's next for your add-on and about any other add-ons you've made for"
+" them to try."
 msgstr ""
-"Ми рекомендуємо подякувати користувачам і написати їм, наскільки ви цінуєте "
-"їх підтримку. Ви також можете розповісти їм про плани розвитку вашого "
-"додатка та про будь-які інші зроблені вами додатки, які ви рекомендуєте "
-"спробувати."
+"Ми рекомендуємо подякувати користувачам і написати їм, наскільки ви цінуєте їх підтримку. Ви також можете розповісти їм про плани розвитку вашого додатка та про будь-які інші зроблені вами додатки,"
+" які ви рекомендуєте спробувати."
 
 #: src/olympia/devhub/templates/devhub/payments/voluntary.html:64
 msgid "Activate Contributions"
@@ -8475,146 +6496,94 @@ msgstr "чи <a id=\"setup-cancel\" href=\"#\">Скасувати</a>"
 msgid "Transfer ownership"
 msgstr "Передача володіння"
 
-#: src/olympia/devhub/templates/devhub/personas/edit.html:77
-#: src/olympia/devhub/templates/devhub/personas/submit.html:31
+#: src/olympia/devhub/templates/devhub/personas/edit.html:77 src/olympia/devhub/templates/devhub/personas/submit.html:31
 msgid "Theme Details"
 msgstr "Інформація про тему"
 
-#: src/olympia/devhub/templates/devhub/personas/edit.html:87
-#: src/olympia/devhub/templates/devhub/personas/submit.html:36
+#: src/olympia/devhub/templates/devhub/personas/edit.html:87 src/olympia/devhub/templates/devhub/personas/submit.html:36
 msgid "Supply a pretty URL for your detail page."
 msgstr "Вказати красивий URL для вашої сторінки з відомостями."
 
-#: src/olympia/devhub/templates/devhub/personas/edit.html:92
-#: src/olympia/devhub/templates/devhub/personas/submit.html:41
+#: src/olympia/devhub/templates/devhub/personas/edit.html:92 src/olympia/devhub/templates/devhub/personas/submit.html:41
 msgid "Select the category that best describes your Theme."
 msgstr "Виберіть категорію, яка найкраще описує вашу тему."
 
-#: src/olympia/devhub/templates/devhub/personas/edit.html:95
-#: src/olympia/devhub/templates/devhub/personas/submit.html:44
+#: src/olympia/devhub/templates/devhub/personas/edit.html:95 src/olympia/devhub/templates/devhub/personas/submit.html:44
 msgid "Add some tags to describe your Theme."
 msgstr "Додайте мітки для опису вашої теми."
 
-#: src/olympia/devhub/templates/devhub/personas/edit.html:106
-msgid ""
-"A short explanation of your theme's basic functionality that is displayed in"
-" search and browse listings, as well as at the top of your theme's details "
-"page."
-msgstr ""
-"Коротке пояснення основних функцій вашої теми, які відображаються в списках "
-"пошуку та перегляду, а також у верхній частині сторінки вашої теми."
+#: src/olympia/devhub/templates/devhub/personas/edit.html:106 src/olympia/devhub/templates/devhub/personas/submit.html:54
+msgid "A short explanation of your theme's basic functionality that is displayed in search and browse listings, as well as at the top of your theme's details page."
+msgstr "Коротке пояснення основних функцій вашої теми, які відображаються в списках пошуку та перегляду, а також у верхній частині сторінки вашої теми."
 
-#: src/olympia/devhub/templates/devhub/personas/edit.html:122
-#: src/olympia/devhub/templates/devhub/personas/submit.html:68
+#: src/olympia/devhub/templates/devhub/personas/edit.html:122 src/olympia/devhub/templates/devhub/personas/submit.html:68
 msgid "Theme License"
 msgstr "Ліцензія теми"
 
-#: src/olympia/devhub/templates/devhub/personas/edit.html:126
-#: src/olympia/devhub/templates/devhub/personas/submit.html:72
+#: src/olympia/devhub/templates/devhub/personas/edit.html:126 src/olympia/devhub/templates/devhub/personas/submit.html:72
 msgid "Can others share your Theme, as long as you're given credit?"
 msgstr "Чи можуть інші ділитися вашою темою, якщо вас вказують як автора?"
 
-#: src/olympia/devhub/templates/devhub/personas/edit.html:132
-#: src/olympia/devhub/templates/devhub/personas/edit.html:153
-#: src/olympia/devhub/templates/devhub/personas/submit.html:78
+#: src/olympia/devhub/templates/devhub/personas/edit.html:132 src/olympia/devhub/templates/devhub/personas/edit.html:153 src/olympia/devhub/templates/devhub/personas/submit.html:78
 #: src/olympia/devhub/templates/devhub/personas/submit.html:99
-msgid ""
-"The licensor permits others to copy, distribute, display, and perform the "
-"work, including for commercial purposes."
-msgstr ""
-"Ліцензіар дозволяє іншим копіювати, розповсюджувати, відтворювати, а також "
-"виконувати роботу, в тому числі в комерційних цілях."
+msgid "The licensor permits others to copy, distribute, display, and perform the work, including for commercial purposes."
+msgstr "Ліцензіар дозволяє іншим копіювати, розповсюджувати, відтворювати, а також виконувати роботу, в тому числі в комерційних цілях."
 
-#: src/olympia/devhub/templates/devhub/personas/edit.html:141
-#: src/olympia/devhub/templates/devhub/personas/edit.html:162
-#: src/olympia/devhub/templates/devhub/personas/submit.html:87
+#: src/olympia/devhub/templates/devhub/personas/edit.html:141 src/olympia/devhub/templates/devhub/personas/edit.html:162 src/olympia/devhub/templates/devhub/personas/submit.html:87
 #: src/olympia/devhub/templates/devhub/personas/submit.html:108
-msgid ""
-"The licensor permits others to copy, distribute, display, and perform the "
-"work for non-commercial purposes only."
-msgstr ""
-"Ліцензіар дозволяє іншим копіювати, розповсюджувати, відтворювати, а також "
-"виконувати роботу тільки в некомерційних цілях."
+msgid "The licensor permits others to copy, distribute, display, and perform the work for non-commercial purposes only."
+msgstr "Ліцензіар дозволяє іншим копіювати, розповсюджувати, відтворювати, а також виконувати роботу тільки в некомерційних цілях."
 
-#: src/olympia/devhub/templates/devhub/personas/edit.html:147
-#: src/olympia/devhub/templates/devhub/personas/submit.html:93
+#: src/olympia/devhub/templates/devhub/personas/edit.html:147 src/olympia/devhub/templates/devhub/personas/submit.html:93
 msgid "Can others make commercial use of your Theme?"
 msgstr "Чи можуть інші використовувати вашу тему в комерційних цілях?"
 
-#: src/olympia/devhub/templates/devhub/personas/edit.html:168
-#: src/olympia/devhub/templates/devhub/personas/submit.html:114
+#: src/olympia/devhub/templates/devhub/personas/edit.html:168 src/olympia/devhub/templates/devhub/personas/submit.html:114
 msgid "Can others create derivative works from your Theme?"
 msgstr "Чи можуть інші створювати похідні роботи на основі вашої теми?"
 
-#: src/olympia/devhub/templates/devhub/personas/edit.html:174
-#: src/olympia/devhub/templates/devhub/personas/submit.html:120
-msgid ""
-"The licensor permits others to copy, distribute, display and perform the "
-"work, as well as make derivative works based on it."
-msgstr ""
-"Ліцензіар дозволяє іншим копіювати, поширювати, показувати і виконувати "
-"роботу, а також створювати на його основі похідні роботи."
+#: src/olympia/devhub/templates/devhub/personas/edit.html:174 src/olympia/devhub/templates/devhub/personas/submit.html:120
+msgid "The licensor permits others to copy, distribute, display and perform the work, as well as make derivative works based on it."
+msgstr "Ліцензіар дозволяє іншим копіювати, поширювати, показувати і виконувати роботу, а також створювати на його основі похідні роботи."
 
-#: src/olympia/devhub/templates/devhub/personas/edit.html:182
-#: src/olympia/devhub/templates/devhub/personas/submit.html:128
+#: src/olympia/devhub/templates/devhub/personas/edit.html:182 src/olympia/devhub/templates/devhub/personas/submit.html:128
 msgid "Yes, as long as they share alike"
 msgstr "Так, якщо вони так само діляться"
 
-#: src/olympia/devhub/templates/devhub/personas/edit.html:183
-#: src/olympia/devhub/templates/devhub/personas/submit.html:129
-msgid ""
-"The licensor permits others to distribute derivativeworks only under the "
-"same license or one compatible with the one that governs the licensor's "
-"work."
-msgstr ""
-"Ліцензіар дозволяє іншим розповсюджувати похідні роботи тільки з тієї ж "
-"ліцензії або ліцензії сумісної з тією, під якою поширюється робота "
-"ліцензіара."
+#: src/olympia/devhub/templates/devhub/personas/edit.html:183 src/olympia/devhub/templates/devhub/personas/submit.html:129
+msgid "The licensor permits others to distribute derivativeworks only under the same license or one compatible with the one that governs the licensor's work."
+msgstr "Ліцензіар дозволяє іншим розповсюджувати похідні роботи тільки з тієї ж ліцензії або ліцензії сумісної з тією, під якою поширюється робота ліцензіара."
 
-#: src/olympia/devhub/templates/devhub/personas/edit.html:192
-#: src/olympia/devhub/templates/devhub/personas/submit.html:138
-msgid ""
-"The licensor permits others to copy, distribute and transmit only unaltered "
-"copies of the work — not derivative works based on it."
-msgstr ""
-"Ліцензіар дозволяє іншим копіювати, поширювати і передавати тільки незмінені"
-" копії роботи — не похідні роботи на його основі."
+#: src/olympia/devhub/templates/devhub/personas/edit.html:192 src/olympia/devhub/templates/devhub/personas/submit.html:138
+msgid "The licensor permits others to copy, distribute and transmit only unaltered copies of the work — not derivative works based on it."
+msgstr "Ліцензіар дозволяє іншим копіювати, поширювати і передавати тільки незмінені копії роботи — не похідні роботи на його основі."
 
-#: src/olympia/devhub/templates/devhub/personas/edit.html:199
-#: src/olympia/devhub/templates/devhub/personas/submit.html:145
+#: src/olympia/devhub/templates/devhub/personas/edit.html:199 src/olympia/devhub/templates/devhub/personas/submit.html:145
 msgid "Your Theme will be released under the following license:"
 msgstr "Ваша тема буде випущена на умовах такої ліцензії:"
 
-#: src/olympia/devhub/templates/devhub/personas/edit.html:202
-#: src/olympia/devhub/templates/devhub/personas/submit.html:148
+#: src/olympia/devhub/templates/devhub/personas/edit.html:202 src/olympia/devhub/templates/devhub/personas/submit.html:148
 msgid "Select a different license."
 msgstr "Виберіть іншу ліцензію."
 
-#: src/olympia/devhub/templates/devhub/personas/edit.html:207
-#: src/olympia/devhub/templates/devhub/personas/submit.html:153
+#: src/olympia/devhub/templates/devhub/personas/edit.html:207 src/olympia/devhub/templates/devhub/personas/submit.html:153
 msgid "Select a license for your Theme."
 msgstr "Виберіть ліцензію для своєї теми."
 
-#: src/olympia/devhub/templates/devhub/personas/edit.html:217
-#: src/olympia/devhub/templates/devhub/personas/submit.html:163
+#: src/olympia/devhub/templates/devhub/personas/edit.html:217 src/olympia/devhub/templates/devhub/personas/submit.html:163
 msgid "Theme Design"
 msgstr "Дизайн теми"
 
-#: src/olympia/devhub/templates/devhub/personas/edit.html:221
-#: src/olympia/devhub/templates/devhub/personas/edit.html:224
+#: src/olympia/devhub/templates/devhub/personas/edit.html:221 src/olympia/devhub/templates/devhub/personas/edit.html:224
 msgid "Upload New Design"
 msgstr "Завантажити новий дизайн"
 
 #: src/olympia/devhub/templates/devhub/personas/edit.html:226
-msgid ""
-"Upon upload and form submission, the AMO Team will review your updated "
-"design. Your current design will still be public in the meantime."
-msgstr ""
-"Після завантаження та відправлення форми команда AMO розгляне ваш оновлений "
-"дизайн. Поки що для загалу буде показаний ваш поточний дизайн."
+msgid "Upon upload and form submission, the AMO Team will review your updated design. Your current design will still be public in the meantime."
+msgstr "Після завантаження та відправлення форми команда AMO розгляне ваш оновлений дизайн. Поки що для загалу буде показаний ваш поточний дизайн."
 
 #: src/olympia/devhub/templates/devhub/personas/edit.html:241
-msgid "Your previously resubmitted design,  which is under pending review."
+msgid "Your previously resubmitted design, which is under pending review."
 msgstr "Ваш раніше представлений дизайн,  який очікує перевірки."
 
 #: src/olympia/devhub/templates/devhub/personas/edit.html:245
@@ -8627,8 +6596,7 @@ msgstr "Чекаюче нижнє зображення"
 
 #: src/olympia/devhub/templates/devhub/personas/edit.html:259
 msgid "You may update your theme design here once it has been approved."
-msgstr ""
-"Ви можете оновити дизайн вашої теми тут після того, як вона буде схвалена."
+msgstr "Ви можете оновити дизайн вашої теми тут після того, як вона буде схвалена."
 
 #: src/olympia/devhub/templates/devhub/personas/edit.html:264
 msgid "Header"
@@ -8638,43 +6606,35 @@ msgstr "Верхнє зображення"
 msgid "Footer"
 msgstr "Нижнє зображення"
 
-#: src/olympia/devhub/templates/devhub/personas/edit.html:274
-#: src/olympia/devhub/templates/devhub/personas/submit.html:167
+#: src/olympia/devhub/templates/devhub/personas/edit.html:274 src/olympia/devhub/templates/devhub/personas/submit.html:167
 msgid "Select colors for your Theme."
 msgstr "Оберіть кольори для вашої теми."
 
-#: src/olympia/devhub/templates/devhub/personas/edit.html:276
-#: src/olympia/devhub/templates/devhub/personas/submit.html:169
+#: src/olympia/devhub/templates/devhub/personas/edit.html:276 src/olympia/devhub/templates/devhub/personas/submit.html:169
 msgid "Foreground Text"
 msgstr "Текст переднього тла"
 
-#: src/olympia/devhub/templates/devhub/personas/edit.html:277
-#: src/olympia/devhub/templates/devhub/personas/submit.html:170
+#: src/olympia/devhub/templates/devhub/personas/edit.html:277 src/olympia/devhub/templates/devhub/personas/submit.html:170
 msgid "This is the color of the tab text."
 msgstr "Це колір тексту вкладки."
 
-#: src/olympia/devhub/templates/devhub/personas/edit.html:279
-#: src/olympia/devhub/templates/devhub/personas/submit.html:172
+#: src/olympia/devhub/templates/devhub/personas/edit.html:279 src/olympia/devhub/templates/devhub/personas/submit.html:172
 msgid "Background"
 msgstr "Тло"
 
-#: src/olympia/devhub/templates/devhub/personas/edit.html:280
-#: src/olympia/devhub/templates/devhub/personas/submit.html:173
+#: src/olympia/devhub/templates/devhub/personas/edit.html:280 src/olympia/devhub/templates/devhub/personas/submit.html:173
 msgid "This is the color of the tabs."
 msgstr "Це колір вкладок."
 
-#: src/olympia/devhub/templates/devhub/personas/edit.html:285
-#: src/olympia/devhub/templates/devhub/personas/submit.html:178
+#: src/olympia/devhub/templates/devhub/personas/edit.html:285 src/olympia/devhub/templates/devhub/personas/submit.html:178
 msgid "Preview"
 msgstr "Попередній перегляд"
 
-#: src/olympia/devhub/templates/devhub/personas/edit.html:291
-#: src/olympia/devhub/templates/devhub/personas/submit.html:183
+#: src/olympia/devhub/templates/devhub/personas/edit.html:291 src/olympia/devhub/templates/devhub/personas/submit.html:183
 msgid "Your Theme's Name"
 msgstr "Ім'я вашої теми"
 
-#: src/olympia/devhub/templates/devhub/personas/edit.html:294
-#: src/olympia/devhub/templates/devhub/personas/submit.html:186
+#: src/olympia/devhub/templates/devhub/personas/edit.html:294 src/olympia/devhub/templates/devhub/personas/submit.html:186
 #, python-format
 msgid "by <a href=\"%(profile_url)s\" target=\"_blank\">%(user)s</a>"
 msgstr "від <a href=\"%(profile_url)s\" target=\"_blank\">%(user)s</a>"
@@ -8685,71 +6645,39 @@ msgstr "Створити нову тему"
 
 #: src/olympia/devhub/templates/devhub/personas/submit.html:18
 #, python-format
-msgid ""
-"Background themes let you easily personalize the look of your Firefox. "
-"Submit your own design below, or <a href=\"%(submit_url)s\">learn how to "
-"create one</a>!"
-msgstr ""
-"Фонові теми дозволяють легко персоналізувати зовнішній вигляд вашого "
-"Firefox. Додайте свій власний дизайн нижче, або <a "
-"href=\"%(submit_url)s\">дізнайтеся, як його створити</a>!"
+msgid "Background themes let you easily personalize the look of your Firefox. Submit your own design below, or <a href=\"%(submit_url)s\">learn how to create one</a>!"
+msgstr "Фонові теми дозволяють легко персоналізувати зовнішній вигляд вашого Firefox. Додайте свій власний дизайн нижче, або <a href=\"%(submit_url)s\">дізнайтеся, як його створити</a>!"
 
 #: src/olympia/devhub/templates/devhub/personas/submit.html:33
 msgid "Give your Theme a name."
 msgstr "Дайте назву своїй темі."
 
-#: src/olympia/devhub/templates/devhub/personas/submit.html:54
-msgid ""
-"A short explanation of your theme's basic functionality that is displayed in"
-" search and browse listings, as well as at the top of your theme's details "
-"page."
-msgstr ""
-"Коротке пояснення основних функцій вашої теми, які відображаються в списках "
-"пошуку та перегляду, а також у верхній частині сторінки вашої теми."
-
 #: src/olympia/devhub/templates/devhub/personas/submit.html:198
 #, python-format
 msgid ""
-"I agree to the <a href=\"%(agreement_url)s\" target=\"_blank\">Firefox Add-"
-"on Distribution Agreement</a> and to my information being handled as "
-"described in the <a href=\"%(privacy_notice_url)s\" "
+"I agree to the <a href=\"%(agreement_url)s\" target=\"_blank\">Firefox Add-on Distribution Agreement</a> and to my information being handled as described in the <a href=\"%(privacy_notice_url)s\" "
 "target=\"_blank\">Websites, Communications and Cookies Privacy Notice</a>."
 msgstr ""
-"Я погоджуюсь з умовами <a href=\"%(agreement_url)s\" target=\"_blank\">Угоди"
-" про розповсюдження додатків Firefox</a> і з тим, що моя інформація "
-"обробляється, як описано в <a href=\"%(privacy_notice_url)s\" "
-"target=\"_blank\">Повідомленні про приватність веб-сайтів, зв'язку та "
-"куків</a>."
+"Я погоджуюсь з умовами <a href=\"%(agreement_url)s\" target=\"_blank\">Угоди про розповсюдження додатків Firefox</a> і з тим, що моя інформація обробляється, як описано в <a "
+"href=\"%(privacy_notice_url)s\" target=\"_blank\">Повідомленні про приватність веб-сайтів, зв'язку та куків</a>."
 
 #: src/olympia/devhub/templates/devhub/personas/submit.html:205
 msgid "Submit Theme"
 msgstr "Представити тему"
 
 #: src/olympia/devhub/templates/devhub/personas/submit_done.html:11
-msgid ""
-"Your theme has been submitted to the Review Queue. You'll receive an email "
-"once it has been reviewed, typically within 24 hours."
-msgstr ""
-"Ваша тема була відправлена в чергу на перевірку. Ви отримаєте електронний "
-"лист після того, як вона буде перевірена, зазвичай протягом 24 годин."
+msgid "Your theme has been submitted to the Review Queue. You'll receive an email once it has been reviewed, typically within 24 hours."
+msgstr "Ваша тема була відправлена в чергу на перевірку. Ви отримаєте електронний лист після того, як вона буде перевірена, зазвичай протягом 24 годин."
 
 #: src/olympia/devhub/templates/devhub/personas/submit_done.html:19
 #, python-format
-msgid ""
-"Provide more details about your theme by <a href=\"%(edit_url)s\">editing "
-"its listing</a>."
-msgstr ""
-"Надайте більш детальну інформацію про вашу тему, <a "
-"href=\"%(edit_url)s\">відредагувавши її сторінку</a>."
+msgid "Provide more details about your theme by <a href=\"%(edit_url)s\">editing its listing</a>."
+msgstr "Надайте більш детальну інформацію про вашу тему, <a href=\"%(edit_url)s\">відредагувавши її сторінку</a>."
 
 #: src/olympia/devhub/templates/devhub/personas/submit_done.html:25
 #, python-format
-msgid ""
-"View and subscribe to your theme's <a href=\"%(feed_url)s\">activity "
-"feed</a> to stay updated on reviews, collections, and more."
-msgstr ""
-"Перегляньте і підпишіться на <a href=\"%(feed_url)s\">стрічку активності</a>"
-" вашої теми, щоб бути в курсі відгуків, добірок і багато іншого."
+msgid "View and subscribe to your theme's <a href=\"%(feed_url)s\">activity feed</a> to stay updated on reviews, collections, and more."
+msgstr "Перегляньте і підпишіться на <a href=\"%(feed_url)s\">стрічку активності</a> вашої теми, щоб бути в курсі відгуків, добірок і багато іншого."
 
 #: src/olympia/devhub/templates/devhub/personas/submit_done.html:32
 #, python-format
@@ -8764,13 +6692,11 @@ msgstr "Виберіть верхнє зображення для вашої т�
 msgid "3000 &times; 200 pixels"
 msgstr "3000 &times; 200 пікселів"
 
-#: src/olympia/devhub/templates/devhub/personas/includes/theme_design.html:9
-#: src/olympia/devhub/templates/devhub/personas/includes/theme_design.html:25
+#: src/olympia/devhub/templates/devhub/personas/includes/theme_design.html:9 src/olympia/devhub/templates/devhub/personas/includes/theme_design.html:25
 msgid "300 KB max"
 msgstr "Максимум 300 КБ"
 
-#: src/olympia/devhub/templates/devhub/personas/includes/theme_design.html:10
-#: src/olympia/devhub/templates/devhub/personas/includes/theme_design.html:26
+#: src/olympia/devhub/templates/devhub/personas/includes/theme_design.html:10 src/olympia/devhub/templates/devhub/personas/includes/theme_design.html:26
 msgid "PNG or JPG"
 msgstr "PNG або JPG"
 
@@ -8799,60 +6725,26 @@ msgid "Select a different footer image"
 msgstr "Виберіть інше нижнє зображення"
 
 #: src/olympia/devhub/templates/devhub/versions/add_file_modal.html:8
-msgid ""
-"Files added to reviewed versions must be reviewed before they will be "
-"available for download."
-msgstr ""
-"Файли, додані в перевірені версії, повинні бути перевірені перед тим як вони"
-" будуть доступні для завантаження."
+msgid "Files added to reviewed versions must be reviewed before they will be available for download."
+msgstr "Файли, додані в перевірені версії, повинні бути перевірені перед тим як вони будуть доступні для завантаження."
 
-#: src/olympia/devhub/templates/devhub/versions/add_file_modal.html:15
-#, python-format
-msgid ""
-"Submission of updates to unlisted add-ons for signing is currently in an "
-"open beta. Manual review may still be required for a large number of add-"
-"ons. Please <a href=\"%(url)s\" target=\"_blank\">report any bugs</a> that "
-"you encounter."
-msgstr ""
-"Подання оновлень для неопублікованих додатків для підпису зараз є відкритою "
-"бетою. Ручний перегляд може все ще вимагатися для великої кількості "
-"додатків. Будь ласка, <a href=\"%(url)s\" target=\"_blank\">повідомте про "
-"будь-які проблеми</a>, з якими ви стикаєтесь."
-
-#: src/olympia/devhub/templates/devhub/versions/add_file_modal.html:35
+#: src/olympia/devhub/templates/devhub/versions/add_file_modal.html:24
 msgid "Select the target platform for this file."
 msgstr "Оберіть платформу для цього файлу."
 
-#: src/olympia/devhub/templates/devhub/versions/add_file_modal.html:46
+#: src/olympia/devhub/templates/devhub/versions/add_file_modal.html:35
 msgid "Which review type would you like to nominate for?"
 msgstr "На який тип перевірки ви хотіли б її номінувати?"
 
-#: src/olympia/devhub/templates/devhub/versions/add_file_modal.html:51
+#: src/olympia/devhub/templates/devhub/versions/add_file_modal.html:40
 msgid "Only publish this version to my beta channel."
 msgstr "Опублікувати цю версію тільки на моєму бета-каналі."
-
-#: src/olympia/devhub/templates/devhub/versions/add_file_modal.html:54
-#, python-format
-msgid ""
-"The behavior of the beta channel has changed to accommodate <a "
-"href=\"%(addon_signing_url)s\" target=\"_blank\">mandatory add-on "
-"signing</a>. The new process is currently in an open beta, and may change "
-"significantly in the near future. Please <a href=\"%(issues_url)s\" "
-"target=\"_blank\">report any bugs</a> that you encounter."
-msgstr ""
-"Поведінка бета каналу змінилася, щоб пристосуватися до <a "
-"href=\"%(addon_signing_url)s\" target=\"_blank\">обов'язкового підписання "
-"додатків</a>. Новий процес в даний момент під відкритою бетою і може значно "
-"змінитися в найближчому майбутньому. Будь ласка, <a href=\"%(issues_url)s\" "
-"target=\"_blank\">повідомляйте про будь-які проблеми</a>, з якими ви "
-"стикаєтесь."
 
 #: src/olympia/devhub/templates/devhub/versions/edit.html:5
 msgid "Manage Version {0}"
 msgstr "Керування версією {0}"
 
-#: src/olympia/devhub/templates/devhub/versions/edit.html:12
-#: src/olympia/devhub/templates/devhub/versions/list.html:3
+#: src/olympia/devhub/templates/devhub/versions/edit.html:12 src/olympia/devhub/templates/devhub/versions/list.html:3
 msgid "Status & Versions"
 msgstr "Стан і версії"
 
@@ -8869,58 +6761,33 @@ msgstr "Файли"
 msgid "Upload Another File"
 msgstr "Завантажити інший файл"
 
-#: src/olympia/devhub/templates/devhub/versions/edit.html:45
-msgid ""
-"Adjusting application information here will allow users to install your add-"
-"on even if the install manifest in the package indicates that the add-on is "
-"incompatible."
-msgstr ""
-"Налаштування інформації про програму тут, дозволить користувачам встановити "
-"Ваш додаток, навіть якщо маніфест встановлення в пакеті вказує, що додаток є"
-" несумісним."
-
 #: src/olympia/devhub/templates/devhub/versions/edit.html:74
 msgid ""
-"Information about changes in this release, new features, known bugs, and "
-"other useful information specific to this release/version. This information "
-"is also shown in the Add-ons Manager when updating."
-msgstr ""
-"Інформація про зміни в цьому випуску, нові можливості, відомі помилки та "
-"інша корисна інформація стосовно цього випуску/версії. Ця інформація буде "
-"також показана в менеджері додатків при оновленні."
+"Information about changes in this release, new features, known bugs, and other useful information specific to this release/version. This information is also shown in the Add-ons Manager when "
+"updating."
+msgstr "Інформація про зміни в цьому випуску, нові можливості, відомі помилки та інша корисна інформація стосовно цього випуску/версії. Ця інформація буде також показана в менеджері додатків при оновленні."
 
 #: src/olympia/devhub/templates/devhub/versions/edit.html:99
 msgid "Approval Status"
 msgstr "Стан схвалення"
 
-#: src/olympia/devhub/templates/devhub/versions/edit.html:113
-#: src/olympia/editors/templates/editors/review.html:108
+#: src/olympia/devhub/templates/devhub/versions/edit.html:113 src/olympia/editors/templates/editors/review.html:108
 msgid "Notes for Reviewers"
 msgstr "Примітки для рецензентів"
 
 #: src/olympia/devhub/templates/devhub/versions/edit.html:114
-msgid ""
-"Optionally, enter any information that may be useful to the Editor reviewing"
-" this add-on, such as test account information."
-msgstr ""
-"За бажанням, введіть будь-яку інформацію, яка може бути корисна для "
-"редактора, який перевіряє цей додаток, наприклад, обліковий запис для "
-"тестування."
+msgid "Optionally, enter any information that may be useful to the Editor reviewing this add-on, such as test account information."
+msgstr "За бажанням, введіть будь-яку інформацію, яка може бути корисна для редактора, який перевіряє цей додаток, наприклад, обліковий запис для тестування."
 
 #: src/olympia/devhub/templates/devhub/versions/edit.html:127
 msgid "Source code"
 msgstr "Програмний код"
 
 #: src/olympia/devhub/templates/devhub/versions/edit.html:128
-msgid ""
-"If your add-on contain binary or obfuscated code, make the source available "
-"here for reviewers."
-msgstr ""
-"Якщо ваш додаток містить бінарний або заплутаний код, надайте його тут тим, "
-"хто перевіряє."
+msgid "If your add-on contain binary or obfuscated code, make the source available here for reviewers."
+msgstr "Якщо ваш додаток містить бінарний або заплутаний код, надайте його тут тим, хто перевіряє."
 
-#: src/olympia/devhub/templates/devhub/versions/edit.html:145
-#: src/olympia/devhub/templates/devhub/versions/edit.html:149
+#: src/olympia/devhub/templates/devhub/versions/edit.html:145 src/olympia/devhub/templates/devhub/versions/edit.html:149
 msgid "Upload a new file"
 msgstr "Завантажити новий файл"
 
@@ -8935,8 +6802,7 @@ msgstr "Файл {file_id} ({platform})"
 #: src/olympia/devhub/templates/devhub/versions/file_status_message.html:5
 #, python-format
 msgid "Created on %(created)s and changed to %(status)s on %(status_date)s"
-msgstr ""
-"Створений %(created)s і його статус змінений %(status_date)s на %(status)s"
+msgstr "Створений %(created)s і його статус змінений %(status_date)s на %(status)s"
 
 #: src/olympia/devhub/templates/devhub/versions/file_status_message.html:9
 #, python-format
@@ -8962,7 +6828,6 @@ msgid "{0} file"
 msgid_plural "{0} files"
 msgstr[0] "{0} файл"
 msgstr[1] "{0} файли"
-msgstr[2] "{0} файлів"
 
 #: src/olympia/devhub/templates/devhub/versions/list.html:25
 msgid "0 files"
@@ -8989,9 +6854,7 @@ msgstr "Запитати повний розгляд"
 msgid "Request Preliminary Review"
 msgstr "Запитати попередній розгляд"
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:80
-#: src/olympia/devhub/templates/devhub/versions/list.html:327
-#: src/olympia/devhub/templates/devhub/versions/list.html:350
+#: src/olympia/devhub/templates/devhub/versions/list.html:80 src/olympia/devhub/templates/devhub/versions/list.html:325 src/olympia/devhub/templates/devhub/versions/list.html:348
 msgid "Cancel Review Request"
 msgstr "Скасувати запит на розгляд"
 
@@ -9004,35 +6867,24 @@ msgid "Listed:"
 msgstr "У списку:"
 
 #: src/olympia/devhub/templates/devhub/versions/list.html:102
-msgid ""
-"Visible to everyone on {0} and included in search results and listing pages"
-msgstr ""
-"Видимий всім на {0} і включений в результати пошуку та інформаційні "
-"сторінки."
+msgid "Visible to everyone on {0} and included in search results and listing pages"
+msgstr "Видимий всім на {0} і включений в результати пошуку та інформаційні сторінки."
 
 #: src/olympia/devhub/templates/devhub/versions/list.html:108
 msgid "Hidden:"
 msgstr "Приховані:"
 
 #: src/olympia/devhub/templates/devhub/versions/list.html:108
-msgid ""
-"Hosted on {0}, but hidden to anyone but authors. Used to temporarily hide "
-"listings or discontinue them."
-msgstr ""
-"Розміщені на {0}, але приховані для всіх, орім авторів. Використовується, "
-"щоб тимчасово приховати або припинити їх."
+msgid "Hosted on {0}, but hidden to anyone but authors. Used to temporarily hide listings or discontinue them."
+msgstr "Розміщені на {0}, але приховані для всіх, орім авторів. Використовується, щоб тимчасово приховати або припинити їх."
 
 #: src/olympia/devhub/templates/devhub/versions/list.html:114
 msgid "Unlisted:"
 msgstr "Не перелічені:"
 
 #: src/olympia/devhub/templates/devhub/versions/list.html:114
-msgid ""
-"Not distributed on {0}. Developers will upload new versions for signing and "
-"distribute the add-ons on their own. (beta)"
+msgid "Not distributed on {0}. Developers will upload new versions for signing and distribute the add-ons on their own."
 msgstr ""
-"Не розповсюджується на {0}. Розробники будуть вивантажувати нові версії для "
-"підписання і розповсюджувати додатки власноруч. (бета)"
 
 #: src/olympia/devhub/templates/devhub/versions/list.html:122
 msgid "Current versions"
@@ -9042,17 +6894,12 @@ msgstr "Поточні версії"
 msgid "Currently on AMO"
 msgstr "Зараз на AMO"
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:129
-#: src/olympia/devhub/templates/devhub/versions/list.html:147
-#: src/olympia/devhub/templates/devhub/versions/list.html:164
-#: src/olympia/editors/templates/editors/includes/search_results_themes.html:7
-#: src/olympia/editors/templates/editors/themes/queue_list.html:50
+#: src/olympia/devhub/templates/devhub/versions/list.html:129 src/olympia/devhub/templates/devhub/versions/list.html:147 src/olympia/devhub/templates/devhub/versions/list.html:164
+#: src/olympia/editors/templates/editors/includes/search_results_themes.html:7 src/olympia/editors/templates/editors/themes/queue_list.html:50
 msgid "Status"
 msgstr "Статус"
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:130
-#: src/olympia/devhub/templates/devhub/versions/list.html:148
-#: src/olympia/devhub/templates/devhub/versions/list.html:165
+#: src/olympia/devhub/templates/devhub/versions/list.html:130 src/olympia/devhub/templates/devhub/versions/list.html:148 src/olympia/devhub/templates/devhub/versions/list.html:165
 #: src/olympia/editors/templates/editors/includes/files_view.html:11
 msgid "Validation"
 msgstr "Перевірка"
@@ -9074,15 +6921,10 @@ msgid "Full review may not be required"
 msgstr "Повний розгляд може бути необов'язковим"
 
 #: src/olympia/devhub/templates/devhub/versions/list.html:201
-msgid ""
-"Unlisted add-ons don't need Full Review unless they are distributed as part "
-"of an application installer. Read <a href=\"{link}\" target=\"_blank\">this "
-"documentation</a> for more information."
+msgid "Unlisted add-ons don't need Full Review unless they are distributed as part of an application installer. Read <a href=\"{link}\" target=\"_blank\">this documentation</a> for more information."
 msgstr ""
-"Неопубліковані додатки не потребують повного розгляду, поки вони "
-"розповсюджуються як частина інсталятора програми. Ознайомтеся з <a "
-"href=\"{link}\" target=\"_blank\">цією документацією</a> для докладної "
-"інформації."
+"Неопубліковані додатки не потребують повного розгляду, поки вони розповсюджуються як частина інсталятора програми. Ознайомтеся з <a href=\"{link}\" target=\"_blank\">цією документацією</a> для "
+"докладної інформації."
 
 #: src/olympia/devhub/templates/devhub/versions/list.html:209
 msgid "Request full review"
@@ -9093,141 +6935,88 @@ msgid "Delete Version {version}"
 msgstr "Видалити версію {version}"
 
 #: src/olympia/devhub/templates/devhub/versions/list.html:218
-msgid ""
-"You are about to delete the current version of your add-on. This may cause "
-"your add-on status to change, or your listing to lose public visibility, if "
-"this is the only public version of your add-on."
-msgstr ""
-"Ви збираєтесь видалити поточну версію свого додатку. Це може призвести до "
-"зміни статусу додатку чи втрати видимості його сторінки для публіки, якщо це"
-" єдина публічна версія вашого додатку."
+msgid "You are about to delete the current version of your add-on. This may cause your add-on status to change, or your listing to lose public visibility, if this is the only public version of your add-on."
+msgstr "Ви збираєтесь видалити поточну версію свого додатку. Це може призвести до зміни статусу додатку чи втрати видимості його сторінки для публіки, якщо це єдина публічна версія вашого додатку."
 
 #: src/olympia/devhub/templates/devhub/versions/list.html:219
 msgid "Deleting this version will permanently delete:"
 msgstr "Видалення цієї версії назавжди видалить:"
 
 #: src/olympia/devhub/templates/devhub/versions/list.html:225
-msgid ""
-"<strong>Important:</strong> Once a version has been deleted, you may not "
-"upload a new version with the same version number."
-msgstr ""
-"<strong>Важливо:</strong> Як тільки версія буде видалена, ви не зможете "
-"вивантажити нову версію з таким самим номером."
+msgid "<strong>Important:</strong> Once a version has been deleted, you may not upload a new version with the same version number."
+msgstr "<strong>Важливо:</strong> Як тільки версія буде видалена, ви не зможете вивантажити нову версію з таким самим номером."
 
 #: src/olympia/devhub/templates/devhub/versions/list.html:230
-msgid ""
-"Deleting a version which has already been reviewed\n"
-"               may also cause a significant delay in the review of\n"
-"               your next update."
-msgstr ""
-"Видалення версії, яка вже була перевірена, також може\n"
-"               спричинити значну затримку при перевірці\n"
-"               вашого наступного оновлення."
-
-#: src/olympia/devhub/templates/devhub/versions/list.html:233
 msgid "Are you sure you wish to delete this version?"
 msgstr "Ви дійсно бажаєте видалити цю версію?"
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:238
+#: src/olympia/devhub/templates/devhub/versions/list.html:235
 msgid "Delete Version"
 msgstr "Видалити версію"
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:240
+#: src/olympia/devhub/templates/devhub/versions/list.html:237
 msgid "Disable Version"
 msgstr "Відключити версію"
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:247
+#: src/olympia/devhub/templates/devhub/versions/list.html:244
 msgid "Add a new Version"
 msgstr "Додати нову версію"
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:249
+#: src/olympia/devhub/templates/devhub/versions/list.html:246
 msgid "Add Version"
 msgstr "Додати версію"
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:256
-#: src/olympia/devhub/templates/devhub/versions/list.html:274
+#: src/olympia/devhub/templates/devhub/versions/list.html:253 src/olympia/devhub/templates/devhub/versions/list.html:279
 msgid "Hide Add-on"
 msgstr "Приховати додаток"
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:259
-msgid ""
-"Hiding your add-on will prevent it from appearing anywhere in our gallery "
-"and will stop users from receiving automatic updates."
-msgstr ""
-"Приховування вашого додатку дозволить запобігти його появі в будь-якому "
-"місці в нашій галереї і заборонити користувачам отримувати автоматичні "
-"оновлення."
+#: src/olympia/devhub/templates/devhub/versions/list.html:256
+msgid "Hiding your add-on will prevent it from appearing anywhere in our gallery and will stop users from receiving automatic updates."
+msgstr "Приховування вашого додатку дозволить запобігти його появі в будь-якому місці в нашій галереї і заборонити користувачам отримувати автоматичні оновлення."
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:265
+#: src/olympia/devhub/templates/devhub/versions/list.html:263
+msgid "The files awaiting review will be disabled and you will need to upload new versions."
+msgstr ""
+
+#: src/olympia/devhub/templates/devhub/versions/list.html:270
 msgid "Are you sure you wish to hide your add-on?"
 msgstr "Ви впевнені, що хочете приховати свій додаток?"
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:286
-#: src/olympia/devhub/templates/devhub/versions/list.html:315
+#: src/olympia/devhub/templates/devhub/versions/list.html:291 src/olympia/devhub/templates/devhub/versions/list.html:313
 msgid "Unlist Add-on"
 msgstr "Прибрати додаток зі списку"
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:289
+#: src/olympia/devhub/templates/devhub/versions/list.html:294
 #, python-format
 msgid ""
-"Unlisting your add-on will make it (and each of its versions/files) "
-"invisible on this website. It won't show up in searches, won't have a public"
-" facing page, and won't be updated automatically for current users.  It is "
-"recommended for unlisted add-ons to provide a custom <a "
-"href=\"%(update_url)s\" target=\"_blank\">updateURL</a> in their manifest "
-"file for automatic updates."
+"Unlisting your add-on will make it (and each of its versions/files) invisible on this website. It won't show up in searches, won't have a public facing page, and won't be updated automatically for "
+"current users. It is recommended for unlisted add-ons to provide a custom <a href=\"%(update_url)s\" target=\"_blank\">updateURL</a> in their manifest file for automatic updates."
 msgstr ""
-"Прибирання вашого додатку зі списку опублікованих зробить його (та всі його "
-"версії/файли) невидимими на цьому веб-сайті. Він не з'являтиметься в "
-"результатах пошуку, не буде мати публічної сторінки, а також не буде "
-"автоматично оновлюватись у поточних користувачів.  Для неопублікованих "
-"додатків рекомендується надавати <a href=\"%(update_url)s\" "
-"target=\"_blank\">updateURL</a> в їхньому файлі маніфесту для забезпечення "
-"автоматичного оновлення."
+"Прибирання вашого додатку зі списку опублікованих зробить його (та всі його версії/файли) невидимими на цьому веб-сайті. Він не з'являтиметься в результатах пошуку, не буде мати публічної сторінки,"
+" а також не буде автоматично оновлюватись у поточних користувачів.  Для неопублікованих додатків рекомендується надавати <a href=\"%(update_url)s\" target=\"_blank\">updateURL</a> в їхньому файлі "
+"маніфесту для забезпечення автоматичного оновлення."
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:299
-#, python-format
-msgid ""
-"Switching add-ons to unlisted is currently in an open beta. Please <a "
-"href=\"%(url)s\" target=\"_blank\">report any bugs</a> that you encounter."
-msgstr ""
-"Функція вилучення додатків зі списку в даний момент знаходиться у відкритій "
-"беті. Будь ласка <a href=\"%(url)s\" target=\"_blank\">повідомляйте про "
-"будь-які помилки</a>, з якими ви стикаєтесь."
-
-#: src/olympia/devhub/templates/devhub/versions/list.html:305
+#: src/olympia/devhub/templates/devhub/versions/list.html:303
 msgid "Unlisting an add-on is irreversible!"
 msgstr "Прибирання додатку зі списку є незворотнім!"
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:305
+#: src/olympia/devhub/templates/devhub/versions/list.html:303
 msgid "An unlisted add-on cannot be switched to be listed."
-msgstr ""
-"Додатки, вилучені зі списку опублікованих, не можуть бути знову "
-"опубліковані."
+msgstr "Додатки, вилучені зі списку опублікованих, не можуть бути знову опубліковані."
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:307
+#: src/olympia/devhub/templates/devhub/versions/list.html:305
 msgid "Are you sure you wish to unlist your add-on?"
 msgstr "Ви дійсно бажаєте прибрати свій додаток зі списку?"
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:330
-msgid ""
-"Canceling your review request will leave your add-on as preliminarily "
-"reviewed."
-msgstr ""
-"Скасування вашого запиту на розгляд залишить ваш додаток, як попередньо "
-"розглянутий."
+#: src/olympia/devhub/templates/devhub/versions/list.html:328
+msgid "Canceling your review request will leave your add-on as preliminarily reviewed."
+msgstr "Скасування вашого запиту на розгляд залишить ваш додаток, як попередньо розглянутий."
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:335
-msgid ""
-"Canceling your review request will mark your add-on incomplete. If you do "
-"not complete your add-on after several days by re-requesting review, it will"
-" be deleted."
-msgstr ""
-"Скасування вашого запиту на розгляд відмітить ваш додаток, як незавершений. "
-"Якщо ви протягом кількох днів не відправите повторний запит для розгляду, "
-"додаток буде видалений."
+#: src/olympia/devhub/templates/devhub/versions/list.html:333
+msgid "Canceling your review request will mark your add-on incomplete. If you do not complete your add-on after several days by re-requesting review, it will be deleted."
+msgstr "Скасування вашого запиту на розгляд відмітить ваш додаток, як незавершений. Якщо ви протягом кількох днів не відправите повторний запит для розгляду, додаток буде видалений."
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:343
+#: src/olympia/devhub/templates/devhub/versions/list.html:341
 msgid "Are you sure you wish to cancel your review request?"
 msgstr "Ви впевнені, що хочете скасувати свій запит на відгук?"
 
@@ -9260,18 +7049,12 @@ msgid "Translate content on the web from and into over 40 languages."
 msgstr "Перекладайте вміст в інтернеті більш ніж 40 мовами."
 
 #: src/olympia/discovery/modules.py:171
-msgid ""
-"Easily connect to your social networks, and share or comment on the page "
-"you're visiting."
-msgstr ""
-"Легко підключайтесь до своїх соціальних мереж та діліться чи коментуйте "
-"сторінки, які відвідуєте."
+msgid "Easily connect to your social networks, and share or comment on the page you're visiting."
+msgstr "Легко підключайтесь до своїх соціальних мереж та діліться чи коментуйте сторінки, які відвідуєте."
 
 #: src/olympia/discovery/modules.py:173
-msgid ""
-"A quick view to compare prices when you shop online or search for flights."
-msgstr ""
-"Швидко порівнюйте ціни при покупках в Інтернеті чи бронюванні авіаквитків."
+msgid "A quick view to compare prices when you shop online or search for flights."
+msgstr "Швидко порівнюйте ціни при покупках в Інтернеті чи бронюванні авіаквитків."
 
 #: src/olympia/discovery/modules.py:183
 msgid "Firefox 4 Collection"
@@ -9314,24 +7097,16 @@ msgid "Add-ons that help you on your travels!"
 msgstr "Додатки, які допомагають вам під час подорожей!"
 
 #: src/olympia/discovery/modules.py:226
-msgid ""
-"Displays a country flag depicting the location of the current website's "
-"server and more."
-msgstr ""
-"Відображає прапор країни, який показує розташування сервера поточного веб-"
-"сайту та інше."
+msgid "Displays a country flag depicting the location of the current website's server and more."
+msgstr "Відображає прапор країни, який показує розташування сервера поточного веб-сайту та інше."
 
 #: src/olympia/discovery/modules.py:228
 msgid "FoxClocks let you keep an eye on the time around the world."
 msgstr "FoxClocks дозволяє вам слідкувати за часом по всьому Світу."
 
 #: src/olympia/discovery/modules.py:230
-msgid ""
-"Automatically get the lowest price when you shop online or search for "
-"flights."
-msgstr ""
-"Автоматично отримуйте найнижчу ціну при покупках онлайн чи пошуку "
-"авіаквитків."
+msgid "Automatically get the lowest price when you shop online or search for flights."
+msgstr "Автоматично отримуйте найнижчу ціну при покупках онлайн чи пошуку авіаквитків."
 
 #: src/olympia/discovery/modules.py:240
 msgid "A+ add-ons for School"
@@ -9370,12 +7145,8 @@ msgid "Put a Theme on It!"
 msgstr "Прикрасьте його темою!"
 
 #: src/olympia/discovery/modules.py:281
-msgid ""
-"Visit addons.mozilla.org from Firefox for Android and dress up your mobile "
-"browser to match your style, mood, or the season."
-msgstr ""
-"Відвідайте addons.mozilla.org з Firefox для Android і одягніть ваш мобільний"
-" браузер під ваш стиль, настрій або сезон."
+msgid "Visit addons.mozilla.org from Firefox for Android and dress up your mobile browser to match your style, mood, or the season."
+msgstr "Відвідайте addons.mozilla.org з Firefox для Android і одягніть ваш мобільний браузер під ваш стиль, настрій або сезон."
 
 #: src/olympia/discovery/modules.py:290
 msgid "Get up and move!"
@@ -9399,16 +7170,11 @@ msgstr "Вільний перегляд без проблем"
 
 #: src/olympia/discovery/modules.py:333
 msgid "Protect your privacy online with the add-ons in this collection."
-msgstr ""
-"Захистіть свою приватність в мережі за допомогою додатків з цієї збірки."
+msgstr "Захистіть свою приватність в мережі за допомогою додатків з цієї збірки."
 
 #: src/olympia/discovery/modules.py:342
-msgid ""
-"Great add-ons for work, fun, privacy, productivity&hellip; just about "
-"anything!"
-msgstr ""
-"Чудові додатки для роботи, розваг, приватності, продуктивності&hellip; на "
-"будь-який смак!"
+msgid "Great add-ons for work, fun, privacy, productivity&hellip; just about anything!"
+msgstr "Чудові додатки для роботи, розваг, приватності, продуктивності&hellip; на будь-який смак!"
 
 #: src/olympia/discovery/modules.py:350
 msgid "Add-ons for Australis Contest Winners"
@@ -9428,23 +7194,16 @@ msgstr "Що таке додатки?"
 
 #: src/olympia/discovery/templates/discovery/pane.html:28
 #, python-format
-msgid ""
-"Add-ons are applications that let you personalize %(app)s with extra "
-"functionality or style. Try a time-saving sidebar, a weather notifier, or a "
-"themed look to make %(app)s your own."
+msgid "Add-ons are applications that let you personalize %(app)s with extra functionality or style. Try a time-saving sidebar, a weather notifier, or a themed look to make %(app)s your own."
 msgstr ""
-"Додатки - це програми, які дозволяють вам налаштувати %(app)s на свій смак, "
-"додавши в нього додаткові функції або надавши свій стиль. Спробуйте "
-"використовувати бічну панель, яка заощаджує час, налаштуйте повідомлення про"
-" прогноз погоди або змініть зовнішній вигляд, щоб зробити %(app)s саме "
-"таким, як ви бажаєте."
+"Додатки - це програми, які дозволяють вам налаштувати %(app)s на свій смак, додавши в нього додаткові функції або надавши свій стиль. Спробуйте використовувати бічну панель, яка заощаджує час, "
+"налаштуйте повідомлення про прогноз погоди або змініть зовнішній вигляд, щоб зробити %(app)s саме таким, як ви бажаєте."
 
 #: src/olympia/discovery/templates/discovery/pane.html:62
 msgid "Learn More About Add-ons"
 msgstr "Докладніше про додатки"
 
-#: src/olympia/discovery/templates/discovery/pane.html:66
-#: src/olympia/discovery/templates/discovery/pane.html:73
+#: src/olympia/discovery/templates/discovery/pane.html:66 src/olympia/discovery/templates/discovery/pane.html:73
 msgid "See all"
 msgstr "Дивитися всі"
 
@@ -9475,12 +7234,8 @@ msgstr "Привіт, {0}"
 
 #: src/olympia/discovery/templates/discovery/pane_account.html:17
 #, python-format
-msgid ""
-"Thanks for using %(app)s and supporting <a href=\"%(url)s\">Mozilla's "
-"mission</a>!"
-msgstr ""
-"Дякуємо за використання %(app)s та підтримку <a href=\"%(url)s\">місії "
-"Mozilla</a>!"
+msgid "Thanks for using %(app)s and supporting <a href=\"%(url)s\">Mozilla's mission</a>!"
+msgstr "Дякуємо за використання %(app)s та підтримку <a href=\"%(url)s\">місії Mozilla</a>!"
 
 #: src/olympia/discovery/templates/discovery/pane_account.html:23
 msgid "Add-ons downloaded:"
@@ -9504,14 +7259,10 @@ msgstr "Отримуйте додатки де б ви не були"
 
 #: src/olympia/discovery/templates/discovery/modules/go-mobile.html:8
 #, python-format
-msgid ""
-"Visit <a href=\"%(url)s\">firefox.com/m</a> to get Firefox on your phone and"
-" personalize your browser anytime, anywhere. Easily discover and install "
-"add-ons from the mobile Add-ons Manager."
+msgid "Visit <a href=\"%(url)s\">firefox.com/m</a> to get Firefox on your phone and personalize your browser anytime, anywhere. Easily discover and install add-ons from the mobile Add-ons Manager."
 msgstr ""
-"Відвідайте <a href=\"%(url)s\">firefox.com/m</a>, щоб отримати Firefox на "
-"свій телефон та налаштувати свій браузер під себе будь-коли, де завгодно. "
-"Легко знаходьте та встановлюйте додатки з мобільного менеджера додатків."
+"Відвідайте <a href=\"%(url)s\">firefox.com/m</a>, щоб отримати Firefox на свій телефон та налаштувати свій браузер під себе будь-коли, де завгодно. Легко знаходьте та встановлюйте додатки з "
+"мобільного менеджера додатків."
 
 #: src/olympia/discovery/templates/discovery/modules/go-mobile.html:13
 msgid "Get Mobile Add-ons"
@@ -9523,24 +7274,15 @@ msgstr "Розумний шопінг в цей святковий сезон"
 
 #: src/olympia/discovery/templates/discovery/modules/holiday.html:5
 msgid "Find great add-ons to help you with all your holiday shopping needs."
-msgstr ""
-"Дізнайтесь про чудові додатки, які допоможуть вам зі святковими покупками."
+msgstr "Дізнайтесь про чудові додатки, які допоможуть вам зі святковими покупками."
 
 #: src/olympia/discovery/templates/discovery/modules/holiday.html:13
-msgid ""
-"Install the Amazon Browser Apps and receive special Amazon features right at"
-" your fingertips."
-msgstr ""
-"Встановіть браузерні додатки Amazon і отримаєте спеціальні можливості від "
-"Amazon."
+msgid "Install the Amazon Browser Apps and receive special Amazon features right at your fingertips."
+msgstr "Встановіть браузерні додатки Amazon і отримаєте спеціальні можливості від Amazon."
 
 #: src/olympia/discovery/templates/discovery/modules/holiday.html:22
-msgid ""
-"Keep an eye on your eBay activity wherever you are on the web when you "
-"install the eBay Sidebar for Firefox."
-msgstr ""
-"Будьте в курсі активності на eBay з будь-якого місця Інтернету, встановивши "
-"eBay Sidebar для Firefox."
+msgid "Keep an eye on your eBay activity wherever you are on the web when you install the eBay Sidebar for Firefox."
+msgstr "Будьте в курсі активності на eBay з будь-якого місця Інтернету, встановивши eBay Sidebar для Firefox."
 
 #: src/olympia/discovery/templates/discovery/modules/holiday.html:31
 msgid "See the entire holiday shopping add-on collection."
@@ -9617,19 +7359,19 @@ msgstr "додаток, редактор чи коментар"
 msgid "Search by add-on name / author email"
 msgstr "Пошук за назвою додатку / електронною адресою автора"
 
-#: src/olympia/editors/forms.py:103
+#: src/olympia/editors/forms.py:103 src/olympia/editors/forms.py:244 src/olympia/editors/forms.py:257
 msgid "yes"
 msgstr "так"
 
-#: src/olympia/editors/forms.py:104
+#: src/olympia/editors/forms.py:104 src/olympia/editors/forms.py:244 src/olympia/editors/forms.py:257
 msgid "no"
 msgstr "ні"
 
-#: src/olympia/editors/forms.py:105
+#: src/olympia/editors/forms.py:105 src/olympia/editors/forms.py:245
 msgid "Admin Flag"
 msgstr "Прапор адміністратора"
 
-#: src/olympia/editors/forms.py:113
+#: src/olympia/editors/forms.py:113 src/olympia/editors/forms.py:253
 msgid "Max. Version"
 msgstr "Найвища версія"
 
@@ -9641,59 +7383,59 @@ msgstr "Днів з моменту представлення"
 msgid "Add-on Types"
 msgstr "Типи додатків"
 
-#: src/olympia/editors/forms.py:126 src/olympia/editors/helpers.py:267
+#: src/olympia/editors/forms.py:126 src/olympia/editors/helpers.py:279
 msgid "Platforms"
 msgstr "Платформи"
 
+#: src/olympia/editors/forms.py:237
+msgid "Search by add-on name / author email / guid"
+msgstr ""
+
 #. L10n: 0 = platform, 1 = filename, 2 = status message
-#: src/olympia/editors/forms.py:238
+#: src/olympia/editors/forms.py:342
 #, python-format
 msgid "<strong>%s</strong> &middot; %s &middot; %s"
 msgstr "<strong>%s</strong> &middot; %s &middot; %s"
 
-#: src/olympia/editors/forms.py:252
+#: src/olympia/editors/forms.py:356
 msgid "Comments:"
 msgstr "Коментарі:"
 
-#: src/olympia/editors/forms.py:256
+#: src/olympia/editors/forms.py:360
 msgid "Operating systems:"
 msgstr "Операційні системи:"
 
-#: src/olympia/editors/forms.py:258
+#: src/olympia/editors/forms.py:362
 msgid "Applications:"
 msgstr "Програми:"
 
-#: src/olympia/editors/forms.py:260
-msgid ""
-"Notify me the next time this add-on is updated. (Subsequent updates will not"
-" generate an email)"
-msgstr ""
-"Повідомити мене при наступному оновленні цього додатку. (Подальші оновлення "
-"не призведуть до відправлення електронного листа)"
+#: src/olympia/editors/forms.py:364
+msgid "Notify me the next time this add-on is updated. (Subsequent updates will not generate an email)"
+msgstr "Повідомити мене при наступному оновленні цього додатку. (Подальші оновлення не призведуть до відправлення електронного листа)"
 
-#: src/olympia/editors/forms.py:265
+#: src/olympia/editors/forms.py:369
 msgid "Clear Admin Review Flag"
 msgstr "Зняти прапор перевірки адміністратором"
 
-#: src/olympia/editors/forms.py:267
+#: src/olympia/editors/forms.py:371
 msgid "Clear more info requested flag"
 msgstr "Зняти прапорець \"запитано більше інформації\""
 
-#: src/olympia/editors/forms.py:281
+#: src/olympia/editors/forms.py:385
 msgid "Choose a canned response..."
 msgstr "Оберіть стандартну відповідь..."
 
 #. L10n: Description of what can be searched for.
-#: src/olympia/editors/forms.py:324
+#: src/olympia/editors/forms.py:423
 msgid "theme name"
 msgstr "ім'я теми"
 
-#: src/olympia/editors/forms.py:350
+#: src/olympia/editors/forms.py:449
 msgid "Someone else is reviewing this theme."
 msgstr "Хтось ще перевіряє цю тему."
 
 #. L10n: Description of what can be searched for.
-#: src/olympia/editors/forms.py:447
+#: src/olympia/editors/forms.py:546
 msgid "app, reviewer, or comment"
 msgstr "додаток, переглядач чи коментар"
 
@@ -9709,300 +7451,266 @@ msgstr "Очікує попереднього розгляду"
 msgid "Rejected or Unreviewed"
 msgstr "Відхилено чи не розглянуто"
 
-#: src/olympia/editors/helpers.py:123 src/olympia/editors/helpers.py:136
+#: src/olympia/editors/helpers.py:125 src/olympia/editors/helpers.py:138
 msgid "Queue"
 msgstr "Черга"
 
-#: src/olympia/editors/helpers.py:124
-#: src/olympia/editors/templates/editors/base.html:50
-#: src/olympia/editors/templates/editors/base.html:65
+#: src/olympia/editors/helpers.py:126 src/olympia/editors/templates/editors/base.html:50 src/olympia/editors/templates/editors/base.html:65
 msgid "Pending Updates"
 msgstr "Очікувані оновлення"
 
-#: src/olympia/editors/helpers.py:125
-#: src/olympia/editors/templates/editors/base.html:48
-#: src/olympia/editors/templates/editors/base.html:63
+#: src/olympia/editors/helpers.py:127 src/olympia/editors/templates/editors/base.html:48 src/olympia/editors/templates/editors/base.html:63
 msgid "Full Reviews"
 msgstr "Повні розгляди"
 
-#: src/olympia/editors/helpers.py:126
-#: src/olympia/editors/templates/editors/base.html:52
-#: src/olympia/editors/templates/editors/base.html:67
+#: src/olympia/editors/helpers.py:128 src/olympia/editors/templates/editors/base.html:52 src/olympia/editors/templates/editors/base.html:67
 msgid "Preliminary Reviews"
 msgstr "Попередні розгляди"
 
-#: src/olympia/editors/helpers.py:127
-#: src/olympia/editors/templates/editors/base.html:54
+#: src/olympia/editors/helpers.py:129 src/olympia/editors/templates/editors/base.html:54
 msgid "Moderated Reviews"
 msgstr "Модеровані розгляди"
 
-#: src/olympia/editors/helpers.py:128
-#: src/olympia/editors/templates/editors/base.html:46
+#: src/olympia/editors/helpers.py:130 src/olympia/editors/templates/editors/base.html:46
 msgid "Fast Track"
 msgstr "Швидке відстеження"
 
-#: src/olympia/editors/helpers.py:130
+#: src/olympia/editors/helpers.py:132
 msgid "Pending Themes"
 msgstr "Очікувані теми"
 
-#: src/olympia/editors/helpers.py:131
-#: src/olympia/editors/templates/editors/themes/queue.html:4
+#: src/olympia/editors/helpers.py:133 src/olympia/editors/templates/editors/themes/queue.html:4
 msgid "Flagged Themes"
 msgstr "Відмічені теми"
 
-#: src/olympia/editors/helpers.py:132
+#: src/olympia/editors/helpers.py:134
 msgid "Update Themes"
 msgstr "Оновити теми"
 
-#: src/olympia/editors/helpers.py:137
+#: src/olympia/editors/helpers.py:139
 msgid "Unlisted Pending Updates"
 msgstr "Невказані очікувані оновлення"
 
-#: src/olympia/editors/helpers.py:138
+#: src/olympia/editors/helpers.py:140
 msgid "Unlisted Full Reviews"
 msgstr "Повні перевірки невказаних"
 
-#: src/olympia/editors/helpers.py:139
+#: src/olympia/editors/helpers.py:141
 msgid "Unlisted Preliminary Reviews"
 msgstr "Попередні перевірки невказаних"
 
-#: src/olympia/editors/helpers.py:170
+#: src/olympia/editors/helpers.py:142
+msgid "Unlisted All Add-ons"
+msgstr ""
+
+#: src/olympia/editors/helpers.py:173
 msgid "Fast Track ({0})"
 msgid_plural "Fast Track ({0})"
 msgstr[0] "Швидке відстеження ({0})"
 msgstr[1] "Швидкі відстеження ({0})"
-msgstr[2] "Швидких відстежень ({0})"
 
-#: src/olympia/editors/helpers.py:175
+#: src/olympia/editors/helpers.py:178
 msgid "Full Review ({0})"
 msgid_plural "Full Reviews ({0})"
 msgstr[0] "Повний розгляд ({0})"
 msgstr[1] "Повні розгляди ({0})"
-msgstr[2] "Повних розглядів ({0})"
 
-#: src/olympia/editors/helpers.py:180
+#: src/olympia/editors/helpers.py:183
 msgid "Pending Update ({0})"
 msgid_plural "Pending Updates ({0})"
 msgstr[0] "Очікуване оновлення ({0})"
 msgstr[1] "Очікувані оновлення ({0})"
-msgstr[2] "Очікуваних оновлень ({0})"
 
-#: src/olympia/editors/helpers.py:185
+#: src/olympia/editors/helpers.py:188
 msgid "Preliminary Review ({0})"
 msgid_plural "Preliminary Reviews ({0})"
 msgstr[0] "Попередній розгляд ({0})"
 msgstr[1] "Попередні розгляди ({0})"
-msgstr[2] "Попередніх розглядів ({0})"
 
-#: src/olympia/editors/helpers.py:190
+#: src/olympia/editors/helpers.py:193
 msgid "Moderated Review ({0})"
 msgid_plural "Moderated Reviews ({0})"
 msgstr[0] "Модерований розгляд ({0})"
 msgstr[1] "Модеровані розгляди ({0})"
-msgstr[2] "Модерованих розглядів ({0})"
 
-#: src/olympia/editors/helpers.py:196
+#: src/olympia/editors/helpers.py:199
 msgid "Unlisted Full Review ({0})"
 msgid_plural "Unlisted Full Reviews ({0})"
 msgstr[0] "Повна перевірка невказаних ({0})"
 msgstr[1] "Повні перевірки невказаних ({0})"
-msgstr[2] "Повні перевірки невказаних ({0})"
 
-#: src/olympia/editors/helpers.py:201
+#: src/olympia/editors/helpers.py:204
 msgid "Unlisted Pending Update ({0})"
 msgid_plural "Unlisted Pending Updates ({0})"
 msgstr[0] "Невказане очікуване оновлення ({0})"
 msgstr[1] "Невказані очікувані оновлення ({0})"
-msgstr[2] "Невказані очікувані оновлення ({0})"
 
-#: src/olympia/editors/helpers.py:206
+#: src/olympia/editors/helpers.py:209
 msgid "Unlisted Preliminary Review ({0})"
 msgid_plural "Unlisted Preliminary Reviews ({0})"
 msgstr[0] "Попередня перевірка невідображених ({0})"
 msgstr[1] "Попередні перевірки невідображених ({0})"
-msgstr[2] "Попередні перевірки невідображених ({0})"
 
-#: src/olympia/editors/helpers.py:261
-msgid "Addon"
-msgstr "Додаток"
+#: src/olympia/editors/helpers.py:214
+msgid "Unlisted All Add-ons ({0})"
+msgid_plural "Unlisted All Add-ons ({0})"
+msgstr[0] ""
+msgstr[1] ""
 
-#: src/olympia/editors/helpers.py:262
+#: src/olympia/editors/helpers.py:274
 msgid "Type"
 msgstr "Тип"
 
-#: src/olympia/editors/helpers.py:263
+#: src/olympia/editors/helpers.py:275
 msgid "Waiting Time"
 msgstr "Час очікування"
 
-#: src/olympia/editors/helpers.py:264
-#: src/olympia/editors/templates/editors/review.html:285
+#: src/olympia/editors/helpers.py:276 src/olympia/editors/templates/editors/review.html:285
 msgid "Flags"
 msgstr "Позначки"
 
-#: src/olympia/editors/helpers.py:265
+#: src/olympia/editors/helpers.py:277
 msgid "Applications"
 msgstr "Програми"
 
-#: src/olympia/editors/helpers.py:270
+#: src/olympia/editors/helpers.py:282
 msgid "Additional"
 msgstr "Додатково"
 
-#: src/olympia/editors/helpers.py:285
+#: src/olympia/editors/helpers.py:302
 msgid "Site Specific"
 msgstr "Специфічні для сайту"
 
-#: src/olympia/editors/helpers.py:287
+#: src/olympia/editors/helpers.py:304
 msgid "Requires External Software"
 msgstr "Потребує стороннє ПЗ"
 
-#: src/olympia/editors/helpers.py:289
+#: src/olympia/editors/helpers.py:306
 msgid "Binary Components"
 msgstr "Бінарні компоненти"
 
-#: src/olympia/editors/helpers.py:313
+#: src/olympia/editors/helpers.py:339
 msgid "moments ago"
 msgstr "щойно"
 
 #. L10n: first argument is number of minutes
-#: src/olympia/editors/helpers.py:316
+#: src/olympia/editors/helpers.py:342
 msgid "{0} minute"
 msgid_plural "{0} minutes"
 msgstr[0] "{0} хвилина"
 msgstr[1] "{0} хвилини"
-msgstr[2] "{0} хвилин"
 
 #. L10n: first argument is number of hours
-#: src/olympia/editors/helpers.py:320
+#: src/olympia/editors/helpers.py:346
 msgid "{0} hour"
 msgid_plural "{0} hours"
 msgstr[0] "{0} година"
 msgstr[1] "{0} години"
-msgstr[2] "{0} годин"
 
 #. L10n: first argument is number of days
-#: src/olympia/editors/helpers.py:324
+#: src/olympia/editors/helpers.py:350
 msgid "{0} day"
 msgid_plural "{0} days"
 msgstr[0] "{0} день"
 msgstr[1] "{0} дні"
-msgstr[2] "{0} днів"
 
-#: src/olympia/editors/helpers.py:488
+#: src/olympia/editors/helpers.py:364
+msgid "Last Review"
+msgstr ""
+
+#: src/olympia/editors/helpers.py:366
+msgid "Last Update"
+msgstr ""
+
+#: src/olympia/editors/helpers.py:387
+msgid "No Reviews"
+msgstr ""
+
+#: src/olympia/editors/helpers.py:561
 msgid "Push to public"
 msgstr "Відправити в загальний доступ"
 
-#: src/olympia/editors/helpers.py:490
+#: src/olympia/editors/helpers.py:563
 msgid "Grant full review"
 msgstr "Надати повний перегляд"
 
-#: src/olympia/editors/helpers.py:505
+#: src/olympia/editors/helpers.py:578
 msgid "Request more information"
 msgstr "Запитати додаткову інформацію"
 
-#: src/olympia/editors/helpers.py:508
+#: src/olympia/editors/helpers.py:581
 msgid "Request super-review"
 msgstr "Запитати супер-перегляд"
 
-#: src/olympia/editors/helpers.py:519
+#: src/olympia/editors/helpers.py:592
 msgid "Grant preliminary review"
 msgstr "Надати попередній перегляд"
 
-#: src/olympia/editors/helpers.py:520
+#: src/olympia/editors/helpers.py:593
 msgid "This will mark the files as preliminarily reviewed."
 msgstr "Це позначить файли як попередньо переглянуті."
 
-#: src/olympia/editors/helpers.py:522
-msgid ""
-"Use this form to request more information from the author. They will receive"
-" an email and be able to answer here. You will be notified by email when "
-"they reply."
-msgstr ""
-"Використовуйте цю форму, щоб запросити додаткову інформацію у авторів. Вони "
-"отримають повідомлення ел. поштою і зможуть тут відповісти. Коли вони дадуть"
-" відповідь, ви будете сповіщені на ел. пошту."
+#: src/olympia/editors/helpers.py:595
+msgid "Use this form to request more information from the author. They will receive an email and be able to answer here. You will be notified by email when they reply."
+msgstr "Використовуйте цю форму, щоб запросити додаткову інформацію у авторів. Вони отримають повідомлення ел. поштою і зможуть тут відповісти. Коли вони дадуть відповідь, ви будете сповіщені на ел. пошту."
 
-#: src/olympia/editors/helpers.py:526
+#: src/olympia/editors/helpers.py:599
 msgid ""
-"If you have concerns about this add-on's security, copyright issues, or "
-"other concerns that an administrator should look into, enter your comments "
-"in the area below. They will be sent to administrators, not the author."
+"If you have concerns about this add-on's security, copyright issues, or other concerns that an administrator should look into, enter your comments in the area below. They will be sent to "
+"administrators, not the author."
 msgstr ""
-"Якщо у вас є сумніви щодо безпеки, авторських прав чи інших проблем цього "
-"додатку, які потребують вивчення адміністратором, введіть свої коментарі у "
-"полі внизу. Вони будуть надіслані адміністраторам, але не авторам."
+"Якщо у вас є сумніви щодо безпеки, авторських прав чи інших проблем цього додатку, які потребують вивчення адміністратором, введіть свої коментарі у полі внизу. Вони будуть надіслані "
+"адміністраторам, але не авторам."
 
-#: src/olympia/editors/helpers.py:532
+#: src/olympia/editors/helpers.py:605
 msgid "This will reject the add-on and remove it from the review queue."
 msgstr "Це відхилить додаток і прибере його з черги на розгляд."
 
-#: src/olympia/editors/helpers.py:534
-msgid "Make a comment on this version.  The author won't be able to see this."
+#: src/olympia/editors/helpers.py:607
+msgid "Make a comment on this version. The author won't be able to see this."
 msgstr "Залиште коментар для цієї версії.  Автор не зможе його побачити."
 
-#: src/olympia/editors/helpers.py:538
+#: src/olympia/editors/helpers.py:611
 msgid "This will reject the files and remove them from the review queue."
 msgstr "Це відхилить файли та прибере їх з черги на розгляд."
 
-#: src/olympia/editors/helpers.py:542
-msgid ""
-"This will mark the add-on as preliminarily reviewed. Future versions will "
-"undergo preliminary review."
-msgstr ""
-"Це відмітить додаток, як попередньо розглянутий. Майбутні версії будуть "
-"підлягати попередньому розгляду."
+#: src/olympia/editors/helpers.py:615
+msgid "This will mark the add-on as preliminarily reviewed. Future versions will undergo preliminary review."
+msgstr "Це відмітить додаток, як попередньо розглянутий. Майбутні версії будуть підлягати попередньому розгляду."
 
-#: src/olympia/editors/helpers.py:547
-msgid ""
-"This will mark the files as preliminarily reviewed. Future versions will "
-"undergo preliminary review."
-msgstr ""
-"Це відмітить файли, як попередньо розглянуті. Майбутні версії будуть "
-"підлягати попередньому розгляду."
+#: src/olympia/editors/helpers.py:620
+msgid "This will mark the files as preliminarily reviewed. Future versions will undergo preliminary review."
+msgstr "Це відмітить файли, як попередньо розглянуті. Майбутні версії будуть підлягати попередньому розгляду."
 
-#: src/olympia/editors/helpers.py:552
+#: src/olympia/editors/helpers.py:625
 msgid "Retain preliminary review"
 msgstr "Залишити попередній розгляд"
 
-#: src/olympia/editors/helpers.py:553
-msgid ""
-"This will retain the add-on as preliminarily reviewed. Future versions will "
-"undergo preliminary review."
-msgstr ""
-"Це залишить додаток, як попередньо розглянутий. Майбутні версії будуть "
-"підлягати попередньому розгляду."
+#: src/olympia/editors/helpers.py:626
+msgid "This will retain the add-on as preliminarily reviewed. Future versions will undergo preliminary review."
+msgstr "Це залишить додаток, як попередньо розглянутий. Майбутні версії будуть підлягати попередньому розгляду."
 
-#: src/olympia/editors/helpers.py:558
-msgid ""
-"This will approve a sandboxed version of a public add-on to appear on the "
-"public side."
-msgstr ""
-"Це схвалить розміщену в \"пісочниці\" версію публічного додатка, яка "
-"з'явиться в загальному доступі."
+#: src/olympia/editors/helpers.py:631
+msgid "This will approve a sandboxed version of a public add-on to appear on the public side."
+msgstr "Це схвалить розміщену в \"пісочниці\" версію публічного додатка, яка з'явиться в загальному доступі."
 
-#: src/olympia/editors/helpers.py:561
-msgid ""
-"This will reject a version of a public add-on and remove it from the queue."
+#: src/olympia/editors/helpers.py:634
+msgid "This will reject a version of a public add-on and remove it from the queue."
 msgstr "Це відкине версію публічного додатка і видалить його з черги."
 
-#: src/olympia/editors/helpers.py:564
-msgid ""
-"This will mark the add-on and its most recent version and files as public. "
-"Future versions will go into the sandbox until they are reviewed by an "
-"editor."
-msgstr ""
-"Це позначить додаток, його найновішу версію і файли як загальнодоступні. "
-"Майбутні версії будуть потрапляти в «пісочницю», поки вони не будуть "
-"перевірені редактором."
-
 #: src/olympia/editors/helpers.py:637
+msgid "This will mark the add-on and its most recent version and files as public. Future versions will go into the sandbox until they are reviewed by an editor."
+msgstr "Це позначить додаток, його найновішу версію і файли як загальнодоступні. Майбутні версії будуть потрапляти в «пісочницю», поки вони не будуть перевірені редактором."
+
+#: src/olympia/editors/helpers.py:714
 msgid "add-on"
 msgstr "додаток"
 
-#: src/olympia/editors/helpers.py:940 src/olympia/editors/helpers.py:960
+#: src/olympia/editors/helpers.py:1020 src/olympia/editors/helpers.py:1040
 msgid "Flagged"
 msgstr "Відмічено"
 
-#: src/olympia/editors/helpers.py:944 src/olympia/editors/helpers.py:963
+#: src/olympia/editors/helpers.py:1024 src/olympia/editors/helpers.py:1043
 msgid "Updates"
 msgstr "Оновлення"
 
@@ -10054,76 +7762,68 @@ msgstr "Представлена тема відмічена для розгля
 msgid "A question about your Theme submission"
 msgstr "Питання щодо представлення вашої теми"
 
-#: src/olympia/editors/views.py:144
+#: src/olympia/editors/views.py:146
 msgid "New Add-ons (Under 5 days)"
 msgstr "Нові додатки (Менше 5 днів)"
 
-#: src/olympia/editors/views.py:145
+#: src/olympia/editors/views.py:147
 msgid "Passable (5 to 10 days)"
 msgstr "Непогано (5-10 днів)"
 
-#: src/olympia/editors/views.py:146
+#: src/olympia/editors/views.py:148
 msgid "Overdue (Over 10 days)"
 msgstr "Прострочено (протягом 10 днів)"
 
-#: src/olympia/editors/views.py:532
+#: src/olympia/editors/views.py:539
 msgid "An unknown error occurred"
 msgstr "Сталася невідома помилка"
 
-#: src/olympia/editors/views.py:587
+#: src/olympia/editors/views.py:592
 msgid "Self-reviews are not allowed."
 msgstr "Самоперевірки не допускаються."
 
-#: src/olympia/editors/views.py:609
+#: src/olympia/editors/views.py:613
 msgid "Review successfully processed."
 msgstr "Перевірка успішно оброблена."
 
-#: src/olympia/editors/views.py:807
+#: src/olympia/editors/views.py:812
 msgid "was approved"
 msgstr "було схвалено"
 
-#: src/olympia/editors/views.py:808
+#: src/olympia/editors/views.py:813
 msgid "given preliminary review"
 msgstr "надано попередній розгляд"
 
-#: src/olympia/editors/views.py:809
+#: src/olympia/editors/views.py:814
 msgid "rejected"
 msgstr "відхилено"
 
-#: src/olympia/editors/views.py:810
+#: src/olympia/editors/views.py:815
 msgctxt "editors_review_history_nominated_adminreview"
 msgid "escalated"
 msgstr "передано вище"
 
-#: src/olympia/editors/views.py:812
+#: src/olympia/editors/views.py:817
 msgid "needs more information"
 msgstr "потребує додаткову інформацію"
 
-#: src/olympia/editors/views.py:813
+#: src/olympia/editors/views.py:818
 msgid "needs super review"
 msgstr "потребує супер-перегляду"
 
-#: src/olympia/editors/views.py:814
+#: src/olympia/editors/views.py:819
 msgid "commented"
 msgstr "прокоментовано"
 
 #: src/olympia/editors/views_themes.py:326
 msgid "{0} theme review successfully processed (+{1} points, {2} total)."
-msgid_plural ""
-"{0} theme reviews successfully processed (+{1} points, {2} total)."
+msgid_plural "{0} theme reviews successfully processed (+{1} points, {2} total)."
 msgstr[0] "успішно проведена {0} перевірка теми (+{1} балів, всього: {2})."
 msgstr[1] "успішно проведено {0} перевірки теми (+{1} балів, всього: {2})."
-msgstr[2] "успішно проведено {0} перевірок теми (+{1} балів, всього: {2})."
 
 #: src/olympia/editors/views_themes.py:341
-msgid ""
-"Your theme locks have successfully been released. Other reviewers may now "
-"review those released themes. You may have to refresh the page to see the "
-"changes reflected in the table below."
-msgstr ""
-"Ваші блокування тем були успішно зняті. Інші рецензенти тепер можуть "
-"перевірити ці розблоковані теми. Можливо, вам знадобиться оновити сторінку, "
-"щоб побачити зміни у таблиці нижче."
+msgid "Your theme locks have successfully been released. Other reviewers may now review those released themes. You may have to refresh the page to see the changes reflected in the table below."
+msgstr "Ваші блокування тем були успішно зняті. Інші рецензенти тепер можуть перевірити ці розблоковані теми. Можливо, вам знадобиться оновити сторінку, щоб побачити зміни у таблиці нижче."
 
 #: src/olympia/editors/templates/editors/abuse_reports.html:4
 msgid "{addon} :: Abuse Reports"
@@ -10147,9 +7847,7 @@ msgstr "<i>anonymous</i> в %(date)s [%(ip_address)s]"
 msgid "Return to the Editor Tools homepage"
 msgstr "Повернутися до домівки інструментів редактора"
 
-#: src/olympia/editors/templates/editors/base.html:43
-#: src/olympia/editors/templates/editors/themes/base.html:14
-#: src/olympia/editors/templates/editors/themes/base.html:28
+#: src/olympia/editors/templates/editors/base.html:43 src/olympia/editors/templates/editors/themes/base.html:14 src/olympia/editors/templates/editors/themes/base.html:28
 #: src/olympia/editors/templates/editors/themes/queue.html:25
 msgid "Queues"
 msgstr "Черги"
@@ -10158,71 +7856,51 @@ msgstr "Черги"
 msgid "Unlisted Queues"
 msgstr "Черги невідображених"
 
-#: src/olympia/editors/templates/editors/base.html:72
-#: src/olympia/editors/templates/editors/performance.html:6
+#: src/olympia/editors/templates/editors/base.html:74 src/olympia/editors/templates/editors/performance.html:6
 msgid "Performance"
 msgstr "Швидкодія"
 
-#: src/olympia/editors/templates/editors/base.html:75
-#: src/olympia/editors/templates/editors/themes/base.html:19
-#: src/olympia/editors/templates/editors/themes/base.html:38
+#: src/olympia/editors/templates/editors/base.html:77 src/olympia/editors/templates/editors/themes/base.html:19 src/olympia/editors/templates/editors/themes/base.html:38
 msgid "Logs"
 msgstr "Логи"
 
-#: src/olympia/editors/templates/editors/base.html:78
-#: src/olympia/editors/templates/editors/reviewlog.html:4
-#: src/olympia/editors/templates/editors/reviewlog.html:27
+#: src/olympia/editors/templates/editors/base.html:80 src/olympia/editors/templates/editors/reviewlog.html:4 src/olympia/editors/templates/editors/reviewlog.html:27
 msgid "Add-on Review Log"
 msgstr "Журнал перевірок додатків"
 
-#: src/olympia/editors/templates/editors/base.html:80
-#: src/olympia/editors/templates/editors/eventlog.html:4
-#: src/olympia/editors/templates/editors/eventlog.html:8
+#: src/olympia/editors/templates/editors/base.html:82 src/olympia/editors/templates/editors/eventlog.html:4 src/olympia/editors/templates/editors/eventlog.html:8
 #: src/olympia/editors/templates/editors/eventlog_detail.html:4
 msgid "Moderated Review Log"
 msgstr "Журнал модерованих перевірок"
 
-#: src/olympia/editors/templates/editors/base.html:82
-#: src/olympia/editors/templates/editors/beta_signed_log.html:4
-#: src/olympia/editors/templates/editors/beta_signed_log.html:8
+#: src/olympia/editors/templates/editors/base.html:84 src/olympia/editors/templates/editors/beta_signed_log.html:4 src/olympia/editors/templates/editors/beta_signed_log.html:8
 msgid "Signed Beta Files Log"
 msgstr "Журнал підписаних файлів бети"
 
-#: src/olympia/editors/templates/editors/base.html:87
-#: src/olympia/editors/templates/editors/includes/daily-message.html:4
+#: src/olympia/editors/templates/editors/base.html:89 src/olympia/editors/templates/editors/includes/daily-message.html:4
 msgid "Announcement"
 msgstr "Оголошення"
 
 #. "Filter" is a button label (verb)
-#: src/olympia/editors/templates/editors/beta_signed_log.html:17
-#: src/olympia/editors/templates/editors/eventlog.html:24
-#: src/olympia/editors/templates/editors/reviewlog.html:21
-#: src/olympia/editors/templates/editors/themes/macros.html:45
-#: src/olympia/editors/templates/editors/themes/includes/logs_filter_deleted.html:12
+#: src/olympia/editors/templates/editors/beta_signed_log.html:17 src/olympia/editors/templates/editors/eventlog.html:24 src/olympia/editors/templates/editors/reviewlog.html:21
+#: src/olympia/editors/templates/editors/themes/macros.html:45 src/olympia/editors/templates/editors/themes/includes/logs_filter_deleted.html:12
 msgid "Filter"
 msgstr "Фільтр"
 
-#: src/olympia/editors/templates/editors/beta_signed_log.html:23
-#: src/olympia/editors/templates/editors/eventlog.html:30
-#: src/olympia/editors/templates/editors/reviewlog.html:34
+#: src/olympia/editors/templates/editors/beta_signed_log.html:23 src/olympia/editors/templates/editors/eventlog.html:30 src/olympia/editors/templates/editors/reviewlog.html:34
 #: src/olympia/editors/templates/editors/themes/logs.html:16
 msgid "Date"
 msgstr "Дата"
 
-#: src/olympia/editors/templates/editors/beta_signed_log.html:24
-#: src/olympia/editors/templates/editors/eventlog.html:31
-#: src/olympia/editors/templates/editors/reviewlog.html:35
+#: src/olympia/editors/templates/editors/beta_signed_log.html:24 src/olympia/editors/templates/editors/eventlog.html:31 src/olympia/editors/templates/editors/reviewlog.html:35
 msgid "Event"
 msgstr "Подія"
 
-#: src/olympia/editors/templates/editors/beta_signed_log.html:37
-#: src/olympia/editors/templates/editors/eventlog.html:44
-#: src/olympia/editors/templates/editors/home.html:180
+#: src/olympia/editors/templates/editors/beta_signed_log.html:37 src/olympia/editors/templates/editors/eventlog.html:44 src/olympia/editors/templates/editors/home.html:180
 msgid "More details."
 msgstr "Детальніше."
 
-#: src/olympia/editors/templates/editors/beta_signed_log.html:46
-#: src/olympia/editors/templates/editors/eventlog.html:53
+#: src/olympia/editors/templates/editors/beta_signed_log.html:46 src/olympia/editors/templates/editors/eventlog.html:53
 msgid "No events found for this period."
 msgstr "Для цього періоду подій не знайдено."
 
@@ -10259,37 +7937,30 @@ msgid "Full Review ({num})"
 msgid_plural "Full Reviews ({num})"
 msgstr[0] "Повний розгляд ({num})"
 msgstr[1] "Повні розгляди ({num})"
-msgstr[2] "Повних розглядів ({num})"
 
 #: src/olympia/editors/templates/editors/home.html:18
 msgid "Pending Update ({num})"
 msgid_plural "Pending Updates ({num})"
 msgstr[0] "Очікуване оновлення ({num})"
 msgstr[1] "Очікувані оновлення ({num})"
-msgstr[2] "Очікуваних оновлень ({num})"
 
 #: src/olympia/editors/templates/editors/home.html:25
 msgid "Preliminary Review ({num})"
 msgid_plural "Preliminary Reviews ({num})"
 msgstr[0] "Попередній розгляд ({num})"
 msgstr[1] "Попередні розгляди ({num})"
-msgstr[2] "Попередніх розглядів ({num})"
 
-#: src/olympia/editors/templates/editors/home.html:36
-#: src/olympia/editors/templates/editors/home.html:86
+#: src/olympia/editors/templates/editors/home.html:36 src/olympia/editors/templates/editors/home.html:86
 msgid "Current waiting times:"
 msgstr "Поточний час очікування:"
 
-#: src/olympia/editors/templates/editors/home.html:44
-#: src/olympia/editors/templates/editors/home.html:94
+#: src/olympia/editors/templates/editors/home.html:44 src/olympia/editors/templates/editors/home.html:94
 msgid "{0} add-on"
 msgid_plural "{0} add-ons"
 msgstr[0] "{0} додаток"
 msgstr[1] "{0} додатки"
-msgstr[2] "{0} додатків"
 
-#: src/olympia/editors/templates/editors/home.html:45
-#: src/olympia/editors/templates/editors/home.html:95
+#: src/olympia/editors/templates/editors/home.html:45 src/olympia/editors/templates/editors/home.html:95
 #, python-format
 msgid "{0}%%"
 msgstr "{0}%%"
@@ -10299,30 +7970,24 @@ msgid "Unlisted Full Review ({num})"
 msgid_plural "Unlisted Full Reviews ({num})"
 msgstr[0] "Повна перевірка невідображених ({num})"
 msgstr[1] "Повні перевірки невідображених ({num})"
-msgstr[2] "Повні перевірки невідображених ({num})"
 
 #: src/olympia/editors/templates/editors/home.html:68
 msgid "Unlisted Pending Update ({num})"
 msgid_plural "Unlisted Pending Updates ({num})"
 msgstr[0] "Очікуване оновлення невідображених ({num})"
 msgstr[1] "Очікувані оновлення невідображених ({num})"
-msgstr[2] "Очікувані оновлення невідображених ({num})"
 
 #: src/olympia/editors/templates/editors/home.html:75
 msgid "Unlisted Preliminary Review ({num})"
 msgid_plural "Unlisted Preliminary Reviews ({num})"
 msgstr[0] "Попередня перевірка невідображених ({num})"
 msgstr[1] "Попередні перевірки невідображених ({num})"
-msgstr[2] "Попередні перевірки невідображених ({num})"
 
-#: src/olympia/editors/templates/editors/home.html:109
-#: src/olympia/editors/templates/editors/performance.html:37
-#: src/olympia/editors/templates/editors/themes/home.html:54
+#: src/olympia/editors/templates/editors/home.html:109 src/olympia/editors/templates/editors/performance.html:37 src/olympia/editors/templates/editors/themes/home.html:54
 msgid "Total Reviews"
 msgstr "Всього розглядів"
 
-#: src/olympia/editors/templates/editors/home.html:110
-#: src/olympia/editors/templates/editors/themes/home.html:55
+#: src/olympia/editors/templates/editors/home.html:110 src/olympia/editors/templates/editors/themes/home.html:55
 msgid "Reviews This Month"
 msgstr "Розгляди цього місяця"
 
@@ -10330,8 +7995,7 @@ msgstr "Розгляди цього місяця"
 msgid "New Editors"
 msgstr "Нові редактори"
 
-#: src/olympia/editors/templates/editors/home.html:126
-#: src/olympia/editors/templates/editors/home.html:141
+#: src/olympia/editors/templates/editors/home.html:126 src/olympia/editors/templates/editors/home.html:141
 msgid "You're #{0} with {1} reviews"
 msgstr "Ви #{0} з {1} перевірками"
 
@@ -10341,15 +8005,12 @@ msgid "Moderated Review ({num})"
 msgid_plural "Moderated Reviews ({num})"
 msgstr[0] "Модерована перевірка ({num})"
 msgstr[1] "Модеровані перевірки ({num})"
-msgstr[2] "Модеровані перевірки ({num})"
 
-#: src/olympia/editors/templates/editors/leaderboard.html:3
-#: src/olympia/editors/templates/editors/includes/reviewers_score_bar.html:56
+#: src/olympia/editors/templates/editors/leaderboard.html:3 src/olympia/editors/templates/editors/includes/reviewers_score_bar.html:56
 msgid "Reviewer Leaderboard"
 msgstr "Панель лідерів редакторів"
 
-#: src/olympia/editors/templates/editors/leaderboard.html:18
-#: src/olympia/editors/templates/editors/performance.html:65
+#: src/olympia/editors/templates/editors/leaderboard.html:18 src/olympia/editors/templates/editors/performance.html:65
 msgid "No review points awarded yet."
 msgstr "Бали за перевірку поки що не нараховано."
 
@@ -10369,8 +8030,7 @@ msgstr "Повідомлення дня"
 msgid "Update message of the day"
 msgstr "Оновити повідомлення дня"
 
-#: src/olympia/editors/templates/editors/motd.html:15
-#: src/olympia/editors/templates/editors/review.html:224
+#: src/olympia/editors/templates/editors/motd.html:15 src/olympia/editors/templates/editors/review.html:224
 msgid "Save"
 msgstr "Зберегти"
 
@@ -10438,51 +8098,45 @@ msgstr "Розширений пошук"
 msgid "clear search"
 msgstr "очистити пошук"
 
-#: src/olympia/editors/templates/editors/queue.html:72
-#: src/olympia/editors/templates/editors/queue.html:122
+#: src/olympia/editors/templates/editors/queue.html:78 src/olympia/editors/templates/editors/queue.html:128
 msgid "Process Reviews"
 msgstr "Обробити відгуки"
 
-#: src/olympia/editors/templates/editors/queue.html:80
+#: src/olympia/editors/templates/editors/queue.html:86
 msgid "Moderation actions:"
 msgstr "Дії для модерації:"
 
-#: src/olympia/editors/templates/editors/queue.html:90
+#: src/olympia/editors/templates/editors/queue.html:96
 #, python-format
 msgid "by %(user)s on %(date)s %(stars)s (%(locale)s)"
 msgstr "від %(user)s %(date)s %(stars)s (%(locale)s)"
 
-#: src/olympia/editors/templates/editors/queue.html:106
+#: src/olympia/editors/templates/editors/queue.html:112
 #, python-format
-msgid ""
-"<strong>%(reason)s</strong> <span class=\"light\">Flagged by %(user)s on "
-"%(date)s</span>"
-msgstr ""
-"<strong>%(reason)s</strong> <span class=\"light\">Позначено %(user)s "
-"%(date)s</span>"
+msgid "<strong>%(reason)s</strong> <span class=\"light\">Flagged by %(user)s on %(date)s</span>"
+msgstr "<strong>%(reason)s</strong> <span class=\"light\">Позначено %(user)s %(date)s</span>"
 
-#: src/olympia/editors/templates/editors/queue.html:119
-msgid "All reviews have been moderated.  Good work!"
+#: src/olympia/editors/templates/editors/queue.html:125
+msgid "All reviews have been moderated. Good work!"
 msgstr "Всі відгуки були промодеровані.  Гарна робота!"
 
-#: src/olympia/editors/templates/editors/queue.html:161
+#: src/olympia/editors/templates/editors/queue.html:167
 msgid "Version Notes / Notes for Reviewer"
 msgstr "Примітки до версії / Примітки для рецензента"
 
-#: src/olympia/editors/templates/editors/queue.html:169
+#: src/olympia/editors/templates/editors/queue.html:175
 msgid "There are currently no add-ons of this type to review."
 msgstr "В даний момент немає додатків цього типу для перегляду."
 
-#: src/olympia/editors/templates/editors/queue.html:181
-#: src/olympia/editors/templates/editors/themes/queue_list.html:85
+#: src/olympia/editors/templates/editors/queue.html:187 src/olympia/editors/templates/editors/themes/queue_list.html:85
 msgid "Helpful Links:"
 msgstr "Корисні посилання:"
 
-#: src/olympia/editors/templates/editors/queue.html:182
+#: src/olympia/editors/templates/editors/queue.html:188
 msgid "Add-on Policy"
 msgstr "Політика додатку"
 
-#: src/olympia/editors/templates/editors/queue.html:184
+#: src/olympia/editors/templates/editors/queue.html:190
 msgid "Editors' Guide"
 msgstr "Інструкції редактора"
 
@@ -10495,19 +8149,14 @@ msgstr "Перевірити {0}"
 msgid "Add-on user change history"
 msgstr "Історія змін користувачів додатку"
 
-#: src/olympia/editors/templates/editors/review.html:52
-#: src/olympia/editors/templates/editors/review.html:266
+#: src/olympia/editors/templates/editors/review.html:52 src/olympia/editors/templates/editors/review.html:266
 msgid "Add-on History"
 msgstr "Історія додатку"
 
 #: src/olympia/editors/templates/editors/review.html:64
 #, python-format
-msgid ""
-"Version %(version)s &middot; %(created)s <span class=\"light\">&middot; "
-"%(version_status)s</span>"
-msgstr ""
-"Версія %(version)s &middot; %(created)s <span class=\"light\">&middot; "
-"%(version_status)s</span>"
+msgid "Version %(version)s &middot; %(created)s <span class=\"light\">&middot; %(version_status)s</span>"
+msgstr "Версія %(version)s &middot; %(created)s <span class=\"light\">&middot; %(version_status)s</span>"
 
 #: src/olympia/editors/templates/editors/review.html:73
 msgid "Compatibility:"
@@ -10530,19 +8179,14 @@ msgid "This version has not been reviewed."
 msgstr "Ця версія не була розглянута."
 
 #: src/olympia/editors/templates/editors/review.html:154
-msgid ""
-"You can still submit this form, however only do so if you know it won't "
-"conflict."
-msgstr ""
-"Ви все ще можете відправити цю форму, але все ж робіть це лише якщо ви "
-"впевнені, що не буде конфлікту."
+msgid "You can still submit this form, however only do so if you know it won't conflict."
+msgstr "Ви все ще можете відправити цю форму, але все ж робіть це лише якщо ви впевнені, що не буде конфлікту."
 
 #: src/olympia/editors/templates/editors/review.html:161
 msgid "Insert canned response..."
 msgstr "Вставити стандартну відповідь..."
 
-#: src/olympia/editors/templates/editors/review.html:167
-#: src/olympia/files/templates/files/viewer.html:54
+#: src/olympia/editors/templates/editors/review.html:167 src/olympia/files/templates/files/viewer.html:54
 msgid "Files:"
 msgstr "Файли:"
 
@@ -10551,27 +8195,18 @@ msgid "Tested on:"
 msgstr "Перевірено на:"
 
 #: src/olympia/editors/templates/editors/review.html:220
-msgid ""
-"<strong>Warning!</strong> Another user was viewing this page before you."
-msgstr ""
-"<strong>Увага!</strong> Інший користувач переглядав цю сторінку перед вами."
+msgid "<strong>Warning!</strong> Another user was viewing this page before you."
+msgstr "<strong>Увага!</strong> Інший користувач переглядав цю сторінку перед вами."
 
 #: src/olympia/editors/templates/editors/review.html:237
-msgid ""
-"The whiteboard is the place to exchange information relevant to this addon "
-"(whatever the version), between the developer and the editor. This is "
-"visible and editable by both."
-msgstr ""
-"Ця дошка є місцем для обміну інформацією, яка відноситься до цього додатку "
-"(незалежно від версії), між розробником і редактором. Вона видима і доступна"
-" для редагування обом."
+msgid "The whiteboard is the place to exchange information relevant to this addon (whatever the version), between the developer and the editor. This is visible and editable by both."
+msgstr "Ця дошка є місцем для обміну інформацією, яка відноситься до цього додатку (незалежно від версії), між розробником і редактором. Вона видима і доступна для редагування обом."
 
 #: src/olympia/editors/templates/editors/review.html:241
 msgid "Update the whiteboard"
 msgstr "Оновити дошку"
 
-#: src/olympia/editors/templates/editors/review.html:257
-#: src/olympia/editors/templates/editors/review.html:258
+#: src/olympia/editors/templates/editors/review.html:257 src/olympia/editors/templates/editors/review.html:258
 msgid "(admin)"
 msgstr "(admin)"
 
@@ -10599,18 +8234,15 @@ msgstr "Редактор"
 msgid "Add-on has been deleted."
 msgstr "Додаток був видалений."
 
-#: src/olympia/editors/templates/editors/reviewlog.html:59
-#: src/olympia/editors/templates/editors/themes/logs.html:36
+#: src/olympia/editors/templates/editors/reviewlog.html:59 src/olympia/editors/templates/editors/themes/logs.html:36
 msgid "Show Comments"
 msgstr "Показати коментарі"
 
-#: src/olympia/editors/templates/editors/reviewlog.html:60
-#: src/olympia/editors/templates/editors/themes/logs.html:37
+#: src/olympia/editors/templates/editors/reviewlog.html:60 src/olympia/editors/templates/editors/themes/logs.html:37
 msgid "Hide Comments"
 msgstr "Приховати коментарі"
 
-#: src/olympia/editors/templates/editors/reviewlog.html:72
-#: src/olympia/editors/templates/editors/themes/logs.html:54
+#: src/olympia/editors/templates/editors/reviewlog.html:72 src/olympia/editors/templates/editors/themes/logs.html:54
 msgid "No reviews found for this period."
 msgstr "Не знайдено відгуків для цього періоду."
 
@@ -10668,12 +8300,8 @@ msgstr "Весь час"
 msgid "You have <span>{0}</span> points."
 msgstr "У вас <span>{0}</span> балів."
 
-#: src/olympia/editors/templates/editors/includes/search_results_themes.html:6
-#: src/olympia/editors/templates/editors/themes/history_table.html:7
-#: src/olympia/editors/templates/editors/themes/logs.html:19
-#: src/olympia/editors/templates/editors/themes/queue_list.html:49
-#: src/olympia/editors/templates/editors/themes/single.html:26
-#: src/olympia/editors/templates/editors/themes/themes.html:45
+#: src/olympia/editors/templates/editors/includes/search_results_themes.html:6 src/olympia/editors/templates/editors/themes/history_table.html:7 src/olympia/editors/templates/editors/themes/logs.html:19
+#: src/olympia/editors/templates/editors/themes/queue_list.html:49 src/olympia/editors/templates/editors/themes/single.html:26 src/olympia/editors/templates/editors/themes/themes.html:45
 msgid "Reviewer"
 msgstr "Рецензент"
 
@@ -10697,8 +8325,7 @@ msgstr "Журнал перевірки теми {0}"
 msgid "Review Date"
 msgstr "Дата перевірки"
 
-#: src/olympia/editors/templates/editors/themes/history_table.html:9
-#: src/olympia/editors/templates/editors/themes/logs.html:18
+#: src/olympia/editors/templates/editors/themes/history_table.html:9 src/olympia/editors/templates/editors/themes/logs.html:18
 msgid "Action"
 msgstr "Дія"
 
@@ -10715,21 +8342,18 @@ msgid "{num} Pending Theme Review"
 msgid_plural "{num} Pending Theme Reviews"
 msgstr[0] "{num} тема очікує на перевірку"
 msgstr[1] "{num} теми очікують на перевірку"
-msgstr[2] "{num} тем очікують на перевірку"
 
 #: src/olympia/editors/templates/editors/themes/home.html:27
 msgid "{num} Flagged Review"
 msgid_plural "{num} Flagged Reviews"
 msgstr[0] "{num} перевірка з позначкою"
 msgstr[1] "{num} перевірки з позначкою"
-msgstr[2] "{num} перевірок з позначкою"
 
 #: src/olympia/editors/templates/editors/themes/home.html:34
 msgid "{num} Update"
 msgid_plural "{num} Updates"
 msgstr[0] "{num} Оновлення"
 msgstr[1] "{num} Оновлення"
-msgstr[2] "{num} Оновлень"
 
 #: src/olympia/editors/templates/editors/themes/logs.html:4
 msgid "Theme Review Log"
@@ -10848,7 +8472,7 @@ msgstr "Задайте питання художнику"
 msgid "Describe your reason for flagging"
 msgstr "Опишіть спою причину для відмітки прапорцем"
 
-#: src/olympia/files/forms.py:88
+#: src/olympia/files/forms.py:90
 msgid "Cannot diff a version against itself"
 msgstr "Різниця версії проти самої себе неможлива"
 
@@ -10866,11 +8490,8 @@ msgid "Problems decoding {0}."
 msgstr "Проблеми декодування {0}."
 
 #: src/olympia/files/helpers.py:186
-msgid ""
-"This file is not viewable online. Please download the file to view the "
-"contents."
-msgstr ""
-"Цей файл неможливо переглянути онлайн. Завантажте його, щоб переглянути."
+msgid "This file is not viewable online. Please download the file to view the contents."
+msgstr "Цей файл неможливо переглянути онлайн. Завантажте його, щоб переглянути."
 
 #: src/olympia/files/helpers.py:194
 msgid "This file is a directory."
@@ -10886,54 +8507,51 @@ msgstr "Сталася помилка під час доступу до файл
 msgid "There was an error accessing file %s."
 msgstr "Сталася помилка під час доступу до файлу %s."
 
-#: src/olympia/files/utils.py:343
+#: src/olympia/files/utils.py:340
 msgid "Could not parse uploaded file."
 msgstr "Не вдалося розібрати завантажений файл."
 
-#: src/olympia/files/utils.py:380
+#: src/olympia/files/utils.py:377
 msgid "Invalid file name in archive: {0}"
 msgstr "Неправильне ім'я файлу в архіві: {0}"
 
-#: src/olympia/files/utils.py:388
+#: src/olympia/files/utils.py:385
 msgid "File exceeding size limit in archive: {0}"
 msgstr "Розмір файлу в архіві перевищує обмеження: {0}"
 
-#: src/olympia/files/utils.py:439
+#: src/olympia/files/utils.py:436
 msgid "Invalid archive."
 msgstr "Некоректний архів."
 
-#: src/olympia/files/utils.py:529 src/olympia/files/utils.py:532
+#: src/olympia/files/utils.py:526 src/olympia/files/utils.py:529
 msgid "Could not parse the manifest file."
 msgstr "Не вдалося обробити файл маніфесту."
 
-#: src/olympia/files/utils.py:551
+#: src/olympia/files/utils.py:548
 msgid "Could not find an add-on ID."
 msgstr "Не вдалося знайти ID додатку."
 
-#: src/olympia/files/utils.py:554
+#: src/olympia/files/utils.py:551
 msgid "Add-on ID must be 64 characters or less."
 msgstr "ID додатку повинен містити не більше 64 символів."
 
-#: src/olympia/files/utils.py:556
+#: src/olympia/files/utils.py:553
 msgid "Add-on ID doesn't match add-on."
 msgstr "ID не відповідає додатку."
 
-#: src/olympia/files/utils.py:564
+#: src/olympia/files/utils.py:561
 msgid "Duplicate add-on ID found."
 msgstr "Знайдено дублікат ID додатку."
 
-#: src/olympia/files/utils.py:567
+#: src/olympia/files/utils.py:564
 msgid "Version numbers should have fewer than 32 characters."
 msgstr "Номери версій повинні мати менше, ніж 32 символи."
 
-#: src/olympia/files/utils.py:570
-msgid ""
-"Version numbers should only contain letters, numbers, and these punctuation "
-"characters: +*.-_."
-msgstr ""
-"Номери версій повинні містити лише літери, цифри та наступні знаки: +*.-_."
+#: src/olympia/files/utils.py:567
+msgid "Version numbers should only contain letters, numbers, and these punctuation characters: +*.-_."
+msgstr "Номери версій повинні містити лише літери, цифри та наступні знаки: +*.-_."
 
-#: src/olympia/files/utils.py:587
+#: src/olympia/files/utils.py:584
 msgid "<em:type> doesn't match add-on"
 msgstr "<em:type> не відповідає додатку"
 
@@ -10951,12 +8569,8 @@ msgstr "Завантажити {0}"
 
 #: src/olympia/files/templates/files/file.html:4
 #, python-format
-msgid ""
-"Version: %(version)s &bull; Size: %(size)s &bull; MD5 hash: %(md5)s &bull; "
-"Mimetype: %(mimetype)s"
-msgstr ""
-"Версія: %(version)s &bull; Розмір: %(size)s &bull; MD5 хеш: %(md5)s &bull; "
-"Тип MIME: %(mimetype)s"
+msgid "Version: %(version)s &bull; Size: %(size)s &bull; MD5 hash: %(md5)s &bull; Mimetype: %(mimetype)s"
+msgstr "Версія: %(version)s &bull; Розмір: %(size)s &bull; MD5 хеш: %(md5)s &bull; Тип MIME: %(mimetype)s"
 
 #: src/olympia/files/templates/files/viewer.html:4
 msgid "File Compare :: Editor tools"
@@ -10994,48 +8608,39 @@ msgstr "Версія SDK додатку:"
 msgid "Tab stops:"
 msgstr "Позиції табуляції:"
 
-#: src/olympia/files/templates/files/viewer.html:79
-#: src/olympia/files/templates/files/viewer.html:80
+#: src/olympia/files/templates/files/viewer.html:79 src/olympia/files/templates/files/viewer.html:80
 msgid "Up file"
 msgstr "Файл вище"
 
-#: src/olympia/files/templates/files/viewer.html:84
-#: src/olympia/files/templates/files/viewer.html:85
+#: src/olympia/files/templates/files/viewer.html:84 src/olympia/files/templates/files/viewer.html:85
 msgid "Down file"
 msgstr "Файл нижче"
 
-#: src/olympia/files/templates/files/viewer.html:90
-#: src/olympia/files/templates/files/viewer.html:91
+#: src/olympia/files/templates/files/viewer.html:90 src/olympia/files/templates/files/viewer.html:91
 msgid "Previous diff"
 msgstr "Попередня різниця"
 
-#: src/olympia/files/templates/files/viewer.html:93
-#: src/olympia/files/templates/files/viewer.html:94
+#: src/olympia/files/templates/files/viewer.html:93 src/olympia/files/templates/files/viewer.html:94
 msgid "Previous note"
 msgstr "Попередня примітка"
 
-#: src/olympia/files/templates/files/viewer.html:100
-#: src/olympia/files/templates/files/viewer.html:101
+#: src/olympia/files/templates/files/viewer.html:100 src/olympia/files/templates/files/viewer.html:101
 msgid "Next diff"
 msgstr "Наступна відмінність"
 
-#: src/olympia/files/templates/files/viewer.html:103
-#: src/olympia/files/templates/files/viewer.html:104
+#: src/olympia/files/templates/files/viewer.html:103 src/olympia/files/templates/files/viewer.html:104
 msgid "Next note"
 msgstr "Наступна примітка"
 
-#: src/olympia/files/templates/files/viewer.html:109
-#: src/olympia/files/templates/files/viewer.html:110
+#: src/olympia/files/templates/files/viewer.html:109 src/olympia/files/templates/files/viewer.html:110
 msgid "Expand all"
 msgstr "Розгорнути все"
 
-#: src/olympia/files/templates/files/viewer.html:114
-#: src/olympia/files/templates/files/viewer.html:115
+#: src/olympia/files/templates/files/viewer.html:114 src/olympia/files/templates/files/viewer.html:115
 msgid "Hide or unhide tree"
 msgstr "Приховати чи показати дерево"
 
-#: src/olympia/files/templates/files/viewer.html:119
-#: src/olympia/files/templates/files/viewer.html:120
+#: src/olympia/files/templates/files/viewer.html:119 src/olympia/files/templates/files/viewer.html:120
 msgid "Wrap or unwrap text"
 msgstr "Загорнути чи розгорнути текст"
 
@@ -11046,6 +8651,10 @@ msgstr "В завантаженому файлі немає файлів."
 #: src/olympia/files/templates/files/viewer.html:134
 msgid "Fetching file."
 msgstr "Отримання файлу."
+
+#: src/olympia/legacy_api/views.py:255
+msgid "Not implemented yet."
+msgstr "Ще не впроваджено."
 
 #: src/olympia/lib/constants.py:6
 msgid "United Arab Emirates Dirham"
@@ -11703,12 +9312,7 @@ msgstr "Замбійська квача"
 msgid "Zimbabwe Dollar"
 msgstr "Зімбабвійський долар"
 
-#: src/olympia/lib/video/ffmpeg.py:112 src/olympia/lib/video/totem.py:81
-msgid "Videos must be in WebM."
-msgstr "Відео повинно бути в WebM."
-
-#: src/olympia/pages/templates/pages/about.lhtml:3
-#: src/olympia/pages/templates/pages/about.lhtml:10
+#: src/olympia/pages/templates/pages/about.lhtml:3 src/olympia/pages/templates/pages/about.lhtml:10
 msgid "About Mozilla Add-ons"
 msgstr "Про додатки Mozilla"
 
@@ -11718,18 +9322,11 @@ msgstr "Що це за веб-сайт?"
 
 #: src/olympia/pages/templates/pages/about.lhtml:13
 msgid ""
-"addons.mozilla.org, commonly known as \"AMO\", is Mozilla's official site "
-"for add-ons to Mozilla software, such as Firefox, Thunderbird, and "
-"SeaMonkey. Add-ons let you add new features and change the way your browser "
-"or application works. Take a look around and explore the thousands of ways "
-"to customize the way you do things online."
+"addons.mozilla.org, commonly known as \"AMO\", is Mozilla's official site for add-ons to Mozilla software, such as Firefox, Thunderbird, and SeaMonkey. Add-ons let you add new features and change "
+"the way your browser or application works. Take a look around and explore the thousands of ways to customize the way you do things online."
 msgstr ""
-"addons.mozilla.org, також відомий як \"AMO\" є офіційним сайтом Mozilla для "
-"додатків до програмного забезпечення Mozilla, таких як Firefox, Thunderbird "
-"та SeaMonkey. Додатки дозволяють вам додавати нові функції та змінювати "
-"спосіб роботи вашого браузера чи іншої програми. Погляньте навколо і "
-"відкрийте тисячі способів пристосувати своє перебування та роботу в "
-"Інтернеті."
+"addons.mozilla.org, також відомий як \"AMO\" є офіційним сайтом Mozilla для додатків до програмного забезпечення Mozilla, таких як Firefox, Thunderbird та SeaMonkey. Додатки дозволяють вам додавати"
+" нові функції та змінювати спосіб роботи вашого браузера чи іншої програми. Погляньте навколо і відкрийте тисячі способів пристосувати своє перебування та роботу в Інтернеті."
 
 #: src/olympia/pages/templates/pages/about.lhtml:19
 msgid "Who creates these add-ons?"
@@ -11737,109 +9334,69 @@ msgstr "Хто створює ці додатки?"
 
 #: src/olympia/pages/templates/pages/about.lhtml:20
 msgid ""
-"The add-ons listed here have been created by thousands of developers from "
-"our community, ranging from individual hobbyists to large corporations. All "
-"publicly listed add-ons are reviewed by a team of editors before being "
-"released. Add-ons marked as Experimental have not been reviewed and should "
-"only be installed with caution."
+"The add-ons listed here have been created by thousands of developers from our community, ranging from individual hobbyists to large corporations. All publicly listed add-ons are reviewed by a team "
+"of editors before being released. Add-ons marked as Experimental have not been reviewed and should only be installed with caution."
 msgstr ""
-"Опубліковані тут додатки були створені тисячами розробників з нашої "
-"спільноти, від окремих любителів і до великих корпорацій. Всі "
-"загальнодоступні додатки перевірені командою редакторів перед їх випуском. "
-"Додатки, позначені як Експериментальні, не були перевірені, і їх слід "
-"встановлювати з обережністю."
+"Опубліковані тут додатки були створені тисячами розробників з нашої спільноти, від окремих любителів і до великих корпорацій. Всі загальнодоступні додатки перевірені командою редакторів перед їх "
+"випуском. Додатки, позначені як Експериментальні, не були перевірені, і їх слід встановлювати з обережністю."
 
 #: src/olympia/pages/templates/pages/about.lhtml:26
 msgid "How do I keep up with what's happening at AMO?"
 msgstr "Як мені бути в курсі того, що відбувається на AMO?"
 
 #: src/olympia/pages/templates/pages/about.lhtml:27
-msgid ""
-"There are several ways to find out the latest news from the world of add-"
-"ons:"
+msgid "There are several ways to find out the latest news from the world of add-ons:"
 msgstr "Є кілька способів бути в курсі останніх новин зі світу додатків:"
 
 #: src/olympia/pages/templates/pages/about.lhtml:29
 #, python-format
-msgid ""
-"Our <a href=\"%(url)s\">Add-ons Blog</a> is regularly updated with "
-"information for both add-on enthusiasts and developers."
-msgstr ""
-"Наш <a href=\"%(url)s\">блог додатків</a> регулярно оновлюється інформацією "
-"як від любителів, так і від розробників."
+msgid "Our <a href=\"%(url)s\">Add-ons Blog</a> is regularly updated with information for both add-on enthusiasts and developers."
+msgstr "Наш <a href=\"%(url)s\">блог додатків</a> регулярно оновлюється інформацією як від любителів, так і від розробників."
 
 #: src/olympia/pages/templates/pages/about.lhtml:32
 #, python-format
-msgid ""
-"We often post news, tips, and tricks to our Twitter account, <a "
-"href=\"%(url)s\">mozamo</a>"
-msgstr ""
-"Ми часто публікуємо новини, поради і хитрощі в нашому обліковому записі "
-"Twitter, <a href=\"%(url)s\">mozamo</a>"
+msgid "We often post news, tips, and tricks to our Twitter account, <a href=\"%(url)s\">mozamo</a>"
+msgstr "Ми часто публікуємо новини, поради і хитрощі в нашому обліковому записі Twitter, <a href=\"%(url)s\">mozamo</a>"
 
 #: src/olympia/pages/templates/pages/about.lhtml:34
 #, python-format
-msgid ""
-"Our <a href=\"%(url)s\">forums</a> are a good place to interact with the "
-"add-ons community and discuss upcoming changes to AMO."
-msgstr ""
-"Наші <a href=\"%(url)s\">форуми</a> є хорошим місцем для взаємодії зі "
-"спільнотою додатків та обговорення майбутніх змін на AMO."
+msgid "Our <a href=\"%(url)s\">forums</a> are a good place to interact with the add-ons community and discuss upcoming changes to AMO."
+msgstr "Наші <a href=\"%(url)s\">форуми</a> є хорошим місцем для взаємодії зі спільнотою додатків та обговорення майбутніх змін на AMO."
 
 #: src/olympia/pages/templates/pages/about.lhtml:39
 msgid "This sounds great! How can I get involved?"
 msgstr "Це звучить чудово! Як я можу долучитися?"
 
 #: src/olympia/pages/templates/pages/about.lhtml:40
-msgid ""
-"There are plenty of ways to get involved. If you're on the technical side:"
+msgid "There are plenty of ways to get involved. If you're on the technical side:"
 msgstr "Є багато способів долучитися. Якщо ви знайомі з технологіями:"
 
 #: src/olympia/pages/templates/pages/about.lhtml:42
 #, python-format
-msgid ""
-"<a href=\"%(url)s\">Make your own add-on</a>. We provide free hosting and "
-"update services and can help you reach a large audience of users."
-msgstr ""
-"<a href=\"%(url)s\">Створіть свій власний додаток</a>. Ми надаємо "
-"безкоштовний хостінг та службу оновлень, а також можемо допомогти вам "
-"охопити широку аудиторію користувачів."
+msgid "<a href=\"%(url)s\">Make your own add-on</a>. We provide free hosting and update services and can help you reach a large audience of users."
+msgstr "<a href=\"%(url)s\">Створіть свій власний додаток</a>. Ми надаємо безкоштовний хостінг та службу оновлень, а також можемо допомогти вам охопити широку аудиторію користувачів."
 
 #: src/olympia/pages/templates/pages/about.lhtml:45
 #, python-format
-msgid ""
-"If you have add-on development experience, <a href=\"%(url)s\"> become an "
-"editor</a>! Our editors are add-on fans with a technical background who "
-"review add-ons for code quality and stability."
+msgid "If you have add-on development experience, <a href=\"%(url)s\"> become an editor</a>! Our editors are add-on fans with a technical background who review add-ons for code quality and stability."
 msgstr ""
-"Якщо ви маєте досвід розробки додатків, <a href=\"%(url)s\"> станьте "
-"редактором</a>! Наші редактори є фанатами додатків з технічною підготовкою, "
-"які переглядають додатки на якість та стабільність коду."
+"Якщо ви маєте досвід розробки додатків, <a href=\"%(url)s\"> станьте редактором</a>! Наші редактори є фанатами додатків з технічною підготовкою, які переглядають додатки на якість та стабільність "
+"коду."
 
 #: src/olympia/pages/templates/pages/about.lhtml:49
 #, python-format
-msgid ""
-"Help improve this website. It's open source, and you can file bugs and "
-"submit patches. <a href=\"%(url)s\"> GitHub</a> contains all of our current "
-"bugs, legacy bugs can still be found in Bugzilla."
+msgid "Help improve this website. It's open source, and you can file bugs and submit patches. <a href=\"%(url)s\"> GitHub</a> contains all of our current bugs, legacy bugs can still be found in Bugzilla."
 msgstr ""
-"Допоможіть покращити цей веб-сайт. Його програмний код є відкритим і ви "
-"можете реєструвати помилки та відправляти виправлення. <a "
-"href=\"%(url)s\">GitHub</a> містить всі наші поточні помилки, успадковані "
-"помилки все ще можуть бути знайдені в Bugzilla."
+"Допоможіть покращити цей веб-сайт. Його програмний код є відкритим і ви можете реєструвати помилки та відправляти виправлення. <a href=\"%(url)s\">GitHub</a> містить всі наші поточні помилки, "
+"успадковані помилки все ще можуть бути знайдені в Bugzilla."
 
 #: src/olympia/pages/templates/pages/about.lhtml:55
-msgid ""
-"If you're interested in add-ons but not quite as technical, there are still "
-"ways to help:"
-msgstr ""
-"Якщо ви цікавитесь додатками, але не зовсім знайомі з технологіями, ви все "
-"одно маєте можливість допомогти:"
+msgid "If you're interested in add-ons but not quite as technical, there are still ways to help:"
+msgstr "Якщо ви цікавитесь додатками, але не зовсім знайомі з технологіями, ви все одно маєте можливість допомогти:"
 
 #: src/olympia/pages/templates/pages/about.lhtml:58
 msgid "Tell your friends! Let people know which add-ons you use."
-msgstr ""
-"Розкажіть своїм друзям! Дайте людям знати, які додатки ви використовуєте."
+msgstr "Розкажіть своїм друзям! Дайте людям знати, які додатки ви використовуєте."
 
 #: src/olympia/pages/templates/pages/about.lhtml:59
 #, python-format
@@ -11847,13 +9404,8 @@ msgid "Participate in our <a href=\"%(url)s\">forums</a>."
 msgstr "Беріть участь в наших <a href=\"%(url)s\">форумах</a>."
 
 #: src/olympia/pages/templates/pages/about.lhtml:61
-msgid ""
-"Review add-ons on the site. Add-on authors are more likely to improve their "
-"add-ons and write new ones when they know people appreciate their work."
-msgstr ""
-"Залишайте відгуки для додатку на сайті. Автори додатку більш схильні до "
-"вдосконалення своїх додатків та написання нових, якщо вони знають, що люди "
-"цінять їх роботу."
+msgid "Review add-ons on the site. Add-on authors are more likely to improve their add-ons and write new ones when they know people appreciate their work."
+msgstr "Залишайте відгуки для додатку на сайті. Автори додатку більш схильні до вдосконалення своїх додатків та написання нових, якщо вони знають, що люди цінять їх роботу."
 
 #: src/olympia/pages/templates/pages/about.lhtml:66
 msgid "I have a question"
@@ -11862,23 +9414,16 @@ msgstr "У мене є питання"
 #: src/olympia/pages/templates/pages/about.lhtml:67
 #, python-format
 msgid ""
-"A good place to start is our <a href=\"%(faq_url)s\"><abbr "
-"title=\"Frequently Asked Questions\">FAQ</abbr></a>. If you don't find an "
-"answer there, you can <a href=\"%(forum_url)s\"> ask on our forums</a>."
+"A good place to start is our <a href=\"%(faq_url)s\"><abbr title=\"Frequently Asked Questions\">FAQ</abbr></a>. If you don't find an answer there, you can <a href=\"%(forum_url)s\"> ask on our "
+"forums</a>."
 msgstr ""
-"Для початку перегляньте наші <a href=\"%(faq_url)s\"><abbr "
-"title=\"Frequently Asked Questions\">ЧаП</abbr></a>. Якщо ви не знайдете там"
-" відповіді, ви можете <a href=\"%(forum_url)s\"> задати питання на наших "
-"форумах</a>."
+"Для початку перегляньте наші <a href=\"%(faq_url)s\"><abbr title=\"Frequently Asked Questions\">ЧаП</abbr></a>. Якщо ви не знайдете там відповіді, ви можете <a href=\"%(forum_url)s\"> задати "
+"питання на наших форумах</a>."
 
 #: src/olympia/pages/templates/pages/about.lhtml:72
 #, python-format
-msgid ""
-"If you really need to contact someone from the Mozilla team, please see our "
-"<a href=\"%(url)s\"> contact information</a> page."
-msgstr ""
-"Якщо вам дійсно потрібно зв'язатися з кимось із команди Mozilla, перегляньте"
-" нашу сторінку з <a href=\"%(url)s\"> контактною інформацією</a>."
+msgid "If you really need to contact someone from the Mozilla team, please see our <a href=\"%(url)s\"> contact information</a> page."
+msgstr "Якщо вам дійсно потрібно зв'язатися з кимось із команди Mozilla, перегляньте нашу сторінку з <a href=\"%(url)s\"> контактною інформацією</a>."
 
 #: src/olympia/pages/templates/pages/about.lhtml:76
 msgid "Who works on this website?"
@@ -11887,14 +9432,10 @@ msgstr "Хто працює над цим веб-сайтом?"
 #: src/olympia/pages/templates/pages/about.lhtml:77
 #, python-format
 msgid ""
-"Over the years, many people have contributed to this website, including both"
-" volunteers from the community and a dedicated AMO team. A list of "
-"significant contributors can be found on our <a href=\"%(url)s\"> Site "
-"Credits</a> page."
+"Over the years, many people have contributed to this website, including both volunteers from the community and a dedicated AMO team. A list of significant contributors can be found on our <a "
+"href=\"%(url)s\"> Site Credits</a> page."
 msgstr ""
-"Протягом років, багато людей зробили свій внесок в цей веб-сайт, як "
-"добровільні помічники зі спільноти, так і окремо команда AMO. Список "
-"важливих помічників можна знайти на нашій сторінці <a "
+"Протягом років, багато людей зробили свій внесок в цей веб-сайт, як добровільні помічники зі спільноти, так і окремо команда AMO. Список важливих помічників можна знайти на нашій сторінці <a "
 "href=\"%(url)s\">авторів сайту</a>."
 
 #: src/olympia/pages/templates/pages/acr_firstrun.html:4
@@ -11906,12 +9447,8 @@ msgid "Add-on Compatibility Reporter has been installed"
 msgstr "Засіб звітів сумісності додатків був встановлений"
 
 #: src/olympia/pages/templates/pages/acr_firstrun.html:28
-msgid ""
-"It’s easy to help us make sure add-ons are updated in time for the release "
-"of the next version of Firefox."
-msgstr ""
-"Можна легко допомогти нам переконатися в тому, що додатки оновлюються вчасно"
-" для випуску наступної версії Firefox."
+msgid "It’s easy to help us make sure add-ons are updated in time for the release of the next version of Firefox."
+msgstr "Можна легко допомогти нам переконатися в тому, що додатки оновлюються вчасно для випуску наступної версії Firefox."
 
 #: src/olympia/pages/templates/pages/acr_firstrun.html:35
 msgid "Here’s how to get started reporting add-on compatibility:"
@@ -11919,53 +9456,36 @@ msgstr "Ось як почати звітувати про сумісність 
 
 #: src/olympia/pages/templates/pages/acr_firstrun.html:40
 msgid ""
-"As you start browsing and using your add-ons, take careful note of anything "
-"that seems different from when you last used the extension. This might be a "
-"display glitch, such as a menu item missing, or something more serious, like"
-" the add-on not working at all or showing errors."
+"As you start browsing and using your add-ons, take careful note of anything that seems different from when you last used the extension. This might be a display glitch, such as a menu item missing, "
+"or something more serious, like the add-on not working at all or showing errors."
 msgstr ""
-"При початку веб-перегляду та використанні додатку старайтеся помітити все, "
-"що змінилося з моменту, коли ви востаннє його використовували. Це може бути "
-"збій відображення, такий як відсутній елемент меню, або щось більш серйозне,"
-" таке як непрацездатність додатку чи показ помилок."
+"При початку веб-перегляду та використанні додатку старайтеся помітити все, що змінилося з моменту, коли ви востаннє його використовували. Це може бути збій відображення, такий як відсутній елемент "
+"меню, або щось більш серйозне, таке як непрацездатність додатку чи показ помилок."
 
 #: src/olympia/pages/templates/pages/acr_firstrun.html:49
 msgid ""
-"Once you know whether a particular add-on works properly or has problems, "
-"open the Add-ons Manager and click Compatibility next to the add-on to let "
-"Mozilla know what you found in your testing. Submitting a report will help "
-"us tell the add-on developer whether their add-on is working properly in "
-"this version or might need some fixes."
+"Once you know whether a particular add-on works properly or has problems, open the Add-ons Manager and click Compatibility next to the add-on to let Mozilla know what you found in your testing. "
+"Submitting a report will help us tell the add-on developer whether their add-on is working properly in this version or might need some fixes."
 msgstr ""
-"Як тільки ви дізналися, чи конкретний додаток працює належним чином або має "
-"проблеми, відкрийте менеджер додатків і натисніть на Сумісність поруч з "
-"додатком, щоб повідомити Mozilla про те, що ви знайшли під час свого "
-"тестування. Надсилання звіту допоможе нам повідомити розробника додатку про "
-"те, чи він працює належним чином в цій версії чи потребує певних виправлень."
+"Як тільки ви дізналися, чи конкретний додаток працює належним чином або має проблеми, відкрийте менеджер додатків і натисніть на Сумісність поруч з додатком, щоб повідомити Mozilla про те, що ви "
+"знайшли під час свого тестування. Надсилання звіту допоможе нам повідомити розробника додатку про те, чи він працює належним чином в цій версії чи потребує певних виправлень."
 
 #: src/olympia/pages/templates/pages/acr_firstrun.html:61
 #, python-format
 msgid ""
-"If you upgrade to a new version of Firefox or update your add-ons, your "
-"reports for the old versions will be hidden to allow you to test the new "
-"version. If you have any questions, please ask in <a href=\"%(url)s\">our "
-"forums</a>."
+"If you upgrade to a new version of Firefox or update your add-ons, your reports for the old versions will be hidden to allow you to test the new version. If you have any questions, please ask in <a"
+" href=\"%(url)s\">our forums</a>."
 msgstr ""
-"Якщо ви оновлюєте Firefox чи свої додатки до нової версії, ваші звіти для "
-"старих версій будуть приховані для можливості тестування вами нових версій. "
-"При виникненні будь-яких питань, будь ласка, задавайте їх на <a "
-"href=\"%(url)s\">наших форумах</a>."
+"Якщо ви оновлюєте Firefox чи свої додатки до нової версії, ваші звіти для старих версій будуть приховані для можливості тестування вами нових версій. При виникненні будь-яких питань, будь ласка, "
+"задавайте їх на <a href=\"%(url)s\">наших форумах</a>."
 
 #: src/olympia/pages/templates/pages/acr_firstrun.html:69
 msgid ""
-"Thousands of add-ons are made by our community every year, and your "
-"assistance with compatibility testing helps us make sure these add-ons stay "
-"useful as we strive to provide a great user experience."
+"Thousands of add-ons are made by our community every year, and your assistance with compatibility testing helps us make sure these add-ons stay useful as we strive to provide a great user "
+"experience."
 msgstr ""
-"Щорічно нашою спільнотою створюються тисячі додатків, і ваше сприяння в "
-"тестуванні сумісності допомагає нам переконатися в тому, що ці додатки "
-"залишаються корисними, так само, як і наші старання забезпечувати "
-"користувачів відмінною якістю їх роботи."
+"Щорічно нашою спільнотою створюються тисячі додатків, і ваше сприяння в тестуванні сумісності допомагає нам переконатися в тому, що ці додатки залишаються корисними, так само, як і наші старання "
+"забезпечувати користувачів відмінною якістю їх роботи."
 
 #: src/olympia/pages/templates/pages/acr_firstrun.html:75
 msgid "Thank you!"
@@ -11976,12 +9496,8 @@ msgid "Site Credits"
 msgstr "Автори сайту"
 
 #: src/olympia/pages/templates/pages/credits.html:12
-msgid ""
-"Mozilla would like to thank the following people for their contributions to "
-"the addons.mozilla.org project over the years:"
-msgstr ""
-"Mozilla бажає висловити подяку наступним людям за їх внески в проект "
-"addons.mozilla.org протягом років:"
+msgid "Mozilla would like to thank the following people for their contributions to the addons.mozilla.org project over the years:"
+msgstr "Mozilla бажає висловити подяку наступним людям за їх внески в проект addons.mozilla.org протягом років:"
 
 #: src/olympia/pages/templates/pages/credits.html:18
 msgid "Developers &amp; Administrators"
@@ -12014,89 +9530,63 @@ msgstr "Програми та зображення"
 
 #: src/olympia/pages/templates/pages/credits.html:59
 msgid ""
-"Some icons used are from the <a "
-"href=\"http://www.famfamfam.com/lab/icons/silk/\">famfamfam Silk Icon "
-"Set</a>, licensed under a <a "
-"href=\"http://creativecommons.org/licenses/by/2.5/\">Creative Commons "
-"Attribution 2.5 License</a>."
+"Some icons used are from the <a href=\"http://www.famfamfam.com/lab/icons/silk/\">famfamfam Silk Icon Set</a>, licensed under a <a href=\"http://creativecommons.org/licenses/by/2.5/\">Creative "
+"Commons Attribution 2.5 License</a>."
 msgstr ""
-"Деякі використані піктограми входять в <a "
-"href=\"http://www.famfamfam.com/lab/icons/silk/\">набір піктограм famfamfam "
-"Silk</a>, ліцензований умовами <a "
-"href=\"http://creativecommons.org/licenses/by/2.5/\">Creative Commons "
-"Attribution версії 2.5</a>."
+"Деякі використані піктограми входять в <a href=\"http://www.famfamfam.com/lab/icons/silk/\">набір піктограм famfamfam Silk</a>, ліцензований умовами <a "
+"href=\"http://creativecommons.org/licenses/by/2.5/\">Creative Commons Attribution версії 2.5</a>."
 
 #: src/olympia/pages/templates/pages/credits.html:60
 msgid ""
-"Some icons used are from the <a href=\"http://www.fatcow.com/free-"
-"icons/\">FatCow Farm-Fresh Web Icons Set</a>, licensed under a <a "
-"href=\"http://creativecommons.org/licenses/by/3.0/us/\">Creative Commons "
-"Attribution 3.0 License</a>."
+"Some icons used are from the <a href=\"http://www.fatcow.com/free-icons/\">FatCow Farm-Fresh Web Icons Set</a>, licensed under a <a href=\"http://creativecommons.org/licenses/by/3.0/us/\">Creative "
+"Commons Attribution 3.0 License</a>."
 msgstr ""
-"Деякі використані піктограми входять в <a href=\"http://www.fatcow.com/free-"
-"icons/\">набір піктограм FatCow Farm-Fresh</a>, ліцензований умовами <a "
-"href=\"http://creativecommons.org/licenses/by/3.0/us/\">Creative Commons "
-"Attribution версії 3.0</a>."
+"Деякі використані піктограми входять в <a href=\"http://www.fatcow.com/free-icons/\">набір піктограм FatCow Farm-Fresh</a>, ліцензований умовами <a "
+"href=\"http://creativecommons.org/licenses/by/3.0/us/\">Creative Commons Attribution версії 3.0</a>."
 
 #: src/olympia/pages/templates/pages/credits.html:61
 msgid ""
-"Some pages use elements of <a "
-"href=\"http://shop.highsoft.com/highcharts.html\">Highcharts</a> (non-"
-"commercial), licensed under a <a href=\"http://creativecommons.org/licenses"
-"/by-nc/3.0/\">Creative Commons Attribution-NonCommercial 3.0 License</a>."
+"Some pages use elements of <a href=\"http://shop.highsoft.com/highcharts.html\">Highcharts</a> (non-commercial), licensed under a <a href=\"http://creativecommons.org/licenses/by-nc/3.0/\">Creative"
+" Commons Attribution-NonCommercial 3.0 License</a>."
 msgstr ""
-"Деякі сторінки використовують елементи з <a "
-"href=\"http://shop.highsoft.com/highcharts.html\">Highcharts</a> "
-"(некомерційна), ліцензованою умовами <a "
-"href=\"http://creativecommons.org/licenses/by-nc/3.0/\">ліцензії Creative "
-"Commons Attribution-NonCommercial версії 3.0</a>."
+"Деякі сторінки використовують елементи з <a href=\"http://shop.highsoft.com/highcharts.html\">Highcharts</a> (некомерційна), ліцензованою умовами <a href=\"http://creativecommons.org/licenses/by-"
+"nc/3.0/\">ліцензії Creative Commons Attribution-NonCommercial версії 3.0</a>."
 
 #: src/olympia/pages/templates/pages/credits.html:65
 #, python-format
-msgid ""
-"For information on contributing, please see our <a href=\"%(url)s\">wiki "
-"page</a>."
-msgstr ""
-"Для отримання інформації про внесок, будь ласка, перевірте нашу <a "
-"href=\"%(url)s\">сторінку wiki</a>."
+msgid "For information on contributing, please see our <a href=\"%(url)s\">wiki page</a>."
+msgstr "Для отримання інформації про внесок, будь ласка, перевірте нашу <a href=\"%(url)s\">сторінку wiki</a>."
 
 #: src/olympia/pages/templates/pages/dev_faq.html:4
 msgid "Developer FAQ"
 msgstr "ЧаП розробника"
 
-#: src/olympia/pages/templates/pages/dev_faq.html:31
-#: src/olympia/pages/templates/pages/review_guide.html:33
+#: src/olympia/pages/templates/pages/dev_faq.html:31 src/olympia/pages/templates/pages/review_guide.html:33
 msgid "Sections"
 msgstr "Секції"
 
-#: src/olympia/pages/templates/pages/dev_faq.html:33
-#: src/olympia/pages/templates/pages/dev_faq.html:45
+#: src/olympia/pages/templates/pages/dev_faq.html:33 src/olympia/pages/templates/pages/dev_faq.html:45
 msgid "Developing an Add-on"
 msgstr "Розробка додатку"
 
 #. Heading for a list of resources for developers
-#: src/olympia/pages/templates/pages/dev_faq.html:34
-#: src/olympia/pages/templates/pages/dev_faq.html:208
+#: src/olympia/pages/templates/pages/dev_faq.html:34 src/olympia/pages/templates/pages/dev_faq.html:208
 msgid "Support Resources"
 msgstr "Ресурси підтримки"
 
-#: src/olympia/pages/templates/pages/dev_faq.html:35
-#: src/olympia/pages/templates/pages/dev_faq.html:261
+#: src/olympia/pages/templates/pages/dev_faq.html:35 src/olympia/pages/templates/pages/dev_faq.html:261
 msgid "Contributing your Add-on"
 msgstr "Сприяння вашому додатку"
 
-#: src/olympia/pages/templates/pages/dev_faq.html:36
-#: src/olympia/pages/templates/pages/dev_faq.html:381
+#: src/olympia/pages/templates/pages/dev_faq.html:36 src/olympia/pages/templates/pages/dev_faq.html:381
 msgid "Add-on Review Process"
 msgstr "Процес розгляду додатків"
 
-#: src/olympia/pages/templates/pages/dev_faq.html:37
-#: src/olympia/pages/templates/pages/dev_faq.html:444
+#: src/olympia/pages/templates/pages/dev_faq.html:37 src/olympia/pages/templates/pages/dev_faq.html:444
 msgid "Managing Your Add-on"
 msgstr "Керування своїм додатком"
 
-#: src/olympia/pages/templates/pages/dev_faq.html:39
-#: src/olympia/pages/templates/pages/dev_faq.html:528
+#: src/olympia/pages/templates/pages/dev_faq.html:39 src/olympia/pages/templates/pages/dev_faq.html:528
 msgid "References for Open Source Licenses"
 msgstr "Посилання на ліцензії для Відкритого Програмного Коду"
 
@@ -12106,14 +9596,8 @@ msgstr "ЧаП розробника додатків"
 
 #: src/olympia/pages/templates/pages/dev_faq.html:47
 #, python-format
-msgid ""
-"<h3>How do I build an Add-on?</h3> <p> Mozilla provides documentation on how"
-" to build an add-on via the <a href=\"%(url)s\">Mozilla Developer "
-"Network</a>. </p>"
-msgstr ""
-"<h3>Як мені створити додаток?</h3> <p> Mozilla надає документацію на <a "
-"href=\"%(url)s\">Mozilla Developer Network</a> про те, як створити додаток. "
-"</p>"
+msgid "<h3>How do I build an Add-on?</h3> <p> Mozilla provides documentation on how to build an add-on via the <a href=\"%(url)s\">Mozilla Developer Network</a>. </p>"
+msgstr "<h3>Як мені створити додаток?</h3> <p> Mozilla надає документацію на <a href=\"%(url)s\">Mozilla Developer Network</a> про те, як створити додаток. </p>"
 
 #: src/olympia/pages/templates/pages/dev_faq.html:55
 msgid "Other resources include:"
@@ -12133,13 +9617,11 @@ msgstr "Які інструменти мені знадобляться для �
 
 #: src/olympia/pages/templates/pages/dev_faq.html:68
 msgid ""
-"You will need to have a version of the Mozilla software that you're building"
-" the add-on for and a code editor of your choice. Add-ons can be built for "
-"almost all Mozilla software but are primarily targeted for:"
+"You will need to have a version of the Mozilla software that you're building the add-on for and a code editor of your choice. Add-ons can be built for almost all Mozilla software but are primarily "
+"targeted for:"
 msgstr ""
-"Вам буде за необхідне мати версію програми Mozilla, для якої ви створюєте "
-"додаток, і редактор коду на ваш вибір. Додатки можуть бути створені майже "
-"для всіх програм Mozilla, але в першу чергу призначені для:"
+"Вам буде за необхідне мати версію програми Mozilla, для якої ви створюєте додаток, і редактор коду на ваш вибір. Додатки можуть бути створені майже для всіх програм Mozilla, але в першу чергу "
+"призначені для:"
 
 #: src/olympia/pages/templates/pages/dev_faq.html:82
 msgid "Popular code editors include:"
@@ -12148,38 +9630,24 @@ msgstr "Популярні редактори коду:"
 #. This is a list of popular code editors.  Feel free to adjust as you like.
 #: src/olympia/pages/templates/pages/dev_faq.html:85
 msgid ""
-"<li><a href=\"http://komodoide.com/komodo-edit/\">Komodo Edit</a></li> "
-"<li><a href=\"http://macromates.com/\">TextMate</a></li> <li><a href=\"http"
-"://notepad-plus-plus.org/\">Notepad++</a></li> <li><a "
-"href=\"http://www.eclipse.org/\">Eclipse IDE</a></li>"
+"<li><a href=\"http://komodoide.com/komodo-edit/\">Komodo Edit</a></li> <li><a href=\"http://macromates.com/\">TextMate</a></li> <li><a href=\"http://notepad-plus-plus.org/\">Notepad++</a></li> "
+"<li><a href=\"http://www.eclipse.org/\">Eclipse IDE</a></li>"
 msgstr ""
-"<li><a href=\"http://komodoide.com/komodo-edit/\">Komodo Edit</a></li> "
-"<li><a href=\"http://macromates.com/\">TextMate</a></li> <li><a href=\"http"
-"://notepad-plus-plus.org/\">Notepad++</a></li> <li><a "
-"href=\"http://www.eclipse.org/\">Eclipse IDE</a></li>"
+"<li><a href=\"http://komodoide.com/komodo-edit/\">Komodo Edit</a></li> <li><a href=\"http://macromates.com/\">TextMate</a></li> <li><a href=\"http://notepad-plus-plus.org/\">Notepad++</a></li> "
+"<li><a href=\"http://www.eclipse.org/\">Eclipse IDE</a></li>"
 
 #: src/olympia/pages/templates/pages/dev_faq.html:94
 #, python-format
-msgid ""
-"You can also learn more about setting up your development environment via "
-"the MDN article <a href=\"%(url)s\">Setting up extension development "
-"environment</a>"
-msgstr ""
-"Ви можете також дізнатися більше про налаштування середовища розробки, "
-"прочитавши статтю в MDN <a href=\"%(url)s\">Setting up extension development"
-" environment</a>"
+msgid "You can also learn more about setting up your development environment via the MDN article <a href=\"%(url)s\">Setting up extension development environment</a>"
+msgstr "Ви можете також дізнатися більше про налаштування середовища розробки, прочитавши статтю в MDN <a href=\"%(url)s\">Setting up extension development environment</a>"
 
 #: src/olympia/pages/templates/pages/dev_faq.html:100
 msgid "What is a \".xpi\" file?"
 msgstr "Що таке файл \".xpi\"?"
 
 #: src/olympia/pages/templates/pages/dev_faq.html:102
-msgid ""
-"Extensions are packaged and distributed in ZIP files or Bundles, with the "
-"XPI (pronounced \"zippy\") file extension."
-msgstr ""
-"Розширення упаковані й поширені у ZIP-файлах чи пакетах, з файловим "
-"розширенням XPI (вимовляється як \"зіппі\")."
+msgid "Extensions are packaged and distributed in ZIP files or Bundles, with the XPI (pronounced \"zippy\") file extension."
+msgstr "Розширення упаковані й поширені у ZIP-файлах чи пакетах, з файловим розширенням XPI (вимовляється як \"зіппі\")."
 
 #: src/olympia/pages/templates/pages/dev_faq.html:108
 msgid "What is XUL?"
@@ -12187,17 +9655,11 @@ msgstr "Що таке XUL?"
 
 #: src/olympia/pages/templates/pages/dev_faq.html:110
 msgid ""
-"XUL (XML User Interface Language) is Mozilla's XML-based language that lets "
-"you build feature-rich cross platform applications. It provides user "
-"interface widgets like buttons, menus, toolbars, trees, etc that can be used"
-" to enhance add-ons by modifying parts of the browser UI."
+"XUL (XML User Interface Language) is Mozilla's XML-based language that lets you build feature-rich cross platform applications. It provides user interface widgets like buttons, menus, toolbars, "
+"trees, etc that can be used to enhance add-ons by modifying parts of the browser UI."
 msgstr ""
-"XUL (XML-мова інтерфейсу користувача) це мова на основі Mozilla XML, яка "
-"дозволяє вам створювати кросплатформні додатки з розширеною "
-"функціональністю. Вона забезпечує віджети інтерфейсу користувача, такі як "
-"кнопки, меню, панелі інструментів, дерева, і т.д., які можуть "
-"використовуватися для збільшення можливостей додатків шляхом змінювання "
-"частин інтерфейсу браузера користувача."
+"XUL (XML-мова інтерфейсу користувача) це мова на основі Mozilla XML, яка дозволяє вам створювати кросплатформні додатки з розширеною функціональністю. Вона забезпечує віджети інтерфейсу "
+"користувача, такі як кнопки, меню, панелі інструментів, дерева, і т.д., які можуть використовуватися для збільшення можливостей додатків шляхом змінювання частин інтерфейсу браузера користувача."
 
 #: src/olympia/pages/templates/pages/dev_faq.html:119
 msgid "What is the \"install.rdf\" file used for?"
@@ -12206,34 +9668,21 @@ msgstr "Для чого використовується файл \"install.rdf\
 #: src/olympia/pages/templates/pages/dev_faq.html:121
 #, python-format
 msgid ""
-"This file, called an <a href=\"%(url)s\">Install Manifest</a>, is used by "
-"Add-on Manager-enabled XUL applications to determine information about an "
-"add-on as it is being installed. It contains metadata identifying the add-"
-"on, providing information about who created it, where more information can "
-"be found about it, which versions of what applications it is compatible "
-"with, how it should be updated, and so on. The format of the Install "
-"Manifest is RDF/XML."
+"This file, called an <a href=\"%(url)s\">Install Manifest</a>, is used by Add-on Manager-enabled XUL applications to determine information about an add-on as it is being installed. It contains "
+"metadata identifying the add-on, providing information about who created it, where more information can be found about it, which versions of what applications it is compatible with, how it should "
+"be updated, and so on. The format of the Install Manifest is RDF/XML."
 msgstr ""
-"Цей файл, що називається <a href=\"%(url)s\">Маніфестом встановлення</a>, "
-"використовується програмами XUL з Менеджером додатків, задля отримання "
-"інформації про додаток в процесі його встановлення. Він містить метадані, "
-"які ідентифікують додаток, надають інформацію про його автора, про те, де "
-"можна знайти більше інформації про нього, з якими версіями програм воно "
-"сумісно, як його треба оновлювати, і так далі. Форматом файлу маніфесту "
-"встановлення є RDF/XML."
+"Цей файл, що називається <a href=\"%(url)s\">Маніфестом встановлення</a>, використовується програмами XUL з Менеджером додатків, задля отримання інформації про додаток в процесі його встановлення. "
+"Він містить метадані, які ідентифікують додаток, надають інформацію про його автора, про те, де можна знайти більше інформації про нього, з якими версіями програм воно сумісно, як його треба "
+"оновлювати, і так далі. Форматом файлу маніфесту встановлення є RDF/XML."
 
 #: src/olympia/pages/templates/pages/dev_faq.html:132
 msgid "What does \"maxVersion\" mean?"
 msgstr "Що значить \"maxVersion\"?"
 
 #: src/olympia/pages/templates/pages/dev_faq.html:134
-msgid ""
-"This determines the maximum version of Firefox you're saying this extension "
-"will work with. Set this to be no newer than the newest currently available "
-"version!"
-msgstr ""
-"Це визначає максимальну версію Firefox, з якої, як ви кажете, буде працювати"
-" це розширення. Встановіть її значення не вище, ніж номер найновішої версії!"
+msgid "This determines the maximum version of Firefox you're saying this extension will work with. Set this to be no newer than the newest currently available version!"
+msgstr "Це визначає максимальну версію Firefox, з якої, як ви кажете, буде працювати це розширення. Встановіть її значення не вище, ніж номер найновішої версії!"
 
 #: src/olympia/pages/templates/pages/dev_faq.html:141
 msgid "Can my add-on contain binary components?"
@@ -12241,43 +9690,25 @@ msgstr "Чи може мій додаток містити бінарні ком
 
 #: src/olympia/pages/templates/pages/dev_faq.html:143
 #, python-format
-msgid ""
-"Yes. You can use Mozilla's <a href=\"%(url)s\">XPCOM component object "
-"model</a> to enhance your add-ons. XPCOM components be used and implemented "
-"in JavaScript, Java, and Python in addition to C++."
+msgid "Yes. You can use Mozilla's <a href=\"%(url)s\">XPCOM component object model</a> to enhance your add-ons. XPCOM components be used and implemented in JavaScript, Java, and Python in addition to C++."
 msgstr ""
-"Так. Ви можете використовувати <a href=\"%(url)s\">об'єктну модель "
-"компоненту XPCOM</a> Mozilla для покращення ваших додатків. Окрім C++, XPCOM"
-" компоненти використовуються й розробляются на JavaScript, Java та Python."
+"Так. Ви можете використовувати <a href=\"%(url)s\">об'єктну модель компоненту XPCOM</a> Mozilla для покращення ваших додатків. Окрім C++, XPCOM компоненти використовуються й розробляются на "
+"JavaScript, Java та Python."
 
 #: src/olympia/pages/templates/pages/dev_faq.html:150
-msgid ""
-"Can I use a JavaScript library like jQuery, MooTools or Prototype to build "
-"my add-on?"
-msgstr ""
-"Чи можу я для створення свого додатку використовувати бібліотеку JavaScript "
-"на зразок jQuery, MooTools чи Prototype?"
+msgid "Can I use a JavaScript library like jQuery, MooTools or Prototype to build my add-on?"
+msgstr "Чи можу я для створення свого додатку використовувати бібліотеку JavaScript на зразок jQuery, MooTools чи Prototype?"
 
 #: src/olympia/pages/templates/pages/dev_faq.html:152
 msgid ""
-"Yes. It's possible, but some of the functionality provided by these "
-"libraries are available through XPCOM, XUL, and JavaScript. In addition, "
-"authors should take care if libraries modify primitive object prototypes "
-"(String.prototype, Date.prototype, etc.) and/or define global functions (eg."
-" the $ function). These are prone to cause conflict with other add-ons, in "
-"particular if different add-ons use different versions of libraries and so "
-"on. Developers need to be very, very careful with using them. Mozilla does "
-"not offer documentation on using them to build add-ons."
+"Yes. It's possible, but some of the functionality provided by these libraries are available through XPCOM, XUL, and JavaScript. In addition, authors should take care if libraries modify primitive "
+"object prototypes (String.prototype, Date.prototype, etc.) and/or define global functions (eg. the $ function). These are prone to cause conflict with other add-ons, in particular if different add-"
+"ons use different versions of libraries and so on. Developers need to be very, very careful with using them. Mozilla does not offer documentation on using them to build add-ons."
 msgstr ""
-"Так. Це можливо, але деякі з функцій, забезпечувані цими бібліотеками, "
-"доступні через XPCOM, XUL і JavaScript. Крім того, автори повинні бути "
-"обережні у випадку, якщо бібліотеки змінюють прототипи примітивних об'єктів "
-"(String.prototype, Date.prototype і т.д.) і / або визначають глобальні "
-"функції (напр. $ функцію). Подібна поведінка схильна викликати конфлікт з "
-"іншими додатками, особливо якщо різні додатки використовують різні версії "
-"бібліотек і так далі. Розробники повинні бути дуже, дуже обережні при їх "
-"використанні. Mozilla не надає документацію щодо їх використання для "
-"створення додатків."
+"Так. Це можливо, але деякі з функцій, забезпечувані цими бібліотеками, доступні через XPCOM, XUL і JavaScript. Крім того, автори повинні бути обережні у випадку, якщо бібліотеки змінюють прототипи "
+"примітивних об'єктів (String.prototype, Date.prototype і т.д.) і / або визначають глобальні функції (напр. $ функцію). Подібна поведінка схильна викликати конфлікт з іншими додатками, особливо якщо"
+" різні додатки використовують різні версії бібліотек і так далі. Розробники повинні бути дуже, дуже обережні при їх використанні. Mozilla не надає документацію щодо їх використання для створення "
+"додатків."
 
 #: src/olympia/pages/templates/pages/dev_faq.html:165
 msgid "How do I debug my add-on?"
@@ -12289,32 +9720,19 @@ msgid "You can use the <a href=\"%(url)s\">Add-on Debugger</a>."
 msgstr "Ви можете скористатись <a href=\"%(url)s\">зневаджувачем додатків</a>."
 
 #: src/olympia/pages/templates/pages/dev_faq.html:172
-msgid ""
-"How do I test for compatibility with the latest version of Mozilla software?"
-msgstr ""
-"Як мені перевірити сумісність з останньою версією програмного забезпечення "
-"Mozilla?"
+msgid "How do I test for compatibility with the latest version of Mozilla software?"
+msgstr "Як мені перевірити сумісність з останньою версією програмного забезпечення Mozilla?"
 
 #: src/olympia/pages/templates/pages/dev_faq.html:174
 msgid ""
-"To ensure compatibility with the latest Mozilla software, it's important to "
-"download updates as they become available and test your add-on to ensure "
-"that it is still functioning as expected. In many cases, the latest version "
-"of Mozilla software may be a beta release. Since these releases at times "
-"introduce architectural changes that may impact the functionality of your "
-"add-on, it's important to be actively involved in the beta process to ensure"
-" that your add-on users are not negatively impacted upon final release of "
-"Mozilla software."
+"To ensure compatibility with the latest Mozilla software, it's important to download updates as they become available and test your add-on to ensure that it is still functioning as expected. In "
+"many cases, the latest version of Mozilla software may be a beta release. Since these releases at times introduce architectural changes that may impact the functionality of your add-on, it's "
+"important to be actively involved in the beta process to ensure that your add-on users are not negatively impacted upon final release of Mozilla software."
 msgstr ""
-"Щоб переконатися в сумісності з останньою версією програмного забезпечення "
-"Mozilla, важливо завантажувати оновлення, як тільки вони стають доступними, "
-"і тестувати додаток для впевненості в тому, що він працює належним чином. В "
-"багатьох випадках остання версія програмного забезпечення Mozilla може бути "
-"випуском бета. Так як ці випуски представляють технічні зміни, які можуть "
-"впливати на функціональність вашого додатку, важливо брати активну участь в "
-"процесі їх тестування для переконання в тому, що користувачі вашого додатку "
-"не зіткнуться з проблемами після випуску фінальної версії програмного "
-"забезпечення Mozilla."
+"Щоб переконатися в сумісності з останньою версією програмного забезпечення Mozilla, важливо завантажувати оновлення, як тільки вони стають доступними, і тестувати додаток для впевненості в тому, що"
+" він працює належним чином. В багатьох випадках остання версія програмного забезпечення Mozilla може бути випуском бета. Так як ці випуски представляють технічні зміни, які можуть впливати на "
+"функціональність вашого додатку, важливо брати активну участь в процесі їх тестування для переконання в тому, що користувачі вашого додатку не зіткнуться з проблемами після випуску фінальної версії"
+" програмного забезпечення Mozilla."
 
 #: src/olympia/pages/templates/pages/dev_faq.html:185
 msgid "How to improve the performance of my add-on?"
@@ -12323,17 +9741,11 @@ msgstr "Як покращити швидкодію свого додатку?"
 #: src/olympia/pages/templates/pages/dev_faq.html:187
 #, python-format
 msgid ""
-"Poorly written extensions can have a severe impact on the browsing "
-"experience, including on the overall performance of Firefox itself. The "
-"following page contains many good <a href=\"%(url)s\">guides</a> that help "
-"you improve performance, whether you're developing core Mozilla code or an "
-"add-on."
+"Poorly written extensions can have a severe impact on the browsing experience, including on the overall performance of Firefox itself. The following page contains many good <a "
+"href=\"%(url)s\">guides</a> that help you improve performance, whether you're developing core Mozilla code or an add-on."
 msgstr ""
-"Погано написане розширення може мати серйозний вплив на роботу браузера, "
-"включаючи загальну швидкодію Firefox. Наступна сторінка містить багато "
-"хороших <a href=\"%(url)s\">інструкцій</a>, які допоможуть вам покращити "
-"швидкодію, чи-то ви займаєтесь розробкою ключового коду Mozilla, чи-то "
-"додатку."
+"Погано написане розширення може мати серйозний вплив на роботу браузера, включаючи загальну швидкодію Firefox. Наступна сторінка містить багато хороших <a href=\"%(url)s\">інструкцій</a>, які "
+"допоможуть вам покращити швидкодію, чи-то ви займаєтесь розробкою ключового коду Mozilla, чи-то додатку."
 
 #: src/olympia/pages/templates/pages/dev_faq.html:195
 msgid "Can my add-on support multiple locales?"
@@ -12342,20 +9754,15 @@ msgstr "Чи може мій додаток підтримувати декіл�
 #: src/olympia/pages/templates/pages/dev_faq.html:197
 #, python-format
 msgid ""
-"Yes. Details on localizing your add-on can be found in the the <a "
-"href=\"%(l10n_url)s\">Mozilla Developer Network Localization page</a>. <a "
-"href=\"%(bz_url)s\">The BabelZilla project</a> is also a great resource for "
-"learning about localization and volunteering to help translate add-ons."
+"Yes. Details on localizing your add-on can be found in the the <a href=\"%(l10n_url)s\">Mozilla Developer Network Localization page</a>. <a href=\"%(bz_url)s\">The BabelZilla project</a> is also a "
+"great resource for learning about localization and volunteering to help translate add-ons."
 msgstr ""
-"Так. Докладні відомості з локалізації вашого додатку можна знайти на <a "
-"href=\"%(l10n_url)s\">сторінці з локалізації Мережі Розробників Mozilla</a>."
-" <a href=\"%(bz_url)s\">проект BabelZilla</a> також є чудовим ресурсом для "
-"вивчення локалізації та допомоги з перекладом додатків."
+"Так. Докладні відомості з локалізації вашого додатку можна знайти на <a href=\"%(l10n_url)s\">сторінці з локалізації Мережі Розробників Mozilla</a>. <a href=\"%(bz_url)s\">проект BabelZilla</a> "
+"також є чудовим ресурсом для вивчення локалізації та допомоги з перекладом додатків."
 
 #: src/olympia/pages/templates/pages/dev_faq.html:210
 msgid "I need some advice building my add-on. Where can I find help?"
-msgstr ""
-"Мені потрібна порада щодо створення додатку. Де я можу знайти допомогу?"
+msgstr "Мені потрібна порада щодо створення додатку. Де я можу знайти допомогу?"
 
 #. #extdev is the name of the IRC channel.  do not change.
 #: src/olympia/pages/templates/pages/dev_faq.html:216
@@ -12369,12 +9776,8 @@ msgstr "#amo (для підтримки з питань розміщення в�
 
 #. #jetpack is the name of the IRC channel.  do not change.
 #: src/olympia/pages/templates/pages/dev_faq.html:220
-msgid ""
-"#jetpack (for discussions about the Add-ons SDK and cfx/jpm - formerly known"
-" as Jetpack)"
-msgstr ""
-"#jetpack (для обговорення з питань SDK додатку та cfx/jpm - раніше відомого "
-"як Jetpack)"
+msgid "#jetpack (for discussions about the Add-ons SDK and cfx/jpm - formerly known as Jetpack)"
+msgstr "#jetpack (для обговорення з питань SDK додатку та cfx/jpm - раніше відомого як Jetpack)"
 
 #. Label for a link to the extension developers mailing list
 #: src/olympia/pages/templates/pages/dev_faq.html:225
@@ -12409,23 +9812,16 @@ msgstr "Ні."
 
 #: src/olympia/pages/templates/pages/dev_faq.html:246
 msgid "Are there 3rd party developers that I can hire to build my add-on?"
-msgstr ""
-"Чи є сторонні розробники, яких я можу найняти для створення свого додатку?"
+msgstr "Чи є сторонні розробники, яких я можу найняти для створення свого додатку?"
 
 #: src/olympia/pages/templates/pages/dev_faq.html:248
 #, python-format
 msgid ""
-"Yes. You may find 3rd party developers via the <a href=\"%(forum_url)s"
-"\">Add-ons forum</a>, <a href=\"%(list_url)s\">mozilla.jobs list</a>, <a "
-"href=\"%(mz_url)s\">mozillaZine forums</a> or <a href=\"%(wiki_url)s\">the "
-"Mozilla Wiki</a>. Please note that Mozilla does not offer developer "
-"recommendations."
+"Yes. You may find 3rd party developers via the <a href=\"%(forum_url)s\">Add-ons forum</a>, <a href=\"%(list_url)s\">mozilla.jobs list</a>, <a href=\"%(mz_url)s\">mozillaZine forums</a> or <a "
+"href=\"%(wiki_url)s\">the Mozilla Wiki</a>. Please note that Mozilla does not offer developer recommendations."
 msgstr ""
-"Так. Ви можете знайти сторонніх розробників через <a "
-"href=\"%(forum_url)s\">форум додатків</a>, <a href=\"%(list_url)s\">список "
-"mozilla.jobs</a>, <a href=\"%(mz_url)s\">форуми mozillaZine</a> або <a "
-"href=\"%(wiki_url)s\">Mozilla Wiki</a>. Зауважте, що Mozilla не пропонує "
-"рекомендації розробників."
+"Так. Ви можете знайти сторонніх розробників через <a href=\"%(forum_url)s\">форум додатків</a>, <a href=\"%(list_url)s\">список mozilla.jobs</a>, <a href=\"%(mz_url)s\">форуми mozillaZine</a> або "
+"<a href=\"%(wiki_url)s\">Mozilla Wiki</a>. Зауважте, що Mozilla не пропонує рекомендації розробників."
 
 #: src/olympia/pages/templates/pages/dev_faq.html:263
 msgid "Can I host my own add-on?"
@@ -12434,22 +9830,13 @@ msgstr "Чи можу я розмістити власний додаток?"
 #: src/olympia/pages/templates/pages/dev_faq.html:265
 #, python-format
 msgid ""
-"Yes. Many developers choose to host their own add-ons. Choosing to host your"
-" add-on on <a href=\"%(amo_url)s\">Mozilla's add-on site</a>, though, allows"
-" for much greater exposure to your add-on due to the large volume of "
-"visitors to the site. <a href=\"%(md_url)s\">mozdev.org</a> offers free "
-"project hosting for Mozilla applications and extensions providing developers"
-" with tools to help manage source code, version control, bug tracking and "
-"documentation."
+"Yes. Many developers choose to host their own add-ons. Choosing to host your add-on on <a href=\"%(amo_url)s\">Mozilla's add-on site</a>, though, allows for much greater exposure to your add-on due"
+" to the large volume of visitors to the site. <a href=\"%(md_url)s\">mozdev.org</a> offers free project hosting for Mozilla applications and extensions providing developers with tools to help "
+"manage source code, version control, bug tracking and documentation."
 msgstr ""
-"Так. Багато розробників надають перевагу розміщенню своїх додатків. Обираючи"
-" для розміщення <a href=\"%(amo_url)s\">сайт додатків Mozilla</a>, ви "
-"отримуєте можливість запропонувати свій додаток значно ширшому колу "
-"користувачів, у зв'язку з великою кількістю відвідувачів цього сайту. <a "
-"href=\"%(md_url)s\">mozdev.org</a> надає безкоштовне розміщення для додатків"
-" і розширень Mozilla, допомагає розробникам, забезпечуючи їх інструментами "
-"для управління програмним кодом, контролю версій, відстеження помилок, а "
-"також документацією."
+"Так. Багато розробників надають перевагу розміщенню своїх додатків. Обираючи для розміщення <a href=\"%(amo_url)s\">сайт додатків Mozilla</a>, ви отримуєте можливість запропонувати свій додаток "
+"значно ширшому колу користувачів, у зв'язку з великою кількістю відвідувачів цього сайту. <a href=\"%(md_url)s\">mozdev.org</a> надає безкоштовне розміщення для додатків і розширень Mozilla, "
+"допомагає розробникам, забезпечуючи їх інструментами для управління програмним кодом, контролю версій, відстеження помилок, а також документацією."
 
 #: src/olympia/pages/templates/pages/dev_faq.html:277
 msgid "Can Mozilla host my add-on?"
@@ -12457,12 +9844,8 @@ msgstr "Чи може Mozilla розмістити мій додаток?"
 
 #: src/olympia/pages/templates/pages/dev_faq.html:279
 #, python-format
-msgid ""
-"Yes. You can host your add-on on <a href=\"%(url)s\">Mozilla's add-on "
-"website</a>."
-msgstr ""
-"Так. Ви можете розмістити свій додаток на <a href=\"%(url)s\">веб-сайті "
-"додатків Mozilla</a>."
+msgid "Yes. You can host your add-on on <a href=\"%(url)s\">Mozilla's add-on website</a>."
+msgstr "Так. Ви можете розмістити свій додаток на <a href=\"%(url)s\">веб-сайті додатків Mozilla</a>."
 
 #: src/olympia/pages/templates/pages/dev_faq.html:284
 msgid "What is AMO?"
@@ -12470,19 +9853,11 @@ msgstr "Що таке AMO?"
 
 #: src/olympia/pages/templates/pages/dev_faq.html:286
 msgid ""
-"Mozilla's AMO (<a "
-"href=\"https://addons.mozilla.org\">https://addons.mozilla.org</a>) is the "
-"incubator that helps developers build, distribute, and support fantastic "
-"consumer products powered by Mozilla. It provides you the tools and "
-"infrastructure necessary to manage, host and expose your add-on to a massive"
-" base of Mozilla users."
+"Mozilla's AMO (<a href=\"https://addons.mozilla.org\">https://addons.mozilla.org</a>) is the incubator that helps developers build, distribute, and support fantastic consumer products powered by "
+"Mozilla. It provides you the tools and infrastructure necessary to manage, host and expose your add-on to a massive base of Mozilla users."
 msgstr ""
-"Mozilla AMO (<a "
-"href=\"https://addons.mozilla.org\">https://addons.mozilla.org</a>) є "
-"місцем, яке допомагає розробникам створювати, поширювати та підтримувати "
-"неймовірні продукти за підтримки Mozilla. Тут вам надаються інструменти та "
-"інфраструктура, необхідна для керування, розміщення та поширення ваших "
-"додатків широкому колу користувачів Mozilla."
+"Mozilla AMO (<a href=\"https://addons.mozilla.org\">https://addons.mozilla.org</a>) є місцем, яке допомагає розробникам створювати, поширювати та підтримувати неймовірні продукти за підтримки "
+"Mozilla. Тут вам надаються інструменти та інфраструктура, необхідна для керування, розміщення та поширення ваших додатків широкому колу користувачів Mozilla."
 
 #: src/olympia/pages/templates/pages/dev_faq.html:295
 msgid "Does Mozilla keep my account information private?"
@@ -12490,12 +9865,8 @@ msgstr "Чи зберігає Mozilla інформацію мого обліко
 
 #: src/olympia/pages/templates/pages/dev_faq.html:297
 #, python-format
-msgid ""
-"Yes. Our <a href=\"%(url)s\">Privacy Policy</a> describes how your "
-"information is managed by Mozilla."
-msgstr ""
-"Так. Наша <a href=\"%(url)s\">політика приватності</a> описує, яким чином "
-"Mozilla обробляє вашу інформацію."
+msgid "Yes. Our <a href=\"%(url)s\">Privacy Policy</a> describes how your information is managed by Mozilla."
+msgstr "Так. Наша <a href=\"%(url)s\">політика приватності</a> описує, яким чином Mozilla обробляє вашу інформацію."
 
 #: src/olympia/pages/templates/pages/dev_faq.html:302
 msgid "What are the \"developer tools\" listed on AMO?"
@@ -12503,35 +9874,24 @@ msgstr "Що таке \"інструменти розробника\", пере�
 
 #: src/olympia/pages/templates/pages/dev_faq.html:304
 msgid ""
-"The \"Developer Tools\" dashboard is the area that provides you the tools to"
-" successfully manage your add-ons. It provides the functionality necessary "
-"to submit your add-ons to AMO, manage add-on information, and review "
-"statistics."
+"The \"Developer Tools\" dashboard is the area that provides you the tools to successfully manage your add-ons. It provides the functionality necessary to submit your add-ons to AMO, manage add-on "
+"information, and review statistics."
 msgstr ""
-"Панель \"Інструменти розробника\" - це область, яка надає вам інструменти "
-"для успішного управління вашими додатками. Вона забезпечує функціональність,"
-" необхідну для представлення ваших додатків на АМО, управління інформацією "
-"про додаток і статистикою відгуків."
+"Панель \"Інструменти розробника\" - це область, яка надає вам інструменти для успішного управління вашими додатками. Вона забезпечує функціональність, необхідну для представлення ваших додатків на "
+"АМО, управління інформацією про додаток і статистикою відгуків."
 
 #: src/olympia/pages/templates/pages/dev_faq.html:312
-msgid ""
-"Does Mozilla have a policy in place as to what is an acceptable submission?"
+msgid "Does Mozilla have a policy in place as to what is an acceptable submission?"
 msgstr "Чи має Mozilla політику, яка визначає, що є прийнятним поданням?"
 
 #: src/olympia/pages/templates/pages/dev_faq.html:314
 #, python-format
 msgid ""
-"Yes. Mozilla's <a href=\"%(p_url)s\">Add-on Policy</a> describes what is an "
-"acceptable submission. This policy is subject to change without notice. In "
-"addition, the AMO editorial team uses the <a href=\"%(g_url)s\">Editors "
-"Reviewing Guide</a> to ensure that your add-on meets specific guidelines for"
-" functionality and security."
+"Yes. Mozilla's <a href=\"%(p_url)s\">Add-on Policy</a> describes what is an acceptable submission. This policy is subject to change without notice. In addition, the AMO editorial team uses the <a "
+"href=\"%(g_url)s\">Editors Reviewing Guide</a> to ensure that your add-on meets specific guidelines for functionality and security."
 msgstr ""
-"Так. <a href=\"%(p_url)s\">Політика додатків Mozilla</a> описує, що є "
-"прийнятним поданням. Ця політика може бути змінена без попереднього "
-"повідомлення. Крім того, група редакторів АМО використовує <a "
-"href=\"%(g_url)s\">Інстрікцію редакторів з перевірки</a>, щоб переконатися, "
-"що ваш додаток відповідає специфічним вимогам з функціональності й безпеки."
+"Так. <a href=\"%(p_url)s\">Політика додатків Mozilla</a> описує, що є прийнятним поданням. Ця політика може бути змінена без попереднього повідомлення. Крім того, група редакторів АМО використовує "
+"<a href=\"%(g_url)s\">Інстрікцію редакторів з перевірки</a>, щоб переконатися, що ваш додаток відповідає специфічним вимогам з функціональності й безпеки."
 
 #: src/olympia/pages/templates/pages/dev_faq.html:324
 msgid "How do I submit my add-on for review?"
@@ -12540,30 +9900,20 @@ msgstr "Як мені подати мій додаток на перевірку
 #: src/olympia/pages/templates/pages/dev_faq.html:326
 #, python-format
 msgid ""
-"The Developer Tools dashboard will allow you to upload and submit add-ons to"
-" AMO. You must be a registered AMO users before you can submit an add-on. "
-"Before submitting your add-on be sure to you have read the AMO <a "
-"href=\"%(url)s\">Editors Reviewing Guide</a> to ensure that your add-on has "
-"met the guidelines used by editors to review add-ons."
+"The Developer Tools dashboard will allow you to upload and submit add-ons to AMO. You must be a registered AMO users before you can submit an add-on. Before submitting your add-on be sure to you "
+"have read the AMO <a href=\"%(url)s\">Editors Reviewing Guide</a> to ensure that your add-on has met the guidelines used by editors to review add-ons."
 msgstr ""
-"Панель Інструментів розробника дозволяє вам завантажувати і представляти "
-"додатки на АМО. Перед тим, як ви зможете подати додаток на АМО, ви повинні "
-"на ньому зареєструватися. Перед поданням вашого додатка обов'язково "
-"прочитайте <a href=\"%(url)s\">Інструкцію редакторів АМО з перевірки</a>, "
-"щоб переконатися, що ваш додаток відповідає вимогам, які використовують "
-"редактори під час перевірки додатків."
+"Панель Інструментів розробника дозволяє вам завантажувати і представляти додатки на АМО. Перед тим, як ви зможете подати додаток на АМО, ви повинні на ньому зареєструватися. Перед поданням вашого "
+"додатка обов'язково прочитайте <a href=\"%(url)s\">Інструкцію редакторів АМО з перевірки</a>, щоб переконатися, що ваш додаток відповідає вимогам, які використовують редактори під час перевірки "
+"додатків."
 
 #: src/olympia/pages/templates/pages/dev_faq.html:336
 msgid "What operating system do I choose for my add-on?"
 msgstr "Яку операційну систему мені вибрати для мого додатку?"
 
 #: src/olympia/pages/templates/pages/dev_faq.html:338
-msgid ""
-"You must choose the operating systems on which your add-on will successfully"
-" function."
-msgstr ""
-"Ви повинні вибрати операційні системи, на яких ваш додаток буде успішно "
-"функціонувати."
+msgid "You must choose the operating systems on which your add-on will successfully function."
+msgstr "Ви повинні вибрати операційні системи, на яких ваш додаток буде успішно функціонувати."
 
 #: src/olympia/pages/templates/pages/dev_faq.html:344
 msgid "What category do I choose for my add-on?"
@@ -12571,57 +9921,37 @@ msgstr "Яку категорію мені вибрати для мого дод
 
 #: src/olympia/pages/templates/pages/dev_faq.html:346
 msgid ""
-"The choice of category is dependent on what type of audience you are "
-"targeting and the functionality of your add-on. If you're unsure of which "
-"category your add-on falls into, please choose \"Other\". The AMO team may "
-"re-categorize your add-on if it's determined that it's better suited in a "
-"different category."
+"The choice of category is dependent on what type of audience you are targeting and the functionality of your add-on. If you're unsure of which category your add-on falls into, please choose "
+"\"Other\". The AMO team may re-categorize your add-on if it's determined that it's better suited in a different category."
 msgstr ""
-"Вибір категорії залежить від типу вашої цільової аудиторії і "
-"функціональності вашого додатка. Якщо ви не впевнені, під яку категорію "
-"підпадає ваш додаток, будь ласка, виберіть \"Інше\". Команда АМО може в "
-"подальшому змінити категорію вашого додатка, якщо буде очевидно, що він "
-"більше підходить до іншої категорії."
+"Вибір категорії залежить від типу вашої цільової аудиторії і функціональності вашого додатка. Якщо ви не впевнені, під яку категорію підпадає ваш додаток, будь ласка, виберіть \"Інше\". Команда АМО"
+" може в подальшому змінити категорію вашого додатка, якщо буде очевидно, що він більше підходить до іншої категорії."
 
 #: src/olympia/pages/templates/pages/dev_faq.html:355
 msgid "What does \"nominating\" my add-on mean?"
 msgstr "Що означає \"номінація\" мого додатку?"
 
 #: src/olympia/pages/templates/pages/dev_faq.html:357
-msgid ""
-"Nominated add-ons are new add-ons that the author has nominated to become "
-"public via the Developer Tools."
-msgstr ""
-"Номіновані додатки це нові додатки, номіновані автором для публічного "
-"представлення через Інструменти розробника."
+msgid "Nominated add-ons are new add-ons that the author has nominated to become public via the Developer Tools."
+msgstr "Номіновані додатки це нові додатки, номіновані автором для публічного представлення через Інструменти розробника."
 
 #: src/olympia/pages/templates/pages/dev_faq.html:363
 msgid "Can I specify a license agreement for using my add-on?"
 msgstr "Чи можу я вказати ліцензійну угоду на використання мого додатка?"
 
 #: src/olympia/pages/templates/pages/dev_faq.html:365
-msgid ""
-"Yes. You can specify a license agreement when submitting your add-on. You "
-"can also add or update a license agreement via the Developer Tools dashboard"
-" after your add-on has been submitted."
-msgstr ""
-"Так. Ви можете вказати ліцензійну угоду під час подання вашого додатка. Ви "
-"також можете додати або оновити ліцензійну угоду через панель Інструментів "
-"Розробника після представлення вашого додатка."
+msgid "Yes. You can specify a license agreement when submitting your add-on. You can also add or update a license agreement via the Developer Tools dashboard after your add-on has been submitted."
+msgstr "Так. Ви можете вказати ліцензійну угоду під час подання вашого додатка. Ви також можете додати або оновити ліцензійну угоду через панель Інструментів Розробника після представлення вашого додатка."
 
 #: src/olympia/pages/templates/pages/dev_faq.html:372
 msgid "Can I include a privacy policy for my add-on?"
 msgstr "Чи можу я включити для мого додатка політику приватності?"
 
 #: src/olympia/pages/templates/pages/dev_faq.html:374
-msgid ""
-"Yes. You can specify a privacy policy when submitting your add-on. You can "
-"also add or update a privacy policy via the Developer Tools dashboard after "
-"your add-on has been submitted."
+msgid "Yes. You can specify a privacy policy when submitting your add-on. You can also add or update a privacy policy via the Developer Tools dashboard after your add-on has been submitted."
 msgstr ""
-"Так. Ви можете вказати політику приватності під час подання вашого додатка. "
-"Ви також можете додати або оновити політику приватності через панель "
-"Інструментів Розробника після представлення вашого додатка."
+"Так. Ви можете вказати політику приватності під час подання вашого додатка. Ви також можете додати або оновити політику приватності через панель Інструментів Розробника після представлення вашого "
+"додатка."
 
 #: src/olympia/pages/templates/pages/dev_faq.html:383
 msgid "Why must my add-on be reviewed?"
@@ -12630,15 +9960,11 @@ msgstr "Чому мій додаток повинен бути перевіре�
 #: src/olympia/pages/templates/pages/dev_faq.html:385
 #, python-format
 msgid ""
-"All add-ons submitted, whether new or updated, are reviewed to ensure that "
-"Mozilla users have a stable and safe experience. All add-ons submissions are"
-" reviewed using the guidelines outlined in the <a href=\"%(url)s\">Editors "
-"Reviewing Guide</a>."
+"All add-ons submitted, whether new or updated, are reviewed to ensure that Mozilla users have a stable and safe experience. All add-ons submissions are reviewed using the guidelines outlined in the"
+" <a href=\"%(url)s\">Editors Reviewing Guide</a>."
 msgstr ""
-"Всі представлені додатки, як нові так і оновлені, піддаються перевірці, щоб "
-"переконатися в їх стабільній і безпечній роботі для користувачів Mozilla. "
-"Всі представлені додатки перевіряються відповідно до принципів, викладених в"
-" <a href=\"%(url)s\">Інструкції редакторів з перевірки</a>."
+"Всі представлені додатки, як нові так і оновлені, піддаються перевірці, щоб переконатися в їх стабільній і безпечній роботі для користувачів Mozilla. Всі представлені додатки перевіряються "
+"відповідно до принципів, викладених в <a href=\"%(url)s\">Інструкції редакторів з перевірки</a>."
 
 #: src/olympia/pages/templates/pages/dev_faq.html:393
 msgid "Who reviews my add-on?"
@@ -12647,20 +9973,13 @@ msgstr "Хто перевіряє мій додаток?"
 #: src/olympia/pages/templates/pages/dev_faq.html:395
 #, python-format
 msgid ""
-"Add-ons are reviewed by the AMO Editors, a group of talented developers that"
-" volunteer to help the Mozilla project by reviewing add-ons to ensure a "
-"stable and safe experience for Mozilla users. When communicating with "
-"editors, please be courteous, patient and respectful as they are working "
-"hard to ensure that your add-on is set up correctly and follows the "
-"guidelines outlined in the <a href=\"%(url)s\">Editors Reviewing Guide</a>."
+"Add-ons are reviewed by the AMO Editors, a group of talented developers that volunteer to help the Mozilla project by reviewing add-ons to ensure a stable and safe experience for Mozilla users. "
+"When communicating with editors, please be courteous, patient and respectful as they are working hard to ensure that your add-on is set up correctly and follows the guidelines outlined in the <a "
+"href=\"%(url)s\">Editors Reviewing Guide</a>."
 msgstr ""
-"Додатки перевіряються редакторами АМО - групою талановитих розробників, які "
-"добровільно допомагають проекту Mozilla у перевірці додатків, щоб "
-"забезпечити стабільну і безпечну роботу користувачів Mozilla. Під час "
-"спілкування з редакторами, будьте ввічливі, терплячі і поважні, тому що вони"
-" наполегливо працюють над тим, щоб упевнитися, що ваш додаток працює "
-"правильно і відповідає принципам, викладеним в <a "
-"href=\"%(url)s\">Інструкції редакторів з перевірки</a>."
+"Додатки перевіряються редакторами АМО - групою талановитих розробників, які добровільно допомагають проекту Mozilla у перевірці додатків, щоб забезпечити стабільну і безпечну роботу користувачів "
+"Mozilla. Під час спілкування з редакторами, будьте ввічливі, терплячі і поважні, тому що вони наполегливо працюють над тим, щоб упевнитися, що ваш додаток працює правильно і відповідає принципам, "
+"викладеним в <a href=\"%(url)s\">Інструкції редакторів з перевірки</a>."
 
 #: src/olympia/pages/templates/pages/dev_faq.html:406
 msgid "What are the guidelines used to review my add-on?"
@@ -12669,29 +9988,19 @@ msgstr "Які критерії використовуються для пере
 #: src/olympia/pages/templates/pages/dev_faq.html:408
 #, python-format
 msgid ""
-"The Mozilla editorial team follows the <a href=\"%(url)s\">Editors Reviewing"
-" Guide</a> when testing an add-on for acceptance onto AMO. It is important "
-"that add-on developers review this guide to ensure that common problem areas"
-" are addressed prior to submitting their add-on for review. This will "
-"greatly assist in expediting the review process."
+"The Mozilla editorial team follows the <a href=\"%(url)s\">Editors Reviewing Guide</a> when testing an add-on for acceptance onto AMO. It is important that add-on developers review this guide to "
+"ensure that common problem areas are addressed prior to submitting their add-on for review. This will greatly assist in expediting the review process."
 msgstr ""
-"Команда редакторів Mozilla керується <a href=\"%(url)s\">Інструкцією "
-"редакторів з перевірки</a> під час тестування додатка для розміщення на АМО."
-" Важливо, щоб розробники додатка переглянули цей посібник, щоб переконатися "
-"у відсутності у додатку типових проблем перед тим, як подавати його на "
-"перевірку. Це значно посприяє прискоренню процесу перевірки."
+"Команда редакторів Mozilla керується <a href=\"%(url)s\">Інструкцією редакторів з перевірки</a> під час тестування додатка для розміщення на АМО. Важливо, щоб розробники додатка переглянули цей "
+"посібник, щоб переконатися у відсутності у додатку типових проблем перед тим, як подавати його на перевірку. Це значно посприяє прискоренню процесу перевірки."
 
 #: src/olympia/pages/templates/pages/dev_faq.html:418
 msgid "How long will it take for my add-on to be reviewed?"
 msgstr "Скільки часу займе перевірка мого додатку?"
 
 #: src/olympia/pages/templates/pages/dev_faq.html:420
-msgid ""
-"We cannot give a time estimate as to how long it will take before an add-on "
-"is reviewed. Many factors affect the time including the:"
-msgstr ""
-"Ми не можемо обчислити час, за який додаток пройде перевірку. На тривалість "
-"перевірки впливають багато факторів, в тому числі:"
+msgid "We cannot give a time estimate as to how long it will take before an add-on is reviewed. Many factors affect the time including the:"
+msgstr "Ми не можемо обчислити час, за який додаток пройде перевірку. На тривалість перевірки впливають багато факторів, в тому числі:"
 
 #. part of a list (<li>)
 #: src/olympia/pages/templates/pages/dev_faq.html:427
@@ -12711,61 +10020,37 @@ msgstr "кількість виявлених проблемних зон"
 #: src/olympia/pages/templates/pages/dev_faq.html:434
 #, python-format
 msgid ""
-"This is why it's very important to read the <a href=\"%(g_url)s\">Editors "
-"Reviewing Guide</a> to ensure that your add-on is setup as expected. It's "
-"also a good idea to read the blog post, <a "
-"href=\"%(blog_url)s\">Successfully Getting your Add-on Reviewed</a> which "
-"provides excellent insight into ensuring a smooth review of your add-on."
+"This is why it's very important to read the <a href=\"%(g_url)s\">Editors Reviewing Guide</a> to ensure that your add-on is setup as expected. It's also a good idea to read the blog post, <a "
+"href=\"%(blog_url)s\">Successfully Getting your Add-on Reviewed</a> which provides excellent insight into ensuring a smooth review of your add-on."
 msgstr ""
-"Саме тому дуже важливо прочитати <a href=\"%(g_url)s\">Інструкцію редакторів"
-" з перевірки</a>, щоб переконатися, що ваш додаток налаштований належним "
-"чином. Також не зайвим буде прочитання допису в блозі, <a "
-"href=\"%(blog_url)s\">Як успішно пройти перевірку для вашого додатка</a>, в "
-"якому відмінно описано те, що потрібно зробити, щоб забезпечити безпроблемну"
-" перевірку для вашого додатка."
+"Саме тому дуже важливо прочитати <a href=\"%(g_url)s\">Інструкцію редакторів з перевірки</a>, щоб переконатися, що ваш додаток налаштований належним чином. Також не зайвим буде прочитання допису в "
+"блозі, <a href=\"%(blog_url)s\">Як успішно пройти перевірку для вашого додатка</a>, в якому відмінно описано те, що потрібно зробити, щоб забезпечити безпроблемну перевірку для вашого додатка."
 
 #: src/olympia/pages/templates/pages/dev_faq.html:446
 msgid "How can I see how many times my add-on has been downloaded?"
 msgstr "Як я можу побачити скільки разів був завантажений мій додаток?"
 
 #: src/olympia/pages/templates/pages/dev_faq.html:448
-msgid ""
-"The Statistics Dashboard found in the Developer Tools dashboard provides "
-"information that can help you determine your add-on downloads since you've "
-"submitted it to AMO."
-msgstr ""
-"Панель статистики, розміщена на панелі Інструментів розробника, надає "
-"інформацію, яка може допомогти вам визначити число завантажень вашого "
-"додатка з моменту його представлення на АМО."
+msgid "The Statistics Dashboard found in the Developer Tools dashboard provides information that can help you determine your add-on downloads since you've submitted it to AMO."
+msgstr "Панель статистики, розміщена на панелі Інструментів розробника, надає інформацію, яка може допомогти вам визначити число завантажень вашого додатка з моменту його представлення на АМО."
 
 #: src/olympia/pages/templates/pages/dev_faq.html:455
 msgid "How can I see how many active users are using my add-on?"
-msgstr ""
-"Як я можу побачити скільки активних користувачів використовують мій додаток?"
+msgstr "Як я можу побачити скільки активних користувачів використовують мій додаток?"
 
 #: src/olympia/pages/templates/pages/dev_faq.html:457
-msgid ""
-"The Statistics Dashboard found in the Developer Tools dashboard provides "
-"information that can help you determine how many users have been actively "
-"using your add-on since you've submitted it to AMO."
+msgid "The Statistics Dashboard found in the Developer Tools dashboard provides information that can help you determine how many users have been actively using your add-on since you've submitted it to AMO."
 msgstr ""
-"Панель статистики, розміщена на панелі Інструментів розробника, надає "
-"інформацію, яка може допомогти вам визначити число користувачів, які активно"
-" використовують ваш додаток з моменту його представлення на АМО."
+"Панель статистики, розміщена на панелі Інструментів розробника, надає інформацію, яка може допомогти вам визначити число користувачів, які активно використовують ваш додаток з моменту його "
+"представлення на АМО."
 
 #: src/olympia/pages/templates/pages/dev_faq.html:464
 msgid "How do I submit an update for my add-on?"
 msgstr "Як мені надіслати оновлення для мого додатку?"
 
 #: src/olympia/pages/templates/pages/dev_faq.html:466
-msgid ""
-"You can submit an update for your add-on via the Developer Tools dashboard "
-"by choosing the option \"Upload a new version\" and uploading a new .xpi "
-"file for your add-on."
-msgstr ""
-"Ви можете подати оновлення для вашого додатка через панель Інструментів "
-"розробника, вибравши опцію \"Завантажити нову версію\" і завантаживши новий "
-"файл вашого додатка з розширенням .xpi."
+msgid "You can submit an update for your add-on via the Developer Tools dashboard by choosing the option \"Upload a new version\" and uploading a new .xpi file for your add-on."
+msgstr "Ви можете подати оновлення для вашого додатка через панель Інструментів розробника, вибравши опцію \"Завантажити нову версію\" і завантаживши новий файл вашого додатка з розширенням .xpi."
 
 #: src/olympia/pages/templates/pages/dev_faq.html:473
 msgid "Does my update need to be reviewed by editors?"
@@ -12773,49 +10058,32 @@ msgstr "Чи моє оновлення повинно бути перевіре�
 
 #: src/olympia/pages/templates/pages/dev_faq.html:475
 msgid ""
-"That depends. If you are simply changing a description of your add-on or "
-"updating a \"maxVersion\" to ensure compatibility with a new Mozilla "
-"software update, then your add-on does not need to be reviewed again. If, "
-"however, you submit a new updated file, then your add-on update will need to"
-" be reviewed by an editor."
+"That depends. If you are simply changing a description of your add-on or updating a \"maxVersion\" to ensure compatibility with a new Mozilla software update, then your add-on does not need to be "
+"reviewed again. If, however, you submit a new updated file, then your add-on update will need to be reviewed by an editor."
 msgstr ""
-"Коли як. Якщо ви просто змінюєте опис вашого додатка або оновлюєте "
-"\"maxVersion\", щоб забезпечити сумісність з новою версією програмного "
-"забезпечення Mozilla, то повторна перевірка вашого додатка не потрібна. "
-"Однак, якщо ви подаєте новий файл, то оновлення вашого додатка повинно бути "
-"перевірено редактором."
+"Коли як. Якщо ви просто змінюєте опис вашого додатка або оновлюєте \"maxVersion\", щоб забезпечити сумісність з новою версією програмного забезпечення Mozilla, то повторна перевірка вашого додатка "
+"не потрібна. Однак, якщо ви подаєте новий файл, то оновлення вашого додатка повинно бути перевірено редактором."
 
 #: src/olympia/pages/templates/pages/dev_faq.html:486
-msgid ""
-"How do I reply to a user who has posted a negative review of my add-on?"
-msgstr ""
-"Як мені відповісти користувачу, який розмістив негативний відгук на мій "
-"додаток?"
+msgid "How do I reply to a user who has posted a negative review of my add-on?"
+msgstr "Як мені відповісти користувачу, який розмістив негативний відгук на мій додаток?"
 
 #: src/olympia/pages/templates/pages/dev_faq.html:488
-msgid ""
-"A developer may reply to any review posted to their add-on as long as they "
-"are logged into AMO. In addition, any user can flag a review as:"
-msgstr ""
-"Розробник може відповісти на будь-який відгук, розміщений на його додаток, "
-"якщо він увійшов до AMO. Крім того, будь-який користувач може відмітити "
-"відгук як:"
+msgid "A developer may reply to any review posted to their add-on as long as they are logged into AMO. In addition, any user can flag a review as:"
+msgstr "Розробник може відповісти на будь-який відгук, розміщений на його додаток, якщо він увійшов до AMO. Крім того, будь-який користувач може відмітити відгук як:"
 
 #. part of a list (<li>)
-#: src/olympia/pages/templates/pages/dev_faq.html:495
-#: src/olympia/reviews/models.py:159
+#: src/olympia/pages/templates/pages/dev_faq.html:495 src/olympia/reviews/models.py:159
 msgid "Spam or otherwise non-review content"
 msgstr "Спам чи інший непереглянутий зміст"
 
 #. part of a list (<li>)
-#: src/olympia/pages/templates/pages/dev_faq.html:497
-#: src/olympia/reviews/models.py:160
+#: src/olympia/pages/templates/pages/dev_faq.html:497 src/olympia/reviews/models.py:160
 msgid "Inappropriate language/dialog"
 msgstr "Невідповідна мова/вікно"
 
 #. part of a list (<li>)
-#: src/olympia/pages/templates/pages/dev_faq.html:499
-#: src/olympia/reviews/models.py:161
+#: src/olympia/pages/templates/pages/dev_faq.html:499 src/olympia/reviews/models.py:161
 msgid "Misplaced bug report or support request"
 msgstr "Неправильно розміщений звіт про ваду чи запит про підтримку"
 
@@ -12825,127 +10093,74 @@ msgid "Other (provides a pop-up prompt for information)"
 msgstr "Інше (виводить виринаючий запит для вводу інформації)"
 
 #: src/olympia/pages/templates/pages/dev_faq.html:504
-msgid ""
-"Currently, AMO does not provide a mechanism to directly communicate with a "
-"reviewer but this feature is being investigated and considered for a future "
-"update."
-msgstr ""
-"В даний час AMO не надає механізму для прямого зв'язку з рецензентом, але ця"
-" можливість зараз розглядається для включення у майбутнє оновлення."
+msgid "Currently, AMO does not provide a mechanism to directly communicate with a reviewer but this feature is being investigated and considered for a future update."
+msgstr "В даний час AMO не надає механізму для прямого зв'язку з рецензентом, але ця можливість зараз розглядається для включення у майбутнє оновлення."
 
 #: src/olympia/pages/templates/pages/dev_faq.html:511
 msgid "Can I request that a review be removed if the review is negative?"
 msgstr "Чи можу я дати запит на вилучення негативного відгуку?"
 
 #: src/olympia/pages/templates/pages/dev_faq.html:513
-msgid ""
-"No. We do not remove negative reviews from add-ons unless they are found to "
-"be false."
-msgstr ""
-"Ні. Ми не вилучаємо негативних відгуків на додатки, якщо тільки їх не буде "
-"визнано помилковими."
+msgid "No. We do not remove negative reviews from add-ons unless they are found to be false."
+msgstr "Ні. Ми не вилучаємо негативних відгуків на додатки, якщо тільки їх не буде визнано помилковими."
 
 #: src/olympia/pages/templates/pages/dev_faq.html:519
 msgid "Can I request that a review be removed if the review is inaccurate?"
 msgstr "Чи можу я дати запит на вилучення некоректного відгуку?"
 
 #: src/olympia/pages/templates/pages/dev_faq.html:521
-msgid ""
-"If an author contacts us and asks for a review containing false or "
-"inaccurate information to be removed, we will review the post and consider "
-"removing it."
-msgstr ""
-"Якщо автор зв'язується з нами та просить вилучити відгук, який містить "
-"неправильну чи неточну інформацію, ми перевіряємо відгук та приймаємо "
-"рішення."
+msgid "If an author contacts us and asks for a review containing false or inaccurate information to be removed, we will review the post and consider removing it."
+msgstr "Якщо автор зв'язується з нами та просить вилучити відгук, який містить неправильну чи неточну інформацію, ми перевіряємо відгук та приймаємо рішення."
 
 #: src/olympia/pages/templates/pages/dev_faq.html:530
 msgid ""
-"Do you need more information about the various open source licenses? Are you"
-" confused as to which license you should select? What rights does a specific"
-" license grant? While nothing replaces reading the full terms of a license, "
-"below are some sites that contain information about some of the key open "
-"source licenses that may help you sort out the differences between them. "
-"These sites are being provided solely for your convenience and as a "
-"reference for your personal use. These resources do not constitute legal "
-"advice nor should they be used in lieu of such advice. Mozilla neither "
-"guarantees nor is responsible for the content of these sites or your "
-"reliance on such content."
+"Do you need more information about the various open source licenses? Are you confused as to which license you should select? What rights does a specific license grant? While nothing replaces "
+"reading the full terms of a license, below are some sites that contain information about some of the key open source licenses that may help you sort out the differences between them. These sites "
+"are being provided solely for your convenience and as a reference for your personal use. These resources do not constitute legal advice nor should they be used in lieu of such advice. Mozilla "
+"neither guarantees nor is responsible for the content of these sites or your reliance on such content."
 msgstr ""
-"Потрібно більше інформації про різні ліцензії для відкритого програмного "
-"коду? Заплутались у виборі ліцензії? Хочете знати, які права надає певна "
-"ліцензія? Хоча немає нічого кращого, ніж ознайомлення з усіма умовами "
-"ліцензії, внизу зазначено деякі сайти з інформацією про основні ліцензії для"
-" відкритого програмного коду, які можуть допомогти вам у визначенні "
-"відмінностей між ними. Ці сайти було надано виключно для вашої зручності та "
-"в якості рекомендації для особистого користування. Ці ресурси не являються "
-"юридичною консультацією та не повинні використовуватись замість таких "
-"консультацій. Mozilla не гарантує та не несе відповідальність за вміст цих "
-"сайтів чи за використання вами цього вмісту."
+"Потрібно більше інформації про різні ліцензії для відкритого програмного коду? Заплутались у виборі ліцензії? Хочете знати, які права надає певна ліцензія? Хоча немає нічого кращого, ніж "
+"ознайомлення з усіма умовами ліцензії, внизу зазначено деякі сайти з інформацією про основні ліцензії для відкритого програмного коду, які можуть допомогти вам у визначенні відмінностей між ними. "
+"Ці сайти було надано виключно для вашої зручності та в якості рекомендації для особистого користування. Ці ресурси не являються юридичною консультацією та не повинні використовуватись замість таких"
+" консультацій. Mozilla не гарантує та не несе відповідальність за вміст цих сайтів чи за використання вами цього вмісту."
 
 #: src/olympia/pages/templates/pages/dev_faq.html:545
 msgid ""
-"In addition to the full text of the Mozilla Public License(\"MPL\"), this "
-"also provides an annotated version of the MPL and an <abbr "
-"title=\"Frequently Asked Questions\">FAQ</abbr> to help you if you want to "
-"use or distribute code licensed under it."
+"In addition to the full text of the Mozilla Public License(\"MPL\"), this also provides an annotated version of the MPL and an <abbr title=\"Frequently Asked Questions\">FAQ</abbr> to help you if "
+"you want to use or distribute code licensed under it."
 msgstr ""
-"На додачу до повного тексту Mozilla Public License(\"MPL\"), додається також"
-" анотовану версію MPL та <abbr title=\"Часті питання\">ЧаП</abbr>, щоб "
-"допомогти вам, якщо ви захочете використовувати чи розповсюджувати код на її"
-" умовах."
+"На додачу до повного тексту Mozilla Public License(\"MPL\"), додається також анотовану версію MPL та <abbr title=\"Часті питання\">ЧаП</abbr>, щоб допомогти вам, якщо ви захочете використовувати чи"
+" розповсюджувати код на її умовах."
 
 #: src/olympia/pages/templates/pages/dev_faq.html:559
-msgid ""
-"A table summarizing and comparing how some of the key open source licenses "
-"treat distributions, proprietary software linking, and redistribution of "
-"code with changes."
+msgid "A table summarizing and comparing how some of the key open source licenses treat distributions, proprietary software linking, and redistribution of code with changes."
 msgstr ""
-"Порівняльна таблиця сумарних показників покриття деякими основними "
-"ліцензіями для відкритого програмного коду дистрибуцій, зв'язку з "
-"посиланнями на власне програмне забезпечення та поширення зміненого коду."
+"Порівняльна таблиця сумарних показників покриття деякими основними ліцензіями для відкритого програмного коду дистрибуцій, зв'язку з посиланнями на власне програмне забезпечення та поширення "
+"зміненого коду."
 
 #: src/olympia/pages/templates/pages/dev_faq.html:572
 msgid ""
-"Free Software Foundation provides short summaries of the key open source "
-"licenses, including whether the license qualifies as a free software license"
-" or a copyleft license. Also includes a discussion of what constitutes a "
-"free software license or a copyleft license (e.g., a Copyleft license is a "
-"general method for making a program or other work free, and requiring all "
-"modified and extended versions of the program to be free as well.)"
+"Free Software Foundation provides short summaries of the key open source licenses, including whether the license qualifies as a free software license or a copyleft license. Also includes a "
+"discussion of what constitutes a free software license or a copyleft license (e.g., a Copyleft license is a general method for making a program or other work free, and requiring all modified and "
+"extended versions of the program to be free as well.)"
 msgstr ""
-"Free Software Foundation надає короткі описи ключових ліцензій для "
-"відкритого програмного коду, в тому числі, чи відповідає ця ліцензія free "
-"software ліцензії або copyleft ліцензії. Також там розташовується "
-"обговорення того, що складає собою free software ліцензія або copyleft "
-"ліцензія (наприклад, Copyleft ліцензія - це типовий метод переводу програм "
-"або інших робіт в розряд безкоштовних, що вимагає, щоб всі змінені і "
-"розширені версії програм також були безкоштовні.)"
+"Free Software Foundation надає короткі описи ключових ліцензій для відкритого програмного коду, в тому числі, чи відповідає ця ліцензія free software ліцензії або copyleft ліцензії. Також там "
+"розташовується обговорення того, що складає собою free software ліцензія або copyleft ліцензія (наприклад, Copyleft ліцензія - це типовий метод переводу програм або інших робіт в розряд "
+"безкоштовних, що вимагає, щоб всі змінені і розширені версії програм також були безкоштовні.)"
 
 #: src/olympia/pages/templates/pages/dev_faq.html:589
-msgid ""
-"Open Source Initiative provides the terms of some of the key open source "
-"licenses."
-msgstr ""
-"Open Source Initiative забезпечує умови деяких з ключових ліцензій для "
-"відкритого програмного коду."
+msgid "Open Source Initiative provides the terms of some of the key open source licenses."
+msgstr "Open Source Initiative забезпечує умови деяких з ключових ліцензій для відкритого програмного коду."
 
 #: src/olympia/pages/templates/pages/dev_faq.html:599
 msgid "A comparison of known open source licenses on Wikipedia."
-msgstr ""
-"Порівняння відомих ліцензій для відкритого програмного коду у Вікіпедії."
+msgstr "Порівняння відомих ліцензій для відкритого програмного коду у Вікіпедії."
 
 #: src/olympia/pages/templates/pages/dev_faq.html:605
-msgid ""
-"A site to provide non-judgmental guidance on choosing a license for your "
-"open source project."
-msgstr ""
-"Сайт, що надає неупереджену інструкцію з вибору ліцензії для вашого проекту "
-"з відкритим програмним кодом."
+msgid "A site to provide non-judgmental guidance on choosing a license for your open source project."
+msgstr "Сайт, що надає неупереджену інструкцію з вибору ліцензії для вашого проекту з відкритим програмним кодом."
 
-#: src/olympia/pages/templates/pages/faq.html:3
-#: src/olympia/pages/templates/pages/faq.html:9
-#: src/olympia/pages/templates/pages/faq.html:10
+#: src/olympia/pages/templates/pages/faq.html:3 src/olympia/pages/templates/pages/faq.html:9 src/olympia/pages/templates/pages/faq.html:10
 msgid "Frequently Asked Questions"
 msgstr "Часті питання"
 
@@ -12960,19 +10175,12 @@ msgstr "Що таке додаток?"
 #: src/olympia/pages/templates/pages/faq.html:16
 #, python-format
 msgid ""
-"Add-ons are small pieces of software that add new features or functionality "
-"to your installation of %(app_name)s. Add-ons can augment %(app_name)s with "
-"new features, foreign language dictionaries, or change its visual "
-"appearance. Through add-ons, you can customize %(app_name)s to meet your "
-"needs and tastes. <a href=\"%(learnmore_url)s\">Learn more about "
-"customization</a>"
+"Add-ons are small pieces of software that add new features or functionality to your installation of %(app_name)s. Add-ons can augment %(app_name)s with new features, foreign language dictionaries, "
+"or change its visual appearance. Through add-ons, you can customize %(app_name)s to meet your needs and tastes. <a href=\"%(learnmore_url)s\">Learn more about customization</a>"
 msgstr ""
-"Додатки це невеликі програми, які додають нові можливості або "
-"функціональність у встановлений вами %(app_name)s. Додатки можуть "
-"доповнювати %(app_name)s новими функціями, додавати словники іноземної мови "
-"або змінювати його зовнішній вигляд. Додатками ви можете налаштувати "
-"%(app_name)s на свій смак, щоб задовольнити свої потреби. <a "
-"href=\"%(learnmore_url)s\">Дізнайтеся більше про налаштування</a>"
+"Додатки це невеликі програми, які додають нові можливості або функціональність у встановлений вами %(app_name)s. Додатки можуть доповнювати %(app_name)s новими функціями, додавати словники "
+"іноземної мови або змінювати його зовнішній вигляд. Додатками ви можете налаштувати %(app_name)s на свій смак, щоб задовольнити свої потреби. <a href=\"%(learnmore_url)s\">Дізнайтеся більше про "
+"налаштування</a>"
 
 #: src/olympia/pages/templates/pages/faq.html:26
 msgid "Will add-ons work with my web browser or application?"
@@ -12981,25 +10189,14 @@ msgstr "Чи будуть додатки працювати з моїм брау
 #: src/olympia/pages/templates/pages/faq.html:27
 #, python-format
 msgid ""
-"Add-ons listed in this gallery only work with Mozilla-based applications, "
-"such as <a href=\"%(getfirefox_url)s\">Firefox</a>, <a "
-"href=\"%(getmobile_url)s\">Firefox Mobile</a>, <a "
-"href=\"%(getseamonkey_url)s\">SeaMonkey</a>, and <a "
-"href=\"%(getthunderbird_url)s\">Thunderbird</a>. However, not all add-ons "
-"work with each of those applications or every version of those applications."
-" Each add-on specifies which applications and versions it works with, such "
-"as Firefox 2.0 - 3.6.*. For Firefox add-ons, the install buttons will "
-"indicate whether the add-on is compatible or not."
+"Add-ons listed in this gallery only work with Mozilla-based applications, such as <a href=\"%(getfirefox_url)s\">Firefox</a>, <a href=\"%(getmobile_url)s\">Firefox Mobile</a>, <a "
+"href=\"%(getseamonkey_url)s\">SeaMonkey</a>, and <a href=\"%(getthunderbird_url)s\">Thunderbird</a>. However, not all add-ons work with each of those applications or every version of those "
+"applications. Each add-on specifies which applications and versions it works with, such as Firefox 2.0 - 3.6.*. For Firefox add-ons, the install buttons will indicate whether the add-on is "
+"compatible or not."
 msgstr ""
-"Додатки в цій галереї працюють тільки з програмами на основі Mozilla, такими"
-" як <a href=\"%(getfirefox_url)s\">Firefox</a>, <a "
-"href=\"%(getmobile_url)s\">мобільний Firefox</a>, <a "
-"href=\"%(getseamonkey_url)s\">SeaMonkey</a> і <a "
-"href=\"%(getthunderbird_url)s\">Thunderbird</a>. Однак, не всі додатки "
-"працюють з кожною із цих програм, чи будь-якою версією цих додатків. У "
-"кожному додатку вказано, з якими програмами і версіями він працює, "
-"наприклад, Firefox 2.0 - 3.6.*. Для додатків Firefox кнопки встановлення "
-"будуть вказувати, сумісний додаток чи ні."
+"Додатки в цій галереї працюють тільки з програмами на основі Mozilla, такими як <a href=\"%(getfirefox_url)s\">Firefox</a>, <a href=\"%(getmobile_url)s\">мобільний Firefox</a>, <a "
+"href=\"%(getseamonkey_url)s\">SeaMonkey</a> і <a href=\"%(getthunderbird_url)s\">Thunderbird</a>. Однак, не всі додатки працюють з кожною із цих програм, чи будь-якою версією цих додатків. У "
+"кожному додатку вказано, з якими програмами і версіями він працює, наприклад, Firefox 2.0 - 3.6.*. Для додатків Firefox кнопки встановлення будуть вказувати, сумісний додаток чи ні."
 
 #: src/olympia/pages/templates/pages/faq.html:42
 msgid "What are the different types of add-ons?"
@@ -13007,77 +10204,44 @@ msgstr "Чому існують різні типи додатків?"
 
 #: src/olympia/pages/templates/pages/faq.html:43
 #, python-format
-msgid ""
-"There are several kinds of add-ons that customize %(app_name)s in different "
-"ways:"
+msgid "There are several kinds of add-ons that customize %(app_name)s in different ways:"
 msgstr "Є кілька типів додатків, які по різному налаштовують %(app_name)s:"
 
 #: src/olympia/pages/templates/pages/faq.html:47
 #, python-format
 msgid ""
-"<strong><a href=\"%(browse_url)s\">Extensions</a></strong> add new features "
-"to %(app_name)s or modify existing functionality. There are extensions that "
-"allow you to block advertisements, download videos from websites, integrate "
-"more closely with social websites, and add features you see in other "
-"applications."
+"<strong><a href=\"%(browse_url)s\">Extensions</a></strong> add new features to %(app_name)s or modify existing functionality. There are extensions that allow you to block advertisements, download "
+"videos from websites, integrate more closely with social websites, and add features you see in other applications."
 msgstr ""
-"<strong><a href=\"%(browse_url)s\">Розширення</a></strong> додають нові "
-"функції в %(app_name)s або змінюють існуючу функціональність. Існують "
-"розширення, які дозволяють блокувати рекламу, завантажувати відео з веб-"
-"сайтів, більш тісно інтегруватися з соціальними мережами і додавати функції,"
-" які ви бачите в інших додатках."
+"<strong><a href=\"%(browse_url)s\">Розширення</a></strong> додають нові функції в %(app_name)s або змінюють існуючу функціональність. Існують розширення, які дозволяють блокувати рекламу, "
+"завантажувати відео з веб-сайтів, більш тісно інтегруватися з соціальними мережами і додавати функції, які ви бачите в інших додатках."
 
 #: src/olympia/pages/templates/pages/faq.html:55
 #, python-format
-msgid ""
-"<strong><a href=\"%(browse_url)s\">Complete Themes</a></strong> change the "
-"entire appearance of %(app_name)s, usually including icons, colors, dialogs,"
-" and other visual styles."
-msgstr ""
-"<strong><a href=\"%(browse_url)s\">Повні теми</a></strong> цілком змінюють "
-"зовнішній вигляд %(app_name)s, включаючи, як правило, іконки, кольори, "
-"діалогові вікна та інші візуальні стилі."
+msgid "<strong><a href=\"%(browse_url)s\">Complete Themes</a></strong> change the entire appearance of %(app_name)s, usually including icons, colors, dialogs, and other visual styles."
+msgstr "<strong><a href=\"%(browse_url)s\">Повні теми</a></strong> цілком змінюють зовнішній вигляд %(app_name)s, включаючи, як правило, іконки, кольори, діалогові вікна та інші візуальні стилі."
 
 #: src/olympia/pages/templates/pages/faq.html:61
 #, python-format
-msgid ""
-"<strong><a href=\"%(browse_url)s\">Themes</a></strong> are lightweight "
-"themes that use background images to customize your %(app_name)s toolbars."
-msgstr ""
-"<strong><a href=\"%(browse_url)s\">Теми</a></strong> це легкі теми, які "
-"використовують фонові зображення для налаштування панелей інструментів вашої"
-" %(app_name)s."
+msgid "<strong><a href=\"%(browse_url)s\">Themes</a></strong> are lightweight themes that use background images to customize your %(app_name)s toolbars."
+msgstr "<strong><a href=\"%(browse_url)s\">Теми</a></strong> це легкі теми, які використовують фонові зображення для налаштування панелей інструментів вашої %(app_name)s."
 
 #: src/olympia/pages/templates/pages/faq.html:66
 #, python-format
-msgid ""
-"<strong><a href=\"%(browse_url)s\">Search Providers</a> </strong> add "
-"additional choices to the search box dropdown. These providers allow you to "
-"quickly search any website."
+msgid "<strong><a href=\"%(browse_url)s\">Search Providers</a> </strong> add additional choices to the search box dropdown. These providers allow you to quickly search any website."
 msgstr ""
-"<strong><a href=\"%(browse_url)s\">Інструменти пошуку</a></strong> додають "
-"додаткові варіанти в випадаючий список панелі пошуку. Ці інструменти "
-"дозволяють вам швидко провести пошук на будь-якому веб-сайті."
+"<strong><a href=\"%(browse_url)s\">Інструменти пошуку</a></strong> додають додаткові варіанти в випадаючий список панелі пошуку. Ці інструменти дозволяють вам швидко провести пошук на будь-якому "
+"веб-сайті."
 
 #: src/olympia/pages/templates/pages/faq.html:72
 #, python-format
-msgid ""
-"<strong><a href=\"%(browse_url)s\">Dictionaries & Language "
-"Packs</a></strong> add support for additional languages to %(app_name)s."
-msgstr ""
-"<strong><a href=\"%(browse_url)s\">Словники та локалі</a></strong> додають "
-"підтримку додаткових мов в %(app_name)s."
+msgid "<strong><a href=\"%(browse_url)s\">Dictionaries & Language Packs</a></strong> add support for additional languages to %(app_name)s."
+msgstr "<strong><a href=\"%(browse_url)s\">Словники та локалі</a></strong> додають підтримку додаткових мов в %(app_name)s."
 
 #: src/olympia/pages/templates/pages/faq.html:77
 #, python-format
-msgid ""
-"<strong><a href=\"%(browse_url)s\">Plugins</a></strong> help %(app_name)s "
-"display or understand different types of media, such as Adobe Flash or Apple"
-" Quicktime."
-msgstr ""
-"<strong><a href=\"%(browse_url)s\">Плагіни</a></strong> допомагають "
-"%(app_name)s відображати або розуміти різні типи медіа, такі як Adobe Flash "
-"або Apple Quicktime."
+msgid "<strong><a href=\"%(browse_url)s\">Plugins</a></strong> help %(app_name)s display or understand different types of media, such as Adobe Flash or Apple Quicktime."
+msgstr "<strong><a href=\"%(browse_url)s\">Плагіни</a></strong> допомагають %(app_name)s відображати або розуміти різні типи медіа, такі як Adobe Flash або Apple Quicktime."
 
 #: src/olympia/pages/templates/pages/faq.html:85
 msgid "How do I install, manage, or remove an add-on?"
@@ -13086,22 +10250,13 @@ msgstr "Як мені встановити, керувати, або вилуч�
 #: src/olympia/pages/templates/pages/faq.html:86
 #, python-format
 msgid ""
-"In most cases, add-ons can be installed by simply clicking the install "
-"button provided. Add-ons can be managed, disabled, or uninstalled from the "
-"Add-ons Manager in %(app_name)s. For more detailed instructions, read <a "
-"href=\"%(extension_url)s\">this article on extensions</a> or <a "
-"href=\"%(theme_url)s\">this one for Themes and Complete Themes</a>. If you "
-"have difficulty installing add-ons, see <a "
-"href=\"%(troubleshooting_url)s\">Troubleshooting Extensions and Themes</a>."
+"In most cases, add-ons can be installed by simply clicking the install button provided. Add-ons can be managed, disabled, or uninstalled from the Add-ons Manager in %(app_name)s. For more detailed "
+"instructions, read <a href=\"%(extension_url)s\">this article on extensions</a> or <a href=\"%(theme_url)s\">this one for Themes and Complete Themes</a>. If you have difficulty installing add-ons, "
+"see <a href=\"%(troubleshooting_url)s\">Troubleshooting Extensions and Themes</a>."
 msgstr ""
-"В більшості випадків, додатки можуть бути встановлені просто натисканням на "
-"кнопку встановлення. Додатками можна керувати, вимикати, або видаляти за "
-"допомогою керування додатками в %(app_name)s. Для детальніших інструкцій, "
-"ознайомтеся з <a href=\"%(extension_url)s\">цією статтею</a> або <a "
-"href=\"%(theme_url)s\">цією для тем та повних тем</a>. Якщо у вас виникли "
-"труднощі з встановленням додатків, перегляньте <a "
-"href=\"%(troubleshooting_url)s\">Виправлення несправностей з розширеннями й "
-"темами</a>."
+"В більшості випадків, додатки можуть бути встановлені просто натисканням на кнопку встановлення. Додатками можна керувати, вимикати, або видаляти за допомогою керування додатками в %(app_name)s. "
+"Для детальніших інструкцій, ознайомтеся з <a href=\"%(extension_url)s\">цією статтею</a> або <a href=\"%(theme_url)s\">цією для тем та повних тем</a>. Якщо у вас виникли труднощі з встановленням "
+"додатків, перегляньте <a href=\"%(troubleshooting_url)s\">Виправлення несправностей з розширеннями й темами</a>."
 
 #: src/olympia/pages/templates/pages/faq.html:100
 msgid "How do I install add-ons without restarting Firefox?"
@@ -13110,17 +10265,11 @@ msgstr "Як мені встановити додатки без перезап�
 #: src/olympia/pages/templates/pages/faq.html:101
 #, python-format
 msgid ""
-"In Firefox, add-ons marked with \"No restart required\" can be installed "
-"without restarting. These add-ons have been created using the <a "
-"href=\"%(sdk_url)s\">Add-on SDK</a> or <a "
-"href=\"%(bootstrap_url)s\">bootstrapping</a>. Other add-ons will still "
-"require a restart before you can use them."
+"In Firefox, add-ons marked with \"No restart required\" can be installed without restarting. These add-ons have been created using the <a href=\"%(sdk_url)s\">Add-on SDK</a> or <a "
+"href=\"%(bootstrap_url)s\">bootstrapping</a>. Other add-ons will still require a restart before you can use them."
 msgstr ""
-"У Firefox, додатки, які мають позначку \"Без перезапуску\" можуть бути "
-"встановлені без перезапуску. Ці додатки були створені з використанням <a "
-"href=\"%(sdk_url)s\">Add-on SDK</a> або <a "
-"href=\"%(bootstrap_url)s\">bootstrapping</a>. Інші додатки все ще потребують"
-" перезапуску, перед тим як ви їх зможете використовувати."
+"У Firefox, додатки, які мають позначку \"Без перезапуску\" можуть бути встановлені без перезапуску. Ці додатки були створені з використанням <a href=\"%(sdk_url)s\">Add-on SDK</a> або <a "
+"href=\"%(bootstrap_url)s\">bootstrapping</a>. Інші додатки все ще потребують перезапуску, перед тим як ви їх зможете використовувати."
 
 #: src/olympia/pages/templates/pages/faq.html:110
 msgid "How do I keep add-ons up-to-date?"
@@ -13129,20 +10278,13 @@ msgstr "Як мені тримати додатки оновленими?"
 #: src/olympia/pages/templates/pages/faq.html:111
 #, python-format
 msgid ""
-"Add-ons, unlike plugins, are automatically checked for updates once every "
-"day. In Firefox, updates are automatically installed by default. Versions of"
-" Firefox prior to 4 (and other applications) will alert you that updates to "
-"your add-ons are available. <a href=\"%(plugin_url)s\">Plugins</a> are not "
-"currently automatically checked for updates, so be sure to regularly visit "
-"the <a href=\"%(plugincheck_url)s\">Plugin Check</a> page to stay up-to-"
-"date."
+"Add-ons, unlike plugins, are automatically checked for updates once every day. In Firefox, updates are automatically installed by default. Versions of Firefox prior to 4 (and other applications) "
+"will alert you that updates to your add-ons are available. <a href=\"%(plugin_url)s\">Plugins</a> are not currently automatically checked for updates, so be sure to regularly visit the <a "
+"href=\"%(plugincheck_url)s\">Plugin Check</a> page to stay up-to-date."
 msgstr ""
-"Додатки, на відміну від плагінів, автоматично перевіряють оновлення один раз"
-" на день. В Firefox, оновлення встановлюються автоматично. Версії Firefox до"
-" 4 (та інші програми) будуть попереджати вас про наявність оновлень для "
-"ваших додатків. <a href=\"%(plugin_url)s\">Плагіни</a> в даний момент не "
-"перевіряють оновлення автоматично, тому рекомендуємо регулярно відвідувати "
-"сторінку <a href=\"%(plugincheck_url)s\">Перевірки плагінів</a>."
+"Додатки, на відміну від плагінів, автоматично перевіряють оновлення один раз на день. В Firefox, оновлення встановлюються автоматично. Версії Firefox до 4 (та інші програми) будуть попереджати вас "
+"про наявність оновлень для ваших додатків. <a href=\"%(plugin_url)s\">Плагіни</a> в даний момент не перевіряють оновлення автоматично, тому рекомендуємо регулярно відвідувати сторінку <a "
+"href=\"%(plugincheck_url)s\">Перевірки плагінів</a>."
 
 #: src/olympia/pages/templates/pages/faq.html:122
 msgid "Are add-ons safe to install?"
@@ -13151,20 +10293,13 @@ msgstr "Чи безпечно встановлювати додатки?"
 #: src/olympia/pages/templates/pages/faq.html:123
 #, python-format
 msgid ""
-"Unless clearly marked otherwise, add-ons available from this gallery have "
-"been checked and approved by Mozilla's team of editors and are safe to "
-"install. We recommend that you only install approved add-ons. If you wish to"
-" install unapproved add-ons or add-ons from third-party websites, use "
-"caution as these add-ons may harm your computer or violate your privacy. <a "
+"Unless clearly marked otherwise, add-ons available from this gallery have been checked and approved by Mozilla's team of editors and are safe to install. We recommend that you only install approved"
+" add-ons. If you wish to install unapproved add-ons or add-ons from third-party websites, use caution as these add-ons may harm your computer or violate your privacy. <a "
 "href=\"%(learnmore_url)s\">Learn more about our approval process</a>"
 msgstr ""
-"Якщо явно не зазначено протилежне, додатки, доступні в цій галереї були "
-"перевірені і схвалені командою редакторів Mozilla і безпечні для установки. "
-"Ми рекомендуємо вам встановлювати тільки схвалені додатки. Якщо ви хочете "
-"встановити несхвалені додатки або додатки зі сторонніх веб-сайтів, будьте "
-"обережні, оскільки ці додатки можуть завдати шкоди вашому комп'ютеру або "
-"порушити вашу приватність. <a href=\"%(learnmore_url)s\">Дізнайтеся більше "
-"про наш процес перевірки</a>"
+"Якщо явно не зазначено протилежне, додатки, доступні в цій галереї були перевірені і схвалені командою редакторів Mozilla і безпечні для установки. Ми рекомендуємо вам встановлювати тільки схвалені"
+" додатки. Якщо ви хочете встановити несхвалені додатки або додатки зі сторонніх веб-сайтів, будьте обережні, оскільки ці додатки можуть завдати шкоди вашому комп'ютеру або порушити вашу "
+"приватність. <a href=\"%(learnmore_url)s\">Дізнайтеся більше про наш процес перевірки</a>"
 
 #: src/olympia/pages/templates/pages/faq.html:133
 #, python-format
@@ -13174,45 +10309,28 @@ msgstr "Чи можуть додатки сповільнити роботу %(a
 #: src/olympia/pages/templates/pages/faq.html:135
 #, python-format
 msgid ""
-"Most add-ons do not cause a perceivable performance decrease in "
-"%(app_name)s, though installing an excessive number may have adverse "
-"effects. If you suspect an add-on is causing %(app_name)s to be slow, try "
-"disabling it."
+"Most add-ons do not cause a perceivable performance decrease in %(app_name)s, though installing an excessive number may have adverse effects. If you suspect an add-on is causing %(app_name)s to be "
+"slow, try disabling it."
 msgstr ""
-"Більшість додатків не викликають явного зменшення продуктивності "
-"%(app_name)s, хоча установка їх надмірної кількості може мати несприятливі "
-"наслідки. Якщо ви підозрюєте, що додаток уповільнює %(app_name)s, спробуйте "
-"його відключити."
+"Більшість додатків не викликають явного зменшення продуктивності %(app_name)s, хоча установка їх надмірної кількості може мати несприятливі наслідки. Якщо ви підозрюєте, що додаток уповільнює "
+"%(app_name)s, спробуйте його відключити."
 
 #: src/olympia/pages/templates/pages/faq.html:141
 #, python-format
-msgid ""
-"%(app_name)s told me an add-on isn't compatible. Is there a way I can still "
-"use it?"
-msgstr ""
-"%(app_name)s сказав мені, що додаток не сумісний. Чи можу я якось продовжити"
-" його використовувати?"
+msgid "%(app_name)s told me an add-on isn't compatible. Is there a way I can still use it?"
+msgstr "%(app_name)s сказав мені, що додаток не сумісний. Чи можу я якось продовжити його використовувати?"
 
 #: src/olympia/pages/templates/pages/faq.html:144
 #, python-format
 msgid ""
-"If an add-on isn't compatible with your version of %(app_name)s, it is "
-"usually either because your version of %(app_name)s is outdated or the add-"
-"on author has not yet updated the add-on to be compatible with a newer "
-"version you are using. Mozilla does not recommend trying to circumvent these"
-" compatibility checks, as they can lead to browser instability or in some "
-"cases loss of data. For users who are testing out alpha or beta versions of "
-"Firefox, we offer the <a href=\"%(acr_url)s\">Add-on Compatibility "
-"Reporter</a> to help add-on developers update their compatibility."
+"If an add-on isn't compatible with your version of %(app_name)s, it is usually either because your version of %(app_name)s is outdated or the add-on author has not yet updated the add-on to be "
+"compatible with a newer version you are using. Mozilla does not recommend trying to circumvent these compatibility checks, as they can lead to browser instability or in some cases loss of data. For"
+" users who are testing out alpha or beta versions of Firefox, we offer the <a href=\"%(acr_url)s\">Add-on Compatibility Reporter</a> to help add-on developers update their compatibility."
 msgstr ""
-"Якщо додаток не сумісний з вашою версією %(app_name)s, то як правило це "
-"означає, що або ваша версія %(app_name)s застаріла, або автор додатка ще не "
-"оновив його, додавши в додаток сумісність з використовуваної вами новою "
-"версією. Mozilla не рекомендує намагатися обійти ці перевірки сумісності, "
-"так як це може призвести до нестабільності браузера або в деяких випадках до"
-" втрати даних. Для користувачів, які тестують альфа або бета версії Firefox,"
-" ми пропонуємо встановити <a href=\"%(acr_url)s\">Add-on Compatibility "
-"Reporter</a>, щоб допомогти розробникам додатків оновити їх сумісність."
+"Якщо додаток не сумісний з вашою версією %(app_name)s, то як правило це означає, що або ваша версія %(app_name)s застаріла, або автор додатка ще не оновив його, додавши в додаток сумісність з "
+"використовуваної вами новою версією. Mozilla не рекомендує намагатися обійти ці перевірки сумісності, так як це може призвести до нестабільності браузера або в деяких випадках до втрати даних. Для "
+"користувачів, які тестують альфа або бета версії Firefox, ми пропонуємо встановити <a href=\"%(acr_url)s\">Add-on Compatibility Reporter</a>, щоб допомогти розробникам додатків оновити їх "
+"сумісність."
 
 #: src/olympia/pages/templates/pages/faq.html:156
 msgid "What if I have problems with an add-on?"
@@ -13221,47 +10339,30 @@ msgstr "Що робити, якщо у мене проблеми з додатк
 #: src/olympia/pages/templates/pages/faq.html:157
 #, python-format
 msgid ""
-"Add-ons are usually created by third-party developers from around the world,"
-" so the best way to get help with an add-on is to look for support links on "
-"the add-on's homepage or contact the developer. If you are having issues "
-"with %(app_name)s that you suspect are related to add-ons you have "
-"installed, <a href=\"%(troubleshooting_url)s\">visit this support "
-"article</a> for troubleshooting tips."
+"Add-ons are usually created by third-party developers from around the world, so the best way to get help with an add-on is to look for support links on the add-on's homepage or contact the "
+"developer. If you are having issues with %(app_name)s that you suspect are related to add-ons you have installed, <a href=\"%(troubleshooting_url)s\">visit this support article</a> for "
+"troubleshooting tips."
 msgstr ""
-"Додатки, як правило, створюються сторонніми розробниками з усього світу, "
-"тому найкращий спосіб отримати допомогу по додатку це пошукати посилання для"
-" отримання підтримки на домашній сторінці додатка або зв'язатися з "
-"розробником. Якщо у вас виникли проблеми з %(app_name)s, які, як ви "
-"підозрюєте, стосуються встановленого у вас додатка, <a "
-"href=\"%(troubleshooting_url)s\">прочитайте цю статтю підтримки</a>, щоб "
-"отримати поради щодо усунення несправностей."
+"Додатки, як правило, створюються сторонніми розробниками з усього світу, тому найкращий спосіб отримати допомогу по додатку це пошукати посилання для отримання підтримки на домашній сторінці "
+"додатка або зв'язатися з розробником. Якщо у вас виникли проблеми з %(app_name)s, які, як ви підозрюєте, стосуються встановленого у вас додатка, <a href=\"%(troubleshooting_url)s\">прочитайте цю "
+"статтю підтримки</a>, щоб отримати поради щодо усунення несправностей."
 
 #: src/olympia/pages/templates/pages/faq.html:169
 msgid "Add-on Gallery"
 msgstr "Галерея додатків"
 
 #: src/olympia/pages/templates/pages/faq.html:171
-msgid ""
-"How do I choose between add-ons that seem to do the same\n"
-"    thing?"
-msgstr ""
-"Як мені обрати додаток серед інших, якщо вони виконують подібні функції?"
+msgid "How do I choose between add-ons that seem to do the same thing?"
+msgstr "Як мені обрати додаток серед інших, якщо вони виконують подібні функції?"
 
-#: src/olympia/pages/templates/pages/faq.html:173
+#: src/olympia/pages/templates/pages/faq.html:172
 msgid ""
-"There are often several add-ons that have similar features. To figure out "
-"which is right for you, read the entire description of the add-on and view "
-"its screenshots. If there are still several in the running, read through the"
-" add-on's ratings, user reviews, and statistics to see which is most liked "
-"by other users. Remember that you can also just try out both and see which "
-"you like better."
+"There are often several add-ons that have similar features. To figure out which is right for you, read the entire description of the add-on and view its screenshots. If there are still several in "
+"the running, read through the add-on's ratings, user reviews, and statistics to see which is most liked by other users. Remember that you can also just try out both and see which you like better."
 msgstr ""
-"Часто є кілька додатків з подібними функціями. Щоб визначити, який для вас є"
-" кращим, ознайомтеся з повним описом додатку та його знімками екрану. Якщо "
-"це вам не допоможе, ознайомтеся з рейтингами додатків, відгуками "
-"користувачів та статистикою, щоб дізнатися який з них найбільше подобається "
-"іншим користувачам. Пам'ятайте, ви можете також просто спробувати обидва і "
-"побачити, який вам більше до вподоби."
+"Часто є кілька додатків з подібними функціями. Щоб визначити, який для вас є кращим, ознайомтеся з повним описом додатку та його знімками екрану. Якщо це вам не допоможе, ознайомтеся з рейтингами "
+"додатків, відгуками користувачів та статистикою, щоб дізнатися який з них найбільше подобається іншим користувачам. Пам'ятайте, ви можете також просто спробувати обидва і побачити, який вам більше "
+"до вподоби."
 
 #: src/olympia/pages/templates/pages/faq.html:180
 msgid "What if I can't find an add-on I'm looking for?"
@@ -13270,39 +10371,24 @@ msgstr "Що, як мені не вдається знайти додаток, �
 #: src/olympia/pages/templates/pages/faq.html:181
 #, python-format
 msgid ""
-"With thousands of add-ons available, there's something for everyone. But if "
-"you're looking for a particular add-on and can't find it, you might try "
-"searching on other sites or posting about it in our <a href=\"%(forum_url)s"
-"\">Add-ons </a>forum."
+"With thousands of add-ons available, there's something for everyone. But if you're looking for a particular add-on and can't find it, you might try searching on other sites or posting about it in "
+"our <a href=\"%(forum_url)s\">Add-ons </a>forum."
 msgstr ""
-"З поміж тисяч доступних додатків, знайдеться щось для кожного. Але якщо ви "
-"шукаєте конкретний додаток і не можете його знайти, можете спробувати "
-"пошукати на інших сайтах, або написати про нього на нашому <a "
-"href=\"%(forum_url)s\">форумі додатків</a>."
+"З поміж тисяч доступних додатків, знайдеться щось для кожного. Але якщо ви шукаєте конкретний додаток і не можете його знайти, можете спробувати пошукати на інших сайтах, або написати про нього на "
+"нашому <a href=\"%(forum_url)s\">форумі додатків</a>."
 
 #: src/olympia/pages/templates/pages/faq.html:187
-msgid ""
-"What does it mean if an add-on is \"experimental\" or \"preliminarily "
-"reviewed\"?"
-msgstr ""
-"Що це означає, коли додаток \"експериментальний\" чи \"попередньо "
-"перевірений\"?"
+msgid "What does it mean if an add-on is \"experimental\" or \"preliminarily reviewed\"?"
+msgstr "Що це означає, коли додаток \"експериментальний\" чи \"попередньо перевірений\"?"
 
 #: src/olympia/pages/templates/pages/faq.html:188
 #, python-format
 msgid ""
-"Experimental add-ons have been checked by our editors to make sure they "
-"don't have security problems, but they may still have bugs or not work "
-"properly. Use caution when installing experimental add-ons and uninstall the"
-" add-on immediately if you notice problems. <a href=\"%(url)s\">Learn more "
-"about our review process</a></dd>"
+"Experimental add-ons have been checked by our editors to make sure they don't have security problems, but they may still have bugs or not work properly. Use caution when installing experimental "
+"add-ons and uninstall the add-on immediately if you notice problems. <a href=\"%(url)s\">Learn more about our review process</a></dd>"
 msgstr ""
-"Експериментальні додатки були перевірені нашими редакторами, щоб "
-"переконатися, що вони не мають проблем з безпекою, але все ж вони можуть "
-"містити помилки чи не працювати належним чином. Будьте обережні під час "
-"установки експериментальних додатків і негайно видаляйте додатки, якщо ви "
-"помітите проблеми. <a href=\"%(url)s\">Дізнайтеся більше про наш процес "
-"перевірки</a></dd>"
+"Експериментальні додатки були перевірені нашими редакторами, щоб переконатися, що вони не мають проблем з безпекою, але все ж вони можуть містити помилки чи не працювати належним чином. Будьте "
+"обережні під час установки експериментальних додатків і негайно видаляйте додатки, якщо ви помітите проблеми. <a href=\"%(url)s\">Дізнайтеся більше про наш процес перевірки</a></dd>"
 
 #: src/olympia/pages/templates/pages/faq.html:196
 msgid "What does it mean if an add-on is \"not reviewed\"?"
@@ -13311,263 +10397,185 @@ msgstr "Що це означає, коли додаток \"не перевір�
 #: src/olympia/pages/templates/pages/faq.html:197
 #, python-format
 msgid ""
-"While all add-ons publicly available in our gallery are reviewed by an "
-"editor, you may receive a direct link to an add-on that hasn't yet been "
-"reviewed. Use caution when installing these add-ons, as they could harm your"
-" computer or violate your privacy. We recommend that you only install "
-"reviewed add-ons. <a href=\"%(url)s\">Learn more about our review "
-"process</a></dd>"
+"While all add-ons publicly available in our gallery are reviewed by an editor, you may receive a direct link to an add-on that hasn't yet been reviewed. Use caution when installing these add-ons, "
+"as they could harm your computer or violate your privacy. We recommend that you only install reviewed add-ons. <a href=\"%(url)s\">Learn more about our review process</a></dd>"
 msgstr ""
-"Хоча всі додатки, яуі публічно доступні в нашій галереї, були перевірені "
-"редакторами, ви все ж можете отримати пряме посилання на додаток, який поки "
-"не було перевірено. Будьте обережні під час установки цих додатків, так як "
-"вони можуть завдати шкоди вашому комп'ютеру або порушити вашу приватність. "
-"Ми рекомендуємо вам встановлювати тільки перевірені додатки. <a "
-"href=\"%(url)s\">Дізнайтеся більше про наш процес перевірки</a></dd>"
+"Хоча всі додатки, яуі публічно доступні в нашій галереї, були перевірені редакторами, ви все ж можете отримати пряме посилання на додаток, який поки не було перевірено. Будьте обережні під час "
+"установки цих додатків, так як вони можуть завдати шкоди вашому комп'ютеру або порушити вашу приватність. Ми рекомендуємо вам встановлювати тільки перевірені додатки. <a href=\"%(url)s\">Дізнайтеся"
+" більше про наш процес перевірки</a></dd>"
 
 #: src/olympia/pages/templates/pages/faq.html:206
 msgid "How much do add-ons cost to purchase?"
 msgstr "Скільки коштують додатки?"
 
 #: src/olympia/pages/templates/pages/faq.html:207
-msgid ""
-"Add-ons hosted in our gallery are free unless clearly marked\n"
-"    otherwise."
-msgstr ""
-"Додатки розміщуються в нашій галереї. Вони безкоштовні, крім випадків коли "
-"явно вказано протилежне."
+msgid "Add-ons hosted in our gallery are free unless clearly marked otherwise."
+msgstr "Додатки розміщуються в нашій галереї. Вони безкоштовні, крім випадків коли явно вказано протилежне."
 
-#: src/olympia/pages/templates/pages/faq.html:210
+#: src/olympia/pages/templates/pages/faq.html:209
 msgid "What does it mean when an add-on asks for contributions?"
 msgstr "Що означає, коли додаток запитує про внесок?"
 
-#: src/olympia/pages/templates/pages/faq.html:211
+#: src/olympia/pages/templates/pages/faq.html:210
 msgid ""
-"Some add-on authors request users who enjoy an add-on to contribute to its "
-"development by making a monetary contribution. These contributions go "
-"directly to the developer unless a third party is indicated, such as the "
-"non-profit Mozilla Foundation."
+"Some add-on authors request users who enjoy an add-on to contribute to its development by making a monetary contribution. These contributions go directly to the developer unless a third party is "
+"indicated, such as the non-profit Mozilla Foundation."
 msgstr ""
-"Деякі автори додатків пропонують користувачам, яким подобається їх додатки, "
-"зробити вклад у його розвиток, зробивши грошовий внесок. Ці внески йдуть "
-"безпосередньо розробнику, якщо тільки не вказана третя сторона, така як "
-"некомерційна Mozilla Foundation."
+"Деякі автори додатків пропонують користувачам, яким подобається їх додатки, зробити вклад у його розвиток, зробивши грошовий внесок. Ці внески йдуть безпосередньо розробнику, якщо тільки не вказана"
+" третя сторона, така як некомерційна Mozilla Foundation."
 
-#: src/olympia/pages/templates/pages/faq.html:216
+#: src/olympia/pages/templates/pages/faq.html:215
 msgid "What are beta add-ons?"
 msgstr "Що таке бета-додатки?"
 
-#: src/olympia/pages/templates/pages/faq.html:218
+#: src/olympia/pages/templates/pages/faq.html:217
 msgid ""
-"Beta add-ons are unreviewed versions which represent the latest work of an "
-"add-on author. While different authors have different standards for beta "
-"code quality, you should assume that these add-ons are less stable than the "
-"general add-on releases."
+"Beta add-ons are unreviewed versions which represent the latest work of an add-on author. While different authors have different standards for beta code quality, you should assume that these add-"
+"ons are less stable than the general add-on releases."
 msgstr ""
-"Бета-версії додатків це неперевірені версії додатків, які представляють "
-"собою останню збірку, випущену автором додатка. Хоча різні автори мають "
-"різні стандарти якості для коду бета-версії, вам слід припускати, що ці "
-"додатки менш стабільні, ніж звичайні релізи додатків."
+"Бета-версії додатків це неперевірені версії додатків, які представляють собою останню збірку, випущену автором додатка. Хоча різні автори мають різні стандарти якості для коду бета-версії, вам слід"
+" припускати, що ці додатки менш стабільні, ніж звичайні релізи додатків."
 
-#: src/olympia/pages/templates/pages/faq.html:222
+#: src/olympia/pages/templates/pages/faq.html:221
 msgid ""
-"Please note that when you install an add-on from the \"Beta Version\" "
-"section of an add-on's listing, you will continue to receive updates for "
-"that add-on as they become available. Like the initial version you "
-"installed, all beta releases are unreviewed by Mozilla and may harm your "
-"computer."
+"Please note that when you install an add-on from the \"Beta Version\" section of an add-on's listing, you will continue to receive updates for that add-on as they become available. Like the initial"
+" version you installed, all beta releases are unreviewed by Mozilla and may harm your computer."
 msgstr ""
-"Будь ласка, зверніть увагу, що коли ви встановлюєте додаток з розділу "
-"\"Бета-версія\" сторінки додатка, ви будете продовжувати отримувати "
-"оновлення для цього додатка, як тільки вони стануть доступні. Як і у випадку"
-" первісної встановленої вами версії, бета-всі версії не перевірені Mozilla і"
-" можуть завдати шкоди вашому комп'ютеру."
+"Будь ласка, зверніть увагу, що коли ви встановлюєте додаток з розділу \"Бета-версія\" сторінки додатка, ви будете продовжувати отримувати оновлення для цього додатка, як тільки вони стануть "
+"доступні. Як і у випадку первісної встановленої вами версії, бета-всі версії не перевірені Mozilla і можуть завдати шкоди вашому комп'ютеру."
 
-#: src/olympia/pages/templates/pages/faq.html:229
-msgid ""
-"What does it mean when an add-on is flagged as\n"
-"    slow?"
+#: src/olympia/pages/templates/pages/faq.html:228
+msgid "What does it mean when an add-on is flagged as slow?"
 msgstr ""
 "Що означає, коли додаток відмічений як \n"
 " повільний?"
 
-#: src/olympia/pages/templates/pages/faq.html:231
-msgid ""
-"Most add-ons load code and resources at the same time Firefox is starting "
-"up. In most cases the impact in start-up time is minimal, but some add-ons "
-"can cause a noticeable slowdown."
+#: src/olympia/pages/templates/pages/faq.html:229
+msgid "Most add-ons load code and resources at the same time Firefox is starting up. In most cases the impact in start-up time is minimal, but some add-ons can cause a noticeable slowdown."
 msgstr ""
-"Більшість додатків завантажують код і ресурси під час запуску Firefox. У "
-"більшості випадків це викликає мінімальний вплив на час запуску, але деякі "
-"додатки можуть викликати його помітне уповільнення."
+"Більшість додатків завантажують код і ресурси під час запуску Firefox. У більшості випадків це викликає мінімальний вплив на час запуску, але деякі додатки можуть викликати його помітне "
+"уповільнення."
 
-#: src/olympia/pages/templates/pages/faq.html:236
+#: src/olympia/pages/templates/pages/faq.html:234
 msgid "How do I report an inappropriate or spam user review?"
 msgstr "Як я можу повідомити про невідповідний відгук чи спам?"
 
-#: src/olympia/pages/templates/pages/faq.html:237
+#: src/olympia/pages/templates/pages/faq.html:235
 msgid ""
-"To report a user review of an add-on, log in with your account and visit the"
-" add-on's reviews page. Find the review you wish to report, click \"Report "
-"this review\" and select a reason. Our editorial team will investigate the "
-"review and take appropriate action."
+"To report a user review of an add-on, log in with your account and visit the add-on's reviews page. Find the review you wish to report, click \"Report this review\" and select a reason. Our "
+"editorial team will investigate the review and take appropriate action."
 msgstr ""
-"Щоб повідомити про відгук користувача на додаток, увійдіть в систему під "
-"своїм обліковим записом і відвідайте сторінку відгуків на додаток. Знайдіть "
-"відгук, про який ви хочете повідомити, перейдіть на сторінку \"Повідомити "
-"про цей відгук\" і виберіть причину. Наша команда редакторів розгляне відгук"
-" і вживе відповідних заходів."
+"Щоб повідомити про відгук користувача на додаток, увійдіть в систему під своїм обліковим записом і відвідайте сторінку відгуків на додаток. Знайдіть відгук, про який ви хочете повідомити, перейдіть"
+" на сторінку \"Повідомити про цей відгук\" і виберіть причину. Наша команда редакторів розгляне відгук і вживе відповідних заходів."
 
-#: src/olympia/pages/templates/pages/faq.html:242
+#: src/olympia/pages/templates/pages/faq.html:240
 msgid "How do I report a bug or contact the Mozilla Add-ons team?"
-msgstr ""
-"Як я можу повідомити про помилку чи зв'язатися з командою додатків Mozilla?"
+msgstr "Як я можу повідомити про помилку чи зв'язатися з командою додатків Mozilla?"
 
-#: src/olympia/pages/templates/pages/faq.html:243
+#: src/olympia/pages/templates/pages/faq.html:241
 #, python-format
 msgid "Please visit our <a href=\"%(contact_url)s\">Contact page</a>."
-msgstr ""
-"Відвідайте будь ласка нашу <a href=\"%(contact_url)s\">Сторінку "
-"контактів</a>."
+msgstr "Відвідайте будь ласка нашу <a href=\"%(contact_url)s\">Сторінку контактів</a>."
 
-#: src/olympia/pages/templates/pages/faq.html:246
+#: src/olympia/pages/templates/pages/faq.html:244
 msgid "What is a Source Code License?"
 msgstr "Що таке ліцензія програмного коду?"
 
-#: src/olympia/pages/templates/pages/faq.html:247
+#: src/olympia/pages/templates/pages/faq.html:245
 #, python-format
 msgid ""
-"The source code used to create an add-on is an exclusive copyright of the "
-"add-on author, unless otherwise declared in a source code license. Many add-"
-"ons on this site have <a href=\"%(url)s\" lang=\"en\">open source "
-"licenses</a> that make the source code publicly available for copy and reuse"
-" under conditions determined by the author. Most authors choose widely known"
-" open source licenses like the GPL or BSD licenses instead of making up "
-"their own."
+"The source code used to create an add-on is an exclusive copyright of the add-on author, unless otherwise declared in a source code license. Many add-ons on this site have <a href=\"%(url)s\" "
+"lang=\"en\">open source licenses</a> that make the source code publicly available for copy and reuse under conditions determined by the author. Most authors choose widely known open source licenses"
+" like the GPL or BSD licenses instead of making up their own."
 msgstr ""
-"Автор додатка має ексклюзивне авторське право на програмний код, "
-"використаний для створення додатка, якщо інше не оголошено в ліцензії "
-"програмного коду. Багато додатків на цьому сайті викладені під <a "
-"href=\"%(url)s\" lang=\"en\">ліцензіями відкритого програмного коду</a>, що "
-"робить програмний код публічно доступним для копіювання та повторного "
-"використання на умовах, встановлених автором. Більшість авторів обирають "
-"широко відомі відкриті ліцензії, такі як GPL або BSD, замість того, щоб "
-"винаходити свої власні."
+"Автор додатка має ексклюзивне авторське право на програмний код, використаний для створення додатка, якщо інше не оголошено в ліцензії програмного коду. Багато додатків на цьому сайті викладені під"
+" <a href=\"%(url)s\" lang=\"en\">ліцензіями відкритого програмного коду</a>, що робить програмний код публічно доступним для копіювання та повторного використання на умовах, встановлених автором. "
+"Більшість авторів обирають широко відомі відкриті ліцензії, такі як GPL або BSD, замість того, щоб винаходити свої власні."
 
-#: src/olympia/pages/templates/pages/faq.html:256
+#: src/olympia/pages/templates/pages/faq.html:254
 #, python-format
-msgid ""
-"Firefox and other Mozilla software are <a href=\"%(url)s\">open source</a>."
-msgstr ""
-"Firefox та інші програмні продукти Mozilla <a href=\"%(url)s\">з відкритим "
-"програмним кодом</a>."
+msgid "Firefox and other Mozilla software are <a href=\"%(url)s\">open source</a>."
+msgstr "Firefox та інші програмні продукти Mozilla <a href=\"%(url)s\">з відкритим програмним кодом</a>."
 
-#: src/olympia/pages/templates/pages/faq.html:264
+#: src/olympia/pages/templates/pages/faq.html:262
 msgid "Collections and Favorites"
 msgstr "Збірки та Вподобання"
 
-#: src/olympia/pages/templates/pages/faq.html:267
+#: src/olympia/pages/templates/pages/faq.html:265
 msgid "What is a collection?"
 msgstr "Що таке збірка?"
 
-#: src/olympia/pages/templates/pages/faq.html:268
+#: src/olympia/pages/templates/pages/faq.html:266
 msgid "Collections are groups of related add-ons created by users to share."
 msgstr "Збірки - це групи додатків, створені користувачами для їх поширення."
 
-#: src/olympia/pages/templates/pages/faq.html:270
+#: src/olympia/pages/templates/pages/faq.html:268
 msgid "What is the My Favorites collection?"
 msgstr "Що таке колекція \"Мої улюблені\"?"
 
-#: src/olympia/pages/templates/pages/faq.html:271
-msgid ""
-"Favorite add-ons are add-ons that you have bookmarked to easily get back to "
-"later. You can add an add-on to your favorites collection by clicking \"Add "
-"to favorites\" on its details page."
+#: src/olympia/pages/templates/pages/faq.html:269
+msgid "Favorite add-ons are add-ons that you have bookmarked to easily get back to later. You can add an add-on to your favorites collection by clicking \"Add to favorites\" on its details page."
 msgstr ""
-"Улюбленими додатками є ті, що ви додали в закладки для легкого доступу до "
-"них пізніше. Ви можете додати його до своєї збірки улюблених додатків, "
-"натиснувши на кнопку \"Додати до вподобань\" на сторінці з його описом."
+"Улюбленими додатками є ті, що ви додали в закладки для легкого доступу до них пізніше. Ви можете додати його до своєї збірки улюблених додатків, натиснувши на кнопку \"Додати до вподобань\" на "
+"сторінці з його описом."
 
-#: src/olympia/pages/templates/pages/faq.html:275
-#: src/olympia/templates/menu_links.html:13
-#: src/olympia/templates/impala/header_title.html:17
+#: src/olympia/pages/templates/pages/faq.html:273 src/olympia/templates/menu_links.html:13 src/olympia/templates/impala/header_title.html:17
 msgid "Mobile Add-ons"
 msgstr "Мобільні додатки"
 
-#: src/olympia/pages/templates/pages/faq.html:278
+#: src/olympia/pages/templates/pages/faq.html:276
 msgid "What are mobile add-ons?"
 msgstr "Що таке мобільні додатки?"
 
-#: src/olympia/pages/templates/pages/faq.html:279
+#: src/olympia/pages/templates/pages/faq.html:277
 #, python-format
 msgid ""
-"Mobile add-ons work with <a href=\"%(mobile_url)s\">Firefox for Mobile</a> "
-"and add or modify functionality just like desktop add-ons. You can find add-"
-"ons that work with Firefox for Mobile in our <a "
-"href=\"%(gallery_url)s\">gallery</a>."
+"Mobile add-ons work with <a href=\"%(mobile_url)s\">Firefox for Mobile</a> and add or modify functionality just like desktop add-ons. You can find add-ons that work with Firefox for Mobile in our "
+"<a href=\"%(gallery_url)s\">gallery</a>."
 msgstr ""
-"Мобільні додатки працюють з <a href=\"%(mobile_url)s\">Firefox для мобільних"
-" пристроїв</a> і додають або змінюють функціональність, як і додатки для "
-"настільних комп'ютерів. Ви можете знайти додатки, які працюють з Firefox для"
-" мобільних пристроїв, в нашій <a href=\"%(gallery_url)s\">галереї</a>."
+"Мобільні додатки працюють з <a href=\"%(mobile_url)s\">Firefox для мобільних пристроїв</a> і додають або змінюють функціональність, як і додатки для настільних комп'ютерів. Ви можете знайти "
+"додатки, які працюють з Firefox для мобільних пристроїв, в нашій <a href=\"%(gallery_url)s\">галереї</a>."
 
-#: src/olympia/pages/templates/pages/faq.html:288
+#: src/olympia/pages/templates/pages/faq.html:286
 msgid "Developer Topics"
 msgstr "Теми для розробників"
 
-#: src/olympia/pages/templates/pages/faq.html:289
+#: src/olympia/pages/templates/pages/faq.html:287
 #, python-format
-msgid ""
-"Please see our <a href=\"%(faq_url)s\">Developer FAQ</a> and <a "
-"href=\"%(hub_url)s\">Developer Hub</a> for answers to add-on developer-"
-"related questions."
-msgstr ""
-"Перегляньте наші <a href=\"%(faq_url)s\">ЧаП розробника</a> і <a "
-"href=\"%(hub_url)s\">Центр розробника</a> для отримання відповідей стосовно "
-"розробки додатків."
+msgid "Please see our <a href=\"%(faq_url)s\">Developer FAQ</a> and <a href=\"%(hub_url)s\">Developer Hub</a> for answers to add-on developer-related questions."
+msgstr "Перегляньте наші <a href=\"%(faq_url)s\">ЧаП розробника</a> і <a href=\"%(hub_url)s\">Центр розробника</a> для отримання відповідей стосовно розробки додатків."
 
-#: src/olympia/pages/templates/pages/faq.html:294
+#: src/olympia/pages/templates/pages/faq.html:292
 msgid "Still have questions?"
 msgstr "Залишились питання?"
 
-#: src/olympia/pages/templates/pages/faq.html:295
+#: src/olympia/pages/templates/pages/faq.html:293
 #, python-format
-msgid ""
-"For general Firefox support, visit our <a href=\"%(sumo_url)s\">support "
-"website</a>. For general add-on and website questions, visit our <a "
-"href=\"%(forum_url)s\">forum</a>."
+msgid "For general Firefox support, visit our <a href=\"%(sumo_url)s\">support website</a>. For general add-on and website questions, visit our <a href=\"%(forum_url)s\">forum</a>."
 msgstr ""
-"Для отримання загальної підтримки по Firefox, відвідайте наш <a "
-"href=\"%(sumo_url)s\">веб-сайт підтримки</a>. Для загальних питань щодо "
-"додатків і веб-сайту, відвідайте наш <a href=\"%(forum_url)s\">форум</a>."
+"Для отримання загальної підтримки по Firefox, відвідайте наш <a href=\"%(sumo_url)s\">веб-сайт підтримки</a>. Для загальних питань щодо додатків і веб-сайту, відвідайте наш <a "
+"href=\"%(forum_url)s\">форум</a>."
 
-#: src/olympia/pages/templates/pages/review_guide.html:36
-#: src/olympia/pages/templates/pages/review_guide.html:51
+#: src/olympia/pages/templates/pages/review_guide.html:36 src/olympia/pages/templates/pages/review_guide.html:51
 msgid "Some tips for writing a great review"
 msgstr "Деякі поради з написання хороших відгуків"
 
-#: src/olympia/pages/templates/pages/review_guide.html:39
-#: src/olympia/pages/templates/pages/review_guide.html:131
+#: src/olympia/pages/templates/pages/review_guide.html:39 src/olympia/pages/templates/pages/review_guide.html:131
 msgid "Frequently Asked Questions about Reviews"
 msgstr "Поширені питання про відгуки"
 
 #: src/olympia/pages/templates/pages/review_guide.html:46
 msgid ""
-"Add-on reviews are a way for you to share your opinions about the add-ons "
-"you’ve installed and used. Our review moderation team reserves the right to "
-"refuse or remove any review that does not comply with these guidelines."
-msgstr ""
-"Відгуки є способом поділитися своїми враженнями про використання додатку. "
-"Наша команда модераторів залишає за собою право відхиляти або видаляти будь-"
-"який відгук, який не відповідає цим критеріям."
+"Add-on reviews are a way for you to share your opinions about the add-ons you’ve installed and used. Our review moderation team reserves the right to refuse or remove any review that does not "
+"comply with these guidelines."
+msgstr "Відгуки є способом поділитися своїми враженнями про використання додатку. Наша команда модераторів залишає за собою право відхиляти або видаляти будь-який відгук, який не відповідає цим критеріям."
 
 #: src/olympia/pages/templates/pages/review_guide.html:53
 msgid "Do:"
 msgstr "Вам слід:"
 
 #: src/olympia/pages/templates/pages/review_guide.html:56
-msgid ""
-"Write like you are telling a friend about your experience with the add-on."
+msgid "Write like you are telling a friend about your experience with the add-on."
 msgstr "Напишіть про свій досвід використання додатку."
 
 #: src/olympia/pages/templates/pages/review_guide.html:61
@@ -13599,8 +10607,7 @@ msgid "Will you continue to use this add-on?"
 msgstr "Чи будете ви надалі користуватися цим додатком?"
 
 #: src/olympia/pages/templates/pages/review_guide.html:73
-msgid ""
-"Take a moment to read your review before submitting it to minimize typos."
+msgid "Take a moment to read your review before submitting it to minimize typos."
 msgstr "Перевірте свій відгук перед відправленням для мінімізації помилок."
 
 #: src/olympia/pages/templates/pages/review_guide.html:79
@@ -13609,71 +10616,47 @@ msgstr "Вам не слід:"
 
 #: src/olympia/pages/templates/pages/review_guide.html:82
 msgid "Submit one-word reviews such as \"Great!\", \"wonderful,\" or \"bad.\""
-msgstr ""
-"Відправляти односкладові відгуки такі, як \"Відмінно!\", \"чудово\" чи "
-"\"погано\"."
+msgstr "Відправляти односкладові відгуки такі, як \"Відмінно!\", \"чудово\" чи \"погано\"."
 
 #: src/olympia/pages/templates/pages/review_guide.html:87
 msgid ""
-"Post technical issues, support requests, or feature suggestions. Use the "
-"available support options for each add-on, if available. You can find them "
-"in the side column next to the About this Add-on section."
+"Post technical issues, support requests, or feature suggestions. Use the available support options for each add-on, if available. You can find them in the side column next to the About this Add-on "
+"section."
 msgstr ""
-"Ставити технічні питання, питання підтримки або пропонувати нові функції. "
-"Використовуйте доступні варіанти підтримки для кожного додатка, якщо вони є."
-" Ви можете знайти їх в бічному стовпчику поряд із розділом Про цей додаток."
+"Ставити технічні питання, питання підтримки або пропонувати нові функції. Використовуйте доступні варіанти підтримки для кожного додатка, якщо вони є. Ви можете знайти їх в бічному стовпчику поряд "
+"із розділом Про цей додаток."
 
 #: src/olympia/pages/templates/pages/review_guide.html:92
 msgid "Write reviews for add-ons which you have not personally used."
 msgstr "Писати відгуки на додатки, які ви особисто не використали."
 
 #: src/olympia/pages/templates/pages/review_guide.html:97
-msgid ""
-"Use profanity, sexual language or language that can be construed as hateful."
-msgstr ""
-"Використовувати ненормативну лексику, непристойні вирази або слова, які "
-"можуть бути витлумачені як ненависть."
+msgid "Use profanity, sexual language or language that can be construed as hateful."
+msgstr "Використовувати ненормативну лексику, непристойні вирази або слова, які можуть бути витлумачені як ненависть."
 
 #: src/olympia/pages/templates/pages/review_guide.html:103
-msgid ""
-"Include HTML, links, source code or code snippets. Reviews are meant to be "
-"text only."
-msgstr ""
-"Включати HTML, посилання, програмний код або фрагменти коду. Відгуки повинні"
-" містити тільки текст."
+msgid "Include HTML, links, source code or code snippets. Reviews are meant to be text only."
+msgstr "Включати HTML, посилання, програмний код або фрагменти коду. Відгуки повинні містити тільки текст."
 
 #: src/olympia/pages/templates/pages/review_guide.html:108
-msgid ""
-"Make false statements, disparage add-on authors or personally insult them."
-msgstr ""
-"Робити неправдиві заяви, принижувати або особисто ображати авторів додатків."
+msgid "Make false statements, disparage add-on authors or personally insult them."
+msgstr "Робити неправдиві заяви, принижувати або особисто ображати авторів додатків."
 
 #: src/olympia/pages/templates/pages/review_guide.html:114
-msgid ""
-"Include your own or anyone else’s email, phone number, or other personal "
-"details."
-msgstr ""
-"Включати ваші власні або чиїсь ще адреси ел. пошти, номери телефонів або "
-"інші персональні дані."
+msgid "Include your own or anyone else’s email, phone number, or other personal details."
+msgstr "Включати ваші власні або чиїсь ще адреси ел. пошти, номери телефонів або інші персональні дані."
 
 #: src/olympia/pages/templates/pages/review_guide.html:119
-msgid ""
-"Post reviews for an add-on you or your organization wrote or represent."
-msgstr ""
-"Розміщувати відгуки на додаток, написаний чи представлений вами або вашою "
-"організацією."
+msgid "Post reviews for an add-on you or your organization wrote or represent."
+msgstr "Розміщувати відгуки на додаток, написаний чи представлений вами або вашою організацією."
 
 #: src/olympia/pages/templates/pages/review_guide.html:125
 msgid ""
-"Criticize an add-on for something it’s intended to do. For example, leaving "
-"a negative review of an add-on for displaying ads or requiring data "
-"gathering, when that is the intended purpose of the add-on, or the add-on "
-"requires gathering data to function."
+"Criticize an add-on for something it’s intended to do. For example, leaving a negative review of an add-on for displaying ads or requiring data gathering, when that is the intended purpose of the "
+"add-on, or the add-on requires gathering data to function."
 msgstr ""
-"Критикувати додаток за щось, що він й призначений робити. Наприклад, "
-"залишати негативний відгук на додаток за показ реклами або вимогу збору "
-"даних, коли це є метою цього додатка, або додатку необхідний збір даних для "
-"його роботи."
+"Критикувати додаток за щось, що він й призначений робити. Наприклад, залишати негативний відгук на додаток за показ реклами або вимогу збору даних, коли це є метою цього додатка, або додатку "
+"необхідний збір даних для його роботи."
 
 #: src/olympia/pages/templates/pages/review_guide.html:133
 msgid "How can I report a problematic review?"
@@ -13681,15 +10664,11 @@ msgstr "Як мені повідомити про некоректний від�
 
 #: src/olympia/pages/templates/pages/review_guide.html:135
 msgid ""
-"Please report or flag any questionable reviews by clicking the \"Report this"
-" review\" and it will be submitted to the site for moderation. Our "
-"moderation team will use the Review Guidelines to evaluate whether or not to"
-" delete the review or restore it back to the site."
+"Please report or flag any questionable reviews by clicking the \"Report this review\" and it will be submitted to the site for moderation. Our moderation team will use the Review Guidelines to "
+"evaluate whether or not to delete the review or restore it back to the site."
 msgstr ""
-"Будь ласка, повідомляйте або відзначайте прапором будь-які сумнівні відгуки,"
-" клацнувши \"Повідомити про цей відгук\" і він буде відправлений на сайт для"
-" модерації. Наша команда модераторів буде використовувати Вказівки щодо "
-"відгуків, щоб вирішити, чи видалити відгук або відновити його на сайті."
+"Будь ласка, повідомляйте або відзначайте прапором будь-які сумнівні відгуки, клацнувши \"Повідомити про цей відгук\" і він буде відправлений на сайт для модерації. Наша команда модераторів буде "
+"використовувати Вказівки щодо відгуків, щоб вирішити, чи видалити відгук або відновити його на сайті."
 
 #: src/olympia/pages/templates/pages/review_guide.html:140
 msgid "I’m an add-on author, can I respond to reviews?"
@@ -13697,15 +10676,10 @@ msgstr "Я автор додатка, чи можу я відповідати н
 
 #: src/olympia/pages/templates/pages/review_guide.html:142
 #, python-format
-msgid ""
-"Yes, add-on authors can provide a single response to a review. You can set "
-"up a discussion topic in our <a href=\"%(forum_url)s\">forum</a> to engage "
-"in additional discussion or follow-up."
+msgid "Yes, add-on authors can provide a single response to a review. You can set up a discussion topic in our <a href=\"%(forum_url)s\">forum</a> to engage in additional discussion or follow-up."
 msgstr ""
-"Так, автори додатків можуть написати одну відповідь на відгук. Ви можете "
-"створити тему для обговорення на нашому <a "
-"href=\"%(forum_url)s\">форумі</a>, щоб взяти участь у додатковій або "
-"подальшої дискусії."
+"Так, автори додатків можуть написати одну відповідь на відгук. Ви можете створити тему для обговорення на нашому <a href=\"%(forum_url)s\">форумі</a>, щоб взяти участь у додатковій або подальшої "
+"дискусії."
 
 #: src/olympia/pages/templates/pages/review_guide.html:149
 msgid "I’m an add-on author, can I delete unfavorable reviews or ratings?"
@@ -13713,18 +10687,11 @@ msgstr "Я автор додатка, чи можу я видаляти несп
 
 #: src/olympia/pages/templates/pages/review_guide.html:151
 msgid ""
-"In general, no. But if the review did not meet the review guidelines "
-"outlined above, you can click \"Report this review\" and have it moderated. "
-"If a review included a complaint that is no longer valid due to a new "
-"release of your add-on, we may consider deleting the review. Submit your "
-"detailed request to amo-editors@mozilla.org."
+"In general, no. But if the review did not meet the review guidelines outlined above, you can click \"Report this review\" and have it moderated. If a review included a complaint that is no longer "
+"valid due to a new release of your add-on, we may consider deleting the review. Submit your detailed request to amo-editors@mozilla.org."
 msgstr ""
-"Загалом, ні. Але якщо відгук не відповідає викладеним вище вимогам до "
-"відгуків, ви можете клацнути на лінк \"Повідомити про цей додаток\" і він "
-"буде перевірений. Якщо відгук містить скаргу, яка більше не є актуальною у "
-"зв'язку з виходом нової версії вашого додатка, ми можемо розглянути "
-"можливість видалення відгуку. Надішліть свій докладний запит на адресу amo-"
-"editors@mozilla.org."
+"Загалом, ні. Але якщо відгук не відповідає викладеним вище вимогам до відгуків, ви можете клацнути на лінк \"Повідомити про цей додаток\" і він буде перевірений. Якщо відгук містить скаргу, яка "
+"більше не є актуальною у зв'язку з виходом нової версії вашого додатка, ми можемо розглянути можливість видалення відгуку. Надішліть свій докладний запит на адресу amo-editors@mozilla.org."
 
 #: src/olympia/pages/templates/pages/sunbird.html:26
 msgid "Sunbird has retired"
@@ -13732,24 +10699,16 @@ msgstr "Sunbird більше не розвивається"
 
 #: src/olympia/pages/templates/pages/sunbird.html:29
 msgid ""
-"Development on the Sunbird project has halted and its final release was on "
-"March 30, 2010. We've been proud to host Sunbird add-ons on this site but as"
-" the project is no longer maintained we have disabled our support for the "
-"add-ons."
+"Development on the Sunbird project has halted and its final release was on March 30, 2010. We've been proud to host Sunbird add-ons on this site but as the project is no longer maintained we have "
+"disabled our support for the add-ons."
 msgstr ""
-"Розробка проекту Sunbird припинена і його останній реліз відбувся 30 березня"
-" 2010 року. Ми були горді тим, що розміщували додатки Sunbird на цьому "
-"сайті, але так як цей проект більше не розвивається, ми відключили підтримку"
-" цих додатків."
+"Розробка проекту Sunbird припинена і його останній реліз відбувся 30 березня 2010 року. Ми були горді тим, що розміщували додатки Sunbird на цьому сайті, але так як цей проект більше не "
+"розвивається, ми відключили підтримку цих додатків."
 
 #: src/olympia/pages/templates/pages/sunbird.html:38
 #, python-format
-msgid ""
-"We recommend upgrading to <a href=\"%(tb_url)s\">Thunderbird</a> and <a "
-"href=\"%(lightning_url)s\">Lightning</a>."
-msgstr ""
-"Ми рекомендуємо оновитися на <a href=\"%(tb_url)s\">Thunderbird</a> і <a "
-"href=\"%(lightning_url)s\">Lightning</a>."
+msgid "We recommend upgrading to <a href=\"%(tb_url)s\">Thunderbird</a> and <a href=\"%(lightning_url)s\">Lightning</a>."
+msgstr "Ми рекомендуємо оновитися на <a href=\"%(tb_url)s\">Thunderbird</a> і <a href=\"%(lightning_url)s\">Lightning</a>."
 
 #: src/olympia/pages/templates/pages/sunbird.html:45
 msgid "Read more about Sunbird"
@@ -13757,8 +10716,7 @@ msgstr "Дізнайтеся більше про Sunbird"
 
 #: src/olympia/paypal/__init__.py:25
 msgid "There was an error communicating with PayPal. Please try again later."
-msgstr ""
-"Під час з'єднання з PayPal сталася помилка. Будь ласка, спробуйте пізніше."
+msgstr "Під час з'єднання з PayPal сталася помилка. Будь ласка, спробуйте пізніше."
 
 #: src/olympia/paypal/__init__.py:50
 msgid "There was an error with this currency."
@@ -13801,8 +10759,7 @@ msgstr "Утримати рецензію; видалити мітки"
 msgid "Skip for now"
 msgstr "Пропустити зараз"
 
-#: src/olympia/reviews/forms.py:151
-#: src/olympia/reviews/templates/reviews/review.html:107
+#: src/olympia/reviews/forms.py:151 src/olympia/reviews/templates/reviews/review.html:107
 msgid "Delete review"
 msgstr "Видалити відгук"
 
@@ -13821,42 +10778,24 @@ msgstr "Додати відгук для {0}"
 #: src/olympia/reviews/templates/reviews/add.html:26
 #, python-format
 msgid ""
-"<h2>Keep these tips in mind:</h2> <ul> <li> Write like you're telling a "
-"friend about your experience with the add-on. Give specifics and helpful "
-"details, such as what features you liked and/or disliked, how easy to use it"
-" is, and any disadvantages it has. Avoid generic language such as calling it"
-" \"Great\" or \"Bad\" unless you can give reasons why you believe this is "
-"so. </li> <li> Please do not post bug reports in reviews. We do not make "
-"your email address available to add-on developers and they may need to "
-"contact you to help resolve your issue. See the <a "
-"href=\"%(support)s\">support section</a> to find out where to get assistance"
-" for this add-on. </li> <li>Please keep reviews clean, avoid the use of "
-"improper language and do not post any personal information. </li> </ul> "
-"<p>Please read the <a href=\"%(guide)s\" target=\"_blank\">Review "
-"Guidelines</a> for more detail about user add-on reviews.</p>"
+"<h2>Keep these tips in mind:</h2> <ul> <li> Write like you're telling a friend about your experience with the add-on. Give specifics and helpful details, such as what features you liked and/or "
+"disliked, how easy to use it is, and any disadvantages it has. Avoid generic language such as calling it \"Great\" or \"Bad\" unless you can give reasons why you believe this is so. </li> <li> "
+"Please do not post bug reports in reviews. We do not make your email address available to add-on developers and they may need to contact you to help resolve your issue. See the <a "
+"href=\"%(support)s\">support section</a> to find out where to get assistance for this add-on. </li> <li>Please keep reviews clean, avoid the use of improper language and do not post any personal "
+"information. </li> </ul> <p>Please read the <a href=\"%(guide)s\" target=\"_blank\">Review Guidelines</a> for more detail about user add-on reviews.</p>"
 msgstr ""
-"<h2>Дотримуйтесь цих порад:</h2> <ul> <li> Пишіть так, наче ви розповідаєте "
-"другу про свій досвід користування додатком. Додайте особливі й корисні "
-"деталі, наприклад, які функції вам сподобались та/або не сподобались, "
-"наскільки він легкий в користуванні, а також будь-які знайдені недоліки. "
-"Уникайте загальних виразів, таких як \"Чудовий\" або \"Поганий\" доки ви не "
-"зможете вказати причин такого висновку. </li> <li> Будь ласка, не додавайте "
-"звіти про помилки до відгуків. Ваша адреса електронної пошти недоступна для "
-"розробників додатку, і їм, можливо, знадобиться зв'язатися з вами для "
-"допомоги у вирішенні проблеми. Перегляньте <a href=\"%(support)s\">розділ "
-"підтримки</a>, щоб дізнатися де отримати допомогу для цього додатку. </li> "
-"<li>Будь ласка, залишайте відгуки чистими, уникайте використання "
-"невідповідної мови та не публікуйте будь-якої особистої інформації. </li> "
-"</ul> <p>Будь ласка, ознайомтеся з <a href=\"%(guide)s\" "
-"target=\"_blank\">Настановами з відгуків</a> для отримання докладних "
-"відомостей про відгуки користувачів про додатки.</p>"
+"<h2>Дотримуйтесь цих порад:</h2> <ul> <li> Пишіть так, наче ви розповідаєте другу про свій досвід користування додатком. Додайте особливі й корисні деталі, наприклад, які функції вам сподобались "
+"та/або не сподобались, наскільки він легкий в користуванні, а також будь-які знайдені недоліки. Уникайте загальних виразів, таких як \"Чудовий\" або \"Поганий\" доки ви не зможете вказати причин "
+"такого висновку. </li> <li> Будь ласка, не додавайте звіти про помилки до відгуків. Ваша адреса електронної пошти недоступна для розробників додатку, і їм, можливо, знадобиться зв'язатися з вами "
+"для допомоги у вирішенні проблеми. Перегляньте <a href=\"%(support)s\">розділ підтримки</a>, щоб дізнатися де отримати допомогу для цього додатку. </li> <li>Будь ласка, залишайте відгуки чистими, "
+"уникайте використання невідповідної мови та не публікуйте будь-якої особистої інформації. </li> </ul> <p>Будь ласка, ознайомтеся з <a href=\"%(guide)s\" target=\"_blank\">Настановами з відгуків</a>"
+" для отримання докладних відомостей про відгуки користувачів про додатки.</p>"
 
 #: src/olympia/reviews/templates/reviews/reply.html:4
 msgid "Reply to review by {0}"
 msgstr "Відповісти на відгук від {0}"
 
-#: src/olympia/reviews/templates/reviews/reply.html:15
-#: src/olympia/reviews/templates/reviews/reply.html:31
+#: src/olympia/reviews/templates/reviews/reply.html:15 src/olympia/reviews/templates/reviews/reply.html:31
 msgid "Reply"
 msgstr "Відповісти"
 
@@ -13864,8 +10803,7 @@ msgstr "Відповісти"
 msgid "Write a Reply"
 msgstr "Написати відповідь"
 
-#: src/olympia/reviews/templates/reviews/reply.html:36
-#: src/olympia/reviews/templates/reviews/report_review.html:12
+#: src/olympia/reviews/templates/reviews/reply.html:36 src/olympia/reviews/templates/reviews/report_review.html:12
 msgid "Submit"
 msgstr "Затвердити"
 
@@ -13885,37 +10823,21 @@ msgid "by %(user)s <b>(Developer)</b> on %(date)s"
 msgstr "від %(user)s <b>(Розробник)</b> %(date)s"
 
 #. {0} is a version number (like 1.01)
-#: src/olympia/reviews/templates/reviews/review.html:50
-#: src/olympia/reviews/templates/reviews/mobile/review_list.html:41
+#: src/olympia/reviews/templates/reviews/review.html:50 src/olympia/reviews/templates/reviews/mobile/review_list.html:41
 msgid "This review is for a previous version of the add-on ({0})."
 msgstr "Цей відгук для попередньої версії додатку ({0})."
 
 #: src/olympia/reviews/templates/reviews/review.html:56
 #, python-format
-msgid ""
-"This user has a <a href=\"%(user_review_url)s\">previous review</a> of this "
-"add-on."
-msgid_plural ""
-"This user has <a href=\"%(user_review_url)s\">%(cnt)s previous reviews</a> "
-"of this add-on."
-msgstr[0] ""
-"Цей користувач має <a href=\"%(user_review_url)s\">попередній відгук</a> про"
-" цей додаток."
-msgstr[1] ""
-"Цей користувач має <a href=\"%(user_review_url)s\">%(cnt)s попередні "
-"відгуки</a> про цей додаток."
-msgstr[2] ""
-"Цей користувач має <a href=\"%(user_review_url)s\">%(cnt)s попередніх "
-"відгуків</a> про цей додаток."
+msgid "This user has a <a href=\"%(user_review_url)s\">previous review</a> of this add-on."
+msgid_plural "This user has <a href=\"%(user_review_url)s\">%(cnt)s previous reviews</a> of this add-on."
+msgstr[0] "Цей користувач має <a href=\"%(user_review_url)s\">попередній відгук</a> про цей додаток."
+msgstr[1] "Цей користувач має <a href=\"%(user_review_url)s\">%(cnt)s попередні відгуки</a> про цей додаток."
 
 #: src/olympia/reviews/templates/reviews/review.html:62
 #, python-format
-msgid ""
-"This user has <a href=\"%(user_review_url)s\">other reviews</a> of this add-"
-"on."
-msgstr ""
-"Цей користувач має <a href=\"%(user_review_url)s\">інші відгуки</a> про цей "
-"додаток."
+msgid "This user has <a href=\"%(user_review_url)s\">other reviews</a> of this add-on."
+msgstr "Цей користувач має <a href=\"%(user_review_url)s\">інші відгуки</a> про цей додаток."
 
 #: src/olympia/reviews/templates/reviews/review.html:72
 msgid "Flagged for review"
@@ -13947,9 +10869,7 @@ msgid "{0} :: Reviews"
 msgstr "{0} :: Відгуки"
 
 #. {0} is an addon name.
-#: src/olympia/reviews/templates/reviews/review_list.html:24
-#: src/olympia/reviews/templates/reviews/mobile/add.html:4
-#: src/olympia/reviews/templates/reviews/mobile/review_list.html:4
+#: src/olympia/reviews/templates/reviews/review_list.html:24 src/olympia/reviews/templates/reviews/mobile/add.html:4 src/olympia/reviews/templates/reviews/mobile/review_list.html:4
 msgid "Reviews for {0}"
 msgstr "Відгуки для {0}"
 
@@ -13959,7 +10879,6 @@ msgid "<b>{0}</b> review for this add-on"
 msgid_plural "<b>{0}</b> reviews for this add-on"
 msgstr[0] "<b>{0}</b> відгук для цього додатку"
 msgstr[1] "<b>{0}</b> відгуки для цього додатку"
-msgstr[2] "<b>{0}</b> відгуків для цього додатку"
 
 #. {0} is a developer's name.
 #: src/olympia/reviews/templates/reviews/review_list.html:33
@@ -13972,7 +10891,6 @@ msgid "Review for %(addon)s by %(user)s"
 msgid_plural "Reviews for %(addon)s by %(user)s"
 msgstr[0] "Відгук для %(addon)s від %(user)s"
 msgstr[1] "Відгуки для %(addon)s від %(user)s"
-msgstr[2] "Відгуків для %(addon)s від %(user)s"
 
 #: src/olympia/reviews/templates/reviews/review_list.html:42
 msgid "No reviews found."
@@ -13987,8 +10905,7 @@ msgstr "<strong>В середньому</strong> (%(total)s)"
 msgid "Write a New Review"
 msgstr "Написати новий відгук"
 
-#: src/olympia/reviews/templates/reviews/review_list.html:81
-#: src/olympia/reviews/templates/reviews/mobile/reviews_link.html:15
+#: src/olympia/reviews/templates/reviews/review_list.html:81 src/olympia/reviews/templates/reviews/mobile/reviews_link.html:15
 msgid "Be the first to write a review."
 msgstr "Напишіть перший відгук."
 
@@ -13997,7 +10914,6 @@ msgid "{num} review"
 msgid_plural "{num} reviews"
 msgstr[0] "{num} відгук"
 msgstr[1] "{num} відгуки"
-msgstr[2] "{num} відгуків"
 
 #: src/olympia/reviews/templates/reviews/impala/reviews_rating.html:1
 msgid "Rated {0} out of 5 stars"
@@ -14008,8 +10924,7 @@ msgstr "Оцінка {0} з 5 зірок"
 msgid "Rated %(rating)s out of 5 stars"
 msgstr "Оцінено на %(rating)s з 5 зірок"
 
-#: src/olympia/reviews/templates/reviews/mobile/add_form.html:3
-#: src/olympia/reviews/templates/reviews/mobile/add_form.html:8
+#: src/olympia/reviews/templates/reviews/mobile/add_form.html:3 src/olympia/reviews/templates/reviews/mobile/add_form.html:8
 msgid "Add a Review"
 msgstr "Додати відгук"
 
@@ -14026,7 +10941,6 @@ msgid "Average from {0} Rating"
 msgid_plural "Average from {0} Ratings"
 msgstr[0] "Середнє з {0} рейтинга"
 msgstr[1] "Середнє з {0} рейтингів"
-msgstr[2] "Середнє з {0} рейтингів"
 
 #: src/olympia/reviews/templates/reviews/mobile/review_list.html:34
 #, python-format
@@ -14043,7 +10957,6 @@ msgid "See All Reviews"
 msgid_plural "See All %(cnt)s Reviews"
 msgstr[0] "Подивитися всі відгуки"
 msgstr[1] "Подивитися всі %(cnt)s відгуки"
-msgstr[2] "Подивитися всі %(cnt)s відгуків"
 
 #: src/olympia/search/forms.py:11
 msgid "Most popular this week"
@@ -14082,18 +10995,12 @@ msgid "Relevance"
 msgstr "Релевантність"
 
 #: src/olympia/search/helpers.py:24
-msgid ""
-"Results <strong>{0}</strong>-<strong>{1}</strong> of <strong>{2}</strong>"
-msgstr ""
-"Результати <strong>{0}</strong>-<strong>{1}</strong> з <strong>{2}</strong>"
+msgid "Results <strong>{0}</strong>-<strong>{1}</strong> of <strong>{2}</strong>"
+msgstr "Результати <strong>{0}</strong>-<strong>{1}</strong> з <strong>{2}</strong>"
 
 #: src/olympia/search/helpers.py:44
-msgid ""
-"Showing {0} - {1} of {2} results for <strong>{3}</strong> tagged with "
-"<strong>{4}</strong>"
-msgstr ""
-"Показ результатів {0} - {1} з {2} для <strong>{3}</strong> позначених як "
-"<strong>{4}</strong>"
+msgid "Showing {0} - {1} of {2} results for <strong>{3}</strong> tagged with <strong>{4}</strong>"
+msgstr "Показ результатів {0} - {1} з {2} для <strong>{3}</strong> позначених як <strong>{4}</strong>"
 
 #: src/olympia/search/helpers.py:49
 msgid "Showing {0} - {1} of {2} results for <strong>{3}</strong>"
@@ -14108,24 +11015,22 @@ msgid "Showing {0} - {1} of {2} results"
 msgstr "Показ результатів {0} - {1} з {2}"
 
 #. {0} is an application, like Firefox.
-#: src/olympia/search/views.py:264 src/olympia/templates/base.html:17
-#: src/olympia/templates/impala/base.html:17
-#: src/olympia/templates/mobile/base_addons.html:17
+#: src/olympia/search/views.py:264 src/olympia/templates/base.html:17 src/olympia/templates/impala/base.html:17 src/olympia/templates/mobile/base_addons.html:17
 msgid "{0} Add-ons"
 msgstr "Додатки {0}"
 
 #. L10n: {0} is an application, such as Firefox. This means "any version of
 #. Firefox."
-#: src/olympia/search/views.py:554
+#: src/olympia/search/views.py:547
 msgid "Any {0}"
 msgstr "Будь-яка {0}"
 
 #. L10n: "All Systems" means show everything regardless of platform.
-#: src/olympia/search/views.py:589
+#: src/olympia/search/views.py:582
 msgid "All Systems"
 msgstr "Всі системи"
 
-#: src/olympia/search/views.py:600
+#: src/olympia/search/views.py:593
 msgid "All Tags"
 msgstr "Всі мітки"
 
@@ -14170,7 +11075,6 @@ msgid "<b>{0}</b> matching result"
 msgid_plural "<b>{0}</b> matching results"
 msgstr[0] "<b>{0}</b> відповідний результат"
 msgstr[1] "<b>{0}</b> відповідних результата"
-msgstr[2] "<b>{0}</b> відповідних результатів"
 
 #: src/olympia/search/templates/search/results.html:67
 msgid "Filter Results"
@@ -14193,7 +11097,6 @@ msgid "{0} post"
 msgid_plural "{0} posts"
 msgstr[0] "{0} пост"
 msgstr[1] "{0} поста"
-msgstr[2] "{0} пости"
 
 #: src/olympia/sharing/__init__.py:20
 msgid "Post to Facebook"
@@ -14204,7 +11107,6 @@ msgid "{0} Like"
 msgid_plural "{0} Likes"
 msgstr[0] "{0} вподобання"
 msgstr[1] "{0} вподобання"
-msgstr[2] "{0} вподобань"
 
 #: src/olympia/sharing/__init__.py:30
 msgid "Tweet on Twitter"
@@ -14215,7 +11117,6 @@ msgid "{0} tweet"
 msgid_plural "{0} tweets"
 msgstr[0] "{0} твіт"
 msgstr[1] "{0} твіти"
-msgstr[2] "{0} твітів"
 
 #: src/olympia/sharing/__init__.py:40
 msgid "Share on g+"
@@ -14250,7 +11151,6 @@ msgid "{0} post on localservice1"
 msgid_plural "{0} posts on localservice1"
 msgstr[0] "{0} поширення на Facebook"
 msgstr[1] "{0} поширення на Facebook"
-msgstr[2] "{0} поширень на Facebook"
 
 #. L10n: Only change if you have reason! wiki.mozilla.org/AMO:Localizers
 #: src/olympia/sharing/__init__.py:76
@@ -14273,7 +11173,6 @@ msgid "{0} post on localservice2"
 msgid_plural "{0} posts on localservice2"
 msgstr[0] "{0} post on localservice2"
 msgstr[1] "{0} posts on localservice2"
-msgstr[2] "{0} posts on localservice2"
 
 #. L10n: Only change if you have reason! wiki.mozilla.org/AMO:Localizers
 #: src/olympia/sharing/__init__.py:91
@@ -14296,7 +11195,6 @@ msgid "{0} post on localservice3"
 msgid_plural "{0} posts on localservice3"
 msgstr[0] "{0} post on localservice3"
 msgstr[1] "{0} posts on localservice3"
-msgstr[2] "{0} posts on localservice3"
 
 #: src/olympia/sharing/templates/sharing/sharing_widget.html:2
 msgid "Share this Add-on"
@@ -14306,36 +11204,31 @@ msgstr "Поділитися цим додатком"
 msgid "Share this Collection"
 msgstr "Поділитися цією збіркою"
 
-#: src/olympia/signing/views.py:30 src/olympia/templates/base.html:75
-#: src/olympia/templates/impala/base.html:115
-msgid ""
-"Some features are temporarily disabled while we perform website maintenance."
-" We'll be back to full capacity shortly."
-msgstr ""
-"Деякі функції тимчасово недоступні, поки ми проводимо обслуговування сайту. "
-"Незабаром ми повернемо повну функціональність."
+#: src/olympia/signing/views.py:33 src/olympia/templates/base.html:71 src/olympia/templates/impala/base.html:112
+msgid "Some features are temporarily disabled while we perform website maintenance. We'll be back to full capacity shortly."
+msgstr "Деякі функції тимчасово недоступні, поки ми проводимо обслуговування сайту. Незабаром ми повернемо повну функціональність."
 
-#: src/olympia/signing/views.py:53
+#: src/olympia/signing/views.py:56
 msgid "Could not find add-on with id \"{}\"."
 msgstr "Не вдалося знайти додаток з ID \"{}\"."
 
-#: src/olympia/signing/views.py:67
+#: src/olympia/signing/views.py:70
 msgid "You do not own this addon."
 msgstr "Ви не володієте цим додатком."
 
-#: src/olympia/signing/views.py:82
+#: src/olympia/signing/views.py:87
 msgid "Missing \"upload\" key in multipart file data."
 msgstr "Відсутній ключ \"upload\" під час надсилання файлу."
 
-#: src/olympia/signing/views.py:96
+#: src/olympia/signing/views.py:101
 msgid "Version does not match the manifest file."
 msgstr "Версія не відповідає файлу маніфесту."
 
-#: src/olympia/signing/views.py:100
+#: src/olympia/signing/views.py:105
 msgid "Version already exists."
 msgstr "Версія вже існує."
 
-#: src/olympia/signing/views.py:136
+#: src/olympia/signing/views.py:141
 msgid "No uploaded file for that addon and version."
 msgstr "Немає завантаженого файлу для цього додатка і версії."
 
@@ -14427,8 +11320,7 @@ msgstr "Від"
 msgid "To"
 msgstr "До"
 
-#: src/olympia/stats/templates/stats/popup.html:27
-#: src/olympia/users/templates/users/pwreset_confirm.html:38
+#: src/olympia/stats/templates/stats/popup.html:27 src/olympia/users/templates/users/pwreset_confirm.html:38
 msgid "Update"
 msgstr "Оновити"
 
@@ -14449,98 +11341,89 @@ msgstr "{0} :: Панель статистики"
 msgid "Statistics Dashboard :: Add-ons for {0}"
 msgstr "Панель статистики :: Додатки для {0}"
 
-#: src/olympia/stats/templates/stats/stats.html:30
-msgid "Controls:"
-msgstr "Керування:"
-
-#: src/olympia/stats/templates/stats/stats.html:33
-msgid "reset zoom"
-msgstr "скинути масштаб"
-
-#: src/olympia/stats/templates/stats/stats.html:40
-msgid "Group by:"
-msgstr "Групувати за:"
-
-#: src/olympia/stats/templates/stats/stats.html:42
-msgid "day"
-msgstr "днем"
-
-#: src/olympia/stats/templates/stats/stats.html:45
-msgid "week"
-msgstr "тижнем"
-
-#: src/olympia/stats/templates/stats/stats.html:48
-msgid "month"
-msgstr "місяцем"
-
-#: src/olympia/stats/templates/stats/stats.html:54
-msgid "For last:"
-msgstr "За останні:"
-
-#: src/olympia/stats/templates/stats/stats.html:57
-msgid "7 days"
-msgstr "7 днів"
-
-#: src/olympia/stats/templates/stats/stats.html:60
-msgid "30 days"
-msgstr "30 днів"
-
-#: src/olympia/stats/templates/stats/stats.html:63
-msgid "90 days"
-msgstr "90 днів"
-
-#: src/olympia/stats/templates/stats/stats.html:66
-msgid "365 days"
-msgstr "365 днів"
-
-#: src/olympia/stats/templates/stats/stats.html:69
-msgid "Custom..."
-msgstr "Вибрати..."
-
 #. {0} is an add-on name
-#: src/olympia/stats/templates/stats/stats.html:88
-#: src/olympia/stats/templates/stats/stats.html:91
+#: src/olympia/stats/templates/stats/stats.html:44 src/olympia/stats/templates/stats/stats.html:47
 msgid "Statistics for {0}"
 msgstr "Статистика для {0}"
 
-#: src/olympia/stats/templates/stats/stats.html:94
+#: src/olympia/stats/templates/stats/stats.html:50
 msgid "Statistics Dashboard"
 msgstr "Панель статистики"
 
-#: src/olympia/stats/templates/stats/stats.html:104
-msgid ""
-"Statistics processing is currently disabled, so recent data is unavailable. "
-"The statistics are still being collected and this page will be updated soon "
-"with the missing data."
-msgstr ""
-"Обробка статистики в даний час відключена, тому останні дані недоступні. "
-"Статистика збирається й досі і ця сторінка буде оновлена найближчим часом з "
-"відсутніми на цей час даними."
+#: src/olympia/stats/templates/stats/stats.html:57
+msgid "Controls:"
+msgstr "Керування:"
 
-#: src/olympia/stats/templates/stats/stats.html:110
+#: src/olympia/stats/templates/stats/stats.html:60
+msgid "reset zoom"
+msgstr "скинути масштаб"
+
+#: src/olympia/stats/templates/stats/stats.html:67
+msgid "Group by:"
+msgstr "Групувати за:"
+
+#: src/olympia/stats/templates/stats/stats.html:69
+msgid "day"
+msgstr "днем"
+
+#: src/olympia/stats/templates/stats/stats.html:72
+msgid "week"
+msgstr "тижнем"
+
+#: src/olympia/stats/templates/stats/stats.html:75
+msgid "month"
+msgstr "місяцем"
+
+#: src/olympia/stats/templates/stats/stats.html:81
+msgid "For last:"
+msgstr "За останні:"
+
+#: src/olympia/stats/templates/stats/stats.html:84
+msgid "7 days"
+msgstr "7 днів"
+
+#: src/olympia/stats/templates/stats/stats.html:87
+msgid "30 days"
+msgstr "30 днів"
+
+#: src/olympia/stats/templates/stats/stats.html:90
+msgid "90 days"
+msgstr "90 днів"
+
+#: src/olympia/stats/templates/stats/stats.html:93
+msgid "365 days"
+msgstr "365 днів"
+
+#: src/olympia/stats/templates/stats/stats.html:96
+msgid "Custom..."
+msgstr "Вибрати..."
+
+#: src/olympia/stats/templates/stats/stats.html:106
+msgid "Statistics processing is currently disabled, so recent data is unavailable. The statistics are still being collected and this page will be updated soon with the missing data."
+msgstr "Обробка статистики в даний час відключена, тому останні дані недоступні. Статистика збирається й досі і ця сторінка буде оновлена найближчим часом з відсутніми на цей час даними."
+
+#: src/olympia/stats/templates/stats/stats.html:112
 msgid "Loading the latest data&hellip;"
 msgstr "Завантаження останніх даних&hellip;"
 
-#: src/olympia/stats/templates/stats/stats.html:142
-#: src/olympia/stats/templates/stats/reports/overview.html:25
-#: src/olympia/stats/templates/stats/reports/overview.html:37
+#: src/olympia/stats/templates/stats/stats.html:144 src/olympia/stats/templates/stats/reports/overview.html:25 src/olympia/stats/templates/stats/reports/overview.html:37
 #: src/olympia/stats/templates/stats/reports/overview.html:49
 msgid "No data available."
 msgstr "Дані відсутні."
 
-#: src/olympia/stats/templates/stats/stats.html:177
+#: src/olympia/stats/templates/stats/stats.html:179
 msgid "This dashboard is currently <b>public</b>."
 msgstr "Зараз ця панель є <b>публічною</b>."
 
-#: src/olympia/stats/templates/stats/stats.html:179
+#: src/olympia/stats/templates/stats/stats.html:181
 msgid "Contribution stats are currently <b>private</b>."
 msgstr "Зараз статистика внесків є <b>приватною</b>."
 
-#: src/olympia/stats/templates/stats/stats.html:182
+#: src/olympia/stats/templates/stats/stats.html:184
 msgid "This dashboard is currently <b>private</b>."
 msgstr "Зараз ця панель є <b>приватною</b>."
 
-#: src/olympia/stats/templates/stats/stats.html:185
+#: src/olympia/stats/templates/stats/stats.html:187
 msgid "Change settings."
 msgstr "Змінити налаштування."
 
@@ -14582,14 +11465,11 @@ msgstr "Як рахуються завантаження?"
 
 #: src/olympia/stats/templates/stats/reports/downloads.html:10
 msgid ""
-"<h2>How are downloads counted?</h2> <p> Download counts are updated every "
-"evening and only include original add-on downloads, not updates. Downloads "
-"can be broken down by the specific source referring the download. </p>"
+"<h2>How are downloads counted?</h2> <p> Download counts are updated every evening and only include original add-on downloads, not updates. Downloads can be broken down by the specific source "
+"referring the download. </p>"
 msgstr ""
-"<h2>Як підраховуються завантаження?</h2> <p> Число завантажень оновлюється "
-"щовечора і включає в себе тільки нові завантаження додатка, а не оновлення. "
-"Завантаження можуть бути розбиті по конкретним джерелам, що посилаються на "
-"завантаження. </p>"
+"<h2>Як підраховуються завантаження?</h2> <p> Число завантажень оновлюється щовечора і включає в себе тільки нові завантаження додатка, а не оновлення. Завантаження можуть бути розбиті по конкретним"
+" джерелам, що посилаються на завантаження. </p>"
 
 #: src/olympia/stats/templates/stats/reports/locales.html:3
 msgid "User languages by Date"
@@ -14603,8 +11483,7 @@ msgstr "Використання платформи за датою"
 msgid "<b>{0}</b> Downloads"
 msgstr "<b>{0}</b> завантажень"
 
-#: src/olympia/stats/templates/stats/reports/overview.html:9
-#: src/olympia/stats/templates/stats/reports/overview.html:13
+#: src/olympia/stats/templates/stats/reports/overview.html:9 src/olympia/stats/templates/stats/reports/overview.html:13
 msgid "Loading..."
 msgstr "Завантаження..."
 
@@ -14655,35 +11534,18 @@ msgstr "Про відстеження зовнішніх джерел..."
 #: src/olympia/stats/templates/stats/reports/sources.html:10
 #, python-format
 msgid ""
-"<h2>Tracking external sources</h2> <p> If you link to your add-on's details "
-"page or directly to its file from an external site, such as your blog or "
-"website, you can append a parameter to be tracked as an additional download "
-"source on this page. For example, the following links would appear as "
-"sourced by your blog: <dl> <dt>Add-on Details Page</dt> "
-"<dd>https://addons.mozilla.org/addon/%(slug)s?src=<b>external-blog</b></dd> "
-"<dt>Direct File Link</dt> "
-"<dd>https://addons.mozilla.org/downloads/latest/%(id)s/addon-%(id)s-latest.xpi?src=<b"
-">external-blog</b></dd> </dl> <p> Only src parameters that begin with "
-"\"external-\" will be tracked, up to 61 additional characters. Any text "
-"after \"external-\" can be used to describe the source, such as \"external-"
-"blog\", \"external-sidebar\", \"external-campaign225\", etc. The following "
-"URL-safe characters are allowed: <code>a-z A-Z - . _ ~ %% +</code>"
+"<h2>Tracking external sources</h2> <p> If you link to your add-on's details page or directly to its file from an external site, such as your blog or website, you can append a parameter to be "
+"tracked as an additional download source on this page. For example, the following links would appear as sourced by your blog: <dl> <dt>Add-on Details Page</dt> "
+"<dd>https://addons.mozilla.org/addon/%(slug)s?src=<b>external-blog</b></dd> <dt>Direct File Link</dt> <dd>https://addons.mozilla.org/downloads/latest/%(id)s/addon-%(id)s-latest.xpi?src=<b>external-"
+"blog</b></dd> </dl> <p> Only src parameters that begin with \"external-\" will be tracked, up to 61 additional characters. Any text after \"external-\" can be used to describe the source, such as "
+"\"external-blog\", \"external-sidebar\", \"external-campaign225\", etc. The following URL-safe characters are allowed: <code>a-z A-Z - . _ ~ %% +</code>"
 msgstr ""
-"<h2>Відстеження зовнішніх джерел</h2> <p> Якщо ви посилаєтеся на сторінку "
-"інформації про ваш додаток чи безпосередньо на його файл з стороннього "
-"сайту, такого як ваш блог або веб-сайт, ви можете додати параметр для "
-"відстеження додаткових джерел завантаження на цій сторінці. Наприклад, "
-"наступні посилання з'являться як ті, що виходять з вашого блогу: <dl> "
-"<dt>Сторінка інформації про додаток</dt> "
-"<dd>https://addons.mozilla.org/addon/%(slug)s?src=<b>external-blog</b></dd> "
-"<dt>Пряме посилання на файл</dt> "
-"<dd>https://addons.mozilla.org/downloads/latest/%(id)s/addon-%(id)s-latest.xpi?src=<b"
-">external-blog</b></dd> </dl> <p> Будуть відслідковані тільки параметри src,"
-" що починаються з \"external-\", довжиною до 61 додаткового символа. Будь-"
-"який текст після \"external-\" може бути використаний для опису джерела, "
-"наприклад \"external-blog\", \"external-sidebar\", \"external-campaign225\","
-" і т.д. Дозволені наступні безпечні для створення URL символи: <code>a-z A-Z"
-" - . _ ~ %% +</code>"
+"<h2>Відстеження зовнішніх джерел</h2> <p> Якщо ви посилаєтеся на сторінку інформації про ваш додаток чи безпосередньо на його файл з стороннього сайту, такого як ваш блог або веб-сайт, ви можете "
+"додати параметр для відстеження додаткових джерел завантаження на цій сторінці. Наприклад, наступні посилання з'являться як ті, що виходять з вашого блогу: <dl> <dt>Сторінка інформації про "
+"додаток</dt> <dd>https://addons.mozilla.org/addon/%(slug)s?src=<b>external-blog</b></dd> <dt>Пряме посилання на файл</dt> "
+"<dd>https://addons.mozilla.org/downloads/latest/%(id)s/addon-%(id)s-latest.xpi?src=<b>external-blog</b></dd> </dl> <p> Будуть відслідковані тільки параметри src, що починаються з \"external-\", "
+"довжиною до 61 додаткового символа. Будь-який текст після \"external-\" може бути використаний для опису джерела, наприклад \"external-blog\", \"external-sidebar\", \"external-campaign225\", і т.д."
+" Дозволені наступні безпечні для створення URL символи: <code>a-z A-Z - . _ ~ %% +</code>"
 
 #: src/olympia/stats/templates/stats/reports/statuses.html:3
 msgid "Add-on Status by Date"
@@ -14703,28 +11565,19 @@ msgstr "Що таке щоденні користувачі?"
 
 #: src/olympia/stats/templates/stats/reports/usage.html:11
 msgid ""
-"<h2>What are daily users?</h2> <p> Themes installed from this site check for"
-" updates once per day. The total number of these update pings is known as "
-"Active Daily Users, or the total number of people using your theme by day. "
-"</p>"
+"<h2>What are daily users?</h2> <p> Themes installed from this site check for updates once per day. The total number of these update pings is known as Active Daily Users, or the total number of "
+"people using your theme by day. </p>"
 msgstr ""
-"<h2>Що таке щоденні користувачі?</h2> <p> Теми, встановлені з цього сайту, "
-"перевіряють наявність оновлень один раз на день. Загальна кількість таких "
-"перевірок на поновлення відомо як Активні Щоденні Користувачі, або загальне "
-"число людей, що використовують вашу тему за день. </p>"
+"<h2>Що таке щоденні користувачі?</h2> <p> Теми, встановлені з цього сайту, перевіряють наявність оновлень один раз на день. Загальна кількість таких перевірок на поновлення відомо як Активні "
+"Щоденні Користувачі, або загальне число людей, що використовують вашу тему за день. </p>"
 
 #: src/olympia/stats/templates/stats/reports/usage.html:20
 msgid ""
-"<h2>What are daily users?</h2> <p> Add-ons downloaded from this site check "
-"for updates once per day. The total number of these update pings is known as"
-" Active Daily Users. Daily users can be broken down by add-on version, "
-"operating system, add-on status, application, and locale. </p>"
+"<h2>What are daily users?</h2> <p> Add-ons downloaded from this site check for updates once per day. The total number of these update pings is known as Active Daily Users. Daily users can be broken"
+" down by add-on version, operating system, add-on status, application, and locale. </p>"
 msgstr ""
-"<h2>Що таке щоденні користувачі?</h2> <p> Додатки, встановлені з цього "
-"сайту, перевіряють наявність оновлень один раз на день. Загальна кількість "
-"таких перевірок на поновлення відомо як Активні Щоденні Користувачі. Щоденні"
-" користувачі можуть бути розбиті на версію додатка, операційну систему, "
-"статус додатка, програму та мову. </p>"
+"<h2>Що таке щоденні користувачі?</h2> <p> Додатки, встановлені з цього сайту, перевіряють наявність оновлень один раз на день. Загальна кількість таких перевірок на поновлення відомо як Активні "
+"Щоденні Користувачі. Щоденні користувачі можуть бути розбиті на версію додатка, операційну систему, статус додатка, програму та мову. </p>"
 
 #: src/olympia/stats/templates/stats/reports/users_created.html:3
 msgid "User Signups by Date"
@@ -14734,45 +11587,27 @@ msgstr "Користувачів зареєстровано, за датою"
 msgid "Application versions by Date"
 msgstr "Версії програми за датою"
 
-#: src/olympia/tags/templates/tags/top_cloud.html:4
-msgid "Top {0} Tags"
-msgstr "{0} найпопулярніших міток"
-
-#. {0} is the current application name
-#: src/olympia/tags/templates/tags/top_cloud.html:14
-msgid "{0} Top Tags"
-msgstr "{0} найпопулярніших міток"
-
-#: src/olympia/templates/amo_footer.html:6
-#: src/olympia/templates/includes/lang_switcher.html:2
+#: src/olympia/templates/amo_footer.html:6 src/olympia/templates/includes/lang_switcher.html:2
 msgid "Other languages"
 msgstr "Інші мови"
 
-#: src/olympia/templates/base.html:9 src/olympia/templates/impala/base.html:9
-#: src/olympia/templates/mobile/base_addons.html:9
+#: src/olympia/templates/base.html:9 src/olympia/templates/impala/base.html:9 src/olympia/templates/mobile/base_addons.html:9
 msgid "Mozilla Add-ons"
 msgstr "Додатки Mozilla"
 
-#: src/olympia/templates/base.html:91
-#: src/olympia/templates/impala/base.html:81
+#: src/olympia/templates/base.html:89 src/olympia/templates/impala/base.html:78
 msgid "Find add-ons for other applications"
 msgstr "Знайти додатки для іншої програми"
 
-#: src/olympia/templates/base.html:92
-#: src/olympia/templates/impala/base.html:81
+#: src/olympia/templates/base.html:90 src/olympia/templates/impala/base.html:78
 msgid "Other Applications"
 msgstr "Інші програми"
 
-#: src/olympia/templates/base.html:141
-#: src/olympia/templates/impala/base.html:194
-msgid ""
-"To create your own collections, you must have a Mozilla Add-ons account."
-msgstr ""
-"Для створення власних збірок, необхідно мати обліковий запис сайту додатків "
-"Mozilla."
+#: src/olympia/templates/base.html:141 src/olympia/templates/impala/base.html:194
+msgid "To create your own collections, you must have a Mozilla Add-ons account."
+msgstr "Для створення власних збірок, необхідно мати обліковий запис сайту додатків Mozilla."
 
-#: src/olympia/templates/base.html:168
-#: src/olympia/templates/impala/base.html:215
+#: src/olympia/templates/base.html:168 src/olympia/templates/impala/base.html:215
 msgid "Footer logo"
 msgstr "Логотип знизу"
 
@@ -14789,20 +11624,18 @@ msgid "View Mobile Site"
 msgstr "Переглянути сайт для мобільного"
 
 #: src/olympia/templates/copyright.html:7
-msgid "Site Status "
+msgid "Site Status"
 msgstr "Статус сайту "
 
 #: src/olympia/templates/footer.html:3
 msgid "get to know <b>add-ons</b>"
 msgstr "дізнайтеся про <b>додатки</b>"
 
-#: src/olympia/templates/footer.html:4
-#: src/olympia/templates/menu_links.html:20
+#: src/olympia/templates/footer.html:4 src/olympia/templates/menu_links.html:20
 msgid "About"
 msgstr "Про"
 
-#: src/olympia/templates/footer.html:5
-#: src/olympia/templates/menu_links.html:32
+#: src/olympia/templates/footer.html:5 src/olympia/templates/menu_links.html:32
 msgid "Blog"
 msgstr "Блог"
 
@@ -14878,9 +11711,7 @@ msgstr "Правові положення"
 msgid "Contact Us"
 msgstr "Зв'язатися з нами"
 
-#: src/olympia/templates/user_login.html:22
-#: src/olympia/users/templates/users/edit.html:31
-#: src/olympia/users/templates/users/includes/navigation.html:12
+#: src/olympia/templates/user_login.html:22 src/olympia/users/templates/users/edit.html:31 src/olympia/users/templates/users/includes/navigation.html:12
 msgid "My Account"
 msgstr "Мій профіль"
 
@@ -14888,64 +11719,48 @@ msgstr "Мій профіль"
 msgid "Welcome, {0}"
 msgstr "Вітаємо, {0}"
 
-#: src/olympia/templates/user_login.html:41
-#: src/olympia/templates/impala/user_login.html:20
+#: src/olympia/templates/user_login.html:41 src/olympia/templates/impala/user_login.html:20
 #, python-format
 msgid "<a href=\"%(reg)s\">Register</a> or <a href=\"%(login)s\">Log in</a>"
 msgstr "<a href=\"%(reg)s\">Зареєструватися</a> чи <a href=\"%(login)s\">Увійти</a>"
 
-#: src/olympia/templates/impala/base.html:126
+#: src/olympia/templates/impala/base.html:123
 #, python-format
-msgid ""
-"To try the thousands of add-ons available here, download <a "
-"href=\"%(url)s\">Mozilla Firefox</a>, a fast, free way to surf the Web!"
-msgstr ""
-"Щоб спробувати тисячі наявних тут додатків, завантажте <a "
-"href=\"%(url)s\">Mozilla Firefox</a>, швидкий, безплатний спосіб "
-"користуватись Інтернетом!"
+msgid "To try the thousands of add-ons available here, download <a href=\"%(url)s\">Mozilla Firefox</a>, a fast, free way to surf the Web!"
+msgstr "Щоб спробувати тисячі наявних тут додатків, завантажте <a href=\"%(url)s\">Mozilla Firefox</a>, швидкий, безплатний спосіб користуватись Інтернетом!"
 
-#: src/olympia/templates/impala/base.html:138
+#: src/olympia/templates/impala/base.html:135
 #, python-format
-msgid ""
-"Add-ons is switching to Firefox Accounts for login. <a href=\"%(url)s\" "
-"class=\"fxa-login\">Sign in now to transfer your account.</a>"
-msgstr ""
-"Система входу на Додатки переходить на Акаунти Firefox. <a href=\"%(url)s\" "
-"class=\"fxa-login\">Увійдіть зараз, щоб перенести свій обліковий запис.</a>"
+msgid "Add-ons is switching to Firefox Accounts for login. <a href=\"%(url)s\" class=\"fxa-login\">Sign in now to transfer your account.</a>"
+msgstr "Система входу на Додатки переходить на Акаунти Firefox. <a href=\"%(url)s\" class=\"fxa-login\">Увійдіть зараз, щоб перенести свій обліковий запис.</a>"
 
 #. {0} is an application, such as Firefox.
-#: src/olympia/templates/impala/base.html:148
+#: src/olympia/templates/impala/base.html:145
 msgid "Welcome to {0} Add-ons."
 msgstr "Ласкаво просимо до додатків {0}."
 
-#: src/olympia/templates/impala/base.html:151
-msgid ""
-"Choose from thousands of extra features and styles to make Firefox your own."
-msgstr ""
-"Обирайте серед тисяч додаткових функцій та стилів, щоб зробити Firefox "
-"своїм."
+#: src/olympia/templates/impala/base.html:148
+msgid "Choose from thousands of extra features and styles to make Firefox your own."
+msgstr "Обирайте серед тисяч додаткових функцій та стилів, щоб зробити Firefox своїм."
 
-#: src/olympia/templates/impala/base.html:156
+#: src/olympia/templates/impala/base.html:153
 #, python-format
 msgid "Add extra features and styles to make %(app)s your own."
 msgstr "Додайте функції та стиль, щоб зробити %(app)s своїм."
 
-#: src/olympia/templates/impala/base.html:164
+#: src/olympia/templates/impala/base.html:161
 msgid "On the go?"
 msgstr "В дорозі?"
 
-#: src/olympia/templates/impala/base.html:166
+#: src/olympia/templates/impala/base.html:163
 msgid "Check out our <a class=\"mobile-link\" href=\"#\">Mobile Add-ons site</a>."
-msgstr ""
-"Перегляньте наш <a class=\"mobile-link\" href=\"#\">сайт додатків для "
-"мобільного</a>."
+msgstr "Перегляньте наш <a class=\"mobile-link\" href=\"#\">сайт додатків для мобільного</a>."
 
 #: src/olympia/templates/impala/header_title.html:21
 msgid "Android Add-ons"
 msgstr "Додатки для Android"
 
-#: src/olympia/templates/includes/forms.html:2
-#: src/olympia/templates/includes/forms.html:6
+#: src/olympia/templates/includes/forms.html:2 src/olympia/templates/includes/forms.html:6
 msgid "required"
 msgstr "потрібно"
 
@@ -14990,15 +11805,11 @@ msgstr "Відвідати Mozilla"
 msgid "menu"
 msgstr "меню"
 
-#: src/olympia/templates/mobile/header_auth.html:7
-#: src/olympia/users/templates/users/register.html:41
-#: src/olympia/users/templates/users/register.html:89
+#: src/olympia/templates/mobile/header_auth.html:7 src/olympia/users/templates/users/register.html:41 src/olympia/users/templates/users/register.html:89
 msgid "Register"
 msgstr "Зареєструватися"
 
-#: src/olympia/templates/mobile/header_auth.html:8
-#: src/olympia/users/templates/users/login_form.html:41
-#: src/olympia/users/templates/users/pwreset_complete.html:15
+#: src/olympia/templates/mobile/header_auth.html:8 src/olympia/users/templates/users/login_form.html:41 src/olympia/users/templates/users/pwreset_complete.html:15
 #: src/olympia/users/templates/users/mobile/login.html:56
 msgid "Log in"
 msgstr "Вхід"
@@ -15009,8 +11820,7 @@ msgstr "Вхід"
 msgid "Localize for: <a id=\"change-locale\" href=\"#\">%(dl)s</a>"
 msgstr "Локалізація для: <a id=\"change-locale\" href=\"#\">%(dl)s</a>"
 
-#: src/olympia/translations/templates/translations/trans-menu.html:16
-#: src/olympia/translations/templates/translations/trans-menu.html:29
+#: src/olympia/translations/templates/translations/trans-menu.html:16 src/olympia/translations/templates/translations/trans-menu.html:29
 #, python-format
 msgid "%(title)s <em>&middot; %(lang)s</em>"
 msgstr "%(title)s <em>&middot; %(lang)s</em>"
@@ -15025,12 +11835,8 @@ msgstr "Нові локалі"
 
 #. {0} is a language name, like 'French'
 #: src/olympia/translations/templates/translations/trans-menu.html:42
-msgid ""
-"You have unsaved changes in the <b>{0}</b> locale. Would you like to save "
-"your changes before switching locales?"
-msgstr ""
-"У вас є незбережені зміни в <b>{0}</b> локалі. Ви хочете зберегти зміни "
-"перед перемиканням локалей?"
+msgid "You have unsaved changes in the <b>{0}</b> locale. Would you like to save your changes before switching locales?"
+msgstr "У вас є незбережені зміни в <b>{0}</b> локалі. Ви хочете зберегти зміни перед перемиканням локалей?"
 
 #: src/olympia/translations/templates/translations/trans-menu.html:49
 msgid "Discard Changes"
@@ -15038,12 +11844,8 @@ msgstr "Відхилити зміни"
 
 #. {0} is a language name, like 'French'
 #: src/olympia/translations/templates/translations/trans-menu.html:56
-msgid ""
-"Are you sure you want to remove all <b>{0}</b> translations? This cannot be "
-"undone."
-msgstr ""
-"Ви впевнені, що хочете прибрати всі <b>{0}</b> переклади? Цю дію неможливо "
-"відмінити."
+msgid "Are you sure you want to remove all <b>{0}</b> translations? This cannot be undone."
+msgstr "Ви впевнені, що хочете прибрати всі <b>{0}</b> переклади? Цю дію неможливо відмінити."
 
 #: src/olympia/translations/templates/translations/trans-menu.html:61
 msgid "Delete Locale"
@@ -15064,25 +11866,14 @@ msgstr "Такий пароль не дозволений."
 
 #: src/olympia/users/forms.py:90
 #, python-format
-msgid ""
-"As part of our new password policy, your password must be %s characters or "
-"more. Please update your password by <a href=\"%s\">issuing a password "
-"reset</a>."
-msgstr ""
-"У рамках нашої нової політики паролів, ваш пароль повинен містити %s чи "
-"більше символів. Будь ласка, оновіть свій пароль, <a href=\"%s\">виконавши "
-"відновлення паролю</a>."
+msgid "As part of our new password policy, your password must be %s characters or more. Please update your password by <a href=\"%s\">issuing a password reset</a>."
+msgstr "У рамках нашої нової політики паролів, ваш пароль повинен містити %s чи більше символів. Будь ласка, оновіть свій пароль, <a href=\"%s\">виконавши відновлення паролю</a>."
 
 #: src/olympia/users/forms.py:115
-msgid ""
-"You must recover your password through Firefox Accounts. Try logging in "
-"instead."
-msgstr ""
-"Ви повинні відновити свій пароль через облікові записи Firefox. Спробуйте "
-"натомість увійти."
+msgid "You must recover your password through Firefox Accounts. Try logging in instead."
+msgstr "Ви повинні відновити свій пароль через облікові записи Firefox. Спробуйте натомість увійти."
 
-#: src/olympia/users/forms.py:206
-#: src/olympia/users/templates/users/pwreset_confirm.html:24
+#: src/olympia/users/forms.py:206 src/olympia/users/templates/users/pwreset_confirm.html:24
 msgid "New password"
 msgstr "Новий пароль"
 
@@ -15095,12 +11886,8 @@ msgid "Usernames cannot contain only digits."
 msgstr "Імена користувачів не можуть містити лише цифри."
 
 #: src/olympia/users/forms.py:274
-msgid ""
-"Enter a valid username consisting of letters, numbers, underscores or "
-"hyphens."
-msgstr ""
-"Введіть дійсне ім'я користувача, що складається з літер, цифр, підкреслень "
-"або дефісів."
+msgid "Enter a valid username consisting of letters, numbers, underscores or hyphens."
+msgstr "Введіть дійсне ім'я користувача, що складається з літер, цифр, підкреслень або дефісів."
 
 #: src/olympia/users/forms.py:277
 msgid "This username cannot be used."
@@ -15110,38 +11897,25 @@ msgstr "Це ім'я користувача не може використову
 msgid "This username is already in use."
 msgstr "Це ім’я користувача вже використовується."
 
-#: src/olympia/users/forms.py:296
-#: src/olympia/users/templates/users/edit.html:107
+#: src/olympia/users/forms.py:296 src/olympia/users/templates/users/edit.html:107
 msgid "Display Name"
 msgstr "Ім'я для показу"
 
-#: src/olympia/users/forms.py:298
-#: src/olympia/users/templates/users/edit.html:112
-#: src/olympia/users/templates/users/vcard.html:10
+#: src/olympia/users/forms.py:298 src/olympia/users/templates/users/edit.html:112 src/olympia/users/templates/users/vcard.html:10
 msgid "Location"
 msgstr "Місцезнаходження"
 
-#: src/olympia/users/forms.py:300
-#: src/olympia/users/templates/users/edit.html:117
-#: src/olympia/users/templates/users/vcard.html:16
+#: src/olympia/users/forms.py:300 src/olympia/users/templates/users/edit.html:117 src/olympia/users/templates/users/vcard.html:16
 msgid "Occupation"
 msgstr "Заняття"
 
 #: src/olympia/users/forms.py:329
-msgid ""
-"This URL has an invalid format. Valid URLs look like "
-"http://example.com/my_page."
-msgstr ""
-"Цей URL має недійсний формат. Дійсні URLи виглядають "
-"http://example.com/my_page."
+msgid "This URL has an invalid format. Valid URLs look like http://example.com/my_page."
+msgstr "Цей URL має недійсний формат. Дійсні URLи виглядають http://example.com/my_page."
 
 #: src/olympia/users/forms.py:337
-msgid ""
-"Please use an email address from a different provider to complete your "
-"registration."
-msgstr ""
-"Для завершення реєстрації, використайте адресу електронної пошти іншого "
-"провайдера."
+msgid "Please use an email address from a different provider to complete your registration."
+msgstr "Для завершення реєстрації, використайте адресу електронної пошти іншого провайдера."
 
 #: src/olympia/users/forms.py:345
 msgid "This display name cannot be used."
@@ -15151,21 +11925,17 @@ msgstr "Це ім'я для показу не можна використати.
 msgid "The passwords did not match."
 msgstr "Паролі не співпали."
 
-#: src/olympia/users/forms.py:377
-#: src/olympia/users/templates/users/edit.html:128
+#: src/olympia/users/forms.py:377 src/olympia/users/templates/users/edit.html:128
 msgid "Profile Photo"
 msgstr "Світлина профілю"
 
-#: src/olympia/users/forms.py:385
-#: src/olympia/users/templates/users/edit.html:142
+#: src/olympia/users/forms.py:385 src/olympia/users/templates/users/edit.html:142
 msgid "Default locale"
 msgstr "Типова локаль"
 
 #: src/olympia/users/forms.py:412
 msgid "Firefox Accounts users cannot currently change their email address."
-msgstr ""
-"В даний час користувачі облікових записів Firefox не можуть змінювати свою "
-"адресу електронної пошти."
+msgstr "В даний час користувачі облікових записів Firefox не можуть змінювати свою адресу електронної пошти."
 
 #: src/olympia/users/forms.py:446
 msgid "Wrong password entered!"
@@ -15176,9 +11946,7 @@ msgid "Email cannot be changed."
 msgstr "Адреса електронної пошти не може бути змінена."
 
 #: src/olympia/users/forms.py:541
-msgid ""
-"To anonymize, enter a reason for the change but do not change any other "
-"field."
+msgid "To anonymize, enter a reason for the change but do not change any other field."
 msgstr "Задля анонімності, зазначте причину зміни, але не змінюйте інші поля."
 
 #: src/olympia/users/forms.py:587
@@ -15208,19 +11976,19 @@ msgstr "Немає користувача з цією адресою ел. по�
 
 #. L10n: {id} will be something like "13ad6a", just a random number
 #. to differentiate this user from other anonymous users.
-#: src/olympia/users/models.py:353
+#: src/olympia/users/models.py:362
 msgid "Anonymous user {id}"
 msgstr "Анонімний користувач {id}"
 
-#: src/olympia/users/models.py:410
+#: src/olympia/users/models.py:419
 msgid "Your account has been restricted"
 msgstr "Ваш обліковий запис було обмежено"
 
-#: src/olympia/users/models.py:480
+#: src/olympia/users/models.py:489
 msgid "Please confirm your email address"
 msgstr "Будь ласка підтвердіть вашу ел.адресу"
 
-#: src/olympia/users/models.py:506
+#: src/olympia/users/models.py:515
 msgid "My Mobile Add-ons"
 msgstr "Мої мобільні додатки"
 
@@ -15274,8 +12042,7 @@ msgstr "мій додаток перевірений редактором"
 
 #: src/olympia/users/notifications.py:117
 msgid "Mozilla needs to contact me about my individual add-on"
-msgstr ""
-"Mozilla необхідно зв'язатися зі мною з приводу мого індивідуального додатку"
+msgstr "Mozilla необхідно зв'язатися зі мною з приводу мого індивідуального додатку"
 
 #: src/olympia/users/notifications.py:126
 msgid "my app is reviewed by an editor"
@@ -15283,21 +12050,15 @@ msgstr "моя програма перевірена редактором"
 
 #: src/olympia/users/notifications.py:132
 msgid "Mozilla needs to contact me about my individual app"
-msgstr ""
-"Mozilla необхідно зв'язатися зі мною з приводу моєї індивідуальної програми"
+msgstr "Mozilla необхідно зв'язатися зі мною з приводу моєї індивідуальної програми"
 
 #: src/olympia/users/notifications.py:139
-msgid ""
-"Mozilla wants to contact me about relevant App Developer news and surveys"
-msgstr ""
-"Mozilla хоче зв'язатися зі мною з приводу новин та опитувань для розробників"
-" програм"
+msgid "Mozilla wants to contact me about relevant App Developer news and surveys"
+msgstr "Mozilla хоче зв'язатися зі мною з приводу новин та опитувань для розробників програм"
 
 #: src/olympia/users/notifications.py:150
 msgid "Mozilla wants to contact me about new regions added to the Marketplace"
-msgstr ""
-"Mozilla хоче зв'язатися зі мною з приводу нових регіонів, що були додані на "
-"Marketplace"
+msgstr "Mozilla хоче зв'язатися зі мною з приводу нових регіонів, що були додані на Marketplace"
 
 #: src/olympia/users/notifications.py:158
 msgid "User Notifications"
@@ -15320,14 +12081,10 @@ msgid "Successfully verified!"
 msgstr "Успішно перевірено!"
 
 #: src/olympia/users/views.py:132
-msgid ""
-"An email has been sent to your address to confirm your account. Before you "
-"can log in, you have to activate your account by clicking on the link "
-"provided in this email."
+msgid "An email has been sent to your address to confirm your account. Before you can log in, you have to activate your account by clicking on the link provided in this email."
 msgstr ""
-"На вашу адресу електронної пошти було надіслано лист для підтвердження "
-"облікового запису. Перед тим, як ви зможете увійти, вам потрібно активувати "
-"обліковий запис, натиснувши на посилання в надісланому листі."
+"На вашу адресу електронної пошти було надіслано лист для підтвердження облікового запису. Перед тим, як ви зможете увійти, вам потрібно активувати обліковий запис, натиснувши на посилання в "
+"надісланому листі."
 
 #: src/olympia/users/views.py:136 src/olympia/users/views.py:619
 msgid "Confirmation Email Sent"
@@ -15351,13 +12108,11 @@ msgstr "Лист з підтвердженням надіслано"
 
 #: src/olympia/users/views.py:197
 msgid ""
-"An email has been sent to {0} to confirm your new email address. For the "
-"change to take effect, you need to click on the link provided in this email."
-" Until then, you can keep logging in with your current email address."
+"An email has been sent to {0} to confirm your new email address. For the change to take effect, you need to click on the link provided in this email. Until then, you can keep logging in with your "
+"current email address."
 msgstr ""
-"Лист був надісланий на {0} для підтвердження нової адреси електронної пошти."
-" Щоб зміни набули чинності, вам потрібно перейти за посиланням в цьому "
-"листі. А поки що, ви можете продовжувати вхід зі своєю поточною адресою."
+"Лист був надісланий на {0} для підтвердження нової адреси електронної пошти. Щоб зміни набули чинності, вам потрібно перейти за посиланням в цьому листі. А поки що, ви можете продовжувати вхід зі "
+"своєю поточною адресою."
 
 #: src/olympia/users/views.py:210
 #, python-format
@@ -15369,17 +12124,12 @@ msgid "Errors Found"
 msgstr "Знайдено помилки"
 
 #: src/olympia/users/views.py:225
-msgid ""
-"There were errors in the changes you made. Please correct them and resubmit."
-msgstr ""
-"У зроблених вами змінах є помилки. Будь ласка, виправте їх та відправте "
-"заново."
+msgid "There were errors in the changes you made. Please correct them and resubmit."
+msgstr "У зроблених вами змінах є помилки. Будь ласка, виправте їх та відправте заново."
 
 #: src/olympia/users/views.py:273
-msgid ""
-"We're sorry, but you are not eligible to request a t-shirt at this time."
-msgstr ""
-"Нам шкода, але в даний момент ви не маєте права давати запит на футболку."
+msgid "We're sorry, but you are not eligible to request a t-shirt at this time."
+msgstr "Нам шкода, але в даний момент ви не маєте права давати запит на футболку."
 
 #: src/olympia/users/views.py:329
 msgid "Your email address was changed successfully"
@@ -15394,26 +12144,17 @@ msgid "Wrong email address or password!"
 msgstr "Неправильна адреса електронної пошти чи пароль!"
 
 #: src/olympia/users/views.py:434
-msgid ""
-"A link to activate your user account was sent by email to your address {0}. "
-"You have to click it before you can log in."
-msgstr ""
-"Посилання для активації облікового запису відправлено на вашу адресу "
-"електронної пошти {0}. Ви повинні перейти за цим посиланням для можливості "
-"увійти."
+msgid "A link to activate your user account was sent by email to your address {0}. You have to click it before you can log in."
+msgstr "Посилання для активації облікового запису відправлено на вашу адресу електронної пошти {0}. Ви повинні перейти за цим посиланням для можливості увійти."
 
 #: src/olympia/users/views.py:439
 #, python-format
 msgid ""
-"If you did not receive the confirmation email, make sure your email service "
-"did not mark it as \"junk mail\" or \"spam\". If you need to, you can have "
-"us <a href=\"%s\">resend the confirmation message</a> to your email address "
-"mentioned above."
+"If you did not receive the confirmation email, make sure your email service did not mark it as \"junk mail\" or \"spam\". If you need to, you can have us <a href=\"%s\">resend the confirmation "
+"message</a> to your email address mentioned above."
 msgstr ""
-"Якщо ви не отримали повідомлення для підтвердження, переконайтесь чи ваш "
-"сервіс електронної пошти не позначив його, як \"спам\". При необхідності ви "
-"можете <a href=\"%s\">відправити повідомлення для підтвердження ще раз</a> "
-"на свою адресу ел. пошти, зазначену вгорі."
+"Якщо ви не отримали повідомлення для підтвердження, переконайтесь чи ваш сервіс електронної пошти не позначив його, як \"спам\". При необхідності ви можете <a href=\"%s\">відправити повідомлення "
+"для підтвердження ще раз</a> на свою адресу ел. пошти, зазначену вгорі."
 
 #: src/olympia/users/views.py:444
 msgid "Activation Email Sent"
@@ -15432,14 +12173,8 @@ msgid "Congratulations! Your user account was successfully created."
 msgstr "Вітаємо! Ваш користувацький рахунок успішно створено."
 
 #: src/olympia/users/views.py:615
-msgid ""
-"An email has been sent to your address {0} to confirm your account. Before "
-"you can log in, you have to activate your account by clicking on the link "
-"provided in this email."
-msgstr ""
-"Надіслано електронного листа на вашу адресу {0} для підтвердження вашого "
-"рахунку. Перед тим, як увійти, ви повинні активувати ваш рахунок, натиснувши"
-" на наведеному у листі посиланні."
+msgid "An email has been sent to your address {0} to confirm your account. Before you can log in, you have to activate your account by clicking on the link provided in this email."
+msgstr "Надіслано електронного листа на вашу адресу {0} для підтвердження вашого рахунку. Перед тим, як увійти, ви повинні активувати ваш рахунок, натиснувши на наведеному у листі посиланні."
 
 #: src/olympia/users/views.py:639
 msgid "There are errors in this form"
@@ -15457,32 +12192,22 @@ msgstr "Відправлено користувачем."
 msgid "new"
 msgstr "нове"
 
-#: src/olympia/users/templates/users/delete.html:4
-#: src/olympia/users/templates/users/delete.html:10
+#: src/olympia/users/templates/users/delete.html:4 src/olympia/users/templates/users/delete.html:10
 msgid "Delete User Account"
 msgstr "Вилучити обліковий запис користувача"
 
 #: src/olympia/users/templates/users/delete.html:14
 #, python-format
 msgid ""
-"You cannot delete your account if you are listed as an <a href=\"%(link)s\">"
-" author of any add-ons</a>. To delete your account, please have another "
-"person in your development group delete you from the list of authors for "
-"your add-ons. Afterwards you will be able to delete your account here."
+"You cannot delete your account if you are listed as an <a href=\"%(link)s\"> author of any add-ons</a>. To delete your account, please have another person in your development group delete you from "
+"the list of authors for your add-ons. Afterwards you will be able to delete your account here."
 msgstr ""
-"Ви не можете видалити свій обліковий запис, якщо ви є <a href=\"%(link)s\"> "
-"автором будь-яких додатків</a>. Для видалення свого облікового запису, "
-"попросіть іншу особу зі своєї групи розробників видалити вас зі списку "
-"авторів ваших додатків. Після цього ви зможете видалити свій обліковий запис"
-" тут."
+"Ви не можете видалити свій обліковий запис, якщо ви є <a href=\"%(link)s\"> автором будь-яких додатків</a>. Для видалення свого облікового запису, попросіть іншу особу зі своєї групи розробників "
+"видалити вас зі списку авторів ваших додатків. Після цього ви зможете видалити свій обліковий запис тут."
 
 #: src/olympia/users/templates/users/delete.html:29
-msgid ""
-"By clicking \"delete\" your account is going to be <strong>permanently "
-"removed</strong>. That means:"
-msgstr ""
-"Натиснувши \"видалити\", ваш обліковий запис буде <strong>остаточно "
-"видалено</strong>. Це означає що:"
+msgid "By clicking \"delete\" your account is going to be <strong>permanently removed</strong>. That means:"
+msgstr "Натиснувши \"видалити\", ваш обліковий запис буде <strong>остаточно видалено</strong>. Це означає що:"
 
 #: src/olympia/users/templates/users/delete.html:35
 #, python-format
@@ -15490,12 +12215,8 @@ msgid "You will not be able to log into %(site)s anymore."
 msgstr "Ви більше не зможете увійти на %(site)s."
 
 #: src/olympia/users/templates/users/delete.html:40
-msgid ""
-"Your reviews and ratings will not be deleted, but they will no longer be "
-"associated with you."
-msgstr ""
-"Ваші відгуки й оцінки не будуть видалені, але вони більше не будуть "
-"пов'язані з вами."
+msgid "Your reviews and ratings will not be deleted, but they will no longer be associated with you."
+msgstr "Ваші відгуки й оцінки не будуть видалені, але вони більше не будуть пов'язані з вами."
 
 #: src/olympia/users/templates/users/delete.html:46
 msgid "Confirm account deletion"
@@ -15509,8 +12230,7 @@ msgstr "Я розумію, що цей крок не може бути неви�
 msgid "Delete my user account now"
 msgstr "Вилучити мій рахунок користувача зараз"
 
-#: src/olympia/users/templates/users/delete_photo.html:3
-#: src/olympia/users/templates/users/delete_photo.html:9
+#: src/olympia/users/templates/users/delete_photo.html:3 src/olympia/users/templates/users/delete_photo.html:9
 msgid "Delete User Photo"
 msgstr "Видалити світлину користувача"
 
@@ -15523,27 +12243,18 @@ msgid "Please set your display name"
 msgstr "Будь ласка, вкажіть Ваше ім’я відображення"
 
 #: src/olympia/users/templates/users/edit.html:21
-msgid ""
-"Please set your display name or username to complete the registration "
-"process."
-msgstr ""
-"Будь ласка, вкажіть ім’я відображення або ім’я користувача для завершення "
-"реєстрації."
+msgid "Please set your display name or username to complete the registration process."
+msgstr "Будь ласка, вкажіть ім’я відображення або ім’я користувача для завершення реєстрації."
 
 #: src/olympia/users/templates/users/edit.html:33
 msgid "Manage basic account information, such as username and email address."
-msgstr ""
-"Керувати основною інформацією облікового запису, такою як ім'я користувача і"
-" адреса електронної пошти."
+msgstr "Керувати основною інформацією облікового запису, такою як ім'я користувача і адреса електронної пошти."
 
-#: src/olympia/users/templates/users/edit.html:39
-#: src/olympia/users/templates/users/register.html:47
+#: src/olympia/users/templates/users/edit.html:39 src/olympia/users/templates/users/register.html:47
 msgid "Username"
 msgstr "Ім'я користувача"
 
-#: src/olympia/users/templates/users/edit.html:45
-#: src/olympia/users/templates/users/pwreset_request.html:21
-#: src/olympia/users/templates/users/register.html:62
+#: src/olympia/users/templates/users/edit.html:45 src/olympia/users/templates/users/pwreset_request.html:21 src/olympia/users/templates/users/register.html:62
 msgid "Email Address"
 msgstr "Адреса електронної пошти"
 
@@ -15555,21 +12266,15 @@ msgstr "Налаштувати обліковий запис Firefox..."
 msgid "Change Password"
 msgstr "Змінити пароль"
 
-#: src/olympia/users/templates/users/edit.html:68
-#: src/olympia/users/templates/users/login_form.html:22
-#: src/olympia/users/templates/users/register.html:67
+#: src/olympia/users/templates/users/edit.html:68 src/olympia/users/templates/users/login_form.html:22 src/olympia/users/templates/users/register.html:67
 #: src/olympia/users/templates/users/mobile/login.html:37
 msgid "Password"
 msgstr "Пароль"
 
 #: src/olympia/users/templates/users/edit.html:70
 #, python-format
-msgid ""
-"Change your password.  If you forgot your password, you can <a "
-"href=\"%(reset_url)s\">use the reset form</a>."
-msgstr ""
-"Змініть свій пароль. Якщо в забули свій пароль, тоді Ви можете скористатися "
-"<a href=\"%(reset_url)s\">формою скидання</a>."
+msgid "Change your password. If you forgot your password, you can <a href=\"%(reset_url)s\">use the reset form</a>."
+msgstr "Змініть свій пароль. Якщо в забули свій пароль, тоді Ви можете скористатися <a href=\"%(reset_url)s\">формою скидання</a>."
 
 #: src/olympia/users/templates/users/edit.html:76
 msgid "Old Password"
@@ -15588,13 +12293,8 @@ msgid "Profile"
 msgstr "Профіль"
 
 #: src/olympia/users/templates/users/edit.html:100
-msgid ""
-"Give us a bit more information about yourself.  All these fields are "
-"optional, but they'll help other users get to know you better."
-msgstr ""
-"Будь ласка, вкажіть трохи більше інформації про себе.  Всі ці поля є "
-"необов’язковими, але вони допоможуть іншим користувачам краще з Вами "
-"познайомитися."
+msgid "Give us a bit more information about yourself. All these fields are optional, but they'll help other users get to know you better."
+msgstr "Будь ласка, вкажіть трохи більше інформації про себе.  Всі ці поля є необов’язковими, але вони допоможуть іншим користувачам краще з Вами познайомитися."
 
 #: src/olympia/users/templates/users/edit.html:124
 msgid "This URL will only be visible if you are a developer."
@@ -15609,20 +12309,12 @@ msgid "Delete current photo"
 msgstr "Видалити поточну світлину"
 
 #: src/olympia/users/templates/users/edit.html:144
-msgid ""
-"This is the default locale used to display information about you (like your "
-"description)."
-msgstr ""
-"Це типова локаль, яка використовується для відображення інформації про вас "
-"(на зразок вашого опису)."
+msgid "This is the default locale used to display information about you (like your description)."
+msgstr "Це типова локаль, яка використовується для відображення інформації про вас (на зразок вашого опису)."
 
 #: src/olympia/users/templates/users/edit.html:152
-msgid ""
-"Introduce yourself to the community, if you like! This text will appear "
-"publicly on your user info page."
-msgstr ""
-"Представтесь спільноті, якщо хочете! Цей текст стане загальнодоступним на "
-"вашій сторінці користувача."
+msgid "Introduce yourself to the community, if you like! This text will appear publicly on your user info page."
+msgstr "Представтесь спільноті, якщо хочете! Цей текст стане загальнодоступним на вашій сторінці користувача."
 
 #: src/olympia/users/templates/users/edit.html:161
 msgid "Allowed HTML: {0}. Links are forbidden."
@@ -15649,21 +12341,12 @@ msgid "Notifications"
 msgstr "Повідомлення"
 
 #: src/olympia/users/templates/users/edit.html:195
-msgid ""
-"From time to time, Mozilla may send you email about upcoming releases and "
-"add-on events. Please select the topics you are interested in."
-msgstr ""
-"Час від часу Mozilla може надсилати вам електронні листи про випуски, що "
-"наближаються, та про події додатків. Будь ласка, оберіть теми, які вас "
-"цікавлять."
+msgid "From time to time, Mozilla may send you email about upcoming releases and add-on events. Please select the topics you are interested in."
+msgstr "Час від часу Mozilla може надсилати вам електронні листи про випуски, що наближаються, та про події додатків. Будь ласка, оберіть теми, які вас цікавлять."
 
 #: src/olympia/users/templates/users/edit.html:205
-msgid ""
-"Mozilla reserves the right to contact you individually about specific "
-"concerns with your hosted add-ons."
-msgstr ""
-"Mozilla зберігає за собою право звернутись до вас особисто з особливими "
-"питаннями щодо доданих вами додатків."
+msgid "Mozilla reserves the right to contact you individually about specific concerns with your hosted add-ons."
+msgstr "Mozilla зберігає за собою право звернутись до вас особисто з особливими питаннями щодо доданих вами додатків."
 
 #: src/olympia/users/templates/users/edit.html:215
 msgid "Admin"
@@ -15685,62 +12368,48 @@ msgstr "нічого"
 msgid "all"
 msgstr "все"
 
-#: src/olympia/users/templates/users/fxa_migration.html:3
-#: src/olympia/users/templates/users/fxa_migration.html:11
-#: src/olympia/users/templates/users/mobile/fxa_migration.html:3
+#: src/olympia/users/templates/users/fxa_migration.html:3 src/olympia/users/templates/users/fxa_migration.html:11 src/olympia/users/templates/users/mobile/fxa_migration.html:3
 #: src/olympia/users/templates/users/mobile/fxa_migration.html:8
 msgid "Migrate to Firefox Accounts"
 msgstr "Перейти на облікові записи Firefox"
 
 #: src/olympia/users/templates/users/fxa_migration_prompt_content.html:3
-msgid ""
-"Mozilla Add-ons has transitioned to Firefox Accounts for login. Continue to "
-"complete the simple upgrade process."
-msgstr ""
-"Сайт додатків Mozilla тепер використовує для входу облікові записи Firefox. "
-"Продовжіть для завершення цього простого процесу оновлення."
+msgid "Mozilla Add-ons has transitioned to Firefox Accounts for login. Continue to complete the simple upgrade process."
+msgstr "Сайт додатків Mozilla тепер використовує для входу облікові записи Firefox. Продовжіть для завершення цього простого процесу оновлення."
 
 #: src/olympia/users/templates/users/fxa_migration_prompt_content.html:14
 msgid "Skip"
 msgstr "Пропустити"
 
-#: src/olympia/users/templates/users/login.html:3
-#: src/olympia/users/templates/users/mobile/login.html:3
+#: src/olympia/users/templates/users/login.html:3 src/olympia/users/templates/users/mobile/login.html:3
 msgid "User Login"
 msgstr "Вхід до аккаунту"
 
-#: src/olympia/users/templates/users/login.html:13
-#: src/olympia/users/templates/users/mobile/login.html:21
+#: src/olympia/users/templates/users/login.html:13 src/olympia/users/templates/users/mobile/login.html:21
 msgid "Enter your email"
 msgstr "Введіть свою адресу електронної пошти"
 
-#: src/olympia/users/templates/users/login.html:15
-#: src/olympia/users/templates/users/mobile/login.html:23
+#: src/olympia/users/templates/users/login.html:15 src/olympia/users/templates/users/mobile/login.html:23
 msgid "Log In"
 msgstr "Увійти"
 
-#: src/olympia/users/templates/users/login_form.html:17
-#: src/olympia/users/templates/users/mobile/login.html:32
+#: src/olympia/users/templates/users/login_form.html:17 src/olympia/users/templates/users/mobile/login.html:32
 msgid "Email address"
 msgstr "Адреса електронної пошти"
 
-#: src/olympia/users/templates/users/login_form.html:30
-#: src/olympia/users/templates/users/mobile/login.html:44
+#: src/olympia/users/templates/users/login_form.html:30 src/olympia/users/templates/users/mobile/login.html:44
 msgid "Remember me on this device"
 msgstr "Запам'ятати мене на цьому пристрої"
 
-#: src/olympia/users/templates/users/login_help.html:3
-#: src/olympia/users/templates/users/mobile/login.html:63
+#: src/olympia/users/templates/users/login_help.html:3 src/olympia/users/templates/users/mobile/login.html:63
 msgid "Login Problems?"
 msgstr "Проблеми при вході?"
 
-#: src/olympia/users/templates/users/login_help.html:5
-#: src/olympia/users/templates/users/mobile/login.html:65
+#: src/olympia/users/templates/users/login_help.html:5 src/olympia/users/templates/users/mobile/login.html:65
 msgid "I don't have an account."
 msgstr "У мене нема аккаунту."
 
-#: src/olympia/users/templates/users/login_help.html:6
-#: src/olympia/users/templates/users/mobile/login.html:66
+#: src/olympia/users/templates/users/login_help.html:6 src/olympia/users/templates/users/mobile/login.html:66
 msgid "I forgot my password."
 msgstr "Я забув(ла) свій пароль."
 
@@ -15749,15 +12418,9 @@ msgstr "Я забув(ла) свій пароль."
 msgid "You are now logged in as <strong>%(user_email)s</strong>!"
 msgstr "Вхід виконано <strong>%(user_email)s</strong>!"
 
-#: src/olympia/users/templates/users/newpw_sent.html:3
-#: src/olympia/users/templates/users/newpw_sent.html:8
-#: src/olympia/users/templates/users/pwreset_complete.html:3
-#: src/olympia/users/templates/users/pwreset_confirm.html:4
-#: src/olympia/users/templates/users/pwreset_confirm.html:18
-#: src/olympia/users/templates/users/pwreset_request.html:4
-#: src/olympia/users/templates/users/pwreset_request.html:10
-#: src/olympia/users/templates/users/pwreset_sent.html:3
-#: src/olympia/users/templates/users/pwreset_sent.html:8
+#: src/olympia/users/templates/users/newpw_sent.html:3 src/olympia/users/templates/users/newpw_sent.html:8 src/olympia/users/templates/users/pwreset_complete.html:3
+#: src/olympia/users/templates/users/pwreset_confirm.html:4 src/olympia/users/templates/users/pwreset_confirm.html:18 src/olympia/users/templates/users/pwreset_request.html:4
+#: src/olympia/users/templates/users/pwreset_request.html:10 src/olympia/users/templates/users/pwreset_sent.html:3 src/olympia/users/templates/users/pwreset_sent.html:8
 msgid "Password Reset"
 msgstr "Скидання пароля"
 
@@ -15773,8 +12436,7 @@ msgstr "Змінити профіль"
 msgid "Manage user"
 msgstr "Керування користувачем"
 
-#: src/olympia/users/templates/users/profile.html:18
-#: src/olympia/users/templates/users/report_abuse_full.html:9
+#: src/olympia/users/templates/users/profile.html:18 src/olympia/users/templates/users/report_abuse_full.html:9
 msgid "Report user"
 msgstr "Поскаржитись на користувача"
 
@@ -15834,54 +12496,35 @@ msgstr "Успішно!"
 msgid "Password successfully reset."
 msgstr "Пароль успішно скинуто."
 
-#: src/olympia/users/templates/users/pwreset_confirm.html:13
-#: src/olympia/users/templates/users/pwreset_confirm.html:46
+#: src/olympia/users/templates/users/pwreset_confirm.html:13 src/olympia/users/templates/users/pwreset_confirm.html:46
 msgid "Password reset unsuccessful"
 msgstr "Скидання пароля не вдалося"
 
 #: src/olympia/users/templates/users/pwreset_confirm.html:14
-msgid ""
-"You have migrated to Firefox Accounts. You can no longer change your "
-"password here."
-msgstr ""
-"Ви перейшли на облікові записи Firefox. Ви більше не можете змінювати свій "
-"пароль тут."
+msgid "You have migrated to Firefox Accounts. You can no longer change your password here."
+msgstr "Ви перейшли на облікові записи Firefox. Ви більше не можете змінювати свій пароль тут."
 
-#: src/olympia/users/templates/users/pwreset_confirm.html:31
-#: src/olympia/users/templates/users/register.html:72
+#: src/olympia/users/templates/users/pwreset_confirm.html:31 src/olympia/users/templates/users/register.html:72
 msgid "Confirm password"
 msgstr "Підтвердіть пароль"
 
 #: src/olympia/users/templates/users/pwreset_confirm.html:47
-msgid ""
-"The password reset link was invalid, possibly because it has already been "
-"used.  Please request a new password reset."
-msgstr ""
-"Посилання для скидання паролю - недійсне, можливо тому, що воно вже було "
-"використано.  Будь ласка, зробіть новий запит на скидання паролю."
+msgid "The password reset link was invalid, possibly because it has already been used. Please request a new password reset."
+msgstr "Посилання для скидання паролю - недійсне, можливо тому, що воно вже було використано.  Будь ласка, зробіть новий запит на скидання паролю."
 
 #: src/olympia/users/templates/users/pwreset_request.html:15
-msgid ""
-"Forgotten your password? Enter your e-mail address below, and we'll e-mail "
-"instructions for setting a new one."
-msgstr ""
-"Забули пароль? Введіть свою адресу електронної пошти внизу і ми надішлемо "
-"інструкції для встановлення нового."
+msgid "Forgotten your password? Enter your e-mail address below, and we'll e-mail instructions for setting a new one."
+msgstr "Забули пароль? Введіть свою адресу електронної пошти внизу і ми надішлемо інструкції для встановлення нового."
 
 #: src/olympia/users/templates/users/pwreset_request.html:25
 msgid "Send password reset link"
 msgstr "Надіслати посилання скидання пароля"
 
 #: src/olympia/users/templates/users/pwreset_sent.html:10
-msgid ""
-"An email has been sent to the requested account with further information. If"
-" you do not receive an email then please confirm you have entered the same "
-"email address used during account registration."
+msgid "An email has been sent to the requested account with further information. If you do not receive an email then please confirm you have entered the same email address used during account registration."
 msgstr ""
-"Лист було надіслано на відповідний обліковий запис з інформацією про "
-"подальші дії. Якщо ви не отримали лист, тоді переконайтеся в тому, що ви "
-"ввели таку саму адресу електронної пошти, яка була використана для "
-"реєстрації облікового запису."
+"Лист було надіслано на відповідний обліковий запис з інформацією про подальші дії. Якщо ви не отримали лист, тоді переконайтеся в тому, що ви ввели таку саму адресу електронної пошти, яка була "
+"використана для реєстрації облікового запису."
 
 #: src/olympia/users/templates/users/register.html:4
 msgid "New User Registration"
@@ -15892,12 +12535,8 @@ msgid "Why register?"
 msgstr "Навіщо реєструватись?"
 
 #: src/olympia/users/templates/users/register.html:14
-msgid ""
-"Registration on AMO is <strong>not required</strong> if you simply want to "
-"download and install public add-ons."
-msgstr ""
-"Реєстрація на AMO є <strong>необов'язковою</strong>, якщо ви хочете просто "
-"завантажити та встановити загальнодоступні додатки."
+msgid "Registration on AMO is <strong>not required</strong> if you simply want to download and install public add-ons."
+msgstr "Реєстрація на AMO є <strong>необов'язковою</strong>, якщо ви хочете просто завантажити та встановити загальнодоступні додатки."
 
 #: src/olympia/users/templates/users/register.html:16
 msgid "You only need to register if:"
@@ -15908,53 +12547,29 @@ msgid "You want to submit reviews for add-ons"
 msgstr "Ви хочете залишати відгуки для додатків"
 
 #: src/olympia/users/templates/users/register.html:19
-msgid ""
-"You want to keep track of your favorite add-on collections or create one "
-"yourself"
-msgstr ""
-"Ви хочете стежити за своїми улюбленими збірками додатків або створити власну"
-" збірку"
+msgid "You want to keep track of your favorite add-on collections or create one yourself"
+msgstr "Ви хочете стежити за своїми улюбленими збірками додатків або створити власну збірку"
 
 #: src/olympia/users/templates/users/register.html:20
-msgid ""
-"You are an add-on developer and want to upload your add-on for hosting on "
-"AMO"
-msgstr ""
-"Ви є розробником додатку і хочете вивантажити свій додаток для хостингу на "
-"AMO"
+msgid "You are an add-on developer and want to upload your add-on for hosting on AMO"
+msgstr "Ви є розробником додатку і хочете вивантажити свій додаток для хостингу на AMO"
 
 #: src/olympia/users/templates/users/register.html:23
-msgid ""
-"Upon successful registration, you will be sent a confirmation email to the "
-"address you provided. Please follow the instructions there to confirm your "
-"account."
-msgstr ""
-"Одразу після успішної реєстрації ви отримаєте електронний лист для "
-"підтвердження на надану вами адресу. Для підтвердження свого облікового "
-"запису, дотримуйтесь зазначених в ньому інструкцій."
+msgid "Upon successful registration, you will be sent a confirmation email to the address you provided. Please follow the instructions there to confirm your account."
+msgstr "Одразу після успішної реєстрації ви отримаєте електронний лист для підтвердження на надану вами адресу. Для підтвердження свого облікового запису, дотримуйтесь зазначених в ньому інструкцій."
 
 #: src/olympia/users/templates/users/register.html:30
 #, python-format
-msgid ""
-"If you like, you can read our <a href=\"%(legal)s\" title=\"Legal "
-"Notices\">Legal Notices</a> and <a href=\"%(privacy)s\" title=\"Privacy "
-"Policy\">Privacy Policy</a>."
-msgstr ""
-"При бажанні, ви можете ознайомитися з нашими <a href=\"%(legal)s\" "
-"title=\"Legal Notices\">Юридичними відомостями</a> та <a "
-"href=\"%(privacy)s\" title=\"Privacy Policy\">Політикою приватності</a>."
+msgid "If you like, you can read our <a href=\"%(legal)s\" title=\"Legal Notices\">Legal Notices</a> and <a href=\"%(privacy)s\" title=\"Privacy Policy\">Privacy Policy</a>."
+msgstr "При бажанні, ви можете ознайомитися з нашими <a href=\"%(legal)s\" title=\"Legal Notices\">Юридичними відомостями</a> та <a href=\"%(privacy)s\" title=\"Privacy Policy\">Політикою приватності</a>."
 
 #: src/olympia/users/templates/users/register.html:52
 msgid "Display name"
 msgstr "Ім'я для показу"
 
 #: src/olympia/users/templates/users/report_abuse.html:7
-msgid ""
-"Please describe why you are reporting this user, such as for spam or an "
-"inappropriate picture."
-msgstr ""
-"Будь ласка, опишіть, чому ви повідомляєте про цього користувача, наприклад "
-"за спам чи за недоречну фотографію."
+msgid "Please describe why you are reporting this user, such as for spam or an inappropriate picture."
+msgstr "Будь ласка, опишіть, чому ви повідомляєте про цього користувача, наприклад за спам чи за недоречну фотографію."
 
 #: src/olympia/users/templates/users/report_abuse_full.html:3
 msgid "Report user {0}"
@@ -15968,42 +12583,25 @@ msgstr "Замовлення футболки"
 msgid "Special Edition Add-on Creator T-shirt"
 msgstr "Футболка Творця Додатків - Спеціальне видання"
 
-#: src/olympia/users/templates/users/t-shirt.html:14
-#: src/olympia/users/templates/users/t-shirt.html:120
+#: src/olympia/users/templates/users/t-shirt.html:14 src/olympia/users/templates/users/t-shirt.html:120
 msgid "Note:"
 msgstr "Нотатка:"
 
 #: src/olympia/users/templates/users/t-shirt.html:15
-msgid ""
-"You have already submitted a request for a t-shirt. You may re-submit this "
-"form to update your information, but you will only receive one shirt."
-msgstr ""
-"Ви вже подали заявку на футболку. Ви можете повторно надіслати цю форму, щоб"
-" оновити інформацію, але ви отримаєте лише одну футболку."
+msgid "You have already submitted a request for a t-shirt. You may re-submit this form to update your information, but you will only receive one shirt."
+msgstr "Ви вже подали заявку на футболку. Ви можете повторно надіслати цю форму, щоб оновити інформацію, але ви отримаєте лише одну футболку."
 
 #: src/olympia/users/templates/users/t-shirt.html:26
-msgid ""
-"Thank you for helping to make Firefox the most extensible browser available!"
-msgstr ""
-"Дякуємо, що допомогли зробити Firefox найбільш розширюваним з доступних "
-"браузерів!"
+msgid "Thank you for helping to make Firefox the most extensible browser available!"
+msgstr "Дякуємо, що допомогли зробити Firefox найбільш розширюваним з доступних браузерів!"
 
 #: src/olympia/users/templates/users/t-shirt.html:33
-msgid ""
-"As a thank you gift, we'd like to send you a special-edition, community-"
-"designed t-shirt. To receive your shirt, please fill out the form below."
-msgstr ""
-"В якості подяки ми б хотіли відправити вам розроблену спільнотою футболку зі"
-" спеціального видання. Щоб отримати футболку, будь ласка, заповніть наведену"
-" нижче форму."
+msgid "As a thank you gift, we'd like to send you a special-edition, community-designed t-shirt. To receive your shirt, please fill out the form below."
+msgstr "В якості подяки ми б хотіли відправити вам розроблену спільнотою футболку зі спеціального видання. Щоб отримати футболку, будь ласка, заповніть наведену нижче форму."
 
 #: src/olympia/users/templates/users/t-shirt.html:41
-msgid ""
-"Your contact information will only be used by Mozilla to ship this special "
-"edition t-shirt."
-msgstr ""
-"Ваша контактна інформація буде використана тільки Mozilla для відправлення "
-"цієї футболки зі спеціального видання."
+msgid "Your contact information will only be used by Mozilla to ship this special edition t-shirt."
+msgstr "Ваша контактна інформація буде використана тільки Mozilla для відправлення цієї футболки зі спеціального видання."
 
 #: src/olympia/users/templates/users/t-shirt.html:60
 msgid "Mailing Address"
@@ -16059,23 +12657,15 @@ msgstr "Запит футболки"
 
 #: src/olympia/users/templates/users/t-shirt.html:137
 msgid ""
-"We're sorry, but in order to qualify for our special edition t-shirt, you "
-"must be an add-on developer with at least one listed add-on, one unlisted "
-"but signed add-on, or any number of background themes with a combined total "
-"of 10,000 average daily users."
+"We're sorry, but in order to qualify for our special edition t-shirt, you must be an add-on developer with at least one listed add-on, one unlisted but signed add-on, or any number of background "
+"themes with a combined total of 10,000 average daily users."
 msgstr ""
-"Шкода, але у відповідності з правом на нашу спеціальну футболку, ви повинні "
-"бути розробником принаймні одного опублікованого додатку, одного "
-"неопублікованого але підписаного додатку, або будь-якої кількості тем із "
-"загальною середньою кількістю щоденних користувачів 10,000."
+"Шкода, але у відповідності з правом на нашу спеціальну футболку, ви повинні бути розробником принаймні одного опублікованого додатку, одного неопублікованого але підписаного додатку, або будь-якої "
+"кількості тем із загальною середньою кількістю щоденних користувачів 10,000."
 
 #: src/olympia/users/templates/users/tougher_password.html:2
-msgid ""
-"For your account a password must contain at least 8 characters including "
-"letters and numbers."
-msgstr ""
-"Для вашого облікового запису пароль повинен містити щонайменше 8 символів, "
-"включаючи літери й цифри."
+msgid "For your account a password must contain at least 8 characters including letters and numbers."
+msgstr "Для вашого облікового запису пароль повинен містити щонайменше 8 символів, включаючи літери й цифри."
 
 #: src/olympia/users/templates/users/unsubscribe.html:2
 msgid "Unsubscribe"
@@ -16087,12 +12677,8 @@ msgstr "Ви успішно відписалися!"
 
 #: src/olympia/users/templates/users/unsubscribe.html:10
 #, python-format
-msgid ""
-"The email address <strong>%(email)s</strong> will no longer get messages "
-"when:"
-msgstr ""
-"На адресу електронної пошти <strong>%(email)s</strong> надалі не будуть "
-"приходити повідомлення, коли:"
+msgid "The email address <strong>%(email)s</strong> will no longer get messages when:"
+msgstr "На адресу електронної пошти <strong>%(email)s</strong> надалі не будуть приходити повідомлення, коли:"
 
 #: src/olympia/users/templates/users/unsubscribe.html:20
 msgid "More Actions:"
@@ -16112,14 +12698,8 @@ msgstr "Нам не вдалося відписати вас"
 
 #: src/olympia/users/templates/users/unsubscribe.html:30
 #, python-format
-msgid ""
-"Unfortunately, we weren't able to unsubscribe you.  The link you clicked is "
-"invalid. However, you can unsubscribe still unsubscribe on your <a "
-"href=\"%(edit_url)s\">edit profile page</a>."
-msgstr ""
-"На жаль, ми не змогли скасувати Вашу підписку.  Використане посилання є "
-"недійсним. Тим не менш Ви досі можете скасувати підписку на своїй <a "
-"href=\"%(edit_url)s\">сторінці редагування профілю</a>."
+msgid "Unfortunately, we weren't able to unsubscribe you. The link you clicked is invalid. However, you can unsubscribe still unsubscribe on your <a href=\"%(edit_url)s\">edit profile page</a>."
+msgstr "На жаль, ми не змогли скасувати Вашу підписку.  Використане посилання є недійсним. Тим не менш Ви досі можете скасувати підписку на своїй <a href=\"%(edit_url)s\">сторінці редагування профілю</a>."
 
 #: src/olympia/users/templates/users/vcard.html:2
 msgid "Developer Information"
@@ -16151,7 +12731,6 @@ msgid "%(num)s theme"
 msgid_plural "%(num)s themes"
 msgstr[0] "%(num)s тема"
 msgstr[1] "%(num)s теми"
-msgstr[2] "%(num)s тем"
 
 #: src/olympia/users/templates/users/vcard.html:62
 #, python-format
@@ -16159,7 +12738,6 @@ msgid "%(num)s add-on"
 msgid_plural "%(num)s add-ons"
 msgstr[0] "%(num)s додаток"
 msgstr[1] "%(num)s додатка"
-msgstr[2] "%(num)s додатків"
 
 #: src/olympia/users/templates/users/vcard.html:75
 msgid "Average rating of developer's add-ons"
@@ -16174,15 +12752,15 @@ msgstr "%s Історія версій"
 msgid "Version History with Changelogs"
 msgstr "Історія версій з протоколом змін"
 
-#: src/olympia/versions/models.py:314
+#: src/olympia/versions/models.py:313
 msgid "Add-on uses binary components."
 msgstr "Додаток використовує бінарні компоненти."
 
-#: src/olympia/versions/models.py:317
+#: src/olympia/versions/models.py:316
 msgid "Add-on has opted into strict compatibility checking."
 msgstr "Додаток включено до суворої перевірки сумісності."
 
-#: src/olympia/versions/models.py:715
+#: src/olympia/versions/models.py:711
 msgid "{app} {min} and later"
 msgstr "{app} {min} і вище"
 
@@ -16198,9 +12776,7 @@ msgstr "Випущено {0}"
 #: src/olympia/versions/templates/versions/version.html:39
 #, python-format
 msgid "Source code released under <a target=\"_blank\" href=\"%(url)s\">%(name)s</a>"
-msgstr ""
-"Програмний код випущено на умовах <a target=\"_blank\" "
-"href=\"%(url)s\">%(name)s</a>"
+msgstr "Програмний код випущено на умовах <a target=\"_blank\" href=\"%(url)s\">%(name)s</a>"
 
 #: src/olympia/versions/templates/versions/version.html:44
 #, python-format
@@ -16222,22 +12798,15 @@ msgid "<b>{0}</b> version"
 msgid_plural "<b>{0}</b> versions"
 msgstr[0] "<b>{0}</b> версія"
 msgstr[1] "<b>{0}</b> версії"
-msgstr[2] "<b>{0}</b> версій"
 
-#: src/olympia/versions/templates/versions/version_list.html:35
-#: src/olympia/versions/templates/versions/mobile/version_list.html:14
+#: src/olympia/versions/templates/versions/version_list.html:35 src/olympia/versions/templates/versions/mobile/version_list.html:14
 msgid "Be careful with old versions!"
 msgstr "Будьте обачні зі старими версіями!"
 
-#: src/olympia/versions/templates/versions/version_list.html:36
-#: src/olympia/versions/templates/versions/mobile/version_list.html:15
+#: src/olympia/versions/templates/versions/version_list.html:36 src/olympia/versions/templates/versions/mobile/version_list.html:15
 #, python-format
-msgid ""
-"These versions are displayed for reference and testing purposes. You should "
-"always use the <a href=\"%(url)s\">latest version</a> of an add-on."
-msgstr ""
-"Ці версії показано для інформації та з метою тестування. Вам краще завжди "
-"використовувати <a href=\"%(url)s\">останню версію</a> додатку."
+msgid "These versions are displayed for reference and testing purposes. You should always use the <a href=\"%(url)s\">latest version</a> of an add-on."
+msgstr "Ці версії показано для інформації та з метою тестування. Вам краще завжди використовувати <a href=\"%(url)s\">останню версію</a> додатку."
 
 #: src/olympia/versions/templates/versions/mobile/version.html:4
 msgid "Beta Version {0}"
@@ -16267,3 +12836,8 @@ msgstr "Надіслати електронний лист після завер
 #: src/olympia/zadmin/forms.py:105
 msgid "Log emails instead of sending"
 msgstr "Журнал електронних листів замість надсилання"
+
+#: src/olympia/zadmin/forms.py:215
+msgid "Deleted versions can`t be changed."
+msgstr ""
+

--- a/locale/uk/LC_MESSAGES/djangojs.po
+++ b/locale/uk/LC_MESSAGES/djangojs.po
@@ -1,1285 +1,1239 @@
-# 
+#
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2016-02-24 21:23+0000\n"
+"POT-Creation-Date: 2016-04-18 15:47+0000\n"
 "PO-Revision-Date: 2016-03-31 08:18+0000\n"
 "Last-Translator: Artem Polivanchuk <a.polivanchuk@outlook.com>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
-"Language: uk\n"
+"Language: \n"
 "MIME-Version: 1.0\n"
-"Content-Type: text/plain; charset=utf-8\n"
+"Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=3; plural=(n%10==1 && n%100!=11 ? 0 : n%10>=2 && n%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2);\n"
 "Generated-By: Babel 2.2.0\n"
-"X-Generator: Pontoon\n"
 
-#: static/js/common/ratingwidget.js:31
+#: static/js/common-all.js:1426 static/js/impala-all.js:1511 static/js/zamboni/discovery-all.js:12598 static/js/zamboni/init.js:28 static/js/zamboni/mobile-all.js:14945
+msgid "This feature is temporarily disabled while we perform website maintenance. Please check back a little later."
+msgstr "Дана функція тимчасово вимкнута доки ми проводимо технічне обслуговування веб-сайту. Будь ласка, спробуйте пізніше."
+
+#. L10n: {0} is an app name like Firefox.
+#: static/js/common-all.js:1837 static/js/impala-all.js:1922 static/js/zamboni/buttons.js:73 static/js/zamboni/discovery-all.js:13108
+msgid "Accept and Install"
+msgstr "Прийняти та встановити"
+
+#: static/js/common-all.js:1837 static/js/impala-all.js:1922 static/js/zamboni/buttons.js:73 static/js/zamboni/discovery-all.js:13108
+msgid "Add to {0}"
+msgstr "Додати до {0}"
+
+#: static/js/common-all.js:1842 static/js/impala-all.js:1927 static/js/zamboni/buttons.js:78 static/js/zamboni/discovery-all.js:13113
+msgid "Download Now"
+msgstr "Завантажити зараз"
+
+#: static/js/common-all.js:1883 static/js/impala-all.js:1968 static/js/zamboni/buttons.js:119 static/js/zamboni/discovery-all.js:13154
+msgid "Add-on has not been updated to support default-to-compatible."
+msgstr "Додаток не було оновлено для типової підтримки сумісності."
+
+#: static/js/common-all.js:1888 static/js/impala-all.js:1973 static/js/zamboni/buttons.js:124 static/js/zamboni/discovery-all.js:13159
+msgid "You need to be using Firefox 10.0 or higher."
+msgstr "Вам необхідно використовувати Firefox 10.0 або новіший."
+
+#: static/js/common-all.js:1900 static/js/impala-all.js:1985 static/js/zamboni/buttons.js:136 static/js/zamboni/discovery-all.js:13171
+msgid "Mozilla has marked this version as incompatible with your Firefox version."
+msgstr "Mozilla відмітила цю версію, як несумісну з вашою версією Firefox."
+
+#. L10n: {0} is an platform like Windows or Linux.
+#: static/js/common-all.js:1981 static/js/impala-all.js:2066 static/js/zamboni/buttons.js:217 static/js/zamboni/discovery-all.js:13252
+msgid "Install for {0} anyway"
+msgstr "Все одно встановити для {0}"
+
+#: static/js/common-all.js:1981 static/js/impala-all.js:2066 static/js/zamboni/buttons.js:217 static/js/zamboni/discovery-all.js:13252
+msgid "Download for {0} anyway"
+msgstr "Все одно завантажити для {0}"
+
+#: static/js/common-all.js:2038 static/js/impala-all.js:2123 static/js/zamboni/buttons.js:274 static/js/zamboni/discovery-all.js:13309
+msgid "Not available for your platform"
+msgstr "Недоступно для вашої платформи"
+
+#. L10n: {0} is an app name, {1} is the app version.
+#: static/js/common-all.js:2049 static/js/common-all.js:2086 static/js/impala-all.js:2134 static/js/impala-all.js:2171 static/js/zamboni/buttons.js:286 static/js/zamboni/buttons.js:324
+#: static/js/zamboni/discovery-all.js:13320 static/js/zamboni/discovery-all.js:13357
+msgid "Not available for {0} {1}"
+msgstr "Недоступно для {0} {1}"
+
+#: static/js/common-all.js:2112 static/js/impala-all.js:2197 static/js/zamboni/buttons.js:351 static/js/zamboni/discovery-all.js:13383
+msgid "Works with {app} {min} - {max}"
+msgstr "Працює з {app} {min} - {max}"
+
+#: static/js/common-all.js:2114 static/js/impala-all.js:2199 static/js/zamboni/buttons.js:353 static/js/zamboni/discovery-all.js:13385
+msgid "View other versions"
+msgstr "Дивитись інші версії"
+
+#: static/js/common-all.js:2162 static/js/impala-all.js:2247 static/js/zamboni/buttons.js:401 static/js/zamboni/discovery-all.js:13433
+msgid "Only with Firefox — Get Firefox Now!"
+msgstr "Лише з Firefox — Отримайте Firefox зараз!"
+
+#: static/js/common-all.js:2278 static/js/impala-all.js:2363 static/js/zamboni/buttons.js:517 static/js/zamboni/discovery-all.js:13549 static/js/zamboni/mobile-all.js:15177
+#: static/js/zamboni/mobile/buttons.js:43
+msgid "Sorry, you need a Mozilla-based browser (such as Firefox) to install a search plugin."
+msgstr "Вибачте, але щоб встановити пошуковий плагін вам потрібен браузер на основі Mozilla (наприклад, Firefox)."
+
+#: static/js/common-all.js:9088 static/js/impala-all.js:9649 static/js/zamboni/global.js:410
+msgid "Loading..."
+msgstr "Завантажується..."
+
+#. L10n: {0} is the number of characters left.
+#: static/js/common-all.js:9152 static/js/impala-all.js:9713 static/js/zamboni/global.js:474
+msgid "<b>{0}</b> character left."
+msgid_plural "<b>{0}</b> characters left."
+msgstr[0] "залишився <b>{0}</b> символ."
+msgstr[1] "залишилось <b>{0}</b> символи."
+
+#: static/js/common-all.js:9589 static/js/common-min.js:6 static/js/impala-all.js:10052 static/js/impala-min.js:6 static/js/common/ratingwidget.js:31 static/js/zamboni/mobile-all.js:16123
+#: static/js/zamboni/mobile-min.js:6
 msgid "{0} star"
 msgid_plural "{0} stars"
 msgstr[0] "{0} зірка"
 msgstr[1] "{0} зірки"
-msgstr[2] "{0} зірок"
 
-#: static/js/common/upload-addon.js:41 static/js/common/upload-image.js:128
+#: static/js/common-all.js:9676 static/js/common-min.js:6 static/js/impala-all.js:10139 static/js/impala-min.js:6 static/js/zamboni/l10n.js:45
+msgid "Remove this localization"
+msgstr "Вилучити цю локалізацію"
+
+#: static/js/common-all.js:10193 static/js/common-min.js:6 static/js/impala-all.js:10674 static/js/impala-min.js:6 static/js/zamboni/discovery-all.js:13678
+msgid "close"
+msgstr ""
+
+#: static/js/common-all.js:10860 static/js/common-min.js:6 static/js/impala-all.js:11481 static/js/impala-min.js:6 static/js/impala/reviews.js:23 static/js/zamboni/reviews.js:18
+msgid "Flagged for review"
+msgstr "Відмічено для розгляду"
+
+#: static/js/common-all.js:10876 static/js/common-min.js:6 static/js/impala-all.js:11498 static/js/impala-min.js:6 static/js/impala/reviews.js:40 static/js/zamboni/reviews.js:34
+msgid "Your input is required"
+msgstr "Потрібна ваша думка"
+
+#: static/js/common-all.js:10945 static/js/common-min.js:6 static/js/impala-all.js:11610 static/js/impala-min.js:7 static/js/impala/reviews.js:152 static/js/zamboni/reviews.js:103
+msgid "Marked for deletion"
+msgstr "Відмічено для вилучення"
+
+#: static/js/common-all.js:11573 static/js/common-min.js:7 static/js/impala-all.js:13809 static/js/impala-min.js:8 static/js/zamboni/collections.js:229
+msgid "Adding to Favorites&hellip;"
+msgstr "Додається до вподобань&hellip;"
+
+#: static/js/common-all.js:11576 static/js/common-min.js:7 static/js/impala-all.js:13812 static/js/impala-min.js:8 static/js/zamboni/collections.js:232
+msgid "Removing Favorite&hellip;"
+msgstr "Вилучається з вподобань&hellip;"
+
+#: static/js/common-all.js:11579 static/js/common-min.js:7 static/js/impala-all.js:13815 static/js/impala-min.js:8 static/js/zamboni/collections.js:235
+msgid "Add to Favorites"
+msgstr "Додати до вподобань"
+
+#: static/js/common-all.js:11582 static/js/common-min.js:7 static/js/impala-all.js:13818 static/js/impala-min.js:8 static/js/zamboni/collections.js:238
+msgid "Remove from Favorites"
+msgstr "Вилучити з вподобань"
+
+#: static/js/common-all.js:11647 static/js/common-min.js:7 static/js/impala-all.js:13883 static/js/impala-min.js:8 static/js/zamboni/collections.js:303
+msgid "Pending"
+msgstr "В очікуванні"
+
+#: static/js/common-all.js:11648 static/js/common-min.js:7 static/js/impala-all.js:13884 static/js/impala-min.js:8 static/js/zamboni/collections.js:304
+msgid "Add a comment"
+msgstr "Прокоментувати"
+
+#: static/js/common-all.js:11648 static/js/common-min.js:7 static/js/impala-all.js:13884 static/js/impala-min.js:8 static/js/zamboni/collections.js:304
+msgid "Comment"
+msgstr "Коментар"
+
+#: static/js/common-all.js:11649 static/js/common-min.js:7 static/js/impala-all.js:13885 static/js/impala-min.js:8 static/js/zamboni/collections.js:305
+msgid "Remove this add-on from the collection"
+msgstr "Вилучити цей додаток зі збірки"
+
+#: static/js/common-all.js:11649 static/js/common-all.js:11678 static/js/common-min.js:7 static/js/impala-all.js:13885 static/js/impala-all.js:13914 static/js/impala-min.js:8
+#: static/js/zamboni/collections.js:305 static/js/zamboni/collections.js:334
+msgid "Remove"
+msgstr "Вилучити"
+
+#: static/js/common-all.js:11678 static/js/common-min.js:7 static/js/impala-all.js:13914 static/js/impala-min.js:8 static/js/zamboni/collections.js:334
+msgid "Remove this user as a contributor"
+msgstr "Вилучити цього користувача з помічників"
+
+#: static/js/common-all.js:11690 static/js/common-min.js:7 static/js/impala-all.js:13926 static/js/impala-min.js:8 static/js/zamboni/collections.js:346
+msgid "An email address is required."
+msgstr "Потрібна електрона адреса."
+
+#: static/js/common-all.js:11708 static/js/common-min.js:7 static/js/impala-all.js:13944 static/js/impala-min.js:8 static/js/zamboni/collections.js:364
+msgid "You cannot add yourself as a contributor."
+msgstr "Ви не можете додати себе, як помічника."
+
+#: static/js/common-all.js:11710 static/js/common-min.js:7 static/js/impala-all.js:13946 static/js/impala-min.js:8 static/js/zamboni/collections.js:366
+msgid "You have already added that user."
+msgstr "Ви вже додали цього користувача."
+
+#: static/js/common-all.js:11917 static/js/common-min.js:7 static/js/impala-all.js:14153 static/js/impala-min.js:8 static/js/zamboni/collections.js:573
+msgid "Add to favorites"
+msgstr "Додати до вподобань"
+
+#: static/js/common-all.js:11921 static/js/common-min.js:7 static/js/impala-all.js:14157 static/js/impala-min.js:8 static/js/zamboni/collections.js:577
+msgid "Remove from favorites"
+msgstr "Вилучити з вподобань"
+
+#: static/js/common-all.js:11939 static/js/common-min.js:7 static/js/impala-all.js:14175 static/js/impala-all.js:14233 static/js/impala-min.js:8 static/js/impala/collections.js:10
+#: static/js/zamboni/collections.js:595
+msgid "Follow this Collection"
+msgstr "Стежити за цією збіркою"
+
+#: static/js/common-all.js:11948 static/js/common-min.js:7 static/js/impala-all.js:14184 static/js/impala-min.js:8 static/js/zamboni/collections.js:604
+msgid "Stop following"
+msgstr "Більше не стежити"
+
+#: static/js/common-all.js:12096 static/js/common-min.js:7 static/js/zamboni/password-strength.js:20
+msgid "Password strength:"
+msgstr "Стійкість паролю:"
+
+#: static/js/common-all.js:12102 static/js/common-min.js:7 static/js/zamboni/password-strength.js:26
+msgid "At least {0} character left."
+msgid_plural "At least {0} characters left."
+msgstr[0] "Залишився щонайменше {0} символ."
+msgstr[1] "Залишилось щонайменше {0} символи."
+
+#: static/js/common-all.js:12286 static/js/common-min.js:7 static/js/impala-all.js:14632 static/js/impala-min.js:8 static/js/impala/suggestions.js:39
+msgid "Search themes for <b>{0}</b>"
+msgstr "Шукати теми для <b>{0}</b>"
+
+#: static/js/common-all.js:12288 static/js/common-min.js:7 static/js/impala-all.js:14634 static/js/impala-min.js:8 static/js/impala/suggestions.js:41
+msgid "Search apps for <b>{0}</b>"
+msgstr "Шукати застосунки для <b>{0}</b>"
+
+#: static/js/common-all.js:12290 static/js/common-min.js:7 static/js/impala-all.js:14636 static/js/impala-min.js:8 static/js/impala/suggestions.js:43
+msgid "Search add-ons for <b>{0}</b>"
+msgstr "Шукати додатки для <b>{0}</b>"
+
+#: static/js/common-all.js:12521 static/js/common-min.js:7 static/js/impala-all.js:14867 static/js/impala-min.js:8 static/js/impala/site_suggestions.js:46
+msgid "Category"
+msgstr "Категорія"
+
+#. L10n: {0} is an app name.
+#: static/js/impala-all.js:11632 static/js/impala-min.js:7 static/js/impala/listing.js:11 static/js/zamboni/themes.js:13
+msgid "This theme is incompatible with your version of {0}"
+msgstr "Ця тема несумісна з вашою версією {0}"
+
+#: static/js/impala-all.js:12146 static/js/impala-all.js:14331 static/js/impala-min.js:7 static/js/impala-min.js:8 static/js/common/upload-image.js:97 static/js/impala/users.js:51
+#: static/js/zamboni/devhub-all.js:894 static/js/zamboni/devhub-min.js:1
+msgid "Images must be either PNG or JPG."
+msgstr "Зображення повинні бути PNG чи JPG."
+
+#: static/js/impala-all.js:12150 static/js/impala-min.js:7 static/js/common/upload-image.js:101 static/js/zamboni/devhub-all.js:898 static/js/zamboni/devhub-min.js:1
+msgid "Videos must be in WebM."
+msgstr "Відео повинні бути у форматі WebM."
+
+#: static/js/impala-all.js:12177 static/js/impala-min.js:7 static/js/common/upload-addon.js:41 static/js/common/upload-image.js:128 static/js/zamboni/devhub-all.js:272
+#: static/js/zamboni/devhub-all.js:925 static/js/zamboni/devhub-min.js:1
 msgid "There was a problem contacting the server."
 msgstr "Виникла проблема при спробі зв'язатись із сервером."
 
-#: static/js/common/upload-addon.js:69
+#: static/js/impala-all.js:13298 static/js/impala-min.js:7 static/js/impala/persona_creation.js:60
+msgid "All Rights Reserved"
+msgstr "Всі права захищені"
+
+#: static/js/impala-all.js:13302 static/js/impala-min.js:7 static/js/impala/persona_creation.js:64
+msgid "Creative Commons Attribution 3.0"
+msgstr "Creative Commons Attribution 3.0"
+
+#: static/js/impala-all.js:13307 static/js/impala-min.js:7 static/js/impala/persona_creation.js:69
+msgid "Creative Commons Attribution-NonCommercial 3.0"
+msgstr "Creative Commons Attribution-NonCommercial 3.0"
+
+#: static/js/impala-all.js:13312 static/js/impala-min.js:7 static/js/impala/persona_creation.js:74
+msgid "Creative Commons Attribution-NonCommercial-NoDerivs 3.0"
+msgstr "Creative Commons Attribution-NonCommercial-NoDerivs 3.0"
+
+#: static/js/impala-all.js:13317 static/js/impala-min.js:7 static/js/impala/persona_creation.js:79
+msgid "Creative Commons Attribution-NonCommercial-Share Alike 3.0"
+msgstr "Creative Commons Attribution-NonCommercial-Share Alike 3.0"
+
+#: static/js/impala-all.js:13322 static/js/impala-min.js:7 static/js/impala/persona_creation.js:84
+msgid "Creative Commons Attribution-NoDerivs 3.0"
+msgstr "Creative Commons Attribution-NoDerivs 3.0"
+
+#: static/js/impala-all.js:13327 static/js/impala-min.js:7 static/js/impala/persona_creation.js:89
+msgid "Creative Commons Attribution-ShareAlike 3.0"
+msgstr "Creative Commons Attribution-ShareAlike 3.0"
+
+#: static/js/impala-all.js:13530 static/js/impala-min.js:7 static/js/impala/persona_creation.js:292
+msgid "Your Theme's Name"
+msgstr "Ім'я вашої теми"
+
+#: static/js/impala-all.js:14242 static/js/impala-min.js:8 static/js/impala/collections.js:19
+msgid "Stop Following"
+msgstr "Більше не стежити"
+
+#: static/js/impala-all.js:14243 static/js/impala-min.js:8 static/js/impala/collections.js:20
+msgid "Following"
+msgstr "Стеження"
+
+#: static/js/impala-all.js:14313 static/js/impala-min.js:8 static/js/impala/users.js:33
+msgid "use original"
+msgstr "використовувати оригінальне"
+
+#: static/js/impala-all.js:14523 static/js/impala-min.js:8 static/js/impala/search.js:114
+msgid "Updating results&hellip;"
+msgstr "Оновлення результатів&hellip;"
+
+#: static/js/common/upload-addon.js:69 static/js/zamboni/devhub-all.js:300 static/js/zamboni/devhub-min.js:1
 msgid "Select a file..."
 msgstr "Виберіть файл..."
 
-#: static/js/common/upload-addon.js:70
+#: static/js/common/upload-addon.js:70 static/js/zamboni/devhub-all.js:301 static/js/zamboni/devhub-min.js:1
 msgid "Your add-on should end with .xpi, .jar or .xml"
 msgstr "Ваш додаток повинен закінчуватись на .xpi, .jar чи .xml"
 
 #. L10n: {0} is the percent of the file that has been uploaded.
-#: static/js/common/upload-addon.js:104
+#: static/js/common/upload-addon.js:104 static/js/zamboni/devhub-all.js:335 static/js/zamboni/devhub-min.js:1
 #, python-format
 msgid "{0}% complete"
 msgstr "{0}% завершено"
 
 #. L10n: "{bytes uploaded} of {total filesize}".
-#: static/js/common/upload-addon.js:107
+#: static/js/common/upload-addon.js:107 static/js/zamboni/devhub-all.js:338 static/js/zamboni/devhub-min.js:1
 msgid "{0} of {1}"
 msgstr "{0} з {1}"
 
-#: static/js/common/upload-addon.js:140
+#: static/js/common/upload-addon.js:140 static/js/zamboni/devhub-all.js:371 static/js/zamboni/devhub-min.js:1
 msgid "Cancel"
 msgstr "Скасувати"
 
-#: static/js/common/upload-addon.js:162
+#: static/js/common/upload-addon.js:162 static/js/zamboni/devhub-all.js:393 static/js/zamboni/devhub-min.js:1
 msgid "Uploading {0}"
 msgstr "Вивантаження {0}"
 
-#: static/js/common/upload-addon.js:189
+#: static/js/common/upload-addon.js:189 static/js/zamboni/devhub-all.js:420 static/js/zamboni/devhub-min.js:1
 msgid "Error with {0}"
 msgstr "Помилка з {0}"
 
-#: static/js/common/upload-addon.js:194
+#: static/js/common/upload-addon.js:194 static/js/zamboni/devhub-all.js:425 static/js/zamboni/devhub-min.js:1
 msgid "Your add-on failed validation with {0} error."
 msgid_plural "Your add-on failed validation with {0} errors."
 msgstr[0] "Ваш додаток не пройшов перевірку з {0} помилкою."
 msgstr[1] "Ваш додаток не пройшов перевірку з {0} помилками."
-msgstr[2] "Ваш додаток не пройшов перевірку з {0} помилками."
 
-#: static/js/common/upload-addon.js:208
+#: static/js/common/upload-addon.js:208 static/js/zamboni/devhub-all.js:439 static/js/zamboni/devhub-min.js:1
 msgid "&hellip;and {0} more"
 msgid_plural "&hellip;and {0} more"
 msgstr[0] "&hellip;і ще {0}"
 msgstr[1] "&hellip;і ще {0}"
-msgstr[2] "&hellip;і ще {0}"
 
-#: static/js/common/upload-addon.js:222 static/js/common/upload-addon.js:512
+#: static/js/common/upload-addon.js:222 static/js/common/upload-addon.js:497 static/js/zamboni/devhub-all.js:453 static/js/zamboni/devhub-all.js:743 static/js/zamboni/devhub-min.js:1
 msgid "See full validation report"
 msgstr "Переглянути повний звіт перевірки"
 
-#: static/js/common/upload-addon.js:234
+#: static/js/common/upload-addon.js:234 static/js/zamboni/devhub-all.js:465 static/js/zamboni/devhub-min.js:1
 msgid "Validating {0}"
 msgstr "Перевірка {0}"
 
 #. L10n: first argument is an HTTP status code
-#: static/js/common/upload-addon.js:273
+#: static/js/common/upload-addon.js:273 static/js/zamboni/devhub-all.js:504 static/js/zamboni/devhub-min.js:1
 msgid "Received an empty response from the server; status: {0}"
 msgstr "Отримано порожню відвідь з серверу; стан: {0}"
 
-#: static/js/common/upload-addon.js:373
+#: static/js/common/upload-addon.js:370 static/js/zamboni/devhub-all.js:604 static/js/zamboni/devhub-min.js:1
 msgid "Unexpected server error while validating."
 msgstr "Несподівана помилка серверу під час перевірки."
 
-#: static/js/common/upload-addon.js:412
+#: static/js/common/upload-addon.js:409 static/js/zamboni/devhub-all.js:643 static/js/zamboni/devhub-min.js:1
 msgid "Finished validating {0}"
 msgstr "Завершена перевірка {0}"
 
-#: static/js/common/upload-addon.js:418
+#: static/js/common/upload-addon.js:415 static/js/zamboni/devhub-all.js:649 static/js/zamboni/devhub-min.js:1
 msgid "Your add-on validation timed out, it will be manually reviewed."
-msgstr ""
-"Час очікування затвердження вашого додатку завершився, він буде розглянутий "
-"вручну."
+msgstr "Час очікування затвердження вашого додатку завершився, він буде розглянутий вручну."
 
-#: static/js/common/upload-addon.js:421
+#: static/js/common/upload-addon.js:418 static/js/zamboni/devhub-all.js:652 static/js/zamboni/devhub-min.js:1
 msgid "Your add-on was validated with no errors and {0} warning."
 msgid_plural "Your add-on was validated with no errors and {0} warnings."
 msgstr[0] "Ваш додаток пройшов перевірку без помилок і з {0} попередженням."
 msgstr[1] "Ваш додаток пройшов перевірку без помилок і з {0} попередженнями."
-msgstr[2] "Ваш додаток пройшов перевірку без помилок і з {0} попередженнями."
 
-#: static/js/common/upload-addon.js:426
+#: static/js/common/upload-addon.js:423 static/js/zamboni/devhub-all.js:657 static/js/zamboni/devhub-min.js:1
 msgid "Your add-on was validated with no errors and {0} message."
 msgid_plural "Your add-on was validated with no errors and {0} messages."
 msgstr[0] "Ваш додаток пройшов перевірку без помилок і з {0} повідомленням."
 msgstr[1] "Ваш додаток пройшов перевірку без помилок і з {0} повідомленнями."
-msgstr[2] "Ваш додаток пройшов перевірку без помилок і з {0} повідомленнями."
 
-#: static/js/common/upload-addon.js:431
+#: static/js/common/upload-addon.js:428 static/js/zamboni/devhub-all.js:662 static/js/zamboni/devhub-min.js:1
 msgid "Your add-on was validated with no errors or warnings."
 msgstr "Ваш додаток пройшов перевірку без помилок чи застережень."
 
-#: static/js/common/upload-addon.js:446
+#: static/js/common/upload-addon.js:443 static/js/zamboni/devhub-all.js:677 static/js/zamboni/devhub-min.js:1
 msgid "Your submission will be automatically signed."
 msgstr "Ваше подання буде автоматично підписане."
 
-#: static/js/common/upload-addon.js:465
+#: static/js/common/upload-addon.js:450 static/js/zamboni/devhub-all.js:696 static/js/zamboni/devhub-min.js:1
 msgid "Include detailed version notes (this can be done in the next step)."
-msgstr ""
-"Включити детальні примітки до випуску (це може бути зроблено в наступному "
-"кроці)."
+msgstr "Включити детальні примітки до випуску (це може бути зроблено в наступному кроці)."
 
-#: static/js/common/upload-addon.js:466
-msgid ""
-"If your add-on requires an account to a website in order to be fully tested,"
-" include a test username and password in the Notes to Reviewer (this can be "
-"done in the next step)."
-msgstr ""
-"Якщо ваш додаток потребує обліковий запис на веб-сайті, зазначте тестові "
-"ім'я користувача та пароль у примітках до випуску (це може бути зроблено в "
-"наступному кроці)."
+#: static/js/common/upload-addon.js:451 static/js/zamboni/devhub-all.js:697 static/js/zamboni/devhub-min.js:1
+msgid "If your add-on requires an account to a website in order to be fully tested, include a test username and password in the Notes to Reviewer (this can be done in the next step)."
+msgstr "Якщо ваш додаток потребує обліковий запис на веб-сайті, зазначте тестові ім'я користувача та пароль у примітках до випуску (це може бути зроблено в наступному кроці)."
 
-#: static/js/common/upload-addon.js:467
-msgid ""
-"If your add-on is intended for a limited audience you should choose "
-"Preliminary Review instead of Full Review."
-msgstr ""
-"Якщо ваш додаток призначений для обмеженого кола користувачів, ви повинні "
-"вибрати Попередній Перегляд замість Повного Перегляду."
+#: static/js/common/upload-addon.js:452 static/js/zamboni/devhub-all.js:698 static/js/zamboni/devhub-min.js:1
+msgid "If your add-on is intended for a limited audience you should choose Preliminary Review instead of Full Review."
+msgstr "Якщо ваш додаток призначений для обмеженого кола користувачів, ви повинні вибрати Попередній Перегляд замість Повного Перегляду."
 
-#: static/js/common/upload-addon.js:480
+#: static/js/common/upload-addon.js:465 static/js/zamboni/devhub-all.js:711 static/js/zamboni/devhub-min.js:1
 msgid "Add-on submission checklist"
 msgstr "Контрольний перелік при представленні додатку"
 
-#: static/js/common/upload-addon.js:481
-msgid ""
-"Please verify the following points before finalizing your submission. This "
-"will minimize delays or misunderstanding during the review process:"
-msgstr ""
-"Перевірте наступні пункти перед завершенням вашого представлення. Це "
-"зменшить затримку чи нерозуміння під час процесу розгляду:"
+#: static/js/common/upload-addon.js:466 static/js/zamboni/devhub-all.js:712 static/js/zamboni/devhub-min.js:1
+msgid "Please verify the following points before finalizing your submission. This will minimize delays or misunderstanding during the review process:"
+msgstr "Перевірте наступні пункти перед завершенням вашого представлення. Це зменшить затримку чи нерозуміння під час процесу розгляду:"
 
-#: static/js/common/upload-addon.js:483
+#: static/js/common/upload-addon.js:468 static/js/zamboni/devhub-all.js:714 static/js/zamboni/devhub-min.js:1
 msgid ""
-"Compiled binaries, as well as minified or obfuscated scripts (excluding "
-"known libraries) need to have their sources submitted separately for review."
-" Make sure that you use the source code upload field to avoid having your "
-"submission rejected."
+"Compiled binaries, as well as minified or obfuscated scripts (excluding known libraries) need to have their sources submitted separately for review. Make sure that you use the source code upload "
+"field to avoid having your submission rejected."
 msgstr ""
-"Програмні коди скомпільованих бінарних файлів, а також мініфікованих чи "
-"обфускованих сценаріїв (окрім відомих бібліотек), необхідно представляти для"
-" перевірки окремо. Переконайтеся, що ви використовуєте поле завантаження "
-"програмного коду, щоб запобігти відхиленню вашого запиту."
+"Програмні коди скомпільованих бінарних файлів, а також мініфікованих чи обфускованих сценаріїв (окрім відомих бібліотек), необхідно представляти для перевірки окремо. Переконайтеся, що ви "
+"використовуєте поле завантаження програмного коду, щоб запобігти відхиленню вашого запиту."
 
-#: static/js/common/upload-addon.js:501
+#: static/js/common/upload-addon.js:486 static/js/zamboni/devhub-all.js:732 static/js/zamboni/devhub-min.js:1
 msgid "The validation process found these issues that can lead to rejections:"
-msgstr ""
-"Під час процесу перевірки було знайдено наступні проблеми, які можуть "
-"призвести до відхилення:"
+msgstr "Під час процесу перевірки було знайдено наступні проблеми, які можуть призвести до відхилення:"
 
-#: static/js/common/upload-addon.js:518
-msgid ""
-"If you are unfamiliar with the add-ons review process, you can read about it"
-" here."
-msgstr ""
-"Якщо ви не знайомі з процесом перевірки додатків, можете прочитати про це "
-"тут."
+#: static/js/common/upload-addon.js:503 static/js/zamboni/devhub-all.js:749 static/js/zamboni/devhub-min.js:1
+msgid "If you are unfamiliar with the add-ons review process, you can read about it here."
+msgstr "Якщо ви не знайомі з процесом перевірки додатків, можете прочитати про це тут."
 
-#: static/js/common/upload-addon.js:555
+#: static/js/common/upload-addon.js:540 static/js/zamboni/devhub-all.js:786 static/js/zamboni/devhub-min.js:1
 msgid "Sorry, no supported platform has been found."
 msgstr "На жаль, не знайдено підтримуваних платформ."
 
-#: static/js/common/upload-base.js:57
+#: static/js/common/upload-base.js:57 static/js/zamboni/devhub-all.js:187 static/js/zamboni/devhub-min.js:1
 msgid "The filetype you uploaded isn't recognized."
 msgstr "Тип вивантаженого вами файлу нерозпізнаний."
 
-#: static/js/common/upload-base.js:79
+#: static/js/common/upload-base.js:79 static/js/zamboni/devhub-all.js:209 static/js/zamboni/devhub-min.js:1
 msgid "You cancelled the upload."
 msgstr "Ви скасували вивантаження."
 
-#: static/js/common/upload-image.js:97 static/js/impala/users.js:51
-msgid "Images must be either PNG or JPG."
-msgstr "Зображення повинні бути PNG чи JPG."
-
-#: static/js/common/upload-image.js:101
-msgid "Videos must be in WebM."
-msgstr "Відео повинні бути у форматі WebM."
-
-#: static/js/impala/collections.js:10 static/js/zamboni/collections.js:595
-msgid "Follow this Collection"
-msgstr "Стежити за цією збіркою"
-
-#: static/js/impala/collections.js:19
-msgid "Stop Following"
-msgstr "Більше не стежити"
-
-#: static/js/impala/collections.js:20
-msgid "Following"
-msgstr "Стеження"
-
-#. L10n: {0} is an app name.
-#: static/js/impala/listing.js:11 static/js/zamboni/themes.js:13
-msgid "This theme is incompatible with your version of {0}"
-msgstr "Ця тема несумісна з вашою версією {0}"
-
-#: static/js/impala/persona_creation.js:60
-msgid "All Rights Reserved"
-msgstr "Всі права захищені"
-
-#: static/js/impala/persona_creation.js:64
-msgid "Creative Commons Attribution 3.0"
-msgstr "Creative Commons Attribution 3.0"
-
-#: static/js/impala/persona_creation.js:69
-msgid "Creative Commons Attribution-NonCommercial 3.0"
-msgstr "Creative Commons Attribution-NonCommercial 3.0"
-
-#: static/js/impala/persona_creation.js:74
-msgid "Creative Commons Attribution-NonCommercial-NoDerivs 3.0"
-msgstr "Creative Commons Attribution-NonCommercial-NoDerivs 3.0"
-
-#: static/js/impala/persona_creation.js:79
-msgid "Creative Commons Attribution-NonCommercial-Share Alike 3.0"
-msgstr "Creative Commons Attribution-NonCommercial-Share Alike 3.0"
-
-#: static/js/impala/persona_creation.js:84
-msgid "Creative Commons Attribution-NoDerivs 3.0"
-msgstr "Creative Commons Attribution-NoDerivs 3.0"
-
-#: static/js/impala/persona_creation.js:89
-msgid "Creative Commons Attribution-ShareAlike 3.0"
-msgstr "Creative Commons Attribution-ShareAlike 3.0"
-
-#: static/js/impala/persona_creation.js:292
-msgid "Your Theme's Name"
-msgstr "Ім'я вашої теми"
-
-#: static/js/impala/reviews.js:23 static/js/zamboni/reviews.js:18
-msgid "Flagged for review"
-msgstr "Відмічено для розгляду"
-
-#: static/js/impala/reviews.js:40 static/js/zamboni/reviews.js:34
-msgid "Your input is required"
-msgstr "Потрібна ваша думка"
-
-#: static/js/impala/reviews.js:152 static/js/zamboni/reviews.js:103
-msgid "Marked for deletion"
-msgstr "Відмічено для вилучення"
-
-#: static/js/impala/search.js:114
-msgid "Updating results&hellip;"
-msgstr "Оновлення результатів&hellip;"
-
-#: static/js/impala/site_suggestions.js:46
-msgid "Category"
-msgstr "Категорія"
-
-#: static/js/impala/suggestions.js:39
-msgid "Search themes for <b>{0}</b>"
-msgstr "Шукати теми для <b>{0}</b>"
-
-#: static/js/impala/suggestions.js:41
-msgid "Search apps for <b>{0}</b>"
-msgstr "Шукати застосунки для <b>{0}</b>"
-
-#: static/js/impala/suggestions.js:43
-msgid "Search add-ons for <b>{0}</b>"
-msgstr "Шукати додатки для <b>{0}</b>"
-
-#: static/js/impala/users.js:33
-msgid "use original"
-msgstr "використовувати оригінальне"
-
-#: static/js/impala/stats/chart.js:267
+#: static/js/impala/stats/chart.js:267 static/js/zamboni/stats-all.js:16898 static/js/zamboni/stats-min.js:5
 msgid "Week of {0}"
 msgstr "Тиждень {0}"
 
-#: static/js/impala/stats/chart.js:269
+#: static/js/impala/stats/chart.js:269 static/js/zamboni/stats-all.js:16900 static/js/zamboni/stats-min.js:5
 msgid " downloads"
-msgstr " завантажень"
+msgstr ""
 
-#: static/js/impala/stats/chart.js:270
+#: static/js/impala/stats/chart.js:270 static/js/zamboni/stats-all.js:16901 static/js/zamboni/stats-min.js:5
 msgid "{0} users"
 msgstr "{0} користувачів"
 
-#: static/js/impala/stats/chart.js:271
+#: static/js/impala/stats/chart.js:271 static/js/zamboni/stats-all.js:16902 static/js/zamboni/stats-min.js:5
 msgid "{0} add-ons"
 msgstr "{0} додатків"
 
-#: static/js/impala/stats/chart.js:272
+#: static/js/impala/stats/chart.js:272 static/js/zamboni/stats-all.js:16903 static/js/zamboni/stats-min.js:5
 msgid "{0} collections"
 msgstr "{0} збірок"
 
-#: static/js/impala/stats/chart.js:273
+#: static/js/impala/stats/chart.js:273 static/js/zamboni/stats-all.js:16904 static/js/zamboni/stats-min.js:5
 msgid "{0} reviews"
 msgstr "{0} оглядів"
 
-#: static/js/impala/stats/chart.js:275
+#: static/js/impala/stats/chart.js:275 static/js/zamboni/stats-all.js:16906 static/js/zamboni/stats-min.js:5
 msgid "{0} sales"
 msgstr "{0} продаж"
 
-#: static/js/impala/stats/chart.js:276
+#: static/js/impala/stats/chart.js:276 static/js/zamboni/stats-all.js:16907 static/js/zamboni/stats-min.js:5
 msgid "{0} refunds"
 msgstr "{0} повернень"
 
-#: static/js/impala/stats/chart.js:277
+#: static/js/impala/stats/chart.js:277 static/js/zamboni/stats-all.js:16908 static/js/zamboni/stats-min.js:5
 msgid "{0} installs"
 msgstr "{0} встановлень"
 
-#: static/js/impala/stats/chart.js:369 static/js/impala/stats/csv_keys.js:3
-#: static/js/impala/stats/csv_keys.js:109
+#: static/js/impala/stats/chart.js:369 static/js/impala/stats/csv_keys.js:3 static/js/impala/stats/csv_keys.js:109 static/js/zamboni/stats-all.js:15284 static/js/zamboni/stats-all.js:15390
+#: static/js/zamboni/stats-all.js:17000 static/js/zamboni/stats-min.js:4 static/js/zamboni/stats-min.js:5
 msgid "Downloads"
 msgstr "Завантажень"
 
-#: static/js/impala/stats/chart.js:379 static/js/impala/stats/csv_keys.js:6
-#: static/js/impala/stats/csv_keys.js:110
+#: static/js/impala/stats/chart.js:379 static/js/impala/stats/csv_keys.js:6 static/js/impala/stats/csv_keys.js:110 static/js/zamboni/stats-all.js:15287 static/js/zamboni/stats-all.js:15391
+#: static/js/zamboni/stats-all.js:17010 static/js/zamboni/stats-min.js:4 static/js/zamboni/stats-min.js:5
 msgid "Daily Users"
 msgstr "Щоденних користувачів"
 
-#: static/js/impala/stats/chart.js:410
+#: static/js/impala/stats/chart.js:410 static/js/zamboni/stats-all.js:17041 static/js/zamboni/stats-min.js:5
 msgid "Amount, in USD"
 msgstr "Сума в USD"
 
-#: static/js/impala/stats/chart.js:421 static/js/impala/stats/csv_keys.js:104
+#: static/js/impala/stats/chart.js:421 static/js/impala/stats/csv_keys.js:104 static/js/zamboni/stats-all.js:15385 static/js/zamboni/stats-all.js:17052 static/js/zamboni/stats-min.js:5
 msgid "Number of Contributions"
 msgstr "Кількість внесків"
 
-#: static/js/impala/stats/chart.js:447
+#: static/js/impala/stats/chart.js:447 static/js/zamboni/stats-all.js:17078 static/js/zamboni/stats-min.js:5
 msgid "More Info..."
 msgstr "Докладніше..."
 
 #. L10n: {0} is an ISO-formatted date.
-#: static/js/impala/stats/chart.js:451
+#: static/js/impala/stats/chart.js:451 static/js/zamboni/stats-all.js:17082 static/js/zamboni/stats-min.js:5
 msgid "Details for {0}"
 msgstr "Докладніше за {0}"
 
-#: static/js/impala/stats/csv_keys.js:9
+#: static/js/impala/stats/csv_keys.js:9 static/js/zamboni/stats-all.js:15290 static/js/zamboni/stats-min.js:4
 msgid "Collections Created"
 msgstr "Створено збірок"
 
-#: static/js/impala/stats/csv_keys.js:12
+#: static/js/impala/stats/csv_keys.js:12 static/js/zamboni/stats-all.js:15293 static/js/zamboni/stats-min.js:4
 msgid "Add-ons in Use"
 msgstr "Використовується додатків"
 
-#: static/js/impala/stats/csv_keys.js:15
+#: static/js/impala/stats/csv_keys.js:15 static/js/zamboni/stats-all.js:15296 static/js/zamboni/stats-min.js:4
 msgid "Add-ons Created"
 msgstr "Створено додатків"
 
-#: static/js/impala/stats/csv_keys.js:18
+#: static/js/impala/stats/csv_keys.js:18 static/js/zamboni/stats-all.js:15299 static/js/zamboni/stats-min.js:4
 msgid "Add-ons Downloaded"
 msgstr "Завантажено додатків"
 
-#: static/js/impala/stats/csv_keys.js:21
+#: static/js/impala/stats/csv_keys.js:21 static/js/zamboni/stats-all.js:15302 static/js/zamboni/stats-min.js:4
 msgid "Add-ons Updated"
 msgstr "Оновлено додатків"
 
-#: static/js/impala/stats/csv_keys.js:24
+#: static/js/impala/stats/csv_keys.js:24 static/js/zamboni/stats-all.js:15305 static/js/zamboni/stats-min.js:4
 msgid "Reviews Written"
 msgstr "Написано оглядів"
 
-#: static/js/impala/stats/csv_keys.js:27
+#: static/js/impala/stats/csv_keys.js:27 static/js/zamboni/stats-all.js:15308 static/js/zamboni/stats-min.js:4
 msgid "User Signups"
 msgstr "Реєстрації користувачів"
 
-#: static/js/impala/stats/csv_keys.js:30
+#: static/js/impala/stats/csv_keys.js:30 static/js/zamboni/stats-all.js:15311 static/js/zamboni/stats-min.js:4
 msgid "Subscribers"
 msgstr "Користувачі"
 
-#: static/js/impala/stats/csv_keys.js:33
+#: static/js/impala/stats/csv_keys.js:33 static/js/zamboni/stats-all.js:15314 static/js/zamboni/stats-min.js:4
 msgid "Ratings"
 msgstr "Рейтинги"
 
-#: static/js/impala/stats/csv_keys.js:36
-#: static/js/impala/stats/csv_keys.js:114
+#: static/js/impala/stats/csv_keys.js:36 static/js/impala/stats/csv_keys.js:114 static/js/zamboni/stats-all.js:15317 static/js/zamboni/stats-all.js:15395 static/js/zamboni/stats-min.js:4
+#: static/js/zamboni/stats-min.js:5
 msgid "Sales"
 msgstr "Продажі"
 
-#: static/js/impala/stats/csv_keys.js:39
-#: static/js/impala/stats/csv_keys.js:113
+#: static/js/impala/stats/csv_keys.js:39 static/js/impala/stats/csv_keys.js:113 static/js/zamboni/stats-all.js:15320 static/js/zamboni/stats-all.js:15394 static/js/zamboni/stats-min.js:4
+#: static/js/zamboni/stats-min.js:5
 msgid "Installs"
 msgstr "Встановлення"
 
-#: static/js/impala/stats/csv_keys.js:42
+#: static/js/impala/stats/csv_keys.js:42 static/js/zamboni/stats-all.js:15323 static/js/zamboni/stats-min.js:4
 msgid "Unknown"
 msgstr "Невідомо"
 
-#: static/js/impala/stats/csv_keys.js:43
+#: static/js/impala/stats/csv_keys.js:43 static/js/zamboni/stats-all.js:15324 static/js/zamboni/stats-min.js:4
 msgid "Add-ons Manager"
 msgstr "Менеджер додатків"
 
-#: static/js/impala/stats/csv_keys.js:44
+#: static/js/impala/stats/csv_keys.js:44 static/js/zamboni/stats-all.js:15325 static/js/zamboni/stats-min.js:4
 msgid "Add-ons Manager Promo"
 msgstr "Менеджер додатків Промо"
 
-#: static/js/impala/stats/csv_keys.js:45
+#: static/js/impala/stats/csv_keys.js:45 static/js/zamboni/stats-all.js:15326 static/js/zamboni/stats-min.js:4
 msgid "Add-ons Manager Featured"
 msgstr "Менеджер додатків Відібрані"
 
-#: static/js/impala/stats/csv_keys.js:46
+#: static/js/impala/stats/csv_keys.js:46 static/js/zamboni/stats-all.js:15327 static/js/zamboni/stats-min.js:4
 msgid "Add-ons Manager Learn More"
 msgstr "Менеджер додатків Докладніше"
 
-#: static/js/impala/stats/csv_keys.js:47
+#: static/js/impala/stats/csv_keys.js:47 static/js/zamboni/stats-all.js:15328 static/js/zamboni/stats-min.js:4
 msgid "Search Suggestions"
 msgstr "Пошукові пропозиції"
 
-#: static/js/impala/stats/csv_keys.js:48
+#: static/js/impala/stats/csv_keys.js:48 static/js/zamboni/stats-all.js:15329 static/js/zamboni/stats-min.js:4
 msgid "Search Results"
 msgstr "Результати пошуку"
 
-#: static/js/impala/stats/csv_keys.js:49 static/js/impala/stats/csv_keys.js:50
-#: static/js/impala/stats/csv_keys.js:51
+#: static/js/impala/stats/csv_keys.js:49 static/js/impala/stats/csv_keys.js:50 static/js/impala/stats/csv_keys.js:51 static/js/zamboni/stats-all.js:15330 static/js/zamboni/stats-all.js:15331
+#: static/js/zamboni/stats-all.js:15332 static/js/zamboni/stats-min.js:4
 msgid "Homepage Promo"
 msgstr "Промо"
 
-#: static/js/impala/stats/csv_keys.js:52 static/js/impala/stats/csv_keys.js:53
+#: static/js/impala/stats/csv_keys.js:52 static/js/impala/stats/csv_keys.js:53 static/js/zamboni/stats-all.js:15333 static/js/zamboni/stats-all.js:15334 static/js/zamboni/stats-min.js:4
 msgid "Homepage Featured"
 msgstr "Відібрані"
 
-#: static/js/impala/stats/csv_keys.js:54 static/js/impala/stats/csv_keys.js:55
+#: static/js/impala/stats/csv_keys.js:54 static/js/impala/stats/csv_keys.js:55 static/js/zamboni/stats-all.js:15335 static/js/zamboni/stats-all.js:15336 static/js/zamboni/stats-min.js:4
 msgid "Homepage Up and Coming"
 msgstr "Набирають популярність"
 
-#: static/js/impala/stats/csv_keys.js:56
+#: static/js/impala/stats/csv_keys.js:56 static/js/zamboni/stats-all.js:15337 static/js/zamboni/stats-min.js:4
 msgid "Homepage Most Popular"
 msgstr "Найпопулярніші"
 
-#: static/js/impala/stats/csv_keys.js:57 static/js/impala/stats/csv_keys.js:59
+#: static/js/impala/stats/csv_keys.js:57 static/js/impala/stats/csv_keys.js:59 static/js/zamboni/stats-all.js:15338 static/js/zamboni/stats-all.js:15340 static/js/zamboni/stats-min.js:4
 msgid "Detail Page"
 msgstr "Сторінка з подробицями"
 
-#: static/js/impala/stats/csv_keys.js:58 static/js/impala/stats/csv_keys.js:60
+#: static/js/impala/stats/csv_keys.js:58 static/js/impala/stats/csv_keys.js:60 static/js/zamboni/stats-all.js:15339 static/js/zamboni/stats-all.js:15341 static/js/zamboni/stats-min.js:4
 msgid "Detail Page (bottom)"
 msgstr "Сторінка з подробицями (низ)"
 
-#: static/js/impala/stats/csv_keys.js:61
+#: static/js/impala/stats/csv_keys.js:61 static/js/zamboni/stats-all.js:15342 static/js/zamboni/stats-min.js:4
 msgid "Detail Page (Development Channel)"
 msgstr "Сторінка з подробицями (Канал розробників)"
 
-#: static/js/impala/stats/csv_keys.js:62 static/js/impala/stats/csv_keys.js:63
-#: static/js/impala/stats/csv_keys.js:64
+#: static/js/impala/stats/csv_keys.js:62 static/js/impala/stats/csv_keys.js:63 static/js/impala/stats/csv_keys.js:64 static/js/zamboni/stats-all.js:15343 static/js/zamboni/stats-all.js:15344
+#: static/js/zamboni/stats-all.js:15345 static/js/zamboni/stats-min.js:4
 msgid "Often Used With"
 msgstr "Часто викор. з"
 
-#: static/js/impala/stats/csv_keys.js:65 static/js/impala/stats/csv_keys.js:66
+#: static/js/impala/stats/csv_keys.js:65 static/js/impala/stats/csv_keys.js:66 static/js/zamboni/stats-all.js:15346 static/js/zamboni/stats-all.js:15347 static/js/zamboni/stats-min.js:4
 msgid "Others By Author"
 msgstr "Інші за автором"
 
-#: static/js/impala/stats/csv_keys.js:67 static/js/impala/stats/csv_keys.js:68
+#: static/js/impala/stats/csv_keys.js:67 static/js/impala/stats/csv_keys.js:68 static/js/zamboni/stats-all.js:15348 static/js/zamboni/stats-all.js:15349 static/js/zamboni/stats-min.js:4
 msgid "Dependencies"
 msgstr "Залежності"
 
-#: static/js/impala/stats/csv_keys.js:69 static/js/impala/stats/csv_keys.js:70
+#: static/js/impala/stats/csv_keys.js:69 static/js/impala/stats/csv_keys.js:70 static/js/zamboni/stats-all.js:15350 static/js/zamboni/stats-all.js:15351 static/js/zamboni/stats-min.js:4
 msgid "Upsell"
 msgstr "Upsell"
 
-#: static/js/impala/stats/csv_keys.js:71
+#: static/js/impala/stats/csv_keys.js:71 static/js/zamboni/stats-all.js:15352 static/js/zamboni/stats-min.js:4
 msgid "Meet the Developer"
 msgstr "Познайомитися з розробником"
 
-#: static/js/impala/stats/csv_keys.js:72
+#: static/js/impala/stats/csv_keys.js:72 static/js/zamboni/stats-all.js:15353 static/js/zamboni/stats-min.js:4
 msgid "User Profile"
 msgstr "Профіль користувача"
 
-#: static/js/impala/stats/csv_keys.js:73
+#: static/js/impala/stats/csv_keys.js:73 static/js/zamboni/stats-all.js:15354 static/js/zamboni/stats-min.js:4
 msgid "Version History"
 msgstr "Історія версій"
 
-#: static/js/impala/stats/csv_keys.js:75
+#: static/js/impala/stats/csv_keys.js:75 static/js/zamboni/stats-all.js:15356 static/js/zamboni/stats-min.js:4
 msgid "Sharing"
 msgstr "Поширення"
 
-#: static/js/impala/stats/csv_keys.js:76
+#: static/js/impala/stats/csv_keys.js:76 static/js/zamboni/stats-all.js:15357 static/js/zamboni/stats-min.js:4
 msgid "Category Pages"
 msgstr "Сторінки категорій"
 
-#: static/js/impala/stats/csv_keys.js:77
+#: static/js/impala/stats/csv_keys.js:77 static/js/zamboni/stats-all.js:15358 static/js/zamboni/stats-min.js:4
 msgid "Collections"
 msgstr "Збірки"
 
-#: static/js/impala/stats/csv_keys.js:78 static/js/impala/stats/csv_keys.js:79
+#: static/js/impala/stats/csv_keys.js:78 static/js/impala/stats/csv_keys.js:79 static/js/zamboni/stats-all.js:15359 static/js/zamboni/stats-all.js:15360 static/js/zamboni/stats-min.js:4
 msgid "Category Landing Featured Carousel"
 msgstr "Розміщення в категорії Карусель обраного"
 
-#: static/js/impala/stats/csv_keys.js:80 static/js/impala/stats/csv_keys.js:81
+#: static/js/impala/stats/csv_keys.js:80 static/js/impala/stats/csv_keys.js:81 static/js/zamboni/stats-all.js:15361 static/js/zamboni/stats-all.js:15362 static/js/zamboni/stats-min.js:4
 msgid "Category Landing Top Rated"
 msgstr "Розміщення в категорії Найвище оцінені"
 
-#: static/js/impala/stats/csv_keys.js:82 static/js/impala/stats/csv_keys.js:83
+#: static/js/impala/stats/csv_keys.js:82 static/js/impala/stats/csv_keys.js:83 static/js/zamboni/stats-all.js:15363 static/js/zamboni/stats-all.js:15364 static/js/zamboni/stats-min.js:5
 msgid "Category Landing Most Popular"
 msgstr "Розміщення в категорії Найпопулярніші"
 
-#: static/js/impala/stats/csv_keys.js:84 static/js/impala/stats/csv_keys.js:85
+#: static/js/impala/stats/csv_keys.js:84 static/js/impala/stats/csv_keys.js:85 static/js/zamboni/stats-all.js:15365 static/js/zamboni/stats-all.js:15366 static/js/zamboni/stats-min.js:5
 msgid "Category Landing Recently Added"
 msgstr "Розміщення в категорії Нещодавно додані"
 
-#: static/js/impala/stats/csv_keys.js:86 static/js/impala/stats/csv_keys.js:87
+#: static/js/impala/stats/csv_keys.js:86 static/js/impala/stats/csv_keys.js:87 static/js/zamboni/stats-all.js:15367 static/js/zamboni/stats-all.js:15368 static/js/zamboni/stats-min.js:5
 msgid "Browse Listing Featured Sort"
 msgstr "Огляд з сортуванням по обраних"
 
-#: static/js/impala/stats/csv_keys.js:88 static/js/impala/stats/csv_keys.js:89
+#: static/js/impala/stats/csv_keys.js:88 static/js/impala/stats/csv_keys.js:89 static/js/zamboni/stats-all.js:15369 static/js/zamboni/stats-all.js:15370 static/js/zamboni/stats-min.js:5
 msgid "Browse Listing Users Sort"
 msgstr "Огляд з сортуванням по користувачах"
 
-#: static/js/impala/stats/csv_keys.js:90 static/js/impala/stats/csv_keys.js:91
+#: static/js/impala/stats/csv_keys.js:90 static/js/impala/stats/csv_keys.js:91 static/js/zamboni/stats-all.js:15371 static/js/zamboni/stats-all.js:15372 static/js/zamboni/stats-min.js:5
 msgid "Browse Listing Rating Sort"
 msgstr "Огляд з сортуванням за рейтингом"
 
-#: static/js/impala/stats/csv_keys.js:92 static/js/impala/stats/csv_keys.js:93
+#: static/js/impala/stats/csv_keys.js:92 static/js/impala/stats/csv_keys.js:93 static/js/zamboni/stats-all.js:15373 static/js/zamboni/stats-all.js:15374 static/js/zamboni/stats-min.js:5
 msgid "Browse Listing Created Sort"
 msgstr "Огляд з сортуванням за датою створення"
 
-#: static/js/impala/stats/csv_keys.js:94 static/js/impala/stats/csv_keys.js:95
+#: static/js/impala/stats/csv_keys.js:94 static/js/impala/stats/csv_keys.js:95 static/js/zamboni/stats-all.js:15375 static/js/zamboni/stats-all.js:15376 static/js/zamboni/stats-min.js:5
 msgid "Browse Listing Name Sort"
 msgstr "Огляд з сортуванням за назвою"
 
-#: static/js/impala/stats/csv_keys.js:96 static/js/impala/stats/csv_keys.js:97
+#: static/js/impala/stats/csv_keys.js:96 static/js/impala/stats/csv_keys.js:97 static/js/zamboni/stats-all.js:15377 static/js/zamboni/stats-all.js:15378 static/js/zamboni/stats-min.js:5
 msgid "Browse Listing Popular Sort"
 msgstr "Огляд з сортуванням за популярністю"
 
-#: static/js/impala/stats/csv_keys.js:98 static/js/impala/stats/csv_keys.js:99
+#: static/js/impala/stats/csv_keys.js:98 static/js/impala/stats/csv_keys.js:99 static/js/zamboni/stats-all.js:15379 static/js/zamboni/stats-all.js:15380 static/js/zamboni/stats-min.js:5
 msgid "Browse Listing Updated Sort"
 msgstr "Огляд з сортуванням за датою оновлення"
 
-#: static/js/impala/stats/csv_keys.js:100
-#: static/js/impala/stats/csv_keys.js:101
+#: static/js/impala/stats/csv_keys.js:100 static/js/impala/stats/csv_keys.js:101 static/js/zamboni/stats-all.js:15381 static/js/zamboni/stats-all.js:15382 static/js/zamboni/stats-min.js:5
 msgid "Browse Listing Up and Coming Sort"
 msgstr "Огляд з сортуванням за очікуванням виходу"
 
-#: static/js/impala/stats/csv_keys.js:105
+#: static/js/impala/stats/csv_keys.js:105 static/js/zamboni/stats-all.js:15386 static/js/zamboni/stats-min.js:5
 msgid "Total Amount Contributed"
 msgstr "Загальна кількість внесків"
 
-#: static/js/impala/stats/csv_keys.js:106
+#: static/js/impala/stats/csv_keys.js:106 static/js/zamboni/stats-all.js:15387 static/js/zamboni/stats-min.js:5
 msgid "Average Contribution"
 msgstr "Середній внесок"
 
-#: static/js/impala/stats/csv_keys.js:115
+#: static/js/impala/stats/csv_keys.js:115 static/js/zamboni/stats-all.js:15396 static/js/zamboni/stats-min.js:5
 msgid "Usage"
 msgstr "Використання"
 
-#: static/js/impala/stats/csv_keys.js:118
+#: static/js/impala/stats/csv_keys.js:118 static/js/zamboni/stats-all.js:15399 static/js/zamboni/stats-min.js:5
 msgid "Firefox"
 msgstr "Firefox"
 
-#: static/js/impala/stats/csv_keys.js:119
+#: static/js/impala/stats/csv_keys.js:119 static/js/zamboni/stats-all.js:15400 static/js/zamboni/stats-min.js:5
 msgid "Mozilla"
 msgstr "Mozilla"
 
-#: static/js/impala/stats/csv_keys.js:120
+#: static/js/impala/stats/csv_keys.js:120 static/js/zamboni/stats-all.js:15401 static/js/zamboni/stats-min.js:5
 msgid "Thunderbird"
 msgstr "Thunderbird"
 
-#: static/js/impala/stats/csv_keys.js:121
+#: static/js/impala/stats/csv_keys.js:121 static/js/zamboni/stats-all.js:15402 static/js/zamboni/stats-min.js:5
 msgid "Sunbird"
 msgstr "Sunbird"
 
-#: static/js/impala/stats/csv_keys.js:122
+#: static/js/impala/stats/csv_keys.js:122 static/js/zamboni/stats-all.js:15403 static/js/zamboni/stats-min.js:5
 msgid "SeaMonkey"
 msgstr "SeaMonkey"
 
-#: static/js/impala/stats/csv_keys.js:123
+#: static/js/impala/stats/csv_keys.js:123 static/js/zamboni/stats-all.js:15404 static/js/zamboni/stats-min.js:5
 msgid "Fennec"
 msgstr "Fennec"
 
-#: static/js/impala/stats/csv_keys.js:124
+#: static/js/impala/stats/csv_keys.js:124 static/js/zamboni/stats-all.js:15405 static/js/zamboni/stats-min.js:5
 msgid "Android"
 msgstr "Android"
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:129
+#: static/js/impala/stats/csv_keys.js:129 static/js/zamboni/stats-all.js:15410 static/js/zamboni/stats-min.js:5
 msgid "Downloads and Daily Users, last {0} days"
 msgstr "Завантажень та щоденних користувачів за останні {0} днів"
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:131
+#: static/js/impala/stats/csv_keys.js:131 static/js/zamboni/stats-all.js:15412 static/js/zamboni/stats-min.js:5
 msgid "Downloads and Daily Users from {0} to {1}"
 msgstr "Завантажень та щоденних користувачів з {0} по {1}"
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:135
+#: static/js/impala/stats/csv_keys.js:135 static/js/zamboni/stats-all.js:15416 static/js/zamboni/stats-min.js:5
 msgid "Installs and Daily Users, last {0} days"
 msgstr "Встановлень та щоденних користувачів за останні {0} днів"
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:137
+#: static/js/impala/stats/csv_keys.js:137 static/js/zamboni/stats-all.js:15418 static/js/zamboni/stats-min.js:5
 msgid "Installs and Daily Users from {0} to {1}"
 msgstr "Встановлень та щоденних користувачів від {0} до {1}"
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:141
+#: static/js/impala/stats/csv_keys.js:141 static/js/zamboni/stats-all.js:15422 static/js/zamboni/stats-min.js:5
 msgid "Downloads, last {0} days"
 msgstr "Завантажень за останні {0} днів"
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:143
+#: static/js/impala/stats/csv_keys.js:143 static/js/zamboni/stats-all.js:15424 static/js/zamboni/stats-min.js:5
 msgid "Downloads from {0} to {1}"
 msgstr "Завантажень з {0} по {1}"
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:147
+#: static/js/impala/stats/csv_keys.js:147 static/js/zamboni/stats-all.js:15428 static/js/zamboni/stats-min.js:5
 msgid "Daily Users, last {0} days"
 msgstr "Щоденних користувачів за останні {0} днів"
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:149
+#: static/js/impala/stats/csv_keys.js:149 static/js/zamboni/stats-all.js:15430 static/js/zamboni/stats-min.js:5
 msgid "Daily Users from {0} to {1}"
 msgstr "Щоденних користувачів з {0} по {1}"
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:153
+#: static/js/impala/stats/csv_keys.js:153 static/js/zamboni/stats-all.js:15434 static/js/zamboni/stats-min.js:5
 msgid "Applications, last {0} days"
 msgstr "Застосунків за останні {0} днів"
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:155
+#: static/js/impala/stats/csv_keys.js:155 static/js/zamboni/stats-all.js:15436 static/js/zamboni/stats-min.js:5
 msgid "Applications from {0} to {1}"
 msgstr "Застосунків з {0} по {1}"
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:159
+#: static/js/impala/stats/csv_keys.js:159 static/js/zamboni/stats-all.js:15440 static/js/zamboni/stats-min.js:5
 msgid "Platforms, last {0} days"
 msgstr "Платформ за останні {0} днів"
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:161
+#: static/js/impala/stats/csv_keys.js:161 static/js/zamboni/stats-all.js:15442 static/js/zamboni/stats-min.js:5
 msgid "Platforms from {0} to {1}"
 msgstr "Платформ з {0} по {1}"
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:165
+#: static/js/impala/stats/csv_keys.js:165 static/js/zamboni/stats-all.js:15446 static/js/zamboni/stats-min.js:5
 msgid "Languages, last {0} days"
 msgstr "Мови за останні {0} днів"
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:167
+#: static/js/impala/stats/csv_keys.js:167 static/js/zamboni/stats-all.js:15448 static/js/zamboni/stats-min.js:5
 msgid "Languages from {0} to {1}"
 msgstr "Мови з {0} по {1}"
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:171
+#: static/js/impala/stats/csv_keys.js:171 static/js/zamboni/stats-all.js:15452 static/js/zamboni/stats-min.js:5
 msgid "Add-on Versions, last {0} days"
 msgstr "Версій додатків за останні {0} днів"
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:173
+#: static/js/impala/stats/csv_keys.js:173 static/js/zamboni/stats-all.js:15454 static/js/zamboni/stats-min.js:5
 msgid "Add-on Versions from {0} to {1}"
 msgstr "Версій додатків з {0} по {1}"
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:177
+#: static/js/impala/stats/csv_keys.js:177 static/js/zamboni/stats-all.js:15458 static/js/zamboni/stats-min.js:5
 msgid "Add-on Status, last {0} days"
 msgstr "Статус додатків за останні {0} днів"
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:179
+#: static/js/impala/stats/csv_keys.js:179 static/js/zamboni/stats-all.js:15460 static/js/zamboni/stats-min.js:5
 msgid "Add-on Status from {0} to {1}"
 msgstr "Статус додатків з {0} по {1}"
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:183
+#: static/js/impala/stats/csv_keys.js:183 static/js/zamboni/stats-all.js:15464 static/js/zamboni/stats-min.js:5
 msgid "Download Sources, last {0} days"
 msgstr "Джерел завантажень за останні {0} днів"
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:185
+#: static/js/impala/stats/csv_keys.js:185 static/js/zamboni/stats-all.js:15466 static/js/zamboni/stats-min.js:5
 msgid "Download Sources from {0} to {1}"
 msgstr "Джерел завантажень з {0} по {1}"
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:189
+#: static/js/impala/stats/csv_keys.js:189 static/js/zamboni/stats-all.js:15470 static/js/zamboni/stats-min.js:5
 msgid "Contributions, last {0} days"
 msgstr "Внесків за останні {0} днів"
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:191
+#: static/js/impala/stats/csv_keys.js:191 static/js/zamboni/stats-all.js:15472 static/js/zamboni/stats-min.js:5
 msgid "Contributions from {0} to {1}"
 msgstr "Внески з {0} по {1}"
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:195
+#: static/js/impala/stats/csv_keys.js:195 static/js/zamboni/stats-all.js:15476 static/js/zamboni/stats-min.js:5
 msgid "Site Metrics, last {0} days"
 msgstr "Статистика сайту за останні {0} днів"
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:197
+#: static/js/impala/stats/csv_keys.js:197 static/js/zamboni/stats-all.js:15478 static/js/zamboni/stats-min.js:5
 msgid "Site Metrics from {0} to {1}"
 msgstr "Статистика сайту з {0} по {1}"
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:201
+#: static/js/impala/stats/csv_keys.js:201 static/js/zamboni/stats-all.js:15482 static/js/zamboni/stats-min.js:5
 msgid "Add-ons in Use, last {0} days"
 msgstr "Додатків використовується, останні {0} днів"
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:203
+#: static/js/impala/stats/csv_keys.js:203 static/js/zamboni/stats-all.js:15484 static/js/zamboni/stats-min.js:5
 msgid "Add-ons in Use from {0} to {1}"
 msgstr "Додатків використовується, з {0} по {1}"
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:207
+#: static/js/impala/stats/csv_keys.js:207 static/js/zamboni/stats-all.js:15488 static/js/zamboni/stats-min.js:5
 msgid "Add-ons Downloaded, last {0} days"
 msgstr "Завантажено додатків за останні {0} днів"
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:209
+#: static/js/impala/stats/csv_keys.js:209 static/js/zamboni/stats-all.js:15490 static/js/zamboni/stats-min.js:5
 msgid "Add-ons Downloaded from {0} to {1}"
 msgstr "Завантажено додатків з {0} по {1}"
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:213
+#: static/js/impala/stats/csv_keys.js:213 static/js/zamboni/stats-all.js:15494 static/js/zamboni/stats-min.js:5
 msgid "Add-ons Created, last {0} days"
 msgstr "Створено додатків за останні {0} днів"
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:215
+#: static/js/impala/stats/csv_keys.js:215 static/js/zamboni/stats-all.js:15496 static/js/zamboni/stats-min.js:5
 msgid "Add-ons Created from {0} to {1}"
 msgstr "Створено додатків з {0} по {1}"
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:219
+#: static/js/impala/stats/csv_keys.js:219 static/js/zamboni/stats-all.js:15500 static/js/zamboni/stats-min.js:5
 msgid "Add-ons Updated, last {0} days"
 msgstr "Оновлено додатків за останні {0} днів"
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:221
+#: static/js/impala/stats/csv_keys.js:221 static/js/zamboni/stats-all.js:15502 static/js/zamboni/stats-min.js:5
 msgid "Add-ons Updated from {0} to {1}"
 msgstr "Оновлено додатків з {0} по {1}"
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:225
+#: static/js/impala/stats/csv_keys.js:225 static/js/zamboni/stats-all.js:15506 static/js/zamboni/stats-min.js:5
 msgid "Reviews Written, last {0} days"
 msgstr "Написано відгуків за останні {0} днів"
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:227
+#: static/js/impala/stats/csv_keys.js:227 static/js/zamboni/stats-all.js:15508 static/js/zamboni/stats-min.js:5
 msgid "Reviews Written from {0} to {1}"
 msgstr "Написано відгуків з {0} по {1}"
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:231
+#: static/js/impala/stats/csv_keys.js:231 static/js/zamboni/stats-all.js:15512 static/js/zamboni/stats-min.js:5
 msgid "User Signups, last {0} days"
 msgstr "Зареєстровано користувачів за останні {0} днів"
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:233
+#: static/js/impala/stats/csv_keys.js:233 static/js/zamboni/stats-all.js:15514 static/js/zamboni/stats-min.js:5
 msgid "User Signups from {0} to {1}"
 msgstr "Зареєстровано користувачів з {0} по {1}"
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:237
+#: static/js/impala/stats/csv_keys.js:237 static/js/zamboni/stats-all.js:15518 static/js/zamboni/stats-min.js:5
 msgid "Collections Created, last {0} days"
 msgstr "Створено збірок за останні {0} днів"
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:239
+#: static/js/impala/stats/csv_keys.js:239 static/js/zamboni/stats-all.js:15520 static/js/zamboni/stats-min.js:5
 msgid "Collections Created from {0} to {1}"
 msgstr "Створено збірок з {0} по {1}"
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:243
+#: static/js/impala/stats/csv_keys.js:243 static/js/zamboni/stats-all.js:15524 static/js/zamboni/stats-min.js:5
 msgid "Subscribers, last {0} days"
 msgstr "Читачів за останні {0} днів"
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:245
+#: static/js/impala/stats/csv_keys.js:245 static/js/zamboni/stats-all.js:15526 static/js/zamboni/stats-min.js:5
 msgid "Subscribers from {0} to {1}"
 msgstr "Читачів з {0} по {1}"
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:249
+#: static/js/impala/stats/csv_keys.js:249 static/js/zamboni/stats-all.js:15530 static/js/zamboni/stats-min.js:5
 msgid "Ratings, last {0} days"
 msgstr "Рейтинги за останні {0} днів"
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:251
+#: static/js/impala/stats/csv_keys.js:251 static/js/zamboni/stats-all.js:15532 static/js/zamboni/stats-min.js:5
 msgid "Ratings from {0} to {1}"
 msgstr "Рейтинги з {0} по {1}"
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:255
+#: static/js/impala/stats/csv_keys.js:255 static/js/zamboni/stats-all.js:15536 static/js/zamboni/stats-min.js:5
 msgid "Sales, last {0} days"
 msgstr "Продажі за останні {0} днів"
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:257
+#: static/js/impala/stats/csv_keys.js:257 static/js/zamboni/stats-all.js:15538 static/js/zamboni/stats-min.js:5
 msgid "Sales from {0} to {1}"
 msgstr "Продажі з {0} по {1}"
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:261
+#: static/js/impala/stats/csv_keys.js:261 static/js/zamboni/stats-all.js:15542 static/js/zamboni/stats-min.js:5
 msgid "Installs, last {0} days"
 msgstr "Встановлень за останні {0} днів"
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:263
+#: static/js/impala/stats/csv_keys.js:263 static/js/zamboni/stats-all.js:15544 static/js/zamboni/stats-min.js:5
 msgid "Installs from {0} to {1}"
 msgstr "Встановлень з {0} по {1}"
 
 #. L10n: {0} and {1} are integers.
-#: static/js/impala/stats/csv_keys.js:269
+#: static/js/impala/stats/csv_keys.js:269 static/js/zamboni/stats-all.js:15550 static/js/zamboni/stats-min.js:5
 msgid "<b>{0}</b> in last {1} days"
 msgstr "<b>{0}</b> за останні {1} днів"
 
 #. L10n: {0} is an integer and {1} and {2} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:271
-#: static/js/impala/stats/csv_keys.js:277
+#: static/js/impala/stats/csv_keys.js:271 static/js/impala/stats/csv_keys.js:277 static/js/zamboni/stats-all.js:15552 static/js/zamboni/stats-all.js:15558 static/js/zamboni/stats-min.js:5
 msgid "<b>{0}</b> from {1} to {2}"
 msgstr "<b>{0}</b> з {1} по {2}"
 
 #. L10n: {0} and {1} are integers.
-#: static/js/impala/stats/csv_keys.js:275
+#: static/js/impala/stats/csv_keys.js:275 static/js/zamboni/stats-all.js:15556 static/js/zamboni/stats-min.js:5
 msgid "<b>{0}</b> average in last {1} days"
 msgstr "<b>{0}</b> в середньому за останні {1} днів"
 
-#: static/js/impala/stats/overview.js:19
+#: static/js/impala/stats/overview.js:19 static/js/zamboni/stats-all.js:16469 static/js/zamboni/stats-min.js:5
 msgid "No data available."
 msgstr "Немає доступних даних."
 
-#: static/js/impala/stats/table.js:74
+#: static/js/impala/stats/table.js:74 static/js/zamboni/stats-all.js:17209 static/js/zamboni/stats-min.js:5
 msgid "Date"
 msgstr "Дата"
 
-#: static/js/impala/stats/topchart.js:96
+#: static/js/impala/stats/topchart.js:96 static/js/zamboni/stats-all.js:16600 static/js/zamboni/stats-min.js:5
 msgid "Other"
 msgstr "Інше"
 
-#: static/js/zamboni/admin_validation.js:24 static/js/zamboni/devhub.js:1229
-#: static/js/zamboni/editors.js:295
+#: static/js/zamboni/admin-all.js:180 static/js/zamboni/admin-min.js:1 static/js/zamboni/admin_validation.js:24 static/js/zamboni/devhub-all.js:2408 static/js/zamboni/devhub-min.js:2
+#: static/js/zamboni/devhub.js:1229 static/js/zamboni/editors-all.js:15576 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:295
 msgid "Select an application first"
 msgstr "Спочатку виберіть програму"
 
-#: static/js/zamboni/admin_validation.js:51
+#: static/js/zamboni/admin-all.js:207 static/js/zamboni/admin-min.js:1 static/js/zamboni/admin_validation.js:51
 msgid "Set {0} add-on to a max version of {1} and email the author."
 msgid_plural "Set {0} add-ons to a max version of {1} and email the authors."
-msgstr[0] ""
-"Встановити для додатку {0} максимальну версію {1} та надіслати лист автору."
-msgstr[1] ""
-"Встановити для додатку {0} максимальну версію {1} та надіслати лист авторам."
-msgstr[2] ""
-"Встановити для додатку {0} максимальну версію {1} та надіслати лист авторам."
+msgstr[0] "Встановити для додатку {0} максимальну версію {1} та надіслати лист автору."
+msgstr[1] "Встановити для додатку {0} максимальну версію {1} та надіслати лист авторам."
 
-#: static/js/zamboni/admin_validation.js:54
+#: static/js/zamboni/admin-all.js:210 static/js/zamboni/admin-min.js:1 static/js/zamboni/admin_validation.js:54
 msgid "Email author of {2} add-on which failed validation."
 msgid_plural "Email authors of {2} add-ons which failed validation."
 msgstr[0] "Надіслати лист автору додатку {2}, який не пройшов перевірку."
 msgstr[1] "Надіслати лист авторам додатку {2}, який не пройшов перевірку."
-msgstr[2] "Надіслати лист авторам додатку {2}, який не пройшов перевірку."
 
-#. L10n: {0} is an app name like Firefox.
-#: static/js/zamboni/buttons.js:66
-msgid "Accept and Install"
-msgstr "Прийняти та встановити"
-
-#: static/js/zamboni/buttons.js:66
-msgid "Add to {0}"
-msgstr "Додати до {0}"
-
-#: static/js/zamboni/buttons.js:71
-msgid "Download Now"
-msgstr "Завантажити зараз"
-
-#: static/js/zamboni/buttons.js:112
-msgid "Add-on has not been updated to support default-to-compatible."
-msgstr "Додаток не було оновлено для типової підтримки сумісності."
-
-#: static/js/zamboni/buttons.js:117
-msgid "You need to be using Firefox 10.0 or higher."
-msgstr "Вам необхідно використовувати Firefox 10.0 або новіший."
-
-#: static/js/zamboni/buttons.js:129
-msgid ""
-"Mozilla has marked this version as incompatible with your Firefox version."
-msgstr "Mozilla відмітила цю версію, як несумісну з вашою версією Firefox."
-
-#. L10n: {0} is an platform like Windows or Linux.
-#: static/js/zamboni/buttons.js:210
-msgid "Install for {0} anyway"
-msgstr "Все одно встановити для {0}"
-
-#: static/js/zamboni/buttons.js:210
-msgid "Download for {0} anyway"
-msgstr "Все одно завантажити для {0}"
-
-#: static/js/zamboni/buttons.js:267
-msgid "Not available for your platform"
-msgstr "Недоступно для вашої платформи"
-
-#. L10n: {0} is an app name, {1} is the app version.
-#: static/js/zamboni/buttons.js:278 static/js/zamboni/buttons.js:315
-msgid "Not available for {0} {1}"
-msgstr "Недоступно для {0} {1}"
-
-#: static/js/zamboni/buttons.js:341
-msgid "Works with {app} {min} - {max}"
-msgstr "Працює з {app} {min} - {max}"
-
-#: static/js/zamboni/buttons.js:343
-msgid "View other versions"
-msgstr "Дивитись інші версії"
-
-#: static/js/zamboni/buttons.js:391
-msgid "Only with Firefox — Get Firefox Now!"
-msgstr "Лише з Firefox — Отримайте Firefox зараз!"
-
-#: static/js/zamboni/buttons.js:507 static/js/zamboni/mobile/buttons.js:43
-msgid ""
-"Sorry, you need a Mozilla-based browser (such as Firefox) to install a "
-"search plugin."
-msgstr ""
-"Вибачте, але щоб встановити пошуковий плагін вам потрібен браузер на основі "
-"Mozilla (наприклад, Firefox)."
-
-#: static/js/zamboni/collections.js:229
-msgid "Adding to Favorites&hellip;"
-msgstr "Додається до вподобань&hellip;"
-
-#: static/js/zamboni/collections.js:232
-msgid "Removing Favorite&hellip;"
-msgstr "Вилучається з вподобань&hellip;"
-
-#: static/js/zamboni/collections.js:235
-msgid "Add to Favorites"
-msgstr "Додати до вподобань"
-
-#: static/js/zamboni/collections.js:238
-msgid "Remove from Favorites"
-msgstr "Вилучити з вподобань"
-
-#: static/js/zamboni/collections.js:303
-msgid "Pending"
-msgstr "В очікуванні"
-
-#: static/js/zamboni/collections.js:304
-msgid "Add a comment"
-msgstr "Прокоментувати"
-
-#: static/js/zamboni/collections.js:304
-msgid "Comment"
-msgstr "Коментар"
-
-#: static/js/zamboni/collections.js:305
-msgid "Remove this add-on from the collection"
-msgstr "Вилучити цей додаток зі збірки"
-
-#: static/js/zamboni/collections.js:305 static/js/zamboni/collections.js:334
-msgid "Remove"
-msgstr "Вилучити"
-
-#: static/js/zamboni/collections.js:334
-msgid "Remove this user as a contributor"
-msgstr "Вилучити цього користувача з помічників"
-
-#: static/js/zamboni/collections.js:346
-msgid "An email address is required."
-msgstr "Потрібна електрона адреса."
-
-#: static/js/zamboni/collections.js:364
-msgid "You cannot add yourself as a contributor."
-msgstr "Ви не можете додати себе, як помічника."
-
-#: static/js/zamboni/collections.js:366
-msgid "You have already added that user."
-msgstr "Ви вже додали цього користувача."
-
-#: static/js/zamboni/collections.js:573
-msgid "Add to favorites"
-msgstr "Додати до вподобань"
-
-#: static/js/zamboni/collections.js:577
-msgid "Remove from favorites"
-msgstr "Вилучити з вподобань"
-
-#: static/js/zamboni/collections.js:604
-msgid "Stop following"
-msgstr "Більше не стежити"
-
-#: static/js/zamboni/devhub.js:110
+#: static/js/zamboni/devhub-all.js:1289 static/js/zamboni/devhub-min.js:1 static/js/zamboni/devhub.js:110
 msgid "Your browser does not support the video tag"
 msgstr "Ваш браузер не підтримує тег відео"
 
-#: static/js/zamboni/devhub.js:371
+#: static/js/zamboni/devhub-all.js:1550 static/js/zamboni/devhub-min.js:1 static/js/zamboni/devhub.js:371
 msgid "Changes Saved"
 msgstr "Зміни збережено"
 
-#: static/js/zamboni/devhub.js:387
+#: static/js/zamboni/devhub-all.js:1566 static/js/zamboni/devhub-min.js:1 static/js/zamboni/devhub.js:387
 msgid "Enter a new author's email address"
 msgstr "Введіть нову адресу ел. пошти автора"
 
-#: static/js/zamboni/devhub.js:536
+#: static/js/zamboni/devhub-all.js:1715 static/js/zamboni/devhub-min.js:1 static/js/zamboni/devhub.js:536
 msgid "There was an error uploading your file."
 msgstr "Сталась помилка при вивантаженні вашого файлу."
 
-#: static/js/zamboni/devhub.js:681
+#: static/js/zamboni/devhub-all.js:1860 static/js/zamboni/devhub-min.js:1 static/js/zamboni/devhub.js:681
 msgid "{files} file"
 msgid_plural "{files} files"
 msgstr[0] "{files} файл"
 msgstr[1] "{files} файли"
-msgstr[2] "{files} файлів"
 
-#: static/js/zamboni/devhub.js:684
+#: static/js/zamboni/devhub-all.js:1863 static/js/zamboni/devhub-min.js:1 static/js/zamboni/devhub.js:684
 msgid "{reviews} user review"
 msgid_plural "{reviews} user reviews"
 msgstr[0] "{reviews} відгук користувача"
 msgstr[1] "{reviews} відгуки користувача"
-msgstr[2] "{reviews} відгуків користувача"
 
-#: static/js/zamboni/devhub.js:796
+#: static/js/zamboni/devhub-all.js:1975 static/js/zamboni/devhub-min.js:2 static/js/zamboni/devhub.js:796
 msgid "Learn more"
 msgstr "Дізнатись більше"
 
-#: static/js/zamboni/devhub.js:800
+#: static/js/zamboni/devhub-all.js:1979 static/js/zamboni/devhub-min.js:2 static/js/zamboni/devhub.js:800
 msgid "Example"
 msgstr "Приклад"
 
-#: static/js/zamboni/devhub.js:1130
+#: static/js/zamboni/devhub-all.js:2309 static/js/zamboni/devhub-min.js:2 static/js/zamboni/devhub.js:1130
 msgid "Image changes being processed"
 msgstr "Обробка змін зображень"
 
-#: static/js/zamboni/devhub.js:1280
+#: static/js/zamboni/devhub-all.js:2459 static/js/zamboni/devhub-min.js:2 static/js/zamboni/devhub.js:1280
 msgid "Must be a valid e-mail address."
 msgstr "Повинна бути дійсна адреса ел. пошти."
+
+#: static/js/zamboni/devhub-all.js:2613 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:80
+msgid "All tests passed successfully."
+msgstr "Всі тести пройшли успішно."
+
+#: static/js/zamboni/devhub-all.js:2616 static/js/zamboni/devhub-all.js:3011 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:83 static/js/zamboni/validator.js:478
+msgid "These tests were not run."
+msgstr "Ці тести не запускались."
+
+#: static/js/zamboni/devhub-all.js:2664 static/js/zamboni/devhub-all.js:2677 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:131 static/js/zamboni/validator.js:144
+msgid "Tests"
+msgstr "Тести"
+
+#: static/js/zamboni/devhub-all.js:2779 static/js/zamboni/devhub-all.js:3108 static/js/zamboni/devhub-all.js:3127 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:246
+#: static/js/zamboni/validator.js:575 static/js/zamboni/validator.js:594
+msgid "Error"
+msgstr "Помилка"
+
+#: static/js/zamboni/devhub-all.js:2780 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:247
+msgid "Warning"
+msgstr "Попередження"
+
+#: static/js/zamboni/devhub-all.js:2794 static/js/zamboni/devhub-min.js:2 static/js/zamboni/files-all.js:5657 static/js/zamboni/files-min.js:3 static/js/zamboni/files.js:411
+#: static/js/zamboni/validator.js:261
+msgid "Ignore this message in future updates"
+msgstr "Ігнорувати це повідомлення в майбутніх оновленнях"
+
+#: static/js/zamboni/devhub-all.js:2817 static/js/zamboni/devhub-min.js:2 static/js/zamboni/files-all.js:5663 static/js/zamboni/files-min.js:3 static/js/zamboni/files.js:417
+#: static/js/zamboni/validator.js:284
+msgid "Severity for automated signing:"
+msgstr "Поглибленість для автоматичного підпису:"
+
+#: static/js/zamboni/devhub-all.js:2832 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:299
+msgid "Suggestions for passing automated signing:"
+msgstr "Пропозиції для проходження автоматичного підпису:"
+
+#: static/js/zamboni/devhub-all.js:2920 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:387
+msgid "Compatibility Tests"
+msgstr "Тести сумісності"
+
+#: static/js/zamboni/devhub-all.js:2999 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:466
+msgid "Add-on failed validation."
+msgstr "Додаток не пройшов перевірку."
+
+#: static/js/zamboni/devhub-all.js:3001 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:468
+msgid "Add-on passed validation."
+msgstr "Додаток пройшов перевірку."
+
+#: static/js/zamboni/devhub-all.js:3014 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:481
+msgid "{0} error"
+msgid_plural "{0} errors"
+msgstr[0] "{0} помилка"
+msgstr[1] "{0} помилки"
+
+#: static/js/zamboni/devhub-all.js:3016 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:483
+msgid "{0} warning"
+msgid_plural "{0} warnings"
+msgstr[0] "{0} попередження"
+msgstr[1] "{0} попередження"
+
+#: static/js/zamboni/devhub-all.js:3018 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:485
+msgid "{0} notice"
+msgid_plural "{0} notices"
+msgstr[0] "{0} повідомлення"
+msgstr[1] "{0} повідомлення"
+
+#: static/js/zamboni/devhub-all.js:3110 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:577
+msgid "Validation task could not complete or completed with errors"
+msgstr "Завдання з перевірки не змогло завершитись або завершилось з помилками"
+
+#: static/js/zamboni/devhub-all.js:3128 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:595
+msgid "Internal server error"
+msgstr "Внутрішня помилка сервера"
 
 #: static/js/zamboni/devhub_search.js:8
 msgid "No results found."
 msgstr "Не знайдено результатів."
 
-#: static/js/zamboni/editors.js:121
+#: static/js/zamboni/editors-all.js:15402 static/js/zamboni/editors-min.js:4 static/js/zamboni/editors.js:121
 msgid "{name} was viewing this page first."
 msgstr "{name} переглядав цю сторінку першим."
 
-#: static/js/zamboni/editors.js:171
+#: static/js/zamboni/editors-all.js:15452 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:171
 msgid "Receipt checked by app."
 msgstr "Чек перевірено застосунком."
 
-#: static/js/zamboni/editors.js:173
+#: static/js/zamboni/editors-all.js:15454 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:173
 msgid "Receipt was not checked by app."
 msgstr "Чек не було перевірено застосунком."
 
-#: static/js/zamboni/editors.js:244
+#: static/js/zamboni/editors-all.js:15525 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:244
 msgid "{name} was viewing this add-on first."
 msgstr "{name} переглядав цей додаток першим."
 
-#: static/js/zamboni/editors.js:255
+#: static/js/zamboni/editors-all.js:15536 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:255
 msgid "Loading&hellip;"
 msgstr "Завантаження&hellip;"
 
-#: static/js/zamboni/editors.js:260
+#: static/js/zamboni/editors-all.js:15541 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:260
 msgid "Version Notes"
 msgstr "Примітки до версії"
 
-#: static/js/zamboni/editors.js:265
+#: static/js/zamboni/editors-all.js:15546 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:265
 msgid "Notes for Reviewers"
 msgstr "Примітки для рецензентів"
 
-#: static/js/zamboni/editors.js:270
+#: static/js/zamboni/editors-all.js:15551 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:270
 msgid "No version notes found"
 msgstr "Не знайдено приміток до версії"
 
-#: static/js/zamboni/editors.js:330
+#: static/js/zamboni/editors-all.js:15611 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:330
 msgid "Average Reviews"
 msgstr "В середньому відгуків"
 
-#: static/js/zamboni/editors.js:386
+#: static/js/zamboni/editors-all.js:15667 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:386
 msgid "Number of Reviews"
 msgstr "Кількість відгуків"
 
-#: static/js/zamboni/editors.js:445
+#: static/js/zamboni/editors-all.js:15726 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:445
 msgid "Error loading translation"
 msgstr "Помилка завантаження перекладу"
 
-#: static/js/zamboni/files.js:411 static/js/zamboni/validator.js:261
-msgid "Ignore this message in future updates"
-msgstr "Ігнорувати це повідомлення в майбутніх оновленнях"
-
-#: static/js/zamboni/files.js:417 static/js/zamboni/validator.js:284
-msgid "Severity for automated signing:"
-msgstr "Поглибленість для автоматичного підпису:"
-
-#: static/js/zamboni/global.js:410
-msgid "Loading..."
-msgstr "Завантажується..."
-
-#. L10n: {0} is the number of characters left.
-#: static/js/zamboni/global.js:474
-msgid "<b>{0}</b> character left."
-msgid_plural "<b>{0}</b> characters left."
-msgstr[0] "залишився <b>{0}</b> символ."
-msgstr[1] "залишилось <b>{0}</b> символи."
-msgstr[2] "залишилось <b>{0}</b> символів."
-
-#: static/js/zamboni/init.js:28
-msgid ""
-"This feature is temporarily disabled while we perform website maintenance. "
-"Please check back a little later."
-msgstr ""
-"Дана функція тимчасово вимкнута доки ми проводимо технічне обслуговування "
-"веб-сайту. Будь ласка, спробуйте пізніше."
-
-#: static/js/zamboni/l10n.js:45
-msgid "Remove this localization"
-msgstr "Вилучити цю локалізацію"
-
-#: static/js/zamboni/password-strength.js:20
-msgid "Password strength:"
-msgstr "Стійкість паролю:"
-
-#: static/js/zamboni/password-strength.js:26
-msgid "At least {0} character left."
-msgid_plural "At least {0} characters left."
-msgstr[0] "Залишився щонайменше {0} символ."
-msgstr[1] "Залишилось щонайменше {0} символи."
-msgstr[2] "Залишилось щонайменше {0} символів."
-
-#: static/js/zamboni/themes_review.js:176
-msgid "Requested Info"
-msgstr "Запитана інформація"
-
-#: static/js/zamboni/themes_review.js:177
-msgid "Flagged"
-msgstr "Відмічено"
-
-#: static/js/zamboni/themes_review.js:178
-msgid "Duplicate"
-msgstr "Дублікат"
-
-#: static/js/zamboni/themes_review.js:179
-msgid "Rejected"
-msgstr "Відхилено"
-
-#: static/js/zamboni/themes_review.js:180
-msgid "Approved"
-msgstr "Затверджено"
-
-#: static/js/zamboni/themes_review.js:424
-msgid "No results found"
-msgstr "Результатів не знайдено"
-
-#: static/js/zamboni/themes_review_templates.js:31
+#: static/js/zamboni/editors-all.js:15975 static/js/zamboni/editors-min.js:5 static/js/zamboni/themes_review_templates.js:31
 msgid "Theme"
 msgstr "Тема"
 
-#: static/js/zamboni/themes_review_templates.js:33
+#: static/js/zamboni/editors-all.js:15977 static/js/zamboni/editors-min.js:5 static/js/zamboni/themes_review_templates.js:33
 msgid "Reviewer"
 msgstr "Редактор"
 
-#: static/js/zamboni/themes_review_templates.js:35
+#: static/js/zamboni/editors-all.js:15979 static/js/zamboni/editors-min.js:5 static/js/zamboni/themes_review_templates.js:35
 msgid "Status"
 msgstr "Стан"
 
-#: static/js/zamboni/validator.js:80
-msgid "All tests passed successfully."
-msgstr "Всі тести пройшли успішно."
+#: static/js/zamboni/editors-all.js:16196 static/js/zamboni/editors-min.js:5 static/js/zamboni/themes_review.js:176
+msgid "Requested Info"
+msgstr "Запитана інформація"
 
-#: static/js/zamboni/validator.js:83 static/js/zamboni/validator.js:478
-msgid "These tests were not run."
-msgstr "Ці тести не запускались."
+#: static/js/zamboni/editors-all.js:16197 static/js/zamboni/editors-min.js:5 static/js/zamboni/themes_review.js:177
+msgid "Flagged"
+msgstr "Відмічено"
 
-#: static/js/zamboni/validator.js:131 static/js/zamboni/validator.js:144
-msgid "Tests"
-msgstr "Тести"
+#: static/js/zamboni/editors-all.js:16198 static/js/zamboni/editors-min.js:5 static/js/zamboni/themes_review.js:178
+msgid "Duplicate"
+msgstr "Дублікат"
 
-#: static/js/zamboni/validator.js:246 static/js/zamboni/validator.js:575
-#: static/js/zamboni/validator.js:594
-msgid "Error"
-msgstr "Помилка"
+#: static/js/zamboni/editors-all.js:16199 static/js/zamboni/editors-min.js:5 static/js/zamboni/themes_review.js:179
+msgid "Rejected"
+msgstr "Відхилено"
 
-#: static/js/zamboni/validator.js:247
-msgid "Warning"
-msgstr "Попередження"
+#: static/js/zamboni/editors-all.js:16200 static/js/zamboni/editors-min.js:5 static/js/zamboni/themes_review.js:180
+msgid "Approved"
+msgstr "Затверджено"
 
-#: static/js/zamboni/validator.js:299
-msgid "Suggestions for passing automated signing:"
-msgstr "Пропозиції для проходження автоматичного підпису:"
+#: static/js/zamboni/editors-all.js:16444 static/js/zamboni/editors-min.js:5 static/js/zamboni/themes_review.js:424
+msgid "No results found"
+msgstr "Результатів не знайдено"
 
-#: static/js/zamboni/validator.js:387
-msgid "Compatibility Tests"
-msgstr "Тести сумісності"
-
-#: static/js/zamboni/validator.js:466
-msgid "Add-on failed validation."
-msgstr "Додаток не пройшов перевірку."
-
-#: static/js/zamboni/validator.js:468
-msgid "Add-on passed validation."
-msgstr "Додаток пройшов перевірку."
-
-#: static/js/zamboni/validator.js:481
-msgid "{0} error"
-msgid_plural "{0} errors"
-msgstr[0] "{0} помилка"
-msgstr[1] "{0} помилки"
-msgstr[2] "{0} помилок"
-
-#: static/js/zamboni/validator.js:483
-msgid "{0} warning"
-msgid_plural "{0} warnings"
-msgstr[0] "{0} попередження"
-msgstr[1] "{0} попередження"
-msgstr[2] "{0} попереджень"
-
-#: static/js/zamboni/validator.js:485
-msgid "{0} notice"
-msgid_plural "{0} notices"
-msgstr[0] "{0} повідомлення"
-msgstr[1] "{0} повідомлення"
-msgstr[2] "{0} повідомлень"
-
-#: static/js/zamboni/validator.js:577
-msgid "Validation task could not complete or completed with errors"
-msgstr ""
-"Завдання з перевірки не змогло завершитись або завершилось з помилками"
-
-#: static/js/zamboni/validator.js:595
-msgid "Internal server error"
-msgstr "Внутрішня помилка сервера"
-
-#: static/js/zamboni/mobile/buttons.js:52
+#: static/js/zamboni/mobile-all.js:15186 static/js/zamboni/mobile/buttons.js:52
 msgid "Not Updated for {0} {1}"
 msgstr "Не оновлено для {0} {1}"
 
-#: static/js/zamboni/mobile/buttons.js:53
+#: static/js/zamboni/mobile-all.js:15187 static/js/zamboni/mobile/buttons.js:53
 msgid "Requires Newer Version of {0}"
 msgstr "Потребує новішу версію {0}"
 
-#: static/js/zamboni/mobile/buttons.js:54
+#: static/js/zamboni/mobile-all.js:15188 static/js/zamboni/mobile/buttons.js:54
 msgid "Unreviewed"
 msgstr "Не перевірено"
 
-#: static/js/zamboni/mobile/buttons.js:55
+#: static/js/zamboni/mobile-all.js:15189 static/js/zamboni/mobile/buttons.js:55
 msgid "Experimental <span>(Learn More)</span>"
 msgstr "Експериментальне <span>(дізнатись більше)</span>"
 
-#: static/js/zamboni/mobile/buttons.js:56
-#: static/js/zamboni/mobile/buttons.js:57
+#: static/js/zamboni/mobile-all.js:15190 static/js/zamboni/mobile-all.js:15191 static/js/zamboni/mobile/buttons.js:56 static/js/zamboni/mobile/buttons.js:57
 msgid "Not Available for {0}"
 msgstr "Недоступно для {0}"
 
-#: static/js/zamboni/mobile/buttons.js:58
+#: static/js/zamboni/mobile-all.js:15192 static/js/zamboni/mobile/buttons.js:58
 msgid "Experimental"
 msgstr "Експериментальне"
 
-#: static/js/zamboni/mobile/buttons.js:59
+#: static/js/zamboni/mobile-all.js:15193 static/js/zamboni/mobile/buttons.js:59
 msgid "Themes Require Newer Version of {0}"
 msgstr "Для тем потрібна новіша версія {0}"
 
-#: static/js/zamboni/mobile/buttons.js:60
+#: static/js/zamboni/mobile-all.js:15194 static/js/zamboni/mobile/buttons.js:60
 msgid "Themes Require {0}"
 msgstr "Для тем потрібно {0}"
 
-#: static/js/zamboni/mobile/buttons.js:105
+#: static/js/zamboni/mobile-all.js:15239 static/js/zamboni/mobile/buttons.js:105
 msgid "Installing..."
 msgstr "Встановлення..."
 
-#: static/js/zamboni/mobile/buttons.js:125
+#: static/js/zamboni/mobile-all.js:15259 static/js/zamboni/mobile/buttons.js:125
 msgid "This add-on has been preliminarily reviewed by Mozilla."
 msgstr "Цей додаток було попередньо розглянуто Mozilla."
 
-#: static/js/zamboni/mobile/buttons.js:250
+#: static/js/zamboni/mobile-all.js:15384 static/js/zamboni/mobile/buttons.js:250
 msgid "Keep it"
 msgstr "Залишити їх"
 
-#: static/js/zamboni/mobile/general.js:344
+#: static/js/zamboni/mobile-all.js:16049 static/js/zamboni/mobile-min.js:6 static/js/zamboni/mobile/general.js:344
 msgid "You're trying it on!"
 msgstr "Зараз ви це спробуєте!"
 
-#: static/js/zamboni/mobile/general.js:356
+#: static/js/zamboni/mobile-all.js:16061 static/js/zamboni/mobile-min.js:6 static/js/zamboni/mobile/general.js:356
 msgid "Added to Firefox"
 msgstr "Додано у Firefox"

--- a/locale/ur/LC_MESSAGES/django.po
+++ b/locale/ur/LC_MESSAGES/django.po
@@ -3,69 +3,70 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2016-02-24 21:23+0000\n"
+"POT-Creation-Date: 2016-04-18 15:47+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
+"Language: \n"
 "MIME-Version: 1.0\n"
-"Content-Type: text/plain; charset=utf-8\n"
+"Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Generated-By: Babel 2.2.0\n"
 
-#: src/olympia/accounts/views.py:52
+#: src/olympia/accounts/views.py:54
 msgid "Your log in attempt could not be parsed. Please try again."
 msgstr ""
 
-#: src/olympia/accounts/views.py:54
+#: src/olympia/accounts/views.py:56
 msgid "Your Firefox Account could not be found. Please try again."
 msgstr ""
 
-#: src/olympia/accounts/views.py:55
+#: src/olympia/accounts/views.py:57
 msgid "You could not be logged in. Please try again."
 msgstr ""
 
-#: src/olympia/accounts/views.py:57
+#: src/olympia/accounts/views.py:59
 msgid "Your account has already been migrated to Firefox Accounts."
 msgstr ""
 
-#: src/olympia/accounts/views.py:59
+#: src/olympia/accounts/views.py:61
 msgid "Your Firefox Account already exists on this site."
 msgstr ""
 
-#: src/olympia/accounts/views.py:108
+#: src/olympia/accounts/views.py:110
 msgid "Great job!"
 msgstr ""
 
-#: src/olympia/accounts/views.py:109
+#: src/olympia/accounts/views.py:111
 msgid "You can now log in to Add-ons with your Firefox Account."
 msgstr ""
 
-#: src/olympia/accounts/views.py:121
+#: src/olympia/accounts/views.py:123
 msgid "Need help?"
 msgstr ""
 
-#: src/olympia/addons/buttons.py:180
+#: src/olympia/addons/buttons.py:177
 msgid "Download Now"
 msgstr ""
 
-#: src/olympia/addons/buttons.py:182
+#: src/olympia/addons/buttons.py:179
 msgid "Download"
 msgstr ""
 
 #. L10n: please keep &nbsp; in the string so &rarr; does not wrap.
-#: src/olympia/addons/buttons.py:186
+#: src/olympia/addons/buttons.py:183
 msgid "Continue to Download&nbsp;&rarr;"
 msgstr ""
 
-#: src/olympia/addons/buttons.py:202 src/olympia/addons/helpers.py:35 src/olympia/addons/views.py:319 src/olympia/addons/templates/addons/impala/details.html:114
+#: src/olympia/addons/buttons.py:199 src/olympia/addons/helpers.py:35 src/olympia/addons/views.py:333 src/olympia/addons/templates/addons/impala/details.html:111
 #: src/olympia/addons/templates/addons/impala/listing/items.html:17 src/olympia/addons/templates/addons/mobile/home.html:40 src/olympia/amo/templates/amo/side_nav.html:6
-#: src/olympia/amo/templates/amo/side_nav.html:10 src/olympia/amo/templates/amo/site_nav.html:2 src/olympia/amo/templates/amo/site_nav.html:55 src/olympia/bandwagon/views.py:95
-#: src/olympia/browse/views.py:54 src/olympia/browse/views.py:68 src/olympia/browse/views.py:235 src/olympia/browse/templates/browse/impala/category_landing.html:22
+#: src/olympia/amo/templates/amo/side_nav.html:10 src/olympia/amo/templates/amo/site_nav.html:2 src/olympia/amo/templates/amo/site_nav.html:53 src/olympia/bandwagon/views.py:95
+#: src/olympia/browse/views.py:54 src/olympia/browse/views.py:68 src/olympia/browse/views.py:202 src/olympia/browse/templates/browse/impala/category_landing.html:22
 #: src/olympia/browse/templates/browse/personas/mobile/category_landing.html:26
 msgid "Featured"
 msgstr ""
 
-#: src/olympia/addons/buttons.py:221
+#: src/olympia/addons/buttons.py:218
 msgid "Add to {0}"
 msgstr ""
 
@@ -113,39 +114,39 @@ msgid_plural "All tags must be at least {0} characters."
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/olympia/addons/forms.py:234
+#: src/olympia/addons/forms.py:238
 msgid "Categories cannot be changed while your add-on is featured for this application."
 msgstr ""
 
 #. L10n: {0} is the number of categories.
-#: src/olympia/addons/forms.py:238
+#: src/olympia/addons/forms.py:242
 msgid "You can have only {0} category."
 msgid_plural "You can have only {0} categories."
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/olympia/addons/forms.py:246
+#: src/olympia/addons/forms.py:250
 msgid "The miscellaneous category cannot be combined with additional categories."
 msgstr ""
 
-#: src/olympia/addons/forms.py:369
+#: src/olympia/addons/forms.py:374
 #, python-format
 msgid "Before changing your default locale you must have a name, summary, and description in that locale. You are missing %s."
 msgstr ""
 
-#: src/olympia/addons/forms.py:484 src/olympia/addons/forms.py:575
+#: src/olympia/addons/forms.py:455 src/olympia/addons/forms.py:546
 msgid "A license must be selected."
 msgstr ""
 
-#: src/olympia/addons/forms.py:556
+#: src/olympia/addons/forms.py:527
 msgid "Give Your Theme a Name."
 msgstr ""
 
-#: src/olympia/addons/forms.py:562 src/olympia/devhub/templates/devhub/personas/submit.html:53
+#: src/olympia/addons/forms.py:533 src/olympia/devhub/templates/devhub/personas/submit.html:53
 msgid "Describe your Theme."
 msgstr ""
 
-#: src/olympia/addons/forms.py:704
+#: src/olympia/addons/forms.py:675
 msgid "Enter a new author's email address"
 msgstr ""
 
@@ -153,37 +154,37 @@ msgstr ""
 msgid "Not Reviewed"
 msgstr ""
 
-#: src/olympia/addons/models.py:301
+#: src/olympia/addons/models.py:298
 msgid "Users have the option of contributing more or less than this amount."
 msgstr ""
 
-#: src/olympia/addons/models.py:309
-msgid "Users will always be asked in the Add-ons Manager (Firefox 4 and above)"
+#: src/olympia/addons/models.py:306
+msgid "Users will always be asked in the Add-ons Manager (Firefox 4 and above). Only applies to desktop."
 msgstr ""
 
-#: src/olympia/addons/models.py:1804 src/olympia/addons/templates/addons/details_box.html:55 src/olympia/devhub/templates/devhub/index.html:92
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:102
+#: src/olympia/addons/models.py:1802 src/olympia/addons/templates/addons/details_box.html:55 src/olympia/devhub/templates/devhub/index.html:92
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:89
 msgid "Listed"
 msgstr ""
 
-#: src/olympia/addons/views.py:320 src/olympia/browse/templates/browse/personas/mobile/category_landing.html:27
+#: src/olympia/addons/views.py:334 src/olympia/browse/templates/browse/personas/mobile/category_landing.html:27
 msgid "Popular"
 msgstr ""
 
-#: src/olympia/addons/views.py:321 src/olympia/browse/views.py:238 src/olympia/browse/views.py:280 src/olympia/browse/views.py:482
+#: src/olympia/addons/views.py:335 src/olympia/browse/views.py:205 src/olympia/browse/views.py:247 src/olympia/browse/views.py:449
 msgid "Recently Added"
 msgstr ""
 
-#: src/olympia/addons/views.py:322 src/olympia/bandwagon/views.py:99 src/olympia/browse/views.py:60 src/olympia/browse/views.py:71 src/olympia/search/forms.py:16 src/olympia/search/forms.py:91
+#: src/olympia/addons/views.py:336 src/olympia/bandwagon/views.py:99 src/olympia/browse/views.py:60 src/olympia/browse/views.py:71 src/olympia/search/forms.py:16 src/olympia/search/forms.py:91
 msgid "Recently Updated"
 msgstr ""
 
 #. l10n: {0} is the addon name
-#: src/olympia/addons/views.py:520
+#: src/olympia/addons/views.py:534
 msgid "Contribution for {0}"
 msgstr ""
 
-#: src/olympia/addons/views.py:613
+#: src/olympia/addons/views.py:627
 msgid "Abuse reported."
 msgstr ""
 
@@ -250,9 +251,9 @@ msgstr ""
 #: src/olympia/devhub/templates/devhub/addons/ajax_compat_update.html:36 src/olympia/devhub/templates/devhub/addons/profile.html:44 src/olympia/devhub/templates/devhub/addons/edit/admin.html:101
 #: src/olympia/devhub/templates/devhub/addons/edit/basic.html:152 src/olympia/devhub/templates/devhub/addons/edit/details.html:85 src/olympia/devhub/templates/devhub/addons/edit/support.html:67
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:166 src/olympia/devhub/templates/devhub/addons/forms_shared/media.html:149
-#: src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:44 src/olympia/devhub/templates/devhub/versions/add_file_modal.html:78 src/olympia/devhub/templates/devhub/versions/edit.html:139
-#: src/olympia/devhub/templates/devhub/versions/list.html:242 src/olympia/devhub/templates/devhub/versions/list.html:276 src/olympia/devhub/templates/devhub/versions/list.html:317
-#: src/olympia/devhub/templates/devhub/versions/list.html:351 src/olympia/reviews/templates/reviews/edit_review.html:16 src/olympia/translations/templates/translations/trans-menu.html:50
+#: src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:43 src/olympia/devhub/templates/devhub/versions/add_file_modal.html:58 src/olympia/devhub/templates/devhub/versions/edit.html:139
+#: src/olympia/devhub/templates/devhub/versions/list.html:239 src/olympia/devhub/templates/devhub/versions/list.html:281 src/olympia/devhub/templates/devhub/versions/list.html:315
+#: src/olympia/devhub/templates/devhub/versions/list.html:349 src/olympia/reviews/templates/reviews/edit_review.html:16 src/olympia/translations/templates/translations/trans-menu.html:50
 #: src/olympia/translations/templates/translations/trans-menu.html:62
 msgid "or"
 msgstr ""
@@ -363,7 +364,7 @@ msgid "Add-on Information for {0}"
 msgstr ""
 
 #: src/olympia/addons/templates/addons/details_box.html:30 src/olympia/addons/templates/addons/persona_detail_table.html:3 src/olympia/addons/templates/addons/mobile/details.html:63
-#: src/olympia/addons/templates/addons/mobile/persona_detail_table.html:7 src/olympia/browse/views.py:459 src/olympia/devhub/views.py:75
+#: src/olympia/addons/templates/addons/mobile/persona_detail_table.html:7 src/olympia/browse/views.py:426 src/olympia/devhub/views.py:73
 msgid "Updated"
 msgstr ""
 
@@ -382,11 +383,11 @@ msgstr ""
 msgid "Visibility"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/details_box.html:57 src/olympia/devhub/templates/devhub/index.html:94 src/olympia/devhub/templates/devhub/includes/addon_details.html:104
+#: src/olympia/addons/templates/addons/details_box.html:57 src/olympia/devhub/templates/devhub/index.html:94 src/olympia/devhub/templates/devhub/includes/addon_details.html:91
 msgid "Hidden"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/details_box.html:59 src/olympia/devhub/templates/devhub/index.html:96 src/olympia/devhub/templates/devhub/includes/addon_details.html:106
+#: src/olympia/addons/templates/addons/details_box.html:59 src/olympia/devhub/templates/devhub/index.html:96 src/olympia/devhub/templates/devhub/includes/addon_details.html:93
 msgid "Unlisted"
 msgstr ""
 
@@ -394,13 +395,13 @@ msgstr ""
 msgid "Required Add-ons"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/details_box.html:81 src/olympia/addons/templates/addons/persona_detail_table.html:15 src/olympia/browse/views.py:462 src/olympia/devhub/views.py:78
-#: src/olympia/devhub/views.py:85 src/olympia/discovery/templates/discovery/addons/detail.html:57 src/olympia/reviews/forms.py:62 src/olympia/reviews/templates/reviews/add.html:57
+#: src/olympia/addons/templates/addons/details_box.html:81 src/olympia/addons/templates/addons/persona_detail_table.html:15 src/olympia/browse/views.py:429 src/olympia/devhub/views.py:76
+#: src/olympia/devhub/views.py:83 src/olympia/discovery/templates/discovery/addons/detail.html:57 src/olympia/reviews/forms.py:62 src/olympia/reviews/templates/reviews/add.html:57
 #: src/olympia/reviews/templates/reviews/mobile/review_list.html:18
 msgid "Rating"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/details_box.html:85 src/olympia/browse/views.py:461 src/olympia/devhub/views.py:77 src/olympia/devhub/views.py:84
+#: src/olympia/addons/templates/addons/details_box.html:85 src/olympia/browse/views.py:428 src/olympia/devhub/views.py:75 src/olympia/devhub/views.py:82
 #: src/olympia/stats/templates/stats/addon_report_menu.html:8 src/olympia/stats/templates/stats/collection_report_menu.html:18
 msgid "Downloads"
 msgstr ""
@@ -420,7 +421,7 @@ msgstr ""
 
 #. The Privacy Policy for this add-on.
 #: src/olympia/addons/templates/addons/details_box.html:121 src/olympia/addons/templates/addons/privacy.html:19 src/olympia/addons/templates/addons/privacy.html:23
-#: src/olympia/addons/templates/addons/impala/button.html:43 src/olympia/addons/templates/addons/impala/details.html:307 src/olympia/devhub/templates/devhub/includes/policy_form.html:20
+#: src/olympia/addons/templates/addons/impala/button.html:43 src/olympia/addons/templates/addons/impala/details.html:312 src/olympia/devhub/templates/devhub/includes/policy_form.html:23
 #: src/olympia/templates/mobile/base_addons.html:87
 msgid "Privacy Policy"
 msgstr ""
@@ -445,7 +446,7 @@ msgstr ""
 msgid "Developer Comments"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/details_box.html:199 src/olympia/addons/templates/addons/impala/details.html:259
+#: src/olympia/addons/templates/addons/details_box.html:199 src/olympia/addons/templates/addons/impala/details.html:264
 msgid "Development Channel"
 msgstr ""
 
@@ -465,7 +466,7 @@ msgid ""
 "developer. To stop receiving development updates, reinstall the default version from the link above."
 msgstr ""
 
-#: src/olympia/addons/templates/addons/details_box.html:220 src/olympia/addons/templates/addons/impala/details.html:278
+#: src/olympia/addons/templates/addons/details_box.html:220 src/olympia/addons/templates/addons/impala/details.html:283
 msgid "Version {0}:"
 msgstr ""
 
@@ -484,7 +485,7 @@ msgid "End-User License Agreement for {0}"
 msgstr ""
 
 #: src/olympia/addons/templates/addons/eula.html:17 src/olympia/addons/templates/addons/eula.html:21 src/olympia/addons/templates/addons/impala/button.html:48
-#: src/olympia/addons/templates/addons/impala/details.html:316 src/olympia/devhub/templates/devhub/includes/policy_form.html:3 src/olympia/discovery/templates/discovery/addons/eula.html:11
+#: src/olympia/addons/templates/addons/impala/details.html:321 src/olympia/devhub/templates/devhub/includes/policy_form.html:3 src/olympia/discovery/templates/discovery/addons/eula.html:11
 msgid "End-User License Agreement"
 msgstr ""
 
@@ -501,7 +502,7 @@ msgstr ""
 msgid "Add-ons for {0}"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/home.html:10 src/olympia/addons/templates/addons/home.html:51 src/olympia/browse/templates/browse/impala/base_listing.html:11
+#: src/olympia/addons/templates/addons/home.html:10 src/olympia/addons/templates/addons/home.html:53 src/olympia/browse/templates/browse/impala/base_listing.html:11
 msgid "Featured Extensions"
 msgstr ""
 
@@ -509,29 +510,29 @@ msgstr ""
 msgid "Popular Extensions"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/home.html:42 src/olympia/amo/templates/amo/side_nav.html:3 src/olympia/amo/templates/amo/side_nav.html:11 src/olympia/amo/templates/amo/site_nav.html:3
-#: src/olympia/amo/templates/amo/site_nav.html:25 src/olympia/browse/views.py:236 src/olympia/browse/views.py:281 src/olympia/browse/views.py:481
+#: src/olympia/addons/templates/addons/home.html:44 src/olympia/amo/templates/amo/side_nav.html:3 src/olympia/amo/templates/amo/side_nav.html:11 src/olympia/amo/templates/amo/site_nav.html:3
+#: src/olympia/amo/templates/amo/site_nav.html:25 src/olympia/browse/views.py:203 src/olympia/browse/views.py:248 src/olympia/browse/views.py:448
 msgid "Most Popular"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/home.html:43
+#: src/olympia/addons/templates/addons/home.html:45
 msgid "All »"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/home.html:52 src/olympia/addons/templates/addons/home.html:61 src/olympia/addons/templates/addons/home.html:70 src/olympia/addons/templates/addons/home.html:78
+#: src/olympia/addons/templates/addons/home.html:54 src/olympia/addons/templates/addons/home.html:63 src/olympia/addons/templates/addons/home.html:72 src/olympia/addons/templates/addons/home.html:80
 #: src/olympia/browse/templates/browse/impala/category_landing.html:36
 msgid "See all »"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/home.html:60
+#: src/olympia/addons/templates/addons/home.html:62
 msgid "Up &amp; Coming Extensions"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/home.html:69 src/olympia/browse/templates/browse/personas/category_landing.html:61 src/olympia/discovery/templates/discovery/pane.html:74
+#: src/olympia/addons/templates/addons/home.html:71 src/olympia/browse/templates/browse/personas/category_landing.html:61 src/olympia/discovery/templates/discovery/pane.html:74
 msgid "Featured Themes"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/home.html:77 src/olympia/bandwagon/templates/bandwagon/impala/collection_listing.html:5
+#: src/olympia/addons/templates/addons/home.html:79 src/olympia/bandwagon/templates/bandwagon/impala/collection_listing.html:5
 msgid "Featured Collections"
 msgstr ""
 
@@ -549,7 +550,7 @@ msgid "Updated {0}"
 msgstr ""
 
 #. {0} is a date.
-#: src/olympia/addons/templates/addons/macros.html:10 src/olympia/addons/templates/addons/macros.html:69 src/olympia/addons/templates/addons/persona_preview.html:21
+#: src/olympia/addons/templates/addons/macros.html:10 src/olympia/addons/templates/addons/macros.html:69 src/olympia/addons/templates/addons/persona_preview.html:22
 #: src/olympia/addons/templates/addons/listing/items_mobile.html:44 src/olympia/addons/templates/addons/listing/macros.html:39
 #: src/olympia/bandwagon/templates/bandwagon/collection_listing_items.html:37 src/olympia/bandwagon/templates/bandwagon/impala/collection_listing_items.html:37
 msgid "Added {0}"
@@ -570,15 +571,14 @@ msgstr[0] ""
 msgstr[1] ""
 
 #. {0} is the number of downloads.
-#: src/olympia/addons/templates/addons/macros.html:53 src/olympia/addons/templates/addons/impala/details.html:61
+#: src/olympia/addons/templates/addons/macros.html:53 src/olympia/addons/templates/addons/impala/details.html:59
 msgid "{0} weekly download"
 msgid_plural "{0} weekly downloads"
 msgstr[0] ""
 msgstr[1] ""
 
 #. {0} is the number of users.
-#: src/olympia/addons/templates/addons/macros.html:61 src/olympia/addons/templates/addons/impala/details.html:54 src/olympia/compat/templates/compat/index.html:71
-#: src/olympia/zadmin/templates/zadmin/compat.html:67
+#: src/olympia/addons/templates/addons/macros.html:61 src/olympia/addons/templates/addons/impala/details.html:52 src/olympia/zadmin/templates/zadmin/compat.html:67
 msgid "{0} user"
 msgid_plural "{0} users"
 msgstr[0] ""
@@ -596,7 +596,7 @@ msgstr ""
 msgid "Return to the addon."
 msgstr ""
 
-#: src/olympia/addons/templates/addons/persona_detail.html:17 src/olympia/addons/templates/addons/impala/details.html:106 src/olympia/addons/templates/addons/mobile/details.html:23
+#: src/olympia/addons/templates/addons/persona_detail.html:17 src/olympia/addons/templates/addons/impala/details.html:103 src/olympia/addons/templates/addons/mobile/details.html:23
 #: src/olympia/addons/templates/addons/mobile/persona_detail.html:21 src/olympia/discovery/templates/discovery/addons/base.html:27 src/olympia/editors/templates/editors/review.html:31
 msgid "by"
 msgstr ""
@@ -640,34 +640,35 @@ msgstr ""
 msgid "License"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/persona_preview.html:12 src/olympia/constants/base.py:48
+#: src/olympia/addons/templates/addons/persona_preview.html:13 src/olympia/constants/base.py:48
 msgid "Awaiting Review"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/persona_preview.html:14 src/olympia/amo/log.py:180 src/olympia/constants/base.py:42 src/olympia/editors/helpers.py:62
+#: src/olympia/addons/templates/addons/persona_preview.html:15 src/olympia/amo/log.py:180 src/olympia/constants/base.py:42 src/olympia/editors/helpers.py:62
 msgid "Rejected"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/persona_preview.html:16 src/olympia/amo/log.py:159
+#: src/olympia/addons/templates/addons/persona_preview.html:17 src/olympia/amo/log.py:159
 msgid "Approved"
 msgstr ""
 
 #. {0} is the number of users.
-#: src/olympia/addons/templates/addons/persona_preview.html:26 src/olympia/addons/templates/addons/listing/items_mobile.html:36 src/olympia/addons/templates/addons/listing/macros.html:31
+#: src/olympia/addons/templates/addons/persona_preview.html:27 src/olympia/addons/templates/addons/listing/items_mobile.html:36 src/olympia/addons/templates/addons/listing/macros.html:31
 msgid "<strong>{0}</strong> user"
 msgid_plural "<strong>{0}</strong> users"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/olympia/addons/templates/addons/persona_preview.html:40
+#: src/olympia/addons/templates/addons/persona_preview.html:41
 msgid "Hover to Preview"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/persona_preview.html:46 src/olympia/addons/templates/addons/persona_preview.html:48 src/olympia/reviews/templates/reviews/add.html:15
+#: src/olympia/addons/templates/addons/persona_preview.html:47 src/olympia/addons/templates/addons/persona_preview.html:49 src/olympia/addons/templates/addons/persona_preview.html:97
+#: src/olympia/reviews/templates/reviews/add.html:15
 msgid "Add"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/persona_preview.html:57 src/olympia/bandwagon/templates/bandwagon/ajax_new.html:16 src/olympia/bandwagon/templates/bandwagon/edit.html:19
+#: src/olympia/addons/templates/addons/persona_preview.html:58 src/olympia/bandwagon/templates/bandwagon/ajax_new.html:16 src/olympia/bandwagon/templates/bandwagon/edit.html:19
 #: src/olympia/bandwagon/templates/bandwagon/includes/addedit.html:19 src/olympia/devhub/templates/devhub/addons/edit/admin.html:13 src/olympia/devhub/templates/devhub/addons/edit/basic.html:10
 #: src/olympia/devhub/templates/devhub/addons/edit/details.html:8 src/olympia/devhub/templates/devhub/addons/edit/media.html:6 src/olympia/devhub/templates/devhub/addons/edit/support.html:8
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:9 src/olympia/devhub/templates/devhub/addons/submit/describe.html:29 src/olympia/editors/templates/editors/review.html:257
@@ -676,21 +677,21 @@ msgstr ""
 
 #. For datetime formatting, see the table on
 #. http://docs.python.org/library/datetime.html#strftime-and-strptime-behavior
-#: src/olympia/addons/templates/addons/persona_preview.html:66
+#: src/olympia/addons/templates/addons/persona_preview.html:67
 #, python-format
 msgid "%%Y-%%m-%%d"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/persona_preview.html:67
+#: src/olympia/addons/templates/addons/persona_preview.html:68
 msgid "by {0} on {1}"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/persona_preview.html:75 src/olympia/reviews/helpers.py:17 src/olympia/reviews/templates/reviews/review_list.html:63
+#: src/olympia/addons/templates/addons/persona_preview.html:76 src/olympia/reviews/helpers.py:17 src/olympia/reviews/templates/reviews/review_list.html:63
 #: src/olympia/reviews/templates/reviews/reviews_link.html:21 src/olympia/reviews/templates/reviews/impala/reviews_link.html:16
 msgid "Not yet rated"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/persona_preview.html:78
+#: src/olympia/addons/templates/addons/persona_preview.html:79
 msgid "<b>{0}</b> users"
 msgstr ""
 
@@ -703,7 +704,7 @@ msgid "Learn more about Firefox"
 msgstr ""
 
 #: src/olympia/addons/templates/addons/popups.html:22
-msgid "or <b><a class=\"installer\" href=\"{url}\">download anyway</a></b>"
+msgid "or <b><a class=\"button installer\" href=\"{url}\">download anyway</a></b>"
 msgstr ""
 
 #: src/olympia/addons/templates/addons/popups.html:26
@@ -802,7 +803,7 @@ msgid ""
 msgstr ""
 
 #: src/olympia/addons/templates/addons/report_abuse.html:6 src/olympia/addons/templates/addons/report_abuse_full.html:10 src/olympia/addons/templates/addons/impala/details-more.html:23
-#: src/olympia/addons/templates/addons/impala/details.html:328
+#: src/olympia/addons/templates/addons/impala/details.html:333
 msgid "Report Abuse"
 msgstr ""
 
@@ -821,9 +822,9 @@ msgstr ""
 #: src/olympia/devhub/templates/devhub/addons/ajax_compat_update.html:36 src/olympia/devhub/templates/devhub/addons/profile.html:44 src/olympia/devhub/templates/devhub/addons/edit/admin.html:104
 #: src/olympia/devhub/templates/devhub/addons/edit/basic.html:155 src/olympia/devhub/templates/devhub/addons/edit/details.html:88 src/olympia/devhub/templates/devhub/addons/edit/support.html:70
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:169 src/olympia/devhub/templates/devhub/addons/forms_shared/media.html:152
-#: src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:44 src/olympia/devhub/templates/devhub/personas/edit.html:222 src/olympia/devhub/templates/devhub/versions/add_file_modal.html:79
-#: src/olympia/devhub/templates/devhub/versions/edit.html:140 src/olympia/devhub/templates/devhub/versions/list.html:208 src/olympia/devhub/templates/devhub/versions/list.html:242
-#: src/olympia/devhub/templates/devhub/versions/list.html:276 src/olympia/devhub/templates/devhub/versions/list.html:317 src/olympia/reviews/templates/reviews/edit_review.html:16
+#: src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:43 src/olympia/devhub/templates/devhub/personas/edit.html:222 src/olympia/devhub/templates/devhub/versions/add_file_modal.html:59
+#: src/olympia/devhub/templates/devhub/versions/edit.html:140 src/olympia/devhub/templates/devhub/versions/list.html:208 src/olympia/devhub/templates/devhub/versions/list.html:239
+#: src/olympia/devhub/templates/devhub/versions/list.html:281 src/olympia/devhub/templates/devhub/versions/list.html:315 src/olympia/reviews/templates/reviews/edit_review.html:16
 #: src/olympia/translations/templates/translations/trans-menu.html:50 src/olympia/translations/templates/translations/trans-menu.html:62 src/olympia/zadmin/templates/zadmin/validation.html:105
 msgid "Cancel"
 msgstr ""
@@ -868,7 +869,7 @@ msgstr ""
 msgid "Review Guidelines"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/review_list_box.html:5 src/olympia/addons/templates/addons/impala/details-more.html:27 src/olympia/editors/helpers.py:921
+#: src/olympia/addons/templates/addons/review_list_box.html:5 src/olympia/addons/templates/addons/impala/details-more.html:27 src/olympia/editors/helpers.py:1001
 #: src/olympia/reviews/templates/reviews/add.html:14 src/olympia/reviews/templates/reviews/reply.html:14 src/olympia/reviews/templates/reviews/review_list.html:19
 #: src/olympia/reviews/templates/reviews/mobile/review_list.html:26
 msgid "Reviews"
@@ -959,119 +960,119 @@ msgid_plural "Other add-ons by these authors"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/olympia/addons/templates/addons/impala/details.html:41
+#: src/olympia/addons/templates/addons/impala/details.html:39
 #, python-format
 msgid "<span itemprop=\"ratingCount\">%(num)s</span> user review"
 msgid_plural "<span itemprop=\"ratingCount\">%(num)s</span> user reviews"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/olympia/addons/templates/addons/impala/details.html:69
+#: src/olympia/addons/templates/addons/impala/details.html:66
 msgid "View statistics"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/impala/details.html:84
+#: src/olympia/addons/templates/addons/impala/details.html:81
 msgid "Manage"
 msgstr ""
 
 #. {0} is an add-on name.
-#: src/olympia/addons/templates/addons/impala/details.html:96
+#: src/olympia/addons/templates/addons/impala/details.html:93
 msgid "Icon of {0}"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/impala/details.html:103 src/olympia/addons/templates/addons/impala/listing/items.html:14
+#: src/olympia/addons/templates/addons/impala/details.html:100 src/olympia/addons/templates/addons/impala/listing/items.html:14
 msgid "No Restart"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/impala/details.html:127
+#: src/olympia/addons/templates/addons/impala/details.html:124
 #, python-format
 msgid "Meet the Developer: <a href=\"%(url)s\">%(name)s</a>"
 msgid_plural "<a href=\"%(url)s\">Meet the Developers</a>"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/olympia/addons/templates/addons/impala/details.html:137
+#: src/olympia/addons/templates/addons/impala/details.html:134
 msgid "Learn why {0} was created and find out what's next for this add-on."
 msgstr ""
 
 #. {0} is an index.
-#: src/olympia/addons/templates/addons/impala/details.html:156
+#: src/olympia/addons/templates/addons/impala/details.html:161
 msgid "Add-on screenshot #{0}"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/impala/details.html:182
+#: src/olympia/addons/templates/addons/impala/details.html:187
 msgid "Add-on home page"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/impala/details.html:185
+#: src/olympia/addons/templates/addons/impala/details.html:190
 msgid "Support site"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/impala/details.html:189
+#: src/olympia/addons/templates/addons/impala/details.html:194
 msgid "Support E-mail"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/impala/details.html:194 src/olympia/devhub/models.py:378 src/olympia/devhub/templates/devhub/versions/list.html:12
+#: src/olympia/addons/templates/addons/impala/details.html:199 src/olympia/devhub/models.py:378 src/olympia/devhub/templates/devhub/versions/list.html:12
 #: src/olympia/versions/templates/versions/version.html:6 src/olympia/versions/templates/versions/mobile/version.html:6
 msgid "Version {0}"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/impala/details.html:194
+#: src/olympia/addons/templates/addons/impala/details.html:199
 msgid "Info"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/impala/details.html:195 src/olympia/devhub/templates/devhub/includes/addon_details.html:129
+#: src/olympia/addons/templates/addons/impala/details.html:200 src/olympia/devhub/templates/devhub/includes/addon_details.html:116
 msgid "Last Updated:"
-msgstr ""
-
-#: src/olympia/addons/templates/addons/impala/details.html:200
-#, python-format
-msgid "Released under <a target=\"_blank\" href=\"%(url)s\">%(name)s</a>"
-msgstr ""
-
-#: src/olympia/addons/templates/addons/impala/details.html:201 src/olympia/addons/templates/addons/impala/details.html:206 src/olympia/amo/helpers.py:398 src/olympia/devhub/forms.py:142
-#: src/olympia/devhub/forms.py:173 src/olympia/versions/templates/versions/version.html:40 src/olympia/versions/templates/versions/version.html:45
-msgid "Custom License"
 msgstr ""
 
 #: src/olympia/addons/templates/addons/impala/details.html:205
 #, python-format
+msgid "Released under <a target=\"_blank\" href=\"%(url)s\">%(name)s</a>"
+msgstr ""
+
+#: src/olympia/addons/templates/addons/impala/details.html:206 src/olympia/addons/templates/addons/impala/details.html:211 src/olympia/amo/helpers.py:398 src/olympia/devhub/forms.py:142
+#: src/olympia/devhub/forms.py:173 src/olympia/versions/templates/versions/version.html:40 src/olympia/versions/templates/versions/version.html:45
+msgid "Custom License"
+msgstr ""
+
+#: src/olympia/addons/templates/addons/impala/details.html:210
+#, python-format
 msgid "Released under <a href=\"%(url)s\">%(name)s</a>"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/impala/details.html:217
+#: src/olympia/addons/templates/addons/impala/details.html:222
 msgid "About this Add-on"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/impala/details.html:233
+#: src/olympia/addons/templates/addons/impala/details.html:238
 msgid "Developer’s Comments"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/impala/details.html:243
+#: src/olympia/addons/templates/addons/impala/details.html:248
 msgid "Version Information"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/impala/details.html:250
+#: src/olympia/addons/templates/addons/impala/details.html:255
 msgid "See complete version history"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/impala/details.html:262
+#: src/olympia/addons/templates/addons/impala/details.html:267
 msgid ""
 "The Development Channel lets you test an experimental new version of this add-on before it's released to the general public. Once you install the development version, you will continue to get "
 "updates from this channel. To stop receiving development updates, reinstall the default version from the link above."
 msgstr ""
 
-#: src/olympia/addons/templates/addons/impala/details.html:272
+#: src/olympia/addons/templates/addons/impala/details.html:277
 msgid "<strong>Caution:</strong> Development versions of this add-on have not been reviewed by Mozilla."
 msgstr ""
 
-#: src/olympia/addons/templates/addons/impala/details.html:287
+#: src/olympia/addons/templates/addons/impala/details.html:292
 msgid "See complete development channel history"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/impala/details.html:306 src/olympia/addons/templates/addons/impala/details.html:315 src/olympia/addons/templates/addons/impala/details.html:327
+#: src/olympia/addons/templates/addons/impala/details.html:311 src/olympia/addons/templates/addons/impala/details.html:320 src/olympia/addons/templates/addons/impala/details.html:332
 #: src/olympia/addons/templates/addons/impala/review_add_box.html:4 src/olympia/stats/templates/stats/popup.html:2 src/olympia/stats/templates/stats/popup.html:8
-#: src/olympia/stats/templates/stats/stats.html:202 src/olympia/users/templates/users/profile.html:119
+#: src/olympia/stats/templates/stats/stats.html:204 src/olympia/users/templates/users/profile.html:119
 msgid "close"
 msgstr ""
 
@@ -1127,15 +1128,11 @@ msgstr ""
 msgid "Source Code License"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/impala/persona_grid.html:16 src/olympia/addons/templates/addons/impala/toplist.html:6
-msgid "{0} users"
-msgstr ""
-
 #: src/olympia/addons/templates/addons/impala/review_list_box.html:19 src/olympia/reviews/templates/reviews/review.html:40
 msgid "permalink"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/impala/review_list_box.html:23 src/olympia/editors/templates/editors/queue.html:98 src/olympia/reviews/templates/reviews/review.html:44
+#: src/olympia/addons/templates/addons/impala/review_list_box.html:23 src/olympia/editors/templates/editors/queue.html:104 src/olympia/reviews/templates/reviews/review.html:44
 msgid "translate"
 msgstr ""
 
@@ -1154,6 +1151,10 @@ msgstr ""
 msgid "Be the first!"
 msgstr ""
 
+#: src/olympia/addons/templates/addons/impala/toplist.html:6
+msgid "{0} users"
+msgstr ""
+
 #: src/olympia/addons/templates/addons/impala/listing/sorter.html:14 src/olympia/devhub/templates/devhub/addons/listing/item_actions.html:49
 msgid "More"
 msgstr ""
@@ -1166,7 +1167,7 @@ msgstr ""
 msgid "My Add-ons"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/includes/dashboard_tabs.html:6 src/olympia/amo/context_processors.py:51
+#: src/olympia/addons/templates/addons/includes/dashboard_tabs.html:6 src/olympia/amo/context_processors.py:50
 msgid "My Themes"
 msgstr ""
 
@@ -1221,7 +1222,7 @@ msgstr ""
 msgid "Weekly Downloads"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/mobile/details.html:99 src/olympia/compat/templates/compat/reporter_detail.html:46 src/olympia/devhub/forms.py:787
+#: src/olympia/addons/templates/addons/mobile/details.html:99 src/olympia/compat/templates/compat/reporter_detail.html:46 src/olympia/devhub/forms.py:788
 #: src/olympia/devhub/templates/devhub/versions/list.html:163
 msgid "Version"
 msgstr ""
@@ -1305,7 +1306,7 @@ msgstr ""
 #: src/olympia/browse/templates/browse/personas/category_landing.html:21 src/olympia/browse/templates/browse/personas/category_landing.html:23
 #: src/olympia/browse/templates/browse/personas/category_landing.html:38 src/olympia/browse/templates/browse/personas/grid.html:7 src/olympia/browse/templates/browse/personas/grid.html:11
 #: src/olympia/browse/templates/browse/personas/mobile/base.html:7 src/olympia/browse/templates/browse/personas/mobile/category_landing.html:19 src/olympia/constants/base.py:180
-#: src/olympia/devhub/templates/devhub/personas/submit.html:13 src/olympia/editors/helpers.py:105 src/olympia/editors/templates/editors/base.html:26
+#: src/olympia/devhub/templates/devhub/personas/submit.html:13 src/olympia/editors/helpers.py:107 src/olympia/editors/templates/editors/base.html:26
 #: src/olympia/editors/templates/editors/performance.html:73 src/olympia/search/templates/search/personas.html:39 src/olympia/templates/menu_links.html:9
 msgid "Themes"
 msgstr ""
@@ -1326,7 +1327,7 @@ msgstr ""
 msgid "Highest Rated"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/mobile/home.html:74 src/olympia/amo/templates/amo/side_nav.html:5 src/olympia/amo/templates/amo/site_nav.html:27 src/olympia/amo/templates/amo/site_nav.html:57
+#: src/olympia/addons/templates/addons/mobile/home.html:74 src/olympia/amo/templates/amo/side_nav.html:5 src/olympia/amo/templates/amo/site_nav.html:27 src/olympia/amo/templates/amo/site_nav.html:55
 #: src/olympia/bandwagon/views.py:97 src/olympia/browse/views.py:57 src/olympia/browse/views.py:67 src/olympia/browse/templates/browse/personas/mobile/category_landing.html:65
 #: src/olympia/search/forms.py:15 src/olympia/search/forms.py:87
 msgid "Newest"
@@ -1340,90 +1341,90 @@ msgstr ""
 msgid "Theme Info &raquo;"
 msgstr ""
 
-#: src/olympia/amo/context_processors.py:39 src/olympia/devhub/templates/devhub/nav.html:43
+#: src/olympia/amo/context_processors.py:37 src/olympia/devhub/templates/devhub/nav.html:43
 msgid "Tools"
 msgstr ""
 
-#: src/olympia/amo/context_processors.py:48 src/olympia/discovery/templates/discovery/pane_account.html:8 src/olympia/users/templates/users/includes/navigation.html:2
+#: src/olympia/amo/context_processors.py:47 src/olympia/discovery/templates/discovery/pane_account.html:8 src/olympia/users/templates/users/includes/navigation.html:2
 msgid "My Profile"
 msgstr ""
 
-#: src/olympia/amo/context_processors.py:54 src/olympia/users/templates/users/edit.html:5 src/olympia/users/templates/users/includes/navigation.html:3
+#: src/olympia/amo/context_processors.py:53 src/olympia/users/templates/users/edit.html:5 src/olympia/users/templates/users/includes/navigation.html:3
 msgid "Account Settings"
 msgstr ""
 
-#: src/olympia/amo/context_processors.py:57 src/olympia/discovery/templates/discovery/pane_account.html:11 src/olympia/users/templates/users/profile.html:83
+#: src/olympia/amo/context_processors.py:56 src/olympia/discovery/templates/discovery/pane_account.html:11 src/olympia/users/templates/users/profile.html:83
 #: src/olympia/users/templates/users/includes/navigation.html:4
 msgid "My Collections"
 msgstr ""
 
-#: src/olympia/amo/context_processors.py:62 src/olympia/discovery/templates/discovery/pane_account.html:10 src/olympia/users/templates/users/includes/navigation.html:7
+#: src/olympia/amo/context_processors.py:61 src/olympia/discovery/templates/discovery/pane_account.html:10 src/olympia/users/templates/users/includes/navigation.html:7
 msgid "My Favorites"
 msgstr ""
 
-#: src/olympia/amo/context_processors.py:67 src/olympia/discovery/templates/discovery/pane_account.html:13 src/olympia/templates/impala/user_login.html:14
+#: src/olympia/amo/context_processors.py:66 src/olympia/discovery/templates/discovery/pane_account.html:13 src/olympia/templates/impala/user_login.html:14
 #: src/olympia/templates/mobile/header_auth.html:5
 msgid "Log out"
 msgstr ""
 
-#: src/olympia/amo/context_processors.py:72 src/olympia/devhub/templates/devhub/addons/dashboard.html:4
+#: src/olympia/amo/context_processors.py:71 src/olympia/devhub/templates/devhub/addons/dashboard.html:4
 msgid "Manage My Submissions"
 msgstr ""
 
-#: src/olympia/amo/context_processors.py:75 src/olympia/devhub/templates/devhub/nav.html:27 src/olympia/devhub/templates/devhub/addons/dashboard.html:25
+#: src/olympia/amo/context_processors.py:74 src/olympia/devhub/templates/devhub/nav.html:27 src/olympia/devhub/templates/devhub/addons/dashboard.html:25
 #: src/olympia/devhub/templates/devhub/addons/submit/base.html:4
 msgid "Submit a New Add-on"
 msgstr ""
 
-#: src/olympia/amo/context_processors.py:77 src/olympia/browse/templates/browse/personas/base.html:50 src/olympia/devhub/templates/devhub/index.html:24
+#: src/olympia/amo/context_processors.py:76 src/olympia/browse/templates/browse/personas/base.html:50 src/olympia/devhub/templates/devhub/index.html:24
 #: src/olympia/devhub/templates/devhub/addons/dashboard.html:29
 msgid "Submit a New Theme"
 msgstr ""
 
-#: src/olympia/amo/context_processors.py:79 src/olympia/amo/templates/amo/site_nav.html:87 src/olympia/devhub/helpers.py:36 src/olympia/devhub/helpers.py:68 src/olympia/devhub/helpers.py:102
+#: src/olympia/amo/context_processors.py:78 src/olympia/amo/templates/amo/site_nav.html:85 src/olympia/devhub/helpers.py:36 src/olympia/devhub/helpers.py:68 src/olympia/devhub/helpers.py:102
 #: src/olympia/templates/footer.html:6 src/olympia/templates/menu_links.html:14
 msgid "Developer Hub"
 msgstr ""
 
-#: src/olympia/amo/context_processors.py:83 src/olympia/devhub/views.py:1792
+#: src/olympia/amo/context_processors.py:81 src/olympia/devhub/views.py:1796
 msgid "Manage API Keys"
 msgstr ""
 
-#: src/olympia/amo/context_processors.py:88 src/olympia/editors/helpers.py:82 src/olympia/editors/helpers.py:102 src/olympia/editors/templates/editors/base.html:10
+#: src/olympia/amo/context_processors.py:86 src/olympia/editors/helpers.py:84 src/olympia/editors/helpers.py:104 src/olympia/editors/templates/editors/base.html:10
 msgid "Editor Tools"
 msgstr ""
 
-#: src/olympia/amo/context_processors.py:92
+#: src/olympia/amo/context_processors.py:90
 msgid "Admin Tools"
 msgstr ""
 
-#: src/olympia/amo/fields.py:15
+#: src/olympia/amo/fields.py:20
 msgid "Incorrect, please try again."
 msgstr ""
 
-#: src/olympia/amo/fields.py:16
+#: src/olympia/amo/fields.py:21
 msgid "Error verifying input, please try again."
 msgstr ""
 
-#: src/olympia/amo/fields.py:32
+#: src/olympia/amo/fields.py:37
 msgid "This must be a valid hex color code, such as #000000."
 msgstr ""
 
-#: src/olympia/amo/fields.py:58
+#: src/olympia/amo/fields.py:63
 msgid "Enter at least one value."
 msgstr ""
 
-#: src/olympia/amo/helpers.py:162 src/olympia/amo/templates/amo/site_nav.html:61 src/olympia/bandwagon/templates/bandwagon/add.html:9
+#: src/olympia/amo/helpers.py:162 src/olympia/amo/templates/amo/site_nav.html:59 src/olympia/bandwagon/templates/bandwagon/add.html:9
 #: src/olympia/bandwagon/templates/bandwagon/collection_detail.html:15 src/olympia/bandwagon/templates/bandwagon/delete.html:9 src/olympia/bandwagon/templates/bandwagon/edit.html:15
 #: src/olympia/bandwagon/templates/bandwagon/user_listing.html:18 src/olympia/bandwagon/templates/bandwagon/user_listing.html:21
 #: src/olympia/bandwagon/templates/bandwagon/impala/collection_listing.html:12 src/olympia/bandwagon/templates/bandwagon/impala/collection_listing.html:20
 #: src/olympia/bandwagon/templates/bandwagon/impala/collection_listing.html:24 src/olympia/bandwagon/templates/bandwagon/impala/collection_sidebar.html:3
 #: src/olympia/bandwagon/templates/bandwagon/includes/collection_sidebar.html:2 src/olympia/bandwagon/templates/bandwagon/mobile/collection_listing.html:3
-#: src/olympia/stats/templates/stats/stats.html:77 src/olympia/templates/menu_links.html:12
+#: src/olympia/stats/templates/stats/stats.html:33 src/olympia/templates/menu_links.html:12
 msgid "Collections"
 msgstr ""
 
-#: src/olympia/amo/helpers.py:171 src/olympia/amo/templates/amo/site_nav.html:85 src/olympia/browse/templates/browse/language_tools.html:3
+#: src/olympia/amo/helpers.py:171 src/olympia/amo/templates/amo/site_nav.html:83 src/olympia/browse/templates/browse/language_tools.html:3
 msgid "Dictionaries & Language Packs"
 msgstr ""
 
@@ -1575,8 +1576,8 @@ msgstr ""
 msgid "Comment on {addon} {version}."
 msgstr ""
 
-#: src/olympia/amo/log.py:236 src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:19 src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:47
-#: src/olympia/editors/helpers.py:511 src/olympia/editors/templates/editors/themes/history_table.html:11
+#: src/olympia/amo/log.py:236 src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:17 src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:45
+#: src/olympia/editors/helpers.py:584 src/olympia/editors/templates/editors/themes/history_table.html:11
 msgid "Comment"
 msgstr ""
 
@@ -1899,7 +1900,7 @@ msgstr ""
 #: src/olympia/amo/templates/amo/mobile/paginator.html:14 src/olympia/amo/templates/amo/mobile/paginator.html:16 src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:51
 #: src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:65 src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:78
 #: src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:91 src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:104
-#: src/olympia/discovery/templates/discovery/pane.html:45 src/olympia/discovery/templates/discovery/addons/detail.html:39 src/olympia/stats/templates/stats/stats.html:167
+#: src/olympia/discovery/templates/discovery/pane.html:45 src/olympia/discovery/templates/discovery/addons/detail.html:39 src/olympia/stats/templates/stats/stats.html:169
 msgid "Next"
 msgstr ""
 
@@ -1931,7 +1932,7 @@ msgid ""
 msgstr ""
 
 #: src/olympia/amo/templates/amo/side_nav.html:4 src/olympia/amo/templates/amo/side_nav.html:12 src/olympia/amo/templates/amo/site_nav.html:4 src/olympia/amo/templates/amo/site_nav.html:26
-#: src/olympia/browse/views.py:56 src/olympia/browse/views.py:66 src/olympia/browse/views.py:237 src/olympia/browse/views.py:282 src/olympia/search/forms.py:86
+#: src/olympia/browse/views.py:56 src/olympia/browse/views.py:66 src/olympia/browse/views.py:204 src/olympia/browse/views.py:249 src/olympia/search/forms.py:86
 msgid "Top Rated"
 msgstr ""
 
@@ -1945,38 +1946,38 @@ msgstr ""
 msgid "Extensions"
 msgstr ""
 
-#: src/olympia/amo/templates/amo/site_nav.html:45
+#: src/olympia/amo/templates/amo/site_nav.html:44
 msgid "Want more customization? Try <b>Complete Themes</b>"
 msgstr ""
 
-#: src/olympia/amo/templates/amo/site_nav.html:56 src/olympia/bandwagon/views.py:96
+#: src/olympia/amo/templates/amo/site_nav.html:54 src/olympia/bandwagon/views.py:96
 msgid "Most Followers"
 msgstr ""
 
-#: src/olympia/amo/templates/amo/site_nav.html:68 src/olympia/bandwagon/templates/bandwagon/impala/collection_sidebar.html:16
+#: src/olympia/amo/templates/amo/site_nav.html:66 src/olympia/bandwagon/templates/bandwagon/impala/collection_sidebar.html:16
 #: src/olympia/bandwagon/templates/bandwagon/includes/collection_sidebar.html:18
 msgid "Collections I've Made"
 msgstr ""
 
-#: src/olympia/amo/templates/amo/site_nav.html:70 src/olympia/bandwagon/templates/bandwagon/user_listing.html:4 src/olympia/bandwagon/templates/bandwagon/impala/collection_sidebar.html:13
+#: src/olympia/amo/templates/amo/site_nav.html:68 src/olympia/bandwagon/templates/bandwagon/user_listing.html:4 src/olympia/bandwagon/templates/bandwagon/impala/collection_sidebar.html:13
 #: src/olympia/bandwagon/templates/bandwagon/includes/collection_sidebar.html:15
 msgid "Collections I'm Following"
 msgstr ""
 
-#: src/olympia/amo/templates/amo/site_nav.html:73 src/olympia/bandwagon/templates/bandwagon/impala/collection_sidebar.html:18
-#: src/olympia/bandwagon/templates/bandwagon/includes/collection_sidebar.html:20 src/olympia/users/models.py:512
+#: src/olympia/amo/templates/amo/site_nav.html:71 src/olympia/bandwagon/templates/bandwagon/impala/collection_sidebar.html:18
+#: src/olympia/bandwagon/templates/bandwagon/includes/collection_sidebar.html:20 src/olympia/users/models.py:521
 msgid "My Favorite Add-ons"
 msgstr ""
 
-#: src/olympia/amo/templates/amo/site_nav.html:78
+#: src/olympia/amo/templates/amo/site_nav.html:76
 msgid "More&hellip;"
 msgstr ""
 
-#: src/olympia/amo/templates/amo/site_nav.html:82
+#: src/olympia/amo/templates/amo/site_nav.html:80
 msgid "Add-ons for Mobile"
 msgstr ""
 
-#: src/olympia/amo/templates/amo/site_nav.html:86 src/olympia/browse/feeds.py:207 src/olympia/browse/templates/browse/search_tools.html:3 src/olympia/constants/base.py:176
+#: src/olympia/amo/templates/amo/site_nav.html:84 src/olympia/browse/feeds.py:207 src/olympia/browse/templates/browse/search_tools.html:3 src/olympia/constants/base.py:176
 #: src/olympia/templates/menu_links.html:10
 msgid "Search Tools"
 msgstr ""
@@ -1992,7 +1993,7 @@ msgid "Jump to first page"
 msgstr ""
 
 #: src/olympia/amo/templates/amo/impala/paginator.html:22 src/olympia/amo/templates/amo/mobile/impala_paginator.html:12 src/olympia/discovery/templates/discovery/pane.html:44
-#: src/olympia/discovery/templates/discovery/addons/detail.html:38 src/olympia/stats/templates/stats/stats.html:164
+#: src/olympia/discovery/templates/discovery/addons/detail.html:38 src/olympia/stats/templates/stats/stats.html:166
 msgid "Previous"
 msgstr ""
 
@@ -2015,30 +2016,49 @@ msgid_plural "Page {n}"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/olympia/amo/templates/services/install.html:38
-#, python-format
-msgid "If you are not prompted to install %(addon_name)s in a moment, please <a href=\"%(addon_xpi)s\">click here</a>."
-msgstr ""
-
-#: src/olympia/amo/tests/test_messages.py:57 src/olympia/amo/tests/test_messages.py:58 src/olympia/reviews/forms.py:25 src/olympia/reviews/forms.py:50 src/olympia/reviews/templates/reviews/add.html:56
+#: src/olympia/amo/tests/test_messages.py:56 src/olympia/amo/tests/test_messages.py:57 src/olympia/reviews/forms.py:25 src/olympia/reviews/forms.py:50 src/olympia/reviews/templates/reviews/add.html:56
 #: src/olympia/reviews/templates/reviews/reply.html:30
 msgid "Title"
 msgstr ""
 
-#: src/olympia/amo/tests/test_messages.py:57 src/olympia/amo/tests/test_messages.py:58
+#: src/olympia/amo/tests/test_messages.py:56 src/olympia/amo/tests/test_messages.py:57
 msgid "Body"
 msgstr ""
 
-#: src/olympia/amo/tests/test_messages.py:59
+#: src/olympia/amo/tests/test_messages.py:58
 msgid "Another Title"
 msgstr ""
 
-#: src/olympia/amo/tests/test_messages.py:59
+#: src/olympia/amo/tests/test_messages.py:58
 msgid "Another Body"
 msgstr ""
 
-#: src/olympia/api/views.py:255
-msgid "Not implemented yet."
+#: src/olympia/api/authentication.py:76
+msgid "Signature has expired."
+msgstr ""
+
+#: src/olympia/api/authentication.py:79
+msgid "Error decoding signature."
+msgstr ""
+
+#: src/olympia/api/authentication.py:82
+msgid "Invalid JWT Token."
+msgstr ""
+
+#: src/olympia/api/authentication.py:130
+msgid "Invalid Authorization header. No credentials provided."
+msgstr ""
+
+#: src/olympia/api/authentication.py:133
+msgid "Invalid Authorization header. Credentials string should not contain spaces."
+msgstr ""
+
+#: src/olympia/api/fields.py:29
+msgid "The field must have a length of at least {num} characters."
+msgstr ""
+
+#: src/olympia/api/fields.py:31
+msgid "The language code {lang_code} is invalid."
 msgstr ""
 
 #: src/olympia/applications/views.py:39 src/olympia/applications/templates/applications/appversions.html:3
@@ -2057,7 +2077,7 @@ msgstr ""
 msgid "Add-ons submitted to Mozilla Add-ons must have a manifest file with at least one of the below applications supported. Only the versions listed below are allowed for these applications."
 msgstr ""
 
-#: src/olympia/applications/templates/applications/appversions.html:25
+#: src/olympia/applications/templates/applications/appversions.html:25 src/olympia/editors/helpers.py:361
 msgid "GUID"
 msgstr ""
 
@@ -2171,8 +2191,8 @@ msgstr ""
 msgid "Remove from favorites"
 msgstr ""
 
-#: src/olympia/bandwagon/views.py:98 src/olympia/bandwagon/views.py:191 src/olympia/browse/views.py:58 src/olympia/browse/views.py:69 src/olympia/browse/views.py:458 src/olympia/devhub/views.py:74
-#: src/olympia/devhub/views.py:82 src/olympia/devhub/templates/devhub/addons/edit/basic.html:20 src/olympia/editors/templates/editors/leaderboard.html:24
+#: src/olympia/bandwagon/views.py:98 src/olympia/bandwagon/views.py:191 src/olympia/browse/views.py:58 src/olympia/browse/views.py:69 src/olympia/browse/views.py:425 src/olympia/devhub/views.py:72
+#: src/olympia/devhub/views.py:80 src/olympia/devhub/templates/devhub/addons/edit/basic.html:20 src/olympia/editors/templates/editors/leaderboard.html:24
 #: src/olympia/editors/templates/editors/themes/queue_list.html:48 src/olympia/search/forms.py:17 src/olympia/search/forms.py:89 src/olympia/users/templates/users/vcard.html:5
 msgid "Name"
 msgstr ""
@@ -2181,7 +2201,7 @@ msgstr ""
 msgid "Recently Popular"
 msgstr ""
 
-#: src/olympia/bandwagon/views.py:189 src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:18
+#: src/olympia/bandwagon/views.py:189 src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:16
 msgid "Added"
 msgstr ""
 
@@ -2195,7 +2215,7 @@ msgstr ""
 
 #: src/olympia/bandwagon/views.py:316
 #, python-format
-msgid "Your new collection is shown below. You can <ahref=\"%(url)s\">edit additional settings</a> if you'dlike."
+msgid "Your new collection is shown below. You can <a href=\"%(url)s\">edit additional settings</a> if you'd like."
 msgstr ""
 
 #: src/olympia/bandwagon/views.py:322
@@ -2323,8 +2343,8 @@ msgid_plural "%(num)s Add-ons in this Collection"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/olympia/bandwagon/templates/bandwagon/collection_detail.html:125 src/olympia/compat/templates/compat/index.html:25 src/olympia/compat/templates/compat/reporter_detail.html:29
-#: src/olympia/files/templates/files/viewer.html:29 src/olympia/templates/amo_footer.html:17 src/olympia/templates/includes/lang_switcher.html:10
+#: src/olympia/bandwagon/templates/bandwagon/collection_detail.html:125 src/olympia/compat/templates/compat/reporter_detail.html:29 src/olympia/files/templates/files/viewer.html:29
+#: src/olympia/templates/amo_footer.html:17 src/olympia/templates/includes/lang_switcher.html:10
 msgid "Go"
 msgstr ""
 
@@ -2491,7 +2511,7 @@ msgid "Remove this user as a contributor"
 msgstr ""
 
 #: src/olympia/bandwagon/templates/bandwagon/edit_contributors.html:18 src/olympia/bandwagon/templates/bandwagon/edit_contributors.html:43
-#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:20 src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:48
+#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:18 src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:46
 #: src/olympia/devhub/templates/devhub/addons/ajax_compat_update.html:19
 msgid "Remove"
 msgstr ""
@@ -2539,7 +2559,7 @@ msgid "<b>Warning:</b> By changing the owner of this collection, you will no lon
 msgstr ""
 
 #: src/olympia/bandwagon/templates/bandwagon/edit_contributors.html:83 src/olympia/devhub/templates/devhub/addons/forms_shared/media.html:157
-#: src/olympia/devhub/templates/devhub/addons/submit/describe.html:69 src/olympia/devhub/templates/devhub/addons/submit/license.html:60 src/olympia/devhub/templates/devhub/addons/submit/upload.html:78
+#: src/olympia/devhub/templates/devhub/addons/submit/describe.html:69 src/olympia/devhub/templates/devhub/addons/submit/license.html:60 src/olympia/devhub/templates/devhub/addons/submit/upload.html:70
 #: src/olympia/devhub/templates/devhub/payments/tier.html:17 src/olympia/editors/templates/editors/themes/themes.html:111 src/olympia/editors/templates/editors/themes/themes.html:128
 #: src/olympia/editors/templates/editors/themes/themes.html:134 src/olympia/editors/templates/editors/themes/themes.html:141 src/olympia/users/templates/users/fxa_migration_prompt_content.html:10
 #: src/olympia/users/templates/users/login_form.html:42 src/olympia/users/templates/users/mobile/login.html:57
@@ -2622,31 +2642,31 @@ msgid "Add-ons in Your Collection"
 msgstr ""
 
 #: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:4
-msgid ""
-"To include an add-on in this collection, enter its name in the box below and hit enter.  You can also use the <strong>Add to Collection</strong> links throughout the site to include add-ons later."
+msgid "To include an add-on in this collection, enter its name in the box below and hit enter."
 msgstr ""
 
-#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:17 src/olympia/constants/base.py:400 src/olympia/devhub/templates/devhub/addons/activity.html:62
+#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:15 src/olympia/constants/base.py:400 src/olympia/devhub/templates/devhub/addons/activity.html:62
+#: src/olympia/editors/helpers.py:273 src/olympia/editors/helpers.py:360
 msgid "Add-on"
 msgstr ""
 
-#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:26
+#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:24
 msgid "Enter the name of the add-on to include"
 msgstr ""
 
-#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:28
+#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:26
 msgid "Add to Collection"
 msgstr ""
 
-#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:45 src/olympia/editors/helpers.py:936 src/olympia/editors/helpers.py:956
+#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:43 src/olympia/editors/helpers.py:1016 src/olympia/editors/helpers.py:1036
 msgid "Pending"
 msgstr ""
 
-#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:47
+#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:45
 msgid "Add a comment"
 msgstr ""
 
-#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:48
+#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:46
 msgid "Remove this add-on from the collection"
 msgstr ""
 
@@ -2753,12 +2773,12 @@ msgstr ""
 msgid "Most Users"
 msgstr ""
 
-#: src/olympia/browse/views.py:61 src/olympia/browse/views.py:72 src/olympia/browse/views.py:279 src/olympia/browse/templates/browse/personas/mobile/category_landing.html:63
+#: src/olympia/browse/views.py:61 src/olympia/browse/views.py:72 src/olympia/browse/views.py:246 src/olympia/browse/templates/browse/personas/mobile/category_landing.html:63
 #: src/olympia/discovery/templates/discovery/pane.html:67 src/olympia/search/forms.py:92
 msgid "Up & Coming"
 msgstr ""
 
-#: src/olympia/browse/views.py:460 src/olympia/devhub/views.py:76 src/olympia/devhub/views.py:83 src/olympia/discovery/templates/discovery/addons/detail.html:66
+#: src/olympia/browse/views.py:427 src/olympia/devhub/views.py:74 src/olympia/devhub/views.py:81 src/olympia/discovery/templates/discovery/addons/detail.html:66
 msgid "Created"
 msgstr ""
 
@@ -2946,8 +2966,8 @@ msgid_plural "See all %(cnt)s extensions in %(name)s &raquo;"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/olympia/browse/templates/browse/mobile/extensions.html:13 src/olympia/compat/templates/compat/index.html:82 src/olympia/devhub/templates/devhub/devhub_search.html:24
-#: src/olympia/devhub/templates/devhub/addons/activity.html:47 src/olympia/search/templates/search/no_results.html:4 src/olympia/search/templates/search/mobile/results.html:36
+#: src/olympia/browse/templates/browse/mobile/extensions.html:13 src/olympia/devhub/templates/devhub/devhub_search.html:24 src/olympia/devhub/templates/devhub/addons/activity.html:47
+#: src/olympia/search/templates/search/no_results.html:4 src/olympia/search/templates/search/mobile/results.html:36
 msgid "No results found."
 msgstr ""
 
@@ -3032,7 +3052,7 @@ msgstr ""
 msgid "All"
 msgstr ""
 
-#: src/olympia/compat/forms.py:22 src/olympia/search/views.py:525
+#: src/olympia/compat/forms.py:22 src/olympia/editors/templates/editors/base.html:69 src/olympia/search/views.py:518
 msgid "All Add-ons"
 msgstr ""
 
@@ -3042,53 +3062,6 @@ msgstr ""
 
 #: src/olympia/compat/forms.py:24
 msgid "Non-binary"
-msgstr ""
-
-#. Review points sources other than add-ons and themes.
-#: src/olympia/compat/views.py:87 src/olympia/constants/base.py:388 src/olympia/devhub/forms.py:162 src/olympia/editors/templates/editors/performance.html:75
-msgid "Other"
-msgstr ""
-
-#: src/olympia/compat/templates/compat/index.html:4
-msgid "Add-on Compatibility Report for {app} {version}"
-msgstr ""
-
-#: src/olympia/compat/templates/compat/index.html:11
-msgid "{app} {version} Compatibility"
-msgstr ""
-
-#: src/olympia/compat/templates/compat/index.html:17
-#, python-format
-msgid "Top 95%% compatible with previous version"
-msgstr ""
-
-#: src/olympia/compat/templates/compat/index.html:18
-#, python-format
-msgid "Top 95%% of all add-ons"
-msgstr ""
-
-#: src/olympia/compat/templates/compat/index.html:19
-msgid "All active add-ons"
-msgstr ""
-
-#: src/olympia/compat/templates/compat/index.html:23 src/olympia/constants/base.py:401
-msgid "App"
-msgstr ""
-
-#: src/olympia/compat/templates/compat/index.html:55
-msgid "Details for add-ons compatible with previous version:"
-msgstr ""
-
-#: src/olympia/compat/templates/compat/index.html:57
-msgid "Show all versions"
-msgstr ""
-
-#: src/olympia/compat/templates/compat/index.html:59
-msgid "Details for add-ons compatible with all versions:"
-msgstr ""
-
-#: src/olympia/compat/templates/compat/index.html:61
-msgid "Show previous version only"
 msgstr ""
 
 #: src/olympia/compat/templates/compat/reporter.html:3
@@ -3142,8 +3115,8 @@ msgstr ""
 msgid "Report Type"
 msgstr ""
 
-#: src/olympia/compat/templates/compat/reporter_detail.html:47 src/olympia/devhub/forms.py:784 src/olympia/devhub/templates/devhub/addons/ajax_compat_update.html:17 src/olympia/editors/forms.py:108
-#: src/olympia/zadmin/forms.py:45
+#: src/olympia/compat/templates/compat/reporter_detail.html:47 src/olympia/devhub/forms.py:785 src/olympia/devhub/templates/devhub/addons/ajax_compat_update.html:17 src/olympia/editors/forms.py:108
+#: src/olympia/editors/forms.py:248 src/olympia/zadmin/forms.py:45
 msgid "Application"
 msgstr ""
 
@@ -3231,7 +3204,8 @@ msgstr ""
 msgid "Preliminarily Reviewed and Awaiting Full Review"
 msgstr ""
 
-#: src/olympia/constants/base.py:33 src/olympia/editors/helpers.py:924 src/olympia/editors/templates/editors/themes/history_table.html:34
+#: src/olympia/constants/base.py:33 src/olympia/editors/forms.py:258 src/olympia/editors/helpers.py:73 src/olympia/editors/helpers.py:1004
+#: src/olympia/editors/templates/editors/themes/history_table.html:34
 msgid "Deleted"
 msgstr ""
 
@@ -3328,6 +3302,11 @@ msgstr ""
 msgid "Ask before users can download this add-on"
 msgstr ""
 
+#. Review points sources other than add-ons and themes.
+#: src/olympia/constants/base.py:388 src/olympia/devhub/forms.py:162 src/olympia/editors/templates/editors/performance.html:75
+msgid "Other"
+msgstr ""
+
 #: src/olympia/constants/base.py:389
 msgid "Exception"
 msgstr ""
@@ -3338,6 +3317,10 @@ msgstr ""
 
 #: src/olympia/constants/base.py:391
 msgid "Change"
+msgstr ""
+
+#: src/olympia/constants/base.py:401
+msgid "App"
 msgstr ""
 
 #: src/olympia/constants/base.py:402
@@ -3488,7 +3471,7 @@ msgstr ""
 msgid "Duplicate"
 msgstr ""
 
-#: src/olympia/constants/editors.py:17 src/olympia/editors/helpers.py:502 src/olympia/editors/templates/editors/themes/queue.html:71 src/olympia/editors/templates/editors/themes/themes.html:94
+#: src/olympia/constants/editors.py:17 src/olympia/editors/helpers.py:575 src/olympia/editors/templates/editors/themes/queue.html:71 src/olympia/editors/templates/editors/themes/themes.html:94
 msgid "Reject"
 msgstr ""
 
@@ -3588,7 +3571,7 @@ msgstr ""
 msgid "Android"
 msgstr ""
 
-#: src/olympia/core/apps.py:19
+#: src/olympia/core/apps.py:21
 msgid "Core"
 msgstr ""
 
@@ -3722,7 +3705,7 @@ msgid "Submit my add-on for manual review."
 msgstr ""
 
 #: src/olympia/devhub/forms.py:537
-msgid "Do not list my add-on on this site (beta)"
+msgid "Do not list my add-on on this site"
 msgstr ""
 
 #: src/olympia/devhub/forms.py:538
@@ -3755,46 +3738,46 @@ msgstr ""
 
 #: src/olympia/devhub/forms.py:592
 #, python-format
-msgid "Version %s already exists"
+msgid "Version %s already exists, or was uploaded before."
 msgstr ""
 
-#: src/olympia/devhub/forms.py:604
+#: src/olympia/devhub/forms.py:605
 msgid "Select a valid choice. That choice is not one of the available choices."
 msgstr ""
 
-#: src/olympia/devhub/forms.py:610
+#: src/olympia/devhub/forms.py:611
 msgid "A file with a version ending with a|alpha|b|beta and an optional number is detected as beta."
 msgstr ""
 
-#: src/olympia/devhub/forms.py:633
+#: src/olympia/devhub/forms.py:634
 msgid "You cannot upload any more files for this version."
 msgstr ""
 
-#: src/olympia/devhub/forms.py:639
+#: src/olympia/devhub/forms.py:640
 msgid "Version doesn't match"
 msgstr ""
 
-#: src/olympia/devhub/forms.py:668
+#: src/olympia/devhub/forms.py:669
 msgid "You cannot delete a file once the review process has started.  You must delete the whole version."
 msgstr ""
 
-#: src/olympia/devhub/forms.py:688
+#: src/olympia/devhub/forms.py:689
 msgid "The platform All cannot be combined with specific platforms."
 msgstr ""
 
-#: src/olympia/devhub/forms.py:693
+#: src/olympia/devhub/forms.py:694
 msgid "A platform can only be chosen once."
 msgstr ""
 
-#: src/olympia/devhub/forms.py:706
+#: src/olympia/devhub/forms.py:707
 msgid "A review type must be selected."
 msgstr ""
 
-#: src/olympia/devhub/forms.py:788 src/olympia/editors/forms.py:114 src/olympia/zadmin/forms.py:49 src/olympia/zadmin/forms.py:52
+#: src/olympia/devhub/forms.py:789 src/olympia/editors/forms.py:114 src/olympia/editors/forms.py:254 src/olympia/zadmin/forms.py:49 src/olympia/zadmin/forms.py:52
 msgid "Select an application first"
 msgstr ""
 
-#: src/olympia/devhub/forms.py:840
+#: src/olympia/devhub/forms.py:841
 msgid "There cannot be more than 3 required add-ons."
 msgstr ""
 
@@ -3828,76 +3811,76 @@ msgstr[1] ""
 msgid "Review"
 msgstr ""
 
-#: src/olympia/devhub/tasks.py:551
+#: src/olympia/devhub/tasks.py:583
 #, python-format
 msgid "%s responded with %s (%s)."
 msgstr ""
 
-#: src/olympia/devhub/tasks.py:555
+#: src/olympia/devhub/tasks.py:587
 #, python-format
 msgid "Connection to \"%s\" timed out."
 msgstr ""
 
-#: src/olympia/devhub/tasks.py:557
+#: src/olympia/devhub/tasks.py:589
 #, python-format
 msgid "Could not contact host at \"%s\"."
 msgstr ""
 
-#: src/olympia/devhub/utils.py:104
+#: src/olympia/devhub/utils.py:105
 #, python-format
 msgid "Validation generated too many errors/warnings so %s messages were truncated. After addressing the visible messages, you'll be able to see the others."
 msgstr ""
 
-#: src/olympia/devhub/views.py:183
+#: src/olympia/devhub/views.py:181
 msgid "All My Add-ons"
 msgstr ""
 
-#: src/olympia/devhub/views.py:210
+#: src/olympia/devhub/views.py:208
 msgid "All Activity"
 msgstr ""
 
-#: src/olympia/devhub/views.py:211
+#: src/olympia/devhub/views.py:209
 msgid "Add-on Updates"
 msgstr ""
 
-#: src/olympia/devhub/views.py:212
+#: src/olympia/devhub/views.py:210
 msgid "Add-on Status"
 msgstr ""
 
-#: src/olympia/devhub/views.py:213
+#: src/olympia/devhub/views.py:211
 msgid "User Collections"
 msgstr ""
 
-#: src/olympia/devhub/views.py:214 src/olympia/devhub/templates/devhub/docs/policies-maintenance.html:68 src/olympia/pages/templates/pages/dev_faq.html:38
+#: src/olympia/devhub/views.py:212 src/olympia/devhub/templates/devhub/docs/policies-maintenance.html:68 src/olympia/pages/templates/pages/dev_faq.html:38
 #: src/olympia/pages/templates/pages/dev_faq.html:484
 msgid "User Reviews"
 msgstr ""
 
-#: src/olympia/devhub/views.py:327 src/olympia/devhub/views.py:331 src/olympia/devhub/views.py:484 src/olympia/devhub/views.py:513 src/olympia/devhub/views.py:564 src/olympia/devhub/views.py:1150
+#: src/olympia/devhub/views.py:325 src/olympia/devhub/views.py:329 src/olympia/devhub/views.py:484 src/olympia/devhub/views.py:513 src/olympia/devhub/views.py:564 src/olympia/devhub/views.py:1156
 msgid "Changes successfully saved."
 msgstr ""
 
-#: src/olympia/devhub/views.py:334 src/olympia/devhub/views.py:1631
+#: src/olympia/devhub/views.py:332 src/olympia/devhub/views.py:1637
 msgid "Please check the form for errors."
 msgstr ""
 
-#: src/olympia/devhub/views.py:346
+#: src/olympia/devhub/views.py:344
 msgid "Add-on cannot be deleted. Disable this add-on instead."
 msgstr ""
 
-#: src/olympia/devhub/views.py:356
+#: src/olympia/devhub/views.py:354
 msgid "Theme deleted."
 msgstr ""
 
-#: src/olympia/devhub/views.py:356
+#: src/olympia/devhub/views.py:354
 msgid "Add-on deleted."
 msgstr ""
 
-#: src/olympia/devhub/views.py:362
+#: src/olympia/devhub/views.py:360
 msgid "URL name was incorrect. Theme was not deleted."
 msgstr ""
 
-#: src/olympia/devhub/views.py:367
+#: src/olympia/devhub/views.py:365
 msgid "URL name was incorrect. Add-on was not deleted."
 msgstr ""
 
@@ -3925,7 +3908,7 @@ msgstr ""
 msgid "Check Add-on Compatibility"
 msgstr ""
 
-#: src/olympia/devhub/views.py:808 src/olympia/signing/views.py:90
+#: src/olympia/devhub/views.py:808 src/olympia/signing/views.py:95
 msgid "You cannot submit this type of add-on"
 msgstr ""
 
@@ -3955,33 +3938,33 @@ msgstr ""
 msgid "There was an error uploading your preview."
 msgstr ""
 
-#: src/olympia/devhub/views.py:1189
+#: src/olympia/devhub/views.py:1195
 #, python-format
 msgid "Version %s disabled."
 msgstr ""
 
-#: src/olympia/devhub/views.py:1193
+#: src/olympia/devhub/views.py:1199
 #, python-format
 msgid "Version %s deleted."
 msgstr ""
 
-#: src/olympia/devhub/views.py:1203
+#: src/olympia/devhub/views.py:1209
 msgid "This upload has failed validation, and may lack complete validation results. Please take due care when reviewing it."
 msgstr ""
 
-#: src/olympia/devhub/views.py:1677
+#: src/olympia/devhub/views.py:1683
 msgid "Preliminary Review Requested."
 msgstr ""
 
-#: src/olympia/devhub/views.py:1678
+#: src/olympia/devhub/views.py:1684
 msgid "Full Review Requested."
 msgstr ""
 
-#: src/olympia/devhub/views.py:1779
+#: src/olympia/devhub/views.py:1783
 msgid "Your old credentials were revoked and are no longer valid. Be sure to update all API clients with the new credentials."
 msgstr ""
 
-#: src/olympia/devhub/views.py:1797
+#: src/olympia/devhub/views.py:1801
 msgid "New API key created"
 msgstr ""
 
@@ -4011,7 +3994,7 @@ msgstr ""
 msgid "{0} :: Search"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/devhub_search.html:6 src/olympia/devhub/templates/devhub/search.html:8 src/olympia/editors/forms.py:435 src/olympia/editors/forms.py:437
+#: src/olympia/devhub/templates/devhub/devhub_search.html:6 src/olympia/devhub/templates/devhub/search.html:8 src/olympia/editors/forms.py:534 src/olympia/editors/forms.py:536
 #: src/olympia/editors/templates/editors/queue.html:27 src/olympia/editors/templates/editors/themes/queue_list.html:14 src/olympia/search/templates/search/collections.html:17
 #: src/olympia/search/templates/search/personas.html:18 src/olympia/search/templates/search/results.html:18 src/olympia/search/templates/search/mobile/results.html:8
 #: src/olympia/templates/search.html:14 src/olympia/templates/impala/search.html:18
@@ -4071,12 +4054,12 @@ msgstr ""
 msgid "Start Making Add-ons"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/index.html:86 src/olympia/devhub/templates/devhub/addons/listing/items.html:25 src/olympia/devhub/templates/devhub/includes/addon_details.html:15
+#: src/olympia/devhub/templates/devhub/index.html:86 src/olympia/devhub/templates/devhub/addons/listing/items.html:25 src/olympia/devhub/templates/devhub/includes/addon_details.html:20
 #: src/olympia/devhub/templates/devhub/personas/edit.html:43
 msgid "Status:"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/index.html:90 src/olympia/devhub/templates/devhub/includes/addon_details.html:100
+#: src/olympia/devhub/templates/devhub/index.html:90 src/olympia/devhub/templates/devhub/includes/addon_details.html:87
 msgid "Visibility:"
 msgstr ""
 
@@ -4084,11 +4067,11 @@ msgstr ""
 msgid "Latest Version:"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/index.html:109 src/olympia/devhub/templates/devhub/includes/addon_details.html:145 src/olympia/devhub/templates/devhub/personas/edit.html:49
+#: src/olympia/devhub/templates/devhub/index.html:109 src/olympia/devhub/templates/devhub/includes/addon_details.html:131 src/olympia/devhub/templates/devhub/personas/edit.html:49
 msgid "Queue Position:"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/index.html:110 src/olympia/devhub/templates/devhub/includes/addon_details.html:146 src/olympia/devhub/templates/devhub/personas/edit.html:50
+#: src/olympia/devhub/templates/devhub/index.html:110 src/olympia/devhub/templates/devhub/includes/addon_details.html:132 src/olympia/devhub/templates/devhub/personas/edit.html:50
 #, python-format
 msgid "%(position)s of %(total)s"
 msgstr ""
@@ -4190,16 +4173,6 @@ msgstr ""
 msgid "Do you want your add-on to be distributed on this site?"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/validate_addon.html:49 src/olympia/devhub/templates/devhub/addons/submit/upload.html:30 src/olympia/devhub/templates/devhub/versions/add_file_modal.html:14
-#: src/olympia/devhub/templates/devhub/versions/add_file_modal.html:53 src/olympia/devhub/templates/devhub/versions/list.html:298
-msgid "Warning:"
-msgstr ""
-
-#: src/olympia/devhub/templates/devhub/validate_addon.html:50 src/olympia/devhub/templates/devhub/addons/submit/upload.html:31
-#, python-format
-msgid "Submission of unlisted add-ons for signing is currently in an open beta. Please <a href=\"%(url)s\" target=\"_blank\">report any bugs</a> that you encounter."
-msgstr ""
-
 #. first parameter is a filename like lorem-ipsum-1.0.2.xpi
 #: src/olympia/devhub/templates/devhub/validation.html:5
 msgid "Validation Results for {0}"
@@ -4274,7 +4247,7 @@ msgstr ""
 msgid "Update Compatibility"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/addons/ajax_compat_update.html:4
+#: src/olympia/devhub/templates/devhub/addons/ajax_compat_update.html:4 src/olympia/devhub/templates/devhub/versions/edit.html:45
 msgid "Adjusting application information here will allow users to install your add-on even if the install manifest in the package indicates that the add-on is incompatible."
 msgstr ""
 
@@ -4286,9 +4259,9 @@ msgstr ""
 msgid "Add Another Application&hellip;"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/addons/ajax_compat_update.html:38 src/olympia/devhub/templates/devhub/addons/owner.html:86 src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:46
-#: src/olympia/devhub/templates/devhub/versions/list.html:351 src/olympia/devhub/templates/devhub/versions/list.html:353 src/olympia/templates/impala/base.html:132
-#: src/olympia/templates/impala/base.html:143 src/olympia/templates/impala/base.html:161 src/olympia/templates/impala/base.html:171
+#: src/olympia/devhub/templates/devhub/addons/ajax_compat_update.html:38 src/olympia/devhub/templates/devhub/addons/owner.html:86 src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:45
+#: src/olympia/devhub/templates/devhub/versions/list.html:349 src/olympia/devhub/templates/devhub/versions/list.html:351 src/olympia/templates/impala/base.html:129
+#: src/olympia/templates/impala/base.html:140 src/olympia/templates/impala/base.html:158 src/olympia/templates/impala/base.html:168
 msgid "Close"
 msgstr ""
 
@@ -4322,7 +4295,7 @@ msgstr ""
 msgid "Manage Authors & License"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/addons/owner.html:29 src/olympia/editors/templates/editors/review.html:270
+#: src/olympia/devhub/templates/devhub/addons/owner.html:29 src/olympia/editors/helpers.py:362 src/olympia/editors/templates/editors/review.html:270
 msgid "Authors"
 msgstr ""
 
@@ -4391,17 +4364,11 @@ msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/basic.html:52
 msgid ""
-"A short explanation of your add-on's basic\n"
-"                          functionality that is displayed in search and browse\n"
-"                          listings, as well as at the top of your add-on's\n"
-"                          details page. It is only relevant for listed add-ons."
+"A short explanation of your add-on's basic functionality that is displayed in search and browse listings, as well as at the top of your add-on's details page. It is only relevant for listed add-ons."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/basic.html:73
-msgid ""
-"Categories are the primary way users browse through add-ons.\n"
-"                        Choose any that fit your add-on's functionality for the most\n"
-"                        exposure. It is only relevant for listed add-ons."
+msgid "Categories are the primary way users browse through add-ons. Choose any that fit your add-on's functionality for the most exposure. It is only relevant for listed add-ons."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/basic.html:90
@@ -4411,11 +4378,7 @@ msgid ""
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/basic.html:119
-msgid ""
-"Tags help users find your add-on and should be short\n"
-"                        descriptors such as tabs, toolbar, or twitter.  You\n"
-"                        may have a maximum of {0} tags. It is only relevant\n"
-"                        for listed add-ons."
+msgid "Tags help users find your add-on and should be short descriptors such as tabs, toolbar, or twitter. You may have a maximum of {0} tags. It is only relevant for listed add-ons."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/basic.html:129 src/olympia/devhub/templates/devhub/personas/edit.html:97 src/olympia/devhub/templates/devhub/personas/submit.html:46
@@ -4443,11 +4406,7 @@ msgid "Add-on Details for {0}"
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/details.html:22
-msgid ""
-"A longer explanation of features,\n"
-"                          functionality, and other relevant information. This\n"
-"                          field is only displayed on the add-on's details\n"
-"                          page. It is only relevant for listed add-ons."
+msgid "A longer explanation of features, functionality, and other relevant information. This field is only displayed on the add-on's details page. It is only relevant for listed add-ons."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/details.html:44 src/olympia/translations/templates/translations/trans-menu.html:13
@@ -4455,10 +4414,7 @@ msgid "Default Locale"
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/details.html:45
-msgid ""
-"Information about your add-on is displayed in this locale\n"
-"                        unless you override it with a locale-specific translation.\n"
-"                        It is only relevant for listed add-ons."
+msgid "Information about your add-on is displayed in this locale unless you override it with a locale-specific translation. It is only relevant for listed add-ons."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/details.html:61 src/olympia/users/forms.py:311 src/olympia/users/templates/users/edit.html:122 src/olympia/users/templates/users/register.html:57
@@ -4468,10 +4424,8 @@ msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/details.html:63
 msgid ""
-"If your add-on has another homepage, enter its\n"
-"                          address here. If your website is localized into other\n"
-"                          languages multiple translations of this field can be\n"
-"                          added. It is only relevant for listed add-ons."
+"If your add-on has another homepage, enter its address here. If your website is localized into other languages multiple translations of this field can be added. It is only relevant for listed add-"
+"ons."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/media.html:3
@@ -4489,19 +4443,14 @@ msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/support.html:22
 msgid ""
-"If you wish to display an e-mail address for support\n"
-"                          inquiries, enter it here. If you have different\n"
-"                          addresses for each language multiple translations of\n"
-"                          this field can be added. It is only relevant for\n"
-"                          listed add-ons."
+"If you wish to display an e-mail address for support inquiries, enter it here. If you have different addresses for each language multiple translations of this field can be added. It is only "
+"relevant for listed add-ons."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/support.html:45
 msgid ""
-"If your add-on has a support website or forum, enter\n"
-"                          its address here. If your website is localized into\n"
-"                          other languages, multiple translations of this field can\n"
-"                          be added. It is only relevant for listed add-ons."
+"If your add-on has a support website or forum, enter its address here. If your website is localized into other languages, multiple translations of this field can be added. It is only relevant for "
+"listed add-ons."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:6
@@ -4515,11 +4464,8 @@ msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:23
 msgid ""
-"Any information end users may want to know that isn't\n"
-"                          necessarily applicable to the add-on summary or description.\n"
-"                          Common uses include listing known major bugs, information on\n"
-"                          how to report bugs, anticipated release date of a new version,\n"
-"                          etc. It is only relevant for listed add-ons."
+"Any information end users may want to know that isn't necessarily applicable to the add-on summary or description. Common uses include listing known major bugs, information on how to report bugs, "
+"anticipated release date of a new version, etc. It is only relevant for listed add-ons."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:46
@@ -4531,9 +4477,7 @@ msgid "Add-on Flags"
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:69
-msgid ""
-"These flags are used to classify add-ons. It is only\n"
-"                        relevant for listed add-ons."
+msgid "These flags are used to classify add-ons. It is only relevant for listed add-ons."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:74
@@ -4549,9 +4493,7 @@ msgid "View Source?"
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:90
-msgid ""
-"Whether the source of your add-on can be displayed in our\n"
-"                        online viewer. It is only relevant for listed add-ons."
+msgid "Whether the source of your add-on can be displayed in our online viewer. It is only relevant for listed add-ons."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:94
@@ -4567,10 +4509,7 @@ msgid "Public Stats?"
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:102
-msgid ""
-"Whether the download and usage stats of your add-on can\n"
-"                        be displayed in our online viewer.\n"
-"                        It is only relevant for listed add-ons."
+msgid "Whether the download and usage stats of your add-on can be displayed in our online viewer. It is only relevant for listed add-ons."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:107
@@ -4586,10 +4525,7 @@ msgid "Upgrade SDK?"
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:116
-msgid ""
-"If selected, we will try to automatically upgrade your\n"
-"                        add-on when a new version of the SDK is released.\n"
-"                        It is only relevant for listed add-ons."
+msgid "If selected, we will try to automatically upgrade your add-on when a new version of the SDK is released. It is only relevant for listed add-ons."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:121
@@ -4640,10 +4576,8 @@ msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/forms_shared/media.html:16
 msgid ""
-"Upload an icon for your add-on or choose from one of ours. The\n"
-"                      icon is displayed nearly everywhere your add-on is. Uploaded images\n"
-"                      must be one of the following image types: .png, .jpg.\n"
-"                      It is only relevant for listed add-ons."
+"Upload an icon for your add-on or choose from one of ours. The icon is displayed nearly everywhere your add-on is. Uploaded images must be one of the following image types: .png, .jpg. It is only "
+"relevant for listed add-ons."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/forms_shared/media.html:25
@@ -4656,9 +4590,7 @@ msgid "32x32px"
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/forms_shared/media.html:39
-msgid ""
-"Used in listings of add-ons, like search results\n"
-"                            and featured add-ons."
+msgid "Used in listings of add-ons, like search results and featured add-ons."
 msgstr ""
 
 #. The size of the icon
@@ -4753,16 +4685,14 @@ msgid "Deleting your add-on will permanently remove it from the site and prevent
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:24
-msgid ""
-"Enter the following text confirm your decision:\n"
-"           {slug}"
+msgid "Enter the following text confirm your decision: {slug}"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:34
+#: src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:33
 msgid "Please tell us why you are deleting your theme:"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:36
+#: src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:35
 msgid "Please tell us why you are deleting your add-on:"
 msgstr ""
 
@@ -4799,8 +4729,8 @@ msgstr ""
 msgid "Daily statistics on downloads and users."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/addons/listing/item_actions.html:45 src/olympia/stats/templates/stats/stats.html:75 src/olympia/stats/templates/stats/stats.html:79
-#: src/olympia/stats/templates/stats/stats.html:81
+#: src/olympia/devhub/templates/devhub/addons/listing/item_actions.html:45 src/olympia/stats/templates/stats/stats.html:31 src/olympia/stats/templates/stats/stats.html:35
+#: src/olympia/stats/templates/stats/stats.html:37
 msgid "Statistics"
 msgstr ""
 
@@ -4919,10 +4849,7 @@ msgid "Your add-on has been submitted to the Full Review queue."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/submit/done.html:18
-msgid ""
-"You'll receive an email once it has been reviewed by an editor. In\n"
-"          the meantime, you and your friends can install it directly from its\n"
-"          details page:"
+msgid "You'll receive an email once it has been reviewed by an editor. In the meantime, you and your friends can install it directly from its details page:"
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/submit/done.html:27 src/olympia/devhub/templates/devhub/addons/submit/done.html:77 src/olympia/devhub/templates/devhub/personas/submit_done.html:16
@@ -5128,11 +5055,11 @@ msgstr ""
 msgid "Use the fields below to upload your add-on package and select any platform restrictions. After upload, a series of automated validation tests will be run on your file."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/addons/submit/upload.html:59 src/olympia/devhub/templates/devhub/versions/add_file_modal.html:39
+#: src/olympia/devhub/templates/devhub/addons/submit/upload.html:51 src/olympia/devhub/templates/devhub/versions/add_file_modal.html:28
 msgid "Which platforms is this file compatible with?"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/addons/submit/upload.html:67 src/olympia/devhub/templates/devhub/versions/add_file_modal.html:65
+#: src/olympia/devhub/templates/devhub/addons/submit/upload.html:59 src/olympia/devhub/templates/devhub/versions/add_file_modal.html:45
 msgid "Administrative overrides"
 msgstr ""
 
@@ -5242,8 +5169,8 @@ msgstr ""
 
 #: src/olympia/devhub/templates/devhub/docs/policies-contact.html:44
 msgid ""
-"If you've found a problem with the site, we'd love to fix it. Please <a href=\"https://github.com/mozilla/olympia/issues\">file a bug report</a> in GitHub, including the location of the problem and "
-"how you encountered it."
+"If you've found a problem with the site, we'd love to fix it. Please <a href=\"https://github.com/mozilla/addons/issues/new\">file a bug report</a> in GitHub, including the location of the problem "
+"and how you encountered it."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/docs/policies-maintenance.html:3 src/olympia/devhub/templates/devhub/docs/policies-maintenance.html:7
@@ -5810,7 +5737,7 @@ msgstr ""
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:282
 msgid ""
-"Add-ons that store or otherwise handle browsing data must support <a href=\"https://developer.mozilla.org/En/Supporting_private_browsing_mode\">Private Browsing Mode</a>.  During a Private Browsing "
+"Add-ons that store or otherwise handle browsing data must support <a href=\"https://developer.mozilla.org/En/Supporting_private_browsing_mode\">Private Browsing Mode</a>. During a Private Browsing "
 "session, no browsing data can be written to disk, and all of this data must be cleared when Firefox quits or the Private Browsing session ends."
 msgstr ""
 
@@ -5975,129 +5902,95 @@ msgstr ""
 msgid "How to get in touch with us regarding these policies or your add-on."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:6
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:10
 msgid "You have disabled this add-on"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:20
-msgid ""
-"Your add-on's listing is disabled and is not showing\n"
-"                             anywhere in our gallery or update service."
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:24
+msgid "Your add-on's listing is disabled and is not showing anywhere in our gallery or update service."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:25
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:27
 msgid "Please complete your add-on."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:29
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:30
 msgid "You will receive an email when the review is complete."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:34
-msgid ""
-"You will receive an email when the review is complete. Until\n"
-"                             then, your add-on is not listed in our gallery but can be\n"
-"                             accessed directly from its details page."
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:33
+msgid "You will receive an email when the review is complete. Until then, your add-on is not listed in our gallery but can be accessed directly from its details page."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:38 src/olympia/devhub/templates/devhub/includes/addon_details.html:48
-msgid ""
-"You will receive an email when the review is\n"
-"                             complete and your add-on is signed."
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:37 src/olympia/devhub/templates/devhub/includes/addon_details.html:45
+msgid "You will receive an email when the review is complete and your add-on is signed."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:44
-msgid ""
-"You will receive an email when the review is complete. Until\n"
-"                             then, your add-on is not listed in our gallery but can be\n"
-"                             accessed directly from its details page. "
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:41
+msgid "You will receive an email when the review is complete. Until then, your add-on is not listed in our gallery but can be accessed directly from its details page. "
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:54
-msgid ""
-"Your add-on is displayed in our gallery and users are\n"
-"                             receiving automatic updates."
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:49
+msgid "Your add-on is displayed in our gallery and users are receiving automatic updates."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:57
-msgid ""
-"Your add-on has been signed and can be bundled with an\n"
-"                             application installer."
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:52
+msgid "Your add-on has been signed and can be bundled with an application installer."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:63
-msgid ""
-"Your add-on was disabled by a site administrator and is no\n"
-"                             longer shown in our gallery. If you have any questions,\n"
-"                             please email amo-admins@mozilla.org."
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:56
+msgid "Your add-on was disabled by a site administrator and is no longer shown in our gallery. If you have any questions, please email amo-admins@mozilla.org."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:70
-msgid ""
-"Your add-on is displayed in our gallery as experimental\n"
-"                             and users are receiving automatic updates. Some features\n"
-"                             are unavailable to your add-on."
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:62
+msgid "Your add-on is displayed in our gallery as experimental and users are receiving automatic updates. Some features are unavailable to your add-on."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:74
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:66
 msgid "Your add-on has been signed."
 msgstr ""
 
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:69
+msgid ""
+"You will receive an email when the full review is complete. Until then, your add-on is displayed in our gallery as experimental and users are receiving automatic updates. Some features are "
+"unavailable to your add-on."
+msgstr ""
+
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:74
+msgid "You will receive an email when the full review is complete, making you able to bundle your add-on with an application installer."
+msgstr ""
+
 #: src/olympia/devhub/templates/devhub/includes/addon_details.html:79
-msgid ""
-"You will receive an email when the full review is complete.\n"
-"                             Until then, your add-on is displayed in our gallery as\n"
-"                             experimental and users are receiving automatic updates.\n"
-"                             Some features are unavailable to your add-on."
+msgid "All add-ons hosted in our gallery must now be reviewed by an editor. If you wish to continue hosting your add-on, please click to select a review process."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:84
-msgid ""
-"You will receive an email when the full review is\n"
-"                             complete, making you able to bundle your add-on with an\n"
-"                             application installer."
-msgstr ""
-
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:91
-msgid ""
-"All add-ons hosted in our gallery must now be reviewed by an\n"
-"                             editor. If you wish to continue hosting your add-on, please\n"
-"                             click to select a review process."
-msgstr ""
-
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:113
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:100
 msgid "Current Version:"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:115
-msgid ""
-"This is the version of your add-on that will\n"
-"                                           be installed if someone clicks the Install\n"
-"                                           button on addons.mozilla.org. It is only\n"
-"                                           relevant for listed add-ons."
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:102
+msgid "This is the version of your add-on that will be installed if someone clicks the Install button on addons.mozilla.org. It is only relevant for listed add-ons."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:123
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:110
 msgid "Created:"
 msgstr ""
 
 #. {0} is a date. dennis-ignore: E201
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:125 src/olympia/devhub/templates/devhub/includes/addon_details.html:131
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:112 src/olympia/devhub/templates/devhub/includes/addon_details.html:118
 #, python-format
 msgid "%%b %%e, %%Y"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:136
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:123
 msgid "Next Version:"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:138
-msgid ""
-"This is the newest uploaded version, however\n"
-"                                           it isn’t live on the site yet."
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:125
+msgid "This is the newest uploaded version, however it isn’t live on the site yet."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:144 src/olympia/devhub/templates/devhub/versions/list.html:30
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:130 src/olympia/devhub/templates/devhub/versions/list.html:30
 msgid "Queues are not reviewed strictly in order"
 msgstr ""
 
@@ -6165,9 +6058,7 @@ msgid "View the blog &#9658;"
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/includes/license_form.html:6
-msgid ""
-"Please choose a license appropriate for the rights you grant on your source code.\n"
-"                  It is only relevant for listed add-ons."
+msgid "Please choose a license appropriate for the rights you grant on your source code. It is only relevant for listed add-ons."
 msgstr ""
 
 #. {0} is a list of HTML tags.
@@ -6194,14 +6085,11 @@ msgstr[1] ""
 #: src/olympia/devhub/templates/devhub/includes/policy_form.html:4
 msgid ""
 "Users will be required to accept the following End-User License Agreement (EULA) prior to installing your add-on. The presence of a EULA significantly affects the number of downloads an add-on "
-"receives. Please note that a EULA is not the same as a code license, such as the GPL or MPL.\n"
-"                It is only relevant for listed add-ons."
+"receives. Please note that a EULA is not the same as a code license, such as the GPL or MPL.It is only relevant for listed add-ons."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/policy_form.html:21
-msgid ""
-"If your add-on transmits any data from the user's computer, a privacy policy is required that explains what data is sent and how it is used.\n"
-"                It is only relevant for listed add-ons."
+#: src/olympia/devhub/templates/devhub/includes/policy_form.html:24
+msgid "If your add-on transmits any data from the user's computer, a privacy policy is required that explains what data is sent and how it is used. It is only relevant for listed add-ons."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/includes/source_form_field.html:2
@@ -6369,12 +6257,8 @@ msgstr ""
 msgid "Add some tags to describe your Theme."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/personas/edit.html:106
-msgid ""
-"A short explanation of your theme's\n"
-"                                basic functionality that is displayed in\n"
-"                                search and browse listings, as well as at\n"
-"                                the top of your theme's details page."
+#: src/olympia/devhub/templates/devhub/personas/edit.html:106 src/olympia/devhub/templates/devhub/personas/submit.html:54
+msgid "A short explanation of your theme's basic functionality that is displayed in search and browse listings, as well as at the top of your theme's details page."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/personas/edit.html:122 src/olympia/devhub/templates/devhub/personas/submit.html:68
@@ -6444,7 +6328,7 @@ msgid "Upon upload and form submission, the AMO Team will review your updated de
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/personas/edit.html:241
-msgid "Your previously resubmitted design,  which is under pending review."
+msgid "Your previously resubmitted design, which is under pending review."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/personas/edit.html:245
@@ -6511,14 +6395,6 @@ msgstr ""
 
 #: src/olympia/devhub/templates/devhub/personas/submit.html:33
 msgid "Give your Theme a name."
-msgstr ""
-
-#: src/olympia/devhub/templates/devhub/personas/submit.html:54
-msgid ""
-"A short explanation of your theme's\n"
-"                                      basic functionality that is displayed in\n"
-"                                      search and browse listings, as well as at\n"
-"                                      the top of your theme's details page."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/personas/submit.html:198
@@ -6595,30 +6471,16 @@ msgstr ""
 msgid "Files added to reviewed versions must be reviewed before they will be available for download."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/add_file_modal.html:15
-#, python-format
-msgid ""
-"Submission of updates to unlisted add-ons for signing is currently in an open beta. Manual review may still be required for a large number of add-ons. Please <a href=\"%(url)s\" target=\"_blank"
-"\">report any bugs</a> that you encounter."
-msgstr ""
-
-#: src/olympia/devhub/templates/devhub/versions/add_file_modal.html:35
+#: src/olympia/devhub/templates/devhub/versions/add_file_modal.html:24
 msgid "Select the target platform for this file."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/add_file_modal.html:46
+#: src/olympia/devhub/templates/devhub/versions/add_file_modal.html:35
 msgid "Which review type would you like to nominate for?"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/add_file_modal.html:51
+#: src/olympia/devhub/templates/devhub/versions/add_file_modal.html:40
 msgid "Only publish this version to my beta channel."
-msgstr ""
-
-#: src/olympia/devhub/templates/devhub/versions/add_file_modal.html:54
-#, python-format
-msgid ""
-"The behavior of the beta channel has changed to accommodate <a href=\"%(addon_signing_url)s\" target=\"_blank\">mandatory add-on signing</a>. The new process is currently in an open beta, and may "
-"change significantly in the near future. Please <a href=\"%(issues_url)s\" target=\"_blank\">report any bugs</a> that you encounter."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/versions/edit.html:5
@@ -6642,19 +6504,10 @@ msgstr ""
 msgid "Upload Another File"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/edit.html:45
-msgid ""
-"Adjusting application information here will allow users to install your\n"
-"                          add-on even if the install manifest in the package indicates that the\n"
-"                          add-on is incompatible."
-msgstr ""
-
 #: src/olympia/devhub/templates/devhub/versions/edit.html:74
 msgid ""
-"Information about changes in this release, new features,\n"
-"                              known bugs, and other useful information specific to this\n"
-"                              release/version. This information is also shown in the\n"
-"                              Add-ons Manager when updating."
+"Information about changes in this release, new features, known bugs, and other useful information specific to this release/version. This information is also shown in the Add-ons Manager when "
+"updating."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/versions/edit.html:99
@@ -6666,10 +6519,7 @@ msgid "Notes for Reviewers"
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/versions/edit.html:114
-msgid ""
-"Optionally, enter any information that may be useful\n"
-"                              to the Editor reviewing this add-on, such as test\n"
-"                              account information."
+msgid "Optionally, enter any information that may be useful to the Editor reviewing this add-on, such as test account information."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/versions/edit.html:127
@@ -6747,7 +6597,7 @@ msgstr ""
 msgid "Request Preliminary Review"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:80 src/olympia/devhub/templates/devhub/versions/list.html:327 src/olympia/devhub/templates/devhub/versions/list.html:350
+#: src/olympia/devhub/templates/devhub/versions/list.html:80 src/olympia/devhub/templates/devhub/versions/list.html:325 src/olympia/devhub/templates/devhub/versions/list.html:348
 msgid "Cancel Review Request"
 msgstr ""
 
@@ -6776,7 +6626,7 @@ msgid "Unlisted:"
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/versions/list.html:114
-msgid "Not distributed on {0}. Developers will upload new versions for signing and distribute the add-ons on their own. (beta)"
+msgid "Not distributed on {0}. Developers will upload new versions for signing and distribute the add-ons on their own."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/versions/list.html:122
@@ -6839,81 +6689,73 @@ msgid "<strong>Important:</strong> Once a version has been deleted, you may not 
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/versions/list.html:230
-msgid ""
-"Deleting a version which has already been reviewed\n"
-"               may also cause a significant delay in the review of\n"
-"               your next update."
-msgstr ""
-
-#: src/olympia/devhub/templates/devhub/versions/list.html:233
 msgid "Are you sure you wish to delete this version?"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:238
+#: src/olympia/devhub/templates/devhub/versions/list.html:235
 msgid "Delete Version"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:240
+#: src/olympia/devhub/templates/devhub/versions/list.html:237
 msgid "Disable Version"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:247
+#: src/olympia/devhub/templates/devhub/versions/list.html:244
 msgid "Add a new Version"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:249
+#: src/olympia/devhub/templates/devhub/versions/list.html:246
 msgid "Add Version"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:256 src/olympia/devhub/templates/devhub/versions/list.html:274
+#: src/olympia/devhub/templates/devhub/versions/list.html:253 src/olympia/devhub/templates/devhub/versions/list.html:279
 msgid "Hide Add-on"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:259
+#: src/olympia/devhub/templates/devhub/versions/list.html:256
 msgid "Hiding your add-on will prevent it from appearing anywhere in our gallery and will stop users from receiving automatic updates."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:265
+#: src/olympia/devhub/templates/devhub/versions/list.html:263
+msgid "The files awaiting review will be disabled and you will need to upload new versions."
+msgstr ""
+
+#: src/olympia/devhub/templates/devhub/versions/list.html:270
 msgid "Are you sure you wish to hide your add-on?"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:286 src/olympia/devhub/templates/devhub/versions/list.html:315
+#: src/olympia/devhub/templates/devhub/versions/list.html:291 src/olympia/devhub/templates/devhub/versions/list.html:313
 msgid "Unlist Add-on"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:289
+#: src/olympia/devhub/templates/devhub/versions/list.html:294
 #, python-format
 msgid ""
 "Unlisting your add-on will make it (and each of its versions/files) invisible on this website. It won't show up in searches, won't have a public facing page, and won't be updated automatically for "
-"current users.  It is recommended for unlisted add-ons to provide a custom <a href=\"%(update_url)s\" target=\"_blank\">updateURL</a> in their manifest file for automatic updates."
+"current users. It is recommended for unlisted add-ons to provide a custom <a href=\"%(update_url)s\" target=\"_blank\">updateURL</a> in their manifest file for automatic updates."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:299
-#, python-format
-msgid "Switching add-ons to unlisted is currently in an open beta. Please <a href=\"%(url)s\" target=\"_blank\">report any bugs</a> that you encounter."
-msgstr ""
-
-#: src/olympia/devhub/templates/devhub/versions/list.html:305
+#: src/olympia/devhub/templates/devhub/versions/list.html:303
 msgid "Unlisting an add-on is irreversible!"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:305
+#: src/olympia/devhub/templates/devhub/versions/list.html:303
 msgid "An unlisted add-on cannot be switched to be listed."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:307
+#: src/olympia/devhub/templates/devhub/versions/list.html:305
 msgid "Are you sure you wish to unlist your add-on?"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:330
+#: src/olympia/devhub/templates/devhub/versions/list.html:328
 msgid "Canceling your review request will leave your add-on as preliminarily reviewed."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:335
+#: src/olympia/devhub/templates/devhub/versions/list.html:333
 msgid "Canceling your review request will mark your add-on incomplete. If you do not complete your add-on after several days by re-requesting review, it will be deleted."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:343
+#: src/olympia/devhub/templates/devhub/versions/list.html:341
 msgid "Are you sure you wish to cancel your review request?"
 msgstr ""
 
@@ -7252,19 +7094,19 @@ msgstr ""
 msgid "Search by add-on name / author email"
 msgstr ""
 
-#: src/olympia/editors/forms.py:103
+#: src/olympia/editors/forms.py:103 src/olympia/editors/forms.py:244 src/olympia/editors/forms.py:257
 msgid "yes"
 msgstr ""
 
-#: src/olympia/editors/forms.py:104
+#: src/olympia/editors/forms.py:104 src/olympia/editors/forms.py:244 src/olympia/editors/forms.py:257
 msgid "no"
 msgstr ""
 
-#: src/olympia/editors/forms.py:105
+#: src/olympia/editors/forms.py:105 src/olympia/editors/forms.py:245
 msgid "Admin Flag"
 msgstr ""
 
-#: src/olympia/editors/forms.py:113
+#: src/olympia/editors/forms.py:113 src/olympia/editors/forms.py:253
 msgid "Max. Version"
 msgstr ""
 
@@ -7276,55 +7118,59 @@ msgstr ""
 msgid "Add-on Types"
 msgstr ""
 
-#: src/olympia/editors/forms.py:126 src/olympia/editors/helpers.py:267
+#: src/olympia/editors/forms.py:126 src/olympia/editors/helpers.py:279
 msgid "Platforms"
 msgstr ""
 
+#: src/olympia/editors/forms.py:237
+msgid "Search by add-on name / author email / guid"
+msgstr ""
+
 #. L10n: 0 = platform, 1 = filename, 2 = status message
-#: src/olympia/editors/forms.py:238
+#: src/olympia/editors/forms.py:342
 #, python-format
 msgid "<strong>%s</strong> &middot; %s &middot; %s"
 msgstr ""
 
-#: src/olympia/editors/forms.py:252
+#: src/olympia/editors/forms.py:356
 msgid "Comments:"
 msgstr ""
 
-#: src/olympia/editors/forms.py:256
+#: src/olympia/editors/forms.py:360
 msgid "Operating systems:"
 msgstr ""
 
-#: src/olympia/editors/forms.py:258
+#: src/olympia/editors/forms.py:362
 msgid "Applications:"
 msgstr ""
 
-#: src/olympia/editors/forms.py:260
+#: src/olympia/editors/forms.py:364
 msgid "Notify me the next time this add-on is updated. (Subsequent updates will not generate an email)"
 msgstr ""
 
-#: src/olympia/editors/forms.py:265
+#: src/olympia/editors/forms.py:369
 msgid "Clear Admin Review Flag"
 msgstr ""
 
-#: src/olympia/editors/forms.py:267
+#: src/olympia/editors/forms.py:371
 msgid "Clear more info requested flag"
 msgstr ""
 
-#: src/olympia/editors/forms.py:281
+#: src/olympia/editors/forms.py:385
 msgid "Choose a canned response..."
 msgstr ""
 
 #. L10n: Description of what can be searched for.
-#: src/olympia/editors/forms.py:324
+#: src/olympia/editors/forms.py:423
 msgid "theme name"
 msgstr ""
 
-#: src/olympia/editors/forms.py:350
+#: src/olympia/editors/forms.py:449
 msgid "Someone else is reviewing this theme."
 msgstr ""
 
 #. L10n: Description of what can be searched for.
-#: src/olympia/editors/forms.py:447
+#: src/olympia/editors/forms.py:546
 msgid "app, reviewer, or comment"
 msgstr ""
 
@@ -7340,246 +7186,264 @@ msgstr ""
 msgid "Rejected or Unreviewed"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:123 src/olympia/editors/helpers.py:136
+#: src/olympia/editors/helpers.py:125 src/olympia/editors/helpers.py:138
 msgid "Queue"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:124 src/olympia/editors/templates/editors/base.html:50 src/olympia/editors/templates/editors/base.html:65
+#: src/olympia/editors/helpers.py:126 src/olympia/editors/templates/editors/base.html:50 src/olympia/editors/templates/editors/base.html:65
 msgid "Pending Updates"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:125 src/olympia/editors/templates/editors/base.html:48 src/olympia/editors/templates/editors/base.html:63
+#: src/olympia/editors/helpers.py:127 src/olympia/editors/templates/editors/base.html:48 src/olympia/editors/templates/editors/base.html:63
 msgid "Full Reviews"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:126 src/olympia/editors/templates/editors/base.html:52 src/olympia/editors/templates/editors/base.html:67
+#: src/olympia/editors/helpers.py:128 src/olympia/editors/templates/editors/base.html:52 src/olympia/editors/templates/editors/base.html:67
 msgid "Preliminary Reviews"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:127 src/olympia/editors/templates/editors/base.html:54
+#: src/olympia/editors/helpers.py:129 src/olympia/editors/templates/editors/base.html:54
 msgid "Moderated Reviews"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:128 src/olympia/editors/templates/editors/base.html:46
+#: src/olympia/editors/helpers.py:130 src/olympia/editors/templates/editors/base.html:46
 msgid "Fast Track"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:130
+#: src/olympia/editors/helpers.py:132
 msgid "Pending Themes"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:131 src/olympia/editors/templates/editors/themes/queue.html:4
+#: src/olympia/editors/helpers.py:133 src/olympia/editors/templates/editors/themes/queue.html:4
 msgid "Flagged Themes"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:132
+#: src/olympia/editors/helpers.py:134
 msgid "Update Themes"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:137
+#: src/olympia/editors/helpers.py:139
 msgid "Unlisted Pending Updates"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:138
+#: src/olympia/editors/helpers.py:140
 msgid "Unlisted Full Reviews"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:139
+#: src/olympia/editors/helpers.py:141
 msgid "Unlisted Preliminary Reviews"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:170
+#: src/olympia/editors/helpers.py:142
+msgid "Unlisted All Add-ons"
+msgstr ""
+
+#: src/olympia/editors/helpers.py:173
 msgid "Fast Track ({0})"
 msgid_plural "Fast Track ({0})"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/olympia/editors/helpers.py:175
+#: src/olympia/editors/helpers.py:178
 msgid "Full Review ({0})"
 msgid_plural "Full Reviews ({0})"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/olympia/editors/helpers.py:180
+#: src/olympia/editors/helpers.py:183
 msgid "Pending Update ({0})"
 msgid_plural "Pending Updates ({0})"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/olympia/editors/helpers.py:185
+#: src/olympia/editors/helpers.py:188
 msgid "Preliminary Review ({0})"
 msgid_plural "Preliminary Reviews ({0})"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/olympia/editors/helpers.py:190
+#: src/olympia/editors/helpers.py:193
 msgid "Moderated Review ({0})"
 msgid_plural "Moderated Reviews ({0})"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/olympia/editors/helpers.py:196
+#: src/olympia/editors/helpers.py:199
 msgid "Unlisted Full Review ({0})"
 msgid_plural "Unlisted Full Reviews ({0})"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/olympia/editors/helpers.py:201
+#: src/olympia/editors/helpers.py:204
 msgid "Unlisted Pending Update ({0})"
 msgid_plural "Unlisted Pending Updates ({0})"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/olympia/editors/helpers.py:206
+#: src/olympia/editors/helpers.py:209
 msgid "Unlisted Preliminary Review ({0})"
 msgid_plural "Unlisted Preliminary Reviews ({0})"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/olympia/editors/helpers.py:261
-msgid "Addon"
-msgstr ""
+#: src/olympia/editors/helpers.py:214
+msgid "Unlisted All Add-ons ({0})"
+msgid_plural "Unlisted All Add-ons ({0})"
+msgstr[0] ""
+msgstr[1] ""
 
-#: src/olympia/editors/helpers.py:262
+#: src/olympia/editors/helpers.py:274
 msgid "Type"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:263
+#: src/olympia/editors/helpers.py:275
 msgid "Waiting Time"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:264 src/olympia/editors/templates/editors/review.html:285
+#: src/olympia/editors/helpers.py:276 src/olympia/editors/templates/editors/review.html:285
 msgid "Flags"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:265
+#: src/olympia/editors/helpers.py:277
 msgid "Applications"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:270
+#: src/olympia/editors/helpers.py:282
 msgid "Additional"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:285
+#: src/olympia/editors/helpers.py:302
 msgid "Site Specific"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:287
+#: src/olympia/editors/helpers.py:304
 msgid "Requires External Software"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:289
+#: src/olympia/editors/helpers.py:306
 msgid "Binary Components"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:313
+#: src/olympia/editors/helpers.py:339
 msgid "moments ago"
 msgstr ""
 
 #. L10n: first argument is number of minutes
-#: src/olympia/editors/helpers.py:316
+#: src/olympia/editors/helpers.py:342
 msgid "{0} minute"
 msgid_plural "{0} minutes"
 msgstr[0] ""
 msgstr[1] ""
 
 #. L10n: first argument is number of hours
-#: src/olympia/editors/helpers.py:320
+#: src/olympia/editors/helpers.py:346
 msgid "{0} hour"
 msgid_plural "{0} hours"
 msgstr[0] ""
 msgstr[1] ""
 
 #. L10n: first argument is number of days
-#: src/olympia/editors/helpers.py:324
+#: src/olympia/editors/helpers.py:350
 msgid "{0} day"
 msgid_plural "{0} days"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/olympia/editors/helpers.py:488
+#: src/olympia/editors/helpers.py:364
+msgid "Last Review"
+msgstr ""
+
+#: src/olympia/editors/helpers.py:366
+msgid "Last Update"
+msgstr ""
+
+#: src/olympia/editors/helpers.py:387
+msgid "No Reviews"
+msgstr ""
+
+#: src/olympia/editors/helpers.py:561
 msgid "Push to public"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:490
+#: src/olympia/editors/helpers.py:563
 msgid "Grant full review"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:505
+#: src/olympia/editors/helpers.py:578
 msgid "Request more information"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:508
+#: src/olympia/editors/helpers.py:581
 msgid "Request super-review"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:519
+#: src/olympia/editors/helpers.py:592
 msgid "Grant preliminary review"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:520
+#: src/olympia/editors/helpers.py:593
 msgid "This will mark the files as preliminarily reviewed."
 msgstr ""
 
-#: src/olympia/editors/helpers.py:522
+#: src/olympia/editors/helpers.py:595
 msgid "Use this form to request more information from the author. They will receive an email and be able to answer here. You will be notified by email when they reply."
 msgstr ""
 
-#: src/olympia/editors/helpers.py:526
+#: src/olympia/editors/helpers.py:599
 msgid ""
 "If you have concerns about this add-on's security, copyright issues, or other concerns that an administrator should look into, enter your comments in the area below. They will be sent to "
 "administrators, not the author."
 msgstr ""
 
-#: src/olympia/editors/helpers.py:532
+#: src/olympia/editors/helpers.py:605
 msgid "This will reject the add-on and remove it from the review queue."
 msgstr ""
 
-#: src/olympia/editors/helpers.py:534
-msgid "Make a comment on this version.  The author won't be able to see this."
+#: src/olympia/editors/helpers.py:607
+msgid "Make a comment on this version. The author won't be able to see this."
 msgstr ""
 
-#: src/olympia/editors/helpers.py:538
+#: src/olympia/editors/helpers.py:611
 msgid "This will reject the files and remove them from the review queue."
 msgstr ""
 
-#: src/olympia/editors/helpers.py:542
+#: src/olympia/editors/helpers.py:615
 msgid "This will mark the add-on as preliminarily reviewed. Future versions will undergo preliminary review."
 msgstr ""
 
-#: src/olympia/editors/helpers.py:547
+#: src/olympia/editors/helpers.py:620
 msgid "This will mark the files as preliminarily reviewed. Future versions will undergo preliminary review."
 msgstr ""
 
-#: src/olympia/editors/helpers.py:552
+#: src/olympia/editors/helpers.py:625
 msgid "Retain preliminary review"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:553
+#: src/olympia/editors/helpers.py:626
 msgid "This will retain the add-on as preliminarily reviewed. Future versions will undergo preliminary review."
 msgstr ""
 
-#: src/olympia/editors/helpers.py:558
+#: src/olympia/editors/helpers.py:631
 msgid "This will approve a sandboxed version of a public add-on to appear on the public side."
 msgstr ""
 
-#: src/olympia/editors/helpers.py:561
+#: src/olympia/editors/helpers.py:634
 msgid "This will reject a version of a public add-on and remove it from the queue."
 msgstr ""
 
-#: src/olympia/editors/helpers.py:564
+#: src/olympia/editors/helpers.py:637
 msgid "This will mark the add-on and its most recent version and files as public. Future versions will go into the sandbox until they are reviewed by an editor."
 msgstr ""
 
-#: src/olympia/editors/helpers.py:637
+#: src/olympia/editors/helpers.py:714
 msgid "add-on"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:940 src/olympia/editors/helpers.py:960
+#: src/olympia/editors/helpers.py:1020 src/olympia/editors/helpers.py:1040
 msgid "Flagged"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:944 src/olympia/editors/helpers.py:963
+#: src/olympia/editors/helpers.py:1024 src/olympia/editors/helpers.py:1043
 msgid "Updates"
 msgstr ""
 
@@ -7631,56 +7495,56 @@ msgstr ""
 msgid "A question about your Theme submission"
 msgstr ""
 
-#: src/olympia/editors/views.py:144
+#: src/olympia/editors/views.py:146
 msgid "New Add-ons (Under 5 days)"
 msgstr ""
 
-#: src/olympia/editors/views.py:145
+#: src/olympia/editors/views.py:147
 msgid "Passable (5 to 10 days)"
 msgstr ""
 
-#: src/olympia/editors/views.py:146
+#: src/olympia/editors/views.py:148
 msgid "Overdue (Over 10 days)"
 msgstr ""
 
-#: src/olympia/editors/views.py:532
+#: src/olympia/editors/views.py:539
 msgid "An unknown error occurred"
 msgstr ""
 
-#: src/olympia/editors/views.py:587
+#: src/olympia/editors/views.py:592
 msgid "Self-reviews are not allowed."
 msgstr ""
 
-#: src/olympia/editors/views.py:609
+#: src/olympia/editors/views.py:613
 msgid "Review successfully processed."
 msgstr ""
 
-#: src/olympia/editors/views.py:807
+#: src/olympia/editors/views.py:812
 msgid "was approved"
 msgstr ""
 
-#: src/olympia/editors/views.py:808
+#: src/olympia/editors/views.py:813
 msgid "given preliminary review"
 msgstr ""
 
-#: src/olympia/editors/views.py:809
+#: src/olympia/editors/views.py:814
 msgid "rejected"
 msgstr ""
 
-#: src/olympia/editors/views.py:810
+#: src/olympia/editors/views.py:815
 msgctxt "editors_review_history_nominated_adminreview"
 msgid "escalated"
 msgstr ""
 
-#: src/olympia/editors/views.py:812
+#: src/olympia/editors/views.py:817
 msgid "needs more information"
 msgstr ""
 
-#: src/olympia/editors/views.py:813
+#: src/olympia/editors/views.py:818
 msgid "needs super review"
 msgstr ""
 
-#: src/olympia/editors/views.py:814
+#: src/olympia/editors/views.py:819
 msgid "commented"
 msgstr ""
 
@@ -7725,28 +7589,28 @@ msgstr ""
 msgid "Unlisted Queues"
 msgstr ""
 
-#: src/olympia/editors/templates/editors/base.html:72 src/olympia/editors/templates/editors/performance.html:6
+#: src/olympia/editors/templates/editors/base.html:74 src/olympia/editors/templates/editors/performance.html:6
 msgid "Performance"
 msgstr ""
 
-#: src/olympia/editors/templates/editors/base.html:75 src/olympia/editors/templates/editors/themes/base.html:19 src/olympia/editors/templates/editors/themes/base.html:38
+#: src/olympia/editors/templates/editors/base.html:77 src/olympia/editors/templates/editors/themes/base.html:19 src/olympia/editors/templates/editors/themes/base.html:38
 msgid "Logs"
 msgstr ""
 
-#: src/olympia/editors/templates/editors/base.html:78 src/olympia/editors/templates/editors/reviewlog.html:4 src/olympia/editors/templates/editors/reviewlog.html:27
+#: src/olympia/editors/templates/editors/base.html:80 src/olympia/editors/templates/editors/reviewlog.html:4 src/olympia/editors/templates/editors/reviewlog.html:27
 msgid "Add-on Review Log"
 msgstr ""
 
-#: src/olympia/editors/templates/editors/base.html:80 src/olympia/editors/templates/editors/eventlog.html:4 src/olympia/editors/templates/editors/eventlog.html:8
+#: src/olympia/editors/templates/editors/base.html:82 src/olympia/editors/templates/editors/eventlog.html:4 src/olympia/editors/templates/editors/eventlog.html:8
 #: src/olympia/editors/templates/editors/eventlog_detail.html:4
 msgid "Moderated Review Log"
 msgstr ""
 
-#: src/olympia/editors/templates/editors/base.html:82 src/olympia/editors/templates/editors/beta_signed_log.html:4 src/olympia/editors/templates/editors/beta_signed_log.html:8
+#: src/olympia/editors/templates/editors/base.html:84 src/olympia/editors/templates/editors/beta_signed_log.html:4 src/olympia/editors/templates/editors/beta_signed_log.html:8
 msgid "Signed Beta Files Log"
 msgstr ""
 
-#: src/olympia/editors/templates/editors/base.html:87 src/olympia/editors/templates/editors/includes/daily-message.html:4
+#: src/olympia/editors/templates/editors/base.html:89 src/olympia/editors/templates/editors/includes/daily-message.html:4
 msgid "Announcement"
 msgstr ""
 
@@ -7967,45 +7831,45 @@ msgstr ""
 msgid "clear search"
 msgstr ""
 
-#: src/olympia/editors/templates/editors/queue.html:72 src/olympia/editors/templates/editors/queue.html:122
+#: src/olympia/editors/templates/editors/queue.html:78 src/olympia/editors/templates/editors/queue.html:128
 msgid "Process Reviews"
 msgstr ""
 
-#: src/olympia/editors/templates/editors/queue.html:80
+#: src/olympia/editors/templates/editors/queue.html:86
 msgid "Moderation actions:"
 msgstr ""
 
-#: src/olympia/editors/templates/editors/queue.html:90
+#: src/olympia/editors/templates/editors/queue.html:96
 #, python-format
 msgid "by %(user)s on %(date)s %(stars)s (%(locale)s)"
 msgstr ""
 
-#: src/olympia/editors/templates/editors/queue.html:106
+#: src/olympia/editors/templates/editors/queue.html:112
 #, python-format
 msgid "<strong>%(reason)s</strong> <span class=\"light\">Flagged by %(user)s on %(date)s</span>"
 msgstr ""
 
-#: src/olympia/editors/templates/editors/queue.html:119
-msgid "All reviews have been moderated.  Good work!"
+#: src/olympia/editors/templates/editors/queue.html:125
+msgid "All reviews have been moderated. Good work!"
 msgstr ""
 
-#: src/olympia/editors/templates/editors/queue.html:161
+#: src/olympia/editors/templates/editors/queue.html:167
 msgid "Version Notes / Notes for Reviewer"
 msgstr ""
 
-#: src/olympia/editors/templates/editors/queue.html:169
+#: src/olympia/editors/templates/editors/queue.html:175
 msgid "There are currently no add-ons of this type to review."
 msgstr ""
 
-#: src/olympia/editors/templates/editors/queue.html:181 src/olympia/editors/templates/editors/themes/queue_list.html:85
+#: src/olympia/editors/templates/editors/queue.html:187 src/olympia/editors/templates/editors/themes/queue_list.html:85
 msgid "Helpful Links:"
 msgstr ""
 
-#: src/olympia/editors/templates/editors/queue.html:182
+#: src/olympia/editors/templates/editors/queue.html:188
 msgid "Add-on Policy"
 msgstr ""
 
-#: src/olympia/editors/templates/editors/queue.html:184
+#: src/olympia/editors/templates/editors/queue.html:190
 msgid "Editors' Guide"
 msgstr ""
 
@@ -8068,10 +7932,7 @@ msgid "<strong>Warning!</strong> Another user was viewing this page before you."
 msgstr ""
 
 #: src/olympia/editors/templates/editors/review.html:237
-msgid ""
-"The whiteboard is the place to exchange information relevant to\n"
-"               this addon (whatever the version), between the developer and the\n"
-"               editor. This is visible and editable by both."
+msgid "The whiteboard is the place to exchange information relevant to this addon (whatever the version), between the developer and the editor. This is visible and editable by both."
 msgstr ""
 
 #: src/olympia/editors/templates/editors/review.html:241
@@ -8345,7 +8206,7 @@ msgstr ""
 msgid "Describe your reason for flagging"
 msgstr ""
 
-#: src/olympia/files/forms.py:88
+#: src/olympia/files/forms.py:90
 msgid "Cannot diff a version against itself"
 msgstr ""
 
@@ -8380,51 +8241,51 @@ msgstr ""
 msgid "There was an error accessing file %s."
 msgstr ""
 
-#: src/olympia/files/utils.py:343
+#: src/olympia/files/utils.py:340
 msgid "Could not parse uploaded file."
 msgstr ""
 
-#: src/olympia/files/utils.py:380
+#: src/olympia/files/utils.py:377
 msgid "Invalid file name in archive: {0}"
 msgstr ""
 
-#: src/olympia/files/utils.py:388
+#: src/olympia/files/utils.py:385
 msgid "File exceeding size limit in archive: {0}"
 msgstr ""
 
-#: src/olympia/files/utils.py:439
+#: src/olympia/files/utils.py:436
 msgid "Invalid archive."
 msgstr ""
 
-#: src/olympia/files/utils.py:529 src/olympia/files/utils.py:532
+#: src/olympia/files/utils.py:526 src/olympia/files/utils.py:529
 msgid "Could not parse the manifest file."
 msgstr ""
 
-#: src/olympia/files/utils.py:551
+#: src/olympia/files/utils.py:548
 msgid "Could not find an add-on ID."
 msgstr ""
 
-#: src/olympia/files/utils.py:554
+#: src/olympia/files/utils.py:551
 msgid "Add-on ID must be 64 characters or less."
 msgstr ""
 
-#: src/olympia/files/utils.py:556
+#: src/olympia/files/utils.py:553
 msgid "Add-on ID doesn't match add-on."
 msgstr ""
 
-#: src/olympia/files/utils.py:564
+#: src/olympia/files/utils.py:561
 msgid "Duplicate add-on ID found."
 msgstr ""
 
-#: src/olympia/files/utils.py:567
+#: src/olympia/files/utils.py:564
 msgid "Version numbers should have fewer than 32 characters."
 msgstr ""
 
-#: src/olympia/files/utils.py:570
+#: src/olympia/files/utils.py:567
 msgid "Version numbers should only contain letters, numbers, and these punctuation characters: +*.-_."
 msgstr ""
 
-#: src/olympia/files/utils.py:587
+#: src/olympia/files/utils.py:584
 msgid "<em:type> doesn't match add-on"
 msgstr ""
 
@@ -8523,6 +8384,10 @@ msgstr ""
 
 #: src/olympia/files/templates/files/viewer.html:134
 msgid "Fetching file."
+msgstr ""
+
+#: src/olympia/legacy_api/views.py:255
+msgid "Not implemented yet."
 msgstr ""
 
 #: src/olympia/lib/constants.py:6
@@ -9181,10 +9046,6 @@ msgstr ""
 msgid "Zimbabwe Dollar"
 msgstr ""
 
-#: src/olympia/lib/video/ffmpeg.py:112 src/olympia/lib/video/totem.py:81
-msgid "Videos must be in WebM."
-msgstr ""
-
 #: src/olympia/pages/templates/pages/about.lhtml:3 src/olympia/pages/templates/pages/about.lhtml:10
 msgid "About Mozilla Add-ons"
 msgstr ""
@@ -9196,7 +9057,7 @@ msgstr ""
 #: src/olympia/pages/templates/pages/about.lhtml:13
 msgid ""
 "addons.mozilla.org, commonly known as \"AMO\", is Mozilla's official site for add-ons to Mozilla software, such as Firefox, Thunderbird, and SeaMonkey. Add-ons let you add new features and change "
-"the way your browser or application works.  Take a look around and explore the thousands of ways to customize the way you do things online."
+"the way your browser or application works. Take a look around and explore the thousands of ways to customize the way you do things online."
 msgstr ""
 
 #: src/olympia/pages/templates/pages/about.lhtml:19
@@ -9541,7 +9402,7 @@ msgstr ""
 msgid ""
 "Yes. It's possible, but some of the functionality provided by these libraries are available through XPCOM, XUL, and JavaScript. In addition, authors should take care if libraries modify primitive "
 "object prototypes (String.prototype, Date.prototype, etc.) and/or define global functions (eg. the $ function). These are prone to cause conflict with other add-ons, in particular if different add-"
-"ons use different versions of libraries and so on. Developers need to be very, very careful with using them.  Mozilla does not offer documentation on using them to build add-ons."
+"ons use different versions of libraries and so on. Developers need to be very, very careful with using them. Mozilla does not offer documentation on using them to build add-ons."
 msgstr ""
 
 #: src/olympia/pages/templates/pages/dev_faq.html:165
@@ -9655,8 +9516,8 @@ msgstr ""
 #, python-format
 msgid ""
 "Yes. Many developers choose to host their own add-ons. Choosing to host your add-on on <a href=\"%(amo_url)s\">Mozilla's add-on site</a>, though, allows for much greater exposure to your add-on due "
-"to the large volume of visitors to the site.  <a href=\"%(md_url)s\">mozdev.org</a> offers free project hosting for Mozilla applications and extensions providing developers with tools to help "
-"manage source code, version control, bug tracking and documentation."
+"to the large volume of visitors to the site. <a href=\"%(md_url)s\">mozdev.org</a> offers free project hosting for Mozilla applications and extensions providing developers with tools to help manage "
+"source code, version control, bug tracking and documentation."
 msgstr ""
 
 #: src/olympia/pages/templates/pages/dev_faq.html:277
@@ -9704,7 +9565,7 @@ msgstr ""
 #: src/olympia/pages/templates/pages/dev_faq.html:314
 #, python-format
 msgid ""
-"Yes. Mozilla's <a href=\"%(p_url)s\">Add-on Policy</a> describes what is an acceptable submission. This policy is subject to change without notice.  In addition, the AMO editorial team uses the <a "
+"Yes. Mozilla's <a href=\"%(p_url)s\">Add-on Policy</a> describes what is an acceptable submission. This policy is subject to change without notice. In addition, the AMO editorial team uses the <a "
 "href=\"%(g_url)s\">Editors Reviewing Guide</a> to ensure that your add-on meets specific guidelines for functionality and security."
 msgstr ""
 
@@ -9821,7 +9682,7 @@ msgstr ""
 #: src/olympia/pages/templates/pages/dev_faq.html:434
 #, python-format
 msgid ""
-"This is why it's very important to read the <a href=\"%(g_url)s\">Editors Reviewing Guide</a> to ensure that your add-on is setup as expected.  It's also a good idea to read the blog post, <a href="
+"This is why it's very important to read the <a href=\"%(g_url)s\">Editors Reviewing Guide</a> to ensure that your add-on is setup as expected. It's also a good idea to read the blog post, <a href="
 "\"%(blog_url)s\">Successfully Getting your Add-on Reviewed</a> which provides excellent insight into ensuring a smooth review of your add-on."
 msgstr ""
 
@@ -9928,7 +9789,7 @@ msgstr ""
 
 #: src/olympia/pages/templates/pages/dev_faq.html:572
 msgid ""
-"Free Software Foundation provides short summaries of the key open source licenses, including whether the license qualifies as a free software license or a copyleft license.  Also includes a "
+"Free Software Foundation provides short summaries of the key open source licenses, including whether the license qualifies as a free software license or a copyleft license. Also includes a "
 "discussion of what constitutes a free software license or a copyleft license (e.g., a Copyleft license is a general method for making a program or other work free, and requiring all modified and "
 "extended versions of the program to be free as well.)"
 msgstr ""
@@ -10106,19 +9967,13 @@ msgid "Add-on Gallery"
 msgstr ""
 
 #: src/olympia/pages/templates/pages/faq.html:171
-msgid ""
-"How do I choose between add-ons that seem to do the same\n"
-"    thing?"
+msgid "How do I choose between add-ons that seem to do the same thing?"
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:173
+#: src/olympia/pages/templates/pages/faq.html:172
 msgid ""
-"There are often several add-ons that have similar features. To\n"
-"    figure out which is right for you, read the entire description of the\n"
-"    add-on and view its screenshots. If there are still several in the running,\n"
-"    read through the add-on's ratings, user reviews, and statistics to see\n"
-"    which is most liked by other users. Remember that you can also just try\n"
-"    out both and see which you like better."
+"There are often several add-ons that have similar features. To figure out which is right for you, read the entire description of the add-on and view its screenshots. If there are still several in "
+"the running, read through the add-on's ratings, user reviews, and statistics to see which is most liked by other users. Remember that you can also just try out both and see which you like better."
 msgstr ""
 
 #: src/olympia/pages/templates/pages/faq.html:180
@@ -10159,80 +10014,67 @@ msgid "How much do add-ons cost to purchase?"
 msgstr ""
 
 #: src/olympia/pages/templates/pages/faq.html:207
-msgid ""
-"Add-ons hosted in our gallery are free unless clearly marked\n"
-"    otherwise."
+msgid "Add-ons hosted in our gallery are free unless clearly marked otherwise."
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:210
+#: src/olympia/pages/templates/pages/faq.html:209
 msgid "What does it mean when an add-on asks for contributions?"
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:211
+#: src/olympia/pages/templates/pages/faq.html:210
 msgid ""
-"Some add-on authors request users who enjoy an add-on to\n"
-"        contribute to its development by making a monetary contribution. These\n"
-"        contributions go directly to the developer unless a third party is\n"
-"        indicated, such as the non-profit Mozilla Foundation."
+"Some add-on authors request users who enjoy an add-on to contribute to its development by making a monetary contribution. These contributions go directly to the developer unless a third party is "
+"indicated, such as the non-profit Mozilla Foundation."
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:216
+#: src/olympia/pages/templates/pages/faq.html:215
 msgid "What are beta add-ons?"
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:218
+#: src/olympia/pages/templates/pages/faq.html:217
 msgid ""
-"Beta add-ons are unreviewed versions which represent the\n"
-"        latest work of an add-on author. While different authors have different\n"
-"        standards for beta code quality, you should assume that these add-ons\n"
-"        are less stable than the general add-on releases."
+"Beta add-ons are unreviewed versions which represent the latest work of an add-on author. While different authors have different standards for beta code quality, you should assume that these add-"
+"ons are less stable than the general add-on releases."
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:222
+#: src/olympia/pages/templates/pages/faq.html:221
 msgid ""
 "Please note that when you install an add-on from the \"Beta Version\" section of an add-on's listing, you will continue to receive updates for that add-on as they become available. Like the initial "
 "version you installed, all beta releases are unreviewed by Mozilla and may harm your computer."
 msgstr ""
 
+#: src/olympia/pages/templates/pages/faq.html:228
+msgid "What does it mean when an add-on is flagged as slow?"
+msgstr ""
+
 #: src/olympia/pages/templates/pages/faq.html:229
-msgid ""
-"What does it mean when an add-on is flagged as\n"
-"    slow?"
+msgid "Most add-ons load code and resources at the same time Firefox is starting up. In most cases the impact in start-up time is minimal, but some add-ons can cause a noticeable slowdown."
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:231
-msgid ""
-"Most add-ons load code and resources at the same time Firefox\n"
-"        is starting up. In most cases the impact in start-up time is minimal,\n"
-"        but some add-ons can cause a noticeable slowdown."
-msgstr ""
-
-#: src/olympia/pages/templates/pages/faq.html:236
+#: src/olympia/pages/templates/pages/faq.html:234
 msgid "How do I report an inappropriate or spam user review?"
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:237
+#: src/olympia/pages/templates/pages/faq.html:235
 msgid ""
-"To report a user review of an add-on, log in with your account\n"
-"    and visit the add-on's reviews page. Find the review you wish to report,\n"
-"    click \"Report this review\" and select a reason. Our editorial team will\n"
-"    investigate the review and take appropriate action."
+"To report a user review of an add-on, log in with your account and visit the add-on's reviews page. Find the review you wish to report, click \"Report this review\" and select a reason. Our "
+"editorial team will investigate the review and take appropriate action."
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:242
+#: src/olympia/pages/templates/pages/faq.html:240
 msgid "How do I report a bug or contact the Mozilla Add-ons team?"
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:243
+#: src/olympia/pages/templates/pages/faq.html:241
 #, python-format
 msgid "Please visit our <a href=\"%(contact_url)s\">Contact page</a>."
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:246
+#: src/olympia/pages/templates/pages/faq.html:244
 msgid "What is a Source Code License?"
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:247
+#: src/olympia/pages/templates/pages/faq.html:245
 #, python-format
 msgid ""
 "The source code used to create an add-on is an exclusive copyright of the add-on author, unless otherwise declared in a source code license. Many add-ons on this site have <a href=\"%(url)s\" lang="
@@ -10240,60 +10082,60 @@ msgid ""
 "the GPL or BSD licenses instead of making up their own."
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:256
+#: src/olympia/pages/templates/pages/faq.html:254
 #, python-format
 msgid "Firefox and other Mozilla software are <a href=\"%(url)s\">open source</a>."
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:264
+#: src/olympia/pages/templates/pages/faq.html:262
 msgid "Collections and Favorites"
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:267
+#: src/olympia/pages/templates/pages/faq.html:265
 msgid "What is a collection?"
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:268
+#: src/olympia/pages/templates/pages/faq.html:266
 msgid "Collections are groups of related add-ons created by users to share."
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:270
+#: src/olympia/pages/templates/pages/faq.html:268
 msgid "What is the My Favorites collection?"
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:271
+#: src/olympia/pages/templates/pages/faq.html:269
 msgid "Favorite add-ons are add-ons that you have bookmarked to easily get back to later. You can add an add-on to your favorites collection by clicking \"Add to favorites\" on its details page."
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:275 src/olympia/templates/menu_links.html:13 src/olympia/templates/impala/header_title.html:17
+#: src/olympia/pages/templates/pages/faq.html:273 src/olympia/templates/menu_links.html:13 src/olympia/templates/impala/header_title.html:17
 msgid "Mobile Add-ons"
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:278
+#: src/olympia/pages/templates/pages/faq.html:276
 msgid "What are mobile add-ons?"
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:279
+#: src/olympia/pages/templates/pages/faq.html:277
 #, python-format
 msgid ""
 "Mobile add-ons work with <a href=\"%(mobile_url)s\">Firefox for Mobile</a> and add or modify functionality just like desktop add-ons. You can find add-ons that work with Firefox for Mobile in our "
 "<a href=\"%(gallery_url)s\">gallery</a>."
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:288
+#: src/olympia/pages/templates/pages/faq.html:286
 msgid "Developer Topics"
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:289
+#: src/olympia/pages/templates/pages/faq.html:287
 #, python-format
 msgid "Please see our <a href=\"%(faq_url)s\">Developer FAQ</a> and <a href=\"%(hub_url)s\">Developer Hub</a> for answers to add-on developer-related questions."
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:294
+#: src/olympia/pages/templates/pages/faq.html:292
 msgid "Still have questions?"
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:295
+#: src/olympia/pages/templates/pages/faq.html:293
 #, python-format
 msgid "For general Firefox support, visit our <a href=\"%(sumo_url)s\">support website</a>. For general add-on and website questions, visit our <a href=\"%(forum_url)s\">forum</a>."
 msgstr ""
@@ -10431,7 +10273,7 @@ msgstr ""
 
 #: src/olympia/pages/templates/pages/sunbird.html:29
 msgid ""
-"Development on the Sunbird project has halted and its final release was on March 30, 2010.  We've been proud to host Sunbird add-ons on this site but as the project is no longer maintained we have "
+"Development on the Sunbird project has halted and its final release was on March 30, 2010. We've been proud to host Sunbird add-ons on this site but as the project is no longer maintained we have "
 "disabled our support for the add-ons."
 msgstr ""
 
@@ -10509,7 +10351,7 @@ msgstr ""
 #, python-format
 msgid ""
 "<h2>Keep these tips in mind:</h2> <ul> <li> Write like you're telling a friend about your experience with the add-on. Give specifics and helpful details, such as what features you liked and/or "
-"disliked, how easy to use it is, and any disadvantages it has.  Avoid generic language such as calling it \"Great\" or \"Bad\" unless you can give reasons why you believe this is so. </li> <li> "
+"disliked, how easy to use it is, and any disadvantages it has. Avoid generic language such as calling it \"Great\" or \"Bad\" unless you can give reasons why you believe this is so. </li> <li> "
 "Please do not post bug reports in reviews. We do not make your email address available to add-on developers and they may need to contact you to help resolve your issue. See the <a href=\"%(support)s"
 "\">support section</a> to find out where to get assistance for this add-on. </li> <li>Please keep reviews clean, avoid the use of improper language and do not post any personal information. </li> </"
 "ul> <p>Please read the <a href=\"%(guide)s\" target=\"_blank\">Review Guidelines</a> for more detail about user add-on reviews.</p>"
@@ -10745,16 +10587,16 @@ msgstr ""
 
 #. L10n: {0} is an application, such as Firefox. This means "any version of
 #. Firefox."
-#: src/olympia/search/views.py:554
+#: src/olympia/search/views.py:547
 msgid "Any {0}"
 msgstr ""
 
 #. L10n: "All Systems" means show everything regardless of platform.
-#: src/olympia/search/views.py:589
+#: src/olympia/search/views.py:582
 msgid "All Systems"
 msgstr ""
 
-#: src/olympia/search/views.py:600
+#: src/olympia/search/views.py:593
 msgid "All Tags"
 msgstr ""
 
@@ -10928,31 +10770,31 @@ msgstr ""
 msgid "Share this Collection"
 msgstr ""
 
-#: src/olympia/signing/views.py:30 src/olympia/templates/base.html:75 src/olympia/templates/impala/base.html:115
+#: src/olympia/signing/views.py:33 src/olympia/templates/base.html:71 src/olympia/templates/impala/base.html:112
 msgid "Some features are temporarily disabled while we perform website maintenance. We'll be back to full capacity shortly."
 msgstr ""
 
-#: src/olympia/signing/views.py:53
+#: src/olympia/signing/views.py:56
 msgid "Could not find add-on with id \"{}\"."
 msgstr ""
 
-#: src/olympia/signing/views.py:67
+#: src/olympia/signing/views.py:70
 msgid "You do not own this addon."
 msgstr ""
 
-#: src/olympia/signing/views.py:82
+#: src/olympia/signing/views.py:87
 msgid "Missing \"upload\" key in multipart file data."
 msgstr ""
 
-#: src/olympia/signing/views.py:96
+#: src/olympia/signing/views.py:101
 msgid "Version does not match the manifest file."
 msgstr ""
 
-#: src/olympia/signing/views.py:100
+#: src/olympia/signing/views.py:105
 msgid "Version already exists."
 msgstr ""
 
-#: src/olympia/signing/views.py:136
+#: src/olympia/signing/views.py:141
 msgid "No uploaded file for that addon and version."
 msgstr ""
 
@@ -11065,89 +10907,89 @@ msgstr ""
 msgid "Statistics Dashboard :: Add-ons for {0}"
 msgstr ""
 
-#: src/olympia/stats/templates/stats/stats.html:30
-msgid "Controls:"
-msgstr ""
-
-#: src/olympia/stats/templates/stats/stats.html:33
-msgid "reset zoom"
-msgstr ""
-
-#: src/olympia/stats/templates/stats/stats.html:40
-msgid "Group by:"
-msgstr ""
-
-#: src/olympia/stats/templates/stats/stats.html:42
-msgid "day"
-msgstr ""
-
-#: src/olympia/stats/templates/stats/stats.html:45
-msgid "week"
-msgstr ""
-
-#: src/olympia/stats/templates/stats/stats.html:48
-msgid "month"
-msgstr ""
-
-#: src/olympia/stats/templates/stats/stats.html:54
-msgid "For last:"
-msgstr ""
-
-#: src/olympia/stats/templates/stats/stats.html:57
-msgid "7 days"
-msgstr ""
-
-#: src/olympia/stats/templates/stats/stats.html:60
-msgid "30 days"
-msgstr ""
-
-#: src/olympia/stats/templates/stats/stats.html:63
-msgid "90 days"
-msgstr ""
-
-#: src/olympia/stats/templates/stats/stats.html:66
-msgid "365 days"
-msgstr ""
-
-#: src/olympia/stats/templates/stats/stats.html:69
-msgid "Custom..."
-msgstr ""
-
 #. {0} is an add-on name
-#: src/olympia/stats/templates/stats/stats.html:88 src/olympia/stats/templates/stats/stats.html:91
+#: src/olympia/stats/templates/stats/stats.html:44 src/olympia/stats/templates/stats/stats.html:47
 msgid "Statistics for {0}"
 msgstr ""
 
-#: src/olympia/stats/templates/stats/stats.html:94
+#: src/olympia/stats/templates/stats/stats.html:50
 msgid "Statistics Dashboard"
 msgstr ""
 
-#: src/olympia/stats/templates/stats/stats.html:104
+#: src/olympia/stats/templates/stats/stats.html:57
+msgid "Controls:"
+msgstr ""
+
+#: src/olympia/stats/templates/stats/stats.html:60
+msgid "reset zoom"
+msgstr ""
+
+#: src/olympia/stats/templates/stats/stats.html:67
+msgid "Group by:"
+msgstr ""
+
+#: src/olympia/stats/templates/stats/stats.html:69
+msgid "day"
+msgstr ""
+
+#: src/olympia/stats/templates/stats/stats.html:72
+msgid "week"
+msgstr ""
+
+#: src/olympia/stats/templates/stats/stats.html:75
+msgid "month"
+msgstr ""
+
+#: src/olympia/stats/templates/stats/stats.html:81
+msgid "For last:"
+msgstr ""
+
+#: src/olympia/stats/templates/stats/stats.html:84
+msgid "7 days"
+msgstr ""
+
+#: src/olympia/stats/templates/stats/stats.html:87
+msgid "30 days"
+msgstr ""
+
+#: src/olympia/stats/templates/stats/stats.html:90
+msgid "90 days"
+msgstr ""
+
+#: src/olympia/stats/templates/stats/stats.html:93
+msgid "365 days"
+msgstr ""
+
+#: src/olympia/stats/templates/stats/stats.html:96
+msgid "Custom..."
+msgstr ""
+
+#: src/olympia/stats/templates/stats/stats.html:106
 msgid "Statistics processing is currently disabled, so recent data is unavailable. The statistics are still being collected and this page will be updated soon with the missing data."
 msgstr ""
 
-#: src/olympia/stats/templates/stats/stats.html:110
+#: src/olympia/stats/templates/stats/stats.html:112
 msgid "Loading the latest data&hellip;"
 msgstr ""
 
-#: src/olympia/stats/templates/stats/stats.html:142 src/olympia/stats/templates/stats/reports/overview.html:25 src/olympia/stats/templates/stats/reports/overview.html:37
+#: src/olympia/stats/templates/stats/stats.html:144 src/olympia/stats/templates/stats/reports/overview.html:25 src/olympia/stats/templates/stats/reports/overview.html:37
 #: src/olympia/stats/templates/stats/reports/overview.html:49
 msgid "No data available."
 msgstr ""
 
-#: src/olympia/stats/templates/stats/stats.html:177
+#: src/olympia/stats/templates/stats/stats.html:179
 msgid "This dashboard is currently <b>public</b>."
 msgstr ""
 
-#: src/olympia/stats/templates/stats/stats.html:179
+#: src/olympia/stats/templates/stats/stats.html:181
 msgid "Contribution stats are currently <b>private</b>."
 msgstr ""
 
-#: src/olympia/stats/templates/stats/stats.html:182
+#: src/olympia/stats/templates/stats/stats.html:184
 msgid "This dashboard is currently <b>private</b>."
 msgstr ""
 
-#: src/olympia/stats/templates/stats/stats.html:185
+#: src/olympia/stats/templates/stats/stats.html:187
 msgid "Change settings."
 msgstr ""
 
@@ -11299,15 +11141,6 @@ msgstr ""
 msgid "Application versions by Date"
 msgstr ""
 
-#: src/olympia/tags/templates/tags/top_cloud.html:4
-msgid "Top {0} Tags"
-msgstr ""
-
-#. {0} is the current application name
-#: src/olympia/tags/templates/tags/top_cloud.html:14
-msgid "{0} Top Tags"
-msgstr ""
-
 #: src/olympia/templates/amo_footer.html:6 src/olympia/templates/includes/lang_switcher.html:2
 msgid "Other languages"
 msgstr ""
@@ -11316,11 +11149,11 @@ msgstr ""
 msgid "Mozilla Add-ons"
 msgstr ""
 
-#: src/olympia/templates/base.html:91 src/olympia/templates/impala/base.html:81
+#: src/olympia/templates/base.html:89 src/olympia/templates/impala/base.html:78
 msgid "Find add-ons for other applications"
 msgstr ""
 
-#: src/olympia/templates/base.html:92 src/olympia/templates/impala/base.html:81
+#: src/olympia/templates/base.html:90 src/olympia/templates/impala/base.html:78
 msgid "Other Applications"
 msgstr ""
 
@@ -11345,7 +11178,7 @@ msgid "View Mobile Site"
 msgstr ""
 
 #: src/olympia/templates/copyright.html:7
-msgid "Site Status "
+msgid "Site Status"
 msgstr ""
 
 #: src/olympia/templates/footer.html:3
@@ -11445,35 +11278,35 @@ msgstr ""
 msgid "<a href=\"%(reg)s\">Register</a> or <a href=\"%(login)s\">Log in</a>"
 msgstr ""
 
-#: src/olympia/templates/impala/base.html:126
+#: src/olympia/templates/impala/base.html:123
 #, python-format
 msgid "To try the thousands of add-ons available here, download <a href=\"%(url)s\">Mozilla Firefox</a>, a fast, free way to surf the Web!"
 msgstr ""
 
-#: src/olympia/templates/impala/base.html:138
+#: src/olympia/templates/impala/base.html:135
 #, python-format
 msgid "Add-ons is switching to Firefox Accounts for login. <a href=\"%(url)s\" class=\"fxa-login\">Sign in now to transfer your account.</a>"
 msgstr ""
 
 #. {0} is an application, such as Firefox.
-#: src/olympia/templates/impala/base.html:148
+#: src/olympia/templates/impala/base.html:145
 msgid "Welcome to {0} Add-ons."
 msgstr ""
 
-#: src/olympia/templates/impala/base.html:151
+#: src/olympia/templates/impala/base.html:148
 msgid "Choose from thousands of extra features and styles to make Firefox your own."
 msgstr ""
 
-#: src/olympia/templates/impala/base.html:156
+#: src/olympia/templates/impala/base.html:153
 #, python-format
 msgid "Add extra features and styles to make %(app)s your own."
 msgstr ""
 
-#: src/olympia/templates/impala/base.html:164
+#: src/olympia/templates/impala/base.html:161
 msgid "On the go?"
 msgstr ""
 
-#: src/olympia/templates/impala/base.html:166
+#: src/olympia/templates/impala/base.html:163
 msgid "Check out our <a class=\"mobile-link\" href=\"#\">Mobile Add-ons site</a>."
 msgstr ""
 
@@ -11697,19 +11530,19 @@ msgstr ""
 
 #. L10n: {id} will be something like "13ad6a", just a random number
 #. to differentiate this user from other anonymous users.
-#: src/olympia/users/models.py:353
+#: src/olympia/users/models.py:362
 msgid "Anonymous user {id}"
 msgstr ""
 
-#: src/olympia/users/models.py:410
+#: src/olympia/users/models.py:419
 msgid "Your account has been restricted"
 msgstr ""
 
-#: src/olympia/users/models.py:480
+#: src/olympia/users/models.py:489
 msgid "Please confirm your email address"
 msgstr ""
 
-#: src/olympia/users/models.py:506
+#: src/olympia/users/models.py:515
 msgid "My Mobile Add-ons"
 msgstr ""
 
@@ -11986,7 +11819,7 @@ msgstr ""
 
 #: src/olympia/users/templates/users/edit.html:70
 #, python-format
-msgid "Change your password.  If you forgot your password, you can <a href=\"%(reset_url)s\">use the reset form</a>."
+msgid "Change your password. If you forgot your password, you can <a href=\"%(reset_url)s\">use the reset form</a>."
 msgstr ""
 
 #: src/olympia/users/templates/users/edit.html:76
@@ -12006,7 +11839,7 @@ msgid "Profile"
 msgstr ""
 
 #: src/olympia/users/templates/users/edit.html:100
-msgid "Give us a bit more information about yourself.  All these fields are optional, but they'll help other users get to know you better."
+msgid "Give us a bit more information about yourself. All these fields are optional, but they'll help other users get to know you better."
 msgstr ""
 
 #: src/olympia/users/templates/users/edit.html:124
@@ -12222,7 +12055,7 @@ msgid "Confirm password"
 msgstr ""
 
 #: src/olympia/users/templates/users/pwreset_confirm.html:47
-msgid "The password reset link was invalid, possibly because it has already been used.  Please request a new password reset."
+msgid "The password reset link was invalid, possibly because it has already been used. Please request a new password reset."
 msgstr ""
 
 #: src/olympia/users/templates/users/pwreset_request.html:15
@@ -12408,7 +12241,7 @@ msgstr ""
 
 #: src/olympia/users/templates/users/unsubscribe.html:30
 #, python-format
-msgid "Unfortunately, we weren't able to unsubscribe you.  The link you clicked is invalid. However, you can unsubscribe still unsubscribe on your <a href=\"%(edit_url)s\">edit profile page</a>."
+msgid "Unfortunately, we weren't able to unsubscribe you. The link you clicked is invalid. However, you can unsubscribe still unsubscribe on your <a href=\"%(edit_url)s\">edit profile page</a>."
 msgstr ""
 
 #: src/olympia/users/templates/users/vcard.html:2
@@ -12462,15 +12295,15 @@ msgstr ""
 msgid "Version History with Changelogs"
 msgstr ""
 
-#: src/olympia/versions/models.py:314
+#: src/olympia/versions/models.py:313
 msgid "Add-on uses binary components."
 msgstr ""
 
-#: src/olympia/versions/models.py:317
+#: src/olympia/versions/models.py:316
 msgid "Add-on has opted into strict compatibility checking."
 msgstr ""
 
-#: src/olympia/versions/models.py:715
+#: src/olympia/versions/models.py:711
 msgid "{app} {min} and later"
 msgstr ""
 
@@ -12545,4 +12378,8 @@ msgstr ""
 
 #: src/olympia/zadmin/forms.py:105
 msgid "Log emails instead of sending"
+msgstr ""
+
+#: src/olympia/zadmin/forms.py:215
+msgid "Deleted versions can`t be changed."
 msgstr ""

--- a/locale/ur/LC_MESSAGES/djangojs.po
+++ b/locale/ur/LC_MESSAGES/djangojs.po
@@ -1,1216 +1,1236 @@
-
 #, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2016-02-24 21:23+0000\n"
+"POT-Creation-Date: 2016-04-18 15:47+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
+"Language: \n"
 "MIME-Version: 1.0\n"
-"Content-Type: text/plain; charset=utf-8\n"
+"Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Generated-By: Babel 2.2.0\n"
 
-#: static/js/common/ratingwidget.js:31
+#: static/js/common-all.js:1426 static/js/impala-all.js:1511 static/js/zamboni/discovery-all.js:12598 static/js/zamboni/init.js:28 static/js/zamboni/mobile-all.js:14945
+msgid "This feature is temporarily disabled while we perform website maintenance. Please check back a little later."
+msgstr ""
+
+#. L10n: {0} is an app name like Firefox.
+#: static/js/common-all.js:1837 static/js/impala-all.js:1922 static/js/zamboni/buttons.js:73 static/js/zamboni/discovery-all.js:13108
+msgid "Accept and Install"
+msgstr ""
+
+#: static/js/common-all.js:1837 static/js/impala-all.js:1922 static/js/zamboni/buttons.js:73 static/js/zamboni/discovery-all.js:13108
+msgid "Add to {0}"
+msgstr ""
+
+#: static/js/common-all.js:1842 static/js/impala-all.js:1927 static/js/zamboni/buttons.js:78 static/js/zamboni/discovery-all.js:13113
+msgid "Download Now"
+msgstr ""
+
+#: static/js/common-all.js:1883 static/js/impala-all.js:1968 static/js/zamboni/buttons.js:119 static/js/zamboni/discovery-all.js:13154
+msgid "Add-on has not been updated to support default-to-compatible."
+msgstr ""
+
+#: static/js/common-all.js:1888 static/js/impala-all.js:1973 static/js/zamboni/buttons.js:124 static/js/zamboni/discovery-all.js:13159
+msgid "You need to be using Firefox 10.0 or higher."
+msgstr ""
+
+#: static/js/common-all.js:1900 static/js/impala-all.js:1985 static/js/zamboni/buttons.js:136 static/js/zamboni/discovery-all.js:13171
+msgid "Mozilla has marked this version as incompatible with your Firefox version."
+msgstr ""
+
+#. L10n: {0} is an platform like Windows or Linux.
+#: static/js/common-all.js:1981 static/js/impala-all.js:2066 static/js/zamboni/buttons.js:217 static/js/zamboni/discovery-all.js:13252
+msgid "Install for {0} anyway"
+msgstr ""
+
+#: static/js/common-all.js:1981 static/js/impala-all.js:2066 static/js/zamboni/buttons.js:217 static/js/zamboni/discovery-all.js:13252
+msgid "Download for {0} anyway"
+msgstr ""
+
+#: static/js/common-all.js:2038 static/js/impala-all.js:2123 static/js/zamboni/buttons.js:274 static/js/zamboni/discovery-all.js:13309
+msgid "Not available for your platform"
+msgstr ""
+
+#. L10n: {0} is an app name, {1} is the app version.
+#: static/js/common-all.js:2049 static/js/common-all.js:2086 static/js/impala-all.js:2134 static/js/impala-all.js:2171 static/js/zamboni/buttons.js:286 static/js/zamboni/buttons.js:324
+#: static/js/zamboni/discovery-all.js:13320 static/js/zamboni/discovery-all.js:13357
+msgid "Not available for {0} {1}"
+msgstr ""
+
+#: static/js/common-all.js:2112 static/js/impala-all.js:2197 static/js/zamboni/buttons.js:351 static/js/zamboni/discovery-all.js:13383
+msgid "Works with {app} {min} - {max}"
+msgstr ""
+
+#: static/js/common-all.js:2114 static/js/impala-all.js:2199 static/js/zamboni/buttons.js:353 static/js/zamboni/discovery-all.js:13385
+msgid "View other versions"
+msgstr ""
+
+#: static/js/common-all.js:2162 static/js/impala-all.js:2247 static/js/zamboni/buttons.js:401 static/js/zamboni/discovery-all.js:13433
+msgid "Only with Firefox — Get Firefox Now!"
+msgstr ""
+
+#: static/js/common-all.js:2278 static/js/impala-all.js:2363 static/js/zamboni/buttons.js:517 static/js/zamboni/discovery-all.js:13549 static/js/zamboni/mobile-all.js:15177
+#: static/js/zamboni/mobile/buttons.js:43
+msgid "Sorry, you need a Mozilla-based browser (such as Firefox) to install a search plugin."
+msgstr ""
+
+#: static/js/common-all.js:9088 static/js/impala-all.js:9649 static/js/zamboni/global.js:410
+msgid "Loading..."
+msgstr ""
+
+#. L10n: {0} is the number of characters left.
+#: static/js/common-all.js:9152 static/js/impala-all.js:9713 static/js/zamboni/global.js:474
+msgid "<b>{0}</b> character left."
+msgid_plural "<b>{0}</b> characters left."
+msgstr[0] ""
+msgstr[1] ""
+
+#: static/js/common-all.js:9589 static/js/common-min.js:6 static/js/impala-all.js:10052 static/js/impala-min.js:6 static/js/common/ratingwidget.js:31 static/js/zamboni/mobile-all.js:16123
+#: static/js/zamboni/mobile-min.js:6
 msgid "{0} star"
 msgid_plural "{0} stars"
 msgstr[0] ""
 msgstr[1] ""
 
-#: static/js/common/upload-addon.js:41 static/js/common/upload-image.js:128
+#: static/js/common-all.js:9676 static/js/common-min.js:6 static/js/impala-all.js:10139 static/js/impala-min.js:6 static/js/zamboni/l10n.js:45
+msgid "Remove this localization"
+msgstr ""
+
+#: static/js/common-all.js:10193 static/js/common-min.js:6 static/js/impala-all.js:10674 static/js/impala-min.js:6 static/js/zamboni/discovery-all.js:13678
+msgid "close"
+msgstr ""
+
+#: static/js/common-all.js:10860 static/js/common-min.js:6 static/js/impala-all.js:11481 static/js/impala-min.js:6 static/js/impala/reviews.js:23 static/js/zamboni/reviews.js:18
+msgid "Flagged for review"
+msgstr ""
+
+#: static/js/common-all.js:10876 static/js/common-min.js:6 static/js/impala-all.js:11498 static/js/impala-min.js:6 static/js/impala/reviews.js:40 static/js/zamboni/reviews.js:34
+msgid "Your input is required"
+msgstr ""
+
+#: static/js/common-all.js:10945 static/js/common-min.js:6 static/js/impala-all.js:11610 static/js/impala-min.js:7 static/js/impala/reviews.js:152 static/js/zamboni/reviews.js:103
+msgid "Marked for deletion"
+msgstr ""
+
+#: static/js/common-all.js:11573 static/js/common-min.js:7 static/js/impala-all.js:13809 static/js/impala-min.js:8 static/js/zamboni/collections.js:229
+msgid "Adding to Favorites&hellip;"
+msgstr ""
+
+#: static/js/common-all.js:11576 static/js/common-min.js:7 static/js/impala-all.js:13812 static/js/impala-min.js:8 static/js/zamboni/collections.js:232
+msgid "Removing Favorite&hellip;"
+msgstr ""
+
+#: static/js/common-all.js:11579 static/js/common-min.js:7 static/js/impala-all.js:13815 static/js/impala-min.js:8 static/js/zamboni/collections.js:235
+msgid "Add to Favorites"
+msgstr ""
+
+#: static/js/common-all.js:11582 static/js/common-min.js:7 static/js/impala-all.js:13818 static/js/impala-min.js:8 static/js/zamboni/collections.js:238
+msgid "Remove from Favorites"
+msgstr ""
+
+#: static/js/common-all.js:11647 static/js/common-min.js:7 static/js/impala-all.js:13883 static/js/impala-min.js:8 static/js/zamboni/collections.js:303
+msgid "Pending"
+msgstr ""
+
+#: static/js/common-all.js:11648 static/js/common-min.js:7 static/js/impala-all.js:13884 static/js/impala-min.js:8 static/js/zamboni/collections.js:304
+msgid "Add a comment"
+msgstr ""
+
+#: static/js/common-all.js:11648 static/js/common-min.js:7 static/js/impala-all.js:13884 static/js/impala-min.js:8 static/js/zamboni/collections.js:304
+msgid "Comment"
+msgstr ""
+
+#: static/js/common-all.js:11649 static/js/common-min.js:7 static/js/impala-all.js:13885 static/js/impala-min.js:8 static/js/zamboni/collections.js:305
+msgid "Remove this add-on from the collection"
+msgstr ""
+
+#: static/js/common-all.js:11649 static/js/common-all.js:11678 static/js/common-min.js:7 static/js/impala-all.js:13885 static/js/impala-all.js:13914 static/js/impala-min.js:8
+#: static/js/zamboni/collections.js:305 static/js/zamboni/collections.js:334
+msgid "Remove"
+msgstr ""
+
+#: static/js/common-all.js:11678 static/js/common-min.js:7 static/js/impala-all.js:13914 static/js/impala-min.js:8 static/js/zamboni/collections.js:334
+msgid "Remove this user as a contributor"
+msgstr ""
+
+#: static/js/common-all.js:11690 static/js/common-min.js:7 static/js/impala-all.js:13926 static/js/impala-min.js:8 static/js/zamboni/collections.js:346
+msgid "An email address is required."
+msgstr ""
+
+#: static/js/common-all.js:11708 static/js/common-min.js:7 static/js/impala-all.js:13944 static/js/impala-min.js:8 static/js/zamboni/collections.js:364
+msgid "You cannot add yourself as a contributor."
+msgstr ""
+
+#: static/js/common-all.js:11710 static/js/common-min.js:7 static/js/impala-all.js:13946 static/js/impala-min.js:8 static/js/zamboni/collections.js:366
+msgid "You have already added that user."
+msgstr ""
+
+#: static/js/common-all.js:11917 static/js/common-min.js:7 static/js/impala-all.js:14153 static/js/impala-min.js:8 static/js/zamboni/collections.js:573
+msgid "Add to favorites"
+msgstr ""
+
+#: static/js/common-all.js:11921 static/js/common-min.js:7 static/js/impala-all.js:14157 static/js/impala-min.js:8 static/js/zamboni/collections.js:577
+msgid "Remove from favorites"
+msgstr ""
+
+#: static/js/common-all.js:11939 static/js/common-min.js:7 static/js/impala-all.js:14175 static/js/impala-all.js:14233 static/js/impala-min.js:8 static/js/impala/collections.js:10
+#: static/js/zamboni/collections.js:595
+msgid "Follow this Collection"
+msgstr ""
+
+#: static/js/common-all.js:11948 static/js/common-min.js:7 static/js/impala-all.js:14184 static/js/impala-min.js:8 static/js/zamboni/collections.js:604
+msgid "Stop following"
+msgstr ""
+
+#: static/js/common-all.js:12096 static/js/common-min.js:7 static/js/zamboni/password-strength.js:20
+msgid "Password strength:"
+msgstr ""
+
+#: static/js/common-all.js:12102 static/js/common-min.js:7 static/js/zamboni/password-strength.js:26
+msgid "At least {0} character left."
+msgid_plural "At least {0} characters left."
+msgstr[0] ""
+msgstr[1] ""
+
+#: static/js/common-all.js:12286 static/js/common-min.js:7 static/js/impala-all.js:14632 static/js/impala-min.js:8 static/js/impala/suggestions.js:39
+msgid "Search themes for <b>{0}</b>"
+msgstr ""
+
+#: static/js/common-all.js:12288 static/js/common-min.js:7 static/js/impala-all.js:14634 static/js/impala-min.js:8 static/js/impala/suggestions.js:41
+msgid "Search apps for <b>{0}</b>"
+msgstr ""
+
+#: static/js/common-all.js:12290 static/js/common-min.js:7 static/js/impala-all.js:14636 static/js/impala-min.js:8 static/js/impala/suggestions.js:43
+msgid "Search add-ons for <b>{0}</b>"
+msgstr ""
+
+#: static/js/common-all.js:12521 static/js/common-min.js:7 static/js/impala-all.js:14867 static/js/impala-min.js:8 static/js/impala/site_suggestions.js:46
+msgid "Category"
+msgstr ""
+
+#. L10n: {0} is an app name.
+#: static/js/impala-all.js:11632 static/js/impala-min.js:7 static/js/impala/listing.js:11 static/js/zamboni/themes.js:13
+msgid "This theme is incompatible with your version of {0}"
+msgstr ""
+
+#: static/js/impala-all.js:12146 static/js/impala-all.js:14331 static/js/impala-min.js:7 static/js/impala-min.js:8 static/js/common/upload-image.js:97 static/js/impala/users.js:51
+#: static/js/zamboni/devhub-all.js:894 static/js/zamboni/devhub-min.js:1
+msgid "Images must be either PNG or JPG."
+msgstr ""
+
+#: static/js/impala-all.js:12150 static/js/impala-min.js:7 static/js/common/upload-image.js:101 static/js/zamboni/devhub-all.js:898 static/js/zamboni/devhub-min.js:1
+msgid "Videos must be in WebM."
+msgstr ""
+
+#: static/js/impala-all.js:12177 static/js/impala-min.js:7 static/js/common/upload-addon.js:41 static/js/common/upload-image.js:128 static/js/zamboni/devhub-all.js:272
+#: static/js/zamboni/devhub-all.js:925 static/js/zamboni/devhub-min.js:1
 msgid "There was a problem contacting the server."
 msgstr ""
 
-#: static/js/common/upload-addon.js:69
+#: static/js/impala-all.js:13298 static/js/impala-min.js:7 static/js/impala/persona_creation.js:60
+msgid "All Rights Reserved"
+msgstr ""
+
+#: static/js/impala-all.js:13302 static/js/impala-min.js:7 static/js/impala/persona_creation.js:64
+msgid "Creative Commons Attribution 3.0"
+msgstr ""
+
+#: static/js/impala-all.js:13307 static/js/impala-min.js:7 static/js/impala/persona_creation.js:69
+msgid "Creative Commons Attribution-NonCommercial 3.0"
+msgstr ""
+
+#: static/js/impala-all.js:13312 static/js/impala-min.js:7 static/js/impala/persona_creation.js:74
+msgid "Creative Commons Attribution-NonCommercial-NoDerivs 3.0"
+msgstr ""
+
+#: static/js/impala-all.js:13317 static/js/impala-min.js:7 static/js/impala/persona_creation.js:79
+msgid "Creative Commons Attribution-NonCommercial-Share Alike 3.0"
+msgstr ""
+
+#: static/js/impala-all.js:13322 static/js/impala-min.js:7 static/js/impala/persona_creation.js:84
+msgid "Creative Commons Attribution-NoDerivs 3.0"
+msgstr ""
+
+#: static/js/impala-all.js:13327 static/js/impala-min.js:7 static/js/impala/persona_creation.js:89
+msgid "Creative Commons Attribution-ShareAlike 3.0"
+msgstr ""
+
+#: static/js/impala-all.js:13530 static/js/impala-min.js:7 static/js/impala/persona_creation.js:292
+msgid "Your Theme's Name"
+msgstr ""
+
+#: static/js/impala-all.js:14242 static/js/impala-min.js:8 static/js/impala/collections.js:19
+msgid "Stop Following"
+msgstr ""
+
+#: static/js/impala-all.js:14243 static/js/impala-min.js:8 static/js/impala/collections.js:20
+msgid "Following"
+msgstr ""
+
+#: static/js/impala-all.js:14313 static/js/impala-min.js:8 static/js/impala/users.js:33
+msgid "use original"
+msgstr ""
+
+#: static/js/impala-all.js:14523 static/js/impala-min.js:8 static/js/impala/search.js:114
+msgid "Updating results&hellip;"
+msgstr ""
+
+#: static/js/common/upload-addon.js:69 static/js/zamboni/devhub-all.js:300 static/js/zamboni/devhub-min.js:1
 msgid "Select a file..."
 msgstr ""
 
-#: static/js/common/upload-addon.js:70
+#: static/js/common/upload-addon.js:70 static/js/zamboni/devhub-all.js:301 static/js/zamboni/devhub-min.js:1
 msgid "Your add-on should end with .xpi, .jar or .xml"
 msgstr ""
 
 #. L10n: {0} is the percent of the file that has been uploaded.
-#: static/js/common/upload-addon.js:104
+#: static/js/common/upload-addon.js:104 static/js/zamboni/devhub-all.js:335 static/js/zamboni/devhub-min.js:1
 #, python-format
 msgid "{0}% complete"
 msgstr ""
 
 #. L10n: "{bytes uploaded} of {total filesize}".
-#: static/js/common/upload-addon.js:107
+#: static/js/common/upload-addon.js:107 static/js/zamboni/devhub-all.js:338 static/js/zamboni/devhub-min.js:1
 msgid "{0} of {1}"
 msgstr ""
 
-#: static/js/common/upload-addon.js:140
+#: static/js/common/upload-addon.js:140 static/js/zamboni/devhub-all.js:371 static/js/zamboni/devhub-min.js:1
 msgid "Cancel"
 msgstr ""
 
-#: static/js/common/upload-addon.js:162
+#: static/js/common/upload-addon.js:162 static/js/zamboni/devhub-all.js:393 static/js/zamboni/devhub-min.js:1
 msgid "Uploading {0}"
 msgstr ""
 
-#: static/js/common/upload-addon.js:189
+#: static/js/common/upload-addon.js:189 static/js/zamboni/devhub-all.js:420 static/js/zamboni/devhub-min.js:1
 msgid "Error with {0}"
 msgstr ""
 
-#: static/js/common/upload-addon.js:194
+#: static/js/common/upload-addon.js:194 static/js/zamboni/devhub-all.js:425 static/js/zamboni/devhub-min.js:1
 msgid "Your add-on failed validation with {0} error."
 msgid_plural "Your add-on failed validation with {0} errors."
 msgstr[0] ""
 msgstr[1] ""
 
-#: static/js/common/upload-addon.js:208
+#: static/js/common/upload-addon.js:208 static/js/zamboni/devhub-all.js:439 static/js/zamboni/devhub-min.js:1
 msgid "&hellip;and {0} more"
 msgid_plural "&hellip;and {0} more"
 msgstr[0] ""
 msgstr[1] ""
 
-#: static/js/common/upload-addon.js:222 static/js/common/upload-addon.js:512
+#: static/js/common/upload-addon.js:222 static/js/common/upload-addon.js:497 static/js/zamboni/devhub-all.js:453 static/js/zamboni/devhub-all.js:743 static/js/zamboni/devhub-min.js:1
 msgid "See full validation report"
 msgstr ""
 
-#: static/js/common/upload-addon.js:234
+#: static/js/common/upload-addon.js:234 static/js/zamboni/devhub-all.js:465 static/js/zamboni/devhub-min.js:1
 msgid "Validating {0}"
 msgstr ""
 
 #. L10n: first argument is an HTTP status code
-#: static/js/common/upload-addon.js:273
+#: static/js/common/upload-addon.js:273 static/js/zamboni/devhub-all.js:504 static/js/zamboni/devhub-min.js:1
 msgid "Received an empty response from the server; status: {0}"
 msgstr ""
 
-#: static/js/common/upload-addon.js:373
+#: static/js/common/upload-addon.js:370 static/js/zamboni/devhub-all.js:604 static/js/zamboni/devhub-min.js:1
 msgid "Unexpected server error while validating."
 msgstr ""
 
-#: static/js/common/upload-addon.js:412
+#: static/js/common/upload-addon.js:409 static/js/zamboni/devhub-all.js:643 static/js/zamboni/devhub-min.js:1
 msgid "Finished validating {0}"
 msgstr ""
 
-#: static/js/common/upload-addon.js:418
+#: static/js/common/upload-addon.js:415 static/js/zamboni/devhub-all.js:649 static/js/zamboni/devhub-min.js:1
 msgid "Your add-on validation timed out, it will be manually reviewed."
 msgstr ""
 
-#: static/js/common/upload-addon.js:421
+#: static/js/common/upload-addon.js:418 static/js/zamboni/devhub-all.js:652 static/js/zamboni/devhub-min.js:1
 msgid "Your add-on was validated with no errors and {0} warning."
 msgid_plural "Your add-on was validated with no errors and {0} warnings."
 msgstr[0] ""
 msgstr[1] ""
 
-#: static/js/common/upload-addon.js:426
+#: static/js/common/upload-addon.js:423 static/js/zamboni/devhub-all.js:657 static/js/zamboni/devhub-min.js:1
 msgid "Your add-on was validated with no errors and {0} message."
 msgid_plural "Your add-on was validated with no errors and {0} messages."
 msgstr[0] ""
 msgstr[1] ""
 
-#: static/js/common/upload-addon.js:431
+#: static/js/common/upload-addon.js:428 static/js/zamboni/devhub-all.js:662 static/js/zamboni/devhub-min.js:1
 msgid "Your add-on was validated with no errors or warnings."
 msgstr ""
 
-#: static/js/common/upload-addon.js:446
+#: static/js/common/upload-addon.js:443 static/js/zamboni/devhub-all.js:677 static/js/zamboni/devhub-min.js:1
 msgid "Your submission will be automatically signed."
 msgstr ""
 
-#: static/js/common/upload-addon.js:465
+#: static/js/common/upload-addon.js:450 static/js/zamboni/devhub-all.js:696 static/js/zamboni/devhub-min.js:1
 msgid "Include detailed version notes (this can be done in the next step)."
 msgstr ""
 
-#: static/js/common/upload-addon.js:466
+#: static/js/common/upload-addon.js:451 static/js/zamboni/devhub-all.js:697 static/js/zamboni/devhub-min.js:1
 msgid "If your add-on requires an account to a website in order to be fully tested, include a test username and password in the Notes to Reviewer (this can be done in the next step)."
 msgstr ""
 
-#: static/js/common/upload-addon.js:467
+#: static/js/common/upload-addon.js:452 static/js/zamboni/devhub-all.js:698 static/js/zamboni/devhub-min.js:1
 msgid "If your add-on is intended for a limited audience you should choose Preliminary Review instead of Full Review."
 msgstr ""
 
-#: static/js/common/upload-addon.js:480
+#: static/js/common/upload-addon.js:465 static/js/zamboni/devhub-all.js:711 static/js/zamboni/devhub-min.js:1
 msgid "Add-on submission checklist"
 msgstr ""
 
-#: static/js/common/upload-addon.js:481
+#: static/js/common/upload-addon.js:466 static/js/zamboni/devhub-all.js:712 static/js/zamboni/devhub-min.js:1
 msgid "Please verify the following points before finalizing your submission. This will minimize delays or misunderstanding during the review process:"
 msgstr ""
 
-#: static/js/common/upload-addon.js:483
+#: static/js/common/upload-addon.js:468 static/js/zamboni/devhub-all.js:714 static/js/zamboni/devhub-min.js:1
 msgid ""
 "Compiled binaries, as well as minified or obfuscated scripts (excluding known libraries) need to have their sources submitted separately for review. Make sure that you use the source code upload "
 "field to avoid having your submission rejected."
 msgstr ""
 
-#: static/js/common/upload-addon.js:501
+#: static/js/common/upload-addon.js:486 static/js/zamboni/devhub-all.js:732 static/js/zamboni/devhub-min.js:1
 msgid "The validation process found these issues that can lead to rejections:"
 msgstr ""
 
-#: static/js/common/upload-addon.js:518
+#: static/js/common/upload-addon.js:503 static/js/zamboni/devhub-all.js:749 static/js/zamboni/devhub-min.js:1
 msgid "If you are unfamiliar with the add-ons review process, you can read about it here."
 msgstr ""
 
-#: static/js/common/upload-addon.js:555
+#: static/js/common/upload-addon.js:540 static/js/zamboni/devhub-all.js:786 static/js/zamboni/devhub-min.js:1
 msgid "Sorry, no supported platform has been found."
 msgstr ""
 
-#: static/js/common/upload-base.js:57
+#: static/js/common/upload-base.js:57 static/js/zamboni/devhub-all.js:187 static/js/zamboni/devhub-min.js:1
 msgid "The filetype you uploaded isn't recognized."
 msgstr ""
 
-#: static/js/common/upload-base.js:79
+#: static/js/common/upload-base.js:79 static/js/zamboni/devhub-all.js:209 static/js/zamboni/devhub-min.js:1
 msgid "You cancelled the upload."
 msgstr ""
 
-#: static/js/common/upload-image.js:97 static/js/impala/users.js:51
-msgid "Images must be either PNG or JPG."
-msgstr ""
-
-#: static/js/common/upload-image.js:101
-msgid "Videos must be in WebM."
-msgstr ""
-
-#: static/js/impala/collections.js:10 static/js/zamboni/collections.js:595
-msgid "Follow this Collection"
-msgstr ""
-
-#: static/js/impala/collections.js:19
-msgid "Stop Following"
-msgstr ""
-
-#: static/js/impala/collections.js:20
-msgid "Following"
-msgstr ""
-
-#. L10n: {0} is an app name.
-#: static/js/impala/listing.js:11 static/js/zamboni/themes.js:13
-msgid "This theme is incompatible with your version of {0}"
-msgstr ""
-
-#: static/js/impala/persona_creation.js:60
-msgid "All Rights Reserved"
-msgstr ""
-
-#: static/js/impala/persona_creation.js:64
-msgid "Creative Commons Attribution 3.0"
-msgstr ""
-
-#: static/js/impala/persona_creation.js:69
-msgid "Creative Commons Attribution-NonCommercial 3.0"
-msgstr ""
-
-#: static/js/impala/persona_creation.js:74
-msgid "Creative Commons Attribution-NonCommercial-NoDerivs 3.0"
-msgstr ""
-
-#: static/js/impala/persona_creation.js:79
-msgid "Creative Commons Attribution-NonCommercial-Share Alike 3.0"
-msgstr ""
-
-#: static/js/impala/persona_creation.js:84
-msgid "Creative Commons Attribution-NoDerivs 3.0"
-msgstr ""
-
-#: static/js/impala/persona_creation.js:89
-msgid "Creative Commons Attribution-ShareAlike 3.0"
-msgstr ""
-
-#: static/js/impala/persona_creation.js:292
-msgid "Your Theme's Name"
-msgstr ""
-
-#: static/js/impala/reviews.js:23 static/js/zamboni/reviews.js:18
-msgid "Flagged for review"
-msgstr ""
-
-#: static/js/impala/reviews.js:40 static/js/zamboni/reviews.js:34
-msgid "Your input is required"
-msgstr ""
-
-#: static/js/impala/reviews.js:152 static/js/zamboni/reviews.js:103
-msgid "Marked for deletion"
-msgstr ""
-
-#: static/js/impala/search.js:114
-msgid "Updating results&hellip;"
-msgstr ""
-
-#: static/js/impala/site_suggestions.js:46
-msgid "Category"
-msgstr ""
-
-#: static/js/impala/suggestions.js:39
-msgid "Search themes for <b>{0}</b>"
-msgstr ""
-
-#: static/js/impala/suggestions.js:41
-msgid "Search apps for <b>{0}</b>"
-msgstr ""
-
-#: static/js/impala/suggestions.js:43
-msgid "Search add-ons for <b>{0}</b>"
-msgstr ""
-
-#: static/js/impala/users.js:33
-msgid "use original"
-msgstr ""
-
-#: static/js/impala/stats/chart.js:267
+#: static/js/impala/stats/chart.js:267 static/js/zamboni/stats-all.js:16898 static/js/zamboni/stats-min.js:5
 msgid "Week of {0}"
 msgstr ""
 
-#: static/js/impala/stats/chart.js:269
+#: static/js/impala/stats/chart.js:269 static/js/zamboni/stats-all.js:16900 static/js/zamboni/stats-min.js:5
 msgid " downloads"
 msgstr ""
 
-#: static/js/impala/stats/chart.js:270
+#: static/js/impala/stats/chart.js:270 static/js/zamboni/stats-all.js:16901 static/js/zamboni/stats-min.js:5
 msgid "{0} users"
 msgstr ""
 
-#: static/js/impala/stats/chart.js:271
+#: static/js/impala/stats/chart.js:271 static/js/zamboni/stats-all.js:16902 static/js/zamboni/stats-min.js:5
 msgid "{0} add-ons"
 msgstr ""
 
-#: static/js/impala/stats/chart.js:272
+#: static/js/impala/stats/chart.js:272 static/js/zamboni/stats-all.js:16903 static/js/zamboni/stats-min.js:5
 msgid "{0} collections"
 msgstr ""
 
-#: static/js/impala/stats/chart.js:273
+#: static/js/impala/stats/chart.js:273 static/js/zamboni/stats-all.js:16904 static/js/zamboni/stats-min.js:5
 msgid "{0} reviews"
 msgstr ""
 
-#: static/js/impala/stats/chart.js:275
+#: static/js/impala/stats/chart.js:275 static/js/zamboni/stats-all.js:16906 static/js/zamboni/stats-min.js:5
 msgid "{0} sales"
 msgstr ""
 
-#: static/js/impala/stats/chart.js:276
+#: static/js/impala/stats/chart.js:276 static/js/zamboni/stats-all.js:16907 static/js/zamboni/stats-min.js:5
 msgid "{0} refunds"
 msgstr ""
 
-#: static/js/impala/stats/chart.js:277
+#: static/js/impala/stats/chart.js:277 static/js/zamboni/stats-all.js:16908 static/js/zamboni/stats-min.js:5
 msgid "{0} installs"
 msgstr ""
 
-#: static/js/impala/stats/chart.js:369 static/js/impala/stats/csv_keys.js:3 static/js/impala/stats/csv_keys.js:109
+#: static/js/impala/stats/chart.js:369 static/js/impala/stats/csv_keys.js:3 static/js/impala/stats/csv_keys.js:109 static/js/zamboni/stats-all.js:15284 static/js/zamboni/stats-all.js:15390
+#: static/js/zamboni/stats-all.js:17000 static/js/zamboni/stats-min.js:4 static/js/zamboni/stats-min.js:5
 msgid "Downloads"
 msgstr ""
 
-#: static/js/impala/stats/chart.js:379 static/js/impala/stats/csv_keys.js:6 static/js/impala/stats/csv_keys.js:110
+#: static/js/impala/stats/chart.js:379 static/js/impala/stats/csv_keys.js:6 static/js/impala/stats/csv_keys.js:110 static/js/zamboni/stats-all.js:15287 static/js/zamboni/stats-all.js:15391
+#: static/js/zamboni/stats-all.js:17010 static/js/zamboni/stats-min.js:4 static/js/zamboni/stats-min.js:5
 msgid "Daily Users"
 msgstr ""
 
-#: static/js/impala/stats/chart.js:410
+#: static/js/impala/stats/chart.js:410 static/js/zamboni/stats-all.js:17041 static/js/zamboni/stats-min.js:5
 msgid "Amount, in USD"
 msgstr ""
 
-#: static/js/impala/stats/chart.js:421 static/js/impala/stats/csv_keys.js:104
+#: static/js/impala/stats/chart.js:421 static/js/impala/stats/csv_keys.js:104 static/js/zamboni/stats-all.js:15385 static/js/zamboni/stats-all.js:17052 static/js/zamboni/stats-min.js:5
 msgid "Number of Contributions"
 msgstr ""
 
-#: static/js/impala/stats/chart.js:447
+#: static/js/impala/stats/chart.js:447 static/js/zamboni/stats-all.js:17078 static/js/zamboni/stats-min.js:5
 msgid "More Info..."
 msgstr ""
 
 #. L10n: {0} is an ISO-formatted date.
-#: static/js/impala/stats/chart.js:451
+#: static/js/impala/stats/chart.js:451 static/js/zamboni/stats-all.js:17082 static/js/zamboni/stats-min.js:5
 msgid "Details for {0}"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:9
+#: static/js/impala/stats/csv_keys.js:9 static/js/zamboni/stats-all.js:15290 static/js/zamboni/stats-min.js:4
 msgid "Collections Created"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:12
+#: static/js/impala/stats/csv_keys.js:12 static/js/zamboni/stats-all.js:15293 static/js/zamboni/stats-min.js:4
 msgid "Add-ons in Use"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:15
+#: static/js/impala/stats/csv_keys.js:15 static/js/zamboni/stats-all.js:15296 static/js/zamboni/stats-min.js:4
 msgid "Add-ons Created"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:18
+#: static/js/impala/stats/csv_keys.js:18 static/js/zamboni/stats-all.js:15299 static/js/zamboni/stats-min.js:4
 msgid "Add-ons Downloaded"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:21
+#: static/js/impala/stats/csv_keys.js:21 static/js/zamboni/stats-all.js:15302 static/js/zamboni/stats-min.js:4
 msgid "Add-ons Updated"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:24
+#: static/js/impala/stats/csv_keys.js:24 static/js/zamboni/stats-all.js:15305 static/js/zamboni/stats-min.js:4
 msgid "Reviews Written"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:27
+#: static/js/impala/stats/csv_keys.js:27 static/js/zamboni/stats-all.js:15308 static/js/zamboni/stats-min.js:4
 msgid "User Signups"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:30
+#: static/js/impala/stats/csv_keys.js:30 static/js/zamboni/stats-all.js:15311 static/js/zamboni/stats-min.js:4
 msgid "Subscribers"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:33
+#: static/js/impala/stats/csv_keys.js:33 static/js/zamboni/stats-all.js:15314 static/js/zamboni/stats-min.js:4
 msgid "Ratings"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:36 static/js/impala/stats/csv_keys.js:114
+#: static/js/impala/stats/csv_keys.js:36 static/js/impala/stats/csv_keys.js:114 static/js/zamboni/stats-all.js:15317 static/js/zamboni/stats-all.js:15395 static/js/zamboni/stats-min.js:4
+#: static/js/zamboni/stats-min.js:5
 msgid "Sales"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:39 static/js/impala/stats/csv_keys.js:113
+#: static/js/impala/stats/csv_keys.js:39 static/js/impala/stats/csv_keys.js:113 static/js/zamboni/stats-all.js:15320 static/js/zamboni/stats-all.js:15394 static/js/zamboni/stats-min.js:4
+#: static/js/zamboni/stats-min.js:5
 msgid "Installs"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:42
+#: static/js/impala/stats/csv_keys.js:42 static/js/zamboni/stats-all.js:15323 static/js/zamboni/stats-min.js:4
 msgid "Unknown"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:43
+#: static/js/impala/stats/csv_keys.js:43 static/js/zamboni/stats-all.js:15324 static/js/zamboni/stats-min.js:4
 msgid "Add-ons Manager"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:44
+#: static/js/impala/stats/csv_keys.js:44 static/js/zamboni/stats-all.js:15325 static/js/zamboni/stats-min.js:4
 msgid "Add-ons Manager Promo"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:45
+#: static/js/impala/stats/csv_keys.js:45 static/js/zamboni/stats-all.js:15326 static/js/zamboni/stats-min.js:4
 msgid "Add-ons Manager Featured"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:46
+#: static/js/impala/stats/csv_keys.js:46 static/js/zamboni/stats-all.js:15327 static/js/zamboni/stats-min.js:4
 msgid "Add-ons Manager Learn More"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:47
+#: static/js/impala/stats/csv_keys.js:47 static/js/zamboni/stats-all.js:15328 static/js/zamboni/stats-min.js:4
 msgid "Search Suggestions"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:48
+#: static/js/impala/stats/csv_keys.js:48 static/js/zamboni/stats-all.js:15329 static/js/zamboni/stats-min.js:4
 msgid "Search Results"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:49 static/js/impala/stats/csv_keys.js:50 static/js/impala/stats/csv_keys.js:51
+#: static/js/impala/stats/csv_keys.js:49 static/js/impala/stats/csv_keys.js:50 static/js/impala/stats/csv_keys.js:51 static/js/zamboni/stats-all.js:15330 static/js/zamboni/stats-all.js:15331
+#: static/js/zamboni/stats-all.js:15332 static/js/zamboni/stats-min.js:4
 msgid "Homepage Promo"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:52 static/js/impala/stats/csv_keys.js:53
+#: static/js/impala/stats/csv_keys.js:52 static/js/impala/stats/csv_keys.js:53 static/js/zamboni/stats-all.js:15333 static/js/zamboni/stats-all.js:15334 static/js/zamboni/stats-min.js:4
 msgid "Homepage Featured"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:54 static/js/impala/stats/csv_keys.js:55
+#: static/js/impala/stats/csv_keys.js:54 static/js/impala/stats/csv_keys.js:55 static/js/zamboni/stats-all.js:15335 static/js/zamboni/stats-all.js:15336 static/js/zamboni/stats-min.js:4
 msgid "Homepage Up and Coming"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:56
+#: static/js/impala/stats/csv_keys.js:56 static/js/zamboni/stats-all.js:15337 static/js/zamboni/stats-min.js:4
 msgid "Homepage Most Popular"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:57 static/js/impala/stats/csv_keys.js:59
+#: static/js/impala/stats/csv_keys.js:57 static/js/impala/stats/csv_keys.js:59 static/js/zamboni/stats-all.js:15338 static/js/zamboni/stats-all.js:15340 static/js/zamboni/stats-min.js:4
 msgid "Detail Page"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:58 static/js/impala/stats/csv_keys.js:60
+#: static/js/impala/stats/csv_keys.js:58 static/js/impala/stats/csv_keys.js:60 static/js/zamboni/stats-all.js:15339 static/js/zamboni/stats-all.js:15341 static/js/zamboni/stats-min.js:4
 msgid "Detail Page (bottom)"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:61
+#: static/js/impala/stats/csv_keys.js:61 static/js/zamboni/stats-all.js:15342 static/js/zamboni/stats-min.js:4
 msgid "Detail Page (Development Channel)"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:62 static/js/impala/stats/csv_keys.js:63 static/js/impala/stats/csv_keys.js:64
+#: static/js/impala/stats/csv_keys.js:62 static/js/impala/stats/csv_keys.js:63 static/js/impala/stats/csv_keys.js:64 static/js/zamboni/stats-all.js:15343 static/js/zamboni/stats-all.js:15344
+#: static/js/zamboni/stats-all.js:15345 static/js/zamboni/stats-min.js:4
 msgid "Often Used With"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:65 static/js/impala/stats/csv_keys.js:66
+#: static/js/impala/stats/csv_keys.js:65 static/js/impala/stats/csv_keys.js:66 static/js/zamboni/stats-all.js:15346 static/js/zamboni/stats-all.js:15347 static/js/zamboni/stats-min.js:4
 msgid "Others By Author"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:67 static/js/impala/stats/csv_keys.js:68
+#: static/js/impala/stats/csv_keys.js:67 static/js/impala/stats/csv_keys.js:68 static/js/zamboni/stats-all.js:15348 static/js/zamboni/stats-all.js:15349 static/js/zamboni/stats-min.js:4
 msgid "Dependencies"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:69 static/js/impala/stats/csv_keys.js:70
+#: static/js/impala/stats/csv_keys.js:69 static/js/impala/stats/csv_keys.js:70 static/js/zamboni/stats-all.js:15350 static/js/zamboni/stats-all.js:15351 static/js/zamboni/stats-min.js:4
 msgid "Upsell"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:71
+#: static/js/impala/stats/csv_keys.js:71 static/js/zamboni/stats-all.js:15352 static/js/zamboni/stats-min.js:4
 msgid "Meet the Developer"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:72
+#: static/js/impala/stats/csv_keys.js:72 static/js/zamboni/stats-all.js:15353 static/js/zamboni/stats-min.js:4
 msgid "User Profile"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:73
+#: static/js/impala/stats/csv_keys.js:73 static/js/zamboni/stats-all.js:15354 static/js/zamboni/stats-min.js:4
 msgid "Version History"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:75
+#: static/js/impala/stats/csv_keys.js:75 static/js/zamboni/stats-all.js:15356 static/js/zamboni/stats-min.js:4
 msgid "Sharing"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:76
+#: static/js/impala/stats/csv_keys.js:76 static/js/zamboni/stats-all.js:15357 static/js/zamboni/stats-min.js:4
 msgid "Category Pages"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:77
+#: static/js/impala/stats/csv_keys.js:77 static/js/zamboni/stats-all.js:15358 static/js/zamboni/stats-min.js:4
 msgid "Collections"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:78 static/js/impala/stats/csv_keys.js:79
+#: static/js/impala/stats/csv_keys.js:78 static/js/impala/stats/csv_keys.js:79 static/js/zamboni/stats-all.js:15359 static/js/zamboni/stats-all.js:15360 static/js/zamboni/stats-min.js:4
 msgid "Category Landing Featured Carousel"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:80 static/js/impala/stats/csv_keys.js:81
+#: static/js/impala/stats/csv_keys.js:80 static/js/impala/stats/csv_keys.js:81 static/js/zamboni/stats-all.js:15361 static/js/zamboni/stats-all.js:15362 static/js/zamboni/stats-min.js:4
 msgid "Category Landing Top Rated"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:82 static/js/impala/stats/csv_keys.js:83
+#: static/js/impala/stats/csv_keys.js:82 static/js/impala/stats/csv_keys.js:83 static/js/zamboni/stats-all.js:15363 static/js/zamboni/stats-all.js:15364 static/js/zamboni/stats-min.js:5
 msgid "Category Landing Most Popular"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:84 static/js/impala/stats/csv_keys.js:85
+#: static/js/impala/stats/csv_keys.js:84 static/js/impala/stats/csv_keys.js:85 static/js/zamboni/stats-all.js:15365 static/js/zamboni/stats-all.js:15366 static/js/zamboni/stats-min.js:5
 msgid "Category Landing Recently Added"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:86 static/js/impala/stats/csv_keys.js:87
+#: static/js/impala/stats/csv_keys.js:86 static/js/impala/stats/csv_keys.js:87 static/js/zamboni/stats-all.js:15367 static/js/zamboni/stats-all.js:15368 static/js/zamboni/stats-min.js:5
 msgid "Browse Listing Featured Sort"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:88 static/js/impala/stats/csv_keys.js:89
+#: static/js/impala/stats/csv_keys.js:88 static/js/impala/stats/csv_keys.js:89 static/js/zamboni/stats-all.js:15369 static/js/zamboni/stats-all.js:15370 static/js/zamboni/stats-min.js:5
 msgid "Browse Listing Users Sort"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:90 static/js/impala/stats/csv_keys.js:91
+#: static/js/impala/stats/csv_keys.js:90 static/js/impala/stats/csv_keys.js:91 static/js/zamboni/stats-all.js:15371 static/js/zamboni/stats-all.js:15372 static/js/zamboni/stats-min.js:5
 msgid "Browse Listing Rating Sort"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:92 static/js/impala/stats/csv_keys.js:93
+#: static/js/impala/stats/csv_keys.js:92 static/js/impala/stats/csv_keys.js:93 static/js/zamboni/stats-all.js:15373 static/js/zamboni/stats-all.js:15374 static/js/zamboni/stats-min.js:5
 msgid "Browse Listing Created Sort"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:94 static/js/impala/stats/csv_keys.js:95
+#: static/js/impala/stats/csv_keys.js:94 static/js/impala/stats/csv_keys.js:95 static/js/zamboni/stats-all.js:15375 static/js/zamboni/stats-all.js:15376 static/js/zamboni/stats-min.js:5
 msgid "Browse Listing Name Sort"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:96 static/js/impala/stats/csv_keys.js:97
+#: static/js/impala/stats/csv_keys.js:96 static/js/impala/stats/csv_keys.js:97 static/js/zamboni/stats-all.js:15377 static/js/zamboni/stats-all.js:15378 static/js/zamboni/stats-min.js:5
 msgid "Browse Listing Popular Sort"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:98 static/js/impala/stats/csv_keys.js:99
+#: static/js/impala/stats/csv_keys.js:98 static/js/impala/stats/csv_keys.js:99 static/js/zamboni/stats-all.js:15379 static/js/zamboni/stats-all.js:15380 static/js/zamboni/stats-min.js:5
 msgid "Browse Listing Updated Sort"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:100 static/js/impala/stats/csv_keys.js:101
+#: static/js/impala/stats/csv_keys.js:100 static/js/impala/stats/csv_keys.js:101 static/js/zamboni/stats-all.js:15381 static/js/zamboni/stats-all.js:15382 static/js/zamboni/stats-min.js:5
 msgid "Browse Listing Up and Coming Sort"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:105
+#: static/js/impala/stats/csv_keys.js:105 static/js/zamboni/stats-all.js:15386 static/js/zamboni/stats-min.js:5
 msgid "Total Amount Contributed"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:106
+#: static/js/impala/stats/csv_keys.js:106 static/js/zamboni/stats-all.js:15387 static/js/zamboni/stats-min.js:5
 msgid "Average Contribution"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:115
+#: static/js/impala/stats/csv_keys.js:115 static/js/zamboni/stats-all.js:15396 static/js/zamboni/stats-min.js:5
 msgid "Usage"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:118
+#: static/js/impala/stats/csv_keys.js:118 static/js/zamboni/stats-all.js:15399 static/js/zamboni/stats-min.js:5
 msgid "Firefox"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:119
+#: static/js/impala/stats/csv_keys.js:119 static/js/zamboni/stats-all.js:15400 static/js/zamboni/stats-min.js:5
 msgid "Mozilla"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:120
+#: static/js/impala/stats/csv_keys.js:120 static/js/zamboni/stats-all.js:15401 static/js/zamboni/stats-min.js:5
 msgid "Thunderbird"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:121
+#: static/js/impala/stats/csv_keys.js:121 static/js/zamboni/stats-all.js:15402 static/js/zamboni/stats-min.js:5
 msgid "Sunbird"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:122
+#: static/js/impala/stats/csv_keys.js:122 static/js/zamboni/stats-all.js:15403 static/js/zamboni/stats-min.js:5
 msgid "SeaMonkey"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:123
+#: static/js/impala/stats/csv_keys.js:123 static/js/zamboni/stats-all.js:15404 static/js/zamboni/stats-min.js:5
 msgid "Fennec"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:124
+#: static/js/impala/stats/csv_keys.js:124 static/js/zamboni/stats-all.js:15405 static/js/zamboni/stats-min.js:5
 msgid "Android"
 msgstr ""
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:129
+#: static/js/impala/stats/csv_keys.js:129 static/js/zamboni/stats-all.js:15410 static/js/zamboni/stats-min.js:5
 msgid "Downloads and Daily Users, last {0} days"
 msgstr ""
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:131
+#: static/js/impala/stats/csv_keys.js:131 static/js/zamboni/stats-all.js:15412 static/js/zamboni/stats-min.js:5
 msgid "Downloads and Daily Users from {0} to {1}"
 msgstr ""
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:135
+#: static/js/impala/stats/csv_keys.js:135 static/js/zamboni/stats-all.js:15416 static/js/zamboni/stats-min.js:5
 msgid "Installs and Daily Users, last {0} days"
 msgstr ""
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:137
+#: static/js/impala/stats/csv_keys.js:137 static/js/zamboni/stats-all.js:15418 static/js/zamboni/stats-min.js:5
 msgid "Installs and Daily Users from {0} to {1}"
 msgstr ""
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:141
+#: static/js/impala/stats/csv_keys.js:141 static/js/zamboni/stats-all.js:15422 static/js/zamboni/stats-min.js:5
 msgid "Downloads, last {0} days"
 msgstr ""
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:143
+#: static/js/impala/stats/csv_keys.js:143 static/js/zamboni/stats-all.js:15424 static/js/zamboni/stats-min.js:5
 msgid "Downloads from {0} to {1}"
 msgstr ""
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:147
+#: static/js/impala/stats/csv_keys.js:147 static/js/zamboni/stats-all.js:15428 static/js/zamboni/stats-min.js:5
 msgid "Daily Users, last {0} days"
 msgstr ""
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:149
+#: static/js/impala/stats/csv_keys.js:149 static/js/zamboni/stats-all.js:15430 static/js/zamboni/stats-min.js:5
 msgid "Daily Users from {0} to {1}"
 msgstr ""
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:153
+#: static/js/impala/stats/csv_keys.js:153 static/js/zamboni/stats-all.js:15434 static/js/zamboni/stats-min.js:5
 msgid "Applications, last {0} days"
 msgstr ""
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:155
+#: static/js/impala/stats/csv_keys.js:155 static/js/zamboni/stats-all.js:15436 static/js/zamboni/stats-min.js:5
 msgid "Applications from {0} to {1}"
 msgstr ""
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:159
+#: static/js/impala/stats/csv_keys.js:159 static/js/zamboni/stats-all.js:15440 static/js/zamboni/stats-min.js:5
 msgid "Platforms, last {0} days"
 msgstr ""
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:161
+#: static/js/impala/stats/csv_keys.js:161 static/js/zamboni/stats-all.js:15442 static/js/zamboni/stats-min.js:5
 msgid "Platforms from {0} to {1}"
 msgstr ""
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:165
+#: static/js/impala/stats/csv_keys.js:165 static/js/zamboni/stats-all.js:15446 static/js/zamboni/stats-min.js:5
 msgid "Languages, last {0} days"
 msgstr ""
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:167
+#: static/js/impala/stats/csv_keys.js:167 static/js/zamboni/stats-all.js:15448 static/js/zamboni/stats-min.js:5
 msgid "Languages from {0} to {1}"
 msgstr ""
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:171
+#: static/js/impala/stats/csv_keys.js:171 static/js/zamboni/stats-all.js:15452 static/js/zamboni/stats-min.js:5
 msgid "Add-on Versions, last {0} days"
 msgstr ""
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:173
+#: static/js/impala/stats/csv_keys.js:173 static/js/zamboni/stats-all.js:15454 static/js/zamboni/stats-min.js:5
 msgid "Add-on Versions from {0} to {1}"
 msgstr ""
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:177
+#: static/js/impala/stats/csv_keys.js:177 static/js/zamboni/stats-all.js:15458 static/js/zamboni/stats-min.js:5
 msgid "Add-on Status, last {0} days"
 msgstr ""
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:179
+#: static/js/impala/stats/csv_keys.js:179 static/js/zamboni/stats-all.js:15460 static/js/zamboni/stats-min.js:5
 msgid "Add-on Status from {0} to {1}"
 msgstr ""
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:183
+#: static/js/impala/stats/csv_keys.js:183 static/js/zamboni/stats-all.js:15464 static/js/zamboni/stats-min.js:5
 msgid "Download Sources, last {0} days"
 msgstr ""
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:185
+#: static/js/impala/stats/csv_keys.js:185 static/js/zamboni/stats-all.js:15466 static/js/zamboni/stats-min.js:5
 msgid "Download Sources from {0} to {1}"
 msgstr ""
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:189
+#: static/js/impala/stats/csv_keys.js:189 static/js/zamboni/stats-all.js:15470 static/js/zamboni/stats-min.js:5
 msgid "Contributions, last {0} days"
 msgstr ""
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:191
+#: static/js/impala/stats/csv_keys.js:191 static/js/zamboni/stats-all.js:15472 static/js/zamboni/stats-min.js:5
 msgid "Contributions from {0} to {1}"
 msgstr ""
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:195
+#: static/js/impala/stats/csv_keys.js:195 static/js/zamboni/stats-all.js:15476 static/js/zamboni/stats-min.js:5
 msgid "Site Metrics, last {0} days"
 msgstr ""
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:197
+#: static/js/impala/stats/csv_keys.js:197 static/js/zamboni/stats-all.js:15478 static/js/zamboni/stats-min.js:5
 msgid "Site Metrics from {0} to {1}"
 msgstr ""
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:201
+#: static/js/impala/stats/csv_keys.js:201 static/js/zamboni/stats-all.js:15482 static/js/zamboni/stats-min.js:5
 msgid "Add-ons in Use, last {0} days"
 msgstr ""
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:203
+#: static/js/impala/stats/csv_keys.js:203 static/js/zamboni/stats-all.js:15484 static/js/zamboni/stats-min.js:5
 msgid "Add-ons in Use from {0} to {1}"
 msgstr ""
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:207
+#: static/js/impala/stats/csv_keys.js:207 static/js/zamboni/stats-all.js:15488 static/js/zamboni/stats-min.js:5
 msgid "Add-ons Downloaded, last {0} days"
 msgstr ""
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:209
+#: static/js/impala/stats/csv_keys.js:209 static/js/zamboni/stats-all.js:15490 static/js/zamboni/stats-min.js:5
 msgid "Add-ons Downloaded from {0} to {1}"
 msgstr ""
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:213
+#: static/js/impala/stats/csv_keys.js:213 static/js/zamboni/stats-all.js:15494 static/js/zamboni/stats-min.js:5
 msgid "Add-ons Created, last {0} days"
 msgstr ""
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:215
+#: static/js/impala/stats/csv_keys.js:215 static/js/zamboni/stats-all.js:15496 static/js/zamboni/stats-min.js:5
 msgid "Add-ons Created from {0} to {1}"
 msgstr ""
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:219
+#: static/js/impala/stats/csv_keys.js:219 static/js/zamboni/stats-all.js:15500 static/js/zamboni/stats-min.js:5
 msgid "Add-ons Updated, last {0} days"
 msgstr ""
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:221
+#: static/js/impala/stats/csv_keys.js:221 static/js/zamboni/stats-all.js:15502 static/js/zamboni/stats-min.js:5
 msgid "Add-ons Updated from {0} to {1}"
 msgstr ""
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:225
+#: static/js/impala/stats/csv_keys.js:225 static/js/zamboni/stats-all.js:15506 static/js/zamboni/stats-min.js:5
 msgid "Reviews Written, last {0} days"
 msgstr ""
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:227
+#: static/js/impala/stats/csv_keys.js:227 static/js/zamboni/stats-all.js:15508 static/js/zamboni/stats-min.js:5
 msgid "Reviews Written from {0} to {1}"
 msgstr ""
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:231
+#: static/js/impala/stats/csv_keys.js:231 static/js/zamboni/stats-all.js:15512 static/js/zamboni/stats-min.js:5
 msgid "User Signups, last {0} days"
 msgstr ""
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:233
+#: static/js/impala/stats/csv_keys.js:233 static/js/zamboni/stats-all.js:15514 static/js/zamboni/stats-min.js:5
 msgid "User Signups from {0} to {1}"
 msgstr ""
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:237
+#: static/js/impala/stats/csv_keys.js:237 static/js/zamboni/stats-all.js:15518 static/js/zamboni/stats-min.js:5
 msgid "Collections Created, last {0} days"
 msgstr ""
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:239
+#: static/js/impala/stats/csv_keys.js:239 static/js/zamboni/stats-all.js:15520 static/js/zamboni/stats-min.js:5
 msgid "Collections Created from {0} to {1}"
 msgstr ""
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:243
+#: static/js/impala/stats/csv_keys.js:243 static/js/zamboni/stats-all.js:15524 static/js/zamboni/stats-min.js:5
 msgid "Subscribers, last {0} days"
 msgstr ""
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:245
+#: static/js/impala/stats/csv_keys.js:245 static/js/zamboni/stats-all.js:15526 static/js/zamboni/stats-min.js:5
 msgid "Subscribers from {0} to {1}"
 msgstr ""
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:249
+#: static/js/impala/stats/csv_keys.js:249 static/js/zamboni/stats-all.js:15530 static/js/zamboni/stats-min.js:5
 msgid "Ratings, last {0} days"
 msgstr ""
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:251
+#: static/js/impala/stats/csv_keys.js:251 static/js/zamboni/stats-all.js:15532 static/js/zamboni/stats-min.js:5
 msgid "Ratings from {0} to {1}"
 msgstr ""
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:255
+#: static/js/impala/stats/csv_keys.js:255 static/js/zamboni/stats-all.js:15536 static/js/zamboni/stats-min.js:5
 msgid "Sales, last {0} days"
 msgstr ""
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:257
+#: static/js/impala/stats/csv_keys.js:257 static/js/zamboni/stats-all.js:15538 static/js/zamboni/stats-min.js:5
 msgid "Sales from {0} to {1}"
 msgstr ""
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:261
+#: static/js/impala/stats/csv_keys.js:261 static/js/zamboni/stats-all.js:15542 static/js/zamboni/stats-min.js:5
 msgid "Installs, last {0} days"
 msgstr ""
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:263
+#: static/js/impala/stats/csv_keys.js:263 static/js/zamboni/stats-all.js:15544 static/js/zamboni/stats-min.js:5
 msgid "Installs from {0} to {1}"
 msgstr ""
 
 #. L10n: {0} and {1} are integers.
-#: static/js/impala/stats/csv_keys.js:269
+#: static/js/impala/stats/csv_keys.js:269 static/js/zamboni/stats-all.js:15550 static/js/zamboni/stats-min.js:5
 msgid "<b>{0}</b> in last {1} days"
 msgstr ""
 
 #. L10n: {0} is an integer and {1} and {2} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:271 static/js/impala/stats/csv_keys.js:277
+#: static/js/impala/stats/csv_keys.js:271 static/js/impala/stats/csv_keys.js:277 static/js/zamboni/stats-all.js:15552 static/js/zamboni/stats-all.js:15558 static/js/zamboni/stats-min.js:5
 msgid "<b>{0}</b> from {1} to {2}"
 msgstr ""
 
 #. L10n: {0} and {1} are integers.
-#: static/js/impala/stats/csv_keys.js:275
+#: static/js/impala/stats/csv_keys.js:275 static/js/zamboni/stats-all.js:15556 static/js/zamboni/stats-min.js:5
 msgid "<b>{0}</b> average in last {1} days"
 msgstr ""
 
-#: static/js/impala/stats/overview.js:19
+#: static/js/impala/stats/overview.js:19 static/js/zamboni/stats-all.js:16469 static/js/zamboni/stats-min.js:5
 msgid "No data available."
 msgstr ""
 
-#: static/js/impala/stats/table.js:74
+#: static/js/impala/stats/table.js:74 static/js/zamboni/stats-all.js:17209 static/js/zamboni/stats-min.js:5
 msgid "Date"
 msgstr ""
 
-#: static/js/impala/stats/topchart.js:96
+#: static/js/impala/stats/topchart.js:96 static/js/zamboni/stats-all.js:16600 static/js/zamboni/stats-min.js:5
 msgid "Other"
 msgstr ""
 
-#: static/js/zamboni/admin_validation.js:24 static/js/zamboni/devhub.js:1229 static/js/zamboni/editors.js:295
+#: static/js/zamboni/admin-all.js:180 static/js/zamboni/admin-min.js:1 static/js/zamboni/admin_validation.js:24 static/js/zamboni/devhub-all.js:2408 static/js/zamboni/devhub-min.js:2
+#: static/js/zamboni/devhub.js:1229 static/js/zamboni/editors-all.js:15576 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:295
 msgid "Select an application first"
 msgstr ""
 
-#: static/js/zamboni/admin_validation.js:51
+#: static/js/zamboni/admin-all.js:207 static/js/zamboni/admin-min.js:1 static/js/zamboni/admin_validation.js:51
 msgid "Set {0} add-on to a max version of {1} and email the author."
 msgid_plural "Set {0} add-ons to a max version of {1} and email the authors."
 msgstr[0] ""
 msgstr[1] ""
 
-#: static/js/zamboni/admin_validation.js:54
+#: static/js/zamboni/admin-all.js:210 static/js/zamboni/admin-min.js:1 static/js/zamboni/admin_validation.js:54
 msgid "Email author of {2} add-on which failed validation."
 msgid_plural "Email authors of {2} add-ons which failed validation."
 msgstr[0] ""
 msgstr[1] ""
 
-#. L10n: {0} is an app name like Firefox.
-#: static/js/zamboni/buttons.js:66
-msgid "Accept and Install"
-msgstr ""
-
-#: static/js/zamboni/buttons.js:66
-msgid "Add to {0}"
-msgstr ""
-
-#: static/js/zamboni/buttons.js:71
-msgid "Download Now"
-msgstr ""
-
-#: static/js/zamboni/buttons.js:112
-msgid "Add-on has not been updated to support default-to-compatible."
-msgstr ""
-
-#: static/js/zamboni/buttons.js:117
-msgid "You need to be using Firefox 10.0 or higher."
-msgstr ""
-
-#: static/js/zamboni/buttons.js:129
-msgid "Mozilla has marked this version as incompatible with your Firefox version."
-msgstr ""
-
-#. L10n: {0} is an platform like Windows or Linux.
-#: static/js/zamboni/buttons.js:210
-msgid "Install for {0} anyway"
-msgstr ""
-
-#: static/js/zamboni/buttons.js:210
-msgid "Download for {0} anyway"
-msgstr ""
-
-#: static/js/zamboni/buttons.js:267
-msgid "Not available for your platform"
-msgstr ""
-
-#. L10n: {0} is an app name, {1} is the app version.
-#: static/js/zamboni/buttons.js:278 static/js/zamboni/buttons.js:315
-msgid "Not available for {0} {1}"
-msgstr ""
-
-#: static/js/zamboni/buttons.js:341
-msgid "Works with {app} {min} - {max}"
-msgstr ""
-
-#: static/js/zamboni/buttons.js:343
-msgid "View other versions"
-msgstr ""
-
-#: static/js/zamboni/buttons.js:391
-msgid "Only with Firefox — Get Firefox Now!"
-msgstr ""
-
-#: static/js/zamboni/buttons.js:507 static/js/zamboni/mobile/buttons.js:43
-msgid "Sorry, you need a Mozilla-based browser (such as Firefox) to install a search plugin."
-msgstr ""
-
-#: static/js/zamboni/collections.js:229
-msgid "Adding to Favorites&hellip;"
-msgstr ""
-
-#: static/js/zamboni/collections.js:232
-msgid "Removing Favorite&hellip;"
-msgstr ""
-
-#: static/js/zamboni/collections.js:235
-msgid "Add to Favorites"
-msgstr ""
-
-#: static/js/zamboni/collections.js:238
-msgid "Remove from Favorites"
-msgstr ""
-
-#: static/js/zamboni/collections.js:303
-msgid "Pending"
-msgstr ""
-
-#: static/js/zamboni/collections.js:304
-msgid "Add a comment"
-msgstr ""
-
-#: static/js/zamboni/collections.js:304
-msgid "Comment"
-msgstr ""
-
-#: static/js/zamboni/collections.js:305
-msgid "Remove this add-on from the collection"
-msgstr ""
-
-#: static/js/zamboni/collections.js:305 static/js/zamboni/collections.js:334
-msgid "Remove"
-msgstr ""
-
-#: static/js/zamboni/collections.js:334
-msgid "Remove this user as a contributor"
-msgstr ""
-
-#: static/js/zamboni/collections.js:346
-msgid "An email address is required."
-msgstr ""
-
-#: static/js/zamboni/collections.js:364
-msgid "You cannot add yourself as a contributor."
-msgstr ""
-
-#: static/js/zamboni/collections.js:366
-msgid "You have already added that user."
-msgstr ""
-
-#: static/js/zamboni/collections.js:573
-msgid "Add to favorites"
-msgstr ""
-
-#: static/js/zamboni/collections.js:577
-msgid "Remove from favorites"
-msgstr ""
-
-#: static/js/zamboni/collections.js:604
-msgid "Stop following"
-msgstr ""
-
-#: static/js/zamboni/devhub.js:110
+#: static/js/zamboni/devhub-all.js:1289 static/js/zamboni/devhub-min.js:1 static/js/zamboni/devhub.js:110
 msgid "Your browser does not support the video tag"
 msgstr ""
 
-#: static/js/zamboni/devhub.js:371
+#: static/js/zamboni/devhub-all.js:1550 static/js/zamboni/devhub-min.js:1 static/js/zamboni/devhub.js:371
 msgid "Changes Saved"
 msgstr ""
 
-#: static/js/zamboni/devhub.js:387
+#: static/js/zamboni/devhub-all.js:1566 static/js/zamboni/devhub-min.js:1 static/js/zamboni/devhub.js:387
 msgid "Enter a new author's email address"
 msgstr ""
 
-#: static/js/zamboni/devhub.js:536
+#: static/js/zamboni/devhub-all.js:1715 static/js/zamboni/devhub-min.js:1 static/js/zamboni/devhub.js:536
 msgid "There was an error uploading your file."
 msgstr ""
 
-#: static/js/zamboni/devhub.js:681
+#: static/js/zamboni/devhub-all.js:1860 static/js/zamboni/devhub-min.js:1 static/js/zamboni/devhub.js:681
 msgid "{files} file"
 msgid_plural "{files} files"
 msgstr[0] ""
 msgstr[1] ""
 
-#: static/js/zamboni/devhub.js:684
+#: static/js/zamboni/devhub-all.js:1863 static/js/zamboni/devhub-min.js:1 static/js/zamboni/devhub.js:684
 msgid "{reviews} user review"
 msgid_plural "{reviews} user reviews"
 msgstr[0] ""
 msgstr[1] ""
 
-#: static/js/zamboni/devhub.js:796
+#: static/js/zamboni/devhub-all.js:1975 static/js/zamboni/devhub-min.js:2 static/js/zamboni/devhub.js:796
 msgid "Learn more"
 msgstr ""
 
-#: static/js/zamboni/devhub.js:800
+#: static/js/zamboni/devhub-all.js:1979 static/js/zamboni/devhub-min.js:2 static/js/zamboni/devhub.js:800
 msgid "Example"
 msgstr ""
 
-#: static/js/zamboni/devhub.js:1130
+#: static/js/zamboni/devhub-all.js:2309 static/js/zamboni/devhub-min.js:2 static/js/zamboni/devhub.js:1130
 msgid "Image changes being processed"
 msgstr ""
 
-#: static/js/zamboni/devhub.js:1280
+#: static/js/zamboni/devhub-all.js:2459 static/js/zamboni/devhub-min.js:2 static/js/zamboni/devhub.js:1280
 msgid "Must be a valid e-mail address."
+msgstr ""
+
+#: static/js/zamboni/devhub-all.js:2613 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:80
+msgid "All tests passed successfully."
+msgstr ""
+
+#: static/js/zamboni/devhub-all.js:2616 static/js/zamboni/devhub-all.js:3011 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:83 static/js/zamboni/validator.js:478
+msgid "These tests were not run."
+msgstr ""
+
+#: static/js/zamboni/devhub-all.js:2664 static/js/zamboni/devhub-all.js:2677 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:131 static/js/zamboni/validator.js:144
+msgid "Tests"
+msgstr ""
+
+#: static/js/zamboni/devhub-all.js:2779 static/js/zamboni/devhub-all.js:3108 static/js/zamboni/devhub-all.js:3127 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:246
+#: static/js/zamboni/validator.js:575 static/js/zamboni/validator.js:594
+msgid "Error"
+msgstr ""
+
+#: static/js/zamboni/devhub-all.js:2780 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:247
+msgid "Warning"
+msgstr ""
+
+#: static/js/zamboni/devhub-all.js:2794 static/js/zamboni/devhub-min.js:2 static/js/zamboni/files-all.js:5657 static/js/zamboni/files-min.js:3 static/js/zamboni/files.js:411
+#: static/js/zamboni/validator.js:261
+msgid "Ignore this message in future updates"
+msgstr ""
+
+#: static/js/zamboni/devhub-all.js:2817 static/js/zamboni/devhub-min.js:2 static/js/zamboni/files-all.js:5663 static/js/zamboni/files-min.js:3 static/js/zamboni/files.js:417
+#: static/js/zamboni/validator.js:284
+msgid "Severity for automated signing:"
+msgstr ""
+
+#: static/js/zamboni/devhub-all.js:2832 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:299
+msgid "Suggestions for passing automated signing:"
+msgstr ""
+
+#: static/js/zamboni/devhub-all.js:2920 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:387
+msgid "Compatibility Tests"
+msgstr ""
+
+#: static/js/zamboni/devhub-all.js:2999 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:466
+msgid "Add-on failed validation."
+msgstr ""
+
+#: static/js/zamboni/devhub-all.js:3001 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:468
+msgid "Add-on passed validation."
+msgstr ""
+
+#: static/js/zamboni/devhub-all.js:3014 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:481
+msgid "{0} error"
+msgid_plural "{0} errors"
+msgstr[0] ""
+msgstr[1] ""
+
+#: static/js/zamboni/devhub-all.js:3016 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:483
+msgid "{0} warning"
+msgid_plural "{0} warnings"
+msgstr[0] ""
+msgstr[1] ""
+
+#: static/js/zamboni/devhub-all.js:3018 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:485
+msgid "{0} notice"
+msgid_plural "{0} notices"
+msgstr[0] ""
+msgstr[1] ""
+
+#: static/js/zamboni/devhub-all.js:3110 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:577
+msgid "Validation task could not complete or completed with errors"
+msgstr ""
+
+#: static/js/zamboni/devhub-all.js:3128 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:595
+msgid "Internal server error"
 msgstr ""
 
 #: static/js/zamboni/devhub_search.js:8
 msgid "No results found."
 msgstr ""
 
-#: static/js/zamboni/editors.js:121
+#: static/js/zamboni/editors-all.js:15402 static/js/zamboni/editors-min.js:4 static/js/zamboni/editors.js:121
 msgid "{name} was viewing this page first."
 msgstr ""
 
-#: static/js/zamboni/editors.js:171
+#: static/js/zamboni/editors-all.js:15452 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:171
 msgid "Receipt checked by app."
 msgstr ""
 
-#: static/js/zamboni/editors.js:173
+#: static/js/zamboni/editors-all.js:15454 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:173
 msgid "Receipt was not checked by app."
 msgstr ""
 
-#: static/js/zamboni/editors.js:244
+#: static/js/zamboni/editors-all.js:15525 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:244
 msgid "{name} was viewing this add-on first."
 msgstr ""
 
-#: static/js/zamboni/editors.js:255
+#: static/js/zamboni/editors-all.js:15536 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:255
 msgid "Loading&hellip;"
 msgstr ""
 
-#: static/js/zamboni/editors.js:260
+#: static/js/zamboni/editors-all.js:15541 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:260
 msgid "Version Notes"
 msgstr ""
 
-#: static/js/zamboni/editors.js:265
+#: static/js/zamboni/editors-all.js:15546 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:265
 msgid "Notes for Reviewers"
 msgstr ""
 
-#: static/js/zamboni/editors.js:270
+#: static/js/zamboni/editors-all.js:15551 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:270
 msgid "No version notes found"
 msgstr ""
 
-#: static/js/zamboni/editors.js:330
+#: static/js/zamboni/editors-all.js:15611 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:330
 msgid "Average Reviews"
 msgstr ""
 
-#: static/js/zamboni/editors.js:386
+#: static/js/zamboni/editors-all.js:15667 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:386
 msgid "Number of Reviews"
 msgstr ""
 
-#: static/js/zamboni/editors.js:445
+#: static/js/zamboni/editors-all.js:15726 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:445
 msgid "Error loading translation"
 msgstr ""
 
-#: static/js/zamboni/files.js:411 static/js/zamboni/validator.js:261
-msgid "Ignore this message in future updates"
-msgstr ""
-
-#: static/js/zamboni/files.js:417 static/js/zamboni/validator.js:284
-msgid "Severity for automated signing:"
-msgstr ""
-
-#: static/js/zamboni/global.js:410
-msgid "Loading..."
-msgstr ""
-
-#. L10n: {0} is the number of characters left.
-#: static/js/zamboni/global.js:474
-msgid "<b>{0}</b> character left."
-msgid_plural "<b>{0}</b> characters left."
-msgstr[0] ""
-msgstr[1] ""
-
-#: static/js/zamboni/init.js:28
-msgid "This feature is temporarily disabled while we perform website maintenance. Please check back a little later."
-msgstr ""
-
-#: static/js/zamboni/l10n.js:45
-msgid "Remove this localization"
-msgstr ""
-
-#: static/js/zamboni/password-strength.js:20
-msgid "Password strength:"
-msgstr ""
-
-#: static/js/zamboni/password-strength.js:26
-msgid "At least {0} character left."
-msgid_plural "At least {0} characters left."
-msgstr[0] ""
-msgstr[1] ""
-
-#: static/js/zamboni/themes_review.js:176
-msgid "Requested Info"
-msgstr ""
-
-#: static/js/zamboni/themes_review.js:177
-msgid "Flagged"
-msgstr ""
-
-#: static/js/zamboni/themes_review.js:178
-msgid "Duplicate"
-msgstr ""
-
-#: static/js/zamboni/themes_review.js:179
-msgid "Rejected"
-msgstr ""
-
-#: static/js/zamboni/themes_review.js:180
-msgid "Approved"
-msgstr ""
-
-#: static/js/zamboni/themes_review.js:424
-msgid "No results found"
-msgstr ""
-
-#: static/js/zamboni/themes_review_templates.js:31
+#: static/js/zamboni/editors-all.js:15975 static/js/zamboni/editors-min.js:5 static/js/zamboni/themes_review_templates.js:31
 msgid "Theme"
 msgstr ""
 
-#: static/js/zamboni/themes_review_templates.js:33
+#: static/js/zamboni/editors-all.js:15977 static/js/zamboni/editors-min.js:5 static/js/zamboni/themes_review_templates.js:33
 msgid "Reviewer"
 msgstr ""
 
-#: static/js/zamboni/themes_review_templates.js:35
+#: static/js/zamboni/editors-all.js:15979 static/js/zamboni/editors-min.js:5 static/js/zamboni/themes_review_templates.js:35
 msgid "Status"
 msgstr ""
 
-#: static/js/zamboni/validator.js:80
-msgid "All tests passed successfully."
+#: static/js/zamboni/editors-all.js:16196 static/js/zamboni/editors-min.js:5 static/js/zamboni/themes_review.js:176
+msgid "Requested Info"
 msgstr ""
 
-#: static/js/zamboni/validator.js:83 static/js/zamboni/validator.js:478
-msgid "These tests were not run."
+#: static/js/zamboni/editors-all.js:16197 static/js/zamboni/editors-min.js:5 static/js/zamboni/themes_review.js:177
+msgid "Flagged"
 msgstr ""
 
-#: static/js/zamboni/validator.js:131 static/js/zamboni/validator.js:144
-msgid "Tests"
+#: static/js/zamboni/editors-all.js:16198 static/js/zamboni/editors-min.js:5 static/js/zamboni/themes_review.js:178
+msgid "Duplicate"
 msgstr ""
 
-#: static/js/zamboni/validator.js:246 static/js/zamboni/validator.js:575 static/js/zamboni/validator.js:594
-msgid "Error"
+#: static/js/zamboni/editors-all.js:16199 static/js/zamboni/editors-min.js:5 static/js/zamboni/themes_review.js:179
+msgid "Rejected"
 msgstr ""
 
-#: static/js/zamboni/validator.js:247
-msgid "Warning"
+#: static/js/zamboni/editors-all.js:16200 static/js/zamboni/editors-min.js:5 static/js/zamboni/themes_review.js:180
+msgid "Approved"
 msgstr ""
 
-#: static/js/zamboni/validator.js:299
-msgid "Suggestions for passing automated signing:"
+#: static/js/zamboni/editors-all.js:16444 static/js/zamboni/editors-min.js:5 static/js/zamboni/themes_review.js:424
+msgid "No results found"
 msgstr ""
 
-#: static/js/zamboni/validator.js:387
-msgid "Compatibility Tests"
-msgstr ""
-
-#: static/js/zamboni/validator.js:466
-msgid "Add-on failed validation."
-msgstr ""
-
-#: static/js/zamboni/validator.js:468
-msgid "Add-on passed validation."
-msgstr ""
-
-#: static/js/zamboni/validator.js:481
-msgid "{0} error"
-msgid_plural "{0} errors"
-msgstr[0] ""
-msgstr[1] ""
-
-#: static/js/zamboni/validator.js:483
-msgid "{0} warning"
-msgid_plural "{0} warnings"
-msgstr[0] ""
-msgstr[1] ""
-
-#: static/js/zamboni/validator.js:485
-msgid "{0} notice"
-msgid_plural "{0} notices"
-msgstr[0] ""
-msgstr[1] ""
-
-#: static/js/zamboni/validator.js:577
-msgid "Validation task could not complete or completed with errors"
-msgstr ""
-
-#: static/js/zamboni/validator.js:595
-msgid "Internal server error"
-msgstr ""
-
-#: static/js/zamboni/mobile/buttons.js:52
+#: static/js/zamboni/mobile-all.js:15186 static/js/zamboni/mobile/buttons.js:52
 msgid "Not Updated for {0} {1}"
 msgstr ""
 
-#: static/js/zamboni/mobile/buttons.js:53
+#: static/js/zamboni/mobile-all.js:15187 static/js/zamboni/mobile/buttons.js:53
 msgid "Requires Newer Version of {0}"
 msgstr ""
 
-#: static/js/zamboni/mobile/buttons.js:54
+#: static/js/zamboni/mobile-all.js:15188 static/js/zamboni/mobile/buttons.js:54
 msgid "Unreviewed"
 msgstr ""
 
-#: static/js/zamboni/mobile/buttons.js:55
+#: static/js/zamboni/mobile-all.js:15189 static/js/zamboni/mobile/buttons.js:55
 msgid "Experimental <span>(Learn More)</span>"
 msgstr ""
 
-#: static/js/zamboni/mobile/buttons.js:56 static/js/zamboni/mobile/buttons.js:57
+#: static/js/zamboni/mobile-all.js:15190 static/js/zamboni/mobile-all.js:15191 static/js/zamboni/mobile/buttons.js:56 static/js/zamboni/mobile/buttons.js:57
 msgid "Not Available for {0}"
 msgstr ""
 
-#: static/js/zamboni/mobile/buttons.js:58
+#: static/js/zamboni/mobile-all.js:15192 static/js/zamboni/mobile/buttons.js:58
 msgid "Experimental"
 msgstr ""
 
-#: static/js/zamboni/mobile/buttons.js:59
+#: static/js/zamboni/mobile-all.js:15193 static/js/zamboni/mobile/buttons.js:59
 msgid "Themes Require Newer Version of {0}"
 msgstr ""
 
-#: static/js/zamboni/mobile/buttons.js:60
+#: static/js/zamboni/mobile-all.js:15194 static/js/zamboni/mobile/buttons.js:60
 msgid "Themes Require {0}"
 msgstr ""
 
-#: static/js/zamboni/mobile/buttons.js:105
+#: static/js/zamboni/mobile-all.js:15239 static/js/zamboni/mobile/buttons.js:105
 msgid "Installing..."
 msgstr ""
 
-#: static/js/zamboni/mobile/buttons.js:125
+#: static/js/zamboni/mobile-all.js:15259 static/js/zamboni/mobile/buttons.js:125
 msgid "This add-on has been preliminarily reviewed by Mozilla."
 msgstr ""
 
-#: static/js/zamboni/mobile/buttons.js:250
+#: static/js/zamboni/mobile-all.js:15384 static/js/zamboni/mobile/buttons.js:250
 msgid "Keep it"
 msgstr ""
 
-#: static/js/zamboni/mobile/general.js:344
+#: static/js/zamboni/mobile-all.js:16049 static/js/zamboni/mobile-min.js:6 static/js/zamboni/mobile/general.js:344
 msgid "You're trying it on!"
 msgstr ""
 
-#: static/js/zamboni/mobile/general.js:356
+#: static/js/zamboni/mobile-all.js:16061 static/js/zamboni/mobile-min.js:6 static/js/zamboni/mobile/general.js:356
 msgid "Added to Firefox"
 msgstr ""
-

--- a/locale/vi/LC_MESSAGES/django.po
+++ b/locale/vi/LC_MESSAGES/django.po
@@ -1,71 +1,71 @@
-
 msgid ""
 msgstr ""
 "Project-Id-Version:  addons.mozilla.org\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2016-02-24 21:23+0000\n"
+"POT-Creation-Date: 2016-04-18 15:47+0000\n"
 "PO-Revision-Date: 2015-09-13 20:29+0000\n"
 "Last-Translator: 1ec5 <mxn@1ec5.org>\n"
 "Language-Team: Vietnamese <LL@li.org>\n"
+"Language: vi\n"
 "MIME-Version: 1.0\n"
-"Content-Type: text/plain; charset=utf-8\n"
+"Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Generated-By: Babel 2.2.0\n"
 
-#: src/olympia/accounts/views.py:52
+#: src/olympia/accounts/views.py:54
 msgid "Your log in attempt could not be parsed. Please try again."
 msgstr ""
 
-#: src/olympia/accounts/views.py:54
+#: src/olympia/accounts/views.py:56
 msgid "Your Firefox Account could not be found. Please try again."
 msgstr ""
 
-#: src/olympia/accounts/views.py:55
+#: src/olympia/accounts/views.py:57
 msgid "You could not be logged in. Please try again."
 msgstr ""
 
-#: src/olympia/accounts/views.py:57
+#: src/olympia/accounts/views.py:59
 msgid "Your account has already been migrated to Firefox Accounts."
 msgstr ""
 
-#: src/olympia/accounts/views.py:59
+#: src/olympia/accounts/views.py:61
 msgid "Your Firefox Account already exists on this site."
 msgstr ""
 
-#: src/olympia/accounts/views.py:108
+#: src/olympia/accounts/views.py:110
 msgid "Great job!"
 msgstr ""
 
-#: src/olympia/accounts/views.py:109
+#: src/olympia/accounts/views.py:111
 msgid "You can now log in to Add-ons with your Firefox Account."
 msgstr ""
 
-#: src/olympia/accounts/views.py:121
+#: src/olympia/accounts/views.py:123
 msgid "Need help?"
 msgstr ""
 
-#: src/olympia/addons/buttons.py:180
+#: src/olympia/addons/buttons.py:177
 msgid "Download Now"
 msgstr "Tải xuống Ngay"
 
-#: src/olympia/addons/buttons.py:182
+#: src/olympia/addons/buttons.py:179
 msgid "Download"
 msgstr "Tải xuống"
 
 #. L10n: please keep &nbsp; in the string so &rarr; does not wrap.
-#: src/olympia/addons/buttons.py:186
+#: src/olympia/addons/buttons.py:183
 msgid "Continue to Download&nbsp;&rarr;"
 msgstr "Tiếp tục để Tải xuống&nbsp;&rarr;"
 
-#: src/olympia/addons/buttons.py:202 src/olympia/addons/helpers.py:35 src/olympia/addons/views.py:319 src/olympia/addons/templates/addons/impala/details.html:114
+#: src/olympia/addons/buttons.py:199 src/olympia/addons/helpers.py:35 src/olympia/addons/views.py:333 src/olympia/addons/templates/addons/impala/details.html:111
 #: src/olympia/addons/templates/addons/impala/listing/items.html:17 src/olympia/addons/templates/addons/mobile/home.html:40 src/olympia/amo/templates/amo/side_nav.html:6
-#: src/olympia/amo/templates/amo/side_nav.html:10 src/olympia/amo/templates/amo/site_nav.html:2 src/olympia/amo/templates/amo/site_nav.html:55 src/olympia/bandwagon/views.py:95
-#: src/olympia/browse/views.py:54 src/olympia/browse/views.py:68 src/olympia/browse/views.py:235 src/olympia/browse/templates/browse/impala/category_landing.html:22
+#: src/olympia/amo/templates/amo/side_nav.html:10 src/olympia/amo/templates/amo/site_nav.html:2 src/olympia/amo/templates/amo/site_nav.html:53 src/olympia/bandwagon/views.py:95
+#: src/olympia/browse/views.py:54 src/olympia/browse/views.py:68 src/olympia/browse/views.py:202 src/olympia/browse/templates/browse/impala/category_landing.html:22
 #: src/olympia/browse/templates/browse/personas/mobile/category_landing.html:26
 msgid "Featured"
 msgstr "Nên dùng"
 
-#: src/olympia/addons/buttons.py:221
+#: src/olympia/addons/buttons.py:218
 msgid "Add to {0}"
 msgstr "Thêm vào {0}"
 
@@ -87,17 +87,20 @@ msgstr ""
 msgid "Invalid tag: {0}"
 msgid_plural "Invalid tags: {0}"
 msgstr[0] "Nhãn không hợp lệ: {0}"
+msgstr[1] ""
 
 #. L10n: {0} is a single tag or a comma-separated list of tags.
 #: src/olympia/addons/forms.py:103
 msgid "\"{0}\" is a reserved tag and cannot be used."
 msgid_plural "\"{0}\" are reserved tags and cannot be used."
 msgstr[0] "\"{0}\"\\ là nhãn dự phòng và không thể dùng."
+msgstr[1] ""
 
 #: src/olympia/addons/forms.py:111
 msgid "You have {0} too many tags."
 msgid_plural "You have {0} too many tags."
 msgstr[0] "Bạn có {0} quá nhiều nhãn."
+msgstr[1] ""
 
 #: src/olympia/addons/forms.py:117
 #, python-format
@@ -108,39 +111,41 @@ msgstr "Tất cả nhãn phải có %s kí tự hoặc ít hơn sau khi kí tự
 msgid "All tags must be at least {0} character."
 msgid_plural "All tags must be at least {0} characters."
 msgstr[0] "Tất cả nhãn phải có ít nhất {0} kí tự."
+msgstr[1] ""
 
-#: src/olympia/addons/forms.py:234
+#: src/olympia/addons/forms.py:238
 msgid "Categories cannot be changed while your add-on is featured for this application."
 msgstr ""
 
 #. L10n: {0} is the number of categories.
-#: src/olympia/addons/forms.py:238
+#: src/olympia/addons/forms.py:242
 msgid "You can have only {0} category."
 msgid_plural "You can have only {0} categories."
 msgstr[0] "Bạn chỉ có thể có {0} phân mục."
+msgstr[1] ""
 
-#: src/olympia/addons/forms.py:246
+#: src/olympia/addons/forms.py:250
 msgid "The miscellaneous category cannot be combined with additional categories."
 msgstr "Phân mục linh tinh không thể được kết hợp với các phân mục phụ."
 
-#: src/olympia/addons/forms.py:369
+#: src/olympia/addons/forms.py:374
 #, python-format
 msgid "Before changing your default locale you must have a name, summary, and description in that locale. You are missing %s."
 msgstr "Trước khi thay đổi bản địa mặc định, bạn phải có tên, tóm tắt và mô tả trong bản địa đó. Bạn đang thiếu %s."
 
-#: src/olympia/addons/forms.py:484 src/olympia/addons/forms.py:575
+#: src/olympia/addons/forms.py:455 src/olympia/addons/forms.py:546
 msgid "A license must be selected."
 msgstr ""
 
-#: src/olympia/addons/forms.py:556
+#: src/olympia/addons/forms.py:527
 msgid "Give Your Theme a Name."
 msgstr ""
 
-#: src/olympia/addons/forms.py:562 src/olympia/devhub/templates/devhub/personas/submit.html:53
+#: src/olympia/addons/forms.py:533 src/olympia/devhub/templates/devhub/personas/submit.html:53
 msgid "Describe your Theme."
 msgstr ""
 
-#: src/olympia/addons/forms.py:704
+#: src/olympia/addons/forms.py:675
 msgid "Enter a new author's email address"
 msgstr ""
 
@@ -148,39 +153,39 @@ msgstr ""
 msgid "Not Reviewed"
 msgstr "Chưa duyệt"
 
-#: src/olympia/addons/models.py:301
+#: src/olympia/addons/models.py:298
 msgid "Users have the option of contributing more or less than this amount."
 msgstr "Người dùng được quyền chọn đóng góp nhiều hoặc ít hơn khoản này."
 
-#: src/olympia/addons/models.py:309
-msgid "Users will always be asked in the Add-ons Manager (Firefox 4 and above)"
-msgstr "Người dùng sẽ luôn được hỏi trong trình Quản lí Tiện ích (Firefox 4 trở lên)"
+#: src/olympia/addons/models.py:306
+msgid "Users will always be asked in the Add-ons Manager (Firefox 4 and above). Only applies to desktop."
+msgstr ""
 
 # Column name in a table.
-#: src/olympia/addons/models.py:1804 src/olympia/addons/templates/addons/details_box.html:55 src/olympia/devhub/templates/devhub/index.html:92
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:102
+#: src/olympia/addons/models.py:1802 src/olympia/addons/templates/addons/details_box.html:55 src/olympia/devhub/templates/devhub/index.html:92
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:89
 msgid "Listed"
 msgstr "Liệt kê"
 
-#: src/olympia/addons/views.py:320 src/olympia/browse/templates/browse/personas/mobile/category_landing.html:27
+#: src/olympia/addons/views.py:334 src/olympia/browse/templates/browse/personas/mobile/category_landing.html:27
 msgid "Popular"
 msgstr "Thông dụng"
 
-#: src/olympia/addons/views.py:321 src/olympia/browse/views.py:238 src/olympia/browse/views.py:280 src/olympia/browse/views.py:482
+#: src/olympia/addons/views.py:335 src/olympia/browse/views.py:205 src/olympia/browse/views.py:247 src/olympia/browse/views.py:449
 msgid "Recently Added"
 msgstr "Được thêm Gần đây"
 
-#: src/olympia/addons/views.py:322 src/olympia/bandwagon/views.py:99 src/olympia/browse/views.py:60 src/olympia/browse/views.py:71 src/olympia/search/forms.py:16 src/olympia/search/forms.py:91
+#: src/olympia/addons/views.py:336 src/olympia/bandwagon/views.py:99 src/olympia/browse/views.py:60 src/olympia/browse/views.py:71 src/olympia/search/forms.py:16 src/olympia/search/forms.py:91
 msgid "Recently Updated"
 msgstr "Được cập nhật Gần đây"
 
 # %1 is an add-on name.
 #. l10n: {0} is the addon name
-#: src/olympia/addons/views.py:520
+#: src/olympia/addons/views.py:534
 msgid "Contribution for {0}"
 msgstr "Đóng góp cho {0}"
 
-#: src/olympia/addons/views.py:613
+#: src/olympia/addons/views.py:627
 msgid "Abuse reported."
 msgstr "Sự lạm dụng đã báo cáo."
 
@@ -249,9 +254,9 @@ msgstr "Đóng góp"
 #: src/olympia/devhub/templates/devhub/addons/ajax_compat_update.html:36 src/olympia/devhub/templates/devhub/addons/profile.html:44 src/olympia/devhub/templates/devhub/addons/edit/admin.html:101
 #: src/olympia/devhub/templates/devhub/addons/edit/basic.html:152 src/olympia/devhub/templates/devhub/addons/edit/details.html:85 src/olympia/devhub/templates/devhub/addons/edit/support.html:67
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:166 src/olympia/devhub/templates/devhub/addons/forms_shared/media.html:149
-#: src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:44 src/olympia/devhub/templates/devhub/versions/add_file_modal.html:78 src/olympia/devhub/templates/devhub/versions/edit.html:139
-#: src/olympia/devhub/templates/devhub/versions/list.html:242 src/olympia/devhub/templates/devhub/versions/list.html:276 src/olympia/devhub/templates/devhub/versions/list.html:317
-#: src/olympia/devhub/templates/devhub/versions/list.html:351 src/olympia/reviews/templates/reviews/edit_review.html:16 src/olympia/translations/templates/translations/trans-menu.html:50
+#: src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:43 src/olympia/devhub/templates/devhub/versions/add_file_modal.html:58 src/olympia/devhub/templates/devhub/versions/edit.html:139
+#: src/olympia/devhub/templates/devhub/versions/list.html:239 src/olympia/devhub/templates/devhub/versions/list.html:281 src/olympia/devhub/templates/devhub/versions/list.html:315
+#: src/olympia/devhub/templates/devhub/versions/list.html:349 src/olympia/reviews/templates/reviews/edit_review.html:16 src/olympia/translations/templates/translations/trans-menu.html:50
 #: src/olympia/translations/templates/translations/trans-menu.html:62
 msgid "or"
 msgstr "hoặc"
@@ -289,14 +294,15 @@ msgstr ""
 
 #: src/olympia/addons/templates/addons/contributions_lightbox.html:15
 #, python-format
-msgid "To show your support for <b>%(addon_name)s</b>, the developer asks that you make a donation to the <a href=\"%(charity_url)s\">%(charity_name)s</a> through <a href=\"%(paypal_url)s\">PayPal</a>."
+msgid ""
+"To show your support for <b>%(addon_name)s</b>, the developer asks that you make a donation to the <a href=\"%(charity_url)s\">%(charity_name)s</a> through <a href=\"%(paypal_url)s\">PayPal</a>."
 msgstr ""
 
 #: src/olympia/addons/templates/addons/contributions_lightbox.html:21
 #, python-format
 msgid ""
-"To show your support for <b>%(addon_name)s</b>, the developer asks that you make a small contribution to <a href=\"%(charity_url)s\">%(charity_name)s</a> through <a "
-"href=\"%(paypal_url)s\">PayPal</a>."
+"To show your support for <b>%(addon_name)s</b>, the developer asks that you make a small contribution to <a href=\"%(charity_url)s\">%(charity_name)s</a> through <a href=\"%(paypal_url)s\">PayPal</"
+"a>."
 msgstr ""
 
 #: src/olympia/addons/templates/addons/contributions_lightbox.html:30
@@ -361,7 +367,7 @@ msgid "Add-on Information for {0}"
 msgstr "Thông tin Tiện ích cho {0}"
 
 #: src/olympia/addons/templates/addons/details_box.html:30 src/olympia/addons/templates/addons/persona_detail_table.html:3 src/olympia/addons/templates/addons/mobile/details.html:63
-#: src/olympia/addons/templates/addons/mobile/persona_detail_table.html:7 src/olympia/browse/views.py:459 src/olympia/devhub/views.py:75
+#: src/olympia/addons/templates/addons/mobile/persona_detail_table.html:7 src/olympia/browse/views.py:426 src/olympia/devhub/views.py:73
 msgid "Updated"
 msgstr "Cập nhật"
 
@@ -380,11 +386,11 @@ msgstr "Hoạt động trên"
 msgid "Visibility"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/details_box.html:57 src/olympia/devhub/templates/devhub/index.html:94 src/olympia/devhub/templates/devhub/includes/addon_details.html:104
+#: src/olympia/addons/templates/addons/details_box.html:57 src/olympia/devhub/templates/devhub/index.html:94 src/olympia/devhub/templates/devhub/includes/addon_details.html:91
 msgid "Hidden"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/details_box.html:59 src/olympia/devhub/templates/devhub/index.html:96 src/olympia/devhub/templates/devhub/includes/addon_details.html:106
+#: src/olympia/addons/templates/addons/details_box.html:59 src/olympia/devhub/templates/devhub/index.html:96 src/olympia/devhub/templates/devhub/includes/addon_details.html:93
 msgid "Unlisted"
 msgstr ""
 
@@ -392,13 +398,13 @@ msgstr ""
 msgid "Required Add-ons"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/details_box.html:81 src/olympia/addons/templates/addons/persona_detail_table.html:15 src/olympia/browse/views.py:462 src/olympia/devhub/views.py:78
-#: src/olympia/devhub/views.py:85 src/olympia/discovery/templates/discovery/addons/detail.html:57 src/olympia/reviews/forms.py:62 src/olympia/reviews/templates/reviews/add.html:57
+#: src/olympia/addons/templates/addons/details_box.html:81 src/olympia/addons/templates/addons/persona_detail_table.html:15 src/olympia/browse/views.py:429 src/olympia/devhub/views.py:76
+#: src/olympia/devhub/views.py:83 src/olympia/discovery/templates/discovery/addons/detail.html:57 src/olympia/reviews/forms.py:62 src/olympia/reviews/templates/reviews/add.html:57
 #: src/olympia/reviews/templates/reviews/mobile/review_list.html:18
 msgid "Rating"
 msgstr "Xếp hạng"
 
-#: src/olympia/addons/templates/addons/details_box.html:85 src/olympia/browse/views.py:461 src/olympia/devhub/views.py:77 src/olympia/devhub/views.py:84
+#: src/olympia/addons/templates/addons/details_box.html:85 src/olympia/browse/views.py:428 src/olympia/devhub/views.py:75 src/olympia/devhub/views.py:82
 #: src/olympia/stats/templates/stats/addon_report_menu.html:8 src/olympia/stats/templates/stats/collection_report_menu.html:18
 msgid "Downloads"
 msgstr "Tải xuống"
@@ -418,7 +424,7 @@ msgstr ""
 
 #. The Privacy Policy for this add-on.
 #: src/olympia/addons/templates/addons/details_box.html:121 src/olympia/addons/templates/addons/privacy.html:19 src/olympia/addons/templates/addons/privacy.html:23
-#: src/olympia/addons/templates/addons/impala/button.html:43 src/olympia/addons/templates/addons/impala/details.html:307 src/olympia/devhub/templates/devhub/includes/policy_form.html:20
+#: src/olympia/addons/templates/addons/impala/button.html:43 src/olympia/addons/templates/addons/impala/details.html:312 src/olympia/devhub/templates/devhub/includes/policy_form.html:23
 #: src/olympia/templates/mobile/base_addons.html:87
 msgid "Privacy Policy"
 msgstr "Chính sách Riêng tư"
@@ -443,7 +449,7 @@ msgstr "Trưng bày Hình ảnh"
 msgid "Developer Comments"
 msgstr "Bình luận của Nhà phát triển"
 
-#: src/olympia/addons/templates/addons/details_box.html:199 src/olympia/addons/templates/addons/impala/details.html:259
+#: src/olympia/addons/templates/addons/details_box.html:199 src/olympia/addons/templates/addons/impala/details.html:264
 msgid "Development Channel"
 msgstr "Kênh Phát triển"
 
@@ -467,7 +473,7 @@ msgstr ""
 "<strong>Cẩn thận:</strong> Phiên bản phát triển của tiện ích này chưa được duyệt bởi Mozilla. Một khi cài đặt phiên bản phát triển, bạn sẽ tiếp tục nhận được cập nhật từ nhà phát triển. Để ngừng "
 "nhận cập nhật kiểu này, hãy cài lại phiên bản mặc định từ liên kết bên trên."
 
-#: src/olympia/addons/templates/addons/details_box.html:220 src/olympia/addons/templates/addons/impala/details.html:278
+#: src/olympia/addons/templates/addons/details_box.html:220 src/olympia/addons/templates/addons/impala/details.html:283
 msgid "Version {0}:"
 msgstr "Phiên bản {0}:"
 
@@ -486,7 +492,7 @@ msgid "End-User License Agreement for {0}"
 msgstr "Thỏa thuận Giấy phép Người dùng cuối cho {0}"
 
 #: src/olympia/addons/templates/addons/eula.html:17 src/olympia/addons/templates/addons/eula.html:21 src/olympia/addons/templates/addons/impala/button.html:48
-#: src/olympia/addons/templates/addons/impala/details.html:316 src/olympia/devhub/templates/devhub/includes/policy_form.html:3 src/olympia/discovery/templates/discovery/addons/eula.html:11
+#: src/olympia/addons/templates/addons/impala/details.html:321 src/olympia/devhub/templates/devhub/includes/policy_form.html:3 src/olympia/discovery/templates/discovery/addons/eula.html:11
 msgid "End-User License Agreement"
 msgstr "Thỏa thuận Giấy phép Người dùng Cuối"
 
@@ -505,7 +511,7 @@ msgstr ""
 msgid "Add-ons for {0}"
 msgstr "Tiện ích {0}"
 
-#: src/olympia/addons/templates/addons/home.html:10 src/olympia/addons/templates/addons/home.html:51 src/olympia/browse/templates/browse/impala/base_listing.html:11
+#: src/olympia/addons/templates/addons/home.html:10 src/olympia/addons/templates/addons/home.html:53 src/olympia/browse/templates/browse/impala/base_listing.html:11
 msgid "Featured Extensions"
 msgstr "Phần mở rộng Chọn lọc"
 
@@ -513,29 +519,29 @@ msgstr "Phần mở rộng Chọn lọc"
 msgid "Popular Extensions"
 msgstr "Phần mở rộng Thông dụng Nhất"
 
-#: src/olympia/addons/templates/addons/home.html:42 src/olympia/amo/templates/amo/side_nav.html:3 src/olympia/amo/templates/amo/side_nav.html:11 src/olympia/amo/templates/amo/site_nav.html:3
-#: src/olympia/amo/templates/amo/site_nav.html:25 src/olympia/browse/views.py:236 src/olympia/browse/views.py:281 src/olympia/browse/views.py:481
+#: src/olympia/addons/templates/addons/home.html:44 src/olympia/amo/templates/amo/side_nav.html:3 src/olympia/amo/templates/amo/side_nav.html:11 src/olympia/amo/templates/amo/site_nav.html:3
+#: src/olympia/amo/templates/amo/site_nav.html:25 src/olympia/browse/views.py:203 src/olympia/browse/views.py:248 src/olympia/browse/views.py:448
 msgid "Most Popular"
 msgstr "Thông dụng Nhất"
 
-#: src/olympia/addons/templates/addons/home.html:43
+#: src/olympia/addons/templates/addons/home.html:45
 msgid "All »"
 msgstr "Tất cả »"
 
-#: src/olympia/addons/templates/addons/home.html:52 src/olympia/addons/templates/addons/home.html:61 src/olympia/addons/templates/addons/home.html:70 src/olympia/addons/templates/addons/home.html:78
+#: src/olympia/addons/templates/addons/home.html:54 src/olympia/addons/templates/addons/home.html:63 src/olympia/addons/templates/addons/home.html:72 src/olympia/addons/templates/addons/home.html:80
 #: src/olympia/browse/templates/browse/impala/category_landing.html:36
 msgid "See all »"
 msgstr "Xem tất cả »"
 
-#: src/olympia/addons/templates/addons/home.html:60
+#: src/olympia/addons/templates/addons/home.html:62
 msgid "Up &amp; Coming Extensions"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/home.html:69 src/olympia/browse/templates/browse/personas/category_landing.html:61 src/olympia/discovery/templates/discovery/pane.html:74
+#: src/olympia/addons/templates/addons/home.html:71 src/olympia/browse/templates/browse/personas/category_landing.html:61 src/olympia/discovery/templates/discovery/pane.html:74
 msgid "Featured Themes"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/home.html:77 src/olympia/bandwagon/templates/bandwagon/impala/collection_listing.html:5
+#: src/olympia/addons/templates/addons/home.html:79 src/olympia/bandwagon/templates/bandwagon/impala/collection_listing.html:5
 msgid "Featured Collections"
 msgstr "Bộ sưu tập Khuyến nghị"
 
@@ -553,9 +559,9 @@ msgid "Updated {0}"
 msgstr "Cập nhật {0}"
 
 #. {0} is a date.
-#: src/olympia/addons/templates/addons/macros.html:10 src/olympia/addons/templates/addons/macros.html:69 src/olympia/addons/templates/addons/persona_preview.html:21
-#: src/olympia/addons/templates/addons/listing/items_mobile.html:44 src/olympia/addons/templates/addons/listing/macros.html:39 src/olympia/bandwagon/templates/bandwagon/collection_listing_items.html:37
-#: src/olympia/bandwagon/templates/bandwagon/impala/collection_listing_items.html:37
+#: src/olympia/addons/templates/addons/macros.html:10 src/olympia/addons/templates/addons/macros.html:69 src/olympia/addons/templates/addons/persona_preview.html:22
+#: src/olympia/addons/templates/addons/listing/items_mobile.html:44 src/olympia/addons/templates/addons/listing/macros.html:39
+#: src/olympia/bandwagon/templates/bandwagon/collection_listing_items.html:37 src/olympia/bandwagon/templates/bandwagon/impala/collection_listing_items.html:37
 msgid "Added {0}"
 msgstr "Đã thêm {0}"
 
@@ -564,25 +570,28 @@ msgstr "Đã thêm {0}"
 msgid "%(num)s weekly download"
 msgid_plural "%(num)s weekly downloads"
 msgstr[0] "%(num)s lượt tải hàng tuần%(num)s lượt tải hàng tuần"
+msgstr[1] ""
 
 #: src/olympia/addons/templates/addons/macros.html:28
 #, python-format
 msgid "%(num)s user"
 msgid_plural "%(num)s users"
 msgstr[0] "%(num)s người dùng%(num)s người dùng"
+msgstr[1] ""
 
 #. {0} is the number of downloads.
-#: src/olympia/addons/templates/addons/macros.html:53 src/olympia/addons/templates/addons/impala/details.html:61
+#: src/olympia/addons/templates/addons/macros.html:53 src/olympia/addons/templates/addons/impala/details.html:59
 msgid "{0} weekly download"
 msgid_plural "{0} weekly downloads"
 msgstr[0] "{0} lượt tải hàng tuần{0} lượt tải hàng tuần"
+msgstr[1] ""
 
 #. {0} is the number of users.
-#: src/olympia/addons/templates/addons/macros.html:61 src/olympia/addons/templates/addons/impala/details.html:54 src/olympia/compat/templates/compat/index.html:71
-#: src/olympia/zadmin/templates/zadmin/compat.html:67
+#: src/olympia/addons/templates/addons/macros.html:61 src/olympia/addons/templates/addons/impala/details.html:52 src/olympia/zadmin/templates/zadmin/compat.html:67
 msgid "{0} user"
 msgid_plural "{0} users"
 msgstr[0] "{0} người dùng{0} người dùng"
+msgstr[1] ""
 
 #: src/olympia/addons/templates/addons/paypal_result.html:12
 msgid "Payment cancelled"
@@ -596,7 +605,7 @@ msgstr "Việc thanh toán đã hoàn tất"
 msgid "Return to the addon."
 msgstr "Quay trở lại tiện ích."
 
-#: src/olympia/addons/templates/addons/persona_detail.html:17 src/olympia/addons/templates/addons/impala/details.html:106 src/olympia/addons/templates/addons/mobile/details.html:23
+#: src/olympia/addons/templates/addons/persona_detail.html:17 src/olympia/addons/templates/addons/impala/details.html:103 src/olympia/addons/templates/addons/mobile/details.html:23
 #: src/olympia/addons/templates/addons/mobile/persona_detail.html:21 src/olympia/discovery/templates/discovery/addons/base.html:27 src/olympia/editors/templates/editors/review.html:31
 msgid "by"
 msgstr "bởi"
@@ -640,33 +649,35 @@ msgstr "Người dùng Hàng ngày"
 msgid "License"
 msgstr "Giấy phép"
 
-#: src/olympia/addons/templates/addons/persona_preview.html:12 src/olympia/constants/base.py:48
+#: src/olympia/addons/templates/addons/persona_preview.html:13 src/olympia/constants/base.py:48
 msgid "Awaiting Review"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/persona_preview.html:14 src/olympia/amo/log.py:180 src/olympia/constants/base.py:42 src/olympia/editors/helpers.py:62
+#: src/olympia/addons/templates/addons/persona_preview.html:15 src/olympia/amo/log.py:180 src/olympia/constants/base.py:42 src/olympia/editors/helpers.py:62
 msgid "Rejected"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/persona_preview.html:16 src/olympia/amo/log.py:159
+#: src/olympia/addons/templates/addons/persona_preview.html:17 src/olympia/amo/log.py:159
 msgid "Approved"
 msgstr ""
 
 #. {0} is the number of users.
-#: src/olympia/addons/templates/addons/persona_preview.html:26 src/olympia/addons/templates/addons/listing/items_mobile.html:36 src/olympia/addons/templates/addons/listing/macros.html:31
+#: src/olympia/addons/templates/addons/persona_preview.html:27 src/olympia/addons/templates/addons/listing/items_mobile.html:36 src/olympia/addons/templates/addons/listing/macros.html:31
 msgid "<strong>{0}</strong> user"
 msgid_plural "<strong>{0}</strong> users"
 msgstr[0] "<strong>{0}</strong> người dùng<strong>{0}</strong> người dùng"
+msgstr[1] ""
 
-#: src/olympia/addons/templates/addons/persona_preview.html:40
+#: src/olympia/addons/templates/addons/persona_preview.html:41
 msgid "Hover to Preview"
 msgstr "Rê chuột lên để Xem trước"
 
-#: src/olympia/addons/templates/addons/persona_preview.html:46 src/olympia/addons/templates/addons/persona_preview.html:48 src/olympia/reviews/templates/reviews/add.html:15
+#: src/olympia/addons/templates/addons/persona_preview.html:47 src/olympia/addons/templates/addons/persona_preview.html:49 src/olympia/addons/templates/addons/persona_preview.html:97
+#: src/olympia/reviews/templates/reviews/add.html:15
 msgid "Add"
 msgstr "Thêm"
 
-#: src/olympia/addons/templates/addons/persona_preview.html:57 src/olympia/bandwagon/templates/bandwagon/ajax_new.html:16 src/olympia/bandwagon/templates/bandwagon/edit.html:19
+#: src/olympia/addons/templates/addons/persona_preview.html:58 src/olympia/bandwagon/templates/bandwagon/ajax_new.html:16 src/olympia/bandwagon/templates/bandwagon/edit.html:19
 #: src/olympia/bandwagon/templates/bandwagon/includes/addedit.html:19 src/olympia/devhub/templates/devhub/addons/edit/admin.html:13 src/olympia/devhub/templates/devhub/addons/edit/basic.html:10
 #: src/olympia/devhub/templates/devhub/addons/edit/details.html:8 src/olympia/devhub/templates/devhub/addons/edit/media.html:6 src/olympia/devhub/templates/devhub/addons/edit/support.html:8
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:9 src/olympia/devhub/templates/devhub/addons/submit/describe.html:29 src/olympia/editors/templates/editors/review.html:257
@@ -675,21 +686,21 @@ msgstr "Chỉnh sửa"
 
 #. For datetime formatting, see the table on
 #. http://docs.python.org/library/datetime.html#strftime-and-strptime-behavior
-#: src/olympia/addons/templates/addons/persona_preview.html:66
+#: src/olympia/addons/templates/addons/persona_preview.html:67
 #, python-format
 msgid "%%Y-%%m-%%d"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/persona_preview.html:67
+#: src/olympia/addons/templates/addons/persona_preview.html:68
 msgid "by {0} on {1}"
 msgstr "bởi {0} ngày {1}"
 
-#: src/olympia/addons/templates/addons/persona_preview.html:75 src/olympia/reviews/helpers.py:17 src/olympia/reviews/templates/reviews/review_list.html:63
+#: src/olympia/addons/templates/addons/persona_preview.html:76 src/olympia/reviews/helpers.py:17 src/olympia/reviews/templates/reviews/review_list.html:63
 #: src/olympia/reviews/templates/reviews/reviews_link.html:21 src/olympia/reviews/templates/reviews/impala/reviews_link.html:16
 msgid "Not yet rated"
 msgstr "Chưa được xếp hạng"
 
-#: src/olympia/addons/templates/addons/persona_preview.html:78
+#: src/olympia/addons/templates/addons/persona_preview.html:79
 msgid "<b>{0}</b> users"
 msgstr "<b>{0}</b> người dùng"
 
@@ -702,8 +713,8 @@ msgid "Learn more about Firefox"
 msgstr "Tìm hiểu thêm về Firefox"
 
 #: src/olympia/addons/templates/addons/popups.html:22
-msgid "or <b><a class=\"installer\" href=\"{url}\">download anyway</a></b>"
-msgstr "hoặc <b><a class=\"installer\" href=\"{url}\">vẫn cứ tải xuống</a></b>"
+msgid "or <b><a class=\"button installer\" href=\"{url}\">download anyway</a></b>"
+msgstr ""
 
 #: src/olympia/addons/templates/addons/popups.html:26
 msgid ""
@@ -794,11 +805,14 @@ msgid "QR code for add-on"
 msgstr "Mã QR cho tiện ích"
 
 #: src/olympia/addons/templates/addons/qr_code.html:6
-msgid "Want {0} on your mobile Firefox? Scan this QR code to install directly to your phone. (You'll need a QR reader. Search your phone's marketplace if don't have one.)"
-msgstr "Muốn {0} trên Firefox di động của bạn? Quét mã QR này để cài đặt trực tiếp vào điện thoại. (Bạn sẽ cần một đầu đọc QR. Tìm trong marketplace của điện thoại của bạn nếu chưa có.)"
+msgid ""
+"Want {0} on your mobile Firefox?  Scan this QR code to install directly\n"
+"  to your phone.  (You'll need a QR reader.  Search your phone's marketplace if\n"
+"  don't have one.)"
+msgstr ""
 
 #: src/olympia/addons/templates/addons/report_abuse.html:6 src/olympia/addons/templates/addons/report_abuse_full.html:10 src/olympia/addons/templates/addons/impala/details-more.html:23
-#: src/olympia/addons/templates/addons/impala/details.html:328
+#: src/olympia/addons/templates/addons/impala/details.html:333
 msgid "Report Abuse"
 msgstr "Báo cáo Lạm dụng"
 
@@ -808,8 +822,8 @@ msgid ""
 "If you suspect this add-on violates <a href=\"%(url)s\">our policies</a> or has security or privacy issues, please use the form below to describe your concerns. Please do not use this form for any "
 "other reason."
 msgstr ""
-"Nếu bạn nghi ngờ tiện ích này vi phạm <a href=\"%(url)s\">chính sách của chúng tôi</a> hoặc có vấn đề về bảo mật hoặc tính riêng tư, vui lòng dùng biểu mẫu bên dưới để mô tả sự lo ngại của bạn. Vui"
-" lòng không dùng biểu mẫu này cho bất kì lí do nào khác."
+"Nếu bạn nghi ngờ tiện ích này vi phạm <a href=\"%(url)s\">chính sách của chúng tôi</a> hoặc có vấn đề về bảo mật hoặc tính riêng tư, vui lòng dùng biểu mẫu bên dưới để mô tả sự lo ngại của bạn. Vui "
+"lòng không dùng biểu mẫu này cho bất kì lí do nào khác."
 
 #: src/olympia/addons/templates/addons/report_abuse.html:24 src/olympia/users/templates/users/report_abuse.html:19
 msgid "Send Report"
@@ -819,9 +833,9 @@ msgstr "Gửi báo cáo"
 #: src/olympia/devhub/templates/devhub/addons/ajax_compat_update.html:36 src/olympia/devhub/templates/devhub/addons/profile.html:44 src/olympia/devhub/templates/devhub/addons/edit/admin.html:104
 #: src/olympia/devhub/templates/devhub/addons/edit/basic.html:155 src/olympia/devhub/templates/devhub/addons/edit/details.html:88 src/olympia/devhub/templates/devhub/addons/edit/support.html:70
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:169 src/olympia/devhub/templates/devhub/addons/forms_shared/media.html:152
-#: src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:44 src/olympia/devhub/templates/devhub/personas/edit.html:222 src/olympia/devhub/templates/devhub/versions/add_file_modal.html:79
-#: src/olympia/devhub/templates/devhub/versions/edit.html:140 src/olympia/devhub/templates/devhub/versions/list.html:208 src/olympia/devhub/templates/devhub/versions/list.html:242
-#: src/olympia/devhub/templates/devhub/versions/list.html:276 src/olympia/devhub/templates/devhub/versions/list.html:317 src/olympia/reviews/templates/reviews/edit_review.html:16
+#: src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:43 src/olympia/devhub/templates/devhub/personas/edit.html:222 src/olympia/devhub/templates/devhub/versions/add_file_modal.html:59
+#: src/olympia/devhub/templates/devhub/versions/edit.html:140 src/olympia/devhub/templates/devhub/versions/list.html:208 src/olympia/devhub/templates/devhub/versions/list.html:239
+#: src/olympia/devhub/templates/devhub/versions/list.html:281 src/olympia/devhub/templates/devhub/versions/list.html:315 src/olympia/reviews/templates/reviews/edit_review.html:16
 #: src/olympia/translations/templates/translations/trans-menu.html:50 src/olympia/translations/templates/translations/trans-menu.html:62 src/olympia/zadmin/templates/zadmin/validation.html:105
 msgid "Cancel"
 msgstr "Hủy bỏ"
@@ -866,7 +880,7 @@ msgstr "Xem <a href=\"%(support)s\">phần trợ giúp</a> để tìm ra nơi nh
 msgid "Review Guidelines"
 msgstr "Hướng dẫn Đánh giá"
 
-#: src/olympia/addons/templates/addons/review_list_box.html:5 src/olympia/addons/templates/addons/impala/details-more.html:27 src/olympia/editors/helpers.py:921
+#: src/olympia/addons/templates/addons/review_list_box.html:5 src/olympia/addons/templates/addons/impala/details-more.html:27 src/olympia/editors/helpers.py:1001
 #: src/olympia/reviews/templates/reviews/add.html:14 src/olympia/reviews/templates/reviews/reply.html:14 src/olympia/reviews/templates/reviews/review_list.html:19
 #: src/olympia/reviews/templates/reviews/mobile/review_list.html:26
 msgid "Reviews"
@@ -886,6 +900,7 @@ msgstr "Hiển thị trả lời của nhà phát triển cho đánh giá này"
 msgid "See all reviews of this add-on"
 msgid_plural "See all %(cnt)s reviews of this add-on"
 msgstr[0] "Xem tất cả %(cnt)s đánh giá của tiện ích này"
+msgstr[1] ""
 
 #: src/olympia/addons/templates/addons/tags_box.html:3 src/olympia/devhub/templates/devhub/addons/edit/basic.html:118
 msgid "Tags"
@@ -954,119 +969,122 @@ msgstr "Thuộc về các Bộ sưu tập này"
 msgid "Other add-ons by %(author)s"
 msgid_plural "Other add-ons by these authors"
 msgstr[0] "Tiện ích khác bởi %(author)s"
+msgstr[1] ""
 
-#: src/olympia/addons/templates/addons/impala/details.html:41
+#: src/olympia/addons/templates/addons/impala/details.html:39
 #, python-format
 msgid "<span itemprop=\"ratingCount\">%(num)s</span> user review"
 msgid_plural "<span itemprop=\"ratingCount\">%(num)s</span> user reviews"
 msgstr[0] "<span itemprop=\"ratingCount\">%(num)s</span> đánh giá của người dùng<span itemprop=\"ratingCount\">%(num)s</span> đánh giá của người dùng"
+msgstr[1] ""
 
-#: src/olympia/addons/templates/addons/impala/details.html:69
+#: src/olympia/addons/templates/addons/impala/details.html:66
 msgid "View statistics"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/impala/details.html:84
+#: src/olympia/addons/templates/addons/impala/details.html:81
 msgid "Manage"
 msgstr "Quản lý"
 
 #. {0} is an add-on name.
-#: src/olympia/addons/templates/addons/impala/details.html:96
+#: src/olympia/addons/templates/addons/impala/details.html:93
 msgid "Icon of {0}"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/impala/details.html:103 src/olympia/addons/templates/addons/impala/listing/items.html:14
+#: src/olympia/addons/templates/addons/impala/details.html:100 src/olympia/addons/templates/addons/impala/listing/items.html:14
 msgid "No Restart"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/impala/details.html:127
+#: src/olympia/addons/templates/addons/impala/details.html:124
 #, fuzzy, python-format
 msgid "Meet the Developer: <a href=\"%(url)s\">%(name)s</a>"
 msgid_plural "<a href=\"%(url)s\">Meet the Developers</a>"
 msgstr[0] "Gặp Nhà phát triển: <a href=\"%(url)s\">%(name)s</a><a href=\"%(url)s\">Gặp các Nhà phát triển</a>"
+msgstr[1] ""
 
 # {0} is an add-on name.
-#: src/olympia/addons/templates/addons/impala/details.html:137
+#: src/olympia/addons/templates/addons/impala/details.html:134
 msgid "Learn why {0} was created and find out what's next for this add-on."
 msgstr "Tìm hiểu tại sao {0} được tạo ra và tìm hiểu điều gì sẽ là kế tiếp cho tiện ích này."
 
 #. {0} is an index.
-#: src/olympia/addons/templates/addons/impala/details.html:156
+#: src/olympia/addons/templates/addons/impala/details.html:161
 msgid "Add-on screenshot #{0}"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/impala/details.html:182
+#: src/olympia/addons/templates/addons/impala/details.html:187
 msgid "Add-on home page"
 msgstr "Trang chủ tiện ích"
 
-#: src/olympia/addons/templates/addons/impala/details.html:185
+#: src/olympia/addons/templates/addons/impala/details.html:190
 msgid "Support site"
 msgstr "Trang trợ giúp"
 
-#: src/olympia/addons/templates/addons/impala/details.html:189
+#: src/olympia/addons/templates/addons/impala/details.html:194
 msgid "Support E-mail"
 msgstr "Trợ giúp qua Thư điện tử"
 
-#: src/olympia/addons/templates/addons/impala/details.html:194 src/olympia/devhub/models.py:378 src/olympia/devhub/templates/devhub/versions/list.html:12
+#: src/olympia/addons/templates/addons/impala/details.html:199 src/olympia/devhub/models.py:378 src/olympia/devhub/templates/devhub/versions/list.html:12
 #: src/olympia/versions/templates/versions/version.html:6 src/olympia/versions/templates/versions/mobile/version.html:6
 msgid "Version {0}"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/impala/details.html:194
+#: src/olympia/addons/templates/addons/impala/details.html:199
 msgid "Info"
 msgstr "Thông tin"
 
-#: src/olympia/addons/templates/addons/impala/details.html:195 src/olympia/devhub/templates/devhub/includes/addon_details.html:129
+#: src/olympia/addons/templates/addons/impala/details.html:200 src/olympia/devhub/templates/devhub/includes/addon_details.html:116
 msgid "Last Updated:"
 msgstr ""
 
-#: src/olympia/addons/templates/addons/impala/details.html:200
+#: src/olympia/addons/templates/addons/impala/details.html:205
 #, python-format
 msgid "Released under <a target=\"_blank\" href=\"%(url)s\">%(name)s</a>"
 msgstr "Được phát hành theo <a target=\"_blank\" href=\"%(url)s\">%(name)s</a>"
 
-#: src/olympia/addons/templates/addons/impala/details.html:201 src/olympia/addons/templates/addons/impala/details.html:206 src/olympia/amo/helpers.py:398 src/olympia/devhub/forms.py:142
+#: src/olympia/addons/templates/addons/impala/details.html:206 src/olympia/addons/templates/addons/impala/details.html:211 src/olympia/amo/helpers.py:398 src/olympia/devhub/forms.py:142
 #: src/olympia/devhub/forms.py:173 src/olympia/versions/templates/versions/version.html:40 src/olympia/versions/templates/versions/version.html:45
 msgid "Custom License"
 msgstr "Giấy phép Tùy biến"
 
-#: src/olympia/addons/templates/addons/impala/details.html:205
+#: src/olympia/addons/templates/addons/impala/details.html:210
 #, python-format
 msgid "Released under <a href=\"%(url)s\">%(name)s</a>"
 msgstr "Được phát hành theo <a href=\"%(url)s\">%(name)s</a>"
 
-#: src/olympia/addons/templates/addons/impala/details.html:217
+#: src/olympia/addons/templates/addons/impala/details.html:222
 msgid "About this Add-on"
 msgstr "Giới thiệu về Tiện ích này"
 
-#: src/olympia/addons/templates/addons/impala/details.html:233
+#: src/olympia/addons/templates/addons/impala/details.html:238
 msgid "Developer’s Comments"
 msgstr "Nhà phát triển Ghi chú"
 
-#: src/olympia/addons/templates/addons/impala/details.html:243
+#: src/olympia/addons/templates/addons/impala/details.html:248
 msgid "Version Information"
 msgstr "Thông tin về Phiên bản"
 
-#: src/olympia/addons/templates/addons/impala/details.html:250
+#: src/olympia/addons/templates/addons/impala/details.html:255
 msgid "See complete version history"
 msgstr "Xem lịch sử phiên bản đầy đủ"
 
-#: src/olympia/addons/templates/addons/impala/details.html:262
+#: src/olympia/addons/templates/addons/impala/details.html:267
 msgid ""
 "The Development Channel lets you test an experimental new version of this add-on before it's released to the general public. Once you install the development version, you will continue to get "
 "updates from this channel. To stop receiving development updates, reinstall the default version from the link above."
 msgstr ""
 
-#: src/olympia/addons/templates/addons/impala/details.html:272
+#: src/olympia/addons/templates/addons/impala/details.html:277
 msgid "<strong>Caution:</strong> Development versions of this add-on have not been reviewed by Mozilla."
 msgstr ""
 
-#: src/olympia/addons/templates/addons/impala/details.html:287
+#: src/olympia/addons/templates/addons/impala/details.html:292
 msgid "See complete development channel history"
 msgstr "Xem lịch sử kênh phát triển đầy đủ"
 
-#: src/olympia/addons/templates/addons/impala/details.html:306 src/olympia/addons/templates/addons/impala/details.html:315 src/olympia/addons/templates/addons/impala/details.html:327
+#: src/olympia/addons/templates/addons/impala/details.html:311 src/olympia/addons/templates/addons/impala/details.html:320 src/olympia/addons/templates/addons/impala/details.html:332
 #: src/olympia/addons/templates/addons/impala/review_add_box.html:4 src/olympia/stats/templates/stats/popup.html:2 src/olympia/stats/templates/stats/popup.html:8
-#: src/olympia/stats/templates/stats/stats.html:202 src/olympia/users/templates/users/profile.html:119
+#: src/olympia/stats/templates/stats/stats.html:204 src/olympia/users/templates/users/profile.html:119
 msgid "close"
 msgstr ""
 
@@ -1099,6 +1117,7 @@ msgstr "Cái gì tiếp theo cho {0}"
 msgid "About the Developer"
 msgid_plural "About the Developers"
 msgstr[0] ""
+msgstr[1] ""
 
 #: src/olympia/addons/templates/addons/impala/developers.html:96 src/olympia/users/templates/users/edit.html:130 src/olympia/users/templates/users/profile.html:26
 msgid "No Photo"
@@ -1124,15 +1143,11 @@ msgstr "Giấy phép Mã nguồn cho {addon}"
 msgid "Source Code License"
 msgstr "Giấy phép Mã nguồn"
 
-#: src/olympia/addons/templates/addons/impala/persona_grid.html:16 src/olympia/addons/templates/addons/impala/toplist.html:6
-msgid "{0} users"
-msgstr "{0} người dùng"
-
 #: src/olympia/addons/templates/addons/impala/review_list_box.html:19 src/olympia/reviews/templates/reviews/review.html:40
 msgid "permalink"
 msgstr "liên kết thường trực"
 
-#: src/olympia/addons/templates/addons/impala/review_list_box.html:23 src/olympia/editors/templates/editors/queue.html:98 src/olympia/reviews/templates/reviews/review.html:44
+#: src/olympia/addons/templates/addons/impala/review_list_box.html:23 src/olympia/editors/templates/editors/queue.html:104 src/olympia/reviews/templates/reviews/review.html:44
 msgid "translate"
 msgstr "dịch"
 
@@ -1141,6 +1156,7 @@ msgstr "dịch"
 msgid "See all user reviews"
 msgid_plural "See all %(cnt)s user reviews"
 msgstr[0] "Xem tất cả đánh giá của người dùngXem tất cả %(cnt)s đánh giá của người dùng"
+msgstr[1] ""
 
 #: src/olympia/addons/templates/addons/impala/review_list_box.html:47 src/olympia/reviews/templates/reviews/review_list.html:84
 msgid "This add-on has not yet been reviewed."
@@ -1149,6 +1165,10 @@ msgstr ""
 #: src/olympia/addons/templates/addons/impala/review_list_box.html:50
 msgid "Be the first!"
 msgstr ""
+
+#: src/olympia/addons/templates/addons/impala/toplist.html:6
+msgid "{0} users"
+msgstr "{0} người dùng"
 
 #: src/olympia/addons/templates/addons/impala/listing/sorter.html:14 src/olympia/devhub/templates/devhub/addons/listing/item_actions.html:49
 msgid "More"
@@ -1162,7 +1182,7 @@ msgstr "Thêm vào bộ sưu tập"
 msgid "My Add-ons"
 msgstr "Tiện ích của Tôi"
 
-#: src/olympia/addons/templates/addons/includes/dashboard_tabs.html:6 src/olympia/amo/context_processors.py:51
+#: src/olympia/addons/templates/addons/includes/dashboard_tabs.html:6 src/olympia/amo/context_processors.py:50
 msgid "My Themes"
 msgstr ""
 
@@ -1203,6 +1223,7 @@ msgstr "Chưa được Xếp hạng"
 msgid "<strong>{0}</strong> weekly download"
 msgid_plural "<strong>{0}</strong> weekly downloads"
 msgstr[0] "<strong>{0}</strong> lượt tải hàng tuần<strong>{0}</strong> lượt tải hàng tuần"
+msgstr[1] ""
 
 #: src/olympia/addons/templates/addons/mobile/details.html:32
 msgid "Read More"
@@ -1216,7 +1237,7 @@ msgstr "Người dùng"
 msgid "Weekly Downloads"
 msgstr "Lượt tải Hàng tuần"
 
-#: src/olympia/addons/templates/addons/mobile/details.html:99 src/olympia/compat/templates/compat/reporter_detail.html:46 src/olympia/devhub/forms.py:787
+#: src/olympia/addons/templates/addons/mobile/details.html:99 src/olympia/compat/templates/compat/reporter_detail.html:46 src/olympia/devhub/forms.py:788
 #: src/olympia/devhub/templates/devhub/versions/list.html:163
 msgid "Version"
 msgstr "Phiên bản"
@@ -1273,8 +1294,9 @@ msgid "Return to the {0} Add-ons homepage"
 msgstr "Trở lại trang chủ Tiện ích {0}"
 
 #: src/olympia/addons/templates/addons/mobile/home.html:21 src/olympia/amo/helpers.py:237 src/olympia/bandwagon/templates/bandwagon/edit.html:34 src/olympia/discovery/templates/discovery/pane.html:92
-#: src/olympia/editors/templates/editors/base.html:21 src/olympia/editors/templates/editors/performance.html:72 src/olympia/templates/menu_links.html:4 src/olympia/templates/impala/header_title.html:13
-#: src/olympia/templates/impala/header_title.html:15 src/olympia/templates/impala/header_title.html:19 src/olympia/templates/impala/header_title.html:23 src/olympia/templates/mobile/base_addons.html:47
+#: src/olympia/editors/templates/editors/base.html:21 src/olympia/editors/templates/editors/performance.html:72 src/olympia/templates/menu_links.html:4
+#: src/olympia/templates/impala/header_title.html:13 src/olympia/templates/impala/header_title.html:15 src/olympia/templates/impala/header_title.html:19
+#: src/olympia/templates/impala/header_title.html:23 src/olympia/templates/mobile/base_addons.html:47
 msgid "Add-ons"
 msgstr "Tiện ích"
 
@@ -1297,11 +1319,12 @@ msgstr ""
 
 #. {0} is a category name. Ex: "Sports"
 #. {0} is a category name, such as Nature.
-#: src/olympia/addons/templates/addons/mobile/home.html:43 src/olympia/amo/templates/amo/site_nav.html:32 src/olympia/browse/feeds.py:107 src/olympia/browse/templates/browse/impala/base_listing.html:38
-#: src/olympia/browse/templates/browse/personas/base.html:6 src/olympia/browse/templates/browse/personas/base.html:42 src/olympia/browse/templates/browse/personas/category_landing.html:21
-#: src/olympia/browse/templates/browse/personas/category_landing.html:23 src/olympia/browse/templates/browse/personas/category_landing.html:38 src/olympia/browse/templates/browse/personas/grid.html:7
-#: src/olympia/browse/templates/browse/personas/grid.html:11 src/olympia/browse/templates/browse/personas/mobile/base.html:7 src/olympia/browse/templates/browse/personas/mobile/category_landing.html:19
-#: src/olympia/constants/base.py:180 src/olympia/devhub/templates/devhub/personas/submit.html:13 src/olympia/editors/helpers.py:105 src/olympia/editors/templates/editors/base.html:26
+#: src/olympia/addons/templates/addons/mobile/home.html:43 src/olympia/amo/templates/amo/site_nav.html:32 src/olympia/browse/feeds.py:107
+#: src/olympia/browse/templates/browse/impala/base_listing.html:38 src/olympia/browse/templates/browse/personas/base.html:6 src/olympia/browse/templates/browse/personas/base.html:42
+#: src/olympia/browse/templates/browse/personas/category_landing.html:21 src/olympia/browse/templates/browse/personas/category_landing.html:23
+#: src/olympia/browse/templates/browse/personas/category_landing.html:38 src/olympia/browse/templates/browse/personas/grid.html:7 src/olympia/browse/templates/browse/personas/grid.html:11
+#: src/olympia/browse/templates/browse/personas/mobile/base.html:7 src/olympia/browse/templates/browse/personas/mobile/category_landing.html:19 src/olympia/constants/base.py:180
+#: src/olympia/devhub/templates/devhub/personas/submit.html:13 src/olympia/editors/helpers.py:107 src/olympia/editors/templates/editors/base.html:26
 #: src/olympia/editors/templates/editors/performance.html:73 src/olympia/search/templates/search/personas.html:39 src/olympia/templates/menu_links.html:9
 msgid "Themes"
 msgstr "Giao diện"
@@ -1322,7 +1345,7 @@ msgstr "Thêm Tiện ích"
 msgid "Highest Rated"
 msgstr "Xếp hạng Cao nhất"
 
-#: src/olympia/addons/templates/addons/mobile/home.html:74 src/olympia/amo/templates/amo/side_nav.html:5 src/olympia/amo/templates/amo/site_nav.html:27 src/olympia/amo/templates/amo/site_nav.html:57
+#: src/olympia/addons/templates/addons/mobile/home.html:74 src/olympia/amo/templates/amo/side_nav.html:5 src/olympia/amo/templates/amo/site_nav.html:27 src/olympia/amo/templates/amo/site_nav.html:55
 #: src/olympia/bandwagon/views.py:97 src/olympia/browse/views.py:57 src/olympia/browse/views.py:67 src/olympia/browse/templates/browse/personas/mobile/category_landing.html:65
 #: src/olympia/search/forms.py:15 src/olympia/search/forms.py:87
 msgid "Newest"
@@ -1336,88 +1359,90 @@ msgstr ""
 msgid "Theme Info &raquo;"
 msgstr "Thông tin Giao diện &raquo;"
 
-#: src/olympia/amo/context_processors.py:39 src/olympia/devhub/templates/devhub/nav.html:43
+#: src/olympia/amo/context_processors.py:37 src/olympia/devhub/templates/devhub/nav.html:43
 msgid "Tools"
 msgstr "Công cụ"
 
-#: src/olympia/amo/context_processors.py:48 src/olympia/discovery/templates/discovery/pane_account.html:8 src/olympia/users/templates/users/includes/navigation.html:2
+#: src/olympia/amo/context_processors.py:47 src/olympia/discovery/templates/discovery/pane_account.html:8 src/olympia/users/templates/users/includes/navigation.html:2
 msgid "My Profile"
 msgstr "Hồ sơ của Tôi"
 
-#: src/olympia/amo/context_processors.py:54 src/olympia/users/templates/users/edit.html:5 src/olympia/users/templates/users/includes/navigation.html:3
+#: src/olympia/amo/context_processors.py:53 src/olympia/users/templates/users/edit.html:5 src/olympia/users/templates/users/includes/navigation.html:3
 msgid "Account Settings"
 msgstr "Thiết lập Tài khoản"
 
-#: src/olympia/amo/context_processors.py:57 src/olympia/discovery/templates/discovery/pane_account.html:11 src/olympia/users/templates/users/profile.html:83
+#: src/olympia/amo/context_processors.py:56 src/olympia/discovery/templates/discovery/pane_account.html:11 src/olympia/users/templates/users/profile.html:83
 #: src/olympia/users/templates/users/includes/navigation.html:4
 msgid "My Collections"
 msgstr "Bộ sưu tập của Tôi"
 
-#: src/olympia/amo/context_processors.py:62 src/olympia/discovery/templates/discovery/pane_account.html:10 src/olympia/users/templates/users/includes/navigation.html:7
+#: src/olympia/amo/context_processors.py:61 src/olympia/discovery/templates/discovery/pane_account.html:10 src/olympia/users/templates/users/includes/navigation.html:7
 msgid "My Favorites"
 msgstr "Ưa thích của Tôi"
 
-#: src/olympia/amo/context_processors.py:67 src/olympia/discovery/templates/discovery/pane_account.html:13 src/olympia/templates/impala/user_login.html:14 src/olympia/templates/mobile/header_auth.html:5
+#: src/olympia/amo/context_processors.py:66 src/olympia/discovery/templates/discovery/pane_account.html:13 src/olympia/templates/impala/user_login.html:14
+#: src/olympia/templates/mobile/header_auth.html:5
 msgid "Log out"
 msgstr "Đăng xuất"
 
-#: src/olympia/amo/context_processors.py:72 src/olympia/devhub/templates/devhub/addons/dashboard.html:4
+#: src/olympia/amo/context_processors.py:71 src/olympia/devhub/templates/devhub/addons/dashboard.html:4
 msgid "Manage My Submissions"
 msgstr "Quản lý Bản Gửi lên của Tôi"
 
-#: src/olympia/amo/context_processors.py:75 src/olympia/devhub/templates/devhub/nav.html:27 src/olympia/devhub/templates/devhub/addons/dashboard.html:25
+#: src/olympia/amo/context_processors.py:74 src/olympia/devhub/templates/devhub/nav.html:27 src/olympia/devhub/templates/devhub/addons/dashboard.html:25
 #: src/olympia/devhub/templates/devhub/addons/submit/base.html:4
 msgid "Submit a New Add-on"
 msgstr "Gửi lên một Tiện ích Mới"
 
-#: src/olympia/amo/context_processors.py:77 src/olympia/browse/templates/browse/personas/base.html:50 src/olympia/devhub/templates/devhub/index.html:24
+#: src/olympia/amo/context_processors.py:76 src/olympia/browse/templates/browse/personas/base.html:50 src/olympia/devhub/templates/devhub/index.html:24
 #: src/olympia/devhub/templates/devhub/addons/dashboard.html:29
 msgid "Submit a New Theme"
 msgstr "Gửi lên một Giao diện Mới"
 
-#: src/olympia/amo/context_processors.py:79 src/olympia/amo/templates/amo/site_nav.html:87 src/olympia/devhub/helpers.py:36 src/olympia/devhub/helpers.py:68 src/olympia/devhub/helpers.py:102
+#: src/olympia/amo/context_processors.py:78 src/olympia/amo/templates/amo/site_nav.html:85 src/olympia/devhub/helpers.py:36 src/olympia/devhub/helpers.py:68 src/olympia/devhub/helpers.py:102
 #: src/olympia/templates/footer.html:6 src/olympia/templates/menu_links.html:14
 msgid "Developer Hub"
 msgstr "Trung tâm Nhà phát triển"
 
-#: src/olympia/amo/context_processors.py:83 src/olympia/devhub/views.py:1792
+#: src/olympia/amo/context_processors.py:81 src/olympia/devhub/views.py:1796
 msgid "Manage API Keys"
 msgstr ""
 
-#: src/olympia/amo/context_processors.py:88 src/olympia/editors/helpers.py:82 src/olympia/editors/helpers.py:102 src/olympia/editors/templates/editors/base.html:10
+#: src/olympia/amo/context_processors.py:86 src/olympia/editors/helpers.py:84 src/olympia/editors/helpers.py:104 src/olympia/editors/templates/editors/base.html:10
 msgid "Editor Tools"
 msgstr "Công cụ của Biên tập viên"
 
-#: src/olympia/amo/context_processors.py:92
+#: src/olympia/amo/context_processors.py:90
 msgid "Admin Tools"
 msgstr "Công cụ Quản trị"
 
-#: src/olympia/amo/fields.py:15
+#: src/olympia/amo/fields.py:20
 msgid "Incorrect, please try again."
 msgstr ""
 
-#: src/olympia/amo/fields.py:16
+#: src/olympia/amo/fields.py:21
 msgid "Error verifying input, please try again."
 msgstr ""
 
-#: src/olympia/amo/fields.py:32
+#: src/olympia/amo/fields.py:37
 msgid "This must be a valid hex color code, such as #000000."
 msgstr ""
 
-#: src/olympia/amo/fields.py:58
+#: src/olympia/amo/fields.py:63
 msgid "Enter at least one value."
 msgstr ""
 
-#: src/olympia/amo/helpers.py:162 src/olympia/amo/templates/amo/site_nav.html:61 src/olympia/bandwagon/templates/bandwagon/add.html:9 src/olympia/bandwagon/templates/bandwagon/collection_detail.html:15
-#: src/olympia/bandwagon/templates/bandwagon/delete.html:9 src/olympia/bandwagon/templates/bandwagon/edit.html:15 src/olympia/bandwagon/templates/bandwagon/user_listing.html:18
-#: src/olympia/bandwagon/templates/bandwagon/user_listing.html:21 src/olympia/bandwagon/templates/bandwagon/impala/collection_listing.html:12
-#: src/olympia/bandwagon/templates/bandwagon/impala/collection_listing.html:20 src/olympia/bandwagon/templates/bandwagon/impala/collection_listing.html:24
-#: src/olympia/bandwagon/templates/bandwagon/impala/collection_sidebar.html:3 src/olympia/bandwagon/templates/bandwagon/includes/collection_sidebar.html:2
-#: src/olympia/bandwagon/templates/bandwagon/mobile/collection_listing.html:3 src/olympia/stats/templates/stats/stats.html:77 src/olympia/templates/menu_links.html:12
+#: src/olympia/amo/helpers.py:162 src/olympia/amo/templates/amo/site_nav.html:59 src/olympia/bandwagon/templates/bandwagon/add.html:9
+#: src/olympia/bandwagon/templates/bandwagon/collection_detail.html:15 src/olympia/bandwagon/templates/bandwagon/delete.html:9 src/olympia/bandwagon/templates/bandwagon/edit.html:15
+#: src/olympia/bandwagon/templates/bandwagon/user_listing.html:18 src/olympia/bandwagon/templates/bandwagon/user_listing.html:21
+#: src/olympia/bandwagon/templates/bandwagon/impala/collection_listing.html:12 src/olympia/bandwagon/templates/bandwagon/impala/collection_listing.html:20
+#: src/olympia/bandwagon/templates/bandwagon/impala/collection_listing.html:24 src/olympia/bandwagon/templates/bandwagon/impala/collection_sidebar.html:3
+#: src/olympia/bandwagon/templates/bandwagon/includes/collection_sidebar.html:2 src/olympia/bandwagon/templates/bandwagon/mobile/collection_listing.html:3
+#: src/olympia/stats/templates/stats/stats.html:33 src/olympia/templates/menu_links.html:12
 msgid "Collections"
 msgstr "Bộ sưu tập"
 
-#: src/olympia/amo/helpers.py:171 src/olympia/amo/templates/amo/site_nav.html:85 src/olympia/browse/templates/browse/language_tools.html:3
+#: src/olympia/amo/helpers.py:171 src/olympia/amo/templates/amo/site_nav.html:83 src/olympia/browse/templates/browse/language_tools.html:3
 msgid "Dictionaries & Language Packs"
 msgstr "Gói Ngôn ngữ & Từ điển"
 
@@ -1569,8 +1594,8 @@ msgstr ""
 msgid "Comment on {addon} {version}."
 msgstr ""
 
-#: src/olympia/amo/log.py:236 src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:19 src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:47
-#: src/olympia/editors/helpers.py:511 src/olympia/editors/templates/editors/themes/history_table.html:11
+#: src/olympia/amo/log.py:236 src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:17 src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:45
+#: src/olympia/editors/helpers.py:584 src/olympia/editors/templates/editors/themes/history_table.html:11
 msgid "Comment"
 msgstr "Bình luận"
 
@@ -1857,18 +1882,18 @@ msgstr "Không tìm thấy"
 #, python-format
 msgid ""
 "<h1>We're sorry, but we can't find what you're looking for.</h1> <p> The page or file you requested wasn't found on our site. It's possible that you clicked a link that's out of date, or typed in "
-"the address incorrectly. </p> <ul> <li>If you typed in the address, please double check the spelling.</li> <li> If you followed a link from somewhere, please let us know at <a "
-"href=\"mailto:webmaster@mozilla.com\">webmaster@mozilla.com</a>. Tell us where you came from and what you were looking for, and we'll do our best to fix it. </li> </ul> <p>Or you can just jump over"
-" to some of the popular pages on our website.</p> <ul> <li>Are you interested in a <a href=\"%(rec)s\">list of featured add-ons</a>?</li> <li> Do you want to <a href=\"%(search)s\">search for add-"
-"ons</a>? You may go to the <a href=\"%(search)s\">search page</a> or just use the search field above. </li> <li> If you prefer to start over, just go to the <a href=\"%(home)s\">add-ons front "
-"page</a>. </li> </ul>"
+"the address incorrectly. </p> <ul> <li>If you typed in the address, please double check the spelling.</li> <li> If you followed a link from somewhere, please let us know at <a href=\"mailto:"
+"webmaster@mozilla.com\">webmaster@mozilla.com</a>. Tell us where you came from and what you were looking for, and we'll do our best to fix it. </li> </ul> <p>Or you can just jump over to some of "
+"the popular pages on our website.</p> <ul> <li>Are you interested in a <a href=\"%(rec)s\">list of featured add-ons</a>?</li> <li> Do you want to <a href=\"%(search)s\">search for add-ons</a>? You "
+"may go to the <a href=\"%(search)s\">search page</a> or just use the search field above. </li> <li> If you prefer to start over, just go to the <a href=\"%(home)s\">add-ons front page</a>. </li> </"
+"ul>"
 msgstr ""
 "<h1>Xin lỗi, nhưng chúng tôi không thể tìm thấy trang mà bạn đang tìm kiếm.</h1> <p> Trang hoặc tập tin mà bạn yêu cầu không có trên trang của chúng tôi. Có thể là bạn đã nhấn vào một liên kết hết "
-"hạn, hoặc gõ địa chỉ không chính xác. </p> <ul> <li>Nếu bạn gõ địa chỉ, vui lòng kiểm tra lại chính tả.</li> <li> Nếu bạn đi theo một liên kết từ nơi nào đó, vui lòng cho chúng tôi biết tại <a "
-"href=\"mailto:webmaster@mozilla.com\">webmaster@mozilla.com</a>. Cho chúng tôi biết bạn đến từ nơi nào và cái mà bạn đang tìm kiếm, chúng tôi sẽ cố sửa. </li> </ul> <p>Hoặc bạn có thể đi tới một số"
-" trang thông dụng sau trên website của chúng tôi.</p> <ul> <li>Bạn có hứng thú với một <a href=\"%(rec)s\">danh sách các tiện ích đáng dùng</a>?</li> <li> Bạn có muốn <a href=\"%(search)s\">tìm "
-"kiếm tiện ích</a>? Bạn có thể vào <a href=\"%(search)s\">trang tìm kiếm</a> hoặc chỉ cần dùng trường tìm kiếm ở phía trên. </li> <li> Nếu bạn muốn bắt đầu từ đầu, chỉ cần vào <a "
-"href=\"%(home)s\">trang đầu Tiện ích</a>. </li> </ul>"
+"hạn, hoặc gõ địa chỉ không chính xác. </p> <ul> <li>Nếu bạn gõ địa chỉ, vui lòng kiểm tra lại chính tả.</li> <li> Nếu bạn đi theo một liên kết từ nơi nào đó, vui lòng cho chúng tôi biết tại <a href="
+"\"mailto:webmaster@mozilla.com\">webmaster@mozilla.com</a>. Cho chúng tôi biết bạn đến từ nơi nào và cái mà bạn đang tìm kiếm, chúng tôi sẽ cố sửa. </li> </ul> <p>Hoặc bạn có thể đi tới một số "
+"trang thông dụng sau trên website của chúng tôi.</p> <ul> <li>Bạn có hứng thú với một <a href=\"%(rec)s\">danh sách các tiện ích đáng dùng</a>?</li> <li> Bạn có muốn <a href=\"%(search)s\">tìm kiếm "
+"tiện ích</a>? Bạn có thể vào <a href=\"%(search)s\">trang tìm kiếm</a> hoặc chỉ cần dùng trường tìm kiếm ở phía trên. </li> <li> Nếu bạn muốn bắt đầu từ đầu, chỉ cần vào <a href=\"%(home)s\">trang "
+"đầu Tiện ích</a>. </li> </ul>"
 
 #: src/olympia/amo/templates/amo/500.html:3
 msgid "Oops"
@@ -1876,8 +1901,8 @@ msgstr "Ôi"
 
 #: src/olympia/amo/templates/amo/500.html:6
 #, python-format
-msgid "<h1>Oops! We had an error.</h1> <p>We'll get to fixing that soon.</p> <p> You can try refreshing the page, or head back to the <a href=\"%(home)s\">Add-ons homepage</a>. </p>"
-msgstr "<h1>Ối! Chúng ta gặp lỗi rồi.</h1> <p>Chúng tôi sẽ bắt tay vào sửa sớm.</p> <p> Bạn có thể thử tải lại trang, hoặc quay về lại <a href=\"%(home)s\">trang chủ Tiện ích</a>. </p>"
+msgid "<h1>Oops!  We had an error.</h1> <p>We'll get to fixing that soon.</p> <p> You can try refreshing the page, or head back to the <a href=\"%(home)s\">Add-ons homepage</a>. </p>"
+msgstr ""
 
 #: src/olympia/amo/templates/amo/license_link.html:10
 msgid "Some rights reserved"
@@ -1899,7 +1924,7 @@ msgstr "Trước"
 #: src/olympia/amo/templates/amo/mobile/paginator.html:14 src/olympia/amo/templates/amo/mobile/paginator.html:16 src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:51
 #: src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:65 src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:78
 #: src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:91 src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:104
-#: src/olympia/discovery/templates/discovery/pane.html:45 src/olympia/discovery/templates/discovery/addons/detail.html:39 src/olympia/stats/templates/stats/stats.html:167
+#: src/olympia/discovery/templates/discovery/pane.html:45 src/olympia/discovery/templates/discovery/addons/detail.html:39 src/olympia/stats/templates/stats/stats.html:169
 msgid "Next"
 msgstr "Sau"
 
@@ -1931,7 +1956,7 @@ msgid ""
 msgstr ""
 
 #: src/olympia/amo/templates/amo/side_nav.html:4 src/olympia/amo/templates/amo/side_nav.html:12 src/olympia/amo/templates/amo/site_nav.html:4 src/olympia/amo/templates/amo/site_nav.html:26
-#: src/olympia/browse/views.py:56 src/olympia/browse/views.py:66 src/olympia/browse/views.py:237 src/olympia/browse/views.py:282 src/olympia/search/forms.py:86
+#: src/olympia/browse/views.py:56 src/olympia/browse/views.py:66 src/olympia/browse/views.py:204 src/olympia/browse/views.py:249 src/olympia/search/forms.py:86
 msgid "Top Rated"
 msgstr "Xếp hạng Cao nhất"
 
@@ -1946,37 +1971,38 @@ msgstr "Khám phá"
 msgid "Extensions"
 msgstr "Phần mở rộng"
 
-#: src/olympia/amo/templates/amo/site_nav.html:45
+#: src/olympia/amo/templates/amo/site_nav.html:44
 msgid "Want more customization? Try <b>Complete Themes</b>"
 msgstr ""
 
-#: src/olympia/amo/templates/amo/site_nav.html:56 src/olympia/bandwagon/views.py:96
+#: src/olympia/amo/templates/amo/site_nav.html:54 src/olympia/bandwagon/views.py:96
 msgid "Most Followers"
 msgstr ""
 
-#: src/olympia/amo/templates/amo/site_nav.html:68 src/olympia/bandwagon/templates/bandwagon/impala/collection_sidebar.html:16 src/olympia/bandwagon/templates/bandwagon/includes/collection_sidebar.html:18
+#: src/olympia/amo/templates/amo/site_nav.html:66 src/olympia/bandwagon/templates/bandwagon/impala/collection_sidebar.html:16
+#: src/olympia/bandwagon/templates/bandwagon/includes/collection_sidebar.html:18
 msgid "Collections I've Made"
 msgstr "Bộ sưu tập Tôi đã tạo"
 
-#: src/olympia/amo/templates/amo/site_nav.html:70 src/olympia/bandwagon/templates/bandwagon/user_listing.html:4 src/olympia/bandwagon/templates/bandwagon/impala/collection_sidebar.html:13
+#: src/olympia/amo/templates/amo/site_nav.html:68 src/olympia/bandwagon/templates/bandwagon/user_listing.html:4 src/olympia/bandwagon/templates/bandwagon/impala/collection_sidebar.html:13
 #: src/olympia/bandwagon/templates/bandwagon/includes/collection_sidebar.html:15
 msgid "Collections I'm Following"
 msgstr "Bộ sưu tập Tôi đang theo dõi"
 
-#: src/olympia/amo/templates/amo/site_nav.html:73 src/olympia/bandwagon/templates/bandwagon/impala/collection_sidebar.html:18 src/olympia/bandwagon/templates/bandwagon/includes/collection_sidebar.html:20
-#: src/olympia/users/models.py:512
+#: src/olympia/amo/templates/amo/site_nav.html:71 src/olympia/bandwagon/templates/bandwagon/impala/collection_sidebar.html:18
+#: src/olympia/bandwagon/templates/bandwagon/includes/collection_sidebar.html:20 src/olympia/users/models.py:521
 msgid "My Favorite Add-ons"
 msgstr "Tiện ích Ưa thích của Tôi"
 
-#: src/olympia/amo/templates/amo/site_nav.html:78
+#: src/olympia/amo/templates/amo/site_nav.html:76
 msgid "More&hellip;"
 msgstr "Thêm&hellip;"
 
-#: src/olympia/amo/templates/amo/site_nav.html:82
+#: src/olympia/amo/templates/amo/site_nav.html:80
 msgid "Add-ons for Mobile"
 msgstr "Tiện ích Di động"
 
-#: src/olympia/amo/templates/amo/site_nav.html:86 src/olympia/browse/feeds.py:207 src/olympia/browse/templates/browse/search_tools.html:3 src/olympia/constants/base.py:176
+#: src/olympia/amo/templates/amo/site_nav.html:84 src/olympia/browse/feeds.py:207 src/olympia/browse/templates/browse/search_tools.html:3 src/olympia/constants/base.py:176
 #: src/olympia/templates/menu_links.html:10
 msgid "Search Tools"
 msgstr "Công cụ Tìm kiếm"
@@ -1992,7 +2018,7 @@ msgid "Jump to first page"
 msgstr ""
 
 #: src/olympia/amo/templates/amo/impala/paginator.html:22 src/olympia/amo/templates/amo/mobile/impala_paginator.html:12 src/olympia/discovery/templates/discovery/pane.html:44
-#: src/olympia/discovery/templates/discovery/addons/detail.html:38 src/olympia/stats/templates/stats/stats.html:164
+#: src/olympia/discovery/templates/discovery/addons/detail.html:38 src/olympia/stats/templates/stats/stats.html:166
 msgid "Previous"
 msgstr "Trước"
 
@@ -2013,32 +2039,52 @@ msgstr "Đang hiện <b>%(begin)s</b>&ndash;<b>%(end)s</b> trên tổng <b>%(cou
 msgid "Page {n}"
 msgid_plural "Page {n}"
 msgstr[0] "Trang {n}Trang {n}"
+msgstr[1] ""
 
-#: src/olympia/amo/templates/services/install.html:38
-#, python-format
-msgid "If you are not prompted to install %(addon_name)s in a moment, please <a href=\"%(addon_xpi)s\">click here</a>."
-msgstr ""
-
-#: src/olympia/amo/tests/test_messages.py:57 src/olympia/amo/tests/test_messages.py:58 src/olympia/reviews/forms.py:25 src/olympia/reviews/forms.py:50 src/olympia/reviews/templates/reviews/add.html:56
+#: src/olympia/amo/tests/test_messages.py:56 src/olympia/amo/tests/test_messages.py:57 src/olympia/reviews/forms.py:25 src/olympia/reviews/forms.py:50 src/olympia/reviews/templates/reviews/add.html:56
 #: src/olympia/reviews/templates/reviews/reply.html:30
 msgid "Title"
 msgstr ""
 
-#: src/olympia/amo/tests/test_messages.py:57 src/olympia/amo/tests/test_messages.py:58
+#: src/olympia/amo/tests/test_messages.py:56 src/olympia/amo/tests/test_messages.py:57
 msgid "Body"
 msgstr ""
 
-#: src/olympia/amo/tests/test_messages.py:59
+#: src/olympia/amo/tests/test_messages.py:58
 msgid "Another Title"
 msgstr ""
 
-#: src/olympia/amo/tests/test_messages.py:59
+#: src/olympia/amo/tests/test_messages.py:58
 msgid "Another Body"
 msgstr ""
 
-#: src/olympia/api/views.py:255
-msgid "Not implemented yet."
-msgstr "Chưa triển khai."
+#: src/olympia/api/authentication.py:76
+msgid "Signature has expired."
+msgstr ""
+
+#: src/olympia/api/authentication.py:79
+msgid "Error decoding signature."
+msgstr ""
+
+#: src/olympia/api/authentication.py:82
+msgid "Invalid JWT Token."
+msgstr ""
+
+#: src/olympia/api/authentication.py:130
+msgid "Invalid Authorization header. No credentials provided."
+msgstr ""
+
+#: src/olympia/api/authentication.py:133
+msgid "Invalid Authorization header. Credentials string should not contain spaces."
+msgstr ""
+
+#: src/olympia/api/fields.py:29
+msgid "The field must have a length of at least {num} characters."
+msgstr ""
+
+#: src/olympia/api/fields.py:31
+msgid "The language code {lang_code} is invalid."
+msgstr ""
 
 #: src/olympia/applications/views.py:39 src/olympia/applications/templates/applications/appversions.html:3
 msgid "Application Versions"
@@ -2056,7 +2102,7 @@ msgstr "Các phiên bản Ứng dụng Hợp lệ"
 msgid "Add-ons submitted to Mozilla Add-ons must have a manifest file with at least one of the below applications supported. Only the versions listed below are allowed for these applications."
 msgstr ""
 
-#: src/olympia/applications/templates/applications/appversions.html:25
+#: src/olympia/applications/templates/applications/appversions.html:25 src/olympia/editors/helpers.py:361
 msgid "GUID"
 msgstr "GUID"
 
@@ -2170,8 +2216,8 @@ msgstr "Ưa thích"
 msgid "Remove from favorites"
 msgstr "Xóa khỏi ưa thích"
 
-#: src/olympia/bandwagon/views.py:98 src/olympia/bandwagon/views.py:191 src/olympia/browse/views.py:58 src/olympia/browse/views.py:69 src/olympia/browse/views.py:458 src/olympia/devhub/views.py:74
-#: src/olympia/devhub/views.py:82 src/olympia/devhub/templates/devhub/addons/edit/basic.html:20 src/olympia/editors/templates/editors/leaderboard.html:24
+#: src/olympia/bandwagon/views.py:98 src/olympia/bandwagon/views.py:191 src/olympia/browse/views.py:58 src/olympia/browse/views.py:69 src/olympia/browse/views.py:425 src/olympia/devhub/views.py:72
+#: src/olympia/devhub/views.py:80 src/olympia/devhub/templates/devhub/addons/edit/basic.html:20 src/olympia/editors/templates/editors/leaderboard.html:24
 #: src/olympia/editors/templates/editors/themes/queue_list.html:48 src/olympia/search/forms.py:17 src/olympia/search/forms.py:89 src/olympia/users/templates/users/vcard.html:5
 msgid "Name"
 msgstr "Tên"
@@ -2180,7 +2226,7 @@ msgstr "Tên"
 msgid "Recently Popular"
 msgstr "Thông dụng Gần đây"
 
-#: src/olympia/bandwagon/views.py:189 src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:18
+#: src/olympia/bandwagon/views.py:189 src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:16
 msgid "Added"
 msgstr "Được thêm"
 
@@ -2194,7 +2240,7 @@ msgstr "Bộ sưu tập đã được tạo!"
 
 #: src/olympia/bandwagon/views.py:316
 #, python-format
-msgid "Your new collection is shown below. You can <ahref=\"%(url)s\">edit additional settings</a> if you'dlike."
+msgid "Your new collection is shown below. You can <a href=\"%(url)s\">edit additional settings</a> if you'd like."
 msgstr ""
 
 #: src/olympia/bandwagon/views.py:322
@@ -2274,6 +2320,7 @@ msgstr "riêng tư"
 msgid "<span>%(num)s</span> follower"
 msgid_plural "<span>%(num)s</span> followers"
 msgstr[0] "<span>%(num)s</span> người theo đuôi"
+msgstr[1] ""
 
 #: src/olympia/bandwagon/templates/bandwagon/collection_detail.html:54
 msgid "About this Collection"
@@ -2312,15 +2359,17 @@ msgstr "Xóa Bộ sưu tập"
 msgid "%(num)s Theme in this Collection"
 msgid_plural "%(num)s Themes in this Collection"
 msgstr[0] ""
+msgstr[1] ""
 
 #: src/olympia/bandwagon/templates/bandwagon/collection_detail.html:111
 #, python-format
 msgid "%(num)s Add-on in this Collection"
 msgid_plural "%(num)s Add-ons in this Collection"
 msgstr[0] "%(num)s Tiện ích trong Bộ sưu tập này"
+msgstr[1] ""
 
-#: src/olympia/bandwagon/templates/bandwagon/collection_detail.html:125 src/olympia/compat/templates/compat/index.html:25 src/olympia/compat/templates/compat/reporter_detail.html:29
-#: src/olympia/files/templates/files/viewer.html:29 src/olympia/templates/amo_footer.html:17 src/olympia/templates/includes/lang_switcher.html:10
+#: src/olympia/bandwagon/templates/bandwagon/collection_detail.html:125 src/olympia/compat/templates/compat/reporter_detail.html:29 src/olympia/files/templates/files/viewer.html:29
+#: src/olympia/templates/amo_footer.html:17 src/olympia/templates/includes/lang_switcher.html:10
 msgid "Go"
 msgstr "Đi"
 
@@ -2354,11 +2403,9 @@ msgstr ""
 
 #: src/olympia/bandwagon/templates/bandwagon/collection_detail.html:186
 msgid ""
-"Add-ons that you mark as favorites using the <b>Add to Favorites</b> feature appear below. This collection is currently <b>private</b>, which means only you can see it. If you would like everyone "
+"Add-ons that you mark as favorites using the <b>Add to Favorites</b> feature appear below. This collection is currently <b>private</b>, which means only you can see it.  If you would like everyone "
 "to be able to see your favorites, click the button below to make it public."
 msgstr ""
-"Những tiện ích mà bạn đánh dấu là ưa thích bằng tính năng <b>Thêm vào Ưa thích</b> xuất hiện bên dưới. Bộ sưu tập này hiện đang <b>riêng tư</b>, có nghĩa là chỉ mình bạn có thể thấy nó. Nếu bạn "
-"muốn mọi người có thể thấy những cái bạn thích, nhấn lên nút bên dưới để chuyển nó thành công khai."
 
 #: src/olympia/bandwagon/templates/bandwagon/collection_detail.html:196
 msgid "My favorite add-ons"
@@ -2369,12 +2416,14 @@ msgstr "Tiện ích ưa thích của tôi"
 msgid "<span>%(addons)s</span> add-on"
 msgid_plural "<span>%(addons)s</span> add-ons"
 msgstr[0] ""
+msgstr[1] ""
 
 #: src/olympia/bandwagon/templates/bandwagon/collection_grid.html:32
 #, python-format
 msgid "<span>%(followers)s</span> follower"
 msgid_plural "<span>%(followers)s</span> followers"
 msgstr[0] ""
+msgstr[1] ""
 
 #. People "follow" collections to get notified of updates.                    Like
 #. Twitter followers.
@@ -2385,6 +2434,7 @@ msgstr[0] ""
 msgid "%(num)s weekly follower"
 msgid_plural "%(num)s weekly followers"
 msgstr[0] ""
+msgstr[1] ""
 
 #. People "follow" collections to get notified of updates.                    Like
 #. Twitter followers.
@@ -2393,6 +2443,7 @@ msgstr[0] ""
 msgid "%(num)s monthly follower"
 msgid_plural "%(num)s monthly followers"
 msgstr[0] ""
+msgstr[1] ""
 
 #. People "follow" collections to get notified of updates.                    Like
 #. Twitter followers.
@@ -2403,6 +2454,7 @@ msgstr[0] ""
 msgid "%(num)s follower"
 msgid_plural "%(num)s followers"
 msgstr[0] ""
+msgstr[1] ""
 
 #: src/olympia/bandwagon/templates/bandwagon/collection_listing_items.html:56 src/olympia/bandwagon/templates/bandwagon/impala/collection_listing_items.html:9
 #: src/olympia/devhub/templates/devhub/personas/edit.html:27
@@ -2487,7 +2539,7 @@ msgid "Remove this user as a contributor"
 msgstr "Xóa người dùng này khỏi tư cách người đóng góp"
 
 #: src/olympia/bandwagon/templates/bandwagon/edit_contributors.html:18 src/olympia/bandwagon/templates/bandwagon/edit_contributors.html:43
-#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:20 src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:48
+#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:18 src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:46
 #: src/olympia/devhub/templates/devhub/addons/ajax_compat_update.html:19
 msgid "Remove"
 msgstr "Xóa"
@@ -2498,11 +2550,9 @@ msgstr "Người đóng góp cho Bộ sưu tập"
 
 #: src/olympia/bandwagon/templates/bandwagon/edit_contributors.html:26
 msgid ""
-"You can add multiple contributors to this collection. A contributor can add and remove add-ons from this collection, but cannot change its name or description. To add a contributor, enter their "
+"You can add multiple contributors to this collection.  A contributor can add and remove add-ons from this collection, but cannot change its name or description.  To add a contributor, enter their "
 "email in the box below. Contributors must have a Mozilla Add-ons account."
 msgstr ""
-"Bạn có thể thêm nhiều người đóng góp cho bộ sưu tập này. Một người đóng góp có thể thêm và xóa tiện tích khỏi bộ sưu tập này, nhưng không thể thay đổi tên hoặc mô tả của nó. Để thêm một người đóng "
-"góp, nhập địa chỉ email của họ ở bên dưới. Những người đóng góp phải có một tài khoản Tiện ích Mozilla."
 
 #: src/olympia/bandwagon/templates/bandwagon/edit_contributors.html:40
 msgid "User"
@@ -2538,7 +2588,7 @@ msgid "<b>Warning:</b> By changing the owner of this collection, you will no lon
 msgstr "<b>Cảnh báo:</b> Bằng việc thay đổi chủ sở hữu của bộ sưu tập này, bạn sẽ không còn có thể chỉnh sửa nó nữa. Bạn sẽ chỉ có thể thêm hoặc bỏ tiện ích khỏi nó."
 
 #: src/olympia/bandwagon/templates/bandwagon/edit_contributors.html:83 src/olympia/devhub/templates/devhub/addons/forms_shared/media.html:157
-#: src/olympia/devhub/templates/devhub/addons/submit/describe.html:69 src/olympia/devhub/templates/devhub/addons/submit/license.html:60 src/olympia/devhub/templates/devhub/addons/submit/upload.html:78
+#: src/olympia/devhub/templates/devhub/addons/submit/describe.html:69 src/olympia/devhub/templates/devhub/addons/submit/license.html:60 src/olympia/devhub/templates/devhub/addons/submit/upload.html:70
 #: src/olympia/devhub/templates/devhub/payments/tier.html:17 src/olympia/editors/templates/editors/themes/themes.html:111 src/olympia/editors/templates/editors/themes/themes.html:128
 #: src/olympia/editors/templates/editors/themes/themes.html:134 src/olympia/editors/templates/editors/themes/themes.html:141 src/olympia/users/templates/users/fxa_migration_prompt_content.html:10
 #: src/olympia/users/templates/users/login_form.html:42 src/olympia/users/templates/users/mobile/login.html:57
@@ -2609,42 +2659,43 @@ msgid "Reset"
 msgstr "Khởi tạo lại"
 
 #: src/olympia/bandwagon/templates/bandwagon/includes/addedit.html:53
-msgid "PNG and JPG supported. Image will be resized to 32x32."
-msgstr "PNG và JPG được hỗ trợ. Hình ảnh sẽ được chỉnh lại thành 32x32."
+msgid "PNG and JPG supported.  Image will be resized to 32x32."
+msgstr ""
 
 #: src/olympia/bandwagon/templates/bandwagon/includes/addedit_errors.html:3
-msgid "There are errors in this form. Please correct them below."
-msgstr "Có nhiều lỗi trong biểu mẫu này. Vui lòng sửa chúng bên dưới."
+msgid "There are errors in this form.  Please correct them below."
+msgstr ""
 
 #: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:2
 msgid "Add-ons in Your Collection"
 msgstr "Tiện ích trong Bộ sưu tập của bạn"
 
 #: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:4
-msgid "To include an add-on in this collection, enter its name in the box below and hit enter. You can also use the <strong>Add to Collection</strong> links throughout the site to include add-ons later."
-msgstr "Để bao gồm một tiện ích trong bộ sưu tập này, nhập tên của nó vào ô bên dưới và ấn Enter. Bạn cũng có thể dùng liên kết <strong>Thêm vào Bộ sưu tập</strong> trên trang để bao gồm tiện ích."
+msgid "To include an add-on in this collection, enter its name in the box below and hit enter."
+msgstr ""
 
-#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:17 src/olympia/constants/base.py:400 src/olympia/devhub/templates/devhub/addons/activity.html:62
+#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:15 src/olympia/constants/base.py:400 src/olympia/devhub/templates/devhub/addons/activity.html:62
+#: src/olympia/editors/helpers.py:273 src/olympia/editors/helpers.py:360
 msgid "Add-on"
 msgstr "Tiện ích"
 
-#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:26
+#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:24
 msgid "Enter the name of the add-on to include"
 msgstr "Nhập tên của tiện ích muốn bao gồm"
 
-#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:28
+#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:26
 msgid "Add to Collection"
 msgstr "Thêm vào Bộ sưu tập"
 
-#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:45 src/olympia/editors/helpers.py:936 src/olympia/editors/helpers.py:956
+#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:43 src/olympia/editors/helpers.py:1016 src/olympia/editors/helpers.py:1036
 msgid "Pending"
 msgstr "Đang chờ"
 
-#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:47
+#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:45
 msgid "Add a comment"
 msgstr "Thêm một bình luận"
 
-#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:48
+#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:46
 msgid "Remove this add-on from the collection"
 msgstr "Bỏ tiện ích này khỏi bộ sưu tập"
 
@@ -2693,10 +2744,8 @@ msgstr "Tiện ích hoặc phần bổ trợ có vấn đề sẽ tự động b
 #, python-format
 msgid ""
 "When Mozilla becomes aware of add-ons, plugins, or other third-party software that seriously compromises %(app)s security, stability, or performance and meets <a href=\"%(criteria)s\">certain "
-"criteria</a>, the software may be blocked from general use. For more information, please read <a href=\"%(support)s\">this support article</a>."
+"criteria</a>, the software may be blocked from general use.  For more information, please read <a href=\"%(support)s\">this support article</a>."
 msgstr ""
-"Khi Mozilla nhận thấy những tiện ích, phần bổ trợ, hoặc phần mềm khác của bên thứ ba có gây ảnh hưởng nghiêm trọng đến tính bảo mật, tính ổn định, hoặc hiệu năng của %(app)s và hợp <a "
-"href=\"%(criteria)s\">tiêu chí nào đó</>, phần mềm đó có thể bị chặn. Để biết thêm thông tin, vui lòng đọc <a href=\"%(support)s\">bài viết hỗ trợ này</a>."
 
 #: src/olympia/blocklist/templates/blocklist/blocked_detail.html:44
 #, python-format
@@ -2753,12 +2802,12 @@ msgstr "Công cụ tìm kiếm"
 msgid "Most Users"
 msgstr "Người dùng Nhiều nhất"
 
-#: src/olympia/browse/views.py:61 src/olympia/browse/views.py:72 src/olympia/browse/views.py:279 src/olympia/browse/templates/browse/personas/mobile/category_landing.html:63
+#: src/olympia/browse/views.py:61 src/olympia/browse/views.py:72 src/olympia/browse/views.py:246 src/olympia/browse/templates/browse/personas/mobile/category_landing.html:63
 #: src/olympia/discovery/templates/discovery/pane.html:67 src/olympia/search/forms.py:92
 msgid "Up & Coming"
 msgstr "Mới nhất"
 
-#: src/olympia/browse/views.py:460 src/olympia/devhub/views.py:76 src/olympia/devhub/views.py:83 src/olympia/discovery/templates/discovery/addons/detail.html:66
+#: src/olympia/browse/views.py:427 src/olympia/devhub/views.py:74 src/olympia/devhub/views.py:81 src/olympia/discovery/templates/discovery/addons/detail.html:66
 msgid "Created"
 msgstr "Đã tạo"
 
@@ -2838,6 +2887,7 @@ msgstr "{0} :: Công cụ Tìm kiếm"
 msgid "<b>{0}</b> add-on"
 msgid_plural "<b>{0}</b> add-ons"
 msgstr[0] "<b>{0}</b> tiện ích"
+msgstr[1] ""
 
 #: src/olympia/browse/templates/browse/search_tools.html:61
 msgid "Search Extensions"
@@ -2943,9 +2993,10 @@ msgstr ""
 msgid "See the %(cnt)s extension in %(name)s &raquo;"
 msgid_plural "See all %(cnt)s extensions in %(name)s &raquo;"
 msgstr[0] ""
+msgstr[1] ""
 
-#: src/olympia/browse/templates/browse/mobile/extensions.html:13 src/olympia/compat/templates/compat/index.html:82 src/olympia/devhub/templates/devhub/devhub_search.html:24
-#: src/olympia/devhub/templates/devhub/addons/activity.html:47 src/olympia/search/templates/search/no_results.html:4 src/olympia/search/templates/search/mobile/results.html:36
+#: src/olympia/browse/templates/browse/mobile/extensions.html:13 src/olympia/devhub/templates/devhub/devhub_search.html:24 src/olympia/devhub/templates/devhub/addons/activity.html:47
+#: src/olympia/search/templates/search/no_results.html:4 src/olympia/search/templates/search/mobile/results.html:36
 msgid "No results found."
 msgstr "Không tìm thấy kết quả."
 
@@ -3030,7 +3081,7 @@ msgstr "&laquo; Tất cả Giao diện"
 msgid "All"
 msgstr "Tất cả"
 
-#: src/olympia/compat/forms.py:22 src/olympia/search/views.py:525
+#: src/olympia/compat/forms.py:22 src/olympia/editors/templates/editors/base.html:69 src/olympia/search/views.py:518
 msgid "All Add-ons"
 msgstr "Tất cả Tiện ích"
 
@@ -3040,53 +3091,6 @@ msgstr ""
 
 #: src/olympia/compat/forms.py:24
 msgid "Non-binary"
-msgstr ""
-
-#. Review points sources other than add-ons and themes.
-#: src/olympia/compat/views.py:87 src/olympia/constants/base.py:388 src/olympia/devhub/forms.py:162 src/olympia/editors/templates/editors/performance.html:75
-msgid "Other"
-msgstr "Khác"
-
-#: src/olympia/compat/templates/compat/index.html:4
-msgid "Add-on Compatibility Report for {app} {version}"
-msgstr ""
-
-#: src/olympia/compat/templates/compat/index.html:11
-msgid "{app} {version} Compatibility"
-msgstr ""
-
-#: src/olympia/compat/templates/compat/index.html:17
-#, python-format
-msgid "Top 95%% compatible with previous version"
-msgstr ""
-
-#: src/olympia/compat/templates/compat/index.html:18
-#, python-format
-msgid "Top 95%% of all add-ons"
-msgstr ""
-
-#: src/olympia/compat/templates/compat/index.html:19
-msgid "All active add-ons"
-msgstr "Tất cả tiện ích hoạt động"
-
-#: src/olympia/compat/templates/compat/index.html:23 src/olympia/constants/base.py:401
-msgid "App"
-msgstr ""
-
-#: src/olympia/compat/templates/compat/index.html:55
-msgid "Details for add-ons compatible with previous version:"
-msgstr ""
-
-#: src/olympia/compat/templates/compat/index.html:57
-msgid "Show all versions"
-msgstr "Xem tất cả phiên bản"
-
-#: src/olympia/compat/templates/compat/index.html:59
-msgid "Details for add-ons compatible with all versions:"
-msgstr ""
-
-#: src/olympia/compat/templates/compat/index.html:61
-msgid "Show previous version only"
 msgstr ""
 
 #: src/olympia/compat/templates/compat/reporter.html:3
@@ -3120,11 +3124,13 @@ msgstr ""
 msgid "{0} success report"
 msgid_plural "{0} success reports"
 msgstr[0] ""
+msgstr[1] ""
 
 #: src/olympia/compat/templates/compat/reporter_detail.html:17
 msgid "{0} problem report"
 msgid_plural "{0} problem reports"
 msgstr[0] ""
+msgstr[1] ""
 
 #: src/olympia/compat/templates/compat/reporter_detail.html:21 src/olympia/users/templates/users/profile.html:70
 msgid "View all"
@@ -3138,8 +3144,8 @@ msgstr "Lọc theo Ứng dụng"
 msgid "Report Type"
 msgstr ""
 
-#: src/olympia/compat/templates/compat/reporter_detail.html:47 src/olympia/devhub/forms.py:784 src/olympia/devhub/templates/devhub/addons/ajax_compat_update.html:17 src/olympia/editors/forms.py:108
-#: src/olympia/zadmin/forms.py:45
+#: src/olympia/compat/templates/compat/reporter_detail.html:47 src/olympia/devhub/forms.py:785 src/olympia/devhub/templates/devhub/addons/ajax_compat_update.html:17 src/olympia/editors/forms.py:108
+#: src/olympia/editors/forms.py:248 src/olympia/zadmin/forms.py:45
 msgid "Application"
 msgstr "Ứng dụng"
 
@@ -3227,7 +3233,8 @@ msgstr "Đã duyệt Sơ bộ"
 msgid "Preliminarily Reviewed and Awaiting Full Review"
 msgstr "Đã duyệt Sơ bộ và Đang đợi Xét duyệt Đầy đủ"
 
-#: src/olympia/constants/base.py:33 src/olympia/editors/helpers.py:924 src/olympia/editors/templates/editors/themes/history_table.html:34
+#: src/olympia/constants/base.py:33 src/olympia/editors/forms.py:258 src/olympia/editors/helpers.py:73 src/olympia/editors/helpers.py:1004
+#: src/olympia/editors/templates/editors/themes/history_table.html:34
 msgid "Deleted"
 msgstr ""
 
@@ -3327,6 +3334,11 @@ msgstr "Hỏi sau khi người dùng bắt đầu tải xuống tiện ích này
 msgid "Ask before users can download this add-on"
 msgstr "Hỏi trước khi người dùng có thể tải xuống tiện ích này"
 
+#. Review points sources other than add-ons and themes.
+#: src/olympia/constants/base.py:388 src/olympia/devhub/forms.py:162 src/olympia/editors/templates/editors/performance.html:75
+msgid "Other"
+msgstr "Khác"
+
 #: src/olympia/constants/base.py:389
 msgid "Exception"
 msgstr ""
@@ -3337,6 +3349,10 @@ msgstr ""
 
 #: src/olympia/constants/base.py:391
 msgid "Change"
+msgstr ""
+
+#: src/olympia/constants/base.py:401
+msgid "App"
 msgstr ""
 
 #: src/olympia/constants/base.py:402
@@ -3487,7 +3503,7 @@ msgstr ""
 msgid "Duplicate"
 msgstr ""
 
-#: src/olympia/constants/editors.py:17 src/olympia/editors/helpers.py:502 src/olympia/editors/templates/editors/themes/queue.html:71 src/olympia/editors/templates/editors/themes/themes.html:94
+#: src/olympia/constants/editors.py:17 src/olympia/editors/helpers.py:575 src/olympia/editors/templates/editors/themes/queue.html:71 src/olympia/editors/templates/editors/themes/themes.html:94
 msgid "Reject"
 msgstr "Từ chối"
 
@@ -3587,7 +3603,7 @@ msgstr "Solaris"
 msgid "Android"
 msgstr "Android"
 
-#: src/olympia/core/apps.py:19
+#: src/olympia/core/apps.py:21
 msgid "Core"
 msgstr ""
 
@@ -3721,7 +3737,7 @@ msgid "Submit my add-on for manual review."
 msgstr ""
 
 #: src/olympia/devhub/forms.py:537
-msgid "Do not list my add-on on this site (beta)"
+msgid "Do not list my add-on on this site"
 msgstr ""
 
 #: src/olympia/devhub/forms.py:538
@@ -3754,46 +3770,46 @@ msgstr ""
 
 #: src/olympia/devhub/forms.py:592
 #, python-format
-msgid "Version %s already exists"
-msgstr "Phiên bản %s đã tồn tại rồi."
+msgid "Version %s already exists, or was uploaded before."
+msgstr ""
 
-#: src/olympia/devhub/forms.py:604
+#: src/olympia/devhub/forms.py:605
 msgid "Select a valid choice. That choice is not one of the available choices."
 msgstr ""
 
-#: src/olympia/devhub/forms.py:610
+#: src/olympia/devhub/forms.py:611
 msgid "A file with a version ending with a|alpha|b|beta and an optional number is detected as beta."
 msgstr ""
 
-#: src/olympia/devhub/forms.py:633
+#: src/olympia/devhub/forms.py:634
 msgid "You cannot upload any more files for this version."
 msgstr "Bạn không thể tải lên thêm tập tin cho phiên bản này."
 
-#: src/olympia/devhub/forms.py:639
+#: src/olympia/devhub/forms.py:640
 msgid "Version doesn't match"
 msgstr "Phiên bản không khớp"
 
-#: src/olympia/devhub/forms.py:668
+#: src/olympia/devhub/forms.py:669
 msgid "You cannot delete a file once the review process has started.  You must delete the whole version."
 msgstr ""
 
-#: src/olympia/devhub/forms.py:688
+#: src/olympia/devhub/forms.py:689
 msgid "The platform All cannot be combined with specific platforms."
 msgstr ""
 
-#: src/olympia/devhub/forms.py:693
+#: src/olympia/devhub/forms.py:694
 msgid "A platform can only be chosen once."
 msgstr "Một nền tảng chỉ có thể được chọn một lần."
 
-#: src/olympia/devhub/forms.py:706
+#: src/olympia/devhub/forms.py:707
 msgid "A review type must be selected."
 msgstr ""
 
-#: src/olympia/devhub/forms.py:788 src/olympia/editors/forms.py:114 src/olympia/zadmin/forms.py:49 src/olympia/zadmin/forms.py:52
+#: src/olympia/devhub/forms.py:789 src/olympia/editors/forms.py:114 src/olympia/editors/forms.py:254 src/olympia/zadmin/forms.py:49 src/olympia/zadmin/forms.py:52
 msgid "Select an application first"
 msgstr "Trước tiên hãy chọn một ứng dụng"
 
-#: src/olympia/devhub/forms.py:840
+#: src/olympia/devhub/forms.py:841
 msgid "There cannot be more than 3 required add-ons."
 msgstr ""
 
@@ -3815,6 +3831,7 @@ msgstr ""
 msgid "{0} error"
 msgid_plural "{0} errors"
 msgstr[0] "{0} lỗi"
+msgstr[1] ""
 
 # {0} is a number
 #. L10n: first parameter is the number of warnings
@@ -3822,81 +3839,82 @@ msgstr[0] "{0} lỗi"
 msgid "{0} warning"
 msgid_plural "{0} warnings"
 msgstr[0] "{0} cảnh báo"
+msgstr[1] ""
 
 #: src/olympia/devhub/models.py:375 src/olympia/reviews/templates/reviews/add.html:58
 msgid "Review"
 msgstr "Đánh giá"
 
-#: src/olympia/devhub/tasks.py:551
+#: src/olympia/devhub/tasks.py:583
 #, python-format
 msgid "%s responded with %s (%s)."
 msgstr ""
 
-#: src/olympia/devhub/tasks.py:555
+#: src/olympia/devhub/tasks.py:587
 #, python-format
 msgid "Connection to \"%s\" timed out."
 msgstr ""
 
-#: src/olympia/devhub/tasks.py:557
+#: src/olympia/devhub/tasks.py:589
 #, python-format
 msgid "Could not contact host at \"%s\"."
 msgstr ""
 
-#: src/olympia/devhub/utils.py:104
+#: src/olympia/devhub/utils.py:105
 #, python-format
 msgid "Validation generated too many errors/warnings so %s messages were truncated. After addressing the visible messages, you'll be able to see the others."
 msgstr ""
 
-#: src/olympia/devhub/views.py:183
+#: src/olympia/devhub/views.py:181
 msgid "All My Add-ons"
 msgstr "Tất cả Tiện ích của Tôi"
 
-#: src/olympia/devhub/views.py:210
+#: src/olympia/devhub/views.py:208
 msgid "All Activity"
 msgstr "Tất cả Hoạt động"
 
-#: src/olympia/devhub/views.py:211
+#: src/olympia/devhub/views.py:209
 msgid "Add-on Updates"
 msgstr "Cập nhật của Tiện ích"
 
-#: src/olympia/devhub/views.py:212
+#: src/olympia/devhub/views.py:210
 msgid "Add-on Status"
 msgstr "Trạng thái Tiện ích"
 
-#: src/olympia/devhub/views.py:213
+#: src/olympia/devhub/views.py:211
 msgid "User Collections"
 msgstr "Bộ sưu tập của Người dùng"
 
-#: src/olympia/devhub/views.py:214 src/olympia/devhub/templates/devhub/docs/policies-maintenance.html:68 src/olympia/pages/templates/pages/dev_faq.html:38
+#: src/olympia/devhub/views.py:212 src/olympia/devhub/templates/devhub/docs/policies-maintenance.html:68 src/olympia/pages/templates/pages/dev_faq.html:38
 #: src/olympia/pages/templates/pages/dev_faq.html:484
 msgid "User Reviews"
 msgstr "Đánh giá của Người dùng"
 
-#: src/olympia/devhub/views.py:327 src/olympia/devhub/views.py:331 src/olympia/devhub/views.py:484 src/olympia/devhub/views.py:513 src/olympia/devhub/views.py:564 src/olympia/devhub/views.py:1150
+#: src/olympia/devhub/views.py:325 src/olympia/devhub/views.py:329 src/olympia/devhub/views.py:484 src/olympia/devhub/views.py:513 src/olympia/devhub/views.py:564 src/olympia/devhub/views.py:1156
 msgid "Changes successfully saved."
 msgstr "Thay đổi đã được lưu thành công."
 
-#: src/olympia/devhub/views.py:334 src/olympia/devhub/views.py:1631
+#: src/olympia/devhub/views.py:332 src/olympia/devhub/views.py:1637
 msgid "Please check the form for errors."
 msgstr ""
 
-#: src/olympia/devhub/views.py:346
+#: src/olympia/devhub/views.py:344
 msgid "Add-on cannot be deleted. Disable this add-on instead."
 msgstr ""
 
-#: src/olympia/devhub/views.py:356
+#: src/olympia/devhub/views.py:354
 msgid "Theme deleted."
 msgstr ""
 
-#: src/olympia/devhub/views.py:356
+#: src/olympia/devhub/views.py:354
 msgid "Add-on deleted."
 msgstr "Tiện ích đã được xóa."
 
-#: src/olympia/devhub/views.py:362
+#: src/olympia/devhub/views.py:360
 msgid "URL name was incorrect. Theme was not deleted."
 msgstr ""
 
-#: src/olympia/devhub/views.py:367
+#: src/olympia/devhub/views.py:365
 msgid "URL name was incorrect. Add-on was not deleted."
 msgstr ""
 
@@ -3924,7 +3942,7 @@ msgstr "Kiểm định Tiện ích"
 msgid "Check Add-on Compatibility"
 msgstr ""
 
-#: src/olympia/devhub/views.py:808 src/olympia/signing/views.py:90
+#: src/olympia/devhub/views.py:808 src/olympia/signing/views.py:95
 msgid "You cannot submit this type of add-on"
 msgstr ""
 
@@ -3954,33 +3972,33 @@ msgstr ""
 msgid "There was an error uploading your preview."
 msgstr "Có lỗi khi đang tải lên ảnh xem trước của bạn."
 
-#: src/olympia/devhub/views.py:1189
+#: src/olympia/devhub/views.py:1195
 #, python-format
 msgid "Version %s disabled."
 msgstr ""
 
-#: src/olympia/devhub/views.py:1193
+#: src/olympia/devhub/views.py:1199
 #, python-format
 msgid "Version %s deleted."
 msgstr "Phiên bản %s đã được xóa."
 
-#: src/olympia/devhub/views.py:1203
+#: src/olympia/devhub/views.py:1209
 msgid "This upload has failed validation, and may lack complete validation results. Please take due care when reviewing it."
 msgstr ""
 
-#: src/olympia/devhub/views.py:1677
+#: src/olympia/devhub/views.py:1683
 msgid "Preliminary Review Requested."
 msgstr "Yêu cầu Xét duyệt Sơ bộ."
 
-#: src/olympia/devhub/views.py:1678
+#: src/olympia/devhub/views.py:1684
 msgid "Full Review Requested."
 msgstr "Yêu cầu Xét duyệt Đầy đủ."
 
-#: src/olympia/devhub/views.py:1779
+#: src/olympia/devhub/views.py:1783
 msgid "Your old credentials were revoked and are no longer valid. Be sure to update all API clients with the new credentials."
 msgstr ""
 
-#: src/olympia/devhub/views.py:1797
+#: src/olympia/devhub/views.py:1801
 msgid "New API key created"
 msgstr ""
 
@@ -4010,10 +4028,10 @@ msgstr "Trở lại Tiện ích"
 msgid "{0} :: Search"
 msgstr "{0} :: Tìm kiếm"
 
-#: src/olympia/devhub/templates/devhub/devhub_search.html:6 src/olympia/devhub/templates/devhub/search.html:8 src/olympia/editors/forms.py:435 src/olympia/editors/forms.py:437
+#: src/olympia/devhub/templates/devhub/devhub_search.html:6 src/olympia/devhub/templates/devhub/search.html:8 src/olympia/editors/forms.py:534 src/olympia/editors/forms.py:536
 #: src/olympia/editors/templates/editors/queue.html:27 src/olympia/editors/templates/editors/themes/queue_list.html:14 src/olympia/search/templates/search/collections.html:17
-#: src/olympia/search/templates/search/personas.html:18 src/olympia/search/templates/search/results.html:18 src/olympia/search/templates/search/mobile/results.html:8 src/olympia/templates/search.html:14
-#: src/olympia/templates/impala/search.html:18
+#: src/olympia/search/templates/search/personas.html:18 src/olympia/search/templates/search/results.html:18 src/olympia/search/templates/search/mobile/results.html:8
+#: src/olympia/templates/search.html:14 src/olympia/templates/impala/search.html:18
 msgid "Search"
 msgstr "Tìm kiếm"
 
@@ -4057,9 +4075,9 @@ msgstr "Tìm hiểu Đầy đủ về Tiện ích"
 
 #: src/olympia/devhub/templates/devhub/index.html:41
 msgid ""
-"Add-ons let millions of Firefox users enhance and customize their browsing experience. If you're a Web developer and know <a href=\"https://developer.mozilla.org/docs/Web/HTML\">HTML</a>, <a "
-"href=\"https://developer.mozilla.org/docs/Web/JavaScript\">JavaScript</a>, and <a href=\"https://developer.mozilla.org/docs/Web/CSS\">CSS</a>, you already have all the necessary skills to make a "
-"great add-on."
+"Add-ons let millions of Firefox users enhance and customize their browsing experience. If you're a Web developer and know <a href=\"https://developer.mozilla.org/docs/Web/HTML\">HTML</a>, <a href="
+"\"https://developer.mozilla.org/docs/Web/JavaScript\">JavaScript</a>, and <a href=\"https://developer.mozilla.org/docs/Web/CSS\">CSS</a>, you already have all the necessary skills to make a great "
+"add-on."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/index.html:51
@@ -4070,12 +4088,12 @@ msgstr ""
 msgid "Start Making Add-ons"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/index.html:86 src/olympia/devhub/templates/devhub/addons/listing/items.html:25 src/olympia/devhub/templates/devhub/includes/addon_details.html:15
+#: src/olympia/devhub/templates/devhub/index.html:86 src/olympia/devhub/templates/devhub/addons/listing/items.html:25 src/olympia/devhub/templates/devhub/includes/addon_details.html:20
 #: src/olympia/devhub/templates/devhub/personas/edit.html:43
 msgid "Status:"
 msgstr "Trạng thái:"
 
-#: src/olympia/devhub/templates/devhub/index.html:90 src/olympia/devhub/templates/devhub/includes/addon_details.html:100
+#: src/olympia/devhub/templates/devhub/index.html:90 src/olympia/devhub/templates/devhub/includes/addon_details.html:87
 msgid "Visibility:"
 msgstr ""
 
@@ -4083,11 +4101,11 @@ msgstr ""
 msgid "Latest Version:"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/index.html:109 src/olympia/devhub/templates/devhub/includes/addon_details.html:145 src/olympia/devhub/templates/devhub/personas/edit.html:49
+#: src/olympia/devhub/templates/devhub/index.html:109 src/olympia/devhub/templates/devhub/includes/addon_details.html:131 src/olympia/devhub/templates/devhub/personas/edit.html:49
 msgid "Queue Position:"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/index.html:110 src/olympia/devhub/templates/devhub/includes/addon_details.html:146 src/olympia/devhub/templates/devhub/personas/edit.html:50
+#: src/olympia/devhub/templates/devhub/index.html:110 src/olympia/devhub/templates/devhub/includes/addon_details.html:132 src/olympia/devhub/templates/devhub/personas/edit.html:50
 #, python-format
 msgid "%(position)s of %(total)s"
 msgstr ""
@@ -4189,16 +4207,6 @@ msgstr ""
 msgid "Do you want your add-on to be distributed on this site?"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/validate_addon.html:49 src/olympia/devhub/templates/devhub/addons/submit/upload.html:30 src/olympia/devhub/templates/devhub/versions/add_file_modal.html:14
-#: src/olympia/devhub/templates/devhub/versions/add_file_modal.html:53 src/olympia/devhub/templates/devhub/versions/list.html:298
-msgid "Warning:"
-msgstr ""
-
-#: src/olympia/devhub/templates/devhub/validate_addon.html:50 src/olympia/devhub/templates/devhub/addons/submit/upload.html:31
-#, python-format
-msgid "Submission of unlisted add-ons for signing is currently in an open beta. Please <a href=\"%(url)s\" target=\"_blank\">report any bugs</a> that you encounter."
-msgstr ""
-
 #. first parameter is a filename like lorem-ipsum-1.0.2.xpi
 #: src/olympia/devhub/templates/devhub/validation.html:5
 msgid "Validation Results for {0}"
@@ -4253,17 +4261,17 @@ msgid ""
 "This add-on is incompatible with <b>%(app_name)s %(app_version)s</b>, the latest release of %(app_name)s. Please consider updating your add-on's compatibility info, or uploading a newer version of "
 "this add-on."
 msgstr ""
-"Tiện ích này không tương thích với <b>%(app_name)s %(app_version)s</b>, bản phát hành mới nhất của %(app_name)s. Vui lòng cân nhắc việc cập nhật thông tin tương thích cho tiện ích của bạn, hoặc tải"
-" lên phiên bản mới cho tiện ích này."
+"Tiện ích này không tương thích với <b>%(app_name)s %(app_version)s</b>, bản phát hành mới nhất của %(app_name)s. Vui lòng cân nhắc việc cập nhật thông tin tương thích cho tiện ích của bạn, hoặc tải "
+"lên phiên bản mới cho tiện ích này."
 
 #: src/olympia/devhub/templates/devhub/addons/ajax_compat_error.html:15
 #, python-format
 msgid ""
-"<a href=\"#\" class=\"button compat-update\" data-updateurl=\"%(update_url)s\">Update Compatibility</a> <a href=\"%(version_url)s\" class=\"button\">Upload New Version</a> or <a href=\"#\" "
-"class=\"close\">Ignore</a>"
+"<a href=\"#\" class=\"button compat-update\" data-updateurl=\"%(update_url)s\">Update Compatibility</a> <a href=\"%(version_url)s\" class=\"button\">Upload New Version</a> or <a href=\"#\" class="
+"\"close\">Ignore</a>"
 msgstr ""
-"<a href=\"#\" class=\"button compat-update\" data-updateurl=\"%(update_url)s\">Cập nhật Tính tương thích</a> <a href=\"%(version_url)s\" class=\"button\">Tải lên Phiên bản Mới</a> hoặc <a "
-"href=\"#\" class=\"close\">Bỏ qua</a>"
+"<a href=\"#\" class=\"button compat-update\" data-updateurl=\"%(update_url)s\">Cập nhật Tính tương thích</a> <a href=\"%(version_url)s\" class=\"button\">Tải lên Phiên bản Mới</a> hoặc <a href=\"#"
+"\" class=\"close\">Bỏ qua</a>"
 
 #: src/olympia/devhub/templates/devhub/addons/ajax_compat_status.html:5
 msgid "View and update application compatibility ranges."
@@ -4277,7 +4285,7 @@ msgstr "Tính tương thích"
 msgid "Update Compatibility"
 msgstr "Cập nhật Tính tương thích"
 
-#: src/olympia/devhub/templates/devhub/addons/ajax_compat_update.html:4
+#: src/olympia/devhub/templates/devhub/addons/ajax_compat_update.html:4 src/olympia/devhub/templates/devhub/versions/edit.html:45
 msgid "Adjusting application information here will allow users to install your add-on even if the install manifest in the package indicates that the add-on is incompatible."
 msgstr "Điều chỉnh thông tin ứng dụng tại đây sẽ cho phép người dùng cài đặt tiện ích của bạn cho dù tập tin chỉ dẫn cài đặt trong gói có ghi rằng tiện ích của bạn không tương thích."
 
@@ -4289,9 +4297,9 @@ msgstr "Phiên bản Được hỗ trợ"
 msgid "Add Another Application&hellip;"
 msgstr "Thêm Ứng dụng Khác&hellip;"
 
-#: src/olympia/devhub/templates/devhub/addons/ajax_compat_update.html:38 src/olympia/devhub/templates/devhub/addons/owner.html:86 src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:46
-#: src/olympia/devhub/templates/devhub/versions/list.html:351 src/olympia/devhub/templates/devhub/versions/list.html:353 src/olympia/templates/impala/base.html:132
-#: src/olympia/templates/impala/base.html:143 src/olympia/templates/impala/base.html:161 src/olympia/templates/impala/base.html:171
+#: src/olympia/devhub/templates/devhub/addons/ajax_compat_update.html:38 src/olympia/devhub/templates/devhub/addons/owner.html:86 src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:45
+#: src/olympia/devhub/templates/devhub/versions/list.html:349 src/olympia/devhub/templates/devhub/versions/list.html:351 src/olympia/templates/impala/base.html:129
+#: src/olympia/templates/impala/base.html:140 src/olympia/templates/impala/base.html:158 src/olympia/templates/impala/base.html:168
 msgid "Close"
 msgstr "Đóng"
 
@@ -4309,6 +4317,7 @@ msgstr "Hoạt động cũ hơn cho Tiện ích của Tôi"
 msgid "<b>{0}</b> theme"
 msgid_plural "<b>{0}</b> themes"
 msgstr[0] ""
+msgstr[1] ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit.html:3 src/olympia/devhub/templates/devhub/addons/listing/item_actions.html:25
 #: src/olympia/devhub/templates/devhub/addons/listing/item_actions_theme.html:7 src/olympia/devhub/templates/devhub/includes/addons_edit_nav.html:2
@@ -4324,7 +4333,7 @@ msgstr "Không"
 msgid "Manage Authors & License"
 msgstr "Quản lí Tác giả & Giấy phép"
 
-#: src/olympia/devhub/templates/devhub/addons/owner.html:29 src/olympia/editors/templates/editors/review.html:270
+#: src/olympia/devhub/templates/devhub/addons/owner.html:29 src/olympia/editors/helpers.py:362 src/olympia/editors/templates/editors/review.html:270
 msgid "Authors"
 msgstr "Tác giả"
 
@@ -4393,36 +4402,28 @@ msgstr "Tóm tắt"
 
 #: src/olympia/devhub/templates/devhub/addons/edit/basic.html:52
 msgid ""
-"A short explanation of your add-on's basic\n"
-"                          functionality that is displayed in search and browse\n"
-"                          listings, as well as at the top of your add-on's\n"
-"                          details page. It is only relevant for listed add-ons."
+"A short explanation of your add-on's basic functionality that is displayed in search and browse listings, as well as at the top of your add-on's details page. It is only relevant for listed add-ons."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/basic.html:73
-msgid ""
-"Categories are the primary way users browse through add-ons.\n"
-"                        Choose any that fit your add-on's functionality for the most\n"
-"                        exposure. It is only relevant for listed add-ons."
+msgid "Categories are the primary way users browse through add-ons. Choose any that fit your add-on's functionality for the most exposure. It is only relevant for listed add-ons."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/basic.html:90
 #, python-format
-msgid "Categories cannot be changed while your add-on is featured for this application. Please email <a href=\"mailto:%(email)s\">%(email)s</a> if there is a reason you need to modify your categories."
+msgid ""
+"Categories cannot be changed while your add-on is featured for this application. Please email <a href=\"mailto:%(email)s\">%(email)s</a> if there is a reason you need to modify your categories."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/basic.html:119
-msgid ""
-"Tags help users find your add-on and should be short\n"
-"                        descriptors such as tabs, toolbar, or twitter.  You\n"
-"                        may have a maximum of {0} tags. It is only relevant\n"
-"                        for listed add-ons."
+msgid "Tags help users find your add-on and should be short descriptors such as tabs, toolbar, or twitter. You may have a maximum of {0} tags. It is only relevant for listed add-ons."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/basic.html:129 src/olympia/devhub/templates/devhub/personas/edit.html:97 src/olympia/devhub/templates/devhub/personas/submit.html:46
 msgid "Comma-separated, minimum of {0} character."
 msgid_plural "Comma-separated, minimum of {0} characters."
 msgstr[0] "Ngăn cách bằng dấu phẩy, tối thiểu {0} kí tự."
+msgstr[1] ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/basic.html:132 src/olympia/devhub/templates/devhub/personas/edit.html:100 src/olympia/devhub/templates/devhub/personas/submit.html:49
 msgid "Example: dark, cinema, noir. Limit 20."
@@ -4432,6 +4433,7 @@ msgstr ""
 msgid "Reserved tag:"
 msgid_plural "Reserved tags:"
 msgstr[0] "Nhãn dự trữ:"
+msgstr[1] ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/details.html:5
 msgid "Add-on Details"
@@ -4442,11 +4444,7 @@ msgid "Add-on Details for {0}"
 msgstr "Chi tiết Tiện ích cho {0}"
 
 #: src/olympia/devhub/templates/devhub/addons/edit/details.html:22
-msgid ""
-"A longer explanation of features,\n"
-"                          functionality, and other relevant information. This\n"
-"                          field is only displayed on the add-on's details\n"
-"                          page. It is only relevant for listed add-ons."
+msgid "A longer explanation of features, functionality, and other relevant information. This field is only displayed on the add-on's details page. It is only relevant for listed add-ons."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/details.html:44 src/olympia/translations/templates/translations/trans-menu.html:13
@@ -4454,10 +4452,7 @@ msgid "Default Locale"
 msgstr "Bản địa Mặc định"
 
 #: src/olympia/devhub/templates/devhub/addons/edit/details.html:45
-msgid ""
-"Information about your add-on is displayed in this locale\n"
-"                        unless you override it with a locale-specific translation.\n"
-"                        It is only relevant for listed add-ons."
+msgid "Information about your add-on is displayed in this locale unless you override it with a locale-specific translation. It is only relevant for listed add-ons."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/details.html:61 src/olympia/users/forms.py:311 src/olympia/users/templates/users/edit.html:122 src/olympia/users/templates/users/register.html:57
@@ -4467,10 +4462,8 @@ msgstr "Trang chủ"
 
 #: src/olympia/devhub/templates/devhub/addons/edit/details.html:63
 msgid ""
-"If your add-on has another homepage, enter its\n"
-"                          address here. If your website is localized into other\n"
-"                          languages multiple translations of this field can be\n"
-"                          added. It is only relevant for listed add-ons."
+"If your add-on has another homepage, enter its address here. If your website is localized into other languages multiple translations of this field can be added. It is only relevant for listed add-"
+"ons."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/media.html:3
@@ -4488,19 +4481,14 @@ msgstr "Thông tin Trợ giúp cho {0}"
 
 #: src/olympia/devhub/templates/devhub/addons/edit/support.html:22
 msgid ""
-"If you wish to display an e-mail address for support\n"
-"                          inquiries, enter it here. If you have different\n"
-"                          addresses for each language multiple translations of\n"
-"                          this field can be added. It is only relevant for\n"
-"                          listed add-ons."
+"If you wish to display an e-mail address for support inquiries, enter it here. If you have different addresses for each language multiple translations of this field can be added. It is only "
+"relevant for listed add-ons."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/support.html:45
 msgid ""
-"If your add-on has a support website or forum, enter\n"
-"                          its address here. If your website is localized into\n"
-"                          other languages, multiple translations of this field can\n"
-"                          be added. It is only relevant for listed add-ons."
+"If your add-on has a support website or forum, enter its address here. If your website is localized into other languages, multiple translations of this field can be added. It is only relevant for "
+"listed add-ons."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:6
@@ -4514,11 +4502,8 @@ msgstr "Chi tiết Kĩ thuật cho {0}"
 
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:23
 msgid ""
-"Any information end users may want to know that isn't\n"
-"                          necessarily applicable to the add-on summary or description.\n"
-"                          Common uses include listing known major bugs, information on\n"
-"                          how to report bugs, anticipated release date of a new version,\n"
-"                          etc. It is only relevant for listed add-ons."
+"Any information end users may want to know that isn't necessarily applicable to the add-on summary or description. Common uses include listing known major bugs, information on how to report bugs, "
+"anticipated release date of a new version, etc. It is only relevant for listed add-ons."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:46
@@ -4530,9 +4515,7 @@ msgid "Add-on Flags"
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:69
-msgid ""
-"These flags are used to classify add-ons. It is only\n"
-"                        relevant for listed add-ons."
+msgid "These flags are used to classify add-ons. It is only relevant for listed add-ons."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:74
@@ -4548,9 +4531,7 @@ msgid "View Source?"
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:90
-msgid ""
-"Whether the source of your add-on can be displayed in our\n"
-"                        online viewer. It is only relevant for listed add-ons."
+msgid "Whether the source of your add-on can be displayed in our online viewer. It is only relevant for listed add-ons."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:94
@@ -4566,10 +4547,7 @@ msgid "Public Stats?"
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:102
-msgid ""
-"Whether the download and usage stats of your add-on can\n"
-"                        be displayed in our online viewer.\n"
-"                        It is only relevant for listed add-ons."
+msgid "Whether the download and usage stats of your add-on can be displayed in our online viewer. It is only relevant for listed add-ons."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:107
@@ -4585,10 +4563,7 @@ msgid "Upgrade SDK?"
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:116
-msgid ""
-"If selected, we will try to automatically upgrade your\n"
-"                        add-on when a new version of the SDK is released.\n"
-"                        It is only relevant for listed add-ons."
+msgid "If selected, we will try to automatically upgrade your add-on when a new version of the SDK is released. It is only relevant for listed add-ons."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:121
@@ -4639,10 +4614,8 @@ msgstr "Biểu tượng tiện ích"
 
 #: src/olympia/devhub/templates/devhub/addons/forms_shared/media.html:16
 msgid ""
-"Upload an icon for your add-on or choose from one of ours. The\n"
-"                      icon is displayed nearly everywhere your add-on is. Uploaded images\n"
-"                      must be one of the following image types: .png, .jpg.\n"
-"                      It is only relevant for listed add-ons."
+"Upload an icon for your add-on or choose from one of ours. The icon is displayed nearly everywhere your add-on is. Uploaded images must be one of the following image types: .png, .jpg. It is only "
+"relevant for listed add-ons."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/forms_shared/media.html:25
@@ -4750,16 +4723,14 @@ msgid "Deleting your add-on will permanently remove it from the site and prevent
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:24
-msgid ""
-"Enter the following text confirm your decision:\n"
-"           {slug}"
+msgid "Enter the following text confirm your decision: {slug}"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:34
+#: src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:33
 msgid "Please tell us why you are deleting your theme:"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:36
+#: src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:35
 msgid "Please tell us why you are deleting your add-on:"
 msgstr ""
 
@@ -4796,13 +4767,13 @@ msgstr "Phiên bản Mới"
 msgid "Daily statistics on downloads and users."
 msgstr "Thống kê hàng này về lượt tải và người dùng."
 
-#: src/olympia/devhub/templates/devhub/addons/listing/item_actions.html:45 src/olympia/stats/templates/stats/stats.html:75 src/olympia/stats/templates/stats/stats.html:79
-#: src/olympia/stats/templates/stats/stats.html:81
+#: src/olympia/devhub/templates/devhub/addons/listing/item_actions.html:45 src/olympia/stats/templates/stats/stats.html:31 src/olympia/stats/templates/stats/stats.html:35
+#: src/olympia/stats/templates/stats/stats.html:37
 msgid "Statistics"
 msgstr "Thống kê"
 
-#: src/olympia/devhub/templates/devhub/addons/listing/item_actions.html:54 src/olympia/devhub/templates/devhub/includes/addons_edit_nav.html:5 src/olympia/devhub/templates/devhub/payments/payments.html:3
-#: src/olympia/devhub/templates/devhub/payments/tier.html:4
+#: src/olympia/devhub/templates/devhub/addons/listing/item_actions.html:54 src/olympia/devhub/templates/devhub/includes/addons_edit_nav.html:5
+#: src/olympia/devhub/templates/devhub/payments/payments.html:3 src/olympia/devhub/templates/devhub/payments/tier.html:4
 msgid "Manage Payments"
 msgstr "Quản lí Khoản chi trả"
 
@@ -4857,6 +4828,7 @@ msgstr ""
 msgid "<strong>{0}</strong> active user"
 msgid_plural "<strong>{0}</strong> active users"
 msgstr[0] "<strong>{0}</strong> người dùng hoạt động"
+msgstr[1] ""
 
 #: src/olympia/devhub/templates/devhub/addons/submit/base.html:11
 msgid "Submit Add-on"
@@ -4915,10 +4887,7 @@ msgid "Your add-on has been submitted to the Full Review queue."
 msgstr "Tiện ích của bạn đã được gửi lên hàng đợi Xét duyệt Đầy đủ."
 
 #: src/olympia/devhub/templates/devhub/addons/submit/done.html:18
-msgid ""
-"You'll receive an email once it has been reviewed by an editor. In\n"
-"          the meantime, you and your friends can install it directly from its\n"
-"          details page:"
+msgid "You'll receive an email once it has been reviewed by an editor. In the meantime, you and your friends can install it directly from its details page:"
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/addons/submit/done.html:27 src/olympia/devhub/templates/devhub/addons/submit/done.html:77 src/olympia/devhub/templates/devhub/personas/submit_done.html:16
@@ -5126,11 +5095,11 @@ msgstr "Bước 2. Tải lên Tiện ích của Bạn"
 msgid "Use the fields below to upload your add-on package and select any platform restrictions. After upload, a series of automated validation tests will be run on your file."
 msgstr "Dùng các trường bên dưới để tải lên gói tiện ích của bạn và chọn giới hạn nền tảng. Sau khi tải lên, một loạt bài kiểm định tự động sẽ được chạy trên tập tin của bạn."
 
-#: src/olympia/devhub/templates/devhub/addons/submit/upload.html:59 src/olympia/devhub/templates/devhub/versions/add_file_modal.html:39
+#: src/olympia/devhub/templates/devhub/addons/submit/upload.html:51 src/olympia/devhub/templates/devhub/versions/add_file_modal.html:28
 msgid "Which platforms is this file compatible with?"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/addons/submit/upload.html:67 src/olympia/devhub/templates/devhub/versions/add_file_modal.html:65
+#: src/olympia/devhub/templates/devhub/addons/submit/upload.html:59 src/olympia/devhub/templates/devhub/versions/add_file_modal.html:45
 msgid "Administrative overrides"
 msgstr ""
 
@@ -5158,8 +5127,8 @@ msgstr ""
 #: src/olympia/devhub/templates/devhub/api/key.html:37
 #, python-format
 msgid ""
-"To make API requests, send a <a href=\"%(jwt_url)s\">JSON Web Token (JWT)</a> as the authorization header. You'll need to generate a JWT for every request as explained in the <a "
-"href=\"%(docs_url)s\">API documentation</a>."
+"To make API requests, send a <a href=\"%(jwt_url)s\">JSON Web Token (JWT)</a> as the authorization header. You'll need to generate a JWT for every request as explained in the <a href=\"%(docs_url)s"
+"\">API documentation</a>."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/api/key.html:47
@@ -5179,8 +5148,8 @@ msgstr ""
 msgid "Generate new credentials"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/docs/policies-agreement.html:3 src/olympia/devhub/templates/devhub/docs/policies-agreement.html:7 src/olympia/devhub/templates/devhub/docs/policies-agreement.html:9
-#: src/olympia/devhub/templates/devhub/docs/policies.html:24 src/olympia/devhub/templates/devhub/docs/policies.html:103
+#: src/olympia/devhub/templates/devhub/docs/policies-agreement.html:3 src/olympia/devhub/templates/devhub/docs/policies-agreement.html:7
+#: src/olympia/devhub/templates/devhub/docs/policies-agreement.html:9 src/olympia/devhub/templates/devhub/docs/policies.html:24 src/olympia/devhub/templates/devhub/docs/policies.html:103
 msgid "Developer Agreement"
 msgstr ""
 
@@ -5214,8 +5183,8 @@ msgstr ""
 #: src/olympia/devhub/templates/devhub/docs/policies-contact.html:26
 #, python-format
 msgid ""
-"If you have a question about an Editor's review of an add-on or want to report a policy violation, please email %(mail_editors)s. <strong>Almost all add-on reports fall under this "
-"category.</strong> Please be sure to include a link to the add-on in question and a detailed description of your question or comment."
+"If you have a question about an Editor's review of an add-on or want to report a policy violation, please email %(mail_editors)s. <strong>Almost all add-on reports fall under this category.</"
+"strong> Please be sure to include a link to the add-on in question and a detailed description of your question or comment."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/docs/policies-contact.html:31
@@ -5230,8 +5199,8 @@ msgstr ""
 #, python-format
 msgid ""
 "If you have discovered a security vulnerability in an add-on, even if it is not hosted here, Mozilla is very interested in your discovery and will work with the add-on developer to correct the "
-"issue as soon as possible. Add-on security issues can be reported <a href=\"http://www.mozilla.org/projects/security/security-bugs-policy.html\">confidentially</a> in <a "
-"href=\"%(link_bugzilla)s\">Bugzilla</a> or by emailing %(mail_admins)s."
+"issue as soon as possible. Add-on security issues can be reported <a href=\"http://www.mozilla.org/projects/security/security-bugs-policy.html\">confidentially</a> in <a href=\"%(link_bugzilla)s"
+"\">Bugzilla</a> or by emailing %(mail_admins)s."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/docs/policies-contact.html:42
@@ -5240,8 +5209,8 @@ msgstr ""
 
 #: src/olympia/devhub/templates/devhub/docs/policies-contact.html:44
 msgid ""
-"If you've found a problem with the site, we'd love to fix it. Please <a href=\"https://github.com/mozilla/olympia/issues\">file a bug report</a> in GitHub, including the location of the problem and"
-" how you encountered it."
+"If you've found a problem with the site, we'd love to fix it. Please <a href=\"https://github.com/mozilla/addons/issues/new\">file a bug report</a> in GitHub, including the location of the problem "
+"and how you encountered it."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/docs/policies-maintenance.html:3 src/olympia/devhub/templates/devhub/docs/policies-maintenance.html:7
@@ -5255,9 +5224,9 @@ msgstr ""
 
 #: src/olympia/devhub/templates/devhub/docs/policies-maintenance.html:12
 msgid ""
-"Developers are encouraged to submit updates to their add-ons to fix bugs, add features, and otherwise improve their product. New versions of an add-on must have a <a "
-"href=\"https://developer.mozilla.org/en/Toolkit_version_format\">higher version number</a> and can be submitted through the Developer Tools provided. There is no limit to the number of versions "
-"that can be submitted, but please remember that versions must be reviewed by an editor."
+"Developers are encouraged to submit updates to their add-ons to fix bugs, add features, and otherwise improve their product. New versions of an add-on must have a <a href=\"https://developer."
+"mozilla.org/en/Toolkit_version_format\">higher version number</a> and can be submitted through the Developer Tools provided. There is no limit to the number of versions that can be submitted, but "
+"please remember that versions must be reviewed by an editor."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/docs/policies-maintenance.html:18
@@ -5320,8 +5289,8 @@ msgstr ""
 
 #: src/olympia/devhub/templates/devhub/docs/policies-maintenance.html:70
 msgid ""
-"Mozilla encourages its users to offer feedback on their experiences when using an add-on. This allows other users to determine if the add-on is stable and useful. It also provides valuable feedback"
-" to developers, allowing them to continuously improve their add-on to meet user needs."
+"Mozilla encourages its users to offer feedback on their experiences when using an add-on. This allows other users to determine if the add-on is stable and useful. It also provides valuable feedback "
+"to developers, allowing them to continuously improve their add-on to meet user needs."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/docs/policies-maintenance.html:76
@@ -5370,7 +5339,8 @@ msgid ""
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/docs/policies-recommended.html:19
-msgid "Featured add-ons are chosen by the Featured Add-ons Advisory Board, a small group of add-on developers and fans from the Mozilla community who have volunteered to review and vote on nominations."
+msgid ""
+"Featured add-ons are chosen by the Featured Add-ons Advisory Board, a small group of add-on developers and fans from the Mozilla community who have volunteered to review and vote on nominations."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/docs/policies-recommended.html:25
@@ -5554,9 +5524,9 @@ msgstr ""
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:31
 msgid ""
-"Detailed descriptions of each option are below. After selecting a review process at submission, the add-on will be placed in the queue. Add-ons are reviewed by the <a "
-"href=\"https://wiki.mozilla.org/AMO:Editors\">AMO Editors</a>, a group of talented developers that volunteer to help the Mozilla project by reviewing add-ons to ensure a stable and safe experience "
-"for users. Developers will receive an email with any updates throughout the review process."
+"Detailed descriptions of each option are below. After selecting a review process at submission, the add-on will be placed in the queue. Add-ons are reviewed by the <a href=\"https://wiki.mozilla."
+"org/AMO:Editors\">AMO Editors</a>, a group of talented developers that volunteer to help the Mozilla project by reviewing add-ons to ensure a stable and safe experience for users. Developers will "
+"receive an email with any updates throughout the review process."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:37
@@ -5567,8 +5537,8 @@ msgstr ""
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:44
 msgid ""
-"Full reviews are appropriate for add-ons that are well-tested, stable, fast, and have wide appeal to our users. If you aren't confident that your add-on meets that criteria, please consider working"
-" out the kinks while in preliminary review and accumulating user feedback first."
+"Full reviews are appropriate for add-ons that are well-tested, stable, fast, and have wide appeal to our users. If you aren't confident that your add-on meets that criteria, please consider working "
+"out the kinks while in preliminary review and accumulating user feedback first."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:50
@@ -5663,8 +5633,8 @@ msgstr ""
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:123
 #, python-format
 msgid ""
-"Many of the above restrictions are tested automatically by an extension scanner that will flag suspicious add-ons for editor review. You can read more about this scanner in the <a "
-"href=\"%(link_validation)s\">Validation Help</a> document."
+"Many of the above restrictions are tested automatically by an extension scanner that will flag suspicious add-ons for editor review. You can read more about this scanner in the <a href="
+"\"%(link_validation)s\">Validation Help</a> document."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:129
@@ -5685,8 +5655,8 @@ msgstr ""
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:142
 msgid ""
-"Subsequent versions of the add-on will automatically be placed in the full review queue. Until the review is completed, the new version will only be displayed on the Version History page of the "
-"add-on. Once reviewed, the version will be updated across the site and deployed through the automatic update service."
+"Subsequent versions of the add-on will automatically be placed in the full review queue. Until the review is completed, the new version will only be displayed on the Version History page of the add-"
+"on. Once reviewed, the version will be updated across the site and deployed through the automatic update service."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:148
@@ -5788,9 +5758,9 @@ msgstr ""
 msgid ""
 "<p> Whenever an add-on includes any unexpected* feature that </p> <ul> <li>compromises user privacy or security (like sending data to third parties),</li> <li>changes default settings like the "
 "homepage or search engine, or</li> <li>changes settings or features in other add-ons or deactivates them altogether</li> </ul> <p>the features must adhere to the following requirements:</p> <ul> "
-"<li>The add-on description must clearly state what changes the add-on makes.</li> <li>All changes must be opt-in, meaning the user must take non-default action to enact the change.</li> <li>The "
-"opt-in dialog must clearly state the name of the add-on requesting the change.</li> <li>Uninstalling the add-on restores the user's original settings if they were changed.</li> </ul> <p>*Unexpected"
-" features are those that are unrelated to the add-on's primary function.</p>"
+"<li>The add-on description must clearly state what changes the add-on makes.</li> <li>All changes must be opt-in, meaning the user must take non-default action to enact the change.</li> <li>The opt-"
+"in dialog must clearly state the name of the add-on requesting the change.</li> <li>Uninstalling the add-on restores the user's original settings if they were changed.</li> </ul> <p>*Unexpected "
+"features are those that are unrelated to the add-on's primary function.</p>"
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:268
@@ -5807,8 +5777,8 @@ msgstr ""
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:282
 msgid ""
-"Add-ons that store or otherwise handle browsing data must support <a href=\"https://developer.mozilla.org/En/Supporting_private_browsing_mode\">Private Browsing Mode</a>.  During a Private Browsing"
-" session, no browsing data can be written to disk, and all of this data must be cleared when Firefox quits or the Private Browsing session ends."
+"Add-ons that store or otherwise handle browsing data must support <a href=\"https://developer.mozilla.org/En/Supporting_private_browsing_mode\">Private Browsing Mode</a>. During a Private Browsing "
+"session, no browsing data can be written to disk, and all of this data must be cleared when Firefox quits or the Private Browsing session ends."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:287
@@ -5851,10 +5821,10 @@ msgstr ""
 
 #: src/olympia/devhub/templates/devhub/docs/policies-submission.html:25
 msgid ""
-"<strong>Is the add-on clearly and accurately described?</strong> It's of the utmost importance to us that users get what they expect when they try a new add-on. Your add-on name should be clear and"
-" concise, and you should refrain from using special characters or numbers to get higher search rankings or for decorative purposes. Your description should provide details about what the add-on "
-"does, how a user should take advantage of it, and what the user should expect when they install it. Links to external documents for detailed instructions are fine, but the description itself should"
-" cover the basics and leave users confident that they know what they'll get. Also, it is important that you maintain version notes appropriately as you improve and change your add-on. Users should "
+"<strong>Is the add-on clearly and accurately described?</strong> It's of the utmost importance to us that users get what they expect when they try a new add-on. Your add-on name should be clear and "
+"concise, and you should refrain from using special characters or numbers to get higher search rankings or for decorative purposes. Your description should provide details about what the add-on "
+"does, how a user should take advantage of it, and what the user should expect when they install it. Links to external documents for detailed instructions are fine, but the description itself should "
+"cover the basics and leave users confident that they know what they'll get. Also, it is important that you maintain version notes appropriately as you improve and change your add-on. Users should "
 "be able to see what's new in an add-on they may have tried previously, and should be made aware of changes that might affect their current use of the add-on when they update."
 msgstr ""
 
@@ -5868,8 +5838,8 @@ msgstr ""
 #: src/olympia/devhub/templates/devhub/docs/policies-submission.html:37
 msgid ""
 "<strong>Has the add-on been well-tested, and is it free of obvious or serious defects?</strong> One important thing that we look for when considering an add-on is whether its user reviews indicate "
-"that it has received thorough testing, and that it doesn't have serious problems or negative impacts on the browser. If reviewers report problems such as major performance issues, crashes, frequent"
-" problems using the functions of the add-on, or spamming of messages to the error console, you should take those reports to heart, and re-submit your add-on after you've addressed them as best you "
+"that it has received thorough testing, and that it doesn't have serious problems or negative impacts on the browser. If reviewers report problems such as major performance issues, crashes, frequent "
+"problems using the functions of the add-on, or spamming of messages to the error console, you should take those reports to heart, and re-submit your add-on after you've addressed them as best you "
 "can. We don't expect you to perfectly optimize or have zero bugs &mdash; Firefox itself undergoes constant improvement in these areas &mdash; but we do want you to take reasonable efforts to "
 "minimize downsides, and to clearly call out cases where users may be surprised by those that remain."
 msgstr ""
@@ -5877,8 +5847,8 @@ msgstr ""
 #: src/olympia/devhub/templates/devhub/docs/policies-submission.html:43
 msgid ""
 "<strong>Do the add-on and add-on author both treat the user respectfully?</strong> Your software should not intrude on the user unnecessarily, try to trick the user, or conceal any of its "
-"activities from the user. Users (or even non-users) are sometimes rude in their comments, and while we will do our best to filter out inaccurate reviews as they're reported to us, we do expect that"
-" authors will avoid retaliating with rudeness of their own."
+"activities from the user. Users (or even non-users) are sometimes rude in their comments, and while we will do our best to filter out inaccurate reviews as they're reported to us, we do expect that "
+"authors will avoid retaliating with rudeness of their own."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/docs/policies-submission.html:49
@@ -5889,8 +5859,8 @@ msgstr ""
 
 #: src/olympia/devhub/templates/devhub/docs/policies-submission.html:55
 msgid ""
-"We are constantly looking at ways to improve the organization of the site to better accommodate add-ons that are exemplary in other ways, but are aimed at only a small community of potential users."
-" Correctly categorizing and maintaining the metadata of your add-on will help us figure out how we can surface more of those sorts of add-ons to people who are most likely to benefit from them."
+"We are constantly looking at ways to improve the organization of the site to better accommodate add-ons that are exemplary in other ways, but are aimed at only a small community of potential users. "
+"Correctly categorizing and maintaining the metadata of your add-on will help us figure out how we can surface more of those sorts of add-ons to people who are most likely to benefit from them."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/docs/policies-submission.html:61
@@ -5901,8 +5871,8 @@ msgstr ""
 
 #: src/olympia/devhub/templates/devhub/docs/policies-submission.html:67
 msgid ""
-"<strong>Is the add-on free of unlicensed trademarks and copyrights?</strong> Though you may mean no harm to the holder of a trademark, or the owner of a copyrighted work, we can't host add-ons that"
-" infringe on trademarks or copyrights. If you don't have permission to use a trademarked name or image, please do not submit your add-on to us. If your add-on includes code that is copyrighted by "
+"<strong>Is the add-on free of unlicensed trademarks and copyrights?</strong> Though you may mean no harm to the holder of a trademark, or the owner of a copyrighted work, we can't host add-ons that "
+"infringe on trademarks or copyrights. If you don't have permission to use a trademarked name or image, please do not submit your add-on to us. If your add-on includes code that is copyrighted by "
 "someone else, and is not licensed to you to use in your add-on, please do not submit your add-on to us."
 msgstr ""
 
@@ -5926,8 +5896,8 @@ msgstr ""
 
 #: src/olympia/devhub/templates/devhub/docs/policies-submission.html:86
 msgid ""
-"Selecting an appropriate license for your add-on is a very important step in the submission process. A license specifies the rights you grant on your source code and is important in protecting your"
-" intellectual property."
+"Selecting an appropriate license for your add-on is a very important step in the submission process. A license specifies the rights you grant on your source code and is important in protecting your "
+"intellectual property."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/docs/policies-submission.html:92
@@ -5972,68 +5942,57 @@ msgstr ""
 msgid "How to get in touch with us regarding these policies or your add-on."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:6
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:10
 msgid "You have disabled this add-on"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:20
-msgid ""
-"Your add-on's listing is disabled and is not showing\n"
-"                             anywhere in our gallery or update service."
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:24
+msgid "Your add-on's listing is disabled and is not showing anywhere in our gallery or update service."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:25
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:27
 msgid "Please complete your add-on."
 msgstr "Vui lòng hoàn tất tiện ích của bạn."
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:29
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:30
 msgid "You will receive an email when the review is complete."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:34
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:33
 msgid "You will receive an email when the review is complete. Until then, your add-on is not listed in our gallery but can be accessed directly from its details page."
 msgstr ""
-"Bạn sẽ nhận được một email khi việc xét duyệt hoàn tất. Cho đến lúc đó, tiện ích của bạn sẽ không được hiển thị trong trang trưng bày của chúng tôi nhưng vẫn có thể được truy cập trực tiếp từ trang"
-" chi tiết."
+"Bạn sẽ nhận được một email khi việc xét duyệt hoàn tất. Cho đến lúc đó, tiện ích của bạn sẽ không được hiển thị trong trang trưng bày của chúng tôi nhưng vẫn có thể được truy cập trực tiếp từ trang "
+"chi tiết."
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:38 src/olympia/devhub/templates/devhub/includes/addon_details.html:48
-msgid ""
-"You will receive an email when the review is\n"
-"                             complete and your add-on is signed."
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:37 src/olympia/devhub/templates/devhub/includes/addon_details.html:45
+msgid "You will receive an email when the review is complete and your add-on is signed."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:44
-msgid "You will receive an email when the review is complete. Until then, your add-on is not listed in our gallery but can be accessed directly from its details page."
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:41
+msgid "You will receive an email when the review is complete. Until then, your add-on is not listed in our gallery but can be accessed directly from its details page. "
 msgstr ""
-"Bạn sẽ nhận được một email khi việc xét duyệt hoàn tất. Cho đến lúc đó, tiện ích của bạn sẽ không được hiển thị trong trang trưng bày của chúng tôi nhưng vẫn có thể được truy cập trực tiếp từ trang"
-" chi tiết."
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:54
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:49
 msgid "Your add-on is displayed in our gallery and users are receiving automatic updates."
 msgstr "Tiện ích của bạn được hiển thị trong trang trưng bày của chúng tôi và người dùng đang nhận được cập nhật tự động."
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:57
-msgid ""
-"Your add-on has been signed and can be bundled with an\n"
-"                             application installer."
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:52
+msgid "Your add-on has been signed and can be bundled with an application installer."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:63
-msgid ""
-"Your add-on was disabled by a site administrator and is no\n"
-"                             longer shown in our gallery. If you have any questions,\n"
-"                             please email amo-admins@mozilla.org."
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:56
+msgid "Your add-on was disabled by a site administrator and is no longer shown in our gallery. If you have any questions, please email amo-admins@mozilla.org."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:70
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:62
 msgid "Your add-on is displayed in our gallery as experimental and users are receiving automatic updates. Some features are unavailable to your add-on."
 msgstr "Tiện ích của bạn được hiển thị trong trang trưng bày của chúng tôi dưới dạng thử nghiệm và người dùng đang nhận được cập nhật tự động. Sẽ không có một số tính năng cho tiện ích của bạn."
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:74
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:66
 msgid "Your add-on has been signed."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:79
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:69
 msgid ""
 "You will receive an email when the full review is complete. Until then, your add-on is displayed in our gallery as experimental and users are receiving automatic updates. Some features are "
 "unavailable to your add-on."
@@ -6041,53 +6000,41 @@ msgstr ""
 "Bạn sẽ nhận được một email khi việc xét duyệt đầy đủ hoàn tất. Cho đến lúc đó, tiện ích của bạn sẽ được hiển thị trong trang trưng bày của chúng tôi dưới dạng thử nghiệm và người dùng đang nhận "
 "được cập nhật tự động. Sẽ không có một số tính năng cho tiện ích của bạn."
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:84
-msgid ""
-"You will receive an email when the full review is\n"
-"                             complete, making you able to bundle your add-on with an\n"
-"                             application installer."
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:74
+msgid "You will receive an email when the full review is complete, making you able to bundle your add-on with an application installer."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:91
-msgid ""
-"All add-ons hosted in our gallery must now be reviewed by an\n"
-"                             editor. If you wish to continue hosting your add-on, please\n"
-"                             click to select a review process."
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:79
+msgid "All add-ons hosted in our gallery must now be reviewed by an editor. If you wish to continue hosting your add-on, please click to select a review process."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:113
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:100
 msgid "Current Version:"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:115
-msgid ""
-"This is the version of your add-on that will\n"
-"                                           be installed if someone clicks the Install\n"
-"                                           button on addons.mozilla.org. It is only\n"
-"                                           relevant for listed add-ons."
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:102
+msgid "This is the version of your add-on that will be installed if someone clicks the Install button on addons.mozilla.org. It is only relevant for listed add-ons."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:123
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:110
 msgid "Created:"
 msgstr ""
 
 #. {0} is a date. dennis-ignore: E201
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:125 src/olympia/devhub/templates/devhub/includes/addon_details.html:131
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:112 src/olympia/devhub/templates/devhub/includes/addon_details.html:118
 #, python-format
 msgid "%%b %%e, %%Y"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:136
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:123
 msgid "Next Version:"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:138
-msgid ""
-"This is the newest uploaded version, however\n"
-"                                           it isn’t live on the site yet."
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:125
+msgid "This is the newest uploaded version, however it isn’t live on the site yet."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:144 src/olympia/devhub/templates/devhub/versions/list.html:30
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:130 src/olympia/devhub/templates/devhub/versions/list.html:30
 msgid "Queues are not reviewed strictly in order"
 msgstr ""
 
@@ -6157,9 +6104,7 @@ msgid "View the blog &#9658;"
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/includes/license_form.html:6
-msgid ""
-"Please choose a license appropriate for the rights you grant on your source code.\n"
-"                  It is only relevant for listed add-ons."
+msgid "Please choose a license appropriate for the rights you grant on your source code. It is only relevant for listed add-ons."
 msgstr ""
 
 #. {0} is a list of HTML tags.
@@ -6181,18 +6126,16 @@ msgstr "Loại bỏ ứng dụng này"
 msgid "Select <b>up to {0}</b> {1} category for this add-on:"
 msgid_plural "Select <b>up to {0}</b> {1} categories for this add-on:"
 msgstr[0] "Chọn <b>nhiều nhất {0}</b> {1} phân mục cho tiện ích này:"
+msgstr[1] ""
 
 #: src/olympia/devhub/templates/devhub/includes/policy_form.html:4
 msgid ""
 "Users will be required to accept the following End-User License Agreement (EULA) prior to installing your add-on. The presence of a EULA significantly affects the number of downloads an add-on "
-"receives. Please note that a EULA is not the same as a code license, such as the GPL or MPL.\n"
-"                It is only relevant for listed add-ons."
+"receives. Please note that a EULA is not the same as a code license, such as the GPL or MPL.It is only relevant for listed add-ons."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/policy_form.html:21
-msgid ""
-"If your add-on transmits any data from the user's computer, a privacy policy is required that explains what data is sent and how it is used.\n"
-"                It is only relevant for listed add-ons."
+#: src/olympia/devhub/templates/devhub/includes/policy_form.html:24
+msgid "If your add-on transmits any data from the user's computer, a privacy policy is required that explains what data is sent and how it is used. It is only relevant for listed add-ons."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/includes/source_form_field.html:2
@@ -6328,8 +6271,8 @@ msgstr "Chúng tôi sẽ tự động gửi email tới những người dùng �
 
 #: src/olympia/devhub/templates/devhub/payments/voluntary.html:49
 msgid ""
-"We recommend thanking the user and telling them how much you appreciate their support. You might also want to tell them about what's next for your add-on and about any other add-ons you've made for"
-" them to try."
+"We recommend thanking the user and telling them how much you appreciate their support. You might also want to tell them about what's next for your add-on and about any other add-ons you've made for "
+"them to try."
 msgstr ""
 "Chúng tôi khuyến nghị bạn nên cảm ơn người dùng và cho họ biết bạn trân trọng sự ủng hộ của họ như thế nào. Bạn cũng có thể muốn nói cho họ biết tương lai tiện ích của bạn có gì và về các tiện ích "
 "khác mà bạn đã tạo ra để họ thử."
@@ -6362,12 +6305,8 @@ msgstr ""
 msgid "Add some tags to describe your Theme."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/personas/edit.html:106
-msgid ""
-"A short explanation of your theme's\n"
-"                                basic functionality that is displayed in\n"
-"                                search and browse listings, as well as at\n"
-"                                the top of your theme's details page."
+#: src/olympia/devhub/templates/devhub/personas/edit.html:106 src/olympia/devhub/templates/devhub/personas/submit.html:54
+msgid "A short explanation of your theme's basic functionality that is displayed in search and browse listings, as well as at the top of your theme's details page."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/personas/edit.html:122 src/olympia/devhub/templates/devhub/personas/submit.html:68
@@ -6437,7 +6376,7 @@ msgid "Upon upload and form submission, the AMO Team will review your updated de
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/personas/edit.html:241
-msgid "Your previously resubmitted design,  which is under pending review."
+msgid "Your previously resubmitted design, which is under pending review."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/personas/edit.html:245
@@ -6504,14 +6443,6 @@ msgstr ""
 
 #: src/olympia/devhub/templates/devhub/personas/submit.html:33
 msgid "Give your Theme a name."
-msgstr ""
-
-#: src/olympia/devhub/templates/devhub/personas/submit.html:54
-msgid ""
-"A short explanation of your theme's\n"
-"                                      basic functionality that is displayed in\n"
-"                                      search and browse listings, as well as at\n"
-"                                      the top of your theme's details page."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/personas/submit.html:198
@@ -6588,30 +6519,16 @@ msgstr ""
 msgid "Files added to reviewed versions must be reviewed before they will be available for download."
 msgstr "Tập tin được thêm vào các phiên bản đã xét duyệt phải được xét duyệt trước khi chúng có thể được tải xuống."
 
-#: src/olympia/devhub/templates/devhub/versions/add_file_modal.html:15
-#, python-format
-msgid ""
-"Submission of updates to unlisted add-ons for signing is currently in an open beta. Manual review may still be required for a large number of add-ons. Please <a href=\"%(url)s\" "
-"target=\"_blank\">report any bugs</a> that you encounter."
-msgstr ""
-
-#: src/olympia/devhub/templates/devhub/versions/add_file_modal.html:35
+#: src/olympia/devhub/templates/devhub/versions/add_file_modal.html:24
 msgid "Select the target platform for this file."
 msgstr "Chọn nền tảng cho tập tin này."
 
-#: src/olympia/devhub/templates/devhub/versions/add_file_modal.html:46
+#: src/olympia/devhub/templates/devhub/versions/add_file_modal.html:35
 msgid "Which review type would you like to nominate for?"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/add_file_modal.html:51
+#: src/olympia/devhub/templates/devhub/versions/add_file_modal.html:40
 msgid "Only publish this version to my beta channel."
-msgstr ""
-
-#: src/olympia/devhub/templates/devhub/versions/add_file_modal.html:54
-#, python-format
-msgid ""
-"The behavior of the beta channel has changed to accommodate <a href=\"%(addon_signing_url)s\" target=\"_blank\">mandatory add-on signing</a>. The new process is currently in an open beta, and may "
-"change significantly in the near future. Please <a href=\"%(issues_url)s\" target=\"_blank\">report any bugs</a> that you encounter."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/versions/edit.html:5
@@ -6635,10 +6552,6 @@ msgstr "Tập tin"
 #: src/olympia/devhub/templates/devhub/versions/edit.html:38
 msgid "Upload Another File"
 msgstr "Tải lên Tập tin Khác"
-
-#: src/olympia/devhub/templates/devhub/versions/edit.html:45
-msgid "Adjusting application information here will allow users to install your add-on even if the install manifest in the package indicates that the add-on is incompatible."
-msgstr "Điều chỉnh thông tin ứng dụng tại đây sẽ cho phép người dùng cài đặt tiện ích của bạn cho dù tập tin chỉ dẫn cài đặt trong gói có ghi rằng tiện ích của bạn không tương thích."
 
 #: src/olympia/devhub/templates/devhub/versions/edit.html:74
 msgid ""
@@ -6708,6 +6621,7 @@ msgstr "Chỉnh sửa phiên bản này"
 msgid "{0} file"
 msgid_plural "{0} files"
 msgstr[0] ""
+msgstr[1] ""
 
 #: src/olympia/devhub/templates/devhub/versions/list.html:25
 msgid "0 files"
@@ -6734,7 +6648,7 @@ msgstr "Yêu cầu Xét duyệt Đầy đủ"
 msgid "Request Preliminary Review"
 msgstr "Yêu cầu Xét duyệt Sơ bộ"
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:80 src/olympia/devhub/templates/devhub/versions/list.html:327 src/olympia/devhub/templates/devhub/versions/list.html:350
+#: src/olympia/devhub/templates/devhub/versions/list.html:80 src/olympia/devhub/templates/devhub/versions/list.html:325 src/olympia/devhub/templates/devhub/versions/list.html:348
 msgid "Cancel Review Request"
 msgstr "Hủy bỏ Yêu cầu Xét duyệt"
 
@@ -6763,7 +6677,7 @@ msgid "Unlisted:"
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/versions/list.html:114
-msgid "Not distributed on {0}. Developers will upload new versions for signing and distribute the add-ons on their own. (beta)"
+msgid "Not distributed on {0}. Developers will upload new versions for signing and distribute the add-ons on their own."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/versions/list.html:122
@@ -6814,7 +6728,8 @@ msgid "Delete Version {version}"
 msgstr "Xóa phiên bản {version}"
 
 #: src/olympia/devhub/templates/devhub/versions/list.html:218
-msgid "You are about to delete the current version of your add-on. This may cause your add-on status to change, or your listing to lose public visibility, if this is the only public version of your add-on."
+msgid ""
+"You are about to delete the current version of your add-on. This may cause your add-on status to change, or your listing to lose public visibility, if this is the only public version of your add-on."
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/versions/list.html:219
@@ -6826,81 +6741,73 @@ msgid "<strong>Important:</strong> Once a version has been deleted, you may not 
 msgstr ""
 
 #: src/olympia/devhub/templates/devhub/versions/list.html:230
-msgid ""
-"Deleting a version which has already been reviewed\n"
-"               may also cause a significant delay in the review of\n"
-"               your next update."
-msgstr ""
-
-#: src/olympia/devhub/templates/devhub/versions/list.html:233
 msgid "Are you sure you wish to delete this version?"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:238
+#: src/olympia/devhub/templates/devhub/versions/list.html:235
 msgid "Delete Version"
 msgstr "Xóa phiên bản"
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:240
+#: src/olympia/devhub/templates/devhub/versions/list.html:237
 msgid "Disable Version"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:247
+#: src/olympia/devhub/templates/devhub/versions/list.html:244
 msgid "Add a new Version"
 msgstr "Thêm một Phiên bản mới"
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:249
+#: src/olympia/devhub/templates/devhub/versions/list.html:246
 msgid "Add Version"
 msgstr "Thêm phiên bản"
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:256 src/olympia/devhub/templates/devhub/versions/list.html:274
+#: src/olympia/devhub/templates/devhub/versions/list.html:253 src/olympia/devhub/templates/devhub/versions/list.html:279
 msgid "Hide Add-on"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:259
+#: src/olympia/devhub/templates/devhub/versions/list.html:256
 msgid "Hiding your add-on will prevent it from appearing anywhere in our gallery and will stop users from receiving automatic updates."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:265
+#: src/olympia/devhub/templates/devhub/versions/list.html:263
+msgid "The files awaiting review will be disabled and you will need to upload new versions."
+msgstr ""
+
+#: src/olympia/devhub/templates/devhub/versions/list.html:270
 msgid "Are you sure you wish to hide your add-on?"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:286 src/olympia/devhub/templates/devhub/versions/list.html:315
+#: src/olympia/devhub/templates/devhub/versions/list.html:291 src/olympia/devhub/templates/devhub/versions/list.html:313
 msgid "Unlist Add-on"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:289
+#: src/olympia/devhub/templates/devhub/versions/list.html:294
 #, python-format
 msgid ""
 "Unlisting your add-on will make it (and each of its versions/files) invisible on this website. It won't show up in searches, won't have a public facing page, and won't be updated automatically for "
-"current users.  It is recommended for unlisted add-ons to provide a custom <a href=\"%(update_url)s\" target=\"_blank\">updateURL</a> in their manifest file for automatic updates."
+"current users. It is recommended for unlisted add-ons to provide a custom <a href=\"%(update_url)s\" target=\"_blank\">updateURL</a> in their manifest file for automatic updates."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:299
-#, python-format
-msgid "Switching add-ons to unlisted is currently in an open beta. Please <a href=\"%(url)s\" target=\"_blank\">report any bugs</a> that you encounter."
-msgstr ""
-
-#: src/olympia/devhub/templates/devhub/versions/list.html:305
+#: src/olympia/devhub/templates/devhub/versions/list.html:303
 msgid "Unlisting an add-on is irreversible!"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:305
+#: src/olympia/devhub/templates/devhub/versions/list.html:303
 msgid "An unlisted add-on cannot be switched to be listed."
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:307
+#: src/olympia/devhub/templates/devhub/versions/list.html:305
 msgid "Are you sure you wish to unlist your add-on?"
 msgstr ""
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:330
+#: src/olympia/devhub/templates/devhub/versions/list.html:328
 msgid "Canceling your review request will leave your add-on as preliminarily reviewed."
 msgstr "Hủy bỏ yêu cầu xét duyệt sẽ để tiện ích của bạn trong tình trạng xét duyệt sơ bộ."
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:335
+#: src/olympia/devhub/templates/devhub/versions/list.html:333
 msgid "Canceling your review request will mark your add-on incomplete. If you do not complete your add-on after several days by re-requesting review, it will be deleted."
 msgstr "Hủy bỏ yêu cầu xét duyệt sẽ đánh dấu tiện ích của bạn là chưa hoàn tất. Nếu bạn không hoàn tất tiện ích của mình sau vài ngày thông qua việc tái yêu cầu xét duyệt, nó sẽ bị xóa."
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:343
+#: src/olympia/devhub/templates/devhub/versions/list.html:341
 msgid "Are you sure you wish to cancel your review request?"
 msgstr "Bạn có chắc chắn là bạn muốn hủy bỏ yêu cầu xét duyệt của mình không?"
 
@@ -7243,19 +7150,19 @@ msgstr ""
 msgid "Search by add-on name / author email"
 msgstr "Tìm kiếm theo tên tiện ích / email tác giả"
 
-#: src/olympia/editors/forms.py:103
+#: src/olympia/editors/forms.py:103 src/olympia/editors/forms.py:244 src/olympia/editors/forms.py:257
 msgid "yes"
 msgstr "có"
 
-#: src/olympia/editors/forms.py:104
+#: src/olympia/editors/forms.py:104 src/olympia/editors/forms.py:244 src/olympia/editors/forms.py:257
 msgid "no"
 msgstr "không"
 
-#: src/olympia/editors/forms.py:105
+#: src/olympia/editors/forms.py:105 src/olympia/editors/forms.py:245
 msgid "Admin Flag"
 msgstr "Cờ quản trị"
 
-#: src/olympia/editors/forms.py:113
+#: src/olympia/editors/forms.py:113 src/olympia/editors/forms.py:253
 msgid "Max. Version"
 msgstr "Phiên bản Tối đa"
 
@@ -7267,55 +7174,59 @@ msgstr "Số ngày kể từ khi Gửi lên"
 msgid "Add-on Types"
 msgstr "Kiểu tiện ích"
 
-#: src/olympia/editors/forms.py:126 src/olympia/editors/helpers.py:267
+#: src/olympia/editors/forms.py:126 src/olympia/editors/helpers.py:279
 msgid "Platforms"
 msgstr "Nền tảng"
 
+#: src/olympia/editors/forms.py:237
+msgid "Search by add-on name / author email / guid"
+msgstr ""
+
 #. L10n: 0 = platform, 1 = filename, 2 = status message
-#: src/olympia/editors/forms.py:238
+#: src/olympia/editors/forms.py:342
 #, python-format
 msgid "<strong>%s</strong> &middot; %s &middot; %s"
 msgstr "<strong>%s</strong> &middot; %s &middot; %s"
 
-#: src/olympia/editors/forms.py:252
+#: src/olympia/editors/forms.py:356
 msgid "Comments:"
 msgstr "Bình luận:"
 
-#: src/olympia/editors/forms.py:256
+#: src/olympia/editors/forms.py:360
 msgid "Operating systems:"
 msgstr "Hệ điều hành:"
 
-#: src/olympia/editors/forms.py:258
+#: src/olympia/editors/forms.py:362
 msgid "Applications:"
 msgstr "Ứng dụng:"
 
-#: src/olympia/editors/forms.py:260
+#: src/olympia/editors/forms.py:364
 msgid "Notify me the next time this add-on is updated. (Subsequent updates will not generate an email)"
 msgstr "Báo tôi biết khi tiện ích này được cập nhật trong lần kế tiếp. (Các cập nhật sau đó sẽ không tạo email)"
 
-#: src/olympia/editors/forms.py:265
+#: src/olympia/editors/forms.py:369
 msgid "Clear Admin Review Flag"
 msgstr ""
 
-#: src/olympia/editors/forms.py:267
+#: src/olympia/editors/forms.py:371
 msgid "Clear more info requested flag"
 msgstr ""
 
-#: src/olympia/editors/forms.py:281
+#: src/olympia/editors/forms.py:385
 msgid "Choose a canned response..."
 msgstr "Chọn một mẫu phản hồi sẵn..."
 
 #. L10n: Description of what can be searched for.
-#: src/olympia/editors/forms.py:324
+#: src/olympia/editors/forms.py:423
 msgid "theme name"
 msgstr ""
 
-#: src/olympia/editors/forms.py:350
+#: src/olympia/editors/forms.py:449
 msgid "Someone else is reviewing this theme."
 msgstr ""
 
 #. L10n: Description of what can be searched for.
-#: src/olympia/editors/forms.py:447
+#: src/olympia/editors/forms.py:546
 msgid "app, reviewer, or comment"
 msgstr ""
 
@@ -7331,181 +7242,210 @@ msgstr "Đang chờ Xét duyệt Sơ bộ"
 msgid "Rejected or Unreviewed"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:123 src/olympia/editors/helpers.py:136
+#: src/olympia/editors/helpers.py:125 src/olympia/editors/helpers.py:138
 msgid "Queue"
 msgstr "Hàng chờ"
 
-#: src/olympia/editors/helpers.py:124 src/olympia/editors/templates/editors/base.html:50 src/olympia/editors/templates/editors/base.html:65
+#: src/olympia/editors/helpers.py:126 src/olympia/editors/templates/editors/base.html:50 src/olympia/editors/templates/editors/base.html:65
 msgid "Pending Updates"
 msgstr "Các cập nhật Đang đợi"
 
-#: src/olympia/editors/helpers.py:125 src/olympia/editors/templates/editors/base.html:48 src/olympia/editors/templates/editors/base.html:63
+#: src/olympia/editors/helpers.py:127 src/olympia/editors/templates/editors/base.html:48 src/olympia/editors/templates/editors/base.html:63
 msgid "Full Reviews"
 msgstr "Xét duyệt Đầy đủ"
 
-#: src/olympia/editors/helpers.py:126 src/olympia/editors/templates/editors/base.html:52 src/olympia/editors/templates/editors/base.html:67
+#: src/olympia/editors/helpers.py:128 src/olympia/editors/templates/editors/base.html:52 src/olympia/editors/templates/editors/base.html:67
 msgid "Preliminary Reviews"
 msgstr "Xét duyệt Sơ bộ"
 
-#: src/olympia/editors/helpers.py:127 src/olympia/editors/templates/editors/base.html:54
+#: src/olympia/editors/helpers.py:129 src/olympia/editors/templates/editors/base.html:54
 msgid "Moderated Reviews"
 msgstr "Xét duyệt Đã được Điều chỉnh"
 
-#: src/olympia/editors/helpers.py:128 src/olympia/editors/templates/editors/base.html:46
+#: src/olympia/editors/helpers.py:130 src/olympia/editors/templates/editors/base.html:46
 msgid "Fast Track"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:130
+#: src/olympia/editors/helpers.py:132
 msgid "Pending Themes"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:131 src/olympia/editors/templates/editors/themes/queue.html:4
+#: src/olympia/editors/helpers.py:133 src/olympia/editors/templates/editors/themes/queue.html:4
 msgid "Flagged Themes"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:132
+#: src/olympia/editors/helpers.py:134
 msgid "Update Themes"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:137
+#: src/olympia/editors/helpers.py:139
 msgid "Unlisted Pending Updates"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:138
+#: src/olympia/editors/helpers.py:140
 msgid "Unlisted Full Reviews"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:139
+#: src/olympia/editors/helpers.py:141
 msgid "Unlisted Preliminary Reviews"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:170
+#: src/olympia/editors/helpers.py:142
+msgid "Unlisted All Add-ons"
+msgstr ""
+
+#: src/olympia/editors/helpers.py:173
 msgid "Fast Track ({0})"
 msgid_plural "Fast Track ({0})"
 msgstr[0] ""
+msgstr[1] ""
 
-#: src/olympia/editors/helpers.py:175
+#: src/olympia/editors/helpers.py:178
 msgid "Full Review ({0})"
 msgid_plural "Full Reviews ({0})"
 msgstr[0] "Xét duyệt Đầy đủ {0}"
+msgstr[1] ""
 
-#: src/olympia/editors/helpers.py:180
+#: src/olympia/editors/helpers.py:183
 msgid "Pending Update ({0})"
 msgid_plural "Pending Updates ({0})"
 msgstr[0] "Cập nhật Đang đợi ({0})"
+msgstr[1] ""
 
-#: src/olympia/editors/helpers.py:185
+#: src/olympia/editors/helpers.py:188
 msgid "Preliminary Review ({0})"
 msgid_plural "Preliminary Reviews ({0})"
 msgstr[0] "Xét duyệt Sơ bộ ({0})"
+msgstr[1] ""
 
-#: src/olympia/editors/helpers.py:190
+#: src/olympia/editors/helpers.py:193
 msgid "Moderated Review ({0})"
 msgid_plural "Moderated Reviews ({0})"
 msgstr[0] "Xét duyệt Đã được Điều chỉnh ({0})"
+msgstr[1] ""
 
-#: src/olympia/editors/helpers.py:196
+#: src/olympia/editors/helpers.py:199
 msgid "Unlisted Full Review ({0})"
 msgid_plural "Unlisted Full Reviews ({0})"
 msgstr[0] ""
+msgstr[1] ""
 
-#: src/olympia/editors/helpers.py:201
+#: src/olympia/editors/helpers.py:204
 msgid "Unlisted Pending Update ({0})"
 msgid_plural "Unlisted Pending Updates ({0})"
 msgstr[0] ""
+msgstr[1] ""
 
-#: src/olympia/editors/helpers.py:206
+#: src/olympia/editors/helpers.py:209
 msgid "Unlisted Preliminary Review ({0})"
 msgid_plural "Unlisted Preliminary Reviews ({0})"
 msgstr[0] ""
+msgstr[1] ""
 
-#: src/olympia/editors/helpers.py:261
-msgid "Addon"
-msgstr "Tiện ích"
+#: src/olympia/editors/helpers.py:214
+msgid "Unlisted All Add-ons ({0})"
+msgid_plural "Unlisted All Add-ons ({0})"
+msgstr[0] ""
+msgstr[1] ""
 
-#: src/olympia/editors/helpers.py:262
+#: src/olympia/editors/helpers.py:274
 msgid "Type"
 msgstr "Kiểu"
 
-#: src/olympia/editors/helpers.py:263
+#: src/olympia/editors/helpers.py:275
 msgid "Waiting Time"
 msgstr "Thời gian chờ"
 
-#: src/olympia/editors/helpers.py:264 src/olympia/editors/templates/editors/review.html:285
+#: src/olympia/editors/helpers.py:276 src/olympia/editors/templates/editors/review.html:285
 msgid "Flags"
 msgstr "Cờ"
 
-#: src/olympia/editors/helpers.py:265
+#: src/olympia/editors/helpers.py:277
 msgid "Applications"
 msgstr "Ứng dụng"
 
-#: src/olympia/editors/helpers.py:270
+#: src/olympia/editors/helpers.py:282
 msgid "Additional"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:285
+#: src/olympia/editors/helpers.py:302
 msgid "Site Specific"
 msgstr "Riêng biệt của Trang"
 
-#: src/olympia/editors/helpers.py:287
+#: src/olympia/editors/helpers.py:304
 msgid "Requires External Software"
 msgstr "Yêu cầu Phần mềm Bên ngoài"
 
-#: src/olympia/editors/helpers.py:289
+#: src/olympia/editors/helpers.py:306
 msgid "Binary Components"
 msgstr "Thành phần Nhị phân"
 
-#: src/olympia/editors/helpers.py:313
+#: src/olympia/editors/helpers.py:339
 msgid "moments ago"
 msgstr "khoảnh khắc trước"
 
 #. L10n: first argument is number of minutes
-#: src/olympia/editors/helpers.py:316
+#: src/olympia/editors/helpers.py:342
 msgid "{0} minute"
 msgid_plural "{0} minutes"
 msgstr[0] "{0} phút"
+msgstr[1] ""
 
 #. L10n: first argument is number of hours
-#: src/olympia/editors/helpers.py:320
+#: src/olympia/editors/helpers.py:346
 msgid "{0} hour"
 msgid_plural "{0} hours"
 msgstr[0] "{0} giờ"
+msgstr[1] ""
 
 #. L10n: first argument is number of days
-#: src/olympia/editors/helpers.py:324
+#: src/olympia/editors/helpers.py:350
 msgid "{0} day"
 msgid_plural "{0} days"
 msgstr[0] "{0} ngày"
+msgstr[1] ""
 
-#: src/olympia/editors/helpers.py:488
+#: src/olympia/editors/helpers.py:364
+msgid "Last Review"
+msgstr ""
+
+#: src/olympia/editors/helpers.py:366
+msgid "Last Update"
+msgstr ""
+
+#: src/olympia/editors/helpers.py:387
+msgid "No Reviews"
+msgstr ""
+
+#: src/olympia/editors/helpers.py:561
 msgid "Push to public"
 msgstr "Đẩy ra công cộng"
 
-#: src/olympia/editors/helpers.py:490
+#: src/olympia/editors/helpers.py:563
 msgid "Grant full review"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:505
+#: src/olympia/editors/helpers.py:578
 msgid "Request more information"
 msgstr "Yêu cầu thêm thông tin"
 
-#: src/olympia/editors/helpers.py:508
+#: src/olympia/editors/helpers.py:581
 msgid "Request super-review"
 msgstr "Yêu cầu siêu xét duyệt"
 
-#: src/olympia/editors/helpers.py:519
+#: src/olympia/editors/helpers.py:592
 msgid "Grant preliminary review"
 msgstr "Cấp phép xét duyệt sơ bộ"
 
-#: src/olympia/editors/helpers.py:520
+#: src/olympia/editors/helpers.py:593
 msgid "This will mark the files as preliminarily reviewed."
 msgstr ""
 
-#: src/olympia/editors/helpers.py:522
+#: src/olympia/editors/helpers.py:595
 msgid "Use this form to request more information from the author. They will receive an email and be able to answer here. You will be notified by email when they reply."
 msgstr "Dùng biểu mẫu này để yêu cầu thêm thông tin từ tác giả. Họ sẽ nhận được một email và có thể trả lời tại đây. Bạn sẽ được thông báo bằng email khi họ trả lời."
 
-#: src/olympia/editors/helpers.py:526
+#: src/olympia/editors/helpers.py:599
 msgid ""
 "If you have concerns about this add-on's security, copyright issues, or other concerns that an administrator should look into, enter your comments in the area below. They will be sent to "
 "administrators, not the author."
@@ -7513,55 +7453,55 @@ msgstr ""
 "Nếu bạn có lo ngại về tính bảo mật, vấn đề bản quyền, và các mối quan tâm khác của tiện ích này này và muốn quản trị viên để ý đến, hãy điền bình luận vào phần bên dưới. Chúng sẽ được gửi đến quản "
 "trị viên, không phải tác giả."
 
-#: src/olympia/editors/helpers.py:532
+#: src/olympia/editors/helpers.py:605
 msgid "This will reject the add-on and remove it from the review queue."
 msgstr "Việc này sẽ từ chối tiện ích và loại bỏ nó khỏi danh sách chờ xét duyệt."
 
-#: src/olympia/editors/helpers.py:534
-msgid "Make a comment on this version.  The author won't be able to see this."
+#: src/olympia/editors/helpers.py:607
+msgid "Make a comment on this version. The author won't be able to see this."
 msgstr ""
 
-#: src/olympia/editors/helpers.py:538
+#: src/olympia/editors/helpers.py:611
 msgid "This will reject the files and remove them from the review queue."
 msgstr "Việc này sẽ từ chối tập tin và loại bỏ nó khỏi danh sách chờ xét duyệt."
 
-#: src/olympia/editors/helpers.py:542
+#: src/olympia/editors/helpers.py:615
 msgid "This will mark the add-on as preliminarily reviewed. Future versions will undergo preliminary review."
 msgstr "Việc này sẽ đánh dấu tiện ích là đã được xét duyệt sơ bộ. Các phiên bản tương lai sẽ trải qua xét duyệt sơ bộ."
 
-#: src/olympia/editors/helpers.py:547
+#: src/olympia/editors/helpers.py:620
 msgid "This will mark the files as preliminarily reviewed. Future versions will undergo preliminary review."
 msgstr "Việc này sẽ đánh dấu tập tin là đã được xét duyệt sơ bộ. Các phiên bản tương lai sẽ trải qua xét duyệt sơ bộ."
 
-#: src/olympia/editors/helpers.py:552
+#: src/olympia/editors/helpers.py:625
 msgid "Retain preliminary review"
 msgstr "Giữ tình trạng xét duyệt sơ bộ"
 
-#: src/olympia/editors/helpers.py:553
+#: src/olympia/editors/helpers.py:626
 msgid "This will retain the add-on as preliminarily reviewed. Future versions will undergo preliminary review."
 msgstr "Việc này sẽ giữ tình trạng tiện ích là đã được xét duyệt sơ bộ. Các phiên bản tương lai sẽ trải qua xét duyệt sơ bộ."
 
-#: src/olympia/editors/helpers.py:558
+#: src/olympia/editors/helpers.py:631
 msgid "This will approve a sandboxed version of a public add-on to appear on the public side."
 msgstr "Điều này sẽ chấp thuận một phiên bản hộp cát của một tiện ích công khai được xuất hiện ở khu vực công cộng."
 
-#: src/olympia/editors/helpers.py:561
+#: src/olympia/editors/helpers.py:634
 msgid "This will reject a version of a public add-on and remove it from the queue."
 msgstr "Điều này sẽ từ chối một phiên bản của một tiện ích công cộng và loại bỏ nó khỏi hàng chờ."
 
-#: src/olympia/editors/helpers.py:564
+#: src/olympia/editors/helpers.py:637
 msgid "This will mark the add-on and its most recent version and files as public. Future versions will go into the sandbox until they are reviewed by an editor."
 msgstr "Việc này sẽ đánh dấu tiện ích và phiên bản và tập tin mới đây nhất của nó là công khai. Các phiên bản tương lai sẽ vào hộp cát cho tới khi chúng được xét duyệt bởi một biên tập viên."
 
-#: src/olympia/editors/helpers.py:637
+#: src/olympia/editors/helpers.py:714
 msgid "add-on"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:940 src/olympia/editors/helpers.py:960
+#: src/olympia/editors/helpers.py:1020 src/olympia/editors/helpers.py:1040
 msgid "Flagged"
 msgstr ""
 
-#: src/olympia/editors/helpers.py:944 src/olympia/editors/helpers.py:963
+#: src/olympia/editors/helpers.py:1024 src/olympia/editors/helpers.py:1043
 msgid "Updates"
 msgstr "Cập nhật"
 
@@ -7613,56 +7553,56 @@ msgstr ""
 msgid "A question about your Theme submission"
 msgstr ""
 
-#: src/olympia/editors/views.py:144
+#: src/olympia/editors/views.py:146
 msgid "New Add-ons (Under 5 days)"
 msgstr "Tiện ích Mới (chưa tới 5 ngày)"
 
-#: src/olympia/editors/views.py:145
+#: src/olympia/editors/views.py:147
 msgid "Passable (5 to 10 days)"
 msgstr "Được (5 đến 10 ngày)"
 
-#: src/olympia/editors/views.py:146
+#: src/olympia/editors/views.py:148
 msgid "Overdue (Over 10 days)"
 msgstr "Quá hạn (hơn 10 ngày)"
 
-#: src/olympia/editors/views.py:532
+#: src/olympia/editors/views.py:539
 msgid "An unknown error occurred"
 msgstr ""
 
-#: src/olympia/editors/views.py:587
+#: src/olympia/editors/views.py:592
 msgid "Self-reviews are not allowed."
 msgstr "Không được tự xét duyệt"
 
-#: src/olympia/editors/views.py:609
+#: src/olympia/editors/views.py:613
 msgid "Review successfully processed."
 msgstr "Việc xét duyệt được tiến hành thành công."
 
-#: src/olympia/editors/views.py:807
+#: src/olympia/editors/views.py:812
 msgid "was approved"
 msgstr "đã được chấp thuận"
 
-#: src/olympia/editors/views.py:808
+#: src/olympia/editors/views.py:813
 msgid "given preliminary review"
 msgstr "được xét duyệt sơ bộ"
 
-#: src/olympia/editors/views.py:809
+#: src/olympia/editors/views.py:814
 msgid "rejected"
 msgstr "bị từ chối"
 
-#: src/olympia/editors/views.py:810
+#: src/olympia/editors/views.py:815
 msgctxt "editors_review_history_nominated_adminreview"
 msgid "escalated"
 msgstr "được nâng cấp"
 
-#: src/olympia/editors/views.py:812
+#: src/olympia/editors/views.py:817
 msgid "needs more information"
 msgstr ""
 
-#: src/olympia/editors/views.py:813
+#: src/olympia/editors/views.py:818
 msgid "needs super review"
 msgstr ""
 
-#: src/olympia/editors/views.py:814
+#: src/olympia/editors/views.py:819
 msgid "commented"
 msgstr ""
 
@@ -7670,6 +7610,7 @@ msgstr ""
 msgid "{0} theme review successfully processed (+{1} points, {2} total)."
 msgid_plural "{0} theme reviews successfully processed (+{1} points, {2} total)."
 msgstr[0] ""
+msgstr[1] ""
 
 #: src/olympia/editors/views_themes.py:341
 msgid "Your theme locks have successfully been released. Other reviewers may now review those released themes. You may have to refresh the page to see the changes reflected in the table below."
@@ -7706,28 +7647,28 @@ msgstr "Hàng chờ"
 msgid "Unlisted Queues"
 msgstr ""
 
-#: src/olympia/editors/templates/editors/base.html:72 src/olympia/editors/templates/editors/performance.html:6
+#: src/olympia/editors/templates/editors/base.html:74 src/olympia/editors/templates/editors/performance.html:6
 msgid "Performance"
 msgstr "Hiệu suất"
 
-#: src/olympia/editors/templates/editors/base.html:75 src/olympia/editors/templates/editors/themes/base.html:19 src/olympia/editors/templates/editors/themes/base.html:38
+#: src/olympia/editors/templates/editors/base.html:77 src/olympia/editors/templates/editors/themes/base.html:19 src/olympia/editors/templates/editors/themes/base.html:38
 msgid "Logs"
 msgstr "Lưu kí"
 
-#: src/olympia/editors/templates/editors/base.html:78 src/olympia/editors/templates/editors/reviewlog.html:4 src/olympia/editors/templates/editors/reviewlog.html:27
+#: src/olympia/editors/templates/editors/base.html:80 src/olympia/editors/templates/editors/reviewlog.html:4 src/olympia/editors/templates/editors/reviewlog.html:27
 msgid "Add-on Review Log"
 msgstr ""
 
-#: src/olympia/editors/templates/editors/base.html:80 src/olympia/editors/templates/editors/eventlog.html:4 src/olympia/editors/templates/editors/eventlog.html:8
+#: src/olympia/editors/templates/editors/base.html:82 src/olympia/editors/templates/editors/eventlog.html:4 src/olympia/editors/templates/editors/eventlog.html:8
 #: src/olympia/editors/templates/editors/eventlog_detail.html:4
 msgid "Moderated Review Log"
 msgstr ""
 
-#: src/olympia/editors/templates/editors/base.html:82 src/olympia/editors/templates/editors/beta_signed_log.html:4 src/olympia/editors/templates/editors/beta_signed_log.html:8
+#: src/olympia/editors/templates/editors/base.html:84 src/olympia/editors/templates/editors/beta_signed_log.html:4 src/olympia/editors/templates/editors/beta_signed_log.html:8
 msgid "Signed Beta Files Log"
 msgstr ""
 
-#: src/olympia/editors/templates/editors/base.html:87 src/olympia/editors/templates/editors/includes/daily-message.html:4
+#: src/olympia/editors/templates/editors/base.html:89 src/olympia/editors/templates/editors/includes/daily-message.html:4
 msgid "Announcement"
 msgstr "Thông báo"
 
@@ -7786,16 +7727,19 @@ msgstr ""
 msgid "Full Review ({num})"
 msgid_plural "Full Reviews ({num})"
 msgstr[0] ""
+msgstr[1] ""
 
 #: src/olympia/editors/templates/editors/home.html:18
 msgid "Pending Update ({num})"
 msgid_plural "Pending Updates ({num})"
 msgstr[0] "Cập nhật Đang đợi ({num})Cập nhật Đang đợi ({num})"
+msgstr[1] ""
 
 #: src/olympia/editors/templates/editors/home.html:25
 msgid "Preliminary Review ({num})"
 msgid_plural "Preliminary Reviews ({num})"
 msgstr[0] ""
+msgstr[1] ""
 
 #: src/olympia/editors/templates/editors/home.html:36 src/olympia/editors/templates/editors/home.html:86
 msgid "Current waiting times:"
@@ -7805,6 +7749,7 @@ msgstr ""
 msgid "{0} add-on"
 msgid_plural "{0} add-ons"
 msgstr[0] ""
+msgstr[1] ""
 
 #: src/olympia/editors/templates/editors/home.html:45 src/olympia/editors/templates/editors/home.html:95
 #, python-format
@@ -7815,16 +7760,19 @@ msgstr ""
 msgid "Unlisted Full Review ({num})"
 msgid_plural "Unlisted Full Reviews ({num})"
 msgstr[0] ""
+msgstr[1] ""
 
 #: src/olympia/editors/templates/editors/home.html:68
 msgid "Unlisted Pending Update ({num})"
 msgid_plural "Unlisted Pending Updates ({num})"
 msgstr[0] ""
+msgstr[1] ""
 
 #: src/olympia/editors/templates/editors/home.html:75
 msgid "Unlisted Preliminary Review ({num})"
 msgid_plural "Unlisted Preliminary Reviews ({num})"
 msgstr[0] ""
+msgstr[1] ""
 
 #: src/olympia/editors/templates/editors/home.html:109 src/olympia/editors/templates/editors/performance.html:37 src/olympia/editors/templates/editors/themes/home.html:54
 msgid "Total Reviews"
@@ -7847,6 +7795,7 @@ msgstr ""
 msgid "Moderated Review ({num})"
 msgid_plural "Moderated Reviews ({num})"
 msgstr[0] ""
+msgstr[1] ""
 
 #: src/olympia/editors/templates/editors/leaderboard.html:3 src/olympia/editors/templates/editors/includes/reviewers_score_bar.html:56
 msgid "Reviewer Leaderboard"
@@ -7940,45 +7889,45 @@ msgstr "Tìm kiếm Nâng cao"
 msgid "clear search"
 msgstr "xóa trắng tìm kiếm"
 
-#: src/olympia/editors/templates/editors/queue.html:72 src/olympia/editors/templates/editors/queue.html:122
+#: src/olympia/editors/templates/editors/queue.html:78 src/olympia/editors/templates/editors/queue.html:128
 msgid "Process Reviews"
 msgstr "Tiến hành Xét duyệt"
 
-#: src/olympia/editors/templates/editors/queue.html:80
+#: src/olympia/editors/templates/editors/queue.html:86
 msgid "Moderation actions:"
 msgstr "Thao tác điều chỉnh:"
 
-#: src/olympia/editors/templates/editors/queue.html:90
+#: src/olympia/editors/templates/editors/queue.html:96
 #, python-format
 msgid "by %(user)s on %(date)s %(stars)s (%(locale)s)"
 msgstr "bởi %(user)s lúc %(date)s %(stars)s (%(locale)s)"
 
-#: src/olympia/editors/templates/editors/queue.html:106
+#: src/olympia/editors/templates/editors/queue.html:112
 #, python-format
 msgid "<strong>%(reason)s</strong> <span class=\"light\">Flagged by %(user)s on %(date)s</span>"
 msgstr ""
 
-#: src/olympia/editors/templates/editors/queue.html:119
+#: src/olympia/editors/templates/editors/queue.html:125
 msgid "All reviews have been moderated. Good work!"
 msgstr "Tất cả xét duyệt đã được điều chỉnh. Làm tốt lắm!"
 
-#: src/olympia/editors/templates/editors/queue.html:161
+#: src/olympia/editors/templates/editors/queue.html:167
 msgid "Version Notes / Notes for Reviewer"
 msgstr ""
 
-#: src/olympia/editors/templates/editors/queue.html:169
+#: src/olympia/editors/templates/editors/queue.html:175
 msgid "There are currently no add-ons of this type to review."
 msgstr "Hiện không có tiện ích nào kiểu này để xét duyệt."
 
-#: src/olympia/editors/templates/editors/queue.html:181 src/olympia/editors/templates/editors/themes/queue_list.html:85
+#: src/olympia/editors/templates/editors/queue.html:187 src/olympia/editors/templates/editors/themes/queue_list.html:85
 msgid "Helpful Links:"
 msgstr "Liên kết Hữu ích:"
 
-#: src/olympia/editors/templates/editors/queue.html:182
+#: src/olympia/editors/templates/editors/queue.html:188
 msgid "Add-on Policy"
 msgstr "Chính sách Tiện ích"
 
-#: src/olympia/editors/templates/editors/queue.html:184
+#: src/olympia/editors/templates/editors/queue.html:190
 msgid "Editors' Guide"
 msgstr "Hướng dẫn của Biên tập viên"
 
@@ -8041,10 +7990,7 @@ msgid "<strong>Warning!</strong> Another user was viewing this page before you."
 msgstr ""
 
 #: src/olympia/editors/templates/editors/review.html:237
-msgid ""
-"The whiteboard is the place to exchange information relevant to\n"
-"               this addon (whatever the version), between the developer and the\n"
-"               editor. This is visible and editable by both."
+msgid "The whiteboard is the place to exchange information relevant to this addon (whatever the version), between the developer and the editor. This is visible and editable by both."
 msgstr ""
 
 #: src/olympia/editors/templates/editors/review.html:241
@@ -8145,8 +8091,9 @@ msgstr "Từ Trước đến Nay"
 msgid "You have <span>{0}</span> points."
 msgstr ""
 
-#: src/olympia/editors/templates/editors/includes/search_results_themes.html:6 src/olympia/editors/templates/editors/themes/history_table.html:7 src/olympia/editors/templates/editors/themes/logs.html:19
-#: src/olympia/editors/templates/editors/themes/queue_list.html:49 src/olympia/editors/templates/editors/themes/single.html:26 src/olympia/editors/templates/editors/themes/themes.html:45
+#: src/olympia/editors/templates/editors/includes/search_results_themes.html:6 src/olympia/editors/templates/editors/themes/history_table.html:7
+#: src/olympia/editors/templates/editors/themes/logs.html:19 src/olympia/editors/templates/editors/themes/queue_list.html:49 src/olympia/editors/templates/editors/themes/single.html:26
+#: src/olympia/editors/templates/editors/themes/themes.html:45
 msgid "Reviewer"
 msgstr ""
 
@@ -8186,16 +8133,19 @@ msgstr ""
 msgid "{num} Pending Theme Review"
 msgid_plural "{num} Pending Theme Reviews"
 msgstr[0] ""
+msgstr[1] ""
 
 #: src/olympia/editors/templates/editors/themes/home.html:27
 msgid "{num} Flagged Review"
 msgid_plural "{num} Flagged Reviews"
 msgstr[0] ""
+msgstr[1] ""
 
 #: src/olympia/editors/templates/editors/themes/home.html:34
 msgid "{num} Update"
 msgid_plural "{num} Updates"
 msgstr[0] "{num} Cập nhật{num} Cập nhật"
+msgstr[1] ""
 
 #: src/olympia/editors/templates/editors/themes/logs.html:4
 msgid "Theme Review Log"
@@ -8314,7 +8264,7 @@ msgstr ""
 msgid "Describe your reason for flagging"
 msgstr ""
 
-#: src/olympia/files/forms.py:88
+#: src/olympia/files/forms.py:90
 msgid "Cannot diff a version against itself"
 msgstr ""
 
@@ -8349,51 +8299,51 @@ msgstr ""
 msgid "There was an error accessing file %s."
 msgstr ""
 
-#: src/olympia/files/utils.py:343
+#: src/olympia/files/utils.py:340
 msgid "Could not parse uploaded file."
 msgstr ""
 
-#: src/olympia/files/utils.py:380
+#: src/olympia/files/utils.py:377
 msgid "Invalid file name in archive: {0}"
 msgstr ""
 
-#: src/olympia/files/utils.py:388
+#: src/olympia/files/utils.py:385
 msgid "File exceeding size limit in archive: {0}"
 msgstr ""
 
-#: src/olympia/files/utils.py:439
+#: src/olympia/files/utils.py:436
 msgid "Invalid archive."
 msgstr "Gói nén bất hợp lệ."
 
-#: src/olympia/files/utils.py:529 src/olympia/files/utils.py:532
+#: src/olympia/files/utils.py:526 src/olympia/files/utils.py:529
 msgid "Could not parse the manifest file."
 msgstr ""
 
-#: src/olympia/files/utils.py:551
+#: src/olympia/files/utils.py:548
 msgid "Could not find an add-on ID."
 msgstr ""
 
-#: src/olympia/files/utils.py:554
+#: src/olympia/files/utils.py:551
 msgid "Add-on ID must be 64 characters or less."
 msgstr ""
 
-#: src/olympia/files/utils.py:556
+#: src/olympia/files/utils.py:553
 msgid "Add-on ID doesn't match add-on."
 msgstr ""
 
-#: src/olympia/files/utils.py:564
+#: src/olympia/files/utils.py:561
 msgid "Duplicate add-on ID found."
 msgstr ""
 
-#: src/olympia/files/utils.py:567
+#: src/olympia/files/utils.py:564
 msgid "Version numbers should have fewer than 32 characters."
 msgstr "Số phiên bản phải ít hơn 32 kí tự."
 
-#: src/olympia/files/utils.py:570
+#: src/olympia/files/utils.py:567
 msgid "Version numbers should only contain letters, numbers, and these punctuation characters: +*.-_."
 msgstr "Số phiên bản chỉ được chứa chữ cái, chữ số, và các kí tự chấm câu sau: +*.-_."
 
-#: src/olympia/files/utils.py:587
+#: src/olympia/files/utils.py:584
 msgid "<em:type> doesn't match add-on"
 msgstr "<em:type> không khớp tiện ích"
 
@@ -8493,6 +8443,10 @@ msgstr "Không có tập tin nào trong tập tin được tải lên."
 #: src/olympia/files/templates/files/viewer.html:134
 msgid "Fetching file."
 msgstr "Đang truy xuất tập tin."
+
+#: src/olympia/legacy_api/views.py:255
+msgid "Not implemented yet."
+msgstr "Chưa triển khai."
 
 #: src/olympia/lib/constants.py:6
 msgid "United Arab Emirates Dirham"
@@ -9150,10 +9104,6 @@ msgstr ""
 msgid "Zimbabwe Dollar"
 msgstr ""
 
-#: src/olympia/lib/video/ffmpeg.py:112 src/olympia/lib/video/totem.py:81
-msgid "Videos must be in WebM."
-msgstr ""
-
 #: src/olympia/pages/templates/pages/about.lhtml:3 src/olympia/pages/templates/pages/about.lhtml:10
 msgid "About Mozilla Add-ons"
 msgstr ""
@@ -9165,7 +9115,7 @@ msgstr ""
 #: src/olympia/pages/templates/pages/about.lhtml:13
 msgid ""
 "addons.mozilla.org, commonly known as \"AMO\", is Mozilla's official site for add-ons to Mozilla software, such as Firefox, Thunderbird, and SeaMonkey. Add-ons let you add new features and change "
-"the way your browser or application works.  Take a look around and explore the thousands of ways to customize the way you do things online."
+"the way your browser or application works. Take a look around and explore the thousands of ways to customize the way you do things online."
 msgstr ""
 
 #: src/olympia/pages/templates/pages/about.lhtml:19
@@ -9221,7 +9171,8 @@ msgstr ""
 
 #: src/olympia/pages/templates/pages/about.lhtml:49
 #, python-format
-msgid "Help improve this website. It's open source, and you can file bugs and submit patches. <a href=\"%(url)s\"> GitHub</a> contains all of our current bugs, legacy bugs can still be found in Bugzilla."
+msgid ""
+"Help improve this website. It's open source, and you can file bugs and submit patches. <a href=\"%(url)s\"> GitHub</a> contains all of our current bugs, legacy bugs can still be found in Bugzilla."
 msgstr ""
 
 #: src/olympia/pages/templates/pages/about.lhtml:55
@@ -9264,8 +9215,8 @@ msgstr ""
 #: src/olympia/pages/templates/pages/about.lhtml:77
 #, python-format
 msgid ""
-"Over the years, many people have contributed to this website, including both volunteers from the community and a dedicated AMO team. A list of significant contributors can be found on our <a "
-"href=\"%(url)s\"> Site Credits</a> page."
+"Over the years, many people have contributed to this website, including both volunteers from the community and a dedicated AMO team. A list of significant contributors can be found on our <a href="
+"\"%(url)s\"> Site Credits</a> page."
 msgstr ""
 
 #: src/olympia/pages/templates/pages/acr_firstrun.html:4
@@ -9299,8 +9250,8 @@ msgstr ""
 #: src/olympia/pages/templates/pages/acr_firstrun.html:61
 #, python-format
 msgid ""
-"If you upgrade to a new version of Firefox or update your add-ons, your reports for the old versions will be hidden to allow you to test the new version. If you have any questions, please ask in <a"
-" href=\"%(url)s\">our forums</a>."
+"If you upgrade to a new version of Firefox or update your add-ons, your reports for the old versions will be hidden to allow you to test the new version. If you have any questions, please ask in <a "
+"href=\"%(url)s\">our forums</a>."
 msgstr ""
 
 #: src/olympia/pages/templates/pages/acr_firstrun.html:69
@@ -9364,8 +9315,8 @@ msgstr ""
 
 #: src/olympia/pages/templates/pages/credits.html:61
 msgid ""
-"Some pages use elements of <a href=\"http://shop.highsoft.com/highcharts.html\">Highcharts</a> (non-commercial), licensed under a <a href=\"http://creativecommons.org/licenses/by-nc/3.0/\">Creative"
-" Commons Attribution-NonCommercial 3.0 License</a>."
+"Some pages use elements of <a href=\"http://shop.highsoft.com/highcharts.html\">Highcharts</a> (non-commercial), licensed under a <a href=\"http://creativecommons.org/licenses/by-nc/3.0/\">Creative "
+"Commons Attribution-NonCommercial 3.0 License</a>."
 msgstr ""
 
 #: src/olympia/pages/templates/pages/credits.html:65
@@ -9497,7 +9448,8 @@ msgstr ""
 
 #: src/olympia/pages/templates/pages/dev_faq.html:143
 #, python-format
-msgid "Yes. You can use Mozilla's <a href=\"%(url)s\">XPCOM component object model</a> to enhance your add-ons. XPCOM components be used and implemented in JavaScript, Java, and Python in addition to C++."
+msgid ""
+"Yes. You can use Mozilla's <a href=\"%(url)s\">XPCOM component object model</a> to enhance your add-ons. XPCOM components be used and implemented in JavaScript, Java, and Python in addition to C++."
 msgstr ""
 
 #: src/olympia/pages/templates/pages/dev_faq.html:150
@@ -9508,7 +9460,7 @@ msgstr ""
 msgid ""
 "Yes. It's possible, but some of the functionality provided by these libraries are available through XPCOM, XUL, and JavaScript. In addition, authors should take care if libraries modify primitive "
 "object prototypes (String.prototype, Date.prototype, etc.) and/or define global functions (eg. the $ function). These are prone to cause conflict with other add-ons, in particular if different add-"
-"ons use different versions of libraries and so on. Developers need to be very, very careful with using them.  Mozilla does not offer documentation on using them to build add-ons."
+"ons use different versions of libraries and so on. Developers need to be very, very careful with using them. Mozilla does not offer documentation on using them to build add-ons."
 msgstr ""
 
 #: src/olympia/pages/templates/pages/dev_faq.html:165
@@ -9538,8 +9490,8 @@ msgstr ""
 #: src/olympia/pages/templates/pages/dev_faq.html:187
 #, python-format
 msgid ""
-"Poorly written extensions can have a severe impact on the browsing experience, including on the overall performance of Firefox itself. The following page contains many good <a "
-"href=\"%(url)s\">guides</a> that help you improve performance, whether you're developing core Mozilla code or an add-on."
+"Poorly written extensions can have a severe impact on the browsing experience, including on the overall performance of Firefox itself. The following page contains many good <a href=\"%(url)s"
+"\">guides</a> that help you improve performance, whether you're developing core Mozilla code or an add-on."
 msgstr ""
 
 #: src/olympia/pages/templates/pages/dev_faq.html:195
@@ -9610,8 +9562,8 @@ msgstr ""
 #: src/olympia/pages/templates/pages/dev_faq.html:248
 #, python-format
 msgid ""
-"Yes. You may find 3rd party developers via the <a href=\"%(forum_url)s\">Add-ons forum</a>, <a href=\"%(list_url)s\">mozilla.jobs list</a>, <a href=\"%(mz_url)s\">mozillaZine forums</a> or <a "
-"href=\"%(wiki_url)s\">the Mozilla Wiki</a>. Please note that Mozilla does not offer developer recommendations."
+"Yes. You may find 3rd party developers via the <a href=\"%(forum_url)s\">Add-ons forum</a>, <a href=\"%(list_url)s\">mozilla.jobs list</a>, <a href=\"%(mz_url)s\">mozillaZine forums</a> or <a href="
+"\"%(wiki_url)s\">the Mozilla Wiki</a>. Please note that Mozilla does not offer developer recommendations."
 msgstr ""
 
 #: src/olympia/pages/templates/pages/dev_faq.html:263
@@ -9621,9 +9573,9 @@ msgstr ""
 #: src/olympia/pages/templates/pages/dev_faq.html:265
 #, python-format
 msgid ""
-"Yes. Many developers choose to host their own add-ons. Choosing to host your add-on on <a href=\"%(amo_url)s\">Mozilla's add-on site</a>, though, allows for much greater exposure to your add-on due"
-" to the large volume of visitors to the site.  <a href=\"%(md_url)s\">mozdev.org</a> offers free project hosting for Mozilla applications and extensions providing developers with tools to help "
-"manage source code, version control, bug tracking and documentation."
+"Yes. Many developers choose to host their own add-ons. Choosing to host your add-on on <a href=\"%(amo_url)s\">Mozilla's add-on site</a>, though, allows for much greater exposure to your add-on due "
+"to the large volume of visitors to the site. <a href=\"%(md_url)s\">mozdev.org</a> offers free project hosting for Mozilla applications and extensions providing developers with tools to help manage "
+"source code, version control, bug tracking and documentation."
 msgstr ""
 
 #: src/olympia/pages/templates/pages/dev_faq.html:277
@@ -9671,7 +9623,7 @@ msgstr ""
 #: src/olympia/pages/templates/pages/dev_faq.html:314
 #, python-format
 msgid ""
-"Yes. Mozilla's <a href=\"%(p_url)s\">Add-on Policy</a> describes what is an acceptable submission. This policy is subject to change without notice.  In addition, the AMO editorial team uses the <a "
+"Yes. Mozilla's <a href=\"%(p_url)s\">Add-on Policy</a> describes what is an acceptable submission. This policy is subject to change without notice. In addition, the AMO editorial team uses the <a "
 "href=\"%(g_url)s\">Editors Reviewing Guide</a> to ensure that your add-on meets specific guidelines for functionality and security."
 msgstr ""
 
@@ -9700,8 +9652,8 @@ msgstr ""
 
 #: src/olympia/pages/templates/pages/dev_faq.html:346
 msgid ""
-"The choice of category is dependent on what type of audience you are targeting and the functionality of your add-on. If you're unsure of which category your add-on falls into, please choose "
-"\"Other\". The AMO team may re-categorize your add-on if it's determined that it's better suited in a different category."
+"The choice of category is dependent on what type of audience you are targeting and the functionality of your add-on. If you're unsure of which category your add-on falls into, please choose \"Other"
+"\". The AMO team may re-categorize your add-on if it's determined that it's better suited in a different category."
 msgstr ""
 
 #: src/olympia/pages/templates/pages/dev_faq.html:355
@@ -9735,8 +9687,8 @@ msgstr ""
 #: src/olympia/pages/templates/pages/dev_faq.html:385
 #, python-format
 msgid ""
-"All add-ons submitted, whether new or updated, are reviewed to ensure that Mozilla users have a stable and safe experience. All add-ons submissions are reviewed using the guidelines outlined in the"
-" <a href=\"%(url)s\">Editors Reviewing Guide</a>."
+"All add-ons submitted, whether new or updated, are reviewed to ensure that Mozilla users have a stable and safe experience. All add-ons submissions are reviewed using the guidelines outlined in the "
+"<a href=\"%(url)s\">Editors Reviewing Guide</a>."
 msgstr ""
 
 #: src/olympia/pages/templates/pages/dev_faq.html:393
@@ -9788,8 +9740,8 @@ msgstr ""
 #: src/olympia/pages/templates/pages/dev_faq.html:434
 #, python-format
 msgid ""
-"This is why it's very important to read the <a href=\"%(g_url)s\">Editors Reviewing Guide</a> to ensure that your add-on is setup as expected.  It's also a good idea to read the blog post, <a "
-"href=\"%(blog_url)s\">Successfully Getting your Add-on Reviewed</a> which provides excellent insight into ensuring a smooth review of your add-on."
+"This is why it's very important to read the <a href=\"%(g_url)s\">Editors Reviewing Guide</a> to ensure that your add-on is setup as expected. It's also a good idea to read the blog post, <a href="
+"\"%(blog_url)s\">Successfully Getting your Add-on Reviewed</a> which provides excellent insight into ensuring a smooth review of your add-on."
 msgstr ""
 
 #: src/olympia/pages/templates/pages/dev_faq.html:446
@@ -9805,7 +9757,8 @@ msgid "How can I see how many active users are using my add-on?"
 msgstr ""
 
 #: src/olympia/pages/templates/pages/dev_faq.html:457
-msgid "The Statistics Dashboard found in the Developer Tools dashboard provides information that can help you determine how many users have been actively using your add-on since you've submitted it to AMO."
+msgid ""
+"The Statistics Dashboard found in the Developer Tools dashboard provides information that can help you determine how many users have been actively using your add-on since you've submitted it to AMO."
 msgstr ""
 
 #: src/olympia/pages/templates/pages/dev_faq.html:464
@@ -9894,7 +9847,7 @@ msgstr ""
 
 #: src/olympia/pages/templates/pages/dev_faq.html:572
 msgid ""
-"Free Software Foundation provides short summaries of the key open source licenses, including whether the license qualifies as a free software license or a copyleft license.  Also includes a "
+"Free Software Foundation provides short summaries of the key open source licenses, including whether the license qualifies as a free software license or a copyleft license. Also includes a "
 "discussion of what constitutes a free software license or a copyleft license (e.g., a Copyleft license is a general method for making a program or other work free, and requiring all modified and "
 "extended versions of the program to be free as well.)"
 msgstr ""
@@ -9929,8 +9882,8 @@ msgid ""
 "Add-ons are small pieces of software that add new features or functionality to your installation of %(app_name)s. Add-ons can augment %(app_name)s with new features, foreign language dictionaries, "
 "or change its visual appearance. Through add-ons, you can customize %(app_name)s to meet your needs and tastes. <a href=\"%(learnmore_url)s\">Learn more about customization</a>"
 msgstr ""
-"Tiện ích là các mẩu phần mềm nhỏ thêm các tính năng hoặc chức năng mới cho %(app_name)s của bạn. Tiện ích có thể bổ sung %(app_name)s với các tính năng mới, từ điển ngôn ngữ, hoặc thay đổi diện mạo"
-" của nó. Thông qua tiện ích, bạn có thể tùy biến %(app_name)s cho phù hợp nhu cầu và sở thích của mình. <a href=\"%(learnmore_url)s\">Tìm hiểu thêm về việc tùy biến</a>"
+"Tiện ích là các mẩu phần mềm nhỏ thêm các tính năng hoặc chức năng mới cho %(app_name)s của bạn. Tiện ích có thể bổ sung %(app_name)s với các tính năng mới, từ điển ngôn ngữ, hoặc thay đổi diện mạo "
+"của nó. Thông qua tiện ích, bạn có thể tùy biến %(app_name)s cho phù hợp nhu cầu và sở thích của mình. <a href=\"%(learnmore_url)s\">Tìm hiểu thêm về việc tùy biến</a>"
 
 #: src/olympia/pages/templates/pages/faq.html:26
 msgid "Will add-ons work with my web browser or application?"
@@ -9939,15 +9892,13 @@ msgstr "Tiện ích có hoạt động trên ứng dụng hoặc trình duyệt 
 #: src/olympia/pages/templates/pages/faq.html:27
 #, python-format
 msgid ""
-"Add-ons listed in this gallery only work with Mozilla-based applications, such as <a href=\"%(getfirefox_url)s\">Firefox</a>, <a href=\"%(getmobile_url)s\">Firefox Mobile</a>, <a "
-"href=\"%(getseamonkey_url)s\">SeaMonkey</a>, and <a href=\"%(getthunderbird_url)s\">Thunderbird</a>. However, not all add-ons work with each of those applications or every version of those "
-"applications. Each add-on specifies which applications and versions it works with, such as Firefox 2.0 - 3.6.*. For Firefox add-ons, the install buttons will indicate whether the add-on is "
-"compatible or not."
+"Add-ons listed in this gallery only work with Mozilla-based applications, such as <a href=\"%(getfirefox_url)s\">Firefox</a>, <a href=\"%(getmobile_url)s\">Firefox Mobile</a>, <a href="
+"\"%(getseamonkey_url)s\">SeaMonkey</a>, and <a href=\"%(getthunderbird_url)s\">Thunderbird</a>. However, not all add-ons work with each of those applications or every version of those applications. "
+"Each add-on specifies which applications and versions it works with, such as Firefox 2.0 - 3.6.*. For Firefox add-ons, the install buttons will indicate whether the add-on is compatible or not."
 msgstr ""
-"Tiện ích được liệt kê tại trang trưng bày này chỉ hoạt động trên các ứng dụng nền Mozilla, như <a href=\"%(getfirefox_url)s\">Firefox</a>, <a href=\"%(getmobile_url)s\">Firefox Mobile</a>, <a "
-"href=\"%(getseamonkey_url)s\">SeaMonkey</a>, and <a href=\"%(getthunderbird_url)s\">Thunderbird</a>. Tuy nhiên, không phải tất cả tiện ích hoạt động với mỗi ứng dụng đó hoặc mỗi phiên bản của các "
-"ứng dụng đó. Mỗi tiện ích đều chỉ rõ ứng dụng và phiên bản mà nó hoạt động được, như Firefox 2.0 - 3.6.*. Đối với các tiện ích Firefox, nút cài đặt sẽ cho biết liệu tiện ích có tương thích hay "
-"không."
+"Tiện ích được liệt kê tại trang trưng bày này chỉ hoạt động trên các ứng dụng nền Mozilla, như <a href=\"%(getfirefox_url)s\">Firefox</a>, <a href=\"%(getmobile_url)s\">Firefox Mobile</a>, <a href="
+"\"%(getseamonkey_url)s\">SeaMonkey</a>, and <a href=\"%(getthunderbird_url)s\">Thunderbird</a>. Tuy nhiên, không phải tất cả tiện ích hoạt động với mỗi ứng dụng đó hoặc mỗi phiên bản của các ứng "
+"dụng đó. Mỗi tiện ích đều chỉ rõ ứng dụng và phiên bản mà nó hoạt động được, như Firefox 2.0 - 3.6.*. Đối với các tiện ích Firefox, nút cài đặt sẽ cho biết liệu tiện ích có tương thích hay không."
 
 #: src/olympia/pages/templates/pages/faq.html:42
 msgid "What are the different types of add-ons?"
@@ -9981,8 +9932,8 @@ msgstr ""
 #, python-format
 msgid "<strong><a href=\"%(browse_url)s\">Search Providers</a> </strong> add additional choices to the search box dropdown. These providers allow you to quickly search any website."
 msgstr ""
-"<strong><a href=\"%(browse_url)s\">Nhà cung cấp Tìm kiếm</a></strong> thêm các lựa chọn bổ sung vào danh sách thả xuống trên hộp tìm kiếm. Các nhà cung cấp này cho phép bạn nhanh chóng tìm kiếm bất"
-" kì trang web nào."
+"<strong><a href=\"%(browse_url)s\">Nhà cung cấp Tìm kiếm</a></strong> thêm các lựa chọn bổ sung vào danh sách thả xuống trên hộp tìm kiếm. Các nhà cung cấp này cho phép bạn nhanh chóng tìm kiếm bất "
+"kì trang web nào."
 
 #: src/olympia/pages/templates/pages/faq.html:72
 #, python-format
@@ -10013,8 +9964,8 @@ msgstr "Làm thế nào để tôi có thể cài đặt tiện ích mà không 
 #: src/olympia/pages/templates/pages/faq.html:101
 #, python-format
 msgid ""
-"In Firefox, add-ons marked with \"No restart required\" can be installed without restarting. These add-ons have been created using the <a href=\"%(sdk_url)s\">Add-on SDK</a> or <a "
-"href=\"%(bootstrap_url)s\">bootstrapping</a>. Other add-ons will still require a restart before you can use them."
+"In Firefox, add-ons marked with \"No restart required\" can be installed without restarting. These add-ons have been created using the <a href=\"%(sdk_url)s\">Add-on SDK</a> or <a href="
+"\"%(bootstrap_url)s\">bootstrapping</a>. Other add-ons will still require a restart before you can use them."
 msgstr ""
 
 #: src/olympia/pages/templates/pages/faq.html:110
@@ -10025,8 +9976,8 @@ msgstr "Làm thế nào để tôi có thể giữ cho tiện ích luôn đượ
 #, python-format
 msgid ""
 "Add-ons, unlike plugins, are automatically checked for updates once every day. In Firefox, updates are automatically installed by default. Versions of Firefox prior to 4 (and other applications) "
-"will alert you that updates to your add-ons are available. <a href=\"%(plugin_url)s\">Plugins</a> are not currently automatically checked for updates, so be sure to regularly visit the <a "
-"href=\"%(plugincheck_url)s\">Plugin Check</a> page to stay up-to-date."
+"will alert you that updates to your add-ons are available. <a href=\"%(plugin_url)s\">Plugins</a> are not currently automatically checked for updates, so be sure to regularly visit the <a href="
+"\"%(plugincheck_url)s\">Plugin Check</a> page to stay up-to-date."
 msgstr ""
 
 #: src/olympia/pages/templates/pages/faq.html:122
@@ -10036,9 +9987,9 @@ msgstr "Tiện ích có an toàn để cài đặt không?"
 #: src/olympia/pages/templates/pages/faq.html:123
 #, python-format
 msgid ""
-"Unless clearly marked otherwise, add-ons available from this gallery have been checked and approved by Mozilla's team of editors and are safe to install. We recommend that you only install approved"
-" add-ons. If you wish to install unapproved add-ons or add-ons from third-party websites, use caution as these add-ons may harm your computer or violate your privacy. <a "
-"href=\"%(learnmore_url)s\">Learn more about our approval process</a>"
+"Unless clearly marked otherwise, add-ons available from this gallery have been checked and approved by Mozilla's team of editors and are safe to install. We recommend that you only install approved "
+"add-ons. If you wish to install unapproved add-ons or add-ons from third-party websites, use caution as these add-ons may harm your computer or violate your privacy. <a href=\"%(learnmore_url)s"
+"\">Learn more about our approval process</a>"
 msgstr ""
 "Trừ khi có đánh dấu khác, tiện ích từ trang trưng bày này đã được kiểm tra và chấp thuận bởi nhóm biên tập viên của Mozilla và hoàn toàn an toàn để cài đặt. Chúng tôi khuyến nghị bạn chỉ cài đặt "
 "các tiện ích được chấp thuận. Nếu bạn muốn cài đặt các tiện ích chưa được chấp thuận hoặc tiện ích từ trang web của bên thứ ba, hãy cẩn trọng vì các tiện ích này có thể làm hại máy tính của bạn "
@@ -10065,8 +10016,8 @@ msgstr "%(app_name)s cho tôi biết một tiện ích không tương thích. C�
 #, python-format
 msgid ""
 "If an add-on isn't compatible with your version of %(app_name)s, it is usually either because your version of %(app_name)s is outdated or the add-on author has not yet updated the add-on to be "
-"compatible with a newer version you are using. Mozilla does not recommend trying to circumvent these compatibility checks, as they can lead to browser instability or in some cases loss of data. For"
-" users who are testing out alpha or beta versions of Firefox, we offer the <a href=\"%(acr_url)s\">Add-on Compatibility Reporter</a> to help add-on developers update their compatibility."
+"compatible with a newer version you are using. Mozilla does not recommend trying to circumvent these compatibility checks, as they can lead to browser instability or in some cases loss of data. For "
+"users who are testing out alpha or beta versions of Firefox, we offer the <a href=\"%(acr_url)s\">Add-on Compatibility Reporter</a> to help add-on developers update their compatibility."
 msgstr ""
 "Nếu một tiện ích không tương thích với phiên bản %(app_name)s của bạn, thì thường là vì phiên bản %(app_name)s đã quá hạn hoặc tác giả tiện ích chưa cập nhật tiện ích cho tương thích với phiên bản "
 "mới mà bạn đang dùng. Mozilla không khuyến khích việc lách các kiểm tra tính tương thích, vì chúng có thể dẫn đến sự bất ổn cho trình duyệt và mất mát dữ liệu trong một vài trường hợp. Đối với "
@@ -10084,8 +10035,8 @@ msgid ""
 "developer. If you are having issues with %(app_name)s that you suspect are related to add-ons you have installed, <a href=\"%(troubleshooting_url)s\">visit this support article</a> for "
 "troubleshooting tips."
 msgstr ""
-"Tiện ích thường được tạo bởi nhà phát triển bên ngoài từ khắp nơi trên thế giới, cho nên cách tốt nhất để được trợ giúp cho một tiện ích là tìm liên kết hỗ trợ trên trang chủ của tiện ích hoặc liên"
-" hệ với nhà phát triển. Nếu gặp vấn đề với %(app_name)s mà bạn nghi ngờ là có liên quan đến các tiện ích mà mình đã cài đặt, <a href=\"%(troubleshooting_url)s\">vào bài viết hỗ trợ này</a> để đọc "
+"Tiện ích thường được tạo bởi nhà phát triển bên ngoài từ khắp nơi trên thế giới, cho nên cách tốt nhất để được trợ giúp cho một tiện ích là tìm liên kết hỗ trợ trên trang chủ của tiện ích hoặc liên "
+"hệ với nhà phát triển. Nếu gặp vấn đề với %(app_name)s mà bạn nghi ngờ là có liên quan đến các tiện ích mà mình đã cài đặt, <a href=\"%(troubleshooting_url)s\">vào bài viết hỗ trợ này</a> để đọc "
 "các mẹo gỡ rối vấn đề."
 
 #: src/olympia/pages/templates/pages/faq.html:169
@@ -10096,7 +10047,7 @@ msgstr "Trang trưng bày Tiện ích"
 msgid "How do I choose between add-ons that seem to do the same thing?"
 msgstr "Làm thế nào để tôi có thể chọn giữa các tiện ích có vẻ như cùng làm một việc giống nhau?"
 
-#: src/olympia/pages/templates/pages/faq.html:173
+#: src/olympia/pages/templates/pages/faq.html:172
 msgid ""
 "There are often several add-ons that have similar features. To figure out which is right for you, read the entire description of the add-on and view its screenshots. If there are still several in "
 "the running, read through the add-on's ratings, user reviews, and statistics to see which is most liked by other users. Remember that you can also just try out both and see which you like better."
@@ -10122,8 +10073,8 @@ msgstr "Nếu một tiện ích là \"thử nghiệm\" hoặc \"đã được x�
 #: src/olympia/pages/templates/pages/faq.html:188
 #, python-format
 msgid ""
-"Experimental add-ons have been checked by our editors to make sure they don't have security problems, but they may still have bugs or not work properly. Use caution when installing experimental "
-"add-ons and uninstall the add-on immediately if you notice problems. <a href=\"%(url)s\">Learn more about our review process</a></dd>"
+"Experimental add-ons have been checked by our editors to make sure they don't have security problems, but they may still have bugs or not work properly. Use caution when installing experimental add-"
+"ons and uninstall the add-on immediately if you notice problems. <a href=\"%(url)s\">Learn more about our review process</a></dd>"
 msgstr ""
 "Tiện ích thử nghiệm đã được kiểm tra bởi các biên tập viên của chúng tôi để chắc chắn là chúng không có các vấn đề bảo mật, nhưng chúng có thể vẫn còn lỗi hoặc không hoạt động tốt. Hãy cẩn trọng "
 "khi cài đặt tiện ích thử nghiệm và gỡ bỏ chúng ngay lập tức nếu bạn thấy có vấn đề. <a href=\"%(url)s\">Tìm hiểu thêm về quá trình xét duyệt của chúng tôi</a></dd>"
@@ -10139,8 +10090,8 @@ msgid ""
 "as they could harm your computer or violate your privacy. We recommend that you only install reviewed add-ons. <a href=\"%(url)s\">Learn more about our review process</a></dd>"
 msgstr ""
 "Trong khi tất cả tiện ích hiện công khai trong trang trưng bày của chúng tôi được xét duyệt bởi biên tập viên, bạn có thể nhận được liên kết trực tiếp tới một tiện ích chưa được xét duyệt. Hãy cẩn "
-"trọng khi cài đặt các tiện ích này, vì chúng có thể làm hại máy tính hoặc vi phạm sự riêng tư của bạn. Chúng tôi khuyến nghị bạn chỉ nên cài đặt các tiện ích đã được xét duyệt. <a "
-"href=\"%(url)s\">Tìm hiểu thêm về quá trình xét duyệt của chúng tôi</a></dd>"
+"trọng khi cài đặt các tiện ích này, vì chúng có thể làm hại máy tính hoặc vi phạm sự riêng tư của bạn. Chúng tôi khuyến nghị bạn chỉ nên cài đặt các tiện ích đã được xét duyệt. <a href=\"%(url)s"
+"\">Tìm hiểu thêm về quá trình xét duyệt của chúng tôi</a></dd>"
 
 #: src/olympia/pages/templates/pages/faq.html:206
 msgid "How much do add-ons cost to purchase?"
@@ -10150,11 +10101,11 @@ msgstr "Tiện ích tốn bao nhiêu tiền?"
 msgid "Add-ons hosted in our gallery are free unless clearly marked otherwise."
 msgstr "Tiện ích được lưu trữ trên trang trưng bày của chúng tôi đều là miễn phí, trừ khi có cái nào được đánh dấu khác."
 
-#: src/olympia/pages/templates/pages/faq.html:210
+#: src/olympia/pages/templates/pages/faq.html:209
 msgid "What does it mean when an add-on asks for contributions?"
 msgstr "Khi một tiện ích đề nghị hỗ trợ tài chính, điều đó có nghĩa là gì?"
 
-#: src/olympia/pages/templates/pages/faq.html:211
+#: src/olympia/pages/templates/pages/faq.html:210
 msgid ""
 "Some add-on authors request users who enjoy an add-on to contribute to its development by making a monetary contribution. These contributions go directly to the developer unless a third party is "
 "indicated, such as the non-profit Mozilla Foundation."
@@ -10162,11 +10113,11 @@ msgstr ""
 "Một số tác giả tiện ích đề nghị những người dùng thích tiện ích của họ hỗ trợ sự phát triển bằng một khoản tài chính nhỏ. Những khoản đóng góp này sẽ được gửi trực tiếp tới nhà phát triển trừ khi "
 "có bên thứ ba nào đó được chỉ định, ví dụ như Quỹ Mozilla phi lợi nhuận."
 
-#: src/olympia/pages/templates/pages/faq.html:216
+#: src/olympia/pages/templates/pages/faq.html:215
 msgid "What are beta add-ons?"
 msgstr "Tiện ích beta là gì?"
 
-#: src/olympia/pages/templates/pages/faq.html:218
+#: src/olympia/pages/templates/pages/faq.html:217
 msgid ""
 "Beta add-ons are unreviewed versions which represent the latest work of an add-on author. While different authors have different standards for beta code quality, you should assume that these add-"
 "ons are less stable than the general add-on releases."
@@ -10174,95 +10125,92 @@ msgstr ""
 "Tiện ích beta là các phiên bản chưa được kiểm tra, đại diện cho thành quả mới nhất của tác giả tiện ích. Mặc dù các tác giả khác nhau sẽ có các chuẩn khác nhau đối với chất lượng của một đoạn mã "
 "beta, bạn nên cho rằng các tiện ích này sẽ ít ổn định hơn so với các bản phát hành thông thường."
 
-#: src/olympia/pages/templates/pages/faq.html:222
+#: src/olympia/pages/templates/pages/faq.html:221
 msgid ""
-"Please note that when you install an add-on from the \"Beta Version\" section of an add-on's listing, you will continue to receive updates for that add-on as they become available. Like the initial"
-" version you installed, all beta releases are unreviewed by Mozilla and may harm your computer."
+"Please note that when you install an add-on from the \"Beta Version\" section of an add-on's listing, you will continue to receive updates for that add-on as they become available. Like the initial "
+"version you installed, all beta releases are unreviewed by Mozilla and may harm your computer."
 msgstr ""
 "Vui lòng lưu ý rằng khi bạn cài đặt một tiện ích từ phần \"Phiên bản Beta\" của trang liệt kê tiện ích, bạn sẽ tiếp tục nhận được cập nhật cho tiện ích đó. Giống như phiên bản ban đầu mà bạn cài, "
 "tất cả bản beta đều không được Mozilla xem xét và có thể gây ảnh hưởng tới máy tính của bạn."
 
-#: src/olympia/pages/templates/pages/faq.html:229
+#: src/olympia/pages/templates/pages/faq.html:228
 msgid "What does it mean when an add-on is flagged as slow?"
 msgstr "Khi một tiện ích bị gắn cờ chậm, điều đó có nghĩa là gì?"
 
-#: src/olympia/pages/templates/pages/faq.html:231
-msgid ""
-"Most add-ons load code and resources at the same time Firefox\n"
-"        is starting up. In most cases the impact in start-up time is minimal,\n"
-"        but some add-ons can cause a noticeable slowdown."
+#: src/olympia/pages/templates/pages/faq.html:229
+msgid "Most add-ons load code and resources at the same time Firefox is starting up. In most cases the impact in start-up time is minimal, but some add-ons can cause a noticeable slowdown."
 msgstr ""
 
-#: src/olympia/pages/templates/pages/faq.html:236
+#: src/olympia/pages/templates/pages/faq.html:234
 msgid "How do I report an inappropriate or spam user review?"
 msgstr "Tôi có thể báo cáo một đánh giá spam hoặc không phù hợp bằng cách nào?"
 
-#: src/olympia/pages/templates/pages/faq.html:237
+#: src/olympia/pages/templates/pages/faq.html:235
 msgid ""
 "To report a user review of an add-on, log in with your account and visit the add-on's reviews page. Find the review you wish to report, click \"Report this review\" and select a reason. Our "
 "editorial team will investigate the review and take appropriate action."
 msgstr ""
-"Để báo cáo một đánh giá người dùng của một tiện ích, đăng nhập bằng tài khoản của bạn và vào trang đánh giá của tiện ích. Tìm đánh giá mà bạn muốn báo cáo, nhấn \"Báo cáo đánh giá này\" và chọn một"
-" lí do. Nhóm biên tập viên của chúng tôi sẽ kiểm tra đánh giá đó và thực hiện các thao tác phù hợp."
+"Để báo cáo một đánh giá người dùng của một tiện ích, đăng nhập bằng tài khoản của bạn và vào trang đánh giá của tiện ích. Tìm đánh giá mà bạn muốn báo cáo, nhấn \"Báo cáo đánh giá này\" và chọn một "
+"lí do. Nhóm biên tập viên của chúng tôi sẽ kiểm tra đánh giá đó và thực hiện các thao tác phù hợp."
 
-#: src/olympia/pages/templates/pages/faq.html:242
+#: src/olympia/pages/templates/pages/faq.html:240
 msgid "How do I report a bug or contact the Mozilla Add-ons team?"
 msgstr "Tôi có thể báo cáo lỗi hoặc liên hệ nhóm Tiện ích Mozilla bằng cách nào?"
 
-#: src/olympia/pages/templates/pages/faq.html:243
+#: src/olympia/pages/templates/pages/faq.html:241
 #, python-format
 msgid "Please visit our <a href=\"%(contact_url)s\">Contact page</a>."
 msgstr "Vui lòng vào <a href=\"%(contact_url)s\">trang Liên hệ</a> của chúng tôi."
 
-#: src/olympia/pages/templates/pages/faq.html:246
+#: src/olympia/pages/templates/pages/faq.html:244
 msgid "What is a Source Code License?"
 msgstr "Giấy phép Mã nguồn là gì?"
 
-#: src/olympia/pages/templates/pages/faq.html:247
+#: src/olympia/pages/templates/pages/faq.html:245
 #, python-format
 msgid ""
-"The source code used to create an add-on is an exclusive copyright of the add-on author, unless otherwise declared in a source code license. Many add-ons on this site have <a href=\"%(url)s\" "
-"lang=\"en\">open source licenses</a> that make the source code publicly available for copy and reuse under conditions determined by the author. Most authors choose widely known open source licenses"
-" like the GPL or BSD licenses instead of making up their own."
+"The source code used to create an add-on is an exclusive copyright of the add-on author, unless otherwise declared in a source code license. Many add-ons on this site have <a href=\"%(url)s\" lang="
+"\"en\">open source licenses</a> that make the source code publicly available for copy and reuse under conditions determined by the author. Most authors choose widely known open source licenses like "
+"the GPL or BSD licenses instead of making up their own."
 msgstr ""
-"Mã nguồn được dùng để tạo ra tiện ích là một bản quyền riêng biệt của tác giả tiện ích, trừ khi có tuyên bố khác trong giấy phép mã nguồn. Nhiều tiện ích trên trang này có <a href=\"%(url)s\" "
-"lang=\"en\">giấy phép mã nguồn mở</a> cho phép mã nguồn hiện hữu công cộng để sao chép và sử dụng lại theo những điều kiện được xác định bởi tác giả. Hầu hết tác giả chọn các giấy phép mã nguồn mở "
-"được biết đến rộng rãi như GPL hoặc BSD thay vì viết cái của riêng họ."
+"Mã nguồn được dùng để tạo ra tiện ích là một bản quyền riêng biệt của tác giả tiện ích, trừ khi có tuyên bố khác trong giấy phép mã nguồn. Nhiều tiện ích trên trang này có <a href=\"%(url)s\" lang="
+"\"en\">giấy phép mã nguồn mở</a> cho phép mã nguồn hiện hữu công cộng để sao chép và sử dụng lại theo những điều kiện được xác định bởi tác giả. Hầu hết tác giả chọn các giấy phép mã nguồn mở được "
+"biết đến rộng rãi như GPL hoặc BSD thay vì viết cái của riêng họ."
 
-#: src/olympia/pages/templates/pages/faq.html:256
+#: src/olympia/pages/templates/pages/faq.html:254
 #, python-format
 msgid "Firefox and other Mozilla software are <a href=\"%(url)s\">open source</a>."
 msgstr "Firefox và các phần mềm Mozilla khác là <a href=\"%(url)s\">mã nguồn mở</a>."
 
-#: src/olympia/pages/templates/pages/faq.html:264
+#: src/olympia/pages/templates/pages/faq.html:262
 msgid "Collections and Favorites"
 msgstr "Bộ sưu tập và Ưa thích"
 
-#: src/olympia/pages/templates/pages/faq.html:267
+#: src/olympia/pages/templates/pages/faq.html:265
 msgid "What is a collection?"
 msgstr "Bộ sưu tập là gì?"
 
-#: src/olympia/pages/templates/pages/faq.html:268
+#: src/olympia/pages/templates/pages/faq.html:266
 msgid "Collections are groups of related add-ons created by users to share."
 msgstr "Bộ sưu tập là nhóm các tiện ích liên quan được tạo bởi người dùng để chia sẻ."
 
-#: src/olympia/pages/templates/pages/faq.html:270
+#: src/olympia/pages/templates/pages/faq.html:268
 msgid "What is the My Favorites collection?"
 msgstr "Bộ sưu tập 'Ưa thích của Tôi' là gì?"
 
-#: src/olympia/pages/templates/pages/faq.html:271
+#: src/olympia/pages/templates/pages/faq.html:269
 msgid "Favorite add-ons are add-ons that you have bookmarked to easily get back to later. You can add an add-on to your favorites collection by clicking \"Add to favorites\" on its details page."
 msgstr "Tiện ích ưa thích là các tiện ích bạn đã đánh dấu để dễ dàng truy cập. Bạn có thể thêm một tiện ích vào bộ sưu tập ưa thích bằng cách nhấn \"Thêm vào ưa thích\" trên trang chi tiết của nó."
 
-#: src/olympia/pages/templates/pages/faq.html:275 src/olympia/templates/menu_links.html:13 src/olympia/templates/impala/header_title.html:17
+#: src/olympia/pages/templates/pages/faq.html:273 src/olympia/templates/menu_links.html:13 src/olympia/templates/impala/header_title.html:17
 msgid "Mobile Add-ons"
 msgstr "Tiện ích cho Di động"
 
-#: src/olympia/pages/templates/pages/faq.html:278
+#: src/olympia/pages/templates/pages/faq.html:276
 msgid "What are mobile add-ons?"
 msgstr "Tiện ích di động là gì?"
 
-#: src/olympia/pages/templates/pages/faq.html:279
+#: src/olympia/pages/templates/pages/faq.html:277
 #, python-format
 msgid ""
 "Mobile add-ons work with <a href=\"%(mobile_url)s\">Firefox for Mobile</a> and add or modify functionality just like desktop add-ons. You can find add-ons that work with Firefox for Mobile in our "
@@ -10271,25 +10219,25 @@ msgstr ""
 "Tiện ích di động hoạt động trên <a href=\"%(mobile_url)s\">Firefox cho Di động</a> và thêm hoặc sửa đổi chức năng như tiện ích cho máy tính để bàn. Bạn có thể tìm các tiện ích hoạt động trên "
 "Firefox cho Di động trong <a href=\"%(gallery_url)s\">trang trưng bày</a> của chúng tôi."
 
-#: src/olympia/pages/templates/pages/faq.html:288
+#: src/olympia/pages/templates/pages/faq.html:286
 msgid "Developer Topics"
 msgstr "Chủ đề Nhà phát triển"
 
-#: src/olympia/pages/templates/pages/faq.html:289
+#: src/olympia/pages/templates/pages/faq.html:287
 #, python-format
 msgid "Please see our <a href=\"%(faq_url)s\">Developer FAQ</a> and <a href=\"%(hub_url)s\">Developer Hub</a> for answers to add-on developer-related questions."
 msgstr "Vui lòng xem <a href=\"%(faq_url)s\">FAQ Nhà phát triển</a> và <a href=\"%(hub_url)s\">Trung tâm Nhà phát triển</a> để tìm câu trả lời cho các câu hỏi liên quan đế nhà phát triển tiện ích."
 
-#: src/olympia/pages/templates/pages/faq.html:294
+#: src/olympia/pages/templates/pages/faq.html:292
 msgid "Still have questions?"
 msgstr "Vẫn còn câu hỏi?"
 
-#: src/olympia/pages/templates/pages/faq.html:295
+#: src/olympia/pages/templates/pages/faq.html:293
 #, python-format
 msgid "For general Firefox support, visit our <a href=\"%(sumo_url)s\">support website</a>. For general add-on and website questions, visit our <a href=\"%(forum_url)s\">forum</a>."
 msgstr ""
-"Đối với hỗ trợ Firefox thông thường, hãy vào <a href=\"%(sumo_url)s\">trang web hỗ trợ</a> của chúng tôi. Đối với các câu hỏi về trang web và tiện ích thông thường, hãy vào <a "
-"href=\"%(forum_url)s\">diễn đàn</a> của chúng tôi."
+"Đối với hỗ trợ Firefox thông thường, hãy vào <a href=\"%(sumo_url)s\">trang web hỗ trợ</a> của chúng tôi. Đối với các câu hỏi về trang web và tiện ích thông thường, hãy vào <a href=\"%(forum_url)s"
+"\">diễn đàn</a> của chúng tôi."
 
 #: src/olympia/pages/templates/pages/review_guide.html:36 src/olympia/pages/templates/pages/review_guide.html:51
 msgid "Some tips for writing a great review"
@@ -10424,7 +10372,7 @@ msgstr ""
 
 #: src/olympia/pages/templates/pages/sunbird.html:29
 msgid ""
-"Development on the Sunbird project has halted and its final release was on March 30, 2010.  We've been proud to host Sunbird add-ons on this site but as the project is no longer maintained we have "
+"Development on the Sunbird project has halted and its final release was on March 30, 2010. We've been proud to host Sunbird add-ons on this site but as the project is no longer maintained we have "
 "disabled our support for the add-ons."
 msgstr ""
 
@@ -10502,10 +10450,10 @@ msgstr "Thêm một đánh giá cho {0}"
 #, python-format
 msgid ""
 "<h2>Keep these tips in mind:</h2> <ul> <li> Write like you're telling a friend about your experience with the add-on. Give specifics and helpful details, such as what features you liked and/or "
-"disliked, how easy to use it is, and any disadvantages it has.  Avoid generic language such as calling it \"Great\" or \"Bad\" unless you can give reasons why you believe this is so. </li> <li> "
-"Please do not post bug reports in reviews. We do not make your email address available to add-on developers and they may need to contact you to help resolve your issue. See the <a "
-"href=\"%(support)s\">support section</a> to find out where to get assistance for this add-on. </li> <li>Please keep reviews clean, avoid the use of improper language and do not post any personal "
-"information. </li> </ul> <p>Please read the <a href=\"%(guide)s\" target=\"_blank\">Review Guidelines</a> for more detail about user add-on reviews.</p>"
+"disliked, how easy to use it is, and any disadvantages it has. Avoid generic language such as calling it \"Great\" or \"Bad\" unless you can give reasons why you believe this is so. </li> <li> "
+"Please do not post bug reports in reviews. We do not make your email address available to add-on developers and they may need to contact you to help resolve your issue. See the <a href=\"%(support)s"
+"\">support section</a> to find out where to get assistance for this add-on. </li> <li>Please keep reviews clean, avoid the use of improper language and do not post any personal information. </li> </"
+"ul> <p>Please read the <a href=\"%(guide)s\" target=\"_blank\">Review Guidelines</a> for more detail about user add-on reviews.</p>"
 msgstr ""
 
 #: src/olympia/reviews/templates/reviews/reply.html:4
@@ -10549,6 +10497,7 @@ msgstr "Đánh giá này là cho một phiên bản trước của tiện ích (
 msgid "This user has a <a href=\"%(user_review_url)s\">previous review</a> of this add-on."
 msgid_plural "This user has <a href=\"%(user_review_url)s\">%(cnt)s previous reviews</a> of this add-on."
 msgstr[0] "Người dùng này có <a href=\"%(user_review_url)s\">đánh giá trước đây</a> về tiện ích này."
+msgstr[1] ""
 
 #: src/olympia/reviews/templates/reviews/review.html:62
 #, python-format
@@ -10594,6 +10543,7 @@ msgstr "Đánh giá cho {0}"
 msgid "<b>{0}</b> review for this add-on"
 msgid_plural "<b>{0}</b> reviews for this add-on"
 msgstr[0] "<b>{0}</b> đánh giá cho tiện ích này"
+msgstr[1] ""
 
 #. {0} is a developer's name.
 #: src/olympia/reviews/templates/reviews/review_list.html:33
@@ -10605,6 +10555,7 @@ msgstr "Trả lời nhà phát triển của {0}"
 msgid "Review for %(addon)s by %(user)s"
 msgid_plural "Reviews for %(addon)s by %(user)s"
 msgstr[0] "Đánh giá cho %(addon)s bởi %(user)s"
+msgstr[1] ""
 
 #: src/olympia/reviews/templates/reviews/review_list.html:42
 msgid "No reviews found."
@@ -10627,6 +10578,7 @@ msgstr "Hãy là người đầu tiên viết đánh giá."
 msgid "{num} review"
 msgid_plural "{num} reviews"
 msgstr[0] "{num} đánh giá"
+msgstr[1] ""
 
 #: src/olympia/reviews/templates/reviews/impala/reviews_rating.html:1
 msgid "Rated {0} out of 5 stars"
@@ -10653,6 +10605,7 @@ msgstr "Chưa có xếp hạng."
 msgid "Average from {0} Rating"
 msgid_plural "Average from {0} Ratings"
 msgstr[0] "Trung bình từ {0} Xếp hạng"
+msgstr[1] ""
 
 #: src/olympia/reviews/templates/reviews/mobile/review_list.html:34
 #, python-format
@@ -10668,6 +10621,7 @@ msgstr "Đọc thêm&nbsp;&raquo;"
 msgid "See All Reviews"
 msgid_plural "See All %(cnt)s Reviews"
 msgstr[0] "Xem Tất cả %(cnt)s Đánh giá"
+msgstr[1] ""
 
 #: src/olympia/search/forms.py:11
 msgid "Most popular this week"
@@ -10748,16 +10702,16 @@ msgstr "{0} Tiện ích"
 
 #. L10n: {0} is an application, such as Firefox. This means "any version of
 #. Firefox."
-#: src/olympia/search/views.py:554
+#: src/olympia/search/views.py:547
 msgid "Any {0}"
 msgstr "Bất kỳ {0}"
 
 #. L10n: "All Systems" means show everything regardless of platform.
-#: src/olympia/search/views.py:589
+#: src/olympia/search/views.py:582
 msgid "All Systems"
 msgstr "Tất cả Hệ điều hành"
 
-#: src/olympia/search/views.py:600
+#: src/olympia/search/views.py:593
 msgid "All Tags"
 msgstr "Tất cả Nhãn"
 
@@ -10801,6 +10755,7 @@ msgstr "Kết quả Tìm kiếm cho nhãn \"{0}\""
 msgid "<b>{0}</b> matching result"
 msgid_plural "<b>{0}</b> matching results"
 msgstr[0] "<b>{0}</b> kết quả trùng khớp<b>{0}</b> kết quả trùng khớp"
+msgstr[1] ""
 
 #: src/olympia/search/templates/search/results.html:67
 msgid "Filter Results"
@@ -10822,6 +10777,7 @@ msgstr "Kết quả Tìm kiếm <i>({num})</i>"
 msgid "{0} post"
 msgid_plural "{0} posts"
 msgstr[0] "{0} bài"
+msgstr[1] ""
 
 #: src/olympia/sharing/__init__.py:20
 msgid "Post to Facebook"
@@ -10831,6 +10787,7 @@ msgstr "Đăng lên Facebook"
 msgid "{0} Like"
 msgid_plural "{0} Likes"
 msgstr[0] ""
+msgstr[1] ""
 
 #: src/olympia/sharing/__init__.py:30
 msgid "Tweet on Twitter"
@@ -10840,6 +10797,7 @@ msgstr ""
 msgid "{0} tweet"
 msgid_plural "{0} tweets"
 msgstr[0] "{0} tweet"
+msgstr[1] ""
 
 #: src/olympia/sharing/__init__.py:40
 msgid "Share on g+"
@@ -10873,6 +10831,7 @@ msgstr ""
 msgid "{0} post on localservice1"
 msgid_plural "{0} posts on localservice1"
 msgstr[0] ""
+msgstr[1] ""
 
 #. L10n: Only change if you have reason! wiki.mozilla.org/AMO:Localizers
 #: src/olympia/sharing/__init__.py:76
@@ -10894,6 +10853,7 @@ msgstr ""
 msgid "{0} post on localservice2"
 msgid_plural "{0} posts on localservice2"
 msgstr[0] ""
+msgstr[1] ""
 
 #. L10n: Only change if you have reason! wiki.mozilla.org/AMO:Localizers
 #: src/olympia/sharing/__init__.py:91
@@ -10915,6 +10875,7 @@ msgstr ""
 msgid "{0} post on localservice3"
 msgid_plural "{0} posts on localservice3"
 msgstr[0] ""
+msgstr[1] ""
 
 #: src/olympia/sharing/templates/sharing/sharing_widget.html:2
 msgid "Share this Add-on"
@@ -10924,31 +10885,31 @@ msgstr "Chia sẻ Tiện ích này"
 msgid "Share this Collection"
 msgstr "Chia sẻ Bộ sưu tập này"
 
-#: src/olympia/signing/views.py:30 src/olympia/templates/base.html:75 src/olympia/templates/impala/base.html:115
+#: src/olympia/signing/views.py:33 src/olympia/templates/base.html:71 src/olympia/templates/impala/base.html:112
 msgid "Some features are temporarily disabled while we perform website maintenance. We'll be back to full capacity shortly."
 msgstr "Một số tính năng tạm thời bị vô hiệu hóa trong khi chúng tôi bảo trì trang web. Chúng tôi sẽ hoạt động đầy đủ lại nhanh thôi."
 
-#: src/olympia/signing/views.py:53
+#: src/olympia/signing/views.py:56
 msgid "Could not find add-on with id \"{}\"."
 msgstr ""
 
-#: src/olympia/signing/views.py:67
+#: src/olympia/signing/views.py:70
 msgid "You do not own this addon."
 msgstr ""
 
-#: src/olympia/signing/views.py:82
+#: src/olympia/signing/views.py:87
 msgid "Missing \"upload\" key in multipart file data."
 msgstr ""
 
-#: src/olympia/signing/views.py:96
+#: src/olympia/signing/views.py:101
 msgid "Version does not match the manifest file."
 msgstr ""
 
-#: src/olympia/signing/views.py:100
+#: src/olympia/signing/views.py:105
 msgid "Version already exists."
 msgstr ""
 
-#: src/olympia/signing/views.py:136
+#: src/olympia/signing/views.py:141
 msgid "No uploaded file for that addon and version."
 msgstr ""
 
@@ -11061,89 +11022,89 @@ msgstr ""
 msgid "Statistics Dashboard :: Add-ons for {0}"
 msgstr ""
 
-#: src/olympia/stats/templates/stats/stats.html:30
-msgid "Controls:"
-msgstr "Điều khiển:"
-
-#: src/olympia/stats/templates/stats/stats.html:33
-msgid "reset zoom"
-msgstr ""
-
-#: src/olympia/stats/templates/stats/stats.html:40
-msgid "Group by:"
-msgstr "Nhóm lại theo:"
-
-#: src/olympia/stats/templates/stats/stats.html:42
-msgid "day"
-msgstr "ngày"
-
-#: src/olympia/stats/templates/stats/stats.html:45
-msgid "week"
-msgstr "tuần"
-
-#: src/olympia/stats/templates/stats/stats.html:48
-msgid "month"
-msgstr "tháng"
-
-#: src/olympia/stats/templates/stats/stats.html:54
-msgid "For last:"
-msgstr "Thời gian về trước:"
-
-#: src/olympia/stats/templates/stats/stats.html:57
-msgid "7 days"
-msgstr "7 ngày"
-
-#: src/olympia/stats/templates/stats/stats.html:60
-msgid "30 days"
-msgstr "30 ngày"
-
-#: src/olympia/stats/templates/stats/stats.html:63
-msgid "90 days"
-msgstr "90 ngày"
-
-#: src/olympia/stats/templates/stats/stats.html:66
-msgid "365 days"
-msgstr "365 ngày"
-
-#: src/olympia/stats/templates/stats/stats.html:69
-msgid "Custom..."
-msgstr "Tùy biến…"
-
 #. {0} is an add-on name
-#: src/olympia/stats/templates/stats/stats.html:88 src/olympia/stats/templates/stats/stats.html:91
+#: src/olympia/stats/templates/stats/stats.html:44 src/olympia/stats/templates/stats/stats.html:47
 msgid "Statistics for {0}"
 msgstr "Thống kê cho {0}"
 
-#: src/olympia/stats/templates/stats/stats.html:94
+#: src/olympia/stats/templates/stats/stats.html:50
 msgid "Statistics Dashboard"
 msgstr ""
 
-#: src/olympia/stats/templates/stats/stats.html:104
+#: src/olympia/stats/templates/stats/stats.html:57
+msgid "Controls:"
+msgstr "Điều khiển:"
+
+#: src/olympia/stats/templates/stats/stats.html:60
+msgid "reset zoom"
+msgstr ""
+
+#: src/olympia/stats/templates/stats/stats.html:67
+msgid "Group by:"
+msgstr "Nhóm lại theo:"
+
+#: src/olympia/stats/templates/stats/stats.html:69
+msgid "day"
+msgstr "ngày"
+
+#: src/olympia/stats/templates/stats/stats.html:72
+msgid "week"
+msgstr "tuần"
+
+#: src/olympia/stats/templates/stats/stats.html:75
+msgid "month"
+msgstr "tháng"
+
+#: src/olympia/stats/templates/stats/stats.html:81
+msgid "For last:"
+msgstr "Thời gian về trước:"
+
+#: src/olympia/stats/templates/stats/stats.html:84
+msgid "7 days"
+msgstr "7 ngày"
+
+#: src/olympia/stats/templates/stats/stats.html:87
+msgid "30 days"
+msgstr "30 ngày"
+
+#: src/olympia/stats/templates/stats/stats.html:90
+msgid "90 days"
+msgstr "90 ngày"
+
+#: src/olympia/stats/templates/stats/stats.html:93
+msgid "365 days"
+msgstr "365 ngày"
+
+#: src/olympia/stats/templates/stats/stats.html:96
+msgid "Custom..."
+msgstr "Tùy biến…"
+
+#: src/olympia/stats/templates/stats/stats.html:106
 msgid "Statistics processing is currently disabled, so recent data is unavailable. The statistics are still being collected and this page will be updated soon with the missing data."
 msgstr ""
 
-#: src/olympia/stats/templates/stats/stats.html:110
+#: src/olympia/stats/templates/stats/stats.html:112
 msgid "Loading the latest data&hellip;"
 msgstr "Đang nạp dữ liệu mới nhất&hellip;"
 
-#: src/olympia/stats/templates/stats/stats.html:142 src/olympia/stats/templates/stats/reports/overview.html:25 src/olympia/stats/templates/stats/reports/overview.html:37
+#: src/olympia/stats/templates/stats/stats.html:144 src/olympia/stats/templates/stats/reports/overview.html:25 src/olympia/stats/templates/stats/reports/overview.html:37
 #: src/olympia/stats/templates/stats/reports/overview.html:49
 msgid "No data available."
 msgstr "Không có dữ liệu."
 
-#: src/olympia/stats/templates/stats/stats.html:177
+#: src/olympia/stats/templates/stats/stats.html:179
 msgid "This dashboard is currently <b>public</b>."
 msgstr "Bảng điều khiển này hiện đang <b>công khai</b>."
 
-#: src/olympia/stats/templates/stats/stats.html:179
+#: src/olympia/stats/templates/stats/stats.html:181
 msgid "Contribution stats are currently <b>private</b>."
 msgstr "Thống kê đóng góp hiện đang <b>riêng tư</b>."
 
-#: src/olympia/stats/templates/stats/stats.html:182
+#: src/olympia/stats/templates/stats/stats.html:184
 msgid "This dashboard is currently <b>private</b>."
 msgstr "Bảng điều khiển này hiện đang <b>riêng tư</b>."
 
-#: src/olympia/stats/templates/stats/stats.html:185
+#: src/olympia/stats/templates/stats/stats.html:187
 msgid "Change settings."
 msgstr ""
 
@@ -11253,10 +11214,10 @@ msgstr "Giới thiệu về theo dõi nguồn bên ngoài…"
 #, python-format
 msgid ""
 "<h2>Tracking external sources</h2> <p> If you link to your add-on's details page or directly to its file from an external site, such as your blog or website, you can append a parameter to be "
-"tracked as an additional download source on this page. For example, the following links would appear as sourced by your blog: <dl> <dt>Add-on Details Page</dt> "
-"<dd>https://addons.mozilla.org/addon/%(slug)s?src=<b>external-blog</b></dd> <dt>Direct File Link</dt> <dd>https://addons.mozilla.org/downloads/latest/%(id)s/addon-%(id)s-latest.xpi?src=<b>external-"
-"blog</b></dd> </dl> <p> Only src parameters that begin with \"external-\" will be tracked, up to 61 additional characters. Any text after \"external-\" can be used to describe the source, such as "
-"\"external-blog\", \"external-sidebar\", \"external-campaign225\", etc. The following URL-safe characters are allowed: <code>a-z A-Z - . _ ~ %% +</code>"
+"tracked as an additional download source on this page. For example, the following links would appear as sourced by your blog: <dl> <dt>Add-on Details Page</dt> <dd>https://addons.mozilla.org/addon/"
+"%(slug)s?src=<b>external-blog</b></dd> <dt>Direct File Link</dt> <dd>https://addons.mozilla.org/downloads/latest/%(id)s/addon-%(id)s-latest.xpi?src=<b>external-blog</b></dd> </dl> <p> Only src "
+"parameters that begin with \"external-\" will be tracked, up to 61 additional characters. Any text after \"external-\" can be used to describe the source, such as \"external-blog\", \"external-"
+"sidebar\", \"external-campaign225\", etc. The following URL-safe characters are allowed: <code>a-z A-Z - . _ ~ %% +</code>"
 msgstr ""
 
 #: src/olympia/stats/templates/stats/reports/statuses.html:3
@@ -11283,8 +11244,8 @@ msgstr ""
 
 #: src/olympia/stats/templates/stats/reports/usage.html:20
 msgid ""
-"<h2>What are daily users?</h2> <p> Add-ons downloaded from this site check for updates once per day. The total number of these update pings is known as Active Daily Users. Daily users can be broken"
-" down by add-on version, operating system, add-on status, application, and locale. </p>"
+"<h2>What are daily users?</h2> <p> Add-ons downloaded from this site check for updates once per day. The total number of these update pings is known as Active Daily Users. Daily users can be broken "
+"down by add-on version, operating system, add-on status, application, and locale. </p>"
 msgstr ""
 
 #: src/olympia/stats/templates/stats/reports/users_created.html:3
@@ -11295,16 +11256,6 @@ msgstr ""
 msgid "Application versions by Date"
 msgstr "Phiên bản ứng dụng theo Ngày"
 
-# {0} is a number
-#: src/olympia/tags/templates/tags/top_cloud.html:4
-msgid "Top {0} Tags"
-msgstr "{0} Nhãn Hạng nhất"
-
-#. {0} is the current application name
-#: src/olympia/tags/templates/tags/top_cloud.html:14
-msgid "{0} Top Tags"
-msgstr "Nhãn {0} Hạng nhất"
-
 #: src/olympia/templates/amo_footer.html:6 src/olympia/templates/includes/lang_switcher.html:2
 msgid "Other languages"
 msgstr "Ngôn ngữ khác"
@@ -11313,11 +11264,11 @@ msgstr "Ngôn ngữ khác"
 msgid "Mozilla Add-ons"
 msgstr "Tiện ích Mozilla"
 
-#: src/olympia/templates/base.html:91 src/olympia/templates/impala/base.html:81
+#: src/olympia/templates/base.html:89 src/olympia/templates/impala/base.html:78
 msgid "Find add-ons for other applications"
 msgstr "Tìm tiện ích cho các ứng dụng khác"
 
-#: src/olympia/templates/base.html:92 src/olympia/templates/impala/base.html:81
+#: src/olympia/templates/base.html:90 src/olympia/templates/impala/base.html:78
 msgid "Other Applications"
 msgstr "Ứng dụng Khác"
 
@@ -11342,7 +11293,7 @@ msgid "View Mobile Site"
 msgstr "Xem trang Di động"
 
 #: src/olympia/templates/copyright.html:7
-msgid "Site Status "
+msgid "Site Status"
 msgstr ""
 
 #: src/olympia/templates/footer.html:3
@@ -11444,35 +11395,35 @@ msgstr "Xin chào, {0}"
 msgid "<a href=\"%(reg)s\">Register</a> or <a href=\"%(login)s\">Log in</a>"
 msgstr "<a href=\"%(reg)s\">Đăng kí</a> hoặc <a href=\"%(login)s\">Đăng nhập</a>"
 
-#: src/olympia/templates/impala/base.html:126
+#: src/olympia/templates/impala/base.html:123
 #, python-format
 msgid "To try the thousands of add-ons available here, download <a href=\"%(url)s\">Mozilla Firefox</a>, a fast, free way to surf the Web!"
 msgstr ""
 
-#: src/olympia/templates/impala/base.html:138
+#: src/olympia/templates/impala/base.html:135
 #, python-format
 msgid "Add-ons is switching to Firefox Accounts for login. <a href=\"%(url)s\" class=\"fxa-login\">Sign in now to transfer your account.</a>"
 msgstr ""
 
 #. {0} is an application, such as Firefox.
-#: src/olympia/templates/impala/base.html:148
+#: src/olympia/templates/impala/base.html:145
 msgid "Welcome to {0} Add-ons."
 msgstr ""
 
-#: src/olympia/templates/impala/base.html:151
+#: src/olympia/templates/impala/base.html:148
 msgid "Choose from thousands of extra features and styles to make Firefox your own."
 msgstr ""
 
-#: src/olympia/templates/impala/base.html:156
+#: src/olympia/templates/impala/base.html:153
 #, python-format
 msgid "Add extra features and styles to make %(app)s your own."
 msgstr ""
 
-#: src/olympia/templates/impala/base.html:164
+#: src/olympia/templates/impala/base.html:161
 msgid "On the go?"
 msgstr ""
 
-#: src/olympia/templates/impala/base.html:166
+#: src/olympia/templates/impala/base.html:163
 msgid "Check out our <a class=\"mobile-link\" href=\"#\">Mobile Add-ons site</a>."
 msgstr ""
 
@@ -11696,19 +11647,19 @@ msgstr "Không người dùng nào có email đó."
 
 #. L10n: {id} will be something like "13ad6a", just a random number
 #. to differentiate this user from other anonymous users.
-#: src/olympia/users/models.py:353
+#: src/olympia/users/models.py:362
 msgid "Anonymous user {id}"
 msgstr ""
 
-#: src/olympia/users/models.py:410
+#: src/olympia/users/models.py:419
 msgid "Your account has been restricted"
 msgstr ""
 
-#: src/olympia/users/models.py:480
+#: src/olympia/users/models.py:489
 msgid "Please confirm your email address"
 msgstr "Vui lòng xác nhận địa chỉ email của bạn"
 
-#: src/olympia/users/models.py:506
+#: src/olympia/users/models.py:515
 msgid "My Mobile Add-ons"
 msgstr "Tiện ích Di động của Tôi"
 
@@ -11917,8 +11868,8 @@ msgid ""
 "You cannot delete your account if you are listed as an <a href=\"%(link)s\"> author of any add-ons</a>. To delete your account, please have another person in your development group delete you from "
 "the list of authors for your add-ons. Afterwards you will be able to delete your account here."
 msgstr ""
-"Bạn không thể xóa tài khoản của mình nếu được liệt kê là <a href=\"%(link)s\"> tác giả của tiện ích bất kì</a>. Để xóa tài khoản của mình, vui lòng nhờ người khác trong nhóm phát triển xóa bạn khỏi"
-" danh sách tác giả tiện ích. Sau đó bạn sẽ có thể xóa tài khoản của mình tại đây."
+"Bạn không thể xóa tài khoản của mình nếu được liệt kê là <a href=\"%(link)s\"> tác giả của tiện ích bất kì</a>. Để xóa tài khoản của mình, vui lòng nhờ người khác trong nhóm phát triển xóa bạn khỏi "
+"danh sách tác giả tiện ích. Sau đó bạn sẽ có thể xóa tài khoản của mình tại đây."
 
 #: src/olympia/users/templates/users/delete.html:29
 msgid "By clicking \"delete\" your account is going to be <strong>permanently removed</strong>. That means:"
@@ -11988,7 +11939,7 @@ msgstr "Mật khẩu"
 
 #: src/olympia/users/templates/users/edit.html:70
 #, python-format
-msgid "Change your password.  If you forgot your password, you can <a href=\"%(reset_url)s\">use the reset form</a>."
+msgid "Change your password. If you forgot your password, you can <a href=\"%(reset_url)s\">use the reset form</a>."
 msgstr ""
 
 #: src/olympia/users/templates/users/edit.html:76
@@ -12240,7 +12191,8 @@ msgid "Send password reset link"
 msgstr "Gửi liên kết khôi phục mật khẩu"
 
 #: src/olympia/users/templates/users/pwreset_sent.html:10
-msgid "An email has been sent to the requested account with further information. If you do not receive an email then please confirm you have entered the same email address used during account registration."
+msgid ""
+"An email has been sent to the requested account with further information. If you do not receive an email then please confirm you have entered the same email address used during account registration."
 msgstr "Một email đã được gửi đến tài khoản với thông tin thêm. Nếu bạn không nhận được email vui lòng chắc chắn rằng bạn đã nhập đúng địa chỉ email đã dùng khi đăng kí tài khoản."
 
 #: src/olympia/users/templates/users/register.html:4
@@ -12413,7 +12365,7 @@ msgstr ""
 
 #: src/olympia/users/templates/users/unsubscribe.html:30
 #, python-format
-msgid "Unfortunately, we weren't able to unsubscribe you.  The link you clicked is invalid. However, you can unsubscribe still unsubscribe on your <a href=\"%(edit_url)s\">edit profile page</a>."
+msgid "Unfortunately, we weren't able to unsubscribe you. The link you clicked is invalid. However, you can unsubscribe still unsubscribe on your <a href=\"%(edit_url)s\">edit profile page</a>."
 msgstr ""
 
 #: src/olympia/users/templates/users/vcard.html:2
@@ -12445,12 +12397,14 @@ msgstr ""
 msgid "%(num)s theme"
 msgid_plural "%(num)s themes"
 msgstr[0] ""
+msgstr[1] ""
 
 #: src/olympia/users/templates/users/vcard.html:62
 #, python-format
 msgid "%(num)s add-on"
 msgid_plural "%(num)s add-ons"
 msgstr[0] ""
+msgstr[1] ""
 
 #: src/olympia/users/templates/users/vcard.html:75
 msgid "Average rating of developer's add-ons"
@@ -12465,15 +12419,15 @@ msgstr "Lược sử Phiên bản %s"
 msgid "Version History with Changelogs"
 msgstr "Lược sử Phiên bản cùng với Lưu kí Thay đổi"
 
-#: src/olympia/versions/models.py:314
+#: src/olympia/versions/models.py:313
 msgid "Add-on uses binary components."
 msgstr ""
 
-#: src/olympia/versions/models.py:317
+#: src/olympia/versions/models.py:316
 msgid "Add-on has opted into strict compatibility checking."
 msgstr ""
 
-#: src/olympia/versions/models.py:715
+#: src/olympia/versions/models.py:711
 msgid "{app} {min} and later"
 msgstr "{app} {min} trở lên"
 
@@ -12511,6 +12465,7 @@ msgstr "{0} Lược sử Phiên bản"
 msgid "<b>{0}</b> version"
 msgid_plural "<b>{0}</b> versions"
 msgstr[0] "<b>{0}</b> phiên bản<b>{0}</b> phiên bản"
+msgstr[1] ""
 
 #: src/olympia/versions/templates/versions/version_list.html:35 src/olympia/versions/templates/versions/mobile/version_list.html:14
 msgid "Be careful with old versions!"
@@ -12550,3 +12505,6 @@ msgstr ""
 msgid "Log emails instead of sending"
 msgstr ""
 
+#: src/olympia/zadmin/forms.py:215
+msgid "Deleted versions can`t be changed."
+msgstr ""

--- a/locale/vi/LC_MESSAGES/djangojs.po
+++ b/locale/vi/LC_MESSAGES/djangojs.po
@@ -1,1201 +1,1235 @@
-
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2016-02-24 21:23+0000\n"
+"POT-Creation-Date: 2016-04-18 15:47+0000\n"
 "PO-Revision-Date: 2015-09-13 20:11+0000\n"
 "Last-Translator: 1ec5 <mxn@1ec5.org>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
+"Language: \n"
 "MIME-Version: 1.0\n"
-"Content-Type: text/plain; charset=utf-8\n"
+"Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Generated-By: Babel 2.2.0\n"
 
-#: static/js/common/ratingwidget.js:31
+#: static/js/common-all.js:1426 static/js/impala-all.js:1511 static/js/zamboni/discovery-all.js:12598 static/js/zamboni/init.js:28 static/js/zamboni/mobile-all.js:14945
+msgid "This feature is temporarily disabled while we perform website maintenance. Please check back a little later."
+msgstr " Tính năng này tạm thời bị vô hiệu hóa trong khi chúng tôi đang bảo trì trang web. Vui lòng kiểm tra lại sau. "
+
+#. L10n: {0} is an app name like Firefox.
+#: static/js/common-all.js:1837 static/js/impala-all.js:1922 static/js/zamboni/buttons.js:73 static/js/zamboni/discovery-all.js:13108
+msgid "Accept and Install"
+msgstr "Chấp nhận và cài đặt"
+
+#: static/js/common-all.js:1837 static/js/impala-all.js:1922 static/js/zamboni/buttons.js:73 static/js/zamboni/discovery-all.js:13108
+msgid "Add to {0}"
+msgstr "Thêm vào {0}"
+
+#: static/js/common-all.js:1842 static/js/impala-all.js:1927 static/js/zamboni/buttons.js:78 static/js/zamboni/discovery-all.js:13113
+msgid "Download Now"
+msgstr "Tải về ngay"
+
+#: static/js/common-all.js:1883 static/js/impala-all.js:1968 static/js/zamboni/buttons.js:119 static/js/zamboni/discovery-all.js:13154
+msgid "Add-on has not been updated to support default-to-compatible."
+msgstr ""
+
+#: static/js/common-all.js:1888 static/js/impala-all.js:1973 static/js/zamboni/buttons.js:124 static/js/zamboni/discovery-all.js:13159
+msgid "You need to be using Firefox 10.0 or higher."
+msgstr "Bạn cần phải sử dụng Firefox 10.0 trở lên."
+
+#: static/js/common-all.js:1900 static/js/impala-all.js:1985 static/js/zamboni/buttons.js:136 static/js/zamboni/discovery-all.js:13171
+msgid "Mozilla has marked this version as incompatible with your Firefox version."
+msgstr "Mozilla đã đánh dấu phiên bản này là không tương thích với phiên bản Firefox của bạn."
+
+#. L10n: {0} is an platform like Windows or Linux.
+#: static/js/common-all.js:1981 static/js/impala-all.js:2066 static/js/zamboni/buttons.js:217 static/js/zamboni/discovery-all.js:13252
+msgid "Install for {0} anyway"
+msgstr "Vẫn cứ cài đặt vào {0}"
+
+#: static/js/common-all.js:1981 static/js/impala-all.js:2066 static/js/zamboni/buttons.js:217 static/js/zamboni/discovery-all.js:13252
+msgid "Download for {0} anyway"
+msgstr "Cứ tải về cho {0}"
+
+#: static/js/common-all.js:2038 static/js/impala-all.js:2123 static/js/zamboni/buttons.js:274 static/js/zamboni/discovery-all.js:13309
+msgid "Not available for your platform"
+msgstr "Không có sẵn cho nền của bạn"
+
+#. L10n: {0} is an app name, {1} is the app version.
+#: static/js/common-all.js:2049 static/js/common-all.js:2086 static/js/impala-all.js:2134 static/js/impala-all.js:2171 static/js/zamboni/buttons.js:286 static/js/zamboni/buttons.js:324
+#: static/js/zamboni/discovery-all.js:13320 static/js/zamboni/discovery-all.js:13357
+msgid "Not available for {0} {1}"
+msgstr "Không có sẵn cho {0} {1}"
+
+#: static/js/common-all.js:2112 static/js/impala-all.js:2197 static/js/zamboni/buttons.js:351 static/js/zamboni/discovery-all.js:13383
+msgid "Works with {app} {min} - {max}"
+msgstr "Hoạt động trên {app} {min} – {max}"
+
+#: static/js/common-all.js:2114 static/js/impala-all.js:2199 static/js/zamboni/buttons.js:353 static/js/zamboni/discovery-all.js:13385
+msgid "View other versions"
+msgstr "Xem các phiên bản khác"
+
+#: static/js/common-all.js:2162 static/js/impala-all.js:2247 static/js/zamboni/buttons.js:401 static/js/zamboni/discovery-all.js:13433
+msgid "Only with Firefox — Get Firefox Now!"
+msgstr ""
+
+#: static/js/common-all.js:2278 static/js/impala-all.js:2363 static/js/zamboni/buttons.js:517 static/js/zamboni/discovery-all.js:13549 static/js/zamboni/mobile-all.js:15177
+#: static/js/zamboni/mobile/buttons.js:43
+msgid "Sorry, you need a Mozilla-based browser (such as Firefox) to install a search plugin."
+msgstr "Rất tiếc, bạn cần phải sử dụng một trình duyệt gốc Mozilla (ví dụ như Firefox) để cài đặt một công cụ tìm kiếm."
+
+#: static/js/common-all.js:9088 static/js/impala-all.js:9649 static/js/zamboni/global.js:410
+msgid "Loading..."
+msgstr ""
+
+#. L10n: {0} is the number of characters left.
+#: static/js/common-all.js:9152 static/js/impala-all.js:9713 static/js/zamboni/global.js:474
+msgid "<b>{0}</b> character left."
+msgid_plural "<b>{0}</b> characters left."
+msgstr[0] ""
+msgstr[1] ""
+
+#: static/js/common-all.js:9589 static/js/common-min.js:6 static/js/impala-all.js:10052 static/js/impala-min.js:6 static/js/common/ratingwidget.js:31 static/js/zamboni/mobile-all.js:16123
+#: static/js/zamboni/mobile-min.js:6
 msgid "{0} star"
 msgid_plural "{0} stars"
 msgstr[0] "{0} sao{0} sao"
+msgstr[1] ""
 
-#: static/js/common/upload-addon.js:41 static/js/common/upload-image.js:128
+#: static/js/common-all.js:9676 static/js/common-min.js:6 static/js/impala-all.js:10139 static/js/impala-min.js:6 static/js/zamboni/l10n.js:45
+msgid "Remove this localization"
+msgstr "Xóa bản dịch này"
+
+#: static/js/common-all.js:10193 static/js/common-min.js:6 static/js/impala-all.js:10674 static/js/impala-min.js:6 static/js/zamboni/discovery-all.js:13678
+msgid "close"
+msgstr ""
+
+#: static/js/common-all.js:10860 static/js/common-min.js:6 static/js/impala-all.js:11481 static/js/impala-min.js:6 static/js/impala/reviews.js:23 static/js/zamboni/reviews.js:18
+msgid "Flagged for review"
+msgstr ""
+
+#: static/js/common-all.js:10876 static/js/common-min.js:6 static/js/impala-all.js:11498 static/js/impala-min.js:6 static/js/impala/reviews.js:40 static/js/zamboni/reviews.js:34
+msgid "Your input is required"
+msgstr ""
+
+#: static/js/common-all.js:10945 static/js/common-min.js:6 static/js/impala-all.js:11610 static/js/impala-min.js:7 static/js/impala/reviews.js:152 static/js/zamboni/reviews.js:103
+msgid "Marked for deletion"
+msgstr ""
+
+#: static/js/common-all.js:11573 static/js/common-min.js:7 static/js/impala-all.js:13809 static/js/impala-min.js:8 static/js/zamboni/collections.js:229
+msgid "Adding to Favorites&hellip;"
+msgstr ""
+
+#: static/js/common-all.js:11576 static/js/common-min.js:7 static/js/impala-all.js:13812 static/js/impala-min.js:8 static/js/zamboni/collections.js:232
+msgid "Removing Favorite&hellip;"
+msgstr ""
+
+#: static/js/common-all.js:11579 static/js/common-min.js:7 static/js/impala-all.js:13815 static/js/impala-min.js:8 static/js/zamboni/collections.js:235
+msgid "Add to Favorites"
+msgstr ""
+
+#: static/js/common-all.js:11582 static/js/common-min.js:7 static/js/impala-all.js:13818 static/js/impala-min.js:8 static/js/zamboni/collections.js:238
+msgid "Remove from Favorites"
+msgstr ""
+
+#: static/js/common-all.js:11647 static/js/common-min.js:7 static/js/impala-all.js:13883 static/js/impala-min.js:8 static/js/zamboni/collections.js:303
+msgid "Pending"
+msgstr "Đang chờ đợi"
+
+#: static/js/common-all.js:11648 static/js/common-min.js:7 static/js/impala-all.js:13884 static/js/impala-min.js:8 static/js/zamboni/collections.js:304
+msgid "Add a comment"
+msgstr "Thêm bình luận"
+
+#: static/js/common-all.js:11648 static/js/common-min.js:7 static/js/impala-all.js:13884 static/js/impala-min.js:8 static/js/zamboni/collections.js:304
+msgid "Comment"
+msgstr "Bình luận"
+
+#: static/js/common-all.js:11649 static/js/common-min.js:7 static/js/impala-all.js:13885 static/js/impala-min.js:8 static/js/zamboni/collections.js:305
+msgid "Remove this add-on from the collection"
+msgstr ""
+
+#: static/js/common-all.js:11649 static/js/common-all.js:11678 static/js/common-min.js:7 static/js/impala-all.js:13885 static/js/impala-all.js:13914 static/js/impala-min.js:8
+#: static/js/zamboni/collections.js:305 static/js/zamboni/collections.js:334
+msgid "Remove"
+msgstr ""
+
+#: static/js/common-all.js:11678 static/js/common-min.js:7 static/js/impala-all.js:13914 static/js/impala-min.js:8 static/js/zamboni/collections.js:334
+msgid "Remove this user as a contributor"
+msgstr ""
+
+#: static/js/common-all.js:11690 static/js/common-min.js:7 static/js/impala-all.js:13926 static/js/impala-min.js:8 static/js/zamboni/collections.js:346
+msgid "An email address is required."
+msgstr "Yêu cầu địa chỉ thư điện tử."
+
+#: static/js/common-all.js:11708 static/js/common-min.js:7 static/js/impala-all.js:13944 static/js/impala-min.js:8 static/js/zamboni/collections.js:364
+msgid "You cannot add yourself as a contributor."
+msgstr ""
+
+#: static/js/common-all.js:11710 static/js/common-min.js:7 static/js/impala-all.js:13946 static/js/impala-min.js:8 static/js/zamboni/collections.js:366
+msgid "You have already added that user."
+msgstr ""
+
+#: static/js/common-all.js:11917 static/js/common-min.js:7 static/js/impala-all.js:14153 static/js/impala-min.js:8 static/js/zamboni/collections.js:573
+msgid "Add to favorites"
+msgstr ""
+
+#: static/js/common-all.js:11921 static/js/common-min.js:7 static/js/impala-all.js:14157 static/js/impala-min.js:8 static/js/zamboni/collections.js:577
+msgid "Remove from favorites"
+msgstr ""
+
+#: static/js/common-all.js:11939 static/js/common-min.js:7 static/js/impala-all.js:14175 static/js/impala-all.js:14233 static/js/impala-min.js:8 static/js/impala/collections.js:10
+#: static/js/zamboni/collections.js:595
+msgid "Follow this Collection"
+msgstr ""
+
+#: static/js/common-all.js:11948 static/js/common-min.js:7 static/js/impala-all.js:14184 static/js/impala-min.js:8 static/js/zamboni/collections.js:604
+msgid "Stop following"
+msgstr ""
+
+#: static/js/common-all.js:12096 static/js/common-min.js:7 static/js/zamboni/password-strength.js:20
+msgid "Password strength:"
+msgstr ""
+
+#: static/js/common-all.js:12102 static/js/common-min.js:7 static/js/zamboni/password-strength.js:26
+msgid "At least {0} character left."
+msgid_plural "At least {0} characters left."
+msgstr[0] "Còn ít nhất {0} ký tự.Còn ít nhất {0} ký tự."
+msgstr[1] ""
+
+#: static/js/common-all.js:12286 static/js/common-min.js:7 static/js/impala-all.js:14632 static/js/impala-min.js:8 static/js/impala/suggestions.js:39
+msgid "Search themes for <b>{0}</b>"
+msgstr "Tìm <b>{0}</b> trong các giao diện"
+
+#: static/js/common-all.js:12288 static/js/common-min.js:7 static/js/impala-all.js:14634 static/js/impala-min.js:8 static/js/impala/suggestions.js:41
+msgid "Search apps for <b>{0}</b>"
+msgstr "Tìm <b>{0}</b> trong các ứng dụng"
+
+#: static/js/common-all.js:12290 static/js/common-min.js:7 static/js/impala-all.js:14636 static/js/impala-min.js:8 static/js/impala/suggestions.js:43
+msgid "Search add-ons for <b>{0}</b>"
+msgstr "Tìm <b>{0}</b> trong các tiện ích"
+
+#: static/js/common-all.js:12521 static/js/common-min.js:7 static/js/impala-all.js:14867 static/js/impala-min.js:8 static/js/impala/site_suggestions.js:46
+msgid "Category"
+msgstr "Phân mục"
+
+#. L10n: {0} is an app name.
+#: static/js/impala-all.js:11632 static/js/impala-min.js:7 static/js/impala/listing.js:11 static/js/zamboni/themes.js:13
+msgid "This theme is incompatible with your version of {0}"
+msgstr ""
+
+#: static/js/impala-all.js:12146 static/js/impala-all.js:14331 static/js/impala-min.js:7 static/js/impala-min.js:8 static/js/common/upload-image.js:97 static/js/impala/users.js:51
+#: static/js/zamboni/devhub-all.js:894 static/js/zamboni/devhub-min.js:1
+msgid "Images must be either PNG or JPG."
+msgstr "Các hình ảnh phải dưới dạng PNG hoặc JPEG."
+
+#: static/js/impala-all.js:12150 static/js/impala-min.js:7 static/js/common/upload-image.js:101 static/js/zamboni/devhub-all.js:898 static/js/zamboni/devhub-min.js:1
+msgid "Videos must be in WebM."
+msgstr "Các video phải dưới dạng WebM."
+
+#: static/js/impala-all.js:12177 static/js/impala-min.js:7 static/js/common/upload-addon.js:41 static/js/common/upload-image.js:128 static/js/zamboni/devhub-all.js:272
+#: static/js/zamboni/devhub-all.js:925 static/js/zamboni/devhub-min.js:1
 msgid "There was a problem contacting the server."
 msgstr ""
 
-#: static/js/common/upload-addon.js:69
+#: static/js/impala-all.js:13298 static/js/impala-min.js:7 static/js/impala/persona_creation.js:60
+msgid "All Rights Reserved"
+msgstr "Bảo lưu toàn quyền"
+
+#: static/js/impala-all.js:13302 static/js/impala-min.js:7 static/js/impala/persona_creation.js:64
+msgid "Creative Commons Attribution 3.0"
+msgstr "Creative Commons Ghi công 3.0"
+
+#: static/js/impala-all.js:13307 static/js/impala-min.js:7 static/js/impala/persona_creation.js:69
+msgid "Creative Commons Attribution-NonCommercial 3.0"
+msgstr "Creative Commons Ghi công/Phi thương mại 3.0"
+
+#: static/js/impala-all.js:13312 static/js/impala-min.js:7 static/js/impala/persona_creation.js:74
+msgid "Creative Commons Attribution-NonCommercial-NoDerivs 3.0"
+msgstr "Creative Commons Ghi công/Phi thương mại/Không phái sinh 3.0"
+
+#: static/js/impala-all.js:13317 static/js/impala-min.js:7 static/js/impala/persona_creation.js:79
+msgid "Creative Commons Attribution-NonCommercial-Share Alike 3.0"
+msgstr "Creative Commons Ghi công/Phi thương mại/Chia sẻ tương tự 3.0"
+
+#: static/js/impala-all.js:13322 static/js/impala-min.js:7 static/js/impala/persona_creation.js:84
+msgid "Creative Commons Attribution-NoDerivs 3.0"
+msgstr "Creative Commons Ghi công/Không phái sinh 3.0"
+
+#: static/js/impala-all.js:13327 static/js/impala-min.js:7 static/js/impala/persona_creation.js:89
+msgid "Creative Commons Attribution-ShareAlike 3.0"
+msgstr "Creative Commons Ghi công/Chia sẻ tương tự 3.0"
+
+#: static/js/impala-all.js:13530 static/js/impala-min.js:7 static/js/impala/persona_creation.js:292
+msgid "Your Theme's Name"
+msgstr "Tên giao diện của bạn"
+
+#: static/js/impala-all.js:14242 static/js/impala-min.js:8 static/js/impala/collections.js:19
+msgid "Stop Following"
+msgstr ""
+
+#: static/js/impala-all.js:14243 static/js/impala-min.js:8 static/js/impala/collections.js:20
+msgid "Following"
+msgstr ""
+
+#: static/js/impala-all.js:14313 static/js/impala-min.js:8 static/js/impala/users.js:33
+msgid "use original"
+msgstr ""
+
+#: static/js/impala-all.js:14523 static/js/impala-min.js:8 static/js/impala/search.js:114
+msgid "Updating results&hellip;"
+msgstr ""
+
+#: static/js/common/upload-addon.js:69 static/js/zamboni/devhub-all.js:300 static/js/zamboni/devhub-min.js:1
 msgid "Select a file..."
 msgstr "Chọn tập tin…"
 
-#: static/js/common/upload-addon.js:70
+#: static/js/common/upload-addon.js:70 static/js/zamboni/devhub-all.js:301 static/js/zamboni/devhub-min.js:1
 msgid "Your add-on should end with .xpi, .jar or .xml"
 msgstr ""
 
 #. L10n: {0} is the percent of the file that has been uploaded.
-#: static/js/common/upload-addon.js:104
+#: static/js/common/upload-addon.js:104 static/js/zamboni/devhub-all.js:335 static/js/zamboni/devhub-min.js:1
 #, python-format
 msgid "{0}% complete"
 msgstr ""
 
 #. L10n: "{bytes uploaded} of {total filesize}".
-#: static/js/common/upload-addon.js:107
+#: static/js/common/upload-addon.js:107 static/js/zamboni/devhub-all.js:338 static/js/zamboni/devhub-min.js:1
 msgid "{0} of {1}"
 msgstr ""
 
-#: static/js/common/upload-addon.js:140
+#: static/js/common/upload-addon.js:140 static/js/zamboni/devhub-all.js:371 static/js/zamboni/devhub-min.js:1
 msgid "Cancel"
 msgstr "Hủy bỏ"
 
-#: static/js/common/upload-addon.js:162
+#: static/js/common/upload-addon.js:162 static/js/zamboni/devhub-all.js:393 static/js/zamboni/devhub-min.js:1
 msgid "Uploading {0}"
 msgstr ""
 
-#: static/js/common/upload-addon.js:189
+#: static/js/common/upload-addon.js:189 static/js/zamboni/devhub-all.js:420 static/js/zamboni/devhub-min.js:1
 msgid "Error with {0}"
 msgstr ""
 
-#: static/js/common/upload-addon.js:194
+#: static/js/common/upload-addon.js:194 static/js/zamboni/devhub-all.js:425 static/js/zamboni/devhub-min.js:1
 msgid "Your add-on failed validation with {0} error."
 msgid_plural "Your add-on failed validation with {0} errors."
 msgstr[0] ""
+msgstr[1] ""
 
-#: static/js/common/upload-addon.js:208
+#: static/js/common/upload-addon.js:208 static/js/zamboni/devhub-all.js:439 static/js/zamboni/devhub-min.js:1
 msgid "&hellip;and {0} more"
 msgid_plural "&hellip;and {0} more"
 msgstr[0] ""
+msgstr[1] ""
 
-#: static/js/common/upload-addon.js:222 static/js/common/upload-addon.js:512
+#: static/js/common/upload-addon.js:222 static/js/common/upload-addon.js:497 static/js/zamboni/devhub-all.js:453 static/js/zamboni/devhub-all.js:743 static/js/zamboni/devhub-min.js:1
 msgid "See full validation report"
 msgstr ""
 
-#: static/js/common/upload-addon.js:234
+#: static/js/common/upload-addon.js:234 static/js/zamboni/devhub-all.js:465 static/js/zamboni/devhub-min.js:1
 msgid "Validating {0}"
 msgstr ""
 
 #. L10n: first argument is an HTTP status code
-#: static/js/common/upload-addon.js:273
+#: static/js/common/upload-addon.js:273 static/js/zamboni/devhub-all.js:504 static/js/zamboni/devhub-min.js:1
 msgid "Received an empty response from the server; status: {0}"
 msgstr ""
 
-#: static/js/common/upload-addon.js:373
+#: static/js/common/upload-addon.js:370 static/js/zamboni/devhub-all.js:604 static/js/zamboni/devhub-min.js:1
 msgid "Unexpected server error while validating."
 msgstr ""
 
-#: static/js/common/upload-addon.js:412
+#: static/js/common/upload-addon.js:409 static/js/zamboni/devhub-all.js:643 static/js/zamboni/devhub-min.js:1
 msgid "Finished validating {0}"
 msgstr ""
 
-#: static/js/common/upload-addon.js:418
+#: static/js/common/upload-addon.js:415 static/js/zamboni/devhub-all.js:649 static/js/zamboni/devhub-min.js:1
 msgid "Your add-on validation timed out, it will be manually reviewed."
 msgstr ""
 
-#: static/js/common/upload-addon.js:421
+#: static/js/common/upload-addon.js:418 static/js/zamboni/devhub-all.js:652 static/js/zamboni/devhub-min.js:1
 msgid "Your add-on was validated with no errors and {0} warning."
 msgid_plural "Your add-on was validated with no errors and {0} warnings."
 msgstr[0] ""
+msgstr[1] ""
 
-#: static/js/common/upload-addon.js:426
+#: static/js/common/upload-addon.js:423 static/js/zamboni/devhub-all.js:657 static/js/zamboni/devhub-min.js:1
 msgid "Your add-on was validated with no errors and {0} message."
 msgid_plural "Your add-on was validated with no errors and {0} messages."
 msgstr[0] ""
+msgstr[1] ""
 
-#: static/js/common/upload-addon.js:431
+#: static/js/common/upload-addon.js:428 static/js/zamboni/devhub-all.js:662 static/js/zamboni/devhub-min.js:1
 msgid "Your add-on was validated with no errors or warnings."
 msgstr ""
 
-#: static/js/common/upload-addon.js:446
+#: static/js/common/upload-addon.js:443 static/js/zamboni/devhub-all.js:677 static/js/zamboni/devhub-min.js:1
 msgid "Your submission will be automatically signed."
 msgstr ""
 
-#: static/js/common/upload-addon.js:465
+#: static/js/common/upload-addon.js:450 static/js/zamboni/devhub-all.js:696 static/js/zamboni/devhub-min.js:1
 msgid "Include detailed version notes (this can be done in the next step)."
 msgstr ""
 
-#: static/js/common/upload-addon.js:466
+#: static/js/common/upload-addon.js:451 static/js/zamboni/devhub-all.js:697 static/js/zamboni/devhub-min.js:1
 msgid "If your add-on requires an account to a website in order to be fully tested, include a test username and password in the Notes to Reviewer (this can be done in the next step)."
 msgstr ""
 
-#: static/js/common/upload-addon.js:467
+#: static/js/common/upload-addon.js:452 static/js/zamboni/devhub-all.js:698 static/js/zamboni/devhub-min.js:1
 msgid "If your add-on is intended for a limited audience you should choose Preliminary Review instead of Full Review."
 msgstr ""
 
-#: static/js/common/upload-addon.js:480
+#: static/js/common/upload-addon.js:465 static/js/zamboni/devhub-all.js:711 static/js/zamboni/devhub-min.js:1
 msgid "Add-on submission checklist"
 msgstr ""
 
-#: static/js/common/upload-addon.js:481
+#: static/js/common/upload-addon.js:466 static/js/zamboni/devhub-all.js:712 static/js/zamboni/devhub-min.js:1
 msgid "Please verify the following points before finalizing your submission. This will minimize delays or misunderstanding during the review process:"
 msgstr ""
 
-#: static/js/common/upload-addon.js:483
+#: static/js/common/upload-addon.js:468 static/js/zamboni/devhub-all.js:714 static/js/zamboni/devhub-min.js:1
 msgid ""
 "Compiled binaries, as well as minified or obfuscated scripts (excluding known libraries) need to have their sources submitted separately for review. Make sure that you use the source code upload "
 "field to avoid having your submission rejected."
 msgstr ""
 
-#: static/js/common/upload-addon.js:501
+#: static/js/common/upload-addon.js:486 static/js/zamboni/devhub-all.js:732 static/js/zamboni/devhub-min.js:1
 msgid "The validation process found these issues that can lead to rejections:"
 msgstr ""
 
-#: static/js/common/upload-addon.js:518
+#: static/js/common/upload-addon.js:503 static/js/zamboni/devhub-all.js:749 static/js/zamboni/devhub-min.js:1
 msgid "If you are unfamiliar with the add-ons review process, you can read about it here."
 msgstr ""
 
-#: static/js/common/upload-addon.js:555
+#: static/js/common/upload-addon.js:540 static/js/zamboni/devhub-all.js:786 static/js/zamboni/devhub-min.js:1
 msgid "Sorry, no supported platform has been found."
 msgstr "Rất tiếc, không tìm thấy nền tảng nào được hỗ trợ."
 
-#: static/js/common/upload-base.js:57
+#: static/js/common/upload-base.js:57 static/js/zamboni/devhub-all.js:187 static/js/zamboni/devhub-min.js:1
 msgid "The filetype you uploaded isn't recognized."
 msgstr ""
 
-#: static/js/common/upload-base.js:79
+#: static/js/common/upload-base.js:79 static/js/zamboni/devhub-all.js:209 static/js/zamboni/devhub-min.js:1
 msgid "You cancelled the upload."
 msgstr ""
 
-#: static/js/common/upload-image.js:97 static/js/impala/users.js:51
-msgid "Images must be either PNG or JPG."
-msgstr "Các hình ảnh phải dưới dạng PNG hoặc JPEG."
-
-#: static/js/common/upload-image.js:101
-msgid "Videos must be in WebM."
-msgstr "Các video phải dưới dạng WebM."
-
-#: static/js/impala/collections.js:10 static/js/zamboni/collections.js:595
-msgid "Follow this Collection"
-msgstr ""
-
-#: static/js/impala/collections.js:19
-msgid "Stop Following"
-msgstr ""
-
-#: static/js/impala/collections.js:20
-msgid "Following"
-msgstr ""
-
-#. L10n: {0} is an app name.
-#: static/js/impala/listing.js:11 static/js/zamboni/themes.js:13
-msgid "This theme is incompatible with your version of {0}"
-msgstr ""
-
-#: static/js/impala/persona_creation.js:60
-msgid "All Rights Reserved"
-msgstr "Bảo lưu toàn quyền"
-
-#: static/js/impala/persona_creation.js:64
-msgid "Creative Commons Attribution 3.0"
-msgstr "Creative Commons Ghi công 3.0"
-
-#: static/js/impala/persona_creation.js:69
-msgid "Creative Commons Attribution-NonCommercial 3.0"
-msgstr "Creative Commons Ghi công/Phi thương mại 3.0"
-
-#: static/js/impala/persona_creation.js:74
-msgid "Creative Commons Attribution-NonCommercial-NoDerivs 3.0"
-msgstr "Creative Commons Ghi công/Phi thương mại/Không phái sinh 3.0"
-
-#: static/js/impala/persona_creation.js:79
-msgid "Creative Commons Attribution-NonCommercial-Share Alike 3.0"
-msgstr "Creative Commons Ghi công/Phi thương mại/Chia sẻ tương tự 3.0"
-
-#: static/js/impala/persona_creation.js:84
-msgid "Creative Commons Attribution-NoDerivs 3.0"
-msgstr "Creative Commons Ghi công/Không phái sinh 3.0"
-
-#: static/js/impala/persona_creation.js:89
-msgid "Creative Commons Attribution-ShareAlike 3.0"
-msgstr "Creative Commons Ghi công/Chia sẻ tương tự 3.0"
-
-#: static/js/impala/persona_creation.js:292
-msgid "Your Theme's Name"
-msgstr "Tên giao diện của bạn"
-
-#: static/js/impala/reviews.js:23 static/js/zamboni/reviews.js:18
-msgid "Flagged for review"
-msgstr ""
-
-#: static/js/impala/reviews.js:40 static/js/zamboni/reviews.js:34
-msgid "Your input is required"
-msgstr ""
-
-#: static/js/impala/reviews.js:152 static/js/zamboni/reviews.js:103
-msgid "Marked for deletion"
-msgstr ""
-
-#: static/js/impala/search.js:114
-msgid "Updating results&hellip;"
-msgstr ""
-
-#: static/js/impala/site_suggestions.js:46
-msgid "Category"
-msgstr "Phân mục"
-
-#: static/js/impala/suggestions.js:39
-msgid "Search themes for <b>{0}</b>"
-msgstr "Tìm <b>{0}</b> trong các giao diện"
-
-#: static/js/impala/suggestions.js:41
-msgid "Search apps for <b>{0}</b>"
-msgstr "Tìm <b>{0}</b> trong các ứng dụng"
-
-#: static/js/impala/suggestions.js:43
-msgid "Search add-ons for <b>{0}</b>"
-msgstr "Tìm <b>{0}</b> trong các tiện ích"
-
-#: static/js/impala/users.js:33
-msgid "use original"
-msgstr ""
-
-#: static/js/impala/stats/chart.js:267
+#: static/js/impala/stats/chart.js:267 static/js/zamboni/stats-all.js:16898 static/js/zamboni/stats-min.js:5
 msgid "Week of {0}"
 msgstr "Tuần {0}"
 
-#: static/js/impala/stats/chart.js:269
+#: static/js/impala/stats/chart.js:269 static/js/zamboni/stats-all.js:16900 static/js/zamboni/stats-min.js:5
 msgid " downloads"
 msgstr ""
 
-#: static/js/impala/stats/chart.js:270
+#: static/js/impala/stats/chart.js:270 static/js/zamboni/stats-all.js:16901 static/js/zamboni/stats-min.js:5
 msgid "{0} users"
 msgstr "{0} người dùng"
 
-#: static/js/impala/stats/chart.js:271
+#: static/js/impala/stats/chart.js:271 static/js/zamboni/stats-all.js:16902 static/js/zamboni/stats-min.js:5
 msgid "{0} add-ons"
 msgstr "{0} tiện ích"
 
-#: static/js/impala/stats/chart.js:272
+#: static/js/impala/stats/chart.js:272 static/js/zamboni/stats-all.js:16903 static/js/zamboni/stats-min.js:5
 msgid "{0} collections"
 msgstr "{0} bộ sưu tập"
 
-#: static/js/impala/stats/chart.js:273
+#: static/js/impala/stats/chart.js:273 static/js/zamboni/stats-all.js:16904 static/js/zamboni/stats-min.js:5
 msgid "{0} reviews"
 msgstr "{0} đánh giá"
 
-#: static/js/impala/stats/chart.js:275
+#: static/js/impala/stats/chart.js:275 static/js/zamboni/stats-all.js:16906 static/js/zamboni/stats-min.js:5
 msgid "{0} sales"
 msgstr ""
 
-#: static/js/impala/stats/chart.js:276
+#: static/js/impala/stats/chart.js:276 static/js/zamboni/stats-all.js:16907 static/js/zamboni/stats-min.js:5
 msgid "{0} refunds"
 msgstr ""
 
-#: static/js/impala/stats/chart.js:277
+#: static/js/impala/stats/chart.js:277 static/js/zamboni/stats-all.js:16908 static/js/zamboni/stats-min.js:5
 msgid "{0} installs"
 msgstr "{0} lần cài đặt"
 
-#: static/js/impala/stats/chart.js:369 static/js/impala/stats/csv_keys.js:3 static/js/impala/stats/csv_keys.js:109
+#: static/js/impala/stats/chart.js:369 static/js/impala/stats/csv_keys.js:3 static/js/impala/stats/csv_keys.js:109 static/js/zamboni/stats-all.js:15284 static/js/zamboni/stats-all.js:15390
+#: static/js/zamboni/stats-all.js:17000 static/js/zamboni/stats-min.js:4 static/js/zamboni/stats-min.js:5
 msgid "Downloads"
 msgstr ""
 
-#: static/js/impala/stats/chart.js:379 static/js/impala/stats/csv_keys.js:6 static/js/impala/stats/csv_keys.js:110
+#: static/js/impala/stats/chart.js:379 static/js/impala/stats/csv_keys.js:6 static/js/impala/stats/csv_keys.js:110 static/js/zamboni/stats-all.js:15287 static/js/zamboni/stats-all.js:15391
+#: static/js/zamboni/stats-all.js:17010 static/js/zamboni/stats-min.js:4 static/js/zamboni/stats-min.js:5
 msgid "Daily Users"
 msgstr "Người dùng Hàng ngày"
 
-#: static/js/impala/stats/chart.js:410
+#: static/js/impala/stats/chart.js:410 static/js/zamboni/stats-all.js:17041 static/js/zamboni/stats-min.js:5
 msgid "Amount, in USD"
 msgstr ""
 
-#: static/js/impala/stats/chart.js:421 static/js/impala/stats/csv_keys.js:104
+#: static/js/impala/stats/chart.js:421 static/js/impala/stats/csv_keys.js:104 static/js/zamboni/stats-all.js:15385 static/js/zamboni/stats-all.js:17052 static/js/zamboni/stats-min.js:5
 msgid "Number of Contributions"
 msgstr ""
 
-#: static/js/impala/stats/chart.js:447
+#: static/js/impala/stats/chart.js:447 static/js/zamboni/stats-all.js:17078 static/js/zamboni/stats-min.js:5
 msgid "More Info..."
 msgstr "Thêm thông tin…"
 
 #. L10n: {0} is an ISO-formatted date.
-#: static/js/impala/stats/chart.js:451
+#: static/js/impala/stats/chart.js:451 static/js/zamboni/stats-all.js:17082 static/js/zamboni/stats-min.js:5
 msgid "Details for {0}"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:9
+#: static/js/impala/stats/csv_keys.js:9 static/js/zamboni/stats-all.js:15290 static/js/zamboni/stats-min.js:4
 msgid "Collections Created"
 msgstr "Bộ sưu tập được Tạo ra"
 
-#: static/js/impala/stats/csv_keys.js:12
+#: static/js/impala/stats/csv_keys.js:12 static/js/zamboni/stats-all.js:15293 static/js/zamboni/stats-min.js:4
 msgid "Add-ons in Use"
 msgstr "Số Tiện ích được Sử dụng"
 
-#: static/js/impala/stats/csv_keys.js:15
+#: static/js/impala/stats/csv_keys.js:15 static/js/zamboni/stats-all.js:15296 static/js/zamboni/stats-min.js:4
 msgid "Add-ons Created"
 msgstr "Số Tiện ích được Tạo"
 
-#: static/js/impala/stats/csv_keys.js:18
+#: static/js/impala/stats/csv_keys.js:18 static/js/zamboni/stats-all.js:15299 static/js/zamboni/stats-min.js:4
 msgid "Add-ons Downloaded"
 msgstr "Số Tiện ích được Tải về"
 
-#: static/js/impala/stats/csv_keys.js:21
+#: static/js/impala/stats/csv_keys.js:21 static/js/zamboni/stats-all.js:15302 static/js/zamboni/stats-min.js:4
 msgid "Add-ons Updated"
 msgstr "Số Tiện ích được Cập nhật"
 
-#: static/js/impala/stats/csv_keys.js:24
+#: static/js/impala/stats/csv_keys.js:24 static/js/zamboni/stats-all.js:15305 static/js/zamboni/stats-min.js:4
 msgid "Reviews Written"
 msgstr "Số bài xem xét được viết"
 
-#: static/js/impala/stats/csv_keys.js:27
+#: static/js/impala/stats/csv_keys.js:27 static/js/zamboni/stats-all.js:15308 static/js/zamboni/stats-min.js:4
 msgid "User Signups"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:30
+#: static/js/impala/stats/csv_keys.js:30 static/js/zamboni/stats-all.js:15311 static/js/zamboni/stats-min.js:4
 msgid "Subscribers"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:33
+#: static/js/impala/stats/csv_keys.js:33 static/js/zamboni/stats-all.js:15314 static/js/zamboni/stats-min.js:4
 msgid "Ratings"
 msgstr "Số đánh giá"
 
-#: static/js/impala/stats/csv_keys.js:36 static/js/impala/stats/csv_keys.js:114
+#: static/js/impala/stats/csv_keys.js:36 static/js/impala/stats/csv_keys.js:114 static/js/zamboni/stats-all.js:15317 static/js/zamboni/stats-all.js:15395 static/js/zamboni/stats-min.js:4
+#: static/js/zamboni/stats-min.js:5
 msgid "Sales"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:39 static/js/impala/stats/csv_keys.js:113
+#: static/js/impala/stats/csv_keys.js:39 static/js/impala/stats/csv_keys.js:113 static/js/zamboni/stats-all.js:15320 static/js/zamboni/stats-all.js:15394 static/js/zamboni/stats-min.js:4
+#: static/js/zamboni/stats-min.js:5
 msgid "Installs"
 msgstr "Lần Cài đặt"
 
-#: static/js/impala/stats/csv_keys.js:42
+#: static/js/impala/stats/csv_keys.js:42 static/js/zamboni/stats-all.js:15323 static/js/zamboni/stats-min.js:4
 msgid "Unknown"
 msgstr "Không rõ"
 
-#: static/js/impala/stats/csv_keys.js:43
+#: static/js/impala/stats/csv_keys.js:43 static/js/zamboni/stats-all.js:15324 static/js/zamboni/stats-min.js:4
 msgid "Add-ons Manager"
 msgstr "Trình Quản lý Tiện ích"
 
-#: static/js/impala/stats/csv_keys.js:44
+#: static/js/impala/stats/csv_keys.js:44 static/js/zamboni/stats-all.js:15325 static/js/zamboni/stats-min.js:4
 msgid "Add-ons Manager Promo"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:45
+#: static/js/impala/stats/csv_keys.js:45 static/js/zamboni/stats-all.js:15326 static/js/zamboni/stats-min.js:4
 msgid "Add-ons Manager Featured"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:46
+#: static/js/impala/stats/csv_keys.js:46 static/js/zamboni/stats-all.js:15327 static/js/zamboni/stats-min.js:4
 msgid "Add-ons Manager Learn More"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:47
+#: static/js/impala/stats/csv_keys.js:47 static/js/zamboni/stats-all.js:15328 static/js/zamboni/stats-min.js:4
 msgid "Search Suggestions"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:48
+#: static/js/impala/stats/csv_keys.js:48 static/js/zamboni/stats-all.js:15329 static/js/zamboni/stats-min.js:4
 msgid "Search Results"
 msgstr "Kết quả tìm kiếm"
 
-#: static/js/impala/stats/csv_keys.js:49 static/js/impala/stats/csv_keys.js:50 static/js/impala/stats/csv_keys.js:51
+#: static/js/impala/stats/csv_keys.js:49 static/js/impala/stats/csv_keys.js:50 static/js/impala/stats/csv_keys.js:51 static/js/zamboni/stats-all.js:15330 static/js/zamboni/stats-all.js:15331
+#: static/js/zamboni/stats-all.js:15332 static/js/zamboni/stats-min.js:4
 msgid "Homepage Promo"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:52 static/js/impala/stats/csv_keys.js:53
+#: static/js/impala/stats/csv_keys.js:52 static/js/impala/stats/csv_keys.js:53 static/js/zamboni/stats-all.js:15333 static/js/zamboni/stats-all.js:15334 static/js/zamboni/stats-min.js:4
 msgid "Homepage Featured"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:54 static/js/impala/stats/csv_keys.js:55
+#: static/js/impala/stats/csv_keys.js:54 static/js/impala/stats/csv_keys.js:55 static/js/zamboni/stats-all.js:15335 static/js/zamboni/stats-all.js:15336 static/js/zamboni/stats-min.js:4
 msgid "Homepage Up and Coming"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:56
+#: static/js/impala/stats/csv_keys.js:56 static/js/zamboni/stats-all.js:15337 static/js/zamboni/stats-min.js:4
 msgid "Homepage Most Popular"
 msgstr "Thông dụng Nhất trên Trang chủ"
 
-#: static/js/impala/stats/csv_keys.js:57 static/js/impala/stats/csv_keys.js:59
+#: static/js/impala/stats/csv_keys.js:57 static/js/impala/stats/csv_keys.js:59 static/js/zamboni/stats-all.js:15338 static/js/zamboni/stats-all.js:15340 static/js/zamboni/stats-min.js:4
 msgid "Detail Page"
 msgstr "Trang Chi tiết"
 
-#: static/js/impala/stats/csv_keys.js:58 static/js/impala/stats/csv_keys.js:60
+#: static/js/impala/stats/csv_keys.js:58 static/js/impala/stats/csv_keys.js:60 static/js/zamboni/stats-all.js:15339 static/js/zamboni/stats-all.js:15341 static/js/zamboni/stats-min.js:4
 msgid "Detail Page (bottom)"
 msgstr "Trang Chi tiết (cuối)"
 
-#: static/js/impala/stats/csv_keys.js:61
+#: static/js/impala/stats/csv_keys.js:61 static/js/zamboni/stats-all.js:15342 static/js/zamboni/stats-min.js:4
 msgid "Detail Page (Development Channel)"
 msgstr "Trang Chi tiết (Kênh Phát triển)"
 
-#: static/js/impala/stats/csv_keys.js:62 static/js/impala/stats/csv_keys.js:63 static/js/impala/stats/csv_keys.js:64
+#: static/js/impala/stats/csv_keys.js:62 static/js/impala/stats/csv_keys.js:63 static/js/impala/stats/csv_keys.js:64 static/js/zamboni/stats-all.js:15343 static/js/zamboni/stats-all.js:15344
+#: static/js/zamboni/stats-all.js:15345 static/js/zamboni/stats-min.js:4
 msgid "Often Used With"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:65 static/js/impala/stats/csv_keys.js:66
+#: static/js/impala/stats/csv_keys.js:65 static/js/impala/stats/csv_keys.js:66 static/js/zamboni/stats-all.js:15346 static/js/zamboni/stats-all.js:15347 static/js/zamboni/stats-min.js:4
 msgid "Others By Author"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:67 static/js/impala/stats/csv_keys.js:68
+#: static/js/impala/stats/csv_keys.js:67 static/js/impala/stats/csv_keys.js:68 static/js/zamboni/stats-all.js:15348 static/js/zamboni/stats-all.js:15349 static/js/zamboni/stats-min.js:4
 msgid "Dependencies"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:69 static/js/impala/stats/csv_keys.js:70
+#: static/js/impala/stats/csv_keys.js:69 static/js/impala/stats/csv_keys.js:70 static/js/zamboni/stats-all.js:15350 static/js/zamboni/stats-all.js:15351 static/js/zamboni/stats-min.js:4
 msgid "Upsell"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:71
+#: static/js/impala/stats/csv_keys.js:71 static/js/zamboni/stats-all.js:15352 static/js/zamboni/stats-min.js:4
 msgid "Meet the Developer"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:72
+#: static/js/impala/stats/csv_keys.js:72 static/js/zamboni/stats-all.js:15353 static/js/zamboni/stats-min.js:4
 msgid "User Profile"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:73
+#: static/js/impala/stats/csv_keys.js:73 static/js/zamboni/stats-all.js:15354 static/js/zamboni/stats-min.js:4
 msgid "Version History"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:75
+#: static/js/impala/stats/csv_keys.js:75 static/js/zamboni/stats-all.js:15356 static/js/zamboni/stats-min.js:4
 msgid "Sharing"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:76
+#: static/js/impala/stats/csv_keys.js:76 static/js/zamboni/stats-all.js:15357 static/js/zamboni/stats-min.js:4
 msgid "Category Pages"
 msgstr "Trang Phân mục"
 
-#: static/js/impala/stats/csv_keys.js:77
+#: static/js/impala/stats/csv_keys.js:77 static/js/zamboni/stats-all.js:15358 static/js/zamboni/stats-min.js:4
 msgid "Collections"
 msgstr "Bộ sưu tập"
 
-#: static/js/impala/stats/csv_keys.js:78 static/js/impala/stats/csv_keys.js:79
+#: static/js/impala/stats/csv_keys.js:78 static/js/impala/stats/csv_keys.js:79 static/js/zamboni/stats-all.js:15359 static/js/zamboni/stats-all.js:15360 static/js/zamboni/stats-min.js:4
 msgid "Category Landing Featured Carousel"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:80 static/js/impala/stats/csv_keys.js:81
+#: static/js/impala/stats/csv_keys.js:80 static/js/impala/stats/csv_keys.js:81 static/js/zamboni/stats-all.js:15361 static/js/zamboni/stats-all.js:15362 static/js/zamboni/stats-min.js:4
 msgid "Category Landing Top Rated"
 msgstr "Trang đầu Phân mục Xếp hạng Cao nhất"
 
-#: static/js/impala/stats/csv_keys.js:82 static/js/impala/stats/csv_keys.js:83
+#: static/js/impala/stats/csv_keys.js:82 static/js/impala/stats/csv_keys.js:83 static/js/zamboni/stats-all.js:15363 static/js/zamboni/stats-all.js:15364 static/js/zamboni/stats-min.js:5
 msgid "Category Landing Most Popular"
 msgstr "Trang đầu Phân mục Thông dụng Nhất"
 
-#: static/js/impala/stats/csv_keys.js:84 static/js/impala/stats/csv_keys.js:85
+#: static/js/impala/stats/csv_keys.js:84 static/js/impala/stats/csv_keys.js:85 static/js/zamboni/stats-all.js:15365 static/js/zamboni/stats-all.js:15366 static/js/zamboni/stats-min.js:5
 msgid "Category Landing Recently Added"
 msgstr "Trang đầu Phân mục Đã thêm Gần đây"
 
-#: static/js/impala/stats/csv_keys.js:86 static/js/impala/stats/csv_keys.js:87
+#: static/js/impala/stats/csv_keys.js:86 static/js/impala/stats/csv_keys.js:87 static/js/zamboni/stats-all.js:15367 static/js/zamboni/stats-all.js:15368 static/js/zamboni/stats-min.js:5
 msgid "Browse Listing Featured Sort"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:88 static/js/impala/stats/csv_keys.js:89
+#: static/js/impala/stats/csv_keys.js:88 static/js/impala/stats/csv_keys.js:89 static/js/zamboni/stats-all.js:15369 static/js/zamboni/stats-all.js:15370 static/js/zamboni/stats-min.js:5
 msgid "Browse Listing Users Sort"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:90 static/js/impala/stats/csv_keys.js:91
+#: static/js/impala/stats/csv_keys.js:90 static/js/impala/stats/csv_keys.js:91 static/js/zamboni/stats-all.js:15371 static/js/zamboni/stats-all.js:15372 static/js/zamboni/stats-min.js:5
 msgid "Browse Listing Rating Sort"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:92 static/js/impala/stats/csv_keys.js:93
+#: static/js/impala/stats/csv_keys.js:92 static/js/impala/stats/csv_keys.js:93 static/js/zamboni/stats-all.js:15373 static/js/zamboni/stats-all.js:15374 static/js/zamboni/stats-min.js:5
 msgid "Browse Listing Created Sort"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:94 static/js/impala/stats/csv_keys.js:95
+#: static/js/impala/stats/csv_keys.js:94 static/js/impala/stats/csv_keys.js:95 static/js/zamboni/stats-all.js:15375 static/js/zamboni/stats-all.js:15376 static/js/zamboni/stats-min.js:5
 msgid "Browse Listing Name Sort"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:96 static/js/impala/stats/csv_keys.js:97
+#: static/js/impala/stats/csv_keys.js:96 static/js/impala/stats/csv_keys.js:97 static/js/zamboni/stats-all.js:15377 static/js/zamboni/stats-all.js:15378 static/js/zamboni/stats-min.js:5
 msgid "Browse Listing Popular Sort"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:98 static/js/impala/stats/csv_keys.js:99
+#: static/js/impala/stats/csv_keys.js:98 static/js/impala/stats/csv_keys.js:99 static/js/zamboni/stats-all.js:15379 static/js/zamboni/stats-all.js:15380 static/js/zamboni/stats-min.js:5
 msgid "Browse Listing Updated Sort"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:100 static/js/impala/stats/csv_keys.js:101
+#: static/js/impala/stats/csv_keys.js:100 static/js/impala/stats/csv_keys.js:101 static/js/zamboni/stats-all.js:15381 static/js/zamboni/stats-all.js:15382 static/js/zamboni/stats-min.js:5
 msgid "Browse Listing Up and Coming Sort"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:105
+#: static/js/impala/stats/csv_keys.js:105 static/js/zamboni/stats-all.js:15386 static/js/zamboni/stats-min.js:5
 msgid "Total Amount Contributed"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:106
+#: static/js/impala/stats/csv_keys.js:106 static/js/zamboni/stats-all.js:15387 static/js/zamboni/stats-min.js:5
 msgid "Average Contribution"
 msgstr "Khoản góp Trung bình"
 
-#: static/js/impala/stats/csv_keys.js:115
+#: static/js/impala/stats/csv_keys.js:115 static/js/zamboni/stats-all.js:15396 static/js/zamboni/stats-min.js:5
 msgid "Usage"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:118
+#: static/js/impala/stats/csv_keys.js:118 static/js/zamboni/stats-all.js:15399 static/js/zamboni/stats-min.js:5
 msgid "Firefox"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:119
+#: static/js/impala/stats/csv_keys.js:119 static/js/zamboni/stats-all.js:15400 static/js/zamboni/stats-min.js:5
 msgid "Mozilla"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:120
+#: static/js/impala/stats/csv_keys.js:120 static/js/zamboni/stats-all.js:15401 static/js/zamboni/stats-min.js:5
 msgid "Thunderbird"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:121
+#: static/js/impala/stats/csv_keys.js:121 static/js/zamboni/stats-all.js:15402 static/js/zamboni/stats-min.js:5
 msgid "Sunbird"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:122
+#: static/js/impala/stats/csv_keys.js:122 static/js/zamboni/stats-all.js:15403 static/js/zamboni/stats-min.js:5
 msgid "SeaMonkey"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:123
+#: static/js/impala/stats/csv_keys.js:123 static/js/zamboni/stats-all.js:15404 static/js/zamboni/stats-min.js:5
 msgid "Fennec"
 msgstr ""
 
-#: static/js/impala/stats/csv_keys.js:124
+#: static/js/impala/stats/csv_keys.js:124 static/js/zamboni/stats-all.js:15405 static/js/zamboni/stats-min.js:5
 msgid "Android"
 msgstr ""
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:129
+#: static/js/impala/stats/csv_keys.js:129 static/js/zamboni/stats-all.js:15410 static/js/zamboni/stats-min.js:5
 msgid "Downloads and Daily Users, last {0} days"
 msgstr "Lượt tải và Người dùng Hàng ngày, {0} ngày trước"
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:131
+#: static/js/impala/stats/csv_keys.js:131 static/js/zamboni/stats-all.js:15412 static/js/zamboni/stats-min.js:5
 msgid "Downloads and Daily Users from {0} to {1}"
 msgstr "Lần Cài đặt và Người dùng Hàng ngày từ {0} đến {1}"
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:135
+#: static/js/impala/stats/csv_keys.js:135 static/js/zamboni/stats-all.js:15416 static/js/zamboni/stats-min.js:5
 msgid "Installs and Daily Users, last {0} days"
 msgstr "Lần Cài đặt và Người dùng Hàng ngày, {0} ngày trước"
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:137
+#: static/js/impala/stats/csv_keys.js:137 static/js/zamboni/stats-all.js:15418 static/js/zamboni/stats-min.js:5
 msgid "Installs and Daily Users from {0} to {1}"
 msgstr "Lần Cài đặt và Người dùng Hàng ngày từ {0} đến {1}"
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:141
+#: static/js/impala/stats/csv_keys.js:141 static/js/zamboni/stats-all.js:15422 static/js/zamboni/stats-min.js:5
 msgid "Downloads, last {0} days"
 msgstr "Lượt tải, {0} ngày trước"
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:143
+#: static/js/impala/stats/csv_keys.js:143 static/js/zamboni/stats-all.js:15424 static/js/zamboni/stats-min.js:5
 msgid "Downloads from {0} to {1}"
 msgstr "Lượt tải từ {0} đến {1}"
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:147
+#: static/js/impala/stats/csv_keys.js:147 static/js/zamboni/stats-all.js:15428 static/js/zamboni/stats-min.js:5
 msgid "Daily Users, last {0} days"
 msgstr "Người dùng Hàng ngày, {0} ngày trước"
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:149
+#: static/js/impala/stats/csv_keys.js:149 static/js/zamboni/stats-all.js:15430 static/js/zamboni/stats-min.js:5
 msgid "Daily Users from {0} to {1}"
 msgstr "Người dùng Hàng ngày từ {0} đến {1}"
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:153
+#: static/js/impala/stats/csv_keys.js:153 static/js/zamboni/stats-all.js:15434 static/js/zamboni/stats-min.js:5
 msgid "Applications, last {0} days"
 msgstr "Ứng dụng, {0} ngày truớc"
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:155
+#: static/js/impala/stats/csv_keys.js:155 static/js/zamboni/stats-all.js:15436 static/js/zamboni/stats-min.js:5
 msgid "Applications from {0} to {1}"
 msgstr "Ứng dụng từ {0} đến {1}"
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:159
+#: static/js/impala/stats/csv_keys.js:159 static/js/zamboni/stats-all.js:15440 static/js/zamboni/stats-min.js:5
 msgid "Platforms, last {0} days"
 msgstr "Nền tảng, {0} ngày trước"
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:161
+#: static/js/impala/stats/csv_keys.js:161 static/js/zamboni/stats-all.js:15442 static/js/zamboni/stats-min.js:5
 msgid "Platforms from {0} to {1}"
 msgstr "Nền tảng từ {0} đến {1}"
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:165
+#: static/js/impala/stats/csv_keys.js:165 static/js/zamboni/stats-all.js:15446 static/js/zamboni/stats-min.js:5
 msgid "Languages, last {0} days"
 msgstr "Ngôn ngữ, {0} ngày trước"
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:167
+#: static/js/impala/stats/csv_keys.js:167 static/js/zamboni/stats-all.js:15448 static/js/zamboni/stats-min.js:5
 msgid "Languages from {0} to {1}"
 msgstr "Ngôn ngữ từ {0} đến {1}"
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:171
+#: static/js/impala/stats/csv_keys.js:171 static/js/zamboni/stats-all.js:15452 static/js/zamboni/stats-min.js:5
 msgid "Add-on Versions, last {0} days"
 msgstr "Phiên bản Tiện ích, {0} ngày trước"
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:173
+#: static/js/impala/stats/csv_keys.js:173 static/js/zamboni/stats-all.js:15454 static/js/zamboni/stats-min.js:5
 msgid "Add-on Versions from {0} to {1}"
 msgstr "Phiên bản Tiện ích từ {0} đến {1}"
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:177
+#: static/js/impala/stats/csv_keys.js:177 static/js/zamboni/stats-all.js:15458 static/js/zamboni/stats-min.js:5
 msgid "Add-on Status, last {0} days"
 msgstr "Trạng thái Tiện ích, {0} ngày trước"
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:179
+#: static/js/impala/stats/csv_keys.js:179 static/js/zamboni/stats-all.js:15460 static/js/zamboni/stats-min.js:5
 msgid "Add-on Status from {0} to {1}"
 msgstr "Trạng thái Tiện ích từ {0} đến {1}"
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:183
+#: static/js/impala/stats/csv_keys.js:183 static/js/zamboni/stats-all.js:15464 static/js/zamboni/stats-min.js:5
 msgid "Download Sources, last {0} days"
 msgstr "Nguồn Tải về, {0} ngày trước"
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:185
+#: static/js/impala/stats/csv_keys.js:185 static/js/zamboni/stats-all.js:15466 static/js/zamboni/stats-min.js:5
 msgid "Download Sources from {0} to {1}"
 msgstr "Nguồn Tải về từ {0} đến {1}"
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:189
+#: static/js/impala/stats/csv_keys.js:189 static/js/zamboni/stats-all.js:15470 static/js/zamboni/stats-min.js:5
 msgid "Contributions, last {0} days"
 msgstr "Khoản Đóng góp, {0} ngày trước"
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:191
+#: static/js/impala/stats/csv_keys.js:191 static/js/zamboni/stats-all.js:15472 static/js/zamboni/stats-min.js:5
 msgid "Contributions from {0} to {1}"
 msgstr "Khoảng Đóng góp từ {0} đến {1}"
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:195
+#: static/js/impala/stats/csv_keys.js:195 static/js/zamboni/stats-all.js:15476 static/js/zamboni/stats-min.js:5
 msgid "Site Metrics, last {0} days"
 msgstr ""
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:197
+#: static/js/impala/stats/csv_keys.js:197 static/js/zamboni/stats-all.js:15478 static/js/zamboni/stats-min.js:5
 msgid "Site Metrics from {0} to {1}"
 msgstr ""
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:201
+#: static/js/impala/stats/csv_keys.js:201 static/js/zamboni/stats-all.js:15482 static/js/zamboni/stats-min.js:5
 msgid "Add-ons in Use, last {0} days"
 msgstr "Tiện ích được Sử dụng, {0} ngày trước"
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:203
+#: static/js/impala/stats/csv_keys.js:203 static/js/zamboni/stats-all.js:15484 static/js/zamboni/stats-min.js:5
 msgid "Add-ons in Use from {0} to {1}"
 msgstr ""
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:207
+#: static/js/impala/stats/csv_keys.js:207 static/js/zamboni/stats-all.js:15488 static/js/zamboni/stats-min.js:5
 msgid "Add-ons Downloaded, last {0} days"
 msgstr ""
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:209
+#: static/js/impala/stats/csv_keys.js:209 static/js/zamboni/stats-all.js:15490 static/js/zamboni/stats-min.js:5
 msgid "Add-ons Downloaded from {0} to {1}"
 msgstr ""
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:213
+#: static/js/impala/stats/csv_keys.js:213 static/js/zamboni/stats-all.js:15494 static/js/zamboni/stats-min.js:5
 msgid "Add-ons Created, last {0} days"
 msgstr ""
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:215
+#: static/js/impala/stats/csv_keys.js:215 static/js/zamboni/stats-all.js:15496 static/js/zamboni/stats-min.js:5
 msgid "Add-ons Created from {0} to {1}"
 msgstr ""
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:219
+#: static/js/impala/stats/csv_keys.js:219 static/js/zamboni/stats-all.js:15500 static/js/zamboni/stats-min.js:5
 msgid "Add-ons Updated, last {0} days"
 msgstr ""
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:221
+#: static/js/impala/stats/csv_keys.js:221 static/js/zamboni/stats-all.js:15502 static/js/zamboni/stats-min.js:5
 msgid "Add-ons Updated from {0} to {1}"
 msgstr ""
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:225
+#: static/js/impala/stats/csv_keys.js:225 static/js/zamboni/stats-all.js:15506 static/js/zamboni/stats-min.js:5
 msgid "Reviews Written, last {0} days"
 msgstr ""
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:227
+#: static/js/impala/stats/csv_keys.js:227 static/js/zamboni/stats-all.js:15508 static/js/zamboni/stats-min.js:5
 msgid "Reviews Written from {0} to {1}"
 msgstr ""
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:231
+#: static/js/impala/stats/csv_keys.js:231 static/js/zamboni/stats-all.js:15512 static/js/zamboni/stats-min.js:5
 msgid "User Signups, last {0} days"
 msgstr ""
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:233
+#: static/js/impala/stats/csv_keys.js:233 static/js/zamboni/stats-all.js:15514 static/js/zamboni/stats-min.js:5
 msgid "User Signups from {0} to {1}"
 msgstr ""
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:237
+#: static/js/impala/stats/csv_keys.js:237 static/js/zamboni/stats-all.js:15518 static/js/zamboni/stats-min.js:5
 msgid "Collections Created, last {0} days"
 msgstr "Bộ sưu tập được Tạo ra, {0} ngày trước"
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:239
+#: static/js/impala/stats/csv_keys.js:239 static/js/zamboni/stats-all.js:15520 static/js/zamboni/stats-min.js:5
 msgid "Collections Created from {0} to {1}"
 msgstr "Bộ sưu tập được Tạo ra từ {0} đến {1}"
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:243
+#: static/js/impala/stats/csv_keys.js:243 static/js/zamboni/stats-all.js:15524 static/js/zamboni/stats-min.js:5
 msgid "Subscribers, last {0} days"
 msgstr ""
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:245
+#: static/js/impala/stats/csv_keys.js:245 static/js/zamboni/stats-all.js:15526 static/js/zamboni/stats-min.js:5
 msgid "Subscribers from {0} to {1}"
 msgstr ""
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:249
+#: static/js/impala/stats/csv_keys.js:249 static/js/zamboni/stats-all.js:15530 static/js/zamboni/stats-min.js:5
 msgid "Ratings, last {0} days"
 msgstr "Đánh giá, {0} ngày trước"
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:251
+#: static/js/impala/stats/csv_keys.js:251 static/js/zamboni/stats-all.js:15532 static/js/zamboni/stats-min.js:5
 msgid "Ratings from {0} to {1}"
 msgstr ""
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:255
+#: static/js/impala/stats/csv_keys.js:255 static/js/zamboni/stats-all.js:15536 static/js/zamboni/stats-min.js:5
 msgid "Sales, last {0} days"
 msgstr ""
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:257
+#: static/js/impala/stats/csv_keys.js:257 static/js/zamboni/stats-all.js:15538 static/js/zamboni/stats-min.js:5
 msgid "Sales from {0} to {1}"
 msgstr ""
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:261
+#: static/js/impala/stats/csv_keys.js:261 static/js/zamboni/stats-all.js:15542 static/js/zamboni/stats-min.js:5
 msgid "Installs, last {0} days"
 msgstr "Lần Cài đặt, {0} ngày trước"
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:263
+#: static/js/impala/stats/csv_keys.js:263 static/js/zamboni/stats-all.js:15544 static/js/zamboni/stats-min.js:5
 msgid "Installs from {0} to {1}"
 msgstr "Lần Cài đặt từ {0} đến {1}"
 
 #. L10n: {0} and {1} are integers.
-#: static/js/impala/stats/csv_keys.js:269
+#: static/js/impala/stats/csv_keys.js:269 static/js/zamboni/stats-all.js:15550 static/js/zamboni/stats-min.js:5
 msgid "<b>{0}</b> in last {1} days"
 msgstr "<b>{0}</b> vào {1} ngày trước"
 
 #. L10n: {0} is an integer and {1} and {2} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:271 static/js/impala/stats/csv_keys.js:277
+#: static/js/impala/stats/csv_keys.js:271 static/js/impala/stats/csv_keys.js:277 static/js/zamboni/stats-all.js:15552 static/js/zamboni/stats-all.js:15558 static/js/zamboni/stats-min.js:5
 msgid "<b>{0}</b> from {1} to {2}"
 msgstr ""
 
 #. L10n: {0} and {1} are integers.
-#: static/js/impala/stats/csv_keys.js:275
+#: static/js/impala/stats/csv_keys.js:275 static/js/zamboni/stats-all.js:15556 static/js/zamboni/stats-min.js:5
 msgid "<b>{0}</b> average in last {1} days"
 msgstr "Trung bình <b>{0}</b> vào {1} ngày trước"
 
-#: static/js/impala/stats/overview.js:19
+#: static/js/impala/stats/overview.js:19 static/js/zamboni/stats-all.js:16469 static/js/zamboni/stats-min.js:5
 msgid "No data available."
 msgstr "Không có dữ liệu."
 
-#: static/js/impala/stats/table.js:74
+#: static/js/impala/stats/table.js:74 static/js/zamboni/stats-all.js:17209 static/js/zamboni/stats-min.js:5
 msgid "Date"
 msgstr "Ngày tháng"
 
-#: static/js/impala/stats/topchart.js:96
+#: static/js/impala/stats/topchart.js:96 static/js/zamboni/stats-all.js:16600 static/js/zamboni/stats-min.js:5
 msgid "Other"
 msgstr "Khác"
 
-#: static/js/zamboni/admin_validation.js:24 static/js/zamboni/devhub.js:1229 static/js/zamboni/editors.js:295
+#: static/js/zamboni/admin-all.js:180 static/js/zamboni/admin-min.js:1 static/js/zamboni/admin_validation.js:24 static/js/zamboni/devhub-all.js:2408 static/js/zamboni/devhub-min.js:2
+#: static/js/zamboni/devhub.js:1229 static/js/zamboni/editors-all.js:15576 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:295
 msgid "Select an application first"
 msgstr "Chọn một ứng dụng trước tiên"
 
-#: static/js/zamboni/admin_validation.js:51
+#: static/js/zamboni/admin-all.js:207 static/js/zamboni/admin-min.js:1 static/js/zamboni/admin_validation.js:51
 msgid "Set {0} add-on to a max version of {1} and email the author."
 msgid_plural "Set {0} add-ons to a max version of {1} and email the authors."
 msgstr[0] ""
+msgstr[1] ""
 
-#: static/js/zamboni/admin_validation.js:54
+#: static/js/zamboni/admin-all.js:210 static/js/zamboni/admin-min.js:1 static/js/zamboni/admin_validation.js:54
 msgid "Email author of {2} add-on which failed validation."
 msgid_plural "Email authors of {2} add-ons which failed validation."
 msgstr[0] ""
+msgstr[1] ""
 
-#. L10n: {0} is an app name like Firefox.
-#: static/js/zamboni/buttons.js:66
-msgid "Accept and Install"
-msgstr "Chấp nhận và cài đặt"
-
-#: static/js/zamboni/buttons.js:66
-msgid "Add to {0}"
-msgstr "Thêm vào {0}"
-
-#: static/js/zamboni/buttons.js:71
-msgid "Download Now"
-msgstr "Tải về ngay"
-
-#: static/js/zamboni/buttons.js:112
-msgid "Add-on has not been updated to support default-to-compatible."
-msgstr ""
-
-#: static/js/zamboni/buttons.js:117
-msgid "You need to be using Firefox 10.0 or higher."
-msgstr "Bạn cần phải sử dụng Firefox 10.0 trở lên."
-
-#: static/js/zamboni/buttons.js:129
-msgid "Mozilla has marked this version as incompatible with your Firefox version."
-msgstr "Mozilla đã đánh dấu phiên bản này là không tương thích với phiên bản Firefox của bạn."
-
-#. L10n: {0} is an platform like Windows or Linux.
-#: static/js/zamboni/buttons.js:210
-msgid "Install for {0} anyway"
-msgstr "Vẫn cứ cài đặt vào {0}"
-
-#: static/js/zamboni/buttons.js:210
-msgid "Download for {0} anyway"
-msgstr "Cứ tải về cho {0}"
-
-#: static/js/zamboni/buttons.js:267
-msgid "Not available for your platform"
-msgstr "Không có sẵn cho nền của bạn"
-
-#. L10n: {0} is an app name, {1} is the app version.
-#: static/js/zamboni/buttons.js:278 static/js/zamboni/buttons.js:315
-msgid "Not available for {0} {1}"
-msgstr "Không có sẵn cho {0} {1}"
-
-#: static/js/zamboni/buttons.js:341
-msgid "Works with {app} {min} - {max}"
-msgstr "Hoạt động trên {app} {min} – {max}"
-
-#: static/js/zamboni/buttons.js:343
-msgid "View other versions"
-msgstr "Xem các phiên bản khác"
-
-#: static/js/zamboni/buttons.js:391
-msgid "Only with Firefox — Get Firefox Now!"
-msgstr ""
-
-#: static/js/zamboni/buttons.js:507 static/js/zamboni/mobile/buttons.js:43
-msgid "Sorry, you need a Mozilla-based browser (such as Firefox) to install a search plugin."
-msgstr "Rất tiếc, bạn cần phải sử dụng một trình duyệt gốc Mozilla (ví dụ như Firefox) để cài đặt một công cụ tìm kiếm."
-
-#: static/js/zamboni/collections.js:229
-msgid "Adding to Favorites&hellip;"
-msgstr ""
-
-#: static/js/zamboni/collections.js:232
-msgid "Removing Favorite&hellip;"
-msgstr ""
-
-#: static/js/zamboni/collections.js:235
-msgid "Add to Favorites"
-msgstr ""
-
-#: static/js/zamboni/collections.js:238
-msgid "Remove from Favorites"
-msgstr ""
-
-#: static/js/zamboni/collections.js:303
-msgid "Pending"
-msgstr "Đang chờ đợi"
-
-#: static/js/zamboni/collections.js:304
-msgid "Add a comment"
-msgstr "Thêm bình luận"
-
-#: static/js/zamboni/collections.js:304
-msgid "Comment"
-msgstr "Bình luận"
-
-#: static/js/zamboni/collections.js:305
-msgid "Remove this add-on from the collection"
-msgstr ""
-
-#: static/js/zamboni/collections.js:305 static/js/zamboni/collections.js:334
-msgid "Remove"
-msgstr ""
-
-#: static/js/zamboni/collections.js:334
-msgid "Remove this user as a contributor"
-msgstr ""
-
-#: static/js/zamboni/collections.js:346
-msgid "An email address is required."
-msgstr "Yêu cầu địa chỉ thư điện tử."
-
-#: static/js/zamboni/collections.js:364
-msgid "You cannot add yourself as a contributor."
-msgstr ""
-
-#: static/js/zamboni/collections.js:366
-msgid "You have already added that user."
-msgstr ""
-
-#: static/js/zamboni/collections.js:573
-msgid "Add to favorites"
-msgstr ""
-
-#: static/js/zamboni/collections.js:577
-msgid "Remove from favorites"
-msgstr ""
-
-#: static/js/zamboni/collections.js:604
-msgid "Stop following"
-msgstr ""
-
-#: static/js/zamboni/devhub.js:110
+#: static/js/zamboni/devhub-all.js:1289 static/js/zamboni/devhub-min.js:1 static/js/zamboni/devhub.js:110
 msgid "Your browser does not support the video tag"
 msgstr "Trình duyệt của bạn không hỗ trợ thẻ video"
 
-#: static/js/zamboni/devhub.js:371
+#: static/js/zamboni/devhub-all.js:1550 static/js/zamboni/devhub-min.js:1 static/js/zamboni/devhub.js:371
 msgid "Changes Saved"
 msgstr ""
 
-#: static/js/zamboni/devhub.js:387
+#: static/js/zamboni/devhub-all.js:1566 static/js/zamboni/devhub-min.js:1 static/js/zamboni/devhub.js:387
 msgid "Enter a new author's email address"
 msgstr ""
 
-#: static/js/zamboni/devhub.js:536
+#: static/js/zamboni/devhub-all.js:1715 static/js/zamboni/devhub-min.js:1 static/js/zamboni/devhub.js:536
 msgid "There was an error uploading your file."
 msgstr ""
 
-#: static/js/zamboni/devhub.js:681
+#: static/js/zamboni/devhub-all.js:1860 static/js/zamboni/devhub-min.js:1 static/js/zamboni/devhub.js:681
 msgid "{files} file"
 msgid_plural "{files} files"
 msgstr[0] ""
+msgstr[1] ""
 
-#: static/js/zamboni/devhub.js:684
+#: static/js/zamboni/devhub-all.js:1863 static/js/zamboni/devhub-min.js:1 static/js/zamboni/devhub.js:684
 msgid "{reviews} user review"
 msgid_plural "{reviews} user reviews"
 msgstr[0] "{reviews} đánh giá của người dùng{reviews} đánh giá của người dùng"
+msgstr[1] ""
 
-#: static/js/zamboni/devhub.js:796
+#: static/js/zamboni/devhub-all.js:1975 static/js/zamboni/devhub-min.js:2 static/js/zamboni/devhub.js:796
 msgid "Learn more"
 msgstr ""
 
-#: static/js/zamboni/devhub.js:800
+#: static/js/zamboni/devhub-all.js:1979 static/js/zamboni/devhub-min.js:2 static/js/zamboni/devhub.js:800
 msgid "Example"
 msgstr ""
 
-#: static/js/zamboni/devhub.js:1130
+#: static/js/zamboni/devhub-all.js:2309 static/js/zamboni/devhub-min.js:2 static/js/zamboni/devhub.js:1130
 msgid "Image changes being processed"
 msgstr ""
 
-#: static/js/zamboni/devhub.js:1280
+#: static/js/zamboni/devhub-all.js:2459 static/js/zamboni/devhub-min.js:2 static/js/zamboni/devhub.js:1280
 msgid "Must be a valid e-mail address."
 msgstr "Yêu cầu địa chỉ thư điện tử hợp lệ."
+
+#: static/js/zamboni/devhub-all.js:2613 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:80
+msgid "All tests passed successfully."
+msgstr ""
+
+#: static/js/zamboni/devhub-all.js:2616 static/js/zamboni/devhub-all.js:3011 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:83 static/js/zamboni/validator.js:478
+msgid "These tests were not run."
+msgstr ""
+
+#: static/js/zamboni/devhub-all.js:2664 static/js/zamboni/devhub-all.js:2677 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:131 static/js/zamboni/validator.js:144
+msgid "Tests"
+msgstr ""
+
+#: static/js/zamboni/devhub-all.js:2779 static/js/zamboni/devhub-all.js:3108 static/js/zamboni/devhub-all.js:3127 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:246
+#: static/js/zamboni/validator.js:575 static/js/zamboni/validator.js:594
+msgid "Error"
+msgstr "Lỗi"
+
+#: static/js/zamboni/devhub-all.js:2780 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:247
+msgid "Warning"
+msgstr "Cảnh báo"
+
+#: static/js/zamboni/devhub-all.js:2794 static/js/zamboni/devhub-min.js:2 static/js/zamboni/files-all.js:5657 static/js/zamboni/files-min.js:3 static/js/zamboni/files.js:411
+#: static/js/zamboni/validator.js:261
+msgid "Ignore this message in future updates"
+msgstr ""
+
+#: static/js/zamboni/devhub-all.js:2817 static/js/zamboni/devhub-min.js:2 static/js/zamboni/files-all.js:5663 static/js/zamboni/files-min.js:3 static/js/zamboni/files.js:417
+#: static/js/zamboni/validator.js:284
+msgid "Severity for automated signing:"
+msgstr ""
+
+#: static/js/zamboni/devhub-all.js:2832 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:299
+msgid "Suggestions for passing automated signing:"
+msgstr ""
+
+#: static/js/zamboni/devhub-all.js:2920 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:387
+msgid "Compatibility Tests"
+msgstr ""
+
+#: static/js/zamboni/devhub-all.js:2999 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:466
+msgid "Add-on failed validation."
+msgstr ""
+
+#: static/js/zamboni/devhub-all.js:3001 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:468
+msgid "Add-on passed validation."
+msgstr ""
+
+#: static/js/zamboni/devhub-all.js:3014 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:481
+msgid "{0} error"
+msgid_plural "{0} errors"
+msgstr[0] ""
+msgstr[1] ""
+
+#: static/js/zamboni/devhub-all.js:3016 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:483
+msgid "{0} warning"
+msgid_plural "{0} warnings"
+msgstr[0] ""
+msgstr[1] ""
+
+#: static/js/zamboni/devhub-all.js:3018 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:485
+msgid "{0} notice"
+msgid_plural "{0} notices"
+msgstr[0] "{0} chú ý{0} chú ý"
+msgstr[1] ""
+
+#: static/js/zamboni/devhub-all.js:3110 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:577
+msgid "Validation task could not complete or completed with errors"
+msgstr ""
+
+#: static/js/zamboni/devhub-all.js:3128 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:595
+msgid "Internal server error"
+msgstr "Lỗi nội bộ máy chủ"
 
 #: static/js/zamboni/devhub_search.js:8
 msgid "No results found."
 msgstr "Không tìm thấy kết quả."
 
-#: static/js/zamboni/editors.js:121
+#: static/js/zamboni/editors-all.js:15402 static/js/zamboni/editors-min.js:4 static/js/zamboni/editors.js:121
 msgid "{name} was viewing this page first."
 msgstr ""
 
-#: static/js/zamboni/editors.js:171
+#: static/js/zamboni/editors-all.js:15452 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:171
 msgid "Receipt checked by app."
 msgstr ""
 
-#: static/js/zamboni/editors.js:173
+#: static/js/zamboni/editors-all.js:15454 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:173
 msgid "Receipt was not checked by app."
 msgstr ""
 
-#: static/js/zamboni/editors.js:244
+#: static/js/zamboni/editors-all.js:15525 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:244
 msgid "{name} was viewing this add-on first."
 msgstr ""
 
-#: static/js/zamboni/editors.js:255
+#: static/js/zamboni/editors-all.js:15536 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:255
 msgid "Loading&hellip;"
 msgstr "Đang tải&hellip;"
 
-#: static/js/zamboni/editors.js:260
+#: static/js/zamboni/editors-all.js:15541 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:260
 msgid "Version Notes"
 msgstr "Ghi chú về phiên bản"
 
-#: static/js/zamboni/editors.js:265
+#: static/js/zamboni/editors-all.js:15546 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:265
 msgid "Notes for Reviewers"
 msgstr "Ghi chú cho người duyệt"
 
-#: static/js/zamboni/editors.js:270
+#: static/js/zamboni/editors-all.js:15551 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:270
 msgid "No version notes found"
 msgstr "Không tìm thấy ghi chú về phiên bản"
 
-#: static/js/zamboni/editors.js:330
+#: static/js/zamboni/editors-all.js:15611 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:330
 msgid "Average Reviews"
 msgstr ""
 
-#: static/js/zamboni/editors.js:386
+#: static/js/zamboni/editors-all.js:15667 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:386
 msgid "Number of Reviews"
 msgstr ""
 
-#: static/js/zamboni/editors.js:445
+#: static/js/zamboni/editors-all.js:15726 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:445
 msgid "Error loading translation"
 msgstr ""
 
-#: static/js/zamboni/files.js:411 static/js/zamboni/validator.js:261
-msgid "Ignore this message in future updates"
-msgstr ""
-
-#: static/js/zamboni/files.js:417 static/js/zamboni/validator.js:284
-msgid "Severity for automated signing:"
-msgstr ""
-
-#: static/js/zamboni/global.js:410
-msgid "Loading..."
-msgstr ""
-
-#. L10n: {0} is the number of characters left.
-#: static/js/zamboni/global.js:474
-msgid "<b>{0}</b> character left."
-msgid_plural "<b>{0}</b> characters left."
-msgstr[0] ""
-
-#: static/js/zamboni/init.js:28
-msgid "This feature is temporarily disabled while we perform website maintenance. Please check back a little later."
-msgstr " Tính năng này tạm thời bị vô hiệu hóa trong khi chúng tôi đang bảo trì trang web. Vui lòng kiểm tra lại sau. "
-
-#: static/js/zamboni/l10n.js:45
-msgid "Remove this localization"
-msgstr "Xóa bản dịch này"
-
-#: static/js/zamboni/password-strength.js:20
-msgid "Password strength:"
-msgstr ""
-
-#: static/js/zamboni/password-strength.js:26
-msgid "At least {0} character left."
-msgid_plural "At least {0} characters left."
-msgstr[0] "Còn ít nhất {0} ký tự.Còn ít nhất {0} ký tự."
-
-#: static/js/zamboni/themes_review.js:176
-msgid "Requested Info"
-msgstr "Thông tin được yêu cầu"
-
-#: static/js/zamboni/themes_review.js:177
-msgid "Flagged"
-msgstr "Đánh cờ"
-
-#: static/js/zamboni/themes_review.js:178
-msgid "Duplicate"
-msgstr "Bản sao"
-
-#: static/js/zamboni/themes_review.js:179
-msgid "Rejected"
-msgstr "Từ chối"
-
-#: static/js/zamboni/themes_review.js:180
-msgid "Approved"
-msgstr "Chấp nhận"
-
-#: static/js/zamboni/themes_review.js:424
-msgid "No results found"
-msgstr ""
-
-#: static/js/zamboni/themes_review_templates.js:31
+#: static/js/zamboni/editors-all.js:15975 static/js/zamboni/editors-min.js:5 static/js/zamboni/themes_review_templates.js:31
 msgid "Theme"
 msgstr ""
 
-#: static/js/zamboni/themes_review_templates.js:33
+#: static/js/zamboni/editors-all.js:15977 static/js/zamboni/editors-min.js:5 static/js/zamboni/themes_review_templates.js:33
 msgid "Reviewer"
 msgstr ""
 
-#: static/js/zamboni/themes_review_templates.js:35
+#: static/js/zamboni/editors-all.js:15979 static/js/zamboni/editors-min.js:5 static/js/zamboni/themes_review_templates.js:35
 msgid "Status"
 msgstr ""
 
-#: static/js/zamboni/validator.js:80
-msgid "All tests passed successfully."
+#: static/js/zamboni/editors-all.js:16196 static/js/zamboni/editors-min.js:5 static/js/zamboni/themes_review.js:176
+msgid "Requested Info"
+msgstr "Thông tin được yêu cầu"
+
+#: static/js/zamboni/editors-all.js:16197 static/js/zamboni/editors-min.js:5 static/js/zamboni/themes_review.js:177
+msgid "Flagged"
+msgstr "Đánh cờ"
+
+#: static/js/zamboni/editors-all.js:16198 static/js/zamboni/editors-min.js:5 static/js/zamboni/themes_review.js:178
+msgid "Duplicate"
+msgstr "Bản sao"
+
+#: static/js/zamboni/editors-all.js:16199 static/js/zamboni/editors-min.js:5 static/js/zamboni/themes_review.js:179
+msgid "Rejected"
+msgstr "Từ chối"
+
+#: static/js/zamboni/editors-all.js:16200 static/js/zamboni/editors-min.js:5 static/js/zamboni/themes_review.js:180
+msgid "Approved"
+msgstr "Chấp nhận"
+
+#: static/js/zamboni/editors-all.js:16444 static/js/zamboni/editors-min.js:5 static/js/zamboni/themes_review.js:424
+msgid "No results found"
 msgstr ""
 
-#: static/js/zamboni/validator.js:83 static/js/zamboni/validator.js:478
-msgid "These tests were not run."
-msgstr ""
-
-#: static/js/zamboni/validator.js:131 static/js/zamboni/validator.js:144
-msgid "Tests"
-msgstr ""
-
-#: static/js/zamboni/validator.js:246 static/js/zamboni/validator.js:575 static/js/zamboni/validator.js:594
-msgid "Error"
-msgstr "Lỗi"
-
-#: static/js/zamboni/validator.js:247
-msgid "Warning"
-msgstr "Cảnh báo"
-
-#: static/js/zamboni/validator.js:299
-msgid "Suggestions for passing automated signing:"
-msgstr ""
-
-#: static/js/zamboni/validator.js:387
-msgid "Compatibility Tests"
-msgstr ""
-
-#: static/js/zamboni/validator.js:466
-msgid "Add-on failed validation."
-msgstr ""
-
-#: static/js/zamboni/validator.js:468
-msgid "Add-on passed validation."
-msgstr ""
-
-#: static/js/zamboni/validator.js:481
-msgid "{0} error"
-msgid_plural "{0} errors"
-msgstr[0] ""
-
-#: static/js/zamboni/validator.js:483
-msgid "{0} warning"
-msgid_plural "{0} warnings"
-msgstr[0] ""
-
-#: static/js/zamboni/validator.js:485
-msgid "{0} notice"
-msgid_plural "{0} notices"
-msgstr[0] "{0} chú ý{0} chú ý"
-
-#: static/js/zamboni/validator.js:577
-msgid "Validation task could not complete or completed with errors"
-msgstr ""
-
-#: static/js/zamboni/validator.js:595
-msgid "Internal server error"
-msgstr "Lỗi nội bộ máy chủ"
-
-#: static/js/zamboni/mobile/buttons.js:52
+#: static/js/zamboni/mobile-all.js:15186 static/js/zamboni/mobile/buttons.js:52
 msgid "Not Updated for {0} {1}"
 msgstr ""
 
-#: static/js/zamboni/mobile/buttons.js:53
+#: static/js/zamboni/mobile-all.js:15187 static/js/zamboni/mobile/buttons.js:53
 msgid "Requires Newer Version of {0}"
 msgstr "Cần phiên bản mới hơn của {0}"
 
-#: static/js/zamboni/mobile/buttons.js:54
+#: static/js/zamboni/mobile-all.js:15188 static/js/zamboni/mobile/buttons.js:54
 msgid "Unreviewed"
 msgstr ""
 
-#: static/js/zamboni/mobile/buttons.js:55
+#: static/js/zamboni/mobile-all.js:15189 static/js/zamboni/mobile/buttons.js:55
 msgid "Experimental <span>(Learn More)</span>"
 msgstr "Thử nghiệm <span>(tìm hiểu thêm)</span>"
 
-#: static/js/zamboni/mobile/buttons.js:56 static/js/zamboni/mobile/buttons.js:57
+#: static/js/zamboni/mobile-all.js:15190 static/js/zamboni/mobile-all.js:15191 static/js/zamboni/mobile/buttons.js:56 static/js/zamboni/mobile/buttons.js:57
 msgid "Not Available for {0}"
 msgstr "Không có sẵn cho {0}"
 
-#: static/js/zamboni/mobile/buttons.js:58
+#: static/js/zamboni/mobile-all.js:15192 static/js/zamboni/mobile/buttons.js:58
 msgid "Experimental"
 msgstr "Thử nghiệm"
 
-#: static/js/zamboni/mobile/buttons.js:59
+#: static/js/zamboni/mobile-all.js:15193 static/js/zamboni/mobile/buttons.js:59
 msgid "Themes Require Newer Version of {0}"
 msgstr "Các giao diện cần phiên bản mới hơn của {0}"
 
-#: static/js/zamboni/mobile/buttons.js:60
+#: static/js/zamboni/mobile-all.js:15194 static/js/zamboni/mobile/buttons.js:60
 msgid "Themes Require {0}"
 msgstr "Các giao diện cần {0}"
 
-#: static/js/zamboni/mobile/buttons.js:105
+#: static/js/zamboni/mobile-all.js:15239 static/js/zamboni/mobile/buttons.js:105
 msgid "Installing..."
 msgstr "Đang cài đặt…"
 
-#: static/js/zamboni/mobile/buttons.js:125
+#: static/js/zamboni/mobile-all.js:15259 static/js/zamboni/mobile/buttons.js:125
 msgid "This add-on has been preliminarily reviewed by Mozilla."
 msgstr ""
 
-#: static/js/zamboni/mobile/buttons.js:250
+#: static/js/zamboni/mobile-all.js:15384 static/js/zamboni/mobile/buttons.js:250
 msgid "Keep it"
 msgstr "Giữ nó"
 
-#: static/js/zamboni/mobile/general.js:344
+#: static/js/zamboni/mobile-all.js:16049 static/js/zamboni/mobile-min.js:6 static/js/zamboni/mobile/general.js:344
 msgid "You're trying it on!"
 msgstr ""
 
-#: static/js/zamboni/mobile/general.js:356
+#: static/js/zamboni/mobile-all.js:16061 static/js/zamboni/mobile-min.js:6 static/js/zamboni/mobile/general.js:356
 msgid "Added to Firefox"
 msgstr "Đã thêm vào Firefox"
-

--- a/locale/zh_CN/LC_MESSAGES/django.po
+++ b/locale/zh_CN/LC_MESSAGES/django.po
@@ -3,7 +3,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version:  AMO\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2016-02-24 21:23+0000\n"
+"POT-Creation-Date: 2016-04-18 15:40+0000\n"
 "PO-Revision-Date: 2016-03-21 02:32+0000\n"
 "Last-Translator: YFdyh000 <yfdyh000@gmail.com>\n"
 "Language-Team: Chinese Simplified, China <LL@li.org>\n"
@@ -12,60 +12,60 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Generated-By: Babel 2.2.0\n"
 
-#: src/olympia/accounts/views.py:52
+#: src/olympia/accounts/views.py:54
 msgid "Your log in attempt could not be parsed. Please try again."
 msgstr "您的登录尝试无法解析。请重试。"
 
-#: src/olympia/accounts/views.py:54
+#: src/olympia/accounts/views.py:56
 msgid "Your Firefox Account could not be found. Please try again."
 msgstr "您的 Firefox 账号未找到。请重试。"
 
-#: src/olympia/accounts/views.py:55
+#: src/olympia/accounts/views.py:57
 msgid "You could not be logged in. Please try again."
 msgstr "您尚未登录。请重试。"
 
-#: src/olympia/accounts/views.py:57
+#: src/olympia/accounts/views.py:59
 msgid "Your account has already been migrated to Firefox Accounts."
 msgstr "您的账户已被迁移到 Firefox 账号。"
 
-#: src/olympia/accounts/views.py:59
+#: src/olympia/accounts/views.py:61
 msgid "Your Firefox Account already exists on this site."
 msgstr "您的 Firefox 账号已在此网站上存在。"
 
-#: src/olympia/accounts/views.py:108
+#: src/olympia/accounts/views.py:110
 msgid "Great job!"
 msgstr "做得好！"
 
-#: src/olympia/accounts/views.py:109
+#: src/olympia/accounts/views.py:111
 msgid "You can now log in to Add-ons with your Firefox Account."
 msgstr "您现在可以使用 Firefox 账号登录附加组件网站了。"
 
-#: src/olympia/accounts/views.py:121
+#: src/olympia/accounts/views.py:123
 msgid "Need help?"
 msgstr "需要帮助？"
 
-#: src/olympia/addons/buttons.py:180
+#: src/olympia/addons/buttons.py:177
 msgid "Download Now"
 msgstr "立即下载"
 
-#: src/olympia/addons/buttons.py:182
+#: src/olympia/addons/buttons.py:179
 msgid "Download"
 msgstr "下载"
 
 #. L10n: please keep &nbsp; in the string so &rarr; does not wrap.
-#: src/olympia/addons/buttons.py:186
+#: src/olympia/addons/buttons.py:183
 msgid "Continue to Download&nbsp;&rarr;"
 msgstr "继续下载&nbsp;&rarr;"
 
-#: src/olympia/addons/buttons.py:202 src/olympia/addons/helpers.py:35 src/olympia/addons/views.py:319 src/olympia/addons/templates/addons/impala/details.html:114
+#: src/olympia/addons/buttons.py:199 src/olympia/addons/helpers.py:35 src/olympia/addons/views.py:333 src/olympia/addons/templates/addons/impala/details.html:111
 #: src/olympia/addons/templates/addons/impala/listing/items.html:17 src/olympia/addons/templates/addons/mobile/home.html:40 src/olympia/amo/templates/amo/side_nav.html:6
-#: src/olympia/amo/templates/amo/side_nav.html:10 src/olympia/amo/templates/amo/site_nav.html:2 src/olympia/amo/templates/amo/site_nav.html:55 src/olympia/bandwagon/views.py:95
-#: src/olympia/browse/views.py:54 src/olympia/browse/views.py:68 src/olympia/browse/views.py:235 src/olympia/browse/templates/browse/impala/category_landing.html:22
+#: src/olympia/amo/templates/amo/side_nav.html:10 src/olympia/amo/templates/amo/site_nav.html:2 src/olympia/amo/templates/amo/site_nav.html:53 src/olympia/bandwagon/views.py:95
+#: src/olympia/browse/views.py:54 src/olympia/browse/views.py:68 src/olympia/browse/views.py:202 src/olympia/browse/templates/browse/impala/category_landing.html:22
 #: src/olympia/browse/templates/browse/personas/mobile/category_landing.html:26
 msgid "Featured"
 msgstr "精选"
 
-#: src/olympia/addons/buttons.py:221
+#: src/olympia/addons/buttons.py:218
 msgid "Add to {0}"
 msgstr "添加到 {0}"
 
@@ -87,17 +87,20 @@ msgstr "短网址不能是“%s”。请另选一个。"
 msgid "Invalid tag: {0}"
 msgid_plural "Invalid tags: {0}"
 msgstr[0] "无效的标签：{0}"
+msgstr[1] ""
 
 #. L10n: {0} is a single tag or a comma-separated list of tags.
 #: src/olympia/addons/forms.py:103
 msgid "\"{0}\" is a reserved tag and cannot be used."
 msgid_plural "\"{0}\" are reserved tags and cannot be used."
 msgstr[0] "“{0}”为保留标签，不能使用。"
+msgstr[1] ""
 
 #: src/olympia/addons/forms.py:111
 msgid "You have {0} too many tags."
 msgid_plural "You have {0} too many tags."
 msgstr[0] "您的标签多出了 {0} 个。"
+msgstr[1] ""
 
 #: src/olympia/addons/forms.py:117
 #, python-format
@@ -108,39 +111,41 @@ msgstr "移除无效字符后，所有标签都必须少于或等于 %s 字符�
 msgid "All tags must be at least {0} character."
 msgid_plural "All tags must be at least {0} characters."
 msgstr[0] "所有标签至少要包含 {0} 个字符。"
+msgstr[1] ""
 
-#: src/olympia/addons/forms.py:234
+#: src/olympia/addons/forms.py:238
 msgid "Categories cannot be changed while your add-on is featured for this application."
 msgstr "您的附加组件目前为此应用程序的精选附加组件，无法更改分类。"
 
 #. L10n: {0} is the number of categories.
-#: src/olympia/addons/forms.py:238
+#: src/olympia/addons/forms.py:242
 msgid "You can have only {0} category."
 msgid_plural "You can have only {0} categories."
 msgstr[0] "您只能选择 {0} 个分类。"
+msgstr[1] ""
 
-#: src/olympia/addons/forms.py:246
+#: src/olympia/addons/forms.py:250
 msgid "The miscellaneous category cannot be combined with additional categories."
 msgstr "这个杂项分类不能与其他分类混用。"
 
-#: src/olympia/addons/forms.py:369
+#: src/olympia/addons/forms.py:374
 #, python-format
 msgid "Before changing your default locale you must have a name, summary, and description in that locale. You are missing %s."
 msgstr "在您更改您的默认语言之前，您必须为那个语言环境输入名称、概述及描述。您目前没有输入 %s。"
 
-#: src/olympia/addons/forms.py:484 src/olympia/addons/forms.py:575
+#: src/olympia/addons/forms.py:455 src/olympia/addons/forms.py:546
 msgid "A license must be selected."
 msgstr "必须选择一种许可协议。"
 
-#: src/olympia/addons/forms.py:556
+#: src/olympia/addons/forms.py:527
 msgid "Give Your Theme a Name."
 msgstr "为您的主题取个名字吧。"
 
-#: src/olympia/addons/forms.py:562 src/olympia/devhub/templates/devhub/personas/submit.html:53
+#: src/olympia/addons/forms.py:533 src/olympia/devhub/templates/devhub/personas/submit.html:53
 msgid "Describe your Theme."
 msgstr "描述您的主题。"
 
-#: src/olympia/addons/forms.py:704
+#: src/olympia/addons/forms.py:675
 msgid "Enter a new author's email address"
 msgstr "输入新的作者电子邮件地址"
 
@@ -148,39 +153,39 @@ msgstr "输入新的作者电子邮件地址"
 msgid "Not Reviewed"
 msgstr "尚未审核"
 
-#: src/olympia/addons/models.py:301
+#: src/olympia/addons/models.py:298
 msgid "Users have the option of contributing more or less than this amount."
 msgstr "用户可以选择捐助多于或少于这个金额。"
 
-#: src/olympia/addons/models.py:309
-msgid "Users will always be asked in the Add-ons Manager (Firefox 4 and above)"
-msgstr "附加组件管理器（Firefox 4 及更高版本）中用户始终会被询问"
+#: src/olympia/addons/models.py:306
+msgid "Users will always be asked in the Add-ons Manager (Firefox 4 and above). Only applies to desktop."
+msgstr ""
 
 # Column name in a table.
-#: src/olympia/addons/models.py:1804 src/olympia/addons/templates/addons/details_box.html:55 src/olympia/devhub/templates/devhub/index.html:92
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:102
+#: src/olympia/addons/models.py:1802 src/olympia/addons/templates/addons/details_box.html:55 src/olympia/devhub/templates/devhub/index.html:92
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:89
 msgid "Listed"
 msgstr "已上架"
 
-#: src/olympia/addons/views.py:320 src/olympia/browse/templates/browse/personas/mobile/category_landing.html:27
+#: src/olympia/addons/views.py:334 src/olympia/browse/templates/browse/personas/mobile/category_landing.html:27
 msgid "Popular"
 msgstr "热门"
 
-#: src/olympia/addons/views.py:321 src/olympia/browse/views.py:238 src/olympia/browse/views.py:280 src/olympia/browse/views.py:482
+#: src/olympia/addons/views.py:335 src/olympia/browse/views.py:205 src/olympia/browse/views.py:247 src/olympia/browse/views.py:449
 msgid "Recently Added"
 msgstr "最近添加"
 
-#: src/olympia/addons/views.py:322 src/olympia/bandwagon/views.py:99 src/olympia/browse/views.py:60 src/olympia/browse/views.py:71 src/olympia/search/forms.py:16 src/olympia/search/forms.py:91
+#: src/olympia/addons/views.py:336 src/olympia/bandwagon/views.py:99 src/olympia/browse/views.py:60 src/olympia/browse/views.py:71 src/olympia/search/forms.py:16 src/olympia/search/forms.py:91
 msgid "Recently Updated"
 msgstr "最近更新"
 
 # %1 is an add-on name.
 #. l10n: {0} is the addon name
-#: src/olympia/addons/views.py:520
+#: src/olympia/addons/views.py:534
 msgid "Contribution for {0}"
 msgstr "捐款给 {0}"
 
-#: src/olympia/addons/views.py:613
+#: src/olympia/addons/views.py:627
 msgid "Abuse reported."
 msgstr "已报告滥用。"
 
@@ -249,9 +254,9 @@ msgstr "捐助"
 #: src/olympia/devhub/templates/devhub/addons/ajax_compat_update.html:36 src/olympia/devhub/templates/devhub/addons/profile.html:44 src/olympia/devhub/templates/devhub/addons/edit/admin.html:101
 #: src/olympia/devhub/templates/devhub/addons/edit/basic.html:152 src/olympia/devhub/templates/devhub/addons/edit/details.html:85 src/olympia/devhub/templates/devhub/addons/edit/support.html:67
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:166 src/olympia/devhub/templates/devhub/addons/forms_shared/media.html:149
-#: src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:44 src/olympia/devhub/templates/devhub/versions/add_file_modal.html:78 src/olympia/devhub/templates/devhub/versions/edit.html:139
-#: src/olympia/devhub/templates/devhub/versions/list.html:242 src/olympia/devhub/templates/devhub/versions/list.html:276 src/olympia/devhub/templates/devhub/versions/list.html:317
-#: src/olympia/devhub/templates/devhub/versions/list.html:351 src/olympia/reviews/templates/reviews/edit_review.html:16 src/olympia/translations/templates/translations/trans-menu.html:50
+#: src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:43 src/olympia/devhub/templates/devhub/versions/add_file_modal.html:58 src/olympia/devhub/templates/devhub/versions/edit.html:139
+#: src/olympia/devhub/templates/devhub/versions/list.html:239 src/olympia/devhub/templates/devhub/versions/list.html:281 src/olympia/devhub/templates/devhub/versions/list.html:315
+#: src/olympia/devhub/templates/devhub/versions/list.html:349 src/olympia/reviews/templates/reviews/edit_review.html:16 src/olympia/translations/templates/translations/trans-menu.html:50
 #: src/olympia/translations/templates/translations/trans-menu.html:62
 msgid "or"
 msgstr "或"
@@ -320,8 +325,7 @@ msgstr "捐款金额必须是数字。"
 msgid "A one-time suggested contribution of {0}"
 msgstr "建议单次捐助 {0}"
 
-#. {0} is a currency symbol (e.g., $),                    {1} is an amount
-#. input
+#. {0} is a currency symbol (e.g., $),                    {1} is an amount input
 #. field
 #: src/olympia/addons/templates/addons/contributions_lightbox.html:64
 msgid "A one-time contribution of {0} {1}"
@@ -362,7 +366,7 @@ msgid "Add-on Information for {0}"
 msgstr "{0} 的附加组件信息"
 
 #: src/olympia/addons/templates/addons/details_box.html:30 src/olympia/addons/templates/addons/persona_detail_table.html:3 src/olympia/addons/templates/addons/mobile/details.html:63
-#: src/olympia/addons/templates/addons/mobile/persona_detail_table.html:7 src/olympia/browse/views.py:459 src/olympia/devhub/views.py:75
+#: src/olympia/addons/templates/addons/mobile/persona_detail_table.html:7 src/olympia/browse/views.py:426 src/olympia/devhub/views.py:74
 msgid "Updated"
 msgstr "更新日期"
 
@@ -381,11 +385,11 @@ msgstr "兼容于"
 msgid "Visibility"
 msgstr "可见性"
 
-#: src/olympia/addons/templates/addons/details_box.html:57 src/olympia/devhub/templates/devhub/index.html:94 src/olympia/devhub/templates/devhub/includes/addon_details.html:104
+#: src/olympia/addons/templates/addons/details_box.html:57 src/olympia/devhub/templates/devhub/index.html:94 src/olympia/devhub/templates/devhub/includes/addon_details.html:91
 msgid "Hidden"
 msgstr "隐藏"
 
-#: src/olympia/addons/templates/addons/details_box.html:59 src/olympia/devhub/templates/devhub/index.html:96 src/olympia/devhub/templates/devhub/includes/addon_details.html:106
+#: src/olympia/addons/templates/addons/details_box.html:59 src/olympia/devhub/templates/devhub/index.html:96 src/olympia/devhub/templates/devhub/includes/addon_details.html:93
 msgid "Unlisted"
 msgstr "未上架"
 
@@ -393,13 +397,13 @@ msgstr "未上架"
 msgid "Required Add-ons"
 msgstr "依赖的附加组件"
 
-#: src/olympia/addons/templates/addons/details_box.html:81 src/olympia/addons/templates/addons/persona_detail_table.html:15 src/olympia/browse/views.py:462 src/olympia/devhub/views.py:78
-#: src/olympia/devhub/views.py:85 src/olympia/discovery/templates/discovery/addons/detail.html:57 src/olympia/reviews/forms.py:62 src/olympia/reviews/templates/reviews/add.html:57
+#: src/olympia/addons/templates/addons/details_box.html:81 src/olympia/addons/templates/addons/persona_detail_table.html:15 src/olympia/browse/views.py:429 src/olympia/devhub/views.py:77
+#: src/olympia/devhub/views.py:84 src/olympia/discovery/templates/discovery/addons/detail.html:57 src/olympia/reviews/forms.py:62 src/olympia/reviews/templates/reviews/add.html:57
 #: src/olympia/reviews/templates/reviews/mobile/review_list.html:18
 msgid "Rating"
 msgstr "评分"
 
-#: src/olympia/addons/templates/addons/details_box.html:85 src/olympia/browse/views.py:461 src/olympia/devhub/views.py:77 src/olympia/devhub/views.py:84
+#: src/olympia/addons/templates/addons/details_box.html:85 src/olympia/browse/views.py:428 src/olympia/devhub/views.py:76 src/olympia/devhub/views.py:83
 #: src/olympia/stats/templates/stats/addon_report_menu.html:8 src/olympia/stats/templates/stats/collection_report_menu.html:18
 msgid "Downloads"
 msgstr "下载次数"
@@ -419,7 +423,7 @@ msgstr "报告滥用行为"
 
 #. The Privacy Policy for this add-on.
 #: src/olympia/addons/templates/addons/details_box.html:121 src/olympia/addons/templates/addons/privacy.html:19 src/olympia/addons/templates/addons/privacy.html:23
-#: src/olympia/addons/templates/addons/impala/button.html:43 src/olympia/addons/templates/addons/impala/details.html:307 src/olympia/devhub/templates/devhub/includes/policy_form.html:20
+#: src/olympia/addons/templates/addons/impala/button.html:43 src/olympia/addons/templates/addons/impala/details.html:312 src/olympia/devhub/templates/devhub/includes/policy_form.html:23
 #: src/olympia/templates/mobile/base_addons.html:87
 msgid "Privacy Policy"
 msgstr "隐私政策"
@@ -444,7 +448,7 @@ msgstr "图片集"
 msgid "Developer Comments"
 msgstr "开发者注释"
 
-#: src/olympia/addons/templates/addons/details_box.html:199 src/olympia/addons/templates/addons/impala/details.html:259
+#: src/olympia/addons/templates/addons/details_box.html:199 src/olympia/addons/templates/addons/impala/details.html:264
 msgid "Development Channel"
 msgstr "开发通道"
 
@@ -464,13 +468,13 @@ msgid ""
 "developer. To stop receiving development updates, reinstall the default version from the link above."
 msgstr "<strong>注意：</strong>此附加组件的开发版本尚未经过 Mozilla 审核。一旦您安装此开发版本，您将持续收到来自此开发者的开发版本的更新。如果您不想再收到此更新，请从上面的链接重新安装默认版本。"
 
-#: src/olympia/addons/templates/addons/details_box.html:220 src/olympia/addons/templates/addons/impala/details.html:278
+#: src/olympia/addons/templates/addons/details_box.html:220 src/olympia/addons/templates/addons/impala/details.html:283
 msgid "Version {0}:"
 msgstr "版本 {0}："
 
 #: src/olympia/addons/templates/addons/details_box.html:234
-msgid "Nothing to see here!  The developer did not include any details."
-msgstr "这里什么也没有。开发者没有包含任何详细信息。"
+msgid "Nothing to see here! The developer did not include any details."
+msgstr "这里什么都没有！开发者没有写下任何详细信息。"
 
 #: src/olympia/addons/templates/addons/details_box.html:251 src/olympia/devhub/templates/devhub/versions/edit.html:73 src/olympia/editors/templates/editors/review.html:98
 msgid "Version Notes"
@@ -483,7 +487,7 @@ msgid "End-User License Agreement for {0}"
 msgstr "{0} 的最终用户许可协议"
 
 #: src/olympia/addons/templates/addons/eula.html:17 src/olympia/addons/templates/addons/eula.html:21 src/olympia/addons/templates/addons/impala/button.html:48
-#: src/olympia/addons/templates/addons/impala/details.html:316 src/olympia/devhub/templates/devhub/includes/policy_form.html:3 src/olympia/discovery/templates/discovery/addons/eula.html:11
+#: src/olympia/addons/templates/addons/impala/details.html:321 src/olympia/devhub/templates/devhub/includes/policy_form.html:3 src/olympia/discovery/templates/discovery/addons/eula.html:11
 msgid "End-User License Agreement"
 msgstr "最终用户许可协议"
 
@@ -503,7 +507,7 @@ msgstr "返回 {0}…"
 msgid "Add-ons for {0}"
 msgstr "{0} 附加组件"
 
-#: src/olympia/addons/templates/addons/home.html:10 src/olympia/addons/templates/addons/home.html:51 src/olympia/browse/templates/browse/impala/base_listing.html:11
+#: src/olympia/addons/templates/addons/home.html:10 src/olympia/addons/templates/addons/home.html:53 src/olympia/browse/templates/browse/impala/base_listing.html:11
 msgid "Featured Extensions"
 msgstr "精选扩展"
 
@@ -511,29 +515,29 @@ msgstr "精选扩展"
 msgid "Popular Extensions"
 msgstr "热门扩展"
 
-#: src/olympia/addons/templates/addons/home.html:42 src/olympia/amo/templates/amo/side_nav.html:3 src/olympia/amo/templates/amo/side_nav.html:11 src/olympia/amo/templates/amo/site_nav.html:3
-#: src/olympia/amo/templates/amo/site_nav.html:25 src/olympia/browse/views.py:236 src/olympia/browse/views.py:281 src/olympia/browse/views.py:481
+#: src/olympia/addons/templates/addons/home.html:44 src/olympia/amo/templates/amo/side_nav.html:3 src/olympia/amo/templates/amo/side_nav.html:11 src/olympia/amo/templates/amo/site_nav.html:3
+#: src/olympia/amo/templates/amo/site_nav.html:25 src/olympia/browse/views.py:203 src/olympia/browse/views.py:248 src/olympia/browse/views.py:448
 msgid "Most Popular"
 msgstr "最热门"
 
-#: src/olympia/addons/templates/addons/home.html:43
+#: src/olympia/addons/templates/addons/home.html:45
 msgid "All »"
 msgstr "全部 »"
 
-#: src/olympia/addons/templates/addons/home.html:52 src/olympia/addons/templates/addons/home.html:61 src/olympia/addons/templates/addons/home.html:70 src/olympia/addons/templates/addons/home.html:78
+#: src/olympia/addons/templates/addons/home.html:54 src/olympia/addons/templates/addons/home.html:63 src/olympia/addons/templates/addons/home.html:72 src/olympia/addons/templates/addons/home.html:80
 #: src/olympia/browse/templates/browse/impala/category_landing.html:36
 msgid "See all »"
 msgstr "查看全部 »"
 
-#: src/olympia/addons/templates/addons/home.html:60
+#: src/olympia/addons/templates/addons/home.html:62
 msgid "Up &amp; Coming Extensions"
 msgstr "扩展新秀"
 
-#: src/olympia/addons/templates/addons/home.html:69 src/olympia/browse/templates/browse/personas/category_landing.html:61 src/olympia/discovery/templates/discovery/pane.html:74
+#: src/olympia/addons/templates/addons/home.html:71 src/olympia/browse/templates/browse/personas/category_landing.html:61 src/olympia/discovery/templates/discovery/pane.html:74
 msgid "Featured Themes"
 msgstr "精选主题"
 
-#: src/olympia/addons/templates/addons/home.html:77 src/olympia/bandwagon/templates/bandwagon/impala/collection_listing.html:5
+#: src/olympia/addons/templates/addons/home.html:79 src/olympia/bandwagon/templates/bandwagon/impala/collection_listing.html:5
 msgid "Featured Collections"
 msgstr "精选收藏集"
 
@@ -551,7 +555,7 @@ msgid "Updated {0}"
 msgstr "{0} 更新"
 
 #. {0} is a date.
-#: src/olympia/addons/templates/addons/macros.html:10 src/olympia/addons/templates/addons/macros.html:69 src/olympia/addons/templates/addons/persona_preview.html:21
+#: src/olympia/addons/templates/addons/macros.html:10 src/olympia/addons/templates/addons/macros.html:69 src/olympia/addons/templates/addons/persona_preview.html:22
 #: src/olympia/addons/templates/addons/listing/items_mobile.html:44 src/olympia/addons/templates/addons/listing/macros.html:39 src/olympia/bandwagon/templates/bandwagon/collection_listing_items.html:37
 #: src/olympia/bandwagon/templates/bandwagon/impala/collection_listing_items.html:37
 msgid "Added {0}"
@@ -562,25 +566,28 @@ msgstr "{0} 添加"
 msgid "%(num)s weekly download"
 msgid_plural "%(num)s weekly downloads"
 msgstr[0] "%(num)s 次周下载量"
+msgstr[1] ""
 
 #: src/olympia/addons/templates/addons/macros.html:28
 #, python-format
 msgid "%(num)s user"
 msgid_plural "%(num)s users"
 msgstr[0] "%(num)s 位用户"
+msgstr[1] ""
 
 #. {0} is the number of downloads.
-#: src/olympia/addons/templates/addons/macros.html:53 src/olympia/addons/templates/addons/impala/details.html:61
+#: src/olympia/addons/templates/addons/macros.html:53 src/olympia/addons/templates/addons/impala/details.html:59
 msgid "{0} weekly download"
 msgid_plural "{0} weekly downloads"
 msgstr[0] "{0} 次周下载量"
+msgstr[1] ""
 
 #. {0} is the number of users.
-#: src/olympia/addons/templates/addons/macros.html:61 src/olympia/addons/templates/addons/impala/details.html:54 src/olympia/compat/templates/compat/index.html:71
-#: src/olympia/zadmin/templates/zadmin/compat.html:67
+#: src/olympia/addons/templates/addons/macros.html:61 src/olympia/addons/templates/addons/impala/details.html:52 src/olympia/zadmin/templates/zadmin/compat.html:67
 msgid "{0} user"
 msgid_plural "{0} users"
 msgstr[0] "{0} 位用户"
+msgstr[1] ""
 
 #: src/olympia/addons/templates/addons/paypal_result.html:12
 msgid "Payment cancelled"
@@ -594,7 +601,7 @@ msgstr "已完成付款"
 msgid "Return to the addon."
 msgstr "返回附加组件。"
 
-#: src/olympia/addons/templates/addons/persona_detail.html:17 src/olympia/addons/templates/addons/impala/details.html:106 src/olympia/addons/templates/addons/mobile/details.html:23
+#: src/olympia/addons/templates/addons/persona_detail.html:17 src/olympia/addons/templates/addons/impala/details.html:103 src/olympia/addons/templates/addons/mobile/details.html:23
 #: src/olympia/addons/templates/addons/mobile/persona_detail.html:21 src/olympia/discovery/templates/discovery/addons/base.html:27 src/olympia/editors/templates/editors/review.html:31
 msgid "by"
 msgstr "作者："
@@ -638,33 +645,35 @@ msgstr "每日用户量"
 msgid "License"
 msgstr "许可协议"
 
-#: src/olympia/addons/templates/addons/persona_preview.html:12 src/olympia/constants/base.py:48
+#: src/olympia/addons/templates/addons/persona_preview.html:13 src/olympia/constants/base.py:48
 msgid "Awaiting Review"
 msgstr "等待审核"
 
-#: src/olympia/addons/templates/addons/persona_preview.html:14 src/olympia/amo/log.py:180 src/olympia/constants/base.py:42 src/olympia/editors/helpers.py:62
+#: src/olympia/addons/templates/addons/persona_preview.html:15 src/olympia/amo/log.py:180 src/olympia/constants/base.py:42 src/olympia/editors/helpers.py:62
 msgid "Rejected"
 msgstr "已被退回"
 
-#: src/olympia/addons/templates/addons/persona_preview.html:16 src/olympia/amo/log.py:159
+#: src/olympia/addons/templates/addons/persona_preview.html:17 src/olympia/amo/log.py:159
 msgid "Approved"
 msgstr "已核准"
 
 #. {0} is the number of users.
-#: src/olympia/addons/templates/addons/persona_preview.html:26 src/olympia/addons/templates/addons/listing/items_mobile.html:36 src/olympia/addons/templates/addons/listing/macros.html:31
+#: src/olympia/addons/templates/addons/persona_preview.html:27 src/olympia/addons/templates/addons/listing/items_mobile.html:36 src/olympia/addons/templates/addons/listing/macros.html:31
 msgid "<strong>{0}</strong> user"
 msgid_plural "<strong>{0}</strong> users"
 msgstr[0] "<strong>{0}</strong> 个用户"
+msgstr[1] ""
 
-#: src/olympia/addons/templates/addons/persona_preview.html:40
+#: src/olympia/addons/templates/addons/persona_preview.html:41
 msgid "Hover to Preview"
 msgstr "鼠标移至上方预览"
 
-#: src/olympia/addons/templates/addons/persona_preview.html:46 src/olympia/addons/templates/addons/persona_preview.html:48 src/olympia/reviews/templates/reviews/add.html:15
+#: src/olympia/addons/templates/addons/persona_preview.html:47 src/olympia/addons/templates/addons/persona_preview.html:49 src/olympia/addons/templates/addons/persona_preview.html:97
+#: src/olympia/reviews/templates/reviews/add.html:15
 msgid "Add"
 msgstr "添加"
 
-#: src/olympia/addons/templates/addons/persona_preview.html:57 src/olympia/bandwagon/templates/bandwagon/ajax_new.html:16 src/olympia/bandwagon/templates/bandwagon/edit.html:19
+#: src/olympia/addons/templates/addons/persona_preview.html:58 src/olympia/bandwagon/templates/bandwagon/ajax_new.html:16 src/olympia/bandwagon/templates/bandwagon/edit.html:19
 #: src/olympia/bandwagon/templates/bandwagon/includes/addedit.html:19 src/olympia/devhub/templates/devhub/addons/edit/admin.html:13 src/olympia/devhub/templates/devhub/addons/edit/basic.html:10
 #: src/olympia/devhub/templates/devhub/addons/edit/details.html:8 src/olympia/devhub/templates/devhub/addons/edit/media.html:6 src/olympia/devhub/templates/devhub/addons/edit/support.html:8
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:9 src/olympia/devhub/templates/devhub/addons/submit/describe.html:29 src/olympia/editors/templates/editors/review.html:257
@@ -673,21 +682,21 @@ msgstr "编辑"
 
 #. For datetime formatting, see the table on
 #. http://docs.python.org/library/datetime.html#strftime-and-strptime-behavior
-#: src/olympia/addons/templates/addons/persona_preview.html:66
+#: src/olympia/addons/templates/addons/persona_preview.html:67
 #, python-format
 msgid "%%Y-%%m-%%d"
 msgstr "%%Y-%%m-%%d"
 
-#: src/olympia/addons/templates/addons/persona_preview.html:67
+#: src/olympia/addons/templates/addons/persona_preview.html:68
 msgid "by {0} on {1}"
 msgstr "由 {0} 发表于 {1}"
 
-#: src/olympia/addons/templates/addons/persona_preview.html:75 src/olympia/reviews/helpers.py:17 src/olympia/reviews/templates/reviews/review_list.html:63
+#: src/olympia/addons/templates/addons/persona_preview.html:76 src/olympia/reviews/helpers.py:17 src/olympia/reviews/templates/reviews/review_list.html:63
 #: src/olympia/reviews/templates/reviews/reviews_link.html:21 src/olympia/reviews/templates/reviews/impala/reviews_link.html:16
 msgid "Not yet rated"
 msgstr "尚无评分"
 
-#: src/olympia/addons/templates/addons/persona_preview.html:78
+#: src/olympia/addons/templates/addons/persona_preview.html:79
 msgid "<b>{0}</b> users"
 msgstr "<b>{0}</b> 位用户"
 
@@ -700,8 +709,8 @@ msgid "Learn more about Firefox"
 msgstr "进一步了解 Firefox"
 
 #: src/olympia/addons/templates/addons/popups.html:22
-msgid "or <b><a class=\"installer\" href=\"{url}\">download anyway</a></b>"
-msgstr "或者 <b><a class=\"installer\" href=\"{url}\">继续下载</a></b>"
+msgid "or <b><a class=\"button installer\" href=\"{url}\">download anyway</a></b>"
+msgstr ""
 
 #: src/olympia/addons/templates/addons/popups.html:26
 msgid ""
@@ -760,9 +769,9 @@ msgstr "此炫彩风格需要 %(app)s %(new_version)s，您目前使用的是 %(
 
 #: src/olympia/addons/templates/addons/popups.html:108
 msgid ""
-"<strong>Caution:</strong> This add-on has not been reviewed by Mozilla and can't be installed on release versions of Firefox 43 and above.  Be careful when installing third-party software that "
-"might harm your computer."
-msgstr "<strong>注意：</strong>此附加组件尚未经过 Mozilla 审核，不能在 Firefox 43 及更高版本上安装。安装第三方软件可能会损害您的计算机，请小心。"
+"<strong>Caution:</strong> This add-on has not been reviewed by Mozilla and can't be installed on release versions of Firefox 43 and above. Be careful when installing third-party software that might"
+" harm your computer."
+msgstr "<strong>注意：</strong>此附加组件尚未经过 Mozilla 审核，不能在 Firefox 43 及以上的发布版本上安装。安装第三方软件可能损害您的计算机，请小心。"
 
 #: src/olympia/addons/templates/addons/popups.html:120
 msgid "<strong>Please note:</strong> This add-on is not compatible with your operating system."
@@ -792,14 +801,11 @@ msgid "QR code for add-on"
 msgstr "附加组件的二维码"
 
 #: src/olympia/addons/templates/addons/qr_code.html:6
-msgid ""
-"Want {0} on your mobile Firefox?  Scan this QR code to install directly\n"
-"  to your phone.  (You'll need a QR reader.  Search your phone's marketplace if\n"
-"  don't have one.)"
-msgstr "想在您的移动版 Firefox 上使用 {0}？扫描此二维码直接安装到您的手机上。（您需要一个 QR 码扫描器。如果还没有，在您手机的应用市场上搜索。）"
+msgid "Want {0} on your mobile Firefox? Scan this QR code to install directly to your phone. (You'll need a QR reader. Search your phone's marketplace if don't have one.)"
+msgstr "想在您的移动版火狐上使用 {0} 吗？扫描此 QR 码（一种二维码）后会直接安装到您的手机上。（您需要一个 QR 码扫描器。如果您的手机上没有，请在您的手机的应用市场里搜索。）"
 
 #: src/olympia/addons/templates/addons/report_abuse.html:6 src/olympia/addons/templates/addons/report_abuse_full.html:10 src/olympia/addons/templates/addons/impala/details-more.html:23
-#: src/olympia/addons/templates/addons/impala/details.html:328
+#: src/olympia/addons/templates/addons/impala/details.html:333
 msgid "Report Abuse"
 msgstr "报告滥用"
 
@@ -818,9 +824,9 @@ msgstr "发送报告"
 #: src/olympia/devhub/templates/devhub/addons/ajax_compat_update.html:36 src/olympia/devhub/templates/devhub/addons/profile.html:44 src/olympia/devhub/templates/devhub/addons/edit/admin.html:104
 #: src/olympia/devhub/templates/devhub/addons/edit/basic.html:155 src/olympia/devhub/templates/devhub/addons/edit/details.html:88 src/olympia/devhub/templates/devhub/addons/edit/support.html:70
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:169 src/olympia/devhub/templates/devhub/addons/forms_shared/media.html:152
-#: src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:44 src/olympia/devhub/templates/devhub/personas/edit.html:222 src/olympia/devhub/templates/devhub/versions/add_file_modal.html:79
-#: src/olympia/devhub/templates/devhub/versions/edit.html:140 src/olympia/devhub/templates/devhub/versions/list.html:208 src/olympia/devhub/templates/devhub/versions/list.html:242
-#: src/olympia/devhub/templates/devhub/versions/list.html:276 src/olympia/devhub/templates/devhub/versions/list.html:317 src/olympia/reviews/templates/reviews/edit_review.html:16
+#: src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:43 src/olympia/devhub/templates/devhub/personas/edit.html:222 src/olympia/devhub/templates/devhub/versions/add_file_modal.html:59
+#: src/olympia/devhub/templates/devhub/versions/edit.html:140 src/olympia/devhub/templates/devhub/versions/list.html:208 src/olympia/devhub/templates/devhub/versions/list.html:239
+#: src/olympia/devhub/templates/devhub/versions/list.html:281 src/olympia/devhub/templates/devhub/versions/list.html:315 src/olympia/reviews/templates/reviews/edit_review.html:16
 #: src/olympia/translations/templates/translations/trans-menu.html:50 src/olympia/translations/templates/translations/trans-menu.html:62 src/olympia/zadmin/templates/zadmin/validation.html:105
 msgid "Cancel"
 msgstr "取消"
@@ -865,7 +871,7 @@ msgstr "参阅<a href=\"%(support)s\">用户支持</a>章节了解如何获得�
 msgid "Review Guidelines"
 msgstr "评价撰写指南"
 
-#: src/olympia/addons/templates/addons/review_list_box.html:5 src/olympia/addons/templates/addons/impala/details-more.html:27 src/olympia/editors/helpers.py:921
+#: src/olympia/addons/templates/addons/review_list_box.html:5 src/olympia/addons/templates/addons/impala/details-more.html:27 src/olympia/editors/helpers.py:1001
 #: src/olympia/reviews/templates/reviews/add.html:14 src/olympia/reviews/templates/reviews/reply.html:14 src/olympia/reviews/templates/reviews/review_list.html:19
 #: src/olympia/reviews/templates/reviews/mobile/review_list.html:26
 msgid "Reviews"
@@ -885,6 +891,7 @@ msgstr "显示开发者对此评价的回复"
 msgid "See all reviews of this add-on"
 msgid_plural "See all %(cnt)s reviews of this add-on"
 msgstr[0] "查看此附加组件的所有评价 (%(cnt)s个)"
+msgstr[1] ""
 
 #: src/olympia/addons/templates/addons/tags_box.html:3 src/olympia/devhub/templates/devhub/addons/edit/basic.html:118
 msgid "Tags"
@@ -953,120 +960,123 @@ msgstr "在这些收藏集中"
 msgid "Other add-ons by %(author)s"
 msgid_plural "Other add-ons by these authors"
 msgstr[0] "作者的其他附加组件"
+msgstr[1] ""
 
-#: src/olympia/addons/templates/addons/impala/details.html:41
+#: src/olympia/addons/templates/addons/impala/details.html:39
 #, python-format
 msgid "<span itemprop=\"ratingCount\">%(num)s</span> user review"
 msgid_plural "<span itemprop=\"ratingCount\">%(num)s</span> user reviews"
 msgstr[0] "<span itemprop=\"ratingCount\">%(num)s</span> 条用户评价"
+msgstr[1] ""
 
-#: src/olympia/addons/templates/addons/impala/details.html:69
+#: src/olympia/addons/templates/addons/impala/details.html:66
 msgid "View statistics"
 msgstr "查看统计数据"
 
-#: src/olympia/addons/templates/addons/impala/details.html:84
+#: src/olympia/addons/templates/addons/impala/details.html:81
 msgid "Manage"
 msgstr "管理"
 
 #. {0} is an add-on name.
-#: src/olympia/addons/templates/addons/impala/details.html:96
+#: src/olympia/addons/templates/addons/impala/details.html:93
 msgid "Icon of {0}"
 msgstr "{0} 的图标"
 
-#: src/olympia/addons/templates/addons/impala/details.html:103 src/olympia/addons/templates/addons/impala/listing/items.html:14
+#: src/olympia/addons/templates/addons/impala/details.html:100 src/olympia/addons/templates/addons/impala/listing/items.html:14
 msgid "No Restart"
 msgstr "无需重启"
 
-#: src/olympia/addons/templates/addons/impala/details.html:127
+#: src/olympia/addons/templates/addons/impala/details.html:124
 #, python-format
 msgid "Meet the Developer: <a href=\"%(url)s\">%(name)s</a>"
 msgid_plural "<a href=\"%(url)s\">Meet the Developers</a>"
 msgstr[0] "<a href=\"%(url)s\">结识开发者</a>"
+msgstr[1] ""
 
 # {0} is an add-on name.
-#: src/olympia/addons/templates/addons/impala/details.html:137
+#: src/olympia/addons/templates/addons/impala/details.html:134
 msgid "Learn why {0} was created and find out what's next for this add-on."
 msgstr "了解开发 {0} 的缘由和这个附加组件的下一步计划。"
 
 #. {0} is an index.
-#: src/olympia/addons/templates/addons/impala/details.html:156
+#: src/olympia/addons/templates/addons/impala/details.html:161
 msgid "Add-on screenshot #{0}"
 msgstr "附加组件截图 #{0}"
 
-#: src/olympia/addons/templates/addons/impala/details.html:182
+#: src/olympia/addons/templates/addons/impala/details.html:187
 msgid "Add-on home page"
 msgstr "附加组件主页"
 
-#: src/olympia/addons/templates/addons/impala/details.html:185
+#: src/olympia/addons/templates/addons/impala/details.html:190
 msgid "Support site"
 msgstr "用户支持网站"
 
-#: src/olympia/addons/templates/addons/impala/details.html:189
+#: src/olympia/addons/templates/addons/impala/details.html:194
 msgid "Support E-mail"
 msgstr "用户支持邮箱"
 
-#: src/olympia/addons/templates/addons/impala/details.html:194 src/olympia/devhub/models.py:378 src/olympia/devhub/templates/devhub/versions/list.html:12
+#: src/olympia/addons/templates/addons/impala/details.html:199 src/olympia/devhub/models.py:378 src/olympia/devhub/templates/devhub/versions/list.html:12
 #: src/olympia/versions/templates/versions/version.html:6 src/olympia/versions/templates/versions/mobile/version.html:6
 msgid "Version {0}"
 msgstr "版本 {0}"
 
-#: src/olympia/addons/templates/addons/impala/details.html:194
+#: src/olympia/addons/templates/addons/impala/details.html:199
 msgid "Info"
 msgstr "信息"
 
-#: src/olympia/addons/templates/addons/impala/details.html:195 src/olympia/devhub/templates/devhub/includes/addon_details.html:129
+#: src/olympia/addons/templates/addons/impala/details.html:200 src/olympia/devhub/templates/devhub/includes/addon_details.html:116
 msgid "Last Updated:"
 msgstr "最近更新："
 
-#: src/olympia/addons/templates/addons/impala/details.html:200
+#: src/olympia/addons/templates/addons/impala/details.html:205
 #, python-format
 msgid "Released under <a target=\"_blank\" href=\"%(url)s\">%(name)s</a>"
 msgstr "在 <a target=\"_blank\" href=\"%(url)s\">%(name)s</a> 下发布"
 
-#: src/olympia/addons/templates/addons/impala/details.html:201 src/olympia/addons/templates/addons/impala/details.html:206 src/olympia/amo/helpers.py:398 src/olympia/devhub/forms.py:142
+#: src/olympia/addons/templates/addons/impala/details.html:206 src/olympia/addons/templates/addons/impala/details.html:211 src/olympia/amo/helpers.py:398 src/olympia/devhub/forms.py:142
 #: src/olympia/devhub/forms.py:173 src/olympia/versions/templates/versions/version.html:40 src/olympia/versions/templates/versions/version.html:45
 msgid "Custom License"
 msgstr "自定义许可协议"
 
-#: src/olympia/addons/templates/addons/impala/details.html:205
+#: src/olympia/addons/templates/addons/impala/details.html:210
 #, python-format
 msgid "Released under <a href=\"%(url)s\">%(name)s</a>"
 msgstr "在 <a href=\"%(url)s\">%(name)s</a> 下发布"
 
-#: src/olympia/addons/templates/addons/impala/details.html:217
+#: src/olympia/addons/templates/addons/impala/details.html:222
 msgid "About this Add-on"
 msgstr "关于这个附加组件"
 
-#: src/olympia/addons/templates/addons/impala/details.html:233
+#: src/olympia/addons/templates/addons/impala/details.html:238
 msgid "Developer’s Comments"
 msgstr "开发者的注明"
 
-#: src/olympia/addons/templates/addons/impala/details.html:243
+#: src/olympia/addons/templates/addons/impala/details.html:248
 msgid "Version Information"
 msgstr "版本信息"
 
-#: src/olympia/addons/templates/addons/impala/details.html:250
+#: src/olympia/addons/templates/addons/impala/details.html:255
 msgid "See complete version history"
 msgstr "查看完整的版本历史"
 
 # 本项译文为用户“wenke”提交，因操作方面的原因导致用户名记录为我的名下，致歉。
-#: src/olympia/addons/templates/addons/impala/details.html:262
+#: src/olympia/addons/templates/addons/impala/details.html:267
 msgid ""
 "The Development Channel lets you test an experimental new version of this add-on before it's released to the general public. Once you install the development version, you will continue to get "
 "updates from this channel. To stop receiving development updates, reinstall the default version from the link above."
 msgstr "在此附加组件发布给所有公众之前，您可以通过开发通道测试此附加组件的实验性新版本。一旦您安装开发版，您就会持续得到来自这个通道的更新。要停止接受开发版的更新，请从上面的链接重新安装默认版。"
 
-#: src/olympia/addons/templates/addons/impala/details.html:272
+#: src/olympia/addons/templates/addons/impala/details.html:277
 msgid "<strong>Caution:</strong> Development versions of this add-on have not been reviewed by Mozilla."
 msgstr "<strong>注意：</strong>此附加组件的开发版本尚未经过 Mozilla 审核。"
 
-#: src/olympia/addons/templates/addons/impala/details.html:287
+#: src/olympia/addons/templates/addons/impala/details.html:292
 msgid "See complete development channel history"
 msgstr "查看完整的开发通道历史记录"
 
-#: src/olympia/addons/templates/addons/impala/details.html:306 src/olympia/addons/templates/addons/impala/details.html:315 src/olympia/addons/templates/addons/impala/details.html:327
+#: src/olympia/addons/templates/addons/impala/details.html:311 src/olympia/addons/templates/addons/impala/details.html:320 src/olympia/addons/templates/addons/impala/details.html:332
 #: src/olympia/addons/templates/addons/impala/review_add_box.html:4 src/olympia/stats/templates/stats/popup.html:2 src/olympia/stats/templates/stats/popup.html:8
-#: src/olympia/stats/templates/stats/stats.html:202 src/olympia/users/templates/users/profile.html:119
+#: src/olympia/stats/templates/stats/stats.html:204 src/olympia/users/templates/users/profile.html:119
 msgid "close"
 msgstr "关闭"
 
@@ -1099,6 +1109,7 @@ msgstr "{0} 的下一步计划"
 msgid "About the Developer"
 msgid_plural "About the Developers"
 msgstr[0] "关于开发者"
+msgstr[1] ""
 
 #: src/olympia/addons/templates/addons/impala/developers.html:96 src/olympia/users/templates/users/edit.html:130 src/olympia/users/templates/users/profile.html:26
 msgid "No Photo"
@@ -1124,15 +1135,11 @@ msgstr "{addon} 的源代码许可协议"
 msgid "Source Code License"
 msgstr "源代码许可协议"
 
-#: src/olympia/addons/templates/addons/impala/persona_grid.html:16 src/olympia/addons/templates/addons/impala/toplist.html:6
-msgid "{0} users"
-msgstr "{0} 位用户"
-
 #: src/olympia/addons/templates/addons/impala/review_list_box.html:19 src/olympia/reviews/templates/reviews/review.html:40
 msgid "permalink"
 msgstr "永久链接"
 
-#: src/olympia/addons/templates/addons/impala/review_list_box.html:23 src/olympia/editors/templates/editors/queue.html:98 src/olympia/reviews/templates/reviews/review.html:44
+#: src/olympia/addons/templates/addons/impala/review_list_box.html:23 src/olympia/editors/templates/editors/queue.html:104 src/olympia/reviews/templates/reviews/review.html:44
 msgid "translate"
 msgstr "翻译"
 
@@ -1141,6 +1148,7 @@ msgstr "翻译"
 msgid "See all user reviews"
 msgid_plural "See all %(cnt)s user reviews"
 msgstr[0] "查看所有用户评价 (%(cnt)s个)"
+msgstr[1] ""
 
 #: src/olympia/addons/templates/addons/impala/review_list_box.html:47 src/olympia/reviews/templates/reviews/review_list.html:84
 msgid "This add-on has not yet been reviewed."
@@ -1149,6 +1157,10 @@ msgstr "此附加组件还没有评价呢。"
 #: src/olympia/addons/templates/addons/impala/review_list_box.html:50
 msgid "Be the first!"
 msgstr "来第一个参与评价吧！"
+
+#: src/olympia/addons/templates/addons/impala/toplist.html:6
+msgid "{0} users"
+msgstr "{0} 位用户"
 
 #: src/olympia/addons/templates/addons/impala/listing/sorter.html:14 src/olympia/devhub/templates/devhub/addons/listing/item_actions.html:49
 msgid "More"
@@ -1162,7 +1174,7 @@ msgstr "添加到收藏集"
 msgid "My Add-ons"
 msgstr "我的附加组件"
 
-#: src/olympia/addons/templates/addons/includes/dashboard_tabs.html:6 src/olympia/amo/context_processors.py:51
+#: src/olympia/addons/templates/addons/includes/dashboard_tabs.html:6 src/olympia/amo/context_processors.py:52
 msgid "My Themes"
 msgstr "我的主题"
 
@@ -1203,6 +1215,7 @@ msgstr "尚无评分"
 msgid "<strong>{0}</strong> weekly download"
 msgid_plural "<strong>{0}</strong> weekly downloads"
 msgstr[0] "<strong>{0}</strong> 次周下载量"
+msgstr[1] ""
 
 #: src/olympia/addons/templates/addons/mobile/details.html:32
 msgid "Read More"
@@ -1216,7 +1229,7 @@ msgstr "用户量"
 msgid "Weekly Downloads"
 msgstr "周下载量"
 
-#: src/olympia/addons/templates/addons/mobile/details.html:99 src/olympia/compat/templates/compat/reporter_detail.html:46 src/olympia/devhub/forms.py:787
+#: src/olympia/addons/templates/addons/mobile/details.html:99 src/olympia/compat/templates/compat/reporter_detail.html:46 src/olympia/devhub/forms.py:788
 #: src/olympia/devhub/templates/devhub/versions/list.html:163
 msgid "Version"
 msgstr "版本"
@@ -1299,7 +1312,7 @@ msgstr "附加组件是一种通过增添额外的功能和样式来让您实现
 #: src/olympia/browse/templates/browse/personas/base.html:6 src/olympia/browse/templates/browse/personas/base.html:42 src/olympia/browse/templates/browse/personas/category_landing.html:21
 #: src/olympia/browse/templates/browse/personas/category_landing.html:23 src/olympia/browse/templates/browse/personas/category_landing.html:38 src/olympia/browse/templates/browse/personas/grid.html:7
 #: src/olympia/browse/templates/browse/personas/grid.html:11 src/olympia/browse/templates/browse/personas/mobile/base.html:7 src/olympia/browse/templates/browse/personas/mobile/category_landing.html:19
-#: src/olympia/constants/base.py:180 src/olympia/devhub/templates/devhub/personas/submit.html:13 src/olympia/editors/helpers.py:105 src/olympia/editors/templates/editors/base.html:26
+#: src/olympia/constants/base.py:180 src/olympia/devhub/templates/devhub/personas/submit.html:13 src/olympia/editors/helpers.py:107 src/olympia/editors/templates/editors/base.html:26
 #: src/olympia/editors/templates/editors/performance.html:73 src/olympia/search/templates/search/personas.html:39 src/olympia/templates/menu_links.html:9
 msgid "Themes"
 msgstr "主题"
@@ -1320,7 +1333,7 @@ msgstr "更多附加组件"
 msgid "Highest Rated"
 msgstr "最受好评"
 
-#: src/olympia/addons/templates/addons/mobile/home.html:74 src/olympia/amo/templates/amo/side_nav.html:5 src/olympia/amo/templates/amo/site_nav.html:27 src/olympia/amo/templates/amo/site_nav.html:57
+#: src/olympia/addons/templates/addons/mobile/home.html:74 src/olympia/amo/templates/amo/side_nav.html:5 src/olympia/amo/templates/amo/site_nav.html:27 src/olympia/amo/templates/amo/site_nav.html:55
 #: src/olympia/bandwagon/views.py:97 src/olympia/browse/views.py:57 src/olympia/browse/views.py:67 src/olympia/browse/templates/browse/personas/mobile/category_landing.html:65
 #: src/olympia/search/forms.py:15 src/olympia/search/forms.py:87
 msgid "Newest"
@@ -1338,84 +1351,84 @@ msgstr "主题信息 &raquo;"
 msgid "Tools"
 msgstr "工具"
 
-#: src/olympia/amo/context_processors.py:48 src/olympia/discovery/templates/discovery/pane_account.html:8 src/olympia/users/templates/users/includes/navigation.html:2
+#: src/olympia/amo/context_processors.py:49 src/olympia/discovery/templates/discovery/pane_account.html:8 src/olympia/users/templates/users/includes/navigation.html:2
 msgid "My Profile"
 msgstr "我的概况"
 
-#: src/olympia/amo/context_processors.py:54 src/olympia/users/templates/users/edit.html:5 src/olympia/users/templates/users/includes/navigation.html:3
+#: src/olympia/amo/context_processors.py:55 src/olympia/users/templates/users/edit.html:5 src/olympia/users/templates/users/includes/navigation.html:3
 msgid "Account Settings"
 msgstr "账户设置"
 
-#: src/olympia/amo/context_processors.py:57 src/olympia/discovery/templates/discovery/pane_account.html:11 src/olympia/users/templates/users/profile.html:83
+#: src/olympia/amo/context_processors.py:58 src/olympia/discovery/templates/discovery/pane_account.html:11 src/olympia/users/templates/users/profile.html:83
 #: src/olympia/users/templates/users/includes/navigation.html:4
 msgid "My Collections"
 msgstr "我的收藏集"
 
-#: src/olympia/amo/context_processors.py:62 src/olympia/discovery/templates/discovery/pane_account.html:10 src/olympia/users/templates/users/includes/navigation.html:7
+#: src/olympia/amo/context_processors.py:63 src/olympia/discovery/templates/discovery/pane_account.html:10 src/olympia/users/templates/users/includes/navigation.html:7
 msgid "My Favorites"
 msgstr "我的收藏夹"
 
-#: src/olympia/amo/context_processors.py:67 src/olympia/discovery/templates/discovery/pane_account.html:13 src/olympia/templates/impala/user_login.html:14 src/olympia/templates/mobile/header_auth.html:5
+#: src/olympia/amo/context_processors.py:68 src/olympia/discovery/templates/discovery/pane_account.html:13 src/olympia/templates/impala/user_login.html:14 src/olympia/templates/mobile/header_auth.html:5
 msgid "Log out"
 msgstr "退出"
 
-#: src/olympia/amo/context_processors.py:72 src/olympia/devhub/templates/devhub/addons/dashboard.html:4
+#: src/olympia/amo/context_processors.py:73 src/olympia/devhub/templates/devhub/addons/dashboard.html:4
 msgid "Manage My Submissions"
 msgstr "管理我的提交"
 
-#: src/olympia/amo/context_processors.py:75 src/olympia/devhub/templates/devhub/nav.html:27 src/olympia/devhub/templates/devhub/addons/dashboard.html:25
+#: src/olympia/amo/context_processors.py:76 src/olympia/devhub/templates/devhub/nav.html:27 src/olympia/devhub/templates/devhub/addons/dashboard.html:25
 #: src/olympia/devhub/templates/devhub/addons/submit/base.html:4
 msgid "Submit a New Add-on"
 msgstr "提交新的附加组件"
 
-#: src/olympia/amo/context_processors.py:77 src/olympia/browse/templates/browse/personas/base.html:50 src/olympia/devhub/templates/devhub/index.html:24
+#: src/olympia/amo/context_processors.py:78 src/olympia/browse/templates/browse/personas/base.html:50 src/olympia/devhub/templates/devhub/index.html:24
 #: src/olympia/devhub/templates/devhub/addons/dashboard.html:29
 msgid "Submit a New Theme"
 msgstr "提交一个新主题"
 
-#: src/olympia/amo/context_processors.py:79 src/olympia/amo/templates/amo/site_nav.html:87 src/olympia/devhub/helpers.py:36 src/olympia/devhub/helpers.py:68 src/olympia/devhub/helpers.py:102
+#: src/olympia/amo/context_processors.py:80 src/olympia/amo/templates/amo/site_nav.html:85 src/olympia/devhub/helpers.py:36 src/olympia/devhub/helpers.py:68 src/olympia/devhub/helpers.py:102
 #: src/olympia/templates/footer.html:6 src/olympia/templates/menu_links.html:14
 msgid "Developer Hub"
 msgstr "开发者中心"
 
-#: src/olympia/amo/context_processors.py:83 src/olympia/devhub/views.py:1792
+#: src/olympia/amo/context_processors.py:84 src/olympia/devhub/views.py:1799
 msgid "Manage API Keys"
 msgstr "管理 API 密钥"
 
-#: src/olympia/amo/context_processors.py:88 src/olympia/editors/helpers.py:82 src/olympia/editors/helpers.py:102 src/olympia/editors/templates/editors/base.html:10
+#: src/olympia/amo/context_processors.py:89 src/olympia/editors/helpers.py:84 src/olympia/editors/helpers.py:104 src/olympia/editors/templates/editors/base.html:10
 msgid "Editor Tools"
 msgstr "审核员工具"
 
-#: src/olympia/amo/context_processors.py:92
+#: src/olympia/amo/context_processors.py:93
 msgid "Admin Tools"
 msgstr "管理工具"
 
-#: src/olympia/amo/fields.py:15
+#: src/olympia/amo/fields.py:20
 msgid "Incorrect, please try again."
 msgstr "不正确，请重试。"
 
-#: src/olympia/amo/fields.py:16
+#: src/olympia/amo/fields.py:21
 msgid "Error verifying input, please try again."
 msgstr "验证输入出错，请重试。"
 
-#: src/olympia/amo/fields.py:32
+#: src/olympia/amo/fields.py:37
 msgid "This must be a valid hex color code, such as #000000."
 msgstr "这里必须是一个有效的十六进制颜色代码，例如 #000000。"
 
-#: src/olympia/amo/fields.py:58
+#: src/olympia/amo/fields.py:63
 msgid "Enter at least one value."
 msgstr "至少输入一个值。"
 
-#: src/olympia/amo/helpers.py:162 src/olympia/amo/templates/amo/site_nav.html:61 src/olympia/bandwagon/templates/bandwagon/add.html:9 src/olympia/bandwagon/templates/bandwagon/collection_detail.html:15
+#: src/olympia/amo/helpers.py:162 src/olympia/amo/templates/amo/site_nav.html:59 src/olympia/bandwagon/templates/bandwagon/add.html:9 src/olympia/bandwagon/templates/bandwagon/collection_detail.html:15
 #: src/olympia/bandwagon/templates/bandwagon/delete.html:9 src/olympia/bandwagon/templates/bandwagon/edit.html:15 src/olympia/bandwagon/templates/bandwagon/user_listing.html:18
 #: src/olympia/bandwagon/templates/bandwagon/user_listing.html:21 src/olympia/bandwagon/templates/bandwagon/impala/collection_listing.html:12
 #: src/olympia/bandwagon/templates/bandwagon/impala/collection_listing.html:20 src/olympia/bandwagon/templates/bandwagon/impala/collection_listing.html:24
 #: src/olympia/bandwagon/templates/bandwagon/impala/collection_sidebar.html:3 src/olympia/bandwagon/templates/bandwagon/includes/collection_sidebar.html:2
-#: src/olympia/bandwagon/templates/bandwagon/mobile/collection_listing.html:3 src/olympia/stats/templates/stats/stats.html:77 src/olympia/templates/menu_links.html:12
+#: src/olympia/bandwagon/templates/bandwagon/mobile/collection_listing.html:3 src/olympia/stats/templates/stats/stats.html:33 src/olympia/templates/menu_links.html:12
 msgid "Collections"
 msgstr "收藏集"
 
-#: src/olympia/amo/helpers.py:171 src/olympia/amo/templates/amo/site_nav.html:85 src/olympia/browse/templates/browse/language_tools.html:3
+#: src/olympia/amo/helpers.py:171 src/olympia/amo/templates/amo/site_nav.html:83 src/olympia/browse/templates/browse/language_tools.html:3
 msgid "Dictionaries & Language Packs"
 msgstr "字典及语言包"
 
@@ -1567,8 +1580,8 @@ msgstr "已要求高级审核"
 msgid "Comment on {addon} {version}."
 msgstr "对 {addon} {version} 的评论。"
 
-#: src/olympia/amo/log.py:236 src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:19 src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:47
-#: src/olympia/editors/helpers.py:511 src/olympia/editors/templates/editors/themes/history_table.html:11
+#: src/olympia/amo/log.py:236 src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:17 src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:45
+#: src/olympia/editors/helpers.py:584 src/olympia/editors/templates/editors/themes/history_table.html:11
 msgid "Comment"
 msgstr "评论"
 
@@ -1721,8 +1734,8 @@ msgid "Reviewer escalation"
 msgstr "审核者向上呈报"
 
 #: src/olympia/amo/log.py:442
-msgid "Video removed from {addon} because of a problem with the video. "
-msgstr "视频存在问题，已从 {addon} 中移除。"
+msgid "Video removed from {addon} because of a problem with the video."
+msgstr "因为该视频存在问题，视频已从 {addon} 移除。"
 
 #: src/olympia/amo/log.py:444
 msgid "Video removed"
@@ -1871,8 +1884,8 @@ msgstr "哎呀"
 
 #: src/olympia/amo/templates/amo/500.html:6
 #, python-format
-msgid "<h1>Oops!  We had an error.</h1> <p>We'll get to fixing that soon.</p> <p> You can try refreshing the page, or head back to the <a href=\"%(home)s\">Add-ons homepage</a>. </p>"
-msgstr "<h1>啊呀！我们遇到一个错误。</h1> <p>我们会尽快修复它。</p> <p>您可以尝试刷新页面，或者返回<a href=\"%(home)s\">附加组件首页</a>。</p>"
+msgid "<h1>Oops! We had an error.</h1> <p>We'll get to fixing that soon.</p> <p> You can try refreshing the page, or head back to the <a href=\"%(home)s\">Add-ons homepage</a>. </p>"
+msgstr "<h1>哎呀！我们这边发生错误了。</h1> <p>我们会尽快修复这个问题。</p> <p>您可以尝试刷新页面，或者返回<a href=\"%(home)s\">附加组件主页</a>。</p>"
 
 #: src/olympia/amo/templates/amo/license_link.html:10
 msgid "Some rights reserved"
@@ -1894,7 +1907,7 @@ msgstr "上一页"
 #: src/olympia/amo/templates/amo/mobile/paginator.html:14 src/olympia/amo/templates/amo/mobile/paginator.html:16 src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:51
 #: src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:65 src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:78
 #: src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:91 src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:104
-#: src/olympia/discovery/templates/discovery/pane.html:45 src/olympia/discovery/templates/discovery/addons/detail.html:39 src/olympia/stats/templates/stats/stats.html:167
+#: src/olympia/discovery/templates/discovery/pane.html:45 src/olympia/discovery/templates/discovery/addons/detail.html:39 src/olympia/stats/templates/stats/stats.html:169
 msgid "Next"
 msgstr "下一页"
 
@@ -1926,7 +1939,7 @@ msgid ""
 msgstr "<p> 请输入下方的<strong>所有文字</strong>，<strong>如有间隔应使用空格分开</strong>。</p> <p> 如果这很难阅读，您可以<a href=\"#\" id=\"recaptcha_different\">尝试下一组文字</a>或者<a href=\"#\" id=\"recaptcha_audio\">另一种验证方式</a>。</p>"
 
 #: src/olympia/amo/templates/amo/side_nav.html:4 src/olympia/amo/templates/amo/side_nav.html:12 src/olympia/amo/templates/amo/site_nav.html:4 src/olympia/amo/templates/amo/site_nav.html:26
-#: src/olympia/browse/views.py:56 src/olympia/browse/views.py:66 src/olympia/browse/views.py:237 src/olympia/browse/views.py:282 src/olympia/search/forms.py:86
+#: src/olympia/browse/views.py:56 src/olympia/browse/views.py:66 src/olympia/browse/views.py:204 src/olympia/browse/views.py:249 src/olympia/search/forms.py:86
 msgid "Top Rated"
 msgstr "评分最高"
 
@@ -1941,37 +1954,37 @@ msgstr "浏览"
 msgid "Extensions"
 msgstr "扩展"
 
-#: src/olympia/amo/templates/amo/site_nav.html:45
+#: src/olympia/amo/templates/amo/site_nav.html:44
 msgid "Want more customization? Try <b>Complete Themes</b>"
 msgstr "想要更强定制性？尝试<b>完整主题</b>"
 
-#: src/olympia/amo/templates/amo/site_nav.html:56 src/olympia/bandwagon/views.py:96
+#: src/olympia/amo/templates/amo/site_nav.html:54 src/olympia/bandwagon/views.py:96
 msgid "Most Followers"
 msgstr "最多关注者"
 
-#: src/olympia/amo/templates/amo/site_nav.html:68 src/olympia/bandwagon/templates/bandwagon/impala/collection_sidebar.html:16 src/olympia/bandwagon/templates/bandwagon/includes/collection_sidebar.html:18
+#: src/olympia/amo/templates/amo/site_nav.html:66 src/olympia/bandwagon/templates/bandwagon/impala/collection_sidebar.html:16 src/olympia/bandwagon/templates/bandwagon/includes/collection_sidebar.html:18
 msgid "Collections I've Made"
 msgstr "我建立的收藏集"
 
-#: src/olympia/amo/templates/amo/site_nav.html:70 src/olympia/bandwagon/templates/bandwagon/user_listing.html:4 src/olympia/bandwagon/templates/bandwagon/impala/collection_sidebar.html:13
+#: src/olympia/amo/templates/amo/site_nav.html:68 src/olympia/bandwagon/templates/bandwagon/user_listing.html:4 src/olympia/bandwagon/templates/bandwagon/impala/collection_sidebar.html:13
 #: src/olympia/bandwagon/templates/bandwagon/includes/collection_sidebar.html:15
 msgid "Collections I'm Following"
 msgstr "我关注的收藏集"
 
-#: src/olympia/amo/templates/amo/site_nav.html:73 src/olympia/bandwagon/templates/bandwagon/impala/collection_sidebar.html:18 src/olympia/bandwagon/templates/bandwagon/includes/collection_sidebar.html:20
-#: src/olympia/users/models.py:512
+#: src/olympia/amo/templates/amo/site_nav.html:71 src/olympia/bandwagon/templates/bandwagon/impala/collection_sidebar.html:18 src/olympia/bandwagon/templates/bandwagon/includes/collection_sidebar.html:20
+#: src/olympia/users/models.py:521
 msgid "My Favorite Add-ons"
 msgstr "我收藏的附加组件"
 
-#: src/olympia/amo/templates/amo/site_nav.html:78
+#: src/olympia/amo/templates/amo/site_nav.html:76
 msgid "More&hellip;"
 msgstr "更多 &hellip;"
 
-#: src/olympia/amo/templates/amo/site_nav.html:82
+#: src/olympia/amo/templates/amo/site_nav.html:80
 msgid "Add-ons for Mobile"
 msgstr "移动版附加组件"
 
-#: src/olympia/amo/templates/amo/site_nav.html:86 src/olympia/browse/feeds.py:207 src/olympia/browse/templates/browse/search_tools.html:3 src/olympia/constants/base.py:176
+#: src/olympia/amo/templates/amo/site_nav.html:84 src/olympia/browse/feeds.py:207 src/olympia/browse/templates/browse/search_tools.html:3 src/olympia/constants/base.py:176
 #: src/olympia/templates/menu_links.html:10
 msgid "Search Tools"
 msgstr "搜索工具"
@@ -1987,7 +2000,7 @@ msgid "Jump to first page"
 msgstr "转到第一页"
 
 #: src/olympia/amo/templates/amo/impala/paginator.html:22 src/olympia/amo/templates/amo/mobile/impala_paginator.html:12 src/olympia/discovery/templates/discovery/pane.html:44
-#: src/olympia/discovery/templates/discovery/addons/detail.html:38 src/olympia/stats/templates/stats/stats.html:164
+#: src/olympia/discovery/templates/discovery/addons/detail.html:38 src/olympia/stats/templates/stats/stats.html:166
 msgid "Previous"
 msgstr "上一页"
 
@@ -1997,7 +2010,7 @@ msgstr "跳到最后一页"
 
 #. First and second arguments are the result range (e.g., 1-20);
 #. third argument is the number of total results (e.g., 1,000).
-#. third
+#. First and second arguments are the result range (e.g., 1-20);              third
 #. argument is the number of total results (e.g., 1,000).
 #: src/olympia/amo/templates/amo/impala/paginator.html:36 src/olympia/amo/templates/amo/mobile/impala_paginator.html:38
 #, python-format
@@ -2008,32 +2021,52 @@ msgstr "目前显示第 <b>%(begin)s</b>&ndash;<b>%(end)s</b> 项，共 <b>%(cou
 msgid "Page {n}"
 msgid_plural "Page {n}"
 msgstr[0] "第 {n} 页"
+msgstr[1] ""
 
-#: src/olympia/amo/templates/services/install.html:38
-#, python-format
-msgid "If you are not prompted to install %(addon_name)s in a moment, please <a href=\"%(addon_xpi)s\">click here</a>."
-msgstr "如果片刻后您没有看到安装 %(addon_name)s 的提示，请点击 <a href=\"%(addon_xpi)s\">这里</a>。"
-
-#: src/olympia/amo/tests/test_messages.py:57 src/olympia/amo/tests/test_messages.py:58 src/olympia/reviews/forms.py:25 src/olympia/reviews/forms.py:50 src/olympia/reviews/templates/reviews/add.html:56
+#: src/olympia/amo/tests/test_messages.py:56 src/olympia/amo/tests/test_messages.py:57 src/olympia/reviews/forms.py:25 src/olympia/reviews/forms.py:50 src/olympia/reviews/templates/reviews/add.html:56
 #: src/olympia/reviews/templates/reviews/reply.html:30
 msgid "Title"
 msgstr "标题"
 
-#: src/olympia/amo/tests/test_messages.py:57 src/olympia/amo/tests/test_messages.py:58
+#: src/olympia/amo/tests/test_messages.py:56 src/olympia/amo/tests/test_messages.py:57
 msgid "Body"
 msgstr "正文"
 
-#: src/olympia/amo/tests/test_messages.py:59
+#: src/olympia/amo/tests/test_messages.py:58
 msgid "Another Title"
 msgstr "另一个标题"
 
-#: src/olympia/amo/tests/test_messages.py:59
+#: src/olympia/amo/tests/test_messages.py:58
 msgid "Another Body"
 msgstr "另一个主体"
 
-#: src/olympia/api/views.py:255
-msgid "Not implemented yet."
-msgstr "尚未完成。"
+#: src/olympia/api/authentication.py:76
+msgid "Signature has expired."
+msgstr ""
+
+#: src/olympia/api/authentication.py:79
+msgid "Error decoding signature."
+msgstr ""
+
+#: src/olympia/api/authentication.py:82
+msgid "Invalid JWT Token."
+msgstr ""
+
+#: src/olympia/api/authentication.py:130
+msgid "Invalid Authorization header. No credentials provided."
+msgstr ""
+
+#: src/olympia/api/authentication.py:133
+msgid "Invalid Authorization header. Credentials string should not contain spaces."
+msgstr ""
+
+#: src/olympia/api/fields.py:29
+msgid "The field must have a length of at least {num} characters."
+msgstr ""
+
+#: src/olympia/api/fields.py:31
+msgid "The language code {lang_code} is invalid."
+msgstr ""
 
 #: src/olympia/applications/views.py:39 src/olympia/applications/templates/applications/appversions.html:3
 msgid "Application Versions"
@@ -2051,7 +2084,7 @@ msgstr "有效应用程序版本"
 msgid "Add-ons submitted to Mozilla Add-ons must have a manifest file with at least one of the below applications supported. Only the versions listed below are allowed for these applications."
 msgstr "提交到 Mozilla 附加组件的附加组件的清单文件必须支持下面的至少一个应用程序。只允许下面列出的这些应用程序版本。"
 
-#: src/olympia/applications/templates/applications/appversions.html:25
+#: src/olympia/applications/templates/applications/appversions.html:25 src/olympia/editors/helpers.py:361
 msgid "GUID"
 msgstr "GUID"
 
@@ -2128,11 +2161,11 @@ msgstr "不允许使用链接。"
 msgid "This url is already in use by another collection"
 msgstr "此网址已被其他收藏集使用"
 
-#: src/olympia/bandwagon/forms.py:197 src/olympia/devhub/views.py:1049
+#: src/olympia/bandwagon/forms.py:197 src/olympia/devhub/views.py:1050
 msgid "Icons must be either PNG or JPG."
 msgstr "图标必须为 PNG 或 JPG 格式。"
 
-#: src/olympia/bandwagon/forms.py:202 src/olympia/devhub/views.py:1067 src/olympia/users/forms.py:476
+#: src/olympia/bandwagon/forms.py:202 src/olympia/devhub/views.py:1068 src/olympia/users/forms.py:476
 #, python-format
 msgid "Please use images smaller than %dMB."
 msgstr "请使用小于 %dMB 的图像。"
@@ -2165,8 +2198,8 @@ msgstr "收藏夹"
 msgid "Remove from favorites"
 msgstr "从收藏夹中移除"
 
-#: src/olympia/bandwagon/views.py:98 src/olympia/bandwagon/views.py:191 src/olympia/browse/views.py:58 src/olympia/browse/views.py:69 src/olympia/browse/views.py:458 src/olympia/devhub/views.py:74
-#: src/olympia/devhub/views.py:82 src/olympia/devhub/templates/devhub/addons/edit/basic.html:20 src/olympia/editors/templates/editors/leaderboard.html:24
+#: src/olympia/bandwagon/views.py:98 src/olympia/bandwagon/views.py:191 src/olympia/browse/views.py:58 src/olympia/browse/views.py:69 src/olympia/browse/views.py:425 src/olympia/devhub/views.py:73
+#: src/olympia/devhub/views.py:81 src/olympia/devhub/templates/devhub/addons/edit/basic.html:20 src/olympia/editors/templates/editors/leaderboard.html:24
 #: src/olympia/editors/templates/editors/themes/queue_list.html:48 src/olympia/search/forms.py:17 src/olympia/search/forms.py:89 src/olympia/users/templates/users/vcard.html:5
 msgid "Name"
 msgstr "名称"
@@ -2175,7 +2208,7 @@ msgstr "名称"
 msgid "Recently Popular"
 msgstr "最近热门"
 
-#: src/olympia/bandwagon/views.py:189 src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:18
+#: src/olympia/bandwagon/views.py:189 src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:16
 msgid "Added"
 msgstr "添加日期"
 
@@ -2189,8 +2222,8 @@ msgstr "收藏集已创建！"
 
 #: src/olympia/bandwagon/views.py:316
 #, python-format
-msgid "Your new collection is shown below. You can <ahref=\"%(url)s\">edit additional settings</a> if you'dlike."
-msgstr "您的新收藏夹显示在下面。如果您不喜欢，您可以<ahref=\"%(url)s\">编辑额外设置</a>。"
+msgid "Your new collection is shown below. You can <a href=\"%(url)s\">edit additional settings</a> if you'd like."
+msgstr "您的新收藏集已显示在下方。如果需要，您可以<a href=\"%(url)s\">编辑其他设置</a>。"
 
 #: src/olympia/bandwagon/views.py:322
 msgid "Collection updated!"
@@ -2269,6 +2302,7 @@ msgstr "私有"
 msgid "<span>%(num)s</span> follower"
 msgid_plural "<span>%(num)s</span> followers"
 msgstr[0] "<span>%(num)s</span> 个关注者"
+msgstr[1] ""
 
 #: src/olympia/bandwagon/templates/bandwagon/collection_detail.html:54
 msgid "About this Collection"
@@ -2307,15 +2341,17 @@ msgstr "删除收藏集"
 msgid "%(num)s Theme in this Collection"
 msgid_plural "%(num)s Themes in this Collection"
 msgstr[0] "此收藏集有 %(num)s 个主题"
+msgstr[1] ""
 
 #: src/olympia/bandwagon/templates/bandwagon/collection_detail.html:111
 #, python-format
 msgid "%(num)s Add-on in this Collection"
 msgid_plural "%(num)s Add-ons in this Collection"
 msgstr[0] "此收藏集中有 %(num)s 个附加组件"
+msgstr[1] ""
 
-#: src/olympia/bandwagon/templates/bandwagon/collection_detail.html:125 src/olympia/compat/templates/compat/index.html:25 src/olympia/compat/templates/compat/reporter_detail.html:29
-#: src/olympia/files/templates/files/viewer.html:29 src/olympia/templates/amo_footer.html:17 src/olympia/templates/includes/lang_switcher.html:10
+#: src/olympia/bandwagon/templates/bandwagon/collection_detail.html:125 src/olympia/compat/templates/compat/reporter_detail.html:29 src/olympia/files/templates/files/viewer.html:29
+#: src/olympia/templates/amo_footer.html:17 src/olympia/templates/includes/lang_switcher.html:10
 msgid "Go"
 msgstr "转到"
 
@@ -2347,9 +2383,9 @@ msgstr "以下这些附加组件已被您使用<b>添加到收藏夹</b>功能�
 
 #: src/olympia/bandwagon/templates/bandwagon/collection_detail.html:186
 msgid ""
-"Add-ons that you mark as favorites using the <b>Add to Favorites</b> feature appear below. This collection is currently <b>private</b>, which means only you can see it.  If you would like everyone "
+"Add-ons that you mark as favorites using the <b>Add to Favorites</b> feature appear below. This collection is currently <b>private</b>, which means only you can see it. If you would like everyone "
 "to be able to see your favorites, click the button below to make it public."
-msgstr "使用在下方出现的 <b>添加到收藏夹</b> 功能标记您的最爱。此收藏目前是<b>私密</b>状态，即只有您能看到它及内容。如果您想每个人都看到您的收藏夹，点击下面的按钮将它公开。"
+msgstr "以下这些附加组件已被您使用<b>添加到收藏夹</b>功能标记为收藏。目前此收藏集是<b>私有的</b>，只有您可以看到它。如果您想让每个人都能看到您的收藏，请点击下面的按钮公开您的收藏集。"
 
 #: src/olympia/bandwagon/templates/bandwagon/collection_detail.html:196
 msgid "My favorite add-ons"
@@ -2360,41 +2396,45 @@ msgstr "我最喜爱的附加组件"
 msgid "<span>%(addons)s</span> add-on"
 msgid_plural "<span>%(addons)s</span> add-ons"
 msgstr[0] "<span>%(addons)s</span> 个附加组件"
+msgstr[1] ""
 
 #: src/olympia/bandwagon/templates/bandwagon/collection_grid.html:32
 #, python-format
 msgid "<span>%(followers)s</span> follower"
 msgid_plural "<span>%(followers)s</span> followers"
 msgstr[0] "<span>%(followers)s</span> 个关注者"
+msgstr[1] ""
 
-#. People "follow" collections to get notified of updates.
-#. Like
+#. People "follow" collections to get notified of updates.                    Like
 #. Twitter followers.
+#. People "follow" collections to get notified of updates.
 #. Like Twitter followers.
 #: src/olympia/bandwagon/templates/bandwagon/collection_listing_items.html:10 src/olympia/bandwagon/templates/bandwagon/impala/collection_listing_items.html:18
 #, python-format
 msgid "%(num)s weekly follower"
 msgid_plural "%(num)s weekly followers"
 msgstr[0] "%(num)s 名周订阅者"
+msgstr[1] ""
 
-#. People "follow" collections to get notified of updates.
-#. Like
+#. People "follow" collections to get notified of updates.                    Like
 #. Twitter followers.
 #: src/olympia/bandwagon/templates/bandwagon/collection_listing_items.html:18
 #, python-format
 msgid "%(num)s monthly follower"
 msgid_plural "%(num)s monthly followers"
 msgstr[0] "每月 %(num)s 个关注者"
+msgstr[1] ""
 
-#. People "follow" collections to get notified of updates.
-#. Like
+#. People "follow" collections to get notified of updates.                    Like
 #. Twitter followers.
+#. People "follow" collections to get notified of updates.
 #. Like Twitter followers.
 #: src/olympia/bandwagon/templates/bandwagon/collection_listing_items.html:26 src/olympia/bandwagon/templates/bandwagon/impala/collection_listing_items.html:26
 #, python-format
 msgid "%(num)s follower"
 msgid_plural "%(num)s followers"
 msgstr[0] "%(num)s 名订阅者"
+msgstr[1] ""
 
 #: src/olympia/bandwagon/templates/bandwagon/collection_listing_items.html:56 src/olympia/bandwagon/templates/bandwagon/impala/collection_listing_items.html:9
 #: src/olympia/devhub/templates/devhub/personas/edit.html:27
@@ -2479,7 +2519,7 @@ msgid "Remove this user as a contributor"
 msgstr "从贡献者中移除此用户"
 
 #: src/olympia/bandwagon/templates/bandwagon/edit_contributors.html:18 src/olympia/bandwagon/templates/bandwagon/edit_contributors.html:43
-#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:20 src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:48
+#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:18 src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:46
 #: src/olympia/devhub/templates/devhub/addons/ajax_compat_update.html:19
 msgid "Remove"
 msgstr "移除"
@@ -2490,9 +2530,9 @@ msgstr "收藏集贡献者"
 
 #: src/olympia/bandwagon/templates/bandwagon/edit_contributors.html:26
 msgid ""
-"You can add multiple contributors to this collection.  A contributor can add and remove add-ons from this collection, but cannot change its name or description.  To add a contributor, enter their "
+"You can add multiple contributors to this collection. A contributor can add and remove add-ons from this collection, but cannot change its name or description. To add a contributor, enter their "
 "email in the box below. Contributors must have a Mozilla Add-ons account."
-msgstr "您可以添加多个贡献者到此收藏集。贡献者可以添加和移除此收藏集内的附加组件，但不能更改收藏集的名称和描述。要添加一个贡献者，请在下方的框中输入他的电子邮件地址。贡献者必须有 Mozilla 附加组件 的账号。"
+msgstr "您可以添加多个贡献者到这个收藏集。被添加的贡献者可以从这个收藏集添加和移除附加组件，但不能更改名称和描述。在下面的框中输入他的电子邮件地址就能将其添加为贡献者了（贡献者必须拥有一个 Mozilla 附加组件帐户）。"
 
 #: src/olympia/bandwagon/templates/bandwagon/edit_contributors.html:40
 msgid "User"
@@ -2528,7 +2568,7 @@ msgid "<b>Warning:</b> By changing the owner of this collection, you will no lon
 msgstr "<b>警告：</b>改变此收藏集的所有者后您就不能再编辑它了，只能添加和删除附加组件。"
 
 #: src/olympia/bandwagon/templates/bandwagon/edit_contributors.html:83 src/olympia/devhub/templates/devhub/addons/forms_shared/media.html:157
-#: src/olympia/devhub/templates/devhub/addons/submit/describe.html:69 src/olympia/devhub/templates/devhub/addons/submit/license.html:60 src/olympia/devhub/templates/devhub/addons/submit/upload.html:78
+#: src/olympia/devhub/templates/devhub/addons/submit/describe.html:69 src/olympia/devhub/templates/devhub/addons/submit/license.html:60 src/olympia/devhub/templates/devhub/addons/submit/upload.html:70
 #: src/olympia/devhub/templates/devhub/payments/tier.html:17 src/olympia/editors/templates/editors/themes/themes.html:111 src/olympia/editors/templates/editors/themes/themes.html:128
 #: src/olympia/editors/templates/editors/themes/themes.html:134 src/olympia/editors/templates/editors/themes/themes.html:141 src/olympia/users/templates/users/fxa_migration_prompt_content.html:10
 #: src/olympia/users/templates/users/login_form.html:42 src/olympia/users/templates/users/mobile/login.html:57
@@ -2599,42 +2639,43 @@ msgid "Reset"
 msgstr "重置"
 
 #: src/olympia/bandwagon/templates/bandwagon/includes/addedit.html:53
-msgid "PNG and JPG supported.  Image will be resized to 32x32."
-msgstr "支持 PNG 和 JPG。图像尺寸将被调整为 32x32。"
+msgid "PNG and JPG supported. Image will be resized to 32x32."
+msgstr "支持 PNG 和 JPG。图像将被缩放为 32x32。"
 
 #: src/olympia/bandwagon/templates/bandwagon/includes/addedit_errors.html:3
-msgid "There are errors in this form.  Please correct them below."
-msgstr "此表单存在错误。请在下面进行更正。"
+msgid "There are errors in this form. Please correct them below."
+msgstr "此表单中有错误，请更正以下内容。"
 
 #: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:2
 msgid "Add-ons in Your Collection"
 msgstr "您收藏集中的附加组件"
 
 #: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:4
-msgid "To include an add-on in this collection, enter its name in the box below and hit enter.  You can also use the <strong>Add to Collection</strong> links throughout the site to include add-ons later."
-msgstr "要在此收藏集中增加一个附加组件，请在下面的框中输入其名称然后回车。您也可以使用遍布整个网站的<strong>添加到收藏集</strong>链接来添加附加组件。"
+msgid "To include an add-on in this collection, enter its name in the box below and hit enter."
+msgstr ""
 
-#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:17 src/olympia/constants/base.py:400 src/olympia/devhub/templates/devhub/addons/activity.html:62
+#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:15 src/olympia/constants/base.py:400 src/olympia/devhub/templates/devhub/addons/activity.html:62
+#: src/olympia/editors/helpers.py:273 src/olympia/editors/helpers.py:360
 msgid "Add-on"
 msgstr "附加组件"
 
-#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:26
+#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:24
 msgid "Enter the name of the add-on to include"
 msgstr "输入要加入的附加组件名称"
 
-#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:28
+#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:26
 msgid "Add to Collection"
 msgstr "添加到收藏集"
 
-#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:45 src/olympia/editors/helpers.py:936 src/olympia/editors/helpers.py:956
+#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:43 src/olympia/editors/helpers.py:1016 src/olympia/editors/helpers.py:1036
 msgid "Pending"
 msgstr "等待中"
 
-#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:47
+#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:45
 msgid "Add a comment"
 msgstr "添加评论"
 
-#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:48
+#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:46
 msgid "Remove this add-on from the collection"
 msgstr "从收藏集中移除此附加组件"
 
@@ -2683,8 +2724,8 @@ msgstr "有问题的附加组件或插件将自动被禁用且不再可用。"
 #, python-format
 msgid ""
 "When Mozilla becomes aware of add-ons, plugins, or other third-party software that seriously compromises %(app)s security, stability, or performance and meets <a href=\"%(criteria)s\">certain "
-"criteria</a>, the software may be blocked from general use.  For more information, please read <a href=\"%(support)s\">this support article</a>."
-msgstr "当 Mozilla 意识到某个附加组件、插件或第三方软件严重威胁 %(app)s 的安全性、稳定性或性能，并且符合<a href=\"%(criteria)s\">特定标准</a>时，该软件可能被阻止正常使用。更多信息请阅读<a href=\"%(support)s\">这篇支持文章</a>。"
+"criteria</a>, the software may be blocked from general use. For more information, please read <a href=\"%(support)s\">this support article</a>."
+msgstr "当 Mozilla 注意到有附加组件、插件，或其他第三方软件严重危及 %(app)s 的安全性、稳定性或性能，并符合<a href=\"%(criteria)s\">特定标准</a>时，该软件就可能被封锁，防止被公众使用。有关更多信息，请阅读<a href=\"%(support)s\">这篇技术支持文章</a>。"
 
 #: src/olympia/blocklist/templates/blocklist/blocked_detail.html:44
 #, python-format
@@ -2741,12 +2782,12 @@ msgstr "搜索工具"
 msgid "Most Users"
 msgstr "用户最多"
 
-#: src/olympia/browse/views.py:61 src/olympia/browse/views.py:72 src/olympia/browse/views.py:279 src/olympia/browse/templates/browse/personas/mobile/category_landing.html:63
+#: src/olympia/browse/views.py:61 src/olympia/browse/views.py:72 src/olympia/browse/views.py:246 src/olympia/browse/templates/browse/personas/mobile/category_landing.html:63
 #: src/olympia/discovery/templates/discovery/pane.html:67 src/olympia/search/forms.py:92
 msgid "Up & Coming"
 msgstr "崭露头角"
 
-#: src/olympia/browse/views.py:460 src/olympia/devhub/views.py:76 src/olympia/devhub/views.py:83 src/olympia/discovery/templates/discovery/addons/detail.html:66
+#: src/olympia/browse/views.py:427 src/olympia/devhub/views.py:75 src/olympia/devhub/views.py:82 src/olympia/discovery/templates/discovery/addons/detail.html:66
 msgid "Created"
 msgstr "创建日期"
 
@@ -2826,6 +2867,7 @@ msgstr "{0} :: 搜索工具"
 msgid "<b>{0}</b> add-on"
 msgid_plural "<b>{0}</b> add-ons"
 msgstr[0] "<b>{0}</b> 个附加组件"
+msgstr[1] ""
 
 #: src/olympia/browse/templates/browse/search_tools.html:61
 msgid "Search Extensions"
@@ -2931,9 +2973,10 @@ msgstr "完整主题新秀"
 msgid "See the %(cnt)s extension in %(name)s &raquo;"
 msgid_plural "See all %(cnt)s extensions in %(name)s &raquo;"
 msgstr[0] "浏览 %(name)s 中的 %(cnt)s 个扩展 &raquo;"
+msgstr[1] ""
 
-#: src/olympia/browse/templates/browse/mobile/extensions.html:13 src/olympia/compat/templates/compat/index.html:82 src/olympia/devhub/templates/devhub/devhub_search.html:24
-#: src/olympia/devhub/templates/devhub/addons/activity.html:47 src/olympia/search/templates/search/no_results.html:4 src/olympia/search/templates/search/mobile/results.html:36
+#: src/olympia/browse/templates/browse/mobile/extensions.html:13 src/olympia/devhub/templates/devhub/devhub_search.html:24 src/olympia/devhub/templates/devhub/addons/activity.html:47
+#: src/olympia/search/templates/search/no_results.html:4 src/olympia/search/templates/search/mobile/results.html:36
 msgid "No results found."
 msgstr "未找到结果。"
 
@@ -3018,7 +3061,7 @@ msgstr "&laquo; 全部主题"
 msgid "All"
 msgstr "全部"
 
-#: src/olympia/compat/forms.py:22 src/olympia/search/views.py:525
+#: src/olympia/compat/forms.py:22 src/olympia/editors/templates/editors/base.html:69 src/olympia/search/views.py:518
 msgid "All Add-ons"
 msgstr "所有附加组件"
 
@@ -3029,53 +3072,6 @@ msgstr "二进制"
 #: src/olympia/compat/forms.py:24
 msgid "Non-binary"
 msgstr "非二进制"
-
-#. Review points sources other than add-ons and themes.
-#: src/olympia/compat/views.py:87 src/olympia/constants/base.py:388 src/olympia/devhub/forms.py:162 src/olympia/editors/templates/editors/performance.html:75
-msgid "Other"
-msgstr "其他"
-
-#: src/olympia/compat/templates/compat/index.html:4
-msgid "Add-on Compatibility Report for {app} {version}"
-msgstr "{app} {version} 的附加组件兼容性报告"
-
-#: src/olympia/compat/templates/compat/index.html:11
-msgid "{app} {version} Compatibility"
-msgstr "{app} {version} 兼容性"
-
-#: src/olympia/compat/templates/compat/index.html:17
-#, python-format
-msgid "Top 95%% compatible with previous version"
-msgstr "与上一版本兼容的前 95%%"
-
-#: src/olympia/compat/templates/compat/index.html:18
-#, python-format
-msgid "Top 95%% of all add-ons"
-msgstr "所有附加组件的前 95%%"
-
-#: src/olympia/compat/templates/compat/index.html:19
-msgid "All active add-ons"
-msgstr "全部的现行附加组件"
-
-#: src/olympia/compat/templates/compat/index.html:23 src/olympia/constants/base.py:401
-msgid "App"
-msgstr "应用"
-
-#: src/olympia/compat/templates/compat/index.html:55
-msgid "Details for add-ons compatible with previous version:"
-msgstr "与前一版本兼容的附加组件的详细信息："
-
-#: src/olympia/compat/templates/compat/index.html:57
-msgid "Show all versions"
-msgstr "显示所有版本"
-
-#: src/olympia/compat/templates/compat/index.html:59
-msgid "Details for add-ons compatible with all versions:"
-msgstr "与所有版本兼容的附加组件的详细信息："
-
-#: src/olympia/compat/templates/compat/index.html:61
-msgid "Show previous version only"
-msgstr "仅显示早期版本"
 
 #: src/olympia/compat/templates/compat/reporter.html:3
 msgid "Add-on Compatibility Reports"
@@ -3108,11 +3104,13 @@ msgstr "{addon} 的兼容性报告"
 msgid "{0} success report"
 msgid_plural "{0} success reports"
 msgstr[0] "{0} 个成功报告"
+msgstr[1] ""
 
 #: src/olympia/compat/templates/compat/reporter_detail.html:17
 msgid "{0} problem report"
 msgid_plural "{0} problem reports"
 msgstr[0] "{0} 个问题报告"
+msgstr[1] ""
 
 #: src/olympia/compat/templates/compat/reporter_detail.html:21 src/olympia/users/templates/users/profile.html:70
 msgid "View all"
@@ -3126,8 +3124,8 @@ msgstr "按应用程序排序"
 msgid "Report Type"
 msgstr "报告类型"
 
-#: src/olympia/compat/templates/compat/reporter_detail.html:47 src/olympia/devhub/forms.py:784 src/olympia/devhub/templates/devhub/addons/ajax_compat_update.html:17 src/olympia/editors/forms.py:108
-#: src/olympia/zadmin/forms.py:45
+#: src/olympia/compat/templates/compat/reporter_detail.html:47 src/olympia/devhub/forms.py:785 src/olympia/devhub/templates/devhub/addons/ajax_compat_update.html:17 src/olympia/editors/forms.py:108
+#: src/olympia/editors/forms.py:248 src/olympia/zadmin/forms.py:45
 msgid "Application"
 msgstr "应用程序"
 
@@ -3215,7 +3213,8 @@ msgstr "已初步审核"
 msgid "Preliminarily Reviewed and Awaiting Full Review"
 msgstr "已初步审核并等待全面审核"
 
-#: src/olympia/constants/base.py:33 src/olympia/editors/helpers.py:924 src/olympia/editors/templates/editors/themes/history_table.html:34
+#: src/olympia/constants/base.py:33 src/olympia/editors/forms.py:258 src/olympia/editors/helpers.py:73 src/olympia/editors/helpers.py:1004
+#: src/olympia/editors/templates/editors/themes/history_table.html:34
 msgid "Deleted"
 msgstr "已删除"
 
@@ -3315,6 +3314,11 @@ msgstr "用户开始下载这个附加组件后询问"
 msgid "Ask before users can download this add-on"
 msgstr "用户下载这个附加组件前询问"
 
+#. Review points sources other than add-ons and themes.
+#: src/olympia/constants/base.py:388 src/olympia/devhub/forms.py:162 src/olympia/editors/templates/editors/performance.html:75
+msgid "Other"
+msgstr "其他"
+
 #: src/olympia/constants/base.py:389
 msgid "Exception"
 msgstr "例外"
@@ -3326,6 +3330,10 @@ msgstr "发布"
 #: src/olympia/constants/base.py:391
 msgid "Change"
 msgstr "更改"
+
+#: src/olympia/constants/base.py:401
+msgid "App"
+msgstr "应用"
 
 #: src/olympia/constants/base.py:402
 msgid "Persona"
@@ -3475,7 +3483,7 @@ msgstr "标记"
 msgid "Duplicate"
 msgstr "重复"
 
-#: src/olympia/constants/editors.py:17 src/olympia/editors/helpers.py:502 src/olympia/editors/templates/editors/themes/queue.html:71 src/olympia/editors/templates/editors/themes/themes.html:94
+#: src/olympia/constants/editors.py:17 src/olympia/editors/helpers.py:575 src/olympia/editors/templates/editors/themes/queue.html:71 src/olympia/editors/templates/editors/themes/themes.html:94
 msgid "Reject"
 msgstr "拒绝"
 
@@ -3575,7 +3583,7 @@ msgstr "Solaris"
 msgid "Android"
 msgstr "Android"
 
-#: src/olympia/core/apps.py:19
+#: src/olympia/core/apps.py:21
 msgid "Core"
 msgstr "核心"
 
@@ -3709,8 +3717,8 @@ msgid "Submit my add-on for manual review."
 msgstr "提交我的附加组件进行人工审核。"
 
 #: src/olympia/devhub/forms.py:537
-msgid "Do not list my add-on on this site (beta)"
-msgstr "不要在此网站上展示我的附加组件（测试版功能）"
+msgid "Do not list my add-on on this site"
+msgstr ""
 
 #: src/olympia/devhub/forms.py:538
 msgid "Check this option if you intend to distribute your add-on on your own and only need it to be signed by Mozilla."
@@ -3742,46 +3750,46 @@ msgstr "文件中的版本以 a|alpha|b|beta|pre|rc 结尾（及可选的数字�
 
 #: src/olympia/devhub/forms.py:592
 #, python-format
-msgid "Version %s already exists"
-msgstr "版本 %s 已存在"
+msgid "Version %s already exists, or was uploaded before."
+msgstr ""
 
-#: src/olympia/devhub/forms.py:604
+#: src/olympia/devhub/forms.py:605
 msgid "Select a valid choice. That choice is not one of the available choices."
 msgstr "请选择一个有效的选项。目前的选项不是可用的选项之一。"
 
-#: src/olympia/devhub/forms.py:610
+#: src/olympia/devhub/forms.py:611
 msgid "A file with a version ending with a|alpha|b|beta and an optional number is detected as beta."
 msgstr "一个文件具有 a|alpha|b|beta 的版本和一个可选的数字将检测为 beta 版本。"
 
-#: src/olympia/devhub/forms.py:633
+#: src/olympia/devhub/forms.py:634
 msgid "You cannot upload any more files for this version."
 msgstr "您不能再为此版本上传文件。"
 
-#: src/olympia/devhub/forms.py:639
+#: src/olympia/devhub/forms.py:640
 msgid "Version doesn't match"
 msgstr "版本不匹配"
 
-#: src/olympia/devhub/forms.py:668
-msgid "You cannot delete a file once the review process has started.  You must delete the whole version."
-msgstr "您不能在审核开始后删除一个文件。您只能删除整个文件。"
+#: src/olympia/devhub/forms.py:669
+msgid "You cannot delete a file once the review process has started. You must delete the whole version."
+msgstr "审核过程开始后您不能删除文件。您必须删除整个版本。"
 
-#: src/olympia/devhub/forms.py:688
+#: src/olympia/devhub/forms.py:689
 msgid "The platform All cannot be combined with specific platforms."
 msgstr "不能既选择所有平台又指定特定平台。"
 
-#: src/olympia/devhub/forms.py:693
+#: src/olympia/devhub/forms.py:694
 msgid "A platform can only be chosen once."
 msgstr "一个平台只能被选择一次。"
 
-#: src/olympia/devhub/forms.py:706
+#: src/olympia/devhub/forms.py:707
 msgid "A review type must be selected."
 msgstr "必须选择一个审核类型。"
 
-#: src/olympia/devhub/forms.py:788 src/olympia/editors/forms.py:114 src/olympia/zadmin/forms.py:49 src/olympia/zadmin/forms.py:52
+#: src/olympia/devhub/forms.py:789 src/olympia/editors/forms.py:114 src/olympia/editors/forms.py:254 src/olympia/zadmin/forms.py:49 src/olympia/zadmin/forms.py:52
 msgid "Select an application first"
 msgstr "请先选择一个应用程序"
 
-#: src/olympia/devhub/forms.py:840
+#: src/olympia/devhub/forms.py:841
 msgid "There cannot be more than 3 required add-ons."
 msgstr "必需的附加组件不能超过三个。"
 
@@ -3803,6 +3811,7 @@ msgstr "开发者文档"
 msgid "{0} error"
 msgid_plural "{0} errors"
 msgstr[0] "{0} 个错误"
+msgstr[1] ""
 
 # {0} is a number
 #. L10n: first parameter is the number of warnings
@@ -3810,165 +3819,166 @@ msgstr[0] "{0} 个错误"
 msgid "{0} warning"
 msgid_plural "{0} warnings"
 msgstr[0] "{0} 个警告"
+msgstr[1] ""
 
 #: src/olympia/devhub/models.py:375 src/olympia/reviews/templates/reviews/add.html:58
 msgid "Review"
 msgstr "评价"
 
-#: src/olympia/devhub/tasks.py:551
+#: src/olympia/devhub/tasks.py:583
 #, python-format
 msgid "%s responded with %s (%s)."
 msgstr "%s 响应 %s（%s）。"
 
-#: src/olympia/devhub/tasks.py:555
+#: src/olympia/devhub/tasks.py:587
 #, python-format
 msgid "Connection to \"%s\" timed out."
 msgstr "连接“%s”超时。"
 
-#: src/olympia/devhub/tasks.py:557
+#: src/olympia/devhub/tasks.py:589
 #, python-format
 msgid "Could not contact host at \"%s\"."
 msgstr "无法连接到主机“%s”。"
 
-#: src/olympia/devhub/utils.py:104
+#: src/olympia/devhub/utils.py:105
 #, python-format
 msgid "Validation generated too many errors/warnings so %s messages were truncated. After addressing the visible messages, you'll be able to see the others."
 msgstr "验证过程中产生的错误或警告信息过多，%s 个信息已被省略。在处理完可见信息后，您将可以看到其他被省略的信息。"
 
-#: src/olympia/devhub/views.py:183
+#: src/olympia/devhub/views.py:182
 msgid "All My Add-ons"
 msgstr "我的所有附加组件"
 
-#: src/olympia/devhub/views.py:210
+#: src/olympia/devhub/views.py:209
 msgid "All Activity"
 msgstr "所有动态"
 
-#: src/olympia/devhub/views.py:211
+#: src/olympia/devhub/views.py:210
 msgid "Add-on Updates"
 msgstr "附加组件更新"
 
-#: src/olympia/devhub/views.py:212
+#: src/olympia/devhub/views.py:211
 msgid "Add-on Status"
 msgstr "附加组件状态"
 
-#: src/olympia/devhub/views.py:213
+#: src/olympia/devhub/views.py:212
 msgid "User Collections"
 msgstr "用户收藏集"
 
-#: src/olympia/devhub/views.py:214 src/olympia/devhub/templates/devhub/docs/policies-maintenance.html:68 src/olympia/pages/templates/pages/dev_faq.html:38
+#: src/olympia/devhub/views.py:213 src/olympia/devhub/templates/devhub/docs/policies-maintenance.html:68 src/olympia/pages/templates/pages/dev_faq.html:38
 #: src/olympia/pages/templates/pages/dev_faq.html:484
 msgid "User Reviews"
 msgstr "用户评价"
 
-#: src/olympia/devhub/views.py:327 src/olympia/devhub/views.py:331 src/olympia/devhub/views.py:484 src/olympia/devhub/views.py:513 src/olympia/devhub/views.py:564 src/olympia/devhub/views.py:1150
+#: src/olympia/devhub/views.py:326 src/olympia/devhub/views.py:330 src/olympia/devhub/views.py:485 src/olympia/devhub/views.py:514 src/olympia/devhub/views.py:565 src/olympia/devhub/views.py:1157
 msgid "Changes successfully saved."
 msgstr "更改已成功保存。"
 
-#: src/olympia/devhub/views.py:334 src/olympia/devhub/views.py:1631
+#: src/olympia/devhub/views.py:333 src/olympia/devhub/views.py:1638
 msgid "Please check the form for errors."
 msgstr "请检查表单中的错误。"
 
-#: src/olympia/devhub/views.py:346
+#: src/olympia/devhub/views.py:345
 msgid "Add-on cannot be deleted. Disable this add-on instead."
 msgstr "附加组件无法被删除，可以禁用。"
 
-#: src/olympia/devhub/views.py:356
+#: src/olympia/devhub/views.py:355
 msgid "Theme deleted."
 msgstr "主题已删除。"
 
-#: src/olympia/devhub/views.py:356
+#: src/olympia/devhub/views.py:355
 msgid "Add-on deleted."
 msgstr "附加组件已删除。"
 
-#: src/olympia/devhub/views.py:362
+#: src/olympia/devhub/views.py:361
 msgid "URL name was incorrect. Theme was not deleted."
 msgstr "URL 名称不正确。主题未被删除。"
 
-#: src/olympia/devhub/views.py:367
+#: src/olympia/devhub/views.py:366
 msgid "URL name was incorrect. Add-on was not deleted."
 msgstr "URL 名称不正确。附加组件未被删除。"
 
-#: src/olympia/devhub/views.py:449
+#: src/olympia/devhub/views.py:450
 msgid "An author has been added to your add-on"
 msgstr "一个作者已被添加到您的附加组件"
 
-#: src/olympia/devhub/views.py:456
+#: src/olympia/devhub/views.py:457
 msgid "An author has a role changed on your add-on"
 msgstr "您的附加组件的一个作者角色已更改"
 
-#: src/olympia/devhub/views.py:476
+#: src/olympia/devhub/views.py:477
 msgid "An author has been removed from your add-on"
 msgstr "一个作者已被从您的附加组件中移除"
 
-#: src/olympia/devhub/views.py:519
+#: src/olympia/devhub/views.py:520
 msgid "There were errors in your submission."
 msgstr "您的提交发生错误。"
 
-#: src/olympia/devhub/views.py:583
+#: src/olympia/devhub/views.py:584
 msgid "Validate Add-on"
 msgstr "验证附加组件"
 
-#: src/olympia/devhub/views.py:594
+#: src/olympia/devhub/views.py:595
 msgid "Check Add-on Compatibility"
 msgstr "检查附加组件兼容性"
 
-#: src/olympia/devhub/views.py:808 src/olympia/signing/views.py:90
+#: src/olympia/devhub/views.py:809 src/olympia/signing/views.py:95
 msgid "You cannot submit this type of add-on"
 msgstr "您不能提交此类型的附加组件"
 
-#: src/olympia/devhub/views.py:1051 src/olympia/users/forms.py:471
+#: src/olympia/devhub/views.py:1052 src/olympia/users/forms.py:471
 msgid "Images must be either PNG or JPG."
 msgstr "图像必须为 PNG 或 JPG 格式。"
 
-#: src/olympia/devhub/views.py:1055
+#: src/olympia/devhub/views.py:1056
 msgid "Icons cannot be animated."
 msgstr "不能使用动画图标。"
 
-#: src/olympia/devhub/views.py:1057
+#: src/olympia/devhub/views.py:1058
 msgid "Images cannot be animated."
 msgstr "不能使用动态图像。"
 
-#: src/olympia/devhub/views.py:1070
+#: src/olympia/devhub/views.py:1071
 #, python-format
 msgid "Images cannot be larger than %dKB."
 msgstr "图像大小不能超过 %dKB。"
 
 #. L10n: {0} is an image width (in pixels), {1} is a height.
-#: src/olympia/devhub/views.py:1080
+#: src/olympia/devhub/views.py:1081
 msgid "Image must be exactly {0} pixels wide and {1} pixels tall."
 msgstr "图像宽度必须刚好为 {0} 像素且高度为 {1} 像素。"
 
-#: src/olympia/devhub/views.py:1087
+#: src/olympia/devhub/views.py:1088
 msgid "There was an error uploading your preview."
 msgstr "上传预览图的过程中发生错误。"
 
-#: src/olympia/devhub/views.py:1189
+#: src/olympia/devhub/views.py:1196
 #, python-format
 msgid "Version %s disabled."
 msgstr "已停用版本 %s。"
 
-#: src/olympia/devhub/views.py:1193
+#: src/olympia/devhub/views.py:1200
 #, python-format
 msgid "Version %s deleted."
 msgstr "版本 %s 已删除。"
 
-#: src/olympia/devhub/views.py:1203
+#: src/olympia/devhub/views.py:1210
 msgid "This upload has failed validation, and may lack complete validation results. Please take due care when reviewing it."
 msgstr "本次上传校验失败，可能缺少完整校验结果。请在检查时特别注意这点。"
 
-#: src/olympia/devhub/views.py:1677
+#: src/olympia/devhub/views.py:1684
 msgid "Preliminary Review Requested."
 msgstr "已请求初步审核。"
 
-#: src/olympia/devhub/views.py:1678
+#: src/olympia/devhub/views.py:1685
 msgid "Full Review Requested."
 msgstr "已请求全面审核。"
 
-#: src/olympia/devhub/views.py:1779
+#: src/olympia/devhub/views.py:1786
 msgid "Your old credentials were revoked and are no longer valid. Be sure to update all API clients with the new credentials."
 msgstr "您的旧证书已经废除并不再有效。请务必使用新证书更新所有 API 客户端。"
 
-#: src/olympia/devhub/views.py:1797
+#: src/olympia/devhub/views.py:1804
 msgid "New API key created"
 msgstr "新的 API 密钥已创建"
 
@@ -3998,7 +4008,7 @@ msgstr "返回附加组件"
 msgid "{0} :: Search"
 msgstr "{0} :: 搜索"
 
-#: src/olympia/devhub/templates/devhub/devhub_search.html:6 src/olympia/devhub/templates/devhub/search.html:8 src/olympia/editors/forms.py:435 src/olympia/editors/forms.py:437
+#: src/olympia/devhub/templates/devhub/devhub_search.html:6 src/olympia/devhub/templates/devhub/search.html:8 src/olympia/editors/forms.py:534 src/olympia/editors/forms.py:536
 #: src/olympia/editors/templates/editors/queue.html:27 src/olympia/editors/templates/editors/themes/queue_list.html:14 src/olympia/search/templates/search/collections.html:17
 #: src/olympia/search/templates/search/personas.html:18 src/olympia/search/templates/search/results.html:18 src/olympia/search/templates/search/mobile/results.html:8 src/olympia/templates/search.html:14
 #: src/olympia/templates/impala/search.html:18
@@ -4060,12 +4070,12 @@ msgstr "请前往 <a href=\"https://developer.mozilla.org/Add-ons\">Mozilla 开�
 msgid "Start Making Add-ons"
 msgstr "开始制作附加组件"
 
-#: src/olympia/devhub/templates/devhub/index.html:86 src/olympia/devhub/templates/devhub/addons/listing/items.html:25 src/olympia/devhub/templates/devhub/includes/addon_details.html:15
+#: src/olympia/devhub/templates/devhub/index.html:86 src/olympia/devhub/templates/devhub/addons/listing/items.html:25 src/olympia/devhub/templates/devhub/includes/addon_details.html:20
 #: src/olympia/devhub/templates/devhub/personas/edit.html:43
 msgid "Status:"
 msgstr "状态："
 
-#: src/olympia/devhub/templates/devhub/index.html:90 src/olympia/devhub/templates/devhub/includes/addon_details.html:100
+#: src/olympia/devhub/templates/devhub/index.html:90 src/olympia/devhub/templates/devhub/includes/addon_details.html:87
 msgid "Visibility:"
 msgstr "可见性："
 
@@ -4073,11 +4083,11 @@ msgstr "可见性："
 msgid "Latest Version:"
 msgstr "最新版本："
 
-#: src/olympia/devhub/templates/devhub/index.html:109 src/olympia/devhub/templates/devhub/includes/addon_details.html:145 src/olympia/devhub/templates/devhub/personas/edit.html:49
+#: src/olympia/devhub/templates/devhub/index.html:109 src/olympia/devhub/templates/devhub/includes/addon_details.html:131 src/olympia/devhub/templates/devhub/personas/edit.html:49
 msgid "Queue Position:"
 msgstr "队列位置："
 
-#: src/olympia/devhub/templates/devhub/index.html:110 src/olympia/devhub/templates/devhub/includes/addon_details.html:146 src/olympia/devhub/templates/devhub/personas/edit.html:50
+#: src/olympia/devhub/templates/devhub/index.html:110 src/olympia/devhub/templates/devhub/includes/addon_details.html:132 src/olympia/devhub/templates/devhub/personas/edit.html:50
 #, python-format
 msgid "%(position)s of %(total)s"
 msgstr "%(position)s / %(total)s"
@@ -4179,16 +4189,6 @@ msgstr "在上传完成后，将会对您的文件执行一系列的自动化验
 msgid "Do you want your add-on to be distributed on this site?"
 msgstr "您想要在本网站上分发您的附加组件？"
 
-#: src/olympia/devhub/templates/devhub/validate_addon.html:49 src/olympia/devhub/templates/devhub/addons/submit/upload.html:30 src/olympia/devhub/templates/devhub/versions/add_file_modal.html:14
-#: src/olympia/devhub/templates/devhub/versions/add_file_modal.html:53 src/olympia/devhub/templates/devhub/versions/list.html:298
-msgid "Warning:"
-msgstr "警告："
-
-#: src/olympia/devhub/templates/devhub/validate_addon.html:50 src/olympia/devhub/templates/devhub/addons/submit/upload.html:31
-#, python-format
-msgid "Submission of unlisted add-ons for signing is currently in an open beta. Please <a href=\"%(url)s\" target=\"_blank\">report any bugs</a> that you encounter."
-msgstr "提交不上架的附加组件进行签名目前处在公测阶段。请<a href=\"%(url)s\" target=\"_blank\">报告</a>你遇到的任何 bug。"
-
 #. first parameter is a filename like lorem-ipsum-1.0.2.xpi
 #: src/olympia/devhub/templates/devhub/validation.html:5
 msgid "Validation Results for {0}"
@@ -4263,7 +4263,7 @@ msgstr "兼容性"
 msgid "Update Compatibility"
 msgstr "更新兼容性"
 
-#: src/olympia/devhub/templates/devhub/addons/ajax_compat_update.html:4
+#: src/olympia/devhub/templates/devhub/addons/ajax_compat_update.html:4 src/olympia/devhub/templates/devhub/versions/edit.html:45
 msgid "Adjusting application information here will allow users to install your add-on even if the install manifest in the package indicates that the add-on is incompatible."
 msgstr "在此调整应用程序信息将可允许用户安装您的附加组件，即使包内的安装清单声明此附加组件不兼容。"
 
@@ -4275,9 +4275,9 @@ msgstr "支持的版本"
 msgid "Add Another Application&hellip;"
 msgstr "添加其他应用程序&hellip;"
 
-#: src/olympia/devhub/templates/devhub/addons/ajax_compat_update.html:38 src/olympia/devhub/templates/devhub/addons/owner.html:86 src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:46
-#: src/olympia/devhub/templates/devhub/versions/list.html:351 src/olympia/devhub/templates/devhub/versions/list.html:353 src/olympia/templates/impala/base.html:132
-#: src/olympia/templates/impala/base.html:143 src/olympia/templates/impala/base.html:161 src/olympia/templates/impala/base.html:171
+#: src/olympia/devhub/templates/devhub/addons/ajax_compat_update.html:38 src/olympia/devhub/templates/devhub/addons/owner.html:86 src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:45
+#: src/olympia/devhub/templates/devhub/versions/list.html:349 src/olympia/devhub/templates/devhub/versions/list.html:351 src/olympia/templates/impala/base.html:129
+#: src/olympia/templates/impala/base.html:140 src/olympia/templates/impala/base.html:158 src/olympia/templates/impala/base.html:168
 msgid "Close"
 msgstr "关闭"
 
@@ -4295,6 +4295,7 @@ msgstr "我的附加组件的早期动态"
 msgid "<b>{0}</b> theme"
 msgid_plural "<b>{0}</b> themes"
 msgstr[0] "<b>{0}</b> 个主题"
+msgstr[1] ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit.html:3 src/olympia/devhub/templates/devhub/addons/listing/item_actions.html:25
 #: src/olympia/devhub/templates/devhub/addons/listing/item_actions_theme.html:7 src/olympia/devhub/templates/devhub/includes/addons_edit_nav.html:2
@@ -4310,7 +4311,7 @@ msgstr "无"
 msgid "Manage Authors & License"
 msgstr "管理作者和许可协议"
 
-#: src/olympia/devhub/templates/devhub/addons/owner.html:29 src/olympia/editors/templates/editors/review.html:270
+#: src/olympia/devhub/templates/devhub/addons/owner.html:29 src/olympia/editors/helpers.py:362 src/olympia/editors/templates/editors/review.html:270
 msgid "Authors"
 msgstr "作者"
 
@@ -4378,18 +4379,11 @@ msgid "Summary"
 msgstr "概述"
 
 #: src/olympia/devhub/templates/devhub/addons/edit/basic.html:52
-msgid ""
-"A short explanation of your add-on's basic\n"
-"                          functionality that is displayed in search and browse\n"
-"                          listings, as well as at the top of your add-on's\n"
-"                          details page. It is only relevant for listed add-ons."
+msgid "A short explanation of your add-on's basic functionality that is displayed in search and browse listings, as well as at the top of your add-on's details page. It is only relevant for listed add-ons."
 msgstr "您的附加组件基本功能的简短说明，它会显示在搜索结果、列表和您的附加组件的详细信息页面中。此项只与上架的附加组件相关。"
 
 #: src/olympia/devhub/templates/devhub/addons/edit/basic.html:73
-msgid ""
-"Categories are the primary way users browse through add-ons.\n"
-"                        Choose any that fit your add-on's functionality for the most\n"
-"                        exposure. It is only relevant for listed add-ons."
+msgid "Categories are the primary way users browse through add-ons. Choose any that fit your add-on's functionality for the most exposure. It is only relevant for listed add-ons."
 msgstr "分类是许多用户浏览附加组件的主要方式。选择任何您的附加组件的功能适合展示的分类。此项只与上架的附加组件相关。"
 
 #: src/olympia/devhub/templates/devhub/addons/edit/basic.html:90
@@ -4398,17 +4392,14 @@ msgid "Categories cannot be changed while your add-on is featured for this appli
 msgstr "您的附加组件目前为此应用程序的精选附加组件，无法更改分类。如果您有理由需要修改其分类，请发送电子邮件到 <a href=\"mailto:%(email)s\">%(email)s</a>。"
 
 #: src/olympia/devhub/templates/devhub/addons/edit/basic.html:119
-msgid ""
-"Tags help users find your add-on and should be short\n"
-"                        descriptors such as tabs, toolbar, or twitter.  You\n"
-"                        may have a maximum of {0} tags. It is only relevant\n"
-"                        for listed add-ons."
+msgid "Tags help users find your add-on and should be short descriptors such as tabs, toolbar, or twitter. You may have a maximum of {0} tags. It is only relevant for listed add-ons."
 msgstr "标签可以帮助用户找到您的附加组件，它应该是简短的描述词，例如：tabs, toolbar, twitter 等。您最多可以使用 {0} 个标签。此项只与上架的附加组件相关。"
 
 #: src/olympia/devhub/templates/devhub/addons/edit/basic.html:129 src/olympia/devhub/templates/devhub/personas/edit.html:97 src/olympia/devhub/templates/devhub/personas/submit.html:46
 msgid "Comma-separated, minimum of {0} character."
 msgid_plural "Comma-separated, minimum of {0} characters."
 msgstr[0] "以逗号分隔，至少 {0} 个字符。"
+msgstr[1] ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/basic.html:132 src/olympia/devhub/templates/devhub/personas/edit.html:100 src/olympia/devhub/templates/devhub/personas/submit.html:49
 msgid "Example: dark, cinema, noir. Limit 20."
@@ -4418,6 +4409,7 @@ msgstr "例如：黑暗、电影院、黑色。最多20个。"
 msgid "Reserved tag:"
 msgid_plural "Reserved tags:"
 msgstr[0] "保留的标签："
+msgstr[1] ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/details.html:5
 msgid "Add-on Details"
@@ -4428,11 +4420,7 @@ msgid "Add-on Details for {0}"
 msgstr "附加组件“{0}”的详细信息"
 
 #: src/olympia/devhub/templates/devhub/addons/edit/details.html:22
-msgid ""
-"A longer explanation of features,\n"
-"                          functionality, and other relevant information. This\n"
-"                          field is only displayed on the add-on's details\n"
-"                          page. It is only relevant for listed add-ons."
+msgid "A longer explanation of features, functionality, and other relevant information. This field is only displayed on the add-on's details page. It is only relevant for listed add-ons."
 msgstr "有关特点、功能和其他有关信息的较长描述。此项仅显示在附加组件的详细信息页面。此项只与上架的附加组件相关。"
 
 #: src/olympia/devhub/templates/devhub/addons/edit/details.html:44 src/olympia/translations/templates/translations/trans-menu.html:13
@@ -4616,9 +4604,7 @@ msgid "32x32px"
 msgstr "32x32px"
 
 #: src/olympia/devhub/templates/devhub/addons/forms_shared/media.html:39
-msgid ""
-"Used in listings of add-ons, like search results\n"
-"                            and featured add-ons."
+msgid "Used in listings of add-ons, like search results and featured add-ons."
 msgstr "在展示附加组件时使用，例如在搜索结果和精选附加组件。"
 
 #. The size of the icon
@@ -4713,18 +4699,16 @@ msgid "Deleting your add-on will permanently remove it from the site and prevent
 msgstr "删除您的附加组件将使其永久从本网站上移除，并且阻止其 GUID 被其他人重新提交。"
 
 #: src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:24
-msgid ""
-"Enter the following text confirm your decision:\n"
-"           {slug}"
+msgid "Enter the following text confirm your decision: {slug}"
 msgstr ""
 "请输入下列文本已确认您的决定：\n"
 "           {slug}"
 
-#: src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:34
+#: src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:33
 msgid "Please tell us why you are deleting your theme:"
 msgstr "请告诉我们您删除此主题的原因："
 
-#: src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:36
+#: src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:35
 msgid "Please tell us why you are deleting your add-on:"
 msgstr "请告诉我们您删除此附加组件的原因："
 
@@ -4761,8 +4745,8 @@ msgstr "新版本"
 msgid "Daily statistics on downloads and users."
 msgstr "下载量与用户量的每日统计数据。"
 
-#: src/olympia/devhub/templates/devhub/addons/listing/item_actions.html:45 src/olympia/stats/templates/stats/stats.html:75 src/olympia/stats/templates/stats/stats.html:79
-#: src/olympia/stats/templates/stats/stats.html:81
+#: src/olympia/devhub/templates/devhub/addons/listing/item_actions.html:45 src/olympia/stats/templates/stats/stats.html:31 src/olympia/stats/templates/stats/stats.html:35
+#: src/olympia/stats/templates/stats/stats.html:37
 msgid "Statistics"
 msgstr "统计数据"
 
@@ -4822,6 +4806,7 @@ msgstr "<b>队列位置：</b>%(pos)s / %(total)s"
 msgid "<strong>{0}</strong> active user"
 msgid_plural "<strong>{0}</strong> active users"
 msgstr[0] "<strong>{0}</strong> 位活跃用户"
+msgstr[1] ""
 
 #: src/olympia/devhub/templates/devhub/addons/submit/base.html:11
 msgid "Submit Add-on"
@@ -4880,10 +4865,7 @@ msgid "Your add-on has been submitted to the Full Review queue."
 msgstr "您的附加组件已被提交到全面审核队列。"
 
 #: src/olympia/devhub/templates/devhub/addons/submit/done.html:18
-msgid ""
-"You'll receive an email once it has been reviewed by an editor. In\n"
-"          the meantime, you and your friends can install it directly from its\n"
-"          details page:"
+msgid "You'll receive an email once it has been reviewed by an editor. In the meantime, you and your friends can install it directly from its details page:"
 msgstr "一旦它已被一名编辑审核，您将收到一封电子邮件。与此同时，您和您的朋友将可以直接从它的详细信息页面安装它："
 
 #: src/olympia/devhub/templates/devhub/addons/submit/done.html:27 src/olympia/devhub/templates/devhub/addons/submit/done.html:77 src/olympia/devhub/templates/devhub/personas/submit_done.html:16
@@ -5089,11 +5071,11 @@ msgstr "第 2 步：上传您的附加组件"
 msgid "Use the fields below to upload your add-on package and select any platform restrictions. After upload, a series of automated validation tests will be run on your file."
 msgstr "使用下面的按钮上传您的附加组件包，并选择可兼容的平台。在上传完成后，将会对您的文件执行一系列的自动化验证测试。"
 
-#: src/olympia/devhub/templates/devhub/addons/submit/upload.html:59 src/olympia/devhub/templates/devhub/versions/add_file_modal.html:39
+#: src/olympia/devhub/templates/devhub/addons/submit/upload.html:51 src/olympia/devhub/templates/devhub/versions/add_file_modal.html:28
 msgid "Which platforms is this file compatible with?"
 msgstr "此文件与哪个平台兼容？"
 
-#: src/olympia/devhub/templates/devhub/addons/submit/upload.html:67 src/olympia/devhub/templates/devhub/versions/add_file_modal.html:65
+#: src/olympia/devhub/templates/devhub/addons/submit/upload.html:59 src/olympia/devhub/templates/devhub/versions/add_file_modal.html:45
 msgid "Administrative overrides"
 msgstr "管理覆盖"
 
@@ -5205,9 +5187,9 @@ msgstr "网站功能与开发"
 
 #: src/olympia/devhub/templates/devhub/docs/policies-contact.html:44
 msgid ""
-"If you've found a problem with the site, we'd love to fix it. Please <a href=\"https://github.com/mozilla/olympia/issues\">file a bug report</a> in GitHub, including the location of the problem and"
-" how you encountered it."
-msgstr "如果您发现了本网站的问题，我们愿意修复它。请<a href=\"https://github.com/mozilla/olympia/issues\">填报 bug</a> 到 GitHub，写清问题出现的位置，以及你如何遇到它。"
+"If you've found a problem with the site, we'd love to fix it. Please <a href=\"https://github.com/mozilla/addons/issues/new\">file a bug report</a> in GitHub, including the location of the problem "
+"and how you encountered it."
+msgstr ""
 
 #: src/olympia/devhub/templates/devhub/docs/policies-maintenance.html:3 src/olympia/devhub/templates/devhub/docs/policies-maintenance.html:7
 #: src/olympia/devhub/templates/devhub/docs/policies-maintenance.html:8
@@ -5943,101 +5925,95 @@ msgstr "提交您的作品到我们网站的服务条款。开发者在提交前
 msgid "How to get in touch with us regarding these policies or your add-on."
 msgstr "如何就这些政策或您的附加组件与我们取得联系。"
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:6
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:10
 msgid "You have disabled this add-on"
 msgstr "您禁用了这个附加组件"
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:20
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:24
 msgid "Your add-on's listing is disabled and is not showing anywhere in our gallery or update service."
 msgstr "已停止展示您的附加组件，它将不再出现于网页和更新服务中。"
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:25
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:27
 msgid "Please complete your add-on."
 msgstr "请完成您的附加组件。"
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:29
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:30
 msgid "You will receive an email when the review is complete."
 msgstr "审核完成时您会收到邮件。"
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:34
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:33
 msgid "You will receive an email when the review is complete. Until then, your add-on is not listed in our gallery but can be accessed directly from its details page."
 msgstr "在审核完成后您会收到一封电子邮件通知。在此期间，您的附加组件不会在我们的展示页面上出现，但可以直接访问它的详细信息页面。"
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:38 src/olympia/devhub/templates/devhub/includes/addon_details.html:48
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:37 src/olympia/devhub/templates/devhub/includes/addon_details.html:45
 msgid "You will receive an email when the review is complete and your add-on is signed."
 msgstr "您将会在您的附加组件完成审核并被签名后收到电子邮件通知。"
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:44
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:41
 msgid "You will receive an email when the review is complete. Until then, your add-on is not listed in our gallery but can be accessed directly from its details page."
 msgstr "在审核完成后您会收到一封电子邮件通知。在此期间，您的附加组件不会在我们的展示页面上出现，但可以直接访问它的详细信息页面。"
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:54
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:49
 msgid "Your add-on is displayed in our gallery and users are receiving automatic updates."
 msgstr "您的附加组件已经展示在我们的展示库中，并且用户会自动收到更新。"
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:57
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:52
 msgid "Your add-on has been signed and can be bundled with an application installer."
 msgstr "您的附加组件已被签名，可以捆绑在应用程序的安装程序中。"
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:63
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:56
 msgid "Your add-on was disabled by a site administrator and is no longer shown in our gallery. If you have any questions, please email amo-admins@mozilla.org."
 msgstr "您的附加组件已被一名网站管理员禁用，并将不再展示。如果您有任何疑问，请发邮件至 amo-admins@mozilla.org。"
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:70
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:62
 msgid "Your add-on is displayed in our gallery as experimental and users are receiving automatic updates. Some features are unavailable to your add-on."
 msgstr "您的附加组件已标记为实验性的附加组件展示在我们的展示库中，并且用户会自动收到更新。部分功能对您的附加组件不可用。"
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:74
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:66
 msgid "Your add-on has been signed."
 msgstr "您的附加组件已被签名。"
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:79
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:69
 msgid ""
 "You will receive an email when the full review is complete. Until then, your add-on is displayed in our gallery as experimental and users are receiving automatic updates. Some features are "
 "unavailable to your add-on."
 msgstr "在全面审核完成后您会收到一封电子邮件通知。在此期间，您的附加组件在我们的展示库中仍会显示为实验性的附加组件，并且用户会自动收到更新。部分功能对您的附加组件不可用。"
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:84
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:74
 msgid "You will receive an email when the full review is complete, making you able to bundle your add-on with an application installer."
 msgstr "在全面审核完成时，您将收到一封电子邮件，以便您可以捆绑您的附加组件到应用程序的安装程序中。"
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:91
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:79
 msgid "All add-ons hosted in our gallery must now be reviewed by an editor. If you wish to continue hosting your add-on, please click to select a review process."
 msgstr "存放在我们的展台中的全部附加组件现在都要通过编辑审核。如果您希望继续存放您的附加组件，请点击选择一个审核流程。"
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:113
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:100
 msgid "Current Version:"
 msgstr "当前版本："
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:115
-msgid ""
-"This is the version of your add-on that will\n"
-"                                           be installed if someone clicks the Install\n"
-"                                           button on addons.mozilla.org. It is only\n"
-"                                           relevant for listed add-ons."
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:102
+msgid "This is the version of your add-on that will be installed if someone clicks the Install button on addons.mozilla.org. It is only relevant for listed add-ons."
 msgstr "这是其他人点击网站 (addons.mozilla.org) 上的“安装”按钮时将安装的您的附加组件的版本。它只与已上架的附加组件相关。"
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:123
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:110
 msgid "Created:"
 msgstr "创建于："
 
 #. {0} is a date. dennis-ignore: E201
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:125 src/olympia/devhub/templates/devhub/includes/addon_details.html:131
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:112 src/olympia/devhub/templates/devhub/includes/addon_details.html:118
 #, python-format
 msgid "%%b %%e, %%Y"
 msgstr "%%Y-%%m-%%d"
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:136
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:123
 msgid "Next Version:"
 msgstr "下一个版本："
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:138
-msgid ""
-"This is the newest uploaded version, however\n"
-"                                           it isn’t live on the site yet."
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:125
+msgid "This is the newest uploaded version, however it isn’t live on the site yet."
 msgstr "这是新上传的版本，但它还没有正式在网站上架。"
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:144 src/olympia/devhub/templates/devhub/versions/list.html:30
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:130 src/olympia/devhub/templates/devhub/versions/list.html:30
 msgid "Queues are not reviewed strictly in order"
 msgstr "审核时并不会严格按照进入队列的先后顺序进行"
 
@@ -6105,9 +6081,7 @@ msgid "View the blog &#9658;"
 msgstr "查看博客 &#9658;"
 
 #: src/olympia/devhub/templates/devhub/includes/license_form.html:6
-msgid ""
-"Please choose a license appropriate for the rights you grant on your source code.\n"
-"                  It is only relevant for listed add-ons."
+msgid "Please choose a license appropriate for the rights you grant on your source code. It is only relevant for listed add-ons."
 msgstr "请选择一个许可协议，标明您对您的源代码授予的权利。此项只与上架的附加组件相关。"
 
 #. {0} is a list of HTML tags.
@@ -6123,22 +6097,21 @@ msgstr "支持一些 HTML。"
 msgid "Remove this application"
 msgstr "移除此应用程序"
 
-#. {0} is the maximum number of add-on categories allowed.                {1}
-#. is
+#. {0} is the maximum number of add-on categories allowed.                {1} is
 #. the application name.
 #: src/olympia/devhub/templates/devhub/includes/macros.html:70
 msgid "Select <b>up to {0}</b> {1} category for this add-on:"
 msgid_plural "Select <b>up to {0}</b> {1} categories for this add-on:"
 msgstr[0] "为此附加组件选择<b>至多 {0} 个</b> {1} 的分类："
+msgstr[1] ""
 
 #: src/olympia/devhub/templates/devhub/includes/policy_form.html:4
 msgid ""
 "Users will be required to accept the following End-User License Agreement (EULA) prior to installing your add-on. The presence of a EULA significantly affects the number of downloads an add-on "
-"receives. Please note that a EULA is not the same as a code license, such as the GPL or MPL.\n"
-"                It is only relevant for listed add-ons."
-msgstr "用户将被要求在安装您的附加组件前接受下列最终用户许可协议（EULA）。EULA 的存在将会大幅度影响附加组件的下载次数。请注意，EULA 与代码许可协议（例如 GPL 或 MPL）是不同的东西。此项只与上架的附加组件相关。"
+"receives. Please note that a EULA is not the same as a code license, such as the GPL or MPL.It is only relevant for listed add-ons."
+msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/policy_form.html:21
+#: src/olympia/devhub/templates/devhub/includes/policy_form.html:24
 msgid "If your add-on transmits any data from the user's computer, a privacy policy is required that explains what data is sent and how it is used. It is only relevant for listed add-ons."
 msgstr "如果您的附加组件会从用户的计算机上传出任何数据，您需要提供一份隐私政策，解释这些数据的发送和将如何使用它。此项仅与公开上架的附加组件相关。"
 
@@ -6307,7 +6280,7 @@ msgstr "选择最适合描述您主题的类别。"
 msgid "Add some tags to describe your Theme."
 msgstr "用一些标签描述您的主题。"
 
-#: src/olympia/devhub/templates/devhub/personas/edit.html:106
+#: src/olympia/devhub/templates/devhub/personas/edit.html:106 src/olympia/devhub/templates/devhub/personas/submit.html:54
 msgid "A short explanation of your theme's basic functionality that is displayed in search and browse listings, as well as at the top of your theme's details page."
 msgstr "对您的主题的基本功能的简短说明，显示在搜索和浏览列表页面，同样也显示在主题详情页面的顶端。"
 
@@ -6378,7 +6351,7 @@ msgid "Upon upload and form submission, the AMO Team will review your updated de
 msgstr "上传并提交，AMO 团队会审核您更新的设计。在此期间，仍然会公开呈现现有的设计。"
 
 #: src/olympia/devhub/templates/devhub/personas/edit.html:241
-msgid "Your previously resubmitted design,  which is under pending review."
+msgid "Your previously resubmitted design, which is under pending review."
 msgstr "您此前重新提交了设计，它正在等待审核。"
 
 #: src/olympia/devhub/templates/devhub/personas/edit.html:245
@@ -6446,10 +6419,6 @@ msgstr "你可以借助背景主题很容易地个性化你的 Firefox 外观。
 #: src/olympia/devhub/templates/devhub/personas/submit.html:33
 msgid "Give your Theme a name."
 msgstr "给主题取个名字。"
-
-#: src/olympia/devhub/templates/devhub/personas/submit.html:54
-msgid "A short explanation of your theme's basic functionality that is displayed in search and browse listings, as well as at the top of your theme's details page."
-msgstr "对您的主题的基本功能的简短说明，显示在搜索和浏览列表页面，同样也显示在主题详情页面的顶端。"
 
 #: src/olympia/devhub/templates/devhub/personas/submit.html:198
 #, python-format
@@ -6525,31 +6494,17 @@ msgstr "选择一个不同的页脚图像"
 msgid "Files added to reviewed versions must be reviewed before they will be available for download."
 msgstr "将文件添加到已通过审核的版本中后，必须再次通过审核才能开放给公众下载。"
 
-#: src/olympia/devhub/templates/devhub/versions/add_file_modal.html:15
-#, python-format
-msgid ""
-"Submission of updates to unlisted add-ons for signing is currently in an open beta. Manual review may still be required for a large number of add-ons. Please <a href=\"%(url)s\" "
-"target=\"_blank\">report any bugs</a> that you encounter."
-msgstr "对不上架附加组件进行签名做出更新目前处在公测阶段。许多附加组件可能需要人工审核。请<a href=\"%(url)s\" target=\"_blank\">报告</a>你遇到的任何 bug。"
-
-#: src/olympia/devhub/templates/devhub/versions/add_file_modal.html:35
+#: src/olympia/devhub/templates/devhub/versions/add_file_modal.html:24
 msgid "Select the target platform for this file."
 msgstr "为此文件选择目标平台。"
 
-#: src/olympia/devhub/templates/devhub/versions/add_file_modal.html:46
+#: src/olympia/devhub/templates/devhub/versions/add_file_modal.html:35
 msgid "Which review type would you like to nominate for?"
 msgstr "您希望提交哪个类型的审核？"
 
-#: src/olympia/devhub/templates/devhub/versions/add_file_modal.html:51
+#: src/olympia/devhub/templates/devhub/versions/add_file_modal.html:40
 msgid "Only publish this version to my beta channel."
 msgstr "仅发布此版本到我的测试通道。"
-
-#: src/olympia/devhub/templates/devhub/versions/add_file_modal.html:54
-#, python-format
-msgid ""
-"The behavior of the beta channel has changed to accommodate <a href=\"%(addon_signing_url)s\" target=\"_blank\">mandatory add-on signing</a>. The new process is currently in an open beta, and may "
-"change significantly in the near future. Please <a href=\"%(issues_url)s\" target=\"_blank\">report any bugs</a> that you encounter."
-msgstr "测试通道的行为已经更改，以适应<a href=\"%(addon_signing_url)s\" target=\"_blank\">附加组件强制性签名</a>。新的流程目前处于公测阶段，并且可能快速发生显著变化。请<a href=\"%(issues_url)s\" target=\"_blank\">报告</a>你遇到的任何 bug。"
 
 #: src/olympia/devhub/templates/devhub/versions/edit.html:5
 msgid "Manage Version {0}"
@@ -6572,10 +6527,6 @@ msgstr "文件"
 #: src/olympia/devhub/templates/devhub/versions/edit.html:38
 msgid "Upload Another File"
 msgstr "上传其他文件"
-
-#: src/olympia/devhub/templates/devhub/versions/edit.html:45
-msgid "Adjusting application information here will allow users to install your add-on even if the install manifest in the package indicates that the add-on is incompatible."
-msgstr "在此调整应用程序信息将可允许用户安装您的附加组件，即使包内的安装清单声明此附加组件不兼容。"
 
 #: src/olympia/devhub/templates/devhub/versions/edit.html:74
 msgid ""
@@ -6643,6 +6594,7 @@ msgstr "编辑此版本"
 msgid "{0} file"
 msgid_plural "{0} files"
 msgstr[0] "{0} 个文件"
+msgstr[1] ""
 
 #: src/olympia/devhub/templates/devhub/versions/list.html:25
 msgid "0 files"
@@ -6669,7 +6621,7 @@ msgstr "请求全面审核"
 msgid "Request Preliminary Review"
 msgstr "请求初步审核"
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:80 src/olympia/devhub/templates/devhub/versions/list.html:327 src/olympia/devhub/templates/devhub/versions/list.html:350
+#: src/olympia/devhub/templates/devhub/versions/list.html:80 src/olympia/devhub/templates/devhub/versions/list.html:325 src/olympia/devhub/templates/devhub/versions/list.html:348
 msgid "Cancel Review Request"
 msgstr "撤回审核请求"
 
@@ -6698,8 +6650,8 @@ msgid "Unlisted:"
 msgstr "不上架："
 
 #: src/olympia/devhub/templates/devhub/versions/list.html:114
-msgid "Not distributed on {0}. Developers will upload new versions for signing and distribute the add-ons on their own. (beta)"
-msgstr "不在 {0} 上发行。开发者将上传新的版本进行签名，然后自行在自己的渠道分发该附加组件。（测试版功能）"
+msgid "Not distributed on {0}. Developers will upload new versions for signing and distribute the add-ons on their own."
+msgstr ""
 
 #: src/olympia/devhub/templates/devhub/versions/list.html:122
 msgid "Current versions"
@@ -6761,78 +6713,73 @@ msgid "<strong>Important:</strong> Once a version has been deleted, you may not 
 msgstr "<strong>重要：</strong>一个版本一旦被删除，就不能再上传有相同版本号的新版本。"
 
 #: src/olympia/devhub/templates/devhub/versions/list.html:230
-msgid "Deleting a version which has already been reviewed may also cause a significant delay in the review of your next update."
-msgstr "删除已审核的版本会导致下次更新时的审核时间显著延长。"
-
-#: src/olympia/devhub/templates/devhub/versions/list.html:233
 msgid "Are you sure you wish to delete this version?"
 msgstr "您确定要删除此版本吗？"
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:238
+#: src/olympia/devhub/templates/devhub/versions/list.html:235
 msgid "Delete Version"
 msgstr "删除版本"
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:240
+#: src/olympia/devhub/templates/devhub/versions/list.html:237
 msgid "Disable Version"
 msgstr "停用版本"
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:247
+#: src/olympia/devhub/templates/devhub/versions/list.html:244
 msgid "Add a new Version"
 msgstr "添加新版本"
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:249
+#: src/olympia/devhub/templates/devhub/versions/list.html:246
 msgid "Add Version"
 msgstr "添加版本"
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:256 src/olympia/devhub/templates/devhub/versions/list.html:274
+#: src/olympia/devhub/templates/devhub/versions/list.html:253 src/olympia/devhub/templates/devhub/versions/list.html:279
 msgid "Hide Add-on"
 msgstr "隐藏附加组件"
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:259
+#: src/olympia/devhub/templates/devhub/versions/list.html:256
 msgid "Hiding your add-on will prevent it from appearing anywhere in our gallery and will stop users from receiving automatic updates."
 msgstr "隐藏您的附加组件会使它从我们的列表和公开页面中消失，并且用户也不会再收到自动更新。"
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:265
+#: src/olympia/devhub/templates/devhub/versions/list.html:263
+msgid "The files awaiting review will be disabled and you will need to upload new versions."
+msgstr ""
+
+#: src/olympia/devhub/templates/devhub/versions/list.html:270
 msgid "Are you sure you wish to hide your add-on?"
 msgstr "您确定想要隐藏您的附加组件？"
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:286 src/olympia/devhub/templates/devhub/versions/list.html:315
+#: src/olympia/devhub/templates/devhub/versions/list.html:291 src/olympia/devhub/templates/devhub/versions/list.html:313
 msgid "Unlist Add-on"
 msgstr "将附加组件下架"
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:289
+#: src/olympia/devhub/templates/devhub/versions/list.html:294
 #, python-format
 msgid ""
 "Unlisting your add-on will make it (and each of its versions/files) invisible on this website. It won't show up in searches, won't have a public facing page, and won't be updated automatically for "
 "current users. It is recommended for unlisted add-ons to provide a custom <a href=\"%(update_url)s\" target=\"_blank\">updateURL</a> in their manifest file for automatic updates."
 msgstr "取消上架您的附加组件将使其（包括其每个版本和文件）在本网站上消失。它不会在搜索中显示，不会有一个面向公众的页面，并且不会为当前的用户提供自动更新。推荐为未上架的附加组件在清单文件中提供一个自定义的 <a href=\"%(update_url)s\" target=\"_blank\">updateURL</a> 以提供自动更新。"
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:299
-#, python-format
-msgid "Switching add-ons to unlisted is currently in an open beta. Please <a href=\"%(url)s\" target=\"_blank\">report any bugs</a> that you encounter."
-msgstr "切换附加组件到不上架目前处在公测阶段。请<a href=\"%(url)s\" target=\"_blank\">报告</a>你遇到的任何 bug。"
-
-#: src/olympia/devhub/templates/devhub/versions/list.html:305
+#: src/olympia/devhub/templates/devhub/versions/list.html:303
 msgid "Unlisting an add-on is irreversible!"
 msgstr "下架一个附加组件是不可逆的！"
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:305
+#: src/olympia/devhub/templates/devhub/versions/list.html:303
 msgid "An unlisted add-on cannot be switched to be listed."
 msgstr "一个未上架的附加组件不能切换到上架。"
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:307
+#: src/olympia/devhub/templates/devhub/versions/list.html:305
 msgid "Are you sure you wish to unlist your add-on?"
 msgstr "您真的确定要将您的附加组件下架吗？"
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:330
+#: src/olympia/devhub/templates/devhub/versions/list.html:328
 msgid "Canceling your review request will leave your add-on as preliminarily reviewed."
 msgstr "撤销您的附加组件审核请求将使其停留在已通过初步审核状态。"
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:335
+#: src/olympia/devhub/templates/devhub/versions/list.html:333
 msgid "Canceling your review request will mark your add-on incomplete. If you do not complete your add-on after several days by re-requesting review, it will be deleted."
 msgstr "撤销您的附加组件审核请求将使其停留在未完成状态。如果您不在几天内重新请求审核，它将被删除。"
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:343
+#: src/olympia/devhub/templates/devhub/versions/list.html:341
 msgid "Are you sure you wish to cancel your review request?"
 msgstr "您确定要撤销您的审核请求吗？"
 
@@ -7171,19 +7118,19 @@ msgstr "附加组件、审核员或意见"
 msgid "Search by add-on name / author email"
 msgstr "以附加组件名称或作者电子邮件地址搜索"
 
-#: src/olympia/editors/forms.py:103
+#: src/olympia/editors/forms.py:103 src/olympia/editors/forms.py:244 src/olympia/editors/forms.py:257
 msgid "yes"
 msgstr "是"
 
-#: src/olympia/editors/forms.py:104
+#: src/olympia/editors/forms.py:104 src/olympia/editors/forms.py:244 src/olympia/editors/forms.py:257
 msgid "no"
 msgstr "否"
 
-#: src/olympia/editors/forms.py:105
+#: src/olympia/editors/forms.py:105 src/olympia/editors/forms.py:245
 msgid "Admin Flag"
 msgstr "管理员标记"
 
-#: src/olympia/editors/forms.py:113
+#: src/olympia/editors/forms.py:113 src/olympia/editors/forms.py:253
 msgid "Max. Version"
 msgstr "最大版本"
 
@@ -7195,55 +7142,59 @@ msgstr "已等待天数"
 msgid "Add-on Types"
 msgstr "附加组件类型"
 
-#: src/olympia/editors/forms.py:126 src/olympia/editors/helpers.py:267
+#: src/olympia/editors/forms.py:126 src/olympia/editors/helpers.py:279
 msgid "Platforms"
 msgstr "平台"
 
+#: src/olympia/editors/forms.py:237
+msgid "Search by add-on name / author email / guid"
+msgstr ""
+
 #. L10n: 0 = platform, 1 = filename, 2 = status message
-#: src/olympia/editors/forms.py:238
+#: src/olympia/editors/forms.py:342
 #, python-format
 msgid "<strong>%s</strong> &middot; %s &middot; %s"
 msgstr "<strong>%s</strong> &middot; %s &middot; %s"
 
-#: src/olympia/editors/forms.py:252
+#: src/olympia/editors/forms.py:356
 msgid "Comments:"
 msgstr "意见："
 
-#: src/olympia/editors/forms.py:256
+#: src/olympia/editors/forms.py:360
 msgid "Operating systems:"
 msgstr "操作系统："
 
-#: src/olympia/editors/forms.py:258
+#: src/olympia/editors/forms.py:362
 msgid "Applications:"
 msgstr "应用程序："
 
-#: src/olympia/editors/forms.py:260
+#: src/olympia/editors/forms.py:364
 msgid "Notify me the next time this add-on is updated. (Subsequent updates will not generate an email)"
 msgstr "在此附加组件下次更新时通知我。（之后的更新不会发送电子邮件通知）"
 
-#: src/olympia/editors/forms.py:265
+#: src/olympia/editors/forms.py:369
 msgid "Clear Admin Review Flag"
 msgstr "清除管理员审核标记"
 
-#: src/olympia/editors/forms.py:267
+#: src/olympia/editors/forms.py:371
 msgid "Clear more info requested flag"
 msgstr "清除请求更多信息的标记"
 
-#: src/olympia/editors/forms.py:281
+#: src/olympia/editors/forms.py:385
 msgid "Choose a canned response..."
 msgstr "选择一项预置的回复..."
 
 #. L10n: Description of what can be searched for.
-#: src/olympia/editors/forms.py:324
+#: src/olympia/editors/forms.py:423
 msgid "theme name"
 msgstr "主题名称"
 
-#: src/olympia/editors/forms.py:350
+#: src/olympia/editors/forms.py:449
 msgid "Someone else is reviewing this theme."
 msgstr "其他人正在审核这个主题。"
 
 #. L10n: Description of what can be searched for.
-#: src/olympia/editors/forms.py:447
+#: src/olympia/editors/forms.py:546
 msgid "app, reviewer, or comment"
 msgstr "应用，审核者或评论"
 
@@ -7259,235 +7210,264 @@ msgstr "等待初步审核"
 msgid "Rejected or Unreviewed"
 msgstr "已拒绝或未审核"
 
-#: src/olympia/editors/helpers.py:123 src/olympia/editors/helpers.py:136
+#: src/olympia/editors/helpers.py:125 src/olympia/editors/helpers.py:138
 msgid "Queue"
 msgstr "队列"
 
-#: src/olympia/editors/helpers.py:124 src/olympia/editors/templates/editors/base.html:50 src/olympia/editors/templates/editors/base.html:65
+#: src/olympia/editors/helpers.py:126 src/olympia/editors/templates/editors/base.html:50 src/olympia/editors/templates/editors/base.html:65
 msgid "Pending Updates"
 msgstr "等待更新"
 
-#: src/olympia/editors/helpers.py:125 src/olympia/editors/templates/editors/base.html:48 src/olympia/editors/templates/editors/base.html:63
+#: src/olympia/editors/helpers.py:127 src/olympia/editors/templates/editors/base.html:48 src/olympia/editors/templates/editors/base.html:63
 msgid "Full Reviews"
 msgstr "全面审核"
 
-#: src/olympia/editors/helpers.py:126 src/olympia/editors/templates/editors/base.html:52 src/olympia/editors/templates/editors/base.html:67
+#: src/olympia/editors/helpers.py:128 src/olympia/editors/templates/editors/base.html:52 src/olympia/editors/templates/editors/base.html:67
 msgid "Preliminary Reviews"
 msgstr "初步审核"
 
-#: src/olympia/editors/helpers.py:127 src/olympia/editors/templates/editors/base.html:54
+#: src/olympia/editors/helpers.py:129 src/olympia/editors/templates/editors/base.html:54
 msgid "Moderated Reviews"
 msgstr "提请仲裁的评论"
 
-#: src/olympia/editors/helpers.py:128 src/olympia/editors/templates/editors/base.html:46
+#: src/olympia/editors/helpers.py:130 src/olympia/editors/templates/editors/base.html:46
 msgid "Fast Track"
 msgstr "快速审核"
 
-#: src/olympia/editors/helpers.py:130
+#: src/olympia/editors/helpers.py:132
 msgid "Pending Themes"
 msgstr "待定主题"
 
-#: src/olympia/editors/helpers.py:131 src/olympia/editors/templates/editors/themes/queue.html:4
+#: src/olympia/editors/helpers.py:133 src/olympia/editors/templates/editors/themes/queue.html:4
 msgid "Flagged Themes"
 msgstr "已标记的主题"
 
-#: src/olympia/editors/helpers.py:132
+#: src/olympia/editors/helpers.py:134
 msgid "Update Themes"
 msgstr "更新主题"
 
-#: src/olympia/editors/helpers.py:137
+#: src/olympia/editors/helpers.py:139
 msgid "Unlisted Pending Updates"
 msgstr "未上架的待定更新"
 
-#: src/olympia/editors/helpers.py:138
+#: src/olympia/editors/helpers.py:140
 msgid "Unlisted Full Reviews"
 msgstr "未上架的全面审核"
 
-#: src/olympia/editors/helpers.py:139
+#: src/olympia/editors/helpers.py:141
 msgid "Unlisted Preliminary Reviews"
 msgstr "未上架的初步审核"
 
-#: src/olympia/editors/helpers.py:170
+#: src/olympia/editors/helpers.py:142
+msgid "Unlisted All Add-ons"
+msgstr ""
+
+#: src/olympia/editors/helpers.py:173
 msgid "Fast Track ({0})"
 msgid_plural "Fast Track ({0})"
 msgstr[0] "快速审核（{0}）"
+msgstr[1] ""
 
-#: src/olympia/editors/helpers.py:175
+#: src/olympia/editors/helpers.py:178
 msgid "Full Review ({0})"
 msgid_plural "Full Reviews ({0})"
 msgstr[0] "全面审核（{0}）"
+msgstr[1] ""
 
-#: src/olympia/editors/helpers.py:180
+#: src/olympia/editors/helpers.py:183
 msgid "Pending Update ({0})"
 msgid_plural "Pending Updates ({0})"
 msgstr[0] "等待更新（{0}）"
+msgstr[1] ""
 
-#: src/olympia/editors/helpers.py:185
+#: src/olympia/editors/helpers.py:188
 msgid "Preliminary Review ({0})"
 msgid_plural "Preliminary Reviews ({0})"
 msgstr[0] "初步审核（{0}）"
+msgstr[1] ""
 
-#: src/olympia/editors/helpers.py:190
+#: src/olympia/editors/helpers.py:193
 msgid "Moderated Review ({0})"
 msgid_plural "Moderated Reviews ({0})"
 msgstr[0] "提请仲裁的评论（{0}）"
+msgstr[1] ""
 
-#: src/olympia/editors/helpers.py:196
+#: src/olympia/editors/helpers.py:199
 msgid "Unlisted Full Review ({0})"
 msgid_plural "Unlisted Full Reviews ({0})"
 msgstr[0] "未上架的全面审核 ({0})"
+msgstr[1] ""
 
-#: src/olympia/editors/helpers.py:201
+#: src/olympia/editors/helpers.py:204
 msgid "Unlisted Pending Update ({0})"
 msgid_plural "Unlisted Pending Updates ({0})"
 msgstr[0] "未上架的待定更新 ({0})"
+msgstr[1] ""
 
-#: src/olympia/editors/helpers.py:206
+#: src/olympia/editors/helpers.py:209
 msgid "Unlisted Preliminary Review ({0})"
 msgid_plural "Unlisted Preliminary Reviews ({0})"
 msgstr[0] "未上架的初步审核 ({0})"
+msgstr[1] ""
 
-#: src/olympia/editors/helpers.py:261
-msgid "Addon"
-msgstr "附加组件"
+#: src/olympia/editors/helpers.py:214
+msgid "Unlisted All Add-ons ({0})"
+msgid_plural "Unlisted All Add-ons ({0})"
+msgstr[0] ""
+msgstr[1] ""
 
-#: src/olympia/editors/helpers.py:262
+#: src/olympia/editors/helpers.py:274
 msgid "Type"
 msgstr "类型"
 
-#: src/olympia/editors/helpers.py:263
+#: src/olympia/editors/helpers.py:275
 msgid "Waiting Time"
 msgstr "等待时间"
 
-#: src/olympia/editors/helpers.py:264 src/olympia/editors/templates/editors/review.html:285
+#: src/olympia/editors/helpers.py:276 src/olympia/editors/templates/editors/review.html:285
 msgid "Flags"
 msgstr "标记"
 
-#: src/olympia/editors/helpers.py:265
+#: src/olympia/editors/helpers.py:277
 msgid "Applications"
 msgstr "应用程序"
 
-#: src/olympia/editors/helpers.py:270
+#: src/olympia/editors/helpers.py:282
 msgid "Additional"
 msgstr "额外信息"
 
-#: src/olympia/editors/helpers.py:285
+#: src/olympia/editors/helpers.py:302
 msgid "Site Specific"
 msgstr "特定网站"
 
-#: src/olympia/editors/helpers.py:287
+#: src/olympia/editors/helpers.py:304
 msgid "Requires External Software"
 msgstr "需要外部软件"
 
-#: src/olympia/editors/helpers.py:289
+#: src/olympia/editors/helpers.py:306
 msgid "Binary Components"
 msgstr "二进制组件"
 
-#: src/olympia/editors/helpers.py:313
+#: src/olympia/editors/helpers.py:339
 msgid "moments ago"
 msgstr "刚刚"
 
 #. L10n: first argument is number of minutes
-#: src/olympia/editors/helpers.py:316
+#: src/olympia/editors/helpers.py:342
 msgid "{0} minute"
 msgid_plural "{0} minutes"
 msgstr[0] "{0} 分钟"
+msgstr[1] ""
 
 #. L10n: first argument is number of hours
-#: src/olympia/editors/helpers.py:320
+#: src/olympia/editors/helpers.py:346
 msgid "{0} hour"
 msgid_plural "{0} hours"
 msgstr[0] "{0} 小时"
+msgstr[1] ""
 
 #. L10n: first argument is number of days
-#: src/olympia/editors/helpers.py:324
+#: src/olympia/editors/helpers.py:350
 msgid "{0} day"
 msgid_plural "{0} days"
 msgstr[0] "{0} 天"
+msgstr[1] ""
 
-#: src/olympia/editors/helpers.py:488
+#: src/olympia/editors/helpers.py:364
+msgid "Last Review"
+msgstr ""
+
+#: src/olympia/editors/helpers.py:366
+msgid "Last Update"
+msgstr ""
+
+#: src/olympia/editors/helpers.py:387
+msgid "No Reviews"
+msgstr ""
+
+#: src/olympia/editors/helpers.py:561
 msgid "Push to public"
 msgstr "发布为公开"
 
-#: src/olympia/editors/helpers.py:490
+#: src/olympia/editors/helpers.py:563
 msgid "Grant full review"
 msgstr "通过全面审核"
 
-#: src/olympia/editors/helpers.py:505
+#: src/olympia/editors/helpers.py:578
 msgid "Request more information"
 msgstr "要求更多信息"
 
-#: src/olympia/editors/helpers.py:508
+#: src/olympia/editors/helpers.py:581
 msgid "Request super-review"
 msgstr "要求超级审核"
 
-#: src/olympia/editors/helpers.py:519
+#: src/olympia/editors/helpers.py:592
 msgid "Grant preliminary review"
 msgstr "批准通过初步审核"
 
-#: src/olympia/editors/helpers.py:520
+#: src/olympia/editors/helpers.py:593
 msgid "This will mark the files as preliminarily reviewed."
 msgstr "这将会把该文件标记为“已通过初步审核”。"
 
-#: src/olympia/editors/helpers.py:522
+#: src/olympia/editors/helpers.py:595
 msgid "Use this form to request more information from the author. They will receive an email and be able to answer here. You will be notified by email when they reply."
 msgstr "使用此表单向作者要求更多信息。他们会收到电子邮件通知，而且可以在此回复。当他们回复时您会收到通知。"
 
-#: src/olympia/editors/helpers.py:526
+#: src/olympia/editors/helpers.py:599
 msgid ""
 "If you have concerns about this add-on's security, copyright issues, or other concerns that an administrator should look into, enter your comments in the area below. They will be sent to "
 "administrators, not the author."
 msgstr "如果您担心此附加组件可能有安全隐患、著作权争议或者有其他需要管理员深入调查的事项，请在下方输入您的意见。意见将会发送给管理员，而不会发送给作者。"
 
-#: src/olympia/editors/helpers.py:532
+#: src/olympia/editors/helpers.py:605
 msgid "This will reject the add-on and remove it from the review queue."
 msgstr "这将会退回附加组件并从审核队列中移除。"
 
-#: src/olympia/editors/helpers.py:534
-msgid "Make a comment on this version.  The author won't be able to see this."
+#: src/olympia/editors/helpers.py:607
+msgid "Make a comment on this version. The author won't be able to see this."
 msgstr "对此版本进行注释。作者不会看到这些。"
 
-#: src/olympia/editors/helpers.py:538
+#: src/olympia/editors/helpers.py:611
 msgid "This will reject the files and remove them from the review queue."
 msgstr "这将会退回文件并从审核队列中移除。"
 
-#: src/olympia/editors/helpers.py:542
+#: src/olympia/editors/helpers.py:615
 msgid "This will mark the add-on as preliminarily reviewed. Future versions will undergo preliminary review."
 msgstr "这将会标记附加组件为已通过初步审核。未来的版本仍需要进行初步审核。"
 
-#: src/olympia/editors/helpers.py:547
+#: src/olympia/editors/helpers.py:620
 msgid "This will mark the files as preliminarily reviewed. Future versions will undergo preliminary review."
 msgstr "这将会标记文件为已通过初步审核。未来的版本仍需要进行初步审核。"
 
-#: src/olympia/editors/helpers.py:552
+#: src/olympia/editors/helpers.py:625
 msgid "Retain preliminary review"
 msgstr "保留初步审核"
 
-#: src/olympia/editors/helpers.py:553
+#: src/olympia/editors/helpers.py:626
 msgid "This will retain the add-on as preliminarily reviewed. Future versions will undergo preliminary review."
 msgstr "这将会保留附加组件为已通过初步审核。未来的版本仍需要进行初步审核。"
 
-#: src/olympia/editors/helpers.py:558
+#: src/olympia/editors/helpers.py:631
 msgid "This will approve a sandboxed version of a public add-on to appear on the public side."
 msgstr "这将会批准一个公开附加组件的沙盒版本并显示在公开区域。"
 
-#: src/olympia/editors/helpers.py:561
+#: src/olympia/editors/helpers.py:634
 msgid "This will reject a version of a public add-on and remove it from the queue."
 msgstr "这将退回一个公开附加组件的一个版本并从审核队列中移除。"
 
-#: src/olympia/editors/helpers.py:564
+#: src/olympia/editors/helpers.py:637
 msgid "This will mark the add-on and its most recent version and files as public. Future versions will go into the sandbox until they are reviewed by an editor."
 msgstr "这将会标记附加组件及其最新版本和文件为公开。未来的版本将会放入沙盒中等待审核员审核。"
 
-#: src/olympia/editors/helpers.py:637
+#: src/olympia/editors/helpers.py:714
 msgid "add-on"
 msgstr "附加组件"
 
-#: src/olympia/editors/helpers.py:940 src/olympia/editors/helpers.py:960
+#: src/olympia/editors/helpers.py:1020 src/olympia/editors/helpers.py:1040
 msgid "Flagged"
 msgstr "已标记"
 
-#: src/olympia/editors/helpers.py:944 src/olympia/editors/helpers.py:963
+#: src/olympia/editors/helpers.py:1024 src/olympia/editors/helpers.py:1043
 msgid "Updates"
 msgstr "更新"
 
@@ -7539,56 +7519,56 @@ msgstr "主题提交标记供审核"
 msgid "A question about your Theme submission"
 msgstr "您提交的主题的一个问题"
 
-#: src/olympia/editors/views.py:144
+#: src/olympia/editors/views.py:146
 msgid "New Add-ons (Under 5 days)"
 msgstr "新附加组件（五天内）"
 
-#: src/olympia/editors/views.py:145
+#: src/olympia/editors/views.py:147
 msgid "Passable (5 to 10 days)"
 msgstr "可通过（五至十天）"
 
-#: src/olympia/editors/views.py:146
+#: src/olympia/editors/views.py:148
 msgid "Overdue (Over 10 days)"
 msgstr "逾期（超过十天）"
 
-#: src/olympia/editors/views.py:532
+#: src/olympia/editors/views.py:539
 msgid "An unknown error occurred"
 msgstr "发生未知错误"
 
-#: src/olympia/editors/views.py:587
+#: src/olympia/editors/views.py:592
 msgid "Self-reviews are not allowed."
 msgstr "不允许自我审核。"
 
-#: src/olympia/editors/views.py:609
+#: src/olympia/editors/views.py:613
 msgid "Review successfully processed."
 msgstr "审核处理成功。"
 
-#: src/olympia/editors/views.py:807
+#: src/olympia/editors/views.py:812
 msgid "was approved"
 msgstr "已通过审核"
 
-#: src/olympia/editors/views.py:808
+#: src/olympia/editors/views.py:813
 msgid "given preliminary review"
 msgstr "已给予初步审核"
 
-#: src/olympia/editors/views.py:809
+#: src/olympia/editors/views.py:814
 msgid "rejected"
 msgstr "已拒绝"
 
-#: src/olympia/editors/views.py:810
+#: src/olympia/editors/views.py:815
 msgctxt "editors_review_history_nominated_adminreview"
 msgid "escalated"
 msgstr "已向上呈报"
 
-#: src/olympia/editors/views.py:812
+#: src/olympia/editors/views.py:817
 msgid "needs more information"
 msgstr "需要更多信息"
 
-#: src/olympia/editors/views.py:813
+#: src/olympia/editors/views.py:818
 msgid "needs super review"
 msgstr "需要超级审核"
 
-#: src/olympia/editors/views.py:814
+#: src/olympia/editors/views.py:819
 msgid "commented"
 msgstr "已留言"
 
@@ -7596,6 +7576,7 @@ msgstr "已留言"
 msgid "{0} theme review successfully processed (+{1} points, {2} total)."
 msgid_plural "{0} theme reviews successfully processed (+{1} points, {2} total)."
 msgstr[0] "{0} 个主题审核成功（+ {1} 点，共 {2} 点）。"
+msgstr[1] ""
 
 #: src/olympia/editors/views_themes.py:341
 msgid "Your theme locks have successfully been released. Other reviewers may now review those released themes. You may have to refresh the page to see the changes reflected in the table below."
@@ -7632,28 +7613,28 @@ msgstr "队列"
 msgid "Unlisted Queues"
 msgstr "未上架队列"
 
-#: src/olympia/editors/templates/editors/base.html:72 src/olympia/editors/templates/editors/performance.html:6
+#: src/olympia/editors/templates/editors/base.html:74 src/olympia/editors/templates/editors/performance.html:6
 msgid "Performance"
 msgstr "性能"
 
-#: src/olympia/editors/templates/editors/base.html:75 src/olympia/editors/templates/editors/themes/base.html:19 src/olympia/editors/templates/editors/themes/base.html:38
+#: src/olympia/editors/templates/editors/base.html:77 src/olympia/editors/templates/editors/themes/base.html:19 src/olympia/editors/templates/editors/themes/base.html:38
 msgid "Logs"
 msgstr "日志"
 
-#: src/olympia/editors/templates/editors/base.html:78 src/olympia/editors/templates/editors/reviewlog.html:4 src/olympia/editors/templates/editors/reviewlog.html:27
+#: src/olympia/editors/templates/editors/base.html:80 src/olympia/editors/templates/editors/reviewlog.html:4 src/olympia/editors/templates/editors/reviewlog.html:27
 msgid "Add-on Review Log"
 msgstr "附加组件审核日志"
 
-#: src/olympia/editors/templates/editors/base.html:80 src/olympia/editors/templates/editors/eventlog.html:4 src/olympia/editors/templates/editors/eventlog.html:8
+#: src/olympia/editors/templates/editors/base.html:82 src/olympia/editors/templates/editors/eventlog.html:4 src/olympia/editors/templates/editors/eventlog.html:8
 #: src/olympia/editors/templates/editors/eventlog_detail.html:4
 msgid "Moderated Review Log"
 msgstr "提请仲裁的评论日志"
 
-#: src/olympia/editors/templates/editors/base.html:82 src/olympia/editors/templates/editors/beta_signed_log.html:4 src/olympia/editors/templates/editors/beta_signed_log.html:8
+#: src/olympia/editors/templates/editors/base.html:84 src/olympia/editors/templates/editors/beta_signed_log.html:4 src/olympia/editors/templates/editors/beta_signed_log.html:8
 msgid "Signed Beta Files Log"
 msgstr "已签名 Beta 文件日志"
 
-#: src/olympia/editors/templates/editors/base.html:87 src/olympia/editors/templates/editors/includes/daily-message.html:4
+#: src/olympia/editors/templates/editors/base.html:89 src/olympia/editors/templates/editors/includes/daily-message.html:4
 msgid "Announcement"
 msgstr "公告"
 
@@ -7712,16 +7693,19 @@ msgstr "取消删除"
 msgid "Full Review ({num})"
 msgid_plural "Full Reviews ({num})"
 msgstr[0] "全面审核（{num} 项）"
+msgstr[1] ""
 
 #: src/olympia/editors/templates/editors/home.html:18
 msgid "Pending Update ({num})"
 msgid_plural "Pending Updates ({num})"
 msgstr[0] "等待更新（{num} 项）"
+msgstr[1] ""
 
 #: src/olympia/editors/templates/editors/home.html:25
 msgid "Preliminary Review ({num})"
 msgid_plural "Preliminary Reviews ({num})"
 msgstr[0] "初步审核（{num} 项）"
+msgstr[1] ""
 
 #: src/olympia/editors/templates/editors/home.html:36 src/olympia/editors/templates/editors/home.html:86
 msgid "Current waiting times:"
@@ -7731,6 +7715,7 @@ msgstr "目前等待时间："
 msgid "{0} add-on"
 msgid_plural "{0} add-ons"
 msgstr[0] "{0} 个附加组件"
+msgstr[1] ""
 
 #: src/olympia/editors/templates/editors/home.html:45 src/olympia/editors/templates/editors/home.html:95
 #, python-format
@@ -7741,16 +7726,19 @@ msgstr "{0}%%"
 msgid "Unlisted Full Review ({num})"
 msgid_plural "Unlisted Full Reviews ({num})"
 msgstr[0] "未上架的全面审核（{num} 项）"
+msgstr[1] ""
 
 #: src/olympia/editors/templates/editors/home.html:68
 msgid "Unlisted Pending Update ({num})"
 msgid_plural "Unlisted Pending Updates ({num})"
 msgstr[0] "未上架的待定更新（{num} 项）"
+msgstr[1] ""
 
 #: src/olympia/editors/templates/editors/home.html:75
 msgid "Unlisted Preliminary Review ({num})"
 msgid_plural "Unlisted Preliminary Reviews ({num})"
 msgstr[0] "未上架的初步审核（{num} 项）"
+msgstr[1] ""
 
 #: src/olympia/editors/templates/editors/home.html:109 src/olympia/editors/templates/editors/performance.html:37 src/olympia/editors/templates/editors/themes/home.html:54
 msgid "Total Reviews"
@@ -7773,6 +7761,7 @@ msgstr "您在审核第 #{0} 项，共 {1} 项"
 msgid "Moderated Review ({num})"
 msgid_plural "Moderated Reviews ({num})"
 msgstr[0] "提请仲裁的评论（{num} 项）"
+msgstr[1] ""
 
 #: src/olympia/editors/templates/editors/leaderboard.html:3 src/olympia/editors/templates/editors/includes/reviewers_score_bar.html:56
 msgid "Reviewer Leaderboard"
@@ -7866,45 +7855,45 @@ msgstr "高级搜索"
 msgid "clear search"
 msgstr "清除搜索"
 
-#: src/olympia/editors/templates/editors/queue.html:72 src/olympia/editors/templates/editors/queue.html:122
+#: src/olympia/editors/templates/editors/queue.html:78 src/olympia/editors/templates/editors/queue.html:128
 msgid "Process Reviews"
 msgstr "处理评论"
 
-#: src/olympia/editors/templates/editors/queue.html:80
+#: src/olympia/editors/templates/editors/queue.html:86
 msgid "Moderation actions:"
 msgstr "仲裁操作："
 
-#: src/olympia/editors/templates/editors/queue.html:90
+#: src/olympia/editors/templates/editors/queue.html:96
 #, python-format
 msgid "by %(user)s on %(date)s %(stars)s (%(locale)s)"
 msgstr "由 %(user)s 于 %(date)s %(stars)s（%(locale)s）"
 
-#: src/olympia/editors/templates/editors/queue.html:106
+#: src/olympia/editors/templates/editors/queue.html:112
 #, python-format
 msgid "<strong>%(reason)s</strong> <span class=\"light\">Flagged by %(user)s on %(date)s</span>"
 msgstr "<strong>%(reason)s</strong> <span class=\"light\">由 %(user)s 于 %(date)s 标记</span>"
 
-#: src/olympia/editors/templates/editors/queue.html:119
-msgid "All reviews have been moderated.  Good work!"
+#: src/olympia/editors/templates/editors/queue.html:125
+msgid "All reviews have been moderated. Good work!"
 msgstr "所有评价都已仲裁。做得不错！"
 
-#: src/olympia/editors/templates/editors/queue.html:161
+#: src/olympia/editors/templates/editors/queue.html:167
 msgid "Version Notes / Notes for Reviewer"
 msgstr "版本说明 / 给审核员的备注"
 
-#: src/olympia/editors/templates/editors/queue.html:169
+#: src/olympia/editors/templates/editors/queue.html:175
 msgid "There are currently no add-ons of this type to review."
 msgstr "目前此类型下没有要审核的附加组件。"
 
-#: src/olympia/editors/templates/editors/queue.html:181 src/olympia/editors/templates/editors/themes/queue_list.html:85
+#: src/olympia/editors/templates/editors/queue.html:187 src/olympia/editors/templates/editors/themes/queue_list.html:85
 msgid "Helpful Links:"
 msgstr "有用的链接："
 
-#: src/olympia/editors/templates/editors/queue.html:182
+#: src/olympia/editors/templates/editors/queue.html:188
 msgid "Add-on Policy"
 msgstr "附加组件政策"
 
-#: src/olympia/editors/templates/editors/queue.html:184
+#: src/olympia/editors/templates/editors/queue.html:190
 msgid "Editors' Guide"
 msgstr "审核员指南"
 
@@ -8109,16 +8098,19 @@ msgstr "暂时尚无评论。"
 msgid "{num} Pending Theme Review"
 msgid_plural "{num} Pending Theme Reviews"
 msgstr[0] "{num} 项待定的主题审核"
+msgstr[1] ""
 
 #: src/olympia/editors/templates/editors/themes/home.html:27
 msgid "{num} Flagged Review"
 msgid_plural "{num} Flagged Reviews"
 msgstr[0] "{num} 项已标记的评论"
+msgstr[1] ""
 
 #: src/olympia/editors/templates/editors/themes/home.html:34
 msgid "{num} Update"
 msgid_plural "{num} Updates"
 msgstr[0] "{num} 个更新"
+msgstr[1] ""
 
 #: src/olympia/editors/templates/editors/themes/logs.html:4
 msgid "Theme Review Log"
@@ -8237,7 +8229,7 @@ msgstr "向艺术家提问"
 msgid "Describe your reason for flagging"
 msgstr "描述您标注的理由"
 
-#: src/olympia/files/forms.py:88
+#: src/olympia/files/forms.py:90
 msgid "Cannot diff a version against itself"
 msgstr "无法判断一个版本与他自身的差别"
 
@@ -8272,51 +8264,51 @@ msgstr "访问文件 %s 时遇到错误。%s。"
 msgid "There was an error accessing file %s."
 msgstr "访问文件 %s 时遇到错误。"
 
-#: src/olympia/files/utils.py:343
+#: src/olympia/files/utils.py:340
 msgid "Could not parse uploaded file."
 msgstr "无法解析上传的文件。"
 
-#: src/olympia/files/utils.py:380
+#: src/olympia/files/utils.py:377
 msgid "Invalid file name in archive: {0}"
 msgstr "无效文件名存在于压缩包：{0}"
 
-#: src/olympia/files/utils.py:388
+#: src/olympia/files/utils.py:385
 msgid "File exceeding size limit in archive: {0}"
 msgstr "超过体积限制的文件存在于压缩包：{0}"
 
-#: src/olympia/files/utils.py:439
+#: src/olympia/files/utils.py:436
 msgid "Invalid archive."
 msgstr "无效的压缩文件。"
 
-#: src/olympia/files/utils.py:529 src/olympia/files/utils.py:532
+#: src/olympia/files/utils.py:526 src/olympia/files/utils.py:529
 msgid "Could not parse the manifest file."
 msgstr "未能解析清单文件。"
 
-#: src/olympia/files/utils.py:551
+#: src/olympia/files/utils.py:548
 msgid "Could not find an add-on ID."
 msgstr "无法找到附加组件 ID。"
 
-#: src/olympia/files/utils.py:554
+#: src/olympia/files/utils.py:551
 msgid "Add-on ID must be 64 characters or less."
 msgstr "附加组件 ID 必须少于或等于 64 个字符。"
 
-#: src/olympia/files/utils.py:556
+#: src/olympia/files/utils.py:553
 msgid "Add-on ID doesn't match add-on."
 msgstr "附加组件 ID 与附加组件不匹配。"
 
-#: src/olympia/files/utils.py:564
+#: src/olympia/files/utils.py:561
 msgid "Duplicate add-on ID found."
 msgstr "发现重复的附加组件 ID。"
 
-#: src/olympia/files/utils.py:567
+#: src/olympia/files/utils.py:564
 msgid "Version numbers should have fewer than 32 characters."
 msgstr "版本号应少于 32 个字符。"
 
-#: src/olympia/files/utils.py:570
+#: src/olympia/files/utils.py:567
 msgid "Version numbers should only contain letters, numbers, and these punctuation characters: +*.-_."
 msgstr "版本号只能包含英文字母、数字以及这些标点符号：+*.-_。"
 
-#: src/olympia/files/utils.py:587
+#: src/olympia/files/utils.py:584
 msgid "<em:type> doesn't match add-on"
 msgstr "<em:type> 与附加组件不匹配"
 
@@ -8416,6 +8408,10 @@ msgstr "上传的文件中没有文件。"
 #: src/olympia/files/templates/files/viewer.html:134
 msgid "Fetching file."
 msgstr "正在获取文件。"
+
+#: src/olympia/legacy_api/views.py:255
+msgid "Not implemented yet."
+msgstr "尚未完成。"
 
 #: src/olympia/lib/constants.py:6
 msgid "United Arab Emirates Dirham"
@@ -9072,10 +9068,6 @@ msgstr "赞比亚克瓦查"
 #: src/olympia/lib/constants.py:169
 msgid "Zimbabwe Dollar"
 msgstr "津巴布韦元"
-
-#: src/olympia/lib/video/ffmpeg.py:112 src/olympia/lib/video/totem.py:81
-msgid "Videos must be in WebM."
-msgstr "视频必须是 WebM 格式。"
 
 #: src/olympia/pages/templates/pages/about.lhtml:3 src/olympia/pages/templates/pages/about.lhtml:10
 msgid "About Mozilla Add-ons"
@@ -10010,12 +10002,10 @@ msgid "Add-on Gallery"
 msgstr "附加组件展台"
 
 #: src/olympia/pages/templates/pages/faq.html:171
-msgid ""
-"How do I choose between add-ons that seem to do the same\n"
-"    thing?"
+msgid "How do I choose between add-ons that seem to do the same thing?"
 msgstr "我该如何在功能似乎差不多的附加组件间选择？"
 
-#: src/olympia/pages/templates/pages/faq.html:173
+#: src/olympia/pages/templates/pages/faq.html:172
 msgid ""
 "There are often several add-ons that have similar features. To figure out which is right for you, read the entire description of the add-on and view its screenshots. If there are still several in "
 "the running, read through the add-on's ratings, user reviews, and statistics to see which is most liked by other users. Remember that you can also just try out both and see which you like better."
@@ -10059,71 +10049,67 @@ msgid "How much do add-ons cost to purchase?"
 msgstr "购买附加组件是什么价格？"
 
 #: src/olympia/pages/templates/pages/faq.html:207
-msgid ""
-"Add-ons hosted in our gallery are free unless clearly marked\n"
-"    otherwise."
+msgid "Add-ons hosted in our gallery are free unless clearly marked otherwise."
 msgstr "在我们网站托管的所有附加组件都是免费的，除非有特别标注。"
 
-#: src/olympia/pages/templates/pages/faq.html:210
+#: src/olympia/pages/templates/pages/faq.html:209
 msgid "What does it mean when an add-on asks for contributions?"
 msgstr "附加组件要求捐款是什么意思？"
 
-#: src/olympia/pages/templates/pages/faq.html:211
+#: src/olympia/pages/templates/pages/faq.html:210
 msgid ""
 "Some add-on authors request users who enjoy an add-on to contribute to its development by making a monetary contribution. These contributions go directly to the developer unless a third party is "
 "indicated, such as the non-profit Mozilla Foundation."
 msgstr "一些附加组件的作者希望用户在享用附加组件的同时也向附加组件捐一点款以帮助其发展。这些捐款会直接转给开发者，除非开发者明确指出了希望捐给其他单位（比如非营利性质的 Mozilla 基金会）。"
 
-#: src/olympia/pages/templates/pages/faq.html:216
+#: src/olympia/pages/templates/pages/faq.html:215
 msgid "What are beta add-ons?"
 msgstr "什么是测试版附加组件？"
 
-#: src/olympia/pages/templates/pages/faq.html:218
+#: src/olympia/pages/templates/pages/faq.html:217
 msgid ""
 "Beta add-ons are unreviewed versions which represent the latest work of an add-on author. While different authors have different standards for beta code quality, you should assume that these add-"
 "ons are less stable than the general add-on releases."
 msgstr "测试版附加组件是未经审核的版本，体现了作者的最新工作成果。由于不同作者有不同的测试版代码质量标准，您应该假定这些附加组件的稳定性不如正式发布的版本。"
 
-#: src/olympia/pages/templates/pages/faq.html:222
+#: src/olympia/pages/templates/pages/faq.html:221
 msgid ""
 "Please note that when you install an add-on from the \"Beta Version\" section of an add-on's listing, you will continue to receive updates for that add-on as they become available. Like the initial"
 " version you installed, all beta releases are unreviewed by Mozilla and may harm your computer."
 msgstr "请注意，当您从附加组件列表的“测试版”中安装附加组件的时候，您将会持续收到这个附加组件的可用更新。和您安装的初始版本一样，所有测试版都没有经过 Mozilla 的审核并且有可能伤害您的计算机。"
 
-#: src/olympia/pages/templates/pages/faq.html:229
-msgid ""
-"What does it mean when an add-on is flagged as\n"
-"    slow?"
+#: src/olympia/pages/templates/pages/faq.html:228
+msgid "What does it mean when an add-on is flagged as slow?"
 msgstr "附加组件被标记为缓慢意味着什么？"
 
-#: src/olympia/pages/templates/pages/faq.html:231
+#: src/olympia/pages/templates/pages/faq.html:229
 msgid "Most add-ons load code and resources at the same time Firefox is starting up. In most cases the impact in start-up time is minimal, but some add-ons can cause a noticeable slowdown."
 msgstr "大多数附加组件在 Firefox 启动的同时加载代码和资源。大多数情况下这对启动时间的影响很小，但有些附加组件可能导致明显的变慢。"
 
-#: src/olympia/pages/templates/pages/faq.html:236
+#: src/olympia/pages/templates/pages/faq.html:234
 msgid "How do I report an inappropriate or spam user review?"
 msgstr "如何报告一个不适当的用户评论？"
 
-#: src/olympia/pages/templates/pages/faq.html:237
+#: src/olympia/pages/templates/pages/faq.html:235
 msgid ""
 "To report a user review of an add-on, log in with your account and visit the add-on's reviews page. Find the review you wish to report, click \"Report this review\" and select a reason. Our "
 "editorial team will investigate the review and take appropriate action."
 msgstr "要报告一个附加组件的某个用户评论，登录您的帐户并访问该附加组件的评论页面。找到您想要报告的评论，点击“报告此评论”然后选择一个原因。我们的审核员团队会调查该评论，并采取适当的行动。"
 
-#: src/olympia/pages/templates/pages/faq.html:242
+#: src/olympia/pages/templates/pages/faq.html:240
 msgid "How do I report a bug or contact the Mozilla Add-ons team?"
 msgstr "我该怎样报告缺陷或者与 Mozilla 附加组件团队联系？"
 
-#: src/olympia/pages/templates/pages/faq.html:243
+#: src/olympia/pages/templates/pages/faq.html:241
 #, python-format
 msgid "Please visit our <a href=\"%(contact_url)s\">Contact page</a>."
 msgstr "请访问我们的<a href=\"%(contact_url)s\">联系页面</a>。"
 
-#: src/olympia/pages/templates/pages/faq.html:246
+#: src/olympia/pages/templates/pages/faq.html:244
 msgid "What is a Source Code License?"
 msgstr "什么是源代码许可协议？"
 
-#: src/olympia/pages/templates/pages/faq.html:247
+#: src/olympia/pages/templates/pages/faq.html:245
 #, python-format
 msgid ""
 "The source code used to create an add-on is an exclusive copyright of the add-on author, unless otherwise declared in a source code license. Many add-ons on this site have <a href=\"%(url)s\" "
@@ -10131,60 +10117,60 @@ msgid ""
 " like the GPL or BSD licenses instead of making up their own."
 msgstr "除非在源代码的许可协议中另有声明，否则一个附加组件的作者拥有其源代码的独家著作权。本网站上的许多附加组件使用<a href=\"%(url)s\" lang=\"en\">开源许可协议</a>，这让源代码可以在作者确定的条件下公开复制和重用。大多数作者都会选择广为人知的开源许可协议，像是 GPL 或 BSD 许可协议，而不是自己写一份。"
 
-#: src/olympia/pages/templates/pages/faq.html:256
+#: src/olympia/pages/templates/pages/faq.html:254
 #, python-format
 msgid "Firefox and other Mozilla software are <a href=\"%(url)s\">open source</a>."
 msgstr "Firefox 和其他 Mozilla 软件皆是<a href=\"%(url)s\">开放源代码的</a>。"
 
-#: src/olympia/pages/templates/pages/faq.html:264
+#: src/olympia/pages/templates/pages/faq.html:262
 msgid "Collections and Favorites"
 msgstr "收藏集和收藏夹"
 
-#: src/olympia/pages/templates/pages/faq.html:267
+#: src/olympia/pages/templates/pages/faq.html:265
 msgid "What is a collection?"
 msgstr "什么是收藏集？"
 
-#: src/olympia/pages/templates/pages/faq.html:268
+#: src/olympia/pages/templates/pages/faq.html:266
 msgid "Collections are groups of related add-ons created by users to share."
 msgstr "收藏集是由用户创建分享的相关附加组件的集合。"
 
-#: src/olympia/pages/templates/pages/faq.html:270
+#: src/olympia/pages/templates/pages/faq.html:268
 msgid "What is the My Favorites collection?"
 msgstr "什么是我最喜爱的收藏集？"
 
-#: src/olympia/pages/templates/pages/faq.html:271
+#: src/olympia/pages/templates/pages/faq.html:269
 msgid "Favorite add-ons are add-ons that you have bookmarked to easily get back to later. You can add an add-on to your favorites collection by clicking \"Add to favorites\" on its details page."
 msgstr "喜爱的附加组件使您已经标记了书签的附加组件，让您在以后可以轻易地找到它。您可以在其详细信息页面通过点击“加入收藏”来添加一个附加组件到您的收藏。"
 
-#: src/olympia/pages/templates/pages/faq.html:275 src/olympia/templates/menu_links.html:13 src/olympia/templates/impala/header_title.html:17
+#: src/olympia/pages/templates/pages/faq.html:273 src/olympia/templates/menu_links.html:13 src/olympia/templates/impala/header_title.html:17
 msgid "Mobile Add-ons"
 msgstr "移动版附加组件"
 
-#: src/olympia/pages/templates/pages/faq.html:278
+#: src/olympia/pages/templates/pages/faq.html:276
 msgid "What are mobile add-ons?"
 msgstr "什么是移动版附加组件？"
 
-#: src/olympia/pages/templates/pages/faq.html:279
+#: src/olympia/pages/templates/pages/faq.html:277
 #, python-format
 msgid ""
 "Mobile add-ons work with <a href=\"%(mobile_url)s\">Firefox for Mobile</a> and add or modify functionality just like desktop add-ons. You can find add-ons that work with Firefox for Mobile in our "
 "<a href=\"%(gallery_url)s\">gallery</a>."
 msgstr "移动版附加组件可在 <a href=\"%(mobile_url)s\">Firefox  移动版</a> 上使用，如同桌面版的附加组件一样，它可以增加或修改功能。您可以在我们的<a href=\"%(gallery_url)s\">展台</a>中找到可工作于 Firefox 移动版的附加组件。"
 
-#: src/olympia/pages/templates/pages/faq.html:288
+#: src/olympia/pages/templates/pages/faq.html:286
 msgid "Developer Topics"
 msgstr "开发者话题"
 
-#: src/olympia/pages/templates/pages/faq.html:289
+#: src/olympia/pages/templates/pages/faq.html:287
 #, python-format
 msgid "Please see our <a href=\"%(faq_url)s\">Developer FAQ</a> and <a href=\"%(hub_url)s\">Developer Hub</a> for answers to add-on developer-related questions."
 msgstr "更多有关附加组件开发者问题的答案，请参阅我们的<a href=\"%(faq_url)s\">开发者常见问题</a>和<a href=\"%(hub_url)s\">开发者中心</a>。"
 
-#: src/olympia/pages/templates/pages/faq.html:294
+#: src/olympia/pages/templates/pages/faq.html:292
 msgid "Still have questions?"
 msgstr "还有问题？"
 
-#: src/olympia/pages/templates/pages/faq.html:295
+#: src/olympia/pages/templates/pages/faq.html:293
 #, python-format
 msgid "For general Firefox support, visit our <a href=\"%(sumo_url)s\">support website</a>. For general add-on and website questions, visit our <a href=\"%(forum_url)s\">forum</a>."
 msgstr "常规的 Firefox 支持，请访问我们的<a href=\"%(sumo_url)s\">支持网站</a>。而常规的附加组件和网站问题，请访问我们的<a href=\"%(forum_url)s\">论坛</a>。"
@@ -10449,6 +10435,7 @@ msgstr "这个评论是针对附加组件的一个早期版本的（{0}）。"
 msgid "This user has a <a href=\"%(user_review_url)s\">previous review</a> of this add-on."
 msgid_plural "This user has <a href=\"%(user_review_url)s\">%(cnt)s previous reviews</a> of this add-on."
 msgstr[0] "对这个附加组件，此用户<a href=\"%(user_review_url)s\">曾发表过%(cnt)s个评价</a>。"
+msgstr[1] ""
 
 #: src/olympia/reviews/templates/reviews/review.html:62
 #, python-format
@@ -10494,6 +10481,7 @@ msgstr "对 {0} 的评论"
 msgid "<b>{0}</b> review for this add-on"
 msgid_plural "<b>{0}</b> reviews for this add-on"
 msgstr[0] "这个附加组件有 <b>{0}</b> 条评论"
+msgstr[1] ""
 
 #. {0} is a developer's name.
 #: src/olympia/reviews/templates/reviews/review_list.html:33
@@ -10505,6 +10493,7 @@ msgstr "由开发者 {0} 做的回复"
 msgid "Review for %(addon)s by %(user)s"
 msgid_plural "Reviews for %(addon)s by %(user)s"
 msgstr[0] "%(user)s 对 %(addon)s 发表的评论"
+msgstr[1] ""
 
 #: src/olympia/reviews/templates/reviews/review_list.html:42
 msgid "No reviews found."
@@ -10527,6 +10516,7 @@ msgstr "来写下第一篇评论吧。"
 msgid "{num} review"
 msgid_plural "{num} reviews"
 msgstr[0] "{num} 条评论"
+msgstr[1] ""
 
 #: src/olympia/reviews/templates/reviews/impala/reviews_rating.html:1
 msgid "Rated {0} out of 5 stars"
@@ -10553,6 +10543,7 @@ msgstr "尚未评分。"
 msgid "Average from {0} Rating"
 msgid_plural "Average from {0} Ratings"
 msgstr[0] "{0} 平均评分"
+msgstr[1] ""
 
 #: src/olympia/reviews/templates/reviews/mobile/review_list.html:34
 #, python-format
@@ -10568,6 +10559,7 @@ msgstr "阅读更多&nbsp;&raquo;"
 msgid "See All Reviews"
 msgid_plural "See All %(cnt)s Reviews"
 msgstr[0] "查看所有评价 (%(cnt)s个)"
+msgstr[1] ""
 
 #: src/olympia/search/forms.py:11
 msgid "Most popular this week"
@@ -10648,16 +10640,16 @@ msgstr "{0} 附加组件"
 
 #. L10n: {0} is an application, such as Firefox. This means "any version of
 #. Firefox."
-#: src/olympia/search/views.py:554
+#: src/olympia/search/views.py:547
 msgid "Any {0}"
 msgstr "任何 {0}"
 
 #. L10n: "All Systems" means show everything regardless of platform.
-#: src/olympia/search/views.py:589
+#: src/olympia/search/views.py:582
 msgid "All Systems"
 msgstr "所有系统"
 
-#: src/olympia/search/views.py:600
+#: src/olympia/search/views.py:593
 msgid "All Tags"
 msgstr "所有标签"
 
@@ -10701,6 +10693,7 @@ msgstr "“{0}”标签的搜索结果"
 msgid "<b>{0}</b> matching result"
 msgid_plural "<b>{0}</b> matching results"
 msgstr[0] "<b>{0}</b> 个匹配的结果"
+msgstr[1] ""
 
 #: src/olympia/search/templates/search/results.html:67
 msgid "Filter Results"
@@ -10722,6 +10715,7 @@ msgstr "搜索结果 <i>({num})</i> 个"
 msgid "{0} post"
 msgid_plural "{0} posts"
 msgstr[0] "{0} 个评论"
+msgstr[1] ""
 
 #: src/olympia/sharing/__init__.py:20
 msgid "Post to Facebook"
@@ -10731,6 +10725,7 @@ msgstr "投递到 Facebook"
 msgid "{0} Like"
 msgid_plural "{0} Likes"
 msgstr[0] "{0} 个赞"
+msgstr[1] ""
 
 #: src/olympia/sharing/__init__.py:30
 msgid "Tweet on Twitter"
@@ -10740,6 +10735,7 @@ msgstr "在 Twitter 上发布推文"
 msgid "{0} tweet"
 msgid_plural "{0} tweets"
 msgstr[0] "{0} 则推文"
+msgstr[1] ""
 
 #: src/olympia/sharing/__init__.py:40
 msgid "Share on g+"
@@ -10773,6 +10769,7 @@ msgstr "http://localservice1/?url={url}&title={title}"
 msgid "{0} post on localservice1"
 msgid_plural "{0} posts on localservice1"
 msgstr[0] "localservice1 上发布了 {0} 个"
+msgstr[1] ""
 
 #. L10n: Only change if you have reason! wiki.mozilla.org/AMO:Localizers
 #: src/olympia/sharing/__init__.py:76
@@ -10794,6 +10791,7 @@ msgstr "http://localservice2/?url={url}&title={title}"
 msgid "{0} post on localservice2"
 msgid_plural "{0} posts on localservice2"
 msgstr[0] "localservice2 上发布了 {0} 个"
+msgstr[1] ""
 
 #. L10n: Only change if you have reason! wiki.mozilla.org/AMO:Localizers
 #: src/olympia/sharing/__init__.py:91
@@ -10815,6 +10813,7 @@ msgstr "http://localservice3/?url={url}&title={title}"
 msgid "{0} post on localservice3"
 msgid_plural "{0} posts on localservice3"
 msgstr[0] "localservice3 上发布了 {0} 个"
+msgstr[1] ""
 
 #: src/olympia/sharing/templates/sharing/sharing_widget.html:2
 msgid "Share this Add-on"
@@ -10824,31 +10823,31 @@ msgstr "分享这个附加组件"
 msgid "Share this Collection"
 msgstr "分享收藏集"
 
-#: src/olympia/signing/views.py:30 src/olympia/templates/base.html:75 src/olympia/templates/impala/base.html:115
+#: src/olympia/signing/views.py:33 src/olympia/templates/base.html:71 src/olympia/templates/impala/base.html:112
 msgid "Some features are temporarily disabled while we perform website maintenance. We'll be back to full capacity shortly."
 msgstr "在我们进行网站维护时，某些功能会被暂时禁用。我们将很快恢复全部功能。"
 
-#: src/olympia/signing/views.py:53
+#: src/olympia/signing/views.py:56
 msgid "Could not find add-on with id \"{}\"."
 msgstr "未能找到 ID 为 \"{}\" 的附加组件。"
 
-#: src/olympia/signing/views.py:67
+#: src/olympia/signing/views.py:70
 msgid "You do not own this addon."
 msgstr "您不拥有此附加组件。"
 
-#: src/olympia/signing/views.py:82
+#: src/olympia/signing/views.py:87
 msgid "Missing \"upload\" key in multipart file data."
 msgstr "多部分文件数据中缺少 \"upload\" 键值。"
 
-#: src/olympia/signing/views.py:96
+#: src/olympia/signing/views.py:101
 msgid "Version does not match the manifest file."
 msgstr "版本与清单文件不匹配。"
 
-#: src/olympia/signing/views.py:100
+#: src/olympia/signing/views.py:105
 msgid "Version already exists."
 msgstr "版本已经存在。"
 
-#: src/olympia/signing/views.py:136
+#: src/olympia/signing/views.py:141
 msgid "No uploaded file for that addon and version."
 msgstr "没有适合该附加组件及版本的已上传文件。"
 
@@ -10961,90 +10960,90 @@ msgstr "{0} :: 统计数据面板"
 msgid "Statistics Dashboard :: Add-ons for {0}"
 msgstr "统计数据面板 :: {0} 的附加组件"
 
-#: src/olympia/stats/templates/stats/stats.html:30
-msgid "Controls:"
-msgstr "控制："
-
-#: src/olympia/stats/templates/stats/stats.html:33
-msgid "reset zoom"
-msgstr "重置缩放"
-
-#: src/olympia/stats/templates/stats/stats.html:40
-msgid "Group by:"
-msgstr "分组按照"
-
-#: src/olympia/stats/templates/stats/stats.html:42
-msgid "day"
-msgstr "天"
-
-#: src/olympia/stats/templates/stats/stats.html:45
-msgid "week"
-msgstr "周"
-
-#: src/olympia/stats/templates/stats/stats.html:48
-msgid "month"
-msgstr "月"
-
-#: src/olympia/stats/templates/stats/stats.html:54
-msgid "For last:"
-msgstr "最近："
-
-#: src/olympia/stats/templates/stats/stats.html:57
-msgid "7 days"
-msgstr "7 天"
-
-#: src/olympia/stats/templates/stats/stats.html:60
-msgid "30 days"
-msgstr "30 天"
-
-#: src/olympia/stats/templates/stats/stats.html:63
-msgid "90 days"
-msgstr "90 天"
-
-#: src/olympia/stats/templates/stats/stats.html:66
-msgid "365 days"
-msgstr "365 天"
-
-#: src/olympia/stats/templates/stats/stats.html:69
-msgid "Custom..."
-msgstr "自定义..."
-
 # %1 is the name of a collection
 #. {0} is an add-on name
-#: src/olympia/stats/templates/stats/stats.html:88 src/olympia/stats/templates/stats/stats.html:91
+#: src/olympia/stats/templates/stats/stats.html:44 src/olympia/stats/templates/stats/stats.html:47
 msgid "Statistics for {0}"
 msgstr "{0} 的统计数据"
 
-#: src/olympia/stats/templates/stats/stats.html:94
+#: src/olympia/stats/templates/stats/stats.html:50
 msgid "Statistics Dashboard"
 msgstr "统计数据面板"
 
-#: src/olympia/stats/templates/stats/stats.html:104
+#: src/olympia/stats/templates/stats/stats.html:57
+msgid "Controls:"
+msgstr "控制："
+
+#: src/olympia/stats/templates/stats/stats.html:60
+msgid "reset zoom"
+msgstr "重置缩放"
+
+#: src/olympia/stats/templates/stats/stats.html:67
+msgid "Group by:"
+msgstr "分组按照"
+
+#: src/olympia/stats/templates/stats/stats.html:69
+msgid "day"
+msgstr "天"
+
+#: src/olympia/stats/templates/stats/stats.html:72
+msgid "week"
+msgstr "周"
+
+#: src/olympia/stats/templates/stats/stats.html:75
+msgid "month"
+msgstr "月"
+
+#: src/olympia/stats/templates/stats/stats.html:81
+msgid "For last:"
+msgstr "最近："
+
+#: src/olympia/stats/templates/stats/stats.html:84
+msgid "7 days"
+msgstr "7 天"
+
+#: src/olympia/stats/templates/stats/stats.html:87
+msgid "30 days"
+msgstr "30 天"
+
+#: src/olympia/stats/templates/stats/stats.html:90
+msgid "90 days"
+msgstr "90 天"
+
+#: src/olympia/stats/templates/stats/stats.html:93
+msgid "365 days"
+msgstr "365 天"
+
+#: src/olympia/stats/templates/stats/stats.html:96
+msgid "Custom..."
+msgstr "自定义..."
+
+#: src/olympia/stats/templates/stats/stats.html:106
 msgid "Statistics processing is currently disabled, so recent data is unavailable. The statistics are still being collected and this page will be updated soon with the missing data."
 msgstr "统计数据处理目前已禁用，因此最近的数据不可用。统计数据仍在收集，此页面将尽快更新缺失的数据。"
 
-#: src/olympia/stats/templates/stats/stats.html:110
+#: src/olympia/stats/templates/stats/stats.html:112
 msgid "Loading the latest data&hellip;"
 msgstr "载入最新数据&hellip;"
 
-#: src/olympia/stats/templates/stats/stats.html:142 src/olympia/stats/templates/stats/reports/overview.html:25 src/olympia/stats/templates/stats/reports/overview.html:37
+#: src/olympia/stats/templates/stats/stats.html:144 src/olympia/stats/templates/stats/reports/overview.html:25 src/olympia/stats/templates/stats/reports/overview.html:37
 #: src/olympia/stats/templates/stats/reports/overview.html:49
 msgid "No data available."
 msgstr "没有可用数据。"
 
-#: src/olympia/stats/templates/stats/stats.html:177
+#: src/olympia/stats/templates/stats/stats.html:179
 msgid "This dashboard is currently <b>public</b>."
 msgstr "这个面板目前<b>公开显示</b>。"
 
-#: src/olympia/stats/templates/stats/stats.html:179
+#: src/olympia/stats/templates/stats/stats.html:181
 msgid "Contribution stats are currently <b>private</b>."
 msgstr "捐款统计目前是<b>私密的</b>。"
 
-#: src/olympia/stats/templates/stats/stats.html:182
+#: src/olympia/stats/templates/stats/stats.html:184
 msgid "This dashboard is currently <b>private</b>."
 msgstr "这个面板目前<b>私密</b>。"
 
-#: src/olympia/stats/templates/stats/stats.html:185
+#: src/olympia/stats/templates/stats/stats.html:187
 msgid "Change settings."
 msgstr "更改设置。"
 
@@ -11199,16 +11198,6 @@ msgstr "依照日期统计的用户注册"
 msgid "Application versions by Date"
 msgstr "依照日期统计的应用程序版本"
 
-# {0} is a number
-#: src/olympia/tags/templates/tags/top_cloud.html:4
-msgid "Top {0} Tags"
-msgstr "最热门的 {0} 个标签"
-
-#. {0} is the current application name
-#: src/olympia/tags/templates/tags/top_cloud.html:14
-msgid "{0} Top Tags"
-msgstr "{0} 分类排行"
-
 #: src/olympia/templates/amo_footer.html:6 src/olympia/templates/includes/lang_switcher.html:2
 msgid "Other languages"
 msgstr "其他语言"
@@ -11217,11 +11206,11 @@ msgstr "其他语言"
 msgid "Mozilla Add-ons"
 msgstr "Mozilla 附加组件"
 
-#: src/olympia/templates/base.html:91 src/olympia/templates/impala/base.html:81
+#: src/olympia/templates/base.html:89 src/olympia/templates/impala/base.html:78
 msgid "Find add-ons for other applications"
 msgstr "查找其他应用程序的附加组件"
 
-#: src/olympia/templates/base.html:92 src/olympia/templates/impala/base.html:81
+#: src/olympia/templates/base.html:90 src/olympia/templates/impala/base.html:78
 msgid "Other Applications"
 msgstr "其他应用程序"
 
@@ -11246,7 +11235,7 @@ msgid "View Mobile Site"
 msgstr "查看移动版网站"
 
 #: src/olympia/templates/copyright.html:7
-msgid "Site Status "
+msgid "Site Status"
 msgstr "网站统计"
 
 #: src/olympia/templates/footer.html:3
@@ -11348,35 +11337,35 @@ msgstr "欢迎，{0}"
 msgid "<a href=\"%(reg)s\">Register</a> or <a href=\"%(login)s\">Log in</a>"
 msgstr "<a href=\"%(reg)s\">注册</a> 或 <a href=\"%(login)s\">登录</a>"
 
-#: src/olympia/templates/impala/base.html:126
+#: src/olympia/templates/impala/base.html:123
 #, python-format
 msgid "To try the thousands of add-ons available here, download <a href=\"%(url)s\">Mozilla Firefox</a>, a fast, free way to surf the Web!"
 msgstr "要尝试这里成千上万的附加组件，下载 <a href=\"%(url)s\">Mozilla Firefox</a>，一个快速、自由的上网工具！"
 
-#: src/olympia/templates/impala/base.html:138
+#: src/olympia/templates/impala/base.html:135
 #, python-format
 msgid "Add-ons is switching to Firefox Accounts for login. <a href=\"%(url)s\" class=\"fxa-login\">Sign in now to transfer your account.</a>"
 msgstr "附加组件正在切换到使用 Firefox 账号进行登录。<a href=\"%(url)s\" class=\"fxa-login\">现在登录以转移您的账户。</a>"
 
 #. {0} is an application, such as Firefox.
-#: src/olympia/templates/impala/base.html:148
+#: src/olympia/templates/impala/base.html:145
 msgid "Welcome to {0} Add-ons."
 msgstr "欢迎访问 {0} 附加组件。"
 
-#: src/olympia/templates/impala/base.html:151
+#: src/olympia/templates/impala/base.html:148
 msgid "Choose from thousands of extra features and styles to make Firefox your own."
 msgstr "从数以千计的额外功能和样式里选择打造您的专属 Firefox。"
 
-#: src/olympia/templates/impala/base.html:156
+#: src/olympia/templates/impala/base.html:153
 #, python-format
 msgid "Add extra features and styles to make %(app)s your own."
 msgstr "添加额外的功能和样式打造您的专属 %(app)s。"
 
-#: src/olympia/templates/impala/base.html:164
+#: src/olympia/templates/impala/base.html:161
 msgid "On the go?"
 msgstr "随身查看？"
 
-#: src/olympia/templates/impala/base.html:166
+#: src/olympia/templates/impala/base.html:163
 msgid "Check out our <a class=\"mobile-link\" href=\"#\">Mobile Add-ons site</a>."
 msgstr "查看我们的<a class=\"mobile-link\" href=\"#\">移动版附加组件网站</a>。"
 
@@ -11600,19 +11589,19 @@ msgstr "那个邮件地址没有用户。"
 
 #. L10n: {id} will be something like "13ad6a", just a random number
 #. to differentiate this user from other anonymous users.
-#: src/olympia/users/models.py:353
+#: src/olympia/users/models.py:362
 msgid "Anonymous user {id}"
 msgstr "匿名用户 {id}"
 
-#: src/olympia/users/models.py:410
+#: src/olympia/users/models.py:419
 msgid "Your account has been restricted"
 msgstr "您的帐号已经被限制"
 
-#: src/olympia/users/models.py:480
+#: src/olympia/users/models.py:489
 msgid "Please confirm your email address"
 msgstr "请确认您的电子邮件地址"
 
-#: src/olympia/users/models.py:506
+#: src/olympia/users/models.py:515
 msgid "My Mobile Add-ons"
 msgstr "我的移动版附加组件"
 
@@ -11890,7 +11879,7 @@ msgstr "密码"
 
 #: src/olympia/users/templates/users/edit.html:70
 #, python-format
-msgid "Change your password.  If you forgot your password, you can <a href=\"%(reset_url)s\">use the reset form</a>."
+msgid "Change your password. If you forgot your password, you can <a href=\"%(reset_url)s\">use the reset form</a>."
 msgstr "更改您的密码。如果您忘记了您的密码，您可以<a href=\"%(reset_url)s\">使用重置表单</a>。"
 
 #: src/olympia/users/templates/users/edit.html:76
@@ -11910,7 +11899,7 @@ msgid "Profile"
 msgstr "个人资料"
 
 #: src/olympia/users/templates/users/edit.html:100
-msgid "Give us a bit more information about yourself.  All these fields are optional, but they'll help other users get to know you better."
+msgid "Give us a bit more information about yourself. All these fields are optional, but they'll help other users get to know you better."
 msgstr "多向我们介绍一下你自己。所有字段都是可选的，但它们有助于其他用户更好的了解你。"
 
 #: src/olympia/users/templates/users/edit.html:124
@@ -12315,7 +12304,7 @@ msgstr "我们无法为您退订"
 
 #: src/olympia/users/templates/users/unsubscribe.html:30
 #, python-format
-msgid "Unfortunately, we weren't able to unsubscribe you.  The link you clicked is invalid. However, you can unsubscribe still unsubscribe on your <a href=\"%(edit_url)s\">edit profile page</a>."
+msgid "Unfortunately, we weren't able to unsubscribe you. The link you clicked is invalid. However, you can unsubscribe still unsubscribe on your <a href=\"%(edit_url)s\">edit profile page</a>."
 msgstr "很抱歉，我们不能为您退订。您点击的链接无效。不过，您仍然可以在您的 <a href=\"%(edit_url)s\">编辑概要页面</a> 退订。"
 
 #: src/olympia/users/templates/users/vcard.html:2
@@ -12347,12 +12336,14 @@ msgstr "{0} 个附加组件"
 msgid "%(num)s theme"
 msgid_plural "%(num)s themes"
 msgstr[0] "%(num)s 个主题"
+msgstr[1] ""
 
 #: src/olympia/users/templates/users/vcard.html:62
 #, python-format
 msgid "%(num)s add-on"
 msgid_plural "%(num)s add-ons"
 msgstr[0] "%(num)s 个附加组件"
+msgstr[1] ""
 
 #: src/olympia/users/templates/users/vcard.html:75
 msgid "Average rating of developer's add-ons"
@@ -12367,15 +12358,15 @@ msgstr "%s 版本历史"
 msgid "Version History with Changelogs"
 msgstr "版本历史记录"
 
-#: src/olympia/versions/models.py:314
+#: src/olympia/versions/models.py:313
 msgid "Add-on uses binary components."
 msgstr "添加使用二进制的附加组件。"
 
-#: src/olympia/versions/models.py:317
+#: src/olympia/versions/models.py:316
 msgid "Add-on has opted into strict compatibility checking."
 msgstr "附加组件选择采用严格的兼容性检查。"
 
-#: src/olympia/versions/models.py:715
+#: src/olympia/versions/models.py:711
 msgid "{app} {min} and later"
 msgstr "{app} {min} 及更新的版本"
 
@@ -12413,6 +12404,7 @@ msgstr "{0} 版本历史"
 msgid "<b>{0}</b> version"
 msgid_plural "<b>{0}</b> versions"
 msgstr[0] "<b>{0}</b> 个版本"
+msgstr[1] ""
 
 #: src/olympia/versions/templates/versions/version_list.html:35 src/olympia/versions/templates/versions/mobile/version_list.html:14
 msgid "Be careful with old versions!"
@@ -12451,4 +12443,8 @@ msgstr "完成时发邮件"
 #: src/olympia/zadmin/forms.py:105
 msgid "Log emails instead of sending"
 msgstr "记录邮件而不是发送"
+
+#: src/olympia/zadmin/forms.py:215
+msgid "Deleted versions can`t be changed."
+msgstr ""
 

--- a/locale/zh_CN/LC_MESSAGES/djangojs.po
+++ b/locale/zh_CN/LC_MESSAGES/djangojs.po
@@ -3,1199 +3,1234 @@ msgid ""
 msgstr ""
 "Project-Id-Version:  AMO\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2016-02-24 21:23+0000\n"
+"POT-Creation-Date: 2016-04-18 15:47+0000\n"
 "PO-Revision-Date: 2015-10-23 07:22+0000\n"
 "Last-Translator: YFdyh000 <yfdyh000@gmail.com>\n"
 "Language-Team: Chinese Simplified, China <LL@li.org>\n"
+"Language: \n"
 "MIME-Version: 1.0\n"
-"Content-Type: text/plain; charset=utf-8\n"
+"Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Generated-By: Babel 2.2.0\n"
 
-#: static/js/common/ratingwidget.js:31
+#: static/js/common-all.js:1426 static/js/impala-all.js:1511 static/js/zamboni/discovery-all.js:12598 static/js/zamboni/init.js:28 static/js/zamboni/mobile-all.js:14945
+msgid "This feature is temporarily disabled while we perform website maintenance. Please check back a little later."
+msgstr "我们正在进行网站维护，此功能暂时无法使用。请您稍后再试。"
+
+#. L10n: {0} is an app name like Firefox.
+#: static/js/common-all.js:1837 static/js/impala-all.js:1922 static/js/zamboni/buttons.js:73 static/js/zamboni/discovery-all.js:13108
+msgid "Accept and Install"
+msgstr "同意并安装"
+
+#: static/js/common-all.js:1837 static/js/impala-all.js:1922 static/js/zamboni/buttons.js:73 static/js/zamboni/discovery-all.js:13108
+msgid "Add to {0}"
+msgstr "添加到 {0}"
+
+#: static/js/common-all.js:1842 static/js/impala-all.js:1927 static/js/zamboni/buttons.js:78 static/js/zamboni/discovery-all.js:13113
+msgid "Download Now"
+msgstr "立即下载"
+
+#: static/js/common-all.js:1883 static/js/impala-all.js:1968 static/js/zamboni/buttons.js:119 static/js/zamboni/discovery-all.js:13154
+msgid "Add-on has not been updated to support default-to-compatible."
+msgstr "附加组件尚未更新以支持默认兼容。"
+
+#: static/js/common-all.js:1888 static/js/impala-all.js:1973 static/js/zamboni/buttons.js:124 static/js/zamboni/discovery-all.js:13159
+msgid "You need to be using Firefox 10.0 or higher."
+msgstr "您需要使用 Firefox 10.0 或更高的版本。"
+
+#: static/js/common-all.js:1900 static/js/impala-all.js:1985 static/js/zamboni/buttons.js:136 static/js/zamboni/discovery-all.js:13171
+msgid "Mozilla has marked this version as incompatible with your Firefox version."
+msgstr "Mozilla 已标记此版本为不兼容您的 Firefox 版本。"
+
+#. L10n: {0} is an platform like Windows or Linux.
+#: static/js/common-all.js:1981 static/js/impala-all.js:2066 static/js/zamboni/buttons.js:217 static/js/zamboni/discovery-all.js:13252
+msgid "Install for {0} anyway"
+msgstr "继续安装 {0} 版本"
+
+#: static/js/common-all.js:1981 static/js/impala-all.js:2066 static/js/zamboni/buttons.js:217 static/js/zamboni/discovery-all.js:13252
+msgid "Download for {0} anyway"
+msgstr "仍要下载 {0}"
+
+#: static/js/common-all.js:2038 static/js/impala-all.js:2123 static/js/zamboni/buttons.js:274 static/js/zamboni/discovery-all.js:13309
+msgid "Not available for your platform"
+msgstr "不适用于您的操作系统"
+
+#. L10n: {0} is an app name, {1} is the app version.
+#: static/js/common-all.js:2049 static/js/common-all.js:2086 static/js/impala-all.js:2134 static/js/impala-all.js:2171 static/js/zamboni/buttons.js:286 static/js/zamboni/buttons.js:324
+#: static/js/zamboni/discovery-all.js:13320 static/js/zamboni/discovery-all.js:13357
+msgid "Not available for {0} {1}"
+msgstr "不适用于 {0} {1}"
+
+#: static/js/common-all.js:2112 static/js/impala-all.js:2197 static/js/zamboni/buttons.js:351 static/js/zamboni/discovery-all.js:13383
+msgid "Works with {app} {min} - {max}"
+msgstr "兼容于 {app} {min} - {max}"
+
+#: static/js/common-all.js:2114 static/js/impala-all.js:2199 static/js/zamboni/buttons.js:353 static/js/zamboni/discovery-all.js:13385
+msgid "View other versions"
+msgstr "查看其他版本"
+
+#: static/js/common-all.js:2162 static/js/impala-all.js:2247 static/js/zamboni/buttons.js:401 static/js/zamboni/discovery-all.js:13433
+msgid "Only with Firefox — Get Firefox Now!"
+msgstr "只能用于 Firefox — 获取 Firefox！"
+
+#: static/js/common-all.js:2278 static/js/impala-all.js:2363 static/js/zamboni/buttons.js:517 static/js/zamboni/discovery-all.js:13549 static/js/zamboni/mobile-all.js:15177
+#: static/js/zamboni/mobile/buttons.js:43
+msgid "Sorry, you need a Mozilla-based browser (such as Firefox) to install a search plugin."
+msgstr "抱歉，您需要一个基于 Mozilla 的浏览器（例如 Firefox）才能安装此搜索插件。"
+
+#: static/js/common-all.js:9088 static/js/impala-all.js:9649 static/js/zamboni/global.js:410
+msgid "Loading..."
+msgstr "正在加载..."
+
+#. L10n: {0} is the number of characters left.
+#: static/js/common-all.js:9152 static/js/impala-all.js:9713 static/js/zamboni/global.js:474
+msgid "<b>{0}</b> character left."
+msgid_plural "<b>{0}</b> characters left."
+msgstr[0] "剩余 <b>{0}</b> 个字符。"
+msgstr[1] ""
+
+#: static/js/common-all.js:9589 static/js/common-min.js:6 static/js/impala-all.js:10052 static/js/impala-min.js:6 static/js/common/ratingwidget.js:31 static/js/zamboni/mobile-all.js:16123
+#: static/js/zamboni/mobile-min.js:6
 msgid "{0} star"
 msgid_plural "{0} stars"
 msgstr[0] "{0} 星"
+msgstr[1] ""
 
-#: static/js/common/upload-addon.js:41 static/js/common/upload-image.js:128
+#: static/js/common-all.js:9676 static/js/common-min.js:6 static/js/impala-all.js:10139 static/js/impala-min.js:6 static/js/zamboni/l10n.js:45
+msgid "Remove this localization"
+msgstr "移除此本地化"
+
+#: static/js/common-all.js:10193 static/js/common-min.js:6 static/js/impala-all.js:10674 static/js/impala-min.js:6 static/js/zamboni/discovery-all.js:13678
+msgid "close"
+msgstr ""
+
+#: static/js/common-all.js:10860 static/js/common-min.js:6 static/js/impala-all.js:11481 static/js/impala-min.js:6 static/js/impala/reviews.js:23 static/js/zamboni/reviews.js:18
+msgid "Flagged for review"
+msgstr "已标记评价"
+
+#: static/js/common-all.js:10876 static/js/common-min.js:6 static/js/impala-all.js:11498 static/js/impala-min.js:6 static/js/impala/reviews.js:40 static/js/zamboni/reviews.js:34
+msgid "Your input is required"
+msgstr "必须输入"
+
+#: static/js/common-all.js:10945 static/js/common-min.js:6 static/js/impala-all.js:11610 static/js/impala-min.js:7 static/js/impala/reviews.js:152 static/js/zamboni/reviews.js:103
+msgid "Marked for deletion"
+msgstr "标记为删除"
+
+#: static/js/common-all.js:11573 static/js/common-min.js:7 static/js/impala-all.js:13809 static/js/impala-min.js:8 static/js/zamboni/collections.js:229
+msgid "Adding to Favorites&hellip;"
+msgstr "正在添加到收藏夹&hellip;"
+
+#: static/js/common-all.js:11576 static/js/common-min.js:7 static/js/impala-all.js:13812 static/js/impala-min.js:8 static/js/zamboni/collections.js:232
+msgid "Removing Favorite&hellip;"
+msgstr "正在从收藏夹中移除&hellip;"
+
+#: static/js/common-all.js:11579 static/js/common-min.js:7 static/js/impala-all.js:13815 static/js/impala-min.js:8 static/js/zamboni/collections.js:235
+msgid "Add to Favorites"
+msgstr "添加到收藏夹"
+
+#: static/js/common-all.js:11582 static/js/common-min.js:7 static/js/impala-all.js:13818 static/js/impala-min.js:8 static/js/zamboni/collections.js:238
+msgid "Remove from Favorites"
+msgstr "从收藏夹中移除"
+
+#: static/js/common-all.js:11647 static/js/common-min.js:7 static/js/impala-all.js:13883 static/js/impala-min.js:8 static/js/zamboni/collections.js:303
+msgid "Pending"
+msgstr "等待中"
+
+#: static/js/common-all.js:11648 static/js/common-min.js:7 static/js/impala-all.js:13884 static/js/impala-min.js:8 static/js/zamboni/collections.js:304
+msgid "Add a comment"
+msgstr "添加评论"
+
+#: static/js/common-all.js:11648 static/js/common-min.js:7 static/js/impala-all.js:13884 static/js/impala-min.js:8 static/js/zamboni/collections.js:304
+msgid "Comment"
+msgstr "评论"
+
+#: static/js/common-all.js:11649 static/js/common-min.js:7 static/js/impala-all.js:13885 static/js/impala-min.js:8 static/js/zamboni/collections.js:305
+msgid "Remove this add-on from the collection"
+msgstr "从收藏集中移除此附加组件"
+
+#: static/js/common-all.js:11649 static/js/common-all.js:11678 static/js/common-min.js:7 static/js/impala-all.js:13885 static/js/impala-all.js:13914 static/js/impala-min.js:8
+#: static/js/zamboni/collections.js:305 static/js/zamboni/collections.js:334
+msgid "Remove"
+msgstr "移除"
+
+#: static/js/common-all.js:11678 static/js/common-min.js:7 static/js/impala-all.js:13914 static/js/impala-min.js:8 static/js/zamboni/collections.js:334
+msgid "Remove this user as a contributor"
+msgstr "从贡献者中移除此用户"
+
+#: static/js/common-all.js:11690 static/js/common-min.js:7 static/js/impala-all.js:13926 static/js/impala-min.js:8 static/js/zamboni/collections.js:346
+msgid "An email address is required."
+msgstr "必须输入电子邮件地址。"
+
+#: static/js/common-all.js:11708 static/js/common-min.js:7 static/js/impala-all.js:13944 static/js/impala-min.js:8 static/js/zamboni/collections.js:364
+msgid "You cannot add yourself as a contributor."
+msgstr "您不能添加自己为贡献者。"
+
+#: static/js/common-all.js:11710 static/js/common-min.js:7 static/js/impala-all.js:13946 static/js/impala-min.js:8 static/js/zamboni/collections.js:366
+msgid "You have already added that user."
+msgstr "您已经添加了该用户。"
+
+#: static/js/common-all.js:11917 static/js/common-min.js:7 static/js/impala-all.js:14153 static/js/impala-min.js:8 static/js/zamboni/collections.js:573
+msgid "Add to favorites"
+msgstr "添加到收藏夹"
+
+#: static/js/common-all.js:11921 static/js/common-min.js:7 static/js/impala-all.js:14157 static/js/impala-min.js:8 static/js/zamboni/collections.js:577
+msgid "Remove from favorites"
+msgstr "从收藏夹中移除"
+
+#: static/js/common-all.js:11939 static/js/common-min.js:7 static/js/impala-all.js:14175 static/js/impala-all.js:14233 static/js/impala-min.js:8 static/js/impala/collections.js:10
+#: static/js/zamboni/collections.js:595
+msgid "Follow this Collection"
+msgstr "关注这个收藏集"
+
+#: static/js/common-all.js:11948 static/js/common-min.js:7 static/js/impala-all.js:14184 static/js/impala-min.js:8 static/js/zamboni/collections.js:604
+msgid "Stop following"
+msgstr "停止关注"
+
+#: static/js/common-all.js:12096 static/js/common-min.js:7 static/js/zamboni/password-strength.js:20
+msgid "Password strength:"
+msgstr "密码强度："
+
+#: static/js/common-all.js:12102 static/js/common-min.js:7 static/js/zamboni/password-strength.js:26
+msgid "At least {0} character left."
+msgid_plural "At least {0} characters left."
+msgstr[0] "至少还需要输入 {0} 个字符。"
+msgstr[1] ""
+
+#: static/js/common-all.js:12286 static/js/common-min.js:7 static/js/impala-all.js:14632 static/js/impala-min.js:8 static/js/impala/suggestions.js:39
+msgid "Search themes for <b>{0}</b>"
+msgstr "搜索匹配 <b>{0}</b> 的主题"
+
+#: static/js/common-all.js:12288 static/js/common-min.js:7 static/js/impala-all.js:14634 static/js/impala-min.js:8 static/js/impala/suggestions.js:41
+msgid "Search apps for <b>{0}</b>"
+msgstr "搜索包含关键字 <b>{0}</b> 的应用"
+
+#: static/js/common-all.js:12290 static/js/common-min.js:7 static/js/impala-all.js:14636 static/js/impala-min.js:8 static/js/impala/suggestions.js:43
+msgid "Search add-ons for <b>{0}</b>"
+msgstr "搜索包含关键字 <b>{0}</b> 的附加组件"
+
+#: static/js/common-all.js:12521 static/js/common-min.js:7 static/js/impala-all.js:14867 static/js/impala-min.js:8 static/js/impala/site_suggestions.js:46
+msgid "Category"
+msgstr "分类"
+
+#. L10n: {0} is an app name.
+#: static/js/impala-all.js:11632 static/js/impala-min.js:7 static/js/impala/listing.js:11 static/js/zamboni/themes.js:13
+msgid "This theme is incompatible with your version of {0}"
+msgstr "这个主题与您所使用的 {0} 版本不兼容"
+
+#: static/js/impala-all.js:12146 static/js/impala-all.js:14331 static/js/impala-min.js:7 static/js/impala-min.js:8 static/js/common/upload-image.js:97 static/js/impala/users.js:51
+#: static/js/zamboni/devhub-all.js:894 static/js/zamboni/devhub-min.js:1
+msgid "Images must be either PNG or JPG."
+msgstr "图像必须为 PNG 或 JPG 格式。"
+
+#: static/js/impala-all.js:12150 static/js/impala-min.js:7 static/js/common/upload-image.js:101 static/js/zamboni/devhub-all.js:898 static/js/zamboni/devhub-min.js:1
+msgid "Videos must be in WebM."
+msgstr "视频必须是 WebM 格式。"
+
+#: static/js/impala-all.js:12177 static/js/impala-min.js:7 static/js/common/upload-addon.js:41 static/js/common/upload-image.js:128 static/js/zamboni/devhub-all.js:272
+#: static/js/zamboni/devhub-all.js:925 static/js/zamboni/devhub-min.js:1
 msgid "There was a problem contacting the server."
 msgstr "连接服务器时发生错误。"
 
-#: static/js/common/upload-addon.js:69
+#: static/js/impala-all.js:13298 static/js/impala-min.js:7 static/js/impala/persona_creation.js:60
+msgid "All Rights Reserved"
+msgstr "保留所有权利"
+
+#: static/js/impala-all.js:13302 static/js/impala-min.js:7 static/js/impala/persona_creation.js:64
+msgid "Creative Commons Attribution 3.0"
+msgstr "知识共享“署名 3.0”"
+
+#: static/js/impala-all.js:13307 static/js/impala-min.js:7 static/js/impala/persona_creation.js:69
+msgid "Creative Commons Attribution-NonCommercial 3.0"
+msgstr "知识共享“署名-非商业性使用 3.0”"
+
+#: static/js/impala-all.js:13312 static/js/impala-min.js:7 static/js/impala/persona_creation.js:74
+msgid "Creative Commons Attribution-NonCommercial-NoDerivs 3.0"
+msgstr "知识共享“署名-非商业性使用-禁止演绎 3.0”"
+
+#: static/js/impala-all.js:13317 static/js/impala-min.js:7 static/js/impala/persona_creation.js:79
+msgid "Creative Commons Attribution-NonCommercial-Share Alike 3.0"
+msgstr "知识共享“署名-非商业性使用-相同方式共享 3.0”"
+
+#: static/js/impala-all.js:13322 static/js/impala-min.js:7 static/js/impala/persona_creation.js:84
+msgid "Creative Commons Attribution-NoDerivs 3.0"
+msgstr "知识共享“署名-禁止演绎 3.0”"
+
+#: static/js/impala-all.js:13327 static/js/impala-min.js:7 static/js/impala/persona_creation.js:89
+msgid "Creative Commons Attribution-ShareAlike 3.0"
+msgstr "知识共享“署名-相同方式共享 3.0”"
+
+#: static/js/impala-all.js:13530 static/js/impala-min.js:7 static/js/impala/persona_creation.js:292
+msgid "Your Theme's Name"
+msgstr "您的主题名称"
+
+#: static/js/impala-all.js:14242 static/js/impala-min.js:8 static/js/impala/collections.js:19
+msgid "Stop Following"
+msgstr "停止关注"
+
+#: static/js/impala-all.js:14243 static/js/impala-min.js:8 static/js/impala/collections.js:20
+msgid "Following"
+msgstr "正在关注"
+
+#: static/js/impala-all.js:14313 static/js/impala-min.js:8 static/js/impala/users.js:33
+msgid "use original"
+msgstr "使用原来的"
+
+#: static/js/impala-all.js:14523 static/js/impala-min.js:8 static/js/impala/search.js:114
+msgid "Updating results&hellip;"
+msgstr "正在更新结果&hellip;"
+
+#: static/js/common/upload-addon.js:69 static/js/zamboni/devhub-all.js:300 static/js/zamboni/devhub-min.js:1
 msgid "Select a file..."
 msgstr "选择文件..."
 
-#: static/js/common/upload-addon.js:70
+#: static/js/common/upload-addon.js:70 static/js/zamboni/devhub-all.js:301 static/js/zamboni/devhub-min.js:1
 msgid "Your add-on should end with .xpi, .jar or .xml"
 msgstr "您的附加组件应该以 .xpi、.jar 或 .xml 结尾"
 
 #. L10n: {0} is the percent of the file that has been uploaded.
-#: static/js/common/upload-addon.js:104
+#: static/js/common/upload-addon.js:104 static/js/zamboni/devhub-all.js:335 static/js/zamboni/devhub-min.js:1
 #, python-format
 msgid "{0}% complete"
 msgstr "已完成 {0}%"
 
 #. L10n: "{bytes uploaded} of {total filesize}".
-#: static/js/common/upload-addon.js:107
+#: static/js/common/upload-addon.js:107 static/js/zamboni/devhub-all.js:338 static/js/zamboni/devhub-min.js:1
 msgid "{0} of {1}"
 msgstr "{0} / {1}"
 
-#: static/js/common/upload-addon.js:140
+#: static/js/common/upload-addon.js:140 static/js/zamboni/devhub-all.js:371 static/js/zamboni/devhub-min.js:1
 msgid "Cancel"
 msgstr "取消"
 
-#: static/js/common/upload-addon.js:162
+#: static/js/common/upload-addon.js:162 static/js/zamboni/devhub-all.js:393 static/js/zamboni/devhub-min.js:1
 msgid "Uploading {0}"
 msgstr "正在上传 {0}"
 
-#: static/js/common/upload-addon.js:189
+#: static/js/common/upload-addon.js:189 static/js/zamboni/devhub-all.js:420 static/js/zamboni/devhub-min.js:1
 msgid "Error with {0}"
 msgstr "{0} 发生错误"
 
-#: static/js/common/upload-addon.js:194
+#: static/js/common/upload-addon.js:194 static/js/zamboni/devhub-all.js:425 static/js/zamboni/devhub-min.js:1
 msgid "Your add-on failed validation with {0} error."
 msgid_plural "Your add-on failed validation with {0} errors."
 msgstr[0] "您的附加组件验证失败，有 {0} 个错误。"
+msgstr[1] ""
 
-#: static/js/common/upload-addon.js:208
+#: static/js/common/upload-addon.js:208 static/js/zamboni/devhub-all.js:439 static/js/zamboni/devhub-min.js:1
 msgid "&hellip;and {0} more"
 msgid_plural "&hellip;and {0} more"
 msgstr[0] "&hellip;还有 {0} 个"
+msgstr[1] ""
 
-#: static/js/common/upload-addon.js:222 static/js/common/upload-addon.js:512
+#: static/js/common/upload-addon.js:222 static/js/common/upload-addon.js:497 static/js/zamboni/devhub-all.js:453 static/js/zamboni/devhub-all.js:743 static/js/zamboni/devhub-min.js:1
 msgid "See full validation report"
 msgstr "查看完整的验证报告"
 
-#: static/js/common/upload-addon.js:234
+#: static/js/common/upload-addon.js:234 static/js/zamboni/devhub-all.js:465 static/js/zamboni/devhub-min.js:1
 msgid "Validating {0}"
 msgstr "正在验证 {0}"
 
 #. L10n: first argument is an HTTP status code
-#: static/js/common/upload-addon.js:273
+#: static/js/common/upload-addon.js:273 static/js/zamboni/devhub-all.js:504 static/js/zamboni/devhub-min.js:1
 msgid "Received an empty response from the server; status: {0}"
 msgstr "从服务器上接收到一个空的响应；状态：{0}"
 
-#: static/js/common/upload-addon.js:373
+#: static/js/common/upload-addon.js:370 static/js/zamboni/devhub-all.js:604 static/js/zamboni/devhub-min.js:1
 msgid "Unexpected server error while validating."
 msgstr "验证时发生了意外的服务器错误。"
 
-#: static/js/common/upload-addon.js:412
+#: static/js/common/upload-addon.js:409 static/js/zamboni/devhub-all.js:643 static/js/zamboni/devhub-min.js:1
 msgid "Finished validating {0}"
 msgstr "已完成验证 {0}"
 
-#: static/js/common/upload-addon.js:418
+#: static/js/common/upload-addon.js:415 static/js/zamboni/devhub-all.js:649 static/js/zamboni/devhub-min.js:1
 msgid "Your add-on validation timed out, it will be manually reviewed."
 msgstr "您的附加组件验证超时，它将经过人工审核。"
 
-#: static/js/common/upload-addon.js:421
+#: static/js/common/upload-addon.js:418 static/js/zamboni/devhub-all.js:652 static/js/zamboni/devhub-min.js:1
 msgid "Your add-on was validated with no errors and {0} warning."
 msgid_plural "Your add-on was validated with no errors and {0} warnings."
 msgstr[0] "您的附加组件已通过验证，无错误，{0} 条警告。"
+msgstr[1] ""
 
-#: static/js/common/upload-addon.js:426
+#: static/js/common/upload-addon.js:423 static/js/zamboni/devhub-all.js:657 static/js/zamboni/devhub-min.js:1
 msgid "Your add-on was validated with no errors and {0} message."
 msgid_plural "Your add-on was validated with no errors and {0} messages."
 msgstr[0] "您的附加组件已通过验证，无错误，{0} 条消息。"
+msgstr[1] ""
 
-#: static/js/common/upload-addon.js:431
+#: static/js/common/upload-addon.js:428 static/js/zamboni/devhub-all.js:662 static/js/zamboni/devhub-min.js:1
 msgid "Your add-on was validated with no errors or warnings."
 msgstr "您的附加组件已通过验证，无错误，无警告。"
 
-#: static/js/common/upload-addon.js:446
+#: static/js/common/upload-addon.js:443 static/js/zamboni/devhub-all.js:677 static/js/zamboni/devhub-min.js:1
 msgid "Your submission will be automatically signed."
 msgstr "您的提交将被自动签名。"
 
-#: static/js/common/upload-addon.js:465
+#: static/js/common/upload-addon.js:450 static/js/zamboni/devhub-all.js:696 static/js/zamboni/devhub-min.js:1
 msgid "Include detailed version notes (this can be done in the next step)."
 msgstr "包括详细的版本说明（这可以在下一步骤中完成）。"
 
-#: static/js/common/upload-addon.js:466
+#: static/js/common/upload-addon.js:451 static/js/zamboni/devhub-all.js:697 static/js/zamboni/devhub-min.js:1
 msgid "If your add-on requires an account to a website in order to be fully tested, include a test username and password in the Notes to Reviewer (this can be done in the next step)."
 msgstr "如果您的附加组件需要有一个某网站的帐号才能进行全面的测试，请在给审核员的说明中写一个测试用的用户名和密码（这可以在下一步骤中完成）。"
 
-#: static/js/common/upload-addon.js:467
+#: static/js/common/upload-addon.js:452 static/js/zamboni/devhub-all.js:698 static/js/zamboni/devhub-min.js:1
 msgid "If your add-on is intended for a limited audience you should choose Preliminary Review instead of Full Review."
 msgstr "如果您的附加组件是面向有限的受众，您应该选择初步审核而不是全面审核。"
 
-#: static/js/common/upload-addon.js:480
+#: static/js/common/upload-addon.js:465 static/js/zamboni/devhub-all.js:711 static/js/zamboni/devhub-min.js:1
 msgid "Add-on submission checklist"
 msgstr "附加组件提交注意事项"
 
-#: static/js/common/upload-addon.js:481
+#: static/js/common/upload-addon.js:466 static/js/zamboni/devhub-all.js:712 static/js/zamboni/devhub-min.js:1
 msgid "Please verify the following points before finalizing your submission. This will minimize delays or misunderstanding during the review process:"
 msgstr "请在完成您的提交前确认以下几点。这将最大限度的减少在审核过程中的延误或误解："
 
-#: static/js/common/upload-addon.js:483
+#: static/js/common/upload-addon.js:468 static/js/zamboni/devhub-all.js:714 static/js/zamboni/devhub-min.js:1
 msgid ""
 "Compiled binaries, as well as minified or obfuscated scripts (excluding known libraries) need to have their sources submitted separately for review. Make sure that you use the source code upload "
 "field to avoid having your submission rejected."
 msgstr "编译后的二进制文件，以及压缩或混淆后的脚本（不含知名库）需要单独提供它们的源代码以供审核。请确保您使用了源代码上传字段，以避免您的提交被拒绝。"
 
-#: static/js/common/upload-addon.js:501
+#: static/js/common/upload-addon.js:486 static/js/zamboni/devhub-all.js:732 static/js/zamboni/devhub-min.js:1
 msgid "The validation process found these issues that can lead to rejections:"
 msgstr "在验证过程中发现下列问题可导致被拒绝："
 
-#: static/js/common/upload-addon.js:518
+#: static/js/common/upload-addon.js:503 static/js/zamboni/devhub-all.js:749 static/js/zamboni/devhub-min.js:1
 msgid "If you are unfamiliar with the add-ons review process, you can read about it here."
 msgstr "如果您不熟悉附加组件的审核流程，您可以到这里查看。"
 
-#: static/js/common/upload-addon.js:555
+#: static/js/common/upload-addon.js:540 static/js/zamboni/devhub-all.js:786 static/js/zamboni/devhub-min.js:1
 msgid "Sorry, no supported platform has been found."
 msgstr "抱歉，找不到支持的平台。"
 
-#: static/js/common/upload-base.js:57
+#: static/js/common/upload-base.js:57 static/js/zamboni/devhub-all.js:187 static/js/zamboni/devhub-min.js:1
 msgid "The filetype you uploaded isn't recognized."
 msgstr "无法识别您上传的文件格式。"
 
-#: static/js/common/upload-base.js:79
+#: static/js/common/upload-base.js:79 static/js/zamboni/devhub-all.js:209 static/js/zamboni/devhub-min.js:1
 msgid "You cancelled the upload."
 msgstr "您已取消上传。"
 
-#: static/js/common/upload-image.js:97 static/js/impala/users.js:51
-msgid "Images must be either PNG or JPG."
-msgstr "图像必须为 PNG 或 JPG 格式。"
-
-#: static/js/common/upload-image.js:101
-msgid "Videos must be in WebM."
-msgstr "视频必须是 WebM 格式。"
-
-#: static/js/impala/collections.js:10 static/js/zamboni/collections.js:595
-msgid "Follow this Collection"
-msgstr "关注这个收藏集"
-
-#: static/js/impala/collections.js:19
-msgid "Stop Following"
-msgstr "停止关注"
-
-#: static/js/impala/collections.js:20
-msgid "Following"
-msgstr "正在关注"
-
-#. L10n: {0} is an app name.
-#: static/js/impala/listing.js:11 static/js/zamboni/themes.js:13
-msgid "This theme is incompatible with your version of {0}"
-msgstr "这个主题与您所使用的 {0} 版本不兼容"
-
-#: static/js/impala/persona_creation.js:60
-msgid "All Rights Reserved"
-msgstr "保留所有权利"
-
-#: static/js/impala/persona_creation.js:64
-msgid "Creative Commons Attribution 3.0"
-msgstr "知识共享“署名 3.0”"
-
-#: static/js/impala/persona_creation.js:69
-msgid "Creative Commons Attribution-NonCommercial 3.0"
-msgstr "知识共享“署名-非商业性使用 3.0”"
-
-#: static/js/impala/persona_creation.js:74
-msgid "Creative Commons Attribution-NonCommercial-NoDerivs 3.0"
-msgstr "知识共享“署名-非商业性使用-禁止演绎 3.0”"
-
-#: static/js/impala/persona_creation.js:79
-msgid "Creative Commons Attribution-NonCommercial-Share Alike 3.0"
-msgstr "知识共享“署名-非商业性使用-相同方式共享 3.0”"
-
-#: static/js/impala/persona_creation.js:84
-msgid "Creative Commons Attribution-NoDerivs 3.0"
-msgstr "知识共享“署名-禁止演绎 3.0”"
-
-#: static/js/impala/persona_creation.js:89
-msgid "Creative Commons Attribution-ShareAlike 3.0"
-msgstr "知识共享“署名-相同方式共享 3.0”"
-
-#: static/js/impala/persona_creation.js:292
-msgid "Your Theme's Name"
-msgstr "您的主题名称"
-
-#: static/js/impala/reviews.js:23 static/js/zamboni/reviews.js:18
-msgid "Flagged for review"
-msgstr "已标记评价"
-
-#: static/js/impala/reviews.js:40 static/js/zamboni/reviews.js:34
-msgid "Your input is required"
-msgstr "必须输入"
-
-#: static/js/impala/reviews.js:152 static/js/zamboni/reviews.js:103
-msgid "Marked for deletion"
-msgstr "标记为删除"
-
-#: static/js/impala/search.js:114
-msgid "Updating results&hellip;"
-msgstr "正在更新结果&hellip;"
-
-#: static/js/impala/site_suggestions.js:46
-msgid "Category"
-msgstr "分类"
-
-#: static/js/impala/suggestions.js:39
-msgid "Search themes for <b>{0}</b>"
-msgstr "搜索匹配 <b>{0}</b> 的主题"
-
-#: static/js/impala/suggestions.js:41
-msgid "Search apps for <b>{0}</b>"
-msgstr "搜索包含关键字 <b>{0}</b> 的应用"
-
-#: static/js/impala/suggestions.js:43
-msgid "Search add-ons for <b>{0}</b>"
-msgstr "搜索包含关键字 <b>{0}</b> 的附加组件"
-
-#: static/js/impala/users.js:33
-msgid "use original"
-msgstr "使用原来的"
-
-#: static/js/impala/stats/chart.js:267
+#: static/js/impala/stats/chart.js:267 static/js/zamboni/stats-all.js:16898 static/js/zamboni/stats-min.js:5
 msgid "Week of {0}"
 msgstr "每周有{0}次"
 
-#: static/js/impala/stats/chart.js:269
+#: static/js/impala/stats/chart.js:269 static/js/zamboni/stats-all.js:16900 static/js/zamboni/stats-min.js:5
 msgid " downloads"
-msgstr " 次下载"
+msgstr ""
 
-#: static/js/impala/stats/chart.js:270
+#: static/js/impala/stats/chart.js:270 static/js/zamboni/stats-all.js:16901 static/js/zamboni/stats-min.js:5
 msgid "{0} users"
 msgstr "{0} 位用户"
 
-#: static/js/impala/stats/chart.js:271
+#: static/js/impala/stats/chart.js:271 static/js/zamboni/stats-all.js:16902 static/js/zamboni/stats-min.js:5
 msgid "{0} add-ons"
 msgstr "{0} 个附加组件"
 
-#: static/js/impala/stats/chart.js:272
+#: static/js/impala/stats/chart.js:272 static/js/zamboni/stats-all.js:16903 static/js/zamboni/stats-min.js:5
 msgid "{0} collections"
 msgstr "{0} 个收藏集"
 
-#: static/js/impala/stats/chart.js:273
+#: static/js/impala/stats/chart.js:273 static/js/zamboni/stats-all.js:16904 static/js/zamboni/stats-min.js:5
 msgid "{0} reviews"
 msgstr "{0} 条评价"
 
-#: static/js/impala/stats/chart.js:275
+#: static/js/impala/stats/chart.js:275 static/js/zamboni/stats-all.js:16906 static/js/zamboni/stats-min.js:5
 msgid "{0} sales"
 msgstr "{0} 份售出"
 
-#: static/js/impala/stats/chart.js:276
+#: static/js/impala/stats/chart.js:276 static/js/zamboni/stats-all.js:16907 static/js/zamboni/stats-min.js:5
 msgid "{0} refunds"
 msgstr "{0} 次退款"
 
-#: static/js/impala/stats/chart.js:277
+#: static/js/impala/stats/chart.js:277 static/js/zamboni/stats-all.js:16908 static/js/zamboni/stats-min.js:5
 msgid "{0} installs"
 msgstr "{0} 次安装"
 
-#: static/js/impala/stats/chart.js:369 static/js/impala/stats/csv_keys.js:3 static/js/impala/stats/csv_keys.js:109
+#: static/js/impala/stats/chart.js:369 static/js/impala/stats/csv_keys.js:3 static/js/impala/stats/csv_keys.js:109 static/js/zamboni/stats-all.js:15284 static/js/zamboni/stats-all.js:15390
+#: static/js/zamboni/stats-all.js:17000 static/js/zamboni/stats-min.js:4 static/js/zamboni/stats-min.js:5
 msgid "Downloads"
 msgstr "下载量"
 
-#: static/js/impala/stats/chart.js:379 static/js/impala/stats/csv_keys.js:6 static/js/impala/stats/csv_keys.js:110
+#: static/js/impala/stats/chart.js:379 static/js/impala/stats/csv_keys.js:6 static/js/impala/stats/csv_keys.js:110 static/js/zamboni/stats-all.js:15287 static/js/zamboni/stats-all.js:15391
+#: static/js/zamboni/stats-all.js:17010 static/js/zamboni/stats-min.js:4 static/js/zamboni/stats-min.js:5
 msgid "Daily Users"
 msgstr "每日用户量"
 
-#: static/js/impala/stats/chart.js:410
+#: static/js/impala/stats/chart.js:410 static/js/zamboni/stats-all.js:17041 static/js/zamboni/stats-min.js:5
 msgid "Amount, in USD"
 msgstr "合计（美元）"
 
-#: static/js/impala/stats/chart.js:421 static/js/impala/stats/csv_keys.js:104
+#: static/js/impala/stats/chart.js:421 static/js/impala/stats/csv_keys.js:104 static/js/zamboni/stats-all.js:15385 static/js/zamboni/stats-all.js:17052 static/js/zamboni/stats-min.js:5
 msgid "Number of Contributions"
 msgstr "捐款次数"
 
-#: static/js/impala/stats/chart.js:447
+#: static/js/impala/stats/chart.js:447 static/js/zamboni/stats-all.js:17078 static/js/zamboni/stats-min.js:5
 msgid "More Info..."
 msgstr "更多信息..."
 
 #. L10n: {0} is an ISO-formatted date.
-#: static/js/impala/stats/chart.js:451
+#: static/js/impala/stats/chart.js:451 static/js/zamboni/stats-all.js:17082 static/js/zamboni/stats-min.js:5
 msgid "Details for {0}"
 msgstr "{0} 的详细信息"
 
-#: static/js/impala/stats/csv_keys.js:9
+#: static/js/impala/stats/csv_keys.js:9 static/js/zamboni/stats-all.js:15290 static/js/zamboni/stats-min.js:4
 msgid "Collections Created"
 msgstr "收藏集创建量"
 
-#: static/js/impala/stats/csv_keys.js:12
+#: static/js/impala/stats/csv_keys.js:12 static/js/zamboni/stats-all.js:15293 static/js/zamboni/stats-min.js:4
 msgid "Add-ons in Use"
 msgstr "附加组件使用量"
 
-#: static/js/impala/stats/csv_keys.js:15
+#: static/js/impala/stats/csv_keys.js:15 static/js/zamboni/stats-all.js:15296 static/js/zamboni/stats-min.js:4
 msgid "Add-ons Created"
 msgstr "附加组件创建量"
 
-#: static/js/impala/stats/csv_keys.js:18
+#: static/js/impala/stats/csv_keys.js:18 static/js/zamboni/stats-all.js:15299 static/js/zamboni/stats-min.js:4
 msgid "Add-ons Downloaded"
 msgstr "附加组件下载量"
 
-#: static/js/impala/stats/csv_keys.js:21
+#: static/js/impala/stats/csv_keys.js:21 static/js/zamboni/stats-all.js:15302 static/js/zamboni/stats-min.js:4
 msgid "Add-ons Updated"
 msgstr "附加组件更新量"
 
-#: static/js/impala/stats/csv_keys.js:24
+#: static/js/impala/stats/csv_keys.js:24 static/js/zamboni/stats-all.js:15305 static/js/zamboni/stats-min.js:4
 msgid "Reviews Written"
 msgstr "评价撰写量"
 
-#: static/js/impala/stats/csv_keys.js:27
+#: static/js/impala/stats/csv_keys.js:27 static/js/zamboni/stats-all.js:15308 static/js/zamboni/stats-min.js:4
 msgid "User Signups"
 msgstr "用户注册量"
 
-#: static/js/impala/stats/csv_keys.js:30
+#: static/js/impala/stats/csv_keys.js:30 static/js/zamboni/stats-all.js:15311 static/js/zamboni/stats-min.js:4
 msgid "Subscribers"
 msgstr "订阅者量"
 
-#: static/js/impala/stats/csv_keys.js:33
+#: static/js/impala/stats/csv_keys.js:33 static/js/zamboni/stats-all.js:15314 static/js/zamboni/stats-min.js:4
 msgid "Ratings"
 msgstr "评分量"
 
-#: static/js/impala/stats/csv_keys.js:36 static/js/impala/stats/csv_keys.js:114
+#: static/js/impala/stats/csv_keys.js:36 static/js/impala/stats/csv_keys.js:114 static/js/zamboni/stats-all.js:15317 static/js/zamboni/stats-all.js:15395 static/js/zamboni/stats-min.js:4
+#: static/js/zamboni/stats-min.js:5
 msgid "Sales"
 msgstr "销量"
 
-#: static/js/impala/stats/csv_keys.js:39 static/js/impala/stats/csv_keys.js:113
+#: static/js/impala/stats/csv_keys.js:39 static/js/impala/stats/csv_keys.js:113 static/js/zamboni/stats-all.js:15320 static/js/zamboni/stats-all.js:15394 static/js/zamboni/stats-min.js:4
+#: static/js/zamboni/stats-min.js:5
 msgid "Installs"
 msgstr "安装量"
 
-#: static/js/impala/stats/csv_keys.js:42
+#: static/js/impala/stats/csv_keys.js:42 static/js/zamboni/stats-all.js:15323 static/js/zamboni/stats-min.js:4
 msgid "Unknown"
 msgstr "未知"
 
-#: static/js/impala/stats/csv_keys.js:43
+#: static/js/impala/stats/csv_keys.js:43 static/js/zamboni/stats-all.js:15324 static/js/zamboni/stats-min.js:4
 msgid "Add-ons Manager"
 msgstr "附加组件管理器"
 
-#: static/js/impala/stats/csv_keys.js:44
+#: static/js/impala/stats/csv_keys.js:44 static/js/zamboni/stats-all.js:15325 static/js/zamboni/stats-min.js:4
 msgid "Add-ons Manager Promo"
 msgstr "附加组件管理器推广"
 
-#: static/js/impala/stats/csv_keys.js:45
+#: static/js/impala/stats/csv_keys.js:45 static/js/zamboni/stats-all.js:15326 static/js/zamboni/stats-min.js:4
 msgid "Add-ons Manager Featured"
 msgstr "附加组件管理器精选"
 
-#: static/js/impala/stats/csv_keys.js:46
+#: static/js/impala/stats/csv_keys.js:46 static/js/zamboni/stats-all.js:15327 static/js/zamboni/stats-min.js:4
 msgid "Add-ons Manager Learn More"
 msgstr "附加组件管理器了解更多"
 
-#: static/js/impala/stats/csv_keys.js:47
+#: static/js/impala/stats/csv_keys.js:47 static/js/zamboni/stats-all.js:15328 static/js/zamboni/stats-min.js:4
 msgid "Search Suggestions"
 msgstr "搜索建议"
 
-#: static/js/impala/stats/csv_keys.js:48
+#: static/js/impala/stats/csv_keys.js:48 static/js/zamboni/stats-all.js:15329 static/js/zamboni/stats-min.js:4
 msgid "Search Results"
 msgstr "搜索结果"
 
-#: static/js/impala/stats/csv_keys.js:49 static/js/impala/stats/csv_keys.js:50 static/js/impala/stats/csv_keys.js:51
+#: static/js/impala/stats/csv_keys.js:49 static/js/impala/stats/csv_keys.js:50 static/js/impala/stats/csv_keys.js:51 static/js/zamboni/stats-all.js:15330 static/js/zamboni/stats-all.js:15331
+#: static/js/zamboni/stats-all.js:15332 static/js/zamboni/stats-min.js:4
 msgid "Homepage Promo"
 msgstr "主页推广"
 
-#: static/js/impala/stats/csv_keys.js:52 static/js/impala/stats/csv_keys.js:53
+#: static/js/impala/stats/csv_keys.js:52 static/js/impala/stats/csv_keys.js:53 static/js/zamboni/stats-all.js:15333 static/js/zamboni/stats-all.js:15334 static/js/zamboni/stats-min.js:4
 msgid "Homepage Featured"
 msgstr "主页精选展示"
 
-#: static/js/impala/stats/csv_keys.js:54 static/js/impala/stats/csv_keys.js:55
+#: static/js/impala/stats/csv_keys.js:54 static/js/impala/stats/csv_keys.js:55 static/js/zamboni/stats-all.js:15335 static/js/zamboni/stats-all.js:15336 static/js/zamboni/stats-min.js:4
 msgid "Homepage Up and Coming"
 msgstr "主页新秀"
 
-#: static/js/impala/stats/csv_keys.js:56
+#: static/js/impala/stats/csv_keys.js:56 static/js/zamboni/stats-all.js:15337 static/js/zamboni/stats-min.js:4
 msgid "Homepage Most Popular"
 msgstr "主页流行榜"
 
-#: static/js/impala/stats/csv_keys.js:57 static/js/impala/stats/csv_keys.js:59
+#: static/js/impala/stats/csv_keys.js:57 static/js/impala/stats/csv_keys.js:59 static/js/zamboni/stats-all.js:15338 static/js/zamboni/stats-all.js:15340 static/js/zamboni/stats-min.js:4
 msgid "Detail Page"
 msgstr "详情页面"
 
-#: static/js/impala/stats/csv_keys.js:58 static/js/impala/stats/csv_keys.js:60
+#: static/js/impala/stats/csv_keys.js:58 static/js/impala/stats/csv_keys.js:60 static/js/zamboni/stats-all.js:15339 static/js/zamboni/stats-all.js:15341 static/js/zamboni/stats-min.js:4
 msgid "Detail Page (bottom)"
 msgstr "详情页面（底部）"
 
-#: static/js/impala/stats/csv_keys.js:61
+#: static/js/impala/stats/csv_keys.js:61 static/js/zamboni/stats-all.js:15342 static/js/zamboni/stats-min.js:4
 msgid "Detail Page (Development Channel)"
 msgstr "详细信息页面（开发通道）"
 
-#: static/js/impala/stats/csv_keys.js:62 static/js/impala/stats/csv_keys.js:63 static/js/impala/stats/csv_keys.js:64
+#: static/js/impala/stats/csv_keys.js:62 static/js/impala/stats/csv_keys.js:63 static/js/impala/stats/csv_keys.js:64 static/js/zamboni/stats-all.js:15343 static/js/zamboni/stats-all.js:15344
+#: static/js/zamboni/stats-all.js:15345 static/js/zamboni/stats-min.js:4
 msgid "Often Used With"
 msgstr "常用搭档"
 
-#: static/js/impala/stats/csv_keys.js:65 static/js/impala/stats/csv_keys.js:66
+#: static/js/impala/stats/csv_keys.js:65 static/js/impala/stats/csv_keys.js:66 static/js/zamboni/stats-all.js:15346 static/js/zamboni/stats-all.js:15347 static/js/zamboni/stats-min.js:4
 msgid "Others By Author"
 msgstr "作者的其他作品"
 
-#: static/js/impala/stats/csv_keys.js:67 static/js/impala/stats/csv_keys.js:68
+#: static/js/impala/stats/csv_keys.js:67 static/js/impala/stats/csv_keys.js:68 static/js/zamboni/stats-all.js:15348 static/js/zamboni/stats-all.js:15349 static/js/zamboni/stats-min.js:4
 msgid "Dependencies"
 msgstr "依赖"
 
-#: static/js/impala/stats/csv_keys.js:69 static/js/impala/stats/csv_keys.js:70
+#: static/js/impala/stats/csv_keys.js:69 static/js/impala/stats/csv_keys.js:70 static/js/zamboni/stats-all.js:15350 static/js/zamboni/stats-all.js:15351 static/js/zamboni/stats-min.js:4
 msgid "Upsell"
 msgstr "追加销售"
 
-#: static/js/impala/stats/csv_keys.js:71
+#: static/js/impala/stats/csv_keys.js:71 static/js/zamboni/stats-all.js:15352 static/js/zamboni/stats-min.js:4
 msgid "Meet the Developer"
 msgstr "结识开发者"
 
-#: static/js/impala/stats/csv_keys.js:72
+#: static/js/impala/stats/csv_keys.js:72 static/js/zamboni/stats-all.js:15353 static/js/zamboni/stats-min.js:4
 msgid "User Profile"
 msgstr "用户个人资料"
 
-#: static/js/impala/stats/csv_keys.js:73
+#: static/js/impala/stats/csv_keys.js:73 static/js/zamboni/stats-all.js:15354 static/js/zamboni/stats-min.js:4
 msgid "Version History"
 msgstr "版本历史"
 
-#: static/js/impala/stats/csv_keys.js:75
+#: static/js/impala/stats/csv_keys.js:75 static/js/zamboni/stats-all.js:15356 static/js/zamboni/stats-min.js:4
 msgid "Sharing"
 msgstr "分享"
 
-#: static/js/impala/stats/csv_keys.js:76
+#: static/js/impala/stats/csv_keys.js:76 static/js/zamboni/stats-all.js:15357 static/js/zamboni/stats-min.js:4
 msgid "Category Pages"
 msgstr "分类页面"
 
-#: static/js/impala/stats/csv_keys.js:77
+#: static/js/impala/stats/csv_keys.js:77 static/js/zamboni/stats-all.js:15358 static/js/zamboni/stats-min.js:4
 msgid "Collections"
 msgstr "收藏集"
 
-#: static/js/impala/stats/csv_keys.js:78 static/js/impala/stats/csv_keys.js:79
+#: static/js/impala/stats/csv_keys.js:78 static/js/impala/stats/csv_keys.js:79 static/js/zamboni/stats-all.js:15359 static/js/zamboni/stats-all.js:15360 static/js/zamboni/stats-min.js:4
 msgid "Category Landing Featured Carousel"
 msgstr "分类首页精选轮播"
 
-#: static/js/impala/stats/csv_keys.js:80 static/js/impala/stats/csv_keys.js:81
+#: static/js/impala/stats/csv_keys.js:80 static/js/impala/stats/csv_keys.js:81 static/js/zamboni/stats-all.js:15361 static/js/zamboni/stats-all.js:15362 static/js/zamboni/stats-min.js:4
 msgid "Category Landing Top Rated"
 msgstr "分类首页评分最高展示"
 
-#: static/js/impala/stats/csv_keys.js:82 static/js/impala/stats/csv_keys.js:83
+#: static/js/impala/stats/csv_keys.js:82 static/js/impala/stats/csv_keys.js:83 static/js/zamboni/stats-all.js:15363 static/js/zamboni/stats-all.js:15364 static/js/zamboni/stats-min.js:5
 msgid "Category Landing Most Popular"
 msgstr "分类首页最热门展示"
 
-#: static/js/impala/stats/csv_keys.js:84 static/js/impala/stats/csv_keys.js:85
+#: static/js/impala/stats/csv_keys.js:84 static/js/impala/stats/csv_keys.js:85 static/js/zamboni/stats-all.js:15365 static/js/zamboni/stats-all.js:15366 static/js/zamboni/stats-min.js:5
 msgid "Category Landing Recently Added"
 msgstr "分类首页最新添加展示"
 
-#: static/js/impala/stats/csv_keys.js:86 static/js/impala/stats/csv_keys.js:87
+#: static/js/impala/stats/csv_keys.js:86 static/js/impala/stats/csv_keys.js:87 static/js/zamboni/stats-all.js:15367 static/js/zamboni/stats-all.js:15368 static/js/zamboni/stats-min.js:5
 msgid "Browse Listing Featured Sort"
 msgstr "按精选顺序浏览"
 
-#: static/js/impala/stats/csv_keys.js:88 static/js/impala/stats/csv_keys.js:89
+#: static/js/impala/stats/csv_keys.js:88 static/js/impala/stats/csv_keys.js:89 static/js/zamboni/stats-all.js:15369 static/js/zamboni/stats-all.js:15370 static/js/zamboni/stats-min.js:5
 msgid "Browse Listing Users Sort"
 msgstr "按用户量的顺序浏览"
 
-#: static/js/impala/stats/csv_keys.js:90 static/js/impala/stats/csv_keys.js:91
+#: static/js/impala/stats/csv_keys.js:90 static/js/impala/stats/csv_keys.js:91 static/js/zamboni/stats-all.js:15371 static/js/zamboni/stats-all.js:15372 static/js/zamboni/stats-min.js:5
 msgid "Browse Listing Rating Sort"
 msgstr "按评分顺序浏览"
 
-#: static/js/impala/stats/csv_keys.js:92 static/js/impala/stats/csv_keys.js:93
+#: static/js/impala/stats/csv_keys.js:92 static/js/impala/stats/csv_keys.js:93 static/js/zamboni/stats-all.js:15373 static/js/zamboni/stats-all.js:15374 static/js/zamboni/stats-min.js:5
 msgid "Browse Listing Created Sort"
 msgstr "按最新添加排序的浏览列表"
 
-#: static/js/impala/stats/csv_keys.js:94 static/js/impala/stats/csv_keys.js:95
+#: static/js/impala/stats/csv_keys.js:94 static/js/impala/stats/csv_keys.js:95 static/js/zamboni/stats-all.js:15375 static/js/zamboni/stats-all.js:15376 static/js/zamboni/stats-min.js:5
 msgid "Browse Listing Name Sort"
 msgstr "按名称排序的浏览列表"
 
-#: static/js/impala/stats/csv_keys.js:96 static/js/impala/stats/csv_keys.js:97
+#: static/js/impala/stats/csv_keys.js:96 static/js/impala/stats/csv_keys.js:97 static/js/zamboni/stats-all.js:15377 static/js/zamboni/stats-all.js:15378 static/js/zamboni/stats-min.js:5
 msgid "Browse Listing Popular Sort"
 msgstr "按热门程度浏览"
 
-#: static/js/impala/stats/csv_keys.js:98 static/js/impala/stats/csv_keys.js:99
+#: static/js/impala/stats/csv_keys.js:98 static/js/impala/stats/csv_keys.js:99 static/js/zamboni/stats-all.js:15379 static/js/zamboni/stats-all.js:15380 static/js/zamboni/stats-min.js:5
 msgid "Browse Listing Updated Sort"
 msgstr "按更新顺序浏览"
 
-#: static/js/impala/stats/csv_keys.js:100 static/js/impala/stats/csv_keys.js:101
+#: static/js/impala/stats/csv_keys.js:100 static/js/impala/stats/csv_keys.js:101 static/js/zamboni/stats-all.js:15381 static/js/zamboni/stats-all.js:15382 static/js/zamboni/stats-min.js:5
 msgid "Browse Listing Up and Coming Sort"
 msgstr "按新秀榜排序的浏览列表"
 
-#: static/js/impala/stats/csv_keys.js:105
+#: static/js/impala/stats/csv_keys.js:105 static/js/zamboni/stats-all.js:15386 static/js/zamboni/stats-min.js:5
 msgid "Total Amount Contributed"
 msgstr "捐款总额"
 
-#: static/js/impala/stats/csv_keys.js:106
+#: static/js/impala/stats/csv_keys.js:106 static/js/zamboni/stats-all.js:15387 static/js/zamboni/stats-min.js:5
 msgid "Average Contribution"
 msgstr "平均捐款金额"
 
-#: static/js/impala/stats/csv_keys.js:115
+#: static/js/impala/stats/csv_keys.js:115 static/js/zamboni/stats-all.js:15396 static/js/zamboni/stats-min.js:5
 msgid "Usage"
 msgstr "使用"
 
-#: static/js/impala/stats/csv_keys.js:118
+#: static/js/impala/stats/csv_keys.js:118 static/js/zamboni/stats-all.js:15399 static/js/zamboni/stats-min.js:5
 msgid "Firefox"
 msgstr "Firefox"
 
-#: static/js/impala/stats/csv_keys.js:119
+#: static/js/impala/stats/csv_keys.js:119 static/js/zamboni/stats-all.js:15400 static/js/zamboni/stats-min.js:5
 msgid "Mozilla"
 msgstr "Mozilla"
 
-#: static/js/impala/stats/csv_keys.js:120
+#: static/js/impala/stats/csv_keys.js:120 static/js/zamboni/stats-all.js:15401 static/js/zamboni/stats-min.js:5
 msgid "Thunderbird"
 msgstr "Thunderbird"
 
-#: static/js/impala/stats/csv_keys.js:121
+#: static/js/impala/stats/csv_keys.js:121 static/js/zamboni/stats-all.js:15402 static/js/zamboni/stats-min.js:5
 msgid "Sunbird"
 msgstr "Sunbird"
 
-#: static/js/impala/stats/csv_keys.js:122
+#: static/js/impala/stats/csv_keys.js:122 static/js/zamboni/stats-all.js:15403 static/js/zamboni/stats-min.js:5
 msgid "SeaMonkey"
 msgstr "SeaMonkey"
 
-#: static/js/impala/stats/csv_keys.js:123
+#: static/js/impala/stats/csv_keys.js:123 static/js/zamboni/stats-all.js:15404 static/js/zamboni/stats-min.js:5
 msgid "Fennec"
 msgstr "Fennec"
 
-#: static/js/impala/stats/csv_keys.js:124
+#: static/js/impala/stats/csv_keys.js:124 static/js/zamboni/stats-all.js:15405 static/js/zamboni/stats-min.js:5
 msgid "Android"
 msgstr "Android"
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:129
+#: static/js/impala/stats/csv_keys.js:129 static/js/zamboni/stats-all.js:15410 static/js/zamboni/stats-min.js:5
 msgid "Downloads and Daily Users, last {0} days"
 msgstr "最近 {0} 天的下载量和每日用户量"
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:131
+#: static/js/impala/stats/csv_keys.js:131 static/js/zamboni/stats-all.js:15412 static/js/zamboni/stats-min.js:5
 msgid "Downloads and Daily Users from {0} to {1}"
 msgstr "从 {0} 至 {1} 的下载量和每日用户量"
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:135
+#: static/js/impala/stats/csv_keys.js:135 static/js/zamboni/stats-all.js:15416 static/js/zamboni/stats-min.js:5
 msgid "Installs and Daily Users, last {0} days"
 msgstr "最近 {0} 天的下载量和每日用户量"
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:137
+#: static/js/impala/stats/csv_keys.js:137 static/js/zamboni/stats-all.js:15418 static/js/zamboni/stats-min.js:5
 msgid "Installs and Daily Users from {0} to {1}"
 msgstr "从 {0} 至 {1} 的下载量和每日用户量"
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:141
+#: static/js/impala/stats/csv_keys.js:141 static/js/zamboni/stats-all.js:15422 static/js/zamboni/stats-min.js:5
 msgid "Downloads, last {0} days"
 msgstr "最近 {0} 天的下载量"
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:143
+#: static/js/impala/stats/csv_keys.js:143 static/js/zamboni/stats-all.js:15424 static/js/zamboni/stats-min.js:5
 msgid "Downloads from {0} to {1}"
 msgstr "从 {0} 至 {1} 的下载量"
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:147
+#: static/js/impala/stats/csv_keys.js:147 static/js/zamboni/stats-all.js:15428 static/js/zamboni/stats-min.js:5
 msgid "Daily Users, last {0} days"
 msgstr "最近 {0} 天的每日用户量"
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:149
+#: static/js/impala/stats/csv_keys.js:149 static/js/zamboni/stats-all.js:15430 static/js/zamboni/stats-min.js:5
 msgid "Daily Users from {0} to {1}"
 msgstr "从 {0} 至 {1} 的每日用户量"
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:153
+#: static/js/impala/stats/csv_keys.js:153 static/js/zamboni/stats-all.js:15434 static/js/zamboni/stats-min.js:5
 msgid "Applications, last {0} days"
 msgstr "最近 {0} 天的应用程序"
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:155
+#: static/js/impala/stats/csv_keys.js:155 static/js/zamboni/stats-all.js:15436 static/js/zamboni/stats-min.js:5
 msgid "Applications from {0} to {1}"
 msgstr "从 {0} 至 {1} 的应用程序"
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:159
+#: static/js/impala/stats/csv_keys.js:159 static/js/zamboni/stats-all.js:15440 static/js/zamboni/stats-min.js:5
 msgid "Platforms, last {0} days"
 msgstr "过去 {0} 天的平台"
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:161
+#: static/js/impala/stats/csv_keys.js:161 static/js/zamboni/stats-all.js:15442 static/js/zamboni/stats-min.js:5
 msgid "Platforms from {0} to {1}"
 msgstr "{0} 至 {1} 的平台"
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:165
+#: static/js/impala/stats/csv_keys.js:165 static/js/zamboni/stats-all.js:15446 static/js/zamboni/stats-min.js:5
 msgid "Languages, last {0} days"
 msgstr "过去 {0} 天的语言"
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:167
+#: static/js/impala/stats/csv_keys.js:167 static/js/zamboni/stats-all.js:15448 static/js/zamboni/stats-min.js:5
 msgid "Languages from {0} to {1}"
 msgstr "{0} 至 {1} 的语言"
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:171
+#: static/js/impala/stats/csv_keys.js:171 static/js/zamboni/stats-all.js:15452 static/js/zamboni/stats-min.js:5
 msgid "Add-on Versions, last {0} days"
 msgstr "过去 {0} 天的附加组件版本"
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:173
+#: static/js/impala/stats/csv_keys.js:173 static/js/zamboni/stats-all.js:15454 static/js/zamboni/stats-min.js:5
 msgid "Add-on Versions from {0} to {1}"
 msgstr "{0} 至 {1} 的附加组件版本"
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:177
+#: static/js/impala/stats/csv_keys.js:177 static/js/zamboni/stats-all.js:15458 static/js/zamboni/stats-min.js:5
 msgid "Add-on Status, last {0} days"
 msgstr "最近 {0} 天的附加组件状态"
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:179
+#: static/js/impala/stats/csv_keys.js:179 static/js/zamboni/stats-all.js:15460 static/js/zamboni/stats-min.js:5
 msgid "Add-on Status from {0} to {1}"
 msgstr "{0} 至 {1} 的附加组件状态"
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:183
+#: static/js/impala/stats/csv_keys.js:183 static/js/zamboni/stats-all.js:15464 static/js/zamboni/stats-min.js:5
 msgid "Download Sources, last {0} days"
 msgstr "过去 {0} 天的下载来源"
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:185
+#: static/js/impala/stats/csv_keys.js:185 static/js/zamboni/stats-all.js:15466 static/js/zamboni/stats-min.js:5
 msgid "Download Sources from {0} to {1}"
 msgstr "{0} 至 {1} 的下载来源"
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:189
+#: static/js/impala/stats/csv_keys.js:189 static/js/zamboni/stats-all.js:15470 static/js/zamboni/stats-min.js:5
 msgid "Contributions, last {0} days"
 msgstr "最近 {0} 天的捐款"
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:191
+#: static/js/impala/stats/csv_keys.js:191 static/js/zamboni/stats-all.js:15472 static/js/zamboni/stats-min.js:5
 msgid "Contributions from {0} to {1}"
 msgstr "从 {0} 至 {1} 的捐款"
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:195
+#: static/js/impala/stats/csv_keys.js:195 static/js/zamboni/stats-all.js:15476 static/js/zamboni/stats-min.js:5
 msgid "Site Metrics, last {0} days"
 msgstr "最近 {0} 天的网站指标"
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:197
+#: static/js/impala/stats/csv_keys.js:197 static/js/zamboni/stats-all.js:15478 static/js/zamboni/stats-min.js:5
 msgid "Site Metrics from {0} to {1}"
 msgstr "{0} 至 {1} 的站点度量"
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:201
+#: static/js/impala/stats/csv_keys.js:201 static/js/zamboni/stats-all.js:15482 static/js/zamboni/stats-min.js:5
 msgid "Add-ons in Use, last {0} days"
 msgstr "过去 {0} 天的附加组件使用量"
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:203
+#: static/js/impala/stats/csv_keys.js:203 static/js/zamboni/stats-all.js:15484 static/js/zamboni/stats-min.js:5
 msgid "Add-ons in Use from {0} to {1}"
 msgstr "正在使用的附加组件（从 {0} 到 {1}）"
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:207
+#: static/js/impala/stats/csv_keys.js:207 static/js/zamboni/stats-all.js:15488 static/js/zamboni/stats-min.js:5
 msgid "Add-ons Downloaded, last {0} days"
 msgstr "过去 {0} 天的附加组件下载量"
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:209
+#: static/js/impala/stats/csv_keys.js:209 static/js/zamboni/stats-all.js:15490 static/js/zamboni/stats-min.js:5
 msgid "Add-ons Downloaded from {0} to {1}"
 msgstr "{0} 至 {1} 的附加组件下载量"
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:213
+#: static/js/impala/stats/csv_keys.js:213 static/js/zamboni/stats-all.js:15494 static/js/zamboni/stats-min.js:5
 msgid "Add-ons Created, last {0} days"
 msgstr "过去 {0} 天的附加组件创建量"
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:215
+#: static/js/impala/stats/csv_keys.js:215 static/js/zamboni/stats-all.js:15496 static/js/zamboni/stats-min.js:5
 msgid "Add-ons Created from {0} to {1}"
 msgstr "{0} 至 {1} 的附加组件创建量"
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:219
+#: static/js/impala/stats/csv_keys.js:219 static/js/zamboni/stats-all.js:15500 static/js/zamboni/stats-min.js:5
 msgid "Add-ons Updated, last {0} days"
 msgstr "过去 {0} 天的附加组件更新量"
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:221
+#: static/js/impala/stats/csv_keys.js:221 static/js/zamboni/stats-all.js:15502 static/js/zamboni/stats-min.js:5
 msgid "Add-ons Updated from {0} to {1}"
 msgstr "{0} 至 {1} 的附加组件更新量"
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:225
+#: static/js/impala/stats/csv_keys.js:225 static/js/zamboni/stats-all.js:15506 static/js/zamboni/stats-min.js:5
 msgid "Reviews Written, last {0} days"
 msgstr "过去 {0} 天的评价撰写量"
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:227
+#: static/js/impala/stats/csv_keys.js:227 static/js/zamboni/stats-all.js:15508 static/js/zamboni/stats-min.js:5
 msgid "Reviews Written from {0} to {1}"
 msgstr "{0} 至 {1} 的评价撰写量"
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:231
+#: static/js/impala/stats/csv_keys.js:231 static/js/zamboni/stats-all.js:15512 static/js/zamboni/stats-min.js:5
 msgid "User Signups, last {0} days"
 msgstr "过去 {0} 天的用户注册量"
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:233
+#: static/js/impala/stats/csv_keys.js:233 static/js/zamboni/stats-all.js:15514 static/js/zamboni/stats-min.js:5
 msgid "User Signups from {0} to {1}"
 msgstr "{0} 至 {1} 的用户注册量"
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:237
+#: static/js/impala/stats/csv_keys.js:237 static/js/zamboni/stats-all.js:15518 static/js/zamboni/stats-min.js:5
 msgid "Collections Created, last {0} days"
 msgstr "最近 {0} 天的收藏集创建"
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:239
+#: static/js/impala/stats/csv_keys.js:239 static/js/zamboni/stats-all.js:15520 static/js/zamboni/stats-min.js:5
 msgid "Collections Created from {0} to {1}"
 msgstr "{0} 至 {1} 的收藏集创建量"
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:243
+#: static/js/impala/stats/csv_keys.js:243 static/js/zamboni/stats-all.js:15524 static/js/zamboni/stats-min.js:5
 msgid "Subscribers, last {0} days"
 msgstr "最近 {0} 天的订阅者量"
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:245
+#: static/js/impala/stats/csv_keys.js:245 static/js/zamboni/stats-all.js:15526 static/js/zamboni/stats-min.js:5
 msgid "Subscribers from {0} to {1}"
 msgstr "{0} 至 {1} 的订阅者量"
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:249
+#: static/js/impala/stats/csv_keys.js:249 static/js/zamboni/stats-all.js:15530 static/js/zamboni/stats-min.js:5
 msgid "Ratings, last {0} days"
 msgstr "最近 {0} 天的评分"
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:251
+#: static/js/impala/stats/csv_keys.js:251 static/js/zamboni/stats-all.js:15532 static/js/zamboni/stats-min.js:5
 msgid "Ratings from {0} to {1}"
 msgstr "从 {0} 至 {1} 的评分"
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:255
+#: static/js/impala/stats/csv_keys.js:255 static/js/zamboni/stats-all.js:15536 static/js/zamboni/stats-min.js:5
 msgid "Sales, last {0} days"
 msgstr "过去 {0} 天的销量"
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:257
+#: static/js/impala/stats/csv_keys.js:257 static/js/zamboni/stats-all.js:15538 static/js/zamboni/stats-min.js:5
 msgid "Sales from {0} to {1}"
 msgstr "{0} 至 {1} 的销量"
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:261
+#: static/js/impala/stats/csv_keys.js:261 static/js/zamboni/stats-all.js:15542 static/js/zamboni/stats-min.js:5
 msgid "Installs, last {0} days"
 msgstr "过去 {0} 天的安装量"
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:263
+#: static/js/impala/stats/csv_keys.js:263 static/js/zamboni/stats-all.js:15544 static/js/zamboni/stats-min.js:5
 msgid "Installs from {0} to {1}"
 msgstr "{0} 至 {1} 的安装量"
 
 #. L10n: {0} and {1} are integers.
-#: static/js/impala/stats/csv_keys.js:269
+#: static/js/impala/stats/csv_keys.js:269 static/js/zamboni/stats-all.js:15550 static/js/zamboni/stats-min.js:5
 msgid "<b>{0}</b> in last {1} days"
 msgstr "过去 {1} 天中有 <b>{0}</b>"
 
 #. L10n: {0} is an integer and {1} and {2} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:271 static/js/impala/stats/csv_keys.js:277
+#: static/js/impala/stats/csv_keys.js:271 static/js/impala/stats/csv_keys.js:277 static/js/zamboni/stats-all.js:15552 static/js/zamboni/stats-all.js:15558 static/js/zamboni/stats-min.js:5
 msgid "<b>{0}</b> from {1} to {2}"
 msgstr "{1} 至 {2} 有 <b>{0}</b>"
 
 #. L10n: {0} and {1} are integers.
-#: static/js/impala/stats/csv_keys.js:275
+#: static/js/impala/stats/csv_keys.js:275 static/js/zamboni/stats-all.js:15556 static/js/zamboni/stats-min.js:5
 msgid "<b>{0}</b> average in last {1} days"
 msgstr "过去 {1} 天中平均 <b>{0}</b>"
 
-#: static/js/impala/stats/overview.js:19
+#: static/js/impala/stats/overview.js:19 static/js/zamboni/stats-all.js:16469 static/js/zamboni/stats-min.js:5
 msgid "No data available."
 msgstr "没有可用数据。"
 
-#: static/js/impala/stats/table.js:74
+#: static/js/impala/stats/table.js:74 static/js/zamboni/stats-all.js:17209 static/js/zamboni/stats-min.js:5
 msgid "Date"
 msgstr "日期"
 
-#: static/js/impala/stats/topchart.js:96
+#: static/js/impala/stats/topchart.js:96 static/js/zamboni/stats-all.js:16600 static/js/zamboni/stats-min.js:5
 msgid "Other"
 msgstr "其他"
 
-#: static/js/zamboni/admin_validation.js:24 static/js/zamboni/devhub.js:1229 static/js/zamboni/editors.js:295
+#: static/js/zamboni/admin-all.js:180 static/js/zamboni/admin-min.js:1 static/js/zamboni/admin_validation.js:24 static/js/zamboni/devhub-all.js:2408 static/js/zamboni/devhub-min.js:2
+#: static/js/zamboni/devhub.js:1229 static/js/zamboni/editors-all.js:15576 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:295
 msgid "Select an application first"
 msgstr "首先选择一个应用程序"
 
-#: static/js/zamboni/admin_validation.js:51
+#: static/js/zamboni/admin-all.js:207 static/js/zamboni/admin-min.js:1 static/js/zamboni/admin_validation.js:51
 msgid "Set {0} add-on to a max version of {1} and email the author."
 msgid_plural "Set {0} add-ons to a max version of {1} and email the authors."
 msgstr[0] "将 {0} 个附加组件的最大版本号设置为 {1} 并用电子邮件通知作者。"
+msgstr[1] ""
 
-#: static/js/zamboni/admin_validation.js:54
+#: static/js/zamboni/admin-all.js:210 static/js/zamboni/admin-min.js:1 static/js/zamboni/admin_validation.js:54
 msgid "Email author of {2} add-on which failed validation."
 msgid_plural "Email authors of {2} add-ons which failed validation."
 msgstr[0] "邮件通知 {2} 个未通过验证的附加组件作者。"
+msgstr[1] ""
 
-#. L10n: {0} is an app name like Firefox.
-#: static/js/zamboni/buttons.js:66
-msgid "Accept and Install"
-msgstr "同意并安装"
-
-#: static/js/zamboni/buttons.js:66
-msgid "Add to {0}"
-msgstr "添加到 {0}"
-
-#: static/js/zamboni/buttons.js:71
-msgid "Download Now"
-msgstr "立即下载"
-
-#: static/js/zamboni/buttons.js:112
-msgid "Add-on has not been updated to support default-to-compatible."
-msgstr "附加组件尚未更新以支持默认兼容。"
-
-#: static/js/zamboni/buttons.js:117
-msgid "You need to be using Firefox 10.0 or higher."
-msgstr "您需要使用 Firefox 10.0 或更高的版本。"
-
-#: static/js/zamboni/buttons.js:129
-msgid "Mozilla has marked this version as incompatible with your Firefox version."
-msgstr "Mozilla 已标记此版本为不兼容您的 Firefox 版本。"
-
-#. L10n: {0} is an platform like Windows or Linux.
-#: static/js/zamboni/buttons.js:210
-msgid "Install for {0} anyway"
-msgstr "继续安装 {0} 版本"
-
-#: static/js/zamboni/buttons.js:210
-msgid "Download for {0} anyway"
-msgstr "仍要下载 {0}"
-
-#: static/js/zamboni/buttons.js:267
-msgid "Not available for your platform"
-msgstr "不适用于您的操作系统"
-
-#. L10n: {0} is an app name, {1} is the app version.
-#: static/js/zamboni/buttons.js:278 static/js/zamboni/buttons.js:315
-msgid "Not available for {0} {1}"
-msgstr "不适用于 {0} {1}"
-
-#: static/js/zamboni/buttons.js:341
-msgid "Works with {app} {min} - {max}"
-msgstr "兼容于 {app} {min} - {max}"
-
-#: static/js/zamboni/buttons.js:343
-msgid "View other versions"
-msgstr "查看其他版本"
-
-#: static/js/zamboni/buttons.js:391
-msgid "Only with Firefox — Get Firefox Now!"
-msgstr "只能用于 Firefox — 获取 Firefox！"
-
-#: static/js/zamboni/buttons.js:507 static/js/zamboni/mobile/buttons.js:43
-msgid "Sorry, you need a Mozilla-based browser (such as Firefox) to install a search plugin."
-msgstr "抱歉，您需要一个基于 Mozilla 的浏览器（例如 Firefox）才能安装此搜索插件。"
-
-#: static/js/zamboni/collections.js:229
-msgid "Adding to Favorites&hellip;"
-msgstr "正在添加到收藏夹&hellip;"
-
-#: static/js/zamboni/collections.js:232
-msgid "Removing Favorite&hellip;"
-msgstr "正在从收藏夹中移除&hellip;"
-
-#: static/js/zamboni/collections.js:235
-msgid "Add to Favorites"
-msgstr "添加到收藏夹"
-
-#: static/js/zamboni/collections.js:238
-msgid "Remove from Favorites"
-msgstr "从收藏夹中移除"
-
-#: static/js/zamboni/collections.js:303
-msgid "Pending"
-msgstr "等待中"
-
-#: static/js/zamboni/collections.js:304
-msgid "Add a comment"
-msgstr "添加评论"
-
-#: static/js/zamboni/collections.js:304
-msgid "Comment"
-msgstr "评论"
-
-#: static/js/zamboni/collections.js:305
-msgid "Remove this add-on from the collection"
-msgstr "从收藏集中移除此附加组件"
-
-#: static/js/zamboni/collections.js:305 static/js/zamboni/collections.js:334
-msgid "Remove"
-msgstr "移除"
-
-#: static/js/zamboni/collections.js:334
-msgid "Remove this user as a contributor"
-msgstr "从贡献者中移除此用户"
-
-#: static/js/zamboni/collections.js:346
-msgid "An email address is required."
-msgstr "必须输入电子邮件地址。"
-
-#: static/js/zamboni/collections.js:364
-msgid "You cannot add yourself as a contributor."
-msgstr "您不能添加自己为贡献者。"
-
-#: static/js/zamboni/collections.js:366
-msgid "You have already added that user."
-msgstr "您已经添加了该用户。"
-
-#: static/js/zamboni/collections.js:573
-msgid "Add to favorites"
-msgstr "添加到收藏夹"
-
-#: static/js/zamboni/collections.js:577
-msgid "Remove from favorites"
-msgstr "从收藏夹中移除"
-
-#: static/js/zamboni/collections.js:604
-msgid "Stop following"
-msgstr "停止关注"
-
-#: static/js/zamboni/devhub.js:110
+#: static/js/zamboni/devhub-all.js:1289 static/js/zamboni/devhub-min.js:1 static/js/zamboni/devhub.js:110
 msgid "Your browser does not support the video tag"
 msgstr "您的浏览器不支持此视频标签"
 
-#: static/js/zamboni/devhub.js:371
+#: static/js/zamboni/devhub-all.js:1550 static/js/zamboni/devhub-min.js:1 static/js/zamboni/devhub.js:371
 msgid "Changes Saved"
 msgstr "更改已保存"
 
-#: static/js/zamboni/devhub.js:387
+#: static/js/zamboni/devhub-all.js:1566 static/js/zamboni/devhub-min.js:1 static/js/zamboni/devhub.js:387
 msgid "Enter a new author's email address"
 msgstr "输入新作者的电子邮件地址"
 
-#: static/js/zamboni/devhub.js:536
+#: static/js/zamboni/devhub-all.js:1715 static/js/zamboni/devhub-min.js:1 static/js/zamboni/devhub.js:536
 msgid "There was an error uploading your file."
 msgstr "上传您的文件时发生错误。"
 
-#: static/js/zamboni/devhub.js:681
+#: static/js/zamboni/devhub-all.js:1860 static/js/zamboni/devhub-min.js:1 static/js/zamboni/devhub.js:681
 msgid "{files} file"
 msgid_plural "{files} files"
 msgstr[0] "{files} 个文件"
+msgstr[1] ""
 
-#: static/js/zamboni/devhub.js:684
+#: static/js/zamboni/devhub-all.js:1863 static/js/zamboni/devhub-min.js:1 static/js/zamboni/devhub.js:684
 msgid "{reviews} user review"
 msgid_plural "{reviews} user reviews"
 msgstr[0] "{reviews} 条用户评价"
+msgstr[1] ""
 
-#: static/js/zamboni/devhub.js:796
+#: static/js/zamboni/devhub-all.js:1975 static/js/zamboni/devhub-min.js:2 static/js/zamboni/devhub.js:796
 msgid "Learn more"
 msgstr "详细了解"
 
-#: static/js/zamboni/devhub.js:800
+#: static/js/zamboni/devhub-all.js:1979 static/js/zamboni/devhub-min.js:2 static/js/zamboni/devhub.js:800
 msgid "Example"
 msgstr "示例"
 
-#: static/js/zamboni/devhub.js:1130
+#: static/js/zamboni/devhub-all.js:2309 static/js/zamboni/devhub-min.js:2 static/js/zamboni/devhub.js:1130
 msgid "Image changes being processed"
 msgstr "正在处理图像更改"
 
-#: static/js/zamboni/devhub.js:1280
+#: static/js/zamboni/devhub-all.js:2459 static/js/zamboni/devhub-min.js:2 static/js/zamboni/devhub.js:1280
 msgid "Must be a valid e-mail address."
 msgstr "必须是一个有效的电子邮件地址。"
+
+#: static/js/zamboni/devhub-all.js:2613 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:80
+msgid "All tests passed successfully."
+msgstr "成功通过全部测试。"
+
+#: static/js/zamboni/devhub-all.js:2616 static/js/zamboni/devhub-all.js:3011 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:83 static/js/zamboni/validator.js:478
+msgid "These tests were not run."
+msgstr "这些测试没有运行。"
+
+#: static/js/zamboni/devhub-all.js:2664 static/js/zamboni/devhub-all.js:2677 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:131 static/js/zamboni/validator.js:144
+msgid "Tests"
+msgstr "测试"
+
+#: static/js/zamboni/devhub-all.js:2779 static/js/zamboni/devhub-all.js:3108 static/js/zamboni/devhub-all.js:3127 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:246
+#: static/js/zamboni/validator.js:575 static/js/zamboni/validator.js:594
+msgid "Error"
+msgstr "错误"
+
+#: static/js/zamboni/devhub-all.js:2780 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:247
+msgid "Warning"
+msgstr "警告"
+
+#: static/js/zamboni/devhub-all.js:2794 static/js/zamboni/devhub-min.js:2 static/js/zamboni/files-all.js:5657 static/js/zamboni/files-min.js:3 static/js/zamboni/files.js:411
+#: static/js/zamboni/validator.js:261
+msgid "Ignore this message in future updates"
+msgstr "在未来的更新中忽略此消息"
+
+#: static/js/zamboni/devhub-all.js:2817 static/js/zamboni/devhub-min.js:2 static/js/zamboni/files-all.js:5663 static/js/zamboni/files-min.js:3 static/js/zamboni/files.js:417
+#: static/js/zamboni/validator.js:284
+msgid "Severity for automated signing:"
+msgstr "自动签名的严重程度："
+
+#: static/js/zamboni/devhub-all.js:2832 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:299
+msgid "Suggestions for passing automated signing:"
+msgstr "通过自动签名的建议："
+
+#: static/js/zamboni/devhub-all.js:2920 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:387
+msgid "Compatibility Tests"
+msgstr "兼容性测试"
+
+#: static/js/zamboni/devhub-all.js:2999 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:466
+msgid "Add-on failed validation."
+msgstr "附加组件验证失败。"
+
+#: static/js/zamboni/devhub-all.js:3001 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:468
+msgid "Add-on passed validation."
+msgstr "附加组件通过验证。"
+
+#: static/js/zamboni/devhub-all.js:3014 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:481
+msgid "{0} error"
+msgid_plural "{0} errors"
+msgstr[0] "{0} 个错误"
+msgstr[1] ""
+
+#: static/js/zamboni/devhub-all.js:3016 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:483
+msgid "{0} warning"
+msgid_plural "{0} warnings"
+msgstr[0] "{0} 个警告"
+msgstr[1] ""
+
+#: static/js/zamboni/devhub-all.js:3018 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:485
+msgid "{0} notice"
+msgid_plural "{0} notices"
+msgstr[0] "{0} 个提醒"
+msgstr[1] ""
+
+#: static/js/zamboni/devhub-all.js:3110 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:577
+msgid "Validation task could not complete or completed with errors"
+msgstr "验证任务无法完成或者已完成但有错误"
+
+#: static/js/zamboni/devhub-all.js:3128 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:595
+msgid "Internal server error"
+msgstr "内部服务器错误"
 
 #: static/js/zamboni/devhub_search.js:8
 msgid "No results found."
 msgstr "找不到结果。"
 
-#: static/js/zamboni/editors.js:121
+#: static/js/zamboni/editors-all.js:15402 static/js/zamboni/editors-min.js:4 static/js/zamboni/editors.js:121
 msgid "{name} was viewing this page first."
 msgstr "{name} 第一个查看了这个页面。"
 
-#: static/js/zamboni/editors.js:171
+#: static/js/zamboni/editors-all.js:15452 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:171
 msgid "Receipt checked by app."
 msgstr "交易收据已经应用核实。"
 
-#: static/js/zamboni/editors.js:173
+#: static/js/zamboni/editors-all.js:15454 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:173
 msgid "Receipt was not checked by app."
 msgstr "交易收据未经应用核实。"
 
-#: static/js/zamboni/editors.js:244
+#: static/js/zamboni/editors-all.js:15525 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:244
 msgid "{name} was viewing this add-on first."
 msgstr "{name} 第一个查看了这个附加组件。"
 
-#: static/js/zamboni/editors.js:255
+#: static/js/zamboni/editors-all.js:15536 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:255
 msgid "Loading&hellip;"
 msgstr "正在加载&hellip;"
 
-#: static/js/zamboni/editors.js:260
+#: static/js/zamboni/editors-all.js:15541 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:260
 msgid "Version Notes"
 msgstr "版本说明"
 
-#: static/js/zamboni/editors.js:265
+#: static/js/zamboni/editors-all.js:15546 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:265
 msgid "Notes for Reviewers"
 msgstr "给审核员的备注"
 
-#: static/js/zamboni/editors.js:270
+#: static/js/zamboni/editors-all.js:15551 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:270
 msgid "No version notes found"
 msgstr "没有找到版本说明"
 
-#: static/js/zamboni/editors.js:330
+#: static/js/zamboni/editors-all.js:15611 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:330
 msgid "Average Reviews"
 msgstr "平均评价"
 
-#: static/js/zamboni/editors.js:386
+#: static/js/zamboni/editors-all.js:15667 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:386
 msgid "Number of Reviews"
 msgstr "评价数量"
 
-#: static/js/zamboni/editors.js:445
+#: static/js/zamboni/editors-all.js:15726 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:445
 msgid "Error loading translation"
 msgstr "载入翻译出错"
 
-#: static/js/zamboni/files.js:411 static/js/zamboni/validator.js:261
-msgid "Ignore this message in future updates"
-msgstr "在未来的更新中忽略此消息"
-
-#: static/js/zamboni/files.js:417 static/js/zamboni/validator.js:284
-msgid "Severity for automated signing:"
-msgstr "自动签名的严重程度："
-
-#: static/js/zamboni/global.js:410
-msgid "Loading..."
-msgstr "正在加载..."
-
-#. L10n: {0} is the number of characters left.
-#: static/js/zamboni/global.js:474
-msgid "<b>{0}</b> character left."
-msgid_plural "<b>{0}</b> characters left."
-msgstr[0] "剩余 <b>{0}</b> 个字符。"
-
-#: static/js/zamboni/init.js:28
-msgid "This feature is temporarily disabled while we perform website maintenance. Please check back a little later."
-msgstr "我们正在进行网站维护，此功能暂时无法使用。请您稍后再试。"
-
-#: static/js/zamboni/l10n.js:45
-msgid "Remove this localization"
-msgstr "移除此本地化"
-
-#: static/js/zamboni/password-strength.js:20
-msgid "Password strength:"
-msgstr "密码强度："
-
-#: static/js/zamboni/password-strength.js:26
-msgid "At least {0} character left."
-msgid_plural "At least {0} characters left."
-msgstr[0] "至少还需要输入 {0} 个字符。"
-
-#: static/js/zamboni/themes_review.js:176
-msgid "Requested Info"
-msgstr "已请求信息"
-
-#: static/js/zamboni/themes_review.js:177
-msgid "Flagged"
-msgstr "已标记"
-
-#: static/js/zamboni/themes_review.js:178
-msgid "Duplicate"
-msgstr "重复"
-
-#: static/js/zamboni/themes_review.js:179
-msgid "Rejected"
-msgstr "已拒绝"
-
-#: static/js/zamboni/themes_review.js:180
-msgid "Approved"
-msgstr "已批准"
-
-#: static/js/zamboni/themes_review.js:424
-msgid "No results found"
-msgstr "未找到结果"
-
-#: static/js/zamboni/themes_review_templates.js:31
+#: static/js/zamboni/editors-all.js:15975 static/js/zamboni/editors-min.js:5 static/js/zamboni/themes_review_templates.js:31
 msgid "Theme"
 msgstr "主题"
 
-#: static/js/zamboni/themes_review_templates.js:33
+#: static/js/zamboni/editors-all.js:15977 static/js/zamboni/editors-min.js:5 static/js/zamboni/themes_review_templates.js:33
 msgid "Reviewer"
 msgstr "审核者"
 
-#: static/js/zamboni/themes_review_templates.js:35
+#: static/js/zamboni/editors-all.js:15979 static/js/zamboni/editors-min.js:5 static/js/zamboni/themes_review_templates.js:35
 msgid "Status"
 msgstr "状态"
 
-#: static/js/zamboni/validator.js:80
-msgid "All tests passed successfully."
-msgstr "成功通过全部测试。"
+#: static/js/zamboni/editors-all.js:16196 static/js/zamboni/editors-min.js:5 static/js/zamboni/themes_review.js:176
+msgid "Requested Info"
+msgstr "已请求信息"
 
-#: static/js/zamboni/validator.js:83 static/js/zamboni/validator.js:478
-msgid "These tests were not run."
-msgstr "这些测试没有运行。"
+#: static/js/zamboni/editors-all.js:16197 static/js/zamboni/editors-min.js:5 static/js/zamboni/themes_review.js:177
+msgid "Flagged"
+msgstr "已标记"
 
-#: static/js/zamboni/validator.js:131 static/js/zamboni/validator.js:144
-msgid "Tests"
-msgstr "测试"
+#: static/js/zamboni/editors-all.js:16198 static/js/zamboni/editors-min.js:5 static/js/zamboni/themes_review.js:178
+msgid "Duplicate"
+msgstr "重复"
 
-#: static/js/zamboni/validator.js:246 static/js/zamboni/validator.js:575 static/js/zamboni/validator.js:594
-msgid "Error"
-msgstr "错误"
+#: static/js/zamboni/editors-all.js:16199 static/js/zamboni/editors-min.js:5 static/js/zamboni/themes_review.js:179
+msgid "Rejected"
+msgstr "已拒绝"
 
-#: static/js/zamboni/validator.js:247
-msgid "Warning"
-msgstr "警告"
+#: static/js/zamboni/editors-all.js:16200 static/js/zamboni/editors-min.js:5 static/js/zamboni/themes_review.js:180
+msgid "Approved"
+msgstr "已批准"
 
-#: static/js/zamboni/validator.js:299
-msgid "Suggestions for passing automated signing:"
-msgstr "通过自动签名的建议："
+#: static/js/zamboni/editors-all.js:16444 static/js/zamboni/editors-min.js:5 static/js/zamboni/themes_review.js:424
+msgid "No results found"
+msgstr "未找到结果"
 
-#: static/js/zamboni/validator.js:387
-msgid "Compatibility Tests"
-msgstr "兼容性测试"
-
-#: static/js/zamboni/validator.js:466
-msgid "Add-on failed validation."
-msgstr "附加组件验证失败。"
-
-#: static/js/zamboni/validator.js:468
-msgid "Add-on passed validation."
-msgstr "附加组件通过验证。"
-
-#: static/js/zamboni/validator.js:481
-msgid "{0} error"
-msgid_plural "{0} errors"
-msgstr[0] "{0} 个错误"
-
-#: static/js/zamboni/validator.js:483
-msgid "{0} warning"
-msgid_plural "{0} warnings"
-msgstr[0] "{0} 个警告"
-
-#: static/js/zamboni/validator.js:485
-msgid "{0} notice"
-msgid_plural "{0} notices"
-msgstr[0] "{0} 个提醒"
-
-#: static/js/zamboni/validator.js:577
-msgid "Validation task could not complete or completed with errors"
-msgstr "验证任务无法完成或者已完成但有错误"
-
-#: static/js/zamboni/validator.js:595
-msgid "Internal server error"
-msgstr "内部服务器错误"
-
-#: static/js/zamboni/mobile/buttons.js:52
+#: static/js/zamboni/mobile-all.js:15186 static/js/zamboni/mobile/buttons.js:52
 msgid "Not Updated for {0} {1}"
 msgstr "未为 {0} {1} 更新"
 
-#: static/js/zamboni/mobile/buttons.js:53
+#: static/js/zamboni/mobile-all.js:15187 static/js/zamboni/mobile/buttons.js:53
 msgid "Requires Newer Version of {0}"
 msgstr "需要较新版本的 {0}"
 
-#: static/js/zamboni/mobile/buttons.js:54
+#: static/js/zamboni/mobile-all.js:15188 static/js/zamboni/mobile/buttons.js:54
 msgid "Unreviewed"
 msgstr "尚未审核"
 
-#: static/js/zamboni/mobile/buttons.js:55
+#: static/js/zamboni/mobile-all.js:15189 static/js/zamboni/mobile/buttons.js:55
 msgid "Experimental <span>(Learn More)</span>"
 msgstr "实验性<span>（详细了解）</span>"
 
-#: static/js/zamboni/mobile/buttons.js:56 static/js/zamboni/mobile/buttons.js:57
+#: static/js/zamboni/mobile-all.js:15190 static/js/zamboni/mobile-all.js:15191 static/js/zamboni/mobile/buttons.js:56 static/js/zamboni/mobile/buttons.js:57
 msgid "Not Available for {0}"
 msgstr "无法用于 {0}"
 
-#: static/js/zamboni/mobile/buttons.js:58
+#: static/js/zamboni/mobile-all.js:15192 static/js/zamboni/mobile/buttons.js:58
 msgid "Experimental"
 msgstr "实验性"
 
-#: static/js/zamboni/mobile/buttons.js:59
+#: static/js/zamboni/mobile-all.js:15193 static/js/zamboni/mobile/buttons.js:59
 msgid "Themes Require Newer Version of {0}"
 msgstr "主题需要 {0} 以上版本"
 
-#: static/js/zamboni/mobile/buttons.js:60
+#: static/js/zamboni/mobile-all.js:15194 static/js/zamboni/mobile/buttons.js:60
 msgid "Themes Require {0}"
 msgstr "主题需要 {0}"
 
-#: static/js/zamboni/mobile/buttons.js:105
+#: static/js/zamboni/mobile-all.js:15239 static/js/zamboni/mobile/buttons.js:105
 msgid "Installing..."
 msgstr "正在安装..."
 
-#: static/js/zamboni/mobile/buttons.js:125
+#: static/js/zamboni/mobile-all.js:15259 static/js/zamboni/mobile/buttons.js:125
 msgid "This add-on has been preliminarily reviewed by Mozilla."
 msgstr "此附加组件已通过 Mozilla 的初步审核。"
 
-#: static/js/zamboni/mobile/buttons.js:250
+#: static/js/zamboni/mobile-all.js:15384 static/js/zamboni/mobile/buttons.js:250
 msgid "Keep it"
 msgstr "保留它"
 
-#: static/js/zamboni/mobile/general.js:344
+#: static/js/zamboni/mobile-all.js:16049 static/js/zamboni/mobile-min.js:6 static/js/zamboni/mobile/general.js:344
 msgid "You're trying it on!"
 msgstr "正在尝试！"
 
-#: static/js/zamboni/mobile/general.js:356
+#: static/js/zamboni/mobile-all.js:16061 static/js/zamboni/mobile-min.js:6 static/js/zamboni/mobile/general.js:356
 msgid "Added to Firefox"
 msgstr "添加到 Firefox"
-

--- a/locale/zh_TW/LC_MESSAGES/django.po
+++ b/locale/zh_TW/LC_MESSAGES/django.po
@@ -3,69 +3,70 @@ msgid ""
 msgstr ""
 "Project-Id-Version: addons-trunk // addons.mozilla.org\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2016-02-24 21:23+0000\n"
+"POT-Creation-Date: 2016-04-18 15:47+0000\n"
 "PO-Revision-Date: 2016-03-05 07:25+0000\n"
 "Last-Translator: Pin-guang Chen <petercpg@mail.moztw.org>\n"
 "Language-Team: Traditional Chinese (Taiwan) <LL@li.org>\n"
+"Language: \n"
 "MIME-Version: 1.0\n"
-"Content-Type: text/plain; charset=utf-8\n"
+"Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Generated-By: Babel 2.2.0\n"
 
-#: src/olympia/accounts/views.py:52
+#: src/olympia/accounts/views.py:54
 msgid "Your log in attempt could not be parsed. Please try again."
 msgstr "無法處理您的登入請求，請再試一次。"
 
-#: src/olympia/accounts/views.py:54
+#: src/olympia/accounts/views.py:56
 msgid "Your Firefox Account could not be found. Please try again."
 msgstr "找不到您的 Firefox 帳號，請再試一次。"
 
-#: src/olympia/accounts/views.py:55
+#: src/olympia/accounts/views.py:57
 msgid "You could not be logged in. Please try again."
 msgstr "無法登入，請再試一次。"
 
-#: src/olympia/accounts/views.py:57
+#: src/olympia/accounts/views.py:59
 msgid "Your account has already been migrated to Firefox Accounts."
 msgstr "您的帳號已整合至 Firefox 帳號。"
 
-#: src/olympia/accounts/views.py:59
+#: src/olympia/accounts/views.py:61
 msgid "Your Firefox Account already exists on this site."
 msgstr "您的 Firefox 帳號已存在於此網站。"
 
-#: src/olympia/accounts/views.py:108
+#: src/olympia/accounts/views.py:110
 msgid "Great job!"
 msgstr "好樣的！"
 
-#: src/olympia/accounts/views.py:109
+#: src/olympia/accounts/views.py:111
 msgid "You can now log in to Add-ons with your Firefox Account."
 msgstr "您現在可以使用 Firefox 帳號登入附加元件站了。"
 
-#: src/olympia/accounts/views.py:121
+#: src/olympia/accounts/views.py:123
 msgid "Need help?"
 msgstr "需要幫助嗎？"
 
-#: src/olympia/addons/buttons.py:180
+#: src/olympia/addons/buttons.py:177
 msgid "Download Now"
 msgstr "立即下載"
 
-#: src/olympia/addons/buttons.py:182
+#: src/olympia/addons/buttons.py:179
 msgid "Download"
 msgstr "下載"
 
 #. L10n: please keep &nbsp; in the string so &rarr; does not wrap.
-#: src/olympia/addons/buttons.py:186
+#: src/olympia/addons/buttons.py:183
 msgid "Continue to Download&nbsp;&rarr;"
 msgstr "繼續下載&nbsp;&rarr;"
 
-#: src/olympia/addons/buttons.py:202 src/olympia/addons/helpers.py:35 src/olympia/addons/views.py:319 src/olympia/addons/templates/addons/impala/details.html:114
+#: src/olympia/addons/buttons.py:199 src/olympia/addons/helpers.py:35 src/olympia/addons/views.py:333 src/olympia/addons/templates/addons/impala/details.html:111
 #: src/olympia/addons/templates/addons/impala/listing/items.html:17 src/olympia/addons/templates/addons/mobile/home.html:40 src/olympia/amo/templates/amo/side_nav.html:6
-#: src/olympia/amo/templates/amo/side_nav.html:10 src/olympia/amo/templates/amo/site_nav.html:2 src/olympia/amo/templates/amo/site_nav.html:55 src/olympia/bandwagon/views.py:95
-#: src/olympia/browse/views.py:54 src/olympia/browse/views.py:68 src/olympia/browse/views.py:235 src/olympia/browse/templates/browse/impala/category_landing.html:22
+#: src/olympia/amo/templates/amo/side_nav.html:10 src/olympia/amo/templates/amo/site_nav.html:2 src/olympia/amo/templates/amo/site_nav.html:53 src/olympia/bandwagon/views.py:95
+#: src/olympia/browse/views.py:54 src/olympia/browse/views.py:68 src/olympia/browse/views.py:202 src/olympia/browse/templates/browse/impala/category_landing.html:22
 #: src/olympia/browse/templates/browse/personas/mobile/category_landing.html:26
 msgid "Featured"
 msgstr "精選"
 
-#: src/olympia/addons/buttons.py:221
+#: src/olympia/addons/buttons.py:218
 msgid "Add to {0}"
 msgstr "新增至 {0}"
 
@@ -87,17 +88,20 @@ msgstr "這個 slug 不能為「%s」。請嘗試另一個。"
 msgid "Invalid tag: {0}"
 msgid_plural "Invalid tags: {0}"
 msgstr[0] "無效的標籤：{0}"
+msgstr[1] ""
 
 #. L10n: {0} is a single tag or a comma-separated list of tags.
 #: src/olympia/addons/forms.py:103
 msgid "\"{0}\" is a reserved tag and cannot be used."
 msgid_plural "\"{0}\" are reserved tags and cannot be used."
 msgstr[0] "\"{0}\" 為保留字不能使用。"
+msgstr[1] ""
 
 #: src/olympia/addons/forms.py:111
 msgid "You have {0} too many tags."
 msgid_plural "You have {0} too many tags."
 msgstr[0] "標籤多出 {0} 個了。"
+msgstr[1] ""
 
 #: src/olympia/addons/forms.py:117
 #, python-format
@@ -108,39 +112,41 @@ msgstr "移除無效的字元之後所有的標籤都必須少於或等於 %s �
 msgid "All tags must be at least {0} character."
 msgid_plural "All tags must be at least {0} characters."
 msgstr[0] "所有的標籤至少為 {0} 字元。"
+msgstr[1] ""
 
-#: src/olympia/addons/forms.py:234
+#: src/olympia/addons/forms.py:238
 msgid "Categories cannot be changed while your add-on is featured for this application."
 msgstr "您的附加元件目前為此應用程式的精選物件，無法更改類別。"
 
 #. L10n: {0} is the number of categories.
-#: src/olympia/addons/forms.py:238
+#: src/olympia/addons/forms.py:242
 msgid "You can have only {0} category."
 msgid_plural "You can have only {0} categories."
 msgstr[0] "您僅可選擇 {0} 個分類。"
+msgstr[1] ""
 
-#: src/olympia/addons/forms.py:246
+#: src/olympia/addons/forms.py:250
 msgid "The miscellaneous category cannot be combined with additional categories."
 msgstr "這個雜項類別不能與其他的類別結合。"
 
-#: src/olympia/addons/forms.py:369
+#: src/olympia/addons/forms.py:374
 #, python-format
 msgid "Before changing your default locale you must have a name, summary, and description in that locale. You are missing %s."
 msgstr "在您更動您的預設語系前，您必須為那個語系填入名稱、概要與敘述。您目前沒有填入 %s。"
 
-#: src/olympia/addons/forms.py:484 src/olympia/addons/forms.py:575
+#: src/olympia/addons/forms.py:455 src/olympia/addons/forms.py:546
 msgid "A license must be selected."
 msgstr "您必須選擇一項授權條款。"
 
-#: src/olympia/addons/forms.py:556
+#: src/olympia/addons/forms.py:527
 msgid "Give Your Theme a Name."
 msgstr "給您的佈景主題一個名稱。"
 
-#: src/olympia/addons/forms.py:562 src/olympia/devhub/templates/devhub/personas/submit.html:53
+#: src/olympia/addons/forms.py:533 src/olympia/devhub/templates/devhub/personas/submit.html:53
 msgid "Describe your Theme."
 msgstr "敘述您的佈景主題。"
 
-#: src/olympia/addons/forms.py:704
+#: src/olympia/addons/forms.py:675
 msgid "Enter a new author's email address"
 msgstr "輸入一個新的作者電子郵件地址"
 
@@ -148,39 +154,39 @@ msgstr "輸入一個新的作者電子郵件地址"
 msgid "Not Reviewed"
 msgstr "尚未審查"
 
-#: src/olympia/addons/models.py:301
+#: src/olympia/addons/models.py:298
 msgid "Users have the option of contributing more or less than this amount."
 msgstr "使用者可以選擇比這個金額更多或較少的捐助。"
 
-#: src/olympia/addons/models.py:309
-msgid "Users will always be asked in the Add-ons Manager (Firefox 4 and above)"
-msgstr "在附加元件管理員中詢問使用者(包含 Firefox 4 或更新的版本)"
+#: src/olympia/addons/models.py:306
+msgid "Users will always be asked in the Add-ons Manager (Firefox 4 and above). Only applies to desktop."
+msgstr ""
 
 # Column name in a table.
-#: src/olympia/addons/models.py:1804 src/olympia/addons/templates/addons/details_box.html:55 src/olympia/devhub/templates/devhub/index.html:92
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:102
+#: src/olympia/addons/models.py:1802 src/olympia/addons/templates/addons/details_box.html:55 src/olympia/devhub/templates/devhub/index.html:92
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:89
 msgid "Listed"
 msgstr "顯示"
 
-#: src/olympia/addons/views.py:320 src/olympia/browse/templates/browse/personas/mobile/category_landing.html:27
+#: src/olympia/addons/views.py:334 src/olympia/browse/templates/browse/personas/mobile/category_landing.html:27
 msgid "Popular"
 msgstr "熱門"
 
-#: src/olympia/addons/views.py:321 src/olympia/browse/views.py:238 src/olympia/browse/views.py:280 src/olympia/browse/views.py:482
+#: src/olympia/addons/views.py:335 src/olympia/browse/views.py:205 src/olympia/browse/views.py:247 src/olympia/browse/views.py:449
 msgid "Recently Added"
 msgstr "最近新增"
 
-#: src/olympia/addons/views.py:322 src/olympia/bandwagon/views.py:99 src/olympia/browse/views.py:60 src/olympia/browse/views.py:71 src/olympia/search/forms.py:16 src/olympia/search/forms.py:91
+#: src/olympia/addons/views.py:336 src/olympia/bandwagon/views.py:99 src/olympia/browse/views.py:60 src/olympia/browse/views.py:71 src/olympia/search/forms.py:16 src/olympia/search/forms.py:91
 msgid "Recently Updated"
 msgstr "最近更新"
 
 # %1 is an add-on name.
 #. l10n: {0} is the addon name
-#: src/olympia/addons/views.py:520
+#: src/olympia/addons/views.py:534
 msgid "Contribution for {0}"
 msgstr "贊助 {0}"
 
-#: src/olympia/addons/views.py:613
+#: src/olympia/addons/views.py:627
 msgid "Abuse reported."
 msgstr "已回報濫用。"
 
@@ -249,9 +255,9 @@ msgstr "捐款"
 #: src/olympia/devhub/templates/devhub/addons/ajax_compat_update.html:36 src/olympia/devhub/templates/devhub/addons/profile.html:44 src/olympia/devhub/templates/devhub/addons/edit/admin.html:101
 #: src/olympia/devhub/templates/devhub/addons/edit/basic.html:152 src/olympia/devhub/templates/devhub/addons/edit/details.html:85 src/olympia/devhub/templates/devhub/addons/edit/support.html:67
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:166 src/olympia/devhub/templates/devhub/addons/forms_shared/media.html:149
-#: src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:44 src/olympia/devhub/templates/devhub/versions/add_file_modal.html:78 src/olympia/devhub/templates/devhub/versions/edit.html:139
-#: src/olympia/devhub/templates/devhub/versions/list.html:242 src/olympia/devhub/templates/devhub/versions/list.html:276 src/olympia/devhub/templates/devhub/versions/list.html:317
-#: src/olympia/devhub/templates/devhub/versions/list.html:351 src/olympia/reviews/templates/reviews/edit_review.html:16 src/olympia/translations/templates/translations/trans-menu.html:50
+#: src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:43 src/olympia/devhub/templates/devhub/versions/add_file_modal.html:58 src/olympia/devhub/templates/devhub/versions/edit.html:139
+#: src/olympia/devhub/templates/devhub/versions/list.html:239 src/olympia/devhub/templates/devhub/versions/list.html:281 src/olympia/devhub/templates/devhub/versions/list.html:315
+#: src/olympia/devhub/templates/devhub/versions/list.html:349 src/olympia/reviews/templates/reviews/edit_review.html:16 src/olympia/translations/templates/translations/trans-menu.html:50
 #: src/olympia/translations/templates/translations/trans-menu.html:62
 msgid "or"
 msgstr "或"
@@ -321,8 +327,7 @@ msgstr "捐款金額必須為數字。"
 msgid "A one-time suggested contribution of {0}"
 msgstr "建議單次捐款{0}"
 
-#. {0} is a currency symbol (e.g., $),                    {1} is an amount
-#. input
+#. {0} is a currency symbol (e.g., $),                    {1} is an amount input
 #. field
 #: src/olympia/addons/templates/addons/contributions_lightbox.html:64
 msgid "A one-time contribution of {0} {1}"
@@ -363,7 +368,7 @@ msgid "Add-on Information for {0}"
 msgstr "{0} 的附加元件資訊"
 
 #: src/olympia/addons/templates/addons/details_box.html:30 src/olympia/addons/templates/addons/persona_detail_table.html:3 src/olympia/addons/templates/addons/mobile/details.html:63
-#: src/olympia/addons/templates/addons/mobile/persona_detail_table.html:7 src/olympia/browse/views.py:459 src/olympia/devhub/views.py:75
+#: src/olympia/addons/templates/addons/mobile/persona_detail_table.html:7 src/olympia/browse/views.py:426 src/olympia/devhub/views.py:73
 msgid "Updated"
 msgstr "更新日期"
 
@@ -382,11 +387,11 @@ msgstr "相容於"
 msgid "Visibility"
 msgstr "公開情況"
 
-#: src/olympia/addons/templates/addons/details_box.html:57 src/olympia/devhub/templates/devhub/index.html:94 src/olympia/devhub/templates/devhub/includes/addon_details.html:104
+#: src/olympia/addons/templates/addons/details_box.html:57 src/olympia/devhub/templates/devhub/index.html:94 src/olympia/devhub/templates/devhub/includes/addon_details.html:91
 msgid "Hidden"
 msgstr "隱藏"
 
-#: src/olympia/addons/templates/addons/details_box.html:59 src/olympia/devhub/templates/devhub/index.html:96 src/olympia/devhub/templates/devhub/includes/addon_details.html:106
+#: src/olympia/addons/templates/addons/details_box.html:59 src/olympia/devhub/templates/devhub/index.html:96 src/olympia/devhub/templates/devhub/includes/addon_details.html:93
 msgid "Unlisted"
 msgstr "未上架"
 
@@ -394,13 +399,13 @@ msgstr "未上架"
 msgid "Required Add-ons"
 msgstr "必要的附加元件"
 
-#: src/olympia/addons/templates/addons/details_box.html:81 src/olympia/addons/templates/addons/persona_detail_table.html:15 src/olympia/browse/views.py:462 src/olympia/devhub/views.py:78
-#: src/olympia/devhub/views.py:85 src/olympia/discovery/templates/discovery/addons/detail.html:57 src/olympia/reviews/forms.py:62 src/olympia/reviews/templates/reviews/add.html:57
+#: src/olympia/addons/templates/addons/details_box.html:81 src/olympia/addons/templates/addons/persona_detail_table.html:15 src/olympia/browse/views.py:429 src/olympia/devhub/views.py:76
+#: src/olympia/devhub/views.py:83 src/olympia/discovery/templates/discovery/addons/detail.html:57 src/olympia/reviews/forms.py:62 src/olympia/reviews/templates/reviews/add.html:57
 #: src/olympia/reviews/templates/reviews/mobile/review_list.html:18
 msgid "Rating"
 msgstr "評分"
 
-#: src/olympia/addons/templates/addons/details_box.html:85 src/olympia/browse/views.py:461 src/olympia/devhub/views.py:77 src/olympia/devhub/views.py:84
+#: src/olympia/addons/templates/addons/details_box.html:85 src/olympia/browse/views.py:428 src/olympia/devhub/views.py:75 src/olympia/devhub/views.py:82
 #: src/olympia/stats/templates/stats/addon_report_menu.html:8 src/olympia/stats/templates/stats/collection_report_menu.html:18
 msgid "Downloads"
 msgstr "下載次數"
@@ -420,7 +425,7 @@ msgstr "濫用回報"
 
 #. The Privacy Policy for this add-on.
 #: src/olympia/addons/templates/addons/details_box.html:121 src/olympia/addons/templates/addons/privacy.html:19 src/olympia/addons/templates/addons/privacy.html:23
-#: src/olympia/addons/templates/addons/impala/button.html:43 src/olympia/addons/templates/addons/impala/details.html:307 src/olympia/devhub/templates/devhub/includes/policy_form.html:20
+#: src/olympia/addons/templates/addons/impala/button.html:43 src/olympia/addons/templates/addons/impala/details.html:312 src/olympia/devhub/templates/devhub/includes/policy_form.html:23
 #: src/olympia/templates/mobile/base_addons.html:87
 msgid "Privacy Policy"
 msgstr "隱私權保護政策"
@@ -445,7 +450,7 @@ msgstr "圖片集"
 msgid "Developer Comments"
 msgstr "開發者意見"
 
-#: src/olympia/addons/templates/addons/details_box.html:199 src/olympia/addons/templates/addons/impala/details.html:259
+#: src/olympia/addons/templates/addons/details_box.html:199 src/olympia/addons/templates/addons/impala/details.html:264
 msgid "Development Channel"
 msgstr "開發頻道"
 
@@ -465,13 +470,13 @@ msgid ""
 "developer. To stop receiving development updates, reinstall the default version from the link above."
 msgstr "<strong>注意:</strong> Mozilla 不會審查此附加元件的開發版本。在您安裝開發版本後，您會持續由該開發者收到開發版本的更新版。如果您不想要再收到此更新，請進入上方的連結重新安裝預設的正式版本。"
 
-#: src/olympia/addons/templates/addons/details_box.html:220 src/olympia/addons/templates/addons/impala/details.html:278
+#: src/olympia/addons/templates/addons/details_box.html:220 src/olympia/addons/templates/addons/impala/details.html:283
 msgid "Version {0}:"
 msgstr "版本 {0}:"
 
 #: src/olympia/addons/templates/addons/details_box.html:234
 msgid "Nothing to see here!  The developer did not include any details."
-msgstr "沒別的東西了！開發者並沒有包含任何詳細資訊。"
+msgstr ""
 
 #: src/olympia/addons/templates/addons/details_box.html:251 src/olympia/devhub/templates/devhub/versions/edit.html:73 src/olympia/editors/templates/editors/review.html:98
 msgid "Version Notes"
@@ -484,7 +489,7 @@ msgid "End-User License Agreement for {0}"
 msgstr "{0} 的使用者授權合約"
 
 #: src/olympia/addons/templates/addons/eula.html:17 src/olympia/addons/templates/addons/eula.html:21 src/olympia/addons/templates/addons/impala/button.html:48
-#: src/olympia/addons/templates/addons/impala/details.html:316 src/olympia/devhub/templates/devhub/includes/policy_form.html:3 src/olympia/discovery/templates/discovery/addons/eula.html:11
+#: src/olympia/addons/templates/addons/impala/details.html:321 src/olympia/devhub/templates/devhub/includes/policy_form.html:3 src/olympia/discovery/templates/discovery/addons/eula.html:11
 msgid "End-User License Agreement"
 msgstr "使用者授權合約"
 
@@ -503,7 +508,7 @@ msgstr "回到 {0}..."
 msgid "Add-ons for {0}"
 msgstr "{0} 附加元件"
 
-#: src/olympia/addons/templates/addons/home.html:10 src/olympia/addons/templates/addons/home.html:51 src/olympia/browse/templates/browse/impala/base_listing.html:11
+#: src/olympia/addons/templates/addons/home.html:10 src/olympia/addons/templates/addons/home.html:53 src/olympia/browse/templates/browse/impala/base_listing.html:11
 msgid "Featured Extensions"
 msgstr "精選擴充套件"
 
@@ -511,29 +516,29 @@ msgstr "精選擴充套件"
 msgid "Popular Extensions"
 msgstr "熱門擴充套件"
 
-#: src/olympia/addons/templates/addons/home.html:42 src/olympia/amo/templates/amo/side_nav.html:3 src/olympia/amo/templates/amo/side_nav.html:11 src/olympia/amo/templates/amo/site_nav.html:3
-#: src/olympia/amo/templates/amo/site_nav.html:25 src/olympia/browse/views.py:236 src/olympia/browse/views.py:281 src/olympia/browse/views.py:481
+#: src/olympia/addons/templates/addons/home.html:44 src/olympia/amo/templates/amo/side_nav.html:3 src/olympia/amo/templates/amo/side_nav.html:11 src/olympia/amo/templates/amo/site_nav.html:3
+#: src/olympia/amo/templates/amo/site_nav.html:25 src/olympia/browse/views.py:203 src/olympia/browse/views.py:248 src/olympia/browse/views.py:448
 msgid "Most Popular"
 msgstr "最熱門"
 
-#: src/olympia/addons/templates/addons/home.html:43
+#: src/olympia/addons/templates/addons/home.html:45
 msgid "All »"
 msgstr "全部 »"
 
-#: src/olympia/addons/templates/addons/home.html:52 src/olympia/addons/templates/addons/home.html:61 src/olympia/addons/templates/addons/home.html:70 src/olympia/addons/templates/addons/home.html:78
+#: src/olympia/addons/templates/addons/home.html:54 src/olympia/addons/templates/addons/home.html:63 src/olympia/addons/templates/addons/home.html:72 src/olympia/addons/templates/addons/home.html:80
 #: src/olympia/browse/templates/browse/impala/category_landing.html:36
 msgid "See all »"
 msgstr "檢視全部 »"
 
-#: src/olympia/addons/templates/addons/home.html:60
+#: src/olympia/addons/templates/addons/home.html:62
 msgid "Up &amp; Coming Extensions"
 msgstr "嶄露頭角的擴充套件"
 
-#: src/olympia/addons/templates/addons/home.html:69 src/olympia/browse/templates/browse/personas/category_landing.html:61 src/olympia/discovery/templates/discovery/pane.html:74
+#: src/olympia/addons/templates/addons/home.html:71 src/olympia/browse/templates/browse/personas/category_landing.html:61 src/olympia/discovery/templates/discovery/pane.html:74
 msgid "Featured Themes"
 msgstr "精選佈景主題"
 
-#: src/olympia/addons/templates/addons/home.html:77 src/olympia/bandwagon/templates/bandwagon/impala/collection_listing.html:5
+#: src/olympia/addons/templates/addons/home.html:79 src/olympia/bandwagon/templates/bandwagon/impala/collection_listing.html:5
 msgid "Featured Collections"
 msgstr "精選收藏集"
 
@@ -551,7 +556,7 @@ msgid "Updated {0}"
 msgstr "{0} 更新"
 
 #. {0} is a date.
-#: src/olympia/addons/templates/addons/macros.html:10 src/olympia/addons/templates/addons/macros.html:69 src/olympia/addons/templates/addons/persona_preview.html:21
+#: src/olympia/addons/templates/addons/macros.html:10 src/olympia/addons/templates/addons/macros.html:69 src/olympia/addons/templates/addons/persona_preview.html:22
 #: src/olympia/addons/templates/addons/listing/items_mobile.html:44 src/olympia/addons/templates/addons/listing/macros.html:39
 #: src/olympia/bandwagon/templates/bandwagon/collection_listing_items.html:37 src/olympia/bandwagon/templates/bandwagon/impala/collection_listing_items.html:37
 msgid "Added {0}"
@@ -562,25 +567,28 @@ msgstr "{0} 新增"
 msgid "%(num)s weekly download"
 msgid_plural "%(num)s weekly downloads"
 msgstr[0] "每週下載次數: %(num)s"
+msgstr[1] ""
 
 #: src/olympia/addons/templates/addons/macros.html:28
 #, python-format
 msgid "%(num)s user"
 msgid_plural "%(num)s users"
 msgstr[0] "%(num)s 個使用者"
+msgstr[1] ""
 
 #. {0} is the number of downloads.
-#: src/olympia/addons/templates/addons/macros.html:53 src/olympia/addons/templates/addons/impala/details.html:61
+#: src/olympia/addons/templates/addons/macros.html:53 src/olympia/addons/templates/addons/impala/details.html:59
 msgid "{0} weekly download"
 msgid_plural "{0} weekly downloads"
 msgstr[0] "每週下載 {0} 次"
+msgstr[1] ""
 
 #. {0} is the number of users.
-#: src/olympia/addons/templates/addons/macros.html:61 src/olympia/addons/templates/addons/impala/details.html:54 src/olympia/compat/templates/compat/index.html:71
-#: src/olympia/zadmin/templates/zadmin/compat.html:67
+#: src/olympia/addons/templates/addons/macros.html:61 src/olympia/addons/templates/addons/impala/details.html:52 src/olympia/zadmin/templates/zadmin/compat.html:67
 msgid "{0} user"
 msgid_plural "{0} users"
 msgstr[0] "{0} 位使用者"
+msgstr[1] ""
 
 #: src/olympia/addons/templates/addons/paypal_result.html:12
 msgid "Payment cancelled"
@@ -594,7 +602,7 @@ msgstr "已完成付款"
 msgid "Return to the addon."
 msgstr "回到這個附加元件。"
 
-#: src/olympia/addons/templates/addons/persona_detail.html:17 src/olympia/addons/templates/addons/impala/details.html:106 src/olympia/addons/templates/addons/mobile/details.html:23
+#: src/olympia/addons/templates/addons/persona_detail.html:17 src/olympia/addons/templates/addons/impala/details.html:103 src/olympia/addons/templates/addons/mobile/details.html:23
 #: src/olympia/addons/templates/addons/mobile/persona_detail.html:21 src/olympia/discovery/templates/discovery/addons/base.html:27 src/olympia/editors/templates/editors/review.html:31
 msgid "by"
 msgstr "作者:"
@@ -638,33 +646,35 @@ msgstr "每日使用者數"
 msgid "License"
 msgstr "授權"
 
-#: src/olympia/addons/templates/addons/persona_preview.html:12 src/olympia/constants/base.py:48
+#: src/olympia/addons/templates/addons/persona_preview.html:13 src/olympia/constants/base.py:48
 msgid "Awaiting Review"
 msgstr "等待審查"
 
-#: src/olympia/addons/templates/addons/persona_preview.html:14 src/olympia/amo/log.py:180 src/olympia/constants/base.py:42 src/olympia/editors/helpers.py:62
+#: src/olympia/addons/templates/addons/persona_preview.html:15 src/olympia/amo/log.py:180 src/olympia/constants/base.py:42 src/olympia/editors/helpers.py:62
 msgid "Rejected"
 msgstr "已被退回"
 
-#: src/olympia/addons/templates/addons/persona_preview.html:16 src/olympia/amo/log.py:159
+#: src/olympia/addons/templates/addons/persona_preview.html:17 src/olympia/amo/log.py:159
 msgid "Approved"
 msgstr "已審查通過"
 
 #. {0} is the number of users.
-#: src/olympia/addons/templates/addons/persona_preview.html:26 src/olympia/addons/templates/addons/listing/items_mobile.html:36 src/olympia/addons/templates/addons/listing/macros.html:31
+#: src/olympia/addons/templates/addons/persona_preview.html:27 src/olympia/addons/templates/addons/listing/items_mobile.html:36 src/olympia/addons/templates/addons/listing/macros.html:31
 msgid "<strong>{0}</strong> user"
 msgid_plural "<strong>{0}</strong> users"
 msgstr[0] "<strong>{0}</strong> 位使用者"
+msgstr[1] ""
 
-#: src/olympia/addons/templates/addons/persona_preview.html:40
+#: src/olympia/addons/templates/addons/persona_preview.html:41
 msgid "Hover to Preview"
 msgstr "移至上方預覽"
 
-#: src/olympia/addons/templates/addons/persona_preview.html:46 src/olympia/addons/templates/addons/persona_preview.html:48 src/olympia/reviews/templates/reviews/add.html:15
+#: src/olympia/addons/templates/addons/persona_preview.html:47 src/olympia/addons/templates/addons/persona_preview.html:49 src/olympia/addons/templates/addons/persona_preview.html:97
+#: src/olympia/reviews/templates/reviews/add.html:15
 msgid "Add"
 msgstr "新增"
 
-#: src/olympia/addons/templates/addons/persona_preview.html:57 src/olympia/bandwagon/templates/bandwagon/ajax_new.html:16 src/olympia/bandwagon/templates/bandwagon/edit.html:19
+#: src/olympia/addons/templates/addons/persona_preview.html:58 src/olympia/bandwagon/templates/bandwagon/ajax_new.html:16 src/olympia/bandwagon/templates/bandwagon/edit.html:19
 #: src/olympia/bandwagon/templates/bandwagon/includes/addedit.html:19 src/olympia/devhub/templates/devhub/addons/edit/admin.html:13 src/olympia/devhub/templates/devhub/addons/edit/basic.html:10
 #: src/olympia/devhub/templates/devhub/addons/edit/details.html:8 src/olympia/devhub/templates/devhub/addons/edit/media.html:6 src/olympia/devhub/templates/devhub/addons/edit/support.html:8
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:9 src/olympia/devhub/templates/devhub/addons/submit/describe.html:29 src/olympia/editors/templates/editors/review.html:257
@@ -673,21 +683,21 @@ msgstr "編輯"
 
 #. For datetime formatting, see the table on
 #. http://docs.python.org/library/datetime.html#strftime-and-strptime-behavior
-#: src/olympia/addons/templates/addons/persona_preview.html:66
+#: src/olympia/addons/templates/addons/persona_preview.html:67
 #, python-format
 msgid "%%Y-%%m-%%d"
 msgstr "%%Y-%%m-%%d"
 
-#: src/olympia/addons/templates/addons/persona_preview.html:67
+#: src/olympia/addons/templates/addons/persona_preview.html:68
 msgid "by {0} on {1}"
 msgstr "作者：{0} 日期：{1}"
 
-#: src/olympia/addons/templates/addons/persona_preview.html:75 src/olympia/reviews/helpers.py:17 src/olympia/reviews/templates/reviews/review_list.html:63
+#: src/olympia/addons/templates/addons/persona_preview.html:76 src/olympia/reviews/helpers.py:17 src/olympia/reviews/templates/reviews/review_list.html:63
 #: src/olympia/reviews/templates/reviews/reviews_link.html:21 src/olympia/reviews/templates/reviews/impala/reviews_link.html:16
 msgid "Not yet rated"
 msgstr "未經評分"
 
-#: src/olympia/addons/templates/addons/persona_preview.html:78
+#: src/olympia/addons/templates/addons/persona_preview.html:79
 msgid "<b>{0}</b> users"
 msgstr "<b>{0}</b> 位使用者"
 
@@ -700,8 +710,8 @@ msgid "Learn more about Firefox"
 msgstr "了解更多關於 Firefox 相關資訊"
 
 #: src/olympia/addons/templates/addons/popups.html:22
-msgid "or <b><a class=\"installer\" href=\"{url}\">download anyway</a></b>"
-msgstr "或 <b><a class=\"installer\" href=\"{url}\">繼續下載</a></b>"
+msgid "or <b><a class=\"button installer\" href=\"{url}\">download anyway</a></b>"
+msgstr ""
 
 #: src/olympia/addons/templates/addons/popups.html:26
 msgid ""
@@ -764,7 +774,7 @@ msgstr "此個性面板需要 %(app)s %(new_version)s。您現在所使用的是
 msgid ""
 "<strong>Caution:</strong> This add-on has not been reviewed by Mozilla and can't be installed on release versions of Firefox 43 and above.  Be careful when installing third-party software that "
 "might harm your computer."
-msgstr "<strong>注意:</strong> 此附加元件尚未由 Mozllla 審核，不能安裝到 Firefox 43 之後的正式發行版本。請小心安裝第三方軟體可能會影響您的電腦。"
+msgstr ""
 
 #: src/olympia/addons/templates/addons/popups.html:120
 msgid "<strong>Please note:</strong> This add-on is not compatible with your operating system."
@@ -799,11 +809,9 @@ msgid ""
 "  to your phone.  (You'll need a QR reader.  Search your phone's marketplace if\n"
 "  don't have one.)"
 msgstr ""
-"想在您的 Firefox 行動版上使用 {0} 嗎？掃描這個 QR 碼在手機上直接安裝。\n"
-"（需要 QR 碼掃描器，請先到您手機的軟體商城下載安裝。）"
 
 #: src/olympia/addons/templates/addons/report_abuse.html:6 src/olympia/addons/templates/addons/report_abuse_full.html:10 src/olympia/addons/templates/addons/impala/details-more.html:23
-#: src/olympia/addons/templates/addons/impala/details.html:328
+#: src/olympia/addons/templates/addons/impala/details.html:333
 msgid "Report Abuse"
 msgstr "濫用回報"
 
@@ -822,9 +830,9 @@ msgstr "回報"
 #: src/olympia/devhub/templates/devhub/addons/ajax_compat_update.html:36 src/olympia/devhub/templates/devhub/addons/profile.html:44 src/olympia/devhub/templates/devhub/addons/edit/admin.html:104
 #: src/olympia/devhub/templates/devhub/addons/edit/basic.html:155 src/olympia/devhub/templates/devhub/addons/edit/details.html:88 src/olympia/devhub/templates/devhub/addons/edit/support.html:70
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:169 src/olympia/devhub/templates/devhub/addons/forms_shared/media.html:152
-#: src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:44 src/olympia/devhub/templates/devhub/personas/edit.html:222 src/olympia/devhub/templates/devhub/versions/add_file_modal.html:79
-#: src/olympia/devhub/templates/devhub/versions/edit.html:140 src/olympia/devhub/templates/devhub/versions/list.html:208 src/olympia/devhub/templates/devhub/versions/list.html:242
-#: src/olympia/devhub/templates/devhub/versions/list.html:276 src/olympia/devhub/templates/devhub/versions/list.html:317 src/olympia/reviews/templates/reviews/edit_review.html:16
+#: src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:43 src/olympia/devhub/templates/devhub/personas/edit.html:222 src/olympia/devhub/templates/devhub/versions/add_file_modal.html:59
+#: src/olympia/devhub/templates/devhub/versions/edit.html:140 src/olympia/devhub/templates/devhub/versions/list.html:208 src/olympia/devhub/templates/devhub/versions/list.html:239
+#: src/olympia/devhub/templates/devhub/versions/list.html:281 src/olympia/devhub/templates/devhub/versions/list.html:315 src/olympia/reviews/templates/reviews/edit_review.html:16
 #: src/olympia/translations/templates/translations/trans-menu.html:50 src/olympia/translations/templates/translations/trans-menu.html:62 src/olympia/zadmin/templates/zadmin/validation.html:105
 msgid "Cancel"
 msgstr "取消"
@@ -869,7 +877,7 @@ msgstr "請見 <a href=\"%(support)s\">技術支援</a> 一節了解如何取得
 msgid "Review Guidelines"
 msgstr "評論撰寫指南"
 
-#: src/olympia/addons/templates/addons/review_list_box.html:5 src/olympia/addons/templates/addons/impala/details-more.html:27 src/olympia/editors/helpers.py:921
+#: src/olympia/addons/templates/addons/review_list_box.html:5 src/olympia/addons/templates/addons/impala/details-more.html:27 src/olympia/editors/helpers.py:1001
 #: src/olympia/reviews/templates/reviews/add.html:14 src/olympia/reviews/templates/reviews/reply.html:14 src/olympia/reviews/templates/reviews/review_list.html:19
 #: src/olympia/reviews/templates/reviews/mobile/review_list.html:26
 msgid "Reviews"
@@ -889,6 +897,7 @@ msgstr "顯示這篇評論的開發者回應"
 msgid "See all reviews of this add-on"
 msgid_plural "See all %(cnt)s reviews of this add-on"
 msgstr[0] "瀏覽此附加元件的所有 %(cnt)s 筆評論"
+msgstr[1] ""
 
 #: src/olympia/addons/templates/addons/tags_box.html:3 src/olympia/devhub/templates/devhub/addons/edit/basic.html:118
 msgid "Tags"
@@ -957,103 +966,106 @@ msgstr "這些收藏集的一部份"
 msgid "Other add-ons by %(author)s"
 msgid_plural "Other add-ons by these authors"
 msgstr[0] "這些作者的其他附加元件"
+msgstr[1] ""
 
-#: src/olympia/addons/templates/addons/impala/details.html:41
+#: src/olympia/addons/templates/addons/impala/details.html:39
 #, python-format
 msgid "<span itemprop=\"ratingCount\">%(num)s</span> user review"
 msgid_plural "<span itemprop=\"ratingCount\">%(num)s</span> user reviews"
 msgstr[0] "<span itemprop=\"ratingCount\">%(num)s</span> 個使用者意見"
+msgstr[1] ""
 
-#: src/olympia/addons/templates/addons/impala/details.html:69
+#: src/olympia/addons/templates/addons/impala/details.html:66
 msgid "View statistics"
 msgstr "檢視統計數據"
 
-#: src/olympia/addons/templates/addons/impala/details.html:84
+#: src/olympia/addons/templates/addons/impala/details.html:81
 msgid "Manage"
 msgstr "管理"
 
 #. {0} is an add-on name.
-#: src/olympia/addons/templates/addons/impala/details.html:96
+#: src/olympia/addons/templates/addons/impala/details.html:93
 msgid "Icon of {0}"
 msgstr "{0} 的圖示"
 
-#: src/olympia/addons/templates/addons/impala/details.html:103 src/olympia/addons/templates/addons/impala/listing/items.html:14
+#: src/olympia/addons/templates/addons/impala/details.html:100 src/olympia/addons/templates/addons/impala/listing/items.html:14
 msgid "No Restart"
 msgstr "不需要重新啟動"
 
-#: src/olympia/addons/templates/addons/impala/details.html:127
+#: src/olympia/addons/templates/addons/impala/details.html:124
 #, python-format
 msgid "Meet the Developer: <a href=\"%(url)s\">%(name)s</a>"
 msgid_plural "<a href=\"%(url)s\">Meet the Developers</a>"
 msgstr[0] "<a href=\"%(url)s\">認識開發者</a>"
+msgstr[1] ""
 
 # {0} is an add-on name.
-#: src/olympia/addons/templates/addons/impala/details.html:137
+#: src/olympia/addons/templates/addons/impala/details.html:134
 msgid "Learn why {0} was created and find out what's next for this add-on."
 msgstr "了解 {0} 的誕生由來，以及這個附加元件的未來發展。"
 
 #. {0} is an index.
-#: src/olympia/addons/templates/addons/impala/details.html:156
+#: src/olympia/addons/templates/addons/impala/details.html:161
 msgid "Add-on screenshot #{0}"
 msgstr "附加元件畫面擷圖 #{0}"
 
-#: src/olympia/addons/templates/addons/impala/details.html:182
+#: src/olympia/addons/templates/addons/impala/details.html:187
 msgid "Add-on home page"
 msgstr "附加元件首頁"
 
-#: src/olympia/addons/templates/addons/impala/details.html:185
+#: src/olympia/addons/templates/addons/impala/details.html:190
 msgid "Support site"
 msgstr "技術支援網站"
 
-#: src/olympia/addons/templates/addons/impala/details.html:189
+#: src/olympia/addons/templates/addons/impala/details.html:194
 msgid "Support E-mail"
 msgstr "技術支援用電子郵件信箱"
 
-#: src/olympia/addons/templates/addons/impala/details.html:194 src/olympia/devhub/models.py:378 src/olympia/devhub/templates/devhub/versions/list.html:12
+#: src/olympia/addons/templates/addons/impala/details.html:199 src/olympia/devhub/models.py:378 src/olympia/devhub/templates/devhub/versions/list.html:12
 #: src/olympia/versions/templates/versions/version.html:6 src/olympia/versions/templates/versions/mobile/version.html:6
 msgid "Version {0}"
 msgstr "版本 {0}"
 
-#: src/olympia/addons/templates/addons/impala/details.html:194
+#: src/olympia/addons/templates/addons/impala/details.html:199
 msgid "Info"
 msgstr "資訊"
 
-#: src/olympia/addons/templates/addons/impala/details.html:195 src/olympia/devhub/templates/devhub/includes/addon_details.html:129
+#: src/olympia/addons/templates/addons/impala/details.html:200 src/olympia/devhub/templates/devhub/includes/addon_details.html:116
 msgid "Last Updated:"
 msgstr "最近更新於:"
 
-#: src/olympia/addons/templates/addons/impala/details.html:200
+#: src/olympia/addons/templates/addons/impala/details.html:205
 #, python-format
 msgid "Released under <a target=\"_blank\" href=\"%(url)s\">%(name)s</a>"
 msgstr "使用 <a target=\"_blank\" href=\"%(url)s\">%(name)s</a> 授權發行"
 
-#: src/olympia/addons/templates/addons/impala/details.html:201 src/olympia/addons/templates/addons/impala/details.html:206 src/olympia/amo/helpers.py:398 src/olympia/devhub/forms.py:142
+#: src/olympia/addons/templates/addons/impala/details.html:206 src/olympia/addons/templates/addons/impala/details.html:211 src/olympia/amo/helpers.py:398 src/olympia/devhub/forms.py:142
 #: src/olympia/devhub/forms.py:173 src/olympia/versions/templates/versions/version.html:40 src/olympia/versions/templates/versions/version.html:45
 msgid "Custom License"
 msgstr "自訂授權"
 
-#: src/olympia/addons/templates/addons/impala/details.html:205
+#: src/olympia/addons/templates/addons/impala/details.html:210
 #, python-format
 msgid "Released under <a href=\"%(url)s\">%(name)s</a>"
 msgstr "以 <a href=\"%(url)s\">%(name)s</a> 釋出"
 
-#: src/olympia/addons/templates/addons/impala/details.html:217
+#: src/olympia/addons/templates/addons/impala/details.html:222
 msgid "About this Add-on"
 msgstr "關於此附加元件"
 
-#: src/olympia/addons/templates/addons/impala/details.html:233
+#: src/olympia/addons/templates/addons/impala/details.html:238
 msgid "Developer’s Comments"
 msgstr "開發者的回覆"
 
-#: src/olympia/addons/templates/addons/impala/details.html:243
+#: src/olympia/addons/templates/addons/impala/details.html:248
 msgid "Version Information"
 msgstr "版本資訊"
 
-#: src/olympia/addons/templates/addons/impala/details.html:250
+#: src/olympia/addons/templates/addons/impala/details.html:255
 msgid "See complete version history"
 msgstr "檢視完整的版本歷史"
 
-#: src/olympia/addons/templates/addons/impala/details.html:262
+#: src/olympia/addons/templates/addons/impala/details.html:267
 msgid ""
 "The Development Channel lets you test an experimental new version of this add-on before it's released to the general public. Once you install the development version, you will continue to get "
 "updates from this channel. To stop receiving development updates, reinstall the default version from the link above."
@@ -1061,17 +1073,17 @@ msgstr ""
 "在附件元件的實驗性新版本公開釋出之前，您可以透過開發頻道先進行測試。一旦您安裝了開發版本，附加元件將會從此開發頻道自動更新。如欲停止開發版本的自動更新，請移除附件元件後，從上面的連結重新安裝預設的版"
 "本。"
 
-#: src/olympia/addons/templates/addons/impala/details.html:272
+#: src/olympia/addons/templates/addons/impala/details.html:277
 msgid "<strong>Caution:</strong> Development versions of this add-on have not been reviewed by Mozilla."
 msgstr "<strong>注意:</strong> 此附加元件的開發版本尚未經 Mozilla 審查。"
 
-#: src/olympia/addons/templates/addons/impala/details.html:287
+#: src/olympia/addons/templates/addons/impala/details.html:292
 msgid "See complete development channel history"
 msgstr "檢視完整的開發頻道紀錄"
 
-#: src/olympia/addons/templates/addons/impala/details.html:306 src/olympia/addons/templates/addons/impala/details.html:315 src/olympia/addons/templates/addons/impala/details.html:327
+#: src/olympia/addons/templates/addons/impala/details.html:311 src/olympia/addons/templates/addons/impala/details.html:320 src/olympia/addons/templates/addons/impala/details.html:332
 #: src/olympia/addons/templates/addons/impala/review_add_box.html:4 src/olympia/stats/templates/stats/popup.html:2 src/olympia/stats/templates/stats/popup.html:8
-#: src/olympia/stats/templates/stats/stats.html:202 src/olympia/users/templates/users/profile.html:119
+#: src/olympia/stats/templates/stats/stats.html:204 src/olympia/users/templates/users/profile.html:119
 msgid "close"
 msgstr "關閉"
 
@@ -1104,6 +1116,7 @@ msgstr "{0} 的下一步"
 msgid "About the Developer"
 msgid_plural "About the Developers"
 msgstr[0] "關於開發者"
+msgstr[1] ""
 
 #: src/olympia/addons/templates/addons/impala/developers.html:96 src/olympia/users/templates/users/edit.html:130 src/olympia/users/templates/users/profile.html:26
 msgid "No Photo"
@@ -1129,15 +1142,11 @@ msgstr "{addon} 的原始碼授權"
 msgid "Source Code License"
 msgstr "原始碼授權"
 
-#: src/olympia/addons/templates/addons/impala/persona_grid.html:16 src/olympia/addons/templates/addons/impala/toplist.html:6
-msgid "{0} users"
-msgstr "{0} 位使用者"
-
 #: src/olympia/addons/templates/addons/impala/review_list_box.html:19 src/olympia/reviews/templates/reviews/review.html:40
 msgid "permalink"
 msgstr "永久網址"
 
-#: src/olympia/addons/templates/addons/impala/review_list_box.html:23 src/olympia/editors/templates/editors/queue.html:98 src/olympia/reviews/templates/reviews/review.html:44
+#: src/olympia/addons/templates/addons/impala/review_list_box.html:23 src/olympia/editors/templates/editors/queue.html:104 src/olympia/reviews/templates/reviews/review.html:44
 msgid "translate"
 msgstr "翻譯"
 
@@ -1146,6 +1155,7 @@ msgstr "翻譯"
 msgid "See all user reviews"
 msgid_plural "See all %(cnt)s user reviews"
 msgstr[0] "瀏覽所有 %(cnt)s 筆使用者評論"
+msgstr[1] ""
 
 #: src/olympia/addons/templates/addons/impala/review_list_box.html:47 src/olympia/reviews/templates/reviews/review_list.html:84
 msgid "This add-on has not yet been reviewed."
@@ -1154,6 +1164,10 @@ msgstr "這個附加元件還沒有任何人評論過。"
 #: src/olympia/addons/templates/addons/impala/review_list_box.html:50
 msgid "Be the first!"
 msgstr "成為第一個評論的人!"
+
+#: src/olympia/addons/templates/addons/impala/toplist.html:6
+msgid "{0} users"
+msgstr "{0} 位使用者"
 
 #: src/olympia/addons/templates/addons/impala/listing/sorter.html:14 src/olympia/devhub/templates/devhub/addons/listing/item_actions.html:49
 msgid "More"
@@ -1167,7 +1181,7 @@ msgstr "新增至收藏集"
 msgid "My Add-ons"
 msgstr "我的附加元件"
 
-#: src/olympia/addons/templates/addons/includes/dashboard_tabs.html:6 src/olympia/amo/context_processors.py:51
+#: src/olympia/addons/templates/addons/includes/dashboard_tabs.html:6 src/olympia/amo/context_processors.py:50
 msgid "My Themes"
 msgstr "我的佈景主題"
 
@@ -1208,6 +1222,7 @@ msgstr "未經評分"
 msgid "<strong>{0}</strong> weekly download"
 msgid_plural "<strong>{0}</strong> weekly downloads"
 msgstr[0] "<strong>{0}</strong> 次每週下載數"
+msgstr[1] ""
 
 #: src/olympia/addons/templates/addons/mobile/details.html:32
 msgid "Read More"
@@ -1221,7 +1236,7 @@ msgstr "使用者數"
 msgid "Weekly Downloads"
 msgstr "每週下載次數"
 
-#: src/olympia/addons/templates/addons/mobile/details.html:99 src/olympia/compat/templates/compat/reporter_detail.html:46 src/olympia/devhub/forms.py:787
+#: src/olympia/addons/templates/addons/mobile/details.html:99 src/olympia/compat/templates/compat/reporter_detail.html:46 src/olympia/devhub/forms.py:788
 #: src/olympia/devhub/templates/devhub/versions/list.html:163
 msgid "Version"
 msgstr "版本"
@@ -1306,7 +1321,7 @@ msgstr "附加元件是可以讓您個人化您 Firefox 的應用程式，並額
 #: src/olympia/browse/templates/browse/personas/category_landing.html:21 src/olympia/browse/templates/browse/personas/category_landing.html:23
 #: src/olympia/browse/templates/browse/personas/category_landing.html:38 src/olympia/browse/templates/browse/personas/grid.html:7 src/olympia/browse/templates/browse/personas/grid.html:11
 #: src/olympia/browse/templates/browse/personas/mobile/base.html:7 src/olympia/browse/templates/browse/personas/mobile/category_landing.html:19 src/olympia/constants/base.py:180
-#: src/olympia/devhub/templates/devhub/personas/submit.html:13 src/olympia/editors/helpers.py:105 src/olympia/editors/templates/editors/base.html:26
+#: src/olympia/devhub/templates/devhub/personas/submit.html:13 src/olympia/editors/helpers.py:107 src/olympia/editors/templates/editors/base.html:26
 #: src/olympia/editors/templates/editors/performance.html:73 src/olympia/search/templates/search/personas.html:39 src/olympia/templates/menu_links.html:9
 msgid "Themes"
 msgstr "佈景主題"
@@ -1327,7 +1342,7 @@ msgstr "更多附加元件"
 msgid "Highest Rated"
 msgstr "評分最高"
 
-#: src/olympia/addons/templates/addons/mobile/home.html:74 src/olympia/amo/templates/amo/side_nav.html:5 src/olympia/amo/templates/amo/site_nav.html:27 src/olympia/amo/templates/amo/site_nav.html:57
+#: src/olympia/addons/templates/addons/mobile/home.html:74 src/olympia/amo/templates/amo/side_nav.html:5 src/olympia/amo/templates/amo/site_nav.html:27 src/olympia/amo/templates/amo/site_nav.html:55
 #: src/olympia/bandwagon/views.py:97 src/olympia/browse/views.py:57 src/olympia/browse/views.py:67 src/olympia/browse/templates/browse/personas/mobile/category_landing.html:65
 #: src/olympia/search/forms.py:15 src/olympia/search/forms.py:87
 msgid "Newest"
@@ -1341,90 +1356,90 @@ msgstr "試穿看看!"
 msgid "Theme Info &raquo;"
 msgstr "佈景主題資訊 &raquo;"
 
-#: src/olympia/amo/context_processors.py:39 src/olympia/devhub/templates/devhub/nav.html:43
+#: src/olympia/amo/context_processors.py:37 src/olympia/devhub/templates/devhub/nav.html:43
 msgid "Tools"
 msgstr "工具"
 
-#: src/olympia/amo/context_processors.py:48 src/olympia/discovery/templates/discovery/pane_account.html:8 src/olympia/users/templates/users/includes/navigation.html:2
+#: src/olympia/amo/context_processors.py:47 src/olympia/discovery/templates/discovery/pane_account.html:8 src/olympia/users/templates/users/includes/navigation.html:2
 msgid "My Profile"
 msgstr "我的個人檔案"
 
-#: src/olympia/amo/context_processors.py:54 src/olympia/users/templates/users/edit.html:5 src/olympia/users/templates/users/includes/navigation.html:3
+#: src/olympia/amo/context_processors.py:53 src/olympia/users/templates/users/edit.html:5 src/olympia/users/templates/users/includes/navigation.html:3
 msgid "Account Settings"
 msgstr "帳號設定"
 
-#: src/olympia/amo/context_processors.py:57 src/olympia/discovery/templates/discovery/pane_account.html:11 src/olympia/users/templates/users/profile.html:83
+#: src/olympia/amo/context_processors.py:56 src/olympia/discovery/templates/discovery/pane_account.html:11 src/olympia/users/templates/users/profile.html:83
 #: src/olympia/users/templates/users/includes/navigation.html:4
 msgid "My Collections"
 msgstr "我的收藏集"
 
-#: src/olympia/amo/context_processors.py:62 src/olympia/discovery/templates/discovery/pane_account.html:10 src/olympia/users/templates/users/includes/navigation.html:7
+#: src/olympia/amo/context_processors.py:61 src/olympia/discovery/templates/discovery/pane_account.html:10 src/olympia/users/templates/users/includes/navigation.html:7
 msgid "My Favorites"
 msgstr "我的最愛"
 
-#: src/olympia/amo/context_processors.py:67 src/olympia/discovery/templates/discovery/pane_account.html:13 src/olympia/templates/impala/user_login.html:14
+#: src/olympia/amo/context_processors.py:66 src/olympia/discovery/templates/discovery/pane_account.html:13 src/olympia/templates/impala/user_login.html:14
 #: src/olympia/templates/mobile/header_auth.html:5
 msgid "Log out"
 msgstr "登出"
 
-#: src/olympia/amo/context_processors.py:72 src/olympia/devhub/templates/devhub/addons/dashboard.html:4
+#: src/olympia/amo/context_processors.py:71 src/olympia/devhub/templates/devhub/addons/dashboard.html:4
 msgid "Manage My Submissions"
 msgstr "管理我的提交"
 
-#: src/olympia/amo/context_processors.py:75 src/olympia/devhub/templates/devhub/nav.html:27 src/olympia/devhub/templates/devhub/addons/dashboard.html:25
+#: src/olympia/amo/context_processors.py:74 src/olympia/devhub/templates/devhub/nav.html:27 src/olympia/devhub/templates/devhub/addons/dashboard.html:25
 #: src/olympia/devhub/templates/devhub/addons/submit/base.html:4
 msgid "Submit a New Add-on"
 msgstr "上傳一個新的附加元件"
 
-#: src/olympia/amo/context_processors.py:77 src/olympia/browse/templates/browse/personas/base.html:50 src/olympia/devhub/templates/devhub/index.html:24
+#: src/olympia/amo/context_processors.py:76 src/olympia/browse/templates/browse/personas/base.html:50 src/olympia/devhub/templates/devhub/index.html:24
 #: src/olympia/devhub/templates/devhub/addons/dashboard.html:29
 msgid "Submit a New Theme"
 msgstr "提交一個新的佈景主題"
 
-#: src/olympia/amo/context_processors.py:79 src/olympia/amo/templates/amo/site_nav.html:87 src/olympia/devhub/helpers.py:36 src/olympia/devhub/helpers.py:68 src/olympia/devhub/helpers.py:102
+#: src/olympia/amo/context_processors.py:78 src/olympia/amo/templates/amo/site_nav.html:85 src/olympia/devhub/helpers.py:36 src/olympia/devhub/helpers.py:68 src/olympia/devhub/helpers.py:102
 #: src/olympia/templates/footer.html:6 src/olympia/templates/menu_links.html:14
 msgid "Developer Hub"
 msgstr "開發者交流中心"
 
-#: src/olympia/amo/context_processors.py:83 src/olympia/devhub/views.py:1792
+#: src/olympia/amo/context_processors.py:81 src/olympia/devhub/views.py:1796
 msgid "Manage API Keys"
 msgstr "管理 API 金鑰"
 
-#: src/olympia/amo/context_processors.py:88 src/olympia/editors/helpers.py:82 src/olympia/editors/helpers.py:102 src/olympia/editors/templates/editors/base.html:10
+#: src/olympia/amo/context_processors.py:86 src/olympia/editors/helpers.py:84 src/olympia/editors/helpers.py:104 src/olympia/editors/templates/editors/base.html:10
 msgid "Editor Tools"
 msgstr "審查者工具"
 
-#: src/olympia/amo/context_processors.py:92
+#: src/olympia/amo/context_processors.py:90
 msgid "Admin Tools"
 msgstr "管理員工具"
 
-#: src/olympia/amo/fields.py:15
+#: src/olympia/amo/fields.py:20
 msgid "Incorrect, please try again."
 msgstr "不正確，請再試一次。"
 
-#: src/olympia/amo/fields.py:16
+#: src/olympia/amo/fields.py:21
 msgid "Error verifying input, please try again."
 msgstr "驗證輸入內容時發生錯誤，請再試一次。"
 
-#: src/olympia/amo/fields.py:32
+#: src/olympia/amo/fields.py:37
 msgid "This must be a valid hex color code, such as #000000."
 msgstr "這必須是個正確的十六進位顏色代碼，像是 #000000。"
 
-#: src/olympia/amo/fields.py:58
+#: src/olympia/amo/fields.py:63
 msgid "Enter at least one value."
 msgstr "請至少輸入一個數值。"
 
-#: src/olympia/amo/helpers.py:162 src/olympia/amo/templates/amo/site_nav.html:61 src/olympia/bandwagon/templates/bandwagon/add.html:9
+#: src/olympia/amo/helpers.py:162 src/olympia/amo/templates/amo/site_nav.html:59 src/olympia/bandwagon/templates/bandwagon/add.html:9
 #: src/olympia/bandwagon/templates/bandwagon/collection_detail.html:15 src/olympia/bandwagon/templates/bandwagon/delete.html:9 src/olympia/bandwagon/templates/bandwagon/edit.html:15
 #: src/olympia/bandwagon/templates/bandwagon/user_listing.html:18 src/olympia/bandwagon/templates/bandwagon/user_listing.html:21
 #: src/olympia/bandwagon/templates/bandwagon/impala/collection_listing.html:12 src/olympia/bandwagon/templates/bandwagon/impala/collection_listing.html:20
 #: src/olympia/bandwagon/templates/bandwagon/impala/collection_listing.html:24 src/olympia/bandwagon/templates/bandwagon/impala/collection_sidebar.html:3
 #: src/olympia/bandwagon/templates/bandwagon/includes/collection_sidebar.html:2 src/olympia/bandwagon/templates/bandwagon/mobile/collection_listing.html:3
-#: src/olympia/stats/templates/stats/stats.html:77 src/olympia/templates/menu_links.html:12
+#: src/olympia/stats/templates/stats/stats.html:33 src/olympia/templates/menu_links.html:12
 msgid "Collections"
 msgstr "收藏集"
 
-#: src/olympia/amo/helpers.py:171 src/olympia/amo/templates/amo/site_nav.html:85 src/olympia/browse/templates/browse/language_tools.html:3
+#: src/olympia/amo/helpers.py:171 src/olympia/amo/templates/amo/site_nav.html:83 src/olympia/browse/templates/browse/language_tools.html:3
 msgid "Dictionaries & Language Packs"
 msgstr "字典及語言套件"
 
@@ -1579,8 +1594,8 @@ msgstr "已要求超級審核者進行審核"
 msgid "Comment on {addon} {version}."
 msgstr "在 {addon} {version} 上的意見。"
 
-#: src/olympia/amo/log.py:236 src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:19 src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:47
-#: src/olympia/editors/helpers.py:511 src/olympia/editors/templates/editors/themes/history_table.html:11
+#: src/olympia/amo/log.py:236 src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:17 src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:45
+#: src/olympia/editors/helpers.py:584 src/olympia/editors/templates/editors/themes/history_table.html:11
 msgid "Comment"
 msgstr "意見"
 
@@ -1734,7 +1749,7 @@ msgstr "審核者向上回報"
 
 #: src/olympia/amo/log.py:442
 msgid "Video removed from {addon} because of a problem with the video. "
-msgstr "已自 {addon} 移除影片，因為該影片有問題。"
+msgstr ""
 
 #: src/olympia/amo/log.py:444
 msgid "Video removed"
@@ -1885,7 +1900,7 @@ msgstr "糟糕"
 #: src/olympia/amo/templates/amo/500.html:6
 #, python-format
 msgid "<h1>Oops!  We had an error.</h1> <p>We'll get to fixing that soon.</p> <p> You can try refreshing the page, or head back to the <a href=\"%(home)s\">Add-ons homepage</a>. </p>"
-msgstr "<h1>喔喔！發生問題了。</h1><p>我們會很快修復。</p><p>您可以試試重新整理頁面，或回到 <a href=\"%(home)s\">附加元件站首頁</a>。</p>"
+msgstr ""
 
 #: src/olympia/amo/templates/amo/license_link.html:10
 msgid "Some rights reserved"
@@ -1907,7 +1922,7 @@ msgstr "上一頁"
 #: src/olympia/amo/templates/amo/mobile/paginator.html:14 src/olympia/amo/templates/amo/mobile/paginator.html:16 src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:51
 #: src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:65 src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:78
 #: src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:91 src/olympia/devhub/templates/devhub/addons/includes/validation_test_results.html:104
-#: src/olympia/discovery/templates/discovery/pane.html:45 src/olympia/discovery/templates/discovery/addons/detail.html:39 src/olympia/stats/templates/stats/stats.html:167
+#: src/olympia/discovery/templates/discovery/pane.html:45 src/olympia/discovery/templates/discovery/addons/detail.html:39 src/olympia/stats/templates/stats/stats.html:169
 msgid "Next"
 msgstr "下一頁"
 
@@ -1941,7 +1956,7 @@ msgstr ""
 "\"recaptcha_audio\">改用不同方式驗證</a>。</p>"
 
 #: src/olympia/amo/templates/amo/side_nav.html:4 src/olympia/amo/templates/amo/side_nav.html:12 src/olympia/amo/templates/amo/site_nav.html:4 src/olympia/amo/templates/amo/site_nav.html:26
-#: src/olympia/browse/views.py:56 src/olympia/browse/views.py:66 src/olympia/browse/views.py:237 src/olympia/browse/views.py:282 src/olympia/search/forms.py:86
+#: src/olympia/browse/views.py:56 src/olympia/browse/views.py:66 src/olympia/browse/views.py:204 src/olympia/browse/views.py:249 src/olympia/search/forms.py:86
 msgid "Top Rated"
 msgstr "評分最高"
 
@@ -1956,38 +1971,38 @@ msgstr "探索"
 msgid "Extensions"
 msgstr "擴充套件"
 
-#: src/olympia/amo/templates/amo/site_nav.html:45
+#: src/olympia/amo/templates/amo/site_nav.html:44
 msgid "Want more customization? Try <b>Complete Themes</b>"
 msgstr "想要有更多客制化程度？試試<b>完整佈景主題</b>"
 
-#: src/olympia/amo/templates/amo/site_nav.html:56 src/olympia/bandwagon/views.py:96
+#: src/olympia/amo/templates/amo/site_nav.html:54 src/olympia/bandwagon/views.py:96
 msgid "Most Followers"
 msgstr "最多訂閱者"
 
-#: src/olympia/amo/templates/amo/site_nav.html:68 src/olympia/bandwagon/templates/bandwagon/impala/collection_sidebar.html:16
+#: src/olympia/amo/templates/amo/site_nav.html:66 src/olympia/bandwagon/templates/bandwagon/impala/collection_sidebar.html:16
 #: src/olympia/bandwagon/templates/bandwagon/includes/collection_sidebar.html:18
 msgid "Collections I've Made"
 msgstr "我建立的收藏集"
 
-#: src/olympia/amo/templates/amo/site_nav.html:70 src/olympia/bandwagon/templates/bandwagon/user_listing.html:4 src/olympia/bandwagon/templates/bandwagon/impala/collection_sidebar.html:13
+#: src/olympia/amo/templates/amo/site_nav.html:68 src/olympia/bandwagon/templates/bandwagon/user_listing.html:4 src/olympia/bandwagon/templates/bandwagon/impala/collection_sidebar.html:13
 #: src/olympia/bandwagon/templates/bandwagon/includes/collection_sidebar.html:15
 msgid "Collections I'm Following"
 msgstr "我訂閱的收藏集"
 
-#: src/olympia/amo/templates/amo/site_nav.html:73 src/olympia/bandwagon/templates/bandwagon/impala/collection_sidebar.html:18
-#: src/olympia/bandwagon/templates/bandwagon/includes/collection_sidebar.html:20 src/olympia/users/models.py:512
+#: src/olympia/amo/templates/amo/site_nav.html:71 src/olympia/bandwagon/templates/bandwagon/impala/collection_sidebar.html:18
+#: src/olympia/bandwagon/templates/bandwagon/includes/collection_sidebar.html:20 src/olympia/users/models.py:521
 msgid "My Favorite Add-ons"
 msgstr "我最愛的附加元件"
 
-#: src/olympia/amo/templates/amo/site_nav.html:78
+#: src/olympia/amo/templates/amo/site_nav.html:76
 msgid "More&hellip;"
 msgstr "更多&hellip;"
 
-#: src/olympia/amo/templates/amo/site_nav.html:82
+#: src/olympia/amo/templates/amo/site_nav.html:80
 msgid "Add-ons for Mobile"
 msgstr "Mobile 附加元件"
 
-#: src/olympia/amo/templates/amo/site_nav.html:86 src/olympia/browse/feeds.py:207 src/olympia/browse/templates/browse/search_tools.html:3 src/olympia/constants/base.py:176
+#: src/olympia/amo/templates/amo/site_nav.html:84 src/olympia/browse/feeds.py:207 src/olympia/browse/templates/browse/search_tools.html:3 src/olympia/constants/base.py:176
 #: src/olympia/templates/menu_links.html:10
 msgid "Search Tools"
 msgstr "搜尋工具"
@@ -2003,7 +2018,7 @@ msgid "Jump to first page"
 msgstr "跳至第一頁"
 
 #: src/olympia/amo/templates/amo/impala/paginator.html:22 src/olympia/amo/templates/amo/mobile/impala_paginator.html:12 src/olympia/discovery/templates/discovery/pane.html:44
-#: src/olympia/discovery/templates/discovery/addons/detail.html:38 src/olympia/stats/templates/stats/stats.html:164
+#: src/olympia/discovery/templates/discovery/addons/detail.html:38 src/olympia/stats/templates/stats/stats.html:166
 msgid "Previous"
 msgstr "之前"
 
@@ -2013,7 +2028,7 @@ msgstr "跳到最後一頁"
 
 #. First and second arguments are the result range (e.g., 1-20);
 #. third argument is the number of total results (e.g., 1,000).
-#. third
+#. First and second arguments are the result range (e.g., 1-20);              third
 #. argument is the number of total results (e.g., 1,000).
 #: src/olympia/amo/templates/amo/impala/paginator.html:36 src/olympia/amo/templates/amo/mobile/impala_paginator.html:38
 #, python-format
@@ -2024,32 +2039,52 @@ msgstr "目前顯示 <b>%(begin)s</b>&ndash;<b>%(end)s</b> 頁，共 <b>%(count)
 msgid "Page {n}"
 msgid_plural "Page {n}"
 msgstr[0] "第 {n} 頁"
+msgstr[1] ""
 
-#: src/olympia/amo/templates/services/install.html:38
-#, python-format
-msgid "If you are not prompted to install %(addon_name)s in a moment, please <a href=\"%(addon_xpi)s\">click here</a>."
-msgstr "若您未在短時間內被提示安裝 %(addon_name)s，請 <a href=\"%(addon_xpi)s\">點這裡</a>。"
-
-#: src/olympia/amo/tests/test_messages.py:57 src/olympia/amo/tests/test_messages.py:58 src/olympia/reviews/forms.py:25 src/olympia/reviews/forms.py:50 src/olympia/reviews/templates/reviews/add.html:56
+#: src/olympia/amo/tests/test_messages.py:56 src/olympia/amo/tests/test_messages.py:57 src/olympia/reviews/forms.py:25 src/olympia/reviews/forms.py:50 src/olympia/reviews/templates/reviews/add.html:56
 #: src/olympia/reviews/templates/reviews/reply.html:30
 msgid "Title"
 msgstr "標題"
 
-#: src/olympia/amo/tests/test_messages.py:57 src/olympia/amo/tests/test_messages.py:58
+#: src/olympia/amo/tests/test_messages.py:56 src/olympia/amo/tests/test_messages.py:57
 msgid "Body"
 msgstr "本文"
 
-#: src/olympia/amo/tests/test_messages.py:59
+#: src/olympia/amo/tests/test_messages.py:58
 msgid "Another Title"
 msgstr "另一個標題"
 
-#: src/olympia/amo/tests/test_messages.py:59
+#: src/olympia/amo/tests/test_messages.py:58
 msgid "Another Body"
 msgstr "另一個本文"
 
-#: src/olympia/api/views.py:255
-msgid "Not implemented yet."
-msgstr "尚未實作。"
+#: src/olympia/api/authentication.py:76
+msgid "Signature has expired."
+msgstr ""
+
+#: src/olympia/api/authentication.py:79
+msgid "Error decoding signature."
+msgstr ""
+
+#: src/olympia/api/authentication.py:82
+msgid "Invalid JWT Token."
+msgstr ""
+
+#: src/olympia/api/authentication.py:130
+msgid "Invalid Authorization header. No credentials provided."
+msgstr ""
+
+#: src/olympia/api/authentication.py:133
+msgid "Invalid Authorization header. Credentials string should not contain spaces."
+msgstr ""
+
+#: src/olympia/api/fields.py:29
+msgid "The field must have a length of at least {num} characters."
+msgstr ""
+
+#: src/olympia/api/fields.py:31
+msgid "The language code {lang_code} is invalid."
+msgstr ""
 
 #: src/olympia/applications/views.py:39 src/olympia/applications/templates/applications/appversions.html:3
 msgid "Application Versions"
@@ -2067,7 +2102,7 @@ msgstr "有效應用程式版本"
 msgid "Add-ons submitted to Mozilla Add-ons must have a manifest file with at least one of the below applications supported. Only the versions listed below are allowed for these applications."
 msgstr "送交到 Mozilla 附加元件站上架的附加元件的安裝資訊檔當中必須支援下列任一種以上的應用程式。僅接受下列版本號碼。"
 
-#: src/olympia/applications/templates/applications/appversions.html:25
+#: src/olympia/applications/templates/applications/appversions.html:25 src/olympia/editors/helpers.py:361
 msgid "GUID"
 msgstr "GUID"
 
@@ -2182,8 +2217,8 @@ msgstr "最愛"
 msgid "Remove from favorites"
 msgstr "從最愛中移除"
 
-#: src/olympia/bandwagon/views.py:98 src/olympia/bandwagon/views.py:191 src/olympia/browse/views.py:58 src/olympia/browse/views.py:69 src/olympia/browse/views.py:458 src/olympia/devhub/views.py:74
-#: src/olympia/devhub/views.py:82 src/olympia/devhub/templates/devhub/addons/edit/basic.html:20 src/olympia/editors/templates/editors/leaderboard.html:24
+#: src/olympia/bandwagon/views.py:98 src/olympia/bandwagon/views.py:191 src/olympia/browse/views.py:58 src/olympia/browse/views.py:69 src/olympia/browse/views.py:425 src/olympia/devhub/views.py:72
+#: src/olympia/devhub/views.py:80 src/olympia/devhub/templates/devhub/addons/edit/basic.html:20 src/olympia/editors/templates/editors/leaderboard.html:24
 #: src/olympia/editors/templates/editors/themes/queue_list.html:48 src/olympia/search/forms.py:17 src/olympia/search/forms.py:89 src/olympia/users/templates/users/vcard.html:5
 msgid "Name"
 msgstr "名稱"
@@ -2192,7 +2227,7 @@ msgstr "名稱"
 msgid "Recently Popular"
 msgstr "最近熱門的"
 
-#: src/olympia/bandwagon/views.py:189 src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:18
+#: src/olympia/bandwagon/views.py:189 src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:16
 msgid "Added"
 msgstr "新增於"
 
@@ -2206,8 +2241,8 @@ msgstr "已建立收藏集！"
 
 #: src/olympia/bandwagon/views.py:316
 #, python-format
-msgid "Your new collection is shown below. You can <ahref=\"%(url)s\">edit additional settings</a> if you'dlike."
-msgstr "您的新收藏集顯示在下方，您想要的話還可以 <a href=\"%(url)s\">編輯其他設定</a>。"
+msgid "Your new collection is shown below. You can <a href=\"%(url)s\">edit additional settings</a> if you'd like."
+msgstr ""
 
 #: src/olympia/bandwagon/views.py:322
 msgid "Collection updated!"
@@ -2286,6 +2321,7 @@ msgstr "私密"
 msgid "<span>%(num)s</span> follower"
 msgid_plural "<span>%(num)s</span> followers"
 msgstr[0] "<span>%(num)s</span> 位訂閱者"
+msgstr[1] ""
 
 #: src/olympia/bandwagon/templates/bandwagon/collection_detail.html:54
 msgid "About this Collection"
@@ -2324,15 +2360,17 @@ msgstr "刪除收藏集"
 msgid "%(num)s Theme in this Collection"
 msgid_plural "%(num)s Themes in this Collection"
 msgstr[0] "此收藏集有%(num)s個佈景主題"
+msgstr[1] ""
 
 #: src/olympia/bandwagon/templates/bandwagon/collection_detail.html:111
 #, python-format
 msgid "%(num)s Add-on in this Collection"
 msgid_plural "%(num)s Add-ons in this Collection"
 msgstr[0] "此收藏集有 %(num)s 個附加元件"
+msgstr[1] ""
 
-#: src/olympia/bandwagon/templates/bandwagon/collection_detail.html:125 src/olympia/compat/templates/compat/index.html:25 src/olympia/compat/templates/compat/reporter_detail.html:29
-#: src/olympia/files/templates/files/viewer.html:29 src/olympia/templates/amo_footer.html:17 src/olympia/templates/includes/lang_switcher.html:10
+#: src/olympia/bandwagon/templates/bandwagon/collection_detail.html:125 src/olympia/compat/templates/compat/reporter_detail.html:29 src/olympia/files/templates/files/viewer.html:29
+#: src/olympia/templates/amo_footer.html:17 src/olympia/templates/includes/lang_switcher.html:10
 msgid "Go"
 msgstr "衝"
 
@@ -2367,7 +2405,7 @@ msgstr "以下這些附加元件已被您使用 <b>加入至我的最愛</b> 功
 msgid ""
 "Add-ons that you mark as favorites using the <b>Add to Favorites</b> feature appear below. This collection is currently <b>private</b>, which means only you can see it.  If you would like everyone "
 "to be able to see your favorites, click the button below to make it public."
-msgstr "您使用 <b>加入至最愛清單</b> 功能標示為最愛的附加元件將顯示在下方。此收藏集目前是 <b>私人</b> 的，只有您看的到。若您想讓其他人也能看到最愛的收藏集，請點擊下方的按鈕將其公開。"
+msgstr ""
 
 #: src/olympia/bandwagon/templates/bandwagon/collection_detail.html:196
 msgid "My favorite add-ons"
@@ -2378,41 +2416,45 @@ msgstr "我最愛的附加元件"
 msgid "<span>%(addons)s</span> add-on"
 msgid_plural "<span>%(addons)s</span> add-ons"
 msgstr[0] "<span>%(addons)s</span> 個附加元件"
+msgstr[1] ""
 
 #: src/olympia/bandwagon/templates/bandwagon/collection_grid.html:32
 #, python-format
 msgid "<span>%(followers)s</span> follower"
 msgid_plural "<span>%(followers)s</span> followers"
 msgstr[0] "<span>%(followers)s</span> 個訂閱者"
+msgstr[1] ""
 
-#. People "follow" collections to get notified of updates.
-#. Like
+#. People "follow" collections to get notified of updates.                    Like
 #. Twitter followers.
+#. People "follow" collections to get notified of updates.
 #. Like Twitter followers.
 #: src/olympia/bandwagon/templates/bandwagon/collection_listing_items.html:10 src/olympia/bandwagon/templates/bandwagon/impala/collection_listing_items.html:18
 #, python-format
 msgid "%(num)s weekly follower"
 msgid_plural "%(num)s weekly followers"
 msgstr[0] "每週訂閱者: %(num)s 位"
+msgstr[1] ""
 
-#. People "follow" collections to get notified of updates.
-#. Like
+#. People "follow" collections to get notified of updates.                    Like
 #. Twitter followers.
 #: src/olympia/bandwagon/templates/bandwagon/collection_listing_items.html:18
 #, python-format
 msgid "%(num)s monthly follower"
 msgid_plural "%(num)s monthly followers"
 msgstr[0] "%(num)s 位每月訂閱者"
+msgstr[1] ""
 
-#. People "follow" collections to get notified of updates.
-#. Like
+#. People "follow" collections to get notified of updates.                    Like
 #. Twitter followers.
+#. People "follow" collections to get notified of updates.
 #. Like Twitter followers.
 #: src/olympia/bandwagon/templates/bandwagon/collection_listing_items.html:26 src/olympia/bandwagon/templates/bandwagon/impala/collection_listing_items.html:26
 #, python-format
 msgid "%(num)s follower"
 msgid_plural "%(num)s followers"
 msgstr[0] "%(num)s 位訂閱者"
+msgstr[1] ""
 
 #: src/olympia/bandwagon/templates/bandwagon/collection_listing_items.html:56 src/olympia/bandwagon/templates/bandwagon/impala/collection_listing_items.html:9
 #: src/olympia/devhub/templates/devhub/personas/edit.html:27
@@ -2497,7 +2539,7 @@ msgid "Remove this user as a contributor"
 msgstr "將這個使用者從貢獻者清單中移除"
 
 #: src/olympia/bandwagon/templates/bandwagon/edit_contributors.html:18 src/olympia/bandwagon/templates/bandwagon/edit_contributors.html:43
-#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:20 src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:48
+#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:18 src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:46
 #: src/olympia/devhub/templates/devhub/addons/ajax_compat_update.html:19
 msgid "Remove"
 msgstr "移除"
@@ -2511,8 +2553,6 @@ msgid ""
 "You can add multiple contributors to this collection.  A contributor can add and remove add-ons from this collection, but cannot change its name or description.  To add a contributor, enter their "
 "email in the box below. Contributors must have a Mozilla Add-ons account."
 msgstr ""
-"您可以加入多位貢獻者至此收藏集。貢獻者可新增或刪除收藏集中的附加元件，但無法修改名稱與描述。若要新增貢獻者，請在下方的欄位輸入他們的電子郵件地址。貢獻者必須已使用該地址註冊 Mozilla 附加元件站的帳"
-"號。"
 
 #: src/olympia/bandwagon/templates/bandwagon/edit_contributors.html:40
 msgid "User"
@@ -2548,7 +2588,7 @@ msgid "<b>Warning:</b> By changing the owner of this collection, you will no lon
 msgstr "<b>警告：</b>改變此收藏集的擁有者，您將無法再編輯此收藏集的內容，且只能新增與移除附加元件。"
 
 #: src/olympia/bandwagon/templates/bandwagon/edit_contributors.html:83 src/olympia/devhub/templates/devhub/addons/forms_shared/media.html:157
-#: src/olympia/devhub/templates/devhub/addons/submit/describe.html:69 src/olympia/devhub/templates/devhub/addons/submit/license.html:60 src/olympia/devhub/templates/devhub/addons/submit/upload.html:78
+#: src/olympia/devhub/templates/devhub/addons/submit/describe.html:69 src/olympia/devhub/templates/devhub/addons/submit/license.html:60 src/olympia/devhub/templates/devhub/addons/submit/upload.html:70
 #: src/olympia/devhub/templates/devhub/payments/tier.html:17 src/olympia/editors/templates/editors/themes/themes.html:111 src/olympia/editors/templates/editors/themes/themes.html:128
 #: src/olympia/editors/templates/editors/themes/themes.html:134 src/olympia/editors/templates/editors/themes/themes.html:141 src/olympia/users/templates/users/fxa_migration_prompt_content.html:10
 #: src/olympia/users/templates/users/login_form.html:42 src/olympia/users/templates/users/mobile/login.html:57
@@ -2622,42 +2662,42 @@ msgstr "重設"
 
 #: src/olympia/bandwagon/templates/bandwagon/includes/addedit.html:53
 msgid "PNG and JPG supported.  Image will be resized to 32x32."
-msgstr "支援 PNG 與 JPG，圖片尺吋將縮放至 32x32。"
+msgstr ""
 
 #: src/olympia/bandwagon/templates/bandwagon/includes/addedit_errors.html:3
 msgid "There are errors in this form.  Please correct them below."
-msgstr "表單內容有誤，請在下方修正。"
+msgstr ""
 
 #: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:2
 msgid "Add-ons in Your Collection"
 msgstr "您收藏集中的附加元件"
 
 #: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:4
-msgid ""
-"To include an add-on in this collection, enter its name in the box below and hit enter.  You can also use the <strong>Add to Collection</strong> links throughout the site to include add-ons later."
-msgstr "若要將附加元件加入至此收藏集，請在下方輸入名稱，並按下 Enter。您也可以使用網站中的 <strong>新增至收藏集</strong> 鏈結來新增。"
+msgid "To include an add-on in this collection, enter its name in the box below and hit enter."
+msgstr ""
 
-#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:17 src/olympia/constants/base.py:400 src/olympia/devhub/templates/devhub/addons/activity.html:62
+#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:15 src/olympia/constants/base.py:400 src/olympia/devhub/templates/devhub/addons/activity.html:62
+#: src/olympia/editors/helpers.py:273 src/olympia/editors/helpers.py:360
 msgid "Add-on"
 msgstr "附加元件"
 
-#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:26
+#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:24
 msgid "Enter the name of the add-on to include"
 msgstr "輸入您要加入的附加元件名稱"
 
-#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:28
+#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:26
 msgid "Add to Collection"
 msgstr "加入收藏集"
 
-#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:45 src/olympia/editors/helpers.py:936 src/olympia/editors/helpers.py:956
+#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:43 src/olympia/editors/helpers.py:1016 src/olympia/editors/helpers.py:1036
 msgid "Pending"
 msgstr "等待中"
 
-#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:47
+#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:45
 msgid "Add a comment"
 msgstr "新增一則評論"
 
-#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:48
+#: src/olympia/bandwagon/templates/bandwagon/includes/addon_selector.html:46
 msgid "Remove this add-on from the collection"
 msgstr "將這個附加元件從收藏集中移除"
 
@@ -2708,8 +2748,6 @@ msgid ""
 "When Mozilla becomes aware of add-ons, plugins, or other third-party software that seriously compromises %(app)s security, stability, or performance and meets <a href=\"%(criteria)s\">certain "
 "criteria</a>, the software may be blocked from general use.  For more information, please read <a href=\"%(support)s\">this support article</a>."
 msgstr ""
-"當 Mozilla 注意到某套附加元件、外掛程式或其他第三方軟體會對 %(app)s 的安全性、穩定性、效能造成影響，並符合 <a href=\"%(criteria)s\">某些條件</a>，該軟體就將被封鎖。若需更多資訊，請參考 <a href="
-"\"%(support)s\">這篇技術支援文件</a>。"
 
 #: src/olympia/blocklist/templates/blocklist/blocked_detail.html:44
 #, python-format
@@ -2766,12 +2804,12 @@ msgstr "搜尋工具"
 msgid "Most Users"
 msgstr "最多使用者"
 
-#: src/olympia/browse/views.py:61 src/olympia/browse/views.py:72 src/olympia/browse/views.py:279 src/olympia/browse/templates/browse/personas/mobile/category_landing.html:63
+#: src/olympia/browse/views.py:61 src/olympia/browse/views.py:72 src/olympia/browse/views.py:246 src/olympia/browse/templates/browse/personas/mobile/category_landing.html:63
 #: src/olympia/discovery/templates/discovery/pane.html:67 src/olympia/search/forms.py:92
 msgid "Up & Coming"
 msgstr "嶄露頭角"
 
-#: src/olympia/browse/views.py:460 src/olympia/devhub/views.py:76 src/olympia/devhub/views.py:83 src/olympia/discovery/templates/discovery/addons/detail.html:66
+#: src/olympia/browse/views.py:427 src/olympia/devhub/views.py:74 src/olympia/devhub/views.py:81 src/olympia/discovery/templates/discovery/addons/detail.html:66
 msgid "Created"
 msgstr "建立日期"
 
@@ -2851,6 +2889,7 @@ msgstr "{0} :: 搜尋工具"
 msgid "<b>{0}</b> add-on"
 msgid_plural "<b>{0}</b> add-ons"
 msgstr[0] "<b>{0}</b> 個附加元件"
+msgstr[1] ""
 
 #: src/olympia/browse/templates/browse/search_tools.html:61
 msgid "Search Extensions"
@@ -2956,9 +2995,10 @@ msgstr "嶄露頭角的完整佈景主題"
 msgid "See the %(cnt)s extension in %(name)s &raquo;"
 msgid_plural "See all %(cnt)s extensions in %(name)s &raquo;"
 msgstr[0] "瀏覽 %(name)s 裡的 %(cnt)s 套件 &raquo;"
+msgstr[1] ""
 
-#: src/olympia/browse/templates/browse/mobile/extensions.html:13 src/olympia/compat/templates/compat/index.html:82 src/olympia/devhub/templates/devhub/devhub_search.html:24
-#: src/olympia/devhub/templates/devhub/addons/activity.html:47 src/olympia/search/templates/search/no_results.html:4 src/olympia/search/templates/search/mobile/results.html:36
+#: src/olympia/browse/templates/browse/mobile/extensions.html:13 src/olympia/devhub/templates/devhub/devhub_search.html:24 src/olympia/devhub/templates/devhub/addons/activity.html:47
+#: src/olympia/search/templates/search/no_results.html:4 src/olympia/search/templates/search/mobile/results.html:36
 msgid "No results found."
 msgstr "找不到結果。"
 
@@ -3043,7 +3083,7 @@ msgstr "&laquo; 全部佈景主題"
 msgid "All"
 msgstr "全部"
 
-#: src/olympia/compat/forms.py:22 src/olympia/search/views.py:525
+#: src/olympia/compat/forms.py:22 src/olympia/editors/templates/editors/base.html:69 src/olympia/search/views.py:518
 msgid "All Add-ons"
 msgstr "所有附加元件"
 
@@ -3054,53 +3094,6 @@ msgstr "二進位"
 #: src/olympia/compat/forms.py:24
 msgid "Non-binary"
 msgstr "非二進位"
-
-#. Review points sources other than add-ons and themes.
-#: src/olympia/compat/views.py:87 src/olympia/constants/base.py:388 src/olympia/devhub/forms.py:162 src/olympia/editors/templates/editors/performance.html:75
-msgid "Other"
-msgstr "其它"
-
-#: src/olympia/compat/templates/compat/index.html:4
-msgid "Add-on Compatibility Report for {app} {version}"
-msgstr "{app}{version} 的附加元件相容性報告"
-
-#: src/olympia/compat/templates/compat/index.html:11
-msgid "{app} {version} Compatibility"
-msgstr "{app} {version} 相容性"
-
-#: src/olympia/compat/templates/compat/index.html:17
-#, python-format
-msgid "Top 95%% compatible with previous version"
-msgstr "與前一版相容的前 95%%"
-
-#: src/olympia/compat/templates/compat/index.html:18
-#, python-format
-msgid "Top 95%% of all add-ons"
-msgstr "所有附加元件前 95%%"
-
-#: src/olympia/compat/templates/compat/index.html:19
-msgid "All active add-ons"
-msgstr "所有有效的附加元件"
-
-#: src/olympia/compat/templates/compat/index.html:23 src/olympia/constants/base.py:401
-msgid "App"
-msgstr "App"
-
-#: src/olympia/compat/templates/compat/index.html:55
-msgid "Details for add-ons compatible with previous version:"
-msgstr "與前一版本相容的詳細資訊："
-
-#: src/olympia/compat/templates/compat/index.html:57
-msgid "Show all versions"
-msgstr "顯示所有版本"
-
-#: src/olympia/compat/templates/compat/index.html:59
-msgid "Details for add-ons compatible with all versions:"
-msgstr "附加元件相容於所有版本的詳細資訊:"
-
-#: src/olympia/compat/templates/compat/index.html:61
-msgid "Show previous version only"
-msgstr "只顯示先前版本"
 
 #: src/olympia/compat/templates/compat/reporter.html:3
 msgid "Add-on Compatibility Reports"
@@ -3133,11 +3126,13 @@ msgstr "{addon} 相容性報告"
 msgid "{0} success report"
 msgid_plural "{0} success reports"
 msgstr[0] "{0} 個正常回報"
+msgstr[1] ""
 
 #: src/olympia/compat/templates/compat/reporter_detail.html:17
 msgid "{0} problem report"
 msgid_plural "{0} problem reports"
 msgstr[0] "{0} 個問題回報"
+msgstr[1] ""
 
 #: src/olympia/compat/templates/compat/reporter_detail.html:21 src/olympia/users/templates/users/profile.html:70
 msgid "View all"
@@ -3151,8 +3146,8 @@ msgstr "依應用程式過濾"
 msgid "Report Type"
 msgstr "報告類型"
 
-#: src/olympia/compat/templates/compat/reporter_detail.html:47 src/olympia/devhub/forms.py:784 src/olympia/devhub/templates/devhub/addons/ajax_compat_update.html:17 src/olympia/editors/forms.py:108
-#: src/olympia/zadmin/forms.py:45
+#: src/olympia/compat/templates/compat/reporter_detail.html:47 src/olympia/devhub/forms.py:785 src/olympia/devhub/templates/devhub/addons/ajax_compat_update.html:17 src/olympia/editors/forms.py:108
+#: src/olympia/editors/forms.py:248 src/olympia/zadmin/forms.py:45
 msgid "Application"
 msgstr "應用程式"
 
@@ -3240,7 +3235,8 @@ msgstr "已初步審核"
 msgid "Preliminarily Reviewed and Awaiting Full Review"
 msgstr "已初步審核並等待完整審核"
 
-#: src/olympia/constants/base.py:33 src/olympia/editors/helpers.py:924 src/olympia/editors/templates/editors/themes/history_table.html:34
+#: src/olympia/constants/base.py:33 src/olympia/editors/forms.py:258 src/olympia/editors/helpers.py:73 src/olympia/editors/helpers.py:1004
+#: src/olympia/editors/templates/editors/themes/history_table.html:34
 msgid "Deleted"
 msgstr "已刪除"
 
@@ -3340,6 +3336,11 @@ msgstr "在使用者下載此附加元件後詢問"
 msgid "Ask before users can download this add-on"
 msgstr "在使用者下載此附加元件時詢問"
 
+#. Review points sources other than add-ons and themes.
+#: src/olympia/constants/base.py:388 src/olympia/devhub/forms.py:162 src/olympia/editors/templates/editors/performance.html:75
+msgid "Other"
+msgstr "其它"
+
 #: src/olympia/constants/base.py:389
 msgid "Exception"
 msgstr "例外"
@@ -3351,6 +3352,10 @@ msgstr "釋出"
 #: src/olympia/constants/base.py:391
 msgid "Change"
 msgstr "修改"
+
+#: src/olympia/constants/base.py:401
+msgid "App"
+msgstr "App"
 
 #: src/olympia/constants/base.py:402
 msgid "Persona"
@@ -3500,7 +3505,7 @@ msgstr "標示"
 msgid "Duplicate"
 msgstr "重製"
 
-#: src/olympia/constants/editors.py:17 src/olympia/editors/helpers.py:502 src/olympia/editors/templates/editors/themes/queue.html:71 src/olympia/editors/templates/editors/themes/themes.html:94
+#: src/olympia/constants/editors.py:17 src/olympia/editors/helpers.py:575 src/olympia/editors/templates/editors/themes/queue.html:71 src/olympia/editors/templates/editors/themes/themes.html:94
 msgid "Reject"
 msgstr "退回"
 
@@ -3606,7 +3611,7 @@ msgstr "Solaris"
 msgid "Android"
 msgstr "Android"
 
-#: src/olympia/core/apps.py:19
+#: src/olympia/core/apps.py:21
 msgid "Core"
 msgstr "核心"
 
@@ -3740,8 +3745,8 @@ msgid "Submit my add-on for manual review."
 msgstr "送出我的附加元件進行手動審查。"
 
 #: src/olympia/devhub/forms.py:537
-msgid "Do not list my add-on on this site (beta)"
-msgstr "不要在此網站顯示我的附加元件（測試中）"
+msgid "Do not list my add-on on this site"
+msgstr ""
 
 #: src/olympia/devhub/forms.py:538
 msgid "Check this option if you intend to distribute your add-on on your own and only need it to be signed by Mozilla."
@@ -3773,46 +3778,46 @@ msgstr "檔案的版本若以 a|alpha|b|beta|pre|rc 與非必要的數字作為�
 
 #: src/olympia/devhub/forms.py:592
 #, python-format
-msgid "Version %s already exists"
-msgstr "版本 %s 已存在"
+msgid "Version %s already exists, or was uploaded before."
+msgstr ""
 
-#: src/olympia/devhub/forms.py:604
+#: src/olympia/devhub/forms.py:605
 msgid "Select a valid choice. That choice is not one of the available choices."
 msgstr "您選的不是有效的選項，請選擇有效的選項。"
 
-#: src/olympia/devhub/forms.py:610
+#: src/olympia/devhub/forms.py:611
 msgid "A file with a version ending with a|alpha|b|beta and an optional number is detected as beta."
 msgstr "檔案版本結尾包含a|alpha|b|beta 與數字會被偵測為 beta 測試版。"
 
-#: src/olympia/devhub/forms.py:633
+#: src/olympia/devhub/forms.py:634
 msgid "You cannot upload any more files for this version."
 msgstr "您不行再對這個版本上傳檔案。"
 
-#: src/olympia/devhub/forms.py:639
+#: src/olympia/devhub/forms.py:640
 msgid "Version doesn't match"
 msgstr "版本不相符"
 
-#: src/olympia/devhub/forms.py:668
+#: src/olympia/devhub/forms.py:669
 msgid "You cannot delete a file once the review process has started.  You must delete the whole version."
-msgstr "審核過程開始後您就無法刪除檔案。必須一次刪除整個版本。"
+msgstr ""
 
-#: src/olympia/devhub/forms.py:688
+#: src/olympia/devhub/forms.py:689
 msgid "The platform All cannot be combined with specific platforms."
 msgstr "所有平台不能與某特定平台結合。"
 
-#: src/olympia/devhub/forms.py:693
+#: src/olympia/devhub/forms.py:694
 msgid "A platform can only be chosen once."
 msgstr "只能選擇一個平台。"
 
-#: src/olympia/devhub/forms.py:706
+#: src/olympia/devhub/forms.py:707
 msgid "A review type must be selected."
 msgstr "您必須選擇一項審核方式。"
 
-#: src/olympia/devhub/forms.py:788 src/olympia/editors/forms.py:114 src/olympia/zadmin/forms.py:49 src/olympia/zadmin/forms.py:52
+#: src/olympia/devhub/forms.py:789 src/olympia/editors/forms.py:114 src/olympia/editors/forms.py:254 src/olympia/zadmin/forms.py:49 src/olympia/zadmin/forms.py:52
 msgid "Select an application first"
 msgstr "先選擇一個應用程式"
 
-#: src/olympia/devhub/forms.py:840
+#: src/olympia/devhub/forms.py:841
 msgid "There cannot be more than 3 required add-ons."
 msgstr "必要的附加元件不能超過三個。"
 
@@ -3834,6 +3839,7 @@ msgstr "開發者文件集"
 msgid "{0} error"
 msgid_plural "{0} errors"
 msgstr[0] "{0} 個錯誤"
+msgstr[1] ""
 
 # {0} is a number
 #. L10n: first parameter is the number of warnings
@@ -3841,81 +3847,82 @@ msgstr[0] "{0} 個錯誤"
 msgid "{0} warning"
 msgid_plural "{0} warnings"
 msgstr[0] "{0} 個警告"
+msgstr[1] ""
 
 #: src/olympia/devhub/models.py:375 src/olympia/reviews/templates/reviews/add.html:58
 msgid "Review"
 msgstr "意見"
 
-#: src/olympia/devhub/tasks.py:551
+#: src/olympia/devhub/tasks.py:583
 #, python-format
 msgid "%s responded with %s (%s)."
 msgstr "%s 回應了 %s (%s)。"
 
-#: src/olympia/devhub/tasks.py:555
+#: src/olympia/devhub/tasks.py:587
 #, python-format
 msgid "Connection to \"%s\" timed out."
 msgstr "至「%s」的連線已經逾時。"
 
-#: src/olympia/devhub/tasks.py:557
+#: src/olympia/devhub/tasks.py:589
 #, python-format
 msgid "Could not contact host at \"%s\"."
 msgstr "無法連線至主機「%s」。"
 
-#: src/olympia/devhub/utils.py:104
+#: src/olympia/devhub/utils.py:105
 #, python-format
 msgid "Validation generated too many errors/warnings so %s messages were truncated. After addressing the visible messages, you'll be able to see the others."
 msgstr "驗證過程中產生太多錯誤或警告訊息，所以已審略了 %s 比訊息。在處理完這些訊息所提到的問題後，您將可以看到其他的錯誤或警告訊息。"
 
-#: src/olympia/devhub/views.py:183
+#: src/olympia/devhub/views.py:181
 msgid "All My Add-ons"
 msgstr "我所有的附加元件"
 
-#: src/olympia/devhub/views.py:210
+#: src/olympia/devhub/views.py:208
 msgid "All Activity"
 msgstr "所有活動"
 
-#: src/olympia/devhub/views.py:211
+#: src/olympia/devhub/views.py:209
 msgid "Add-on Updates"
 msgstr "附加元件更新"
 
-#: src/olympia/devhub/views.py:212
+#: src/olympia/devhub/views.py:210
 msgid "Add-on Status"
 msgstr "附加元件狀態"
 
-#: src/olympia/devhub/views.py:213
+#: src/olympia/devhub/views.py:211
 msgid "User Collections"
 msgstr "使用者收藏集"
 
-#: src/olympia/devhub/views.py:214 src/olympia/devhub/templates/devhub/docs/policies-maintenance.html:68 src/olympia/pages/templates/pages/dev_faq.html:38
+#: src/olympia/devhub/views.py:212 src/olympia/devhub/templates/devhub/docs/policies-maintenance.html:68 src/olympia/pages/templates/pages/dev_faq.html:38
 #: src/olympia/pages/templates/pages/dev_faq.html:484
 msgid "User Reviews"
 msgstr "使用者意見"
 
-#: src/olympia/devhub/views.py:327 src/olympia/devhub/views.py:331 src/olympia/devhub/views.py:484 src/olympia/devhub/views.py:513 src/olympia/devhub/views.py:564 src/olympia/devhub/views.py:1150
+#: src/olympia/devhub/views.py:325 src/olympia/devhub/views.py:329 src/olympia/devhub/views.py:484 src/olympia/devhub/views.py:513 src/olympia/devhub/views.py:564 src/olympia/devhub/views.py:1156
 msgid "Changes successfully saved."
 msgstr "已成功儲存變更。"
 
-#: src/olympia/devhub/views.py:334 src/olympia/devhub/views.py:1631
+#: src/olympia/devhub/views.py:332 src/olympia/devhub/views.py:1637
 msgid "Please check the form for errors."
 msgstr "請檢查表格是否有錯誤。"
 
-#: src/olympia/devhub/views.py:346
+#: src/olympia/devhub/views.py:344
 msgid "Add-on cannot be deleted. Disable this add-on instead."
 msgstr "無法刪除此附加元件，請停用。"
 
-#: src/olympia/devhub/views.py:356
+#: src/olympia/devhub/views.py:354
 msgid "Theme deleted."
 msgstr "已刪除佈景主題。"
 
-#: src/olympia/devhub/views.py:356
+#: src/olympia/devhub/views.py:354
 msgid "Add-on deleted."
 msgstr "已刪除附加元件。"
 
-#: src/olympia/devhub/views.py:362
+#: src/olympia/devhub/views.py:360
 msgid "URL name was incorrect. Theme was not deleted."
 msgstr "網址不正確，並未刪除佈景主題。"
 
-#: src/olympia/devhub/views.py:367
+#: src/olympia/devhub/views.py:365
 msgid "URL name was incorrect. Add-on was not deleted."
 msgstr "網址不正確，並未刪除附加元件。"
 
@@ -3943,7 +3950,7 @@ msgstr "驗證附加元件"
 msgid "Check Add-on Compatibility"
 msgstr "檢查附加元件的相容性"
 
-#: src/olympia/devhub/views.py:808 src/olympia/signing/views.py:90
+#: src/olympia/devhub/views.py:808 src/olympia/signing/views.py:95
 msgid "You cannot submit this type of add-on"
 msgstr "您無法送出此類型的附加元件。"
 
@@ -3973,33 +3980,33 @@ msgstr "圖檔的寬必須剛好為 {0} 像素並且高 {1} 像素。"
 msgid "There was an error uploading your preview."
 msgstr "上傳截圖的過程中發生錯誤。"
 
-#: src/olympia/devhub/views.py:1189
+#: src/olympia/devhub/views.py:1195
 #, python-format
 msgid "Version %s disabled."
 msgstr "已停用 %s 版本。"
 
-#: src/olympia/devhub/views.py:1193
+#: src/olympia/devhub/views.py:1199
 #, python-format
 msgid "Version %s deleted."
 msgstr "已刪除版本 %s。"
 
-#: src/olympia/devhub/views.py:1203
+#: src/olympia/devhub/views.py:1209
 msgid "This upload has failed validation, and may lack complete validation results. Please take due care when reviewing it."
 msgstr "本上傳驗證失敗，因此驗證結果可能不完整，請在審核時格加注意。"
 
-#: src/olympia/devhub/views.py:1677
+#: src/olympia/devhub/views.py:1683
 msgid "Preliminary Review Requested."
 msgstr "已要求初步審核。"
 
-#: src/olympia/devhub/views.py:1678
+#: src/olympia/devhub/views.py:1684
 msgid "Full Review Requested."
 msgstr "已要求完整審核。"
 
-#: src/olympia/devhub/views.py:1779
+#: src/olympia/devhub/views.py:1783
 msgid "Your old credentials were revoked and are no longer valid. Be sure to update all API clients with the new credentials."
 msgstr "您的舊金鑰已被撤銷，不再有效。請記得更新所有 API 客戶端上使用的金鑰。"
 
-#: src/olympia/devhub/views.py:1797
+#: src/olympia/devhub/views.py:1801
 msgid "New API key created"
 msgstr "已建立新 API 金鑰"
 
@@ -4029,7 +4036,7 @@ msgstr "返回附加元件網站"
 msgid "{0} :: Search"
 msgstr "{0} :: 搜尋"
 
-#: src/olympia/devhub/templates/devhub/devhub_search.html:6 src/olympia/devhub/templates/devhub/search.html:8 src/olympia/editors/forms.py:435 src/olympia/editors/forms.py:437
+#: src/olympia/devhub/templates/devhub/devhub_search.html:6 src/olympia/devhub/templates/devhub/search.html:8 src/olympia/editors/forms.py:534 src/olympia/editors/forms.py:536
 #: src/olympia/editors/templates/editors/queue.html:27 src/olympia/editors/templates/editors/themes/queue_list.html:14 src/olympia/search/templates/search/collections.html:17
 #: src/olympia/search/templates/search/personas.html:18 src/olympia/search/templates/search/results.html:18 src/olympia/search/templates/search/mobile/results.html:8
 #: src/olympia/templates/search.html:14 src/olympia/templates/impala/search.html:18
@@ -4091,12 +4098,12 @@ msgstr "請前往 <a href=\"https://developer.mozilla.org/Add-ons\">Mozilla Deve
 msgid "Start Making Add-ons"
 msgstr "開始製作附加元件"
 
-#: src/olympia/devhub/templates/devhub/index.html:86 src/olympia/devhub/templates/devhub/addons/listing/items.html:25 src/olympia/devhub/templates/devhub/includes/addon_details.html:15
+#: src/olympia/devhub/templates/devhub/index.html:86 src/olympia/devhub/templates/devhub/addons/listing/items.html:25 src/olympia/devhub/templates/devhub/includes/addon_details.html:20
 #: src/olympia/devhub/templates/devhub/personas/edit.html:43
 msgid "Status:"
 msgstr "狀態："
 
-#: src/olympia/devhub/templates/devhub/index.html:90 src/olympia/devhub/templates/devhub/includes/addon_details.html:100
+#: src/olympia/devhub/templates/devhub/index.html:90 src/olympia/devhub/templates/devhub/includes/addon_details.html:87
 msgid "Visibility:"
 msgstr "公開情況："
 
@@ -4104,11 +4111,11 @@ msgstr "公開情況："
 msgid "Latest Version:"
 msgstr "最新版本："
 
-#: src/olympia/devhub/templates/devhub/index.html:109 src/olympia/devhub/templates/devhub/includes/addon_details.html:145 src/olympia/devhub/templates/devhub/personas/edit.html:49
+#: src/olympia/devhub/templates/devhub/index.html:109 src/olympia/devhub/templates/devhub/includes/addon_details.html:131 src/olympia/devhub/templates/devhub/personas/edit.html:49
 msgid "Queue Position:"
 msgstr "佇列位置："
 
-#: src/olympia/devhub/templates/devhub/index.html:110 src/olympia/devhub/templates/devhub/includes/addon_details.html:146 src/olympia/devhub/templates/devhub/personas/edit.html:50
+#: src/olympia/devhub/templates/devhub/index.html:110 src/olympia/devhub/templates/devhub/includes/addon_details.html:132 src/olympia/devhub/templates/devhub/personas/edit.html:50
 #, python-format
 msgid "%(position)s of %(total)s"
 msgstr "第 %(position)s 位，共 %(total)s 位"
@@ -4210,16 +4217,6 @@ msgstr "上傳之後，將會執行一連串的自動驗證測試。"
 msgid "Do you want your add-on to be distributed on this site?"
 msgstr "您想要在此網站上發行您的附加元件嗎？"
 
-#: src/olympia/devhub/templates/devhub/validate_addon.html:49 src/olympia/devhub/templates/devhub/addons/submit/upload.html:30 src/olympia/devhub/templates/devhub/versions/add_file_modal.html:14
-#: src/olympia/devhub/templates/devhub/versions/add_file_modal.html:53 src/olympia/devhub/templates/devhub/versions/list.html:298
-msgid "Warning:"
-msgstr "警告:"
-
-#: src/olympia/devhub/templates/devhub/validate_addon.html:50 src/olympia/devhub/templates/devhub/addons/submit/upload.html:31
-#, python-format
-msgid "Submission of unlisted add-ons for signing is currently in an open beta. Please <a href=\"%(url)s\" target=\"_blank\">report any bugs</a> that you encounter."
-msgstr "送出未公開上架的附加元件進行簽署的功能目前正在開放測試中。請 <a href=\"%(url)s\" target=\"_blank\">回報任何遇到的問題</a>。"
-
 #. first parameter is a filename like lorem-ipsum-1.0.2.xpi
 #: src/olympia/devhub/templates/devhub/validation.html:5
 msgid "Validation Results for {0}"
@@ -4295,7 +4292,7 @@ msgstr "相容性"
 msgid "Update Compatibility"
 msgstr "更新相容性"
 
-#: src/olympia/devhub/templates/devhub/addons/ajax_compat_update.html:4
+#: src/olympia/devhub/templates/devhub/addons/ajax_compat_update.html:4 src/olympia/devhub/templates/devhub/versions/edit.html:45
 msgid "Adjusting application information here will allow users to install your add-on even if the install manifest in the package indicates that the add-on is incompatible."
 msgstr "就算封裝檔案當中的安裝指出此附加元件並不相容，在此調整應用程式資訊將會允許使用者安裝您的附加元件。"
 
@@ -4307,9 +4304,9 @@ msgstr "支援版本"
 msgid "Add Another Application&hellip;"
 msgstr "新增其他應用程式&hellip;"
 
-#: src/olympia/devhub/templates/devhub/addons/ajax_compat_update.html:38 src/olympia/devhub/templates/devhub/addons/owner.html:86 src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:46
-#: src/olympia/devhub/templates/devhub/versions/list.html:351 src/olympia/devhub/templates/devhub/versions/list.html:353 src/olympia/templates/impala/base.html:132
-#: src/olympia/templates/impala/base.html:143 src/olympia/templates/impala/base.html:161 src/olympia/templates/impala/base.html:171
+#: src/olympia/devhub/templates/devhub/addons/ajax_compat_update.html:38 src/olympia/devhub/templates/devhub/addons/owner.html:86 src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:45
+#: src/olympia/devhub/templates/devhub/versions/list.html:349 src/olympia/devhub/templates/devhub/versions/list.html:351 src/olympia/templates/impala/base.html:129
+#: src/olympia/templates/impala/base.html:140 src/olympia/templates/impala/base.html:158 src/olympia/templates/impala/base.html:168
 msgid "Close"
 msgstr "關閉"
 
@@ -4327,6 +4324,7 @@ msgstr "我的附加元件較早的活動"
 msgid "<b>{0}</b> theme"
 msgid_plural "<b>{0}</b> themes"
 msgstr[0] "<b>{0}</b>個佈景主題"
+msgstr[1] ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit.html:3 src/olympia/devhub/templates/devhub/addons/listing/item_actions.html:25
 #: src/olympia/devhub/templates/devhub/addons/listing/item_actions_theme.html:7 src/olympia/devhub/templates/devhub/includes/addons_edit_nav.html:2
@@ -4342,7 +4340,7 @@ msgstr "無"
 msgid "Manage Authors & License"
 msgstr "管理作者與授權條款"
 
-#: src/olympia/devhub/templates/devhub/addons/owner.html:29 src/olympia/editors/templates/editors/review.html:270
+#: src/olympia/devhub/templates/devhub/addons/owner.html:29 src/olympia/editors/helpers.py:362 src/olympia/editors/templates/editors/review.html:270
 msgid "Authors"
 msgstr "作者"
 
@@ -4413,17 +4411,11 @@ msgstr "摘要"
 
 #: src/olympia/devhub/templates/devhub/addons/edit/basic.html:52
 msgid ""
-"A short explanation of your add-on's basic\n"
-"                          functionality that is displayed in search and browse\n"
-"                          listings, as well as at the top of your add-on's\n"
-"                          details page. It is only relevant for listed add-ons."
+"A short explanation of your add-on's basic functionality that is displayed in search and browse listings, as well as at the top of your add-on's details page. It is only relevant for listed add-ons."
 msgstr "關於您附加元件的基本功能的簡短描述，會顯示在搜尋結果、瀏覽清單，以及附加元件詳細資訊頁面。這僅與公開上架的附加元件有關。"
 
 #: src/olympia/devhub/templates/devhub/addons/edit/basic.html:73
-msgid ""
-"Categories are the primary way users browse through add-ons.\n"
-"                        Choose any that fit your add-on's functionality for the most\n"
-"                        exposure. It is only relevant for listed add-ons."
+msgid "Categories are the primary way users browse through add-ons. Choose any that fit your add-on's functionality for the most exposure. It is only relevant for listed add-ons."
 msgstr "使用者主要會透過分類的方式來瀏覽附加元件。請選擇符合您附加元件功能的分類以獲得最大的曝光程度。這僅與公開上架的附加元件有關。"
 
 #: src/olympia/devhub/templates/devhub/addons/edit/basic.html:90
@@ -4433,17 +4425,14 @@ msgid ""
 msgstr "當您的附加元件成為該應用程式的精選時，您無法更變它的隸屬類別。如有特殊理由需要更動類別，請 email 到 <a href=\"mailto:%(email)s\">%(email)s</a>。"
 
 #: src/olympia/devhub/templates/devhub/addons/edit/basic.html:119
-msgid ""
-"Tags help users find your add-on and should be short\n"
-"                        descriptors such as tabs, toolbar, or twitter.  You\n"
-"                        may have a maximum of {0} tags. It is only relevant\n"
-"                        for listed add-ons."
+msgid "Tags help users find your add-on and should be short descriptors such as tabs, toolbar, or twitter. You may have a maximum of {0} tags. It is only relevant for listed add-ons."
 msgstr "使用標籤能幫助使用者找到您的附加元件，這個欄位應該盡量減短，例如可輸入「tab」、「toolbar」、「twitter」。您最多可設定 {0} 個標籤。這僅與公開上架的附加元件有關。"
 
 #: src/olympia/devhub/templates/devhub/addons/edit/basic.html:129 src/olympia/devhub/templates/devhub/personas/edit.html:97 src/olympia/devhub/templates/devhub/personas/submit.html:46
 msgid "Comma-separated, minimum of {0} character."
 msgid_plural "Comma-separated, minimum of {0} characters."
 msgstr[0] "逗號區隔，至少 {0} 個字元。"
+msgstr[1] ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/basic.html:132 src/olympia/devhub/templates/devhub/personas/edit.html:100 src/olympia/devhub/templates/devhub/personas/submit.html:49
 msgid "Example: dark, cinema, noir. Limit 20."
@@ -4453,6 +4442,7 @@ msgstr "例子: Dark, cinema, noir. Limit 20。"
 msgid "Reserved tag:"
 msgid_plural "Reserved tags:"
 msgstr[0] "保留字："
+msgstr[1] ""
 
 #: src/olympia/devhub/templates/devhub/addons/edit/details.html:5
 msgid "Add-on Details"
@@ -4463,11 +4453,7 @@ msgid "Add-on Details for {0}"
 msgstr "{0} 的附加元件詳細資訊"
 
 #: src/olympia/devhub/templates/devhub/addons/edit/details.html:22
-msgid ""
-"A longer explanation of features,\n"
-"                          functionality, and other relevant information. This\n"
-"                          field is only displayed on the add-on's details\n"
-"                          page. It is only relevant for listed add-ons."
+msgid "A longer explanation of features, functionality, and other relevant information. This field is only displayed on the add-on's details page. It is only relevant for listed add-ons."
 msgstr "關於功能或其他相關資訊更完整的描述。此欄位僅顯示於附加元件的詳細資訊頁面，僅與公開上架的附加元件有關。"
 
 #: src/olympia/devhub/templates/devhub/addons/edit/details.html:44 src/olympia/translations/templates/translations/trans-menu.html:13
@@ -4475,10 +4461,7 @@ msgid "Default Locale"
 msgstr "預設地區"
 
 #: src/olympia/devhub/templates/devhub/addons/edit/details.html:45
-msgid ""
-"Information about your add-on is displayed in this locale\n"
-"                        unless you override it with a locale-specific translation.\n"
-"                        It is only relevant for listed add-ons."
+msgid "Information about your add-on is displayed in this locale unless you override it with a locale-specific translation. It is only relevant for listed add-ons."
 msgstr "您的附加元件將預設使用此語系顯示，除非您稍後再指定其他語系的翻譯內容。僅與公開上架的附加元件有關。"
 
 #: src/olympia/devhub/templates/devhub/addons/edit/details.html:61 src/olympia/users/forms.py:311 src/olympia/users/templates/users/edit.html:122 src/olympia/users/templates/users/register.html:57
@@ -4488,10 +4471,8 @@ msgstr "首頁"
 
 #: src/olympia/devhub/templates/devhub/addons/edit/details.html:63
 msgid ""
-"If your add-on has another homepage, enter its\n"
-"                          address here. If your website is localized into other\n"
-"                          languages multiple translations of this field can be\n"
-"                          added. It is only relevant for listed add-ons."
+"If your add-on has another homepage, enter its address here. If your website is localized into other languages multiple translations of this field can be added. It is only relevant for listed add-"
+"ons."
 msgstr "若您的附加元件有自己的網站，請在此輸入網址。若您的網站有多國語系版本，亦可在此欄位新增。僅與公開上架的附加元件有關。"
 
 #: src/olympia/devhub/templates/devhub/addons/edit/media.html:3
@@ -4509,19 +4490,14 @@ msgstr "{0} 的支援資訊"
 
 #: src/olympia/devhub/templates/devhub/addons/edit/support.html:22
 msgid ""
-"If you wish to display an e-mail address for support\n"
-"                          inquiries, enter it here. If you have different\n"
-"                          addresses for each language multiple translations of\n"
-"                          this field can be added. It is only relevant for\n"
-"                          listed add-ons."
+"If you wish to display an e-mail address for support inquiries, enter it here. If you have different addresses for each language multiple translations of this field can be added. It is only "
+"relevant for listed add-ons."
 msgstr "若您想要顯示一組提供技術支援的電子郵件地址，請在此輸入。若您對不同語言提供不同的地址，亦可新增多個欄位。此欄位僅與公開上架的附加元件有關。"
 
 #: src/olympia/devhub/templates/devhub/addons/edit/support.html:45
 msgid ""
-"If your add-on has a support website or forum, enter\n"
-"                          its address here. If your website is localized into\n"
-"                          other languages, multiple translations of this field can\n"
-"                          be added. It is only relevant for listed add-ons."
+"If your add-on has a support website or forum, enter its address here. If your website is localized into other languages, multiple translations of this field can be added. It is only relevant for "
+"listed add-ons."
 msgstr "若您的附加元件有技術支援網站或討論區，請在此輸入網址。若該網站有多國語言版本，亦可新增多個網址。此欄位僅與公開上架的附加元件有關。"
 
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:6
@@ -4535,11 +4511,8 @@ msgstr "{0} 的詳細技術資訊"
 
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:23
 msgid ""
-"Any information end users may want to know that isn't\n"
-"                          necessarily applicable to the add-on summary or description.\n"
-"                          Common uses include listing known major bugs, information on\n"
-"                          how to report bugs, anticipated release date of a new version,\n"
-"                          etc. It is only relevant for listed add-ons."
+"Any information end users may want to know that isn't necessarily applicable to the add-on summary or description. Common uses include listing known major bugs, information on how to report bugs, "
+"anticipated release date of a new version, etc. It is only relevant for listed add-ons."
 msgstr "任何使用者可能會想要知道但與附加元件概要、描述無關的內容可填於此處。一般來說可填入已知的重大 bug、如何回報 bug 的方式，或是預計下次發行新版本的時間等等。此欄位僅與公開上架的附加元件有關。"
 
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:46
@@ -4551,9 +4524,7 @@ msgid "Add-on Flags"
 msgstr "附加元件標記"
 
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:69
-msgid ""
-"These flags are used to classify add-ons. It is only\n"
-"                        relevant for listed add-ons."
+msgid "These flags are used to classify add-ons. It is only relevant for listed add-ons."
 msgstr "這些旗標用來分類附加元件。此欄位僅與公開上架的附加元件有關。"
 
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:74
@@ -4569,9 +4540,7 @@ msgid "View Source?"
 msgstr "檢視原始碼？"
 
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:90
-msgid ""
-"Whether the source of your add-on can be displayed in our\n"
-"                        online viewer. It is only relevant for listed add-ons."
+msgid "Whether the source of your add-on can be displayed in our online viewer. It is only relevant for listed add-ons."
 msgstr "是否要將附加元件原始碼顯示於我們的線上檢視器。此欄位僅與公開上架的附加元件有關。"
 
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:94
@@ -4587,10 +4556,7 @@ msgid "Public Stats?"
 msgstr "公開統計數據？"
 
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:102
-msgid ""
-"Whether the download and usage stats of your add-on can\n"
-"                        be displayed in our online viewer.\n"
-"                        It is only relevant for listed add-ons."
+msgid "Whether the download and usage stats of your add-on can be displayed in our online viewer. It is only relevant for listed add-ons."
 msgstr "是否要將您附加元件的下載次數與使用統計顯示於我們的線上檢視器。此欄位僅與公開上架的附加元件有關。"
 
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:107
@@ -4606,10 +4572,7 @@ msgid "Upgrade SDK?"
 msgstr "要升級 SDK 嗎?"
 
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:116
-msgid ""
-"If selected, we will try to automatically upgrade your\n"
-"                        add-on when a new version of the SDK is released.\n"
-"                        It is only relevant for listed add-ons."
+msgid "If selected, we will try to automatically upgrade your add-on when a new version of the SDK is released. It is only relevant for listed add-ons."
 msgstr "若選擇此選項，我們將在有新版的 SDK 發布時嘗試自動升級您的附加元件。此欄位僅與公開上架的附加元件有關。"
 
 #: src/olympia/devhub/templates/devhub/addons/edit/technical.html:121
@@ -4662,10 +4625,8 @@ msgstr "附加元件圖示"
 
 #: src/olympia/devhub/templates/devhub/addons/forms_shared/media.html:16
 msgid ""
-"Upload an icon for your add-on or choose from one of ours. The\n"
-"                      icon is displayed nearly everywhere your add-on is. Uploaded images\n"
-"                      must be one of the following image types: .png, .jpg.\n"
-"                      It is only relevant for listed add-ons."
+"Upload an icon for your add-on or choose from one of ours. The icon is displayed nearly everywhere your add-on is. Uploaded images must be one of the following image types: .png, .jpg. It is only "
+"relevant for listed add-ons."
 msgstr "上傳您附加元件的圖示，或從我們提供的圖示中挑選一個。附加元件所在之處幾乎都會顯示此圖示。上傳的圖片必須使用下列任一格式: .png、.jpg。此欄位僅與公開上架的附加元件有關。"
 
 #: src/olympia/devhub/templates/devhub/addons/forms_shared/media.html:25
@@ -4678,9 +4639,7 @@ msgid "32x32px"
 msgstr "32x32 像素"
 
 #: src/olympia/devhub/templates/devhub/addons/forms_shared/media.html:39
-msgid ""
-"Used in listings of add-ons, like search results\n"
-"                            and featured add-ons."
+msgid "Used in listings of add-ons, like search results and featured add-ons."
 msgstr "使用在附加元件清單，像是搜尋結果與精選附加元件當中。"
 
 #. The size of the icon
@@ -4775,16 +4734,14 @@ msgid "Deleting your add-on will permanently remove it from the site and prevent
 msgstr "刪除附加元件後將會將其自網站永久移除，並防止相容 GUID 的附加元件被其他人再次上架。"
 
 #: src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:24
-msgid ""
-"Enter the following text confirm your decision:\n"
-"           {slug}"
+msgid "Enter the following text confirm your decision: {slug}"
 msgstr "請輸入下列文字作為確認: {slug}"
 
-#: src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:34
+#: src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:33
 msgid "Please tell us why you are deleting your theme:"
 msgstr "請告訴我們為什麼您要刪除您的佈景主題:"
 
-#: src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:36
+#: src/olympia/devhub/templates/devhub/addons/listing/delete_form.html:35
 msgid "Please tell us why you are deleting your add-on:"
 msgstr "請告訴我們為什麼您要刪除您的附加元件:"
 
@@ -4821,8 +4778,8 @@ msgstr "新版本"
 msgid "Daily statistics on downloads and users."
 msgstr "下載數與使用者的每日統計資訊。"
 
-#: src/olympia/devhub/templates/devhub/addons/listing/item_actions.html:45 src/olympia/stats/templates/stats/stats.html:75 src/olympia/stats/templates/stats/stats.html:79
-#: src/olympia/stats/templates/stats/stats.html:81
+#: src/olympia/devhub/templates/devhub/addons/listing/item_actions.html:45 src/olympia/stats/templates/stats/stats.html:31 src/olympia/stats/templates/stats/stats.html:35
+#: src/olympia/stats/templates/stats/stats.html:37
 msgid "Statistics"
 msgstr "統計資訊"
 
@@ -4882,6 +4839,7 @@ msgstr "<b>佇列位置:</b> 共%(total)s位，您是第%(pos)s位。"
 msgid "<strong>{0}</strong> active user"
 msgid_plural "<strong>{0}</strong> active users"
 msgstr[0] "<strong>{0}</strong> 位活躍的使用者"
+msgstr[1] ""
 
 #: src/olympia/devhub/templates/devhub/addons/submit/base.html:11
 msgid "Submit Add-on"
@@ -4940,10 +4898,7 @@ msgid "Your add-on has been submitted to the Full Review queue."
 msgstr "您的附加元件已提交至完整審核等待區。"
 
 #: src/olympia/devhub/templates/devhub/addons/submit/done.html:18
-msgid ""
-"You'll receive an email once it has been reviewed by an editor. In\n"
-"          the meantime, you and your friends can install it directly from its\n"
-"          details page:"
+msgid "You'll receive an email once it has been reviewed by an editor. In the meantime, you and your friends can install it directly from its details page:"
 msgstr "您將在編輯完成審核後收到郵件通知。在此同時，您跟您的朋友可到此元件的詳細資訊頁面直接安裝:"
 
 #: src/olympia/devhub/templates/devhub/addons/submit/done.html:27 src/olympia/devhub/templates/devhub/addons/submit/done.html:77 src/olympia/devhub/templates/devhub/personas/submit_done.html:16
@@ -5149,11 +5104,11 @@ msgstr "步驟二：上傳您的附加元件"
 msgid "Use the fields below to upload your add-on package and select any platform restrictions. After upload, a series of automated validation tests will be run on your file."
 msgstr "使用下方欄位上傳您的附加元件並選擇可執行的平台。當上傳完成後，將會對您的檔案進行一系列自動化的驗證測試。"
 
-#: src/olympia/devhub/templates/devhub/addons/submit/upload.html:59 src/olympia/devhub/templates/devhub/versions/add_file_modal.html:39
+#: src/olympia/devhub/templates/devhub/addons/submit/upload.html:51 src/olympia/devhub/templates/devhub/versions/add_file_modal.html:28
 msgid "Which platforms is this file compatible with?"
 msgstr "這個檔案與哪些平台相容？"
 
-#: src/olympia/devhub/templates/devhub/addons/submit/upload.html:67 src/olympia/devhub/templates/devhub/versions/add_file_modal.html:65
+#: src/olympia/devhub/templates/devhub/addons/submit/upload.html:59 src/olympia/devhub/templates/devhub/versions/add_file_modal.html:45
 msgid "Administrative overrides"
 msgstr "管理員覆寫"
 
@@ -5267,9 +5222,9 @@ msgstr "網站功能 & 開發"
 
 #: src/olympia/devhub/templates/devhub/docs/policies-contact.html:44
 msgid ""
-"If you've found a problem with the site, we'd love to fix it. Please <a href=\"https://github.com/mozilla/olympia/issues\">file a bug report</a> in GitHub, including the location of the problem and "
-"how you encountered it."
-msgstr "若您發現網站上有問題，我們很樂意修正。請到 GitHub 上的 <a href=\"https://github.com/mozilla/olympia/issues\">張貼錯誤回報</a>，當中請包含發生問題的地方，以及您是怎麼遇到問題的。"
+"If you've found a problem with the site, we'd love to fix it. Please <a href=\"https://github.com/mozilla/addons/issues/new\">file a bug report</a> in GitHub, including the location of the problem "
+"and how you encountered it."
+msgstr ""
 
 #: src/olympia/devhub/templates/devhub/docs/policies-maintenance.html:3 src/olympia/devhub/templates/devhub/docs/policies-maintenance.html:7
 #: src/olympia/devhub/templates/devhub/docs/policies-maintenance.html:8
@@ -5869,7 +5824,7 @@ msgstr "私密瀏覽模式"
 
 #: src/olympia/devhub/templates/devhub/docs/policies-reviews.html:282
 msgid ""
-"Add-ons that store or otherwise handle browsing data must support <a href=\"https://developer.mozilla.org/En/Supporting_private_browsing_mode\">Private Browsing Mode</a>.  During a Private Browsing "
+"Add-ons that store or otherwise handle browsing data must support <a href=\"https://developer.mozilla.org/En/Supporting_private_browsing_mode\">Private Browsing Mode</a>. During a Private Browsing "
 "session, no browsing data can be written to disk, and all of this data must be cleared when Firefox quits or the Private Browsing session ends."
 msgstr ""
 "會儲存或處理瀏覽資料的附加元件必須支援<a href=\"https://developer.mozilla.org/En/Supporting_private_browsing_mode\">隱私瀏覽模式</a>。在隱私瀏覽階段中，將不會寫入任何資料到硬碟中，且必須在離開 "
@@ -6062,129 +6017,95 @@ msgstr "關於提交您的著作至本站的服務條款。開發者在提交前
 msgid "How to get in touch with us regarding these policies or your add-on."
 msgstr "如何聯絡我們關於這些政策或您的附加元件。"
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:6
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:10
 msgid "You have disabled this add-on"
 msgstr "您已經停用這個附加元件"
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:20
-msgid ""
-"Your add-on's listing is disabled and is not showing\n"
-"                             anywhere in our gallery or update service."
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:24
+msgid "Your add-on's listing is disabled and is not showing anywhere in our gallery or update service."
 msgstr "您的附加元件已下架，不會在網站的任何地方或自動更新服務中出現。"
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:25
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:27
 msgid "Please complete your add-on."
 msgstr "請完成您的附加元件。"
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:29
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:30
 msgid "You will receive an email when the review is complete."
 msgstr "審核完成時您將會收到郵件。"
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:34
-msgid ""
-"You will receive an email when the review is complete. Until\n"
-"                             then, your add-on is not listed in our gallery but can be\n"
-"                             accessed directly from its details page."
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:33
+msgid "You will receive an email when the review is complete. Until then, your add-on is not listed in our gallery but can be accessed directly from its details page."
 msgstr "您會在審查完成時收到郵件通知。在那之前，您的附加元件還不會公開上架，但可開啟詳細資訊頁面。"
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:38 src/olympia/devhub/templates/devhub/includes/addon_details.html:48
-msgid ""
-"You will receive an email when the review is\n"
-"                             complete and your add-on is signed."
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:37 src/olympia/devhub/templates/devhub/includes/addon_details.html:45
+msgid "You will receive an email when the review is complete and your add-on is signed."
 msgstr "您會在審查與簽署完成時收到郵件通知。"
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:44
-msgid ""
-"You will receive an email when the review is complete. Until\n"
-"                             then, your add-on is not listed in our gallery but can be\n"
-"                             accessed directly from its details page. "
-msgstr "您會在審查完成時收到郵件通知。在那之前，您的附加元件還不會公開上架，但可開啟詳細資訊頁面。"
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:41
+msgid "You will receive an email when the review is complete. Until then, your add-on is not listed in our gallery but can be accessed directly from its details page. "
+msgstr ""
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:54
-msgid ""
-"Your add-on is displayed in our gallery and users are\n"
-"                             receiving automatic updates."
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:49
+msgid "Your add-on is displayed in our gallery and users are receiving automatic updates."
 msgstr "您的附加元件已公開陳列在網站上，使用者將接收自動更新。"
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:57
-msgid ""
-"Your add-on has been signed and can be bundled with an\n"
-"                             application installer."
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:52
+msgid "Your add-on has been signed and can be bundled with an application installer."
 msgstr "您的附加元件已被簽署，可與應用程式安裝程式一同發行。"
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:63
-msgid ""
-"Your add-on was disabled by a site administrator and is no\n"
-"                             longer shown in our gallery. If you have any questions,\n"
-"                             please email amo-admins@mozilla.org."
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:56
+msgid "Your add-on was disabled by a site administrator and is no longer shown in our gallery. If you have any questions, please email amo-admins@mozilla.org."
 msgstr "您的附加元件已被網站管理員停用，不在網站上公開上架。若您有任何問題，請聯絡 amo-admins@mozilla.org。"
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:70
-msgid ""
-"Your add-on is displayed in our gallery as experimental\n"
-"                             and users are receiving automatic updates. Some features\n"
-"                             are unavailable to your add-on."
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:62
+msgid "Your add-on is displayed in our gallery as experimental and users are receiving automatic updates. Some features are unavailable to your add-on."
 msgstr "您的附加元件被標示為「實驗性」，使用者將接收自動更新。某些功能無法在附加元件中使用。"
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:74
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:66
 msgid "Your add-on has been signed."
 msgstr "已經簽署您的附加元件。"
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:79
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:69
 msgid ""
-"You will receive an email when the full review is complete.\n"
-"                             Until then, your add-on is displayed in our gallery as\n"
-"                             experimental and users are receiving automatic updates.\n"
-"                             Some features are unavailable to your add-on."
+"You will receive an email when the full review is complete. Until then, your add-on is displayed in our gallery as experimental and users are receiving automatic updates. Some features are "
+"unavailable to your add-on."
 msgstr "您會在完整審查完成時收到郵件通知。在那之前，您的附加元件會先公開上架，會被標示為「實驗中」，使用者也會收到自動更新。您的附加元件中有些功能尚無法使用。"
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:84
-msgid ""
-"You will receive an email when the full review is\n"
-"                             complete, making you able to bundle your add-on with an\n"
-"                             application installer."
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:74
+msgid "You will receive an email when the full review is complete, making you able to bundle your add-on with an application installer."
 msgstr "您會在完整審查完成時收到郵件通知，讓您可將附加元件與應用程式的安裝程式一同發佈。"
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:91
-msgid ""
-"All add-ons hosted in our gallery must now be reviewed by an\n"
-"                             editor. If you wish to continue hosting your add-on, please\n"
-"                             click to select a review process."
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:79
+msgid "All add-ons hosted in our gallery must now be reviewed by an editor. If you wish to continue hosting your add-on, please click to select a review process."
 msgstr "所有交由本網站代管的附加元件自現在起皆須由編輯進行審核。若您想繼續交由本站管理，請點擊選擇審核方式。"
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:113
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:100
 msgid "Current Version:"
 msgstr "目前版本:"
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:115
-msgid ""
-"This is the version of your add-on that will\n"
-"                                           be installed if someone clicks the Install\n"
-"                                           button on addons.mozilla.org. It is only\n"
-"                                           relevant for listed add-ons."
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:102
+msgid "This is the version of your add-on that will be installed if someone clicks the Install button on addons.mozilla.org. It is only relevant for listed add-ons."
 msgstr "這就是當使用者在 addons.mozilla.org 上點擊安裝您的附加元件後，會下載安裝的版本。此欄位僅與公開上架的附加元件有關。"
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:123
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:110
 msgid "Created:"
 msgstr "建立於:"
 
 #. {0} is a date. dennis-ignore: E201
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:125 src/olympia/devhub/templates/devhub/includes/addon_details.html:131
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:112 src/olympia/devhub/templates/devhub/includes/addon_details.html:118
 #, python-format
 msgid "%%b %%e, %%Y"
 msgstr "%%Y-%%m-%%d"
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:136
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:123
 msgid "Next Version:"
 msgstr "下個版本:"
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:138
-msgid ""
-"This is the newest uploaded version, however\n"
-"                                           it isn’t live on the site yet."
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:125
+msgid "This is the newest uploaded version, however it isn’t live on the site yet."
 msgstr "這是最新上傳的版本，但還沒有在網站上公開發佈。"
 
-#: src/olympia/devhub/templates/devhub/includes/addon_details.html:144 src/olympia/devhub/templates/devhub/versions/list.html:30
+#: src/olympia/devhub/templates/devhub/includes/addon_details.html:130 src/olympia/devhub/templates/devhub/versions/list.html:30
 msgid "Queues are not reviewed strictly in order"
 msgstr "我們並不完全按照等待審核區之先後順序來審核"
 
@@ -6252,9 +6173,7 @@ msgid "View the blog &#9658;"
 msgstr "瀏覽部落格 &#9658;"
 
 #: src/olympia/devhub/templates/devhub/includes/license_form.html:6
-msgid ""
-"Please choose a license appropriate for the rights you grant on your source code.\n"
-"                  It is only relevant for listed add-ons."
+msgid "Please choose a license appropriate for the rights you grant on your source code. It is only relevant for listed add-ons."
 msgstr "請選擇您的原始碼要使用哪個條款釋出，此欄位僅與公開上架的附加元件有關。"
 
 #. {0} is a list of HTML tags.
@@ -6270,26 +6189,22 @@ msgstr "支援部分 HTML。"
 msgid "Remove this application"
 msgstr "移除這個應用程式"
 
-#. {0} is the maximum number of add-on categories allowed.                {1}
-#. is
+#. {0} is the maximum number of add-on categories allowed.                {1} is
 #. the application name.
 #: src/olympia/devhub/templates/devhub/includes/macros.html:70
 msgid "Select <b>up to {0}</b> {1} category for this add-on:"
 msgid_plural "Select <b>up to {0}</b> {1} categories for this add-on:"
 msgstr[0] "為這個附加元件選擇<b>最多 {0}</b> {1} 個分類："
+msgstr[1] ""
 
 #: src/olympia/devhub/templates/devhub/includes/policy_form.html:4
 msgid ""
 "Users will be required to accept the following End-User License Agreement (EULA) prior to installing your add-on. The presence of a EULA significantly affects the number of downloads an add-on "
-"receives. Please note that a EULA is not the same as a code license, such as the GPL or MPL.\n"
-"                It is only relevant for listed add-ons."
+"receives. Please note that a EULA is not the same as a code license, such as the GPL or MPL.It is only relevant for listed add-ons."
 msgstr ""
-"使用者將被在安裝您的附加元件前被要求接受下列終端使用者授權合約（EULA）。出現此合約將大幅度影響附加元件的下載數。請注意 EULA 與原始碼的 GPL 或 MPL 等授權條款不同。此欄位僅與公開上架的附加元件有關。"
 
-#: src/olympia/devhub/templates/devhub/includes/policy_form.html:21
-msgid ""
-"If your add-on transmits any data from the user's computer, a privacy policy is required that explains what data is sent and how it is used.\n"
-"                It is only relevant for listed add-ons."
+#: src/olympia/devhub/templates/devhub/includes/policy_form.html:24
+msgid "If your add-on transmits any data from the user's computer, a privacy policy is required that explains what data is sent and how it is used. It is only relevant for listed add-ons."
 msgstr "若您的附加元件會從使用者電腦傳出任何資料，將需要提供隱私權保護政策，當中解釋會傳出那些資料、這些資料會被如何使用。此欄位僅與公開上架的附加元件有關。"
 
 #: src/olympia/devhub/templates/devhub/includes/source_form_field.html:2
@@ -6458,12 +6373,8 @@ msgstr "選擇適合您的主題的分類。"
 msgid "Add some tags to describe your Theme."
 msgstr "加入有些標籤來敘述您的主題。"
 
-#: src/olympia/devhub/templates/devhub/personas/edit.html:106
-msgid ""
-"A short explanation of your theme's\n"
-"                                basic functionality that is displayed in\n"
-"                                search and browse listings, as well as at\n"
-"                                the top of your theme's details page."
+#: src/olympia/devhub/templates/devhub/personas/edit.html:106 src/olympia/devhub/templates/devhub/personas/submit.html:54
+msgid "A short explanation of your theme's basic functionality that is displayed in search and browse listings, as well as at the top of your theme's details page."
 msgstr "關於您的佈景主題的基本功能的簡短描述，會顯示在搜尋與瀏覽清單，以及佈景主題的詳細資訊頁面頂端。"
 
 #: src/olympia/devhub/templates/devhub/personas/edit.html:122 src/olympia/devhub/templates/devhub/personas/submit.html:68
@@ -6537,7 +6448,7 @@ msgid "Upon upload and form submission, the AMO Team will review your updated de
 msgstr "在您上傳設計與提交表格後，AMO團隊將審核您已更新的設計。在此期間，公眾仍可存取您現有的設計。"
 
 #: src/olympia/devhub/templates/devhub/personas/edit.html:241
-msgid "Your previously resubmitted design,  which is under pending review."
+msgid "Your previously resubmitted design, which is under pending review."
 msgstr "您先前重新送出的設計，還在審核當中。"
 
 #: src/olympia/devhub/templates/devhub/personas/edit.html:245
@@ -6605,14 +6516,6 @@ msgstr "背景圖片讓您輕易自訂 Firefox 瀏覽器的外觀。您可以在
 #: src/olympia/devhub/templates/devhub/personas/submit.html:33
 msgid "Give your Theme a name."
 msgstr "主題的名稱為"
-
-#: src/olympia/devhub/templates/devhub/personas/submit.html:54
-msgid ""
-"A short explanation of your theme's\n"
-"                                      basic functionality that is displayed in\n"
-"                                      search and browse listings, as well as at\n"
-"                                      the top of your theme's details page."
-msgstr "關於您的佈景主題的基本功能的簡短描述，會顯示在搜尋與瀏覽清單，以及佈景主題的詳細資訊頁面頂端。"
 
 #: src/olympia/devhub/templates/devhub/personas/submit.html:198
 #, python-format
@@ -6692,33 +6595,17 @@ msgstr "選擇一個不同的底部圖案"
 msgid "Files added to reviewed versions must be reviewed before they will be available for download."
 msgstr "如果您將新檔案加入至已審核通過的版本，新檔案仍需經過審核才能開放公眾下載。"
 
-#: src/olympia/devhub/templates/devhub/versions/add_file_modal.html:15
-#, python-format
-msgid ""
-"Submission of updates to unlisted add-ons for signing is currently in an open beta. Manual review may still be required for a large number of add-ons. Please <a href=\"%(url)s\" target=\"_blank"
-"\">report any bugs</a> that you encounter."
-msgstr "送出未公開上架的附加元件進行簽署的功能目前正在開放測試中。若送審的附加元件數量較多時可能還是需要進行人工審核，請<a href=\"%(url)s\" target=\"_blank\">回報任何遇到的問題</a>。"
-
-#: src/olympia/devhub/templates/devhub/versions/add_file_modal.html:35
+#: src/olympia/devhub/templates/devhub/versions/add_file_modal.html:24
 msgid "Select the target platform for this file."
 msgstr "選擇這個檔案的目標平台。"
 
-#: src/olympia/devhub/templates/devhub/versions/add_file_modal.html:46
+#: src/olympia/devhub/templates/devhub/versions/add_file_modal.html:35
 msgid "Which review type would you like to nominate for?"
 msgstr "您想要送交哪種類型的審核？"
 
-#: src/olympia/devhub/templates/devhub/versions/add_file_modal.html:51
+#: src/olympia/devhub/templates/devhub/versions/add_file_modal.html:40
 msgid "Only publish this version to my beta channel."
 msgstr "僅發佈此版本到我的 Beta 頻道。"
-
-#: src/olympia/devhub/templates/devhub/versions/add_file_modal.html:54
-#, python-format
-msgid ""
-"The behavior of the beta channel has changed to accommodate <a href=\"%(addon_signing_url)s\" target=\"_blank\">mandatory add-on signing</a>. The new process is currently in an open beta, and may "
-"change significantly in the near future. Please <a href=\"%(issues_url)s\" target=\"_blank\">report any bugs</a> that you encounter."
-msgstr ""
-"為了符合 <a href=\"%(addon_signing_url)s\" target=\"_blank\">附加元件強制簽署</a>政策，Beta 測試頻道的功能已有修改。新流程正在開放測試當中，近期內可能還會有所修改。請 <a href=\"%(issues_url)s\" "
-"target=\"_blank\">回報任何遇到的問題</a>。"
 
 #: src/olympia/devhub/templates/devhub/versions/edit.html:5
 msgid "Manage Version {0}"
@@ -6742,19 +6629,10 @@ msgstr "檔案"
 msgid "Upload Another File"
 msgstr "上傳其他檔案"
 
-#: src/olympia/devhub/templates/devhub/versions/edit.html:45
-msgid ""
-"Adjusting application information here will allow users to install your\n"
-"                          add-on even if the install manifest in the package indicates that the\n"
-"                          add-on is incompatible."
-msgstr "可在此調整應用程式資訊，將允許使用者在就算安裝資訊檔中表示附加元件不相容時仍能安裝附加元件。"
-
 #: src/olympia/devhub/templates/devhub/versions/edit.html:74
 msgid ""
-"Information about changes in this release, new features,\n"
-"                              known bugs, and other useful information specific to this\n"
-"                              release/version. This information is also shown in the\n"
-"                              Add-ons Manager when updating."
+"Information about changes in this release, new features, known bugs, and other useful information specific to this release/version. This information is also shown in the Add-ons Manager when "
+"updating."
 msgstr "這個版本有什麼新功能、已知問題、其他相關資訊。更新時，此資訊也會顯示在附加元件管理員。"
 
 #: src/olympia/devhub/templates/devhub/versions/edit.html:99
@@ -6766,10 +6644,7 @@ msgid "Notes for Reviewers"
 msgstr "審核者意見"
 
 #: src/olympia/devhub/templates/devhub/versions/edit.html:114
-msgid ""
-"Optionally, enter any information that may be useful\n"
-"                              to the Editor reviewing this add-on, such as test\n"
-"                              account information."
+msgid "Optionally, enter any information that may be useful to the Editor reviewing this add-on, such as test account information."
 msgstr "可在此選填任何編輯在審核此附加元件時可用的資訊，例如測試帳號資訊等。"
 
 #: src/olympia/devhub/templates/devhub/versions/edit.html:127
@@ -6820,6 +6695,7 @@ msgstr "編輯這個版本"
 msgid "{0} file"
 msgid_plural "{0} files"
 msgstr[0] "{0} 個檔案"
+msgstr[1] ""
 
 #: src/olympia/devhub/templates/devhub/versions/list.html:25
 msgid "0 files"
@@ -6846,7 +6722,7 @@ msgstr "送出完整審核需求"
 msgid "Request Preliminary Review"
 msgstr "送出初步審核需求"
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:80 src/olympia/devhub/templates/devhub/versions/list.html:327 src/olympia/devhub/templates/devhub/versions/list.html:350
+#: src/olympia/devhub/templates/devhub/versions/list.html:80 src/olympia/devhub/templates/devhub/versions/list.html:325 src/olympia/devhub/templates/devhub/versions/list.html:348
 msgid "Cancel Review Request"
 msgstr "取消審核要求"
 
@@ -6875,8 +6751,8 @@ msgid "Unlisted:"
 msgstr "不上架:"
 
 #: src/olympia/devhub/templates/devhub/versions/list.html:114
-msgid "Not distributed on {0}. Developers will upload new versions for signing and distribute the add-ons on their own. (beta)"
-msgstr "不在 {0} 上架。開發者將上傳新的版本進行簽署，並自行發布附加元件。（Beta 測試中）"
+msgid "Not distributed on {0}. Developers will upload new versions for signing and distribute the add-ons on their own."
+msgstr ""
 
 #: src/olympia/devhub/templates/devhub/versions/list.html:122
 msgid "Current versions"
@@ -6939,83 +6815,75 @@ msgid "<strong>Important:</strong> Once a version has been deleted, you may not 
 msgstr "<strong>重要:</strong> 黨您刪除某版本後，您將無法上傳同為該版本號的新版本。"
 
 #: src/olympia/devhub/templates/devhub/versions/list.html:230
-msgid ""
-"Deleting a version which has already been reviewed\n"
-"               may also cause a significant delay in the review of\n"
-"               your next update."
-msgstr "刪除已經通過審核的版本可能會造成您在下次更新審核時的速度變慢。"
-
-#: src/olympia/devhub/templates/devhub/versions/list.html:233
 msgid "Are you sure you wish to delete this version?"
 msgstr "您確定要刪除這個版本嗎？"
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:238
+#: src/olympia/devhub/templates/devhub/versions/list.html:235
 msgid "Delete Version"
 msgstr "刪除版本"
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:240
+#: src/olympia/devhub/templates/devhub/versions/list.html:237
 msgid "Disable Version"
 msgstr "停用版本"
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:247
+#: src/olympia/devhub/templates/devhub/versions/list.html:244
 msgid "Add a new Version"
 msgstr "新增一個新版本"
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:249
+#: src/olympia/devhub/templates/devhub/versions/list.html:246
 msgid "Add Version"
 msgstr "新增版本"
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:256 src/olympia/devhub/templates/devhub/versions/list.html:274
+#: src/olympia/devhub/templates/devhub/versions/list.html:253 src/olympia/devhub/templates/devhub/versions/list.html:279
 msgid "Hide Add-on"
 msgstr "隱藏附加元件"
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:259
+#: src/olympia/devhub/templates/devhub/versions/list.html:256
 msgid "Hiding your add-on will prevent it from appearing anywhere in our gallery and will stop users from receiving automatic updates."
 msgstr "隱藏您的附加元件將會讓該附加元件消失，使用者並將不再收到自動更新。"
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:265
+#: src/olympia/devhub/templates/devhub/versions/list.html:263
+msgid "The files awaiting review will be disabled and you will need to upload new versions."
+msgstr ""
+
+#: src/olympia/devhub/templates/devhub/versions/list.html:270
 msgid "Are you sure you wish to hide your add-on?"
 msgstr "您確定要隱藏附加元件嗎？"
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:286 src/olympia/devhub/templates/devhub/versions/list.html:315
+#: src/olympia/devhub/templates/devhub/versions/list.html:291 src/olympia/devhub/templates/devhub/versions/list.html:313
 msgid "Unlist Add-on"
 msgstr "將附加元件下架"
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:289
+#: src/olympia/devhub/templates/devhub/versions/list.html:294
 #, python-format
 msgid ""
 "Unlisting your add-on will make it (and each of its versions/files) invisible on this website. It won't show up in searches, won't have a public facing page, and won't be updated automatically for "
-"current users.  It is recommended for unlisted add-ons to provide a custom <a href=\"%(update_url)s\" target=\"_blank\">updateURL</a> in their manifest file for automatic updates."
+"current users. It is recommended for unlisted add-ons to provide a custom <a href=\"%(update_url)s\" target=\"_blank\">updateURL</a> in their manifest file for automatic updates."
 msgstr ""
 "下架附加元件後將會讓其（以及所有版本、檔案）在網站中消失。下架後將不會顯示在搜尋結果、不再擁有公開頁面，也不會對現有的使用者提供自動更新。建議您為下架的附加元件中的安裝資訊檔提供自訂的 <a href="
 "\"%(update_url)s\" target=\"_blank\">updateURL</a> 以提供自動更新功能。"
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:299
-#, python-format
-msgid "Switching add-ons to unlisted is currently in an open beta. Please <a href=\"%(url)s\" target=\"_blank\">report any bugs</a> that you encounter."
-msgstr "將附加元件切換為不上架的功能目前正在開放測試中。請<a href=\"%(url)s\" target=\"_blank\">回報任何遇到的問題</a>。"
-
-#: src/olympia/devhub/templates/devhub/versions/list.html:305
+#: src/olympia/devhub/templates/devhub/versions/list.html:303
 msgid "Unlisting an add-on is irreversible!"
 msgstr "無法復原下架附加元件！"
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:305
+#: src/olympia/devhub/templates/devhub/versions/list.html:303
 msgid "An unlisted add-on cannot be switched to be listed."
 msgstr "不上架的附加元件無法切換為上架。"
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:307
+#: src/olympia/devhub/templates/devhub/versions/list.html:305
 msgid "Are you sure you wish to unlist your add-on?"
 msgstr "您確定要下架您的附加元件嗎？"
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:330
+#: src/olympia/devhub/templates/devhub/versions/list.html:328
 msgid "Canceling your review request will leave your add-on as preliminarily reviewed."
 msgstr "取消您的附加元件審核要求，將保留初步審核狀態。"
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:335
+#: src/olympia/devhub/templates/devhub/versions/list.html:333
 msgid "Canceling your review request will mark your add-on incomplete. If you do not complete your add-on after several days by re-requesting review, it will be deleted."
 msgstr "取消您的附加元件審核要求，元件將會停留在尚未完成狀態。如果您在幾天內沒有再送出審核要求，附加元件將會被刪除。"
 
-#: src/olympia/devhub/templates/devhub/versions/list.html:343
+#: src/olympia/devhub/templates/devhub/versions/list.html:341
 msgid "Are you sure you wish to cancel your review request?"
 msgstr "您是否確定要取消審核要求？"
 
@@ -7354,19 +7222,19 @@ msgstr "附加元件，編輯器或意見"
 msgid "Search by add-on name / author email"
 msgstr "以附加元件名稱或作者電子郵件搜尋"
 
-#: src/olympia/editors/forms.py:103
+#: src/olympia/editors/forms.py:103 src/olympia/editors/forms.py:244 src/olympia/editors/forms.py:257
 msgid "yes"
 msgstr "是"
 
-#: src/olympia/editors/forms.py:104
+#: src/olympia/editors/forms.py:104 src/olympia/editors/forms.py:244 src/olympia/editors/forms.py:257
 msgid "no"
 msgstr "否"
 
-#: src/olympia/editors/forms.py:105
+#: src/olympia/editors/forms.py:105 src/olympia/editors/forms.py:245
 msgid "Admin Flag"
 msgstr "管理員標記"
 
-#: src/olympia/editors/forms.py:113
+#: src/olympia/editors/forms.py:113 src/olympia/editors/forms.py:253
 msgid "Max. Version"
 msgstr "最新版本"
 
@@ -7378,55 +7246,59 @@ msgstr "已等待的時間"
 msgid "Add-on Types"
 msgstr "附加元件類型"
 
-#: src/olympia/editors/forms.py:126 src/olympia/editors/helpers.py:267
+#: src/olympia/editors/forms.py:126 src/olympia/editors/helpers.py:279
 msgid "Platforms"
 msgstr "平台"
 
+#: src/olympia/editors/forms.py:237
+msgid "Search by add-on name / author email / guid"
+msgstr ""
+
 #. L10n: 0 = platform, 1 = filename, 2 = status message
-#: src/olympia/editors/forms.py:238
+#: src/olympia/editors/forms.py:342
 #, python-format
 msgid "<strong>%s</strong> &middot; %s &middot; %s"
 msgstr "<strong>%s</strong> &middot; %s &middot; %s"
 
-#: src/olympia/editors/forms.py:252
+#: src/olympia/editors/forms.py:356
 msgid "Comments:"
 msgstr "評論:"
 
-#: src/olympia/editors/forms.py:256
+#: src/olympia/editors/forms.py:360
 msgid "Operating systems:"
 msgstr "作業系統:"
 
-#: src/olympia/editors/forms.py:258
+#: src/olympia/editors/forms.py:362
 msgid "Applications:"
 msgstr "應用程式:"
 
-#: src/olympia/editors/forms.py:260
+#: src/olympia/editors/forms.py:364
 msgid "Notify me the next time this add-on is updated. (Subsequent updates will not generate an email)"
 msgstr "在此附加元件下次更新的時候通知我。（隨後的更新將不會發送郵件通知）"
 
-#: src/olympia/editors/forms.py:265
+#: src/olympia/editors/forms.py:369
 msgid "Clear Admin Review Flag"
 msgstr "清除管理員審核旗標"
 
-#: src/olympia/editors/forms.py:267
+#: src/olympia/editors/forms.py:371
 msgid "Clear more info requested flag"
 msgstr "清除要求更多資訊的旗標"
 
-#: src/olympia/editors/forms.py:281
+#: src/olympia/editors/forms.py:385
 msgid "Choose a canned response..."
 msgstr "選擇一個制式回覆..."
 
 #. L10n: Description of what can be searched for.
-#: src/olympia/editors/forms.py:324
+#: src/olympia/editors/forms.py:423
 msgid "theme name"
 msgstr "佈景主題名稱"
 
-#: src/olympia/editors/forms.py:350
+#: src/olympia/editors/forms.py:449
 msgid "Someone else is reviewing this theme."
 msgstr "他人正在審核此佈景主題。"
 
 #. L10n: Description of what can be searched for.
-#: src/olympia/editors/forms.py:447
+#: src/olympia/editors/forms.py:546
 msgid "app, reviewer, or comment"
 msgstr "應用程式，審核者或評論"
 
@@ -7448,236 +7320,265 @@ msgstr "被退回或未審核"
 
 # 83%
 # 100%
-#: src/olympia/editors/helpers.py:123 src/olympia/editors/helpers.py:136
+#: src/olympia/editors/helpers.py:125 src/olympia/editors/helpers.py:138
 msgid "Queue"
 msgstr "等待審核區"
 
-#: src/olympia/editors/helpers.py:124 src/olympia/editors/templates/editors/base.html:50 src/olympia/editors/templates/editors/base.html:65
+#: src/olympia/editors/helpers.py:126 src/olympia/editors/templates/editors/base.html:50 src/olympia/editors/templates/editors/base.html:65
 msgid "Pending Updates"
 msgstr "等待更新"
 
-#: src/olympia/editors/helpers.py:125 src/olympia/editors/templates/editors/base.html:48 src/olympia/editors/templates/editors/base.html:63
+#: src/olympia/editors/helpers.py:127 src/olympia/editors/templates/editors/base.html:48 src/olympia/editors/templates/editors/base.html:63
 msgid "Full Reviews"
 msgstr "完整審核"
 
-#: src/olympia/editors/helpers.py:126 src/olympia/editors/templates/editors/base.html:52 src/olympia/editors/templates/editors/base.html:67
+#: src/olympia/editors/helpers.py:128 src/olympia/editors/templates/editors/base.html:52 src/olympia/editors/templates/editors/base.html:67
 msgid "Preliminary Reviews"
 msgstr "初步審核"
 
-#: src/olympia/editors/helpers.py:127 src/olympia/editors/templates/editors/base.html:54
+#: src/olympia/editors/helpers.py:129 src/olympia/editors/templates/editors/base.html:54
 msgid "Moderated Reviews"
 msgstr "有問題的評論"
 
-#: src/olympia/editors/helpers.py:128 src/olympia/editors/templates/editors/base.html:46
+#: src/olympia/editors/helpers.py:130 src/olympia/editors/templates/editors/base.html:46
 msgid "Fast Track"
 msgstr "快速審核"
 
-#: src/olympia/editors/helpers.py:130
+#: src/olympia/editors/helpers.py:132
 msgid "Pending Themes"
 msgstr "審核中的佈景主題"
 
-#: src/olympia/editors/helpers.py:131 src/olympia/editors/templates/editors/themes/queue.html:4
+#: src/olympia/editors/helpers.py:133 src/olympia/editors/templates/editors/themes/queue.html:4
 msgid "Flagged Themes"
 msgstr "已標記的佈景主題"
 
-#: src/olympia/editors/helpers.py:132
+#: src/olympia/editors/helpers.py:134
 msgid "Update Themes"
 msgstr "佈景主題更新"
 
-#: src/olympia/editors/helpers.py:137
+#: src/olympia/editors/helpers.py:139
 msgid "Unlisted Pending Updates"
 msgstr "未上架的準備中更新"
 
-#: src/olympia/editors/helpers.py:138
+#: src/olympia/editors/helpers.py:140
 msgid "Unlisted Full Reviews"
 msgstr "未上架的完整審查"
 
-#: src/olympia/editors/helpers.py:139
+#: src/olympia/editors/helpers.py:141
 msgid "Unlisted Preliminary Reviews"
 msgstr "未上架的初步審查"
 
-#: src/olympia/editors/helpers.py:170
+#: src/olympia/editors/helpers.py:142
+msgid "Unlisted All Add-ons"
+msgstr ""
+
+#: src/olympia/editors/helpers.py:173
 msgid "Fast Track ({0})"
 msgid_plural "Fast Track ({0})"
 msgstr[0] "快速審核 ({0})"
+msgstr[1] ""
 
-#: src/olympia/editors/helpers.py:175
+#: src/olympia/editors/helpers.py:178
 msgid "Full Review ({0})"
 msgid_plural "Full Reviews ({0})"
 msgstr[0] "完整審核 ({0})"
+msgstr[1] ""
 
-#: src/olympia/editors/helpers.py:180
+#: src/olympia/editors/helpers.py:183
 msgid "Pending Update ({0})"
 msgid_plural "Pending Updates ({0})"
 msgstr[0] "等待更新 ({0})"
+msgstr[1] ""
 
-#: src/olympia/editors/helpers.py:185
+#: src/olympia/editors/helpers.py:188
 msgid "Preliminary Review ({0})"
 msgid_plural "Preliminary Reviews ({0})"
 msgstr[0] "初步審核 ({0})"
+msgstr[1] ""
 
-#: src/olympia/editors/helpers.py:190
+#: src/olympia/editors/helpers.py:193
 msgid "Moderated Review ({0})"
 msgid_plural "Moderated Reviews ({0})"
 msgstr[0] "有問題的評論 ({0})"
+msgstr[1] ""
 
-#: src/olympia/editors/helpers.py:196
+#: src/olympia/editors/helpers.py:199
 msgid "Unlisted Full Review ({0})"
 msgid_plural "Unlisted Full Reviews ({0})"
 msgstr[0] "未上架的完整審查 ({0})"
+msgstr[1] ""
 
-#: src/olympia/editors/helpers.py:201
+#: src/olympia/editors/helpers.py:204
 msgid "Unlisted Pending Update ({0})"
 msgid_plural "Unlisted Pending Updates ({0})"
 msgstr[0] "未上架的準備中更新 ({0})"
+msgstr[1] ""
 
-#: src/olympia/editors/helpers.py:206
+#: src/olympia/editors/helpers.py:209
 msgid "Unlisted Preliminary Review ({0})"
 msgid_plural "Unlisted Preliminary Reviews ({0})"
 msgstr[0] "未上架的準備中審查 ({0})"
+msgstr[1] ""
 
-#: src/olympia/editors/helpers.py:261
-msgid "Addon"
-msgstr "附加元件"
+#: src/olympia/editors/helpers.py:214
+msgid "Unlisted All Add-ons ({0})"
+msgid_plural "Unlisted All Add-ons ({0})"
+msgstr[0] ""
+msgstr[1] ""
 
-#: src/olympia/editors/helpers.py:262
+#: src/olympia/editors/helpers.py:274
 msgid "Type"
 msgstr "類型"
 
-#: src/olympia/editors/helpers.py:263
+#: src/olympia/editors/helpers.py:275
 msgid "Waiting Time"
 msgstr "等待時間"
 
-#: src/olympia/editors/helpers.py:264 src/olympia/editors/templates/editors/review.html:285
+#: src/olympia/editors/helpers.py:276 src/olympia/editors/templates/editors/review.html:285
 msgid "Flags"
 msgstr "標記"
 
-#: src/olympia/editors/helpers.py:265
+#: src/olympia/editors/helpers.py:277
 msgid "Applications"
 msgstr "應用程式"
 
-#: src/olympia/editors/helpers.py:270
+#: src/olympia/editors/helpers.py:282
 msgid "Additional"
 msgstr "額外資訊"
 
-#: src/olympia/editors/helpers.py:285
+#: src/olympia/editors/helpers.py:302
 msgid "Site Specific"
 msgstr "特定網站"
 
-#: src/olympia/editors/helpers.py:287
+#: src/olympia/editors/helpers.py:304
 msgid "Requires External Software"
 msgstr "需要外部的軟體"
 
-#: src/olympia/editors/helpers.py:289
+#: src/olympia/editors/helpers.py:306
 msgid "Binary Components"
 msgstr "可執行元件"
 
-#: src/olympia/editors/helpers.py:313
+#: src/olympia/editors/helpers.py:339
 msgid "moments ago"
 msgstr "不久前"
 
 #. L10n: first argument is number of minutes
-#: src/olympia/editors/helpers.py:316
+#: src/olympia/editors/helpers.py:342
 msgid "{0} minute"
 msgid_plural "{0} minutes"
 msgstr[0] "{0} 分鐘"
+msgstr[1] ""
 
 #. L10n: first argument is number of hours
-#: src/olympia/editors/helpers.py:320
+#: src/olympia/editors/helpers.py:346
 msgid "{0} hour"
 msgid_plural "{0} hours"
 msgstr[0] "{0} 小時"
+msgstr[1] ""
 
 #. L10n: first argument is number of days
-#: src/olympia/editors/helpers.py:324
+#: src/olympia/editors/helpers.py:350
 msgid "{0} day"
 msgid_plural "{0} days"
 msgstr[0] "{0} 天"
+msgstr[1] ""
 
-#: src/olympia/editors/helpers.py:488
+#: src/olympia/editors/helpers.py:364
+msgid "Last Review"
+msgstr ""
+
+#: src/olympia/editors/helpers.py:366
+msgid "Last Update"
+msgstr ""
+
+#: src/olympia/editors/helpers.py:387
+msgid "No Reviews"
+msgstr ""
+
+#: src/olympia/editors/helpers.py:561
 msgid "Push to public"
 msgstr "公開發佈"
 
-#: src/olympia/editors/helpers.py:490
+#: src/olympia/editors/helpers.py:563
 msgid "Grant full review"
 msgstr "通過完整審查"
 
-#: src/olympia/editors/helpers.py:505
+#: src/olympia/editors/helpers.py:578
 msgid "Request more information"
 msgstr "要求更多資訊"
 
-#: src/olympia/editors/helpers.py:508
+#: src/olympia/editors/helpers.py:581
 msgid "Request super-review"
 msgstr "要求超級審核"
 
-#: src/olympia/editors/helpers.py:519
+#: src/olympia/editors/helpers.py:592
 msgid "Grant preliminary review"
 msgstr "通過初步審核"
 
-#: src/olympia/editors/helpers.py:520
+#: src/olympia/editors/helpers.py:593
 msgid "This will mark the files as preliminarily reviewed."
 msgstr "這會將檔案標示為已通過初步審核。"
 
-#: src/olympia/editors/helpers.py:522
+#: src/olympia/editors/helpers.py:595
 msgid "Use this form to request more information from the author. They will receive an email and be able to answer here. You will be notified by email when they reply."
 msgstr "使用此表格向開發者要求更多資訊。他們會收到電子郵件通知而且能夠在此回覆。當開發者回覆時您會收到通知。"
 
-#: src/olympia/editors/helpers.py:526
+#: src/olympia/editors/helpers.py:599
 msgid ""
 "If you have concerns about this add-on's security, copyright issues, or other concerns that an administrator should look into, enter your comments in the area below. They will be sent to "
 "administrators, not the author."
 msgstr "如果您認為此附加元件可能有安全性或著作權爭議的問題，或其他需要管理員調查的事項，請在此區域輸入您的意見。意見將會傳送至管理員，不會傳送至開發者。"
 
-#: src/olympia/editors/helpers.py:532
+#: src/olympia/editors/helpers.py:605
 msgid "This will reject the add-on and remove it from the review queue."
 msgstr "這將會退回附加元件並從等待審核區移除。"
 
-#: src/olympia/editors/helpers.py:534
-msgid "Make a comment on this version.  The author won't be able to see this."
+#: src/olympia/editors/helpers.py:607
+msgid "Make a comment on this version. The author won't be able to see this."
 msgstr "為此版本加上留言，作者不會看到。"
 
-#: src/olympia/editors/helpers.py:538
+#: src/olympia/editors/helpers.py:611
 msgid "This will reject the files and remove them from the review queue."
 msgstr "這將會退回檔案並從等待審核區移除。"
 
-#: src/olympia/editors/helpers.py:542
+#: src/olympia/editors/helpers.py:615
 msgid "This will mark the add-on as preliminarily reviewed. Future versions will undergo preliminary review."
 msgstr "這將會把附加元件標示為已經過初步審核。未來版本將將會進行初步審核。"
 
-#: src/olympia/editors/helpers.py:547
+#: src/olympia/editors/helpers.py:620
 msgid "This will mark the files as preliminarily reviewed. Future versions will undergo preliminary review."
 msgstr "這會標記檔案為通過初步審核。未來的版本將會進行初步審核。"
 
-#: src/olympia/editors/helpers.py:552
+#: src/olympia/editors/helpers.py:625
 msgid "Retain preliminary review"
 msgstr "保留初步審核"
 
-#: src/olympia/editors/helpers.py:553
+#: src/olympia/editors/helpers.py:626
 msgid "This will retain the add-on as preliminarily reviewed. Future versions will undergo preliminary review."
 msgstr "這當會把附加元件保持為通過初步審核。未來的版本將會進行初步審核。"
 
-#: src/olympia/editors/helpers.py:558
+#: src/olympia/editors/helpers.py:631
 msgid "This will approve a sandboxed version of a public add-on to appear on the public side."
 msgstr "這將會於公開處先通過一個公開附加元件的沙盒版本。"
 
-#: src/olympia/editors/helpers.py:561
+#: src/olympia/editors/helpers.py:634
 msgid "This will reject a version of a public add-on and remove it from the queue."
 msgstr "這將會退回一個版本的公開附加元件，並將其從審核等待區移除。"
 
-#: src/olympia/editors/helpers.py:564
+#: src/olympia/editors/helpers.py:637
 msgid "This will mark the add-on and its most recent version and files as public. Future versions will go into the sandbox until they are reviewed by an editor."
 msgstr "這將會把附加元件與其最新的版本標示為公開。未來的版本在被審核者審核之前將會先被放到沙盒之中。"
 
-#: src/olympia/editors/helpers.py:637
+#: src/olympia/editors/helpers.py:714
 msgid "add-on"
 msgstr "附加元件"
 
-#: src/olympia/editors/helpers.py:940 src/olympia/editors/helpers.py:960
+#: src/olympia/editors/helpers.py:1020 src/olympia/editors/helpers.py:1040
 msgid "Flagged"
 msgstr "已標記"
 
 # 85%
-#: src/olympia/editors/helpers.py:944 src/olympia/editors/helpers.py:963
+#: src/olympia/editors/helpers.py:1024 src/olympia/editors/helpers.py:1043
 msgid "Updates"
 msgstr "更新"
 
@@ -7729,60 +7630,60 @@ msgstr "佈景主題提交被標記以供審核"
 msgid "A question about your Theme submission"
 msgstr "關於您送出佈景主題的問題"
 
-#: src/olympia/editors/views.py:144
+#: src/olympia/editors/views.py:146
 msgid "New Add-ons (Under 5 days)"
 msgstr "新的附加元件 (五天內)"
 
-#: src/olympia/editors/views.py:145
+#: src/olympia/editors/views.py:147
 msgid "Passable (5 to 10 days)"
 msgstr "可通過 (五至十天)"
 
-#: src/olympia/editors/views.py:146
+#: src/olympia/editors/views.py:148
 msgid "Overdue (Over 10 days)"
 msgstr "逾期 (超過十天)"
 
-#: src/olympia/editors/views.py:532
+#: src/olympia/editors/views.py:539
 msgid "An unknown error occurred"
 msgstr "發生了未知的錯誤"
 
-#: src/olympia/editors/views.py:587
+#: src/olympia/editors/views.py:592
 msgid "Self-reviews are not allowed."
 msgstr "不允許自我審核。"
 
-#: src/olympia/editors/views.py:609
+#: src/olympia/editors/views.py:613
 msgid "Review successfully processed."
 msgstr "審核流程已順利開始。"
 
-#: src/olympia/editors/views.py:807
+#: src/olympia/editors/views.py:812
 msgid "was approved"
 msgstr "已經審核通過"
 
 # 80%
 # 100%
-#: src/olympia/editors/views.py:808
+#: src/olympia/editors/views.py:813
 msgid "given preliminary review"
 msgstr "給予初步審核"
 
-#: src/olympia/editors/views.py:809
+#: src/olympia/editors/views.py:814
 msgid "rejected"
 msgstr "已退回"
 
-#: src/olympia/editors/views.py:810
+#: src/olympia/editors/views.py:815
 msgctxt "editors_review_history_nominated_adminreview"
 msgid "escalated"
 msgstr "已提升審核層級"
 
 # 79%
 # 100%
-#: src/olympia/editors/views.py:812
+#: src/olympia/editors/views.py:817
 msgid "needs more information"
 msgstr "需要更多資訊"
 
-#: src/olympia/editors/views.py:813
+#: src/olympia/editors/views.py:818
 msgid "needs super review"
 msgstr "需要超級審核"
 
-#: src/olympia/editors/views.py:814
+#: src/olympia/editors/views.py:819
 msgid "commented"
 msgstr "已留言"
 
@@ -7790,6 +7691,7 @@ msgstr "已留言"
 msgid "{0} theme review successfully processed (+{1} points, {2} total)."
 msgid_plural "{0} theme reviews successfully processed (+{1} points, {2} total)."
 msgstr[0] "{0} 佈景主題審查成功（+{1} 點數，共 {2} 點）。"
+msgstr[1] ""
 
 #: src/olympia/editors/views_themes.py:341
 msgid "Your theme locks have successfully been released. Other reviewers may now review those released themes. You may have to refresh the page to see the changes reflected in the table below."
@@ -7826,28 +7728,28 @@ msgstr "審核等待區"
 msgid "Unlisted Queues"
 msgstr "未上架佇列"
 
-#: src/olympia/editors/templates/editors/base.html:72 src/olympia/editors/templates/editors/performance.html:6
+#: src/olympia/editors/templates/editors/base.html:74 src/olympia/editors/templates/editors/performance.html:6
 msgid "Performance"
 msgstr "效能"
 
-#: src/olympia/editors/templates/editors/base.html:75 src/olympia/editors/templates/editors/themes/base.html:19 src/olympia/editors/templates/editors/themes/base.html:38
+#: src/olympia/editors/templates/editors/base.html:77 src/olympia/editors/templates/editors/themes/base.html:19 src/olympia/editors/templates/editors/themes/base.html:38
 msgid "Logs"
 msgstr "歷史記錄"
 
-#: src/olympia/editors/templates/editors/base.html:78 src/olympia/editors/templates/editors/reviewlog.html:4 src/olympia/editors/templates/editors/reviewlog.html:27
+#: src/olympia/editors/templates/editors/base.html:80 src/olympia/editors/templates/editors/reviewlog.html:4 src/olympia/editors/templates/editors/reviewlog.html:27
 msgid "Add-on Review Log"
 msgstr "附加元件審核紀錄"
 
-#: src/olympia/editors/templates/editors/base.html:80 src/olympia/editors/templates/editors/eventlog.html:4 src/olympia/editors/templates/editors/eventlog.html:8
+#: src/olympia/editors/templates/editors/base.html:82 src/olympia/editors/templates/editors/eventlog.html:4 src/olympia/editors/templates/editors/eventlog.html:8
 #: src/olympia/editors/templates/editors/eventlog_detail.html:4
 msgid "Moderated Review Log"
 msgstr "有問題的評論之紀錄"
 
-#: src/olympia/editors/templates/editors/base.html:82 src/olympia/editors/templates/editors/beta_signed_log.html:4 src/olympia/editors/templates/editors/beta_signed_log.html:8
+#: src/olympia/editors/templates/editors/base.html:84 src/olympia/editors/templates/editors/beta_signed_log.html:4 src/olympia/editors/templates/editors/beta_signed_log.html:8
 msgid "Signed Beta Files Log"
 msgstr "簽署的 Beta 檔案紀錄"
 
-#: src/olympia/editors/templates/editors/base.html:87 src/olympia/editors/templates/editors/includes/daily-message.html:4
+#: src/olympia/editors/templates/editors/base.html:89 src/olympia/editors/templates/editors/includes/daily-message.html:4
 msgid "Announcement"
 msgstr "消息"
 
@@ -7909,18 +7811,21 @@ msgstr "反刪除"
 msgid "Full Review ({num})"
 msgid_plural "Full Reviews ({num})"
 msgstr[0] "完整審核 ({num})"
+msgstr[1] ""
 
 # 86%
 #: src/olympia/editors/templates/editors/home.html:18
 msgid "Pending Update ({num})"
 msgid_plural "Pending Updates ({num})"
 msgstr[0] "等待更新 ({num})"
+msgstr[1] ""
 
 # 88%
 #: src/olympia/editors/templates/editors/home.html:25
 msgid "Preliminary Review ({num})"
 msgid_plural "Preliminary Reviews ({num})"
 msgstr[0] "初步審核 ({num})"
+msgstr[1] ""
 
 #: src/olympia/editors/templates/editors/home.html:36 src/olympia/editors/templates/editors/home.html:86
 msgid "Current waiting times:"
@@ -7930,6 +7835,7 @@ msgstr "目前等待時間:"
 msgid "{0} add-on"
 msgid_plural "{0} add-ons"
 msgstr[0] "{0} 個附加元件"
+msgstr[1] ""
 
 #: src/olympia/editors/templates/editors/home.html:45 src/olympia/editors/templates/editors/home.html:95
 #, python-format
@@ -7940,16 +7846,19 @@ msgstr "{0}%%"
 msgid "Unlisted Full Review ({num})"
 msgid_plural "Unlisted Full Reviews ({num})"
 msgstr[0] "未上架的完整審查 ({num})"
+msgstr[1] ""
 
 #: src/olympia/editors/templates/editors/home.html:68
 msgid "Unlisted Pending Update ({num})"
 msgid_plural "Unlisted Pending Updates ({num})"
 msgstr[0] "未上架的準備中更新 ({num})"
+msgstr[1] ""
 
 #: src/olympia/editors/templates/editors/home.html:75
 msgid "Unlisted Preliminary Review ({num})"
 msgid_plural "Unlisted Preliminary Reviews ({num})"
 msgstr[0] "未上架的初步審查 ({num})"
+msgstr[1] ""
 
 #: src/olympia/editors/templates/editors/home.html:109 src/olympia/editors/templates/editors/performance.html:37 src/olympia/editors/templates/editors/themes/home.html:54
 msgid "Total Reviews"
@@ -7972,6 +7881,7 @@ msgstr "您是 #{0}，共 {1} 條評論"
 msgid "Moderated Review ({num})"
 msgid_plural "Moderated Reviews ({num})"
 msgstr[0] "有問題的評論 ({num})篇"
+msgstr[1] ""
 
 #: src/olympia/editors/templates/editors/leaderboard.html:3 src/olympia/editors/templates/editors/includes/reviewers_score_bar.html:56
 msgid "Reviewer Leaderboard"
@@ -8065,45 +7975,45 @@ msgstr "進階搜尋"
 msgid "clear search"
 msgstr "清除搜尋"
 
-#: src/olympia/editors/templates/editors/queue.html:72 src/olympia/editors/templates/editors/queue.html:122
+#: src/olympia/editors/templates/editors/queue.html:78 src/olympia/editors/templates/editors/queue.html:128
 msgid "Process Reviews"
 msgstr "審核處理"
 
-#: src/olympia/editors/templates/editors/queue.html:80
+#: src/olympia/editors/templates/editors/queue.html:86
 msgid "Moderation actions:"
 msgstr "管理行為"
 
-#: src/olympia/editors/templates/editors/queue.html:90
+#: src/olympia/editors/templates/editors/queue.html:96
 #, python-format
 msgid "by %(user)s on %(date)s %(stars)s (%(locale)s)"
 msgstr "由 %(user)s 於 %(date)s %(stars)s (%(locale)s)"
 
-#: src/olympia/editors/templates/editors/queue.html:106
+#: src/olympia/editors/templates/editors/queue.html:112
 #, python-format
 msgid "<strong>%(reason)s</strong> <span class=\"light\">Flagged by %(user)s on %(date)s</span>"
 msgstr "<strong>%(reason)s</strong><span class=\"light\">在 %(date)s 由 %(user)s 所標記。</span>"
 
-#: src/olympia/editors/templates/editors/queue.html:119
-msgid "All reviews have been moderated.  Good work!"
+#: src/olympia/editors/templates/editors/queue.html:125
+msgid "All reviews have been moderated. Good work!"
 msgstr "已處理所有待審項目，讚！"
 
-#: src/olympia/editors/templates/editors/queue.html:161
+#: src/olympia/editors/templates/editors/queue.html:167
 msgid "Version Notes / Notes for Reviewer"
 msgstr "版本資訊 / 給審核者的資訊"
 
-#: src/olympia/editors/templates/editors/queue.html:169
+#: src/olympia/editors/templates/editors/queue.html:175
 msgid "There are currently no add-ons of this type to review."
 msgstr "目前這個分類沒有附加元件要審核。"
 
-#: src/olympia/editors/templates/editors/queue.html:181 src/olympia/editors/templates/editors/themes/queue_list.html:85
+#: src/olympia/editors/templates/editors/queue.html:187 src/olympia/editors/templates/editors/themes/queue_list.html:85
 msgid "Helpful Links:"
 msgstr "實用連結："
 
-#: src/olympia/editors/templates/editors/queue.html:182
+#: src/olympia/editors/templates/editors/queue.html:188
 msgid "Add-on Policy"
 msgstr "附加元件政策"
 
-#: src/olympia/editors/templates/editors/queue.html:184
+#: src/olympia/editors/templates/editors/queue.html:190
 msgid "Editors' Guide"
 msgstr "編輯指南"
 
@@ -8168,10 +8078,7 @@ msgid "<strong>Warning!</strong> Another user was viewing this page before you."
 msgstr "<strong>警告！</strong> 有其他使用者在您之前檢視了此頁面。"
 
 #: src/olympia/editors/templates/editors/review.html:237
-msgid ""
-"The whiteboard is the place to exchange information relevant to\n"
-"               this addon (whatever the version), between the developer and the\n"
-"               editor. This is visible and editable by both."
+msgid "The whiteboard is the place to exchange information relevant to this addon (whatever the version), between the developer and the editor. This is visible and editable by both."
 msgstr "白板（whiteboard）是一個能夠讓開發者與編輯交換附加元件相關資訊的地方（不論版本），雙方皆可檢視與編輯。"
 
 #: src/olympia/editors/templates/editors/review.html:241
@@ -8315,16 +8222,19 @@ msgstr "目前沒有任何審核。"
 msgid "{num} Pending Theme Review"
 msgid_plural "{num} Pending Theme Reviews"
 msgstr[0] "{num} 個佈景主題正在審核中{num} 個佈景主題正在審核中"
+msgstr[1] ""
 
 #: src/olympia/editors/templates/editors/themes/home.html:27
 msgid "{num} Flagged Review"
 msgid_plural "{num} Flagged Reviews"
 msgstr[0] "{num} 個已標記的審核{num} 個已標記的審核"
+msgstr[1] ""
 
 #: src/olympia/editors/templates/editors/themes/home.html:34
 msgid "{num} Update"
 msgid_plural "{num} Updates"
 msgstr[0] "{num} 個更新{num} 個更新"
+msgstr[1] ""
 
 #: src/olympia/editors/templates/editors/themes/logs.html:4
 msgid "Theme Review Log"
@@ -8443,7 +8353,7 @@ msgstr "向作者發問"
 msgid "Describe your reason for flagging"
 msgstr "敘述您標記的理由"
 
-#: src/olympia/files/forms.py:88
+#: src/olympia/files/forms.py:90
 msgid "Cannot diff a version against itself"
 msgstr "無法判斷一個版本與其自身的差異"
 
@@ -8478,51 +8388,51 @@ msgstr "在存取檔案 %s 時發生錯誤。%s。"
 msgid "There was an error accessing file %s."
 msgstr "存取檔案 %s 時發生錯誤。"
 
-#: src/olympia/files/utils.py:343
+#: src/olympia/files/utils.py:340
 msgid "Could not parse uploaded file."
 msgstr "無法解析已上傳的檔案。"
 
-#: src/olympia/files/utils.py:380
+#: src/olympia/files/utils.py:377
 msgid "Invalid file name in archive: {0}"
 msgstr "壓縮檔中有無效檔名: {0}"
 
-#: src/olympia/files/utils.py:388
+#: src/olympia/files/utils.py:385
 msgid "File exceeding size limit in archive: {0}"
 msgstr "壓縮檔中有超過大小限制的檔案: {0}"
 
-#: src/olympia/files/utils.py:439
+#: src/olympia/files/utils.py:436
 msgid "Invalid archive."
 msgstr "無效的封存。"
 
-#: src/olympia/files/utils.py:529 src/olympia/files/utils.py:532
+#: src/olympia/files/utils.py:526 src/olympia/files/utils.py:529
 msgid "Could not parse the manifest file."
 msgstr "無法剖析安裝資訊檔。"
 
-#: src/olympia/files/utils.py:551
+#: src/olympia/files/utils.py:548
 msgid "Could not find an add-on ID."
 msgstr "無法找到附加元件 ID。"
 
-#: src/olympia/files/utils.py:554
+#: src/olympia/files/utils.py:551
 msgid "Add-on ID must be 64 characters or less."
 msgstr "附加元件 ID 必須少於 64 字元。"
 
-#: src/olympia/files/utils.py:556
+#: src/olympia/files/utils.py:553
 msgid "Add-on ID doesn't match add-on."
 msgstr "附加元件 ID 與附加元件不符。"
 
-#: src/olympia/files/utils.py:564
+#: src/olympia/files/utils.py:561
 msgid "Duplicate add-on ID found."
 msgstr "發現重複的附加元件 ID。"
 
-#: src/olympia/files/utils.py:567
+#: src/olympia/files/utils.py:564
 msgid "Version numbers should have fewer than 32 characters."
 msgstr "版本號碼應該少於 32 個字元。"
 
-#: src/olympia/files/utils.py:570
+#: src/olympia/files/utils.py:567
 msgid "Version numbers should only contain letters, numbers, and these punctuation characters: +*.-_."
 msgstr "版本號碼只能含有英文字母、數字，以及這些標點符號: +*.-_。"
 
-#: src/olympia/files/utils.py:587
+#: src/olympia/files/utils.py:584
 msgid "<em:type> doesn't match add-on"
 msgstr "<em:type> 與附加元件不相符"
 
@@ -8625,6 +8535,10 @@ msgstr "上傳的檔案當中沒有檔案。"
 #: src/olympia/files/templates/files/viewer.html:134
 msgid "Fetching file."
 msgstr "正在取得檔案。"
+
+#: src/olympia/legacy_api/views.py:255
+msgid "Not implemented yet."
+msgstr "尚未實作。"
 
 #: src/olympia/lib/constants.py:6
 msgid "United Arab Emirates Dirham"
@@ -9282,10 +9196,6 @@ msgstr "尚比亞克瓦查"
 msgid "Zimbabwe Dollar"
 msgstr "辛巴威元"
 
-#: src/olympia/lib/video/ffmpeg.py:112 src/olympia/lib/video/totem.py:81
-msgid "Videos must be in WebM."
-msgstr "影片必須使用 WebM 格式。"
-
 #: src/olympia/pages/templates/pages/about.lhtml:3 src/olympia/pages/templates/pages/about.lhtml:10
 msgid "About Mozilla Add-ons"
 msgstr "關於 Mozilla 附加元件站"
@@ -9297,7 +9207,7 @@ msgstr "這是什麼網站？"
 #: src/olympia/pages/templates/pages/about.lhtml:13
 msgid ""
 "addons.mozilla.org, commonly known as \"AMO\", is Mozilla's official site for add-ons to Mozilla software, such as Firefox, Thunderbird, and SeaMonkey. Add-ons let you add new features and change "
-"the way your browser or application works.  Take a look around and explore the thousands of ways to customize the way you do things online."
+"the way your browser or application works. Take a look around and explore the thousands of ways to customize the way you do things online."
 msgstr ""
 "addons.mozilla.org，通常稱為「AMO」，是 Mozilla 產品，例如 Firefox、Thunderbird、SeaMonkey 等等的官方附加元件網站。附加元件可讓您新增功能或修改瀏覽器與應用程式的運作方式。歡迎隨處看看，探索數以千計"
 "的不同上網方式。"
@@ -9656,7 +9566,7 @@ msgstr "我可以使用像是 jQuery、MooTools 或 Prototype 等 JavaScript 程
 msgid ""
 "Yes. It's possible, but some of the functionality provided by these libraries are available through XPCOM, XUL, and JavaScript. In addition, authors should take care if libraries modify primitive "
 "object prototypes (String.prototype, Date.prototype, etc.) and/or define global functions (eg. the $ function). These are prone to cause conflict with other add-ons, in particular if different add-"
-"ons use different versions of libraries and so on. Developers need to be very, very careful with using them.  Mozilla does not offer documentation on using them to build add-ons."
+"ons use different versions of libraries and so on. Developers need to be very, very careful with using them. Mozilla does not offer documentation on using them to build add-ons."
 msgstr ""
 "是，可以。但這些程式庫需透過 XPCOM、XUL 及 JavaScript 才能提供某些功能。此外，作者應該注意程式庫是否會修改到原始物件原型（String.prototype, Date.prototype 等等）或定義全域函數（例如 $ 函數）。這些行"
 "為很容易會與其他附加元件相衝突，尤其是當不同附加元件使用了不同版本的函示庫的時候。開發者使用時請一定要很小心、很小心、很小心。Mozilla 不提供關於如何使用這些工具開發附加元件的相關文件。"
@@ -9778,8 +9688,8 @@ msgstr "我可以自己 host 我的附加元件嗎？"
 #, python-format
 msgid ""
 "Yes. Many developers choose to host their own add-ons. Choosing to host your add-on on <a href=\"%(amo_url)s\">Mozilla's add-on site</a>, though, allows for much greater exposure to your add-on due "
-"to the large volume of visitors to the site.  <a href=\"%(md_url)s\">mozdev.org</a> offers free project hosting for Mozilla applications and extensions providing developers with tools to help "
-"manage source code, version control, bug tracking and documentation."
+"to the large volume of visitors to the site. <a href=\"%(md_url)s\">mozdev.org</a> offers free project hosting for Mozilla applications and extensions providing developers with tools to help manage "
+"source code, version control, bug tracking and documentation."
 msgstr ""
 "可以。許多開發者選擇自行提供附加元件下載。但由於有大量的使用者會前往 AMO 瀏覽，若選擇將附加元件交由 <a href=\"%(amo_url)s\">Mozilla 的附加元件站</a> 將能夠有較大的曝光率。<a href=\"%(md_url)s"
 "\">mozdev.org</a> 亦為 Mozilla 相關應用程式及擴充套件提供免費的專案代管，並提供開發者工具以幫助管理程式碼、版本控制、問題追蹤及開發文件等。"
@@ -9831,7 +9741,7 @@ msgstr "Mozilla 有任何關於可接受的提交的標準政策嗎？"
 #: src/olympia/pages/templates/pages/dev_faq.html:314
 #, python-format
 msgid ""
-"Yes. Mozilla's <a href=\"%(p_url)s\">Add-on Policy</a> describes what is an acceptable submission. This policy is subject to change without notice.  In addition, the AMO editorial team uses the <a "
+"Yes. Mozilla's <a href=\"%(p_url)s\">Add-on Policy</a> describes what is an acceptable submission. This policy is subject to change without notice. In addition, the AMO editorial team uses the <a "
 "href=\"%(g_url)s\">Editors Reviewing Guide</a> to ensure that your add-on meets specific guidelines for functionality and security."
 msgstr ""
 "是的。Mozilla 的 <a href=\"%(p_url)s\">附加元件政策</a> 當中描述了什麼是可接受的提交。此政策可能會隨時修訂，不另行公告。此外，AMO 團隊將使用 <a href=\"%(g_url)s\">編輯審核指南</a> 以確保您附加元件的"
@@ -9956,7 +9866,7 @@ msgstr "找到的問題數量"
 #: src/olympia/pages/templates/pages/dev_faq.html:434
 #, python-format
 msgid ""
-"This is why it's very important to read the <a href=\"%(g_url)s\">Editors Reviewing Guide</a> to ensure that your add-on is setup as expected.  It's also a good idea to read the blog post, <a href="
+"This is why it's very important to read the <a href=\"%(g_url)s\">Editors Reviewing Guide</a> to ensure that your add-on is setup as expected. It's also a good idea to read the blog post, <a href="
 "\"%(blog_url)s\">Successfully Getting your Add-on Reviewed</a> which provides excellent insight into ensuring a smooth review of your add-on."
 msgstr ""
 "這就是為什麼要先閱讀 <a href=\"%(g_url)s\">編輯審核指南</a> 相當重要，如此才能確保附加元件如預期地設定。閱讀 <a href=\"%(blog_url)s\">Successfully Getting your Add-on Reviewed</a> 這篇部落格文章也是"
@@ -10067,7 +9977,7 @@ msgstr "這個表格總結以及比較主要的開源授權規定的散佈、軟
 
 #: src/olympia/pages/templates/pages/dev_faq.html:572
 msgid ""
-"Free Software Foundation provides short summaries of the key open source licenses, including whether the license qualifies as a free software license or a copyleft license.  Also includes a "
+"Free Software Foundation provides short summaries of the key open source licenses, including whether the license qualifies as a free software license or a copyleft license. Also includes a "
 "discussion of what constitutes a free software license or a copyleft license (e.g., a Copyleft license is a general method for making a program or other work free, and requiring all modified and "
 "extended versions of the program to be free as well.)"
 msgstr ""
@@ -10266,19 +10176,13 @@ msgid "Add-on Gallery"
 msgstr "附加元件藝廊"
 
 #: src/olympia/pages/templates/pages/faq.html:171
-msgid ""
-"How do I choose between add-ons that seem to do the same\n"
-"    thing?"
+msgid "How do I choose between add-ons that seem to do the same thing?"
 msgstr "我要如何在有相同功能的附加元件間做選擇？"
 
-#: src/olympia/pages/templates/pages/faq.html:173
+#: src/olympia/pages/templates/pages/faq.html:172
 msgid ""
-"There are often several add-ons that have similar features. To\n"
-"    figure out which is right for you, read the entire description of the\n"
-"    add-on and view its screenshots. If there are still several in the running,\n"
-"    read through the add-on's ratings, user reviews, and statistics to see\n"
-"    which is most liked by other users. Remember that you can also just try\n"
-"    out both and see which you like better."
+"There are often several add-ons that have similar features. To figure out which is right for you, read the entire description of the add-on and view its screenshots. If there are still several in "
+"the running, read through the add-on's ratings, user reviews, and statistics to see which is most liked by other users. Remember that you can also just try out both and see which you like better."
 msgstr ""
 "常常會有許多附加元件提供類似的功能。若要找出哪一套才是最適合您的，請閱讀附加元件的描述並看看畫面擷圖。若還是有很幾套無法決定，請閱讀附加元件的評分、使用者留言及統計資訊以了解其他使用者最喜歡哪套附加"
 "元件。請記住您也可以每套都試試看再決定您最喜歡哪套。"
@@ -10325,80 +10229,67 @@ msgid "How much do add-ons cost to purchase?"
 msgstr "我需要花多少錢購買附加元件？"
 
 #: src/olympia/pages/templates/pages/faq.html:207
-msgid ""
-"Add-ons hosted in our gallery are free unless clearly marked\n"
-"    otherwise."
+msgid "Add-ons hosted in our gallery are free unless clearly marked otherwise."
 msgstr "除非有另外標示，我們網站上代管的附加元件都是免費的。"
 
-#: src/olympia/pages/templates/pages/faq.html:210
+#: src/olympia/pages/templates/pages/faq.html:209
 msgid "What does it mean when an add-on asks for contributions?"
 msgstr "附加元件的捐款請求是什麼？"
 
-#: src/olympia/pages/templates/pages/faq.html:211
+#: src/olympia/pages/templates/pages/faq.html:210
 msgid ""
-"Some add-on authors request users who enjoy an add-on to\n"
-"        contribute to its development by making a monetary contribution. These\n"
-"        contributions go directly to the developer unless a third party is\n"
-"        indicated, such as the non-profit Mozilla Foundation."
+"Some add-on authors request users who enjoy an add-on to contribute to its development by making a monetary contribution. These contributions go directly to the developer unless a third party is "
+"indicated, such as the non-profit Mozilla Foundation."
 msgstr "某些附加元件的作者希望喜歡他們的附加元件的使用者可以捐款，以幫助附加元件的開發。除非另外寫明，這些捐款將直接、完全提供給開發者。"
 
-#: src/olympia/pages/templates/pages/faq.html:216
+#: src/olympia/pages/templates/pages/faq.html:215
 msgid "What are beta add-ons?"
 msgstr "測試版附加元件是什麼？"
 
-#: src/olympia/pages/templates/pages/faq.html:218
+#: src/olympia/pages/templates/pages/faq.html:217
 msgid ""
-"Beta add-ons are unreviewed versions which represent the\n"
-"        latest work of an add-on author. While different authors have different\n"
-"        standards for beta code quality, you should assume that these add-ons\n"
-"        are less stable than the general add-on releases."
+"Beta add-ons are unreviewed versions which represent the latest work of an add-on author. While different authors have different standards for beta code quality, you should assume that these add-"
+"ons are less stable than the general add-on releases."
 msgstr "Beta 測試版的附加元件是尚未經過審核的版本，代表附加元件作者推出的最新版本。不同作者對於「測試版」的程式碼品質定義可能不同，您應該假設這些附加元件會比正式版本較不穩定。"
 
-#: src/olympia/pages/templates/pages/faq.html:222
+#: src/olympia/pages/templates/pages/faq.html:221
 msgid ""
 "Please note that when you install an add-on from the \"Beta Version\" section of an add-on's listing, you will continue to receive updates for that add-on as they become available. Like the initial "
 "version you installed, all beta releases are unreviewed by Mozilla and may harm your computer."
 msgstr "請注意，當您在「測試版本」區域安裝了附加元件之後，將會持續收到更新通知，直到附加元件脫離測試狀態為止。所有測試版本皆未通過 Mozilla 的審核，有可能會傷害您的電腦。"
 
-#: src/olympia/pages/templates/pages/faq.html:229
-msgid ""
-"What does it mean when an add-on is flagged as\n"
-"    slow?"
+#: src/olympia/pages/templates/pages/faq.html:228
+msgid "What does it mean when an add-on is flagged as slow?"
 msgstr "附加元件被標示為「緩慢」是什麼意思？"
 
-#: src/olympia/pages/templates/pages/faq.html:231
-msgid ""
-"Most add-ons load code and resources at the same time Firefox\n"
-"        is starting up. In most cases the impact in start-up time is minimal,\n"
-"        but some add-ons can cause a noticeable slowdown."
+#: src/olympia/pages/templates/pages/faq.html:229
+msgid "Most add-ons load code and resources at the same time Firefox is starting up. In most cases the impact in start-up time is minimal, but some add-ons can cause a noticeable slowdown."
 msgstr "大部分附加元件都會在 Firefox 啟動時載入程式碼與資源。大部分情況下對啟動時間的影響不大，但某些原件還是會讓您注意到載入變慢了。"
 
-#: src/olympia/pages/templates/pages/faq.html:236
+#: src/olympia/pages/templates/pages/faq.html:234
 msgid "How do I report an inappropriate or spam user review?"
 msgstr "我要如何回報不適當的使用者評論？"
 
-#: src/olympia/pages/templates/pages/faq.html:237
+#: src/olympia/pages/templates/pages/faq.html:235
 msgid ""
-"To report a user review of an add-on, log in with your account\n"
-"    and visit the add-on's reviews page. Find the review you wish to report,\n"
-"    click \"Report this review\" and select a reason. Our editorial team will\n"
-"    investigate the review and take appropriate action."
+"To report a user review of an add-on, log in with your account and visit the add-on's reviews page. Find the review you wish to report, click \"Report this review\" and select a reason. Our "
+"editorial team will investigate the review and take appropriate action."
 msgstr "若要回報使用者對附加元件的評論，請登入您的帳號並前往附加元件的評論頁面，找到您想要回報的評論項目，然後點擊「回報此評論」然後選擇原因。我們的編輯團隊將調查該評論並做出適當的反應。"
 
-#: src/olympia/pages/templates/pages/faq.html:242
+#: src/olympia/pages/templates/pages/faq.html:240
 msgid "How do I report a bug or contact the Mozilla Add-ons team?"
 msgstr "我要如何回報問題與聯繫 Mozilla 附加元件團隊？"
 
-#: src/olympia/pages/templates/pages/faq.html:243
+#: src/olympia/pages/templates/pages/faq.html:241
 #, python-format
 msgid "Please visit our <a href=\"%(contact_url)s\">Contact page</a>."
 msgstr "請前往我們的 <a href=\"%(contact_url)s\">聯絡頁面</a>。"
 
-#: src/olympia/pages/templates/pages/faq.html:246
+#: src/olympia/pages/templates/pages/faq.html:244
 msgid "What is a Source Code License?"
 msgstr "原始碼授權條款是什麼？"
 
-#: src/olympia/pages/templates/pages/faq.html:247
+#: src/olympia/pages/templates/pages/faq.html:245
 #, python-format
 msgid ""
 "The source code used to create an add-on is an exclusive copyright of the add-on author, unless otherwise declared in a source code license. Many add-ons on this site have <a href=\"%(url)s\" lang="
@@ -10408,40 +10299,40 @@ msgstr ""
 "除非在原始碼當中有特別指定使用哪種授權方式，用來打造附加元件的原始碼是附加元件作者專屬的智慧財產。這個網站上的許多附加元件作者都使用在某些條件下讓原始碼可以公開被複製或重新使用的 <a href=\"%(url)s"
 "\" lang=\"en\">開放原始碼授權</a>。多數的作者都選擇諸如 GPL 或 BSD 等被廣泛使用的開放原始碼授權，而不自己撰寫授權條款。"
 
-#: src/olympia/pages/templates/pages/faq.html:256
+#: src/olympia/pages/templates/pages/faq.html:254
 #, python-format
 msgid "Firefox and other Mozilla software are <a href=\"%(url)s\">open source</a>."
 msgstr "Firefox 與其他 Mozilla 軟體皆為<a href=\"%(url)s\">開放原始碼</a>。"
 
-#: src/olympia/pages/templates/pages/faq.html:264
+#: src/olympia/pages/templates/pages/faq.html:262
 msgid "Collections and Favorites"
 msgstr "收藏集與最愛"
 
-#: src/olympia/pages/templates/pages/faq.html:267
+#: src/olympia/pages/templates/pages/faq.html:265
 msgid "What is a collection?"
 msgstr "收藏集是什麼？"
 
-#: src/olympia/pages/templates/pages/faq.html:268
+#: src/olympia/pages/templates/pages/faq.html:266
 msgid "Collections are groups of related add-ons created by users to share."
 msgstr "收藏集是由使用者建立分享的附加元件集合。"
 
-#: src/olympia/pages/templates/pages/faq.html:270
+#: src/olympia/pages/templates/pages/faq.html:268
 msgid "What is the My Favorites collection?"
 msgstr "我最愛的收藏集是什麼？"
 
-#: src/olympia/pages/templates/pages/faq.html:271
+#: src/olympia/pages/templates/pages/faq.html:269
 msgid "Favorite add-ons are add-ons that you have bookmarked to easily get back to later. You can add an add-on to your favorites collection by clicking \"Add to favorites\" on its details page."
 msgstr "最愛的附加元件是您在書籤當中留下的一些附加元件，讓您可以在之後快速地回來。您可以在附加元件的詳細資訊頁面點下「加入至我的最愛」來新增某套附加元件到您的最愛收藏集。"
 
-#: src/olympia/pages/templates/pages/faq.html:275 src/olympia/templates/menu_links.html:13 src/olympia/templates/impala/header_title.html:17
+#: src/olympia/pages/templates/pages/faq.html:273 src/olympia/templates/menu_links.html:13 src/olympia/templates/impala/header_title.html:17
 msgid "Mobile Add-ons"
 msgstr "Mobile 附加元件"
 
-#: src/olympia/pages/templates/pages/faq.html:278
+#: src/olympia/pages/templates/pages/faq.html:276
 msgid "What are mobile add-ons?"
 msgstr "什麼是 Mobile 附加元件?"
 
-#: src/olympia/pages/templates/pages/faq.html:279
+#: src/olympia/pages/templates/pages/faq.html:277
 #, python-format
 msgid ""
 "Mobile add-ons work with <a href=\"%(mobile_url)s\">Firefox for Mobile</a> and add or modify functionality just like desktop add-ons. You can find add-ons that work with Firefox for Mobile in our "
@@ -10450,20 +10341,20 @@ msgstr ""
 "Mobile 附加元件可於 <a href=\"%(mobile_url)s\">Firefox Mobile</a>上使用，如同桌面版的附加元件一樣，可以新增或修改功能。您可以在我們的 <a href=\"%(gallery_url)s\">藝廊</a> 當中找到可於 Firefox "
 "Mobile 使用的附加元件。"
 
-#: src/olympia/pages/templates/pages/faq.html:288
+#: src/olympia/pages/templates/pages/faq.html:286
 msgid "Developer Topics"
 msgstr "開發者問題"
 
-#: src/olympia/pages/templates/pages/faq.html:289
+#: src/olympia/pages/templates/pages/faq.html:287
 #, python-format
 msgid "Please see our <a href=\"%(faq_url)s\">Developer FAQ</a> and <a href=\"%(hub_url)s\">Developer Hub</a> for answers to add-on developer-related questions."
 msgstr "更多關於附加元件開發者的相關問題，請前往我們的<a href=\"%(faq_url)s\">開發者常見問題集</a>與<a href=\"%(hub_url)s\">開發者交流中心</a>。"
 
-#: src/olympia/pages/templates/pages/faq.html:294
+#: src/olympia/pages/templates/pages/faq.html:292
 msgid "Still have questions?"
 msgstr "還有疑問嗎？"
 
-#: src/olympia/pages/templates/pages/faq.html:295
+#: src/olympia/pages/templates/pages/faq.html:293
 #, python-format
 msgid "For general Firefox support, visit our <a href=\"%(sumo_url)s\">support website</a>. For general add-on and website questions, visit our <a href=\"%(forum_url)s\">forum</a>."
 msgstr "Firefox 一般性協助，請前往我們的<a href=\"%(sumo_url)s\">支援網站</a>。而一般性附加元件與網站問題，請前往我們的<a href=\"%(forum_url)s\">討論區</a>。"
@@ -10603,7 +10494,7 @@ msgstr "Sunbird 已經退休"
 
 #: src/olympia/pages/templates/pages/sunbird.html:29
 msgid ""
-"Development on the Sunbird project has halted and its final release was on March 30, 2010.  We've been proud to host Sunbird add-ons on this site but as the project is no longer maintained we have "
+"Development on the Sunbird project has halted and its final release was on March 30, 2010. We've been proud to host Sunbird add-ons on this site but as the project is no longer maintained we have "
 "disabled our support for the add-ons."
 msgstr "Sunbird 計畫的開發已經終止，最後一次發行時間是 2010 年 3 月 30 日。我們很驕傲曾經能在此網站提供 Sunbird 附加元件代管，但隨計畫中止，我們也已停止對這些附加元件的支援。"
 
@@ -10681,7 +10572,7 @@ msgstr "新增對 {0} 的意見"
 #, python-format
 msgid ""
 "<h2>Keep these tips in mind:</h2> <ul> <li> Write like you're telling a friend about your experience with the add-on. Give specifics and helpful details, such as what features you liked and/or "
-"disliked, how easy to use it is, and any disadvantages it has.  Avoid generic language such as calling it \"Great\" or \"Bad\" unless you can give reasons why you believe this is so. </li> <li> "
+"disliked, how easy to use it is, and any disadvantages it has. Avoid generic language such as calling it \"Great\" or \"Bad\" unless you can give reasons why you believe this is so. </li> <li> "
 "Please do not post bug reports in reviews. We do not make your email address available to add-on developers and they may need to contact you to help resolve your issue. See the <a href=\"%(support)s"
 "\">support section</a> to find out where to get assistance for this add-on. </li> <li>Please keep reviews clean, avoid the use of improper language and do not post any personal information. </li> </"
 "ul> <p>Please read the <a href=\"%(guide)s\" target=\"_blank\">Review Guidelines</a> for more detail about user add-on reviews.</p>"
@@ -10731,6 +10622,7 @@ msgstr "此意見為舊版本 ({0}) 的附加元件。"
 msgid "This user has a <a href=\"%(user_review_url)s\">previous review</a> of this add-on."
 msgid_plural "This user has <a href=\"%(user_review_url)s\">%(cnt)s previous reviews</a> of this add-on."
 msgstr[0] "此使用者對此附加元件 <a href=\"%(user_review_url)s\">曾發表過 %(cnt)s 筆評論</a>。"
+msgstr[1] ""
 
 #: src/olympia/reviews/templates/reviews/review.html:62
 #, python-format
@@ -10776,6 +10668,7 @@ msgstr "對 {0} 的評論"
 msgid "<b>{0}</b> review for this add-on"
 msgid_plural "<b>{0}</b> reviews for this add-on"
 msgstr[0] "<b>{0}</b> 篇附加元件的評論"
+msgstr[1] ""
 
 #. {0} is a developer's name.
 #: src/olympia/reviews/templates/reviews/review_list.html:33
@@ -10787,6 +10680,7 @@ msgstr "開發者 {0} 回覆"
 msgid "Review for %(addon)s by %(user)s"
 msgid_plural "Reviews for %(addon)s by %(user)s"
 msgstr[0] "%(user)s 發表對 %(addon)s 的評論"
+msgstr[1] ""
 
 #: src/olympia/reviews/templates/reviews/review_list.html:42
 msgid "No reviews found."
@@ -10809,6 +10703,7 @@ msgstr "寫下第一篇評論吧。"
 msgid "{num} review"
 msgid_plural "{num} reviews"
 msgstr[0] "{num} 篇評論"
+msgstr[1] ""
 
 #: src/olympia/reviews/templates/reviews/impala/reviews_rating.html:1
 msgid "Rated {0} out of 5 stars"
@@ -10835,6 +10730,7 @@ msgstr "未經評分。"
 msgid "Average from {0} Rating"
 msgid_plural "Average from {0} Ratings"
 msgstr[0] "{0} 平均評分"
+msgstr[1] ""
 
 #: src/olympia/reviews/templates/reviews/mobile/review_list.html:34
 #, python-format
@@ -10850,6 +10746,7 @@ msgstr "了解更多&nbsp;&raquo;"
 msgid "See All Reviews"
 msgid_plural "See All %(cnt)s Reviews"
 msgstr[0] "檢視所有 %(cnt)s 筆評論"
+msgstr[1] ""
 
 #: src/olympia/search/forms.py:11
 msgid "Most popular this week"
@@ -10930,16 +10827,16 @@ msgstr "{0} 附加元件"
 
 #. L10n: {0} is an application, such as Firefox. This means "any version of
 #. Firefox."
-#: src/olympia/search/views.py:554
+#: src/olympia/search/views.py:547
 msgid "Any {0}"
 msgstr "任何版本的 {0}"
 
 #. L10n: "All Systems" means show everything regardless of platform.
-#: src/olympia/search/views.py:589
+#: src/olympia/search/views.py:582
 msgid "All Systems"
 msgstr "所有作業系統"
 
-#: src/olympia/search/views.py:600
+#: src/olympia/search/views.py:593
 msgid "All Tags"
 msgstr "所有標籤"
 
@@ -10983,6 +10880,7 @@ msgstr "標籤 \"{0}\" 的搜尋結果"
 msgid "<b>{0}</b> matching result"
 msgid_plural "<b>{0}</b> matching results"
 msgstr[0] "找到<b>{0}</b>項符合的搜尋結果"
+msgstr[1] ""
 
 #: src/olympia/search/templates/search/results.html:67
 msgid "Filter Results"
@@ -11004,6 +10902,7 @@ msgstr "搜尋結果 <i>({num})</i>"
 msgid "{0} post"
 msgid_plural "{0} posts"
 msgstr[0] "{0} 篇意見"
+msgstr[1] ""
 
 #: src/olympia/sharing/__init__.py:20
 msgid "Post to Facebook"
@@ -11013,6 +10912,7 @@ msgstr "發佈到 Facebook"
 msgid "{0} Like"
 msgid_plural "{0} Likes"
 msgstr[0] "{0} 個讚"
+msgstr[1] ""
 
 #: src/olympia/sharing/__init__.py:30
 msgid "Tweet on Twitter"
@@ -11022,6 +10922,7 @@ msgstr "推到 Twitter"
 msgid "{0} tweet"
 msgid_plural "{0} tweets"
 msgstr[0] "{0} 則 tweet"
+msgstr[1] ""
 
 #: src/olympia/sharing/__init__.py:40
 msgid "Share on g+"
@@ -11055,6 +10956,7 @@ msgstr "http://www.plurk.com/?qualifier=shares&status={url} ({title}) Firefox �
 msgid "{0} post on localservice1"
 msgid_plural "{0} posts on localservice1"
 msgstr[0] "噗浪上的 {0} 篇分享"
+msgstr[1] ""
 
 #. L10n: Only change if you have reason! wiki.mozilla.org/AMO:Localizers
 #: src/olympia/sharing/__init__.py:76
@@ -11076,6 +10978,7 @@ msgstr "http://localservice2/?url={url}&title={title}"
 msgid "{0} post on localservice2"
 msgid_plural "{0} posts on localservice2"
 msgstr[0] "{0} posts on localservice2"
+msgstr[1] ""
 
 #. L10n: Only change if you have reason! wiki.mozilla.org/AMO:Localizers
 #: src/olympia/sharing/__init__.py:91
@@ -11097,6 +11000,7 @@ msgstr "http://localservice3/?url={url}&title={title}"
 msgid "{0} post on localservice3"
 msgid_plural "{0} posts on localservice3"
 msgstr[0] "{0} posts on localservice3"
+msgstr[1] ""
 
 #: src/olympia/sharing/templates/sharing/sharing_widget.html:2
 msgid "Share this Add-on"
@@ -11106,31 +11010,31 @@ msgstr "分享此元件"
 msgid "Share this Collection"
 msgstr "分享此收藏集"
 
-#: src/olympia/signing/views.py:30 src/olympia/templates/base.html:75 src/olympia/templates/impala/base.html:115
+#: src/olympia/signing/views.py:33 src/olympia/templates/base.html:71 src/olympia/templates/impala/base.html:112
 msgid "Some features are temporarily disabled while we perform website maintenance. We'll be back to full capacity shortly."
 msgstr "我們正在進行網站維護，部分功能暫時無法使用。我們將盡快完全復原。"
 
-#: src/olympia/signing/views.py:53
+#: src/olympia/signing/views.py:56
 msgid "Could not find add-on with id \"{}\"."
 msgstr "找不到 ID 為「{}」的附加元件。"
 
-#: src/olympia/signing/views.py:67
+#: src/olympia/signing/views.py:70
 msgid "You do not own this addon."
 msgstr "您並未擁有此附加元件。"
 
-#: src/olympia/signing/views.py:82
+#: src/olympia/signing/views.py:87
 msgid "Missing \"upload\" key in multipart file data."
 msgstr "在 multipart 檔案資料中缺少「upload」鍵值。"
 
-#: src/olympia/signing/views.py:96
+#: src/olympia/signing/views.py:101
 msgid "Version does not match the manifest file."
 msgstr "版本號碼與安裝資訊檔不符。"
 
-#: src/olympia/signing/views.py:100
+#: src/olympia/signing/views.py:105
 msgid "Version already exists."
 msgstr "版本已存在。"
 
-#: src/olympia/signing/views.py:136
+#: src/olympia/signing/views.py:141
 msgid "No uploaded file for that addon and version."
 msgstr "該附加元件與版本沒有已上傳的檔案。"
 
@@ -11243,90 +11147,90 @@ msgstr "{0} :: 統計資訊儀表板"
 msgid "Statistics Dashboard :: Add-ons for {0}"
 msgstr "統計資訊儀表板 :: {0} 的附加元件"
 
-#: src/olympia/stats/templates/stats/stats.html:30
-msgid "Controls:"
-msgstr "控制圖表:"
-
-#: src/olympia/stats/templates/stats/stats.html:33
-msgid "reset zoom"
-msgstr "重設縮放"
-
-#: src/olympia/stats/templates/stats/stats.html:40
-msgid "Group by:"
-msgstr "以此分類:"
-
-#: src/olympia/stats/templates/stats/stats.html:42
-msgid "day"
-msgstr "日"
-
-#: src/olympia/stats/templates/stats/stats.html:45
-msgid "week"
-msgstr "週"
-
-#: src/olympia/stats/templates/stats/stats.html:48
-msgid "month"
-msgstr "月"
-
-#: src/olympia/stats/templates/stats/stats.html:54
-msgid "For last:"
-msgstr "最近:"
-
-#: src/olympia/stats/templates/stats/stats.html:57
-msgid "7 days"
-msgstr "7 天"
-
-#: src/olympia/stats/templates/stats/stats.html:60
-msgid "30 days"
-msgstr "30 天"
-
-#: src/olympia/stats/templates/stats/stats.html:63
-msgid "90 days"
-msgstr "90 天"
-
-#: src/olympia/stats/templates/stats/stats.html:66
-msgid "365 days"
-msgstr "365 天"
-
-#: src/olympia/stats/templates/stats/stats.html:69
-msgid "Custom..."
-msgstr "自訂..."
-
 # %1 is the name of a collection
 #. {0} is an add-on name
-#: src/olympia/stats/templates/stats/stats.html:88 src/olympia/stats/templates/stats/stats.html:91
+#: src/olympia/stats/templates/stats/stats.html:44 src/olympia/stats/templates/stats/stats.html:47
 msgid "Statistics for {0}"
 msgstr "{0} 的統計資訊"
 
-#: src/olympia/stats/templates/stats/stats.html:94
+#: src/olympia/stats/templates/stats/stats.html:50
 msgid "Statistics Dashboard"
 msgstr "統計資訊儀表板"
 
-#: src/olympia/stats/templates/stats/stats.html:104
+#: src/olympia/stats/templates/stats/stats.html:57
+msgid "Controls:"
+msgstr "控制圖表:"
+
+#: src/olympia/stats/templates/stats/stats.html:60
+msgid "reset zoom"
+msgstr "重設縮放"
+
+#: src/olympia/stats/templates/stats/stats.html:67
+msgid "Group by:"
+msgstr "以此分類:"
+
+#: src/olympia/stats/templates/stats/stats.html:69
+msgid "day"
+msgstr "日"
+
+#: src/olympia/stats/templates/stats/stats.html:72
+msgid "week"
+msgstr "週"
+
+#: src/olympia/stats/templates/stats/stats.html:75
+msgid "month"
+msgstr "月"
+
+#: src/olympia/stats/templates/stats/stats.html:81
+msgid "For last:"
+msgstr "最近:"
+
+#: src/olympia/stats/templates/stats/stats.html:84
+msgid "7 days"
+msgstr "7 天"
+
+#: src/olympia/stats/templates/stats/stats.html:87
+msgid "30 days"
+msgstr "30 天"
+
+#: src/olympia/stats/templates/stats/stats.html:90
+msgid "90 days"
+msgstr "90 天"
+
+#: src/olympia/stats/templates/stats/stats.html:93
+msgid "365 days"
+msgstr "365 天"
+
+#: src/olympia/stats/templates/stats/stats.html:96
+msgid "Custom..."
+msgstr "自訂..."
+
+#: src/olympia/stats/templates/stats/stats.html:106
 msgid "Statistics processing is currently disabled, so recent data is unavailable. The statistics are still being collected and this page will be updated soon with the missing data."
 msgstr "已暫時停止處理統計，無法提供近期資料。我們仍然有在收集統計資料，很快就會在此頁面更新。"
 
-#: src/olympia/stats/templates/stats/stats.html:110
+#: src/olympia/stats/templates/stats/stats.html:112
 msgid "Loading the latest data&hellip;"
 msgstr "讀取最新資料&hellip;"
 
-#: src/olympia/stats/templates/stats/stats.html:142 src/olympia/stats/templates/stats/reports/overview.html:25 src/olympia/stats/templates/stats/reports/overview.html:37
+#: src/olympia/stats/templates/stats/stats.html:144 src/olympia/stats/templates/stats/reports/overview.html:25 src/olympia/stats/templates/stats/reports/overview.html:37
 #: src/olympia/stats/templates/stats/reports/overview.html:49
 msgid "No data available."
 msgstr "無資料。"
 
-#: src/olympia/stats/templates/stats/stats.html:177
+#: src/olympia/stats/templates/stats/stats.html:179
 msgid "This dashboard is currently <b>public</b>."
 msgstr "這個儀表板目前是<b>公開的</b>。"
 
-#: src/olympia/stats/templates/stats/stats.html:179
+#: src/olympia/stats/templates/stats/stats.html:181
 msgid "Contribution stats are currently <b>private</b>."
 msgstr "貢獻統計資訊目前是<b>不公開的</b>。"
 
-#: src/olympia/stats/templates/stats/stats.html:182
+#: src/olympia/stats/templates/stats/stats.html:184
 msgid "This dashboard is currently <b>private</b>."
 msgstr "這個儀表板目前是<b>不公開的</b>。"
 
-#: src/olympia/stats/templates/stats/stats.html:185
+#: src/olympia/stats/templates/stats/stats.html:187
 msgid "Change settings."
 msgstr "更改設定。"
 
@@ -11483,15 +11387,6 @@ msgstr "依日期顯示新註冊的使用者"
 msgid "Application versions by Date"
 msgstr "依日期顯示應用程式版本"
 
-#: src/olympia/tags/templates/tags/top_cloud.html:4
-msgid "Top {0} Tags"
-msgstr "前 {0} 名標籤"
-
-#. {0} is the current application name
-#: src/olympia/tags/templates/tags/top_cloud.html:14
-msgid "{0} Top Tags"
-msgstr "{0} 最多人標記項目"
-
 #: src/olympia/templates/amo_footer.html:6 src/olympia/templates/includes/lang_switcher.html:2
 msgid "Other languages"
 msgstr "其他語言"
@@ -11500,11 +11395,11 @@ msgstr "其他語言"
 msgid "Mozilla Add-ons"
 msgstr "Mozilla 附加元件"
 
-#: src/olympia/templates/base.html:91 src/olympia/templates/impala/base.html:81
+#: src/olympia/templates/base.html:89 src/olympia/templates/impala/base.html:78
 msgid "Find add-ons for other applications"
 msgstr "尋找其他應用程式使用的附加元件"
 
-#: src/olympia/templates/base.html:92 src/olympia/templates/impala/base.html:81
+#: src/olympia/templates/base.html:90 src/olympia/templates/impala/base.html:78
 msgid "Other Applications"
 msgstr "其他應用程式"
 
@@ -11529,7 +11424,7 @@ msgid "View Mobile Site"
 msgstr "瀏覽行動版網站"
 
 #: src/olympia/templates/copyright.html:7
-msgid "Site Status "
+msgid "Site Status"
 msgstr "網站狀態"
 
 #: src/olympia/templates/footer.html:3
@@ -11631,35 +11526,35 @@ msgstr "歡迎您，{0}"
 msgid "<a href=\"%(reg)s\">Register</a> or <a href=\"%(login)s\">Log in</a>"
 msgstr "<a href=\"%(reg)s\">註冊</a>或<a href=\"%(login)s\">登入</a>"
 
-#: src/olympia/templates/impala/base.html:126
+#: src/olympia/templates/impala/base.html:123
 #, python-format
 msgid "To try the thousands of add-ons available here, download <a href=\"%(url)s\">Mozilla Firefox</a>, a fast, free way to surf the Web!"
 msgstr "立即下載 <a href=\"%(url)s\">Mozilla Firefox</a>，體驗快速、自由地在網路中穿梭，並且享受成千上萬的擴充套件！"
 
-#: src/olympia/templates/impala/base.html:138
+#: src/olympia/templates/impala/base.html:135
 #, python-format
 msgid "Add-ons is switching to Firefox Accounts for login. <a href=\"%(url)s\" class=\"fxa-login\">Sign in now to transfer your account.</a>"
 msgstr "附加元件站已改用 Firefox 帳號登入。<a href=\"%(url)s\" class=\"fxa-login\">請立刻登入合併您的帳號。</a>"
 
 #. {0} is an application, such as Firefox.
-#: src/olympia/templates/impala/base.html:148
+#: src/olympia/templates/impala/base.html:145
 msgid "Welcome to {0} Add-ons."
 msgstr "歡迎來到 {0} 附加元件。"
 
-#: src/olympia/templates/impala/base.html:151
+#: src/olympia/templates/impala/base.html:148
 msgid "Choose from thousands of extra features and styles to make Firefox your own."
 msgstr "從上千個額外的功能與樣式自訂您的 Firefox。"
 
-#: src/olympia/templates/impala/base.html:156
+#: src/olympia/templates/impala/base.html:153
 #, python-format
 msgid "Add extra features and styles to make %(app)s your own."
 msgstr "新增額外的功能與樣式自訂您的 %(app)s。"
 
-#: src/olympia/templates/impala/base.html:164
+#: src/olympia/templates/impala/base.html:161
 msgid "On the go?"
 msgstr "帶著走？"
 
-#: src/olympia/templates/impala/base.html:166
+#: src/olympia/templates/impala/base.html:163
 msgid "Check out our <a class=\"mobile-link\" href=\"#\">Mobile Add-ons site</a>."
 msgstr "造訪我們的<a class=\"mobile-link\" href=\"#\">行動版附加元件網站</a>。"
 
@@ -11883,19 +11778,19 @@ msgstr "無使用者使用此信箱。"
 
 #. L10n: {id} will be something like "13ad6a", just a random number
 #. to differentiate this user from other anonymous users.
-#: src/olympia/users/models.py:353
+#: src/olympia/users/models.py:362
 msgid "Anonymous user {id}"
 msgstr "匿名使用者 {id}"
 
-#: src/olympia/users/models.py:410
+#: src/olympia/users/models.py:419
 msgid "Your account has been restricted"
 msgstr "您的帳號已被限制"
 
-#: src/olympia/users/models.py:480
+#: src/olympia/users/models.py:489
 msgid "Please confirm your email address"
 msgstr "請確認您的電子郵件"
 
-#: src/olympia/users/models.py:506
+#: src/olympia/users/models.py:515
 msgid "My Mobile Add-ons"
 msgstr "我的 Mobile 附加元件"
 
@@ -12173,7 +12068,7 @@ msgstr "密碼"
 
 #: src/olympia/users/templates/users/edit.html:70
 #, python-format
-msgid "Change your password.  If you forgot your password, you can <a href=\"%(reset_url)s\">use the reset form</a>."
+msgid "Change your password. If you forgot your password, you can <a href=\"%(reset_url)s\">use the reset form</a>."
 msgstr "修改密碼。若您忘記了密碼，您可以 <a href=\"%(reset_url)s\">使用重設表單</a>。"
 
 #: src/olympia/users/templates/users/edit.html:76
@@ -12193,7 +12088,7 @@ msgid "Profile"
 msgstr "個人檔案"
 
 #: src/olympia/users/templates/users/edit.html:100
-msgid "Give us a bit more information about yourself.  All these fields are optional, but they'll help other users get to know you better."
+msgid "Give us a bit more information about yourself. All these fields are optional, but they'll help other users get to know you better."
 msgstr "請提供關於您的更多資訊給我們。這些欄位均為選填，但能夠幫助其他人了解您更多。"
 
 #: src/olympia/users/templates/users/edit.html:124
@@ -12413,7 +12308,7 @@ msgid "Confirm password"
 msgstr "請再次輸入密碼"
 
 #: src/olympia/users/templates/users/pwreset_confirm.html:47
-msgid "The password reset link was invalid, possibly because it has already been used.  Please request a new password reset."
+msgid "The password reset link was invalid, possibly because it has already been used. Please request a new password reset."
 msgstr "密碼重設鏈結無效，可能是已經被使用過了。請重新要求密碼重設。"
 
 #: src/olympia/users/templates/users/pwreset_request.html:15
@@ -12599,7 +12494,7 @@ msgstr "我們無法取消您的訂閱"
 
 #: src/olympia/users/templates/users/unsubscribe.html:30
 #, python-format
-msgid "Unfortunately, we weren't able to unsubscribe you.  The link you clicked is invalid. However, you can unsubscribe still unsubscribe on your <a href=\"%(edit_url)s\">edit profile page</a>."
+msgid "Unfortunately, we weren't able to unsubscribe you. The link you clicked is invalid. However, you can unsubscribe still unsubscribe on your <a href=\"%(edit_url)s\">edit profile page</a>."
 msgstr "很抱歉，我們無法取消您的訂閱。您點擊的鏈結無效。但您還是可到 <a href=\"%(edit_url)s\">資料編輯頁面</a> 退訂。"
 
 #: src/olympia/users/templates/users/vcard.html:2
@@ -12631,12 +12526,14 @@ msgstr "{0} 個附加元件"
 msgid "%(num)s theme"
 msgid_plural "%(num)s themes"
 msgstr[0] "%(num)s 佈景主題"
+msgstr[1] ""
 
 #: src/olympia/users/templates/users/vcard.html:62
 #, python-format
 msgid "%(num)s add-on"
 msgid_plural "%(num)s add-ons"
 msgstr[0] "%(num)s 個附加元件"
+msgstr[1] ""
 
 #: src/olympia/users/templates/users/vcard.html:75
 msgid "Average rating of developer's add-ons"
@@ -12651,15 +12548,15 @@ msgstr "%s 的版本歷史"
 msgid "Version History with Changelogs"
 msgstr "版本歷史記錄"
 
-#: src/olympia/versions/models.py:314
+#: src/olympia/versions/models.py:313
 msgid "Add-on uses binary components."
 msgstr "使用二進位元件的附加元件。"
 
-#: src/olympia/versions/models.py:317
+#: src/olympia/versions/models.py:316
 msgid "Add-on has opted into strict compatibility checking."
 msgstr "附加元件已要求進行嚴格的相容性檢測。"
 
-#: src/olympia/versions/models.py:715
+#: src/olympia/versions/models.py:711
 msgid "{app} {min} and later"
 msgstr "{app} {min} 及更新版"
 
@@ -12697,6 +12594,7 @@ msgstr "{0} 版本記錄"
 msgid "<b>{0}</b> version"
 msgid_plural "<b>{0}</b> versions"
 msgstr[0] "版本: <b>{0}</b>"
+msgstr[1] ""
 
 #: src/olympia/versions/templates/versions/version_list.html:35 src/olympia/versions/templates/versions/mobile/version_list.html:14
 msgid "Be careful with old versions!"
@@ -12736,3 +12634,7 @@ msgstr "完成後請寄電子郵件通知"
 #: src/olympia/zadmin/forms.py:105
 msgid "Log emails instead of sending"
 msgstr "保存 email 不寄出"
+
+#: src/olympia/zadmin/forms.py:215
+msgid "Deleted versions can`t be changed."
+msgstr ""

--- a/locale/zh_TW/LC_MESSAGES/djangojs.po
+++ b/locale/zh_TW/LC_MESSAGES/djangojs.po
@@ -3,1201 +3,1236 @@ msgid ""
 msgstr ""
 "Project-Id-Version: AMO-JS 0.1\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2016-02-24 21:23+0000\n"
+"POT-Creation-Date: 2016-04-18 15:47+0000\n"
 "PO-Revision-Date: 2015-10-17 11:11+0000\n"
 "Last-Translator: Pin-guang Chen <petercpg@mail.moztw.org>\n"
 "Language-Team: Traditional Chinese (Taiwan) <LL@li.org>\n"
+"Language: \n"
 "MIME-Version: 1.0\n"
-"Content-Type: text/plain; charset=utf-8\n"
+"Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Generated-By: Babel 2.2.0\n"
 
-#: static/js/common/ratingwidget.js:31
+#: static/js/common-all.js:1426 static/js/impala-all.js:1511 static/js/zamboni/discovery-all.js:12598 static/js/zamboni/init.js:28 static/js/zamboni/mobile-all.js:14945
+msgid "This feature is temporarily disabled while we perform website maintenance. Please check back a little later."
+msgstr "我們正在維護網站，這個功能暫時無法使用。請您稍後再試。"
+
+#. L10n: {0} is an app name like Firefox.
+#: static/js/common-all.js:1837 static/js/impala-all.js:1922 static/js/zamboni/buttons.js:73 static/js/zamboni/discovery-all.js:13108
+msgid "Accept and Install"
+msgstr "接受並安裝"
+
+#: static/js/common-all.js:1837 static/js/impala-all.js:1922 static/js/zamboni/buttons.js:73 static/js/zamboni/discovery-all.js:13108
+msgid "Add to {0}"
+msgstr "新增至 {0}"
+
+#: static/js/common-all.js:1842 static/js/impala-all.js:1927 static/js/zamboni/buttons.js:78 static/js/zamboni/discovery-all.js:13113
+msgid "Download Now"
+msgstr "立刻下載"
+
+#: static/js/common-all.js:1883 static/js/impala-all.js:1968 static/js/zamboni/buttons.js:119 static/js/zamboni/discovery-all.js:13154
+msgid "Add-on has not been updated to support default-to-compatible."
+msgstr "附加元件未被更新為預設相容版本。"
+
+#: static/js/common-all.js:1888 static/js/impala-all.js:1973 static/js/zamboni/buttons.js:124 static/js/zamboni/discovery-all.js:13159
+msgid "You need to be using Firefox 10.0 or higher."
+msgstr "您必須使用 Firefox 10.0 或更新版本。"
+
+#: static/js/common-all.js:1900 static/js/impala-all.js:1985 static/js/zamboni/buttons.js:136 static/js/zamboni/discovery-all.js:13171
+msgid "Mozilla has marked this version as incompatible with your Firefox version."
+msgstr "Mozilla 已將此版本標示為與您的 Firefox 版本不相容。"
+
+#. L10n: {0} is an platform like Windows or Linux.
+#: static/js/common-all.js:1981 static/js/impala-all.js:2066 static/js/zamboni/buttons.js:217 static/js/zamboni/discovery-all.js:13252
+msgid "Install for {0} anyway"
+msgstr "繼續安裝 {0} 版本"
+
+#: static/js/common-all.js:1981 static/js/impala-all.js:2066 static/js/zamboni/buttons.js:217 static/js/zamboni/discovery-all.js:13252
+msgid "Download for {0} anyway"
+msgstr "仍然下載 {0}"
+
+#: static/js/common-all.js:2038 static/js/impala-all.js:2123 static/js/zamboni/buttons.js:274 static/js/zamboni/discovery-all.js:13309
+msgid "Not available for your platform"
+msgstr "與您的作業系統不相容"
+
+#. L10n: {0} is an app name, {1} is the app version.
+#: static/js/common-all.js:2049 static/js/common-all.js:2086 static/js/impala-all.js:2134 static/js/impala-all.js:2171 static/js/zamboni/buttons.js:286 static/js/zamboni/buttons.js:324
+#: static/js/zamboni/discovery-all.js:13320 static/js/zamboni/discovery-all.js:13357
+msgid "Not available for {0} {1}"
+msgstr "無法使用於 {0} {1}"
+
+#: static/js/common-all.js:2112 static/js/impala-all.js:2197 static/js/zamboni/buttons.js:351 static/js/zamboni/discovery-all.js:13383
+msgid "Works with {app} {min} - {max}"
+msgstr "可於 {app} {min} - {max} 使用"
+
+#: static/js/common-all.js:2114 static/js/impala-all.js:2199 static/js/zamboni/buttons.js:353 static/js/zamboni/discovery-all.js:13385
+msgid "View other versions"
+msgstr "檢視其他版本"
+
+#: static/js/common-all.js:2162 static/js/impala-all.js:2247 static/js/zamboni/buttons.js:401 static/js/zamboni/discovery-all.js:13433
+msgid "Only with Firefox — Get Firefox Now!"
+msgstr "只在 Firefox 上才有，快來安裝！"
+
+#: static/js/common-all.js:2278 static/js/impala-all.js:2363 static/js/zamboni/buttons.js:517 static/js/zamboni/discovery-all.js:13549 static/js/zamboni/mobile-all.js:15177
+#: static/js/zamboni/mobile/buttons.js:43
+msgid "Sorry, you need a Mozilla-based browser (such as Firefox) to install a search plugin."
+msgstr "抱歉，您需要 Mozilla 系列的瀏覽器 (像是 Firefox) 才能安裝此搜尋外掛。"
+
+#: static/js/common-all.js:9088 static/js/impala-all.js:9649 static/js/zamboni/global.js:410
+msgid "Loading..."
+msgstr "載入中..."
+
+#. L10n: {0} is the number of characters left.
+#: static/js/common-all.js:9152 static/js/impala-all.js:9713 static/js/zamboni/global.js:474
+msgid "<b>{0}</b> character left."
+msgid_plural "<b>{0}</b> characters left."
+msgstr[0] "還剩下 <b>{0}</b> 個字元可以輸入。"
+msgstr[1] ""
+
+#: static/js/common-all.js:9589 static/js/common-min.js:6 static/js/impala-all.js:10052 static/js/impala-min.js:6 static/js/common/ratingwidget.js:31 static/js/zamboni/mobile-all.js:16123
+#: static/js/zamboni/mobile-min.js:6
 msgid "{0} star"
 msgid_plural "{0} stars"
 msgstr[0] "{0} 顆星"
+msgstr[1] ""
 
-#: static/js/common/upload-addon.js:41 static/js/common/upload-image.js:128
+#: static/js/common-all.js:9676 static/js/common-min.js:6 static/js/impala-all.js:10139 static/js/impala-min.js:6 static/js/zamboni/l10n.js:45
+msgid "Remove this localization"
+msgstr "移除此語系"
+
+#: static/js/common-all.js:10193 static/js/common-min.js:6 static/js/impala-all.js:10674 static/js/impala-min.js:6 static/js/zamboni/discovery-all.js:13678
+msgid "close"
+msgstr ""
+
+#: static/js/common-all.js:10860 static/js/common-min.js:6 static/js/impala-all.js:11481 static/js/impala-min.js:6 static/js/impala/reviews.js:23 static/js/zamboni/reviews.js:18
+msgid "Flagged for review"
+msgstr "評論已被標記"
+
+#: static/js/common-all.js:10876 static/js/common-min.js:6 static/js/impala-all.js:11498 static/js/impala-min.js:6 static/js/impala/reviews.js:40 static/js/zamboni/reviews.js:34
+msgid "Your input is required"
+msgstr "必填"
+
+#: static/js/common-all.js:10945 static/js/common-min.js:6 static/js/impala-all.js:11610 static/js/impala-min.js:7 static/js/impala/reviews.js:152 static/js/zamboni/reviews.js:103
+msgid "Marked for deletion"
+msgstr "標示刪除"
+
+#: static/js/common-all.js:11573 static/js/common-min.js:7 static/js/impala-all.js:13809 static/js/impala-min.js:8 static/js/zamboni/collections.js:229
+msgid "Adding to Favorites&hellip;"
+msgstr "加入至我的最愛&hellip;"
+
+#: static/js/common-all.js:11576 static/js/common-min.js:7 static/js/impala-all.js:13812 static/js/impala-min.js:8 static/js/zamboni/collections.js:232
+msgid "Removing Favorite&hellip;"
+msgstr "從我的最愛中移除&hellip;"
+
+#: static/js/common-all.js:11579 static/js/common-min.js:7 static/js/impala-all.js:13815 static/js/impala-min.js:8 static/js/zamboni/collections.js:235
+msgid "Add to Favorites"
+msgstr "加入至我的最愛"
+
+#: static/js/common-all.js:11582 static/js/common-min.js:7 static/js/impala-all.js:13818 static/js/impala-min.js:8 static/js/zamboni/collections.js:238
+msgid "Remove from Favorites"
+msgstr "從我的最愛中移除"
+
+#: static/js/common-all.js:11647 static/js/common-min.js:7 static/js/impala-all.js:13883 static/js/impala-min.js:8 static/js/zamboni/collections.js:303
+msgid "Pending"
+msgstr "擱置"
+
+#: static/js/common-all.js:11648 static/js/common-min.js:7 static/js/impala-all.js:13884 static/js/impala-min.js:8 static/js/zamboni/collections.js:304
+msgid "Add a comment"
+msgstr "新增一個意見"
+
+#: static/js/common-all.js:11648 static/js/common-min.js:7 static/js/impala-all.js:13884 static/js/impala-min.js:8 static/js/zamboni/collections.js:304
+msgid "Comment"
+msgstr "意見"
+
+#: static/js/common-all.js:11649 static/js/common-min.js:7 static/js/impala-all.js:13885 static/js/impala-min.js:8 static/js/zamboni/collections.js:305
+msgid "Remove this add-on from the collection"
+msgstr "從收藏集中移除此附加元件"
+
+#: static/js/common-all.js:11649 static/js/common-all.js:11678 static/js/common-min.js:7 static/js/impala-all.js:13885 static/js/impala-all.js:13914 static/js/impala-min.js:8
+#: static/js/zamboni/collections.js:305 static/js/zamboni/collections.js:334
+msgid "Remove"
+msgstr "移除"
+
+#: static/js/common-all.js:11678 static/js/common-min.js:7 static/js/impala-all.js:13914 static/js/impala-min.js:8 static/js/zamboni/collections.js:334
+msgid "Remove this user as a contributor"
+msgstr "剝奪這位使用者的貢獻者資格"
+
+#: static/js/common-all.js:11690 static/js/common-min.js:7 static/js/impala-all.js:13926 static/js/impala-min.js:8 static/js/zamboni/collections.js:346
+msgid "An email address is required."
+msgstr "必須輸入電子郵件地址。"
+
+#: static/js/common-all.js:11708 static/js/common-min.js:7 static/js/impala-all.js:13944 static/js/impala-min.js:8 static/js/zamboni/collections.js:364
+msgid "You cannot add yourself as a contributor."
+msgstr "您不能新增自己為貢獻者。"
+
+#: static/js/common-all.js:11710 static/js/common-min.js:7 static/js/impala-all.js:13946 static/js/impala-min.js:8 static/js/zamboni/collections.js:366
+msgid "You have already added that user."
+msgstr "您已經新增該使用者。"
+
+#: static/js/common-all.js:11917 static/js/common-min.js:7 static/js/impala-all.js:14153 static/js/impala-min.js:8 static/js/zamboni/collections.js:573
+msgid "Add to favorites"
+msgstr "加入至我的最愛"
+
+#: static/js/common-all.js:11921 static/js/common-min.js:7 static/js/impala-all.js:14157 static/js/impala-min.js:8 static/js/zamboni/collections.js:577
+msgid "Remove from favorites"
+msgstr "從我的最愛移除"
+
+#: static/js/common-all.js:11939 static/js/common-min.js:7 static/js/impala-all.js:14175 static/js/impala-all.js:14233 static/js/impala-min.js:8 static/js/impala/collections.js:10
+#: static/js/zamboni/collections.js:595
+msgid "Follow this Collection"
+msgstr "追蹤這個收藏集"
+
+#: static/js/common-all.js:11948 static/js/common-min.js:7 static/js/impala-all.js:14184 static/js/impala-min.js:8 static/js/zamboni/collections.js:604
+msgid "Stop following"
+msgstr "停止追蹤"
+
+#: static/js/common-all.js:12096 static/js/common-min.js:7 static/js/zamboni/password-strength.js:20
+msgid "Password strength:"
+msgstr "密碼強度:"
+
+#: static/js/common-all.js:12102 static/js/common-min.js:7 static/js/zamboni/password-strength.js:26
+msgid "At least {0} character left."
+msgid_plural "At least {0} characters left."
+msgstr[0] "至少還需要再輸入 {0} 個字元。"
+msgstr[1] ""
+
+#: static/js/common-all.js:12286 static/js/common-min.js:7 static/js/impala-all.js:14632 static/js/impala-min.js:8 static/js/impala/suggestions.js:39
+msgid "Search themes for <b>{0}</b>"
+msgstr "搜尋符合<b>{0}</b>的佈景主題"
+
+#: static/js/common-all.js:12288 static/js/common-min.js:7 static/js/impala-all.js:14634 static/js/impala-min.js:8 static/js/impala/suggestions.js:41
+msgid "Search apps for <b>{0}</b>"
+msgstr "搜尋含有 <b>{0}</b>的應用程式"
+
+#: static/js/common-all.js:12290 static/js/common-min.js:7 static/js/impala-all.js:14636 static/js/impala-min.js:8 static/js/impala/suggestions.js:43
+msgid "Search add-ons for <b>{0}</b>"
+msgstr "搜尋含有 <b>{0}</b> 的附加元件"
+
+#: static/js/common-all.js:12521 static/js/common-min.js:7 static/js/impala-all.js:14867 static/js/impala-min.js:8 static/js/impala/site_suggestions.js:46
+msgid "Category"
+msgstr "分類"
+
+#. L10n: {0} is an app name.
+#: static/js/impala-all.js:11632 static/js/impala-min.js:7 static/js/impala/listing.js:11 static/js/zamboni/themes.js:13
+msgid "This theme is incompatible with your version of {0}"
+msgstr "這個佈景主題與您所使用的 {0} 版本不相容"
+
+#: static/js/impala-all.js:12146 static/js/impala-all.js:14331 static/js/impala-min.js:7 static/js/impala-min.js:8 static/js/common/upload-image.js:97 static/js/impala/users.js:51
+#: static/js/zamboni/devhub-all.js:894 static/js/zamboni/devhub-min.js:1
+msgid "Images must be either PNG or JPG."
+msgstr "圖片必須是 PNG 或 JPG 格式。"
+
+#: static/js/impala-all.js:12150 static/js/impala-min.js:7 static/js/common/upload-image.js:101 static/js/zamboni/devhub-all.js:898 static/js/zamboni/devhub-min.js:1
+msgid "Videos must be in WebM."
+msgstr "影片必須為 WebM 格式。"
+
+#: static/js/impala-all.js:12177 static/js/impala-min.js:7 static/js/common/upload-addon.js:41 static/js/common/upload-image.js:128 static/js/zamboni/devhub-all.js:272
+#: static/js/zamboni/devhub-all.js:925 static/js/zamboni/devhub-min.js:1
 msgid "There was a problem contacting the server."
 msgstr "連線到伺服器時發生問題。"
 
-#: static/js/common/upload-addon.js:69
+#: static/js/impala-all.js:13298 static/js/impala-min.js:7 static/js/impala/persona_creation.js:60
+msgid "All Rights Reserved"
+msgstr "保留所有權利"
+
+#: static/js/impala-all.js:13302 static/js/impala-min.js:7 static/js/impala/persona_creation.js:64
+msgid "Creative Commons Attribution 3.0"
+msgstr "Creative Commons 姓名標示 3.0"
+
+#: static/js/impala-all.js:13307 static/js/impala-min.js:7 static/js/impala/persona_creation.js:69
+msgid "Creative Commons Attribution-NonCommercial 3.0"
+msgstr "Creative Commons 姓名標示-非商業性 3.0"
+
+#: static/js/impala-all.js:13312 static/js/impala-min.js:7 static/js/impala/persona_creation.js:74
+msgid "Creative Commons Attribution-NonCommercial-NoDerivs 3.0"
+msgstr "Creative Commons 姓名標示-非商業性-禁止改作 3.0"
+
+#: static/js/impala-all.js:13317 static/js/impala-min.js:7 static/js/impala/persona_creation.js:79
+msgid "Creative Commons Attribution-NonCommercial-Share Alike 3.0"
+msgstr "Creative Commons 姓名標示-非商業性-相同方式分享 3.0"
+
+#: static/js/impala-all.js:13322 static/js/impala-min.js:7 static/js/impala/persona_creation.js:84
+msgid "Creative Commons Attribution-NoDerivs 3.0"
+msgstr "Creative Commons 姓名標示-禁止改作 3.0"
+
+#: static/js/impala-all.js:13327 static/js/impala-min.js:7 static/js/impala/persona_creation.js:89
+msgid "Creative Commons Attribution-ShareAlike 3.0"
+msgstr "Creative Commons 姓名標示-相同方式分享 3.0"
+
+#: static/js/impala-all.js:13530 static/js/impala-min.js:7 static/js/impala/persona_creation.js:292
+msgid "Your Theme's Name"
+msgstr "您的佈景主題名稱"
+
+#: static/js/impala-all.js:14242 static/js/impala-min.js:8 static/js/impala/collections.js:19
+msgid "Stop Following"
+msgstr "停止訂閱"
+
+#: static/js/impala-all.js:14243 static/js/impala-min.js:8 static/js/impala/collections.js:20
+msgid "Following"
+msgstr "訂閱中"
+
+#: static/js/impala-all.js:14313 static/js/impala-min.js:8 static/js/impala/users.js:33
+msgid "use original"
+msgstr "使用原始的"
+
+#: static/js/impala-all.js:14523 static/js/impala-min.js:8 static/js/impala/search.js:114
+msgid "Updating results&hellip;"
+msgstr "正在更新搜尋結果&hellip;"
+
+#: static/js/common/upload-addon.js:69 static/js/zamboni/devhub-all.js:300 static/js/zamboni/devhub-min.js:1
 msgid "Select a file..."
 msgstr "選擇一個檔案..."
 
-#: static/js/common/upload-addon.js:70
+#: static/js/common/upload-addon.js:70 static/js/zamboni/devhub-all.js:301 static/js/zamboni/devhub-min.js:1
 msgid "Your add-on should end with .xpi, .jar or .xml"
 msgstr "您的附加元件應該以 .xpi、.jar 或 .xml 為副檔名"
 
 #. L10n: {0} is the percent of the file that has been uploaded.
-#: static/js/common/upload-addon.js:104
+#: static/js/common/upload-addon.js:104 static/js/zamboni/devhub-all.js:335 static/js/zamboni/devhub-min.js:1
 #, python-format
 msgid "{0}% complete"
 msgstr "已完成 {0}%"
 
 #. L10n: "{bytes uploaded} of {total filesize}".
-#: static/js/common/upload-addon.js:107
+#: static/js/common/upload-addon.js:107 static/js/zamboni/devhub-all.js:338 static/js/zamboni/devhub-min.js:1
 msgid "{0} of {1}"
 msgstr "{0} / {1}"
 
-#: static/js/common/upload-addon.js:140
+#: static/js/common/upload-addon.js:140 static/js/zamboni/devhub-all.js:371 static/js/zamboni/devhub-min.js:1
 msgid "Cancel"
 msgstr "取消"
 
-#: static/js/common/upload-addon.js:162
+#: static/js/common/upload-addon.js:162 static/js/zamboni/devhub-all.js:393 static/js/zamboni/devhub-min.js:1
 msgid "Uploading {0}"
 msgstr "正在上傳 {0}"
 
-#: static/js/common/upload-addon.js:189
+#: static/js/common/upload-addon.js:189 static/js/zamboni/devhub-all.js:420 static/js/zamboni/devhub-min.js:1
 msgid "Error with {0}"
 msgstr "{0} 發生錯誤"
 
-#: static/js/common/upload-addon.js:194
+#: static/js/common/upload-addon.js:194 static/js/zamboni/devhub-all.js:425 static/js/zamboni/devhub-min.js:1
 msgid "Your add-on failed validation with {0} error."
 msgid_plural "Your add-on failed validation with {0} errors."
 msgstr[0] "您的附加元件未通過驗證，有 {0} 個錯誤。"
+msgstr[1] ""
 
-#: static/js/common/upload-addon.js:208
+#: static/js/common/upload-addon.js:208 static/js/zamboni/devhub-all.js:439 static/js/zamboni/devhub-min.js:1
 msgid "&hellip;and {0} more"
 msgid_plural "&hellip;and {0} more"
 msgstr[0] "&hellip;還有 {0} 個"
+msgstr[1] ""
 
-#: static/js/common/upload-addon.js:222 static/js/common/upload-addon.js:512
+#: static/js/common/upload-addon.js:222 static/js/common/upload-addon.js:497 static/js/zamboni/devhub-all.js:453 static/js/zamboni/devhub-all.js:743 static/js/zamboni/devhub-min.js:1
 msgid "See full validation report"
 msgstr "檢視完整驗證報告"
 
-#: static/js/common/upload-addon.js:234
+#: static/js/common/upload-addon.js:234 static/js/zamboni/devhub-all.js:465 static/js/zamboni/devhub-min.js:1
 msgid "Validating {0}"
 msgstr "{0} 驗證中"
 
 #. L10n: first argument is an HTTP status code
-#: static/js/common/upload-addon.js:273
+#: static/js/common/upload-addon.js:273 static/js/zamboni/devhub-all.js:504 static/js/zamboni/devhub-min.js:1
 msgid "Received an empty response from the server; status: {0}"
 msgstr "從伺服器收到一個空白的回覆; 狀態:{0}"
 
-#: static/js/common/upload-addon.js:373
+#: static/js/common/upload-addon.js:370 static/js/zamboni/devhub-all.js:604 static/js/zamboni/devhub-min.js:1
 msgid "Unexpected server error while validating."
 msgstr "在驗證時發生了不可預見的伺服器錯誤。"
 
-#: static/js/common/upload-addon.js:412
+#: static/js/common/upload-addon.js:409 static/js/zamboni/devhub-all.js:643 static/js/zamboni/devhub-min.js:1
 msgid "Finished validating {0}"
 msgstr "已完成驗證 {0}"
 
-#: static/js/common/upload-addon.js:418
+#: static/js/common/upload-addon.js:415 static/js/zamboni/devhub-all.js:649 static/js/zamboni/devhub-min.js:1
 msgid "Your add-on validation timed out, it will be manually reviewed."
 msgstr "您的附加元件驗證已逾時，需要進行手動審查。"
 
-#: static/js/common/upload-addon.js:421
+#: static/js/common/upload-addon.js:418 static/js/zamboni/devhub-all.js:652 static/js/zamboni/devhub-min.js:1
 msgid "Your add-on was validated with no errors and {0} warning."
 msgid_plural "Your add-on was validated with no errors and {0} warnings."
 msgstr[0] "您的附加元件已通過驗證，沒有錯誤，有 {0} 條警告。"
+msgstr[1] ""
 
-#: static/js/common/upload-addon.js:426
+#: static/js/common/upload-addon.js:423 static/js/zamboni/devhub-all.js:657 static/js/zamboni/devhub-min.js:1
 msgid "Your add-on was validated with no errors and {0} message."
 msgid_plural "Your add-on was validated with no errors and {0} messages."
 msgstr[0] "已驗證您的附加元件，無錯誤，有 {0} 條訊息。"
+msgstr[1] ""
 
-#: static/js/common/upload-addon.js:431
+#: static/js/common/upload-addon.js:428 static/js/zamboni/devhub-all.js:662 static/js/zamboni/devhub-min.js:1
 msgid "Your add-on was validated with no errors or warnings."
 msgstr "已驗證您的附加元件，無錯誤或警告。"
 
-#: static/js/common/upload-addon.js:446
+#: static/js/common/upload-addon.js:443 static/js/zamboni/devhub-all.js:677 static/js/zamboni/devhub-min.js:1
 msgid "Your submission will be automatically signed."
 msgstr "您的提交已被自動簽署。"
 
-#: static/js/common/upload-addon.js:465
+#: static/js/common/upload-addon.js:450 static/js/zamboni/devhub-all.js:696 static/js/zamboni/devhub-min.js:1
 msgid "Include detailed version notes (this can be done in the next step)."
 msgstr "包含詳細的版本資訊（可以在下一步完成）。"
 
-#: static/js/common/upload-addon.js:466
+#: static/js/common/upload-addon.js:451 static/js/zamboni/devhub-all.js:697 static/js/zamboni/devhub-min.js:1
 msgid "If your add-on requires an account to a website in order to be fully tested, include a test username and password in the Notes to Reviewer (this can be done in the next step)."
 msgstr "若您的附加元件需要在某個網站上有帳號才能進行測試，請也在給審核者的紀錄中包含測試帳號的帳號名稱與密碼。（可以在下一步完成）"
 
-#: static/js/common/upload-addon.js:467
+#: static/js/common/upload-addon.js:452 static/js/zamboni/devhub-all.js:698 static/js/zamboni/devhub-min.js:1
 msgid "If your add-on is intended for a limited audience you should choose Preliminary Review instead of Full Review."
 msgstr "若您的附加元件只打算給少部分的使用者使用，您應該選擇初步審查，而不需選擇完整審查。"
 
-#: static/js/common/upload-addon.js:480
+#: static/js/common/upload-addon.js:465 static/js/zamboni/devhub-all.js:711 static/js/zamboni/devhub-min.js:1
 msgid "Add-on submission checklist"
 msgstr "附加元件送出前檢查清單"
 
-#: static/js/common/upload-addon.js:481
+#: static/js/common/upload-addon.js:466 static/js/zamboni/devhub-all.js:712 static/js/zamboni/devhub-min.js:1
 msgid "Please verify the following points before finalizing your submission. This will minimize delays or misunderstanding during the review process:"
 msgstr "送出前，請確認下列幾項是否已完成。這樣將可以降低審查時間:"
 
-#: static/js/common/upload-addon.js:483
+#: static/js/common/upload-addon.js:468 static/js/zamboni/devhub-all.js:714 static/js/zamboni/devhub-min.js:1
 msgid ""
 "Compiled binaries, as well as minified or obfuscated scripts (excluding known libraries) need to have their sources submitted separately for review. Make sure that you use the source code upload "
 "field to avoid having your submission rejected."
 msgstr "若有編譯過的二元碼，以及最小化過或擾亂過的指令碼（已知的程式庫除外），請同時另外送出原始碼提供審查。請確定您在原始碼上傳欄位中也上傳了這些檔案，以避免被退回。"
 
-#: static/js/common/upload-addon.js:501
+#: static/js/common/upload-addon.js:486 static/js/zamboni/devhub-all.js:732 static/js/zamboni/devhub-min.js:1
 msgid "The validation process found these issues that can lead to rejections:"
 msgstr "驗證過程找到下列可能會造成您的送出被退回的問題:"
 
-#: static/js/common/upload-addon.js:518
+#: static/js/common/upload-addon.js:503 static/js/zamboni/devhub-all.js:749 static/js/zamboni/devhub-min.js:1
 msgid "If you are unfamiliar with the add-ons review process, you can read about it here."
 msgstr "若您不熟悉附加元件的審查過程，可以在此處閱讀。"
 
-#: static/js/common/upload-addon.js:555
+#: static/js/common/upload-addon.js:540 static/js/zamboni/devhub-all.js:786 static/js/zamboni/devhub-min.js:1
 msgid "Sorry, no supported platform has been found."
 msgstr "抱歉，找不到支援的平台。"
 
-#: static/js/common/upload-base.js:57
+#: static/js/common/upload-base.js:57 static/js/zamboni/devhub-all.js:187 static/js/zamboni/devhub-min.js:1
 msgid "The filetype you uploaded isn't recognized."
 msgstr "無法辨識您上傳的檔案格式。"
 
-#: static/js/common/upload-base.js:79
+#: static/js/common/upload-base.js:79 static/js/zamboni/devhub-all.js:209 static/js/zamboni/devhub-min.js:1
 msgid "You cancelled the upload."
 msgstr "您已經取消上傳了。"
 
-#: static/js/common/upload-image.js:97 static/js/impala/users.js:51
-msgid "Images must be either PNG or JPG."
-msgstr "圖片必須是 PNG 或 JPG 格式。"
-
-#: static/js/common/upload-image.js:101
-msgid "Videos must be in WebM."
-msgstr "影片必須為 WebM 格式。"
-
-#: static/js/impala/collections.js:10 static/js/zamboni/collections.js:595
-msgid "Follow this Collection"
-msgstr "追蹤這個收藏集"
-
-#: static/js/impala/collections.js:19
-msgid "Stop Following"
-msgstr "停止訂閱"
-
-#: static/js/impala/collections.js:20
-msgid "Following"
-msgstr "訂閱中"
-
-#. L10n: {0} is an app name.
-#: static/js/impala/listing.js:11 static/js/zamboni/themes.js:13
-msgid "This theme is incompatible with your version of {0}"
-msgstr "這個佈景主題與您所使用的 {0} 版本不相容"
-
-#: static/js/impala/persona_creation.js:60
-msgid "All Rights Reserved"
-msgstr "保留所有權利"
-
-#: static/js/impala/persona_creation.js:64
-msgid "Creative Commons Attribution 3.0"
-msgstr "Creative Commons 姓名標示 3.0"
-
-#: static/js/impala/persona_creation.js:69
-msgid "Creative Commons Attribution-NonCommercial 3.0"
-msgstr "Creative Commons 姓名標示-非商業性 3.0"
-
-#: static/js/impala/persona_creation.js:74
-msgid "Creative Commons Attribution-NonCommercial-NoDerivs 3.0"
-msgstr "Creative Commons 姓名標示-非商業性-禁止改作 3.0"
-
-#: static/js/impala/persona_creation.js:79
-msgid "Creative Commons Attribution-NonCommercial-Share Alike 3.0"
-msgstr "Creative Commons 姓名標示-非商業性-相同方式分享 3.0"
-
-#: static/js/impala/persona_creation.js:84
-msgid "Creative Commons Attribution-NoDerivs 3.0"
-msgstr "Creative Commons 姓名標示-禁止改作 3.0"
-
-#: static/js/impala/persona_creation.js:89
-msgid "Creative Commons Attribution-ShareAlike 3.0"
-msgstr "Creative Commons 姓名標示-相同方式分享 3.0"
-
-#: static/js/impala/persona_creation.js:292
-msgid "Your Theme's Name"
-msgstr "您的佈景主題名稱"
-
-#: static/js/impala/reviews.js:23 static/js/zamboni/reviews.js:18
-msgid "Flagged for review"
-msgstr "評論已被標記"
-
-#: static/js/impala/reviews.js:40 static/js/zamboni/reviews.js:34
-msgid "Your input is required"
-msgstr "必填"
-
-#: static/js/impala/reviews.js:152 static/js/zamboni/reviews.js:103
-msgid "Marked for deletion"
-msgstr "標示刪除"
-
-#: static/js/impala/search.js:114
-msgid "Updating results&hellip;"
-msgstr "正在更新搜尋結果&hellip;"
-
-#: static/js/impala/site_suggestions.js:46
-msgid "Category"
-msgstr "分類"
-
-#: static/js/impala/suggestions.js:39
-msgid "Search themes for <b>{0}</b>"
-msgstr "搜尋符合<b>{0}</b>的佈景主題"
-
-#: static/js/impala/suggestions.js:41
-msgid "Search apps for <b>{0}</b>"
-msgstr "搜尋含有 <b>{0}</b>的應用程式"
-
-#: static/js/impala/suggestions.js:43
-msgid "Search add-ons for <b>{0}</b>"
-msgstr "搜尋含有 <b>{0}</b> 的附加元件"
-
-#: static/js/impala/users.js:33
-msgid "use original"
-msgstr "使用原始的"
-
-#: static/js/impala/stats/chart.js:267
+#: static/js/impala/stats/chart.js:267 static/js/zamboni/stats-all.js:16898 static/js/zamboni/stats-min.js:5
 msgid "Week of {0}"
 msgstr "第 {0} 週"
 
-#: static/js/impala/stats/chart.js:269
+#: static/js/impala/stats/chart.js:269 static/js/zamboni/stats-all.js:16900 static/js/zamboni/stats-min.js:5
 msgid " downloads"
-msgstr " 下載"
+msgstr ""
 
-#: static/js/impala/stats/chart.js:270
+#: static/js/impala/stats/chart.js:270 static/js/zamboni/stats-all.js:16901 static/js/zamboni/stats-min.js:5
 msgid "{0} users"
 msgstr "{0} 位使用者"
 
-#: static/js/impala/stats/chart.js:271
+#: static/js/impala/stats/chart.js:271 static/js/zamboni/stats-all.js:16902 static/js/zamboni/stats-min.js:5
 msgid "{0} add-ons"
 msgstr "{0} 個附加元件"
 
-#: static/js/impala/stats/chart.js:272
+#: static/js/impala/stats/chart.js:272 static/js/zamboni/stats-all.js:16903 static/js/zamboni/stats-min.js:5
 msgid "{0} collections"
 msgstr "{0} 個收藏集"
 
-#: static/js/impala/stats/chart.js:273
+#: static/js/impala/stats/chart.js:273 static/js/zamboni/stats-all.js:16904 static/js/zamboni/stats-min.js:5
 msgid "{0} reviews"
 msgstr "{0} 個評論"
 
-#: static/js/impala/stats/chart.js:275
+#: static/js/impala/stats/chart.js:275 static/js/zamboni/stats-all.js:16906 static/js/zamboni/stats-min.js:5
 msgid "{0} sales"
 msgstr "{0} 筆銷售"
 
-#: static/js/impala/stats/chart.js:276
+#: static/js/impala/stats/chart.js:276 static/js/zamboni/stats-all.js:16907 static/js/zamboni/stats-min.js:5
 msgid "{0} refunds"
 msgstr "{0} 筆退費"
 
-#: static/js/impala/stats/chart.js:277
+#: static/js/impala/stats/chart.js:277 static/js/zamboni/stats-all.js:16908 static/js/zamboni/stats-min.js:5
 msgid "{0} installs"
 msgstr "{0} 個安裝數"
 
-#: static/js/impala/stats/chart.js:369 static/js/impala/stats/csv_keys.js:3 static/js/impala/stats/csv_keys.js:109
+#: static/js/impala/stats/chart.js:369 static/js/impala/stats/csv_keys.js:3 static/js/impala/stats/csv_keys.js:109 static/js/zamboni/stats-all.js:15284 static/js/zamboni/stats-all.js:15390
+#: static/js/zamboni/stats-all.js:17000 static/js/zamboni/stats-min.js:4 static/js/zamboni/stats-min.js:5
 msgid "Downloads"
 msgstr "下載數"
 
-#: static/js/impala/stats/chart.js:379 static/js/impala/stats/csv_keys.js:6 static/js/impala/stats/csv_keys.js:110
+#: static/js/impala/stats/chart.js:379 static/js/impala/stats/csv_keys.js:6 static/js/impala/stats/csv_keys.js:110 static/js/zamboni/stats-all.js:15287 static/js/zamboni/stats-all.js:15391
+#: static/js/zamboni/stats-all.js:17010 static/js/zamboni/stats-min.js:4 static/js/zamboni/stats-min.js:5
 msgid "Daily Users"
 msgstr "每日使用者"
 
-#: static/js/impala/stats/chart.js:410
+#: static/js/impala/stats/chart.js:410 static/js/zamboni/stats-all.js:17041 static/js/zamboni/stats-min.js:5
 msgid "Amount, in USD"
 msgstr "金額，以美元計價"
 
-#: static/js/impala/stats/chart.js:421 static/js/impala/stats/csv_keys.js:104
+#: static/js/impala/stats/chart.js:421 static/js/impala/stats/csv_keys.js:104 static/js/zamboni/stats-all.js:15385 static/js/zamboni/stats-all.js:17052 static/js/zamboni/stats-min.js:5
 msgid "Number of Contributions"
 msgstr "捐款次數"
 
-#: static/js/impala/stats/chart.js:447
+#: static/js/impala/stats/chart.js:447 static/js/zamboni/stats-all.js:17078 static/js/zamboni/stats-min.js:5
 msgid "More Info..."
 msgstr "更多資訊..."
 
 #. L10n: {0} is an ISO-formatted date.
-#: static/js/impala/stats/chart.js:451
+#: static/js/impala/stats/chart.js:451 static/js/zamboni/stats-all.js:17082 static/js/zamboni/stats-min.js:5
 msgid "Details for {0}"
 msgstr "{0} 的詳細資訊"
 
-#: static/js/impala/stats/csv_keys.js:9
+#: static/js/impala/stats/csv_keys.js:9 static/js/zamboni/stats-all.js:15290 static/js/zamboni/stats-min.js:4
 msgid "Collections Created"
 msgstr "已建立的收藏集"
 
-#: static/js/impala/stats/csv_keys.js:12
+#: static/js/impala/stats/csv_keys.js:12 static/js/zamboni/stats-all.js:15293 static/js/zamboni/stats-min.js:4
 msgid "Add-ons in Use"
 msgstr "使用的附加元件"
 
-#: static/js/impala/stats/csv_keys.js:15
+#: static/js/impala/stats/csv_keys.js:15 static/js/zamboni/stats-all.js:15296 static/js/zamboni/stats-min.js:4
 msgid "Add-ons Created"
 msgstr "建立的附加元件"
 
-#: static/js/impala/stats/csv_keys.js:18
+#: static/js/impala/stats/csv_keys.js:18 static/js/zamboni/stats-all.js:15299 static/js/zamboni/stats-min.js:4
 msgid "Add-ons Downloaded"
 msgstr "下載過的附加元件"
 
-#: static/js/impala/stats/csv_keys.js:21
+#: static/js/impala/stats/csv_keys.js:21 static/js/zamboni/stats-all.js:15302 static/js/zamboni/stats-min.js:4
 msgid "Add-ons Updated"
 msgstr "已更新的附加元件"
 
-#: static/js/impala/stats/csv_keys.js:24
+#: static/js/impala/stats/csv_keys.js:24 static/js/zamboni/stats-all.js:15305 static/js/zamboni/stats-min.js:4
 msgid "Reviews Written"
 msgstr "寫過的意見"
 
-#: static/js/impala/stats/csv_keys.js:27
+#: static/js/impala/stats/csv_keys.js:27 static/js/zamboni/stats-all.js:15308 static/js/zamboni/stats-min.js:4
 msgid "User Signups"
 msgstr "註冊過的使用者"
 
-#: static/js/impala/stats/csv_keys.js:30
+#: static/js/impala/stats/csv_keys.js:30 static/js/zamboni/stats-all.js:15311 static/js/zamboni/stats-min.js:4
 msgid "Subscribers"
 msgstr "訂閱者"
 
-#: static/js/impala/stats/csv_keys.js:33
+#: static/js/impala/stats/csv_keys.js:33 static/js/zamboni/stats-all.js:15314 static/js/zamboni/stats-min.js:4
 msgid "Ratings"
 msgstr "評分"
 
-#: static/js/impala/stats/csv_keys.js:36 static/js/impala/stats/csv_keys.js:114
+#: static/js/impala/stats/csv_keys.js:36 static/js/impala/stats/csv_keys.js:114 static/js/zamboni/stats-all.js:15317 static/js/zamboni/stats-all.js:15395 static/js/zamboni/stats-min.js:4
+#: static/js/zamboni/stats-min.js:5
 msgid "Sales"
 msgstr "銷售"
 
-#: static/js/impala/stats/csv_keys.js:39 static/js/impala/stats/csv_keys.js:113
+#: static/js/impala/stats/csv_keys.js:39 static/js/impala/stats/csv_keys.js:113 static/js/zamboni/stats-all.js:15320 static/js/zamboni/stats-all.js:15394 static/js/zamboni/stats-min.js:4
+#: static/js/zamboni/stats-min.js:5
 msgid "Installs"
 msgstr "安裝數"
 
-#: static/js/impala/stats/csv_keys.js:42
+#: static/js/impala/stats/csv_keys.js:42 static/js/zamboni/stats-all.js:15323 static/js/zamboni/stats-min.js:4
 msgid "Unknown"
 msgstr "未知"
 
-#: static/js/impala/stats/csv_keys.js:43
+#: static/js/impala/stats/csv_keys.js:43 static/js/zamboni/stats-all.js:15324 static/js/zamboni/stats-min.js:4
 msgid "Add-ons Manager"
 msgstr "附加元件管理員"
 
-#: static/js/impala/stats/csv_keys.js:44
+#: static/js/impala/stats/csv_keys.js:44 static/js/zamboni/stats-all.js:15325 static/js/zamboni/stats-min.js:4
 msgid "Add-ons Manager Promo"
 msgstr "附加元件管理員 Promo"
 
-#: static/js/impala/stats/csv_keys.js:45
+#: static/js/impala/stats/csv_keys.js:45 static/js/zamboni/stats-all.js:15326 static/js/zamboni/stats-min.js:4
 msgid "Add-ons Manager Featured"
 msgstr "附加元件管理員精選"
 
-#: static/js/impala/stats/csv_keys.js:46
+#: static/js/impala/stats/csv_keys.js:46 static/js/zamboni/stats-all.js:15327 static/js/zamboni/stats-min.js:4
 msgid "Add-ons Manager Learn More"
 msgstr "附加元件管理員了解更多"
 
-#: static/js/impala/stats/csv_keys.js:47
+#: static/js/impala/stats/csv_keys.js:47 static/js/zamboni/stats-all.js:15328 static/js/zamboni/stats-min.js:4
 msgid "Search Suggestions"
 msgstr "搜尋建議"
 
-#: static/js/impala/stats/csv_keys.js:48
+#: static/js/impala/stats/csv_keys.js:48 static/js/zamboni/stats-all.js:15329 static/js/zamboni/stats-min.js:4
 msgid "Search Results"
 msgstr "搜尋結果"
 
-#: static/js/impala/stats/csv_keys.js:49 static/js/impala/stats/csv_keys.js:50 static/js/impala/stats/csv_keys.js:51
+#: static/js/impala/stats/csv_keys.js:49 static/js/impala/stats/csv_keys.js:50 static/js/impala/stats/csv_keys.js:51 static/js/zamboni/stats-all.js:15330 static/js/zamboni/stats-all.js:15331
+#: static/js/zamboni/stats-all.js:15332 static/js/zamboni/stats-min.js:4
 msgid "Homepage Promo"
 msgstr "首頁促銷"
 
-#: static/js/impala/stats/csv_keys.js:52 static/js/impala/stats/csv_keys.js:53
+#: static/js/impala/stats/csv_keys.js:52 static/js/impala/stats/csv_keys.js:53 static/js/zamboni/stats-all.js:15333 static/js/zamboni/stats-all.js:15334 static/js/zamboni/stats-min.js:4
 msgid "Homepage Featured"
 msgstr "首頁精選"
 
-#: static/js/impala/stats/csv_keys.js:54 static/js/impala/stats/csv_keys.js:55
+#: static/js/impala/stats/csv_keys.js:54 static/js/impala/stats/csv_keys.js:55 static/js/zamboni/stats-all.js:15335 static/js/zamboni/stats-all.js:15336 static/js/zamboni/stats-min.js:4
 msgid "Homepage Up and Coming"
 msgstr "首頁嶄露頭角"
 
-#: static/js/impala/stats/csv_keys.js:56
+#: static/js/impala/stats/csv_keys.js:56 static/js/zamboni/stats-all.js:15337 static/js/zamboni/stats-min.js:4
 msgid "Homepage Most Popular"
 msgstr "首頁最熱門"
 
-#: static/js/impala/stats/csv_keys.js:57 static/js/impala/stats/csv_keys.js:59
+#: static/js/impala/stats/csv_keys.js:57 static/js/impala/stats/csv_keys.js:59 static/js/zamboni/stats-all.js:15338 static/js/zamboni/stats-all.js:15340 static/js/zamboni/stats-min.js:4
 msgid "Detail Page"
 msgstr "詳細資訊頁面"
 
-#: static/js/impala/stats/csv_keys.js:58 static/js/impala/stats/csv_keys.js:60
+#: static/js/impala/stats/csv_keys.js:58 static/js/impala/stats/csv_keys.js:60 static/js/zamboni/stats-all.js:15339 static/js/zamboni/stats-all.js:15341 static/js/zamboni/stats-min.js:4
 msgid "Detail Page (bottom)"
 msgstr "詳細資訊頁面 (底端)"
 
-#: static/js/impala/stats/csv_keys.js:61
+#: static/js/impala/stats/csv_keys.js:61 static/js/zamboni/stats-all.js:15342 static/js/zamboni/stats-min.js:4
 msgid "Detail Page (Development Channel)"
 msgstr "詳細資訊頁面 (開發頻道)"
 
-#: static/js/impala/stats/csv_keys.js:62 static/js/impala/stats/csv_keys.js:63 static/js/impala/stats/csv_keys.js:64
+#: static/js/impala/stats/csv_keys.js:62 static/js/impala/stats/csv_keys.js:63 static/js/impala/stats/csv_keys.js:64 static/js/zamboni/stats-all.js:15343 static/js/zamboni/stats-all.js:15344
+#: static/js/zamboni/stats-all.js:15345 static/js/zamboni/stats-min.js:4
 msgid "Often Used With"
 msgstr "常與以下元件混用"
 
-#: static/js/impala/stats/csv_keys.js:65 static/js/impala/stats/csv_keys.js:66
+#: static/js/impala/stats/csv_keys.js:65 static/js/impala/stats/csv_keys.js:66 static/js/zamboni/stats-all.js:15346 static/js/zamboni/stats-all.js:15347 static/js/zamboni/stats-min.js:4
 msgid "Others By Author"
 msgstr "由我建立的元件"
 
-#: static/js/impala/stats/csv_keys.js:67 static/js/impala/stats/csv_keys.js:68
+#: static/js/impala/stats/csv_keys.js:67 static/js/impala/stats/csv_keys.js:68 static/js/zamboni/stats-all.js:15348 static/js/zamboni/stats-all.js:15349 static/js/zamboni/stats-min.js:4
 msgid "Dependencies"
 msgstr "相依性"
 
-#: static/js/impala/stats/csv_keys.js:69 static/js/impala/stats/csv_keys.js:70
+#: static/js/impala/stats/csv_keys.js:69 static/js/impala/stats/csv_keys.js:70 static/js/zamboni/stats-all.js:15350 static/js/zamboni/stats-all.js:15351 static/js/zamboni/stats-min.js:4
 msgid "Upsell"
 msgstr "付費升級"
 
-#: static/js/impala/stats/csv_keys.js:71
+#: static/js/impala/stats/csv_keys.js:71 static/js/zamboni/stats-all.js:15352 static/js/zamboni/stats-min.js:4
 msgid "Meet the Developer"
 msgstr "認識開發者"
 
-#: static/js/impala/stats/csv_keys.js:72
+#: static/js/impala/stats/csv_keys.js:72 static/js/zamboni/stats-all.js:15353 static/js/zamboni/stats-min.js:4
 msgid "User Profile"
 msgstr "使用者資料"
 
-#: static/js/impala/stats/csv_keys.js:73
+#: static/js/impala/stats/csv_keys.js:73 static/js/zamboni/stats-all.js:15354 static/js/zamboni/stats-min.js:4
 msgid "Version History"
 msgstr "版本紀錄"
 
-#: static/js/impala/stats/csv_keys.js:75
+#: static/js/impala/stats/csv_keys.js:75 static/js/zamboni/stats-all.js:15356 static/js/zamboni/stats-min.js:4
 msgid "Sharing"
 msgstr "分享"
 
-#: static/js/impala/stats/csv_keys.js:76
+#: static/js/impala/stats/csv_keys.js:76 static/js/zamboni/stats-all.js:15357 static/js/zamboni/stats-min.js:4
 msgid "Category Pages"
 msgstr "類別頁面"
 
-#: static/js/impala/stats/csv_keys.js:77
+#: static/js/impala/stats/csv_keys.js:77 static/js/zamboni/stats-all.js:15358 static/js/zamboni/stats-min.js:4
 msgid "Collections"
 msgstr "收藏集"
 
-#: static/js/impala/stats/csv_keys.js:78 static/js/impala/stats/csv_keys.js:79
+#: static/js/impala/stats/csv_keys.js:78 static/js/impala/stats/csv_keys.js:79 static/js/zamboni/stats-all.js:15359 static/js/zamboni/stats-all.js:15360 static/js/zamboni/stats-min.js:4
 msgid "Category Landing Featured Carousel"
 msgstr "分類 Landing 精選旋轉木馬"
 
-#: static/js/impala/stats/csv_keys.js:80 static/js/impala/stats/csv_keys.js:81
+#: static/js/impala/stats/csv_keys.js:80 static/js/impala/stats/csv_keys.js:81 static/js/zamboni/stats-all.js:15361 static/js/zamboni/stats-all.js:15362 static/js/zamboni/stats-min.js:4
 msgid "Category Landing Top Rated"
 msgstr "分類 Landing 評分最高"
 
-#: static/js/impala/stats/csv_keys.js:82 static/js/impala/stats/csv_keys.js:83
+#: static/js/impala/stats/csv_keys.js:82 static/js/impala/stats/csv_keys.js:83 static/js/zamboni/stats-all.js:15363 static/js/zamboni/stats-all.js:15364 static/js/zamboni/stats-min.js:5
 msgid "Category Landing Most Popular"
 msgstr "分類 Landing 最熱門"
 
-#: static/js/impala/stats/csv_keys.js:84 static/js/impala/stats/csv_keys.js:85
+#: static/js/impala/stats/csv_keys.js:84 static/js/impala/stats/csv_keys.js:85 static/js/zamboni/stats-all.js:15365 static/js/zamboni/stats-all.js:15366 static/js/zamboni/stats-min.js:5
 msgid "Category Landing Recently Added"
 msgstr "分類 Landing 最近新增"
 
-#: static/js/impala/stats/csv_keys.js:86 static/js/impala/stats/csv_keys.js:87
+#: static/js/impala/stats/csv_keys.js:86 static/js/impala/stats/csv_keys.js:87 static/js/zamboni/stats-all.js:15367 static/js/zamboni/stats-all.js:15368 static/js/zamboni/stats-min.js:5
 msgid "Browse Listing Featured Sort"
 msgstr "瀏覽頁面精選類別"
 
-#: static/js/impala/stats/csv_keys.js:88 static/js/impala/stats/csv_keys.js:89
+#: static/js/impala/stats/csv_keys.js:88 static/js/impala/stats/csv_keys.js:89 static/js/zamboni/stats-all.js:15369 static/js/zamboni/stats-all.js:15370 static/js/zamboni/stats-min.js:5
 msgid "Browse Listing Users Sort"
 msgstr "瀏覽頁面使用者類別"
 
-#: static/js/impala/stats/csv_keys.js:90 static/js/impala/stats/csv_keys.js:91
+#: static/js/impala/stats/csv_keys.js:90 static/js/impala/stats/csv_keys.js:91 static/js/zamboni/stats-all.js:15371 static/js/zamboni/stats-all.js:15372 static/js/zamboni/stats-min.js:5
 msgid "Browse Listing Rating Sort"
 msgstr "瀏覽頁面評分類別"
 
-#: static/js/impala/stats/csv_keys.js:92 static/js/impala/stats/csv_keys.js:93
+#: static/js/impala/stats/csv_keys.js:92 static/js/impala/stats/csv_keys.js:93 static/js/zamboni/stats-all.js:15373 static/js/zamboni/stats-all.js:15374 static/js/zamboni/stats-min.js:5
 msgid "Browse Listing Created Sort"
 msgstr "瀏覽頁面 Created 類別"
 
-#: static/js/impala/stats/csv_keys.js:94 static/js/impala/stats/csv_keys.js:95
+#: static/js/impala/stats/csv_keys.js:94 static/js/impala/stats/csv_keys.js:95 static/js/zamboni/stats-all.js:15375 static/js/zamboni/stats-all.js:15376 static/js/zamboni/stats-min.js:5
 msgid "Browse Listing Name Sort"
 msgstr "瀏覽頁面名稱類別"
 
-#: static/js/impala/stats/csv_keys.js:96 static/js/impala/stats/csv_keys.js:97
+#: static/js/impala/stats/csv_keys.js:96 static/js/impala/stats/csv_keys.js:97 static/js/zamboni/stats-all.js:15377 static/js/zamboni/stats-all.js:15378 static/js/zamboni/stats-min.js:5
 msgid "Browse Listing Popular Sort"
 msgstr "瀏覽頁面熱門類別"
 
-#: static/js/impala/stats/csv_keys.js:98 static/js/impala/stats/csv_keys.js:99
+#: static/js/impala/stats/csv_keys.js:98 static/js/impala/stats/csv_keys.js:99 static/js/zamboni/stats-all.js:15379 static/js/zamboni/stats-all.js:15380 static/js/zamboni/stats-min.js:5
 msgid "Browse Listing Updated Sort"
 msgstr "瀏覽頁面已更新類別"
 
-#: static/js/impala/stats/csv_keys.js:100 static/js/impala/stats/csv_keys.js:101
+#: static/js/impala/stats/csv_keys.js:100 static/js/impala/stats/csv_keys.js:101 static/js/zamboni/stats-all.js:15381 static/js/zamboni/stats-all.js:15382 static/js/zamboni/stats-min.js:5
 msgid "Browse Listing Up and Coming Sort"
 msgstr "瀏覽頁面嶄露頭角類別"
 
-#: static/js/impala/stats/csv_keys.js:105
+#: static/js/impala/stats/csv_keys.js:105 static/js/zamboni/stats-all.js:15386 static/js/zamboni/stats-min.js:5
 msgid "Total Amount Contributed"
 msgstr "總共貢獻量"
 
-#: static/js/impala/stats/csv_keys.js:106
+#: static/js/impala/stats/csv_keys.js:106 static/js/zamboni/stats-all.js:15387 static/js/zamboni/stats-min.js:5
 msgid "Average Contribution"
 msgstr "平均貢獻"
 
-#: static/js/impala/stats/csv_keys.js:115
+#: static/js/impala/stats/csv_keys.js:115 static/js/zamboni/stats-all.js:15396 static/js/zamboni/stats-min.js:5
 msgid "Usage"
 msgstr "使用情況"
 
-#: static/js/impala/stats/csv_keys.js:118
+#: static/js/impala/stats/csv_keys.js:118 static/js/zamboni/stats-all.js:15399 static/js/zamboni/stats-min.js:5
 msgid "Firefox"
 msgstr "Firefox"
 
-#: static/js/impala/stats/csv_keys.js:119
+#: static/js/impala/stats/csv_keys.js:119 static/js/zamboni/stats-all.js:15400 static/js/zamboni/stats-min.js:5
 msgid "Mozilla"
 msgstr "Mozilla"
 
-#: static/js/impala/stats/csv_keys.js:120
+#: static/js/impala/stats/csv_keys.js:120 static/js/zamboni/stats-all.js:15401 static/js/zamboni/stats-min.js:5
 msgid "Thunderbird"
 msgstr "thunderbird"
 
-#: static/js/impala/stats/csv_keys.js:121
+#: static/js/impala/stats/csv_keys.js:121 static/js/zamboni/stats-all.js:15402 static/js/zamboni/stats-min.js:5
 msgid "Sunbird"
 msgstr "Sunbird"
 
-#: static/js/impala/stats/csv_keys.js:122
+#: static/js/impala/stats/csv_keys.js:122 static/js/zamboni/stats-all.js:15403 static/js/zamboni/stats-min.js:5
 msgid "SeaMonkey"
 msgstr "SeaMonkey"
 
-#: static/js/impala/stats/csv_keys.js:123
+#: static/js/impala/stats/csv_keys.js:123 static/js/zamboni/stats-all.js:15404 static/js/zamboni/stats-min.js:5
 msgid "Fennec"
 msgstr "Fennec"
 
-#: static/js/impala/stats/csv_keys.js:124
+#: static/js/impala/stats/csv_keys.js:124 static/js/zamboni/stats-all.js:15405 static/js/zamboni/stats-min.js:5
 msgid "Android"
 msgstr "Android"
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:129
+#: static/js/impala/stats/csv_keys.js:129 static/js/zamboni/stats-all.js:15410 static/js/zamboni/stats-min.js:5
 msgid "Downloads and Daily Users, last {0} days"
 msgstr "下載數與每日使用者數，最近 {0} 天"
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:131
+#: static/js/impala/stats/csv_keys.js:131 static/js/zamboni/stats-all.js:15412 static/js/zamboni/stats-min.js:5
 msgid "Downloads and Daily Users from {0} to {1}"
 msgstr "下載數與每日使用者數，從 {0} 至 {1}"
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:135
+#: static/js/impala/stats/csv_keys.js:135 static/js/zamboni/stats-all.js:15416 static/js/zamboni/stats-min.js:5
 msgid "Installs and Daily Users, last {0} days"
 msgstr "安裝數與每日使用者數，最近 {0} 天"
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:137
+#: static/js/impala/stats/csv_keys.js:137 static/js/zamboni/stats-all.js:15418 static/js/zamboni/stats-min.js:5
 msgid "Installs and Daily Users from {0} to {1}"
 msgstr "安裝數與每日使用者數，從 {0} 至 {1}"
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:141
+#: static/js/impala/stats/csv_keys.js:141 static/js/zamboni/stats-all.js:15422 static/js/zamboni/stats-min.js:5
 msgid "Downloads, last {0} days"
 msgstr "下載數，最近 {0} 天"
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:143
+#: static/js/impala/stats/csv_keys.js:143 static/js/zamboni/stats-all.js:15424 static/js/zamboni/stats-min.js:5
 msgid "Downloads from {0} to {1}"
 msgstr "下載數，從 {0} 至 {1}"
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:147
+#: static/js/impala/stats/csv_keys.js:147 static/js/zamboni/stats-all.js:15428 static/js/zamboni/stats-min.js:5
 msgid "Daily Users, last {0} days"
 msgstr "每日使用者數，最近 {0} 天"
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:149
+#: static/js/impala/stats/csv_keys.js:149 static/js/zamboni/stats-all.js:15430 static/js/zamboni/stats-min.js:5
 msgid "Daily Users from {0} to {1}"
 msgstr "每日使用者數，從 {0} 至 {1}"
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:153
+#: static/js/impala/stats/csv_keys.js:153 static/js/zamboni/stats-all.js:15434 static/js/zamboni/stats-min.js:5
 msgid "Applications, last {0} days"
 msgstr "應用程式，最近 {0} 天"
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:155
+#: static/js/impala/stats/csv_keys.js:155 static/js/zamboni/stats-all.js:15436 static/js/zamboni/stats-min.js:5
 msgid "Applications from {0} to {1}"
 msgstr "應用程式，從 {0} 至 {1}"
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:159
+#: static/js/impala/stats/csv_keys.js:159 static/js/zamboni/stats-all.js:15440 static/js/zamboni/stats-min.js:5
 msgid "Platforms, last {0} days"
 msgstr "平台，最近 {0} 天"
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:161
+#: static/js/impala/stats/csv_keys.js:161 static/js/zamboni/stats-all.js:15442 static/js/zamboni/stats-min.js:5
 msgid "Platforms from {0} to {1}"
 msgstr "平台，從 {0} 至 {1}"
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:165
+#: static/js/impala/stats/csv_keys.js:165 static/js/zamboni/stats-all.js:15446 static/js/zamboni/stats-min.js:5
 msgid "Languages, last {0} days"
 msgstr "語言，最近 {0} 天"
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:167
+#: static/js/impala/stats/csv_keys.js:167 static/js/zamboni/stats-all.js:15448 static/js/zamboni/stats-min.js:5
 msgid "Languages from {0} to {1}"
 msgstr "語言，從 {0} 至 {1}"
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:171
+#: static/js/impala/stats/csv_keys.js:171 static/js/zamboni/stats-all.js:15452 static/js/zamboni/stats-min.js:5
 msgid "Add-on Versions, last {0} days"
 msgstr "附加元件版本，最近 {0} 天"
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:173
+#: static/js/impala/stats/csv_keys.js:173 static/js/zamboni/stats-all.js:15454 static/js/zamboni/stats-min.js:5
 msgid "Add-on Versions from {0} to {1}"
 msgstr "附加元件版本，從 {0} 至 {1}"
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:177
+#: static/js/impala/stats/csv_keys.js:177 static/js/zamboni/stats-all.js:15458 static/js/zamboni/stats-min.js:5
 msgid "Add-on Status, last {0} days"
 msgstr "附加元件狀態，最近 {0} 天"
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:179
+#: static/js/impala/stats/csv_keys.js:179 static/js/zamboni/stats-all.js:15460 static/js/zamboni/stats-min.js:5
 msgid "Add-on Status from {0} to {1}"
 msgstr "附加元件狀態，從 {0} 至 {1}"
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:183
+#: static/js/impala/stats/csv_keys.js:183 static/js/zamboni/stats-all.js:15464 static/js/zamboni/stats-min.js:5
 msgid "Download Sources, last {0} days"
 msgstr "下載來源，最近 {0} 天"
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:185
+#: static/js/impala/stats/csv_keys.js:185 static/js/zamboni/stats-all.js:15466 static/js/zamboni/stats-min.js:5
 msgid "Download Sources from {0} to {1}"
 msgstr "下載來源，從 {0} 至 {1}"
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:189
+#: static/js/impala/stats/csv_keys.js:189 static/js/zamboni/stats-all.js:15470 static/js/zamboni/stats-min.js:5
 msgid "Contributions, last {0} days"
 msgstr "貢獻，最近 {0} 天"
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:191
+#: static/js/impala/stats/csv_keys.js:191 static/js/zamboni/stats-all.js:15472 static/js/zamboni/stats-min.js:5
 msgid "Contributions from {0} to {1}"
 msgstr "從 {0} 至 {1} 的貢獻"
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:195
+#: static/js/impala/stats/csv_keys.js:195 static/js/zamboni/stats-all.js:15476 static/js/zamboni/stats-min.js:5
 msgid "Site Metrics, last {0} days"
 msgstr "網頁分析，最近 {0} 天"
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:197
+#: static/js/impala/stats/csv_keys.js:197 static/js/zamboni/stats-all.js:15478 static/js/zamboni/stats-min.js:5
 msgid "Site Metrics from {0} to {1}"
 msgstr "網頁分析，從 {0} 至 {1}"
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:201
+#: static/js/impala/stats/csv_keys.js:201 static/js/zamboni/stats-all.js:15482 static/js/zamboni/stats-min.js:5
 msgid "Add-ons in Use, last {0} days"
 msgstr "使用中的附加元件，最近 {0} 天"
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:203
+#: static/js/impala/stats/csv_keys.js:203 static/js/zamboni/stats-all.js:15484 static/js/zamboni/stats-min.js:5
 msgid "Add-ons in Use from {0} to {1}"
 msgstr "使用中的附加元件，從 {0} 至 {1}"
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:207
+#: static/js/impala/stats/csv_keys.js:207 static/js/zamboni/stats-all.js:15488 static/js/zamboni/stats-min.js:5
 msgid "Add-ons Downloaded, last {0} days"
 msgstr "附加元件下載數，最近 {0} 天"
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:209
+#: static/js/impala/stats/csv_keys.js:209 static/js/zamboni/stats-all.js:15490 static/js/zamboni/stats-min.js:5
 msgid "Add-ons Downloaded from {0} to {1}"
 msgstr "附加元件下載數，從 {0} 至 {1}"
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:213
+#: static/js/impala/stats/csv_keys.js:213 static/js/zamboni/stats-all.js:15494 static/js/zamboni/stats-min.js:5
 msgid "Add-ons Created, last {0} days"
 msgstr "新建立的附加元件，最近 {0} 天"
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:215
+#: static/js/impala/stats/csv_keys.js:215 static/js/zamboni/stats-all.js:15496 static/js/zamboni/stats-min.js:5
 msgid "Add-ons Created from {0} to {1}"
 msgstr "新建立的附加元件，從 {0} 至 {1}"
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:219
+#: static/js/impala/stats/csv_keys.js:219 static/js/zamboni/stats-all.js:15500 static/js/zamboni/stats-min.js:5
 msgid "Add-ons Updated, last {0} days"
 msgstr "有更新的附加元件，最近 {0} 天"
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:221
+#: static/js/impala/stats/csv_keys.js:221 static/js/zamboni/stats-all.js:15502 static/js/zamboni/stats-min.js:5
 msgid "Add-ons Updated from {0} to {1}"
 msgstr "有更新的附加元件，從 {0} 至 {1}"
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:225
+#: static/js/impala/stats/csv_keys.js:225 static/js/zamboni/stats-all.js:15506 static/js/zamboni/stats-min.js:5
 msgid "Reviews Written, last {0} days"
 msgstr "給出的留言，最近 {0} 天"
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:227
+#: static/js/impala/stats/csv_keys.js:227 static/js/zamboni/stats-all.js:15508 static/js/zamboni/stats-min.js:5
 msgid "Reviews Written from {0} to {1}"
 msgstr "給出的留言，從 {0} 至 {1}"
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:231
+#: static/js/impala/stats/csv_keys.js:231 static/js/zamboni/stats-all.js:15512 static/js/zamboni/stats-min.js:5
 msgid "User Signups, last {0} days"
 msgstr "註冊的使用者，最近 {0} 天"
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:233
+#: static/js/impala/stats/csv_keys.js:233 static/js/zamboni/stats-all.js:15514 static/js/zamboni/stats-min.js:5
 msgid "User Signups from {0} to {1}"
 msgstr "註冊的使用者，從 {0} 至 {1}"
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:237
+#: static/js/impala/stats/csv_keys.js:237 static/js/zamboni/stats-all.js:15518 static/js/zamboni/stats-min.js:5
 msgid "Collections Created, last {0} days"
 msgstr "建立的收藏集，最近 {0} 天"
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:239
+#: static/js/impala/stats/csv_keys.js:239 static/js/zamboni/stats-all.js:15520 static/js/zamboni/stats-min.js:5
 msgid "Collections Created from {0} to {1}"
 msgstr "建立的收藏集，從 {0} 至 {1}"
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:243
+#: static/js/impala/stats/csv_keys.js:243 static/js/zamboni/stats-all.js:15524 static/js/zamboni/stats-min.js:5
 msgid "Subscribers, last {0} days"
 msgstr "訂閱者，最近 {0} 天"
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:245
+#: static/js/impala/stats/csv_keys.js:245 static/js/zamboni/stats-all.js:15526 static/js/zamboni/stats-min.js:5
 msgid "Subscribers from {0} to {1}"
 msgstr "訂閱者，從 {0} 至 {1}"
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:249
+#: static/js/impala/stats/csv_keys.js:249 static/js/zamboni/stats-all.js:15530 static/js/zamboni/stats-min.js:5
 msgid "Ratings, last {0} days"
 msgstr "評分，最近 {0} 天"
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:251
+#: static/js/impala/stats/csv_keys.js:251 static/js/zamboni/stats-all.js:15532 static/js/zamboni/stats-min.js:5
 msgid "Ratings from {0} to {1}"
 msgstr "評分，從 {0} 至 {1}"
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:255
+#: static/js/impala/stats/csv_keys.js:255 static/js/zamboni/stats-all.js:15536 static/js/zamboni/stats-min.js:5
 msgid "Sales, last {0} days"
 msgstr "銷售，最近 {0} 天"
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:257
+#: static/js/impala/stats/csv_keys.js:257 static/js/zamboni/stats-all.js:15538 static/js/zamboni/stats-min.js:5
 msgid "Sales from {0} to {1}"
 msgstr "銷售，從 {0} 至 {1}"
 
 #. L10n: {0} is an integer.
-#: static/js/impala/stats/csv_keys.js:261
+#: static/js/impala/stats/csv_keys.js:261 static/js/zamboni/stats-all.js:15542 static/js/zamboni/stats-min.js:5
 msgid "Installs, last {0} days"
 msgstr "安裝數，最近 {0} 天"
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:263
+#: static/js/impala/stats/csv_keys.js:263 static/js/zamboni/stats-all.js:15544 static/js/zamboni/stats-min.js:5
 msgid "Installs from {0} to {1}"
 msgstr "安裝數，從 {0} 至 {1}"
 
 #. L10n: {0} and {1} are integers.
-#: static/js/impala/stats/csv_keys.js:269
+#: static/js/impala/stats/csv_keys.js:269 static/js/zamboni/stats-all.js:15550 static/js/zamboni/stats-min.js:5
 msgid "<b>{0}</b> in last {1} days"
 msgstr "最近 {1} 天有 <b>{0}</b> 個"
 
 #. L10n: {0} is an integer and {1} and {2} are dates in YYYY-MM-DD format.
-#: static/js/impala/stats/csv_keys.js:271 static/js/impala/stats/csv_keys.js:277
+#: static/js/impala/stats/csv_keys.js:271 static/js/impala/stats/csv_keys.js:277 static/js/zamboni/stats-all.js:15552 static/js/zamboni/stats-all.js:15558 static/js/zamboni/stats-min.js:5
 msgid "<b>{0}</b> from {1} to {2}"
 msgstr "從 {1} 至 {2} 的 <b>{0}</b>"
 
 #. L10n: {0} and {1} are integers.
-#: static/js/impala/stats/csv_keys.js:275
+#: static/js/impala/stats/csv_keys.js:275 static/js/zamboni/stats-all.js:15556 static/js/zamboni/stats-min.js:5
 msgid "<b>{0}</b> average in last {1} days"
 msgstr "最近 {1} 天平均有 <b>{0}</b> 個"
 
-#: static/js/impala/stats/overview.js:19
+#: static/js/impala/stats/overview.js:19 static/js/zamboni/stats-all.js:16469 static/js/zamboni/stats-min.js:5
 msgid "No data available."
 msgstr "沒有資料。"
 
-#: static/js/impala/stats/table.js:74
+#: static/js/impala/stats/table.js:74 static/js/zamboni/stats-all.js:17209 static/js/zamboni/stats-min.js:5
 msgid "Date"
 msgstr "日期"
 
-#: static/js/impala/stats/topchart.js:96
+#: static/js/impala/stats/topchart.js:96 static/js/zamboni/stats-all.js:16600 static/js/zamboni/stats-min.js:5
 msgid "Other"
 msgstr "其他"
 
-#: static/js/zamboni/admin_validation.js:24 static/js/zamboni/devhub.js:1229 static/js/zamboni/editors.js:295
+#: static/js/zamboni/admin-all.js:180 static/js/zamboni/admin-min.js:1 static/js/zamboni/admin_validation.js:24 static/js/zamboni/devhub-all.js:2408 static/js/zamboni/devhub-min.js:2
+#: static/js/zamboni/devhub.js:1229 static/js/zamboni/editors-all.js:15576 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:295
 msgid "Select an application first"
 msgstr "請先選擇一份申請書"
 
-#: static/js/zamboni/admin_validation.js:51
+#: static/js/zamboni/admin-all.js:207 static/js/zamboni/admin-min.js:1 static/js/zamboni/admin_validation.js:51
 msgid "Set {0} add-on to a max version of {1} and email the author."
 msgid_plural "Set {0} add-ons to a max version of {1} and email the authors."
 msgstr[0] "把 {0} 個附加元件的最大版本設定為 {1} 並用電子郵件通知作者。"
+msgstr[1] ""
 
-#: static/js/zamboni/admin_validation.js:54
+#: static/js/zamboni/admin-all.js:210 static/js/zamboni/admin-min.js:1 static/js/zamboni/admin_validation.js:54
 msgid "Email author of {2} add-on which failed validation."
 msgid_plural "Email authors of {2} add-ons which failed validation."
 msgstr[0] "通知 {2} 套未通過驗證的附加元件作者。"
+msgstr[1] ""
 
-#. L10n: {0} is an app name like Firefox.
-#: static/js/zamboni/buttons.js:66
-msgid "Accept and Install"
-msgstr "接受並安裝"
-
-#: static/js/zamboni/buttons.js:66
-msgid "Add to {0}"
-msgstr "新增至 {0}"
-
-#: static/js/zamboni/buttons.js:71
-msgid "Download Now"
-msgstr "立刻下載"
-
-#: static/js/zamboni/buttons.js:112
-msgid "Add-on has not been updated to support default-to-compatible."
-msgstr "附加元件未被更新為預設相容版本。"
-
-#: static/js/zamboni/buttons.js:117
-msgid "You need to be using Firefox 10.0 or higher."
-msgstr "您必須使用 Firefox 10.0 或更新版本。"
-
-#: static/js/zamboni/buttons.js:129
-msgid "Mozilla has marked this version as incompatible with your Firefox version."
-msgstr "Mozilla 已將此版本標示為與您的 Firefox 版本不相容。"
-
-#. L10n: {0} is an platform like Windows or Linux.
-#: static/js/zamboni/buttons.js:210
-msgid "Install for {0} anyway"
-msgstr "繼續安裝 {0} 版本"
-
-#: static/js/zamboni/buttons.js:210
-msgid "Download for {0} anyway"
-msgstr "仍然下載 {0}"
-
-#: static/js/zamboni/buttons.js:267
-msgid "Not available for your platform"
-msgstr "與您的作業系統不相容"
-
-#. L10n: {0} is an app name, {1} is the app version.
-#: static/js/zamboni/buttons.js:278 static/js/zamboni/buttons.js:315
-msgid "Not available for {0} {1}"
-msgstr "無法使用於 {0} {1}"
-
-#: static/js/zamboni/buttons.js:341
-msgid "Works with {app} {min} - {max}"
-msgstr "可於 {app} {min} - {max} 使用"
-
-#: static/js/zamboni/buttons.js:343
-msgid "View other versions"
-msgstr "檢視其他版本"
-
-#: static/js/zamboni/buttons.js:391
-msgid "Only with Firefox — Get Firefox Now!"
-msgstr "只在 Firefox 上才有，快來安裝！"
-
-#: static/js/zamboni/buttons.js:507 static/js/zamboni/mobile/buttons.js:43
-msgid "Sorry, you need a Mozilla-based browser (such as Firefox) to install a search plugin."
-msgstr "抱歉，您需要 Mozilla 系列的瀏覽器 (像是 Firefox) 才能安裝此搜尋外掛。"
-
-#: static/js/zamboni/collections.js:229
-msgid "Adding to Favorites&hellip;"
-msgstr "加入至我的最愛&hellip;"
-
-#: static/js/zamboni/collections.js:232
-msgid "Removing Favorite&hellip;"
-msgstr "從我的最愛中移除&hellip;"
-
-#: static/js/zamboni/collections.js:235
-msgid "Add to Favorites"
-msgstr "加入至我的最愛"
-
-#: static/js/zamboni/collections.js:238
-msgid "Remove from Favorites"
-msgstr "從我的最愛中移除"
-
-#: static/js/zamboni/collections.js:303
-msgid "Pending"
-msgstr "擱置"
-
-#: static/js/zamboni/collections.js:304
-msgid "Add a comment"
-msgstr "新增一個意見"
-
-#: static/js/zamboni/collections.js:304
-msgid "Comment"
-msgstr "意見"
-
-#: static/js/zamboni/collections.js:305
-msgid "Remove this add-on from the collection"
-msgstr "從收藏集中移除此附加元件"
-
-#: static/js/zamboni/collections.js:305 static/js/zamboni/collections.js:334
-msgid "Remove"
-msgstr "移除"
-
-#: static/js/zamboni/collections.js:334
-msgid "Remove this user as a contributor"
-msgstr "剝奪這位使用者的貢獻者資格"
-
-#: static/js/zamboni/collections.js:346
-msgid "An email address is required."
-msgstr "必須輸入電子郵件地址。"
-
-#: static/js/zamboni/collections.js:364
-msgid "You cannot add yourself as a contributor."
-msgstr "您不能新增自己為貢獻者。"
-
-#: static/js/zamboni/collections.js:366
-msgid "You have already added that user."
-msgstr "您已經新增該使用者。"
-
-#: static/js/zamboni/collections.js:573
-msgid "Add to favorites"
-msgstr "加入至我的最愛"
-
-#: static/js/zamboni/collections.js:577
-msgid "Remove from favorites"
-msgstr "從我的最愛移除"
-
-#: static/js/zamboni/collections.js:604
-msgid "Stop following"
-msgstr "停止追蹤"
-
-#: static/js/zamboni/devhub.js:110
+#: static/js/zamboni/devhub-all.js:1289 static/js/zamboni/devhub-min.js:1 static/js/zamboni/devhub.js:110
 msgid "Your browser does not support the video tag"
 msgstr "您的瀏覽器不支援此視訊標籤"
 
-#: static/js/zamboni/devhub.js:371
+#: static/js/zamboni/devhub-all.js:1550 static/js/zamboni/devhub-min.js:1 static/js/zamboni/devhub.js:371
 msgid "Changes Saved"
 msgstr "修改已儲存"
 
-#: static/js/zamboni/devhub.js:387
+#: static/js/zamboni/devhub-all.js:1566 static/js/zamboni/devhub-min.js:1 static/js/zamboni/devhub.js:387
 msgid "Enter a new author's email address"
 msgstr "輸入新作者的電子郵件地址"
 
-#: static/js/zamboni/devhub.js:536
+#: static/js/zamboni/devhub-all.js:1715 static/js/zamboni/devhub-min.js:1 static/js/zamboni/devhub.js:536
 msgid "There was an error uploading your file."
 msgstr "上傳您的檔案時發生錯誤。"
 
-#: static/js/zamboni/devhub.js:681
+#: static/js/zamboni/devhub-all.js:1860 static/js/zamboni/devhub-min.js:1 static/js/zamboni/devhub.js:681
 msgid "{files} file"
 msgid_plural "{files} files"
 msgstr[0] "{files} 個檔案"
+msgstr[1] ""
 
-#: static/js/zamboni/devhub.js:684
+#: static/js/zamboni/devhub-all.js:1863 static/js/zamboni/devhub-min.js:1 static/js/zamboni/devhub.js:684
 msgid "{reviews} user review"
 msgid_plural "{reviews} user reviews"
 msgstr[0] "{reviews} 筆使用者評論"
+msgstr[1] ""
 
-#: static/js/zamboni/devhub.js:796
+#: static/js/zamboni/devhub-all.js:1975 static/js/zamboni/devhub-min.js:2 static/js/zamboni/devhub.js:796
 msgid "Learn more"
 msgstr "了解詳情"
 
-#: static/js/zamboni/devhub.js:800
+#: static/js/zamboni/devhub-all.js:1979 static/js/zamboni/devhub-min.js:2 static/js/zamboni/devhub.js:800
 msgid "Example"
 msgstr "範例"
 
-#: static/js/zamboni/devhub.js:1130
+#: static/js/zamboni/devhub-all.js:2309 static/js/zamboni/devhub-min.js:2 static/js/zamboni/devhub.js:1130
 msgid "Image changes being processed"
 msgstr "正在處理圖片更改"
 
-#: static/js/zamboni/devhub.js:1280
+#: static/js/zamboni/devhub-all.js:2459 static/js/zamboni/devhub-min.js:2 static/js/zamboni/devhub.js:1280
 msgid "Must be a valid e-mail address."
 msgstr "必須為有效的電子郵件地址。"
+
+#: static/js/zamboni/devhub-all.js:2613 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:80
+msgid "All tests passed successfully."
+msgstr "成功通過所有的測試。"
+
+#: static/js/zamboni/devhub-all.js:2616 static/js/zamboni/devhub-all.js:3011 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:83 static/js/zamboni/validator.js:478
+msgid "These tests were not run."
+msgstr "這些測試沒有執行。"
+
+#: static/js/zamboni/devhub-all.js:2664 static/js/zamboni/devhub-all.js:2677 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:131 static/js/zamboni/validator.js:144
+msgid "Tests"
+msgstr "測試"
+
+#: static/js/zamboni/devhub-all.js:2779 static/js/zamboni/devhub-all.js:3108 static/js/zamboni/devhub-all.js:3127 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:246
+#: static/js/zamboni/validator.js:575 static/js/zamboni/validator.js:594
+msgid "Error"
+msgstr "錯誤"
+
+#: static/js/zamboni/devhub-all.js:2780 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:247
+msgid "Warning"
+msgstr "警告"
+
+#: static/js/zamboni/devhub-all.js:2794 static/js/zamboni/devhub-min.js:2 static/js/zamboni/files-all.js:5657 static/js/zamboni/files-min.js:3 static/js/zamboni/files.js:411
+#: static/js/zamboni/validator.js:261
+msgid "Ignore this message in future updates"
+msgstr "在未來的更新中忽略此錯誤"
+
+#: static/js/zamboni/devhub-all.js:2817 static/js/zamboni/devhub-min.js:2 static/js/zamboni/files-all.js:5663 static/js/zamboni/files-min.js:3 static/js/zamboni/files.js:417
+#: static/js/zamboni/validator.js:284
+msgid "Severity for automated signing:"
+msgstr "自動簽署的嚴重性:"
+
+#: static/js/zamboni/devhub-all.js:2832 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:299
+msgid "Suggestions for passing automated signing:"
+msgstr "通過自動簽署的建議:"
+
+#: static/js/zamboni/devhub-all.js:2920 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:387
+msgid "Compatibility Tests"
+msgstr "相容性測試"
+
+#: static/js/zamboni/devhub-all.js:2999 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:466
+msgid "Add-on failed validation."
+msgstr "附加元件無法通過驗證。"
+
+#: static/js/zamboni/devhub-all.js:3001 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:468
+msgid "Add-on passed validation."
+msgstr "附加元件通過驗證。"
+
+#: static/js/zamboni/devhub-all.js:3014 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:481
+msgid "{0} error"
+msgid_plural "{0} errors"
+msgstr[0] "{0} 個錯誤"
+msgstr[1] ""
+
+#: static/js/zamboni/devhub-all.js:3016 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:483
+msgid "{0} warning"
+msgid_plural "{0} warnings"
+msgstr[0] "{0} 個警告"
+msgstr[1] ""
+
+#: static/js/zamboni/devhub-all.js:3018 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:485
+msgid "{0} notice"
+msgid_plural "{0} notices"
+msgstr[0] "{0} 則通知{0} 則通知"
+msgstr[1] ""
+
+#: static/js/zamboni/devhub-all.js:3110 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:577
+msgid "Validation task could not complete or completed with errors"
+msgstr "驗證工作無法完成或是完成時發生錯誤"
+
+#: static/js/zamboni/devhub-all.js:3128 static/js/zamboni/devhub-min.js:2 static/js/zamboni/validator.js:595
+msgid "Internal server error"
+msgstr "伺服器內部錯誤"
 
 #: static/js/zamboni/devhub_search.js:8
 msgid "No results found."
 msgstr "找不到結果。"
 
-#: static/js/zamboni/editors.js:121
+#: static/js/zamboni/editors-all.js:15402 static/js/zamboni/editors-min.js:4 static/js/zamboni/editors.js:121
 msgid "{name} was viewing this page first."
 msgstr "{name} 最先檢視此頁面。"
 
-#: static/js/zamboni/editors.js:171
+#: static/js/zamboni/editors-all.js:15452 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:171
 msgid "Receipt checked by app."
 msgstr "應用程式已檢查收據。"
 
-#: static/js/zamboni/editors.js:173
+#: static/js/zamboni/editors-all.js:15454 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:173
 msgid "Receipt was not checked by app."
 msgstr "應用程式未檢查收據。"
 
-#: static/js/zamboni/editors.js:244
+#: static/js/zamboni/editors-all.js:15525 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:244
 msgid "{name} was viewing this add-on first."
 msgstr "{name} 先檢視了這個附加元件。"
 
-#: static/js/zamboni/editors.js:255
+#: static/js/zamboni/editors-all.js:15536 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:255
 msgid "Loading&hellip;"
 msgstr "載入中&hellip;"
 
-#: static/js/zamboni/editors.js:260
+#: static/js/zamboni/editors-all.js:15541 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:260
 msgid "Version Notes"
 msgstr "版本資訊"
 
-#: static/js/zamboni/editors.js:265
+#: static/js/zamboni/editors-all.js:15546 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:265
 msgid "Notes for Reviewers"
 msgstr "給審查者的筆記"
 
-#: static/js/zamboni/editors.js:270
+#: static/js/zamboni/editors-all.js:15551 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:270
 msgid "No version notes found"
 msgstr "找不到版本紀錄"
 
-#: static/js/zamboni/editors.js:330
+#: static/js/zamboni/editors-all.js:15611 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:330
 msgid "Average Reviews"
 msgstr "平均評等"
 
-#: static/js/zamboni/editors.js:386
+#: static/js/zamboni/editors-all.js:15667 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:386
 msgid "Number of Reviews"
 msgstr "留言數量"
 
-#: static/js/zamboni/editors.js:445
+#: static/js/zamboni/editors-all.js:15726 static/js/zamboni/editors-min.js:5 static/js/zamboni/editors.js:445
 msgid "Error loading translation"
 msgstr "讀取翻譯錯誤"
 
-#: static/js/zamboni/files.js:411 static/js/zamboni/validator.js:261
-msgid "Ignore this message in future updates"
-msgstr "在未來的更新中忽略此錯誤"
-
-#: static/js/zamboni/files.js:417 static/js/zamboni/validator.js:284
-msgid "Severity for automated signing:"
-msgstr "自動簽署的嚴重性:"
-
-#: static/js/zamboni/global.js:410
-msgid "Loading..."
-msgstr "載入中..."
-
-#. L10n: {0} is the number of characters left.
-#: static/js/zamboni/global.js:474
-msgid "<b>{0}</b> character left."
-msgid_plural "<b>{0}</b> characters left."
-msgstr[0] "還剩下 <b>{0}</b> 個字元可以輸入。"
-
-#: static/js/zamboni/init.js:28
-msgid "This feature is temporarily disabled while we perform website maintenance. Please check back a little later."
-msgstr "我們正在維護網站，這個功能暫時無法使用。請您稍後再試。"
-
-#: static/js/zamboni/l10n.js:45
-msgid "Remove this localization"
-msgstr "移除此語系"
-
-#: static/js/zamboni/password-strength.js:20
-msgid "Password strength:"
-msgstr "密碼強度:"
-
-#: static/js/zamboni/password-strength.js:26
-msgid "At least {0} character left."
-msgid_plural "At least {0} characters left."
-msgstr[0] "至少還需要再輸入 {0} 個字元。"
-
-#: static/js/zamboni/themes_review.js:176
-msgid "Requested Info"
-msgstr "已要求資訊"
-
-#: static/js/zamboni/themes_review.js:177
-msgid "Flagged"
-msgstr "已標記"
-
-#: static/js/zamboni/themes_review.js:178
-msgid "Duplicate"
-msgstr "重複"
-
-#: static/js/zamboni/themes_review.js:179
-msgid "Rejected"
-msgstr "已拒絕"
-
-#: static/js/zamboni/themes_review.js:180
-msgid "Approved"
-msgstr "已核准"
-
-#: static/js/zamboni/themes_review.js:424
-msgid "No results found"
-msgstr "找不到結果"
-
-#: static/js/zamboni/themes_review_templates.js:31
+#: static/js/zamboni/editors-all.js:15975 static/js/zamboni/editors-min.js:5 static/js/zamboni/themes_review_templates.js:31
 msgid "Theme"
 msgstr "佈景主題"
 
-#: static/js/zamboni/themes_review_templates.js:33
+#: static/js/zamboni/editors-all.js:15977 static/js/zamboni/editors-min.js:5 static/js/zamboni/themes_review_templates.js:33
 msgid "Reviewer"
 msgstr "審核者"
 
-#: static/js/zamboni/themes_review_templates.js:35
+#: static/js/zamboni/editors-all.js:15979 static/js/zamboni/editors-min.js:5 static/js/zamboni/themes_review_templates.js:35
 msgid "Status"
 msgstr "狀態"
 
-#: static/js/zamboni/validator.js:80
-msgid "All tests passed successfully."
-msgstr "成功通過所有的測試。"
+#: static/js/zamboni/editors-all.js:16196 static/js/zamboni/editors-min.js:5 static/js/zamboni/themes_review.js:176
+msgid "Requested Info"
+msgstr "已要求資訊"
 
-#: static/js/zamboni/validator.js:83 static/js/zamboni/validator.js:478
-msgid "These tests were not run."
-msgstr "這些測試沒有執行。"
+#: static/js/zamboni/editors-all.js:16197 static/js/zamboni/editors-min.js:5 static/js/zamboni/themes_review.js:177
+msgid "Flagged"
+msgstr "已標記"
 
-#: static/js/zamboni/validator.js:131 static/js/zamboni/validator.js:144
-msgid "Tests"
-msgstr "測試"
+#: static/js/zamboni/editors-all.js:16198 static/js/zamboni/editors-min.js:5 static/js/zamboni/themes_review.js:178
+msgid "Duplicate"
+msgstr "重複"
 
-#: static/js/zamboni/validator.js:246 static/js/zamboni/validator.js:575 static/js/zamboni/validator.js:594
-msgid "Error"
-msgstr "錯誤"
+#: static/js/zamboni/editors-all.js:16199 static/js/zamboni/editors-min.js:5 static/js/zamboni/themes_review.js:179
+msgid "Rejected"
+msgstr "已拒絕"
 
-#: static/js/zamboni/validator.js:247
-msgid "Warning"
-msgstr "警告"
+#: static/js/zamboni/editors-all.js:16200 static/js/zamboni/editors-min.js:5 static/js/zamboni/themes_review.js:180
+msgid "Approved"
+msgstr "已核准"
 
-#: static/js/zamboni/validator.js:299
-msgid "Suggestions for passing automated signing:"
-msgstr "通過自動簽署的建議:"
+#: static/js/zamboni/editors-all.js:16444 static/js/zamboni/editors-min.js:5 static/js/zamboni/themes_review.js:424
+msgid "No results found"
+msgstr "找不到結果"
 
-#: static/js/zamboni/validator.js:387
-msgid "Compatibility Tests"
-msgstr "相容性測試"
-
-#: static/js/zamboni/validator.js:466
-msgid "Add-on failed validation."
-msgstr "附加元件無法通過驗證。"
-
-#: static/js/zamboni/validator.js:468
-msgid "Add-on passed validation."
-msgstr "附加元件通過驗證。"
-
-#: static/js/zamboni/validator.js:481
-msgid "{0} error"
-msgid_plural "{0} errors"
-msgstr[0] "{0} 個錯誤"
-
-#: static/js/zamboni/validator.js:483
-msgid "{0} warning"
-msgid_plural "{0} warnings"
-msgstr[0] "{0} 個警告"
-
-#: static/js/zamboni/validator.js:485
-msgid "{0} notice"
-msgid_plural "{0} notices"
-msgstr[0] "{0} 則通知{0} 則通知"
-
-#: static/js/zamboni/validator.js:577
-msgid "Validation task could not complete or completed with errors"
-msgstr "驗證工作無法完成或是完成時發生錯誤"
-
-#: static/js/zamboni/validator.js:595
-msgid "Internal server error"
-msgstr "伺服器內部錯誤"
-
-#: static/js/zamboni/mobile/buttons.js:52
+#: static/js/zamboni/mobile-all.js:15186 static/js/zamboni/mobile/buttons.js:52
 msgid "Not Updated for {0} {1}"
 msgstr "未為 {0} {1} 更新"
 
-#: static/js/zamboni/mobile/buttons.js:53
+#: static/js/zamboni/mobile-all.js:15187 static/js/zamboni/mobile/buttons.js:53
 msgid "Requires Newer Version of {0}"
 msgstr "需要安裝 {0} 的較新版本"
 
-#: static/js/zamboni/mobile/buttons.js:54
+#: static/js/zamboni/mobile-all.js:15188 static/js/zamboni/mobile/buttons.js:54
 msgid "Unreviewed"
 msgstr "尚未審查"
 
-#: static/js/zamboni/mobile/buttons.js:55
+#: static/js/zamboni/mobile-all.js:15189 static/js/zamboni/mobile/buttons.js:55
 msgid "Experimental <span>(Learn More)</span>"
 msgstr "實驗中 <span>(更多資訊)</span>"
 
 # 80%
 # 100%
-#: static/js/zamboni/mobile/buttons.js:56 static/js/zamboni/mobile/buttons.js:57
+#: static/js/zamboni/mobile-all.js:15190 static/js/zamboni/mobile-all.js:15191 static/js/zamboni/mobile/buttons.js:56 static/js/zamboni/mobile/buttons.js:57
 msgid "Not Available for {0}"
 msgstr "無法使用於 {0}"
 
-#: static/js/zamboni/mobile/buttons.js:58
+#: static/js/zamboni/mobile-all.js:15192 static/js/zamboni/mobile/buttons.js:58
 msgid "Experimental"
 msgstr "實驗中"
 
-#: static/js/zamboni/mobile/buttons.js:59
+#: static/js/zamboni/mobile-all.js:15193 static/js/zamboni/mobile/buttons.js:59
 msgid "Themes Require Newer Version of {0}"
 msgstr "佈景主題需要 {0} 或更新的版本"
 
-#: static/js/zamboni/mobile/buttons.js:60
+#: static/js/zamboni/mobile-all.js:15194 static/js/zamboni/mobile/buttons.js:60
 msgid "Themes Require {0}"
 msgstr "佈景主題需要 {0}"
 
-#: static/js/zamboni/mobile/buttons.js:105
+#: static/js/zamboni/mobile-all.js:15239 static/js/zamboni/mobile/buttons.js:105
 msgid "Installing..."
 msgstr "安裝中..."
 
-#: static/js/zamboni/mobile/buttons.js:125
+#: static/js/zamboni/mobile-all.js:15259 static/js/zamboni/mobile/buttons.js:125
 msgid "This add-on has been preliminarily reviewed by Mozilla."
 msgstr "此附加元件已經通過 Mozilla 初步審查。"
 
-#: static/js/zamboni/mobile/buttons.js:250
+#: static/js/zamboni/mobile-all.js:15384 static/js/zamboni/mobile/buttons.js:250
 msgid "Keep it"
 msgstr "保留它"
 
-#: static/js/zamboni/mobile/general.js:344
+#: static/js/zamboni/mobile-all.js:16049 static/js/zamboni/mobile-min.js:6 static/js/zamboni/mobile/general.js:344
 msgid "You're trying it on!"
 msgstr "您正在試穿它!"
 
-#: static/js/zamboni/mobile/general.js:356
+#: static/js/zamboni/mobile-all.js:16061 static/js/zamboni/mobile-min.js:6 static/js/zamboni/mobile/general.js:356
 msgid "Added to Firefox"
 msgstr "已新增至 Firefox"
-


### PR DESCRIPTION
this time I did the following:

* normalize all message ids, strip whitespaces at all cost
* restore known missing translations
* run extraction again to ensure we have the latest strings
* tried to make sure we're not deleting anything
* run translation restoration again, just to make sure we're not missing anything
* run extraction again to make sure we finally format and extract everything again and have everythning formatted the way it's supposed to be.

From my tests it appears this finally resolves any wrong message ids, restores old translations where possible but doesn't touch recently translated messages.

Please let me know what you think.